### PR TITLE
[2.2] Install afp_ldap.conf based on LDAP support, not availability of ACLs.

### DIFF
--- a/config/Makefile.am
+++ b/config/Makefile.am
@@ -23,7 +23,7 @@ else
 CONFFILES = AppleVolumes.system netatalk.conf
 endif
 
-if HAVE_ACLS
+if HAVE_LDAP
 CONFFILES += afp_ldap.conf
 endif
 

--- a/include/atalk/ldapconfig.h
+++ b/include/atalk/ldapconfig.h
@@ -1,5 +1,4 @@
 #ifdef HAVE_LDAP
-#ifdef HAVE_ACLS
 
 #ifndef LDAPCONFIG_H
 #define LDAPCONFIG_H
@@ -40,5 +39,4 @@ extern struct pref_array prefs_array[];
 extern int ldap_config_valid;
 
 #endif /* LDAPCONFIG_H */
-#endif /* HAVE_ACLS */
 #endif /* HAVE_LDAP */


### PR DESCRIPTION
Reverts the change in https://github.com/Netatalk/Netatalk/commit/096575860727879781fe809b8ef4165ef5ac0297#diff-62bf7ac6043eccf1da242490184942eceb426dc601fb3215a3f89bef1fc59e68

> Correct an erroneous patch that was unfortunately submitted upstream.
> Providing an empty header because we do not support ACLs only serves to break ldap support.
\- hauke

[Downstream patch from NetBSD](http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/patch-include_atalk_ldapconfig.h?rev=1.3&content-type=text/x-cvsweb-markup&sortby=date)