### PR TITLE
[2.2] .gitignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,12 +19,15 @@ ltconfig
 ltmain.sh
 autom4te.cache
 autoscan.log
+test-driver
 *.rpm
 *.deb
 *.dsc
 *.changes
 *.tar.gz
 *.diff.gz
+*.diff
+*.orig
+*.rej
 *~
-.gitignore
 *.o

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/bin/adv1tov2/.gitignore
+++ b/bin/adv1tov2/.gitignore
@@ -3,5 +3,4 @@ Makefile.in
 adv1tov2
 .deps
 .libs
-.gitignore
 adv1tov2.o

--- a/bin/aecho/.gitignore
+++ b/bin/aecho/.gitignore
@@ -3,5 +3,4 @@ Makefile.in
 aecho
 .deps
 .libs
-.gitignore
 aecho.o

--- a/bin/afppasswd/.gitignore
+++ b/bin/afppasswd/.gitignore
@@ -3,5 +3,4 @@ Makefile.in
 afppasswd
 .deps
 .libs
-.gitignore
 afppasswd.o

--- a/bin/cnid/.gitignore
+++ b/bin/cnid/.gitignore
@@ -6,5 +6,4 @@ cnid_maint
 cnid_index
 .deps
 .libs
-.gitignore
 ad_cp.o ad_ls.o ad.o ad_util.o

--- a/bin/getzones/.gitignore
+++ b/bin/getzones/.gitignore
@@ -3,5 +3,4 @@ Makefile.in
 getzones
 .deps
 .libs
-.gitignore
 getzones.o

--- a/bin/megatron/.gitignore
+++ b/bin/megatron/.gitignore
@@ -3,5 +3,4 @@ Makefile.in
 megatron
 .deps
 .libs
-.gitignore
 asingle.o hqx.o macbin.o megatron.o nad.o updcrc.o

--- a/bin/misc/.gitignore
+++ b/bin/misc/.gitignore
@@ -7,5 +7,3 @@ logger_test
 .deps
 .libs
 *.o
-
-

--- a/bin/nbp/.gitignore
+++ b/bin/nbp/.gitignore
@@ -5,5 +5,4 @@ nbprgstr
 nbpunrgstr
 .deps
 .libs
-.gitignore
 nbplkup.o nbprgstr.o nbpunrgstr.o

--- a/bin/pap/.gitignore
+++ b/bin/pap/.gitignore
@@ -4,5 +4,4 @@ pap
 papstatus
 .deps
 .libs
-.gitignore
 pap.o papstatus.o

--- a/bin/psorder/.gitignore
+++ b/bin/psorder/.gitignore
@@ -3,5 +3,4 @@ Makefile.in
 psorder
 .deps
 .libs
-.gitignore
 pa.o psorder.o

--- a/bin/uniconv/.gitignore
+++ b/bin/uniconv/.gitignore
@@ -3,5 +3,4 @@ Makefile.in
 uniconv
 .deps
 .libs
-.gitignore
 iso8859_1_adapted.o uniconv.o

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -2,5 +2,4 @@ AppleVolumes.default
 Makefile
 Makefile.in
 afpd.conf
-.gitignore
 *.o

--- a/config/pam/.gitignore
+++ b/config/pam/.gitignore
@@ -1,5 +1,4 @@
 Makefile
 Makefile.in
 netatalk.pam
-.gitignore
 *.o

--- a/contrib/.gitignore
+++ b/contrib/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/contrib/a2boot/.gitignore
+++ b/contrib/a2boot/.gitignore
@@ -3,5 +3,4 @@ Makefile.in
 a2boot
 .deps
 .libs
-.gitignore
 *.o

--- a/contrib/macusers/.gitignore
+++ b/contrib/macusers/.gitignore
@@ -1,5 +1,4 @@
 Makefile
 Makefile.in
 macusers
-.gitignore
 *.o

--- a/contrib/printing/.gitignore
+++ b/contrib/printing/.gitignore
@@ -3,5 +3,4 @@ Makefile.in
 timeout
 .deps
 .libs
-.gitignore
 *.o

--- a/contrib/shell_utils/.gitignore
+++ b/contrib/shell_utils/.gitignore
@@ -9,5 +9,4 @@ netatalkshorternamelinks.pl
 lp2pap.sh
 asip-status.pl
 apple_dump
-.gitignore
 *.o

--- a/contrib/timelord/.gitignore
+++ b/contrib/timelord/.gitignore
@@ -3,5 +3,4 @@ Makefile.in
 timelord
 .deps
 .libs
-.gitignore
 *.o

--- a/distrib/.gitignore
+++ b/distrib/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/distrib/config/.gitignore
+++ b/distrib/config/.gitignore
@@ -1,5 +1,4 @@
 Makefile
 Makefile.in
 netatalk-config
-.gitignore
 *.o

--- a/distrib/initscripts/.gitignore
+++ b/distrib/initscripts/.gitignore
@@ -9,5 +9,4 @@ rc.atalk.sysv
 netatalk
 atalk
 *.service
