### PR TITLE
Fix garbage read in bsd_attr_list

### DIFF
--- a/libatalk/vfs/extattr.c
+++ b/libatalk/vfs/extattr.c
@@ -354,7 +354,7 @@ static ssize_t bsd_attr_list (int type, extattr_arg arg, char *list, size_t size
 
     /* Convert from pascal strings to C strings */
     len = list[0];
-    memmove(list, list + 1, list_size);
+    memmove(list, list + 1, list_size - 1);
 
     for(i = len; i < list_size; ) {
         LOG(log_maxdebug, logtype_afpd, "len: %d, i: %d", len, i);

--- a/libatalk/vfs/extattr.c
+++ b/libatalk/vfs/extattr.c
@@ -353,13 +353,13 @@ static ssize_t bsd_attr_list (int type, extattr_arg arg, char *list, size_t size
     }
 
     /* Convert from pascal strings to C strings */
-    len = list[0];
+    len = (unsigned char)list[0];
     memmove(list, list + 1, list_size - 1);
 
     for(i = len; i < list_size; ) {
         LOG(log_maxdebug, logtype_afpd, "len: %d, i: %d", len, i);
 
-        len = list[i];
+        len = (unsigned char)list[i];
         list[i] = '\0';
         i += len + 1;
     }


### PR DESCRIPTION
Calling memmove(3) for one byte more than what was retrieved by
extattr_list_link(2) causes clang on FreeBSD to complain about a heap
buffer overflow when we try to read that byte at line 362.

Found with Clang's address sanitizer. Report attached:
[sanitize-report2.txt](https://github.com/Netatalk/Netatalk/files/4406008/sanitize-report2.txt)
