### PR TITLE
More elegant solution to variable substitution in manpages

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,6 +87,12 @@ AC_SEARCH_LIBS(gethostbyname, nsl)
 AC_SEARCH_LIBS(connect, socket)
 AC_CHECK_FUNCS(getifaddrs) dnl comes after gethostbyname and connect so it picks up the libs
 
+dnl We substitute these in the manpage templates.
+localstatedir=`eval echo $localstatedir`
+AC_SUBST(localstatedir)
+pkgconfdir=`eval echo $sysconfdir`
+AC_SUBST(pkgconfdir)
+
 AX_PTHREAD(, [AC_MSG_ERROR([missing pthread_sigmask])])
 
 AC_DEFINE(OPEN_NOFOLLOW_ERRNO, ELOOP, errno returned by open with O_NOFOLLOW)
@@ -301,8 +307,26 @@ AC_CONFIG_FILES([
   macros/Makefile
   man/Makefile
   man/man1/Makefile
+  man/man1/ad.1
+  man/man1/afpldaptest.1
+  man/man1/afppasswd.1
+  man/man1/afpstats.1
+  man/man1/apple_dump.1
+  man/man1/asip-status.1
+  man/man1/dbd.1
+  man/man1/macusers.1
+  man/man1/netatalk-config.1
+  man/man1/uniconv.1
   man/man5/Makefile
+  man/man5/afp.conf.5
+  man/man5/afp_signature.conf.5
+  man/man5/afp_voluuid.conf.5
+  man/man5/extmap.conf.5
   man/man8/Makefile
+  man/man8/afpd.8
+  man/man8/cnid_dbd.8
+  man/man8/cnid_metad.8
+  man/man8/netatalk.8
   test/Makefile
   test/afpd/Makefile
 ])

--- a/doc/manpages/man1/ad.1.xml
+++ b/doc/manpages/man1/ad.1.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">05 Dec 2015</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/afpldaptest.1.xml
+++ b/doc/manpages/man1/afpldaptest.1.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">22 Mar 2012</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv id="name">
@@ -43,7 +43,7 @@
     <title>DESCRIPTION</title>
 
     <para><command>afpldaptest</command> is a simple command to syntactically
-    check ldap parameters in :pkgconfdir:/afp.conf.</para>
+    check ldap parameters in @pkgconfdir@/afp.conf.</para>
 
   </refsect1>
 

--- a/doc/manpages/man1/afppasswd.1.xml
+++ b/doc/manpages/man1/afppasswd.1.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">22 Mar 2012</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/afpstats.1.xml
+++ b/doc/manpages/man1/afpstats.1.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">24 Mar 2013</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -36,7 +36,7 @@
     "<command>afpd -V</command>".</para>
 
     <para>"<option>afpstats = yes</option>" must be set in
-    <filename>:pkgconfdir:/afp.conf</filename>.</para>
+    <filename>@pkgconfdir@/afp.conf</filename>.</para>
 
   </refsect1>
 

--- a/doc/manpages/man1/apple_dump.1.xml
+++ b/doc/manpages/man1/apple_dump.1.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">12 Nov 2015</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/asip-status.1.xml
+++ b/doc/manpages/man1/asip-status.1.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">06 May 2016</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/dbd.1.xml
+++ b/doc/manpages/man1/dbd.1.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">12 Nov 2015</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/macusers.1.xml
+++ b/doc/manpages/man1/macusers.1.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">13 Oct 2011</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/megatron.1.xml
+++ b/doc/manpages/man1/megatron.1.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">02 Sep 2011</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/netatalk-config.1.xml
+++ b/doc/manpages/man1/netatalk-config.1.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">10 Nov 2015</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/uniconv.1.xml
+++ b/doc/manpages/man1/uniconv.1.xml
@@ -8,7 +8,7 @@
 
     <refmiscinfo class="date">19 Jan 2013</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">11 Apr 2023</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -415,7 +415,7 @@
                 <listitem>
                   <para>allows Random Number and Two-Way Random Number
                   Exchange for authentication (requires a separate file
-                  containing the passwords, either :pkgconfdir:/afppasswd file or
+                  containing the passwords, either @pkgconfdir@/afppasswd file or
                   the one specified via "<option>passwd file</option>"). See
                   <citerefentry>
                       <refentrytitle>afppasswd</refentrytitle>
