### PR TITLE
[2.4] meson: Define long-form libatalk soversion as 18.0.0

### DIFF
--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -55,6 +55,7 @@ libatalk = both_libraries(
         libutil,
         libvfs,
     ],
-    soversion: 18,
+    version: '18.0.0',
+    soversion: '18',
     install: true,
 )


### PR DESCRIPTION
As a side note, the 2.x libatalk wasn't versioned in Autotools. The soversion scheme was introduced with 3.0.0.
In hindsight I don't know it was the right choice to version 2.x libatalk, but what's done is done.