### PR TITLE
meson: Refactor UAM detection and simplify summary

### DIFF
--- a/etc/uams/meson.build
+++ b/etc/uams/meson.build
@@ -47,7 +47,34 @@ if have_embedded_ssl
 endif
 
 if have_ssl
+    uams_randnum_sources = ['uams_randnum.c']
     uams_dhx_passwd_sources = ['uams_dhx_passwd.c']
+
+    shared_module(
+        'uams_randnum',
+        uams_randnum_sources,
+        include_directories: root_includes,
+        dependencies: [crack, pam, ssl_deps, nettle],
+        link_with: ssl_links,
+        name_prefix: '',
+        name_suffix: 'so',
+        install: true,
+        install_dir: libdir / 'netatalk',
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
+    static_library(
+        'uams_randnum',
+        uams_randnum_sources,
+        include_directories: root_includes,
+        dependencies: [crack, pam, ssl_deps, nettle],
+        link_with: ssl_links,
+        name_prefix: '',
+        install: true,
+        install_dir: libdir / 'netatalk',
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
 
     shared_module(
         'uams_dhx_passwd',
@@ -216,37 +243,7 @@ else
     )
 endif
 
-if have_ssl
-    uams_randnum_sources = ['uams_randnum.c']
-
-    shared_module(
-        'uams_randnum',
-        uams_randnum_sources,
-        include_directories: root_includes,
-        dependencies: [crack, pam, ssl_deps, nettle],
-        link_with: ssl_links,
-        name_prefix: '',
-        name_suffix: 'so',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: rpath_libdir,
-        install_rpath: rpath_libdir,
-    )
-    static_library(
-        'uams_randnum',
-        uams_randnum_sources,
-        include_directories: root_includes,
-        dependencies: [crack, pam, ssl_deps, nettle],
-        link_with: ssl_links,
-        name_prefix: '',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: rpath_libdir,
-        install_rpath: rpath_libdir,
-    )
-endif
-
-if enable_pgp_uam
+if have_pgp_uam
     uams_pgp_sources = ['uams_pgp.c']
 
     shared_module(

--- a/meson.build
+++ b/meson.build
@@ -1640,7 +1640,7 @@ else
 
     if have_pam
         cdata.set('USE_PAM', 1)
-        uams_options += 'PAM'
+        uams_options += 'PAM '
         pampath = pam_dir / 'etc/pam.d'
         # Debian/SuSE
         if fs.exists(pampath / 'common-auth')
@@ -1721,7 +1721,7 @@ else
     have_shadow = (cc.has_header('shadow.h'))
     if have_shadow
         cdata.set('SHADOWPW', 1)
-        uams_options += ' SHADOW'
+        uams_options += 'SHADOW'
     else
         have_shadow = false
         warning('Shadow password support requested but required header not found')
@@ -2128,8 +2128,6 @@ summary(summary_info, bool_yn: true, section: 'Compilation:')
 
 # Configuration summary
 
-uams_using_options = '(' + uams_options + ')'
-
 summary({'Netatalk version': netatalk_version}, section: 'Configuration Summary:')
 summary_info = {
     '  Initscript style': init_style,
@@ -2148,30 +2146,19 @@ summary_info = {
 summary(summary_info, bool_yn: true, section: '  CNID:')
 
 summary_info = {
-    '  Kerberos V': have_krb5_uam,
-    '  PGP': enable_pgp_uam,
-    '  Randnum': '(afppasswd)',
-    '  clrtxt': uams_using_options,
-    '  guest': true,
+    '  Access control': uams_options,
 }
-if have_ssl
-    summary_info += {
-        '  DHX': uams_using_options,
-    }
-else
-    summary_info += {
-        '  DHX': false,
-    }
-endif
-if have_libgcrypt
-    summary_info += {
-        '  DHX2': uams_using_options,
-    }
-else
-    summary_info += {
-        '  DHX2': false,
-    }
-endif
+summary(summary_info, bool_yn: true, section: '  Authentication:')
+
+summary_info = {
+    '  ClearTxt': true,
+    '  DHX': have_ssl,
+    '  DHX2': have_libgcrypt,
+    '  Guest': true,
+    '  Kerberos V': have_krb5_uam,
+    '  PGP': have_pgp_uam,
+    '  RandNum': have_ssl,
+}
 summary(summary_info, bool_yn: true, section: '  UAMs:')
 
 summary_info = {


### PR DESCRIPTION
- Build Randnum and PGP UAMs only when the SSL dependency is present.
- In the summary, print the access control method separately, and have simple yes/no for individual UAMs