### PR TITLE
[2.2] Handle special FIRSTNET behavior on NetBSD 

### DIFF
--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -296,10 +296,10 @@ static void as_timer(int sig _U_)
 		    LOG(log_info, logtype_atalkd, "config for no router" );
 		      
 		    if ( iface->i_flags & IFACE_PHASE2 ) {
-			iface->i_rt->rt_firstnet = 0;
+			iface->i_rt->rt_firstnet = htons( OS_STARTUP_FIRSTNET );
 			iface->i_rt->rt_lastnet = htons( STARTUP_LASTNET );
 			setaddr( iface, IFACE_PHASE2, iface->i_addr.sat_addr.s_net, iface->i_addr.sat_addr.s_node,
-				0, htons( STARTUP_LASTNET ));
+				htons( OS_STARTUP_FIRSTNET ), htons( STARTUP_LASTNET ));
 		    }
 		    if ( looproute( iface, RTMP_ADD ) ) { /* -1 or 1 */
 			LOG(log_error, logtype_atalkd, "as_timer: can't route %u.%u to loopback: %s",

--- a/etc/atalkd/rtmp.h
+++ b/etc/atalkd/rtmp.h
@@ -77,6 +77,13 @@ struct rtmp_tuple {
 #define STARTUP_FIRSTNET	0xff00
 #define STARTUP_LASTNET		0xfffe
 
+/* On NetBSD, Net 0 is reserved for lo0, it can't be used on other interfaces. */
+#ifndef __NetBSD__
+#define OS_STARTUP_FIRSTNET 	0
+#else
+#define OS_STARTUP_FIRSTNET 	1
+#endif
+
 extern int	rtfd;
 struct rtmptab	*newrt (const struct interface *);
 void rtmp_delzonemap  (struct rtmptab *);


### PR DESCRIPTION
With PR #131 merged, compatibility with NetBSD that was originally fixed in bbc0d89 is again broken, while fixing it for Linux. 
This change captures this special case inside an #ifndef macro.
See also discussion in this Ubuntu bug ticket https://bugs.launchpad.net/ubuntu/+source/netatalk/+bug/1839015