### PR TITLE
[2.2] Fix all warnings on running  bootstrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ test-driver
 *.rej
 *~
 *.o
+build-aux
+**/.DS_Store

--- a/bootstrap
+++ b/bootstrap
@@ -5,21 +5,7 @@ set -x
 rm -rf autom4te*.cache
 
 # build it all.
-aclocal -I macros $ACLOCAL_FLAGS || exit 1
-autoheader || exit 1
-libtoolize --force --copy
-automake --include-deps --add-missing --foreign --copy || exit 1
-autoconf || exit 1
-
-# Original configure call was:
-#./configure --enable-maintainer-mode "$@"
-# However, according to:
-#  http://sources.redhat.com/autobook/autobook/autobook_43.html#SEC43
-# we need to have AM_MAINTAINER_MODE in configure.in in order to use
-# this feature.  It's not there at the moment, so I'm changing the
-# configure call.
-# And sometimes I don't want this to run.
-# [ -z "$NOEXECCONFIGURE" ] && ./configure "$@"
+autoreconf -fi || exit 1
 
 # Let's not fall off the end...
 exit 0

--- a/configure.ac
+++ b/configure.ac
@@ -1,25 +1,23 @@
 dnl configure.in for netatalk
 
-AC_INIT([netatalk], [m4_esyscmd([echo -n `cat VERSION`])])
+AC_INIT([netatalk],m4_normalize(m4_include([VERSION])))
 
 NETATALK_VERSION=`cat $srcdir/VERSION`
 AC_SUBST(NETATALK_VERSION)
 
-AC_CANONICAL_SYSTEM
+AC_CANONICAL_HOST
 AM_INIT_AUTOMAKE([subdir-objects])
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 AC_CONFIG_MACRO_DIRS([macros])
 AM_MAINTAINER_MODE([enable])
 
 dnl Checks for programs.
 AC_PROG_AWK
 AC_PROG_CC
-AC_PROG_CC_C99
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
-AC_LIBTOOL_DLOPEN
-AC_PROG_LIBTOOL
+LT_INIT([dlopen])
 AC_PROG_PERL
 AC_PROG_GREP
 AC_PROG_PS
@@ -28,7 +26,6 @@ AM_PROG_CC_C_O
 
 dnl Checks for header files.
 AC_HEADER_DIRENT
