### PR TITLE
[2.3] Switch from compile-time debug to run-time debug where applicable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -199,44 +199,6 @@ AC_ARG_ENABLE(ddp,
 	]
 )
 
-AC_MSG_CHECKING([whether to enable debug code])
-AC_ARG_ENABLE(debug1,
-	[  --enable-debug1         enable debug code],[
-	if test "$enableval" != "no"; then
-		if test "$enableval" = "yes"; then
-			AC_DEFINE(DEBUG1, 1, [Define if debugging information should be included])
-		else
-			AC_DEFINE_UNQUOTED(DEBUG1, $enableval, [Define if debugging information should be included])
-		fi 
-		AC_MSG_RESULT([yes])
-	else
-		AC_MSG_RESULT([no])
-	fi
-	],[
-		AC_MSG_RESULT([no])
-	]
-)
-
-AC_MSG_CHECKING([whether to enable verbose debug code])
-AC_ARG_ENABLE(debug,
-	[  --enable-debug          enable verbose debug code],[
-	if test "$enableval" != "no"; then
-		if test "$enableval" = "yes"; then
-			AC_DEFINE(DEBUG, 1, [Define if verbose debugging information should be included])
-		else
-			AC_DEFINE_UNQUOTED(DEBUG, $enableval, [Define if verbose debugging information should be included])
-		fi 
-		AC_MSG_RESULT([yes])
-	else
-		AC_MSG_RESULT([no])
-        AC_DEFINE(NDEBUG, 1, [Disable assertions])
-	fi
-	],[
-		AC_MSG_RESULT([no])
-        AC_DEFINE(NDEBUG, 1, [Disable assertions])
-	]
-)
-
 AC_MSG_CHECKING([whether to enable debugging with debuggers])
 AC_ARG_ENABLE(debugging,
 	[  --enable-debugging      disable SIGALRM timers and DSI tickles (eg for debugging with gdb/dbx/...)],[

--- a/doc/manual/man/man5/afpd.conf.5.xml
+++ b/doc/manual/man/man5/afpd.conf.5.xml
@@ -736,10 +736,10 @@
       </varlistentry>
 
       <varlistentry>
-        <term>-nodebug</term>
+        <term>-debug</term>
 
         <listitem>
-          <para>Disables debugging.</para>
+          <para>Prevents afpd from forking, for debugging purposes.</para>
         </listitem>
       </varlistentry>
 

--- a/doc/manual/man/man8/afpd.8.xml
+++ b/doc/manual/man/man8/afpd.8.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>8</manvolnum>
 
-    <refmiscinfo class="date">01 Mar 2023</refmiscinfo>
+    <refmiscinfo class="date">24 Dec 2023</refmiscinfo>
 
     <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
   </refmeta>
@@ -89,9 +89,7 @@
         <term>-d</term>
 
         <listitem>
-          <para>Specifies that the daemon should not fork. If netatalk has
-          been configured with <emphasis>--enable-debug1</emphasis>, a trace
-          of all AFP commands will be written to stdout.</para>
+          <para>Prevents the daemon from forking, for debugging purposes.</para>
         </listitem>
       </varlistentry>
 

--- a/doc/manual/man/man8/papd.8.xml
+++ b/doc/manual/man/man8/papd.8.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>8</manvolnum>
 
-    <refmiscinfo class="date">01 Mar 2023</refmiscinfo>
+    <refmiscinfo class="date">24 Dec 2023</refmiscinfo>
 
     <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
   </refmeta>
@@ -210,8 +210,7 @@
         <term>-d</term>
 
         <listitem>
-          <para>Do not fork or disassociate from the terminal. Write some
-          debugging information to stderr.</para>
+          <para>Do not fork or disassociate from the terminal.</para>
         </listitem>
       </varlistentry>
 

--- a/etc/afpd/afp_asp.c
+++ b/etc/afpd/afp_asp.c
@@ -212,9 +212,7 @@ void afp_over_asp(AFPObj *obj)
     ASP asp;
     struct sigaction  action;
     int		func,  reply = 0;
-#ifdef DEBUG1
     int ccnt = 0;
-#endif    
 
     AFPobj = obj;
     obj->exit = afp_asp_die;
@@ -306,22 +304,13 @@ void afp_over_asp(AFPObj *obj)
             afp_asp_close(obj);
             LOG(log_info, logtype_afpd, "done" );
 
-#ifdef DEBUG1
-            if ( obj->options.flags & OPTION_DEBUG ) {
-                printf( "done\n" );
-            }
-#endif
             return;
             break;
 
         case ASPFUNC_CMD :
             func = (u_char) asp->commands[0];
-#ifdef DEBUG1
-            if ( obj->options.flags & OPTION_DEBUG ) {
-                printf("command: %d (%s)\n", func, AfpNum2name(func));
-                bprint( asp->commands, asp->cmdlen );
-            }
-#endif            
+            LOG(log_debug9, logtype_afpd, "command: %d (%s)\n", func, AfpNum2name(func));
+
             if ( afp_switch[ func ] != NULL ) {
                 /*
                  * The function called from afp_switch is expected to
@@ -338,12 +327,9 @@ void afp_over_asp(AFPObj *obj)
                 asp->datalen = 0;
                 reply = AFPERR_NOOP;
             }
-#ifdef DEBUG1
-            if ( obj->options.flags & OPTION_DEBUG ) {
-                printf( "reply: %d, %d\n", reply, ccnt++ );
-                bprint( asp->data, asp->datalen );
-            }
-#endif
+
+            LOG(log_debug9, logtype_afpd, "reply: %d, %d\n", reply, ccnt++ );
+
             if ( asp_cmdreply( asp, reply ) < 0 ) {
                 LOG(log_error, logtype_afpd, "asp_cmdreply: %s", strerror(errno) );
                 afp_asp_die(EXITERR_CLNT);
@@ -352,12 +338,9 @@ void afp_over_asp(AFPObj *obj)
 
         case ASPFUNC_WRITE :
             func = (u_char) asp->commands[0];
-#ifdef DEBUG1
-            if ( obj->options.flags & OPTION_DEBUG ) {
-                printf( "(write) command: %d\n", func );
-                bprint( asp->commands, asp->cmdlen );
-            }
-#endif
+
+            LOG(log_debug9, logtype_afpd, "(write) command: %d\n", func );
+
             if ( afp_switch[ func ] != NULL ) {
                 asp->datalen = ASP_DATASIZ;
                 reply = (*afp_switch[ func ])(obj,
@@ -368,12 +351,9 @@ void afp_over_asp(AFPObj *obj)
                 asp->datalen = 0;
                 reply = AFPERR_NOOP;
             }
-#ifdef DEBUG1
-            if ( obj->options.flags & OPTION_DEBUG ) {
-                printf( "(write) reply code: %d, %d\n", reply, ccnt++ );
-                bprint( asp->data, asp->datalen );
-            }
-#endif
+
+            LOG(log_debug9, logtype_afpd, "(write) reply code: %d, %d\n", reply, ccnt++ );
+
             if ( asp_wrtreply( asp, reply ) < 0 ) {
                 LOG(log_error, logtype_afpd, "asp_wrtreply: %s", strerror(errno) );
                 afp_asp_die(EXITERR_CLNT);
@@ -387,12 +367,12 @@ void afp_over_asp(AFPObj *obj)
             LOG(log_info, logtype_afpd, "main: asp_getrequest: %d", reply );
             break;
         }
-#ifdef DEBUG1
+
         if ( obj->options.flags & OPTION_DEBUG ) {
             of_pforkdesc( stdout );
             fflush( stdout );
         }
-#endif
+
     }
 }
 

--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -216,8 +216,8 @@ int afp_options_parseline(char *buf, struct afp_options *options)
         options->server = opt;
 
     /* parse toggles */
-    if (strstr(buf, " -nodebug"))
-        options->flags &= ~OPTION_DEBUG;
+    if (strstr(buf, " -debug"))
+        options->flags |= OPTION_DEBUG;
 #ifdef USE_SRVLOC
     if (strstr(buf, " -slp"))
         options->flags &= ~OPTION_NOSLP;

--- a/etc/afpd/desktop.c
+++ b/etc/afpd/desktop.c
@@ -38,7 +38,6 @@
 #include "desktop.h"
 #include "mangle.h"
 
-
 int afp_opendt(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t *rbuflen)
 {
     struct vol	*vol;
@@ -225,12 +224,7 @@ addicon_err:
         if ((asp_wrtcont(obj->handle, rbuf, &buflen) < 0) || buflen != bsize)
             return( AFPERR_PARAM );
 
-#ifdef DEBUG1
-        if (obj->options.flags & OPTION_DEBUG) {
-            printf("(write) len: %d\n", (unsigned long) buflen);
-            bprint(rbuf, buflen);
-        }
-#endif
+	LOG(log_debug9, logtype_afpd, "(write) len: %d\n", buflen);
 
         /*
          * We're at the end of the file, add the headers, etc.  */
@@ -577,9 +571,8 @@ char *mtoupath(const struct vol *vol, char *mpath, cnid_t did, int utf8)
 	    return NULL;
     }
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_afpd, "mtoupath: '%s':'%s'", mpath, upath);
-#endif /* DEBUG */
+
     return( upath );
 }
 
@@ -613,9 +606,8 @@ char *utompath(const struct vol *vol, char *upath, cnid_t id, int utf8)
 
     m = mangle(vol, mpath, outlen, upath, id, flags);
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_afpd, "utompath: '%s':'%s':'%2.2X'", upath, m, ntohl(id));
-#endif /* DEBUG */
+
     return(m);
 
 utompath_error:

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -857,9 +857,7 @@ int setfilparams(struct vol *vol,
     ssize_t len;
     char symbuf[MAXPATHLEN+1];
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_afpd, "begin setfilparams:");
-#endif /* DEBUG */
 
     adp = of_ad(vol, path, &ad);
     upath = path->u_name;
