### PR TITLE
[2.4] meson: default OPEN_NOFOLLOW_ERRNO overwrites platform customization

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1833,6 +1833,8 @@ endif
 # OS-specific configuration
 #
 
+cdata.set('OPEN_NOFOLLOW_ERRNO', 'ELOOP')
+
 if host_os == 'freebsd'
     cdata.set('BSD4_4', 1)
     cdata.set('FREEBSD', 1)
@@ -1895,7 +1897,6 @@ cdata.set('includedir', includedir)
 cdata.set('libdir', libdir)
 cdata.set('localstatedir', localstatedir)
 cdata.set('NETATALK_VERSION', netatalk_version)
-cdata.set('OPEN_NOFOLLOW_ERRNO', 'ELOOP')
 cdata.set('pkgconfdir', pkgconfdir)
 cdata.set('prefix', prefix)
 cdata.set('sbindir', sbindir)


### PR DESCRIPTION
The default OPEN_NOFOLLOW_ERRNO substitution comes after the platform specific ones.