### PR TITLE
Use single substitution for all variables in macros, manpages and docbook man/html files #441

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,12 +87,6 @@ AC_SEARCH_LIBS(gethostbyname, nsl)
 AC_SEARCH_LIBS(connect, socket)
 AC_CHECK_FUNCS(getifaddrs) dnl comes after gethostbyname and connect so it picks up the libs
 
-dnl We substitute these in the manpage templates.
-localstatedir=`eval echo $localstatedir`
-AC_SUBST(localstatedir)
-pkgconfdir=`eval echo $sysconfdir`
-AC_SUBST(pkgconfdir)
-
 AX_PTHREAD(, [AC_MSG_ERROR([missing pthread_sigmask])])
 
 AC_DEFINE(OPEN_NOFOLLOW_ERRNO, ELOOP, errno returned by open with O_NOFOLLOW)

--- a/doc/manpages/man1/afpldaptest.1.xml
+++ b/doc/manpages/man1/afpldaptest.1.xml
@@ -43,7 +43,7 @@
     <title>DESCRIPTION</title>
 
     <para><command>afpldaptest</command> is a simple command to syntactically
-    check ldap parameters in @pkgconfdir@/afp.conf.</para>
+    check ldap parameters in @prefix@/etc/afp.conf.</para>
 
   </refsect1>
 

--- a/doc/manpages/man1/afpstats.1.xml
+++ b/doc/manpages/man1/afpstats.1.xml
@@ -36,7 +36,7 @@
     "<command>afpd -V</command>".</para>
 
     <para>"<option>afpstats = yes</option>" must be set in
-    <filename>@pkgconfdir@/afp.conf</filename>.</para>
+    <filename>@prefix@/etc/afp.conf</filename>.</para>
 
   </refsect1>
 

--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -415,7 +415,7 @@
                 <listitem>
                   <para>allows Random Number and Two-Way Random Number
                   Exchange for authentication (requires a separate file
-                  containing the passwords, either @pkgconfdir@/afppasswd file or
+                  containing the passwords, either @prefix@/etc/afppasswd file or
                   the one specified via "<option>passwd file</option>"). See
                   <citerefentry>
                       <refentrytitle>afppasswd</refentrytitle>
@@ -541,7 +541,7 @@
 
           <listitem>
             <para>Sets the path to the Randnum UAM passwd file for this server
-            (default is @pkgconfdir@/afppasswd).</para>
+            (default is @prefix@/etc/afppasswd).</para>
           </listitem>
         </varlistentry>
 
@@ -948,7 +948,7 @@
 
           <listitem>
             <para>Sets the path to the file which defines file extension
-            type/creator mappings. (default is @pkgconfdir@/extmap.conf).</para>
+            type/creator mappings. (default is @prefix@/etc/extmap.conf).</para>
           </listitem>
         </varlistentry>
 
@@ -1035,7 +1035,7 @@
             characters. This option is useful for clustered environments, to
             provide fault isolation etc. By default, afpd generate signature
             and saving it to
-            <filename>@localstatedir@/netatalk/afp_signature.conf</filename>
+            <filename>@prefix@/var/netatalk/afp_signature.conf</filename>
             automatically (based on random number). See also
             asip-status(1).</para>
           </listitem>
@@ -1146,7 +1146,7 @@
             <para>Sets the database information to be stored in path. You have
             to specify a writable location, even if the volume is read only.
             The default is
-            <filename>@localstatedir@/netatalk/CNID/$v/</filename>.</para>
+            <filename>@prefix@/var/netatalk/CNID/$v/</filename>.</para>
           </listitem>
         </varlistentry>
 
@@ -2212,7 +2212,7 @@
     not by name. Netatalk needs a way to store these ID's in a persistent way,
     to achieve this several different CNID backends are available. The CNID
     Databases are by default located in the
-    <filename>@localstatedir@/netatalk/CNID/(volumename)/.AppleDB/</filename>
+    <filename>@prefix@/var/netatalk/CNID/(volumename)/.AppleDB/</filename>
     directory.</para>
 
     <variablelist>

--- a/doc/manpages/man5/afp_signature.conf.5.xml
+++ b/doc/manpages/man5/afp_signature.conf.5.xml
@@ -21,7 +21,7 @@
   <refsect1>
     <title>Description</title>
 
-    <para><filename>@localstatedir@/netatalk/afp_signature.conf</filename> is the
+    <para><filename>@prefix@/var/netatalk/afp_signature.conf</filename> is the
     configuration file used by <command>afpd</command> to specify
     server signature automagically. The configuration lines are
     composed like:</para>

