### PR TITLE
meson: with-rpath syntax is invalid

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -353,7 +353,7 @@ enable_rpath = get_option('with-rpath')
 
 if not get_option('with-rpath')
     enable_rpath = false
-elif host_os == 'sunos' or host_os == 'netbsd' or get_option('enable-rpath')
+elif host_os == 'sunos' or host_os == 'netbsd'
     enable_rpath = true
 endif
 


### PR DESCRIPTION
If you try to do `-Dwith-rpath=true` you get error

```
../meson.build:414:7: ERROR: Tried to access unknown option 'enable-rpath'.
```

I think that part should just be removed, no?