### PR TITLE
Fix variable substitution in configure summary

### DIFF
--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -112,12 +112,18 @@ AC_DEFUN([AC_NETATALK_DBUS_GLIB], [
   if test x"$withval" = x"yes" -a x"$atalk_cv_with_dbus" = x"no"; then
     AC_MSG_ERROR([afpstats requested but dbus-glib not found])
   fi
+  
+  if test x$prefix = xNONE ; then
+    prefix=/usr/local
+  fi
+  sysconfdir=`eval echo $sysconfdir`
+  AC_SUBST(sysconfdir)
 
   AC_ARG_WITH(
       dbus-sysconf-dir,
       [AS_HELP_STRING([--with-dbus-sysconf-dir=PATH],[Path to dbus system bus security configuration directory (default: ${sysconfdir}/dbus-1/system.d/)])],
       ac_cv_dbus_sysdir=$withval,
-      ac_cv_dbus_sysdir='${sysconfdir}/dbus-1/system.d'
+      ac_cv_dbus_sysdir=${sysconfdir}/dbus-1/system.d
   )
   DBUS_SYS_DIR=""
   if test x$atalk_cv_with_dbus = xyes ; then

--- a/macros/pam-check.m4
+++ b/macros/pam-check.m4
@@ -151,11 +151,17 @@ AC_DEFUN([AC_NETATALK_PATH_PAM], [
 	    AC_DEFINE(USE_PAM, 1, [Define to enable PAM support])
 	fi
 
+  if test x$prefix = xNONE ; then
+    prefix=/usr/local
+  fi
+  sysconfdir=`eval echo $sysconfdir`
+  AC_SUBST(sysconfdir)
+    
     AC_ARG_WITH(
         pam-confdir,
         [AS_HELP_STRING([--with-pam-confdir=PATH],[Path to PAM config dir (default: ${sysconfdir}/pam.d)])],
         ac_cv_pamdir=$withval,
-        ac_cv_pamdir='${sysconfdir}/pam.d'
+        ac_cv_pamdir=${sysconfdir}/pam.d
     )
 
     PAMDIR="$ac_cv_pamdir"


### PR DESCRIPTION
This issue has been here since the dawn of time. Removed extraneous quotation marks from netatalk and pam macros, used AC_SUBST macro to perform sysconfdir substitution