### PR TITLE
Fix some compiler warnings generated by clang on macOS

### DIFF
--- a/etc/afpd/afpstats_obj.c
+++ b/etc/afpd/afpstats_obj.c
@@ -58,7 +58,7 @@ static void afpstats_obj_class_intern_init(gpointer klass)
 GType afpstats_obj_get_type(void)
 {
 	static volatile gsize g_define_type_id__volatile = 0;
-	if (g_once_init_enter(&g_define_type_id__volatile)) {
+	if (g_once_init_enter((gsize *)&g_define_type_id__volatile)) {
 		GType g_define_type_id = g_type_register_static_simple(
             G_TYPE_OBJECT,
             g_intern_static_string("AFPStatsObj"),

--- a/etc/cnid_dbd/cmd_dbd_scanvol.c
+++ b/etc/cnid_dbd/cmd_dbd_scanvol.c
@@ -430,8 +430,7 @@ static int check_eafile_in_adouble(const char *name)
 
             /* Get string before "::EA" from EA filename */
             namep[0] = 0;
-            strlcpy(pname + 3, namedup, sizeof(pname)); /* Prepends "../" */
-
+            strlcpy(pname + 3, namedup, sizeof(pname) - 3); /* Prepends "../" */
             if ((access( pname, F_OK)) == 0) {
                 ret = 1;
                 goto ea_check_done;

--- a/libatalk/compat/rquota_xdr.c
+++ b/libatalk/compat/rquota_xdr.c
@@ -80,7 +80,7 @@ bool_t xdr_rquota(XDR *xdrs, rquota *objp)
 #if defined(HAVE_RQUOTA_H_QR_STATUS)
 bool_t xdr_gqr_status(XDR *xdrs, qr_status *objp)
 #else
-xdr_gqr_status(XDR *xdrs, gqr_status *objp)
+bool_t xdr_gqr_status(XDR *xdrs, gqr_status *objp)
 #endif
 {
 	if (!xdr_enum(xdrs, (enum_t *)objp)) {

--- a/libatalk/compat/rquota_xdr.c
+++ b/libatalk/compat/rquota_xdr.c
@@ -28,10 +28,7 @@
 #define u_int unsigned
 #endif
 
-bool_t
-xdr_getquota_args(xdrs, objp)
-	XDR *xdrs;
-	getquota_args *objp;
+bool_t xdr_getquota_args(XDR *xdrs, getquota_args *objp)
 {
 	if (!xdr_string(xdrs, &objp->gqa_pathp, RQ_PATHLEN)) {
 		return (FALSE);
@@ -43,10 +40,7 @@ xdr_getquota_args(xdrs, objp)
 }
 
 
-bool_t
-xdr_rquota(xdrs, objp)
-	XDR *xdrs;
-	rquota *objp;
+bool_t xdr_rquota(XDR *xdrs, rquota *objp)
 {
 	if (!xdr_int(xdrs, &objp->rq_bsize)) {
 		return (FALSE);
@@ -83,14 +77,10 @@ xdr_rquota(xdrs, objp)
 
 
 
-
-bool_t
-xdr_gqr_status(xdrs, objp)
-	XDR *xdrs;
 #if defined(HAVE_RQUOTA_H_QR_STATUS)
-	qr_status *objp;
+bool_t xdr_gqr_status(XDR *xdrs, qr_status *objp)
 #else
-	gqr_status *objp;
+xdr_gqr_status(XDR *xdrs, gqr_status *objp)
 #endif
 {
 	if (!xdr_enum(xdrs, (enum_t *)objp)) {
@@ -100,10 +90,7 @@ xdr_gqr_status(xdrs, objp)
 }
 
 
-bool_t
-xdr_getquota_rslt(xdrs, objp)
-	XDR *xdrs;
-	getquota_rslt *objp;
+bool_t xdr_getquota_rslt(XDR *xdrs, getquota_rslt *objp)
 {
 	if (!xdr_gqr_status(xdrs, &objp->status)) {
 		return (FALSE);


### PR DESCRIPTION
- Fix buffer overflow warning in etc/cnid_dbd/cmd_dbd_scanvol.c
- Fix deprecated-non-prototype warnings in rquota_xdr.c
- Fix incompatible pointer types discards qualifiers warning in afpstats_obj.c