### PR TITLE
meson: Define long-form libatalk soversion as 18.0.0

### DIFF
--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -49,6 +49,7 @@ libatalk = both_libraries(
         libutil,
         libvfs,
     ],
-    soversion: 18,
+    version: '18.0.0',
+    soversion: '18',
     install: true,
 )


### PR DESCRIPTION
This should bring the resulting library symlinks in line with what autotools produce