### PR TITLE
Introduce option to control the format of file log timestamp

### DIFF
--- a/bin/ad/ad.c
+++ b/bin/ad/ad.c
@@ -25,6 +25,7 @@
 #include <signal.h>
 #include <string.h>
 #include <errno.h>
+#include <stdbool.h>
 
 #include <atalk/cnid.h>
 #include <atalk/logger.h>
@@ -56,7 +57,7 @@ int main(int argc, char **argv)
     if (afp_config_parse(&obj, "ad") != 0)
         return 1;
 
-    setuplog("default:note", "/dev/tty");
+    setuplog("default:note", "/dev/tty", true);
 
     if (load_volumes(&obj, LV_DEFAULT) != 0)
         return 1;

--- a/bin/misc/logger_test.c
+++ b/bin/misc/logger_test.c
@@ -43,11 +43,11 @@ int main(int argc, char *argv[])
 #endif
   /* filelog testing */
 
-  setuplog("DSI:maxdebug", "test.log");
+  setuplog("DSI:maxdebug", "test.log", true);
   LOG(log_info, logtype_dsi, "This should log.");
   LOG(log_error, logtype_default, "This should not log.");
 
-  setuplog("Default:debug", "test.log");
+  setuplog("Default:debug", "test.log", true);
   LOG(log_debug, logtype_default, "This should log.");
   LOG(log_maxdebug, logtype_default, "This should not log.");
 

--- a/bin/misc/uuidtest.c
+++ b/bin/misc/uuidtest.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
+#include <stdbool.h>
 
 #ifdef HAVE_LDAP
 #define LDAP_DEPRECATED 1
@@ -86,14 +87,14 @@ int main( int argc, char **argv)
         case 'v':
             if (! verbose) {
                 verbose = 1;
-                setuplog("default:maxdebug", "/dev/tty");
+                setuplog("default:maxdebug", "/dev/tty", true);
                 logsetup = 1;
             }
             break;
 
         case 'u':
             if (! logsetup)
-                setuplog("default:info", "/dev/tty");
+                setuplog("default:info", "/dev/tty", true);
             parse_ldapconf();
             printf("Searching user: %s\n", optarg);
             ret = getuuidfromname( optarg, UUID_USER, uuid);
@@ -106,7 +107,7 @@ int main( int argc, char **argv)
 
         case 'g':
             if (! logsetup)
-                setuplog("default:info", "/dev/tty");
+                setuplog("default:info", "/dev/tty", true);
             parse_ldapconf();
             printf("Searching group: %s\n", optarg);
             ret = getuuidfromname( optarg, UUID_GROUP, uuid);
@@ -119,7 +120,7 @@ int main( int argc, char **argv)
 
         case 'i':
             if (! logsetup)
-                setuplog("default:info", "/dev/tty");
+                setuplog("default:info", "/dev/tty", true);
             parse_ldapconf();
             printf("Searching uuid: %s\n", optarg);
             uuid_string2bin(optarg, uuid);

--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -1240,6 +1240,18 @@
             </note>
           </listitem>
         </varlistentry>
+
+        <varlistentry>
+          <term>log microseconds = <replaceable>BOOLEAN</replaceable> (default:
+          <emphasis>yes</emphasis>
+          <type>(G)</type></term>
+
+          <listitem>
+            <para>Log timestamps with accuracy down to microseconds.
+            If disabled, the timestamps record only full seconds.
+            Used in tandem with <option>log file</option>.</para>
+          </listitem>
+        </varlistentry>
       </variablelist>
     </refsect2>
 

--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -15,6 +15,7 @@
 #include <signal.h>
 #include <string.h>
 #include <errno.h>
+#include <stdbool.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif /* HAVE_UNISTD_H */
@@ -560,15 +561,15 @@ void afp_over_dsi(AFPObj *obj)
 
             if (debugging) {
                 if (obj->options.logconfig)
-                    setuplog(obj->options.logconfig, obj->options.logfile);
+                    setuplog(obj->options.logconfig, obj->options.logfile, obj->options.log_us_timestamp);
                 else
-                    setuplog("default:note", NULL);
+                    setuplog("default:note", NULL, true);
                 debugging = 0;
             } else {
                 char logstr[50];
                 debugging = 1;
                 sprintf(logstr, "/tmp/afpd.%u.XXXXXX", getpid());
-                setuplog("default:maxdebug", logstr);
+                setuplog("default:maxdebug", logstr, true);
             }
         }
 

