### PR TITLE
libatalk: Check that FPDisconnectOldSession is successful

### DIFF
--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -279,6 +279,9 @@ static int login(AFPObj *obj, struct passwd *pwd, void (*logout)(void), int expi
     obj->uid = pwd->pw_uid;
     obj->euid = geteuid();
 
+    /* report to parent */
+    ipc_child_write(obj->ipc_fd, IPC_LOGINDONE, 0, "");
+
     /* pam_umask or similar might have changed our umask */
     (void)umask(obj->options.umask);
 

--- a/include/atalk/server_child.h
+++ b/include/atalk/server_child.h
@@ -52,6 +52,7 @@ extern void server_child_kill_one_by_id(server_child_t *children, pid_t pid, uid
                                         uint32_t len, char *id, uint32_t boottime);
 extern int  server_child_transfer_session(server_child_t *children, pid_t, uid_t, int, uint16_t);
 extern void server_child_handler(server_child_t *);
+extern void server_child_login_done(server_child_t *children, pid_t pid, uid_t);
 extern void server_reset_signal(void);
 
 #endif

--- a/include/atalk/server_ipc.h
+++ b/include/atalk/server_ipc.h
@@ -9,6 +9,7 @@
 #define IPC_GETSESSION       1
 #define IPC_STATE            2  /* pass AFP session state */
 #define IPC_VOLUMES          3  /* pass list of open volumes */
+#define IPC_LOGINDONE        4
 
 extern int ipc_server_read(server_child_t *children, int fd);
 extern int ipc_child_write(int fd, uint16_t command, int len, void *token);

--- a/libatalk/util/server_child.c
+++ b/libatalk/util/server_child.c
@@ -321,6 +321,32 @@ void server_child_kill_one_by_id(server_child_t *children, pid_t pid,
     pthread_mutex_unlock(&children->servch_lock);
 }
 
+/*  */
+void server_child_login_done(server_child_t *children, pid_t pid,
+                                 uid_t uid)
+{
+    afp_child_t *child;
+    afp_child_t *tmp;
+
+    pthread_mutex_lock(&children->servch_lock);
+
+    for (int i = 0; i < CHILD_HASHSIZE; i++) {
+        child = children->servch_table[i];
+        while (child) {
+            tmp = child->afpch_next;
+            if (child->afpch_pid == pid) {
+                /* update childs own slot */
+                LOG(log_debug, logtype_default, "Setting client ID for %u", child->afpch_pid);
+                child->afpch_uid = uid;
+                child->afpch_valid = 1;
+            }
+            child = tmp;
+        }
+    }
+
+    pthread_mutex_unlock(&children->servch_lock);
+}
+
 /* ---------------------------
  * reset children signals
  */


### PR DESCRIPTION
Patch by @kenjiuno originally contributed in https://sourceforge.net/p/netatalk/bugs/634/