### PR TITLE
[2.4] meson: Enable rpath for binaries only when with-rpath is enabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,8 @@ jobs:
       - name: Autotools - Configure
         run: |
           ./configure \
-            --enable-debian \
+            --disable-install-priviledged \
+            --enable-systemd \
             --enable-krbV-uam \
             --enable-pgp-uam \
             --enable-quota \
@@ -210,9 +211,10 @@ jobs:
       - name: Meson - Configure
         run: |
           meson setup build \
-            -Dwith-tests=true \
-            -Dwith-init-style=debian-sysv \
-            -Dwith-quota=true
+            -Dwith-init-hooks=false \
+            -Dwith-init-style=debian-systemd \
+            -Dwith-quota=true \
+            -Dwith-tests=true
       - name: Meson - Build
         run: meson compile -C build
       - name: Meson - Tests
@@ -308,7 +310,6 @@ jobs:
           zypper in -y \
             cracklib-devel \
             glib2-devel \
-            krb5-devel \
             libacl-devel \
             libavahi-devel \
             libdb-4_8-devel \
@@ -326,10 +327,10 @@ jobs:
         run: |
           ./configure \
             --disable-install-priviledged \
-            --enable-krbV-uam \
+            --disable-krbV-uam \
             --enable-pgp-uam \
-            --with-cracklib \
-            --enable-systemd
+            --enable-systemd \
+            --with-cracklib
       - name: Autotools - Build
         run: make -j $(nproc)
       - name: Autotools - Run tests
@@ -343,6 +344,7 @@ jobs:
           meson setup build \
             -Dwith-init-hooks=false \
             -Dwith-init-style=suse-systemd \
+            -Dwith-krbV-uam=false \
             -Dwith-tests=true
       - name: Meson - Build
         run: meson compile -C build
@@ -532,7 +534,7 @@ jobs:
               libressl \
               libtool \
               meson \
-              openldap26-client-2.6.7 \
+              openldap26-client-2.6.8 \
               pkgconf
           run: |
             set -e

--- a/bin/ad/meson.build
+++ b/bin/ad/meson.build
@@ -14,14 +14,26 @@ if have_acls
     ad_deps += acl_deps
 endif
 
-executable(
-    'ad',
-    ad_sources,
-    include_directories: root_includes,
-    dependencies: ad_deps,
-    link_with: [libatalk, libcnid],
-    c_args: [ad, dversion],
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'ad',
+        ad_sources,
+        include_directories: root_includes,
+        dependencies: ad_deps,
+        link_with: [libatalk, libcnid],
+        c_args: [ad, dversion],
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'ad',
+        ad_sources,
+        include_directories: root_includes,
+        dependencies: ad_deps,
+        link_with: [libatalk, libcnid],
+        c_args: [ad, dversion],
+        install: true,
+    )
+endif

