### PR TITLE
meson: Prioritize tests and run single-threaded to avoid race condition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,8 @@ jobs:
             -Dwith-tests=true
       - name: Build
         run: meson compile -C build
+      - name: Run tests
+        run: cd build && meson test
       - name: Install
         run: meson install -C build
       - name: Uninstall

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -179,5 +179,15 @@ afpdtest = executable(
 
 test_sh = find_program('test.sh')
 
-test('test1', test_sh)
-test('test2', afpdtest)
+test(
+    'test1',
+    test_sh,
+    is_parallel: false,
+    priority: 1,
+)
+test(
+    'test2',
+    afpdtest,
+    is_parallel: false,
+    priority: 0,
+)


### PR DESCRIPTION
The integration tests are designed to be run sequentially in order. This stops Meson from trying to run them out of order or in parallel.