### PR TITLE
[2.2] Fix user visible typos and improve English grammar

### DIFF
--- a/doc/manual/man/man1/ad.1.xml
+++ b/doc/manual/man/man1/ad.1.xml
@@ -35,7 +35,7 @@
   <refsect1>
     <title>Description</title>
 
-    <para><command>ad</command> is a UNIX file utlity suite with Netatalk
+    <para><command>ad</command> is a UNIX file utility suite with Netatalk
     compatibity. AppleDouble files in <filename>.AppleDouble</filename> directories and
     the CNID databases are updated as appropriate.</para>
   </refsect1>
@@ -132,7 +132,7 @@
         <term>-R</term>
 
         <listitem>
-          <para>list subdirectories recursively</para>
+          <para>List subdirectories recursively</para>
         </listitem>
       </varlistentry>
 
@@ -195,7 +195,7 @@ Note: any letter appearing in uppercase means the flag is set but it's a directo
     detects an attempt to copy a file to itself, the copy will fail.</para>
 
     <para>Netatalk AFP volumes are detected by means of their ".AppleDesktop"
-    directory which is located in their volume root. When a copy targetting an
+    directory which is located in their volume root. When a copy targeting an
     AFP volume is detected, its CNID database daemon is connected and all
     copies will also go through the CNID database. AppleDouble data are also
     copied and created as needed when the target is an AFP volume.</para>

--- a/doc/manual/man/man1/apple_dump.1.xml
+++ b/doc/manual/man/man1/apple_dump.1.xml
@@ -80,10 +80,10 @@
   <refsect1>
     <title>DESCRIPTION</title>
 
-    <para><command>apple_dump</command> is a perl script to dump
+    <para><command>apple_dump</command> dumps
     AppleSingle/AppleDouble format data. </para>
-    <para>This script can dump various AppleSingle/AppleDouble data created
-    by mailer, archiver, Mac OS X, Netatalk and so on.</para>
+    <para>It can dump various AppleSingle/AppleDouble data created
+    by mailers, archivers, Mac OS X, Netatalk and so on.</para>
     <para>With no <replaceable>FILE</replaceable>|<replaceable>DIR</replaceable>, or when <replaceable>FILE</replaceable>|<replaceable>DIR</replaceable> is '-', read standard input.</para>
 
   </refsect1>
@@ -96,16 +96,16 @@
         <term><option>-a</option> [<replaceable>FILE</replaceable>|<replaceable>DIR</replaceable>]</term>
 
         <listitem>
-          <para>This is default.
-          Dump a AppleSingle/AppleDouble data for
+          <para>This is the default.
+          Dump AppleSingle/AppleDouble data for
           <replaceable>FILE</replaceable> or <replaceable>DIR</replaceable>
           automatically.
-          If FILE is not AppleSingle/AppleDouble format,
-          look for extended attribute,
+          If FILE is not in AppleSingle/AppleDouble format,
+          look for extended attributes,
           <replaceable>.AppleDouble/FILE</replaceable> and
           <replaceable>._FILE</replaceable>.
           If <replaceable>DIR</replaceable>, look for
-          extended attribute,
+          extended attributes,
           <replaceable>DIR/.AppleDouble/.Parent</replaceable> and
           <replaceable>._DIR</replaceable>.</para>
         </listitem>
@@ -115,7 +115,7 @@
         <term><option>-e</option> <replaceable>FILE</replaceable>|<replaceable>DIR</replaceable></term>
 
         <listitem>
-          <para>Dump extended attribute of <replaceable>FILE</replaceable> or <replaceable>DIR</replaceable>.</para>
+          <para>Dump extended attributes of <replaceable>FILE</replaceable> or <replaceable>DIR</replaceable>.</para>
         </listitem>
       </varlistentry>
 
@@ -161,11 +161,11 @@
     <title>NOTE</title>
 
     <para>There is no way to detect whether FinderInfo is FileInfo or DirInfo.
-    By default, apple_dump examines whether file or directory, a parent directory
+    By default, apple_dump examines whether the file, directory, or parent directory
     is .AppleDouble, filename is ._*, filename is .Parent, and so on.</para>
 
