### PR TITLE
etc/uams/openssl_compat.h: fix build with libressl >= 2.7.0

### DIFF
--- a/etc/uams/openssl_compat.h
+++ b/etc/uams/openssl_compat.h
@@ -11,7 +11,7 @@ http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt
 #ifndef OPENSSL_COMPAT_H
 #define OPENSSL_COMPAT_H
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || defined(LIBRESSL_VERSION_NUMBER)
+#if OPENSSL_VERSION_NUMBER < 0x10100000L || (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER < 0x2070000L)
 inline static int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
 {
    /* If the fields p and g in d are NULL, the corresponding input


### PR DESCRIPTION
Fix the following build failure with libressl >= 2.7.0 which added `DH_set0_pqg` with https://github.com/libressl-portable/openbsd/commit/848e2a019c796b685fc8c5848283b86e48fbe0bf:

```
In file included from uams_dhx_passwd.c:35:
openssl_compat.h:15:19: error: static declaration of 'DH_set0_pqg' follows non-static declaration
   15 | inline static int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g)
      |                   ^~~~~~~~~~~
In file included from uams_dhx_passwd.c:33:
/home/autobuild/autobuild/instance-2/output-1/host/mips64-buildroot-linux-uclibc/sysroot/usr/include/openssl/dh.h:195:5: note: previous declaration of 'DH_set0_pqg' was here
  195 | int DH_set0_pqg(DH *dh, BIGNUM *p, BIGNUM *q, BIGNUM *g);
      |     ^~~~~~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/fc6e308f346570f8198542602bc8c1bdd0a4869e
 - https://github.com/Netatalk/Netatalk/issues/105

[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/netatalk/0002-etc-uams-openssl_compat.h-fix-build-with-libressl-2..patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>