### PR TITLE
Remove substitutions for configurable file paths in man pages

### DIFF
--- a/doc/manpages/man1/afpldaptest.1.xml
+++ b/doc/manpages/man1/afpldaptest.1.xml
@@ -45,7 +45,7 @@
     <title>DESCRIPTION</title>
 
     <para><command>afpldaptest</command> is a simple command to syntactically
-    check ldap parameters in @prefix@/etc/afp.conf.</para>
+    check ldap parameters in afp.conf.</para>
 
   </refsect1>
 

--- a/doc/manpages/man1/afpstats.1.xml
+++ b/doc/manpages/man1/afpstats.1.xml
@@ -38,7 +38,7 @@
     "<command>afpd -V</command>".</para>
 
     <para>"<option>afpstats = yes</option>" must be set in
-    <filename>@prefix@/etc/afp.conf</filename>.</para>
+    <filename>afp.conf</filename>.</para>
 
   </refsect1>
 

--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -417,7 +417,7 @@
                 <listitem>
                   <para>allows Random Number and Two-Way Random Number
                   Exchange for authentication (requires a separate file
-                  containing the passwords, either @prefix@/etc/afppasswd file or
+                  containing the passwords, either the default afppasswd file or
                   the one specified via "<option>passwd file</option>"). See
                   <citerefentry>
                       <refentrytitle>afppasswd</refentrytitle>
@@ -542,8 +542,7 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>Sets the path to the Randnum UAM passwd file for this server
-            (default is @prefix@/etc/afppasswd).</para>
+            <para>Sets the path to the Randnum UAM passwd file for this server.</para>
           </listitem>
         </varlistentry>
 
@@ -950,7 +949,7 @@
 
           <listitem>
             <para>Sets the path to the file which defines file extension
-            type/creator mappings. (default is @prefix@/etc/extmap.conf).</para>
+            type/creator mappings.</para>
           </listitem>
         </varlistentry>
 
@@ -1035,10 +1034,10 @@
           <listitem>
             <para>Specify a server signature. The maximum length is 16
             characters. This option is useful for clustered environments, to
-            provide fault isolation etc. By default, afpd generate signature
-            and saving it to
-            <filename>@prefix@/var/netatalk/afp_signature.conf</filename>
-            automatically (based on random number). See also
+            provide fault isolation etc. By default, afpd generates a signature
+            and saves it to a file called
+            <filename>afp_signature.conf</filename>
+            automatically (based on random numbers). See also
             asip-status(1).</para>
           </listitem>
         </varlistentry>
@@ -1145,10 +1144,8 @@
           <type>(G)/(V)</type></term>
 
           <listitem>
-            <para>Sets the database information to be stored in path. You have
-            to specify a writable location, even if the volume is read only.
-            The default is
-            <filename>@prefix@/var/netatalk/CNID/$v/</filename>.</para>
+            <para>Sets the path where the database information will be stored. You have
+            to specify a writable location, even if the volume is read only.</para>
           </listitem>
         </varlistentry>
 
@@ -2210,12 +2207,11 @@
   <refsect1>
     <title>CNID backends</title>
 
-    <para>The AFP protocol mostly refers to files and directories by ID and
-    not by name. Netatalk needs a way to store these ID's in a persistent way,
-    to achieve this several different CNID backends are available. The CNID
-    Databases are by default located in the
-    <filename>@prefix@/var/netatalk/CNID/(volumename)/.AppleDB/</filename>
-    directory.</para>
+    <para>The AFP protocol primarily refers to files and directories by ID and
+    not by name. Netatalk needs a way to store these IDs in a persistent way.
+    To achieve this, Netatalk provides multiple CNID backends with different
+    capabilities. The CNID databases are by default located under localstatedir.
+    </para>
 
     <variablelist>
       <varlistentry>

--- a/doc/manpages/man5/afp_signature.conf.5.xml
+++ b/doc/manpages/man5/afp_signature.conf.5.xml
@@ -23,7 +23,7 @@
   <refsect1>
     <title>Description</title>
 
-    <para><filename>@prefix@/var/netatalk/afp_signature.conf</filename> is the
+    <para><filename>afp_signature.conf</filename> is the
     configuration file used by <command>afpd</command> to specify
     server signature automagically. The configuration lines are
     composed like:</para>

