### PR TITLE
meson: Fix executables not linking correctly with libatalk shared library

### DIFF
--- a/bin/ad/meson.build
+++ b/bin/ad/meson.build
@@ -18,4 +18,5 @@ executable(
     link_with: libatalk,
     c_args: [ad, dversion],
     install: true,
+    install_rpath: rpath,
 )

--- a/bin/afppasswd/meson.build
+++ b/bin/afppasswd/meson.build
@@ -13,4 +13,5 @@ executable(
         dversion,
     ],
     install: true,
+    install_rpath: rpath,
 )

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -186,6 +186,7 @@ executable(
     export_dynamic: true,
     install: true,
     install_dir: sbindir,
+    install_rpath: rpath,
 )
 
 

--- a/etc/cnid_dbd/meson.build
+++ b/etc/cnid_dbd/meson.build
@@ -26,6 +26,7 @@ executable(
     link_args: bdb_link_args,
     install: true,
     install_dir: sbindir,
+    install_rpath: rpath,
 )
 
 cnid_metad_sources = ['cnid_metad.c', 'usockfd.c', 'db_param.c']
@@ -39,6 +40,7 @@ executable(
     c_args: [cnid_dbd, dversion],
     install: true,
     install_dir: sbindir,
+    install_rpath: rpath,
 )
 
 dbd_sources = [
@@ -64,4 +66,5 @@ executable(
     c_args: dversion,
     link_args: [dversion, bdb_link_args],
     install: true,
+    install_rpath: rpath,
 )

--- a/etc/netatalk/meson.build
+++ b/etc/netatalk/meson.build
@@ -9,4 +9,5 @@ executable(
     c_args: [confdir, statedir, afpd, cnid_metad, dversion],
     install: true,
     install_dir: sbindir,
+    install_rpath: rpath,
 )

--- a/meson.build
+++ b/meson.build
@@ -40,6 +40,7 @@ localstatedir = prefix / get_option('localstatedir')
 mandir = prefix / get_option('mandir')
 pkgconfdir = prefix / get_option('sysconfdir')
 sbindir = prefix / get_option('sbindir')
+rpath = '$ORIGIN/../' + get_option('libdir')
 
 ##################
 # Compiler flags #
@@ -326,6 +327,7 @@ if (cpu in ['ppc64', 's390x', 'sparc64', 'x86_64', 'i386'] and compiler_mode)
 else
     atalk_libname = 'lib'
 endif
+
 message('atalk_libname =', atalk_libname)
 
 #


### PR DESCRIPTION
Fixes issue #793 