### PR TITLE
Set service name as hostname in init scripts

### DIFF
--- a/config/netatalk.conf
+++ b/config/netatalk.conf
@@ -5,15 +5,16 @@
 #########################################################################
 
 #### machine's AFPserver/AppleTalk name.
+#### Uncomment this to override rc/sysv init script
 #ATALK_NAME=machinename
 
 #### server (unix) and legacy client (<= Mac OS 9) charsets
-ATALK_UNIX_CHARSET='LOCALE'
-ATALK_MAC_CHARSET='MAC_ROMAN'
+#ATALK_UNIX_CHARSET='LOCALE'
+#ATALK_MAC_CHARSET='MAC_ROMAN'
 
 #### Don't Edit. export the charsets, read form ENV by apps
-export ATALK_UNIX_CHARSET
-export ATALK_MAC_CHARSET
+#export ATALK_UNIX_CHARSET
+#export ATALK_MAC_CHARSET
 
 #########################################################################
 # AFP specific configuration
@@ -28,8 +29,6 @@ AFPD_RUN=yes
 #AFPD_MAX_CLIENTS=20
 
 #### UAMs (User Authentication Modules)
-#### available options: uams_dhx.so, uams_dhx2.so, uams_guest.so,
-####                    uams_clrtxt.so, uams_randnum.so
 #AFPD_UAMLIST="-U uams_dhx2.so"
 
 #### Set the id of the guest user when using uams_guest.so
@@ -39,20 +38,18 @@ AFPD_RUN=yes
 #CNID_CONFIG="-l log_note"
 
 #########################################################################
-# AppleTalk specific configuration (legacy)
+# AppleTalk specific configuration
 #########################################################################
 
-#### Set which legacy daemons to run.
-#### If you need AppleTalk, run atalkd.
+#### Turn off if you didn't build netatalk with AppleTalk support.
 #### papd, timelord and a2boot are dependent upon atalkd.
-#ATALKD_RUN=no
-#PAPD_RUN=no
-#TIMELORD_RUN=no
-#A2BOOT_RUN=no
+ATALKD_RUN=yes
+PAPD_RUN=yes
+TIMELORD_RUN=yes
+A2BOOT_RUN=yes
 
 #### Control whether the daemons are started in the background.
 #### If it is dissatisfied that legacy atalkd starts slowly, set "yes".
-#### In case using systemd/systemctl, this is not so significant.
 #ATALK_BGROUND=no
 
 #### Set the AppleTalk Zone name.

--- a/distrib/initscripts/atalkd.service.tmpl
+++ b/distrib/initscripts/atalkd.service.tmpl
@@ -9,7 +9,10 @@ After=network-online.target
 [Service]
 Type=forking
 GuessMainPID=no
+ExecStartPre=/bin/sh -c 'systemctl set-environment ATALK_NAME=$$(hostname|cut -d. -f1)'
 ExecStart=:SBINDIR:/atalkd
+ExecStartPost=:BINDIR:/nbprgstr -p 4 "${ATALK_NAME}:Workstation"
+ExecStartPost=:BINDIR:/nbprgstr -p 4 "${ATALK_NAME}:netatalk"
 Restart=always
 RestartSec=1
 

--- a/distrib/initscripts/rc.debian.tmpl
+++ b/distrib/initscripts/rc.debian.tmpl
@@ -17,6 +17,7 @@ set -e
 
 . /lib/lsb/init-functions
 
+ATALK_NAME=`/bin/hostname --short`
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DESC="Netatalk"
 NAME=netatalk
