### PR TITLE
[2.2] Enable compilation on macOS hosts v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,14 +18,38 @@ env:
 
 jobs:
   integration_test:
-    name: Integration Tests
+    name: Ubuntu
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: sudo apt-get install --assume-yes --no-install-recommends ${{ env.APT_PACKAGES }}
+      - name: Bootstrap
+        run: ./bootstrap
+      - name: Configure
+        run: ./configure
       - name: Build
-        run: ./bootstrap && ./configure && make -j $(nproc)
+        run: make -j $(nproc)
+      - name: Run tests
+        run: make check
+
+  build-macos:
+    name: macOS
+    runs-on: macos-13
+    env:
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: brew install automake libressl pkg-config
+      - name: Bootstrap
+        run: ./bootstrap
+      - name: Configure
+        # DDP and related services in the absence of an AppleTalk stack on macOS
+        run: ./configure --with-ssl-dir=/usr/local/opt/libressl --with-bdb=/usr/local/opt/berkeley-db --disable-ddp --disable-timelord --disable-a2boot
+      - name: Build
+        run: make -j $(nproc)
       - name: Run tests
         run: make check
 

--- a/bin/ad/ad_cp.c
+++ b/bin/ad/ad_cp.c
@@ -841,7 +841,7 @@ static int setfile(const struct stat *fs, int fd)
     islink = !fdval && S_ISLNK(fs->st_mode);
     mode = fs->st_mode & (S_ISUID | S_ISGID | S_ISVTX | S_IRWXU | S_IRWXG | S_IRWXO);
 
-#if defined(__FreeBSD__) || defined(__NetBSD__)
+#if defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__)
     TIMESPEC_TO_TIMEVAL(&tv[0], &fs->st_atimespec);
     TIMESPEC_TO_TIMEVAL(&tv[1], &fs->st_mtimespec);
 #else

--- a/bootstrap
+++ b/bootstrap
@@ -10,7 +10,7 @@ DIE=0
   DIE=1
 }
 
-(libtool --version) < /dev/null > /dev/null 2>&1 || {
+(libtool --version || glibtool --version) < /dev/null > /dev/null 2>&1 || {
   echo
   echo "**Error**: You must have \`libtool' installed."
   echo "Get ftp://ftp.gnu.org/pub/gnu/libtool-1.2d.tar.gz"

--- a/configure.ac
+++ b/configure.ac
@@ -687,7 +687,7 @@ if test x"$this_os" = "xmacosx"; then
 	dnl AC_DEFINE(NO_DLFCN_H)
 	dnl AC_DEFINE(NO_DDP, 1, [Define if DDP should be disabled])
 	AC_DEFINE(NO_QUOTA_SUPPORT, 1, [Define if Quota support should be disabled])
-	AC_DEFINE(MACOSX_SERVER, 1, [Define if compiling for MacOS X Server])
+	dnl AC_DEFINE(MACOSX_SERVER, 1, [Define if compiling for MacOS X Server])
 fi
 
 dnl ----- NetBSD specific -----

--- a/configure.ac
+++ b/configure.ac
@@ -682,7 +682,7 @@ fi
 dnl ----- Mac OSX specific -----
 if test x"$this_os" = "xmacosx"; then 
 	AC_MSG_RESULT([ * Mac OSX specific configuration])
-	AC_DEFINE(BSD4_4, 1, [BSD compatiblity macro])
+	dnl AC_DEFINE(BSD4_4, 1, [BSD compatiblity macro])
 	AC_DEFINE(HAVE_2ARG_DBTOB, 1, [Define if dbtob takes two arguments])
 	dnl AC_DEFINE(NO_DLFCN_H)
 	dnl AC_DEFINE(NO_DDP, 1, [Define if DDP should be disabled])

--- a/configure.ac
+++ b/configure.ac
@@ -682,12 +682,7 @@ fi
 dnl ----- Mac OSX specific -----
 if test x"$this_os" = "xmacosx"; then 
 	AC_MSG_RESULT([ * Mac OSX specific configuration])
-	dnl AC_DEFINE(BSD4_4, 1, [BSD compatiblity macro])
-	AC_DEFINE(HAVE_2ARG_DBTOB, 1, [Define if dbtob takes two arguments])
-	dnl AC_DEFINE(NO_DLFCN_H)
-	dnl AC_DEFINE(NO_DDP, 1, [Define if DDP should be disabled])
 	AC_DEFINE(NO_QUOTA_SUPPORT, 1, [Define if Quota support should be disabled])
-	dnl AC_DEFINE(MACOSX_SERVER, 1, [Define if compiling for MacOS X Server])
 fi
 
 dnl ----- NetBSD specific -----

--- a/configure.ac
+++ b/configure.ac
@@ -1158,6 +1158,19 @@ case "$this_os" in
   *freebsd4* | *dragonfly* )
     AC_DEFINE(BROKEN_EXTATTR, 1, [Does extattr API work])
   ;;
+	
+	*macosx*)
+	AC_SEARCH_LIBS(getxattr, [attr])
+    if test "x$neta_cv_eas_sys_found" != "xyes" ; then
+       AC_CHECK_FUNCS([getxattr fgetxattr listxattr],
+                      [neta_cv_eas_sys_found=yes],
+                      [neta_cv_eas_sys_not_found=yes])
+	   AC_CHECK_FUNCS([flistxattr removexattr fremovexattr],,
+                      [neta_cv_eas_sys_not_found=yes])
+	   AC_CHECK_FUNCS([setxattr fsetxattr],,
+                      [neta_cv_eas_sys_not_found=yes])
+    fi
+  ;;
 
   *)
 	AC_SEARCH_LIBS(getxattr, [attr])

