### PR TITLE
[2.3] Docker: Check for mandatory env variables; more configurability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:bullseye-slim
 
 ENV LIB_DEPS cups \
     libavahi-client3 \
@@ -6,7 +6,7 @@ ENV LIB_DEPS cups \
     libdb5.3 \
     libgcrypt20 \
     libpam0g \
-    libssl3
+    libssl1.1
 ENV BUILD_DEPS autoconf \
     automake \
     build-essential \
@@ -21,7 +21,7 @@ ENV BUILD_DEPS autoconf \
     pkg-config
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
-  apt-get install --yes --no-install-recommends $LIB_DEPS $BUILD_DEPS
+    apt-get install --yes --no-install-recommends $LIB_DEPS $BUILD_DEPS
 
 RUN useradd builder
 WORKDIR /build
@@ -41,18 +41,19 @@ RUN userdel builder && make install
 WORKDIR /mnt/afpshare
 
 RUN apt-get remove --yes --auto-remove --purge $BUILD_DEPS && \
-  apt-get --quiet --yes autoclean && \
-  apt-get --quiet --yes autoremove && \
-  apt-get --quiet --yes clean
+    apt-get --quiet --yes autoclean && \
+    apt-get --quiet --yes autoremove && \
+    apt-get --quiet --yes clean
 RUN rm -rf \
-  /build \
-  /usr/include/netatalk \
-  /usr/share/man \
-  /usr/share/doc \
-  /usr/share/poppler \
-  /var/lib/apt/lists \
-  /tmp \
-  /var/tmp
+    /build \
+    /usr/include/netatalk \
+    /usr/share/man \
+    /usr/share/mime \
+    /usr/share/doc \
+    /usr/share/poppler \
+    /var/lib/apt/lists \
+    /tmp \
+    /var/tmp
 
 COPY contrib/shell_utils/docker-entrypoint.sh /docker-entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,8 +54,6 @@ RUN rm -rf \
   /tmp \
   /var/tmp
 
-RUN ln -sf /dev/stdout /var/log/afpd.log
-
 COPY contrib/shell_utils/docker-entrypoint.sh /docker-entrypoint.sh
 
 EXPOSE 548 631

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ You may have to restart papd (or the entire container) after adding a CUPS print
 - `AFPD_OPTIONS` <- options to append to afpd.conf
 - `AVOLUMES_OPTIONS` <- options to append to AppleVolumes.default
 - `ATALKD_OPTIONS` <- options to append to atalkd.conf
+- `INSECURE_AUTH` <- when non-zero, use the "Clear Text" UAM instead of "Random Number"
 
 ### Advanced
 - `MANUAL_CONFIG` <- when non-zero, manage users, volumes, and configurations manually. This overrides all of the above env variables. Use this together with bind mounted shared volumes and config files for the most versatile setup.


### PR DESCRIPTION
This changeset attempts to address an incompatibility with an older Synology NAS

- Revert to Bullseye image, and enable DHX UAM
- Bail out early if AFP_USER or AFP_PASS are undefined
- Introduce AFPD_LOGLEVEL and INSECURE_AUTH options