### PR TITLE
[2.2] afpd: reading from file may fail (backport from 3.x)

### DIFF
--- a/etc/afpd/extattrs.c
+++ b/etc/afpd/extattrs.c
@@ -86,6 +86,7 @@ int afp_listextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
 
     static int          buf_valid = 0;
     static size_t       attrbuflen = 0;
+    bool                close_ad = false;
 
     *rbuflen = 0;
     ibuf += 2;
@@ -167,6 +168,7 @@ int afp_listextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
         }
 
         if (adp) {
+            close_ad = true;
             FinderInfo = ad_entry(adp, ADEID_FINDERI);
             /* Check if FinderInfo equals default and empty FinderInfo*/
             if (memcmp(FinderInfo, emptyFinderInfo, 32) != 0) {
@@ -228,7 +230,7 @@ int afp_listextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
 exit:
     if (ret != AFP_OK)
         buf_valid = 0;
-    if (adp)
+    if (close_ad)
         ad_close_metadata( adp);
 
     return ret;


### PR DESCRIPTION
When we get a request to list xattrs of a file that:

o is an open fork file handle in use by the client

o has no associated metadata

we call ad_close() on the adouble handle which does a refcount decrement which closes the file handle.

The fix is remembering whether we the ad_open() actually succeeded and only call ad_close() in that case.

Bug: https://sourceforge.net/p/netatalk/bugs/619/

Signed-off-by: Ralph Boehme <slow@samba.org>
Reviewed-by: Andrew Stormont <andyjstormont@gmail.com>