### PR TITLE
[3.2] meson: Better output when cryptographic UAMs aren't buil

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2128,10 +2128,18 @@ if have_ssl
     summary_info += {
         '  DHX': uams_using_options,
     }
+else
+    summary_info += {
+        '  DHX': false,
+    }
 endif
 if have_libgcrypt
     summary_info += {
         '  DHX2': uams_using_options,
+    }
+else
+    summary_info += {
+        '  DHX2': false,
     }
 endif
 summary(summary_info, bool_yn: true, section: '  UAMs:')


### PR DESCRIPTION
Explicit output in summary when DHX or DHX2 aren't built.