### PR TITLE
meson: Enable rpath for binaries only when with-rpath is enabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,7 @@ jobs:
     name: Debian Linux
     runs-on: ubuntu-22.04
     container:
-      image: debian:bookworm
+      image: debian:latest
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -243,11 +243,12 @@ jobs:
         run: |
           ./configure \
             --disable-dependency-tracking \
+            --disable-init-hooks \
             --enable-krbV-uam \
             --enable-pgp-uam \
             --enable-quota \
             --with-cracklib \
-            --with-init-style=debian-sysv \
+            --with-init-style=debian-systemd \
             --with-tracker-pkgconfig-version=3.0
       - name: Autotools - Build
         run: make -j $(nproc) all
@@ -255,27 +256,20 @@ jobs:
         run: make check
       - name: Autotools - Install
         run: make install
-      - name: Start netatalk
-        run: /etc/init.d/netatalk start && sleep 2 && asip-status localhost
-      - name: Stop netatalk
-        run: /etc/init.d/netatalk stop
       - name: Autotools - Uninstall
         run: make uninstall
       - name: Meson - Configure
         run: |
           meson setup build \
             -Dwith-tests=true \
-            -Dwith-init-style=debian-sysv
+            -Dwith-init-hooks=false \
+            -Dwith-init-style=debian-systemd
       - name: Meson - Build
         run: meson compile -C build
       - name: Meson - Run tests
         run: cd build && meson test
       - name: Meson - Install
         run: meson install -C build
-      - name: Start netatalk
-        run: /etc/init.d/netatalk start && sleep 2 && asip-status localhost
-      - name: Stop netatalk
-        run: /etc/init.d/netatalk stop
       - name: Meson - Uninstall
         run: ninja -C build uninstall
 
@@ -378,7 +372,6 @@ jobs:
             dbus-1-glib-devel \
             flex \
             glib2-devel \
-            krb5-devel \
             libacl-devel \
             libavahi-devel \
             libdb-4_8-devel \
@@ -400,7 +393,7 @@ jobs:
         run: |
           ./configure \
             --disable-init-hooks \
-            --enable-krbV-uam \
+            --disable-krbV-uam \
             --enable-pgp-uam \
             --with-cracklib \
             --with-init-style=suse-systemd \
@@ -416,6 +409,7 @@ jobs:
       - name: Meson - Configure
         run: |
           meson setup build \
+            -Dwith-krbV-uam=false \
             -Dwith-tests=true \
             -Dwith-init-hooks=false \
             -Dwith-init-style=suse-systemd
@@ -566,7 +560,7 @@ jobs:
               libressl \
               libtool \
               meson \
-              openldap26-client-2.6.7 \
+              openldap26-client-2.6.8 \
               pkgconf \
               talloc \
               tracker3

--- a/bin/ad/meson.build
+++ b/bin/ad/meson.build
@@ -16,14 +16,26 @@ if use_mysql_backend
     ad_deps += mysqlclient
 endif
 
-executable(
-    'ad',
-    ad_sources,
-    include_directories: root_includes,
-    dependencies: ad_deps,
-    link_with: libatalk,
-    c_args: [ad, dversion],
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'ad',
+        ad_sources,
+        include_directories: root_includes,
+        dependencies: ad_deps,
+        link_with: libatalk,
+        c_args: [ad, dversion],
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'ad',
+        ad_sources,
+        include_directories: root_includes,
+        dependencies: ad_deps,
+        link_with: libatalk,
+        c_args: [ad, dversion],
+        install: true,
+    )
+endif

--- a/bin/afppasswd/meson.build
+++ b/bin/afppasswd/meson.build
@@ -21,18 +21,34 @@ if have_embedded_ssl
     afppasswd_libs += libatalk
 endif
 
