### PR TITLE
meson: afpstats should depend on Perl; don't install dev scripts

### DIFF
--- a/contrib/shell_utils/meson.build
+++ b/contrib/shell_utils/meson.build
@@ -1,12 +1,12 @@
-afpstats_script = configure_file(
-    input: 'afpstats.in',
-    output: 'afpstats',
-    configuration: cdata,
-)
-
-install_data(afpstats_script, install_dir: bindir)
-
 if perl.found() and grep.found()
+    afpstats_script = configure_file(
+        input: 'afpstats.in',
+        output: 'afpstats',
+        configuration: cdata,
+    )
+
+    install_data(afpstats_script, install_dir: bindir)
+
     appledump_script = configure_file(
         input: 'apple_dump.in',
         output: 'apple_dump',
@@ -23,9 +23,3 @@ if perl.found() and grep.found()
 
     install_data(asipstatus_script, install_dir: bindir)
 endif
-
-install_data('fce_ev_script.sh', install_dir: bindir)
-
-install_data('make-casetable.pl', install_dir: bindir)
-
-install_data('make-precompose.h.pl', install_dir: bindir)


### PR DESCRIPTION
This fixes two issues with the shell_utils meson script:

- afpstats should only be processed & installed when Perl+grep are detected (forgot to update this after rewriting it in Perl)
- Do not install dev scripts (FCE sample script, unicode header generator script, etc.)