### PR TITLE
docker: Bump to Alpine 3.20 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
-FROM alpine:3.19
+FROM alpine:3.20
 
 ENV LIB_DEPS \
     acl \
     avahi \
+    avahi-compat-libdns_sd \
     bash \
     db \
     dbus \
@@ -10,8 +11,11 @@ ENV LIB_DEPS \
     krb5 \
     libevent \
     libgcrypt \
+    libtirpc \
+    libtracker \
     linux-pam \
     openldap \
+    rpcsvc-proto \
     talloc \
     tracker \
     tracker-miners
@@ -22,17 +26,20 @@ ENV BUILD_DEPS \
     curl \
     db-dev \
     dbus-dev \
+    dbus-glib-dev \
     build-base \
     flex \
     gcc \
     krb5-dev \
     libevent-dev \
     libgcrypt-dev \
+    libtirpc-dev \
     linux-pam-dev \
     meson \
     ninja \
     openldap-dev \
     pkgconfig \
+    rpcsvc-proto-dev \
     talloc-dev \
     tracker-dev
 RUN apk update \


### PR DESCRIPTION
Alpine 3.20.1 has two busybox security patches. Let's bump from 3.19

https://alpinelinux.org/posts/Alpine-3.20.1-released.html
https://alpinelinux.org/posts/Alpine-3.20.0-released.html