### PR TITLE
libatalk: Use only DHX2 UAM by default. Issue #358

### DIFF
--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>5</manvolnum>
 
-    <refmiscinfo class="date">11 Apr 2023</refmiscinfo>
+    <refmiscinfo class="date">24 Jun 2023</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -387,7 +387,7 @@
 
           <listitem>
             <para>Space or comma separated list of UAMs. (The default is
-            "uams_dhx.so uams_dhx2.so").</para>
+            "uams_dhx2.so").</para>
 
             <para>The most commonly used UAMs are:</para>
 

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2068,7 +2068,7 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     options->extmapfile     = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "extmap file",    _PATH_CONFDIR "extmap.conf");
     options->passwdfile     = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "passwd file",    _PATH_AFPDPWFILE);
     options->uampath        = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "uam path",       _PATH_AFPDUAMPATH);
-    options->uamlist        = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "uam list",       "uams_dhx.so uams_dhx2.so");
+    options->uamlist        = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "uam list",       "uams_dhx2.so");
     options->port           = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "afp port",       "548");
     options->signatureopt   = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "signature",      "");
     options->k5service      = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "k5 service",     NULL);


### PR DESCRIPTION
As discussed in https://github.com/Netatalk/netatalk/issues/358 -- the DHX UAM will no longer work properly when using the latest OpenSSL 3.0, which is the default with the newly released Debian Bookworm. You can still build and execute the DHX code, but it leads to cryptic (no pun intended) errors when attempting to authenticate with the UAM with a client such as Mac OS 9.

There are workarounds such as building with LibreSSL or WolfSSL, but DHX is inherently insecure in this day and age, so I think it is advisable to not have it enabled by default.