### PR TITLE
[2.3] docs: Print netatalk version as subtitle, and header on each html page

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1188,6 +1188,7 @@ AC_CONFIG_FILES([Makefile
 	doc/man.xsl
 	doc/manual/Makefile
 	doc/manual/manual.xml
+	doc/manual/netatalk.html
 	doc/manpages/Makefile
 	doc/manpages/man1/Makefile
 	doc/manpages/man3/Makefile

--- a/doc/html.xsl.in
+++ b/doc/html.xsl.in
@@ -1,9 +1,10 @@
 <?xml version='1.0'?> 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"> 
 	<xsl:import href="@DOCBOOK_ROOT@/xhtml/chunk.xsl"/>
-	<xsl:param name="use.id.as.filename" select="'1'"/>
-	<xsl:param name="chunk.section.depth" select="0"></xsl:param>
-	<xsl:param name="chunk.separate.lots" select="1"></xsl:param>
+	<xsl:param name="use.id.as.filename" select="1"/>
+	<xsl:param name="chunker.output.indent" select="'yes'"/>
+	<xsl:param name="chunk.section.depth" select="0"/>
+	<xsl:param name="chunk.separate.lots" select="1"/>
 	<xsl:param name="html.stylesheet" select="'https://netatalk.io/css/netatalk.css'"/>
 
 	<xsl:template name="user.header.navigation">

--- a/doc/manual/.gitignore
+++ b/doc/manual/.gitignore
@@ -1,2 +1,3 @@
 manual.xml
+netatalk.html
 *.html

--- a/doc/manual/Makefile.am
+++ b/doc/manual/Makefile.am
@@ -16,7 +16,7 @@ EXTRA_DIST = \
 	install.xml \
 	intro.xml \
 	upgrade.xml \
-	netatalk.html
+	netatalk.html.in
 
 HTML_PAGES = \
 	a2boot.8.html \
@@ -66,7 +66,7 @@ HTML_PAGES = \
 	uniconv.1.html \
 	upgrade.html
 
-DISTCLEANFILES = manual.xml
+DISTCLEANFILES = manual.xml natatalk.html
 
 if HAVE_XSLTPROC
 CLEANFILES += $(HTML_PAGES)

--- a/doc/manual/manual.xml.in
+++ b/doc/manual/manual.xml.in
@@ -46,13 +46,7 @@
 <!ENTITY uniconv.1 SYSTEM "../manpages/man1/uniconv.1.xml">
 ]>
 <book id="netatalk-manual">
-  <title revision="0.1 initial version">Netatalk 2.3 Manual</title>
-  
-
-  <bookinfo>
-    <date>01-04-2024</date>
-    <releaseinfo>@NETATALK_VERSION@</releaseinfo>
-  </bookinfo>
+  <title>Netatalk @NETATALK_VERSION@ Manual</title>
 
  <?latex \setcounter{page}{3} ?>
 <preface>

--- a/doc/manual/manual.xml.in
+++ b/doc/manual/manual.xml.in
@@ -46,7 +46,11 @@
 <!ENTITY uniconv.1 SYSTEM "../manpages/man1/uniconv.1.xml">
 ]>
 <book id="netatalk-manual">
-  <title>Netatalk @NETATALK_VERSION@ Manual</title>
+  <title>Netatalk Manual</title>
+
+  <bookinfo>
+    <subtitle>Version @NETATALK_VERSION@</subtitle>
+  </bookinfo>
 
  <?latex \setcounter{page}{3} ?>
 <preface>

--- a/doc/manual/netatalk.html
+++ b/doc/manual/netatalk.html
@@ -4,10 +4,10 @@
         <div id="menlinks">
           <a href="/" title="Return to Netatalk home">[main]</a>
           <a href="/docs" title="Netatalk Wiki">[wiki]</a>
-          <a href="/documentation.php" title="Netatalk Manual">[documentation]</a>
-          <a href="/download.php" title="Download Netatalk">[downloads]</a>
-          <a href="/support.php" title="Support">[support]</a>
-          <a href="/links.php" title="Netatalk related links">[links]</a>
+          <a href="/documentation.html" title="Netatalk Manual">[documentation]</a>
+          <a href="/download.html" title="Download Netatalk">[downloads]</a>
+          <a href="/support.html" title="Support">[support]</a>
+          <a href="/links.html" title="Netatalk related links">[links]</a>
           <img src="/gfx/end.gif" alt="" width="125" height="7" />
         </div>
     </div>

--- a/doc/manual/netatalk.html.in
+++ b/doc/manual/netatalk.html.in
@@ -11,4 +11,5 @@
           <img src="/gfx/end.gif" alt="" width="125" height="7" />
         </div>
     </div>
+    <div class="navheader" align="center">@NETATALK_VERSION@</div>
 </html>


### PR DESCRIPTION
This change is meant to make it clearer in the generated html manual which version of Netatalk it is for. We now put a header with the version number on each generated html chunk.