### PR TITLE
[2.2] Fix incorrect type in printer status check

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 Changes in 2.2.9
 ================
 
+* FIX: Fix printing from old Mac OS LaserWriter drivers
 * FIX: CVE-2022-45188
 * FIX: Improve systemd service dependencies GH#232
 * FIX: macusers: Fix output for long usernames

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -307,7 +307,7 @@ cups_get_printer_status (struct printer *pr)
 
 	if ((attr = ippFindAttribute(response, "printer-is-accepting-jobs", IPP_TAG_BOOLEAN)) != NULL)
 	{
-		if ( ippGetInteger(attr, 0) == 0 )
+		if ( ippGetBoolean(attr, 0) == 0 )
 			status = 0;
 	}
 		


### PR DESCRIPTION
The `printer-is-accepting-jobs` attribute is a boolean, not an integer, so check for Boolean. 

Before this fix the client's driver would detect the printer but would fail to print, complaining that the printer was rejecting jobs. There would be a corresponding message in the `papd` log like `appletalk papd: CUPS_PAP_OPEN: Canon_MF632CDW is not accepting jobs`.

This fix causes `cups_get_printer_status` to return a non-zero `status` when the printer is ready, allowing printing to work. Tested on Mac OS 8.6 and 9.2.2 and 10.2.8