@@ -541,7 +541,7 @@
 
           <listitem>
             <para>Sets the path to the Randnum UAM passwd file for this server
-            (default is :pkgconfdir:/afppasswd).</para>
+            (default is @pkgconfdir@/afppasswd).</para>
           </listitem>
         </varlistentry>
 
@@ -948,7 +948,7 @@
 
           <listitem>
             <para>Sets the path to the file which defines file extension
-            type/creator mappings. (default is :pkgconfdir:/extmap.conf).</para>
+            type/creator mappings. (default is @pkgconfdir@/extmap.conf).</para>
           </listitem>
         </varlistentry>
 
@@ -1035,7 +1035,7 @@
             characters. This option is useful for clustered environments, to
             provide fault isolation etc. By default, afpd generate signature
             and saving it to
-            <filename>:localstatedir:/netatalk/afp_signature.conf</filename>
+            <filename>@localstatedir@/netatalk/afp_signature.conf</filename>
             automatically (based on random number). See also
             asip-status(1).</para>
           </listitem>
@@ -1146,7 +1146,7 @@
             <para>Sets the database information to be stored in path. You have
             to specify a writable location, even if the volume is read only.
             The default is
-            <filename>:localstatedir:/netatalk/CNID/$v/</filename>.</para>
+            <filename>@localstatedir@/netatalk/CNID/$v/</filename>.</para>
           </listitem>
         </varlistentry>
 
@@ -2212,7 +2212,7 @@
     not by name. Netatalk needs a way to store these ID's in a persistent way,
     to achieve this several different CNID backends are available. The CNID
     Databases are by default located in the
-    <filename>:localstatedir:/netatalk/CNID/(volumename)/.AppleDB/</filename>
+    <filename>@localstatedir@/netatalk/CNID/(volumename)/.AppleDB/</filename>
     directory.</para>
 
     <variablelist>

--- a/doc/manpages/man5/afp_signature.conf.5.xml
+++ b/doc/manpages/man5/afp_signature.conf.5.xml
@@ -8,7 +8,7 @@
 
     <refmiscinfo class="date">23 Mar 2012</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -21,7 +21,7 @@
   <refsect1>
     <title>Description</title>
 
-    <para><filename>:localstatedir:/netatalk/afp_signature.conf</filename> is the
+    <para><filename>@localstatedir@/netatalk/afp_signature.conf</filename> is the
     configuration file used by <command>afpd</command> to specify
     server signature automagically. The configuration lines are
     composed like:</para>

--- a/doc/manpages/man5/afp_voluuid.conf.5.xml
+++ b/doc/manpages/man5/afp_voluuid.conf.5.xml
@@ -8,7 +8,7 @@
 
     <refmiscinfo class="date">27 June 2016</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -21,7 +21,7 @@
   <refsect1>
     <title>Description</title>
 
-    <para><filename>:localstatedir:/netatalk/afp_voluuid.conf</filename> is the
+    <para><filename>@localstatedir@/netatalk/afp_voluuid.conf</filename> is the
     configuration file used by <command>afpd</command> to specify
     UUID of all AFP volumes. The configuration
     lines are composed like:</para>

--- a/doc/manpages/man5/extmap.conf.5.xml
+++ b/doc/manpages/man5/extmap.conf.5.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">19 Jan 2013</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -19,7 +19,7 @@
 
   <refsynopsisdiv>
     <cmdsynopsis>
-      <command>:pkgconfdir:/extmap.conf</command>
+      <command>@pkgconfdir@/extmap.conf</command>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -27,7 +27,7 @@
     <title>Description</title>
 
     <para>
-    <filename>:pkgconfdir:/extmap.conf</filename> is the
+    <filename>@pkgconfdir@/extmap.conf</filename> is the
     configuration file used by <command>afpd</command> to
     specify file name extension mappings.</para>
 

--- a/doc/manpages/man8/afpd.8.xml
+++ b/doc/manpages/man8/afpd.8.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">19 Jan 2013</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -44,7 +44,7 @@
     interface to the Unix file system. It is normally started at boot time
     by <command>netatalk</command>(8).</para>
 
-    <para><filename>:pkgconfdir:/afp.conf</filename> is the configuration file
+    <para><filename>@pkgconfdir@/afp.conf</filename> is the configuration file
     used by <command>afpd</command> to determine the behavior and
     configuration of a file server.</para>
 
