### PR TITLE
[2.2] Overhaul html manual page sources

### DIFF
--- a/doc/manual/netatalk.html
+++ b/doc/manual/netatalk.html
@@ -3,9 +3,9 @@
         <div id="logo"></div>
         <div id="menlinks">
           <a href="/" title="Return to Netatalk home">[main]</a>
-          <a href="https://sourceforge.net/apps/mediawiki/netatalk/index.php?title=Main_Page" title="Netatalk Wiki">[wiki]</a>
+          <a href="https://github.com/Netatalk/Netatalk/wiki" title="Netatalk Wiki">[wiki]</a>
           <a href="/2.2/htmldocs" title="Netatalk Manual">[documentation]</a>
-          <a href="http://sourceforge.net/project/showfiles.php?group_id=8642" title="Download Netatalk from sourceforge">[downloads]</a>
+          <a href="https://sourceforge.net/projects/netatalk/files/netatalk/" title="Download Netatalk from sourceforge">[downloads]</a>
           <a href="/support.php" title="Support">[support]</a>
           <a href="/links.php" title="Netatalk related links">[links]</a>
           <img src="/gfx/end.gif" alt="" width="125" height="7" />

--- a/doc/manual/netatalk/configuration.xml
+++ b/doc/manual/netatalk/configuration.xml
@@ -23,17 +23,18 @@
       <title>Setting up the AFP file server</title>
 
       <para>AFP (the Apple Filing Protocol) is the protocol Apple Macintoshes
-      use for file services. The protocol has evolved over the years. The
-      latest changes to the protocol, called "AFP 3.3", were added with the
-      release of Snow Leopard<indexterm>
-          <primary>Snow Leopard</primary>
+      use for file services up until OS X Mountain Lion (10.8). The protocol
+      has evolved over the years. The
+      latest change to the protocol, AFP 3.4, was introduced with
+      the release of OS X Mountain Lion<indexterm>
+          <primary>Mountain Lion</primary>
 
-          <secondary>Mac OS X 10.6</secondary>
-        </indexterm> (Mac OS X 10.6).</para>
+          <secondary>Mac OS X 10.8</secondary>
+        </indexterm>. Netatalk 2.2 supports up to AFP 3.3.</para>
 
       <para>AFP3 brought some big changes. For the first time, AFP3 supports
       pathnames up to 65535 characters. It is virtually unlimited. Netatalk
-      2.x supports filenames up to 255 characters because Mac OS X 10.4 and
+      2.2 supports filenames up to 255 characters because Mac OS X 10.4 and
       earlier can use it up to 255 characters (actually 255 bytes leading to
       85-255 chars depending on the glyphs used), Decomposed UTF-8 (UTF8-MAC)
       is used on the wire and large files (&gt;4GB) are supported.</para>
@@ -57,7 +58,7 @@
 
           <secondary>UNIX symlink</secondary>
         </indexterm> can be used on the server. Semantics are the same as for
-      eg NFS, ie they are not resolved on the server side but instead it's
+      eg NFS, i.e. they are not resolved on the server side but instead it's
       completely up to the client to resolve them, resulting in links that
       point somewhere inside the clients filesystem view.</para>
 
@@ -119,7 +120,7 @@
           <secondary>CNID backend</secondary>
         </indexterm></title>
 
-      <para>Unlike other protocols like smb or nfs, the AFP protocol mostly
+      <para>Unlike other protocols like SMB or NFS, the AFP protocol mostly
       refers to files and directories by ID and not by a path (the IDs are
       also called CNID, that means Catalog Node ID). A typical AFP request
       uses a directory ID<indexterm>
@@ -145,7 +146,7 @@
       <para>Netatalk needs to map IDs to files and folders in the host
       filesystem. To achieve this, several different CNID backends<indexterm>
           <primary>CNID backend</primary>
-        </indexterm> are available and can be choosed by the
+        </indexterm> are available and can be selected with the
       <option>cnidscheme</option><indexterm>
           <primary>cnidscheme</primary>
 
@@ -219,45 +220,6 @@
         </itemizedlist>
       </note>
 
-      <important>
-        <para>In order to update between Netatalk releases using different
-        BerkeleyDB library versions, follow this steps:</para>
-
-        <itemizedlist>
-          <listitem>
-            <para>Stop the to be upgraded old version of Netatalk</para>
-          </listitem>
-
-          <listitem>
-            <para>Using the old BerkeleyDB utilities run <command>db_recover
-            -h &lt;path to .AppleDB&gt;</command></para>
-          </listitem>
-
-          <listitem>
-            <para>Using the new BerkeleyDB utilities run <command>db_upgrade
-            -v -h &lt;path to .AppleDB&gt; -f cnid2.db</command></para>
-          </listitem>
-
-          <listitem>
-            <para>Again using the new BerkeleyDB utilities run
-            <command>db_checkpoint -1 -h &lt;path to
-            .AppleDB&gt;</command></para>
-          </listitem>
-
-          <listitem>
-            <para>Start the the new version of Netatalk</para>
-          </listitem>
-        </itemizedlist>
-
-        <para>Note that the first version to appear <emphasis>after</emphasis>
-        Netatalk 2.1 ie Netatalk 2.1.1, will support BerkeleyDB updates on the
-        fly without manual intervention. In other words Netatalk 2.1 does
-        contain code to prepare the BerkeleyDB database for upgrades and to
-        upgrade it in case it has been prepared before. That means it can't
-        upgrade a 2.0.x version because that one didn't prepare the
-        database.</para>
-      </important>
-
       <sect3>
         <title>cdb<indexterm>
             <primary>CDB</primary>
