### PR TITLE
[2.4] meson: Restore linking with 64-bit libdb on Solaris

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -704,7 +704,8 @@ jobs:
             meson setup build \
               -Dpkg_config_path=/opt/local/lib/pkgconfig \
               -Dwith-init-style=solaris \
-              -Dwith-ldap-path=/opt/local
+              -Dwith-ldap-path=/opt/local \
+              -Dwith-pgp-uam=true
             meson compile -C build
             meson install -C build
             chmod 744 /etc/rc2.d/S90netatalk
@@ -729,6 +730,7 @@ jobs:
         with:
           release: 11.4
           prepare: |
+            pkg update --accept
             pkg install \
               autoconf \
               automake \
@@ -736,6 +738,7 @@ jobs:
               libgcrypt \
               libtool \
               pkg-config
+            pip install meson
             wget https://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.gz --no-check-certificate
             wget https://ftp.gnu.org/gnu/automake/automake-1.16.5.tar.gz --no-check-certificate
             tar xvf autoconf-2.71.tar.gz
@@ -759,6 +762,20 @@ jobs:
             gmake -j $(nproc) all
             gmake install
             gmake uninstall
+            echo "Building with Meson"
+            meson setup build \
+              -Dpkg_config_path=/usr/lib/amd64/pkgconfig \
+              -Dwith-init-style=solaris \
+              -Dwith-pgp-uam=true
+            meson compile -C build
+            meson install -C build
+            chmod 744 /etc/rc2.d/S90netatalk
+            chmod 744 /etc/rc0.d/K04netatalk
+            /etc/rc2.d/S90netatalk start
+            sleep 2
+            /usr/local/bin/asip-status localhost
+            /etc/rc2.d/S90netatalk stop
+            ninja -C build uninstall
 
   static_analysis:
     name: Static Analysis

--- a/meson.build
+++ b/meson.build
@@ -377,6 +377,22 @@ endif
 #################
 
 #
+# Check for 64-bit libraries
+#
+
+run_command(
+    cc,
+    '-c', meson.project_source_root() / 'libatalk/dummy.c',
+    '-o', meson.global_build_root() / 'dummy.o',
+    check: false,
+)
+compiler_64_bit_mode = run_command(
+    '/usr/bin/file',
+    meson.global_build_root() / 'dummy.o',
+    check: true,
+).stdout().strip().contains('ELF 64')
+
+#
 # Check whether to enable rpath (the default on Solaris and NetBSD)
 #
 
@@ -450,7 +466,11 @@ else
         foreach subdir : bdb_subdirs
             if fs.exists(dir / 'include' / subdir / 'db.h')
                 bdb_header += dir / 'include' / subdir / 'db.h'
-                bdb_libdir += dir / 'lib'
+                if target_os == 'sunos' and compiler_64_bit_mode and fs.exists(dir / 'lib/64')
+                    bdb_libdir += dir / 'lib/64'
+                else
+                    bdb_libdir += dir / 'lib'
+                endif
                 bdb_includes += include_directories(
                     dir / 'include' / subdir,
                 )


### PR DESCRIPTION
In https://github.com/Netatalk/netatalk/pull/1211 the broad legacy check for 64 bit library paths was removed. This PR restores a limited version of that for sunos specifically.

This also adds tentative CI workflow steps for building on Solaris with Meson (currently disabled, pending an update to the solaris vmactions image.)