--- a/configure.ac
+++ b/configure.ac
@@ -685,7 +685,7 @@ if test x"$this_os" = "xmacosx"; then
 	AC_DEFINE(BSD4_4, 1, [BSD compatiblity macro])
 	AC_DEFINE(HAVE_2ARG_DBTOB, 1, [Define if dbtob takes two arguments])
 	dnl AC_DEFINE(NO_DLFCN_H)
-	AC_DEFINE(NO_DDP, 1, [Define if DDP should be disabled])
+	dnl AC_DEFINE(NO_DDP, 1, [Define if DDP should be disabled])
 	AC_DEFINE(NO_QUOTA_SUPPORT, 1, [Define if Quota support should be disabled])
 	AC_DEFINE(MACOSX_SERVER, 1, [Define if compiling for MacOS X Server])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1045,7 +1045,8 @@ if test x"$with_acl_support" = x"yes" ; then
 		;;
 	*darwin*)
 		AC_MSG_NOTICE(ACLs on Darwin currently not supported)
-		AC_DEFINE(HAVE_NO_ACLS,1,[Whether no ACLs support is available])
+		with_acl_support=no
+		ac_cv_have_acls=no
 		;;
 	*)
 		AC_CHECK_LIB(acl,acl_get_file,[ACL_LIBS="$ACL_LIBS -lacl"])

--- a/etc/uams/uams_passwd.c
+++ b/etc/uams/uams_passwd.c
@@ -10,8 +10,6 @@
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 
-#include <atalk/standards.h>
-
 #include <sys/types.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -50,6 +48,7 @@ char *strchr (), *strrchr ();
 #include <atalk/logger.h>
 #include <atalk/uam.h>
 #include <atalk/util.h>
+#include <atalk/standards.h>
 
 #define PASSWDLEN 8
 

--- a/include/atalk/netddp.h
+++ b/include/atalk/netddp.h
@@ -22,20 +22,12 @@
 
 extern int netddp_open   (struct sockaddr_at *, struct sockaddr_at *);
 
-#if !defined(NO_DDP) && defined(MACOSX_SERVER)
-extern int netddp_sendto (int, void *, size_t, unsigned int, 
-			   const struct sockaddr *, unsigned int);
-extern int netddp_recvfrom (int, void *, int, unsigned int, 
-			     struct sockaddr *, unsigned int *);
-#define netddp_close(a)  ddp_close(a)
-#else
 #include <unistd.h>
 #include <sys/types.h>
 
 #define netddp_close(a)  close(a)
 #define netddp_sendto    sendto
 #define netddp_recvfrom  recvfrom
-#endif
 
 #endif  /* NO_DDP */
 #endif /* netddp.h */

