### PR TITLE
[2.3] atalkd: Fix for RTMP broadcast bug.

### DIFF
--- a/doc/manual/man/man8/atalkd.8.xml
+++ b/doc/manual/man/man8/atalkd.8.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>8</manvolnum>
 
-    <refmiscinfo class="date">19 Dec 2023</refmiscinfo>
+    <refmiscinfo class="date">18 Jan 2024</refmiscinfo>
 
     <refmiscinfo class="source">:NETATALK_VERSION:</refmiscinfo>
   </refmeta>
@@ -51,8 +51,6 @@
       <arg>-2</arg>
 
       <arg>-d</arg>
-
-      <arg>-q</arg>
 
       <arg>-t</arg>
 
@@ -154,24 +152,6 @@
         <listitem>
           <para>Specifies the file in which <command>atalkd</command> stores its
           process id.</para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term>-q</term>
-
-        <listitem>
-          <para>Stops <command>atalkd</command> from broadcasting RTMP routing tuples
-	      to other AppleTalk routers on the network. This improves compatibility with
-	      AsantéTalk and Dayna EtherPrint bridge devices. However,
-	      clients behind other routers on the network can't see or communicate
-	      with network segments that <command>atalkd</command> is routing.</para>
-
-	  <note>
-	    <para>Do NOT use this option unless you absolutely need it.
-	        It breaks the AppleTalk specification.
-	        Ref. page 5-11 in "Inside AppleTalk".</para>
-	  </note>
         </listitem>
       </varlistentry>
 

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -558,9 +558,9 @@ static void as_timer(int sig _U_)
 		     * TODO: This is an ugly hack that breaks the AppleTalk
 		     * specification. A better solution is needed.
 		     */
-		    if (quirks && (rtmp->rt_iface != iface)) {
+		    if ((iface->i_flags & IFACE_RSEED) && (rtmp->rt_iface != iface)) {
 		        continue;
-		    } else if (!quirks && (rtmp->rt_iface == iface)) {
+		    } else if (!(iface->i_flags & IFACE_RSEED) && (rtmp->rt_iface == iface)) {
 		        continue;
 		    }
 

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -80,7 +80,7 @@ static int		atservNATSERV = elements( atserv );
 
 struct interface	*interfaces = NULL, *ciface = NULL;
 
-int			debug = 0, quirks = 0;
+int			debug = 0;
 static char		*configfile = NULL;
 static int		ziptimeout = 0;
 static int		stable = 0, noparent = 0;
@@ -548,19 +548,12 @@ static void as_timer(int sig _U_)
 
 		    /* split horizon */
 
-		    /* Quirks mode that stops atalkd from rebroadcasting
-		     * routing information for other subnets.
-		     *
-		     * Makes the AsanteTalk bridge consistently start up in
-		     * AppleTalk Phase 2, and stop the Dayna bridge from
-		     * crashing GS/OS.
-		     *
-		     * TODO: This is an ugly hack that breaks the AppleTalk
-		     * specification. A better solution is needed.
+		    /* HACK: If we only have one interface configured and are using
+      		     * the -router switch to seed that interface, we need not
+	     	     * worry about split horizon. Otherwise interface won't
+	    	     * transmit RTMP broadcasts.
 		     */
-		    if ((iface->i_flags & IFACE_RSEED) && (rtmp->rt_iface != iface)) {
-		        continue;
-		    } else if (!(iface->i_flags & IFACE_RSEED) && (rtmp->rt_iface == iface)) {
+		    if (!(iface->i_flags & IFACE_RSEED) && (rtmp->rt_iface == iface)) {
 		        continue;
 		    }
 
@@ -828,7 +821,7 @@ int main( int ac, char **av)
     socklen_t 		fromlen;
     char		*prog;
 
-    while (( c = getopt( ac, av, "12df:P:qtv" )) != EOF ) {
+    while (( c = getopt( ac, av, "12df:P:tv" )) != EOF ) {
 	switch ( c ) {
 	case '1' :
 	    defphase = IFACE_PHASE1;
@@ -850,10 +843,6 @@ int main( int ac, char **av)
 	    pidfile = optarg;
 	    break;
 
-	case 'q' :	/* quirks mode */
-	    quirks++;
-	    break;
-
 	case 't' :	/* transition */
 	    transition++;
 	    break;
@@ -864,7 +853,7 @@ int main( int ac, char **av)
 	    break;
 
 	default :
-	    fprintf( stderr, "Usage:\tatalkd -1 -2 [-f configfile] [-P pidfile] -q -t -d\n" );
+	    fprintf( stderr, "Usage:\tatalkd -1 -2 [-f configfile] [-P pidfile] -t -d\n" );
 	    exit( 1 );
 	}
     }


### PR DESCRIPTION
If the (only) interface was configured with the `-router` switch, automatically enable quirks mode. Otherwise don't. This is a hack as the split horizon logic is clearly broken here. If a single interface is configured as a router, it should ALWAYS broadcast RTMP packets no matter what.

Note: This patch doesn't remove the "quirks mode" command line switch or manpage documentation.