### PR TITLE
Modernize Systemd service file

### DIFF
--- a/distrib/initscripts/service.systemd.tmpl
+++ b/distrib/initscripts/service.systemd.tmpl
@@ -4,7 +4,7 @@
 Description=Netatalk AFP fileserver for Macintosh clients
 Documentation=man:afp.conf(5) man:netatalk(8) man:afpd(8) man:cnid_metad(8) man:cnid_dbd(8)
 Documentation=http://netatalk.sourceforge.net/
-After=syslog.target network.target avahi-daemon.service
+After=network.target avahi-daemon.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
 Declaring After=syslog.target is unnecessary:
 syslog is socket-activated and will therefore be started when needed.
Author: Jonas Smedegaard <dr@jones.dk>
Signed off by: Daniel Markstedt <markstedt@gmail.com>

Downstream patch from Debian: https://sources.debian.org/src/netatalk/3.1.14~ds-1/debian/patches/104_modernize_systemd.patch/