--- a/doc/manpages/man5/afp_voluuid.conf.5.xml
+++ b/doc/manpages/man5/afp_voluuid.conf.5.xml
@@ -23,7 +23,7 @@
   <refsect1>
     <title>Description</title>
 
-    <para><filename>@prefix@/var/netatalk/afp_voluuid.conf</filename> is the
+    <para><filename>afp_voluuid.conf</filename> is the
     configuration file used by <command>afpd</command> to specify
     UUID of all AFP volumes. The configuration
     lines are composed like:</para>

--- a/doc/manpages/man5/extmap.conf.5.xml
+++ b/doc/manpages/man5/extmap.conf.5.xml
@@ -21,7 +21,7 @@
 
   <refsynopsisdiv>
     <cmdsynopsis>
-      <command>@prefix@/etc/extmap.conf</command>
+      <command>extmap.conf</command>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -29,7 +29,7 @@
     <title>Description</title>
 
     <para>
-    <filename>@prefix@/etc/extmap.conf</filename> is the
+    <filename>extmap.conf</filename> is the
     configuration file used by <command>afpd</command> to
     specify file name extension mappings.</para>
 

--- a/doc/manpages/man8/afpd.8.xml
+++ b/doc/manpages/man8/afpd.8.xml
@@ -46,7 +46,7 @@
     interface to the Unix file system. It is normally started at boot time
     by <command>netatalk</command>(8).</para>
 
-    <para><filename>@prefix@/etc/afp.conf</filename> is the configuration file
+    <para><filename>afp.conf</filename> is the configuration file
     used by <command>afpd</command> to determine the behavior and
     configuration of a file server.</para>
 
@@ -93,8 +93,7 @@
         <term>-F <replaceable>configfile</replaceable></term>
 
         <listitem>
-          <para>Specifies the configuration file to use. (Defaults to
-          <filename>@prefix@/etc/afp.conf</filename>.)</para>
+          <para>Specifies the configuration file to use.</para>
         </listitem>
       </varlistentry>
 
@@ -180,7 +179,7 @@
 
     <variablelist>
       <varlistentry>
-        <term><filename>@prefix@/etc/afp.conf</filename></term>
+        <term><filename>afp.conf</filename></term>
 
         <listitem>
           <para>configuration file used by afpd</para>
@@ -188,7 +187,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@prefix@/var/netatalk/afp_signature.conf</filename></term>
+        <term><filename>afp_signature.conf</filename></term>
 
         <listitem>
           <para>list of server signature</para>
@@ -196,7 +195,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@prefix@/var/netatalk/afp_voluuid.conf</filename></term>
+        <term><filename>afp_voluuid.conf</filename></term>
 
         <listitem>
           <para>list of UUID for Time Machine volume</para>
@@ -204,7 +203,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@prefix@/etc/extmap.conf</filename></term>
+        <term><filename>extmap.conf</filename></term>
 
         <listitem>
           <para>file name extension mapping</para>
@@ -212,7 +211,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@prefix@/etc/msg/message.pid</filename></term>
+        <term><filename>message.pid</filename></term>
 
         <listitem>
           <para>contains messages to be sent to users.</para>

--- a/doc/manpages/man8/cnid_metad.8.xml
+++ b/doc/manpages/man8/cnid_metad.8.xml
@@ -71,8 +71,7 @@
 
         <listitem>
           <para>Use <emphasis remap="I">configuration file</emphasis> as the
-            configuration file. The default is
-            <emphasis remap="I">@prefix@/etc/afp.conf</emphasis>.</para>
+            configuration file.</para>
         </listitem>
       </varlistentry>
 

--- a/doc/manpages/man8/netatalk.8.xml
+++ b/doc/manpages/man8/netatalk.8.xml
@@ -61,8 +61,7 @@
         <term>-F <replaceable>configfile</replaceable></term>
 
         <listitem>
-          <para>Specifies the configuration file to use. (Defaults to
-          <filename>@prefix@/etc/afp.conf</filename>.)</para>
+          <para>Specifies the configuration file to use.</para>
         </listitem>
       </varlistentry>
 
@@ -97,7 +96,7 @@
 
     <variablelist>
       <varlistentry>
-        <term><filename>@prefix@/etc/afp.conf</filename></term>
+        <term><filename>afp.conf</filename></term>
 
         <listitem>
           <para>configuration file used by <command>netatalk</command>(8),


### PR DESCRIPTION
Rewrite paragraphs that referred to specific configurable file system paths.