@@ -92,7 +92,7 @@
 
         <listitem>
           <para>Specifies the configuration file to use. (Defaults to
-          <filename>:pkgconfdir:/afp.conf</filename>.)</para>
+          <filename>@pkgconfdir@/afp.conf</filename>.)</para>
         </listitem>
       </varlistentry>
 
@@ -178,7 +178,7 @@
 
     <variablelist>
       <varlistentry>
-        <term><filename>:pkgconfdir:/afp.conf</filename></term>
+        <term><filename>@pkgconfdir@/afp.conf</filename></term>
 
         <listitem>
           <para>configuration file used by afpd</para>
@@ -186,7 +186,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>:localstatedir:/netatalk/afp_signature.conf</filename></term>
+        <term><filename>@localstatedir@/netatalk/afp_signature.conf</filename></term>
 
         <listitem>
           <para>list of server signature</para>
@@ -194,7 +194,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>:localstatedir:/netatalk/afp_voluuid.conf</filename></term>
+        <term><filename>@localstatedir@/netatalk/afp_voluuid.conf</filename></term>
 
         <listitem>
           <para>list of UUID for Time Machine volume</para>
@@ -202,7 +202,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>:pkgconfdir:/extmap.conf</filename></term>
+        <term><filename>@pkgconfdir@/extmap.conf</filename></term>
 
         <listitem>
           <para>file name extension mapping</para>
@@ -210,7 +210,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>:pkgconfdir:/msg/message.pid</filename></term>
+        <term><filename>@pkgconfdir@/msg/message.pid</filename></term>
 
         <listitem>
           <para>contains messages to be sent to users.</para>

--- a/doc/manpages/man8/cnid_dbd.8.xml
+++ b/doc/manpages/man8/cnid_dbd.8.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">10 Nov 2015</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man8/cnid_metad.8.xml
+++ b/doc/manpages/man8/cnid_metad.8.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">23 Mar 2012</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -70,7 +70,7 @@
         <listitem>
           <para>Use <emphasis remap="I">configuration file</emphasis> as the
             configuration file. The default is
-            <emphasis remap="I">:pkgconfdir:/afp.conf</emphasis>.</para>
+            <emphasis remap="I">@pkgconfdir@/afp.conf</emphasis>.</para>
         </listitem>
       </varlistentry>
 

--- a/doc/manpages/man8/netatalk.8.xml
+++ b/doc/manpages/man8/netatalk.8.xml
@@ -7,7 +7,7 @@
 
     <refmiscinfo class="date">13 Jun 2016</refmiscinfo>
 
-    <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
+    <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>
@@ -60,7 +60,7 @@
 
         <listitem>
           <para>Specifies the configuration file to use. (Defaults to
-          <filename>:pkgconfdir:/afp.conf</filename>.)</para>
+          <filename>@pkgconfdir@/afp.conf</filename>.)</para>
         </listitem>
       </varlistentry>
 
@@ -95,7 +95,7 @@
 
     <variablelist>
       <varlistentry>
-        <term><filename>:pkgconfdir:/afp.conf</filename></term>
+        <term><filename>@pkgconfdir@/afp.conf</filename></term>
 
         <listitem>
           <para>configuration file used by <command>netatalk</command>(8),

--- a/doc/manual/Makefile.am
+++ b/doc/manual/Makefile.am
@@ -51,8 +51,8 @@ HTML_PAGES = \
 
 do_subst =  sed \
   -i. \
-	-e 's|:pkgconfdir[:]|$(sysconfdir)|g' \
-  -e 's|:localstatedir[:]|$(localstatedir)|g'
+	-e 's|@pkgconfdir[@]|$(sysconfdir)|g' \
+  -e 's|@localstatedir[@]|$(localstatedir)|g'
 
 DISTCLEANFILES = manual.xml
 

--- a/man/man1/Makefile.am
+++ b/man/man1/Makefile.am
@@ -1,13 +1,5 @@
 # Makefile.am for man/man1/
 
-SUFFIXES = .in .
-
-.in:
-	sed -e s@:NETATALK_VERSION:@${NETATALK_VERSION}@ \
-	    -e s@:pkgconfdir:@${sysconfdir}@ \
-	    -e s@:localstatedir:@${localstatedir}@ \
-	    <$< >$@
-
 man_MANS = \
 	ad.1 \
 	afpldaptest.1 \
