### PR TITLE
Add support for macOS hosts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ test-driver
 *.diff.gz
 *~
 *.o
+**/.DS_Store
+build-aux

--- a/bin/ad/ad_cp.c
+++ b/bin/ad/ad_cp.c
@@ -821,7 +821,7 @@ static int setfile(const struct stat *fs, int fd)
     islink = !fdval && S_ISLNK(fs->st_mode);
     mode = fs->st_mode & (S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO);
 
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
     TIMESPEC_TO_TIMEVAL(&tv[0], &fs->st_atimespec);
     TIMESPEC_TO_TIMEVAL(&tv[1], &fs->st_mtimespec);
 #else

--- a/bootstrap
+++ b/bootstrap
@@ -10,7 +10,7 @@ DIE=0
   DIE=1
 }
 
-(libtool --version) < /dev/null > /dev/null 2>&1 || {
+(libtool --version || glibtool --version) < /dev/null > /dev/null 2>&1 || {
   echo
   echo "**Error**: You must have \`libtool' installed."
   echo "Get ftp://ftp.gnu.org/pub/gnu/libtool-1.2d.tar.gz"

--- a/distrib/initscripts/Makefile.am
+++ b/distrib/initscripts/Makefile.am
@@ -218,6 +218,28 @@ uninstall-startup:
 
 endif
 
+#
+# checking for macOS init script
+#
+
+if USE_MACOS_LAUNCHD
+
+bin_SCRIPTS = netatalkd
+launchd_PLIST = com.netatalk.daemon.plist
+
+install-data-hook:
+	(if [ ! -f $(INIT_DIR)/$(launchd_PLIST) ] ; then \
+		cp $(launchd_PLIST) $(INIT_DIR) && \
+		launchctl load -w $(INIT_DIR)/$(launchd_PLIST); \
+	fi)
+
+uninstall-startup:
+	$(bin_SCRIPTS) stop
+	launchctl unload -w $(INIT_DIR)/$(launchd_PLIST)
+	rm -f $(DESTDIR)$(bindir)/$(bin_SCRIPTS)
+	rm -f $(INIT_DIR)/$(launchd_PLIST)
+
+endif
 
 #
 # defaults, no init scripts installed

--- a/distrib/initscripts/com.netatalk.daemon.plist
+++ b/distrib/initscripts/com.netatalk.daemon.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/usr/local/bin</string>
+	</dict>
+	<key>Label</key>
+	<string>com.netatalk.daemon</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/usr/local/bin/netatalkd</string>
+		<string>start</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>/tmp/netatalk.err</string>
+	<key>StandardOutPath</key>
+	<string>/tmp/netatalk.out</string>
+</dict>
+</plist>

--- a/distrib/initscripts/netatalkd
+++ b/distrib/initscripts/netatalkd
@@ -1,0 +1,44 @@
+#!/bin/zsh
+
+# # Startup daemon for netatalk on macOS
+
+# Prepare the environment
+export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+PREFIX=/usr/local/sbin
+. /etc/rc.common
+
+# root check
+if [ "$(id -u)" != "0" ]; then
+  printf "Error: The start/stop/restart script for netatalk needs to be executed with sudo privileges.\n" 1>&2
+  exit 1
+fi
+
+#Ensure network availability before running daemon
+CheckForNetwork
+while [ "${NETWORKUP}" != "-YES-" ]; do
+  sleep 5
+  NETWORKUP=
+  CheckForNetwork
+done
+
+# The start subroutine
+StartService() {
+  ConsoleMessage "Starting netatalk fileserver..."
+  rm -f /var/run/netatalk.pid
+  $PREFIX/netatalk
+}
+
+# The stop subroutine
+StopService() {
+  ConsoleMessage "Stopping netatalk fileserver..."
+  killall -TERM netatalk
+}
+
+# The restart subroutine
+RestartService() {
+  StopService
+  rm -f /var/run/netatalk.pid
+  StartService
+}
+
+RunService "$1"

--- a/etc/uams/uams_passwd.c
+++ b/etc/uams/uams_passwd.c
@@ -8,8 +8,6 @@
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 
-#include <atalk/standards.h>
-
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -31,6 +29,7 @@
 #include <atalk/uam.h>
 #include <atalk/util.h>
 #include <atalk/compat.h>
+#include <atalk/standards.h>
 
 #define PASSWDLEN 8
 

--- a/libatalk/adouble/ad_lock.c
+++ b/libatalk/adouble/ad_lock.c
@@ -16,18 +16,17 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <inttypes.h>
+#include <string.h>
+
 #include <atalk/adouble.h>
 #include <atalk/logger.h>
 #include <atalk/compat.h>
 #include <atalk/errchk.h>
 #include <atalk/util.h>
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <inttypes.h>
-
-#include <string.h>
 
 #include "ad_lock.h"
 

--- a/libatalk/bstring/bstrlib.c
+++ b/libatalk/bstring/bstrlib.c
@@ -2737,7 +2737,7 @@ struct genBstrList g;
 #define START_VSNBUFF (256)
 #else
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 /* Something is making gcc complain about this prototype not being here, so 
    I've just gone ahead and put it in. */
 extern int vsnprintf (char *buf, size_t count, const char *format, va_list arg);

--- a/libatalk/util/socket.c
+++ b/libatalk/util/socket.c
@@ -21,8 +21,6 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#include <atalk/standards.h>
-
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/types.h>
@@ -40,6 +38,7 @@
 #include <atalk/logger.h>
 #include <atalk/util.h>
 #include <atalk/errchk.h>
+#include <atalk/standards.h>
 
 static char ipv4mapprefix[] = {0,0,0,0,0,0,0,0,0,0,0xff,0xff};
 

--- a/macros/db3-check.m4
+++ b/macros/db3-check.m4
@@ -86,7 +86,7 @@ AC_DEFUN([AC_NETATALK_PATH_BDB],[
 if test "x$bdb_required" = "xyes"; then
     trybdbdir=""
     dobdbsearch=yes
-    bdb_search_dirs="/usr/local /usr"
+    bdb_search_dirs="/usr/local /usr /usr/local/opt/berkeley-db /opt/homebrew/opt/berkeley-db"
     search_subdirs="/ /db6.1 /db6 /db5 /db5.3 /db5.2 /db5.1 /db51 /db5.0 /db50 /db4.8 /db48 /db4.7 /db47 /db4.6 /db46 /db4"
 
     bdbfound=no

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -1045,6 +1045,19 @@ case "$this_os" in
   *freebsd4* | *dragonfly* )
     AC_DEFINE(BROKEN_EXTATTR, 1, [Does extattr API work])
   ;;
+  
+  *macosx*)
+	AC_SEARCH_LIBS(getxattr, [attr])
+    if test "x$neta_cv_eas_sys_found" != "xyes" ; then
+       AC_CHECK_FUNCS([getxattr fgetxattr listxattr],
+                      [neta_cv_eas_sys_found=yes],
+                      [neta_cv_eas_sys_not_found=yes])
+	   AC_CHECK_FUNCS([flistxattr removexattr fremovexattr],,
+                      [neta_cv_eas_sys_not_found=yes])
+	   AC_CHECK_FUNCS([setxattr fsetxattr],,
+                      [neta_cv_eas_sys_not_found=yes])
+    fi
+  ;;
 
   *)
 	AC_SEARCH_LIBS(getxattr, [attr])

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -486,10 +486,17 @@ AC_ARG_ENABLE(shell-check,
 dnl Check for optional initscript install
 AC_DEFUN([AC_NETATALK_INIT_STYLE], [
     AC_ARG_WITH(init-style,
-                [  --with-init-style       use OS specific init config [[redhat-sysv|redhat-systemd|suse-sysv|suse-systemd|gentoo-openrc|gentoo-systemd|netbsd|debian-sysv|debian-systemd|solaris|openrc|systemd]]],
+                [  --with-init-style       use OS specific init config [[redhat-sysv|redhat-systemd|suse-sysv|suse-systemd|gentoo-openrc|gentoo-systemd|netbsd|debian-sysv|debian-systemd|solaris|openrc|systemd|macos-launchd]]],
                 init_style="$withval", init_style=none
     )
-    case "$init_style" in 
+    case "$host_os" in
+    *darwin*)
+    if test x"$init_style" = x"none" ; then
+    init_style=macos-launchd
+    fi
+    ;;
+    esac
+    case "$init_style" in
     "redhat")
 	    AC_MSG_ERROR([--with-init-style=redhat is obsoleted. Use redhat-sysv or redhat-systemd.])
         ;;
@@ -550,6 +557,10 @@ AC_DEFUN([AC_NETATALK_INIT_STYLE], [
 	    AC_MSG_RESULT([enabling general systemd support])
 	    ac_cv_init_dir="/usr/lib/systemd/system"
         ;;
+    "macos-launchd")
+    	AC_MSG_RESULT([enabling macOS-style launchd initscript support])
+    	ac_cv_init_dir="/Library/LaunchDaemons"
+        ;;    
     "none")
 	    AC_MSG_RESULT([disabling init-style support])
 	    ac_cv_init_dir="none"
@@ -566,6 +577,7 @@ AC_DEFUN([AC_NETATALK_INIT_STYLE], [
     AM_CONDITIONAL(USE_DEBIAN_SYSV, test x$init_style = xdebian-sysv)
     AM_CONDITIONAL(USE_SYSTEMD, test x$init_style = xsystemd || test x$init_style = xredhat-systemd || test x$init_style = xsuse-systemd || test x$init_style = xgentoo-systemd)
     AM_CONDITIONAL(USE_DEBIAN_SYSTEMD, test x$init_style = xdebian-systemd)
+    AM_CONDITIONAL(USE_MACOS_LAUNCHD, test x$init_style = xmacos-launchd)
     AM_CONDITIONAL(USE_UNDEF, test x$init_style = xnone)
 
     AC_ARG_WITH(init-dir,

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -52,6 +52,13 @@ AC_DEFUN([AC_NETATALK_DTRACE], [
     [WDTRACE=$withval],
     [WDTRACE=auto]
   )
+  case "$host_os" in
+  *darwin*)
+  if test x"$WDTRACE" = x"auto" ; then
+  WDTRACE=no
+  fi
+  ;;
+  esac
   if test "x$WDTRACE" = "xyes" -o "x$WDTRACE" = "xauto" ; then
     AC_CHECK_PROG([atalk_cv_have_dtrace], [dtrace], [yes], [no])
     if test "x$atalk_cv_have_dtrace" = "xno" ; then
@@ -899,7 +906,12 @@ fi
 
 # Platform specific checks
 if test x"$with_acl_support" != x"no" ; then
-	case "$host_os" in
+   case "$host_os" in
+  *darwin*)
+    AC_MSG_NOTICE(Darwin ACLs are currently unsupported)
+    with_acl_support=no
+    ac_cv_have_acls=no
+    ;;
 	*solaris*)
 		AC_MSG_NOTICE(Using solaris ACLs)
 		AC_DEFINE(HAVE_SOLARIS_ACLS,1,[Whether Solaris ACLs are available])

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -314,7 +314,7 @@ AC_DEFUN([AC_NETATALK_LOCKFILE], [
             *freebsd*)
                 ac_cv_netatalk_lock=/var/spool/lock/netatalk
                 ;;
-            *netbsd*|*openbsd*)
+            *netbsd*|*openbsd*|*darwin*)
                 ac_cv_netatalk_lock=/var/run/netatalk.pid
                 ;;
             *linux*)

--- a/macros/pam-check.m4
+++ b/macros/pam-check.m4
@@ -97,6 +97,13 @@ AC_DEFUN([AC_NETATALK_PATH_PAM], [
            PAM_ACCOUNT=system
            PAM_PASSWORD=system
            PAM_SESSION=system
+        dnl macOS
+        elif test -f "$pampath/chkpasswd"; then
+           PAM_DIRECTIVE=required
+           PAM_AUTH=pam_opendirectory.so
+           PAM_ACCOUNT=pam_opendirectory.so
+           PAM_PASSWORD=pam_permit.so
+           PAM_SESSION=pam_permit.so
         dnl Solaris 11+
         elif test -f "$pampath/other" ; then
            PAM_DIRECTIVE=include

--- a/macros/ssl-check.m4
+++ b/macros/ssl-check.m4
@@ -45,7 +45,7 @@ dnl	compile_ssl=no
 
 	if test "$tryssl" = "yes"; then
 		AC_MSG_CHECKING([for SSL])
-		for ssldir in "" $tryssldir /usr /usr/local/openssl /usr/$atalk_libname/openssl /usr/local/ssl /usr/$atalk_libname/ssl /usr/local /usr/pkg /opt /opt/openssl /usr/local/ssl ; do
+		for ssldir in "" $tryssldir /usr /usr/local/openssl /usr/$atalk_libname/openssl /usr/local/ssl /usr/$atalk_libname/ssl /usr/local /usr/pkg /opt /opt/openssl /usr/local/ssl /usr/local/opt/openssl@1.1 /opt/homebrew/opt/openssl@1.1; do
 			if test -f "$ssldir/include/openssl/cast.h" ; then
 				SSL_CFLAGS="$SSL_CFLAGS -I$ssldir/include -I$ssldir/include/openssl"
 				SSL_LIBS="$SSL_LIBS -L$ssldir/$atalk_libname -L$ssldir -lcrypto"

--- a/macros/zeroconf.m4
+++ b/macros/zeroconf.m4
@@ -64,11 +64,28 @@ AC_DEFUN([AC_NETATALK_ZEROCONF], [
                 AC_DEFINE(HAVE_MDNS, 1, [Use mDNSRespnder/DNS-SD registration])
                 found_zeroconf=yes
             fi
-		fi
+		    fi
+
+		    # mDNS support using mDNSResponder on macOS
+		    if test x"$found_zeroconf" != x"yes" ; then
+				    AC_CHECK_HEADER(
+						    dns_sd.h,
+						    AC_CHECK_LIB(
+								    System,
+								    DNSServiceRegister,
+								    AC_DEFINE(USE_ZEROCONF, 1, [Use DNS-SD registration]))
+				    )
+
+				    if test "$ac_cv_lib_System_DNSServiceRegister" = yes; then
+						    ZEROCONF_LIBS="-lSystem"
+						    AC_DEFINE(HAVE_MDNS, 1, [Use mDNSRespnder/DNS-SD registration])
+						    found_zeroconf=yes
+				    fi
+        fi
 	fi
 
 	netatalk_cv_zeroconf=no
-	AC_MSG_CHECKING([whether to enable Zerconf support])
+	AC_MSG_CHECKING([whether to enable Zeroconf support])
 	if test "x$found_zeroconf" = "xyes"; then
 		AC_MSG_RESULT([yes])
 		AC_DEFINE(USE_ZEROCONF, 1, [Define to enable Zeroconf support])


### PR DESCRIPTION
This initial changeset adds support for macOS hosts which do not have a built-in afp server (macOS Big Sur onwards) or which do not support AFP 2.2, the version required to connect to vintage Macs running classic Mac OS. In summary:
- is compatible with modern Intel and Apple Silicon based Macs
- fixes compilation errors when using the macOS native compiler. Apple's version of clang is picky about header orders, it likes the system headers to be iterated before the atalk and same-dir headers.
- fixes macro to enable Zeroconf support on macOS
- fixes EA macro to ensure sys EA support
- fixes the lock file location on macOS
- fixes db3 and ssl macros to ensure OpenSSL and Berkeley DB dependencies installed via Homebrew are found
- fixes PAM macro to enable authentication on macOS
- disables ACL and dtrace support as Apple implementations are currently not supported
- installs a macOS LaunchDaemon to start netatalk on boot and restart from the command line when required
- requires dependencies to be installed via Homebrew:
`brew install berkeley-db libevent libgcrypt mysql libressl openssl@1.1 pkg-config`

What is currently unsupported in this changeset (but possible, proof of concept please see my fork https://github.com/dgsga/netatalk):

- building documentation using docbook (WIP)
- DBUS support / afpstats (WIP)

I have tested these code changes extensively on my Macs over a two year period. I have also tested the PR branch on Debian 11 to check for inadvertent regressions, none found yet. Please test if you have Mac hardware available