### PR TITLE
Fix CVE-2022-23121, CVE-2022-23123 regression

### DIFF
--- a/etc/afpd/desktop.c
+++ b/etc/afpd/desktop.c
@@ -859,7 +859,7 @@ static int ad_addcomment(const AFPObj *obj, struct vol *vol, struct path *path, 
         return( AFPERR_ACCESS );
     }
 
-    if (ad_getentryoff(adp, ADEID_COMMENT)) {
+    if (ad_getentryoff(adp, ADEID_COMMENT) && ad_entry(adp, ADEID_COMMENT)) {
         if ( (ad_get_MD_flags( adp ) & O_CREAT) ) {
             if ( *path->m_name == '\0' ) {
                 name = (char *)curdir->d_m_name->data;
@@ -932,7 +932,7 @@ static int ad_getcomment(struct vol *vol, struct path *path, char *rbuf, size_t 
         return( AFPERR_NOITEM );
     }
 
-    if (!ad_getentryoff(adp, ADEID_COMMENT)) {
+    if (!ad_getentryoff(adp, ADEID_COMMENT) || !ad_entry(adp, ADEID_COMMENT)) {
         ad_close(adp, ADFLAGS_HF);
         return AFPERR_NOITEM;
     }

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -1520,10 +1520,7 @@ int getdirparams(const AFPObj *obj,
             break;
 
         case DIRPBIT_FINFO :
-            if ( isad ) {
-                ade = ad_entry(&ad, ADEID_FINDERI);
-                AFP_ASSERT(ade != NULL);
-
+            if ( isad && (ade = ad_entry(&ad, ADEID_FINDERI)) != NULL) {
                 memcpy( data, ade, 32 );
             } else { /* no appledouble */
                 memset( data, 0, 32 );
@@ -1903,15 +1900,13 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap, char *bu
             }
             break;
         case DIRPBIT_FINFO :
-            if (isad) {
+            if (isad && (ade = ad_entry(&ad, ADEID_FINDERI)) != NULL) {
                 /* Fixes #2802236 */
                 uint16_t fflags;
                 memcpy(&fflags, finder_buf + FINDERINFO_FRFLAGOFF, sizeof(uint16_t));
                 fflags &= htons(~FINDERINFO_ISHARED);
                 memcpy(finder_buf + FINDERINFO_FRFLAGOFF, &fflags, sizeof(uint16_t));
                 /* #2802236 end */
-                ade = ad_entry(&ad, ADEID_FINDERI);
-                AFP_ASSERT(ade != NULL);
 
                 if (  dir->d_did == DIRDID_ROOT ) {
                     /*

--- a/etc/afpd/extattrs.c
+++ b/etc/afpd/extattrs.c
@@ -146,6 +146,7 @@ int afp_listextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
 
     adp = &ad;
     ad_init(adp, vol);
+    ad_init_offsets(adp);
 
     if (path_isadir(s_path)) {
 	    LOG(log_debug, logtype_afpd, "afp_listextattr(%s): is a dir", uname);
@@ -175,7 +176,7 @@ int afp_listextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
         close_ad = true;
         FinderInfo = ad_entry(adp, ADEID_FINDERI);
         /* Check if FinderInfo equals default and empty FinderInfo*/
-        if (memcmp(FinderInfo, emptyFinderInfo, 32) != 0) {
+        if (FinderInfo && memcmp(FinderInfo, emptyFinderInfo, 32) != 0) {
             /* FinderInfo contains some non 0 bytes -> include "com.apple.FinderInfo" */
             strcpy(attrnamebuf, ea_finderinfo);
             attrbuflen += strlen(ea_finderinfo) + 1;

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -497,10 +497,7 @@ int getmetadata(const AFPObj *obj,
                 data += sizeof( aint );
             }
             else {
-                if ( adp ) {
-                    ade = ad_entry(adp, ADEID_FINDERI);
-                    AFP_ASSERT(ade != NULL);
-
+                if ( adp && (ade = ad_entry(adp, ADEID_FINDERI)) != NULL) {
                     memcpy(fdType, ade, 4);
 
                     if ( memcmp( fdType, "TEXT", 4 ) == 0 ) {
@@ -588,10 +585,8 @@ int getmetadata(const AFPObj *obj,
              * improper ops on symlink adoubles will be
              * more visible (assert).
              */
-            if (adp && (ad_meta_fileno(adp) != AD_SYMLINK)) {
-                ade = ad_entry(adp, ADEID_FINDERI);
-                AFP_ASSERT(ade != NULL);
-
+            if (adp && (ad_meta_fileno(adp) != AD_SYMLINK)
+                && (ade = ad_entry(adp, ADEID_FINDERI)) != NULL) {
 	        memcpy(fdType, ade, 4);
                 if ( memcmp( fdType, "slnk", 4 ) == 0 ) {
 	 	    aint |= S_IFLNK;
@@ -1071,7 +1066,10 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
                 break;
             }
             ade = ad_entry(adp, ADEID_FINDERI);
-            AFP_ASSERT(ade != NULL);
+            if (ade == NULL) {
+                LOG(log_debug, logtype_afpd, "setfilparams(\"%s\"): invalid FinderInfo", path->u_name);
+                break;
+            }
             if (default_type(ade)
                     && ( 
                      ((em = getextmap( path->m_name )) &&
@@ -1094,12 +1092,11 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
             if (isad == 0) {
                 break;
             }
-            ade = ad_entry(adp, ADEID_FINDERI);
-            AFP_ASSERT(ade != NULL);
-
             if (obj->afp_version < 30) { /* else it's UTF8 name */
-                memcpy(ade, fdType, 4 );
-                memcpy(ade + 4, "pdos", 4 );
+                if ((ade = ad_entry(adp, ADEID_FINDERI)) != NULL) {
+                    memcpy(ade, fdType, 4 );
+                    memcpy(ade + 4, "pdos", 4 );
+                }
                 break;
             }
             /* fallthrough */

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -330,11 +330,8 @@ static int getvolparams(const AFPObj *obj, uint16_t bitmap, struct vol *vol, str
             slash++;
         else
             slash = vol->v_path;
-        if (ad_getentryoff(&ad, ADEID_NAME)) {
+        if (ad_getentryoff(&ad, ADEID_NAME) && (ade = ad_entry(&ad, ADEID_NAME)) != NULL) {
             ad_setentrylen( &ad, ADEID_NAME, strlen( slash ));
-            ade = ad_entry(&ad, ADEID_NAME);
-            AFP_ASSERT(ade != NULL);
-
             memcpy(ade, slash, ad_getentrylen( &ad, ADEID_NAME ));
         }
         vol_setdate(vol->v_vid, &ad, st->st_mtime);

--- a/libatalk/adouble/ad_date.c
+++ b/libatalk/adouble/ad_date.c
@@ -16,7 +16,7 @@ int ad_setdate(struct adouble *ad,
     if (xlate)
         date = AD_DATE_FROM_UNIX(date);
 
-    if (!ad_getentryoff(ad, ADEID_FILEDATESI))
+    if (!ad_getentryoff(ad, ADEID_FILEDATESI) || !ad_entry(ad, ADEID_FILEDATESI))
         return -1;
 
     if (dateoff > AD_DATE_ACCESS)
@@ -38,7 +38,7 @@ int ad_getdate(const struct adouble *ad,
     char *ade = NULL;
 
     dateoff &= AD_DATE_MASK;
-    if (!ad_getentryoff(ad, ADEID_FILEDATESI))
+    if (!ad_getentryoff(ad, ADEID_FILEDATESI) || !ad_entry(ad, ADEID_FILEDATESI))
         return -1;
 
     if (dateoff > AD_DATE_ACCESS)


### PR DESCRIPTION
- Added guard check before access ad_entry()
- Allow zero length entry, for AppleDouble specification