### PR TITLE
Fix Spotlight support detection and compilation on Fedora

### DIFF
--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -42,7 +42,9 @@
 #include <atalk/fce_api.h>
 #include <atalk/globals.h>
 #include <atalk/netatalk_conf.h>
+#ifdef WITH_SPOTLIGHT
 #include <atalk/spotlight.h>
+#endif
 
 #include "switch.h"
 #include "auth.h"

--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -40,7 +40,9 @@ extern void afp_get_cmdline( int *ac, char ***av );
 #include <atalk/uuid.h>
 #include <atalk/globals.h>
 #include <atalk/fce_api.h>
+#ifdef WITH_SPOTLIGHT
 #include <atalk/spotlight.h>
+#endif
 #include <atalk/unix.h>
 
 #include "auth.h"

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -25,7 +25,9 @@
 #include <atalk/globals.h>
 #include <atalk/fce_api.h>
 #include <atalk/netatalk_conf.h>
+#ifdef WITH_SPOTLIGHT
 #include <atalk/spotlight.h>
+#endif
 #include <atalk/dsi.h>
 
 #include "directory.h"

--- a/include/atalk/spotlight.h
+++ b/include/atalk/spotlight.h
@@ -128,4 +128,3 @@ extern int sl_unpack(DALLOC_CTX *query, const char *buf);
 extern void configure_spotlight_attributes(const char *attributes);
 
 #endif /* SPOTLIGHT_H */
-#endif /* WITH_SPOTLIGHT */

--- a/include/atalk/spotlight.h
+++ b/include/atalk/spotlight.h
@@ -12,8 +12,6 @@
   GNU General Public License for more details.
 */
 
-#ifdef WITH_SPOTLIGHT
-
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
@@ -24,14 +22,16 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include <atalk/dalloc.h>
 #include <atalk/globals.h>
 #include <atalk/volume.h>
 
+#ifdef WITH_SPOTLIGHT
 #include <gio/gio.h>
 #include <tracker-sparql.h>
+#include <atalk/dalloc.h>
 #ifndef HAVE_TRACKER3
 #include <libtracker-miner/tracker-miner.h>
+#endif
 #endif
 
 /******************************************************************************


### PR DESCRIPTION
Tested on Fedora39 x86_64 and aarch64 with configuration as per the wiki. Also tested on FreeBSD14, Debian12