### PR TITLE
[2.4] quota: Stricter check for rpcsvc in meson

### DIFF
--- a/etc/afpd/nfsquota.c
+++ b/etc/afpd/nfsquota.c
@@ -37,7 +37,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if !defined(NO_QUOTA_SUPPORT) && !defined(HAVE_LIBQUOTA)
+#if !defined(NO_QUOTA_SUPPORT) || defined(HAVE_LIBQUOTA)
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
@@ -65,7 +65,7 @@
 static int
 callaurpc(struct vol *vol,
     u_long prognum, u_long versnum, u_long procnum,
-    xdrproc_t inproc, char *in, 
+    xdrproc_t inproc, char *in,
     xdrproc_t outproc, char *out)
 {
     enum clnt_stat clnt_stat;
@@ -187,4 +187,4 @@ int getnfsquota(struct vol *vol, const int uid, const u_int32_t bsize,
     *hostpath = ':';
     return AFPERR_PARAM;
 }
-#endif /* ! NO_QUOTA_SUPPORT && !HAVE_LIBQUOTA */
+#endif /* ! NO_QUOTA_SUPPORT || HAVE_LIBQUOTA */

--- a/meson.build
+++ b/meson.build
@@ -764,12 +764,15 @@ else
             or cc.has_header('rpcsvc/rquota.h')
         )
     )
-        have_quota = cc.has_function('main', dependencies: rpcsvc)
+        have_rpcsvc = cc.has_function('main', dependencies: rpcsvc)
         quota_link_args += '-lrpcsvc'
-        if quota.found()
+        if quota.found() and have_rpcsvc
             have_quota = cc.has_function('getfsquota', dependencies: quota)
             cdata.set('HAVE_LIBQUOTA', 1)
             quota_link_args += ['-lquota', '-lprop', '-lrpcsvc']
+        else
+            have_quota = false
+            cdata.set('NO_QUOTA_SUPPORT', 1)
         endif
     else
         have_quota = false


### PR DESCRIPTION
This is a small backport from the 3.x quota PR. It explicitly disables quota when either rpcsvc or quota isn't found. This addresses compilation errors on DragonflyBSD.