@@ -19,20 +11,5 @@ man_MANS = \
 	macusers.1 \
 	netatalk-config.1 \
 	uniconv.1
-	
-TEMPLATES = \
-	ad.1.in \
-	afpldaptest.1.in \
-	afppasswd.1.in \
-	afpstats.1.in \
-	apple_dump.1.in \
-	asip-status.1.in \
-	dbd.1.in \
-	macusers.1.in \
-	netatalk-config.1.in \
-	uniconv.1.in
 
-CLEANFILES = $(man_MANS)
-EXTRA_DIST = $(TEMPLATES)
-noinst_DATA = $(man_MANS)
-
+DISTCLEANFILES = $(man_MANS)

--- a/man/man1/ad.1.in
+++ b/man/man1/ad.1.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 05 Dec 2015
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "AD" "1" "05 Dec 2015" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "AD" "1" "05 Dec 2015" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/man/man1/afpldaptest.1.in
+++ b/man/man1/afpldaptest.1.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 22 Mar 2012
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "AFPLDAPTEST" "1" "22 Mar 2012" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "AFPLDAPTEST" "1" "22 Mar 2012" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -37,7 +37,7 @@ afpldaptest \- Syntactically check ldap parameters in afp\&.conf
 .SH "DESCRIPTION"
 .PP
 \fBafpldaptest\fR
-is a simple command to syntactically check ldap parameters in :pkgconfdir:/afp\&.conf\&.
+is a simple command to syntactically check ldap parameters in @pkgconfdir@/afp\&.conf\&.
 .SH "OPTIONS"
 .PP
 \fB\-u\fR \fIUSER\fR

--- a/man/man1/afppasswd.1.in
+++ b/man/man1/afppasswd.1.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 22 Mar 2012
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "AFPPASSWD" "1" "22 Mar 2012" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "AFPPASSWD" "1" "22 Mar 2012" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/man/man1/afpstats.1.in
+++ b/man/man1/afpstats.1.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 24 Mar 2013
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "AFPSTATS" "1" "24 Mar 2013" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "AFPSTATS" "1" "24 Mar 2013" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -42,7 +42,7 @@ list AFP statistics via D\-Bus IPC\&.
 must support D\-Bus\&. Check it by "\fBafpd \-V\fR"\&.
 .PP
 "\fBafpstats = yes\fR" must be set in
-:pkgconfdir:/afp\&.conf\&.
+@pkgconfdir@/afp\&.conf\&.
 .SH "SEE ALSO"
 .PP
 \fBafpd\fR(8),

--- a/man/man1/apple_dump.1.in
+++ b/man/man1/apple_dump.1.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 12 Nov 2015
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "APPLE_DUMP" "1" "12 Nov 2015" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "APPLE_DUMP" "1" "12 Nov 2015" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/man/man1/asip-status.1.in
+++ b/man/man1/asip-status.1.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 06 May 2016
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "ASIP\-STATUS\&.PL" "1" "06 May 2016" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "ASIP\-STATUS\&.PL" "1" "06 May 2016" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/man/man1/dbd.1.in
+++ b/man/man1/dbd.1.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 12 Nov 2015
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "DBD" "1" "12 Nov 2015" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "DBD" "1" "12 Nov 2015" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/man/man1/macusers.1.in
+++ b/man/man1/macusers.1.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 13 Oct 2011
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "MACUSERS" "1" "13 Oct 2011" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "MACUSERS" "1" "13 Oct 2011" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/man/man1/megatron.1.in
+++ b/man/man1/megatron.1.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 02 Sep 2011
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "MEGATRON" "1" "02 Sep 2011" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "MEGATRON" "1" "02 Sep 2011" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/man/man1/netatalk-config.1.in
+++ b/man/man1/netatalk-config.1.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 10 Nov 2015
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "NETATALK\-CONFIG" "1" "10 Nov 2015" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "NETATALK\-CONFIG" "1" "10 Nov 2015" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/man/man1/uniconv.1.in
+++ b/man/man1/uniconv.1.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 19 Jan 2013
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "UNICONV" "1" "19 Jan 2013" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "UNICONV" "1" "19 Jan 2013" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/man/man5/Makefile.am
+++ b/man/man5/Makefile.am
@@ -1,25 +1,9 @@
 # Makefile.am for man/man5/
 
