### PR TITLE
[2.2] Revert "Make the resource fork length equal to ad->ad_data"

### DIFF
--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -536,7 +536,6 @@ static int ad_header_read(struct adouble *ad, struct stat *hst)
 {
     char                *buf = ad->ad_data;
     u_int16_t           nentries;
-    int                 len;
     ssize_t             header_len;
     static int          warning = 0;
     struct stat         st;
@@ -596,17 +595,12 @@ static int ad_header_read(struct adouble *ad, struct stat *hst)
         return -1;
     }
 
-    len = nentries * AD_ENTRY_LEN;
-    if (len + AD_HEADER_LEN > sizeof(ad->ad_data))
-        len = sizeof(ad->ad_data) - AD_HEADER_LEN;
-
-    if (len + AD_HEADER_LEN > header_len) {
+    if ((nentries * AD_ENTRY_LEN) + AD_HEADER_LEN > header_len) {
         LOG(log_error, logtype_default, "ad_header_read: too many entries: %zd", header_len);
         errno = EIO;
         return -1;
     }
 
-    nentries = len / AD_ENTRY_LEN;
     if (parse_entries(ad, nentries, header_len) != 0) {
         LOG(log_warning, logtype_default, "ad_header_read(): malformed AppleDouble");
         errno = EIO;


### PR DESCRIPTION
Revert "Make the resource fork length equal to ad->ad_data in case it is larger. This avoids unwanted entry parsing errors when operating on small files in GS/OS and Classic Mac OS."

This reverts commit 60ce27db6fb69ef1301005637613af8b8d310b96.

Further analysis showed that the assertion in Netatalk was caused by invalid adouble headers created by the `cppo` tool which is part of [A2SERVER](https://github.com/RasppleII/a2server). The bug was fixed in cppo with https://github.com/NJRoadfan/a2server/commit/7e3637f6983ccec008b1e5c9f091efb687f7b0f7 so we can restore the stricter validation in Netatalk. See https://github.com/rdmark/Netatalk-2.x/issues/18 for the full discussion.