-AC_HEADER_STDC
 AC_HEADER_SYS_WAIT
 AC_CHECK_HEADERS(fcntl.h limits.h stdint.h strings.h time.h sys/param.h sys/fcntl.h sys/file.h sys/ioctl.h sys/time.h sys/mnttab.h sys/statvfs.h sys/stat.h sys/vfs.h mntent.h syslog.h unistd.h termios.h sys/termios.h netdb.h sgtty.h ufs/quota.h mount.h statfs.h sys/types.h dlfcn.h errno.h sys/errno.h sys/uio.h langinfo.h locale.h sys/filio.h)
 AC_CHECK_HEADER(sys/cdefs.h,,
@@ -49,16 +46,14 @@ AC_TYPE_MODE_T
 AC_TYPE_OFF_T
 AC_TYPE_PID_T
 AC_TYPE_SIZE_T
-AC_STRUCT_ST_RDEV
-AC_HEADER_TIME
 AC_STRUCT_TM
 
 dnl --------------------------------------------------------------------------
 dnl check if dlsym needs to add an underscore, uses libtool macros 
 dnl --------------------------------------------------------------------------
-AC_LTDL_DLLIB
+LT_LIB_DLLOAD
 AC_CHECK_FUNCS(dlopen dlsym dlclose)
-AC_LTDL_DLSYM_USCORE
+LT_FUNC_DLSYM_USCORE
 if test x"$libltdl_cv_need_uscore" = xyes; then
     AC_DEFINE(DLSYM_PREPEND_UNDERSCORE, 1, [BSD compatibility macro])
 fi
@@ -69,9 +64,16 @@ AC_PROG_GCC_TRADITIONAL
 AC_FUNC_MEMCMP
 AC_HEADER_MAJOR
 AC_FUNC_MMAP
-AC_TYPE_SIGNAL
+AC_CACHE_CHECK([return type of signal handlers],[ac_cv_type_signal],[AC_COMPILE_IFELSE(
+[AC_LANG_PROGRAM([#include <sys/types.h>
+#include <signal.h>
+],
+		 [return *(signal (0, 0)) (0) == 1;])],
+		   [ac_cv_type_signal=int],
+		   [ac_cv_type_signal=void])])
+AC_DEFINE_UNQUOTED([RETSIGTYPE],[$ac_cv_type_signal],[Define as the return type of signal handlers
+		    (`int' or `void').])
 AC_FUNC_UTIME_NULL
-AC_FUNC_WAIT3
 AC_CHECK_FUNCS(getcwd gethostname gettimeofday getusershell mkdir rmdir select socket strdup strcasestr strstr strtoul strchr memcpy)
 AC_CHECK_FUNCS(backtrace_symbols setlocale nl_langinfo strlcpy strlcat setlinebuf dirfd pselect access pread pwrite)
 AC_CHECK_FUNCS(waitpid getcwd strdup strndup strnlen strtoul strerror chown fchown chmod fchmod chroot link mknod mknod64)
@@ -647,17 +649,16 @@ if test x"$this_os" = "xlinux"; then
 	dnl ----- kernel 2.6 changed struct at_addr to atalk_addr
 	AC_MSG_CHECKING([for struct atalk_addr])
 dnl	AC_COMPILE_IFELSE([
-	AC_TRY_COMPILE([
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/socket.h>
 #include <asm/types.h>
 #include <linux/atalk.h>
 
 	struct atalk_addr foo;
-],
-[ ], [
+]], [[ ]])],[
 		ac_have_atalk_addr=yes
 		AC_MSG_RESULT([yes])
-	], [
+	],[
 		AC_MSG_RESULT([no])
 	])
 
@@ -789,13 +790,11 @@ if test x"$this_os" = "xsolaris"; then
 	   fi
 
            AC_CACHE_CHECK([for timeout_id_t],netatalk_cv_HAVE_TIMEOUT_ID_T,[
-           AC_TRY_LINK([\
+           AC_LINK_IFELSE([AC_LANG_PROGRAM([[\
 #include <sys/stream.h>
-#include <sys/ddi.h>],
-[\
+#include <sys/ddi.h>]], [[\
 timeout_id_t dummy;
-],
-netatalk_cv_HAVE_TIMEOUT_ID_T=yes,netatalk_cv_HAVE_TIMEOUT_ID_T=no,netatalk_cv_HAVE_TIMEOUT_ID_T=cross)])
+]])],[netatalk_cv_HAVE_TIMEOUT_ID_T=yes],[netatalk_cv_HAVE_TIMEOUT_ID_T=no])])
 
 	   AC_DEFINE(HAVE_TIMEOUT_ID_T, test x"$netatalk_cv_HAVE_TIMEOUT_ID" = x"yes", [define for timeout_id_t])
 	fi
@@ -1058,17 +1057,15 @@ if test x"$with_acl_support" = x"yes" ; then
 		AC_CACHE_CHECK([for POSIX ACL support],netatalk_cv_HAVE_POSIX_ACLS,[
 			acl_LIBS=$LIBS
 			LIBS="$LIBS $ACL_LIBS"
-			AC_TRY_LINK([
+			AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 				#include <sys/types.h>
 				#include <sys/acl.h>
-			],[
+			]], [[
 				acl_t acl;
 				int entry_id;
 				acl_entry_t *entry_p;
 				return acl_get_entry(acl, entry_id, entry_p);
-			],
-			[netatalk_cv_HAVE_POSIX_ACLS=yes],
-			[netatalk_cv_HAVE_POSIX_ACLS=no
+			]])],[netatalk_cv_HAVE_POSIX_ACLS=yes],[netatalk_cv_HAVE_POSIX_ACLS=no
                 with_acl_support=no])
 			LIBS=$acl_LIBS
 		])