-SUFFIXES = .in .
-
-.in:
-	sed -e s@:NETATALK_VERSION:@${NETATALK_VERSION}@ \
-	    -e s@:pkgconfdir:@${sysconfdir}@ \
-	    -e s@:localstatedir:@${localstatedir}@ \
-	    <$< >$@
-
 man_MANS = \
 	afp.conf.5 \
 	afp_signature.conf.5 \
 	afp_voluuid.conf.5 \
 	extmap.conf.5
 
-TEMPLATES = \
-	afp.conf.5.in \
-	afp_signature.conf.5.in \
-	afp_voluuid.conf.5.in \
-	extmap.conf.5.in
-
-CLEANFILES = $(man_MANS)
-EXTRA_DIST = $(TEMPLATES)
-noinst_DATA = $(man_MANS)
+DISTCLEANFILES = $(man_MANS)

--- a/man/man5/afp.conf.5.in
+++ b/man/man5/afp.conf.5.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 11 Apr 2023
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "AFP\&.CONF" "5" "11 Apr 2023" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "AFP\&.CONF" "5" "11 Apr 2023" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -322,7 +322,7 @@ uams_clrtxt\&.so
 .PP
 uams_randnum\&.so
 .RS 4
-allows Random Number and Two\-Way Random Number Exchange for authentication (requires a separate file containing the passwords, either :pkgconfdir:/afppasswd file or the one specified via "\fBpasswd file\fR")\&. See
+allows Random Number and Two\-Way Random Number Exchange for authentication (requires a separate file containing the passwords, either @pkgconfdir@/afppasswd file or the one specified via "\fBpasswd file\fR")\&. See
 \fBafppasswd\fR(1)
 for details\&. (legacy)
 .RE
@@ -398,7 +398,7 @@ Specifies the encoding of the volumes filesystem\&. By default, it is the same a
 .PP
 passwd file = \fIpath\fR \fB(G)\fR
 .RS 4
-Sets the path to the Randnum UAM passwd file for this server (default is :pkgconfdir:/afppasswd)\&.
+Sets the path to the Randnum UAM passwd file for this server (default is @pkgconfdir@/afppasswd)\&.
 .RE
 .PP
 passwd minlen = \fInumber\fR \fB(G)\fR
@@ -635,7 +635,7 @@ Default size is 8192, maximum size is 131072\&. Given value is rounded up to nea
 .PP
 extmap file = \fIpath\fR \fB(G)\fR
 .RS 4
-Sets the path to the file which defines file extension type/creator mappings\&. (default is :pkgconfdir:/extmap\&.conf)\&.
+Sets the path to the file which defines file extension type/creator mappings\&. (default is @pkgconfdir@/extmap\&.conf)\&.
 .RE
 .PP
 force xattr with sticky bit = \fIBOOLEAN\fR (default: \fIno\fR) \fB(G/V)\fR
@@ -680,7 +680,7 @@ Specifies the icon model that appears on clients\&. Defaults to off\&. Note that
 signature = <text> \fB(G)\fR
 .RS 4
 Specify a server signature\&. The maximum length is 16 characters\&. This option is useful for clustered environments, to provide fault isolation etc\&. By default, afpd generate signature and saving it to
-:localstatedir:/netatalk/afp_signature\&.conf
+@localstatedir@/netatalk/afp_signature\&.conf
 automatically (based on random number)\&. See also asip\-status\&.pl(1)\&.
 .RE
 .PP
@@ -739,7 +739,7 @@ Send optional AFP messages for vetoed files\&. Then whenever a client tries to a
 vol dbpath = \fIpath\fR \fB(G)/(V)\fR
 .RS 4
 Sets the database information to be stored in path\&. You have to specify a writable location, even if the volume is read only\&. The default is
-:localstatedir:/netatalk/CNID/$v/\&.
+@localstatedir@/netatalk/CNID/$v/\&.
 .RE
 .PP
 vol dbnest = \fIBOOLEAN\fR (default: \fIno\fR) \fB(G)\fR
