### PR TITLE
[2.2] Resolve CUPS compilation time errors

### DIFF
--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -165,7 +165,7 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 
         if ((response = cupsDoRequest(http, request, "/")) == NULL)
         {
-     		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
+    		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
                          ippErrorString(cupsLastError()));
                 httpClose(http);
                 return (0);
@@ -186,7 +186,7 @@ cups_printername_ok(char *name)         /* I - Name of printer */
                 return (1);
         }
 
- 	return (0);
+	return (0);
 }
 
 const char * 
@@ -206,13 +206,13 @@ cups_get_printer_status (struct printer *pr)
         ipp_attribute_t *attr;          /* Current attribute */
         cups_lang_t     *language;      /* Default language */
         char            uri[HTTP_MAX_URI]; /* printer-uri attribute */
- 	int 		status = -1;
+	int 		status = -1;
 
         static const char *pattrs[] =   /* Requested printer attributes */
                         {
                           "printer-state",
                           "printer-state-message",
- 			  "printer-is-accepting-jobs"
+			  "printer-is-accepting-jobs"
                         };
 
        /*
@@ -293,25 +293,25 @@ cups_get_printer_status (struct printer *pr)
         * Get the current printer status and convert it to the status values.
         */
 
- 	memset ( pr->p_status, 0 ,sizeof(pr->p_status));
+	memset ( pr->p_status, 0 ,sizeof(pr->p_status));
 
         if ((attr = ippFindAttribute(response, "printer-state", IPP_TAG_ENUM)) != NULL)
         {
                 if (ippGetInteger(attr, 0) == IPP_PRINTER_STOPPED)
- 			status = 1;
+			status = 1;
                 else if (ippGetInteger(attr,0) == IPP_NOT_ACCEPTING)
- 			status = 0;
- 		else
- 			status = 2;
+			status = 0;
+		else
+			status = 2;
         }
 
- 	if ((attr = ippFindAttribute(response, "printer-is-accepting-jobs", IPP_TAG_BOOLEAN)) != NULL)
- 	{
+	if ((attr = ippFindAttribute(response, "printer-is-accepting-jobs", IPP_TAG_BOOLEAN)) != NULL)
+	{
 		if ( ippGetInteger(attr, 0) == 0 )
- 			status = 0;
- 	}
- 		
- 	snprintf ( pr->p_status, 255, cups_status_msg[status], pr->p_printer );
+			status = 0;
+	}
+		
+	snprintf ( pr->p_status, 255, cups_status_msg[status], pr->p_printer );
 
         if ((attr = ippFindAttribute(response, "printer-state-message", IPP_TAG_TEXT)) != NULL)
 		strncat ( pr->p_status, ippGetString(attr, 0, NULL), 255-strlen(pr->p_status));
@@ -324,7 +324,7 @@ cups_get_printer_status (struct printer *pr)
 
         httpClose(http);
 
- 	return (status);
+	return (status);
 }
 
 

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -165,7 +165,7 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 
         if ((response = cupsDoRequest(http, request, "/")) == NULL)
         {
-    		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
+      		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
                          ippErrorString(cupsLastError()));
                 httpClose(http);
                 return (0);

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -165,7 +165,7 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 
         if ((response = cupsDoRequest(http, request, "/")) == NULL)
         {
-                LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
+     		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
                          ippErrorString(cupsLastError()));
                 httpClose(http);
                 return (0);
@@ -175,9 +175,8 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 
         if (cupsLastError() >= IPP_OK_CONFLICT)
         {
-                LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
+      		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
                          ippErrorString(cupsLastError()));
-
                 ippDelete(response);
                 return (0);
         }
@@ -187,7 +186,7 @@ cups_printername_ok(char *name)         /* I - Name of printer */
                 return (1);
         }
 
-        return (0);
+ 	return (0);
 }
 
 const char * 
@@ -207,13 +206,13 @@ cups_get_printer_status (struct printer *pr)
         ipp_attribute_t *attr;          /* Current attribute */
         cups_lang_t     *language;      /* Default language */
         char            uri[HTTP_MAX_URI]; /* printer-uri attribute */
