### PR TITLE
[2.2] Fix byte order detection on OpenIndiana

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+Changes in 2.2.10
+================
+
+* FIX: afpd: Byte order detection. Fixes an error where Netatalk on
+       OpenIndiana returned wrong volume size information.
+
 Changes in 2.2.9
 ================
 

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,7 @@ AC_CHECK_HEADERS([sys/mount.h], , ,
 dnl Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST
 AC_TYPE_UID_T
+AC_C_BIGENDIAN
 AC_C_INLINE
 AC_TYPE_MODE_T
 AC_TYPE_OFF_T

--- a/include/atalk/util.h
+++ b/include/atalk/util.h
@@ -58,14 +58,14 @@
 #define MIN(a,b) ((a) < (b) ? a : b)
 #endif
 
-#if BYTE_ORDER == BIG_ENDIAN
+#ifdef WORDS_BIGENDIAN
 #define hton64(x)       (x)
 #define ntoh64(x)       (x)
-#else /* BYTE_ORDER == BIG_ENDIAN */
+#else
 #define hton64(x)       ((uint64_t) (htonl(((x) >> 32) & 0xffffffffLL)) | \
                          (uint64_t) ((htonl(x) & 0xffffffffLL) << 32))
 #define ntoh64(x)       (hton64(x))
-#endif /* BYTE_ORDER == BIG_ENDIAN */
+#endif
 
 #ifdef WITH_SENDFILE
 extern ssize_t sys_sendfile (int __out_fd, int __in_fd, off_t *__offset,size_t __count);


### PR DESCRIPTION
Backport of 3.x patch: https://github.com/Netatalk/netatalk/commit/a0b26922623b9de65f227a3ee3a47819d8530613