### PR TITLE
Update .gitignore for generated macOS initscripts

### DIFF
--- a/distrib/initscripts/.gitignore
+++ b/distrib/initscripts/.gitignore
@@ -1,3 +1,4 @@
+com.netatalk.daemon.plist
 rc.bsd
 rc.debian
 rc.gentoo
@@ -9,3 +10,4 @@ service.systemd
 netatalk
 netatalk.service
 netatalk.xml
+netatalkd


### PR DESCRIPTION
A small oversight from the recent move to templates for macOS initscripts