### PR TITLE
[2.3] Minor cleanup of residual afprun code

### DIFF
--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -79,8 +79,7 @@ static void afp_dsi_close(AFPObj *obj)
     obj->ipc_fd = -1;
 
     /* we may have been called from a signal handler caught when afpd was running
-     * as uid 0, that's the wrong user for volume's prexec_close scripts if any,
-     * restore our login user
+     * as uid 0, so restore our login user
      */
     if (geteuid() != obj->uid) {
         if (seteuid( obj->uid ) < 0) {

--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -311,7 +311,7 @@ static int login(AFPObj *obj, struct passwd *pwd, void (*logout)(void), int expi
         uuid = pwd->pw_uid;
 
     set_auth_switch(expired);
-    /* save our euid, we need it for preexec_close */
+    /* save our euid */
     obj->uid = geteuid();
     obj->logout = logout;
 

--- a/include/atalk/volume.h
+++ b/include/atalk/volume.h
@@ -81,12 +81,6 @@ struct vol {
     int             v_hide;       /* new volume wait until old volume is closed */
     int             v_new;        /* volume deleted but there's a new one with the same name */
     int             v_deleted;    /* volume open but deleted in new config file */
-    char            *v_root_preexec;
-    char            *v_preexec;
-    char            *v_root_postexec;
-    char            *v_postexec;
-    int             v_root_preexec_close;
-    int             v_preexec_close;
     char            *v_uuid;    /* For TimeMachine zeroconf record */
 #ifdef __svr4__
     int         v_qfd;


### PR DESCRIPTION
I decided to keep the "save euid" code since it is used by another feature now, namely the reloading of groups when a volume changes https://github.com/Netatalk/netatalk/commit/534030591702e03f002ae3e11f638d57925054e8