### PR TITLE
Fix 2 build warnings

### DIFF
--- a/libatalk/adouble/ad_flush.c
+++ b/libatalk/adouble/ad_flush.c
@@ -39,6 +39,7 @@
 #include <atalk/bstradd.h>
 #include <atalk/errchk.h>
 #include <atalk/util.h>
+#include <atalk/unix.h>
 
 #include "ad_lock.h"
 


### PR DESCRIPTION
ad_flush.c:306:25: warning: implicit declaration of function 'become_root' is invalid in C99 [-Wimplicit-function-declaration]
                        become_root();
                        ^
ad_flush.c:308:25: warning: implicit declaration of function 'unbecome_root' is invalid in C99 [-Wimplicit-function-declaration]
                        unbecome_root();
                        ^
2 warnings generated.