### PR TITLE
meson: Detect init style and allow multiple init styles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,7 +267,6 @@ jobs:
           meson setup build \
             -Dwith-tests=true \
             -Dwith-init-hooks=false \
-            -Dwith-init-style=debian-systemd \
             -Dwith-pkgconfdir-path=/etc/netatalk
       - name: Meson - Build
         run: meson compile -C build
@@ -469,8 +468,7 @@ jobs:
           meson setup build \
             -Dwith-tests=true \
             -Dwith-manual=true \
-            -Dwith-init-hooks=false \
-            -Dwith-init-style=debian-systemd
+            -Dwith-init-hooks=false
       - name: Meson - Build and generate manual pages
         run: meson compile -C build
       - name: Meson - Run tests
@@ -592,8 +590,7 @@ jobs:
             gmake uninstall
             echo "Building with Meson"
             meson setup build \
-              -Dpkg_config_path=/usr/local/libdata/pkgconfig \
-              -Dwith-init-style=freebsd
+              -Dpkg_config_path=/usr/local/libdata/pkgconfig
             meson compile -C build
             meson install -C build
             /etc/rc.d/netatalk start
@@ -658,8 +655,7 @@ jobs:
             echo "Building with Meson"
             meson setup build \
               -Dpkg_config_path=/usr/pkg/lib/pkgconfig \
-              -Dwith-dtrace=false \
-              -Dwith-init-style=netbsd
+              -Dwith-dtrace=false
             meson compile -C build
             meson install -C build
             service netatalk onestart
@@ -717,8 +713,7 @@ jobs:
             gmake -j $(nproc)
             echo "Building with Meson"
             meson setup build \
-              -Dpkg_config_path=/usr/local/lib/pkgconfig \
-              -Dwith-init-style=openbsd
+              -Dpkg_config_path=/usr/local/lib/pkgconfig
             meson compile -C build
             meson install -C build
             rcctl -d start netatalk
@@ -764,7 +759,6 @@ jobs:
       - name: Meson - Configure
         run: |
           meson setup build \
-            -Dwith-init-style=macos-launchd \
             -Dwith-tests=true
       - name: Meson - Build
         run: meson compile -C build
@@ -830,7 +824,6 @@ jobs:
             echo "Building with Meson"
             meson setup build \
               -Dpkg_config_path=/opt/local/lib/pkgconfig \
-              -Dwith-init-style=solaris \
               -Dwith-ldap-path=/opt/local \
               -Dwith-pgp-uam=true
             meson compile -C build
@@ -901,7 +894,6 @@ jobs:
             echo "Building with Meson"
             meson setup build \
               -Dpkg_config_path=/usr/lib/amd64/pkgconfig \
-              -Dwith-init-style=solaris \
               -Dwith-pgp-uam=true
             meson compile -C build
             meson install -C build

--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -1,15 +1,14 @@
-if get_option('with-init-style') == 'none'
-    init_dir = 'none'
-    init_dirs += init_dir
+if init_style == 'none'
+    init_dirs += 'none'
 endif
 
 if (
-    get_option('with-init-style') == 'debian'
-    or get_option('with-init-style') == 'debian-systemd'
-    or get_option('with-init-style') == 'gentoo-systemd'
-    or get_option('with-init-style') == 'redhat-systemd'
-    or get_option('with-init-style') == 'suse-systemd'
-    or get_option('with-init-style') == 'systemd'
+    init_style == 'debian'
+    or init_style == 'debian-systemd'
+    or init_style == 'gentoo-systemd'
+    or init_style == 'redhat-systemd'
+    or init_style == 'suse-systemd'
+    or init_style == 'systemd'
 )
     init_dir = '/usr/lib/systemd/system'
     init_dirs += init_dir
