### PR TITLE
[2.3] docs: Improve man page summaries

### DIFF
--- a/doc/manpages/man1/ad.1.xml
+++ b/doc/manpages/man1/ad.1.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>1</manvolnum>
 
-    <refmiscinfo class="date">05 Dec 2015</refmiscinfo>
+    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -13,7 +13,7 @@
   <refnamediv>
     <refname>ad</refname>
 
-    <refpurpose>Netatalk compatible UNIX file utility suite.</refpurpose>
+    <refpurpose>AppleDouble file utility suite</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
@@ -35,9 +35,10 @@
   <refsect1>
     <title>Description</title>
 
-    <para><command>ad</command> is a UNIX file utility suite with Netatalk
+    <para><command>ad</command> is an AppleDouble file utility suite with Netatalk
     compatibity. AppleDouble files in <filename>.AppleDouble</filename> directories and
-    the CNID databases are updated as appropriate.</para>
+    the CNID databases are updated as appropriate when files in a shared Netatalk volume
+    are modified.</para>
   </refsect1>
 
   <refsect1>

--- a/doc/manpages/man1/afppasswd.1.xml
+++ b/doc/manpages/man1/afppasswd.1.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>1</manvolnum>
 
-    <refmiscinfo class="date">31 May 2011</refmiscinfo>
+    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -13,7 +13,7 @@
   <refnamediv>
     <refname>afppasswd</refname>
 
-    <refpurpose>netatalk password maintenance utility</refpurpose>
+    <refpurpose>AFP Random Number UAM password maintenance utility</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
@@ -42,14 +42,14 @@
 
     <para><command>afppasswd</command> can either be called by root with
     parameters, or can be called by local system users with no parameters to
-    change their AFP passwords.</para>
+    change their own AFP passwords.</para>
 
     <note>
       <para>With this utility you can only change the passwords used by two
       specific UAMs. As they provide only weak password encryption, the use of
       the "Randnum exchange" and "2-Way Randnum exchange" UAMs is deprecated
       unless one has to support very old AFP clients, that can not deal with
-      the more secure "DHCAST128" and "DHX2" UAM instead. Please compare with
+      the more secure "DHX" or "DHX2" UAMs instead. Please compare with
       the <link linkend="authentication">Authentication chapter</link> inside
       Netatalk's documentation.</para>
     </note>

--- a/doc/manpages/man1/uniconv.1.xml
+++ b/doc/manpages/man1/uniconv.1.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <refentry id="uniconv.1">
-  <!--  $Id: uniconv.1.xml,v 1.5 2009-06-14 09:02:50 franklahm Exp $ -->
 
   <refmeta>
     <refentrytitle>uniconv</refentrytitle>

--- a/doc/manpages/man5/AppleVolumes.default.5.xml
+++ b/doc/manpages/man5/AppleVolumes.default.5.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>5</manvolnum>
 
-    <refmiscinfo class="date">31 Jan 2024</refmiscinfo>
+    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -17,9 +17,8 @@
 
     <refname>AppleVolumes</refname>
 
-    <refpurpose>Configuration file used by <command>afpd</command>(8) to
-    determine the shares made available through AFP and specify file name
-    extension mappings.<indexterm>
+    <refpurpose>Configuration file(s) used by <command>afpd</command>(8) to
+    determine the shared volumes made available through AFP<indexterm>
         <primary>AppleVolumes.default</primary>
       </indexterm><indexterm>
         <primary>cnidscheme</primary>
@@ -69,10 +68,16 @@
     <filename>~/AppleVolumes</filename>,
     <filename>~/.AppleVolumes</filename>,
     <filename>~/applevolumes</filename>, or
-    <filename>~/.applevolumes</filename>  are the
+    <filename>~/.applevolumes</filename> are the
     configuration files used by <command>afpd</command> to determine what
-    portions of the file system will be shared via Apple Filing Protocol, as
-    well as their behaviour.</para>
+    portions of the file system will be shared via Apple Filing Protocol,
+    their behaviour, as well as file name extension mappings.</para>
+
+    <para>The present convention is that <filename>AppleVolumes.system</filename>
+    contains the global file extension mappings, while
+    <filename>AppleVolumes.default</filename> contains the global shared volumes.
+    When present, the config file in the user's home dir contains
+    user overrides to either.</para>
 
     <para>Any line not prefixed with # is interpreted.
     Newline escaping is supported. The configuration lines are composed
@@ -109,7 +114,7 @@
 
     <note>
       <para>File name extension mapping is useful for Mac OS 9 and earlier.
