### PR TITLE
docs: Generate compilation manual page from build.yml

### DIFF
--- a/doc/manual/compile.xml
+++ b/doc/manual/compile.xml
@@ -1,0 +1,556 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appendix id="compile">
+	<title>Compile Netatalk from Source</title>
+	<sect1 id="compile-overview">
+		<title>Overview</title>
+	</sect1>
+	<sect1>
+		<para>
+            This section describes how to compile Netatalk from source for specific operating systems.
+            </para>
+		<para>
+            The Netatalk project is in the process of transitioning the build system
+            from GNU Autotools to Meson.
+            During the transitional period,
+            the documentation will contain both Autotools and Meson build instructions.
+            </para>
+		<para>
+            Please note that this document is automatically generated from the GitHub workflow YAML file.
+            This may or may not be the most optimal way to build Netatalk for your system.
+            </para>
+	</sect1>
+	<sect1 id="compile-os">
+		<title>Operating Systems</title>
+	</sect1>
+	<sect1>
+		<para>
+            Note: You only have to use execute the steps for one of the build systems, not both.
+            Additionally, the test steps are entirely optional for compiling from source.
+            </para>
+		<sect2 id="build-ubuntu">
+			<title>Ubuntu</title>
+			<para>Install dependencies</para>
+			<para>
+				<screen>sudo apt-get update
+sudo apt-get install --assume-yes --no-install-recommends autoconf \
+automake \
+bison \
+docbook-xsl \
+flex \
+libacl1-dev \
+libavahi-client-dev \
+libcrack2-dev \
+libdb-dev \
+libdbus-1-dev \
+libdbus-glib-1-dev \
+libevent-dev \
+libgcrypt-dev \
+libglib2.0-dev \
+libkrb5-dev \
+libldap2-dev \
+libmysqlclient-dev \
+libpam0g-dev \
+libssl-dev \
+libtalloc-dev \
+libtool \
+libtool-bin \
+libtracker-sparql-3.0-dev \
+libwrap0-dev \
+meson \
+ninja-build \
+systemtap-sdt-dev \
+tcpd \
+tracker \
+xsltproc
+
+</screen>
+			</para>
+			<para>Bootstrap</para>
+			<para>
+				<screen>./bootstrap</screen>
+			</para>
+			<para>Configure</para>
+			<para>
+				<screen>./configure \
+  --enable-krbV-uam \
+  --enable-pgp-uam \
+  --with-cracklib \
+  --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl \
+  --with-tracker-pkgconfig-version=3.0
+</screen>
+			</para>
+			<para>Generate man pages</para>
+			<para>
+				<screen>make html</screen>
+			</para>
+			<para>Build</para>
+			<para>
+				<screen>make -j $(nproc) all</screen>
+			</para>
+			<para>Run tests</para>
+			<para>
+				<screen>make check</screen>
+			</para>
+			<para>Run distribution tests</para>
+			<para>
+				<screen>make distcheck</screen>
+			</para>
+			<para>Meson configure</para>
+			<para>
+				<screen>meson setup build \
+  -Dbuild-tests=true \
+  -Dbuild-manual=true
+</screen>
+			</para>
+			<para>Meson build and generate man pages</para>
+			<para>
+				<screen>ninja -C build</screen>
+			</para>
+			<para>Meson tests</para>
+			<para>
+				<screen>cd build &amp;&amp; meson test</screen>
+			</para>
+			<para>Meson distribution tests</para>
+			<para>
+				<screen>cd build &amp;&amp; meson dist</screen>
+			</para>
+		</sect2>
+		<sect2 id="build-debian">
+			<title>Debian</title>
+			<para>Install dependencies</para>
+			<para>
+				<screen>apt-get update
+apt-get install --assume-yes --no-install-recommends \
+  autoconf \
+  automake \
+  bison \
+  default-libmysqlclient-dev \
+  file \
+  flex \
+  gcc \
+  libacl1-dev \
+  libavahi-client-dev \
+  libcrack2-dev \
+  libdb-dev \
+  libdbus-1-dev \
+  libdbus-glib-1-dev \
+  libevent-dev \
+  libgcrypt-dev \
+  libglib2.0-dev \
+  libkrb5-dev \
+  libldap2-dev \
+  libltdl-dev \
+  libpam0g-dev \
+  libssl-dev \
+  libtalloc-dev \
+  libtool \
+  libtool-bin \
+  libtracker-sparql-3.0-dev \
+  libwrap0-dev \
+  make \
+  meson \
+  ninja-build \
+  systemtap-sdt-dev \
+  tcpd \
+  tracker
+</screen>
+			</para>
+			<para>Bootstrap</para>
+			<para>
+				<screen>./bootstrap</screen>
+			</para>
+			<para>Configure</para>
+			<para>
+				<screen>./configure \
+  --disable-dependency-tracking \
+  --enable-krbV-uam \
+  --enable-pgp-uam \
+  --with-cracklib \
+  --with-tracker-pkgconfig-version=2.0
+</screen>
+			</para>
+			<para>Build</para>
+			<para>
+				<screen>make -j $(nproc) all</screen>
+			</para>
+			<para>Run tests</para>
+			<para>
+				<screen>make check</screen>
+			</para>
+			<para>Meson configure</para>
+			<para>
+				<screen>meson setup build \
+  -Dbuild-tests=true
+</screen>
+			</para>
+			<para>Meson build</para>
+			<para>
+				<screen>ninja -C build</screen>
+			</para>
+			<para>Meson tests</para>
+			<para>
+				<screen>cd build &amp;&amp; meson test</screen>
+			</para>
+		</sect2>
+		<sect2 id="build-fedora">
+			<title>Fedora</title>
+			<para>Install dependencies</para>
+			<para>
+				<screen>dnf -y install \
+  automake \
+  avahi-devel \
+  bison \
+  cracklib-devel \
+  dbus-devel \
+  dbus-glib-devel \
+  flex \
+  glib2-devel \
+  krb5-devel \
+  libacl-devel \
+  libdb-devel \
+  libgcrypt-devel \
+  libtalloc-devel \
+  libtool \
+  meson \
+  ninja-build \
+  openldap-devel \
+  openssl-devel \
+  pam-devel \
+  perl \
+  systemtap-sdt-devel \
+  tracker-devel
+</screen>
+			</para>
+			<para>Bootstrap</para>
+			<para>
+				<screen>./bootstrap</screen>
+			</para>
+			<para>Configure</para>
+			<para>
+				<screen>./configure \
+  --enable-krbV-uam \
+  --enable-pgp-uam \
+  --with-cracklib \
+  --with-init-style=redhat-systemd \
+  --with-tracker-pkgconfig-version=3.0
+</screen>
+			</para>
+			<para>Build</para>
+			<para>
+				<screen>make -j $(nproc)</screen>
+			</para>
+			<para>Run tests</para>
+			<para>
+				<screen>make check</screen>
+			</para>
+			<para>Meson configure</para>
+			<para>
+				<screen>meson setup build \
+  -Dbuild-tests=true
+</screen>
+			</para>
+			<para>Meson build</para>
+			<para>
+				<screen>ninja -C build</screen>
+			</para>
+			<para>Meson tests</para>
+			<para>
+				<screen>cd build &amp;&amp; meson test</screen>
+			</para>
+		</sect2>
+		<sect2 id="build-macos">
+			<title>macOS</title>
+			<para>Install dependencies</para>
+			<para>
+				<screen>brew install automake libressl mysql talloc krb5 berkeley-db meson</screen>
+			</para>
+			<para>Bootstrap</para>
+			<para>
+				<screen>./bootstrap</screen>
+			</para>
+			<para>Configure</para>
+			<para>
+				<screen>./configure \
+  --enable-krbV-uam \
+  --enable-pgp-uam \
+  --with-bdb=/usr/local/opt/berkeley-db \
+  --with-ssl-dir=/usr/local/opt/libressl
+</screen>
+			</para>
+			<para>Build</para>
+			<para>
+				<screen>make -j $(nproc) all</screen>
+			</para>
+			<para>Run tests</para>
+			<para>
+				<screen>make check</screen>
+			</para>
+			<para>Meson configure</para>
+			<para>
+				<screen>meson setup build \
+  -Dwith-bdb=/usr/local/opt/berkeley-db \
+  -Dwith-ssl-dir=/usr/local/opt/libressl \
+  -Dbuild-tests=true
+</screen>
+			</para>
+			<para>Meson build</para>
+			<para>
+				<screen>ninja -C build</screen>
+			</para>
+			<para>Meson tests</para>
+			<para>
+				<screen>cd build &amp;&amp; meson test</screen>
+			</para>
+		</sect2>
+		<sect2 id="build-freebsd">
+			<title>FreeBSD</title>
+			<para>Install dependencies</para>
+			<para>
+				<screen>pkg install -y \
+  autoconf \
+  automake \
+  avahi \
+  bison \
+  db5 \
+  flex \
+  gmake \
+  libevent \
+  libgcrypt \
+  libressl \
+  libtool \
+  meson \
+  pkgconf \
+  talloc \
+  tracker3
+</screen>
+			</para>
+			<para>Configure and build</para>
+			<para>
+				<screen>set -e
+./bootstrap
+./configure \
+  --enable-krbV-uam \
+  --enable-pgp-uam \
+  --with-ssl-dir=/usr/local \
+  --with-tracker-pkgconfig-version=3.0 \
+  MAKE=gmake \
+  PKG_CONFIG_PATH=/usr/local/libdata/pkgconfig
+gmake -j $(nproc)
+meson setup build \
+  -Dpkg_config_path=/usr/local/libdata/pkgconfig
+ninja -C build
+</screen>
+			</para>
+		</sect2>
+		<sect2 id="build-openbsd">
+			<title>OpenBSD</title>
+			<para>Install dependencies</para>
+			<para>
+				<screen>pkg_add -I \
+  autoconf-2.71 \
+  automake-1.16.5 \
+  avahi \
+  bison \
+  dbus-glib \
+  db-4.6.21p7v0 \
+  flex \
+  gcc-11.2.0p9 \
+  gmake \
+  libevent \
+  libgcrypt \
+  libtalloc \
+  libtool \
+  meson \
+  openldap-client-2.6.6v0 \
+  pkgconf \
+  tracker3
+</screen>
+			</para>
+			<para>Configure and build</para>
+			<para>
+				<screen>set -e
+export AUTOCONF_VERSION=2.71
+export AUTOMAKE_VERSION=1.16
+autoreconf -fi
+./configure \
+  --with-tracker-pkgconfig-version=3.0 \
+  MAKE=gmake \
+  PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+gmake -j $(nproc)
+meson setup build \
+  -Dpkg_config_path=/usr/local/lib/pkgconfig
+ninja -C build
+</screen>
+			</para>
+		</sect2>
+		<sect2 id="build-netbsd">
+			<title>NetBSD</title>
+			<para>Install dependencies</para>
+			<para>
+				<screen>pkg_add \
+  autoconf \
+  automake \
+  avahi \
+  bison \
+  db5 \
+  dbus-glib \
+  flex \
+  gcc13 \
+  gmake \
+  gnome-tracker \
+  libevent \
+  libgcrypt \
+  libressl \
+  libtool \
+  meson \
+  pkg-config \
+  talloc
+</screen>
+			</para>
+			<para>Configure and build</para>
+			<para>
+				<screen>set -e
+./bootstrap
+./configure \
+  --enable-krbV-uam \
+  --enable-pgp-uam \
+  --with-bdb=/usr/pkg \
+  --with-libgcrypt-dir=/usr/pkg \
+  --with-tracker-pkgconfig-version=3.0 \
+  MAKE=gmake \
+  PKG_CONFIG_PATH=/usr/pkg/lib/pkgconfig
+gmake -j $(nproc)
+meson setup build \
+  -Dpkg_config_path=/usr/pkg/lib/pkgconfig
+ninja -C build
+</screen>
+			</para>
+		</sect2>
+		<sect2 id="build-dflybsd">
+			<title>DragonflyBSD</title>
+			<para>Install dependencies</para>
+			<para>
+				<screen>pkg install -y \
+  autoconf \
+  automake \
+  avahi \
+  bison \
+  db5 \
+  gmake \
+  libevent \
+  libgcrypt \
+  libtool \
+  meson \
+  perl5 \
+  pkgconf \
+  py39-gdbm \
+  py39-sqlite3 \
+  py39-tkinter \
+  talloc \
+  tracker3
+</screen>
+			</para>
+			<para>Configure and build</para>
+			<para>
+				<screen>set -e
+./bootstrap
+./configure \
+  --with-ssl-dir=/usr/local \
+  --with-tracker-pkgconfig-version=3.0 \
+  LDFLAGS=-L/usr/local/lib \
+  MAKE=gmake
+gmake -j2
+meson setup build
+ninja -C build
+</screen>
+			</para>
+		</sect2>
+		<sect2 id="build-solaris">
+			<title>Solaris</title>
+			<para>Install dependencies</para>
+			<para>
+				<screen>pkg install \
+  autoconf \
+  automake \
+  bison \
+  flex \
+  gcc \
+  libevent \
+  libgcrypt \
+  libtool \
+  pkg-config
+wget https://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.gz --no-check-certificate
+wget https://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.gz --no-check-certificate
+tar xvf autoconf-2.71.tar.gz
+tar xvf automake-1.16.5.tar.gz
+cd autoconf-2.71
+./configure --prefix=/usr
+make
+make install
+cd ../automake-1.16.5
+./configure --prefix=/usr
+make
+make install
+cd ..
+</screen>
+			</para>
+			<para>Configure and build</para>
+			<para>
+				<screen>set -e
+./bootstrap
+./configure \
+  --enable-krbV-uam \
+  --enable-pgp-uam \
+  --without-afpstats \
+  MAKE=gmake \
+  PKG_CONFIG_PATH=/usr/lib/amd64/pkgconfig
+gmake -j $(nproc)
+</screen>
+			</para>
+		</sect2>
+		<sect2 id="build-omnios">
+			<title>OmniOS</title>
+			<para>Install dependencies</para>
+			<para>
+				<screen>pkg install \
+  build-essential \
+  libtool \
+  pkg-config
+curl -O https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-trunk-x86_64-20230910.tar.gz
+tar -zxpf bootstrap-trunk-x86_64-20230910.tar.gz -C /
+export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
+pkgin -y install \
+  avahi \
+  dbus-glib \
+  gnome-tracker \
+  libevent \
+  libgcrypt \
+  meson \
+  talloc
+</screen>
+			</para>
+			<para>Configure and build</para>
+			<para>
+				<screen>set -e
+export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
+./bootstrap
+./configure \
+  --enable-pgp-uam \
+  --with-bdb=/opt/local \
+  --with-init-style=solaris \
+  --with-ldap=/opt/local \
+  --with-libgcrypt-dir=/opt/local \
+  --with-tracker-pkgconfig-version=3.0 \
+  MAKE=gmake \
+  PKG_CONFIG_PATH=/opt/local/lib/pkgconfig
+gmake -j $(nproc)
+meson setup build \
+  -Dpkg_config_path=/opt/local/lib/pkgconfig \
+  -Dwith-ldap=/opt/local
+ninja -C build
+</screen>
+			</para>
+		</sect2>
+		<sect2></sect2>
+	</sect1>
+</appendix>

