### PR TITLE
[2.3] papd: Update cups_print_job() to use CUPS destination API

### DIFF
--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -562,12 +562,14 @@ int cups_print_job ( char * name, char *filename, char *job, char *username, cha
 	{
 		LOG(log_error, logtype_papd,
 		    "Unable to get destination \"%s\": %s", name, cupsLastErrorString());
+		cupsFreeDests(1,dests);
 		return (0);
 	}
 	if ((http = cupsConnectDest(dest, CUPS_DEST_FLAGS_NONE, 30000, NULL, NULL, 0, NULL, NULL)) == NULL)
 	{
 		LOG(log_error, logtype_papd,
 		    "Unable to connect to destination \"%s\": %s", dest->name, cupsLastErrorString());
+		cupsFreeDests(1,dests);
 		return (0);
 	}
 

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -562,14 +562,14 @@ int cups_print_job ( char * name, char *filename, char *job, char *username, cha
 	{
 		LOG(log_error, logtype_papd,
 		    "Unable to get destination \"%s\": %s", name, cupsLastErrorString());
-		cupsFreeDests(1,dests);
+		cupsFreeDests(1,dest);
 		return (0);
 	}
 	if ((http = cupsConnectDest(dest, CUPS_DEST_FLAGS_NONE, 30000, NULL, NULL, 0, NULL, NULL)) == NULL)
 	{
 		LOG(log_error, logtype_papd,
 		    "Unable to connect to destination \"%s\": %s", dest->name, cupsLastErrorString());
-		cupsFreeDests(1,dests);
+		cupsFreeDests(1,dest);
 		return (0);
 	}
 


### PR DESCRIPTION
The function cupsPrintFile() is being removed in CUPS 3.0. Use the CUPS destination API to send print jobs from papd from now on.