-    <para>If setting option -e, -f or -d,  assume FinderInfo and doesn't look
-    for another data.</para>
+    <para>When setting option -e, -f or -d,  assume FinderInfo and don't look
+    for other data.</para>
 
   </refsect1>
 

--- a/doc/manual/man/man1/megatron.1.xml
+++ b/doc/manual/man/man1/megatron.1.xml
@@ -78,7 +78,7 @@
     (AppleShare) server. BinHex, MacBinary, and AppleSingle are commonly used
     formats for transferring Macintosh files between machines via email or
     file transfer protocols. <command>megatron</command> uses its name to
-    determine what type of tranformation is being asked of it.</para>
+    determine what type of transformation is being asked of it.</para>
 
     <para>If <command>megatron</command> is called as <command>unhex</command>
     , <command>unbin</command> or <command>unsingle</command>, it tries to

--- a/doc/manual/man/man4/atalk.4.xml
+++ b/doc/manual/man/man4/atalk.4.xml
@@ -56,7 +56,7 @@
     The node for <emphasis remap="B">bind</emphasis> must always be <emphasis
     remap="B">ATADDR_ANYNODE</emphasis>: ``this node.&#39;&#39; The net may be
     <emphasis remap="B">ATADDR_ANYNET</emphasis> or <emphasis remap="B">ATADDR_LATENET</emphasis>.
-    <emphasis remap="B">ATADDR_ANYNET</emphasis> coresponds to the
+    <emphasis remap="B">ATADDR_ANYNET</emphasis> corresponds to the
     machine&#39;s ``primary&#39;&#39; address (the first configured).
     <emphasis remap="B">ATADDR_LATENET</emphasis> causes the address in
     outgoing packets to be determined when a packet is sent, i.e. determined

--- a/doc/manual/man/man5/AppleVolumes.default.5.xml
+++ b/doc/manual/man/man5/AppleVolumes.default.5.xml
@@ -113,7 +113,7 @@
     </note>
 
     <para>It is possible to specify default options for all volumes with a
-    <emphasis>:DEFAULT: </emphasis>line preceeding these volume
+    <emphasis>:DEFAULT: </emphasis>line preceding these volume
     definitions:</para>
       <example>
         <title>:DEFAULT: configuration line</title>
@@ -231,7 +231,7 @@
 
         <listitem>
           <para>Sets the database information to be stored in path. You have
-          to specifiy a writable location, even if the volume is read
+          to specify a writable location, even if the volume is read
           only.</para>
         </listitem>
       </varlistentry>
@@ -265,7 +265,7 @@
               <listitem>
                 <para>Try <option>sys</option> (by setting an EA on the shared
                 directory itself), fallback to <option>ad</option>. Requires
-                a writeable volume for perfoming the test.
+                a writeable volume for performing the test.
                 <option>options:ro</option> overwrites <option>auto</option>
                 with <option>none</option>. Use explicit
                 <option>ea:sys|ad</option> for read-only volumes where
@@ -335,7 +335,7 @@
               <term>tm</term>
 
               <listitem>
-                <para>Enable Time Machine suport for this volume.</para>
+                <para>Enable Time Machine support for this volume.</para>
               </listitem>
             </varlistentry>
 
@@ -684,7 +684,7 @@
 
         <listitem>
           <para>"Concurrent database", backend is based on Sleepycat's Berkeley
-          DB. With this backend several <command>afpd</command> deamons access
+          DB. With this backend several <command>afpd</command> daemons access
           the CNID database directly. Berkeley DB locking is used to
           synchronize access, if more than one <command>afpd</command> process
           is active for a volume. The drawback is, that the crash of a single
@@ -923,7 +923,7 @@
               <listitem>
                 <para>Forces filename restrictions imposed by MS WinXX.
                 <emphasis>Warning</emphasis>: This is <emphasis>NOT</emphasis>
-                recommened for volumes mainly used by Macs. Please make sure
+                recommended for volumes mainly used by Macs. Please make sure
                 you fully understand this option before using it.</para>
 
                 <warning>

--- a/doc/manual/man/man5/afpd.conf.5.xml
+++ b/doc/manual/man/man5/afpd.conf.5.xml
@@ -406,8 +406,8 @@
 
         <listitem>
           <para>Use this instead of the result from calling hostname for
