### PR TITLE
[2.2] Enable compilation on macOS hosts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,38 @@ env:
 
 jobs:
   integration_test:
-    name: Integration Tests
+    name: Ubuntu
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: sudo apt-get install --assume-yes --no-install-recommends ${{ env.APT_PACKAGES }}
+      - name: Bootstrap
+        run: ./bootstrap
+      - name: Configure
+        run: ./configure
       - name: Build
-        run: ./bootstrap && ./configure && make -j $(nproc)
+        run: make -j $(nproc)
+      - name: Run tests
+        run: make check
+
+  build-macos:
+    name: macOS
+    runs-on: macos-13
+    env:
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: brew install automake libressl pkg-config
+      - name: Bootstrap
+        run: ./bootstrap
+      - name: Configure
+        # DDP and related services in the absence of an AppleTalk stack on macOS
+        run: ./configure --with-ssl-dir=/usr/local/opt/libressl --with-bdb=/usr/local/opt/berkeley-db --disable-ddp --disable-timelord --disable-a2boot
+      - name: Build
+        run: make -j $(nproc)
       - name: Run tests
         run: make check
 

--- a/bin/ad/ad_cp.c
+++ b/bin/ad/ad_cp.c
@@ -841,7 +841,7 @@ static int setfile(const struct stat *fs, int fd)
     islink = !fdval && S_ISLNK(fs->st_mode);
     mode = fs->st_mode & (S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO);
 
-#if defined(__FreeBSD__) || defined(__NetBSD__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
     TIMESPEC_TO_TIMEVAL(&tv[0], &fs->st_atimespec);
     TIMESPEC_TO_TIMEVAL(&tv[1], &fs->st_mtimespec);
 #else

--- a/bootstrap
+++ b/bootstrap
@@ -10,7 +10,7 @@ DIE=0
   DIE=1
 }
 
-(libtool --version) < /dev/null > /dev/null 2>&1 || {
+(libtool --version || glibtool --version) < /dev/null > /dev/null 2>&1 || {
   echo
   echo "**Error**: You must have \`libtool' installed."
   echo "Get ftp://ftp.gnu.org/pub/gnu/libtool-1.2d.tar.gz"

--- a/configure.ac
+++ b/configure.ac
@@ -685,7 +685,6 @@ if test x"$this_os" = "xmacosx"; then
 	AC_DEFINE(BSD4_4, 1, [BSD compatiblity macro])
 	AC_DEFINE(HAVE_2ARG_DBTOB, 1, [Define if dbtob takes two arguments])
 	dnl AC_DEFINE(NO_DLFCN_H)
-	AC_DEFINE(NO_DDP, 1, [Define if DDP should be disabled])
 	AC_DEFINE(NO_QUOTA_SUPPORT, 1, [Define if Quota support should be disabled])
 	AC_DEFINE(MACOSX_SERVER, 1, [Define if compiling for MacOS X Server])
 fi
@@ -1045,7 +1044,8 @@ if test x"$with_acl_support" = x"yes" ; then
 		;;
 	*darwin*)
 		AC_MSG_NOTICE(ACLs on Darwin currently not supported)
-		AC_DEFINE(HAVE_NO_ACLS,1,[Whether no ACLs support is available])
+		with_acl_support=no
+		ac_cv_have_acls=no
 		;;
 	*)
 		AC_CHECK_LIB(acl,acl_get_file,[ACL_LIBS="$ACL_LIBS -lacl"])
@@ -1156,6 +1156,19 @@ case "$this_os" in
 
   *freebsd4* | *dragonfly* )
     AC_DEFINE(BROKEN_EXTATTR, 1, [Does extattr API work])
+  ;;
+
+  *macosx*)
+	AC_SEARCH_LIBS(getxattr, [attr])
+    if test "x$neta_cv_eas_sys_found" != "xyes" ; then
+       AC_CHECK_FUNCS([getxattr fgetxattr listxattr],
+                      [neta_cv_eas_sys_found=yes],
+                      [neta_cv_eas_sys_not_found=yes])
+	   AC_CHECK_FUNCS([flistxattr removexattr fremovexattr],,
+                      [neta_cv_eas_sys_not_found=yes])
+	   AC_CHECK_FUNCS([setxattr fsetxattr],,
+                      [neta_cv_eas_sys_not_found=yes])
+    fi
   ;;
 
   *)

--- a/etc/uams/uams_passwd.c
+++ b/etc/uams/uams_passwd.c
@@ -10,8 +10,6 @@
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 
-#include <atalk/standards.h>
-
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -50,6 +48,7 @@ char *strchr (), *strrchr ();
 #include <atalk/logger.h>
 #include <atalk/uam.h>
 #include <atalk/util.h>
