### PR TITLE
meson: Match netatalk-dbus.conf install dir to value of -Dwith-dbus-sysconf-dir option

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -25,7 +25,7 @@ endif
 
 install_data('extmap.conf', install_dir: pkgconfdir)
 
-install_data('netatalk-dbus.conf', install_dir: pkgconfdir / 'dbus-1/system.d')
+install_data('netatalk-dbus.conf', install_dir: dbus_sysconf_dir)
 
 install_data('README', install_dir: localstatedir / 'netatalk')
 


### PR DESCRIPTION
Default is /etc/dbus-1/system.d