### PR TITLE
[2.2] Update manual to match current behavior

### DIFF
--- a/doc/manual/netatalk/configuration.xml
+++ b/doc/manual/netatalk/configuration.xml
@@ -79,7 +79,7 @@
         <para>Leaving the afpd.conf file empty equals to the following
         configuration:</para>
 
-        <para><programlisting>- -tcp -noddp -uamlist uams_dhx.so,uams_dhx2.so -nosavepassword</programlisting></para>
+        <para><programlisting>- -transall -uamlist uams_dhx.so,uams_dhx2.so</programlisting></para>
 
         <para>For a more detailed explanation of the available options, please
         refer to the <citerefentry>


### PR DESCRIPTION
Overlooked updating the manual following the default configuration change