--- a/doc/manpages/man5/afp_voluuid.conf.5.xml
+++ b/doc/manpages/man5/afp_voluuid.conf.5.xml
@@ -21,7 +21,7 @@
   <refsect1>
     <title>Description</title>
 
-    <para><filename>@localstatedir@/netatalk/afp_voluuid.conf</filename> is the
+    <para><filename>@prefix@/var/netatalk/afp_voluuid.conf</filename> is the
     configuration file used by <command>afpd</command> to specify
     UUID of all AFP volumes. The configuration
     lines are composed like:</para>

--- a/doc/manpages/man5/extmap.conf.5.xml
+++ b/doc/manpages/man5/extmap.conf.5.xml
@@ -19,7 +19,7 @@
 
   <refsynopsisdiv>
     <cmdsynopsis>
-      <command>@pkgconfdir@/extmap.conf</command>
+      <command>@prefix@/etc/extmap.conf</command>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -27,7 +27,7 @@
     <title>Description</title>
 
     <para>
-    <filename>@pkgconfdir@/extmap.conf</filename> is the
+    <filename>@prefix@/etc/extmap.conf</filename> is the
     configuration file used by <command>afpd</command> to
     specify file name extension mappings.</para>
 

--- a/doc/manpages/man8/afpd.8.xml
+++ b/doc/manpages/man8/afpd.8.xml
@@ -44,7 +44,7 @@
     interface to the Unix file system. It is normally started at boot time
     by <command>netatalk</command>(8).</para>
 
-    <para><filename>@pkgconfdir@/afp.conf</filename> is the configuration file
+    <para><filename>@prefix@/etc/afp.conf</filename> is the configuration file
     used by <command>afpd</command> to determine the behavior and
     configuration of a file server.</para>
 
@@ -92,7 +92,7 @@
 
         <listitem>
           <para>Specifies the configuration file to use. (Defaults to
-          <filename>@pkgconfdir@/afp.conf</filename>.)</para>
+          <filename>@prefix@/etc/afp.conf</filename>.)</para>
         </listitem>
       </varlistentry>
 
@@ -178,7 +178,7 @@
 
     <variablelist>
       <varlistentry>
-        <term><filename>@pkgconfdir@/afp.conf</filename></term>
+        <term><filename>@prefix@/etc/afp.conf</filename></term>
 
         <listitem>
           <para>configuration file used by afpd</para>
@@ -186,7 +186,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@localstatedir@/netatalk/afp_signature.conf</filename></term>
+        <term><filename>@prefix@/var/netatalk/afp_signature.conf</filename></term>
 
         <listitem>
           <para>list of server signature</para>
@@ -194,7 +194,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@localstatedir@/netatalk/afp_voluuid.conf</filename></term>
+        <term><filename>@prefix@/var/netatalk/afp_voluuid.conf</filename></term>
 
         <listitem>
           <para>list of UUID for Time Machine volume</para>
@@ -202,7 +202,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@pkgconfdir@/extmap.conf</filename></term>
+        <term><filename>@prefix@/etc/extmap.conf</filename></term>
 
         <listitem>
           <para>file name extension mapping</para>
@@ -210,7 +210,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@pkgconfdir@/msg/message.pid</filename></term>
+        <term><filename>@prefix@/etc/msg/message.pid</filename></term>
 
         <listitem>
           <para>contains messages to be sent to users.</para>

--- a/doc/manpages/man8/cnid_metad.8.xml
+++ b/doc/manpages/man8/cnid_metad.8.xml
@@ -70,7 +70,7 @@
         <listitem>
           <para>Use <emphasis remap="I">configuration file</emphasis> as the
             configuration file. The default is
-            <emphasis remap="I">@pkgconfdir@/afp.conf</emphasis>.</para>
+            <emphasis remap="I">@prefix@/etc/afp.conf</emphasis>.</para>
         </listitem>
       </varlistentry>
 

--- a/doc/manpages/man8/netatalk.8.xml
+++ b/doc/manpages/man8/netatalk.8.xml
@@ -60,7 +60,7 @@
 
         <listitem>
           <para>Specifies the configuration file to use. (Defaults to
-          <filename>@pkgconfdir@/afp.conf</filename>.)</para>
+          <filename>@prefix@/etc/afp.conf</filename>.)</para>
         </listitem>
       </varlistentry>
 
@@ -95,7 +95,7 @@
 
     <variablelist>
       <varlistentry>