@@ -265,7 +227,7 @@
             <secondary>"cdb" CNID backend</secondary>
           </indexterm></title>
 
-        <para>The "concurrent database" backend is based on sleepycat's
+        <para>The "concurrent database" backend is based on
         Berkeley DB. With this backend, several afpd daemons access the CNID
         database directly. Berkeley DB locking is used to synchronize access,
         if more than one afpd process is active for a volume. The drawback is,
@@ -290,7 +252,7 @@
         probably better off using cdb for sharing home directories for a
         larger number of users.</para>
 
-        <para>This is the default backend starting with Netatalk 2.1.</para>
+        <para>This is the default backend since Netatalk 2.1.</para>
       </sect3>
 
       <sect3>
@@ -394,7 +356,7 @@
         <emphasis>multibyte</emphasis> character sets.</para>
 
         <para>One standardized multibyte charset encoding scheme is known as
-        <ulink url="http://www.unicode.org/">unicode</ulink>. A big advantage
+        <ulink url="https://www.unicode.org/">Unicode</ulink>. A big advantage
         of using a multibyte charset is that you only need one. There is no
         need to make sure two computers use the same charset when they are
         communicating.</para>
@@ -428,7 +390,7 @@
           </listitem>
 
           <listitem>
-            <para>MacCroation</para>
+            <para>MacCroatian</para>
           </listitem>
 
           <listitem>
@@ -477,7 +439,7 @@
         </itemizedlist>
 
         <para>Starting with Mac OS X and AFP3, <ulink
-        url="http://www.utf-8.com/">UTF-8</ulink> is used. UTF-8 encodes
+        url="https://www.utf-8.com/">UTF-8</ulink> is used. UTF-8 encodes
         Unicode characters in an ASCII compatible way, each Unicode character
         is encoded into 1-6 ASCII characters. UTF-8 is therefore not really a
         charset itself, it's an encoding of the Unicode charset.</para>
@@ -485,7 +447,7 @@
         <para>To complicate things, Unicode defines several <emphasis> <ulink
         url="http://www.unicode.org/reports/tr15/index.html">normalization</ulink>
         </emphasis> forms. While <ulink
-        url="http://www.samba.org">samba</ulink><indexterm>
+        url="https://www.samba.org">Samba</ulink><indexterm>
             <primary>Samba</primary>
           </indexterm> uses <emphasis>precomposed</emphasis><indexterm>
             <primary>Precomposed</primary>
@@ -664,7 +626,7 @@
               character to <emphasis>maccodepage</emphasis> first. If this
               conversion fails, you'll receive a -50 error on the mac.
               <emphasis>Note</emphasis>: Whenever you can, please stick with
-              the default UTF-8 volume format. see <citerefentry>
+              the default UTF-8 volume format. See <citerefentry>
                   <refentrytitle>AppleVolumes.default</refentrytitle>
 
                   <manvolnum>5</manvolnum>
@@ -831,7 +793,7 @@
         <para>On Mac OS X, there exist some client-side techniques to make the
         AFP-client more verbose, so one can have a look what's happening while
         negotiating the UAMs to use. Compare with this <ulink
-        url="http://article.gmane.org/gmane.network.netatalk.devel/7383/">hint</ulink>.</para>
+        url="https://web.archive.org/web/20080312054723/http://article.gmane.org/gmane.network.netatalk.devel/7383/">hint</ulink>.</para>
       </sect3>
 
       <sect3>
@@ -911,7 +873,7 @@
 
         <para>For a more detailed overview over the technical implications of
         the different UAMs, please have a look at Apple's <ulink
-        url="http://developer.apple.com/documentation/Networking/Conceptual/AFP/Chapter_1/chapter_2_section_6.html">File
+        url="https://web.archive.org/web/20040916191641/http://developer.apple.com/documentation/Networking/Conceptual/AFP/Chapter_1/chapter_2_section_6.html">File
         Server Security</ulink> pages.</para>
       </sect3>
 
@@ -1013,7 +975,7 @@ uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting> then you're using PAM,
               </row>
 
               <row>
-                <entry align="center" rotate="0" valign="middle">pssword
+                <entry align="center" rotate="0" valign="middle">Password
                 length</entry>
 
                 <entry>guest access</entry>
