### PR TITLE
Fix Zeroconf support on *BSD platforms

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,7 +97,7 @@ jobs:
             tar -zxpf bootstrap-trunk-x86_64-20230910.tar.gz -C /
             echo "export PATH="/opt/local/sbin:/opt/local/bin:$PATH"" >> .profile
             source .profile
-            /opt/local/bin/pkgin -y install libgcrypt libevent db5 gnome-tracker talloc
+            /opt/local/bin/pkgin -y install libgcrypt libevent db5 gnome-tracker talloc avahi
           run: |
             ./bootstrap
             ./configure --with-init-style=solaris MAKE=gmake PKG_CONFIG_PATH=/opt/local/lib/pkgconfig --with-bdb=/opt/local --with-libgcrypt-dir=/opt/local --with-tracker-pkgconfig-version=3.0
@@ -117,10 +117,10 @@ jobs:
           release: 13.2
           copyback: false
           prepare: |
-            pkg install -y autoconf automake libtool pkgconf libgcrypt libevent libressl tracker3 talloc db5
+            pkg install -y autoconf automake libtool pkgconf libgcrypt libevent libressl tracker3 talloc db5 avahi
           run: |
             ./bootstrap
-            ./configure --with-ssl-dir=/usr/local --with-tracker-pkgconfig-version=3.0
+            ./configure --with-ssl-dir=/usr/local --with-tracker-pkgconfig-version=3.0 PKG_CONFIG_PATH=/usr/local/libdata/pkgconfig
             make -j2
           
   build-openbsd:
@@ -137,7 +137,7 @@ jobs:
           release: 7.4
           copyback: false
           prepare: |
-            pkg_add -I gcc-11.2.0p9 autoconf-2.71 automake-1.16.5 libtool pkgconf libgcrypt libevent dbus-glib tracker3 libtalloc avahi wget
+            pkg_add -I gcc-11.2.0p9 autoconf-2.71 automake-1.16.5 libtool pkgconf libgcrypt libevent dbus-glib tracker3 libtalloc avahi wget bison flex
             wget https://download.oracle.com/berkeley-db/db-5.3.28.tar.gz
             tar -xvzf db-5.3.28.tar.gz
             cd db-5.3.28/build_unix
@@ -165,7 +165,7 @@ jobs:
           release: 9.3
           copyback: false
           prepare: |
-            pkg_add gcc13 autoconf automake libtool pkg-config db5 libgcrypt libevent libressl gmake gnome-tracker talloc dbus-glib
+            pkg_add gcc13 autoconf automake libtool pkg-config db5 libgcrypt libevent libressl gmake gnome-tracker talloc dbus-glib avahi bison flex
           run: |
             ./bootstrap
             ./configure MAKE=gmake PKG_CONFIG_PATH=/usr/pkg/lib/pkgconfig --with-bdb=/usr/pkg --with-libgcrypt-dir=/usr/pkg --with-tracker-pkgconfig-version=3.0
@@ -187,7 +187,7 @@ jobs:
             pkg install -y autoconf automake libtool pkgconf db5 libgcrypt libevent tracker3 talloc avahi
           run: |
             ./bootstrap
-            ./configure --with-ssl-dir=/usr/local --with-tracker-pkgconfig-version=3.0 LDFLAGS=-L/usr/local/lib CFLAGS=-I/usr/local/include
+            ./configure --with-ssl-dir=/usr/local --with-tracker-pkgconfig-version=3.0 LDFLAGS=-L/usr/local/lib
             make -j2
 
   build-solaris:
@@ -202,6 +202,7 @@ jobs:
         uses: vmactions/solaris-vm@v1
         with:
           release: 11.4
+          copyback: false
           prepare: |
             pkg install autoconf automake libtool pkg-config gcc libevent libgcrypt
             wget https://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.gz --no-check-certificate
@@ -219,7 +220,7 @@ jobs:
             cd ..            
           run: |
             ./bootstrap
-            ./configure MAKE=gmake --without-afpstats
+            ./configure MAKE=gmake --without-afpstats PKG_CONFIG_PATH=/usr/lib/amd64/pkgconfig
             gmake -j2
   
   static_analysis:

--- a/macros/zeroconf.m4
+++ b/macros/zeroconf.m4
@@ -26,28 +26,19 @@ AC_DEFUN([AC_NETATALK_ZEROCONF], [
 		fi
 
         # mDNS support using Avahi
-        AC_CHECK_HEADER(
-            avahi-client/client.h,
-            AC_CHECK_LIB(
-                avahi-client,
-                avahi_client_new,
-                AC_DEFINE(USE_ZEROCONF, 1, [Use DNS-SD registration]))
-        )
-
-        case "$ac_cv_lib_avahi_client_avahi_client_new" in
-        yes)
-            PKG_CHECK_MODULES(AVAHI, [ avahi-client >= 0.6 ])
-            PKG_CHECK_MODULES(AVAHI_TPOLL, [ avahi-client >= 0.6.4 ],
-                [AC_DEFINE(HAVE_AVAHI_THREADED_POLL, 1, [Uses Avahis threaded poll implementation])],
-                [AC_MSG_WARN(This Avahi implementation is not supporting threaded poll objects. Maybe this is not what you want.)])
-            ZEROCONF_LIBS="$AVAHI_LIBS"
-            ZEROCONF_CFLAGS="$AVAHI_CFLAGS"
-            AC_DEFINE(HAVE_AVAHI, 1, [Use Avahi/DNS-SD registration])
-            found_zeroconf=yes
-            ;;
-        esac
-	  	CPPFLAGS="$savedcppflags"
-	    LDFLAGS="$savedldflags"
+        PKG_CHECK_MODULES(AVAHI, [avahi-client >= 0.6], ac_cv_have_avahi=yes, ac_cv_have_avahi=no)
+        if test x"$ac_cv_have_avahi" = x"yes" ; then
+          PKG_CHECK_MODULES(AVAHI_TPOLL, [avahi-client >= 0.6.4],
+            [AC_DEFINE(HAVE_AVAHI_THREADED_POLL, 1, [Uses Avahis threaded poll implementation])],
+            [AC_MSG_WARN(This Avahi implementation is not supporting threaded poll objects. Maybe this is not what you want.)])
+          ZEROCONF_LIBS="$AVAHI_LIBS"
+          ZEROCONF_CFLAGS="$AVAHI_CFLAGS"
+          AC_DEFINE(USE_ZEROCONF, 1, [Use DNS-SD registration])
+          AC_DEFINE(HAVE_AVAHI, 1, [Use Avahi/DNS-SD registration])
+          found_zeroconf=yes
+        fi
+        CPPFLAGS="$savedcppflags"
+        LDFLAGS="$savedldflags"
 
         # mDNS support using mDNSResponder
         if test x"$found_zeroconf" != x"yes" ; then


### PR DESCRIPTION
This commit fixes a macro failure where the avahi-client/client.h header (and hence the library) is not detected on multiple *BSD platforms because of unconventional file locations. Avahi detection is now managed entirely by pkg_config and the use of the PKG_CONFIG_PATH configure variable where necessary.