### PR TITLE
[2.4] Remove hard dependencies on perl and grep

### DIFF
--- a/contrib/macusers/meson.build
+++ b/contrib/macusers/meson.build
@@ -1,7 +1,9 @@
-macusers_script = configure_file(
-    input: 'macusers.in',
-    output: 'macusers',
-    configuration: cdata,
-)
+if perl.found() and grep.found()
+    macusers_script = configure_file(
+        input: 'macusers.in',
+        output: 'macusers',
+        configuration: cdata,
+    )
 
-install_data(macusers_script, install_dir: bindir)
+    install_data(macusers_script, install_dir: bindir)
+endif

--- a/contrib/shell_utils/meson.build
+++ b/contrib/shell_utils/meson.build
@@ -1,24 +1,26 @@
-appledump_script = configure_file(
-    input: 'apple_dump.in',
-    output: 'apple_dump',
-    configuration: cdata,
-)
+if perl.found() and grep.found()
+    appledump_script = configure_file(
+        input: 'apple_dump.in',
+        output: 'apple_dump',
+        configuration: cdata,
+    )
 
-asipstatus_script = configure_file(
-    input: 'asip-status.in',
-    output: 'asip-status',
-    configuration: cdata,
-)
+    asipstatus_script = configure_file(
+        input: 'asip-status.in',
+        output: 'asip-status',
+        configuration: cdata,
+    )
 
-install_data(
-    [
-        appledump_script,
-        asipstatus_script,
-        'make-casetable.pl',
-        'make-precompose.h.pl',
-    ],
-    install_dir: bindir,
-)
+    install_data(
+        [
+            appledump_script,
+            asipstatus_script,
+            'make-casetable.pl',
+            'make-precompose.h.pl',
+        ],
+        install_dir: bindir,
+    )
+endif
 
 custom_target(
     'lp2pap_sh',

--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -38,7 +38,11 @@ elif get_option('enable-systemd')
             install_dir: init_dir,
         )
     endforeach
-    meson.add_install_script(find_program('systemctl'), 'daemon-reload', '--no-ask-password')
+    meson.add_install_script(
+        find_program('systemctl'),
+        'daemon-reload',
+        '--no-ask-password',
+    )
 elif get_option('enable-suse')
     init_style += 'suse'
     init_dir += '/etc/init.d'

--- a/doc/manpages/man1/asip-status.1.xml
+++ b/doc/manpages/man1/asip-status.1.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>1</manvolnum>
 
-    <refmiscinfo class="date">06 May 2016</refmiscinfo>
+    <refmiscinfo class="date">27 Apr 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -13,7 +13,7 @@
   <refnamediv>
     <refname>asip-status</refname>
 
-    <refpurpose>Queries AFP servers for their capabilities</refpurpose>
+    <refpurpose>Queries an AFP server for its capabilities</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
@@ -62,22 +62,19 @@
     <title>Description</title>
 
     <para><command>asip-status</command>
-    sends a FPGetSrvrInfo request to an AFP server at
+    sends an FPGetSrvrInfo request to an AFP server at
     <replaceable>HOSTNAME</replaceable>:<replaceable>PORT</replaceable> and
-    displays the results, namely "Machine type", the server's name, supported
+    displays the results: "Machine type", the server's name, supported
     AFP versions, UAMs and AFP flags, the "server signature" and the network
-    addresses, the server provides AFP services on.</para>
+    addresses that the server provides AFP services on.</para>
 
     <para>When you don't supply <replaceable>PORT</replaceable>, then the
     default AFP port, 548, will be used.</para>
 
     <para>Starting with Netatalk 2.2.8, <command>asip-status</command>
-    supports both IPv4 and IPv6. It's decided by your system which IP version
-    to use. You can use -4 or -6 option to specify IP version.</para>
-
-    <note><para><command>asip-status</command> requires IO::Socket::IP
-    module.</para></note>
-
+    supports both IPv4 and IPv6. By default, your system automatically decides
+    which protocol version to use. You can use -4 or -6 option to force IPv4
+    or IPv6, respectively.</para>
   </refsect1>
 
   <refsect1>