@@ -1078,16 +1075,14 @@ if test x"$with_acl_support" = x"yes" ; then
 			AC_CACHE_CHECK([for acl_get_perm_np],netatalk_cv_HAVE_ACL_GET_PERM_NP,[
 				acl_LIBS=$LIBS
 				LIBS="$LIBS $ACL_LIBS"
-				AC_TRY_LINK([
+				AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 					#include <sys/types.h>
 					#include <sys/acl.h>
-				],[
+				]], [[
 					acl_permset_t permset_d;
 					acl_perm_t perm;
 					return acl_get_perm_np(permset_d, perm);
-				],
-				[netatalk_cv_HAVE_ACL_GET_PERM_NP=yes],
-				[netatalk_cv_HAVE_ACL_GET_PERM_NP=no])
+				]])],[netatalk_cv_HAVE_ACL_GET_PERM_NP=yes],[netatalk_cv_HAVE_ACL_GET_PERM_NP=no])
 				LIBS=$acl_LIBS
 			])
 			if test x"$netatalk_cv_HAVE_ACL_GET_PERM_NP" = x"yes"; then
@@ -1198,18 +1193,16 @@ if test x"$ac_cv_func_getxattr" = x"yes" ; then
 	AC_CACHE_CHECK([whether xattr interface takes additional options], smb_attr_cv_xattr_add_opt, [
 		old_LIBS=$LIBS
 		LIBS="$LIBS $ACL_LIBS"
-		AC_TRY_COMPILE([
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 			#include <sys/types.h>
 			#if HAVE_ATTR_XATTR_H
 			#include <attr/xattr.h>
 			#elif HAVE_SYS_XATTR_H
 			#include <sys/xattr.h>
 			#endif
-		],[
+		]], [[
 			getxattr(0, 0, 0, 0, 0, 0);
-		],
-	        [smb_attr_cv_xattr_add_opt=yes],
-		[smb_attr_cv_xattr_add_opt=no;LIBS=$old_LIBS])
+		]])],[smb_attr_cv_xattr_add_opt=yes],[smb_attr_cv_xattr_add_opt=no;LIBS=$old_LIBS])
 	])
 	if test x"$smb_attr_cv_xattr_add_opt" = x"yes"; then
 		AC_DEFINE(XATTR_ADD_OPT, 1, [xattr functions have additional options])
