### PR TITLE
configure: Revert the subdir-objects option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  APT_PACKAGES: libtool libtool-bin automake autoconf libevent-dev libssl-dev libgcrypt-dev libkrb5-dev libpam0g-dev libdb-dev libtdb-dev libmysqlclient-dev libavahi-client-dev libacl1-dev libcrack2-dev libdbus-1-dev libdbus-glib-1-dev libglib2.0-dev tracker tcpd
+  APT_PACKAGES: libtool libtool-bin automake autoconf libevent-dev libssl-dev libgcrypt-dev libkrb5-dev libpam0g-dev libdb-dev libtdb-dev libmysqlclient-dev libavahi-client-dev libacl1-dev libcrack2-dev libdbus-1-dev libdbus-glib-1-dev libglib2.0-dev systemtap-sdt-dev tracker tcpd
 
 jobs:
   build-ubuntu:
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get install --assume-yes --no-install-recommends ${{ env.APT_PACKAGES }}
       - name: Build
-        run: ./bootstrap && ./configure --with-dtrace=no && make -j $(nproc) # disable dtrace; issue #313
+        run: ./bootstrap && ./configure && make -j $(nproc)
       - name: Run tests
         run: make check
 

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 
 AC_CANONICAL_HOST
 
-AM_INIT_AUTOMAKE([subdir-objects])
+AM_INIT_AUTOMAKE
 AM_MAINTAINER_MODE([enable])
 
 dnl Checks for programs.


### PR DESCRIPTION
Temporarily reverting the subdir-objects option for bootstrapping. A more comprehensive solution will be required to make this work with the test/afpd/

https://github.com/Netatalk/netatalk/issues/313