-        int 		status = -1;
+ 	int 		status = -1;
 
         static const char *pattrs[] =   /* Requested printer attributes */
                         {
                           "printer-state",
                           "printer-state-message",
-                          "printer-is-accepting-jobs"
+ 			  "printer-is-accepting-jobs"
                         };
 
        /*
@@ -275,7 +274,7 @@ cups_get_printer_status (struct printer *pr)
 
         if ((response = cupsDoRequest(http, request, "/")) == NULL)
         {
-                LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", pr->p_printer,
+      		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", pr->p_printer,
                          ippErrorString(cupsLastError()));
                 httpClose(http);
                 return (0);
@@ -283,9 +282,8 @@ cups_get_printer_status (struct printer *pr)
 
         if (cupsLastError() >= IPP_OK_CONFLICT)
         {
-		        LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", pr->p_printer,
+      		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", pr->p_printer,
                          ippErrorString(cupsLastError()));
-
                 ippDelete(response);
                 httpClose(http);
                 return (0);
@@ -295,28 +293,28 @@ cups_get_printer_status (struct printer *pr)
         * Get the current printer status and convert it to the status values.
         */
 
-        memset ( pr->p_status, 0 ,sizeof(pr->p_status));
+ 	memset ( pr->p_status, 0 ,sizeof(pr->p_status));
 
         if ((attr = ippFindAttribute(response, "printer-state", IPP_TAG_ENUM)) != NULL)
         {
                 if (ippGetInteger(attr, 0) == IPP_PRINTER_STOPPED)
-                        status = 1;
+ 			status = 1;
                 else if (ippGetInteger(attr,0) == IPP_NOT_ACCEPTING)
-                        status = 0;
-                else
-                        status = 2;
+ 			status = 0;
+ 		else
+ 			status = 2;
         }
 
-        if ((attr = ippFindAttribute(response, "printer-is-accepting-jobs", IPP_TAG_BOOLEAN)) != NULL)
-        {
-		        if ( ippGetInteger(attr, 0) == 0 )
-                        status = 0;
-        }
-
-        snprintf ( pr->p_status, 255, cups_status_msg[status], pr->p_printer );
+ 	if ((attr = ippFindAttribute(response, "printer-is-accepting-jobs", IPP_TAG_BOOLEAN)) != NULL)
+ 	{
+		if ( ippGetInteger(attr, 0) == 0 )
+ 			status = 0;
+ 	}
+ 		
+ 	snprintf ( pr->p_status, 255, cups_status_msg[status], pr->p_printer );
 
         if ((attr = ippFindAttribute(response, "printer-state-message", IPP_TAG_TEXT)) != NULL)
-                strncat ( pr->p_status, ippGetString(attr, 0, NULL), 255-strlen(pr->p_status));
+		strncat ( pr->p_status, ippGetString(attr, 0, NULL), 255-strlen(pr->p_status));
 
         ippDelete(response);
 
@@ -326,7 +324,7 @@ cups_get_printer_status (struct printer *pr)
 
         httpClose(http);
 
-        return (status);
+ 	return (status);
 }
 
 

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -39,11 +39,11 @@
 
 #ifdef HAVE_CUPS
 
-/* enable pre-1.6 CUPS API for now */
-#define _PPD_DEPRECATED
-
-/* expose structs that are private post-1.5 CUPS */
-#define _IPP_PRIVATE_STRUCTURES 1
+/*
+ * Do not error out on deprecation messages
+ * -- darktable does this in their "src/common/cups_print.c"
+ */
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 #include <cups/ipp.h>
 #include <cups/cups.h>
@@ -60,6 +60,11 @@
 
 #define MAXCHOOSERLEN 31
 #define HTTP_MAX_URI 1024
+
+/* Deal with post-1.7 deprecated httpConnect() */
+#define httpConnect(host, port)		httpConnect2(host, port, NULL, AF_UNSPEC, HTTP_ENCRYPTION_IF_REQUESTED, 1, 1000, NULL)
+
+/* XXX Also: cupsGetPPD() */
 
 static const char* cups_status_msg[] = {
         "status: busy; info: \"%s\" is rejecting jobs; ",
@@ -136,11 +141,7 @@ cups_printername_ok(char *name)         /* I - Name of printer */
         *    requested-attributes
         *    printer-uri
         */
-
-        request = ippNew();
-
-        request->request.op.operation_id = IPP_GET_PRINTER_ATTRIBUTES;
-        request->request.op.request_id   = 1;
+        request = ippNewRequest(IPP_OP_GET_PRINTER_ATTRIBUTES);
 
         language = cupsLangDefault();
 
@@ -164,7 +165,7 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 
         if ((response = cupsDoRequest(http, request, "/")) == NULL)
         {
-      		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
+                LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
                          ippErrorString(cupsLastError()));
                 httpClose(http);
                 return (0);
@@ -172,10 +173,11 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 
         httpClose(http);
 
-        if (response->request.status.status_code >= IPP_OK_CONFLICT)
+        if (cupsLastError() >= IPP_OK_CONFLICT)
         {
-      		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
-                         ippErrorString(response->request.status.status_code));
+                LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
+                         ippErrorString(cupsLastError()));
+
                 ippDelete(response);
                 return (0);
         }