@@ -1090,9 +1088,8 @@ setfilparam_done:
         setdirparams(vol, &Cur_Path, bitmap, (char *)&newdate);
     }
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_afpd, "end setfilparams:");
-#endif /* DEBUG */
+
     return err;
 }
 
@@ -1375,9 +1372,7 @@ static int copy_all(const int dfd, const void *buf,
 {
     ssize_t cc;
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_afpd, "begin copy_all:");
-#endif /* DEBUG */
 
     while (buflen > 0) {
         if ((cc = write(dfd, buf, buflen)) < 0) {
@@ -1391,9 +1386,7 @@ static int copy_all(const int dfd, const void *buf,
         buflen -= cc;
     }
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_afpd, "end copy_all:");
-#endif /* DEBUG */
 
     return 0;
 }

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -36,12 +36,6 @@
 #include "desktop.h"
 #include "volume.h"
 
-#ifdef DEBUG1
-#define Debug(a) ((a)->options.flags & OPTION_DEBUG)
-#else
-#define Debug(a) (0)
-#endif
-
 static int getforkparams(struct ofork *ofork, u_int16_t bitmap, char *buf, size_t *buflen)
 {
     struct path         path;
@@ -942,7 +936,7 @@ static int read_fork(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, si
         /* due to the nature of afp packets, we have to exit if we get
            an error. we can't do this with translation on. */
 #ifdef WITH_SENDFILE 
-        if (!(xlate || Debug(obj) )) {
+        if (!(xlate || obj->options.flags & OPTION_DEBUG)) {
             int fd;
                         
             fd = ad_readfile_init(ofork->of_ad, eid, &offset, 0);
@@ -1265,12 +1259,11 @@ static int write_fork(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, s
             return( AFPERR_PARAM );
         }
 
-#ifdef DEBUG1
         if (obj->options.flags & OPTION_DEBUG) {
             printf("(write) len: %ld\n", (unsigned long) *rbuflen);
             bprint(rbuf, *rbuflen);
         }
-#endif
+
         if ((cc = write_file(ofork, eid, offset, rbuf, *rbuflen,
                              xlate)) < 0) {
             *rbuflen = 0;

--- a/etc/afpd/messages.c
+++ b/etc/afpd/messages.c
@@ -22,7 +22,6 @@
 
 #include "misc.h"
 
-
 #define MAXMESGSIZE 199
 
 /* this is only used by afpd children, so it's okay. */
@@ -57,9 +56,7 @@ void readmessage(AFPObj *obj)
 
     sprintf(filename, "%s/message.%d", SERVERTEXT, getpid());
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_afpd, "Reading file %s ", filename);
-#endif 
 
     message=fopen(filename, "r");
     if (message==NULL) {
@@ -100,13 +97,13 @@ void readmessage(AFPObj *obj)
         if (rc < 0) {
             LOG(log_error, logtype_afpd, "Error deleting %s: %s", filename, strerror(rc));
         }
-#ifdef DEBUG
+
         else {
-            LOG(log_debug9, logtype_afpd, "Deleted %s", filename);
+	    LOG(log_debug9, logtype_afpd, "Deleted %s", filename);
         }
 
-        LOG(log_debug9, logtype_afpd, "Set server message to \"%s\"", servermesg);
-#endif
+	LOG(log_debug9, logtype_afpd, "Set server message to \"%s\"", servermesg);
+
     }
     free(filename);
 #endif /* SERVERTEXT */

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -60,7 +60,6 @@ static void of_unhash(struct ofork *of)
     }
 }
 
-#ifdef DEBUG1
 void of_pforkdesc( FILE *f)
 {
     int ofrefnum;
@@ -74,7 +73,6 @@ void of_pforkdesc( FILE *f)
         }
     }
 }
-#endif
 
 int of_flush(const struct vol *vol)
 {

--- a/etc/atalkd/rtmp.c
+++ b/etc/atalkd/rtmp.c
@@ -39,6 +39,8 @@
 #include "route.h"
 #include "main.h"
 
+extern int debug;
+
 void rtmp_delzonemap(struct rtmptab *rtmp)
 {
     struct list		*lz, *flz, *lr, *flr;
@@ -793,11 +795,9 @@ int rtmp_packet(struct atport *ap, struct sockaddr_at *from, char *data, int len
 		LOG(log_error, logtype_atalkd, "as_timer sendto: %s", strerror(errno) );
 	    }
 	} else if ( *data == 2 || *data == 3 ) {
-#ifdef DEBUG
-	    printf( "rtmp_packet rdr (%d) from %u.%u\n",
+            LOG(log_debug, logtype_atalkd, "rtmp_packet rdr (%d) from %u.%u\n",
 		    *data, ntohs( from->sat_addr.s_net ),
 		    from->sat_addr.s_node );
-#endif /* DEBUG */
 	} else {
 	    LOG(log_info, logtype_atalkd, "rtmp_packet unknown request from %u.%u",
 		    ntohs( from->sat_addr.s_net ), from->sat_addr.s_node );

--- a/etc/atalkd/zip.c
+++ b/etc/atalkd/zip.c
@@ -43,7 +43,6 @@
 
 struct ziptab	*ziptab = NULL, *ziplast = NULL;
 
-
 static int zonecheck(struct rtmptab *rtmp, struct interface *iface)
 {
     struct list		*l;
@@ -736,10 +735,8 @@ int zip_packet(struct atport *ap,struct sockaddr_at *from, char *data, int len)
 	    break;
 
 	case ZIPOP_NOTIFY :
-#ifdef DEBUG
-	    printf( "zip notify from %u.%u\n", ntohs( from->sat_addr.s_net ),
-		    from->sat_addr.s_node );
-#endif /* DEBUG */
+	    LOG(log_debug, logtype_atalkd, "zip notify from %u.%u\n", ntohs( from->sat_addr.s_net ),
+		from->sat_addr.s_node );
 	    break;
 
 	default :

--- a/etc/papd/headers.c
+++ b/etc/papd/headers.c
@@ -127,9 +127,7 @@ int ch_title( struct papfile *in, struct papfile *out _U_)
         return( CH_ERROR );
     }
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_papd, "Parsing %%Title");
-#endif
 
     cmt = get_text(start, linelength);
 
@@ -194,9 +192,8 @@ int ch_endcomm( struct papfile *in, struct papfile *out _U_)
     char                *start;
     int                 linelength, crlflength;
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_papd, "End Comment");
-#endif
+
     in->pf_state |= PF_STW;
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
@@ -223,9 +220,7 @@ int ch_starttranslate( struct papfile *in, struct papfile *out _U_)
     char                *start;
     int                 linelength, crlflength;
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_papd, "Start translate");
-#endif
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :
@@ -250,9 +245,7 @@ int ch_endtranslate(struct papfile *in, struct papfile *out _U_)
     char                *start;
     int                 linelength, crlflength;
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_papd, "EndTranslate");
-#endif
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :
@@ -277,9 +270,7 @@ int ch_translateone( struct papfile *in, struct papfile *out _U_)
     char                *start;
     int                 linelength, crlflength;
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_papd, "TranslateOne");
-#endif
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :

