### PR TITLE
[2.4] Fix missing rresvport function on systems using musl C library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1066,6 +1066,12 @@ if test x"$neta_cv_REALPATH_TAKES_NULL" = x"yes"; then
     AC_DEFINE(REALPATH_TAKES_NULL,1,[Whether the realpath function allows NULL])
 fi
 
+dnl --------------------- Check for musl C library
+neta_cv_musl=`/usr/bin/ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1`
+if test "x$neta_cv_musl" != "xyes"; then
+    AC_DEFINE(MUSL,	1, [Define if musl C library is present])
+fi
+
 dnl --------------------- last minute substitutions
 
 AC_SUBST(LIBS)

--- a/etc/papd/lp.c
+++ b/etc/papd/lp.c
@@ -33,6 +33,34 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
+ *
+ * Portions:
+ * Copyright (C) 1998 WIDE Project.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the project nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
  */
 
 /*
@@ -81,6 +109,54 @@
 #include  "print_cups.h"
 #endif
 
+#ifdef MUSL
+int
+rresvport (int *alport)
+{
+	union {
+		struct sockaddr generic;
+		struct sockaddr_in in;
+		struct sockaddr_in6 in6;
+	} ss;
+	int s;
+	size_t len;
+	uint16_t *sport;
+
+	len = sizeof(struct sockaddr_in);
+	sport = &ss.in.sin_port;
+	/* NB: No SOCK_CLOEXEC for backwards compatibility.  */
+	s = socket(AF_INET, SOCK_STREAM, 0);
+	if (s < 0)
+		return -1;
+
+	memset (&ss, '\0', sizeof(ss));
+#ifdef SALEN
+	ss.generic.__ss_len = len;
+#endif
+	ss.generic.sa_family = AF_INET;
+
+	/* Ignore invalid values.  */
+	if (*alport < IPPORT_RESERVED / 2)
+		*alport = IPPORT_RESERVED / 2;
+	else if (*alport >= IPPORT_RESERVED)
+		*alport = IPPORT_RESERVED - 1;
+
+	int start = *alport;
+	do {
+		*sport = htons((uint16_t) *alport);
+		if (bind(s, &ss.generic, len) >= 0)
+			return s;
+		if (errno != EADDRINUSE) {
+			(void)close(s);
+			return -1;
+		}
+		if ((*alport)-- == IPPORT_RESERVED/2)
+			*alport = IPPORT_RESERVED - 1;
+	} while (*alport != start);
+	(void)close(s);
+	return -1;
+}
+#endif
 
 /* These functions aren't used outside of lp.c */
 int lp_conn_inet();

--- a/etc/papd/lp.h
+++ b/etc/papd/lp.h
@@ -25,4 +25,6 @@ int lp_write ( struct papfile *,char *, size_t );
 /* close current spooling file */
 int lp_close ( void );
 
+extern int rresvport (int *__alport);
+
 #endif /* PAPD_LP_H */

--- a/meson.build
+++ b/meson.build
@@ -1600,6 +1600,16 @@ if get_option('enable-systemd')
 endif
 
 #
+# Check for musl C library
+#
+
+if host_os == 'linux'
+    if run_command('ldd', '/bin/ls', check: true).stdout().strip().contains('musl')
+        cdata.set('MUSL', 1)
+    endif
+endif
+
+#
 # OS-specific configuration
 #
 

--- a/meson_config.h
+++ b/meson_config.h
@@ -679,6 +679,9 @@
    <sysmacros.h>. */
 #mesondefine MAJOR_IN_SYSMACROS
 
+/* Define to 1 if musl C library is present. */
+#mesondefine MUSL
+
 /* Define various xdr functions */
 #mesondefine NEED_RQUOTA
 


### PR DESCRIPTION
This commit:

- Fixes the missing rresvport function on linux systems using musl, credit @daimh