--- a/bin/adv1tov2/meson.build
+++ b/bin/adv1tov2/meson.build
@@ -1,9 +1,19 @@
-executable(
-    'adv1tov2',
-    'adv1tov2.c',
-    include_directories: root_includes,
-    link_with: libatalk,
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'adv1tov2',
+        'adv1tov2.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'adv1tov2',
+        'adv1tov2.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+    )
+endif

--- a/bin/aecho/meson.build
+++ b/bin/aecho/meson.build
@@ -1,9 +1,19 @@
-executable(
-    'aecho',
-    'aecho.c',
-    include_directories: root_includes,
-    link_with: libatalk,
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'aecho',
+        'aecho.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'aecho',
+        'aecho.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+    )
+endif

--- a/bin/afppasswd/meson.build
+++ b/bin/afppasswd/meson.build
@@ -17,15 +17,28 @@ if have_cracklib
     afppasswd_deps += crack
 endif
 
-executable(
-    'afppasswd',
-    'afppasswd.c',
-    include_directories: root_includes,
-    dependencies: afppasswd_deps,
-    link_with: afppasswd_libs,
-    c_args: [afpdpwfile, dversion],
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-    install_mode: 'rwsr-xr-x',
-)
+if enable_rpath
+    executable(
+        'afppasswd',
+        'afppasswd.c',
+        include_directories: root_includes,
+        dependencies: afppasswd_deps,
+        link_with: afppasswd_libs,
+        c_args: [afpdpwfile, dversion],
+        install: true,
+        install_mode: 'rwsr-xr-x',
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'afppasswd',
+        'afppasswd.c',
+        include_directories: root_includes,
+        dependencies: afppasswd_deps,
+        link_with: afppasswd_libs,
+        c_args: [afpdpwfile, dversion],
+        install: true,
+        install_mode: 'rwsr-xr-x',
+    )
+endif

--- a/bin/getzones/meson.build
+++ b/bin/getzones/meson.build
@@ -1,9 +1,19 @@
-executable(
-    'getzones',
-    'getzones.c',
-    include_directories: root_includes,
-    link_with: libatalk,
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'getzones',
+        'getzones.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'getzones',
+        'getzones.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+    )
+endif

--- a/bin/megatron/meson.build
+++ b/bin/megatron/meson.build
@@ -7,13 +7,24 @@ megatron_sources = [
     'updcrc.c',
 ]
 
-executable(
-    'megatron',
-    megatron_sources,
-    include_directories: root_includes,
-    link_with: libatalk,
-    c_args: dversion,
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'megatron',
+        megatron_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: dversion,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'megatron',
+        megatron_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: dversion,
+        install: true,
+    )
+endif

--- a/bin/misc/meson.build
+++ b/bin/misc/meson.build
@@ -23,15 +23,27 @@ executable(
 )
 
 if have_ldap
-    executable(
-        'afpldaptest',
-        'uuidtest.c',
-        include_directories: root_includes,
-        dependencies: ldap,
-        link_with: libatalk,
-        c_args: acl_ldapconf,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
+    if enable_rpath
+        executable(
+            'afpldaptest',
+            'uuidtest.c',
+            include_directories: root_includes,
+            dependencies: ldap,
+            link_with: libatalk,
+            c_args: acl_ldapconf,
+            install: true,
+            build_rpath: libdir,
+            install_rpath: libdir,
+        )
+    else
+        executable(
+            'afpldaptest',
+            'uuidtest.c',
+            include_directories: root_includes,
+            dependencies: ldap,
+            link_with: libatalk,
+            c_args: acl_ldapconf,
+            install: true,
+        )
+    endif
 endif

--- a/bin/nbp/meson.build
+++ b/bin/nbp/meson.build
@@ -1,29 +1,51 @@
-executable(
-    'nbplkup',
-    'nbplkup.c',
-    include_directories: root_includes,
-    link_with: libatalk,
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
-
-executable(
-    'nbprgstr',
-    'nbprgstr.c',
-    include_directories: root_includes,
-    link_with: libatalk,
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
-
-executable(
-    'nbpunrgstr',
-    'nbpunrgstr.c',
-    include_directories: root_includes,
-    link_with: libatalk,
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'nbplkup',
+        'nbplkup.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+    executable(
+        'nbprgstr',
+        'nbprgstr.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+    executable(
+        'nbpunrgstr',
+        'nbpunrgstr.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'nbplkup',
+        'nbplkup.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+    )
+    executable(
+        'nbprgstr',
+        'nbprgstr.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+    )
+    executable(
+        'nbpunrgstr',
+        'nbpunrgstr.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+    )
+endif

--- a/bin/pap/meson.build
+++ b/bin/pap/meson.build
@@ -1,18 +1,35 @@
-executable(
-    'pap',
-    'pap.c',
-    include_directories: root_includes,
-    link_with: libatalk,
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
-executable(
-    'papstatus',
-    'papstatus.c',
-    include_directories: root_includes,
-    link_with: libatalk,
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'pap',
+        'pap.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+    executable(
+        'papstatus',
+        'papstatus.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'pap',
+        'pap.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+    )
+    executable(
+        'papstatus',
+        'papstatus.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+    )
+endif

--- a/bin/psorder/meson.build
+++ b/bin/psorder/meson.build
@@ -3,12 +3,22 @@ psorder_sources = [
     'psorder.c',
 ]
 
-executable(
-    'psorder',
-    psorder_sources,
-    include_directories: root_includes,
-    link_with: libatalk,
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'psorder',
+        psorder_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'psorder',
+        psorder_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+    )
+endif

--- a/bin/uniconv/meson.build
+++ b/bin/uniconv/meson.build
@@ -1,12 +1,23 @@
 uniconv_sources = ['iso8859_1_adapted.c', 'uniconv.c']
 
-executable(
-    'uniconv',
-    uniconv_sources,
-    include_directories: root_includes,
-    link_with: libatalk,
-    c_args: dversion,
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'uniconv',
+        uniconv_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: dversion,
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'uniconv',
+        uniconv_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: dversion,
+        install: true,
+    )
+endif

--- a/contrib/a2boot/meson.build
+++ b/contrib/a2boot/meson.build
@@ -1,19 +1,33 @@
-executable(
-    'a2boot',
-    'a2boot.c',
-    include_directories: root_includes,
-    link_with: libatalk,
-    c_args: [
-        '-D_PATH_A_GS_BLOCKS="'
-        + pkgconfdir
-        + '/a2boot/ProDOS16 Boot Blocks"',
-        '-D_PATH_A_2E_BLOCKS="'
-        + pkgconfdir
-        + '/a2boot/Apple :2f:2fe Boot Blocks"',
-        '-D_PATH_P16_IMAGE="' + pkgconfdir + '/a2boot/ProDOS16 Image"',
-    ],
-    install: true,
-    install_dir: sbindir,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+a2boot_c_args = [
+    '-D_PATH_A_GS_BLOCKS="'
+    + pkgconfdir
+    + '/a2boot/ProDOS16 Boot Blocks"',
+    '-D_PATH_A_2E_BLOCKS="'
+    + pkgconfdir
+    + '/a2boot/Apple :2f:2fe Boot Blocks"',
+    '-D_PATH_P16_IMAGE="' + pkgconfdir + '/a2boot/ProDOS16 Image"',
+]
+
+if enable_rpath
+    executable(
+        'a2boot',
+        'a2boot.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: a2boot_c_args,
+        install: true,
+        install_dir: sbindir,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'a2boot',
+        'a2boot.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: a2boot_c_args,
+        install: true,
+        install_dir: sbindir,
+    )
+endif

--- a/contrib/timelord/meson.build
+++ b/contrib/timelord/meson.build
@@ -1,10 +1,21 @@
-executable(
-    'timelord',
-    'timelord.c',
-    include_directories: root_includes,
-    link_with: libatalk,
-    install: true,
-    install_dir: sbindir,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'timelord',
+        'timelord.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+        install_dir: sbindir,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'timelord',
+        'timelord.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        install: true,
+        install_dir: sbindir,
+    )
+endif

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -75,30 +75,46 @@ if have_srvloc
     afpd_external_deps += slp
 endif
 
-executable(
-    'afpd',
-    afpd_sources,
-    include_directories: root_includes,
-    link_with: [afpd_internal_deps, libatalk],
-    dependencies: afpd_external_deps,
-    c_args: [
-        '-DAPPLCNAME', acl_ldapconf,
-        afpdconf,
-        afpddefvol,
-        afpdpwfile,
-        afpdsigconf,
-        afpdsysvol,
-        afpduuidconf,
-        dversion,
-        messagedir,
-        uamdir,
-    ],
-    export_dynamic: true,
-    install: true,
-    install_dir: sbindir,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+afpd_c_args = [
+    '-DAPPLCNAME', acl_ldapconf,
+    afpdconf,
+    afpddefvol,
+    afpdpwfile,
+    afpdsigconf,
+    afpdsysvol,
+    afpduuidconf,
+    dversion,
+    messagedir,
+    uamdir,
+]
+
+if enable_rpath
+    executable(
+        'afpd',
+        afpd_sources,
+        include_directories: root_includes,
+        link_with: [afpd_internal_deps, libatalk],
+        dependencies: afpd_external_deps,
+        c_args: afpd_c_args,
+        export_dynamic: true,
+        install: true,
+        install_dir: sbindir,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'afpd',
+        afpd_sources,
+        include_directories: root_includes,
+        link_with: [afpd_internal_deps, libatalk],
+        dependencies: afpd_external_deps,
+        c_args: afpd_c_args,
+        export_dynamic: true,
+        install: true,
+        install_dir: sbindir,
+    )
+endif
 
 executable(
     'fce',

--- a/etc/atalkd/meson.build
+++ b/etc/atalkd/meson.build
@@ -9,14 +9,28 @@ atalkd_sources = [
     'zip.c',
 ]
 
-executable(
-    'atalkd',
-    atalkd_sources,
-    include_directories: root_includes,
-    link_with: libatalk,
-    c_args: ['-D_PATH_ATALKDCONF="' + pkgconfdir + '/atalkd.conf"', dversion],
-    install: true,
-    install_dir: sbindir,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+atalkd_c_args = ['-D_PATH_ATALKDCONF="' + pkgconfdir + '/atalkd.conf"', dversion]
+
+if enable_rpath
+    executable(
+        'atalkd',
+        atalkd_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: atalkd_c_args,
+        install: true,
+        install_dir: sbindir,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'atalkd',
+        atalkd_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: atalkd_c_args,
+        install: true,
+        install_dir: sbindir,
+    )
+endif

--- a/etc/cnid_dbd/meson.build
+++ b/etc/cnid_dbd/meson.build
@@ -17,33 +17,7 @@ if use_dbd_backend
         'pack.c',
     ]
 
-    executable(
-        'cnid_dbd',
-        cnid_dbd_sources,
-        include_directories: [bdb_includes, root_includes],
-        link_with: libatalk,
-        dependencies: db,
-        c_args: [cnid_dbd, dversion],
-        link_args: bdb_link_args,
-        install: true,
-        install_dir: sbindir,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-
     cnid_metad_sources = ['cnid_metad.c', 'usockfd.c', 'db_param.c']
-
-    executable(
-        'cnid_metad',
-        cnid_metad_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: [cnid_dbd, dversion],
-        install: true,
-        install_dir: sbindir,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
 
     dbd_sources = [
         'cmd_dbd.c',
@@ -59,16 +33,73 @@ if use_dbd_backend
         'pack.c',
     ]
 
-    executable(
-        'dbd',
-        dbd_sources,
-        include_directories: [bdb_includes, root_includes],
-        link_with: libatalk,
-        dependencies: db,
-        c_args: dversion,
-        link_args: [dversion, bdb_link_args],
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
+    if enable_rpath
+        executable(
+            'cnid_dbd',
+            cnid_dbd_sources,
+            include_directories: [bdb_includes, root_includes],
+            link_with: libatalk,
+            dependencies: db,
+            c_args: [cnid_dbd, dversion],
+            link_args: bdb_link_args,
+            install: true,
+            install_dir: sbindir,
+            build_rpath: libdir,
+            install_rpath: libdir,
+        )
+        executable(
+            'cnid_metad',
+            cnid_metad_sources,
+            include_directories: root_includes,
+            link_with: libatalk,
+            c_args: [cnid_dbd, dversion],
+            install: true,
+            install_dir: sbindir,
+            build_rpath: libdir,
+            install_rpath: libdir,
+        )
+        executable(
+            'dbd',
+            dbd_sources,
+            include_directories: [bdb_includes, root_includes],
+            link_with: libatalk,
+            dependencies: db,
+            c_args: dversion,
+            link_args: [dversion, bdb_link_args],
+            install: true,
+            build_rpath: libdir,
+            install_rpath: libdir,
+        )
+    else
+        executable(
+            'cnid_dbd',
+            cnid_dbd_sources,
+            include_directories: [bdb_includes, root_includes],
+            link_with: libatalk,
+            dependencies: db,
+            c_args: [cnid_dbd, dversion],
+            link_args: bdb_link_args,
+            install: true,
+            install_dir: sbindir,
+        )
+        executable(
+            'cnid_metad',
+            cnid_metad_sources,
+            include_directories: root_includes,
+            link_with: libatalk,
+            c_args: [cnid_dbd, dversion],
+            install: true,
+            install_dir: sbindir,
+        )
+        executable(
+            'dbd',
+            dbd_sources,
+            include_directories: [bdb_includes, root_includes],
+            link_with: libatalk,
+            dependencies: db,
+            c_args: dversion,
+            link_args: [dversion, bdb_link_args],
+            install: true,
+        )
+    endif
 endif

--- a/etc/papd/meson.build
+++ b/etc/papd/meson.build
@@ -14,35 +14,58 @@ papd_sources = [
     'uam.c',
 ]
 
-executable(
-    'papd',
-    papd_sources,
-    include_directories: root_includes,
-    link_with: libatalk,
-    dependencies: cups,
-    c_args: [
-        '-D_PATH_PAPDCONF="' + pkgconfdir + '/papd.conf"',
-        '-D_PATH_PAPDUAMPATH="' + libdir + '/netatalk/"',
-        '-DSPOOLDIR="' + spooldir + '/"',
-        dversion,
-    ],
-    export_dynamic: true,
-    install: true,
-    install_dir: sbindir,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+papd_c_args = [
+    '-D_PATH_PAPDCONF="' + pkgconfdir + '/papd.conf"',
+    '-D_PATH_PAPDUAMPATH="' + libdir + '/netatalk/"',
+    '-DSPOOLDIR="' + spooldir + '/"',
+    dversion,
+]
 
-executable(
-    'showppd',
-    ['ppd.c', 'showppd.c'],
-    include_directories: root_includes,
-    link_with: libatalk,
-    c_args: '-DSHOWPPD',
-    install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'papd',
+        papd_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        dependencies: cups,
+        c_args: papd_c_args,
+        export_dynamic: true,
+        install: true,
+        install_dir: sbindir,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+    executable(
+        'showppd',
+        ['ppd.c', 'showppd.c'],
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: '-DSHOWPPD',
+        install: true,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'papd',
+        papd_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        dependencies: cups,
+        c_args: papd_c_args,
+        export_dynamic: true,
+        install: true,
+        install_dir: sbindir,
+    )
+    executable(
+        'showppd',
+        ['ppd.c', 'showppd.c'],
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: '-DSHOWPPD',
+        install: true,
+    )
+endif
 
 if have_cups and spooldir_required
     install_emptydir(spooldir, install_mode: 'rwxrwxrwx')

--- a/etc/psf/meson.build
+++ b/etc/psf/meson.build
@@ -1,42 +1,59 @@
-executable(
-    'psa',
-    'psa.c',
-    include_directories: root_includes,
-    link_with: libatalk,
-    c_args: [
-        '-DZEROWIDTH',
-        '-D_PATH_PAP="' + sbindir + '/pap"',
-        '-D_PATH_PSORDER="' + bindir + '/psorder"',
-        '-D_PATH_PSA="' + libexecdir + '/psa"',
-        '-D_PATH_PSFILTER="' + libexecdir + '/etc2ps.sh"',
-        '-D_PATH_PAGECOUNT="' + datadir + '/pagecount.ps"',
-    ],
-    export_dynamic: true,
-    install: true,
-    install_dir: libexecdir,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+psf_c_args = [
+    '-DZEROWIDTH',
+    '-D_PATH_PAP="' + sbindir + '/pap"',
+    '-D_PATH_PSORDER="' + bindir + '/psorder"',
+    '-D_PATH_PSA="' + libexecdir + '/psa"',
+    '-D_PATH_PSFILTER="' + libexecdir + '/etc2ps.sh"',
+    '-D_PATH_PAGECOUNT="' + datadir + '/pagecount.ps"',
+]
 
-executable(
-    'psf',
-    'psf.c',
-    include_directories: root_includes,
-    link_with: libatalk,
-    c_args: [
-        '-DZEROWIDTH',
-        '-D_PATH_PAP="' + sbindir + '/pap"',
-        '-D_PATH_PSORDER="' + bindir + '/psorder"',
-        '-D_PATH_PSA="' + libexecdir + '/psa"',
-        '-D_PATH_PSFILTER="' + libexecdir + '/etc2ps.sh"',
-        '-D_PATH_PAGECOUNT="' + datadir + '/pagecount.ps"',
-    ],
-    export_dynamic: true,
-    install: true,
-    install_dir: libexecdir,
-    build_rpath: libdir,
-    install_rpath: libdir,
-)
+if enable_rpath
+    executable(
+        'psa',
+        'psa.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: psf_c_args,
+        export_dynamic: true,
+        install: true,
+        install_dir: libexecdir,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+    executable(
+        'psf',
+        'psf.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: psf_c_args,
+        export_dynamic: true,
+        install: true,
+        install_dir: libexecdir,
+        build_rpath: libdir,
+        install_rpath: libdir,
+    )
+else
+    executable(
+        'psa',
+        'psa.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: psf_c_args,
+        export_dynamic: true,
+        install: true,
+        install_dir: libexecdir,
+    )
+    executable(
+        'psf',
+        'psf.c',
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: psf_c_args,
+        export_dynamic: true,
+        install: true,
+        install_dir: libexecdir,
+    )
+endif
 
 install_data('pagecount.ps', install_dir: datadir / 'netatalk')
 

--- a/etc/uams/meson.build
+++ b/etc/uams/meson.build
@@ -51,40 +51,12 @@ endif
 if have_ssl
     uams_dhx_passwd_sources = ['uams_dhx_passwd.c']
 
-    uams_dhx_passwd = shared_module(
-        'uams_dhx_passwd',
-        uams_dhx_passwd_sources,
-        include_directories: root_includes,
-        dependencies: [crypt, ssl_deps],
-        link_with: ssl_links,
-        name_prefix: '',
-        name_suffix: 'so',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-
-    uams_dhx_passwd = static_library(
-        'uams_dhx_passwd',
-        uams_dhx_passwd_sources,
-        include_directories: root_includes,
-        dependencies: [crypt, ssl_deps],
-        link_with: ssl_links,
-        name_prefix: '',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-    if have_pam
-        uams_dhx_pam_sources = ['uams_dhx_pam.c']
-
-        uams_dhx_pam = shared_module(
-            'uams_dhx_pam',
-            uams_dhx_pam_sources,
-            include_directories: [pam_includes, root_includes],
-            dependencies: [pam, ssl_deps],
+    if enable_rpath
+        uams_dhx_passwd = shared_module(
+            'uams_dhx_passwd',
+            uams_dhx_passwd_sources,
+            include_directories: root_includes,
+            dependencies: [crypt, ssl_deps],
             link_with: ssl_links,
             name_prefix: '',
             name_suffix: 'so',
@@ -93,12 +65,11 @@ if have_ssl
             build_rpath: libdir,
             install_rpath: libdir,
         )
-
-        uams_dhx_pam = static_library(
-            'uams_dhx_pam',
-            uams_dhx_pam_sources,
-            include_directories: [pam_includes, root_includes],
-            dependencies: [pam, ssl_deps],
+        uams_dhx_passwd = static_library(
+            'uams_dhx_passwd',
+            uams_dhx_passwd_sources,
+            include_directories: root_includes,
+            dependencies: [crypt, ssl_deps],
             link_with: ssl_links,
             name_prefix: '',
             install: true,
@@ -106,6 +77,81 @@ if have_ssl
             build_rpath: libdir,
             install_rpath: libdir,
         )
+    else
+        uams_dhx_passwd = shared_module(
+            'uams_dhx_passwd',
+            uams_dhx_passwd_sources,
+            include_directories: root_includes,
+            dependencies: [crypt, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            name_suffix: 'so',
+            install: true,
+            install_dir: libdir / 'netatalk',
+        )
+        uams_dhx_passwd = static_library(
+            'uams_dhx_passwd',
+            uams_dhx_passwd_sources,
+            include_directories: root_includes,
+            dependencies: [crypt, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            install: true,
+            install_dir: libdir / 'netatalk',
+        )
+    endif
+    if have_pam
+        uams_dhx_pam_sources = ['uams_dhx_pam.c']
+
+        if enable_rpath
+            uams_dhx_pam = shared_module(
+                'uams_dhx_pam',
+                uams_dhx_pam_sources,
+                include_directories: [pam_includes, root_includes],
+                dependencies: [pam, ssl_deps],
+                link_with: ssl_links,
+                name_prefix: '',
+                name_suffix: 'so',
+                install: true,
+                install_dir: libdir / 'netatalk',
+                build_rpath: libdir,
+                install_rpath: libdir,
+            )
+            uams_dhx_pam = static_library(
+                'uams_dhx_pam',
+                uams_dhx_pam_sources,
+                include_directories: [pam_includes, root_includes],
+                dependencies: [pam, ssl_deps],
+                link_with: ssl_links,
+                name_prefix: '',
+                install: true,
+                install_dir: libdir / 'netatalk',
+                build_rpath: libdir,
+                install_rpath: libdir,
+            )
+        else
+            uams_dhx_pam = shared_module(
+                'uams_dhx_pam',
+                uams_dhx_pam_sources,
+                include_directories: [pam_includes, root_includes],
+                dependencies: [pam, ssl_deps],
+                link_with: ssl_links,
+                name_prefix: '',
+                name_suffix: 'so',
+                install: true,
+                install_dir: libdir / 'netatalk',
+            )
+            uams_dhx_pam = static_library(
+                'uams_dhx_pam',
+                uams_dhx_pam_sources,
+                include_directories: [pam_includes, root_includes],
+                dependencies: [pam, ssl_deps],
+                link_with: ssl_links,
+                name_prefix: '',
+                install: true,
+                install_dir: libdir / 'netatalk',
+            )
+        endif
 
         install_symlink(
             'uams_dhx.so',
@@ -222,32 +268,55 @@ endif
 if have_ssl
     uams_randnum_sources = ['uams_randnum.c']
 
-    uams_randnum = shared_module(
-        'uams_randnum',
-        uams_randnum_sources,
-        include_directories: root_includes,
-        dependencies: [crack, pam, ssl_deps],
-        link_with: ssl_links,
-        name_prefix: '',
-        name_suffix: 'so',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-
-    uams_randnum = static_library(
-        'uams_randnum',
-        uams_randnum_sources,
-        include_directories: root_includes,
-        dependencies: [crack, pam, ssl_deps],
-        link_with: ssl_links,
-        name_prefix: '',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
+    if enable_rpath
+        uams_randnum = shared_module(
+            'uams_randnum',
+            uams_randnum_sources,
+            include_directories: root_includes,
+            dependencies: [crack, pam, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            name_suffix: 'so',
+            install: true,
+            install_dir: libdir / 'netatalk',
+            build_rpath: libdir,
+            install_rpath: libdir,
+        )
+        uams_randnum = static_library(
+            'uams_randnum',
+            uams_randnum_sources,
+            include_directories: root_includes,
+            dependencies: [crack, pam, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            install: true,
+            install_dir: libdir / 'netatalk',
+            build_rpath: libdir,
+            install_rpath: libdir,
+        )
+    else
+        uams_randnum = shared_module(
+            'uams_randnum',
+            uams_randnum_sources,
+            include_directories: root_includes,
+            dependencies: [crack, pam, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            name_suffix: 'so',
+            install: true,
+            install_dir: libdir / 'netatalk',
+        )
+        uams_randnum = static_library(
+            'uams_randnum',
+            uams_randnum_sources,
+            include_directories: root_includes,
+            dependencies: [crack, pam, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            install: true,
+            install_dir: libdir / 'netatalk',
+        )
+    endif
 endif
 
 if enable_pgp_uam

--- a/meson.build
+++ b/meson.build
@@ -380,12 +380,10 @@ endif
 # Check whether to enable rpath (the default on Solaris and NetBSD)
 #
 
-enable_rpath = get_option('with-rpath')
-
-if not get_option('with-rpath')
-    enable_rpath = false
-elif host_os == 'sunos' or host_os == 'netbsd'
+if host_os == 'sunos' or host_os == 'netbsd'
     enable_rpath = true
+else
+    enable_rpath = get_option('with-rpath')
 endif
 
 if host_os == 'linux'
@@ -594,9 +592,9 @@ endif
 # Check whether Kerberos V UAM can be built
 #
 
-enable_krb5_uam = get_option('with-krbV-uam')
+enable_krbV_uam = get_option('with-krbV-uam')
 
-if not enable_krb5_uam
+if not enable_krbV_uam
     have_krb5_uam = false
     have_gssapi = false
 else


### PR DESCRIPTION


This change enables rpath for compiled binaries only when with-rpath is enabled, or when the OS is NetBSD or Solaris[h]. There might a more graceful way to do this than duplicating each executable() call, but I couldn't find out how.

It also tweaks the GitHub CI actions to:

    Use the latest stable Debian image, and with systemd instead of sysv (Trixie seems to finally do away with sysv init script wrappers.) We lose the ability to test the dynamic execution of netatalk on Debian, unfortunately, but we still test it on Ubuntu, so...

    Turn off kerberos for openSUSE, since they keep breaking the dependencies for their krb5 package.

    Bumps the openldap library version for FreeBSD