### PR TITLE
docs: Update Japanese manual for 3.2.0

### DIFF
--- a/doc/ja/manpages/man1/ad.1.xml
+++ b/doc/ja/manpages/man1/ad.1.xml
@@ -8,7 +8,9 @@
     <refmiscinfo class="date">17 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
@@ -37,7 +39,10 @@
   <refsect1>
     <title>説明</title>
 
-    <para><command>ad</command>は、Netatalk 互換の AppleDouble ファイルユーティリティ一式である。Netatalk 共有ボリューム内の AppleDouble データ (ファイルの拡張属性や、同じディレクトリ内の._fileや、<filename>.AppleDouble</filename>ディレクトリ内のファイル) とCNIDデータベースを適切に更新する。</para>
+    <para><command>ad</command>は、Netatalk 互換の AppleDouble
+    ファイルユーティリティ一式である。Netatalk 共有ボリューム内の AppleDouble データ
+    (ファイルの拡張属性や、同じディレクトリ内の._fileや、<filename>.AppleDouble</filename>ディレクトリ内のファイル)
+    とCNIDデータベースを適切に更新する。</para>
   </refsect1>
 
   <refsect1>
@@ -231,7 +236,8 @@ Note: any letter appearing in uppercase means the flag is set but it's a directo
         <term>-p</term>
 
         <listitem>
-          <para>以下に示すそれぞれのコピー元ファイルの属性を、パーミッションが許す限り維持する: 変更時刻、アクセス時刻、ファイルフラグ、ファイルモード、ユーザIDグループID。ユーザIDとグループIDが維持されない場合、エラーメッセージは表示されず、終了コードは変更されない。</para>
+          <para>以下に示すそれぞれのコピー元ファイルの属性を、パーミッションが許す限り維持する:
+          変更時刻、アクセス時刻、ファイルフラグ、ファイルモード、ユーザIDグループID。ユーザIDとグループIDが維持されない場合、エラーメッセージは表示されず、終了コードは変更されない。</para>
         </listitem>
       </varlistentry>
 
@@ -356,8 +362,9 @@ Note: any letter appearing in uppercase means the flag is set but it's a directo
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/afpldaptest.1.xml
+++ b/doc/ja/manpages/man1/afpldaptest.1.xml
@@ -8,7 +8,9 @@
     <refmiscinfo class="date">22 Mar 2012</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
@@ -24,7 +26,9 @@
 
       <group choice="req">
         <arg choice="plain">-u <replaceable>USER</replaceable></arg>
+
         <arg choice="plain">-g <replaceable>GROUP</replaceable></arg>
+
         <arg choice="plain">-i <replaceable>UUID</replaceable></arg>
       </group>
     </cmdsynopsis>
@@ -34,18 +38,18 @@
 
       <group choice="req">
         <arg choice="plain">-h</arg>
+
         <arg choice="plain">-?</arg>
+
         <arg choice="plain">-:</arg>
       </group>
-
     </cmdsynopsis>
   </refsynopsisdiv>
 
   <refsect1>
     <title>説明</title>
 
-    <para><command>afpldaptest</command>は@pkgconfdir@/afp.confのldapパラメータを構文チェックするシンプルなコマンドです。</para>
-
+    <para><command>afpldaptest</command>はafp.confのldapパラメータを構文チェックするシンプルなコマンドである。</para>
   </refsect1>
 
   <refsect1>
@@ -74,7 +78,6 @@
         <listitem>
           <para><replaceable>UUID</replaceable>のためのuserかgroupかlocal-uuidを表示する。</para>
         </listitem>
-
       </varlistentry>
 
       <varlistentry>
@@ -83,21 +86,24 @@
         <listitem>
           <para>ヘルプを表示して終了する。</para>
         </listitem>
-
       </varlistentry>
-
     </variablelist>
   </refsect1>
 
   <refsect1>
     <title>参照</title>
 
-    <para><citerefentry><refentrytitle>afp.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry></para>
+    <para><citerefentry>
+        <refentrytitle>afp.conf</refentrytitle>
+
+        <manvolnum>5</manvolnum>
+      </citerefentry></para>
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/afppasswd.1.xml
+++ b/doc/ja/manpages/man1/afppasswd.1.xml
@@ -5,10 +5,12 @@
 
     <manvolnum>1</manvolnum>
 
-    <refmiscinfo class="date">17 Mar 2024</refmiscinfo>
+    <refmiscinfo class="date">01 May 2024</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
@@ -37,12 +39,15 @@
   <refsect1>
     <title>説明</title>
 
-    <para><command>afppasswd</command>は、uams_randnum.so UAMで使うために、netatalkが作るafppasswdファイルを保守する。(このUAMは"Randnum exchange"と"2-Way Randnum exchange"ユーザ認証モジュールを提供する)</para>
+    <para><command>afppasswd</command> は、「Randnum exchange」および「2-Way Randnum
+    exchange」ユーザー認証モジュールのユーザー資格情報を提供する afppasswd ファイルを作成および管理する。</para>
 
-    <para><command>afppasswd</command>は、rootがパラメータ付きで呼び出すことも、ローカルシステムのユーザが自分のAFPパスワードを変更するためにパラメータなしで呼び出すこともできる。</para>
+    <para><command>afppasswd</command>は、rootがパラメータ付きで呼び出すことも、一般のユーザが自分のAFPパスワードを変更するためにパラメータなしで呼び出すこともできる。</para>
 
     <note>
-      <para>このユーティリティでは、Random Number UAM の2種類が利用するパスワードのみ変更できる。かなり弱いパスワード暗号化を提供するため、非常に古いAFPクライアントをサポートしなければならない限り、より安全な"DHX" ("DHCAST128") 及び "DHX2" UAMを推奨する。Netatalkマニュアルの<link linkend="authentication">認証の章</link>で比較してください。</para>
+      <para>このユーティリティでは、Random Number UAM
+      の2種類が利用するパスワードのみ変更できる。かなり弱いパスワード暗号化を提供するため、非常に古いAFPクライアントをサポートしなければならない限り、より安全な"DHX"
+      ("DHCAST128") 及び "DHX2" UAMを推奨する。</para>
     </note>
   </refsect1>
 
@@ -87,7 +92,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>-p</option><replaceable> path</replaceable></term>
+        <term><option>-p</option><replaceable> パス</replaceable></term>
 
         <listitem>
           <para><command>afppasswd</command>ファイルのパス。</para>
@@ -98,7 +103,8 @@
         <term><option>-n</option></term>
 
         <listitem>
-          <para>もしcracklibサポートが<emphasis remap="B">netatalk</emphasis>に組み込まれており、cracklib辞書に対して実行されたパスワードを持つことをスーパユーザが望まないなら、このオプションはcracklibチェックを無効にできるだろう。</para>
+          <para>もしcracklibサポートが<emphasis
+          remap="B">netatalk</emphasis>に組み込まれており、cracklib辞書に対して実行されたパスワードを持つことをスーパユーザが望まないなら、このオプションはcracklibチェックを無効にできるだろう。</para>
         </listitem>
       </varlistentry>
 
@@ -107,7 +113,17 @@
         uid</replaceable></term>
 
         <listitem>
-          <para>これは、<command>afppasswd</command>がユーザを作成するときに使う最小の<emphasis remap="I">ユーザid</emphasis> (uid)である。</para>
+          <para>これは、<command>afppasswd</command>がユーザを作成するときに使う最小の<emphasis
+          remap="I">ユーザid</emphasis> (uid)である。</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>-w <emphasis>文字列</emphasis></term>
+
+        <listitem>
+          <para>パスワードを対話形式で入力するのではなく、文字列をパスワードとして使用する。
+          パスワードは平文で端末履歴に残るため、このオプションは絶対に必要な場合にのみ使用してください。</para>
         </listitem>
       </varlistentry>
     </variablelist>
@@ -128,8 +144,9 @@
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/afpstats.1.xml
+++ b/doc/ja/manpages/man1/afpstats.1.xml
@@ -5,17 +5,19 @@
 
     <manvolnum>1</manvolnum>
 
-    <refmiscinfo class="date">24 Mar 2013</refmiscinfo>
+    <refmiscinfo class="date">27 Apr 2024</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>
     <refname>afpstats</refname>
 
-    <refpurpose>AFPの統計をリストする</refpurpose>
+    <refpurpose>AFP サーバの利用状況を参照する</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
@@ -27,30 +29,52 @@
   <refsect1>
     <title>説明</title>
 
-    <para><command>afpstats</command>はD-Bus IPC経由でAFPの統計をリストします。</para>
-
+    <para><command>afpstats</command>
+    は接続中のユーザ、マウント中のボリュームなどの利用状況が参照できる。</para>
   </refsect1>
 
   <refsect1>
     <title>注記</title>
 
-    <para><command>afpd</command>がD-Busをサポートしなければならない。"<command>afpd -V</command>"でそれをチェックしてください。</para>
+    <para><command>afpd</command>がD-Busをサポートしなければならない。"<command>afpd
+    -V</command>"でそれをチェックしてください。</para>
 
-    <para><filename>@pkgconfdir@/afp.conf</filename>で"<option>afpstats = yes</option>"を設定しなければならない。</para>
+    <para>その上、<filename>afp.conf</filename> で"<option>afpstats =
+    yes</option>"を設定しなければならない。</para>
+  </refsect1>
 
+  <refsect1>
+    <title>例</title>
+
+    <para><programlisting>$ <emphasis remap="B">afpstats</emphasis>
+Connected user   PID      Login time        State          Mounted volumes
+sandy            452547   Apr 28 21:58:50   active         Test Volume, sandy's Home
+charlie          451969   Apr 28 21:21:32   active         My AFP Volume
+  </programlisting></para>
   </refsect1>
 
   <refsect1>
     <title>参照</title>
 
-    <para><citerefentry><refentrytitle>afpd</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
-    <citerefentry><refentrytitle>afp.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>,
-    <citerefentry><refentrytitle>dbus-daemon</refentrytitle><manvolnum>1</manvolnum></citerefentry></para>
+    <para><citerefentry>
+        <refentrytitle>afpd</refentrytitle>
+
+        <manvolnum>8</manvolnum>
+      </citerefentry>, <citerefentry>
+        <refentrytitle>afp.conf</refentrytitle>
+
+        <manvolnum>5</manvolnum>
+      </citerefentry>, <citerefentry>
+        <refentrytitle>dbus-daemon</refentrytitle>
+
+        <manvolnum>1</manvolnum>
+      </citerefentry></para>
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/apple_dump.1.xml
+++ b/doc/ja/manpages/man1/apple_dump.1.xml
@@ -8,7 +8,9 @@
     <refmiscinfo class="date">12 Nov 2015</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
@@ -26,6 +28,7 @@
 
       <group choice="opt">
         <arg choice="plain"><replaceable>FILE</replaceable></arg>
+
         <arg choice="plain"><replaceable>DIR</replaceable></arg>
       </group>
     </cmdsynopsis>
@@ -37,6 +40,7 @@
 
       <group choice="plain">
         <arg choice="plain"><replaceable>FILE</replaceable></arg>
+
         <arg choice="plain"><replaceable>DIR</replaceable></arg>
       </group>
     </cmdsynopsis>
@@ -62,7 +66,9 @@
 
       <group choice="plain">
         <arg choice="plain">-h</arg>
+
         <arg choice="plain">-help</arg>
+
         <arg choice="plain">--help</arg>
       </group>
     </cmdsynopsis>
@@ -72,10 +78,11 @@
 
       <group choice="plain">
         <arg choice="plain">-v</arg>
+
         <arg choice="plain">-version</arg>
+
         <arg choice="plain">--version</arg>
       </group>
-
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -83,9 +90,11 @@
     <title>説明</title>
 
     <para><command>apple_dump</command>はAppleSingle/AppleDoubleフォーマットのデータをダンプするperlスクリプトです。</para>
-    <para>このスクリプトはメーラ、アーカイバ、Mac OS X、Netatalkなどが生成する様々なAppleSingle/AppleDoubleデータをダンプできます。</para>
-    <para><replaceable>FILE</replaceable>|<replaceable>DIR</replaceable>がない、または<replaceable>FILE</replaceable>|<replaceable>DIR</replaceable>が「-」であるとき、標準入力を読み込みます。</para>
 
+    <para>このスクリプトはメーラ、アーカイバ、Mac OS
+    X、Netatalkなどが生成する様々なAppleSingle/AppleDoubleデータをダンプできます。</para>
+
+    <para><replaceable>FILE</replaceable>|<replaceable>DIR</replaceable>がない、または<replaceable>FILE</replaceable>|<replaceable>DIR</replaceable>が「-」であるとき、標準入力を読み込みます。</para>
   </refsect1>
 
   <refsect1>
@@ -93,7 +102,8 @@
 
     <variablelist remap="TP">
       <varlistentry>
-        <term><option>-a</option> [<replaceable>FILE</replaceable>|<replaceable>DIR</replaceable>]</term>
+        <term><option>-a</option>
+        [<replaceable>FILE</replaceable>|<replaceable>DIR</replaceable>]</term>
 
         <listitem>
           <para>これがデフォルトです。<replaceable>FILE</replaceable>または<replaceable>DIR</replaceable>のためのAppleSingle/AppleDoubleデータを自動的にダンプします。もしFILEがAppleSingle/AppleDoubleフォーマットでないなら、拡張属性と<replaceable>.AppleDouble/FILE</replaceable>と<replaceable>._FILE</replaceable>を探します。もし<replaceable>DIR</replaceable>なら、拡張属性と<replaceable>DIR/.AppleDouble/.Parent</replaceable>と<replaceable>._DIR</replaceable>を探します。</para>
@@ -101,7 +111,8 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>-e</option> <replaceable>FILE</replaceable>|<replaceable>DIR</replaceable></term>
+        <term><option>-e</option>
+        <replaceable>FILE</replaceable>|<replaceable>DIR</replaceable></term>
 
         <listitem>
           <para><replaceable>FILE</replaceable>または<replaceable>DIR</replaceable>の拡張属性をダンプします。</para>
@@ -122,7 +133,6 @@
         <listitem>
           <para><replaceable>FILE</replaceable>をダンプします。FinderInfoがDirInfoであると仮定します。</para>
         </listitem>
-
       </varlistentry>
 
       <varlistentry>
@@ -131,7 +141,6 @@
         <listitem>
           <para>ヘルプを表示してから終了します。</para>
         </listitem>
-
       </varlistentry>
 
       <varlistentry>
@@ -140,9 +149,7 @@
         <listitem>
           <para>バージョンを表示してから終了します。</para>
         </listitem>
-
       </varlistentry>
-
     </variablelist>
   </refsect1>
 
@@ -152,23 +159,42 @@
     <para>FinderInfoがFileInfoなのかDirInfoなのかを検出する方法がありません。デフォルトでは、apple_dumpはそれがファイルなのかディレクトリなのか、親ディレクトリが.AppleDoubleか、ファイル名が._*か、ファイル名が.Parentかなどを調査します。</para>
 
     <para>もしオプション-eまたは-fまたは-dを設定した場合、FinderInfoを仮定し他のデータを探しません。</para>
-
   </refsect1>
 
   <refsect1>
     <title>参照</title>
 
-    <para><citerefentry><refentrytitle>ad</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-    <citerefentry><refentrytitle>getfattr</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-    <citerefentry><refentrytitle>attr</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-    <citerefentry><refentrytitle>runat</refentrytitle><manvolnum>1</manvolnum></citerefentry>,
-    <citerefentry><refentrytitle>getextattr</refentrytitle><manvolnum>8</manvolnum></citerefentry>,
-    <citerefentry><refentrytitle>lsextattr</refentrytitle><manvolnum>8</manvolnum></citerefentry></para>
+    <para><citerefentry>
+        <refentrytitle>ad</refentrytitle>
+
+        <manvolnum>1</manvolnum>
+      </citerefentry>, <citerefentry>
+        <refentrytitle>getfattr</refentrytitle>
+
+        <manvolnum>1</manvolnum>
+      </citerefentry>, <citerefentry>
+        <refentrytitle>attr</refentrytitle>
+
+        <manvolnum>1</manvolnum>
+      </citerefentry>, <citerefentry>
+        <refentrytitle>runat</refentrytitle>
+
+        <manvolnum>1</manvolnum>
+      </citerefentry>, <citerefentry>
+        <refentrytitle>getextattr</refentrytitle>
+
+        <manvolnum>8</manvolnum>
+      </citerefentry>, <citerefentry>
+        <refentrytitle>lsextattr</refentrytitle>
+
+        <manvolnum>8</manvolnum>
+      </citerefentry></para>
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/asip-status.1.xml
+++ b/doc/ja/manpages/man1/asip-status.1.xml
@@ -8,7 +8,9 @@
     <refmiscinfo class="date">06 May 2016</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
@@ -24,13 +26,18 @@
 
       <group choice="opt">
         <arg choice="plain">-4</arg>
+
         <arg choice="plain">-6</arg>
       </group>
+
       <arg choice="opt">-d</arg>
+
       <arg choice="opt">-i</arg>
+
       <arg choice="opt">-x</arg>
 
       <arg choice="plain"><replaceable>HOSTNAME</replaceable></arg>
+
       <arg choice="opt"><replaceable>PORT</replaceable></arg>
     </cmdsynopsis>
 
@@ -39,13 +46,18 @@
 
       <group choice="opt">
         <arg choice="plain">-4</arg>
+
         <arg choice="plain">-6</arg>
       </group>
+
       <arg choice="opt">-d</arg>
+
       <arg choice="opt">-i</arg>
+
       <arg choice="opt">-x</arg>
 
-      <arg choice="plain"><replaceable>HOSTNAME</replaceable>:<replaceable>PORT</replaceable></arg>
+      <arg
+      choice="plain"><replaceable>HOSTNAME</replaceable>:<replaceable>PORT</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
@@ -53,26 +65,24 @@
 
       <group choice="plain">
         <arg choice="plain">-v</arg>
+
         <arg choice="plain">-version</arg>
+
         <arg choice="plain">--version</arg>
       </group>
     </cmdsynopsis>
-
   </refsynopsisdiv>
 
   <refsect1>
     <title>説明</title>
 
-    <para><command>asip-status</command>は、<replaceable>HOSTNAME</replaceable>:<replaceable>PORT</replaceable>で示したAFPサーバにFPGetSrvrInfoリクエストを送信し、その結果を表示する。すなわち、そのサーバがAFPサービスで提供する"Machine type"、サーバ名、サポートするAFPバージョン、ユーザ認証モジュール(UAM)、AFPフラグ、サーバシグネチャ、ネットワークアドレスである。</para>
+    <para><command>asip-status</command>は、<replaceable>HOSTNAME</replaceable>:<replaceable>PORT</replaceable>で示したAFPサーバにFPGetSrvrInfoリクエストを送信し、その結果を表示する。すなわち、そのサーバがAFPサービスで提供する"Machine
+    type"、サーバ名、サポートするAFPバージョン、ユーザ認証モジュール(UAM)、AFPフラグ、サーバシグネチャ、ネットワークアドレスである。</para>
 
     <para><replaceable>PORT</replaceable>を与えない場合は、デフォルトのAFPポートである548が使われる。</para>
 
     <para>Netatalk 3.1.9以降では、 <command>asip-status</command>
     はIPv4とIPv6の両方をサポートする。どちらのIPバージョンを利用するかは、あなたのシステムが決定する。利用するIPバージョンを指定するには、-4または-6オプションを使うことができる。</para>
-
-    <note><para><command>asip-status</command> は IO::Socket::IP
-    モジュールを要求する。</para></note>
-
   </refsect1>
 
   <refsect1>
@@ -125,7 +135,6 @@
         <listitem>
           <para>バージョンを表示する。</para>
         </listitem>
-
       </varlistentry>
     </variablelist>
   </refsect1>
@@ -142,7 +151,7 @@ Machine type: Macintosh
 AFP versions: AFPVersion 1.1,AFPVersion 2.0,AFPVersion 2.1,AFP2.2
 UAMs: Cleartxt passwrd,Randnum exchange,2-Way Randnum exchange
 Volume Icon &amp; Mask: Yes
-Flags: 
+Flags:
     SupportsCopyFile
     SupportsChgPwd
     SupportsServerMessages
@@ -152,7 +161,7 @@ Flags:
 Server name: bookchan
 Signature:
 04 1d 65 23 04 1d 65 23 04 1d 65 23 04 1d 65 23  ..e#..e#..e#..e#
-                                                  
+
 Network address: 192.168.1.15:548 (IPv4 address and port)
 Network address: 65280.128 (ddp address)
 </programlisting></para>
@@ -166,7 +175,7 @@ Machine type: Netatalk3.1.9
 AFP versions: AFP2.2,AFPX03,AFP3.1,AFP3.2,AFP3.3,AFP3.4
 UAMs: DHX2,DHCAST128
 Volume Icon &amp; Mask: Yes
-Flags: 
+Flags:
     SupportsCopyFile
     SupportsServerMessages
     SupportsServerSignature
@@ -180,15 +189,16 @@ Flags:
 Server name: myserver
 Signature:
 ea 56 61 0d bf 29 36 31 fa 6a 8a 24 a8 f0 cc 1d  .Va..)61.j.$....
-                                                  
+
 Network address: [fd00:0000:0000:0000:0000:0000:0001:0160]:10548 (IPv6 address + port)
 UTF8 Servername: myserver
 </programlisting></para>
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/dbd.1.xml
+++ b/doc/ja/manpages/man1/dbd.1.xml
@@ -8,7 +8,9 @@
     <refmiscinfo class="date">12 Nov 2015</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
@@ -42,7 +44,8 @@
         <term>-c</term>
 
         <listitem>
-          <para>「<option>appledouble = v2</option>」から「<option>appledouble = ea</option>」へ変換する</para>
+          <para>「<option>appledouble = v2</option>」から「<option>appledouble =
+          ea</option>」へ変換する</para>
         </listitem>
       </varlistentry>
 
@@ -125,8 +128,9 @@
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/macusers.1.xml
+++ b/doc/ja/manpages/man1/macusers.1.xml
@@ -8,7 +8,9 @@
     <refmiscinfo class="date">13 Oct 2011</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
@@ -28,21 +30,24 @@
 
       <group choice="plain">
         <arg choice="plain">-v</arg>
+
         <arg choice="plain">-version</arg>
+
         <arg choice="plain">--version</arg>
+
         <arg choice="plain">-h</arg>
+
         <arg choice="plain">-help</arg>
+
         <arg choice="plain">--help</arg>
       </group>
-
     </cmdsynopsis>
   </refsynopsisdiv>
 
   <refsect1>
     <title>説明</title>
 
-    <para><command>macusers</command>はAFP経由で接続しているユーザをリストします。</para>
-
+    <para><command>macusers</command>はAFP経由で接続しているユーザをリストする。</para>
   </refsect1>
 
   <refsect1>
@@ -55,7 +60,6 @@
         <listitem>
           <para>バージョンを表示して終了する</para>
         </listitem>
-
       </varlistentry>
 
       <varlistentry>
@@ -64,7 +68,6 @@
         <listitem>
           <para>ヘルプを表示して終了する</para>
         </listitem>
-
       </varlistentry>
     </variablelist>
   </refsect1>
@@ -72,12 +75,17 @@
   <refsect1>
     <title>参照</title>
 
-    <para><citerefentry><refentrytitle>afpd</refentrytitle><manvolnum>8</manvolnum></citerefentry></para>
+    <para><citerefentry>
+        <refentrytitle>afpd</refentrytitle>
+
+        <manvolnum>8</manvolnum>
+      </citerefentry></para>
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/netatalk-config.1.xml
+++ b/doc/ja/manpages/man1/netatalk-config.1.xml
@@ -8,7 +8,9 @@
     <refmiscinfo class="date">10 Nov 2015</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
@@ -22,7 +24,8 @@
     <cmdsynopsis>
       <command>netatalk-config</command>
 
-      <arg choice="opt"><arg choice="plain">--prefix </arg><arg choice="opt"><replaceable>=DIR</replaceable></arg></arg>
+      <arg choice="opt"><arg choice="plain">--prefix </arg><arg
+      choice="opt"><replaceable>=DIR</replaceable></arg></arg>
 
       <arg choice="opt"><arg choice="plain">--exec_prefix </arg><arg
       choice="opt"><replaceable>=DIR</replaceable></arg></arg>
@@ -46,8 +49,9 @@
   <refsect1>
     <title>説明</title>
 
-    <para><command>netatalk-config</command> は コンパイラー・リンカのフラグを 設定・決定するためのツールである。
-    このフラグは <emphasis remap="I">netatalk</emphasis> ランタイムライブラリを使う プログラムをコンパイル・リンクするときに使われる。</para>
+    <para><command>netatalk-config</command> は コンパイラー・リンカのフラグを
+    設定・決定するためのツールである。 このフラグは <emphasis remap="I">netatalk</emphasis>
+    ランタイムライブラリを使う プログラムをコンパイル・リンクするときに使われる。</para>
   </refsect1>
 
   <refsect1>
@@ -68,7 +72,8 @@
         <term><option>--version</option></term>
 
         <listitem>
-          <para>現在インストールされている <emphasis remap="I">netatalk</emphasis> のバージョンを標準出力に表示する。</para>
+          <para>現在インストールされている <emphasis remap="I">netatalk</emphasis>
+          のバージョンを標準出力に表示する。</para>
         </listitem>
       </varlistentry>
 
@@ -76,7 +81,8 @@
         <term><option>--libs</option></term>
 
         <listitem>
-          <para><emphasis remap="I">netatalk</emphasis> ランタイムライブラリをリンクするのに必要な リンカフラグを表示する。</para>
+          <para><emphasis remap="I">netatalk</emphasis> ランタイムライブラリをリンクするのに必要な
+          リンカフラグを表示する。</para>
         </listitem>
       </varlistentry>
 
@@ -100,7 +106,8 @@
         <term><option>--cflags</option></term>
 
         <listitem>
-          <para><emphasis remap="I">netatalk</emphasis> ランタイムライブラリにリンクされるプログラムを コンパイルするのに必要なコンパイラーフラグを表示する。</para>
+          <para><emphasis remap="I">netatalk</emphasis>
+          ランタイムライブラリにリンクされるプログラムを コンパイルするのに必要なコンパイラーフラグを表示する。</para>
         </listitem>
       </varlistentry>
 
@@ -108,7 +115,8 @@
         <term><option>--macros</option></term>
 
         <listitem>
-          <para><emphasis remap="I">netatalk</emphasis> の m4 ディレクトリを表示する。</para>
+          <para><emphasis remap="I">netatalk</emphasis> の m4
+          ディレクトリを表示する。</para>
         </listitem>
       </varlistentry>
 
@@ -116,9 +124,10 @@
         <term><option>--prefix=PREFIX</option></term>
 
         <listitem>
-          <para>このオプションを指定すると、--cflags と --libs を表示する場合に、 <emphasis remap="I">netatalk</emphasis> を構築したときに使った インストール先プレフィックスではなく PREFIX を使う。
-          このオプションは --exec-prefix が指定されていない場合の 実行プレフィックスとしても使われる。
-          このオプションは --libs や --cflags オプションより 前に指定しなければならない。</para>
+          <para>このオプションを指定すると、--cflags と --libs を表示する場合に、 <emphasis
+          remap="I">netatalk</emphasis> を構築したときに使った インストール先プレフィックスではなく PREFIX
+          を使う。 このオプションは --exec-prefix が指定されていない場合の 実行プレフィックスとしても使われる。 このオプションは
+          --libs や --cflags オプションより 前に指定しなければならない。</para>
         </listitem>
       </varlistentry>
 
@@ -126,8 +135,9 @@
         <term><option>--exec_prefix=PREFIX</option></term>
 
         <listitem>
-          <para>このオプションを指定すると、--cflags と --libs を表示する場合に、 <emphasis remap="I">netatalk</emphasis> を構築したときに使った 実行プログラムのインストール先プレフィックスではなく PREFIX を使う。
-          このオプションは --libs や --cflags オプションより 前に指定しなければならない。</para>
+          <para>このオプションを指定すると、--cflags と --libs を表示する場合に、 <emphasis
+          remap="I">netatalk</emphasis> を構築したときに使った 実行プログラムのインストール先プレフィックスではなく
+          PREFIX を使う。 このオプションは --libs や --cflags オプションより 前に指定しなければならない。</para>
         </listitem>
       </varlistentry>
     </variablelist>
@@ -144,12 +154,14 @@
     both that copyright notice and this permission notice appear in supporting
     documentation.</para>
 
-    <para>この man ページは Sebastian Rittau が 2001 年に作成した <command>netatalk-config</command> に適合している。</para>
+    <para>この man ページは Sebastian Rittau が 2001 年に作成した
+    <command>netatalk-config</command> に適合している。</para>
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man5/afp.conf.5.xml
+++ b/doc/ja/manpages/man5/afp.conf.5.xml
@@ -5,10 +5,12 @@
 
     <manvolnum>5</manvolnum>
 
-    <refmiscinfo class="date">11 Apr 2023</refmiscinfo>
+    <refmiscinfo class="date">15 May 2024</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
@@ -21,7 +23,8 @@
   <refsect1>
     <title>概要</title>
 
-    <para><filename>afp.conf</filename>は<emphasis role="bold">Netatalk</emphasis> AFPファイルサーバの設定ファイルである。</para>
+    <para><filename>afp.conf</filename>は<emphasis
+    role="bold">Netatalk</emphasis> AFPファイルサーバの設定ファイルである。</para>
 
     <para>全てのAFP固有の設定とAFPボリュームの定義がこのファイルを通して行われる。</para>
   </refsect1>
@@ -42,11 +45,14 @@
 
     <para>セミコロン(<quote>;</quote>)やハッシュ文字(<quote>#</quote>)で始まるいかなる行も、空白だけの行と同様に無視される。</para>
 
-    <para><quote> <literal>\</literal> </quote>で終わるいかなる行も、通例のUNIX方式で次の行に続くことを意味する。</para>
+    <para><quote> <literal>\</literal>
+    </quote>で終わるいかなる行も、通例のUNIX方式で次の行に続くことを意味する。</para>
 
-    <para>パラメータにおいて等号の後ろに続く値は、文字列(引用符は必要ない)または真偽値である。真偽値はyes/no、1/0、true/falseで表現する。大文字と小文字の区別は真偽値では意味を持たないが、文字列では保存される。「file perm」のようないくつかの項目は数値を表す。</para>
+    <para>パラメータにおいて等号の後ろに続く値は、文字列(引用符は必要ない)または真偽値である。真偽値はyes/no、1/0、true/falseで表現する。大文字と小文字の区別は真偽値では意味を持たないが、文字列では保存される。「file
+    perm」のようないくつかの項目は数値を表す。</para>
 
-    <para>「<option>include =　<replaceable>path</replaceable></option>」というパラメータは、設定ファイルの中にもう一つの設定ファイルを組み込むことを可能にする。そのファイルはまるでその場所に書き込まれたように、そっくりそのまま組み込まれる。入れ子になった組み込みはサポートされない。</para>
+    <para>「<option>include
+    =　<replaceable>path</replaceable></option>」というパラメータは、設定ファイルの中にもう一つの設定ファイルを組み込むことを可能にする。そのファイルはまるでその場所に書き込まれたように、そっくりそのまま組み込まれる。入れ子になった組み込みはサポートされない。</para>
   </refsect1>
 
   <refsect1>
@@ -58,12 +64,13 @@
 
     <para>一つのボリュームは、アクセスを許可するディレクトリ設定と、そのサービスにおいてユーザに与えるアクセス権設定で成り立つ。ボリュームに対して<option>path</option>オプションを使って共有ディレクトリを指定しなければならない。</para>
 
-    <para><option>path</option>オプションのないボリュームセクションは、他のボリュームセクションから<option>vol preset</option>オプション経由で呼び出され、ボリュームのデフォルト値を決める<emphasis>ボリュームプリセット</emphasis>と見なされる。プリセット<emphasis>と</emphasis>ボリュームセクションの両方で指定されたオプションについては、ボリュームオプション設定がプリセットオプションを完全に上書きする。</para>
+    <para><option>path</option>オプションのないボリュームセクションは、他のボリュームセクションから<option>vol
+    preset</option>オプション経由で呼び出され、ボリュームのデフォルト値を決める<emphasis>ボリュームプリセット</emphasis>と見なされる。プリセット<emphasis>と</emphasis>ボリュームセクションの両方で指定されたオプションについては、ボリュームオプション設定がプリセットオプションを完全に上書きする。</para>
 
     <para>サーバが許可したアクセス権は、ホストシステムの特定のUNIXユーザまたはゲストユーザのアクセス権でマスクされる。サーバはホストシステムの許可以上の許可をしない。</para>
 
-    <para>以下のセクションの例は、一つのAFPボリュームを定義している。ユーザはパス<filename>/foo/bar</filename>への完全なアクセス権を持つ。 <literal>baz</literal>という共有名でアクセスできる:
-    <programlisting> [baz]
+    <para>以下のセクションの例は、一つのAFPボリュームを定義している。ユーザはパス<filename>/foo/bar</filename>への完全なアクセス権を持つ。
+    <literal>baz</literal>という共有名でアクセスできる: <programlisting> [baz]
     path = /foo/bar </programlisting></para>
   </refsect1>
 
@@ -79,7 +86,10 @@
     <refsect2>
       <title>[Homes]セクション</title>
 
-      <para>このセクションはUNIXサーバ側のユーザのホームディレクトリを共有できるようにする。オプションの<option>path</option>パラメータを指定すると、ユーザのホームディレクトリ全体ではなく、サブディレクトリ<option>path</option>が共有される。<option>basedir regex</option>オプションを定義する必要がある。これはホームディレクトリの親ディレクトリにマッチする正規表現である。(H)の印がついているパラメータはこのボリュームセクション用である。オプションパラメータ<option>home name</option>はAFPボリューム名を変更するのに使うものであり、デフォルトは<emphasis>$u's home</emphasis>である。下の「変数置換」の項を見よ。</para>
+      <para>このセクションはUNIXサーバ側のユーザのホームディレクトリを共有できるようにする。オプションの<option>path</option>パラメータを指定すると、ユーザのホームディレクトリ全体ではなく、サブディレクトリ<option>path</option>が共有される。<option>basedir
+      regex</option>オプションを定義する必要がある。これはホームディレクトリの親ディレクトリにマッチする正規表現である。(H)の印がついているパラメータはこのボリュームセクション用である。オプションパラメータ<option>home
+      name</option>はAFPボリューム名を変更するのに使うものであり、デフォルトは<emphasis>$u's
+      home</emphasis>である。下の「変数置換」の項を見よ。</para>
 
       <para>以下の例でこれを解説する。全てのユーザのホームディレクトリは<filename>/home</filename>の下にある:
       <programlisting> [Homes]
@@ -87,7 +97,8 @@
       basedir regex = /home</programlisting>
       ユーザ<emphasis>john</emphasis>について、<filename>/home/john/afp-data</filename>というパスがAFPホームボリュームになる。</para>
 
-      <para><option>basedir regex</option>ががシンボリックリンクを含む場合、正規化した絶対パスを設定してください。<filename>/home</filename>が<filename>/usr/home</filename>にリンクしているとき:
+      <para><option>basedir
+      regex</option>ががシンボリックリンクを含む場合、正規化した絶対パスを設定してください。<filename>/home</filename>が<filename>/usr/home</filename>にリンクしているとき:
       <programlisting> [Homes]
       basedir regex = /usr/home</programlisting></para>
     </refsect2>
@@ -98,7 +109,8 @@
 
     <para>パラメータはセクション固有の属性を定義する。</para>
 
-    <para>いくつかのパラメータは[Global]セクションに固有のものである(たとえば<emphasis>log type</emphasis>)。それ以外は全てボリュームセクションのみに許される。(<emphasis>G</emphasis>)はパラメータが[Global]セクション固有であることを示す。(<emphasis>V</emphasis>)はボリューム固有のセクションで指定できることを示す。</para>
+    <para>いくつかのパラメータは[Global]セクションに固有のものである(たとえば<emphasis>log
+    type</emphasis>)。それ以外は全てボリュームセクションのみに許される。(<emphasis>G</emphasis>)はパラメータが[Global]セクション固有であることを示す。(<emphasis>V</emphasis>)はボリューム固有のセクションで指定できることを示す。</para>
   </refsect1>
 
   <refsect1>
@@ -221,7 +233,8 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>認証時にユーザ名に@DOMAINを追加する。Active Directory環境で有用。さもなくば、完全な文字列user@domainで参加するユーザを要求するだろう。</para>
+            <para>認証時にユーザ名に@DOMAINを追加する。Active
+            Directory環境で有用。さもなくば、完全な文字列user@domainで参加するユーザを要求するだろう。</para>
           </listitem>
         </varlistentry>
 
@@ -230,7 +243,11 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>例えば"<option>admin auth user = root</option>"を指定すると、通常ユーザのログインが失敗したときにafpdは必ず指定した<option>admin auth user</option>として認証を試みる。これが成功した場合、元の接続ユーザとして通常のセッションが確立される。言い換えると、あなたが<option>admin auth user</option>のパスワードを知っている場合、如何なる他のユーザとしてでも認証できる。</para>
+            <para>例えば"<option>admin auth user =
+            root</option>"を指定すると、通常ユーザのログインが失敗したときにafpdは必ず指定した<option>admin
+            auth
+            user</option>として認証を試みる。これが成功した場合、元の接続ユーザとして通常のセッションが確立される。言い換えると、あなたが<option>admin
+            auth user</option>のパスワードを知っている場合、如何なる他のユーザとしてでも認証できる。</para>
           </listitem>
         </varlistentry>
 
@@ -311,7 +328,8 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>スペースまたはカンマで区切られたUAMの一覧。(デフォルトは「uams_dhx.so uams_dhx2.so」)</para>
+            <para>スペースまたはカンマで区切られたUAMの一覧。(デフォルトは「uams_dhx.so
+            uams_dhx2.so」)</para>
 
             <para>最も一般的に使われるUAMは以下の通り:</para>
 
@@ -328,7 +346,8 @@
                 <term>uams_clrtxt.so</term>
 
                 <listitem>
-                  <para>(uams_pam.soまたはuams_passwd.so) 暗号化なしで転送されたパスワードによるログインを許可する。(時代遅れ)</para>
+                  <para>(uams_pam.soまたはuams_passwd.so)
+                  暗号化なしで転送されたパスワードによるログインを許可する。(時代遅れ)</para>
                 </listitem>
               </varlistentry>
 
@@ -336,8 +355,9 @@
                 <term>uams_randnum.so</term>
 
                 <listitem>
-                  <para>認証のための乱数および双方向乱数交換を許可する (パスワードを含んだファイル、つまり@pkgconfdir@/afppasswdファイルか"<option>passwd file</option>"で指定したファイルのどちらかが必要)。詳細は
-                  <citerefentry>
+                  <para>認証のための乱数および双方向乱数交換を許可する
+                  (パスワードを含んだファイル、つまりafppasswdファイルか"<option>passwd
+                  file</option>"で指定したファイルのどちらかが必要)。詳細は <citerefentry>
                       <refentrytitle>afppasswd</refentrytitle>
 
                       <manvolnum>1</manvolnum>
@@ -349,7 +369,8 @@
                 <term>uams_dhx.so</term>
 
                 <listitem>
-                  <para>(uams_dhx_pam.soまたはuams_dhx_passwd.so) 認証のためのDiffie-Hellman交換(DHX)を許可する。</para>
+                  <para>(uams_dhx_pam.soまたはuams_dhx_passwd.so)
+                  認証のためのDiffie-Hellman交換(DHX)を許可する。</para>
                 </listitem>
               </varlistentry>
 
@@ -357,7 +378,8 @@
                 <term>uams_dhx2.so</term>
 
                 <listitem>
-                  <para>(uams_dhx2_pam.soまたはuams_dhx2_passwd.so) 認証のためのDiffie-Hellman交換2(DHX2)を許可する。</para>
+                  <para>(uams_dhx2_pam.soまたはuams_dhx2_passwd.so)
+                  認証のためのDiffie-Hellman交換2(DHX2)を許可する。</para>
                 </listitem>
               </varlistentry>
 
@@ -377,7 +399,7 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>このサーバのためのUAMのデフォルトパスを設定する(デフォルトは@libdir@/netatalk)。</para>
+            <para>このサーバのためのUAMのデフォルトパスを設定する。</para>
           </listitem>
         </varlistentry>
       </variablelist>
@@ -386,11 +408,16 @@
     <refsect2>
       <title>文字セットオプション</title>
 
-      <para>OS XでAppleはAFP3プロトコルを導入した。大きな変更の一つは、AFP3は分解済UTF-8 (UTF8-MAC)としてエンコードされたUnicode名を用いることである。以前のAFP及びOSバージョンはMacRomanやMacCentralEuropeといった文字セットを用いた。</para>
+      <para>OS XでAppleはAFP3プロトコルを導入した。大きな変更の一つは、AFP3は分解済UTF-8
+      (UTF8-MAC)としてエンコードされたUnicode名を用いることである。以前のAFP及びOSバージョンはMacRomanやMacCentralEuropeといった文字セットを用いた。</para>
 
-      <para>AFP3と古いクライアントに同時に応対できるように、<command>afpd</command>はUTF-8とMac文字セットの間の変換ができる必要がある。OS Xですら部分的にMac文字セットに依存している。AFP3以前のクライアントが使うコードページを<command>afpd</command>が検出する方法はないので、あなたは<option>mac charset</option>オプションを使ってそれを指定しなけらばならない。デフォルトはMacRomanであり、多くの西欧ユーザにとって良いであろう。</para>
+      <para>AFP3と古いクライアントに同時に応対できるように、<command>afpd</command>はUTF-8とMac文字セットの間の変換ができる必要がある。OS
+      Xですら部分的にMac文字セットに依存している。AFP3以前のクライアントが使うコードページを<command>afpd</command>が検出する方法はないので、あなたは<option>mac
+      charset</option>オプションを使ってそれを指定しなけらばならない。デフォルトはMacRomanであり、多くの西欧ユーザにとって良いであろう。</para>
 
-      <para><command>afpd</command>はUNIXオペレーティングシステムとも相互に作用する必要があるので、UTF8-MAC/Mac文字セットからUNIX文字セットへ変換できる必要がある。デフォルトで<command>afpd</command>は<emphasis>UTF8</emphasis>を用いる。<option>unix charset</option>オプションを使ってUNIX文字セットを設定できる。<command>afpd</command>のための設定ファイルで拡張文字セットを使う場合、端末が<option>unix charset</option>に一致することを確認してください。</para>
+      <para><command>afpd</command>はUNIXオペレーティングシステムとも相互に作用する必要があるので、UTF8-MAC/Mac文字セットからUNIX文字セットへ変換できる必要がある。デフォルトで<command>afpd</command>は<emphasis>UTF8</emphasis>を用いる。<option>unix
+      charset</option>オプションを使ってUNIX文字セットを設定できる。<command>afpd</command>のための設定ファイルで拡張文字セットを使う場合、端末が<option>unix
+      charset</option>に一致することを確認してください。</para>
 
       <variablelist>
         <varlistentry>
@@ -398,7 +425,9 @@
           <type>(G)/(V)</type></term>
 
           <listitem>
-            <para>Macクライアントの文字セット、例えば<emphasis>MAC_ROMAN</emphasis>を指定する。これは文字列やファイル名をOS9やClassic環境のクライアントコードページに変換するために用いられる。すなわち認証やAFPメッセージ(SIGUSR2 messaging)である。これはボリュームの<option>mac charset</option>のデフォルトにもなる。デフォルトは<emphasis>MAC_ROMAN</emphasis>。</para>
+            <para>Macクライアントの文字セット、例えば<emphasis>MAC_ROMAN</emphasis>を指定する。これは文字列やファイル名をOS9やClassic環境のクライアントコードページに変換するために用いられる。すなわち認証やAFPメッセージ(SIGUSR2
+            messaging)である。これはボリュームの<option>mac
+            charset</option>のデフォルトにもなる。デフォルトは<emphasis>MAC_ROMAN</emphasis>。</para>
           </listitem>
         </varlistentry>
 
@@ -416,7 +445,8 @@
           <type>(G)/(V)</type></term>
 
           <listitem>
-            <para>ボリュームのファイルシステムのエンコーディングを指定する。デフォルトでは<option>unix charset</option>と同じである。</para>
+            <para>ボリュームのファイルシステムのエンコーディングを指定する。デフォルトでは<option>unix
+            charset</option>と同じである。</para>
           </listitem>
         </varlistentry>
       </variablelist>
@@ -431,7 +461,7 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>このサーバの乱数UAMパスワードファイルのパスを設定する (デフォルトは@pkgconfdir@/afppasswd)。</para>
+            <para>このサーバの乱数UAMパスワードファイルのパスを設定する。</para>
           </listitem>
         </varlistentry>
 
@@ -455,21 +485,24 @@
           <emphasis>no</emphasis>) <type>(G)</type></term>
 
           <listitem>
-            <para>古いMac OS Xクライアント(10.3.3から10.4)にSSHでトンネルしたAFP接続を魔法のように自動的に確立させる。このオプションを設定した場合、クライアントのFPGetSrvrInfo要求へのサーバの返答は追加エントリを含む。これはクライアントの設定と<citerefentry>
+            <para>古いMac OS
+            Xクライアント(10.3.3から10.4)にSSHでトンネルしたAFP接続を魔法のように自動的に確立させる。このオプションを設定した場合、クライアントのFPGetSrvrInfo要求へのサーバの返答は追加エントリを含む。これはクライアントの設定と<citerefentry>
                 <refentrytitle>sshd</refentrytitle>
 
                 <manvolnum>8</manvolnum>
               </citerefentry>が正しく設定されて動作するサーバ上で実行中であるかに依存する。</para>
 
             <note>
-              <para>SSHを介した全体を暗号化するAFP接続はサーバの負荷を著しく増加させるので、このオプションの設定は推奨しない。一方、バージョン10.3.4より前のMacOS Xにおけるこの機能のAppleクライアント側の実装はセキュリティ欠陥があった。</para>
+              <para>SSHを介した全体を暗号化するAFP接続はサーバの負荷を著しく増加させるので、このオプションの設定は推奨しない。一方、バージョン10.3.4より前のMacOS
+              Xにおけるこの機能のAppleクライアント側の実装はセキュリティ欠陥があった。</para>
             </note>
           </listitem>
         </varlistentry>
 
         <varlistentry>
           <term>afp interfaces = <replaceable>name [name ...]</replaceable>
-            <type>(G)</type></term>
+          <type>(G)</type></term>
+
           <listitem>
             <para>サーバがリッスンするネットワークインターフェースを指定する。デフォルトではシステムの最初のIPアドレスを宣伝するが、入ってくる如何なる要求もリッスンする。</para>
           </listitem>
@@ -480,8 +513,11 @@
           ...]</replaceable> <type>(G)</type></term>
 
           <listitem>
-            <para>サーバが宣伝<emphasis role="bold">および</emphasis>リッスンするIPアドレスを指定する。デフォルトではシステムの最初のIPアドレスを宣伝するが、入ってくる如何なる要求もリッスンする。ネットワークアドレスはIPv4のドット付き10進数フォーマットやIPv6の16進数フォーマットのどちらでも指定してよい。</para>
-            <para>IPv6 address + portの組み合わせは角かっこを使ったフォーマット[IPv6]:portのURLを使わなければならない。</para>
+            <para>サーバが宣伝<emphasis
+            role="bold">および</emphasis>リッスンするIPアドレスを指定する。デフォルトではシステムの最初のIPアドレスを宣伝するが、入ってくる如何なる要求もリッスンする。ネットワークアドレスはIPv4のドット付き10進数フォーマットやIPv6の16進数フォーマットのどちらでも指定してよい。</para>
+
+            <para>IPv6 address +
+            portの組み合わせは角かっこを使ったフォーマット[IPv6]:portのURLを使わなければならない。</para>
           </listitem>
         </varlistentry>
 
@@ -490,7 +526,8 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>異なるTCPポートをAFPに使わせる。デフォルトは548である。<option>afp listen</option>オプションで何も指定しなかった場合も適用されたデフォルトポートを設定する。</para>
+            <para>異なるTCPポートをAFPに使わせる。デフォルトは548である。<option>afp
+            listen</option>オプションで何も指定しなかった場合も適用されたデフォルトポートを設定する。</para>
           </listitem>
         </varlistentry>
 
@@ -499,7 +536,8 @@
           address[:port] ...]</replaceable> <type>(G)</type></term>
 
           <listitem>
-            <para>CNIDサーバがリッスンするIPアドレスを指定する。デフォルトは<emphasis role="bold">localhost:4700</emphasis>である。</para>
+            <para>CNIDサーバがリッスンするIPアドレスを指定する。デフォルトは<emphasis
+            role="bold">localhost:4700</emphasis>である。</para>
           </listitem>
         </varlistentry>
 
@@ -517,7 +555,11 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>DSI/TCP先読みバッファのサイズを決定する係数。デフォルトは12である。これにDSI server quantum (デフォルトは1MiB)をかけるとバッファサイズになる。この値を増やすと速いローカルネットワークでのボリュームからボリュームへのコピーのスループットが増えるかもしれない。 <emphasis>注記</emphasis>: このバッファはafpdの子プロセス毎に割り当てられるので、大きな値を指定すると大量のメモリが食われる (バッファサイズ * クライアント数)。</para>
+            <para>DSI/TCP先読みバッファのサイズを決定する係数。デフォルトは12である。これにDSI server quantum
+            (デフォルトは1MiB)をかけるとバッファサイズになる。この値を増やすと速いローカルネットワークでのボリュームからボリュームへのコピーのスループットが増えるかもしれない。
+            <emphasis>注記</emphasis>:
+            このバッファはafpdの子プロセス毎に割り当てられるので、大きな値を指定すると大量のメモリが食われる (バッファサイズ *
+            クライアント数)。</para>
           </listitem>
         </varlistentry>
 
@@ -526,7 +568,9 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>完全修飾ドメイン名をオプションのポート番号と共に指定する。サーバがこれを解決できない場合は破棄される。AppleShare clients 3.8.3以前はこのオプションを評価しない。このオプションはデフォルトで無効である。これによりクライアント側は名前解決を二段階踏むことになるので注意して使ってください。afpdはこのname:portの組み合わせを宣伝しますが自動的にはリッスンしないことにも注意してください。</para>
+            <para>完全修飾ドメイン名をオプションのポート番号と共に指定する。サーバがこれを解決できない場合は破棄される。AppleShare
+            clients
+            3.8.3以前はこのオプションを評価しない。このオプションはデフォルトで無効である。これによりクライアント側は名前解決を二段階踏むことになるので注意して使ってください。afpdはこのname:portの組み合わせを宣伝しますが自動的にはリッスンしないことにも注意してください。</para>
           </listitem>
         </varlistentry>
 
@@ -535,7 +579,8 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>宣伝用のIPアドレスを決定するため、ホスト名の呼出結果の代わりにこれを用いる。従って、このホスト名から宣伝用IPアドレスが解決されるようになる。これはリスニングには使われないし、<option>afp listen</option>によっても上書きされてしまう。</para>
+            <para>宣伝用のIPアドレスを決定するため、ホスト名の呼出結果の代わりにこれを用いる。従って、このホスト名から宣伝用IPアドレスが解決されるようになる。これはリスニングには使われないし、<option>afp
+            listen</option>によっても上書きされてしまう。</para>
           </listitem>
         </varlistentry>
 
@@ -553,7 +598,8 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>これはDSI server quantumを指定する。デフォルト値は0x100000 (1MiB)である。最大値は0xFFFFFFFFFであり最小値は32000である。範囲外の値を指定した場合、デフォルト値が設定される。自分が何をしようとしているか確信がない限り、この値を変更しないでください。</para>
+            <para>これはDSI server quantumを指定する。デフォルト値は0x100000
+            (1MiB)である。最大値は0xFFFFFFFFFであり最小値は32000である。範囲外の値を指定した場合、デフォルト値が設定される。自分が何をしようとしているか確信がない限り、この値を変更しないでください。</para>
           </listitem>
         </varlistentry>
 
@@ -613,7 +659,6 @@
           </listitem>
         </varlistentry>
 
-
         <varlistentry>
           <term>zeroconf = <replaceable>BOOLEAN</replaceable> (デフォルト:
           <emphasis>yes</emphasis>) <type>(G)</type></term>
@@ -656,26 +701,35 @@
           <type>(H)</type></term>
 
           <listitem>
-            <para>ユーザホームの親ディレクトリにマッチする正規表現。<option>basedir regex</option>がシンボリックリンクを含む場合、正規化した絶対パスを設定しなければならない。簡単なケースだとこれは単に一つのパスである。つまり<option>basedir regex = /home</option>である。</para>
+            <para>ユーザホームの親ディレクトリにマッチする正規表現。<option>basedir
+            regex</option>がシンボリックリンクを含む場合、正規化した絶対パスを設定しなければならない。簡単なケースだとこれは単に一つのパスである。つまり<option>basedir
+            regex = /home</option>である。</para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
-          <term>chmod request = <replaceable>preserve (デフォルト) | ignore | simple</replaceable>
-          <type>(G)/(V)</type></term>
+          <term>chmod request = <replaceable>preserve (デフォルト) | ignore |
+          simple</replaceable> <type>(G)/(V)</type></term>
 
           <listitem>
             <para>ACLに対応する高度なパーミッション制御。</para>
 
             <itemizedlist>
-              <listitem><para> <option>ignore</option> - UNIXのchmod()要求を完全に無視する。新規作成を上書きして親ディレクトリのACL継承に完全コントロールさせるためにこのオプションを使う。</para></listitem>
-              <listitem><para>
-                <option>preserve</option> - 名前付きユーザとグループのためのZFS ACEやPOSIX ACLグループマスクを維持する
-		      </para></listitem>
-              <listitem><para>
-		<option>simple</option> -  いかなる追加の手順も踏まず、単に要求通りにchmod()する
-		      </para></listitem>
-		    </itemizedlist>
+              <listitem>
+                <para><option>ignore</option> -
+                UNIXのchmod()要求を完全に無視する。新規作成を上書きして親ディレクトリのACL継承に完全コントロールさせるためにこのオプションを使う。</para>
+              </listitem>
+
+              <listitem>
+                <para><option>preserve</option> - 名前付きユーザとグループのためのZFS
+                ACEやPOSIX ACLグループマスクを維持する</para>
+              </listitem>
+
+              <listitem>
+                <para><option>simple</option> -
+                いかなる追加の手順も踏まず、単に要求通りにchmod()する</para>
+              </listitem>
+            </itemizedlist>
           </listitem>
         </varlistentry>
 
@@ -689,8 +743,8 @@
         </varlistentry>
 
         <varlistentry>
-          <term>cnid mysql host = <replaceable>MySQL server address</replaceable>
-          <type>(G)</type></term>
+          <term>cnid mysql host = <replaceable>MySQL server
+          address</replaceable> <type>(G)</type></term>
 
           <listitem>
             <para>mysql CNIDバックエンド利用時のMySQLサーバの名前またはアドレス。</para>
@@ -729,7 +783,8 @@
           <type>(G)/(V)</type></term>
 
           <listitem>
-            <para>cnid_metadサーバのIPアドレスとポート番号を指定する。CNID dbdバックエンドのために必要。デフォルトはlocalhost:4700。ネットワークアドレスはIPv4のドット分割10進数フォーマットでもよいし、IPv6の16進数フォーマットでもよい。</para>
+            <para>cnid_metadサーバのIPアドレスとポート番号を指定する。CNID
+            dbdバックエンドのために必要。デフォルトはlocalhost:4700。ネットワークアドレスはIPv4のドット分割10進数フォーマットでもよいし、IPv6の16進数フォーマットでもよい。</para>
           </listitem>
         </varlistentry>
 
@@ -738,7 +793,9 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>Spotlight機能が使用するdbus-daemon実行ファイルのパスを設定する。デフォルト値 <filename>[@DBUS_DAEMON_PATH@]</filename> はnetatalkのビルド時に決定される。</para>
+            <para>Spotlight機能が使用するdbus-daemon実行ファイルのパスを設定する。デフォルト値
+            <filename>[@DBUS_DAEMON_PATH@]</filename>
+            はnetatalkのビルド時に決定される。</para>
           </listitem>
         </varlistentry>
 
@@ -758,14 +815,14 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>ファイル拡張子とタイプ/クリエータのマッピングを定義するファイルのパスを設定する。(デフォルトは@pkgconfdir@/extmap.confである)</para>
+            <para>ファイル拡張子とタイプ/クリエータのマッピングを定義するファイルのパスを設定する。</para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
           <term>force xattr with sticky bit =
-          <replaceable>BOOLEAN</replaceable> (デフォルト:
-          <emphasis>no</emphasis>) <type>(G/V)</type></term>
+          <replaceable>BOOLEAN</replaceable> (デフォルト: <emphasis>no</emphasis>)
+          <type>(G/V)</type></term>
 
           <listitem>
             <para>ディレクトリへの書き込み権限があったとしても、スティッキービット設定を使ってメタデータ(拡張属性)を書き込むことに失敗するかもしれない。なぜなら、スティッキービットが設定されている場合、所有者だけが拡張属性への書き込みを許されるからである。</para>
@@ -795,12 +852,16 @@
         </varlistentry>
 
         <varlistentry>
-          <term>ignored attributes = <replaceable>all | nowrite | nodelete | norename</replaceable>
-          <type>(G)/(V)</type></term>
+          <term>ignored attributes = <replaceable>all | nowrite | nodelete |
+          norename</replaceable> <type>(G)/(V)</type></term>
 
           <listitem>
             <para>サーバが無視すべきファイルとディレクトリの属性を設定する。<option>all</option>はオプション全部という意味である。</para>
-            <para>OS Xにおいて、Finderがファイル/ディレクトリのロックを設定する場合、またはターミナルでBSD uchgフラグを設定する場合、3つの属性が全て使われる。従って、Finderロック/BSD uchgフラグを無視する目的で<emphasis>ignored attributes = all</emphasis>の設定を追加してください。</para>
+
+            <para>OS Xにおいて、Finderがファイル/ディレクトリのロックを設定する場合、またはターミナルでBSD
+            uchgフラグを設定する場合、3つの属性が全て使われる。従って、Finderロック/BSD
+            uchgフラグを無視する目的で<emphasis>ignored attributes =
+            all</emphasis>の設定を追加してください。</para>
           </listitem>
         </varlistentry>
 
@@ -809,7 +870,8 @@
           <type>(G)/(V)</type></term>
 
           <listitem>
-            <para>クライアントがサーバにログオンしたときに表示されるメッセージを設定する。メッセージは<option>unix charset</option>で書く。拡張文字が使える。</para>
+            <para>クライアントがサーバにログオンしたときに表示されるメッセージを設定する。メッセージは<option>unix
+            charset</option>で書く。拡張文字が使える。</para>
           </listitem>
         </varlistentry>
 
@@ -818,9 +880,26 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>クライアント上に表示されるアイコンモデルを指定する。デフォルトではオフになっている。netatalkがZeroconfをサポートしなければならないことに注意してください。例: RackMac (same as Xserve), PowerBook, PowerMac,
-            Macmini, iMac, MacBook, MacBookPro, MacBookAir, MacPro,
-            AppleTV1,1, AirPort.</para>
+            <para>クライアント上に表示されるアイコンモデルを指定する。デフォルトではクライアント Mac
+            に任せること。netatalkがZeroconfをサポートしなければならないことに注意してください。例:</para>
+
+            <itemizedlist>
+              <listitem>
+                <para><option>Laptop</option></para>
+              </listitem>
+
+              <listitem>
+                <para><option>RackMount</option></para>
+              </listitem>
+
+              <listitem>
+                <para><option>Tower</option></para>
+              </listitem>
+            </itemizedlist>
+
+            <para>macOSは認識しているモデルコードは
+            <filename>/System/Library/CoreServices/CoreTypes.bundle/Contents/Info.plist
+            </filename> を参照すれば確認できる。(macOS 14 Sonoma の場合)</para>
           </listitem>
         </varlistentry>
 
@@ -828,24 +907,24 @@
           <term>signature = &lt;text&gt; <type>(G)</type></term>
 
           <listitem>
-            <para>サーバシグネチャを指定する。最大長は16文字である。このオプションは障害隔離などを提供するクラスタ環境において有用である。デフォルトでは、afpdは自動的にシグネチャを(乱数を元に)生成し、それを<filename>@localstatedir@/netatalk/afp_signature.conf</filename>に保存する。asip-status(1)も見よ。</para>
+            <para>サーバシグネチャを指定する。最大長は16文字である。このオプションは障害隔離などを提供するクラスタ環境において有用である。デフォルトでは、afpdは自動的にシグネチャを(乱数を元に)生成し、それを<filename>afp_signature.conf</filename>に保存する。asip-status(1)も見よ。</para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
           <term>solaris share reservations =
-          <replaceable>BOOLEAN</replaceable> (デフォルト:
-          <emphasis>yes</emphasis>) <type>(G)</type></term>
+          <replaceable>BOOLEAN</replaceable> (デフォルト: <emphasis>yes</emphasis>)
+          <type>(G)</type></term>
 
           <listitem>
-            <para>Solarisの共有予約を利用する。Solaris CIFSサーバもこれを利用するので、ロックを統一したマルチプロトコルサーバを形成する。</para>
+            <para>Solarisの共有予約を利用する。Solaris
+            CIFSサーバもこれを利用するので、ロックを統一したマルチプロトコルサーバを形成する。</para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
-          <term>sparql results limit =
-          <replaceable>NUMBER</replaceable> (デフォルト:
-          <emphasis>無制限</emphasis>) <type>(G)</type></term>
+          <term>sparql results limit = <replaceable>NUMBER</replaceable>
+          (デフォルト: <emphasis>無制限</emphasis>) <type>(G)</type></term>
 
           <listitem>
             <para>SPARQLクエリを介したTrackerからのクエリ結果の数に制限を課す。</para>
@@ -853,29 +932,28 @@
         </varlistentry>
 
         <varlistentry>
-          <term>spotlight =
-          <replaceable>BOOLEAN</replaceable> (デフォルト:
+          <term>spotlight = <replaceable>BOOLEAN</replaceable> (デフォルト:
           <emphasis>no</emphasis>) <type>(G)/(V)</type></term>
 
           <listitem>
-            <para>Spotlight検索を有効にするかどうか。注記: 一度グローバルオプションで有効にすると、有効でないボリュームは全く検索できない。<emphasis>dbus daemon</emphasis>オプションも見よ。</para>
+            <para>Spotlight検索を有効にするかどうか。注記:
+            一度グローバルオプションで有効にすると、有効でないボリュームは全く検索できない。<emphasis>dbus
+            daemon</emphasis>オプションも見よ。</para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
-          <term>spotlight attributes =
-          <replaceable>カンマで分割した文字列</replaceable> (デフォルト:
-          <emphasis>空</emphasis>) <type>(G)</type></term>
+          <term>spotlight attributes = <replaceable>カンマで分割した文字列</replaceable>
+          (デフォルト: <emphasis>空</emphasis>) <type>(G)</type></term>
 
           <listitem>
-            <para>Spotlight検索で使うことを許された属性のリスト。デフォルトでは全ての属性を検索できるが、文字列を渡せば属性をその文字列の要素に制限できる。 例:
-	    <programlisting>spotlight attributes = *,kMDItemTextContent</programlisting></para>
+            <para>Spotlight検索で使うことを許された属性のリスト。デフォルトでは全ての属性を検索できるが、文字列を渡せば属性をその文字列の要素に制限できる。
+            例: <programlisting>spotlight attributes = *,kMDItemTextContent</programlisting></para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
-          <term>spotlight expr =
-          <replaceable>BOOLEAN</replaceable> (デフォルト:
+          <term>spotlight expr = <replaceable>BOOLEAN</replaceable> (デフォルト:
           <emphasis>yes</emphasis>) <type>(G)</type></term>
 
           <listitem>
@@ -884,8 +962,7 @@
         </varlistentry>
 
         <varlistentry>
-          <term>start dbus =
-          <replaceable>BOOLEAN</replaceable> (デフォルト:
+          <term>start dbus = <replaceable>BOOLEAN</replaceable> (デフォルト:
           <emphasis>yes</emphasis>) <type>(G)</type></term>
 
           <listitem>
@@ -894,12 +971,13 @@
         </varlistentry>
 
         <varlistentry>
-          <term>start tracker =
-          <replaceable>BOOLEAN</replaceable> (デフォルト:
+          <term>start tracker = <replaceable>BOOLEAN</replaceable> (デフォルト:
           <emphasis>yes</emphasis>) <type>(G)</type></term>
 
           <listitem>
-            <para>"<command>tracker daemon -s</command>"によってTrackerを開始するかどうか。古いTrackerの場合、"<command>tracker-control -s</command>"が代わりに使われる。</para>
+            <para>"<command>tracker daemon
+            -s</command>"によってTrackerを開始するかどうか。古いTrackerの場合、"<command>tracker-control
+            -s</command>"が代わりに使われる。</para>
           </listitem>
         </varlistentry>
 
@@ -917,7 +995,7 @@
           <type>(G)/(V)</type></term>
 
           <listitem>
-            <para>データベース情報をpathに格納するように設定する。ボリュームが読み込み専用だったとしても、書き込み可能な場所を設定しなければならない。デフォルトは<filename>@localstatedir@/netatalk/CNID/$v/</filename>である。</para>
+            <para>データベース情報をpathに格納するように設定する。ボリュームが読み込み専用だったとしても、書き込み可能な場所を設定しなければならない。</para>
           </listitem>
         </varlistentry>
 
@@ -926,7 +1004,8 @@
           <emphasis>no</emphasis>) <type>(G)</type></term>
 
           <listitem>
-            <para>このオプションをtrueに設定するとNetatalk 2の動作に立ち返る。つまり、それぞれの共有のボリュームルートの下にある.AppleDBというフォルダにCNIDデータベースを格納する。</para>
+            <para>このオプションをtrueに設定するとNetatalk
+            2の動作に立ち返る。つまり、それぞれの共有のボリュームルートの下にある.AppleDBというフォルダにCNIDデータベースを格納する。</para>
           </listitem>
         </varlistentry>
 
@@ -935,12 +1014,13 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>Mac OS XのためのUTF8-MACボリューム名の最大長。ハングルはこれに特に敏感なので注意してください。</para>
+            <para>Mac OS
+            XのためのUTF8-MACボリューム名の最大長。ハングルはこれに特に敏感なので注意してください。</para>
 
             <para><programlisting>73: Mac OS X 10.1の制限
 80: Mac OS X 10.4/10.5の制限 (デフォルト)
-255: 最近のMac OS Xの制限</programlisting>
-            Mac OS 9以前はこれに影響されない。なぜならMac文字セットのボリューム名は常に27バイト制限がある。</para>
+255: 最近のMac OS Xの制限</programlisting> Mac OS
+            9以前はこれに影響されない。なぜならMac文字セットのボリューム名は常に27バイト制限がある。</para>
           </listitem>
         </varlistentry>
 
@@ -949,7 +1029,8 @@
           <type>(G)/(V)</type></term>
 
           <listitem>
-            <para>([Global]セクションで設定したときは) 全ボリューム、(ボリュームセクションで設定したときは)そのボリュームのオプション初期設定となるセクションの<option>name</option>を使う。</para>
+            <para>([Global]セクションで設定したときは)
+            全ボリューム、(ボリュームセクションで設定したときは)そのボリュームのオプション初期設定となるセクションの<option>name</option>を使う。</para>
           </listitem>
         </varlistentry>
 
@@ -958,7 +1039,8 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>登録サービスをユニークに表した、人間が読めるnameを設定する。このzeroconf nameは最大長63オクテット（バイト）のUTF-8で宣伝される。netatalkがZeroconfをサポートしなければならないことに注意してください。</para>
+            <para>登録サービスをユニークに表した、人間が読めるnameを設定する。このzeroconf
+            nameは最大長63オクテット（バイト）のUTF-8で宣伝される。netatalkがZeroconfをサポートしなければならないことに注意してください。</para>
           </listitem>
         </varlistentry>
       </variablelist>
@@ -985,7 +1067,8 @@
           ...]</replaceable> <type>(G)</type></term>
 
           <listitem>
-            <para>与えられた<option>log level</option>までのログレベルのメッセージを出力するように設定する。</para>
+            <para>与えられた<option>log
+            level</option>までのログレベルのメッセージを出力するように設定する。</para>
 
             <para>デフォルトではafpdは<option>default:note</option>に相当する設定でsyslogに出力する。</para>
 
@@ -1007,20 +1090,47 @@
           <primary>FCE</primary>
         </indexterm>)</title>
 
-	<para>Netatalk には素敵なファイルシステム変更イベント機構が含まれている．ここで， afpd プロセスは，なにがしかのファイルシステムイベントについて，関心を寄せているリスナーに， UDP ネットワークデータグラムで通知する．</para>
+      <para>Netatalk には素敵なファイルシステム変更イベント機構が含まれている。ここで、afpd
+      プロセスは、なにがしかのファイルシステムイベントについて、関心を寄せているリスナーに、UDP ネットワークデータグラムで通知する。</para>
 
       <para>以下の FCE イベントが定義されている:</para>
 
       <itemizedlist>
-        <listitem><para>ファイル変更 (<option>fmod</option>)</para></listitem>
-        <listitem><para>ファイル削除 (<option>fdel</option>)</para></listitem>
-        <listitem><para>ディレクトリ削除 (<option>ddel</option>)</para></listitem>
-        <listitem><para>ファイル作成 (<option>fcre</option>)</para></listitem>
-        <listitem><para>ディレクトリ作成 (<option>dcre</option>)</para></listitem>
-        <listitem><para>ファイル移動または名前変更 (<option>fmov</option>)</para></listitem>
-        <listitem><para>ディレクトリ移動または名前変更 (<option>dmov</option>)</para></listitem>
-        <listitem><para>ログイン (<option>login</option>)</para></listitem>
-        <listitem><para>ログアウト (<option>logout</option>)</para></listitem>
+        <listitem>
+          <para>ファイル変更 (<option>fmod</option>)</para>
+        </listitem>
+
+        <listitem>
+          <para>ファイル削除 (<option>fdel</option>)</para>
+        </listitem>
+
+        <listitem>
+          <para>ディレクトリ削除 (<option>ddel</option>)</para>
+        </listitem>
+
+        <listitem>
+          <para>ファイル作成 (<option>fcre</option>)</para>
+        </listitem>
+
+        <listitem>
+          <para>ディレクトリ作成 (<option>dcre</option>)</para>
+        </listitem>
+
+        <listitem>
+          <para>ファイル移動または名前変更 (<option>fmov</option>)</para>
+        </listitem>
+
+        <listitem>
+          <para>ディレクトリ移動または名前変更 (<option>dmov</option>)</para>
+        </listitem>
+
+        <listitem>
+          <para>ログイン (<option>login</option>)</para>
+        </listitem>
+
+        <listitem>
+          <para>ログアウト (<option>logout</option>)</para>
+        </listitem>
       </itemizedlist>
 
       <variablelist>
@@ -1029,7 +1139,9 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>FCE イベントを指定された <parameter>host</parameter> に送ることができるようにする．もし指定されていなければデフォルトの <parameter>port</parameter> は 12250 である．複数のリスナーを指定するにはそれぞれのリスナーに対するオプションを一度に指定することである．</para>
+            <para>FCE イベントを指定された <parameter>host</parameter>
+            に送ることができるようにする。もし指定されていなければデフォルトの <parameter>port</parameter> は
+            12250 である。複数のリスナーを指定するにはそれぞれのリスナーに対するオプションを一度に指定することである。</para>
           </listitem>
         </varlistentry>
 
@@ -1038,7 +1150,8 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>FCE プロトコルのヴァージョンで，デフォルトでは 1 である．fmov，dmov，login あるいは logout イベントのためにはバージョン 2 が必要である．</para>
+            <para>FCE プロトコルのヴァージョンで、デフォルトでは 1 である。fmov、dmov、login あるいは logout
+            イベントのためにはバージョン 2 が必要である。</para>
           </listitem>
         </varlistentry>
 
@@ -1048,7 +1161,8 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>どの FCE イベントがアクティブかを指定する．デフォルトでは <parameter>fmod,fdel,ddel,fcre,dcre</parameter> である．</para>
+            <para>どの FCE イベントがアクティブかを指定する。デフォルトでは
+            <parameter>fmod,fdel,ddel,fcre,dcre</parameter> である。</para>
           </listitem>
         </varlistentry>
 
@@ -1057,7 +1171,7 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>FCE イベントを結合する．</para>
+            <para>FCE イベントを結合する。</para>
           </listitem>
         </varlistentry>
 
@@ -1066,7 +1180,21 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>これは，もしクライアントによって FCE ファイル変更イベント (fmod) を送信する前に同じファイルに対する別の変更が同時に行われる場合，常に待機する遅延時間を秒単位で決定する．例えば，フォトショップでファイルを保存することでそのファイル自体の複数のイベントを引き起こす．なぜなら，アプリケーションはその“保存する”たびにファイルを複数回，開き，変更しそして閉じるからである．デフォルトでは 60 秒である．</para>
+            <para>これは、もしクライアントによって FCE ファイル変更イベント (fmod)
+            を送信する前に同じファイルに対する別の変更が同時に行われる場合、常に待機する遅延時間を秒単位で決定する。例えば、フォトショップでファイルを保存することでそのファイル自体の複数のイベントを引き起こす。なぜなら、アプリケーションはその“保存する”たびにファイルを複数回、開き、変更しそして閉じるからである。デフォルトでは
+            60 秒である。</para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>fce sendwait = <replaceable>ミリ秒</replaceable>
+          <type>(G)</type></term>
+
+          <listitem>
+            <para>各 FCE イベントの発行間の遅延をミリ秒単位で定義する。 非常に多くのファイルを一度に作成または削除するときに、FCE
+            イベントの損失が発生する場合は、これを使用して問題を防げる。 このような操作によって引き起こされる大量のイベントにより、UDP
+            バッファ オーバーフローが発生し、その後パケット損失が発生する可能性があります。 0 から 999 までの値は設定可能。デフォルト:
+            0 ミリ秒。</para>
           </listitem>
         </varlistentry>
 
@@ -1075,13 +1203,14 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>FCE イベントを生成すべきでないファイル名をスラッシュで区切ったリスト．デフォルトでは .DS_Store．</para>
+            <para>FCE イベントを生成すべきでないファイル名をスラッシュで区切ったリスト。デフォルトでは
+            .DS_Store。</para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
-          <term>fce ignore directories = <replaceable>NAME[,NAME2,...]</replaceable>
-          <type>(G)</type></term>
+          <term>fce ignore directories =
+          <replaceable>NAME[,NAME2,...]</replaceable> <type>(G)</type></term>
 
           <listitem>
             <para>FCE イベントが生成されないディレクトリのカンマ区切りのリスト。デフォルトは無し。</para>
@@ -1093,10 +1222,10 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>各々の FCE イベントに対して実行されるスクリプト．スクリプト例については，Netatalk のソースの contrib/shell_utils/fce_ev_script.sh を参照のこと．</para>
+            <para>各々の FCE イベントに対して実行されるスクリプト。スクリプト例については、Netatalk のソースの
+            contrib/shell_utils/fce_ev_script.sh を参照のこと。</para>
           </listitem>
         </varlistentry>
-
       </variablelist>
     </refsect2>
 
@@ -1129,9 +1258,12 @@
           <emphasis>no</emphasis>) <type>(G)</type></term>
 
           <listitem>
-            <para>このオプションを有効にすると、afpdはserver notificationの機能があることを宣伝しない。これは、接続中のクライアントが開いているサーバのウインドウの変更を検出するために10秒毎にポーリングするのを目的としている。<emphasis>注記</emphasis>: 同時接続クライアント数とネットワークスピード次第でネットワークの負荷が相当に高くなる!</para>
+            <para>このオプションを有効にすると、afpdはserver
+            notificationの機能があることを宣伝しない。これは、接続中のクライアントが開いているサーバのウインドウの変更を検出するために10秒毎にポーリングするのを目的としている。<emphasis>注記</emphasis>:
+            同時接続クライアント数とネットワークスピード次第でネットワークの負荷が相当に高くなる!</para>
 
-            <para>現在のNetatalkはserver notificationを正確にサポートしており、接続中のクライアントは他のクライアントが内容を変更したときにフォルダ内の一覧を更新できるので、もはやこのオプションは使わないでください。</para>
+            <para>現在のNetatalkはserver
+            notificationを正確にサポートしており、接続中のクライアントは他のクライアントが内容を変更したときにフォルダ内の一覧を更新できるので、もはやこのオプションは使わないでください。</para>
           </listitem>
         </varlistentry>
       </variablelist>
@@ -1140,7 +1272,8 @@
     <refsect2 id="acl_options">
       <title>ACL処理のためのオプション</title>
 
-      <para>デフォルトでは、認証済ユーザの有効な権限は記載済UARights権限構造にだけマップされる。UNIXモードではない。この挙動は設定オプション<option>map acls</option>で調整できる:</para>
+      <para>デフォルトでは、認証済ユーザの有効な権限は記載済UARights権限構造にだけマップされる。UNIXモードではない。この挙動は設定オプション<option>map
+      acls</option>で調整できる:</para>
 
       <variablelist id="map_acls">
         <varlistentry>
@@ -1177,9 +1310,17 @@
         </varlistentry>
       </variablelist>
 
-      <para>もしクライアント上で ACL を表示できるようにしたければ， クライアントもサーバーも認証ドメイン（ディレクトリサービス，例えば，LDAP，Open Directory， Active Directory）の一部としてセットアップしなければならない．その理由は，OS X の ACL は単に uid ないしは gid と結合しているのではなく，UUID と結合しているからである．それ故，Netatalk は，OS X の UUID と紐付けした UNIX uid と gid に結合したサーバー側の ACL を返せるように，ファイルシステム全ての uid と gid を UUID と紐付けできるようにしなければならない．</para>
+      <para>もしクライアント上で ACL を表示できるようにしたければ、
+      クライアントもサーバーも認証ドメイン（ディレクトリサービス、例えば、LDAP、Open Directory、Active
+      Directory）の一部としてセットアップしなければならない。その理由は、OS X の ACL は単に uid ないしは gid
+      と結合しているのではなく、UUID と結合しているからである。それ故、Netatalk は、OS X の UUID と紐付けした UNIX
+      uid と gid に結合したサーバー側の ACL を返せるように、ファイルシステム全ての uid と gid を UUID
+      と紐付けできるようにしなければならない。</para>
 
-      <para>Netatalk は LDAP 検索を用いてディレクトリサーバーを検索をすることができる．ディレクトリサーバーが既にユーザーとグループの UUID 属性を提供している（Active Directory，Open Directory）か，ディレクトリサーバー（例えばOpenLDAP）の未使用の属性を再使用（あるいは新しい属性を追加）するか，のいずれかである．</para>
+      <para>Netatalk は LDAP
+      検索を用いてディレクトリサーバーを検索をすることができる。ディレクトリサーバーが既にユーザーとグループの UUID
+      属性を提供している（Active Directory、Open
+      Directory）か、ディレクトリサーバー（例えばOpenLDAP）の未使用の属性を再使用（あるいは新しい属性を追加）するか、のいずれかである。</para>
 
       <para>Netatalk では以下の LDAP オプションが設定されなければならない:</para>
 
@@ -1189,8 +1330,7 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>認証方式: <option>none | simple |
-            sasl</option></para>
+            <para>認証方式: <option>none | simple | sasl</option></para>
 
             <para><variablelist>
                 <varlistentry>
@@ -1225,7 +1365,7 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>簡易認証でのユーザーの識別名．</para>
+            <para>簡易認証でのユーザーの識別名。</para>
           </listitem>
         </varlistentry>
 
@@ -1234,23 +1374,24 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>簡易認証でのパスワード．</para>
+            <para>簡易認証でのパスワード。</para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
-          <term>ldap server = <parameter>host</parameter>
+          <term>ldap uri = <parameter>ldap://somehost:1234/</parameter>
           <type>(G)</type></term>
 
           <listitem>
-            <para>LDAP サーバーの名前か IP アドレス．これは，LDAP に UUID の問い合わせをできるようにするために，明示的な ACL サポートを必要とする時のみ必要．</para>
+            <para>接続先のLDAP サーバーのURI。選択可能の URI スキームは ldap、ldapi 又は ldaps
+            である。TCP、ICP 又は TLS プロトコルに当たる。実際のサポートは LDAP ライブラリ次第。本オプションは LDAP に
+            UUID の問い合わせをできるようにするために、明示的な ACL サポートを必要とする時のみ必要。</para>
 
             <para>設定の構文的なチェックのために <citerefentry>
                 <refentrytitle>afpldaptest</refentrytitle>
 
                 <manvolnum>1</manvolnum>
-              </citerefentry>
-            を使うこともできる．</para>
+              </citerefentry> を使うこともできる。</para>
           </listitem>
         </varlistentry>
 
@@ -1259,7 +1400,7 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>LDAP 内のユーザーコンテナの DN．</para>
+            <para>LDAP 内のユーザーコンテナの DN。</para>
           </listitem>
         </varlistentry>
 
@@ -1277,7 +1418,7 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>LDAP 内のグループコンテナの DN．</para>
+            <para>LDAP 内のグループコンテナの DN。</para>
           </listitem>
         </varlistentry>
 
@@ -1295,9 +1436,9 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>UUID のある LDAP 属性の名前．</para>
+            <para>UUID のある LDAP 属性の名前。</para>
 
-            <para>注記: これはユーザーでもグループでも双方で用いられる．</para>
+            <para>注記: これはユーザーでもグループでも双方で用いられる。</para>
           </listitem>
         </varlistentry>
 
@@ -1306,7 +1447,7 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>ユーザーの短縮名のある LDAP 属性の名前．</para>
+            <para>ユーザーの短縮名のある LDAP 属性の名前。</para>
           </listitem>
         </varlistentry>
 
@@ -1315,7 +1456,7 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>グループの短縮名のある LDAP 属性の名前．</para>
+            <para>グループの短縮名のある LDAP 属性の名前。</para>
           </listitem>
         </varlistentry>
 
@@ -1324,7 +1465,8 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>ディレクトリでの UUID 文字列のフォーマット．'x' と '-'を続けたもので，それぞれの 'x' は 0-9a-f の値を示し，'-' はそれぞれ区切り文字である．</para>
+            <para>ディレクトリでの UUID 文字列のフォーマット。'x' と '-'を続けたもので、それぞれの 'x' は 0-9a-f
+            の値を示し、'-' はそれぞれ区切り文字である。</para>
 
             <para>デフォルト: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</para>
           </listitem>
@@ -1335,14 +1477,21 @@
           string)</parameter> <type>(G)</type></term>
 
           <listitem>
-            <para>LDAP 属性の UUID のフォーマットは Active Directory からの obhectGUID バイナリーフィールドの使用を許す．もし未指定のままだと string がデフォルトとなる．これはほとんどの LDAP ストアによって ASCII UUID を通して渡される．もし ms-guid が設定されると，サーバーと相互に動作する時 Active Directory 内にあるオブジェクトの objectGUID 属性で用いられる内部 UUID 表記とバイナリー形式が相互に変換される．</para>
-            <para>オプション <option>ldap user filter</option> 及び <option>ldap group filter</option> も参照のこと．</para>
+            <para>LDAP 属性の UUID のフォーマットは Active Directory からの obhectGUID
+            バイナリーフィールドの使用を許す。もし未指定のままだと string がデフォルトとなる。これはほとんどの LDAP ストアによって
+            ASCII UUID を通して渡される。もし ms-guid が設定されると、サーバーと相互に動作する時 Active
+            Directory 内にあるオブジェクトの objectGUID 属性で用いられる内部 UUID
+            表記とバイナリー形式が相互に変換される。</para>
+
+            <para>オプション <option>ldap user filter</option> 及び <option>ldap
+            group filter</option> も参照のこと。</para>
+
             <para><variablelist>
                 <varlistentry>
                   <term>string</term>
 
                   <listitem>
-                    <para>UUID は文字列．例えば OpenDirectory とで使用する．</para>
+                    <para>UUID は文字列。例えば OpenDirectory とで使用する。</para>
                   </listitem>
                 </varlistentry>
 
@@ -1350,7 +1499,7 @@
                   <term>ms-guid</term>
 
                   <listitem>
-                    <para>Active Directory からの objectGUID バイナリー．</para>
+                    <para>Active Directory からの objectGUID バイナリー。</para>
                   </listitem>
                 </varlistentry>
               </variablelist></para>
@@ -1362,8 +1511,12 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>ユーザーオブジェクトにマッチする任意の LDAP フィルター．これは，ユーザーとグループが同じディレクトリのサブツリーに保存されている Active Directory 環境で必要．</para>
-            <para>Active Directory での推奨設定: <parameter>objectClass=user</parameter></para>
+            <para>ユーザーオブジェクトにマッチする任意の LDAP
+            フィルター。これは、ユーザーとグループが同じディレクトリのサブツリーに保存されている Active Directory
+            環境で必要。</para>
+
+            <para>Active Directory での推奨設定:
+            <parameter>objectClass=user</parameter></para>
           </listitem>
         </varlistentry>
 
@@ -1372,11 +1525,14 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>グループオブジェクトにマッチする任意の LDAP フィルター．これは，ユーザーとグループが同じディレクトリのサブツリーに保存されている Active Directory 環境で必要．</para>
-            <para>Active Directory での推奨設定: <parameter>objectClass=group</parameter></para>
+            <para>グループオブジェクトにマッチする任意の LDAP
+            フィルター。これは、ユーザーとグループが同じディレクトリのサブツリーに保存されている Active Directory
+            環境で必要。</para>
+
+            <para>Active Directory での推奨設定:
+            <parameter>objectClass=group</parameter></para>
           </listitem>
         </varlistentry>
-
       </variablelist>
     </refsect2>
   </refsect1>
@@ -1387,14 +1543,17 @@
     <refsect2>
       <title>パラメータ</title>
 
-      <para>セクション名ボリューム名を定義する．同じ名前の二つのボリュームというのは無いであろう．ボリューム名が文字 <keycode>':'</keycode> を含むことはできない． ボリューム名がとても長ければマングルされる．Mac キャラクターセットのボリューム名は27 文字までに制限される．UTF8-MAC ボリューム名は volnamelen パラメータで制限される．</para>
+      <para>セクション名ボリューム名を定義する。同じ名前の二つのボリュームというのは無いであろう。ボリューム名が文字
+      <keycode>':'</keycode> を含むことはできない。ボリューム名がとても長ければマングルされる。Mac
+      キャラクターセットのボリューム名は27 文字までに制限される。UTF8-MAC ボリューム名は volnamelen
+      パラメータで制限される。</para>
 
       <variablelist>
         <varlistentry>
           <term>path = <replaceable>PATH</replaceable> <type>(V)</type></term>
 
           <listitem>
-            <para>パス名は完全修飾パス名でなければならない．</para>
+            <para>パス名は完全修飾パス名でなければならない。</para>
           </listitem>
         </varlistentry>
 
@@ -1403,7 +1562,9 @@
           <type>(V)</type></term>
 
           <listitem>
-            <para>メタデータファイルのフォーマットを指定する．これは Mac のリソースフォークの保存にも用いられる．初期のバージョンでは AppleDouble v2 が用いられ，新しいデフォルトのフォーマットは <emphasis role="bold">ea</emphasis> である．</para>
+            <para>メタデータファイルのフォーマットを指定する。これは Mac のリソースフォークの保存にも用いられる。初期のバージョンでは
+            AppleDouble v2 が用いられ、新しいデフォルトのフォーマットは <emphasis
+            role="bold">ea</emphasis> である。</para>
           </listitem>
         </varlistentry>
 
@@ -1412,7 +1573,14 @@
           <type>(V)</type></term>
 
           <listitem>
-            <para>Time Machine に有用：報告されるボリュームサイズを制限する．故に Time Machine がバックアップのために実ディスク領域全体を使うことを防止する．例えば "vol size limit = 1000" は報告されるディスク領域を 1 GB に制限する． <emphasis role="bold">重要:</emphasis> これは Time Machine sparsebundle イメージの中身を考慮した概算である．それ故このオプションを使用した時，このボリュームを他のコンテンツを保管するのに使用 “してはならない”．なぜなら勘定に入っていないからである．計算は: sparsebundle の Info.plist XML ファイルからバンドサイズを読む，バンドファイルの数を数えて バンド／ディレクトリ を読む，そしてお互いの乗算をする．ことによって行われる．</para>
+            <para>Time Machine に有用：報告されるボリュームサイズを制限する。故に Time Machine
+            がバックアップのために実ディスク領域全体を使うことを防止する。例えば "vol size limit = 1000"
+            は報告されるディスク領域を 1 GB に制限する。<emphasis role="bold">重要:</emphasis> これは
+            Time Machine sparsebundle
+            イメージの中身を考慮した概算である。それ故このオプションを使用した時、このボリュームを他のコンテンツを保管するのに使用
+            “してはならない”。なぜなら勘定に入っていないからである。計算は: sparsebundle の Info.plist XML
+            ファイルからバンドサイズを読む、バンドファイルの数を数えて バンド／ディレクトリ
+            を読む、そしてお互いの乗算をする。ことによって行われる。</para>
           </listitem>
         </varlistentry>
 
@@ -1421,8 +1589,8 @@
           <type>(V)</type></term>
 
           <listitem>
-            <para>この許可オプションは指定された共有にそのユーザーとグループのアクセスを許可する．ユーザーとグループはスペースかコンマで区切って指定する．グループは @ プレフィックスで明示する．例:
-            <programlisting>valid users = user @group</programlisting></para>
+            <para>この許可オプションは指定された共有にそのユーザーとグループのアクセスを許可する。ユーザーとグループはスペースかコンマで区切って指定する。グループは
+            @ プレフィックスで明示する。例: <programlisting>valid users = user @group</programlisting></para>
           </listitem>
         </varlistentry>
 
@@ -1431,16 +1599,18 @@
           <type>(V)</type></term>
 
           <listitem>
-            <para>この拒否オプションはその共有にアクセスを許可しないユーザーとグループを指定する．それ以外は "valid users" オプションと同じフォーマットである．</para>
+            <para>この拒否オプションはその共有にアクセスを許可しないユーザーとグループを指定する。それ以外は "valid users"
+            オプションと同じフォーマットである。</para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
-          <term>hosts allow = <replaceable>IPホストアドレス/IPマスクビット [
-          ... ]</replaceable> <type>(V)</type></term>
+          <term>hosts allow = <replaceable>IPホストアドレス/IPマスクビット [ ...
+          ]</replaceable> <type>(V)</type></term>
 
           <listitem>
-            <para>列挙されたホストとネットワークのみが許可され，ほかの全ては拒否される．ネットワークアドレスは IPv4 のドット区切りフォーマット， IPv6の16進数フォーマットのどちらでもよい．</para>
+            <para>列挙されたホストとネットワークのみが許可され、ほかの全ては拒否される。ネットワークアドレスは IPv4
+            のドット区切りフォーマット、IPv6の16進数フォーマットのどちらでもよい。</para>
 
             <para>例: hosts allow = 10.1.0.0/16 10.2.1.100
             2001:0db8:1234::/48</para>
@@ -1448,11 +1618,11 @@
         </varlistentry>
 
         <varlistentry>
-          <term>hosts deny = <replaceable>IPホストアドレス/IPマスクビット [
-          ... ]</replaceable> <type>(V)</type></term>
+          <term>hosts deny = <replaceable>IPホストアドレス/IPマスクビット [ ...
+          ]</replaceable> <type>(V)</type></term>
 
           <listitem>
-            <para>列挙されたホストとネットのみが拒否され，ほかの全ては許可される．</para>
+            <para>列挙されたホストとネットのみが拒否され、ほかの全ては許可される。</para>
 
             <para>例: hosts deny = 192.168.100/24 10.1.1.1
             2001:db8::1428:57ab</para>
@@ -1464,7 +1634,9 @@
           <type>(V)</type></term>
 
           <listitem>
-            <para>そのボリュームに使う CNID バックエンドをセットする．デフォルトのバックエンドは [@DEFAULT_CNID_SCHEME@] で，有効なバックエンドは [@compiled_backends@] である．</para>
+            <para>そのボリュームに使う CNID バックエンドをセットする。デフォルトのバックエンドは
+            [@DEFAULT_CNID_SCHEME@] で、有効なバックエンドは [@compiled_backends@]
+            である。</para>
           </listitem>
         </varlistentry>
 
@@ -1475,14 +1647,20 @@
           <listitem>
             <para>拡張属性<indexterm>
                 <primary>拡張属性</primary>
-              </indexterm>をどのように保存するか指定する． <option>auto</option> がデフォルトである．</para>
+              </indexterm>をどのように保存するか指定する。<option>auto</option>
+            がデフォルトである。</para>
 
             <variablelist>
               <varlistentry>
                 <term>auto</term>
 
                 <listitem>
-                  <para>（共有ディレクトリ自体に EA を設定することにより） <option>sys</option> を試行して，フォールバックすると <option>ad</option> になる．試行を実行するためにはボリュームが書き込み可能であることが必要である． "<option>read only = yes</option>" ならば <option>auto</option> は <option>none</option> で上書きされる．書き込み専用のボリュームには必要に応じて明確に "<option>ea = sys|ad</option>" を使ってください．</para>
+                  <para>（共有ディレクトリ自体に EA を設定することにより） <option>sys</option>
+                  を試行して、フォールバックすると <option>ad</option>
+                  になる。試行を実行するためにはボリュームが書き込み可能であることが必要である。"<option>read only =
+                  yes</option>" ならば <option>auto</option> は
+                  <option>none</option> で上書きされる。書き込み専用のボリュームには必要に応じて明確に
+                  "<option>ea = sys|ad</option>" を使ってください。</para>
                 </listitem>
               </varlistentry>
 
@@ -1490,22 +1668,24 @@
                 <term>sys</term>
 
                 <listitem>
-                  <para>ファイルシステムの拡張属性を使う．</para>
+                  <para>ファイルシステムの拡張属性を使う。</para>
                 </listitem>
               </varlistentry>
 
-	      <varlistentry>
+              <varlistentry>
                 <term>samba</term>
 
                 <listitem>
-                  <para>ファイルシステムの拡張属性を使うが，Sambaのvfs_streams_xattrとの互換性の目的で，それぞれの拡張属性に値がゼロの1バイトを追加する．</para>                </listitem>
+                  <para>ファイルシステムの拡張属性を使うが、Sambaのvfs_streams_xattrとの互換性の目的で、それぞれの拡張属性に値がゼロの1バイトを追加する。</para>
+                </listitem>
               </varlistentry>
 
               <varlistentry>
                 <term>ad</term>
 
                 <listitem>
-                  <para><emphasis>.AppleDouble</emphasis> ディレクトリ内のファイルを使う．</para>
+                  <para><emphasis>.AppleDouble</emphasis>
+                  ディレクトリ内のファイルを使う。</para>
                 </listitem>
               </varlistentry>
 
@@ -1513,7 +1693,7 @@
                 <term>none</term>
 
                 <listitem>
-                  <para>拡張属性をサポートしない．</para>
+                  <para>拡張属性をサポートしない。</para>
                 </listitem>
               </varlistentry>
             </variablelist>
@@ -1525,7 +1705,10 @@
           <type>(V)</type></term>
 
           <listitem>
-            <para>もしグローバル設定を適用する指定がなければ，そのボリュームに対しての Mac クライアントのキャラクターセット，例えば <emphasis>MAC_ROMAN</emphasis>，<emphasis>MAC_CYRILLIC</emphasis> 等を指定する．この設定は Mac キャラクターセットが [Global] セクションで全体的にセットしたキャラクターセットと異なるというボリュームを必要とする時のみ必須である．</para>
+            <para>もしグローバル設定を適用する指定がなければ、そのボリュームに対しての Mac クライアントのキャラクターセット、例えば
+            <emphasis>MAC_ROMAN</emphasis>、<emphasis>MAC_CYRILLIC</emphasis>
+            等を指定する。この設定は Mac キャラクターセットが [Global]
+            セクションで全体的にセットしたキャラクターセットと異なるというボリュームを必要とする時のみ必須である。</para>
           </listitem>
         </varlistentry>
 
@@ -1533,15 +1716,17 @@
           <term>casefold = <option>option</option> <type>(V)</type></term>
 
           <listitem>
-            <para>ファイル名の大文字小文字を変更すべき場合，casefold オプションが処理する．有効なオプションは:</para>
+            <para>ファイル名の大文字小文字を変更すべき場合、casefold オプションが処理する。有効なオプションは:</para>
 
             <para><option>tolower</option> - 双方向で名前を小文字に変換する。</para>
 
             <para><option>toupper</option> - 双方向で名前を大文字に変換する。</para>
 
-            <para><option>xlatelower</option> - クライアントでは小文字に見えて、サーバでは大文字に見える。</para>
+            <para><option>xlatelower</option> -
+            クライアントでは小文字に見えて、サーバでは大文字に見える。</para>
 
-            <para><option>xlateupper</option> - クライアントでは大文字に見えて、サーバでは小文字にみえる。</para>
+            <para><option>xlateupper</option> -
+            クライアントでは大文字に見えて、サーバでは小文字にみえる。</para>
           </listitem>
         </varlistentry>
 
@@ -1550,7 +1735,8 @@
           <type>(V)</type></term>
 
           <listitem>
-            <para>このオプションはボリュームパスワードの設定を許可する．パスワードは最大で 8 文字の長さ（これを記入するときには ASCII を強く推奨）</para>
+            <para>このオプションはボリュームパスワードの設定を許可する。パスワードは最大で 8 文字の長さ（これを記入するときには
+            ASCII を強く推奨）</para>
           </listitem>
         </varlistentry>
 
@@ -1562,7 +1748,9 @@
           <type>(V)</type></term>
 
           <listitem>
-            <para>クライアントが要求した権限との論理和(or)をとる． <option>file perm</option> はファイルにのみ， <option>directory perm</option> はディレクトリにのみ用いる． "<option>unix priv = no</option>" と共に用いてはならない．</para>
+            <para>クライアントが要求した権限との論理和(or)をとる。<option>file perm</option>
+            はファイルにのみ、<option>directory perm</option> はディレクトリにのみ用いる。
+            "<option>unix priv = no</option>" と共に用いてはならない。</para>
 
             <example>
               <title>共同ワークグループ用ボリューム</title>
@@ -1578,7 +1766,8 @@ directory perm = 0770</programlisting></para>
           <type>(V)</type></term>
 
           <listitem>
-            <para>権限のマスクを設定する． "<option>unix priv = no</option>" と共に用いてはならない．</para>
+            <para>権限のマスクを設定する。"<option>unix priv = no</option>"
+            と共に用いてはならない。</para>
           </listitem>
         </varlistentry>
 
@@ -1622,7 +1811,8 @@ directory perm = 0770</programlisting></para>
           <term>rolist = <option>users/groups</option> <type>(V)</type></term>
 
           <listitem>
-            <para>信頼するユーザー及びグループの共有に対する読み込み専用アクセスを許可する．フォーマットは allow オプションに準ずる．</para>
+            <para>信頼するユーザー及びグループの共有に対する読み込み専用アクセスを許可する。フォーマットは allow
+            オプションに準ずる。</para>
           </listitem>
         </varlistentry>
 
@@ -1631,7 +1821,8 @@ directory perm = 0770</programlisting></para>
           <type>(V)</type></term>
 
           <listitem>
-            <para>信頼するユーザー及びグループの共有に対する読み込み／書き込みアクセスを許可する．フォーマットは allow オプションに準ずる．</para>
+            <para>信頼するユーザー及びグループの共有に対する読み込み／書き込みアクセスを許可する。フォーマットは allow
+            オプションに準ずる。</para>
           </listitem>
         </varlistentry>
 
@@ -1640,7 +1831,9 @@ directory perm = 0770</programlisting></para>
           <type>(V)</type></term>
 
           <listitem>
-            <para>'/' で区切られた 禁止名のどれかに一致するパスのファイルとディレクトリを隠す．禁止文字列は常に '/' で終わらなければならない．例えば，"veto files = veto1/"，"veto files = veto1/veto2/"．</para>
+            <para>'/' で区切られた 禁止名のどれかに一致するパスのファイルとディレクトリを隠す。禁止文字列は常に '/'
+            で終わらなければならない。例えば、"veto files = veto1/"、"veto files =
+            veto1/veto2/"。</para>
           </listitem>
         </varlistentry>
       </variablelist>
@@ -1649,7 +1842,7 @@ directory perm = 0770</programlisting></para>
     <refsect2>
       <title>ボリュームオプション</title>
 
-      <para>ブーリアン型のボリュームオプション．</para>
+      <para>ブーリアン型のボリュームオプション。</para>
 
       <variablelist>
         <varlistentry>
@@ -1657,7 +1850,8 @@ directory perm = 0770</programlisting></para>
           <emphasis>yes</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>ボリュームが ACL をサポートしてるというフラグを立てるかどうか． もし ACL サポートでコンパイルしていれば，これはデフォルトで yes．</para>
+            <para>ボリュームが ACL をサポートしてるというフラグを立てるかどうか。もし ACL
+            サポートでコンパイルしていれば、これはデフォルトで yes。</para>
           </listitem>
         </varlistentry>
 
@@ -1666,9 +1860,12 @@ directory perm = 0770</programlisting></para>
           <emphasis>yes</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>ボリュームが大文字小文字を区別したファイル名をサポートしてるというフラグを立てるかどうか． もしファイルシステムが大文字小文字を区別しなければ no を設定せよ．しかしながらこれは完全には確かめられていない．</para>
+            <para>ボリュームが大文字小文字を区別したファイル名をサポートしてるというフラグを立てるかどうか。
+            もしファイルシステムが大文字小文字を区別しなければ no を設定せよ。しかしながらこれは完全には確かめられていない。</para>
+
             <note>
-              <para>実際には大文字小文字を区別しているにもかかわらず，netatalk 3.1.3 とそれ以前のものはクライアントに kCaseSensitive フラグを通知しなかった．バージョン 3.1.4 からはデフォルトで正しく通知される．</para>
+              <para>実際には大文字小文字を区別しているにもかかわらず、netatalk 3.1.3 とそれ以前のものはクライアントに
+              kCaseSensitive フラグを通知しなかった。バージョン 3.1.4 からはデフォルトで正しく通知される。</para>
             </note>
           </listitem>
         </varlistentry>
@@ -1678,7 +1875,8 @@ directory perm = 0770</programlisting></para>
           <emphasis>yes</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>CNID バックエンド内でデバイス番号を使うかどうか． 例えばクラスターなどでリブートを経るとデバイス番号が固定ではない時有用．</para>
+            <para>CNID バックエンド内でデバイス番号を使うかどうか。
+            例えばクラスターなどでリブートを経るとデバイス番号が固定ではない時有用。</para>
           </listitem>
         </varlistentry>
 
@@ -1687,17 +1885,26 @@ directory perm = 0770</programlisting></para>
           (デフォルト: <emphasis>yes</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>クライアントからのファイルシステムへのアクセス時， <option>appledouble = v2</option> から <option>appledouble = ea</option> への自動的な変換を行うかどうか．これは概して有用であるがいくらかパフォーマンスが犠牲となる．ボリューム上で <command>dbd</command> を実行しそれで変換をするのが推奨される．その後このオプションを no に設定することもできる．</para>
+            <para>クライアントからのファイルシステムへのアクセス時、<option>appledouble = v2</option>
+            から <option>appledouble = ea</option>
+            への自動的な変換を行うかどうか。これは概して有用であるがいくらかパフォーマンスが犠牲となる。ボリューム上で
+            <command>dbd</command> を実行しそれで変換をするのが推奨される。その後このオプションを no
+            に設定することもできる。</para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
-          <term>delete veto files = <replaceable>BOOLEAN</replaceable>
-          (デフォルト: <emphasis>no</emphasis>) <type>(V)</type></term>
+          <term>delete veto files = <replaceable>BOOLEAN</replaceable> (デフォルト:
+          <emphasis>no</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>このオプションは Netatalk が一つあるいはそれ以上の veto されたファイルあるいはディレクトリ（veto files オプションを見よ）を削除しようとした時用いられる．もしこのオプションを no に設定し（デフォルト），そしてもしあるディレクトリが何か非 veto ファイルないしはディレクトリを含んでいたら，ディレクトリの削除は失敗するであろう．これは通常あなたの望むところの動作である．</para>
-            <para>もしこのオプションが yes に設定されていたら，Netatalk は veto 化ディレクトリ・ディレクトリ内も含めあらゆるファイル，ディレクトリを再帰的に削除しようとするであろう．</para>
+            <para>このオプションは Netatalk が一つあるいはそれ以上の veto されたファイルあるいはディレクトリ（veto
+            files オプションを見よ）を削除しようとした時用いられる。もしこのオプションを no
+            に設定し（デフォルト）、そしてもしあるディレクトリが何か非 veto
+            ファイルないしはディレクトリを含んでいたら、ディレクトリの削除は失敗するであろう。これは通常あなたの望むところの動作である。</para>
+
+            <para>もしこのオプションが yes に設定されていたら、Netatalk は veto
+            化ディレクトリ・ディレクトリ内も含めあらゆるファイル、ディレクトリを再帰的に削除しようとするであろう。</para>
           </listitem>
         </varlistentry>
 
@@ -1706,9 +1913,13 @@ directory perm = 0770</programlisting></para>
           <emphasis>no</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>デフォルトの設定では偽なのでサーバー上でシンボリックリンクは辿られない．これは OS X の AFP サーバーと同じ挙動である．オプションを真に設定すると afpd がサーバー上でシンボリックリンクを辿るようにさせる．今のところ afpd は "wide symlinks" を全く検査しないので，シンボリックリンクは AFP ボリューム以外を指しているかもしれない．</para>
+            <para>デフォルトの設定では偽なのでサーバー上でシンボリックリンクは辿られない。これは OS X の AFP
+            サーバーと同じ挙動である。オプションを真に設定すると afpd がサーバー上でシンボリックリンクを辿るようにさせる。今のところ
+            afpd は "wide symlinks" を全く検査しないので、シンボリックリンクは AFP
+            ボリューム以外を指しているかもしれない。</para>
+
             <note>
-              <para>シンボリックリンクがファイルシステムの境界をまたいで張られている時，このオプションは巧妙に断ち切る．</para>
+              <para>シンボリックリンクがファイルシステムの境界をまたいで張られている時、このオプションは巧妙に断ち切る。</para>
             </note>
           </listitem>
         </varlistentry>
@@ -1718,7 +1929,12 @@ directory perm = 0770</programlisting></para>
           <emphasis>no</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>ドットファイルを不可視にする． 警告：このオプションを有効にすると，望まない副作用を OS X アプリケーションに引き起こす．つまり， 先頭がドットではじまる一時ファイルにファイルをセーブし，それから一時ファイルを最終的なファイル名にリネームした時， 結果としてセーブしたファイルが見えなくなる．唯一このオプションが有用なのは，Mac OS 9 でドットからはじまるファイルを見えなくさせるためである．Mac OS X では，Finder でもターミナルでもドットではじまるファイルはいずれにしても隠しファイルなので，完全に無駄である．</para>
+            <para>ドットファイルを不可視にする。警告：このオプションを有効にすると、望まない副作用を OS X
+            アプリケーションに引き起こす。つまり、
+            先頭がドットではじまる一時ファイルにファイルをセーブし、それから一時ファイルを最終的なファイル名にリネームした時、
+            結果としてセーブしたファイルが見えなくなる。唯一このオプションが有用なのは、Mac OS 9
+            でドットからはじまるファイルを見えなくさせるためである。Mac OS X では、Finder
+            でもターミナルでもドットではじまるファイルはいずれにしても隠しファイルなので、完全に無駄である。</para>
           </listitem>
         </varlistentry>
 
@@ -1727,7 +1943,8 @@ directory perm = 0770</programlisting></para>
           <emphasis>yes</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>サーバーがネットワーク id をサポートするかどうか．これを <emphasis>no</emphasis> に設定すると結果としてクライアントは ACL AFP 機能を使わなくなる．</para>
+            <para>サーバーがネットワーク id をサポートするかどうか。これを <emphasis>no</emphasis>
+            に設定すると結果としてクライアントは ACL AFP 機能を使わなくなる。</para>
           </listitem>
         </varlistentry>
 
@@ -1736,7 +1953,8 @@ directory perm = 0770</programlisting></para>
           <emphasis>no</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>preexec からの 0 以外のリターンコードで，クライアントがボリュームをマウントする／見ることを防ぐために当該ボリュームを即座に閉じる．</para>
+            <para>preexec からの 0
+            以外のリターンコードで、クライアントがボリュームをマウントする／見ることを防ぐために当該ボリュームを即座に閉じる。</para>
           </listitem>
         </varlistentry>
 
@@ -1745,16 +1963,18 @@ directory perm = 0770</programlisting></para>
           <emphasis>no</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>その共有を全てのユーザーに対して読み込み専用と指定する．<option>ea = auto</option> は <option>ea = none</option> で上書きされる．</para>
+            <para>その共有を全てのユーザーに対して読み込み専用と指定する。<option>ea = auto</option> は
+            <option>ea = none</option> で上書きされる。</para>
           </listitem>
         </varlistentry>
 
         <varlistentry>
-          <term>root preexec close= <replaceable>BOOLEAN</replaceable>
-          (デフォルト: <emphasis>no</emphasis>) <type>(V)</type></term>
+          <term>root preexec close= <replaceable>BOOLEAN</replaceable> (デフォルト:
+          <emphasis>no</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>root_preexec からの 0 以外のリターンコードで，クライアントがボリュームをマウントする／見ることを防ぐために当該ボリュームを即座に閉じる．</para>
+            <para>root_preexec からの 0
+            以外のリターンコードで、クライアントがボリュームをマウントする／見ることを防ぐために当該ボリュームを即座に閉じる。</para>
           </listitem>
         </varlistentry>
 
@@ -1763,7 +1983,9 @@ directory perm = 0770</programlisting></para>
           <emphasis>no</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>低速な再帰的ファイルシステム検索の代わりに高速な CNID データベースの名前検索を用いる．矛盾のない CNID データベースを信頼する，すなわち Samba やローカルのファイルシステムのアクセスが不正確さらには誤った結果を招く．"dbd" CNID db のボリュームのみで動作する．</para>
+            <para>低速な再帰的ファイルシステム検索の代わりに高速な CNID データベースの名前検索を用いる。矛盾のない CNID
+            データベースを信頼する、すなわち Samba やローカルのファイルシステムのアクセスが不正確さらには誤った結果を招く。"dbd"
+            CNID db のボリュームのみで動作する。</para>
           </listitem>
         </varlistentry>
 
@@ -1772,7 +1994,8 @@ directory perm = 0770</programlisting></para>
           <emphasis>yes</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>ボリュームリストを列挙するときにボリュームパスを stat するかどうか．オートマウントや preexec スクリプトで作成されたボリュームに有用である．</para>
+            <para>ボリュームリストを列挙するときにボリュームパスを stat するかどうか。オートマウントや preexec
+            スクリプトで作成されたボリュームに有用である。</para>
           </listitem>
         </varlistentry>
 
@@ -1781,7 +2004,7 @@ directory perm = 0770</programlisting></para>
           <emphasis>no</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>このボリュームの Time Machine サポートを有効にするかどうか．</para>
+            <para>このボリュームの Time Machine サポートを有効にするかどうか。</para>
           </listitem>
         </varlistentry>
 
@@ -1790,7 +2013,9 @@ directory perm = 0770</programlisting></para>
           <emphasis>yes</emphasis>) <type>(V)</type></term>
 
           <listitem>
-            <para>AFP3 UNIX 権限を使うかどうか．これは OS X クライアントに対しては設定すべきである．<option>file perm</option>， <option>directory perm</option> 及び <option>umask</option> も参照．</para>
+            <para>AFP3 UNIX 権限を使うかどうか。これは OS X
+            クライアントに対しては設定すべきである。<option>file perm</option>、<option>directory
+            perm</option> 及び <option>umask</option> も参照。</para>
           </listitem>
         </varlistentry>
       </variablelist>
@@ -1800,14 +2025,20 @@ directory perm = 0770</programlisting></para>
   <refsect1>
     <title>CNID バックエンド</title>
 
-    <para>AFP プロトコルはたいていはファイルとディレクトリを名前ではなく ID で参照する．Netatalk はこの ID を永続的な方法で保管する方法を必要とする．これを達成するためにいくつかの異なる CNID バックエンドが用意されている．CNID データベースはデフォルトで <filename>@localstatedir@/netatalk/CNID/(volumename)/.AppleDB/</filename> ディレクトリに置かれている．</para>
+    <para>AFP プロトコルはたいていはファイルとディレクトリを名前ではなく ID で参照する。Netatalk はこの ID
+    を永続的な方法で保管する方法を必要とする。これを達成するためにいくつかの異なる CNID バックエンドが用意されている。CNID
+    データベースはデフォルトで localstatedir の下に置かれている。</para>
 
     <variablelist>
       <varlistentry>
         <term>cdb</term>
 
         <listitem>
-          <para>"Concurrent database" バックエンドは Oracle Berkeley DB を基礎としている．このバックエンドだと，いくつかの <command>afpd</command> デーモンが直接 CNID データベースにアクセスする．もし一つのボリュームあたり，一つ以上の <command>afpd</command> プロセスがアクティブならば，Berkeley DB ロッキングがアクセスを同期するために用いられる．欠点は単一の <command>afpd</command> プロセスのクラッシュがデータベースを壊すかもしれないということである．</para>
+          <para>"Concurrent database" バックエンドは Oracle Berkeley DB
+          を基礎としている。このバックエンドだと、いくつかの <command>afpd</command> デーモンが直接 CNID
+          データベースにアクセスする。もし一つのボリュームあたり、一つ以上の <command>afpd</command>
+          プロセスがアクティブならば、Berkeley DB ロッキングがアクセスを同期するために用いられる。欠点は単一の
+          <command>afpd</command> プロセスのクラッシュがデータベースを壊すかもしれないということである。</para>
         </listitem>
       </varlistentry>
 
@@ -1815,7 +2046,11 @@ directory perm = 0770</programlisting></para>
         <term>dbd</term>
 
         <listitem>
-          <para>CNID データベースへのアクセスは <command>cnid_metad</command> デーモンプロセスによって制限されている．<command>afpd</command> プロセスはこのデーモンとデータベースの読み込みと更新のために通信する．もし Berkeley DB トランザクションとでビルドすれば，データベースの壊れる可能性は経験的にはゼロである． しかし，パフォーマンスは <option>cdb</option> とによるものより遅いかもしれない．</para>
+          <para>CNID データベースへのアクセスは <command>cnid_metad</command>
+          デーモンプロセスによって制限されている。<command>afpd</command>
+          プロセスはこのデーモンとデータベースの読み込みと更新のために通信する。もし Berkeley DB
+          トランザクションとでビルドすれば、データベースの壊れる可能性は経験的にはゼロである。しかし、パフォーマンスは
+          <option>cdb</option> とによるものより遅いかもしれない。</para>
         </listitem>
       </varlistentry>
 
@@ -1823,32 +2058,43 @@ directory perm = 0770</programlisting></para>
         <term>last</term>
 
         <listitem>
-          <para>このバックエンドは，ID の持続性の点では，例外である．ID はカレントセッションでしか有効ではない．これは基本的には <command>afpd</command> がバージョン 1.5（と1.6）で行ったことである．このバックエンドは，例えば共有 CD-ROM などで有用なので未だに有効である．Netatalk 3.0 からは，これは自動的に<emphasis>読み込み専用モード</emphasis>になる．</para>
+          <para>このバックエンドは、ID の持続性の点では、例外である。ID はカレントセッションでしか有効ではない。これは基本的には
+          <command>afpd</command> がバージョン 1.5（と1.6）で行ったことである。このバックエンドは、例えば共有
+          CD-ROM などで有用なので未だに有効である。Netatalk 3.0
+          からは、これは自動的に<emphasis>読み込み専用モード</emphasis>になる。</para>
 
-          <para><emphasis role="bold">警告</emphasis>: 今や <command>afpd</command> が持続性のある ID データベースに重く依存しているので，このバックエンドをボリュームに使用するのはもはや推奨<emphasis>されていない</emphasis>．エイリアスはおそらく機能しないだろうし，ファイル名のマングリングもサポートされていない．</para>
+          <para><emphasis role="bold">警告</emphasis>: 今や
+          <command>afpd</command> が持続性のある ID
+          データベースに重く依存しているので、このバックエンドをボリュームに使用するのはもはや推奨<emphasis>されていない</emphasis>。エイリアスはおそらく機能しないだろうし、ファイル名のマングリングもサポートされていない。</para>
         </listitem>
       </varlistentry>
     </variablelist>
 
-    <para><command>./configure --help</command> で他の有効なバックエンドがあると表示するかもしれない．にも関わらずそれらは壊れていることもありえるし，あるいは主にテストのために使われていることを注意すべきである． あなたが何をしているのかわかっている場合以外はそれらを使用してはならない．それらは将来のバージョンでそれ以上の通告なく除去されるかもしれない．</para>
+    <para><command>./configure --help</command>
+    で他の有効なバックエンドがあると表示するかもしれない。にも関わらずそれらは壊れていることもありえるし、あるいは主にテストのために使われていることを注意すべきである。
+    あなたが何をしているのかわかっている場合以外はそれらを使用してはならない。それらは将来のバージョンでそれ以上の通告なく除去されるかもしれない。</para>
   </refsect1>
 
   <refsect1>
     <title>文字セットオプション</title>
 
-    <para>OS XでAppleはAFP3プロトコルを導入した。最も重要な変更の一つは、AFP3は分解済UTF-8 としてエンコードされたUnicode名を用いることである。以前のAFP及びOSバージョンはMacRomanやMacCentralEuropeといったコードページを用いた。</para>
+    <para>OS XでAppleはAFP3プロトコルを導入した。最も重要な変更の一つは、AFP3は分解済UTF-8
+    としてエンコードされたUnicode名を用いることである。以前のAFP及びOSバージョンはMacRomanやMacCentralEuropeといったコードページを用いた。</para>
 
     <para><command>afpd</command>がunixファイルシステム上にファイルを保存するとき、拡張されたMacintosh文字やunixファイル名としては不正な文字を維持する方法が必要である。現在のバージョンは今、名前のためのデフォルトエンコーディングとしてUTF-8を用いる。「<keycode>/</keycode>」は「<keycode>:</keycode>」に変換される。</para>
 
-    <para>初期のバージョンはいわゆるCAPエンコーディングを用いた。一つの拡張文字(&gt;0x7F)は一つの :xx シーケンスに変換された。例えば、Appleロゴ (MacRoman: 0xF0)は<literal>:f0</literal>として保存された。幾つかの特殊な文字も :xx表記として変換された。「<keycode>/</keycode>」は<literal>:2f</literal>にエンコードされ、先頭のドット「<keycode>.</keycode>」は<literal>:2e</literal>にエンコードされた。</para>
+    <para>初期のバージョンはいわゆるCAPエンコーディングを用いた。一つの拡張文字(&gt;0x7F)は一つの :xx
+    シーケンスに変換された。例えば、Appleロゴ (MacRoman:
+    0xF0)は<literal>:f0</literal>として保存された。幾つかの特殊な文字も
+    :xx表記として変換された。「<keycode>/</keycode>」は<literal>:2f</literal>にエンコードされ、先頭のドット「<keycode>.</keycode>」は<literal>:2e</literal>にエンコードされた。</para>
 
-    <para><option>vol charset</option>オプションは他のボリュームエンコーディングを選べるようにする。<command>afpd</command>は
+    <para><option>vol
+    charset</option>オプションは他のボリュームエンコーディングを選べるようにする。<command>afpd</command>は
     <citerefentry>
         <refentrytitle><command>iconv</command></refentrytitle>
 
         <manvolnum>1</manvolnum>
-      </citerefentry>
-    が提供する如何なる文字セットも受け入れる。デフォルトのUTF-8を使うことをを強く推奨する。</para>
+      </citerefentry> が提供する如何なる文字セットも受け入れる。デフォルトのUTF-8を使うことをを強く推奨する。</para>
   </refsect1>
 
   <refsect1>
@@ -1878,8 +2124,9 @@ directory perm = 0770</programlisting></para>
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man5/afp_signature.conf.5.xml
+++ b/doc/ja/manpages/man5/afp_signature.conf.5.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <refentry id="afp_signature.conf.5">
-
   <refmeta>
     <refentrytitle>afp_signature.conf</refentrytitle>
 
@@ -9,35 +8,43 @@
     <refmiscinfo class="date">23 Mar 2012</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>
     <refname>afp_signature.conf</refname>
 
-    <refpurpose>サーバシグネチャを指定するために <command>afpd</command>(8) が利用する設定ファイル</refpurpose>
+    <refpurpose>サーバシグネチャを指定するために <command>afpd</command>(8)
+    が利用する設定ファイル</refpurpose>
   </refnamediv>
 
   <refsect1>
     <title>説明</title>
 
-    <para><filename>@localstatedir@/netatalk/afp_signature.conf</filename>はサーバシグネチャを魔法のように自動的に指定するために<command>afpd</command>が利用する設定ファイルである。設定行は以下のように構成される。</para>
+    <para><filename>afp_signature.conf</filename>はサーバシグネチャを魔法のように自動的に指定するために<command>afpd</command>が利用する設定ファイルである。設定行は以下のように構成される。</para>
 
     <para><replaceable>"server name" </replaceable>
     <replaceable>hexa-string</replaceable></para>
 
-    <para>最初のフィールドはサーバ名である。 サーバ名がスペースを含む場合、それを引用符で囲まなければならない。第二のフィールドは16バイトのサーバシグネチャのための32文字の16進数文字列である。</para>
+    <para>最初のフィールドはサーバ名である。
+    サーバ名がスペースを含む場合、それを引用符で囲まなければならない。第二のフィールドは16バイトのサーバシグネチャのための32文字の16進数文字列である。</para>
+
     <para>先頭のスペースとタブは無視される。空行は無視される。頭に#が付いた行は無視される。不正な行は無視される。</para>
 
     <note>
-        <para>サーバシグネチャは同じサーバに二重にログオンするのを防ぐために使われる固有の16バイトの識別子である。</para>
-        <para>Netatalk 2.0以前はgethostid()を使ってサーバシグネチャを生成した。他のサーバが同じシグネチャをもつ問題があった。なぜなら、hostidは十分に固有でないからである。</para>
-        <para>現在のnetatalkは乱数からシグネチャを生成し、それをafp_signature.confに保存する。次回起動したとき、それはこのファイルから読み込まれる。</para>
-        <para>このファイルを軽率に編集すべきでないし、他のサーバにコピーすべきでもない。もし意図的にシグネチャを設定したいなら、afp.confで"signature ="オプションを使いなさい。この場合、afp_signature.confは利用されない。</para>
-    </note>
+      <para>サーバシグネチャは同じサーバに二重にログオンするのを防ぐために使われる固有の16バイトの識別子である。</para>
 
-    <para></para>
+      <para>Netatalk
+      2.0以前はgethostid()を使ってサーバシグネチャを生成した。他のサーバが同じシグネチャをもつ問題があった。なぜなら、hostidは十分に固有でないからである。</para>
+
+      <para>現在のnetatalkは乱数からシグネチャを生成し、それをafp_signature.confに保存する。次回起動したとき、それはこのファイルから読み込まれる。</para>
+
+      <para>このファイルを軽率に編集すべきでないし、他のサーバにコピーすべきでもない。もし意図的にシグネチャを設定したいなら、afp.confで"signature
+      ="オプションを使いなさい。この場合、afp_signature.confは利用されない。</para>
+    </note>
   </refsect1>
 
   <refsect1>
@@ -70,8 +77,9 @@
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man5/afp_voluuid.conf.5.xml
+++ b/doc/ja/manpages/man5/afp_voluuid.conf.5.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <refentry id="afp_voluuid.conf.5">
-
   <refmeta>
     <refentrytitle>afp_voluuid.conf</refentrytitle>
 
@@ -9,35 +8,38 @@
     <refmiscinfo class="date">27 June 2016</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>
     <refname>afp_voluuid.conf</refname>
 
-    <refpurpose>AFPボリュームのUUIDを指定するために <command>afpd</command>(8) が利用する設定ファイル</refpurpose>
+    <refpurpose>AFPボリュームのUUIDを指定するために <command>afpd</command>(8)
+    が利用する設定ファイル</refpurpose>
   </refnamediv>
 
   <refsect1>
     <title>説明</title>
 
-    <para><filename>@localstatedir@/netatalk/afp_voluuid.conf</filename>は全てのAFPボリュームのUUIDを魔法のように自動的に指定するために<command>afpd</command>が利用する設定ファイルである。設定行は以下のように構成される。</para>
+    <para><filename>afp_voluuid.conf</filename>は全てのAFPボリュームのUUIDを魔法のように自動的に指定するために<command>afpd</command>が利用する設定ファイルである。設定行は以下のように構成される。</para>
 
     <para><replaceable>"volume name" </replaceable>
     <replaceable>uuid-string</replaceable></para>
 
     <para>最初のフィールドはボリューム名である。ボリューム名がスペースを含む場合、それを引用符で囲まなければならない。第二のフィールドは36文字からなるUUIDの16進数ASCII文字列表現である。</para>
-    <para>先頭のスペースとタブは無視される。空行は無視される。頭に#が付いた行は無視される。不正な行は無視される。
-    </para>
+
+    <para>先頭のスペースとタブは無視される。空行は無視される。頭に#が付いた行は無視される。不正な行は無視される。</para>
 
     <note>
       <para>このUUIDはTime Machineボリュームの強固な曖昧さ除去を提供する目的でZeroconfによって宣伝される。</para>
+
       <para>MySQL CNIDバックエンドにも使用されている。</para>
+
       <para>このファイルを軽率に編集すべきでないし、他のサーバにコピーすべきでもない。</para>
     </note>
-
-    <para></para>
   </refsect1>
 
   <refsect1>
@@ -76,8 +78,9 @@ mary 6331E2D1-446C-B68C-3066-D685AADBE911</programlisting>
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man5/extmap.conf.5.xml
+++ b/doc/ja/manpages/man5/extmap.conf.5.xml
@@ -8,35 +8,37 @@
     <refmiscinfo class="date">19 Jan 2013</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>
     <refname>extmap.conf</refname>
 
-    <refpurpose>ファイル名拡張子マッピングを指定するために <command>afpd</command>(8) が利用する設定ファイル</refpurpose>
+    <refpurpose>ファイル名拡張子マッピングを指定するために <command>afpd</command>(8)
+    が利用する設定ファイル</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
     <cmdsynopsis>
-      <command>@pkgconfdir@/extmap.conf</command>
+      <command>extmap.conf</command>
     </cmdsynopsis>
   </refsynopsisdiv>
 
   <refsect1>
     <title>説明</title>
 
-    <para>
-      <filename>@pkgconfdir@/extmap.conf</filename>はファイル名拡張子マッピングを指定するために<command>afpd</command>が利用する設定ファイルである。</para>
+    <para><filename>extmap.conf</filename>はファイル名拡張子マッピングを指定するために<command>afpd</command>が利用する設定ファイルである。</para>
 
     <para>設定行は以下のように構成される。</para>
 
-    <para><filename>.extension</filename> <replaceable> [ type [
-    creator ] ]</replaceable></para>
+    <para><filename>.extension</filename> <replaceable> [ type [ creator ]
+    ]</replaceable></para>
 
-    <para>ハッシュ文字(“#”) で始まるいかなる行も無視される。ドットで始まる行はファイル名拡張子マッピングを指定する。拡張子 '.' は他の非分類Unixファイルのデフォルトのタイプとクリエータを設定する。</para>
-
+    <para>ハッシュ文字(“#”) で始まるいかなる行も無視される。ドットで始まる行はファイル名拡張子マッピングを指定する。拡張子 '.'
+    は他の非分類Unixファイルのデフォルトのタイプとクリエータを設定する。</para>
   </refsect1>
 
   <refsect1>
@@ -45,15 +47,14 @@
     <example>
       <title>拡張子がjpg。タイプが"JPEG"。クリエータが"ogle"。</title>
 
-            <programlisting>.jpg "JPEG" "ogle"</programlisting>
-          </example>
+      <programlisting>.jpg "JPEG" "ogle"</programlisting>
+    </example>
 
     <example>
       <title>拡張子がlzh。タイプが"LHA "。クリエータは定義されない。</title>
 
-            <programlisting>.lzh "LHA "</programlisting>
-          </example>
-
+      <programlisting>.lzh "LHA "</programlisting>
+    </example>
   </refsect1>
 
   <refsect1>
@@ -71,8 +72,9 @@
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man8/afpd.8.xml
+++ b/doc/ja/manpages/man8/afpd.8.xml
@@ -8,7 +8,9 @@
     <refmiscinfo class="date">19 Jan 2013</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
@@ -32,20 +34,21 @@
 
       <group choice="plain">
         <arg choice="plain">-v</arg>
+
         <arg choice="plain">-V</arg>
+
         <arg choice="plain">-h</arg>
       </group>
-
     </cmdsynopsis>
   </refsynopsisdiv>
 
   <refsect1>
     <title>説明</title>
 
-    <para><command>afpd</command>はUnixファイルシステムにApple Filing Protocol (AFP)インターフェースを提供する。これは通常、<command>netatalk</command>(8)によってブート時に起動される。</para>
+    <para><command>afpd</command>はUnixファイルシステムにApple Filing Protocol
+    (AFP)インターフェースを提供する。これは通常、<command>netatalk</command>(8)によってブート時に起動される。</para>
 
-    <para><command>afpd</command>はファイルサーバの挙動と設定を決めるために<filename>@pkgconfdir@/afp.conf</filename>を利用する。</para>
-
+    <para><command>afpd</command>はファイルサーバの挙動と設定を決めるために<filename>afp.conf</filename>を利用する。</para>
   </refsect1>
 
   <refsect1>
@@ -59,7 +62,6 @@
           <para>デーモンがフォークしないことを指定する。</para>
         </listitem>
       </varlistentry>
-
 
       <varlistentry>
         <term>-v</term>
@@ -89,23 +91,25 @@
         <term>-F <replaceable>configfile</replaceable></term>
 
         <listitem>
-          <para>利用する設定ファイルを指定する。 (デフォルトは<filename>@pkgconfdir@/afp.conf</filename> )</para>
+          <para>利用する設定ファイルを指定する。 (デフォルトは<filename>afp.conf</filename> )</para>
         </listitem>
       </varlistentry>
-
     </variablelist>
   </refsect1>
 
   <refsect1>
     <title>シグナル</title>
 
-    <para>最終手段を除いて、ユーザの<command>afpd</command>をシャットダウンするために<command>SIGKILL (-9)</command>を使うのは推奨しない。なぜなら、CNIDデータベースが矛盾したままになるかもしれないからである。<command>afpd</command>を終了する安全な方法は、<command>SIGTERM (-15)</command>シグナルを送ってそれ自身が停止するのを待つことである。</para>
+    <para>最終手段を除いて、ユーザの<command>afpd</command>をシャットダウンするために<command>SIGKILL
+    (-9)</command>を使うのは推奨しない。なぜなら、CNIDデータベースが矛盾したままになるかもしれないからである。<command>afpd</command>を終了する安全な方法は、<command>SIGTERM
+    (-15)</command>シグナルを送ってそれ自身が停止するのを待つことである。</para>
 
     <para>メインの<command>afpd</command>プロセスにSIGTERMやSIGUSR1を送れば子プロセスに伝わるので、全部に作用するだろう。</para>
 
     <variablelist>
       <varlistentry>
         <term>SIGTERM</term>
+
         <listitem>
           <para>きれいに終了する。マスタプロセスから子プロセスに伝わる。</para>
         </listitem>
@@ -113,6 +117,7 @@
 
       <varlistentry>
         <term>SIGQUIT</term>
+
         <listitem>
           <para>マスタ<command>afpd</command>にこれを送ると全ての子プロセスを終了する。休止時間なしでAFPサービスを実施するのに使われる。</para>
         </listitem>
@@ -120,6 +125,7 @@
 
       <varlistentry>
         <term>SIGHUP</term>
+
         <listitem>
           <para>afpdに<command>SIGHUP</command>を送ると設定ファイルを再読み込みする。</para>
         </listitem>
@@ -127,6 +133,7 @@
 
       <varlistentry>
         <term>SIGINT</term>
+
         <listitem>
           <para>子プロセスの<command>afpd</command>に<command>SIGINT</command>を送ると、このプロセスの<emphasis>max_debug</emphasis>ログを有効にします。ログは<filename>/tmp/afpd.PID.XXXXXX</filename>に送られます。更に<command>SIGINT</command>を送ると元のログ設定に戻ります。</para>
         </listitem>
@@ -134,13 +141,17 @@
 
       <varlistentry>
         <term>SIGUSR1</term>
+
         <listitem>
-          <para><command>afpd</command>プロセスはクライアントに「The server is going down for maintenance.」というメッセージを送り、5分後に自身を終了します。新規接続を許しません。子プロセスのafpdにこれを送った場合、他の子プロセスには影響しません。それでもメインプロセスは終了するだろうし、全ての新規接続は無効になります。</para>
+          <para><command>afpd</command>プロセスはクライアントに「The server is going down
+          for
+          maintenance.」というメッセージを送り、5分後に自身を終了します。新規接続を許しません。子プロセスのafpdにこれを送った場合、他の子プロセスには影響しません。それでもメインプロセスは終了するだろうし、全ての新規接続は無効になります。</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
         <term>SIGUSR2</term>
+
         <listitem>
           <para><command>afpd</command>プロセスはビルド時に設定したメッセージディレクトリの下のmessage.pidという名前のファイルを探します。発見したプロセスについて、その内容をメッセージとして対応するAFPクライアントに送ります。メッセージを送った後にファイルは削除されます。このシグナルは子プロセスの<command>afpd</command>にのみ送るべきです。</para>
         </listitem>
@@ -153,7 +164,7 @@
 
     <variablelist>
       <varlistentry>
-        <term><filename>@pkgconfdir@/afp.conf</filename></term>
+        <term><filename>afp.conf</filename></term>
 
         <listitem>
           <para>afpdが使う設定ファイル</para>
@@ -161,7 +172,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@localstatedir@/netatalk/afp_signature.conf</filename></term>
+        <term><filename>afp_signature.conf</filename></term>
 
         <listitem>
           <para>サーバシグネチャのリスト</para>
@@ -169,7 +180,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@localstatedir@/netatalk/afp_voluuid.conf</filename></term>
+        <term><filename>afp_voluuid.conf</filename></term>
 
         <listitem>
           <para>Time MachineボリュームのUUIDのリスト</para>
@@ -177,7 +188,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@pkgconfdir@/extmap.conf</filename></term>
+        <term><filename>extmap.conf</filename></term>
 
         <listitem>
           <para>ファイル名拡張子マッピング</para>
@@ -185,7 +196,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><filename>@pkgconfdir@/msg/message.pid</filename></term>
+        <term><filename>message.pid</filename></term>
 
         <listitem>
           <para>ユーザへ送るメッセージの内容。</para>
@@ -229,8 +240,9 @@
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man8/cnid_dbd.8.xml
+++ b/doc/ja/manpages/man8/cnid_dbd.8.xml
@@ -8,7 +8,9 @@
     <refmiscinfo class="date">17 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
@@ -26,27 +28,53 @@
     <cmdsynopsis>
       <command>cnid_dbd</command>
 
-        <group choice="plain">
-          <arg choice="plain">-v</arg>
-          <arg choice="plain">-V</arg>
-        </group>
+      <group choice="plain">
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 
   <refsect1>
     <title>説明</title>
 
-    <para><command>cnid_dbd</command>はストレージとカタログノードID (CNID)と関連情報の検索のためのインターフェースを<emphasis remap="B">afpd</emphasis>デーモンに提供する。CNIDはMacintoshベースのファイルシステムの構成要素であるが、これの動作は単純にはUnixファイルシステム上にマッピングできない。従って、一つのデータベース内に分離した記憶域が必要となる。<command>cnid_dbd</command>は<emphasis remap="B">afpd</emphasis>の<emphasis remap="B">CNIDバックエンド</emphasis>の一つであり、<emphasis remap="B">dbd</emphasis>バックエンドを実装する。</para>
+    <para><command>cnid_dbd</command>はストレージとカタログノードID
+    (CNID)と関連情報の検索のためのインターフェースを<emphasis
+    remap="B">afpd</emphasis>デーモンに提供する。CNIDはMacintoshベースのファイルシステムの構成要素であるが、これの動作は単純にはUnixファイルシステム上にマッピングできない。従って、一つのデータベース内に分離した記憶域が必要となる。<command>cnid_dbd</command>は<emphasis
+    remap="B">afpd</emphasis>の<emphasis
+    remap="B">CNIDバックエンド</emphasis>の一つであり、<emphasis
+    remap="B">dbd</emphasis>バックエンドを実装する。</para>
 
-    <para><command>cnid_dbd</command>はコマンドラインやシステム起動スクリプトではなく、<emphasis remap="B">cnid_metad</emphasis>デーモンによって起動する。netatalkボリューム一つにつき、<command>cnid_dbd</command>のインスタンスが一つである。</para>
+    <para><command>cnid_dbd</command>はコマンドラインやシステム起動スクリプトではなく、<emphasis
+    remap="B">cnid_metad</emphasis>デーモンによって起動する。netatalkボリューム一つにつき、<command>cnid_dbd</command>のインスタンスが一つである。</para>
 
-    <para><command>cnid_dbd</command>は<emphasis remap="B">Berkeley DB</emphasis>データベースライブラリを用いて、トランザクションで保護したアップデートを行う。トランザクションによる<emphasis remap="B">dbd</emphasis>バックエンドは、たとえシステムが不意にクラッシュしても、CNIDデータベースの破損を防ぐだろう。</para>
+    <para><command>cnid_dbd</command>は<emphasis remap="B">Berkeley
+    DB</emphasis>データベースライブラリを用いて、トランザクションで保護したアップデートを行う。トランザクションによる<emphasis
+    remap="B">dbd</emphasis>バックエンドは、たとえシステムが不意にクラッシュしても、CNIDデータベースの破損を防ぐだろう。</para>
 
-    <para><command>cnid_dbd</command>は起動時に<emphasis remap="B">cnid_metad</emphasis>からの有効なユーザIDとグループIDを継承する。普通、この動作はnetatalkボリュームをクライアントへ提供する<emphasis remap="B">afpd</emphasis>によって生じる。それはボリュームに関連付けられた<emphasis remap="B">Berkeley DB</emphasis>データベースのホームディレクトリ<emphasis remap="I">dbdir</emphasis>を変更する。もし<emphasis remap="B">cnid_metad</emphasis>から継承したユーザIDが0 (root)ならば、<command>cnid_dbd</command>はユーザIDとグループIDをデータベースホームディレクトリの所有者とグループに変更する。そうでない場合は、継承した値を使い続ける。このとき、<command>cnid_dbd</command>はデータベースを開き、ファイル記述子<emphasis remap="I">clntfd</emphasis>を使って要求されたものを提供開始する。同じボリュームへアクセスしようとする次の<emphasis remap="B">afpd</emphasis>のインスタンスは、ファイル記述子<emphasis remap="I">ctrlfd</emphasis>を用いる<emphasis remap="B">cnid_metad</emphasis>によって、既に動いている<command>cnid_dbd</command>へリダイレクトされる。</para>
+    <para><command>cnid_dbd</command>は起動時に<emphasis
+    remap="B">cnid_metad</emphasis>からの有効なユーザIDとグループIDを継承する。普通、この動作はnetatalkボリュームをクライアントへ提供する<emphasis
+    remap="B">afpd</emphasis>によって生じる。それはボリュームに関連付けられた<emphasis
+    remap="B">Berkeley DB</emphasis>データベースのホームディレクトリ<emphasis
+    remap="I">dbdir</emphasis>を変更する。もし<emphasis
+    remap="B">cnid_metad</emphasis>から継承したユーザIDが0
+    (root)ならば、<command>cnid_dbd</command>はユーザIDとグループIDをデータベースホームディレクトリの所有者とグループに変更する。そうでない場合は、継承した値を使い続ける。このとき、<command>cnid_dbd</command>はデータベースを開き、ファイル記述子<emphasis
+    remap="I">clntfd</emphasis>を使って要求されたものを提供開始する。同じボリュームへアクセスしようとする次の<emphasis
+    remap="B">afpd</emphasis>のインスタンスは、ファイル記述子<emphasis
+    remap="I">ctrlfd</emphasis>を用いる<emphasis
+    remap="B">cnid_metad</emphasis>によって、既に動いている<command>cnid_dbd</command>へリダイレクトされる。</para>
 
-    <para><command>cnid_dbd</command>は、永久に動作するか、または不活性期間の後に終了するかを設定できる。もし<command>cnid_dbd</command>がTERMやINTシグナルを受け取った場合、汚れたデータベースバッファをディスクにフラッシュし、<emphasis remap="B">Berkeley DB</emphasis>データベース環境を閉じてから、綺麗に終了する。この方法で<command>cnid_dbd</command>を終了するのは安全な事であり、もし必要なら再起動する。他のシグナルは処理されず、即座に終了するか、もしかすると(トランザクションなしのとき)CNIDデータベースを矛盾した状態のままにしておくか、(トランザクションありのとき)リカバリ中の直近の更新を失うかするだろう。</para>
+    <para><command>cnid_dbd</command>は、永久に動作するか、または不活性期間の後に終了するかを設定できる。もし<command>cnid_dbd</command>がTERMやINTシグナルを受け取った場合、汚れたデータベースバッファをディスクにフラッシュし、<emphasis
+    remap="B">Berkeley
+    DB</emphasis>データベース環境を閉じてから、綺麗に終了する。この方法で<command>cnid_dbd</command>を終了するのは安全な事であり、もし必要なら再起動する。他のシグナルは処理されず、即座に終了するか、もしかすると(トランザクションなしのとき)CNIDデータベースを矛盾した状態のままにしておくか、(トランザクションありのとき)リカバリ中の直近の更新を失うかするだろう。</para>
 
-    <para><emphasis remap="B">Berkeley DB</emphasis>データベースサブシステムは、データベースのホームディレクトリ<emphasis remap="I">dbdir</emphasis>にlog.xxxxxxxxxxという名前のファイルを作る。ここでxxxxxxxxxxは、単調増加する整数である。これらのファイルにはトランザクションにおけるデータベースの変更が記載されている。これらのファイルは、<emphasis remap="I">db_param</emphasis>設定ファイル(以下を見よ)で<emphasis remap="B">logfile_autoremove</emphasis>の値が0 (デフォルトは1)に設定されている場合を除いて、定期的に削除される。</para>
+    <para><emphasis remap="B">Berkeley
+    DB</emphasis>データベースサブシステムは、データベースのホームディレクトリ<emphasis
+    remap="I">dbdir</emphasis>にlog.xxxxxxxxxxという名前のファイルを作る。ここでxxxxxxxxxxは、単調増加する整数である。これらのファイルにはトランザクションにおけるデータベースの変更が記載されている。これらのファイルは、<emphasis
+    remap="I">db_param</emphasis>設定ファイル(以下を見よ)で<emphasis
+    remap="B">logfile_autoremove</emphasis>の値が0
+    (デフォルトは1)に設定されている場合を除いて、定期的に削除される。</para>
   </refsect1>
 
   <refsect1>
@@ -66,14 +94,17 @@
   <refsect1>
     <title>設定</title>
 
-    <para><command>cnid_dbd</command>は起動時、データベースディレクトリ<emphasis remap="I">dbdir</emphasis> の中のファイル<emphasis remap="I">db_param</emphasis>から設定情報を読む。ファイルがない場合やパラメータが載っていない場合、適切なデフォルト値が使われる。ひとつのパラメータのフォーマットは、まずパラメータ名、それに続く一つ以上のスペース、それに続くパラメータ値、それに続く改行で構成される。現在以下のパラメータが認識される:</para>
+    <para><command>cnid_dbd</command>は起動時、データベースディレクトリ<emphasis
+    remap="I">dbdir</emphasis> の中のファイル<emphasis
+    remap="I">db_param</emphasis>から設定情報を読む。ファイルがない場合やパラメータが載っていない場合、適切なデフォルト値が使われる。ひとつのパラメータのフォーマットは、まずパラメータ名、それに続く一つ以上のスペース、それに続くパラメータ値、それに続く改行で構成される。現在以下のパラメータが認識される:</para>
 
     <variablelist remap="TP">
       <varlistentry>
         <term><emphasis remap="B">logfile_autoremove</emphasis></term>
 
         <listitem>
-          <para>もし0を設定した場合、<command>cnid_dbd</command>の起動時に未使用のBerkeley DBトランザクションのログファイル(データベースホームディレクトリの中のlog.xxxxxxxxxx)の定期的な削除が行われない。デフォルトは1。</para>
+          <para>もし0を設定した場合、<command>cnid_dbd</command>の起動時に未使用のBerkeley
+          DBトランザクションのログファイル(データベースホームディレクトリの中のlog.xxxxxxxxxx)の定期的な削除が行われない。デフォルトは1。</para>
         </listitem>
       </varlistentry>
 
@@ -81,7 +112,13 @@
         <term><emphasis remap="B">cachesize</emphasis></term>
 
         <listitem>
-          <para>Berkeley DBのキャッシュサイズをキロバイト単位で決定する。デフォルトは8192。それぞれの<command>cnid_dbd</command>プロセスは通常のメモリ占有量に加えて大量のメモリを獲得する。これはデータベースのパフォーマンスを調整するのに使われる。Berkeley DBに附属する<emphasis remap="B">db_stat</emphasis>ユーティリティに<option>-m</option>オプションを付けると、この値を変更すべきかどうかを決定するのに役立つ。デフォルトではキャッシュが要求の大半を丁度良く満たすように極めて保守的な値になっている。メモリがシステムのボトルネックにならないなら、あなたはその値を放置してよい。<emphasis remap="B">Berkeley DB Tutorial and Reference Guide</emphasis>には、より詳しい情報を記した<emphasis remap="B">Selecting a cache size</emphasis>という章がある。</para>
+          <para>Berkeley
+          DBのキャッシュサイズをキロバイト単位で決定する。デフォルトは8192。それぞれの<command>cnid_dbd</command>プロセスは通常のメモリ占有量に加えて大量のメモリを獲得する。これはデータベースのパフォーマンスを調整するのに使われる。Berkeley
+          DBに附属する<emphasis
+          remap="B">db_stat</emphasis>ユーティリティに<option>-m</option>オプションを付けると、この値を変更すべきかどうかを決定するのに役立つ。デフォルトではキャッシュが要求の大半を丁度良く満たすように極めて保守的な値になっている。メモリがシステムのボトルネックにならないなら、あなたはその値を放置してよい。<emphasis
+          remap="B">Berkeley DB Tutorial and Reference
+          Guide</emphasis>には、より詳しい情報を記した<emphasis remap="B">Selecting a cache
+          size</emphasis>という章がある。</para>
         </listitem>
       </varlistentry>
 
@@ -91,7 +128,12 @@
         <term><emphasis remap="B">flush_interval</emphasis></term>
 
         <listitem>
-          <para><emphasis remap="I">flush_frequency</emphasis> (デフォルト: 1000)と<emphasis remap="I">flush_interval</emphasis> (デフォルト: 1800)はデータベースへの変更を書き戻す頻度を制御する。これらの両方動作は、i) <emphasis remap="I">flush_frequency</emphasis>を越える要求を受け取った場合、ii) 最後の保存/書き戻しから<emphasis remap="I">flush_interval</emphasis>秒よりも経過した場合のどちらかで実行される。ディスクキャッシュ設定のため、あなたのハードディスク設定の確認に慎重を期してください。多くのIDEディスクはデフォルト動作では書き込みを単にキャッシュするだけです。従って、たとえデータベースファイルをフラッシュしても期待した効果は得られないでしょう。</para>
+          <para><emphasis remap="I">flush_frequency</emphasis> (デフォルト:
+          1000)と<emphasis remap="I">flush_interval</emphasis> (デフォルト:
+          1800)はデータベースへの変更を書き戻す頻度を制御する。これらの両方動作は、i) <emphasis
+          remap="I">flush_frequency</emphasis>を越える要求を受け取った場合、ii)
+          最後の保存/書き戻しから<emphasis
+          remap="I">flush_interval</emphasis>秒よりも経過した場合のどちらかで実行される。ディスクキャッシュ設定のため、あなたのハードディスク設定の確認に慎重を期してください。多くのIDEディスクはデフォルト動作では書き込みを単にキャッシュするだけです。従って、たとえデータベースファイルをフラッシュしても期待した効果は得られないでしょう。</para>
         </listitem>
       </varlistentry>
 
@@ -99,7 +141,10 @@
         <term><emphasis remap="B">fd_table_size</emphasis></term>
 
         <listitem>
-          <para><emphasis remap="B">afpd</emphasis>クライアントが<emphasis remap="B">cnid_dbd</emphasis>で処理するために開く最大の接続数(ファイル記述子数)。デフォルトは512。この値を超えた場合、存在する接続のうち一つを閉じて再利用する。影響を受けた<emphasis remap="B">afpd</emphasis>プロセスは後に透過的に再接続される。これは僅かなオーバヘッドを生じる。一方、全ての記述子を<function>select()</function>システムコールでチェックしなければならないので、このパラメータを極めて高い値に設定すると<command>cnid_dbd</command>のパフォーマンスに影響するかもしれないし、更に悪いことにプロセスあたりに開くファイル記述子のシステム上の上限を超えるかもしれない。たった一つの<emphasis remap="B">afpd</emphasis>クライアントプロセスが動作すると予想されるボリュームでは、この値を1に設定すると安全である。例えばホームディレクトリである。</para>
+          <para><emphasis remap="B">afpd</emphasis>クライアントが<emphasis
+          remap="B">cnid_dbd</emphasis>で処理するために開く最大の接続数(ファイル記述子数)。デフォルトは512。この値を超えた場合、存在する接続のうち一つを閉じて再利用する。影響を受けた<emphasis
+          remap="B">afpd</emphasis>プロセスは後に透過的に再接続される。これは僅かなオーバヘッドを生じる。一方、全ての記述子を<function>select()</function>システムコールでチェックしなければならないので、このパラメータを極めて高い値に設定すると<command>cnid_dbd</command>のパフォーマンスに影響するかもしれないし、更に悪いことにプロセスあたりに開くファイル記述子のシステム上の上限を超えるかもしれない。たった一つの<emphasis
+          remap="B">afpd</emphasis>クライアントプロセスが動作すると予想されるボリュームでは、この値を1に設定すると安全である。例えばホームディレクトリである。</para>
         </listitem>
       </varlistentry>
 
@@ -116,9 +161,13 @@
   <refsect1>
     <title>アップデート</title>
 
-    <para>Netatalk 2.1の<emphasis>後</emphasis>に出た最初のバージョン、すなわちNetatalk 2.1.1は、手動操作なしに自動的にBerkeley DBアップデートをサポートすることに注意せよ。言い換えると、Netatalk 2.1はBerkeley DBデータベースのアップグレードを準備するコードと、既に準備されている場合にそれをアップグレードするコードを含んでいる。これはバージョン2.0.xからはアップグレードできないことを意味する。なぜならデータベースの準備をしていないからである。</para>
+    <para>Netatalk 2.1の<emphasis>後</emphasis>に出た最初のバージョン、すなわちNetatalk
+    2.1.1は、手動操作なしに自動的にBerkeley DBアップデートをサポートすることに注意せよ。言い換えると、Netatalk
+    2.1はBerkeley
+    DBデータベースのアップグレードを準備するコードと、既に準備されている場合にそれをアップグレードするコードを含んでいる。これはバージョン2.0.xからはアップグレードできないことを意味する。なぜならデータベースの準備をしていないからである。</para>
 
-    <para>異なるバージョンのBerkeley DBライブラリを使っている古いNetatalkをアップデートするためには、以下の手順をとります:</para>
+    <para>異なるバージョンのBerkeley
+    DBライブラリを使っている古いNetatalkをアップデートするためには、以下の手順をとります:</para>
 
     <itemizedlist>
       <listitem>
@@ -136,14 +185,14 @@
       </listitem>
 
       <listitem>
-        <para>再び新しいBerkeley DBユーティリティを使って、<command>db_checkpoint -1 -h &lt;.AppleDBのパス&gt;</command> を実行する</para>
+        <para>再び新しいBerkeley DBユーティリティを使って、<command>db_checkpoint -1 -h
+        &lt;.AppleDBのパス&gt;</command> を実行する</para>
       </listitem>
 
       <listitem>
         <para>新しいバージョンのNetatalkを起動する</para>
       </listitem>
     </itemizedlist>
-
   </refsect1>
 
   <refsect1>
@@ -165,8 +214,9 @@
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man8/cnid_metad.8.xml
+++ b/doc/ja/manpages/man8/cnid_metad.8.xml
@@ -8,14 +8,17 @@
     <refmiscinfo class="date">17 Mar 2024</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
   <refnamediv>
     <refname>cnid_metad</refname>
 
-    <refpurpose>要求に応じて <command>cnid_dbd</command>(8) デーモンを起動するデーモン</refpurpose>
+    <refpurpose>要求に応じて <command>cnid_dbd</command>(8)
+    デーモンを起動するデーモン</refpurpose>
   </refnamediv>
 
   <refsynopsisdiv>
@@ -31,37 +34,44 @@
     <cmdsynopsis>
       <command>cnid_metad</command>
 
-	<group choice="plain">
-	  <arg choice="plain">-v</arg>
-	  <arg choice="plain">-V</arg>
-	</group>
+      <group choice="plain">
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 
   <refsect1>
     <title>説明</title>
 
-    <para><command>cnid_metad</command>は<emphasis remap="B">afpd</emphasis>からの要求を待ち、<emphasis remap="B">cnid_dbd</emphasis>デーモンのインスタンスを起動する。一度起動した<emphasis remap="B">cnid_dbd</emphasis>インスタンスの状態を絶えず把握し、もし必要なら再起動する。<command>cnid_metad</command>は通常、<command>netatalk</command>(8)によってブート時に起動され、シャットダウンまでずっと動作する。</para>
+    <para><command>cnid_metad</command>は<emphasis
+    remap="B">afpd</emphasis>からの要求を待ち、<emphasis
+    remap="B">cnid_dbd</emphasis>デーモンのインスタンスを起動する。一度起動した<emphasis
+    remap="B">cnid_dbd</emphasis>インスタンスの状態を絶えず把握し、もし必要なら再起動する。<command>cnid_metad</command>は通常、<command>netatalk</command>(8)によってブート時に起動され、シャットダウンまでずっと動作する。</para>
   </refsect1>
 
   <refsect1>
     <title>オプション</title>
 
     <variablelist remap="TP">
- 
-     <varlistentry>
+      <varlistentry>
         <term><option>-d</option></term>
 
         <listitem>
-          <para><emphasis remap="B">cnid_metadはフォアグラウンドに留まり、</emphasis>更に標準入力、標準出力、標準エラー出力のファイル記述子を開いたままにする。デバッグに有用。</para>
+          <para><emphasis
+          remap="B">cnid_metadはフォアグラウンドに留まり、</emphasis>更に標準入力、標準出力、標準エラー出力のファイル記述子を開いたままにする。デバッグに有用。</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
-        <term><option>-F</option> <replaceable>configuration file</replaceable></term>
+        <term><option>-F</option> <replaceable>configuration
+        file</replaceable></term>
 
         <listitem>
-          <para>設定ファイルとして<emphasis remap="I">configuration file</emphasis>を使う。デフォルトは<emphasis remap="I">@pkgconfdir@/afp.conf</emphasis>である。</para>
+          <para>設定ファイルとして<emphasis remap="I">configuration
+          file</emphasis>を使う。デフォルトは<emphasis
+          remap="I">afp.conf</emphasis>である。</para>
         </listitem>
       </varlistentry>
 
@@ -78,7 +88,9 @@
   <refsect1>
     <title>警告</title>
 
-    <para><command>cnid_metad</command>はSIGPIPEを除くいかなるシグナルもブロックしないし補足もしない。従って、受け取ったほとんどのシグナルにより終了する。これは、<command>cnid_metad</command>により起動した全ての<emphasis remap="B">cnid_dbd</emphasis>のインスタンスを優雅に終了させる。このような状況により、サブプロセスにアクセスするIPCは<command>cnid_metad</command>によりメモリ上で維持されるだけなので、これは望ましい動作だといえる。<command>cnid_metad</command>が再起動したあとすぐ、<emphasis remap="B">afpd</emphasis>プロセスは透過的に再接続する。</para>
+    <para><command>cnid_metad</command>はSIGPIPEを除くいかなるシグナルもブロックしないし補足もしない。従って、受け取ったほとんどのシグナルにより終了する。これは、<command>cnid_metad</command>により起動した全ての<emphasis
+    remap="B">cnid_dbd</emphasis>のインスタンスを優雅に終了させる。このような状況により、サブプロセスにアクセスするIPCは<command>cnid_metad</command>によりメモリ上で維持されるだけなので、これは望ましい動作だといえる。<command>cnid_metad</command>が再起動したあとすぐ、<emphasis
+    remap="B">afpd</emphasis>プロセスは透過的に再接続する。</para>
   </refsect1>
 
   <refsect1>
@@ -108,8 +120,9 @@
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man8/netatalk.8.xml
+++ b/doc/ja/manpages/man8/netatalk.8.xml
@@ -8,7 +8,9 @@
     <refmiscinfo class="date">13 Jun 2016</refmiscinfo>
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
+
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
     <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
 
@@ -30,6 +32,7 @@
 
       <group choice="plain">
         <arg choice="plain">-v</arg>
+
         <arg choice="plain">-V</arg>
       </group>
     </cmdsynopsis>
@@ -38,7 +41,8 @@
   <refsect1>
     <title>説明</title>
 
-    <para><command>netatalk</command>は、AFPデーモン<command>afpd</command>とCNIDデーモン<command>cnid_metad</command>の起動と再起動を請け負うサービスコントローラデーモンである。これは通常、ブート時にinitシステム (BSDスタイルinit、SysVスタイルinit、systemd、Upstart、OpenRC、SMF等) によって起動される。</para>
+    <para><command>netatalk</command>は、AFPデーモン<command>afpd</command>とCNIDデーモン<command>cnid_metad</command>の起動と再起動を請け負うサービスコントローラデーモンである。これは通常、ブート時にinitシステム
+    (BSDスタイルinit、SysVスタイルinit、systemd、Upstart、OpenRC、SMF等) によって起動される。</para>
   </refsect1>
 
   <refsect1>
@@ -46,10 +50,10 @@
 
     <variablelist>
       <varlistentry>
-        <term>-v | -V</term>
+        <term>-d</term>
 
         <listitem>
-          <para>バージョン情報を表示して終了する。</para>
+          <para>デバッグ目的で、netatalk を非フォーク モードで開始する。</para>
         </listitem>
       </varlistentry>
 
@@ -57,11 +61,17 @@
         <term>-F <replaceable>configfile</replaceable></term>
 
         <listitem>
-          <para>利用する設定ファイルを指定する。 (デフォルトは
-          <filename>@pkgconfdir@/afp.conf</filename> )</para>
+          <para>利用する設定ファイルを指定する。</para>
         </listitem>
       </varlistentry>
 
+      <varlistentry>
+        <term>-v | -V</term>
+
+        <listitem>
+          <para>バージョン情報を表示して終了する。</para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 
@@ -81,7 +91,7 @@
         <term>SIGHUP</term>
 
         <listitem>
-          <para><command>SIGHUP</command>を送るとAFPデーモンが設定ファイルを再読み込みします。</para>
+          <para><command>SIGHUP</command>を送るとAFPデーモンが設定ファイルを再読み込みする。</para>
         </listitem>
       </varlistentry>
     </variablelist>
@@ -92,7 +102,7 @@
 
     <variablelist>
       <varlistentry>
-        <term><filename>@pkgconfdir@/afp.conf</filename></term>
+        <term><filename>afp.conf</filename></term>
 
         <listitem>
           <para><command>netatalk</command>(8)と<command>afpd</command>(8)と<command>cnid_metad</command>(8)が使う設定ファイル</para>
@@ -120,8 +130,9 @@
   </refsect1>
 
   <refsect1>
-      <title>著作者</title>
+    <title>著作者</title>
 
-      <para><ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manual/compile.xml
+++ b/doc/ja/manual/compile.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <appendix id="compile">
-	<title>Compile Netatalk from Source</title>
+	<title>Netatalk をソースコードからコンパイルする</title>
 	<sect1 id="compile-overview">
-		<title>Overview</title>
+		<title>概要</title>
 	</sect1>
 	<sect1>
-		<para>This section describes how to compile Netatalk from source for specific operating systems.</para>
-		<para>Please note that this chapter is automatically generated and may not be optimized for your system.</para>
+		<para>本付録では、特定のオペレーティング システムのソースから Netatalk をコンパイルする方法について説明する。</para>
+		<para>以下文章は自動的に生成されるため、お使いのシステムに最適化されていない可能性があることに注意してください。</para>
 	</sect1>
 	<sect1 id="compile-os">
-		<title>Operating Systems</title>
+		<title>オペレーティング システム一覧</title>
 	</sect1>
 	<sect1>
-		<para>Choose either Autotools or Meson as the build system. Test steps are optional.</para>
+		<para>ビルド システムとして Autotools と Meson から選択する。 テスト手順は任意である。</para>
 		<sect2 id="build-alpine">
 			<title>Alpine Linux</title>
 			<para>Install dependencies</para>
@@ -601,7 +601,7 @@ xsltproc
 		</sect2>
 		<sect2 id="build-dflybsd">
 			<title>DragonflyBSD</title>
-			<para>Install required packages</para>
+			<para>必要なパッケージをインストールする</para>
 			<para>
 				<screen>pkg install -y \
   autoconf \
@@ -623,7 +623,7 @@ xsltproc
   tracker3
 </screen>
 			</para>
-			<para>Configure and build</para>
+			<para>コンフィグレーションとビルド</para>
 			<para>
 				<screen>set -e
 echo "Building with Autotools"
@@ -647,7 +647,7 @@ ninja -C build uninstall
 		</sect2>
 		<sect2 id="build-freebsd">
 			<title>FreeBSD</title>
-			<para>Install required packages</para>
+			<para>必要なパッケージをインストールする</para>
 			<para>
 				<screen>pkg install -y \
   autoconf \
@@ -668,7 +668,7 @@ ninja -C build uninstall
   tracker3
 </screen>
 			</para>
-			<para>Configure and build</para>
+			<para>コンフィグレーションとビルド</para>
 			<para>
 				<screen>set -e
 echo "Building with Autotools"
@@ -707,7 +707,7 @@ ninja -C build uninstall
 		</sect2>
 		<sect2 id="build-netbsd">
 			<title>NetBSD</title>
-			<para>Install required packages</para>
+			<para>必要なパッケージをインストールする</para>
 			<para>
 				<screen>pkg_add \
   autoconf \
@@ -729,7 +729,7 @@ ninja -C build uninstall
   talloc
 </screen>
 			</para>
-			<para>Configure and build</para>
+			<para>コンフィグレーションとビルド</para>
 			<para>
 				<screen>set -e
 echo "Building with Autotools"
@@ -768,7 +768,7 @@ ninja -C build uninstall
 		</sect2>
 		<sect2 id="build-openbsd">
 			<title>OpenBSD</title>
-			<para>Install required packages</para>
+			<para>必要なパッケージをインストールする</para>
 			<para>
 				<screen>pkg_add -I \
   autoconf-2.71 \
@@ -790,7 +790,7 @@ ninja -C build uninstall
   tracker3
 </screen>
 			</para>
-			<para>Configure and build</para>
+			<para>コンフィグレーションとビルド</para>
 			<para>
 				<screen>set -e
 echo "Building with Autotools"
@@ -908,7 +908,7 @@ ninja -C build uninstall
 		</sect2>
 		<sect2 id="build-omnios">
 			<title>OmniOS</title>
-			<para>Install required packages</para>
+			<para>必要なパッケージをインストールする</para>
 			<para>
 				<screen>pkg install \
   build-essential \
@@ -927,7 +927,7 @@ pkgin -y install \
   talloc
 </screen>
 			</para>
-			<para>Configure and build</para>
+			<para>コンフィグレーションとビルド</para>
 			<para>
 				<screen>set -e
 export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
@@ -967,7 +967,7 @@ ninja -C build uninstall
 		</sect2>
 		<sect2 id="build-solaris">
 			<title>Solaris</title>
-			<para>Install required packages</para>
+			<para>必要なパッケージをインストールする</para>
 			<para>
 				<screen>pkg install \
   autoconf \
@@ -994,7 +994,7 @@ make install
 cd ..
 </screen>
 			</para>
-			<para>Configure and build</para>
+			<para>コンフィグレーションとビルド</para>
 			<para>
 				<screen>set -e
 echo "Building with Autotools"

--- a/doc/ja/manual/configuration.xml
+++ b/doc/ja/manual/configuration.xml
@@ -3,1506 +3,1349 @@
   <chapterinfo>
     <author role="first-last">
       <firstname>Eiichirou</firstname>
-      
+
       <surname>UDA（日本語訳）</surname>
     </author>
-    
+
     <pubdate>2016 年 7 月 26 日（訳）</pubdate>
-    
   </chapterinfo>
 
   <title>Netatalk のセットアップ</title>
 
   <sect1>
-    <title>ファイルサービス<indexterm>
-        <primary>ファイルサービス</primary>
+    <title>AFP ファイルサーバーのセットアップ</title>
 
-        <secondary>Netatalk のファイルサービス</secondary>
-      </indexterm></title>
-
-    <para>Netatalk は AFP<indexterm>
+    <para>AFP<indexterm>
         <primary>AFP</primary>
 
         <secondary>Apple Filing Protocol</secondary>
-      </indexterm> サービスを提供するものである．</para>
+      </indexterm> (Apple Filing Protocol) はアップル・マッキントッシュのファイルサービス<indexterm>
+        <primary>ファイルサービス</primary>
+
+        <secondary>Netatalk のファイルサービス</secondary>
+      </indexterm>に用いるプロトコルである。AFP プロトコルは年を追うごとに進展を見せ、最終バージョンは OS X
+    Lion<indexterm>
+        <primary>Lion</primary>
+
+        <secondary>Mac OS X 10.7</secondary>
+      </indexterm> (10.7) のマイナーリリースにあわせて加えられた "AFP 3.4" である。</para>
+
+    <para>Netatalk の afpd デーモンはアップルのクライアントに対して AFP ファイルサービスを提供する。設定ファイルは
+    <filename>afp.conf</filename> のみで、"ini" スタイルの構文で記述する。</para>
+
+    <para><link linkend="spotlight">Spotlight</link><indexterm>
+        <primary>Spotlight</primary>
+      </indexterm> サポートは Netatalk 3.1 より加えられた。</para>
+
+    <para>Mac OS X 10.5 (Leopard) で、AFP 経由での Time Machine
+    バックアップがサポートされるようになった。二つの新機能で、バックアップをただサーバーのキャッシュにではなく、
+    動作中のディスクに書き込むことを確実にしている。ホストのオペレーティングシステムが異なると、
+    このキャッシュをフラッシュする払い出し方も異なる。ヴォリュームを作成するために、Time Machine
+    ターゲットのボリューム作成にはボリュームオプション "<option>time machine = yes</option>"
+    を使用する。</para>
+
+    <para>Netatalk 2.1 以降では UNIX シンボリックリンク<indexterm>
+        <primary>シンボリックリンク</primary>
+
+        <secondary>UNIX シンボリックリンク</secondary>
+      </indexterm>をサーバー上で使うことができる。セマンティクスは例えば NFS と同じである、すなわち、Netatalk
+    はサーバー側でシンボリックリンクを追わないが、代わりにクライアント側でシンボリックリンクを解決できるよう完全に転送して、
+    結果としてクライアントのファイルシステムのビュー内でしかるべき場所を示すリンクとなる。</para>
 
     <sect2>
-      <title>AFP ファイルサーバーのセットアップ</title>
+      <title>afp.conf</title>
 
-      <para>AFP (Apple Filing Protocol) はアップル・マッキントッシュのファイルサービスに用いるプロトコルである．
-      AFP プロトコルは年を追うごとに進展を見せ，最新の変更は OS X Lion<indexterm>
-          <primary>Lion</primary>
+      <para><filename>afp.conf</filename> は、AFP ファイルサーバー及び提供する AFP
+      ボリュームの挙動と設定を決定するために afpd が使用する設定ファイルである。</para>
 
-          <secondary>Mac OS X 10.7</secondary>
-        </indexterm> (10.7) のマイナーリリースにあわせて加えられた "AFP 3.4" である．</para>
+      <para><filename>afp.conf</filename> は複数のサーバーセクションに分割できる。すなわち：
+      <variablelist>
+          <varlistentry>
+            <term>[Global]</term>
 
-      <para>afpd デーモンはアップルのクライアントに対してファイルサービスを提供する．唯一必要な設定ファイルは  
-      <filename>afp.conf</filename> のみで，"ini" スタイルの構文で記述する．</para>
+            <listitem>
+              <para>グローバルセクションで基本的なサーバーオプションを定義する</para>
+            </listitem>
+          </varlistentry>
 
-      <para><link linkend="spotlight">Spotlight</link><indexterm>
-          <primary>Spotlight</primary>
-        </indexterm> サポートは Netatalk 3.1 より加えられた．Spotlight をサポートした Netatalk を
-      コンパイルするための情報はこの<link linkend="spotlight-compile">節</link>を参照のこと．</para>
+          <varlistentry>
+            <term>[Homes]</term>
 
-      <para>Mac OS X 10.5 (Leopard) で，AFP 経由での Time Machine バックアップがサポートされるようになった．
-      二つの新機能で，バックアップをただサーバーのキャッシュにではなく，
-      動作中のディスクに書き込むことを確実にしている．ホストのオペレーティングシステムが異なると，
-      このキャッシュをフラッシュする払い出し方も異なる．ヴォリュームを作成するために，
-      Time Machine ターゲットのボリューム作成にはボリュームオプション "<option>time machine = yes</option>" を使用する．</para>
+            <listitem>
+              <para>ホームセクションでユーザーのホームボリュームを定義する</para>
+            </listitem>
+          </varlistentry>
+        </variablelist><option>Global</option> とも
+      <option>Homes</option>、とも呼ばれないセクションは単なる一つの AFP ボリュームであると解釈される</para>
 
-      <para>Netatalk 2.1 以降では UNIX シンボリックリンク<indexterm>
-          <primary>シンボリックリンク</primary>
+      <para><option>Homes</option> を定義してユーザーのホームディレクトリを共有するために、
+      <option>basedir regex</option> オプションを明記しなければならない。
+      これは全てのユーザーのホームの親ディレクトリのパスあるいは正規表現からなる単純な文字列でよい。</para>
 
-          <secondary>UNIX シンボリックリンク</secondary>
-        </indexterm>をサーバー上で使うことができる．セマンティクスは例えば NFS と同じである，
-      すなわち，Netatalk はサーバー側でシンボリックリンクを追わないが，
-      代わりにクライアント側でシンボリックリンクを解決できるよう完全に転送して，
-      結果としてクライアントのファイルシステムのビュー内でしかるべき場所を示すリンクとなる．</para>
+      <para>例：</para>
 
-      <sect3>
-        <title>afp.conf</title>
-
-        <para><filename>afp.conf</filename> は，AFP ファイルサーバー及び提供する AFP 
-        ボリュームの挙動と設定を決定するために afpd が使用する設定ファイルである．</para>
-
-        <para><filename>afp.conf</filename> は複数のサーバーセクションに分割できる．すなわち：
-          <variablelist>
-            <varlistentry>
-              <term>[Global]</term>
-
-              <listitem>
-                <para>グローバルセクションで基本的なサーバーオプションを定義する</para>
-              </listitem>
-            </varlistentry>
-
-            <varlistentry>
-              <term>[Homes]</term>
-
-              <listitem>
-                <para>ホームセクションでユーザーのホームボリュームを定義する</para>
-              </listitem>
-            </varlistentry>
-          </variablelist><option>Global</option> とも 
-          <option>Homes</option>，とも呼ばれないセクションは単なる一つの AFP 
-          ボリュームであると解釈される</para>
-
-        <para><option>Homes</option> を定義してユーザーのホームディレクトリを共有するために，
-        <option>basedir regex</option> オプションを明記しなければならない．
-        これは全てのユーザーのホームの親ディレクトリのパスあるいは正規表現からなる単純な文字列でよい．</para>
-
-        <para>例：</para>
-
-        <para><programlisting>[Homes]
+      <para><programlisting>[Homes]
 basedir regex = /home
 </programlisting></para>
 
-        <para>この場合，AFP サーバーにログインできるユーザーはそれぞれ <filename>/home/（ユーザー名）</filename> 
-        というパス名でのユーザーボリュームを使用できる．</para>
+      <para>この場合、AFP サーバーにログインできるユーザーはそれぞれ <filename>/home/（ユーザー名）</filename>
+      というパス名でのユーザーボリュームを使用できる。</para>
 
-        <para>より複雑なセットアップで，例えば二つの異なったファイルシステムにわたって分割された，
-        大量のユーザーホームディレクトリーのあるサーバーなら：
-          <itemizedlist>
-            <listitem>
-              <para>/RAID1/homes</para>
-            </listitem>
+      <para>より複雑なセットアップで、例えば二つの異なったファイルシステムにわたって分割された、
+      大量のユーザーホームディレクトリーのあるサーバーなら： <itemizedlist>
+          <listitem>
+            <para>/RAID1/homes</para>
+          </listitem>
 
-            <listitem>
-              <para>/RAID2/morehomes</para>
-            </listitem>
-          </itemizedlist>以下の設定が必要である：<programlisting>[Homes]
+          <listitem>
+            <para>/RAID2/morehomes</para>
+          </listitem>
+        </itemizedlist>以下の設定が必要である：<programlisting>[Homes]
 basedir regex = /RAID./.*homes
 </programlisting></para>
 
-        <para>もし，<option>basedir regex</option> にシンボリックリンクが含まれる場合，
-        正規化された絶対パスを指定すべきである．つまり，パス <filename>/home</filename> から 
-        <filename>/usr/home</filename> にシンボリックリンクがはられていた場合：<programlisting>[Homes]
+      <para>もし、<option>basedir regex</option> にシンボリックリンクが含まれる場合、
+      正規化された絶対パスを指定すべきである。つまり、パス <filename>/home</filename> から
+      <filename>/usr/home</filename> にシンボリックリンクがはられていた場合：<programlisting>[Homes]
 basedir regex = /usr/home</programlisting></para>
 
-        <para>他の使用できるオプションの詳細な解説については <citerefentry>
-            <refentrytitle>afp.conf</refentrytitle>
-
-            <manvolnum>5</manvolnum>
-          </citerefentry> の man page を参照いただきたい．</para>
-      </sect3>
-    </sect2>
-
-    <sect2 id="CNID-backends">
-      <title>CNID<indexterm>
-          <primary>CNID</primary>
-
-          <secondary>Catalog Node ID</secondary>
-        </indexterm> バックエンド<indexterm>
-          <primary>バックエンド</primary>
-
-          <secondary>CNID バックエンド</secondary>
-        </indexterm></title>
-
-      <para>SMB や NFS のようなほかのプロトコルとは異なり，ほとんどの場合，
-      AFP プロトコルはファイルやディレクトリをパスではなく ID を通して参照している．
-      （その ID は CNID とも言われ，カタログ・ノード ID (Catalog Node ID) の略である）
-      典型的には，まず AFP リクエストで，例えば，<phrase>“サーバーさん id 167 のディレクトリにある，
-      ファイル名 'Test' というのを開いてください．”</phrase>といった調子でディレクトリ ID<indexterm>
-          <primary>DID</primary>
-
-          <secondary>ディレクトリ ID</secondary>
-        </indexterm>とファイル名を用いる．
-      例えば，Mac での "Aliases" は基本的には ID 
-      として作用する（より最近の AFP クライアントでは絶対パスにフォールバックするが，
-      これは Finder のみで当てはまることであり，アプリケーションでは当てはまらない）．</para>
-
-      <para>AFP ボリュームにある各々のファイルに一意のファイル ID<indexterm>
-          <primary>FID</primary>
-
-          <secondary>ファイル ID</secondary>
-        </indexterm> が割り当てられる．仕様により ID は絶対に再利用禁止であり，ID は 32 bit の数字である．
-      （ディレクトリ ID も同じ ID プールを使用する）このため，
-      ある AFP ボリュームにおよそ 40 億個以上のファイル・フォルダーを書き込むと，
-      その時点で ID プールが枯渇され，当該ボリュームへの新ファイルの書き込みができなくなる．
-      愚痴はなしということでお願いしたい :-)</para>
-
-      <para>Netatalk はホストのファイルシステム内で 
-      ID とファイルあるいはフォルダーのマップ（ID との対応付け）をする必要がある．
-      それを実現するためにいくつかの異なる CNID バックエンド<indexterm>
-          <primary>CNID バックエンド</primary>
-        </indexterm>が用意されていて，<citerefentry>
+      <para>他の使用できるオプションの詳細な解説については <citerefentry>
           <refentrytitle>afp.conf</refentrytitle>
 
           <manvolnum>5</manvolnum>
-        </citerefentry> 設定ファイル内で <option>cnid
-      scheme</option><indexterm>
-          <primary>cnidscheme</primary>
-
-          <secondary>特定の CNID を指定する</secondary>
-        </indexterm> オプションで選択が可能である．CNID バックエンドは基本的には，
-        ストアされた ID &lt;-&gt; 名前を一対一対応させるデータベースである．</para>
-
-      <para>The CNID データベースはデフォルトで <filename>/var/netatalk/CNID</filename> に置かれる．
-      コンパイル時に <command>--localstatedir=PATH</command> オプションで場所を変えられる．</para>
-
-      <para>CNID データベースの検証・修復・再構築のために用いることができる <command>dbd</command> 
-      という名のコマンドが用意されていている．</para>
-
-      <note>
-        <para>netatalk で作業する上で，いくつかの CNID に関する点を留意しておかなければならない．
-        すなわち：</para>
-
-        <itemizedlist>
-          <listitem>
-            <para>"<option>vol dbnest = yes</option>"
-            が指定してある時以外はボリュームをネスト（入れ子）にしてはならない．<indexterm>
-                <primary>ボリュームをネスト（入れ子）にする</primary>
-              </indexterm></para>
-
-          </listitem>
-
-          <listitem>
-            <para>CNID バックエンドはデータベースである．
-            それ故 afpd はファイルサーバーとデータベースの混成物とならしめている．</para>
-          </listitem>
-
-          <listitem>
-            <para>もしファイルシステムに空き容量がなくなった場合，データベースは破損するかもしれない．
-            それを回避するために取る策としては，<option>vol dbpath</option> オプションを使用して，
-            データベースファイルをどこか別の場所に置く，か，クオータ<indexterm>
-                <primary>クオータ</primary>
-
-                <secondary>ディスク使用量のクオータ</secondary>
-            </indexterm>を使っているならば CNID 
-            データベースフォルダーがクオータなしでユーザー／グループのオーナーとなっているか確認する．
-            のいずれかである．</para>
-          </listitem>
-
-          <listitem>
-            <para>NFS 経由でマウントされているボリュームの CNID データベースには注意すべきである．
-            いずれにしろそのような構成にすると決める事自体かなり無謀である．
-            が，さらにデータベースもその上に置くとなると決定的にトラブルの元となる．要はデータベースの破損である．
-            もしどうしても NFS<indexterm>
-                <primary>NFS</primary>
-
-                <secondary>ネットワークファイルシステム</secondary>
-              </indexterm> マウントしたボリュームを使わねばならない場合はデータベースをローカルディスクに置くために
-            <option>vol dbpath</option> ディレクティブを使用するべきである．</para>
-          </listitem>
-        </itemizedlist>
-      </note>
-
-      <sect3>
-        <title>cdb<indexterm>
-            <primary>CDB</primary>
-
-            <secondary>"cdb" CNID バックエンド</secondary>
-          </indexterm></title>
-
-        <para>“コンカレント（concurrent:同時進行）データベース”バックエンドは Berkeley DB を基礎としたものである．
-        このバックエンドだと複数の afpd デーモンが CNID データベースに直接アクセスできる．
-        たとえ複数の afpd プロセスがある一つのボリュームに対して動作中の場合でも同期アクセスについては 
-        Berkeley DB ロック機構が全て負ってくれる．欠点としては，一つの afpd 
-        プロセスのクラッシュのみでデータベースの破損するかもしれないという点である．
-        cdb は数多くのユーザーのホームディレクトリを共有するときのみ使用すべきで，
-        <emphasis>かつ</emphasis>，
-        多数の <command>cnid_dbd</command> プロセスという状態は確実に問題を引き起こすということである．</para>
-      </sect3>
-
-      <sect3>
-        <title>dbd<indexterm>
-            <primary>DBD</primary>
-
-            <secondary>"dbd" CNID バックエンド</secondary>
-          </indexterm></title>
-
-        <para>CNID データベースへのアクセスは cnid_dbd デーモンプロセスのみに制限されている．
-        afpd プロセスはデータベースの読み込みと更新のために cnid_dbd デーモン とやりとりをする．
-        データベースが破損する可能性は経験的にはゼロである．</para>
-
-        <para>本バックエンドは Netatalk 2.1 以来，デフォルトのバックエンドとなっている．</para>
-      </sect3>
-
-      <sect3>
-        <title>tdb<indexterm>
-            <primary>tdb</primary>
-
-            <secondary>"tdb" CNID バックエンド</secondary>
-          </indexterm></title>
-
-        <para><abbrev>tdb</abbrev> はまた別の永続性のある CNID データベースの一つであり，
-        Samba の <emphasis>Trivial Database（軽量データベース）</emphasis>のことでもある．
-        ユーザーボリューム用として <abbrev>cdb</abbrev> の代わりに使用することもできる．
-          <important>
-            <para>本バックエンドは，いかなる場合でも，共有されても<emphasis>なく</emphasis>，
-            複数のクライアントが一度にアクセスすることも<emphasis>ない</emphasis>
-            ボリュームにのみ使用すること．</para>
-          </important><abbrev>tdb</abbrev> はメモリーにデータを保持するデータベースとして動作できるので，
-        このバックエンドは内部向けに（メモリーにデータを保持する CNID データベースとして），
-        最初のデータベースが開けない時など，予備として用いることもできる．
-        これはもちろん再起動にすると CNID は失われるということを意味している．</para>
-      </sect3>
-
-      <sect3>
-        <title>last<indexterm>
-            <primary>Last</primary>
-
-            <secondary>"last" CNID バックエンド</secondary>
-          </indexterm></title>
-
-        <para>last バックエンドはメモリーにデータを保持する tdb データベースである．それ故永続性がない．
-        netatalk 3.0 からは，それは自動的に<emphasis>読み込み専用モード</emphasis>になる．
-        このバックエンドは例えば CD-ROM などに有用である．</para>
-      </sect3>
-
-      <sect3>
-        <title>mysql<indexterm>
-            <primary>MySQL</primary>
-
-            <secondary>"mysql" CNID バックエンド</secondary>
-          </indexterm></title>
-
-        <para>CNID バックエンドは MySQL サーバーを使用する．
-        mysql 開発ライブラリが検出されると、自動的に設定される．
-        コンパイル時に<command>--without-mysql-config</command>で無効にする．</para>
-      </sect3>
+        </citerefentry> の man page を参照いただきたい。</para>
     </sect2>
+  </sect1>
 
-    <sect2 id="charsets">
-      <title>Charsets<indexterm>
-          <primary>Charset</primary>
+  <sect1 id="CNID-backends">
+    <title>CNID<indexterm>
+        <primary>CNID</primary>
 
-          <secondary>キャラクターセット</secondary>
-        </indexterm>/Unicode<indexterm>
-          <primary>Unicode</primary>
+        <secondary>Catalog Node ID</secondary>
+      </indexterm> バックエンド<indexterm>
+        <primary>バックエンド</primary>
+
+        <secondary>CNID バックエンド</secondary>
+      </indexterm></title>
+
+    <para>SMB や NFS のようなほかのプロトコルとは異なり、ほとんどの場合、AFP プロトコルはファイルやディレクトリをパスではなく ID
+    を通して参照している。（その ID は CNID とも言われ、カタログ・ノード ID (Catalog Node ID) の略である）
+    典型的には、まず AFP リクエストで、例えば、<phrase>“サーバーさん id 167 のディレクトリにある、ファイル名 'Test'
+    というのを開いてください。”</phrase>といった調子でディレクトリ ID<indexterm>
+        <primary>DID</primary>
+
+        <secondary>ディレクトリ ID</secondary>
+      </indexterm>とファイル名を用いる。例えば、Mac での "Aliases" は基本的には ID として作用する（より最近の AFP
+    クライアントでは絶対パスにフォールバックするが、これは Finder
+    のみで当てはまることであり、アプリケーションでは当てはまらない）。</para>
+
+    <para>AFP ボリュームにある各々のファイルに一意のファイル ID<indexterm>
+        <primary>FID</primary>
+
+        <secondary>ファイル ID</secondary>
+      </indexterm> が割り当てられる。仕様により ID は絶対に再利用禁止であり、ID は 32 bit の数字である。（ディレクトリ
+    ID も同じ ID プールを使用する）このため、ある AFP ボリュームにおよそ 40 億個以上のファイル・フォルダーを書き込むと、その時点で
+    ID プールが枯渇され、当該ボリュームへの新ファイルの書き込みができなくなる。愚痴はなしということでお願いしたい :-)</para>
+
+    <para>Netatalk はホストのファイルシステム内で ID とファイルあるいはフォルダーのマップ（ID との対応付け）をする必要がある。
+    それを実現するためにいくつかの異なる CNID バックエンド<indexterm>
+        <primary>CNID バックエンド</primary>
+      </indexterm>が用意されていて、<citerefentry>
+        <refentrytitle>afp.conf</refentrytitle>
+
+        <manvolnum>5</manvolnum>
+      </citerefentry> 設定ファイル内で <option>cnid scheme</option><indexterm>
+        <primary>cnidscheme</primary>
+
+        <secondary>特定の CNID を指定する</secondary>
+      </indexterm> オプションで選択が可能である。CNID バックエンドは基本的には、ストアされた ID &lt;-&gt;
+    名前を一対一対応させるデータベースである。</para>
+
+    <para>The CNID データベースはデフォルトで <filename>/var/netatalk/CNID</filename>
+    に置かれる。コンパイル時に <command>localstatedir=PATH</command>
+    オプションで場所を変えられる。</para>
+
+    <para>CNID データベースの検証・修復・再構築のために用いることができる <command>dbd</command>
+    という名のコマンドが用意されていている。</para>
+
+    <note>
+      <para>netatalk で作業する上で、いくつかの CNID に関する点を留意しておかなければならない。すなわち：</para>
+
+      <itemizedlist>
+        <listitem>
+          <para>"<option>vol dbnest = yes</option>"
+          が指定してある時以外はボリュームをネスト（入れ子）にしてはならない。<indexterm>
+              <primary>ボリュームをネスト（入れ子）にする</primary>
+            </indexterm></para>
+        </listitem>
+
+        <listitem>
+          <para>CNID バックエンドはデータベースである。それ故 afpd
+          はファイルサーバーとデータベースの混成物とならしめている。</para>
+        </listitem>
+
+        <listitem>
+          <para>もしファイルシステムに空き容量がなくなった場合、データベースは破損するかもしれない。
+          それを回避するために取る策としては、<option>vol dbpath</option> オプションを使用して、
+          データベースファイルをどこか別の場所に置く、か、クオータ<indexterm>
+              <primary>クオータ</primary>
+
+              <secondary>ディスク使用量のクオータ</secondary>
+            </indexterm>を使っているならば CNID
+          データベースフォルダーがクオータなしでユーザー／グループのオーナーとなっているか確認する。のいずれかである。</para>
+        </listitem>
+
+        <listitem>
+          <para>NFS 経由でマウントされているボリュームの CNID データベースには注意すべきである。
+          いずれにしろそのような構成にすると決める事自体かなり無謀である。
+          が、さらにデータベースもその上に置くとなると決定的にトラブルの元となる。要はデータベースの破損である。もしどうしても
+          NFS<indexterm>
+              <primary>NFS</primary>
+
+              <secondary>ネットワークファイルシステム</secondary>
+            </indexterm> マウントしたボリュームを使わねばならない場合はデータベースをローカルディスクに置くために
+          <option>vol dbpath</option> ディレクティブを使用するべきである。</para>
+        </listitem>
+      </itemizedlist>
+    </note>
+
+    <sect2>
+      <title>cdb<indexterm>
+          <primary>CDB</primary>
+
+          <secondary>"cdb" CNID バックエンド</secondary>
         </indexterm></title>
 
-      <para></para>
-
-      <sect3>
-        <title>なぜ Unicode？</title>
-
-        <para>内部的には，コンピューターは文字（キャラクター）について，
-        テキストについて何も知らない，唯一“数字（数）”ならコンピュータにもわかる．
-        それ故各々の“字”には“数”が割り当てられている．キャラクターセット，しばしば
-        <emphasis>charset</emphasis> あるいは
-        <emphasis>codepage</emphasis><indexterm>
-            <primary>コードページ</primary>
-          </indexterm> とも呼ばれるが，これは“数”と“字”の一対一対応を規定している．</para>
-
-        <para>二つあるいはそれ以上のコンピューターがお互いに通信する必要がある場合，
-        各々は同じキャラクターセットを使う必要がある．1960 年代には ASCII<indexterm>
-            <primary>ASCII</primary>
-
-            <secondary>American Standard Code for Information
-            Interchange</secondary>
-          </indexterm> (American Standard Code for Information Interchange) 
-        キャラクターセットが 
-        ASA（米国標準協会：the American Standards Association）によって標準化された．
-        オリジナルの ASCII 形式は，
-        英語で用いられるアルファベット及び数字を網羅するのに十分な数より多い 128 
-        のキャラクターを表している．今日においても，
-        ASCII はコンピューターで使われるキャラクタースキームの標準的なものである．</para>
-
-        <para>国際的にもっと都合よく，そして若干内輪向けの記号文字を含めるために，
-        つづくバージョンでは 256 のキャラクターを規定した．
-        このエンコードの仕様だと一文字はきっちり 1 バイトに収まるが，
-        明らかに，256 キャラクターというのは，
-        いろいろな言語で用いる全ての文字を一つのキャラクターに一対一対応させるのに依然十分ではなかった．
-        </para>
-
-        <para>結果的には後にローカライズされたキャラクターセットが規定された．
-        例えば ISO-8859 キャラクターセットである．
-        ほとんどのオペレーティングシステムベンダーは自らの要求を満たすために，
-        独自のキャラクターセットを導入した．すなわち IBM であれば 
-        <emphasis>コードページ 437 (DOSLatinUS)</emphasis>，アップルは 
-        <emphasis>MacRoman</emphasis><indexterm>
-            <primary>MacRoman</primary>
-
-            <secondary>MacRoman charset</secondary>
-          </indexterm> コードページ，などである．
-        127 以上のキャラクターが定義されているものを<emphasis>拡張</emphasis>
-        キャラクターと呼ぶ．
-        これらのキャラクターセットは異なるキャラクターに同じ番号をふってあるので，
-        他のキャラクターセットとまたはキャラクターセット同士で衝突を起こす．</para>
-
-        <para>そういったキャラクターセットのほぼ全てが 256 個のキャラクターを定義していて，
-        最初の 128 個（0 から 127 まで）のキャラクターを ASCII と同一対応となるようにしている．        
-        結果的に，違ったコードページを使っているシステム同士の通信では，事実上
-        ASCII キャラクターセット限定となった．</para>
-
-        <para>この問題を新たに解決するために，より大きいキャラクターセットが規定された．
-        より多くのキャラクターマッピングの場所を確保するために，
-        これらのキャラクターセットは一つのキャラクターの格納のために最低でも 2 バイトを使用する．
-        このためそういったキャラクターセットは<emphasis>マルチバイト</emphasis>
-        キャラクターセットと呼ばれる．</para>
-
-        <para>標準化されたマルチバイトキャラクターエンコード方式として知られているものの一つとして
-        <ulink url="http://www.unicode.org/">ユニコード</ulink>がある．
-        マルチバイトキャラクターセット使用の大きな利点として“それ一つで済む”がある．
-        二つのコンピューターが通信しているときに両者が同じキャラクターセットを使用しているか確認する必要がない．</para>
-      </sect3>
-
-      <sect3>
-        <title>Apple で使われている（使われていた）キャラクターセット</title>
-
-        <para>過去に Apple クライアントは，
-        ネットワーク間の通信のためにシングルバイトのキャラクターセットを使用していた．
-        年を経るに従い，Apple はいくつものキャラクターセットを定義したが，
-        欧米ユーザーは <emphasis>MacRoman</emphasis> コードセットを最もよく使用するであろう．</para>
-
-        <para>Apple の定義したコードページに含まれるもの：</para>
-
-        <itemizedlist>
-          <listitem>
-            <para>MacArabic, MacFarsi</para>
-          </listitem>
-
-          <listitem>
-            <para>MacCentralEurope</para>
-          </listitem>
-
-          <listitem>
-            <para>MacChineseSimple</para>
-          </listitem>
-
-          <listitem>
-            <para>MacChineseTraditional</para>
-          </listitem>
-
-          <listitem>
-            <para>MacCroatian</para>
-          </listitem>
-
-          <listitem>
-            <para>MacCyrillic</para>
-          </listitem>
-
-          <listitem>
-            <para>MacDevanagari</para>
-          </listitem>
-
-          <listitem>
-            <para>MacGreek</para>
-          </listitem>
-
-          <listitem>
-            <para>MacHebrew</para>
-          </listitem>
-
-          <listitem>
-            <para>MacIcelandic</para>
-          </listitem>
-
-          <listitem>
-            <para>MacJapanese</para>
-          </listitem>
-
-          <listitem>
-            <para>MacKorean</para>
-          </listitem>
-
-          <listitem>
-            <para>MacRoman</para>
-          </listitem>
-
-          <listitem>
-            <para>MacRomanian</para>
-          </listitem>
-
-          <listitem>
-            <para>MacThai</para>
-          </listitem>
-
-          <listitem>
-            <para>MacTurkish</para>
-          </listitem>
-        </itemizedlist>
-
-        <para>Mac OS X 以降そして AFP3 以降では <ulink url="http://www.utf-8.com/">UTF-8</ulink> 
-        が用いられる．UTF-8 は Unicode キャラクターを ASCII 互換のやり方でエンコードする．
-        各々の Unicode キャラクターは一個から六個の ASCII キャラクターにエンコードされる．
-        故に， UTF-8 自体が本当のキャラクターセットなのではなく，ユニコードキャラクターセットのエンコーディングなのである．</para>
-
-        <para>厄介なことにも Unicode はいくつかの <emphasis> <ulink
-        url="http://www.unicode.org/reports/tr15/index.html">normalization（正規化）</ulink>
-        </emphasis>方式を規定している．<ulink 
-        url="http://www.samba.org">Samba</ulink><indexterm>
-            <primary>Samba</primary>
-          </indexterm> はほとんどの Unix ツールも好んで用いる 
-        <emphasis>precomposed</emphasis><indexterm>
-            <primary>Precomposed</primary>
-
-            <secondary>Precomposed Unicode normalization</secondary>
-          </indexterm> Unicode を使用する．一方 Apple は 
-        <emphasis>decomposed</emphasis><indexterm>
-            <primary>Decomposed</primary>
-
-            <secondary>Decomposed Unicode normalization</secondary>
-          </indexterm> normalization を使うことに決めた．</para>
-
-        <para>例として、ドイツ語の文字 '<keycode>ä</keycode>' についてみてみる．
-        Precomposed normalization を使えば Unicode はこの文字に 0xE4 を対応付ける．
-        Decomposed normalization では 'ä' を正確には 0x61 と 0x308 の二つの文字に対応付ける．
-        0x61 は 'a' に，0x308 は <emphasis>COMBINING
-        DIAERESIS</emphasis>（訳注：いわゆるウムラウト）に対応付けられている．</para>
-
-        <para>Netatalk では precomposed UTF-8 を
-        <emphasis>UTF8</emphasis><indexterm>
-            <primary>UTF8</primary>
-
-            <secondary>Netatalk の precomposed UTF-8 エンコーディング</secondary>
-          </indexterm> と，decomposed UTF-8 を
-        <emphasis>UTF8-MAC</emphasis><indexterm>
-            <primary>UTF8-MAC</primary>
-
-            <secondary>Netatalk の decomposed UTF-8 エンコーディング</secondary>
-          </indexterm> と呼ぶ．</para>
-
-      </sect3>
-
-      <sect3>
-        <title>afpd とキャラクターセット</title>
-
-        <para>新しい AFP 3.x クライアントも古い AFP 2.x クライアントも同時にサポートするために，
-        afpd は使われている様々なキャラクターセット間の変換が可能であることを必要とした．
-        AFP 3.x クライアントは常に UTF8-MAC を，
-        AFP 2.x クライアントは Apple コードページのうちの一つを使う．</para>
-
-        <para>本稿執筆時点（訳注：原文の）で，
-        netatalk は以下の Apple コードページをサポートしている：</para>
-
-        <itemizedlist>
-          <listitem>
-            <para>MAC_CENTRALEUROPE</para>
-          </listitem>
-
-          <listitem>
-            <para>MAC_CHINESE_SIMP</para>
-          </listitem>
-
-          <listitem>
-            <para>MAC_CHINESE_TRAD</para>
-          </listitem>
-
-          <listitem>
-            <para>MAC_CYRILLIC</para>
-          </listitem>
-
-          <listitem>
-            <para>MAC_GREEK</para>
-          </listitem>
-
-          <listitem>
-            <para>MAC_HEBREW</para>
-          </listitem>
-
-          <listitem>
-            <para>MAC_JAPANESE</para>
-          </listitem>
-
-          <listitem>
-            <para>MAC_KOREAN</para>
-          </listitem>
-
-          <listitem>
-            <para>MAC_ROMAN</para>
-          </listitem>
-
-          <listitem>
-            <para>MAC_TURKISH</para>
-          </listitem>
-        </itemizedlist>
-
-        <para>afpd は三つの異なるキャラクターセットオプションを扱う：</para>
-
-        <variablelist>
-          <varlistentry>
-            <term>unix charset<indexterm>
-                <primary>unix charset</primary>
-
-                <secondary>afpd の unix charset セッティング</secondary>
-              </indexterm></term>
-
-            <listitem>
-              <para>これはオペレーティングシステムの内側で使われているコードページである．
-              もし指定されていなければ，デフォルトで <option>UTF8</option> になる．
-              もし <option>LOCALE</option> が指定されていて，
-              システムが Unix locales をサポートしていれば，afpd はコードページを検出しようとし，
-              afpd は検出したコードページを使って設定ファイルを読む．
-              なので，ボリューム名やログインメッセージなどに拡張文字を使うことができる．
-              <citerefentry>
-                  <refentrytitle>afp.conf</refentrytitle>
-
-                  <manvolnum>5</manvolnum>
-                </citerefentry> を参照のこと．</para>
-            </listitem>
-          </varlistentry>
-
-          <varlistentry>
-            <term>mac charset<indexterm>
-                <primary>mac charset</primary>
-
-                <secondary>afpd の mac charset セッティング</secondary>
-              </indexterm></term>
-
-            <listitem>
-              <para>既に述べたように，
-              旧式の Mac OS クライアント（AFP 2.2 までのもの）は 
-              afpd と通信するのにコードページを用いる．しかしながら，
-              AFP プロトコルにはクライアントが使用しているコードページの折り合いをつけるというサポートはない．
-              もしほかのどこかで指定されていないと，
-              afpd は <emphasis>MacRoman</emphasis> コードページが使われていると仮定する．
-              クライアントが別のコードページ，
-              例えば <emphasis>MacCyrillic</emphasis> を使っていたならば, 
-              それを明示的に設定<emphasis role="bold">しなければならない</emphasis>だろう．
-              <citerefentry>
-                  <refentrytitle>afp.conf</refentrytitle>
-
-                  <manvolnum>5</manvolnum>
-                </citerefentry> を参照のこと．</para>
-            </listitem>
-          </varlistentry>
-
-          <varlistentry>
-            <term>vol charset<indexterm>
-                <primary>vol charset</primary>
-
-                <secondary>afpd の vol charset セッティング</secondary>
-              </indexterm></term>
-
-            <listitem>
-              <para>これは afpd がディスク上のファイル名として使うべき charset を定義する．
-              デフォルトでは <option>unix
-              charset</option> と同じである．もし <ulink
-              url="http://www.gnu.org/software/libiconv/">iconv</ulink><indexterm>
-                  <primary>Iconv</primary>
-
-                  <secondary>iconv エンコーディング変換エンジン</secondary>
-                </indexterm> がインストールしてあるならば，
-                iconv が提供するキャラクターセットも使用することができる．</para>
-
-              <para>afpd はファイルを unix のファイルシステムに保存する時，
-              拡張マッキントッシュキャラクター，
-              あるいは unix のファイル名として不正なキャラクターを保持する手段が必要である．
-              初期のバージョンでは，いわゆる CAP エンコーディング<indexterm>
-                  <primary>CAP エンコーディング</primary>
-
-                  <secondary>CAP スタイルキャラクターエンコーディング</secondary>
-                </indexterm>を使った．拡張キャラクター (&gt;0x7F) は :xx 
-              の 16 進数に変換される．例えば，アップルのロゴ (MacRoman:
-              0xF0) は :f0 として保存される．
-              いくつかの特殊なキャラクターも :xx という表記に変換される．
-              '/' は :2f にエンコードされる．
-              もし， <option>usedots</option> オプションが設定されていなければ，
-              先頭のピリオド '.' は :2e にエンコードされる．</para>
-
-              <para>本ドキュメントでのバージョンではファイル名のデフォルトエンコーディングとして
-              <option>UTF8</option> を使っているにもかかわらず，'/' は ':' に変換される．
-              欧米のユーザーにとって別の有用な設定として <option>vol charset = ISO-8859-15</option> 
-              もあり得る．</para>
-
-              <para>もし，あるキャラクターが <option>mac charset</option> から選定した 
-              <option>vol charset</option> への変換ができない場合，マック上で -50 エラーを受け取るだろう．
-              <emphasis>注意</emphasis>：
-              可能な限り常に，デフォルトの UTF8 ボリュームフォーマットにしてください．
-                            <citerefentry>
-                  <refentrytitle>afp.conf</refentrytitle>
-
-                  <manvolnum>5</manvolnum>
-                </citerefentry> を参照のこと．</para>
-            </listitem>
-          </varlistentry>
-        </variablelist>
-      </sect3>
+      <para>“コンカレント（concurrent:同時進行）データベース”バックエンドは Berkeley DB を基礎としたものである。
+      このバックエンドだと複数の afpd デーモンが CNID データベースに直接アクセスできる。たとえ複数の afpd
+      プロセスがある一つのボリュームに対して動作中の場合でも同期アクセスについては Berkeley DB
+      ロック機構が全て負ってくれる。欠点としては、一つの afpd プロセスのクラッシュのみでデータベースの破損するかもしれないという点である。
+      cdb は数多くのユーザーのホームディレクトリを共有するときのみ使用すべきで、<emphasis>かつ</emphasis>、多数の
+      <command>cnid_dbd</command> プロセスという状態は確実に問題を引き起こすということである。</para>
     </sect2>
 
-    <sect2 id="authentication">
-      <title>認証<indexterm>
-          <primary>認証</primary>
+    <sect2>
+      <title>dbd<indexterm>
+          <primary>DBD</primary>
 
-          <secondary>AFP クライアントとサーバー間の</secondary>
+          <secondary>"dbd" CNID バックエンド</secondary>
         </indexterm></title>
 
-      <sect3>
-        <title>AFP 認証の基本</title>
+      <para>CNID データベースへのアクセスは cnid_dbd デーモンプロセスのみに制限されている。afpd
+      プロセスはデータベースの読み込みと更新のために cnid_dbd デーモン とやりとりをする。
+      データベースが破損する可能性は経験的にはほぼゼロである。</para>
 
-        <para>Apple は AFP クライアントとサーバー間の認証のために 
-        "User Authentication Modules"
-          <indexterm>
-            <primary>UAM</primary>
+      <para>本バックエンドは Netatalk 2.1 以来、デフォルトのバックエンドとなっている。</para>
+    </sect2>
 
-            <secondary>User Authentication Module</secondary>
-          </indexterm> (UAM) と呼ばれる柔軟なモデルを選んだ．
-        AFP クライアントがまず最初に AFP サーバーと接続するとき，
-        サーバーが提供している UAM のリストを問い合わせる．
-        そして，クライアントがサポートしている最も強い暗号化の UAM を選ぶ．</para>
+    <sect2>
+      <title>last<indexterm>
+          <primary>Last</primary>
 
-        <para>数個の UAM は時間をかけて Apple が開発してものであり，
-        サードパーティの開発者によるものもある．</para>
+          <secondary>"last" CNID バックエンド</secondary>
+        </indexterm></title>
+
+      <para>last バックエンドはメモリーにデータを保持する tdb データベースである。それ故永続性がない。netatalk 3.0
+      からは、それは自動的に<emphasis>読み込み専用モード</emphasis>になる。このバックエンドは例えば CD-ROM
+      などに有用である。</para>
+    </sect2>
+
+    <sect2>
+      <title>mysql<indexterm>
+          <primary>MySQL</primary>
+
+          <secondary>"mysql" CNID バックエンド</secondary>
+        </indexterm></title>
+
+      <para>CNID バックエンドは MySQL サーバーを使用する。mysql 開発ライブラリが検出されると、自動的に設定される。
+      コンパイル時に<command>mysql-config</command>で無効にする。</para>
+    </sect2>
+  </sect1>
+
+  <sect1 id="charsets">
+    <title>Charsets<indexterm>
+        <primary>Charset</primary>
+
+        <secondary>キャラクターセット</secondary>
+      </indexterm>/Unicode<indexterm>
+        <primary>Unicode</primary>
+      </indexterm></title>
+
+    <sect2>
+      <title>なぜ Unicode？</title>
+
+      <para>内部的には、コンピューターは文字（キャラクター）について、
+      テキストについて何も知らない、唯一“数字（数）”ならコンピュータにもわかる。
+      それ故各々の“字”には“数”が割り当てられている。キャラクターセット、しばしば <emphasis>charset</emphasis>
+      あるいは <emphasis>codepage</emphasis><indexterm>
+          <primary>コードページ</primary>
+        </indexterm> とも呼ばれるが、これは“数”と“字”の一対一対応を規定している。</para>
+
+      <para>二つあるいはそれ以上のコンピューターがお互いに通信する必要がある場合、各々は同じキャラクターセットを使う必要がある。1960
+      年代には ASCII<indexterm>
+          <primary>ASCII</primary>
+
+          <secondary>American Standard Code for Information
+          Interchange</secondary>
+        </indexterm> (American Standard Code for Information Interchange)
+      キャラクターセットが ASA（米国標準協会：the American Standards Association）によって標準化された。
+      オリジナルの ASCII 形式は、英語で用いられるアルファベット及び数字を網羅するのに十分な数より多い 128
+      のキャラクターを表している。今日においても、ASCII はコンピューターで使われるキャラクタースキームの標準的なものである。</para>
+
+      <para>国際的にもっと都合よく、そして若干内輪向けの記号文字を含めるために、つづくバージョンでは 256 のキャラクターを規定した。
+      このエンコードの仕様だと一文字はきっちり 1 バイトに収まるが、明らかに、256 キャラクターというのは、
+      いろいろな言語で用いる全ての文字を一つのキャラクターに一対一対応させるのに依然十分ではなかった。</para>
+
+      <para>結果的には後にローカライズされたキャラクターセットが規定された。例えば ISO-8859 キャラクターセットである。
+      ほとんどのオペレーティングシステムベンダーは自らの要求を満たすために、独自のキャラクターセットを導入した。すなわち IBM であれば
+      <emphasis>コードページ 437 (DOSLatinUS)</emphasis>、アップルは
+      <emphasis>MacRoman</emphasis><indexterm>
+          <primary>MacRoman</primary>
+
+          <secondary>MacRoman charset</secondary>
+        </indexterm> コードページ、などである。127
+      以上のキャラクターが定義されているものを<emphasis>拡張</emphasis> キャラクターと呼ぶ。
+      これらのキャラクターセットは異なるキャラクターに同じ番号をふってあるので、
+      他のキャラクターセットとまたはキャラクターセット同士で衝突を起こす。</para>
+
+      <para>そういったキャラクターセットのほぼ全てが 256 個のキャラクターを定義していて、最初の 128 個（0 から 127
+      まで）のキャラクターを ASCII と同一対応となるようにしている。結果的に、違ったコードページを使っているシステム同士の通信では、事実上
+      ASCII キャラクターセット限定となった。</para>
+
+      <para>この問題を新たに解決するために、より大きいキャラクターセットが規定された。より多くのキャラクターマッピングの場所を確保するために、
+      これらのキャラクターセットは一つのキャラクターの格納のために最低でも 2 バイトを使用する。
+      このためそういったキャラクターセットは<emphasis>マルチバイト</emphasis> キャラクターセットと呼ばれる。</para>
+
+      <para>標準化されたマルチバイトキャラクターエンコード方式として知られているものの一つとして <ulink
+      url="http://www.unicode.org/">ユニコード</ulink>がある。
+      マルチバイトキャラクターセット使用の大きな利点として“それ一つで済む”がある。
+      二つのコンピューターが通信しているときに両者が同じキャラクターセットを使用しているか確認する必要がない。</para>
+    </sect2>
+
+    <sect2>
+      <title>Apple で使われている（使われていた）キャラクターセット</title>
+
+      <para>過去に Apple クライアントは、ネットワーク間の通信のためにシングルバイトのキャラクターセットを使用していた。
+      年を経るに従い、Apple はいくつものキャラクターセットを定義したが、欧米ユーザーは
+      <emphasis>MacRoman</emphasis> コードセットを最もよく使用するであろう。</para>
+
+      <para>Apple の定義したコードページに含まれるもの：</para>
+
+      <itemizedlist>
+        <listitem>
+          <para>MacArabic, MacFarsi</para>
+        </listitem>
+
+        <listitem>
+          <para>MacCentralEurope</para>
+        </listitem>
+
+        <listitem>
+          <para>MacChineseSimple</para>
+        </listitem>
+
+        <listitem>
+          <para>MacChineseTraditional</para>
+        </listitem>
+
+        <listitem>
+          <para>MacCroatian</para>
+        </listitem>
+
+        <listitem>
+          <para>MacCyrillic</para>
+        </listitem>
+
+        <listitem>
+          <para>MacDevanagari</para>
+        </listitem>
+
+        <listitem>
+          <para>MacGreek</para>
+        </listitem>
+
+        <listitem>
+          <para>MacHebrew</para>
+        </listitem>
+
+        <listitem>
+          <para>MacIcelandic</para>
+        </listitem>
+
+        <listitem>
+          <para>MacJapanese</para>
+        </listitem>
+
+        <listitem>
+          <para>MacKorean</para>
+        </listitem>
+
+        <listitem>
+          <para>MacRoman</para>
+        </listitem>
+
+        <listitem>
+          <para>MacRomanian</para>
+        </listitem>
+
+        <listitem>
+          <para>MacThai</para>
+        </listitem>
+
+        <listitem>
+          <para>MacTurkish</para>
+        </listitem>
+      </itemizedlist>
+
+      <para>Mac OS X 以降そして AFP3 以降では <ulink
+      url="http://www.utf-8.com/">UTF-8</ulink> が用いられる。UTF-8 は Unicode キャラクターを
+      ASCII 互換のやり方でエンコードする。各々の Unicode キャラクターは一個から六個の ASCII キャラクターにエンコードされる。
+      故に、UTF-8 自体が本当のキャラクターセットなのではなく、ユニコードキャラクターセットのエンコーディングなのである。</para>
+
+      <para>厄介なことにも Unicode はいくつかの <emphasis> <ulink
+      url="http://www.unicode.org/reports/tr15/index.html">normalization（正規化）</ulink>
+      </emphasis>方式を規定している。<ulink
+      url="http://www.samba.org">Samba</ulink><indexterm>
+          <primary>Samba</primary>
+        </indexterm> はほとんどの Unix ツールも好んで用いる
+      <emphasis>precomposed</emphasis><indexterm>
+          <primary>Precomposed</primary>
+
+          <secondary>Precomposed Unicode normalization</secondary>
+        </indexterm> Unicode を使用する。一方 Apple は
+      <emphasis>decomposed</emphasis><indexterm>
+          <primary>Decomposed</primary>
+
+          <secondary>Decomposed Unicode normalization</secondary>
+        </indexterm> normalization を使うことに決めた。</para>
+
+      <para>例として、ドイツ語の文字 '<keycode>ä</keycode>' についてみてみる。Precomposed
+      normalization を使えば Unicode はこの文字に 0xE4 を対応付ける。Decomposed normalization
+      では 'ä' を正確には 0x61 と 0x308 の二つの文字に対応付ける。0x61 は 'a' に、0x308 は
+      <emphasis>COMBINING DIAERESIS</emphasis>（訳注：いわゆるウムラウト）に対応付けられている。</para>
+
+      <para>Netatalk では precomposed UTF-8 を
+      <emphasis>UTF8</emphasis><indexterm>
+          <primary>UTF8</primary>
+
+          <secondary>Netatalk の precomposed UTF-8 エンコーディング</secondary>
+        </indexterm> と、decomposed UTF-8 を
+      <emphasis>UTF8-MAC</emphasis><indexterm>
+          <primary>UTF8-MAC</primary>
+
+          <secondary>Netatalk の decomposed UTF-8 エンコーディング</secondary>
+        </indexterm> と呼ぶ。</para>
+    </sect2>
+
+    <sect2>
+      <title>afpd とキャラクターセット</title>
+
+      <para>新しい AFP 3.x クライアントも古い AFP 2.x クライアントも同時にサポートするために、afpd
+      は使われている様々なキャラクターセット間の変換が可能であることを必要とした。AFP 3.x クライアントは常に UTF8-MAC を、AFP
+      2.x クライアントは Apple コードページのうちの一つを使う。</para>
+
+      <para>本稿執筆時点（訳注：原文の）で、netatalk は以下の Apple コードページをサポートしている：</para>
+
+      <itemizedlist>
+        <listitem>
+          <para>MAC_CENTRALEUROPE</para>
+        </listitem>
+
+        <listitem>
+          <para>MAC_CHINESE_SIMP</para>
+        </listitem>
+
+        <listitem>
+          <para>MAC_CHINESE_TRAD</para>
+        </listitem>
+
+        <listitem>
+          <para>MAC_CYRILLIC</para>
+        </listitem>
+
+        <listitem>
+          <para>MAC_GREEK</para>
+        </listitem>
+
+        <listitem>
+          <para>MAC_HEBREW</para>
+        </listitem>
+
+        <listitem>
+          <para>MAC_JAPANESE</para>
+        </listitem>
+
+        <listitem>
+          <para>MAC_KOREAN</para>
+        </listitem>
+
+        <listitem>
+          <para>MAC_ROMAN</para>
+        </listitem>
+
+        <listitem>
+          <para>MAC_TURKISH</para>
+        </listitem>
+      </itemizedlist>
+
+      <para>afpd は三つの異なるキャラクターセットオプションを扱う：</para>
+
+      <variablelist>
+        <varlistentry>
+          <term>unix charset<indexterm>
+              <primary>unix charset</primary>
+
+              <secondary>afpd の unix charset セッティング</secondary>
+            </indexterm></term>
+
+          <listitem>
+            <para>これはオペレーティングシステムの内側で使われているコードページである。もし指定されていなければ、デフォルトで
+            <option>UTF8</option> になる。もし <option>LOCALE</option> が指定されていて、
+            システムが Unix locales をサポートしていれば、afpd はコードページを検出しようとし、afpd
+            は検出したコードページを使って設定ファイルを読む。なので、ボリューム名やログインメッセージなどに拡張文字を使うことができる。
+            <citerefentry>
+                <refentrytitle>afp.conf</refentrytitle>
+
+                <manvolnum>5</manvolnum>
+              </citerefentry> を参照のこと。</para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>mac charset<indexterm>
+              <primary>mac charset</primary>
+
+              <secondary>afpd の mac charset セッティング</secondary>
+            </indexterm></term>
+
+          <listitem>
+            <para>既に述べたように、旧式の Mac OS クライアント（AFP 2.2 までのもの）は afpd
+            と通信するのにコードページを用いる。しかしながら、AFP
+            プロトコルにはクライアントが使用しているコードページの折り合いをつけるというサポートはない。もしほかのどこかで指定されていないと、
+            afpd は <emphasis>MacRoman</emphasis> コードページが使われていると仮定する。
+            クライアントが別のコードページ、例えば <emphasis>MacCyrillic</emphasis> を使っていたならば,
+            それを明示的に設定<emphasis role="bold">しなければならない</emphasis>だろう。
+            <citerefentry>
+                <refentrytitle>afp.conf</refentrytitle>
+
+                <manvolnum>5</manvolnum>
+              </citerefentry> を参照のこと。</para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>vol charset<indexterm>
+              <primary>vol charset</primary>
+
+              <secondary>afpd の vol charset セッティング</secondary>
+            </indexterm></term>
+
+          <listitem>
+            <para>これは afpd がディスク上のファイル名として使うべき charset を定義する。デフォルトでは
+            <option>unix charset</option> と同じである。もし <ulink
+            url="http://www.gnu.org/software/libiconv/">iconv</ulink><indexterm>
+                <primary>Iconv</primary>
+
+                <secondary>iconv エンコーディング変換エンジン</secondary>
+              </indexterm> がインストールしてあるならば、iconv
+            が提供するキャラクターセットも使用することができる。</para>
+
+            <para>afpd はファイルを unix のファイルシステムに保存する時、拡張マッキントッシュキャラクター、あるいは
+            unix のファイル名として不正なキャラクターを保持する手段が必要である。初期のバージョンでは、いわゆる CAP
+            エンコーディング<indexterm>
+                <primary>CAP エンコーディング</primary>
+
+                <secondary>CAP スタイルキャラクターエンコーディング</secondary>
+              </indexterm>を使った。拡張キャラクター (&gt;0x7F) は :xx の 16
+            進数に変換される。例えば、アップルのロゴ (MacRoman: 0xF0) は :f0 として保存される。
+            いくつかの特殊なキャラクターも :xx という表記に変換される。'/' は :2f にエンコードされる。もし、
+            <option>usedots</option> オプションが設定されていなければ、先頭のピリオド '.' は :2e
+            にエンコードされる。</para>
+
+            <para>本ドキュメントでのバージョンではファイル名のデフォルトエンコーディングとして <option>UTF8</option>
+            を使っているにもかかわらず、'/' は ':' に変換される。欧米のユーザーにとって別の有用な設定として <option>vol
+            charset = ISO-8859-15</option> もあり得る。</para>
+
+            <para>もし、あるキャラクターが <option>mac charset</option> から選定した <option>vol
+            charset</option> への変換ができない場合、マック上で -50 エラーを受け取るだろう。
+            <emphasis>注意</emphasis>： 可能な限り常に、デフォルトの UTF8 ボリュームフォーマットにしてください。
+            <citerefentry>
+                <refentrytitle>afp.conf</refentrytitle>
+
+                <manvolnum>5</manvolnum>
+              </citerefentry> を参照のこと。</para>
+          </listitem>
+        </varlistentry>
+      </variablelist>
+    </sect2>
+  </sect1>
+
+  <sect1 id="authentication">
+    <title>認証<indexterm>
+        <primary>認証</primary>
+
+        <secondary>AFP クライアントとサーバー間の</secondary>
+      </indexterm></title>
+
+    <sect2>
+      <title>AFP 認証の基本</title>
+
+      <para>Apple は AFP クライアントとサーバー間の認証のために "User Authentication Modules"
+      <indexterm>
+          <primary>UAM</primary>
+
+          <secondary>User Authentication Module</secondary>
+        </indexterm> (UAM) と呼ばれる柔軟なモデルを選んだ。AFP クライアントがまず最初に AFP サーバーと接続するとき、
+      サーバーが提供している UAM のリストを問い合わせる。そして、クライアントがサポートしている最も強い暗号化の UAM を選ぶ。</para>
+
+      <para>数個の UAM は時間をかけて Apple が開発してものであり、サードパーティの開発者によるものもある。</para>
+    </sect2>
+
+    <sect2>
+      <title>Netatalk でサポートされている UAM</title>
+
+      <para>Netatalk はデフォルトで以下のものをサポートしている：</para>
+
+      <itemizedlist>
+        <listitem>
+          <para>"No User Authent"<indexterm>
+              <primary>No User Authent</primary>
+
+              <secondary>“ユーザー認証なし”UAM（ゲストアクセス）</secondary>
+            </indexterm> UAM（ユーザー認証なしのゲスト接続）</para>
+        </listitem>
+
+        <listitem>
+          <para>"Cleartxt Passwrd"<indexterm>
+              <primary>Cleartxt Passwrd</primary>
+
+              <secondary>“クリアテキスト(平文)パスワード”UAM</secondary>
+            </indexterm> UAM（クリアテキスト(平文)パスワード、暗号化なし）</para>
+        </listitem>
+
+        <listitem>
+          <para>"Randnum exchange"<indexterm>
+              <primary>Randnum exchange</primary>
+
+              <secondary>"Randnum exchange" UAM</secondary>
+            </indexterm>、"2-Way Randnum exchange"<indexterm>
+              <primary>2-Way Randnum exchange</primary>
+
+              <secondary>“双方向乱数交換”UAM</secondary>
+            </indexterm> UAM （乱数交換・双方向乱数交換、弱いパスワード暗号化、パスワードを別途保存する）</para>
+        </listitem>
+
+        <listitem>
+          <para>"DHCAST128"<indexterm>
+              <primary>DHCAST128</primary>
+
+              <secondary>"DHCAST128" UAM</secondary>
+            </indexterm> UAM（より強いパスワード暗号化）</para>
+        </listitem>
+
+        <listitem>
+          <para>"DHX2"<indexterm>
+              <primary>DHX2</primary>
+
+              <secondary>"DHX2" UAM</secondary>
+            </indexterm> UAM（DHCAST128 の後継版）</para>
+        </listitem>
+      </itemizedlist>
+
+      <para>他にもオプションとして以下のような UAM がある：</para>
+
+      <itemizedlist>
+        <listitem>
+          <para>"PGPuam 1.0"<indexterm>
+              <primary>PGPuam 1.0</primary>
+
+              <secondary>"PGPuam 1.0" UAM</secondary>
+            </indexterm><indexterm>
+              <primary>uams_pgp.so</primary>
+
+              <secondary>"PGPuam 1.0" UAM</secondary>
+            </indexterm> UAM（Mac OS X 以前のクライアント用、PGP ベースの認証。これを動作させようとするには
+          <ulink url="http://www.vmeng.com/vinnie/papers/pgpuam.html">PGPuam
+          クライアント</ulink>も別途必要である。</para>
+
+          <para>この UAM を有効にするためには、configure オプションに
+          <filename>"enable-pgp-uam"</filename> を追加しなければならない。</para>
+        </listitem>
+
+        <listitem>
+          <para>"Client Krb v2"<indexterm>
+              <primary>Client Krb v2</primary>
+
+              <secondary>"Client Krb v2" UAM (Kerberos V)</secondary>
+            </indexterm> UAM （Kerberos V、OS X
+          で“シングルサインオン”環境には最も適当である――下記参照）</para>
+
+          <para><filename>"enable-krbV-uam"</filename> オプションでこの UAM
+          を使用できるようになるであろう。</para>
+        </listitem>
+      </itemizedlist>
+
+      <para>"<option>uam list</option>" を <option>Global</option>
+      セクションで定義することによって、どの UAM を有効化すべきか設定できる。<command>afpd</command> はどの UAM
+      を使っているのか、UAM を有効化した時に問題が起こっているのかどうかを、<filename>netatalk.log</filename>
+      あるいは起動時の syslog にログとして保存する。<citerefentry>
+          <refentrytitle>asip-status</refentrytitle>
+
+          <manvolnum>1</manvolnum>
+        </citerefentry> も AFP サーバーで有効な UAM の問い合わせをするのに使うことができる。</para>
+
+      <para>ある特定の UAM がサーバー上で有効であるということが、直ちに、
+      クライアントもそれを使うことができるということを意味するわけではない。クライアント側でのサポートもまた必要である。Mac OS X
+      以前が使われている古いマッキントッシュでも、DHCAST128 のサポートは AppleShare クライアント 3.8.x
+      以降には存在している。</para>
+
+      <para>OS X では、AFP クライアントをもっと冗長にするクライアント側のテクニックがいくつかあるので、使用する UAM
+      と折り合いをつけるまでに何が起こっているのか見ることができる。<ulink
+      url="https://web.archive.org/web/20080312054723/http://article.gmane.org/gmane.network.netatalk.devel/7383/">このヒント</ulink>
+      と比較してみるとよい。</para>
+    </sect2>
+
+    <sect2>
+      <title>どの UAM を有効にすべきか？</title>
+
+      <para>第一義的には“何が必要か”と “サポートしようと考えている MAC OS のバージョンの種類”に依存する。
+      基本的にはそのパスワード暗号化の強力さから、可能な限り DHCAST128 および DHX2 を試すべきである。</para>
+
+      <itemizedlist>
+        <listitem>
+          <para>サーバーのボリュームに本当にゲストアクセスを供することが必要な場合以外は、"No User Authent"
+          が無効化されているか確認すべきである。さもないと、意図しない権限のないアクセスを引き起こすことにもなる。
+          ゲストアクセスを有効にしなければならない場合は、アクセスコントロールを使って、
+          ボリューム各々についてゲストアクセスを有効化することを強制するように気を配るべきである。</para>
+        </listitem>
+
+        <listitem>
+          <para>"ClearTxt Passwrd" UAM ではパスワードがネットワーク上を暗号化されずに伝わっていくので、
+          字句そのまんまに良くない。クライアント側のみならずサーバー側でも無効にするよう務めるべきである。注意：もし NetBoot
+          サービスを使用している Mac OS 8/9 にサービスを提供したい場合、cleartext.so の UAM が必要となる。
+          これはそういった Mac のファームウエアに組み込まれた AFP
+          クライアントがこうした基本的な形の認証しか扱わないためである。</para>
+        </listitem>
+
+        <listitem>
+          <para>"Randnum exchange" と "2-Way Randnum exchange" は 56 ビット DES
+          暗号化しか使わないので、これらもやはり回避すべきである。
+          そしてなおかつ不利なのは、パスワードがサーバーに平文テキストとして保存されなければならないこと、および PAM 環境とも古典的な
+          /etc/shadow とも統合がとれない （もしクライアントがこれらの UAM を使わなければならない場合、<citerefentry>
+              <refentrytitle>afppasswd</refentrytitle>
+
+              <manvolnum>1</manvolnum>
+            </citerefentry> ユーティリティを使って別途パスワードを管理しなければならない）という点である。</para>
+        </listitem>
+
+        <listitem>
+          <para>"DHCAST128" あるいは "DHX2" は PAM との統合と強力な暗号化とが組み合わせられているので、
+          ほとんどの人々にとって良い妥協案であろう。</para>
+        </listitem>
+
+        <listitem>
+          <para>Kerberos V<indexterm>
+              <primary>Kerberos V</primary>
+
+              <secondary>"Client Krb v2" UAM</secondary>
+            </indexterm> ("Client Krb v2") UAM を用いれば、Kerberos
+          チケットを用いて真のシングルサインオン環境を実装することが可能である。パスワードがネットワークを通して送られることもない。
+          その代わり、ユーザーのパスワードは appleshare サーバーへのサービスチケットを暗号から復号するのに用いられる。
+          サービスチケットにはクライアントの暗号鍵と幾らかの暗号化されたデータが含まれる （それは appleshare
+          サーバーだけが復号できる）。サービスチケットの暗号化された部分がサーバーに送られ、ユーザーを認証するのに使われる。afpd
+          サービスプリンシパル検知の実装の仕方のために、この認証方法は中間者攻撃に対して脆弱である。</para>
+        </listitem>
+      </itemizedlist>
+
+      <para>様々な UAM の技術的実装についてのより詳細な概要については、Apple の <ulink
+      url="http://developer.apple.com/library/mac/#documentation/Networking/Conceptual/AFP/AFPSecurity/AFPSecurity.html#//apple_ref/doc/uid/TP40000854-CH232-SW1">File
+      Server Security</ulink> ページを見ていただきたい。</para>
+    </sect2>
+
+    <sect2>
+      <title>特定の UAM で別の認証ソースを使う</title>
+
+      <para>いくつかの UAM は別の認証“バックエンド”を使えるようにしてある。いわゆる
+      <filename>uams_cleartext.so</filename>、<filename>uams_dhx.so</filename>
+      及び <filename>uams_dhx2.so</filename>である。これらは
+      <filename>/etc/passwd</filename> (<filename>/etc/shadow</filename>)
+      からの古典的 Unix パスワードでも、システムがサポートしていれば　PAM でもどちらでも使うことができる。
+      <filename>uams_cleartext.so</filename> は
+      <filename>uams_passwd.so</filename> ないしは
+      <filename>uams_pam.so</filename> へのシンボリックリンクとして、
+      <filename>uams_dhx.so</filename> は
+      <filename>uams_dhx_passwd.so</filename> ないしは
+      <filename>uams_dhx_pam.so</filename> へのシンボリックリンクとして、さらには
+      <filename>uams_dhx2.so</filename> は
+      <filename>uams_dhx2_passwd.so</filename> ないしは
+      <filename>uams_dhx2_pam.so</filename>へのシンボリックリンクとすることができる。</para>
+
+      <para>なので、もし Netatalk の UAM フォルダー（デフォルトで
+      <filename>/etc/netatalk/uams/</filename>）が以下のようであれば： <programlisting>uams_clrtxt.so -&gt; uams_pam.so
+uams_dhx.so -&gt; uams_dhx_pam.so
+uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting> PAM さもなくば古典的な Unix
+      パスワードを使用しているわけである。PAM を使用することで最も有利なのは、例えば LDAP 経由、あるいは NIS
+      経由などの集約した認証環境に Netatalk を統合できることである。そのような環境でのユーザーのログイン資格情報
+      (credentials) の保護は、UAM そのものが供している暗号化の強さにもまた依存している。
+      ということを常に念頭においていただきたい。なので、"ClearTxt Passwrd" や "Randnum exchange" のような弱い
+      UAM をネットワーク上から 完全に除去することを考えるべきである。</para>
+    </sect2>
+
+    <sect2>
+      <title>Netatalk UAM を概要表</title>
+
+      <para>最も一般的に用いられる UAM の概観。</para>
+
+      <table orient="land">
+        <title>Netatalk UAM 概観</title>
+
+        <tgroup align="center" cols="7">
+          <colspec colname="col1" colnum="1" colwidth="0.5*"/>
+
+          <colspec colname="uam_guest" colnum="2" colwidth="1*"/>
+
+          <colspec colname="uam_clrtxt" colnum="3" colwidth="1*"/>
+
+          <colspec colname="uam_randnum" colnum="4" colwidth="1*"/>
+
+          <colspec colname="uam_dhx" colnum="5" colwidth="1*"/>
+
+          <colspec colname="uam_dhx2" colnum="6" colwidth="1*"/>
+
+          <colspec colname="uam_gss" colnum="7" colwidth="1*"/>
+
+          <tbody>
+            <row>
+              <entry align="center" rotate="0" valign="middle">UAM</entry>
+
+              <entry>No User Authent<indexterm>
+                  <primary>uams_guest.so</primary>
+
+                  <secondary>“ユーザー認証なし”UAM（ゲストアクセス）</secondary>
+                </indexterm></entry>
+
+              <entry>Cleartxt Passwrd<indexterm>
+                  <primary>uams_cleartxt.so</primary>
+
+                  <secondary>“クリアテキスト(平文)パスワード”UAM</secondary>
+                </indexterm></entry>
+
+              <entry>(2-Way) Randnum exchange<indexterm>
+                  <primary>uams_randnum.so</primary>
+
+                  <secondary>“（双方向）乱数交換”UAM</secondary>
+                </indexterm></entry>
+
+              <entry>DHCAST128<indexterm>
+                  <primary>uams_dhx.so</primary>
+
+                  <secondary>"DHCAST128" UAM</secondary>
+                </indexterm></entry>
+
+              <entry>DHX2<indexterm>
+                  <primary>uams_dhx2.so</primary>
+
+                  <secondary>"DHX2" UAM</secondary>
+                </indexterm></entry>
+
+              <entry>Client Krb v2<indexterm>
+                  <primary>uams_gss.so</primary>
+
+                  <secondary>"Client Krb v2" UAM (Kerberos V)</secondary>
+                </indexterm></entry>
+            </row>
+
+            <row>
+              <entry align="center" rotate="0" valign="middle">パスワード長</entry>
+
+              <entry>ゲストアクセス</entry>
+
+              <entry>最大 8 文字</entry>
+
+              <entry>最大 8 文字</entry>
+
+              <entry>最大 64 文字</entry>
+
+              <entry>最大 256 文字</entry>
+
+              <entry>Kerberos チケット</entry>
+            </row>
+
+            <row>
+              <entry align="center" rotate="0"
+              valign="middle">サポートするクライアント</entry>
+
+              <entry>全ての Mac OS のバージョンで組み込み済</entry>
+
+              <entry>10.0 を除く全ての Mac OS のバージョンで組み込み済。
+              最近のバージョンでは明示的にアクティブ化する必要がある。</entry>
+
+              <entry>ほとんど全ての Mac OS のバージョンで組み込み済</entry>
+
+              <entry>AppleShare クライアント 3.8.4 より組み込み済で、3.8.3 では Mac OS X の AFP
+              クライアントに統合したプラグインとしての用意あり。</entry>
+
+              <entry>Mac OS X 10.2 より組み込み済</entry>
+
+              <entry>Mac OS X 10.2 より組み込み済</entry>
+            </row>
+
+            <row>
+              <entry align="center" rotate="0" valign="middle">暗号化</entry>
+
+              <entry>クライアント・サーバー間で認証なくゲストアクセス可能。</entry>
+
+              <entry>パスワードがネットワーク上を暗号化されずに伝わっていく。
+              字句そのままに悪いので、可能ならば全面的に使用を回避すべき （注意：NetBoot サービスの提供には ClearTxt UAM
+              が必要）</entry>
+
+              <entry>DES, 56 ビットに相当する 8 バイトの乱数がネットワーク上に送出。オフラインの辞書攻撃に対して脆弱。
+              パスワードがサーバー上で平文であることが求められる。</entry>
+
+              <entry>パスワードは 128 ビット SSL で暗号化され、ユーザーはサーバーに認証されるが、“逆もまた真”ではない。
+              このため中間者攻撃に対して弱い。</entry>
+
+              <entry>パスワードは libgcrypt の CAST 128、CBC モードを用いて暗号化される。
+              ユーザーはサーバーに認証されるが、“逆もまた真”ではない。このため中間者攻撃に対して弱い。</entry>
+
+              <entry>パスワードがネットワークを通して送られることがない。サービスプリンシパル検知の方法が原因で、
+              この認証方法は中間者攻撃に対して脆弱である。</entry>
+            </row>
+
+            <row>
+              <entry align="center" rotate="0"
+              valign="middle">サーバーがサポートする共有オブジェクト</entry>
+
+              <entry align="center" valign="middle">uams_guest.so</entry>
+
+              <entry align="center" valign="middle">uams_cleartxt.so</entry>
+
+              <entry align="center" valign="middle">uams_randnum.so</entry>
+
+              <entry align="center" valign="middle">uams_dhx.so</entry>
+
+              <entry align="center" valign="middle">uams_dhx2.so</entry>
+
+              <entry align="center" valign="middle">uams_gss.so</entry>
+            </row>
+
+            <row>
+              <entry align="center" rotate="0"
+              valign="middle">パスワードの保管方法</entry>
+
+              <entry align="center" valign="middle">なし</entry>
+
+              <entry align="center" valign="middle">/etc/passwd (/etc/shadow)
+              ないしは PAM</entry>
+
+              <entry align="center"
+              valign="middle">パスワードは別のテキストファイルに平文として保存される</entry>
+
+              <entry align="center" valign="middle">/etc/passwd (/etc/shadow)
+              ないしは PAM</entry>
+
+              <entry align="center" valign="middle">/etc/passwd (/etc/shadow)
+              ないしは PAM</entry>
+
+              <entry align="center" valign="middle">Kerberos キー配布センター*</entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+
+      <para>* <ulink
+      url="https://web.archive.org/web/20070705043002/http://cryptnet.net/fdp/admin/kerby-infra/en/kerby-infra.html">Kerberos
+      概要</ulink> も一読のこと</para>
+    </sect2>
+
+    <sect2 id="sshtunnel">
+      <title>SSH トンネリング</title>
+
+      <para>トンネリングや VPN のたぐいのもの全ては、AFP 認証や UAM に関してすべきことは概ね皆無である。
+      しかしながらアップルが「SSHを用いて安全な接続を可能にする」というオプションを導入して以来、
+      多数の人が両者について混乱する傾向にある。以下ではその点についても述べる。</para>
+
+      <sect3 id="manualsshtunnel">
+        <title>手動で AFP セッションをトンネリング</title>
+
+        <para>これは、"AFP over TCP" を“話すことができる”最初の AFP
+        サーバーがネットワークに登場して以来うまく動作する。リモートサーバーの AFP ポートをローカルの 548
+        番以外の異なるポートにトンネルし、その後ローカルでこのポートににつなげるだけである。OS X では以下のようにすればよい。</para>
+
+        <programlisting>ssh -l $USER $SERVER -L 10548:127.0.0.1:548 sleep 3000</programlisting>
+
+        <para>トンネルを確立したならば、“サーバーに接続”ダイアログで
+        <filename>"afp://127.0.0.1:10548"</filename> を使うことができる。ローカルの AFP
+        クライアントは Mac のローカル 10548 番ポートに接続し、そのポートは SSH を通してリモートサーバーの AFP
+        ポート（デフォルトでは 548 番を使う）に転送されているので、端緒の接続試行も含めて全ての AFP
+        トラフィックがネットワークを暗号化されて送られる。</para>
+
+        <para>この手のトンネルは、もし、“真の” VPN を使えないが、インターネットを通じて、弱い認証機構しかない AFP
+        サーバーにアクセスしなければならない場合の理想的な解決手段である。<command>ssh</command> の "-C"
+        オプションでデータ圧縮が可能であり、トンネルの端点を AFP クライアント、サーバーどちらとも異なるようにすることが可能である
+        （詳細については SSH のドキュメントと比較してほしい）という点に留意すべきである。</para>
       </sect3>
 
-      <sect3>
-        <title>Netatalk でサポートされている UAM</title>
+      <sect3 id="autosshtunnel">
+        <title>自動的にトンネル AFP 接続を確立する</title>
 
-        <para>Netatalk はデフォルトで以下のものをサポートしている：</para>
+        <para>Apple は Mac OS X 10.2 から 10.4 で、「サーバーに接続」ダイアログに
+        「SSHを用いて安全な接続を可能にする」チェックボックスを追加した。この考えの裏にあるのは：サーバーが SSH
+        で接続できるというサインを出した時、Mac OS X の AFP クライアントはトンネルを確立しようとし、自動的に全ての AFP
+        トラフィックをこのトンネルを通して送る。ということなのである。</para>
 
-        <itemizedlist>
-          <listitem>
-            <para>"No User Authent"<indexterm>
-                <primary>No User Authent</primary>
+        <para>しかし、この機能が初めて…部分的に、動作するようになるのに Mac OS X 10.3 までかかった。SSH
+        トンネルが確立できない時、AFP クライアントは<emphasis
+        role="strong">何の通知もなく</emphasis>暗号化していない AFP 接続試行にフォールバックした。</para>
 
-                <secondary>“ユーザー認証なし”UAM（ゲストアクセス）</secondary>
-              </indexterm> UAM（ユーザー認証なしのゲスト接続）</para>
-          </listitem>
-
-          <listitem>
-            <para>"Cleartxt Passwrd"<indexterm>
-                <primary>Cleartxt Passwrd</primary>
-
-                <secondary>“クリアテキスト(平文)パスワード”UAM</secondary>
-              </indexterm> UAM（クリアテキスト(平文)パスワード，暗号化なし）</para>
-          </listitem>
-
-          <listitem>
-            <para>"Randnum exchange"<indexterm>
-                <primary>Randnum exchange</primary>
-
-                <secondary>"Randnum exchange" UAM</secondary>
-              </indexterm>，"2-Way Randnum exchange"<indexterm>
-                <primary>2-Way Randnum exchange</primary>
-
-                <secondary>“双方向乱数交換”UAM</secondary>
-              </indexterm> UAM
-            （乱数交換・双方向乱数交換，弱いパスワード暗号化，パスワードを別途保存する）</para>
-          </listitem>
-
-          <listitem>
-            <para>"DHCAST128"<indexterm>
-                <primary>DHCAST128</primary>
-
-                <secondary>"DHCAST128" UAM</secondary>
-              </indexterm> UAM（より強いパスワード暗号化）</para>
-          </listitem>
-
-          <listitem>
-            <para>"DHX2"<indexterm>
-                <primary>DHX2</primary>
-
-                <secondary>"DHX2" UAM</secondary>
-              </indexterm> UAM（DHCAST128 の後継版）</para>
-          </listitem>
-        </itemizedlist>
-
-        <para>他にもオプションとして以下のような UAM がある：</para>
-
-        <itemizedlist>
-          <listitem>
-            <para>"PGPuam 1.0"<indexterm>
-                <primary>PGPuam 1.0</primary>
-
-                <secondary>"PGPuam 1.0" UAM</secondary>
-              </indexterm><indexterm>
-                <primary>uams_pgp.so</primary>
-
-                <secondary>"PGPuam 1.0" UAM</secondary>
-              </indexterm> UAM（Mac OS X 以前のクライアント用，PGP ベースの認証．
-            これを動作させようとするには <ulink
-            url="http://www.vmeng.com/vinnie/papers/pgpuam.html">PGPuam
-            クライアント</ulink>も別途必要である．</para>
-
-            <para>この UAM を有効にするためには，configure オプションに 
-            <filename>"--enable-pgp-uam"</filename> を追加しなければならない．</para>
-          </listitem>
-
-          <listitem>
-            <para>"Kerberos IV"<indexterm>
-                <primary>Kerberos IV</primary>
-
-                <secondary>"Kerberos IV" UAM</secondary>
-              </indexterm><indexterm>
-                <primary>uams_krb4.so</primary>
-
-                <secondary>"Kerberos IV" UAM</secondary>
-              </indexterm>/"AFS Kerberos"<indexterm>
-                <primary>AFS Kerberos</primary>
-
-                <secondary>"AFS Kerberos" UAM (Kerberos IV)</secondary>
-              </indexterm> UAM
-            （<ulink url="http://web.mit.edu/macdev/KfM/Common/Documentation/faq.html">
-            Kerberos v4 ベースの認証</ulink>で AFS ファイルサーバーを使用するのに適している）
-            </para>
-
-            <para>この UAM を有効化するにはコンパイル時点で 
-            <filename>"--enable-krb4-uam"</filename> オプションを使用する．</para>
-          </listitem>
-
-          <listitem>
-            <para>"Client Krb v2"<indexterm>
-                <primary>Client Krb v2</primary>
-
-                <secondary>"Client Krb v2" UAM (Kerberos V)</secondary>
-              </indexterm> UAM
-            （Kerberos V，OS X で“シングルサインオン”環境には最も適当である――下記参照）</para>
-
-            <para><filename>"--enable-krbV-uam"</filename> 
-            オプションでこの UAM を使用できるようになるであろう．</para>
-          </listitem>
-        </itemizedlist>
-
-        <para>"<option>uam list</option>" を <option>Global</option> 
-        セクションで定義することによって，どの UAM を有効化すべきか設定できる．
-        <command>afpd</command> はどの UAM を使っているのか，
-        UAM を有効化した時に問題が起こっているのかどうかを， <filename>netatalk.log</filename> 
-        あるいは起動時の syslog にログとして保存する．
+        <para>"<option>advertise ssh</option>" および "<option>fqdn</option>"
+        オプション両方を <option>Global</option> セクションで設定（設定を変更したら、afpd を再起動した後
         <citerefentry>
             <refentrytitle>asip-status</refentrytitle>
 
             <manvolnum>1</manvolnum>
-          </citerefentry>  
-        も AFP サーバーで有効な UAM の問い合わせをするのに使うことができる．</para>
-
-        <para>ある特定の UAM がサーバー上で有効であるということが，直ちに，
-        クライアントもそれを使うことができるということを意味するわけではない．
-        クライアント側でのサポートもまた必要である．
-        Mac OS X 以前が使われている古いマッキントッシュでも，
-        DHCAST128 のサポートは AppleShare クライアント 3.8.x 以降には存在している．</para>
-
-        <para>OS X では，
-        AFP クライアントをもっと冗長にするクライアント側のテクニックがいくつかあるので，
-        使用する UAM と折り合いをつけるまでに何が起こっているのか見ることができる．<ulink
-        url="https://web.archive.org/web/20080312054723/http://article.gmane.org/gmane.network.netatalk.devel/7383/">このヒント</ulink>
-        と比較してみるとよい．</para>
-      </sect3>
-
-      <sect3>
-        <title>どの UAM を有効にすべきか？</title>
-
-        <para>第一義的には“何が必要か”と
-        “サポートしようと考えている MAC OS のバージョンの種類”に依存する．
-        基本的にはそのパスワード暗号化の強力さから，
-        可能な限り DHCAST128 および DHX2 を試すべきである．</para>
+          </citerefentry> で二重チェックするべき）した時は、SSH トンネルした AFP リクエストの扱いが可能であることを
+        Netatalk の afpd はレポートする。しかし、このオプションを決して使用したくなくなる２、３の理由がある：</para>
 
         <itemizedlist>
           <listitem>
-            <para>サーバーのボリュームに本当にゲストアクセスを供することが必要な場合以外は，
-            "No User Authent" が無効化されているか確認すべきである．
-            さもないと，意図しない権限のないアクセスを引き起こすことにもなる．
-            ゲストアクセスを有効にしなければならない場合は，
-            アクセスコントロールを使って，
-            ボリューム各々についてゲストアクセスを有効化することを強制するように気を配るべきである．</para>
+            <para>こう言うような機能を必要とする大部分のユーザーは、 おそらく使い慣れている VPN はあるとしたら、
+            通常のVPNを使用して AFP サーバーが実行されているネットワークに接続し、 AFP
+            サーバーにアクセスする方が簡単だろう。</para>
+
+            <para>とはいっても、１台の AFP サーバーに接続するという単純なケースでは、 VPN より直接 SSH
+            接続の方がパフォーマンス的に良いだろう。噂と違って、SSH 経由のトンネリングでは、 いわゆる「TCP-over-TCP
+            メルトダウン」は発生しない。何故なら、トンネリングされるAFPデータが TCP
+            データをカプセル化していないためである。</para>
           </listitem>
 
           <listitem>
-            <para>"ClearTxt Passwrd" UAM 
-            ではパスワードがネットワーク上を暗号化されずに伝わっていくので，
-            字句そのまんまに良くない．
-            クライアント側のみならずサーバー側でも無効にするよう務めるべきである．
-            注意：もし NetBoot サービスを使用している Mac OS 8/9 にサービスを提供したい場合，
-            cleartext.so の UAM が必要となる．
-            これはそういった Mac のファームウエアに組み込まれた AFP クライアントがこうした基本的な形の認証しか扱わないためである．</para>
+            <para>このように SSH でその場をしのぐことは AFP 認証機構に直接統合された通常の UAM ではないし、
+            代わりにこの方法では、トンネルの確立を<emphasis role="strong">試行
+            </emphasis>できるのかどうなのかのサインをクライアントに送るために、単一のフラグを用いる。
+            このため、何かがおかしい時に何が起こっているのかを見ようとする気を失ってしまう。</para>
           </listitem>
 
           <listitem>
-            <para>"Randnum exchange" と "2-Way Randnum exchange" は 56 ビット DES 暗号化しか使わないので，
-            これらもやはり回避すべきである．
-            そしてなおかつ不利なのは，パスワードがサーバーに平文テキストとして保存されなければならないこと，
-            および PAM 環境とも古典的な /etc/shadow とも統合がとれない
-            （もしクライアントがこれらの UAM を使わなければならない場合，<citerefentry>
-                <refentrytitle>afppasswd</refentrytitle>
-
-                <manvolnum>1</manvolnum>
-              </citerefentry>
-            ユーティリティを使って別途パスワードを管理しなければならない）という点である．</para>
+            <para>全ての接続試行は localhost から行われているように見えるので、
+            <command>macusers</command> のような Netatalk ツールによって、
+            どのマシンがログオンしているのか制御ができない。</para>
           </listitem>
 
           <listitem>
-            <para>"DHCAST128" あるいは "DHX2" は PAM との統合と強力な暗号化とが組み合わせられているので，
-            ほとんどの人々にとって良い妥協案であろう．</para>
+            <para>実際、AFP セッションが全てが SSH で暗号化されていることを確実にしたい場合は、afpd へのアクセスを
+            localhost のみ発信される接続に制限する必要がある。たとえば、Wietse Venema の TCP
+            ラッパーを使用するか、適切なファイアウォールやパケットフィルタリング機能を使用するなど。</para>
+
+            <para>そうしなければ、10.2 から 10.3.3 を使っている場合は、予想とは逆に：
+            トンネルの確立に失敗したという通知一つもなく、ネットワーク上で暗号化されていない AFP
+            の通信（ログイン資格情報を含む）が起こりえるということである。Apple は Mac OS X 10.3.4
+            になってそれをはじめて修正した。</para>
           </listitem>
 
           <listitem>
-            <para>Kerberos V<indexterm>
-                <primary>Kerberos V</primary>
-
-                <secondary>"Client Krb v2" UAM</secondary>
-              </indexterm> 
-            ("Client Krb v2") UAM を用いれば，
-            Kerberos チケットを用いて真のシングルサインオン環境を実装することが可能である．
-            パスワードがネットワークを通して送られることもない．
-            その代わり，ユーザーのパスワードは appleshare サーバーへのサービスチケットを暗号から復号するのに用いられる．
-            サービスチケットにはクライアントの暗号鍵と幾らかの暗号化されたデータが含まれる
-            （それは appleshare サーバーだけが復号できる）．
-            サービスチケットの暗号化された部分がサーバーに送られ，ユーザーを認証するのに使われる．
-            afpd サービスプリンシパル検知の実装の仕方のために，この認証方法は中間者攻撃に対して脆弱である．</para>
+            <para>SSH 経由で全ての AFP セッションを暗号化するることは、Netatalk
+            サーバーの負荷の著しい上昇を招く可能性がある。
+            ユーザーが信頼できるネットワーク経由で接続している場合、そのような暗号化は無駄かもしれない。</para>
           </listitem>
         </itemizedlist>
-
-        <para>様々な UAM の技術的実装についてのより詳細な概要については，Apple の <ulink
-        url="http://developer.apple.com/library/mac/#documentation/Networking/Conceptual/AFP/AFPSecurity/AFPSecurity.html#//apple_ref/doc/uid/TP40000854-CH232-SW1">File
-        Server Security</ulink> ページを見ていただきたい．</para>
       </sect3>
-
-      <sect3>
-        <title>特定の UAM で別の認証ソースを使う</title>
-
-        <para>いくつかの UAM は別の認証“バックエンド”を使えるようにしてある．
-        いわゆる <filename>uams_cleartext.so</filename>，
-        <filename>uams_dhx.so</filename> 及び
-        <filename>uams_dhx2.so</filename>である．これらは
-        <filename>/etc/passwd</filename> 
-        (<filename>/etc/shadow</filename>) からの古典的 Unix パスワードでも，
-        システムがサポートしていれば　PAM でもどちらでも使うことができる．
-        <filename>uams_cleartext.so</filename> は <filename>uams_passwd.so</filename> ないしは
-        <filename>uams_pam.so</filename> へのシンボリックリンクとして，
-        <filename>uams_dhx.so</filename> は <filename>uams_dhx_passwd.so</filename> ないしは
-        <filename>uams_dhx_pam.so</filename> へのシンボリックリンクとして，さらには
-        <filename>uams_dhx2.so</filename> は <filename>uams_dhx2_passwd.so</filename> ないしは
-        <filename>uams_dhx2_pam.so</filename>へのシンボリックリンクとすることができる．</para>
-
-        <para>なので，もし Netatalk の UAM フォルダー（デフォルトで 
-        <filename>/etc/netatalk/uams/</filename>）が以下のようであれば：
-        <programlisting>uams_clrtxt.so -&gt; uams_pam.so
-uams_dhx.so -&gt; uams_dhx_pam.so
-uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting>
-        PAM さもなくば古典的な Unix パスワードを使用しているわけである．
-        PAM を使用することで最も有利なのは，
-        例えば LDAP 経由，あるいは NIS 経由などの集約した認証環境に Netatalk を統合できることである．
-        そのような環境でのユーザーのログイン資格情報 (credentials) の保護は，
-        UAM そのものが供している暗号化の強さにもまた依存している．
-        ということを常に念頭においていただきたい．
-        なので，"ClearTxt Passwrd" や "Randnum exchange" のような弱い UAM をネットワーク上から
-        完全に除去することを考えるべきである．</para>
-      </sect3>
-
-      <sect3>
-        <title>Netatalk UAM を概要表</title>
-
-        <para>最も一般的に用いられる UAM の概観．</para>
-
-        <table orient="land">
-          <title>Netatalk UAM 概観</title>
-
-          <tgroup align="center" cols="7">
-            <colspec colname="col1" colnum="1" colwidth="0.5*" />
-
-            <colspec colname="uam_guest" colnum="2" colwidth="1*" />
-
-            <colspec colname="uam_clrtxt" colnum="3" colwidth="1*" />
-
-            <colspec colname="uam_randnum" colnum="4" colwidth="1*" />
-
-            <colspec colname="uam_dhx" colnum="5" colwidth="1*" />
-
-            <colspec colname="uam_dhx2" colnum="6" colwidth="1*" />
-
-            <colspec colname="uam_gss" colnum="7" colwidth="1*" />
-
-            <tbody>
-              <row>
-                <entry align="center" rotate="0" valign="middle">UAM</entry>
-
-                <entry>No User Authent<indexterm>
-                    <primary>uams_guest.so</primary>
-
-                    <secondary>“ユーザー認証なし”UAM（ゲストアクセス）</secondary>
-                  </indexterm></entry>
-
-                <entry>Cleartxt Passwrd<indexterm>
-                    <primary>uams_cleartxt.so</primary>
-
-                    <secondary>“クリアテキスト(平文)パスワード”UAM</secondary>
-                  </indexterm></entry>
-
-                <entry>(2-Way) Randnum exchange<indexterm>
-                    <primary>uams_randnum.so</primary>
-
-                    <secondary>“（双方向）乱数交換”UAM</secondary>
-                  </indexterm></entry>
-
-                <entry>DHCAST128<indexterm>
-                    <primary>uams_dhx.so</primary>
-
-                    <secondary>"DHCAST128" UAM</secondary>
-                  </indexterm></entry>
-
-                <entry>DHX2<indexterm>
-                    <primary>uams_dhx2.so</primary>
-
-                    <secondary>"DHX2" UAM</secondary>
-                  </indexterm></entry>
-
-                <entry>Client Krb v2<indexterm>
-                    <primary>uams_gss.so</primary>
-
-                    <secondary>"Client Krb v2" UAM (Kerberos V)</secondary>
-                  </indexterm></entry>
-              </row>
-
-              <row>
-                <entry align="center" rotate="0" valign="middle">パスワード長</entry>
-
-                <entry>ゲストアクセス</entry>
-
-                <entry>最大 8 文字</entry>
-
-                <entry>最大 8 文字</entry>
-
-                <entry>最大 64 文字</entry>
-
-                <entry>最大 256 文字</entry>
-
-                <entry>Kerberos チケット</entry>
-              </row>
-
-              <row>
-                <entry align="center" rotate="0" valign="middle">サポートするクライアント</entry>
-
-                <entry>全ての Mac OS のバージョンで組み込み済</entry>
-
-                <entry>10.0 を除く全ての Mac OS のバージョンで組み込み済．
-                最近のバージョンでは明示的にアクティブ化する必要がある．</entry>
-
-                <entry>ほとんど全ての Mac OS のバージョンで組み込み済</entry>
-
-                <entry>AppleShare クライアント 3.8.4 より組み込み済で，
-                3.8.3 では Mac OS X の AFP クライアントに統合したプラグインとしての用意あり．</entry>
-
-                <entry>Mac OS X 10.2 より組み込み済</entry>
-
-                <entry>Mac OS X 10.2 より組み込み済</entry>
-              </row>
-
-              <row>
-                <entry align="center" rotate="0"
-                valign="middle">暗号化</entry>
-
-                <entry>クライアント・サーバー間で認証なくゲストアクセス可能．</entry>
-
-                <entry>パスワードがネットワーク上を暗号化されずに伝わっていく．
-                字句そのままに悪いので，可能ならば全面的に使用を回避すべき
-                （注意：NetBoot サービスの提供には ClearTxt UAM が必要）</entry>
-
-                <entry>DES, 56 ビットに相当する 8 バイトの乱数がネットワーク上に送出．
-                オフラインの辞書攻撃に対して脆弱．
-                パスワードがサーバー上で平文であることが求められる．</entry>
-
-                <entry>パスワードは 128 ビット SSL で暗号化され，
-                ユーザーはサーバーに認証されるが，“逆もまた真”ではない．
-                このため中間者攻撃に対して弱い．</entry>
-
-                <entry>パスワードは libgcrypt の CAST 128，CBC モードを用いて暗号化される．
-                ユーザーはサーバーに認証されるが，“逆もまた真”ではない．
-                このため中間者攻撃に対して弱い．</entry>
-
-                <entry>パスワードがネットワークを通して送られることがない．
-                サービスプリンシパル検知の方法が原因で，
-                この認証方法は中間者攻撃に対して脆弱である．</entry>
-              </row>
-
-              <row>
-                <entry align="center" rotate="0" valign="middle">
-                サーバーがサポートする共有オブジェクト
-                </entry>
-
-                <entry align="center" valign="middle">uams_guest.so</entry>
-
-                <entry align="center" valign="middle">uams_cleartxt.so</entry>
-
-                <entry align="center" valign="middle">uams_randnum.so</entry>
-
-                <entry align="center" valign="middle">uams_dhx.so</entry>
-
-                <entry align="center" valign="middle">uams_dhx2.so</entry>
-
-                <entry align="center" valign="middle">uams_gss.so</entry>
-              </row>
-
-              <row>
-                <entry align="center" rotate="0" valign="middle">パスワードの保管方法</entry>
-
-                <entry align="center" valign="middle">なし</entry>
-
-                <entry align="center" valign="middle">/etc/passwd (/etc/shadow) 
-                ないしは PAM</entry>
-
-                <entry align="center" valign="middle">
-                パスワードは別のテキストファイルに平文として保存される
-                </entry>
-
-                <entry align="center" valign="middle">/etc/passwd (/etc/shadow) 
-                ないしは PAM</entry>
-
-                <entry align="center" valign="middle">/etc/passwd (/etc/shadow) 
-                ないしは PAM</entry>
-
-                <entry align="center" valign="middle">Kerberos キー配布センター*</entry>
-              </row>
-            </tbody>
-          </tgroup>
-        </table>
-
-        <para>* <ulink
-        url="https://web.archive.org/web/20070705043002/http://cryptnet.net/fdp/admin/kerby-infra/en/kerby-infra.html">Kerberos
-        概要</ulink> も一読のこと</para>
-      </sect3>
-
-      <sect3 id="sshtunnel">
-        <title>SSH トンネリング</title>
-
-        <para>トンネリングや VPN のたぐいのもの全ては，
-        AFP 認証や UAM に関してすべきことは概ね皆無である．
-        しかしながらアップルが「SSHを用いて安全な接続を可能にする」というオプションを導入して以来，
-        多数の人が両者について混乱する傾向にある．以下ではその点についても述べる．</para>
-
-        <sect4 id="manualsshtunnel">
-          <title>手動で AFP セッションをトンネリング</title>
-
-          <para>これは，
-          "AFP over TCP" を“話すことができる”最初の AFP サーバーがネットワークに登場して以来うまく動作する．
-          リモートサーバーの AFP ポートをローカルの 548 番以外の異なるポートにトンネルし，
-          その後ローカルでこのポートににつなげるだけである．OS X では以下のようにすればよい．</para>
-
-          <programlisting>ssh -l $USER $SERVER -L 10548:127.0.0.1:548 sleep 3000</programlisting>
-
-          <para>トンネルを確立したならば，
-          “サーバーに接続”ダイアログで <filename>"afp://127.0.0.1:10548"</filename> 
-          を使うことができる．
-          ローカルの AFP クライアントは Mac のローカル 10548 番ポートに接続し，
-          そのポートは SSH を通してリモートサーバーの AFP ポート（デフォルトでは 548 番を使う）に転送されているので，
-          端緒の接続試行も含めて全ての AFP トラフィックがネットワークを暗号化されて送られる．</para>
-
-          <para>この手のトンネルは，もし，“真の” VPN を使えないが，インターネットを通じて，
-          弱い認証機構しかない AFP サーバーにアクセスしなければならない場合の理想的な解決手段である．
-          <command>ssh</command> の "-C" オプションでデータ圧縮が可能であり，
-          トンネルの端点を AFP クライアント，サーバーどちらとも異なるようにすることが可能である
-          （詳細については SSH のドキュメントと比較してほしい）という点に留意すべきである．</para>
-        </sect4>
-
-        <sect4 id="autosshtunnel">
-          <title>自動的にトンネル AFP 接続を確立する</title>
-
-          <para>Apple は Mac OS X 10.2 から 10.4 で，
-          「サーバーに接続」ダイアログに
-          「SSHを用いて安全な接続を可能にする」チェックボックスを追加した．
-          この考えの裏にあるのは：サーバーが SSH で接続できるというサインを出した時，
-          Mac OS X の AFP クライアントはトンネルを確立しようとし，
-          自動的に全ての AFP トラフィックをこのトンネルを通して送る．ということなのである．</para>
-
-          <para>しかし，この機能が初めて…部分的に，
-          動作するようになるのに Mac OS X 10.3 までかかった．
-          SSH トンネルが確立できない時，
-          AFP クライアントは<emphasis role="strong">何の通知もなく</emphasis>暗号化していない 
-          AFP 接続試行にフォールバックした．</para>
-
-          <para>"<option>advertise ssh</option>" および 
-          "<option>fqdn</option>" オプション両方を <option>Global</option> 
-          セクションで設定（設定を変更したら，afpd を再起動した後 <citerefentry>
-              <refentrytitle>asip-status</refentrytitle>
-
-              <manvolnum>1</manvolnum>
-            </citerefentry> で二重チェックするべき）した時は，
-          SSH トンネルした AFP リクエストの扱いが可能であることを Netatalk の afpd はレポートする．
-          しかし，このオプションを決して使用したくなくなる２，３の理由がある：</para>
+    </sect2>
+  </sect1>
+
+  <sect1 id="acls">
+    <title>ACL のサーポート<indexterm>
+        <primary>ACL</primary>
+      </indexterm></title>
+
+    <para>afp の ACL サポートは Solaris の ZFS ACL、派生したプラットフォーム、そして、Linux の POSIX 1e
+    ACL で実装されている。</para>
+
+    <sect2>
+      <title>環境設定</title>
+
+      <para>基本的な方式で運用するならば設定することは何もない。Netatalk は ACL をオンザフライで読み込み、そののちいわゆる
+      UARights<indexterm>
+          <primary>UARights</primary>
+        </indexterm> パーミションビット経由で AFP クライアントに送られる有効なパーミッションを算出する。
+      マック上では、これらのビットを Finder ウィンドウ内のパーミッションと調整するために Finder が使用する。例：UNIX
+      のモードでは書き込み専用だが ACL がユーザーに書き込み権限を与えているフォルダーは有効な読み書き権限を表示する。権限のマッピングなしに
+      Finder は読み込み専用アイコンを表示するだろうし、ユーザーはそのフォルダーに書き込みはできないであろう。</para>
+
+      <para>デフォルトでは、認証ユーザーに有効なパーミションは UNIX のモードではなく、前記 UARights<indexterm>
+          <primary>UARights</primary>
+        </indexterm> の機構のみに対応付けられる。この挙動は設定オプション <link linkend="map_acls">map
+      acls</link> で修正することができる。</para>
+
+      <para>しかしながら、Finder の“情報を見る”ウィンドウでもターミナルでも、ACL を見ることは不可能で、そこで見ているのは OS
+      X で ACL がどのように設計されたのかという結果である。もしクライアント上でも ACL
+      を表示させたいと思うならば、諸々を認証ドメイン（ディレクトリサービス、例えば、LDAP
+      やOpenDirectory）の一部と、より内包されているようにして、クライアント側でもサーバー側でもセットアップをおこなうべきである。
+      その理由は、OS X ACL が ただ、uid と gid だけでなく UUID と紐付いているためである。このため、afpd
+      は全てのファイルシステムの uid と git を UUID に紐付けできなければならない。そうすれば、afpd は OS X の UUID
+      に紐付けた UNIX uid と gid も含めたサーバー側の ACL を返すことができる。</para>
+
+      <para>Netatalk は LDAP クエリーを使ってディレクトリサーバーに問い合わせができる。ディレクトリサーバー（Active
+      Directory、Open Directory）が既にユーザーとグループの UUID 属性を提供している。
+      あるいはディレクトリサーバー（例えば
+      OpenLDAP）に使用されていない属性を再利用する（あるいは新たに追加する）のいずれかである。</para>
+
+      <para>より踏み込むと：</para>
+
+      <orderedlist>
+        <listitem>
+          <para>ZFS を使っている Solarisの ZFS ボリュームごとに対して、</para>
+
+          <para>Netatalk を使用したいと思っているあらゆるボリュームを ZFS ACL
+          がわかるように構成すべきである：</para>
+
+          <screen>aclinherit = passthrough
+aclmode = passthrough</screen>
+
+          <para>このひとひねりが何をするのか、どのように適用するのか、についての説明は、ホストの ZFS ドキュメンテーション（例えば
+          man zfs）を確認のこと。</para>
+        </listitem>
+
+        <listitem>
+          <para>認証ドメイン</para>
+
+          <para>サーバーとクライアントがセキュリティ連携の一部となっていて、ユーザー id
+          データは共通のソースから出てこなければならない。Darwin の ACL は UUID に基づいている。なので、AFP 3.2 での
+          ACL の仕様は Darwin の ACL である。故に id
+          データのソースは全てのユーザーとグループの属性を提供できなければならない。ここで UUID は ASCII
+          テキストとして保管されている。言い換えれば：</para>
 
           <itemizedlist>
             <listitem>
-              <para>こう言うような機能を必要とする大部分のユーザーは、
-              おそらく使い慣れている VPN はあるとしたら、
-              通常のVPNを使用して AFP サーバーが実行されているネットワークに接続し、
-              AFP サーバーにアクセスする方が簡単だろう．</para>
-
-              <para>とはいっても、１台の AFP サーバーに接続するという単純なケースでは、
-              VPN より直接 SSH 接続の方がパフォーマンス的に良いだろう．
-              噂と違って、SSH 経由のトンネリングでは、
-              いわゆる「TCP-over-TCP メルトダウン」は発生しない．
-              何故なら、トンネリングされるAFPデータが TCP データをカプセル化していないためである．</para>
+              <para>UUID を何らかの属性に保管している場合は Open Directory サーバーないしは LDAP
+              サーバーが必要である。</para>
             </listitem>
 
             <listitem>
-              <para>このように SSH でその場をしのぐことは AFP 認証機構に直接統合された通常の 
-              UAM ではないし，
-              代わりにこの方法では，
-              トンネルの確立を<emphasis role="strong">試行
-              </emphasis>できるのかどうなのかのサインをクライアントに送るために，
-              単一のフラグを用いる．
-              このため，何かがおかしい時に何が起こっているのかを見ようとする気を失ってしまう．</para>
+              <para>クライアントはこのサーバーを使用するように構成されていなければならない。</para>
             </listitem>
 
             <listitem>
-              <para>全ての接続試行は localhost から行われているように見えるので，
-              <command>macusers</command> のような Netatalk ツールによって，
-              どのマシンがログオンしているのか制御ができない．</para>
+              <para>サーバーは nsswitch と PAM 経由で使用されるよう構成しなければならない。</para>
             </listitem>
 
             <listitem>
-              <para>実際，AFP セッションが全てが SSH で暗号化されていることを確実にしたい場合は，
-              afpd へのアクセスを localhost のみ発信される接続に制限する必要がある．
-              たとえば，Wietse Venema の TCP ラッパーを使用するか，
-              適切なファイアウォールやパケットフィルタリング機能を使用するなど．</para>
-
-              <para>そうしなければ、10.2 から 10.3.3 を使っている場合は，予想とは逆に：
-              トンネルの確立に失敗したという通知一つもなく，
-              ネットワーク上で暗号化されていない AFP の通信（ログイン資格情報を含む）が起こりえるということである．
-              Apple は Mac OS X 10.3.4 になってそれをはじめて修正した．</para>
-            </listitem>
-
-            <listitem>
-              <para>SSH 経由で全ての AFP セッションを暗号化するることは，
-              Netatalk サーバーの負荷の著しい上昇を招く可能性がある</para>
+              <para>Netatalk が LDAP 検索クエリでユーザーとグループの UUID を引き出せるように、<link
+              linkend="afp.conf.5">afp.conf</link> 内で <link
+              linkend="acl_options">ACL 専用のオプションを</link>使って Netatalk
+              を設定しなければならない。</para>
             </listitem>
           </itemizedlist>
-        </sect4>
-      </sect3>
+        </listitem>
+      </orderedlist>
     </sect2>
 
-    <sect2 id="acls">
-      <title>ACL のサーポート<indexterm>
-          <primary>ACL</primary>
-        </indexterm></title>
+    <sect2>
+      <title>OS X の ACL</title>
 
-      <para>afp の ACL サポートは Solaris の ZFS ACL，派生したプラットフォーム，そして，
-      Linux の POSIX 1e ACL で実装されている．</para>
+      <para>アクセス制御リスト (ACL) と共に、Mac OS X は正統的な UNIX のパーミッションモデルの有力な拡張を提案した。
+      ACL は、所定のユーザーあるいはグループのパーミッションのセットを明示的に許可したり拒否するアクセス制御エントリー (ACE)
+      の番号つきリストである。</para>
 
-      <sect3>
-        <title>環境設定</title>
+      <para>ユーザー ID、またはグループ ID と紐付いている UNIX パーミッションとは異なり、ACL は UUID
+      と紐付いている。この理由により、あるオブジェクトの ACL にアクセスすると、サーバーとクライアントは、UUID と ユーザー／グループ ID
+      間の変換をしてくれる、共通のディレクトリサービスを使うことを要求される。</para>
 
-        <para>基本的な方式で運用するならば設定することは何もない．
-        Netatalk は ACL をオンザフライで読み込み，そののちいわゆる UARights<indexterm>
-            <primary>UARights</primary>
-          </indexterm> パーミションビット経由で AFP クライアントに送られる有効なパーミッションを算出する．
-        マック上では，これらのビットを Finder ウィンドウ内のパーミッションと調整するために Finder が使用する．
-        例：UNIX のモードでは書き込み専用だが ACL がユーザーに書き込み権限を与えているフォルダーは有効な読み書き権限を表示する．
-        権限のマッピングなしに Finder は読み込み専用アイコンを表示するだろうし，
-        ユーザーはそのフォルダーに書き込みはできないであろう．</para>
-
-        <para>デフォルトでは，認証ユーザーに有効なパーミションは UNIX のモードではなく，
-        前記 UARights<indexterm>
-            <primary>UARights</primary>
-          </indexterm> の機構のみに対応付けられる．
-        この挙動は設定オプション <link
-        linkend="map_acls">map acls</link> で修正することができる．</para>
-
-        <para>しかしながら，Finder の“情報を見る”ウィンドウでもターミナルでも，
-        ACL を見ることは不可能で，そこで見ているのは OS X で ACL がどのように設計されたのかという結果である．
-        もしクライアント上でも ACL を表示させたいと思うならば，諸々を認証ドメイン（ディレクトリサービス，
-        例えば，LDAP やOpenDirectory）の一部と，より内包されているようにして，
-        クライアント側でもサーバー側でもセットアップをおこなうべきである．
-        その理由は，OS X ACL が ただ，uid と gid だけでなく UUID と紐付いているためである．
-        このため，afpd は全てのファイルシステムの uid と git を UUID に紐付けできなければならない．
-        そうすれば， afpd は OS X の UUID に紐付けた UNIX uid と gid も含めたサーバー側の ACL を返すことができる．
-        </para>
-
-        <para>Netatalk は LDAP クエリーを使ってディレクトリサーバーに問い合わせができる．
-        ディレクトリサーバー（Active Directory，Open Directory）が既にユーザーとグループの UUID 属性を提供している．
-        あるいはディレクトリサーバー（例えば 
-        OpenLDAP）に使用されていない属性を再利用する（あるいは新たに追加する）のいずれかである．</para>
-
-        <para>より踏み込むと：</para>
-
-        <orderedlist>
-          <listitem>
-            <para>ZFS を使っている Solarisの ZFS ボリュームごとに対して，</para>
-            
-            <para>Netatalk を使用したいと思っているあらゆるボリュームを
-            ZFS ACL がわかるように構成すべきである：</para>
-
-            <screen>aclinherit = passthrough
-aclmode = passthrough</screen>
-
-            <para>このひとひねりが何をするのか，どのように適用するのか，についての説明は，
-            ホストの ZFS ドキュメンテーション（例えば man zfs）を確認のこと．</para>
-          </listitem>
-
-          <listitem>
-            <para>認証ドメイン</para>
-
-            <para>サーバーとクライアントがセキュリティ連携の一部となっていて，
-            ユーザー id データは共通のソースから出てこなければならない．
-            Darwin の ACL は UUID に基づいている．
-            なので，AFP 3.2 での ACL の仕様は Darwin の ACL である．
-            故に id データのソースは全てのユーザーとグループの属性を提供できなければならない．
-            ここで UUID は ASCII テキストとして保管されている．言い換えれば：</para>
-
-            <itemizedlist>
-              <listitem>
-                <para>UUID を何らかの属性に保管している場合は 
-                Open Directory サーバーないしは LDAP サーバーが必要である．</para>
-              </listitem>
-
-              <listitem>
-                <para>クライアントはこのサーバーを使用するように構成されていなければならない．</para>
-              </listitem>
-
-              <listitem>
-                <para>サーバーは nsswitch と PAM 経由で使用されるよう構成しなければならない．</para>
-              </listitem>
-
-              <listitem>
-                <para>Netatalk が LDAP 検索クエリでユーザーとグループの UUID を引き出せるように，
-                <link linkend="afp.conf.5">afp.conf</link> 内で <link
-                linkend="acl_options">ACL 専用のオプションを</link>使って Netatalk を設定しなければならない．</para>
-              </listitem>
-            </itemizedlist>
-          </listitem>
-        </orderedlist>
-      </sect3>
-
-      <sect3>
-        <title>OS X の ACL</title>
-
-        <para>アクセス制御リスト (ACL) と共に，
-        Mac OS X は正統的な UNIX のパーミッションモデルの有力な拡張を提案した．
-        ACL は，
-        所定のユーザーあるいはグループのパーミッションのセットを明示的に許可したり拒否するアクセス制御エントリー 
-        (ACE) の番号つきリストである．</para>
-
-        <para>ユーザー ID，またはグループ ID と紐付いている UNIX パーミッションとは異なり，
-        ACL は UUID と紐付いている．この理由により，あるオブジェクトの ACL にアクセスすると，
-        サーバーとクライアントは，UUID と ユーザー／グループ ID 間の変換をしてくれる，
-        共通のディレクトリサービスを使うことを要求される．</para>
-
-        <para>ACL と UNIX のパーミションの相互関係は比較的シンプルなものである．
-        ACL はオプションなので，UNIX パーミションはアクセス制御のデフォルトのメカニズムの役割をする．
-        オブジェクトの UNIX パーミションを変更しても ACL は手付かずのままで，
-        ACL の修正でもオブジェクトの UNIX パーミションは決して変更されない．アクセスチェックの間，
-        OS X は最初に以下の順序で ACE の評価をして，オブジェクトの ACL を検査する：
-        全てのリクエスト権限が許可されるまで，リクエストされた権限が ACE によって明示的に拒否された，
-        あるいはリストの最後までたどり着いた．である．ACL がない，
-        あるいは ACL に許可されたパーミションがリクエストを実行するのに十分でない場合，
-        OS X は次にオブジェクトの UNIX パーミションの評価に入る．
-        つまり，ACL は常に UNIX のパーミションより優先順位が上位ということである．</para>
-      </sect3>
-
-      <sect3>
-        <title>ZFS の ACL</title>
-
-        <para>ZFS の ACL はほぼ OS X の ACL に匹敵するものである．
-        両者ともほぼ同一の良い粒度のパーミションと設定の継承が提供されている．</para>
-      </sect3>
-
-      <sect3>
-        <title>POSIX の ACL</title>
-
-        <sect4>
-          <title>概要</title>
-
-          <para>OS X あるいは NFSv4 の ACL と比較すると，Posix ACL は，
-          伝統的な UNIX パーミションの制限を打開するには異質で汎用性のないアプローチを表現している．
-          実装は Posix 標準を取り込んだものを基礎としている．</para>
-
-          <para>Posix 1003.1e 標準では二つのタイプの ACL を定義している．
-          ファイルとディレクトリは，
-          アクセスチェックのために問い合わせを受けるアクセス ACL を保持することができる．
-          ディレクトリはアクセスチェックには向いていないデフォルトの ACL も保持することができる．
-          デフォルトの ACL 付きでディレクトリの内側に新規オブジェクトが作成された時，
-          デフォルトの ACL はそれがアクセス ACL であるものとして新規オブジェクトに適用される．
-          サブディレクトリは親ディレクトリのデフォルト ACL を継承する．
-          継承制御にそれ以上のメカニズムは何もない．</para>
-
-          <para>設計上，Posix ACL と OS X 間の違いに含まれている特筆すべき点は：</para>
-
-          <para><itemizedlist>
-              <listitem>
-                <para>パーミションモデルは何も細分化されていない．
-                UNIX のパーミション同様，Posix ACL は読み込み，書き込み，そして実行権限を区別している．</para>
-              </listitem>
-
-              <listitem>
-                <para>ACL 内のエントリーに順序はない．</para>
-              </listitem>
-
-              <listitem>
-                <para>Posix ACL は権限を許可することしかできない．
-                エントリーから権限を明示的に拒否する手立てはない．</para>
-              </listitem>
-
-              <listitem>
-                <para>UNIX パーミションは特別なエントリーとして ACL に統合されている．</para>
-              </listitem>
-            </itemizedlist></para>
-
-          <para>Posix 1003.1e は 6 つの異なるタイプの ACL エントリーを定義している．
-          前半の 3 つは標準の UNIX パーミションを統合するのに用いられている．
-          これらは ACL として最小限の形であり，存在することは必須であり，
-          そして各々のタイプにつきたった一つのエントリーだけが ACL 内に許される．</para>
-
-          <para><itemizedlist>
-              <listitem>
-                <para>ACL_USER_OBJ：所有ユーザー（オーナー）のアクセス権限．</para>
-              </listitem>
-
-              <listitem>
-                <para>ACL_GROUP_OBJ：所有グループ（オーナーグループ）のアクセス権限．</para>
-              </listitem>
-
-              <listitem>
-                <para>ACL_OTHER：あらゆるユーザー・グループに対するアクセス権限．</para>
-              </listitem>
-            </itemizedlist></para>
-
-          <para>残りのエントリーのタイプは伝統的パーミションモデルの拡張である：</para>
-
-          <para><itemizedlist>
-              <listitem>
-                <para>ACL_USER：あるユーザーに対するアクセス権を許可する．</para>
-              </listitem>
-
-              <listitem>
-                <para>ACL_GROUP：あるグループに対するアクセス権を許可する．</para>
-              </listitem>
-
-              <listitem>
-                <para>ACL_MASK：ACL_GROUP_OBJ，ACL_USER および ACL_GROUP 
-                タイプのエントリーで許可されうるアクセス権の最大値を制限する．名前の示すように，
-                このエントリーはマスクとして働く．一つの ACL あたり一個だけの ACL_MASK エントリーが許される．
-                もし ACL に，ACL_USER ないしは ACL_GROUP エントリーが含まれているのであれば，
-                ACL_MASK エントリーも存在しなければならない．さもなくば，ACL_MASK はオプションである．</para>
-              </listitem>
-            </itemizedlist></para>
-
-          <para>ACL を意識していないアプリケーションとの互換性を維持のため，
-          Posix 1003.1e は，オブジェクトの UNIX 
-          パーミションを検索したり処理するシステムコールやユーティリティーのセマンティクスを変える．
-          オブジェクトが必要最低限の ACL のみ保持している場合，
-          UNIX パーミションのグループパーミションビットは ACL_GROUP_OBJ エントリーの値に対応する．</para>
-
-          <para>しかしながら，もし ACL に ACL_MASK エントリーが含まれている場合，
-          上記システムコールやユーティリティーの挙動は異なるものとなる．
-          UNIX パーミションのグループパーミションビットは ACL_MASK エントリーの値に対応する，
-          すなわち，"chmod g-w" の呼び出しは，グループに対する書き込みアクセスを無効にするだけでなく，
-          ACL_USER ないしは ACL_GROUP 
-          エントリーによって許可されていた書き込みアクセスのエンティティ全てを無効にするのである．</para>
-        </sect4>
-
-        <sect4>
-          <title>POSIX ACL から OSX の ACL へのマッピング</title>
-
-          <para>クライアントがオブジェクトの ACL を読み込もうとした時，
-          afpd は Posix ACL からそれに等価な OS X の ACL にマップする．
-          オブジェクトの ACL の書き込みには afpd が OS X の ACL を Posix ACL にマップすることが要求される．
-          Posix ACL の設計上の制約から，
-          マッピングを経た結果がオリジナルの ACL 
-          のセマンティクスと概ね同じになるような正確なマッピングを見出すことは通常不可能である．</para>
-
-          <para><itemizedlist>
-              <listitem>
-                <para>afpd はパーミション一式を拒否したエントリーを通告なしに破棄する．
-                これは Posix の設計では表現する手立てがないためである．</para>
-              </listitem>
-
-              <listitem>
-                <para>Posix ACL ではエントリーが順序付きではないので，順序を保管するのは不可能である．</para>
-              </listitem>
-
-              <listitem>
-                <para>継承制御もまた厳しい制限を受けやすい：<itemizedlist>
-                    <listitem>
-                      <para>only_inherit フラグが設定されたエントリーはディレクトリのデフォルト 
-                      ACL の一部にしかならない．</para>
-                    </listitem>
-
-                    <listitem>
-                      <para>少なくとも file_inherit，directory_inherit ないしは limit_inherit 
-                      のうち一つが設定されたエントリーはディレクトリアクセスとデフォルト ACL の一部分となる．
-                      しかし継承に課せられた制約は無視される．</para>
-                    </listitem>
-                  </itemizedlist></para>
-              </listitem>
-
-              <listitem>
-                <para>Posix 側により細分化されたパーミションモデルがないことで，
-                結果としては通常は許可されるパーミションが増えるという結果になる．</para>
-              </listitem>
-            </itemizedlist></para>
-
-          <para>OS X クライアントは Posix 1003.1e 特有の UNIX パーミションと ACL_MASK との関係を意識していないので，
-          afpd は互換性問題を回避するためにこの機能をクライアントに公開せず，
-          そして afpd は *unix パーミションと ACL をアップルの AFP 
-          用リファレンス実装がするのと同じ方法で扱う．
-          オブジェクトの UNIX パーミションがリクエストされた時，afpd は適切なグループ権限を算出し，
-          FPUnixPrivs 構造の "permissions" と "ua_permissions" 
-          要素を介し，オーナーおよび全ての者のアクセス権限も共に付して，リクエストした側に結果を返す．
-          （Apple Filing Protocol Reference の 181 ページ参照）
-          オブジェクトのパーミションを変更すると，afpd は常に ACL_USER_OBJ，ACL_GROUP_OBJ および ACL_OTHERS を更新する．
-          もし ACL_MASK エントリーも存在すれば，新しいグループの権限が有効になり，かつ，
-          既存の ACL_USER あるいは ACL_GROUP 型のエントリーは手付かずになるような ACL_MASK の値の再計算を afpd が行う．</para>
-        </sect4>
-      </sect3>
+      <para>ACL と UNIX のパーミションの相互関係は比較的シンプルなものである。ACL はオプションなので、UNIX
+      パーミションはアクセス制御のデフォルトのメカニズムの役割をする。オブジェクトの UNIX パーミションを変更しても ACL
+      は手付かずのままで、ACL の修正でもオブジェクトの UNIX パーミションは決して変更されない。アクセスチェックの間、OS X
+      は最初に以下の順序で ACE の評価をして、オブジェクトの ACL を検査する： 全てのリクエスト権限が許可されるまで、リクエストされた権限が
+      ACE によって明示的に拒否された、あるいはリストの最後までたどり着いた。である。ACL がない、あるいは ACL
+      に許可されたパーミションがリクエストを実行するのに十分でない場合、OS X は次にオブジェクトの UNIX パーミションの評価に入る。
+      つまり、ACL は常に UNIX のパーミションより優先順位が上位ということである。</para>
     </sect2>
 
-    <sect2 id="fce">
-      <title>ファイルシステム変更イベント<indexterm>
-          <primary>FCE</primary>
-        </indexterm></title>
+    <sect2>
+      <title>ZFS の ACL</title>
 
-      <para>Netatalk には素敵なファイルシステム変更イベント機構が含まれている．ここで，
-      afpd プロセスは，なにがしかのファイルシステムイベントについて，関心を寄せているリスナーに，
-      UDP ネットワークデータグラム経由で通知する．</para>
-
-      <para>この UDP パケットのフォーマットについて，また，
-      これらをリスナー内でどのように使用するかのデモを試してみる C アプリケーションの実例については，
-      Netatalk のソースファイル <filename>bin/misc/fce.c</filename> に目を通していただきたい．</para>
-
-      <para>現在サポートされている FCE （ファイルシステム変更イベント：Filesystem Change Events）は以下である：<itemizedlist>
-          <listitem>
-            <para>ファイル変更：file modification (fmod)</para>
-          </listitem>
-
-          <listitem>
-            <para>ファイル削除：file deletion (fdel)</para>
-          </listitem>
-
-          <listitem>
-            <para>ディレクトリ削除：directory deletion (ddel)</para>
-          </listitem>
-
-          <listitem>
-            <para>ファイル作成：file creation (fcre)</para>
-          </listitem>
-
-          <listitem>
-            <para>ディレクトリ削除：directory deletion (ddel)</para>
-          </listitem>
-        </itemizedlist></para>
-
-      <para>利用可能で基本的な設定オプションの詳細については  <filename><link
-      linkend="fceconf">afp.conf</link></filename> に目を通していただきたい．</para>
+      <para>ZFS の ACL はほぼ OS X の ACL に匹敵するものである。
+      両者ともほぼ同一の良い粒度のパーミションと設定の継承が提供されている。</para>
     </sect2>
+
+    <sect2>
+      <title>POSIX の ACL</title>
+
+      <sect3>
+        <title>概要</title>
+
+        <para>OS X あるいは NFSv4 の ACL と比較すると、Posix ACL は、伝統的な UNIX
+        パーミションの制限を打開するには異質で汎用性のないアプローチを表現している。実装は Posix
+        標準を取り込んだものを基礎としている。</para>
+
+        <para>Posix 1003.1e 標準では二つのタイプの ACL を定義している。ファイルとディレクトリは、
+        アクセスチェックのために問い合わせを受けるアクセス ACL を保持することができる。
+        ディレクトリはアクセスチェックには向いていないデフォルトの ACL も保持することができる。デフォルトの ACL
+        付きでディレクトリの内側に新規オブジェクトが作成された時、デフォルトの ACL はそれがアクセス ACL
+        であるものとして新規オブジェクトに適用される。サブディレクトリは親ディレクトリのデフォルト ACL を継承する。
+        継承制御にそれ以上のメカニズムは何もない。</para>
+
+        <para>設計上、Posix ACL と OS X 間の違いに含まれている特筆すべき点は：</para>
+
+        <para><itemizedlist>
+            <listitem>
+              <para>パーミションモデルは何も細分化されていない。UNIX のパーミション同様、Posix ACL
+              は読み込み、書き込み、そして実行権限を区別している。</para>
+            </listitem>
+
+            <listitem>
+              <para>ACL 内のエントリーに順序はない。</para>
+            </listitem>
+
+            <listitem>
+              <para>Posix ACL は権限を許可することしかできない。
+              エントリーから権限を明示的に拒否する手立てはない。</para>
+            </listitem>
+
+            <listitem>
+              <para>UNIX パーミションは特別なエントリーとして ACL に統合されている。</para>
+            </listitem>
+          </itemizedlist></para>
+
+        <para>Posix 1003.1e は 6 つの異なるタイプの ACL エントリーを定義している。前半の 3 つは標準の UNIX
+        パーミションを統合するのに用いられている。これらは ACL として最小限の形であり、存在することは必須であり、
+        そして各々のタイプにつきたった一つのエントリーだけが ACL 内に許される。</para>
+
+        <para><itemizedlist>
+            <listitem>
+              <para>ACL_USER_OBJ：所有ユーザー（オーナー）のアクセス権限。</para>
+            </listitem>
+
+            <listitem>
+              <para>ACL_GROUP_OBJ：所有グループ（オーナーグループ）のアクセス権限。</para>
+            </listitem>
+
+            <listitem>
+              <para>ACL_OTHER：あらゆるユーザー・グループに対するアクセス権限。</para>
+            </listitem>
+          </itemizedlist></para>
+
+        <para>残りのエントリーのタイプは伝統的パーミションモデルの拡張である：</para>
+
+        <para><itemizedlist>
+            <listitem>
+              <para>ACL_USER：あるユーザーに対するアクセス権を許可する。</para>
+            </listitem>
+
+            <listitem>
+              <para>ACL_GROUP：あるグループに対するアクセス権を許可する。</para>
+            </listitem>
+
+            <listitem>
+              <para>ACL_MASK：ACL_GROUP_OBJ、ACL_USER および ACL_GROUP
+              タイプのエントリーで許可されうるアクセス権の最大値を制限する。名前の示すように、このエントリーはマスクとして働く。一つの
+              ACL あたり一個だけの ACL_MASK エントリーが許される。もし ACL に、ACL_USER ないしは
+              ACL_GROUP エントリーが含まれているのであれば、ACL_MASK
+              エントリーも存在しなければならない。さもなくば、ACL_MASK はオプションである。</para>
+            </listitem>
+          </itemizedlist></para>
+
+        <para>ACL を意識していないアプリケーションとの互換性を維持のため、Posix 1003.1e は、オブジェクトの UNIX
+        パーミションを検索したり処理するシステムコールやユーティリティーのセマンティクスを変える。オブジェクトが必要最低限の ACL
+        のみ保持している場合、UNIX パーミションのグループパーミションビットは ACL_GROUP_OBJ
+        エントリーの値に対応する。</para>
+
+        <para>しかしながら、もし ACL に ACL_MASK エントリーが含まれている場合、
+        上記システムコールやユーティリティーの挙動は異なるものとなる。UNIX パーミションのグループパーミションビットは ACL_MASK
+        エントリーの値に対応する、すなわち、"chmod g-w" の呼び出しは、グループに対する書き込みアクセスを無効にするだけでなく、
+        ACL_USER ないしは ACL_GROUP
+        エントリーによって許可されていた書き込みアクセスのエンティティ全てを無効にするのである。</para>
+      </sect3>
+
+      <sect3>
+        <title>POSIX ACL から OSX の ACL へのマッピング</title>
+
+        <para>クライアントがオブジェクトの ACL を読み込もうとした時、afpd は Posix ACL からそれに等価な OS X の
+        ACL にマップする。オブジェクトの ACL の書き込みには afpd が OS X の ACL を Posix ACL
+        にマップすることが要求される。Posix ACL の設計上の制約から、マッピングを経た結果がオリジナルの ACL
+        のセマンティクスと概ね同じになるような正確なマッピングを見出すことは通常不可能である。</para>
+
+        <para><itemizedlist>
+            <listitem>
+              <para>afpd はパーミション一式を拒否したエントリーを通告なしに破棄する。これは Posix
+              の設計では表現する手立てがないためである。</para>
+            </listitem>
+
+            <listitem>
+              <para>Posix ACL ではエントリーが順序付きではないので、順序を保管するのは不可能である。</para>
+            </listitem>
+
+            <listitem>
+              <para>継承制御もまた厳しい制限を受けやすい：<itemizedlist>
+                  <listitem>
+                    <para>only_inherit フラグが設定されたエントリーはディレクトリのデフォルト ACL
+                    の一部にしかならない。</para>
+                  </listitem>
+
+                  <listitem>
+                    <para>少なくとも file_inherit、directory_inherit ないしは
+                    limit_inherit のうち一つが設定されたエントリーはディレクトリアクセスとデフォルト ACL
+                    の一部分となる。しかし継承に課せられた制約は無視される。</para>
+                  </listitem>
+                </itemizedlist></para>
+            </listitem>
+
+            <listitem>
+              <para>Posix 側により細分化されたパーミションモデルがないことで、
+              結果としては通常は許可されるパーミションが増えるという結果になる。</para>
+            </listitem>
+          </itemizedlist></para>
+
+        <para>OS X クライアントは Posix 1003.1e 特有の UNIX パーミションと ACL_MASK
+        との関係を意識していないので、afpd は互換性問題を回避するためにこの機能をクライアントに公開せず、そして afpd は *unix
+        パーミションと ACL をアップルの AFP 用リファレンス実装がするのと同じ方法で扱う。オブジェクトの UNIX
+        パーミションがリクエストされた時、afpd は適切なグループ権限を算出し、FPUnixPrivs 構造の "permissions" と
+        "ua_permissions" 要素を介し、オーナーおよび全ての者のアクセス権限も共に付して、リクエストした側に結果を返す。（Apple
+        Filing Protocol Reference の 181 ページ参照） オブジェクトのパーミションを変更すると、afpd は常に
+        ACL_USER_OBJ、ACL_GROUP_OBJ および ACL_OTHERS を更新する。もし ACL_MASK
+        エントリーも存在すれば、新しいグループの権限が有効になり、かつ、既存の ACL_USER あるいは ACL_GROUP
+        型のエントリーは手付かずになるような ACL_MASK の値の再計算を afpd が行う。</para>
+      </sect3>
+    </sect2>
+  </sect1>
+
+  <sect1 id="fce">
+    <title>ファイルシステム変更イベント<indexterm>
+        <primary>FCE</primary>
+      </indexterm></title>
+
+    <para>Netatalk には素敵なファイルシステム変更イベント機構が含まれている。ここで、afpd
+    プロセスは、なにがしかのファイルシステムイベントについて、関心を寄せているリスナーに、UDP
+    ネットワークデータグラム経由で通知する。</para>
+
+    <para>この UDP パケットのフォーマットについて、また、これらをリスナー内でどのように使用するかのデモを試してみる C
+    アプリケーションの実例については、Netatalk のソースファイル <filename>bin/misc/fce.c</filename>
+    に目を通していただきたい。</para>
+
+    <para>現在サポートされている FCE （ファイルシステム変更イベント：Filesystem Change
+    Events）は以下である：<itemizedlist>
+        <listitem>
+          <para>ファイル変更：file modification (fmod)</para>
+        </listitem>
+
+        <listitem>
+          <para>ファイル削除：file deletion (fdel)</para>
+        </listitem>
+
+        <listitem>
+          <para>ディレクトリ削除：directory deletion (ddel)</para>
+        </listitem>
+
+        <listitem>
+          <para>ファイル作成：file creation (fcre)</para>
+        </listitem>
+
+        <listitem>
+          <para>ディレクトリ削除：directory deletion (ddel)</para>
+        </listitem>
+      </itemizedlist></para>
+
+    <para>利用可能で基本的な設定オプションの詳細については <filename><link
+    linkend="fceconf">afp.conf</link></filename> に目を通していただきたい。</para>
   </sect1>
 
   <sect1>
@@ -1510,28 +1353,28 @@ aclmode = passthrough</screen>
         <primary>Spotlight</primary>
       </indexterm></title>
 
-    <para>バージョン 3.1 から，Netatalk は Spotlight 検索をサポートしている．
-    Netatalk はメタデータの保存，インデックス化およびサーチエンジンに Gnome
-    <ulink url="https://projects.gnome.org/tracker/">Tracker</ulink> を用いる．</para>
+    <para>バージョン 3.1 から、Netatalk は Spotlight 検索をサポートしている。Netatalk
+    はメタデータの保存、インデックス化およびサーチエンジンに Gnome <ulink
+    url="https://projects.gnome.org/tracker/">Tracker</ulink> を用いる。</para>
 
     <sect2>
       <title>設定</title>
 
-      <para><option>spotlight</option> オプションを使って，
-      グローバルで，あるいは，ボリューム単位ごとに Spotlight とインデックス化を有効にできる．</para>
+      <para><option>spotlight</option> オプションを使って、グローバルで、あるいは、ボリューム単位ごとに
+      Spotlight とインデックス化を有効にできる。</para>
 
       <warning>
-        <para>一旦 Spotlight をどこか単一のボリュームで有効にすると，
-        Spotlight が無効にされたことになるその他全てのボリュームでは全く検索できないようになる．</para>
+        <para>一旦 Spotlight をどこか単一のボリュームで有効にすると、Spotlight
+        が無効にされたことになるその他全てのボリュームでは全く検索できないようになる。</para>
       </warning>
 
-      <para>The <command>dbus-daemon</command> バイナリは Spotlight 機能のためにインストールしなければならない．
-      dbus-daemon へのパスは "configure" の --with-dbus-daemon オプションで決定する．</para>
+      <para>The <command>dbus-daemon</command> バイナリは Spotlight
+      機能のためにインストールしなければならない。dbus-daemon へのパスは "configure" の with-dbus-daemon
+      オプションで決定する。</para>
 
-      <para><command>dbus-daemon</command> バイナリが，他のパスにインストールされている場合，
-      パスを指示するためにグローバルオプション <option>dbus daemon</option> を用いなければならない．
-      例えば Solaris 上で OpenCSW 由来の Tracker を用いている場合は以下のようにする：
-      <screen>dbus daemon = /opt/csw/bin/dbus-daemon</screen></para>
+      <para><command>dbus-daemon</command> バイナリが、他のパスにインストールされている場合、
+      パスを指示するためにグローバルオプション <option>dbus daemon</option> を用いなければならない。例えば
+      Solaris 上で OpenCSW 由来の Tracker を用いている場合は以下のようにする： <screen>dbus daemon = /opt/csw/bin/dbus-daemon</screen></para>
     </sect2>
 
     <sect2>
@@ -1541,28 +1384,27 @@ aclmode = passthrough</screen>
         <listitem>
           <para>大きいファイルシステム</para>
 
-          <para>Linux 上の Tracker はファイルシステム変更の追跡に inotify 
-          カーネルファイルシステム変更イベント API を使用する．大きなファイルシステムではこれが問題になりやすい．
-          なぜなら，この inotofy API は再帰的ディレクトリ監視を提供してはおらず，
-          代わりにあらゆるサブディレクトリの監視が各々で追加されなければならないということを要求してくるからである．</para>
+          <para>Linux 上の Tracker はファイルシステム変更の追跡に inotify カーネルファイルシステム変更イベント
+          API を使用する。大きなファイルシステムではこれが問題になりやすい。なぜなら、この inotofy API
+          は再帰的ディレクトリ監視を提供してはおらず、
+          代わりにあらゆるサブディレクトリの監視が各々で追加されなければならないということを要求してくるからである。</para>
 
-          <para>Solaris ではファイルイベント通知（FEN: File Event Notification) が用いられる．
-          この Solaris のサブシステムではどんな制限とリソース消費があるのか不明である．</para>
+          <para>Solaris ではファイルイベント通知（FEN: File Event Notification) が用いられる。この
+          Solaris のサブシステムではどんな制限とリソース消費があるのか不明である。</para>
 
-          <para>それ故，ライブでのファイルシステム監視は無効にして，
-          その代わりに定期的に Tracker にファイルシステム変更のスキャンを行わせることを推奨する．
-          下記 Tracker オプション，<link
+          <para>それ故、ライブでのファイルシステム監視は無効にして、その代わりに定期的に Tracker
+          にファイルシステム変更のスキャンを行わせることを推奨する。下記 Tracker オプション、<link
           linkend="enable-monitors">enable-monitors</link> および <link
-          linkend="crawling-interval">crawling-interval</link> を参照のこと．</para>
+          linkend="crawling-interval">crawling-interval</link> を参照のこと。</para>
         </listitem>
-       	<listitem>
+
+        <listitem>
           <para>home ディレクトリのインデックスは作成されない</para>
 
-          <para>現在の実装の既知の制限により，
-          ユーザーのhome ディレクトリ内の共有ボリュームは
-          Spotlight によってインデックス付けされない．</para>
+          <para>現在の実装の既知の制限により、ユーザーのhome ディレクトリ内の共有ボリュームは Spotlight
+          によってインデックス付けされない。</para>
 
-          <para>回避策として，ファイルシステム別場所に共有ボリュームを設定する．</para>
+          <para>回避策として、ファイルシステム別場所に共有ボリュームを設定する。</para>
         </listitem>
       </itemizedlist>
     </sect2>
@@ -1570,10 +1412,9 @@ aclmode = passthrough</screen>
     <sect2>
       <title>サーバー上での Tracker コマンドラインツールの使用</title>
 
-      <para>Netatalk は動作中でなければならず，コマンドの実行は root 権限で行わなければならない．
-      そしていくつかの環境変数を設定されなければならない．必要に応じて.tracker_profileを作成し，
-      /root/.profile より source を指定する．PREFIX は Netatalk 
-      をインストールしたベースディレクトリにあわせて読み替える．<screen>$ su
+      <para>Netatalk は動作中でなければならず、コマンドの実行は root 権限で行わなければならない。
+      そしていくつかの環境変数を設定されなければならない。必要に応じて.tracker_profileを作成し、/root/.profile より
+      source を指定する。PREFIX は Netatalk をインストールしたベースディレクトリにあわせて読み替える。<screen>$ su
 # cat .tracker_profile
 PREFIX="/usr/local"
 export XDG_DATA_HOME="$PREFIX/var/netatalk/"
@@ -1583,8 +1424,7 @@ export DBUS_SESSION_BUS_ADDRESS="unix:path=$PREFIX/var/netatalk/spotlight.ipc"
 #
 </screen></para>
 
-      <para>OpenCSW の Tracker を使用していたら PATH 
-      も以下のように更新する：<screen># export PATH=/opt/csw/bin:$PATH</screen></para>
+      <para>OpenCSW の Tracker を使用していたら PATH も以下のように更新する：<screen># export PATH=/opt/csw/bin:$PATH</screen></para>
 
       <sect3>
         <title>Tracker コマンド</title>
@@ -1592,6 +1432,7 @@ export DBUS_SESSION_BUS_ADDRESS="unix:path=$PREFIX/var/netatalk/spotlight.ipc"
         <variablelist>
           <varlistentry>
             <term>Tracker の状態の問い合わせ:</term>
+
             <listitem>
               <screen># tracker daemon</screen>
             </listitem>
@@ -1599,6 +1440,7 @@ export DBUS_SESSION_BUS_ADDRESS="unix:path=$PREFIX/var/netatalk/spotlight.ipc"
 
           <varlistentry>
             <term>Tracker の停止:</term>
+
             <listitem>
               <screen># tracker daemon -t</screen>
             </listitem>
@@ -1606,6 +1448,7 @@ export DBUS_SESSION_BUS_ADDRESS="unix:path=$PREFIX/var/netatalk/spotlight.ipc"
 
           <varlistentry>
             <term>Tracker の開始:</term>
+
             <listitem>
               <screen># tracker daemon -s</screen>
             </listitem>
@@ -1613,6 +1456,7 @@ export DBUS_SESSION_BUS_ADDRESS="unix:path=$PREFIX/var/netatalk/spotlight.ipc"
 
           <varlistentry>
             <term>ディレクトリの再インデックス:</term>
+
             <listitem>
               <screen># tracker index -f PATH</screen>
             </listitem>
@@ -1620,6 +1464,7 @@ export DBUS_SESSION_BUS_ADDRESS="unix:path=$PREFIX/var/netatalk/spotlight.ipc"
 
           <varlistentry>
             <term>Tracker にファイルやディレクトリの情報を問い合わせる:</term>
+
             <listitem>
               <screen># tracker info PATH</screen>
             </listitem>
@@ -1627,77 +1472,75 @@ export DBUS_SESSION_BUS_ADDRESS="unix:path=$PREFIX/var/netatalk/spotlight.ipc"
 
           <varlistentry>
             <term>Tracker で検索:</term>
+
             <listitem>
               <screen># tracker search QUERY</screen>
             </listitem>
           </varlistentry>
         </variablelist>
+      </sect3>
 
-        </sect3>
-    </sect2>
+      <sect3>
+        <title>Tracker コマンドラインのより進んだ設定</title>
 
-    <sect2>
-      <title>Tracker コマンドラインのより進んだ設定</title>
+        <para>Tracker はその設定を Gnome dconf バックエンド経由で保管し、これ
+        <command>gsettings</command> コマンドで変更できる。</para>
 
-      <para>Tracker はその設定を Gnome dconf バックエンド経由で保管し，
-      これ <command>gsettings</command> コマンドで変更できる．</para>
+        <para>Gnome dconf の設定は各々のユーザーベースである。よって、Netatalk は Tracker プロセスを root
+        権限で実行するため、設定は root ユーザーのコンテキストで保管され、これら設定の読み込み書き込みも root
+        権限で行われ、Netatalk
+        はこのとき動作中でなければならない。（そして繰り返しになるが、環境を前記のように設定しなければならない）</para>
 
-      <para>Gnome dconf の設定は各々のユーザーベースである．よって，Netatalk
-      は Tracker プロセスを root 権限で実行するため，設定は root 
-      ユーザーのコンテキストで保管され，これら設定の読み込み書き込みも root 
-      権限で行われ，Netatalk 
-      はこのとき動作中でなければならない．（そして繰り返しになるが，環境を前記のように設定しなければならない）</para>
-
-      <para><screen># gsettings list-recursively | grep Tracker
+        <para><screen># gsettings list-recursively | grep Tracker
 org.freedesktop.Tracker.Writeback verbosity 'debug'
 ...</screen></para>
 
-      <para>以下のリストで Tracker
-      の一部重要なオプションおよびそのデフォルト設定について示す．</para>
+        <para>以下のリストで Tracker の一部重要なオプションおよびそのデフォルト設定について示す。</para>
 
-      <variablelist>
-        <varlistentry>
-          <term>org.freedesktop.Tracker.Miner.Files
-          index-recursive-directories</term>
+        <variablelist>
+          <varlistentry>
+            <term>org.freedesktop.Tracker.Miner.Files
+            index-recursive-directories</term>
 
-          <listitem>
-            <para>このオプションは Tracker がどのディレクトリをインデックス化するかを制御する．
-            本オプションは Netatalk ボリュームそれぞれの <option>Spotlight</option> 
-            オプションの設定を反映して自動的に Netatalk によってセットされるので，手動で変更してはならない．</para>
-          </listitem>
-        </varlistentry>
+            <listitem>
+              <para>このオプションは Tracker がどのディレクトリをインデックス化するかを制御する。本オプションは
+              Netatalk ボリュームそれぞれの <option>Spotlight</option> オプションの設定を反映して自動的に
+              Netatalk によってセットされるので、手動で変更してはならない。</para>
+            </listitem>
+          </varlistentry>
 
-        <varlistentry>
-          <term id="enable-monitors">org.freedesktop.Tracker.Miner.Files
-          enable-monitors <parameter> true</parameter></term>
+          <varlistentry>
+            <term id="enable-monitors">org.freedesktop.Tracker.Miner.Files
+            enable-monitors <parameter> true</parameter></term>
 
-          <listitem>
-            <para>この値は Tracker が全ての設定パスの変更を監視するかどうかを制御する．
-            ファイルシステムの変更バックエンド（Linux なら FAM，Solaris なら FEN）に依存しているので，
-            この機能は期待するほどの信頼度をもって動作しないかもしれない．
-            それ故，この機能は無効にして代わりに Tracker 自体の定期的なクローリングに頼るほうが安全であろう．
-            オプション <option>crawling-interval </option> も参照のこと．</para>
-          </listitem>
-        </varlistentry>
+            <listitem>
+              <para>この値は Tracker が全ての設定パスの変更を監視するかどうかを制御する。
+              ファイルシステムの変更バックエンド（Linux なら FAM、Solaris なら FEN）に依存しているので、
+              この機能は期待するほどの信頼度をもって動作しないかもしれない。それ故、この機能は無効にして代わりに Tracker
+              自体の定期的なクローリングに頼るほうが安全であろう。オプション <option>crawling-interval
+              </option> も参照のこと。</para>
+            </listitem>
+          </varlistentry>
 
-        <varlistentry>
-          <term id="crawling-interval">org.freedesktop.Tracker.Miner.Files
-          crawling-interval <parameter>-1</parameter></term>
+          <varlistentry>
+            <term id="crawling-interval">org.freedesktop.Tracker.Miner.Files
+            crawling-interval <parameter>-1</parameter></term>
 
-          <listitem>
-            <para>ファイルシステムがデータベース上で最新であるかチェックする間隔（日にち単位）．
-            最大は 365 まで，デフォルトでは -1，-2 = クローリングは完全に行われない．
-            -1 = スタートアップ時にクローリングが行われる“はず”（シャットダウンが完全でなかった場合）．
-            0 = 強制的にクローリングされる</para>
-          </listitem>
-        </varlistentry>
-      </variablelist>
+            <listitem>
+              <para>ファイルシステムがデータベース上で最新であるかチェックする間隔（日にち単位）。最大は 365 まで、デフォルトでは
+              -1、-2 = クローリングは完全に行われない。-1 =
+              スタートアップ時にクローリングが行われる“はず”（シャットダウンが完全でなかった場合）。0 =
+              強制的にクローリングされる</para>
+            </listitem>
+          </varlistentry>
+        </variablelist>
+      </sect3>
     </sect2>
 
     <sect2>
       <title>サポートされているメタデータ属性</title>
 
-      <para>下記表にサポートされている Spotlight メタデータ属性を挙げる．</para>
+      <para>下記表にサポートされている Spotlight メタデータ属性を挙げる。</para>
 
       <table>
         <title>サポートされている Spotlight メタデータ属性</title>
@@ -1775,13 +1618,13 @@ org.freedesktop.Tracker.Writeback verbosity 'debug'
             </row>
 
             <row>
-              <entry>コンテンツの幅（ピクセル）：例えば，画像ならばピクセル幅，動画ならばフレームの幅</entry>
+              <entry>コンテンツの幅（ピクセル）：例えば、画像ならばピクセル幅、動画ならばフレームの幅</entry>
 
               <entry>kMDItemPixelWidth</entry>
             </row>
 
             <row>
-              <entry>コンテンツの高さ（ピクセル）：例えば，画像ならばピクセルでの高さ，動画ならばフレームの高さ</entry>
+              <entry>コンテンツの高さ（ピクセル）：例えば、画像ならばピクセルでの高さ、動画ならばフレームの高さ</entry>
 
               <entry>kMDItemPixelHeight</entry>
             </row>
@@ -1793,7 +1636,7 @@ org.freedesktop.Tracker.Writeback verbosity 'debug'
             </row>
 
             <row>
-              <entry>サンプルあたりのビット値（訳注：分解能，量子化ビット数，色深度など）</entry>
+              <entry>サンプルあたりのビット値（訳注：分解能、量子化ビット数、色深度など）</entry>
 
               <entry>kMDItemBitsPerSample</entry>
             </row>
@@ -1811,7 +1654,7 @@ org.freedesktop.Tracker.Writeback verbosity 'debug'
             </row>
 
             <row>
-              <entry>ドキュメントの向き．許容される値は 0（ランドスケープ：横向き）と 1 （ポートレイト：縦向き）</entry>
+              <entry>ドキュメントの向き。許容される値は 0（ランドスケープ：横向き）と 1 （ポートレイト：縦向き）</entry>
 
               <entry>kMDItemOrientation</entry>
             </row>
@@ -1849,60 +1692,21 @@ org.freedesktop.Tracker.Writeback verbosity 'debug'
         </tgroup>
       </table>
 
+      <sect3>
+        <title>参考</title>
+
+        <orderedlist>
+          <listitem>
+            <para><ulink
+            url="https://developer.apple.com/documentation/coreservices/mditemref/">MDItem</ulink></para>
+          </listitem>
+
+          <listitem>
+            <para><ulink
+            url="https://gnome.pages.gitlab.gnome.org/tracker/docs/developer/">Tracker</ulink></para>
+          </listitem>
+        </orderedlist>
+      </sect3>
     </sect2>
-
-    <sect2>
-      <title>参考</title>
-
-      <orderedlist>
-        <listitem>
-          <para><ulink
-          url="https://developer.apple.com/documentation/coreservices/mditemref/">MDItem</ulink></para>
-        </listitem>
-
-        <listitem>
-          <para><ulink
-          url="https://gnome.pages.gitlab.gnome.org/tracker/docs/developer/">Tracker</ulink></para>
-        </listitem>
-      </orderedlist>
-    </sect2>
-  </sect1>
-
-  <sect1>
-    <title>Netatalk の起動と停止</title>
-
-    <para>Netatalk の配布物は，
-    いくつかのオペレーティングシステム固有のスタートアップ・スクリプト・テンプレートを備えている．
-    これらテンプレートは，コンパイル前に "configure" スクリプトに与えられるオプションに応じて最適化されている．
-    現時点で，RedHat（sysv 形式），RedHat（systemd 形式），SUSE（sysv 形式），SUSE（systemd 形式），
-    Debian（sysv 形式），Debian（systemd 形式），Gentoo，NetBSD，および Solaris 向けのテンプレートが用意されている．
-    "configure" スクリプトにシステムタイプを指示することで，どのスタートアップスクリプト
-      <indexterm>
-        <primary>Startscript</primary>
-
-        <secondary>スタートアップスクリプト</secondary>
-      </indexterm>を生成してインストールするのか選ぶことができる．
-    スタートアップスクリプトを自動でインストールさせるには，
-    <option>--with-init-style</option> オプションで有効なものを "configure" に加える．</para>
-
-    <para>Linux ディストーションの新しいリリースは頻繁に出てくるし，
-    上記で触れたようなほかのシステムのスタートアップの手続きもまた変わりうる．
-    それ故，盲目的にスタートアップスクリプトをインストールするのではなく，
-    自分のシステムで動作するであろうかということをまず見てみる，というのがおそらくいい考えである．
-    Linux ディストーションの RPM あるいは BSD のパッケージのような所定のセットアップの一部として使用する場合，
-    諸々の事は概ねよしなに取り計らわれるだろう．
-    それ故，Netatalk そのものをコンパイルするユーザーには概ね下記のことが当てはまる．</para>
-
-    <para>いかなるスタートアップスクリプト機構を使っていても，下記のデーモンは必要である：</para>
-
-    <itemizedlist>
-      <listitem>
-        <para>netatalk<indexterm>
-            <primary>netatalk</primary>
-          </indexterm></para>
-      </listitem>
-    </itemizedlist>
-
-    <para>加えて，設定ファイル <filename>afp.conf</filename> が正しい場所にあるか確認する．</para>
   </sect1>
 </chapter>

--- a/doc/ja/manual/install.xml
+++ b/doc/ja/manual/install.xml
@@ -2,21 +2,21 @@
 <chapter id="installation">
   <chapterinfo>
     <date>17.1.2015</date>
-    
+
     <author role="first-last">
       <firstname>Eiichirou</firstname>
-      
+
       <surname>UDA（日本語訳）</surname>
     </author>
-    
+
     <pubdate>2016 年 7 月 26 日（訳）</pubdate>
-    
+
   </chapterinfo>
 
   <title>インストール</title>
 
   <warning>
-    <para>Netatalk 3 は他バージョンと共存できないので，以前に Netatalk の古いバージョンを使ったことがあるなら，
+    <para>Netatalk 3 は他バージョンと共存できないので、以前に Netatalk の古いバージョンを使ったことがあるなら、
     “<link linkend="upgrade">Netatalk 2 からのアップグレード</link>”の章をまず読んでいただきたい！！！</para>
   </warning>
 
@@ -31,60 +31,15 @@
     <sect2>
       <title>バイナリーパッケージ</title>
 
-      <para>Netatalk のバイナリーパッケージは，いくつかの Linux，Unix
-      ディストリビューションに含まれている．通常の配布元も見たいだろうと思う。</para>
+      <para>Netatalk のバイナリーパッケージは、いくつかの Linux、Unix
+      ディストリビューションに含まれている。通常の配布元も見たいだろうと思う。</para>
 
-      <para>Ubuntu パッケージ：<ulink
-      url="https://launchpad.net/ubuntu">https://launchpad.net/ubuntu
-      </ulink></para>
-
-      <para>Debian パッケージ：<ulink
-      url="https://www.debian.org/distrib/packages">http://www.debian.org/
-      </ulink></para>
-
-      <para>様々な RPM パッケージ：<ulink
-      url="http://rpmfind.net/">http://rpmfind.net/</ulink></para>
-
-      <para>Fedora/RHEL パッケージ：<ulink
-      url="http://koji.fedoraproject.org/koji/search">http://koji.fedoraproject.org/koji/search
-      </ulink></para>
-
-      <para>Gentoo パッケージ：<ulink
-      url="http://packages.gentoo.org/">http://packages.gentoo.org/
-      </ulink></para>
-
-      <para>openSUSE パッケージ：<ulink
-      url="http://software.opensuse.org/">http://software.opensuse.org/
-      </ulink></para>
-
-      <para>Solaris パッケージ：<ulink
-      url="http://www.opencsw.org/packages/CSWnetatalk/">http://www.opencsw.org/</ulink></para>
-
-      <para>FreeBSD ポート：<ulink
-      url="http://www.freebsd.org/ports/index.html">http://www.freebsd.org/ports/index.html
-      </ulink></para>
-
-      <para>NetBSD pkgsrc: <ulink
-      url="http://pkgsrc.se/search.php">http://pkgsrc.se/search.php
-      </ulink></para>
-
-      <para>OpenBSD ports:<ulink
-      url="https://openports.pl">https://openports.pl
-      </ulink></para>
-
-      <para>などである．<indexterm>
-          <primary>RPM</primary>
-
-          <secondary>Red Hat Package Manager package</secondary>
-        </indexterm><indexterm>
-          <primary>Deb</primary>
-
-          <secondary>Debian package</secondary>
-        </indexterm><indexterm>
-          <primary>Ports</primary>
-
-          <secondary>FreeBSD port</secondary>
-        </indexterm></para>
+      <para>第三者が提供しているパッケージ リポジトリも参照する手もある。例えば、Red Hat 派生 Linux ディストリビューションの為の<ulink
+      url="https://rpmfind.net/">rpmfind</ulink> Solaris 系 OS の為の
+      <ulink url="https://www.opencsw.org/">OpenCSW</ulink>
+      又は macOS の為の <ulink url="https://brew.sh/">
+      Homebrew</ulink> か <ulink url="https://www.macports.org/">MacPorts
+      </ulink>。</para>
     </sect2>
 
     <sect2>
@@ -94,7 +49,7 @@
         <title>Tarball</title>
 
         <para>Netatalk のソースを tar で固めた .tar.xz および .tar.bz2 形式のものが <ulink
-        url="https://github.com/Netatalk/netatalk">GitHub の netatalk のページ</ulink>にある．</para>
+        url="https://github.com/Netatalk/netatalk">GitHub の netatalk のページ</ulink>にある。</para>
       </sect3>
 
       <sect3>
@@ -104,44 +59,40 @@
 
         <orderedlist>
           <listitem>
-            <para>Git がインストールしてあることを確認する．<command>which
-            git</command> は git のパスを示してくれるはずである．</para>
+            <para>Git がインストールしてあることを確認する。<command>which
+            git</command> は git のパスを示してくれるはずである。</para>
 
             <screen><prompt>$</prompt> <userinput>which git</userinput>
 <computeroutput>/usr/bin/git</computeroutput></screen>
           </listitem>
 
           <listitem>
-            <para>ソースを取得してみよう．</para>
+            <para>ソースを取得してみよう。</para>
 
             <screen><prompt>$</prompt> <userinput>git clone https://github.com/Netatalk/netatalk.git netatalk-code
-</userinput><computeroutput>Initialized empty Git repository in /path/to/new/source/dir/netatalk/.git/
-remote: Counting objects: 2503, done.
+</userinput><computeroutput>Cloning into 'netatalk-code'...
+remote: Enumerating objects: 41592, done.
 ...
+Resolving deltas: 100% (32227/32227), done.
 </computeroutput></screen>
 
-            <para>上記で Git リポジトリから，Netatalk のソース全体の完全でまっさらのコピーを含む
-            <filename>netatalk-code</filename> という名前のローカルディレクトリが作成される．</para>
+            <para>上記で Git リポジトリから、Netatalk のソース全体の完全でまっさらのコピーを含む
+            <filename>netatalk-code</filename> という名前のローカルディレクトリが作成される。</para>
           </listitem>
 
           <listitem>
-            <para>レポジトリのコピーを最新の状態にしておきたい場合，適宜以下を実行する．</para>
+            <para>ブランチやタグを指定しない場合は、最先端の開発コードが取得さる。例えば、最新の安定した
+　　　　　　　Netatalk 3.1 コードを入手するには、「branch-netatalk-3-1」という名前のブランチをチェックアウトする：</para>
+
+            <screen><prompt>$</prompt> <userinput>git checkout branch-netatalk-3-1</userinput></screen>
+          </listitem>
+
+          <listitem>
+            <para>レポジトリのコピーを最新の状態にしておきたい場合、適宜以下を実行する。</para>
 
             <screen><prompt>$</prompt> <userinput>git pull</userinput></screen>
           </listitem>
-
-          <listitem>
-            <para>netatalk-code ディレクトリに <command>cd</command> して，
-            <command>./bootstrap</command>を実行する．これで次の段階で必要となる
-            <filename>configure</filename> スクリプトが作成される．</para>
-
-            <screen><prompt>$</prompt> <userinput>./bootstrap</userinput></screen>
-          </listitem>
         </orderedlist>
-
-        <para>さらなる情報については<ulink
-        url="https://netatalk.io/docs/Developer-Notes">Developer Notes ページ</ulink>
-        も参照のこと．</para>
       </sect3>
     </sect2>
   </sect1>
@@ -152,12 +103,6 @@ remote: Counting objects: 2503, done.
     <sect2>
       <title>前提条件</title>
 
-      <note>
-        <para>お使いのOSには下記ソフトウェアのバイナリーパッケージが提供される可能性が高い．</para>
-
-        <para>パッケージマネージャで検索すれば見つけられるだろう．</para>
-      </note>
-
       <sect3>
         <title>必要なサードパーティソフトウェア</title>
 
@@ -167,16 +112,23 @@ remote: Counting objects: 2503, done.
                 <primary>BDB</primary>
                 <secondary>Berkeley DB</secondary>
               </indexterm>.</para>
-            <para>書き込みの時に最低でもバージョン 4.6 が必要となる．</para>
+            <para>書き込みの時に最低でもバージョン 4.6 が必要となる。</para>
 
-            <para>推奨バージョンは 5.3 である Sleepycat ライセンスで提供された最終リリースである．</para>
+            <para>推奨バージョンは 5.3 である Sleepycat ライセンスで提供された最終リリースである。</para>
           </listitem>
 
           <listitem>
             <para>Libgcrypt</para>
 
             <para>OS X 10.7 とそれ以降で必須となった DHX2 のために <ulink url="http://directory.fsf.org/wiki/Libgcrypt">
-            Libgcrypt</ulink> が必要である．</para>
+            Libgcrypt</ulink> が必要である。</para>
+          </listitem>
+
+          <listitem>
+            <para>libevent</para>
+
+            <para>netatalk サービス コントローラー デーモンの内部イベント コールバックは、
+　　　　　　　libevent バージョン 2 に基づいて構築されている。</para>
           </listitem>
         </itemizedlist>
       </sect3>
@@ -184,39 +136,51 @@ remote: Counting objects: 2503, done.
       <sect3>
         <title>任意のサードパーティソフトウェア</title>
 
-        <para>Netatalk はその機能性を拡充するために以下のサードパーティソフトウェアを使用することができる．</para>
+        <para>Netatalk はその機能性を拡充するために以下のサードパーティソフトウェアを使用することができる。</para>
 
         <itemizedlist>
+          <listitem>
+            <para>OpenSSL / LibreSSL / WolfSSL</para>
+
+            <para>OpenSSL 1.1 又は LibreSSL は、Classic Mac OS に最も強力なパスワード暗号化を提供する DHCAST128 (別名 DHX) UAM に必要。Random Number UAM もこのライブラリを使用している。</para>
+
+            <para>netatalk 3.2.0 以降は、バンドルされている WolfSSL ライブラリがデフォルトの DHX プロバイダーとして netatalk とともに配布されている。</para>
+          </listitem>
+
           <listitem>
             <para>Spotlight<indexterm>
                 <primary>Spotlight</primary>
               </indexterm> サポートのための Tracker</para>
 
             <para>Netatalk はメタデータのバックエンドとして
-            <ulink url="https://tracker.gnome.org">Tracker</ulink> 
-            を使用する．最近の Linux ディストリビューションには，Tracker のバージョン 0.7 以来使用可能な
-            libtracker-sparql が提供されている．</para>
+            <ulink url="https://tracker.gnome.org">Tracker</ulink>
+            を使用する。最近の Linux ディストリビューションには、Tracker のバージョン 0.7 以来使用可能な
+            libtracker-sparql が提供されている。</para>
+
+            <para>Samba プロジェクトの talloc ライブラリと、bison の様な Yacc パーサ、
+            そして flex の様な字句解析ツールも必要になる。</para>
           </listitem>
 
           <listitem>
             <para>Bonjour（Zeroconf としても知られる）のための mDNSresponderPOSIX または Avahi</para>
 
-            <para>サービス探索のために Mac OS X 10.2 及び以降のものは 
-            Bonjour（Zeroconf としても知られる）を使用する．</para>
+            <para>サービス探索のために Mac OS X 10.2 及び以降のバージョンは
+            Bonjour（Zeroconf としても知られる）を使用する。AFP ファイルサーバー又は
+            Time Machine サービスをクライアントに通知することができる。</para>
 
             <para>Avahi は DBUS サポートのもとで (
-            <userinput>--enable-dbus</userinput>) ビルドされなければならない．</para>
+            <userinput>--enable-dbus</userinput>) ビルドされなければならない。</para>
           </listitem>
 
           <listitem>
             <para>TCP wrappers</para>
 
-            <para>TCPD または LOG_TCP としても知られる Wietse Venema のネットワークロガー．</para>
+            <para>TCPD または LOG_TCP としても知られる Wietse Venema のネットワークロガー。</para>
 
             <para>セキュリティオプションは：
             ホストごとドメインごとかつ／ないしはサービスごとのアクセス制御；
             ホスト名のなりすましあるいはホストアドレスのなりすまし検出；
-            早期警告システムを実装するブービートラップ；である．</para>
+            早期警告システムを実装するブービートラップ；である。</para>
           </listitem>
 
           <listitem>
@@ -226,21 +190,78 @@ remote: Counting objects: 2503, done.
                 <secondary>Pluggable Authentication Modules</secondary>
               </indexterm></para>
 
-            <para>PAM はユーザー認証の柔軟な機構を実現する．PAM は SUN<indexterm>
+            <para>PAM はユーザー認証の柔軟な機構を実現する。PAM は SUN<indexterm>
                 <primary>SUN</primary>
 
                 <secondary>Sun Microsystems</secondary>
-              </indexterm> Microsystems によって作り出された．
-            Linux-PAM はアプリケーションがどのようにユーザーを認証するのかを選択できるようなローカルシステム管理を実現する共有ライブラリーのセットである．</para>
+              </indexterm> Microsystems によって作り出された。
+            Linux-PAM はアプリケーションがどのようにユーザーを認証するのかを選択できるようなローカルシステム管理を実現する共有ライブラリーのセットである。</para>
+          </listitem>
+
+          <listitem>
+            <para>Kerberos V</para>
+
+            <para>Kerberos v5 は、マサチューセッツ工科大学で発明されたクライアント サーバー ベースの認証プロトコルである。
+            Kerberos ライブラリを使用すると、netatalk は既存の Kerberos インフラストラクチャで認証するための GSS UAM ライブラリを生成できる。</para>
+          </listitem>
+
+          <listitem>
+            <para>ACL と LDAP</para>
+
+            <para>LDAP は ACL の高度な権限スキームと連携して動作する、オープンな業界標準のユーザー ディレクトリ プロトコルである。
+            一部のオペレーティング システムでは、ACL および LDAP ライブラリがシステムに組み込まれているが、
+            他のオペレーティング システムでは、この機能を有効にするためにサポート パッケージをインストールする必要がある。</para>
+          </listitem>
+
+          <listitem>
+            <para>MySQL</para>
+
+            <para>MySQL 互換のクライアント ライブラリを活用することで、拡張性と信頼性の高い MySQL CNID バックエンドを使用して netatalk を構築できる。
+            管理者は、このバックエンドで使用する別のデータベース インスタンスを提供する必要がある。</para>
+          </listitem>
+
+          <listitem>
+            <para>D-Bus と GLib バインディング</para>
+
+            <para><userinput>afpstats</userinput> ツールに使われ、afpd サーバ状況を参照する子ができる。
+            </para>
           </listitem>
 
           <listitem>
             <para>iconv</para>
 
-            <para>iconv はたくさんの文字エンコーディングの変換ルーチンを提供する．Netatalk 
-            は iconv を使用して内蔵されていない ISO-8859-1 のようなキャラクターセット変換を実現する．
-            glibc システムでは glibc の提供する iconv 実装を使うことができる．さもなくば GNU libiconv
-            実装を使うことができる．</para>
+            <para>iconv はたくさんの文字エンコーディングの変換ルーチンを提供する。Netatalk
+            は iconv を使用して内蔵されていない ISO-8859-1 のようなキャラクターセット変換を実現する。
+            glibc システムでは glibc の提供する iconv 実装を使うことができる。さもなくば GNU libiconv
+            実装を使うことができる。</para>
+          </listitem>
+
+          <listitem>
+            <para>CrackLib</para>
+
+            <para>Random Number UAM と netatalk の固有パスワード管理ツール
+            <userinput>afppasswd</userinput> を使用する際、CrackLib を使う事によって
+            弱いパスワードの設定を防ぐことができる。</para>
+          </listitem>
+
+          <listitem>
+            <para>Perl</para>
+
+            <para><userinput>afpstats</userinput>、
+            <userinput>apple_dump</userinput>、
+            <userinput>asip-status</userinput> 又は
+            <userinput>macusers</userinput> という管理者向けツールは Perl 5.8 以降の実行環境を
+            使用している。下記 Perl モジュールは必須：
+            <emphasis>IO::Socket::IP</emphasis> (asip-status) 又は
+            <emphasis>Net::DBus</emphasis> (afpstats)。</para>
+          </listitem>
+
+          <listitem>
+            <para>DocBook XSL と xsltproc</para>
+
+            <para>本マニュアル含めての netatalk ドキュメンテーションは XML 様式に作成され
+            DocBook XSL スタイルシートを適用し生成されている。フォーマット変換は xsltproc
+            で実施している。</para>
           </listitem>
         </itemizedlist>
       </sect3>
@@ -253,111 +274,53 @@ remote: Counting objects: 2503, done.
           <secondary>Netatalk のソースからのコンパイル</secondary>
         </indexterm></title>
 
-      <sect3>
-        <title>ビルドの設定をする</title>
+      <para>ビルドシステムの使い方、コードのコンフィグ又はビルドの手順書は <ulink
+      url="https://github.com/Netatalk/netatalk/blob/main/INSTALL">INSTALL</ulink>
+      ファイルを参考してください。</para>
 
-        <para>バイナリーをビルドするには最初にソースのディレクトリで 
-        <command>./configure</command> プログラムを実行する．これによって Netatalk 
-        がターゲットのオペレーティングシステム向けに自動的に設定されるはずである．
-        もし普通とは違う要求がある場合，以下を実行すれば特殊なオプションで有効化できるものを見ることができる．</para>
-
-        <screen><prompt>$</prompt> <userinput>./configure --help</userinput></screen>
-
-        <para>最も頻繁に使用されるオプションは：</para>
-
-        <itemizedlist>
-          <listitem>
-            <para><option>--with-init-style</option>=redhat-sysv|redhat-systemd|suse-sysv|suse-systemd|gentoo-openrc|gentoo-systemd|netbsd|debian-sysv|debian-systemd|solaris|openrc|systemd|macos-launchd</para>
-
-            <para>このオプションがスタートアップスクリプトをどこにインストールするかの助けになる．</para>
-          </listitem>
-
-          <listitem>
-            <para><option>--with-bdb</option>=<replaceable>/path/to/bdb/installation/</replaceable></para>
-
-            <para>Berkeley DB を標準的な場所以外にインストールした場合，このオプションを使って netatalk 
-            に Berkeley DB をインストールした場所（訳注：すなわち 
-            <replaceable>/path/to/bdb/installation/</replaceable>
-            ）を指示<emphasis>しなければならない</emphasis>．</para>
-          </listitem>
-
-          <listitem>
-            <para><option>--with-ssl-dir</option>=<replaceable>/path/to/ssl/installation/</replaceable></para>
-
-            <para>OpenSSL または LibreSSL を標準以外の場所にインストールした場合，
-            このオプションを指定<emphasis>しなければならない</emphasis>．</para>
-          </listitem>
-        </itemizedlist>
-
-        <para>そして必要なあらゆるオプションを含めて configure を実行する．</para>
-
-        <screen><prompt>$</prompt> <userinput>./configure [arguments]</userinput></screen>
-
-        <para>Netatalk の Makefile 作成に使われた設定の概要を表示して configure は終了する．</para>
-      </sect3>
-
-      <sect3 id="spotlight-compile">
-        <title>Spotlight<indexterm>
-            <primary>Spotlight</primary>
-          </indexterm></title>
-
-        <para>Netatalk はメタデータのバックエンドに Gnome 
-        <ulink url="https://projects.gnome.org/tracker/">Tracker</ulink> を用いる．少なくとも最初に
-        <ulink url="https://gnome.pages.gitlab.gnome.org/tracker/docs/developer/">SPARQL</ulink> 
-        をサポートしたバージョン 0.7 以降が必要である．</para>
-
-        <para>まだインストールしていなければ <emphasis>tracker</emphasis> パッケージと 
-        <emphasis>tracker-devel</emphasis> パッケージをインストールする．Solaris では 
-        <ulink url="http://www.opencsw.org/">OpenCSW</ulink> をインストールした後に OpenCSW 
-        の不安定版レポジトリーにある Tracker のパッケージをインストールする．</para>
-
-        <para>Tracker のパッケージは pkg-config 経由で見つかる．デフォルトのバージョン 0.12 
-        より新しいバージョンがインストールされている場合もあるので，
-        末尾のバージョン番号も渡す必要があるかもしれない．すなわち</para>
-
-        <screen><prompt>$</prompt> <userinput>pkg-config --list-all | grep tracker
-        </userinput>tracker-sparql-3.0             tracker-sparql-3.0 - Tracker : A SPARQL triple store library</screen>
-
-        <para>であれば：</para>
-
-        <screen><prompt>$</prompt> <userinput>./configure --with-tracker-pkgconfig-version=3.0 ...</userinput></screen>
-        
-        <para>とする．</para>
-
-        <para>もし Solaris と OpenCSW 由来の Tracker を使っていれば，PKG_CONFIG_PATH 
-        環境変数を設定し，--with-tracker-prefix configure オプションを加え，
-        LDFLAGS="-R/opt/csw/lib" を加える必要がある．</para>
-
-        <screen>PKG_CONFIG_PATH=/opt/csw/lib/pkgconfig LDFLAGS="-R/opt/csw/lib" ./configure --with-tracker-prefix=/opt/csw --with-tracker-pkgconfig-version=0.16 ...</screen>
-
-        <para>Tracker ライブラリーが見つけられているかどうか，configure の出力を確認する：</para>
-
-        <screen>checking for TRACKER... yes
-        checking for TRACKER_MINER... yes
-        ...
-        Configure summary:
-        ...
-          AFP:
-            Spotlight: yes
-        ...</screen>
-      </sect3>
-
-      <sect3>
-        <title>コンパイルとインストール</title>
-
-        <para>次に以下を実行</para>
-
-        <screen><prompt>$</prompt> <userinput>make</userinput></screen>
-
-        <para>すると Netatalk のバイナリーを生成するはずである．（この段階は完了するのに数分かかる）</para>
-
-        <para>この過程が終了すれば，以下のコマンドを使って</para>
-
-        <screen><prompt>$</prompt> <userinput>make install</userinput></screen>
-
-        <para>ドキュメントとバイナリーのインストール（デフォルトの場所を使う場合は 
-        "root" として行わなければならない）ができる．</para>
-      </sect3>
+      <para>特定の OS に対しての具体的なビルド事例は <link linkend="compile">
+      Netatalk をソースコードからコンパイルする</link> 付録を参考してください。</para>
     </sect2>
+  </sect1>
+
+  <sect1>
+    <title>Netatalk の起動と停止</title>
+
+    <para>Netatalk の配布物は、
+    いくつかのオペレーティングシステム固有のスタートアップ・スクリプト・テンプレートを備えている。
+    これらテンプレートは、コンパイル前に指定できる。
+    現時点で、systemd、openrc、Linux、BSD、Solaris、そして macOS 向けのテンプレートが用意されている。
+    ビルドスクリプトにシステムタイプを指示することで、どのスタートアップスクリプト
+      <indexterm>
+        <primary>Startscript</primary>
+
+        <secondary>スタートアップスクリプト</secondary>
+      </indexterm>を生成してインストールするのか選ぶことができる。
+    スタートアップスクリプトを自動でインストールさせるには、
+    <option>with-init-style</option> オプションで有効なものを加える。</para>
+
+    <para>Linux ディストリビューションの新しいリリースは頻繁に出てくるし、
+    上記で触れたようなほかのシステムのスタートアップの手続きもまた変わりうる。
+    それ故、盲目的にスタートアップスクリプトをインストールするのではなく、
+    自分のシステムで動作するであろうかということをまず見てみる、というのがおそらくいい考えである。</para>
+
+    <para>Linux ディストリビューションの RPM あるいは BSD のパッケージのような所定のセットアップの一部として使用する場合、
+    諸々の事は概ねよしなに取り計らわれるだろう。
+    それ故、Netatalk そのものをコンパイルするユーザーには概ね下記のことが当てはまる。</para>
+
+    <para>いかなるスタートアップスクリプト機構を使っていても、下記のデーモンは必要である：</para>
+
+    <itemizedlist>
+      <listitem>
+        <para>netatalk<indexterm>
+            <primary>netatalk</primary>
+          </indexterm></para>
+      </listitem>
+    </itemizedlist>
+
+    <para>スタートアップスクリプトは無くても、root ユーザとして netatalk デーモンを実行し、
+    使い終わったら SIGTERM で終了させることができす。</para>
+
+    <para>加えて、設定ファイル <filename>afp.conf</filename> が正しい場所にあるか確認する。</para>
   </sect1>
 </chapter>

--- a/doc/ja/manual/intro.xml
+++ b/doc/ja/manual/intro.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <chapter id="intro">
   <chapterinfo>
-
     <author role="first-last">
       <firstname>Eiichirou</firstname>
 
@@ -9,38 +8,30 @@
     </author>
 
     <pubdate>2015 年 6 月 10 日（訳）</pubdate>
-
   </chapterinfo>
+
   <title>序説</title>
 
   <sect1>
-  <title>法的条項</title>
+    <title>法的条項</title>
 
-  <para>
-  本ドキュメントは GNU 一般公衆利用許諾書 (GPL) バージョン 2 のもとで配布されている．
-  Netatalk ソース一式にも本ドキュメントと同様に許諾書のコピーが同梱されている．許諾書のコピーのオンライン版は <ulink
-  url="http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt">http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</ulink>
-  で閲覧できる
-  </para>
+    <para>本ドキュメントは GNU 一般公衆利用許諾書 (GPL) バージョン 2 のもとで配布されている。 Netatalk
+    ソース一式にも本ドキュメントと同様に許諾書のコピーが同梱されている。許諾書のコピーのオンライン版は <ulink
+    url="http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt">http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</ulink>
+    で閲覧できる</para>
   </sect1>
 
   <sect1>
-  <title>Netatalk 概要</title>
+    <title>Netatalk 概要</title>
 
-  <para>Netatalk は，*NIX 
-  マシンを極めて高性能で極めて軽いマッキントッシュコンピューター用ファイルサーバーに変身させる，
-  オープンソースのソフトウェアのパッケージである．</para>
+    <para>Netatalk は、*NIX マシンを極めて高性能で極めて軽いマッキントッシュコンピューター用ファイルサーバーに変身させる、
+    オープンソースのソフトウェアのパッケージである。</para>
 
-  <para>Netatalk の AFP 3.4
-  準拠のファイルサーバーは，考え得る最高のユーザーエクスペリエンス
-  （マッキントッシュのメタデータの完全なサポート．クラシック Mac OS と macOS
-  の混在環境も問題なくサポート）をもたらしつつ，Mac が Samba/NFS
-  経由でサーバーにアクセスしたのと比較して著しく高い転送速度をもたらす．</para>
+    <para>Netatalk の AFP 3.4 準拠のファイルサーバーは、考え得る最高のユーザーエクスペリエンス
+    （マッキントッシュのメタデータの完全なサポート。クラシック Mac OS と macOS の混在環境も問題なくサポート）をもたらしつつ、Mac が
+    Samba/NFS 経由でサーバーにアクセスしたのと比較して著しく高い転送速度をもたらす。</para>
 
-  <para>あらゆる導入環境に対応できるよう、さまざまな認証方法が付属しています．
-  Bonjour サービス検出、Time Machine バックアップ，
-  Spotlight インデックス検索などの最新の macOS 機能もサポートされています．
-  </para>
+    <para>あらゆる導入環境に対応できるよう、さまざまな認証方法が付属しています。 Bonjour サービス検出、Time Machine
+    バックアップ、 Spotlight インデックス検索などの最新の macOS 機能もサポートされている。</para>
   </sect1>
-
 </chapter>

--- a/doc/ja/manual/manual.xml.in
+++ b/doc/ja/manual/manual.xml.in
@@ -3,6 +3,7 @@
 "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd" [
 
 <!ENTITY Configuration SYSTEM "configuration.xml">
+<!ENTITY Compile SYSTEM "compile.xml">
 <!ENTITY Intro SYSTEM "intro.xml">
 <!ENTITY Install SYSTEM "install.xml">
 <!ENTITY License SYSTEM "gpl.xml">
@@ -91,6 +92,9 @@
 
     &netatalk-config.1;
   </chapter>
+  <?latex \cleardoublepage ?>
+
+  &Compile;
   <?latex \cleardoublepage ?>
 
   &License;

--- a/doc/ja/manual/meson.build
+++ b/doc/ja/manual/meson.build
@@ -11,6 +11,7 @@ netatalk_html = configure_file(
 )
 
 manual_pages = [
+    'compile.xml',
     'configuration.xml',
     'gpl.xml',
     'install.xml',
@@ -39,6 +40,7 @@ manual_gen = custom_target(
         'asip-status.1.html',
         'cnid_dbd.8.html',
         'cnid_metad.8.html',
+        'compile.html',
         'configuration.html',
         'dbd.1.html',
         'example-toc.html',

--- a/doc/ja/manual/upgrade.xml
+++ b/doc/ja/manual/upgrade.xml
@@ -10,15 +10,14 @@
     </author>
 
     <pubdate>6 Sep, 2013</pubdate>
-    
+
     <author role="first-last">
       <firstname>Eiichirou</firstname>
-      
+
       <surname>UDA（日本語訳）</surname>
     </author>
-    
+
     <pubdate>2015 年 5 月 5 日（訳）</pubdate>
-    
   </chapterinfo>
 
   <title>Netatalk 2 からのアップグレード</title>
@@ -28,13 +27,13 @@
 
     <para>Netatalk の主要な変更は以下の二点：<orderedlist>
         <listitem>
-          <para>これまでの設定ファイルすべてが廃止された，全く新しい設定ファイルとしての 
-          <filename><link linkend="afp.conf.5">afp.conf</link></filename></para>        
+          <para>これまでの設定ファイルすべてが廃止された、全く新しい設定ファイルとしての <filename><link
+          linkend="afp.conf.5">afp.conf</link></filename></para>
         </listitem>
 
         <listitem>
-          <para>マックのメタデータとリソースフォークをファイルシステムの拡張属性に保存する 
-          "<option>appledouble = ea</option>" という新しい AppleDouble のバックエンド．</para>
+          <para>マックのメタデータとリソースフォークをファイルシステムの拡張属性に保存する "<option>appledouble =
+          ea</option>" という新しい AppleDouble のバックエンド。</para>
         </listitem>
       </orderedlist></para>
 
@@ -47,87 +46,84 @@
           </listitem>
 
           <listitem>
-            <para>一つで設定すべてを指示するという点：
-            AFP 及びボリュームの構成を共に一つのファイルで設定することになるという点</para>
+            <para>一つで設定すべてを指示するという点： AFP
+            及びボリュームの構成を共に一つのファイルで設定することになるという点</para>
           </listitem>
 
           <listitem>
-            <para><filename>afpd.conf</filename>，
-            <filename>netatalk.conf</filename>，
-            <filename>AppleVolumes.default</filename> 及び，
+            <para><filename>afpd.conf</filename>、
+            <filename>netatalk.conf</filename>、
+            <filename>AppleVolumes.default</filename> 及び、
             <filename>afp_ldap.conf</filename> の廃止</para>
           </listitem>
         </itemizedlist><warning>
-          <para>ほとんどのオプション名は変更されたので，
-          詳細については <link linkend="afp.conf.5">afp.conf</link> の manpage 全体を読むこと</para>
+          <para>ほとんどのオプション名は変更されたので、 詳細については <link
+          linkend="afp.conf.5">afp.conf</link> の manpage 全体を読むこと</para>
         </warning></para>
     </sect2>
 
     <sect2>
       <title>新たな AppleDouble バックエンド</title>
 
-      <para>マックのメタデータとリソースフォークをファイルシステムの拡張属性に保存する 
-      "<option>appledouble = ea</option>" という新しい AppleDouble のバックエンド．<itemizedlist>
+      <para>マックのメタデータとリソースフォークをファイルシステムの拡張属性に保存する "<option>appledouble =
+      ea</option>" という新しい AppleDouble のバックエンド。<itemizedlist>
           <listitem>
             <para>デフォルトのバックエンドである（！）</para>
           </listitem>
 
           <listitem>
-            <para>拡張属性のあるファイルシステムが必須．
-            さもなくば "<option>appledouble = v2</option>" オプションの使用が代替となる</para>
+            <para>拡張属性のあるファイルシステムが必須。 さもなくば "<option>appledouble =
+            v2</option>" オプションの使用が代替となる</para>
           </listitem>
 
           <listitem>
-            <para>"<option>appledouble = v2</option>" から "<option>appledouble = ea</option>" 
-            ファイルシステムへの変換はアクセス時，その都度行われる（無効にすることも可能）</para>
+            <para>"<option>appledouble = v2</option>" から "<option>appledouble
+            = ea</option>" ファイルシステムへの変換はアクセス時、その都度行われる（無効にすることも可能）</para>
           </listitem>
 
           <listitem>
-            <para>一括で変換する場合 <command><link linkend="dbd.1">dbd</link></command> 
-            を用いることができる</para>
+            <para>一括で変換する場合 <command><link
+            linkend="dbd.1">dbd</link></command> を用いることができる</para>
           </listitem>
         </itemizedlist></para>
 
       <para>実装の詳細：<itemizedlist>
           <listitem>
-            <para>Mac のメタデータ（すなわち FinderInfo，AFP フラグ，コメント，CNID）は 
-            “<filename>org.netatalk.Metadata</filename>” という名前の拡張属性に保存される．</para>
+            <para>Mac のメタデータ（すなわち FinderInfo、AFP フラグ、コメント、CNID）は
+            “<filename>org.netatalk.Metadata</filename>”
+            という名前の拡張属性に保存される。</para>
           </listitem>
 
           <listitem>
             <para>マックのリソースフォークは：<itemizedlist>
                 <listitem>
-                  <para>ZFS を用いた Solaris では 
-                  “<filename>org.netatalk.ResourceFork</filename>” 
-                  という拡張属性に保存される．</para>
+                  <para>ZFS を用いた Solaris では
+                  “<filename>org.netatalk.ResourceFork</filename>”
+                  という拡張属性に保存される。</para>
                 </listitem>
 
                 <listitem>
-                  <para>ないしは，ファイル名が “<filename>file</filename>” 
-                  であるものに対して各々， “<filename>._file</filename>” 
-                  という名の別の AppleDouble ファイルに保存される．</para>
+                  <para>ないしは、ファイル名が “<filename>file</filename>”
+                  であるものに対して各々、“<filename>._file</filename>” という名の別の
+                  AppleDouble ファイルに保存される。</para>
                 </listitem>
               </itemizedlist></para>
           </listitem>
 
           <listitem>
-            <para>"._" ファイルのフォーマットは，
-            たとえそのファイルシステムに CIFS サーバー (Samba) 経由でアクセスした場合でも，
-            マックの CIFS クライアントが想定しているフォーマットと全く同じである．
-            なので，データを失う危険性（リソースもメタデータも）なく，
-            マックから同じデータセットに AFP 経由と CIFS 経由と並行してアクセスすることができる．
-            一方，ウィンドウズから当該データセットに CIFS 経由でアクセスした場合は，未だに 
-            “<filename>file</filename>” と “<filename>file</filename>” 
-            の紐付けを失うこととなるであろう（非 ZFS ファイルシステムの場合．上記参照）．
-            今のところその点で拡張 Samba VFS モジュールが必要である（改善中）．</para>
+            <para>"._" ファイルのフォーマットは、 たとえそのファイルシステムに CIFS サーバー (Samba)
+            経由でアクセスした場合でも、 マックの CIFS クライアントが想定しているフォーマットと全く同じである。
+            なので、データを失う危険性（リソースもメタデータも）なく、 マックから同じデータセットに AFP 経由と CIFS
+            経由と並行してアクセスすることができる。 一方、ウィンドウズから当該データセットに CIFS 経由でアクセスした場合は、未だに
+            “<filename>file</filename>” と “<filename>file</filename>”
+            の紐付けを失うこととなるであろう（非 ZFS ファイルシステムの場合。上記参照）。 今のところその点で拡張 Samba VFS
+            モジュールが必要である（改善中）。</para>
           </listitem>
         </itemizedlist></para>
 
-
-      <para>昨今，リソースフォークを使用しているアプリケーションは　
-      Adobe Photoshop（イメージプレビュー）と Postscript Type 1 フォントのみなので，
-      例えば Linux 上においても，あらゆる余分な Netatalk AppleDouble ファイル（及びフォルダー）からは 
-      99% 無関係でいられる．</para>
+      <para>昨今、リソースフォークを使用しているアプリケーションは　 Adobe Photoshop（イメージプレビュー）と
+      Postscript Type 1 フォントのみなので、 例えば Linux 上においても、あらゆる余分な Netatalk
+      AppleDouble ファイル（及びフォルダー）からは 99% 無関係でいられる。</para>
     </sect2>
 
     <sect2>
@@ -135,24 +131,24 @@
 
       <para><itemizedlist>
           <listitem>
-            <para>AFP 及び CNID デーモンの起動・再起動を担う新しいサービスコントローラデーモン 
-            <link linkend="netatalk.8">netatalk</link> の導入．バンドルされているスタートスクリプトが
-            すべて更新されているため，自分の環境でもアップデートされているか確認する必要あり！</para>
+            <para>AFP 及び CNID デーモンの起動・再起動を担う新しいサービスコントローラデーモン <link
+            linkend="netatalk.8">netatalk</link> の導入。バンドルされているスタートスクリプトが
+            すべて更新されているため、自分の環境でもアップデートされているか確認する必要あり！</para>
           </listitem>
 
           <listitem>
-            <para>CNID データベースはデフォルトで <filename>/var/netatalk/CNID/</filename> 
-            以下に保存される．保存場所を変更するには，コンパイル時に <command>--localstatedir=PATH</command>
-            のコンフィグオプションを使用する．</para>
+            <para>CNID データベースはデフォルトで <filename>/var/netatalk/CNID/</filename>
+            以下に保存される。保存場所を変更するには、コンパイル時に
+            <command>--localstatedir=PATH</command> のコンフィグオプションを使用する。</para>
           </listitem>
 
           <listitem>
-            <para>Netatalk 2.x のボリュームオプション “usedots” 及び “upriv” 
-            はデフォルトとなった．</para>
+            <para>Netatalk 2.x のボリュームオプション “usedots” 及び “upriv”
+            はデフォルトとなった。</para>
           </listitem>
 
           <listitem>
-            <para>SLP 及び AFP プロキシのサポート機能は削除．</para>
+            <para>SLP 及び AFP プロキシのサポート機能は削除。</para>
           </listitem>
 
           <listitem>
@@ -175,93 +171,130 @@
         </listitem>
 
         <listitem>
-          <para>設定 <option>afp.conf</option> 及び <option>extmap.conf</option> 
+          <para>設定 <option>afp.conf</option> 及び <option>extmap.conf</option>
           を自力で書き換える</para>
         </listitem>
 
         <listitem>
-          <para><link linkend="netatalk.8">netatalk</link> 起動にのみ関連している，
-          Netatalk 起動スクリプト（SMF，systemd，ほかすべて…）を更新する</para>
+          <para><link linkend="netatalk.8">netatalk</link> 起動にのみ関連している、
+          Netatalk 起動スクリプト（SMF、systemd、ほかすべて…）を更新する</para>
         </listitem>
 
         <listitem>
-          <para><filename>afp_voluuid.conf</filename> 及び 
-          <filename>afp_signature.conf</filename>  を localstate ディレクトリ
-          （デフォルトでは <filename>/var/netatalk/</filename>），に移動．
-          正しいパスを見つけるために  <command>afpd -v</command> コマンドが有用</para>
+          <para><filename>afp_voluuid.conf</filename> 及び
+          <filename>afp_signature.conf</filename> を localstate ディレクトリ （デフォルトでは
+          <filename>/var/netatalk/</filename>）、に移動。 正しいパスを見つけるために
+          <command>afpd -v</command> コマンドが有用</para>
         </listitem>
 
         <listitem>
-        </listitem>
           <para>Netatalk 3 を起動する</para>
+        </listitem>
       </orderedlist></para>
   </sect1>
 
   <sect1>
     <title>新旧設定ファイル名対照表</title>
+
     <para><table frame="all">
         <title>設定ファイル名対照表</title>
+
         <tgroup cols="3">
           <colspec colname="c1" colnum="1" colwidth="1.0*"/>
+
           <colspec colname="c2" colnum="2" colwidth="1.0*"/>
+
           <colspec colname="c3" colnum="3" colwidth="1.0*"/>
+
           <thead>
             <row>
               <entry>旧ファイル名</entry>
+
               <entry>新ファイル名</entry>
+
               <entry>注記</entry>
             </row>
           </thead>
+
           <tbody>
             <row>
               <entry>-</entry>
+
               <entry><filename>etc/afp.conf</filename></entry>
+
               <entry>新しい "ini" 様式のフォーマット</entry>
             </row>
+
             <row>
               <entry>-</entry>
+
               <entry><filename>etc/extmap.conf</filename></entry>
+
               <entry>netatalk 3.0.2 から採用</entry>
             </row>
+
             <row>
               <entry><filename>etc/netatalk/afp_signature.conf</filename></entry>
+
               <entry><filename>var/netatalk/afp_signature.conf</filename></entry>
+
               <entry>厳密には $localstatedir に移動</entry>
             </row>
+
             <row>
               <entry><filename>etc/netatalk/afp_voluuid.conf</filename></entry>
+
               <entry><filename>var/netatalk/afp_voluuid.conf</filename></entry>
+
               <entry>厳密には $localstatedir に移動</entry>
             </row>
+
             <row>
               <entry><filename>etc/netatalk/netatalk.conf</filename>
               (<filename>/etc/default/netatalk</filename>)</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry><filename>etc/netatalk/afpd.conf</filename></entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry><filename>etc/netatalk/afp_ldap.conf</filename></entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry><filename>etc/netatalk/AppleVolumes.default</filename></entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry><filename>etc/netatalk/AppleVolumes.system</filename></entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry><filename>~/.AppleVolumes</filename></entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
           </tbody>
@@ -271,1259 +304,2186 @@
 
   <sect1>
     <title>新旧オプション対応表</title>
+
     <para><table frame="all">
         <title>netatalk.conf (/etc/default/netatalk) から afp.conf</title>
+
         <tgroup cols="6">
           <colspec colname="c1" colnum="1" colwidth="1.0*"/>
+
           <colspec colname="c2" colnum="2" colwidth="1.0*"/>
+
           <colspec colname="c3" colnum="3" colwidth="1.0*"/>
+
           <colspec colname="c4" colnum="4" colwidth="1.0*"/>
+
           <colspec colname="c5" colnum="5" colwidth="1.0*"/>
+
           <colspec colname="c6" colnum="6" colwidth="1.0*"/>
+
           <thead>
             <row>
               <entry>旧 netatalk.conf</entry>
+
               <entry>新 afp.conf</entry>
+
               <entry>旧デフォルト値</entry>
+
               <entry>新デフォルト値</entry>
+
               <entry>セクション</entry>
+
               <entry>詳細</entry>
             </row>
           </thead>
+
           <tbody>
             <row>
               <entry>ATALK_NAME</entry>
+
               <entry>hostname</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>デフォルトでは gethostname() を使用</entry>
             </row>
+
             <row>
               <entry>ATALK_UNIX_CHARSET</entry>
+
               <entry>unix charset</entry>
+
               <entry><emphasis role="bold">LOCALE</emphasis></entry>
+
               <entry><emphasis role="bold">UTF8</emphasis></entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>ATALK_MAC_CHARSET</entry>
+
               <entry>mac charset</entry>
+
               <entry>MAC_ROMAN</entry>
+
               <entry>MAC_ROMAN</entry>
+
               <entry>(G)/(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>CNID_METAD_RUN</entry>
+
               <entry>-</entry>
+
               <entry>yes</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>netatalk(8) で制御</entry>
             </row>
+
             <row>
               <entry>AFPD_RUN</entry>
+
               <entry>-</entry>
+
               <entry>yes</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>netatalk(8) で制御</entry>
             </row>
+
             <row>
               <entry>AFPD_MAX_CLIENTS</entry>
+
               <entry>max connections</entry>
+
               <entry><emphasis role="bold">20</emphasis></entry>
+
               <entry><emphasis role="bold">200</emphasis></entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>AFPD_UAMLIST</entry>
+
               <entry>uam list</entry>
+
               <entry>-U uams_dhx.so,uams_dhx2.so</entry>
+
               <entry>uams_dhx.so uams_dhx2.so</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>AFPD_GUEST</entry>
+
               <entry>guest account</entry>
+
               <entry>nobody</entry>
+
               <entry>nobody</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>CNID_CONFIG</entry>
+
               <entry>log level</entry>
+
               <entry>-l log_note</entry>
+
               <entry>cnid:note</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>CNID_CONFIG</entry>
+
               <entry>log file</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>ATALKD_RUN</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>AppleTalk が廃止</entry>
             </row>
+
             <row>
               <entry>PAPD_RUN</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>AppleTalk が廃止</entry>
             </row>
+
             <row>
               <entry>TIMELORD_RUN</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>AppleTalk が廃止</entry>
             </row>
+
             <row>
               <entry>A2BOOT_RUN</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>AppleTalk が廃止</entry>
             </row>
+
             <row>
               <entry>ATALK_BGROUND</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>AppleTalk が廃止</entry>
             </row>
+
             <row>
               <entry>ATALK_ZONE</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>AppleTalk が廃止</entry>
             </row>
           </tbody>
         </tgroup>
       </table><table frame="all">
         <title>afpd.conf から afp.conf</title>
+
         <tgroup cols="6">
           <colspec colname="c1" colnum="1" colwidth="1.0*"/>
+
           <colspec colname="c2" colnum="2" colwidth="1.0*"/>
+
           <colspec colname="c3" colnum="3" colwidth="1.0*"/>
+
           <colspec colname="c4" colnum="4" colwidth="1.0*"/>
+
           <colspec colname="c5" colnum="5" colwidth="1.0*"/>
+
           <colspec colname="c6" colnum="6" colwidth="1.0*"/>
+
           <thead>
             <row>
               <entry>旧 afpd.conf</entry>
+
               <entry>新 afp.conf</entry>
+
               <entry>旧デフォルト値</entry>
+
               <entry>新デフォルト値</entry>
+
               <entry>セクション</entry>
+
               <entry>詳細</entry>
             </row>
           </thead>
+
           <tbody>
             <row>
               <entry>一番目のフィールド（"-" あるいは“サーバー名”)</entry>
+
               <entry>hostname</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>デフォルトでは gethostname() を使用</entry>
             </row>
+
             <row>
               <entry>-uamlist</entry>
+
               <entry>uam list</entry>
+
               <entry>-U uams_dhx.so,uams_dhx2.so</entry>
+
               <entry>uams_dhx.so uams_dhx2.so</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-nozeroconf</entry>
+
               <entry>zeroconf</entry>
+
               <entry>-</entry>
+
               <entry>（サポートされていれば） yes</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-advertise_ssh</entry>
+
               <entry>advertise ssh</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-[no]savepassword</entry>
+
               <entry>save password</entry>
+
               <entry>-savepassword</entry>
+
               <entry>yes</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-[no]setpassword</entry>
+
               <entry>set password</entry>
+
               <entry>-nosetpassword</entry>
+
               <entry>no</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-client_polling</entry>
+
               <entry>client polling</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-hostname</entry>
+
               <entry>hostname</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>デフォルトでは gethostname() を使用</entry>
             </row>
+
             <row>
               <entry>-loginmesg</entry>
+
               <entry>login message</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)/(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-guestname</entry>
+
               <entry>guest account</entry>
+
               <entry>nobody</entry>
+
               <entry>nobody</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-passwdfile</entry>
+
               <entry>passwd file</entry>
+
               <entry>afppasswd</entry>
+
               <entry>afppasswd</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-passwdminlen</entry>
+
               <entry>passwd minlen</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-tickleval</entry>
+
               <entry>tickleval</entry>
+
               <entry>30</entry>
+
               <entry>30</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-timeout</entry>
+
               <entry>timeout</entry>
+
               <entry>4</entry>
+
               <entry>4</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-sleep</entry>
+
               <entry>sleep time</entry>
+
               <entry>10</entry>
+
               <entry>10</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-dsireadbuf</entry>
+
               <entry>dsireadbuf</entry>
+
               <entry>12</entry>
+
               <entry>12</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-server_quantum</entry>
+
               <entry>server quantum</entry>
+
               <entry><emphasis role="bold">303840</emphasis></entry>
+
               <entry><emphasis role="bold">1048576</emphasis></entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-volnamelen</entry>
+
               <entry>volnamelen</entry>
+
               <entry>80</entry>
+
               <entry>80</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-setuplog</entry>
+
               <entry>log level</entry>
+
               <entry>default log_note</entry>
+
               <entry>default:note</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-setuplog</entry>
+
               <entry>log file</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-admingroup</entry>
+
               <entry>admingroup</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-k5service</entry>
+
               <entry>k5 service</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-k5realm</entry>
+
               <entry>k5 realm</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-k5keytab</entry>
+
               <entry>k5 keytab</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-uampath</entry>
+
               <entry>uam path</entry>
-              <entry><emphasis role="bold">etc/netatalk/uams/</emphasis></entry>
+
+              <entry><emphasis
+              role="bold">etc/netatalk/uams/</emphasis></entry>
+
               <entry><emphasis role="bold">lib/netatalk/</emphasis></entry>
+
               <entry>(G)</entry>
+
               <entry>厳密には $libdir に移動</entry>
             </row>
+
             <row>
               <entry>-ipaddr</entry>
+
               <entry>afp listen</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-cnidserver</entry>
+
               <entry>cnid server</entry>
+
               <entry>localhost:4700</entry>
+
               <entry>localhost:4700</entry>
+
               <entry>(G)/(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-port</entry>
+
               <entry>port</entry>
+
               <entry>548</entry>
+
               <entry>548</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-signature</entry>
+
               <entry>signature</entry>
+
               <entry>auto</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-fqdn</entry>
+
               <entry>fqdn</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-unixcodepage</entry>
+
               <entry>unix charset</entry>
+
               <entry><emphasis role="bold">LOCALE</emphasis></entry>
+
               <entry><emphasis role="bold">UTF8</emphasis></entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-maccodepage</entry>
+
               <entry>mac charset</entry>
+
               <entry>MAC_ROMAN</entry>
+
               <entry>MAC_ROMAN</entry>
+
               <entry>(G)/(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-closevol</entry>
+
               <entry>close vol</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-ntdomain</entry>
+
               <entry>nt domain</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-ntseparator</entry>
+
               <entry>nt separator</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-dircachesize</entry>
+
               <entry>dircachesize</entry>
+
               <entry>8192</entry>
+
               <entry>8192</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-tcpsndbuf</entry>
+
               <entry>tcpsndbuf</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>OS のデフォルト</entry>
             </row>
+
             <row>
               <entry>-tcprcvbuf</entry>
+
               <entry>tcprcvbuf</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>OS のデフォルト</entry>
             </row>
+
             <row>
               <entry>-fcelistener</entry>
+
               <entry>fce listener</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-fcecoalesce</entry>
+
               <entry>fce coalesce</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-fceevents</entry>
+
               <entry>fce events</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-fceholdfmod</entry>
+
               <entry>fce holdfmod</entry>
+
               <entry>60</entry>
+
               <entry>60</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-mimicmodel</entry>
+
               <entry>mimic model</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-adminauthuser</entry>
+
               <entry>admin auth user</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-noacl2maccess</entry>
+
               <entry>map acls</entry>
+
               <entry>-</entry>
+
               <entry>rights</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>-[no]tcp</entry>
+
               <entry>-</entry>
+
               <entry>-tcp</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>常に TCP のみ</entry>
             </row>
+
             <row>
               <entry>-[no]ddp</entry>
+
               <entry>-</entry>
+
               <entry>-noddp</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>AppleTalk が廃止</entry>
             </row>
+
             <row>
               <entry>-[no]transall</entry>
+
               <entry>-</entry>
+
               <entry>-tcp -noddp</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>常に TCP のみ</entry>
             </row>
+
             <row>
               <entry>-nodebug</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>-[no]slp</entry>
+
               <entry>-</entry>
+
               <entry>-noslp</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>SLP サポートが廃止</entry>
             </row>
+
             <row>
               <entry>-[no]uservolfirst</entry>
+
               <entry>-</entry>
+
               <entry>-nouservolfirst</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>uservol が廃止</entry>
             </row>
+
             <row>
               <entry>-[no]uservol</entry>
+
               <entry>-</entry>
+
               <entry>-uservol</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>uservol が廃止</entry>
             </row>
+
             <row>
               <entry>-proxy</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>AppleTalk が廃止</entry>
             </row>
+
             <row>
               <entry>-defaultvol</entry>
+
               <entry>-</entry>
+
               <entry>AppleVolumes.default</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>afp.conf のみ</entry>
             </row>
+
             <row>
               <entry>-systemvol</entry>
+
               <entry>-</entry>
+
               <entry>AppleVolumes.system</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>afp.conf のみ</entry>
             </row>
+
             <row>
               <entry>-loginmaxfail</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>そもそも最初からサポートされていない</entry>
             </row>
+
             <row>
               <entry>-unsetuplog</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>-authprintdir</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>AppleTalk が廃止</entry>
             </row>
+
             <row>
               <entry>-ddpaddr</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>AppleTalk が廃止</entry>
             </row>
+
             <row>
               <entry>-[no]icon</entry>
+
               <entry>-</entry>
+
               <entry>-noicon</entry>
-              <entry></entry>
+
+              <entry/>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>-keepsessions</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
-              <entry>廃止．kill -HUP を使用</entry>
+
+              <entry>廃止。kill -HUP を使用</entry>
             </row>
           </tbody>
         </tgroup>
       </table><table frame="all">
         <title>from afp_ldap.conf から afp.conf</title>
+
         <tgroup cols="6">
           <colspec colname="c1" colnum="1" colwidth="1.0*"/>
+
           <colspec colname="c2" colnum="2" colwidth="1.0*"/>
+
           <colspec colname="c3" colnum="3" colwidth="1.0*"/>
+
           <colspec colname="c4" colnum="4" colwidth="1.0*"/>
+
           <colspec colname="c5" colnum="5" colwidth="1.0*"/>
+
           <colspec colname="c6" colnum="6" colwidth="1.0*"/>
+
           <thead>
             <row>
               <entry>旧 afp_ldap.conf</entry>
+
               <entry>新 afp.conf</entry>
+
               <entry>旧デフォルト値</entry>
+
               <entry>新デフォルト値</entry>
+
               <entry>セクション</entry>
+
               <entry>詳細</entry>
             </row>
           </thead>
+
           <tbody>
             <row>
               <entry>ldap_server</entry>
+
               <entry>ldap server</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>ldap_auth_method</entry>
+
               <entry>ldap auth method</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>ldap_auth_dn</entry>
+
               <entry>ldap auth dn</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>ldap_auth_pw</entry>
+
               <entry>ldap auth pw</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>ldap_userbase</entry>
+
               <entry>ldap userbase</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>ldap_userscope</entry>
+
               <entry>ldap userscope</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>ldap_groupbase</entry>
+
               <entry>ldap groupbase</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>ldap_groupscope</entry>
+
               <entry>ldap groupscope</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>ldap_uuid_attr</entry>
+
               <entry>ldap uuid attr</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>ldap_uuid_string</entry>
+
               <entry>ldap uuid string</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>ldap_name_attr</entry>
+
               <entry>ldap name attr</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
-              <entry> ldap_group_attr</entry>
+              <entry>ldap_group_attr</entry>
+
               <entry>ldap group attr</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(G)</entry>
+
               <entry>-</entry>
             </row>
           </tbody>
         </tgroup>
       </table><table frame="all">
         <title>AppleVolumes.* から afp.conf</title>
+
         <tgroup cols="6">
           <colspec colname="c1" colnum="1" colwidth="1.0*"/>
+
           <colspec colname="c2" colnum="2" colwidth="1.0*"/>
+
           <colspec colname="c3" colnum="3" colwidth="1.0*"/>
+
           <colspec colname="c4" colnum="4" colwidth="1.0*"/>
+
           <colspec colname="c5" colnum="5" colwidth="1.0*"/>
+
           <colspec colname="c6" colnum="6" colwidth="1.0*"/>
+
           <thead>
             <row>
               <entry>旧 AppleVolumes.*</entry>
+
               <entry>新 afp.conf</entry>
+
               <entry>旧デフォルト値</entry>
+
               <entry>新デフォルト値</entry>
+
               <entry>セクション</entry>
+
               <entry>詳細</entry>
             </row>
           </thead>
+
           <tbody>
             <row>
               <entry>（ピリオドで始まる行）</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>extmap.conf で使用する</entry>
             </row>
+
             <row>
               <entry>:DEFAULT:</entry>
+
               <entry>-</entry>
+
               <entry>options:upriv,usedots</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>"vol preset =" を使用する</entry>
             </row>
+
             <row>
               <entry>一番目のフィールド ("~")</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>[Homes] セクションを使用する</entry>
             </row>
+
             <row>
               <entry>一番目のフィールド ("/path")</entry>
+
               <entry>path</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>二番目のフィールド</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>セクション名を使用する</entry>
             </row>
+
             <row>
               <entry>allow:</entry>
+
               <entry>valid users</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>deny:</entry>
+
               <entry>invalid users</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>rwlist:</entry>
+
               <entry>rwlist</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>rolist:</entry>
+
               <entry>rolist</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>volcharset:</entry>
+
               <entry>vol charset</entry>
+
               <entry><emphasis role="bold">UTF8</emphasis></entry>
-              <entry><emphasis role="bold">（unix charset と同じ）</emphasis></entry>
+
+              <entry><emphasis role="bold">（unix charset
+              と同じ）</emphasis></entry>
+
               <entry>(G)/(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>maccharset:</entry>
+
               <entry>mac charset</entry>
+
               <entry>MAC_ROMAN</entry>
+
               <entry>MAC_ROMAN</entry>
+
               <entry>(G)/(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>veto:</entry>
+
               <entry>veto files</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>cnidscheme:</entry>
+
               <entry>cnid scheme</entry>
+
               <entry>dbd</entry>
+
               <entry>dbd</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>casefold:</entry>
+
               <entry>casefold</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>adouble:</entry>
+
               <entry>appledouble</entry>
+
               <entry><emphasis role="bold">v2</emphasis></entry>
+
               <entry><emphasis role="bold">ea</emphasis></entry>
+
               <entry>(V)</entry>
-              <entry>v1，osx 及び sfm は廃止</entry>
+
+              <entry>v1、osx 及び sfm は廃止</entry>
             </row>
+
             <row>
               <entry>cnidserver:</entry>
+
               <entry>cnid server</entry>
+
               <entry>localhost:4700</entry>
+
               <entry>localhost:4700</entry>
+
               <entry>(G)/(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>dbpath:</entry>
+
               <entry>vol dbpath</entry>
+
               <entry><emphasis role="bold">（ボリュームディレクトリ）</emphasis></entry>
-              <entry><emphasis role="bold">var/netatalk/CNID/</emphasis></entry>
+
+              <entry><emphasis
+              role="bold">var/netatalk/CNID/</emphasis></entry>
+
               <entry>(G)</entry>
+
               <entry>厳密には $localstatedir に移動</entry>
             </row>
+
             <row>
               <entry>umask:</entry>
+
               <entry>umask</entry>
+
               <entry>0000</entry>
+
               <entry>0000</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>dperm:</entry>
+
               <entry>directory perm</entry>
+
               <entry>0000</entry>
+
               <entry>0000</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>fperm:</entry>
+
               <entry>file perm</entry>
+
               <entry>0000</entry>
+
               <entry>0000</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>password:</entry>
+
               <entry>password</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>root_preexec:</entry>
+
               <entry>root preexec</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>preexec:</entry>
+
               <entry>preexec</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>root_postexec:</entry>
+
               <entry>root postexec</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>postexec:</entry>
+
               <entry>postexec</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>allowed_hosts:</entry>
+
               <entry>hosts allow</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>denied_hosts:</entry>
+
               <entry>hosts deny</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>ea:</entry>
+
               <entry>ea</entry>
+
               <entry>auto</entry>
+
               <entry>auto</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>volsizelimit:</entry>
+
               <entry>vol size limit</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>perm:</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>"directory perm" 及び "file perm" を使用する</entry>
-              
             </row>
+
             <row>
               <entry>forceuid:</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>forcegid:</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>options:ro</entry>
+
               <entry>read only</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>options:invisibledots</entry>
+
               <entry>invisible dots</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>options:nostat</entry>
+
               <entry>stat vol</entry>
+
               <entry>-</entry>
+
               <entry>yes</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>options:preexec_close</entry>
+
               <entry>preexec close</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>options:root_preexec_close</entry>
+
               <entry>root preexec close</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>options:upriv</entry>
+
               <entry>unix priv</entry>
+
               <entry>-</entry>
+
               <entry><emphasis role="bold">yes</emphasis></entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>options:nodev</entry>
+
               <entry>cnid dev</entry>
+
               <entry>-</entry>
+
               <entry>yes</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>options:illegalseq</entry>
+
               <entry>illegal seq</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>options:tm</entry>
+
               <entry>time machine</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>options:searchdb</entry>
+
               <entry>search db</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>options:nonetids</entry>
+
               <entry>network ids</entry>
+
               <entry>-</entry>
+
               <entry>yes</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>options:noacls</entry>
+
               <entry>acls</entry>
+
               <entry>-</entry>
+
               <entry>yes</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>options:followsymlinks</entry>
+
               <entry>follow symlinks</entry>
+
               <entry>-</entry>
+
               <entry>no</entry>
+
               <entry>(V)</entry>
+
               <entry>-</entry>
             </row>
+
             <row>
               <entry>options:nohex</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>":2f" は ":" に自動変換される</entry>
             </row>
+
             <row>
               <entry>options:usedots</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>":2e" は "." に自動変換される</entry>
             </row>
+
             <row>
               <entry>options:nofileid</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>options:prodos</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>options:mswindows</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>options:crlf</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>options:noadouble</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>options:limitsize</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>options:dropbox</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>options:dropkludge</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>options:nocnidcache</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
+
             <row>
               <entry>options:caseinsensitive</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>-</entry>
+
               <entry>廃止</entry>
             </row>
           </tbody>
@@ -1536,8 +2496,8 @@
 
     <para><itemizedlist>
         <listitem>
-          <para><command>ad</command> ユーティリティーを <option>appledouble = ea</option> 
-          のもとでテスト</para>
+          <para><command>ad</command> ユーティリティーを <option>appledouble =
+          ea</option> のもとでテスト</para>
         </listitem>
       </itemizedlist></para>
   </sect1>

--- a/doc/manual/.gitignore
+++ b/doc/manual/.gitignore
@@ -1,2 +1,3 @@
 manual.xml
 *.html
+venv

--- a/doc/manual/generate_compile_docs.py
+++ b/doc/manual/generate_compile_docs.py
@@ -6,49 +6,59 @@ import re
 import yaml
 import xmltodict
 
-def main():
-  with open('../../.github/workflows/build.yml', 'r') as file:
-    workflow = yaml.safe_load(file)
+lang_en = {
+  "title_1": "Compile Netatalk from Source",
+  "title_2": "Overview",
+  "title_3": "Operating Systems",
+  "heading_1": "Install required packages",
+  "heading_2": "Configure and build",
+  "para_1": "This section describes how to compile Netatalk from source for specific operating systems.",
+  "para_2": "Please note that this chapter is automatically generated and may not be optimized for your system.",
+  "para_3": "Choose either Autotools or Meson as the build system. Test steps are optional.",
+}
+lang_jp = {
+  "title_1": "Netatalk をソースコードからコンパイルする",
+  "title_2": "概要",
+  "title_3": "オペレーティング システム一覧",
+  "heading_1": "必要なパッケージをインストールする",
+  "heading_2": "コンフィグレーションとビルド",
+  "para_1": "本付録では、特定のオペレーティング システムのソースから Netatalk をコンパイルする方法について説明する。",
+  "para_2": "以下文章は自動的に生成されるため、お使いのシステムに最適化されていない可能性があることに注意してください。",
+  "para_3": "ビルド システムとして Autotools と Meson から選択する。 テスト手順は任意である。",
+}
 
-  apt_packages_pattern = r'\$\{\{\senv\.APT_PACKAGES\s\}\}'
-  apt_packages = workflow["env"]["APT_PACKAGES"]
+output_en = "compile.xml"
+output_jp = "../ja/manual/compile.xml"
 
+with open('../../.github/workflows/build.yml', 'r') as file:
+  workflow = yaml.safe_load(file)
+
+apt_packages_pattern = r'\$\{\{\senv\.APT_PACKAGES\s\}\}'
+apt_packages = workflow["env"]["APT_PACKAGES"]
+
+def generate_docbook(strings, output_file):
   docbook = {
     "appendix": {
       "@id": "compile",
-      "title": "Compile Netatalk from Source",
+      "title": strings["title_1"],
       "sect1": [
         {
           "@id": "compile-overview",
-          "title": "Overview",
+          "title": strings["title_2"],
         },
         {
           "para": [
-            """
-            This section describes how to compile Netatalk from source for specific operating systems.
-            """,
-            """
-            The Netatalk project is in the process of transitioning the build system
-            from GNU Autotools to Meson.
-            During the transitional period,
-            the documentation will contain both Autotools and Meson build instructions.
-            """,
-            """
-            Please note that this document is automatically generated from the GitHub workflow YAML file.
-            This may or may not be the most optimal way to build Netatalk for your system.
-            """,
+            strings["para_1"],
+            strings["para_2"],
           ],
         },
         {
           "@id": "compile-os",
-          "title": "Operating Systems",
+          "title": strings["title_3"],
         },
         {
           "para": [
-            """
-            Note: You only have to use execute the steps for one of the build systems, not both.
-            Additionally, the test steps are entirely optional for compiling from source.
-            """,
+            strings["para_3"],
           ],
           "sect2": [],
         }
@@ -58,7 +68,7 @@ def main():
 
   for key, value in workflow["jobs"].items():
     sections = {}
-    # Skip the SonarQube job
+    # Skip the SonarCloud job
     if value["name"] != "Static Analysis":
       sections["@id"] = key
       sections["title"] = value["name"]
@@ -76,9 +86,9 @@ def main():
 
         # The vmactions jobs have a different structure
         if "uses" in step and step["uses"].startswith("vmactions/"):
-          para.append("Install dependencies")
+          para.append(strings["heading_1"])
           para.append({"screen": step["with"]["prepare"]})
-          para.append("Configure and build")
+          para.append(strings["heading_2"])
           para.append({"screen": step["with"]["run"]})
         else:
           para.append(step["name"])
@@ -90,10 +100,10 @@ def main():
 
   xml = xmltodict.unparse(docbook, pretty=True)
 
-  with open('compile.xml', 'w') as file:
+  with open(output_file, 'w') as file:
     file.write(xml)
 
-  print("Wrote compile.xml")
+  print("Wrote to " + output_file)
 
-if __name__ == '__main__':
-    main()
+generate_docbook(lang_en, output_en)
+generate_docbook(lang_jp, output_jp)


### PR DESCRIPTION
- Translate new and changed strings
- Standardize punctuation to 。、
- Autoformat XML with XMLmind
- Generate Japanese compile.xml
- Regenerate the English compile.xml