### PR TITLE
Hotfix: Don't try to bootstrap doc/Makefile

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1328,7 +1328,6 @@ AC_OUTPUT([Makefile
 	distrib/config/netatalk-config
 	distrib/initscripts/Makefile
 	distrib/m4/Makefile
-	doc/Makefile
 	etc/Makefile
 	etc/afpd/Makefile
 	etc/atalkd/Makefile


### PR DESCRIPTION
Hotfix for breakage introduced with https://github.com/Netatalk/Netatalk/pull/203
`doc/Makefile` should not be bootstrapped in configure.ac anymore, since we have a static Makefile imported from netatalk-docs