### PR TITLE
[2.4] docs: Move documentation from conf file templates to man pages

### DIFF
--- a/config/AppleVolumes.default.tmpl
+++ b/config/AppleVolumes.default.tmpl
@@ -1,4 +1,4 @@
-# Netatalk 2.x afp volume cofiguration
+# AFP shared volume configuration (Netatalk 2.x)
 
 #
 # volume format:

--- a/config/afp_ldap.conf
+++ b/config/afp_ldap.conf
@@ -1,13 +1,3 @@
-# Netatalk 2.x LDAP configuration
-
-# ldap_server      = localhost
-# ldap_auth_method = simple
-# ldap_auth_dn     = cn=admin,dc=domain,dc=org
-# ldap_auth_pw     = notthisone
-# ldap_userbase    = ou=users,dc=domain,dc=org
-# ldap_userscope   = one
-# ldap_groupbase   = ou=groups,dc=domain,dc=org
-# ldap_groupscope  = one
-# ldap_uuid_attr   = apple-generateduid
-# ldap_name_attr   = cn
-# ldap_group_attr  = cn
+# AFP LDAP configuration (Netatalk 2.x)
+#
+# See the `afp_ldap.conf' manual page for examples.

--- a/config/afpd.conf.tmpl
+++ b/config/afpd.conf.tmpl
@@ -1,16 +1,6 @@
+# AFP file sharing server daemon configuration (Netatalk 2.x)
 #
-# CONFIGURATION FOR AFPD (Netatalk 2.x)
-#
-# Each single line defines a virtual server that should be available.
-# Though, using "\" character, newline escaping is supported.
-# Empty lines and lines beginning with `#' are ignored.
-# Options in this file will override both compiled-in defaults
-# and command line options.
-#
-# Format:
-#  - [options]               to specify options for the default server
-#  "Server name" [options]   to specify an additional server
-#
+# See the `afpd.conf' manual page for examples.
 
 # default:
 # - -transall -uamlist uams_dhx.so,uams_dhx2.so

--- a/config/atalkd.conf
+++ b/config/atalkd.conf
@@ -1,37 +1,3 @@
+# AppleTalk daemon configuration (netatalk 2.x)
 #
-# Format of lines in this file:
-#
-#    interface [ -seed ] [ -router | -dontroute ] 
-#       [ -phase { 1 | 2 } ] [ -addr net.node ]
-#	[ -net first[-last] ] [ -zone ZoneName ] ...
-#
-# -seed only works if you have multi-interfaces.  Any missing arguments are
-# automatically configured from the network.  Note: lines can't actually be
-# split, tho it's a good idea.
-#
-# -router is like -seed but it allows single-interface routing. -dontroute 
-# disables routing for the specified interface.
-#
-# Some examples:
-#
-#	The simplest case is no atalkd.conf.  This works on most platforms
-#	(notably not Solaris), since atalkd can discover the local interfaces
-#	on the machine.
-#
-#	Very slightly more complicated:
-#
-#		le0
-#	or
-#		eth0
-#
-#	for Solaris or Linux, respectively.
-#
-#	A much more complicated example:
-#
-#		le0 -phase 1
-#		le1 -seed -phase 2 -addr 66.6 -net 66-67 -zone "No Parking"
-#
-#	This turns on transition routing between the le0 and le1
-#	interfaces on Solaris.  It also causes atalkd to fail if other
-#	routers disagree about its configuration of le1.
-#
+# See the `atalkd.conf' manual page for examples.

--- a/config/papd.conf
+++ b/config/papd.conf
@@ -1,45 +1,6 @@
-# Attributes are:
+# PAP print server daemon configuration (Netatalk 2.x)
 #
-#	Name Type Default	Description
-#	pd   str  ".ppd"	Pathname to ppd file.
-#	pr   str  "lp"		LPD printer name.
-#       pa   str  "0.0"         AppleTalk address (not usually needed).
-#	op   str  "operator"	Operator name, for LPD spooling.
-#	au   flag not-present	If present, authentication required
-#				note that if ca and sp are both set,
-#				ca will be tried first and then sp
-#	am   str  none		Comma separated list of uams to use
-#				(for every printer) whenever 
-#				authentication is on
-#	ca   str  not-present	If present, use cap-style authentication
-#				directory to place print authentication files 
-#	sp   flag not-present	use PSSP authentication.
-#
-# Some examples:
-#
-#	On many systems (notably not Solaris), no papd.conf is required,
-#	since papd shares the same defaults as lpd.
-#
-#	A simple example:
-#
-#		terminator:\
-#			:pr=lp:op=wes:\
-#			:pd=/usr/share/lib/ppd/HPLJ_4M.PPD:
-#
-#	An example with authenticated printing:
-#		authprn:\
-#			:pr=|/usr/bin/lpr -Plp:\
-#			:pd=/usr/share/lib/ppd/HPLJ_4M.PPD:\
-#			:sp:ca=/tmp/print:\
-#			:am=uams_clrtxt.so:
-#
-#	Note also that papd.conf can list several printers.
-#
-#	The printer name in papd may be a full NBP-name of the form
-#	name:type@zone, for example:
-#		Printer 1:LaserWriter@Printing and Mailing:\
-#			:pr=|/usr/bin/lpr -Plp1:
-#
-# Warning: If you are using more than 15 printers and you do not
-# specify the zone in the printer name, only some of the printers may
-# appear in the Chooser.
+# See the `papd.conf' manual page for examples.
+
+# Uncomment the following line to share all CUPS enabled printers.
+# cupsautoadd:op=root:

