### PR TITLE
[2.4] afpd: Remove multiple deprecated options

### DIFF
--- a/doc/manpages/man5/afpd.conf.5.xml
+++ b/doc/manpages/man5/afpd.conf.5.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <refentry id="afpd.conf.5">
-
   <refmeta>
     <refentrytitle>afpd.conf</refentrytitle>
 
     <manvolnum>5</manvolnum>
 
-    <refmiscinfo class="date">14 May 2024</refmiscinfo>
+    <refmiscinfo class="date">24 May 2024</refmiscinfo>
 
     <refmiscinfo class="source">@NETATALK_VERSION@</refmiscinfo>
   </refmeta>
@@ -14,17 +13,16 @@
   <refnamediv>
     <refname>afpd.conf</refname>
 
-    <refpurpose>Configuration file used by <command>afpd</command>(8)
-    to determine the capabilities of its file sharing services</refpurpose>
+    <refpurpose>Configuration file used by <command>afpd</command>(8) to
+    determine the capabilities of its file sharing services</refpurpose>
   </refnamediv>
 
   <refsect1>
     <title>Description</title>
 
-    <para><filename>afpd.conf</filename> is the configuration file
-    used by <command>afpd</command> to determine the behavior and
-    capabilities of one or more virtual file servers that it
-    provides.</para>
+    <para><filename>afpd.conf</filename> is the configuration file used by
+    <command>afpd</command> to determine the behavior and capabilities of one
+    or more virtual file servers that it provides.</para>
 
     <para>Any line not prefixed with # is interpreted. The configuration lines
     are composed like: server name [ options ] If a <option>-</option> is used
@@ -35,13 +33,12 @@
     are listed below.</para>
 
     <note>
-        <para>Each server has to be configured on a <emphasis
-        role="bold">single</emphasis> line. Though, using "\" character,
-        newline escaping is supported.</para>
+      <para>Each server has to be configured on a <emphasis
+      role="bold">single</emphasis> line. Though, using "\" character, newline
+      escaping is supported.</para>
     </note>
 
     <para>The possible options and their meanings are:</para>
-
   </refsect1>
 
   <refsect1>
