### PR TITLE
libatalk: Use portable fcntl() instead of flock()

### DIFF
--- a/include/atalk/compat.h
+++ b/include/atalk/compat.h
@@ -26,10 +26,6 @@ extern int pselect(int, fd_set * restrict, fd_set * restrict,
                    const sigset_t * restrict);
 #endif
 
-#ifndef HAVE_FLOCK
-extern int flock (int, int);
-#endif
-
 #ifndef HAVE_STRNLEN
 extern size_t strnlen(const char *s, size_t n);
 #endif


### PR DESCRIPTION
This aligns netatalk_conf.c with the rest of the codebase which consistently uses fcntl() for file locking.