### PR TITLE
[2.4] Don't attempt to restart atalkd if NBP registrations fail

### DIFF
--- a/distrib/initscripts/atalkd.service.tmpl
+++ b/distrib/initscripts/atalkd.service.tmpl
@@ -11,8 +11,8 @@ Type=forking
 GuessMainPID=no
 ExecStartPre=/bin/sh -c 'systemctl set-environment ATALK_NAME=$$(hostname|cut -d. -f1)'
 ExecStart=:SBINDIR:/atalkd
-ExecStartPost=:BINDIR:/nbprgstr -p 4 "${ATALK_NAME}:Workstation"
-ExecStartPost=:BINDIR:/nbprgstr -p 4 "${ATALK_NAME}:netatalk"
+ExecStartPost=-:BINDIR:/nbprgstr -p 4 "${ATALK_NAME}:Workstation"
+ExecStartPost=-:BINDIR:/nbprgstr -p 4 "${ATALK_NAME}:netatalk"
 Restart=always
 RestartSec=1
 


### PR DESCRIPTION
In some configurations, the NBP registrations of "workstation" and "netatalk" may fail. Don't attempt to restart the atalkd service as these are not critical failures. Note, this fixes the issue that lead to these changes being reverted in #473.