### PR TITLE
meson: Correct overwrite install logic for afp.conf

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -15,17 +15,31 @@ custom_target(
 )
 
 if (
-    not fs.exists(pkgconfdir / 'afp.conf')
-    or (get_option('with-overwrite') and fs.exists(pkgconfdir / 'afp.conf'))
+    fs.exists(pkgconfdir / 'afp.conf')
+    and not get_option('with-overwrite')
 )
-    install_data(afp_conf, install_dir: pkgconfdir)
+    message('will not replace existing', pkgconfdir / 'afp.conf')
 else
-    message('not overwriting', 'afp.conf')
+    install_data(afp_conf, install_dir: pkgconfdir)
 endif
 
-install_data('extmap.conf', install_dir: pkgconfdir)
+if (
+    fs.exists(pkgconfdir / 'extmap.conf')
+    and not get_option('with-overwrite')
+)
+    message('will not replace existing', pkgconfdir / 'extmap.conf')
+else
+    install_data('extmap.conf', install_dir: pkgconfdir)
+endif
 
-install_data('netatalk-dbus.conf', install_dir: dbus_sysconf_path)
+if (
+    fs.exists(dbus_sysconfpath / 'netatalk-dbus.conf')
+    and not get_option('with-overwrite')
+)
+    message('will not replace existing', dbus_sysconfpath / 'netatalk-dbus.conf')
+else
+    install_data('netatalk-dbus.conf', install_dir: dbus_sysconfpath)
+endif
 
 install_data('README', install_dir: localstatedir / 'netatalk')
 

--- a/config/pam/meson.build
+++ b/config/pam/meson.build
@@ -4,4 +4,11 @@ netatalk_pamd = configure_file(
     configuration: cdata,
 )
 
-install_data(netatalk_pamd, install_dir: pam_confdir)
+if (
+    fs.exists(pam_confdir / 'netatalk')
+    and not get_option('with-overwrite')
+)
+    message('will not replace existing', pam_confdir / 'netatalk')
+else
+    install_data(netatalk_pamd, install_dir: pam_confdir)
+endif

--- a/meson.build
+++ b/meson.build
@@ -37,11 +37,12 @@ includedir = prefix / get_option('includedir')
 libdir = prefix / get_option('libdir')
 localstatedir = prefix / get_option('localstatedir')
 mandir = prefix / get_option('mandir')
-pkgconfdir = get_option('with-pkgconfdir-path')
 sbindir = prefix / get_option('sbindir')
+sysconfdir = prefix / get_option('sysconfdir')
 
+pkgconfdir = get_option('with-pkgconfdir-path')
 if pkgconfdir == ''
-    pkgconfdir = prefix / get_option('sysconfdir')
+    pkgconfdir = sysconfdir
 endif
 
 ##################
@@ -1172,8 +1173,8 @@ if dbus_sysconf_path != ''
     dbus_sysconfpath += dbus_sysconf_path
     cdata.set('DBUS_SYS_DIR', '"' + dbus_sysconf_path + '"')
 else
-    dbus_sysconfpath += pkgconfdir / 'dbus-1/system.d'
-    cdata.set('DBUS_SYS_DIR', '"' + pkgconfdir + '/dbus-1/system.d' + '"')
+    dbus_sysconfpath += sysconfdir / 'dbus-1/system.d'
+    cdata.set('DBUS_SYS_DIR', '"' + sysconfdir + '/dbus-1/system.d' + '"')
 endif
 
 #


### PR DESCRIPTION
The old logic was buggy, and lead to config files not being installed properly sometimes.