### PR TITLE
[2.3] macusers: Fallback output when full name not available

### DIFF
--- a/contrib/macusers/macusers.in
+++ b/contrib/macusers/macusers.in
@@ -121,7 +121,11 @@ while (<PS>) {
                 } else {
                         ($t, $t, $uid, $t, $t, $t, $name, $t, $t) = getpwnam($user);
                 }
-                ($name) = ( $name =~ /(^[^,]+)/ );
+                if ($name =~ /(^[^,]+)/) {
+                        $name = $1;
+                } else {
+                        $name = "-";
+                }
                 printf "%-8d %-8d %-16s %-20s %-9s %s\n", $pid, $uid, $user,
                     $name, $time, $mac{$pid};
         }


### PR DESCRIPTION
Small improvement to the macusers script: When the user's full name is not available, out a `-` instead of nothing.