### PR TITLE
[2.2] Update atalkd.service to be consistent with other init scripts.

### DIFF
--- a/distrib/initscripts/atalkd.service.tmpl
+++ b/distrib/initscripts/atalkd.service.tmpl
@@ -7,7 +7,10 @@ After=network-online.target
 [Service]
 Type=forking
 GuessMainPID=no
+ExecStartPre=/bin/sh -c 'systemctl set-environment ATALK_NAME=$$(hostname|cut -d. -f1)'
 ExecStart=:SBINDIR:/atalkd
+ExecStartPost=:BINDIR:/nbprgstr -p 4 "${ATALK_NAME}:Workstation"
+ExecStartPost=:BINDIR:/nbprgstr -p 4 "${ATALK_NAME}:netatalk"
 Restart=always
 RestartSec=1
 


### PR DESCRIPTION
The original init scripts for atalkd registered the NBP entries of "Workstation" and "netatalk". This commit adds this functionality to the systemd unit file.