### PR TITLE
[2.4] meson: Fix issues with quota support on macOS and linux hosts

### DIFF
--- a/etc/afpd/unix.h
+++ b/etc/afpd/unix.h
@@ -49,16 +49,9 @@
 #endif /* ! __svr4__ || HAVE_DQB_BTIMELIMIT */
 
 #if defined(__linux__) || defined(HAVE_QUOTA_H)
-#ifndef NEED_QUOTACTL_WRAPPER
-/*#include <sys/quota.h>*/
-/*long quotactl (int, const char *, unsigned int, caddr_t); */
-/* extern long quotactl (int, const char *, long, caddr_t); */
-
-#else /* ! NEED_QUOTACTL_WRAPPER */
 #include <asm/types.h>
 #include <asm/unistd.h>
 #include <linux/quota.h>
-#endif /* ! NEED_QUOTACTL_WRAPPER */
 #endif /* linux || HAVE_QUOTA_H */
 
 #ifdef __svr4__
@@ -72,6 +65,9 @@
 #include <ufs/ufs/quota.h>
 #include <ufs/ufs/quota1.h>
 #include <ufs/ufs/quota2.h>
+#elif defined(__APPLE__)
+#include <sys/quota.h>
+#define dqb_curblocks dqb_curbytes
 #else /* DragonFly */
 #include <ufs/ufs/quota.h>
 #endif /* DragonFly */

--- a/libatalk/compat/rquota_xdr.c
+++ b/libatalk/compat/rquota_xdr.c
@@ -17,8 +17,9 @@
 /* list of machines that don't have these functions:
 	solaris
 	linux libc5
+	macOS
 */
-#if defined(NEED_RQUOTA) || defined(SOLARIS) || (defined(__GNU_LIBRARY__) && __GNU_LIBRARY__ < 6)
+#if defined(NEED_RQUOTA) || defined(SOLARIS) || (defined(__GNU_LIBRARY__) && __GNU_LIBRARY__ < 6) || defined(__APPLE__)
 
 #include <rpcsvc/rquota.h>
 

--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -2,6 +2,7 @@ subdir('acl')
 subdir('adouble')
 subdir('bstring')
 subdir('cnid')
+subdir('compat')
 subdir('dsi')
 subdir('util')
 subdir('unicode')
@@ -10,11 +11,6 @@ subdir('vfs')
 libatalk_deps = []
 libatalk_libs = []
 libatalk_sources = []
-
-if host_os != 'darwin'
-    subdir('compat')
-    libatalk_libs += libcompat
-endif
 
 if have_acls
     libatalk_deps += acl_deps
@@ -54,6 +50,7 @@ libatalk = both_libraries(
         libatalk_libs,
         libbstring,
         libcnid,
+        libcompat,
         libdsi,
         libunicode,
         libutil,

--- a/meson.build
+++ b/meson.build
@@ -1667,6 +1667,7 @@ int main (void){
     )
         cdata.set('HAVE_ATALK_ADDR', 1)
     endif
+    cdata.set('HAVE_BROKEN_DBTOB', 1)
 elif host_os == 'netbsd'
     cdata.set('BSD4_4', 1)
     cdata.set('NETBSD', 1)

--- a/meson.build
+++ b/meson.build
@@ -1683,6 +1683,8 @@ elif host_os == 'sunos'
     cdata.set('_XOPEN_SOURCE', 600)
     cdata.set('NO_STRUCT_TM_GMTOFF', 1)
     cdata.set('SOLARIS', 1)
+elif host_os == 'darwin'
+    cdata.set('HAVE_BROKEN_DBTOB', 1)
 endif
 
 #

--- a/meson.build
+++ b/meson.build
@@ -792,7 +792,7 @@ else
 endif
 
 if with_quota != 'false' and not have_quota
-    warning('Ouota support requested but libtirpc or libquota libraries not found')
+    warning('Quota support requested but libtirpc or libquota libraries not found')
 endif
 
 #
@@ -1641,9 +1641,7 @@ endif
 # OS-specific configuration
 #
 
-if host_os == 'darwin'
-    cdata.set('NO_QUOTA_SUPPORT', 1)
-elif host_os == 'freebsd'
+if host_os == 'freebsd'
     cdata.set('BSD4_4', 1)
     cdata.set('FREEBSD', 1)
     cdata.set('OPEN_NOFOLLOW_ERRNO', 'EMLINK')
@@ -1669,7 +1667,6 @@ int main (void){
     )
         cdata.set('HAVE_ATALK_ADDR', 1)
     endif
-    cdata.set('NO_QUOTA_SUPPORT', 1)
 elif host_os == 'netbsd'
     cdata.set('BSD4_4', 1)
     cdata.set('NETBSD', 1)

--- a/meson_config.h
+++ b/meson_config.h
@@ -119,6 +119,9 @@
 /* Define to 1 if you have the 'backtrace_symbols' function. */
 #mesondefine HAVE_BACKTRACE_SYMBOLS
 
+/* Define to 1 if dbtob implementation is broken. */
+#mesondefine HAVE_BROKEN_DBTOB
+
 /* Define to 1 if you have the 'chmod' function. */
 #mesondefine HAVE_CHMOD
 


### PR DESCRIPTION
This changeset:

- Fixes quota support on macOS hosts
- Restores missing configuration option for linux hosts (taken from autotools netatalk.m4 macro)
- Removes obsolete quota configuration data for linux and macOS hosts

macOS quota support tested on Sonoma host with Mac OS 9 client