### PR TITLE
[2.3] manual: Remove obsoleted html-upload target, and update css URL

### DIFF
--- a/doc/html.xsl.in
+++ b/doc/html.xsl.in
@@ -4,7 +4,7 @@
 	<xsl:param name="use.id.as.filename" select="'1'"/>
 	<xsl:param name="chunk.section.depth" select="0"></xsl:param>
 	<xsl:param name="chunk.separate.lots" select="1"></xsl:param>
-	<xsl:param name="html.stylesheet" select="'https://netatalk.sourceforge.io/css/netatalk.css'"/>
+	<xsl:param name="html.stylesheet" select="'https://netatalk.io/css/netatalk.css'"/>
 
 	<xsl:template name="user.header.navigation">
 		<xsl:variable name="codefile" select="document('netatalk.html',/)"/>

--- a/doc/manual/Makefile.am
+++ b/doc/manual/Makefile.am
@@ -75,7 +75,4 @@ html-local: $(XML_PAGES)
 	@xsltproc $(HTML_STYLESHEET) manual.xml
 	rm -f *.
 
-html-upload: html-local
-	scp $(HTML_PAGES) $$USER,netatalk@web.sourceforge.net:/home/project-web/netatalk/htdocs/2.3/htmldocs/
-
 endif


### PR DESCRIPTION
Small updates to accommodate the move away from sourceforge hosting