### PR TITLE
[2.2] Resolve automake warnings running bootstrap

### DIFF
--- a/bin/adv1tov2/Makefile.am
+++ b/bin/adv1tov2/Makefile.am
@@ -1,6 +1,6 @@
 # Makefile.am for bin/adv1tov2/
 
-INCLUDES = -I$(top_srcdir)/include -I$(top_srcdir)/sys
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/sys
 
 bin_PROGRAMS = adv1tov2
 

--- a/bin/aecho/Makefile.am
+++ b/bin/aecho/Makefile.am
@@ -1,6 +1,6 @@
 # Makefile.am for bin/aecho/
 
-INCLUDES = -I$(top_srcdir)/include -I$(top_srcdir)/sys
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/sys
 
 bin_PROGRAMS = aecho
 

--- a/bin/getzones/Makefile.am
+++ b/bin/getzones/Makefile.am
@@ -1,6 +1,6 @@
 # Makefile.am for bin/getzones/
 
-INCLUDES = -I$(top_srcdir)/include -I$(top_srcdir)/sys
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/sys
 
 bin_PROGRAMS = getzones
 

--- a/bin/megatron/Makefile.am
+++ b/bin/megatron/Makefile.am
@@ -1,6 +1,6 @@
 # Makefile.am for bin/megatron/
 
-INCLUDES = -I$(top_srcdir)/include -I$(top_srcdir)/sys
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/sys
 
 bin_PROGRAMS = megatron
 

--- a/bin/nbp/Makefile.am
+++ b/bin/nbp/Makefile.am
@@ -1,6 +1,6 @@
 # Makefile.am for bin/nbp/
 
-INCLUDES = -I$(top_srcdir)/include -I$(top_srcdir)/sys
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/sys
 
 bin_PROGRAMS = nbplkup nbprgstr nbpunrgstr
 

--- a/bin/pap/Makefile.am
+++ b/bin/pap/Makefile.am
@@ -1,6 +1,6 @@
 # Makefile.am for bin/pap/
 
-INCLUDES = -I$(top_srcdir)/include -I$(top_srcdir)/sys
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/sys
 
 bin_PROGRAMS = pap papstatus
 

--- a/bin/psorder/Makefile.am
+++ b/bin/psorder/Makefile.am
@@ -1,6 +1,6 @@
 # Makefile.am for bin/psorder
 
-INCLUDES = -I$(top_srcdir)/include -I$(top_srcdir)/sys
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/sys
 
 bin_PROGRAMS = psorder
 

--- a/bin/uniconv/Makefile.am
+++ b/bin/uniconv/Makefile.am
@@ -1,6 +1,6 @@
 # Makefile.am for bin/aecho/
 
-INCLUDES = -I$(top_srcdir)/include -I$(top_srcdir)/sys
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/sys
 
 bin_PROGRAMS = uniconv
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,13 +1,14 @@
 dnl configure.in for netatalk
 
-AC_INIT(etc/afpd/main.c)
+AC_INIT([netatalk], [m4_esyscmd([echo -n `cat VERSION`])])
 
 NETATALK_VERSION=`cat $srcdir/VERSION`
 AC_SUBST(NETATALK_VERSION)
 
 AC_CANONICAL_SYSTEM
-AM_INIT_AUTOMAKE(netatalk, ${NETATALK_VERSION})
+AM_INIT_AUTOMAKE([subdir-objects])
 AM_CONFIG_HEADER(config.h)
+AC_CONFIG_MACRO_DIRS([macros])
 AM_MAINTAINER_MODE([enable])
 
 dnl Checks for programs.

--- a/libatalk/dsi/Makefile.am
+++ b/libatalk/dsi/Makefile.am
@@ -1,6 +1,6 @@
 # Makefile.am for libatalk/dsi/
 
-INCLUDES = -I$(top_srcdir)/include -I$(top_srcdir)/sys
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/sys
 
 LIBS = @LIBS@
 


### PR DESCRIPTION
Resolve warnings with outdated syntax thrown by automake when running the bootstrap script.