### PR TITLE
[2.2] Fixes for the OpenSSL 1.1 API; add OpenSSL 1.0 backwards compat

### DIFF
--- a/etc/uams/openssl_compat.h
+++ b/etc/uams/openssl_compat.h
@@ -1,0 +1,45 @@
+/*
+
+Copyright (c) 2017 Denis Bychkov (manover@gmail.com)
+
+This file is released under the GNU General Public License (GPLv2).
+The full license text is available at:
+
+http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
+*/
+
+#ifndef OPENSSL_COMPAT_H
+#define OPENSSL_COMPAT_H
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+inline static int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
+{
+   /* If the fields p and g in d are NULL, the corresponding input
+    * parameters MUST be non-NULL.  q may remain NULL.
+    */
+   if ((dh->p == NULL && p == NULL) || (dh->g == NULL && g == NULL))
+       return 0;
+
+   if (p != NULL)
+       dh->p = p;
+   if (q != NULL)
+       dh->q = q;
+   if (g != NULL)
+       dh->g = g;
+
+   if (q != NULL)
+       dh->length = BN_num_bits(q);
+
+   return 1;
+}
+
+inline static void DH_get0_key(const DH *dh, const BIGNUM **pub_key, const BIGNUM **priv_key)
+{
+   if (pub_key != NULL)
+       *pub_key = dh->pub_key;
+   if (priv_key != NULL)
+       *priv_key = dh->priv_key;
+}
+#endif /* OPENSSL_VERSION_NUMBER */
+
+#endif /* OPENSSL_COMPAT_H */

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -190,6 +190,7 @@ static int dhx_setup(void *obj, char *ibuf, size_t ibuflen _U_,
     u_int16_t sessid;
     size_t i;
     BIGNUM *bn, *gbn, *pbn;
+    const BIGNUM *pub_key;
     DH *dh;
 
     /* get the client's public key */
@@ -233,9 +234,16 @@ static int dhx_setup(void *obj, char *ibuf, size_t ibuflen _U_,
       return AFPERR_PARAM;
     }
 
+    if (!DH_set0_pqg(dh, pbn, NULL, gbn)) {
+      BN_free(pbn);
+      BN_free(gbn);
+    /* Log Entry */
+      LOG(log_info, logtype_uams, "uams_dhx_pam.c :PAM DH_set0_pqg() mysteriously failed  -- %s", strerror(errno));
+    /* Log Entry */
+      goto pam_fail;
+    }
+
     /* generate key and make sure that we have enough space */
-    dh->p = pbn;
-    dh->g = gbn;
     if (DH_generate_key(dh) == 0) {
 	unsigned long dherror;
 	char errbuf[256];
@@ -249,16 +257,17 @@ static int dhx_setup(void *obj, char *ibuf, size_t ibuflen _U_,
 	ERR_free_strings();
 	goto pam_fail;
     }
-    if (BN_num_bytes(dh->pub_key) > KEYSIZE) {
+    DH_get0_key(dh, &pub_key, NULL);
+    if (BN_num_bytes(pub_key) > KEYSIZE) {
 	LOG(log_info, logtype_uams, "uams_dhx_pam.c :PAM: Err Generating Key -- Not enough Space? -- %s", strerror(errno));
 	goto pam_fail;
     }
 
     /* figure out the key. store the key in rbuf for now. */
-    i = DH_compute_key(rbuf, bn, dh);
+    i = DH_compute_key((unsigned char *)rbuf, bn, dh);
     
     /* set the key */
-    CAST_set_key(&castkey, i, rbuf);
+    CAST_set_key(&castkey, i, (unsigned char *)rbuf);
     
     /* session id. it's just a hashed version of the object pointer. */
     sessid = dhxhash(obj);
@@ -267,7 +276,7 @@ static int dhx_setup(void *obj, char *ibuf, size_t ibuflen _U_,
     *rbuflen += sizeof(sessid);
     
     /* public key */
-    BN_bn2bin(dh->pub_key, rbuf); 
+    BN_bn2bin(pub_key, (unsigned char *)rbuf); 
     rbuf += KEYSIZE;
     *rbuflen += KEYSIZE;
 

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -35,6 +35,7 @@
 #include <openssl/dh.h>
 #include <openssl/cast.h>
 #include <openssl/err.h>
+#include "openssl_compat.h"
 #else /* OPENSSL_DHX */
 #include <bn.h>
 #include <dh.h>

--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -37,6 +37,7 @@
 #include <openssl/bn.h>
 #include <openssl/dh.h>
 #include <openssl/cast.h>
+#include "openssl_compat.h"
 #else /* OPENSSL_DHX */
 #include <bn.h>
 #include <dh.h>


### PR DESCRIPTION
- [OpenSSL 1.0 backwards compatibility header](https://github.com/NJRoadfan/a2server/blob/ivanx-1.5.x/files/netatalkpatches.tar.gz), downstream patch from the A2SERVER project
- [Downstream patch from NetBSD](http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/patch-etc_uams_uams__dhx__pam.c?rev=1.2&content-type=text/x-cvsweb-markup&sortby=date)

Note: The latter patch was originally part of the cluster of NetBSD fixes for OpenSSL 1.1 that was merged in https://github.com/Netatalk/Netatalk/pull/131