### PR TITLE
Use non-interactive PAM session, fixes #361 

### DIFF
--- a/macros/pam-check.m4
+++ b/macros/pam-check.m4
@@ -82,7 +82,13 @@ AC_DEFUN([AC_NETATALK_PATH_PAM], [
            PAM_AUTH=common-auth
            PAM_ACCOUNT=common-account
            PAM_PASSWORD=common-password
-           PAM_SESSION=common-session
+           if test -f "$pampath/common-session-noninteractive" ; then
+               PAM_SESSION=common-session-noninteractive
+           elif test -f "$pampath/common-session-nonlogin" ; then
+               PAM_SESSION=common-session-nonlogin
+           else
+               PAM_SESSION=common-session
+           fi
         dnl RHEL/FC
         elif test -f "$pampath/system-auth" ; then
            PAM_DIRECTIVE=include


### PR DESCRIPTION
`pam_systemd.so` should not be loaded, as it causes dbus errors. See #361 and [here](https://bugs.launchpad.net/ubuntu/+source/netatalk/+bug/1538004) for details.
```
/etc/pam.d$ diff -u common-session common-session-noninteractive
--- common-session      2023-06-16 14:50:01.333615224 +0200
+++ common-session-noninteractive       2023-06-16 14:50:01.337615060 +0200
@@ -1,9 +1,10 @@
 #
-# /etc/pam.d/common-session - session-related modules common to all services
+# /etc/pam.d/common-session-noninteractive - session-related modules
+# common to all non-interactive services
 #
 # This file is included from other service-specific PAM config files,
 # and should contain a list of modules that define tasks to be performed
-# at the start and end of interactive sessions.
+# at the start and end of all non-interactive sessions.
 #
 # As of pam 1.0.1-6, this file is managed by pam-auth-update by default.
 # To take advantage of this, it is recommended that you configure any
@@ -21,5 +22,4 @@
 session        required                        pam_permit.so
 # and here are more per-package modules (the "Additional" block)
 session        required        pam_unix.so 
-session        optional        pam_systemd.so 
 # end of pam-auth-update config
```

