### PR TITLE
fix CVE-2022-43634

### DIFF
--- a/libatalk/dsi/dsi_write.c
+++ b/libatalk/dsi/dsi_write.c
@@ -23,7 +23,7 @@
 #include <atalk/util.h>
 #include <atalk/logger.h>
 
-size_t dsi_writeinit(DSI *dsi, void *buf, const size_t buflen _U_)
+size_t dsi_writeinit(DSI *dsi, void *buf, const size_t buflen)
 {
     size_t bytes = 0;
     dsi->datasize = ntohl(dsi->header.dsi_len) - dsi->header.dsi_data.dsi_doff;
@@ -31,7 +31,7 @@ size_t dsi_writeinit(DSI *dsi, void *buf, const size_t buflen _U_)
     if (dsi->eof > dsi->start) {
         /* We have data in the buffer */
         bytes = MIN(dsi->eof - dsi->start, dsi->datasize);
-        memmove(buf, dsi->start, bytes);
+        memmove(buf, dsi->start, MIN(buflen, bytes));
         dsi->start += bytes;
         dsi->datasize -= bytes;
         if (dsi->start >= dsi->eof)


### PR DESCRIPTION
This commit fixes the buffer overflow in dsi_writeinit().