### PR TITLE
pam_conv: Only Solarish seems to use non-const struct type.

### DIFF
--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -136,7 +136,7 @@ error:
  * echo off means password.
  */
 static int PAM_conv (int num_msg,
-#ifdef LINUX
+#if !defined(__svr4__)
                      const struct pam_message **msg,
 #else
                      struct pam_message **msg,

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -80,7 +80,7 @@ static char *PAM_password;
  * echo off means password.
  */
 static int PAM_conv (int num_msg,
-#ifdef LINUX
+#if !defined(__svr4__)
                      const struct pam_message **msg,
 #else
                      struct pam_message **msg,

--- a/etc/uams/uams_pam.c
+++ b/etc/uams/uams_pam.c
@@ -53,7 +53,7 @@ extern UAM_MODULE_EXPORT void append(struct papfile *, const char *, int);
  * echo off means password.
  */
 static int PAM_conv (int num_msg,
-#ifdef LINUX
+#if !defined(__svr4__)
                      const struct pam_message **msg,
 #else
                      struct pam_message **msg,


### PR DESCRIPTION
Linux, NetBSD, and FreeBSD use this data structure in the PAM library:

```
struct pam_conv {
    int (*conv)(int num_msg, const struct pam_message **msg,
                struct pam_response **resp, void *appdata_ptr);
    void *appdata_ptr;
};
```

e.g. FreeBSD https://man.freebsd.org/cgi/man.cgi?query=pam_conv&apropos=0&sektion=3&manpath=FreeBSD+14.0-RELEASE&arch=default&format=html

Out of our supported platforms, only Solarish (Solaris-like) OSes seem to use the non-const pam_message pointer.

```
struct pam_conv {
	int (*conv)(int, struct pam_message **,
	    struct pam_response **, void *);
	void *appdata_ptr;		/* Application data ptr */
};
```

e.g. Illumos https://github.com/illumos/illumos-gate/blob/master/usr/src/lib/libpam/pam_appl.h