### PR TITLE
docs: manual: Remove wrong TCP-over-TCP info; minor copy editing

### DIFF
--- a/doc/manual/configuration.xml
+++ b/doc/manual/configuration.xml
@@ -1091,9 +1091,9 @@ uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting> then you're using PAM,
           forwarded to the remote server's AFP port (we used the default 548)
           over SSH.</para>
 
-          <para>These sorts of tunnels are an ideal solution if you've to
-          access an AFP server providing weak authentications mechanisms
-          through the Internet without having the ability to use a "real" VPN.
+          <para>This sort of tunnel is an ideal solution if you must access
+          an AFP server through the Internet without having the ability
+          or desire to use a "real" VPN.
           Note that you can let <command>ssh</command> compress the data by
           using its "-C" switch and that the tunnel endpoints can be different
           from both AFP client and server (compare with the SSH documentation
@@ -1128,9 +1128,18 @@ uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting> then you're using PAM,
 
           <itemizedlist>
             <listitem>
-              <para>Tunneling TCP over TCP (as SSH does) is not the best idea.
-              There exist better solutions like VPNs based on the IP
-              layer.</para>
+              <para>Most users who need such a feature are probably already
+              familiar with using a VPN; it might be easier for the user to
+              employ the same VPN software in order to connect to the network
+              on which the AFP server is running, and then to access the AFP
+              server as normal.</para>
+
+              <para>That being said, for the simple case of connecting
+              to one specific AFP server, a direct SSH connection is likely to
+              perform better than a general-purpose VPN; contrary to popular
+              belief, tunneling via SSH does <emphasis role="strong">not</emphasis>
+              result in what's called "TCP-over-TCP meltdown", because the
+              AFP data that are being tunneled do not encapsulate TCP data.</para>
             </listitem>
 
             <listitem>
@@ -1149,22 +1158,25 @@ uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting> then you're using PAM,
             </listitem>
 
             <listitem>
-              <para>On the other side you've to limit access to afpd to
-              localhost only (TCP wrappers) when you want to ensure that all
-              AFP sessions are SSH encrypted or...</para>
-            </listitem>
+              <para>Indeed, to ensure that all AFP sessions are encrypted
+              via SSH, you need to limit afpd to connections that originate
+              only from localhost (e.g., by using Wietse Venema's TCP Wrappers,
+              or by using suitable firewall or packet-filtering facilities, etc.).</para>
 
-            <listitem>
-              <para>...when you're using 10.2 - 10.3.3 then you get the
-              opposite of what you'd expect: potentially unencrypted AFP
-              communication (including logon credentials) on the network
+              <para>Otherwise, when you're using Mac OS X 10.2 through 10.3.3,
+              you get the opposite of what you'd expect: potentially unencrypted AFP
+              communications (including login credentials) being sent across the network
               without a single notification that establishing the tunnel
               failed. Apple fixed that not until Mac OS X 10.3.4.</para>
             </listitem>
 
             <listitem>
               <para>Encrypting all AFP sessions via SSH can lead to a
-              significantly higher load on the Netatalk server</para>
+              significantly higher load on the computer that is running
+              the AFP server, because that computer must also handle
+              encryption; if the user is connecting through a trusted
+              network, then such encryption might be an unnecessary
+              overhead.</para>
             </listitem>
           </itemizedlist>
         </sect4>


### PR DESCRIPTION
This commit is intended to apply cleanly as a **fast&#x2011;forward&nbsp;merge**. The reason for this is that a future pull request will merge this commit's changes into `branch-netatalk-3-1`, so as to record the nature of the development and to avoid the duplication of cherry-picking.

Of course, if this is not possible, that future pull request can be re-configured.

---------------

The main reason for this commit is to remove this text:

> Tunneling TCP over TCP (as SSH does) is not the best idea. There exist better solutions like VPNs based on the IP layer.

It's true that TCP-over-TCP is a bad idea, because it can lead to TCP "meltdown"; however, it is *not* true that tunneling via SSH implies TCP&#x2011;over&#x2011;TCP. Indeed, because a VPN is a much more general solution to tunneling, it is likely to perform worse than SSH for the simple case of connecting to a single, specific AFP&nbsp;Server.

Consider the following port forwarding (using OpenSSH):

&nbsp;&nbsp;`ssh -N -L localhost:1234:localhost:548 example.com`

When an AFP Client communicates with an AFP&nbsp;Server through this tunnel, the data they exchange is encapsulated in TCP and decapsulated from TCP such that TCP is never encapsulated by TCP; that is, TCP&#x2011;over&#x2011;TCP *never* occurs (view the following diagram with a monospace font and with at least 93 coloumns of text):

                       localhost:1234           example.com:22           localhost:548
                             |                        |                        |
                             |                        |                        |
                             V   encrypt(AFP)--+      V                        V
                                               |
    +--------------+         +--------------+  V      +--------------+         +--------------+
    |          AFP | AFP/TCP |     AFP      | ???/TCP |     AFP      | AFP/TCP | AFP          |
    |   data <=====o=========o==============o=========o==============o=========o=====> data   |
    |              |         |              |         |              |         |              |
    |  AFP Client  |         |  SSH Client  |         |  SSH Server  |         |  AFP Server  |
    +--------------+         +--------------+         +--------------+         +--------------+

Anyway, while I was in the source rummaging around, I took the opportunity to perform some copy editing, including a few mild additions and clarifications.
