### PR TITLE
[2.2] papd patches for compatibility with older Apple LaserWriter drivers on Mac and GS/OS

### DIFF
--- a/etc/papd/file.c
+++ b/etc/papd/file.c
@@ -52,12 +52,14 @@ int markline( struct papfile *pf, char **start, int *linelength, int *crlflength
     (p[*crlflength]=='\r' || p[*crlflength]=='\n')) {
 	(*crlflength)++;
     }
-    
+
+    /* Apple LaserWriter 8 drivers don't respect line lengths
     if (!*crlflength) {
-        /* line is way too long, something fishy is going on, give up */
+        // line is way too long, something fishy is going on, give up
         LOG(log_error, logtype_papd, "markline: no crlf in comment, give up" );
         return( -2 );
     }
+    */
 
     /* success, return 1 */
     return( 1 );

--- a/etc/papd/file.h
+++ b/etc/papd/file.h
@@ -25,6 +25,7 @@ struct papfile {
 #define PF_QUERY	(1<<2)
 #define PF_STW		(1<<3)
 #define PF_TRANSLATE	(1<<4)
+#define PF_FONT_QUERY	(1<<5)
 
 #define CONSUME( pf, len )  {   (pf)->pf_data += (len); \
 				(pf)->pf_datalen -= (len); \

--- a/etc/papd/magics.c
+++ b/etc/papd/magics.c
@@ -46,6 +46,10 @@ int ps( struct papfile *infile, struct papfile *outfile, struct sockaddr_at *sat
 		}
 		state = 1;
 	}	
