### PR TITLE
afpd: Deal better with large numbers of FCE events

### DIFF
--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -1347,6 +1347,22 @@
         </varlistentry>
 
         <varlistentry>
+          <term>fce sendwait = <replaceable>milliseconds</replaceable>
+          <type>(G)</type></term>
+
+          <listitem>
+            <para>Defines a delay in milliseconds between
+            the emission of each FCE event.
+            Use this if you are experiencing lost FCE events when
+            creating or deleting a very large number of files at once.
+            The deluge of events that such an operation triggers can lead to
+            UDP buffer overflow and subsequently to packet loss.
+            Has to be a number between 0 and 999. Default: 0
+            milliseconds.</para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
           <term>fce ignore names = <replaceable>NAME[/NAME2/...]</replaceable>
           <type>(G)</type></term>
 

--- a/etc/afpd/fce_api.c
+++ b/etc/afpd/fce_api.c
@@ -581,7 +581,11 @@ int fce_register(const AFPObj *obj, fce_ev_t event, const char *path, const char
 
     switch (event) {
     case FCE_FILE_MODIFY:
-        save_close_event(obj, path);
+        if (obj->options.fce_fmodwait != 0){
+            save_close_event(obj, path);
+        } else {
+            send_fce_event(obj, event, path, oldpath);
+        }
         break;
     default:
         send_fce_event(obj, event, path, oldpath);

--- a/etc/afpd/fce_api.c
+++ b/etc/afpd/fce_api.c
@@ -46,6 +46,7 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <stdbool.h>
+#include <unistd.h>
 
 #include <atalk/adouble.h>
 #include <atalk/vfs.h>
@@ -370,6 +371,13 @@ static void send_fce_event(const AFPObj *obj, int event, const char *path, const
         }
         (void)afprun_bg(1, bdata(cmd));
         bdestroy(cmd);
+    }
+
+    if (obj->options.fce_sendwait > 0 && obj->options.fce_sendwait < 1000) {
+	struct timespec t;
+	t.tv_sec  = 0;
+	t.tv_nsec = 1000 * 1000 * obj->options.fce_sendwait;
+	while(nanosleep(&t, NULL));
     }
 
     for (int i = 0; i < udp_sockets; i++) {

--- a/include/atalk/globals.h
+++ b/include/atalk/globals.h
@@ -94,6 +94,7 @@ struct afp_options {
     int sleep;                  /* Maximum time allowed to sleep (in tickles) */
     int disconnected;           /* Maximum time in disconnected state (in tickles) */
     int fce_fmodwait;           /* number of seconds FCE file mod events are put on hold */
+    int fce_sendwait;           /* number of ms to wait between udp event sending */
     unsigned int tcp_sndbuf, tcp_rcvbuf;
     unsigned char passwdbits, passwdminlen;
     uint32_t server_quantum;

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2111,6 +2111,7 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     options->tcp_sndbuf     = atalk_iniparser_getint   (config, INISEC_GLOBAL, "tcpsndbuf",      0);
     options->tcp_rcvbuf     = atalk_iniparser_getint   (config, INISEC_GLOBAL, "tcprcvbuf",      0);
     options->fce_fmodwait   = atalk_iniparser_getint   (config, INISEC_GLOBAL, "fce holdfmod",   60);
+    options->fce_sendwait   = atalk_iniparser_getint   (config, INISEC_GLOBAL, "fce sendwait",   0);
     options->sleep          = atalk_iniparser_getint   (config, INISEC_GLOBAL, "sleep time",     10);
     options->disconnected   = atalk_iniparser_getint   (config, INISEC_GLOBAL, "disconnect time",24);
     options->splice_size    = atalk_iniparser_getint   (config, INISEC_GLOBAL, "splice size",    64*1024);


### PR DESCRIPTION
Two measures to allow for better handling of very large numbers of simultaneous FCE events

- If fce holdfmod is 0 the modification events must be thrown directly
- Added configurable wait between fce event sending to avoid udp event loss

Both patches by @seiman 