### PR TITLE
Meson hotfixes

### DIFF
--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -14,7 +14,7 @@ elif get_option('with-init-style') == 'redhat-sysv'
     )
     meson.add_install_script(
         find_program('chkconfig'),
-        'add',
+        '--add',
         '/etc/rc.d/init.d/netatalk',
     )
 elif (

--- a/meson.build
+++ b/meson.build
@@ -1879,7 +1879,7 @@ summary({'Netatalk version': version}, section: 'Configuration Summary:')
 summary_info = {
     '  Initscript style': get_option('with-init-style'),
 }
-summary(summary_info, bool_yn: true, section: '  INIT STYLE:')
+summary(summary_info, bool_yn: true, section: '  Init Style:')
 
 summary_info = {
     '  Extended Attributes': netatalk_ea,

--- a/meson.build
+++ b/meson.build
@@ -1397,14 +1397,17 @@ pam_paths = [
     '/usr/local',
 ]
 
-if host_os == 'sunos'
-    pam_dir += '/etc/pam.conf'
-else
-    foreach path : pam_paths
-        if fs.is_dir(path / 'etc/pam.d')
-            pam_dir += path
-        endif
-    endforeach
+foreach path : pam_paths
+    if fs.is_dir(path / 'etc/pam.d')
+        pam_dir += path
+    endif
+    break
+endforeach
+
+if pam_dir == '' and host_os == 'sunos'
+    warning(
+        'PAM installation file = /etc/pam.conf. Please edit this file to enable PAM support',
+    )
 endif
 
 if with_pam != '' and pam_dir != '/'
@@ -1416,11 +1419,15 @@ else
     pam = cc.find_library('pam', dirs: libsearch_dirs, required: false)
 endif
 
-have_pam = (
-    cc.has_header('security/pam_appl.h')
-    or cc.has_header('pam/pam_appl.h')
-    or cc.has_function('pam_set_item', dependencies: pam)
-)
+if get_option('without-pam')
+    have_pam = false
+else
+    have_pam = (
+        cc.has_header('security/pam_appl.h')
+        or cc.has_header('pam/pam_appl.h')
+        or cc.has_function('pam_set_item', dependencies: pam)
+    )
+endif
 
 if have_pam
     cdata.set('USE_PAM', 1)
@@ -1477,7 +1484,7 @@ if have_pam
     endif
 elif have_pam and (pam_dir == '')
     warning(
-        'PAM support can be compiled, but the install location for the netatalk.pamd file could not be determined. Either install this file by hand or specify the install path.',
+        'PAM support can be compiled, but the install location for the netatalk.pamd file could not be determined. Please install this file manually. If you are running a Solaris-based host which still relies on /etc/pam.conf you will have to edit this file to get PAM working',
     )
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -260,3 +260,9 @@ option(
     value: 'libdir / netatalk',
     description: 'Path to UAMs',
 )
+option(
+    'without-pam',
+    type: 'boolean',
+    value: false,
+    description: 'Disable PAM support',
+)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -204,7 +204,7 @@ option(
     'with-lockfile',
     type: 'string',
     value: '',
-    description: 'Path of Netatalk lockfile)',
+    description: 'Path to Netatalk lockfile',
 )
 option(
     'with-mysql-config',


### PR DESCRIPTION
- Fixes for PAM detection on Solaris and Omnios: The preferred mechanism for PAM configuration on Solaris is now using per-service files in /etc/pam.d. Some solaris-based systems still use the /etc/pam.conf configuration file
- Fix typos in root meson.build and meson options file
- Fix error in redhat_sysv custom target