### PR TITLE
[2.2] afpd: Add option to disable afp session tickles

### DIFF
--- a/config/afpd.conf.tmpl
+++ b/config/afpd.conf.tmpl
@@ -175,6 +175,7 @@
 #                         Note, this defaults to 30 seconds, and really 
 #                         shouldn't be changed.  If you want to control
 #                         the server idle timeout, use the -timeout option.
+#                         A value of 0 disables session timer tickles.
 #     -timeout <number>   Specify the number of tickles to send before
 #                         timing out a connection.
 #                         The default is 4, therefore a connection will

--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -318,7 +318,7 @@ int afp_options_parseline(char *buf, struct afp_options *options)
         options->loginmaxfail = atoi(c);
     if ((c = getoption(buf, "-tickleval"))) {
         options->tickleval = atoi(c);
-        if (options->tickleval <= 0) {
+        if (options->tickleval < 0) {
             options->tickleval = 30;
         }
     }

--- a/libatalk/asp/asp_getsess.c
+++ b/libatalk/asp/asp_getsess.c
@@ -163,8 +163,8 @@ ASP asp_getsession(ASP asp, server_child *server_children,
 
       timer.it_interval.tv_sec = timer.it_value.tv_sec = tickleval;
       timer.it_interval.tv_usec = timer.it_value.tv_usec = 0;
-      if ((sigaction(SIGALRM, &action, NULL) < 0) ||
-	  (setitimer(ITIMER_REAL, &timer, NULL) < 0)) {
+      if (tickleval && ((sigaction(SIGALRM, &action, NULL) < 0) ||
+	  (setitimer(ITIMER_REAL, &timer, NULL) < 0))) {
 	free(asp_ac);
 	server_asp = NULL;
 	asp_ac = NULL;

--- a/man/man5/afpd.conf.5.tmpl
+++ b/man/man5/afpd.conf.5.tmpl
@@ -598,6 +598,7 @@ These options are useful for debugging only\&.
 \-tickleval \fI[number]\fR
 .RS 4
 Sets the tickle timeout interval (in seconds)\&. Defaults to 30\&.
+A value of 0 disables session tickles.
 .RE
 .PP
 \-timeout \fI[number]\fR


### PR DESCRIPTION
The ability to disable AFP session tickles. Needed when using AFP with AppleTalk tunneled with very slow connections such as PPP.

Original patch by Nat Sloss. [NetBSD downstream patch repo](http://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk22/patches/?sortby=date#dirlist).