### PR TITLE
[2.3] papd: Update cups_autoadd_printers() to use current API call.

### DIFF
--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -641,7 +641,7 @@ cups_autoadd_printers ( struct printer	*defprinter, struct printer *printers)
 	char 	    	name[MAXCHOOSERLEN+1], *p;
 
         language  = cupsLangDefault();		/* needed for conversion */
-        num_dests = cupsGetDests(&dests);	/* get the available destination from CUPS */
+        num_dests = cupsGetDests2(CUPS_HTTP_DEFAULT, &dests);	/* get the available destination from CUPS */
 
         for  (i=0; i< num_dests; i++)
         {


### PR DESCRIPTION
Replace deprecated cupsGetDests() with cupsGetDests2(). The original cupsGetDests() function is due to be removed in CUPS 3.0. Confusingly, cupsGetDest2() will be renamed to cupsGetDest() in libcups3, so we'll need a define macro for this in the future in order to maintain compatibility with both libcups2 and libcups3.