### PR TITLE
Add copyright for mac_roman.h

### DIFF
--- a/libatalk/unicode/charsets/mac_roman.h
+++ b/libatalk/unicode/charsets/mac_roman.h
@@ -1,5 +1,5 @@
-
 /*
+ * Copyright (C) 1999-2000 Free Software Foundation, Inc.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
All code in this file is lifted verbatim from lib/mac_roman.h in libiconv.

Therefore, adding the same copyright year and author as in libiconv 1.9.2 which was contemporaneous to when mac_roman.h was added to Netatalk.

https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.9.2.tar.gz