### PR TITLE
OpenSSL 1.1.x compatibility

### DIFF
--- a/etc/uams/openssl_compat.h
+++ b/etc/uams/openssl_compat.h
@@ -1,0 +1,45 @@
+/*
+
+Copyright (c) 2017 Denis Bychkov (manover@gmail.com)
+
+This file is released under the GNU General Public License (GPLv2).
+The full license text is available at:
+
+http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+*/
+
+#ifndef OPENSSL_COMPAT_H
+#define OPENSSL_COMPAT_H
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+inline static int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
+{
+   /* If the fields p and g in d are NULL, the corresponding input
+    * parameters MUST be non-NULL.  q may remain NULL.
+    */
+   if ((dh->p == NULL && p == NULL) || (dh->g == NULL && g == NULL))
+       return 0;
+
+   if (p != NULL)
+       dh->p = p;
+   if (q != NULL)
+       dh->q = q;
+   if (g != NULL)
+       dh->g = g;
+
+   if (q != NULL)
+       dh->length = BN_num_bits(q);
+
+   return 1;
+}
+
+inline static void DH_get0_key(const DH *dh, const BIGNUM **pub_key, const BIGNUM **priv_key)
+{
+   if (pub_key != NULL)
+       *pub_key = dh->pub_key;
+   if (priv_key != NULL)
+       *priv_key = dh->priv_key;
+}
+#endif /* OPENSSL_VERSION_NUMBER */
+
+#endif /* OPENSSL_COMPAT_H */

--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -32,6 +32,7 @@
 #include <openssl/bn.h>
 #include <openssl/dh.h>
 #include <openssl/cast.h>
+#include "openssl_compat.h"
 #else /* OPENSSL_DHX */
 #include <bn.h>
 #include <dh.h>
@@ -76,6 +77,7 @@ static int pwd_login(void *obj, char *username, int ulen, struct passwd **uam_pw
     struct spwd *sp;
 #endif /* SHADOWPW */
     BIGNUM *bn, *gbn, *pbn;
+    const BIGNUM *pub_key;
     uint16_t sessid;
     size_t i;
     DH *dh;
@@ -139,10 +141,18 @@ static int pwd_login(void *obj, char *username, int ulen, struct passwd **uam_pw
       return AFPERR_PARAM;
     }
 
+    if (!DH_set0_pqg(dh, pbn, NULL, gbn)) {
+      BN_free(pbn);
+      BN_free(gbn);
+      goto passwd_fail;
+    }
+
     /* generate key and make sure we have enough space */
-    dh->p = pbn;
-    dh->g = gbn;
-    if (!DH_generate_key(dh) || (BN_num_bytes(dh->pub_key) > KEYSIZE)) {
+    if (!DH_generate_key(dh)) {
+      goto passwd_fail;
+    }
+    DH_get0_key(dh, &pub_key, NULL);
+    if (BN_num_bytes(pub_key) > KEYSIZE) {
       goto passwd_fail;
     }
 
@@ -159,7 +169,7 @@ static int pwd_login(void *obj, char *username, int ulen, struct passwd **uam_pw
     *rbuflen += sizeof(sessid);
     
     /* send our public key */
-    BN_bn2bin(dh->pub_key, (unsigned char *)rbuf); 
+    BN_bn2bin(pub_key, (unsigned char *)rbuf);
     rbuf += KEYSIZE;
     *rbuflen += KEYSIZE;
 


### PR DESCRIPTION
Netatalk currently does not build against OpenSSL 1.1.0+, producing
a half a dozen error messages like this:
```
error: dereferencing pointer to incomplete type ‘DH {aka struct dh_st}’
```
This is caused by OpenSSL making certain structs opaque, which forces the library users to employ special getters and setters when accessing these structs.
This PR makes Netatalk build against the new version of OpenSSL, but it cannot be merged as-is because it breaks compatibility with the older versions. It could be easily fixed with a couple of `ifdef`-s,
however I am not certain this project wants to hardcode external dependencies versions in the core code, so maybe there is a better way through m4 configure scripts, for example.

Please review.