--- a/doc/manual/generate_compile_docs.py
+++ b/doc/manual/generate_compile_docs.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+# This script generates the compile.xml manual page from the GitHub build.yml file.
+
+import re
+import yaml
+import xmltodict
+
+def main():
+  with open('../../.github/workflows/build.yml', 'r') as file:
+    workflow = yaml.safe_load(file)
+
+  apt_packages_pattern = r'\$\{\{\senv\.APT_PACKAGES\s\}\}'
+  apt_packages = workflow["env"]["APT_PACKAGES"]
+
+  docbook = {
+    "appendix": {
+      "@id": "compile",
+      "title": "Compile Netatalk from Source",
+      "sect1": [
+        {
+          "@id": "compile-overview",
+          "title": "Overview",
+        },
+        {
+          "para": [
+            """
+            This section describes how to compile Netatalk from source for specific operating systems.
+            """,
+            """
+            The Netatalk project is in the process of transitioning the build system
+            from GNU Autotools to Meson.
+            During the transitional period,
+            the documentation will contain both Autotools and Meson build instructions.
+            """,
+            """
+            Please note that this document is automatically generated from the GitHub workflow YAML file.
+            This may or may not be the most optimal way to build Netatalk for your system.
+            """,
+          ],
+        },
+        {
+          "@id": "compile-os",
+          "title": "Operating Systems",
+        },
+        {
+          "para": [
+            """
+            Note: You only have to use execute the steps for one of the build systems, not both.
+            Additionally, the test steps are entirely optional for compiling from source.
+            """,
+          ],
+          "sect2": [],
+        }
+      ],
+    },
+  }
+
+  for key, value in workflow["jobs"].items():
+    sections = {}
+    # Skip the SonarQube job
+    if value["name"] != "Static Analysis":
+      sections["@id"] = key
+      sections["title"] = value["name"]
+      para = []
+      for step in value["steps"]:
+        # Skip unnamed steps
+        if "name" not in step:
+          continue
+        # Skip GitHub actions steps irrelevant to documentation
+        if "uses" in step and step["uses"].startswith("actions/"):
+          continue
+        # Substitute the APT_PACKAGES variable with the actual list of packages
+        if "run" in step and re.search(apt_packages_pattern, step["run"]):
+          step["run"] = re.sub(apt_packages_pattern, apt_packages, step["run"])
+
+        # The vmactions jobs have a different structure
+        if "uses" in step and step["uses"].startswith("vmactions/"):
+          para.append("Install dependencies")
+          para.append({"screen": step["with"]["prepare"]})
+          para.append("Configure and build")
+          para.append({"screen": step["with"]["run"]})
+        else:
+          para.append(step["name"])
+          para.append({"screen": step["run"]})
+
+      sections["para"] = para
+
+    docbook["appendix"]["sect1"][3]["sect2"].append(sections)
+
+  xml = xmltodict.unparse(docbook, pretty=True)
+
+  with open('compile.xml', 'w') as file:
+    file.write(xml)
+
+  print("Wrote compile.xml")
+
+if __name__ == '__main__':
+    main()

