### PR TITLE
[2.4] meson: Address various issues with the meson build system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,7 +142,8 @@ jobs:
             make \
             meson \
             ninja \
-            pkgconfig
+            pkgconfig \
+            rpcsvc-proto
       - name: Autotools - Bootstrap
         run: ./bootstrap
       - name: Autotools - Configure

--- a/bin/ad/meson.build
+++ b/bin/ad/meson.build
@@ -8,11 +8,17 @@ ad_sources = [
     'ad.c',
 ]
 
+ad_deps = []
+
+if have_acls
+    ad_deps += acl_deps
+endif
+
 executable(
     'ad',
     ad_sources,
     include_directories: root_includes,
-    dependencies: acl_deps,
+    dependencies: ad_deps,
     link_with: [libatalk, libcnid],
     c_args: [ad, dversion],
     install: true,

--- a/bin/afppasswd/meson.build
+++ b/bin/afppasswd/meson.build
@@ -1,9 +1,28 @@
+afppasswd_deps = []
+afppasswd_libs = []
+
+if have_cracklib
+    afppasswd_deps += crack
+endif
+
+if crypto.found()
+    afppasswd_deps += ssl_deps
+endif
+
+if have_embedded_ssl
+    afppasswd_libs += libatalk
+endif
+
+if have_cracklib
+    afppasswd_deps += crack
+endif
+
 executable(
     'afppasswd',
     'afppasswd.c',
     include_directories: root_includes,
-    dependencies: [crack, ssl_deps],
-    link_with: libatalk,
+    dependencies: afppasswd_deps,
+    link_with: afppasswd_libs,
     c_args: [afpdpwfile, dversion],
     install: true,
     build_rpath: libdir,

--- a/bin/misc/meson.build
+++ b/bin/misc/meson.build
@@ -22,13 +22,16 @@ executable(
     install: false,
 )
 
-executable(
-    'afpldaptest',
-    'uuidtest.c',
-    include_directories: root_includes,
-    link_with: libatalk,
-    c_args: acl_ldapconf,
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if have_ldap
+    executable(
+        'afpldaptest',
+        'uuidtest.c',
+        include_directories: root_includes,
+       dependencies: ldap,
+        link_with: libatalk,
+        c_args: acl_ldapconf,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+endif

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -1,6 +1,3 @@
-afpd_internal_deps = []
-afpd_external_deps = []
-
 afpd_sources = [
     'afp_asp.c',
     'afp_avahi.c',
@@ -38,9 +35,50 @@ afpd_sources = [
     'volume.c',
 ]
 
+afpd_external_deps = [libgcrypt]
+afpd_internal_deps = [libcnid]
+afpd_link_args = []
+
 if have_acls
     afpd_sources += 'acls.c'
     afpd_external_deps += [acl_deps]
+endif
+
+if have_quota
+    afpd_sources += [
+        'nfsquota.c',
+        'quota.c',
+    ]
+    if tirpc.found()
+        afpd_external_deps += tirpc
+    elif rpcsvc.found()
+        afpd_external_deps += rpcsvc
+        afpd_link_args += sunrpc_link_args
+    endif
+    if quota.found()
+        afpd_external_deps += quota
+        afpd_link_args += libquota_link_args
+    endif
+endif
+
+if have_gssapi
+    afpd_external_deps += gss
+endif
+
+if have_tcpwrap
+    afpd_external_deps += wrap
+endif
+
+if threads.found()
+    afpd_external_deps += threads
+endif
+
+if avahi.found()
+    afpd_external_deps += avahi
+endif
+
+if have_dns
+    afpd_external_deps += dns_sd
 endif
 
 executable(
@@ -48,15 +86,7 @@ executable(
     afpd_sources,
     include_directories: root_includes,
     link_with: [afpd_internal_deps, libatalk],
-    dependencies: [
-        afpd_external_deps,
-        avahi,
-        libgcrypt,
-        dns_sd,
-        threads,
-        tirpc,
-        wrap,
-    ],
+    dependencies: afpd_external_deps,
     c_args: [
         '-DAPPLCNAME', acl_ldapconf,
         afpdconf,
@@ -69,10 +99,7 @@ executable(
         messagedir,
         uamdir,
     ],
-    link_args: [
-        netatalk_common_link_args,
-        quota_link_args,
-    ],
+    link_args: afpd_link_args,
     export_dynamic: true,
     install: true,
     install_dir: sbindir,

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -38,7 +38,7 @@ afpd_sources = [
     'volume.c',
 ]
 
-if with_acls
+if have_acls
     afpd_sources += 'acls.c'
     afpd_external_deps += [acl_deps]
 endif

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -37,7 +37,6 @@ afpd_sources = [
 
 afpd_external_deps = [libgcrypt]
 afpd_internal_deps = [libcnid]
-afpd_link_args = []
 
 if have_acls
     afpd_sources += 'acls.c'
@@ -49,16 +48,7 @@ if have_quota
         'nfsquota.c',
         'quota.c',
     ]
-    if tirpc.found()
-        afpd_external_deps += tirpc
-    elif rpcsvc.found()
-        afpd_external_deps += rpcsvc
-        afpd_link_args += sunrpc_link_args
-    endif
-    if quota.found()
-        afpd_external_deps += quota
-        afpd_link_args += libquota_link_args
-    endif
+    afpd_external_deps += [quota_deps]
 endif
 
 if have_gssapi
@@ -99,7 +89,6 @@ executable(
         messagedir,
         uamdir,
     ],
-    link_args: afpd_link_args,
     export_dynamic: true,
     install: true,
     install_dir: sbindir,

--- a/etc/afpd/unix.h
+++ b/etc/afpd/unix.h
@@ -12,7 +12,7 @@
 #include <sys/vfs.h>
 #endif /* HAVE_SYS_VFS_H */
 
-#if defined(HAVE_STATFS_H) 
+#if defined(HAVE_STATFS_H)
 #include <sys/statfs.h>
 /* this might not be right. */
 #define f_mntfromname f_fname
@@ -29,14 +29,17 @@
 #include <sys/mnttab.h>
 #endif /* __svr4__ || HAVE_SYS_MNTTAB_H */
 
-#if defined(HAVE_SYS_MOUNT_H)
+#if defined(__DragonFly__)
+#define dqblk ufs_dqblk
+#endif
+
+#if defined(HAVE_SYS_MOUNT_H) || defined(BSD4_4) || defined(__linux__)
 #include <sys/mount.h>
-#endif /* HAVE_SYS_MOUNT_H */
+#endif /* HAVE_SYS_MOUNT_H || BSD4_4 || __linux__ */
 
-#if defined(HAVE_MNTENT_H)
+#if defined(__linux__) || defined(HAVE_MNTENT_H)
 #include <mntent.h>
-#endif /* HAVE_MNTENT_H */
-
+#endif /* linux || HAVE_MNTENT_H */
 
 #ifndef NO_QUOTA_SUPPORT
 #if !defined(HAVE_LIBQUOTA)
@@ -58,12 +61,20 @@
 #endif /* ! NEED_QUOTACTL_WRAPPER */
 #endif /* linux || HAVE_QUOTA_H */
 
-#ifdef __svr4__ 
+#ifdef __svr4__
 #include <sys/fs/ufs_quota.h>
 #endif /* __svr4__ */
 
 #ifdef BSD4_4
+#if defined(__DragonFly__)
+#include <vfs/ufs/quota.h>
+#elif defined(__NetBSD__)
 #include <ufs/ufs/quota.h>
+#include <ufs/ufs/quota1.h>
+#include <ufs/ufs/quota2.h>
+#else /* DragonFly */
+#include <ufs/ufs/quota.h>
+#endif /* DragonFly */
 #endif /* BSD4_4 */
 
 #ifdef HAVE_UFS_QUOTA_H

--- a/etc/cnid_dbd/meson.build
+++ b/etc/cnid_dbd/meson.build
@@ -1,72 +1,74 @@
-cnid_dbd_sources = [
-    'comm.c',
-    'db_param.c',
-    'dbd_add.c',
-    'dbd_dbcheck.c',
-    'dbd_delete.c',
-    'dbd_get.c',
-    'dbd_getstamp.c',
-    'dbd_lookup.c',
-    'dbd_rebuild_add.c',
-    'dbd_resolve.c',
-    'dbd_search.c',
-    'dbd_update.c',
-    'dbif.c',
-    'main.c',
-    'pack.c',
-]
+if use_dbd_backend
+    cnid_dbd_sources = [
+        'comm.c',
+        'db_param.c',
+        'dbd_add.c',
+        'dbd_dbcheck.c',
+        'dbd_delete.c',
+        'dbd_get.c',
+        'dbd_getstamp.c',
+        'dbd_lookup.c',
+        'dbd_rebuild_add.c',
+        'dbd_resolve.c',
+        'dbd_search.c',
+        'dbd_update.c',
+        'dbif.c',
+        'main.c',
+        'pack.c',
+    ]
 
-executable(
-    'cnid_dbd',
-    cnid_dbd_sources,
-    include_directories: [bdb_includes, root_includes],
-    link_with: libatalk,
-    dependencies: db,
-    c_args: [cnid_dbd, dversion],
-    link_args: bdb_link_args,
-    install: true,
-    install_dir: sbindir,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+    executable(
+        'cnid_dbd',
+        cnid_dbd_sources,
+        include_directories: [bdb_includes, root_includes],
+        link_with: libatalk,
+        dependencies: db,
+        c_args: [cnid_dbd, dversion],
+        link_args: bdb_link_args,
+        install: true,
+        install_dir: sbindir,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
 
-cnid_metad_sources = ['cnid_metad.c', 'usockfd.c', 'db_param.c']
+    cnid_metad_sources = ['cnid_metad.c', 'usockfd.c', 'db_param.c']
 
-executable(
-    'cnid_metad',
-    cnid_metad_sources,
-    include_directories: root_includes,
-    link_with: libatalk,
-    c_args: [cnid_dbd, dversion],
-    install: true,
-    install_dir: sbindir,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+    executable(
+        'cnid_metad',
+        cnid_metad_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: [cnid_dbd, dversion],
+        install: true,
+        install_dir: sbindir,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
 
-dbd_sources = [
-    'cmd_dbd.c',
-    'cmd_dbd_scanvol.c',
-    'dbd_add.c',
-    'dbd_delete.c',
-    'dbd_getstamp.c',
-    'dbd_lookup.c',
-    'dbd_rebuild_add.c',
-    'dbd_resolve.c',
-    'dbd_update.c',
-    'dbif.c',
-    'pack.c',
-]
+    dbd_sources = [
+        'cmd_dbd.c',
+        'cmd_dbd_scanvol.c',
+        'dbd_add.c',
+        'dbd_delete.c',
+        'dbd_getstamp.c',
+        'dbd_lookup.c',
+        'dbd_rebuild_add.c',
+        'dbd_resolve.c',
+        'dbd_update.c',
+        'dbif.c',
+        'pack.c',
+    ]
 
-executable(
-    'dbd',
-    dbd_sources,
-    include_directories: [bdb_includes, root_includes],
-    link_with: libatalk,
-    dependencies: db,
-    c_args: dversion,
-    link_args: [dversion, bdb_link_args],
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+    executable(
+        'dbd',
+        dbd_sources,
+        include_directories: [bdb_includes, root_includes],
+        link_with: libatalk,
+        dependencies: db,
+        c_args: dversion,
+        link_args: [dversion, bdb_link_args],
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+endif

--- a/libatalk/acl/meson.build
+++ b/libatalk/acl/meson.build
@@ -4,17 +4,20 @@ acl_sources = [
     'uuid.c',
 ]
 
+libacl_deps = [acl_deps]
+
 if have_ldap
     acl_sources += [
         'ldap.c',
         'ldap_config.c',
     ]
+    libacl_deps += ldap
 endif
 
 libacl = static_library(
     'acl',
     acl_sources,
     include_directories: root_includes,
-    dependencies: [acl_deps, ldap],
+    dependencies: libacl_deps,
     install: false,
 )

--- a/libatalk/compat/meson.build
+++ b/libatalk/compat/meson.build
@@ -4,11 +4,27 @@ compat_sources = [
     'rquota_xdr.c',
 ]
 
+libcompat_deps = []
+libcompat_link_args = []
+
+if have_quota
+    if tirpc.found()
+        libcompat_deps += tirpc
+    elif rpcsvc.found()
+        libcompat_deps += rpcsvc
+        libcompat_link_args += sunrpc_link_args
+    endif
+    if quota.found()
+        libcompat_deps += quota
+        libcompat_link_args += libquota_link_args
+    endif
+endif
+
 libcompat = static_library(
     'compat',
     compat_sources,
     include_directories: root_includes,
-    dependencies: tirpc,
-    link_args: quota_link_args,
+    dependencies: libcompat_deps,
+    link_args: libcompat_link_args,
     install: false,
 )

--- a/libatalk/compat/meson.build
+++ b/libatalk/compat/meson.build
@@ -5,19 +5,9 @@ compat_sources = [
 ]
 
 libcompat_deps = []
-libcompat_link_args = []
 
 if have_quota
-    if tirpc.found()
-        libcompat_deps += tirpc
-    elif rpcsvc.found()
-        libcompat_deps += rpcsvc
-        libcompat_link_args += sunrpc_link_args
-    endif
-    if quota.found()
-        libcompat_deps += quota
-        libcompat_link_args += libquota_link_args
-    endif
+    libcompat_deps += quota_deps
 endif
 
 libcompat = static_library(
@@ -25,6 +15,5 @@ libcompat = static_library(
     compat_sources,
     include_directories: root_includes,
     dependencies: libcompat_deps,
-    link_args: libcompat_link_args,
     install: false,
 )

--- a/libatalk/compat/rquota_xdr.c
+++ b/libatalk/compat/rquota_xdr.c
@@ -20,7 +20,6 @@
 */
 #if defined(NEED_RQUOTA) || defined(SOLARIS) || (defined(__GNU_LIBRARY__) && __GNU_LIBRARY__ < 6)
 
-#include <rpc/rpc.h>
 #include <rpcsvc/rquota.h>
 
 bool_t

--- a/libatalk/dsi/meson.build
+++ b/libatalk/dsi/meson.build
@@ -13,10 +13,16 @@ dsi_sources = [
     'dsi_write.c',
 ]
 
+libdsi_deps = []
+
+if have_tcpwrap
+    libdsi_deps += wrap
+endif
+
 libdsi = static_library(
     'dsi',
     dsi_sources,
-    dependencies: wrap,
+    dependencies: libdsi_deps,
     include_directories: root_includes,
     install: false,
 )

--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -1,6 +1,3 @@
-libatalk_sources = []
-libatalk_libs = []
-
 subdir('acl')
 subdir('adouble')
 subdir('bstring')
@@ -10,9 +7,21 @@ subdir('util')
 subdir('unicode')
 subdir('vfs')
 
+libatalk_deps = []
+libatalk_libs = []
+libatalk_sources = []
+
 if host_os != 'darwin'
     subdir('compat')
     libatalk_libs += libcompat
+endif
+
+if have_acls
+    libatalk_deps += acl_deps
+endif
+
+if threads.found()
+    libatalk_deps += threads
 endif
 
 if get_option('enable-ddp')
@@ -38,7 +47,7 @@ libatalk = both_libraries(
     'atalk',
     libatalk_sources,
     include_directories: root_includes,
-    dependencies: [acl_deps, libcnid_deps, threads],
+    dependencies: [libatalk_deps, libcnid_deps],
     link_whole: [
         libacl,
         libadouble,

--- a/libatalk/vfs/meson.build
+++ b/libatalk/vfs/meson.build
@@ -1,6 +1,6 @@
 vfs_sources = ['ea_sys.c', 'ea.c', 'sys_ea.c', 'unix.c', 'vfs.c']
 
-if with_acls
+if have_acls
     vfs_sources += ['acl.c']
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -585,56 +585,45 @@ gssapi_headers = [
 foreach header : gssapi_headers
     if cc.has_header(
         header,
-        include_directories: include_directories(
-            [with_gssapi / 'include', header_dir],
-        ),
+        include_directories: include_directories(header_dir),
     )
         cdata.set('HAVE_' + header.underscorify().to_upper(), 1)
     endif
 
 endforeach
 
-if get_option('with-gssapi') != ''
+if get_option('with-gssapi') == 'false'
+    have_gssapi = false
+elif get_option('with-gssapi') != ''
+    have_gssapi = true
     gss = cc.find_library(
         'gssapi',
         dirs: with_gssapi / 'lib',
         required: false,
     )
     gssapi_includes += include_directories(with_gssapi / 'include')
+
 else
     gss = cc.find_library('gss', dirs: libsearch_dirs, required: false)
     if gss.found()
         cdata.set('HAVE_LIBGSS', 1)
-    elif not gss.found()
+    else
         gss = cc.find_library('gssapi', dirs: libsearch_dirs, required: false)
         if gss.found()
             cdata.set('HAVE_LIBGSSAPI', 1)
-        elif not gss.found()
-            gss = cc.find_library(
-                'gssapi_krb5',
-                dirs: libsearch_dirs,
-                required: false,
-            )
+        else
+            gss = cc.find_library('gssapi_krb5', dirs: libsearch_dirs, required: false)
             if gss.found()
                 cdata.set('HAVE_LIBGSSAPI_KRB5', 1)
+            else
+                have_gssapi = false
             endif
         endif
     endif
-endif
-
-if not gss.found()
-    have_gssapi = false
-else
     have_gssapi = (
         gss.found()
-        and cc.has_function(
-            'gss_acquire_cred',
-            dependencies: gss,
-        )
+        and cc.has_function('gss_acquire_cred', dependencies: gss)
     )
-    if with_gssapi != '' and not have_gssapi
-        error('GSSAPI support requested but not found')
-    endif
 endif
 
 if have_gssapi
@@ -1504,7 +1493,7 @@ elif fs.is_dir('/usr/local/share/cracklib')
     cracklib_dict += '/usr/local/share/cracklib/cracklib-small'
 endif
 
-if not crack.found()
+if with_cracklib == 'false'
     have_cracklib = false
 else
     have_cracklib = crack.found() and (with_cracklib != '' or cracklib_dict != '')
@@ -1515,12 +1504,16 @@ else
         elif host_os == 'darwin'
             cdata.set(
                 '_PATH_CRACKLIB',
-                '"' + brew_prefix / 'var/cracklib/cracklib-words' + '"',
+                '"' + macos_prefix / 'var/cracklib/cracklib-words' + '"',
             )
         elif cracklib_dict != ''
             cdata.set('_PATH_CRACKLIB', '"' + cracklib_dict + '"')
         endif
     endif
+endif
+
+if with_cracklib != 'false' and not have_cracklib
+    message('Cracklib support requested but cracklib library not found')
 endif
 
 #

--- a/meson.build
+++ b/meson.build
@@ -210,9 +210,6 @@ check_headers = [
     'ndir.h',
     'netdb.h',
     'pam/pam_appl.h',
-    'rpcsvc/rquota.h',
-    'rpc/pmap/prot.h',
-    'rpc/rpc.h',
     'security/pam_appl.h',
     'sgtty.h',
     'statfs.h',
@@ -729,11 +726,14 @@ endif
 # Check for quota support
 #
 
-rpcsvc = cc.find_library('rpcsvc', required: false)
+prop = cc.find_library('prop', required: false)
 quota = cc.find_library('quota', required: false)
+rpcsvc = cc.find_library('rpcsvc', required: false)
 tirpc = dependency('libtirpc', required: false)
 
-quota_link_args = []
+sunrpc_link_args = []
+libquota_link_args = []
+quota_provider = ''
 
 rpc_headers = [
     'rpc/rpc.h',
@@ -741,62 +741,53 @@ rpc_headers = [
     'rpcsvc/rquota.h',
 ]
 
-foreach header : rpc_headers
-    if cc.has_header(header)
+rpc_headers_ok = (
+    cc.has_header('rpc/rpc.h')
+    and cc.has_header('rpc/pmap_prot.h')
+    and cc.has_header('rpcsvc/rquota.h')
+)
+
+if rpc_headers_ok
+    foreach header : rpc_headers
         cdata.set('HAVE_' + header.underscorify().to_upper(), 1)
-    endif
-endforeach
+    endforeach
+endif
 
 if get_option('enable-quota').disabled()
     have_quota = false
     cdata.set('NO_QUOTA_SUPPORT', 1)
-else
-    if tirpc.found() and get_option('with-libtirpc')
-        have_quota = true
-        cdata.set('NEED_RQUOTA', 1)
-
-        rquota_test = cc.compiles(
-            '''
+elif tirpc.found() and cc.has_header('rpcsvc/rquota.h')
+    have_quota = true
+    cdata.set('NEED_RQUOTA', 1)
+    quota_provider += 'libtirpc'
+    if cc.compiles(
+        '''
                 #include <rpcsvc/rquota.h>
                 int main(void) {
                     enum qr_status foo;
                     foo = Q_OK;
                     return 0;
                 }
-            ''', dependencies: tirpc
-        )
-        if rquota_test
-            cdata.set('HAVE_RQUOTA_H_QR_STATUS', 1)
-        endif
-
-        if get_option('with-libtirpc') and not tirpc.found()
-            message('Libtirpc requested, but library not found')
-        endif
-    elif (
-        rpcsvc.found()
-        and (
-            cc.has_header('rpc/rpc.h')
-            or cc.has_header('rpc/pmap_prot.h')
-            or cc.has_header('rpcsvc/rquota.h')
-        )
+            ''',
+        dependencies: tirpc,
     )
-        have_rpcsvc = cc.has_function('main', dependencies: rpcsvc)
-        quota_link_args += '-lrpcsvc'
-        if quota.found() and have_rpcsvc
-            have_quota = cc.has_function('getfsquota', dependencies: quota)
-            cdata.set('HAVE_LIBQUOTA', 1)
-            quota_link_args += ['-lquota', '-lprop', '-lrpcsvc']
-        else
-            have_quota = false
-            cdata.set('NO_QUOTA_SUPPORT', 1)
-        endif
-    else
-        have_quota = false
+        cdata.set('HAVE_RQUOTA_H_QR_STATUS', 1)
     endif
-endif
-
-if get_option('enable-quota').enabled() and not have_quota
-    warning('Quota support requested but required libraries nor found')
+elif rpcsvc.found() and rpc_headers_ok
+    have_quota = true
+    sunrpc_link_args += '-lrpcsvc'
+    quota_provider += 'SunRPC'
+    if quota.found() and cc.has_function('getfsquota', dependencies: [quota, prop, rpcsvc])
+        cdata.set('HAVE_LIBQUOTA', 1)
+        libquota_link_args += ['-lquota', '-lprop']
+    endif
+else
+    have_quota = false
+    cdata.set('NO_QUOTA_SUPPORT', 1)
+    warning(
+        'Quota support disabled as required libraries not found.',
+        'Please install either libtirpc or libquota if your system supports these libraries.',
+    )
 endif
 
 #

--- a/meson.build
+++ b/meson.build
@@ -725,13 +725,14 @@ endif
 # Check for quota support
 #
 
+with_quota = get_option('with-quota')
+
 prop = cc.find_library('prop', required: false)
 quota = cc.find_library('quota', required: false)
 rpcsvc = cc.find_library('rpcsvc', required: false)
 tirpc = dependency('libtirpc', required: false)
 
-sunrpc_link_args = []
-libquota_link_args = []
+quota_deps = []
 quota_provider = ''
 
 rpc_headers = [
@@ -752,12 +753,13 @@ if rpc_headers_ok
     endforeach
 endif
 
-if get_option('enable-quota').disabled()
+if with_quota == 'false'
     have_quota = false
     cdata.set('NO_QUOTA_SUPPORT', 1)
 elif tirpc.found() and cc.has_header('rpcsvc/rquota.h')
     have_quota = true
     cdata.set('NEED_RQUOTA', 1)
+    quota_deps += tirpc
     quota_provider += 'libtirpc'
     if cc.compiles(
         '''
@@ -774,19 +776,19 @@ elif tirpc.found() and cc.has_header('rpcsvc/rquota.h')
     endif
 elif rpcsvc.found() and rpc_headers_ok
     have_quota = true
-    sunrpc_link_args += '-lrpcsvc'
+    quota_deps += rpcsvc
     quota_provider += 'SunRPC'
     if quota.found() and cc.has_function('getfsquota', dependencies: [quota, prop, rpcsvc])
+        quota_deps += [quota, prop]
         cdata.set('HAVE_LIBQUOTA', 1)
-        libquota_link_args += ['-lquota', '-lprop']
     endif
 else
     have_quota = false
     cdata.set('NO_QUOTA_SUPPORT', 1)
-    warning(
-        'Quota support disabled as required libraries not found.',
-        'Please install either libtirpc or libquota if your system supports these libraries.',
-    )
+endif
+
+if with_quota != 'false' and not have_quota
+    message('Ouota support requested but libtirpc or libquota libraries not found')
 endif
 
 #
@@ -1811,6 +1813,13 @@ summary_info = {
     '  GSSAPI support': have_gssapi,
     '  LDAP support': have_ldap,
     '  Quota support': have_quota,
+}
+if have_quota
+    summary_info += {
+        '  Quota provider': quota_provider,
+    }
+endif
+summary_info += {
     '  SSL provider': ssl_provider,
     '  TCP wrapper support': have_tcpwrap,
     '  valid shell check': valid_shellcheck,

--- a/meson.build
+++ b/meson.build
@@ -1058,18 +1058,29 @@ endif
 
 with_ldap = get_option('with-ldap')
 
-if with_ldap != ''
+ldap_link_args = []
+
+if with_ldap == 'false'
+    have_ldap = false
+elif with_ldap != ''
+    ldap_link_args += ['-L' + with_ldap / 'lib', '-lldap', '-R' + with_ldap / 'lib']
     ldap = declare_dependency(
-        link_args: ['-L' + with_ldap / 'lib', '-lldap', '-R' + with_ldap / 'lib'],
+        link_args: ldap_link_args,
         include_directories: include_directories(with_ldap / 'include'),
     )
+    have_ldap = cc.has_function('ldap_initialize', dependencies: ldap)
 else
     ldap = cc.find_library('ldap', dirs: libsearch_dirs, required: false)
+    have_ldap = (
+        ldap.found()
+        and cc.has_function('ldap_initialize', dependencies: ldap)
+    )
 endif
 
-have_ldap = (ldap.found() and cc.has_function('ldap_initialize', dependencies: ldap))
 if have_ldap
     cdata.set('HAVE_LDAP', 1)
+elif with_ldap != 'false' and not have_ldap
+    message('LDAP support requested but LDAP library not found')
 endif
 
 #

--- a/meson.build
+++ b/meson.build
@@ -985,12 +985,12 @@ acl_includes = []
 acl_link_args = []
 
 if get_option('with-acls').disabled()
-    with_acls = false
+    have_acls = false
 elif host_os == 'darwin'
-    with_acls = false
+    have_acls = false
     message('Darwin ACLs are currently unsupported')
 elif host_os.contains('sunos')
-    with_acls = true
+    have_acls = true
     sec = cc.find_library('sec', required: false)
     acl_deps += sec
     cdata.set('HAVE_ACLS', 1)
@@ -1024,8 +1024,8 @@ else
             return acl_get_entry(acl, entry_id, entry_p);
         }
     '''
-    with_acls = cc.links(acl_get_entry_code, args: acl_link_args)
-    if with_acls
+    have_acls = cc.links(acl_get_entry_code, args: acl_link_args)
+    if have_acls
         cdata.set('HAVE_ACLS', 1)
         cdata.set('HAVE_POSIX_ACLS', 1)
         acl_get_perm_np_code = '''
@@ -1044,10 +1044,10 @@ else
             cdata.set('HAVE_ACL_FROM_MODE', 1)
         endif
     else
-        with_acls = false
+        have_acls = false
     endif
 
-    if not get_option('with-acls').disabled() and not with_acls
+    if not get_option('with-acls').disabled() and not have_acls
         warning('ACL support requested but not found')
     endif
 endif
@@ -1801,7 +1801,7 @@ summary(summary_info, bool_yn: true, section: '  UAMs:')
 
 summary_info = {
     '  admin group support': admin_group,
-    '  ACL support': with_acls,
+    '  ACL support': have_acls,
     '  CUPS support': have_cups,
     '  DDP (AppleTalk) support': get_option('enable-ddp'),
     '  Cracklib support': have_cracklib,

--- a/meson.build
+++ b/meson.build
@@ -129,6 +129,15 @@ grep = find_program('grep', required: false)
 perl = find_program('perl', required: false)
 uname = find_program('uname', required: false)
 
+macos_prefix = ''
+if host_os == 'darwin'
+    if cpu == 'aarch64'
+        macos_prefix += '/opt/homebrew'
+    elif cpu == 'x86_64'
+        macos_prefix += '/usr/local'
+    endif
+endif
+
 ################
 # Dependencies #
 ################
@@ -414,6 +423,7 @@ bdb_dirs = [
     '/usr/local',
     '/usr/pkg',
     '/opt/local',
+    macos_prefix / 'opt/berkeley-db',
     '/usr',
 ]
 bdb_subdirs = [

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -113,9 +113,9 @@ option(
     description: 'Enable build of PGP UAM module',
 )
 option(
-    'enable-quota',
-    type: 'feature',
-    value: 'auto',
+    'with-quota',
+    type: 'string',
+    value: '',
     description: 'Turn on quota support',
 )
 option(

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -1,6 +1,3 @@
-test_internal_deps = []
-test_external_deps = []
-
 test_sources = [
     'afpfunc_helpers.c',
     'subtests.c',
@@ -30,9 +27,7 @@ test_sources = [
     meson.project_source_root() / 'etc/afpd/hash.c',
     meson.project_source_root() / 'etc/afpd/mangle.c',
     meson.project_source_root() / 'etc/afpd/messages.c',
-    meson.project_source_root() / 'etc/afpd/nfsquota.c',
     meson.project_source_root() / 'etc/afpd/ofork.c',
-    meson.project_source_root() / 'etc/afpd/quota.c',
     meson.project_source_root() / 'etc/afpd/status.c',
     meson.project_source_root() / 'etc/afpd/switch.c',
     meson.project_source_root() / 'etc/afpd/uam.c',
@@ -40,9 +35,50 @@ test_sources = [
     meson.project_source_root() / 'etc/afpd/volume.c',
 ]
 
+test_external_deps = [libgcrypt]
+test_internal_deps = []
+test_link_args = []
+
 if have_acls
     test_sources += meson.project_source_root() / 'etc/afpd/acls.c'
     test_external_deps += [acl_deps]
+endif
+
+if have_quota
+    test_sources += [
+        meson.project_source_root() / 'etc/afpd/nfsquota.c',
+        meson.project_source_root() / 'etc/afpd/quota.c',
+    ]
+    if tirpc.found()
+        test_external_deps += tirpc
+    elif rpcsvc.found()
+        test_external_deps += rpcsvc
+        test_link_args += sunrpc_link_args
+    endif
+    if quota.found()
+        test_external_deps += quota
+        test_link_args += libquota_link_args
+    endif
+endif
+
+if have_gssapi
+    test_external_deps += gss
+endif
+
+if have_tcpwrap
+    test_external_deps += wrap
+endif
+
+if threads.found()
+    test_external_deps += threads
+endif
+
+if avahi.found()
+    test_external_deps += avahi
+endif
+
+if have_dns
+    test_external_deps += dns_sd
 endif
 
 afpdtest = executable(
@@ -50,14 +86,7 @@ afpdtest = executable(
     test_sources,
     include_directories: root_includes,
     link_with: [test_internal_deps, libatalk],
-    dependencies: [
-        test_external_deps,
-        avahi,
-        libgcrypt,
-        dns_sd,
-        tirpc,
-        wrap,
-    ],
+    dependencies: test_external_deps,
     c_args: [
         '-DAPPLCNAME',
         acl_ldapconf,
@@ -71,7 +100,7 @@ afpdtest = executable(
         messagedir,
         uamdir,
     ],
-    link_args: quota_link_args,
+    link_args: test_link_args,
     export_dynamic: true,
     install: false,
 )

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -49,16 +49,7 @@ if have_quota
         meson.project_source_root() / 'etc/afpd/nfsquota.c',
         meson.project_source_root() / 'etc/afpd/quota.c',
     ]
-    if tirpc.found()
-        test_external_deps += tirpc
-    elif rpcsvc.found()
-        test_external_deps += rpcsvc
-        test_link_args += sunrpc_link_args
-    endif
-    if quota.found()
-        test_external_deps += quota
-        test_link_args += libquota_link_args
-    endif
+    test_external_deps += [quota_deps]
 endif
 
 if have_gssapi

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -40,7 +40,7 @@ test_sources = [
     meson.project_source_root() / 'etc/afpd/volume.c',
 ]
 
-if with_acls
+if have_acls
     test_sources += meson.project_source_root() / 'etc/afpd/acls.c'
     test_external_deps += [acl_deps]
 endif


### PR DESCRIPTION
This changeset refines the meson build system:

- Enables quota support on all flavours of linux and BSD (including macOS)
- Adds the quota provider to the configuration summary
- Adds user options to disable gssapi, cracklib and LDAP support
- Sets dependencies according to user configuration
- Improves the syntax of the ACL macro
- Automates Berkeley DB library detection on macOS