### PR TITLE
[2.2] Fall back to timezone when tm_gmtoff is unavailable

### DIFF
--- a/contrib/timelord/timelord.c
+++ b/contrib/timelord/timelord.c
@@ -243,7 +243,11 @@ int main( int ac, char **av )
             exit( 1 );
             }
 
-            mtime = tv.tv_sec + EPOCH + tm->tm_gmtoff;
+#if defined (HAVE_STRUCT_TM_GMTOFF)
+			mtime = tv.tv_sec + EPOCH + tm->tm_gmtoff;
+#else /* HAVE_STRUCT_TM_GMTOFF */
+			mtime = tv.tv_sec + EPOCH - timezone;
+#endif /* HAVE_STRUCT_TM_GMTOFF */
         }
         else {
             if (( tm = gmtime( &tv.tv_sec )) == 0 ) {


### PR DESCRIPTION
On Solaris/OmniOS `tm_gmtoff` is not available in `struct tm` in time.h, unlike *BSD/Linux.
https://www.gnu.org/software/libc/manual/html_node/Broken_002ddown-Time.html

As a fallback, use `timezone` (also from time.h). The main drawback is that timezone does not take daylight savings into consideration.
https://www.gnu.org/software/libc/manual/html_node/Time-Zone-Functions.html