### PR TITLE
GitHub CI: quota and tracker on Fedora

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,8 +307,10 @@ jobs:
             openssl-devel \
             pam-devel \
             perl \
+            quota-devel \
             systemd \
             systemtap-sdt-devel \
+            tracker \
             tracker-devel
       - name: Autotools - Bootstrap
         run: ./bootstrap
@@ -318,8 +320,10 @@ jobs:
             --disable-init-hooks \
             --enable-krbV-uam \
             --enable-pgp-uam \
+            --enable-quota \
             --with-cracklib \
             --with-init-style=redhat-systemd \
+            --with-libtirpc \
             --with-tracker-pkgconfig-version=3.0
       - name: Autotools - Build
         run: make -j $(nproc)
@@ -334,7 +338,8 @@ jobs:
           meson setup build \
             -Dbuild-tests=true \
             -Ddisable-init-hooks=true \
-            -Dwith-init-style=redhat-systemd
+            -Dwith-init-style=redhat-systemd \
+            -Dwith-libtirpc=true
       - name: Meson - Build
         run: ninja -C build
       - name: Meson - Run tests

--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,7 @@ Changes in 3.2.0
 * FIX: afpd: Prevent theoretical crash in FPSetACL, GitHub #364
 * FIX: libatalk: Restore invalid EA metadata cleanup, GitHub #400
 * FIX: quota: Use the NetBSD 6 quota API, GitHub #1028
+* FIX: quota: Workaround for rquota.h symbol name on Fedora 40, GitHub #1040
 * FIX: Shore up error handling and type safety, GitHub #952
 * UPD: Rewrite the afpstats script in Perl, GitHub #893
        And, improve the formatting of the standard output.

--- a/libatalk/compat/rquota_xdr.c
+++ b/libatalk/compat/rquota_xdr.c
@@ -87,7 +87,11 @@ xdr_rquota(xdrs, objp)
 bool_t
 xdr_gqr_status(xdrs, objp)
 	XDR *xdrs;
+#if defined(HAVE_RQUOTA_H_QR_STATUS)
+	qr_status *objp;
+#else
 	gqr_status *objp;
+#endif
 {
 	if (!xdr_enum(xdrs, (enum_t *)objp)) {
 		return (FALSE);

--- a/macros/quota-check.m4
+++ b/macros/quota-check.m4
@@ -15,7 +15,21 @@ AC_DEFUN([AC_NETATALK_CHECK_QUOTA], [
 				netatalk_cv_quotasupport="yes"
 				AC_DEFINE(NEED_RQUOTA, 1, [Define various xdr functions])],
 				[AC_MSG_ERROR([libtirpc requested, but library not found.])]
-				)
+			)
+			old_CFLAGS=$CFLAGS
+			CFLAGS="$CFLAGS $QUOTA_CFLAGS"
+			AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+					#include <rpcsvc/rquota.h>
+				]], [[
+					enum qr_status foo;
+					foo = Q_OK;
+				]])],
+				[netatalk_cv_rquota_qr_status="yes"], [netatalk_cv_rquota_qr_status="no"]
+			)
+			CFLAGS=$old_CFLAGS
+			if test x"$netatalk_cv_rquota_qr_status" = x"yes"; then
+				AC_DEFINE(HAVE_RQUOTA_H_QR_STATUS, 1, [rquota.h has enum qr_status member])
+			fi
 		else
 			QUOTA_CFLAGS=""
 			QUOTA_LIBS=""
@@ -37,4 +51,3 @@ AC_DEFUN([AC_NETATALK_CHECK_QUOTA], [
 	AC_SUBST(QUOTA_CFLAGS)
 	AC_SUBST(QUOTA_LIBS)
 ])
-

--- a/meson.build
+++ b/meson.build
@@ -868,6 +868,21 @@ else
     if tirpc.found() and get_option('with-libtirpc')
         have_quota = true
         cdata.set('NEED_RQUOTA', 1)
+
+        rquota_test = cc.compiles(
+            '''
+                #include <rpcsvc/rquota.h>
+                int main(void) {
+                    enum qr_status foo;
+                    foo = Q_OK;
+                    return 0;
+                }
+            ''', dependencies: tirpc
+        )
+        if rquota_test
+            cdata.set('HAVE_RQUOTA_H_QR_STATUS', 1)
+        endif
+
         if get_option('with-libtirpc') and not tirpc.found()
             message('Libtirpc requested, but library not found')
         endif

--- a/meson_config.h
+++ b/meson_config.h
@@ -401,6 +401,9 @@
 /* Define to 1 if you have the <rpc/rpc.h> header file. */
 #mesondefine HAVE_RPC_RPC_H
 
+/* Define to 1 if the <rpcsvc/rquota.h> header file has a qr_status member. */
+#mesondefine HAVE_RQUOTA_H_QR_STATUS
+
 /* Define to 1 if you have the <security/pam_appl.h> header file. */
 #mesondefine HAVE_SECURITY_PAM_APPL_H
 


### PR DESCRIPTION
configuring with quota and libtirpc -- turned out that we need a capability check to make this work on Fedora

tracker isn't a dependency of tracker-devel in Fedora, so let's install it explicitly