### PR TITLE
meson: Prioritize native WolfSSL package over built-in SSL library if it has the correct configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,7 @@ env:
     libtool \
     libtool-bin \
     libtracker-sparql-3.0-dev \
+    libwolfssl-dev \
     libwrap0-dev \
     meson \
     ninja-build \
@@ -226,6 +227,7 @@ jobs:
             libtool \
             libtool-bin \
             libtracker-sparql-3.0-dev \
+            libwolfssl-dev \
             libwrap0-dev \
             make \
             meson \
@@ -794,8 +796,8 @@ jobs:
               build-essential \
               libtool \
               pkg-config
-            curl -O https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-trunk-x86_64-20230910.tar.gz
-            tar -zxpf bootstrap-trunk-x86_64-20230910.tar.gz -C /
+            curl -O https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-trunk-x86_64-20240116.tar.gz
+            tar -zxpf bootstrap-trunk-x86_64-20240116.tar.gz -C /
             export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
             pkgin -y install \
               avahi \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -92,20 +92,20 @@ Required for Spotlight support:
 
 Optional:
 
-  - avahi or mDNSresponder  (for Zeroconf support)
-  - cracklib                (for cracklib support)
-  - Docbook XSL stylesheets (for manpages & manual documentation)
-  - GLib 2 and dbus-glib    (for afpstats support)
-  - Kerberos V              (for krbV UAM support)
-  - libacl                  (for ACL support)
-  - libldap                 (for LDAP support)
-  - libpam                  (for PAM support)
-  - libressl or OpenSSL@1.1 (for Randnum and DHX UAM support.
-                             Built-in SSL supportis also available)
-  - libtirpc / libquota     (for Quota support)
-  - perl                    (for various scripts)
-  - tcpwrap                 (for TCP wrapper support)
-  - xsltproc                (for manpages and mananual documentation)
+  - avahi or mDNSresponder           (for Zeroconf support)
+  - cracklib                         (for cracklib support)
+  - Docbook XSL stylesheets          (for manpages & manual documentation)
+  - GLib 2 and dbus-glib             (for afpstats support)
+  - Kerberos V                       (for krbV UAM support)
+  - libacl                           (for ACL support)
+  - libldap                          (for LDAP support)
+  - libpam                           (for PAM support)
+  - WolfSSL, libressl or OpenSSL@1.1 (for Randnum and DHX UAM support.
+                                      Built-in SSL support is also available)
+  - libtirpc / libquota              (for Quota support)
+  - perl                             (for various scripts)
+  - tcpwrap                          (for TCP wrapper support)
+  - xsltproc                         (for manpages and mananual documentation)
 
 More details about dependencies can be found in the documentation at
 https://netatalk.io/stable/htmldocs/installation

--- a/bin/afppasswd/afppasswd.c
+++ b/bin/afppasswd/afppasswd.c
@@ -39,7 +39,10 @@
 #include <crack.h>
 #endif /* USE_CRACKLIB */
 
-#if defined(EMBEDDED_SSL)
+#if defined(EMBEDDED_SSL) || defined(WOLFSSL_DHX)
+#if defined(WOLFSSL_DHX)
+#include <wolfssl/options.h>
+#endif
 #include <wolfssl/openssl/des.h>
 #elif defined(OPENSSL_DHX)
 #include <openssl/des.h>

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -26,7 +26,10 @@
 #include <security/pam_appl.h>
 #endif
 
-#if defined(EMBEDDED_SSL)
+#if defined(EMBEDDED_SSL) || defined(WOLFSSL_DHX)
+#if defined(WOLFSSL_DHX)
+#include <wolfssl/options.h>
+#endif
 #include <wolfssl/openssl/bn.h>
 #include <wolfssl/openssl/dh.h>
 #include <wolfssl/openssl/err.h>

--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -25,7 +25,10 @@
 #include <shadow.h>
 #endif /* SHADOWPW */
 
-#if defined(EMBEDDED_SSL)
+#if defined(EMBEDDED_SSL) || defined(WOLFSSL_DHX)
+#if defined(WOLFSSL_DHX)
+#include <wolfssl/options.h>
+#endif
 #include <wolfssl/openssl/bn.h>
 #include <wolfssl/openssl/dh.h>
 #include <wolfssl/openssl/err.h>

