### PR TITLE
Eliminate unused code identified by cppcheck

### DIFF
--- a/bin/ad/ad_cp.c
+++ b/bin/ad/ad_cp.c
@@ -114,7 +114,7 @@ static void upfunc(void)
   catch SIGINT and SIGTERM which cause clean exit. Ignore anything else.
 */
 
-static void sig_handler(int signo)
+static void sig_handler(int signo _U_)
 {
     alarmed = 1;
     return;
@@ -350,7 +350,7 @@ int ad_cp(int argc, char *argv[], AFPObj *obj)
 
 static int copy(const char *path,
                 const struct stat *statp,
-                int tflag,
+                int tflag _U_,
                 struct FTW *ftw)
 {
     static int base = 0;
@@ -624,7 +624,7 @@ static int copy(const char *path,
 #endif
 #define BUFSIZE_SMALL (MAXPHYS)
 
-static int ftw_copy_file(const struct FTW *entp,
+static int ftw_copy_file(const struct FTW *entp _U_,
                          const char *spath,
                          const struct stat *sp,
                          int dne)
@@ -787,7 +787,7 @@ static int ftw_copy_file(const struct FTW *entp,
     return (rval);
 }
 
-static int ftw_copy_link(const struct FTW *p,
+static int ftw_copy_link(const struct FTW *p _U_,
                          const char *spath,
                          const struct stat *sstp,
                          int exists)
@@ -880,7 +880,7 @@ static int setfile(const struct stat *fs, int fd)
     return (rval);
 }
 
-static int preserve_fd_acls(int source_fd, int dest_fd)
+static int preserve_fd_acls(int source_fd _U_, int dest_fd _U_)
 {
 #if 0
     acl_t acl;

--- a/bin/ad/ad_find.c
+++ b/bin/ad/ad_find.c
@@ -43,7 +43,7 @@ static volatile sig_atomic_t alarmed;
   catch SIGINT and SIGTERM which cause clean exit. Ignore anything else.
 */
 
-static void sig_handler(int signo)
+static void sig_handler(int signo _U_)
 {
     alarmed = 1;
     return;

--- a/bin/ad/ad_ls.c
+++ b/bin/ad/ad_ls.c
@@ -77,7 +77,7 @@ static char *labels[] = {
   catch SIGINT and SIGTERM which cause clean exit. Ignore anything else.
 */
 
-static void sig_handler(int signo)
+static void sig_handler(int signo _U_)
 {
     alarmed = 1;
     return;

--- a/bin/ad/ad_mv.c
+++ b/bin/ad/ad_mv.c
@@ -59,7 +59,7 @@ static int do_move(const char *, const char *);
   catch SIGINT and SIGTERM which cause clean exit. Ignore anything else.
 */
 
-static void sig_handler(int signo)
+static void sig_handler(int signo _U_)
 {
     alarmed = 1;
     return;

--- a/bin/ad/ad_rm.c
+++ b/bin/ad/ad_rm.c
@@ -84,7 +84,7 @@ static void upfunc(void)
   catch SIGINT and SIGTERM which cause clean exit. Ignore anything else.
 */
 
-static void sig_handler(int signo)
+static void sig_handler(int signo _U_)
 {
     alarmed = 1;
     return;
@@ -181,8 +181,8 @@ int ad_rm(int argc, char *argv[], AFPObj *obj)
 
 static int rm(const char *path,
               const struct stat *statp,
-              int tflag,
-              struct FTW *ftw)
+              int tflag _U_,
+              struct FTW *ftw _U_)
 {
     cnid_t cnid;
 

--- a/bin/ad/ad_set.c
+++ b/bin/ad/ad_set.c
@@ -91,7 +91,7 @@ static void usage_set(void)
         );
 }
 
-static void change_type(char *path, afpvol_t *vol, const struct stat *st, struct adouble *ad, char *new_type)
+static void change_type(char *path _U_, afpvol_t *vol _U_, const struct stat *st _U_, struct adouble *ad, char *new_type)
 {
     char *FinderInfo;
 
@@ -99,7 +99,7 @@ static void change_type(char *path, afpvol_t *vol, const struct stat *st, struct
         memcpy(FinderInfo, new_type, 4);
 }
 
-static void change_creator(char *path, afpvol_t *vol, const struct stat *st, struct adouble *ad, char *new_creator)
+static void change_creator(char *path _U_, afpvol_t *vol _U_, const struct stat *st _U_, struct adouble *ad, char *new_creator)
 {
     char *FinderInfo;
 
@@ -108,7 +108,7 @@ static void change_creator(char *path, afpvol_t *vol, const struct stat *st, str
 
 }
 
-static void change_label(char *path, afpvol_t *vol, const struct stat *st, struct adouble *ad, char *new_label)
+static void change_label(char *path _U_, afpvol_t *vol _U_, const struct stat *st _U_, struct adouble *ad, char *new_label)
 {
     char *FinderInfo;
     const char **color = &labels[0];
@@ -139,7 +139,7 @@ static void change_label(char *path, afpvol_t *vol, const struct stat *st, struc
     }
 }
 
-static void change_attributes(char *path, afpvol_t *vol, const struct stat *st, struct adouble *ad, char *new_attributes)
+static void change_attributes(char *path _U_, afpvol_t *vol _U_, const struct stat *st, struct adouble *ad, char *new_attributes)
 {
     uint16_t AFPattributes;
 
@@ -182,7 +182,7 @@ static void change_attributes(char *path, afpvol_t *vol, const struct stat *st, 
     ad_setattr(ad, AFPattributes);
 }
 
-static void change_flags(char *path, afpvol_t *vol, const struct stat *st, struct adouble *ad, char *new_flags)
+static void change_flags(char *path _U_, afpvol_t *vol _U_, const struct stat *st, struct adouble *ad, char *new_flags)
 {
     char *FinderInfo;
     uint16_t FinderFlags;

--- a/bin/ad/ad_util.c
+++ b/bin/ad/ad_util.c
@@ -203,7 +203,7 @@ char *utompath(const struct vol *vol, const char *upath)
  *
  * @returns 0 on sucess, -1 on error
  */
-int convert_dots_encoding(const afpvol_t *svol, const afpvol_t *dvol, char *path, size_t buflen)
+int convert_dots_encoding(const afpvol_t *svol, const afpvol_t *dvol, char *path, size_t buflen _U_)
 {
     static charset_t from = (charset_t) -1;
     static char buf[MAXPATHLEN+2];

--- a/bin/misc/fce.c
+++ b/bin/misc/fce.c
@@ -37,9 +37,9 @@ static char *fce_ev_names[] = {
 static int unpack_fce_packet(unsigned char *buf, struct fce_packet *packet)
 {
     unsigned char *p = buf;
-    uint16_t uint16;
-    uint32_t uint32;
-    uint64_t uint64;
+    uint16_t uint16 _U_;
+    uint32_t uint32 _U_;
+    uint64_t uint64 _U_;
 
     memcpy(&packet->fcep_magic[0], p, sizeof(packet->fcep_magic));
     p += sizeof(packet->fcep_magic);

--- a/bin/misc/logger_test.c
+++ b/bin/misc/logger_test.c
@@ -21,7 +21,7 @@
 
 #include <atalk/logger.h>
 
-int main(int argc, char *argv[])
+int main(int argc _U_, char *argv[] _U_)
 {
   set_processname("logger_Test");
 

--- a/bin/misc/uuidtest.c
+++ b/bin/misc/uuidtest.c
@@ -43,7 +43,7 @@ static void usage(void)
 static void parse_ldapconf(void)
 {
     static int inited = 0;
-    dictionary *iniconfig;
+    dictionary *iniconfig _U_;
 
     if (! inited) {
 #ifdef HAVE_LDAP
@@ -153,4 +153,3 @@ int main( int argc, char **argv)
 
     return 0;
 }
-

--- a/etc/afpd/afp_config.c
+++ b/etc/afpd/afp_config.c
@@ -88,9 +88,9 @@ int configinit(AFPObj *obj)
     DSI **next = &obj->dsi;
     char *p = NULL, *q = NULL, *savep;
     const char *r;
-    struct ifaddrs *ifaddr, *ifa;
-    int family, s;
-    static char interfaddr[NI_MAXHOST];
+    struct ifaddrs *ifaddr _U_, *ifa _U_;
+    int family _U_, s _U_;
+    static char interfaddr[NI_MAXHOST] _U_;
 
     auth_load(obj, obj->options.uampath, obj->options.uamlist);
     set_signature(&obj->options);

--- a/etc/afpd/afpstats.c
+++ b/etc/afpd/afpstats.c
@@ -39,7 +39,7 @@
  */
 static server_child_t *childs;
 
-static gpointer afpstats_thread(gpointer _data)
+static gpointer afpstats_thread(gpointer _data _U_)
 {
     DBusGConnection *bus;
     DBusGProxy *bus_proxy;
@@ -88,9 +88,9 @@ static gpointer afpstats_thread(gpointer _data)
 }
 
 static void my_glib_log(const gchar *log_domain,
-                        GLogLevelFlags log_level,
+                        GLogLevelFlags log_level _U_,
                         const gchar *message,
-                        gpointer user_data)
+                        gpointer user_data _U_)
 {
     LOG(log_error, logtype_afpd, "%s: %s", log_domain, message);
 }

--- a/etc/afpd/afpstats_obj.c
+++ b/etc/afpd/afpstats_obj.c
@@ -39,11 +39,11 @@ struct AFPStatsObjClass
   GObjectClass parent;
 };
 
-static void afpstats_obj_init(AFPStatsObj *obj)
+static void afpstats_obj_init(AFPStatsObj *obj _U_)
 {
 }
 
-static void afpstats_obj_class_init(AFPStatsObjClass *klass)
+static void afpstats_obj_class_init(AFPStatsObjClass *klass _U_)
 {
 }
 
@@ -72,7 +72,7 @@ GType afpstats_obj_get_type(void)
 	return g_define_type_id__volatile;
 }
 
-gboolean afpstats_obj_get_users(AFPStatsObj *obj, gchar ***ret, GError **error)
+gboolean afpstats_obj_get_users(AFPStatsObj *obj _U_, gchar ***ret, GError **error _U_)
 {
     gchar **names;
     server_child_t *childs = afpstats_get_and_lock_childs();

--- a/etc/afpd/catsearch.c
+++ b/etc/afpd/catsearch.c
@@ -133,7 +133,7 @@ static void clearstack(void)
 }
 
 /* Puts new item onto directory stack. */
-static int addstack(char *uname, struct dir *dir, int pidx)
+static int addstack(char *uname _U_, struct dir *dir, int pidx _U_)
 {
 	struct dsitem *ds;
     struct dsitem *tmpds = NULL;
@@ -701,7 +701,7 @@ catsearch_end: /* Exiting catsearch: error condition */
  */
 static int catsearch_db(const AFPObj *obj,
                         struct vol *vol,
-                        struct dir *dir,
+                        struct dir *dir _U_,
                         const char *uname,
                         int rmatches,
                         uint32_t *pos,

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -2060,7 +2060,7 @@ int renamedir(struct vol *vol,
               int dirfd,
               char *src,
               char *dst,
-              struct dir *dir,
+              struct dir *dir _U_,
               struct dir *newparent,
               char *newname)
 {
@@ -2110,8 +2110,8 @@ int renamedir(struct vol *vol,
 /* delete an empty directory */
 int deletecurdir(struct vol *vol)
 {
-    struct dirent *de;
-    struct stat st;
+    struct dirent *de _U_;
+    struct stat st _U_;
     struct dir  *fdir, *pdir;
     struct adouble  ad;
     uint16_t       ashort;

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -59,9 +59,10 @@
 int         afp_errno;
 /* As long as directory.c hasn't got its own init call, this get initialized in dircache_init */
 struct dir rootParent  = {
-    NULL, NULL, NULL, NULL,          /* path, d_m_name, d_u_name, d_m_name_ucs2 */
-    NULL, 0, 0,                      /* qidx_node, ctime, d_flags */
-    0, 0, 0, 0                       /* pdid, did, offcnt, d_vid */
+    NULL, NULL, NULL, NULL,          /* d_fullpath, d_m_name, d_u_name, d_m_name_ucs2 */
+    NULL, 0, 0, 0,                   /* qidx_node, d_ctime, d_flags d_pdid */
+    0, 0, 0, 0,                      /* d_did, d_offcnt, d_vid, d_rights_cache */
+    0, 0                             /* d_cache_ctime, d_cache_ino */
 };
 struct dir  *curdir = &rootParent;
 struct path Cur_Path = {

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -2060,7 +2060,6 @@ int renamedir(struct vol *vol,
               int dirfd,
               char *src,
               char *dst,
-              struct dir *dir _U_,
               struct dir *newparent,
               char *newname)
 {
@@ -2110,8 +2109,6 @@ int renamedir(struct vol *vol,
 /* delete an empty directory */
 int deletecurdir(struct vol *vol)
 {
-    struct dirent *de _U_;
-    struct stat st _U_;
     struct dir  *fdir, *pdir;
     struct adouble  ad;
     uint16_t       ashort;

--- a/etc/afpd/directory.h
+++ b/etc/afpd/directory.h
@@ -101,8 +101,7 @@ extern int         getdirparams (const AFPObj *obj, const struct vol *, uint16_t
                                  struct dir *, char *, size_t *);
 
 extern int         setdirparams(struct vol *, struct path *, uint16_t, char *);
-extern int         renamedir(struct vol *, int, char *, char *, struct dir *,
-                             struct dir *, char *);
+extern int         renamedir(struct vol *, int, char *, char *, struct dir *, char *);
 extern int         path_error(struct path *, int error);
 extern void        setdiroffcnt(struct dir *dir, struct stat *st,  uint32_t count);
 extern int         dirreenumerate(struct dir *dir, struct stat *st);

--- a/etc/afpd/extattrs.c
+++ b/etc/afpd/extattrs.c
@@ -235,7 +235,7 @@ int afp_getextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, 
     struct vol          *vol;
     struct dir          *dir;
     struct path         *s_path;
-    struct adouble	ad, *adp = NULL;
+    struct adouble	ad _U_, *adp = NULL;
     struct ofork	*opened = NULL;
 
 
@@ -331,7 +331,7 @@ int afp_setextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _
     struct vol          *vol;
     struct dir          *dir;
     struct path         *s_path;
-    struct adouble	ad, *adp = NULL;
+    struct adouble	ad _U_, *adp = NULL;
     struct ofork	*opened = NULL;
 
     *rbuflen = 0;
@@ -424,7 +424,7 @@ int afp_remextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _
     struct vol          *vol;
     struct dir          *dir;
     struct path         *s_path;
-    struct adouble	ad, *adp = NULL;
+    struct adouble	ad _U_, *adp = NULL;
     struct ofork	*opened = NULL;
 
     *rbuflen = 0;

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -363,7 +363,7 @@ static int moveandrename(const AFPObj *obj,
                 of_rename(vol, opened, sdir, oldname, curdir, newname);
         }
     } else {
-        rc = renamedir(vol, sdir_fd, oldunixname, upath, sdir, curdir, newname);
+        rc = renamedir(vol, sdir_fd, oldunixname, upath, curdir, newname);
     }
     if ( rc == AFP_OK && id ) {
         /* renaming may have moved the file/dir across a filesystem */

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -141,7 +141,7 @@ static int sum_neg(int is64, off_t offset, off_t reqcount)
     return 0;
 }
 
-static int fork_setmode(const AFPObj *obj, struct adouble *adp, int eid, int access, int ofrefnum)
+static int fork_setmode(const AFPObj *obj _U_, struct adouble *adp, int eid, int access, int ofrefnum)
 {
     int ret;
     int readset;
@@ -765,7 +765,7 @@ static int read_file(const struct ofork *ofork, int eid, off_t offset, char *rbu
     return AFP_OK;
 }
 
-static int read_fork(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t *rbuflen, int is64)
+static int read_fork(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, size_t *rbuflen, int is64)
 {
     DSI          *dsi = obj->dsi;
     struct ofork *ofork;

--- a/etc/afpd/uam.c
+++ b/etc/afpd/uam.c
@@ -137,20 +137,20 @@ int uam_register(const int type, const char *path, const char *name, ...)
     va_start(ap, name);
     switch (type) {
     case UAM_SERVER_LOGIN_EXT: /* expect four arguments */
-        uam->u.uam_login.login = va_arg(ap, void *);
-        uam->u.uam_login.logincont = va_arg(ap, void *);
-        uam->u.uam_login.logout = va_arg(ap, void *);
-        uam->u.uam_login.login_ext = va_arg(ap, void *);
+        uam->u.uam_login.login = va_arg(ap, int (*)(void *, struct passwd **, char *, int, char *, size_t *));
+        uam->u.uam_login.logincont = va_arg(ap, int (*)(void *, struct passwd **, char *, int, char *, size_t *));
+        uam->u.uam_login.logout = va_arg(ap, void (*)(void));
+        uam->u.uam_login.login_ext = va_arg(ap, int (*)(void *, char *, struct passwd **, char *, int, char *, size_t *));
         break;
 
     case UAM_SERVER_LOGIN: /* expect three arguments */
-        uam->u.uam_login.login_ext = NULL;
-        uam->u.uam_login.login = va_arg(ap, void *);
-        uam->u.uam_login.logincont = va_arg(ap, void *);
-        uam->u.uam_login.logout = va_arg(ap, void *);
+    uam->u.uam_login.login_ext = NULL;
+    uam->u.uam_login.login = va_arg(ap, int (*)(void *, struct passwd **, char *, int, char *, size_t *));
+    uam->u.uam_login.logincont = va_arg(ap, int (*)(void *, struct passwd **, char *, int, char *, size_t *));
+    uam->u.uam_login.logout = va_arg(ap, void (*)(void));
         break;
     case UAM_SERVER_CHANGEPW: /* one argument */
-        uam->u.uam_changepw = va_arg(ap, void *);
+        uam->u.uam_changepw = va_arg(ap, int (*)(void *, char *, struct passwd *, char *, int, char *, size_t *));
         break;
     case UAM_SERVER_PRINTAUTH: /* x arguments */
     default:

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -641,7 +641,7 @@ static int volume_codepage(AFPObj *obj, struct vol *volume)
 }
 
 /* ------------------------- */
-static int volume_openDB(const AFPObj *obj, struct vol *volume)
+static int volume_openDB(const AFPObj *obj _U_, struct vol *volume)
 {
     int flags = 0;
 

--- a/etc/cnid_dbd/cmd_dbd.c
+++ b/etc/cnid_dbd/cmd_dbd.c
@@ -52,7 +52,7 @@ static dbd_flags_t flags;
  * SIGNAL handling:
  * catch SIGINT and SIGTERM which cause clean exit. Ignore anything else.
  */
-static void sig_handler(int signo)
+static void sig_handler(int signo _U_)
 {
     alarmed = 1;
     return;

--- a/etc/cnid_dbd/cmd_dbd_scanvol.c
+++ b/etc/cnid_dbd/cmd_dbd_scanvol.c
@@ -430,7 +430,8 @@ static int check_eafile_in_adouble(const char *name)
 
             /* Get string before "::EA" from EA filename */
             namep[0] = 0;
-            strlcpy(pname + 3, namedup, sizeof(pname) - 3); /* Prepends "../" */
+            strlcpy(pname + 3, namedup, strlen(pname)); /* Prepends "../" */
+
             if ((access( pname, F_OK)) == 0) {
                 ret = 1;
                 goto ea_check_done;

--- a/etc/cnid_dbd/cmd_dbd_scanvol.c
+++ b/etc/cnid_dbd/cmd_dbd_scanvol.c
@@ -60,8 +60,8 @@ static char           *special_dirs[] = {
     ".zfs",
     NULL
 };
-static struct cnid_dbd_rqst rqst;
-static struct cnid_dbd_rply rply;
+static struct cnid_dbd_rqst rqst _U_;
+static struct cnid_dbd_rply rply _U_;
 static jmp_buf jmp;
 static char pname[MAXPATHLEN] = "../";
 
@@ -233,7 +233,7 @@ static int check_adfile(const char *fname, const struct stat *st, const char **n
 /*
    Remove all files with file::EA* from adouble dir
 */
-static void remove_eafiles(const char *name, struct ea *ea)
+static void remove_eafiles(const char *name, struct ea *ea _U_)
 {
     DIR *dp = NULL;
     struct dirent *ep;
@@ -335,7 +335,7 @@ static int check_eafiles(const char *fname)
 /*
   Check for .AppleDouble folder and .Parent, create if missing
 */
-static int check_addir(int volroot)
+static int check_addir(int volroot _U_)
 {
     int addir_ok, adpar_ok;
     struct stat st;

--- a/etc/cnid_dbd/cnid_metad.c
+++ b/etc/cnid_dbd/cnid_metad.c
@@ -303,7 +303,7 @@ static int set_dbdir(const char *dbdir, const char *vpath)
 {
     EC_INIT;
     struct stat st;
-    bstring oldpath, newpath;
+    bstring oldpath, newpath = NULL;
     char *cmd_argv[4];
 
     LOG(log_debug, logtype_cnid, "set_dbdir: volume: %s, db path: %s", vpath, dbdir);

--- a/etc/cnid_dbd/main.c
+++ b/etc/cnid_dbd/main.c
@@ -127,7 +127,7 @@ static int get_lock(int cmd, const char *dbpath)
     case LOCK_EXCL:
     case LOCK_SHRD:
         if (lockfd == -1) {
-            if ( (strlen(dbpath) + strlen(LOCKFILENAME+1)) > (PATH_MAX - 1) ) {
+            if ( (strlen(dbpath) + strlen(&LOCKFILENAME[1])) > (PATH_MAX - 1) ) {
                 LOG(log_error, logtype_cnid, ".AppleDB pathname too long");
                 return -1;
             }

--- a/etc/netatalk/afp_mdns.c
+++ b/etc/netatalk/afp_mdns.c
@@ -92,7 +92,7 @@ static struct pollfd *fds;
 /*
  * This is the thread that polls the filehandles
  */
-static void *polling_thread(void *arg) {
+static void *polling_thread(void *arg _U_) {
     // First we loop through getting the filehandles and adding them to our poll, we
     // need to allocate our pollfd's
     DNSServiceErrorType error;
@@ -121,8 +121,8 @@ static void *polling_thread(void *arg) {
  * we can do if we get problems, so we don't really need to do anything other than report
  * the issue.
  */
-static void RegisterReply(DNSServiceRef sdRef, DNSServiceFlags flags, DNSServiceErrorType errorCode,
-                          const char *name, const char *regtype, const char *domain, void *context)
+static void RegisterReply(DNSServiceRef sdRef _U_, DNSServiceFlags flags _U_, DNSServiceErrorType errorCode,
+                          const char *name, const char *regtype, const char *domain, void *context _U_)
 {
     if (errorCode != kDNSServiceErr_NoError) {
         LOG(log_error, logtype_afpd, "Failed to register mDNS service: %s%s%s: code=%d",
@@ -335,7 +335,7 @@ fail:
  * neccessary config setting.
  */
 void md_zeroconf_register(const AFPObj *obj) {
-    int error;
+    int error _U_;
 
     register_stuff(obj);
     return;

--- a/etc/netatalk/afp_zeroconf.c
+++ b/etc/netatalk/afp_zeroconf.c
@@ -23,7 +23,7 @@
 /*
  * Functions (actually they are just facades)
  */
-void zeroconf_register(const AFPObj *configs)
+void zeroconf_register(const AFPObj *configs _U_)
 {
 #if defined (HAVE_MDNS)
   LOG(log_debug, logtype_afpd, "Attempting to register with mDNS using mDNSResponder");

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -64,11 +64,11 @@ static AFPObj obj;
 static pid_t afpd_pid = NETATALK_SRV_NEEDED;
 static pid_t cnid_metad_pid = NETATALK_SRV_NEEDED;
 static pid_t dbus_pid = NETATALK_SRV_OPTIONAL;
-static uint afpd_restarts, cnid_metad_restarts, dbus_restarts;
+static uint afpd_restarts, cnid_metad_restarts, dbus_restarts _U_;
 static struct event_base *base;
 struct event *sigterm_ev, *sigquit_ev, *sigchld_ev, *sighup_ev, *timer_ev;
 static int in_shutdown;
-static const char *dbus_path;
+static const char *dbus_path _U_;
 
 /******************************************************************
  * Misc stuff
@@ -151,7 +151,7 @@ static void libevent_logmsg_cb(int severity, const char *msg)
  ******************************************************************/
 
 /* SIGTERM callback */
-static void sigterm_cb(evutil_socket_t fd, short what, void *arg)
+static void sigterm_cb(evutil_socket_t fd _U_, short what _U_, void *arg _U_)
 {
     sigset_t sigs;
     struct timeval tv;
@@ -183,7 +183,7 @@ static void sigterm_cb(evutil_socket_t fd, short what, void *arg)
 }
 
 /* SIGQUIT callback */
-static void sigquit_cb(evutil_socket_t fd, short what, void *arg)
+static void sigquit_cb(evutil_socket_t fd _U_, short what _U_, void *arg _U_)
 {
     LOG(log_note, logtype_afpd, "Exiting on SIGQUIT");
 #ifdef WITH_SPOTLIGHT
@@ -193,7 +193,7 @@ static void sigquit_cb(evutil_socket_t fd, short what, void *arg)
 }
 
 /* SIGHUP callback */
-static void sighup_cb(evutil_socket_t fd, short what, void *arg)
+static void sighup_cb(evutil_socket_t fd _U_, short what _U_, void *arg _U_)
 {
     LOG(log_note, logtype_afpd, "Received SIGHUP, sending all processes signal to reload config");
 
@@ -209,7 +209,7 @@ static void sighup_cb(evutil_socket_t fd, short what, void *arg)
 }
 
 /* SIGCHLD callback */
-static void sigchld_cb(evutil_socket_t fd, short what, void *arg)
+static void sigchld_cb(evutil_socket_t fd _U_, short what _U_, void *arg _U_)
 {
     int status;
     pid_t pid;
@@ -246,7 +246,7 @@ static void sigchld_cb(evutil_socket_t fd, short what, void *arg)
 }
 
 /* timer callback */
-static void timer_cb(evutil_socket_t fd, short what, void *arg)
+static void timer_cb(evutil_socket_t fd _U_, short what _U_, void *arg _U_)
 {
     if (in_shutdown)
         return;
@@ -339,7 +339,7 @@ static pid_t run_process(const char *path, ...)
 
 static void show_netatalk_version( void )
 {
-	int num, i;
+	int num _U_, i _U_;
 
 	printf( "netatalk %s - Netatalk AFP server service controller daemon\n\n", VERSION );
 

--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -574,7 +574,7 @@ static int logincont2(void *obj_in, struct passwd **uam_pwd,
     int ret = AFPERR_MISC;
     int PAM_error;
     const char *hostname = NULL;
-    gcry_mpi_t retServerNonce;
+    gcry_mpi_t retServerNonce = NULL;
     gcry_cipher_hd_t ctx;
     gcry_error_t ctxerror;
     char *utfpass = NULL;
@@ -777,7 +777,7 @@ static int changepw_3(void *obj _U_,
     uid_t uid;
     pam_handle_t *lpamh;
     const char *hostname = NULL;
-    gcry_mpi_t retServerNonce;
+    gcry_mpi_t retServerNonce = NULL;
     gcry_cipher_hd_t ctx;
     gcry_error_t ctxerror;
 
@@ -922,7 +922,7 @@ static int dhx2_changepw(void *obj _U_, char *uname,
     return ret;
 }
 
-static int uam_setup(void *obj, const char *path)
+static int uam_setup(void *obj _U_, const char *path)
 {
     if (uam_register(UAM_SERVER_LOGIN_EXT, path, "DHX2", pam_login,
                      pam_logincont, pam_logout, pam_login_ext) < 0)

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -760,7 +760,7 @@ static int pam_changepw(void *obj, unsigned char *username,
 }
 
 
-static int uam_setup(void *obj, const char *path)
+static int uam_setup(void *obj _U_, const char *path)
 {
   if (uam_register(UAM_SERVER_LOGIN_EXT, path, "DHCAST128", pam_login,
 		   pam_logincont, pam_logout, pam_login_ext) < 0)

--- a/etc/uams/uams_gss.c
+++ b/etc/uams/uams_gss.c
@@ -276,7 +276,7 @@ static int accept_sec_context(gss_ctx_id_t *context,
     return 0;
 }
 
-static int do_gss_auth(void *obj,
+static int do_gss_auth(void *obj _U_,
                        char *ibuf, size_t ibuflen,
                        char *rbuf, int *rbuflen,
                        char *username, size_t ulen,
@@ -340,9 +340,9 @@ cleanup_client_name:
  * login-session id. None of the data provided by the client up to this
  * point is trustworthy as we'll have a signed ticket to parse in logincont.
  */
-static int gss_login(void *obj,
-                     struct passwd **uam_pwd,
-                     char *ibuf, size_t ibuflen,
+static int gss_login(void *obj _U_,
+                     struct passwd **uam_pwd _U_,
+                     char *ibuf _U_, size_t ibuflen _U_,
                      char *rbuf, size_t *rbuflen)
 {
     *rbuflen = 0;
@@ -481,7 +481,7 @@ static void gss_logout(void)
 }
 
 static int gss_login_ext(void *obj,
-                         char *uname,
+                         char *uname _U_,
                          struct passwd **uam_pwd,
                          char *ibuf, size_t ibuflen,
                          char *rbuf, size_t *rbuflen)
@@ -606,7 +606,7 @@ krb5_cleanup:
         goto exit;
 
     char principal[255];
-    size_t len = snprintf(principal, sizeof(principal), "%s/%s@%s",
+    size_t len _U_ = snprintf(principal, sizeof(principal), "%s/%s@%s",
                           obj->options.k5service, obj->options.fqdn, obj->options.k5realm);
     (void)set_principal(obj, principal);
     rv = 0;

--- a/etc/uams/uams_pam.c
+++ b/etc/uams/uams_pam.c
@@ -446,7 +446,7 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
 }
 
 
-static int uam_setup(void *obj, const char *path)
+static int uam_setup(void *obj _U_, const char *path)
 {
   if (uam_register(UAM_SERVER_LOGIN_EXT, path, "Cleartxt Passwrd",
 		   pam_login, NULL, pam_logout, pam_login_ext) < 0)

--- a/include/atalk/vfs.h
+++ b/include/atalk/vfs.h
@@ -29,28 +29,28 @@
 #include <atalk/adouble.h>
 #include <atalk/volume.h>
 
-#define VFS_FUNC_ARGS_VALIDUPATH const struct vol *vol, const char *name
+#define VFS_FUNC_ARGS_VALIDUPATH const struct vol *vol _U_, const char *name
 #define VFS_FUNC_VARS_VALIDUPATH vol, name
 
 #define VFS_FUNC_ARGS_CHOWN const struct vol *vol, const char *path, uid_t uid, gid_t gid
 #define VFS_FUNC_VARS_CHOWN vol, path, uid, gid
 
-#define VFS_FUNC_ARGS_RENAMEDIR const struct vol *vol, int dirfd, const char *oldpath, const char *newpath
+#define VFS_FUNC_ARGS_RENAMEDIR const struct vol *vol _U_, int dirfd _U_, const char *oldpath _U_, const char *newpath _U_
 #define VFS_FUNC_VARS_RENAMEDIR vol, dirfd, oldpath, newpath
 
 #define VFS_FUNC_ARGS_DELETECURDIR const struct vol *vol
 #define VFS_FUNC_VARS_DELETECURDIR vol
 
-#define VFS_FUNC_ARGS_SETFILEMODE const struct vol *vol, const char *name, mode_t mode, struct stat *st
+#define VFS_FUNC_ARGS_SETFILEMODE const struct vol *vol, const char *name, mode_t mode, struct stat *st _U_
 #define VFS_FUNC_VARS_SETFILEMODE vol, name, mode, st
 
-#define VFS_FUNC_ARGS_SETDIRMODE const struct vol *vol,  const char *name, mode_t mode, struct stat *st
+#define VFS_FUNC_ARGS_SETDIRMODE const struct vol *vol _U_,  const char *name _U_, mode_t mode _U_, struct stat *st _U_
 #define VFS_FUNC_VARS_SETDIRMODE vol, name, mode, st
 
-#define VFS_FUNC_ARGS_SETDIRUNIXMODE const struct vol *vol, const char *name, mode_t mode, struct stat *st
+#define VFS_FUNC_ARGS_SETDIRUNIXMODE const struct vol *vol _U_, const char *name _U_, mode_t mode _U_, struct stat *st _U_
 #define VFS_FUNC_VARS_SETDIRUNIXMODE vol, name, mode, st
 
-#define VFS_FUNC_ARGS_SETDIROWNER const struct vol *vol, const char *name, uid_t uid, gid_t gid
+#define VFS_FUNC_ARGS_SETDIROWNER const struct vol *vol _U_, const char *name _U_, uid_t uid _U_, gid_t gid _U_
 #define VFS_FUNC_VARS_SETDIROWNER vol, name, uid, gid
 
 #define VFS_FUNC_ARGS_DELETEFILE const struct vol *vol, int dirfd, const char *file
@@ -59,7 +59,7 @@
 #define VFS_FUNC_ARGS_RENAMEFILE const struct vol *vol, int dirfd, const char *src, const char *dst
 #define VFS_FUNC_VARS_RENAMEFILE vol, dirfd, src, dst
 
-#define VFS_FUNC_ARGS_COPYFILE const struct vol *vol, int sfd, const char *src, const char *dst
+#define VFS_FUNC_ARGS_COPYFILE const struct vol *vol _U_, int sfd, const char *src, const char *dst
 #define VFS_FUNC_VARS_COPYFILE vol, sfd, src, dst
 
 #ifdef HAVE_NFSV4_ACLS
@@ -74,19 +74,19 @@
 #define VFS_FUNC_ARGS_REMOVE_ACL const struct vol *vol, const char *path, int dir
 #define VFS_FUNC_VARS_REMOVE_ACL vol, path, dir
 
-#define VFS_FUNC_ARGS_EA_GETSIZE const struct vol * restrict vol, char * restrict rbuf, size_t * restrict rbuflen, const char * restrict uname, int oflag, const char * restrict attruname, int fd
+#define VFS_FUNC_ARGS_EA_GETSIZE const struct vol * restrict vol, char * restrict rbuf, size_t * restrict rbuflen, const char * restrict uname, int oflag _U_, const char * restrict attruname, int fd _U_
 #define VFS_FUNC_VARS_EA_GETSIZE vol, rbuf, rbuflen, uname, oflag, attruname, fd
 
-#define VFS_FUNC_ARGS_EA_GETCONTENT const struct vol * restrict vol, char * restrict rbuf, size_t * restrict rbuflen,  const char * restrict uname, int oflag, const char * restrict attruname, int maxreply, int fd
+#define VFS_FUNC_ARGS_EA_GETCONTENT const struct vol * restrict vol, char * restrict rbuf, size_t * restrict rbuflen,  const char * restrict uname, int oflag _U_, const char * restrict attruname, int maxreply, int fd
 #define VFS_FUNC_VARS_EA_GETCONTENT vol, rbuf, rbuflen, uname, oflag, attruname, maxreply, fd
 
-#define VFS_FUNC_ARGS_EA_LIST const struct vol * restrict vol, char * restrict attrnamebuf, size_t * restrict buflen, const char * restrict uname, int oflag, int fd
+#define VFS_FUNC_ARGS_EA_LIST const struct vol * restrict vol, char * restrict attrnamebuf, size_t * restrict buflen, const char * restrict uname, int oflag _U_, int fd _U_
 #define VFS_FUNC_VARS_EA_LIST vol, attrnamebuf, buflen, uname, oflag, fd
 
-#define VFS_FUNC_ARGS_EA_SET const struct vol * restrict vol, const char * restrict uname, const char * restrict attruname, const char * restrict ibuf, size_t attrsize, int oflag, int fd
+#define VFS_FUNC_ARGS_EA_SET const struct vol * restrict vol, const char * restrict uname, const char * restrict attruname, const char * restrict ibuf, size_t attrsize, int oflag, int fd _U_
 #define VFS_FUNC_VARS_EA_SET vol, uname, attruname, ibuf, attrsize, oflag, fd
 
-#define VFS_FUNC_ARGS_EA_REMOVE const struct vol * restrict vol, const char * restrict uname, const char * restrict attruname, int oflag, int fd
+#define VFS_FUNC_ARGS_EA_REMOVE const struct vol * restrict vol _U_, const char * restrict uname, const char * restrict attruname, int oflag _U_, int fd _U_
 #define VFS_FUNC_VARS_EA_REMOVE vol, uname, attruname, oflag, fd
 
 /*

--- a/libatalk/acl/ldap.c
+++ b/libatalk/acl/ldap.c
@@ -275,7 +275,6 @@ cleanup:
 static char *gen_uuid_filter(const char *uuidstr_in, const char *attr_filter)
 {
     EC_INIT;
-    int len;
     const char *uuidstr = uuidstr_in;
 
 #define MAX_FILTER_SIZE 512
@@ -317,12 +316,11 @@ static char *gen_uuid_filter(const char *uuidstr_in, const char *attr_filter)
     }
 
     if (attr_filter) {
-        len = snprintf(filter, 256, "(&(%s=%s)(%s))", ldap_uuid_attr, uuidstr, attr_filter);
+        snprintf(filter, 256, "(&(%s=%s)(%s))", ldap_uuid_attr, uuidstr, attr_filter);
     } else {
-        len = snprintf(filter, 256, "%s=%s", ldap_uuid_attr, uuidstr);
+        snprintf(filter, 256, "%s=%s", ldap_uuid_attr, uuidstr);
     }
 
-EC_CLEANUP:
     if (ret != 0)
         return NULL;
     return filter;

--- a/libatalk/adouble/ad_lock.c
+++ b/libatalk/adouble/ad_lock.c
@@ -152,7 +152,7 @@ static void adf_freelock(struct ad_fd *ad, const int i)
  * i converted to using arrays of locks. everytime a lock
  * gets removed, we shift all of the locks down.
  */
-static void adf_unlock(struct adouble *ad, struct ad_fd *adf, const int fork, int unlckbrl)
+static void adf_unlock(struct adouble *ad _U_, struct ad_fd *adf, const int fork, int unlckbrl)
 {
     adf_lock_t *lock = adf->adf_lock;
     int i;

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -359,7 +359,7 @@ int ad_init_offsets(struct adouble *ad)
 /* ----------------------------------- */
 static int new_ad_header(struct adouble *ad, const char *path, struct stat *stp, int adflags)
 {
-    const struct entry  *eid;
+    const struct entry  *eid _U_;
     uint16_t            ashort;
     struct stat         st;
     char                *adp = NULL;
@@ -757,7 +757,7 @@ static int ad_header_read_ea(const char *path, struct adouble *ad, const struct 
 {
     EC_INIT;
     uint16_t nentries;
-    int      len;
+    int      len _U_;
     ssize_t  header_len;
     char     *buf = ad->ad_data;
 
@@ -944,7 +944,7 @@ static int ad_header_upgrade_ea(struct adouble *ad _U_, const char *name _U_)
  */
 static int ad_error(struct adouble *ad, int adflags)
 {
-    int err = errno;
+    int err _U_ = errno;
     if (adflags & ADFLAGS_NOHF) { /* 1 */
         return 0;
     }
@@ -1209,7 +1209,7 @@ EC_CLEANUP:
     EC_EXIT;
 }
 
-static int ad_open_hf_ea(const char *path, int adflags, int mode, struct adouble *ad)
+static int ad_open_hf_ea(const char *path, int adflags, int mode _U_, struct adouble *ad)
 {
     EC_INIT;
     int oflags;
@@ -1328,7 +1328,7 @@ static int ad_open_hf(const char *path, int adflags, int mode, struct adouble *a
 /*!
  * Get resofork length for adouble:ea, parameter 'ad' may be NULL
  */
-off_t ad_reso_size(const char *path, int adflags, struct adouble *ad)
+off_t ad_reso_size(const char *path, int adflags, struct adouble *ad _U_)
 {
     EC_INIT;
     struct stat st;
@@ -1369,7 +1369,7 @@ EC_CLEANUP:
     return rlen;
 }
 
-static int ad_open_rf_v2(const char *path, int adflags, int mode, struct adouble *ad)
+static int ad_open_rf_v2(const char *path, int adflags, int mode _U_, struct adouble *ad)
 {
     EC_INIT;
 

--- a/libatalk/bstring/bstradd.c
+++ b/libatalk/bstring/bstradd.c
@@ -151,7 +151,7 @@ int bstrListPush(struct bstrList *sl, bstring bs)
 /*!
  * @brief Pop a bstring from the end of a list
  */
-bstring bstrListPop(struct bstrList *sl)
+bstring bstrListPop(struct bstrList *sl _U_)
 {
     return NULL;
 }

--- a/libatalk/cnid/last/cnid_last.c
+++ b/libatalk/cnid/last/cnid_last.c
@@ -99,7 +99,7 @@ cnid_t cnid_last_lookup(struct _cnid_db *cdb _U_, const struct stat *st _U_, cni
 }
 
 
-static struct _cnid_db *cnid_last_new(struct vol *vol)
+static struct _cnid_db *cnid_last_new(struct vol *vol _U_)
 {
     struct _cnid_db *cdb;
     struct _cnid_last_private *priv;

--- a/libatalk/cnid/mysql/cnid_mysql.c
+++ b/libatalk/cnid/mysql/cnid_mysql.c
@@ -741,15 +741,15 @@ EC_CLEANUP:
 }
 
 
-int cnid_mysql_find(struct _cnid_db *cdb, const char *name, size_t namelen, void *buffer, size_t buflen)
+int cnid_mysql_find(struct _cnid_db *cdb _U_, const char *name, size_t namelen _U_, void *buffer _U_, size_t buflen _U_)
 {
     LOG(log_error, logtype_cnid,
         "cnid_mysql_find(\"%s\"): not supported with MySQL CNID backend", name);
     return -1;
 }
 
-cnid_t cnid_mysql_rebuild_add(struct _cnid_db *cdb, const struct stat *st,
-                              cnid_t did, const char *name, size_t len, cnid_t hint)
+cnid_t cnid_mysql_rebuild_add(struct _cnid_db *cdb _U_, const struct stat *st _U_,
+                              cnid_t did _U_, const char *name, size_t len _U_, cnid_t hint _U_)
 {
     LOG(log_error, logtype_cnid,
         "cnid_mysql_rebuild_add(\"%s\"): not supported with MySQL CNID backend", name);

--- a/libatalk/util/fault.c
+++ b/libatalk/util/fault.c
@@ -82,7 +82,7 @@ static void (*CatchSignal(int signum,void (*handler)(int )))(int)
  Something really nasty happened - panic !
 ********************************************************************/
 
-void netatalk_panic(const char *why)
+void netatalk_panic(const char *why _U_)
 {
 #ifdef HAVE_BACKTRACE_SYMBOLS
 	void *backtrace_stack[BACKTRACE_STACK_SIZE];

--- a/libatalk/util/ftw.c
+++ b/libatalk/util/ftw.c
@@ -628,7 +628,7 @@ ftw_dir (struct ftw_data *data, struct STAT *st, struct dir_data *old_dir)
 
 static int ftw_startup (const char *dir,
                         int is_nftw,
-                        void *func,
+                        nftw_func_t func,
                         dir_notification_func_t up,
                         int descriptors,
                         int flags)

--- a/libatalk/util/logger.c
+++ b/libatalk/util/logger.c
@@ -116,7 +116,7 @@ static const unsigned int num_loglevel_strings = COUNT_ARRAY(arr_loglevel_string
 
 static int generate_message(char **message_details_buffer,
                             char *user_message,
-                            int display_options,
+                            int display_options _U_,
                             enum loglevels loglevel,
                             enum logtypes logtype,
                             bool log_us_timestamp)

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -546,7 +546,7 @@ EC_CLEANUP:
     EC_EXIT;
 }
 
-static int hostaccessvol(const AFPObj *obj, const char *volname, const char *args)
+static int hostaccessvol(const AFPObj *obj, const char *volname _U_, const char *args)
 {
     int mask_int;
     char buf[MAXPATHLEN + 1], *p, *b;
@@ -2021,7 +2021,7 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     EC_INIT;
     dictionary *config;
     struct afp_options *options = &AFPObj->options;
-    int c;
+    int c _U_;
     const char *p;
     char *q, *r;
     char val[MAXVAL];

--- a/libatalk/util/server_lock.c
+++ b/libatalk/util/server_lock.c
@@ -62,7 +62,7 @@ pid_t server_lock(char *program, char *pidfile, int debug)
    * Disassociate from controlling tty.
    */
 
-    int		i;
+    int		i _U_;
 
     getitimer(ITIMER_PROF, &itimer);
     switch (pid = fork()) {

--- a/libatalk/util/unix.c
+++ b/libatalk/util/unix.c
@@ -298,7 +298,7 @@ int ochmod(char *path, mode_t mode, const struct stat *st, int options)
  * @param path    (r) pathname
  * @param st      (rw) pointer to struct stat
  */
-int ostatat(int dirfd, const char *path, struct stat *st, int options)
+int ostatat(int dirfd _U_, const char *path, struct stat *st, int options)
 {
 #ifdef HAVE_ATFUNCS
     if (dirfd == -1)

--- a/libatalk/vfs/ea_sys.c
+++ b/libatalk/vfs/ea_sys.c
@@ -280,7 +280,7 @@ int sys_list_eas(VFS_FUNC_ARGS_EA_LIST)
     int     ret, len, nlen;
     char    *buf;
     char    *ptr;
-    struct adouble ad, *adp;
+    struct adouble ad _U_, *adp _U_;
 
     buf = malloc(ATTRNAMEBUFSIZ);
     if (!buf)

--- a/libatalk/vfs/extattr.c
+++ b/libatalk/vfs/extattr.c
@@ -90,7 +90,7 @@ static const char *prefix(const char *uname)
 #endif
 }
 
-int sys_getxattrfd(int fd, const char *uname, int oflag, ...)
+int sys_getxattrfd(int fd _U_, const char *uname _U_, int oflag _U_, ...)
 {
 #if defined(SOLARIS)
     int eafd;
@@ -499,7 +499,7 @@ ssize_t sys_listxattr (const char *path, char *list, size_t size)
 #endif
 }
 
-ssize_t sys_flistxattr (int filedes, const char *path, char *list, size_t size)
+ssize_t sys_flistxattr (int filedes _U_, const char *path, char *list, size_t size)
 {
 #if defined(HAVE_LISTXATTR)
 	ssize_t ret;
@@ -605,7 +605,7 @@ int sys_removexattr (const char *path, const char *uname)
 #endif
 }
 
-int sys_fremovexattr (int filedes, const char *path, const char *uname)
+int sys_fremovexattr (int filedes _U_, const char *path, const char *uname)
 {
 	const char *name = prefix(uname);
 #if defined(HAVE_REMOVEXATTR)
@@ -673,7 +673,7 @@ int sys_lremovexattr (const char *path, const char *uname)
 #endif
 }
 
-int sys_setxattr (const char *path, const char *uname, const void *value, size_t size, int flags)
+int sys_setxattr (const char *path, const char *uname, const void *value, size_t size, int flags _U_)
 {
 	const char *name = prefix(uname);
 #if defined(HAVE_SETXATTR)
@@ -735,7 +735,7 @@ int sys_setxattr (const char *path, const char *uname, const void *value, size_t
 #endif
 }
 
-int sys_fsetxattr (int filedes, const char *uname, const void *value, size_t size, int flags)
+int sys_fsetxattr (int filedes, const char *uname, const void *value, size_t size, int flags _U_)
 {
     const char *name = prefix(uname);
 
@@ -801,7 +801,7 @@ int sys_fsetxattr (int filedes, const char *uname, const void *value, size_t siz
 #endif
 }
 
-int sys_lsetxattr (const char *path, const char *uname, const void *value, size_t size, int flags)
+int sys_lsetxattr (const char *path, const char *uname, const void *value, size_t size, int flags _U_)
 {
 	const char *name = prefix(uname);
 #if defined(HAVE_LSETXATTR)

--- a/libatalk/vfs/unix.c
+++ b/libatalk/vfs/unix.c
@@ -61,7 +61,7 @@ int setfilmode(const struct vol *vol, const char *name, mode_t mode, struct stat
  *
  * Supports *at semantics (cf openat) if HAVE_ATFUNCS. Pass dirfd=-1 to ignore this.
  */
-int netatalk_rmdir_all_errors(int dirfd, const char *name)
+int netatalk_rmdir_all_errors(int dirfd _U_, const char *name)
 {
     int err;
 
@@ -166,7 +166,7 @@ EC_CLEANUP:
 /*
  * Supports *at semantics if HAVE_ATFUNCS, pass dirfd=-1 to ignore this
  */
-int copy_file(int dirfd, const char *src, const char *dst, mode_t mode)
+int copy_file(int dirfd _U_, const char *src, const char *dst, mode_t mode)
 {
     int    ret = 0;
     int    sfd = -1;
@@ -218,7 +218,7 @@ exit:
  *
  * Supports *at semantics if HAVE_ATFUNCS, pass dirfd=-1 to ignore this
  */
-int copy_ea(const char *ea, int dirfd, const char *src, const char *dst, mode_t mode)
+int copy_ea(const char *ea, int dirfd _U_, const char *src, const char *dst, mode_t mode)
 {
     EC_INIT;
     int    sfd = -1;
@@ -253,7 +253,7 @@ EC_CLEANUP:
 /*
  * at wrapper for netatalk_unlink
  */
-int netatalk_unlinkat(int dirfd, const char *name)
+int netatalk_unlinkat(int dirfd _U_, const char *name)
 {
 #ifdef HAVE_ATFUNCS
     if (dirfd == -1)
@@ -292,7 +292,7 @@ int netatalk_unlinkat(int dirfd, const char *name)
  * @param dfd        (r) same as sfd
  * @param newpath    (r) guess what
  */
-int unix_rename(int sfd, const char *oldpath, int dfd, const char *newpath)
+int unix_rename(int sfd _U_, const char *oldpath, int dfd _U_, const char *newpath)
 {
 #ifdef HAVE_ATFUNCS
     if (sfd == -1)
@@ -319,7 +319,7 @@ int unix_rename(int sfd, const char *oldpath, int dfd, const char *newpath)
  * @param path    (r) pathname
  * @param st      (rw) pointer to struct stat
  */
-int statat(int dirfd, const char *path, struct stat *st)
+int statat(int dirfd _U_, const char *path, struct stat *st)
 {
 #ifdef HAVE_ATFUNCS
     if (dirfd == -1)

--- a/libatalk/vfs/vfs.c
+++ b/libatalk/vfs/vfs.c
@@ -735,7 +735,11 @@ static struct vfs_ops netatalk_adouble_v2 = {
     /* vfs_deletefile:    */ RF_deletefile_adouble,
     /* vfs_renamefile:    */ RF_renamefile_adouble,
     /* vfs_copyfile:      */ RF_copyfile_adouble,
-    NULL
+    /* vfs_ea_getsize:    */ NULL,
+    /* vfs_ea_getcontent: */ NULL,
+    /* vfs_ea_list:       */ NULL,
+    /* vfs_ea_set:        */ NULL,
+    /* vfs_ea_remove:     */ NULL
 };
 
 static struct vfs_ops netatalk_adouble_ea = {
@@ -750,7 +754,11 @@ static struct vfs_ops netatalk_adouble_ea = {
     /* vfs_deletefile:    */ RF_deletefile_ea,
     /* vfs_renamefile:    */ RF_renamefile_ea,
     /* vfs_copyfile:      */ RF_copyfile_ea,
-    NULL
+    /* vfs_ea_getsize:    */ NULL,
+    /* vfs_ea_getcontent: */ NULL,
+    /* vfs_ea_list:       */ NULL,
+    /* vfs_ea_set:        */ NULL,
+    /* vfs_ea_remove:     */ NULL
 };
 
 /*

--- a/libatalk/vfs/vfs.c
+++ b/libatalk/vfs/vfs.c
@@ -127,7 +127,7 @@ static int RF_renamedir_adouble(VFS_FUNC_ARGS_RENAMEDIR)
 }
 
 /* ----------------- */
-static int deletecurdir_adouble_loop(const struct vol *vol, struct dirent *de, char *name, void *data _U_, int flag _U_)
+static int deletecurdir_adouble_loop(const struct vol *vol _U_, struct dirent *de, char *name, void *data _U_, int flag _U_)
 {
     struct stat st;
     int         err;
@@ -480,7 +480,7 @@ static int deletecurdir_ea_osx_chkifempty_loop(const struct vol *vol, struct dir
     return 0;
 }
 
-static int deletecurdir_ea_osx_loop(const struct vol *vol, struct dirent *de, char *name, void *data _U_, int flag _U_)
+static int deletecurdir_ea_osx_loop(const struct vol *vol _U_, struct dirent *de _U_, char *name, void *data _U_, int flag _U_)
 {
     int ret;
     struct stat sb;

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -49,7 +49,7 @@ static AFPObj obj;
 static char *args[] = {"test", "-F", "test.conf"};
 /* Static variables */
 
-int main(int argc, char **argv)
+int main()
 {
     int reti;
     uint16_t vid;


### PR DESCRIPTION
- Fix [-Wmissing-field-initializers] warnings
- Fix [-W-pedantic] warnings
- Fix [-Wstring-plus-int] warning in cnid_dbd/main.c
- Fix [-Wbuiltin-memcpy-chk-size] warning in etc/cnid_dbd/cmd_dbd_scanvol.c
- Fix [-Wunused-variable], [-Wunneeded-internal-declaration], [-Wunused-parameter], and [-Wsometimes-uninitialized] warnings

