### PR TITLE
[2.4] meson: Fix errors in PAM support macro

### DIFF
--- a/config/pam/meson.build
+++ b/config/pam/meson.build
@@ -5,10 +5,10 @@ netatalk_pamd = configure_file(
 )
 
 if (
-    not fs.exists(pampath / 'netatalk')
+    not fs.exists(pam_confdir / 'netatalk')
     or (get_option('with-overwrite') and fs.exists(pampath / 'netatalk'))
 )
-    install_data(netatalk_pamd, install_dir: pampath)
+    install_data(netatalk_pamd, install_dir: pam_confdir)
 else
     message('not overwriting', file)
 endif

--- a/meson.build
+++ b/meson.build
@@ -1379,51 +1379,55 @@ endif
 
 enable_pam = get_option('with-pam')
 pam_path = get_option('with-pam-path')
+pam_conf_path = get_option('with-pam-config-path')
 
 pam_dir = ''
+pam_confdir = ''
 pam_includes = []
 pam_link_args = []
 uams_options = ''
-pam_paths = [
-    '/',
-    '/usr',
-    '/usr/local',
-]
-
-foreach path : pam_paths
-    if fs.is_dir(path / 'etc/pam.d')
-        pam_dir += path
-    endif
-    break
-endforeach
-
-if pam_dir == '' and host_os == 'sunos'
-    warning(
-        'PAM installation file = /etc/pam.conf. Please edit this file to enable PAM support',
-    )
-endif
-
-if pam_path != '' and pam_dir != '/'
-    pam_link_args += ['-L' + pam_path / 'lib', '-lpam']
-    if enable_rpath
-        pam_link_args += ['-R' + pam_path / 'lib']
-    endif
-    pam = declare_dependency(
-        link_args: pam_link_args,
-        include_directories: include_directories(pam_path / 'include'),
-    )
-else
-    pam = cc.find_library('pam', dirs: libsearch_dirs, required: false)
-endif
 
 if not enable_pam
     have_pam = false
 else
+    if host_os != 'sunos'
+        pam_paths = [
+            '/',
+            '/usr',
+            '/usr/local',
+        ]
+
+        foreach path : pam_paths
+            if fs.is_dir(path / 'etc/pam.d')
+                pam_dir += path
+            endif
+            break
+        endforeach
+    else
+        warning(
+            'PAM installation file = /etc/pam.conf. Please edit this file to enable PAM support',
+        )
+    endif
+
+    if pam_path != '' and pam_dir != '/'
+        pam_link_args += ['-L' + pam_path / 'lib', '-lpam']
+        if enable_rpath
+            pam_link_args += ['-R' + pam_path / 'lib']
+        endif
+        pam = declare_dependency(
+            link_args: pam_link_args,
+            include_directories: include_directories(pam_path / 'include'),
+        )
+    else
+        pam = cc.find_library('pam', dirs: libsearch_dirs, required: false)
+    endif
+
     have_pam = (
         cc.has_header('security/pam_appl.h')
         or cc.has_header('pam/pam_appl.h')
         or cc.has_function('pam_set_item', dependencies: pam)
     )
+
     if have_pam
         cdata.set('USE_PAM', 1)
         uams_options += 'PAM'
@@ -1434,9 +1438,9 @@ else
             cdata.set('PAM_AUTH', 'common-auth')
             cdata.set('PAM_ACCOUNT', 'common-account')
             cdata.set('PAM_PASSWORD', 'common-password')
-            if fs.exists(pam_dir / 'common-session-noninteractive')
+            if fs.exists(pampath / 'common-session-noninteractive')
                 cdata.set('PAM_SESSION', 'common-session-noninteractive')
-            elif fs.exists(pam_dir / 'common-session-nonlogin')
+            elif fs.exists(pampath / 'common-session-nonlogin')
                 cdata.set('PAM_SESSION', 'common-session-nonlogin')
             else
                 cdata.set('PAM_SESSION', 'common-session')
@@ -1487,6 +1491,12 @@ else
         have_pam = false
         warning('PAM support requested but required library not found')
     endif
+endif
+
+if pam_conf_path != ''
+    pam_confdir += pam_conf_path
+else
+    pam_confdir += prefix / 'etc/pam.d'
 endif
 
 #

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -238,6 +238,12 @@ option(
     description: 'Set path to PAM installation',
 )
 option(
+    'with-pam-config-path',
+    type: 'string',
+    value: '',
+    description: 'Set path to PAM config directory',
+)
+option(
     'with-srvloc-path',
     type: 'string',
     value: '',


### PR DESCRIPTION
Restore missing option to set PAM config path
Install PAM config file to correct location
Fix PAM_SESSION entry in PAM config file for Debian/SuSE