### PR TITLE
Fix user visible typos and improve English grammar

### DIFF
--- a/doc/manpages/man1/apple_dump.1.xml
+++ b/doc/manpages/man1/apple_dump.1.xml
@@ -80,10 +80,10 @@
   <refsect1>
     <title>DESCRIPTION</title>
 
-    <para><command>apple_dump</command> is a perl script to dump
+    <para><command>apple_dump</command> dumps
     AppleSingle/AppleDouble format data. </para>
-    <para>This script can dump various AppleSingle/AppleDouble data created
-    by mailer, archiver, Mac OS X, Netatalk and so on.</para>
+    <para>It can dump various AppleSingle/AppleDouble data created
+    by mailers, archivers, Mac OS X, Netatalk and so on.</para>
     <para>With no <replaceable>FILE</replaceable>|<replaceable>DIR</replaceable>, or when <replaceable>FILE</replaceable>|<replaceable>DIR</replaceable> is '-', read standard input.</para>
 
   </refsect1>
@@ -96,16 +96,16 @@
         <term><option>-a</option> [<replaceable>FILE</replaceable>|<replaceable>DIR</replaceable>]</term>
 
         <listitem>
-          <para>This is default.
-          Dump a AppleSingle/AppleDouble data for
+          <para>This is the default.
+          Dump AppleSingle/AppleDouble data for
           <replaceable>FILE</replaceable> or <replaceable>DIR</replaceable>
           automatically.
-          If FILE is not AppleSingle/AppleDouble format,
-          look for extended attribute,
+          If FILE is not in AppleSingle/AppleDouble format,
+          look for extended attributes,
           <replaceable>.AppleDouble/FILE</replaceable> and
           <replaceable>._FILE</replaceable>.
           If <replaceable>DIR</replaceable>, look for
-          extended attribute,
+          extended attributes,
           <replaceable>DIR/.AppleDouble/.Parent</replaceable> and
           <replaceable>._DIR</replaceable>.</para>
         </listitem>
@@ -115,7 +115,7 @@
         <term><option>-e</option> <replaceable>FILE</replaceable>|<replaceable>DIR</replaceable></term>
 
         <listitem>
-          <para>Dump extended attribute of <replaceable>FILE</replaceable> or <replaceable>DIR</replaceable>.</para>
+          <para>Dump extended attributes of <replaceable>FILE</replaceable> or <replaceable>DIR</replaceable>.</para>
         </listitem>
       </varlistentry>
 
@@ -161,11 +161,11 @@
     <title>NOTE</title>
 
     <para>There is no way to detect whether FinderInfo is FileInfo or DirInfo.
-    By default, apple_dump examines whether file or directory, a parent directory
+    By default, apple_dump examines whether the file, directory or parent directory
     is .AppleDouble, filename is ._*, filename is .Parent, and so on.</para>
 
-    <para>If setting option -e, -f or -d,  assume FinderInfo and doesn't look
-    for another data.</para>
+    <para>When setting option -e, -f or -d, assume FinderInfo and don't look
+    for other data.</para>
 
   </refsect1>
 

--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -993,7 +993,7 @@
           <type>(G)/(V)</type></term>
 
           <listitem>
-            <para>Speficy a set of file and directory attributes that shall
+            <para>Specify a set of file and directory attributes that shall
             be ignored by the server, <option>all</option> includes all
             the other options.</para>
             <para>In OS X when the Finder sets a lock on a file/directory or you
@@ -1457,7 +1457,7 @@
       setup both client and server as part on a authentication domain
       (directory service, e.g. LDAP, Open Directory, Active Directory). The
       reason is, in OS X ACLs are bound to UUIDs, not just uid's or gid's.
-      Therefor Netatalk must be able to map every filesystem uid and gid to a
+      Therefore Netatalk must be able to map every filesystem uid and gid to a
       UUID so that it can return the server side ACLs which are bound to UNIX
       uid and gid mapped to OS X UUIDs.</para>
 
@@ -1726,9 +1726,9 @@
             for backup. Example: "vol size limit = 1000" would limit the
             reported disk space to 1 GB. <emphasis role="bold">IMPORTANT:
             </emphasis> This is an approximated calculation taking into
-            account the contents of Time Machine sparsebundle images. Therefor
+            account the contents of Time Machine sparsebundle images. Therefore
             you MUST NOT use this volume to store other content when using
-            this option, because it would NOT be accounted. The calculation
+            this option, because it would NOT be accounted for. The calculation
             works by reading the band size from the Info.plist XML file of the
             sparsebundle, reading the bands/ directory counting the number of
             band files, and then multiplying one with the other.</para>

--- a/etc/afpd/spotlight.c
+++ b/etc/afpd/spotlight.c
@@ -932,7 +932,7 @@ static int sl_rpc_openQuery(AFPObj *obj,
 
     ret = map_spotlight_to_sparql_query(slq, &sparql_query);
     if (ret != 0) {
-        LOG(log_debug, logtype_sl, "mapping retured non-zero");
+        LOG(log_debug, logtype_sl, "mapping returned non-zero");
         EC_FAIL;
     }
     LOG(log_debug, logtype_sl, "SPARQL query: \"%s\"", sparql_query);

--- a/etc/uams/uams_gss.c
+++ b/etc/uams/uams_gss.c
@@ -220,7 +220,7 @@ static int wrap_sessionkey(gss_ctx_id_t context, struct session_info *sinfo)
     /* store the wrapped session key in afpd's session_info struct */
     if (NULL == (sinfo->cryptedkey = malloc(wrap_buff.length))) {
         LOG_UAMS(log_error,
-                 "wrap_sessionkey: out of memory tyring to allocate %u bytes",
+                 "wrap_sessionkey: out of memory trying to allocate %u bytes",
                  wrap_buff.length);
         ret = 1;
     } else {


### PR DESCRIPTION
- Removed two cases of explicit reference to the underlying implementation (Perl script)
- Improve English grammar for a few sentences
- Several typos reported by Debian's lintian