### PR TITLE
meson: Restore linking with 64-bit libdb on Solaris

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -823,7 +823,8 @@ jobs:
             meson setup build \
               -Dpkg_config_path=/opt/local/lib/pkgconfig \
               -Dwith-init-style=solaris \
-              -Dwith-ldap-path=/opt/local
+              -Dwith-ldap-path=/opt/local \
+              -Dwith-pgp-uam=true
             meson compile -C build
             meson install -C build
             svcadm enable svc:/network/netatalk:default
@@ -856,6 +857,7 @@ jobs:
               libgcrypt \
               libtool \
               pkg-config
+            pip install meson
             wget https://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.gz --no-check-certificate
             wget https://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.gz --no-check-certificate
             tar xvf autoconf-2.71.tar.gz
@@ -877,6 +879,7 @@ jobs:
               --enable-krbV-uam \
               --enable-pgp-uam \
               --with-init-style=solaris \
+              --with-tracker-pkgconfig-version=2.0 \
               --without-afpstats \
               MAKE=gmake \
               PKG_CONFIG_PATH=/usr/lib/amd64/pkgconfig
@@ -887,6 +890,18 @@ jobs:
             /usr/local/bin/asip-status localhost
             svcadm disable -s svc:/network/netatalk:default
             gmake uninstall
+            echo "Building with Meson"
+            meson setup build \
+              -Dpkg_config_path=/usr/lib/amd64/pkgconfig \
+              -Dwith-init-style=solaris \
+              -Dwith-pgp-uam=true
+            meson compile -C build
+            meson install -C build
+            svcadm enable svc:/network/netatalk:default
+            sleep 2
+            /usr/local/bin/asip-status localhost
+            svcadm disable svc:/network/netatalk:default
+            ninja -C build uninstall
 
   static_analysis:
     name: Static Analysis

--- a/meson.build
+++ b/meson.build
@@ -316,6 +316,22 @@ endif
 #################
 
 #
+# Check for 64-bit libraries
+#
+
+run_command(
+    cc,
+    '-c', meson.project_source_root() / 'libatalk/dummy.c',
+    '-o', meson.global_build_root() / 'dummy.o',
+    check: false,
+)
+compiler_64_bit_mode = run_command(
+    '/usr/bin/file',
+    meson.global_build_root() / 'dummy.o',
+    check: true,
+).stdout().strip().contains('ELF 64')
+
+#
 # Check whether to enable rpath (the default on Solaris and NetBSD)
 #
 
@@ -389,7 +405,11 @@ else
         foreach subdir : bdb_subdirs
             if fs.exists(dir / 'include' / subdir / 'db.h')
                 bdb_header += dir / 'include' / subdir / 'db.h'
-                bdb_libdir += dir / 'lib'
+                if target_os == 'sunos' and compiler_64_bit_mode and fs.exists(dir / 'lib/64')
+                    bdb_libdir += dir / 'lib/64'
+                else
+                    bdb_libdir += dir / 'lib'
+                endif
                 bdb_includes += include_directories(
                     dir / 'include' / subdir,
                 )


### PR DESCRIPTION
In https://github.com/Netatalk/netatalk/pull/1207 the broad legacy check for 64 bit library paths was removed. This PR restores a limited version of that for sunos specifically.

This also adds tentative CI workflow steps for building on Solaris with Meson (currently disabled, pending an update to the solaris vmactions image.)