@@ -122,8 +119,8 @@
               <listitem>
                 <para>allows Random Number and Two-Way Random Number Exchange
                 for authentication (requires a separate file containing the
-                passwords, either afppasswd file or the one specified
-                via <option>-passwdfile</option>. See <citerefentry>
+                passwords, either afppasswd file or the one specified via
+                <option>-passwdfile</option>. See <citerefentry>
                     <refentrytitle>afppasswd</refentrytitle>
 
                     <manvolnum>1</manvolnum>
@@ -196,17 +193,17 @@
 
       <varlistentry>
         <term>-adminauthuser</term>
+
         <listitem>
-          <para>
-            Specifying e.g. <option>-adminauthuser root</option>
-            whenever a normal user login fails, afpd will try to authenticate as
-            the specified <option>adminauthuser</option>. If this succeeds, a normal session is created
-            for the original connecting user. Said differently: if you know the
-            password of <option>adminauthuser</option>, you can authenticate as any other user.
-          </para>
+          <para>Specifying e.g. <option>-adminauthuser root</option> whenever
+          a normal user login fails, afpd will try to authenticate as the
+          specified <option>adminauthuser</option>. If this succeeds, a normal
+          session is created for the original connecting user. Said
+          differently: if you know the password of
+          <option>adminauthuser</option>, you can authenticate as any other
+          user.</para>
         </listitem>
       </varlistentry>
-
     </variablelist>
   </refsect1>
 
@@ -254,8 +251,8 @@
         <listitem>
           <para>Specifies the Mac client's codepage, e.g. "MAC_ROMAN". This is
           used to convert strings and filenames to the clients codepage for
-          Mac OS 9 and Classic, i.e. for authentication and AFP messages (SIGUSR2
-          messaging). This will also be the default for the volumes
+          Mac OS 9 and Classic, i.e. for authentication and AFP messages
+          (SIGUSR2 messaging). This will also be the default for the volumes
           maccharset. Defaults to MAC_ROMAN.</para>
         </listitem>
       </varlistentry>
@@ -267,28 +264,11 @@
 
     <variablelist>
       <varlistentry>
-        <term>-loginmaxfail [<parameter>number</parameter>]</term>
-
-        <listitem>
-          <para>Sets the maximum number of failed logins, if supported by the
-          UAM (currently none)</para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
         <term>-passwdfile [<parameter>path</parameter>]</term>
 
         <listitem>
-          <para>Sets the path to the Randnum UAM passwd file for this server.</para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term>-passwdminlen [<parameter>number</parameter>]</term>
-
-        <listitem>
-          <para>Sets the minimum password length, if supported by the
-          UAM</para>
+          <para>Sets the path to the Randnum UAM passwd file for this
+          server.</para>
         </listitem>
       </varlistentry>
 
@@ -339,8 +319,8 @@
         <term>-[no]transall</term>
 
         <listitem>
-          <para>Enables or disables both transport protocols.
-          Default is <option>-transall</option>.</para>
+          <para>Enables or disables both transport protocols. Default is
+          <option>-transall</option>.</para>
         </listitem>
       </varlistentry>
     </variablelist>
@@ -365,8 +345,8 @@
             </citerefentry> on the server to let things work.</para>
 
           <note>
-            <para>Apple's client side implementation of this feature 
-            in Mac OS X versions prior to 10.3.4 contained a security flaw.</para>
+            <para>Apple's client side implementation of this feature in Mac OS
+            X versions prior to 10.3.4 contained a security flaw.</para>
           </note>
         </listitem>
       </varlistentry>
@@ -426,16 +406,16 @@
 
           <example>
             <title>afpd.conf configuration line</title>
+
             <programlisting>
               fluxxus -hostname afp.example.org -ipaddr 192.168.0.1 -fqdn www.example.com
             </programlisting>
-            <para>
-              <emphasis role="bold">Result</emphasis>
-            </para>
-            <para>
-              (UTF8) Server name: fluxxus, Listening and advertised network address: 192.168.0.1, Advertised network address: www.example.com,
-              hostname is not used.
-            </para>
+
+            <para><emphasis role="bold">Result</emphasis></para>
+
+            <para>(UTF8) Server name: fluxxus, Listening and advertised
+            network address: 192.168.0.1, Advertised network address:
+            www.example.com, hostname is not used.</para>
           </example>
         </listitem>
       </varlistentry>
@@ -479,39 +459,39 @@
 
       <varlistentry>
         <term>-dsireadbuf <replaceable>[number]</replaceable></term>
-        <listitem>
-          <para>
-            Scale factor that determines the size of the DSI/TCP readahead buffer, default is 12.
-            This is multiplied with the DSI server quantum (default ~300k) to give the size of
-            the buffer. Increasing this value might increase throughput in fast local networks
-            for volume to volume copies.
-          </para>
 
-		<note>
-			<para>This buffer is allocated per afpd child process, so
-			specifying large values will eat up large amounts of memory
-			(buffer size * number of clients).</para>
-		</note>
+        <listitem>
+          <para>Scale factor that determines the size of the DSI/TCP readahead
+          buffer, default is 12. This is multiplied with the DSI server
+          quantum (default ~300k) to give the size of the buffer. Increasing
+          this value might increase throughput in fast local networks for
+          volume to volume copies.</para>
+
+          <note>
+            <para>This buffer is allocated per afpd child process, so
+            specifying large values will eat up large amounts of memory
+            (buffer size * number of clients).</para>
+          </note>
         </listitem>
       </varlistentry>
 
       <varlistentry>
         <term>-tcprcvbuf <replaceable>[number]</replaceable></term>
+
         <listitem>
-          <para>
-            Try to set TCP receive buffer using setsockpt(). Often OSes impose restrictions
-            on the applications' ability to set this value.
-          </para>
+          <para>Try to set TCP receive buffer using setsockpt(). Often OSes
+          impose restrictions on the applications' ability to set this
+          value.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
         <term>-tcpsndbuf <replaceable>[number]</replaceable></term>
+
         <listitem>
-          <para>
-            Try to set TCP send buffer using setsockpt(). Often OSes impose restrictions
-            on the applications' ability to set this value.
-          </para>
+          <para>Try to set TCP send buffer using setsockpt(). Often OSes
+          impose restrictions on the applications' ability to set this
+          value.</para>
         </listitem>
       </varlistentry>
 
@@ -521,8 +501,10 @@
         <listitem>
           <para>Disable automatic Zeroconf<indexterm>
               <primary>Zeroconf</primary>
+
               <secondary>Bonjour</secondary>
-            </indexterm> service registration if support was compiled in.</para>
+            </indexterm> service registration if support was compiled
+          in.</para>
         </listitem>
       </varlistentry>
 
@@ -563,35 +545,6 @@
           examine to determine if a print job should be allowed. These files
           are created at login, and if they are to be properly removed, this
           directory probably needs to be umode 1777.</para>
-
-          <note>
-            <para><option>-authprintdir</option> will only work for clients
-            connecting via DDP. Almost all modern Clients will use TCP.</para>
-          </note>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
-        <term>-client_polling</term>
-
-        <listitem>
-          <para>With this switch enabled, afpd won't advertise that it is
-          capable of server notifications, so that connected clients poll the
-          server every 10 seconds to detect changes in opened server windows.
-          </para>
-
-          <note>
-            <para>Depending on the number of simultaneously
-            connected clients and the network's speed, this can lead to a
-            significantly higher load on your network!</para>
-          </note>
-
-          <note>
-            <para>Do not use this option any longer as Netatalk 2.x correctly
-            supports server notifications, allowing connected clients to
-            update folder listings in case another client changed the
-            contents.</para>
-          </note>
         </listitem>
       </varlistentry>
 
@@ -633,42 +586,43 @@
 
       <varlistentry>
         <term>-fcelistener <replaceable>host[:port]</replaceable></term>
+
         <listitem>
-          <para>
-            Enables sending FCE events to the specified <parameter>host</parameter>,
-            default <parameter>port</parameter> is 12250 if not specified. Specifying
-            multiple listeners is done by having this option once for each of them.
-          </para>
+          <para>Enables sending FCE events to the specified
+          <parameter>host</parameter>, default <parameter>port</parameter> is
+          12250 if not specified. Specifying multiple listeners is done by
+          having this option once for each of them.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
-        <term>-fceevents <replaceable>fmod,fdel,ddel,fcre,dcre,tmsz</replaceable></term>
+        <term>-fceevents
+        <replaceable>fmod,fdel,ddel,fcre,dcre,tmsz</replaceable></term>
+
         <listitem>
-          <para>
-            Specifies which FCE events are active, default is <parameter>fmod,fdel,ddel,fcre,dcre</parameter>.
-          </para>
+          <para>Specifies which FCE events are active, default is
+          <parameter>fmod,fdel,ddel,fcre,dcre</parameter>.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
         <term>-fcecoalesce <replaceable>all|delete|create</replaceable></term>
+
         <listitem>
-          <para>
-            Coalesce FCE events.
-          </para>
+          <para>Coalesce FCE events.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
         <term>-fceholdfmod <replaceable>seconds</replaceable></term>
+
         <listitem>
-          <para>
-            This determines the time delay in seconds which is always waited if another file modification for the
-            same file is done by a client before sending an FCE file modification event (fmod). For example, saving
-            a file in Photoshop would generate multiple events by itself because the application is opening,
-            modifying and closing a file multiple times for every "save". Default: 60 seconds.
-          </para>
+          <para>This determines the time delay in seconds which is always
+          waited if another file modification for the same file is done by a
+          client before sending an FCE file modification event (fmod). For
+          example, saving a file in Photoshop would generate multiple events
+          by itself because the application is opening, modifying and closing
+          a file multiple times for every "save". Default: 60 seconds.</para>
         </listitem>
       </varlistentry>
 
@@ -685,19 +639,24 @@
         <term>-[no]icon</term>
 
         <listitem>
-          <para>[Don't] Use the Netatalk icon for mounted volumes. Later Mac OS versions ignores this.</para>
+          <para>[Don't] Use the Netatalk icon for mounted volumes. Later Mac
+          OS versions ignores this.</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
         <term>-keepsessions</term>
+
         <listitem>
-          <para>Enable "Continuous AFP Service". This means the ability to stop the master afpd process with
-          a SIGQUIT signal, possibly install an afpd update and start the afpd process. Existing AFP sessions'
-          afpd processes will remain unaffected. Technically they will be notified of the master afpd shutdown,
-          sleep 15-20 seconds and then try to reconnect their IPC channel to the master afpd process. If this
-          reconnect fails, the sessions are in an undefined state. Therefore it's absolutely critical to restart
-          the master process in time!</para>
+          <para>Enable "Continuous AFP Service". This means the ability to
+          stop the master afpd process with a SIGQUIT signal, possibly install
+          an afpd update and start the afpd process. Existing AFP sessions'
+          afpd processes will remain unaffected. Technically they will be
+          notified of the master afpd shutdown, sleep 15-20 seconds and then
+          try to reconnect their IPC channel to the master afpd process. If
+          this reconnect fails, the sessions are in an undefined state.
+          Therefore it's absolutely critical to restart the master process in
+          time!</para>
         </listitem>
       </varlistentry>
 
@@ -715,19 +674,26 @@
         <term>-mimicmodel <replaceable>model</replaceable></term>
 
         <listitem>
-          <para>Specifies a custom icon for the mounted AFP volume
-          on macOS / Mac OS X clients. Default is to let macOS choose.
-          Requires netatalk to be built with Zeroconf.
-          Examples:</para>
+          <para>Specifies a custom icon for the mounted AFP volume on macOS /
+          Mac OS X clients. Default is to let macOS choose. Requires netatalk
+          to be built with Zeroconf. Examples:</para>
 
           <itemizedlist>
-            <listitem><para><option>Laptop</option></para></listitem>
-            <listitem><para><option>RackMount</option></para></listitem>
-            <listitem><para><option>Tower</option></para></listitem>
+            <listitem>
+              <para><option>Laptop</option></para>
+            </listitem>
+
+            <listitem>
+              <para><option>RackMount</option></para>
+            </listitem>
+
+            <listitem>
+              <para><option>Tower</option></para>
+            </listitem>
           </itemizedlist>
 
-          <para>A complete set of supported model codes by a macOS client
-          can be found by inspecting
+          <para>A complete set of supported model codes by a macOS client can
+          be found by inspecting
           <filename>/System/Library/CoreServices/CoreTypes.bundle/Contents/Info.plist
           </filename> (as of macOS 14 Sonoma).</para>
         </listitem>
@@ -735,6 +701,7 @@
 
       <varlistentry>
         <term>-noacl2maccess</term>
+
         <listitem>
           <para>Don't map filesystem ACLs to effective permissions.</para>
         </listitem>
@@ -759,27 +726,28 @@
           is "auto". "auto" signature type allows afpd to generate a signature
           and saving it to <filename>afp_signature.conf</filename>
           automatically (based on a random number). The "host" signature type
-          switches back to "auto" because it is obsoleted. The "user" signature
-          type allows an administrator to set up a signature string manually. The
-          maximum length is 16 characters.</para>
+          switches back to "auto" because it is obsoleted. The "user"
+          signature type allows an administrator to set up a signature string
+          manually. The maximum length is 16 characters.</para>
 
           <example>
             <title>Three server definitions using 2 different server
             signatures</title>
 
-            <para><programlisting>first -signature user:USERS 
-            second -signature user:USERS 
+            <para><programlisting>first -signature user:USERS
+            second -signature user:USERS
             third -signature user:ADMINS</programlisting></para>
           </example>
 
-          <para>The first two servers will appear as one logical AFP service to
-          the clients - if a user logs in to the first one and then connects to
-          the second one, the session will be automatically redirected to the first
-          one. But if a client connects to the first and then to the third, they will be
-          asked for the password twice and will see resources of both servers.
-          The traditional method of signature generation causes two independent
-          afpd instances to have the same signature and thus cause clients to
-          be redirected automatically to the server they logged in to first.</para>
+          <para>The first two servers will appear as one logical AFP service
+          to the clients - if a user logs in to the first one and then
+          connects to the second one, the session will be automatically
+          redirected to the first one. But if a client connects to the first
+          and then to the third, they will be asked for the password twice and
+          will see resources of both servers. The traditional method of
+          signature generation causes two independent afpd instances to have
+          the same signature and thus cause clients to be redirected
+          automatically to the server they logged in to first.</para>
         </listitem>
       </varlistentry>
 
@@ -792,9 +760,8 @@
 
           <para><programlisting>73:  limit of Mac OS X 10.1
           80:  limit for Mac OS X 10.4/10.5 (default)
-	  255: limit of spec</programlisting>
-          Mac OS 9 and earlier are not influenced by
-          this, because Maccharset volume name is always limited to 27
+	  255: limit of spec</programlisting> Mac OS 9 and earlier are not influenced
+          by this, because Maccharset volume name is always limited to 27
           bytes.</para>
         </listitem>
       </varlistentry>
@@ -815,9 +782,8 @@
           filename is omitted, the loglevel applies to messages passed to
           syslog.</para>
 
-          <para>By default afpd logs
-          to syslog with a default logging setup equivalent to
-          <option>-setuplog "default log_note"</option>.</para>
+          <para>By default afpd logs to syslog with a default logging setup
+          equivalent to <option>-setuplog "default log_note"</option>.</para>
 
           <para>logtypes: Default, AFPDaemon, Logger, UAMSDaemon</para>
 
@@ -887,8 +853,8 @@
         <term>-tickleval <replaceable>[number]</replaceable></term>
 
         <listitem>
-          <para>Sets the tickle timeout interval (in seconds). Defaults to
-          30. A value of 0 disables session timer tickles.</para>
+          <para>Sets the tickle timeout interval (in seconds). Defaults to 30.
+          A value of 0 disables session timer tickles.</para>
         </listitem>
       </varlistentry>
 
@@ -916,8 +882,8 @@
     <example>
       <title>afpd.conf setup for Kerberos V auth with newline escaping</title>
 
-      <programlisting>- -uamlist uams_dhx.so,uams_dhx2.so,uams_guest.so,uams_gss.so \ 
--k5service afpserver -k5keytab /path/to/afpserver.keytab \ 
+      <programlisting>- -uamlist uams_dhx.so,uams_dhx2.so,uams_guest.so,uams_gss.so \
+-k5service afpserver -k5keytab /path/to/afpserver.keytab \
 -k5realm YOUR.REALM -fqdn your.fqdn.namel:548</programlisting>
     </example>
 

--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -201,11 +201,11 @@ void afp_options_init(struct afp_options *options)
 
 /* parse an afpd.conf line. i'm doing it this way because it's
  * easy. it is, however, massively hokey. sample afpd.conf:
- * server:AFPServer@zone -loginmesg "blah blah blah" -nodsi 
+ * server:AFPServer@zone -loginmesg "blah blah blah" -nodsi
  * "private machine"@zone2 -noguest -port 11012
  * server2 -nocleartxt -nodsi
  *
- * NOTE: this ignores unknown options 
+ * NOTE: this ignores unknown options
  */
 int afp_options_parseline(char *buf, struct afp_options *options)
 {
@@ -270,8 +270,6 @@ int afp_options_parseline(char *buf, struct afp_options *options)
         options->transports |= AFPTRANS_DDP;
     if (strstr(buf, " -noddp"))
         options->transports &= ~AFPTRANS_DDP;
-    if (strstr(buf, "-client_polling"))
-        options->server_notif = 0;
 
     /* figure out options w/ values. currently, this will ignore the setting
      * if memory is lacking. */
@@ -304,16 +302,12 @@ int afp_options_parseline(char *buf, struct afp_options *options)
         }
         opt[j] = 0;
         options->loginmesg = opt;
-        
+
     }
     if ((c = getoption(buf, "-guestname")) && (opt = strdup(c)))
         options->guest = opt;
     if ((c = getoption(buf, "-passwdfile")) && (opt = strdup(c)))
         options->passwdfile = opt;
-    if ((c = getoption(buf, "-passwdminlen")))
-        options->passwdminlen = MIN(1, atoi(c));
-    if ((c = getoption(buf, "-loginmaxfail")))
-        options->loginmaxfail = atoi(c);
     if ((c = getoption(buf, "-tickleval"))) {
         options->tickleval = atoi(c);
         if (options->tickleval < 0) {
@@ -451,7 +445,7 @@ int afp_options_parseline(char *buf, struct afp_options *options)
                 options->unixcodepage = opt;
 	}
     }
-	
+
     if ((c = getoption(buf, "-maccodepage"))) {
     	if ((charset_t)-1 == ( options->maccharset = add_charset(c)) ) {
             options->maccharset = CH_MAC;
@@ -462,7 +456,7 @@ int afp_options_parseline(char *buf, struct afp_options *options)
                 options->maccodepage = opt;
 	}
     }
-    
+
     if ((c = strstr(buf, "-closevol"))) {
         options->closevol= 1;
     }
@@ -475,7 +469,7 @@ int afp_options_parseline(char *buf, struct afp_options *options)
 
     if ((c = getoption(buf, "-dircachesize")))
         options->dircachesize = atoi(c);
-     
+
     if ((c = getoption(buf, "-tcpsndbuf")))
         options->tcp_sndbuf = atoi(c);
 

--- a/etc/afpd/uam.c
+++ b/etc/afpd/uam.c
@@ -143,7 +143,7 @@ int uam_register(const int type, const char *path, const char *name, ...)
         uam->u.uam_login.logout = va_arg(ap, void *);
         uam->u.uam_login.login_ext = va_arg(ap, void *);
         break;
-    
+
     case UAM_SERVER_LOGIN: /* expect three arguments */
         uam->u.uam_login.login_ext = NULL;
         uam->u.uam_login.login = va_arg(ap, void *);
@@ -185,7 +185,7 @@ void uam_unregister(const int type, const char *name)
     free(uam);
 }
 
-/* --- helper functions for plugin uams --- 
+/* --- helper functions for plugin uams ---
  * name: user name
  * len:  size of name buffer.
 */
@@ -202,7 +202,7 @@ struct passwd *uam_getname(void *private, char *name, const int len)
 
     if ((pwent = getpwnam(name)))
         return pwent;
-        
+
     /* if we have a NT domain name try with it */
     if (obj->options.ntdomain && obj->options.ntseparator) {
         /* FIXME What about charset ? */
@@ -214,9 +214,9 @@ struct passwd *uam_getname(void *private, char *name, const int len)
             pwent = getpwnam(p);
             free(p);
             if (pwent) {
-                int len = strlen(pwent->pw_name);              
+                int len = strlen(pwent->pw_name);
                 if (len < MAXUSERLEN) {
-                    strncpy(name,pwent->pw_name, MAXUSERLEN);  
+                    strncpy(name,pwent->pw_name, MAXUSERLEN);
                 }else{
                     LOG(log_error, logtype_uams, "MAJOR:The name %s is longer than %d",pwent->pw_name,MAXUSERLEN);
                 }
@@ -237,9 +237,9 @@ struct passwd *uam_getname(void *private, char *name, const int len)
         if ((p = strchr(pwent->pw_gecos, ',')))
             *p = '\0';
 
-	gecoslen = convert_string(obj->options.unixcharset, CH_UCS2, 
+	gecoslen = convert_string(obj->options.unixcharset, CH_UCS2,
 				pwent->pw_gecos, -1, user, sizeof(username));
-	pwnamelen = convert_string(obj->options.unixcharset, CH_UCS2, 
+	pwnamelen = convert_string(obj->options.unixcharset, CH_UCS2,
 				pwent->pw_name, -1, pwname, sizeof(username));
 	if ((size_t)-1 == gecoslen && (size_t)-1 == pwnamelen)
 		continue;
@@ -248,7 +248,7 @@ struct passwd *uam_getname(void *private, char *name, const int len)
         /* check against both the gecos and the name fields. the user
          * might have just used a different capitalization. */
 
-	if ( (namelen == gecoslen && strncasecmp_w((ucs2_t*)user, (ucs2_t*)username, len) == 0) || 
+	if ( (namelen == gecoslen && strncasecmp_w((ucs2_t*)user, (ucs2_t*)username, len) == 0) ||
 		( namelen == pwnamelen && strncasecmp_w ( (ucs2_t*) pwname, (ucs2_t*) username, len) == 0)) {
             strlcpy(name, pwent->pw_name, len);
             break;
@@ -350,25 +350,9 @@ int uam_afpserver_option(void *private, const int what, void *option,
         if (!len)
             return -1;
 
-        switch (*len) {
-        case UAM_PASSWD_FILENAME:
+        if (*len == UAM_PASSWD_FILENAME) {
             *buf = obj->options.passwdfile;
             *len = strlen(obj->options.passwdfile);
-            break;
-
-        case UAM_PASSWD_MINLENGTH:
-            *((int *) option) = obj->options.passwdminlen;
-            *len = sizeof(obj->options.passwdminlen);
-            break;
-
-        case UAM_PASSWD_MAXFAIL:
-            *((int *) option) = obj->options.loginmaxfail;
-            *len = sizeof(obj->options.loginmaxfail);
-            break;
-
-        case UAM_PASSWD_EXPIRETIME: /* not implemented */
-        default:
-            return -1;
             break;
         }
         break;
@@ -395,13 +379,13 @@ int uam_afpserver_option(void *private, const int what, void *option,
     case UAM_OPTION_PROTOCOL:
         *((int *) option) = obj->proto;
         break;
-        
+
     case UAM_OPTION_CLIENTNAME:
     {
         struct DSI *dsi = obj->handle;
         const struct sockaddr *sa;
         static char hbuf[NI_MAXHOST];
-        
+
         sa = (struct sockaddr *)&dsi->client;
         if (getnameinfo(sa, sizeof(dsi->client), hbuf, sizeof(hbuf), NULL, 0, 0) == 0)
             *buf = hbuf;

--- a/etc/uams/uams_pam.c
+++ b/etc/uams/uams_pam.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1990,1993 Regents of The University of Michigan.
- * Copyright (c) 1999 Adrian Sun (asun@u.washington.edu) 
+ * Copyright (c) 1999 Adrian Sun (asun@u.washington.edu)
  * All Rights Reserved.  See COPYRIGHT.
  */
 
@@ -36,7 +36,7 @@
 /* Static variables used to communicate between the conversation function
  * and the server_login function
  */
-static pam_handle_t *pamh = NULL; 
+static pam_handle_t *pamh = NULL;
 static const char *hostname;
 static char *PAM_username;
 static char *PAM_password;
@@ -56,17 +56,17 @@ static int PAM_conv (int num_msg,
                      struct pam_message **msg,
 #endif
                      struct pam_response **resp,
-                     void *appdata_ptr _U_) 
+                     void *appdata_ptr _U_)
 {
   struct pam_response *reply;
   int count;
-  
+
 #define COPY_STRING(s) (s) ? strdup(s) : NULL
-  
+
   if (num_msg < 1)
     return PAM_CONV_ERR;
 
-  reply = (struct pam_response *) 
+  reply = (struct pam_response *)
     calloc(num_msg, sizeof(struct pam_response));
 
   if (!reply)
@@ -95,7 +95,7 @@ static int PAM_conv (int num_msg,
       goto pam_fail_conv;
     }
 
-    if (string) {  
+    if (string) {
       reply[count].resp_retcode = 0;
       reply[count].resp = string;
       string = NULL;
@@ -113,7 +113,7 @@ pam_fail_conv:
     case PAM_PROMPT_ECHO_OFF:
     case PAM_PROMPT_ECHO_ON:
       free(reply[count].resp);
-      break;      
+      break;
     }
   }
   free(reply);
@@ -138,7 +138,7 @@ static int login(void *obj, char *username, int ulen,  struct passwd **uam_pwd,
 	LOG(log_info, logtype_uams, "uams_pam.c :PAM: unable to retrieve client hostname");
 	hostname = NULL;
     }
-    
+
     ibuf[ PASSWDLEN ] = '\0';
 
     if (( pwd = uam_getname(obj, username, ulen)) == NULL ) {
@@ -157,20 +157,19 @@ static int login(void *obj, char *username, int ulen,  struct passwd **uam_pwd,
 
     pam_set_item(pamh, PAM_TTY, "afpd");
     pam_set_item(pamh, PAM_RHOST, hostname);
-    /* use PAM_DISALLOW_NULL_AUTHTOK if passwdminlen > 0 */
     PAM_error = pam_authenticate(pamh,0);
     if (PAM_error != PAM_SUCCESS) {
-      if (PAM_error == PAM_MAXTRIES) 
+      if (PAM_error == PAM_MAXTRIES)
 	err = AFPERR_PWDEXPR;
       goto login_err;
-    }      
+    }
 
     PAM_error = pam_acct_mgmt(pamh, 0);
     if (PAM_error != PAM_SUCCESS) {
       if (PAM_error == PAM_NEW_AUTHTOK_REQD) /* Password change required */
 	err = AFPERR_PWDEXPR;
 #ifdef PAM_AUTHTOKEN_REQD
-      else if (PAM_error == PAM_AUTHTOKEN_REQD) 
+      else if (PAM_error == PAM_AUTHTOKEN_REQD)
 	err = AFPERR_PWDCHNG;
 #endif /* PAM_AUTHTOKEN_REQD */
       else
@@ -202,13 +201,13 @@ login_err:
 }
 
 /* --------------------------
-   cleartxt login 
+   cleartxt login
 */
 static int pam_login(void *obj, struct passwd **uam_pwd,
 		     char *ibuf, size_t ibuflen,
 		     char *rbuf, size_t *rbuflen)
 {
-    char *username; 
+    char *username;
     size_t  len, ulen;
 
     *rbuflen = 0;
@@ -237,7 +236,7 @@ static int pam_login_ext(void *obj, char *uname, struct passwd **uam_pwd,
 		     char *ibuf, size_t ibuflen,
 		     char *rbuf, size_t *rbuflen)
 {
-    char *username; 
+    char *username;
     size_t  len, ulen;
     u_int16_t  temp16;
 
@@ -257,7 +256,7 @@ static int pam_login_ext(void *obj, char *uname, struct passwd **uam_pwd,
     }
     memcpy(username, uname +2, len );
     username[ len ] = '\0';
-    
+
     return (login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
 }
 
@@ -289,11 +288,11 @@ static int pam_changepw(void *obj _U_, char *username,
 
     /* Set these things up for the conv function */
     PAM_username = username;
-    PAM_password = pw; 
+    PAM_password = pw;
 
     PAM_error = pam_start("netatalk", username, &PAM_conversation,
 			  &lpamh);
-    if (PAM_error != PAM_SUCCESS) 
+    if (PAM_error != PAM_SUCCESS)
       return AFPERR_PARAM;
     pam_set_item(lpamh, PAM_TTY, "afpd");
     pam_set_item(lpamh, PAM_RHOST, hostname);
@@ -312,7 +311,7 @@ static int pam_changepw(void *obj _U_, char *username,
     ibuf += PASSWDLEN;
     PAM_password = ibuf;
     ibuf[PASSWDLEN] = '\0';
-    
+
     /* this really does need to be done as root */
     PAM_error = pam_chauthtok(lpamh, 0);
     seteuid(uid); /* un-root ourselves. */
@@ -394,7 +393,7 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
     PAM_error = pam_start("netatalk", username, &PAM_conversation,
                           &pamh);
     if (PAM_error != PAM_SUCCESS) {
-	LOG(log_info, logtype_uams, "Bad Login ClearTxtUAM: %s: %s", 
+	LOG(log_info, logtype_uams, "Bad Login ClearTxtUAM: %s: %s",
 			username, pam_strerror(pamh, PAM_error));
         pam_end(pamh, PAM_error);
         pamh = NULL;
@@ -405,16 +404,16 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
     pam_set_item(pamh, PAM_RHOST, hostname);
     PAM_error = pam_authenticate(pamh,0);
     if (PAM_error != PAM_SUCCESS) {
-	LOG(log_info, logtype_uams, "Bad Login ClearTxtUAM: %s: %s", 
+	LOG(log_info, logtype_uams, "Bad Login ClearTxtUAM: %s: %s",
 			username, pam_strerror(pamh, PAM_error));
         pam_end(pamh, PAM_error);
         pamh = NULL;
         return(-1);
-    }      
+    }
 
     PAM_error = pam_acct_mgmt(pamh, 0);
     if (PAM_error != PAM_SUCCESS) {
-	LOG(log_info, logtype_uams, "Bad Login ClearTxtUAM: %s: %s", 
+	LOG(log_info, logtype_uams, "Bad Login ClearTxtUAM: %s: %s",
 			username, pam_strerror(pamh, PAM_error));
         pam_end(pamh, PAM_error);
         pamh = NULL;
@@ -423,7 +422,7 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
 
     PAM_error = pam_open_session(pamh, 0);
     if (PAM_error != PAM_SUCCESS) {
-	LOG(log_info, logtype_uams, "Bad Login ClearTxtUAM: %s: %s", 
+	LOG(log_info, logtype_uams, "Bad Login ClearTxtUAM: %s: %s",
 			username, pam_strerror(pamh, PAM_error));
         pam_end(pamh, PAM_error);
         pamh = NULL;
@@ -444,7 +443,7 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
 
 static int uam_setup(const char *path)
 {
-  if (uam_register(UAM_SERVER_LOGIN_EXT, path, "Cleartxt Passwrd", 
+  if (uam_register(UAM_SERVER_LOGIN_EXT, path, "Cleartxt Passwrd",
 		   pam_login, NULL, pam_logout, pam_login_ext) < 0)
 	return -1;
 

--- a/include/atalk/globals.h
+++ b/include/atalk/globals.h
@@ -60,7 +60,7 @@ struct afp_options {
     int disconnected;           /* Maximum time in disconnected state (in tickles) */
     int fce_fmodwait;           /* number of seconds FCE file mod events are put on hold */
     unsigned int tcp_sndbuf, tcp_rcvbuf;
-    unsigned char passwdbits, passwdminlen, loginmaxfail;
+    unsigned char passwdbits;
     u_int32_t server_quantum;
     int dsireadbuf; /* scale factor for sizefof(dsi->buffer) = server_quantum * dsireadbuf */
     char hostname[MAXHOSTNAMELEN + 1], *server, *ipaddr, *port, *configfile;
@@ -81,7 +81,7 @@ struct afp_options {
     unsigned char signature[16];
     char *k5service, *k5realm, *k5keytab;
     char *unixcodepage,*maccodepage;
-    charset_t maccharset, unixcharset; 
+    charset_t maccharset, unixcharset;
     mode_t umask;
     mode_t save_mask;
 #ifdef ADMIN_GRP
@@ -102,7 +102,7 @@ typedef struct _AFPObj {
     int proto;
     unsigned long servernum;
     void *handle;               /* either (DSI *) or (ASP *) */
-    void *config; 
+    void *config;
     struct afp_options options;
     char *Obj, *Type, *Zone;
     char username[MAXUSERLEN];

--- a/include/atalk/uam.h
+++ b/include/atalk/uam.h
@@ -12,7 +12,7 @@
 
 /* just a label for exported bits */
 #ifndef UAM_MODULE_EXPORT
-#define UAM_MODULE_EXPORT 
+#define UAM_MODULE_EXPORT
 #endif
 
 /* type of uam */
@@ -25,7 +25,7 @@
 /* things for which we can have uams */
 #define UAM_SERVER_LOGIN         (1 << 0)
 #define UAM_SERVER_CHANGEPW      (1 << 1)
-#define UAM_SERVER_PRINTAUTH     (1 << 2) 
+#define UAM_SERVER_PRINTAUTH     (1 << 2)
 #define UAM_SERVER_LOGIN_EXT     (1 << 3)
 
 /* options */
@@ -48,9 +48,9 @@
 /* some password options. you pass these in the length parameter and
  * get back the corresponding option. not all of these are implemented. */
 #define UAM_PASSWD_FILENAME     (1 << 0)
-#define UAM_PASSWD_MINLENGTH    (1 << 1)
-#define UAM_PASSWD_MAXFAIL      (1 << 2) /* not implemented yet. */
-#define UAM_PASSWD_EXPIRETIME   (1 << 3) /* not implemented yet. */
+// #define UAM_PASSWD_MINLENGTH    (1 << 1)
+// #define UAM_PASSWD_MAXFAIL      (1 << 2)
+// #define UAM_PASSWD_EXPIRETIME   (1 << 3)
 
 /* max lenght of username  */
 #define UAM_USERNAMELEN 	255


### PR DESCRIPTION
Resolves https://github.com/Netatalk/netatalk/issues/1001 and https://github.com/Netatalk/netatalk/issues/1004

Sorry for the noise in the changeset. Pulsar and XMLmind are opinionated when it comes to trailing line endings etc.