### PR TITLE
[2.2] Improve systemd services dependencies

### DIFF
--- a/distrib/initscripts/a2boot.service.tmpl
+++ b/distrib/initscripts/a2boot.service.tmpl
@@ -1,10 +1,8 @@
-# This is experimental service file.
-# See distrib/systemd/README
 # This file is part of Netatalk :NETATALK_VERSION:.
 
 [Unit]
 Description=Apple II boot daemon
-After=syslog.target network.target atalkd.service
+After=network-online.target atalkd.service
 Requires=atalkd.service
 
 [Service]

--- a/distrib/initscripts/afpd.service.tmpl
+++ b/distrib/initscripts/afpd.service.tmpl
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Netatalk AFP fileserver for Macintosh clients
-After=syslog.target network.target slpd.service avahi-daemon.service cnid.service atalkd.service
+After=network-online.target slpd.service avahi-daemon.service cnid.service atalkd.service
 Requires=cnid.service
 
 [Service]

--- a/distrib/initscripts/atalkd.service.tmpl
+++ b/distrib/initscripts/atalkd.service.tmpl
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Netatalk AppleTalk daemon
-After=syslog.target network.target
+After=network-online.target
 
 [Service]
 Type=forking

--- a/distrib/initscripts/cnid.service.tmpl
+++ b/distrib/initscripts/cnid.service.tmpl
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=Netatalk CNID database daemon for AFP fileserver
-After=syslog.target network.target
+After=network-online.target
 Before=afpd.service
 Requires=afpd.service
 

--- a/distrib/initscripts/papd.service.tmpl
+++ b/distrib/initscripts/papd.service.tmpl
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=AppleTalk PAP printer server daemon
-After=syslog.target network.target atalkd.service
+After=network-online.target atalkd.service
 Requires=atalkd.service
 
 [Service]

--- a/distrib/initscripts/timelord.service.tmpl
+++ b/distrib/initscripts/timelord.service.tmpl
@@ -2,7 +2,7 @@
 
 [Unit]
 Description=AppleTalk Timelord time server daemon
-After=syslog.target network.target atalkd.service
+After=network-online.target atalkd.service
 Requires=atalkd.service
 
 [Service]


### PR DESCRIPTION
atalkd will fail to start unless a network connection is established. All other DDP services depend on atalkd to have started first, so make them do the same.

This is critical for when netatalk is running on a device that only has a wlan interface, such as an RPi Zero W.

Addresses https://github.com/Netatalk/netatalk/issues/232

Also pulls in the improvement from downstream https://sources.debian.org/src/netatalk/3.1.14~ds-1/debian/patches/104_modernize_systemd.patch/