### PR TITLE
[2.2] Update URL for css stylesheet in manual pages

### DIFF
--- a/doc/manual/html.xsl
+++ b/doc/manual/html.xsl
@@ -4,7 +4,7 @@
 	<xsl:param name="use.id.as.filename" select="'1'"/>
 	<xsl:param name="chunk.section.depth" select="0"></xsl:param>
 	<xsl:param name="chunk.separate.lots" select="1"></xsl:param>
-	<xsl:param name="html.stylesheet" select="'http://netatalk.sourceforge.net/css/netatalk.css'"/>
+	<xsl:param name="html.stylesheet" select="'https://netatalk.sourceforge.io/css/netatalk.css'"/>
 
 	<xsl:template name="user.header.navigation">
 		<xsl:variable name="codefile" select="document('netatalk.html',/)"/>

--- a/doc/manual/netatalk.html
+++ b/doc/manual/netatalk.html
@@ -5,7 +5,7 @@
           <a href="/" title="Return to Netatalk home">[main]</a>
           <a href="https://github.com/Netatalk/Netatalk/wiki" title="Netatalk Wiki">[wiki]</a>
           <a href="/2.2/htmldocs" title="Netatalk Manual">[documentation]</a>
-          <a href="https://sourceforge.net/projects/netatalk/files/netatalk/" title="Download Netatalk from sourceforge">[downloads]</a>
+          <a href="https://sourceforge.net/projects/netatalk/files/" title="Download Netatalk from SourceForge">[downloads]</a>
           <a href="/support.php" title="Support">[support]</a>
           <a href="/links.php" title="Netatalk related links">[links]</a>
           <img src="/gfx/end.gif" alt="" width="125" height="7" />


### PR DESCRIPTION
The css stylesheet for html manual pages is currently hard coded to an old sourceforge domain that isn't used anymore. As a result, the stylesheet isn't found and the manual pages stay unstyled. I think this is because the user agent refuses to load resources over insecure http in a https context.