### PR TITLE
[2.4] meson: Better way to handle rpath executable targets

### DIFF
--- a/bin/ad/meson.build
+++ b/bin/ad/meson.build
@@ -14,26 +14,14 @@ if have_acls
     ad_deps += acl_deps
 endif
 
-if enable_rpath
-    executable(
-        'ad',
-        ad_sources,
-        include_directories: root_includes,
-        dependencies: ad_deps,
-        link_with: [libatalk, libcnid],
-        c_args: [ad, dversion],
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'ad',
-        ad_sources,
-        include_directories: root_includes,
-        dependencies: ad_deps,
-        link_with: [libatalk, libcnid],
-        c_args: [ad, dversion],
-        install: true,
-    )
-endif
+executable(
+    'ad',
+    ad_sources,
+    include_directories: root_includes,
+    dependencies: ad_deps,
+    link_with: [libatalk, libcnid],
+    c_args: [ad, dversion],
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/bin/adv1tov2/meson.build
+++ b/bin/adv1tov2/meson.build
@@ -1,19 +1,9 @@
-if enable_rpath
-    executable(
-        'adv1tov2',
-        'adv1tov2.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'adv1tov2',
-        'adv1tov2.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-    )
-endif
+executable(
+    'adv1tov2',
+    'adv1tov2.c',
+    include_directories: root_includes,
+    link_with: libatalk,
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/bin/aecho/meson.build
+++ b/bin/aecho/meson.build
@@ -1,19 +1,9 @@
-if enable_rpath
-    executable(
-        'aecho',
-        'aecho.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'aecho',
-        'aecho.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-    )
-endif
+executable(
+    'aecho',
+    'aecho.c',
+    include_directories: root_includes,
+    link_with: libatalk,
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/bin/afppasswd/meson.build
+++ b/bin/afppasswd/meson.build
@@ -17,28 +17,15 @@ if have_cracklib
     afppasswd_deps += crack
 endif
 
-if enable_rpath
-    executable(
-        'afppasswd',
-        'afppasswd.c',
-        include_directories: root_includes,
-        dependencies: afppasswd_deps,
-        link_with: afppasswd_libs,
-        c_args: [afpdpwfile, dversion],
-        install: true,
-        install_mode: 'rwsr-xr-x',
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'afppasswd',
-        'afppasswd.c',
-        include_directories: root_includes,
-        dependencies: afppasswd_deps,
-        link_with: afppasswd_libs,
-        c_args: [afpdpwfile, dversion],
-        install: true,
-        install_mode: 'rwsr-xr-x',
-    )
-endif
+executable(
+    'afppasswd',
+    'afppasswd.c',
+    include_directories: root_includes,
+    dependencies: afppasswd_deps,
+    link_with: afppasswd_libs,
+    c_args: [afpdpwfile, dversion],
+    install: true,
+    install_mode: 'rwsr-xr-x',
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/bin/getzones/meson.build
+++ b/bin/getzones/meson.build
@@ -1,19 +1,9 @@
-if enable_rpath
-    executable(
-        'getzones',
-        'getzones.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'getzones',
-        'getzones.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-    )
-endif
+executable(
+    'getzones',
+    'getzones.c',
+    include_directories: root_includes,
+    link_with: libatalk,
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/bin/megatron/meson.build
+++ b/bin/megatron/meson.build
@@ -7,27 +7,16 @@ megatron_sources = [
     'updcrc.c',
 ]
 
-if enable_rpath
-    executable(
-        'megatron',
-        megatron_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: dversion,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'megatron',
-        megatron_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: dversion,
-        install: true,
-    )
-endif
+executable(
+    'megatron',
+    megatron_sources,
+    include_directories: root_includes,
+    link_with: libatalk,
+    c_args: dversion,
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)
 
 megatron_symlinks = [
     'binheader',

--- a/bin/misc/meson.build
+++ b/bin/misc/meson.build
@@ -23,27 +23,15 @@ executable(
 )
 
 if have_ldap
-    if enable_rpath
-        executable(
-            'afpldaptest',
-            'uuidtest.c',
-            include_directories: root_includes,
-            dependencies: ldap,
-            link_with: libatalk,
-            c_args: acl_ldapconf,
-            install: true,
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-    else
-        executable(
-            'afpldaptest',
-            'uuidtest.c',
-            include_directories: root_includes,
-            dependencies: ldap,
-            link_with: libatalk,
-            c_args: acl_ldapconf,
-            install: true,
-        )
-    endif
+    executable(
+        'afpldaptest',
+        'uuidtest.c',
+        include_directories: root_includes,
+        dependencies: ldap,
+        link_with: libatalk,
+        c_args: acl_ldapconf,
+        install: true,
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
 endif

--- a/bin/nbp/meson.build
+++ b/bin/nbp/meson.build
@@ -1,51 +1,27 @@
-if enable_rpath
-    executable(
-        'nbplkup',
-        'nbplkup.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-    executable(
-        'nbprgstr',
-        'nbprgstr.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-    executable(
-        'nbpunrgstr',
-        'nbpunrgstr.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'nbplkup',
-        'nbplkup.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-    )
-    executable(
-        'nbprgstr',
-        'nbprgstr.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-    )
-    executable(
-        'nbpunrgstr',
-        'nbpunrgstr.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-    )
-endif
+executable(
+    'nbplkup',
+    'nbplkup.c',
+    include_directories: root_includes,
+    link_with: libatalk,
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)
+executable(
+    'nbprgstr',
+    'nbprgstr.c',
+    include_directories: root_includes,
+    link_with: libatalk,
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)
+executable(
+    'nbpunrgstr',
+    'nbpunrgstr.c',
+    include_directories: root_includes,
+    link_with: libatalk,
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/bin/pap/meson.build
+++ b/bin/pap/meson.build
@@ -1,35 +1,18 @@
-if enable_rpath
-    executable(
-        'pap',
-        'pap.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-    executable(
-        'papstatus',
-        'papstatus.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'pap',
-        'pap.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-    )
-    executable(
-        'papstatus',
-        'papstatus.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-    )
-endif
+executable(
+    'pap',
+    'pap.c',
+    include_directories: root_includes,
+    link_with: libatalk,
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)
+executable(
+    'papstatus',
+    'papstatus.c',
+    include_directories: root_includes,
+    link_with: libatalk,
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/bin/psorder/meson.build
+++ b/bin/psorder/meson.build
@@ -3,22 +3,12 @@ psorder_sources = [
     'psorder.c',
 ]
 
-if enable_rpath
-    executable(
-        'psorder',
-        psorder_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'psorder',
-        psorder_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-    )
-endif
+executable(
+    'psorder',
+    psorder_sources,
+    include_directories: root_includes,
+    link_with: libatalk,
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/bin/uniconv/meson.build
+++ b/bin/uniconv/meson.build
@@ -1,23 +1,12 @@
 uniconv_sources = ['iso8859_1_adapted.c', 'uniconv.c']
 
-if enable_rpath
-    executable(
-        'uniconv',
-        uniconv_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: dversion,
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'uniconv',
-        uniconv_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: dversion,
-        install: true,
-    )
-endif
+executable(
+    'uniconv',
+    uniconv_sources,
+    include_directories: root_includes,
+    link_with: libatalk,
+    c_args: dversion,
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/contrib/a2boot/meson.build
+++ b/contrib/a2boot/meson.build
@@ -8,26 +8,14 @@ a2boot_c_args = [
     '-D_PATH_P16_IMAGE="' + pkgconfdir + '/a2boot/ProDOS16 Image"',
 ]
 
-if enable_rpath
-    executable(
-        'a2boot',
-        'a2boot.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: a2boot_c_args,
-        install: true,
-        install_dir: sbindir,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'a2boot',
-        'a2boot.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: a2boot_c_args,
-        install: true,
-        install_dir: sbindir,
-    )
-endif
+executable(
+    'a2boot',
+    'a2boot.c',
+    include_directories: root_includes,
+    link_with: libatalk,
+    c_args: a2boot_c_args,
+    install: true,
+    install_dir: sbindir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/contrib/timelord/meson.build
+++ b/contrib/timelord/meson.build
@@ -1,21 +1,10 @@
-if enable_rpath
-    executable(
-        'timelord',
-        'timelord.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-        install_dir: sbindir,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'timelord',
-        'timelord.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        install: true,
-        install_dir: sbindir,
-    )
-endif
+executable(
+    'timelord',
+    'timelord.c',
+    include_directories: root_includes,
+    link_with: libatalk,
+    install: true,
+    install_dir: sbindir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -88,33 +88,19 @@ afpd_c_args = [
     uamdir,
 ]
 
-if enable_rpath
-    executable(
-        'afpd',
-        afpd_sources,
-        include_directories: root_includes,
-        link_with: [afpd_internal_deps, libatalk],
-        dependencies: afpd_external_deps,
-        c_args: afpd_c_args,
-        export_dynamic: true,
-        install: true,
-        install_dir: sbindir,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'afpd',
-        afpd_sources,
-        include_directories: root_includes,
-        link_with: [afpd_internal_deps, libatalk],
-        dependencies: afpd_external_deps,
-        c_args: afpd_c_args,
-        export_dynamic: true,
-        install: true,
-        install_dir: sbindir,
-    )
-endif
+executable(
+    'afpd',
+    afpd_sources,
+    include_directories: root_includes,
+    link_with: [afpd_internal_deps, libatalk],
+    dependencies: afpd_external_deps,
+    c_args: afpd_c_args,
+    export_dynamic: true,
+    install: true,
+    install_dir: sbindir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)
 
 executable(
     'fce',

--- a/etc/atalkd/meson.build
+++ b/etc/atalkd/meson.build
@@ -11,26 +11,14 @@ atalkd_sources = [
 
 atalkd_c_args = ['-D_PATH_ATALKDCONF="' + pkgconfdir + '/atalkd.conf"', dversion]
 
-if enable_rpath
-    executable(
-        'atalkd',
-        atalkd_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: atalkd_c_args,
-        install: true,
-        install_dir: sbindir,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'atalkd',
-        atalkd_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: atalkd_c_args,
-        install: true,
-        install_dir: sbindir,
-    )
-endif
+executable(
+    'atalkd',
+    atalkd_sources,
+    include_directories: root_includes,
+    link_with: libatalk,
+    c_args: atalkd_c_args,
+    install: true,
+    install_dir: sbindir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/etc/cnid_dbd/meson.build
+++ b/etc/cnid_dbd/meson.build
@@ -33,73 +33,40 @@ if use_dbd_backend
         'pack.c',
     ]
 
-    if enable_rpath
-        executable(
-            'cnid_dbd',
-            cnid_dbd_sources,
-            include_directories: [bdb_includes, root_includes],
-            link_with: libatalk,
-            dependencies: db,
-            c_args: [cnid_dbd, dversion],
-            link_args: bdb_link_args,
-            install: true,
-            install_dir: sbindir,
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-        executable(
-            'cnid_metad',
-            cnid_metad_sources,
-            include_directories: root_includes,
-            link_with: libatalk,
-            c_args: [cnid_dbd, dversion],
-            install: true,
-            install_dir: sbindir,
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-        executable(
-            'dbd',
-            dbd_sources,
-            include_directories: [bdb_includes, root_includes],
-            link_with: libatalk,
-            dependencies: db,
-            c_args: dversion,
-            link_args: [dversion, bdb_link_args],
-            install: true,
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-    else
-        executable(
-            'cnid_dbd',
-            cnid_dbd_sources,
-            include_directories: [bdb_includes, root_includes],
-            link_with: libatalk,
-            dependencies: db,
-            c_args: [cnid_dbd, dversion],
-            link_args: bdb_link_args,
-            install: true,
-            install_dir: sbindir,
-        )
-        executable(
-            'cnid_metad',
-            cnid_metad_sources,
-            include_directories: root_includes,
-            link_with: libatalk,
-            c_args: [cnid_dbd, dversion],
-            install: true,
-            install_dir: sbindir,
-        )
-        executable(
-            'dbd',
-            dbd_sources,
-            include_directories: [bdb_includes, root_includes],
-            link_with: libatalk,
-            dependencies: db,
-            c_args: dversion,
-            link_args: [dversion, bdb_link_args],
-            install: true,
-        )
-    endif
+    executable(
+        'cnid_dbd',
+        cnid_dbd_sources,
+        include_directories: [bdb_includes, root_includes],
+        link_with: libatalk,
+        dependencies: db,
+        c_args: [cnid_dbd, dversion],
+        link_args: bdb_link_args,
+        install: true,
+        install_dir: sbindir,
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
+    executable(
+        'cnid_metad',
+        cnid_metad_sources,
+        include_directories: root_includes,
+        link_with: libatalk,
+        c_args: [cnid_dbd, dversion],
+        install: true,
+        install_dir: sbindir,
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
+    executable(
+        'dbd',
+        dbd_sources,
+        include_directories: [bdb_includes, root_includes],
+        link_with: libatalk,
+        dependencies: db,
+        c_args: dversion,
+        link_args: [dversion, bdb_link_args],
+        install: true,
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
 endif

--- a/etc/papd/meson.build
+++ b/etc/papd/meson.build
@@ -21,51 +21,29 @@ papd_c_args = [
     dversion,
 ]
 
-if enable_rpath
-    executable(
-        'papd',
-        papd_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        dependencies: cups,
-        c_args: papd_c_args,
-        export_dynamic: true,
-        install: true,
-        install_dir: sbindir,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-    executable(
-        'showppd',
-        ['ppd.c', 'showppd.c'],
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: '-DSHOWPPD',
-        install: true,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'papd',
-        papd_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        dependencies: cups,
-        c_args: papd_c_args,
-        export_dynamic: true,
-        install: true,
-        install_dir: sbindir,
-    )
-    executable(
-        'showppd',
-        ['ppd.c', 'showppd.c'],
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: '-DSHOWPPD',
-        install: true,
-    )
-endif
+executable(
+    'papd',
+    papd_sources,
+    include_directories: root_includes,
+    link_with: libatalk,
+    dependencies: cups,
+    c_args: papd_c_args,
+    export_dynamic: true,
+    install: true,
+    install_dir: sbindir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)
+executable(
+    'showppd',
+    ['ppd.c', 'showppd.c'],
+    include_directories: root_includes,
+    link_with: libatalk,
+    c_args: '-DSHOWPPD',
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)
 
 if have_cups and spooldir_required
     install_emptydir(spooldir, install_mode: 'rwxrwxrwx')

--- a/etc/psf/meson.build
+++ b/etc/psf/meson.build
@@ -7,53 +7,30 @@ psf_c_args = [
     '-D_PATH_PAGECOUNT="' + datadir + '/pagecount.ps"',
 ]
 
-if enable_rpath
-    executable(
-        'psa',
-        'psa.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: psf_c_args,
-        export_dynamic: true,
-        install: true,
-        install_dir: libexecdir,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-    executable(
-        'psf',
-        'psf.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: psf_c_args,
-        export_dynamic: true,
-        install: true,
-        install_dir: libexecdir,
-        build_rpath: libdir,
-        install_rpath: libdir,
-    )
-else
-    executable(
-        'psa',
-        'psa.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: psf_c_args,
-        export_dynamic: true,
-        install: true,
-        install_dir: libexecdir,
-    )
-    executable(
-        'psf',
-        'psf.c',
-        include_directories: root_includes,
-        link_with: libatalk,
-        c_args: psf_c_args,
-        export_dynamic: true,
-        install: true,
-        install_dir: libexecdir,
-    )
-endif
+executable(
+    'psa',
+    'psa.c',
+    include_directories: root_includes,
+    link_with: libatalk,
+    c_args: psf_c_args,
+    export_dynamic: true,
+    install: true,
+    install_dir: libexecdir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)
+executable(
+    'psf',
+    'psf.c',
+    include_directories: root_includes,
+    link_with: libatalk,
+    c_args: psf_c_args,
+    export_dynamic: true,
+    install: true,
+    install_dir: libexecdir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)
 
 install_data('pagecount.ps', install_dir: datadir / 'netatalk')
 

--- a/etc/uams/meson.build
+++ b/etc/uams/meson.build
@@ -50,108 +50,88 @@ endif
 
 if have_ssl
     uams_dhx_passwd_sources = ['uams_dhx_passwd.c']
+    uams_randnum_sources = ['uams_randnum.c']
 
-    if enable_rpath
-        uams_dhx_passwd = shared_module(
-            'uams_dhx_passwd',
-            uams_dhx_passwd_sources,
-            include_directories: root_includes,
-            dependencies: [crypt, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            name_suffix: 'so',
-            install: true,
-            install_dir: libdir / 'netatalk',
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-        uams_dhx_passwd = static_library(
-            'uams_dhx_passwd',
-            uams_dhx_passwd_sources,
-            include_directories: root_includes,
-            dependencies: [crypt, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            install: true,
-            install_dir: libdir / 'netatalk',
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-    else
-        uams_dhx_passwd = shared_module(
-            'uams_dhx_passwd',
-            uams_dhx_passwd_sources,
-            include_directories: root_includes,
-            dependencies: [crypt, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            name_suffix: 'so',
-            install: true,
-            install_dir: libdir / 'netatalk',
-        )
-        uams_dhx_passwd = static_library(
-            'uams_dhx_passwd',
-            uams_dhx_passwd_sources,
-            include_directories: root_includes,
-            dependencies: [crypt, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            install: true,
-            install_dir: libdir / 'netatalk',
-        )
-    endif
+    uams_randnum = shared_module(
+        'uams_randnum',
+        uams_randnum_sources,
+        include_directories: root_includes,
+        dependencies: [crack, pam, ssl_deps],
+        link_with: ssl_links,
+        name_prefix: '',
+        name_suffix: 'so',
+        install: true,
+        install_dir: libdir / 'netatalk',
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
+    uams_randnum = static_library(
+        'uams_randnum',
+        uams_randnum_sources,
+        include_directories: root_includes,
+        dependencies: [crack, pam, ssl_deps],
+        link_with: ssl_links,
+        name_prefix: '',
+        install: true,
+        install_dir: libdir / 'netatalk',
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
+
+    uams_dhx_passwd = shared_module(
+        'uams_dhx_passwd',
+        uams_dhx_passwd_sources,
+        include_directories: root_includes,
+        dependencies: [crypt, ssl_deps],
+        link_with: ssl_links,
+        name_prefix: '',
+        name_suffix: 'so',
+        install: true,
+        install_dir: libdir / 'netatalk',
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
+    uams_dhx_passwd = static_library(
+        'uams_dhx_passwd',
+        uams_dhx_passwd_sources,
+        include_directories: root_includes,
+        dependencies: [crypt, ssl_deps],
+        link_with: ssl_links,
+        name_prefix: '',
+        install: true,
+        install_dir: libdir / 'netatalk',
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
+
     if have_pam
         uams_dhx_pam_sources = ['uams_dhx_pam.c']
 
-        if enable_rpath
-            uams_dhx_pam = shared_module(
-                'uams_dhx_pam',
-                uams_dhx_pam_sources,
-                include_directories: [pam_includes, root_includes],
-                dependencies: [pam, ssl_deps],
-                link_with: ssl_links,
-                name_prefix: '',
-                name_suffix: 'so',
-                install: true,
-                install_dir: libdir / 'netatalk',
-                build_rpath: libdir,
-                install_rpath: libdir,
-            )
-            uams_dhx_pam = static_library(
-                'uams_dhx_pam',
-                uams_dhx_pam_sources,
-                include_directories: [pam_includes, root_includes],
-                dependencies: [pam, ssl_deps],
-                link_with: ssl_links,
-                name_prefix: '',
-                install: true,
-                install_dir: libdir / 'netatalk',
-                build_rpath: libdir,
-                install_rpath: libdir,
-            )
-        else
-            uams_dhx_pam = shared_module(
-                'uams_dhx_pam',
-                uams_dhx_pam_sources,
-                include_directories: [pam_includes, root_includes],
-                dependencies: [pam, ssl_deps],
-                link_with: ssl_links,
-                name_prefix: '',
-                name_suffix: 'so',
-                install: true,
-                install_dir: libdir / 'netatalk',
-            )
-            uams_dhx_pam = static_library(
-                'uams_dhx_pam',
-                uams_dhx_pam_sources,
-                include_directories: [pam_includes, root_includes],
-                dependencies: [pam, ssl_deps],
-                link_with: ssl_links,
-                name_prefix: '',
-                install: true,
-                install_dir: libdir / 'netatalk',
-            )
-        endif
+        uams_dhx_pam = shared_module(
+            'uams_dhx_pam',
+            uams_dhx_pam_sources,
+            include_directories: [pam_includes, root_includes],
+            dependencies: [pam, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            name_suffix: 'so',
+            install: true,
+            install_dir: libdir / 'netatalk',
+            build_rpath: rpath_libdir,
+            install_rpath: rpath_libdir,
+        )
+        uams_dhx_pam = static_library(
+            'uams_dhx_pam',
+            uams_dhx_pam_sources,
+            include_directories: [pam_includes, root_includes],
+            dependencies: [pam, ssl_deps],
+            link_with: ssl_links,
+            name_prefix: '',
+            install: true,
+            install_dir: libdir / 'netatalk',
+            build_rpath: rpath_libdir,
+            install_rpath: rpath_libdir,
+        )
 
         install_symlink(
             'uams_dhx.so',
@@ -263,60 +243,6 @@ else
         install_dir: libdir / 'netatalk',
         pointing_to: 'uams_passwd.so',
     )
-endif
-
-if have_ssl
-    uams_randnum_sources = ['uams_randnum.c']
-
-    if enable_rpath
-        uams_randnum = shared_module(
-            'uams_randnum',
-            uams_randnum_sources,
-            include_directories: root_includes,
-            dependencies: [crack, pam, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            name_suffix: 'so',
-            install: true,
-            install_dir: libdir / 'netatalk',
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-        uams_randnum = static_library(
-            'uams_randnum',
-            uams_randnum_sources,
-            include_directories: root_includes,
-            dependencies: [crack, pam, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            install: true,
-            install_dir: libdir / 'netatalk',
-            build_rpath: libdir,
-            install_rpath: libdir,
-        )
-    else
-        uams_randnum = shared_module(
-            'uams_randnum',
-            uams_randnum_sources,
-            include_directories: root_includes,
-            dependencies: [crack, pam, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            name_suffix: 'so',
-            install: true,
-            install_dir: libdir / 'netatalk',
-        )
-        uams_randnum = static_library(
-            'uams_randnum',
-            uams_randnum_sources,
-            include_directories: root_includes,
-            dependencies: [crack, pam, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
-            install: true,
-            install_dir: libdir / 'netatalk',
-        )
-    endif
 endif
 
 if enable_pgp_uam

--- a/meson.build
+++ b/meson.build
@@ -399,6 +399,12 @@ else
     enable_rpath = get_option('with-rpath')
 endif
 
+if enable_rpath
+    rpath_libdir = libdir
+else
+    rpath_libdir = ''
+endif
+
 #
 # Check for the Berkeley DB library
 #


### PR DESCRIPTION
Instead of repeating each executable target with and without rpath, this defines a global variable that controls the same.