### PR TITLE
[2.4] Add GitHub CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# they will be requested for review when someone opens a pull request.
+*       @dgsga @rdmark


### PR DESCRIPTION
This is needed for automatic PR assignment for 2.3 branch PRs.