### PR TITLE
[2.4] meson: Missing install step for Solaris

### DIFF
--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -103,6 +103,10 @@ elif get_option('enable-solaris')
             '-f', '/etc/rc2.d/S90netatalk',
         )
         meson.add_install_script(
+            find_program('rm'),
+            '-f', '/etc/rc0.d/K04netatalk',
+        )
+        meson.add_install_script(
             find_program('ln'),
             '-s', '/etc/init.d/netatalk',
             '/etc/rc2.d/S90netatalk',


### PR DESCRIPTION
One install step was missing from the Meson script for the Solaris init script, as compared to Autotools.