### PR TITLE
[2.3] Enable, sort, and flesh out file type translation

### DIFF
--- a/config/AppleVolumes.system
+++ b/config/AppleVolumes.system
@@ -11,6 +11,13 @@
 ###
 ### inoue@ma.ns.musashi-tech.ac.jp.
 ###
+### Last Updated Jan 2, 2002
+### Use at your own risk.  Take care !
+###
+### I'd like to dedicate this as follows code to Miss.Tamaki Imazu
+###
+### Kazuhiko Okudaira the Nursery Teacher
+### kokudaira@hotmail.com
 
 ### default translation -- note that CR <-> LF translation is done on all
 ### files of type TEXT (if crlf is set in volume's options).  
@@ -20,307 +27,301 @@
 ###.         "BINA"  "UNIX"      Unix Binary                    Unix                      application/octet-stream
 ###.         "TEXT"  "ttxt"      ASCII Text                     SimpleText                text/plain
 
-#.1st      "TEXT"  "ttxt"      Text Readme                    SimpleText                application/text
-#.669      "6669"  "SNPL"      669 MOD Music                  PlayerPro
-#.8med     "STrk"  "SCPL"      Amiga OctaMed music            SoundApp
-#.8svx     "8SVX"  "SCPL"      Amiga 8-bit sound              SoundApp
-#.a        "TEXT"  "ttxt"      Assembly Source                SimpleText
-#.aif      "AIFF"  "SCPL"      AIFF Sound                     SoundApp                  audio/x-aiff
-#.aifc     "AIFC"  "SCPL"      AIFF Sound Compressed          SoundApp                  audio/x-aiff
-#.aiff     "AIFF"  "SCPL"      AIFF Sound                     SoundApp                  audio/x-aiff
-#.al       "ALAW"  "SCPL"      ALAW Sound                     SoundApp
-#.ani      "ANIi"  "GKON"      Animated NeoChrome             GraphicConverter
-#.apd      "TEXT"  "ALD3"      Aldus Printer Description      Aldus PageMaker
-#.arc      "mArc"  "SITx"      PC ARChive                     StuffIt Expander
-#.arj      "BINA"  "DArj"      ARJ Archive                    DeArj
-#.arr      "ARR "  "GKON"      Amber ARR image                GraphicConverter
-#.art      "ART "  "GKON"      First Publisher                GraphicConverter
-#.asc      "TEXT"  "ttxt"      ASCII Text                     SimpleText                text/plain
-#.ascii    "TEXT"  "ttxt"      ASCII Text                     SimpleText                text/plain
-#.asf      "ASF_"  "Ms01"      Netshow Player                 Netshow Server            video/x-ms-asf
-#.asm      "TEXT"  "ttxt"      Assembly Source                SimpleText
-#.asx      "ASX_"  "Ms01"      Netshow Player                 Netshow Server            video/x-ms-asf
-#.au       "ULAW"  "TVOD"      Sun Sound                      QuickTime Player          audio/basic
-#.avi      "VfW "  "TVOD"      AVI Movie                      QuickTime Player          video/avi
-#.bar      "BARF"  "S691"      Unix BAR Archive               SunTar
-#.bas      "TEXT"  "ttxt"      BASIC Source                   SimpleText
-#.bat      "TEXT"  "ttxt"      MS-DOS Batch File              SimpleText
-#.bga      "BMPp"  "ogle"      OS/2 Bitmap                    PictureViewer
-#.bib      "TEXT"  "ttxt"      BibTex Bibliography            SimpleText
-#.bin      "SIT!"  "SITx"      MacBinary                      StuffIt Expander          application/macbinary
-#.binary   "BINA"  "hDmp"      Untyped Binary Data            HexEdit                   application/octet-stream
-#.bmp      "BMPp"  "ogle"      Windows Bitmap                 PictureViewer
-#.boo      "TEXT"  "ttxt"      BOO encoded                    SimpleText
-#.bst      "TEXT"  "ttxt"      BibTex Style                   SimpleText
-#.bw       "SGI "  "GKON"      SGI Image                      GraphicConverter
-#.c        "TEXT"  "CWIE"      C Source                       CodeWarrior
-#.cgm      "CGMm"  "GKON"      Computer Graphics Meta         GraphicConverter
-#.class    "Clss"  "CWIE"      Java Class File                CodeWarrior
-#.clp      "CLPp"  "GKON"      Windows Clipboard              GraphicConverter
-#.cmd      "TEXT"  "ttxt"      OS/2 Batch File                SimpleText
-#.com      "PCFA"  "SWIN"      MS-DOS Executable              SoftWindows
-#.cp       "TEXT"  "CWIE"      C++ Source                     CodeWarrior
-#.cpp      "TEXT"  "CWIE"      C++ Source                     CodeWarrior
-#.cpt      "PACT"  "SITx"      Compact Pro Archive            StuffIt Expander
-#.csv      "TEXT"  "XCEL"      Comma Separated Vars           Excel
-#.ct       "..CT"  "GKON"      Scitex-CT                      GraphicConverter
-#.cut      "Halo"  "GKON"      Dr Halo Image                  GraphicConverter
-#.cvs      "drw2"  "DAD2"      Canvas Drawing                 Canvas
-#.dbf      "COMP"  "FOX+"      DBase Document                 FoxBase+
-#.dcx      "DCXx"  "GKON"      Some PCX Images                GraphicConverter
-#.dif      "TEXT"  "XCEL"      Data Interchange Format        Excel
-#.diz      "TEXT"  "R*Ch"      BBS Descriptive Text           BBEdit
-#.dl       "DL  "  "AnVw"      DL Animation                   MacAnim Viewer
-#.dll      "PCFL"  "SWIN"      Windows DLL                    SoftWindows
-#.doc      "WDBN"  "MSWD"      Word Document                  Microsoft Word            application/msword
-#.dot      "sDBN"  "MSWD"      Word for Windows Template      Microsoft Word
-#.dvi      "ODVI"  "xdvi"      TeX DVI Document               xdvi                      application/x-dvi
-#.dwt      "TEXT"  "DmWr"      Dreamweaver Template           Dreamweaver
-#.dxf      "TEXT"  "SWVL"      AutoCAD 3D Data                Swivel Pro
-#.eps      "EPSF"  "vgrd"      Postscript                     LaserWriter 8             application/postscript
-#.epsf     "EPSF"  "vgrd"      Postscript                     LaserWriter 8             application/postscript
-#.etx      "TEXT"  "ezVu"      SEText                         Easy View                 text/x-setext
-#.evy      "EVYD"  "ENVY"      Envoy Document                 Envoy
-#.exe      "PCFA"  "SWIN"      MS-DOS Executable              SoftWindows
-#.faq      "TEXT"  "ttxt"      ASCII Text                     SimpleText                text/x-usenet-faq
-#.fit      "FITS"  "GKON"      Flexible Image Transport       GraphicConverter          image/x-fits
-#.flc      "FLI "  "TVOD"      FLIC Animation                 QuickTime Player
-#.fli      "FLI "  "TVOD"      FLI Animation                  QuickTime Player
-#.fm       "FMPR"  "FMPR"      FileMaker Pro Database         FileMaker Pro
-#.for      "TEXT"  "MPS "      Fortran Source                 MPW Shell
-#.fts      "FITS"  "GKON"      Flexible Image Transport       GraphicConverter
-#.gem      "GEM-"  "GKON"      GEM Metafile                   GraphicConverter
-#.gif      "GIFf"  "ogle"      GIF Picture                    PictureViewer             image/gif
-#.gl       "GL  "  "AnVw"      GL Animation                   MacAnim Viewer
-#.grp      "GRPp"  "GKON"      GRP Image                      GraphicConverter
-#.gz       "SIT!"  "SITx"      Gnu ZIP Archive                StuffIt Expander          application/x-gzip
-#.h        "TEXT"  "CWIE"      C Include File                 CodeWarrior
-#.hcom     "FSSD"  "SCPL"      SoundEdit Sound ex SOX         SoundApp
-#.hp       "TEXT"  "CWIE"      C Include File                 CodeWarrior
-#.hpgl     "HPGL"  "GKON"      HP GL/2                        GraphicConverter
-#.hpp      "TEXT"  "CWIE"      C Include File                 CodeWarrior
-#.hqx      "TEXT"  "SITx"      BinHex                         StuffIt Expander          application/mac-binhex40
-#.htm      "TEXT"  "MOSS"      HyperText                      Netscape Communicator     text/html
-#.html     "TEXT"  "MOSS"      HyperText                      Netscape Communicator     text/html
-#.i3       "TEXT"  "R*ch"      Modula 3 Interface             BBEdit
-#.ic1      "IMAG"  "GKON"      Atari Image                    GraphicConverter
-#.ic2      "IMAG"  "GKON"      Atari Image                    GraphicConverter
-#.ic3      "IMAG"  "GKON"      Atari Image                    GraphicConverter
-#.icn      "ICO "  "GKON"      Windows Icon                   GraphicConverter
-#.ico      "ICO "  "GKON"      Windows Icon                   GraphicConverter
-#.ief      "IEF "  "GKON"      IEF image                      GraphicConverter          image/ief
-#.iff      "ILBM"  "GKON"      Amiga IFF Image                GraphicConverter
-#.ilbm     "ILBM"  "GKON"      Amiga ILBM Image               GraphicConverter
-#.image    "dImg"  "ddsk"      Apple DiskCopy Image           Disk Copy
+
+.1st      "TEXT"  "ttxt"      Text Readme                    SimpleText                application/text
+.669      "6669"  "SNPL"      669 MOD Music                  PlayerPro
+.8med     "STrk"  "SCPL"      Amiga OctaMed music            SoundApp
+.8svx     "8SVX"  "SCPL"      Amiga 8-bit sound              SoundApp
+.aif      "AIFF"  "SCPL"      AIFF Sound                     SoundApp                  audio/x-aiff
+.aifc     "AIFC"  "SCPL"      AIFF Sound Compressed          SoundApp                  audio/x-aiff
+.aiff     "AIFF"  "SCPL"      AIFF Sound                     SoundApp                  audio/x-aiff
+.al       "ALAW"  "SCPL"      ALAW Sound                     SoundApp
+.ani      "ANIi"  "GKON"      Animated NeoChrome             GraphicConverter
+.apd      "TEXT"  "ALD3"      Aldus Printer Description      Aldus PageMaker
+.arc      "mArc"  "SITx"      PC ARChive                     StuffIt Expander
+.arj      "BINA"  "DArj"      ARJ Archive                    DeArj
+.arr      "ARR "  "GKON"      Amber ARR image                GraphicConverter
+.art      "ART "  "GKON"      First Publisher                GraphicConverter
+.ascii    "TEXT"  "ttxt"      ASCII Text                     SimpleText                text/plain
+.asc      "TEXT"  "ttxt"      ASCII Text                     SimpleText                text/plain
+.asf      "ASF_"  "Ms01"      Netshow Player                 Netshow Server            video/x-ms-asf
+.asm      "TEXT"  "ttxt"      Assembly Source                SimpleText
+.asx      "ASX_"  "Ms01"      Netshow Player                 Netshow Server            video/x-ms-asf
+.a        "TEXT"  "ttxt"      Assembly Source                SimpleText
+.au       "ULAW"  "TVOD"      Sun Sound                      QuickTime Player          audio/basic
+.avi      "VfW "  "TVOD"      AVI Movie                      QuickTime Player          video/avi
+.bar      "BARF"  "S691"      Unix BAR Archive               SunTar
+.bas      "TEXT"  "ttxt"      BASIC Source                   SimpleText
+.bat      "TEXT"  "ttxt"      MS-DOS Batch File              SimpleText
+.bga      "BMPp"  "ogle"      OS/2 Bitmap                    PictureViewer
+.bib      "TEXT"  "ttxt"      BibTex Bibliography            SimpleText
+.binary   "BINA"  "hDmp"      Untyped Binary Data            HexEdit                   application/octet-stream
+.bin      "SIT!"  "SITx"      MacBinary                      StuffIt Expander          application/macbinary
+.bld  "BLD "  "GKON"  BLD                            GraphicConverter
+.bmp      "BMPp"  "ogle"      Windows Bitmap                 PictureViewer
+.boo      "TEXT"  "ttxt"      BOO encoded                    SimpleText
+.bst      "TEXT"  "ttxt"      BibTex Style                   SimpleText
+.bum  ".bMp"  "GKON"  QuickTime Importer(QuickDraw)  GraphicConverter
+.bw       "SGI "  "GKON"      SGI Image                      GraphicConverter
+.cel  "CEL "  "GKON"  KISS CEL                       GraphicConverter
+.cgm      "CGMm"  "GKON"      Computer Graphics Meta         GraphicConverter
+.class    "Clss"  "CWIE"      Java Class File                CodeWarrior
+.clp      "CLPp"  "GKON"      Windows Clipboard              GraphicConverter
+.cmd      "TEXT"  "ttxt"      OS/2 Batch File                SimpleText
+.com      "PCFA"  "SWIN"      MS-DOS Executable              SoftWindows
+.cpp      "TEXT"  "CWIE"      C++ Source                     CodeWarrior
+.cp       "TEXT"  "CWIE"      C++ Source                     CodeWarrior
+.cpt      "PACT"  "SITx"      Compact Pro Archive            StuffIt Expander
+.csv      "TEXT"  "XCEL"      Comma Separated Vars           Excel
+.ct       "..CT"  "GKON"      Scitex-CT                      GraphicConverter
+.c        "TEXT"  "CWIE"      C Source                       CodeWarrior
+.cur  "CUR "  "GKON"  Windows Cursor                 GraphicConverter
+.cut      "Halo"  "GKON"      Dr Halo Image                  GraphicConverter
+.cvs      "drw2"  "DAD2"      Canvas Drawing                 Canvas
+.cwj  "CWSS"  "cwkj"  ClarisWorks Document           ClarisWorks 4.0
+.dat  "TCLl"  "GKON"  TCL image                      GraphicConverter
+.dbf      "COMP"  "FOX+"      DBase Document                 FoxBase+
+.dcx      "DCXx"  "GKON"      Some PCX Images                GraphicConverter
+.dif      "TEXT"  "XCEL"      Data Interchange Format        Excel
+.diz      "TEXT"  "R*Ch"      BBS Descriptive Text           BBEdit
+.dl       "DL  "  "AnVw"      DL Animation                   MacAnim Viewer
+.dll      "PCFL"  "SWIN"      Windows DLL                    SoftWindows
+.doc      "WDBN"  "MSWD"      Word Document                  Microsoft Word            application/msword
+.dot      "sDBN"  "MSWD"      Word for Windows Template      Microsoft Word
+.dsk      "dimg"  "dCpy"      Apple DiskCopy Image           Disk Copy
+.dvi      "ODVI"  "xdvi"      TeX DVI Document               xdvi                      application/x-dvi
+.dwt      "TEXT"  "DmWr"      Dreamweaver Template           Dreamweaver
+.dxf      "TEXT"  "SWVL"      AutoCAD 3D Data                Swivel Pro
+.eps      "EPSF"  "vgrd"      Postscript                     LaserWriter 8             application/postscript
+.epsf     "EPSF"  "vgrd"      Postscript                     LaserWriter 8             application/postscript
+.etx      "TEXT"  "ezVu"      SEText                         Easy View                 text/x-setext
+.evy      "EVYD"  "ENVY"      Envoy Document                 Envoy
+.exe      "PCFA"  "SWIN"      MS-DOS Executable              SoftWindows
+.faq      "TEXT"  "ttxt"      ASCII Text                     SimpleText                text/x-usenet-faq
+.fit      "FITS"  "GKON"      Flexible Image Transport       GraphicConverter          image/x-fits
+.fla  "SPA "  "MFL2"  Flash source                   Macromedia Flash
+.flc      "FLI "  "TVOD"      FLIC Animation                 QuickTime Player
+.fli      "FLI "  "TVOD"      FLI Animation                  QuickTime Player
+.fm       "FMPR"  "FMPR"      FileMaker Pro Database         FileMaker Pro
+.for      "TEXT"  "MPS "      Fortran Source                 MPW Shell
+.fts      "FITS"  "GKON"      Flexible Image Transport       GraphicConverter
+.gem      "GEM-"  "GKON"      GEM Metafile                   GraphicConverter
+.gif      "GIFf"  "ogle"      GIF Picture                    PictureViewer             image/gif
+.gl       "GL  "  "AnVw"      GL Animation                   MacAnim Viewer
+.grp      "GRPp"  "GKON"      GRP Image                      GraphicConverter
+.gz       "SIT!"  "SITx"      Gnu ZIP Archive                StuffIt Expander          application/x-gzip
+.hcom     "FSSD"  "SCPL"      SoundEdit Sound ex SOX         SoundApp
+.hpgl     "HPGL"  "GKON"      HP GL/2                        GraphicConverter
+.hpp      "TEXT"  "CWIE"      C Include File                 CodeWarrior
+.hp       "TEXT"  "CWIE"      C Include File                 CodeWarrior
+.hqx      "TEXT"  "SITx"      BinHex                         StuffIt Expander          application/mac-binhex40
+.hr   "TR80"  "GKON"  TSR-80 HR                      GraphicConverter
+.h        "TEXT"  "CWIE"      C Include File                 CodeWarrior
+.html     "TEXT"  "MOSS"      HyperText                      Netscape Communicator     text/html
+.htm      "TEXT"  "MOSS"      HyperText                      Netscape Communicator     text/html
+.i3       "TEXT"  "R*ch"      Modula 3 Interface             BBEdit
+.ic1      "IMAG"  "GKON"      Atari Image                    GraphicConverter
+.ic2      "IMAG"  "GKON"      Atari Image                    GraphicConverter
+.ic3      "IMAG"  "GKON"      Atari Image                    GraphicConverter
+.icn      "ICO "  "GKON"      Windows Icon                   GraphicConverter
+.ico      "ICO "  "GKON"      Windows Icon                   GraphicConverter
+.ief      "IEF "  "GKON"      IEF image                      GraphicConverter          image/ief
+.iff      "ILBM"  "GKON"      Amiga IFF Image                GraphicConverter
+.ilbm     "ILBM"  "GKON"      Amiga ILBM Image               GraphicConverter
+.image    "dImg"  "ddsk"      Apple DiskCopy Image           Disk Copy
+.img      "dImg"  "ddsk"      Apple DiskCopy Image           Disk Copy
 #.img      "IMGg"  "GKON"      GEM bit image/XIMG             GraphicConverter
