### PR TITLE
Ability to disable session tickles; papd response improvements for AppleTalk =<58

### DIFF
--- a/config/afpd.conf.tmpl
+++ b/config/afpd.conf.tmpl
@@ -175,11 +175,11 @@
 #                         Note, this defaults to 30 seconds, and really 
 #                         shouldn't be changed.  If you want to control
 #                         the server idle timeout, use the -timeout option.
+#                         A value of 0 disables session timer tickles.
 #     -timeout <number>   Specify the number of tickles to send before
 #                         timing out a connection.
 #                         The default is 4, therefore a connection will
 #                         timeout in 2 minutes.
-#                         A value of -1 disables session timer tickles.
 #     -[no]icon           [Don't] Use the platform-specific icon. Recent
 #                         Mac OS don't display it any longer.
 #     -volnamelen <number>

--- a/config/afpd.conf.tmpl
+++ b/config/afpd.conf.tmpl
@@ -179,6 +179,7 @@
 #                         timing out a connection.
 #                         The default is 4, therefore a connection will
 #                         timeout in 2 minutes.
+#                         A value of -1 disables session timer tickles.
 #     -[no]icon           [Don't] Use the platform-specific icon. Recent
 #                         Mac OS don't display it any longer.
 #     -volnamelen <number>

--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -318,7 +318,7 @@ int afp_options_parseline(char *buf, struct afp_options *options)
         options->loginmaxfail = atoi(c);
     if ((c = getoption(buf, "-tickleval"))) {
         options->tickleval = atoi(c);
-        if (options->tickleval != -1 && options->tickleval <= 0) {
+        if (options->tickleval != 0 && options->tickleval < 0) {
             options->tickleval = 30;
         }
     }

--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -318,7 +318,7 @@ int afp_options_parseline(char *buf, struct afp_options *options)
         options->loginmaxfail = atoi(c);
     if ((c = getoption(buf, "-tickleval"))) {
         options->tickleval = atoi(c);
-        if (options->tickleval <= 0) {
+        if (options->tickleval != -1 && options->tickleval <= 0) {
             options->tickleval = 30;
         }
     }

--- a/etc/papd/file.c
+++ b/etc/papd/file.c
@@ -40,7 +40,7 @@ int markline( struct papfile *pf, char **start, int *linelength, int *crlflength
     if ( *linelength >= pf->pf_datalen ) {
 	if ( pf->pf_state & PF_EOF ) {
 	    append( pf, "\n", 1 );
-	} else if (*linelength < 1024) {
+	} else {
 	    return( -1 );
 	}
     }
@@ -106,6 +106,20 @@ void append(struct papfile *pf, const char *data, int len)
     }
 }
 
+
+void spoolreply(struct papfile *out, char *str)
+{
+    char	*pserr1 = "%%[ status: ";
+    char	*pserr2 = " ]%%\n";
+
+    if ( str == NULL ) {
+	str = "Spooler error.";
+    }
+
+    append( out, pserr1, strlen( pserr1 ));
+    append( out, str, strlen( str ));
+    append( out, pserr2, strlen( pserr2 ));
+}
 
 void spoolerror(struct papfile *out, char *str)
 {

--- a/etc/papd/file.h
+++ b/etc/papd/file.h
@@ -40,5 +40,6 @@ int markline ( struct papfile *, char **, int *, int * );
 void morespace ( struct papfile *, const char *, int );
 void append ( struct papfile *, const char *, int );
 void spoolerror ( struct papfile *, char * );
+void spoolreply ( struct papfile *, char * );
 
 #endif /* PAPD_FILE_H */

--- a/etc/papd/magics.c
+++ b/etc/papd/magics.c
@@ -74,6 +74,7 @@ int ps( struct papfile *infile, struct papfile *outfile, struct sockaddr_at *sat
 		return( 0 );
 
 	    case -1 :
+		spoolreply( outfile, "Processing..." );
 		return( 0 );
 	    }
 
@@ -98,6 +99,7 @@ int ps( struct papfile *infile, struct papfile *outfile, struct sockaddr_at *sat
 	    CONSUME( infile, linelength + crlflength );
 	}
     }
+    return 0;
 }
 
 int cm_psquery( struct papfile *in, struct papfile *out, struct sockaddr_at *sat _U_)
