### PR TITLE
[2.2] Create man page for cnid2_create tool

### DIFF
--- a/doc/manual/Makefile
+++ b/doc/manual/Makefile
@@ -34,6 +34,7 @@ manpages = manpages/ad.1 \
 		manpages/afppasswd.1 \
 		manpages/apple_dump.1 \
 		manpages/asip-status.1 \
+		manpages/cnid2_create.1 \
 		manpages/dbd.1 \
 		manpages/getzones.1 \
 		manpages/macusers.1 \

--- a/doc/manual/man/man1/cnid2_create.1.xml
+++ b/doc/manual/man/man1/cnid2_create.1.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<refentry id="cnid2_create.1">
+  <refmeta>
+    <refentrytitle>cnid2_create</refentrytitle>
+
+    <manvolnum>1</manvolnum>
+
+    <refmiscinfo class="date">08 Aug 2023</refmiscinfo>
+
+    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+  </refmeta>
+
+  <refnamediv>
+    <refname>cnid2_create</refname>
+
+    <refpurpose>Convert CNID 1 database to CNID 2</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+    <cmdsynopsis>
+      <command>cnid2_create</command>
+
+      <arg choice="plain"><replaceable>volume</replaceable></arg>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+
+  <refsect1>
+    <title>DESCRIPTION</title>
+
+    <para><command>cnid2_create</command> converts a CNID database created
+    with Netatalk 1 to a CNID database compatible with Netatalk 2.</para>
+
+    <note>
+    <para>This section is borrowed with minor modification
+    from the Upgrade guide in the Netatalk 2 manual.</para>
+    </note>
+
+    <para>The steps to upgrade depend on what version of Berkeley DB is
+    installed on your system. If you already use one of the supported
+    versions of Berkeley DB (4.1.25 or 4.2.52) for your old Netatalk
+    installation and plan to use it for Netatalk 2 as well, just use the
+    <command>db_dump</command> and <command>db_load</command> utilities that
+    came with it as indicated below. Otherwise it is probably best to have
+    the old and the new (to be used with Netatalk 2) version of Berkeley
+    DB installed side by side until you have finished the upgrade. The
+    reason for this is that we will dump out the old databases with the
+    currently installed version of Berkeley DB in ASCII format and reload
+    them with the new version. This avoids any incompatibility problems
+    between Berkeley DB releases with respect to the on-disk format.</para>
+
+    <para>For each volume to be upgraded, follow these steps <itemizedlist>
+         <listitem>
+            <para>Stop all afpd daemons accessing the volume.</para>
+          </listitem>
+
+          <listitem>
+            <para>Change to the database directory for that volume, most
+            likely the <filename>.AppleDB</filename> subdirectory of the
+            volume toplevel directory in question.</para>
+          </listitem>
+
+          <listitem>
+            <para>Dump the contents of <filename>cnid.db</filename> and
+            <filename>didname.db</filename> using the old (installed) version
+            of Berkeley DB like this:</para>
+
+            <programlisting> db_dump -f cnid.dump cnid.db 
+ db_dump -f didname.dump didname.db</programlisting>
+
+            <para>Make sure the db_dump utility you are using is the correct
+            (currently used) one. Use the full path to the db_dump executable
+            if in doubt. So if this database was created with Berkeley DB 3.xx
+            installed in <filename>/usr/local/db3</filename> use
+            <filename>/usr/local/db3/bin/db_dump</filename> instead. This will
+            create two files, <filename>cnid.dump</filename> and
+            <filename>didname.dump</filename> in the current directory.</para>
+          </listitem>
+
+          <listitem>
+            <para>Run the cnid2_create script:</para>
+
+            <programlisting> cnid2_create </programlisting>
+
+            <para>The script assumes that <filename>.AppleDB</filename> is a
+            subdirectory of the volume directory to be upgraded. If that is
+            not the case give the full path name of the volume as the first
+            argument to <command>cnid2_create</command>. The script will
+            create a file <filename>cnid2.dump</filename> in ASCII
+            format.</para>
+          </listitem>
+
+          <listitem>
+            <para>Remove the old Berkeley DB environment and logfiles (if
+            present):</para>
+
+            <programlisting> rm __db.* log.*</programlisting>
+          </listitem>
+
+          <listitem>
+            <para>Load <filename>cnid2.dump</filename> into the new database.
+            You should use the <command>db_load</command> utility of Berkeley
+            DB that will be used with version 2 of Netatalk. So if Berkeley
+            DB 4.xx lives in <filename>/usr/local/db4</filename> use</para>
+
+            <programlisting> /usr/local/db4/bin/db_load -f cnid2.dump cnid2.db </programlisting>
+
+            <para>This will create the new database file,
+            <filename>cnid2.db</filename>. Remove the old database files
+            <filename>cnid.db</filename>, <filename>didname.db</filename> and
+            <filename>devino.db</filename>. The intermediate files
+            <filename>cnid.dump</filename>, <filename>didname.dump</filename>
+            and <filename>cnid2.dump</filename> can be removed now or at some
+            later time.</para>
+          </listitem>
+        </itemizedlist></para>
+
+    <para>If you do not want to have two versions of Berkeley DB installed
+    side by side during the upgrade, you should first dump out the old
+    databases as indicated above for all volumes, upgrade Berkeley DB and
+    then load them with db_load. The <command>cnid2_create</command> script
+    can be run before or after the upgrade. Berkeley DB environment and
+    logfiles should still be removed before running
+    <command>db_load</command>.</para>
+  </refsect1>
+
+  <refsect1>
+    <title>SEE ALSO</title>
+
+    <para><citerefentry><refentrytitle>apple_dump</refentrytitle><manvolnum>1</manvolnum></citerefentry></para>
+    <para><citerefentry><refentrytitle>dbd</refentrytitle><manvolnum>1</manvolnum></citerefentry></para>
+  </refsect1>
+</refentry>