@@ -1457,7 +1457,7 @@ and
 .SH "CNID BACKENDS"
 .PP
 The AFP protocol mostly refers to files and directories by ID and not by name\&. Netatalk needs a way to store these ID\*(Aqs in a persistent way, to achieve this several different CNID backends are available\&. The CNID Databases are by default located in the
-:localstatedir:/netatalk/CNID/(volumename)/\&.AppleDB/
+@localstatedir@/netatalk/CNID/(volumename)/\&.AppleDB/
 directory\&.
 .PP
 cdb

--- a/man/man5/afp_signature.conf.5.in
+++ b/man/man5/afp_signature.conf.5.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 23 Mar 2012
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "AFP_SIGNATURE\&.CONF" "5" "23 Mar 2012" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "AFP_SIGNATURE\&.CONF" "5" "23 Mar 2012" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,7 +31,7 @@
 afp_signature.conf \- Configuration file used by afpd(8) to specify server signature
 .SH "DESCRIPTION"
 .PP
-:localstatedir:/netatalk/afp_signature\&.conf
+@localstatedir@/netatalk/afp_signature\&.conf
 is the configuration file used by
 \fBafpd\fR
 to specify server signature automagically\&. The configuration lines are composed like:

--- a/man/man5/afp_voluuid.conf.5.in
+++ b/man/man5/afp_voluuid.conf.5.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 27 June 2016
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "AFP_VOLUUID\&.CONF" "5" "27 June 2016" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "AFP_VOLUUID\&.CONF" "5" "27 June 2016" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -31,7 +31,7 @@
 afp_voluuid.conf \- Configuration file used by afpd(8) to specify UUID for AFP volumes
 .SH "DESCRIPTION"
 .PP
-:localstatedir:/netatalk/afp_voluuid\&.conf
+@localstatedir@/netatalk/afp_voluuid\&.conf
 is the configuration file used by
 \fBafpd\fR
 to specify UUID of all AFP volumes\&. The configuration lines are composed like:

--- a/man/man5/extmap.conf.5.in
+++ b/man/man5/extmap.conf.5.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 19 Jan 2013
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "EXTMAP\&.CONF" "5" "19 Jan 2013" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "EXTMAP\&.CONF" "5" "19 Jan 2013" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -30,11 +30,11 @@
 .SH "NAME"
 extmap.conf \- Configuration file used by afpd(8) to specify file name extension mappings\&.
 .SH "SYNOPSIS"
-.HP \w'\fB:pkgconfdir:/extmap\&.conf\fR\ 'u
-\fB:pkgconfdir:/extmap\&.conf\fR
+.HP \w'\fB@pkgconfdir@/extmap\&.conf\fR\ 'u
+\fB@pkgconfdir@/extmap\&.conf\fR
 .SH "DESCRIPTION"
 .PP
-:pkgconfdir:/extmap\&.conf
+@pkgconfdir@/extmap\&.conf
 is the configuration file used by
 \fBafpd\fR
 to specify file name extension mappings\&.

--- a/man/man8/Makefile.am
+++ b/man/man8/Makefile.am
@@ -1,25 +1,9 @@
 ## Makefile.am for man/man8/
 
-SUFFIXES = .in .
-
-.in:
-	sed -e s@:NETATALK_VERSION:@${NETATALK_VERSION}@ \
-	    -e s@:pkgconfdir:@${sysconfdir}@ \
-	    -e s@:localstatedir:@${localstatedir}@ \
-	    <$< >$@
-
 man_MANS = \
 	afpd.8 \
 	cnid_dbd.8 \
 	cnid_metad.8 \
 	netatalk.8
 
-TEMPLATES = \
-	afpd.8.in \
-	cnid_dbd.8.in \
-	cnid_metad.8.in \
-	netatalk.8.in
-
-CLEANFILES = $(man_MANS)
-EXTRA_DIST = $(TEMPLATES)
-noinst_DATA = $(man_MANS)
+DISTCLEANFILES = $(man_MANS)

--- a/man/man8/afpd.8.in
+++ b/man/man8/afpd.8.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 19 Jan 2013
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "AFPD" "8" "19 Jan 2013" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "AFPD" "8" "19 Jan 2013" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -40,7 +40,7 @@ afpd \- Apple Filing Protocol daemon
 provides an Apple Filing Protocol (AFP) interface to the Unix file system\&. It is normally started at boot time by
 \fBnetatalk\fR(8)\&.
 .PP
-:pkgconfdir:/afp\&.conf
+@pkgconfdir@/afp\&.conf
 is the configuration file used by
 \fBafpd\fR
 to determine the behavior and configuration of a file server\&.
@@ -69,7 +69,7 @@ Print help and exit\&.
 \-F \fIconfigfile\fR
 .RS 4
 Specifies the configuration file to use\&. (Defaults to
-:pkgconfdir:/afp\&.conf\&.)
+@pkgconfdir@/afp\&.conf\&.)
 .RE
 .SH "SIGNALS"
 .PP
