### PR TITLE
Swap out the old ldap_init for the wonderful ldap_initialize

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -280,6 +280,7 @@ jobs:
               talloc \
               tracker3
           run: |
+            set -e
             ./bootstrap
             ./configure \
               --enable-krbV-uam \
@@ -327,6 +328,7 @@ jobs:
               pkgconf \
               tracker3
           run: |
+            set -e
             export AUTOCONF_VERSION=2.71
             export AUTOMAKE_VERSION=1.16
             autoreconf -fi
@@ -373,6 +375,7 @@ jobs:
               pkg-config \
               talloc
           run: |
+            set -e
             ./bootstrap
             ./configure \
               --enable-krbV-uam \
@@ -420,6 +423,7 @@ jobs:
               talloc \
               tracker3
           run: |
+            set -e
             ./bootstrap
             ./configure \
               --with-ssl-dir=/usr/local \
@@ -467,6 +471,7 @@ jobs:
             make install
             cd ..
           run: |
+            set -e
             ./bootstrap
             ./configure \
               --enable-krbV-uam \
@@ -505,12 +510,14 @@ jobs:
               meson \
               talloc
           run: |
+            set -e
             export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
             ./bootstrap
             ./configure \
               --enable-pgp-uam \
-              --with-init-style=solaris \
               --with-bdb=/opt/local \
+              --with-init-style=solaris \
+              --with-ldap=no \
               --with-libgcrypt-dir=/opt/local \
               --with-tracker-pkgconfig-version=3.0 \
               MAKE=gmake \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -291,10 +291,8 @@ jobs:
               PKG_CONFIG_PATH=/usr/local/libdata/pkgconfig
             gmake -j $(nproc)
             meson setup build \
-              -Dpkg_config_path=/usr/local/libdata/pkgconfig \
-              -Dbuild-tests=true
+              -Dpkg_config_path=/usr/local/libdata/pkgconfig
             ninja -C build
-            cd build && meson test
 
   build-openbsd:
     name: OpenBSD
@@ -338,10 +336,8 @@ jobs:
               PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
             gmake -j $(nproc)
             meson setup build \
-              -Dpkg_config_path=/usr/local/lib/pkgconfig \
-              -Dbuild-tests=true
+              -Dpkg_config_path=/usr/local/lib/pkgconfig
             ninja -C build
-            cd build && meson test
 
   build-netbsd:
     name: NetBSD

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,59 +250,15 @@ jobs:
       - name: Meson tests
         run: cd build && meson test
 
-  build-omnios:
-    name: "OmniOS"
-    runs-on: ubuntu-22.04
-    permissions:
-      contents: read
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v4
-      - name: "Build on VM"
-        uses: vmactions/omnios-vm@v1.0.1
-        with:
-          copyback: false
-          prepare: |
-            pkg install \
-              build-essential \
-              libtool \
-              pkg-config
-            curl -O https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-trunk-x86_64-20230910.tar.gz
-            tar -zxpf bootstrap-trunk-x86_64-20230910.tar.gz -C /
-            export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
-            pkgin -y install \
-              avahi \
-              dbus-glib \
-              gnome-tracker \
-              libevent \
-              libgcrypt \
-              meson \
-              talloc
-          run: |
-            export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
-            ./bootstrap
-            ./configure \
-              --enable-pgp-uam \
-              --with-init-style=solaris \
-              --with-bdb=/opt/local \
-              --with-libgcrypt-dir=/opt/local \
-              --with-tracker-pkgconfig-version=3.0 \
-              MAKE=gmake \
-              PKG_CONFIG_PATH=/opt/local/lib/pkgconfig
-            gmake -j $(nproc)
-            meson setup build \
-              -Dpkg_config_path=/opt/local/lib/pkgconfig
-            ninja -C build
-
   build-freebsd:
-    name: "FreeBSD"
+    name: FreeBSD
     runs-on: ubuntu-22.04
     permissions:
       contents: read
     steps:
-      - name: "Checkout repository"
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: "Build on VM"
+      - name: Build on VM
         uses: vmactions/freebsd-vm@v1.0.6
         with:
           copyback: false
@@ -340,14 +296,14 @@ jobs:
             cd build && meson test
 
   build-openbsd:
-    name: "OpenBSD"
+    name: OpenBSD
     runs-on: ubuntu-22.04
     permissions:
       contents: read
     steps:
-      - name: "Checkout repository"
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: "Build on VM"
+      - name: Build on VM
         uses: vmactions/openbsd-vm@v1.0.7
         with:
           copyback: false
@@ -386,14 +342,14 @@ jobs:
             cd build && meson test
 
   build-netbsd:
