### PR TITLE
[2.4] meson: Remove duplicate dependency check for posix threads

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -141,12 +141,6 @@ if host_os == 'darwin'
     endif
 endif
 
-################
-# Dependencies #
-################
-
-threads = dependency('threads', required: true)
-
 #############
 # Libraries #
 #############


### PR DESCRIPTION
The exact same check for posix threads is done further down in the main script.