-executable(
-    'afppasswd',
-    afppasswd_sources,
-    include_directories: root_includes,
-    dependencies: afppasswd_deps,
-    link_with: afppasswd_libs,
-    c_args: [
-        afpdpwfile,
-        dversion,
-    ],
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-    install_mode: 'rwsr-xr-x',
-)
+if enable_rpath
+    executable(
+        'afppasswd',
+        afppasswd_sources,
+        include_directories: root_includes,
+        dependencies: afppasswd_deps,
+        link_with: afppasswd_libs,
+        c_args: [
+            afpdpwfile,
+            dversion,
+        ],
+        install: true,
+        install_mode: 'rwsr-xr-x',
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'afppasswd',
+        afppasswd_sources,
+        include_directories: root_includes,
+        dependencies: afppasswd_deps,
+        link_with: afppasswd_libs,
+        c_args: [
+            afpdpwfile,
+            dversion,
+        ],
+        install: true,
+        install_mode: 'rwsr-xr-x',
+    )
+endif

--- a/bin/misc/meson.build
+++ b/bin/misc/meson.build
@@ -40,15 +40,27 @@ if use_mysql_backend
 endif
 
 if have_ldap
-    executable(
-        'afpldaptest',
-        afpldaptest_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        dependencies: [afpldaptest_deps, ldap],
-        c_args: confdir,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
+    if enable_rpath
+        executable(
+            'afpldaptest',
+            afpldaptest_sources,
+            include_directories: root_includes,
+            link_with: libatalk,
+            dependencies: [afpldaptest_deps, ldap],
+            c_args: confdir,
+            install: true,
+            build_rpath: libdir,
+            install_rpath: libdir,
+        )
+    else
+        executable(
+            'afpldaptest',
+            afpldaptest_sources,
+            include_directories: root_includes,
+            link_with: libatalk,
+            dependencies: [afpldaptest_deps, ldap],
+            c_args: confdir,
+            install: true,
+        )
+    endif
 endif

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -182,25 +182,48 @@ if have_dtrace and host_os != 'darwin'
     afpd_external_deps += dtrace_deps
 endif
 
-executable(
-    'afpd',
-    afpd_dtrace_input,
-    objects: afpd_objs,
-    include_directories: root_includes,
-    link_with: [afpd_internal_deps, libatalk],
-    dependencies: afpd_external_deps,
-    c_args: [
-        '-DAPPLCNAME', afpd_c_args,
-        confdir,
-        dversion,
-        messagedir,
-        statedir,
-        uamdir,
-    ],
-    link_args: netatalk_common_link_args,
-    export_dynamic: true,
-    install: true,
-    install_dir: sbindir,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'afpd',
+        afpd_dtrace_input,
+        objects: afpd_objs,
+        include_directories: root_includes,
+        link_with: [afpd_internal_deps, libatalk],
+        dependencies: afpd_external_deps,
+        c_args: [
+            '-DAPPLCNAME', afpd_c_args,
+            confdir,
+            dversion,
+            messagedir,
+            statedir,
+            uamdir,
+        ],
+        link_args: netatalk_common_link_args,
+        export_dynamic: true,
+        install: true,
+        install_dir: sbindir,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'afpd',
+        afpd_dtrace_input,
+        objects: afpd_objs,
+        include_directories: root_includes,
+        link_with: [afpd_internal_deps, libatalk],
+        dependencies: afpd_external_deps,
+        c_args: [
+            '-DAPPLCNAME', afpd_c_args,
+            confdir,
+            dversion,
+            messagedir,
+            statedir,
+            uamdir,
+        ],
+        link_args: netatalk_common_link_args,
+        export_dynamic: true,
+        install: true,
+        install_dir: sbindir,
+    )
+endif

--- a/etc/cnid_dbd/meson.build
+++ b/etc/cnid_dbd/meson.build
@@ -23,34 +23,7 @@ if use_dbd_backend
         cnid_dbd_deps += mysqlclient
     endif
 
-    executable(
-        'cnid_dbd',
-        cnid_dbd_sources,
-        include_directories: [bdb_includes, root_includes],
-        link_with: libatalk,
-        dependencies: [cnid_dbd_deps, db],
-        c_args: [cnid_dbd, dversion],
-        link_args: bdb_link_args,
-        install: true,
-        install_dir: sbindir,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-
     cnid_metad_sources = ['cnid_metad.c', 'usockfd.c', 'db_param.c']
-
-    executable(
-        'cnid_metad',
-        cnid_metad_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        dependencies: cnid_dbd_deps,
-        c_args: [cnid_dbd, dversion],
-        install: true,
-        install_dir: sbindir,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
 
     dbd_sources = [
         'cmd_dbd.c',
@@ -66,16 +39,75 @@ if use_dbd_backend
         'pack.c',
     ]
 
-    executable(
-        'dbd',
-        dbd_sources,
-        include_directories: [bdb_includes, root_includes],
-        link_with: libatalk,
-        dependencies: [cnid_dbd_deps, db],
-        c_args: dversion,
-        link_args: bdb_link_args,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
+    if enable_rpath
+        executable(
+            'cnid_dbd',
+            cnid_dbd_sources,
+            include_directories: [bdb_includes, root_includes],
+            link_with: libatalk,
+            dependencies: [cnid_dbd_deps, db],
+            c_args: [cnid_dbd, dversion],
+            link_args: bdb_link_args,
+            install: true,
+            install_dir: sbindir,
+            build_rpath: libdir,
+            install_rpath: libdir,
+        )
+        executable(
+            'cnid_metad',
+            cnid_metad_sources,
+            include_directories: root_includes,
+            link_with: libatalk,
+            dependencies: cnid_dbd_deps,
+            c_args: [cnid_dbd, dversion],
+            install: true,
+            install_dir: sbindir,
+            build_rpath: libdir,
+            install_rpath: libdir,
+        )
+        executable(
+            'dbd',
+            dbd_sources,
+            include_directories: [bdb_includes, root_includes],
+            link_with: libatalk,
+            dependencies: [cnid_dbd_deps, db],
+            c_args: dversion,
+            link_args: bdb_link_args,
+            install: true,
+            build_rpath: libdir,
+            install_rpath: libdir,
+        )
+    else
+        executable(
+            'cnid_dbd',
+            cnid_dbd_sources,
+            include_directories: [bdb_includes, root_includes],
+            link_with: libatalk,
+            dependencies: [cnid_dbd_deps, db],
+            c_args: [cnid_dbd, dversion],
+            link_args: bdb_link_args,
+            install: true,
+            install_dir: sbindir,
+        )
+        executable(
+            'cnid_metad',
+            cnid_metad_sources,
+            include_directories: root_includes,
+            link_with: libatalk,
+            dependencies: cnid_dbd_deps,
+            c_args: [cnid_dbd, dversion],
+            install: true,
+            install_dir: sbindir,
+        )
+        executable(
+            'dbd',
+            dbd_sources,
+            include_directories: [bdb_includes, root_includes],
+            link_with: libatalk,
+            dependencies: [cnid_dbd_deps, db],
+            c_args: dversion,
+            link_args: bdb_link_args,
+            install: true,
+        )
+    endif
 endif

--- a/etc/netatalk/meson.build
+++ b/etc/netatalk/meson.build
@@ -11,15 +11,28 @@ elif avahi.found()
     netatalk_deps += avahi
 endif
 
-executable(
-    'netatalk',
-    netatalk_sources,
-    include_directories: root_includes,
-    link_with: libatalk,
-    dependencies: netatalk_deps,
-    c_args: [confdir, statedir, afpd, cnid_metad, dversion],
-    install: true,
-    install_dir: sbindir,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'netatalk',
+        netatalk_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        dependencies: netatalk_deps,
+        c_args: [confdir, statedir, afpd, cnid_metad, dversion],
+        install: true,
+        install_dir: sbindir,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'netatalk',
+        netatalk_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        dependencies: netatalk_deps,
+        c_args: [confdir, statedir, afpd, cnid_metad, dversion],
+        install: true,
+        install_dir: sbindir,
+    )
+endif

--- a/etc/uams/meson.build
+++ b/etc/uams/meson.build
@@ -51,40 +51,12 @@ endif
 if have_ssl
     uams_dhx_passwd_sources = ['uams_dhx_passwd.c']
 
-    uams_dhx_passwd = shared_module(
-        'uams_dhx_passwd',
-        uams_dhx_passwd_sources,
-        include_directories: root_includes,
-        dependencies: [crypt, ssl_deps],
-        link_with: ssl_links,
-        name_prefix: '',
-        name_suffix: 'so',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-
-    uams_dhx_passwd = static_library(
-        'uams_dhx_passwd',
-        uams_dhx_passwd_sources,
-        include_directories: root_includes,
-        dependencies: [crypt, ssl_deps],
-        link_with: ssl_links,
-        name_prefix: '',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-    if have_pam
-        uams_dhx_pam_sources = ['uams_dhx_pam.c']
-
-        uams_dhx_pam = shared_module(
-            'uams_dhx_pam',
-            uams_dhx_pam_sources,
-            include_directories: [pam_includes, root_includes],
-            dependencies: [pam, ssl_deps],
+    if enable_rpath
+        uams_dhx_passwd = shared_module(
+            'uams_dhx_passwd',
+            uams_dhx_passwd_sources,
+            include_directories: root_includes,
+            dependencies: [crypt, ssl_deps],
             link_with: ssl_links,
             name_prefix: '',
             name_suffix: 'so',
@@ -93,12 +65,11 @@ if have_ssl
             build_rpath: libdir,
             install_rpath: libdir,
         )
-
-        uams_dhx_pam = static_library(
-            'uams_dhx_pam',
-            uams_dhx_pam_sources,
-            include_directories: [pam_includes, root_includes],
-            dependencies: [pam, ssl_deps],
+        uams_dhx_passwd = static_library(
+            'uams_dhx_passwd',
+            uams_dhx_passwd_sources,
+            include_directories: root_includes,
+            dependencies: [crypt, ssl_deps],
             link_with: ssl_links,
             name_prefix: '',
             install: true,
@@ -106,6 +77,81 @@ if have_ssl
             build_rpath: libdir,
             install_rpath: libdir,
         )
+    else
+        uams_dhx_passwd = shared_module(
+            'uams_dhx_passwd',
+            uams_dhx_passwd_sources,
+            include_directories: root_includes,
+            dependencies: [crypt, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            name_suffix: 'so',
+            install: true,
+            install_dir: libdir / 'netatalk',
+        )
+        uams_dhx_passwd = static_library(
+            'uams_dhx_passwd',
+            uams_dhx_passwd_sources,
+            include_directories: root_includes,
+            dependencies: [crypt, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            install: true,
+            install_dir: libdir / 'netatalk',
+        )
+    endif
+    if have_pam
+        uams_dhx_pam_sources = ['uams_dhx_pam.c']
+
+        if enable_rpath
+            uams_dhx_pam = shared_module(
+                'uams_dhx_pam',
+                uams_dhx_pam_sources,
+                include_directories: [pam_includes, root_includes],
+                dependencies: [pam, ssl_deps],
+                link_with: ssl_links,
+                name_prefix: '',
+                name_suffix: 'so',
+                install: true,
+                install_dir: libdir / 'netatalk',
+                build_rpath: libdir,
+                install_rpath: libdir,
+            )
+            uams_dhx_pam = static_library(
+                'uams_dhx_pam',
+                uams_dhx_pam_sources,
+                include_directories: [pam_includes, root_includes],
+                dependencies: [pam, ssl_deps],
+                link_with: ssl_links,
+                name_prefix: '',
+                install: true,
+                install_dir: libdir / 'netatalk',
+                build_rpath: libdir,
+                install_rpath: libdir,
+            )
+        else
+            uams_dhx_pam = shared_module(
+                'uams_dhx_pam',
+                uams_dhx_pam_sources,
+                include_directories: [pam_includes, root_includes],
+                dependencies: [pam, ssl_deps],
+                link_with: ssl_links,
+                name_prefix: '',
+                name_suffix: 'so',
+                install: true,
+                install_dir: libdir / 'netatalk',
+            )
+            uams_dhx_pam = static_library(
+                'uams_dhx_pam',
+                uams_dhx_pam_sources,
+                include_directories: [pam_includes, root_includes],
+                dependencies: [pam, ssl_deps],
+                link_with: ssl_links,
+                name_prefix: '',
+                install: true,
+                install_dir: libdir / 'netatalk',
+            )
+        endif
 
         install_symlink(
             'uams_dhx.so',
@@ -222,32 +268,55 @@ endif
 if have_ssl
     uams_randnum_sources = ['uams_randnum.c']
 
-    uams_randnum = shared_module(
-        'uams_randnum',
-        uams_randnum_sources,
-        include_directories: root_includes,
-        dependencies: [crack, pam, ssl_deps],
-        link_with: ssl_links,
-        name_prefix: '',
-        name_suffix: 'so',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-
-    uams_randnum = static_library(
-        'uams_randnum',
-        uams_randnum_sources,
-        include_directories: root_includes,
-        dependencies: [crack, pam, ssl_deps],
-        link_with: ssl_links,
-        name_prefix: '',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
+    if enable_rpath
+        uams_randnum = shared_module(
+            'uams_randnum',
+            uams_randnum_sources,
+            include_directories: root_includes,
+            dependencies: [crack, pam, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            name_suffix: 'so',
+            install: true,
+            install_dir: libdir / 'netatalk',
+            build_rpath: libdir,
+            install_rpath: libdir,
+        )
+        uams_randnum = static_library(
+            'uams_randnum',
+            uams_randnum_sources,
+            include_directories: root_includes,
+            dependencies: [crack, pam, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            install: true,
+            install_dir: libdir / 'netatalk',
+            build_rpath: libdir,
+            install_rpath: libdir,
+        )
+    else
+        uams_randnum = shared_module(
+            'uams_randnum',
+            uams_randnum_sources,
+            include_directories: root_includes,
+            dependencies: [crack, pam, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            name_suffix: 'so',
+            install: true,
+            install_dir: libdir / 'netatalk',
+        )
+        uams_randnum = static_library(
+            'uams_randnum',
+            uams_randnum_sources,
+            include_directories: root_includes,
+            dependencies: [crack, pam, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            install: true,
+            install_dir: libdir / 'netatalk',
+        )
+    endif
 endif
 
 if enable_pgp_uam

--- a/meson.build
+++ b/meson.build
@@ -319,12 +319,10 @@ endif
 # Check whether to enable rpath (the default on Solaris and NetBSD)
 #
 
-enable_rpath = get_option('with-rpath')
-
-if not get_option('with-rpath')
-    enable_rpath = false
-elif host_os == 'sunos' or host_os == 'netbsd'
+if host_os == 'sunos' or host_os == 'netbsd'
     enable_rpath = true
+else
+    enable_rpath = get_option('with-rpath')
 endif
 
 if host_os == 'linux'


### PR DESCRIPTION
This change enables rpath for compiled binaries only when with-rpath is enabled, or when the OS is NetBSD or Solaris[h]. There might a more graceful way to do this than duplicating each executable() call, but I couldn't find out how.

It also tweaks the GitHub CI actions to:

1. Use the latest stable Debian image, and with systemd instead of sysv (Trixie seems to finally do away with sysv init script wrappers.) We lose the ability to test the dynamic execution of netatalk on Debian, unfortunately, but we still test it on Ubuntu, so... 

2. Turn off kerberos for openSUSE, since they keep breaking the dependencies for their krb5 package.

3. Bumps the openldap library version for FreeBSD