### PR TITLE
[2.4] CVE-2024-38439,CVE-2024-38440,CVE-2024-38441: Harden user login

### DIFF
--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -688,6 +688,9 @@ int afp_login(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf, size_t *rbufl
     if (ibuflen < 2)
         return send_reply(obj, AFPERR_BADVERS );
 
+    if (ibuf == NULL)
+        return send_reply(obj, AFPERR_PARAM);
+
     ibuf++;
     len = (unsigned char) *ibuf++;
     ibuflen -= 2;
@@ -741,6 +744,9 @@ int afp_login_ext(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf, size_t *r
 
     if (ibuflen < 5)
         return send_reply(obj, AFPERR_BADVERS );
+
+    if (ibuf == NULL)
+        return send_reply(obj, AFPERR_PARAM);
 
     ibuf++;
     ibuf++;     /* pad  */
@@ -829,6 +835,10 @@ int afp_login_ext(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf, size_t *r
         return send_reply(obj, AFPERR_PARAM);
     }
 #endif
+    if (ibuflen < len) {
+        LOG(log_error, logtype_afpd, "login_ext: Login failed. Invalid directory service name!" );
+        return send_reply(obj, AFPERR_PARAM);
+    }
     ibuf += len;
     ibuflen -= len;
 

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -2425,6 +2425,9 @@ int afp_mapname(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, siz
         return( AFPERR_PARAM );
     }
 
+    if (len >= ibuflen - 1)
+        return AFPERR_PARAM;
+
     ibuf[ len ] = '\0';
 
     if ( len == 0 )

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -677,6 +677,8 @@ static int pam_changepw(void *obj, unsigned char *username,
     /* Set these things up for the conv function. the old password
      * is at the end. */
     ibuf += KEYSIZE;
+    if (ibuflen <= PASSWDLEN + PASSWDLEN)
+        return AFPERR_PARAM;
     ibuf[PASSWDLEN + PASSWDLEN] = '\0';
     PAM_password = ibuf + PASSWDLEN;
 
@@ -707,6 +709,8 @@ static int pam_changepw(void *obj, unsigned char *username,
 
     /* new password */
     PAM_password = ibuf;
+    if (ibuflen <= PASSWDLEN)
+        return AFPERR_PARAM;
     ibuf[PASSWDLEN] = '\0';
 
     /* this really does need to be done as root */

--- a/etc/uams/uams_pam.c
+++ b/etc/uams/uams_pam.c
@@ -139,6 +139,8 @@ static int login(void *obj, char *username, int ulen,  struct passwd **uam_pwd,
 	hostname = NULL;
     }
 
+    if (ibuflen <= PASSWDLEN)
+        return AFPERR_PARAM;
     ibuf[ PASSWDLEN ] = '\0';
 
     if (( pwd = uam_getname(obj, username, ulen)) == NULL ) {

--- a/etc/uams/uams_passwd.c
+++ b/etc/uams/uams_passwd.c
@@ -57,7 +57,7 @@ static int pwd_login(void *obj, char *username, int ulen, struct passwd **uam_pw
 #endif /* SHADOWPW */
 
 
-    if (ibuflen < PASSWDLEN) {
+    if (ibuflen <= PASSWDLEN) {
         return( AFPERR_PARAM );
     }
     ibuf[ PASSWDLEN ] = '\0';
@@ -160,7 +160,7 @@ static int passwd_login_ext(void *obj, char *uname, struct passwd **uam_pwd,
                              (void *) &username, &ulen) < 0)
         return AFPERR_MISC;
 
-    if (*uname != 3)
+    if (*uname != 3 || ibuflen < 2)
         return AFPERR_PARAM;
     uname++;
     memcpy(&temp16, uname, sizeof(temp16));


### PR DESCRIPTION
* Check that input buffer can accommodate null terminator
* Input buffer null pointer and length checks