### PR TITLE
[2.3] papd: update cups_get_printer_status()

### DIFF
--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -96,12 +96,13 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 	cups_dest_t	*dest = NULL;	/* Destination */
         ipp_t           *request,       /* IPP Request */
                         *response;      /* IPP Response */
+        //char            uri[HTTP_MAX_URI]; /* printer-uri attribute */
 
        /*
         * Make sure we don't ask for passwords...
         */
 
-        cupsSetPasswordCB2(cups_passwd_cb, NULL);
+        cupsSetPasswordCB(cups_passwd_cb, NULL);
 
 	/*
 	 * Try to connect to the requested printer...
@@ -121,56 +122,8 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 		    "Unable to connect to destination \"%s\": %s", dest->name, cupsLastErrorString());
 		return (0);
 	}
-	
 
-       /*
-        * Build an IPP_GET_PRINTER_ATTRS request, which requires the following
-        * attributes:
-        *
-        *    attributes-charset
-        *    attributes-natural-language
-        *    requested-attributes
-        *    printer-uri
-        */
-        request = ippNewRequest(IPP_OP_GET_PRINTER_ATTRIBUTES);
-
-        ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
-                     "requested-attributes", NULL, "printer-uri");
-
-        const char *uri = cupsGetOption("printer-uri-supported", dest->num_options, dest->options);
-
-        ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
-                     "printer-uri", NULL, uri);
-
-       /*
-        * Do the request and get back a response...
-        */
-
-        if ((response = cupsDoRequest(http, request, "/")) == NULL)
-        {
-      		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
-                         ippErrorString(cupsLastError()));
-		cupsFreeDests(1, dest);
-                httpClose(http);
-                return (0);
-        }
-	cupsFreeDests(1, dest);
-        httpClose(http);
-
-        if (cupsLastError() >= IPP_STATUS_OK_CONFLICTING)
-        {
-      		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", name,
-                         ippErrorString(cupsLastError()));
-                ippDelete(response);
-                return (0);
-        }
-        else
-        {
-                ippDelete(response);
-                return (1);
-        }
-
-	return (0);
+	return (1);
 }
 
 const char * 

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -51,7 +51,7 @@
 
 static const char* cups_status_msg[] = {
         "status: busy; info: \"%s\" is rejecting jobs; ",
-        "status: idle; info: \"%s\" is stopped, accepting jobs ;",
+        "status: idle; info: \"%s\" is stopped, accepting jobs ; ",
         "status: idle; info: \"%s\" is ready ; ",
 	"status: busy; info: \"%s\" is processing a job ; ",
 };
