### PR TITLE
[2.4] meson: Fix MAXQUOTAS redefined warnings on linux systems

### DIFF
--- a/etc/afpd/unix.h
+++ b/etc/afpd/unix.h
@@ -85,8 +85,6 @@
 
 #if defined (__linux__)
 
-#define MAXQUOTAS 2
-
 /* definitions from sys/quota.h */
 #define USRQUOTA  0             /* element used for user quotas */
 #define GRPQUOTA  1             /* element used for group quotas */


### PR DESCRIPTION
Missing backport of fix in main branch