### PR TITLE
[2.4] Meson hotfixes

### DIFF
--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -12,7 +12,7 @@ if get_option('enable-redhat-sysv')
         install_mode: 'rwxr-xr-x',
     )
     meson.add_install_script(
-        find_program('/usr/sbin/chkconfig'),
+        find_program('chkconfig'),
         '--add',
         '/etc/rc.d/init.d/netatalk',
     )

--- a/meson.build
+++ b/meson.build
@@ -1262,14 +1262,17 @@ pam_paths = [
     '/usr/local',
 ]
 
-if host_os == 'sunos'
-    pam_dir += '/etc/pam.conf'
-else
-    foreach path : pam_paths
-        if fs.is_dir(path / 'etc/pam.d')
-            pam_dir += path
-        endif
-    endforeach
+foreach path : pam_paths
+    if fs.is_dir(path / 'etc/pam.d')
+        pam_dir += path
+    endif
+    break
+endforeach
+
+if pam_dir == '' and host_os == 'sunos'
+    warning(
+        'PAM installation file = /etc/pam.conf. Please edit this file to enable PAM support',
+    )
 endif
 
 if with_pam != '' and pam_dir != '/'
@@ -1281,11 +1284,15 @@ else
     pam = cc.find_library('pam', dirs: libsearch_dirs, required: false)
 endif
 
-have_pam = (
-    cc.has_header('security/pam_appl.h')
-    or cc.has_header('pam/pam_appl.h')
-    or cc.has_function('pam_set_item', dependencies: pam)
-)
+if get_option('without-pam')
+    have_pam = false
+else
+    have_pam = (
+        cc.has_header('security/pam_appl.h')
+        or cc.has_header('pam/pam_appl.h')
+        or cc.has_function('pam_set_item', dependencies: pam)
+    )
+endif
 
 if have_pam
     cdata.set('USE_PAM', 1)
@@ -1342,7 +1349,7 @@ if have_pam
     endif
 elif have_pam and (pam_dir == '')
     warning(
-        'PAM support can be compiled, but the install location for the netatalk.pamd file could not be determined. Either install this file by hand or specify the install path.',
+        'PAM support can be compiled, but the install location for the netatalk.pamd file could not be determined. Please install this file manually. If you are running a Solaris-based host which still relies on /etc/pam.conf you will have to edit this file to get PAM working',
     )
 endif
 
@@ -1707,7 +1714,7 @@ summary({'Netatalk version': version}, section: 'Configuration Summary:')
 summary_info = {
     '  Initscript style': init_style,
 }
-summary(summary_info, bool_yn: true, section: '  INIT STYLE:')
+summary(summary_info, bool_yn: true, section: '  Init Style:')
 
 summary_info = {
     '  Extended Attributes': netatalk_ea,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -250,3 +250,9 @@ option(
     value: 'libdir / netatalk',
     description: 'Path to UAMs',
 )
+option(
+    'without-pam',
+    type: 'boolean',
+    value: false,
+    description: 'Disable PAM support',
+)


### PR DESCRIPTION
* Fix typos in root meson.build

* Fixes for PAM detection on solaris-based systems

The preferred mechanism for PAM configuration on Solaris is now using per-service files in /etc/pam.d. Some solaris-based operating systems (e.g Omnios) use the old /etc/pam.conf configuration file

* Fix error in redhat_sysv custom target