--- a/etc/papd/lp.c
+++ b/etc/papd/lp.c
@@ -185,22 +185,16 @@ static void lp_setup_comments (charset_t dest)
     }
 
     if (lp.lp_job) {
-#ifdef DEBUG1
         LOG(log_debug9, logtype_papd, "job: %s", lp.lp_job );
-#endif
         translate(from, dest, &lp.lp_job);
     }
     if (lp.lp_created_for) {
-#ifdef DEBUG1
         LOG(log_debug9, logtype_papd, "for: %s", lp.lp_created_for );
-#endif
         translate(from, dest, &lp.lp_created_for);
     }
     if (lp.lp_person) {
-#ifdef DEBUG1
-       LOG(log_debug9, logtype_papd, "person: %s", lp.lp_person );
-#endif
-       translate(from, dest, &lp.lp_person);
+        LOG(log_debug9, logtype_papd, "person: %s", lp.lp_person );
+        translate(from, dest, &lp.lp_person);
     }
 }
 
@@ -358,10 +352,7 @@ void lp_job(char *job)
     }
 
     lp.lp_job = strdup(job);
-#ifdef DEBUG
     LOG(log_debug9, logtype_papd, "job: %s", lp.lp_job );
-#endif
-    
 }
 
 void lp_for (char *lpfor)
