### PR TITLE
libatalk: fix parsing of macOS created AppleDouble files

### DIFF
--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -668,6 +668,11 @@ static int ad_header_read_osx(const char *path, struct adouble *ad, const struct
     int                 retry_read = 0;
 
 reread:
+    if (hst == NULL) {
+        hst = &st;
+        EC_NEG1( fstat(ad_reso_fileno(ad), hst) );
+    }
+
     LOG(log_debug, logtype_ad, "ad_header_read_osx: %s", path ? fullpathname(path) : "");
     ad_init_old(&adosx, AD_VERSION_EA, ad->ad_options);
     buf = &adosx.ad_data[0];
@@ -707,7 +712,7 @@ reread:
         return -1;
     }
 
-    if (parse_entries(&adosx, nentries, header_len) != 0) {
+    if (parse_entries(&adosx, nentries, hst->st_size) != 0) {
         LOG(log_warning, logtype_ad, "ad_header_read(%s): malformed AppleDouble",
             path ? fullpathname(path) : "");
             errno = EIO;
@@ -725,6 +730,7 @@ reread:
         }
         retry_read++;
         if (ad_convert_osx(path, &adosx) == 1) {
+            hst = NULL;
             goto reread;
         }
         errno = EIO;
@@ -738,11 +744,6 @@ reread:
         LOG(log_error, logtype_ad, "ad_header_read_osx: problem with rfork entry offset.");
         errno = EIO;
         return -1;
-    }
-
-    if (hst == NULL) {
-        hst = &st;
-        EC_NEG1( fstat(ad_reso_fileno(ad), &st) );
     }
 
     ad_setentryoff(ad, ADEID_RFORK, ad_getentryoff(&adosx, ADEID_RFORK));


### PR DESCRIPTION
header_len is just AD_DATASZ_OSX which is 82. Pass the size of the AppleDouble file to parse_entries() so the bound checks correctly work with the file size, not just the header size.

With an FinderInfo AppleDouble entry that contains embedded xattrs, the FinderInfo entry will be much larger then 32 bytes, typically it looks like this:

Entry ID   : 00000009 : Finder Info
Offset     : 00000032 : 50
Length     : 00000EB0 : 3760

As offset + length is bigger then FinderInfo, parse_entries() fails the validation.

Signed-off-by:    Ralph Boehme <slow@samba.org>
Reviewed-by:      Daniel Markstedt <daniel@mindani.net>