### PR TITLE
tracker: small fixes

### DIFF
--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -154,7 +154,7 @@ AC_DEFUN([AC_NETATALK_SPOTLIGHT], [
     )
 
     AC_ARG_WITH([tracker-prefix],
-      [AS_HELP_STRING([--with-tracker-prefix=PATH],[Prefix of Tracker installation (default: none)])],
+      [AS_HELP_STRING([--with-tracker-prefix=PATH],[Prefix of Tracker (default: none)])],
       [ac_cv_tracker_prefix=$withval],
       [ac_cv_tracker_prefix="`pkg-config --variable=prefix tracker-sparql-$ac_cv_tracker_pkg_version`"]
     )
@@ -164,18 +164,6 @@ AC_DEFUN([AC_NETATALK_SPOTLIGHT], [
       [ac_cv_tracker_install_prefix=$withval],
       [ac_cv_tracker_install_prefix=$ac_cv_tracker_prefix]
     )
-
-    dnl Tracker Managing Command
-    AC_CHECK_PROGS(ac_cv_tracker_manage, tracker tracker-control, , ["$ac_cv_tracker_prefix"/bin])
-    if test x"$ac_cv_tracker_manage" = x"tracker" ; then
-       TRACKER_MANAGING_COMMAND="tracker daemon"
-       AC_DEFINE(TRACKER_MANAGING_COMMAND, "tracker daemon", [tracker managing command])
-    elif test x"$ac_cv_tracker_manage" = x"tracker-control" ; then
-       TRACKER_MANAGING_COMMAND="tracker-control"
-       AC_DEFINE(TRACKER_MANAGING_COMMAND, "tracker-control", [tracker managing command])
-    else
-       AC_MSG_ERROR([could find neither tracker command nor tracker-control command])
-    fi
 
     AC_ARG_WITH([dbus-daemon],
       [AS_HELP_STRING([--with-dbus-daemon=PATH],[Path to DBus daemon (default: /bin/dbus-daemon)])],
@@ -196,6 +184,20 @@ AC_DEFUN([AC_NETATALK_SPOTLIGHT], [
         AC_DEFINE(HAVE_TRACKER, 1, [Define if Tracker is available])
         AC_DEFINE_UNQUOTED(TRACKER_PREFIX, ["$ac_cv_tracker_install_prefix"], [Path to Tracker])
         AC_DEFINE_UNQUOTED([DBUS_DAEMON_PATH], ["$ac_cv_dbus_daemon"], [Path to dbus-daemon])
+    fi
+
+    dnl Tracker Managing Command
+    if test x"$ac_cv_have_tracker" = x"yes" ; then
+        AC_CHECK_PROGS(ac_cv_tracker_manage, tracker tracker-control, , ["$ac_cv_tracker_install_prefix"/bin])
+        if test x"$ac_cv_tracker_manage" = x"tracker" ; then
+           TRACKER_MANAGING_COMMAND="tracker daemon"
+           AC_DEFINE(TRACKER_MANAGING_COMMAND, "tracker daemon", [tracker managing command])
+        elif test x"$ac_cv_tracker_manage" = x"tracker-control" ; then
+           TRACKER_MANAGING_COMMAND="tracker-control"
+           AC_DEFINE(TRACKER_MANAGING_COMMAND, "tracker-control", [tracker managing command])
+        else
+           AC_MSG_ERROR([could find neither tracker command nor tracker-control command])
+        fi
     fi
 
     AC_SUBST(TRACKER_CFLAGS)

--- a/macros/summary.m4
+++ b/macros/summary.m4
@@ -66,7 +66,8 @@ dnl	AC_MSG_RESULT([         Samba sharemode interop: $neta_cv_have_smbshmd])
 	if test x"$ac_cv_have_tracker" = x"yes"; then
 		AC_MSG_RESULT([         dbus daemon path:        $ac_cv_dbus_daemon])
 		AC_MSG_RESULT([         tracker prefix:          $ac_cv_tracker_prefix])
-		AC_MSG_RESULT([         tracker managing command:$ac_cv_tracker_prefix/bin/$TRACKER_MANAGING_COMMAND])
+		AC_MSG_RESULT([         tracker install prefix:  $ac_cv_tracker_install_prefix])
+		AC_MSG_RESULT([         tracker manager:         $ac_cv_tracker_install_prefix/bin/$TRACKER_MANAGING_COMMAND])
 	fi
 	if test x"$use_pam_so" = x"yes"; then
 	   if test x"$netatalk_cv_install_pam" = x"yes"; then


### PR DESCRIPTION
Only when $ac_cv_have_tracker=yes, tracker managing command is checked in "$ac_cv_tracker_install_prefix"/bin.
Add $ac_cv_tracker_install_prefix in configure summary.
Change the description of the --with-tracker-prefix option "Prefix of Tracker (default: none)])".