--- a/doc/manual/manual.xml
+++ b/doc/manual/manual.xml
@@ -13,6 +13,7 @@
 <!ENTITY afpd.8 SYSTEM "man/man8/afpd.8.xml">
 <!ENTITY cnid_dbd.8 SYSTEM "man/man8/cnid_dbd.8.xml">
 <!ENTITY cnid_metad.8 SYSTEM "man/man8/cnid_metad.8.xml">
+<!ENTITY cnid2_create.1 SYSTEM "man/man1/cnid2_create.1.xml">
 <!ENTITY papd.8 SYSTEM "man/man8/papd.8.xml">
 <!ENTITY papstatus.8 SYSTEM "man/man8/papstatus.8.xml">
 <!ENTITY psf.8 SYSTEM "man/man8/psf.8.xml">
@@ -123,6 +124,8 @@ url="http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt">http://www.gnu.org/li
     &cnid_dbd.8;
 
     &cnid_metad.8;
+
+    &cnid2_create.1;
 
     &dbd.1;
 

--- a/man/man1/.gitignore
+++ b/man/man1/.gitignore
@@ -2,5 +2,6 @@ Makefile
 Makefile.in
 asip-status.1
 afpldaptest.1
+cnid2_create.1
 uniconv.1
 *.o

--- a/man/man1/Makefile.am
+++ b/man/man1/Makefile.am
@@ -12,8 +12,14 @@ SUFFIXES= .tmpl .
 	    -e s@:DEFAULT_CNID_SCHEME:@${DEFAULT_CNID_SCHEME}@ \
 	    <$< >$@
 
-GENERATED_MANS	= uniconv.1 asip-status.1 afpldaptest.1
-TEMPLATE_FILES	= uniconv.1.tmpl asip-status.1.tmpl afpldaptest.1.tmpl
+GENERATED_MANS	= uniconv.1 \
+		  asip-status.1 \
+		  afpldaptest.1 \
+		  cnid2_create.1
+TEMPLATE_FILES	= uniconv.1.tmpl \
+		  asip-status.1.tmpl \
+		  afpldaptest.1.tmpl \
+		  cnid2_create.1.tmpl
 NONGENERATED_MANS	=	ad.1 \
 				afppasswd.1 \
 				apple_dump.1 \

