### PR TITLE
meson: Fix false positive for DHX support in Alpine when SSL headers absent

### DIFF
--- a/bin/meson.build
+++ b/bin/meson.build
@@ -1,4 +1,6 @@
 subdir('ad')
-subdir('afppasswd')
+if have_ssl
+    subdir('afppasswd')
+endif
 subdir('cnid')
 subdir('misc')

--- a/meson.build
+++ b/meson.build
@@ -519,6 +519,9 @@ foreach dir : ssl_dirs
             dir / 'include/openssl',
         )
     endif
+    if ssl_link_args != []
+        break
+    endif
 endforeach
 
 crypto = declare_dependency(
@@ -526,7 +529,7 @@ crypto = declare_dependency(
     include_directories: ssl_includes,
 )
 
-if crypto.found()
+if ssl_link_args != [] and ssl_includes != []
     have_ssl = true
     cdata.set('HAVE_LIBCRYPTO', 1)
     cdata.set('OPENSSL_DHX', 1)


### PR DESCRIPTION
This commit also enables all options within the Alpine Linux job