### PR TITLE
spotlight: Use current directive %define parse.error verbose

### DIFF
--- a/etc/spotlight/sparql_parser.y
+++ b/etc/spotlight/sparql_parser.y
@@ -55,7 +55,7 @@
 }
 
 %expect 5
-%error-verbose
+%define parse.error verbose
 
 %type <sval> match expr line function
 %type <tval> date


### PR DESCRIPTION
The gcc10 compiler throwing these warnings:

```
Making all in etc
make[2]: Entering directory '/home/dmark/dev/netatalk/etc'
Making all in spotlight
make[3]: Entering directory '/home/dmark/dev/netatalk/etc/spotlight'
  YACC     sparql_parser.c
/home/dmark/dev/netatalk/etc/spotlight/sparql_parser.y:44.1-5: warning: POSIX Yacc does not support %code [-Wyacc]
   44 | %code provides {
      | ^~~~~
/home/dmark/dev/netatalk/etc/spotlight/sparql_parser.y:57.1-7: warning: POSIX Yacc does not support %expect [-Wyacc]
   57 | %expect 5
      | ^~~~~~~
/home/dmark/dev/netatalk/etc/spotlight/sparql_parser.y:58.1-14: warning: POSIX Yacc does not support %error-verbose [-Wyacc]
   58 | %error-verbose
      | ^~~~~~~~~~~~~~
/home/dmark/dev/netatalk/etc/spotlight/sparql_parser.y:58.1-14: warning: deprecated directive: ‘%error-verbose’, use ‘%define parse.error verbose’ [-Wdeprecated]
   58 | %error-verbose
      | ^~~~~~~~~~~~~~
      | %define parse.error verbose
/home/dmark/dev/netatalk/etc/spotlight/sparql_parser.y: warning: fix-its can be applied.  Rerun with option '--update'. [-Wother]
sparql_parser.h is unchanged
```

With gnu bison 3.7.5, resolves the deprecation warning:

```
$ bison --update sparql_parser.y
```

I think the -Wyacc warnings are spurious.