@@ -1226,7 +1219,7 @@ AC_DEFINE_UNQUOTED(EA_MODULES,["$neta_cv_eas"],[Available Extended Attributes mo
 dnl --------------------- Check if realpath() takes NULL
 AC_CACHE_CHECK([if the realpath function allows a NULL argument],
     neta_cv_REALPATH_TAKES_NULL, [
-        AC_TRY_RUN([
+        AC_RUN_IFELSE([AC_LANG_SOURCE([[
             #include <stdio.h>
             #include <limits.h>
             #include <signal.h>
@@ -1240,11 +1233,8 @@ AC_CACHE_CHECK([if the realpath function allows a NULL argument],
                 signal(SIGSEGV, exit_on_core);
                 newpath = realpath("/tmp", NULL);
                 exit((newpath != NULL) ? 0 : 1);
-            }],
-            neta_cv_REALPATH_TAKES_NULL=yes,
-            neta_cv_REALPATH_TAKES_NULL=no,
-            neta_cv_REALPATH_TAKES_NULL=cross
-        )
+            }]])],[neta_cv_REALPATH_TAKES_NULL=yes],[neta_cv_REALPATH_TAKES_NULL=no],[neta_cv_REALPATH_TAKES_NULL=cross
+        ])
     ]
 )
 
@@ -1293,7 +1283,7 @@ AM_CONDITIONAL(HAVE_ATFUNCS, test x"$ac_neta_haveatfuncs" = x"yes")
 
 dnl --------------------- generate files
 
-AC_OUTPUT([Makefile
+AC_CONFIG_FILES([Makefile
 	bin/Makefile
 	bin/ad/Makefile
 	bin/adv1tov2/Makefile
@@ -1373,9 +1363,10 @@ AC_OUTPUT([Makefile
 	sys/ultrix/Makefile
 	test/Makefile
 	test/afpd/Makefile
-	],
-	[chmod a+x distrib/config/netatalk-config contrib/shell_utils/apple_*]
-)
+	])
+AC_CONFIG_COMMANDS([default],[chmod a+x distrib/config/netatalk-config contrib/shell_utils/apple_*
+],[])
+AC_OUTPUT
 
 AC_NETATALK_LIBS_SUMMARY
 AC_NETATALK_CONFIG_SUMMARY

--- a/configure.ac
+++ b/configure.ac
@@ -1281,6 +1281,9 @@ AM_CONDITIONAL(USE_BDB, test x$bdb_required = xyes)
 AM_CONDITIONAL(USE_APPLETALK, test x$netatalk_cv_ddp_enabled = xyes)
 AM_CONDITIONAL(HAVE_ATFUNCS, test x"$ac_neta_haveatfuncs" = x"yes")
 
+dnl Enable silent Automake rules if present
+m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])
+
 dnl --------------------- generate files
 
 AC_CONFIG_FILES([Makefile

--- a/distrib/initscripts/Makefile.am
+++ b/distrib/initscripts/Makefile.am
@@ -105,7 +105,7 @@ install-data-hook:
 
 uninstall-startup:
 	-systemctl disable $(service_DATA)
-	rm -f $(addprefix $(DESTDIR)$(servicedir)/, $(service_DATA))
+	rm -f $(DESTDIR)$(servicedir)/{a2boot,afpd,atalkd,cnid,papd,timelord}.service
 	-systemctl daemon-reload
 
 endif

--- a/macros/cups.m4
+++ b/macros/cups.m4
@@ -29,7 +29,7 @@ AC_DEFUN([NETATALK_AC_CUPS], [
 			netatalk_cv_use_cups=yes
 	
 			if test x"$netatalk_cv_HAVE_USABLE_ICONV" = x"no" ; then
-				AC_WARN([*** Warning: iconv not found on your system, using simple ascii mapping***])
+				AC_MSG_WARN(*** Warning: iconv not found on your system, using simple ascii mapping***)
 			fi
 	                spool_required="yes"
 		elif test x"$enable_cups" = "xyes"; then

--- a/macros/db3-check.m4
+++ b/macros/db3-check.m4
@@ -36,7 +36,7 @@ AC_DEFUN([NETATALK_BDB_TRY_LINK],[
     for lib in $atalk_cv_bdb_try_libs ; do
         LIBS="-l$lib $savedlibs"
         AC_MSG_CHECKING([Berkeley DB library (-l$lib)])
-        AC_TRY_RUN([
+        AC_RUN_IFELSE([AC_LANG_SOURCE([[
             #include <stdio.h>
             #include <db.h>
             int main(void) {
@@ -55,7 +55,7 @@ AC_DEFUN([NETATALK_BDB_TRY_LINK],[
                 printf("%d.%d.%d ... ",major, minor, patch);
                 return (0);
             }
-        ],[
+        ]])],[
             AC_MSG_RESULT(yes)
             atalk_cv_bdb_version="yes"
             atalk_cv_lib_db="-l$lib"

--- a/macros/iconv.m4
+++ b/macros/iconv.m4
@@ -28,14 +28,14 @@ dnl	# check for libiconv support
         LDFLAGS="$LDFLAGS $ICONV_LIBS -liconv"
 
 	AC_CACHE_CHECK([for libiconv],netatalk_cv_iconv,[
-          AC_TRY_LINK([
+          AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <stdlib.h>
 #include <iconv.h>
-],[
+]], [[
 	iconv_t cd = iconv_open("","");
         iconv(cd,NULL,NULL,NULL,NULL);
         iconv_close(cd);
-], netatalk_cv_iconv=yes, netatalk_cv_iconv=no, netatalk_cv_iconv=cross)])
+]])],[netatalk_cv_iconv=yes],[netatalk_cv_iconv=no])])
 
 	if test x"$netatalk_cv_iconv" = x"yes"; then
 	    ICONV_LIBS="$ICONV_LIBS -liconv"
@@ -60,14 +60,14 @@ dnl	############
 dnl	# check for iconv usability
 
 	AC_CACHE_CHECK([for working iconv],netatalk_cv_HAVE_USABLE_ICONV,[
-		AC_TRY_RUN([\
+		AC_RUN_IFELSE([AC_LANG_SOURCE([[\
 #include <iconv.h>
 main() {
        iconv_t cd = iconv_open("ASCII", "UTF-8");
        if (cd == 0 || cd == (iconv_t)-1) return -1;
        return 0;
 }
-], netatalk_cv_HAVE_USABLE_ICONV=yes,netatalk_cv_HAVE_USABLE_ICONV=no,netatalk_cv_HAVE_USABLE_ICONV=cross)])
+]])],[netatalk_cv_HAVE_USABLE_ICONV=yes],[netatalk_cv_HAVE_USABLE_ICONV=no],[netatalk_cv_HAVE_USABLE_ICONV=cross])])
 
 	if test x"$netatalk_cv_HAVE_USABLE_ICONV" = x"yes"; then
 	    AC_DEFINE(HAVE_USABLE_ICONV,1,[Whether to use native iconv])
@@ -77,7 +77,7 @@ dnl	###########
 dnl	# check if iconv needs const
   	if test x"$netatalk_cv_HAVE_USABLE_ICONV" = x"yes"; then
     		AC_CACHE_VAL(am_cv_proto_iconv, [
-      		AC_TRY_COMPILE([\
+      		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[\
 #include <stdlib.h>
 #include <iconv.h>
 extern
@@ -89,7 +89,7 @@ size_t iconv (iconv_t cd, char * *inbuf, size_t *inbytesleft, char * *outbuf, si
 #else
 size_t iconv();
 #endif
-], [], am_cv_proto_iconv_arg1="", am_cv_proto_iconv_arg1="const")
+]], [[]])],[am_cv_proto_iconv_arg1=""],[am_cv_proto_iconv_arg1="const"])
 	      	am_cv_proto_iconv="extern size_t iconv (iconv_t cd, $am_cv_proto_iconv_arg1 char * *inbuf, size_t *inbytesleft, char * *outbuf, size_t *outbytesleft);"])
     		AC_DEFINE_UNQUOTED(ICONV_CONST, $am_cv_proto_iconv_arg1,
       			[Define as const if the declaration of iconv() needs const.])
@@ -99,14 +99,14 @@ dnl     ###########
 dnl     # check if (lib)iconv supports UCS-2-INTERNAL
 	if test x"$netatalk_cv_HAVE_USABLE_ICONV" = x"yes"; then
 	    AC_CACHE_CHECK([whether iconv supports UCS-2-INTERNAL],netatalk_cv_HAVE_UCS2INTERNAL,[
-		AC_TRY_RUN([\
+		AC_RUN_IFELSE([AC_LANG_SOURCE([[\
 #include <iconv.h>
 int main() {
        iconv_t cd = iconv_open("ASCII", "UCS-2-INTERNAL");
        if (cd == 0 || cd == (iconv_t)-1) return -1;
        return 0;
 }
-], netatalk_cv_HAVE_UCS2INTERNAL=yes,netatalk_cv_HAVE_UCS2INTERNAL=no,netatalk_cv_HAVEUCS2INTERNAL=cross)])
+]])],[netatalk_cv_HAVE_UCS2INTERNAL=yes],[netatalk_cv_HAVE_UCS2INTERNAL=no],[netatalk_cv_HAVEUCS2INTERNAL=cross])])
 
 	if test x"$netatalk_cv_HAVE_UCS2INTERNAL" = x"yes"; then
 		AC_DEFINE(HAVE_UCS2INTERNAL,1,[Whether UCS-2-INTERNAL is supported])

