### PR TITLE
Fix variable substitution in manpages and docbook man/html pages #383

### DIFF
--- a/doc/manual/Makefile.am
+++ b/doc/manual/Makefile.am
@@ -49,6 +49,12 @@ HTML_PAGES = \
 	uniconv.1.html \
 	upgrade.html
 
+do_subst =  sed \
+  -i '' \
+  -e 's|@pkgconfdir[@]|$(sysconfdir)|g' \
+  -e 's|@localstatedir[@]|$(localstatedir)|g' \
+  -e 's|@prefix[@]|$(prefix)|g'
+
 DISTCLEANFILES = manual.xml
 
 if HAVE_XSLTPROC
@@ -56,6 +62,7 @@ CLEANFILES += $(HTML_PAGES)
 
 html-local: $(XML_PAGES)
 	@xsltproc $(HTML_STYLESHEET) manual.xml
+	$(do_subst)	$(HTML_PAGES)
 
 html-upload: html-local
 	scp $(HTML_PAGES) $$USER,netatalk@web.sourceforge.net:/home/project-web/netatalk/htdocs/3.1/htmldocs/

--- a/man/man1/Makefile.am
+++ b/man/man1/Makefile.am
@@ -1,5 +1,13 @@
 # Makefile.am for man/man1/
 
+SUFFIXES = .in .
+
+.in:
+	sed -e "s,[@]pkgconfdir[@],${sysconfdir},g" \
+		-e "s,[@]localstatedir[@],${localstatedir}," \
+		-e "s,[@]prefix[@],${prefix}," \
+	    <$< >$@
+
 man_MANS = \
 	ad.1 \
 	afpldaptest.1 \
@@ -11,5 +19,20 @@ man_MANS = \
 	macusers.1 \
 	netatalk-config.1 \
 	uniconv.1
+	
+TEMPLATES = \
+	ad.1.in \
+	afpldaptest.1.in \
+	afppasswd.1.in \
+	afpstats.1.in \
+	apple_dump.1.in \
+	asip-status.1.in \
+	dbd.1.in \
+	macusers.1.in \
+	netatalk-config.1.in \
+	uniconv.1.in
 
+CLEANFILES = $(man_MANS)
 DISTCLEANFILES = $(man_MANS)
+noinst_DATA = $(man_MANS)
+

--- a/man/man5/Makefile.am
+++ b/man/man5/Makefile.am
@@ -1,9 +1,25 @@
 # Makefile.am for man/man5/
 
+SUFFIXES = .in .
+
+.in:
+	sed -e "s,[@]pkgconfdir[@],${sysconfdir},g" \
+		-e "s,[@]localstatedir[@],${localstatedir}," \
+		-e "s,[@]prefix[@],${prefix}," \
+	    <$< >$@
+
 man_MANS = \
 	afp.conf.5 \
 	afp_signature.conf.5 \
 	afp_voluuid.conf.5 \
 	extmap.conf.5
 
+TEMPLATES = \
+	afp.conf.5.in \
+	afp_signature.conf.5.in \
+	afp_voluuid.conf.5.in \
+	extmap.conf.5.in
+
+CLEANFILES = $(man_MANS)
 DISTCLEANFILES = $(man_MANS)
+noinst_DATA = $(man_MANS)

--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -1,9 +1,25 @@
 ## Makefile.am for man/man8/
 
+SUFFIXES = .in .
+
+.in:
+	sed -e "s,[@]pkgconfdir[@],${sysconfdir},g" \
+		-e "s,[@]localstatedir[@],${localstatedir}," \
+		-e "s,[@]prefix[@],${prefix}," \
+	    <$< >$@
+
 man_MANS = \
 	afpd.8 \
 	cnid_dbd.8 \
 	cnid_metad.8 \
 	netatalk.8
 
+TEMPLATES = \
+	afpd.8.in \
+	cnid_dbd.8.in \
+	cnid_metad.8.in \
+	netatalk.8.in
+
+CLEANFILES = $(man_MANS)
 DISTCLEANFILES = $(man_MANS)
+noinst_DATA = $(man_MANS)


### PR DESCRIPTION
This commit fixes the failure to substitute installation path variables in manages and docbook man/html pages.