### PR TITLE
docs: Rephrase tarball section of manual

### DIFF
--- a/doc/ja/manual/install.xml
+++ b/doc/ja/manual/install.xml
@@ -48,8 +48,8 @@
       <sect3>
         <title>Tarball</title>
 
-        <para>Netatalk のソースを tar で固めた .tar.xz および .tar.bz2 形式のものが <ulink
-        url="https://github.com/Netatalk/netatalk">GitHub の netatalk のページ</ulink>にある。</para>
+        <para>tar で固めた Netatalk 安定版ソースコードは <ulink
+        url="https://github.com/Netatalk/netatalk/releases">GitHub の Netatalk リリースページ</ulink>にある。</para>
       </sect3>
 
       <sect3>

--- a/doc/manual/install.xml
+++ b/doc/manual/install.xml
@@ -38,10 +38,10 @@
       <sect3>
         <title>Tarballs</title>
 
-        <para>Prepackaged tarballs in .tar.xz and .tar.bz2 format containing
-        the netatalk source code are available on the <ulink
-        url="https://github.com/Netatalk/netatalk">Netatalk project page on
-        GitHub</ulink>.</para>
+        <para>Prepackaged tarballs with stable releases of the Netatalk source
+        code are available on the <ulink
+        url="https://github.com/Netatalk/netatalk/releases">Netatalk releases
+        page on GitHub</ulink>.</para>
       </sect3>
 
       <sect3>


### PR DESCRIPTION
This is to avoid talking about specific compression techniques (we currently don't distribute bzip2)