### PR TITLE
Remove unneeded HAVE_TRACKER conditional and warn if Spotlight components are missing at configure time

### DIFF
--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -145,7 +145,7 @@ static void show_version_extended(void )
 #endif
 
 	printf( "     Spotlight support:\t" );
-#ifdef HAVE_TRACKER
+#ifdef WITH_SPOTLIGHT
 	puts( "Yes" );
 #else
 	puts( "No" );

--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -189,7 +189,7 @@ static int set_auth_switch(const AFPObj *obj, int expired)
         case 31:
             uam_afpserver_action(AFP_SYNCDIR, UAM_AFPSERVER_POSTAUTH, afp_syncdir, NULL);
             uam_afpserver_action(AFP_SYNCFORK, UAM_AFPSERVER_POSTAUTH, afp_syncfork, NULL);
-#ifdef HAVE_TRACKER
+#ifdef WITH_SPOTLIGHT
             uam_afpserver_action(AFP_SPOTLIGHT_PRIVATE, UAM_AFPSERVER_POSTAUTH, afp_spotlight_rpc, NULL);
 #endif
             uam_afpserver_action(AFP_ENUMERATE_EXT2, UAM_AFPSERVER_POSTAUTH, afp_enumerate_ext2, NULL);

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -175,7 +175,7 @@ static void sigterm_cb(evutil_socket_t fd, short what, void *arg)
     event_del(sighup_ev);
     event_del(timer_ev);
 
-#ifdef HAVE_TRACKER
+#ifdef WITH_SPOTLIGHT
     system(TRACKER_MANAGING_COMMAND " -t");
 #endif
     kill_childs(SIGTERM, &afpd_pid, &cnid_metad_pid, &dbus_pid, NULL);
@@ -185,7 +185,7 @@ static void sigterm_cb(evutil_socket_t fd, short what, void *arg)
 static void sigquit_cb(evutil_socket_t fd, short what, void *arg)
 {
     LOG(log_note, logtype_afpd, "Exiting on SIGQUIT");
-#ifdef HAVE_TRACKER
+#ifdef WITH_SPOTLIGHT
     system(TRACKER_MANAGING_COMMAND " -t");
 #endif
     kill_childs(SIGQUIT, &afpd_pid, &cnid_metad_pid, &dbus_pid, NULL);
@@ -266,7 +266,7 @@ static void timer_cb(evutil_socket_t fd, short what, void *arg)
         }
     }
 