--- a/include/atalk/paths.h
+++ b/include/atalk/paths.h
@@ -19,11 +19,7 @@
 #  if defined (FHS_COMPATIBILITY) || defined (__NetBSD__) || defined (__OpenBSD__) || defined (__APPLE__)
 #    define _PATH_LOCKDIR	"/var/run/"
 #  elif defined (BSD4_4)
-#    ifdef MACOSX_SERVER
-#      define _PATH_LOCKDIR	"/var/run/"
-#    else
 #      define _PATH_LOCKDIR	"/var/spool/lock/"
-#    endif
 #  elif defined (linux)
 #    define _PATH_LOCKDIR	"/var/lock/"
 #  else

--- a/include/atalk/paths.h
+++ b/include/atalk/paths.h
@@ -16,7 +16,7 @@
 
 /* lock file path. this should be re-organized a bit. */
 #if ! defined (_PATH_LOCKDIR)
-#  if defined (FHS_COMPATIBILITY) || defined (__NetBSD__) || defined (__OpenBSD__)
+#  if defined (FHS_COMPATIBILITY) || defined (__NetBSD__) || defined (__OpenBSD__) || defined (__APPLE__)
 #    define _PATH_LOCKDIR	"/var/run/"
 #  elif defined (BSD4_4)
 #    ifdef MACOSX_SERVER

--- a/libatalk/atp/atp_open.c
+++ b/libatalk/atp/atp_open.c
@@ -33,6 +33,7 @@
 #include <sys/time.h>
 #include <sys/param.h>
 #include <sys/socket.h>
+#include <unistd.h>
 
 #include <netatalk/at.h>
 #include <netatalk/endian.h>

--- a/libatalk/nbp/nbp_lkup.c
+++ b/libatalk/nbp/nbp_lkup.c
@@ -60,11 +60,7 @@ int nbp_lookup( const char *obj, const char *type, const char *zone, struct nbpn
       return -1;
 
     *data++ = DDPTYPE_NBP;
-#ifdef MACOSX_SERVER
-    nh.nh_op = from.sat_addr.s_node ? NBPOP_BRRQ : NBPOP_LKUP;
-#else /* MACOSX_SERVER */
     nh.nh_op = NBPOP_BRRQ;
-#endif /* MACOSX_SERVER */
 
     nh.nh_cnt = 1;
     nh.nh_id = ++nbp_id;
@@ -117,14 +113,6 @@ int nbp_lookup( const char *obj, const char *type, const char *zone, struct nbpn
       }
     }
 
-#ifdef MACOSX_SERVER
-    if (from.sat_addr.s_node) {
-      memcpy(&addr.sat_addr, &from.sat_addr, sizeof(addr.sat_addr));
-    } else {
-      addr.sat_addr.s_net = ATADDR_ANYNET;
-      addr.sat_addr.s_node = ATADDR_BCAST;
-    }
-#endif /* MACOSX_SERVER */
     addr.sat_port = nbp_port;
 
     cnt = 0;

--- a/libatalk/netddp/netddp_open.c
+++ b/libatalk/netddp/netddp_open.c
@@ -18,11 +18,6 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 
-#ifdef MACOSX_SERVER
-#include <netat/appletalk.h>
-#include <netat/ddp.h>
-#endif /* MACOSX_SERVER */
-
 #include <netatalk/at.h>
 #include <atalk/netddp.h>
 
@@ -34,31 +29,6 @@ int netddp_open(struct sockaddr_at *addr, struct sockaddr_at *bridge)
 #else /* !NO_DDP */
 
     int s;
-
-#ifdef MACOSX_SERVER
-    at_inet_t address, baddress;
-
-    if ((s = ddp_open(addr ? &addr->sat_port : NULL)) < 0)
-        return -1;
-
-    if (!addr)
-      return s;
-
-    if (rtmp_netinfo(s, &address, &baddress) < 0) {
-        ddp_close(s);
-	return -1;
-    }
-    
-    memcpy(&addr->sat_addr.s_net, &address.net, sizeof(addr->sat_addr.s_net));
-    addr->sat_addr.s_node = address.node;
-    addr->sat_port = address.socket;
-    if (bridge) {
-      memcpy(&bridge->sat_addr.s_net, &baddress.net, 
-	     sizeof(bridge->sat_addr.s_net));
-      bridge->sat_addr.s_node = baddress.node;
-      bridge->sat_port = baddress.socket;
-    }
-#else /* MACOSX_SERVER */
     socklen_t len;
 
     if ((s = socket( AF_APPLETALK, SOCK_DGRAM, 0 )) < 0) 