-        <term><filename>@pkgconfdir@/afp.conf</filename></term>
+        <term><filename>@prefix@/etc/afp.conf</filename></term>
 
         <listitem>
           <para>configuration file used by <command>netatalk</command>(8),

--- a/doc/manual/Makefile.am
+++ b/doc/manual/Makefile.am
@@ -3,6 +3,10 @@ XSLTPROC_FLAGS=@XSLTPROC_FLAGS@
 HTML_STYLESHEET=$(top_srcdir)/doc/html.xsl
 CLEANFILES =
 
+do_subst =  sed \
+	-i. \
+	-e 's|@prefix[@]|$(prefix)|g'
+
 XML_PAGES = \
 	manual.xml \
 	configuration.xml \
@@ -49,11 +53,6 @@ HTML_PAGES = \
 	uniconv.1.html \
 	upgrade.html
 
-do_subst =  sed \
-  -i. \
-	-e 's|@pkgconfdir[@]|$(sysconfdir)|g' \
-  -e 's|@localstatedir[@]|$(localstatedir)|g'
-
 DISTCLEANFILES = manual.xml
 
 if HAVE_XSLTPROC
@@ -61,7 +60,7 @@ CLEANFILES += $(HTML_PAGES)
 
 html-local: $(XML_PAGES)
 	@xsltproc $(HTML_STYLESHEET) manual.xml
