### PR TITLE
Option to build html manual for local or Web consumption

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,6 @@ jobs:
           meson setup build \
             -Dwith-docbook-path=/usr/share/xml/docbook/xsl-stylesheets \
             -Dwith-init-style=openrc \
-            -Dwith-manual=true \
             -Dwith-pgp-uam=true \
             -Dwith-tests=true
       - name: Build
@@ -157,7 +156,6 @@ jobs:
             -Dwith-docbook-path=/usr/share/xml/docbook/xsl-stylesheets-1.79.2 \
             -Dwith-init-hooks=false \
             -Dwith-init-style=systemd \
-            -Dwith-manual=true \
             -Dwith-pgp-uam=true \
             -Dwith-tests=true
       - name: Build
@@ -183,7 +181,6 @@ jobs:
           meson setup build \
             -Dwith-tests=true \
             -Dwith-init-hooks=false \
-            -Dwith-manual=true \
             -Dwith-pgp-uam=true \
             -Dwith-pkgconfdir-path=/etc/netatalk
       - name: Build
@@ -238,7 +235,6 @@ jobs:
           meson setup build \
             -Dwith-init-hooks=false \
             -Dwith-init-style=redhat-systemd \
-            -Dwith-manual=true \
             -Dwith-pgp-uam=true \
             -Dwith-tests=true
       - name: Build
@@ -296,7 +292,6 @@ jobs:
             -Dwith-docbook-path=/usr/share/xml/docbook/stylesheet/nwalsh/1.79.2 \
             -Dwith-init-hooks=false \
             -Dwith-init-style=suse-systemd \
-            -Dwith-manual=true \
             -Dwith-pgp-uam=true \
             -Dwith-tests=true
       - name: Build
@@ -321,7 +316,6 @@ jobs:
         run: |
           meson setup build \
             -Dwith-init-hooks=false \
-            -Dwith-manual=true \
             -Dwith-pgp-uam=true \
             -Dwith-tests=true
       - name: Build
@@ -377,7 +371,6 @@ jobs:
             set -e
             wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
             meson setup build \
-              -Dwith-manual=true \
               -Dwith-pgp-uam=true
             meson compile -C build
             meson install -C build
@@ -418,7 +411,6 @@ jobs:
             wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
             meson setup build \
               -Dpkg_config_path=/usr/local/libdata/pkgconfig \
-              -Dwith-manual=true \
               -Dwith-pgp-uam=true
             meson compile -C build
             meson install -C build
@@ -467,7 +459,6 @@ jobs:
             meson setup build \
               -Dpkg_config_path=/usr/pkg/lib/pkgconfig \
               -Dwith-dtrace=false \
-              -Dwith-manual=true \
               -Dwith-pgp-uam=true
             meson compile -C build
             meson install -C build
@@ -513,7 +504,6 @@ jobs:
             wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
             meson setup build \
               -Dpkg_config_path=/usr/local/lib/pkgconfig \
-              -Dwith-manual=true \
               -Dwith-pgp-uam=true
             meson compile -C build
             meson install -C build
@@ -540,7 +530,6 @@ jobs:
       - name: Configure
         run: |
           meson setup build \
-            -Dwith-manual=true \
             -Dwith-pgp-uam=true \
             -Dwith-tests=true
       - name: Build
@@ -593,7 +582,6 @@ jobs:
             meson setup build \
               -Dpkg_config_path=/opt/local/lib/pkgconfig \
               -Dwith-ldap-path=/opt/local \
-              -Dwith-manual=true \
               -Dwith-pgp-uam=true
             meson compile -C build
             meson install -C build
@@ -634,7 +622,6 @@ jobs:
             meson setup build \
               -Dpkg_config_path=/usr/lib/amd64/pkgconfig \
               -Dwith-docbook-path=/usr/share/sgml/docbook/xsl-stylesheets \
-              -Dwith-manual=true \
               -Dwith-pgp-uam=true
             meson compile -C build
             meson install -C build
@@ -667,7 +654,6 @@ jobs:
           mkdir -p ${{ env.BUILD_WRAPPER_OUT_DIR }}
           meson setup build \
             -Dwith-init-style=none \
-            -Dwith-manual=true \
             -Dwith-pgp-uam=true \
             -Dwith-tests=true
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} meson compile -C build

--- a/doc/html-www.xsl.in
+++ b/doc/html-www.xsl.in
@@ -6,4 +6,10 @@
 	<xsl:param name="chunk.section.depth" select="0"/>
 	<xsl:param name="chunk.separate.lots" select="1"/>
 	<xsl:param name="toc.max.depth" select="2"/>
+	<xsl:param name="html.stylesheet" select="'/css/netatalk.css'"/>
+
+	<xsl:template name="user.header.navigation">
+		<xsl:variable name="codefile" select="document('pageheader.txt',/)"/>
+		<xsl:copy-of select="$codefile/*/node()"/>
+	</xsl:template>
 </xsl:stylesheet>