@@ -80,7 +50,6 @@ int netddp_open(struct sockaddr_at *addr, struct sockaddr_at *bridge)
         close(s);
 	return -1;
     }
-#endif /* MACOSX_SERVER */
 
     return s;
 #endif /* NO_DDP */

--- a/libatalk/netddp/netddp_recvfrom.c
+++ b/libatalk/netddp/netddp_recvfrom.c
@@ -21,11 +21,6 @@
 #include <sys/uio.h>
 #include <errno.h>
 
-#ifdef MACOSX_SERVER
-#include <netat/appletalk.h>
-#include <netat/ddp.h>
-#endif /* MACOSX_SERVER */
-
 #include <netatalk/at.h>
 #include <netatalk/endian.h>
 #include <netatalk/ddp.h>
@@ -34,34 +29,4 @@
 #ifndef MAX
 #define MAX(a, b)  ((a) < (b) ? (b) : (a))
 #endif /* ! MAX */
-
-#ifdef MACOSX_SERVER
-int netddp_recvfrom(int fd, void *buf, int buflen, unsigned int dummy, 
-		     struct sockaddr *addr, unsigned int *addrlen)
-{
-    ssize_t i;
-    struct ddpehdr ddphdr;
-    struct sockaddr_at *sat = (struct sockaddr_at *) addr;
-    struct iovec iov[2];
-
-    iov[0].iov_base = (void *) &ddphdr;
-    iov[0].iov_len = sizeof(ddphdr);
-    iov[1].iov_base = buf;
-    iov[1].iov_len = buflen;
-
-    while ((i = readv(fd, iov, 2)) < 0) {
-      if (errno != EINTR)
-	return -1;
-    }
-
-    if (addr) {
-      sat->sat_addr.s_net = ddphdr.deh_snet;
-      sat->sat_addr.s_node = ddphdr.deh_snode;
-      sat->sat_port = ddphdr.deh_sport;
-    }
-
-    return MAX(0, i - sizeof(ddphdr));
-}
-
-#endif /* os x server */
 #endif /* no ddp */

--- a/libatalk/netddp/netddp_sendto.c
+++ b/libatalk/netddp/netddp_sendto.c
@@ -22,11 +22,6 @@
 #include <sys/uio.h>
 #include <errno.h>
 
-#ifdef MACOSX_SERVER
-#include <netat/appletalk.h>
-#include <netat/ddp.h>
-#endif /* MACOSX_SERVER */
-
 #include <netatalk/at.h>
 #include <netatalk/endian.h>
 #include <netatalk/ddp.h>
@@ -35,36 +30,4 @@
 #ifndef MAX
 #define MAX(a, b)  ((a) < (b) ? (b) : (a))
 #endif /* ! MAX */
-
-#ifdef MACOSX_SERVER
-int netddp_sendto(int fd, void *buf, size_t buflen, unsigned int dummy, 
-		  const struct sockaddr *addr, unsigned int addrlen)
-{
-    ssize_t i;
-    struct ddpehdr ddphdr;
-    const struct sockaddr_at *sat = (const struct sockaddr_at *) addr;
-    struct iovec iov[2];
-
-    iov[0].iov_base = (void *) &ddphdr;
-    iov[0].iov_len = sizeof(ddphdr);
-    iov[1].iov_base = buf;
-    iov[1].iov_len = buflen;
-
-    if (!addr)
-      return -1;
-
-    memset(&ddphdr, 0, sizeof(ddphdr));
-    ddphdr.deh_len = htons(sizeof(ddphdr) + (u_int16_t) buflen);
-    ddphdr.deh_dnet = sat->sat_addr.s_net;
-    ddphdr.deh_dnode = sat->sat_addr.s_node;
-    ddphdr.deh_dport = sat->sat_port;
-    while ((i = writev(fd, iov, 2)) < 0) {
-      if (errno != EINTR)
-	return -1;
-    }
-
-    return MAX(0, i - sizeof(ddphdr));
-}
-
-#endif /* os x server */
 #endif /* no ddp */

