### PR TITLE
CVE-2024-38439,CVE-2024-38440,CVE-2024-38441: Harden user login

### DIFF
--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -610,6 +610,9 @@ int afp_login(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf, size_t *rbufl
     if (ibuflen < 2)
         return send_reply(obj, AFPERR_BADVERS );
 
+    if (ibuf == NULL)
+        return send_reply(obj, AFPERR_PARAM);
+
     ibuf++;
     len = (unsigned char) *ibuf++;
     ibuflen -= 2;
@@ -663,6 +666,9 @@ int afp_login_ext(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf, size_t *r
 
     if (ibuflen < 5)
         return send_reply(obj, AFPERR_BADVERS );
+
+    if (ibuf == NULL)
+        return send_reply(obj, AFPERR_PARAM);
 
     ibuf++;
     ibuf++;     /* pad  */
@@ -751,6 +757,10 @@ int afp_login_ext(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf, size_t *r
         return send_reply(obj, AFPERR_PARAM);
     }
 #endif
+    if (ibuflen < len) {
+        LOG(log_error, logtype_afpd, "login_ext: Login failed. Invalid directory service name!" );
+        return send_reply(obj, AFPERR_PARAM);
+    }
     ibuf += len;
     ibuflen -= len;
 

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -2330,6 +2330,9 @@ int afp_mapname(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
         return( AFPERR_PARAM );
     }
 
+    if (len >= ibuflen - 1)
+        return AFPERR_PARAM;
+
     ibuf[ len ] = '\0';
 
     if ( len == 0 )

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -682,6 +682,8 @@ static int pam_changepw(void *obj, unsigned char *username,
     /* Set these things up for the conv function. the old password
      * is at the end. */
     ibuf += KEYSIZE;
+    if (ibuflen <= PASSWDLEN + PASSWDLEN)
+        return AFPERR_PARAM;
     ibuf[PASSWDLEN + PASSWDLEN] = '\0';
     PAM_password = ibuf + PASSWDLEN;
 
@@ -712,6 +714,8 @@ static int pam_changepw(void *obj, unsigned char *username,
 
     /* new password */
     PAM_password = ibuf;
+    if (ibuflen <= PASSWDLEN)
+        return AFPERR_PARAM;
     ibuf[PASSWDLEN] = '\0';
 
     /* this really does need to be done as root */

--- a/etc/uams/uams_pam.c
+++ b/etc/uams/uams_pam.c
@@ -141,6 +141,8 @@ static int login(void *obj, char *username, int ulen,  struct passwd **uam_pwd,
 	hostname = NULL;
     }
 
+    if (ibuflen <= PASSWDLEN)
+        return AFPERR_PARAM;
     ibuf[ PASSWDLEN ] = '\0';
 
     if (( pwd = uam_getname(obj, username, ulen)) == NULL ) {

--- a/etc/uams/uams_passwd.c
+++ b/etc/uams/uams_passwd.c
@@ -55,7 +55,7 @@ static int pwd_login(void *obj, char *username, int ulen, struct passwd **uam_pw
     struct spwd *sp;
 #endif /* SHADOWPW */
 
-    if (ibuflen < PASSWDLEN) {
+    if (ibuflen <= PASSWDLEN) {
         return( AFPERR_PARAM );
     }
     ibuf[ PASSWDLEN ] = '\0';
@@ -158,7 +158,7 @@ static int passwd_login_ext(void *obj, char *uname, struct passwd **uam_pwd,
                              (void *) &username, &ulen) < 0)
         return AFPERR_MISC;
 
-    if (*uname != 3)
+    if (*uname != 3 || ibuflen < 2)
         return AFPERR_PARAM;
     uname++;
     memcpy(&temp16, uname, sizeof(temp16));


### PR DESCRIPTION
* Check that input buffer can accommodate null terminator
* Input buffer null pointer and length checks