### PR TITLE
[2.4] meson: Correct overwrite install logic for package config files

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -1,24 +1,32 @@
-gen_templates = ['afpd.conf', 'AppleVolumes.default']
-gen_files = []
+afpd_conf = configure_file(
+    input: 'afpd.conf.tmpl',
+    output: 'afpd.conf',
+    configuration: cdata,
+)
 
-foreach template : gen_templates
-    gen_files += configure_file(
-        input: template + '.tmpl',
-        output: template,
-        configuration: cdata,
-    )
-endforeach
+avolumesdefault_conf = configure_file(
+    input: 'AppleVolumes.default.tmpl',
+    output: 'AppleVolumes.default',
+    configuration: cdata,
+)
 
-foreach file : gen_templates
-    if (
-        not fs.exists(pkgconfdir / file)
-        or (get_option('with-overwrite') and fs.exists(pkgconfdir / file))
-    )
-        install_data(gen_files, install_dir: pkgconfdir)
-    else
-        message('not overwriting', file)
-    endif
-endforeach
+if (
+    fs.exists(pkgconfdir / 'afpd.conf')
+    and not get_option('with-overwrite')
+)
+    message('will not replace existing', pkgconfdir / 'afpd.conf')
+else
+    install_data(afpd_conf, install_dir: pkgconfdir)
+endif
+
+if (
+    fs.exists(pkgconfdir / 'AppleVolumes.default')
+    and not get_option('with-overwrite')
+)
+    message('will not replace existing', pkgconfdir / 'AppleVolumes.default')
+else
+    install_data(avolumesdefault_conf, install_dir: pkgconfdir)
+endif
 
 conf_files = []
 
@@ -38,12 +46,12 @@ endif
 
 foreach file : conf_files
     if (
-        not fs.exists(pkgconfdir / file)
-        or (get_option('with-overwrite') and fs.exists(file))
+        fs.exists(pkgconfdir / file)
+        and not get_option('with-overwrite')
     )
-        install_data(file, install_dir: pkgconfdir)
+        message('will not replace existing', pkgconfdir / file)
     else
-        message('not overwriting', file)
+        install_data(file, install_dir: pkgconfdir)
     endif
 endforeach
 

--- a/config/pam/meson.build
+++ b/config/pam/meson.build
@@ -5,10 +5,10 @@ netatalk_pamd = configure_file(
 )
 
 if (
-    not fs.exists(pam_confdir / 'netatalk')
-    or (get_option('with-overwrite') and fs.exists(pampath / 'netatalk'))
+    fs.exists(pam_confdir / 'netatalk')
+    and not get_option('with-overwrite')
 )
-    install_data(netatalk_pamd, install_dir: pam_confdir)
+    message('will not replace existing', pam_confdir / 'netatalk')
 else
-    message('not overwriting', file)
+    install_data(netatalk_pamd, install_dir: pam_confdir)
 endif


### PR DESCRIPTION
The old logic was buggy, and lead to config files not being installed properly sometimes.