### PR TITLE
[3.2] meson: Refactor libcrypto check and print better status messages

### DIFF
--- a/etc/uams/meson.build
+++ b/etc/uams/meson.build
@@ -49,7 +49,34 @@ if have_embedded_ssl
 endif
 
 if have_ssl
+    uams_randnum_sources = ['uams_randnum.c']
     uams_dhx_passwd_sources = ['uams_dhx_passwd.c']
+
+    shared_module(
+        'uams_randnum',
+        uams_randnum_sources,
+        include_directories: root_includes,
+        dependencies: [crack, pam, ssl_deps],
+        link_with: ssl_links,
+        name_prefix: '',
+        name_suffix: 'so',
+        install: true,
+        install_dir: libdir / 'netatalk',
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
+    static_library(
+        'uams_randnum',
+        uams_randnum_sources,
+        include_directories: root_includes,
+        dependencies: [crack, pam, ssl_deps],
+        link_with: ssl_links,
+        name_prefix: '',
+        install: true,
+        install_dir: libdir / 'netatalk',
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
 
     shared_module(
         'uams_dhx_passwd',
@@ -218,37 +245,7 @@ else
     )
 endif
 
-if have_ssl
-    uams_randnum_sources = ['uams_randnum.c']
-
-    shared_module(
-        'uams_randnum',
-        uams_randnum_sources,
-        include_directories: root_includes,
-        dependencies: [crack, pam, ssl_deps],
-        link_with: ssl_links,
-        name_prefix: '',
-        name_suffix: 'so',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: rpath_libdir,
-        install_rpath: rpath_libdir,
-    )
-    static_library(
-        'uams_randnum',
-        uams_randnum_sources,
-        include_directories: root_includes,
-        dependencies: [crack, pam, ssl_deps],
-        link_with: ssl_links,
-        name_prefix: '',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: rpath_libdir,
-        install_rpath: rpath_libdir,
-    )
-endif
-
-if enable_pgp_uam
+if have_pgp_uam
     uams_pgp_sources = ['uams_pgp.c']
 
     shared_module(

--- a/meson.build
+++ b/meson.build
@@ -537,39 +537,39 @@ else
     have_wolfssl = false
 endif
 
-if ((have_wolfssl or have_embedded_ssl) and crypto.found()) or crypto.found()
+if crypto.found()
     have_ssl = true
     cdata.set('HAVE_LIBCRYPTO', 1)
     cdata.set('UAM_DHX', 1)
-endif
-
-if have_wolfssl
-    if force_embedded_ssl
-        have_embedded_ssl = true
+    if have_wolfssl
+        if force_embedded_ssl
+            have_embedded_ssl = true
+            ssl_deps += crypto
+            ssl_provider += 'built-in'
+            cdata.set('EMBEDDED_SSL', 1)
+        else
+            ssl_deps += [crypto, wolfssl]
+            ssl_provider += 'WolfSSL'
+            cdata.set('WOLFSSL_DHX', 1)
+        endif
+    elif have_embedded_ssl
         ssl_deps += crypto
         ssl_provider += 'built-in'
         cdata.set('EMBEDDED_SSL', 1)
     else
-        ssl_deps += [crypto, wolfssl]
-        ssl_provider += 'WolfSSL'
-        cdata.set('WOLFSSL_DHX', 1)
-    endif
-elif have_embedded_ssl
-    ssl_deps += crypto
-    ssl_provider += 'built-in'
-    cdata.set('EMBEDDED_SSL', 1)
-elif crypto.found()
-    ssl_deps += crypto
-    cdata.set('OPENSSL_DHX', 1)
-    if libtls.found()
-        ssl_provider += 'LibreSSL'
-    elif not libtls.found()
-        ssl_provider += 'OpenSSL'
+        ssl_deps += crypto
+        cdata.set('OPENSSL_DHX', 1)
+        if libtls.found()
+            ssl_provider += 'LibreSSL'
+        elif not libtls.found()
+            ssl_provider += 'OpenSSL'
+        endif
     endif
 else
     have_ssl = false
+    ssl_provider += 'none'
     warning(
-        'Built-in WolfSSL, LibreSSL or OpenSSL version 1.1 is required for DHX and RANDNUM support',
+        'LibreSSL or OpenSSL version 1.1 is required for DHX and RANDNUM support',
     )
 endif
 
@@ -2125,17 +2125,18 @@ summary(summary_info, bool_yn: true, section: '  CNID:')
 
 summary_info = {
     '  Kerberos V': have_krb5_uam,
-    '  PGP': enable_pgp_uam,
-    '  Randnum': '(afppasswd)',
+    '  PGP': have_pgp_uam,
     '  clrtxt': uams_using_options,
     '  guest': true,
 }
 if have_ssl
     summary_info += {
+        '  Randnum': '(afppasswd)',
         '  DHX': uams_using_options,
     }
 else
     summary_info += {
+        '  Randnum': false,
         '  DHX': false,
     }
 endif


### PR DESCRIPTION
- Correct handling of Randnum/DHX/PGP UAM build scripts when libcrypto is missing
- Correct summary status of Randnum and PPG when libcrypto is missing
- Refactoring