### PR TITLE
meson: Don't install Japanese manual

### DIFF
--- a/doc/ja/manual/meson.build
+++ b/doc/ja/manual/meson.build
@@ -66,6 +66,5 @@ manual_gen = custom_target(
         manual_stylesheet_ja,
         '@INPUT@',
     ],
-    install: true,
-    install_dir: datadir / 'doc/netatalk/ja',
+    install: false,
 )


### PR DESCRIPTION
The Japanese html manual is meant for publishing to the web, so let's not install it with Meson.

This is akin to how we treat the Japanese manual pages.