### PR TITLE
Fix native libiconv detection on macOS, #343

### DIFF
--- a/macros/iconv.m4
+++ b/macros/iconv.m4
@@ -26,6 +26,18 @@ dnl	# check for libiconv support
 
 	CFLAGS="$ICONV_CFLAGS $CFLAGS"
         LDFLAGS="$LDFLAGS $ICONV_LIBS -liconv"
+				
+  # native libiconv support on macOS
+  case "$host_os" in
+  *darwin*)
+  AC_CHECK_HEADER(
+      iconv.h,
+      AC_CHECK_LIB(
+      iconv,
+      iconv_open,
+      [netatalk_cv_iconv="yes"]))
+  ;;
+  esac	
 
 	AC_CACHE_CHECK([for libiconv],netatalk_cv_iconv,[
           AC_LINK_IFELSE([AC_LANG_SOURCE([[

--- a/macros/summary.m4
+++ b/macros/summary.m4
@@ -168,4 +168,9 @@ AC_DEFUN([AC_NETATALK_LIBS_SUMMARY], [
 		AC_MSG_RESULT([        LIBS   = $MYSQL_LIBS])
 		AC_MSG_RESULT([        CFLAGS = $MYSQL_CFLAGS])
 	fi
+	if test x"$netatalk_cv_iconv" = x"yes"; then
+		AC_MSG_RESULT([    ICONV:])
+		AC_MSG_RESULT([        LIBS   = $ICONV_LIBS])
+		AC_MSG_RESULT([        CFLAGS = $ICONV_CFLAGS])
+	fi
 ])


### PR DESCRIPTION
This commit fixes the macOS native libiconv detection failure resulting from the library being moved into the dyld shared cache