### PR TITLE
Modernize autoconf syntax

### DIFF
--- a/bin/uniconv/Makefile.am
+++ b/bin/uniconv/Makefile.am
@@ -1,6 +1,6 @@
 # Makefile.am for bin/aecho/
 
-INCLUDES = -I$(top_srcdir)/include -I$(top_srcdir)/sys
+AM_CPPFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/sys
 
 bin_PROGRAMS = uniconv
 

--- a/configure.ac
+++ b/configure.ac
@@ -7,12 +7,12 @@ NETATALK_VERSION=`cat $srcdir/VERSION`
 AC_SUBST(NETATALK_VERSION)
 
 AC_CONFIG_HEADERS([config.h])
-AC_CONFIG_MACRO_DIR([macros])
+AC_CONFIG_MACRO_DIRS([macros])
 AC_CONFIG_AUX_DIR([build-aux])
 
 AC_CANONICAL_HOST
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AM_MAINTAINER_MODE([enable])
 
 dnl Checks for programs.


### PR DESCRIPTION
autoconf syntax fixes to silence deprecation warnings

- AC_CONFIG_MACRO_DIR is deprecated in favor of AC_CONFIG_MACRO_DIRS
https://www.gnu.org/software/autoconf/manual/autoconf-2.70/html_node/Input.html

- INCLUDES is deprecated in favor of AM_CPPFLAGS
https://www.gnu.org/software/automake/manual/html_node/Program-Variables.html

- The `subdir-objects` option is required for the structure of our code.
https://www.gnu.org/software/automake/manual/html_node/Program-and-Library-Variables.html