### PR TITLE
CVE-2023-42464: Validate data type in dalloc_value_for_key()

### DIFF
--- a/etc/afpd/spotlight.c
+++ b/etc/afpd/spotlight.c
@@ -862,7 +862,8 @@ static int sl_rpc_openQuery(AFPObj *obj,
     /* convert spotlight query charset to host charset */
     sl_query = dalloc_value_for_key(query, "DALLOC_CTX", 0,
                                     "DALLOC_CTX", 1,
-                                    "kMDQueryString");
+                                    "kMDQueryString",
+                                    "char *");
     if (sl_query == NULL) {
         EC_FAIL;
     }
@@ -893,14 +894,14 @@ static int sl_rpc_openQuery(AFPObj *obj,
     slq->slq_ctx2 = *uint64;
 
     reqinfo = dalloc_value_for_key(query, "DALLOC_CTX", 0, "DALLOC_CTX", 1,
-                                   "kMDAttributeArray");
+                                   "kMDAttributeArray", "sl_array_t");
     if (reqinfo == NULL) {
         EC_FAIL;
     }
     slq->slq_reqinfo = talloc_steal(slq, reqinfo);
 
     scope_array = dalloc_value_for_key(query, "DALLOC_CTX", 0, "DALLOC_CTX", 1,
-                                       "kMDScopeArray");
+                                       "kMDScopeArray", "sl_array_t");
     if (scope_array == NULL) {
         scope = g_uri_escape_string(v->v_path,
                                     G_URI_RESERVED_CHARS_ALLOWED_IN_PATH, TRUE);
@@ -925,7 +926,7 @@ static int sl_rpc_openQuery(AFPObj *obj,
     LOG(log_debug, logtype_sl, "Search scope: \"%s\"", slq->slq_scope);
 
     cnids = dalloc_value_for_key(query, "DALLOC_CTX", 0, "DALLOC_CTX", 1,
-                                 "kMDQueryItemArray");
+                                 "kMDQueryItemArray", "sl_array_t");
     if (cnids) {
         EC_ZERO_LOG( sl_createCNIDArray(slq, cnids->ca_cnids) );
     }
@@ -1089,7 +1090,8 @@ static int sl_rpc_storeAttributesForOIDArray(const AFPObj *obj,
      * that seems to be candidates for updating filesystem metadata.
      */
 
-    if ((sl_time = dalloc_value_for_key(query, "DALLOC_CTX", 0, "DALLOC_CTX", 1, "DALLOC_CTX", 1, "kMDItemFSContentChangeDate"))) {
+    if ((sl_time = dalloc_value_for_key(query, "DALLOC_CTX", 0, "DALLOC_CTX", 1, "DALLOC_CTX", 1,
+                                        "kMDItemFSContentChangeDate", "sl_time_t"))) {
         struct utimbuf utimes;
         utimes.actime = utimes.modtime = sl_time->tv_sec;
         utime(path, &utimes);

--- a/libatalk/talloc/dalloc.c
+++ b/libatalk/talloc/dalloc.c
@@ -215,7 +215,7 @@ void *dalloc_value_for_key(const DALLOC_CTX *d, ...)
     EC_INIT;
     void *p = NULL;
     va_list args;
-    const char *type;
+    const char *type = NULL;
     int elem;
     const char *elemtype;
     char *s;
@@ -241,9 +241,18 @@ void *dalloc_value_for_key(const DALLOC_CTX *d, ...)
             break;
         }            
     }
-    va_end(args);
+    if (p == NULL) {
+        EC_FAIL;
+    }
+
+    type = va_arg(args, const char *);
+    if (STRCMP(talloc_get_name(p), !=, type)) {
+        p = NULL;
+    }
+
 
 EC_CLEANUP:
+    va_end(args);
     if (ret != 0)
         p = NULL;
     return p;


### PR DESCRIPTION
A Type Confusion vulnerability was found in the Spotlight RPC functions in Netatalk's afpd daemon. When parsing Spotlight RPC packets, one encoded data structure is a key-value style dictionary where the keys are character strings, and the values can be any of the supported types in the underlying protocol. Due to a lack of type checking in callers of the dalloc_value_for_key() function, which returns the object associated with a key, a malicious actor may be able to fully control the value of the pointer and theoretically achieve Remote Code Execution on the host.

The underlying code for Spotlight queries in Netatalk shares a common heritage with Samba, and hence the root cause and fix are logically identical with those described in CVE-2023-34967.