### PR TITLE
docs: Standardize reference entry naming for netatalk-config man page

### DIFF
--- a/doc/ja/manpages/man1/netatalk-config.1.xml
+++ b/doc/ja/manpages/man1/netatalk-config.1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<refentry id="netatalkconfig.1">
+<refentry id="netatalk-config.1">
   <refmeta>
     <refentrytitle>netatalk-config</refentrytitle>
 

--- a/doc/ja/manual/Makefile.am
+++ b/doc/ja/manual/Makefile.am
@@ -44,7 +44,7 @@ HTML_PAGES = \
 	man-pages.html \
 	manual-index.html \
 	netatalk.8.html \
-	netatalkconfig.1.html \
+	netatalk-config.1.html \
 	pr01.html \
 	table-toc.html \
 	upgrade.html

--- a/doc/ja/manual/meson.build
+++ b/doc/ja/manual/meson.build
@@ -53,7 +53,7 @@ manual_gen = custom_target(
         'man-pages.html',
         'manual-index.html',
         'netatalk.8.html',
-        'netatalkconfig.1.html',
+        'netatalk-config.1.html',
         'table-toc.html',
         'upgrade.html',
     ],

--- a/doc/manpages/man1/netatalk-config.1.xml
+++ b/doc/manpages/man1/netatalk-config.1.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<refentry id="netatalkconfig.1">
+<refentry id="netatalk-config.1">
   <refmeta>
     <refentrytitle>netatalk-config</refentrytitle>
 

--- a/doc/manual/Makefile.am
+++ b/doc/manual/Makefile.am
@@ -47,7 +47,7 @@ HTML_PAGES = \
 	man-pages.html \
 	manual-index.html \
 	netatalk.8.html \
-	netatalkconfig.1.html \
+	netatalk-config.1.html \
 	pr01.html \
 	table-toc.html \
 	upgrade.html

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -53,7 +53,7 @@ manual_gen = custom_target(
         'man-pages.html',
         'manual-index.html',
         'netatalk.8.html',
-        'netatalkconfig.1.html',
+        'netatalk-config.1.html',
         'table-toc.html',
         'upgrade.html',
     ],


### PR DESCRIPTION
netatalk-config manual page reference entries have inconsistent naming: some with and some without hyphen. This uses the hyphen across the board.

Note that this change was made in the 2.x branch long time ago