@@ -185,7 +187,7 @@ cups_printername_ok(char *name)         /* I - Name of printer */
                 return (1);
         }
 
-	return (0);
+        return (0);
 }
 
 const char * 
@@ -205,13 +207,13 @@ cups_get_printer_status (struct printer *pr)
         ipp_attribute_t *attr;          /* Current attribute */
         cups_lang_t     *language;      /* Default language */
         char            uri[HTTP_MAX_URI]; /* printer-uri attribute */
-	int 		status = -1;
+        int 		status = -1;
 
         static const char *pattrs[] =   /* Requested printer attributes */
                         {
                           "printer-state",
                           "printer-state-message",
-			  "printer-is-accepting-jobs"
+                          "printer-is-accepting-jobs"
                         };
 
        /*
@@ -249,10 +251,7 @@ cups_get_printer_status (struct printer *pr)
         *    printer-uri
         */
 
-        request = ippNew();
-
-        request->request.op.operation_id = IPP_GET_PRINTER_ATTRIBUTES;
-        request->request.op.request_id   = 1;
+        request = ippNewRequest(IPP_OP_GET_PRINTER_ATTRIBUTES);
 
         language = cupsLangDefault();
 
@@ -276,16 +275,17 @@ cups_get_printer_status (struct printer *pr)
 
         if ((response = cupsDoRequest(http, request, "/")) == NULL)
         {
-      		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", pr->p_printer,
+                LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", pr->p_printer,
                          ippErrorString(cupsLastError()));
                 httpClose(http);
                 return (0);
         }
 
-        if (response->request.status.status_code >= IPP_OK_CONFLICT)
+        if (cupsLastError() >= IPP_OK_CONFLICT)
         {
-      		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", pr->p_printer,
-                         ippErrorString(response->request.status.status_code));
+		        LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", pr->p_printer,
+                         ippErrorString(cupsLastError()));
+
                 ippDelete(response);
                 httpClose(http);
                 return (0);
@@ -295,28 +295,28 @@ cups_get_printer_status (struct printer *pr)
         * Get the current printer status and convert it to the status values.
         */
 
-	memset ( pr->p_status, 0 ,sizeof(pr->p_status));
+        memset ( pr->p_status, 0 ,sizeof(pr->p_status));
 
         if ((attr = ippFindAttribute(response, "printer-state", IPP_TAG_ENUM)) != NULL)
         {
-                if (attr->values[0].integer == IPP_PRINTER_STOPPED)
-			status = 1;
-                else if (attr->values[0].integer == IPP_NOT_ACCEPTING)
-			status = 0;
-		else
-			status = 2;
+                if (ippGetInteger(attr, 0) == IPP_PRINTER_STOPPED)
+                        status = 1;
+                else if (ippGetInteger(attr,0) == IPP_NOT_ACCEPTING)
+                        status = 0;
+                else
+                        status = 2;
         }
 
-	if ((attr = ippFindAttribute(response, "printer-is-accepting-jobs", IPP_TAG_BOOLEAN)) != NULL)
-	{
-		if ( attr->values[0].integer == 0 ) 
-			status = 0;
-	}
-		
-	snprintf ( pr->p_status, 255, cups_status_msg[status], pr->p_printer );
+        if ((attr = ippFindAttribute(response, "printer-is-accepting-jobs", IPP_TAG_BOOLEAN)) != NULL)
+        {
+		        if ( ippGetInteger(attr, 0) == 0 )
+                        status = 0;
+        }
+
+        snprintf ( pr->p_status, 255, cups_status_msg[status], pr->p_printer );
 
         if ((attr = ippFindAttribute(response, "printer-state-message", IPP_TAG_TEXT)) != NULL)
-		strncat ( pr->p_status, attr->values[0].string.text, 255-strlen(pr->p_status));
+                strncat ( pr->p_status, ippGetString(attr, 0, NULL), 255-strlen(pr->p_status));
 
         ippDelete(response);
 
@@ -326,7 +326,7 @@ cups_get_printer_status (struct printer *pr)
 
         httpClose(http);
 
-	return (status);
+        return (status);
 }
 
 


### PR DESCRIPTION
Deprecated functions: Remove obsolete define, and disable compiler errors for deprecation warnings, as seen in the darktable print code.

Accessors: Cups has abstracted away access to ipp_t fields, use accessor functions.

(from [NetBSD](http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/patch-etc_papd_print_cups.c?rev=1.3&content-type=text/x-cvsweb-markup&sortby=date))