### PR TITLE
FIX: Spotlight: searching in user homes, bug #543

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,7 @@ Changes in 3.1.7
        escalation in afpd processes
 * FIX: afpd: ACL related error messages, now logged with loglevel
        debug instead of error
+* FIX: Spotlight: searching in user homes, bug #543
 
 Changes in 3.1.6
 ================


### PR DESCRIPTION
Spotlight cannot search in user homes.
When netatalk(8) starts, it sets up paths for Spotlight.
Since user has not logged in yet, nobody sets up home's path.