-          dertermening which IP address to advertise, therfore the hostname is
-          resolved to an IP which is the advertised. This is NOT used for
+          determining which IP address to advertise, therefore the hostname is
+          resolved to an IP which is the advertised one. This is NOT used for
           listening and it is also overwritten by
           <option>-ipaddr</option>.</para>
         </listitem>
@@ -418,11 +418,11 @@
 
         <listitem>
           <para>Specifies the IP address that the server should advertise
-          <emphasis role="bold">and</emphasis> listen to. The default is
+          <emphasis role="bold">and</emphasis> listen to. The default is to
           advertise the first IP address of the system, but to listen for any
           incoming request. The network address may be specified either in
           dotted-decimal format for IPv4 or in hexadecimal format for IPv6.
-          This option also allows to use one machine to advertise the
+          This option also allows one to use one machine to advertise the
           AFP-over-TCP/IP settings of another machine via NBP<indexterm>
               <primary>NBP</primary>
 
@@ -636,7 +636,7 @@
           <para>
             Enables sending FCE events to the specified <parameter>host</parameter>,
             default <parameter>port</parameter> is 12250 if not specified. Specifying
-            mutliple listeners is done by having this option once for each of them.
+            multiple listeners is done by having this option once for each of them.
           </para>
         </listitem>
       </varlistentry>
@@ -666,7 +666,7 @@
             This determines the time delay in seconds which is always waited if another file modification for the
             same file is done by a client before sending an FCE file modification event (fmod). For example, saving
             a file in Photoshop would generate multiple events by itself because the application is opening,
-            modifying and closing a file mutliple times for every "save". Default: 60 seconds.
+            modifying and closing a file multiple times for every "save". Default: 60 seconds.
           </para>
         </listitem>
       </varlistentry>
@@ -695,7 +695,7 @@
           a SIGQUIT signal, possibly install an afpd update and start the afpd process. Existing AFP sessions'
           afpd processes will remain unaffected. Technically they will be notified of the master afpd shutdown,
           sleep 15-20 seconds and then try to reconnect their IPC channel to the master afpd process. If this
-          reconnect fails, the sessions are in an undefined state. Therefor it's absolutely critical to restart
+          reconnect fails, the sessions are in an undefined state. Therefore it's absolutely critical to restart
           the master process in time!</para>
         </listitem>
       </varlistentry>
@@ -757,7 +757,7 @@
           in clustered environments, to provide fault isolation etc.). Default
           is "auto". "auto" signature type allows afpd to generate a signature
           and saving it to <filename>:ETCDIR:/afp_signature.conf</filename>
-          automatically (based on random number). The "host" signature type
+          automatically (based on a random number). The "host" signature type
           switches back to "auto" because it is obsoleted. The "user" signature
           type allows an administrator to set up a signature string manually. The
           maximum length is 16 characters.</para>
@@ -792,7 +792,7 @@ third -signature user:ADMINS</programlisting></para>
           <para><programlisting>73:  limit of Mac OS X 10.1
 80:  limit for Mac OS X 10.4/10.5 (default)
 255: limit of spec</programlisting>Mac OS 9 and earlier are not influenced by
-          this, because Maccharset volume name is always limitted to 27
+          this, because Maccharset volume name is always limited to 27
           bytes.</para>
         </listitem>
       </varlistentry>
@@ -810,7 +810,7 @@ third -signature user:ADMINS</programlisting></para>
         <listitem>
           <para>Specify that any message of a loglevel up to the given
           <option>loglevel</option> should be logged to the given file. If the
-          filename is ommited the loglevel applies to messages passed to
+          filename is omitted, the loglevel applies to messages passed to
           syslog.</para>
 
           <para>By default afpd logs
@@ -824,7 +824,7 @@ third -signature user:ADMINS</programlisting></para>
           LOG_MAXDEBUG</para>
 
           <note>
-            <para>The config is case-ignoring</para>
+            <para>The config is case insensitive</para>
           </note>
 
           <example>

--- a/doc/manual/man/man8/afpd.8.xml
+++ b/doc/manual/man/man8/afpd.8.xml
@@ -196,7 +196,7 @@
           <filename>AppleVolumes</filename> file to override volume names in
           the system's <filename>AppleVolumes</filename> file. The default is
           to read the system <filename>AppleVolumes</filename> file first.
