### PR TITLE
Fix support for cross-compilation with mysql_config and dtrace

### DIFF
--- a/etc/afpd/Makefile.am
+++ b/etc/afpd/Makefile.am
@@ -89,7 +89,7 @@ if WITH_DTRACE
 DTRACE_OBJ = afpd-afp_dsi.o afpd-fork.o afpd-appl.o afpd-catsearch.o afpd-directory.o afpd-enumerate.o afpd-file.o afpd-filedir.o
 afp_dtrace.o: $(top_srcdir)/include/atalk/afp_dtrace.d $(DTRACE_OBJ)
 	if test -f afp_dtrace.o ; then rm -f afp_dtrace.o ; fi
-	$(LIBTOOL) --mode=execute dtrace -G -s $(top_srcdir)/include/atalk/afp_dtrace.d -o afp_dtrace.o $(DTRACE_OBJ)
+	CC=$(CC) $(LIBTOOL) --mode=execute dtrace -G -s $(top_srcdir)/include/atalk/afp_dtrace.d -o afp_dtrace.o $(DTRACE_OBJ)
 afpd_LDADD += afp_dtrace.o @DTRACE_LIBS@
 CLEANFILES += afp_dtrace.o
 endif

--- a/macros/cnid-backend.m4
+++ b/macros/cnid-backend.m4
@@ -120,7 +120,9 @@ AC_DEFUN([AC_NETATALK_CNID], [
     )
 
     if test -z "$MYSQL_CONFIG" -a -z "$MYSQL_CFLAGS" -a -z "$MYSQL_LIBS" ; then
-        AC_PATH_PROG(MYSQL_CONFIG, mysql_config)
+        PKG_CHECK_MODULES([MYSQL],[mysqlclient],[],[
+          AC_PATH_PROG(MYSQL_CONFIG, mysql_config)
+        ])
     fi
 
     if test -x "$MYSQL_CONFIG" ; then


### PR DESCRIPTION
Description: Fix support for cross-compilation with mysql_config and dtrace
 This patch makes netatalk consult pkg-config before mysql_config
 and supports exporting the compiler as CC environment variable.
Author: Helmut Grohne <helmut@subdivi.de>
Reviewed-by: Daniel Markstedt <daniel@mindani.net>