### PR TITLE
[2.2] Rearrange the dummy file system paths for the tests

### DIFF
--- a/test/afpd/.gitignore
+++ b/test/afpd/.gitignore
@@ -5,3 +5,7 @@ Makefile.in
 test
 test.conf
 test.default
+test.log
+test.trs
+test.sh.*
+test-suite.log

--- a/test/afpd/Makefile.am
+++ b/test/afpd/Makefile.am
@@ -1,6 +1,6 @@
 # Makefile.am for test/afpd/
 
-pkgconfdir = @PKGCONFDIR@
+tmpconfdir = /tmp/netatalk
 
 TESTS = test.sh test
 
@@ -53,14 +53,14 @@ test_CFLAGS = -I$(top_srcdir)/include -I$(top_srcdir)/etc/afpd \
 	 @SLP_CFLAGS@ @ZEROCONF_CFLAGS@ @QUOTA_CFLAGS@ \
 	 -DAPPLCNAME \
 	 -DSERVERTEXT=\"$(SERVERTEXT)/\" \
-	 -D_PATH_AFPDDEFVOL=\"$(pkgconfdir)/AppleVolumes.default\" \
-	 -D_PATH_AFPDSYSVOL=\"$(pkgconfdir)/AppleVolumes.system\" \
-	 -D_PATH_AFPDPWFILE=\"$(pkgconfdir)/afppasswd\" \
-	 -D_PATH_AFPDCONF=\"$(pkgconfdir)/afpd.conf\" \
-	 -D_PATH_AFPDUAMPATH=\"$(UAMS_PATH)/\" \
-	 -D_PATH_ACL_LDAPCONF=\"$(pkgconfdir)/afp_ldap.conf\" \
-	 -D_PATH_AFPDSIGCONF=\"$(pkgconfdir)/afp_signature.conf\" \
-	 -D_PATH_AFPDUUIDCONF=\"$(pkgconfdir)/afp_voluuid.conf\"
+	 -D_PATH_AFPDDEFVOL=\"$(tmpconfdir)/AppleVolumes.default\" \
+	 -D_PATH_AFPDSYSVOL=\"$(tmpconfdir)/AppleVolumes.system\" \
+	 -D_PATH_AFPDPWFILE=\"$(tmpconfdir)/afppasswd\" \
+	 -D_PATH_AFPDCONF=\"$(tmpconfdir)/afpd.conf\" \
+	 -D_PATH_AFPDUAMPATH=\"$(tmpconfdir)/\" \
+	 -D_PATH_ACL_LDAPCONF=\"$(tmpconfdir)/afp_ldap.conf\" \
+	 -D_PATH_AFPDSIGCONF=\"$(tmpconfdir)/afp_signature.conf\" \
+	 -D_PATH_AFPDUUIDCONF=\"$(tmpconfdir)/afp_voluuid.conf\"
 
 test_LDADD = $(top_builddir)/libatalk/cnid/libcnid.la \
 	$(top_builddir)/libatalk/libatalk.la \

--- a/test/afpd/test.sh
+++ b/test/afpd/test.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
-if [ ! -d /tmp/AFPtestvolume ] ; then
-    mkdir -p /tmp/AFPtestvolume
+if [ ! -d /tmp/netatalk/AFPtestvolume ] ; then
+    mkdir -p /tmp/netatalk/AFPtestvolume
     if [ $? -ne 0 ] ; then
-        echo Error creating AFP test volume /tmp/AFPtestvolume
+        echo Error creating AFP test volume /tmp/netatalk/AFPtestvolume
         exit 1
     fi
 fi
@@ -18,7 +18,7 @@ fi
 if [ ! -f test.default ] ; then
     echo -n "Creating volume config template ... "
     cat > test.default <<EOF
-/tmp/AFPtestvolume "test" ea:none cnidscheme:last
+/tmp/netatalk/AFPtestvolume "test" ea:none cnidscheme:last
 EOF
     echo [ok]
 fi


### PR DESCRIPTION
The new default location for autoconf (libdir) isn't valid on macOS.