+	if ( infile->pf_state & PF_QUERY )
+	{
+		infile->pf_state |= PF_BOT;
+	}
 	if ( (comment = compeek()) ) {
 	    switch( (*comment->c_handler)( infile, outfile, sat )) {
 	    case CH_DONE :
@@ -81,6 +85,10 @@ int ps( struct papfile *infile, struct papfile *outfile, struct sockaddr_at *sat
 		if (( comment = commatch( start, start+linelength, magics )) != NULL ) {
 		    compush( comment );
 		    continue;	/* top of for (;;) */
+		}
+		else {
+		    CONSUME( infile, linelength + crlflength );
+		    continue; /* clear out the input queue if client sent data before magic string */
 		}
 #if 0
 		infile->pf_state &= ~PF_BOT;

--- a/etc/papd/magics.c
+++ b/etc/papd/magics.c
@@ -115,6 +115,12 @@ int cm_psquery( struct papfile *in, struct papfile *out, struct sockaddr_at *sat
     int			linelength, crlflength;
 
     for (;;) {
+	if ( in->pf_state & PF_QUERY )
+	{
+	    /* handle eof at end of query job */
+	    compop();
+	    return (CH_DONE);
+	}
 	switch ( markline( in, &start, &linelength, &crlflength )) {
 	case 0 :
 	    /* eof on infile */
@@ -189,6 +195,11 @@ int cm_psswitch(struct papfile *in, struct papfile *out, struct sockaddr_at *sat
     char		*start, *stop, *p;
     int			linelength, crlflength;
 
+	if ( in->pf_state & PF_QUERY )
+	{
+	    /*handle eof at end of query job */
+	    in->pf_state &= ~PF_QUERY;
+	}
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :
 	/* eof on infile */

--- a/etc/papd/queries.c
+++ b/etc/papd/queries.c
@@ -47,6 +47,7 @@ int gq_product( struct papfile * );
 
 int cq_query( struct papfile *, struct papfile * );
 void cq_font_answer( char *, char *, struct papfile * );
+int cq_fontlist(struct papfile *, struct papfile * );
 int cq_font( struct papfile *, struct papfile * );
 int cq_feature( struct papfile *, struct papfile * );
 int cq_printer( struct papfile *, struct papfile * );
@@ -430,6 +431,76 @@ void cq_font_answer( char *start, char *stop, struct papfile *out)
 
     return;
 }
+
+int cq_fontlist(struct papfile *in, struct papfile *out)
+{
+    char		*start;
+    int			linelength, crlflength;
+    struct papd_comment	*comment = compeek();
+    for (;;){
+        switch ( markline( in, &start, &linelength, &crlflength )) {
+        case 0 :
+	return( 0 );
+
+        case -1 :
+	return( CH_MORE );
+
+        case -2 :
+        return( CH_ERROR );
+        }
+	if ( comgetflags() == 0 ) {
+	    comsetflags( 1 );
+	    /* Send the default 35 PostScript fonts since some cups-filters PPDs lack any font entries. */
+	    append( out,"AvantGarde-Book\n", 16 );
+	    append( out,"AvantGarde-BookOblique\n", 23 );
+	    append( out,"AvantGarde-Demi\n", 16 );
+	    append( out,"AvantGarde-DemiOblique\n", 23 );
+	    append( out,"Bookman-Demi\n", 13 );
+	    append( out,"Bookman-DemiItalic\n", 19 );
+	    append( out,"Bookman-Light\n", 14 );
+	    append( out,"Bookman-LightItalic\n", 20 );
+	    append( out,"Courier\n", 8 );
+	    append( out,"Courier-Bold\n", 13 );
+	    append( out,"Courier-BoldOblique\n", 20 );
+	    append( out,"Courier-Oblique\n", 16 );
+	    append( out,"Helvetica\n", 10 );
+	    append( out,"Helvetica-Bold\n", 15 );
+	    append( out,"Helvetica-BoldOblique\n", 22 );
+	    append( out,"Helvetica-Narrow\n", 17 );
+	    append( out,"Helvetica-Narrow-Bold\n", 22 );
+	    append( out,"Helvetica-Narrow-BoldOblique\n", 29 );
+	    append( out,"Helvetica-Narrow-Oblique\n", 25 );
+	    append( out,"Helvetica-Oblique\n", 18 );
+	    append( out,"NewCenturySchlbk-Bold\n", 22 );
+	    append( out,"NewCenturySchlbk-BoldItalic\n", 28 );
+	    append( out,"NewCenturySchlbk-Italic\n", 24 );
+	    append( out,"NewCenturySchlbk-Roman\n", 23 );
+	    append( out,"Palatino-Bold\n", 14 );
+	    append( out,"Palatino-BoldItalic\n", 20 );
+	    append( out,"Palatino-Italic\n", 16 );
+	    append( out,"Palatino-Roman\n", 15 );
+	    append( out,"Symbol\n", 7 );
+	    append( out,"Times-Bold\n", 11 );
+	    append( out,"Times-BoldItalic\n", 17 );
+	    append( out,"Times-Italic\n", 13 );
+	    append( out,"Times-Roman\n", 12 );
+	    append( out,"ZapfChancery-MediumItalic\n", 26 );
+	    append( out,"ZapfDingbats\n", 13 );
+	    append( out,"*\n", 2 ); /* Terminate the list */
+	    out->pf_state |= PF_FONT_QUERY;
+        }
+        else {
+	    if ( comcmp( start, start+linelength, comment->c_end, 0 ) == 0 ) {
+		compop();
+		CONSUME( in, linelength + crlflength );
+		return( CH_DONE );
+	    }
+
+        }
+    CONSUME( in, linelength + crlflength );
+    }
+}
+
 
 int cq_font(struct papfile *in, struct papfile *out)
 {
@@ -815,6 +886,7 @@ struct papd_comment	queries[] = {
     { "%%?BeginQuery",		"%%?EndQuery",		cq_query,	0 },
     { "%%?BeginFeatureQuery",	"%%?EndFeatureQuery",	cq_feature,	0 },
     { "%%?BeginFontQuery",	"%%?EndFontQuery",	cq_font,	0 },
+    { "%%?BeginFontListQuery",  "%%?EndFontListQuery",  cq_fontlist,    0 },
     { "%%?BeginPrinterQuery",	"%%?EndPrinterQuery",	cq_printer,C_FULL },
     { "%%?Begin",		"%%?End",		cq_default,	0 },
     { "%%EOF",			NULL,			cq_end,		0 },

--- a/etc/papd/queries.c
+++ b/etc/papd/queries.c
@@ -43,6 +43,7 @@ int gq_pagecost( struct papfile * );
 int gq_true( struct papfile * );
 int gq_rbispoolerid( struct papfile * );
 int gq_rbiuamlist( struct papfile * );
+int gq_product( struct papfile * );
 
 int cq_query( struct papfile *, struct papfile * );
 void cq_font_answer( char *, char *, struct papfile * );
@@ -297,6 +298,15 @@ int gq_rbiuamlist( struct papfile *out)
     }
 }
 
+int gq_product( struct papfile *out)
+{
+    struct ppd_feature	*pdprod;
+    pdprod = ppd_feature( "*Product\n", strlen( "*Product\n" ));
+    append( out, pdprod->pd_value, strlen( pdprod->pd_value ));
+    append( out, "\r", 1 );
+    return(0);
+}
+
 
 struct genquery {
     char	*gq_name;
@@ -308,6 +318,7 @@ struct genquery {
 #endif /* notdef */
     { "RBISpoolerID",	gq_rbispoolerid },
     { "RBIUAMListQuery", gq_rbiuamlist },
+    { "Product", gq_product },
     { "ADOIsBinaryOK?", gq_true },
     { "UMICHListQueue", gq_true },
     { "UMICHDeleteJob", gq_true },


### PR DESCRIPTION
-  Comment out line length check since Apple LaserWriter 8 drivers don't respect line lengths.
-  Clear input queue and switch to query mode if Postscript magic string is detected after first line of text is sent to papd. This is needed for the GS/OS driver since that driver sends raw Postscript to the printer in order to change it's PAPStatus display before sending the magic string. This is poor driver behavior on Apple's part, but other PAP servers had no problem handling it.
-  Properly support %%EOF termination of queries. Needed for GS/OS driver. 
-  Add support for Product queries (return's printer model name). LaserWriter 7 queries this to enable/disable driver features.
-  Add support for %%?Begin/EndFontListQuery. Sends font names in individual PAP packets vs. one large packet to be consistent with other PAP servers and real PostScript printers. Needed by LaserWriter 7.x and GS/OS driver.

Downstream patches from the A2SERVER project: https://github.com/NJRoadfan/a2server/blob/ivanx-1.5.x/files/netatalkpatches.tar.gz -> papd.patch

Credits goes to @NJRoadfan