### PR TITLE
[3.2] meson: Remove duplicate dependency check for posix threads

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -136,12 +136,6 @@ else
     bison = find_program('bison', required: false)
 endif
 
-################
-# Dependencies #
-################
-
-threads = dependency('threads', required: true)
-
 #############
 # Libraries #
 #############


### PR DESCRIPTION
The exact same check for posix threads is done further down in the main script.