--- a/etc/cnid_dbd/cmd_dbd.c
+++ b/etc/cnid_dbd/cmd_dbd.c
@@ -26,6 +26,7 @@
 #include <string.h>
 #include <errno.h>
 #include <pwd.h>
+#include <stdbool.h>
 
 #include <atalk/logger.h>
 #include <atalk/globals.h>
@@ -214,9 +215,9 @@ int main(int argc, char **argv)
 
     /* Setup logging. Should be portable among *NIXes */
     if (flags & DBD_FLAGS_VERBOSE)
-        setuplog("default:note, cnid:debug", "/dev/tty");
+        setuplog("default:note, cnid:debug", "/dev/tty", true);
     else
-        setuplog("default:note", "/dev/tty");
+        setuplog("default:note", "/dev/tty", true);
 
     /* Set username */
     if (username) {

--- a/include/atalk/globals.h
+++ b/include/atalk/globals.h
@@ -126,6 +126,7 @@ struct afp_options {
     char *ntdomain, *ntseparator, *addomain;
     char *logconfig;
     char *logfile;
+    bool log_us_timestamp;
     char *mimicmodel;
     char *zeroconfname;
     char *adminauthuser;

--- a/include/atalk/logger.h
+++ b/include/atalk/logger.h
@@ -144,6 +144,7 @@ typedef struct {
     int            fd;            /* logfiles fd */
     enum loglevels level;         /* Log Level to put in this file */
     int            display_options;
+    bool           timestamp_us;  /* Log time stamps in us instead of s */
 } logtype_conf_t;
 
 
@@ -160,11 +161,11 @@ extern UAM_MODULE_EXPORT logtype_conf_t type_configs[logtype_end_of_list_marker]
     Global function decarations
    ========================================================================= */
 
-void setuplog(const char *loglevel, const char *logfile);
+void setuplog(const char *loglevel, const char *logfile, const bool log_us_timestamp);
 void set_processname(const char *processname);
 
 /* LOG macro func no.1: log the message to file */
-UAM_MODULE_EXPORT  void make_log_entry(enum loglevels loglevel, enum logtypes logtype, const char *file, int line, char *message, ...);
+UAM_MODULE_EXPORT  void make_log_entry(enum loglevels loglevel, enum logtypes logtype, const char *file, const bool log_us_timestamp, int line, char *message, ...);
 
 /*
  * How to write a LOG macro:
@@ -183,7 +184,7 @@ UAM_MODULE_EXPORT  void make_log_entry(enum loglevels loglevel, enum logtypes lo
     do {                                                                \
         if (log_level <= LOG_MAX)                                       \
             if (log_level <= type_configs[type].level)                  \
-                make_log_entry((log_level), (type), __FILE__, __LINE__,  __VA_ARGS__); \
+                make_log_entry((log_level), (type), __FILE__, type_configs[type].timestamp_us, __LINE__,  __VA_ARGS__); \
     } while(0)
 
 #else  /* ! NO_DEBUG */
@@ -191,7 +192,7 @@ UAM_MODULE_EXPORT  void make_log_entry(enum loglevels loglevel, enum logtypes lo
 #define LOG(log_level, type, ...)               \
     do {                                                                \
         if (log_level <= type_configs[type].level)                      \
-            make_log_entry((log_level), (type), __FILE__, __LINE__,  __VA_ARGS__); \
+            make_log_entry((log_level), (type), __FILE__, type_configs[type].timestamp_us, __LINE__,  __VA_ARGS__); \
     } while(0)
 
 #endif  /* NO_DEBUG */

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2029,8 +2029,9 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     /* [Global] */
     options->logconfig = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "log level", "default:note");
     options->logfile   = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "log file",  NULL);
+    options->log_us_timestamp = atalk_iniparser_getboolean(config, INISEC_GLOBAL, "log microseconds", 1);
 
-    setuplog(options->logconfig, options->logfile);
+    setuplog(options->logconfig, options->logfile, options->log_us_timestamp);
 
     /* "server options" boolean options */
     if (!atalk_iniparser_getboolean(config, INISEC_GLOBAL, "zeroconf", 1))

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -60,7 +60,7 @@ int main(int argc, char **argv)
 
     /* initialize */
     printf("Initializing\n============\n");
-    TEST(setuplog("default:note","/dev/tty"));
+    TEST(setuplog("default:note", "/dev/tty", true));
 
     TEST( afp_options_parse_cmdline(&obj, 3, &args[0]) );
 


### PR DESCRIPTION
Introduces a boolean afp.conf option "log microseconds", enabled by default, which turns on and off microsecond timestamps in file logs.