@@ -115,6 +117,7 @@ int cm_psquery( struct papfile *in, struct papfile *out, struct sockaddr_at *sat
 	    return( CH_DONE );
 
 	case -1 :
+	    spoolreply( out, "Processing..." );
 	    return( CH_MORE );
 
         case -2 :
@@ -149,6 +152,7 @@ int cm_psadobe( struct papfile *in, struct papfile *out, struct sockaddr_at *sat
 	    return( CH_DONE );
 
 	case -1 :
+	    spoolreply( out, "Processing..." );
 	    return( CH_MORE );
 
         case -2 :

--- a/libatalk/asp/asp_getsess.c
+++ b/libatalk/asp/asp_getsess.c
@@ -163,8 +163,8 @@ ASP asp_getsession(ASP asp, server_child *server_children,
 
       timer.it_interval.tv_sec = timer.it_value.tv_sec = tickleval;
       timer.it_interval.tv_usec = timer.it_value.tv_usec = 0;
-      if ((sigaction(SIGALRM, &action, NULL) < 0) ||
-	  (setitimer(ITIMER_REAL, &timer, NULL) < 0)) {
+      if (tickleval != -1 && ((sigaction(SIGALRM, &action, NULL) < 0) ||
+	  (setitimer(ITIMER_REAL, &timer, NULL) < 0))) {
 	free(asp_ac);
 	server_asp = NULL;
 	asp_ac = NULL;

--- a/libatalk/asp/asp_getsess.c
+++ b/libatalk/asp/asp_getsess.c
@@ -163,7 +163,7 @@ ASP asp_getsession(ASP asp, server_child *server_children,
 
       timer.it_interval.tv_sec = timer.it_value.tv_sec = tickleval;
       timer.it_interval.tv_usec = timer.it_value.tv_usec = 0;
-      if (tickleval != -1 && ((sigaction(SIGALRM, &action, NULL) < 0) ||
+      if (tickleval != 0 && ((sigaction(SIGALRM, &action, NULL) < 0) ||
 	  (setitimer(ITIMER_REAL, &timer, NULL) < 0))) {
 	free(asp_ac);
 	server_asp = NULL;

--- a/man/man5/afpd.conf.5.tmpl
+++ b/man/man5/afpd.conf.5.tmpl
@@ -598,6 +598,7 @@ These options are useful for debugging only\&.
 \-tickleval \fI[number]\fR
 .RS 4
 Sets the tickle timeout interval (in seconds)\&. Defaults to 30\&.
+A value of -1 disables session tickles.
 .RE
 .PP
 \-timeout \fI[number]\fR

--- a/man/man5/afpd.conf.5.tmpl
+++ b/man/man5/afpd.conf.5.tmpl
@@ -598,7 +598,7 @@ These options are useful for debugging only\&.
 \-tickleval \fI[number]\fR
 .RS 4
 Sets the tickle timeout interval (in seconds)\&. Defaults to 30\&.
-A value of -1 disables session tickles.
+A value of 0 disables session tickles.
 .RE
 .PP
 \-timeout \fI[number]\fR


### PR DESCRIPTION
Introduce code to better support AppleTalk 58 and earlier versions:
- Interpret "-tickleval 0" for disabling session tickles. (the original patch did '-1' instead of 0, but that value could not be parsed from afpd.conf)
- Send a reply when more data required by papd server.
- Introduce spoolreply() for sending a response back to the client.

Downstream patches from NetBSD; author is "nat":
http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/patch-man_man5_afpd.conf.5.tmpl?rev=1.1&content-type=text/x-cvsweb-markup&sortby=date
http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/patch-libatalk_asp_asp__getsess.c?rev=1.1&content-type=text/x-cvsweb-markup&sortby=date
http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/patch-etc_afpd_afp__options.c?rev=1.1&content-type=text/x-cvsweb-markup&sortby=date
http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/patch-config_afpd.conf.tmpl?rev=1.1&content-type=text/x-cvsweb-markup&sortby=date
http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/patch-etc_papd_magics.c?rev=1.1&content-type=text/x-cvsweb-markup&sortby=date
http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/patch-etc_papd_file.h?rev=1.1&content-type=text/x-cvsweb-markup&sortby=date
http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/patch-etc_papd_file.c?rev=1.1&content-type=text/x-cvsweb-markup&sortby=date