### PR TITLE
Update Netatalk volume capacity reporting to match Samba behavior

### DIFF
--- a/etc/afpd/unix.c
+++ b/etc/afpd/unix.c
@@ -67,8 +67,7 @@ int ustatfs_getvolspace(const struct vol *vol, VolSpace *bfree, VolSpace *btotal
     *btotal = (VolSpace)
               ( sfs.fd_req.btot - ( sfs.fd_req.bfree - sfs.fd_req.bfreen ));
 #else /* !ultrix */
-    *btotal = (VolSpace)
-              ( sfs.f_blocks - ( sfs.f_bfree - sfs.f_bavail ));
+    *btotal = (VolSpace) sfs.f_blocks;
 #endif /* ultrix */
 
     /* see similar block above comments */


### PR DESCRIPTION
Currently, Netatalk's reported volume capacity will shrink as the difference
between 'free' and 'available' blocks increases.  This updates the reporting
to not do this, which matches Samba's behavior.

Signed-off-by: Scott Talbert <scott.talbert@wdc.com>