-.gitignore
 *.o

--- a/distrib/m4/.gitignore
+++ b/distrib/m4/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,4 +1,3 @@
 Makefile.in
 Makefile
-.gitignore
 *.o

--- a/etc/.gitignore
+++ b/etc/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/etc/afpd/.gitignore
+++ b/etc/afpd/.gitignore
@@ -6,5 +6,4 @@ hash
 test_parse_mtab
 .deps
 .libs
-.gitignore
 afpd-afp_asp.o afpd-afp_config.o afpd-afp_dsi.o afpd-afp_options.o afpd-afprun.o afpd-afp_util.o afpd-afs.o afpd-appl.o afpd-auth.o afpd-catsearch.o afpd-desktop.o afpd-directory.o afpd-enumerate.o afpd-extattrs.o afpd-filedir.o afpd-file.o afpd-fork.o afpd-gettok.o afpd-hash.o afpd-main.o afpd-mangle.o afpd-messages.o afpd-nfsquota.o afpd-ofork.o afpd-quota.o afpd-status.o afpd-switch.o afpd-uam.o afpd-uid.o afpd-unix.o afpd-volume.o hash-hash.o

--- a/etc/atalkd/.gitignore
+++ b/etc/atalkd/.gitignore
@@ -3,5 +3,4 @@ Makefile.in
 atalkd
 .deps
 .libs
-.gitignore
 aep.o config.o main.o multicast.o nbp.o route.o rtmp.o zip.o

--- a/etc/cnid_dbd/.gitignore
+++ b/etc/cnid_dbd/.gitignore
@@ -5,5 +5,4 @@ cnid_dbd
 dbd
 .deps
 .libs
-.gitignore
 cmd_dbd.o cmd_dbd_scanvol.o cnid_metad.o comm.o dbd_add.o dbd_dbcheck.o dbd_delete.o dbd_get.o dbd_getstamp.o dbd_lookup.o dbd_rebuild_add.o dbd_resolve.o dbd_update.o dbif.o db_param.o main.o pack.o usockfd.o

--- a/etc/papd/.gitignore
+++ b/etc/papd/.gitignore
@@ -4,5 +4,4 @@ papd
 showppd
 .deps
 .libs
-.gitignore
 auth.o comment.o file.o headers.o lp.o magics.o main.o ppd.o printcap.o print_cups.o queries.o session.o showppd-ppd.o showppd-showppd.o uam.o

--- a/etc/psf/.gitignore
+++ b/etc/psf/.gitignore
@@ -4,5 +4,4 @@ psf
 psa
 .deps
 .libs
-.gitignore
 psa.o psf.o

--- a/etc/uams/.gitignore
+++ b/etc/uams/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 .libs
 *.lo
 *.la
-.gitignore
 uams_dhx2_pam_la-uams_dhx2_pam.o uams_dhx2_passwd.o uams_dhx_pam_la-uams_dhx_pam.o uams_dhx_passwd.o uams_gss_la-uams_gss.o uams_guest.o uams_pam_la-uams_pam.o uams_passwd.o uams_randnum.o

--- a/etc/uams/uams_krb4/.gitignore
+++ b/etc/uams/uams_krb4/.gitignore
@@ -6,5 +6,4 @@
 core
 Makefile.in
 Makefile
-.gitignore
 *.o

--- a/include/.gitignore
+++ b/include/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/include/atalk/.gitignore
+++ b/include/atalk/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/libatalk/.gitignore
+++ b/libatalk/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 dummy.o

--- a/libatalk/acl/.gitignore
+++ b/libatalk/acl/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 .libs
 *.lo
 *.la
-.gitignore
 *.o

--- a/libatalk/adouble/.gitignore
+++ b/libatalk/adouble/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 ad_attr.o ad_date.o ad_flush.o ad_lock.o ad_mmap.o ad_open.o ad_read.o ad_sendfile.o ad_size.o ad_write.o

--- a/libatalk/asp/.gitignore
+++ b/libatalk/asp/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 asp_attn.o asp_close.o asp_cmdreply.o asp_getreq.o asp_getsess.o asp_init.o asp_shutdown.o asp_tickle.o asp_write.o

--- a/libatalk/atp/.gitignore
+++ b/libatalk/atp/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 atp_bufs.o atp_close.o atp_open.o atp_packet.o atp_rreq.o atp_rresp.o atp_rsel.o atp_sreq.o atp_sresp.o

--- a/libatalk/cnid/.gitignore
+++ b/libatalk/cnid/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 cnid_init.o cnid.o

--- a/libatalk/cnid/cdb/.gitignore
+++ b/libatalk/cnid/cdb/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 libcnid_cdb_la-cnid_cdb_add.o libcnid_cdb_la-cnid_cdb_close.o libcnid_cdb_la-cnid_cdb_delete.o libcnid_cdb_la-cnid_cdb_get.o libcnid_cdb_la-cnid_cdb_lookup.o libcnid_cdb_la-cnid_cdb_open.o libcnid_cdb_la-cnid_cdb_rebuild_add.o libcnid_cdb_la-cnid_cdb_resolve.o libcnid_cdb_la-cnid_cdb_update.o

