### PR TITLE
Modernize autotools bootstrapping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: brew install automake libressl mysql pkg-config
+        run: brew install automake libressl dgsga/netatalk-mysql/mysql pkg-config
       - name: Build
         run: ./bootstrap && ./configure --with-ssl-dir=/usr/local/opt/libressl --with-bdb=/usr/local/opt/berkeley-db && make -j $(nproc)
       - name: Run tests

--- a/bootstrap
+++ b/bootstrap
@@ -49,18 +49,8 @@ set -x
 
 rm -rf autom4te*.cache
 
-LIBTOOLIZE=libtoolize
-SYSNAME=`uname`
-if [ "x$SYSNAME" = "xDarwin" ] ; then
-  LIBTOOLIZE=glibtoolize
-fi
-
 # build it all.
-aclocal -I macros $ACLOCAL_FLAGS || exit 1
-autoheader || exit 1
-$LIBTOOLIZE --force --copy
-automake --include-deps --add-missing --foreign --copy || exit 1
-autoconf || exit 1
+autoreconf -fi || exit 1
 
 # Let's not fall off the end...
 exit 0

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl configure.ac for netatalk
 
-AC_INIT([netatalk],[m4_esyscmd(cat VERSION)])
+AC_INIT([netatalk],m4_normalize(m4_include([VERSION])))
 AC_CONFIG_SRCDIR([etc/afpd/main.c])
 
 NETATALK_VERSION=`cat $srcdir/VERSION`
@@ -12,25 +12,23 @@ AC_CONFIG_AUX_DIR([build-aux])
 
 AC_CANONICAL_HOST
 
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 AM_MAINTAINER_MODE([enable])
 
 dnl Checks for programs.
 AC_PROG_AWK
 AC_PROG_CC
-AC_PROG_CC_C99
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
-AC_LIBTOOL_DLOPEN
-AC_PROG_LIBTOOL
+LT_INIT([dlopen])
 AC_PROG_PERL
 AC_PROG_GREP
 AC_PROG_PS
 AM_PROG_CC_C_O
 AC_C_BIGENDIAN
 AC_C_INLINE
-AC_PROG_LEX
+AC_PROG_LEX([noyywrap])
 AC_PROG_YACC
 
 dnl Check if we can use attribute unused (gcc only) from ethereal
@@ -63,9 +61,9 @@ AC_SYS_LARGEFILE([], AC_MSG_ERROR([AFP 3.x support requires Large File Support.]
 dnl --------------------------------------------------------------------------
 dnl check if dlsym needs to add an underscore, uses libtool macros
 dnl --------------------------------------------------------------------------
-AC_LTDL_DLLIB
+LT_LIB_DLLOAD
 AC_CHECK_FUNCS(dlopen dlsym dlclose)
-AC_LTDL_DLSYM_USCORE
+LT_FUNC_DLSYM_USCORE
 if test x"$libltdl_cv_need_uscore" = xyes; then
     AC_DEFINE(DLSYM_PREPEND_UNDERSCORE, 1, [BSD compatibility macro])
 fi

--- a/doc/manpages/man1/Makefile.am
+++ b/doc/manpages/man1/Makefile.am
@@ -32,7 +32,7 @@ EXTRA_DIST = \
 if HAVE_XSLTPROC
 CLEANFILES += $(MAN_MANPAGES)
 
-%.1 : %.1.xml
+$(MAN_MANPAGES) : %.1 : %.1.xml
 	@xsltproc $(MAN_STYLESHEET) $<
 	@cp $@ $(top_builddir)/man/man1/$@.in
 

--- a/doc/manpages/man5/Makefile.am
+++ b/doc/manpages/man5/Makefile.am
@@ -18,7 +18,7 @@ EXTRA_DIST = \
 if HAVE_XSLTPROC
 CLEANFILES += $(MAN_MANPAGES)
 
-%.5 : %.5.xml
+$(MAN_MANPAGES) : %.5 : %.5.xml
 	@xsltproc $(MAN_STYLESHEET) $<
 	@cp $@ $(top_builddir)/man/man5/$@.in
 

--- a/doc/manpages/man8/Makefile.am
+++ b/doc/manpages/man8/Makefile.am
@@ -18,7 +18,7 @@ EXTRA_DIST = \
 if HAVE_XSLTPROC
 CLEANFILES += $(MAN_MANPAGES)
 
-%.8 : %.8.xml
+$(MAN_MANPAGES) : %.8 : %.8.xml
 	@xsltproc $(MAN_STYLESHEET) $<
 	@cp $@ $(top_builddir)/man/man8/$@.in
 

--- a/macros/db3-check.m4
+++ b/macros/db3-check.m4
@@ -35,7 +35,7 @@ AC_DEFUN([NETATALK_BDB_TRY_LINK],[
     for lib in $atalk_cv_bdb_try_libs ; do
         LIBS="-l$lib $savedlibs"
         AC_MSG_CHECKING([Berkeley DB library (-l$lib)])
-        AC_TRY_RUN([
+        AC_RUN_IFELSE([AC_LANG_SOURCE([[
             #include <stdio.h>
             #include <db.h>
             int main(void) {
@@ -54,7 +54,7 @@ AC_DEFUN([NETATALK_BDB_TRY_LINK],[
                 printf("%d.%d.%d ... ",major, minor, patch);
                 return (0);
             }
-        ],[
+        ]])],[
             AC_MSG_RESULT(yes)
             atalk_cv_bdb_version="yes"
             atalk_cv_lib_db="-l$lib"

--- a/macros/iconv.m4
+++ b/macros/iconv.m4
@@ -28,14 +28,14 @@ dnl	# check for libiconv support
         LDFLAGS="$LDFLAGS $ICONV_LIBS -liconv"
 
 	AC_CACHE_CHECK([for libiconv],netatalk_cv_iconv,[
-          AC_TRY_LINK([
+          AC_LINK_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>
 #include <iconv.h>
 ],[
 	iconv_t cd = iconv_open("","");
         iconv(cd,NULL,NULL,NULL,NULL);
         iconv_close(cd);
-], netatalk_cv_iconv=yes, netatalk_cv_iconv=no, netatalk_cv_iconv=cross)])
+]])], netatalk_cv_iconv=yes, netatalk_cv_iconv=no, netatalk_cv_iconv=cross)])
 
 	if test x"$netatalk_cv_iconv" = x"yes"; then
 	    ICONV_LIBS="$ICONV_LIBS -liconv"
@@ -60,14 +60,14 @@ dnl	############
 dnl	# check for iconv usability
 
 	AC_CACHE_CHECK([for working iconv],netatalk_cv_HAVE_USABLE_ICONV,[
-		AC_TRY_RUN([\
+		AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <iconv.h>
 int main(void) {
        iconv_t cd = iconv_open("ASCII", "UTF-8");
        if (cd == 0 || cd == (iconv_t)-1) return -1;
        return 0;
 }
-], netatalk_cv_HAVE_USABLE_ICONV=yes,netatalk_cv_HAVE_USABLE_ICONV=no,netatalk_cv_HAVE_USABLE_ICONV=cross)])
+]])], netatalk_cv_HAVE_USABLE_ICONV=yes,netatalk_cv_HAVE_USABLE_ICONV=no,netatalk_cv_HAVE_USABLE_ICONV=cross)])
 
 	if test x"$netatalk_cv_HAVE_USABLE_ICONV" = x"yes"; then
 	    AC_DEFINE(HAVE_USABLE_ICONV,1,[Whether to use native iconv])