@@ -318,14 +318,14 @@ cups_get_printer_ppd ( char * name)
 int
 cups_get_printer_status (struct printer *pr)
 {
-	http_t* http;          /* HTTP connection to server */
-	cups_dest_t* dest = NULL;	/* Destination */
+	http_t* 	http;          /* HTTP connection to server */
+	cups_dest_t* 	dest = NULL;	/* Destination */
 	int 		status = -1;
-	char printer_reason[150];
+	char 		printer_reason[150];
 	memset(printer_reason, 0, sizeof(printer_reason));
-	int printer_avail = 0;
-	int printer_state = 3;
-	unsigned flags;
+	int 		printer_avail = 0;
+	int 		printer_state = 3;
+	unsigned 	flags;
 
 	/*
 	 * Make sure we don't ask for passwords...
@@ -367,7 +367,7 @@ cups_get_printer_status (struct printer *pr)
 		cupsFreeDests(1, dest);
 		return (0);
 	}
-	ipp_t* request,       /* IPP Request */
+	ipp_t	* request,       /* IPP Request */
 		* response;      /* IPP Response */
 	const char* pattrs[] =   /* Requested printer attributes */
 	{
@@ -375,6 +375,7 @@ cups_get_printer_status (struct printer *pr)
 	  "printer-is-accepting-jobs",
 	  "printer-state-reasons"
 	};
+	
 	ipp_attribute_t* attr;
 
 	/*
@@ -454,8 +455,9 @@ cups_get_printer_status (struct printer *pr)
 	snprintf(pr->p_status, 255, cups_status_msg[status], pr->p_printer);
 
 	/* printer state */
-	strncat(pr->p_status, printer_reason, 255 - strlen(pr->p_status));
-
+	if (!strcmp(printer_reason, "none\n"))
+		strncat(pr->p_status, printer_reason, 255 - strlen(pr->p_status));
+	
 	/*
 	 * Return the print status ...
 	 */

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -53,6 +53,7 @@ static const char* cups_status_msg[] = {
         "status: busy; info: \"%s\" is rejecting jobs; ",
         "status: idle; info: \"%s\" is stopped, accepting jobs ;",
         "status: idle; info: \"%s\" is ready ; ",
+	"status: busy; info: \"%s\" is processing a job ; ",
 };
 
 /* Local functions */
@@ -317,15 +318,20 @@ cups_get_printer_ppd ( char * name)
 int
 cups_get_printer_status (struct printer *pr)
 {
-        http_t          *http;          /* HTTP connection to server */
-	cups_dest_t	*dest = NULL;	/* Destination */
+	http_t* http;          /* HTTP connection to server */
+	cups_dest_t* dest = NULL;	/* Destination */
 	int 		status = -1;
+	char printer_reason_t[255];
+	memset(printer_reason_t, 0, sizeof(printer_reason_t));
+	int printer_avail = 0;
+	int printer_state = 3;
+	int temp_printer = 0;
 
-       /*
-        * Make sure we don't ask for passwords...
-        */
+	/*
+	 * Make sure we don't ask for passwords...
+	 */
 
-        cupsSetPasswordCB2(cups_passwd_cb, NULL);
+	cupsSetPasswordCB2(cups_passwd_cb, NULL);
 
 	/*
 	 * Try to connect to the requested printer...
@@ -336,70 +342,128 @@ cups_get_printer_status (struct printer *pr)
 	if (!dest)
 	{
 		LOG(log_error, logtype_papd,
-		    "Unable to get destination \"%s\": %s", pr->p_printer, cupsLastErrorString());
+			"Unable to get destination \"%s\": %s", pr->p_printer, cupsLastErrorString());
+		snprintf(pr->p_status, 255, "status: busy; info: \"%s\" appears to be offline.", pr->p_printer);
 		return (0);
 	}
-	if ((http = cupsConnectDest(dest, CUPS_DEST_FLAGS_NONE, 30000, NULL, NULL, 0, NULL, NULL)) == NULL)
-	{
-		LOG(log_error, logtype_papd,
-		    "Unable to connect to destination \"%s\": %s", dest->name, cupsLastErrorString());
-		return (0);
-	}
-
-       /*
-        * Collect the needed attributes...
-        */
-
-	int printerstate = cupsGetIntegerOption("printer-state", dest->num_options, dest->options);
-	const char *printeravail = cupsGetOption("printer-is-accepting-jobs", dest->num_options, dest->options);
-	const char *printerreason = cupsGetOption("printer-state-reasons", dest->num_options, dest->options);
 
 	/*
- 	 * If a temporary queue isn't finished building, still return success.
-   	 * CUPS says everything is fine, but hasn't returned responses to
-     	 * cupsGetOption() above.
+	 * Collect the needed attributes...
 	 */
+	const char* printer_uri_supported = cupsGetOption("printer-uri-supported", dest->num_options, dest->options);
+	const char* uri = cupsGetOption("device-uri", dest->num_options, dest->options);
+	const char* printer_is_temporary = cupsGetOption("printer-is-temporary", dest->num_options, dest->options);
+	const char* printer_avail_p = cupsGetOption("printer-is-accepting-jobs", dest->num_options, dest->options);
+	const char* printer_reason = cupsGetOption("printer-state-reasons", dest->num_options, dest->options);
 	
-	if (!printerreason)
+	memset(pr->p_status, 0, sizeof(pr->p_status));
+
+	if (!printer_uri_supported || !strcmp(printer_is_temporary, "true")) /* DNS-SD discovered IPP printer: Get status directly from printer */
 	{
-		httpClose(http);
-		cupsFreeDests(1, dest);
-		if (cupsLastError() == IPP_STATUS_OK)
-		{
-			snprintf(pr->p_status, 255, "status: busy; info: creating temporary printer queue for \"%s\"", pr->p_printer);
-			return(1);
-		}
-		else
+		temp_printer = 1;
+		if ((http = cupsConnectDest(dest, CUPS_DEST_FLAGS_DEVICE, 30000, NULL, NULL, 0, NULL, NULL)) == NULL)
 		{
 			LOG(log_error, logtype_papd,
-				"Unable to get status \"%s\": %s", pr->p_printer, cupsLastErrorString());
+				"Unable to connect to destination \"%s\": %s", dest->name, cupsLastErrorString());
+			snprintf(pr->p_status, 255, "status: busy; info: \"%s\" appears to be offline.", pr->p_printer);
+			cupsFreeDests(1, dest);
 			return (0);
 		}
+		ipp_t* request,       /* IPP Request */
+			* response;      /* IPP Response */
+		const char* pattrs[] =   /* Requested printer attributes */
+		{
+		  "printer-state",
+		  "printer-is-accepting-jobs",
+		  "printer-state-reasons"
+		};
+		ipp_attribute_t* attr;
+
+
+		/*
+		 * Build an IPP_OP_GET_PRINTER_ATTRIBUTES request, which requires the
+		 * following attributes:
+		 *
+		 *    requested-attributes
+		 *    printer-uri
+		 */
+
+		request = ippNewRequest(IPP_OP_GET_PRINTER_ATTRIBUTES);
+
+		ippAddStrings(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
+			"requested-attributes",
+			(sizeof(pattrs) / sizeof(pattrs[0])), NULL, pattrs);
+
+		ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
+			"printer-uri", NULL, uri);
+
+		/*
+		 * Do the request and get back a response...
+		 */
+
+		if ((response = cupsDoRequest(http, request, "/")) == NULL)
+		{
+			LOG(log_error, logtype_papd, "Unable to get printer attribs for %s - %s", pr->p_printer,
+				ippErrorString(cupsLastError()));
+			snprintf(pr->p_status, 255, "status: busy; info: \"%s\" appears to be offline.", pr->p_printer);
+			httpClose(http);
+			cupsFreeDests(1, dest);
+			return (0);
+		}
+		if ((attr = ippFindAttribute(response, "printer-state",
+			IPP_TAG_ENUM)) != NULL)
+		{
+			printer_state = ippGetInteger(attr, 0);
+		}
+		if ((attr = ippFindAttribute(response, "printer-is-accepting-jobs",
+			IPP_TAG_BOOLEAN)) != NULL)
+		{
+			printer_avail = ippGetBoolean(attr, 0);
+		}
+		if ((attr = ippFindAttribute(response, "printer-state-reasons",
+			IPP_TAG_KEYWORD)) != NULL)
+		{
+			int i, count = ippGetCount(attr);
+			for (i = 0; i < count; i++)
+			{
+				strncat(printer_reason_t, ippGetString(attr, i, NULL), 255 - strlen(printer_reason_t));
+			}
+		}
+		ippDelete(response);
+		httpClose(http);
+	}
+	else /* Permanent queue: Get status from CUPS scheduler */
+	{
+		if (strcmp(printer_avail_p, "true") == 0)
+			printer_avail = 1;
+		printer_state = cupsGetIntegerOption("printer-state", dest->num_options, dest->options);
 	}
 
