### PR TITLE
Fix a typo in debug message

### DIFF
--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -1165,7 +1165,7 @@ struct path *cname(struct vol *vol, struct dir *dir, char **cpath)
             return NULL;
         }
 
-        LOG(log_maxdebug, logtype_afpd, "came('%s'): {node: '%s}", cfrombstr(dir->d_fullpath), ret.u_name);
+        LOG(log_maxdebug, logtype_afpd, "cname('%s'): {node: '%s}", cfrombstr(dir->d_fullpath), ret.u_name);
 
         /* Prevent access to our special folders like .AppleDouble */
         if (check_name(vol, ret.u_name)) {


### PR DESCRIPTION
While debugging one of Netatalk installs I scrolled through logs and noticed unknown term 'came', dug into source code and found out it was just a typo, so I fixed it.