### PR TITLE
Resolve gcc10 compiler warnings

### DIFF
--- a/etc/afpd/afpstats.c
+++ b/etc/afpd/afpstats.c
@@ -111,12 +111,10 @@ int afpstats_init(server_child_t *childs_in)
     GThread *thread;
 
     childs = childs_in;
-    g_type_init();
-    g_thread_init(NULL);
     dbus_g_thread_init();
     (void)g_log_set_default_handler(my_glib_log, NULL);
 
-    thread = g_thread_create(afpstats_thread, NULL, TRUE, NULL);
+    thread = g_thread_new("afpstats", afpstats_thread, NULL);
 
     return 0;
 }

--- a/etc/afpd/spotlight.c
+++ b/etc/afpd/spotlight.c
@@ -42,6 +42,7 @@
 #include <atalk/netatalk_conf.h>
 #include <atalk/volume.h>
 #include <atalk/spotlight.h>
+#include <atalk/compat.h>
 
 #include "directory.h"
 #include "etc/spotlight/sparql_parser.h"
@@ -1435,7 +1436,7 @@ int afp_spotlight_rpc(AFPObj *obj, char *ibuf, size_t ibuflen,
         RSIVAL(rbuf, 0, ntohs(vid));
         RSIVAL(rbuf, 4, 0);
         len = strlen(vol->v_path) + 1;
-        strncpy(rbuf + 8, vol->v_path, len);
+        strlcpy(rbuf + 8, vol->v_path, len);
         *rbuflen += 8 + len;
         break;
 

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -791,7 +791,7 @@ static struct vol *creatvol(AFPObj *obj,
     if (atalk_iniparser_getboolean(obj->iniconfig, INISEC_GLOBAL, "vol dbnest", 0)) {
         EC_NULL( volume->v_dbpath = strdup(path) );
     } else {
-        char *global_path;
+        const char *global_path;
         val = getoption(obj->iniconfig, section, "vol dbpath", preset, NULL);
         if (val == NULL) {
             /* check global option */
@@ -1573,7 +1573,7 @@ int load_volumes(AFPObj *obj, lv_flags_t flags)
     struct stat         st;
     int                 retries = 0;
     struct vol         *vol;
-    char               *includefile;
+    const char         *includefile;
 
     LOG(log_debug, logtype_afpd, "load_volumes: BEGIN");
 


### PR DESCRIPTION
- Use strlcpy() in spotlight code 
https://linux.die.net/man/3/strlcpy
- glib init calls have been deprecated and the system starts up automatically
https://www.manpagez.com/html/gobject/gobject-2.56.0/gobject-Type-Information.php#g-type-init
- glib thread creation has changed
https://docs.gtk.org/glib/ctor.Thread.new.html
- declare as const to math the return data type of the later assignment