### PR TITLE
[2.2] Do not install at.h when glibc header is present

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -692,6 +692,11 @@ dnl	AC_COMPILE_IFELSE([
 		AC_MSG_RESULT([no])
 	])
 
+	dnl ----- Use the glibc at.h header if found -----
+	AC_CHECK_HEADER([netatalk/at.h], [
+		use_glibc_at_header=yes
+	])
+
 if test "x$ac_have_atalk_addr" = "xyes"; then
 	AC_DEFINE(HAVE_ATALK_ADDR, 1, [set if struct at_addr is called atalk_addr])
 fi
@@ -1320,6 +1325,7 @@ AM_CONDITIONAL(USE_BDB, test x$bdb_required = xyes)
 AM_CONDITIONAL(USE_APPLETALK, test x$netatalk_cv_ddp_enabled = xyes)
 AM_CONDITIONAL(HAVE_ATFUNCS, test x"$ac_neta_haveatfuncs" = x"yes")
 AM_CONDITIONAL(USE_INSTALL_PRIVILEGED, test x"$install_privileged" = x"yes")
+AM_CONDITIONAL(USE_GLIBC_AT_HEADER, test x$use_glibc_at_header = xyes)
 
 dnl Enable silent Automake rules if present
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])

--- a/sys/netatalk/Makefile.am
+++ b/sys/netatalk/Makefile.am
@@ -1,6 +1,12 @@
 # Makefile.am for sys/netatalk/
 
+# Install at.h only on systems that don't use glibc
+if USE_GLIBC_AT_HEADER
+pkginclude_HEADERS = aarp.h at_var.h ddp.h ddp_var.h endian.h phase2.h
+noinst_HEADERS = at.h
+else
 pkginclude_HEADERS = aarp.h at.h at_var.h ddp.h ddp_var.h endian.h phase2.h
+endif
 
 SOURCES = aarp.c at_control.c at_proto.c ddp_input.c ddp_output.c ddp_usrreq.c
 


### PR DESCRIPTION
The at.h header conflicts with at.h distributed with glibc. Therefore, install the header only on systems where glibc isn't distributed by default. We still want to distribute it in the tarball, however.

As a side note, our at.h is probably relevant only for NetBSD presently, which is the one non-Linux OS where an appletalk kernel module is being kept alive.