### PR TITLE
make afpstats python 3 compatible

### DIFF
--- a/contrib/shell_utils/afpstats
+++ b/contrib/shell_utils/afpstats
@@ -23,7 +23,7 @@ def main():
 
     reply = iface.GetUsers()
     for name in reply:
-        print name
+        print(name)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Fedora is deprecating Python 2, requiring us to update any packages containing Python 2 scripts to Python 3. This simple PR appears all that is necessary to make the afpstats script compatible with Python 3.

It fixes this error:
```
$afpstats
  File "/usr/bin/afpstats", line 26
    print name
             ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(name)?
```