--- a/doc/manpages/man1/meson.build
+++ b/doc/manpages/man1/meson.build
@@ -3,12 +3,9 @@ man_xml = [
     'aecho',
     'afpldaptest',
     'afppasswd',
-    'apple_dump',
-    'asip-status',
     'cnid2_create',
     'dbd',
     'getzones',
-    'macusers',
     'megatron',
     'nbp',
     'netatalk-config',
@@ -17,6 +14,14 @@ man_xml = [
     'showppd',
     'uniconv',
 ]
+
+if perl.found() and grep.found()
+    man_xml += [
+        'apple_dump',
+        'asip-status',
+        'macusers',
+    ]
+endif
 
 foreach man : man_xml
     man_xmlfile = configure_file(

--- a/doc/manual/install.xml
+++ b/doc/manual/install.xml
@@ -140,7 +140,7 @@ Resolving deltas: 100% (32227/32227), done.
                 <primary>BDB</primary>
 
                 <secondary>Berkeley DB</secondary>
-              </indexterm>.</para>
+              </indexterm></para>
 
             <para>At the time of writing you need at least version 4.6.</para>
 
@@ -155,14 +155,6 @@ Resolving deltas: 100% (32227/32227), done.
             <para>The <ulink url="http://directory.fsf.org/wiki/Libgcrypt">
             Libgcrypt</ulink> library enables the DHX2 UAM, which is required
             to authenticate with OS X 10.7 and later.</para>
-          </listitem>
-
-          <listitem>
-            <para>Perl</para>
-
-            <para>Administrative utilities such as
-            <userinput>asip-status</userinput> and
-            <userinput>macusers</userinput> rely on the Perl runtime.</para>
           </listitem>
         </itemizedlist>
       </sect3>
@@ -302,7 +294,19 @@ Resolving deltas: 100% (32227/32227), done.
           </listitem>
 
           <listitem>
-            <para>DocBook and xsltproc</para>
+            <para>Perl</para>
+
+            <para>Administrative utilities such as
+            <userinput>apple_dump</userinput>,
+            <userinput>asip-status</userinput> and
+            <userinput>macusers</userinput> rely on the Perl runtime, version
+            5.8 or later. Additionally, the
+            <emphasis>IO::Socket::IP</emphasis> module is required by
+            asip-status.</para>
+          </listitem>
+
+          <listitem>
+            <para>DocBook XSL and xsltproc</para>
 
             <para>The netatalk documentation (such as this manual) are
             authored in XML format, and then styled with DocBook XSL

--- a/macros/grep-check.m4
+++ b/macros/grep-check.m4
@@ -3,7 +3,7 @@ dnl Autoconf macro to check for the existence of grep
 AC_DEFUN([AC_PROG_GREP], [
 AC_REQUIRE([AC_EXEEXT])
 test x$GREP = x && AC_PATH_PROG(GREP, grep$EXEEXT, grep$EXEEXT)
-test x$GREP = x && AC_MSG_ERROR([no acceptable grep found in \$PATH])
+test x$GREP = x && AC_MSG_WARN([no acceptable grep found in \$PATH])
 ])
 
 AC_SUBST(GREP)

--- a/macros/perl-check.m4
+++ b/macros/perl-check.m4
@@ -3,7 +3,7 @@ dnl Autoconf macro to check for the existence of Perl
 AC_DEFUN([AC_PROG_PERL], [
 	AC_REQUIRE([AC_EXEEXT])
 	test "x$PERL" = x && AC_PATH_PROG(PERL, perl$EXEEXT, perl$EXEEXT)
-	test "x$PERL" = x && AC_MSG_ERROR([no acceptable Perl found in \$PATH])
+	test "x$PERL" = x && AC_MSG_WARN([no acceptable Perl found in \$PATH])
 ])
 
 AC_SUBST(PERL)

--- a/man/man1/meson.build
+++ b/man/man1/meson.build
@@ -3,12 +3,9 @@ man1_files = [
     'aecho.1',
     'afpldaptest.1',
     'afppasswd.1',
-    'apple_dump.1',
-    'asip-status.1',
     'cnid2_create.1',
     'dbd.1',
     'getzones.1',
-    'macusers.1',
     'megatron.1',
     'nbp.1',
     'netatalk-config.1',
@@ -17,6 +14,15 @@ man1_files = [
     'showppd.1',
     'uniconv.1',
 ]
+
+if perl.found() and grep.found()
+    man1_files += [
+        'apple_dump.1',
+        'asip-status.1',
+        'macusers.1',
+    ]
+endif
+
 foreach file : man1_files
     install_data(file + '.in', rename: file, install_dir: mandir / 'man1')
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -170,8 +170,8 @@ add_global_link_arguments(netatalk_common_link_args, language: 'c')
 # Programs #
 ############
 
-grep = find_program('grep', required: true)
-perl = find_program('perl', required: true)
+grep = find_program('grep', required: false)
+perl = find_program('perl', required: false)
 
 #################
 # Header checks #
@@ -440,7 +440,7 @@ if get_option('with-bdb') != ''
         endif
         if bdb_header != ''
             break
-        endif 
+        endif
     endforeach
 else
     foreach dir : bdb_dirs
@@ -454,7 +454,7 @@ else
             endif
             if bdb_header != ''
                 break
-            endif 
+            endif
         endforeach
         if bdb_header != ''
             break
@@ -1646,7 +1646,7 @@ elif host_os == 'sunos'
 endif
 
 #
-# Variable substitution 
+# Variable substitution
 #
 
 # Reserved for future use:
@@ -1661,10 +1661,13 @@ cdata.set('libdir', libdir)
 cdata.set('localstatedir', localstatedir)
 cdata.set('NETATALK_VERSION', version)
 cdata.set('OPEN_NOFOLLOW_ERRNO', 'ELOOP')
-cdata.set('PERL', perl.full_path())
 cdata.set('pkgconfdir', pkgconfdir)
 cdata.set('prefix', prefix)
 cdata.set('sbindir', sbindir)
+
+if perl.found()
+    cdata.set('PERL', perl.full_path())
+endif
 
 configure_file(
     input: 'meson_config.h',


### PR DESCRIPTION
- make perl and grep build system checks optional
- do not build or install perl scripts when either is not found
- update documentation on perl requirements
- automated meson script formatting