--- a/doc/manpages/man5/atalkd.conf.5.xml
+++ b/doc/manpages/man5/atalkd.conf.5.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <refentry id="atalkd.conf.5">
-
   <refmeta>
     <refentrytitle>atalkd.conf</refentrytitle>
 
     <manvolnum>5</manvolnum>
 
-    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
+    <refmiscinfo class="date">24 May 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -14,40 +13,69 @@
   <refnamediv>
     <refname>atalkd.conf</refname>
 
-    <refpurpose>Configuration file used by <command>atalkd</command>(8) to configure the
-    interfaces used by AppleTalk<indexterm><primary>atalkd.conf</primary></indexterm><indexterm>
-              <primary>ALLMULTI</primary>
+    <refpurpose>Configuration file used by <command>atalkd</command>(8) to
+    configure the interfaces used by AppleTalk<indexterm>
+        <primary>atalkd.conf</primary>
+      </indexterm><indexterm>
+        <primary>ALLMULTI</primary>
 
-              <secondary>NIC multicast settings</secondary>
-            </indexterm><indexterm>
-              <primary>Phase</primary>
+        <secondary>NIC multicast settings</secondary>
+      </indexterm><indexterm>
+        <primary>Phase</primary>
 
-              <secondary>AppleTalk phase 1 or 2</secondary>
-            </indexterm></refpurpose>
+        <secondary>AppleTalk phase 1 or 2</secondary>
+      </indexterm></refpurpose>
   </refnamediv>
 
   <refsect1>
     <title>Description</title>
 
-    <para><emphasis remap="B">atalkd.conf</emphasis> is the
-    configuration file used by atalkd to configure the Appletalk interfaces
-    and their behavior</para>
+    <para><emphasis remap="B">atalkd.conf</emphasis> is the configuration file
+    used by atalkd to configure the Appletalk interfaces and their
+    behavior</para>
 
     <para>Any line not prefixed with <emphasis remap="B">#</emphasis> is
-    interpreted. The configuration lines are composed like:</para>
+    interpreted. Each interface has be configured on an uninterrupted line,
+    with no support for split lines. The configuration line format is:</para>
 
-    <para><emphasis remap="I">Interface</emphasis> <emphasis
-    remap="B">[</emphasis> <emphasis remap="I">options</emphasis> <emphasis
-    remap="B">]</emphasis></para>
+    <para><emphasis remap="I">interface</emphasis> [ <option>-seed</option> ]
+    [ <option>-phase</option> <replaceable>number</replaceable> ] [
+    <option>-net</option> <replaceable>net-range</replaceable> ] [
+    <option>-addr</option> <replaceable>address</replaceable> ] [
+    <option>-zone</option> <replaceable>zonename</replaceable> ] ...</para>
 
     <para>The simplest case is to have either no atalkd.conf, or to have one
-    that has no active lines. In this case, atalkd should auto-discover the
-    local interfaces on the machine. Please note that you cannot split
-    lines.</para>
+    that has no active lines. In this case, atalkd will auto-discover the
+    local interfaces on the machine and write to the atalkd.conf file,
+    creating it if one does not exist.</para>
 
     <para>The interface is the network interface that this to work over, such
     as <emphasis remap="B">eth0</emphasis> for Linux, or <emphasis
-    remap="B">le0</emphasis> for Sun.</para>
+    remap="B">le0</emphasis> for Solaris.</para>
+
+    <para>Note that all fields except the interface are optional. The loopback
+    interface is configured automatically. If <option>-seed</option> is
+    specified, all other fields must be present. Also,
+    <command>atalkd</command> will exit during startup if a router disagrees
+    with its seed information. If <option>-seed</option> is not given, all
+    other information may be overridden during auto-configuration. If no
+    <option>-phase</option> option is given, the default phase as given on the
+    command line is used (the default is 2). If <option>-addr</option> is
+    given and <option>-net</option> is not, a net-range of one is
+    assumed.</para>
+
+    <para>The first -zone directive for each interface is the ``default''
+    zone. Under Phase 1, there is only one zone. Under Phase 2, all routers on
+    the network are configured with the default zone and must agree.
+    <command>atalkd</command> maps ``*'' to the default zone of the first
+    interface. Note: The default zone for a machine is determined by the
+    configuration of the local routers; to appear in a non-default zone, each
+    service, e.g. <command>afpd</command>, must individually specify the
+    desired zone. See also <citerefentry>
+        <refentrytitle>nbp_name</refentrytitle>
+
+        <manvolnum>3</manvolnum>
+      </citerefentry>.</para>
 
     <para>The possible options and their meanings are:</para>
 
