### PR TITLE
[2.3] papd - More cleanup and moderization of print_cups.c

### DIFF
--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -237,10 +237,7 @@ cups_get_printer_ppd ( char * name)
 	 *    printer-uri
 	 */
 
-        request = ippNew();
-
-        ippSetOperation(request, IPP_OP_GET_PRINTER_ATTRIBUTES);
-        ippSetRequestId(request, 1);
+        request = ippNewRequest(IPP_OP_GET_PRINTER_ATTRIBUTES);
 
 	ippAddStrings(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
 		      "requested-attributes",

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -166,7 +166,7 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 
         httpClose(http);
 
-        if (cupsLastError() >= IPP_OK_CONFLICT)
+        if (cupsLastError() >= IPP_STATUS_OK_CONFLICTING)
         {
       		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
                          ippErrorString(cupsLastError()));
@@ -238,7 +238,7 @@ cups_get_printer_ppd ( char * name)
 	sprintf(uri, "ipp://localhost/printers/%s", name);
 
 	/*
-	 * Build an IPP_GET_PRINTER_ATTRIBUTES request, which requires the
+	 * Build an IPP_OP_GET_PRINTER_ATTRIBUTES request, which requires the
 	 * following attributes:
 	 *
 	 *    attributes-charset
@@ -249,7 +249,7 @@ cups_get_printer_ppd ( char * name)
 
         request = ippNew();
 
-        ippSetOperation(request, IPP_GET_PRINTER_ATTRIBUTES);
+        ippSetOperation(request, IPP_OP_GET_PRINTER_ATTRIBUTES);
         ippSetRequestId(request, 1);
 
 	language = cupsLangDefault();
@@ -282,7 +282,7 @@ cups_get_printer_ppd ( char * name)
                 return (0);
         }
 
-        if (ippGetStatusCode(response) >= IPP_OK_CONFLICT)
+        if (ippGetStatusCode(response) >= IPP_STATUS_OK_CONFLICTING)
         {
       		 LOG(log_error, logtype_papd,  "Unable to get printer attribs for %s - %s", name,
                          ippErrorString(ippGetStatusCode(response)));
@@ -441,7 +441,7 @@ cups_get_printer_status (struct printer *pr)
 
 
        /*
-        * Build an IPP_GET_PRINTER_ATTRIBUTES request, which requires the
+        * Build an IPP_OP_GET_PRINTER_ATTRIBUTES request, which requires the
         * following attributes:
         *
         *    attributes-charset
@@ -480,7 +480,7 @@ cups_get_printer_status (struct printer *pr)
                 return (0);
         }
 
-        if (cupsLastError() >= IPP_OK_CONFLICT)
+        if (cupsLastError() >= IPP_STATUS_OK_CONFLICTING)
         {
       		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", pr->p_printer,
                          ippErrorString(cupsLastError()));
@@ -497,9 +497,9 @@ cups_get_printer_status (struct printer *pr)
 
         if ((attr = ippFindAttribute(response, "printer-state", IPP_TAG_ENUM)) != NULL)
         {
-                if (ippGetInteger(attr, 0) == IPP_PRINTER_STOPPED)
+                if (ippGetInteger(attr, 0) == IPP_PSTATE_STOPPED)
 			status = 1;
-                else if (ippGetInteger(attr,0) == IPP_NOT_ACCEPTING)
+                else if (ippGetInteger(attr,0) == IPP_STATUS_ERROR_NOT_ACCEPTING_JOBS)
 			status = 0;
 		else
 			status = 2;

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -136,14 +136,6 @@ cups_printername_ok(char *name)         /* I - Name of printer */
         */
         request = ippNewRequest(IPP_OP_GET_PRINTER_ATTRIBUTES);
 
-        language = cupsLangDefault();
-
-        ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_CHARSET,
-                     "attributes-charset", NULL, cupsLangEncoding(language));
-
-        ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_LANGUAGE,
-                     "attributes-natural-language", NULL, language->language);
-
         ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
                      "requested-attributes", NULL, "printer-uri");
 
@@ -251,16 +243,6 @@ cups_get_printer_ppd ( char * name)
 
         ippSetOperation(request, IPP_OP_GET_PRINTER_ATTRIBUTES);
         ippSetRequestId(request, 1);
