### PR TITLE
Handle special FIRSTNET behavior in NetBSD

### DIFF
--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -296,10 +296,10 @@ static void as_timer(int sig _U_)
 		    LOG(log_info, logtype_atalkd, "config for no router" );
 		      
 		    if ( iface->i_flags & IFACE_PHASE2 ) {
-			iface->i_rt->rt_firstnet = htons( STARTUP_FIRSTNET );
+			iface->i_rt->rt_firstnet = htons( OS_STARTUP_FIRSTNET );
 			iface->i_rt->rt_lastnet = htons( STARTUP_LASTNET );
 			setaddr( iface, IFACE_PHASE2, iface->i_addr.sat_addr.s_net, iface->i_addr.sat_addr.s_node,
-				htons( STARTUP_FIRSTNET ), htons( STARTUP_LASTNET ));
+				htons( OS_STARTUP_FIRSTNET ), htons( STARTUP_LASTNET ));
 		    }
 		    if ( looproute( iface, RTMP_ADD ) ) { /* -1 or 1 */
 			LOG(log_error, logtype_atalkd, "as_timer: can't route %u.%u to loopback: %s",

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -293,13 +293,20 @@ static void as_timer(int sig _U_)
 		     * Configure for no router operation.  Wait for a route
 		     * to become available in rtmp_packet().
 		     */
+
+#ifdef __NetBSD__
+#define STARTUP_FIRSTNET 1
+#else
+#define STARTUP_FIRSTNET 0
+#endif
+
 		    LOG(log_info, logtype_atalkd, "config for no router" );
 		      
 		    if ( iface->i_flags & IFACE_PHASE2 ) {
-			iface->i_rt->rt_firstnet = 0;
+			iface->i_rt->rt_firstnet = htons( STARTUP_FIRSTNET );
 			iface->i_rt->rt_lastnet = htons( STARTUP_LASTNET );
 			setaddr( iface, IFACE_PHASE2, iface->i_addr.sat_addr.s_net, iface->i_addr.sat_addr.s_node,
-				0, htons( STARTUP_LASTNET ));
+				htons( STARTUP_FIRSTNET ), htons( STARTUP_LASTNET ));
 		    }
 		    if ( looproute( iface, RTMP_ADD ) ) { /* -1 or 1 */
 			LOG(log_error, logtype_atalkd, "as_timer: can't route %u.%u to loopback: %s",

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -293,7 +293,6 @@ static void as_timer(int sig _U_)
 		     * Configure for no router operation.  Wait for a route
 		     * to become available in rtmp_packet().
 		     */
-
 		    LOG(log_info, logtype_atalkd, "config for no router" );
 		      
 		    if ( iface->i_flags & IFACE_PHASE2 ) {

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -294,7 +294,7 @@ static void as_timer(int sig _U_)
 		     * to become available in rtmp_packet().
 		     */
 
-#ifdef __NetBSD__
+#ifdef NETBSD
 #define STARTUP_FIRSTNET 1
 #else
 #define STARTUP_FIRSTNET 0

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -294,12 +294,6 @@ static void as_timer(int sig _U_)
 		     * to become available in rtmp_packet().
 		     */
 
-#ifdef NETBSD
-#define STARTUP_FIRSTNET 1
-#else
-#define STARTUP_FIRSTNET 0
-#endif
-
 		    LOG(log_info, logtype_atalkd, "config for no router" );
 		      
 		    if ( iface->i_flags & IFACE_PHASE2 ) {

--- a/etc/atalkd/rtmp.h
+++ b/etc/atalkd/rtmp.h
@@ -69,14 +69,14 @@ struct rtmp_tuple {
 #ifndef BSD4_4
 #define RTMP_ADD	SIOCADDRT
 #define RTMP_DEL	SIOCDELRT
-#define OS_STARTUP_FIRSTNET    0
+#define OS_STARTUP_FIRSTNET 	0
 #else /* BSD4_4 */
 #define RTMP_ADD	RTM_ADD
 #define RTMP_DEL	RTM_DELETE
-#define OS_STARTUP_FIRSTNET    1
+#define OS_STARTUP_FIRSTNET 	1
 #endif /* BSD4_4 */
 
-#define STARTUP_FIRSTNET    0xff00
+#define STARTUP_FIRSTNET 	0xff00
 #define STARTUP_LASTNET		0xfffe
 
 extern int	rtfd;

--- a/etc/atalkd/rtmp.h
+++ b/etc/atalkd/rtmp.h
@@ -74,6 +74,11 @@ struct rtmp_tuple {
 #define RTMP_DEL	RTM_DELETE
 #endif /* BSD4_4 */
 
+#ifdef NETBSD
+#define STARTUP_FIRSTNET    1
+#else
+#define STARTUP_FIRSTNET    0
+#endif
 #define STARTUP_LASTNET		0xfffe
 
 extern int	rtfd;

--- a/etc/atalkd/rtmp.h
+++ b/etc/atalkd/rtmp.h
@@ -74,7 +74,6 @@ struct rtmp_tuple {
 #define RTMP_DEL	RTM_DELETE
 #endif /* BSD4_4 */
 
-#define STARTUP_FIRSTNET	0xff00
 #define STARTUP_LASTNET		0xfffe
 
 extern int	rtfd;

--- a/etc/atalkd/rtmp.h
+++ b/etc/atalkd/rtmp.h
@@ -76,7 +76,7 @@ struct rtmp_tuple {
 #define OS_STARTUP_FIRSTNET 	1
 #endif /* BSD4_4 */
 
-#define STARTUP_FIRSTNET 	0xff00
+#define STARTUP_FIRSTNET	0xff00
 #define STARTUP_LASTNET		0xfffe
 
 extern int	rtfd;

--- a/etc/atalkd/rtmp.h
+++ b/etc/atalkd/rtmp.h
@@ -69,12 +69,16 @@ struct rtmp_tuple {
 #ifndef BSD4_4
 #define RTMP_ADD	SIOCADDRT
 #define RTMP_DEL	SIOCDELRT
-#define OS_STARTUP_FIRSTNET 	0
 #else /* BSD4_4 */
 #define RTMP_ADD	RTM_ADD
 #define RTMP_DEL	RTM_DELETE
-#define OS_STARTUP_FIRSTNET 	1
 #endif /* BSD4_4 */
+
+#ifndef __NetBSD__
+#define OS_STARTUP_FIRSTNET 	0
+#else
+#define OS_STARTUP_FIRSTNET 	1
+#endif
 
 #define STARTUP_FIRSTNET	0xff00
 #define STARTUP_LASTNET		0xfffe

--- a/etc/atalkd/rtmp.h
+++ b/etc/atalkd/rtmp.h
@@ -69,16 +69,14 @@ struct rtmp_tuple {
 #ifndef BSD4_4
 #define RTMP_ADD	SIOCADDRT
 #define RTMP_DEL	SIOCDELRT
+#define OS_STARTUP_FIRSTNET    0
 #else /* BSD4_4 */
 #define RTMP_ADD	RTM_ADD
 #define RTMP_DEL	RTM_DELETE
+#define OS_STARTUP_FIRSTNET    1
 #endif /* BSD4_4 */
 
-#ifdef NETBSD
-#define STARTUP_FIRSTNET    1
-#else
-#define STARTUP_FIRSTNET    0
-#endif
+#define STARTUP_FIRSTNET    0xff00
 #define STARTUP_LASTNET		0xfffe
 
 extern int	rtfd;


### PR DESCRIPTION
With PR https://github.com/Netatalk/Netatalk/pull/131 merged, compatibility with NetBSD that was originally fixed in https://github.com/Netatalk/Netatalk/commit/bbc0d89c056be3a2b5efa6bf5428f7ba8f07a1d0 is again broken.

This captures this special case inside an ifndef macro.