+	 /*
+	  * Get the current printer status and convert it to the status values.
+	  */
 
-       /*
-        * Get the current printer status and convert it to the status values.
-        */
+	if (printer_state == 5) /* printer is stopped */
+		status = 1;
+	else if (printer_state == 4) /* printer is processing a job */
+		status = 3;
+	else /* ready */
+		status = 2;
 
-	memset ( pr->p_status, 0 ,sizeof(pr->p_status));
-
-	if (printerstate == 5) /* printer is paused */
-			status = 1;
-		else
-			status = 2; /* ready */
-	if (strcmp(printeravail, "false") == 0)
+	if (!printer_avail)
 		status = 0; /* printer is rejecting jobs */
 
 	snprintf(pr->p_status, 255, cups_status_msg[status], pr->p_printer);
-	if (strcmp(printerreason, "none") != 0)
-		strncat(pr->p_status, printerreason , 255 - strlen(pr->p_status));
 
-       /*
-        * Return the print status ...
-        */
-	httpClose(http);
-	cupsFreeDests(1,dest);
+	if (temp_printer) /* printer state */
+		strncat(pr->p_status, printer_reason_t, 255 - strlen(pr->p_status));
+	else
+		strncat(pr->p_status, printer_reason, 255 - strlen(pr->p_status));
+	/*
+	 * Return the print status ...
+	 */
+
+	cupsFreeDests(1, dest);
 	return (status);
 }
 

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -403,12 +403,13 @@ cups_get_printer_status (struct printer *pr)
 
 		if ((response = cupsDoRequest(http, request, "/")) == NULL)
 		{
+			/* Printer didn't respond to status request. Don't block print jobs as the scheduler will handle them */
 			LOG(log_error, logtype_papd, "Unable to get printer attribs for %s - %s", pr->p_printer,
 				ippErrorString(cupsLastError()));
-			snprintf(pr->p_status, 255, "status: busy; info: \"%s\" appears to be offline.", pr->p_printer);
+			snprintf(pr->p_status, 255, "status: busy; info: \"%s\" not responding to queries.", pr->p_printer);
 			httpClose(http);
 			cupsFreeDests(1, dest);
-			return (0);
+			return (1);
 		}
 		if ((attr = ippFindAttribute(response, "printer-state",
 			IPP_TAG_ENUM)) != NULL)