--- a/macros/largefile-check.m4
+++ b/macros/largefile-check.m4
@@ -20,11 +20,11 @@ define(WX_SYS_LARGEFILE_MACRO_VALUE,
 [
     AC_CACHE_CHECK([for $1 value needed for large files], [$3],
         [
-          AC_TRY_COMPILE([#define $1 $2
-                          #include <sys/types.h>],
-                         WX_SYS_LARGEFILE_TEST,
-                         [$3=$2],
-                         [$3=no])
+            AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#define $1 $2
+                #include <sys/types.h>],
+                WX_SYS_LARGEFILE_TEST])],
+                [$3=$2],
+                [$3=no])
         ]
     )
 
@@ -57,11 +57,10 @@ if test "$enable_largefile" != no; then
 
     
     AC_CACHE_CHECK([for 64 bit off_t],netatalk_cv_SIZEOF_OFF_T,[
-    AC_TRY_RUN([#include <stdio.h>
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[#include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
-int main() { exit((sizeof(off_t) == 8) ? 0 : 1); }],
-netatalk_cv_SIZEOF_OFF_T=yes,netatalk_cv_SIZEOF_OFF_T=no,netatalk_cv_SIZEOF_OFF_T=cross)])
+int main() { exit((sizeof(off_t) == 8) ? 0 : 1); }]])],[netatalk_cv_SIZEOF_OFF_T=yes],[netatalk_cv_SIZEOF_OFF_T=no],[netatalk_cv_SIZEOF_OFF_T=cross])])
 
     AC_MSG_CHECKING([if large file support is available])
     if test "x$netatalk_cv_SIZEOF_OFF_T" != "xno"; then

