### PR TITLE
C99 compatibility fixes

### DIFF
--- a/etc/afpd/afprun.c
+++ b/etc/afpd/afprun.c
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 /* #define __USE_GNU 1 */
 #include <unistd.h>
+#include <grp.h>
 
 #include <errno.h>
 #include <sys/wait.h>

--- a/macros/iconv.m4
+++ b/macros/iconv.m4
@@ -62,7 +62,7 @@ dnl	# check for iconv usability
 	AC_CACHE_CHECK([for working iconv],netatalk_cv_HAVE_USABLE_ICONV,[
 		AC_TRY_RUN([\
 #include <iconv.h>
-main() {
+int main(void) {
        iconv_t cd = iconv_open("ASCII", "UTF-8");
        if (cd == 0 || cd == (iconv_t)-1) return -1;
        return 0;

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -1220,6 +1220,7 @@ AC_DEFUN([AC_NETATALK_REALPATH], [
 AC_CACHE_CHECK([if the realpath function allows a NULL argument],
     neta_cv_REALPATH_TAKES_NULL, [
         AC_RUN_IFELSE([AC_LANG_SOURCE([[
+	    #include <stdlib.h>
             #include <stdio.h>
             #include <limits.h>
             #include <signal.h>
@@ -1228,7 +1229,7 @@ AC_CACHE_CHECK([if the realpath function allows a NULL argument],
                  exit(1);
             }
 
-            main() {
+            int main(void) {
                 char *newpath;
                 signal(SIGSEGV, exit_on_core);
                 newpath = realpath("/tmp", NULL);

--- a/macros/tcp-wrappers.m4
+++ b/macros/tcp-wrappers.m4
@@ -18,14 +18,14 @@ AC_DEFUN([AC_NETATALK_TCP_WRAPPERS], [
 		saved_LIBS=$LIBS
 		W_LIBS="-lwrap" 
 		LIBS="$LIBS $W_LIBS"
-		AC_TRY_LINK([ int allow_severity = 0; int deny_severity = 0;]
+		AC_TRY_LINK([ int allow_severity = 0; int deny_severity = 0; extern char hosts_access(void);]
 			,[hosts_access();]
 			, netatalk_cv_tcpwrap=yes , 
    			[
 				LIBS=$saved_LIBS
 				W_LIBS="-lwrap -lnsl" 
 				LIBS="$LIBS $W_LIBS"
-				AC_TRY_LINK([ int allow_severity = 0; int deny_severity = 0;]
+				AC_TRY_LINK([ int allow_severity = 0; int deny_severity = 0; extern char hosts_access(void);]
 					,[hosts_access();]
 					, netatalk_cv_tcpwrap=yes , netatalk_cv_tcpwrap=no)
 			]


### PR DESCRIPTION
Avoid build failures with future compilers.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
