### PR TITLE
[2.2] Remove bitrotted code

### DIFF
--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -709,8 +709,6 @@ exit:
     return ret;
 }
 
-#define ENUMVETO "./../Network Trash Folder/TheVolumeSettingsFolder/TheFindByContentFolder/:2eDS_Store/Contents/Desktop Folder/Trash/Benutzer/"
-
 int caseenumerate(const struct vol *vol, struct path *path, struct dir *dir)
 {
     DIR               *dp;
@@ -724,9 +722,6 @@ int caseenumerate(const struct vol *vol, struct path *path, struct dir *dir)
     char          *tmp, *savepath;
 
     if (!(vol->v_flags & AFPVOL_CASEINSEN))
-        return -1;
-
-    if (veto_file(ENUMVETO, path->u_name))
         return -1;
 
     savepath = path->u_name;

--- a/libatalk/bstring/bstrlib.c
+++ b/libatalk/bstring/bstrlib.c
@@ -2737,12 +2737,6 @@ struct genBstrList g;
 #define START_VSNBUFF (256)
 #else
 
-#ifdef __GNUC__
-/* Something is making gcc complain about this prototype not being here, so 
-   I've just gone ahead and put it in. */
-extern int vsnprintf (char *buf, size_t count, const char *format, va_list arg);
-#endif
-
 #define exvsnprintf(r,b,n,f,a) {r = vsnprintf (b,n,f,a);}
 #endif
 #endif


### PR DESCRIPTION
* Remove bitrotted inline prototype for a libc function  [Downstream patch from NetBSD](http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/patch-libatalk_bstring_bstrlib.c?rev=1.1&content-type=text/x-cvsweb-markup&sortby=date). Fixing a compilation error on that platform.
* Remove the remnants of someone's local dev environment. Downstream patch from netatalk-classic https://github.com/christopherkobayashi/netatalk-classic/commit/daaed65a8a8deb2475c3d60778f1467ea682204e. 