-#.ini      "TEXT"  "ttxt"      Windows INI File               SimpleText
-#.java     "TEXT"  "CWIE"      Java Source File               CodeWarrior
-#.jfif     "JPEG"  "ogle"      JFIF Image                     PictureViewer
-#.jpe      "JPEG"  "ogle"      JPEG Picture                   PictureViewer             image/jpeg
-#.jpeg     "JPEG"  "ogle"      JPEG Picture                   PictureViewer             image/jpeg
-#.jpg      "JPEG"  "ogle"      JPEG Picture                   PictureViewer             image/jpeg
-#.latex    "TEXT"  "OTEX"      Latex                          OzTex                     application/x-latex
-#.lbm      "ILBM"  "GKON"      Amiga IFF Image                GraphicConverter
-#.lha      "LHA "  "SITx"      LHArc Archive                  StuffIt Expander
-#.lzh      "LHA "  "SITx"      LHArc Archive                  StuffIt Expander
-#.m1a      "MPEG"  "TVOD"      MPEG-1 audiostream             MoviePlayer               audio/x-mpeg
-#.m1s      "MPEG"  "TVOD"      MPEG-1 systemstream            MoviePlayer
-#.m1v      "M1V "  "TVOD"      MPEG-1 IPB videostream         MoviePlayer               video/mpeg
-#.m2       "TEXT"  "R*ch"      Modula 2 Source                BBEdit
-#.m2v      "MPG2"  "MPG2"      MPEG-2 IPB videostream         MPEG2decoder
-#.m3       "TEXT"  "R*ch"      Modula 3 Source                BBEdit
-#.mac      "PICT"  "ogle"      PICT Picture                   PictureViewer             image/x-pict
-#.mak      "TEXT"  "R*ch"      Makefile                       BBEdit
-#.mcw      "WDBN"  "MSWD"      Mac Word Document              Microsoft Word
-#.me       "TEXT"  "ttxt"      Text Readme                    SimpleText
-#.med      "STrk"  "SCPL"      Amiga MED Sound                SoundApp
-#.mf       "TEXT"  "*MF*"      Metafont                       Metafont
-#.mid      "Midi"  "TVOD"      MIDI Music                     MoviePlayer
-#.midi     "Midi"  "TVOD"      MIDI Music                     MoviePlayer
-#.mif      "TEXT"  "Fram"      FrameMaker MIF                 FrameMaker                application/x-framemaker
-#.mime     "TEXT"  "SITx"      MIME Message                   StuffIt Expander          message/rfc822
-#.ml       "TEXT"  "R*ch"      ML Source                      BBEdit
-#.mod      "STrk"  "SCPL"      MOD Music                      SoundApp
-#.mol      "TEXT"  "RSML"      MDL Molfile                    RasMac
-#.moov     "MooV"  "TVOD"      QuickTime Movie                MoviePlayer               video/quicktime
-#.mov      "MooV"  "TVOD"      QuickTime Movie                MoviePlayer               video/quicktime
-#.mp2      "MPEG"  "TVOD"      MPEG-1 audiostream             MoviePlayer               audio/x-mpeg
-#.mp3      "MPG3"  "TVOD"      MPEG-3 audiostream             MoviePlayer               audio/x-mpeg
-#.mpa      "MPEG"  "TVOD"      MPEG-1 audiostream             MoviePlayer               audio/x-mpeg
-#.mpe      "MPEG"  "TVOD"      MPEG Movie of some sort        MoviePlayer               video/mpeg
-#.mpeg     "MPEG"  "TVOD"      MPEG Movie of some sort        MoviePlayer               video/mpeg
-#.mpg      "MPEG"  "TVOD"      MPEG Movie of some sort        MoviePlayer               video/mpeg
-#.msp      "MSPp"  "GKON"      Microsoft Paint                GraphicConverter
-#.mtm      "MTM "  "SNPL"      MultiMOD Music                 PlayerPro
-#.mw       "MW2D"  "MWII"      MacWrite Document              MacWrite II               application/macwriteii
-#.mwii     "MW2D"  "MWII"      MacWrite Document              MacWrite II               application/macwriteii
-#.neo      "NeoC"  "GKON"      Atari NeoChrome                GraphicConverter
-#.nfo      "TEXT"  "ttxt"      Info Text                      SimpleText                application/text
-#.nst      "STrk"  "SCPL"      MOD Music                      SoundApp
-#.obj      "PCFL"  "SWIN"      Object (DOS/Windows)           SoftWindows
-#.oda      "ODIF"  "ODA "      ODA Document                   MacODA XTND Translator    application/oda
-#.okt      "OKTA"  "SCPL"      Oktalyser MOD Music            SoundApp
-#.out      "BINA"  "hDmp"      Output File                    HexEdit
-#.ovl      "PCFL"  "SWIN"      Overlay (DOS/Windows)          SoftWindows
-#.p        "TEXT"  "CWIE"      Pascal Source                  CodeWarrior
-#.pac      "STAD"  "GKON"      Atari STAD Image               GraphicConverter
-#.pas      "TEXT"  "CWIE"      Pascal Source                  CodeWarrior
-#.pbm      "PPGM"  "GKON"      Portable Bitmap                GraphicConverter          image/x-portable-bitmap
-#.pc1      "Dega"  "GKON"      Atari Degas Image              GraphicConverter
-#.pc2      "Dega"  "GKON"      Atari Degas Image              GraphicConverter
-#.pc3      "Dega"  "GKON"      Atari Degas Image              GraphicConverter
-#.pcs      "PICS"  "GKON"      Animated PICTs                 GraphicConverter
-#.pct      "PICT"  "ogle"      PICT Picture                   PictureViewer             image/x-pict
-#.pcx      "PCXx"  "GKON"      PC PaintBrush                  GraphicConverter
-#.pdb      "TEXT"  "RSML"      Brookhaven PDB file            RasMac
-#.pdf      "PDF "  "CARO"      Portable Document Format       Acrobat Reader            application/pdf
-#.pdx      "TEXT"  "ALD5"      Printer Description            PageMaker
-#.pf       "CSIT"  "SITx"      Private File                   StuffIt Expander 
-#.pgm      "PPGM"  "GKON"      Portable Graymap               GraphicConverter          image/x-portable-graymap
-#.pi1      "Dega"  "GKON"      Atari Degas Image              GraphicConverter
-#.pi2      "Dega"  "GKON"      Atari Degas Image              GraphicConverter
-#.pi3      "Dega"  "GKON"      Atari Degas Image              GraphicConverter
-#.pic      "PICT"  "ogle"      PICT Picture                   PictureViewer             image/x-pict
-#.pict     "PICT"  "ogle"      PICT Picture                   PictureViewer             image/x-macpict
-#.pit      "PIT "  "SITx"      PackIt Archive                 StuffIt Expander
-#.pkg      "HBSF"  "SITx"      AppleLink Package              StuffIt Expander
-#.pl       "TEXT"  "McPL"      Perl Source                    MacPerl
-#.plt      "HPGL"  "GKON"      HP GL/2                        GraphicConverter
-#.pm       "PMpm"  "GKON"      Bitmap from xv                 GraphicConverter
-#.pm3      "ALB3"  "ALD3"      PageMaker 3 Document           PageMaker
-#.pm4      "ALB4"  "ALD4"      PageMaker 4 Document           PageMaker
-#.pm5      "ALB5"  "ALD5"      PageMaker 5 Document           PageMaker
-#.png      "PNG "  "ogle"      Portable Network Graphic       PictureViewer
-#.pntg     "PNTG"  "ogle"      Macintosh Painting             PictureViewer
-#.ppd      "TEXT"  "ALD5"      Printer Description            PageMaker
-#.ppm      "PPGM"  "GKON"      Portable Pixmap                GraphicConverter          image/x-portable-pixmap
-#.prn      "TEXT"  "R*ch"      Printer Output File            BBEdit
-#.ps       "TEXT"  "vgrd"      PostScript                     LaserWriter 8             application/postscript
-#.psd      "8BPS"  "8BIM"      PhotoShop Document             Photoshop
-#.pt4      "ALT4"  "ALD4"      PageMaker 4 Template           PageMaker
-#.pt5      "ALT5"  "ALD5"      PageMaker 5 Template           PageMaker
-#.pxr      "PXR "  "8BIM"      Pixar Image                    Photoshop
-#.qdv      "QDVf"  "GKON"      QDV image                      GraphicConverter
-#.qt       "MooV"  "TVOD"      QuickTime Movie                MoviePlayer               video/quicktime
-#.qxd      "XDOC"  "XPR3"      QuarkXpress Document           QuarkXpress
-#.qxt      "XTMP"  "XPR3"      QuarkXpress Template           QuarkXpress
+.ini      "TEXT"  "ttxt"      Windows INI File               SimpleText
+.iso      "rodh"  "ddsk"      Apple ISO Image                Disk Copy
+.iss  "ISS "  "GKON"  ISS                            GraphicConverter
+.java     "TEXT"  "CWIE"      Java Source File               CodeWarrior
+.jfif     "JPEG"  "ogle"      JFIF Image                     PictureViewer
+.jif  "JIFf"  "GKON"  JIF99a                         GraphicConverter
+.jpeg     "JPEG"  "ogle"      JPEG Picture                   PictureViewer             image/jpeg
+.jpe      "JPEG"  "ogle"      JPEG Picture                   PictureViewer             image/jpeg
+.jpg      "JPEG"  "ogle"      JPEG Picture                   PictureViewer             image/jpeg
+.latex    "TEXT"  "OTEX"      Latex                          OzTex                     application/x-latex
+.lbm      "ILBM"  "GKON"      Amiga IFF Image                GraphicConverter
+.lha      "LHA "  "SITx"      LHArc Archive                  StuffIt Expander
+.lwf  "lwfF"  "GKON"  LuraWave(LWF)                  GraphicConverter
+.lzh      "LHA "  "SITx"      LHArc Archive                  StuffIt Expander
+.m1a      "MPEG"  "TVOD"      MPEG-1 audiostream             MoviePlayer               audio/x-mpeg
+.m1s      "MPEG"  "TVOD"      MPEG-1 systemstream            MoviePlayer
+.m1v      "M1V "  "TVOD"      MPEG-1 IPB videostream         MoviePlayer               video/mpeg
+.m2       "TEXT"  "R*ch"      Modula 2 Source                BBEdit
+.m2v      "MPG2"  "MPG2"      MPEG-2 IPB videostream         MPEG2decoder
+.m3       "TEXT"  "R*ch"      Modula 3 Source                BBEdit
+.mac      "PICT"  "ogle"      PICT Picture                   PictureViewer             image/x-pict
+.mak      "TEXT"  "R*ch"      Makefile                       BBEdit
+.mbm  "MBM "  "GKON"  PSION 5(MBM)                   GraphicConverter
+.mcw      "WDBN"  "MSWD"      Mac Word Document              Microsoft Word
+.med      "STrk"  "SCPL"      Amiga MED Sound                SoundApp
+.me       "TEXT"  "ttxt"      Text Readme                    SimpleText
+.mf       "TEXT"  "*MF*"      Metafont                       Metafont
+.midi     "Midi"  "TVOD"      MIDI Music                     MoviePlayer
+.mid      "Midi"  "TVOD"      MIDI Music                     MoviePlayer
+.mif      "TEXT"  "Fram"      FrameMaker MIF                 FrameMaker                application/x-framemaker
+.mime     "TEXT"  "SITx"      MIME Message                   StuffIt Expander          message/rfc822
+.ml       "TEXT"  "R*ch"      ML Source                      BBEdit
+.mod      "STrk"  "SCPL"      MOD Music                      SoundApp
+.mol      "TEXT"  "RSML"      MDL Molfile                    RasMac
+.moov     "MooV"  "TVOD"      QuickTime Movie                MoviePlayer               video/quicktime
+.mov      "MooV"  "TVOD"      QuickTime Movie                MoviePlayer               video/quicktime
+.mp2      "MPEG"  "TVOD"      MPEG-1 audiostream             MoviePlayer               audio/x-mpeg
+.mp3      "MPG3"  "TVOD"      MPEG-3 audiostream             MoviePlayer               audio/x-mpeg
+.mpa      "MPEG"  "TVOD"      MPEG-1 audiostream             MoviePlayer               audio/x-mpeg
+.mpeg     "MPEG"  "TVOD"      MPEG Movie of some sort        MoviePlayer               video/mpeg
+.mpe      "MPEG"  "TVOD"      MPEG Movie of some sort        MoviePlayer               video/mpeg
+.mpg      "MPEG"  "TVOD"      MPEG Movie of some sort        MoviePlayer               video/mpeg
+.msp      "MSPp"  "GKON"      Microsoft Paint                GraphicConverter
+.mtm      "MTM "  "SNPL"      MultiMOD Music                 PlayerPro
+.mwii     "MW2D"  "MWII"      MacWrite Document              MacWrite II               application/macwriteii
+.mw       "MW2D"  "MWII"      MacWrite Document              MacWrite II               application/macwriteii
+.neo      "NeoC"  "GKON"      Atari NeoChrome                GraphicConverter
+.nfo      "TEXT"  "ttxt"      Info Text                      SimpleText                application/text
+.ngg  "NGGC"  "GKON"  Mobile Phone(Nokia)Format      GraphicConverter
+.nol  "NOL "  "GKON"  Mobile Phone(Nokia)Format      GraphicConverter
+.nst      "STrk"  "SCPL"      MOD Music                      SoundApp
+.obj      "PCFL"  "SWIN"      Object (DOS/Windows)           SoftWindows
+.oda      "ODIF"  "ODA "      ODA Document                   MacODA XTND Translator    application/oda
+.okt      "OKTA"  "SCPL"      Oktalyser MOD Music            SoundApp
+.out      "BINA"  "hDmp"      Output File                    HexEdit
+.ovl      "PCFL"  "SWIN"      Overlay (DOS/Windows)          SoftWindows
+.pac      "STAD"  "GKON"      Atari STAD Image               GraphicConverter
+.pal  "8BCT"  "8BIM"  Color Table                    GraphicConverter
+.pas      "TEXT"  "CWIE"      Pascal Source                  CodeWarrior
+.pbm      "PPGM"  "GKON"      Portable Bitmap                GraphicConverter          image/x-portable-bitmap
+.pc1      "Dega"  "GKON"      Atari Degas Image              GraphicConverter
+.pc2      "Dega"  "GKON"      Atari Degas Image              GraphicConverter
+.pc3      "Dega"  "GKON"      Atari Degas Image              GraphicConverter
+.pcs      "PICS"  "GKON"      Animated PICTs                 GraphicConverter
+.pct      "PICT"  "ogle"      PICT Picture                   PictureViewer             image/x-pict
+.pcx      "PCXx"  "GKON"      PC PaintBrush                  GraphicConverter
+.pdb      "TEXT"  "RSML"      Brookhaven PDB file            RasMac
+.pdf      "PDF "  "CARO"      Portable Document Format       Acrobat Reader            application/pdf
+.pdx      "TEXT"  "ALD5"      Printer Description            PageMaker
+.pf       "CSIT"  "SITx"      Private File                   StuffIt Expander 
+.pgc  "PGCF"  "GKON"  PGC/PGF  Atari Portfolio PCG   GraphicConverter
+.pgm      "PPGM"  "GKON"      Portable Graymap               GraphicConverter          image/x-portable-graymap
+.pi1      "Dega"  "GKON"      Atari Degas Image              GraphicConverter
+.pi2      "Dega"  "GKON"      Atari Degas Image              GraphicConverter
+.pi3      "Dega"  "GKON"      Atari Degas Image              GraphicConverter
+.pic      "PICT"  "ogle"      PICT Picture                   PictureViewer             image/x-pict
+.pics "PICS"  "GKON"  PICS-PICT Sequence             GraphicConverter
+.pict     "PICT"  "ogle"      PICT Picture                   PictureViewer             image/x-macpict
+.pit      "PIT "  "SITx"      PackIt Archive                 StuffIt Expander
+.pkg      "HBSF"  "SITx"      AppleLink Package              StuffIt Expander
+.pl       "TEXT"  "McPL"      Perl Source                    MacPerl
+.plt      "HPGL"  "GKON"      HP GL/2                        GraphicConverter
+.pm3      "ALB3"  "ALD3"      PageMaker 3 Document           PageMaker
+.pm4      "ALB4"  "ALD4"      PageMaker 4 Document           PageMaker
+.pm5      "ALB5"  "ALD5"      PageMaker 5 Document           PageMaker
+.pm       "PMpm"  "GKON"      Bitmap from xv                 GraphicConverter
+.png      "PNG "  "ogle"      Portable Network Graphic       PictureViewer
+.pntg     "PNTG"  "ogle"      Macintosh Painting             PictureViewer
+.ppd      "TEXT"  "ALD5"      Printer Description            PageMaker
+.ppm      "PPGM"  "GKON"      Portable Pixmap                GraphicConverter          image/x-portable-pixmap
+.prn      "TEXT"  "R*ch"      Printer Output File            BBEdit
+.psd      "8BPS"  "8BIM"      PhotoShop Document             Photoshop
+.ps       "TEXT"  "vgrd"      PostScript                     LaserWriter 8             application/postscript
+.pt4      "ALT4"  "ALD4"      PageMaker 4 Template           PageMaker
+.pt5      "ALT5"  "ALD5"      PageMaker 5 Template           PageMaker
+.p        "TEXT"  "CWIE"      Pascal Source                  CodeWarrior
+.pxr      "PXR "  "8BIM"      Pixar Image                    Photoshop
+.qdv      "QDVf"  "GKON"      QDV image                      GraphicConverter
+.qt       "MooV"  "TVOD"      QuickTime Movie                MoviePlayer               video/quicktime
+.qxd      "XDOC"  "XPR3"      QuarkXpress Document           QuarkXpress
+.qxt      "XTMP"  "XPR3"      QuarkXpress Template           QuarkXpress
+.raw      "rodh"  "ddsk"      Apple raw disk Image           Disk Copy
 #.raw      "BINA"  "GKON"      Raw Image                      GraphicConverter
