### PR TITLE
Reintroduce quota support, modernized with meson build system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,12 +47,14 @@ env:
     libpam0g-dev \
     libssl-dev \
     libtalloc-dev \
+    libtirpc-dev \
     libtool \
     libtool-bin \
     libtracker-sparql-3.0-dev \
     libwrap0-dev \
     meson \
     ninja-build \
+    quota \
     systemtap-sdt-dev \
     tcpd \
     tracker \
@@ -87,6 +89,7 @@ jobs:
             krb5-dev \
             libevent-dev \
             libgcrypt-dev \
+            libtirpc-dev \
             libtool \
             libtracker \
             linux-pam-dev \
@@ -96,6 +99,7 @@ jobs:
             openrc \
             openssl-dev \
             pkgconfig \
+            rpcsvc-proto-dev \
             talloc-dev \
             tracker \
             tracker-dev
@@ -122,7 +126,8 @@ jobs:
         run: |
           meson setup build \
             -Dbuild-tests=true \
-            -Dwith-init-style=openrc
+            -Dwith-init-style=openrc \
+            -Dwith-libtirpc=true
       - name: Meson - Build
         run: ninja -C build
       - name: Meson - Run tests
@@ -215,6 +220,7 @@ jobs:
             libpam0g-dev \
             libssl-dev \
             libtalloc-dev \
+            libtirpc-dev \
             libtool \
             libtool-bin \
             libtracker-sparql-3.0-dev \
@@ -222,6 +228,7 @@ jobs:
             make \
             meson \
             ninja-build \
+            quota \
             systemtap-sdt-dev \
             tcpd \
             tracker
@@ -233,8 +240,10 @@ jobs:
             --disable-dependency-tracking \
             --enable-krbV-uam \
             --enable-pgp-uam \
+            --enable-quota \
             --with-cracklib \
             --with-init-style=debian-sysv \
+            --with-libtirpc \
             --with-tracker-pkgconfig-version=3.0
       - name: Autotools - Build
         run: make -j $(nproc) all
@@ -252,7 +261,8 @@ jobs:
         run: |
           meson setup build \
             -Dbuild-tests=true \
-            -Dwith-init-style=debian-sysv
+            -Dwith-init-style=debian-sysv \
+            -Dwith-libtirpc=true
       - name: Meson - Build
         run: ninja -C build
       - name: Meson - Run tests
@@ -429,9 +439,11 @@ jobs:
             --disable-init-hooks \
             --enable-krbV-uam \
             --enable-pgp-uam \
+            --enable-quota \
             --with-cracklib \
             --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl \
             --with-init-style=debian-systemd \
+            --with-libtirpc \
             --with-tracker-pkgconfig-version=3.0
       - name: Autotools - Generate manual pages
         run: make html
@@ -455,7 +467,8 @@ jobs:
             -Dbuild-tests=true \
             -Dbuild-manual=true \
             -Ddisable-init-hooks=true \
-            -Dwith-init-style=debian-systemd
+            -Dwith-init-style=debian-systemd \
+            -Dwith-libtirpc=true
       - name: Meson - Build and generate manual pages
         run: ninja -C build
       - name: Meson - Run tests

--- a/NEWS
+++ b/NEWS
@@ -22,7 +22,6 @@ Changes in 3.2.0
        Enable with afp.conf option: "fce sendwait"
 * NEW: afppasswd: Add -w option to set password from the CLI, GitHub #936
 * UPD: BREAKING: Remove legacy cdb and tdb CNID backends, GitHub #508
-* UPD: BREAKING: Remove quota functionality, GitHub #493
 * UPD: BREAKING: Remove Andrew File System (AFS) support, GitHub #554
 * UPD: BREAKING: Remove bundled talloc, GitHub #479
        Get the stand-alone talloc library from the Samba project
@@ -38,7 +37,8 @@ Changes in 3.2.0
 * UPD: docs: Document libraries, init scripts in manual, GitHub #808
 * FIX: afpd: Prevent theoretical crash in FPSetACL, GitHub #364
 * FIX: libatalk: Restore invalid EA metadata cleanup, GitHub #400
-* FIX: Shore up error handling and type safety, GItHub #952
+* FIX: quota: Use the NetBSD 6 quota API, GitHub #1028
+* FIX: Shore up error handling and type safety, GitHub #952
 * UPD: Rewrite the afpstats script in Perl, GitHub #893
        And, improve the formatting of the standard output.
        Requires the Net::DBus Perl extension.

--- a/configure.ac
+++ b/configure.ac
@@ -115,6 +115,9 @@ AC_NETATALK_CHECK_ICONV
 dnl Check for CNID database backends
 AC_NETATALK_CNID([bdb_required=yes],[bdb_required=no])
 
+dnl Check for quota support
+AC_NETATALK_CHECK_QUOTA
+
 dnl Check for optional Zeroconf support
 AC_NETATALK_ZEROCONF
 

--- a/etc/afpd/Makefile.am
+++ b/etc/afpd/Makefile.am
@@ -31,7 +31,9 @@ afpd_SOURCES = \
 	main.c \
 	mangle.c \
 	messages.c  \
+	nfsquota.c \
 	ofork.c \
+	quota.c \
 	status.c \
 	switch.c \
 	uam.c \
@@ -41,12 +43,12 @@ afpd_SOURCES = \
 
 afpd_LDADD =  \
 	$(top_builddir)/libatalk/libatalk.la \
-	@LIBGCRYPT_LIBS@ @WRAP_LIBS@ @LIBADD_DL@ @ACL_LIBS@ @PTHREAD_LIBS@ @GSSAPI_LIBS@ @KRB5_LIBS@ @MYSQL_LIBS@
+	@LIBGCRYPT_LIBS@ @QUOTA_LIBS@ @WRAP_LIBS@ @LIBADD_DL@ @ACL_LIBS@ @PTHREAD_LIBS@ @GSSAPI_LIBS@ @KRB5_LIBS@ @MYSQL_LIBS@
 
 afpd_LDFLAGS = -export-dynamic
 
 afpd_CFLAGS = \
-	@GSSAPI_CFLAGS@ @KRB5_CFLAGS@ @PTHREAD_CFLAGS@ \
+	@GSSAPI_CFLAGS@ @KRB5_CFLAGS@ @PTHREAD_CFLAGS@ @QUOTA_CFLAGS@\
 	-DAPPLCNAME \
 	-DSERVERTEXT=\"$(SERVERTEXT)/\" \
 	-D_PATH_AFPDPWFILE=\"$(pkgconfdir)/afppasswd\" \

--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -103,6 +103,13 @@ static void show_version_extended(void )
 	puts( "No" );
 #endif
 