+#include <atalk/standards.h>
 
 #define PASSWDLEN 8
 

--- a/libatalk/adouble/ad_lock.c
+++ b/libatalk/adouble/ad_lock.c
@@ -18,15 +18,14 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#include <atalk/adouble.h>
-#include <atalk/logger.h>
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
 #include <inttypes.h>
-
 #include <string.h>
+
+#include <atalk/adouble.h>
+#include <atalk/logger.h>
 
 #include "ad_private.h"
 

--- a/libatalk/asp/asp_attn.c
+++ b/libatalk/asp/asp_attn.c
@@ -10,12 +10,12 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <atalk/logger.h>
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/uio.h>
 #include <sys/socket.h>
 
+#include <atalk/logger.h>
 #include <atalk/atp.h>
 #include <atalk/asp.h>
 #include <atalk/afp.h>

--- a/libatalk/atp/atp_open.c
+++ b/libatalk/atp/atp_open.c
@@ -27,6 +27,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <unistd.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>

--- a/libatalk/util/socket.c
+++ b/libatalk/util/socket.c
@@ -21,8 +21,6 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#include <atalk/standards.h>
-
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/types.h>
@@ -39,6 +37,7 @@
 
 #include <atalk/logger.h>
 #include <atalk/util.h>
+#include <atalk/standards.h>
 
 static char ipv4mapprefix[] = {0,0,0,0,0,0,0,0,0,0,0xff,0xff};
 

--- a/macros/pam-check.m4
+++ b/macros/pam-check.m4
@@ -97,6 +97,13 @@ AC_DEFUN([AC_PATH_PAM], [
            PAM_ACCOUNT=system
            PAM_PASSWORD=system
            PAM_SESSION=system
+        dnl macOS
+        elif test -f "$pampath/chkpasswd"; then
+           PAM_DIRECTIVE=required
+           PAM_AUTH=pam_opendirectory.so
+           PAM_ACCOUNT=pam_opendirectory.so
+           PAM_PASSWORD=pam_permit.so
+           PAM_SESSION=pam_permit.so
         dnl Fallback
         else
            PAM_DIRECTIVE=required

--- a/macros/zeroconf.m4
+++ b/macros/zeroconf.m4
@@ -65,10 +65,26 @@ AC_DEFUN([NETATALK_ZEROCONF], [
                 found_zeroconf=yes
             fi
 		fi
+
+		    # mDNS support using mDNSResponder on macOS
+		    if test x"$found_zeroconf" != x"yes" ; then
+				    AC_CHECK_HEADER(
+						    dns_sd.h,
+						    AC_CHECK_LIB(
+								    System,
+								    DNSServiceRegister,
+								    AC_DEFINE(USE_ZEROCONF, 1, [Use DNS-SD registration]))
+				    )
+				    if test "$ac_cv_lib_System_DNSServiceRegister" = yes; then
+						    ZEROCONF_LIBS="-lSystem"
+						    AC_DEFINE(HAVE_MDNS, 1, [Use mDNSRespnder/DNS-SD registration])
+						    found_zeroconf=yes
+				    fi
+        fi
 	fi
 
 	netatalk_cv_zeroconf=no
-	AC_MSG_CHECKING([whether to enable Zerconf support])
+	AC_MSG_CHECKING([whether to enable Zeroconf support])
 	if test "x$found_zeroconf" = "xyes"; then
 		AC_MSG_RESULT([yes])
 		AC_DEFINE(USE_ZEROCONF, 1, [Define to enable Zeroconf support])


### PR DESCRIPTION
Enable building and running netatalk2 on macOS. The homebrew setup is covered in the wiki, and so is the configuration parameters for pointing to openssl and berkeleydb libraries: https://github.com/Netatalk/netatalk/wiki/Installing-on-macOS

Note that for appletalk/DDP support, AppleTalk headers are required. F.e. Apple XNU netat: https://opensource.apple.com/source/xnu/xnu-2050.9.2/bsd/netat/

In their absence, disable AppleTalk with configure options:
`--disable-ddp --disable-timelord --disable-a2boot`

* Enable Zeroconf support on macOS
* Fix implicit-function-declaration errors when compiling on macOS
* Default to correct __FreeBSD__ define in ad_cp.c when compiling on macOS
* Fix PAM detection on macOS
* Disable ACL on macOS
* Remove the flag permanently disabling DDP on macOS

Credit to @rofore for the inspiration & several of the patches