@@ -507,7 +508,7 @@ int cups_print_job ( char * name, char *filename, char *job, char *username, cha
 	}
 
 	info = cupsCopyDestInfo(CUPS_HTTP_DEFAULT, dest);
-	
+
 	if ( username != NULL )
 	{
 		/* Add options using cupsAddOption() */

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -321,11 +321,11 @@ cups_get_printer_status (struct printer *pr)
 	http_t* http;          /* HTTP connection to server */
 	cups_dest_t* dest = NULL;	/* Destination */
 	int 		status = -1;
-	char printer_reason_t[255];
-	memset(printer_reason_t, 0, sizeof(printer_reason_t));
+	char printer_reason[150];
+	memset(printer_reason, 0, sizeof(printer_reason));
 	int printer_avail = 0;
 	int printer_state = 3;
-	int temp_printer = 0;
+	unsigned flags;
 
 	/*
 	 * Make sure we don't ask for passwords...
@@ -352,92 +352,90 @@ cups_get_printer_status (struct printer *pr)
 	 */
 	const char* printer_uri_supported = cupsGetOption("printer-uri-supported", dest->num_options, dest->options);
 	const char* printer_is_temporary = cupsGetOption("printer-is-temporary", dest->num_options, dest->options);
-	const char* printer_avail_p = cupsGetOption("printer-is-accepting-jobs", dest->num_options, dest->options);
-	const char* printer_reason = cupsGetOption("printer-state-reasons", dest->num_options, dest->options);
-	
+
 	memset(pr->p_status, 0, sizeof(pr->p_status));
-
 	if (!printer_uri_supported || !strcmp(printer_is_temporary, "true")) /* DNS-SD discovered IPP printer: Get status directly from printer */
+		flags = CUPS_DEST_FLAGS_DEVICE;
+	else
+		flags = CUPS_DEST_FLAGS_NONE;
+
+	if ((http = cupsConnectDest(dest, flags, 30000, NULL, NULL, 0, NULL, NULL)) == NULL)
 	{
-		temp_printer = 1;
-		if ((http = cupsConnectDest(dest, CUPS_DEST_FLAGS_DEVICE, 30000, NULL, NULL, 0, NULL, NULL)) == NULL)
-		{
-			LOG(log_error, logtype_papd,
-				"Unable to connect to destination \"%s\": %s", dest->name, cupsLastErrorString());
-			snprintf(pr->p_status, 255, "status: busy; info: \"%s\" appears to be offline.", pr->p_printer);
-			cupsFreeDests(1, dest);
-			return (0);
-		}
-		ipp_t* request,       /* IPP Request */
-			* response;      /* IPP Response */
-		const char* pattrs[] =   /* Requested printer attributes */
-		{
-		  "printer-state",
-		  "printer-is-accepting-jobs",
-		  "printer-state-reasons"
-		};
-		ipp_attribute_t* attr;
-		const char* uri = cupsGetOption("device-uri", dest->num_options, dest->options);
+		LOG(log_error, logtype_papd,
+			"Unable to connect to destination \"%s\": %s", dest->name, cupsLastErrorString());
+		snprintf(pr->p_status, 255, "status: busy; info: \"%s\" appears to be offline.", pr->p_printer);
+		cupsFreeDests(1, dest);
+		return (0);
+	}
+	ipp_t* request,       /* IPP Request */
+		* response;      /* IPP Response */
+	const char* pattrs[] =   /* Requested printer attributes */
+	{
+	  "printer-state",
+	  "printer-is-accepting-jobs",
+	  "printer-state-reasons"
+	};
+	ipp_attribute_t* attr;
 
-		/*
-		 * Build an IPP_OP_GET_PRINTER_ATTRIBUTES request, which requires the
-		 * following attributes:
-		 *
-		 *    requested-attributes
-		 *    printer-uri
-		 */
+	/*
+	 * Build an IPP_OP_GET_PRINTER_ATTRIBUTES request, which requires the
+	 * following attributes:
+	 *
+	 *    requested-attributes
+	 *    printer-uri
+	 */
 
-		request = ippNewRequest(IPP_OP_GET_PRINTER_ATTRIBUTES);
+	request = ippNewRequest(IPP_OP_GET_PRINTER_ATTRIBUTES);
+	const char* uri = cupsGetOption("device-uri", dest->num_options, dest->options);
 
-		ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
-			"printer-uri", NULL, uri);
-		
-		ippAddStrings(request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD,
-			"requested-attributes",
-			(sizeof(pattrs) / sizeof(pattrs[0])), NULL, pattrs);
+	if (flags == CUPS_DEST_FLAGS_DEVICE)
+               	ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
+                       	"printer-uri", NULL, uri);
+	else
+               	ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
+                       	"printer-uri", NULL, printer_uri_supported);
 
