### PR TITLE
[2.4] Enable the DHX UAM with embedded WolfSSL in default conf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ ENV LIB_DEPS \
     libgcrypt \
     linux-pam \
     openldap \
-    openssl \
     shadow
 ENV BUILD_DEPS \
     acl-dev \
@@ -26,7 +25,6 @@ ENV BUILD_DEPS \
     meson \
     ninja \
     openldap-dev \
-    openssl-dev \
     pkgconfig
 
 RUN apk update \
@@ -48,6 +46,7 @@ USER builder
 
 RUN meson setup build \
     -Denable-pgp-uam=disabled \
+    -Dwith-embedded-ssl=true \
     -Dwith-libtirpc=true \
 &&  ninja -C build
 

--- a/config/afpd.conf.tmpl
+++ b/config/afpd.conf.tmpl
@@ -7,38 +7,10 @@
 # Options in this file will override both compiled-in defaults
 # and command line options.
 #
-
-
-#
 # Format:
 #  - [options]               to specify options for the default server
 #  "Server name" [options]   to specify an additional server
 #
 
-
-#
-# Some examples:
-#
-#       The simplest case is to not have an afpd.conf.
-#
-#       4 servers w/ names server1-3 and one w/ the hostname. Servers
-#       1-3 get routed to different ports with server3 being bound
-#       specifically to address 192.168.1.3
-#
-#           -
-#           server1 -port 12000
-#           server2 -port 12001
-#           server3 -port 12002 -ipaddr 192.168.1.3
-#
-#       A dedicated guest server, a user server, and a special
-#       AppleTalk-only server:
-#
-#           "Guest Server" -uamlist uams_guest.so \
-#                   -loginmesg "Welcome guest! I'm a public server."
-#           "User Server" -uamlist uams_dhx2.so -port 12000
-#           "special" -ddp -notcp -defaultvol <path> -systemvol <path>
-#
-
-
 # default:
-# - -transall -uamlist uams_dhx2.so
+# - -transall -uamlist uams_dhx.so,uams_dhx2.so

--- a/config/netatalk.conf
+++ b/config/netatalk.conf
@@ -29,7 +29,7 @@ AFPD_RUN=yes
 #AFPD_MAX_CLIENTS=20
 
 #### UAMs (User Authentication Modules)
-#AFPD_UAMLIST="-U uams_dhx2.so"
+#AFPD_UAMLIST="-U uams_dhx.so,uams_dhx2.so"
 
 #### Set the id of the guest user when using uams_guest.so
 #AFPD_GUEST=nobody

--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -89,7 +89,7 @@ function helper::configure() {
 	echo "*** Configuring afpd.conf"
 
 	AFPD_DEFAULT_OPTIONS="-transall -setuplog \"default log_${AFPD_LOGLEVEL:-info} /dev/stdout\""
-	AFPD_UAMS="-uamlist uams_dhx2.so,uams_guest.so,uams_randnum.so"
+	AFPD_UAMS="-uamlist uams_dhx.so,uams_dhx2.so,uams_guest.so,uams_randnum.so"
 
 	if [ ! -z "${INSECURE_AUTH}" ]; then
 		AFPD_UAMS+=",uams_clrtxt.so"

--- a/doc/manpages/man5/afpd.conf.5.xml
+++ b/doc/manpages/man5/afpd.conf.5.xml
@@ -94,7 +94,7 @@
 
         <listitem>
           <para>Comma separated list of UAMs. (The default is
-          uams_dhx2.so).</para>
+          uams_dhx.so,uams_dhx2.so).</para>
 
           <para>The most commonly used UAMs are:</para>
 

--- a/doc/manual/configuration.xml
+++ b/doc/manual/configuration.xml
@@ -78,7 +78,8 @@
         <para>Leaving the afpd.conf file empty equals to the following
         configuration:</para>
 
-        <para><programlisting>- -transall -uamlist uams_dhx2.so</programlisting></para>
+        <para><programlisting>- -transall -uamlist uams_dhx.so,uams_dhx2.so
+        </programlisting></para>
 
         <para>For a more detailed explanation of the available options, please
         refer to the <citerefentry>

--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -158,7 +158,7 @@ void afp_options_init(struct afp_options *options)
     options->sigconffile = _PATH_AFPDSIGCONF;
     options->uuidconf = _PATH_AFPDUUIDCONF;
     options->uampath = _PATH_AFPDUAMPATH;
-    options->uamlist = "uams_dhx2.so";
+    options->uamlist = "uams_dhx.so,uams_dhx2.so";
     options->guest = "nobody";
     options->loginmesg = "";
     options->transports = AFPTRANS_ALL; /*  TCP and DDP */


### PR DESCRIPTION
With embedded wolfssl DHX is now built in the standard configuration, enable this as the default afpd configuration, as well as the default Docker container configuration.