@@ -544,9 +535,7 @@ int lp_open(struct papfile *out, struct sockaddr_at *sat)
     int		fd;
     struct passwd	*pwent;
 
-#ifdef DEBUG
     LOG (log_debug9, logtype_papd, "lp_open");
-#endif
 
     if ( lp.lp_flags & LP_JOBPENDING ) {
 	lp_print();
@@ -630,9 +619,7 @@ int lp_open(struct papfile *out, struct sockaddr_at *sat)
 	    spoolerror( out, NULL );
 	    return( -1 );
 	}
-#ifdef DEBUG        
-        LOG(log_debug9, logtype_papd, "lp_open: opened %s", name );
-#endif	
+	LOG(log_debug9, logtype_papd, "lp_open: opened %s", name );
     }
     lp.lp_flags |= LP_OPEN;
     return( 0 );
@@ -683,9 +670,7 @@ int lp_write(struct papfile *in, char *buf, size_t len)
             tempbuf2[len] = 0;
             tbuf = tempbuf2;
             last_line_translated = 1;
-#ifdef DEBUG
             LOG(log_debug9, logtype_papd, "lp_write: %s", tbuf );
-#endif
         }
         else {
             LOG(log_error, logtype_papd, "lp_write: conversion buffer too small" );
@@ -704,10 +689,8 @@ int lp_write(struct papfile *in, char *buf, size_t len)
      * we store the start of the print job in a buffer.
      * %%EndComment triggers writing to file */
     if (( lp.lp_flags & LP_OPEN ) == 0 ) {
-#ifdef DEBUG
         LOG(log_debug9, logtype_papd, "lp_write: writing to temporary buffer" );
-#endif
-    	if ((bufpos+len) > BUFSIZE) {
+        if ((bufpos+len) > BUFSIZE) {
             LOG(log_error, logtype_papd, "lp_write: temporary buffer too small" );
             /* FIXME: call lp_open here? abort isn't nice... */
             abort();

--- a/etc/papd/main.c
+++ b/etc/papd/main.c
@@ -249,9 +249,8 @@ int main(int ac, char **av)
       exit(0);
     }      
 
-#ifdef DEBUG1
-    fault_setup(NULL);
-#endif
+    if ( debug ) 
+	fault_setup(NULL);
 
     /*
      * Start logging.
@@ -393,9 +392,8 @@ int main(int ac, char **av)
 		    * If cups is not accepting jobs, we return
 		    * 0xffff to indicate we're busy
 		    */
-#ifdef DEBUG
-                    LOG(log_debug9, logtype_papd, "CUPS: PAP_OPEN");
-#endif
+		    LOG(log_debug9, logtype_papd, "CUPS: PAP_OPEN");
+
 		    if ( (pr->p_flags & P_SPOOLED) && (cups_get_printer_status ( pr ) == 0)) {
                         LOG(log_error, logtype_papd, "CUPS_PAP_OPEN: %s is not accepting jobs",
                                 pr->p_printer );

--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -639,9 +639,7 @@ static int logincont2(void *obj_in, struct passwd **uam_pwd,
     }
     PAM_password = utfpass;
 
-#ifdef DEBUG
     LOG(log_maxdebug, logtype_default, "DHX2: password: %s", PAM_password);
-#endif
 
     /* Set these things up for the conv function */
 

--- a/etc/uams/uams_gss.c
+++ b/etc/uams/uams_gss.c
@@ -87,7 +87,6 @@ static void log_status( char *s, OM_uint32 major_status,
 
 static void log_ctx_flags( OM_uint32 flags )
 {
-#ifdef DEBUG1
     if (flags & GSS_C_DELEG_FLAG)
         LOG(log_debug, logtype_uams, "uams_gss.c :context flag: GSS_C_DELEG_FLAG" );
     if (flags & GSS_C_MUTUAL_FLAG)
@@ -100,7 +99,6 @@ static void log_ctx_flags( OM_uint32 flags )
         LOG(log_debug, logtype_uams, "uams_gss.c :context flag: GSS_C_CONF_FLAG" );
     if (flags & GSS_C_INTEG_FLAG)
         LOG(log_debug, logtype_uams, "uams_gss.c :context flag: GSS_C_INTEG_FLAG" );
-#endif
 }
 
 static void log_principal(gss_name_t server_name)

--- a/libatalk/unicode/charcnv.c
+++ b/libatalk/unicode/charcnv.c
@@ -234,9 +234,7 @@ charset_t add_charset(const char* name)
     charsets[cur_charset_t] = get_charset_functions (cur_charset_t);
     max_charset_t++;
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_default, "Added charset %s with handle %u", name, cur_charset_t);
-#endif
     return (cur_charset_t);
 }
 

--- a/libatalk/util/bprint.c
+++ b/libatalk/util/bprint.c
@@ -2,7 +2,6 @@
 #include "config.h"
 #endif
 
-#ifdef DEBUG1
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -49,4 +48,3 @@ void bprint( data, len )
 
     printf("(end)\n");
 }
-#endif


### PR DESCRIPTION
- Remove the --enable-debug --enable-debug1 configure options 
- refactor the afpd non-forking debug mode, and flip the afpd.conf option from -nodebug to -debug
- Replace debug macros with debug9 level logs
- in papd and atalkd, use the runtime debug mode instead of compile time macro