### PR TITLE
[2.2] Recommend BerkeleyDB 5.3

### DIFF
--- a/doc/manual/netatalk/install.xml
+++ b/doc/manual/netatalk/install.xml
@@ -154,10 +154,14 @@ remote: Counting objects: 2503, done.
     <sect2>
       <title>Prerequisites</title>
 
-      <para>The following pieces of software are likely to have a package
-      available for your OS distribution of choice. Please see the <ulink
-      url="https://github.com/Netatalk/Netatalk/wiki/Installation-Notes">
-      Installation Notes</ulink> wiki page as a starting point.</para>
+      <note>
+        <para>The following pieces of software are likely to have a package
+        available for your OS distribution of choice.</para>
+
+        <para>Please see the <ulink
+        url="https://github.com/Netatalk/Netatalk/wiki/Installation-Notes">
+        Installation Notes</ulink> wiki page as a starting point.</para>
+      </note>
 
       <sect3>
         <title>System requirements</title>
@@ -182,7 +186,7 @@ remote: Counting objects: 2503, done.
       </sect3>
 
       <sect3>
-        <title>Required third party software</title>
+        <title>Required third-party software</title>
 
         <para>Netatalk makes use of Berkeley DB<indexterm>
             <primary>BDB</primary>
@@ -195,15 +199,18 @@ remote: Counting objects: 2503, done.
           <listitem>
             <para>minimum 4.6.x</para>
           </listitem>
+          <listitem>
+            <para>recommended 5.3.x</para>
+          </listitem>
         </itemizedlist>
 
       </sect3>
 
       <sect3>
-        <title>Optional third party software</title>
+        <title>Optional third-party software</title>
 
-        <para>Netatalk can use the following third party software to enhance
-        it's functionality.</para>
+        <para>Netatalk can use the following third-party software to enhance
+        its functionality.</para>
 
         <itemizedlist>
           <listitem>
@@ -315,12 +322,14 @@ remote: Counting objects: 2503, done.
 
         <itemizedlist>
           <listitem>
-            <para>--enable-[systemd/redhat-sysv/suse-sysv/gentoo/debian/netbsd/fhs]</para>
+            <para>--enable-[systemd/redhat-sysv/suse-sysv/gentoo/debian/netbsd]</para>
 
             <para>This option helps netatalk to determine where to install the
-		start scripts. The <command>--enable-systemd</command> option is
-                cross-platform and should work with most contemporary Linux or *BSD
-                distributions that have adopted systemd.</para>
+            start scripts.</para>
+
+            <para>The <command>--enable-systemd</command> option is
+            cross-platform and should work with most contemporary Linux or *BSD
+            distributions that have adopted systemd.</para>
           </listitem>
 
           <listitem>

--- a/macros/db3-check.m4
+++ b/macros/db3-check.m4
@@ -79,7 +79,7 @@ AC_DEFUN([AC_PATH_BDB],[
     trybdbdir=""
     dobdbsearch=yes
     bdb_search_dirs="/usr/local /usr"
-    search_subdirs="/ /db5 /db5.1 /db51 /db5.0 /db50 /db4.8 /db48 /db4.7 /db47 /db4.6 /db46 /db4"
+    search_subdirs="/ /db5 /db5.3 /db5.2 /db5.1 /db51 /db5.0 /db50 /db4.8 /db48 /db4.7 /db47 /db4.6 /db46 /db4"
 
     bdbfound=no
     savedcflags="$CFLAGS"


### PR DESCRIPTION
- Document recommended bdb version
- Don't list 'fhs' as a commonly used option -- it's meant for distribution packagers
- Improve layout
- Typo fixes
- Add checks to the autoconf macro for bdb 5.2 and 5.3