@@ -136,27 +136,27 @@ process will look in the message directory configured at build time for a file n
 .RE
 .SH "FILES"
 .PP
-:pkgconfdir:/afp\&.conf
+@pkgconfdir@/afp\&.conf
 .RS 4
 configuration file used by afpd
 .RE
 .PP
-:localstatedir:/netatalk/afp_signature\&.conf
+@localstatedir@/netatalk/afp_signature\&.conf
 .RS 4
 list of server signature
 .RE
 .PP
-:localstatedir:/netatalk/afp_voluuid\&.conf
+@localstatedir@/netatalk/afp_voluuid\&.conf
 .RS 4
 list of UUID for Time Machine volume
 .RE
 .PP
-:pkgconfdir:/extmap\&.conf
+@pkgconfdir@/extmap\&.conf
 .RS 4
 file name extension mapping
 .RE
 .PP
-:pkgconfdir:/msg/message\&.pid
+@pkgconfdir@/msg/message\&.pid
 .RS 4
 contains messages to be sent to users\&.
 .RE

--- a/man/man8/cnid_dbd.8.in
+++ b/man/man8/cnid_dbd.8.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 10 Nov 2015
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "CNID_DBD" "8" "10 Nov 2015" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "CNID_DBD" "8" "10 Nov 2015" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------

--- a/man/man8/cnid_metad.8.in
+++ b/man/man8/cnid_metad.8.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 23 Mar 2012
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "CNID_METAD" "8" "23 Mar 2012" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "CNID_METAD" "8" "23 Mar 2012" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -60,7 +60,7 @@ will also leave the standard input, standard output and standard error file desc
 Use
 \fIconfiguration file\fR
 as the configuration file\&. The default is
-\fI:pkgconfdir:/afp\&.conf\fR\&.
+\fI@pkgconfdir@/afp\&.conf\fR\&.
 .RE
 .PP
 \fB\-v, \-V\fR

--- a/man/man8/netatalk.8.in
+++ b/man/man8/netatalk.8.in
@@ -3,11 +3,11 @@
 .\"    Author: [FIXME: author] [see http://docbook.sf.net/el/author]
 .\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 13 Jun 2016
-.\"    Manual: :NETATALK_VERSION:
-.\"    Source: :NETATALK_VERSION:
+.\"    Manual: @NETATALK_VERSION@
+.\"    Source: @NETATALK_VERSION@
 .\"  Language: English
 .\"
-.TH "NETATALK" "8" "13 Jun 2016" ":NETATALK_VERSION:" ":NETATALK_VERSION:"
+.TH "NETATALK" "8" "13 Jun 2016" "@NETATALK_VERSION@" "@NETATALK_VERSION@"
 .\" -----------------------------------------------------------------
 .\" * Define some portability stuff
 .\" -----------------------------------------------------------------
@@ -51,7 +51,7 @@ Print version information and exit\&.
 \-F \fIconfigfile\fR
 .RS 4
 Specifies the configuration file to use\&. (Defaults to
-:pkgconfdir:/afp\&.conf\&.)
+@pkgconfdir@/afp\&.conf\&.)
 .RE
 .SH "SIGNALS"
 .PP
@@ -68,7 +68,7 @@ will cause the AFP daemon reload its configuration file\&.
 .RE
 .SH "FILES"
 .PP
-:pkgconfdir:/afp\&.conf
+@pkgconfdir@/afp\&.conf
 .RS 4
 configuration file used by
 \fBnetatalk\fR(8),


### PR DESCRIPTION
This is a much cleaner approach to substitution in the manpages, it uses the AC_SUBST macro in configure.ac. Have reverted the colon notation to the original at-mark notation. Have tested in Debian 12 and macOS