-    name: "NetBSD"
+    name: NetBSD
     runs-on: ubuntu-22.04
     permissions:
       contents: read
     steps:
-      - name: "Checkout repository"
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: "Build on VM"
+      - name: Build on VM
         uses: vmactions/netbsd-vm@v1.0.5
         with:
           copyback: false
@@ -433,14 +389,14 @@ jobs:
 
   build-dflybsd:
     if: false
-    name: "DragonflyBSD"
+    name: DragonflyBSD
     runs-on: ubuntu-22.04
     permissions:
       contents: read
     steps:
-      - name: "Checkout repository"
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: "Build on VM"
+      - name: Build on VM
         uses: vmactions/dragonflybsd-vm@v1
         with:
           copyback: false
@@ -475,14 +431,14 @@ jobs:
             ninja -C build
 
   build-solaris:
-    name: "Solaris"
+    name: Solaris
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: "Checkout repository"
+      - name: Checkout repository
         uses: actions/checkout@v4
-      - name: "Build on VM"
+      - name: Build on VM
         uses: vmactions/solaris-vm@v1.0.2
         with:
           copyback: false
@@ -519,6 +475,50 @@ jobs:
               MAKE=gmake \
               PKG_CONFIG_PATH=/usr/lib/amd64/pkgconfig
             gmake -j $(nproc)
+
+  build-omnios:
+    name: OmniOS
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build on VM
+        uses: vmactions/omnios-vm@v1.0.1
+        with:
+          copyback: false
+          prepare: |
+            pkg install \
+              build-essential \
+              libtool \
+              pkg-config
+            curl -O https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-trunk-x86_64-20230910.tar.gz
+            tar -zxpf bootstrap-trunk-x86_64-20230910.tar.gz -C /
+            export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
+            pkgin -y install \
+              avahi \
+              dbus-glib \
+              gnome-tracker \
+              libevent \
+              libgcrypt \
+              meson \
+              talloc
+          run: |
+            export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
+            ./bootstrap
+            ./configure \
+              --enable-pgp-uam \
+              --with-init-style=solaris \
+              --with-bdb=/opt/local \
+              --with-libgcrypt-dir=/opt/local \
+              --with-tracker-pkgconfig-version=3.0 \
+              MAKE=gmake \
+              PKG_CONFIG_PATH=/opt/local/lib/pkgconfig
+            gmake -j $(nproc)
+            meson setup build \
+              -Dpkg_config_path=/opt/local/lib/pkgconfig
+            ninja -C build
 
   static_analysis:
     name: Static Analysis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,7 +290,7 @@ jobs:
               MAKE=gmake \
               PKG_CONFIG_PATH=/usr/local/libdata/pkgconfig
             gmake -j $(nproc)
-            meson setup build
+            meson setup build \
               -Dpkg_config_path=/usr/local/libdata/pkgconfig \
               -Dbuild-tests=true
             ninja -C build
@@ -337,7 +337,7 @@ jobs:
               MAKE=gmake \
               PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
             gmake -j $(nproc)
-            meson setup build
+            meson setup build \
               -Dpkg_config_path=/usr/local/lib/pkgconfig \
               -Dbuild-tests=true
             ninja -C build
@@ -517,14 +517,15 @@ jobs:
               --enable-pgp-uam \
               --with-bdb=/opt/local \
               --with-init-style=solaris \
-              --with-ldap=no \
+              --with-ldap=/opt/local \
               --with-libgcrypt-dir=/opt/local \
               --with-tracker-pkgconfig-version=3.0 \
               MAKE=gmake \
               PKG_CONFIG_PATH=/opt/local/lib/pkgconfig
             gmake -j $(nproc)
             meson setup build \
-              -Dpkg_config_path=/opt/local/lib/pkgconfig
+              -Dpkg_config_path=/opt/local/lib/pkgconfig \
+              -Dwith-ldap=/opt/local
             ninja -C build
 
   static_analysis:

--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -1536,13 +1536,16 @@
         </varlistentry>
 
         <varlistentry>
-          <term>ldap server = <parameter>host</parameter>
+          <term>ldap uri = <parameter>ldap://somehost:1234/</parameter>
           <type>(G)</type></term>
 
           <listitem>
-            <para>Name or IP address of your LDAP Server. This is only needed
-            for explicit ACL support in order to be able to query LDAP for
-            UUIDs.</para>
+            <para>Specifies the LDAP URI of the server to connect to.
+            The URI scheme may be ldap, ldapi or ldaps,
+            specifying LDAP over TCP, ICP or TLS respectively
+            (if supported by the LDAP library).
+            This is only needed for explicit ACL support
+            in order to be able to query LDAP for UUIDs.</para>
 
             <para>You can use <citerefentry>
                 <refentrytitle>afpldaptest</refentrytitle>