-		/*
-		 * Do the request and get back a response...
-		 */
+	ippAddStrings(request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD,
+		"requested-attributes",
+		(sizeof(pattrs) / sizeof(pattrs[0])), NULL, pattrs);
 
-		if ((response = cupsDoRequest(http, request, "/")) == NULL)
-		{
-			/* Printer didn't respond to status request. Don't block print jobs as the scheduler will handle them */
-			LOG(log_error, logtype_papd, "Unable to get printer attribs for %s - %s", pr->p_printer,
-				ippErrorString(cupsLastError()));
-			snprintf(pr->p_status, 255, "status: busy; info: \"%s\" not responding to queries.", pr->p_printer);
-			httpClose(http);
-			cupsFreeDests(1, dest);
-			return (1);
-		}
-		if ((attr = ippFindAttribute(response, "printer-state",
-			IPP_TAG_ENUM)) != NULL)
-		{
-			printer_state = ippGetInteger(attr, 0);
-		}
-		if ((attr = ippFindAttribute(response, "printer-is-accepting-jobs",
-			IPP_TAG_BOOLEAN)) != NULL)
-		{
-			printer_avail = ippGetBoolean(attr, 0);
-		}
-		if ((attr = ippFindAttribute(response, "printer-state-reasons",
-			IPP_TAG_KEYWORD)) != NULL)
-		{
-			int i, count = ippGetCount(attr);
-			for (i = 0; i < count; i++)
-			{
-				strncat(printer_reason_t, ippGetString(attr, i, NULL), 255 - strlen(printer_reason_t));
-			}
-		}
-		ippDelete(response);
+	/*
+	 * Do the request and get back a response...
+	 */
+
+	if ((response = cupsDoRequest(http, request, "/")) == NULL)
+	{
+		/* Printer didn't respond to status request. Don't block print jobs as the scheduler will handle them */
+		LOG(log_error, logtype_papd, "Unable to get printer attribs for %s - %s", pr->p_printer,
+			ippErrorString(cupsLastError()));
+		snprintf(pr->p_status, 255, "status: busy; info: \"%s\" not responding to queries.", pr->p_printer);
 		httpClose(http);
+		cupsFreeDests(1, dest);
+		return (1);
 	}
