### PR TITLE
[2.2] Backport Netatalk 3 patches

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 Changes in 2.2.6
 ================
+* FIX: Saving from applications like Photoshop may fail, because
+       removing the resource fork AppleDouble file failed. Bug #542.
 * FIX: Fix handling of large number of volumes. Bug #527.
 
 Changes in 2.2.5

--- a/etc/afpd/acls.c
+++ b/etc/afpd/acls.c
@@ -985,7 +985,7 @@ static int get_and_map_acl(char *name, char *rbuf, size_t *rbuflen)
     EC_INIT;
     int mapped_aces = 0;
     int dirflag;
-    uint32_t *darwin_ace_count = (u_int32_t *)rbuf;
+    char *darwin_ace_count = rbuf;
 #ifdef HAVE_SOLARIS_ACLS
     int ace_count = 0;
     ace_t *aces = NULL;
@@ -1034,8 +1034,9 @@ static int get_and_map_acl(char *name, char *rbuf, size_t *rbuflen)
 
     LOG(log_debug, logtype_afpd, "get_and_map_acl: mapped %d ACEs", mapped_aces);
 
-    *darwin_ace_count = htonl(mapped_aces);
     *rbuflen += sizeof(darwin_acl_header_t) + (mapped_aces * sizeof(darwin_ace_t));
