### PR TITLE
libatalk: Remove dequoting of double quotes in the iniparser, again

### DIFF
--- a/libatalk/iniparser/iniparser.c
+++ b/libatalk/iniparser/iniparser.c
@@ -587,7 +587,7 @@ static line_status atalk_iniparser_line(
         sscanf(line, "[%[^]]", section);
         strstrip(section);
         sta = LINE_SECTION;
-    } else if (sscanf(line, "%[^=] = \"%[^\"]\"", key, value) == 2 || sscanf(line, "%[^=] = '%[^\']'", key, value) == 2) {
+    } else if (sscanf(line, "%[^=] = '%[^\']'", key, value) == 2) {
         /* Usual key=value with quotes, with or without comments */
         strstrip(key);
         /* Don't strip spaces from values surrounded with quotes */


### PR DESCRIPTION
Partially reverts https://github.com/Netatalk/netatalk/commit/b568955f3f970cffe70289bcaa7e7cf9ddaf0687
Restores the change originally made in https://github.com/Netatalk/netatalk/commit/3343c2