--- a/doc/manual/install.xml
+++ b/doc/manual/install.xml
@@ -141,20 +141,7 @@ Resolving deltas: 100% (32227/32227), done.
 
             <screen><prompt>$</prompt> <userinput>git pull</userinput></screen>
           </listitem>
-
-          <listitem>
-            <para>Now <command>cd</command> to the netatalk-code directory and run
-            <command>./bootstrap</command>. This will create the
-            <filename>configure</filename> script required in the next
-            step.</para>
-
-            <screen><prompt>$</prompt> <userinput>./bootstrap</userinput></screen>
-          </listitem>
         </orderedlist>
-
-        <para>For futher information refer to the <ulink
-        url="https://github.com/Netatalk/netatalk/blob/main/INSTALL">INSTALL</ulink>
-        file.</para>
       </sect3>
     </sect2>
   </sect1>
@@ -164,15 +151,6 @@ Resolving deltas: 100% (32227/32227), done.
 
     <sect2>
       <title>Prerequisites</title>
-
-      <note>
-        <para>The following pieces of software are likely to have a package
-        available for your OS distribution of choice.</para>
-
-        <para>Please see the <ulink
-        url="https://github.com/Netatalk/netatalk/wiki/Installation-Notes">
-        Installation Notes</ulink> wiki page as a starting point.</para>
-      </note>
 
       <sect3>
         <title>Required third-party software</title>