--- a/libatalk/cnid/dbd/.gitignore
+++ b/libatalk/cnid/dbd/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 cnid_dbd.o

--- a/libatalk/cnid/last/.gitignore
+++ b/libatalk/cnid/last/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 cnid_last.o

--- a/libatalk/cnid/tdb/.gitignore
+++ b/libatalk/cnid/tdb/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 cnid_tdb_add.o cnid_tdb_close.o cnid_tdb_delete.o cnid_tdb_get.o cnid_tdb_lookup.o cnid_tdb_open.o cnid_tdb_resolve.o cnid_tdb_update.o

--- a/libatalk/compat/.gitignore
+++ b/libatalk/compat/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 getusershell.o inet_aton.o mktemp.o pselect.o rquota_xdr.o snprintf.o strcasecmp.o strdup.o strstr.o

--- a/libatalk/dsi/.gitignore
+++ b/libatalk/dsi/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 dsi_attn.o dsi_close.o dsi_cmdreply.o dsi_getsess.o dsi_getstat.o dsi_init.o dsi_opensess.o dsi_read.o dsi_stream.o dsi_tcp.o dsi_tickle.o dsi_write.o

--- a/libatalk/nbp/.gitignore
+++ b/libatalk/nbp/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 nbp_lkup.o nbp_rgstr.o nbp_unrgstr.o nbp_util.o

--- a/libatalk/netddp/.gitignore
+++ b/libatalk/netddp/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 netddp_open.o netddp_recvfrom.o netddp_sendto.o

--- a/libatalk/pap/.gitignore
+++ b/libatalk/pap/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 *.o

--- a/libatalk/tdb/.gitignore
+++ b/libatalk/tdb/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 spinlock.o tdb.o

--- a/libatalk/unicode/.gitignore
+++ b/libatalk/unicode/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 charcnv.o iconv.o utf16_case.o utf8.o util_unistr.o

--- a/libatalk/unicode/charsets/.gitignore
+++ b/libatalk/unicode/charsets/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 generic_cjk.o generic_mb.o mac_centraleurope.o mac_chinese_simp.o mac_chinese_trad.o mac_cyrillic.o mac_greek.o mac_hebrew.o mac_japanese.o mac_korean.o mac_roman.o mac_turkish.o

--- a/libatalk/util/.gitignore
+++ b/libatalk/util/.gitignore
@@ -4,5 +4,4 @@ Makefile.in
 *.la
 .deps
 .libs
-.gitignore
 atalk_addr.o bprint.o fault.o getiface.o locking.o logger.o module.o server_child.o server_ipc.o server_lock.o socket.o strcasestr.o strdicasecmp.o strlcpy.o unix.o volinfo.o

--- a/libatalk/vfs/.gitignore
+++ b/libatalk/vfs/.gitignore
@@ -5,5 +5,4 @@ Makefile.in
 *.loT
 .deps
 .libs
-.gitignore
 ea.o ea_sys.o sys_ea.o unix.o vfs.o

--- a/man/.gitignore
+++ b/man/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/man/man1/.gitignore
+++ b/man/man1/.gitignore
@@ -3,5 +3,4 @@ Makefile.in
 asip-status.pl.1
 afpldaptest.1
 uniconv.1
-.gitignore
 *.o

--- a/man/man3/.gitignore
+++ b/man/man3/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/man/man4/.gitignore
+++ b/man/man4/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/man/man5/.gitignore
+++ b/man/man5/.gitignore
@@ -8,5 +8,4 @@ afpd.conf.5
 atalkd.conf.5
 netatalk.conf.5
 papd.conf.5
-.gitignore
 *.o

--- a/man/man8/.gitignore
+++ b/man/man8/.gitignore
@@ -1,5 +1,4 @@
 Makefile
 Makefile.in
-.gitignore
 *.o
 *.8

--- a/sys/.gitignore
+++ b/sys/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/sys/generic/.gitignore
+++ b/sys/generic/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/sys/generic/sys/.gitignore
+++ b/sys/generic/sys/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/sys/netatalk/.gitignore
+++ b/sys/netatalk/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/sys/netbsd/.gitignore
+++ b/sys/netbsd/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/sys/netbsd/netatalk/.gitignore
+++ b/sys/netbsd/netatalk/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/sys/solaris/.gitignore
+++ b/sys/solaris/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 ddp
-.gitignore
 *.o

--- a/sys/sunos/.gitignore
+++ b/sys/sunos/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o

--- a/sys/ultrix/.gitignore
+++ b/sys/ultrix/.gitignore
@@ -1,4 +1,3 @@
 Makefile
 Makefile.in
-.gitignore
 *.o


### PR DESCRIPTION
- Remove .gitignore from all .gitignore files. They were added as a temporary measure during the cvs to git migration. Right now, they're causing issues with working with .gitignore files in git.
- Add global patterns for common temporary files to the root .gitignore.