### PR TITLE
[2.4] Fix Zeroconf on Alpine Linux, and in the Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,20 @@ FROM alpine:3.20
 
 ENV LIB_DEPS \
     acl \
+    avahi \
+    avahi-compat-libdns_sd \
     bash \
     cups \
     db \
     krb5 \
     libgcrypt \
-    libtirpc \
     linux-pam \
     openldap \
-    rpcsvc-proto \
+    openssl \
     shadow
 ENV BUILD_DEPS \
     acl-dev \
+    avahi-dev \
     cups-dev \
     curl \
     db-dev \
@@ -21,15 +23,12 @@ ENV BUILD_DEPS \
     gcc \
     krb5-dev \
     libgcrypt-dev \
-    libtirpc-dev \
     linux-pam-dev \
     meson \
     ninja \
     openldap-dev \
-    openssl \
     openssl-dev \
-    pkgconfig \
-    rpcsvc-proto-dev
+    pkgconfig
 
 RUN apk update \
 &&  apk add --no-cache \
@@ -50,6 +49,10 @@ USER builder
 
 RUN meson setup build \
     -Dwith-cracklib=false \
+    -Dwith-embedded-ssl=true \
+    -Dwith-init-style=none \
+    -Dwith-pgp-uam=false \
+    -Dwith-quota=false \
     -Dwith-tcp-wrappers=false \
 &&  meson compile -C build
 

--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,7 @@ Changes in 2.4.2
 * UPD: meson: Add option to override system WolfSSL
        with embedded WolfSSL: `with-ssl-override', GitHub #1175
 * UPD: Remove obsolete Red Hat Upstart and SuSE SysV init scripts, GitHub #1162
+* FIX: Restore Zeroconf functionality for Alpine Linux, GitHub #1198
 * FIX: meson: Fix errors in PAM support macro, GitHub #1179
 * FIX: meson: Fix perl shebang substitution in cnid2_create script, GitHub #1184
 * FIX: meson: Fix errors in shadow password macro, GitHub #1191

--- a/meson.build
+++ b/meson.build
@@ -721,7 +721,7 @@ avahi = dependency('avahi-client', required: false)
 
 dns_sd_libs = []
 
-dns_sd = cc.find_library('dns_sd', has_headers: 'dns_sd.h', required: false)
+dns_sd = cc.find_library('dns_sd', required: false)
 if dns_sd.found()
     dns_sd_libs += dns_sd
 endif
@@ -735,7 +735,7 @@ zeroconf_provider = ''
 freebsd_zeroconf_daemon = ''
 
 have_dns = (
-    (dns_sd.found() or system.found())
+    (dns_sd.found() or system.found()) and cc.has_header('dns_sd.h')
     and cc.has_function(
         'DNSServiceRegister',
         dependencies: dns_sd_libs,


### PR DESCRIPTION
This restores functionality of the Docker container in 2.4:

- Missing fix for https://github.com/Netatalk/netatalk/pull/1155 in 2.4
- openssl needs to be a LIB_DEV, otherwise it gets purged before exporting the layers
- avahi compatibility libraries are required
- Disabling quota for now, as I was seeing errors in the afpd logs
- More explicit configuration flags