### PR TITLE
[2.3] papd - Update print_cups.c to support both libcups3 and libcups2.

### DIFF
--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -54,6 +54,9 @@
 #if CUPS_VERSION_MAJOR < 3
 #define cupsGetDests	cupsGetDests2
 #define cupsCreateTempFile(prefix,suffix,buffer,bufsize)	cupsTempFile2(buffer,bufsize)
+#define cups_len_t	int
+#else
+#define cups_len_t	size_t
 #endif
 
 static const char* cups_status_msg[] = {
@@ -219,7 +222,7 @@ cups_get_printer_ppd ( char * name)
 	 *the CUPS temporary queue, which we don't want.
 	 */
 
-	int num_dests = cupsGetDests(CUPS_HTTP_DEFAULT, &dests);
+	cups_len_t num_dests = cupsGetDests(CUPS_HTTP_DEFAULT, &dests);
 	dest = cupsGetDest(name, NULL, num_dests, dests);
 	const char *make_model = cupsGetOption("printer-make-and-model", dest->num_options, dest->options);
 
@@ -545,7 +548,7 @@ int cups_print_job ( char * name, char *filename, char *job, char *username, cha
 	cups_dinfo_t 	*info = NULL;
 	int 		jobid;
 	char 		filepath[MAXPATHLEN];
-	int           	num_options;
+	cups_len_t	num_options;
 	cups_option_t 	*options;
 
 	/* Initialize the options array */
@@ -640,7 +643,7 @@ struct printer	*
 cups_autoadd_printers ( struct printer	*defprinter, struct printer *printers)
 {
 	struct printer 	*pr;
-        int         	num_dests,i;
+	cups_len_t	i, num_dests;
 	int 	    	ret;
         cups_dest_t 	*dests;
         cups_lang_t 	*language;

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -50,6 +50,12 @@
 #define MAXCHOOSERLEN 31
 #define HTTP_MAX_URI 1024
 
+/* Some functions changed names with the introduction of libcups3. Accomodate them here so we can still work with CUPS 2.x */
+#if CUPS_VERSION_MAJOR < 3
+#define cupsGetDests	cupsGetDests2
+#define cupsCreateTempFile(prefix,suffix,buffer,bufsize)	cupsTempFile2(buffer,bufsize)
+#endif
+
 static const char* cups_status_msg[] = {
         "status: busy; info: \"%s\" is rejecting jobs; ",
         "status: idle; info: \"%s\" is stopped, accepting jobs ;",
@@ -213,7 +219,7 @@ cups_get_printer_ppd ( char * name)
 	 *the CUPS temporary queue, which we don't want.
 	 */
 
-	int num_dests = cupsGetDests2(CUPS_HTTP_DEFAULT, &dests);
+	int num_dests = cupsGetDests(CUPS_HTTP_DEFAULT, &dests);
 	dest = cupsGetDest(name, NULL, num_dests, dests);
 	const char *make_model = cupsGetOption("printer-make-and-model", dest->num_options, dest->options);
 
@@ -323,7 +329,7 @@ cups_get_printer_ppd ( char * name)
 	 * Open a temporary file for the PPD...
 	 */
 
-	if ((fp = cupsTempFile2(buffer, (int)bufsize)) == NULL)
+	if ((fp = cupsCreateTempFile(NULL, NULL, buffer, (int)bufsize)) == NULL)
 	{
 		LOG(log_error, logtype_papd, strerror(errno));
                 ippDelete(response);
@@ -641,7 +647,7 @@ cups_autoadd_printers ( struct printer	*defprinter, struct printer *printers)
 	char 	    	name[MAXCHOOSERLEN+1], *p;
 
         language  = cupsLangDefault();		/* needed for conversion */
-        num_dests = cupsGetDests2(CUPS_HTTP_DEFAULT, &dests);	/* get the available destination from CUPS */
+        num_dests = cupsGetDests(CUPS_HTTP_DEFAULT, &dests);	/* get the available destination from CUPS */
 
         for  (i=0; i< num_dests; i++)
         {

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -618,7 +618,7 @@ int cups_print_job ( char * name, char *filename, char *job, char *username, cha
 	size_t bytes;
 	char buffer[65536];
 	
-	if (cupsStartDestDocument(CUPS_HTTP_DEFAULT, dest, info, jobid, job, CUPS_FORMAT_AUTO, 0, NULL, 1) == HTTP_STATUS_CONTINUE)
+	if (cupsStartDestDocument(CUPS_HTTP_DEFAULT, dest, info, jobid, job, CUPS_FORMAT_AUTO, 0, NULL, true) == HTTP_STATUS_CONTINUE)
 		{
 		while ((bytes = fread(buffer, 1, sizeof(buffer), fp)) > 0)
 			if (cupsWriteRequestData(CUPS_HTTP_DEFAULT, buffer, bytes) != HTTP_STATUS_CONTINUE)


### PR DESCRIPTION
Some CUPS API function names are changing with the introduction of CUPS 3.0. Add a macro to allow compiling on systems with either CUPS 2.0 or 3.0.