### PR TITLE
[2.2] Fix 'multiple definition' compile time errors

### DIFF
--- a/etc/afpd/directory.h
+++ b/etc/afpd/directory.h
@@ -93,7 +93,7 @@ struct maccess {
 #define	AR_UWRITE	(1<<2)
 #define	AR_UOWN		(1<<7)
 
-q_t *invalid_dircache_entries;
+extern q_t *invalid_dircache_entries;
 
 typedef int (*dir_loop)(struct dirent *, char *, void *);
 

--- a/etc/afpd/volume.h
+++ b/etc/afpd/volume.h
@@ -36,6 +36,6 @@ int afp_closevol     (AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf,  size
 /* netatalk functions */
 extern void     close_all_vol   (void);
 
-struct vol *current_vol;        /* last volume from getvolbyvid() */
+extern struct vol *current_vol;        /* last volume from getvolbyvid() */
 
 #endif


### PR DESCRIPTION
gcc 10 on Linux throws "multiple definition" errors; declares two variables as external to avoid this.