### PR TITLE
[2.4] Swap out the old ldap_init for the wonderful ldap_initialize

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -875,7 +875,7 @@ if test x"$with_ldap" != x"no" ; then
         fi
 		with_ldap=no
         ])
-	AC_CHECK_LIB(ldap, ldap_init, with_ldap=yes,
+	AC_CHECK_LIB(ldap, ldap_initialize, with_ldap=yes,
         [ if test x"$with_ldap" = x"yes" ; then
             AC_MSG_ERROR([Missing LDAP library])
         fi

--- a/doc/manpages/man5/afp_ldap.conf.5.xml
+++ b/doc/manpages/man5/afp_ldap.conf.5.xml
@@ -42,10 +42,15 @@
 
     <variablelist>
       <varlistentry>
-        <term>ldap_server</term>
+        <term>ldap_uri</term>
 
         <listitem>
-          <para>Name or IP address of your LDAP Server</para>
+          <para>Specifies the LDAP URI of the server to connect to.
+          The URI scheme may be ldap, ldapi or ldaps,
+          specifying LDAP over TCP, ICP or TLS respectively
+          (if supported by the LDAP library).
+          This is only needed for explicit ACL support
+          in order to be able to query LDAP for UUIDs.</para>
 
           <para></para>
         </listitem>
@@ -188,7 +193,7 @@
     <example>
       <title>afp_ldap.conf setup with simple bind</title>
 
-      <programlisting>ldap_server      = localhost
+      <programlisting>ldap_uri         = ldap://somehost:1234/
 ldap_auth_method = simple
 ldap_auth_dn     = cn=admin,dc=domain,dc=org
 ldap_auth_pw     = notthisone

--- a/libatalk/acl/ldap.c
+++ b/libatalk/acl/ldap.c
@@ -40,7 +40,7 @@ typedef enum {
  ********************************************************/
 int ldap_config_valid;
 
-char *ldap_server;
+char *ldap_uri;
 int  ldap_auth_method;
 char *ldap_auth_dn;
 char *ldap_auth_pw;
@@ -55,7 +55,7 @@ char *ldap_group_attr;
 char *ldap_uid_attr;
 
 struct ldap_pref ldap_prefs[] = {
-    {&ldap_server,     "ldap_server",      0, 0, -1},
+    {&ldap_uri,        "ldap_uri",         0, 0, -1},
     {&ldap_auth_method,"ldap_auth_method", 1, 1, -1},
     {&ldap_auth_dn,    "ldap_auth_dn",     0, 0,  0},
     {&ldap_auth_pw,    "ldap_auth_pw",     0, 0,  0},
@@ -129,13 +129,16 @@ retry:
     ret = 0;
 
     if (ld == NULL) {
-        LOG(log_maxdebug, logtype_default, "ldap: server: \"%s\"",
-            ldap_server);
-        if ((ld = ldap_init(ldap_server, LDAP_PORT)) == NULL ) {
-            LOG(log_error, logtype_default, "ldap: ldap_init error: %s",
-                strerror(errno));
+        LOG(log_maxdebug, logtype_default, "ldap: uri: \"%s\"",
+            ldap_uri);
+
+        ret = ldap_initialize(&ld, ldap_uri);
+        if (ret != LDAP_SUCCESS) {
+            LOG(log_error, logtype_default, "ldap: ldap_initialize error: %s (%d)",
+                ldap_err2string(ret), ret);
             return -1;
         }
+
         if (ldap_set_option(ld, LDAP_OPT_PROTOCOL_VERSION, &desired_version) != 0) {
             /* LDAP_OPT_SUCCESS is not in the proposed standard, so we check for 0
                http://tools.ietf.org/id/draft-ietf-ldapext-ldap-c-api-05.txt */


### PR DESCRIPTION
- Use the more modern ldap_initialize to init LDAP, which enables the use of advanced server URI schemes
- **BREAKING** The `ldap_server` options has been replaced by `ldap_uri` in afpd.conf and has a new syntax
- **BREAKING** Make the build system check for the ldap_initialize symbol, which requires the system ldap library to supply this symbol
- Update the documentation