### PR TITLE
Revert "[2.2] Update atalkd.service to be consistent with other init scripts."

### DIFF
--- a/distrib/initscripts/atalkd.service.tmpl
+++ b/distrib/initscripts/atalkd.service.tmpl
@@ -9,10 +9,7 @@ After=network-online.target
 [Service]
 Type=forking
 GuessMainPID=no
-ExecStartPre=/bin/sh -c 'systemctl set-environment ATALK_NAME=$$(hostname|cut -d. -f1)'
 ExecStart=:SBINDIR:/atalkd
-ExecStartPost=:BINDIR:/nbprgstr -p 4 "${ATALK_NAME}:Workstation"
-ExecStartPost=:BINDIR:/nbprgstr -p 4 "${ATALK_NAME}:netatalk"
 Restart=always
 RestartSec=1
 


### PR DESCRIPTION
Reverts Netatalk/netatalk#372

I found atalkd and the other appletalk services to be unable to start up when other instances of atalkd run on other hosts on the same LAN.