@@ -77,7 +77,7 @@ dnl	###########
 dnl	# check if iconv needs const
   	if test x"$netatalk_cv_HAVE_USABLE_ICONV" = x"yes"; then
     		AC_CACHE_VAL(am_cv_proto_iconv, [
-      		AC_TRY_COMPILE([\
+      		AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
 #include <stdlib.h>
 #include <iconv.h>
 extern
@@ -89,7 +89,7 @@ size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, si
 #else
 size_t iconv();
 #endif
-], [], am_cv_proto_iconv_arg1="", am_cv_proto_iconv_arg1="const")
+]])], [], am_cv_proto_iconv_arg1="", am_cv_proto_iconv_arg1="const")
 	      	am_cv_proto_iconv="extern size_t iconv (iconv_t cd, $am_cv_proto_iconv_arg1 char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);"])
     		AC_DEFINE_UNQUOTED(ICONV_CONST, $am_cv_proto_iconv_arg1,
       			[Define as const if the declaration of iconv() needs const.])
@@ -99,14 +99,14 @@ dnl     ###########
 dnl     # check if (lib)iconv supports UCS-2-INTERNAL
 	if test x"$netatalk_cv_HAVE_USABLE_ICONV" = x"yes"; then
 	    AC_CACHE_CHECK([whether iconv supports UCS-2-INTERNAL],netatalk_cv_HAVE_UCS2INTERNAL,[
-		AC_TRY_RUN([\
+		AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <iconv.h>
 int main() {
        iconv_t cd = iconv_open("ASCII", "UCS-2-INTERNAL");
        if (cd == 0 || cd == (iconv_t)-1) return -1;
        return 0;
 }
-], netatalk_cv_HAVE_UCS2INTERNAL=yes,netatalk_cv_HAVE_UCS2INTERNAL=no,netatalk_cv_HAVEUCS2INTERNAL=cross)])
+]])], netatalk_cv_HAVE_UCS2INTERNAL=yes,netatalk_cv_HAVE_UCS2INTERNAL=no,netatalk_cv_HAVEUCS2INTERNAL=cross)])
 
 	if test x"$netatalk_cv_HAVE_UCS2INTERNAL" = x"yes"; then
 		AC_DEFINE(HAVE_UCS2INTERNAL,1,[Whether UCS-2-INTERNAL is supported])