-      But it should not use for Mac OS X.</para>
+      However, it is not helpful on Mac OS X.</para>
     </note>
 
     <para>It is possible to specify default options for all volumes with a

--- a/doc/manpages/man5/afp_ldap.conf.5.xml
+++ b/doc/manpages/man5/afp_ldap.conf.5.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <refentry id="afp_ldap.conf.5">
-  <!--  $Id: afp_ldap.conf.5.xml,v 1.6 2009-11-28 11:25:17 franklahm Exp $ -->
 
   <refmeta>
     <refentrytitle>afp_ldap.conf</refentrytitle>
 
     <manvolnum>5</manvolnum>
 
-    <refmiscinfo class="date">30 Mar 2011</refmiscinfo>
+    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -15,17 +14,17 @@
   <refnamediv>
     <refname>afp_ldap.conf</refname>
 
-    <refpurpose>Configuration file used by afpd(8) to configure a LDAP
-    connection to an LDAP server. That is needed for ACL support in order to
-    be able to query LDAP for UUIDs.</refpurpose>
+    <refpurpose>Configuration file used by <command>afpd</command>(8) to configure
+    connections to an LDAP server</refpurpose>
   </refnamediv>
 
   <refsect1>
     <title>Description</title>
 
     <para><filename>afp_ldap.conf</filename> is the configuration
-    file used by <command>afpd</command> to set up an LDAP connection to an
-    LDAP server.</para>
+    file used by <command>afpd</command> to set up connections to an
+    LDAP server. This is needed for ACL support in order to
+    be able to query LDAP for UUIDs.</para>
 
     <para>Any line not prefixed with # is interpreted.</para>
 

--- a/doc/manpages/man5/afp_signature.conf.5.xml
+++ b/doc/manpages/man5/afp_signature.conf.5.xml
@@ -14,7 +14,7 @@
   <refnamediv>
     <refname>afp_signature.conf</refname>
 
-    <refpurpose>Configuration file used by afpd(8) to specify server
+    <refpurpose>Configuration file used by <command>afpd</command>(8) to specify server
         signature</refpurpose>
   </refnamediv>
 

--- a/doc/manpages/man5/afp_voluuid.conf.5.xml
+++ b/doc/manpages/man5/afp_voluuid.conf.5.xml
@@ -6,7 +6,7 @@
 
     <manvolnum>5</manvolnum>
 
-    <refmiscinfo class="date">8 March 2011</refmiscinfo>
+    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -14,8 +14,8 @@
   <refnamediv>
     <refname>afp_voluuid.conf</refname>
 
-    <refpurpose>Configuration file used by afpd(8) to specify UUID
-        for Time Machine volume</refpurpose>
+    <refpurpose>Configuration file used by <command>afpd</command>(8) to specify UUID
+        for Time Machine volumes</refpurpose>
   </refnamediv>
 
   <refsect1>
@@ -23,8 +23,8 @@
 
     <para><filename>afp_voluuid.conf</filename> is the
     configuration file used by <command>afpd</command> to specify
-    UUID of Time Machine volume automagically. The configuration
-    lines are composed like:</para>
+    the UUID of Time Machine volumes automagically. The configuration
+    lines are composed like this:</para>
 
     <para><replaceable>"volume-name"</replaceable>
     <replaceable>uuid-string</replaceable></para>
@@ -33,16 +33,16 @@
     if they contain spaces. The second field is the 36 character
     hexadecimal ASCII string representation of a UUID.</para>
     <para>The leading spaces and tabs are ignored. Blank lines are ignored.
-    The lines prefixed with # are ignored. The illegal lines are ignored.
+    The lines prefixed with # are ignored. Illegal lines are ignored.
     </para>
 
     <note>
         <para>This UUID is advertised by Zeroconf in order to provide
-        robust disambiguation of Time Machine volume.</para>
-        <para>The afpd generates the UUID from random numbers and saves it
-        into afp_voluuid.conf, only when setting "tm" option in AppleVolumes
-        file.</para>
-        <para>This file should not be thoughtlessly edited and be copied
+        robust disambiguation of the Time Machine volume.</para>
+        <para>The afpd process generates the UUID from random numbers and saves it
+        into afp_voluuid.conf, when the <option>tm</option> option is enabled
+        for the volume in the AppleVolumes configuration file.</para>
+        <para>This file should not be thoughtlessly edited or copied
         onto another server.</para>
     </note>
 

