### PR TITLE
[2.2] Preserve file dates during copying in GS/OS, in an AFP3 compliant way

### DIFF
--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -895,7 +895,9 @@ int setfilparams(struct vol *vol,
         }
         switch(  bit ) {
         case FILPBIT_ATTR :
-            change_mdate = 1;
+            /* Preserve file dates during a GS/OS folder copy */
+            if (afp_version >= 30) 
+                change_mdate = 1;
             memcpy(&ashort, buf, sizeof( ashort ));
             buf += sizeof( ashort );
             break;


### PR DESCRIPTION
AFP2 and earlier did not expect file date stamps to get updated when copied. This patch makes this line conditional of AFP3.

See discussion in https://68kmla.org/bb/index.php?threads/yet-another-netatalk-2-2-fork.39889/post-435799