### PR TITLE
[2.2] Provide MNTTYPE_NFS on OmniOS

### DIFF
--- a/etc/afpd/quota.c
+++ b/etc/afpd/quota.c
@@ -39,6 +39,10 @@ char *strchr (), *strrchr ();
 #include <fcntl.h>
 #endif /* HAVE_FCNTL_H */
 
+#if defined(HAVE_SYS_MNTTAB_H) || defined(__svr4__)
+#include <sys/mntent.h>
+#endif
+
 #include <atalk/logger.h>
 #include <atalk/afp.h>
 #include <atalk/compat.h>


### PR DESCRIPTION
This enables compilation on OmniOSce r151044k. Patch by Hauke Fath.