### PR TITLE
Alpine workflow: Add missing tracker-miners package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,8 @@ jobs:
             rpcsvc-proto-dev \
             talloc-dev \
             tracker \
-            tracker-dev
+            tracker-dev \
+            tracker-miners
       - name: Autotools - Bootstrap
         run: ./bootstrap
       - name: Autotools - Configure


### PR DESCRIPTION
The tracker-miners package adds the missing daemon command to tracker3 on Alpine Linux