### PR TITLE
Make macOS initscripts prefix sensitive

### DIFF
--- a/distrib/initscripts/Makefile.am
+++ b/distrib/initscripts/Makefile.am
@@ -25,7 +25,9 @@ GENERATED_FILES = \
 	rc.solaris \
 	rc.suse \
 	service.systemd \
-	netatalk.xml
+	netatalk.xml \
+	com.netatalk.daemon.plist \
+	netatalkd
 
 TEMPLATES = \
 	rc.bsd.tmpl \
@@ -36,7 +38,9 @@ TEMPLATES = \
 	rc.solaris.tmpl \
 	rc.suse.tmpl \
 	service.systemd.tmpl \
-	netatalk.xml.tmpl
+	netatalk.xml.tmpl \
+	com.netatalk.daemon.plist.tmpl \
+	netatalkd.tmpl
 
 CLEANFILES = $(GENERATED_FILES) $(sysv_SCRIPTS) $(service_DATA) afpd cnid_metad
 EXTRA_DIST = $(TEMPLATES)

--- a/distrib/initscripts/com.netatalk.daemon.plist.tmpl
+++ b/distrib/initscripts/com.netatalk.daemon.plist.tmpl
@@ -5,13 +5,13 @@
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/usr/local/bin</string>
+		<string>:BINDIR:</string>
 	</dict>
 	<key>Label</key>
 	<string>com.netatalk.daemon</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>/usr/local/bin/netatalkd</string>
+		<string>:BINDIR:/netatalkd</string>
 		<string>start</string>
 	</array>
 	<key>RunAtLoad</key>

--- a/distrib/initscripts/com.netatalk.daemon.plist.tmpl
+++ b/distrib/initscripts/com.netatalk.daemon.plist.tmpl
@@ -6,6 +6,8 @@
 	<dict>
 		<key>PATH</key>
 		<string>:SBINDIR:::BINDIR::/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<key>OBJC_DISABLE_INITIALIZE_FORK_SAFETY</key>
+		<string>YES</string>
 	</dict>
 	<key>Label</key>
 	<string>com.netatalk.daemon</string>

--- a/distrib/initscripts/com.netatalk.daemon.plist.tmpl
+++ b/distrib/initscripts/com.netatalk.daemon.plist.tmpl
@@ -5,13 +5,13 @@
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>:BINDIR:</string>
+		<string>:SBINDIR:::BINDIR::/usr/bin:/bin:/usr/sbin:/sbin</string>
 	</dict>
 	<key>Label</key>
 	<string>com.netatalk.daemon</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>:BINDIR:/netatalkd</string>
+		<string>:SBINDIR:/netatalk</string>
 		<string>start</string>
 	</array>
 	<key>RunAtLoad</key>

--- a/distrib/initscripts/netatalkd.tmpl
+++ b/distrib/initscripts/netatalkd.tmpl
@@ -4,7 +4,6 @@
 
 # Prepare the environment
 export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
-PREFIX=/usr/local/sbin
 . /etc/rc.common
 
 # root check
@@ -25,7 +24,7 @@ done
 StartService() {
   ConsoleMessage "Starting netatalk fileserver..."
   rm -f /var/run/netatalk.pid
-  $PREFIX/netatalk
+  :SBINDIR:/netatalk
 }
 
 # The stop subroutine


### PR DESCRIPTION
This  commit fixes the failure of the macOS initscripts if Netatalk is installed in a non-standard location