### PR TITLE
meson: Correct prefix lookup for tracker-control

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -855,7 +855,7 @@ else
             cdata.set(
                 'TRACKER_PREFIX',
                 '"'
-                + tracker_control.get_variable(pkgconfig: 'prefix')
+                + tracker_sparql.get_variable(pkgconfig: 'prefix')
                 + '"',
             )
             tracker_manager += 'tracker_control'


### PR DESCRIPTION
Fixing a copy-paste mistake from when the Meson build system was first set up.