### PR TITLE
[2.2] papd: Send replies to client when printing to prompt more data

### DIFF
--- a/etc/papd/file.c
+++ b/etc/papd/file.c
@@ -40,7 +40,7 @@ int markline( struct papfile *pf, char **start, int *linelength, int *crlflength
     if ( *linelength >= pf->pf_datalen ) {
 	if ( pf->pf_state & PF_EOF ) {
 	    append( pf, "\n", 1 );
-	} else if (*linelength < 1024) {
+	} else {
 	    return( -1 );
 	}
     }
@@ -106,6 +106,20 @@ void append(struct papfile *pf, const char *data, int len)
     }
 }
 
+
+void spoolreply(struct papfile *out, char *str)
+{
+    char	*pserr1 = "%%[ status: ";
+    char	*pserr2 = " ]%%\n";
+
+    if ( str == NULL ) {
+	str = "Spooler error.";
+    }
+
+    append( out, pserr1, strlen( pserr1 ));
+    append( out, str, strlen( str ));
+    append( out, pserr2, strlen( pserr2 ));
+}
 
 void spoolerror(struct papfile *out, char *str)
 {

--- a/etc/papd/file.h
+++ b/etc/papd/file.h
@@ -40,5 +40,6 @@ int markline ( struct papfile *, char **, int *, int * );
 void morespace ( struct papfile *, const char *, int );
 void append ( struct papfile *, const char *, int );
 void spoolerror ( struct papfile *, char * );
+void spoolreply ( struct papfile *, char * );
 
 #endif /* PAPD_FILE_H */

--- a/etc/papd/magics.c
+++ b/etc/papd/magics.c
@@ -74,6 +74,7 @@ int ps( struct papfile *infile, struct papfile *outfile, struct sockaddr_at *sat
 		return( 0 );
 
 	    case -1 :
+		spoolreply( outfile, "Processing..." );
 		return( 0 );
 	    }
 
@@ -115,6 +116,7 @@ int cm_psquery( struct papfile *in, struct papfile *out, struct sockaddr_at *sat
 	    return( CH_DONE );
 
 	case -1 :
+	    spoolreply( out, "Processing..." );
 	    return( CH_MORE );
 
         case -2 :


### PR DESCRIPTION
Patch to provide status replies when printing with AppleTalk over PPP.
Background printing does not work, since papd would only send the first block and if a status reply was not sent it would not continue with the print

Original patches by Nat Sloss. [NetBSD downstream patch repo](http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/?sortby=date#dirlist).