### PR TITLE
Enable / disable the entire spotlight support toolchain at configure time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,10 +185,7 @@ AC_NETATALK_RECVFILE
 dnl Check for libevent
 AC_NETATALK_LIBEVENT
 
-dnl Check for talloc
-AC_NETATALK_TALLOC
-
-dnl Check for Tracker
+dnl Check whether to enable Spotlight support
 AC_NETATALK_SPOTLIGHT
 
 dnl Check for dtrace

--- a/configure.ac
+++ b/configure.ac
@@ -185,7 +185,7 @@ AC_NETATALK_RECVFILE
 dnl Check for libevent
 AC_NETATALK_LIBEVENT
 
-dnl Check whether bundled talloc shall be used
+dnl Check for talloc
 AC_NETATALK_TALLOC
 
 dnl Check for Tracker

--- a/etc/afpd/Makefile.am
+++ b/etc/afpd/Makefile.am
@@ -55,7 +55,7 @@ afpd_CFLAGS = \
 	-D_PATH_CONFDIR=\"$(pkgconfdir)/\" \
 	-D_PATH_STATEDIR='"$(localstatedir)/netatalk/"'
 
-if HAVE_TRACKER
+if WITH_SPOTLIGHT
 afpd_SOURCES += spotlight.c spotlight_marshalling.c
 afpd_LDADD += $(top_builddir)/etc/spotlight/libspotlight.la @TALLOC_LIBS@
 afpd_CFLAGS += @TRACKER_CFLAGS@ @TALLOC_CFLAGS@

--- a/etc/spotlight/Makefile.am
+++ b/etc/spotlight/Makefile.am
@@ -8,7 +8,7 @@ BUILT_SOURCES =
 
 AM_YFLAGS = -d
 
-if HAVE_TRACKER
+if WITH_SPOTLIGHT
 BUILT_SOURCES += sparql_parser.h
 noinst_PROGRAMS += srp
 noinst_LTLIBRARIES += libspotlight.la

--- a/include/atalk/spotlight.h
+++ b/include/atalk/spotlight.h
@@ -26,7 +26,7 @@
 #include <atalk/globals.h>
 #include <atalk/volume.h>
 
-#ifdef HAVE_TRACKER
+#ifdef WITH_SPOTLIGHT
 #include <gio/gio.h>
 #include <tracker-sparql.h>
 #ifndef HAVE_TRACKER3

--- a/libatalk/Makefile.am
+++ b/libatalk/Makefile.am
@@ -34,7 +34,7 @@ libatalk_la_DEPENDENCIES = \
 	util/libutil.la		\
 	vfs/libvfs.la
 	