-
-	language = cupsLangDefault();
-
-	ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_CHARSET,
-		     "attributes-charset", NULL,
-		     cupsLangEncoding(language));
-
-	ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_LANGUAGE,
-		     "attributes-natural-language", NULL,
-		     language->language);
 
 	ippAddStrings(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
 		      "requested-attributes",
@@ -451,14 +433,6 @@ cups_get_printer_status (struct printer *pr)
         */
 
         request = ippNewRequest(IPP_OP_GET_PRINTER_ATTRIBUTES);
-
-        language = cupsLangDefault();
-
-        ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_CHARSET,
-                     "attributes-charset", NULL, cupsLangEncoding(language));
-
-        ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_LANGUAGE,
-                     "attributes-natural-language", NULL, language->language);
 
         ippAddStrings(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
                       "requested-attributes",

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -96,7 +96,6 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 	cups_dest_t	*dest = NULL;	/* Destination */
         ipp_t           *request,       /* IPP Request */
                         *response;      /* IPP Response */
-        cups_lang_t     *language;      /* Default language */
         char            uri[HTTP_MAX_URI]; /* printer-uri attribute */
 
        /*
@@ -182,7 +181,6 @@ cups_get_printer_ppd ( char * name)
 	cups_dest_t 	*dests;		/* Destination List */
 	ipp_t           *request,       /* IPP Request */
 			*response;      /* IPP Response */
-	cups_lang_t	*language;      /* Default language */
 	char		uri[HTTP_MAX_URI]; /* printer-uri attribute */
         const char	*pattrs[] =   /* Requested printer attributes */
                         {
@@ -377,7 +375,6 @@ cups_get_printer_status (struct printer *pr)
         ipp_t           *request,       /* IPP Request */
                         *response;      /* IPP Response */
         ipp_attribute_t *attr;          /* Current attribute */
-        cups_lang_t     *language;      /* Default language */
         char            uri[HTTP_MAX_URI]; /* printer-uri attribute */
 	int 		status = -1;
 

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -580,7 +580,7 @@ int cups_print_job ( char * name, char *filename, char *job, char *username, cha
 	size_t bytes;
 	char buffer[65536];
 	
-	if (cupsStartDestDocument(CUPS_HTTP_DEFAULT, dest, info, jobid, job, CUPS_FORMAT_AUTO, 0, NULL, 1) == HTTP_STATUS_CONTINUE)
+	if (cupsStartDestDocument(CUPS_HTTP_DEFAULT, dest, info, jobid, job, CUPS_FORMAT_AUTO, 0, NULL, true) == HTTP_STATUS_CONTINUE)
 		{
 		while ((bytes = fread(buffer, 1, sizeof(buffer), fp)) > 0)
 			if (cupsWriteRequestData(CUPS_HTTP_DEFAULT, buffer, bytes) != HTTP_STATUS_CONTINUE)

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -76,7 +76,7 @@ const char * cups_get_language (void)
  */
 
 static const char *                            /* O - Password or NULL */
-cups_passwd_cb(const char *prompt _U_)      /* I - Prompt */
+cups_passwd_cb(const char *prompt _U_, http_t *http, const char *method, const char *resource, void *user_data)      /* I - Prompt */
 {
  /*
   * Always return NULL to indicate that no password is available...
@@ -103,7 +103,7 @@ cups_printername_ok(char *name)         /* I - Name of printer */
         * Make sure we don't ask for passwords...
         */
 
-        cupsSetPasswordCB(cups_passwd_cb);
+        cupsSetPasswordCB2(cups_passwd_cb, NULL);
 
 	/*
 	 * Try to connect to the requested printer...
@@ -205,7 +205,7 @@ cups_get_printer_ppd ( char * name)
 			*model;
 
 
-	cupsSetPasswordCB(cups_passwd_cb);
+	cupsSetPasswordCB2(cups_passwd_cb, NULL);
 
 	/*
 	 *We have to go this roundabout way to correctly get the make and 
@@ -410,7 +410,7 @@ cups_get_printer_status (struct printer *pr)
         * Make sure we don't ask for passwords...
         */
 
-        cupsSetPasswordCB(cups_passwd_cb);
+        cupsSetPasswordCB2(cups_passwd_cb, NULL);
 
 	/*
 	 * Try to connect to the requested printer...
@@ -550,7 +550,7 @@ int cups_print_job ( char * name, char *filename, char *job, char *username, cha
         * Make sure we don't ask for passwords...
         */
 
-        cupsSetPasswordCB(cups_passwd_cb);
+        cupsSetPasswordCB2(cups_passwd_cb, NULL);
 
 	/*
 	 * Try to connect to the requested printer...


### PR DESCRIPTION
Another attempt to clean things up for CUPS 3.0. Removed yet more deprecated API calls. Updated IPP commands to current values. Also removed unneeded calls to get language information since CUPS does that for you automatically via ippNewRequest().