@@ -58,7 +86,7 @@
 
         <listitem>
           <para>Allows specification of the net and node numbers for this
-          interface, specified in Appletalk numbering format (example:
+          interface, specified in AppleTalk numbering format (example:
           <option>-addr 66.6</option>).</para>
         </listitem>
       </varlistentry>
@@ -67,7 +95,7 @@
         <term><option>-dontroute</option></term>
 
         <listitem>
-          <para>Disables Appletalk routing. It is the opposite of
+          <para>Disables AppleTalk routing. It is the inverse of
           <option>-router</option>.</para>
         </listitem>
       </varlistentry>
@@ -82,15 +110,14 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>-noallmulti</option> (linux only)</term>
+        <term><option>-noallmulti</option> (Linux only)</term>
 
         <listitem>
-          <para>On linux the interfaces, atalkd uses, are set to
-          ALLMULTI by default caused by countless NICs having problems
-          without being forced into this mode (some even don't work with
-          allmulti set). In case, you've a NIC known to support multicasts
-          properly, you might want to set this option causing less packets to
-          be processed</para>
+          <para>On Linux, the interfaces atalkd uses are set to ALLMULTI by
+          default, because of countless NICs having problems when not being
+          forced into this mode (some don't even work with ALLMULTI set). In
+          case you have a NIC known to support multicasts properly, you might
+          want to set this option to make fewer packets be processed</para>
         </listitem>
       </varlistentry>
 
@@ -98,7 +125,7 @@
         <term><option>-phase ( 1 | 2 )</option></term>
 
         <listitem>
-          <para>Specifies the Appletalk phase that this interface is to use
+          <para>Specifies the AppleTalk phase that this interface is to use
           (either Phase 1 or Phase 2).</para>
         </listitem>
       </varlistentry>
@@ -107,8 +134,9 @@
         <term><option>-router</option></term>
 
         <listitem>
-          <para>Like <option>-seed</option>, but allows single interface
-          routing. It is the opposite of <option>-dontroute</option>.</para>
+          <para>Seed an AppleTalk router on a single interface. The inverse
+          option is <option>-dontroute</option>. Akin to
+          <option>-seed</option>, but allows single interface routing.</para>
         </listitem>
       </varlistentry>
 
@@ -116,9 +144,10 @@
         <term><option>-seed</option></term>
 
         <listitem>
-          <para>The seed option only works if you have multiple interfaces. It
-          also causes all missing arguments to be automagically configured
-          from the network.</para>
+          <para>Seed an AppleTalk router. This requires two or more interfaces
+          to be configured. If you have a single network interface, use
+          <option>-route</option> instead. It also causes all missing
+          arguments to be automagically configured from the network.</para>
         </listitem>
       </varlistentry>
 
@@ -127,13 +156,30 @@
         <replaceable>zonename</replaceable></option></term>
 
         <listitem>
-          <para>Specifies a specific zone that this interface should appear on (example:
-          <option>-zone "Parking Lot"</option>). Please note that zones with
-          spaces and other special characters should be enclosed in
+          <para>Specifies a specific zone that this interface should appear on
+          (example: <option>-zone "Parking Lot"</option>). Please note that
+          zones with spaces and other special characters should be enclosed in
           parentheses.</para>
         </listitem>
       </varlistentry>
     </variablelist>
+  </refsect1>
+
+  <refsect1>
+    <title>Examples</title>
+
+    <para>Single interface on Solaris with auto-detected
+    parameters.<programlisting>   le0</programlisting></para>
+
+    <para>The same on Linux.<programlisting>   eth0</programlisting></para>
+
+    <para>Below is an example configuration file from a Sun 4/40. The machine
+    has two interfaces, ``le0'' and ``le1''. The ``le0'' interface is
+    configured automatically from other routers on the network. The machine is
+    the only router for the ``le1'' interface.</para>
+
+    <para><programlisting>   le0
+   le1 -seed -net 9461-9471 -zone netatalk -zone Argus</programlisting></para>
   </refsect1>
 
   <refsect1>

--- a/doc/manpages/man5/papd.conf.5.xml
+++ b/doc/manpages/man5/papd.conf.5.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <refentry id="papd.conf.5">
-
   <refmeta>
     <refentrytitle>papd.conf</refentrytitle>
 
     <manvolnum>5</manvolnum>
 
-    <refmiscinfo class="date">06 Sep 2004</refmiscinfo>
+    <refmiscinfo class="date">24 May 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -14,8 +13,9 @@
   <refnamediv>
     <refname>papd.conf</refname>
 
-    <refpurpose>Configuration file used by <command>papd</command>(8) to determine the
-    configuration of printers used by the Netatalk printing daemon<indexterm>
+    <refpurpose>Configuration file used by <command>papd</command>(8) to
+    determine the configuration of printers used by the Netatalk printing
+    daemon<indexterm>
         <primary>papd.conf</primary>
       </indexterm></refpurpose>
   </refnamediv>
@@ -23,22 +23,26 @@
   <refsect1>
     <title>Description</title>
 
-    <para><emphasis remap="B">papd.conf</emphasis> is the
-    configuration file used by papd to configure the printing services offered
-    by netatalk.
+    <para><emphasis remap="B">papd.conf</emphasis> is the configuration file
+    used by papd to configure the printing services offered by netatalk.
     <emphasis remap="B">papd</emphasis> shares the same defaults as lpd on
-    many systems, but not Solaris.</para>
+    many systems. One notable exception is Solaris.</para>
 
-    <para>Any line not prefixed with <emphasis remap="B">#</emphasis> is
-    interpreted. The configuration lines are composed like:</para>
+    <para>The format of papd.conf is derived from <citerefentry>
+        <refentrytitle>printcap</refentrytitle>
+
+        <manvolnum>5</manvolnum>
+      </citerefentry> and can contain configurations for one or more printers.
+    Any line not prefixed with <emphasis remap="B">#</emphasis> is
+    interpreted. The configuration lines are composed like this:</para>
 
     <para><emphasis remap="I">printername:[options]</emphasis></para>
 
-    <para>On systems running a System V printing system the simplest case is
+    <para>On systems running a System V printing system, the simplest case is
     to have either no papd.conf, or to have one that has no active lines. In
-    this case, atalkd should auto-discover the local printers on the machine.
-    Please note that you can split lines by using <emphasis
-    remap="B">\\fR.</emphasis></para>
+    this case, <emphasis>atalkd</emphasis> should auto-discover the local
+    printers on the machine. Please note that you can split lines with a
+    <emphasis remap="B">\</emphasis> (backslash).</para>
 
     <para>printername may be just a name (<emphasis remap="B">Printer
     1</emphasis>), or it may be a full name in nbp_name format (<emphasis
@@ -49,16 +53,16 @@
     option (e.g. <emphasis remap="B">pr=|/usr/bin/lpr</emphasis>).</para>
 
     <para>When CUPS support is compiled in, then <emphasis
-    remap="B">cupsautoadd </emphasis> as the first entry in papd.conf will
-    automagically share all CUPS printers by papd utilizing the PPDs assigned
-    in CUPS (customizable -- see below). This can be overwritten for individal
+    remap="B">cupsautoadd</emphasis> as the first entry in papd.conf will
+    automagically configure and make all CUPS printers available to papd
+    (customizable -- see below). This can be overwritten for individual
     printers by subsequently adding individual entries using the CUPS queue
-    name as <emphasis remap="B">pr </emphasis> entry. Note: CUPS support is
+    name as <emphasis remap="B">pr</emphasis> entry. Note: CUPS support is
     mutually exclusive with System V support described above.</para>
 
     <para>The possible options are colon delimited (<emphasis
     remap="B">:</emphasis>), and lines must be terminated with colons. The
-    possible options and flags are:</para>
+    available options and flags are:</para>
 
     <variablelist remap="TP">
       <varlistentry>
@@ -67,12 +71,11 @@
         <listitem>
           <para>The <emphasis remap="B">am</emphasis> option allows specific
           UAMs to be specified for a particular printer. It has no effect if
-          the <emphasis remap="B">au</emphasis> flag is not present or if papd
-          authentication was not built into netatalk. Note: possible values
-          are <emphasis remap="B">uams_guest.so</emphasis> and <emphasis
-          remap="B"> uams_clrtxt.so</emphasis> only. The first method requires
-          a valid username, but no password. The second requires both a valid
-          username and the correct password.</para>
+          the <emphasis remap="B">au</emphasis> flag is not present. Note:
+          possible values are <emphasis remap="B">uams_guest.so</emphasis> and
+          <emphasis remap="B"> uams_clrtxt.so</emphasis> only. The first
+          method requires a valid username, but no password. The second
+          requires both a valid username and the correct password.</para>
         </listitem>
       </varlistentry>
 
@@ -80,9 +83,8 @@
         <term><emphasis remap="B">au</emphasis></term>
 
         <listitem>
-          <para>If present, this flag enables authentication for the printer.
-          Please note that papd authentication must be built into netatalk for
-          this to take effect.</para>
+          <para>If present, this flag enables authentication for the
+          printer.</para>
         </listitem>
       </varlistentry>
 
@@ -103,7 +105,7 @@
         <listitem>
           <para>If used as the first entry in papd.conf this will share all
           CUPS printers via papd. type/zone settings as well as other
-          parameters assigned to this special printer share will apply to all
+          parameters assigned to this special shared printer will apply to all
           CUPS printers. Unless the <emphasis remap="B">pd</emphasis> option
           is set, the CUPS PPDs will be used. To overwrite these global
           settings for individual printers simply add them subsequently to
@@ -116,7 +118,7 @@
 
         <listitem>
           <para>If present, this flag enables a hack to translate line endings
-          originating from pre Mac OS X LaserWriter drivers to let <emphasis
+          originating from pre-Mac OS X LaserWriter drivers to let <emphasis
           remap="B">foomatic-rip</emphasis> recognize foomatic PPD options set
           in the printer dialog. Attention: Use with caution since this might
           corrupt binary print jobs!</para>
@@ -127,7 +129,8 @@
         <term><emphasis remap="B">op=(operator)</emphasis></term>
 
         <listitem>
-          <para>This specifies the operator name, for lpd spooling.</para>
+          <para>This specifies the operator name, for lpd spooling. Default
+          value is "operator".</para>
         </listitem>
       </varlistentry>
 
@@ -135,7 +138,7 @@
         <term><emphasis remap="B">pa=(appletalk address)</emphasis></term>
 
         <listitem>
-          <para>Allows specification of Appletalk addresses. Usually not
+          <para>Allows specification of AppleTalk addresses. Usually not
           needed.</para>
         </listitem>
       </varlistentry>
@@ -155,7 +158,8 @@
 
         <listitem>
           <para>Sets the <emphasis remap="B">lpd</emphasis> or <emphasis
-          remap="B">CUPS</emphasis> printer that this is spooled to.</para>
+          remap="B">CUPS</emphasis> printer that this is spooled to. Default
+          value is "lp".</para>
         </listitem>
       </varlistentry>
     </variablelist>
@@ -187,8 +191,8 @@ HP Printer:\
     </example>
 
     <para>An alternative to the technique outlined above is to direct papd's
-    output via a pipe into another program. Using this mechanism almost all
-    printing systems can be driven.</para>
+    output via a pipe into another program. Almost any printing system can be
+    driven using this mechanism.</para>
 
     <example>
       <title>papd.conf examples using pipes</title>
@@ -198,18 +202,16 @@ HP Printer:\
       printing is enabled, as is CAP-style authenticated printing. Both
       methods support guest and cleartext authentication as specified by the
       '<option>am</option>' option. The PPD used is
-      <filename>/etc/atalk/ppds/hp8100.ppd</filename>.
-      <programlisting>HP 8100:\
+      <filename>/etc/atalk/ppds/hp8100.ppd</filename>. <programlisting>HP 8100:\
    :pr=|/usr/bin/lpr -Plp:\
    :sp:\
    :ca=/tmp/print:\
-   :am=uams_guest.so,uams_pam.so:\
+   :am=uams_guest.so,uams_clrtxt.so:\
    :pd=/etc/atalk/ppds/hp8100.ppd:
-      </programlisting>
-      </para>
+      </programlisting></para>
     </example>
 
-    <para>Starting with Netatalk 2.0 direct CUPS integration is available. In
+    <para>Starting with Netatalk 2.0, direct CUPS integration is available. In
     this case, defining only a queue name as <option>pr</option> parameter
     won't invoke the SysV lpd daemon but uses CUPS instead. Unless a specific
     PPD has been assigned using the <option>pd</option> switch, the PPD
@@ -228,13 +230,21 @@ HP Printer:\
       All those shares appear in the zone "1st floor" and since no additional
       settings have been made, they use the CUPS printer name as NBP name and
       use the PPD configured in CUPS. The second entry defines different
-      settings for one single CUPS printer. It's NBP name is differing from
-      the printer's name and the registration happens in another zone.
+      settings for one single CUPS printer. Its NBP name is differing from the
+      printer's name and the registration happens in another zone.
       <programlisting>cupsautoadd@1st floor:op=root:
 
 Boss' LaserWriter@2nd floor:\
    :pr=laserwriter-chief:</programlisting></para>
     </example>
+  </refsect1>
+
+  <refsect1>
+    <title>Caveats</title>
+
+    <para>If you are using more than 15 printers in your network, you must
+    specify AppleTalk zones for the papd printer configurations. Otherwise,
+    only some of the printers may appear in the Chooser on Mac clients.</para>
   </refsect1>
 
   <refsect1>

--- a/doc/manpages/man8/atalkd.8.xml
+++ b/doc/manpages/man8/atalkd.8.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>8</manvolnum>
 
-    <refmiscinfo class="date">08 Mar 2024</refmiscinfo>
+    <refmiscinfo class="date">24 May 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -68,46 +68,19 @@
         <refentrytitle>ping</refentrytitle>
 
         <manvolnum>8</manvolnum>
-      </citerefentry>).
-    Specifically, this corresponds to the RTMP, NBP, ZIP, and AEP protocols.</para>
-      
-    <para><command>atalkd</command> is typically started at boot
-    time from system init scripts or services. It first reads from its
-    configuration file, <filename>atalkd.conf</filename>. If there is
-    no configuration file, <command>atalkd</command> will attempt to configure
-    all available interfaces and will create a configuration file. The file
-    consists of a series of interfaces, one per line. Lines with `#' in the
-    first column are ignored, as are blank lines. The syntax is</para>
+      </citerefentry>). Specifically, this corresponds to the RTMP, NBP, ZIP,
+    and AEP protocols in the AppleTalk protocol family.</para>
 
-    <para><emphasis remap="I">interface</emphasis> [ <option>-seed</option> ]
-    [ <option>-phase</option> <replaceable>number</replaceable> ] [
-    <option>-net</option> <replaceable>net-range</replaceable> ] [
-    <option>-addr</option> <replaceable>address</replaceable> ] [
-    <option>-zone</option> <replaceable>zonename</replaceable> ] ...</para>
+    <para>The init system of your OS will typically start the
+    <command>atalkd</command> daemon at bootup. The daemon first reads from
+    its configuration file, <filename>atalkd.conf</filename>. If there is no
+    configuration file, or if no interfaces have been defined,
+    <command>atalkd</command> will attempt to configure all available
+    interfaces and will create a configuration file. See <citerefentry>
+        <refentrytitle>atalkd.conf</refentrytitle>
 
-    <para>Note that all fields except the interface are optional. The loopback
-    interface is configured automatically. If <option>-seed</option> is
-    specified, all other fields must be present. Also,
-    <command>atalkd</command> will exit during bootstrap­ping, if a router
-    disagrees with its seed information. If <option>-seed</option> is not
-    given, all other information may be overridden during auto-configuration.
-    If no <option>-phase</option> option is given, the default phase as given
-    on the command line is used (the default is 2). If <option>-addr</option>
-    is given and <option>-net</option> is not, a net-range of one is
-    assumed.</para>
-
-    <para>The first -zone directive for each interface is the ``default''
-    zone. Under Phase 1, there is only one zone. Under Phase 2, all routers on
-    the network are configured with the default zone and must agree.
-    <command>atalkd</command> maps ``*'' to the default zone of the first
-    interface. Note: The default zone for a machine is determined by the
-    configuration of the local routers; to appear in a non-default zone, each
-    service, e.g. <command>afpd</command>, must individually specify the
-    desired zone. See also <citerefentry>
-        <refentrytitle>nbp_name</refentrytitle>
-
-        <manvolnum>3</manvolnum>
-      </citerefentry>.</para>
+        <manvolnum>5</manvolnum>
+      </citerefentry> for details on the configuration file format.</para>
   </refsect1>
 
   <refsect1>
@@ -134,8 +107,7 @@
         <term>-d</term>
 
         <listitem>
-          <para>Write some additional
-          debugging information to stdout.</para>
+          <para>Write some additional debugging information to stdout.</para>
         </listitem>
       </varlistentry>
 
@@ -153,8 +125,8 @@
         <term>-P <replaceable>pidfile</replaceable></term>
 
         <listitem>
-          <para>Specifies the file in which <command>atalkd</command> stores its
-          process id.</para>
+          <para>Specifies the file in which <command>atalkd</command> stores
+          its process id.</para>
         </listitem>
       </varlistentry>
 
@@ -179,9 +151,9 @@
   <refsect1>
     <title>Routing</title>
 
-    <para>If you are connecting a netatalk router to an existing AppleTalk
-    network, you should first contact your local network administrators to
-    obtain appropriate network addresses.</para>
+    <para>If you are connecting an <command>atalkd</command> router to an
+    existing AppleTalk network, you should first contact your local network
+    administrators to obtain appropriate network addresses.</para>
 
     <para><command>atalkd</command> can provide routing between interfaces by
     configuring multiple interfaces. Each interface must be assigned a unique
@@ -191,35 +163,19 @@
         <secondary>AppleTalk net-range</secondary>
       </indexterm> between 1 and 65279 (0 and 65535 are illegal, and addresses
     between 65280 and 65534 are reserved for startup). It is best to choose
-    the smallest useful net-range, i.e. if you have three machines on a
-    LAN, don't chose a net-range of 1000-2000. Each net-range may have an
-    arbitrary list of zones associated with it.</para>
-  </refsect1>
+    the smallest useful net-range, i.e. if you have three machines on a LAN,
+    choose a net-range below 1000. Each net-range may have an arbitrary list
+    of zones associated with it.</para>
 
-  <refsect1>
-    <title>Examples</title>
-
-    <para>Below is an example configuration file for a sun4/40. The machine
-    has two interfaces, ``le0'' and ``le1''. The ``le0'' interface is
-    configured automatically from other routers on the network. The machine is
-    the only router for the ``le1'' interface.</para>
-
-    <para><programlisting>   le0
-   le1 -seed -net 9461-9471 -zone netatalk -zone Argus</programlisting><command>atalkd</command>
-    automatically acts as a router if there is more than one interface.</para>
+    <para>Note that <command>atalkd</command> automatically acts as a router
+    if there is more than one interface, and no other configurations are
+    present.</para>
   </refsect1>
 
   <refsect1>
     <title>Files</title>
 
     <para><filename>atalkd.conf</filename> configuration file</para>
-  </refsect1>
-
-  <refsect1>
-    <title>Bugs</title>
-
-    <para>On some systems, <command>atalkd</command> can not be
-    restarted.</para>
   </refsect1>
 
   <refsect1>

--- a/doc/manpages/man8/papd.8.xml
+++ b/doc/manpages/man8/papd.8.xml
@@ -5,7 +5,7 @@
 
     <manvolnum>8</manvolnum>
 
-    <refmiscinfo class="date">24 Dec 2023</refmiscinfo>
+    <refmiscinfo class="date">24 May 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -18,7 +18,9 @@
 
   <refsynopsisdiv>
     <cmdsynopsis>
-      <command>papd<indexterm><primary>papd</primary></indexterm><indexterm>
+      <command>papd<indexterm>
+          <primary>papd</primary>
+        </indexterm><indexterm>
           <primary>UAM</primary>
 
           <secondary>User Authentication Module</secondary>
@@ -29,6 +31,8 @@
       <arg>-f configfile</arg>
 
       <arg>-p printcap</arg>
+
+      <arg>-P pidfile</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -55,151 +59,19 @@
 
     <para>As of Netatalk 2.0, CUPS is also supported. Simply using <emphasis
     remap="B">cupsautoadd</emphasis> as the first papd.conf entry will share
-    all CUPS printers automagically. It is still possible to overwrite
-    these defaults by individually defining printer
-    shares. See <citerefentry>
+    all CUPS printers automagically. It is still possible to overwrite these
+    defaults by individually defining printer shares. See <citerefentry>
         <refentrytitle>papd.conf</refentrytitle>
 
         <manvolnum>5</manvolnum>
-      </citerefentry> for details.</para>
+      </citerefentry> for details on the configuration file format.</para>
 
     <para><command>papd</command> is typically started at boot time from
-    system init scripts or services. It first reads from its configuration file,
-    <filename>papd.conf</filename>. The file is in the same format as
-    <filename>/etc/printcap</filename>. See <citerefentry>
-        <refentrytitle>printcap</refentrytitle>
+    system init scripts or services. It first reads from its configuration
+    file, <filename>papd.conf</filename>.</para>
 
-        <manvolnum>5</manvolnum>
-      </citerefentry> for details. The name of the entry is registered with
-    NBP.</para>
-
-    <para>The following options are supported: <informaltable frame="none"
-        pgwide="0">
-        <tgroup cols="4">
-          <colspec align="center" />
-
-          <thead>
-            <row>
-              <entry align="center">Name</entry>
-
-              <entry align="center">Type</entry>
-
-              <entry align="center">Default</entry>
-
-              <entry align="left">Description</entry>
-            </row>
-          </thead>
-
-          <tbody>
-            <row>
-              <entry>pd</entry>
-
-              <entry>str</entry>
-
-              <entry>'.ppd'</entry>
-
-              <entry>Pathname to PPD file</entry>
-            </row>
-
-            <row>
-              <entry>pr</entry>
-
-              <entry>str</entry>
-
-              <entry>'lp'</entry>
-
-              <entry>LPD or CUPS printer name (or pipe to a print
-              command)</entry>
-            </row>
-
-            <row>
-              <entry>op</entry>
-
-              <entry>str</entry>
-
-              <entry>'operator'</entry>
-
-              <entry>Operator name for LPD spooling</entry>
-            </row>
-
-            <row>
-              <entry>au</entry>
-
-              <entry>bool</entry>
-
-              <entry>false</entry>
-
-              <entry>Whether to do authenticated printing or not</entry>
-            </row>
-
-            <row>
-              <entry>ca</entry>
-
-              <entry>str</entry>
-
-              <entry>NULL</entry>
-
-              <entry>Pathname used for CAP-style authentication</entry>
-            </row>
-
-            <row>
-              <entry>sp</entry>
-
-              <entry>bool</entry>
-
-              <entry>false</entry>
-
-              <entry>PSSP-style authentication</entry>
-            </row>
-
-            <row>
-              <entry>am</entry>
-
-              <entry>str</entry>
-
-              <entry>NULL</entry>
-
-              <entry>UAMS to use for authentication</entry>
-            </row>
-
-            <row>
-              <entry>pa</entry>
-
-              <entry>str</entry>
-
-              <entry>NULL</entry>
-
-              <entry>Printer's AppleTalk address</entry>
-            </row>
-
-            <row>
-              <entry>co</entry>
-
-              <entry>str</entry>
-
-              <entry>NULL</entry>
-
-              <entry>CUPS options as supplied to the <citerefentry>
-                  <refentrytitle>lp</refentrytitle>
-
-                  <manvolnum>1</manvolnum>
-                </citerefentry> command with "-o"</entry>
-            </row>
-
-            <row>
-              <entry>fo</entry>
-
-              <entry>bool</entry>
-
-              <entry>false</entry>
-
-              <entry>adjust lineending for foomatic-rip</entry>
-            </row>
-          </tbody>
-        </tgroup>
-      </informaltable> If no configuration file is given, the hostname of the
-    machine is used as the NBP name and all options take their default
-    value.</para>
+    <para>If no configuration file is given, the hostname of the machine is
+    used as the NBP name, and all options take their default value.</para>
   </refsect1>
 
   <refsect1>
@@ -231,6 +103,15 @@
           <para>Consult <replaceable>printcap</replaceable> instead of
           <filename>/etc/printcap</filename> for LPD configuration
           information.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>-P <replaceable>pidfile</replaceable></term>
+
+        <listitem>
+          <para>Specifies the file in which <command>papd</command> stores its
+          process id.</para>
         </listitem>
       </varlistentry>
     </variablelist>
@@ -272,22 +153,19 @@
     If both CAP and PSSP are enabled for a particular printer, CAP will be
     tried first, then <command>papd</command> will fall back to PSSP.</para>
 
-    <para>The list of UAMs to use for authentication (specified with the 'am' option)
-    applies to all printers. It is not possible to define different
+    <para>The list of UAMs to use for authentication (specified with the 'am'
+    option) applies to all printers. It is not possible to define different
     authentication methods on each printer. You can specify the list of UAMS
-    multiple times, but only the last setting will be used. Currently only
-    uams_guest.so and uams_clrtxt.so are supported as printer authentication
-    methods. The guest method requires a valid username, but not a password.
-    The Cleartext UAM requires both a valid username and the correct
-    password.</para>
+    multiple times, but only the last setting will be used. Currently,
+    <emphasis>uams_guest.so</emphasis> and <emphasis>uams_clrtxt.so</emphasis>
+    are supported as printer authentication methods. The guest method requires
+    a valid username, but not a password. The Cleartext UAM requires both a
+    valid username and the correct password.</para>
 
     <note>
-      <para>As of this writing, Mac OS X makes no use of PSSP authentication
-      any longer. CAP-style authentication normally won't be an option, either,
-      because of the use of AFP over TCP these days.</para>
+      <para>Print authentication is only supported on Mac OS 9 and
+      earlier.</para>
     </note>
-
-    <para></para>
   </refsect1>
 
   <refsect1>
@@ -330,27 +208,29 @@
 
     <para><command>papd</command> accepts characters with the high bit set (a
     full 8-bits) from the clients, but some PostScript printers (including
-    Apple Computer's LaserWriter family) only accept 7-bit characters on their
-    serial interface by default. The same applies for some printers when
-    they're accessed via TCP/IP methods (remote LPR or socket). You will need
-    to configure your printer to accept a full 8 bits or take special
-    precautions and convert the printjob's encoding (e.g. by using <emphasis
+    Apple's LaserWriter family) only accept 7-bit characters on their serial
+    interface by default. The same applies for some printers when they're
+    accessed via TCP/IP methods (remote LPR or socket). You will need to
+    configure your printer to accept a full 8 bits or take special precautions
+    and convert the printjob's encoding (e.g. by using <emphasis
     remap="B">co="protocol=BCP"</emphasis> when using CUPS 1.1.19 or
     above).</para>
 
-    <para>When printing clients run Mac OS 10.2 or above, take care that PPDs
-    do not make use of <emphasis remap="B">*cupsFilter:</emphasis> comments
-    unless the appropriate filters are installed at the client's side, too
-    (remember: Starting with 10.2 Apple chose to integrate CUPS into Mac OS X).
-    For in-depth information on how CUPS uses PPDs see chapter 3.4 in <ulink
-    url="http://tinyurl.com/zbxn"> http://tinyurl.com/zbxn</ulink>).</para>
+    <para>When printing clients run Mac OS X 10.2 or later, take care that
+    PPDs do not make use of <emphasis remap="B">*cupsFilter:</emphasis>
+    comments unless the appropriate filters are installed at the client's
+    side, too.</para>
   </refsect1>
 
   <refsect1>
     <title>See also</title>
 
     <para><citerefentry>
-        <refentrytitle>lpr</refentrytitle>
+        <refentrytitle><citerefentry>
+            <refentrytitle>lp</refentrytitle>
+
+            <manvolnum>1</manvolnum>
+          </citerefentry>,lpr</refentrytitle>
 
         <manvolnum>1</manvolnum>
       </citerefentry>,<citerefentry>
@@ -369,10 +249,10 @@
         <refentrytitle>lpd</refentrytitle>
 
         <manvolnum>8</manvolnum>
-      </citerefentry>, <citerefentry>
-        <refentrytitle>lp</refentrytitle>
+      </citerefentry>,<citerefentry>
+        <refentrytitle>papd.conf</refentrytitle>
 
-        <manvolnum>1</manvolnum>
+        <manvolnum>8</manvolnum>
       </citerefentry>.</para>
   </refsect1>
 </refentry>


### PR DESCRIPTION
- Move docs and examples from conf files to man pages, leaving only a file description and reference to the man page in the former
- Move docs concerning the conf file from the daemon man pages to the conf file man pages
- Grammar and organization touchups
- Format with XMLmind