### PR TITLE
GitHub CI job with openSUSE Tumbleweed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -201,6 +201,7 @@ jobs:
             libtool \
             meson \
             ninja \
+            openrc \
             openssl-dev \
             pkgconfig &&
           wget https://github.com/berkeleydb/libdb/releases/download/v5.3.28/db-5.3.28.tar.gz --no-check-certificate &&
@@ -306,6 +307,83 @@ jobs:
         run: sudo ninja -C build install
       - name: Meson - Uninstall
         run: sudo ninja -C build uninstall
+
+  build-opensuse:
+    name: openSUSE
+    runs-on: ubuntu-22.04
+    container:
+      image: opensuse/tumbleweed:latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          zypper in -y \
+            automake \
+            file \
+            gawk \
+            gcc \
+            libtool \
+            make \
+            meson \
+            ninja \
+            systemd \
+            wget &&
+          zypper in -y \
+            bison \
+            cracklib-devel \
+            dbus-1-devel \
+            dbus-1-glib-devel \
+            flex \
+            glib2-devel \
+            krb5-devel \
+            libacl-devel \
+            libavahi-devel \
+            libdb-4_8-devel \
+            libevent-devel \
+            libgcrypt-devel \
+            libmariadb-devel \
+            libopenssl-devel \
+            libtalloc-devel \
+            libtdb-devel \
+            openldap2-devel \
+            pam-devel \
+            systemtap-sdt-devel \
+            tcpd-devel \
+            tracker \
+            tracker-devel
+      - name: Autotools - Bootstrap
+        run: ./bootstrap
+      - name: Autotools - Configure
+        run: |
+          ./configure \
+            --disable-init-hooks \
+            --enable-krbV-uam \
+            --enable-pgp-uam \
+            --with-cracklib \
+            --with-init-style=suse-systemd \
+            --with-tracker-pkgconfig-version=3.0
+      - name: Autotools - Build
+        run: make -j $(nproc)
+      - name: Autotools - Run tests
+        run: make check
+      - name: Autotools - Install
+        run: make install
+      - name: Autotools - Uninstall
+        run: make uninstall
+      - name: Meson - Configure
+        run: |
+          meson setup build \
+            -Dbuild-tests=true \
+            -Ddisable-init-hooks=true \
+            -Dwith-init-style=suse-systemd
+      - name: Meson - Build
+        run: ninja -C build
+      - name: Meson - Run tests
+        run: cd build && meson test
+      - name: Meson - Install
+        run: ninja -C build install
+      - name: Meson - Uninstall
+        run: ninja -C build uninstall
 
   build-macos:
     name: macOS

--- a/distrib/initscripts/Makefile.am
+++ b/distrib/initscripts/Makefile.am
@@ -261,8 +261,8 @@ if USE_OPENRC
 sysvdir = $(INIT_DIR)
 sysv_SCRIPTS = netatalk
 
-$(sysv_SCRIPTS): rc.gentoo
-	cp -f rc.gentoo $(sysv_SCRIPTS)
+$(sysv_SCRIPTS): rc.openrc
+	cp -f rc.openrc $(sysv_SCRIPTS)
 	chmod a+x $(sysv_SCRIPTS)
 
 install-data-hook:
@@ -344,4 +344,3 @@ uninstall-hook:
 uninstall-startup: uninstall-am
 
 endif
-

--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -134,7 +134,7 @@ elif (
     init_dir += '/etc/init.d'
     custom_target(
         'openrc',
-        input: 'rc.gentoo.tmpl',
+        input: 'rc.openrc.tmpl',
         output: 'netatalk',
         command: sed_command,
         capture: true,


### PR DESCRIPTION
- Because openSUSE Tumbleweed doesn't have a insserv or insserv-compat package available, cannot use `suse-sysv`
- Tried using openSUSE Leap (each 15.x release image) for a more stable base OS but all of them fails in GitHub Actions (cannot find `tar` which points to PATH being bad)
- The `zypper` command is split up into two because it bugs out when installing too many packages at once 👎 