### PR TITLE
Revert "Temporary workaround for -lzlib not found issue in upstream mysql version 8.0.33"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
-        run: brew install automake libressl dgsga/netatalk-mysql/mysql pkg-config
+        run: brew install automake libressl mysql pkg-config
       - name: Build
         run: ./bootstrap && ./configure --with-ssl-dir=/usr/local/opt/libressl --with-bdb=/usr/local/opt/berkeley-db && make -j $(nproc)
       - name: Run tests


### PR DESCRIPTION
The bad linker flags in mysql_config are now fixed the upstream Homebrew formula for mysql.