### PR TITLE
[2.2] Improve compatibility with GS/OS and LocalTalk bridge hardware

### DIFF
--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -895,7 +895,6 @@ int setfilparams(struct vol *vol,
         }
         switch(  bit ) {
         case FILPBIT_ATTR :
-            change_mdate = 1;
             memcpy(&ashort, buf, sizeof( ashort ));
             buf += sizeof( ashort );
             break;

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -895,6 +895,9 @@ int setfilparams(struct vol *vol,
         }
         switch(  bit ) {
         case FILPBIT_ATTR :
+            /* Preserve file dates after a GS/OS folder copy
+             *
+             * change_mdate = 1; */
             memcpy(&ashort, buf, sizeof( ashort ));
             buf += sizeof( ashort );
             break;

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -582,6 +582,12 @@ static void as_timer(int sig _U_)
 		    }
 
 		    /* split horizon */
+            /* Made the AsanteTalk bridge consistently start up in
+             * AppleTalk Phase 2, and stop the Dayna bridge from
+             * crashing GS/OS.
+             *
+             * if (rtmp->rt_iface == iface) {
+             */
 		    if (rtmp->rt_iface != iface) {
 		        continue;
 		    }

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -582,7 +582,7 @@ static void as_timer(int sig _U_)
 		    }
 
 		    /* split horizon */
-		    if (rtmp->rt_iface == iface) {
+		    if (rtmp->rt_iface != iface) {
 		        continue;
 		    }
 


### PR DESCRIPTION
```
        # Patch the source so file dates are preserved during a GS/OS folder copy,
        #   and the AsanteTalk bridge consistently starts up in AppleTalk Phase 2
        #   and the Dayna bridge doesn't crash GS/OS
        # props to Steven Hirsch for these
        sed -i ':a;N;$!ba;s/case FILPBIT_ATTR :\n *change_mdate = 1;\n/case FILPBIT_ATTR :\n/g' etc/afpd/file.c
        sed -i 's/rtmp->rt_iface == iface/rtmp->rt_iface != iface/g' etc/atalkd/main.c
```

Source: http://appleii.ivanx.com/a2server/scripts/a2server-3-sharing.txt