-	else /* Permanent queue: Get status from CUPS scheduler */
+	if ((attr = ippFindAttribute(response, "printer-state",
+		IPP_TAG_ENUM)) != NULL)
 	{
-		if (strcmp(printer_avail_p, "true") == 0)
-			printer_avail = 1;
-		printer_state = cupsGetIntegerOption("printer-state", dest->num_options, dest->options);
+		printer_state = ippGetInteger(attr, 0);
 	}
+	if ((attr = ippFindAttribute(response, "printer-is-accepting-jobs",
+		IPP_TAG_BOOLEAN)) != NULL)
+	{
+		printer_avail = ippGetBoolean(attr, 0);
+	}
+	if ((attr = ippFindAttribute(response, "printer-state-reasons",
+		IPP_TAG_KEYWORD)) != NULL)
+	{
+		int i, count = ippGetCount(attr);
+		for (i = 0; i < count; i++)
+		{
+			strncat(printer_reason, ippGetString(attr, i, NULL), 150 - strlen(printer_reason));
+			if ( i != (count-1))
+				strncat(printer_reason, ", ", 150 - strlen(printer_reason));
+		}
+	}
+	ippDelete(response);
+	httpClose(http);
 
 	 /*
 	  * Get the current printer status and convert it to the status values.
@@ -455,10 +453,9 @@ cups_get_printer_status (struct printer *pr)
 
 	snprintf(pr->p_status, 255, cups_status_msg[status], pr->p_printer);
 
-	if (temp_printer) /* printer state */
-		strncat(pr->p_status, printer_reason_t, 255 - strlen(pr->p_status));
-	else
-		strncat(pr->p_status, printer_reason, 255 - strlen(pr->p_status));
+	/* printer state */
+	strncat(pr->p_status, printer_reason, 255 - strlen(pr->p_status));
+
 	/*
 	 * Return the print status ...
 	 */

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -351,7 +351,6 @@ cups_get_printer_status (struct printer *pr)
 	 * Collect the needed attributes...
 	 */
 	const char* printer_uri_supported = cupsGetOption("printer-uri-supported", dest->num_options, dest->options);
-	const char* uri = cupsGetOption("device-uri", dest->num_options, dest->options);
 	const char* printer_is_temporary = cupsGetOption("printer-is-temporary", dest->num_options, dest->options);
 	const char* printer_avail_p = cupsGetOption("printer-is-accepting-jobs", dest->num_options, dest->options);
 	const char* printer_reason = cupsGetOption("printer-state-reasons", dest->num_options, dest->options);
@@ -378,7 +377,7 @@ cups_get_printer_status (struct printer *pr)
 		  "printer-state-reasons"
 		};
 		ipp_attribute_t* attr;
-
+		const char* uri = cupsGetOption("device-uri", dest->num_options, dest->options);
 
 		/*
 		 * Build an IPP_OP_GET_PRINTER_ATTRIBUTES request, which requires the
@@ -390,12 +389,12 @@ cups_get_printer_status (struct printer *pr)
 
 		request = ippNewRequest(IPP_OP_GET_PRINTER_ATTRIBUTES);
 
-		ippAddStrings(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
-			"requested-attributes",
-			(sizeof(pattrs) / sizeof(pattrs[0])), NULL, pattrs);
-
 		ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
 			"printer-uri", NULL, uri);
+		
+		ippAddStrings(request, IPP_TAG_OPERATION, IPP_TAG_KEYWORD,
+			"requested-attributes",
+			(sizeof(pattrs) / sizeof(pattrs[0])), NULL, pattrs);
 
 		/*
 		 * Do the request and get back a response...
@@ -451,7 +450,7 @@ cups_get_printer_status (struct printer *pr)
 	else /* ready */
 		status = 2;
 
-	if (!printer_avail)
+	if (!printer_avail && printer_state != 4)
 		status = 0; /* printer is rejecting jobs */
 
 	snprintf(pr->p_status, 255, cups_status_msg[status], pr->p_printer);

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -102,7 +102,7 @@ cups_printername_ok(char *name)         /* I - Name of printer */
         * Make sure we don't ask for passwords...
         */
 
