### PR TITLE
Adopt rc script from FreeBSD ports.

### DIFF
--- a/distrib/initscripts/Makefile.am
+++ b/distrib/initscripts/Makefile.am
@@ -14,6 +14,7 @@ pkgconfdir = @PKGCONFDIR@
 	    -e s@:ETCDIR:@${pkgconfdir}@ \
 	    -e s@:NETATALK_VERSION:@${NETATALK_VERSION}@ \
 	    -e s@:PATH_NETATALK_LOCK:@${PATH_NETATALK_LOCK}@ \
+	    -e s@:ZEROCONF:@${FREEBSD_ZEROCONF_DAEMON}@ \
 	    <$< >$@
 
 GENERATED_FILES = \

--- a/distrib/initscripts/rc.freebsd.tmpl
+++ b/distrib/initscripts/rc.freebsd.tmpl
@@ -1,14 +1,66 @@
 #!/bin/sh
+
+# Copyright (c) 2001-2024, Joe Marcus Clarke <marcus@FreeBSD.org>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #
 # Netatalk :NETATALK_VERSION: daemons.
 #
+
+# PROVIDE: netatalk
+# REQUIRE: DAEMON :ZEROCONF:
+# KEYWORD: shutdown
+#
+# AFP fileserver for Mac clients.  Add the following to /etc/rc.conf to
+# enable:
+#
+# netatalk_enable="YES"
+#
+
+netatalk_enable=${netatalk_enable-"NO"}
 
 . /etc/rc.subr
 
 name=netatalk
 rcvar=netatalk_enable
 
+load_rc_config ${name}
+
 command=":SBINDIR:/${name}"
 
-load_rc_config $name
+extra_commands="reload"
+reload_cmd="netatalk_reload"
+
+netatalk_reload()
+{
+        local status
+
+        if ! status=`run_rc_command status 2>&1`; then
+                echo $status
+                return 1
+        fi
+        echo 'Reloading netatalk.'
+        kill -HUP $rc_pid
+}
+
 run_rc_command "$1"

--- a/macros/zeroconf.m4
+++ b/macros/zeroconf.m4
@@ -35,6 +35,8 @@ AC_DEFUN([AC_NETATALK_ZEROCONF], [
           ZEROCONF_CFLAGS="$AVAHI_CFLAGS"
           AC_DEFINE(USE_ZEROCONF, 1, [Use DNS-SD registration])
           AC_DEFINE(HAVE_AVAHI, 1, [Use Avahi/DNS-SD registration])
+          FREEBSD_ZEROCONF_DAEMON="avahi_daemon"
+          AC_SUBST(FREEBSD_ZEROCONF_DAEMON)
           found_zeroconf=yes
         fi
         CPPFLAGS="$savedcppflags"
@@ -53,6 +55,8 @@ AC_DEFUN([AC_NETATALK_ZEROCONF], [
             if test "$ac_cv_lib_dns_sd_DNSServiceRegister" = yes; then
                 ZEROCONF_LIBS="-ldns_sd"
                 AC_DEFINE(HAVE_MDNS, 1, [Use mDNSRespnder/DNS-SD registration])
+                FREEBSD_ZEROCONF_DAEMON="mdnsd"
+                AC_SUBST(FREEBSD_ZEROCONF_DAEMON)
                 found_zeroconf=yes
             fi
 		    fi

--- a/meson.build
+++ b/meson.build
@@ -684,6 +684,7 @@ dns_sd = cc.find_library('dns_sd', has_headers: 'dns_sd.h', required: false)
 system = cc.find_library('system', required: false)
 dns_sd_libs = [dns_sd, system]
 zeroconf_provider = []
+freebsd_zeroconf_daemon = ''
 
 have_dns = (
     (dns_sd.found() or system.found())
@@ -704,6 +705,7 @@ endif
 
 if avahi.found()
     cdata.set('HAVE_AVAHI', 1)
+    freebsd_zeroconf_daemon = 'avahi_daemon'
     if avahi.version() >= '0.6.4'
         cdata.set('HAVE_AVAHI_THREADED_POLL', 1)
     endif
@@ -713,6 +715,7 @@ endif
 if have_dns
     cdata.set('HAVE_MDNS', 1)
     zeroconf_provider += 'mDNS'
+    freebsd_zeroconf_daemon = 'mdnsd'
 endif
 
 if enable_zeroconf
@@ -1721,6 +1724,8 @@ sed_command = [
     's@:NETATALK_VERSION:@' + version + '@',
     '-e',
     's@:PATH_NETATALK_LOCK:@' + lockfile_path + '@',
+    '-e',
+    's@:ZEROCONF:@' + freebsd_zeroconf_daemon + '@',
     '@INPUT@',
 ]
 


### PR DESCRIPTION
Takes in the FreeBSD rc script from FreeBSD ports, by Joe Marcus Clarke, with minor modification.

- Added a copyright notice with the BSD 2-clause license
- Changed substitution deliminator from %%%% to :: to match our build system

Implementation note: `avahi_daemon` and `mdnsd` is what the respective zeroconf daemon is named in FreeBSD. We need one of these to be injected into the rc script for the startup ordering to work properly.