### PR TITLE
[3.2] meson: Don't make dtags depend on rpath

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -431,9 +431,10 @@ endif
 
 if enable_rpath
     bdb_link_args += '-R' + bdb_libdir
-    if enable_dtags
-        bdb_link_args += '-Wl,--enable-new-dtags'
-    endif
+endif
+
+if enable_dtags
+    bdb_link_args += '-Wl,--enable-new-dtags'
 endif
 
 if bdb_header != ''


### PR DESCRIPTION
Fix an incorrect nesting of dtags under rpath.