### PR TITLE
[2.2] Update docbook scripts and readme

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -2,3 +2,4 @@ html.tgz
 html/
 manpages/
 tmp/
+docbook-xsl*

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -4,6 +4,7 @@
 #
 # Available targets:
 #   html: make html doc
+#   html-upload: upload html doc to SourceForce server
 #   man: make manpages
 #   install: copy manpages to Netatalk source code tree
 
@@ -27,6 +28,7 @@ TMPDIR   = tmp
 
 MAN_XSL_TMP  = $(TMPDIR)/$(MAN_XSL)
 HTML_XSL_TMP = $(TMPDIR)/$(HTML_XSL)
+XSL_PATH     = $(shell pwd)/$(XSL)
 
 manpages = manpages/ad.1 \
 		manpages/aecho.1 \
@@ -112,8 +114,8 @@ $(MAN_XSL_TMP) : manual/man.xsl
 			exit 1; \
 		fi
 		@cp manual/man.xsl $(MAN_XSL_TMP)
-		@echo Configuring XSL stylesheet with path $(XSL)
-		@$(sed) -i -e "s@PATH_TO_XSL_STYLESHEETS_DIR@$(XSL)@" $(MAN_XSL_TMP)
+		@echo Configuring XSL stylesheet with path $(XSL_PATH)
+		@$(sed) -i -e "s@PATH_TO_XSL_STYLESHEETS_DIR@$(XSL_PATH)@" $(MAN_XSL_TMP)
 
 manpageinit: tmpdir $(MAN_XSL_TMP)
 		@if [ "x$(VERSION)" = "x" ] ; then \
@@ -125,11 +127,11 @@ manpageinit: tmpdir $(MAN_XSL_TMP)
 		fi
 
 install:
-		@if [ "x$(DIR)" = "x" ] ; then \
-			echo 'Set $$DIR to be the path of your Netatalk directory.'; \
+		@if [ ! -d ../man ] ; then \
+			echo 'No `man` dir to install into in parent directory.'; \
 			exit 1; \
 		fi
-		sh checkinmans.sh "$(DIR)"
+		sh checkinmans.sh
 
 # html targets
 
@@ -162,6 +164,6 @@ $(HTML_XSL_TMP) : manual/html.xsl
 			exit 1; \
 		fi
 		@cp manual/html.xsl $(HTML_XSL_TMP)
-		@echo Configuring XSL stylesheet with path $(XSL)
-		@$(sed) -i -e "s@PATH_TO_XSL_STYLESHEETS_DIR@$(XSL)@" $(HTML_XSL_TMP)
+		@echo Configuring XSL stylesheet with path $(XSL_PATH)
+		@$(sed) -i -e "s@PATH_TO_XSL_STYLESHEETS_DIR@$(XSL_PATH)@" $(HTML_XSL_TMP)
 

--- a/doc/README
+++ b/doc/README
@@ -7,54 +7,43 @@
 
 	1. Install `xsltproc`.
 	2. Get the latest Docbook XSL stylesheet distribution from:
-	   https://sourceforge.net/project/showfiles.php?group_id=21935
+	   https://sourceforge.net/projects/docbook/files/docbook-xsl/
 
-	   Tested docbook-xsl stylesheet version is 1.75.2.
+	   Recommended docbook-xsl stylesheet version is 1.79.1.
+	   Version 1.79.2 and later introduced a namespace that our stylesheets don't support (yet).
 
-    3. Fix indexterm bug in xsl stylesheet:
-       inside the xsl stylesheet distribution in manpages/inline.xsl remove these lines:
-
-        <!-- * indexterm instances produce groff comments like this: -->
-        <!-- * .\" primary: secondary: tertiary -->
-        <xsl:template match="indexterm">
-          <xsl:text>.\" </xsl:text>
-          <xsl:apply-templates/>
-          <xsl:text>&#10;</xsl:text>
-        </xsl:template>
-
-        <xsl:template match="primary">
-          <xsl:value-of select="normalize-space(.)"/>
-        </xsl:template>
-
-        <xsl:template match="secondary|tertiary">
-          <xsl:text>: </xsl:text>
-          <xsl:value-of select="normalize-space(.)"/>
-        </xsl:template>
 
    Usage
    -----
 
 	Preparation:
 
-	1. Get netatalk-doc from CVS
-	2. `cd` to "netatalk-doc"
+	1. Clone the Netatalk repo with git
+	2. `cd` to "doc"
 
 	Create manpages:
 
-	3. XSL=<path to XSL stylesheets> VERSION=2.x make man
-	4. Copy the generated man pages to your CVS working copy:
-	   DIR=<path to netatalk> make install
+	3. XSL=<path to XSL stylesheets> VERSION=2.2 make man
+	4. Copy the generated man pages to the correct locations in the code repo
+	   make install
 
 	Create HTML:
 