@@ -48,13 +49,13 @@ atalk_startup() {
 
 	echo -n " atalkd"
 	fi
-	
+
 	# prepare startup of file services
 	if [ "x$CNID_METAD_RUN" = "xyes" -a -x :SBINDIR:/cnid_metad ] ; then
 		echo -n " cnid_metad"
         :SBINDIR:/cnid_metad $CNID_CONFIG
     fi
-	
+
 	if [ x"$AFPD_RUN" = x"yes" ]; then
 	:SBINDIR:/afpd $AFPD_UAMLIST -g $AFPD_GUEST -c $AFPD_MAX_CLIENTS \
 		-n "$ATALK_NAME$ATALK_ZONE"
@@ -98,12 +99,12 @@ case "$1" in
 
 		echo -n " cnid_metad"
 		start-stop-daemon --stop --quiet --oknodo --exec :SBINDIR:/cnid_metad
-	
+
 		if test -x :SBINDIR:/papd; then
                     echo -n " papd"
 		    start-stop-daemon --stop --quiet --oknodo --exec :SBINDIR:/papd
 	        fi
-	
+
 		if test -x :SBINDIR:/timelord; then
                     echo -n " timelord"
 		    start-stop-daemon --stop --quiet --oknodo --exec :SBINDIR:/timelord
@@ -118,10 +119,10 @@ case "$1" in
                     echo -n " atalkd"
 		    start-stop-daemon --stop --quiet --oknodo --exec :SBINDIR:/atalkd
 	        fi
-	
+
 		echo "."
 	;;
-	
+
 	restart)
 		$0 force-reload
 	;;
@@ -136,7 +137,7 @@ case "$1" in
 			echo "done."
 		fi
 	;;
-  
+
 	*)
 		echo "Usage: $0 {start|stop|restart|force-reload}" >&2
 		exit 1

--- a/distrib/initscripts/rc.openrc.tmpl
+++ b/distrib/initscripts/rc.openrc.tmpl
@@ -5,6 +5,8 @@
 # its data structures must have time to stablize before running the
 # other processes.
 