@@ -215,17 +193,17 @@ Resolving deltas: 100% (32227/32227), done.
 
             <para>Netatalk uses <ulink
             url="https://tracker.gnome.org">Tracker</ulink> as the
-            metadata backend. Recent Linux distributions will provide the
-            libtracker-sparql library which is available since Tracker version
-            0.7.</para>
+            metadata backend. The minimum required version is 0.7 as that's the
+            first version to support <ulink url="https://gnome.pages.gitlab.gnome.org/tracker/">
+            SPARQL</ulink>.</para>
           </listitem>
 
           <listitem>
-            <para>mDNSresponderPOSIX or Avahi for Bonjour (aka
-            Zeroconf)</para>
+            <para>mDNSresponderPOSIX or Avahi for Bonjour</para>
 
-            <para>Mac OS X 10.2 and later use Bonjour (aka Zeroconf) for
-            service discovery.</para>
+            <para>Mac OS X 10.2 and later use Bonjour
+            (a.k.a. Zeroconf, and earlier Rendezvous)
+            for service discovery.</para>
 
             <para>The Avahi library must be built with DBUS support (
             <userinput>--enable-dbus</userinput>).</para>
@@ -273,121 +251,18 @@ Resolving deltas: 100% (32227/32227), done.
     </sect2>
 
     <sect2 id="compiling-netatalk">
