### PR TITLE
fixes for misc compiler issues

### DIFF
--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -24,6 +24,7 @@
 #include <utime.h>
 #include <errno.h>
 #include <string.h>
+#include <sys/file.h>
 #include <sys/param.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/macros/largefile-check.m4
+++ b/macros/largefile-check.m4
@@ -60,7 +60,7 @@ if test "$enable_largefile" != no; then
     AC_TRY_RUN([#include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
-main() { exit((sizeof(off_t) == 8) ? 0 : 1); }],
+int main() { exit((sizeof(off_t) == 8) ? 0 : 1); }],
 netatalk_cv_SIZEOF_OFF_T=yes,netatalk_cv_SIZEOF_OFF_T=no,netatalk_cv_SIZEOF_OFF_T=cross)])
 
     AC_MSG_CHECKING([if large file support is available])


### PR DESCRIPTION
correct main definition is required as otherwise the test fails with implicit-int

include is required for:

```
netatalk_conf.c:84:32: error: 'LOCK_EX' undeclared (first use in this function)
   84 |     result = flock(fileno(fp), LOCK_EX);
```

which comes from sys/file.h: https://linux.die.net/man/2/flock