### PR TITLE
Debian Trixie expects systemd scripts in /usr/lib

### DIFF
--- a/distrib/initscripts/Makefile.am
+++ b/distrib/initscripts/Makefile.am
@@ -82,36 +82,10 @@ endif
 endif
 
 #
-# checking for general systemd scripts:
+# checking for systemd scripts:
 #
 
 if USE_SYSTEMD
-
-servicedir	= $(INIT_DIR)
-service_DATA	= netatalk.service
-
-netatalk.service: service.systemd
-	cp -f service.systemd netatalk.service
-
-install-data-hook:
-if USE_INIT_HOOKS
-	-systemctl daemon-reload
-endif
-
-uninstall-startup:
-if USE_INIT_HOOKS
-	-systemctl disable $(service_DATA)
-	rm -f $(DESTDIR)$(servicedir)/netatalk.service
-	-systemctl daemon-reload
-endif
-
-endif
-
-#
-# checking for "Debian" style systemd scripts:
-#
-
-if USE_DEBIAN_SYSTEMD
 
 servicedir	= $(INIT_DIR)
 service_DATA	= netatalk.service

--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -1,5 +1,46 @@
 if get_option('with-init-style') == 'none'
     init_dir += 'none'
+elif (
+    get_option('with-init-style') == 'debian-systemd'
+    or get_option('with-init-style') == 'gentoo-systemd'
+    or get_option('with-init-style') == 'redhat-systemd'
+    or get_option('with-init-style') == 'suse-systemd'
+    or get_option('with-init-style') == 'systemd'
+)
+    init_dir += '/usr/lib/systemd/system'
+    custom_target(
+        'systemd',
+        input: 'service.systemd.tmpl',
+        output: 'netatalk.service',
+        command: sed_command,
+        capture: true,
+        install: true,
+        install_dir: init_dir,
+    )
+    if get_option('with-init-hooks')
+        meson.add_install_script(find_program('systemctl'), 'daemon-reload')
+    endif
+elif get_option('with-init-style') == 'debian-sysv'
+    init_dir += '/etc/init.d'
+    custom_target(
+        'debian_sysv',
+        input: 'rc.debian.tmpl',
+        output: 'netatalk',
+        command: sed_command,
+        capture: true,
+        install: true,
+        install_dir: init_dir,
+        install_mode: 'rwxr-xr-x',
+    )
+    if get_option('with-init-hooks')
+        meson.add_install_script(
+            find_program('update-rc.d'),
+            'netatalk',
+            'defaults',
+            '90',
+            '10',
+        )
+    endif
 elif get_option('with-init-style') == 'redhat-sysv'
     init_dir += '/etc/rc.d/init.d'
     custom_target(
@@ -17,39 +58,6 @@ elif get_option('with-init-style') == 'redhat-sysv'
             find_program('chkconfig'),
             '--add', '/etc/rc.d/init.d/netatalk',
         )
-    endif
-elif (
-    get_option('with-init-style') == 'gentoo-systemd'
-    or get_option('with-init-style') == 'systemd'
-    or get_option('with-init-style') == 'redhat-systemd'
-    or get_option('with-init-style') == 'suse-systemd'
-)
-    init_dir += '/usr/lib/systemd/system'
-    custom_target(
-        'systemd',
-        input: 'service.systemd.tmpl',
-        output: 'netatalk.service',
-        command: sed_command,
-        capture: true,
-        install: true,
-        install_dir: init_dir,
-    )
-    if get_option('with-init-hooks')
-        meson.add_install_script(find_program('systemctl'), 'daemon-reload')
-    endif
-elif get_option('with-init-style') == 'debian-systemd'
-    init_dir += '/lib/systemd/system'
-    custom_target(
-        'debian_systemd',
-        input: 'service.systemd.tmpl',
-        output: 'netatalk.service',
-        command: sed_command,
-        capture: true,
-        install: true,
-        install_dir: init_dir,
-    )
-    if get_option('with-init-hooks')
-        meson.add_install_script(find_program('systemctl'), 'daemon-reload')
     endif
 elif get_option('with-init-style') == 'suse-sysv'
     init_dir += '/etc/init.d'
@@ -158,27 +166,6 @@ elif (
             'add',
             'netatalk',
             'default',
-        )
-    endif
-elif get_option('with-init-style') == 'debian-sysv'
-    init_dir += '/etc/init.d'
-    custom_target(
-        'debian_sysv',
-        input: 'rc.debian.tmpl',
-        output: 'netatalk',
-        command: sed_command,
-        capture: true,
-        install: true,
-        install_dir: init_dir,
-        install_mode: 'rwxr-xr-x',
-    )
-    if get_option('with-init-hooks')
-        meson.add_install_script(
-            find_program('update-rc.d'),
-            'netatalk',
-            'defaults',
-            '90',
-            '10',
         )
     endif
 elif get_option('with-init-style') == 'macos-launchd'

--- a/macros/netatalk.m4
+++ b/macros/netatalk.m4
@@ -583,7 +583,7 @@ AC_DEFUN([AC_NETATALK_INIT_STYLE], [
         ;;
     "debian-systemd")
 	    AC_MSG_RESULT([enabling debian-style systemd support])
-	    ac_cv_init_dir="/lib/systemd/system"
+	    ac_cv_init_dir="/usr/lib/systemd/system"
 	    ;;
     "solaris")
 	    AC_MSG_RESULT([enabling solaris-style SMF support])
@@ -617,8 +617,7 @@ AC_DEFUN([AC_NETATALK_INIT_STYLE], [
     AM_CONDITIONAL(USE_SOLARIS, test x$init_style = xsolaris)
     AM_CONDITIONAL(USE_OPENRC, test x$init_style = xopenrc || test x$init_style = xgentoo-openrc)
     AM_CONDITIONAL(USE_DEBIAN_SYSV, test x$init_style = xdebian-sysv)
-    AM_CONDITIONAL(USE_SYSTEMD, test x$init_style = xsystemd || test x$init_style = xredhat-systemd || test x$init_style = xsuse-systemd || test x$init_style = xgentoo-systemd)
-    AM_CONDITIONAL(USE_DEBIAN_SYSTEMD, test x$init_style = xdebian-systemd)
+    AM_CONDITIONAL(USE_SYSTEMD, test x$init_style = xsystemd || test x$init_style = xdebian-systemd || test x$init_style = xgentoo-systemd || test x$init_style = xredhat-systemd || test x$init_style = xsuse-systemd)
     AM_CONDITIONAL(USE_MACOS_LAUNCHD, test x$init_style = xmacos-launchd)
     AM_CONDITIONAL(USE_UNDEF, test x$init_style = xnone)
 


### PR DESCRIPTION
This means Debian aligns with all the other known Linux distros, so the special case in our build scripts is removed.

Also sorting the options a bit for readability.