### PR TITLE
Document how the mysql cnid backend is configured.

### DIFF
--- a/doc/manual/configuration.xml
+++ b/doc/manual/configuration.xml
@@ -294,7 +294,9 @@ basedir regex = /usr/home</programlisting></para>
             <secondary>"mysql" CNID backend</secondary>
           </indexterm></title>
 
-        <para>CNID backend using a MySQL server.</para>
+          <para>CNID backend using a MySQL server. Gets automatically configured if the
+          mysql development libraries are detected. Disable it by passing <command>
+          --without-mysql-config</command> to the configure script.</para>
       </sect3>
     </sect2>
 


### PR DESCRIPTION
Since the mysql cnid backend is configured slightly differently from the others, and it isn't clear from the configure helptext, document in the html manual.