### PR TITLE
Ensure debian initscript 'status' command exits with proper exit code.

### DIFF
--- a/distrib/initscripts/rc.debian.tmpl
+++ b/distrib/initscripts/rc.debian.tmpl
@@ -70,6 +70,7 @@ case "$1" in
         else
             echo "Netatalk is not running."
         fi
+        exit $EXIT_CODE
         ;;
     *)
         echo "Usage: $0 {start|stop|restart|force-reload|status}" >&2


### PR DESCRIPTION
Other software depends on the status exit codes listed in the Linux Standard Base PDA Specification 3.0RC1.
https://refspecs.linuxbase.org/LSB_3.0.0/LSB-PDA/LSB-PDA/iniscrptact.html

Configuration managers depend heavily on such things.