--- a/macros/libgcrypt.m4
+++ b/macros/libgcrypt.m4
@@ -10,8 +10,7 @@ dnl with a changed API.
 dnl
 AC_DEFUN([AM_PATH_LIBGCRYPT],
 [ AC_ARG_WITH(libgcrypt-dir,
-            AC_HELP_STRING([--with-libgcrypt-dir=PATH],
-                           [path where LIBGCRYPT is installed (optional). 
+            AS_HELP_STRING([--with-libgcrypt-dir=PATH],[path where LIBGCRYPT is installed (optional). 
 			    Must contain lib and include dirs.]),
      libgcrypt_config_prefix="$withval", libgcrypt_config_prefix="")
   if test x$libgcrypt_config_prefix != x ; then

--- a/macros/snprintf-check.m4
+++ b/macros/snprintf-check.m4
@@ -9,15 +9,14 @@ AC_DEFUN([NETATALK_SNPRINTF_CHECK], [
 	AC_CACHE_CHECK(for errno,
 	ac_cv_errno,
 	[
-	AC_TRY_LINK(,[extern int errno; return (errno);],
-		ac_cv_errno=yes, ac_cv_errno=no)
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[extern int errno; return (errno);]])],[ac_cv_errno=yes],[ac_cv_errno=no])
 	])
 	if test "$ac_cv_errno" = yes; then
 		AC_DEFINE(HAVE_ERRNO, 1, [Define if errno declaration exists])
 		AC_CACHE_CHECK(for errno declaration,
 		ac_cv_decl_errno,
 		[
-		AC_TRY_COMPILE([
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 		#include <stdio.h>
 		#ifdef HAVE_STDLIB_H
 		#include <stdlib.h>
@@ -28,8 +27,7 @@ AC_DEFUN([NETATALK_SNPRINTF_CHECK], [
 		#ifdef HAVE_ERRNO_H
 		#include <errno.h>
 		#endif
-		],[return(sys_nerr);],
-			ac_cv_decl_errno=yes, ac_cv_decl_errno=no)
+		]], [[return(sys_nerr);]])],[ac_cv_decl_errno=yes],[ac_cv_decl_errno=no])
 		])
 		if test "$ac_cv_decl_errno" = yes; then
 			AC_DEFINE(HAVE_DECL_ERRNO, 1, [Define if errno declaration exists])