-          Note that this option doesn't effect the precendence of filename
+          Note that this option doesn't effect the precedence of filename
           extension mappings: the user's <filename>AppleVolumes</filename>
           file always has precedence.</para>
         </listitem>
@@ -217,7 +217,7 @@
 
         <listitem>
           <para>Specifies the maximum number of connections to allow for this
-          <command>afpd</command>. The default is 20.</para>
+          instance of <command>afpd</command>. The default is 20.</para>
         </listitem>
       </varlistentry>
 

--- a/doc/manual/man/man8/atalkd.8.xml
+++ b/doc/manual/man/man8/atalkd.8.xml
@@ -79,7 +79,7 @@
     specified, all other fields must be present. Also,
     <command>atalkd</command> will exit during bootstrap­ping, if a router
     disagrees with its seed information. If <option>-seed</option> is not
-    given, all other information may be overriden during auto-configuration.
+    given, all other information may be overridden during auto-configuration.
     If no <option>-phase</option> option is given, the default phase as given
     on the command line is used (the default is 2). If <option>-addr</option>
     is given and <option>-net</option> is not, a net-range of one is
@@ -103,7 +103,7 @@
     <title>Routing</title>
 
     <para>If you are connecting a netatalk router to an existing AppleTalk
-    internet, you should first contact your local network administrators to
+    network, you should first contact your local network administrators to
     obtain appropriate network addresses.</para>
 
     <para><command>atalkd</command> can provide routing between interfaces by
@@ -114,8 +114,8 @@
         <secondary>AppleTalk net-range</secondary>
       </indexterm> between 1 and 65279 (0 and 65535 are illegal, and addresses
     between 65280 and 65534 are reserved for startup). It is best to choose
-    the smallest useful net-range, i.e. if you have three machines on an
-    Ethernet, don't chose a net-range of 1000-2000. Each net-range may have an
+    the smallest useful net-range, i.e. if you have three machines on a
+    LAN, don't chose a net-range of 1000-2000. Each net-range may have an
     arbitrary list of zones associated with it.</para>
   </refsect1>
 

--- a/doc/manual/man/man8/cnid_dbd.8.xml
+++ b/doc/manual/man/man8/cnid_dbd.8.xml
@@ -45,7 +45,7 @@
     <para><command>cnid_dbd</command> provides an interface for storage and
     retrieval of catalog node IDs (CNIDs) and related information to the
     <emphasis remap="B">afpd</emphasis> daemon. CNIDs are a component of
-    Macintosh based file systems with semantics that map not easily onto Unix
+    Macintosh based file systems with semantics that do not easily map onto Unix
     file systems. This makes separate storage in a database necessary.
     <command>cnid_dbd</command> is part of the <emphasis remap="B">CNID
     backend</emphasis> framework of <emphasis remap="B">afpd</emphasis> and
@@ -88,7 +88,7 @@
     a TERM or an INT signal it will exit cleanly after flushing dirty database
     buffers to disk and closing <emphasis remap="B">Berkleley DB</emphasis>
     database environments. It is safe to terminate <command>cnid_dbd</command>
-    this way, it will be restarted when necessary. Other signals are not
+    this way, because it will be restarted when necessary. Other signals are not
     handled and will cause an immediate exit, possibly leaving the CNID
     database in an inconsistent state (no transactions) or losing recent
     updates during recovery (transactions).</para>
@@ -96,8 +96,8 @@
     <para>The <emphasis remap="B">Berkleley DB</emphasis> database subsystem
     will create files named log.xxxxxxxxxx in the database home directory
     <emphasis remap="I">dbdir</emphasis>, where xxxxxxxxxx is a monotonically
-    increasing integer. These files contain ithe transactional database
-    changes. They will be removed regularily, unless the <emphasis
+    increasing integer. These files contain the transactional database
+    changes. They will be removed regularly, unless the <emphasis
     remap="B">logfile_autoremove</emphasis> option is specified in the
     <emphasis remap="I">db_param</emphasis> configuration file (see
     below) with a value of 0 (default 1).</para>

--- a/doc/manual/man/man8/cnid_metad.8.xml
+++ b/doc/manual/man/man8/cnid_metad.8.xml
@@ -59,7 +59,7 @@
     remap="B">cnid_dbd</emphasis> daemon. It keeps track of the status of a
     <emphasis remap="B">cnid_dbd</emphasis> instance once started and will
     restart it if necessary. <command>cnid_metad</command> is normally started
