### PR TITLE
Tell automake to look for compiled objects in top_builddir

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,8 @@ jobs:
         run: make -j $(nproc) all
       - name: Run tests
         run: make check
+      - name: Run distribution tests
+        run: make distcheck
 
   build-macos:
     name: macOS

--- a/test/afpd/Makefile.am
+++ b/test/afpd/Makefile.am
@@ -70,14 +70,14 @@ test_CFLAGS += @TRACKER_CFLAGS@
 endif
 
 if WITH_DTRACE
-DTRACE_OBJ = $(top_srcdir)/etc/afpd/test-afp_dsi.o \
-             $(top_srcdir)/etc/afpd/test-fork.o \
-             $(top_srcdir)/etc/afpd/test-appl.o \
-             $(top_srcdir)/etc/afpd/test-catsearch.o \
-             $(top_srcdir)/etc/afpd/test-directory.o \
-             $(top_srcdir)/etc/afpd/test-enumerate.o \
-             $(top_srcdir)/etc/afpd/test-file.o \
-             $(top_srcdir)/etc/afpd/test-filedir.o
+DTRACE_OBJ = $(top_builddir)/etc/afpd/test-afp_dsi.o \
+             $(top_builddir)/etc/afpd/test-fork.o \
+             $(top_builddir)/etc/afpd/test-appl.o \
+             $(top_builddir)/etc/afpd/test-catsearch.o \
+             $(top_builddir)/etc/afpd/test-directory.o \
+             $(top_builddir)/etc/afpd/test-enumerate.o \
+             $(top_builddir)/etc/afpd/test-file.o \
+             $(top_builddir)/etc/afpd/test-filedir.o
 afp_dtrace.o: $(top_srcdir)/include/atalk/afp_dtrace.d $(DTRACE_OBJ)
 	if test -f afp_dtrace.o ; then rm -f afp_dtrace.o ; fi
 	$(LIBTOOL) --mode=execute dtrace -G -s $(top_srcdir)/include/atalk/afp_dtrace.d -o afp_dtrace.o $(DTRACE_OBJ)


### PR DESCRIPTION
This solves https://github.com/Netatalk/netatalk/issues/377 by allowing automake to find the compiled objects for afpd when linking the test binary with the distcheck target.

Also adding a `make distcheck` step for the Ubuntu job to catch this kind of breakage earlier in the future. It adds about 2 min to the runtime.

The distcheck target is broken on macOS so won't run it there.