### PR TITLE
[2.2] man pages: create an a2boot man page

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -56,6 +56,7 @@ manpages = manpages/ad.1 \
 		manpages/AppleVolumes.default.5 \
 		manpages/atalkd.conf.5 \
 		manpages/netatalk.conf.5 \
+		manpages/a2boot.8 \
 		manpages/afpd.8 \
 		manpages/atalkd.8 \
 		manpages/cnid_dbd.8 \

--- a/doc/manual/man/man8/a2boot.8.xml
+++ b/doc/manual/man/man8/a2boot.8.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<refentry id="a2boot.8">
+  <refmeta>
+    <refentrytitle>a2boot</refentrytitle>
+
+    <manvolnum>8</manvolnum>
+
+    <refmiscinfo class="date">01 Mar 2023</refmiscinfo>
+
+    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+  </refmeta>
+
+  <refnamediv>
+    <refname>a2boot</refname>
+
+    <refpurpose>Apple II netboot server</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+    <cmdsynopsis>
+      <command>a2boot</command>
+
+      <arg choice="opt">-d</arg>
+
+      <arg choice="opt">-n <replaceable>nbpname</replaceable></arg>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+
+  <refsect1>
+    <title>DESCRIPTION</title>
+
+    <para><emphasis remap="B">a2boot</emphasis> is a netboot server for
+    Apple IIe and IIGS computers. It allows compatible clients to boot
+    over an AppleTalk network </para>
+
+    <para><emphasis remap="B">a2boot</emphasis> serves multiple AFP volumes
+    that the Apple II client is configured to boot off of. These volumes
+    have to be populated with the appropriate ProDOS or GS/OS system files
+    before they can be used as boot volumes.</para>
+  </refsect1>
+
+  <refsect1>
+    <title>OPTIONS</title>
+
+    <variablelist remap="TP">
+      <varlistentry>
+        <term><option>-d</option></term>
+
+        <listitem>
+          <para>Debug mode, i.e. don't disassociate from controlling
+          TTY.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>-n</option> <replaceable>nbpname</replaceable></term>
+
+        <listitem>
+          <para>Register this server as <emphasis
+          remap="I">nbpname</emphasis>. This defaults to the hostname.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+</refentry>

--- a/doc/manual/manual.xml
+++ b/doc/manual/manual.xml
@@ -7,6 +7,7 @@
 <!ENTITY Upgrade SYSTEM "netatalk/upgrade.xml">
 <!ENTITY Configuration SYSTEM "netatalk/configuration.xml">
 
+<!ENTITY a2boot.8 SYSTEM "man/man8/a2boot.8.xml">
 <!ENTITY ad.1 SYSTEM "man/man1/ad.1.xml">
 <!ENTITY atalkd.8 SYSTEM "man/man8/atalkd.8.xml">
 <!ENTITY afpd.8 SYSTEM "man/man8/afpd.8.xml">
@@ -84,6 +85,8 @@ url="http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt">http://www.gnu.org/li
     <title>Manual Pages</title>
 
     <para>This is a collection of the man pages delivered with Netatalk.</para>
+
+    &a2boot.8;
 
     &ad.1;
 

--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -13,7 +13,7 @@ SUFFIXES = .tmpl .
 	    -e s@:NETATALK_VERSION:@${NETATALK_VERSION}@ \
 	    <$< >$@
 
-NONGENERATED_MANS = timelord.8
+NONGENERATED_MANS = a2boot.8 timelord.8
 GENERATED_MANS    = afpd.8 cnid_dbd.8 cnid_metad.8
 TEMPLATE_FILES    = afpd.8.tmpl cnid_dbd.8.tmpl cnid_metad.8.tmpl
 ATALK_MANS        = atalkd.8.tmpl papd.8.tmpl papstatus.8.tmpl psf.8.tmpl

--- a/man/man8/a2boot.8
+++ b/man/man8/a2boot.8
@@ -1,0 +1,53 @@
+'\" t
+.\"     Title: a2boot
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 01 Mar 2023
+.\"    Manual: Netatalk 2.2
+.\"    Source: Netatalk 2.2
+.\"  Language: English
+.\"
+.TH "A2BOOT" "8" "01 Mar 2023" "Netatalk 2.2" "Netatalk 2.2"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+a2boot \- Apple II netboot server
+.SH "SYNOPSIS"
+.HP \w'\fBa2boot\fR\ 'u
+\fBa2boot\fR [\-d] [\-n\ \fInbpname\fR]
+.SH "DESCRIPTION"
+.PP
+\fBa2boot\fR
+is a netboot server for Apple IIe and IIGS computers\&. It allows compatible clients to boot over an AppleTalk network
+.PP
+\fBa2boot\fR
+serves multiple AFP volumes that the Apple II client is configured to boot off of\&. These volumes have to be populated with the appropriate ProDOS or GS/OS system files before they can be used as boot volumes\&.
+.SH "OPTIONS"
+.PP
+\fB\-d\fR
+.RS 4
+Debug mode, i\&.e\&. don\*(Aqt disassociate from controlling TTY\&.
+.RE
+.PP
+\fB\-n\fR \fInbpname\fR
+.RS 4
+Register this server as
+\fInbpname\fR\&. This defaults to the hostname\&.
+.RE


### PR DESCRIPTION
This daemon never had a man page AFAICT. This PR adds one.