### PR TITLE
[2.4] meson: Introduce check for Kerberos API when building krbV UAM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -344,7 +344,6 @@ jobs:
           meson setup build \
             -Dwith-init-hooks=false \
             -Dwith-init-style=suse-systemd \
-            -Dwith-krbV-uam=false \
             -Dwith-tests=true
       - name: Meson - Build
         run: meson compile -C build

--- a/etc/uams/meson.build
+++ b/etc/uams/meson.build
@@ -344,7 +344,7 @@ if enable_pgp_uam
     )
 endif
 
-if have_gssapi
+if have_krb5_uam
     uams_gss_sources = ['uams_gss.c']
 
     uams_gss = shared_module(

--- a/meson.build
+++ b/meson.build
@@ -589,21 +589,24 @@ else
 endif
 
 #
-# Check whether Kerberos V UAM can be built
+# Check whether Kerberos V UAM should be compiled
 #
 
-enable_krbV_uam = get_option('with-krbV-uam')
+enable_krb5_uam = get_option('with-krbV-uam')
 
-if not enable_krbV_uam
+if not enable_krb5_uam
     have_krb5_uam = false
     have_gssapi = false
+    have_kerberos = false
 else
     #
     # Check for GSSAPI
     #
 
-    with_gssapi = get_option('with-gssapi')
+    enable_gssapi = get_option('with-gssapi')
     gssapi_path = get_option('with-gssapi-path')
+
+    gss_libs = []
     gssapi_includes = []
     gssapi_headers = [
         'gssapi.h',
@@ -615,14 +618,15 @@ else
     foreach header : gssapi_headers
         if cc.has_header(
             header,
-            include_directories: include_directories(header_dir),
+            include_directories: include_directories(
+                [gssapi_path / 'include', header_dir],
+            ),
         )
             cdata.set('HAVE_' + header.underscorify().to_upper(), 1)
         endif
-
     endforeach
 
-    if not get_option('with-gssapi')
+    if not enable_gssapi
         have_gssapi = false
     elif get_option('with-gssapi-path') != ''
         have_gssapi = true
@@ -632,44 +636,97 @@ else
             required: false,
         )
         gssapi_includes += include_directories(gssapi_path / 'include')
-
     else
         gss = cc.find_library('gss', dirs: libsearch_dirs, required: false)
-        if gss.found()
-            cdata.set('HAVE_LIBGSS', 1)
-        else
+        if not gss.found()
             gss = cc.find_library('gssapi', dirs: libsearch_dirs, required: false)
-            if gss.found()
-                cdata.set('HAVE_LIBGSSAPI', 1)
-            else
-                gss = cc.find_library('gssapi_krb5', dirs: libsearch_dirs, required: false)
-                if gss.found()
-                    cdata.set('HAVE_LIBGSSAPI_KRB5', 1)
-                else
+            if not gss.found()
+                gss = cc.find_library(
+                    'gssapi_krb5',
+                    dirs: libsearch_dirs,
+                    required: false,
+                )
+                if not gss.found()
                     have_gssapi = false
                 endif
             endif
         endif
-        have_gssapi = (
-            gss.found()
-            and cc.has_function('gss_acquire_cred', dependencies: gss)
-        )
+        have_gssapi = gss.found() and cc.has_function('gss_acquire_cred', dependencies: gss)
         if have_gssapi
+            gss_libs += gss
+            cdata.set('HAVE_GSSAPI', 1)
             # Heimdal/MIT compatibility fix
             foreach header : gssapi_headers
                 if cc.has_header_symbol(header, 'GSS_C_NT_HOSTBASED_SERVICE')
                     cdata.set('HAVE_GSS_C_NT_HOSTBASED_SERVICE', 1)
                 endif
             endforeach
-            cdata.set('HAVE_GSSAPI', 1)
+        else
+            have_gssapi = false
+            warning('GSSAPI support requested but gssapi libraries not found')
         endif
     endif
 
-    if with_gssapi and not have_gssapi
-        warning('GSSAPI support requested but GSSAPI library not found')
+    #
+    # Check for Kerberos V
+    #
+
+    enable_kerberos = get_option('with-kerberos')
+
+    kerberos = cc.find_library('krb5', dirs: libsearch_dirs, required: false)
+    krb5_config = find_program('krb5-config', required: false)
+
+    kerberos_c_args = []
+    kerberos_headers = [
+        'kerberosv5/krb5.h',
+        'krb5.h',
+        'krb5/krb5.h',
+    ]
+
+    foreach header : kerberos_headers
+        if cc.has_header(
+            header,
+            include_directories: include_directories(header_dir),
+        )
+            cdata.set('HAVE_' + header.underscorify().to_upper(), 1)
+        endif
+    endforeach
+
+    if not enable_kerberos
+        have_kerberos = false
+    else
+        have_kerberos = kerberos.found()
+        if have_kerberos
+            gss_libs += kerberos
+            if host_os == 'sunos'
+                kerberos_c_args += run_command(
+                    krb5_config,
+                    '--cflags',
+                    check: true,
+                ).stdout().strip()
+            endif
+            kerberos_functions = [
+                'krb5_free_unparsed_name',
+                'krb5_free_error_message',
+                'krb5_free_keytab_entry_contents',
+                'krb5_kt_free_entry',
+            ]
+            foreach function : kerberos_functions
+                if cc.has_function(function, dependencies: kerberos)
+                    cdata.set('HAVE_' + function.underscorify().to_upper(), 1)
+                endif
+            endforeach
+        else
+            have_kerberos = false
+            warning('Kerberos API support requested but libkrb5 not found')
+        endif
     endif
-    enable_krbV_uam = have_gssapi
-    if enable_krbV_uam and not have_gssapi
+    if have_gssapi and have_kerberos
+        have_krb5_uam = true
+    else
+        have_krb5_uam = false
+    endif
+    if enable_krb5_uam and not have_gssapi
         warning('Need GSSAPI support to build Kerberos V UAM')
     endif
 endif
@@ -1879,7 +1936,7 @@ summary_info = {
 summary(summary_info, bool_yn: true, section: '  CNID:')
 
 summary_info = {
-    '  Kerberos V': enable_krbV_uam,
+    '  Kerberos V': have_krb5_uam,
     '  PGP': enable_pgp_uam,
     '  Randnum': '(afppasswd)',
     '  clrtxt': uams_using_options,
@@ -1904,6 +1961,7 @@ summary_info = {
     '  DDP (AppleTalk) support': have_ddp,
     '  Cracklib support': have_cracklib,
     '  GSSAPI support': have_gssapi,
+    '  Kerberos support': have_kerberos,
     '  LDAP support': have_ldap,
     '  Quota support': have_quota,
 }

--- a/meson_config.h
+++ b/meson_config.h
@@ -331,15 +331,6 @@
 /* Define if the DHX2 modules should be built with libgcrypt */
 #mesondefine HAVE_LIBGCRYPT
 
-/* Define to 1 if you have the 'gss' library (-lgss). */
-#mesondefine HAVE_LIBGSS
-
-/* Define to 1 if you have the 'gssapi' library (-lgssapi). */
-#mesondefine HAVE_LIBGSSAPI
-
-/* Define to 1 if you have the 'gssapi_krb5' library (-lgssapi_krb5). */
-#mesondefine HAVE_LIBGSSAPI_KRB5
-
 /* Define to 1 if you have the 'nsl' library (-lnsl). */
 #mesondefine HAVE_LIBNSL
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -76,6 +76,12 @@ option(
     description: 'Enable install hooks for OS specific init system',
 )
 option(
+    'with-kerberos',
+    type: 'boolean',
+    value: true,
+    description: 'Enable Kerberos V API support',
+)
+option(
     'with-krbV-uam',
     type: 'boolean',
     value: true,


### PR DESCRIPTION
Backport the build system check for Kerberos headers / APIs from main. Check for both kerberos and gssapi before enabling the krbV UAM.