### PR TITLE
[2.4] meson: Fix platform specific issues

### DIFF
--- a/distrib/initscripts/.gitignore
+++ b/distrib/initscripts/.gitignore
@@ -1,10 +1,15 @@
+a2boot
 a2boot.service
+afpd
 afpd.service
+atalkd
 atalkd.service
+cnid_metad
 cnid.service
 io.netatalk.daemon.plist
 netatalk
 netatalkd
+papd
 papd.service
 rc.a2boot.netbsd
 rc.afpd.netbsd
@@ -17,4 +22,5 @@ rc.redhat
 rc.solaris
 rc.suse
 rc.timelord.netbsd
+timelord
 timelord.service

--- a/distrib/initscripts/Makefile.am
+++ b/distrib/initscripts/Makefile.am
@@ -82,11 +82,15 @@ $(sysv_SCRIPTS): rc.redhat
 	chmod a+x $(sysv_SCRIPTS)
 
 install-data-hook:
+if USE_INSTALL_PRIVILEGED
 	-chkconfig --add $(sysv_SCRIPTS)
+endif
 
 uninstall-startup:
+if USE_INSTALL_PRIVILEGED
 	-chkconfig --del $(sysv_SCRIPTS)
 	rm -f $(DESTDIR)$(sysvdir)/$(sysv_SCRIPTS)
+endif
 
 endif
 
@@ -107,9 +111,7 @@ endif
 uninstall-startup:
 if USE_INSTALL_PRIVILEGED
 	-systemctl disable $(service_DATA)
-endif
 	rm -f $(DESTDIR)$(servicedir)/{a2boot,afpd,atalkd,cnid,papd,timelord}.service
-if USE_INSTALL_PRIVILEGED
 	-systemctl daemon-reload
 endif
 
@@ -129,11 +131,15 @@ $(sysv_SCRIPTS): rc.suse
 	chmod a+x $(sysv_SCRIPTS)
 
 install-data-hook:
+if USE_INSTALL_PRIVILEGED
 	-insserv $(sysv_SCRIPTS)
+endif
 
 uninstall-startup:
+if USE_INSTALL_PRIVILEGED
 	-insserv -d $(sysv_SCRIPTS)
 	rm -f $(DESTDIR)$(sysvdir)/$(sysv_SCRIPTS)
+endif
 
 endif
 
@@ -192,15 +198,19 @@ $(sysv_SCRIPTS): rc.solaris
 	chmod a+x $@
 
 install-data-hook:
+if USE_INSTALL_PRIVILEGED
 	rm -f $(DESTDIR)/etc/rc2.d/S90$(sysv_SCRIPTS)
 	-ln -s ../init.d/$(sysv_SCRIPTS) $(DESTDIR)/etc/rc2.d/S90$(sysv_SCRIPTS)
 	rm -f $(DESTDIR)/etc/rc0.d/K04$(sysv_SCRIPTS)
 	-ln -s ../init.d/$(sysv_SCRIPTS) $(DESTDIR)/etc/rc0.d/K04$(sysv_SCRIPTS)
+endif
 
 uninstall-startup:
+if USE_INSTALL_PRIVILEGED
 	rm -f $(DESTDIR)$(sysvdir)/$(sysv_SCRIPTS) \
 		$(DESTDIR)/etc/rc2.d/S90$(sysv_SCRIPTS) \
 		$(DESTDIR)/etc/rc0.d/K04$(sysv_SCRIPTS)
+endif
 
 endif
 
@@ -218,11 +228,15 @@ $(sysv_SCRIPTS): rc.openrc
 	chmod a+x $(sysv_SCRIPTS)
 
 install-data-hook:
-#	-rc-update add $(sysv_SCRIPTS) default
+if USE_INSTALL_PRIVILEGED
+	-rc-update add $(sysv_SCRIPTS) default
+endif
 
 uninstall-startup:
-#	-rc-update del $(sysv_SCRIPTS) default
-#	rm -f $(DESTDIR)$(sysvdir)/$(sysv_SCRIPTS)
+if USE_INSTALL_PRIVILEGED
+	-rc-update del $(sysv_SCRIPTS) default
+	rm -f $(DESTDIR)$(sysvdir)/$(sysv_SCRIPTS)
+endif
 
 endif
 
@@ -240,11 +254,15 @@ $(sysv_SCRIPTS): rc.debian
 	chmod a+x $(sysv_SCRIPTS)
 
 install-data-hook:
-#	update-rc.d $(sysv_SCRIPTS) defaults 90 10
+if USE_INSTALL_PRIVILEGED
+	update-rc.d $(sysv_SCRIPTS) defaults 90 10
+endif
 
 uninstall-startup:
-#	rm -f $(DESTDIR)$(sysvdir)/$(sysv_SCRIPTS)
-#	update-rc.d netatalk remove
+if USE_INSTALL_PRIVILEGED
+	rm -f $(DESTDIR)$(sysvdir)/$(sysv_SCRIPTS)
+	update-rc.d netatalk remove
+endif
 
 endif
 
@@ -259,16 +277,20 @@ bin_SCRIPTS = netatalkd
 launchd_DATA = io.netatalk.daemon.plist
 
 install-data-hook:
+if USE_INSTALL_PRIVILEGED
 	(if [ ! -f $(launchddir)/$(launchd_DATA) ] ; then \
 		cp $(launchd_DATA) $(launchddir) && \
 		launchctl load -w $(launchddir)/$(launchd_DATA); \
 	fi)
+endif
 
 uninstall-startup:
+if USE_INSTALL_PRIVILEGED
 	$(bin_SCRIPTS) stop
 	launchctl unload -w $(launchddir)/$(launchd_DATA)
 	rm -f $(DESTDIR)$(bindir)/$(bin_SCRIPTS)
 	rm -f $(launchddir)/$(launchd_DATA)
+endif
 
 endif
 

--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -77,7 +77,7 @@ elif get_option('enable-netbsd')
         custom_target(
             script + '.netbsd',
             input: script + '.netbsd.tmpl',
-            output: script + 'netbsd',
+            output: script.substring(3),
             command: sed_command,
             capture: true,
             install: true,

--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -11,10 +11,12 @@ if get_option('enable-redhat')
         install_dir: init_dir,
         install_mode: 'rwxr-xr-x',
     )
-    meson.add_install_script(
-        find_program('chkconfig'),
-        '--add', '/etc/rc.d/init.d/netatalk',
-    )
+    if not get_option('disable-install-privileged')
+        meson.add_install_script(
+            find_program('chkconfig'),
+            '--add', '/etc/rc.d/init.d/netatalk',
+        )
+    endif
 elif get_option('enable-systemd')
     init_style += 'systemd'
     init_dir += systemddir
@@ -37,11 +39,13 @@ elif get_option('enable-systemd')
             install_dir: init_dir,
         )
     endforeach
-    meson.add_install_script(
-        find_program('systemctl'),
-        'daemon-reload',
-        '--no-ask-password',
-    )
+    if not get_option('disable-install-privileged')
+        meson.add_install_script(
+            find_program('systemctl'),
+            'daemon-reload',
+            '--no-ask-password',
+        )
+    endif
 elif get_option('enable-suse')
     init_style += 'suse'
     init_dir += '/etc/init.d'
@@ -55,7 +59,9 @@ elif get_option('enable-suse')
         install_dir: init_dir,
         install_mode: 'rwxr-xr-x',
     )
-    meson.add_install_script(find_program('insserv'), '/etc/init.d/netatalk')
+    if not get_option('disable-install-privileged')
+        meson.add_install_script(find_program('insserv'), '/etc/init.d/netatalk')
+    endif
 elif get_option('enable-netbsd')
     init_style += 'netbsd'
     init_dir += '/etc/rc.d'
@@ -91,20 +97,22 @@ elif get_option('enable-solaris')
         install: true,
         install_dir: init_dir,
     )
-    meson.add_install_script(
-        find_program('rm'),
-        '-f', '/etc/rc2.d/S90netatalk',
-    )
-    meson.add_install_script(
-        find_program('ln'),
-        '-s', '/etc/init.d/netatalk',
-        '/etc/rc2.d/S90netatalk',
-    )
-    meson.add_install_script(
-        find_program('ln'),
-        '-s', '/etc/init.d/netatalk',
-        '/etc/rc0.d/K04netatalk',
-    )
+    if not get_option('disable-install-privileged')
+        meson.add_install_script(
+            find_program('rm'),
+            '-f', '/etc/rc2.d/S90netatalk',
+        )
+        meson.add_install_script(
+            find_program('ln'),
+            '-s', '/etc/init.d/netatalk',
+            '/etc/rc2.d/S90netatalk',
+        )
+        meson.add_install_script(
+            find_program('ln'),
+            '-s', '/etc/init.d/netatalk',
+            '/etc/rc0.d/K04netatalk',
+        )
+    endif
 elif get_option('enable-openrc')
     init_style += 'openrc'
     init_dir += '/etc/init.d'
@@ -153,7 +161,10 @@ elif get_option('enable-macos')
         install: true,
         install_dir: init_dir,
     )
-    if not fs.exists('/Library/LaunchDaemons/io.netatalk.daemon.plist')
+    if (
+        not fs.exists('/Library/LaunchDaemons/io.netatalk.daemon.plist')
+        and not get_option('disable-install-privileged')
+    )
         meson.add_install_script(
             find_program('launchctl'),
             'load',

--- a/meson.build
+++ b/meson.build
@@ -420,7 +420,6 @@ bdb_dirs = [
     '/usr',
 ]
 bdb_subdirs = [
-    '',
     'db4.6',
     'db4.7',
     'db4.8',
@@ -436,6 +435,7 @@ bdb_subdirs = [
     'db50',
     'db51',
     'db6.1',
+    '',
 ]
 
 if get_option('with-bdb') != ''
@@ -443,7 +443,9 @@ if get_option('with-bdb') != ''
         if fs.exists(with_bdb / 'include' / subdir / 'db.h')
             bdb_header += with_bdb / 'include' / subdir / 'db.h'
             bdb_libdir += with_bdb / 'lib'
-            bdb_includes += include_directories(with_bdb / 'include' / subdir)
+            bdb_includes += include_directories(
+                with_bdb / 'include' / subdir,
+            )
         endif
         if bdb_header != ''
             break

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -101,6 +101,12 @@ option(
     description: 'Overwrite configuration files during installation',
 )
 option(
+    'disable-install-privileged',
+    type: 'boolean',
+    value: false,
+    description: 'Disable install hooks for OS specific init system',
+)
+option(
     'enable-pgp-uam',
     type: 'feature',
     value: 'auto',


### PR DESCRIPTION
- BerkeleyDB detection on openSUSE: Overlooked backport of https://github.com/Netatalk/netatalk/pull/875
- Bring disable-privileged-install into Meson, and apply it consistently across Meson and existing makefiles https://github.com/Netatalk/netatalk/issues/1024
- Correct naming when installing NetBSD rc scripts. https://github.com/Netatalk/netatalk/issues/1030