-        cupsSetPasswordCB(cups_passwd_cb, NULL);
+        cupsSetPasswordCB2(cups_passwd_cb, NULL);
 
 	/*
 	 * Try to connect to the requested printer...
@@ -318,20 +318,9 @@ cups_get_printer_ppd ( char * name)
 int
 cups_get_printer_status (struct printer *pr)
 {
-
         http_t          *http;          /* HTTP connection to server */
 	cups_dest_t	*dest = NULL;	/* Destination */
-        ipp_t           *request,       /* IPP Request */
-                        *response;      /* IPP Response */
-        ipp_attribute_t *attr;          /* Current attribute */
 	int 		status = -1;
-
-        static const char *pattrs[] =   /* Requested printer attributes */
-                        {
-                          "printer-state",
-                          "printer-state-message",
-			  "printer-is-accepting-jobs"
-                        };
 
        /*
         * Make sure we don't ask for passwords...
@@ -344,6 +333,7 @@ cups_get_printer_status (struct printer *pr)
 	 */
 
 	dest = cupsGetNamedDest(CUPS_HTTP_DEFAULT, pr->p_printer, NULL);
+
 	if (!dest)
 	{
 		LOG(log_error, logtype_papd,
@@ -358,55 +348,36 @@ cups_get_printer_status (struct printer *pr)
 	}
 
        /*
-        * Generate the printer URI...
+        * Collect the needed attributes...
         */
 
-        const char *uri = cupsGetOption("printer-uri-supported", dest->num_options, dest->options);
+	const char *printerstate = cupsGetOption("printer-state", dest->num_options, dest->options);
+	const char *printeravail = cupsGetOption("printer-is-accepting-jobs", dest->num_options, dest->options);
+	const char *printerreason = cupsGetOption("printer-state-reasons", dest->num_options, dest->options);
 
-
-
-       /*
-        * Build an IPP_OP_GET_PRINTER_ATTRIBUTES request, which requires the
-        * following attributes:
-        *
-        *    attributes-charset
-        *    attributes-natural-language
-        *    requested-attributes
-        *    printer-uri
-        */
-
-        request = ippNewRequest(IPP_OP_GET_PRINTER_ATTRIBUTES);
-
-        ippAddStrings(request, IPP_TAG_OPERATION, IPP_TAG_NAME,
-                      "requested-attributes",
-                      (sizeof(pattrs) / sizeof(pattrs[0])),
-                      NULL, pattrs);
-
-        ippAddString(request, IPP_TAG_OPERATION, IPP_TAG_URI,
-                     "printer-uri", NULL, uri);
-
-       /*
-        * Do the request and get back a response...
-        */
-
-        if ((response = cupsDoRequest(http, request, "/")) == NULL)
-        {
-      		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", pr->p_printer,
-                         ippErrorString(cupsLastError()));
+	/*
+ 	 * If a temporary queue isn't finished building, still return success.
+   	 * CUPS says everything is fine, but hasn't returned responses to
+     	 * cupsGetOption() above.
+	 */
+	
+	if (!printerreason)
+	{
+		httpClose(http);
 		cupsFreeDests(1, dest);
-                httpClose(http);
-                return (0);
-        }
+		if (cupsLastError() == IPP_STATUS_OK)
+		{
+			snprintf(pr->p_status, 255, "status: busy; info: creating temporary printer queue for \"%s\"", pr->p_printer);
+			return(1);
+		}
+		else
+		{
+			LOG(log_error, logtype_papd,
+				"Unable to get status \"%s\": %s", pr->p_printer, cupsLastErrorString());
+			return (0);
+		}
+	}
 
