### PR TITLE
Better default Homes basedir regex example

### DIFF
--- a/config/afp.conf.tmpl
+++ b/config/afp.conf.tmpl
@@ -6,7 +6,7 @@
 ; Global server settings
 
 ; [Homes]
-; basedir regex = /xxxx
+; basedir regex = /home
 
 ; [My AFP Volume]
 ; path = /path/to/volume


### PR DESCRIPTION
I think the `/xxxx` Homes basedir regex example is potentially confusing to less technically proficient users. Let's use the most baseline real life example instead.