### PR TITLE
Tweak Sonar scanning config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - main
+      - branch-netatalk-3-1
+      - branch-netatalk-2-2
   pull_request:
     types: [opened, synchronize, reopened]
 
@@ -13,6 +15,7 @@ jobs:
   build:
     name: Build and analyze
     runs-on: ubuntu-22.04
+    if: github.repository == 'Netatalk/netatalk'
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     steps:


### PR DESCRIPTION
Scan only PRs coming from the present repo. Github does not pass tokens to forks, so Sonar jobs will fail for PRs originating from forks. See https://docs.github.com/en/actions/security-guides/encrypted-secrets#using-encrypted-secrets-in-a-workflow

Scan the two active stable branches in addition to main.