--- a/doc/ja/html-www.xsl.in
+++ b/doc/ja/html-www.xsl.in
@@ -6,4 +6,11 @@
 	<xsl:param name="chunk.section.depth" select="0"/>
 	<xsl:param name="chunk.separate.lots" select="1"/>
 	<xsl:param name="toc.max.depth" select="2"/>
+	<xsl:param name="l10n.gentext.default.language">ja</xsl:param>
+	<xsl:param name="html.stylesheet" select="'/css/netatalk.css'"/>
+
+	<xsl:template name="user.header.navigation">
+		<xsl:variable name="codefile" select="document('pageheader.txt',/)"/>
+		<xsl:copy-of select="$codefile/*/node()"/>
+	</xsl:template>
 </xsl:stylesheet>

--- a/doc/ja/html.xsl.in
+++ b/doc/ja/html.xsl.in
@@ -5,12 +5,6 @@
 	<xsl:param name="chunker.output.indent" select="'yes'"/>
 	<xsl:param name="chunk.section.depth" select="0"/>
 	<xsl:param name="chunk.separate.lots" select="1"/>
-	<xsl:param name="html.stylesheet" select="'https://netatalk.io/css/netatalk.css'"/>
-	<xsl:param name="l10n.gentext.default.language">ja</xsl:param>
 	<xsl:param name="toc.max.depth" select="2"/>
-
-	<xsl:template name="user.header.navigation">
-		<xsl:variable name="codefile" select="document('pageheader.txt',/)"/>
-		<xsl:copy-of select="$codefile/*/node()"/>
-	</xsl:template>
+	<xsl:param name="l10n.gentext.default.language">ja</xsl:param>
 </xsl:stylesheet>

--- a/doc/ja/meson.build
+++ b/doc/ja/meson.build
@@ -1,5 +1,11 @@
+if get_option('with-manual') == 'www'
+    input_file = 'html-www.xsl.in'
+else
+    input_file = 'html.xsl.in'
+endif
+
 manual_stylesheet_ja = configure_file(
-    input: 'html.xsl.in',
+    input: input_file,
     output: 'html.xsl',
     configuration: cdata,
 )

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,3 +1,9 @@
+if get_option('with-manual') == 'www'
+    input_file = 'html-www.xsl.in'
+else
+    input_file = 'html.xsl.in'
+endif
+
 manpages_stylesheet = configure_file(
     input: 'man.xsl.in',
     output: 'man.xsl',
@@ -5,7 +11,7 @@ manpages_stylesheet = configure_file(
 )
 
 manual_stylesheet = configure_file(
-    input: 'html.xsl.in',
+    input: input_file,
     output: 'html.xsl',
     configuration: cdata,
 )

--- a/meson.build
+++ b/meson.build
@@ -1539,7 +1539,7 @@ endif
 #
 
 docbook_path = get_option('with-docbook-path')
-compile_manual = get_option('with-manual')
+compile_manual = get_option('with-manual') != 'none'
 
 xsltproc = find_program('xsltproc', required: false)
 xsl = []
@@ -2086,7 +2086,7 @@ subdir('etc')
 subdir('contrib')
 subdir('distrib')
 
-if get_option('with-manual')
+if get_option('with-manual') != 'none'
     subdir('doc')
 endif
 
@@ -2215,5 +2215,8 @@ if have_spotlight
 endif
 summary(summary_info, bool_yn: true, section: '  Paths:')
 
-summary_info = {'  Docbook': build_xml_docs}
+summary_info = {
+    '  Docbook': build_xml_docs,
+    '  Manual style': get_option('with-manual'),
+}
 summary(summary_info, bool_yn: true, section: '  Documentation:')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -100,12 +100,6 @@ option(
     description: 'Enable iconv support',
 )
 option(
-    'with-manual',
-    type: 'boolean',
-    value: false,
-    description: 'Set path to Docbook XSL directory',
-)
-option(
     'with-overwrite',
     type: 'boolean',
     value: false,
@@ -307,6 +301,17 @@ option(
 # The following options set the preferred init-style and default CNID backend:
 
 option(
+    'with-cnid-default-backend',
+    type: 'combo',
+    choices: [
+        'dbd',
+        'last',
+        'mysql',
+    ],
+    value: 'dbd',
+    description: 'Set default DID scheme',
+)
+option(
     'with-init-style',
     type: 'combo',
     choices: [
@@ -331,13 +336,13 @@ option(
     description: 'Use OS specific init config',
 )
 option(
-    'with-cnid-default-backend',
+    'with-manual',
     type: 'combo',
     choices: [
-        'dbd',
-        'last',
-        'mysql',
+        'none',
+        'local',
+        'www',
     ],
-    value: 'dbd',
-    description: 'Set default DID scheme',
+    value: 'local',
+    description: 'Compile Netatalk documentation',
 )


### PR DESCRIPTION
Turns the `with-manual` option into a combo option with none, local, and www as options. Default is local.

The www option is only meant for publishing on the web, i.e. the netatalk homepage.