### PR TITLE
Fix nfs detection, allow to use on remote fuse systems

### DIFF
--- a/etc/afpd/quota.c
+++ b/etc/afpd/quota.c
@@ -386,11 +386,9 @@ mountp( char *file, int *nfs)
             return mnt.mnt_mountp;
         }
 
-        /* check for nfs. we probably should use
-         * strcmp(mnt.mnt_fstype, MNTTYPE_NFS), but that's not as fast. */
-        if ((stat(mnt.mnt_mountp, &sb) == 0) && (devno == sb.st_dev) &&
-                strchr(mnt.mnt_special, ':')) {
-            *nfs = 1;
+        /* check for nfs. */
+        if ((stat(mnt.mnt_mountp, &sb) == 0) && (devno == sb.st_dev)) {
+            *nfs = strcmp(mnt.mnt_fstype, MNTTYPE_NFS) == 0 ? 1 : 0;
             fclose( mtab );
             return mnt.mnt_special;
         }


### PR DESCRIPTION
Hi! I would like to use Netatalk with mounted fuse filesystem. By default, afpd detects it as a NFS share , if mount point has a colon in the name. But my partition is not an NFS share. So, I think it must be corrected. 