### PR TITLE
[2.2] Backport March 2022 CVEs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Changes in 2.2.7
+================
+* FIX: CVE-2022-23121
+* FIX: CVE-2022-23123
+* FIX: CVE-2022-23125
+
 Changes in 2.2.6
 ================
 * FIX: Saving from applications like Photoshop may fail, because

--- a/etc/afpd/appl.c
+++ b/etc/afpd/appl.c
@@ -95,6 +95,11 @@ static int copyapplfile(int sfd, int dfd, char *mpath, u_short mplen)
         p = buf + sizeof(appltag);
         memcpy( &len, p, sizeof(len));
         len = ntohs( len );
+        if (len > MAXPATHLEN - (sizeof(appltag) + sizeof(len))) {
+            errno = EINVAL;
+            cc = -1;
+            break;
+        }
         p += sizeof( len );
         if (( cc = read( sa.sdt_fd, p, len )) < len ) {
             break;

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -137,6 +137,8 @@
 #define ADEDLEN_MACFILEI        4
 #define ADEDLEN_PRODOSFILEI     8
 #define ADEDLEN_MSDOSFILEI      2
+#define ADEDLEN_ICONBW          128
+#define ADEDLEN_ICONCOL         1024
 #define ADEDLEN_DID             4
 #define ADEDLEN_PRIVDEV         8
 #define ADEDLEN_PRIVINO         8

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -489,10 +489,10 @@ bail_err:
 }
 #endif /* AD_VERSION == AD_VERSION2 */
 
-/* -------------------------------------
-   read in the entries
-*/
-static void parse_entries(struct adouble *ad, char *buf,
+/**
+ * Read an AppleDouble buffer, returns 0 on success, -1 if an entry was malformatted
+ **/
+static int parse_entries(struct adouble *ad, char *buf,
                           u_int16_t nentries)
 {
     u_int32_t   eid, len, off;
@@ -520,6 +520,8 @@ static void parse_entries(struct adouble *ad, char *buf,
                 nentries, eid );
         }
     }
+
+    return 0;
 }
 
 
@@ -534,7 +536,6 @@ static int ad_header_read(struct adouble *ad, struct stat *hst)
 {
     char                *buf = ad->ad_data;
     u_int16_t           nentries;
-    int                 len;
     ssize_t             header_len;
     static int          warning = 0;
     struct stat         st;
@@ -588,25 +589,23 @@ static int ad_header_read(struct adouble *ad, struct stat *hst)
     memcpy(ad->ad_filler, buf + ADEDOFF_FILLER, sizeof( ad->ad_filler ));
     memcpy(&nentries, buf + ADEDOFF_NENTRIES, sizeof( nentries ));
     nentries = ntohs( nentries );
-
-    /* read in all the entry headers. if we have more than the
-     * maximum, just hope that the rfork is specified early on. */
-    len = nentries*AD_ENTRY_LEN;
-
-    if (len + AD_HEADER_LEN > sizeof(ad->ad_data))
-        len = sizeof(ad->ad_data) - AD_HEADER_LEN;
-
-    buf += AD_HEADER_LEN;
-    if (len > header_len - AD_HEADER_LEN) {
-        LOG(log_debug, logtype_default, "ad_header_read: can't read entry info.");
+    if (nentries > 16) {
+        LOG(log_error, logtype_default, "ad_open: too many entries: %d", nentries);
         errno = EIO;
         return -1;
     }
 
-    /* figure out all of the entry offsets and lengths. if we aren't
-     * able to read a resource fork entry, bail. */
-    nentries = len / AD_ENTRY_LEN;
-    parse_entries(ad, buf, nentries);
+    if ((nentries * AD_ENTRY_LEN) + AD_HEADER_LEN > header_len) {
+        LOG(log_error, logtype_default, "ad_header_read: too many entries: %zd", header_len);
+        errno = EIO;
+        return -1;
+    }
+
+    if (parse_entries(ad, buf + AD_HEADER_LEN, nentries) != 0) {
+        LOG(log_warning, logtype_default, "ad_header_read(): malformed AppleDouble");
+        errno = EIO;
+        return -1;
+    }
     if (!ad_getentryoff(ad, ADEID_RFORK)
         || (ad_getentryoff(ad, ADEID_RFORK) > sizeof(ad->ad_data))
         ) {


### PR DESCRIPTION
Includes:
- CVE-2022-23121: libatalk: apply some hardening to ad_header_read[_osx]() (and a few lines from https://github.com/Netatalk/Netatalk/commit/c8385d28c3ea94a88c11d7062f969ad03c881ce1 )
- CVE-2022-23121: apply hardening to parse_entries()
- CVE-2022-23123: libatalk: add defines for icon lengths
- CVE-2022-23125: harden copyapplfile()

Does not include:
- CVE-2021-31439: libatalk: apply limit checking to DSI write offset (not affecting 2.2)
- CVE-2022-23123: libatalk: harden ad_entry() (yet able to resolve all corner cases that led to unwanted asserts)