--- a/libatalk/util/module.c
+++ b/libatalk/util/module.c
@@ -10,43 +10,7 @@
 #include <string.h>
 #include <atalk/util.h>
 
-#ifndef HAVE_DLFCN_H
-#ifdef MACOSX_SERVER
-#include <mach-o/dyld.h>
-
-void *mod_open(const char *path)
-{
-  NSObjectFileImage file;
-
-  if (NSCreateObjectFileImageFromFile(path, &file) != 
-      NSObjectFileImageSuccess)
-    return NULL;
-  return NSLinkModule(file, path, TRUE);
-}
-
-void *mod_symbol(void *module, const char *name)
-{
-   NSSymbol symbol;
-   char *underscore;
-
-   if ((underscore = (char *) malloc(strlen(name) + 2)) == NULL)
-     return NULL;
-   strcpy(underscore, "_");
-   strcat(underscore, name);
-   symbol = NSLookupAndBindSymbol(underscore);
-   free(underscore);
-
-   return NSAddressOfSymbol(symbol);
-}
-
-void mod_close(void *module)
-{
-  NSUnLinkModule(module, FALSE);
-}
-#endif /* MACOSX_SERVER */
-
-#else /* HAVE_DLFCN_H */
-
+#ifdef HAVE_DLFCN_H
 #include <dlfcn.h>
 
 #ifdef DLSYM_PREPEND_UNDERSCORE

--- a/libatalk/util/socket.c
+++ b/libatalk/util/socket.c
@@ -21,8 +21,6 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#include <atalk/standards.h>
-
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/types.h>
@@ -39,6 +37,7 @@
 
 #include <atalk/logger.h>
 #include <atalk/util.h>
+#include <atalk/standards.h>
 
 static char ipv4mapprefix[] = {0,0,0,0,0,0,0,0,0,0,0xff,0xff};
 

