### PR TITLE
Remove unused function 'evutil_secure_rng_add_bytes', fixing build on SmartOS.

### DIFF
--- a/libevent/evutil_rand.c
+++ b/libevent/evutil_rand.c
@@ -137,11 +137,3 @@ evutil_secure_rng_get_bytes(void *buf, size_t n)
 {
 	ev_arc4random_buf(buf, n);
 }
-
-void
-evutil_secure_rng_add_bytes(const char *buf, size_t n)
-{
-	arc4random_addrandom((unsigned char*)buf,
-	    n>(size_t)INT_MAX ? INT_MAX : (int)n);
-}
-

--- a/libevent/include/event2/util.h
+++ b/libevent/include/event2/util.h
@@ -668,22 +668,6 @@ void evutil_secure_rng_get_bytes(void *buf, size_t n);
  */
 int evutil_secure_rng_init(void);
 
-/** Seed the random number generator with extra random bytes.
-
-    You should almost never need to call this function; it should be
-    sufficient to invoke evutil_secure_rng_init(), or let Libevent take
-    care of calling evutil_secure_rng_init() on its own.
-
-    If you call this function as a _replacement_ for the regular
-    entropy sources, then you need to be sure that your input
-    contains a fairly large amount of strong entropy.  Doing so is
-    notoriously hard: most people who try get it wrong.  Watch out!
-
-    @param dat a buffer full of a strong source of random numbers
-    @param datlen the number of bytes to read from datlen
- */
-void evutil_secure_rng_add_bytes(const char *dat, size_t datlen);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This function was not used anywhere in netatalk. Additionally, it
was calling arc4random_addrandom() which is apparently notoriously
difficult to use correctly and has since been removed from OpenBSD
and SmartOS.

See: https://www.illumos.org/issues/5949