### PR TITLE
docs: Indicate license for software package, and add SSLeay notice

### DIFF
--- a/doc/ja/manual/intro.xml
+++ b/doc/ja/manual/intro.xml
@@ -15,10 +15,13 @@
   <sect1>
     <title>法的条項</title>
 
-    <para>本ドキュメントは GNU 一般公衆利用許諾書 (GPL) バージョン 2 のもとで配布されている。 Netatalk
-    ソース一式にも本ドキュメントと同様に許諾書のコピーが同梱されている。許諾書のコピーのオンライン版は <ulink
+    <para>Netatalk のソフトウェアのパッケージまたは本ドキュメントは GNU 一般公衆利用許諾書 (GPL) バージョン 2
+    のもとで配布されている。 Netatalk ソース一式にも本ドキュメントと同様に許諾書のコピーが同梱されている。許諾書のコピーのオンライン版は
+    <ulink
     url="http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt">http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</ulink>
-    で閲覧できる</para>
+    で閲覧できる。</para>
+
+    <para>この製品には、Eric Youngが作成した暗号化ソフトウェアが含まれている。</para>
   </sect1>
 
   <sect1>

--- a/doc/manual/intro.xml
+++ b/doc/manual/intro.xml
@@ -3,34 +3,34 @@
   <title>Introduction</title>
 
   <sect1>
-  <title>Legal Notice</title>
+    <title>Legal Notice</title>
 
-  <para>
-  This documentation is distributed under the GNU General Public License (GPL) version 2.
-  A copy of the license is included in this documentation, as well as within the Netatalk source
-  distribution.  An on-line copy can be found at <ulink
-  url="http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt">http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</ulink>
-  </para>
+    <para>The Netatalk software package as well as this documentation are
+    distributed under the GNU General Public License (GPL) version 2. A copy
+    of the license is included in this documentation, as well as within the
+    Netatalk source distribution. An on-line copy can be found at <ulink
+    url="http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt">http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt</ulink></para>
+
+    <para>This product includes cryptographic software written by Eric Young
+    (eay@cryptsoft.com)</para>
   </sect1>
 
   <sect1>
-  <title>Overview of Netatalk</title>
+    <title>Overview of Netatalk</title>
 
-  <para>Netatalk is an Open Source software package that can be used to turn
-  a *NIX machine into a fast, light-weight and
-  reliable file server for Macintosh computers.</para>
+    <para>Netatalk is an Open Source software package that can be used to turn
+    a *NIX machine into a fast, light-weight and reliable file server for
+    Macintosh computers.</para>
 
-  <para>Using Netatalk's AFP 3.4 compliant file-server leads to significantly
-  higher transmission speeds for older Macs compared to
-  Samba/NFS, while providing clients with the best possible user experience:
-  full support for Macintosh metadata, flawlessly supporting mixed
-  environments of classic Mac OS and OS X clients.</para>
+    <para>Using Netatalk's AFP 3.4 compliant file-server leads to
+    significantly higher transmission speeds for older Macs compared to
+    Samba/NFS, while providing clients with the best possible user experience:
+    full support for Macintosh metadata, flawlessly supporting mixed
+    environments of classic Mac OS and OS X clients.</para>
 
-  <para>It ships with  range of authentication methods to accommodate
-  any deployment environment.
-  Modern macOS features such as Bonjour service discovery,
-  Time Machine backups, and Spotlight indexed search are also supported.
-  </para>
+    <para>It ships with range of authentication methods to accommodate any
+    deployment environment. Modern macOS features such as Bonjour service
+    discovery, Time Machine backups, and Spotlight indexed search are also
+    supported.</para>
   </sect1>
-
 </chapter>


### PR DESCRIPTION
This is to clarify that the manual's legal notice to not only regard the documentation, but also the software package itself.

And then, adds the SSLeay legal notice to comply with the terms of the source files we borrowed from OpenSSL.

Formatting applied by the XMLmind editor.