### PR TITLE
meson: Move to native method for variable substitution and configure afp.conf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,7 +114,6 @@ jobs:
       - name: Configure
         run: |
           meson setup build \
-            -Dwith-docbook-path=/usr/share/xml/docbook/xsl-stylesheets \
             -Dwith-init-style=openrc \
             -Dwith-pgp-uam=true \
             -Dwith-tests=true

--- a/config/afp.conf.tmpl
+++ b/config/afp.conf.tmpl
@@ -1,12 +1,12 @@
 ;
-; Netatalk 3.x configuration file
+; Netatalk 4.x configuration file
 ;
 
 [Global]
 ; Global server settings
 
-; [Homes]
-; basedir regex = /home
+[Homes]
+basedir regex = @homedir@
 
 ; [My AFP Volume]
 ; path = /path/to/volume

--- a/config/dbus-session.conf.tmpl
+++ b/config/dbus-session.conf.tmpl
@@ -8,7 +8,7 @@
        the behavior of child processes. -->
   <keep_umask/>
 
-  <listen>unix:path=:LOCALSTATEDIR:/netatalk/spotlight.ipc</listen>
+  <listen>unix:path=@localstatedir@/netatalk/spotlight.ipc</listen>
 
   <standard_session_servicedirs />
 

--- a/config/meson.build
+++ b/config/meson.build
@@ -4,14 +4,10 @@ afp_conf = configure_file(
     configuration: cdata,
 )
 