+    mapped_aces = htonl(mapped_aces);
+    memcpy(darwin_ace_count, &mapped_aces, sizeof(uint32_t));
 
     EC_STATUS(0);
 

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -1996,9 +1996,12 @@ int setdirparams(struct vol *vol, struct path *path, u_int16_t d_bitmap, char *b
         case DIRPBIT_FINFO :
             if (isad) {
                 /* Fixes #2802236 */
-                u_int16_t *fflags = (u_int16_t *)(finder_buf + FINDERINFO_FRFLAGOFF);
-                *fflags &= htons(~FINDERINFO_ISHARED);
+                uint16_t fflags;
+                memcpy(&fflags, finder_buf + FINDERINFO_FRFLAGOFF, sizeof(uint16_t));
+                fflags &= htons(~FINDERINFO_ISHARED);
+                memcpy(finder_buf + FINDERINFO_FRFLAGOFF, &fflags, sizeof(uint16_t));
                 /* #2802236 end */
+
                 if (  dir->d_did == DIRDID_ROOT ) {
                     /*
                      * Alright, we admit it, this is *really* sick!

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -785,8 +785,6 @@ int afp_moveandrename(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U
             rc = AFPERR_PARAM;
             goto exit;
         }
-        curdir->d_offcnt++;
-        sdir->d_offcnt--;
 #ifdef DROPKLUDGE
         if (vol->v_flags & AFPVOL_DROPBOX) {
             /* FIXME did is not always the source id */

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -522,6 +522,8 @@ openfork_err:
 int afp_setforkparams(AFPObj *obj _U_, char *ibuf, size_t ibuflen, char *rbuf _U_, size_t *rbuflen)
 {
     struct ofork	*ofork;
+    struct vol      *vol;
+    struct dir      *dir;
     off_t		size;
     u_int16_t		ofrefnum, bitmap;
     int                 err;
@@ -542,6 +544,16 @@ int afp_setforkparams(AFPObj *obj _U_, char *ibuf, size_t ibuflen, char *rbuf _U
     if (NULL == ( ofork = of_find( ofrefnum )) ) {
         LOG(log_error, logtype_afpd, "afp_setforkparams: of_find(%d) could not locate fork", ofrefnum );
         return( AFPERR_PARAM );
+    }
+
+    vol = ofork->of_vol;
+    if ((dir = dirlookup(vol, ofork->of_did)) == NULL) {
+        LOG(log_error, logtype_afpd, "%s: bad fork did",  of_name(ofork));
+        return AFPERR_MISC;
+    }
+    if (movecwd(vol, dir) != 0) {
+        LOG(log_error, logtype_afpd, "%s: bad fork directory", dir->d_fullpath);
+        return AFPERR_MISC;
     }
 
     if (ofork->of_vol->v_flags & AFPVOL_RO)

--- a/etc/afpd/quota.c
+++ b/etc/afpd/quota.c
@@ -450,11 +450,9 @@ mountp( char *file, int *nfs)
             return mnt.mnt_mountp;
         }
 
-        /* check for nfs. we probably should use
-         * strcmp(mnt.mnt_fstype, MNTTYPE_NFS), but that's not as fast. */
-        if ((stat(mnt.mnt_mountp, &sb) == 0) && (devno == sb.st_dev) &&
-                strchr(mnt.mnt_special, ':')) {
-            *nfs = 1;
+        /* check for nfs. */
+        if ((stat(mnt.mnt_mountp, &sb) == 0) && (devno == sb.st_dev)) {
+            *nfs = strcmp(mnt.mnt_fstype, MNTTYPE_NFS) == 0 ? 1 : 0;
             fclose( mtab );
             return mnt.mnt_special;
         }

--- a/etc/afpd/unix.c
+++ b/etc/afpd/unix.c
@@ -84,8 +84,7 @@ int ustatfs_getvolspace(const struct vol *vol, VolSpace *bfree, VolSpace *btotal
     *btotal = (VolSpace)
               ( sfs.fd_req.btot - ( sfs.fd_req.bfree - sfs.fd_req.bfreen ));
 #else /* !ultrix */
-    *btotal = (VolSpace)
-              ( sfs.f_blocks - ( sfs.f_bfree - sfs.f_bavail ));
+    *btotal = (VolSpace) sfs.f_blocks;
 #endif /* ultrix */
 
     /* see similar block above comments */

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -2311,7 +2311,7 @@ int afp_openvol(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
     }
 
     if ( volume == NULL ) {
-        return AFPERR_PARAM;
+        return AFPERR_NOOBJ;
     }
 
     /* check for a volume password */

--- a/etc/cnid_dbd/dbd_getstamp.c
+++ b/etc/cnid_dbd/dbd_getstamp.c
@@ -50,10 +50,6 @@ int dbd_getstamp(DBD *dbd, struct cnid_dbd_rqst *rqst _U_, struct cnid_dbd_rply 
     
     rply->namelen = CNID_DEV_LEN;
     rply->name = (char *)data.data + CNID_DEV_OFS;
-    
-
-    LOG(log_debug, logtype_cnid, "cnid_getstamp: Returning stamp '%08x'", *(uint32_t *)rply->name);
-
     rply->result = CNID_DBD_RES_OK;
     return 1;
 }

--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -242,6 +242,7 @@ static int dhx2_setup(void *obj, char *ibuf _U_, size_t ibuflen _U_,
     size_t nwritten;
     gcry_mpi_t Ma;
     char *Ra_binary = NULL;
+    uint16_t uint16;
 
     *rbuflen = 0;
 
@@ -267,7 +268,8 @@ static int dhx2_setup(void *obj, char *ibuf _U_, size_t ibuflen _U_,
 
     /* Session ID first */
     ID = dhxhash(obj);
-    *(u_int16_t *)rbuf = htons(ID);
+    uint16 = htons(ID);
+    memcpy(rbuf, &uint16, sizeof(uint16_t));
     rbuf += 2;
     *rbuflen += 2;
 
@@ -281,7 +283,9 @@ static int dhx2_setup(void *obj, char *ibuf _U_, size_t ibuflen _U_,
     *rbuflen += 4;
 
     /* len = length of p = PRIMEBITS/8 */
-    *(u_int16_t *)rbuf = htons((u_int16_t) PRIMEBITS/8);
+
+    uint16 = htons((uint16_t) PRIMEBITS/8);
+    memcpy(rbuf, &uint16, sizeof(uint16_t));
     rbuf += 2;
     *rbuflen += 2;
 
@@ -403,6 +407,7 @@ static int logincont1(void *obj _U_, char *ibuf, size_t ibuflen, char *rbuf, siz
     char serverNonce_bin[16];
     gcry_cipher_hd_t ctx;
     gcry_error_t ctxerror;
+    uint16_t uint16;
 
     *rbuflen = 0;
 
@@ -488,7 +493,8 @@ static int logincont1(void *obj _U_, char *ibuf, size_t ibuflen, char *rbuf, siz
     /* ---- Start building reply packet ---- */
 
     /* Session ID + 1 first */
-    *(u_int16_t *)rbuf = htons(ID+1);
+    uint16 = htons(ID+1);
+    memcpy(rbuf, &uint16, sizeof(uint16_t));
     rbuf += 2;
     *rbuflen += 2;
 
@@ -719,7 +725,8 @@ static int pam_logincont(void *obj, struct passwd **uam_pwd,
     int ret;
 
     /* check for session id */
-    retID = ntohs(*(u_int16_t *)ibuf);
+    memcpy(&retID, ibuf, sizeof(uint16_t));
+    retID = ntohs(retID);
     if (retID == ID)
         ret = logincont1(obj, ibuf, ibuflen, rbuf, rbuflen);
     else if (retID == ID+1)

--- a/etc/uams/uams_dhx2_passwd.c
+++ b/etc/uams/uams_dhx2_passwd.c
@@ -167,6 +167,7 @@ static int dhx2_setup(void *obj, char *ibuf _U_, size_t ibuflen _U_,
 #ifdef SHADOWPW
     struct spwd *sp;
 #endif /* SHADOWPW */
+    uint16_t uint16;
 
     *rbuflen = 0;
 
@@ -216,7 +217,8 @@ static int dhx2_setup(void *obj, char *ibuf _U_, size_t ibuflen _U_,
 
     /* Session ID first */
     ID = dhxhash(obj);
-    *(u_int16_t *)rbuf = htons(ID);
+    uint16 = htons(ID);
+    memcpy(rbuf, &uint16, sizeof(uint16_t));
     rbuf += 2;
     *rbuflen += 2;
 
@@ -230,7 +232,8 @@ static int dhx2_setup(void *obj, char *ibuf _U_, size_t ibuflen _U_,
     *rbuflen += 4;
 
     /* len = length of p = PRIMEBITS/8 */
-    *(u_int16_t *)rbuf = htons((u_int16_t) PRIMEBITS/8);
+    uint16 = htons((uint16_t) PRIMEBITS/8);
+    memcpy(rbuf, &uint16, sizeof(uint16_t));
     rbuf += 2;
     *rbuflen += 2;
 
@@ -355,6 +358,7 @@ static int logincont1(void *obj _U_, struct passwd **uam_pwd _U_,
     char serverNonce_bin[16];
     gcry_cipher_hd_t ctx;
     gcry_error_t ctxerror;
+    uint16_t uint16;
 
     *rbuflen = 0;
 
@@ -442,7 +446,8 @@ static int logincont1(void *obj _U_, struct passwd **uam_pwd _U_,
     /* ---- Start building reply packet ---- */
 
     /* Session ID + 1 first */
-    *(u_int16_t *)rbuf = htons(ID+1);
+    uint16 = htons(ID+1);
+    memcpy(rbuf, &uint16, sizeof(uint16_t));
     rbuf += 2;
     *rbuflen += 2;
 
@@ -593,7 +598,8 @@ static int passwd_logincont(void *obj, struct passwd **uam_pwd,
     int ret;
 
     /* check for session id */
-    retID = ntohs(*(u_int16_t *)ibuf);
+    memcpy(&retID, ibuf, sizeof(uint16_t));
+    retID = ntohs(retID);
     if (retID == ID)
         ret = logincont1(obj, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
     else if (retID == ID+1)

--- a/libatalk/acl/uuid.c
+++ b/libatalk/acl/uuid.c
@@ -228,6 +228,7 @@ int getnamefromuuid(const uuidp_t uuidp, char **name, uuidtype_t *type) {
     int ret;
     uid_t uid;
     gid_t gid;
+    uint32_t tmp;
     struct passwd *pwd;
     struct group *grp;
 
@@ -249,7 +250,8 @@ int getnamefromuuid(const uuidp_t uuidp, char **name, uuidtype_t *type) {
     /* Check if UUID is a client local one */
     if (memcmp(uuidp, local_user_uuid, 12) == 0) {
         *type = UUID_USER;
-        uid = ntohl(*(uint32_t *)(uuidp + 12));
+        memcpy(&tmp, uuidp + 12, sizeof(uint32_t));
+        uid = ntohl(tmp);
         if ((pwd = getpwuid(uid)) == NULL) {
             /* not found, add negative entry to cache */
             add_cachebyuuid(uuidp, "UUID_ENOENT", UUID_ENOENT, 0);
@@ -265,7 +267,8 @@ int getnamefromuuid(const uuidp_t uuidp, char **name, uuidtype_t *type) {
         return ret;
     } else if (memcmp(uuidp, local_group_uuid, 12) == 0) {
         *type = UUID_GROUP;
-        gid = ntohl(*(uint32_t *)(uuidp + 12));
+        memcpy(&tmp, uuidp + 12, sizeof(uint32_t));
+        gid = ntohl(tmp);
         if ((grp = getgrgid(gid)) == NULL) {
             /* not found, add negative entry to cache */
             add_cachebyuuid(uuidp, "UUID_ENOENT", UUID_ENOENT, 0);

--- a/libatalk/vfs/ea.c
+++ b/libatalk/vfs/ea.c
@@ -122,26 +122,30 @@ static int unpack_header(struct ea * restrict ea)
 {
     int ret = 0;
     unsigned int count = 0;
+    uint16_t uint16;
     uint32_t uint32;
     char *buf;
 
     /* Check magic and version */
     buf = ea->ea_data;
-    if (*(uint32_t *)buf != htonl(EA_MAGIC)) {
-        LOG(log_error, logtype_afpd, "unpack_header: wrong magic 0x%08x", *(uint32_t *)buf);
+    memcpy(&uint32, buf, sizeof(uint32_t));
+    if (uint32 != htonl(EA_MAGIC)) {
+        LOG(log_error, logtype_afpd, "unpack_header: wrong magic 0x%08x", uint32);
         ret = -1;
         goto exit;
     }
     buf += 4;
-    if (*(uint16_t *)buf != htons(EA_VERSION)) {
-        LOG(log_error, logtype_afpd, "unpack_header: wrong version 0x%04x", *(uint16_t *)buf);
+    memcpy(&uint16, buf, sizeof(uint16_t));
+    if (uint16 != htons(EA_VERSION)) {
+        LOG(log_error, logtype_afpd, "unpack_header: wrong version 0x%04x", uint16);
         ret = -1;
         goto exit;
     }
     buf += 2;
 
     /* Get EA count */
-    ea->ea_count = ntohs(*(uint16_t *)buf);
+    memcpy(&uint16, buf, sizeof(uint16_t));
+    ea->ea_count = ntohs(uint16);
     LOG(log_debug, logtype_afpd, "unpack_header: number of EAs: %u", ea->ea_count);
     buf += 2;
 
@@ -389,6 +393,8 @@ static int create_ea_header(const char * restrict uname,
 {
     int fd = -1, err = 0;
     char *ptr;
+    uint16_t uint16;
+    uint32_t uint32;
 
     if ((fd = open(uname, O_RDWR | O_CREAT | O_EXCL, 0666 & ~ea->vol->v_umask)) == -1) {
         LOG(log_error, logtype_afpd, "ea_create: open race condition with ea header for file: %s", uname);
@@ -404,11 +410,15 @@ static int create_ea_header(const char * restrict uname,
 
     /* Now init it */
     ptr = ea->ea_data;
-    *(uint32_t *)ptr = htonl(EA_MAGIC);
+    uint32 = htonl(EA_MAGIC);
+    memcpy(ptr, &uint32, sizeof(uint32_t));
     ptr += EA_MAGIC_LEN;
-    *(uint16_t *)ptr = htons(EA_VERSION);
+
+    uint16 = htons(EA_VERSION);
+    memcpy(ptr, &uint16, sizeof(uint16_t));
     ptr += EA_VERSION_LEN;
-    *(uint16_t *)ptr = 0;       /* count */
+
+    memset(ptr, 0, 2);          /* count */
 
     ea->ea_size = EA_HEADER_SIZE;
     ea->ea_inited = EA_INITED;

--- a/macros/zeroconf.m4
+++ b/macros/zeroconf.m4
@@ -25,46 +25,46 @@ AC_DEFUN([NETATALK_ZEROCONF], [
 			zeroconf_dir="$zeroconf"
 		fi
 
-        # mDNS support using mDNSResponder
+        # mDNS support using Avahi
         AC_CHECK_HEADER(
-            dns_sd.h,
+            avahi-client/client.h,
             AC_CHECK_LIB(
-                dns_sd,
-                DNSServiceRegister,
+                avahi-client,
+                avahi_client_new,
                 AC_DEFINE(USE_ZEROCONF, 1, [Use DNS-SD registration]))
         )
 
-        if test "$ac_cv_lib_dns_sd_DNSServiceRegister" = yes; then
-            ZEROCONF_LIBS="-ldns_sd"
-            AC_DEFINE(HAVE_MDNS, 1, [Use mDNSRespnder/DNS-SD registration])
+        case "$ac_cv_lib_avahi_client_avahi_client_new" in
+        yes)
+            PKG_CHECK_MODULES(AVAHI, [ avahi-client >= 0.6 ])
+            PKG_CHECK_MODULES(AVAHI_TPOLL, [ avahi-client >= 0.6.4 ],
+                [AC_DEFINE(HAVE_AVAHI_THREADED_POLL, 1, [Uses Avahis threaded poll implementation])],
+                [AC_MSG_WARN(This Avahi implementation is not supporting threaded poll objects. Maybe this is not what you want.)])
+            ZEROCONF_LIBS="$AVAHI_LIBS"
+            ZEROCONF_CFLAGS="$AVAHI_CFLAGS"
+            AC_DEFINE(HAVE_AVAHI, 1, [Use Avahi/DNS-SD registration])
             found_zeroconf=yes
-        fi
+            ;;
+        esac
+	  	CPPFLAGS="$savedcppflags"
+	    LDFLAGS="$savedldflags"
 
-        # mDNS support using Avahi
+        # mDNS support using mDNSResponder
         if test x"$found_zeroconf" != x"yes" ; then
             AC_CHECK_HEADER(
-                avahi-client/client.h,
+                dns_sd.h,
                 AC_CHECK_LIB(
-                    avahi-client,
-                    avahi_client_new,
+                    dns_sd,
+                    DNSServiceRegister,
                     AC_DEFINE(USE_ZEROCONF, 1, [Use DNS-SD registration]))
             )
 
-            case "$ac_cv_lib_avahi_client_avahi_client_new" in
-            yes)
-                PKG_CHECK_MODULES(AVAHI, [ avahi-client >= 0.6 ])
-                PKG_CHECK_MODULES(AVAHI_TPOLL, [ avahi-client >= 0.6.4 ],
-                    [AC_DEFINE(HAVE_AVAHI_THREADED_POLL, 1, [Uses Avahis threaded poll implementation])],
-                    [AC_MSG_WARN(This Avahi implementation is not supporting threaded poll objects. Maybe this is not what you want.)])
-                ZEROCONF_LIBS="$AVAHI_LIBS"
-                ZEROCONF_CFLAGS="$AVAHI_CFLAGS"
-                AC_DEFINE(HAVE_AVAHI, 1, [Use Avahi/DNS-SD registration])
+            if test "$ac_cv_lib_dns_sd_DNSServiceRegister" = yes; then
+                ZEROCONF_LIBS="-ldns_sd"
+                AC_DEFINE(HAVE_MDNS, 1, [Use mDNSRespnder/DNS-SD registration])
                 found_zeroconf=yes
-                ;;
-            esac
-	    	CPPFLAGS="$savedcppflags"
-		    LDFLAGS="$savedldflags"
-    	fi
+            fi
+		fi
 	fi
 
 	netatalk_cv_zeroconf=no


### PR DESCRIPTION
* afpd: Return the correct error for non-existent volume https://sourceforge.net/p/netatalk/bugs/577/
* Native avahi API should be the default choice https://sourceforge.net/p/netatalk/bugs/586/
* Saving from Photoshop sometimes fails https://sourceforge.net/p/netatalk/bugs/542/
* Update Netatalk volume capacity reporting to match Samba behavior https://github.com/Netatalk/Netatalk/pull/79
* Fix possible alignment violations due to bad casts https://sourceforge.net/p/netatalk/code/ci/802908edf9df6d57637c0b3d410f0c0b4c3509c6/
* Fix crash when moving files with shortened file names https://github.com/Netatalk/Netatalk/issues/150
* Fix NFS detection, allow to use on remote fuse systems