### PR TITLE
Rename launchd plist to io.netatalk* and sort file names

### DIFF
--- a/distrib/initscripts/.gitignore
+++ b/distrib/initscripts/.gitignore
@@ -1,4 +1,8 @@
-com.netatalk.daemon.plist
+io.netatalk.daemon.plist
+netatalk
+netatalk.service
+netatalk.xml
+netatalkd
 rc.bsd
 rc.debian
 rc.gentoo
@@ -7,7 +11,3 @@ rc.redhat
 rc.solaris
 rc.suse
 service.systemd
-netatalk
-netatalk.service
-netatalk.xml
-netatalkd

--- a/distrib/initscripts/Makefile.am
+++ b/distrib/initscripts/Makefile.am
@@ -17,6 +17,9 @@ pkgconfdir = @PKGCONFDIR@
 	    <$< >$@
 
 GENERATED_FILES = \
+	io.netatalk.daemon.plist \
+	netatalk.xml \
+	netatalkd \
 	rc.bsd \
 	rc.debian \
 	rc.gentoo \
@@ -24,12 +27,12 @@ GENERATED_FILES = \
 	rc.redhat \
 	rc.solaris \
 	rc.suse \
-	service.systemd \
-	netatalk.xml \
-	com.netatalk.daemon.plist \
-	netatalkd
+	service.systemd
 
 TEMPLATES = \
+	io.netatalk.daemon.plist.tmpl \
+	netatalk.xml.tmpl \
+	netatalkd.tmpl \
 	rc.bsd.tmpl \
 	rc.debian.tmpl \
 	rc.gentoo.tmpl \
@@ -37,10 +40,7 @@ TEMPLATES = \
 	rc.redhat.tmpl \
 	rc.solaris.tmpl \
 	rc.suse.tmpl \
-	service.systemd.tmpl \
-	netatalk.xml.tmpl \
-	com.netatalk.daemon.plist.tmpl \
-	netatalkd.tmpl
+	service.systemd.tmpl
 
 CLEANFILES = $(GENERATED_FILES) $(sysv_SCRIPTS) $(service_DATA) afpd cnid_metad
 EXTRA_DIST = $(TEMPLATES)
@@ -229,7 +229,7 @@ endif
 if USE_MACOS_LAUNCHD
 
 bin_SCRIPTS = netatalkd
-launchd_PLIST = com.netatalk.daemon.plist
+launchd_PLIST = io.netatalk.daemon.plist
 
 install-data-hook:
 	(if [ ! -f $(INIT_DIR)/$(launchd_PLIST) ] ; then \

--- a/distrib/initscripts/io.netatalk.daemon.plist.tmpl
+++ b/distrib/initscripts/io.netatalk.daemon.plist.tmpl
@@ -10,7 +10,7 @@
 		<string>YES</string>
 	</dict>
 	<key>Label</key>
-	<string>com.netatalk.daemon</string>
+	<string>io.netatalk.daemon</string>
 	<key>ProgramArguments</key>
 	<array>
 		<string>:SBINDIR:/netatalk</string>

--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -128,20 +128,19 @@ elif get_option('with-init-style') == 'macos-launchd'
     )
     custom_target(
         'plist',
-        input: 'com.netatalk.daemon.plist.tmpl',
-        output: 'com.netatalk.daemon.plist',
+        input: 'io.netatalk.daemon.plist.tmpl',
+        output: 'io.netatalk.daemon.plist',
         command: sed_command,
         capture: true,
         install: true,
         install_dir: init_dir,
     )
-    if not fs.exists(init_dir / 'com.netatalk.daemon.plist')
+    if not fs.exists(init_dir / 'io.netatalk.daemon.plist')
         meson.add_install_script(
             find_program('launchctl'),
             'load',
             '-w',
-            init_dir / 'com.netatalk.daemon.plist',
+            init_dir / 'io.netatalk.daemon.plist',
         )
     endif
 endif
-


### PR DESCRIPTION
This is a breaking change. Users need to manually disable com.netatalk.daemon.plist first. 

```
sudo launchctl disable system/com.netatalk.daemon
```

And in my experience, restart macOS for the old com.netatalk.daemon record to go away completely (i.e. from `launchctl list` )