### PR TITLE
[2.2] fix largefile-check macro for largefile with clang16

### DIFF
--- a/macros/largefile-check.m4
+++ b/macros/largefile-check.m4
@@ -60,7 +60,7 @@ if test "$enable_largefile" != no; then
     AC_TRY_RUN([#include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
-main() { exit((sizeof(off_t) == 8) ? 0 : 1); }],
+int main() { exit((sizeof(off_t) == 8) ? 0 : 1); }],
 netatalk_cv_SIZEOF_OFF_T=yes,netatalk_cv_SIZEOF_OFF_T=no,netatalk_cv_SIZEOF_OFF_T=cross)])
 
     AC_MSG_CHECKING([if large file support is available])


### PR DESCRIPTION
main() without a return type fails with Werror=implicit-int, which makes it fail to detect largefile support with clang 16

Backport of https://github.com/Netatalk/Netatalk/commit/a08e6137afaf8f6ec2139c250482c8515ceb3e2f