### PR TITLE
meson: Install more documentation by default and organize it better

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ on:
 env:
   APT_PACKAGES: |
     bison \
+    cmark-gfm \
     docbook-xsl \
     file \
     flex \
@@ -524,7 +525,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          brew install berkeley-db docbook-xsl libxslt meson mysql talloc
+          brew install berkeley-db cmark-gfm docbook-xsl libxslt meson mysql talloc
           wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
       - name: Configure
         run: |

--- a/doc/ja/manual/meson.build
+++ b/doc/ja/manual/meson.build
@@ -20,7 +20,7 @@ manual_pages = [
 ]
 
 foreach page : manual_pages
-    manual_xmlfile = configure_file(
+    configure_file(
         input: page,
         output: page,
         configuration: cdata,

--- a/doc/ja/manual/meson.build
+++ b/doc/ja/manual/meson.build
@@ -68,5 +68,5 @@ custom_target(
         '@INPUT@',
     ],
     install: true,
-    install_dir: datadir / 'doc/netatalk/ja',
+    install_dir: datadir / 'doc/netatalk/htmldocs/ja',
 )

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -20,7 +20,7 @@ manual_pages = [
 ]
 
 foreach page : manual_pages
-    manual_xmlfile = configure_file(
+    configure_file(
         input: page,
         output: page,
         configuration: cdata,

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -68,5 +68,5 @@ custom_target(
         '@INPUT@',
     ],
     install: true,
-    install_dir: datadir / 'doc/netatalk',
+    install_dir: datadir / 'doc/netatalk/htmldocs',
 )

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -16,6 +16,9 @@ manual_stylesheet = configure_file(
     configuration: cdata,
 )
 
-subdir('ja')
 subdir('manpages')
 subdir('manual')
+
+if get_option('with-manual') == 'www'
+    subdir('ja')
+endif

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -16,6 +16,13 @@ manual_stylesheet = configure_file(
     configuration: cdata,
 )
 
+if get_option('with-readmes')
+    install_data(
+        'DEVELOPER',
+        install_dir: datadir / 'doc/netatalk',
+    )
+endif
+
 subdir('manpages')
 subdir('manual')
 

--- a/meson.build
+++ b/meson.build
@@ -135,6 +135,8 @@ flex = find_program('flex', required: false)
 grep = find_program('grep', required: false)
 perl = find_program('perl', required: true)
 uname = find_program('uname', required: false)
+cmarkgfm = find_program('cmark-gfm', required: false)
+
 if host_os == 'darwin'
     bison = find_program(macos_prefix / 'opt/bison/bin/bison', required: false)
     if not bison.found()
@@ -2074,6 +2076,57 @@ configure_file(
     output: 'config.h',
     configuration: cdata,
 )
+
+#########################
+# Prepare documentation #
+#########################
+
+
+if get_option('with-readmes')
+    readmes = [
+        'CONTRIBUTORS',
+        'NEWS',
+    ]
+
+    if cmarkgfm.found()
+        readmes_md = [
+            'INSTALL',
+            'README',
+            'SECURITY',
+        ]
+
+        foreach file : readmes_md
+            custom_target(
+                'readmes_' + file,
+                input: file + '.md',
+                output: file + '.txt',
+                command: [
+                    'cmark-gfm',
+                    '--width', '80',
+                    '--to', 'plaintext',
+                    '@INPUT@',
+                ],
+                capture: true,
+                install: true,
+                install_dir: datadir / 'doc/netatalk',
+            )
+        endforeach
+    else
+        warning('cmark-gfm is required for markdown to text conversion')
+        readmes += [
+            'INSTALL.md',
+            'README.md',
+            'SECURITY.md',
+        ]
+    endif
+
+    foreach file : readmes
+        install_data(
+            file,
+            install_dir: datadir / 'doc/netatalk',
+        )
+    endforeach
+endif
 
 subdir('include')
 subdir('libatalk')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -124,6 +124,12 @@ option(
     description: 'Enable quota support',
 )
 option(
+    'with-readmes',
+    type: 'boolean',
+    value: true,
+    description: 'Install README documentation',
+)
+option(
     'with-rpath',
     type: 'boolean',
     value: false,
@@ -344,5 +350,5 @@ option(
         'www',
     ],
     value: 'local',
-    description: 'Compile Netatalk documentation',
+    description: 'Build and install the html manual',
 )


### PR DESCRIPTION
- Install generated html manual files into a htmldocs subdir to doc/netatalk
- Generate the Japanese localized html manual files only when building for Web publishing
- Install readme files, optionally processed from markdown to plain text (new `with-readmes` option)