### PR TITLE
meson: Fix 'libatalk not found' error on NetBSD

### DIFF
--- a/bin/ad/meson.build
+++ b/bin/ad/meson.build
@@ -18,5 +18,5 @@ executable(
     link_with: libatalk,
     c_args: [ad, dversion],
     install: true,
-    install_rpath: rpath,
+    build_rpath: libdir,
 )

--- a/bin/afppasswd/meson.build
+++ b/bin/afppasswd/meson.build
@@ -13,5 +13,5 @@ executable(
         dversion,
     ],
     install: true,
-    install_rpath: rpath,
+    build_rpath: libdir,
 )

--- a/bin/misc/meson.build
+++ b/bin/misc/meson.build
@@ -41,4 +41,5 @@ executable(
     dependencies: [mysqlclient, ldap],
     c_args: confdir,
     install: true,
+    build_rpath: libdir,
 )

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -185,5 +185,5 @@ executable(
     export_dynamic: true,
     install: true,
     install_dir: sbindir,
-    install_rpath: rpath,
+    build_rpath: libdir,
 )

--- a/etc/cnid_dbd/meson.build
+++ b/etc/cnid_dbd/meson.build
@@ -26,7 +26,7 @@ executable(
     link_args: bdb_link_args,
     install: true,
     install_dir: sbindir,
-    install_rpath: rpath,
+    build_rpath: libdir,
 )
 
 cnid_metad_sources = ['cnid_metad.c', 'usockfd.c', 'db_param.c']
@@ -40,7 +40,7 @@ executable(
     c_args: [cnid_dbd, dversion],
     install: true,
     install_dir: sbindir,
-    install_rpath: rpath,
+    build_rpath: libdir,
 )
 
 dbd_sources = [
@@ -66,5 +66,5 @@ executable(
     c_args: dversion,
     link_args: [dversion, bdb_link_args],
     install: true,
-    install_rpath: rpath,
+    build_rpath: libdir,
 )

--- a/etc/netatalk/meson.build
+++ b/etc/netatalk/meson.build
@@ -9,5 +9,5 @@ executable(
     c_args: [confdir, statedir, afpd, cnid_metad, dversion],
     install: true,
     install_dir: sbindir,
-    install_rpath: rpath,
+    build_rpath: libdir,
 )


### PR DESCRIPTION
This commit ensures that all executables are correctly linked to libatalk at build-time