--- a/man/man1/cnid2_create.1.tmpl
+++ b/man/man1/cnid2_create.1.tmpl
@@ -1,0 +1,220 @@
+'\" t
+.\"     Title: cnid2_create
+.\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
+.\"      Date: 08 Aug 2023
+.\"    Manual: Netatalk 2.2
+.\"    Source: Netatalk 2.2
+.\"  Language: English
+.\"
+.TH "CNID2_CREATE" "1" "08 Aug 2023" "Netatalk 2.2" "Netatalk 2.2"
+.\" -----------------------------------------------------------------
+.\" * Define some portability stuff
+.\" -----------------------------------------------------------------
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.\" http://bugs.debian.org/507673
+.\" http://lists.gnu.org/archive/html/groff/2009-02/msg00013.html
+.\" ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.ie \n(.g .ds Aq \(aq
+.el       .ds Aq '
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+cnid2_create \- Convert CNID 1 database to CNID 2
+.SH "SYNOPSIS"
+.HP \w'\fBcnid2_create\fR\ 'u
+\fBcnid2_create\fR \fIvolume\fR
+.SH "DESCRIPTION"
+.PP
+\fBcnid2_create\fR
+converts a CNID database created with Netatalk 1 to a CNID database compatible with Netatalk 2\&.
+.if n \{\
+.sp
+.\}
+.RS 4
+.it 1 an-trap
+.nr an-no-space-flag 1
+.nr an-break-flag 1
+.br
+.ps +1
+\fBNote\fR
+.ps -1
+.br
+.PP
+This section is borrowed with minor modification from the Upgrade guide in the Netatalk 2 manual\&.
+.sp .5v
+.RE
+.PP
+The steps to upgrade depend on what version of Berkeley DB is installed on your system\&. If you already use one of the supported versions of Berkeley DB (4\&.1\&.25 or 4\&.2\&.52) for your old Netatalk installation and plan to use it for Netatalk 2 as well, just use the
+\fBdb_dump\fR
+and
+\fBdb_load\fR
+utilities that came with it as indicated below\&. Otherwise it is probably best to have the old and the new (to be used with Netatalk 2) version of Berkeley DB installed side by side until you have finished the upgrade\&. The reason for this is that we will dump out the old databases with the currently installed version of Berkeley DB in ASCII format and reload them with the new version\&. This avoids any incompatibility problems between Berkeley DB releases with respect to the on\-disk format\&.
+.PP
+For each volume to be upgraded, follow these steps
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Stop all afpd daemons accessing the volume\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Change to the database directory for that volume, most likely the
+\&.AppleDB
+subdirectory of the volume toplevel directory in question\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Dump the contents of
+cnid\&.db
+and
+didname\&.db
+using the old (installed) version of Berkeley DB like this:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+ db_dump \-f cnid\&.dump cnid\&.db 
+ db_dump \-f didname\&.dump didname\&.db
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+Make sure the db_dump utility you are using is the correct (currently used) one\&. Use the full path to the db_dump executable if in doubt\&. So if this database was created with Berkeley DB 3\&.xx installed in
+/usr/local/db3
+use
+/usr/local/db3/bin/db_dump
+instead\&. This will create two files,
+cnid\&.dump
+and
+didname\&.dump
+in the current directory\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Run the cnid2_create script:
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+ cnid2_create 
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+The script assumes that
+\&.AppleDB
+is a subdirectory of the volume directory to be upgraded\&. If that is not the case give the full path name of the volume as the first argument to
+\fBcnid2_create\fR\&. The script will create a file
+cnid2\&.dump
+in ASCII format\&.
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Remove the old Berkeley DB environment and logfiles (if present):
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+ rm __db\&.* log\&.*
+.fi
+.if n \{\
+.RE
+.\}
+.RE
+.sp
+.RS 4
+.ie n \{\
+\h'-04'\(bu\h'+03'\c
+.\}
+.el \{\
+.sp -1
+.IP \(bu 2.3
+.\}
+Load
+cnid2\&.dump
+into the new database\&. You should use the
+\fBdb_load\fR
+utility of Berkeley DB that will be used with version 2 of Netatalk\&. So if Berkeley DB 4\&.xx lives in
+/usr/local/db4
+use
+.sp
+.if n \{\
+.RS 4
+.\}
+.nf
+ /usr/local/db4/bin/db_load \-f cnid2\&.dump cnid2\&.db 
+.fi
+.if n \{\
+.RE
+.\}
+.sp
+This will create the new database file,
+cnid2\&.db\&. Remove the old database files
+cnid\&.db,
+didname\&.db
+and
+devino\&.db\&. The intermediate files
+cnid\&.dump,
+didname\&.dump
+and
+cnid2\&.dump
+can be removed now or at some later time\&.
+.RE
+.PP
+If you do not want to have two versions of Berkeley DB installed side by side during the upgrade, you should first dump out the old databases as indicated above for all volumes, upgrade Berkeley DB and then load them with db_load\&. The
+\fBcnid2_create\fR
+script can be run before or after the upgrade\&. Berkeley DB environment and logfiles should still be removed before running
+\fBdb_load\fR\&.
+.SH "SEE ALSO"
+.PP
+\fBapple_dump\fR(1)
+.PP
+\fBdbd\fR(1)


### PR DESCRIPTION
The cnid2_create tool is used to convert a Netatalk 1 CNID database to a Netatalk 2 compatible CNID database. I don't think it ever had a man page, so here's one that's based on the Upgrade guide.