@@ -39,23 +37,21 @@ AC_DEFUN([NETATALK_SNPRINTF_CHECK], [
 	AC_CACHE_CHECK(for sys_nerr,
 	ac_cv_sys_nerr,
 	[
-	AC_TRY_LINK(,[extern int sys_nerr; return (sys_nerr);],
-		ac_cv_sys_nerr=yes, ac_cv_sys_nerr=no)
+	AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[extern int sys_nerr; return (sys_nerr);]])],[ac_cv_sys_nerr=yes],[ac_cv_sys_nerr=no])
 	])
 	if test "$ac_cv_sys_nerr" = yes; then
 		AC_DEFINE(HAVE_SYS_NERR, 1, [Define if sys_nerr declaration exists])
 		AC_CACHE_CHECK(for sys_nerr declaration,
 		ac_cv_decl_sys_nerr,
 		[
-		AC_TRY_COMPILE([
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 		#include <stdio.h>
 		#ifdef HAVE_STDLIB_H
 		#include <stdlib.h>
 		#endif
 		#ifdef HAVE_UNISTD_H
 		#include <unistd.h>
-		#endif],[return(sys_nerr);],
-		ac_cv_decl_sys_nerr_def=yes, ac_cv_decl_sys_nerr_def=no)
+		#endif]], [[return(sys_nerr);]])],[ac_cv_decl_sys_nerr_def=yes],[ac_cv_decl_sys_nerr_def=no])
 		])
 		if test "$ac_cv_decl_sys_nerr" = yes; then
 			AC_DEFINE(HAVE_DECL_SYS_NERR, 1, [Define if sys_nerr declaration exists])
@@ -65,15 +61,14 @@ AC_DEFUN([NETATALK_SNPRINTF_CHECK], [
 
 	AC_CACHE_CHECK(for sys_errlist array,
 	ac_cv_sys_errlist,
-	[AC_TRY_LINK(,[extern char *sys_errlist[];
-		sys_errlist[0];],
-		ac_cv_sys_errlist=yes, ac_cv_sys_errlist=no)
+	[AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[extern char *sys_errlist[];
+		sys_errlist[0];]])],[ac_cv_sys_errlist=yes],[ac_cv_sys_errlist=no])
 	])
 	if test "$ac_cv_sys_errlist" = yes; then
 		AC_DEFINE(HAVE_SYS_ERRLIST, 1, [Define if sys_errlist declaration exists])
 		AC_CACHE_CHECK(for sys_errlist declaration,
 		ac_cv_sys_errlist_def,
-		[AC_TRY_COMPILE([
+		[AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 		#include <stdio.h>
 		#include <errno.h>
 		#ifdef HAVE_STDLIB_H
@@ -81,8 +76,7 @@ AC_DEFUN([NETATALK_SNPRINTF_CHECK], [
 		#endif
 		#ifdef HAVE_UNISTD_H
 		#include <unistd.h>
-		#endif],[char *s = sys_errlist[0]; return(*s);],
-		ac_cv_decl_sys_errlist=yes, ac_cv_decl_sys_errlist=no)
+		#endif]], [[char *s = sys_errlist[0]; return(*s);]])],[ac_cv_decl_sys_errlist=yes],[ac_cv_decl_sys_errlist=no])
 		])
 		if test "$ac_cv_decl_sys_errlist" = yes; then
 			AC_DEFINE(HAVE_DECL_SYS_ERRLIST, 1, [Define if sys_errlist declaration exists])
@@ -94,11 +88,10 @@ AC_DEFUN([NETATALK_SNPRINTF_CHECK], [
 	AC_CACHE_CHECK(for long long,
 	ac_cv_long_long,
 	[
-	AC_TRY_COMPILE([
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 	#include <stdio.h>
 	#include <sys/types.h>
-	], [printf("%d",sizeof(long long));],
-	ac_cv_long_long=yes, ac_cv_long_long=no)
+	]], [[printf("%d",sizeof(long long));]])],[ac_cv_long_long=yes],[ac_cv_long_long=no])
 	])
 	if test $ac_cv_long_long = yes; then
 	  AC_DEFINE(HAVE_LONG_LONG, 1, [Define if long long is a valid data type])
@@ -107,11 +100,10 @@ AC_DEFUN([NETATALK_SNPRINTF_CHECK], [
 	AC_CACHE_CHECK(for long double,
 	ac_cv_long_double,
 	[
-	AC_TRY_COMPILE([
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 	#include <stdio.h>
 	#include <sys/types.h>
-	], [printf("%d",sizeof(long double));],
-	ac_cv_long_double=yes, ac_cv_long_double=no)
+	]], [[printf("%d",sizeof(long double));]])],[ac_cv_long_double=yes],[ac_cv_long_double=no])
 	])
 	if test $ac_cv_long_double = yes; then
 	  AC_DEFINE(HAVE_LONG_DOUBLE, 1, [Define if long double is a valid data type])
