### PR TITLE
Sonar: Analyze against Python 3.9

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,6 @@
 sonar.projectKey=Netatalk_netatalk
 sonar.organization=netatalk
+sonar.python.version=3.9
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=netatalk


### PR DESCRIPTION
This addresses a Sonar warning that it doesn't know which version of Python to analyze our code against.

https://docs.sonarqube.org/latest/analyzing-source-code/languages/python/

Python 3.9.2 is the default in Debian Bullseye. It's possible to add more versions if needed.

Note: With https://github.com/Netatalk/netatalk/pull/227 we're removing all Python code except `afpstats`.