-custom_target(
-    'dbus_session',
+dbus_session_conf = configure_file(
     input: 'dbus-session.conf.tmpl',
     output: 'dbus-session.conf',
-    command: sed_command,
-    capture: true,
-    install: true,
-    install_dir: pkgconfdir,
+    configuration: cdata,
 )
 
 if (
@@ -30,6 +26,15 @@ if (
     message('will not replace existing', pkgconfdir / 'extmap.conf')
 else
     install_data('extmap.conf', install_dir: pkgconfdir)
+endif
+
+if (
+    fs.exists(pkgconfdir / 'dbus-session.conf')
+    and not get_option('with-overwrite')
+)
+    message('will not replace existing', pkgconfdir / 'dbus-session.conf')
+else
+    install_data(dbus_session_conf, install_dir: pkgconfdir)
 endif
 
 if (

--- a/contrib/macusers/macusers.in
+++ b/contrib/macusers/macusers.in
@@ -11,7 +11,7 @@ use vars qw($MAIN_PID $NETATALK_PROCESS $AFPD_PROCESS $PS_STR $MATCH_STR $ASIP_P
 # Support has also been added for 16 character usernames.
 
 if ($ARGV[0] =~ /^(-v|-version|--version)$/ ) {
-        printf ("%s \(Netatalk @NETATALK_VERSION@\)\n", basename($0));
+        printf ("%s \(Netatalk @netatalk_version@\)\n", basename($0));
         exit(1);
 } elsif ($ARGV[0] =~ /^(-h|-help|--help)$/ ) {
         printf ("usage: %s \[-v|-version|--version|-h|-help|--help\]\n", basename($0));

--- a/contrib/shell_utils/apple_dump.in
+++ b/contrib/shell_utils/apple_dump.in
@@ -105,7 +105,7 @@ while ($arg = shift @ARGV)
         printf ("another file.\n");
         exit 1;
     } elsif ($arg =~ /^(-v|-version|--version)$/ ) {
-        printf ("%s \(Netatalk @NETATALK_VERSION@\)\n", basename($0));
+        printf ("%s \(Netatalk @netatalk_version@\)\n", basename($0));
         exit 1;
     } elsif ($arg eq "-a") {
         $finderinfo = 0;

--- a/contrib/shell_utils/asip-status.in
+++ b/contrib/shell_utils/asip-status.in
@@ -16,7 +16,7 @@
 #
 
 #
-# This edition is a part of netatalk @NETATALK_VERSION@.
+# This edition is a part of netatalk @netatalk_version@.
 #
 
 use strict;
@@ -45,7 +45,7 @@ if ($main::showver ==1)
 {
         print "$0\n";
         print "Original edition: 7 May 1997 \(v1.0\) James W. Abendschan\n";
-        print "This edition is a part of Netatalk @NETATALK_VERSION@\n";
+        print "This edition is a part of Netatalk @netatalk_version@\n";
         exit(-1);
 }
 

--- a/distrib/config/netatalk-config.in
+++ b/distrib/config/netatalk-config.in
@@ -196,7 +196,7 @@ if test "X$af_echo_exec_prefix" = "Xyes"; then
 fi
 
 if test "X$af_echo_version" = "Xyes"; then
-        echo @NETATALK_VERSION@
+        echo @netatalk_version@
         exit 0
 fi
 

--- a/distrib/initscripts/io.netatalk.daemon.plist.tmpl
+++ b/distrib/initscripts/io.netatalk.daemon.plist.tmpl
@@ -5,13 +5,13 @@
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>:SBINDIR:::BINDIR::/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>@sbindir@:@bindir@:/usr/bin:/bin:/usr/sbin:/sbin</string>
 	</dict>
 	<key>Label</key>
 	<string>io.netatalk.daemon</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>:BINDIR:/netatalkd</string>
+		<string>@bindir@/netatalkd</string>
 		<string>start</string>
 	</array>
 	<key>RunAtLoad</key>

--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -12,12 +12,10 @@ if (
 )
     init_dir = '/usr/lib/systemd/system'
     init_dirs += init_dir
-    custom_target(
-        'systemd',
+    configure_file(
         input: 'service.systemd.tmpl',
         output: 'netatalk.service',
-        command: sed_command,
-        capture: true,
+        configuration: cdata,
         install: true,
         install_dir: init_dir,
     )
@@ -32,12 +30,10 @@ if (
 )
     init_dir = '/etc/init.d'
     init_dirs += init_dir
-    custom_target(
-        'debian_sysv',
+    configure_file(
         input: 'rc.debian.tmpl',
         output: 'netatalk',
-        command: sed_command,
-        capture: true,
+        configuration: cdata,
         install: true,
         install_dir: init_dir,
         install_mode: 'rwxr-xr-x',
@@ -56,12 +52,10 @@ endif
 if init_style == 'freebsd'
     init_dir = '/etc/rc.d'
     init_dirs += init_dir
-    custom_target(
-        'freebsd',
+    configure_file(
         input: 'rc.freebsd.tmpl',
         output: 'netatalk',
-        command: sed_command,
-        capture: true,
+        configuration: cdata,
         install: true,
         install_dir: init_dir,
         install_mode: 'rwxr-xr-x',
@@ -78,12 +72,10 @@ endif
 if init_style == 'netbsd'
     init_dir = '/etc/rc.d'
     init_dirs += init_dir
-    custom_target(
-        'netbsd',
+    configure_file(
         input: 'rc.netbsd.tmpl',
         output: 'netatalk',
-        command: sed_command,
-        capture: true,
+        configuration: cdata,
         install: true,
         install_dir: init_dir,
         install_mode: 'rwxr-xr-x',
@@ -93,12 +85,10 @@ endif
 if init_style == 'openbsd'
     init_dir = '/etc/rc.d'
     init_dirs += init_dir
-    custom_target(
-        'freebsd',
+    configure_file(
         input: 'rc.openbsd.tmpl',
         output: 'netatalk',
-        command: sed_command,
-        capture: true,
+        configuration: cdata,
         install: true,
         install_dir: init_dir,
         install_mode: 'rwxr-xr-x',
@@ -115,12 +105,10 @@ endif
 if init_style == 'solaris'
     init_dir = '/lib/svc/manifest/network'
     init_dirs += init_dir
-    custom_target(
-        'solaris',
+    configure_file(
         input: 'netatalk.xml.tmpl',
         output: 'netatalk.xml',
-        command: sed_command,
-        capture: true,
+        configuration: cdata,
         install: true,
         install_dir: init_dir,
     )
@@ -139,12 +127,10 @@ if (
 )
     init_dir = '/etc/init.d'
     init_dirs += init_dir
-    custom_target(
-        'openrc',
+    configure_file(
         input: 'rc.openrc.tmpl',
         output: 'netatalk',
-        command: sed_command,
-        capture: true,
+        configuration: cdata,
         install: true,
         install_dir: init_dir,
         install_mode: 'rwxr-xr-x',
@@ -162,22 +148,18 @@ endif
 if init_style == 'macos-launchd'
     init_dir = '/Library/LaunchDaemons'
     init_dirs += init_dir
-    custom_target(
-        'netatalkd',
+    configure_file(
         input: 'netatalkd.tmpl',
         output: 'netatalkd',
-        command: sed_command,
-        capture: true,
+        configuration: cdata,
         install: true,
         install_dir: bindir,
         install_mode: 'rwxr-xr-x',
     )
-    custom_target(
-        'plist',
+    configure_file(
         input: 'io.netatalk.daemon.plist.tmpl',
         output: 'io.netatalk.daemon.plist',
-        command: sed_command,
-        capture: true,
+        configuration: cdata,
         install: true,
         install_dir: init_dir,
     )

--- a/distrib/initscripts/netatalk.xml.tmpl
+++ b/distrib/initscripts/netatalk.xml.tmpl
@@ -23,7 +23,7 @@
         <method_context>
         </method_context>
 
-        <exec_method type="method" name="start" exec=":SBINDIR:/netatalk" timeout_seconds="60"/>
+        <exec_method type="method" name="start" exec="@sbindir@/netatalk" timeout_seconds="60"/>
 
         <exec_method type="method" name="stop" exec=":kill" timeout_seconds="60"/>
 
@@ -33,7 +33,7 @@
         </property_group>
 
         <property_group name="application" type="application">
-            <propval name="config_file" type="astring" value=":ETCDIR:/afp.conf"/>
+            <propval name="config_file" type="astring" value="@etcdir@/afp.conf"/>
         </property_group>
 
         <stability value="Evolving"/>

--- a/distrib/initscripts/netatalkd.tmpl
+++ b/distrib/initscripts/netatalkd.tmpl
@@ -24,7 +24,7 @@ done
 StartService() {
   ConsoleMessage "Starting netatalk fileserver..."
   rm -f /var/run/netatalk.pid
-  :SBINDIR:/netatalk
+  @sbindir@/netatalk
 }
 
 # The stop subroutine

--- a/distrib/initscripts/rc.debian.tmpl
+++ b/distrib/initscripts/rc.debian.tmpl
@@ -10,7 +10,7 @@
 # Description:       Enables the netatalk AFP file sharing server.
 ### END INIT INFO
 #
-# netatalk      Netatalk :NETATALK_VERSION: initscript
+# netatalk      Netatalk @netatalk_version@ initscript
 #
 
 set -e
@@ -21,7 +21,7 @@ PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 DESC="Netatalk"
 NAME=netatalk
 SCRIPTNAME=/etc/init.d/$NAME
-DAEMON=:SBINDIR:/netatalk
+DAEMON=@sbindir@/netatalk
 PIDFILE=/var/run/lock/netatalk
 
 # Guard to prevent execution if netatalk was removed.

--- a/distrib/initscripts/rc.freebsd.tmpl
+++ b/distrib/initscripts/rc.freebsd.tmpl
@@ -24,11 +24,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #
-# Netatalk :NETATALK_VERSION: daemons.
+# Netatalk @netatalk_version@ daemons.
 #
 
 # PROVIDE: netatalk
-# REQUIRE: DAEMON :ZEROCONF:
+# REQUIRE: DAEMON @freebsd_zeroconf@
 # KEYWORD: shutdown
 #
 # AFP fileserver for Mac clients.  Add the following to /etc/rc.conf to
@@ -46,7 +46,7 @@ rcvar=netatalk_enable
 
 load_rc_config ${name}
 
-command=":SBINDIR:/${name}"
+command="@sbindir@/${name}"
 
 extra_commands="reload"
 reload_cmd="netatalk_reload"

--- a/distrib/initscripts/rc.netbsd.tmpl
+++ b/distrib/initscripts/rc.netbsd.tmpl
@@ -3,15 +3,15 @@
 # PROVIDE: netatalk
 # KEYWORD: shutdown
 #
-# AFP fileserver for Macintosh clients (netatalk :NETATALK_VERSION:)
+# AFP fileserver for Macintosh clients (netatalk @netatalk_version@)
 #
 
 . /etc/rc.subr
 
 name="netatalk"
 rcvar=$name
-command=":SBINDIR:/netatalk"
-etcdir=":ETCDIR:"
+command="@sbindir@/netatalk"
+etcdir="@etcdir@"
 pidfile="/var/run/${name}.pid"
 required_files="$etcdir/afp.conf"
 

--- a/distrib/initscripts/rc.openbsd.tmpl
+++ b/distrib/initscripts/rc.openbsd.tmpl
@@ -1,9 +1,9 @@
 #!/bin/ksh
 #
-# Netatalk :NETATALK_VERSION: daemons.
+# Netatalk @netatalk_version@ daemons.
 #
 
-daemon=":SBINDIR:/netatalk"
+daemon="@sbindir@/netatalk"
 
 . /etc/rc.d/rc.subr
 

--- a/distrib/initscripts/rc.openrc.tmpl
+++ b/distrib/initscripts/rc.openrc.tmpl
@@ -2,9 +2,9 @@
 # Copyright 1999-2012 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 #
-# Netatalk :NETATALK_VERSION: daemons.
+# Netatalk @netatalk_version@ daemons.
 
-command=":SBINDIR:/${SVCNAME}"
+command="@sbindir@/${SVCNAME}"
 
 depend() {
 	need net

--- a/distrib/initscripts/rc.solaris.tmpl
+++ b/distrib/initscripts/rc.solaris.tmpl
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# Start/stop the Netatalk :NETATALK_VERSION: daemons.
+# Start/stop the Netatalk @netatalk_version@ daemons.
 #
 
 #
@@ -20,8 +20,8 @@ killproc() {
 netatalk_startup() {
     echo 'starting netatalk daemons: \c'
 
-    if [ -x :SBINDIR:/netatalk ]; then
-        :SBINDIR:/netatalk
+    if [ -x @sbindir@/netatalk ]; then
+        @sbindir@/netatalk
         echo ' netatalk\c'
     fi
 
@@ -42,7 +42,7 @@ case "$1" in
 
         echo 'stopping netatalk daemons:\c'
 
-        if [ -x :SBINDIR:/netatalk ]; then
+        if [ -x @sbindir@/netatalk ]; then
             killproc netatalk;                      echo ' netatalk\c'
         fi
 

--- a/distrib/initscripts/service.systemd.tmpl
+++ b/distrib/initscripts/service.systemd.tmpl
@@ -1,4 +1,4 @@
-# This file is part of netatalk :NETATALK_VERSION:.
+# This file is part of netatalk @netatalk_version@.
 
 [Unit]
 Description=Netatalk AFP fileserver for Macintosh clients
@@ -9,8 +9,8 @@ After=network.target avahi-daemon.service
 [Service]
 Type=forking
 GuessMainPID=no
-ExecStart=:SBINDIR:/netatalk
-PIDFile=:PATH_NETATALK_LOCK:
+ExecStart=@sbindir@/netatalk
+PIDFile=@lockfile_path@
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=1

--- a/doc/ja/manpages/man1/ad.1.xml
+++ b/doc/ja/manpages/man1/ad.1.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man1/afpldaptest.1.xml
+++ b/doc/ja/manpages/man1/afpldaptest.1.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man1/afppasswd.1.xml
+++ b/doc/ja/manpages/man1/afppasswd.1.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man1/afpstats.1.xml
+++ b/doc/ja/manpages/man1/afpstats.1.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man1/apple_dump.1.xml
+++ b/doc/ja/manpages/man1/apple_dump.1.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man1/asip-status.1.xml
+++ b/doc/ja/manpages/man1/asip-status.1.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man1/dbd.1.xml
+++ b/doc/ja/manpages/man1/dbd.1.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man1/macusers.1.xml
+++ b/doc/ja/manpages/man1/macusers.1.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man1/netatalk-config.1.xml
+++ b/doc/ja/manpages/man1/netatalk-config.1.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man5/afp.conf.5.xml
+++ b/doc/ja/manpages/man5/afp.conf.5.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man5/afp_signature.conf.5.xml
+++ b/doc/ja/manpages/man5/afp_signature.conf.5.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man5/afp_voluuid.conf.5.xml
+++ b/doc/ja/manpages/man5/afp_voluuid.conf.5.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man5/extmap.conf.5.xml
+++ b/doc/ja/manpages/man5/extmap.conf.5.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man8/afpd.8.xml
+++ b/doc/ja/manpages/man8/afpd.8.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man8/cnid_dbd.8.xml
+++ b/doc/ja/manpages/man8/cnid_dbd.8.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man8/cnid_metad.8.xml
+++ b/doc/ja/manpages/man8/cnid_metad.8.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manpages/man8/netatalk.8.xml
+++ b/doc/ja/manpages/man8/netatalk.8.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/ja/manual/manual.xml.in
+++ b/doc/ja/manual/manual.xml.in
@@ -31,7 +31,7 @@
   <title>Netatalk マニュアル</title>
 
   <bookinfo>
-    <subtitle>バージョン @NETATALK_VERSION@</subtitle>
+    <subtitle>バージョン @netatalk_version@</subtitle>
   </bookinfo>
 
   <?latex \setcounter{page}{3} ?>

--- a/doc/ja/manual/meson.build
+++ b/doc/ja/manual/meson.build
@@ -4,7 +4,7 @@ manual_xml = configure_file(
     configuration: cdata,
 )
 
-pageheader = configure_file(
+configure_file(
     input: 'pageheader.txt.in',
     output: 'pageheader.txt',
     configuration: cdata,
@@ -27,7 +27,7 @@ foreach page : manual_pages
     )
 endforeach
 
-manual_gen = custom_target(
+custom_target(
     'manual',
     output: [
         'ad.1.html',

--- a/doc/ja/manual/pageheader.txt.in
+++ b/doc/ja/manual/pageheader.txt.in
@@ -11,5 +11,5 @@
           <img src="/gfx/end.gif" alt="" width="125" height="7" />
         </div>
     </div>
-    <div class="navheader" align="center">Netatalk @NETATALK_VERSION@</div>
+    <div class="navheader" align="center">Netatalk @netatalk_version@</div>
 </html>

--- a/doc/manpages/man1/ad.1.xml
+++ b/doc/manpages/man1/ad.1.xml
@@ -9,7 +9,7 @@
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/afpldaptest.1.xml
+++ b/doc/manpages/man1/afpldaptest.1.xml
@@ -9,7 +9,7 @@
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/afppasswd.1.xml
+++ b/doc/manpages/man1/afppasswd.1.xml
@@ -9,7 +9,7 @@
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/afpstats.1.xml
+++ b/doc/manpages/man1/afpstats.1.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/apple_dump.1.xml
+++ b/doc/manpages/man1/apple_dump.1.xml
@@ -8,7 +8,7 @@
     <refmiscinfo class="date">12 Nov 2015</refmiscinfo>
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/asip-status.1.xml
+++ b/doc/manpages/man1/asip-status.1.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/dbd.1.xml
+++ b/doc/manpages/man1/dbd.1.xml
@@ -9,7 +9,7 @@
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/macusers.1.xml
+++ b/doc/manpages/man1/macusers.1.xml
@@ -9,7 +9,7 @@
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man1/netatalk-config.1.xml
+++ b/doc/manpages/man1/netatalk-config.1.xml
@@ -9,7 +9,7 @@
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -11,7 +11,7 @@
 
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
 
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man5/afp_signature.conf.5.xml
+++ b/doc/manpages/man5/afp_signature.conf.5.xml
@@ -10,7 +10,7 @@
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man5/afp_voluuid.conf.5.xml
+++ b/doc/manpages/man5/afp_voluuid.conf.5.xml
@@ -10,7 +10,7 @@
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man5/extmap.conf.5.xml
+++ b/doc/manpages/man5/extmap.conf.5.xml
@@ -9,7 +9,7 @@
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man8/afpd.8.xml
+++ b/doc/manpages/man8/afpd.8.xml
@@ -9,7 +9,7 @@
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man8/cnid_dbd.8.xml
+++ b/doc/manpages/man8/cnid_dbd.8.xml
@@ -9,7 +9,7 @@
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man8/cnid_metad.8.xml
+++ b/doc/manpages/man8/cnid_metad.8.xml
@@ -9,7 +9,7 @@
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manpages/man8/netatalk.8.xml
+++ b/doc/manpages/man8/netatalk.8.xml
@@ -9,7 +9,7 @@
 
     <refmiscinfo class="source">Netatalk</refmiscinfo>
     <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
-    <refmiscinfo class="version">@NETATALK_VERSION@</refmiscinfo>
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
   </refmeta>
 
   <refnamediv>

--- a/doc/manual/manual.xml.in
+++ b/doc/manual/manual.xml.in
@@ -31,7 +31,7 @@
   <title>Netatalk Manual</title>
 
   <bookinfo>
-    <subtitle>Version @NETATALK_VERSION@</subtitle>
+    <subtitle>Version @netatalk_version@</subtitle>
   </bookinfo>
 
   <?latex \setcounter{page}{3} ?>

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -4,7 +4,7 @@ manual_xml = configure_file(
     configuration: cdata,
 )
 
-pageheader = configure_file(
+configure_file(
     input: 'pageheader.txt.in',
     output: 'pageheader.txt',
     configuration: cdata,
@@ -27,7 +27,7 @@ foreach page : manual_pages
     )
 endforeach
 
-manual_gen = custom_target(
+custom_target(
     'manual',
     output: [
         'ad.1.html',

--- a/doc/manual/pageheader.txt.in
+++ b/doc/manual/pageheader.txt.in
@@ -11,5 +11,5 @@
           <img src="/gfx/end.gif" alt="" width="125" height="7" />
         </div>
     </div>
-    <div class="navheader" align="center">Netatalk @NETATALK_VERSION@</div>
+    <div class="navheader" align="center">Netatalk @netatalk_version@</div>
 </html>

--- a/meson.build
+++ b/meson.build
@@ -45,6 +45,14 @@ if pkgconfdir == ''
     pkgconfdir = sysconfdir
 endif
 
+if host_os == 'darwin'
+    homedir = '/Users'
+elif host_os == 'sunos'
+    homedir = '/export/home'
+else
+    homedir = '/home'
+endif
+
 ##################
 # Compiler flags #
 ##################
@@ -136,35 +144,11 @@ else
     bison = find_program('bison', required: false)
 endif
 
-##############
-# Init Style #
-##############
-
-uname_stdout = run_command(uname, '-a', check: false).stdout().strip()
-init_style = get_option('with-init-style')
-
-if init_style == 'auto'
-    if uname_stdout.to_lower().contains('debian') or uname_stdout.to_lower().contains('ubuntu')
-        init_style = 'debian-systemd'
-    elif host_os == 'freebsd'
-        init_style = 'freebsd'
-    elif host_os == 'netbsd'
-        init_style = 'netbsd'
-    elif host_os == 'openbsd'
-        init_style = 'openbsd'
-    elif host_os == 'darwin'
-        init_style = 'macos-launchd'
-    elif host_os == 'sunos'
-        init_style = 'solaris'
-    else
-        init_style = 'none'
-    endif
-endif
-
 #############
 # Libraries #
 #############
 
+uname_stdout = run_command(uname, '-a', check: false).stdout().strip()
 libsearch_dirs = []
 
 if host_os in ['dragonfly', 'freebsd', 'openbsd']
@@ -765,7 +749,6 @@ if dns_sd.found()
 endif
 
 zeroconf_provider = ''
-freebsd_zeroconf_daemon = ''
 
 have_dns = (
     (dns_sd.found() or system.found())
@@ -783,7 +766,7 @@ else
     if have_dns
         cdata.set('USE_ZEROCONF', 1)
         cdata.set('HAVE_MDNS', 1)
-        freebsd_zeroconf_daemon = 'mdnsd'
+        cdata.set('freebsd_zeroconf', 'mdnsd')
         zeroconf_provider += 'mDNS'
     else
         have_zeroconf = avahi.found()
@@ -793,7 +776,7 @@ else
             if avahi.version() >= '0.6.4'
                 cdata.set('HAVE_AVAHI_THREADED_POLL', 1)
             endif
-            freebsd_zeroconf_daemon = 'avahi_daemon'
+            cdata.set('freebsd_zeroconf', 'avahi_daemon')
             zeroconf_provider += 'Avahi'
         else
             have_zeroconf = false
@@ -885,7 +868,7 @@ else
             cdata.set(
                 'TRACKER_PREFIX',
                 '"'
-                + tracker_control.get_variable(pkgconfig: 'prefix')
+                + tracker_sparql.get_variable(pkgconfig: 'prefix')
                 + '"',
             )
             tracker_manager += 'tracker_control'
@@ -1548,6 +1531,7 @@ docbook_xsl_dirs = [
     docbook_path,
     '/usr/share/sgml/docbook/xsl-stylesheets',
     '/usr/share/xml/docbook/stylesheet/docbook-xsl',
+    '/usr/share/xml/docbook/xsl-stylesheets',
     '/opt/local/share/xsl/docbook',
     '/usr/local/share/xsl/docbook',
     '/usr/pkg/share/xsl/docbook',
@@ -1899,19 +1883,26 @@ endif
 # Check for optional initscript install
 #
 
+init_style = get_option('with-init-style')
 init_dirs = []
 
-sed_command = [
-    find_program('sed', required: false),
-    '-e', 's@:BINDIR:@' + bindir + '@',
-    '-e', 's@:LOCALSTATEDIR:@' + localstatedir + '@',
-    '-e', 's@:ETCDIR:@' + pkgconfdir + '@',
-    '-e', 's@:SBINDIR:@' + sbindir + '@',
-    '-e', 's@:NETATALK_VERSION:@' + netatalk_version + '@',
-    '-e', 's@:PATH_NETATALK_LOCK:@' + lockfile_path + '@',
-    '-e', 's@:ZEROCONF:@' + freebsd_zeroconf_daemon + '@',
-    '@INPUT@',
-]
+if init_style == 'auto'
+    if uname_stdout.to_lower().contains('debian') or uname_stdout.to_lower().contains('ubuntu')
+        init_style = 'debian-systemd'
+    elif host_os == 'freebsd'
+        init_style = 'freebsd'
+    elif host_os == 'netbsd'
+        init_style = 'netbsd'
+    elif host_os == 'openbsd'
+        init_style = 'openbsd'
+    elif host_os == 'darwin'
+        init_style = 'macos-launchd'
+    elif host_os == 'sunos'
+        init_style = 'solaris'
+    else
+        init_style = 'none'
+    endif
+endif
 
 #
 # Check for cracklib support
@@ -1997,6 +1988,8 @@ endif
 # OS-specific configuration
 #
 
+cdata.set('OPEN_NOFOLLOW_ERRNO', 'ELOOP')
+
 if host_os.contains('freebsd')
     cdata.set('BSD4_4', 1)
     cdata.set('FREEBSD', 1)
@@ -2052,18 +2045,15 @@ endif
 # Variable substitution
 #
 
-# Reserved for future use:
-#cdata.set('BINDIR', bindir)
-#cdata.set('ETCDIR', pkgconfdir)
-#cdata.set('PATH_NETATALK_LOCK', lockfile_path)
-#cdata.set('SBINDIR', sbindir)
-
+cdata.set('bindir', bindir)
+cdata.set('etcdir', pkgconfdir)
 cdata.set('exec_prefix', exec_prefix)
-cdata.set('includedir', includedir)
+cdata.set('homedir', homedir)
 cdata.set('libdir', libdir)
+cdata.set('includedir', includedir)
 cdata.set('localstatedir', localstatedir)
-cdata.set('NETATALK_VERSION', netatalk_version)
-cdata.set('OPEN_NOFOLLOW_ERRNO', 'ELOOP')
+cdata.set('lockfile_path', lockfile_path)
+cdata.set('netatalk_version', netatalk_version)
 cdata.set('pkgconfdir', pkgconfdir)
 cdata.set('prefix', prefix)
 cdata.set('sbindir', sbindir)
@@ -2202,6 +2192,7 @@ summary_info = {
     '  init directory': init_dirs,
     '  Netatalk lockfile': lockfile,
     '  PAM config directory': pam_confdir,
+    '  User home basedir': homedir,
 }
 if have_spotlight
     summary_info += {


### PR DESCRIPTION
- Remove the variable substitution that uses sed 
- Activate native meson variable substitution for all global variables
- Standardize global substitution tokens to lower case snake case
- Add home basedir substitution and apply it to afp.conf while enabling home dir sharing by default
- dbus_session.conf now falls under enable-overwrite 
- Minor build system bug fixes