### PR TITLE
Fixing bugs that can cause system errors

### DIFF
--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -827,7 +827,7 @@ int afp_logout(AFPObj *obj, char *ibuf _U_, size_t ibuflen  _U_, char *rbuf  _U_
  */
 int afp_changepw(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf, size_t *rbuflen)
 {
-    char username[MACFILELEN + 1], *start = ibuf;
+    char username[MAXUSERLEN], *start = ibuf;
     struct uam_obj *uam;
     struct passwd *pwd;
     size_t len;


### PR DESCRIPTION
It seems unlikely that a bug will occur, but it seems that a patch is needed just in case.

```
diff --git a/etc/afpd/auth.c b/etc/afpd/auth.c
index 15e16441..89a2a3b3 100644
--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -827,7 +827,7 @@ int afp_logout(AFPObj *obj, char *ibuf _U_, size_t ibuflen  _U_, char *rbuf  _U_
  */
 int afp_changepw(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf, size_t *rbuflen)
 {
-    char username[MACFILELEN + 1], *start = ibuf;
+    char username[MAXUSERLEN], *start = ibuf;
     struct uam_obj *uam;
     struct passwd *pwd;
     size_t len;
```
It could be overflowed when uam_getname is called in afp_changepw. (that function is in etc/afpd/uam.c)
(name buf size is 32 but MAXUSERLEN is 255)