--- a/doc/manpages/man5/afpd.conf.5.xml
+++ b/doc/manpages/man5/afpd.conf.5.xml
@@ -6,7 +6,7 @@
 
     <manvolnum>5</manvolnum>
 
-    <refmiscinfo class="date">03 May 2023</refmiscinfo>
+    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -14,8 +14,8 @@
   <refnamediv>
     <refname>afpd.conf</refname>
 
-    <refpurpose>Configuration file used by afpd(8) to determine the setup of
-    its file sharing services</refpurpose>
+    <refpurpose>Configuration file used by <command>afpd</command>(8)
+    to determine the capabilities of its file sharing services</refpurpose>
   </refnamediv>
 
   <refsect1>
@@ -23,7 +23,7 @@
 
     <para><filename>afpd.conf</filename> is the configuration file
     used by <command>afpd</command> to determine the behavior and
-    configuration of the different virtual file servers that it
+    capabilities of one or more virtual file servers that it
     provides.</para>
 
     <para>Any line not prefixed with # is interpreted. The configuration lines

--- a/doc/manpages/man5/atalkd.conf.5.xml
+++ b/doc/manpages/man5/atalkd.conf.5.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <refentry id="atalkd.conf.5">
-  <!--  $Id: atalkd.conf.5.xml,v 1.6 2004-07-20 09:41:42 tkaiser Exp $ -->
 
   <refmeta>
     <refentrytitle>atalkd.conf</refentrytitle>
 
     <manvolnum>5</manvolnum>
 
-    <refmiscinfo class="date">22 September 2000</refmiscinfo>
+    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -15,8 +14,8 @@
   <refnamediv>
     <refname>atalkd.conf</refname>
 
-    <refpurpose>Configuration file used by atalkd(8) to determine the
-    interfaces used by the master Netatalk daemon<indexterm><primary>atalkd.conf</primary></indexterm><indexterm>
+    <refpurpose>Configuration file used by <command>atalkd</command>(8) to configure the
+    interfaces used by AppleTalk<indexterm><primary>atalkd.conf</primary></indexterm><indexterm>
               <primary>ALLMULTI</primary>
 
               <secondary>NIC multicast settings</secondary>

--- a/doc/manpages/man5/netatalk.conf.5.xml
+++ b/doc/manpages/man5/netatalk.conf.5.xml
@@ -6,7 +6,7 @@
 
     <manvolnum>5</manvolnum>
 
-    <refmiscinfo class="date">13 Feb 2023</refmiscinfo>
+    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -14,8 +14,7 @@
   <refnamediv>
     <refname>netatalk.conf</refname>
 
-    <refpurpose>Configuration file used by the Netatalk init script to determine its
-    general configuration<indexterm>
+    <refpurpose>Configuration file used by certain Netatalk init scripts<indexterm>
         <primary>netatalk.conf</primary>
       </indexterm><indexterm>
         <primary>AFPD_GUEST</primary>
@@ -57,9 +56,10 @@
   <refsect1>
     <title>Description</title>
 
-    <para><emphasis remap="B">netatalk.conf</emphasis> is the
-    configuration file used by the netatalk init script to determine what portions of the file
-    system will be shared via AFP, as well as their behaviors.</para>
+    <para><emphasis remap="B">netatalk.conf</emphasis>
+    is a configuration file used by certain netatalk init scripts
+    to determine what portions of the file system will be shared via AFP,
+    as well as their behaviors.</para>
 
     <para>If netatalk has been configured with --enable-debian, this file is named
     <emphasis remap="B">/etc/default/netatalk</emphasis> without the file ending.</para>
@@ -71,7 +71,7 @@
     individually.</para></note>
 
     <para>Any line not prefixed with <emphasis remap="B">#</emphasis> is
-    interpreted. The configuration lines are composed like:</para>
+    interpreted. The configuration lines are composed like this:</para>
 
     <para><emphasis remap="I">option</emphasis> <emphasis
     remap="B">=</emphasis> <emphasis remap="I">value</emphasis></para>

--- a/doc/manpages/man5/papd.conf.5.xml
+++ b/doc/manpages/man5/papd.conf.5.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <refentry id="papd.conf.5">
-  <!--  $Id: papd.conf.5.xml,v 1.12 2009-07-20 08:46:34 franklahm Exp $ -->
 
   <refmeta>
     <refentrytitle>papd.conf</refentrytitle>
@@ -15,7 +14,7 @@
   <refnamediv>
     <refname>papd.conf</refname>
 
