### PR TITLE
[2.3] Use correct BSD make syntax in initscripts Makefile

### DIFF
--- a/distrib/initscripts/Makefile.am
+++ b/distrib/initscripts/Makefile.am
@@ -165,7 +165,7 @@ timelord: rc.timelord.netbsd
 	chmod a+x $@
 
 a2boot: rc.a2boot.netbsd
-	cp -f $< $@
+	cp -f $? $@
 	chmod a+x $@
 
 install-data-hook:


### PR DESCRIPTION
This fixes an error when building on NetBSD with stock make (not gmake)