### PR TITLE
docs: Limit max TOC depth to 2 in html manual; use DocBook 4.5 DTD

### DIFF
--- a/doc/html.xsl.in
+++ b/doc/html.xsl.in
@@ -6,6 +6,7 @@
 	<xsl:param name="chunk.section.depth" select="0"/>
 	<xsl:param name="chunk.separate.lots" select="1"/>
 	<xsl:param name="html.stylesheet" select="'https://netatalk.io/css/netatalk.css'"/>
+	<xsl:param name="toc.max.depth" select="2"/>
 
 	<xsl:template name="user.header.navigation">
 		<xsl:variable name="codefile" select="document('netatalk.html',/)"/>

--- a/doc/manual/manual.xml.in
+++ b/doc/manual/manual.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
-"http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd" [
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN"
+"http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
 
 <!ENTITY Configuration SYSTEM "configuration.xml">
 <!ENTITY Intro SYSTEM "intro.xml">
@@ -55,7 +55,7 @@
   <chapter id="man-pages">
     <title>Manual Pages</title>
 
-    <para>This is a collection of the man pages delivered with Netatalk.</para>
+    <para>This is a collection of manual pages for Netatalk components.</para>
 
     &ad.1;
 

--- a/doc/manual/netatalk.html.in
+++ b/doc/manual/netatalk.html.in
@@ -11,5 +11,5 @@
           <img src="/gfx/end.gif" alt="" width="125" height="7" />
         </div>
     </div>
-    <div class="navheader" align="center">@NETATALK_VERSION@</div>
+    <div class="navheader" align="center">Netatalk @NETATALK_VERSION@</div>
 </html>


### PR DESCRIPTION
Another batch of minor improvements to the docbook docs:

- Limit TOC depth to 2 in the generated html manual: improves readability of the top level TOC, without sacrificing the detailed TOC on individual chapter pages.
- Bump to DocBook 4.5 DTD from 4.2 -- the GPL DocBook uses the 4.4 DTD, so I bumped to the last 4.x series DTD for good measure. I ran a diff test on the generated html/man files and there was no difference in how the XML was transformed.
- Small wording tweaks