### PR TITLE
Pretty formatting of afpstats output

### DIFF
--- a/contrib/shell_utils/afpstats.in
+++ b/contrib/shell_utils/afpstats.in
@@ -27,10 +27,15 @@ sub main {
         my $remote_object = $service->get_object("/org/netatalk/AFPStats",
                                                  "org.netatalk.AFPStats");
 
-        foreach my $name (@{$remote_object->GetUsers}) {
-            print $name, "\n";
+        print "Username         PID      Login time        State          Volumes\n";
+
+        foreach my $user (@{$remote_object->GetUsers}) {
+            if ($user =~ /name: ([^,]+), pid: ([^,]+), logintime: ([^,]+), state: ([^,]+), volumes: (.+)/) {
+                my ($name, $pid, $logintime, $state, $volume) = ($1, $2, $3, $4, $5);
+                printf "%-17s%-9s%-18s%-15s%s\n", $name, $pid, $logintime, $state, $volume;
+            }
         }
-    };
+    }
     if ($@) {
         print "Error: $@\n";
         exit 1;
@@ -38,4 +43,3 @@ sub main {
 }
 
 main();
-


### PR DESCRIPTION
While tinkering with the afpstats script, I thought it would be nice to give the output a more human readable format.

This is an example of what it looks like now:

```
name: dmark, pid: 396739, logintime: Apr 26 22:56:08, state: active, volumes: dmark's Home
name: dmark, pid: 397710, logintime: Apr 26 23:56:11, state: active, volumes: My AFP Volume
```

This is what it looks like after this PR:

```
Username         PID      Login time        State          Volumes
dmark            452547   Apr 28 21:58:50   active         Test Volume
dmark            451969   Apr 28 21:21:32   active         My AFP Volume
```