### PR TITLE
Revisit CVE-2022-23121, CVE-2022-23123 regression fixes by @andychen-syno and @anodos325

### DIFF
--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -1248,7 +1248,6 @@ int getdirparams(const AFPObj *obj,
     struct maccess  ma;
     struct adouble  ad;
     char        *data, *l_nameoff = NULL, *utf_nameoff = NULL;
-    char        *ade = NULL;
     int         bit = 0, isad = 0;
     uint32_t           aint;
     uint16_t       ashort;
@@ -1342,8 +1341,8 @@ int getdirparams(const AFPObj *obj,
             break;
 
         case DIRPBIT_FINFO :
-            if ( isad && (ade = ad_entry(&ad, ADEID_FINDERI)) != NULL) {
-                memcpy( data, ade, 32 );
+            if ( isad && ad_entry(&ad, ADEID_FINDERI)) {
+                memcpy( data, ad_entry( &ad, ADEID_FINDERI ), 32 );
             } else { /* no appledouble */
                 memset( data, 0, 32 );
                 /* dot files are by default visible */
@@ -1567,7 +1566,6 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap, char *bu
     struct timeval      tv;
 
     char                *upath;
-    char                *ade = NULL;
     struct dir          *dir;
     int         bit, isad = 0;
     int                 cdate, bdate;
@@ -1722,7 +1720,7 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap, char *bu
             }
             break;
         case DIRPBIT_FINFO :
-            if (isad && (ade = ad_entry(&ad, ADEID_FINDERI)) != NULL) {
+            if (isad && ad_entry(&ad, ADEID_FINDERI)) {
                 /* Fixes #2802236 */
                 uint16_t fflags;
                 memcpy(&fflags, finder_buf + FINDERINFO_FRFLAGOFF, sizeof(uint16_t));
@@ -1739,10 +1737,10 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap, char *bu
                      * behavior one sees when mounting above another mount
                      * point.
                      */
-                    memcpy( ade, finder_buf, 10 );
-                    memcpy( ade + 14, finder_buf + 14, 18 );
+                    memcpy( ad_entry( &ad, ADEID_FINDERI ), finder_buf, 10 );
+                    memcpy( ad_entry( &ad, ADEID_FINDERI ) + 14, finder_buf + 14, 18 );
                 } else {
-                    memcpy( ade, finder_buf, 32 );
+                    memcpy( ad_entry( &ad, ADEID_FINDERI ), finder_buf, 32 );
                 }
             }
             break;

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -290,7 +290,6 @@ static int getvolparams(const AFPObj *obj, uint16_t bitmap, struct vol *vol, str
     char *data = NULL;
     char *nameoff = NULL;
     const char *slash = NULL;
-    char *ade = NULL;
 
     LOG(log_debug, logtype_afpd, "getvolparams: Volume '%s'", vol->v_localname);
 
@@ -312,9 +311,10 @@ static int getvolparams(const AFPObj *obj, uint16_t bitmap, struct vol *vol, str
             slash++;
         else
             slash = vol->v_path;
-        if (ad_getentryoff(&ad, ADEID_NAME) && (ade = ad_entry(&ad, ADEID_NAME)) != NULL) {
+        if (ad_getentryoff(&ad, ADEID_NAME) && ad_entry(&ad, ADEID_NAME)) {
             ad_setentrylen( &ad, ADEID_NAME, strlen( slash ));
-            memcpy(ade, slash, ad_getentrylen( &ad, ADEID_NAME ));
+            memcpy(ad_entry( &ad, ADEID_NAME ), slash,
+                   ad_getentrylen( &ad, ADEID_NAME ));
         }
         vol_setdate(vol->v_vid, &ad, st->st_mtime);
         ad_flush(&ad);

--- a/libatalk/adouble/ad_attr.c
+++ b/libatalk/adouble/ad_attr.c
@@ -23,15 +23,14 @@
 int ad_getattr(const struct adouble *ad, uint16_t *attr)
 {
     uint16_t fflags;
-    char *adp = NULL;
     *attr = 0;
 
-    if (ad_getentryoff(ad, ADEID_AFPFILEI) && (adp = ad_entry(ad, ADEID_AFPFILEI)) != NULL) {
-        memcpy(attr, adp + AFPFILEIOFF_ATTR, 2);
+    if (ad_getentryoff(ad, ADEID_AFPFILEI) && ad_entry(ad, ADEID_AFPFILEI)) {
+        memcpy(attr, ad_entry(ad, ADEID_AFPFILEI) + AFPFILEIOFF_ATTR, 2);
 
         /* Now get opaque flags from FinderInfo */
-        if ((adp = ad_entry(ad, ADEID_FINDERI)) != NULL) {
-            memcpy(&fflags, adp + FINDERINFO_FRFLAGOFF, 2);
+        if (ad_entry(ad, ADEID_FINDERI)) {
+            memcpy(&fflags, ad_entry(ad, ADEID_FINDERI) + FINDERINFO_FRFLAGOFF, 2);
         } else {
             LOG(log_debug, logtype_default, "ad_getattr(%s): invalid FinderInfo", ad->ad_name);
             memset(&fflags, 0, 2);
@@ -61,7 +60,6 @@ int ad_getattr(const struct adouble *ad, uint16_t *attr)
 int ad_setattr(const struct adouble *ad, const uint16_t attribute)
 {
     uint16_t fflags;
-    char *ade = NULL, *adp = NULL;
 
     /* we don't save open forks indicator */
     uint16_t attr = attribute & ~htons(ATTRBIT_DOPEN | ATTRBIT_ROPEN);
@@ -71,12 +69,12 @@ int ad_setattr(const struct adouble *ad, const uint16_t attribute)
     if (ad->ad_adflags & ADFLAGS_DIR)
         attr &= ~(ATTRBIT_MULTIUSER | ATTRBIT_NOWRITE | ATTRBIT_NOCOPY);
 
-    if (ad_getentryoff(ad, ADEID_AFPFILEI) && (ade = ad_entry(ad, ADEID_AFPFILEI)) != NULL
-        && ad_getentryoff(ad, ADEID_FINDERI) && (adp = ad_entry(ad, ADEID_FINDERI)) != NULL) {
-        memcpy(ade + AFPFILEIOFF_ATTR, &attr, sizeof(attr));
-
+    if (ad_getentryoff(ad, ADEID_AFPFILEI) && ad_entry(ad, ADEID_AFPFILEI)
+        && ad_getentryoff(ad, ADEID_FINDERI) && ad_entry(ad, ADEID_FINDERI)) {
+        memcpy(ad_entry(ad, ADEID_AFPFILEI) + AFPFILEIOFF_ATTR, &attr, sizeof(attr));
+            
         /* Now set opaque flags in FinderInfo too */
-        memcpy(&fflags, adp + FINDERINFO_FRFLAGOFF, 2);
+        memcpy(&fflags, ad_entry(ad, ADEID_FINDERI) + FINDERINFO_FRFLAGOFF, 2);
         if (attr & htons(ATTRBIT_INVISIBLE))
             fflags |= htons(FINDERINFO_INVISIBLE);
         else
@@ -89,7 +87,7 @@ int ad_setattr(const struct adouble *ad, const uint16_t attribute)
         } else
             fflags &= htons(~FINDERINFO_ISHARED);
 
-        memcpy(adp + FINDERINFO_FRFLAGOFF, &fflags, 2);
+        memcpy(ad_entry(ad, ADEID_FINDERI) + FINDERINFO_FRFLAGOFF, &fflags, 2);
     }
 
     return 0;
@@ -98,13 +96,11 @@ int ad_setattr(const struct adouble *ad, const uint16_t attribute)
 /* --------------
  * save file/folder ID in AppleDoubleV2 netatalk private parameters
  * return 1 if resource fork has been modified
- * return -1 on error.
  */
 int ad_setid (struct adouble *adp, const dev_t dev, const ino_t ino , const uint32_t id, const cnid_t did, const void *stamp)
 {
     EC_INIT;
     uint32_t tmp;
-    char *ade = NULL;
     ssize_t id_len = -1, dev_len = -1, ino_len = -1, did_len = -1, syn_len = -1;
 
     id_len = ad_getentrylen(adp, ADEID_PRIVID);
@@ -112,57 +108,47 @@ int ad_setid (struct adouble *adp, const dev_t dev, const ino_t ino , const uint
     tmp = id;
     if (adp->ad_vers == AD_VERSION_EA)
         tmp = htonl(tmp);
-
-    ade = ad_entry(adp, ADEID_PRIVID);
-    if (ade == NULL) {
-        LOG(log_warning, logtype_ad, "ad_setid(%s): failed to set ADEID_PRIVID", adp->ad_name);
+    if (!ad_entry(adp, ADEID_PRIVID)) {
+        LOG(log_debug, logtype_default, "ad_setid(%s): invalid PRIVID", adp->ad_name);
         EC_FAIL;
     }
-    memcpy(ade, &tmp, sizeof(tmp));
+    memcpy(ad_entry( adp, ADEID_PRIVID ), &tmp, sizeof(tmp));
 
     dev_len = ad_getentrylen(adp, ADEID_PRIVDEV);
     ad_setentrylen( adp, ADEID_PRIVDEV, sizeof(dev_t));
-    ade = ad_entry(adp, ADEID_PRIVDEV);
-    if (ade == NULL) {
-        LOG(log_warning, logtype_ad, "ad_setid(%s): failed to set ADEID_PRIVDEV", adp->ad_name);
+    if (!ad_entry(adp, ADEID_PRIVDEV)) {
+        LOG(log_debug, logtype_default, "ad_setid(%s): invalid PRIVDEV", adp->ad_name);
         EC_FAIL;
     }
-
     if ((adp->ad_options & ADVOL_NODEV)) {
-        memset(ade, 0, sizeof(dev_t));
+        memset(ad_entry( adp, ADEID_PRIVDEV ), 0, sizeof(dev_t));
     } else {
-        memcpy(ade, &dev, sizeof(dev_t));
+        memcpy(ad_entry( adp, ADEID_PRIVDEV ), &dev, sizeof(dev_t));
     }
 
     ino_len = ad_getentrylen(adp, ADEID_PRIVINO);
     ad_setentrylen( adp, ADEID_PRIVINO, sizeof(ino_t));
-    ade = ad_entry(adp, ADEID_PRIVINO);
-    if (ade == NULL) {
-        LOG(log_warning, logtype_ad, "ad_setid(%s): failed to set ADEID_PRIVINO", adp->ad_name);
+    if (!ad_entry(adp, ADEID_PRIVINO)) {
+        LOG(log_debug, logtype_default, "ad_setid(%s): invalid PRIVINO", adp->ad_name);
         EC_FAIL;
     }
-    memcpy(ade, &ino, sizeof(ino_t));
+    memcpy(ad_entry( adp, ADEID_PRIVINO ), &ino, sizeof(ino_t));
 
-    if (adp->ad_vers != AD_VERSION_EA) {
-        did_len = ad_getentrylen(adp, ADEID_DID);
-        ad_setentrylen( adp, ADEID_DID, sizeof(did));
-
-        ade = ad_entry(adp, ADEID_DID);
-        if (ade == NULL) {
-            LOG(log_warning, logtype_ad, "ad_setid(%s): failed to set ADEID_DID", adp->ad_name);
-            EC_FAIL;
-        }
-        memcpy(ade, &did, sizeof(did));
+    did_len = ad_getentrylen(adp, ADEID_DID);
+    ad_setentrylen( adp, ADEID_DID, sizeof(did));
+    if (!ad_entry(adp, ADEID_DID)) {
+        LOG(log_debug, logtype_default, "ad_setid(%s): invalid DID", adp->ad_name);
+        EC_FAIL;
     }
+    memcpy(ad_entry( adp, ADEID_DID ), &did, sizeof(did));
 
     syn_len = ad_getentrylen(adp, ADEID_PRIVSYN);
     ad_setentrylen( adp, ADEID_PRIVSYN, ADEDLEN_PRIVSYN);
-    ade = ad_entry(adp, ADEID_PRIVSYN);
-    if (ade == NULL) {
-        LOG(log_warning, logtype_ad, "ad_setid(%s): failed to set ADEID_PRIVSYN", adp->ad_name);
+    if (!ad_entry(adp, ADEID_PRIVSYN)) {
+        LOG(log_debug, logtype_default, "ad_setid(%s): invalid PRIVSYN", adp->ad_name);
         EC_FAIL;
     }
-    memcpy(ade, stamp, ADEDLEN_PRIVSYN);
+    memcpy(ad_entry( adp, ADEID_PRIVSYN ), stamp, ADEDLEN_PRIVSYN);
 
 EC_CLEANUP:
     if (ret != 0) {
@@ -177,51 +163,28 @@ EC_CLEANUP:
     return 1;
 }
 
-/*
- * Retrieve stored file / folder. Callers should treat a return of CNID_INVALID (0) as an invalid value.
- */
+/* ----------------------------- */
 uint32_t ad_getid (struct adouble *adp, const dev_t st_dev, const ino_t st_ino , const cnid_t did, const void *stamp _U_)
 {
     uint32_t aint = 0;
     dev_t  dev;
     ino_t  ino;
-    cnid_t a_did = 0;
+    cnid_t a_did;
 
     if (adp) {
-        if (sizeof(dev_t) == ad_getentrylen(adp, ADEID_PRIVDEV)) {
-            char *ade = NULL;
-            ade = ad_entry(adp, ADEID_PRIVDEV);
-            if (ade == NULL) {
-                LOG(log_warning, logtype_ad, "ad_getid: failed to retrieve ADEID_PRIVDEV\n");
-                return CNID_INVALID;
-            }
-            memcpy(&dev, ade, sizeof(dev_t));
-            ade = ad_entry(adp, ADEID_PRIVINO);
-            if (ade == NULL) {
-                LOG(log_warning, logtype_ad, "ad_getid: failed to retrieve ADEID_PRIVINO\n");
-                return CNID_INVALID;
-            }
-            memcpy(&ino, ade, sizeof(ino_t));
-
-            if (adp->ad_vers != AD_VERSION_EA) {
-                /* ADEID_DID is not stored for AD_VERSION_EA */
-                ade = ad_entry(adp, ADEID_DID);
-                if (ade == NULL) {
-                    LOG(log_warning, logtype_ad, "ad_getid: failed to retrieve ADEID_DID\n");
-                    return CNID_INVALID;
-                }
-                memcpy(&a_did, ade, sizeof(cnid_t));
-            }
+        if (sizeof(dev_t) == ad_getentrylen(adp, ADEID_PRIVDEV)
+            && ad_entry(adp, ADEID_PRIVDEV)
+            && ad_entry(adp, ADEID_PRIVINO)
+            && ad_entry(adp, ADEID_DID)) {
+            memcpy(&dev, ad_entry(adp, ADEID_PRIVDEV), sizeof(dev_t));
+            memcpy(&ino, ad_entry(adp, ADEID_PRIVINO), sizeof(ino_t));
+            memcpy(&a_did, ad_entry(adp, ADEID_DID), sizeof(cnid_t));
 
             if (((adp->ad_options & ADVOL_NODEV) || (dev == st_dev))
                 && ino == st_ino
-                && (!did || a_did == 0 || a_did == did) ) {
-                ade = ad_entry(adp, ADEID_PRIVID);
-                if (ade == NULL) {
-                    LOG(log_warning, logtype_ad, "ad_getid: failed to retrieve ADEID_PRIVID\n");
-                    return CNID_INVALID;
-                }
-                memcpy(&aint, ade, sizeof(aint));
+                && (!did || a_did == did)
+                && ad_entry(adp, ADEID_PRIVID)) {
+                memcpy(&aint, ad_entry(adp, ADEID_PRIVID), sizeof(aint));
                 if (adp->ad_vers == AD_VERSION2)
                     return aint;
                 else
@@ -229,7 +192,7 @@ uint32_t ad_getid (struct adouble *adp, const dev_t st_dev, const ino_t st_ino ,
             }
         }
     }
-    return CNID_INVALID;
+    return 0;
 }
 
 /* ----------------------------- */
@@ -237,19 +200,14 @@ uint32_t ad_forcegetid (struct adouble *adp)
 {
     uint32_t aint = 0;
 
-    if (adp) {
-        char *ade = NULL;
-        ade = ad_entry(adp, ADEID_PRIVID);
-        if (ade == NULL) {
-            return CNID_INVALID;
-        }
-        memcpy(&aint, ade, sizeof(aint));
+    if (adp && ad_entry(adp, ADEID_PRIVID)) {
+        memcpy(&aint, ad_entry(adp, ADEID_PRIVID), sizeof(aint));
         if (adp->ad_vers == AD_VERSION2)
             return aint;
         else
             return ntohl(aint);
     }
-    return CNID_INVALID;
+    return 0;
 }
 
 /* -----------------
@@ -260,14 +218,9 @@ int ad_setname(struct adouble *ad, const char *path)
     int len;
     if ((len = strlen(path)) > ADEDLEN_NAME)
         len = ADEDLEN_NAME;
-    if (path && ad_getentryoff(ad, ADEID_NAME)) {
-        char *ade = NULL;
+    if (path && ad_getentryoff(ad, ADEID_NAME) && ad_entry(ad, ADEID_NAME)) {
         ad_setentrylen( ad, ADEID_NAME, len);
-        ade = ad_entry(ad, ADEID_NAME);
-        if (ade == NULL) {
-            return -1;
-        }
-        memcpy(ade, path, len);
+        memcpy(ad_entry( ad, ADEID_NAME ), path, len);
         return 1;
     }
     return 0;

--- a/libatalk/adouble/ad_conv.c
+++ b/libatalk/adouble/ad_conv.c
@@ -93,7 +93,7 @@ static int ad_conv_v22ea_hf(const char *path, const struct stat *sp, const struc
         goto copy;
     if (ad_getentryoff(&adv2, ADEID_FINDERI)
         && (ad_getentrylen(&adv2, ADEID_FINDERI) == ADEDLEN_FINDERI)
-        && (ad_entry(&adv2, ADEID_FINDERI) != NULL)
+        && (ad_entry(&adv2, ADEID_FINDERI))
         && (memcmp(ad_entry(&adv2, ADEID_FINDERI), emptyad, ADEDLEN_FINDERI) != 0))
         goto copy;
     if (ad_getentryoff(&adv2, ADEID_FILEDATESI)) {
@@ -102,7 +102,7 @@ static int ad_conv_v22ea_hf(const char *path, const struct stat *sp, const struc
         if ((ctime != mtime) || (mtime != sp->st_mtime))
             goto copy;
     }
-    if (ad_getentryoff(&adv2, ADEID_AFPFILEI) && (ad_entry(&adv2, ADEID_AFPFILEI) != NULL)) {
+    if (ad_getentryoff(&adv2, ADEID_AFPFILEI) && ad_entry(&adv2, ADEID_AFPFILEI)) {
         if (memcmp(ad_entry(&adv2, ADEID_AFPFILEI), &afpinfo, ADEDLEN_AFPFILEI) != 0)
             goto copy;
     }
@@ -116,7 +116,6 @@ copy:
     EC_ZERO_LOGSTR( ad_open(&adea, path, adflags | ADFLAGS_HF | ADFLAGS_RDWR | ADFLAGS_CREATE),
                     "ad_conv_v22ea_hf(\"%s\"): error creating metadata EA: %s",
                     fullpathname(path), strerror(errno));
-    AFP_ASSERT(ad_refresh(path, &adea) == 0);
     EC_ZERO_LOG( ad_copy_header(&adea, &adv2) );
     ad_flush(&adea);
 

--- a/libatalk/adouble/ad_date.c
+++ b/libatalk/adouble/ad_date.c
@@ -11,7 +11,6 @@ int ad_setdate(struct adouble *ad,
                unsigned int dateoff, uint32_t date)
 {
     int xlate = (dateoff & AD_DATE_UNIX);
-    char *ade = NULL;
 
     dateoff &= AD_DATE_MASK;
     if (xlate)
@@ -22,12 +21,7 @@ int ad_setdate(struct adouble *ad,
 
     if (dateoff > AD_DATE_ACCESS)
         return -1;
-
-    ade = ad_entry(ad, ADEID_FILEDATESI);
-    if (ade == NULL) {
-        return -1;
-    }
-    memcpy(ade + dateoff, &date, sizeof(date));
+    memcpy(ad_entry(ad, ADEID_FILEDATESI) + dateoff, &date, sizeof(date));
 
     return 0;
 }
@@ -36,7 +30,6 @@ int ad_getdate(const struct adouble *ad,
                unsigned int dateoff, uint32_t *date)
 {
     int xlate = (dateoff & AD_DATE_UNIX);
-    char *ade = NULL;
 
     dateoff &= AD_DATE_MASK;
     if (!ad_getentryoff(ad, ADEID_FILEDATESI) || !ad_entry(ad, ADEID_FILEDATESI))
@@ -44,13 +37,7 @@ int ad_getdate(const struct adouble *ad,
 
     if (dateoff > AD_DATE_ACCESS)
         return -1;
-
-
-    ade = ad_entry(ad, ADEID_FILEDATESI);
-    if (ade == NULL) {
-        return -1;
-    }
-    memcpy(date, ade + dateoff, sizeof(uint32_t));
+    memcpy(date, ad_entry(ad, ADEID_FILEDATESI) + dateoff, sizeof(uint32_t));
 
     if (xlate)
         *date = AD_DATE_TO_UNIX(*date);

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -140,17 +140,17 @@ static struct adouble_fops ad_adouble_ea = {
 
 static const struct entry entry_order2[ADEID_NUM_V2 + 1] = {
     {ADEID_NAME,        ADEDOFF_NAME_V2,     ADEDLEN_INIT},
-    {ADEID_COMMENT,     ADEDOFF_COMMENT_V2,  ADEDLEN_COMMENT},
+    {ADEID_COMMENT,     ADEDOFF_COMMENT_V2,  ADEDLEN_INIT},
     {ADEID_FILEDATESI,  ADEDOFF_FILEDATESI,  ADEDLEN_FILEDATESI},
     {ADEID_FINDERI,     ADEDOFF_FINDERI_V2,  ADEDLEN_FINDERI},
     {ADEID_DID,         ADEDOFF_DID,         ADEDLEN_DID},
     {ADEID_AFPFILEI,    ADEDOFF_AFPFILEI,    ADEDLEN_AFPFILEI},
     {ADEID_SHORTNAME,   ADEDOFF_SHORTNAME,   ADEDLEN_INIT},
     {ADEID_PRODOSFILEI, ADEDOFF_PRODOSFILEI, ADEDLEN_PRODOSFILEI},
-    {ADEID_PRIVDEV,     ADEDOFF_PRIVDEV,     ADEDLEN_PRIVDEV},
-    {ADEID_PRIVINO,     ADEDOFF_PRIVINO,     ADEDLEN_PRIVINO},
-    {ADEID_PRIVSYN,     ADEDOFF_PRIVSYN,     ADEDLEN_PRIVSYN},
-    {ADEID_PRIVID,      ADEDOFF_PRIVID,      ADEDLEN_PRIVID},
+    {ADEID_PRIVDEV,     ADEDOFF_PRIVDEV,     ADEDLEN_INIT},
+    {ADEID_PRIVINO,     ADEDOFF_PRIVINO,     ADEDLEN_INIT},
+    {ADEID_PRIVSYN,     ADEDOFF_PRIVSYN,     ADEDLEN_INIT},
+    {ADEID_PRIVID,      ADEDOFF_PRIVID,      ADEDLEN_INIT},
     {ADEID_RFORK,       ADEDOFF_RFORK_V2,    ADEDLEN_INIT},
     {0, 0, 0}
 };
@@ -158,13 +158,13 @@ static const struct entry entry_order2[ADEID_NUM_V2 + 1] = {
 /* Using Extended Attributes */
 static const struct entry entry_order_ea[ADEID_NUM_EA + 1] = {
     {ADEID_FINDERI,    ADEDOFF_FINDERI_EA,    ADEDLEN_FINDERI},
-    {ADEID_COMMENT,    ADEDOFF_COMMENT_EA,    ADEDLEN_COMMENT},
+    {ADEID_COMMENT,    ADEDOFF_COMMENT_EA,    ADEDLEN_INIT},
     {ADEID_FILEDATESI, ADEDOFF_FILEDATESI_EA, ADEDLEN_FILEDATESI},
     {ADEID_AFPFILEI,   ADEDOFF_AFPFILEI_EA,   ADEDLEN_AFPFILEI},
-    {ADEID_PRIVDEV,    ADEDOFF_PRIVDEV_EA,    ADEDLEN_PRIVDEV},
-    {ADEID_PRIVINO,    ADEDOFF_PRIVINO_EA,    ADEDLEN_PRIVINO},
-    {ADEID_PRIVSYN,    ADEDOFF_PRIVSYN_EA,    ADEDLEN_PRIVSYN},
-    {ADEID_PRIVID,     ADEDOFF_PRIVID_EA,     ADEDLEN_PRIVID},
+    {ADEID_PRIVDEV,    ADEDOFF_PRIVDEV_EA,    ADEDLEN_INIT},
+    {ADEID_PRIVINO,    ADEDOFF_PRIVINO_EA,    ADEDLEN_INIT},
+    {ADEID_PRIVSYN,    ADEDOFF_PRIVSYN_EA,    ADEDLEN_INIT},
+    {ADEID_PRIVID,     ADEDOFF_PRIVID_EA,     ADEDLEN_INIT},
     {0, 0, 0}
 };
 
@@ -362,24 +362,19 @@ static int new_ad_header(struct adouble *ad, const char *path, struct stat *stp,
     const struct entry  *eid;
     uint16_t            ashort;
     struct stat         st;
-    char                *adp = NULL;
 
     LOG(log_debug, logtype_ad, "new_ad_header(\"%s\")", path);
 
     if (ad_init_offsets(ad) != 0)
         return -1;
 
-    if (ad->valid_data_len == 0) {
-        ad->valid_data_len = ad->ad_vers == AD_VERSION_EA ? AD_DATASZ_EA : AD_DATASZ2;
-    }
-    adp = ad_entry(ad, ADEID_FINDERI);
-    if (adp == NULL) {
+    if (!ad_entry(ad, ADEID_FINDERI)) {
         LOG(log_debug, logtype_ad, "new_ad_header(\"%s\"): invalid FinderInfo", path);
         return -1;
     }
     /* set default creator/type fields */
-    memcpy(adp + FINDERINFO_FRTYPEOFF,"\0\0\0\0", 4);
-    memcpy(adp + FINDERINFO_FRCREATOFF,"\0\0\0\0", 4);
+    memcpy(ad_entry(ad, ADEID_FINDERI) + FINDERINFO_FRTYPEOFF,"\0\0\0\0", 4);
+    memcpy(ad_entry(ad, ADEID_FINDERI) + FINDERINFO_FRCREATOFF,"\0\0\0\0", 4);
 
     /* make things invisible */
     if ((ad->ad_options & ADVOL_INVDOTS)
@@ -389,16 +384,14 @@ static int new_ad_header(struct adouble *ad, const char *path, struct stat *stp,
         ashort = htons(ATTRBIT_INVISIBLE);
         ad_setattr(ad, ashort);
         ashort = htons(FINDERINFO_INVISIBLE);
-        memcpy(adp + FINDERINFO_FRFLAGOFF, &ashort, sizeof(ashort));
+        memcpy(ad_entry(ad, ADEID_FINDERI) + FINDERINFO_FRFLAGOFF, &ashort, sizeof(ashort));
     }
 
     /* put something sane in the date fields */
     if (stp == NULL) {
         stp = &st;
-        if (lstat(path, &st) != 0) {
-            ad->valid_data_len = 0;
+        if (lstat(path, &st) != 0)
             return -1;
-        }
     }
     ad_setdate(ad, AD_DATE_CREATE | AD_DATE_UNIX, stp->st_mtime);
     ad_setdate(ad, AD_DATE_MODIFY | AD_DATE_UNIX, stp->st_mtime);
@@ -430,7 +423,7 @@ static int parse_entries(struct adouble *ad, uint16_t nentries, size_t valid_dat
 
         if (!eid
             || eid > ADEID_MAX
-            || ((eid != ADEID_RFORK) && (off > valid_data_len))
+            || off > valid_data_len
             || ((eid != ADEID_RFORK) && (off + len >  valid_data_len)))
         {
             LOG(log_warning, logtype_ad, "parse_entries: bogus eid: %u, off: %u, len: %u",
@@ -813,7 +806,7 @@ static int ad_header_read_ea(const char *path, struct adouble *ad, const struct 
         || !ad_entry(ad, ADEID_PRIVINO)
         || !ad_entry(ad, ADEID_PRIVSYN)
         || !ad_entry(ad, ADEID_PRIVID)) {
-
+        LOG(log_error, logtype_ad, "ad_header_read_ea(\"%s\"): invalid metadata EA", fullpathname(path));
         errno = EINVAL;
         EC_FAIL;
     }
@@ -831,10 +824,7 @@ EC_CLEANUP:
         become_root();
         (void)sys_removexattr(path, AD_EA_META);
         unbecome_root();
-        LOG(log_error, logtype_ad,
-            "ad_header_read_ea(%s, %d): deleted invalid metadata EA",
-            path ? fullpathname(path) : "UNKNOWN", nentries);
-
+        LOG(log_error, logtype_ad, "ad_header_read_ea(\"%s\"): deleted invalid metadata EA", fullpathname(path), nentries);
         errno = ENOENT;
     }
     EC_EXIT;


### PR DESCRIPTION
- Added guard check before access ad_entry()
- Allow zero length entry in compliance with AppleDouble specification
- Avoid setting adouble entries on symlinks