### PR TITLE
meson: Correct description for with-manual option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -103,7 +103,7 @@ option(
     'with-manual',
     type: 'boolean',
     value: false,
-    description: 'Set path to Docbook XSL directory',
+    description: 'Compile Netatalk documentation',
 )
 option(
     'with-overwrite',


### PR DESCRIPTION
Fixing a copy-paste mistake from when the meson build system was set up.