-    at boot time from <filename>/etc/rc</filename> or equivalent and runs
+    at boot time from system init scripts or services, and runs
     until shutdown. <emphasis remap="B">afpd</emphasis> needs to be configured
     with the <option>-cnidserver</option> option in <emphasis
     remap="B">afpd.conf</emphasis> in order to access <emphasis
@@ -78,10 +78,10 @@
         &lt;filename&gt;]</replaceable></term>
 
         <listitem>
-          <para>Specify that any message of a loglevel up to the given
+          <para>Specify that any message of a log level up to the given
           <option>loglevel</option> should be logged to the given file. If the
-          filename is ommited the loglevel applies to messages passed to
-          syslog. Default is logs to syslog with a default logging setup of
+          filename is omitted, the log level applies to messages passed to
+          syslog. Default is to log to syslog with a default log level of
           <option>"log_note</option>".</para>
 
           <para><emphasis remap="B">Note:</emphasis>
@@ -114,7 +114,7 @@
 
         <listitem>
           <para><emphasis remap="B">cnid_metad will remain in the foreground
-          and</emphasis> will also leave the standard input, standard output
+          and</emphasis> also leave the standard input, standard output
           and standard error file descriptors open. Useful for
           debugging.</para>
         </listitem>
@@ -170,7 +170,7 @@
 
         <listitem>
           <para>Use <emphasis remap="I">cnid_dbd pathname</emphasis> as the
-          pathname of the executeable of the <emphasis
+          pathname of the executable of the <emphasis
           remap="B">cnid_dbd</emphasis> daemon. The default is <emphasis
           remap="I">:SBINDIR:/cnid_dbd.</emphasis></para>
         </listitem>
@@ -189,14 +189,14 @@
   <refsect1>
     <title>CAVEATS</title>
 
-    <para>The number of <emphasis remap="B">cnid_dbd</emphasis> subprocecesses
+    <para>The number of <emphasis remap="B">cnid_dbd</emphasis> subprocesses
     is currently limited to 512.</para>
 
     <para><command>cnid_metad</command> does not block or catch any signals
     apart from SIGPIPE. It will therefore exit on most signals received. This
-    will also cause all instances of <emphasis remap="B">cnid_dbd's</emphasis>
+    will also cause all instances of <emphasis remap="B">cnid_dbd</emphasis>
     started by that <command>cnid_metad</command> to exit gracefully. Since
-    state about and IPC access to the subprocesses is only maintained in
+    the state of and IPC access to the subprocesses is only maintained in
     memory by <command>cnid_metad</command> this is desired behaviour. As soon
     as <command>cnid_metad</command> is restarted <emphasis
     remap="B">afpd</emphasis> processes will transparently reconnect.</para>

--- a/doc/manual/man/man8/papd.8.xml
+++ b/doc/manual/man/man8/papd.8.xml
@@ -54,9 +54,9 @@
     <command>lpd</command> in use.</para>
 
     <para>As of Netatalk 2.0, CUPS is also supported. Simply using <emphasis
-    remap="B">cupsautoadd</emphasis> as first papd.conf entry will share all
-    CUPS printers automagically using the PPD files configured in CUPS. It ist
-    still possible to overwrite these defaults by individually define printer
+    remap="B">cupsautoadd</emphasis> as the first papd.conf entry will share
+    all CUPS printers automagically. It is still possible to overwrite
+    these defaults by individually defining printer
     shares. See <citerefentry>
         <refentrytitle>papd.conf</refentrytitle>
 
@@ -139,7 +139,7 @@
 
               <entry>NULL</entry>
 
-              <entry>Pathname used for CAP-style authentification</entry>
+              <entry>Pathname used for CAP-style authentication</entry>
             </row>
 
             <row>
@@ -149,7 +149,7 @@
 
               <entry>false</entry>
 
-              <entry>PSSP-style authetication</entry>
+              <entry>PSSP-style authentication</entry>
             </row>
 
             <row>
@@ -265,7 +265,7 @@
     requires that a user login to a file share before they print.
     <command>afpd</command> records the username in a temporary file named
     after the client's AppleTalk address, and it deletes the temporary file
