### PR TITLE
[2.4] Cleanup of copyright headers to make them more scanner friendly

### DIFF
--- a/etc/afpd/mangle.c
+++ b/etc/afpd/mangle.c
@@ -1,5 +1,5 @@
-/* 
- * Copyright (c) 2002. Joe Marcus Clarke (marcus@marcuscom.com)
+/*
+ * Copyright (c) 2002 Joe Marcus Clarke (marcus@marcuscom.com)
  * All Rights Reserved.  See COPYRIGHT.
  *
  * mangle, demangle (filename):
@@ -72,7 +72,7 @@ static char *demangle_checks(const struct vol *vol, char* uname, char * mfilenam
     /* the mangled name we got ..					*/
 
     flags = CONV_IGNORE | CONV_UNESCAPEHEX;
-    if ( (size_t) -1 == (len = convert_charset(vol->v_volcharset, vol->v_maccharset, 0, 
+    if ( (size_t) -1 == (len = convert_charset(vol->v_volcharset, vol->v_maccharset, 0,
 				      uname, strlen(uname), buffer, MAXPATHLEN, &flags)) ) {
 	return mfilename;
     }
@@ -82,18 +82,18 @@ static char *demangle_checks(const struct vol *vol, char* uname, char * mfilenam
         flags |= CONV_REQMANGLE;
         len = prefix;
     }
-    
+
     /* Ok, mangling was needed, now we do some further checks    */
     /* this is still necessary, as we might have a file abcde:xx */
     /* with id 12, mangled to abcde#12, and a passed filename    */
-    /* abcd#12 						     */ 
+    /* abcd#12 						     */
     /* if we only checked if "prefix" number of characters match */
     /* we get a false postive in above case			     */
 
     if ( (flags & CONV_REQMANGLE) ) {
-        if (len) { 
+        if (len) {
             /* convert the buffer to UTF8_MAC ... */
-            if ((size_t) -1 == (len = convert_charset(vol->v_maccharset, CH_UTF8_MAC, 0, 
+            if ((size_t) -1 == (len = convert_charset(vol->v_maccharset, CH_UTF8_MAC, 0,
             			buffer, len, buffer, MAXPATHLEN, &flags)) ) {
                 return mfilename;
             }
@@ -101,7 +101,7 @@ static char *demangle_checks(const struct vol *vol, char* uname, char * mfilenam
             /* prefix can be longer than len, OSX might send us the first character(s) of a     */
             /* decomposed char as the *last* character(s) before the #, so our match below will */
             /* still work, but leaves room for a race ... FIXME				    */
-            if ( (prefix >= len || mfilenamelen == MACFILELEN) 
+            if ( (prefix >= len || mfilenamelen == MACFILELEN)
                  && !strncmp (mfilename, buffer, len)) {
                  return uname;
             }
@@ -115,8 +115,8 @@ static char *demangle_checks(const struct vol *vol, char* uname, char * mfilenam
             /* ..but OSX might send us only the first characters of a decomposed character. */
             /*  So convert to UTF8_MAC again, now at least the prefix number of 	  */
             /* characters have to match ... again a possible race FIXME			  */
-            
-            if ( (size_t) -1 == (len = convert_charset(vol->v_volcharset, CH_UTF8_MAC, 0, 
+
+            if ( (size_t) -1 == (len = convert_charset(vol->v_volcharset, CH_UTF8_MAC, 0,
 	                          uname, strlen(uname), buffer, MAXPATHLEN, &flags)) ) {
 	        return mfilename;
 	    }
@@ -132,7 +132,7 @@ static char *demangle_checks(const struct vol *vol, char* uname, char * mfilenam
 /* -------------------------------------------------------
 */
 static char *
-private_demangle(const struct vol *vol, char *mfilename, cnid_t did, cnid_t *osx) 
+private_demangle(const struct vol *vol, char *mfilename, cnid_t did, cnid_t *osx)
 {
     char *t;
     char *u_name;
@@ -149,7 +149,7 @@ private_demangle(const struct vol *vol, char *mfilename, cnid_t did, cnid_t *osx
         return mfilename;
     }
     prefix = t - mfilename;
-    /* FIXME 
+    /* FIXME
      * is prefix == 0 a valid mangled filename ?
     */
     /* may be a mangled filename */
@@ -215,10 +215,10 @@ demangle(const struct vol *vol, char *mfilename, cnid_t did)
 }
 
 /* -------------------------------------------------------
- * OS X  
+ * OS X
 */
 char *
-demangle_osx(const struct vol *vol, char *mfilename, cnid_t did, cnid_t *fileid) 
+demangle_osx(const struct vol *vol, char *mfilename, cnid_t did, cnid_t *fileid)
 {
     return private_demangle(vol, mfilename, did, fileid);
 }
@@ -237,7 +237,7 @@ demangle_osx(const struct vol *vol, char *mfilename, cnid_t did, cnid_t *fileid)
    ------------------------
    with utf8 filename not always round trip
    filename   mac filename too long or first chars if unmatchable chars.
-   uname      unix filename 
+   uname      unix filename
    id         file/folder ID or 0
 */
 char *
@@ -249,7 +249,7 @@ mangle(const struct vol *vol, char *filename, size_t filenamelen, char *uname, c
     size_t ext_len;
     size_t maxlen;
     int k;
-    
+
     maxlen = (flags & 2)?UTF8FILELEN_EARLY:MACFILELEN; /* was vol->max_filename */
     /* Do we really need to mangle this filename? */
     if (!(flags & 1) && filenamelen <= maxlen) {

--- a/etc/papd/lp.c
+++ b/etc/papd/lp.c
@@ -16,8 +16,8 @@
  *    documentation and/or other materials provided with the distribution.
  * 3. All advertising materials mentioning features or use of this software
  *    must display the following acknowledgement:
- *      This product includes software developed by the University of
- *      California, Berkeley and its contributors.
+ *    This product includes software developed by the University of
+ *    California, Berkeley and its contributors.
  * 4. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
@@ -216,7 +216,7 @@ static void convert_octal (char *string, charset_t dest)
                     *q = '.';
                 p += 2;
             }
-       	    else 
+       	    else
                 *q = '.';
        }
        else {
@@ -304,12 +304,12 @@ size_t used = 0;
 
 static char* pipexlate(char *src)
 {
-    char *p, *q, *dest; 
+    char *p, *q, *dest;
     static char destbuf[MAXPATHLEN +1];
     size_t destlen = MAXPATHLEN;
     int len = 0;
-   
-    dest = destbuf; 
+
+    dest = destbuf;
 
     if (!src)
 	return NULL;
@@ -338,7 +338,7 @@ static char* pipexlate(char *src)
             q =  lp.lp_created_for;
         } else if (is_var(p, "%%")) {
             q = "%";
-        } 
+        }
 
         /* copy the stuff over. if we don't understand something that we
          * should, just skip it over. */
@@ -471,8 +471,8 @@ static int lp_init(struct papfile *out, struct sockaddr_at *sat)
 	    FILE *cap_file;
 
 	    memset( auth_string, 0, 256 );
-	    sprintf(addr_filename, "%s/net%d.%dnode%d", 
-		printer->p_authprintdir, addr_net/256, addr_net%256, 
+	    sprintf(addr_filename, "%s/net%d.%dnode%d",
+		printer->p_authprintdir, addr_net/256, addr_net%256,
 		addr_node);
 	    if (stat(addr_filename, &cap_st) == 0) {
 		if ((cap_file = fopen(addr_filename, "r")) != NULL) {
@@ -669,7 +669,7 @@ int lp_open(struct papfile *out, struct sockaddr_at *sat)
 	    LOG(log_error, logtype_papd, "malloc: %s", strerror(errno));
 	    exit(1);
 	}
-	strcpy ( lp.lp_spoolfile, name);	
+	strcpy ( lp.lp_spoolfile, name);
 
 	if (lp.lp_person != NULL) {
 	    if ((pwent = getpwnam(lp.lp_person)) == NULL) {
@@ -729,10 +729,10 @@ int lp_write(struct papfile *in, char *buf, size_t len)
     if (lp.lp_flags & LP_JOBPENDING)
 	lp_print();
 
-    /* foomatic doesn't handle mac line endings, so we convert them for 
+    /* foomatic doesn't handle mac line endings, so we convert them for
      * the Postscript headers
      * REALLY ugly hack, remove ASAP again */
-    if ((printer->p_flags & P_FOOMATIC_HACK) && (in->pf_state & PF_TRANSLATE) && 
+    if ((printer->p_flags & P_FOOMATIC_HACK) && (in->pf_state & PF_TRANSLATE) &&
         (buf[len-1] != '\n') ) {
         if (len <= BUFSIZE) {
 	    if (!last_line_translated) {
@@ -741,7 +741,7 @@ int lp_write(struct papfile *in, char *buf, size_t len)
 	    }
 	    else
             	memcpy(tempbuf2, buf, len);
-		
+
             if (tempbuf2[len-1] == '\r')
 	        tempbuf2[len-1] = '\n';
             tempbuf2[len] = 0;
@@ -1066,7 +1066,7 @@ int lp_queue( struct papfile *out)
     int				s;
     size_t			len;
     ssize_t			n;
-	
+
     if (( s = lp_conn_unix()) < 0 ) {
 	LOG(log_error, logtype_papd, "lp_queue: %s", strerror(errno) );
 	return( -1 );

--- a/etc/papd/printcap.c
+++ b/etc/papd/printcap.c
@@ -15,8 +15,8 @@
  *    documentation and/or other materials provided with the distribution.
  * 3. All advertising materials mentioning features or use of this software
  *    must display the following acknowledgement:
- *	This product includes software developed by the University of
- *	California, Berkeley and its contributors.
+ *    This product includes software developed by the University of
+ *    California, Berkeley and its contributors.
  * 4. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.

--- a/libatalk/cnid/last/cnid_last.c
+++ b/libatalk/cnid/last/cnid_last.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999. Adrian Sun (asun@zoology.washington.edu)
+ * Copyright (c) 1999 Adrian Sun (asun@zoology.washington.edu)
  * All Rights Reserved. See COPYRIGHT.
  */
 
@@ -94,7 +94,7 @@ cnid_t cnid_last_get(struct _cnid_db *cdb _U_, const cnid_t did _U_, char *name 
 
 
 /* */
-cnid_t cnid_last_lookup(struct _cnid_db *cdb _U_, const struct stat *st _U_, const cnid_t did _U_, 
+cnid_t cnid_last_lookup(struct _cnid_db *cdb _U_, const struct stat *st _U_, const cnid_t did _U_,
     char *name _U_, const size_t len _U_)
 {
     /* FIXME: this function doesn't work in [last] scheme ! */
@@ -136,7 +136,7 @@ static struct _cnid_db *cnid_last_new(const char *volpath)
     cdb->cnid_resolve = cnid_last_resolve;
     cdb->cnid_update = cnid_last_update;
     cdb->cnid_close = cnid_last_close;
-    
+
     return cdb;
 }
 

--- a/libatalk/compat/rquota_xdr.c
+++ b/libatalk/compat/rquota_xdr.c
@@ -1,8 +1,8 @@
 /*
  * taken from the quota-1.55 used on linux. here's the bsd copyright:
  *
- * Copyright (c) 1980, 1990 Regents of the University of California. All
- * rights reserved.
+ * Copyright (c) 1980, 1990 Regents of the University of California.
+ * All rights reserved.
  *
  * This code is derived from software contributed to Berkeley by Robert Elz at
  * The University of Melbourne.

--- a/libatalk/util/volinfo.c
+++ b/libatalk/util/volinfo.c
@@ -1,4 +1,7 @@
 /*
+   volinfo file handling, command line utilities
+   Copyright (C) Bjoern Fernhomberg 2004
+
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation; either version 2 of the License, or
@@ -12,9 +15,6 @@
    You should have received a copy of the GNU General Public License
    along with this program; if not, write to the Free Software
    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-   .volinfo file handling, command line utilities
-   copyright Bjoern Fernhomberg, 2004
 */
 
 #ifdef HAVE_CONFIG_H
@@ -66,7 +66,7 @@ static const vol_opt_name_t vol_opt_names[] = {
     {AFPVOL_CASEINSEN,  "CASEINSENSITIVE"}, /* volume is case insensitive */
     {AFPVOL_EILSEQ,     "ILLEGALSEQ"},  /* encode illegal sequence */
     {AFPVOL_CACHE,      "CACHEID"},     /* Use adouble v2 CNID caching, default don't use it */
-    {AFPVOL_INV_DOTS,   "INVISIBLEDOTS"}, 
+    {AFPVOL_INV_DOTS,   "INVISIBLEDOTS"},
     {AFPVOL_ACLS,       "ACLS"},        /* Vol supports ACLs */
     {AFPVOL_TM,         "TM"},          /* Set "kSupportsTMLockSteal" is volume attributes */
     {0, NULL}
@@ -171,12 +171,12 @@ static char * make_path_absolute(char *path, size_t bufsize)
             *p = '\0';
     }
 
-    if (!getcwd(savecwd, sizeof(savecwd)) || chdir(abspath) < 0)	
+    if (!getcwd(savecwd, sizeof(savecwd)) || chdir(abspath) < 0)
         return NULL;
 
     if (!getcwd(abspath, sizeof(abspath)) || chdir (savecwd) < 0)
         return NULL;
-    
+
     if (strlen(abspath) > bufsize)
         return NULL;
 
@@ -187,7 +187,7 @@ static char * make_path_absolute(char *path, size_t bufsize)
 static char * find_volumeroot(char *path, size_t maxlen)
 {
     char *volume = make_path_absolute(path, maxlen);
-        
+
     if (volume == NULL)
        return NULL;
 
@@ -217,7 +217,7 @@ static int parse_options (char *buf, int *flags, const vol_opt_name_t *options)
     char *p, *q;
     const vol_opt_name_t *op;
 
-    q = p = buf; 
+    q = p = buf;
 
     while ( *p != '\0') {
         if (*p == ' ') {
@@ -235,8 +235,8 @@ static int parse_options (char *buf, int *flags, const vol_opt_name_t *options)
     }
 
     return 0;
-} 
-            
+}
+
 
 
 static int parseline ( char *buf, struct volinfo *vol)
@@ -293,7 +293,7 @@ static int parseline ( char *buf, struct volinfo *vol)
       case CNIDDBDPORT:
         if ((vol->v_dbd_port = strdup(value)) == NULL) {
 	    fprintf (stderr, "strdup: %s", strerror(errno));
-            return -1;            
+            return -1;
         }
         break;
       case CNID_DBPATH:
@@ -324,7 +324,7 @@ static int parseline ( char *buf, struct volinfo *vol)
         parse_options(value, &vol->v_casefold, &vol_opt_casefold[0]);
         break;
     case EXTATTRTYPE:
-        if (strcasecmp(value, "AFPVOL_EA_AD") == 0)    
+        if (strcasecmp(value, "AFPVOL_EA_AD") == 0)
             vol->v_vfs_ea = AFPVOL_EA_AD;
         else if (strcasecmp(value, "AFPVOL_EA_SYS") == 0)
             vol->v_vfs_ea = AFPVOL_EA_SYS;
@@ -334,10 +334,10 @@ static int parseline ( char *buf, struct volinfo *vol)
 	return (-1);
         break;
     }
-        
+
     return 0;
 }
-    
+
 
 int loadvolinfo (char *path, struct volinfo *vol)
 {
@@ -354,7 +354,7 @@ int loadvolinfo (char *path, struct volinfo *vol)
     memset(vol, 0, sizeof(struct volinfo));
     strlcpy(volinfofile, path, sizeof(volinfofile));
 
-    /* volinfo file is in .AppleDesktop */ 
+    /* volinfo file is in .AppleDesktop */
     if ( NULL == find_volumeroot(volinfofile, sizeof(volinfofile)))
         return -1;
 
@@ -377,9 +377,9 @@ int loadvolinfo (char *path, struct volinfo *vol)
 	fprintf (stderr, "error opening volinfo (%s): %s", volinfofile, strerror(errno));
         return (-1);
     }
-    fd = fileno(fp); 
+    fd = fileno(fp);
 
-    /* try to get a read lock */ 
+    /* try to get a read lock */
     lock.l_start  = 0;
     lock.l_whence = SEEK_SET;
     lock.l_len    = 0;


### PR DESCRIPTION
Also includes trailing space cleanup, caused by my editor.