### PR TITLE
docker: Add option to enable ClearText and Guest UAMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ These are required to set the credentials used to authenticate with the file ser
 - `SERVER_NAME` <- the name of the server reported to Zeroconf
 - `SHARE_NAME` <- the name of the file sharing volume
 - `AFP_LOGLEVEL` <- the verbosity of logs; default is "info"
+- `INSECURE_AUTH` <- when non-zero, enable the "Clear Text" and "Guest" UAMs
 - `MANUAL_CONFIG` <- when non-zero, skip netatalk config file modification, allowing you to manually manage them
 
 # Webmin module

--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -80,6 +80,12 @@ elif [ ! -z "${AFP_USER}" ]; then
     chown "${AFP_USER}:${AFP_USER}" /mnt/afpbackup
 fi
 
+UAMS="uams_dhx.so uams_dhx2.so uams_randnum.so"
+
+if [ ! -z "${INSECURE_AUTH}" ]; then
+    UAMS+=" uams_clrtxt.so uams_guest.so"
+fi
+
 if [ -z "${MANUAL_CONFIG}" ]; then
     echo "*** Configuring Netatalk"
     cat <<EOF > /usr/local/etc/afp.conf
@@ -87,7 +93,7 @@ if [ -z "${MANUAL_CONFIG}" ]; then
 log file = /var/log/afpd.log
 log level = default:${AFP_LOGLEVEL:-info}
 spotlight = yes
-uam list = uams_dhx2.so uams_dhx.so uams_randnum.so
+uam list = ${UAMS}
 zeroconf name = ${SERVER_NAME:-Netatalk File Server}
 [${SHARE_NAME:-File Sharing}]
 path = /mnt/afpshare


### PR DESCRIPTION
This option exists in the 2.x docker configuration. It can be handy for 3.x as well.