### PR TITLE
configure: Strip newline from VERSION if needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl configure.ac for netatalk
 
-AC_INIT([netatalk],[m4_esyscmd(cat VERSION)])
+AC_INIT([netatalk], [m4_esyscmd([echo -n `cat VERSION`])])
 AC_CONFIG_SRCDIR([etc/afpd/main.c])
 
 NETATALK_VERSION=`cat $srcdir/VERSION`


### PR DESCRIPTION
vi/vim or even the github web code editor silently adds newlines to any file that they edit, breaking the bootstrapping process when a newline enters VERSION. This makes sure the newline gets stripped when bootstrapping the configure script.