### PR TITLE
[2.3] Change default log level to INFO

### DIFF
--- a/etc/afpd/main.c
+++ b/etc/afpd/main.c
@@ -277,7 +277,7 @@ int main(int ac, char **av)
 
     /* Default log setup: log to syslog */
     set_processname("afpd");
-    setuplog("default log_note");
+    setuplog("default log_info");
 
     /* Save the user's current umask */
     default_options.save_mask = umask( default_options.umask );


### PR DESCRIPTION
Makes logging slightly more verbose: 431 instances of log_info vs. 63 instances of log_note