### PR TITLE
[2.4] meson: Adjust libatalk soversion to 0.0.0

### DIFF
--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -55,7 +55,7 @@ libatalk = both_libraries(
         libutil,
         libvfs,
     ],
-    version: '18.0.0',
-    soversion: '18',
+    version: '0.0.0',
+    soversion: '0',
     install: true,
 )


### PR DESCRIPTION
This aligns with the versioning produced by Autotools.
The soversion was previously set to 18, which was a mistake from when backporting the Meson build scripts from 3.x.

Compare https://github.com/Netatalk/netatalk/pull/269
Versions before 3.0.0-beta2 had libatalk soversion 0.0.0, while 3.1.9 and later got soversion 18.0.0