### PR TITLE
[2.2] autoconf: Fold a2boot and timelord under the appletalk conditional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -505,26 +505,6 @@ AC_ARG_ENABLE(install-privileged,
 	]
 )
 
-dnl ----- timelord compilation (enabled by default)
-AC_MSG_CHECKING([whether timelord should be compiled])
-compile_timelord=yes
-AC_ARG_ENABLE(timelord,
-	[  --enable-timelord       enable compilation of timelord server],
-	[compile_timelord="$enableval"],
-	[compile_timelord="yes"]
-)
-AC_MSG_RESULT([$compile_timelord])
-
-dnl ----- a2boot compilation (enabled by default)
-AC_MSG_CHECKING([whether a2boot should be compiled])
-compile_a2boot=yes
-AC_ARG_ENABLE(a2boot,
-	[  --enable-a2boot         enable compilation of Apple2 boot server],
-	[compile_a2boot="$enableval"],
-	[compile_a2boot="yes"]
-)
-AC_MSG_RESULT([$compile_a2boot])
-
 AC_ARG_WITH(uams-path,
 	[  --with-uams-path=PATH   path to UAMs [[PKGCONF/uams]]],[
 		uams_path="$withval"
@@ -1296,8 +1276,6 @@ AC_SUBST(CFLAGS)
 AC_SUBST(OVERWRITE_CONFIG)
 
 AM_CONDITIONAL(SOLARIS_MODULE, test x$solaris_module = xyes)
-AM_CONDITIONAL(COMPILE_TIMELORD, test x$compile_timelord = xyes)
-AM_CONDITIONAL(COMPILE_A2BOOT, test x$compile_a2boot = xyes)
 AM_CONDITIONAL(HAVE_LIBGCRYPT, test x$neta_cv_have_libgcrypt = xyes)
 AM_CONDITIONAL(HAVE_OPENSSL, test x$neta_cv_have_openssl = xyes)
 AM_CONDITIONAL(HAVE_ACLS, test x"$with_acl_support" = x"yes")

--- a/contrib/Makefile.am
+++ b/contrib/Makefile.am
@@ -2,14 +2,6 @@
 
 SUBDIRS = macusers misc shell_utils
 
-if COMPILE_TIMELORD
-SUBDIRS += timelord
-endif
-
-if COMPILE_A2BOOT
-SUBDIRS += a2boot
-endif
-
 if USE_APPLETALK
-SUBDIRS += printing
+SUBDIRS += a2boot printing timelord
 endif

--- a/macros/summary.m4
+++ b/macros/summary.m4
@@ -47,7 +47,6 @@ AC_DEFUN([AC_NETATALK_CONFIG_SUMMARY], [
 	AC_MSG_RESULT([         DDP (AppleTalk) support: $netatalk_cv_ddp_enabled])
 	if test "x$netatalk_cv_ddp_enabled" = "xyes"; then
 		AC_MSG_RESULT([         CUPS support:            $netatalk_cv_use_cups])
-		AC_MSG_RESULT([         Apple 2 boot support:    $compile_a2boot])
 	fi
 	AC_MSG_RESULT([         SLP support:             $netatalk_cv_srvloc])
 	AC_MSG_RESULT([         Zeroconf support:        $netatalk_cv_zeroconf])

--- a/man/man1/Makefile.am
+++ b/man/man1/Makefile.am
@@ -33,7 +33,9 @@ NONGENERATED_MANS	=	ad.1 \
 				unbin.1 \
 				unhex.1 \
 				unsingle.1
-ATALK_MANS = aecho.1 \
+
+if USE_APPLETALK
+NONGENERATED_MANS	+=	aecho.1 \
 				getzones.1 \
 				nbp.1 \
 				nbplkup.1 \
@@ -42,11 +44,8 @@ ATALK_MANS = aecho.1 \
 				pap.1 \
 				papstatus.1 \
 				psorder.1
-
-if USE_APPLETALK
-NONGENERATED_MANS += $(ATALK_MANS)
 endif
 
 man_MANS = $(GENERATED_MANS) $(NONGENERATED_MANS)
 CLEANFILES = $(GENERATED_MANS)
-EXTRA_DIST = $(TEMPLATE_FILES) $(NONGENERATED_MANS) $(ATALK_MANS)
+EXTRA_DIST = $(TEMPLATE_FILES) $(NONGENERATED_MANS)

--- a/man/man3/Makefile.am
+++ b/man/man3/Makefile.am
@@ -1,9 +1,9 @@
 # Makefile.am for man/man3
 
-ATALK_MANS = atalk_aton.3 nbp_name.3
+NONGENERATED_MANS =
 
 if USE_APPLETALK
-man_MANS = $(ATALK_MANS)
+NONGENERATED_MANS += atalk_aton.3 nbp_name.3
 endif
 
-EXTRA_DIST = $(ATALK_MANS)
+EXTRA_DIST = $(NONGENERATED_MANS)

--- a/man/man5/Makefile.am
+++ b/man/man5/Makefile.am
@@ -27,11 +27,9 @@ TEMPLATE_FILES = AppleVolumes.default.5.tmpl \
 	afp_signature.conf.5.tmpl \
 	afp_voluuid.conf.5.tmpl
 
-ATALK_MANS = atalkd.conf.5.tmpl papd.conf.5.tmpl
-
 if USE_APPLETALK
 GENERATED_MANS += atalkd.conf.5 papd.conf.5
-TEMPLATE_FILES += $(ATALK_MANS)
+TEMPLATE_FILES += atalkd.conf.5.tmpl papd.conf.5.tmpl
 endif
 
 NONGENERATED_MANS = AppleVolumes.5 AppleVolumes.system.5
@@ -40,4 +38,4 @@ man_MANS = $(GENERATED_MANS) $(NONGENERATED_MANS)
 
 CLEANFILES = $(GENERATED_MANS)
 
-EXTRA_DIST = $(TEMPLATE_FILES) $(NONGENERATED_MANS) $(ATALK_MANS)
+EXTRA_DIST = $(TEMPLATE_FILES) $(NONGENERATED_MANS)

--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -13,18 +13,18 @@ SUFFIXES = .tmpl .
 	    -e s@:NETATALK_VERSION:@${NETATALK_VERSION}@ \
 	    <$< >$@
 
-NONGENERATED_MANS = a2boot.8 timelord.8
+NONGENERATED_MANS =
 GENERATED_MANS    = afpd.8 cnid_dbd.8 cnid_metad.8
 TEMPLATE_FILES    = afpd.8.tmpl cnid_dbd.8.tmpl cnid_metad.8.tmpl
-ATALK_MANS        = atalkd.8.tmpl papd.8.tmpl papstatus.8.tmpl psf.8.tmpl
 
 if USE_APPLETALK
+NONGENERATED_MANS += a2boot.8 timelord.8
 GENERATED_MANS += atalkd.8 papd.8 papstatus.8 psf.8
-TEMPLATE_FILES += $(ATALK_MANS)
+TEMPLATE_FILES += atalkd.8.tmpl papd.8.tmpl papstatus.8.tmpl psf.8.tmpl
 endif
 
 man_MANS = $(GENERATED_MANS) $(NONGENERATED_MANS)
 
 CLEANFILES = $(GENERATED_MANS)
 
-EXTRA_DIST = $(TEMPLATE_FILES) $(NONGENERATED_MANS) $(ATALK_MANS)
+EXTRA_DIST = $(TEMPLATE_FILES) $(NONGENERATED_MANS)


### PR DESCRIPTION
- Remove the distinct --enable-a2boot and --enable-timelord config options, and fold them under --enable-ddp.
- Simplify appletalk conditionals in man makefiles