@@ -1065,11 +1027,11 @@ uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting> then you're using PAM,
 
                 <entry>Password will be encrypted with 128 bit SSL, user will
                 be authenticated against the server but not vice versa.
-                Therefor weak against man-in-the-middle attacks.</entry>
+                Therefore weak against man-in-the-middle attacks.</entry>
 
                 <entry>Password will be encrypted using libgcrypt with CAST
                 128 in CBC mode. User will be authenticated against the server
-                but not vice versa. Therefor weak against man-in-the-middle
+                but not vice versa. Therefore weak against man-in-the-middle
                 attacks.</entry>
 
                 <entry>Password is not sent over the network. Due to the
@@ -1120,7 +1082,7 @@ uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting> then you're using PAM,
         </table>
 
         <para>* Have a look at this <ulink
-        url="http://cryptnet.net/fdp/admin/kerby-infra/en/kerby-infra.html">Kerberos
+        url="https://web.archive.org/web/20070705043002/http://cryptnet.net/fdp/admin/kerby-infra/en/kerby-infra.html">Kerberos
         overview</ulink></para>
       </sect3>
 
@@ -1150,9 +1112,9 @@ uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting> then you're using PAM,
           forwarded to the remote server's AFP port (we used the default 548)
           over SSH.</para>
 