@@ -28,8 +27,8 @@ if (
 endif
 
 if (
-  get_option('with-init-style') == 'debian'
-  or get_option('with-init-style') == 'debian-sysv'
+  init_style == 'debian'
+  or init_style == 'debian-sysv'
 )
     init_dir = '/etc/init.d'
     init_dirs += init_dir
@@ -54,7 +53,7 @@ if (
     endif
 endif
 
-if get_option('with-init-style') == 'freebsd'
+if init_style == 'freebsd'
     init_dir = '/etc/rc.d'
     init_dirs += init_dir
     custom_target(
@@ -76,7 +75,7 @@ if get_option('with-init-style') == 'freebsd'
     endif
 endif
 
-if get_option('with-init-style') == 'netbsd'
+if init_style == 'netbsd'
     init_dir = '/etc/rc.d'
     init_dirs += init_dir
     custom_target(
@@ -91,7 +90,7 @@ if get_option('with-init-style') == 'netbsd'
     )
 endif
 
-if get_option('with-init-style') == 'openbsd'
+if init_style == 'openbsd'
     init_dir = '/etc/rc.d'
     init_dirs += init_dir
     custom_target(
@@ -113,7 +112,7 @@ if get_option('with-init-style') == 'openbsd'
     endif
 endif
 
-if get_option('with-init-style') == 'solaris'
+if init_style == 'solaris'
     init_dir = '/lib/svc/manifest/network'
     init_dirs += init_dir
     custom_target(
@@ -135,8 +134,8 @@ if get_option('with-init-style') == 'solaris'
 endif
 
 if (
-    get_option('with-init-style') == 'openrc'
-    or get_option('with-init-style') == 'gentoo-openrc'
+    init_style == 'openrc'
+    or init_style == 'gentoo-openrc'
 )
     init_dir = '/etc/init.d'
     init_dirs += init_dir
@@ -160,7 +159,7 @@ if (
     endif
 endif
 
-if get_option('with-init-style') == 'macos-launchd'
+if init_style == 'macos-launchd'
     init_dir = '/Library/LaunchDaemons'
     init_dirs += init_dir
     custom_target(

--- a/meson.build
+++ b/meson.build
@@ -136,6 +136,31 @@ else
     bison = find_program('bison', required: false)
 endif
 
+##############
+# Init Style #
+##############
+
+uname_stdout = run_command(uname, '-a', check: false).stdout().strip()
+init_style = get_option('with-init-style')
+
+if init_style == 'auto'
+    if uname_stdout.to_lower().contains('debian') or uname_stdout.to_lower().contains('ubuntu')
+        init_style = 'debian-systemd'
+    elif host_os == 'freebsd'
+        init_style = 'freebsd'
+    elif host_os == 'netbsd'
+        init_style = 'netbsd'
+    elif host_os == 'openbsd'
+        init_style = 'openbsd'
+    elif host_os == 'darwin'
+        init_style = 'macos-launchd'
+    elif host_os == 'sunos'
+        init_style = 'solaris'
+    else
+        init_style = 'none'
+    endif
+endif
+
 #############
 # Libraries #
 #############
@@ -150,7 +175,7 @@ if host_os == 'netbsd'
     libsearch_dirs += '/usr/pkg/lib'
 endif
 
-if uname.found() and run_command(uname, '-n', check: false).stdout().strip().contains('omnios')
+if uname.found() and uname_stdout.to_lower().contains('omnios')
     libsearch_dirs += '/opt/local/lib'
 endif
 
@@ -2083,7 +2108,7 @@ uams_using_options = '(' + uams_options + ')'
 
 summary({'Netatalk version': netatalk_version}, section: 'Configuration Summary:')
 summary_info = {
-    '  Initscript style': get_option('with-init-style'),
+    '  Initscript style': init_style,
 }
 summary(summary_info, bool_yn: true, section: '  Init Style:')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -305,6 +305,7 @@ option(
     type: 'combo',
     choices: [
         'none',
+        'auto',
         'debian',
         'debian-systemd',
         'debian-sysv',
@@ -320,7 +321,7 @@ option(
         'suse-systemd',
         'systemd',
     ],
-    value: 'none',
+    value: 'auto',
     description: 'Use OS specific init config',
 )
 option(


### PR DESCRIPTION
Introduce an 'auto' init-style option, selected by default, which attempts to cleanly choose the appropriate init system style for the host OS.