### PR TITLE
[2.3] Add long-forgotten patch to make papd safer.

### DIFF
--- a/etc/papd/main.c
+++ b/etc/papd/main.c
@@ -73,8 +73,6 @@ char *strchr (), *strrchr ();
 #include "print_cups.h"
 
 
-#define PIPED_STATUS	"status: print spooler processing job"
-
 /* This maps to TReq and TResp, per "Inside AppleTalk" 10-13 */
 
 typedef struct __attribute__((__packed__)) {
@@ -93,7 +91,7 @@ int		debug = 0;
 static char	*conffile = _PATH_PAPDCONF;
 char		*printcap = _PATH_PAPDPRINTCAP;
 unsigned char	connid, quantum, sock, oquantum = PAP_MAXQUANTUM;
-char		*cannedstatus = PIPED_STATUS;
+char		*cannedstatus = "status: print spooler processing job";
 struct printer	*printer = NULL;
 char		*version = VERSION;
 static char	*pidfile = _PATH_PAPDLOCK;
@@ -584,12 +582,12 @@ int getstatus(struct printer *pr, rbuf_t *buf)
 #ifdef HAVE_CUPS
     if ( pr->p_flags & P_PIPED ) {
 	buf->buf_len = strlen(cannedstatus);
-	snprintf(buf->buf, 254, cannedstatus);
+	snprintf(buf->buf, 254, "%s", cannedstatus);
 	return (buf->buf_len + 1);
     } else {
 	cups_get_printer_status( pr );
 	buf->buf_len = strlen(pr->p_status);
-	snprintf(buf->buf, 254, pr->p_status);
+	snprintf(buf->buf, 254, "%s", pr->p_status);
 	return (buf->buf_len + 1);
     }
 #else
@@ -606,7 +604,7 @@ int getstatus(struct printer *pr, rbuf_t *buf)
 
     if ((pr->p_flags & P_PIPED) || (fd == NULL)) {
 	buf->buf_len = strlen(cannedstatus);
-	snprintf(buf->buf, 254, cannedstatus);
+	snprintf(buf->buf, 254, "%s", cannedstatus);
 	return (buf->buf_len + 1);
     } else {
 	rc = fread(getstatus_buffer, 255, sizeof(unsigned char), fd);
@@ -615,11 +613,11 @@ int getstatus(struct printer *pr, rbuf_t *buf)
 	if (rc > 0) {
 		if (temp != NULL) {
 			temp[strcspn(temp, "\n")] = '\0';
-			snprintf(buf->buf, 254, temp);
+			snprintf(buf->buf, 254, "%s", temp);
 			buf->buf_len = strlen(buf->buf);
 		}
 	} else {
-		snprintf(buf->buf, 254, "thisisanemptystring");
+		snprintf(buf->buf, 254, "%s", "thisisanemptystring");
 		buf->buf_len = 0;
 	}
 


### PR DESCRIPTION
Quoting Chris K:

> That was part of an attempt last year to make papd less dangerous.  The code
constructs packets by allocating a char buffer and scribbling into that --
the patch replaces that nonsense with packed structs that dramatically reduces
the possibility of stack smashing.