### PR TITLE
meson: Require kerberos before enabling krb5 UAM, not just GSSAPI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -409,7 +409,6 @@ jobs:
       - name: Meson - Configure
         run: |
           meson setup build \
-            -Dwith-krbV-uam=false \
             -Dwith-tests=true \
             -Dwith-init-hooks=false \
             -Dwith-init-style=suse-systemd

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -85,7 +85,7 @@ if have_quota
     afpd_external_deps += quota_deps
 endif
 
-if enable_krb5_uam
+if have_krb5_uam
     afpd_external_deps += gss
 endif
 

--- a/etc/uams/meson.build
+++ b/etc/uams/meson.build
@@ -344,7 +344,7 @@ if enable_pgp_uam
     )
 endif
 
-if have_gssapi
+if have_krb5_uam
     uams_gss_sources = ['uams_gss.c']
 
     uams_gss = shared_module(

--- a/meson.build
+++ b/meson.build
@@ -679,7 +679,11 @@ else
             warning('Kerberos API support requested but libkrb5 not found')
         endif
     endif
-    have_krb5_uam = have_gssapi
+    if have_gssapi and have_kerberos
+        have_krb5_uam = true
+    else
+        have_krb5_uam = false
+    endif
     if enable_krb5_uam and not have_gssapi
         warning('Need GSSAPI support to build Kerberos V UAM')
     endif
@@ -2092,7 +2096,7 @@ summary_info = {
 summary(summary_info, bool_yn: true, section: '  CNID:')
 
 summary_info = {
-    '  Kerberos V': enable_krb5_uam,
+    '  Kerberos V': have_krb5_uam,
     '  PGP': enable_pgp_uam,
     '  Randnum': '(afppasswd)',
     '  clrtxt': uams_using_options,

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -62,7 +62,7 @@ if have_quota
     test_external_deps += quota_deps
 endif
 
-if enable_krb5_uam
+if have_krb5_uam
     test_external_deps += gss
 endif
 


### PR DESCRIPTION
Validate the kerberos flag in addition to gssapi capability check when enabling the krb5 UAM.

Also apply the have-krb5-uam capability flag rather than the enable flag when injecting dependencies across the build system.