### PR TITLE
Switch openrc init script to openrc-run

### DIFF
--- a/distrib/initscripts/rc.gentoo.tmpl
+++ b/distrib/initscripts/rc.gentoo.tmpl
@@ -1,4 +1,4 @@
-#!/sbin/runscript
+#!/sbin/openrc-run
 # Copyright 1999-2012 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 #


### PR DESCRIPTION
Openrc has been switching from /sbin/runscript to /sbin/openrc-run
a long time ago. Currently there is a big push to curate all init scripts.

Signed-off-by: Justin Lecher <jlec@gentoo.org>