### PR TITLE
meson: Address various issues with the meson build system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,7 +154,8 @@ jobs:
             make \
             meson \
             ninja \
-            pkgconfig
+            pkgconfig \
+            rpcsvc-proto
       - name: Autotools - Bootstrap
         run: ./bootstrap
       - name: Autotools - Configure

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,6 @@ jobs:
             --enable-pgp-uam \
             --with-cracklib \
             --with-init-style=openrc \
-            --with-libtirpc \
             --with-tracker-pkgconfig-version=3.0
       - name: Autotools - Build
         run: make -j $(nproc)
@@ -127,8 +126,7 @@ jobs:
         run: |
           meson setup build \
             -Dbuild-tests=true \
-            -Dwith-init-style=openrc \
-            -Dwith-libtirpc=true
+            -Dwith-init-style=openrc
       - name: Meson - Build
         run: ninja -C build
       - name: Meson - Run tests
@@ -244,7 +242,6 @@ jobs:
             --enable-quota \
             --with-cracklib \
             --with-init-style=debian-sysv \
-            --with-libtirpc \
             --with-tracker-pkgconfig-version=3.0
       - name: Autotools - Build
         run: make -j $(nproc) all
@@ -262,8 +259,7 @@ jobs:
         run: |
           meson setup build \
             -Dbuild-tests=true \
-            -Dwith-init-style=debian-sysv \
-            -Dwith-libtirpc=true
+            -Dwith-init-style=debian-sysv
       - name: Meson - Build
         run: ninja -C build
       - name: Meson - Run tests
@@ -324,7 +320,6 @@ jobs:
             --enable-quota \
             --with-cracklib \
             --with-init-style=redhat-systemd \
-            --with-libtirpc \
             --with-tracker-pkgconfig-version=3.0
       - name: Autotools - Build
         run: make -j $(nproc)
@@ -339,8 +334,7 @@ jobs:
           meson setup build \
             -Dbuild-tests=true \
             -Ddisable-init-hooks=true \
-            -Dwith-init-style=redhat-systemd \
-            -Dwith-libtirpc=true
+            -Dwith-init-style=redhat-systemd
       - name: Meson - Build
         run: ninja -C build
       - name: Meson - Run tests
@@ -449,7 +443,6 @@ jobs:
             --with-cracklib \
             --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl \
             --with-init-style=debian-systemd \
-            --with-libtirpc \
             --with-tracker-pkgconfig-version=3.0
       - name: Autotools - Generate manual pages
         run: make html
@@ -473,8 +466,7 @@ jobs:
             -Dbuild-tests=true \
             -Dbuild-manual=true \
             -Ddisable-init-hooks=true \
-            -Dwith-init-style=debian-systemd \
-            -Dwith-libtirpc=true
+            -Dwith-init-style=debian-systemd
       - name: Meson - Build and generate manual pages
         run: ninja -C build
       - name: Meson - Run tests

--- a/bin/ad/meson.build
+++ b/bin/ad/meson.build
@@ -10,11 +10,17 @@ ad_sources = [
     'ad.h',
 ]
 