-          <para>These sorts of tunnels are an ideal solution if you've to
-          access an AFP server providing weak authentications mechanisms
-          through the Internet without having the ability to use a "real" VPN.
+          <para>This sort of tunnel is an ideal solution if you must access
+          an AFP server through the Internet without having the ability
+          or desire to use a "real" VPN.
           Note that you can let <command>ssh</command> compress the data by
           using its "-C" switch and that the tunnel endpoints can be different
           from both AFP client and server (compare with the SSH documentation
@@ -1190,9 +1152,18 @@ uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting> then you're using PAM,
 
           <itemizedlist>
             <listitem>
-              <para>Tunneling TCP over TCP (as SSH does) is not the best idea.
-              There exist better solutions like VPNs based on the IP
-              layer.</para>
+              <para>Most users who need such a feature are probably already
+              familiar with using a VPN; it might be easier for the user to
+              employ the same VPN software in order to connect to the network
+              on which the AFP server is running, and then to access the AFP
+              server as normal.</para>
+
+              <para>That being said, for the simple case of connecting
+              to one specific AFP server, a direct SSH connection is likely to
+              perform better than a general-purpose VPN; contrary to popular
+              belief, tunneling via SSH does <emphasis role="strong">not</emphasis>
+              result in what's called "TCP-over-TCP meltdown", because the
+              AFP data that are being tunneled do not encapsulate TCP data.</para>
             </listitem>
 
             <listitem>
@@ -1211,23 +1182,23 @@ uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting> then you're using PAM,
             </listitem>
 
             <listitem>
-              <para>On the other side you've to limit access to afpd to
-              localhost only (TCP wrappers) and disable AFP over DDP when you
-              want to ensure that all AFP sessions are SSH encrypted
-              or...</para>
-            </listitem>
+              <para>Indeed, to ensure that all AFP over TCP sessions are encrypted
+              via SSH, you need to limit afpd to connections that originate
+              only from localhost (e.g., by using Wietse Venema's TCP Wrappers,
+              or by using suitable firewall or packet-filtering facilities, etc.).</para>
 
-            <listitem>
-              <para>...when you're using 10.2 - 10.3.3 then you get the
-              opposite of what you'd expect: potentially unencrypted AFP
-              communication (including logon credentials) on the network
+              <para>Otherwise, when you're using Mac OS X 10.2 through 10.3.3,
+              you get the opposite of what you'd expect: potentially unencrypted AFP
+              communications (including login credentials) being sent across the network
               without a single notification that establishing the tunnel
               failed. Apple fixed that not until Mac OS X 10.3.4.</para>
             </listitem>
 
             <listitem>
               <para>Encrypting all AFP sessions via SSH can lead to a
-              significantly higher load on the Netatalk server</para>
+              significantly higher load on the computer that is running
+              the AFP server, because that computer must also handle
+              encryption.</para>
             </listitem>
           </itemizedlist>
         </sect4>
@@ -1239,26 +1210,33 @@ uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting> then you're using PAM,
           <primary>ACLs</primary>
         </indexterm></title>
 
-      <para>ACL support for AFP is implemented for Solaris/ZFS/NFSv4 ACLs and
-      POSIX 1e ACLs on Linux.</para>
+      <para>ACL support for AFP is implemented for ZFS ACLs on Solaris and
+      derived platforms and for POSIX 1e ACLs on Linux.</para>
 
       <sect3>
         <title>Configuration</title>
 
-        <para>For a basic mode of operation where all you want to achieve is
-        that read/write/execute permissions are displayed appropiately, taking
-        ACLs into accout, there's nothing to configure. afpd reads ACLs on the
-        fly, calculating effective permissions and returning the calculated
-        permissions via the so called <emphasis>UARights</emphasis> permission
-        bits. The client, notable the Finder uses these bits to display
-        permissions.</para>
+        <para>For a basic mode of operation there's nothing to configure.
+        Netatalk reads ACLs on the fly and calculates effective permissions
+        which are then sent to the AFP client via the so called
+        UARights<indexterm>
+            <primary>UARights</primary>
+          </indexterm> permission bits. On a Mac, the Finder uses these bits
+          to adjust permission in Finder windows. Example: a folder whose
+          UNIX mode is read-only and an ACL giving the user write access,
+          will display the effective read-write permission. Without the
+          permission mapping the Finder would display a read-only icon and
+          the user wouldn't be able to write to the folder.</para>
 
-        <para>If you want to be able to display ACLs on the client, things get
-        more involed as you must then setup both client and server to be part
-        on a authentication domain (eg LDAP, OpenDirectory). The reason is,
-        that in OS X ACLs are bound to UUIDs, not just uid's or gid's.
-        Therefor afpd must be able to map every filesystem uid and gid to a
-        UUID.</para>
+        <para>However, neither in Finder "Get Info" windows nor in Terminal
+        will you be able to see the ACLs, that's a result of how ACLs in OS X
+        are designed. If you want to be able to display ACLs on the client,
+        things get more involved as you must then setup both client and server
+        to be part on a authentication domain (directory service, eg LDAP,
+        OpenDirectory). The reason is, that in OS X ACLs are bound to UUIDs,
+        not just uid's or gid's. Therefore, afpd must be able to map every
+        filesystem uid and gid to a UUID so that it can return the server side
+        ACLs which are bound to UNIX uid and gid mapped to OS X UUIDs.</para>
 
         <para>In detail:</para>
 
@@ -1282,7 +1260,7 @@ aclmode = passthrough (if available)</screen>
             <para>Your server and the clients must be part of a security
             association where identity data is coming from a common source.
             ACLs in Darwin are based on UUIDs and so is the ACL specification
-            in AFP 3.2. Therefor your source of identity data has to provide
+            in AFP 3.2. Therefore your source of identity data has to provide
             an attribute for every user and group where a UUID is stored as a
             ASCII string. In other words:</para>
 
@@ -1341,12 +1319,13 @@ aclmode = passthrough (if available)</screen>
 
           <manvolnum>8</manvolnum>
         </citerefentry> for older AFP clients not capable of using AFP over
-      TCP. You'll need it also, if you want to use the deprecated
+      TCP. You'll need it also if you want to use the
       AppleTalk-based timeserver <citerefentry>
           <refentrytitle>timelord</refentrytitle>
 
           <manvolnum>8</manvolnum>
-        </citerefentry> for older Mac clients.</para>
+        </citerefentry> for older Mac clients, or netboot server a2boot
+      for Apple II clients.</para>
 
       <para>But even if you don't need PAP or AFP over AppleTalk, you might
       consider using AppleTalk for service propagation/location, having the
@@ -1714,7 +1693,7 @@ eth1 -seed -phase 2 -net 99-100 -addr 99.200 -zone "Testing"</programlisting>
     has been a great advantage compared with other protocols like Adobe's
     Standard Protocol to drive serial and parallel PostScript printers
     (compare with <ulink
-    url="http://partners.adobe.com/asn/tech/ps/specifications.jsp">Adobe
+    url="https://web.archive.org/web/20041022165533/http://partners.adobe.com/asn/tech/ps/specifications.jsp">Adobe
     TechNote 5009</ulink>) or LPR<indexterm>
         <primary>LPR</primary>
 
@@ -1726,7 +1705,7 @@ eth1 -seed -phase 2 -net 99-100 -addr 99.200 -zone "Testing"</programlisting>
     (usually a Macintosh computer) and destination (a printer or spooler
     implementation) communicate about both destination's capabilities via
     feature queries (compare with <ulink
-    url="http://partners.adobe.com/asn/tech/ps/archive.jsp">Adobe TechNote
+    url="https://web.archive.org/web/20041022123331/http://partners.adobe.com/asn/tech/ps/archive.jsp">Adobe TechNote
     5133</ulink>) and device status. This allows the LaserWriter driver on the
     Macintosh to generate appropriate device specific PostScript code (color
     or b/w, only embedding needed fonts, and so on) on the one hand and
@@ -1816,6 +1795,14 @@ eth1 -seed -phase 2 -net 99-100 -addr 99.200 -zone "Testing"</programlisting>
         automagically using the parameters assigned to this global share. But
         subsequent printer definitions can be used to override these global
         settings for individual spoolers.</para>
+
+	<example>
+	<title>Example syntax, assigning root as operator:</title>
+
+	<para>
+	<programlisting>cupsautoadd:op=root:</programlisting>
+	</para>
+	</example>
       </sect3>
     </sect2>
 
@@ -1895,12 +1882,18 @@ eth1 -seed -phase 2 -net 99-100 -addr 99.200 -zone "Testing"</programlisting>
 
       <para><command>timelord</command><indexterm>
           <primary>timelord</primary>
-        </indexterm>, an AppleTalk based time server, is deprecated these
-      days. Use NTP<indexterm>
+          </indexterm>, an AppleTalk based time server, is useful for classic
+          Mac OS clients that do not support NTP<indexterm>
           <primary>NTP</primary>
 
           <secondary>Network Time Protocol</secondary>
-        </indexterm> instead.</para>
+        </indexterm>.</para>
+
+	<para>Netatalk's <command>timelord</command> is compatible with the <ulink
+        url="https://macintoshgarden.org/apps/tardis-and-timelord">tardis</ulink>
+        client for Macintosh developed at the <ulink
+        url="https://web.archive.org/web/20010303220117/http://www.cs.mu.oz.au/appletalk/readmes/TMLD.README.html">
+        University of Melbourne.</ulink></para>
 
       <para>For further information please have a look at the <citerefentry>
           <refentrytitle>timelord</refentrytitle>
@@ -1916,9 +1909,9 @@ eth1 -seed -phase 2 -net 99-100 -addr 99.200 -zone "Testing"</programlisting>
     <para>The Netatalk distribution comes with several operating system
     specific startup script templates that are tailored according to the
     options given to the "configure" script before compiling. Currently,
-    templates are provided for RedHat (sysv style), RedHat (systemd style),
-    SuSE, Gentoo, NetBSD and Debian. You can select to install the generated
-    startup script(s)
+    templates are provided for systemd (cross-platform), RedHat,
+    SuSE, Gentoo, Debian, NetBSD, Solaris, and Tru64. You can select to
+    install the generated startup script(s).
     <indexterm>
         <primary>Startscript</primary>
 
@@ -1926,13 +1919,18 @@ eth1 -seed -phase 2 -net 99-100 -addr 99.200 -zone "Testing"</programlisting>
       </indexterm> by specifying a system type to "configure". To
     automatically install startup scripts for e.g. the Ubuntu distribution
     try to give the <option>--enable-debian</option> option to "configure". Some
-    of the scripts can be further parametrized by the configuration file
+    of the non-systemd scripts can be further parametrized by the configuration file
     netatalk.conf (described in the <citerefentry>
         <refentrytitle>netatalk.conf</refentrytitle>
 
         <manvolnum>5</manvolnum>
       </citerefentry> manual page), some obtain that information in another,
     operating system specific way (like NetBSD, Debian and so on).</para>
+
+    <para>If you use the cross-platform <option>--enable-systemd</option>
+    option, there is no need to specify the system type. Also, the <filename>
+    netatalk.conf</filename> configuration file is <emphasis>not</emphasis>
+    used by systemd unit configurations.</para>
 
     <para>Since new releases of Linux distributions appear all the time and
     the startup procedure for the other systems mentioned above might change
@@ -1963,15 +1961,14 @@ eth1 -seed -phase 2 -net 99-100 -addr 99.200 -zone "Testing"</programlisting>
       <listitem>
         <para>timelord<indexterm>
             <primary>timelord</primary>
-          </indexterm> (for old style time synchronisation via
+          </indexterm> (for old style time synchronization via
         AppleTalk)</para>
       </listitem>
 
       <listitem>
         <para>a2boot<indexterm>
             <primary>a2boot</primary>
-          </indexterm> (Apple II boot server via AppleTalk, not necessary any
-        longer)</para>
+          </indexterm> (Apple II boot server via AppleTalk)</para>
       </listitem>
 
       <listitem>

--- a/doc/manual/netatalk/install.xml
+++ b/doc/manual/netatalk/install.xml
@@ -17,11 +17,11 @@
   <sect1>
     <title>How to obtain Netatalk</title>
 
-    <para>Please have a look at the netatalk page on sourceforge for the most
+    <para>Please have a look at the netatalk page on GitHub for the most
     recent informations on this issue.</para>
 
     <para><ulink
-    url="http://sourceforge.net/projects/netatalk/">http://sourceforge.net/projects/netatalk/</ulink></para>
+    url="https://github.com/Netatalk/Netatalk">https://github.com/Netatalk/Netatalk</ulink></para>
 
     <sect2>
       <title>Binary packages</title>
@@ -35,38 +35,38 @@
       </ulink></para>
 
       <para>Debian package: <ulink
-      url="http://packages.debian.org/">http://packages.debian.org/
+      url="https://www.debian.org/distrib/packages">https://www.debian.org/distrib/packages
       </ulink></para>
 
-      <para>various RPM package: <ulink
-      url="http://rpmfind.net/">http://rpmfind.net/ </ulink></para>
+      <para>Various RPM packages: <ulink
+      url="https://rpmfind.net/">https://rpmfind.net/ </ulink></para>
 
       <para>Fedora/RHEL package: <ulink
-      url="http://koji.fedoraproject.org/koji/search">http://koji.fedoraproject.org/koji/search
+      url="https://koji.fedoraproject.org/koji/search">https://koji.fedoraproject.org/koji/search
       </ulink></para>
 
       <para>Gentoo package: <ulink
-      url="http://packages.gentoo.org/">http://packages.gentoo.org/
+      url="https://packages.gentoo.org/">https://packages.gentoo.org/
       </ulink></para>
 
       <para>openSUSE package: <ulink
-      url="http://software.opensuse.org/">http://software.opensuse.org/
+      url="https://software.opensuse.org/">https://software.opensuse.org/
       </ulink></para>
 
       <para>Solaris package: <ulink
-      url="http://www.blastwave.org/">http://www.blastwave.org/
+      url="https://www.opencsw.org/packages/CSWnetatalk/">https://www.opencsw.org/
       </ulink></para>
 
       <para>FreeBSD ports: <ulink
-      url="http://www.freebsd.org/ports/index.html">http://www.freebsd.org/ports/index.html
+      url="https://www.freebsd.org/ports/">https://www.freebsd.org/ports/
       </ulink></para>
 
       <para>NetBSD pkgsrc: <ulink
-      url="http://pkgsrc.se/search.php">http://pkgsrc.se/search.php
+      url="https://pkgsrc.se/search.php">https://pkgsrc.se/search.php
       </ulink></para>
 
       <para>OpenBSD ports:<ulink
-      url="http://openports.se/search.php">http://openports.se/search.php
+      url="https://openports.pl">https://openports.pl
       </ulink></para>
 
       <para>etc.<indexterm>
@@ -92,51 +92,43 @@
 
         <para>Prepacked tarballs in .tar.gz and tar.bz2 format are available
         on the netatalk page on <ulink
-        url="http://netatalk.sourceforge.net/">sourceforge</ulink>.</para>
+        url="https://github.com/Netatalk/Netatalk">GitHub</ulink>.</para>
       </sect3>
 
       <sect3>
-        <title>Read-only Git</title>
+        <title>Git</title>
 
         <para>Downloading the Git repository can be done quickly and
-        easily.</para>
+        easily:</para>
 
         <orderedlist>
           <listitem>
             <para>Make sure you have Git installed. <command>which
             git</command> should produce a path to git.</para>
 
-            <screen><prompt>$&gt;</prompt> <userinput>which git</userinput>
+            <screen><prompt>$</prompt> <userinput>which git</userinput>
 <computeroutput>/usr/bin/git</computeroutput></screen>
-          </listitem>
-
-          <listitem>
-            <para>If you don't have one make a source directory.
-            <command>cd</command> to this directory.</para>
-
-            <screen><prompt>$&gt;</prompt> <userinput>mkdir /path/to/new/source/dir</userinput>
-<prompt>$&gt;</prompt> <userinput>cd /path/to/new/source/dir</userinput></screen>
           </listitem>
 
           <listitem>
             <para>Now get the source:</para>
 
-            <screen><prompt>$&gt;</prompt> <userinput>git clone git://netatalk.git.sourceforge.net/gitroot/netatalk/netatalk
+            <screen><prompt>$</prompt> <userinput>git clone -b main https://github.com/Netatalk/Netatalk.git netatalk-code
 </userinput><computeroutput>Initialized empty Git repository in /path/to/new/source/dir/netatalk/.git/
 remote: Counting objects: 2503, done.
 ...
 </computeroutput></screen>
 
-            <para>This will create a local directory called "netatalk"
-            containing a complete and fresh copy of the whole Netatalk source
-            from the Git repository.</para>
+            <para>This will create a local directory called
+            <filename>netatalk-code</filename> containing a complete and fresh
+            copy of the whole Netatalk source from the Git repository.</para>
           </listitem>
 
           <listitem>
             <para>In order to keep your repository copy updated, occasionally
             run:</para>
 
-            <screen><prompt>$&gt;</prompt> <userinput>git pull</userinput></screen>
+            <screen><prompt>$</prompt> <userinput>git pull</userinput></screen>
           </listitem>
 
           <listitem>
@@ -145,11 +137,13 @@ remote: Counting objects: 2503, done.
             <filename>configure</filename> script required in the next
             step.</para>
 
-            <screen><prompt>$&gt;</prompt> <userinput>./bootstrap</userinput></screen>
+            <screen><prompt>$</prompt> <userinput>./bootstrap</userinput></screen>
           </listitem>
         </orderedlist>
 
-        <para></para>
+        <para>For futher information refer to the <ulink
+        url="https://github.com/Netatalk/Netatalk/wiki/Developer-Notes">Developer Notes</ulink>
+        wiki page.</para>
       </sect3>
     </sect2>
   </sect1>
@@ -159,6 +153,11 @@ remote: Counting objects: 2503, done.
 
     <sect2>
       <title>Prerequisites</title>
+
+      <para>The following pieces of software are likely to have a package
+      available for your OS distribution of choice. Please see the <ulink
+      url="https://github.com/Netatalk/Netatalk/wiki/Installation-Notes">
+      Installation Notes</ulink> wiki page as a starting point.</para>
 
       <sect3>
         <title>System requirements</title>
@@ -185,7 +184,7 @@ remote: Counting objects: 2503, done.
       <sect3>
         <title>Required third party software</title>
 
-        <para>Netatalk makes use of sleepycats' Berkeley DB<indexterm>
+        <para>Netatalk makes use of Berkeley DB<indexterm>
             <primary>BDB</primary>
 
             <secondary>Berkeley DB</secondary>
@@ -198,15 +197,6 @@ remote: Counting objects: 2503, done.
           </listitem>
         </itemizedlist>
 
-        <para>In case Berkeley DB is not installed on your system, please
-        download it from:</para>
-
-        <para><ulink
-        url="http://www.oracle.com/database/berkeley-db/index.html">
-        http://www.oracle.com/database/berkeley-db/index.html</ulink></para>
-
-        <para>and follow the <link linkend="build-bdb">installation
-        instructions</link>.</para>
       </sect3>
 
       <sect3>
@@ -223,13 +213,6 @@ remote: Counting objects: 2503, done.
             will be sent over the network in clear text. Libgcrypt is needed
             for DHX2. OpenSSL is needed for the older DHCAST128 (aka
             DHX).</para>
-
-            <para>Libgcrypt can be downloaded from: <ulink
-            url="http://directory.fsf.org/project/libgcrypt/">
-            http://directory.fsf.org/project/libgcrypt/</ulink>.</para>
-
-            <para>OpenSSL can be downloaded from: <ulink
-            url="http://www.openssl.org/">http://www.openssl.org/</ulink>.</para>
           </listitem>
 
           <listitem>
@@ -250,9 +233,6 @@ remote: Counting objects: 2503, done.
 
             <para>Mac OS 8.5 - Mac OS X 10.4 use SLP to locate AFP
             servers.</para>
-
-            <para>You can download OpenSLP from: <ulink
-            url="http://www.openslp.org/">http://www.openslp.org/</ulink>.</para>
           </listitem>
 
           <listitem>
@@ -263,17 +243,11 @@ remote: Counting objects: 2503, done.
             Avahi or mDNSResponder.</para>
 
             <para>Avahi is a freely-available implementation of Zeroconf.
-            Avahi must be build with DBUS support (
+            Avahi itself must be built with DBUS support (
               <userinput>--enable-dbus</userinput>).</para>
-
-            <para>You can download Avahi from: <ulink
-            url="http://www.avahi.org/">http://www.avahi.org/</ulink>.</para>
 
             <para>Starting with Netatalk 2.2.3, mDNSResponder is also available.
             </para>
-
-            <para>You can download mDNSResponder from: <ulink
-            url="http://developer.apple.com/bonjour/">http://developer.apple.com/bonjour/</ulink>.</para>
           </listitem>
 
           <listitem>
@@ -285,9 +259,6 @@ remote: Counting objects: 2503, done.
             <para>Security options are: access control per host, domain and/or
             service; detection of host name spoofing or host address spoofing;
             booby traps to implement an early-warning system.</para>
-
-            <para>TCP Wrappers can be downloaded from: <ulink
-            url="ftp://ftp.porcupine.org/pub/security">ftp://ftp.porcupine.org/pub/security</ulink>/</para>
           </listitem>
 
           <listitem>
@@ -306,9 +277,6 @@ remote: Counting objects: 2503, done.
             libraries that enable the local system administrator to choose how
             applications authenticate users.</para>
 
-            <para>You can get the Linux PAM documentation and sources from
-            <ulink
-            url="http://www.kernel.org/pub/linux/libs/pam/">http://www.kernel.org/pub/linux/libs/pam/</ulink>.</para>
           </listitem>
 
           <listitem>
@@ -319,9 +287,6 @@ remote: Counting objects: 2503, done.
             built in conversions for, like ISO-8859-1. On glibc systems,
             Netatalk can use the glibc provided iconv implementation.
             Otherwise you can use the GNU libiconv implementation.</para>
-
-            <para>You can download GNU libiconv from: <olink><ulink
-            url="http://www.gnu.org/software/libiconv/">http://www.gnu.org/software/libiconv/</ulink></olink>.</para>
           </listitem>
         </itemizedlist>
       </sect3>
@@ -342,7 +307,7 @@ remote: Counting objects: 2503, done.
         automatically configure Netatalk for your operating system. If you
         have unusual needs, then you may wish to run</para>
 
-        <screen>$&gt; <userinput>./configure --help</userinput></screen>
+        <screen><prompt>$</prompt> <userinput>./configure --help</userinput></screen>
 
         <para>to see what special options you can enable.</para>
 
@@ -350,10 +315,12 @@ remote: Counting objects: 2503, done.
 
         <itemizedlist>
           <listitem>
-            <para>--enable-[redhat-sysv/redhat-systemd/suse-sysv/suse-systemd/gentoo/netbsd/debian/systemd/fhs]</para>
+            <para>--enable-[systemd/redhat-sysv/suse-sysv/gentoo/debian/netbsd/fhs]</para>
 
             <para>This option helps netatalk to determine where to install the
-            start scripts.</para>
+		start scripts. The <command>--enable-systemd</command> option is
+                cross-platform and should work with most contemporary Linux or *BSD
+                distributions that have adopted systemd.</para>
           </listitem>
 
           <listitem>
@@ -367,25 +334,25 @@ remote: Counting objects: 2503, done.
 
         <para>Now run configure with any options you need</para>
 
-        <screen><prompt>$&gt;</prompt> <userinput>./configure [arguments] [--with-bdb=/bdb/install/path]</userinput></screen>
+        <screen><prompt>$</prompt> <userinput>./configure [arguments] [--with-bdb=/bdb/install/path]</userinput></screen>
 
         <para>Configure will end up in an overview showing the settings the
         Netatalk Makefiles have been created with.</para>
 
         <para>If this step fails please visit the <ulink
-        url="http://netatalk.sourceforge.net/wiki/index.php/Troubleshooting">troubleshooting
+        url="https://github.com/Netatalk/Netatalk/wiki/Troubleshooting">troubleshooting
         guide</ulink>.</para>
 
         <para>Next, running</para>
 
-        <screen><prompt>$&gt;</prompt> <userinput>make</userinput></screen>
+        <screen><prompt>$</prompt> <userinput>make</userinput></screen>
 
         <para>should produce the Netatalk binaries (this step can take several
         minutes to complete).</para>
 
         <para>When the process finished you can use</para>
 
-        <screen><prompt>$&gt;</prompt> <userinput>make install</userinput></screen>
+        <screen><prompt>$</prompt> <userinput>make install</userinput></screen>
 
         <para>to install the binaries and documentation (must be done as
         "root" when using default locations).</para>

--- a/doc/manual/netatalk/intro.xml
+++ b/doc/manual/netatalk/intro.xml
@@ -2,21 +2,23 @@
 <chapter id="intro">
   <title>Introduction to Netatalk</title>
 
-  <para>Netatalk is an OpenSource software package, that can be used to turn
-  a *NIX machine into an extremely high-performance and
-  reliable file server for Macintosh computers.</para>
+  <para>Netatalk is an Open Source software package that can be used to turn
+  a *NIX machine into an extremely light-weight and
+  versatile file server for Macintosh computers. It speaks both AFP over TCP
+  as well as the legacy AppleTalk protocol, which means it can act as a bridge between
+  older Macs, networked Apple IIs, and the very latest macOS systems.</para>
 
-  <para>Using Netatalk's AFP 3.3 compliant file-server leads to significantly
-  higher transmission speeds compared with Macs accessing a server via
-  SaMBa/NFS while providing clients with the best possible user experience
-  (full support for Macintosh metadata, flawlessly supporting mixed
-  environments of classic MacOS and MacOS X clients)</para>
+  <para>Netatalk is AFP 3.3 compliant with AFP 2 backwards compatibility.
+  Its file server offers high transmission speeds and full
+  support for Macintosh metadata (resource forks), while offering a wide range of
+  authentication methods to accommodate any deployment environment.</para>
 
-  <para>Due to Netatalk speaking AppleTalk, the print-server task can provide
-  printing clients with full AppleTalk support as well as the server itself
-  with printing capabilities for AppleTalk-only printers. Starting with
-  version 2.0, Netatalk seamlessly interacts with CUPS on the server.</para>
+  <para>The included print server daemon can provide Apple II and Macintosh clients
+  with the ability to print to AppleTalk-only printers.
+  In addition, Netatalk is fully integrated with CUPS, allowing any networked Mac
+  to discover and print to a CUPS/AirPrint compatible printer on the network.</para>
 
-  <para>After all, Netatalk can be used to act as an AppleTalk router,
-  providing both segmentation and zone names in Macintosh networks.</para>
+  <para>Additionally, Netatalk can be used to act as an AppleTalk router,
+  providing both segmentation and zone names in traditional Macintosh networks.
+  </para>
 </chapter>


### PR DESCRIPTION
- Backport applicable improvements from 3.1
- Fix broken external URLs
- Document the new `--enable-systemd` configuration option
- Improve documentation for papd and timelord
- Rewrite the intro page to make more sense in today's context
- Point to Github project pages