### PR TITLE
[2.4] meson: Generate papd.conf manual html page

### DIFF
--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -68,6 +68,7 @@ manual_gen = custom_target(
         'netatalk-config.1.html',
         'pap.1.html',
         'papd.8.html',
+        'papd.conf.5.html',
         'papstatus.8.html',
         'psf.8.html',
         'psorder.1.html',


### PR DESCRIPTION
An oversight from when the meson build script was created