### PR TITLE
docker: Alpine based container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
       - branch-*
     paths-ignore:
       - "CONTRIBUTORS"
+      - "COPYING"
+      - "COPYRIGHT"
+      - "Dockerfile"
+      - "INSTALL"
       - "NEWS"
       - "README.md"
   pull_request:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,87 +1,71 @@
-FROM debian:bookworm-slim
+FROM alpine:3.19
 
 ENV LIB_DEPS \
-    libavahi-client3 \
-    libdb5.3 \
-    libevent-2.1-7 \
-    libgcrypt20 \
-    libglib2.0-0 \
-    libldap-2.5-0 \
-    libmariadb3 \
-    libpam0g \
-    libssl3 \
-    libtalloc2 \
-    libtracker-sparql-3.0-0 \
-    libwrap0 \
-    systemtap \
+    acl \
+    avahi \
+    bash \
+    db \
+    dbus \
+    dbus-glib \
+    krb5 \
+    libevent \
+    libgcrypt \
+    linux-pam \
+    openldap \
+    openssl \
+    talloc \
     tracker
 ENV BUILD_DEPS \
+    acl-dev \
+    avahi-dev \
     bison \
-    build-essential \
-    default-libmysqlclient-dev \
-    file \
+    curl \
+    db-dev \
+    dbus-dev \
+    build-base \
     flex \
-    libacl1-dev \
-    libattr1-dev \
-    libavahi-client-dev \
-    libcrack2-dev \
-    libcups2-dev \
-    libdb5.3-dev \
+    gcc \
+    krb5-dev \
     libevent-dev \
-    libgcrypt20-dev \
-    libglib2.0-dev \
-    libldap2-dev \
-    libltdl-dev \
-    libpam0g-dev \
-    libssl-dev \
-    libtalloc-dev \
-    libtracker-sparql-3.0-dev \
-    libwrap0-dev \
+    libgcrypt-dev \
+    linux-pam-dev \
     meson \
-    ninja-build \
-    pkg-config \
-    systemtap-sdt-dev
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && \
-    apt-get install --yes --no-install-recommends \
+    ninja \
+    openldap-dev \
+    openssl-dev \
+    pkgconfig \
+    talloc-dev \
+    tracker-dev
+RUN apk update && \
+    apk add --no-cache \
     $LIB_DEPS \
     $BUILD_DEPS
 
-RUN useradd builder
+RUN adduser -D -H builder
 WORKDIR /netatalk-code
 COPY . .
 RUN chown -R builder:builder . && rm -rf build || true
 USER builder
 
 RUN meson setup build \
-    -Dbuild-manual=false \
-    -Dpkg_config_path=/usr/lib/pkgconfig \
-    -Dwith-afpstats=disabled \
-    -Dwith-bdb=/usr \
-    -Dwith-dtrace=false \
-    -Dwith-init-style=none
-RUN ninja -C build
+    -Denable-pgp-uam=disabled \
+    -Dwith-dbus-daemon=/usr/bin/dbus-daemon \
+    -Dwith-dbus-sysconf-dir=/etc \
+    -Dwith-init-style=none && \
+    ninja -C build
 
 USER root
-RUN userdel builder && ninja -C build install
+RUN deluser builder && ninja -C build install
 
 WORKDIR /mnt
-RUN apt-get remove --yes --auto-remove --purge $BUILD_DEPS && \
-    apt-get --quiet --yes autoclean && \
-    apt-get --quiet --yes autoremove && \
-    apt-get --quiet --yes clean
-RUN rm -rf \
+RUN apk del $BUILD_DEPS && \
+    rm -rf \
     /netatalk-code \
-    /usr/include/netatalk \
-    /usr/share/man \
-    /usr/share/mime \
-    /usr/share/doc \
-    /usr/share/poppler \
-    /var/lib/apt/lists \
-    /tmp \
-    /var/tmp
-RUN ln -sf /dev/stdout /var/log/afpd.log
-COPY contrib/shell_utils/docker-entrypoint.sh /docker-entrypoint.sh
+    /usr/local/include/atalk \
+    /var/tmp \
+    /tmp && \
+    ln -sf /dev/stdout /var/log/afpd.log
+COPY contrib/shell_utils/docker-entrypoint.sh /entrypoint.sh
 EXPOSE 548
 VOLUME ["/mnt/afpshare", "/mnt/afpbackup"]
-CMD ["/docker-entrypoint.sh"]
+CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ Without this, the shared volume be stored in volatile storage that is lost upon 
 Sample `docker-compose.yml` with docker managed volume and Zeroconf
 
 ```
-version: "3"
-
 services:
   netatalk:
     image: netatalk3:latest


### PR DESCRIPTION
Use the latest stable alpine 3.19 docker image instead of bookworm-slim.

Pros:
- About half the size, ~1GB -> ~500MB
- Zero vulnerabilities (down from almost 200)
- Builds so, so quickly