### PR TITLE
Create GitHub build file with Sonar scanning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: SonarCloud
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+env:
+  APT_PACKAGES: libtool-bin libdb-dev libavahi-client-dev libevent-dev tracker tcpd
+
+jobs:
+  build:
+    name: Build and analyze
+    runs-on: ubuntu-22.04
+    env:
+      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Install dependencies
+        run: sudo apt-get install --no-install-recommends ${{ env.APT_PACKAGES }}
+      - name: Install sonar-scanner and build-wrapper
+        uses: SonarSource/sonarcloud-github-c-cpp@v1
+      - name: Run build-wrapper
+        run: |
+          mkdir -p ${{ env.BUILD_WRAPPER_OUT_DIR }}
+          ./bootstrap
+          ./configure
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} make -j $(nproc) all
+      - name: Run sonar-scanner
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"

--- a/libatalk/cnid/mysql/cnid_mysql.c
+++ b/libatalk/cnid/mysql/cnid_mysql.c
@@ -848,7 +848,7 @@ struct _cnid_db *cnid_mysql_open(struct cnid_open_args *args)
 
     /* Initialize and connect to MySQL server */
     EC_NULL( db->cnid_mysql_con = mysql_init(NULL) );
-    my_bool my_recon = true;
+    bool my_recon = true;
     EC_ZERO( mysql_options(db->cnid_mysql_con, MYSQL_OPT_RECONNECT, &my_recon) );
     int my_timeout = 600;
     EC_ZERO( mysql_options(db->cnid_mysql_con, MYSQL_OPT_CONNECT_TIMEOUT, &my_timeout) );

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,12 @@
+sonar.projectKey=Netatalk_netatalk
+sonar.organization=netatalk
+
+# This is the name and version displayed in the SonarCloud UI.
+#sonar.projectName=netatalk
+#sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+#sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
- Add new build.yml file that builds the master branch and runs the Sonar scan
- Add new sonar_project.properties with baseline project settings
- Fixes a deprecated my_bool data type that blocked compilation on all available Linux runtime environments ([deprecated with MySQL 8.0.1](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html#mysqld-8-0-1-compiling))