### PR TITLE
[2.4] a2boot - Update meson.build file paths

### DIFF
--- a/contrib/a2boot/meson.build
+++ b/contrib/a2boot/meson.build
@@ -6,11 +6,11 @@ executable(
     c_args: [
         '-D_PATH_A_GS_BLOCKS="'
         + pkgconfdir
-        + '/a2boot/ProDOS16\ Boot\ Blocks"',
+        + '/a2boot/ProDOS16 Boot Blocks"',
         '-D_PATH_A_2E_BLOCKS="'
         + pkgconfdir
-        + '/a2boot/Apple\ :2f:2fe\ Boot\ Blocks"',
-        '-D_PATH_P16_IMAGE="' + pkgconfdir + '/a2boot/ProDOS16\ Image"',
+        + '/a2boot/Apple :2f:2fe Boot Blocks"',
+        '-D_PATH_P16_IMAGE="' + pkgconfdir + '/a2boot/ProDOS16 Image"',
     ],
     install: true,
     install_dir: sbindir,


### PR DESCRIPTION
When built with meson, a2boot wasn't able to find the boot block files due to invalid path. Fixes #1095