### PR TITLE
meson: Restore SLP (srvloc) support

### DIFF
--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -71,6 +71,10 @@ if have_dns
     afpd_external_deps += dns_sd
 endif
 
+if have_srvloc
+    afpd_external_deps += slp
+endif
+
 executable(
     'afpd',
     afpd_sources,

--- a/meson.build
+++ b/meson.build
@@ -1684,6 +1684,37 @@ if host_os == 'linux'
 endif
 
 #
+# Check for optional server location protocol support (used by Classic Mac OS and Mac OS X to 10.1)
+#
+
+enable_srvloc = get_option('with-srvloc')
+srvloc_path = get_option('with-srvloc-path')
+
+srvloc_link_args = []
+
+if srvloc_path != ''
+    srvloc_link_args += ['-L' + srvloc_path / 'lib', '-lslp']
+    slp = declare_dependency(
+        link_args: srvloc_link_args,
+        include_directories: include_directories(srvloc_path / 'include'),
+    )
+else
+    slp = cc.find_library( 'slp', required: false)
+endif
+
+if not enable_srvloc
+    have_srvloc = false
+else
+    have_srvloc = cc.has_function('SLPOpen', dependencies: slp)
+    if have_srvloc
+        cdata.set('USE_SRVLOC', 1)
+    else
+        have_srvloc = false
+        warning('SLP support requested but slp library not found')
+    endif
+endif
+
+#
 # OS-specific configuration
 #
 
@@ -1870,6 +1901,7 @@ if have_quota
     }
 endif
 summary_info += {
+    '  SLP (srvloc) support': have_srvloc,
     '  SSL provider': ssl_provider,
     '  TCP wrapper support': have_tcpwrap,
     '  valid shell check': valid_shellcheck,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -160,6 +160,12 @@ option(
     description: 'Set path for spooldir used for CUPS support',
 )
 option(
+    'with-srvloc',
+    type: 'boolean',
+    value: true,
+    description: 'Enable SLP (srvloc) support',
+)
+option(
     'with-tcp-wrappers',
     type: 'boolean',
     value: true,
@@ -230,6 +236,12 @@ option(
     type: 'string',
     value: '',
     description: 'Set path to PAM installation',
+)
+option(
+    'with-srvloc-path',
+    type: 'string',
+    value: '',
+    description: 'Set path to SLP (srvloc) installation',
 )
 option(
     'with-uams-path',

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -72,6 +72,10 @@ if have_dns
     test_external_deps += dns_sd
 endif
 
+if have_srvloc
+    test_external_deps += slp
+endif
+
 afpdtest = executable(
     'afpdtest',
     test_sources,


### PR DESCRIPTION
Tested on Debian 11 VM with OpenSLP installed from source (Debian does not have a package for OpenSLP)