-    when the user disconnects. Therefore CAP style authentification will
+    when the user disconnects. Therefore CAP style authentication will
     <emphasis>not</emphasis> work for clients connected to
     <command>afpd</command> via TCP/IP. <command>papd</command> gets the
     username from the file with the same AppleTalk address as the machine
@@ -284,8 +284,8 @@
 
     <note>
       <para>As of this writing, Mac OS X makes no use of PSSP authentication
-      any longer. CAP-style authentication normally won't be an option, too
-      caused by the use of AFP over TCP these days.</para>
+      any longer. CAP-style authentication normally won't be an option, either,
+      because of the use of AFP over TCP these days.</para>
     </note>
 
     <para></para>

--- a/etc/afpd/main.c
+++ b/etc/afpd/main.c
@@ -399,7 +399,7 @@ int main(int ac, char **av)
     /* watch atp, dsi sockets and ipc parent/child file descriptor. */
 
     if (default_options.flags & OPTION_KEEPSESSIONS) {
-        LOG(log_note, logtype_afpd, "Activating continous service");
+        LOG(log_note, logtype_afpd, "Activating continuous service");
         disasociated_ipc_fd = ipc_server_uds(_PATH_AFP_IPC);
     }
 

--- a/etc/cnid_dbd/cmd_dbd.c
+++ b/etc/cnid_dbd/cmd_dbd.c
@@ -190,7 +190,7 @@ static void usage (void)
            "               -n Don't open CNID database, skip CNID checks.\n\n"
            "   -r Rebuild volume:\n"
            "      1. Sync CNIDs in database with volume\n"
-           "      2. Make sure .AppleDouble dir exist, create if missing\n"
+           "      2. Make sure .AppleDouble dir exists, create if missing\n"
            "      3. Make sure AppleDouble file exists, create if missing\n"
            "      4. Delete orphaned AppleDouble files\n"
            "      5. Check for directories inside AppleDouble directories\n"
@@ -211,7 +211,7 @@ static void usage (void)
            "   -v verbose\n\n"
            "WARNING:\n"
            "For -r -f restore of the CNID database from the adouble files,\n"
-           "the CNID must of course be synched to them files first with a plain -r rebuild!\n"
+           "the CNID must of course be synced to the files first with a plain -r rebuild!\n"
            , VERSION
         );
 }
@@ -355,7 +355,7 @@ int main(int argc, char **argv)
                 exit(EXIT_FAILURE);
             }
         } else {
-            dbd_log( LOGSTD, "Somethings wrong with .AppleDB for \"%s\", giving up: %s", dbpath, strerror(errno));
+            dbd_log( LOGSTD, "Something is wrong with .AppleDB for \"%s\", giving up: %s", dbpath, strerror(errno));
             exit(EXIT_FAILURE);
         }
     } else {
@@ -368,7 +368,7 @@ int main(int argc, char **argv)
     if (db_locked != LOCK_EXCL) {
         /* Couldn't get exclusive lock, try shared lock if -e wasn't requested */
         if (exclusive) {
-            dbd_log(LOGSTD, "Database is in use and exlusive was requested");
+            dbd_log(LOGSTD, "Database is in use and exclusive was requested");
             goto exit_noenv;
         }
         if ((db_locked = get_lock(LOCK_SHRD, NULL)) != LOCK_SHRD)

--- a/etc/uams/uams_gss.c
+++ b/etc/uams/uams_gss.c
@@ -305,7 +305,7 @@ static int wrap_sessionkey(gss_ctx_id_t context, struct session_info *sinfo)
     /* store the wrapped session key in afpd's session_info struct */
     if ( NULL == (sinfo->cryptedkey = malloc ( wrap_buff.length )) ) {
         LOG(log_error, logtype_uams,
-            "wrap_sessionkey: out of memory tyring to allocate %u bytes",
+            "wrap_sessionkey: out of memory trying to allocate %u bytes",
             wrap_buff.length);
         ret = 1;
     } else {


### PR DESCRIPTION
- Removed two cases of explicit reference to the underlying implementation (Perl script)
- Improve English grammar for a few sentences
- Several typos reported by Debian's lintian
- Capitalization fixes
- Word choice improvements