-      <title>Compiling<indexterm>
+      <title>Configure and Build<indexterm>
           <primary>Compile</primary>
 
           <secondary>Compiling Netatalk from Source</secondary>
         </indexterm> Netatalk</title>
 
-      <sect3>
-        <title>Configuring the build</title>
+      <para>Instructions on how to use the build system are documented in the
+      <ulink url="https://github.com/Netatalk/netatalk/blob/main/INSTALL">
+	    INSTALL</ulink> file in the Netatalk source tree.</para>
 
-        <para>To build the binaries, first run the program
-        <command>./configure</command> in the source directory. This should
-        automatically configure Netatalk for your operating system. If you
-        have unusual needs, then you may wish to run</para>
-
-    <screen><prompt>$</prompt> <userinput>./configure --help</userinput></screen>
-
-        <para>to see what special options you can enable.</para>
-
-        <para>The most used configure options are:</para>
-
-        <itemizedlist>
-          <listitem>
-            <para><option>--with-init-style</option>=redhat-sysv|redhat-systemd|suse-sysv|suse-systemd|gentoo-openrc|gentoo-systemd|netbsd|debian-sysv|debian-systemd|solaris|openrc|systemd|macos-launchd</para>
-
-            <para>This option helps Netatalk to determine where to install the
-            start scripts.</para>
-          </listitem>
-
-          <listitem>
-            <para><option>--with-bdb</option>=<replaceable>/path/to/bdb/installation/</replaceable></para>
-
-            <para>In case you installed Berkeley DB in a non-standard
-            location, you will <emphasis>have</emphasis> to give the install
-            location to Netatalk, using this switch.</para>
-          </listitem>
-
-          <listitem>
-            <para><option>--with-ssl-dir</option>=<replaceable>/path/to/ssl/installation/</replaceable></para>
-
-            <para>In case you installed OpenSSL or LibreSSL in a non-standard
-            location, you will <emphasis>have</emphasis> to give the install
-            location to Netatalk, using this switch.</para>
-          </listitem>
-        </itemizedlist>
-
-        <para>Now run configure with any options you need</para>
-
-        <screen><prompt>$</prompt> <userinput>./configure [arguments]</userinput></screen>
-
-        <para>Configure will end up in an overview showing the settings the
-        Netatalk Makefiles have been created with.</para>
-      </sect3>
-
-      <sect3 id="spotlight-compile">
-        <title>Spotlight<indexterm>
-            <primary>Spotlight</primary>
-          </indexterm></title>
-
-        <para>Netatalk uses Gnome <ulink url="https://projects.gnome.org/tracker/">Tracker</ulink> as the
-        metadata backend. The minimum required version is 0.7 as that's the
-        first version to support <ulink url="https://gnome.pages.gitlab.gnome.org/tracker/docs/developer/">SPARQL</ulink>.</para>
-
-        <para>If not already installed, install the packages
-        <emphasis>tracker</emphasis> and <emphasis>tracker-devel</emphasis>,
-        on Solaris install <ulink url="http://www.opencsw.org/">OpenCSW</ulink> and then install
-        the Tracker package from the OpenCSW unstable repository.</para>
-
-        <para>The tracker packages are found via pkg-config, you may have to
-        pass the version suffix as you may have a newer version installed then
-        the default 0.12, e.g.</para>
-
-        <screen><prompt>$</prompt> <userinput>pkg-config --list-all | grep tracker
-	</userinput>tracker-sparql-3.0             tracker-sparql-3.0 - Tracker : A SPARQL triple store library</screen>
-
-        <para>So in this example, configure with:</para>
-
-        <screen><prompt>$</prompt> <userinput>./configure --with-tracker-pkgconfig-version=3.0 ...</userinput></screen>
-
-        <para>If you're using Solaris and Tracker from OpenCSW, then you need
-        to set the PKG_CONFIG_PATH environment variable, add the
-        --with-tracker-prefix configure option and add
-        LDFLAGS="-R/opt/csw/lib"</para>
-
-        <screen>PKG_CONFIG_PATH=/opt/csw/lib/pkgconfig LDFLAGS="-R/opt/csw/lib" ./configure --with-tracker-prefix=/opt/csw --with-tracker-pkgconfig-version=0.16 ...</screen>
-
-        <para>Check the configure output whether the Tracker libs were
-        found:</para>
-
-        <screen>checking for TRACKER... yes
-        checking for TRACKER_MINER... yes
-        ...
-        Configure summary:
-        ...
-          AFP:
-            Spotlight: yes
-        ...</screen>
-      </sect3>
-
-      <sect3>
-        <title>Compile and install</title>
-
-        <para>Next, running</para>
-
-        <screen><prompt>$</prompt> <userinput>make</userinput></screen>
-
-        <para>should produce the Netatalk binaries (this step can take several
-        minutes to complete).</para>
-
-        <para>When the process finished you can use</para>
-
-        <screen><prompt>$</prompt> <userinput>make install</userinput></screen>
-
-        <para>to install the binaries and documentation (must be done as
-        "root" when using default locations).</para>
-      </sect3>
+      <para>For examples of concrete steps to compile on specific operating systems, refer to the
+      <link linkend="compile">Compile Netatalk from Source</link> appendix.</para>
     </sect2>
   </sect1>
 </chapter>

--- a/doc/manual/manual.xml.in
+++ b/doc/manual/manual.xml.in
@@ -3,6 +3,7 @@
 "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
 
 <!ENTITY Configuration SYSTEM "configuration.xml">
+<!ENTITY Compile SYSTEM "compile.xml">
 <!ENTITY Intro SYSTEM "intro.xml">
 <!ENTITY Install SYSTEM "install.xml">
 <!ENTITY License SYSTEM "gpl.xml">
@@ -91,6 +92,9 @@
 
     &netatalk-config.1;
   </chapter>
+  <?latex \cleardoublepage ?>
+
+  &Compile;
   <?latex \cleardoublepage ?>
 
   &License;


### PR DESCRIPTION
- Add a python script for generating a docbook XML manual page derived from the GitHub workflow build.yml
- Add the new manual page as an appendix to the html manual
- Remove autotools specific human written steps

To run the python script, the `xmltodict` package is required. The other libraries are built in. On debian, you can get this package by installing `python3-xmltodict` with apt. Elsewhere you may have to install it with pip (system or virtual env.)