-#.readme   "TEXT"  "ttxt"      Text Readme                    SimpleText                application/text
-#.rgb      "SGI "  "GKON"      SGI Image                      GraphicConverter          image/x-rgb
-#.rgba     "SGI "  "GKON"      SGI Image                      GraphicConverter          image/x-rgb
-#.rib      "TEXT"  "RINI"      Renderman 3D Data              Renderman
-#.rif      "RIFF"  "GKON"      RIFF Graphic                   GraphicConverter
-#.rle      "RLE "  "GKON"      RLE image                      GraphicConverter
-#.rme      "TEXT"  "ttxt"      Text Readme                    SimpleText
-#.rpl      "FRL!"  "REP!"      Replica Document               Replica
-#.rsc      "rsrc"  "RSED"      Resource File                  ResEdit
-#.rsrc     "rsrc"  "RSED"      Resource File                  ResEdit
-#.rtf      "TEXT"  "MSWD"      Rich Text Format               Microsoft Word            application/rtf
-#.rtx      "TEXT"  "R*ch"      Rich Text                      BBEdit                    text/richtext
-#.s3m      "S3M "  "SNPL"      ScreamTracker 3 MOD            PlayerPro
-#.scc      "MSX "  "GKON"      MSX pitcure                    GraphicConverter
-#.scg      "RIX3"  "GKON"      ColoRIX                        GraphicConverter
-#.sci      "RIX3"  "GKON"      ColoRIX                        GraphicConverter
-#.scp      "RIX3"  "GKON"      ColoRIX                        GraphicConverter
-#.scr      "RIX3"  "GKON"      ColoRIX                        GraphicConverter
-#.scu      "RIX3"  "GKON"      ColoRIX                        GraphicConverter
-#.sea      "APPL"  "????"      Self-Extracting Archive        Self Extracting Archive
-#.sf       "IRCM"  "SDHK"      IRCAM Sound                    SoundHack
-#.sgi      ".SGI"  "ogle"      SGI Image                      PictureViewer
-#.sha      "TEXT"  "UnSh"      Unix Shell Archive             UnShar                    application/x-shar
-#.shar     "TEXT"  "UnSh"      Unix Shell Archive             UnShar                    application/x-shar
-#.shp      "SHPp"  "GKON"      Printmaster Icon Library       GraphicConverter
-#.sit      "SIT!"  "SITx"      StuffIt 1.5.1 Archive          StuffIt Expander          application/x-stuffit
-#.sithqx   "TEXT"  "SITx"      BinHexed StuffIt Archive       StuffIt Expander          application/mac-binhex40
-#.six      "SIXE"  "GKON"      SIXEL image                    GraphicConverter
-#.slk      "TEXT"  "XCEL"      SYLK Spreadsheet               Excel
-#.snd      "BINA"  "SCPL"      Sound of various types         SoundApp
-#.spc      "Spec"  "GKON"      Atari Spectrum 512             GraphicConverter
-#.sr       "SUNn"  "GKON"      Sun Raster Image               GraphicConverter
-#.sty      "TEXT"  "*TEX"      TeX Style                      Textures
-#.sun      "SUNn"  "GKON"      Sun Raster Image               GraphicConverter
-#.sup      "SCRN"  "GKON"      StartupScreen                  GraphicConverter
-#.svx      "8SVX"  "SCPL"      Amiga IFF Sound                SoundApp
-#.syk      "TEXT"  "XCEL"      SYLK Spreadsheet               Excel
-#.sylk     "TEXT"  "XCEL"      SYLK Spreadsheet               Excel
-#.tar      "TARF"  "SITx"      Unix Tape ARchive              StuffIt Expander          application/x-tar
-#.targa    "TPIC"  "GKON"      Truevision Image               GraphicConverter
-#.taz      "ZIVU"  "SITx"      Compressed Tape ARchive        StuffIt Expander          application/x-compress
-#.tex      "TEXT"  "OTEX"      TeX Document                   OzTeX                     application/x-tex
-#.texi     "TEXT"  "OTEX"      TeX Document                   OzTeX
-#.texinfo  "TEXT"  "OTEX"      TeX Document                   OzTeX                     application/x-texinfo
-#.text     "TEXT"  "ttxt"      ASCII Text                     SimpleText                text/plain
-#.tga      "TPIC"  "GKON"      Truevision Image               GraphicConverter
-#.tgz      "Gzip"  "SITx"      Gnu ZIPed Tape ARchive         StuffIt Expander          application/x-gzip
-#.tif      "TIFF"  "ogle"      TIFF Picture                   PictureViewer             image/tiff
-#.tiff     "TIFF"  "ogle"      TIFF Picture                   PictureViewer             image/tiff
-#.tny      "TINY"  "GKON"      Atari TINY Bitmap              GraphicConverter
-#.tsv      "TEXT"  "XCEL"      Tab Separated Values           Excel                     text/tab-separated-values
-#.tx8      "TEXT"  "ttxt"      8-bit ASCII Text               SimpleText
-#.txt      "TEXT"  "ttxt"      ASCII Text                     SimpleText                text/plain
-#.ul       "ULAW"  "TVOD"      Mu-Law Sound                   MoviePlayer               audio/basic
-#.url      "AURL"  "Arch"      URL Bookmark                   Anarchie                  message/external-body
-#.uu       "TEXT"  "SITx"      UUEncode                       StuffIt Expander
-#.uue      "TEXT"  "SITx"      UUEncode                       StuffIt Expander
-#.vff      "VFFf"  "GKON"      DESR VFF Greyscale Image       GraphicConverter
-#.vga      "BMPp"  "ogle"      OS/2 Bitmap                    PictureViewer
-#.voc      "VOC "  "SCPL"      VOC Sound                      SoundApp
-#.w51      ".WP5"  "WPC2"      WordPerfect PC 5.1 Doc         WordPerfect               application/wordperfect5.1
-#.wav      "WAVE"  "TVOD"      Windows WAV Sound              MoviePlayer               audio/x-wav
-#.wk1      "XLBN"  "XCEL"      Lotus Spreadsheet r2.1         Excel
-#.wks      "XLBN"  "XCEL"      Lotus Spreadsheet r1.x         Excel
-#.wmf      "WMF "  "GKON"      Windows Metafile               GraphicConverter
-#.wp       ".WP5"  "WPC2"      WordPerfect PC 5.1 Doc         WordPerfect               application/wordperfect5.1
-#.wp4      ".WP4"  "WPC2"      WordPerfect PC 4.2 Doc         WordPerfect
-#.wp5      ".WP5"  "WPC2"      WordPerfect PC 5.x Doc         WordPerfect               application/wordperfect5.1
-#.wp6      ".WP6"  "WPC2"      WordPerfect PC 6.x Doc         WordPerfect
-#.wpg      "WPGf"  "GKON"      WordPerfect Graphic            GraphicConverter
-#.wpm      "WPD1"  "WPC2"      WordPerfect Mac                WordPerfect
-#.wri      "WDBN"  "MSWD"      MS Write/Windows               Microsoft Word
-#.wve      "BINA"  "SCPL"      PSION sound                    SoundApp
-#.x10      "XWDd"  "GKON"      X-Windows Dump                 GraphicConverter          image/x-xwd
-#.x11      "XWDd"  "GKON"      X-Windows Dump                 GraphicConverter          image/x-xwd
-#.xbm      "XBM "  "GKON"      X-Windows Bitmap               GraphicConverter          image/x-xbm
-#.xl       "XLS "  "XCEL"      Excel Spreadsheet              Excel
-#.xlc      "XLC "  "XCEL"      Excel Chart                    Excel
-#.xlm      "XLM "  "XCEL"      Excel Macro                    Excel
-#.xls      "XLS "  "XCEL"      Excel Spreadsheet              Excel
-#.xlw      "XLW "  "XCEL"      Excel Workspace                Excel
-#.xm       "XM  "  "SNPL"      FastTracker MOD Music          PlayerPro
-#.xpm      "XPM "  "GKON"      X-Windows Pixmap               GraphicConverter          image/x-xpm
-#.xwd      "XWDd"  "GKON"      X-Windows Dump                 GraphicConverter          image/x-xwd
-#.Z        "ZIVU"  "SITx"      Unix Compress Archive          StuffIt Expander          application/x-compress
-#.zip      "ZIP "  "SITx"      PC ZIP Archive                 StuffIt Expander          application/zip
-#.zoo      "Zoo "  "Booz"      Zoo Archive                    MacBooz
-
-### Last Updated Jan 2, 2002
-### Use at your own risk.  Take care !
-###
-### I'd like to dedicate this as follows code to Miss.Tamaki Imazu
-###
-### Kazuhiko Okudaira the Nursery Teacher
-### kokudaira@hotmail.com
-
-#.bld  "BLD "  "GKON"  BLD                            GraphicConverter
-#.bum  ".bMp"  "GKON"  QuickTime Importer(QuickDraw)  GraphicConverter
-#.cel  "CEL "  "GKON"  KISS CEL                       GraphicConverter
-#.cur  "CUR "  "GKON"  Windows Cursor                 GraphicConverter
-#.cwj  "CWSS"  "cwkj"  ClarisWorks Document           ClarisWorks 4.0
-#.dat  "TCLl"  "GKON"  TCL image                      GraphicConverter
-#.hr   "TR80"  "GKON"  TSR-80 HR                      GraphicConverter
-#.iss  "ISS "  "GKON"  ISS                            GraphicConverter
-#.jif  "JIFf"  "GKON"  JIF99a                         GraphicConverter
-#.lwf  "lwfF"  "GKON"  LuraWave(LWF)                  GraphicConverter
-#.mbm  "MBM "  "GKON"  PSION 5(MBM)                   GraphicConverter
-#.ngg  "NGGC"  "GKON"  Mobile Phone(Nokia)Format      GraphicConverter
-#.nol  "NOL "  "GKON"  Mobile Phone(Nokia)Format      GraphicConverter
-#.pal  "8BCT"  "8BIM"  Color Table                    GraphicConverter
-#.pgc  "PGCF"  "GKON"  PGC/PGF  Atari Portfolio PCG   GraphicConverter
-#.pics "PICS"  "GKON"  PICS-PICT Sequence             GraphicConverter
-#.swf  "SWFL"  "SWF2"  Flash                          Macromedia Flash
-#.vpb  "VPB "  "GKON"  VPB QUANTEL                    GraphicConverter
-#.wbmp "WBMP"  "GKON"  WBMP                           GraphicConverter
-#.x-face  "TEXT"  "GKON"  X-Face                      GraphicConverter
-
-### Nov 29, 2002
-#.fla  "SPA "  "MFL2"  Flash source                   Macromedia Flash
+.readme   "TEXT"  "ttxt"      Text Readme                    SimpleText                application/text
+.rgba     "SGI "  "GKON"      SGI Image                      GraphicConverter          image/x-rgb
+.rgb      "SGI "  "GKON"      SGI Image                      GraphicConverter          image/x-rgb
+.rib      "TEXT"  "RINI"      Renderman 3D Data              Renderman
+.rif      "RIFF"  "GKON"      RIFF Graphic                   GraphicConverter
+.rle      "RLE "  "GKON"      RLE image                      GraphicConverter
+.rme      "TEXT"  "ttxt"      Text Readme                    SimpleText
+.rpl      "FRL!"  "REP!"      Replica Document               Replica
+.rsc      "rsrc"  "RSED"      Resource File                  ResEdit
+.rsrc     "rsrc"  "RSED"      Resource File                  ResEdit
+.rtf      "TEXT"  "MSWD"      Rich Text Format               Microsoft Word            application/rtf
+.rtx      "TEXT"  "R*ch"      Rich Text                      BBEdit                    text/richtext
+.s3m      "S3M "  "SNPL"      ScreamTracker 3 MOD            PlayerPro
+.scc      "MSX "  "GKON"      MSX pitcure                    GraphicConverter
+.scg      "RIX3"  "GKON"      ColoRIX                        GraphicConverter
+.sci      "RIX3"  "GKON"      ColoRIX                        GraphicConverter
+.scp      "RIX3"  "GKON"      ColoRIX                        GraphicConverter
+.scr      "RIX3"  "GKON"      ColoRIX                        GraphicConverter
+.scu      "RIX3"  "GKON"      ColoRIX                        GraphicConverter
+.sea      "APPL"  "????"      Self-Extracting Archive        Self Extracting Archive
+.sf       "IRCM"  "SDHK"      IRCAM Sound                    SoundHack
+.sgi      ".SGI"  "ogle"      SGI Image                      PictureViewer
+.shar     "TEXT"  "UnSh"      Unix Shell Archive             UnShar                    application/x-shar
+.sha      "TEXT"  "UnSh"      Unix Shell Archive             UnShar                    application/x-shar
+.shp      "SHPp"  "GKON"      Printmaster Icon Library       GraphicConverter
+.sithqx   "TEXT"  "SITx"      BinHexed StuffIt Archive       StuffIt Expander          application/mac-binhex40
+.sit      "SIT!"  "SITx"      StuffIt 1.5.1 Archive          StuffIt Expander          application/x-stuffit
+.six      "SIXE"  "GKON"      SIXEL image                    GraphicConverter
+.slk      "TEXT"  "XCEL"      SYLK Spreadsheet               Excel
+.snd      "BINA"  "SCPL"      Sound of various types         SoundApp
+.spc      "Spec"  "GKON"      Atari Spectrum 512             GraphicConverter
+.sr       "SUNn"  "GKON"      Sun Raster Image               GraphicConverter
+.sty      "TEXT"  "*TEX"      TeX Style                      Textures
+.sun      "SUNn"  "GKON"      Sun Raster Image               GraphicConverter
+.sup      "SCRN"  "GKON"      StartupScreen                  GraphicConverter
+.svx      "8SVX"  "SCPL"      Amiga IFF Sound                SoundApp
+.swf  "SWFL"  "SWF2"  Flash                          Macromedia Flash
+.syk      "TEXT"  "XCEL"      SYLK Spreadsheet               Excel
+.sylk     "TEXT"  "XCEL"      SYLK Spreadsheet               Excel
+.targa    "TPIC"  "GKON"      Truevision Image               GraphicConverter
+.tar      "TARF"  "SITx"      Unix Tape ARchive              StuffIt Expander          application/x-tar
+.taz      "ZIVU"  "SITx"      Compressed Tape ARchive        StuffIt Expander          application/x-compress
+.texinfo  "TEXT"  "OTEX"      TeX Document                   OzTeX                     application/x-texinfo
+.texi     "TEXT"  "OTEX"      TeX Document                   OzTeX
+.tex      "TEXT"  "OTEX"      TeX Document                   OzTeX                     application/x-tex
+.text     "TEXT"  "ttxt"      ASCII Text                     SimpleText                text/plain
+.tga      "TPIC"  "GKON"      Truevision Image               GraphicConverter
+.tgz      "Gzip"  "SITx"      Gnu ZIPed Tape ARchive         StuffIt Expander          application/x-gzip
+.tiff     "TIFF"  "ogle"      TIFF Picture                   PictureViewer             image/tiff
+.tif      "TIFF"  "ogle"      TIFF Picture                   PictureViewer             image/tiff
+.tny      "TINY"  "GKON"      Atari TINY Bitmap              GraphicConverter
+.tsv      "TEXT"  "XCEL"      Tab Separated Values           Excel                     text/tab-separated-values
+.tx8      "TEXT"  "ttxt"      8-bit ASCII Text               SimpleText
+.txt      "TEXT"  "ttxt"      ASCII Text                     SimpleText                text/plain
+.ul       "ULAW"  "TVOD"      Mu-Law Sound                   MoviePlayer               audio/basic
+.url      "AURL"  "Arch"      URL Bookmark                   Anarchie                  message/external-body
+.uue      "TEXT"  "SITx"      UUEncode                       StuffIt Expander
+.uu       "TEXT"  "SITx"      UUEncode                       StuffIt Expander
+.vff      "VFFf"  "GKON"      DESR VFF Greyscale Image       GraphicConverter
+.vga      "BMPp"  "ogle"      OS/2 Bitmap                    PictureViewer
+.voc      "VOC "  "SCPL"      VOC Sound                      SoundApp
+.vpb  "VPB "  "GKON"  VPB QUANTEL                    GraphicConverter
+.w51      ".WP5"  "WPC2"      WordPerfect PC 5.1 Doc         WordPerfect               application/wordperfect5.1
+.wav      "WAVE"  "TVOD"      Windows WAV Sound              MoviePlayer               audio/x-wav
+.wbmp "WBMP"  "GKON"  WBMP                           GraphicConverter
+.wk1      "XLBN"  "XCEL"      Lotus Spreadsheet r2.1         Excel
+.wks      "XLBN"  "XCEL"      Lotus Spreadsheet r1.x         Excel
+.wmf      "WMF "  "GKON"      Windows Metafile               GraphicConverter
+.wp4      ".WP4"  "WPC2"      WordPerfect PC 4.2 Doc         WordPerfect
+.wp5      ".WP5"  "WPC2"      WordPerfect PC 5.x Doc         WordPerfect               application/wordperfect5.1
+.wp6      ".WP6"  "WPC2"      WordPerfect PC 6.x Doc         WordPerfect
+.wpg      "WPGf"  "GKON"      WordPerfect Graphic            GraphicConverter
+.wpm      "WPD1"  "WPC2"      WordPerfect Mac                WordPerfect
+.wp       ".WP5"  "WPC2"      WordPerfect PC 5.1 Doc         WordPerfect               application/wordperfect5.1
+.wri      "WDBN"  "MSWD"      MS Write/Windows               Microsoft Word
+.wve      "BINA"  "SCPL"      PSION sound                    SoundApp
+.x10      "XWDd"  "GKON"      X-Windows Dump                 GraphicConverter          image/x-xwd
+.x11      "XWDd"  "GKON"      X-Windows Dump                 GraphicConverter          image/x-xwd
+.xbm      "XBM "  "GKON"      X-Windows Bitmap               GraphicConverter          image/x-xbm
+.x-face  "TEXT"  "GKON"  X-Face                      GraphicConverter
+.xlc      "XLC "  "XCEL"      Excel Chart                    Excel
+.xlm      "XLM "  "XCEL"      Excel Macro                    Excel
+.xls      "XLS "  "XCEL"      Excel Spreadsheet              Excel
+.xlw      "XLW "  "XCEL"      Excel Workspace                Excel
+.xl       "XLS "  "XCEL"      Excel Spreadsheet              Excel
+.xm       "XM  "  "SNPL"      FastTracker MOD Music          PlayerPro
+.xpm      "XPM "  "GKON"      X-Windows Pixmap               GraphicConverter          image/x-xpm
+.xwd      "XWDd"  "GKON"      X-Windows Dump                 GraphicConverter          image/x-xwd
+.zip      "ZIP "  "SITx"      PC ZIP Archive                 StuffIt Expander          application/zip
+.zoo      "Zoo "  "Booz"      Zoo Archive                    MacBooz
+.Z        "ZIVU"  "SITx"      Unix Compress Archive          StuffIt Expander          application/x-compress


### PR DESCRIPTION
Re-enable the file type translation configurations. They were disabled back in 2009 with https://github.com/Netatalk/netatalk/commit/df237c9a38416b32bfdd2bcab4a0d7bcbc69f78d arguing that they may be inappropriate for Mac OS X.

With Classic Mac OS being the primary use case for netatalk2, it worth revisiting this, in particular for identification of binary files downloaded from the web directly to the netatalk server file system. F.e. disk images, sit files, zip files, etc.