### PR TITLE
Improve logger_test and remove outdated comments

### DIFF
--- a/bin/misc/.gitignore
+++ b/bin/misc/.gitignore
@@ -7,5 +7,4 @@ logger_test
 .deps
 .libs
 *.o
-
-
+*.log

--- a/bin/misc/Makefile.am
+++ b/bin/misc/Makefile.am
@@ -11,7 +11,7 @@ netacnv_LDADD = $(top_builddir)/libatalk/libatalk.la @MYSQL_LIBS@
 logger_test_SOURCES = logger_test.c
 logger_test_LDADD = $(top_builddir)/libatalk/libatalk.la @MYSQL_LIBS@
 
-fce_SOOURCE = fce.c
+fce_SOURCES = fce.c
 fce_LDADD = $(top_builddir)/libatalk/libatalk.la @MYSQL_LIBS@
 fce_CFLAGS = -I$(top_srcdir)/include
 

--- a/bin/misc/logger_test.c
+++ b/bin/misc/logger_test.c
@@ -24,41 +24,42 @@
 int main(int argc, char *argv[])
 {
   set_processname("logger_Test");
-#if 0
-  LOG(log_severe, logtype_logger, "Logging Test starting: this should only log to syslog");
 
   /* syslog testing */
-  LOG(log_severe, logtype_logger, "Disabling syslog logging.");
-  unsetuplog("Default");
-  LOG(log_error, logtype_default, "This shouldn't log to syslog: LOG(log_error, logtype_default).");
-  LOG(log_error, logtype_logger, "This shouldn't log to syslog: LOG(log_error, logtype_logger).");
-  setuplog("Default LOG_INFO");
-  LOG(log_info, logtype_logger, "Set syslog logging to 'log_info', so this should log again. LOG(log_info, logtype_logger).");
-  LOG(log_error, logtype_logger, "This should log to syslog: LOG(log_error, logtype_logger).");
-  LOG(log_error, logtype_default, "This should log to syslog. LOG(log_error, logtype_default).");
-  LOG(log_debug, logtype_logger, "This shouldn't log to syslog. LOG(log_debug, logtype_logger).");
-  LOG(log_debug, logtype_default, "This shouldn't log to syslog. LOG(log_debug, logtype_default).");
-  LOG(log_severe, logtype_logger, "Disabling syslog logging.");
-  unsetuplog("Default");
-#endif
+
+  setuplog("default:severe", NULL, false);
+  LOG(log_severe, logtype_logger, "[1/4] Syslog Test starting: this should only log to syslog LOG(log_severe, logtype_default).");
+
+  setuplog("default:info", NULL, false);
+  LOG(log_info, logtype_logger, "[2/4] Set syslog logging to 'log_info', so this should log again. LOG(log_info, logtype_logger).");
+  LOG(log_error, logtype_logger, "[3/4] This should log to syslog: LOG(log_error, logtype_logger).");
+  LOG(log_error, logtype_default, "[4/4] This should log to syslog. LOG(log_error, logtype_default).");
+  LOG(log_debug, logtype_logger, "[1/2] This shouldn't log to syslog. LOG(log_debug, logtype_logger).");
+  LOG(log_debug, logtype_default, "[2/2] This shouldn't log to syslog. LOG(log_debug, logtype_default).");
+
   /* filelog testing */
 
-  setuplog("DSI:maxdebug", "test.log", true);
-  LOG(log_info, logtype_dsi, "This should log.");
-  LOG(log_error, logtype_default, "This should not log.");
+  setuplog("default:severe", "test.log", true);
+  LOG(log_severe, logtype_logger, "[1/4] Filelog Test starting: this should only log to file LOG(log_severe, logtype_default).");
+  setuplog("dsi:maxdebug", "test.log", true);
+  LOG(log_info, logtype_dsi, "[2/4] This should log LOG(log_info, logtype_dsi).");
+  LOG(log_error, logtype_default, "[1/2] This should not log LOG(log_default, logtype_dsi).");
 
-  setuplog("Default:debug", "test.log", true);
-  LOG(log_debug, logtype_default, "This should log.");
-  LOG(log_maxdebug, logtype_default, "This should not log.");
+  setuplog("default:debug", "test.log", true);
+  LOG(log_debug, logtype_default, "[3/4] This should log LOG(log_debug, logtype_default).");
+  LOG(log_maxdebug, logtype_default, "[2/2] This should not log LOG(log_maxdebug, logtype_default).");
 
-  LOG(log_maxdebug, logtype_dsi, "This should still log.");
+  LOG(log_maxdebug, logtype_dsi, "[4/4] This should still log LOG(log_maxdebug, logtype_dsi).");
 
   /* flooding prevention check */
+
   LOG(log_debug, logtype_default, "Flooding 3x");
   for (int i = 0; i < 3; i++) {
       LOG(log_debug, logtype_default, "Flooding...");
   }
+
   /* wipe the array */
+
   LOG(log_debug, logtype_default, "1"); LOG(log_debug, logtype_default, "2"); LOG(log_debug, logtype_default, "3");
 
   LOG(log_debug, logtype_default, "-============");
@@ -108,5 +109,4 @@ int main(int argc, char *argv[])
 
   return 0;
 }
-
 

--- a/include/atalk/logger.h
+++ b/include/atalk/logger.h
@@ -1,60 +1,6 @@
 #ifndef _ATALK_LOGGER_H
 #define _ATALK_LOGGER_H 1
 
-/*
- * logger LOG Macro Usage
- * ======================
- *
- * LOG(<logtype>, <loglevel>, "<string>"[, args]);
- *
- *
- * logger API Setup
- * ================
- *
- * Standard interface:
- * -------------------
- *
- *    setuplog(char *confstring)
- *    confstring = "<logtype> <loglevel> [<filename>]"
- *
- * Calling without <filename> configures basic logging to syslog. Specifying <filename>
- * configures extended logging to <filename>.
- *
- * You can later disable logging by calling
- *
- *    unsetuplog(char *confstring)
- *    confstring = "<logtype> [<any_string>]"
- *
- * Calling without <any_string> disables syslog logging, calling with <any_string>
- * disables file logging.
- *
- * <logtype>:
- * you can setup a default with "Default". Any other logtype used in LOG will then
- * use the default if not setup itself. This is probabyl the only thing you may
- * want to use.
- *
- * Example:
- * setuplog("default log_debug /var/log/debug.log");
- * See also libatalk/util/test/logger_test.c
- *
- * "Legacy" interface:
- * -------------------
- *
- * Some netatalk daemons (31.3.2009.: e.g. atalkd, papd) may not be converted to
- * use the new API and might still call
- *
- *    syslog_setup(int loglevel, enum logtypes logtype, int display_options, int facility);
- *
- * directly. These daemons are therefore limited to syslog logging. Also their
- * loglevel can't be changed at runtime.
- *
- *
- * Note:
- * don't get confused by log_init(). It only gets called if your app
- * forgets to setup logging before calling LOG.
- */
-
-
 #include <limits.h>
 #include <stdio.h>
 #include <stdbool.h>


### PR DESCRIPTION
Improved logger_test:
- log type identifiers should be lower case
- Uncommended the syslog tests, and brought their logging API calls up to date
- Added a switch to the default log scope when changing from syslog to file log, otherwise the file logging didn’t take effect.
- Fleshed out and numbered the test case outputs


Additionally: removed inline documentation of the log API that was outdated. The code itself is readable enough to serve as documentation. 