### PR TITLE
[2.4] meson: Introduce pkgconfdir override option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,7 @@ jobs:
           meson setup build \
             -Dwith-init-hooks=false \
             -Dwith-init-style=debian-systemd \
+            -Dwith-pkgconfdir-path=/etc/netatalk \
             -Dwith-quota=true \
             -Dwith-tests=true
       - name: Meson - Build

--- a/meson.build
+++ b/meson.build
@@ -39,8 +39,12 @@ libdir = prefix / get_option('libdir')
 libexecdir = prefix / get_option('libexecdir')
 localstatedir = prefix / get_option('localstatedir')
 mandir = prefix / get_option('mandir')
-pkgconfdir = prefix / get_option('sysconfdir') / 'netatalk'
+pkgconfdir = get_option('with-pkgconfdir-path')
 sbindir = prefix / get_option('sbindir')
+
+if pkgconfdir == ''
+    pkgconfdir = prefix / get_option('sysconfdir')
+endif
 
 ##################
 # Compiler flags #
@@ -1924,6 +1928,7 @@ summary_info = {
     'Library directory': libdir,
     'Manual page directory': mandir,
     'System executable directory': sbindir,
+    'Package conf directory': pkgconfdir,
 }
 summary(summary_info, bool_yn: true, section: 'Directories:')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -256,6 +256,12 @@ option(
     description: 'Set path to PAM config directory',
 )
 option(
+    'with-pkgconfdir-path',
+    type: 'string',
+    value: '',
+    description: 'Set path to the package conf dir that overrides sysconfdir',
+)
+option(
     'with-srvloc-path',
     type: 'string',
     value: '',


### PR DESCRIPTION
This introduces a `with-pkgconfdir-path` Meson option.

It also removes the hard-coded "netatalk/" path suffix to sysconfdir as the default pkgconfdir.