### PR TITLE
Change sed substitution syntax so it works for both GNU and BSD versions

### DIFF
--- a/doc/manual/Makefile.am
+++ b/doc/manual/Makefile.am
@@ -50,7 +50,7 @@ HTML_PAGES = \
 	upgrade.html
 
 do_subst =  sed \
-  -i '' \
+  -i.'' \
   -e 's|@pkgconfdir[@]|$(sysconfdir)|g' \
   -e 's|@localstatedir[@]|$(localstatedir)|g' \
   -e 's|@prefix[@]|$(prefix)|g'


### PR DESCRIPTION
This commit fixes the GNU sed syntax error resulting from commit ffbe839