--- a/etc/uams/uams_pgp.c
+++ b/etc/uams/uams_pgp.c
@@ -21,7 +21,10 @@
 #include <crypt.h>
 #endif /* HAVE_CRYPT_H */
 
-#if defined(EMBEDDED_SSL)
+#if defined(EMBEDDED_SSL) || defined(WOLFSSL_DHX)
+#if defined(WOLFSSL_DHX)
+#include <wolfssl/options.h>
+#endif
 #include <wolfssl/openssl/bn.h>
 #include <wolfssl/openssl/dh.h>
 #include <wolfssl/openssl/err.h>

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -25,7 +25,10 @@
 #include <crack.h>
 #endif /* USE_CRACKLIB */
 
-#if defined(EMBEDDED_SSL)
+#if defined(EMBEDDED_SSL) || defined(WOLFSSL_DHX)
+#if defined(WOLFSSL_DHX)
+#include <wolfssl/options.h>
+#endif
 #include <wolfssl/openssl/des.h>
 #elif defined(OPENSSL_DHX)
 #include <openssl/des.h>

--- a/meson.build
+++ b/meson.build
@@ -522,13 +522,44 @@ if enable_dtags
     ssl_link_args += '-Wl,--enable-new-dtags'
 endif
 
-if have_embedded_ssl or crypto.found()
+wolfssl = dependency('wolfssl', required: false)
+
+if wolfssl.found()
+    wolfssl_check = run_command(
+        find_program('cat', required: false),
+        wolfssl.get_variable(pkgconfig: 'includedir') / 'wolfssl/options.h',
+        check: false,
+    ).stdout().strip()
+
+    if (
+        wolfssl_check.contains('HAVE_DH_DEFAULT_PARAMS')
+        and wolfssl_check.contains('WOLFSSL_DES_ECB')
+        and wolfssl_check.contains('OPENSSL_EXTRA')
+        and wolfssl_check.contains('OPENSSL_ALL')
+    )
+        have_wolfssl = true
+        have_embedded_ssl = false
+    else
+        have_wolfssl = false
+        message(
+            'The WolfSSL package on this system does not have the correct configuration for DHX and RANDNUM support'
+        )
+    endif
+else
+    have_wolfssl = false
+endif
+
+if have_wolfssl or have_embedded_ssl or crypto.found()
     have_ssl = true
     cdata.set('HAVE_LIBCRYPTO', 1)
     cdata.set('UAM_DHX', 1)
 endif
 
-if have_embedded_ssl
+if have_wolfssl
+    ssl_deps += wolfssl
+    ssl_provider += 'WolfSSL'
+    cdata.set('WOLFSSL_DHX', 1)
+elif have_embedded_ssl
     ssl_provider += 'built-in'
     cdata.set('EMBEDDED_SSL', 1)
 elif crypto.found()
@@ -542,7 +573,7 @@ elif crypto.found()
 else
     have_ssl = false
     warning(
-        'Either LibreSSL or OpenSSL version 1.1 is required for DHX and RANDNUM support',
+        'Built-in WolfSSL, LibreSSL or OpenSSL version 1.1 is required for DHX and RANDNUM support',
     )
 endif
 
@@ -961,7 +992,7 @@ if libgcrypt_path != ''
         include_directories: include_directories(libgcrypt_path / 'include'),
     )
 else
-    libgcrypt = dependency('libgcrypt', version : '>=1.2.3', required: false)
+    libgcrypt = dependency('libgcrypt', version: '>=1.2.3', required: false)
     if not libgcrypt.found()
         libgcrypt = cc.find_library(
             'libgcrypt',

--- a/meson_config.h
+++ b/meson_config.h
@@ -671,6 +671,9 @@
 /* Define whether to enable Spotlight support */
 #mesondefine WITH_SPOTLIGHT
 
+/* Define if the WolfSSL DHX modules should be built */
+#mesondefine WOLFSSL_DHX
+
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
 #if defined AC_APPLE_UNIVERSAL_BUILD


### PR DESCRIPTION
This commit enables meson to detect if a native WolfSSL library with the correct configuration is present and use it in preference to built-in SSL support