### PR TITLE
[2.4] meson: Fix papd crash when cupsautoadd is enabled

### DIFF
--- a/contrib/a2boot/meson.build
+++ b/contrib/a2boot/meson.build
@@ -14,4 +14,6 @@ executable(
     ],
     install: true,
     install_dir: sbindir,
+    build_rpath: libdir,
+    install_rpath: libdir,
 )

--- a/contrib/timelord/meson.build
+++ b/contrib/timelord/meson.build
@@ -5,4 +5,6 @@ executable(
     link_with: libatalk,
     install: true,
     install_dir: sbindir,
+    build_rpath: libdir,
+    install_rpath: libdir,
 )

--- a/etc/papd/meson.build
+++ b/etc/papd/meson.build
@@ -43,3 +43,7 @@ executable(
     build_rpath: libdir,
     install_rpath: libdir,
 )
+
+if have_cups and spooldir_required
+    install_emptydir(spooldir, install_mode: 'rwxrwxrwx')
+endif

--- a/meson.build
+++ b/meson.build
@@ -1158,7 +1158,7 @@ if iconv.found() or libiconv.found()
         cdata.set('ICONV_CONST', 'const')
     endif
 
-    if cc.compiles(
+    if cc.run(
         '''
     #include <iconv.h>
     int main(void) {
@@ -1167,7 +1167,7 @@ if iconv.found() or libiconv.found()
         return 0;
     }
     ''',
-    )
+    ).returncode() == 0
         cdata.set('HAVE_UCS2INTERNAL', 1)
     endif
 else

--- a/meson.build
+++ b/meson.build
@@ -716,7 +716,7 @@ else
         if get_option('with-spooldir') != ''
             spooldir += get_option('with-spooldir')
         else
-            spooldir += localstatedir / 'spool/netatalk'
+            spooldir += prefix / 'var/spool/netatalk'
         endif
     endif
 endif


### PR DESCRIPTION
This commit:

- Fixes the logic of the UCS-2-INTERNAL macro that was causing the crash (credit: @NJRoadfan)
- Creates the required empty spooldir on install
- Fixes the linking of a2boot and timelord with libatalk