### PR TITLE
Compile spotlight.h only when Spotlight is enabled

### DIFF
--- a/etc/afpd/spotlight.c
+++ b/etc/afpd/spotlight.c
@@ -27,16 +27,12 @@
 #include <inttypes.h>
 #include <time.h>
 #include <utime.h>
+#include <talloc.h>
 
 #include <atalk/list.h>
 #include <atalk/errchk.h>
 #include <atalk/util.h>
 #include <atalk/logger.h>
-#if USE_BUILTIN_TALLOC
-#include <atalk/talloc.h>
-#else
-#include <talloc.h>
-#endif
 #include <atalk/dalloc.h>
 #include <atalk/byteorder.h>
 #include <atalk/netatalk_conf.h>

--- a/etc/afpd/spotlight_marshalling.c
+++ b/etc/afpd/spotlight_marshalling.c
@@ -23,15 +23,11 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <inttypes.h>
+#include <talloc.h>
 
 #include <atalk/errchk.h>
 #include <atalk/util.h>
 #include <atalk/logger.h>
-#if USE_BUILTIN_TALLOC
-#include <atalk/talloc.h>
-#else
-#include <talloc.h>
-#endif
 #include <atalk/dalloc.h>
 #include <atalk/byteorder.h>
 #include <atalk/netatalk_conf.h>

--- a/etc/spotlight/sparql_parser.c
+++ b/etc/spotlight/sparql_parser.c
@@ -75,14 +75,10 @@
   #include <stdio.h>
   #include <string.h>
   #include <time.h>
+  #include <talloc.h>
 
   #include <gio/gio.h>
 
-  #if USE_BUILTIN_TALLOC
-  #include <atalk/talloc.h>
-  #else
-  #include <talloc.h>
-  #endif
   #include <atalk/logger.h>
   #include <atalk/errchk.h>
   #include <atalk/spotlight.h>

--- a/etc/spotlight/sparql_parser.y
+++ b/etc/spotlight/sparql_parser.y
@@ -5,14 +5,10 @@
   #include <stdio.h>
   #include <string.h>
   #include <time.h>
+  #include <talloc.h>
 
   #include <gio/gio.h>
 
-  #if USE_BUILTIN_TALLOC
-  #include <atalk/talloc.h>
-  #else
-  #include <talloc.h>
-  #endif
   #include <atalk/logger.h>
   #include <atalk/errchk.h>
   #include <atalk/spotlight.h>

--- a/etc/spotlight/spotlight_rawquery_lexer.l
+++ b/etc/spotlight/spotlight_rawquery_lexer.l
@@ -6,12 +6,8 @@
 
 %{
 #include <stdbool.h>
-#include <gio/gio.h>
-#if USE_BUILTIN_TALLOC
-#include <atalk/talloc.h>
-#else
 #include <talloc.h>
-#endif
+#include <gio/gio.h>
 #include <atalk/spotlight.h>
 #ifdef HAVE_TRACKER
 #include "sparql_parser.h"

--- a/include/atalk/dalloc.h
+++ b/include/atalk/dalloc.h
@@ -19,11 +19,7 @@
 #ifndef DALLOC_H
 #define DALLOC_H
 
-#if USE_BUILTIN_TALLOC
-#include <atalk/talloc.h>
-#else
 #include <talloc.h>
-#endif
 
 /* dynamic datastore */
 typedef struct {

--- a/include/atalk/spotlight.h
+++ b/include/atalk/spotlight.h
@@ -12,6 +12,8 @@
   GNU General Public License for more details.
 */
 
+#ifdef WITH_SPOTLIGHT
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
@@ -26,12 +28,10 @@
 #include <atalk/globals.h>
 #include <atalk/volume.h>
 
-#ifdef WITH_SPOTLIGHT
 #include <gio/gio.h>
 #include <tracker-sparql.h>
 #ifndef HAVE_TRACKER3
 #include <libtracker-miner/tracker-miner.h>
-#endif
 #endif
 
 /******************************************************************************
@@ -128,3 +128,4 @@ extern int sl_unpack(DALLOC_CTX *query, const char *buf);
 extern void configure_spotlight_attributes(const char *attributes);
 
 #endif /* SPOTLIGHT_H */
+#endif /* WITH_SPOTLIGHT */

--- a/libatalk/talloc/dalloc.c
+++ b/libatalk/talloc/dalloc.c
@@ -117,15 +117,11 @@
 #include <errno.h>
 #include <stdbool.h>
 #include <inttypes.h>
+#include <talloc.h>
 
 #include <atalk/errchk.h>
 #include <atalk/util.h>
 #include <atalk/logger.h>
-#if USE_BUILTIN_TALLOC
-#include <atalk/talloc.h>
-#else
-#include <talloc.h>
-#endif
 #include <atalk/bstrlib.h>
 #include <atalk/dalloc.h>
 


### PR DESCRIPTION
The dalloc.h header depends on talloc so it shouldn't be imported without the Spotlight toolchain.

Also, the symbols in spotlight.h aren't needed without Spotlight to let's ifdef them away (unless there's a more graceful way to do this?)