-	$(do_subst)	$(HTML_PAGES)
+	$(do_subst) $(HTML_PAGES)
 	rm -f *.
 
 html-upload: html-local

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -116,14 +116,12 @@ AC_DEFUN([AC_NETATALK_DBUS_GLIB], [
   if test x$prefix = xNONE ; then
     prefix=/usr/local
   fi
-  sysconfdir=`eval echo $sysconfdir`
-  AC_SUBST(sysconfdir)
-
+  
   AC_ARG_WITH(
       dbus-sysconf-dir,
-      [AS_HELP_STRING([--with-dbus-sysconf-dir=PATH],[Path to dbus system bus security configuration directory (default: ${sysconfdir}/dbus-1/system.d/)])],
+      [AS_HELP_STRING([--with-dbus-sysconf-dir=PATH],[Path to dbus system bus security configuration directory (default: ${sprefix}/etc/dbus-1/system.d/)])],
       ac_cv_dbus_sysdir=$withval,
-      ac_cv_dbus_sysdir=${sysconfdir}/dbus-1/system.d
+      ac_cv_dbus_sysdir=${prefix}/etc/dbus-1/system.d
   )
   DBUS_SYS_DIR=""
   if test x$atalk_cv_with_dbus = xyes ; then

--- a/macros/pam-check.m4
+++ b/macros/pam-check.m4
@@ -154,14 +154,12 @@ AC_DEFUN([AC_NETATALK_PATH_PAM], [
   if test x$prefix = xNONE ; then
     prefix=/usr/local
   fi
-  sysconfdir=`eval echo $sysconfdir`
-  AC_SUBST(sysconfdir)
-    
+
     AC_ARG_WITH(
         pam-confdir,
-        [AS_HELP_STRING([--with-pam-confdir=PATH],[Path to PAM config dir (default: ${sysconfdir}/pam.d)])],
+        [AS_HELP_STRING([--with-pam-confdir=PATH],[Path to PAM config dir (default: ${prefix}/etc/pam.d)])],
         ac_cv_pamdir=$withval,
-        ac_cv_pamdir=${sysconfdir}/pam.d
+        ac_cv_pamdir=${prefix}/etc/pam.d
     )
 
     PAMDIR="$ac_cv_pamdir"

--- a/man/man1/afpldaptest.1.in
+++ b/man/man1/afpldaptest.1.in
@@ -37,7 +37,7 @@ afpldaptest \- Syntactically check ldap parameters in afp\&.conf
 .SH "DESCRIPTION"
 .PP
 \fBafpldaptest\fR
-is a simple command to syntactically check ldap parameters in @pkgconfdir@/afp\&.conf\&.
+is a simple command to syntactically check ldap parameters in @prefix@/etc/afp\&.conf\&.
 .SH "OPTIONS"
 .PP
 \fB\-u\fR \fIUSER\fR

--- a/man/man1/afpstats.1.in
+++ b/man/man1/afpstats.1.in
@@ -42,7 +42,7 @@ list AFP statistics via D\-Bus IPC\&.
 must support D\-Bus\&. Check it by "\fBafpd \-V\fR"\&.
 .PP
 "\fBafpstats = yes\fR" must be set in
-@pkgconfdir@/afp\&.conf\&.
+@prefix@/etc/afp\&.conf\&.
 .SH "SEE ALSO"
 .PP
 \fBafpd\fR(8),

--- a/man/man5/afp.conf.5.in
+++ b/man/man5/afp.conf.5.in
@@ -322,7 +322,7 @@ uams_clrtxt\&.so
 .PP
 uams_randnum\&.so
 .RS 4
-allows Random Number and Two\-Way Random Number Exchange for authentication (requires a separate file containing the passwords, either @pkgconfdir@/afppasswd file or the one specified via "\fBpasswd file\fR")\&. See
+allows Random Number and Two\-Way Random Number Exchange for authentication (requires a separate file containing the passwords, either @prefix@/etc/afppasswd file or the one specified via "\fBpasswd file\fR")\&. See
 \fBafppasswd\fR(1)
 for details\&. (legacy)
 .RE
@@ -398,7 +398,7 @@ Specifies the encoding of the volumes filesystem\&. By default, it is the same a
 .PP
 passwd file = \fIpath\fR \fB(G)\fR
 .RS 4
-Sets the path to the Randnum UAM passwd file for this server (default is @pkgconfdir@/afppasswd)\&.
+Sets the path to the Randnum UAM passwd file for this server (default is @prefix@/etc/afppasswd)\&.
 .RE
 .PP
 passwd minlen = \fInumber\fR \fB(G)\fR
@@ -635,7 +635,7 @@ Default size is 8192, maximum size is 131072\&. Given value is rounded up to nea
 .PP
 extmap file = \fIpath\fR \fB(G)\fR
 .RS 4
-Sets the path to the file which defines file extension type/creator mappings\&. (default is @pkgconfdir@/extmap\&.conf)\&.
+Sets the path to the file which defines file extension type/creator mappings\&. (default is @prefix@/etc/extmap\&.conf)\&.
 .RE
 .PP
 force xattr with sticky bit = \fIBOOLEAN\fR (default: \fIno\fR) \fB(G/V)\fR
@@ -680,7 +680,7 @@ Specifies the icon model that appears on clients\&. Defaults to off\&. Note that
 signature = <text> \fB(G)\fR
 .RS 4
 Specify a server signature\&. The maximum length is 16 characters\&. This option is useful for clustered environments, to provide fault isolation etc\&. By default, afpd generate signature and saving it to
-@localstatedir@/netatalk/afp_signature\&.conf
+@prefix@/var/netatalk/afp_signature\&.conf
 automatically (based on random number)\&. See also asip\-status\&.pl(1)\&.
 .RE
 .PP
@@ -739,7 +739,7 @@ Send optional AFP messages for vetoed files\&. Then whenever a client tries to a
 vol dbpath = \fIpath\fR \fB(G)/(V)\fR
 .RS 4
 Sets the database information to be stored in path\&. You have to specify a writable location, even if the volume is read only\&. The default is
-@localstatedir@/netatalk/CNID/$v/\&.
+@prefix@/var/netatalk/CNID/$v/\&.
 .RE
 .PP
 vol dbnest = \fIBOOLEAN\fR (default: \fIno\fR) \fB(G)\fR
@@ -1457,7 +1457,7 @@ and
 .SH "CNID BACKENDS"
 .PP
 The AFP protocol mostly refers to files and directories by ID and not by name\&. Netatalk needs a way to store these ID\*(Aqs in a persistent way, to achieve this several different CNID backends are available\&. The CNID Databases are by default located in the
-@localstatedir@/netatalk/CNID/(volumename)/\&.AppleDB/
+@prefix@/var/netatalk/CNID/(volumename)/\&.AppleDB/
 directory\&.
 .PP
 cdb

--- a/man/man5/afp_signature.conf.5.in
+++ b/man/man5/afp_signature.conf.5.in
@@ -31,7 +31,7 @@
 afp_signature.conf \- Configuration file used by afpd(8) to specify server signature
 .SH "DESCRIPTION"
 .PP
-@localstatedir@/netatalk/afp_signature\&.conf
+@prefix@/var/netatalk/afp_signature\&.conf
 is the configuration file used by
 \fBafpd\fR
 to specify server signature automagically\&. The configuration lines are composed like:

--- a/man/man5/afp_voluuid.conf.5.in
+++ b/man/man5/afp_voluuid.conf.5.in
@@ -31,7 +31,7 @@
 afp_voluuid.conf \- Configuration file used by afpd(8) to specify UUID for AFP volumes
 .SH "DESCRIPTION"
 .PP
-@localstatedir@/netatalk/afp_voluuid\&.conf
+@prefix@/var/netatalk/afp_voluuid\&.conf
 is the configuration file used by
 \fBafpd\fR
 to specify UUID of all AFP volumes\&. The configuration lines are composed like:

--- a/man/man5/extmap.conf.5.in
+++ b/man/man5/extmap.conf.5.in
@@ -30,11 +30,11 @@
 .SH "NAME"
 extmap.conf \- Configuration file used by afpd(8) to specify file name extension mappings\&.
 .SH "SYNOPSIS"
-.HP \w'\fB@pkgconfdir@/extmap\&.conf\fR\ 'u
-\fB@pkgconfdir@/extmap\&.conf\fR
+.HP \w'\fB@prefix@/etc/extmap\&.conf\fR\ 'u
+\fB@prefix@/etc/extmap\&.conf\fR
 .SH "DESCRIPTION"
 .PP
-@pkgconfdir@/extmap\&.conf
+@prefix@/etc/extmap\&.conf
 is the configuration file used by
 \fBafpd\fR
 to specify file name extension mappings\&.

--- a/man/man8/afpd.8.in
+++ b/man/man8/afpd.8.in
@@ -40,7 +40,7 @@ afpd \- Apple Filing Protocol daemon
 provides an Apple Filing Protocol (AFP) interface to the Unix file system\&. It is normally started at boot time by
 \fBnetatalk\fR(8)\&.
 .PP
-@pkgconfdir@/afp\&.conf
+@prefix@/etc/afp\&.conf
 is the configuration file used by
 \fBafpd\fR
 to determine the behavior and configuration of a file server\&.
@@ -69,7 +69,7 @@ Print help and exit\&.
 \-F \fIconfigfile\fR
 .RS 4
 Specifies the configuration file to use\&. (Defaults to
-@pkgconfdir@/afp\&.conf\&.)
+@prefix@/etc/afp\&.conf\&.)
 .RE
 .SH "SIGNALS"
 .PP
@@ -136,27 +136,27 @@ process will look in the message directory configured at build time for a file n
 .RE
 .SH "FILES"
 .PP
-@pkgconfdir@/afp\&.conf
+@prefix@/etc/afp\&.conf
 .RS 4
 configuration file used by afpd
 .RE
 .PP
-@localstatedir@/netatalk/afp_signature\&.conf
+@prefix@/var/netatalk/afp_signature\&.conf
 .RS 4
 list of server signature
 .RE
 .PP
-@localstatedir@/netatalk/afp_voluuid\&.conf
+@prefix@/var/netatalk/afp_voluuid\&.conf
 .RS 4
 list of UUID for Time Machine volume
 .RE
 .PP
-@pkgconfdir@/extmap\&.conf
+@prefix@/etc/extmap\&.conf
 .RS 4
 file name extension mapping
 .RE
 .PP
-@pkgconfdir@/msg/message\&.pid
+@prefix@/etc/msg/message\&.pid
 .RS 4
 contains messages to be sent to users\&.
 .RE

--- a/man/man8/cnid_metad.8.in
+++ b/man/man8/cnid_metad.8.in
@@ -60,7 +60,7 @@ will also leave the standard input, standard output and standard error file desc
 Use
 \fIconfiguration file\fR
 as the configuration file\&. The default is
-\fI@pkgconfdir@/afp\&.conf\fR\&.
+\fI@prefix@/etc/afp\&.conf\fR\&.
 .RE
 .PP
 \fB\-v, \-V\fR

--- a/man/man8/netatalk.8.in
+++ b/man/man8/netatalk.8.in
@@ -51,7 +51,7 @@ Print version information and exit\&.
 \-F \fIconfigfile\fR
 .RS 4
 Specifies the configuration file to use\&. (Defaults to
-@pkgconfdir@/afp\&.conf\&.)
+@prefix@/etc/afp\&.conf\&.)
 .RE
 .SH "SIGNALS"
 .PP
@@ -68,7 +68,7 @@ will cause the AFP daemon reload its configuration file\&.
 .RE
 .SH "FILES"
 .PP
-@pkgconfdir@/afp\&.conf
+@prefix@/etc/afp\&.conf
 .RS 4
 configuration file used by
 \fBnetatalk\fR(8),


### PR DESCRIPTION
Tested on FreeBSD, Debian and macOS:
Config summary works
Substitution in man/man1, man/man5 and man/man8 works
Substitution in manual html files works
make distcheck works in Debian and FreeBSD
No NONE's in sight
Never again...