### PR TITLE
[2.3] Don't seteuid() if process is already running as that uid.

### DIFF
--- a/etc/afpd/afp_asp.c
+++ b/etc/afpd/afp_asp.c
@@ -52,8 +52,12 @@ static void afp_asp_close(AFPObj *obj)
 {
     ASP asp = obj->handle;
 
-    if (seteuid( obj->uid ) < 0) {
-        LOG(log_error, logtype_afpd, "can't seteuid back %s", strerror(errno));
+    if ( obj->uid != geteuid() ) {
+        if (seteuid(obj->uid) < 0) {
+            LOG(log_error, logtype_afpd,
+			"afp_asp_close: can't seteuid back to %i from %i (%s)",
+			obj->uid, geteuid(), strerror(errno));
+        }
         exit(EXITERR_SYS);
     }
     close_all_vol();


### PR DESCRIPTION
A straggler patch from 2.x / netatalk-classic.