### PR TITLE
[2.2] Downstream patches for NetBSD compatibility

### DIFF
--- a/contrib/macusers/macusers.in
+++ b/contrib/macusers/macusers.in
@@ -20,7 +20,7 @@ if ($ARGV[0] =~ /^(-v|-version|--version)$/ ) {
 }
 
 $MAC_PROCESS = "afpd";
-if ($^O eq "freebsd" || $^O eq "openbsd") {
+if ($^O eq "freebsd" || $^O eq "openbsd" || $^O eq "netbsd") {
         $PS_STR    = "-awwxouser,pid,ppid,start,command";
         $MATCH_STR = '(\w+)\s+(\d+)\s+(\d+)\s+([\d\w:]+)';
 } elsif ($^O eq "solaris") {
@@ -37,7 +37,7 @@ $ASIP_PORT_NO = 548;
 $LSOF = 1;
 my %mac = ();
 
-if ($^O eq "freebsd") {
+if ($^O eq "freebsd" || $^O eq "netbsd") {
         open(SOCKSTAT, "sockstat -4 | grep $MAC_PROCESS | grep -v grep |");
 
         while (<SOCKSTAT>) {

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -1228,8 +1228,14 @@ void bootaddr(struct interface *iface)
     }
 
     if ( iface->i_flags & IFACE_PHASE1 ) {
+#ifndef __NetBSD__
 	setaddr( iface, IFACE_PHASE1, 0,
 		iface->i_caddr.sat_addr.s_node, 0, 0 );
+#else
+       setaddr( iface, IFACE_PHASE1, iface->i_caddr.sat_addr.s_net,
+		iface->i_caddr.sat_addr.s_node,
+		iface->i_rt->rt_firstnet, iface->i_rt->rt_lastnet );
+#endif
 
 	if ( iface->i_flags & IFACE_LOOPBACK ) {
 	    iface->i_flags |= IFACE_CONFIG | IFACE_ADDR;


### PR DESCRIPTION
- Set interface address correctly for phase 1 networks on NetBSD. http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/patch-etc_atalkd_main.c?rev=1.1&content-type=text/x-cvsweb-markup&sortby=date
- Explicitly support NetBSD in the macusers script. https://github.com/christopherkobayashi/netatalk-classic/commit/9c62cc37180efcce74adf0798d430cedaed6f40d