### PR TITLE
libatalk: remove const keyword for variable that changes

### DIFF
--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -1816,7 +1816,7 @@ struct vol *getvolbypath(AFPObj *obj, const char *path)
     static regex_t reg;
     struct vol *vol;
     struct vol *tmp;
-    const struct passwd *pw;
+    struct passwd *pw;
     char        volname[AFPVOL_U8MNAMELEN + 1];
     char        abspath[MAXPATHLEN + 1];
     char        volpath[MAXPATHLEN + 1], *realvolpath = NULL;


### PR DESCRIPTION
gcc10 complains about discarded qualifiers, so removing the const keyword from a variable that has multiple assignments throughout the function

This was a minor regression introduced by https://github.com/Netatalk/netatalk/pull/299