+ad_deps = []
+
+if use_mysql_backend
+    ad_deps += mysqlclient
+endif
+
 executable(
     'ad',
     ad_sources,
     include_directories: root_includes,
-    dependencies: mysqlclient,
+    dependencies: ad_deps,
     link_with: libatalk,
     c_args: [ad, dversion],
     install: true,

--- a/bin/afppasswd/meson.build
+++ b/bin/afppasswd/meson.build
@@ -2,12 +2,31 @@ afppasswd_sources = [
     'afppasswd.c',
 ]
 
+afppasswd_deps = []
+afppasswd_libs = []
+
+if have_cracklib
+    afppasswd_deps += crack
+endif
+
+if crypto.found()
+    afppasswd_deps += ssl_deps
+endif
+
+if use_mysql_backend
+    afppasswd_deps += mysqlclient
+endif
+
+if have_embedded_ssl
+    afppasswd_libs += libatalk
+endif
+
 executable(
     'afppasswd',
     afppasswd_sources,
     include_directories: root_includes,
-    dependencies: [crack, ssl_deps, mysqlclient],
-    link_with: libatalk,
+    dependencies: afppasswd_deps,
+    link_with: afppasswd_libs,
     c_args: [
         afpdpwfile,
         dversion,

--- a/bin/misc/meson.build
+++ b/bin/misc/meson.build
@@ -33,14 +33,22 @@ executable(
     install: false,
 )
 
-executable(
-    'afpldaptest',
-    afpldaptest_sources,
-    include_directories: root_includes,
-    link_with: libatalk,
-    dependencies: [mysqlclient, ldap],
-    c_args: confdir,
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+afpldaptest_deps = []
+
+if use_mysql_backend
+    afpldaptest_deps += mysqlclient
+endif
+
+if have_ldap
+    executable(
+        'afpldaptest',
+        afpldaptest_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        dependencies: [afpldaptest_deps, ldap],
+        c_args: confdir,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+endif

--- a/doc/ja/manual/compile.xml
+++ b/doc/ja/manual/compile.xml
@@ -66,7 +66,6 @@
   --enable-pgp-uam \
   --with-cracklib \
   --with-init-style=openrc \
-  --with-libtirpc \
   --with-tracker-pkgconfig-version=3.0
 </screen>
 			</para>
@@ -90,8 +89,7 @@
 			<para>
 				<screen>meson setup build \
   -Dbuild-tests=true \
-  -Dwith-init-style=openrc \
-  -Dwith-libtirpc=true
+  -Dwith-init-style=openrc
 </screen>
 			</para>
 			<para>Meson - Build</para>
@@ -235,7 +233,6 @@ apt-get install --assume-yes --no-install-recommends \
   --enable-quota \
   --with-cracklib \
   --with-init-style=debian-sysv \
-  --with-libtirpc \
   --with-tracker-pkgconfig-version=3.0
 </screen>
 			</para>
@@ -267,8 +264,7 @@ apt-get install --assume-yes --no-install-recommends \
 			<para>
 				<screen>meson setup build \
   -Dbuild-tests=true \
-  -Dwith-init-style=debian-sysv \
-  -Dwith-libtirpc=true
+  -Dwith-init-style=debian-sysv
 </screen>
 			</para>
 			<para>Meson - Build</para>
@@ -342,7 +338,6 @@ apt-get install --assume-yes --no-install-recommends \
   --enable-quota \
   --with-cracklib \
   --with-init-style=redhat-systemd \
-  --with-libtirpc \
   --with-tracker-pkgconfig-version=3.0
 </screen>
 			</para>
@@ -367,8 +362,7 @@ apt-get install --assume-yes --no-install-recommends \
 				<screen>meson setup build \
   -Dbuild-tests=true \
   -Ddisable-init-hooks=true \
-  -Dwith-init-style=redhat-systemd \
-  -Dwith-libtirpc=true
+  -Dwith-init-style=redhat-systemd
 </screen>
 			</para>
 			<para>Meson - Build</para>
@@ -539,7 +533,6 @@ xsltproc
   --with-cracklib \
   --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl \
   --with-init-style=debian-systemd \
-  --with-libtirpc \
   --with-tracker-pkgconfig-version=3.0
 </screen>
 			</para>
@@ -581,8 +574,7 @@ xsltproc
   -Dbuild-tests=true \
   -Dbuild-manual=true \
   -Ddisable-init-hooks=true \
-  -Dwith-init-style=debian-systemd \
-  -Dwith-libtirpc=true
+  -Dwith-init-style=debian-systemd
 </screen>
 			</para>
 			<para>Meson - Build and generate manual pages</para>

--- a/doc/manual/compile.xml
+++ b/doc/manual/compile.xml
@@ -66,7 +66,6 @@
   --enable-pgp-uam \
   --with-cracklib \
   --with-init-style=openrc \
-  --with-libtirpc \
   --with-tracker-pkgconfig-version=3.0
 </screen>
 			</para>
@@ -90,8 +89,7 @@
 			<para>
 				<screen>meson setup build \
   -Dbuild-tests=true \
-  -Dwith-init-style=openrc \
-  -Dwith-libtirpc=true
+  -Dwith-init-style=openrc
 </screen>
 			</para>
 			<para>Meson - Build</para>
@@ -235,7 +233,6 @@ apt-get install --assume-yes --no-install-recommends \
   --enable-quota \
   --with-cracklib \
   --with-init-style=debian-sysv \
-  --with-libtirpc \
   --with-tracker-pkgconfig-version=3.0
 </screen>
 			</para>
@@ -267,8 +264,7 @@ apt-get install --assume-yes --no-install-recommends \
 			<para>
 				<screen>meson setup build \
   -Dbuild-tests=true \
-  -Dwith-init-style=debian-sysv \
-  -Dwith-libtirpc=true
+  -Dwith-init-style=debian-sysv
 </screen>
 			</para>
 			<para>Meson - Build</para>
@@ -342,7 +338,6 @@ apt-get install --assume-yes --no-install-recommends \
   --enable-quota \
   --with-cracklib \
   --with-init-style=redhat-systemd \
-  --with-libtirpc \
   --with-tracker-pkgconfig-version=3.0
 </screen>
 			</para>
@@ -367,8 +362,7 @@ apt-get install --assume-yes --no-install-recommends \
 				<screen>meson setup build \
   -Dbuild-tests=true \
   -Ddisable-init-hooks=true \
-  -Dwith-init-style=redhat-systemd \
-  -Dwith-libtirpc=true
+  -Dwith-init-style=redhat-systemd
 </screen>
 			</para>
 			<para>Meson - Build</para>
@@ -539,7 +533,6 @@ xsltproc
   --with-cracklib \
   --with-docbook=/usr/share/xml/docbook/stylesheet/docbook-xsl \
   --with-init-style=debian-systemd \
-  --with-libtirpc \
   --with-tracker-pkgconfig-version=3.0
 </screen>
 			</para>
@@ -581,8 +574,7 @@ xsltproc
   -Dbuild-tests=true \
   -Dbuild-manual=true \
   -Ddisable-init-hooks=true \
-  -Dwith-init-style=debian-systemd \
-  -Dwith-libtirpc=true
+  -Dwith-init-style=debian-systemd
 </screen>
 			</para>
 			<para>Meson - Build and generate manual pages</para>

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -1,7 +1,3 @@
-afpd_internal_deps = []
-afpd_external_deps = []
-afpd_c_args = []
-
 afpd_sources = [
     'afp_config.c',
     'afp_dsi.c',
@@ -32,6 +28,11 @@ afpd_sources = [
     'volume.c',
     'main.c',
 ]
+
+afpd_c_args = []
+afpd_external_deps = [libgcrypt]
+afpd_internal_deps = []
+afpd_link_args = []
 
 if have_spotlight
     afpd_sources += [
@@ -85,11 +86,33 @@ if have_quota
         afpd_external_deps += tirpc
     elif rpcsvc.found()
         afpd_external_deps += rpcsvc
-        netatalk_common_link_args += quota_link_args
-    elif quota.found()
-        afpd_external_deps += rpcsvc
-        netatalk_common_link_args += quota_link_args
+        afpd_link_args += sunrpc_link_args
     endif
+    if quota.found()
+        afpd_external_deps += quota
+        afpd_link_args += libquota_link_args
+    endif
+endif
+
+if have_gssapi
+    afpd_external_deps += gss
+endif
+
+if have_kerberos
+    afpd_external_deps += kerberos
+    afpd_c_args += kerberos_c_args
+endif
+
+if have_tcpwrap
+    afpd_external_deps += wrap
+endif
+
+if use_mysql_backend
+    afpd_external_deps += mysqlclient
+endif
+
+if threads.found()
+    afpd_external_deps += threads
 endif
 
 # For dtrace probes we need to invoke dtrace on all input files, before
@@ -104,19 +127,11 @@ libafpd = static_library(
     afpd_sources,
     include_directories: root_includes,
     link_with: [afpd_internal_deps, libatalk],
-    dependencies: [
-        afpd_external_deps,
-        gss,
-        kerberos,
-        libgcrypt,
-        libcnid_deps,
-        threads,
-        tirpc,
-    ],
+    dependencies: afpd_external_deps,
     c_args: [
-        '-DAPPLCNAME', confdir,
+        '-DAPPLCNAME', afpd_c_args,
+        confdir,
         dversion,
-        kerberos_c_args,
         messagedir,
         statedir,
         uamdir,
@@ -182,18 +197,11 @@ executable(
     objects: afpd_objs,
     include_directories: root_includes,
     link_with: [afpd_internal_deps, libatalk],
-    dependencies: [
-        afpd_external_deps,
-        gss,
-        kerberos,
-        libgcrypt,
-        libcnid_deps,
-        threads,
-    ],
+    dependencies: afpd_external_deps,
     c_args: [
-        '-DAPPLCNAME', confdir,
+        '-DAPPLCNAME', afpd_c_args,
+        confdir,
         dversion,
-        kerberos_c_args,
         messagedir,
         statedir,
         uamdir,

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -24,9 +24,7 @@ afpd_sources = [
     'hash.c',
     'mangle.c',
     'messages.c',
-    'nfsquota.c',
     'ofork.c',
-    'quota.c',
     'status.c',
     'switch.c',
     'uam.c',
@@ -78,6 +76,22 @@ if with_acls
     afpd_external_deps += [acl_deps]
 endif
 
+if have_quota
+    afpd_sources += [
+        'nfsquota.c',
+        'quota.c',
+    ]
+    if tirpc.found()
+        afpd_external_deps += tirpc
+    elif rpcsvc.found()
+        afpd_external_deps += rpcsvc
+        netatalk_common_link_args += quota_link_args
+    elif quota.found()
+        afpd_external_deps += rpcsvc
+        netatalk_common_link_args += quota_link_args
+    endif
+endif
+
 # For dtrace probes we need to invoke dtrace on all input files, before
 # linking the final executable.
 #
@@ -107,10 +121,7 @@ libafpd = static_library(
         statedir,
         uamdir,
     ],
-    link_args: [
-        netatalk_common_link_args,
-        quota_link_args,
-    ],
+    link_args: netatalk_common_link_args,
     install: false,
     build_by_default: false,
 )
@@ -187,10 +198,7 @@ executable(
         statedir,
         uamdir,
     ],
-    link_args: [
-        netatalk_common_link_args,
-        quota_link_args,
-    ],
+    link_args: netatalk_common_link_args,
     export_dynamic: true,
     install: true,
     install_dir: sbindir,

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -71,7 +71,7 @@ if with_afpstats
     afpd_c_args += '-DDBUS_COMPILATION'
 endif
 
-if with_acls
+if have_acls
     afpd_sources += 'acls.c'
     afpd_external_deps += [acl_deps]
 endif

--- a/etc/afpd/unix.h
+++ b/etc/afpd/unix.h
@@ -27,12 +27,17 @@
 #include <sys/mnttab.h>
 #endif /* __svr4__ || HAVE_SYS_MNTTAB_H */
 
+#if defined(__DragonFly__)
+#define dqblk ufs_dqblk
+#endif
+
+#if defined(HAVE_SYS_MOUNT_H) || defined(BSD4_4) || defined(__linux__)
 #include <sys/mount.h>
+#endif /* HAVE_SYS_MOUNT_H || BSD4_4 || __linux__ */
 
-#if defined(HAVE_MNTENT_H)
+#if defined(linux) || defined(HAVE_MNTENT_H)
 #include <mntent.h>
-#endif /* HAVE_MNTENT_H */
-
+#endif /* linux || HAVE_MNTENT_H */
 
 #ifndef NO_QUOTA_SUPPORT
 #if !defined(HAVE_LIBQUOTA)
@@ -61,6 +66,10 @@
 #ifdef BSD4_4
 #if defined(__DragonFly__)
 #include <vfs/ufs/quota.h>
+#elif defined(__NetBSD__)
+#include <ufs/ufs/quota.h>
+#include <ufs/ufs/quota1.h>
+#include <ufs/ufs/quota2.h>
 #else /* DragonFly */
 #include <ufs/ufs/quota.h>
 #endif /* DragonFly */
@@ -74,7 +83,6 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include "directory.h"
-
 
 #if defined (__linux__)
 
@@ -201,5 +209,9 @@ extern int setdirowner      (const struct vol *, const char *, const uid_t, cons
 extern int setfilunixmode   (const struct vol *, struct path*, const mode_t);
 extern int setfilowner      (const struct vol *, const uid_t, const gid_t, struct path*);
 extern void accessmode      (const AFPObj *obj, const struct vol *, char *, struct maccess *, struct dir *, struct stat *);
+
+#ifdef AFS	
+    #define accessmode afsmode
+#endif
 
 #endif /* UNIX_H */

--- a/etc/afpd/unix.h
+++ b/etc/afpd/unix.h
@@ -76,7 +76,7 @@
 #include "directory.h"
 
 
-#if defined (linux)
+#if defined (__linux__)
 
 #define MAXQUOTAS 2
 

--- a/etc/cnid_dbd/meson.build
+++ b/etc/cnid_dbd/meson.build
@@ -1,73 +1,81 @@
-cnid_dbd_sources = [
-    'comm.c',
-    'db_param.c',
-    'dbd_add.c',
-    'dbd_dbcheck.c',
-    'dbd_delete.c',
-    'dbd_get.c',
-    'dbd_getstamp.c',
-    'dbd_lookup.c',
-    'dbd_rebuild_add.c',
-    'dbd_resolve.c',
-    'dbd_search.c',
-    'dbd_update.c',
-    'dbif.c',
-    'main.c',
-    'pack.c',
-]
+if use_dbd_backend
+    cnid_dbd_sources = [
+        'comm.c',
+        'db_param.c',
+        'dbd_add.c',
+        'dbd_dbcheck.c',
+        'dbd_delete.c',
+        'dbd_get.c',
+        'dbd_getstamp.c',
+        'dbd_lookup.c',
+        'dbd_rebuild_add.c',
+        'dbd_resolve.c',
+        'dbd_search.c',
+        'dbd_update.c',
+        'dbif.c',
+        'main.c',
+        'pack.c',
+    ]
 
-executable(
-    'cnid_dbd',
-    cnid_dbd_sources,
-    include_directories: [bdb_includes, root_includes],
-    link_with: libatalk,
-    dependencies: [db, mysqlclient],
-    c_args: [cnid_dbd, dversion],
-    link_args: bdb_link_args,
-    install: true,
-    install_dir: sbindir,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+    cnid_dbd_deps = []
 
-cnid_metad_sources = ['cnid_metad.c', 'usockfd.c', 'db_param.c']
+    if use_mysql_backend
+        cnid_dbd_deps += mysqlclient
+    endif
 
-executable(
-    'cnid_metad',
-    cnid_metad_sources,
-    include_directories: root_includes,
-    link_with: libatalk,
-    dependencies: mysqlclient,
-    c_args: [cnid_dbd, dversion],
-    install: true,
-    install_dir: sbindir,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+    executable(
+        'cnid_dbd',
+        cnid_dbd_sources,
+        include_directories: [bdb_includes, root_includes],
+        link_with: libatalk,
+        dependencies: [cnid_dbd_deps, db],
+        c_args: [cnid_dbd, dversion],
+        link_args: bdb_link_args,
+        install: true,
+        install_dir: sbindir,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
 
-dbd_sources = [
-    'cmd_dbd.c',
-    'cmd_dbd_scanvol.c',
-    'dbd_add.c',
-    'dbd_delete.c',
-    'dbd_getstamp.c',
-    'dbd_lookup.c',
-    'dbd_rebuild_add.c',
-    'dbd_resolve.c',
-    'dbd_update.c',
-    'dbif.c',
-    'pack.c',
-]
+    cnid_metad_sources = ['cnid_metad.c', 'usockfd.c', 'db_param.c']
 
-executable(
-    'dbd',
-    dbd_sources,
-    include_directories: [bdb_includes, root_includes],
-    link_with: libatalk,
-    dependencies: [db, mysqlclient],
-    c_args: dversion,
-    link_args: [dversion, bdb_link_args],
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+    executable(
+        'cnid_metad',
+        cnid_metad_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        dependencies: cnid_dbd_deps,
+        c_args: [cnid_dbd, dversion],
+        install: true,
+        install_dir: sbindir,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+
+    dbd_sources = [
+        'cmd_dbd.c',
+        'cmd_dbd_scanvol.c',
+        'dbd_add.c',
+        'dbd_delete.c',
+        'dbd_getstamp.c',
+        'dbd_lookup.c',
+        'dbd_rebuild_add.c',
+        'dbd_resolve.c',
+        'dbd_update.c',
+        'dbif.c',
+        'pack.c',
+    ]
+
+    executable(
+        'dbd',
+        dbd_sources,
+        include_directories: [bdb_includes, root_includes],
+        link_with: libatalk,
+        dependencies: [cnid_dbd_deps, db],
+        c_args: dversion,
+        link_args: bdb_link_args,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+endif

--- a/etc/netatalk/meson.build
+++ b/etc/netatalk/meson.build
@@ -1,11 +1,22 @@
 netatalk_sources = ['afp_avahi.c', 'afp_mdns.c', 'afp_zeroconf.c', 'netatalk.c']
+netatalk_deps = [libevent]
+
+if use_mysql_backend
+    netatalk_deps += mysqlclient
+endif
+
+if avahi.found()
+    netatalk_deps += avahi
+elif have_dns
+    netatalk_deps += dns_sd
+endif
 
 executable(
     'netatalk',
     netatalk_sources,
     include_directories: root_includes,
     link_with: libatalk,
-    dependencies: [mysqlclient, dns_sd, avahi, libevent],
+    dependencies: netatalk_deps,
     c_args: [confdir, statedir, afpd, cnid_metad, dversion],
     install: true,
     install_dir: sbindir,

--- a/libatalk/acl/meson.build
+++ b/libatalk/acl/meson.build
@@ -4,17 +4,21 @@ acl_sources = [
     'uuid.c',
 ]
 
+libacl_deps = [acl_deps]
+
 if have_ldap
     acl_sources += [
         'ldap.c',
         'ldap_config.c',
     ]
+    libacl_deps += ldap
+    
 endif
 
 libacl = static_library(
     'acl',
     acl_sources,
     include_directories: root_includes,
-    dependencies: [acl_deps, ldap],
+    dependencies: libacl_deps,
     install: false,
 )

--- a/libatalk/compat/meson.build
+++ b/libatalk/compat/meson.build
@@ -5,14 +5,18 @@ compat_sources = [
 ]
 
 libcompat_deps = []
+libcompat_link_args = []
 
 if have_quota
     if tirpc.found()
         libcompat_deps += tirpc
     elif rpcsvc.found()
         libcompat_deps += rpcsvc
-    elif quota.found()
+        libcompat_link_args += sunrpc_link_args
+    endif
+    if quota.found()
         libcompat_deps += quota
+        libcompat_link_args += libquota_link_args
     endif
 endif
 
@@ -21,6 +25,6 @@ libcompat = static_library(
     compat_sources,
     include_directories: root_includes,
     dependencies: libcompat_deps,
-    link_args: quota_link_args,
+    link_args: libcompat_link_args,
     install: false,
 )

--- a/libatalk/compat/meson.build
+++ b/libatalk/compat/meson.build
@@ -4,11 +4,23 @@ compat_sources = [
     'strlcpy.c',
 ]
 
+libcompat_deps = []
+
+if have_quota
+    if tirpc.found()
+        libcompat_deps += tirpc
+    elif rpcsvc.found()
+        libcompat_deps += rpcsvc
+    elif quota.found()
+        libcompat_deps += quota
+    endif
+endif
+
 libcompat = static_library(
     'compat',
     compat_sources,
     include_directories: root_includes,
-    dependencies: tirpc,
+    dependencies: libcompat_deps,
     link_args: quota_link_args,
     install: false,
 )

--- a/libatalk/compat/rquota_xdr.c
+++ b/libatalk/compat/rquota_xdr.c
@@ -21,7 +21,6 @@
 */
 #if defined(NEED_RQUOTA) || defined(SOLARIS) || (defined(__GNU_LIBRARY__) && __GNU_LIBRARY__ < 6)
 
-#include <rpc/rpc.h>
 #include <rpcsvc/rquota.h>
 
 #ifndef u_int

--- a/libatalk/dsi/meson.build
+++ b/libatalk/dsi/meson.build
@@ -13,10 +13,16 @@ dsi_sources = [
     'dsi_write.c',
 ]
 
+libdsi_deps = []
+
+if have_tcpwrap
+    libdsi_deps += wrap
+endif
+
 libdsi = static_library(
     'dsi',
     dsi_sources,
-    dependencies: wrap,
+    dependencies: libdsi_deps,
     include_directories: root_includes,
     install: false,
 )

--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -1,6 +1,3 @@
-libatalk_sources = []
-libatalk_libs = []
-
 subdir('acl')
 subdir('adouble')
 subdir('bstring')
@@ -11,9 +8,21 @@ subdir('util')
 subdir('unicode')
 subdir('vfs')
 
+libatalk_deps = []
+libatalk_libs = []
+libatalk_sources = []
+
 if host_os != 'darwin'
     subdir('compat')
     libatalk_libs += libcompat
+endif
+
+if have_acls
+    libatalk_deps += acl_deps
+endif
+
+if have_threads
+    libatalk_deps += threads
 endif
 
 if have_embedded_ssl
@@ -31,7 +40,7 @@ libatalk = both_libraries(
     'atalk',
     libatalk_sources,
     include_directories: root_includes,
-    dependencies: [acl_deps, libcnid_deps, threads],
+    dependencies: [libatalk_deps, libcnid_deps],
     link_whole: [
         libacl,
         libadouble,

--- a/libatalk/vfs/meson.build
+++ b/libatalk/vfs/meson.build
@@ -1,6 +1,6 @@
 vfs_sources = ['ea_ad.c', 'ea_sys.c', 'extattr.c', 'unix.c', 'vfs.c']
 
-if with_acls
+if have_acls
     vfs_sources += ['acl.c']
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -852,7 +852,8 @@ quota = cc.find_library('quota', required: false)
 rpcsvc = cc.find_library('rpcsvc', required: false)
 tirpc = dependency('libtirpc', required: false)
 
-quota_link_args = []
+sunrpc_link_args = []
+libquota_link_args = []
 quota_provider = ''
 
 rpc_headers = [
@@ -872,8 +873,6 @@ if rpc_headers_ok
         cdata.set('HAVE_' + header.underscorify().to_upper(), 1)
     endforeach
 endif
-
-message(rpc_headers_ok)
 
 if get_option('enable-quota').disabled()
     have_quota = false
@@ -911,8 +910,6 @@ else
         'Please install either libtirpc or libquota if your system supports these libraries.',
     )
 endif
-
-message(quota_link_args)
 
 #
 # Check for libgcrypt
@@ -1779,21 +1776,22 @@ endif
 
 threads = dependency('threads', required: true)
 if threads.found()
+    have_threads = true
     cdata.set('HAVE_PTHREAD', 1)
-endif
 
-# Check for PTHREAD_PRIO_INHERIT
+    # Check for PTHREAD_PRIO_INHERIT
 
-if cc.compiles(
-    '''
-#include <pthread.h>
-int main(void) {
-int i = PTHREAD_PRIO_INHERIT;
-  return i;
-}
-''',
-)
-    cdata.set('HAVE_PTHREAD_PRIO_INHERIT', 1)
+    if cc.compiles(
+        '''
+    #include <pthread.h>
+    int main(void) {
+    int i = PTHREAD_PRIO_INHERIT;
+      return i;
+    }
+    ''',
+    )
+        cdata.set('HAVE_PTHREAD_PRIO_INHERIT', 1)
+    endif
 endif
 
 #

--- a/meson.build
+++ b/meson.build
@@ -853,6 +853,7 @@ rpcsvc = cc.find_library('rpcsvc', required: false)
 tirpc = dependency('libtirpc', required: false)
 
 quota_link_args = []
+quota_provider = ''
 
 rpc_headers = [
     'rpc/rpc.h',
@@ -860,9 +861,11 @@ rpc_headers = [
     'rpcsvc/rquota.h',
 ]
 
-rpc_headers_ok = (cc.has_header('rpc/rpc.h')
-                 and cc.has_header('rpc/pmap_prot.h')
-                 and cc.has_header('rpcsvc/rquota.h'))
+rpc_headers_ok = (
+    cc.has_header('rpc/rpc.h')
+    and cc.has_header('rpc/pmap_prot.h')
+    and cc.has_header('rpcsvc/rquota.h')
+)
 
 if rpc_headers_ok
     foreach header : rpc_headers
@@ -872,12 +875,13 @@ endif
 
 message(rpc_headers_ok)
 
-if get_option('enable-quota').disabled() or not rpc_headers_ok
+if get_option('enable-quota').disabled()
     have_quota = false
     cdata.set('NO_QUOTA_SUPPORT', 1)
 elif tirpc.found() and rpc_headers_ok
     have_quota = true
     cdata.set('NEED_RQUOTA', 1)
+    quota_provider += 'libtirpc'
     if cc.compiles(
         '''
                 #include <rpcsvc/rquota.h>
@@ -891,7 +895,7 @@ elif tirpc.found() and rpc_headers_ok
     )
         cdata.set('HAVE_RQUOTA_H_QR_STATUS', 1)
     endif
-elif rpcsvc.found()
+elif rpcsvc.found() and rpc_headers_ok
     have_quota = true
     sunrpc_link_args += '-lrpcsvc'
     quota_provider += 'SunRPC'
@@ -2067,6 +2071,13 @@ summary_info = {
     '  Kerberos support': have_kerberos,
     '  LDAP support': have_ldap,
     '  Quota support': have_quota,
+}
+if have_quota
+    summary_info += {
+        '  Quota provider': quota_provider,
+    }
+endif
+summary_info += {
     '  SSL provider': ssl_provider,
     '  TCP wrapper support': have_tcpwrap,
     '  Zeroconf support': enable_zeroconf,

--- a/meson.build
+++ b/meson.build
@@ -198,9 +198,6 @@ check_headers = [
     'mntent.h',
     'netdb.h',
     'pam/pam_appl.h',
-    'rpc/pmap/prot.h',
-    'rpc/rpc.h',
-    'rpcsvc/rquota.h',
     'security/pam_appl.h',
     'sgtty.h',
     'statfs.h',
@@ -850,8 +847,9 @@ libevent = dependency(
 # Check for quota support
 #
 
-rpcsvc = cc.find_library('rpcsvc', required: false)
+prop = cc.find_library('prop', required: false)
 quota = cc.find_library('quota', required: false)
+rpcsvc = cc.find_library('rpcsvc', required: false)
 tirpc = dependency('libtirpc', required: false)
 
 quota_link_args = []
@@ -862,63 +860,55 @@ rpc_headers = [
     'rpcsvc/rquota.h',
 ]
 
-foreach header : rpc_headers
-    if cc.has_header(header)
-        cdata.set('HAVE_' + header.underscorify().to_upper(), 1)
-    endif
-endforeach
+rpc_headers_ok = (cc.has_header('rpc/rpc.h')
+                 and cc.has_header('rpc/pmap_prot.h')
+                 and cc.has_header('rpcsvc/rquota.h'))
 
-if get_option('enable-quota').disabled()
+if rpc_headers_ok
+    foreach header : rpc_headers
+        cdata.set('HAVE_' + header.underscorify().to_upper(), 1)
+    endforeach
+endif
+
+message(rpc_headers_ok)
+
+if get_option('enable-quota').disabled() or not rpc_headers_ok
     have_quota = false
     cdata.set('NO_QUOTA_SUPPORT', 1)
-else
-    if tirpc.found() and get_option('with-libtirpc')
-        have_quota = true
-        cdata.set('NEED_RQUOTA', 1)
-
-        rquota_test = cc.compiles(
-            '''
+elif tirpc.found() and rpc_headers_ok
+    have_quota = true
+    cdata.set('NEED_RQUOTA', 1)
+    if cc.compiles(
+        '''
                 #include <rpcsvc/rquota.h>
                 int main(void) {
                     enum qr_status foo;
                     foo = Q_OK;
                     return 0;
                 }
-            ''', dependencies: tirpc
-        )
-        if rquota_test
-            cdata.set('HAVE_RQUOTA_H_QR_STATUS', 1)
-        endif
-
-        if get_option('with-libtirpc') and not tirpc.found()
-            message('Libtirpc requested, but library not found')
-        endif
-    elif (
-        rpcsvc.found()
-        and (
-            cc.has_header('rpc/rpc.h')
-            or cc.has_header('rpc/pmap_prot.h')
-            or cc.has_header('rpcsvc/rquota.h')
-        )
+            ''',
+        dependencies: tirpc,
     )
-        have_rpcsvc = cc.has_function('main', dependencies: rpcsvc)
-        quota_link_args += '-lrpcsvc'
-        if quota.found() and have_rpcsvc
-            have_quota = cc.has_function('getfsquota', dependencies: quota)
-            cdata.set('HAVE_LIBQUOTA', 1)
-            quota_link_args += ['-lquota', '-lprop', '-lrpcsvc']
-        else
-            have_quota = false
-            cdata.set('NO_QUOTA_SUPPORT', 1)
-        endif
-    else
-        have_quota = false
+        cdata.set('HAVE_RQUOTA_H_QR_STATUS', 1)
     endif
+elif rpcsvc.found()
+    have_quota = true
+    sunrpc_link_args += '-lrpcsvc'
+    quota_provider += 'SunRPC'
+    if quota.found() and cc.has_function('getfsquota', dependencies: [quota, prop, rpcsvc])
+        cdata.set('HAVE_LIBQUOTA', 1)
+        libquota_link_args += ['-lquota', '-lprop']
+    endif
+else
+    have_quota = false
+    cdata.set('NO_QUOTA_SUPPORT', 1)
+    warning(
+        'Quota support disabled as required libraries not found.',
+        'Please install either libtirpc or libquota if your system supports these libraries.',
+    )
 endif
 
-if get_option('enable-quota').enabled() and not have_quota
-    warning('Quota support requested but required libraries not found')
-endif
+message(quota_link_args)
 
 #
 # Check for libgcrypt

--- a/meson.build
+++ b/meson.build
@@ -1251,7 +1251,9 @@ with_ldap = get_option('with-ldap')
 
 ldap_link_args = []
 
-if with_ldap != ''
+if with_ldap == 'false'
+    have_ldap = false
+elif with_ldap != ''
     ldap_link_args += ['-L' + with_ldap / 'lib', '-lldap']
     if enable_rpath
         ldap_link_args += ['-R' + with_ldap / 'lib']
@@ -1260,13 +1262,19 @@ if with_ldap != ''
         link_args: ldap_link_args,
         include_directories: include_directories(with_ldap / 'include'),
     )
+    have_ldap = cc.has_function('ldap_initialize', dependencies: ldap)
 else
     ldap = cc.find_library('ldap', dirs: libsearch_dirs, required: false)
+    have_ldap = (
+        ldap.found()
+        and cc.has_function('ldap_initialize', dependencies: ldap)
+    )
 endif
 
-have_ldap = (ldap.found() and cc.has_function('ldap_initialize', dependencies: ldap))
 if have_ldap
     cdata.set('HAVE_LDAP', 1)
+elif with_ldap != 'no' and not ldap.found()
+    message('LDAP support requested but LDAP library not found')
 endif
 
 #

--- a/meson.build
+++ b/meson.build
@@ -1158,12 +1158,12 @@ acl_includes = []
 acl_link_args = []
 
 if get_option('with-acls').disabled()
-    with_acls = false
+    have_acls = false
 elif host_os == 'darwin'
-    with_acls = false
+    have_acls = false
     message('Darwin ACLs are currently unsupported')
 elif host_os.contains('sunos')
-    with_acls = true
+    have_acls = true
     sec = cc.find_library('sec', required: false)
     acl_deps += sec
     cdata.set('HAVE_ACLS', 1)
@@ -1175,15 +1175,15 @@ elif host_os == 'freebsd'
         dirs: libsearch_dirs,
         required: false,
     )
-    with_acls = cc.has_function('acl', dependencies: sunacl)
-    if with_acls
+    have_acls = cc.has_function('acl', dependencies: sunacl)
+    if have_acls
         acl_deps += sunacl
         cdata.set('HAVE_ACLS', 1)
         cdata.set('HAVE_FREEBSD_SUNACL', 1)
         cdata.set('HAVE_LIBSUNACL', 1)
         cdata.set('HAVE_NFSV4_ACLS', 1)
     else
-        with_acls = false
+        have_acls = false
         warning('libsunacl not found, disabling ZFS ACL support')
     endif
 else
@@ -1215,8 +1215,8 @@ else
             return acl_get_entry(acl, entry_id, entry_p);
         }
     '''
-    with_acls = cc.links(acl_get_entry_code, args: acl_link_args)
-    if with_acls
+    have_acls = cc.links(acl_get_entry_code, args: acl_link_args)
+    if have_acls
         cdata.set('HAVE_ACLS', 1)
         cdata.set('HAVE_POSIX_ACLS', 1)
         acl_get_perm_np_code = '''
@@ -1235,10 +1235,10 @@ else
             cdata.set('HAVE_ACL_FROM_MODE', 1)
         endif
     else
-        with_acls = false
+        have_acls = false
     endif
 
-    if not get_option('with-acls').disabled() and not with_acls
+    if get_option('with-acls').enabled() and not have_acls
         warning('ACL support requested but not found')
     endif
 endif
@@ -1273,7 +1273,7 @@ endif
 
 if have_ldap
     cdata.set('HAVE_LDAP', 1)
-elif with_ldap != 'no' and not ldap.found()
+elif with_ldap != 'no' and not have_ldap
     message('LDAP support requested but LDAP library not found')
 endif
 
@@ -2059,7 +2059,7 @@ endif
 summary(summary_info, bool_yn: true, section: '  UAMs:')
 
 summary_info = {
-    '  ACL support': with_acls,
+    '  ACL support': have_acls,
     '  AFP stats via dbus': with_afpstats,
     '  Cracklib support': have_cracklib,
     '  dtrace probes': with_dtrace,

--- a/meson.build
+++ b/meson.build
@@ -877,7 +877,7 @@ endif
 if get_option('enable-quota').disabled()
     have_quota = false
     cdata.set('NO_QUOTA_SUPPORT', 1)
-elif tirpc.found() and rpc_headers_ok
+elif tirpc.found() and cc.has_header('rpcsvc/rquota.h')
     have_quota = true
     cdata.set('NEED_RQUOTA', 1)
     quota_provider += 'libtirpc'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -193,7 +193,7 @@ option(
 option(
     'disable-init-hooks',
     type: 'boolean',
-    value: 'false',
+    value: false,
     description: 'Disable install hooks for OS specific init system',
 )
 option(
@@ -219,12 +219,6 @@ option(
     type: 'string',
     value: '',
     description: 'Path to libiconv installation. Must contain lib and include dirs',
-)
-option(
-    'with-libtirpc',
-    type: 'boolean',
-    value: false,
-    description: 'Use libtirpc as RPC implementation (instead of sunrpc)',
 )
 option(
     'with-lockfile',

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -1,5 +1,3 @@
-test_internal_deps = []
-test_external_deps = []
 test_sources = [
     'afpfunc_helpers.c',
     'subtests.c',
@@ -33,6 +31,10 @@ test_sources = [
     meson.project_source_root() / 'etc/afpd/volume.c',
 ]
 
+test_external_deps = []
+test_internal_deps = []
+test_link_args = []
+
 if have_spotlight
     test_sources += [
         meson.project_source_root() / 'etc/afpd/spotlight.c',
@@ -57,13 +59,14 @@ if have_quota
         meson.project_source_root() / 'etc/afpd/quota.c',
     ]
     if tirpc.found()
-        afpd_external_deps += tirpc
+        test_external_deps += tirpc
     elif rpcsvc.found()
-        afpd_external_deps += rpcsvc
-        netatalk_common_link_args += quota_link_args
-    elif quota.found()
-        afpd_external_deps += rpcsvc
-        netatalk_common_link_args += quota_link_args
+        test_external_deps += rpcsvc
+        netatalk_common_link_args += sunrpc_link_args
+    endif
+    if quota.found()
+        test_external_deps += quota
+        netatalk_common_link_args += libquota_link_args
     endif
 endif
 
@@ -96,7 +99,7 @@ afpdtestlib = static_library(
         statedir,
         uamdir,
     ],
-    link_args: netatalk_common_link_args,
+    link_args: test_link_args,
     install: false,
     build_by_default: false,
 )
@@ -166,7 +169,7 @@ afpdtest = executable(
         tirpc,
     ],
     c_args: ['-DAPPLCNAME', dversion, messagedir, uamdir, confdir, statedir],
-    link_args: quota_link_args,
+    link_args: test_link_args,
     export_dynamic: true,
     install: false,
 )

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -46,7 +46,7 @@ if have_spotlight
     ]
 endif
 
-if with_acls
+if have_acls
     test_sources += meson.project_source_root() / 'etc/afpd/acls.c'
     test_external_deps += acl_deps
 endif

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -25,9 +25,7 @@ test_sources = [
     meson.project_source_root() / 'etc/afpd/hash.c',
     meson.project_source_root() / 'etc/afpd/mangle.c',
     meson.project_source_root() / 'etc/afpd/messages.c',
-    meson.project_source_root() / 'etc/afpd/nfsquota.c',
     meson.project_source_root() / 'etc/afpd/ofork.c',
-    meson.project_source_root() / 'etc/afpd/quota.c',
     meson.project_source_root() / 'etc/afpd/status.c',
     meson.project_source_root() / 'etc/afpd/switch.c',
     meson.project_source_root() / 'etc/afpd/uam.c',
@@ -51,6 +49,22 @@ endif
 if with_acls
     test_sources += meson.project_source_root() / 'etc/afpd/acls.c'
     test_external_deps += acl_deps
+endif
+
+if have_quota
+    test_sources += [
+        meson.project_source_root() / 'etc/afpd/nfsquota.c',
+        meson.project_source_root() / 'etc/afpd/quota.c',
+    ]
+    if tirpc.found()
+        afpd_external_deps += tirpc
+    elif rpcsvc.found()
+        afpd_external_deps += rpcsvc
+        netatalk_common_link_args += quota_link_args
+    elif quota.found()
+        afpd_external_deps += rpcsvc
+        netatalk_common_link_args += quota_link_args
+    endif
 endif
 
 # For dtrace probes we need to invoke dtrace on all input files, before
@@ -82,7 +96,7 @@ afpdtestlib = static_library(
         statedir,
         uamdir,
     ],
-    #link_args: kerberos_link_args,
+    link_args: netatalk_common_link_args,
     install: false,
     build_by_default: false,
 )


### PR DESCRIPTION
This changeset refines the meson build system:

- Enables quota support on all flavours of linux and BSD (including macOS)
- Adds the quota provider to the configuration summary
- Adds a user option to disable LDAP support
- Sets dependencies according to user configuration
- Improves the syntax of the ACL macro