@@ -120,11 +112,10 @@ AC_DEFUN([NETATALK_SNPRINTF_CHECK], [
 	AC_CACHE_CHECK(for quad_t,
 	ac_cv_quad_t,
 	[
-	AC_TRY_COMPILE([
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 	#include <stdio.h>
 	#include <sys/types.h>
-	], [printf("%d",sizeof(quad_t));],
-	ac_cv_quad_t=yes, ac_cv_quad_t=no)
+	]], [[printf("%d",sizeof(quad_t));]])],[ac_cv_quad_t=yes],[ac_cv_quad_t=no])
 	])
 	if test $ac_cv_quad_t = yes; then
 	  AC_DEFINE(HAVE_QUAD_T, 1, [Define if quad_t is a valid data type])

--- a/macros/srvloc.m4
+++ b/macros/srvloc.m4
@@ -31,15 +31,13 @@ AC_DEFUN([NETATALK_SRVLOC], [
 		LDFLAGS="$LDFLAGS -L$srvlocdir/$atalk_libname"
 
 		AC_MSG_CHECKING([for slp.h])
-		AC_TRY_CPP([#include <slp.h>],
-			[
+		AC_PREPROC_IFELSE([AC_LANG_SOURCE([[#include <slp.h>]])],[
 				AC_MSG_RESULT([yes])
 				found_slp=yes
-			],
-			[
+			],[
 				AC_MSG_RESULT([no])
-			]
-		)
+			
+		])
 		
 		if test "x$found_slp" = "xyes"; then
 			AC_CHECK_LIB(slp, SLPOpen, [

--- a/macros/tcp-wrappers.m4
+++ b/macros/tcp-wrappers.m4
@@ -19,18 +19,17 @@ AC_DEFUN([NETATALK_TCP_WRAPPERS], [
 		saved_LIBS=$LIBS
 		W_LIBS="-lwrap" 
 		LIBS="$LIBS $W_LIBS"
-		AC_TRY_LINK([ int allow_severity = 0; int deny_severity = 0;]
-			,[hosts_access();]
-			, netatalk_cv_tcpwrap=yes , 
-   			[
+		AC_LINK_IFELSE([AC_LANG_PROGRAM([[ int allow_severity = 0; int deny_severity = 0;
+			]], [[hosts_access();
+			]])],[netatalk_cv_tcpwrap=yes ],[
 				LIBS=$saved_LIBS
 				W_LIBS="-lwrap -lnsl" 
 				LIBS="$LIBS $W_LIBS"
-				AC_TRY_LINK([ int allow_severity = 0; int deny_severity = 0;]
-					,[hosts_access();]
-					, netatalk_cv_tcpwrap=yes , netatalk_cv_tcpwrap=no)
-			]
-			, netatalk_cv_tcpwrap=cross)
+				AC_LINK_IFELSE([AC_LANG_PROGRAM([[ int allow_severity = 0; int deny_severity = 0;
+					]], [[hosts_access();
+					]])],[netatalk_cv_tcpwrap=yes ],[netatalk_cv_tcpwrap=no])
+			
+			])
 
 		LIBS=$saved_LIBS
 	fi


### PR DESCRIPTION
These commit fixes all the obsolete macros and syntax in bootstrap, configure.ac and the m4 macros #345 