### PR TITLE
[2.2] Allow non-unicode volume to be scanned by the repair tool.

### DIFF
--- a/etc/cnid_dbd/cmd_dbd_scanvol.c
+++ b/etc/cnid_dbd/cmd_dbd_scanvol.c
@@ -1204,10 +1204,10 @@ int cmd_dbd_scanvol(DBD *dbd_ref, struct volinfo *vi, dbd_flags_t flags)
     /* Make it accessible for all funcs */
     dbd = dbd_ref;
 
-    /* We only support unicode volumes ! */
+    /* Officially, we only support unicode volumes */
     if ( vi->v_volcharset != CH_UTF8) {
         dbd_log( LOGSTD, "Not a Unicode volume: %s, %u != %u", vi->v_volcodepage, vi->v_volcharset, CH_UTF8);
-        return -1;
+        /* Log the unexpected charset and proceed */
     }
 
     /* Get volume stamp */


### PR DESCRIPTION
Based on patch by hauke, [FreeBSD downstream](http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/patch-etc_cnid_dbd_cmd_dbd_scanvol.c?rev=1.1&content-type=text/x-cvsweb-markup&sortby=date)