### PR TITLE
add support for tracker3

### DIFF
--- a/etc/spotlight/sparql_parser.c
+++ b/etc/spotlight/sparql_parser.c
@@ -1455,7 +1455,7 @@ yyreduce:
         result_limit = "";
     ssp_result = talloc_asprintf(ssp_slq,
                                  "SELECT ?url WHERE "
-                                 "{ %s . ?obj nie:url ?url . FILTER(tracker:uri-is-descendant('file://%s/', ?url)) } %s",
+                                 "{ %s . ?obj nie:isStoredAs ?file . ?file nie:url ?url . FILTER(tracker:uri-is-descendant('file://%s/', ?url)) } %s",
                                  (yyvsp[(1) - (1)].sval), ssp_slq->slq_scope, result_limit);
     (yyval.sval) = ssp_result;
 }

--- a/etc/spotlight/sparql_parser.y
+++ b/etc/spotlight/sparql_parser.y
@@ -78,7 +78,7 @@ expr                           {
         result_limit = "";
     ssp_result = talloc_asprintf(ssp_slq,
                                  "SELECT ?url WHERE "
-                                 "{ %s . ?obj nie:url ?url . FILTER(tracker:uri-is-descendant('file://%s/', ?url)) } %s",
+                                 "{ %s . ?obj nie:isStoredAs ?file . ?file nie:url ?url . FILTER(tracker:uri-is-descendant('file://%s/', ?url)) } %s",
                                  $1, ssp_slq->slq_scope, result_limit);
     $$ = ssp_result;
 }

--- a/include/atalk/spotlight.h
+++ b/include/atalk/spotlight.h
@@ -29,7 +29,9 @@
 #ifdef HAVE_TRACKER
 #include <gio/gio.h>
 #include <tracker-sparql.h>
+#ifndef HAVE_TRACKER3
 #include <libtracker-miner/tracker-miner.h>
+#endif
 #endif
 
 /******************************************************************************

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -184,14 +184,22 @@ AC_DEFUN([AC_NETATALK_SPOTLIGHT], [
         AC_DEFINE(HAVE_TRACKER, 1, [Define if Tracker is available])
         AC_DEFINE_UNQUOTED(TRACKER_PREFIX, ["$ac_cv_tracker_install_prefix"], [Path to Tracker])
         AC_DEFINE_UNQUOTED([DBUS_DAEMON_PATH], ["$ac_cv_dbus_daemon"], [Path to dbus-daemon])
+
+        ac_cv_tracker_pkg_version_MAJOR=`echo $ac_cv_tracker_pkg_version | cut -d. -f1`
+        if test $ac_cv_tracker_pkg_version_MAJOR -ge 3 ; then
+          AC_DEFINE(HAVE_TRACKER3, 1, [Define if Tracker3 is used])
+        fi
     fi
 
     dnl Tracker Managing Command
     if test x"$ac_cv_have_tracker" = x"yes" ; then
-        AC_CHECK_PROGS(ac_cv_tracker_manage, tracker tracker-control, , ["$ac_cv_tracker_prefix"/bin])
+        AC_CHECK_PROGS(ac_cv_tracker_manage, tracker tracker3 tracker-control, , ["$ac_cv_tracker_prefix"/bin])
         if test x"$ac_cv_tracker_manage" = x"tracker" ; then
            TRACKER_MANAGING_COMMAND="tracker daemon"
            AC_DEFINE(TRACKER_MANAGING_COMMAND, "tracker daemon", [tracker managing command])
+        elif test x"$ac_cv_tracker_manage" = x"tracker3" ; then
+           TRACKER_MANAGING_COMMAND="tracker3 daemon"
+           AC_DEFINE(TRACKER_MANAGING_COMMAND, "tracker3 daemon", [tracker managing command])
         elif test x"$ac_cv_tracker_manage" = x"tracker-control" ; then
            TRACKER_MANAGING_COMMAND="tracker-control"
            AC_DEFINE(TRACKER_MANAGING_COMMAND, "tracker-control", [tracker managing command])


### PR DESCRIPTION
Spotlight: Allow building with Tracker 3.x

This recent Tracker series contain some changes wrt the older versions,
notably to netatalk:
  - The TrackerSparqlConnection constructor changed, it is no longer
    a singleton.
  - The topology of the data graph is slightly different (even though
    it conforms to the same ontology/schema). Tracker data is now split
    between "physical" (e.g. a file in a filesystem) and "logical" (e.g.
    a representation of the content) interrelated with each other. Before,
    both aspects would be conflated in a single resource.

For the former, handle this new constructor if built with Tracker 3.x,
accessing the tracker-miner-fs instance specifically. For the latter,
adapt the SPARQL query so it works correctly on both 3.x and prior
versions, despite the difference.

Patch originating from https://sourceforge.net/p/netatalk/patches/147/