### PR TITLE
Fix libevent2 linking on OpenIndiana

### DIFF
--- a/etc/netatalk/Makefile.am
+++ b/etc/netatalk/Makefile.am
@@ -1,4 +1,4 @@
-# Makefile.am for etc/netatlk/
+# Makefile.am for etc/netatalk/
 
 pkgconfdir = @PKGCONFDIR@
 
@@ -18,7 +18,7 @@ netatalk_LDADD = \
 	@ZEROCONF_LIBS@ \
 	$(top_builddir)/libatalk/libatalk.la
 
-netatalk_LDFLAGS = @LIBEVENT_LDFLAGS@ -levent
+netatalk_LDFLAGS = @LIBEVENT_LIBS@
 
 netatalk_CFLAGS += @LIBEVENT_CFLAGS@
 

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -233,7 +233,6 @@ AC_DEFUN([AC_NETATALK_LIBEVENT], [
     PKG_CHECK_MODULES(LIBEVENT, libevent, , [AC_MSG_ERROR([couldn't find libevent with pkg-config])])
     AC_SUBST(LIBEVENT_CFLAGS)
     AC_SUBST(LIBEVENT_LIBS)
-    AC_SUBST(LIBEVENT_LDFLAGS)
 ])
 
 dnl Whether to disable bundled tdb


### PR DESCRIPTION
This error occurs because of incorrect syntax in the netatalk binary makefile and the libevent check macro