### PR TITLE
configure option "--with-init-style=" for Gentoo.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@ Changes in 3.1.9
 * NEW: afpd: new options "force user" and "force group"
 * FIX: listening on IPv6 wildcard address may fail if IPv6 is
        disabled, bug #606
+* UPD: configure option "--with-init-style=" for Gentoo.
+       "gentoo" is renamed to "gentoo-openrc".
+       "gentoo-openrc" is same as "openrc".
+       "gentoo-systemd" is same as "systemd".
 
 Changes in 3.1.8
 ================

--- a/distrib/initscripts/Makefile.am
+++ b/distrib/initscripts/Makefile.am
@@ -175,10 +175,10 @@ uninstall-startup:
 endif
 
 #
-# checking for "Gentoo" style sysv scripts:
+# checking for general openrc scripts:
 #
 
-if USE_GENTOO
+if USE_OPENRC
 
 sysvdir = $(INIT_DIR)
 sysv_SCRIPTS = netatalk

--- a/doc/manual/install.xml
+++ b/doc/manual/install.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <chapter id="installation">
   <chapterinfo>
-    <date>22.8.2014</date>
+    <date>17.1.2015</date>
   </chapterinfo>
 
   <title>Installation</title>
@@ -270,7 +270,7 @@ remote: Counting objects: 2503, done.
 
         <itemizedlist>
           <listitem>
-            <para><option>--with-init-style</option>=redhat-sysv|redhat-systemd|suse-sysv|suse-systemd|gentoo|netbsd|debian-sysv|debian-systemd|solaris|systemd</para>
+            <para><option>--with-init-style</option>=redhat-sysv|redhat-systemd|suse-sysv|suse-systemd|gentoo-openrc|gentoo-systemd|netbsd|debian-sysv|debian-systemd|solaris|openrc|systemd</para>
 
             <para>This option helps netatalk to determine where to install the
             start scripts.</para>

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -461,7 +461,7 @@ AC_ARG_ENABLE(shell-check,
 dnl Check for optional initscript install
 AC_DEFUN([AC_NETATALK_INIT_STYLE], [
     AC_ARG_WITH(init-style,
-                [  --with-init-style       use OS specific init config [[redhat-sysv|redhat-systemd|suse-sysv|suse-systemd|gentoo|netbsd|debian-sysv|debian-systemd|solaris|systemd]]],
+                [  --with-init-style       use OS specific init config [[redhat-sysv|redhat-systemd|suse-sysv|suse-systemd|gentoo-openrc|gentoo-systemd|netbsd|debian-sysv|debian-systemd|solaris|openrc|systemd]]],
                 init_style="$withval", init_style=none
     )
     case "$init_style" in 
@@ -488,8 +488,15 @@ AC_DEFUN([AC_NETATALK_INIT_STYLE], [
 	    ac_cv_init_dir="/usr/lib/systemd/system"
 	    ;;
     "gentoo")
-	    AC_MSG_RESULT([enabling gentoo-style initscript support])
+	    AC_MSG_ERROR([--with-init-style=gentoo is obsoleted. Use gentoo-openrc or gentoo-systemd.])
+        ;;
+    "gentoo-openrc")
+	    AC_MSG_RESULT([enabling gentoo-style openrc support])
 	    ac_cv_init_dir="/etc/init.d"
+        ;;
+    "gentoo-systemd")
+	    AC_MSG_RESULT([enabling gentoo-style systemd support])
+	    ac_cv_init_dir="/usr/lib/systemd/system"
         ;;
     "netbsd")
 	    AC_MSG_RESULT([enabling netbsd-style initscript support])
@@ -510,6 +517,10 @@ AC_DEFUN([AC_NETATALK_INIT_STYLE], [
 	    AC_MSG_RESULT([enabling solaris-style SMF support])
 	    ac_cv_init_dir="/lib/svc/manifest/network/"
         ;;
+    "openrc")
+	    AC_MSG_RESULT([enabling general openrc support])
+	    ac_cv_init_dir="/etc/init.d"
+        ;;
     "systemd")
 	    AC_MSG_RESULT([enabling general systemd support])
 	    ac_cv_init_dir="/usr/lib/systemd/system"
@@ -526,9 +537,9 @@ AC_DEFUN([AC_NETATALK_INIT_STYLE], [
     AM_CONDITIONAL(USE_REDHAT_SYSV, test x$init_style = xredhat-sysv)
     AM_CONDITIONAL(USE_SUSE_SYSV, test x$init_style = xsuse-sysv)
     AM_CONDITIONAL(USE_SOLARIS, test x$init_style = xsolaris)
-    AM_CONDITIONAL(USE_GENTOO, test x$init_style = xgentoo)
+    AM_CONDITIONAL(USE_OPENRC, test x$init_style = xopenrc || test x$init_style = xgentoo-openrc)
     AM_CONDITIONAL(USE_DEBIAN_SYSV, test x$init_style = xdebian-sysv)
-    AM_CONDITIONAL(USE_SYSTEMD, test x$init_style = xsystemd || test x$init_style = xredhat-systemd || test x$init_style = xsuse-systemd)
+    AM_CONDITIONAL(USE_SYSTEMD, test x$init_style = xsystemd || test x$init_style = xredhat-systemd || test x$init_style = xsuse-systemd || test x$init_style = xgentoo-systemd)
     AM_CONDITIONAL(USE_DEBIAN_SYSTEMD, test x$init_style = xdebian-systemd)
     AM_CONDITIONAL(USE_UNDEF, test x$init_style = xnone)
 


### PR DESCRIPTION
"gentoo" is renamed to "gentoo-openrc".
"gentoo-openrc" is same as "openrc".
"gentoo-systemd" is same as "systemd".