### PR TITLE
Fix use after free in get_tm_used()

### DIFF
--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -183,6 +183,7 @@ static int get_tm_used(struct vol * restrict vol)
             
             if ((bandsize = get_tm_bandsize(cfrombstr(infoplist))) == -1) {
                 bdestroy(infoplist);
+                infoplist = NULL;
                 continue;
             }
 
@@ -190,7 +191,9 @@ static int get_tm_used(struct vol * restrict vol)
 
             if ((links = get_tm_bands(cfrombstr(bandsdir))) == -1) {
                 bdestroy(infoplist);
+                infoplist = NULL;
                 bdestroy(bandsdir);
+                bandsdir = NULL;
                 continue;
             }
 


### PR DESCRIPTION
If get_tm_used encounters a directory with a name ending in
"sparsebunlde", and the logged-in user does not have execute permission
on that directory, we destroy the infoplist bstring we created, and
move on to the next entry. Unfortunately, we do not set infoplist to
NULL, and trying to bdestroy infoplist at cleanup time causes an
attempted read of bstring->slen in a region that was freed.

Found with Clang's address sanitizer.
[sanitize-report.txt](https://github.com/Netatalk/Netatalk/files/4406013/sanitize-report.txt)
