### PR TITLE
[2.3] Add NetBSD, Solaris, Fedora build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Bootstrap
         run: ./bootstrap
       - name: Configure
-        run: ./configure --enable-pgp-uam --enable-krbV-uam
+        run: ./configure --enable-pgp-uam --enable-krbV-uam --enable-systemd
       - name: Build
         run: make -j $(nproc)
       - name: Run tests
@@ -55,11 +55,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
-          dnf -y install openssl-devel libgcrypt-devel libdb-devel automake libtool avahi-devel cups-devel
+          dnf -y install openssl-devel libgcrypt-devel libdb-devel automake libtool avahi-devel cups-devel krb5-devel libacl-devel openldap-devel cracklib-devel
       - name: Bootstrap
         run: ./bootstrap
       - name: Configure
-        run: ./configure --enable-pgp-uam --enable-krbV-uam
+        run: ./configure --enable-pgp-uam --enable-krbV-uam --enable-redhat-sysv --with-cracklib=/usr/share/cracklib
       - name: Build
         run: make -j $(nproc)
       - name: Run tests
@@ -108,7 +108,7 @@ jobs:
             pkg_add gcc13 autoconf automake libtool pkg-config db5 libgcrypt libressl gmake cups
           run: |
             ./bootstrap
-            ./configure MAKE=gmake PKG_CONFIG_PATH=/usr/pkg/lib/pkgconfig --with-bdb=/usr/pkg --with-libgcrypt-dir=/usr/pkg
+            ./configure MAKE=gmake PKG_CONFIG_PATH=/usr/pkg/lib/pkgconfig --with-bdb=/usr/pkg --with-libgcrypt-dir=/usr/pkg --enable-netbsd
             gmake -j2
 
   build-solaris:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
             cd ..            
           run: |
             ./bootstrap
-            ./configure MAKE=gmake
+            ./configure MAKE=gmake --enable-cups=no
             gmake -j2
 
   static_analysis:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,25 @@ jobs:
       - name: Run distribution tests
         run: make distcheck
 
+  build-fedora:
+    name: Fedora
+    runs-on: ubuntu-22.04
+    container:
+      image: fedora:rawhide
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          dnf -y install openssl-devel libgcrypt-devel libdb-devel automake libtool avahi-devel cups-devel
+      - name: Bootstrap
+        run: ./bootstrap
+      - name: Configure
+        run: ./configure --enable-pgp-uam --enable-krbV-uam
+      - name: Build
+        run: make -j $(nproc)
+      - name: Run tests
+        run: make check
+
   build-macos:
     name: macOS
     runs-on: macos-13

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Configure
         run: ./configure --enable-pgp-uam --enable-krbV-uam --enable-systemd
       - name: Build
-        run: make -j $(nproc)
+        run: make -j $(nproc) all
       - name: Run tests
         run: make check
       - name: Run distribution tests
@@ -61,7 +61,7 @@ jobs:
       - name: Configure
         run: ./configure --enable-pgp-uam --enable-krbV-uam --enable-redhat-sysv --with-cracklib=/usr/share/cracklib
       - name: Build
-        run: make -j $(nproc)
+        run: make -j $(nproc) all
       - name: Run tests
         run: make check
 
@@ -87,7 +87,7 @@ jobs:
           --enable-krbV-uam \
           --disable-ddp
       - name: Build
-        run: make -j $(nproc)
+        run: make -j $(nproc) all
       - name: Run tests
         run: make check
 
@@ -109,7 +109,7 @@ jobs:
           run: |
             ./bootstrap
             ./configure MAKE=gmake PKG_CONFIG_PATH=/usr/pkg/lib/pkgconfig --with-bdb=/usr/pkg --with-libgcrypt-dir=/usr/pkg --enable-netbsd
-            gmake -j2
+            gmake -j2 all
 
   build-solaris:
     name: "Solaris"
@@ -141,7 +141,7 @@ jobs:
           run: |
             ./bootstrap
             ./configure MAKE=gmake --enable-cups=no
-            gmake -j2
+            gmake -j2 all
 
   static_analysis:
     name: Static Analysis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
           release: 9.3
           copyback: false
           prepare: |
-            pkg_add gcc13 autoconf automake libtool pkg-config db5 libgcrypt libressl gmake
+            pkg_add gcc13 autoconf automake libtool pkg-config db5 libgcrypt libressl gmake cups
           run: |
             ./bootstrap
             ./configure MAKE=gmake PKG_CONFIG_PATH=/usr/pkg/lib/pkgconfig --with-bdb=/usr/pkg --with-libgcrypt-dir=/usr/pkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,58 @@ jobs:
       - name: Run tests
         run: make check
 
+  build-netbsd:
+    name: "NetBSD"
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+      - name: "Build on VM"
+        uses: vmactions/netbsd-vm@v1
+        with:
+          release: 9.3
+          copyback: false
+          prepare: |
+            pkg_add gcc13 autoconf automake libtool pkg-config db5 libgcrypt libressl gmake
+          run: |
+            ./bootstrap
+            ./configure MAKE=gmake PKG_CONFIG_PATH=/usr/pkg/lib/pkgconfig --with-bdb=/usr/pkg --with-libgcrypt-dir=/usr/pkg
+            gmake -j2
+
+  build-solaris:
+    name: "Solaris"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+      - name: "Build on VM"
+        uses: vmactions/solaris-vm@v1
+        with:
+          release: 11.4
+          prepare: |
+            pkg install autoconf automake libtool pkg-config gcc libgcrypt
+            wget https://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.gz --no-check-certificate
+            wget https://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.gz --no-check-certificate
+            tar xvf autoconf-2.71.tar.gz
+            tar xvf automake-1.16.5.tar.gz
+            cd autoconf-2.71
+            ./configure --prefix=/usr
+            make
+            make install
+            cd ../automake-1.16.5
+            ./configure --prefix=/usr
+            make
+            make install
+            cd ..            
+          run: |
+            ./bootstrap
+            ./configure MAKE=gmake
+            gmake -j2
+
   static_analysis:
     name: Static Analysis
     runs-on: ubuntu-22.04

--- a/test/afpd/Makefile.am
+++ b/test/afpd/Makefile.am
@@ -5,8 +5,7 @@ tmpconfdir = /tmp/netatalk
 TESTS = test.sh test
 
 check_PROGRAMS = test
-noinst_HEADERS = test.h subtests.h afpfunc_helpers.h
-EXTRA_DIST = test.sh
+EXTRA_DIST = test.sh test.h subtests.h afpfunc_helpers.h
 CLEANFILES = test.default test.conf
 
 test_SOURCES =  test.c subtests.c afpfunc_helpers.c \


### PR DESCRIPTION
Add build workflows for three platforms that are relevant for netatalk v2, namely they have appletalk networking support:

- NetBSD
- Solaris
- Fedora Linux