-#ifdef HAVE_TRACKER
+#ifdef WITH_SPOTLIGHT
     if (dbus_pid == NETATALK_SRV_NEEDED) {
         dbus_restarts++;
         LOG(log_note, logtype_afpd, "Restarting 'dbus' (restarts: %u)", dbus_restarts);
@@ -359,7 +359,7 @@ static void show_netatalk_version( void )
 #endif
 
 	printf( "     Spotlight support:\t" );
-#ifdef HAVE_TRACKER
+#ifdef WITH_SPOTLIGHT
 	puts( "Yes" );
 #else
 	puts( "No" );
@@ -369,18 +369,14 @@ static void show_netatalk_version( void )
 
 static void show_netatalk_paths( void )
 {
+	printf( "              afp.conf:\t%s\n", _PATH_CONFDIR "afp.conf");
 	printf( "                  afpd:\t%s\n", _PATH_AFPD);
 	printf( "            cnid_metad:\t%s\n", _PATH_CNID_METAD);
-
-#ifdef HAVE_TRACKER
-	printf( "       tracker manager:\t%s\n", TRACKER_PREFIX "/bin/" TRACKER_MANAGING_COMMAND);
+  
+#ifdef WITH_SPOTLIGHT
 	printf( "           dbus-daemon:\t%s\n", DBUS_DAEMON_PATH);
-#endif
-
-	printf( "              afp.conf:\t%s\n", _PATH_CONFDIR "afp.conf");
-
-#ifdef HAVE_TRACKER
-	printf( "     dbus-session.conf:\t%s\n", _PATH_CONFDIR "dbus-session.conf");
+  printf( "     dbus-session.conf:\t%s\n", _PATH_CONFDIR "dbus-session.conf");  
+	printf( "       tracker manager:\t%s\n", TRACKER_PREFIX "/bin/" TRACKER_MANAGING_COMMAND);
 #endif
 
 #ifndef SOLARIS
@@ -483,7 +479,7 @@ int main(int argc, char **argv)
     sigdelset(&blocksigs, SIGHUP);
     sigprocmask(SIG_SETMASK, &blocksigs, NULL);
 
-#ifdef HAVE_TRACKER
+#ifdef WITH_SPOTLIGHT
     if (obj.options.flags & OPTION_SPOTLIGHT) {
         setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=" _PATH_STATEDIR "spotlight.ipc", 1);
         setenv("XDG_DATA_HOME", _PATH_STATEDIR, 0);

--- a/etc/spotlight/spotlight_rawquery_lexer.c
+++ b/etc/spotlight/spotlight_rawquery_lexer.c
@@ -502,10 +502,8 @@ char *yytext;
 #include <gio/gio.h>
 #include <atalk/talloc.h>
 #include <atalk/spotlight.h>
-#ifdef HAVE_TRACKER
 #include "sparql_parser.h"
 #define SLQ_VAR ssp_slq
-#endif
 #line 510 "spotlight_rawquery_lexer.c"
 
 #define INITIAL 0

--- a/etc/spotlight/spotlight_rawquery_lexer.l
+++ b/etc/spotlight/spotlight_rawquery_lexer.l
@@ -9,10 +9,8 @@
 #include <talloc.h>
 #include <gio/gio.h>
 #include <atalk/spotlight.h>
-#ifdef HAVE_TRACKER
 #include "sparql_parser.h"
 #define SLQ_VAR ssp_slq
-#endif
 %}
 
 ASC     [a-zA-Z0-9_\*\:\-\.]

--- a/include/atalk/spotlight.h
+++ b/include/atalk/spotlight.h
@@ -25,13 +25,11 @@
 #include <atalk/globals.h>
 #include <atalk/volume.h>
 
-#ifdef WITH_SPOTLIGHT
 #include <gio/gio.h>
 #include <tracker-sparql.h>
 #include <atalk/dalloc.h>
 #ifndef HAVE_TRACKER3
 #include <libtracker-miner/tracker-miner.h>
-#endif
 #endif
 
 /******************************************************************************
@@ -108,11 +106,9 @@ typedef struct _slq_t {
 } slq_t;
 
 struct sl_ctx {
-#ifdef HAVE_TRACKER
     TrackerSparqlConnection *tracker_con;
     GCancellable *cancellable;
     GMainLoop *mainloop;
-#endif
     slq_t *query_list; /* list of active queries */
 };
 

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -233,7 +233,7 @@ AC_DEFUN([AC_NETATALK_SPOTLIGHT], [
     if test x"$ac_cv_have_talloc" = x"yes" -a x"$ac_cv_have_tracker" = x"yes" -a x"$ac_cv_have_tracker_sparql" = x"yes"; then
         AC_DEFINE(WITH_SPOTLIGHT, 1, [Define whether to enable Spotlight support])
     fi
-    if test x"$ac_cv_have_tracker" = x"no" ; then
+    if test x"$ac_cv_have_tracker" != x"yes" ; then
     AC_MSG_WARN([tracker is not found (required for Spotlight support)])
     fi
     

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -188,12 +188,12 @@ AC_DEFUN([AC_NETATALK_SPOTLIGHT], [
     PKG_CHECK_MODULES([TRACKER], [tracker-sparql-$ac_cv_tracker_pkg_version >= $ac_cv_tracker_pkg_version_min], [ac_cv_have_tracker_sparql=yes], [ac_cv_have_tracker_sparql=no])
 
     if test x"$ac_cv_have_tracker_sparql" = x"no" ; then
+        AC_MSG_WARN([tracker SPARQL not found (required for Spotlight support)])
         if test x"$need_tracker_sparql" = x"yes" ; then
             AC_MSG_ERROR([$ac_cv_tracker_pkg not found])
         fi
     else
         ac_cv_have_tracker=yes
-        AC_DEFINE(HAVE_TRACKER, 1, [Define if Tracker is available])
         AC_DEFINE_UNQUOTED(TRACKER_PREFIX, ["$ac_cv_tracker_install_prefix"], [Path to Tracker])
         AC_DEFINE_UNQUOTED([DBUS_DAEMON_PATH], ["$ac_cv_dbus_daemon"], [Path to dbus-daemon])
 
@@ -225,12 +225,18 @@ AC_DEFUN([AC_NETATALK_SPOTLIGHT], [
     if test x"$ac_cv_have_talloc" = x"yes" ; then
         AC_DEFINE(HAVE_TALLOC, 1, [Define if talloc library is available])
     fi
+    if test x"$ac_cv_have_talloc" = x"no" ; then
+    AC_MSG_WARN([talloc library is not found (required for Spotlight support)])
+    fi
     
     dnl Enable Spotlight support
     if test x"$ac_cv_have_talloc" = x"yes" -a x"$ac_cv_have_tracker" = x"yes" -a x"$ac_cv_have_tracker_sparql" = x"yes"; then
         AC_DEFINE(WITH_SPOTLIGHT, 1, [Define whether to enable Spotlight support])
     fi
-
+    if test x"$ac_cv_have_tracker" = x"no" ; then
+    AC_MSG_WARN([tracker is not found (required for Spotlight support)])
+    fi
+    
     AC_SUBST(DBUS_DAEMON_PATH)
     AC_SUBST(TALLOC_CFLAGS)
     AC_SUBST(TALLOC_LIBS)

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -216,7 +216,7 @@ AC_DEFUN([AC_NETATALK_SPOTLIGHT], [
            TRACKER_MANAGING_COMMAND="tracker-control"
            AC_DEFINE(TRACKER_MANAGING_COMMAND, "tracker-control", [tracker managing command])
         else
-           AC_MSG_ERROR([could find neither tracker command nor tracker-control command])
+           AC_MSG_WARN([tracker not found (required for Spotlight support)])
         fi
     fi
     
@@ -226,7 +226,7 @@ AC_DEFUN([AC_NETATALK_SPOTLIGHT], [
         AC_DEFINE(HAVE_TALLOC, 1, [Define if talloc library is available])
     fi
     if test x"$ac_cv_have_talloc" = x"no" ; then
-    AC_MSG_WARN([talloc library is not found (required for Spotlight support)])
+    AC_MSG_WARN([talloc library not found (required for Spotlight support)])
     fi
     
     dnl Enable Spotlight support

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -233,9 +233,6 @@ AC_DEFUN([AC_NETATALK_SPOTLIGHT], [
     if test x"$ac_cv_have_talloc" = x"yes" -a x"$ac_cv_have_tracker" = x"yes" -a x"$ac_cv_have_tracker_sparql" = x"yes"; then
         AC_DEFINE(WITH_SPOTLIGHT, 1, [Define whether to enable Spotlight support])
     fi
-    if test x"$ac_cv_have_tracker" != x"yes" ; then
-    AC_MSG_WARN([tracker is not found (required for Spotlight support)])
-    fi
     
     AC_SUBST(DBUS_DAEMON_PATH)
     AC_SUBST(TALLOC_CFLAGS)


### PR DESCRIPTION
The HAVE_TRACKER3 conditional remains to distinguish whether tracker v3 is present vs v1 / v2