-    5. XSL=<path to XSL stylesheets> VERSION=2.x make html
+    5. XSL=<path to XSL stylesheets> VERSION=2.2 make html
        The generated html files are then inside the directory html.
+	6. Upload the generated html files to SourceForge: (admins only)
+	   USER=<SourceForge user> make html-upload
+
+	Clean-up:
+
+	7. Remove the generated files in tmp/ before running the script again.
+	   make clean
 
    Editing Docbook Sources
    -----------------------
 
 	Free WYSIWYG editor with only one minor drawback is XMLEditor from XMLmind:
-	http://www.xmlmind.com/xmleditor/persoedition.html
+	https://www.xmlmind.com/xmleditor/
 
 	Drawback: in order to be able to edit any of the  nested xml files, you have to "promote" them to valid Docbook
 	files by referencing the Docbook DTD: insert as line 2+3:

--- a/doc/checkinmans.sh
+++ b/doc/checkinmans.sh
@@ -1,19 +1,14 @@
 #!/bin/sh
 
 #
-# Copies man pages from dir "manpages" to netalk CVS working copy man directory structure <dir>
-# As some man pages contain path variables that are substituded at build time we have to be carefull:
-# we try to figure out which they are by examing the Makefile.am's and append ".tml" to any of them.
+# Copies man pages from dir "manpages" to the man page dir structure in the parent dir.
+# As some man pages contain path variables that are substituded at build time we have to be careful:
+# we try to figure out which they are by examing the Makefile.am's and append ".tmpl" to any of them.
 #
-
-if test $# -ne 1; then
-    echo "Usage: checkinmans <netatalk source dir>"
-    exit 1
-fi
 
 CURRDIR="`pwd`"
 WORKDIR="$CURRDIR/manpages"
-MANDIR="$1/man"
+MANDIR="$CURRDIR/../man"
 
 cd "$MANDIR"
 

--- a/doc/manual/html.xsl
+++ b/doc/manual/html.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?> 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"> 
-	<xsl:import href="PATH_TO_XSL_STYLESHEETS_DIR/xhtml/chunk.xsl"/> 
+	<xsl:import href="PATH_TO_XSL_STYLESHEETS_DIR/xhtml/chunk.xsl"/>
 	<xsl:param name="use.id.as.filename" select="'1'"/>
 	<xsl:param name="chunk.section.depth" select="0"></xsl:param>
 	<xsl:param name="chunk.separate.lots" select="1"></xsl:param>

--- a/doc/manual/man.xsl
+++ b/doc/manual/man.xsl
@@ -1,6 +1,6 @@
 <?xml version='1.0'?> 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"> 
-<xsl:import href="PATH_TO_XSL_STYLESHEETS_DIR/manpages/docbook.xsl"/> 
+<xsl:import href="PATH_TO_XSL_STYLESHEETS_DIR/manpages/docbook.xsl"/>
 
 <!-- * Collect date from <refmiscinfo class="date"> -->
 <xsl:param name="refentry.date.profile.enabled">1</xsl:param>
@@ -8,8 +8,11 @@
   (//refmiscinfo[@class='date'])[last()]
 </xsl:param>
 
-<!-- * Suppress extra :VERSION: -->
-<xsl:param name="refentry.version.suppress">1</xsl:param>
+<!-- * Collect manual name from <refmiscinfo class="source"> -->
+<xsl:param name="refentry.manual.profile.enabled">1</xsl:param>
+<xsl:param name="refentry.manual.profile">
+  (//refmiscinfo[@class='source'])[last()]
+</xsl:param>
 
 <!-- * Example without numbering -->
 <xsl:param name="local.l10n.xml" select="document('')"/>


### PR DESCRIPTION
Make the docbook makefile/script/docs work better with newer docbook & dir structure
- html.xsl and man.xsl import works relative to the tmp dir
- manpage install target to always install into ../man rather than as a variable
- Explicitly use "source" as "manual"
- Remove outdated workarounds

Interestingly, the last docbook release that is fully compatible with our man pages is 1.79.1, because in 1.79.2 and beyond the refmiscinfo date and manual overrides are ignored. What's bizarre is that [the authors claim](https://github.com/docbook/xslt10-stylesheets/releases/tag/release%2F1.79.2) that 1.79.1 and 1.79.2 are functionally identical, which is clearly a lie.

Edit: Digging around I figured out that they introduced new namespaces in 1.79.2, in particular the `:d` namespace that applies to all styles. I think we need to update our local stylesheets to support this, if we want to be forwards compatible. Something for a future PR.

```
<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                xmlns:d="http://docbook.org/ns/docbook"
                xmlns:exsl="http://exslt.org/common"
                xmlns:ng="http://docbook.org/docbook-ng"
                xmlns:db="http://docbook.org/ns/docbook"
                exclude-result-prefixes="exsl d"
                version='1.0'>
```