### PR TITLE
[3.2] meson: Allow choosing shared or static libraries to build

### DIFF
--- a/etc/uams/meson.build
+++ b/etc/uams/meson.build
@@ -1,43 +1,38 @@
+if get_option('default_library') != 'static'
+    build_shared_lib = true
+else
+    build_shared_lib = false
+endif
+
+if host_os == 'darwin'
+    lib_suffix = 'so'
+else
+    lib_suffix = []
+endif
+
 uams_guest_sources = ['uams_guest.c']
 
-shared_module(
+library(
     'uams_guest',
     uams_guest_sources,
     include_directories: root_includes,
     name_prefix: '',
-    name_suffix: 'so',
-    install: true,
-    install_dir: libdir / 'netatalk',
-)
-
-static_library(
-    'uams_guest',
-    uams_guest_sources,
-    include_directories: root_includes,
-    name_prefix: '',
+    name_suffix: lib_suffix,
+    override_options: 'b_lundef=false',
     install: true,
     install_dir: libdir / 'netatalk',
 )
 
 uams_passwd_sources = ['uams_passwd.c']
 
-shared_module(
+library(
     'uams_passwd',
     uams_passwd_sources,
     include_directories: root_includes,
     dependencies: [crypt],
     name_prefix: '',
-    name_suffix: 'so',
-    install: true,
-    install_dir: libdir / 'netatalk',
-)
-
-static_library(
-    'uams_passwd',
-    uams_passwd_sources,
-    include_directories: root_includes,
-    dependencies: [crypt],
-    name_prefix: '',
+    name_suffix: lib_suffix,
+    override_options: 'b_lundef=false',
     install: true,
     install_dir: libdir / 'netatalk',
 )
@@ -52,52 +47,30 @@ if have_ssl
     uams_randnum_sources = ['uams_randnum.c']
     uams_dhx_passwd_sources = ['uams_dhx_passwd.c']
 
-    shared_module(
+    library(
         'uams_randnum',
         uams_randnum_sources,
         include_directories: root_includes,
         dependencies: [crack, pam, ssl_deps],
         link_with: ssl_links,
         name_prefix: '',
-        name_suffix: 'so',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: rpath_libdir,
-        install_rpath: rpath_libdir,
-    )
-    static_library(
-        'uams_randnum',
-        uams_randnum_sources,
-        include_directories: root_includes,
-        dependencies: [crack, pam, ssl_deps],
-        link_with: ssl_links,
-        name_prefix: '',
+        name_suffix: lib_suffix,
+        override_options: 'b_lundef=false',
         install: true,
         install_dir: libdir / 'netatalk',
         build_rpath: rpath_libdir,
         install_rpath: rpath_libdir,
     )
 
-    shared_module(
+    library(
         'uams_dhx_passwd',
         uams_dhx_passwd_sources,
         include_directories: root_includes,
         dependencies: [crypt, ssl_deps],
         link_with: ssl_links,
         name_prefix: '',
-        name_suffix: 'so',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: rpath_libdir,
-        install_rpath: rpath_libdir,
-    )
-    static_library(
-        'uams_dhx_passwd',
-        uams_dhx_passwd_sources,
-        include_directories: root_includes,
-        dependencies: [crypt, ssl_deps],
-        link_with: ssl_links,
-        name_prefix: '',
+        name_suffix: lib_suffix,
+        override_options: 'b_lundef=false',
         install: true,
         install_dir: libdir / 'netatalk',
         build_rpath: rpath_libdir,
@@ -107,38 +80,29 @@ if have_ssl
     if have_pam
         uams_dhx_pam_sources = ['uams_dhx_pam.c']
 
-        shared_module(
+        library(
             'uams_dhx_pam',
             uams_dhx_pam_sources,
             include_directories: [pam_includes, root_includes],
             dependencies: [pam, ssl_deps],
             link_with: ssl_links,
             name_prefix: '',
-            name_suffix: 'so',
-            install: true,
-            install_dir: libdir / 'netatalk',
-            build_rpath: rpath_libdir,
-            install_rpath: rpath_libdir,
-        )
-        static_library(
-            'uams_dhx_pam',
-            uams_dhx_pam_sources,
-            include_directories: [pam_includes, root_includes],
-            dependencies: [pam, ssl_deps],
-            link_with: ssl_links,
-            name_prefix: '',
+            name_suffix: lib_suffix,
+            override_options: 'b_lundef=false',
             install: true,
             install_dir: libdir / 'netatalk',
             build_rpath: rpath_libdir,
             install_rpath: rpath_libdir,
         )
 
-        install_symlink(
-            'uams_dhx.so',
-            install_dir: libdir / 'netatalk',
-            pointing_to: 'uams_dhx_pam.so',
-        )
-    else
+        if build_shared_lib
+            install_symlink(
+                'uams_dhx.so',
+                install_dir: libdir / 'netatalk',
+                pointing_to: 'uams_dhx_pam.so',
+            )
+        endif
+    elif build_shared_lib
         install_symlink(
             'uams_dhx.so',
             install_dir: libdir / 'netatalk',
@@ -150,56 +114,40 @@ endif
 if have_libgcrypt
     uams_dhx2_passwd_sources = ['uams_dhx2_passwd.c']
 
-    shared_module(
+    library(
         'uams_dhx2_passwd',
         uams_dhx2_passwd_sources,
         include_directories: root_includes,
         dependencies: [crypt, libgcrypt],
         name_prefix: '',
-        name_suffix: 'so',
-        install: true,
-        install_dir: libdir / 'netatalk',
-    )
-
-    static_library(
-        'uams_dhx2_passwd',
-        uams_dhx2_passwd_sources,
-        include_directories: root_includes,
-        dependencies: [crypt, libgcrypt],
-        name_prefix: '',
+        name_suffix: lib_suffix,
+        override_options: 'b_lundef=false',
         install: true,
         install_dir: libdir / 'netatalk',
     )
     if have_pam
         uams_dhx2_pam_sources = ['uams_dhx2_pam.c']
 
-        shared_module(
+        library(
             'uams_dhx2_pam',
             uams_dhx2_pam_sources,
             include_directories: [pam_includes, root_includes],
             dependencies: [pam, libgcrypt],
             name_prefix: '',
-            name_suffix: 'so',
+            name_suffix: lib_suffix,
+            override_options: 'b_lundef=false',
             install: true,
             install_dir: libdir / 'netatalk',
         )
 
-        static_library(
-            'uams_dhx2_pam',
-            uams_dhx2_pam_sources,
-            include_directories: [pam_includes, root_includes],
-            dependencies: [pam, libgcrypt],
-            name_prefix: '',
-            install: true,
-            install_dir: libdir / 'netatalk',
-        )
-
-        install_symlink(
-            'uams_dhx2.so',
-            install_dir: libdir / 'netatalk',
-            pointing_to: 'uams_dhx2_pam.so',
-        )
-    else
+        if build_shared_lib
+            install_symlink(
+                'uams_dhx2.so',
+                install_dir: libdir / 'netatalk',
+                pointing_to: 'uams_dhx2_pam.so',
+            )
+        endif
+    elif build_shared_lib
         install_symlink(
             'uams_dhx2.so',
             install_dir: libdir / 'netatalk',
@@ -211,33 +159,26 @@ endif
 if have_pam
     uams_pam_sources = ['uams_pam.c']
 
-    shared_module(
+    library(
         'uams_pam',
         uams_pam_sources,
         include_directories: [pam_includes, root_includes],
         dependencies: pam,
         name_prefix: '',
-        name_suffix: 'so',
+        name_suffix: lib_suffix,
+        override_options: 'b_lundef=false',
         install: true,
         install_dir: libdir / 'netatalk',
     )
 
-    static_library(
-        'uams_pam',
-        uams_pam_sources,
-        include_directories: [pam_includes, root_includes],
-        dependencies: pam,
-        name_prefix: '',
-        install: true,
-        install_dir: libdir / 'netatalk',
-    )
-
-    install_symlink(
-        'uams_clrtxt.so',
-        install_dir: libdir / 'netatalk',
-        pointing_to: 'uams_pam.so',
-    )
-else
+    if build_shared_lib
+        install_symlink(
+            'uams_clrtxt.so',
+            install_dir: libdir / 'netatalk',
+            pointing_to: 'uams_pam.so',
+        )
+    endif
+elif build_shared_lib
     install_symlink(
         'uams_clrtxt.so',
         install_dir: libdir / 'netatalk',
@@ -248,23 +189,14 @@ endif
 if have_pgp_uam
     uams_pgp_sources = ['uams_pgp.c']
 
-    shared_module(
+    library(
         'uams_pgp',
         uams_pgp_sources,
         include_directories: root_includes,
         dependencies: [crypt, ssl_deps],
         name_prefix: '',
-        name_suffix: 'so',
-        install: true,
-        install_dir: libdir / 'netatalk',
-    )
-
-    static_library(
-        'uams_pgp',
-        uams_pgp_sources,
-        include_directories: root_includes,
-        dependencies: [crypt, ssl_deps],
-        name_prefix: '',
+        name_suffix: lib_suffix,
+        override_options: 'b_lundef=false',
         install: true,
         install_dir: libdir / 'netatalk',
     )
@@ -273,25 +205,15 @@ endif
 if have_krb5_uam
     uams_gss_sources = ['uams_gss.c']
 
-    shared_module(
+    library(
         'uams_gss',
         uams_gss_sources,
         include_directories: [gssapi_includes, root_includes],
         dependencies: gss_libs,
         c_args: kerberos_c_args,
         name_prefix: '',
-        name_suffix: 'so',
-        install: true,
-        install_dir: libdir / 'netatalk',
-    )
-
-    static_library(
-        'uams_gss',
-        uams_gss_sources,
-        include_directories: [gssapi_includes, root_includes],
-        dependencies: gss_libs,
-        c_args: kerberos_c_args,
-        name_prefix: '',
+        name_suffix: lib_suffix,
+        override_options: 'b_lundef=false',
         install: true,
         install_dir: libdir / 'netatalk',
     )

--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -31,7 +31,7 @@ if have_spotlight
     libatalk_libs += libtalloc
 endif
 
-libatalk = both_libraries(
+libatalk = library(
     'atalk',
     libatalk_sources,
     include_directories: root_includes,


### PR DESCRIPTION
This change respects the `-Ddefault_library` meson option and enables or disables the building or shared or static libraries.