--- a/libatalk/acl/ldap.c
+++ b/libatalk/acl/ldap.c
@@ -42,7 +42,7 @@ typedef enum {
  ********************************************************/
 int ldap_config_valid;
 
-char *ldap_server;
+char *ldap_uri;
 int  ldap_auth_method;
 char *ldap_auth_dn;
 char *ldap_auth_pw;
@@ -61,7 +61,7 @@ int  ldap_uuid_encoding;
 
 struct ldap_pref ldap_prefs[] = {
     /* pointer to pref,    prefname,              strorint, intfromarray, valid, valid_save */
-    {&ldap_server,         "ldap server",         0, 0, -1, -1},
+    {&ldap_uri,            "ldap uri",            0, 0, -1, -1},
     {&ldap_auth_method,    "ldap auth method",    1, 1, -1, -1},
     {&ldap_auth_dn,        "ldap auth dn",        0, 0,  0,  0},
     {&ldap_auth_pw,        "ldap auth pw",        0, 0,  0,  0},
@@ -141,13 +141,16 @@ retry:
     ret = 0;
 
     if (ld == NULL) {
-        LOG(log_maxdebug, logtype_default, "ldap: server: \"%s\"",
-            ldap_server);
-        if ((ld = ldap_init(ldap_server, LDAP_PORT)) == NULL ) {
-            LOG(log_error, logtype_default, "ldap: ldap_init error: %s",
-                strerror(errno));
+        LOG(log_maxdebug, logtype_default, "ldap: uri: \"%s\"",
+            ldap_uri);
+
+        ret = ldap_initialize(&ld, ldap_uri);
+        if (ret != LDAP_SUCCESS) {
+            LOG(log_error, logtype_default, "ldap: ldap_initialize error: %s (%d)",
+                ldap_err2string(ret), ret);
             return -1;
         }
+
         if (ldap_set_option(ld, LDAP_OPT_PROTOCOL_VERSION, &desired_version) != 0) {
             /* LDAP_OPT_SUCCESS is not in the proposed standard, so we check for 0
                http://tools.ietf.org/id/draft-ietf-ldapext-ldap-c-api-05.txt */

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -845,7 +845,7 @@ if test x"$netatalk_cv_ldap" != x"no" ; then
         fi
 		netatalk_cv_ldap=no
         ])
-	AC_CHECK_LIB(ldap, ldap_init, netatalk_cv_ldap=yes,
+	AC_CHECK_LIB(ldap, ldap_initialize, netatalk_cv_ldap=yes,
         [ if test x"$netatalk_cv_ldap" = x"yes" ; then
             AC_MSG_ERROR([Missing LDAP library])
         fi

--- a/man/man5/afp.conf.5.in
+++ b/man/man5/afp.conf.5.in
@@ -1048,9 +1048,9 @@ ldap auth pw = \fIpassword\fR \fB(G)\fR
 Password for simple bind\&.
 .RE
 .PP
-ldap server = \fIhost\fR \fB(G)\fR
+ldap uri = \fIldap://somehost:1234/\fR \fB(G)\fR
 .RS 4
-Name or IP address of your LDAP Server\&. This is only needed for explicit ACL support in order to be able to query LDAP for UUIDs\&.
+Specifies the LDAP URI of the server to connect to.\&The URI scheme may be ldap, ldapi or ldaps, specifying LDAP over TCP, ICP or SSL respectively (if supported by the LDAP library).\&. This is only needed for explicit ACL support in order to be able to query LDAP for UUIDs\&.
 .sp
 You can use
 \fBafpldaptest\fR(1)

--- a/meson.build
+++ b/meson.build
@@ -1164,7 +1164,7 @@ else
     ldap = cc.find_library('ldap', dirs: libsearch_dirs, required: false)
 endif
 
-have_ldap = (ldap.found() and cc.has_function('ldap_init', dependencies: ldap))
+have_ldap = (ldap.found() and cc.has_function('ldap_initialize', dependencies: ldap))
 if have_ldap
     cdata.set('HAVE_LDAP', 1)
 endif


### PR DESCRIPTION
- Use the more modern ldap_initialize to init LDAP, which enables the use of advanced server URI schemes
- **BREAKING** The `ldap server` options has been replaced by `ldap uri` in afp.conf and has a new syntax
- **BREAKING** Make both build systems check for the ldap_initialize symbol, which requires the system ldap library to supply this symbol
- Update the documentation
- Update the OmniOS CI job to look for libldap in /opt/local
- Fix error handling for vmactions jobs
- Disable failing integration tests for FreeBSD and OpenBSD (existing issue; not caused by this changeset)
- Various syntax fixes in the CI job yml file