### PR TITLE
Branch netatalk 3 1 fork2

### DIFF
--- a/etc/afpd/fce_api.c
+++ b/etc/afpd/fce_api.c
@@ -97,7 +97,7 @@ static char *fce_event_names[] = {
 /*
  *
  * Initialize network structs for any listeners
- * We don't give return code because all errors are handled internally (I hope..)
+ * We dont give return code because all errors are handled internally (I hope..)
  *
  * */
 void fce_init_udp()
@@ -284,7 +284,7 @@ static ssize_t build_fce_packet(const AFPObj *obj,
 
 /*
  * Send the fce information to all (connected) listeners
- * We don't give return code because all errors are handled internally (I hope..)
+ * We dont give return code because all errors are handled internally (I hope..)
  * */
 static void send_fce_event(const AFPObj *obj, int event, const char *path, const char *oldpath)
 {    
@@ -410,7 +410,7 @@ static void send_fce_event(const AFPObj *obj, int event, const char *path, const
         /* Problems ? */
         if (sent_data != data_len) {
             /* Argh, socket broke, we close and retry later */
-            LOG(log_error, logtype_fce, "send_fce_event: error sending packet to %s:%s, transferred %d of %d: %s",
+            LOG(log_error, logtype_fce, "send_fce_event: error sending packet to %s:%s, transfered %d of %d: %s",
                 udp_entry->addr, udp_entry->port, sent_data, data_len, strerror(errno));
 
             close( udp_entry->sock );
@@ -532,7 +532,11 @@ int fce_register(const AFPObj *obj, fce_ev_t event, const char *path, const char
 
     switch (event) {
     case FCE_FILE_MODIFY:
-        save_close_event(obj, path);
+        if (obj->options.fce_fmodwait != 0){
+            save_close_event(obj, path);
+        } else {
+            send_fce_event(obj, event, path, oldpath);
+        }
         break;
     default:
         send_fce_event(obj, event, path, oldpath);

--- a/etc/afpd/fce_api.c
+++ b/etc/afpd/fce_api.c
@@ -97,7 +97,7 @@ static char *fce_event_names[] = {
 /*
  *
  * Initialize network structs for any listeners
- * We dont give return code because all errors are handled internally (I hope..)
+ * We don't give return code because all errors are handled internally (I hope..)
  *
  * */
 void fce_init_udp()
@@ -284,10 +284,10 @@ static ssize_t build_fce_packet(const AFPObj *obj,
 
 /*
  * Send the fce information to all (connected) listeners
- * We dont give return code because all errors are handled internally (I hope..)
+ * We don't give return code because all errors are handled internally (I hope..)
  * */
 static void send_fce_event(const AFPObj *obj, int event, const char *path, const char *oldpath)
-{    
+{
     static bool first_event = true;
     static uint32_t event_id = 0; /* the unique packet couter to detect packet/data loss. Going from 0xFFFFFFFF to 0x0 is a valid increment */
     static char *user;
@@ -375,7 +375,7 @@ static void send_fce_event(const AFPObj *obj, int event, const char *path, const
             udp_entry->sock = socket(udp_entry->addrinfo.ai_family,
                                      udp_entry->addrinfo.ai_socktype,
                                      udp_entry->addrinfo.ai_protocol);
-            
+
             if (udp_entry->sock == -1) {
                 /* failed again, so go to rest again */
                 LOG(log_error, logtype_fce, "Cannot recreate socket for fce UDP connection: errno %d", errno  );
@@ -410,7 +410,7 @@ static void send_fce_event(const AFPObj *obj, int event, const char *path, const
         /* Problems ? */
         if (sent_data != data_len) {
             /* Argh, socket broke, we close and retry later */
-            LOG(log_error, logtype_fce, "send_fce_event: error sending packet to %s:%s, transfered %d of %d: %s",
+            LOG(log_error, logtype_fce, "send_fce_event: error sending packet to %s:%s, transferred %d of %d: %s",
                 udp_entry->addr, udp_entry->port, sent_data, data_len, strerror(errno));
 
             close( udp_entry->sock );
@@ -596,7 +596,7 @@ int fce_set_events(const char *events)
 {
     char *e;
     char *p;
-    
+
     if (events == NULL)
         return AFPERR_PARAM;
 

--- a/etc/afpd/fce_api.c
+++ b/etc/afpd/fce_api.c
@@ -287,7 +287,7 @@ static ssize_t build_fce_packet(const AFPObj *obj,
  * We don't give return code because all errors are handled internally (I hope..)
  * */
 static void send_fce_event(const AFPObj *obj, int event, const char *path, const char *oldpath)
-{
+{    
     static bool first_event = true;
     static uint32_t event_id = 0; /* the unique packet couter to detect packet/data loss. Going from 0xFFFFFFFF to 0x0 is a valid increment */
     static char *user;
@@ -375,7 +375,7 @@ static void send_fce_event(const AFPObj *obj, int event, const char *path, const
             udp_entry->sock = socket(udp_entry->addrinfo.ai_family,
                                      udp_entry->addrinfo.ai_socktype,
                                      udp_entry->addrinfo.ai_protocol);
-
+            
             if (udp_entry->sock == -1) {
                 /* failed again, so go to rest again */
                 LOG(log_error, logtype_fce, "Cannot recreate socket for fce UDP connection: errno %d", errno  );
@@ -596,7 +596,7 @@ int fce_set_events(const char *events)
 {
     char *e;
     char *p;
-
+    
     if (events == NULL)
         return AFPERR_PARAM;
 

--- a/include/atalk/globals.h
+++ b/include/atalk/globals.h
@@ -94,6 +94,7 @@ struct afp_options {
     int sleep;                  /* Maximum time allowed to sleep (in tickles) */
     int disconnected;           /* Maximum time in disconnected state (in tickles) */
     int fce_fmodwait;           /* number of seconds FCE file mod events are put on hold */
+    int fce_sendwait;           /* numer of ms to wait between udp event sending */
     unsigned int tcp_sndbuf, tcp_rcvbuf;
     unsigned char passwdbits, passwdminlen;
     uint32_t server_quantum;
@@ -113,7 +114,7 @@ struct afp_options {
     size_t k5principal_buflen;
     char *k5principal;
     char *unixcodepage, *maccodepage, *volcodepage;
-    charset_t maccharset, unixcharset; 
+    charset_t maccharset, unixcharset;
     mode_t umask;
     mode_t save_mask;
     gid_t admingid;

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -1981,6 +1981,7 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     options->tcp_sndbuf     = atalk_iniparser_getint   (config, INISEC_GLOBAL, "tcpsndbuf",      0);
     options->tcp_rcvbuf     = atalk_iniparser_getint   (config, INISEC_GLOBAL, "tcprcvbuf",      0);
     options->fce_fmodwait   = atalk_iniparser_getint   (config, INISEC_GLOBAL, "fce holdfmod",   60);
+    options->fce_sendwait   = atalk_iniparser_getint   (config, INISEC_GLOBAL, "fce sendwait",   0);
     options->sleep          = atalk_iniparser_getint   (config, INISEC_GLOBAL, "sleep time",     10);
     options->disconnected   = atalk_iniparser_getint   (config, INISEC_GLOBAL, "disconnect time",24);
     options->splice_size    = atalk_iniparser_getint   (config, INISEC_GLOBAL, "splice size",    64*1024);
@@ -2102,7 +2103,7 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
         options->volcodepage = strdup(p);
     }
     LOG(log_debug, logtype_afpd, "Global vol charset is %s", options->volcodepage);
-    
+
     /* mac charset is in [G] and [V] */
     if (!(p = atalk_iniparser_getstring(config, INISEC_GLOBAL, "mac charset", NULL))) {
         options->maccodepage = strdup("MAC_ROMAN");


### PR DESCRIPTION
The Analysis of the `fce_api.c` routines has show that during the creation and deletion of many small files a huge amount of udp events get lost during the communication with the udp server.
Although the udp server is written as performant as possible we still get a udp buffer overflow resulting in package loss.
Increasing the buffer size helps to avoid the problem but we still added a waiting parameter between sending events to reduce the risk of event loss on low memory server. 