### PR TITLE
Revert Asante and Dayna GS/OS Fix.

### DIFF
--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -547,14 +547,7 @@ static void as_timer(int sig _U_)
 		    }
 
 		    /* split horizon */
-
-		    /* Made the AsanteTalk bridge consistently start up in
-		     * AppleTalk Phase 2, and stop the Dayna bridge from
-		     * crashing GS/OS.
-		     *
-		     * if (rtmp->rt_iface == iface) {
-		     */
-		    if (rtmp->rt_iface != iface) {
+		    if (rtmp->rt_iface == iface) {
 		        continue;
 		    }
 


### PR DESCRIPTION
This patch was causing unintended side effects, namely atalkd ceased broadcasting RTMP routing tuples to other routers on the network. Confirmed issue testing with a Shiva Fastpath 5 hardware router and a software router called TashRouter.