### PR TITLE
[3.2] meson: Better way to handle rpath executable targets

### DIFF
--- a/bin/ad/meson.build
+++ b/bin/ad/meson.build
@@ -16,26 +16,14 @@ if use_mysql_backend
     ad_deps += mysqlclient
 endif
 
-if enable_rpath
-    executable(
-        'ad',
-        ad_sources,
-        include_directories: root_includes,
-        dependencies: ad_deps,
-        link_with: libatalk,
-        c_args: [ad, dversion],
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'ad',
-        ad_sources,
-        include_directories: root_includes,
-        dependencies: ad_deps,
-        link_with: libatalk,
-        c_args: [ad, dversion],
-        install: true,
-    )
-endif
+executable(
+    'ad',
+    ad_sources,
+    include_directories: root_includes,
+    dependencies: ad_deps,
+    link_with: libatalk,
+    c_args: [ad, dversion],
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/bin/afppasswd/meson.build
+++ b/bin/afppasswd/meson.build
@@ -21,34 +21,18 @@ if have_embedded_ssl
     afppasswd_libs += libatalk
 endif
 
-if enable_rpath
-    executable(
-        'afppasswd',
-        afppasswd_sources,
-        include_directories: root_includes,
-        dependencies: afppasswd_deps,
-        link_with: afppasswd_libs,
-        c_args: [
-            afpdpwfile,
-            dversion,
-        ],
-        install: true,
-        install_mode: 'rwsr-xr-x',
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'afppasswd',
-        afppasswd_sources,
-        include_directories: root_includes,
-        dependencies: afppasswd_deps,
-        link_with: afppasswd_libs,
-        c_args: [
-            afpdpwfile,
-            dversion,
-        ],
-        install: true,
-        install_mode: 'rwsr-xr-x',
-    )
-endif
+executable(
+    'afppasswd',
+    afppasswd_sources,
+    include_directories: root_includes,
+    dependencies: afppasswd_deps,
+    link_with: afppasswd_libs,
+    c_args: [
+        afpdpwfile,
+        dversion,
+    ],
+    install: true,
+    install_mode: 'rwsr-xr-x',
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/bin/misc/meson.build
+++ b/bin/misc/meson.build
@@ -40,27 +40,15 @@ if use_mysql_backend
 endif
 
 if have_ldap
-    if enable_rpath
-        executable(
-            'afpldaptest',
-            afpldaptest_sources,
-            include_directories: root_includes,
-            link_with: libatalk,
-            dependencies: [afpldaptest_deps, ldap],
-            c_args: confdir,
-            install: true,
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-    else
-        executable(
-            'afpldaptest',
-            afpldaptest_sources,
-            include_directories: root_includes,
-            link_with: libatalk,
-            dependencies: [afpldaptest_deps, ldap],
-            c_args: confdir,
-            install: true,
-        )
-    endif
+    executable(
+        'afpldaptest',
+        afpldaptest_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        dependencies: [afpldaptest_deps, ldap],
+        c_args: confdir,
+        install: true,
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
 endif

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -182,48 +182,25 @@ if have_dtrace and host_os != 'darwin'
     afpd_external_deps += dtrace_deps
 endif
 
-if enable_rpath
-    executable(
-        'afpd',
-        afpd_dtrace_input,
-        objects: afpd_objs,
-        include_directories: root_includes,
-        link_with: [afpd_internal_deps, libatalk],
-        dependencies: afpd_external_deps,
-        c_args: [
-            '-DAPPLCNAME', afpd_c_args,
-            confdir,
-            dversion,
-            messagedir,
-            statedir,
-            uamdir,
-        ],
-        link_args: netatalk_common_link_args,
-        export_dynamic: true,
-        install: true,
-        install_dir: sbindir,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'afpd',
-        afpd_dtrace_input,
-        objects: afpd_objs,
-        include_directories: root_includes,
-        link_with: [afpd_internal_deps, libatalk],
-        dependencies: afpd_external_deps,
-        c_args: [
-            '-DAPPLCNAME', afpd_c_args,
-            confdir,
-            dversion,
-            messagedir,
-            statedir,
-            uamdir,
-        ],
-        link_args: netatalk_common_link_args,
-        export_dynamic: true,
-        install: true,
-        install_dir: sbindir,
-    )
-endif
+executable(
+    'afpd',
+    afpd_dtrace_input,
+    objects: afpd_objs,
+    include_directories: root_includes,
+    link_with: [afpd_internal_deps, libatalk],
+    dependencies: afpd_external_deps,
+    c_args: [
+        '-DAPPLCNAME', afpd_c_args,
+        confdir,
+        dversion,
+        messagedir,
+        statedir,
+        uamdir,
+    ],
+    link_args: netatalk_common_link_args,
+    export_dynamic: true,
+    install: true,
+    install_dir: sbindir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/etc/cnid_dbd/meson.build
+++ b/etc/cnid_dbd/meson.build
@@ -39,75 +39,41 @@ if use_dbd_backend
         'pack.c',
     ]
 
-    if enable_rpath
-        executable(
-            'cnid_dbd',
-            cnid_dbd_sources,
-            include_directories: [bdb_includes, root_includes],
-            link_with: libatalk,
-            dependencies: [cnid_dbd_deps, db],
-            c_args: [cnid_dbd, dversion],
-            link_args: bdb_link_args,
-            install: true,
-            install_dir: sbindir,
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-        executable(
-            'cnid_metad',
-            cnid_metad_sources,
-            include_directories: root_includes,
-            link_with: libatalk,
-            dependencies: cnid_dbd_deps,
-            c_args: [cnid_dbd, dversion],
-            install: true,
-            install_dir: sbindir,
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-        executable(
-            'dbd',
-            dbd_sources,
-            include_directories: [bdb_includes, root_includes],
-            link_with: libatalk,
-            dependencies: [cnid_dbd_deps, db],
-            c_args: dversion,
-            link_args: bdb_link_args,
-            install: true,
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-    else
-        executable(
-            'cnid_dbd',
-            cnid_dbd_sources,
-            include_directories: [bdb_includes, root_includes],
-            link_with: libatalk,
-            dependencies: [cnid_dbd_deps, db],
-            c_args: [cnid_dbd, dversion],
-            link_args: bdb_link_args,
-            install: true,
-            install_dir: sbindir,
-        )
-        executable(
-            'cnid_metad',
-            cnid_metad_sources,
-            include_directories: root_includes,
-            link_with: libatalk,
-            dependencies: cnid_dbd_deps,
-            c_args: [cnid_dbd, dversion],
-            install: true,
-            install_dir: sbindir,
-        )
-        executable(
-            'dbd',
-            dbd_sources,
-            include_directories: [bdb_includes, root_includes],
-            link_with: libatalk,
-            dependencies: [cnid_dbd_deps, db],
-            c_args: dversion,
-            link_args: bdb_link_args,
-            install: true,
-        )
-    endif
+    executable(
+        'cnid_dbd',
+        cnid_dbd_sources,
+        include_directories: [bdb_includes, root_includes],
+        link_with: libatalk,
+        dependencies: [cnid_dbd_deps, db],
+        c_args: [cnid_dbd, dversion],
+        link_args: bdb_link_args,
+        install: true,
+        install_dir: sbindir,
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
+    executable(
+        'cnid_metad',
+        cnid_metad_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        dependencies: cnid_dbd_deps,
+        c_args: [cnid_dbd, dversion],
+        install: true,
+        install_dir: sbindir,
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
+    executable(
+        'dbd',
+        dbd_sources,
+        include_directories: [bdb_includes, root_includes],
+        link_with: libatalk,
+        dependencies: [cnid_dbd_deps, db],
+        c_args: dversion,
+        link_args: bdb_link_args,
+        install: true,
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
 endif

--- a/etc/netatalk/meson.build
+++ b/etc/netatalk/meson.build
@@ -11,28 +11,15 @@ elif avahi.found()
     netatalk_deps += avahi
 endif
 
-if enable_rpath
-    executable(
-        'netatalk',
-        netatalk_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        dependencies: netatalk_deps,
-        c_args: [confdir, statedir, afpd, cnid_metad, dversion],
-        install: true,
-        install_dir: sbindir,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'netatalk',
-        netatalk_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        dependencies: netatalk_deps,
-        c_args: [confdir, statedir, afpd, cnid_metad, dversion],
-        install: true,
-        install_dir: sbindir,
-    )
-endif
+executable(
+    'netatalk',
+    netatalk_sources,
+    include_directories: root_includes,
+    link_with: libatalk,
+    dependencies: netatalk_deps,
+    c_args: [confdir, statedir, afpd, cnid_metad, dversion],
+    install: true,
+    install_dir: sbindir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/etc/uams/meson.build
+++ b/etc/uams/meson.build
@@ -1,6 +1,6 @@
 uams_guest_sources = ['uams_guest.c']
 
-uams_guest = shared_module(
+shared_module(
     'uams_guest',
     uams_guest_sources,
     include_directories: root_includes,
@@ -10,7 +10,7 @@ uams_guest = shared_module(
     install_dir: libdir / 'netatalk',
 )
 
-uams_guest = static_library(
+static_library(
     'uams_guest',
     uams_guest_sources,
     include_directories: root_includes,
@@ -21,7 +21,7 @@ uams_guest = static_library(
 
 uams_passwd_sources = ['uams_passwd.c']
 
-uams_passwd = shared_module(
+shared_module(
     'uams_passwd',
     uams_passwd_sources,
     include_directories: root_includes,
@@ -32,7 +32,7 @@ uams_passwd = shared_module(
     install_dir: libdir / 'netatalk',
 )
 
-uams_passwd = static_library(
+static_library(
     'uams_passwd',
     uams_passwd_sources,
     include_directories: root_includes,
@@ -51,107 +51,60 @@ endif
 if have_ssl
     uams_dhx_passwd_sources = ['uams_dhx_passwd.c']
 
-    if enable_rpath
-        uams_dhx_passwd = shared_module(
-            'uams_dhx_passwd',
-            uams_dhx_passwd_sources,
-            include_directories: root_includes,
-            dependencies: [crypt, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            name_suffix: 'so',
-            install: true,
-            install_dir: libdir / 'netatalk',
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-        uams_dhx_passwd = static_library(
-            'uams_dhx_passwd',
-            uams_dhx_passwd_sources,
-            include_directories: root_includes,
-            dependencies: [crypt, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            install: true,
-            install_dir: libdir / 'netatalk',
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-    else
-        uams_dhx_passwd = shared_module(
-            'uams_dhx_passwd',
-            uams_dhx_passwd_sources,
-            include_directories: root_includes,
-            dependencies: [crypt, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            name_suffix: 'so',
-            install: true,
-            install_dir: libdir / 'netatalk',
-        )
-        uams_dhx_passwd = static_library(
-            'uams_dhx_passwd',
-            uams_dhx_passwd_sources,
-            include_directories: root_includes,
-            dependencies: [crypt, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            install: true,
-            install_dir: libdir / 'netatalk',
-        )
-    endif
+    shared_module(
+        'uams_dhx_passwd',
+        uams_dhx_passwd_sources,
+        include_directories: root_includes,
+        dependencies: [crypt, ssl_deps],
+        link_with: ssl_links,
+        name_prefix: '',
+        name_suffix: 'so',
+        install: true,
+        install_dir: libdir / 'netatalk',
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
+    static_library(
+        'uams_dhx_passwd',
+        uams_dhx_passwd_sources,
+        include_directories: root_includes,
+        dependencies: [crypt, ssl_deps],
+        link_with: ssl_links,
+        name_prefix: '',
+        install: true,
+        install_dir: libdir / 'netatalk',
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
+
     if have_pam
         uams_dhx_pam_sources = ['uams_dhx_pam.c']
 
-        if enable_rpath
-            uams_dhx_pam = shared_module(
-                'uams_dhx_pam',
-                uams_dhx_pam_sources,
-                include_directories: [pam_includes, root_includes],
-                dependencies: [pam, ssl_deps],
-                link_with: ssl_links,
-                name_prefix: '',
-                name_suffix: 'so',
-                install: true,
-                install_dir: libdir / 'netatalk',
-                build_rpath: libdir,
-                install_rpath: libdir,
-            )
-            uams_dhx_pam = static_library(
-                'uams_dhx_pam',
-                uams_dhx_pam_sources,
-                include_directories: [pam_includes, root_includes],
-                dependencies: [pam, ssl_deps],
-                link_with: ssl_links,
-                name_prefix: '',
-                install: true,
-                install_dir: libdir / 'netatalk',
-                build_rpath: libdir,
-                install_rpath: libdir,
-            )
-        else
-            uams_dhx_pam = shared_module(
-                'uams_dhx_pam',
-                uams_dhx_pam_sources,
-                include_directories: [pam_includes, root_includes],
-                dependencies: [pam, ssl_deps],
-                link_with: ssl_links,
-                name_prefix: '',
-                name_suffix: 'so',
-                install: true,
-                install_dir: libdir / 'netatalk',
-            )
-            uams_dhx_pam = static_library(
-                'uams_dhx_pam',
-                uams_dhx_pam_sources,
-                include_directories: [pam_includes, root_includes],
-                dependencies: [pam, ssl_deps],
-                link_with: ssl_links,
-                name_prefix: '',
-                install: true,
-                install_dir: libdir / 'netatalk',
-            )
-        endif
+        shared_module(
+            'uams_dhx_pam',
+            uams_dhx_pam_sources,
+            include_directories: [pam_includes, root_includes],
+            dependencies: [pam, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            name_suffix: 'so',
+            install: true,
+            install_dir: libdir / 'netatalk',
+            build_rpath: rpath_libdir,
+            install_rpath: rpath_libdir,
+        )
+        static_library(
+            'uams_dhx_pam',
+            uams_dhx_pam_sources,
+            include_directories: [pam_includes, root_includes],
+            dependencies: [pam, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            install: true,
+            install_dir: libdir / 'netatalk',
+            build_rpath: rpath_libdir,
+            install_rpath: rpath_libdir,
+        )
 
         install_symlink(
             'uams_dhx.so',
@@ -170,7 +123,7 @@ endif
 if have_libgcrypt
     uams_dhx2_passwd_sources = ['uams_dhx2_passwd.c']
 
-    uams_dhx2_passwd = shared_module(
+    shared_module(
         'uams_dhx2_passwd',
         uams_dhx2_passwd_sources,
         include_directories: root_includes,
@@ -181,7 +134,7 @@ if have_libgcrypt
         install_dir: libdir / 'netatalk',
     )
 
-    uams_dhx2_passwd = static_library(
+    static_library(
         'uams_dhx2_passwd',
         uams_dhx2_passwd_sources,
         include_directories: root_includes,
@@ -193,7 +146,7 @@ if have_libgcrypt
     if have_pam
         uams_dhx2_pam_sources = ['uams_dhx2_pam.c']
 
-        uams_dhx2_pam = shared_module(
+        shared_module(
             'uams_dhx2_pam',
             uams_dhx2_pam_sources,
             include_directories: [pam_includes, root_includes],
@@ -204,7 +157,7 @@ if have_libgcrypt
             install_dir: libdir / 'netatalk',
         )
 
-        uams_dhx2_pam = static_library(
+        static_library(
             'uams_dhx2_pam',
             uams_dhx2_pam_sources,
             include_directories: [pam_includes, root_includes],
@@ -231,7 +184,7 @@ endif
 if have_pam
     uams_pam_sources = ['uams_pam.c']
 
-    uams_pam = shared_module(
+    shared_module(
         'uams_pam',
         uams_pam_sources,
         include_directories: [pam_includes, root_includes],
@@ -242,7 +195,7 @@ if have_pam
         install_dir: libdir / 'netatalk',
     )
 
-    uams_pam = static_library(
+    static_library(
         'uams_pam',
         uams_pam_sources,
         include_directories: [pam_includes, root_includes],
@@ -268,61 +221,37 @@ endif
 if have_ssl
     uams_randnum_sources = ['uams_randnum.c']
 
-    if enable_rpath
-        uams_randnum = shared_module(
-            'uams_randnum',
-            uams_randnum_sources,
-            include_directories: root_includes,
-            dependencies: [crack, pam, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            name_suffix: 'so',
-            install: true,
-            install_dir: libdir / 'netatalk',
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-        uams_randnum = static_library(
-            'uams_randnum',
-            uams_randnum_sources,
-            include_directories: root_includes,
-            dependencies: [crack, pam, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            install: true,
-            install_dir: libdir / 'netatalk',
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-    else
-        uams_randnum = shared_module(
-            'uams_randnum',
-            uams_randnum_sources,
-            include_directories: root_includes,
-            dependencies: [crack, pam, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            name_suffix: 'so',
-            install: true,
-            install_dir: libdir / 'netatalk',
-        )
-        uams_randnum = static_library(
-            'uams_randnum',
-            uams_randnum_sources,
-            include_directories: root_includes,
-            dependencies: [crack, pam, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            install: true,
-            install_dir: libdir / 'netatalk',
-        )
-    endif
+    shared_module(
+        'uams_randnum',
+        uams_randnum_sources,
+        include_directories: root_includes,
+        dependencies: [crack, pam, ssl_deps],
+        link_with: ssl_links,
+        name_prefix: '',
+        name_suffix: 'so',
+        install: true,
+        install_dir: libdir / 'netatalk',
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
+    static_library(
+        'uams_randnum',
+        uams_randnum_sources,
+        include_directories: root_includes,
+        dependencies: [crack, pam, ssl_deps],
+        link_with: ssl_links,
+        name_prefix: '',
+        install: true,
+        install_dir: libdir / 'netatalk',
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
 endif
 
 if enable_pgp_uam
     uams_pgp_sources = ['uams_pgp.c']
 
-    uams_pgp = shared_module(
+    shared_module(
         'uams_pgp',
         uams_pgp_sources,
         include_directories: root_includes,
@@ -333,7 +262,7 @@ if enable_pgp_uam
         install_dir: libdir / 'netatalk',
     )
 
-    uams_pgp = static_library(
+    static_library(
         'uams_pgp',
         uams_pgp_sources,
         include_directories: root_includes,
@@ -347,7 +276,7 @@ endif
 if have_krb5_uam
     uams_gss_sources = ['uams_gss.c']
 
-    uams_gss = shared_module(
+    shared_module(
         'uams_gss',
         uams_gss_sources,
         include_directories: [gssapi_includes, root_includes],
@@ -359,7 +288,7 @@ if have_krb5_uam
         install_dir: libdir / 'netatalk',
     )
 
-    uams_gss = static_library(
+    static_library(
         'uams_gss',
         uams_gss_sources,
         include_directories: [gssapi_includes, root_includes],

--- a/meson.build
+++ b/meson.build
@@ -346,6 +346,12 @@ else
     enable_rpath = get_option('with-rpath')
 endif
 
+if enable_rpath
+    rpath_libdir = libdir
+else
+    rpath_libdir = ''
+endif
+
 if host_os == 'linux'
     enable_dtags = true
 else


### PR DESCRIPTION
Instead of repeating each executable target with and without rpath, this defines a global variable that controls the same.