### PR TITLE
Don't build and distribute cnid2_create

### DIFF
--- a/bin/cnid/Makefile.am
+++ b/bin/cnid/Makefile.am
@@ -1,7 +1,7 @@
 # Makefile.am for bin/cnid/
 
-EXTRA_DIST = cnid2_create.in
+#EXTRA_DIST = cnid2_create.in
 
-if USE_BDB
-bin_SCRIPTS = cnid2_create
-endif
+#if USE_BDB
+#bin_SCRIPTS = cnid2_create
+#endif


### PR DESCRIPTION
The cnid2_create script is used to convert a CNID database created by Netatalk 1.x to a format compatible with Netatalk 2.x.

Debian lintian is complaining about missing man pages, and rather than adding a man page I think it's time to stop distributing it. If someone needs a legacy tool like this, it is available in the 2.2 branch.