-    <refpurpose>Configuration file used by papd(8) to determine the
+    <refpurpose>Configuration file used by <command>papd</command>(8) to determine the
     configuration of printers used by the Netatalk printing daemon<indexterm>
         <primary>papd.conf</primary>
       </indexterm></refpurpose>

--- a/doc/manpages/man8/a2boot.8.xml
+++ b/doc/manpages/man8/a2boot.8.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>8</manvolnum>
 
-    <refmiscinfo class="date">01 Mar 2023</refmiscinfo>
+    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -13,7 +13,7 @@
   <refnamediv>
     <refname>a2boot</refname>
 
-    <refpurpose>Apple II netboot server</refpurpose>
+    <refpurpose>Apple II netboot server daemon</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
@@ -30,13 +30,31 @@
     <title>Description</title>
 
     <para><emphasis remap="B">a2boot</emphasis> is a netboot server for
-    Apple IIe and IIGS computers. It allows compatible clients to boot
-    over an AppleTalk network </para>
+    Apple IIe and IIGS computers. It allows compatible clients to boot into
+    ProDOS or GS/OS over an AppleTalk network.
+    This is functionally comparable to the Apple II netboot software included
+    in early versions of AppleShare File Server for Macintosh.</para>
 
-    <para><emphasis remap="B">a2boot</emphasis> serves multiple AFP volumes
-    that the Apple II client is configured to boot off of. These volumes
-    have to be populated with the appropriate ProDOS or GS/OS system files
-    before they can be used as boot volumes.</para>
+    <para>When running, the daemon will create the following
+    hard-coded AFP volumes.</para>
+
+    <itemizedlist>
+      <listitem>
+        <para>Apple //e Boot</para>
+      </listitem>
+      <listitem>
+        <para>Apple //gs</para>
+      </listitem>
+      <listitem>
+        <para>ProDOS16 Image</para>
+      </listitem>
+    </itemizedlist>
+
+    <para>These volumes need to be populated with the appropriate
+    ProDOS or GS/OS system files in order to function as boot volumes.
+    For more information, see the documentation for
+    AppleShare File Server for Macintosh.</para>
+
   </refsect1>
 
   <refsect1>

--- a/doc/manpages/man8/atalkd.8.xml
+++ b/doc/manpages/man8/atalkd.8.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>8</manvolnum>
 
-    <refmiscinfo class="date">18 Jan 2024</refmiscinfo>
+    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -13,7 +13,7 @@
   <refnamediv>
     <refname>atalkd</refname>
 
-    <refpurpose>AppleTalk RTMP, NBP, ZIP, and AEP manager</refpurpose>
+    <refpurpose>userland AppleTalk network manager daemon</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
@@ -68,7 +68,10 @@
         <refentrytitle>ping</refentrytitle>
 
         <manvolnum>8</manvolnum>
-      </citerefentry>). <command>atalkd</command> is typically started at boot
+      </citerefentry>).
+    Specifically, this corresponds to the RTMP, NBP, ZIP, and AEP protocols.</para>
+      
+    <para><command>atalkd</command> is typically started at boot
     time from system init scripts or services. It first reads from its
     configuration file, <filename>atalkd.conf</filename>. If there is
     no configuration file, <command>atalkd</command> will attempt to configure

--- a/doc/manpages/man8/cnid_dbd.8.xml
+++ b/doc/manpages/man8/cnid_dbd.8.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>8</manvolnum>
 
-    <refmiscinfo class="date">01 Jan 2012</refmiscinfo>
+    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -13,8 +13,7 @@
   <refnamediv>
     <refname>cnid_dbd</refname>
 
-    <refpurpose>implement access to CNID databases through a dedicated daemon
-    process</refpurpose>
+    <refpurpose>CNID database access daemon</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>

--- a/doc/manpages/man8/cnid_metad.8.xml
+++ b/doc/manpages/man8/cnid_metad.8.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>8</manvolnum>
 
-    <refmiscinfo class="date">01 Jan 2012</refmiscinfo>
+    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -13,7 +13,7 @@
   <refnamediv>
     <refname>cnid_metad</refname>
 
-    <refpurpose>start cnid_dbd daemons on request</refpurpose>
+    <refpurpose>daemon for starting cnid_dbd daemons on demand</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>


### PR DESCRIPTION
The purpose of this changeset is to make the man page descriptions more accurate, to allow for at a glance overview when looking at a list of the man page (e.g. https://netatalk.io/oldstable/htmldocs/man-pages )