### PR TITLE
[2.4] meson: Do not install char encoding scripts

### DIFF
--- a/contrib/shell_utils/meson.build
+++ b/contrib/shell_utils/meson.build
@@ -15,8 +15,6 @@ if perl.found() and grep.found()
         [
             appledump_script,
             asipstatus_script,
-            'make-casetable.pl',
-            'make-precompose.h.pl',
         ],
         install_dir: bindir,
     )


### PR DESCRIPTION
Update the meson build script not to install :
-            make-casetable.pl
-            make-precompose.h.pl

These are perl scripts that generate character encoding / unicode source files, and are of use only for netatalk developers. AFAIK. :)

Note that the Autotools build system does not install these files.