-if HAVE_TRACKER
+if WITH_SPOTLIGHT
 SUBDIRS += talloc
 libatalk_la_LIBADD += talloc/libtalloc.la
 libatalk_la_DEPENDENCIES += talloc/libtalloc.la 

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -237,9 +237,15 @@ AC_DEFUN([AC_NETATALK_LIBEVENT], [
 
 dnl Check for talloc library
 AC_DEFUN([AC_NETATALK_TALLOC], [
-    PKG_CHECK_MODULES(TALLOC, talloc, , have_talloc=yes, have_talloc=no)
+    PKG_CHECK_MODULES(TALLOC, talloc, ac_cv_have_talloc=yes, ac_cv_have_talloc=no)
+    
+    if test x"$ac_cv_have_talloc" = x"yes" ; then
+        AC_DEFINE(HAVE_TALLOC, 1, [Define if talloc library is available])
+    fi
+    
     AC_SUBST(TALLOC_CFLAGS)
     AC_SUBST(TALLOC_LIBS)
+    AM_CONDITIONAL(HAVE_TALLOC, [test x"ac_cv_have_talloc" = x"yes"])
 ])
 
 dnl Filesystem Hierarchy Standard (FHS) compatibility

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -151,7 +151,7 @@ AC_DEFUN([AC_NETATALK_DBUS_GLIB], [
   AM_CONDITIONAL(HAVE_DBUS_GLIB, test x$atalk_cv_with_dbus = xyes)
 ])
 
-dnl Tracker, for Spotlight
+dnl Spotlight support
 AC_DEFUN([AC_NETATALK_SPOTLIGHT], [
     ac_cv_have_tracker=no
     ac_cv_tracker_pkg_version_default=0.12
@@ -219,13 +219,26 @@ AC_DEFUN([AC_NETATALK_SPOTLIGHT], [
            AC_MSG_ERROR([could find neither tracker command nor tracker-control command])
         fi
     fi
+    
+    dnl Check for talloc library
+    PKG_CHECK_MODULES(TALLOC, talloc, ac_cv_have_talloc=yes, ac_cv_have_talloc=no)
+    if test x"$ac_cv_have_talloc" = x"yes" ; then
+        AC_DEFINE(HAVE_TALLOC, 1, [Define if talloc library is available])
+    fi
+    
+    dnl Enable Spotlight support
+    if test x"$ac_cv_have_talloc" = x"yes" -a x"$ac_cv_have_tracker" = x"yes" -a x"$ac_cv_have_tracker_sparql" = x"yes"; then
+        AC_DEFINE(WITH_SPOTLIGHT, 1, [Define whether to enable Spotlight support])
+    fi
 
+    AC_SUBST(DBUS_DAEMON_PATH)
+    AC_SUBST(TALLOC_CFLAGS)
+    AC_SUBST(TALLOC_LIBS)
     AC_SUBST(TRACKER_CFLAGS)
     AC_SUBST(TRACKER_LIBS)
     AC_SUBST(TRACKER_MINER_CFLAGS)
     AC_SUBST(TRACKER_MINER_LIBS)
-    AC_SUBST(DBUS_DAEMON_PATH)
-    AM_CONDITIONAL(HAVE_TRACKER, [test x"$ac_cv_have_tracker" = x"yes"])
+    AM_CONDITIONAL(WITH_SPOTLIGHT, [test x"$ac_cv_have_talloc" = x"yes" -a x"$ac_cv_have_tracker" = x"yes" -a x"$ac_cv_have_tracker_sparql" = x"yes"])
 ])
 
 dnl Check for libevent
@@ -233,19 +246,6 @@ AC_DEFUN([AC_NETATALK_LIBEVENT], [
     PKG_CHECK_MODULES(LIBEVENT, libevent, , [AC_MSG_ERROR([couldn't find libevent with pkg-config])])
     AC_SUBST(LIBEVENT_CFLAGS)
     AC_SUBST(LIBEVENT_LIBS)
-])
-
-dnl Check for talloc library
-AC_DEFUN([AC_NETATALK_TALLOC], [
-    PKG_CHECK_MODULES(TALLOC, talloc, ac_cv_have_talloc=yes, ac_cv_have_talloc=no)
-    
-    if test x"$ac_cv_have_talloc" = x"yes" ; then
-        AC_DEFINE(HAVE_TALLOC, 1, [Define if talloc library is available])
-    fi
-    
-    AC_SUBST(TALLOC_CFLAGS)
-    AC_SUBST(TALLOC_LIBS)
-    AM_CONDITIONAL(HAVE_TALLOC, [test x"ac_cv_have_talloc" = x"yes"])
 ])
 
 dnl Filesystem Hierarchy Standard (FHS) compatibility

--- a/test/afpd/Makefile.am
+++ b/test/afpd/Makefile.am
@@ -60,7 +60,7 @@ if HAVE_ACLS
 test_SOURCES += $(top_srcdir)/etc/afpd/acls.c
 endif
 
-if HAVE_TRACKER
+if WITH_SPOTLIGHT
 test_SOURCES += $(top_srcdir)/etc/afpd/spotlight.c $(top_srcdir)/etc/afpd/spotlight_marshalling.c
 test_LDADD += $(top_builddir)/etc/spotlight/libspotlight.la @TALLOC_LIBS@
 test_CFLAGS += @TRACKER_CFLAGS@ @TALLOC_CFLAGS@


### PR DESCRIPTION
1. Move talloc search macro to Spotlight support macro
2.  Compile Spotlight support only if all three components are present (talloc, tracker and tracker-sparql)