+	printf( "         Quota support:\t" );
+#ifndef NO_QUOTA_SUPPORT
+	puts( "Yes" );
+#else
+	puts( "No" );
+#endif
+
 	printf( "   Admin group support:\t" );
 	puts( "Yes" );
 

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -24,7 +24,9 @@ afpd_sources = [
     'hash.c',
     'mangle.c',
     'messages.c',
+    'nfsquota.c',
     'ofork.c',
+    'quota.c',
     'status.c',
     'switch.c',
     'uam.c',
@@ -95,6 +97,7 @@ libafpd = static_library(
         libgcrypt,
         libcnid_deps,
         threads,
+        tirpc,
     ],
     c_args: [
         '-DAPPLCNAME', confdir,
@@ -104,7 +107,10 @@ libafpd = static_library(
         statedir,
         uamdir,
     ],
-    link_args: netatalk_common_link_args,
+    link_args: [
+        netatalk_common_link_args,
+        quota_link_args,
+    ],
     install: false,
     build_by_default: false,
 )
@@ -181,7 +187,10 @@ executable(
         statedir,
         uamdir,
     ],
-    link_args: netatalk_common_link_args,
+    link_args: [
+        netatalk_common_link_args,
+        quota_link_args,
+    ],
     export_dynamic: true,
     install: true,
     install_dir: sbindir,

--- a/etc/afpd/nfsquota.c
+++ b/etc/afpd/nfsquota.c
@@ -37,13 +37,13 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if !defined(NO_QUOTA_SUPPORT) && !defined(HAVE_LIBQUOTA)
+#if !defined(NO_QUOTA_SUPPORT) || defined(HAVE_LIBQUOTA)
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/param.h> /* for DEV_BSIZE */
-#include <sys/time.h>  /* <rpc/rpc.h> on ultrix doesn't include this */
+#include <sys/time.h>
 #ifdef HAVE_NETDB_H
 #include <netdb.h>
 #endif /* HAVE_NETDB_H */
@@ -101,14 +101,8 @@ callaurpc(struct vol *vol,
 }
 
 
-/* sunos 4 machines structure things a little differently. */
-#ifdef USE_OLD_RQUOTA
-#define GQR_STATUS gqr_status
-#define GQR_RQUOTA gqr_rquota
-#else /* USE_OLD_RQUOTA */
 #define GQR_STATUS status
 #define GQR_RQUOTA getquota_rslt_u.gqr_rquota
-#endif /* USE_OLD_RQUOTA */
 
 int getnfsquota(struct vol *vol, const int uid, const uint32_t bsize,
                 struct dqblk *dqp)
@@ -155,15 +149,15 @@ int getnfsquota(struct vol *vol, const int uid, const uint32_t bsize,
     case Q_OK: /* we only copy the bits that we need. */
         gettimeofday(&tv, NULL);
 
-#if defined(__svr4__) || defined(TRU64)
+#if defined(__svr4__)
         /* why doesn't using bsize work? */
 #define NFS_BSIZE gq_rslt.GQR_RQUOTA.rq_bsize / DEV_BSIZE
-#else /* __svr4__ || TRU64 */
+#else /* __svr4__ */
         /* NOTE: linux' rquotad program doesn't currently report the
         * correct rq_bsize. */
 	/* NOTE: This is integer division and can introduce rounding errors */
 #define NFS_BSIZE gq_rslt.GQR_RQUOTA.rq_bsize / bsize
-#endif /* __svr4__  || TRU64 */
+#endif /* __svr4__ */
 
         dqp->dqb_bhardlimit =
             gq_rslt.GQR_RQUOTA.rq_bhardlimit*NFS_BSIZE;
@@ -171,13 +165,8 @@ int getnfsquota(struct vol *vol, const int uid, const uint32_t bsize,
             gq_rslt.GQR_RQUOTA.rq_bsoftlimit*NFS_BSIZE;
         dqp->dqb_curblocks =
             gq_rslt.GQR_RQUOTA.rq_curblocks*NFS_BSIZE;
-
-#ifdef ultrix
-        dqp->dqb_bwarn = gq_rslt.GQR_RQUOTA.rq_btimeleft;
-#else /* ultrix */
         dqp->dqb_btimelimit =
             tv.tv_sec + gq_rslt.GQR_RQUOTA.rq_btimeleft;
-#endif /* ultrix */
 
         *hostpath = ':';
         return AFP_OK;
@@ -191,4 +180,4 @@ int getnfsquota(struct vol *vol, const int uid, const uint32_t bsize,
     *hostpath = ':';
     return AFPERR_PARAM;
 }
-#endif /* ! NO_QUOTA_SUPPORT && !HAVE_LIBQUOTA */
+#endif /* ! NO_QUOTA_SUPPORT || HAVE_LIBQUOTA */

--- a/etc/afpd/nfsquota.c
+++ b/etc/afpd/nfsquota.c
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 1980, 1990, 1993
+ *      The Regents of the University of California.  All rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by
+ * Robert Elz at The University of Melbourne.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * Ported for AIX (jfs) by Joerg Schumacher (J.Schumacher@tu-bs.de) at the
+ * Technische Universitaet Braunschweig, FRG
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#if !defined(NO_QUOTA_SUPPORT) && !defined(HAVE_LIBQUOTA)
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/param.h> /* for DEV_BSIZE */
+#include <sys/time.h>  /* <rpc/rpc.h> on ultrix doesn't include this */
+#ifdef HAVE_NETDB_H
+#include <netdb.h>
+#endif /* HAVE_NETDB_H */
+#include <netinet/in.h>
+#ifndef PORTMAP
+#define PORTMAP 1
+#endif
+#include <rpc/rpc.h>
+#include <rpc/pmap_prot.h>
+#include <rpcsvc/rquota.h>
+
+
+#include <atalk/afp.h>
+#include <atalk/logger.h>
+
+#include "unix.h"
+
+/* lifted (with modifications) from the bsd quota program */
+static int
+callaurpc(struct vol *vol,
+    u_long prognum, u_long versnum, u_long procnum,
+    xdrproc_t inproc, char *in,
+    xdrproc_t outproc, char *out)
+{
+    enum clnt_stat clnt_stat;
+    struct timeval tottimeout;
+
+    if (!vol->v_nfsclient) {
+        struct hostent *hp;
+        struct sockaddr_in server_addr;
+        struct timeval timeout;
+        int socket = RPC_ANYSOCK;
+
+        if ((hp = gethostbyname(vol->v_gvs)) == NULL)
+            return ((int) RPC_UNKNOWNHOST);
+        timeout.tv_usec = 0;
+        timeout.tv_sec = 6;
+        memcpy(&server_addr.sin_addr, hp->h_addr, hp->h_length);
+        server_addr.sin_family = AF_INET;
+        server_addr.sin_port =  0;
+
+        if ((vol->v_nfsclient = (void *)
+                                clntudp_create(&server_addr, prognum, versnum,
+                                               timeout, &socket)) == NULL)
+            return ((int) rpc_createerr.cf_stat);
+
+        ((CLIENT *) vol->v_nfsclient)->cl_auth = authunix_create_default();
+    }
+
+    tottimeout.tv_sec = 10;
+    tottimeout.tv_usec = 0;
+    clnt_stat = clnt_call((CLIENT *) vol->v_nfsclient, procnum,
+                          inproc, in, outproc, out, tottimeout);
+    return ((int) clnt_stat);
+}
+
+
+/* sunos 4 machines structure things a little differently. */
+#ifdef USE_OLD_RQUOTA
+#define GQR_STATUS gqr_status
+#define GQR_RQUOTA gqr_rquota
+#else /* USE_OLD_RQUOTA */
+#define GQR_STATUS status
+#define GQR_RQUOTA getquota_rslt_u.gqr_rquota
+#endif /* USE_OLD_RQUOTA */
+
+int getnfsquota(struct vol *vol, const int uid, const uint32_t bsize,
+                struct dqblk *dqp)
+{
+
+    struct getquota_args gq_args;
+    struct getquota_rslt gq_rslt;
+    struct timeval tv;
+    char *hostpath;
+
+    /* figure out the host and path */
+    if ((hostpath = strchr(vol->v_gvs, ':')) == NULL) {
+        LOG(log_error, logtype_afpd, "can't find hostname for %s", vol->v_gvs);
+        return AFPERR_PARAM;
+    }
+
+    if (*(hostpath + 1) != '/')
+        return AFPERR_PARAM;
+
+    /* separate host from hostpath */
+    *hostpath = '\0';
+
+    gq_args.gqa_pathp = hostpath + 1;
+    gq_args.gqa_uid = uid;
+
+    if(callaurpc(vol, RQUOTAPROG, RQUOTAVERS, RQUOTAPROC_GETQUOTA,
+                 (xdrproc_t) xdr_getquota_args, (char *) &gq_args,
+                 (xdrproc_t) xdr_getquota_rslt, (char *) &gq_rslt) != 0) {
+        LOG(log_info, logtype_afpd, "nfsquota: can't retrieve nfs quota information. \
+            make sure that rpc.rquotad is running on %s.", vol->v_gvs);
+        *hostpath = ':';
+        return AFPERR_PARAM;
+    }
+
+    switch (gq_rslt.GQR_STATUS) {
+    case Q_NOQUOTA:
+        break;
+
+    case Q_EPERM:
+        LOG(log_error, logtype_afpd, "nfsquota: quota permission error, host: %s",
+            vol->v_gvs);
+        break;
+
+    case Q_OK: /* we only copy the bits that we need. */
+        gettimeofday(&tv, NULL);
+
+#if defined(__svr4__) || defined(TRU64)
+        /* why doesn't using bsize work? */
+#define NFS_BSIZE gq_rslt.GQR_RQUOTA.rq_bsize / DEV_BSIZE
+#else /* __svr4__ || TRU64 */
+        /* NOTE: linux' rquotad program doesn't currently report the
+        * correct rq_bsize. */
+	/* NOTE: This is integer division and can introduce rounding errors */
+#define NFS_BSIZE gq_rslt.GQR_RQUOTA.rq_bsize / bsize
+#endif /* __svr4__  || TRU64 */
+
+        dqp->dqb_bhardlimit =
+            gq_rslt.GQR_RQUOTA.rq_bhardlimit*NFS_BSIZE;
+        dqp->dqb_bsoftlimit =
+            gq_rslt.GQR_RQUOTA.rq_bsoftlimit*NFS_BSIZE;
+        dqp->dqb_curblocks =
+            gq_rslt.GQR_RQUOTA.rq_curblocks*NFS_BSIZE;
+
+#ifdef ultrix
+        dqp->dqb_bwarn = gq_rslt.GQR_RQUOTA.rq_btimeleft;
+#else /* ultrix */
+        dqp->dqb_btimelimit =
+            tv.tv_sec + gq_rslt.GQR_RQUOTA.rq_btimeleft;
+#endif /* ultrix */
+
+        *hostpath = ':';
+        return AFP_OK;
+        break;
+
+    default:
+        LOG(log_info, logtype_afpd, "bad rpc result, host: %s", vol->v_gvs);
+        break;
+    }
+
+    *hostpath = ':';
+    return AFPERR_PARAM;
+}
+#endif /* ! NO_QUOTA_SUPPORT && !HAVE_LIBQUOTA */

--- a/etc/afpd/quota.c
+++ b/etc/afpd/quota.c
@@ -36,14 +36,18 @@
 #include "unix.h"
 
 #ifdef HAVE_LIBQUOTA
-#include <quota/quota.h>
+#include <quota.h>
+
 
 static int
 getfreespace(const AFPObj *obj, struct vol *vol, VolSpace *bfree, VolSpace *btotal,
-	     uid_t uid, const char *classq)
+	     id_t id, int idtype)
 {
-	int retq;
-	struct ufs_quota_entry ufsq[QUOTA_NLIMITS];
+	uid_t prevuid;
+	const char *msg;
+	struct quotahandle *qh;
+	struct quotakey qk;
+	struct quotaval qv;
 	time_t now;
 
 	if (time(&now) == -1) {
@@ -54,62 +58,94 @@ getfreespace(const AFPObj *obj, struct vol *vol, VolSpace *bfree, VolSpace *btot
 
     become_root();
 
-	if ((retq = getfsquota(obj, vol, ufsq, uid, classq)) < 0) {
-		LOG(log_info, logtype_afpd, "getfsquota(%s, %s): %s",
-		    vol->v_path, classq, strerror(errno));
+	/*
+	 * In a tidier world we might keep the quotahandle open for longer...
+	 */
+	qh = quota_open(vol->v_path);
+	if (qh == NULL) {
+		if (errno == EOPNOTSUPP || errno == ENXIO) {
+			/* no quotas on this volume */
+			seteuid( prevuid );
+			return 0;
+		}
+
+		LOG(log_info, logtype_afpd, "quota_open(%s): %s", vol->v_path,
+		    strerror(errno));
+		seteuid( prevuid );
+		return -1;
 	}
+
+	qk.qk_idtype = idtype;
+	qk.qk_id = id;
+	qk.qk_objtype = QUOTA_OBJTYPE_BLOCKS;
+	if (quota_get(qh, &qk, &qv) < 0) {
+		if (errno == ENOENT) {
+			/* no quotas for this id */
+			quota_close(qh);
+			seteuid( prevuid );
+			return 0;
+		}
+		msg = strerror(errno);
+		LOG(log_info, logtype_afpd, "quota_get(%s, %s): %s",
+		    vol->v_path, quota_idtype_getname(qh, idtype), msg);
+		quota_close(qh);
+		seteuid( prevuid );
+		return -1;
+	}
+
+	quota_close(qh);
 
     unbecome_root();
 
-	if (retq < 1)
-		return retq;
-
-	switch(QL_STATUS(quota_check_limit(ufsq[QUOTA_LIMIT_BLOCK].ufsqe_cur, 1,
-	    ufsq[QUOTA_LIMIT_BLOCK].ufsqe_softlimit,
-	    ufsq[QUOTA_LIMIT_BLOCK].ufsqe_hardlimit,
-	    ufsq[QUOTA_LIMIT_BLOCK].ufsqe_time, now))) {
-	case QL_S_DENY_HARD:
-	case QL_S_DENY_GRACE:
+	if (qv.qv_usage >= qv.qv_hardlimit ||
+	    (qv.qv_usage >= qv.qv_softlimit && now > qv.qv_expiretime)) {
 		*bfree = 0;
-		*btotal = dbtob(ufsq[QUOTA_LIMIT_BLOCK].ufsqe_cur);
-		break;
-	default:
-		*bfree = dbtob(ufsq[QUOTA_LIMIT_BLOCK].ufsqe_hardlimit -
-		    ufsq[QUOTA_LIMIT_BLOCK].ufsqe_cur);
-		*btotal = dbtob(ufsq[QUOTA_LIMIT_BLOCK].ufsqe_hardlimit);
-		break;
+		*btotal = dbtob(qv.qv_usage);
 	}
+	else {
+		*bfree = dbtob(qv.qv_hardlimit - qv.qv_usage);
+		*btotal = dbtob(qv.qv_hardlimit);
+	}
+
 	return 1;
 }
 
 int uquota_getvolspace(const AFPObj *obj, struct vol *vol, VolSpace *bfree, VolSpace *btotal, const u_int32_t bsize)
 {
-	int uretq, gretq;
+	int uret, gret;
 	VolSpace ubfree, ubtotal;
 	VolSpace gbfree, gbtotal;
 
-	uretq = getfreespace(obj, vol, &ubfree, &ubtotal,
-			     uuid, QUOTADICT_CLASS_USER);
-	LOG(log_info, logtype_afpd, "getfsquota(%s): %d %d",
-	    vol->v_path, (int)ubfree, (int)ubtotal);
+	uret = getfreespace(obj, vol, &ubfree, &ubtotal,
+	    uuid, QUOTA_IDTYPE_USER);
+	if (uret == 1) {
+		LOG(log_info, logtype_afpd, "quota_get(%s, user): %d %d",
+		    vol->v_path, (int)ubfree, (int)ubtotal);
+	}
+
 	if (obj->ngroups >= 1) {
-		gretq = getfreespace(vol, &ubfree, &ubtotal,
-		    obj->groups[0], QUOTADICT_CLASS_GROUP);
+		gret = getfreespace(obj, vol, &gbfree, &gbtotal,
+		    obj->groups[0], QUOTA_IDTYPE_GROUP);
+		if (gret == 1) {
+			LOG(log_info, logtype_afpd, "quota_get(%s, group): %d %d",
+			    vol->v_path, (int)gbfree, (int)gbtotal);
+		}
 	} else
-		gretq = -1;
-	if (uretq < 1 && gretq < 1) { /* no quota for this fs */
+		gret = 0;
+
+	if (uret < 1 && gret < 1) { /* no quota for this fs */
 		return AFPERR_PARAM;
 	}
-	if (uretq < 1) {
-		/* use group quotas */
+	if (uret < 1) {
+		/* no user quotas, but group quotas; use them */
 		*bfree = gbfree;
 		*btotal = gbtotal;
-	} else if (gretq < 1) {
-		/* use user quotas */
+	} else if (gret < 1) {
+		/* no group quotas, but user quotas; use them */
 		*bfree = ubfree;
 		*btotal = ubtotal;
 	} else {
-		/* return smallest remaining space of user and group */
+		/* both; return smallest remaining space of user and group */
 		if (ubfree < gbfree) {
 			*bfree = ubfree;
 			*btotal = ubtotal;

--- a/etc/afpd/quota.c
+++ b/etc/afpd/quota.c
@@ -1,0 +1,816 @@
+/*
+ *
+ * Copyright (c) 1990,1993 Regents of The University of Michigan.
+ * All Rights Reserved.  See COPYRIGHT.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#ifndef NO_QUOTA_SUPPORT
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/param.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#if defined(HAVE_SYS_MNTTAB_H) || defined(__svr4__)
+#include <sys/mntent.h>
+#endif
+
+#include <atalk/logger.h>
+#include <atalk/afp.h>
+#include <atalk/compat.h>
+#include <atalk/unix.h>
+#include <atalk/util.h>
+
+#include "auth.h"
+#include "volume.h"
+#include "unix.h"
+
+#ifdef HAVE_LIBQUOTA
+#include <quota/quota.h>
+
+static int
+getfreespace(const AFPObj *obj, struct vol *vol, VolSpace *bfree, VolSpace *btotal,
+	     uid_t uid, const char *classq)
+{
+	int retq;
+	struct ufs_quota_entry ufsq[QUOTA_NLIMITS];
+	time_t now;
+
+	if (time(&now) == -1) {
+		LOG(log_info, logtype_afpd, "time(): %s",
+		    strerror(errno));
+		return -1;
+	}
+
+    become_root();
+
+	if ((retq = getfsquota(obj, vol, ufsq, uid, classq)) < 0) {
+		LOG(log_info, logtype_afpd, "getfsquota(%s, %s): %s",
+		    vol->v_path, classq, strerror(errno));
+	}
+
+    unbecome_root();
+
+	if (retq < 1)
+		return retq;
+
+	switch(QL_STATUS(quota_check_limit(ufsq[QUOTA_LIMIT_BLOCK].ufsqe_cur, 1,
+	    ufsq[QUOTA_LIMIT_BLOCK].ufsqe_softlimit,
+	    ufsq[QUOTA_LIMIT_BLOCK].ufsqe_hardlimit,
+	    ufsq[QUOTA_LIMIT_BLOCK].ufsqe_time, now))) {
+	case QL_S_DENY_HARD:
+	case QL_S_DENY_GRACE:
+		*bfree = 0;
+		*btotal = dbtob(ufsq[QUOTA_LIMIT_BLOCK].ufsqe_cur);
+		break;
+	default:
+		*bfree = dbtob(ufsq[QUOTA_LIMIT_BLOCK].ufsqe_hardlimit -
+		    ufsq[QUOTA_LIMIT_BLOCK].ufsqe_cur);
+		*btotal = dbtob(ufsq[QUOTA_LIMIT_BLOCK].ufsqe_hardlimit);
+		break;
+	}
+	return 1;
+}
+
+int uquota_getvolspace(const AFPObj *obj, struct vol *vol, VolSpace *bfree, VolSpace *btotal, const u_int32_t bsize)
+{
+	int uretq, gretq;
+	VolSpace ubfree, ubtotal;
+	VolSpace gbfree, gbtotal;
+
+	uretq = getfreespace(obj, vol, &ubfree, &ubtotal,
+			     uuid, QUOTADICT_CLASS_USER);
+	LOG(log_info, logtype_afpd, "getfsquota(%s): %d %d",
+	    vol->v_path, (int)ubfree, (int)ubtotal);
+	if (obj->ngroups >= 1) {
+		gretq = getfreespace(vol, &ubfree, &ubtotal,
+		    obj->groups[0], QUOTADICT_CLASS_GROUP);
+	} else
+		gretq = -1;
+	if (uretq < 1 && gretq < 1) { /* no quota for this fs */
+		return AFPERR_PARAM;
+	}
+	if (uretq < 1) {
+		/* use group quotas */
+		*bfree = gbfree;
+		*btotal = gbtotal;
+	} else if (gretq < 1) {
+		/* use user quotas */
+		*bfree = ubfree;
+		*btotal = ubtotal;
+	} else {
+		/* return smallest remaining space of user and group */
+		if (ubfree < gbfree) {
+			*bfree = ubfree;
+			*btotal = ubtotal;
+		} else {
+			*bfree = gbfree;
+			*btotal = gbtotal;
+		}
+	}
+	return AFP_OK;
+
+}
+
+#else /* HAVE_LIBQUOTA */
+
+/*
+#define DEBUG_QUOTA 0
+*/
+
+#define WANT_USER_QUOTA 0
+#define WANT_GROUP_QUOTA 1
+
+#ifdef NEED_QUOTACTL_WRAPPER
+int quotactl(int cmd, const char *special, int id, caddr_t addr)
+{
+    return syscall(__NR_quotactl, cmd, special, id, addr);
+}
+#endif /* NEED_QUOTACTL_WRAPPER */
+
+static int overquota( struct dqblk *);
+
+#ifdef linux
+
+#ifdef HAVE_LINUX_XQM_H
+#include <linux/xqm.h>
+#else
+#ifdef HAVE_XFS_XQM_H
+#include <xfs/xqm.h>
+#define HAVE_LINUX_XQM_H
+#else
+#ifdef  HAVE_LINUX_DQBLK_XFS_H
+#include <linux/dqblk_xfs.h>
+#define HAVE_LINUX_XQM_H
+#endif /* HAVE_LINUX_DQBLK_XFS_H */
+#endif /* HAVE_XFS_XQM_H */
+#endif /* HAVE_LINUX_XQM_H */
+
+#include <linux/unistd.h>
+
+static int is_xfs = 0;
+
+static int get_linux_xfs_quota(int, char*, uid_t, struct dqblk *);
+static int get_linux_fs_quota(int, char*, uid_t, struct dqblk *);
+
+/* format supported by current kernel */
+static int kernel_iface = IFACE_UNSET;
+
+/*
+**  Check kernel quota version
+**  Taken from quota-tools 3.08 by Jan Kara <jack@suse.cz>
+*/
+static void linuxquota_get_api( void )
+{
+#ifndef LINUX_API_VERSION
+    struct stat st;
+
+    if (stat("/proc/sys/fs/quota", &st) == 0) {
+        kernel_iface = IFACE_GENERIC;
+    }
+    else {
+        struct dqstats_v2 v2_stats;
+        struct sigaction  sig;
+        struct sigaction  oldsig;
+
+        /* This signal handling is needed because old kernels send us SIGSEGV as they try to resolve the device */
+        sig.sa_handler   = SIG_IGN;
+        sig.sa_sigaction = NULL;
+        sig.sa_flags     = 0;
+        sigemptyset(&sig.sa_mask);
+        if (sigaction(SIGSEGV, &sig, &oldsig) < 0) {
+	    LOG( log_error, logtype_afpd, "cannot set SEGV signal handler: %s", strerror(errno));
+            goto failure;
+        }
+        if (quotactl(QCMD(Q_V2_GETSTATS, 0), NULL, 0, (void *)&v2_stats) >= 0) {
+            kernel_iface = IFACE_VFSV0;
+        }
+        else if (errno != ENOSYS && errno != ENOTSUP) {
+            /* RedHat 7.1 (2.4.2-2) newquota check
+             * Q_V2_GETSTATS in it's old place, Q_GETQUOTA in the new place
+             * (they haven't moved Q_GETSTATS to its new value) */
+            int err_stat = 0;
+            int err_quota = 0;
+            char tmp[1024];         /* Just temporary buffer */
+
+            if (quotactl(QCMD(Q_V1_GETSTATS, 0), NULL, 0, tmp))
+                err_stat = errno;
+            if (quotactl(QCMD(Q_V1_GETQUOTA, 0), "/dev/null", 0, tmp))
+                err_quota = errno;
+
+            /* On a RedHat 2.4.2-2 	we expect 0, EINVAL
+             * On a 2.4.x 		we expect 0, ENOENT
+             * On a 2.4.x-ac	we wont get here */
+            if (err_stat == 0 && err_quota == EINVAL) {
+                kernel_iface = IFACE_VFSV0;
+            }
+            else {
+                kernel_iface = IFACE_VFSOLD;
+            }
+        }
+        else {
+            /* This branch is *not* in quota-tools 3.08
+            ** but without it quota version is not correctly
+            ** identified for the original SuSE 8.0 kernel */
+            unsigned int vers_no;
+            FILE * qf;
+
+            if ((qf = fopen("/proc/fs/quota", "r"))) {
+                if (fscanf(qf, "Version %u", &vers_no) == 1) {
+                    if ( (vers_no == (6*10000 + 5*100 + 0)) ||
+                         (vers_no == (6*10000 + 5*100 + 1)) ) {
+                        kernel_iface = IFACE_VFSV0;
+                    }
+                }
+                fclose(qf);
+            }
+        }
+        if (sigaction(SIGSEGV, &oldsig, NULL) < 0) {
+	    LOG(log_error, logtype_afpd, "cannot reset signal handler: %s", strerror(errno));
+            goto failure;
+        }
+    }
+
+failure:
+    if (kernel_iface == IFACE_UNSET)
+       kernel_iface = IFACE_VFSOLD;
+
+#else /* defined LINUX_API_VERSION */
+    kernel_iface = LINUX_API_VERSION;
+#endif
+}
+
+/****************************************************************************/
+
+static int get_linux_quota(int what, char *path, uid_t euser_id, struct dqblk *dp)
+{
+	int r; /* result */
+
+	if ( is_xfs )
+		r=get_linux_xfs_quota(what, path, euser_id, dp);
+	else
+    		r=get_linux_fs_quota(what, path, euser_id, dp);
+
+	return r;
+}
+
+/****************************************************************************
+ Abstract out the XFS Quota Manager quota get call.
+****************************************************************************/
+
+static int get_linux_xfs_quota(int what, char *path, uid_t euser_id, struct dqblk *dqb)
+{
+	int ret = -1;
+#ifdef HAVE_LINUX_XQM_H
+	struct fs_disk_quota D;
+	
+	memset (&D, 0, sizeof(D));
+
+	if ((ret = quotactl(QCMD(Q_XGETQUOTA,(what ? GRPQUOTA : USRQUOTA)), path, euser_id, (caddr_t)&D)))
+               return ret;
+
+	dqb->bsize = (uint64_t)512;
+        dqb->dqb_bsoftlimit  = (uint64_t)D.d_blk_softlimit;
+        dqb->dqb_bhardlimit  = (uint64_t)D.d_blk_hardlimit;
+        dqb->dqb_ihardlimit  = (uint64_t)D.d_ino_hardlimit;
+        dqb->dqb_isoftlimit  = (uint64_t)D.d_ino_softlimit;
+        dqb->dqb_curinodes   = (uint64_t)D.d_icount;
+        dqb->dqb_curblocks   = (uint64_t)D.d_bcount;
+#endif
+       return ret;
+}
+
+/*
+** Wrapper for the quotactl(GETQUOTA) call.
+** For API v2 the results are copied back into a v1 structure.
+** Taken from quota-1.4.8 perl module
+*/
+static int get_linux_fs_quota(int what, char *path, uid_t euser_id, struct dqblk *dqb)
+{
+	int ret;
+
+	if (kernel_iface == IFACE_UNSET)
+    		linuxquota_get_api();
+
+	if (kernel_iface == IFACE_GENERIC)
+  	{
+    		struct dqblk_v3 dqb3;
+
+    		ret = quotactl(QCMD(Q_V3_GETQUOTA, (what ? GRPQUOTA : USRQUOTA)), path, euser_id, (caddr_t) &dqb3);
+    		if (ret == 0)
+    		{
+      			dqb->dqb_bhardlimit = dqb3.dqb_bhardlimit;
+      			dqb->dqb_bsoftlimit = dqb3.dqb_bsoftlimit;
+      			dqb->dqb_curblocks  = dqb3.dqb_curspace / DEV_QBSIZE;
+      			dqb->dqb_ihardlimit = dqb3.dqb_ihardlimit;
+      			dqb->dqb_isoftlimit = dqb3.dqb_isoftlimit;
+      			dqb->dqb_curinodes  = dqb3.dqb_curinodes;
+      			dqb->dqb_btime      = dqb3.dqb_btime;
+      			dqb->dqb_itime      = dqb3.dqb_itime;
+			dqb->bsize	    = DEV_QBSIZE;
+    		}
+  	}
+  	else if (kernel_iface == IFACE_VFSV0)
+  	{
+    		struct dqblk_v2 dqb2;
+
+    		ret = quotactl(QCMD(Q_V2_GETQUOTA, (what ? GRPQUOTA : USRQUOTA)), path, euser_id, (caddr_t) &dqb2);
+    		if (ret == 0)
+    		{
+      			dqb->dqb_bhardlimit = dqb2.dqb_bhardlimit;
+      			dqb->dqb_bsoftlimit = dqb2.dqb_bsoftlimit;
+      			dqb->dqb_curblocks  = dqb2.dqb_curspace / DEV_QBSIZE;
+      			dqb->dqb_ihardlimit = dqb2.dqb_ihardlimit;
+      			dqb->dqb_isoftlimit = dqb2.dqb_isoftlimit;
+      			dqb->dqb_curinodes  = dqb2.dqb_curinodes;
+      			dqb->dqb_btime      = dqb2.dqb_btime;
+      			dqb->dqb_itime      = dqb2.dqb_itime;
+			dqb->bsize	    = DEV_QBSIZE;
+    		}
+  	}
+  	else /* if (kernel_iface == IFACE_VFSOLD) */
+  	{
+    		struct dqblk_v1 dqb1;
+
+    		ret = quotactl(QCMD(Q_V1_GETQUOTA, (what ? GRPQUOTA : USRQUOTA)), path, euser_id, (caddr_t) &dqb1);
+    		if (ret == 0)
+    		{
+      			dqb->dqb_bhardlimit = dqb1.dqb_bhardlimit;
+      			dqb->dqb_bsoftlimit = dqb1.dqb_bsoftlimit;
+      			dqb->dqb_curblocks  = dqb1.dqb_curblocks;
+      			dqb->dqb_ihardlimit = dqb1.dqb_ihardlimit;
+      			dqb->dqb_isoftlimit = dqb1.dqb_isoftlimit;
+      			dqb->dqb_curinodes  = dqb1.dqb_curinodes;
+      			dqb->dqb_btime      = dqb1.dqb_btime;
+      			dqb->dqb_itime      = dqb1.dqb_itime;
+			dqb->bsize	    = DEV_QBSIZE;
+    		}
+  	}
+  	return ret;
+}
+
+#endif /* linux */
+
+#if defined(HAVE_SYS_MNTTAB_H) || defined(__svr4__)
+/*
+ * Return the mount point associated with the filesystem
+ * on which "file" resides.  Returns NULL on failure.
+ */
+static char *
+mountp( char *file, int *nfs)
+{
+    struct stat			sb;
+    FILE 			*mtab;
+    dev_t			devno;
+    static struct mnttab	mnt;
+
+    if (stat(file, &sb) < 0) {
+        return( NULL );
+    }
+    devno = sb.st_dev;
+
+    if (( mtab = fopen( "/etc/mnttab", "r" )) == NULL ) {
+        return( NULL );
+    }
+
+    while ( getmntent( mtab, &mnt ) == 0 ) {
+        /* local fs */
+        if ( (stat( mnt.mnt_special, &sb ) == 0) && (devno == sb.st_rdev)) {
+            fclose( mtab );
+            return mnt.mnt_mountp;
+        }
+
+        /* check for nfs. */
+        if ((stat(mnt.mnt_mountp, &sb) == 0) && (devno == sb.st_dev)) {
+            *nfs = strcmp(mnt.mnt_fstype, MNTTYPE_NFS) == 0 ? 1 : 0;
+            fclose( mtab );
+            return mnt.mnt_special;
+        }
+    }
+
+    fclose( mtab );
+    return( NULL );
+}
+
+#else /* __svr4__ */
+#ifdef ultrix
+/*
+* Return the block-special device name associated with the filesystem
+* on which "file" resides.  Returns NULL on failure.
+*/
+
+static char *
+special( char *file, int *nfs)
+{
+    static struct fs_data	fsd;
+
+    if ( getmnt(0, &fsd, 0, STAT_ONE, file ) < 0 ) {
+        LOG(log_info, logtype_afpd, "special: getmnt %s: %s", file, strerror(errno) );
+        return( NULL );
+    }
+
+    /* XXX: does this really detect an nfs mounted fs? */
+    if (strchr(fsd.fd_req.devname, ':'))
+        *nfs = 1;
+    return( fsd.fd_req.devname );
+}
+
+#else /* ultrix */
+#if (defined(HAVE_SYS_MOUNT_H) && !defined(__linux__)) || defined(BSD4_4) || defined(_IBMR2)
+
+static char *
+special(char *file, int *nfs)
+{
+    static struct statfs	sfs;
+
+    if ( statfs( file, &sfs ) < 0 ) {
+        return( NULL );
+    }
+
+#ifdef TRU64
+    /* Digital UNIX: The struct sfs contains a field sfs.f_type,
+     * the MOUNT_* constants are defined in <sys/mount.h> */
+    if ((sfs.f_type == MOUNT_NFS)||(sfs.f_type == MOUNT_NFS3))
+#else /* TRU64 */
+    /* XXX: make sure this really detects an nfs mounted fs */
+    if (strchr(sfs.f_mntfromname, ':'))
+#endif /* TRU64 */
+        *nfs = 1;
+    return( sfs.f_mntfromname );
+}
+
+#else /* BSD4_4 */
+
+static char *
+special(char *file, int *nfs)
+{
+    struct stat		sb;
+    FILE 		*mtab;
+    dev_t		devno;
+    struct mntent	*mnt;
+    int 		found=0;
+
+    if (stat(file, &sb) < 0 ) {
+        return( NULL );
+    }
+    devno = sb.st_dev;
+
+    if (( mtab = setmntent( "/etc/mtab", "r" )) == NULL ) {
+        return( NULL );
+    }
+
+    while (( mnt = getmntent( mtab )) != NULL ) {
+        /* check for local fs */
+        if ( (stat( mnt->mnt_fsname, &sb ) == 0) && devno == sb.st_rdev) {
+	    found = 1;
+	    break;
+        }
+
+        /* check for an nfs mount entry. the alternative is to use
+        * strcmp(mnt->mnt_type, MNTTYPE_NFS) instead of the strchr. */
+        if ((stat(mnt->mnt_dir, &sb) == 0) && (devno == sb.st_dev) &&
+                strchr(mnt->mnt_fsname, ':')) {
+            *nfs = 1;
+	    found = 1;
+	    break;
+        }
+    }
+
+    endmntent( mtab );
+
+    if (!found)
+	return (NULL);
+#ifdef linux
+    if (strcmp(mnt->mnt_type, "xfs") == 0)
+	is_xfs = 1;
+#endif
+	
+    return( mnt->mnt_fsname );
+}
+
+#endif /* BSD4_4 */
+#endif /* ultrix */
+#endif /* __svr4__ */
+
+
+static int getfsquota(const AFPObj *obj, struct vol *vol, const int uid, struct dqblk *dq)
+
+{
+	struct dqblk dqg;
+
+#ifdef __svr4__
+    struct quotctl      qc;
+#endif
+
+    memset(dq, 0, sizeof(struct dqblk));
+    memset(&dqg, 0, sizeof(dqg));
+	
+#ifdef __svr4__
+    qc.op = Q_GETQUOTA;
+    qc.uid = uid;
+    qc.addr = (caddr_t)dq;
+    if ( ioctl( vol->v_qfd, Q_QUOTACTL, &qc ) < 0 ) {
+        return( AFPERR_PARAM );
+    }
+
+#else /* __svr4__ */
+#ifdef ultrix
+    if ( quota( Q_GETDLIM, uid, vol->v_gvs, dq ) != 0 ) {
+        return( AFPERR_PARAM );
+    }
+#else /* ultrix */
+
+#ifndef USRQUOTA
+#define USRQUOTA   0
+#endif
+
+#ifndef QCMD
+#define QCMD(a,b)  (a)
+#endif
+
+#ifndef TRU64
+    /* for group quotas. we only use these if the user belongs
+    * to one group. */
+#endif /* TRU64 */
+
+#ifdef BSD4_4
+    become_root();
+        if ( quotactl( vol->v_path, QCMD(Q_GETQUOTA,USRQUOTA),
+                       uid, (char *)dq ) != 0 ) {
+            /* try group quotas */
+            if (obj->ngroups >= 1) {
+                if ( quotactl(vol->v_path, QCMD(Q_GETQUOTA, GRPQUOTA),
+                              obj->groups[0], (char *) &dqg) != 0 ) {
+                    unbecome_root();
+                    return( AFPERR_PARAM );
+                }
+            }
+        }
+        unbecome_root();
+    }
+
+#else /* BSD4_4 */
+    if (get_linux_quota (WANT_USER_QUOTA, vol->v_gvs, uid, dq) !=0) {
+#ifdef DEBUG_QUOTA
+        LOG(log_debug, logtype_afpd, "user quota did not work!" );
+#endif /* DEBUG_QUOTA */
+    }
+
+    if (get_linux_quota(WANT_GROUP_QUOTA, vol->v_gvs, getegid(),  &dqg) != 0) {
+#ifdef DEBUG_QUOTA
+        LOG(log_debug, logtype_afpd, "group quota did not work!" );
+#endif /* DEBUG_QUOTA */
+
+	return AFP_OK; /* no need to check user vs group quota */
+    }
+#endif  /* BSD4_4 */
+
+
+#ifndef TRU64
+    /* return either the group quota entry or user quota entry,
+       whichever has the least amount of space remaining
+    */
+
+    /* if user space remaining > group space remaining */
+    if(
+        /* if overquota, free space is 0 otherwise hard-current */
+        ( overquota( dq ) ? 0 : ( dq->dqb_bhardlimit ? dq->dqb_bhardlimit -
+                                  dq->dqb_curblocks : ~((uint64_t) 0) ) )
+
+      >
+
+        ( overquota( &dqg ) ? 0 : ( dqg.dqb_bhardlimit ? dqg.dqb_bhardlimit -
+                                    dqg.dqb_curblocks : ~((uint64_t) 0) ) )
+
+      ) /* if */
+    {
+        /* use group quota limits rather than user limits */
+        dq->dqb_bhardlimit = dqg.dqb_bhardlimit;
+        dq->dqb_bsoftlimit = dqg.dqb_bsoftlimit;
+        dq->dqb_curblocks = dqg.dqb_curblocks;
+        dq->dqb_ihardlimit = dqg.dqb_ihardlimit;
+        dq->dqb_isoftlimit = dqg.dqb_isoftlimit;
+        dq->dqb_curinodes = dqg.dqb_curinodes;
+        dq->dqb_btime = dqg.dqb_btime;
+        dq->dqb_itime = dqg.dqb_itime;
+        dq->bsize = dqg.bsize;
+    } /* if */
+
+#endif /* TRU64 */
+
+#endif /* ultrix */
+#endif /* __svr4__ */
+
+    return AFP_OK;
+}
+
+
+static int getquota(const AFPObj *obj, struct vol *vol, struct dqblk *dq, const uint32_t bsize)
+{
+    char *p;
+
+#ifdef __svr4__
+    char		buf[ MAXPATHLEN + 1];
+
+    if ( vol->v_qfd == -1 && vol->v_gvs == NULL) {
+        if (( p = mountp( vol->v_path, &vol->v_nfs)) == NULL ) {
+            LOG(log_info, logtype_afpd, "getquota: mountp %s fails", vol->v_path );
+            return( AFPERR_PARAM );
+        }
+
+        if (vol->v_nfs) {
+            if (( vol->v_gvs = (char *)malloc( strlen( p ) + 1 )) == NULL ) {
+                LOG(log_error, logtype_afpd, "getquota: malloc: %s", strerror(errno) );
+                return AFPERR_MISC;
+            }
+            strcpy( vol->v_gvs, p );
+
+        } else {
+            sprintf( buf, "%s/quotas", p );
+            if (( vol->v_qfd = open( buf, O_RDONLY, 0 )) < 0 ) {
+                LOG(log_info, logtype_afpd, "open %s: %s", buf, strerror(errno) );
+                return( AFPERR_PARAM );
+            }
+        }
+
+    }
+#else
+    if ( vol->v_gvs == NULL ) {
+        if (( p = special( vol->v_path, &vol->v_nfs )) == NULL ) {
+            LOG(log_info, logtype_afpd, "getquota: special %s fails", vol->v_path );
+            return( AFPERR_PARAM );
+        }
+
+        if (( vol->v_gvs = (char *)malloc( strlen( p ) + 1 )) == NULL ) {
+            LOG(log_error, logtype_afpd, "getquota: malloc: %s", strerror(errno) );
+            return AFPERR_MISC;
+        }
+        strcpy( vol->v_gvs, p );
+    }
+#endif
+
+#ifdef TRU64
+    /* Digital UNIX: Two forms of specifying an NFS filesystem are possible,
+       either 'hostname:path' or 'path@hostname' (Ultrix heritage) */
+    if (vol->v_nfs) {
+	char *hostpath;
+	char pathstring[MNAMELEN];
+	/* MNAMELEN ist defined in <sys/mount.h> */
+	int result;
+	
+	if ((hostpath = strchr(vol->v_gvs,'@')) != NULL ) {
+	    /* convert 'path@hostname' to 'hostname:path',
+	     * call getnfsquota(),
+	     * convert 'hostname:path' back to 'path@hostname' */
+	    *hostpath = '\0';
+	    sprintf(pathstring,"%s:%s",hostpath+1,vol->v_gvs);
+	    strcpy(vol->v_gvs,pathstring);
+	
+	    result = getnfsquota(vol, uuid, bsize, dq);
+	
+	    hostpath = strchr(vol->v_gvs,':');
+	    *hostpath = '\0';
+	    sprintf(pathstring,"%s@%s",hostpath+1,vol->v_gvs);
+	    strcpy(vol->v_gvs,pathstring);
+	
+	    return result;
+	}
+	else
+	    /* vol->v_gvs is of the form 'hostname:path' */
+	    return getnfsquota(vol, uuid, bsize, dq);
+    } else
+	/* local filesystem */
+      return getfsquota(obj, vol, obj->uid, dq);
+	
+#else /* TRU64 */
+    return vol->v_nfs ? getnfsquota(vol, obj->uid, bsize, dq) :
+      getfsquota(obj, vol, obj->uid, dq);
+#endif /* TRU64 */
+}
+
+static int overquota( struct dqblk *dqblk)
+{
+    struct timeval	tv;
+
+    if ( dqblk->dqb_curblocks > dqblk->dqb_bhardlimit &&
+         dqblk->dqb_bhardlimit != 0 ) {
+        return( 1 );
+    }
+
+    if ( dqblk->dqb_curblocks < dqblk->dqb_bsoftlimit ||
+         dqblk->dqb_bsoftlimit == 0 ) {
+        return( 0 );
+    }
+#ifdef ultrix
+    if ( dqblk->dqb_bwarn ) {
+        return( 0 );
+    }
+#else /* ultrix */
+    if ( gettimeofday( &tv, NULL ) < 0 ) {
+        LOG(log_error, logtype_afpd, "overquota: gettimeofday: %s", strerror(errno) );
+        return( AFPERR_PARAM );
+    }
+    if ( dqblk->dqb_btimelimit && dqblk->dqb_btimelimit > tv.tv_sec ) {
+        return( 0 );
+    }
+#endif /* ultrix */
+    return( 1 );
+}
+
+/*
+ * This next bit is basically for linux -- everything is fine
+ * if you use 1k blocks... but if you try (for example) to mount
+ * a volume via nfs from a netapp (which might use 4k blocks) everything
+ * gets reported improperly.  I have no idea about dbtob on other
+ * platforms.
+ */
+
+#ifdef HAVE_BROKEN_DBTOB
+#undef dbtob
+#define dbtob(a, b)	((VolSpace)((VolSpace)(a) * (VolSpace)(b)))
+#define HAVE_2ARG_DBTOB
+#endif
+
+#ifndef dbtob
+#define dbtob(a)       ((a) << 10)
+#endif
+
+/* i do the cast to VolSpace here to make sure that 64-bit shifts
+   work */
+#ifdef HAVE_2ARG_DBTOB
+#define tobytes(a, b)  dbtob((VolSpace) (a), (VolSpace) (b))
+#else
+#define tobytes(a, b)  dbtob((VolSpace) (a))
+#endif
+
+int uquota_getvolspace(const AFPObj *obj, struct vol *vol, VolSpace *bfree, VolSpace *btotal, const uint32_t bsize)
+{
+	uint64_t this_bsize;
+	struct dqblk dqblk;
+
+	this_bsize = bsize;
+			
+	if (getquota(obj, vol, &dqblk, bsize) != 0 ) {
+		return( AFPERR_PARAM );
+	}
+
+#ifdef linux
+	this_bsize = dqblk.bsize;
+#endif
+
+#ifdef DEBUG_QUOTA
+        LOG(log_debug, logtype_afpd, "after calling getquota in uquota_getvolspace!" );
+        LOG(log_debug, logtype_afpd, "dqb_ihardlimit: %u", dqblk.dqb_ihardlimit );
+        LOG(log_debug, logtype_afpd, "dqb_isoftlimit: %u", dqblk.dqb_isoftlimit );
+        LOG(log_debug, logtype_afpd, "dqb_curinodes : %u", dqblk.dqb_curinodes );
+        LOG(log_debug, logtype_afpd, "dqb_bhardlimit: %u", dqblk.dqb_bhardlimit );
+        LOG(log_debug, logtype_afpd, "dqb_bsoftlimit: %u", dqblk.dqb_bsoftlimit );
+        LOG(log_debug, logtype_afpd, "dqb_curblocks : %u", dqblk.dqb_curblocks );
+        LOG(log_debug, logtype_afpd, "dqb_btime     : %u", dqblk.dqb_btime );
+        LOG(log_debug, logtype_afpd, "dqb_itime     : %u", dqblk.dqb_itime );
+        LOG(log_debug, logtype_afpd, "bsize/this_bsize : %u/%u", bsize, this_bsize );
+	LOG(log_debug, logtype_afpd, "dqblk.dqb_bhardlimit size: %u", tobytes( dqblk.dqb_bhardlimit, this_bsize ));
+	LOG(log_debug, logtype_afpd, "dqblk.dqb_bsoftlimit size: %u", tobytes( dqblk.dqb_bsoftlimit, this_bsize ));
+	LOG(log_debug, logtype_afpd, "dqblk.dqb_curblocks  size: %u", tobytes( dqblk.dqb_curblocks, this_bsize ));
+#endif /* DEBUG_QUOTA */
+
+	/* no limit set for this user. it might be set in the future. */
+	if (dqblk.dqb_bsoftlimit == 0 && dqblk.dqb_bhardlimit == 0) {
+        	*btotal = *bfree = ~((VolSpace) 0);
+    	} else if ( overquota( &dqblk )) {
+        	if ( tobytes( dqblk.dqb_curblocks, this_bsize ) > tobytes( dqblk.dqb_bsoftlimit, this_bsize ) ) {
+            		*btotal = tobytes( dqblk.dqb_curblocks, this_bsize );
+            		*bfree = 0;
+        	}
+        	else {
+            		*btotal = tobytes( dqblk.dqb_bsoftlimit, this_bsize );
+            		*bfree  = tobytes( dqblk.dqb_bsoftlimit, this_bsize ) -
+                     		  tobytes( dqblk.dqb_curblocks, this_bsize );
+        	}
+    	} else {
+        	*btotal = tobytes( dqblk.dqb_bhardlimit, this_bsize );
+        	*bfree  = tobytes( dqblk.dqb_bhardlimit, this_bsize  ) -
+                 	  tobytes( dqblk.dqb_curblocks, this_bsize );
+    	}
+
+#ifdef DEBUG_QUOTA
+        LOG(log_debug, logtype_afpd, "bfree          : %u", *bfree );
+        LOG(log_debug, logtype_afpd, "btotal         : %u", *btotal );
+        LOG(log_debug, logtype_afpd, "bfree          : %uKB", *bfree/1024 );
+        LOG(log_debug, logtype_afpd, "btotal         : %uKB", *btotal/1024 );
+#endif
+
+	return( AFP_OK );
+}
+#endif /* HAVE_LIBQUOTA */
+#endif

--- a/etc/afpd/unix.h
+++ b/etc/afpd/unix.h
@@ -41,7 +41,7 @@
 #define dqb_btimelimit  dqb_btime
 #endif /* ! __svr4__ || HAVE_DQB_BTIMELIMIT */
 
-#if defined(linux) || defined(ultrix) || defined(HAVE_QUOTA_H)
+#if defined(linux) || defined(HAVE_QUOTA_H)
 #ifndef NEED_QUOTACTL_WRAPPER
 /*#include <sys/quota.h>*/
 /*long quotactl (int, const char *, unsigned int, caddr_t); */
@@ -52,23 +52,23 @@
 #include <asm/unistd.h>
 #include <linux/quota.h>
 #endif /* ! NEED_QUOTACTL_WRAPPER */
-#endif /* linux || ultrix || HAVE_QUOTA_H */
+#endif /* linux || HAVE_QUOTA_H */
 
 #ifdef __svr4__
 #include <sys/fs/ufs_quota.h>
 #endif /* __svr4__ */
 
 #ifdef BSD4_4
+#if defined(__DragonFly__)
+#include <vfs/ufs/quota.h>
+#else /* DragonFly */
 #include <ufs/ufs/quota.h>
+#endif /* DragonFly */
 #endif /* BSD4_4 */
 
 #ifdef HAVE_UFS_QUOTA_H
 #include <ufs/quota.h>
 #endif /* HAVE_UFS_QUOTA_H */
-
-#ifdef _IBMR2
-#include <jfs/quota.h>
-#endif /* _IBMR2 */
 
 #include <unistd.h>
 #include <sys/types.h>

--- a/etc/afpd/unix.h
+++ b/etc/afpd/unix.h
@@ -33,6 +33,166 @@
 #include <mntent.h>
 #endif /* HAVE_MNTENT_H */
 
+
+#ifndef NO_QUOTA_SUPPORT
+#if !defined(HAVE_LIBQUOTA)
+
+#if !(defined(__svr4__) || defined(HAVE_DQB_BTIMELIMIT))
+#define dqb_btimelimit  dqb_btime
+#endif /* ! __svr4__ || HAVE_DQB_BTIMELIMIT */
+
+#if defined(linux) || defined(ultrix) || defined(HAVE_QUOTA_H)
+#ifndef NEED_QUOTACTL_WRAPPER
+/*#include <sys/quota.h>*/
+/*long quotactl (int, const char *, unsigned int, caddr_t); */
+/* extern long quotactl (int, const char *, long, caddr_t); */
+
+#else /* ! NEED_QUOTACTL_WRAPPER */
+#include <asm/types.h>
+#include <asm/unistd.h>
+#include <linux/quota.h>
+#endif /* ! NEED_QUOTACTL_WRAPPER */
+#endif /* linux || ultrix || HAVE_QUOTA_H */
+
+#ifdef __svr4__
+#include <sys/fs/ufs_quota.h>
+#endif /* __svr4__ */
+
+#ifdef BSD4_4
+#include <ufs/ufs/quota.h>
+#endif /* BSD4_4 */
+
+#ifdef HAVE_UFS_QUOTA_H
+#include <ufs/quota.h>
+#endif /* HAVE_UFS_QUOTA_H */
+
+#ifdef _IBMR2
+#include <jfs/quota.h>
+#endif /* _IBMR2 */
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include "directory.h"
+
+
+#if defined (linux)
+
+#define MAXQUOTAS 2
+
+/* definitions from sys/quota.h */
+#define USRQUOTA  0             /* element used for user quotas */
+#define GRPQUOTA  1             /* element used for group quotas */
+
+/*
+ * Command definitions for the 'quotactl' system call.
+ * The commands are broken into a main command defined below
+ * and a subcommand that is used to convey the type of
+ * quota that is being manipulated (see above).
+ */
+#define SUBCMDMASK  0x00ff
+#define SUBCMDSHIFT 8
+#define QCMD(cmd, type)  (((cmd) << SUBCMDSHIFT) | ((type) & SUBCMDMASK))
+
+/* declare an internal version of the quota block struct */
+typedef u_int64_t qsize_t;	/* Type in which we store size limitations */
+typedef u_int32_t qid_t;	/* Type in which we store ids in memory */
+
+struct dqblk {
+  qsize_t bsize;
+  qsize_t dqb_ihardlimit;   /* absolute limit on allocated inodes */
+  qsize_t dqb_isoftlimit;   /* preferred inode limit */
+  qsize_t dqb_curinodes;    /* current # allocated inodes */
+  qsize_t dqb_bhardlimit;   /* absolute limit on disk blks alloc */
+  qsize_t dqb_bsoftlimit;   /* preferred limit on disk blks */
+  qsize_t dqb_curblocks;    /* current block count */
+  time_t  dqb_btime;        /* time limit for excessive disk use */
+  time_t  dqb_itime;        /* time limit for excessive inode use */
+};
+
+/* API v1 command definitions */
+#define Q_V1_GETQUOTA  0x0300
+#define Q_V1_SYNC      0x0600
+#define Q_V1_SETQLIM   0x0700
+#define Q_V1_GETSTATS  0x0800
+/* API v2 command definitions */
+#define Q_V2_SYNC      0x0600
+#define Q_V2_SETQLIM   0x0700
+#define Q_V2_GETQUOTA  0x0D00
+#define Q_V2_GETSTATS  0x1100
+/* proc API command definitions */
+#define Q_V3_SYNC      0x800001
+#define Q_V3_GETQUOTA  0x800007
+#define Q_V3_SETQUOTA  0x800008
+
+/* Interface versions */
+#define IFACE_UNSET 0
+#define IFACE_VFSOLD 1
+#define IFACE_VFSV0 2
+#define IFACE_GENERIC 3
+
+#define DEV_QBSIZE 1024
+
+struct dqblk_v3 {
+  u_int64_t dqb_bhardlimit;
+  u_int64_t dqb_bsoftlimit;
+  u_int64_t dqb_curspace;
+  u_int64_t dqb_ihardlimit;
+  u_int64_t dqb_isoftlimit;
+  u_int64_t dqb_curinodes;
+  u_int64_t dqb_btime;
+  u_int64_t dqb_itime;
+  u_int32_t dqb_valid;
+};
+
+struct dqblk_v2 {
+  unsigned int dqb_ihardlimit;
+  unsigned int dqb_isoftlimit;
+  unsigned int dqb_curinodes;
+  unsigned int dqb_bhardlimit;
+  unsigned int dqb_bsoftlimit;
+  qsize_t dqb_curspace;
+  time_t dqb_btime;
+  time_t dqb_itime;
+};
+
+struct dqstats_v2 {
+  u_int32_t lookups;
+  u_int32_t drops;
+  u_int32_t reads;
+  u_int32_t writes;
+  u_int32_t cache_hits;
+  u_int32_t allocated_dquots;
+  u_int32_t free_dquots;
+  u_int32_t syncs;
+  u_int32_t version;
+};
+
+struct dqblk_v1 {
+  u_int32_t dqb_bhardlimit;
+  u_int32_t dqb_bsoftlimit;
+  u_int32_t dqb_curblocks;
+  u_int32_t dqb_ihardlimit;
+  u_int32_t dqb_isoftlimit;
+  u_int32_t dqb_curinodes;
+  time_t dqb_btime;
+  time_t dqb_itime;
+};
+
+extern long quotactl (unsigned int, const char *, int, caddr_t);
+
+
+
+#endif /* linux */
+
+extern int getnfsquota (struct vol *, const int, const uint32_t,
+                        struct dqblk *);
+
+#endif /* ! HAVE_LIBQUOTA */
+extern int uquota_getvolspace (const AFPObj *obj, struct vol *, VolSpace *, VolSpace *,
+                               const uint32_t);
+#endif /* NO_QUOTA_SUPPORT */
+
 extern struct afp_options default_options;
 
 extern int setdirunixmode   (const struct vol *, char *, mode_t);

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -50,6 +50,7 @@
 #include <atalk/util.h>
 #include <atalk/uuid.h>
 #include <atalk/vfs.h>
+#include <atalk/volume.h>
 
 #include "acls.h"
 #include "directory.h"
@@ -230,6 +231,7 @@ static int getvolspace(const AFPObj *obj, struct vol *vol,
     uint32_t   maxsize;
 #ifndef NO_QUOTA_SUPPORT
     VolSpace    qfree, qtotal;
+    int         spaceflag = AFPVOL_GVSMASK & vol->v_flags;
 #endif
 
     /* report up to 2GB if afp version is < 2.2 (4GB if not) */

--- a/include/atalk/volume.h
+++ b/include/atalk/volume.h
@@ -111,9 +111,12 @@ typedef enum {
 /* volume flags */
 #define AFPVOL_OPEN (1<<0)
 
+/* flags for quota 0xxx0 */
 #define AFPVOL_GVSMASK  (7<<2)
 #define AFPVOL_NONE     (0<<2)
+// Previously used for Andrew File System: AFPVOL_AFSGVS   (1<<2)
 #define AFPVOL_USTATFS  (1<<3)
+#define AFPVOL_UQUOTA   (1<<4)
 
 #define AFPVOL_NOV2TOEACONV (1 << 5) /* no adouble:v2 to adouble:ea conversion */
 #define AFPVOL_SPOTLIGHT (1 << 6)   /* Index volume for Spotlight searches */

--- a/libatalk/compat/Makefile.am
+++ b/libatalk/compat/Makefile.am
@@ -2,9 +2,10 @@
 
 noinst_LTLIBRARIES = libcompat.la
 
-libcompat_la_CFLAGS =
-libcompat_la_LIBADD =
+libcompat_la_CFLAGS = @QUOTA_CFLAGS@
+libcompat_la_LIBADD = @QUOTA_LIBS@
 
 libcompat_la_SOURCES =	\
 	misc.c \
+	rquota_xdr.c	\
 	strlcpy.c

--- a/libatalk/compat/meson.build
+++ b/libatalk/compat/meson.build
@@ -1,5 +1,6 @@
 compat_sources = [
     'misc.c',
+    'rquota_xdr.c',
     'strlcpy.c',
 ]
 
@@ -7,5 +8,7 @@ libcompat = static_library(
     'compat',
     compat_sources,
     include_directories: root_includes,
+    dependencies: tirpc,
+    link_args: quota_link_args,
     install: false,
 )

--- a/libatalk/compat/rquota_xdr.c
+++ b/libatalk/compat/rquota_xdr.c
@@ -1,0 +1,122 @@
+/*
+ *
+ * taken from the quota-1.55 used on linux. here's the bsd copyright:
+ *
+ * Copyright (c) 1980, 1990 Regents of the University of California. All
+ * rights reserved.
+ *
+ * This code is derived from software contributed to Berkeley by Robert Elz at
+ * The University of Melbourne.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <stdio.h> /* to get __GNU_LIBRARY__ */
+
+/* list of machines that don't have these functions:
+	solaris
+	linux libc5
+*/
+#if defined(NEED_RQUOTA) || defined(SOLARIS) || (defined(__GNU_LIBRARY__) && __GNU_LIBRARY__ < 6)
+
+#include <rpc/rpc.h>
+#include <rpcsvc/rquota.h>
+
+#ifndef u_int
+#define u_int unsigned
+#endif
+
+bool_t
+xdr_getquota_args(xdrs, objp)
+	XDR *xdrs;
+	getquota_args *objp;
+{
+	if (!xdr_string(xdrs, &objp->gqa_pathp, RQ_PATHLEN)) {
+		return (FALSE);
+	}
+	if (!xdr_int(xdrs, &objp->gqa_uid)) {
+		return (FALSE);
+	}
+	return (TRUE);
+}
+
+
+bool_t
+xdr_rquota(xdrs, objp)
+	XDR *xdrs;
+	rquota *objp;
+{
+	if (!xdr_int(xdrs, &objp->rq_bsize)) {
+		return (FALSE);
+	}
+	if (!xdr_bool(xdrs, &objp->rq_active)) {
+		return (FALSE);
+	}
+	if (!xdr_u_int(xdrs, &objp->rq_bhardlimit)) {
+		return (FALSE);
+	}
+	if (!xdr_u_int(xdrs, &objp->rq_bsoftlimit)) {
+		return (FALSE);
+	}
+	if (!xdr_u_int(xdrs, &objp->rq_curblocks)) {
+		return (FALSE);
+	}
+	if (!xdr_u_int(xdrs, &objp->rq_fhardlimit)) {
+		return (FALSE);
+	}
+	if (!xdr_u_int(xdrs, &objp->rq_fsoftlimit)) {
+		return (FALSE);
+	}
+	if (!xdr_u_int(xdrs, &objp->rq_curfiles)) {
+		return (FALSE);
+	}
+	if (!xdr_u_int(xdrs, &objp->rq_btimeleft)) {
+		return (FALSE);
+	}
+	if (!xdr_u_int(xdrs, &objp->rq_ftimeleft)) {
+		return (FALSE);
+	}
+	return (TRUE);
+}
+
+
+
+
+bool_t
+xdr_gqr_status(xdrs, objp)
+	XDR *xdrs;
+	gqr_status *objp;
+{
+	if (!xdr_enum(xdrs, (enum_t *)objp)) {
+		return (FALSE);
+	}
+	return (TRUE);
+}
+
+
+bool_t
+xdr_getquota_rslt(xdrs, objp)
+	XDR *xdrs;
+	getquota_rslt *objp;
+{
+	if (!xdr_gqr_status(xdrs, &objp->status)) {
+		return (FALSE);
+	}
+	switch (objp->status) {
+	case Q_OK:
+		if (!xdr_rquota(xdrs, &objp->getquota_rslt_u.gqr_rquota)) {
+			return (FALSE);
+		}
+		break;
+	case Q_NOQUOTA:
+		break;
+	case Q_EPERM:
+		break;
+	default:
+		return (FALSE);
+	}
+	return (TRUE);
+}
+#endif

--- a/macros/Makefile.am
+++ b/macros/Makefile.am
@@ -12,6 +12,7 @@ EXTRA_DIST = \
 	pam-check.m4		\
 	perl-check.m4		\
 	ps-check.m4		\
+	quota-check.m4		\
 	ssl-check.m4		\
 	summary.m4		\
 	tcp-wrappers.m4		\

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -683,6 +683,17 @@ dnl ----- Linux specific -----
 if test x"$this_os" = "xlinux"; then
 	AC_MSG_RESULT([ * Linux specific configuration])
     AC_DEFINE(LINUX, 1, [OS is Linux])	
+	dnl ----- check if we need the quotactl wrapper
+    AC_CHECK_HEADERS(linux/dqblk_xfs.h,,
+		[AC_CHECK_HEADERS(linux/xqm.h linux/xfs_fs.h)
+        	AC_CHECK_HEADERS(xfs/libxfs.h xfs/xqm.h xfs/xfs_fs.h)]
+	)
+
+
+	dnl ----- as far as I can tell, dbtob always does the wrong thing
+	dnl ----- on every single version of linux I've ever played with.
+	dnl ----- see etc/afpd/quota.c
+	AC_DEFINE(HAVE_BROKEN_DBTOB, 1, [Define if dbtob is broken])
 fi
 
 dnl ----- NetBSD specific -----
@@ -716,6 +727,12 @@ if test x"$this_os" = "xsolaris"; then
     AC_DEFINE(_XOPEN_SOURCE, 600, [Solaris compilation environment])
     AC_DEFINE(__EXTENSIONS__,  1, [Solaris compilation environment])
 	init_style=solaris
+fi
+
+dnl ----- macOS specific -----
+if test x"$this_os" = "xmacosx"; then
+	AC_MSG_RESULT([ * macOS specific configuration])
+    AC_DEFINE(NO_QUOTA_SUPPORT, 1, [No quota support])
 fi
 
 dnl Whether to run ldconfig after installing libraries

--- a/macros/quota-check.m4
+++ b/macros/quota-check.m4
@@ -1,0 +1,40 @@
+dnl Autoconf macro to check for quota support
+dnl FIXME: This is in now way complete.
+
+AC_DEFUN([AC_NETATALK_CHECK_QUOTA], [
+	AC_ARG_ENABLE(quota,
+	[  --enable-quota           Turn on quota support (default=auto)])
+	AC_ARG_WITH([libtirpc], [AS_HELP_STRING([--with-libtirpc], [Use libtirpc as RPC implementation (instead of sunrpc)])])
+
+	if test x$enable_quota != xno; then
+		if test "x$with_libtirpc" = xyes; then
+			PKG_CHECK_MODULES([TIRPC],
+				[libtirpc],
+				[QUOTA_CFLAGS=$TIRPC_CFLAGS
+				QUOTA_LIBS=$TIRPC_LIBS
+				netatalk_cv_quotasupport="yes"
+				AC_DEFINE(NEED_RQUOTA, 1, [Define various xdr functions])],
+				[AC_MSG_ERROR([libtirpc requested, but library not found.])]
+				)
+		else
+			QUOTA_CFLAGS=""
+			QUOTA_LIBS=""
+			netatalk_cv_quotasupport="yes"
+			AC_CHECK_LIB(rpcsvc, main, [QUOTA_LIBS="-lrpcsvc"])
+			AC_CHECK_HEADERS([rpc/rpc.h rpc/pmap_prot.h rpcsvc/rquota.h],[],[
+				QUOTA_LIBS=""
+				netatalk_cv_quotasupport="no"
+				AC_DEFINE(NO_QUOTA_SUPPORT, 1, [Define if quota support should not compiled])
+			])
+			AC_CHECK_LIB(quota, getfsquota, [QUOTA_LIBS="-lquota -lprop -lrpcsvc"
+				AC_DEFINE(HAVE_LIBQUOTA, 1, [define if you have libquota])], [], [-lprop -lrpcsvc])
+		fi
+	else
+		netatalk_cv_quotasupport="no"
+		AC_DEFINE(NO_QUOTA_SUPPORT, 1, [Define if quota support should not compiled])
+	fi
+
+	AC_SUBST(QUOTA_CFLAGS)
+	AC_SUBST(QUOTA_LIBS)
+])
+

--- a/macros/summary.m4
+++ b/macros/summary.m4
@@ -50,6 +50,7 @@ AC_DEFUN([AC_NETATALK_CONFIG_SUMMARY], [
 dnl	if test x"$netatalk_cv_linux_sendfile" != x; then
 dnl		AC_MSG_RESULT([         Linux sendfile support:  $netatalk_cv_linux_sendfile])
 dnl	fi
+	AC_MSG_RESULT([         quota support:           $netatalk_cv_quotasupport])
 	AC_MSG_RESULT([         valid shell check:       $netatalk_cv_use_shellcheck])
 	AC_MSG_RESULT([         cracklib support:        $netatalk_cv_with_cracklib])
 dnl	AC_MSG_RESULT([         Samba sharemode interop: $neta_cv_have_smbshmd])

--- a/meson.build
+++ b/meson.build
@@ -76,12 +76,6 @@ uamdir = '-D_PATH_AFPDUAMPATH="' + libdir + '/netatalk/"'
 # Includes #
 ############
 
-root_includes = include_directories(
-    '.',
-    'include',
-    'etc/afpd',
-)
-
 if host_os in ['dragonfly', 'freebsd', 'openbsd']
     root_includes = include_directories(
         '.',
@@ -185,7 +179,6 @@ endif
 check_headers = [
     'acl/libacl.h',
     'attr/xattr.h',
-    'attr/xattr.h',
     'dlfcn.h',
     'dns_sd.h',
     'fcntl.h',
@@ -200,6 +193,7 @@ check_headers = [
     'pam/pam_appl.h',
     'rpc/pmap/prot.h',
     'rpc/rpc.h',
+    'rpcsvc/rquota.h',
     'security/pam_appl.h',
     'sgtty.h',
     'statfs.h',
@@ -222,6 +216,7 @@ check_headers = [
     'sys/vfs.h',
     'sys/xattr.h',
     'termios.h',
+    'ufs/quota.h',
     'unistd.h',
     'xfs/libxfs.h',
     'xfs/xfs/fs.h',
@@ -843,6 +838,65 @@ libevent = dependency(
     required: true,
     not_found_message: 'Libevent library required but not found! Please install the libevent devel package',
 )
+
+#
+# Check for quota support
+#
+
+rpcsvc = cc.find_library('rpcsvc', required: false)
+quota = cc.find_library('quota', required: false)
+tirpc = dependency('libtirpc', required: false)
+
+quota_link_args = []
+
+rpc_headers = [
+    'rpc/rpc.h',
+    'rpc/pmap_prot.h',
+    'rpcsvc/rquota.h',
+]
+
+foreach header : rpc_headers
+    if cc.has_header(header)
+        cdata.set('HAVE_' + header.underscorify().to_upper(), 1)
+    endif
+endforeach
+
+if get_option('enable-quota').disabled()
+    have_quota = false
+    cdata.set('NO_QUOTA_SUPPORT', 1)
+else
+    if tirpc.found() and get_option('with-libtirpc')
+        have_quota = true
+        cdata.set('NEED_RQUOTA', 1)
+        if get_option('with-libtirpc') and not tirpc.found()
+            message('Libtirpc requested, but library not found')
+        endif
+    elif (
+        rpcsvc.found()
+        and (
+            cc.has_header('rpc/rpc.h')
+            or cc.has_header('rpc/pmap_prot.h')
+            or cc.has_header('rpcsvc/rquota.h')
+        )
+    )
+        have_rpcsvc = cc.has_function('main', dependencies: rpcsvc)
+        quota_link_args += '-lrpcsvc'
+        if quota.found() and have_rpcsvc
+            have_quota = cc.has_function('getfsquota', dependencies: quota)
+            cdata.set('HAVE_LIBQUOTA', 1)
+            quota_link_args += ['-lquota', '-lprop', '-lrpcsvc']
+        else
+            have_quota = false
+            cdata.set('NO_QUOTA_SUPPORT', 1)
+        endif
+    else
+        have_quota = false
+    endif
+endif
+
+if get_option('enable-quota').enabled() and not have_quota
+    warning('Quota support requested but required libraries not found')
+endif
 
 #
 # Check for libgcrypt
@@ -1789,13 +1843,16 @@ endif
 # OS-specific configuration
 #
 
-if host_os.contains('freebsd')
+if host_os.contains('darwin')
+    cdata.set('NO_QUOTA_SUPPORT', 1)
+elif host_os.contains('freebsd')
     cdata.set('BSD4_4', 1)
     cdata.set('FREEBSD', 1)
     cdata.set('OPEN_NOFOLLOW_ERRNO', 'EMLINK')
 elif host_os.contains('linux')
     cdata.set('_GNU_SOURCE', 1)
     cdata.set('LINUX', 1)
+    cdata.set('NO_QUOTA_SUPPORT', 1)
 elif host_os.contains('netbsd')
     cdata.set('BSD4_4', 1)
     cdata.set('NETBSD', 1)
@@ -1966,6 +2023,7 @@ summary_info = {
     '  GSSAPI support': have_gssapi,
     '  Kerberos support': have_kerberos,
     '  LDAP support': have_ldap,
+    '  Quota support': have_quota,
     '  SSL provider': ssl_provider,
     '  TCP wrapper support': have_tcpwrap,
     '  Zeroconf support': enable_zeroconf,

--- a/meson_config.h
+++ b/meson_config.h
@@ -308,6 +308,9 @@
 /* Define if the DHX2 modules should be built with libgcrypt */
 #mesondefine HAVE_LIBGCRYPT
 
+/* define if you have libquota */
+#mesondefine HAVE_LIBQUOTA
+
 /* Define to 1 if you have the `sunacl' library (-lsunacl). */
 #mesondefine HAVE_LIBSUNACL
 
@@ -388,6 +391,15 @@
 
 /* Define to 1 if you have the `renameat' function. */
 #mesondefine HAVE_RENAMEAT
+
+/* Define to 1 if you have the <rpcsvc/rquota.h> header file. */
+#mesondefine HAVE_RPCSVC_RQUOTA_H
+
+/* Define to 1 if you have the <rpc/pmap_prot.h> header file. */
+#mesondefine HAVE_RPC_PMAP_PROT_H
+
+/* Define to 1 if you have the <rpc/rpc.h> header file. */
+#mesondefine HAVE_RPC_RPC_H
 
 /* Define to 1 if you have the <security/pam_appl.h> header file. */
 #mesondefine HAVE_SECURITY_PAM_APPL_H
@@ -539,11 +551,17 @@
 /* Disable assertions */
 #mesondefine NDEBUG
 
+/* Define various xdr functions */
+#mesondefine NEED_RQUOTA
+
 /* Define if dlsym() requires a leading underscore in symbol names. */
 #mesondefine NEED_USCORE
 
 /* Define if OS is NetBSD */
 #mesondefine NETBSD
+
+/* Define if Quota support should be disabled */
+#mesondefine NO_QUOTA_SUPPORT
 
 /* Define if the gmtoff member of struct tm is not available */
 #mesondefine NO_STRUCT_TM_GMTOFF

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -65,6 +65,12 @@ option(
     description: 'Enable build of PGP UAM module',
 )
 option(
+    'enable-quota',
+    type: 'feature',
+    value: 'auto',
+    description: 'Turn on quota support',
+)
+option(
     'enable-rpath',
     type: 'boolean',
     value: false,
@@ -213,6 +219,12 @@ option(
     type: 'string',
     value: '',
     description: 'Path to libiconv installation. Must contain lib and include dirs',
+)
+option(
+    'with-libtirpc',
+    type: 'boolean',
+    value: false,
+    description: 'Use libtirpc as RPC implementation (instead of sunrpc)',
 )
 option(
     'with-lockfile',

--- a/test/afpd/Makefile.am
+++ b/test/afpd/Makefile.am
@@ -30,7 +30,9 @@ test_SOURCES =  test.c subtests.c afpfunc_helpers.c \
 				$(top_srcdir)/etc/afpd/hash.c \
 				$(top_srcdir)/etc/afpd/mangle.c \
 				$(top_srcdir)/etc/afpd/messages.c \
+				$(top_srcdir)/etc/afpd/nfsquota.c \
 				$(top_srcdir)/etc/afpd/ofork.c \
+				$(top_srcdir)/etc/afpd/quota.c \
 				$(top_srcdir)/etc/afpd/status.c \
 				$(top_srcdir)/etc/afpd/switch.c \
 				$(top_srcdir)/etc/afpd/uam.c \
@@ -41,7 +43,7 @@ test_CFLAGS = \
 	-I$(top_srcdir)/etc/afpd \
 	-I$(top_srcdir)/include \
 	-I$(top_srcdir)/sys \
-	@GSSAPI_CFLAGS@ @KRB5_CFLAGS@ \
+	@GSSAPI_CFLAGS@ @KRB5_CFLAGS@ @QUOTA_CFLAGS@\
 	-DAPPLCNAME \
 	-DSERVERTEXT=\"$(SERVERTEXT)/\" \
 	-D_PATH_AFPDPWFILE=\"$(pkgconfdir)/afppasswd\" \
@@ -51,7 +53,7 @@ test_CFLAGS = \
 
 test_LDADD = \
 	$(top_builddir)/libatalk/libatalk.la \
-	@LIBGCRYPT_LIBS@ @WRAP_LIBS@ @LIBADD_DL@ @ACL_LIBS@ @PTHREAD_LIBS@ @GSSAPI_LIBS@ @KRB5_LIBS@ @MYSQL_LIBS@
+	@LIBGCRYPT_LIBS@ @QUOTA_LIBS@ @WRAP_LIBS@ @LIBADD_DL@ @ACL_LIBS@ @PTHREAD_LIBS@ @GSSAPI_LIBS@ @KRB5_LIBS@ @MYSQL_LIBS@
 
 test_LDFLAGS = -export-dynamic
 

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -25,7 +25,9 @@ test_sources = [
     meson.project_source_root() / 'etc/afpd/hash.c',
     meson.project_source_root() / 'etc/afpd/mangle.c',
     meson.project_source_root() / 'etc/afpd/messages.c',
+    meson.project_source_root() / 'etc/afpd/nfsquota.c',
     meson.project_source_root() / 'etc/afpd/ofork.c',
+    meson.project_source_root() / 'etc/afpd/quota.c',
     meson.project_source_root() / 'etc/afpd/status.c',
     meson.project_source_root() / 'etc/afpd/switch.c',
     meson.project_source_root() / 'etc/afpd/uam.c',
@@ -70,6 +72,7 @@ afpdtestlib = static_library(
         libgcrypt,
         libcnid_deps,
         threads,
+        tirpc,
     ],
     c_args: [
         '-DAPPLCNAME', confdir,
@@ -138,6 +141,7 @@ afpdtest = executable(
     afpdtest_dtrace_input,
     objects: test_objs,
     include_directories: root_includes,
+    link_with: [test_internal_deps, libatalk],
     dependencies: [
         test_external_deps,
         gss,
@@ -145,9 +149,12 @@ afpdtest = executable(
         libgcrypt,
         libcnid_deps,
         threads,
+        tirpc,
     ],
     c_args: ['-DAPPLCNAME', dversion, messagedir, uamdir, confdir, statedir],
-    link_with: [test_internal_deps, libatalk],
+    link_args: quota_link_args,
+    export_dynamic: true,
+    install: false,
 )
 
 test_sh = find_program('test.sh')


### PR DESCRIPTION
As per discussion in https://github.com/Netatalk/netatalk/issues/1028, bring back quota which was removed within this release cycle.

- Revert https://github.com/Netatalk/netatalk/issues/493
- Forward-port NetBSD patch that was only in 2.x https://github.com/Netatalk/netatalk/commit/bf1bbf20b105c69712d786465ce3452c3617af9f
- Modernize quota code, removing ancient platform workarounds
- Linux ifdefs for code introduced with https://github.com/Netatalk/netatalk/commit/450114e8c52574c5444d856e8a0208f2bbaab80c (caused build errors for DragonflyBSD; might be a cleaner way to do this...)
- Forward-port Meson build system scripts from 2.x with modifications