-        if (cupsLastError() >= IPP_STATUS_OK_CONFLICTING)
-        {
-      		LOG(log_error, logtype_papd, "Unable to get printer status for %s - %s", pr->p_printer,
-                         ippErrorString(cupsLastError()));
-                ippDelete(response);
-		cupsFreeDests(1, dest);
-                httpClose(http);
-                return (0);
-        }
 
        /*
         * Get the current printer status and convert it to the status values.
@@ -414,35 +385,22 @@ cups_get_printer_status (struct printer *pr)
 
 	memset ( pr->p_status, 0 ,sizeof(pr->p_status));
 
-        if ((attr = ippFindAttribute(response, "printer-state", IPP_TAG_ENUM)) != NULL)
-        {
-                if (ippGetInteger(attr, 0) == IPP_PSTATE_STOPPED)
+	if (strcmp(printerstate, "5") == 0) /* printer is paused */
 			status = 1;
-                else if (ippGetInteger(attr,0) == IPP_STATUS_ERROR_NOT_ACCEPTING_JOBS)
-			status = 0;
 		else
-			status = 2;
-        }
+			status = 2; /* ready */
+	if (strcmp(printeravail, "false") == 0)
+		status = 0; /* printer is rejecting jobs */
 
-	if ((attr = ippFindAttribute(response, "printer-is-accepting-jobs", IPP_TAG_BOOLEAN)) != NULL)
-	{
-		if ( ippGetBoolean(attr, 0) == 0 )
-			status = 0;
-	}
-		
-	snprintf ( pr->p_status, 255, cups_status_msg[status], pr->p_printer );
-
-        if ((attr = ippFindAttribute(response, "printer-state-message", IPP_TAG_TEXT)) != NULL)
-		strncat ( pr->p_status, ippGetString(attr, 0, NULL), 255-strlen(pr->p_status));
-
-        ippDelete(response);
+	snprintf(pr->p_status, 255, cups_status_msg[status], pr->p_printer);
+	if (strcmp(printerreason, "none") != 0)
+		strncat(pr->p_status, printerreason , 255 - strlen(pr->p_status));
 
        /*
         * Return the print status ...
         */
-	cupsFreeDests(1, dest);
-        httpClose(http);
-
+	httpClose(http);
+	cupsFreeDests(1,dest);
 	return (status);
 }
 

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -96,7 +96,6 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 	cups_dest_t	*dest = NULL;	/* Destination */
         ipp_t           *request,       /* IPP Request */
                         *response;      /* IPP Response */
-        //char            uri[HTTP_MAX_URI]; /* printer-uri attribute */
 
        /*
         * Make sure we don't ask for passwords...
@@ -351,7 +350,7 @@ cups_get_printer_status (struct printer *pr)
         * Collect the needed attributes...
         */
 
-	const char *printerstate = cupsGetOption("printer-state", dest->num_options, dest->options);
+	int printerstate = cupsGetIntegerOption("printer-state", dest->num_options, dest->options);
 	const char *printeravail = cupsGetOption("printer-is-accepting-jobs", dest->num_options, dest->options);
 	const char *printerreason = cupsGetOption("printer-state-reasons", dest->num_options, dest->options);
 
@@ -385,7 +384,7 @@ cups_get_printer_status (struct printer *pr)
 
 	memset ( pr->p_status, 0 ,sizeof(pr->p_status));
 
-	if (strcmp(printerstate, "5") == 0) /* printer is paused */
+	if (printerstate == 5) /* printer is paused */
 			status = 1;
 		else
 			status = 2; /* ready */
@@ -442,16 +441,9 @@ int cups_print_job ( char * name, char *filename, char *job, char *username, cha
 		cupsFreeDests(1,dest);
 		return (0);
 	}
-	if ((http = cupsConnectDest(dest, CUPS_DEST_FLAGS_NONE, 30000, NULL, NULL, 0, NULL, NULL)) == NULL)
-	{
-		LOG(log_error, logtype_papd,
-		    "Unable to connect to destination \"%s\": %s", dest->name, cupsLastErrorString());
-		cupsFreeDests(1,dest);
-		return (0);
-	}
 
 	info = cupsCopyDestInfo(CUPS_HTTP_DEFAULT, dest);
-
+	
 	if ( username != NULL )
 	{
 		/* Add options using cupsAddOption() */


### PR DESCRIPTION
More code cleanup. Switch to using solely the CUPS Destination API to speak with the server instead of doing IPP queries ourselves. If we have a DNS-SD discovered printer, we query it directly for the status.