--- a/macros/largefile-check.m4
+++ b/macros/largefile-check.m4
@@ -20,9 +20,9 @@ define(WX_SYS_LARGEFILE_MACRO_VALUE,
 [
     AC_CACHE_CHECK([for $1 value needed for large files], [$3],
         [
-          AC_TRY_COMPILE([#define $1 $2
+          AC_COMPILE_IFELSE([AC_LANG_SOURCE([[#define $1 $2
                           #include <sys/types.h>],
-                         WX_SYS_LARGEFILE_TEST,
+                         WX_SYS_LARGEFILE_TEST])],
                          [$3=$2],
                          [$3=no])
         ]
@@ -57,10 +57,10 @@ if test "$enable_largefile" != no; then
 
     
     AC_CACHE_CHECK([for 64 bit off_t],netatalk_cv_SIZEOF_OFF_T,[
-    AC_TRY_RUN([#include <stdio.h>
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
-int main() { exit((sizeof(off_t) == 8) ? 0 : 1); }],
+int main() { exit((sizeof(off_t) == 8) ? 0 : 1);}]])],
 netatalk_cv_SIZEOF_OFF_T=yes,netatalk_cv_SIZEOF_OFF_T=no,netatalk_cv_SIZEOF_OFF_T=cross)])
 
     AC_MSG_CHECKING([if large file support is available])

--- a/macros/libgcrypt.m4
+++ b/macros/libgcrypt.m4
@@ -10,7 +10,7 @@ dnl with a changed API.
 dnl
 AC_DEFUN([AC_NETATALK_PATH_LIBGCRYPT],
 [ AC_ARG_WITH(libgcrypt-dir,
-            AC_HELP_STRING([--with-libgcrypt-dir=PATH],
+            AS_HELP_STRING([--with-libgcrypt-dir=PATH],
                            [path where LIBGCRYPT is installed (optional). 
 			    Must contain lib and include dirs.]),
      libgcrypt_config_prefix="$withval", libgcrypt_config_prefix="")

--- a/macros/tcp-wrappers.m4
+++ b/macros/tcp-wrappers.m4
@@ -18,15 +18,15 @@ AC_DEFUN([AC_NETATALK_TCP_WRAPPERS], [
 		saved_LIBS=$LIBS
 		W_LIBS="-lwrap" 
 		LIBS="$LIBS $W_LIBS"
-		AC_TRY_LINK([ int allow_severity = 0; int deny_severity = 0; extern char hosts_access(void);]
-			,[hosts_access();]
+		AC_LINK_IFELSE([AC_LANG_SOURCE([[ int allow_severity = 0; int deny_severity = 0; extern char hosts_access(void);]
+			,[hosts_access();]])]
 			, netatalk_cv_tcpwrap=yes , 
    			[
 				LIBS=$saved_LIBS
 				W_LIBS="-lwrap -lnsl" 
 				LIBS="$LIBS $W_LIBS"
-				AC_TRY_LINK([ int allow_severity = 0; int deny_severity = 0; extern char hosts_access(void);]
-					,[hosts_access();]
+				AC_LINK_IFELSE([AC_LANG_SOURCE([[ int allow_severity = 0; int deny_severity = 0; extern char hosts_access(void);]
+					,[hosts_access();]])]
 					, netatalk_cv_tcpwrap=yes , netatalk_cv_tcpwrap=no)
 			]
 			, netatalk_cv_tcpwrap=cross)

--- a/test/afpd/Makefile.am
+++ b/test/afpd/Makefile.am
@@ -70,7 +70,14 @@ test_CFLAGS += @TRACKER_CFLAGS@
 endif
 
 if WITH_DTRACE
-DTRACE_OBJ = test-afp_dsi.o test-fork.o test-appl.o test-catsearch.o test-directory.o test-enumerate.o test-file.o test-filedir.o
+DTRACE_OBJ = $(top_srcdir)/etc/afpd/test-afp_dsi.o \
+             $(top_srcdir)/etc/afpd/test-fork.o \
+             $(top_srcdir)/etc/afpd/test-appl.o \
+             $(top_srcdir)/etc/afpd/test-catsearch.o \
+             $(top_srcdir)/etc/afpd/test-directory.o \
+             $(top_srcdir)/etc/afpd/test-enumerate.o \
+             $(top_srcdir)/etc/afpd/test-file.o \
+             $(top_srcdir)/etc/afpd/test-filedir.o
 afp_dtrace.o: $(top_srcdir)/include/atalk/afp_dtrace.d $(DTRACE_OBJ)
 	if test -f afp_dtrace.o ; then rm -f afp_dtrace.o ; fi
 	$(LIBTOOL) --mode=execute dtrace -G -s $(top_srcdir)/include/atalk/afp_dtrace.d -o afp_dtrace.o $(DTRACE_OBJ)


### PR DESCRIPTION
This PR:

1. Updates the autoconf syntax in bootstrap and configure.ac and updates all obsolete macros.
2. Fixes the make check error that occurs when AM_INIT_AUTOMAKE([subdir-objects]) is present in configure.ac.