### PR TITLE
manual: Link to custom download and wiki mirrors in navbar

### DIFF
--- a/doc/manual/netatalk.html
+++ b/doc/manual/netatalk.html
@@ -3,9 +3,9 @@
         <div id="logo"></div>
         <div id="menlinks">
           <a href="/" title="Return to Netatalk home">[main]</a>
-          <a href="https://github.com/Netatalk/netatalk/wiki" title="Netatalk Wiki">[wiki]</a>
+          <a href="/docs" title="Netatalk Wiki">[wiki]</a>
           <a href="/3.1/htmldocs" title="Netatalk Manual">[documentation]</a>
-          <a href="https://sourceforge.net/projects/netatalk/files/" title="Download Netatalk from SourceForge">[downloads]</a>
+          <a href="/download.php" title="Download Netatalk">[downloads]</a>
           <a href="/support.php" title="Support">[support]</a>
           <a href="/links.php" title="Netatalk related links">[links]</a>
           <img src="/gfx/end.gif" alt="" width="125" height="7" />


### PR DESCRIPTION
I created a download.php page to link to instead of the sourceforge archive, and a self-hosted wiki mirror