--- a/macros/pam-check.m4
+++ b/macros/pam-check.m4
@@ -97,6 +97,13 @@ AC_DEFUN([AC_PATH_PAM], [
            PAM_ACCOUNT=system
            PAM_PASSWORD=system
            PAM_SESSION=system
+        dnl macOS
+        elif test -f "$pampath/chkpasswd"; then
+           PAM_DIRECTIVE=required
+           PAM_AUTH=pam_opendirectory.so
+           PAM_ACCOUNT=pam_opendirectory.so
+           PAM_PASSWORD=pam_permit.so
+           PAM_SESSION=pam_permit.so
         dnl Fallback
         else
            PAM_DIRECTIVE=required

--- a/macros/zeroconf.m4
+++ b/macros/zeroconf.m4
@@ -65,6 +65,22 @@ AC_DEFUN([NETATALK_ZEROCONF], [
                 found_zeroconf=yes
             fi
 		fi
+				
+        # mDNS support using mDNSResponder on macOS
+        if test x"$found_zeroconf" != x"yes" ; then
+		        AC_CHECK_HEADER(
+				        dns_sd.h,
+				        AC_CHECK_LIB(
+						        System,
+						        DNSServiceRegister,
+						        AC_DEFINE(USE_ZEROCONF, 1, [Use DNS-SD registration]))
+		        )
+		        if test "$ac_cv_lib_System_DNSServiceRegister" = yes; then
+				        ZEROCONF_LIBS="-lSystem"
+				        AC_DEFINE(HAVE_MDNS, 1, [Use mDNSRespnder/DNS-SD registration])
+				        found_zeroconf=yes
+		        fi
+    fi
 	fi
 
 	netatalk_cv_zeroconf=no

--- a/sys/netatalk/at.h
+++ b/sys/netatalk/at.h
@@ -74,15 +74,15 @@ struct at_addr {
 #ifdef s_net
 #undef s_net
 #endif /* s_net */
-    u_short	s_net;
-    u_char	s_node;
+    unsigned short	s_net;
+    unsigned char	s_node;
 };
 #endif /* MACOSX_SERVER */
 
-#define ATADDR_ANYNET	(u_short)0x0000
-#define ATADDR_ANYNODE	(u_char)0x00
-#define ATADDR_ANYPORT	(u_char)0x00
-#define ATADDR_BCAST	(u_char)0xff		/* There is no BCAST for NET */
+#define ATADDR_ANYNET	(unsigned short)0x0000
+#define ATADDR_ANYNODE	(unsigned char)0x00
+#define ATADDR_ANYPORT	(unsigned char)0x00
+#define ATADDR_BCAST	(unsigned char)0xff		/* There is no BCAST for NET */
 
 /*
  * Socket address, AppleTalk style.  We keep magic information in the 
@@ -94,26 +94,26 @@ struct at_addr {
 #ifndef MACOSX_SERVER
 struct sockaddr_at {
 #ifdef BSD4_4
-    u_char		sat_len;
-    u_char		sat_family;
+    unsigned char		sat_len;
+    unsigned char		sat_family;
 #else /* BSD4_4 */
     short		sat_family;
 #endif /* BSD4_4 */
-    u_char		sat_port;
+    unsigned char		sat_port;
     struct at_addr	sat_addr;
 #ifdef notdef
     struct {
-	u_char		sh_type;
+	unsigned char		sh_type;
 # define SATHINT_NONE	0
 # define SATHINT_CONFIG	1
 # define SATHINT_IFACE	2
 	union {
 	    char		su_zero[ 7 ];	/* XXX check size */
 	    struct {
-		u_char		sr_phase;
-		u_short		sr_firstnet, sr_lastnet;
+		unsigned char		sr_phase;
+		unsigned short		sr_firstnet, sr_lastnet;
 	    } su_range;
-	    u_short		su_interface;
+	    unsigned short		su_interface;
 	} sh_un;
     } sat_hints;
 #else /* notdef */
@@ -123,9 +123,9 @@ struct sockaddr_at {
 #endif /* MACOSX_SERVER */
 
 struct netrange {
-    u_char		nr_phase;
-    u_short		nr_firstnet;
-    u_short		nr_lastnet;
+    unsigned char		nr_phase;
+    unsigned short		nr_firstnet;
+    unsigned short		nr_lastnet;
 };
 
 #ifdef KERNEL

--- a/sys/netatalk/at.h
+++ b/sys/netatalk/at.h
@@ -28,10 +28,6 @@
 #include <sys/types.h>
 #include <netinet/in.h> /* so that we can deal with sun's s_net #define */
 
-#ifdef MACOSX_SERVER
-#include <netat/appletalk.h>
-#endif /* MACOSX_SERVER */
-
 /*
  * Supported protocols
  */
@@ -69,7 +65,6 @@
 /*
  * AppleTalk address.
  */
-#ifndef MACOSX_SERVER
 struct at_addr {
 #ifdef s_net
 #undef s_net
@@ -77,7 +72,6 @@ struct at_addr {
     unsigned short	s_net;
     unsigned char	s_node;
 };
-#endif /* MACOSX_SERVER */
 
 #define ATADDR_ANYNET	(unsigned short)0x0000
 #define ATADDR_ANYNODE	(unsigned char)0x00
@@ -91,7 +85,6 @@ struct at_addr {
  * interface.  IFACE may be filled in by the client, and is filled in
  * by the kernel.
  */
-#ifndef MACOSX_SERVER
 struct sockaddr_at {
 #ifdef BSD4_4
     unsigned char		sat_len;
@@ -120,7 +113,6 @@ struct sockaddr_at {
     char		sat_zero[ 8 ];
 #endif /* notdef */
 };
-#endif /* MACOSX_SERVER */
 
 struct netrange {
     unsigned char		nr_phase;


### PR DESCRIPTION
This commit enables the 2.2 branch to be compiled on macOS hosts. The DDP, a2boot and timelord configure options can be enabled in preparation for a possible development of a userland AppleTalk stack for modern macOS iterations. Note that compiling for macOS is _not_ the same as compiling for Mac OS X Server, the kernel has long since discarded all AppleTalk/DDP related code (xnu/netat) and use of the /netat header files is not indicated.