+ATALK_NAME=`echo ${HOSTNAME}|cut -d. -f1`
+
 depend() {
 	need net
 	use logger dns

--- a/distrib/initscripts/rc.redhat.tmpl
+++ b/distrib/initscripts/rc.redhat.tmpl
@@ -1,7 +1,7 @@
 #! /bin/sh
 # chkconfig: - 91 35
 # description: This package is an implementation of "AFP over TCP"
-#              and provides printer, file sharing, and routing 
+#              and provides printer, file sharing, and routing
 #              services via legacy AppleTalk networking protocol.
 #
 # Netatalk :NETATALK_VERSION: daemons.
@@ -9,6 +9,7 @@
 # its data structures must have time to stablize before running the
 # other processes.
 
+ATALK_NAME=`echo ${HOSTNAME}|cut -d. -f1`
 ATALK_BIN=:BINDIR:
 ATALK_CONF_DIR=:ETCDIR:
 ATALK_SBIN=:SBINDIR:
@@ -35,7 +36,7 @@ RETVAL_AFPD=0
 atalk_startup() {
     # Check that networking is up.
     if [ ${NETWORKING} = "no" ]; then
-         echo "[Network isn't started]"; 
+         echo "[Network isn't started]";
          exit 1;
     fi
 
@@ -44,7 +45,7 @@ atalk_startup() {
          exit 6;
     fi
 
-    if [ x"${ATALKD_RUN}" != x"no" -a -x ${ATALK_SBIN}/atalkd ]; then 
+    if [ x"${ATALKD_RUN}" != x"no" -a -x ${ATALK_SBIN}/atalkd ]; then
          # Quickly probe for appletalk and warn if we can't find it
          #/sbin/modprobe appletalk || echo "[could not load appletalk module]"
          # Check for IP Encapsulation support
@@ -54,10 +55,10 @@ atalk_startup() {
 	RETVAL_ATALKD=$?
 	echo
 
-	if [ -x ${ATALK_BIN}/nbprgstr ]; then	
+	if [ -x ${ATALK_BIN}/nbprgstr ]; then
 	    action "  Registering ${ATALK_NAME}:Workstation${ATALK_ZONE}:" ${ATALK_BIN}/nbprgstr -p 4 \"${ATALK_NAME}:Workstation${ATALK_ZONE}\"
 	    action "  Registering ${ATALK_NAME}:netatalk${ATALK_ZONE}:" ${ATALK_BIN}/nbprgstr -p 4 \"${ATALK_NAME}:netatalk${ATALK_ZONE}\"
-	fi	
+	fi
 
 	if [ x"${PAPD_RUN}" = x"yes"  -a -x ${ATALK_SBIN}/papd ]; then
 	    echo -n "  Starting papd:"
@@ -120,14 +121,14 @@ atalk_startup() {
 case "$1" in
 'start')
 	echo -n 'Starting Netatalk services: '
-	if [ x"${ATALK_BGROUND}" = x"yes" -a x"${ATALKD_RUN}" != x"no" ]; then 
+	if [ x"${ATALK_BGROUND}" = x"yes" -a x"${ATALKD_RUN}" != x"no" ]; then
 	    echo -n "(backgrounded)"
 	    atalk_startup >& /dev/null &
 	else
 	    echo
 	    atalk_startup
 	fi
-	echo 
+	echo
 	;;
 'stop')
 	echo 'Shutting down Netatalk services: '

--- a/distrib/initscripts/rc.solaris.tmpl
+++ b/distrib/initscripts/rc.solaris.tmpl
@@ -17,8 +17,9 @@ killproc() {
 	[ "$pid" != "" ] && kill $pid
 }
 
-. :ETCDIR:/netatalk.conf
+ATALK_NAME=`hostname|cut -d. -f1`
 
+. :ETCDIR:/netatalk.conf
 
 #
 # Start the netatalk server processes.

--- a/distrib/initscripts/rc.suse.tmpl
+++ b/distrib/initscripts/rc.suse.tmpl
@@ -1,10 +1,10 @@
 #! /bin/sh
 # Copyright (c) 1996-2001 SuSE GmbH Nuernberg, Germany.  All rights reserved.
 #
-# Author: 
+# Author:
 #	Reinhold Sojer, <reinhold@suse.de>
 #	Olaf Hering, <olh@suse.de>
-# 
+#
 ### BEGIN INIT INFO
 # Provides:       netatalk
 # Required-Start: $local_fs
@@ -18,24 +18,26 @@
 
 # Netatalk :NETATALK_VERSION:
 
+ATALK_NAME=`hostname|sed 's/\..*$//'`
+
 . /etc/rc.status
 . :ETCDIR:/netatalk.conf
 
 # startup code for everything
 atalk_startup() {
-    if [ x"${ATALKD_RUN}" != x"no" ]; then 
+    if [ x"${ATALKD_RUN}" != x"no" ]; then
 	echo -n "  Starting atalkd ... "
 	:SBINDIR:/atalkd ; my_ec=$?
 
-	if [ -x :BINDIR:/nbprgstr -a "$my_ec" = "0" ]; then	
+	if [ -x :BINDIR:/nbprgstr -a "$my_ec" = "0" ]; then
 	    echo -n ".. "
 	    :BINDIR:/nbprgstr -p 4 ${ATALK_NAME}:Workstation
 	    echo -n ". "
 	    :BINDIR:/nbprgstr -p 4 ${ATALK_NAME}:netatalk
-	fi	
+	fi
 	if [ "$my_ec" != "0" ] ; then false ; fi
 	rc_status -v
-	
+
 	rc_reset
 
 	if [ x"${PAPD_RUN}" = x"yes"  -a -x :SBINDIR:/papd ]; then
@@ -81,7 +83,7 @@ atalk_startup() {
 	    rc_status -v
     fi
 
-	touch /var/lock/subsys/atalk 
+	touch /var/lock/subsys/atalk
 }
 
 case "$1" in
@@ -90,7 +92,7 @@ case "$1" in
 		echo "you have to be root to start netatalk daemons"
 		rc_failed
 	else
-	if [ x"${ATALK_BGROUND}" = x"yes" -a x"${ATALKD_RUN}" != x"no" ]; then 
+	if [ x"${ATALK_BGROUND}" = x"yes" -a x"${ATALKD_RUN}" != x"no" ]; then
 	    echo -n "Starting netatalk in the background ..."
 	    atalk_startup >& /dev/null &
 	    rc_status -v


### PR DESCRIPTION
- Bring back hostname-as-servicename logic to init scripts
- Enable appletalk services by default in netatalk.conf
- Disable charset env variables, which afpd already has built-in defaults for

(Pardon the trailing whitespace cleanup. I'm using an "opinionated" editor.)