### PR TITLE
Use the correct macro in tcp-wrappers check

### DIFF
--- a/macros/tcp-wrappers.m4
+++ b/macros/tcp-wrappers.m4
@@ -18,18 +18,26 @@ AC_DEFUN([AC_NETATALK_TCP_WRAPPERS], [
 		saved_LIBS=$LIBS
 		W_LIBS="-lwrap"
 		LIBS="$LIBS $W_LIBS"
-		AC_LINK_IFELSE([AC_LANG_SOURCE([[ int allow_severity = 0; int deny_severity = 0; extern char hosts_access(void);]
-			,[hosts_access();]])]
-			, netatalk_cv_tcpwrap=yes ,
+		AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+			#include <tcpd.h>
+		]],[[
+			int allow_severity = 0;
+			int deny_severity = 0;
+		]])],
+			netatalk_cv_tcpwrap=yes,
    			[
 				LIBS=$saved_LIBS
 				W_LIBS="-lwrap -lnsl"
 				LIBS="$LIBS $W_LIBS"
-				AC_LINK_IFELSE([AC_LANG_SOURCE([[ int allow_severity = 0; int deny_severity = 0; extern char hosts_access(void);]
-					,[hosts_access();]])]
-					, netatalk_cv_tcpwrap=yes , netatalk_cv_tcpwrap=no)
-			]
-			, netatalk_cv_tcpwrap=cross)
+				AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+					#include <tcpd.h>
+				]],[[
+					int allow_severity = 0;
+					int deny_severity = 0;
+				]])],
+				netatalk_cv_tcpwrap=yes, netatalk_cv_tcpwrap=no)
+			],
+			netatalk_cv_tcpwrap=cross)
 
 		LIBS=$saved_LIBS
 	fi


### PR DESCRIPTION
The migration path for the obsolete `AC_TRY_LINK` macro is this:

```
AC_LINK_IFELSE(
            [AC_LANG_PROGRAM([[includes]],
               [[function-body]])],
            [action-if-true],
            [action-if-false])
```

We mistakenly used `AC_LANG_SOURCE` in the tcp-wrappers check. This should take care of it.

https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html