### PR TITLE
meson: Control the MySQL CNID backend, and support MariaDB

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,6 @@ env:
     libkrb5-dev \
     libldap2-dev \
     libmariadb-dev \
-    libmariadb-dev-compat \
     libpam0g-dev \
     libtalloc-dev \
     libtirpc-dev \
@@ -102,6 +101,7 @@ jobs:
             libtracker \
             libxslt \
             linux-pam-dev \
+            mariadb-dev \
             meson \
             nettle-dev \
             ninja \
@@ -146,6 +146,7 @@ jobs:
             docbook-xsl \
             gcc \
             libxslt \
+            mariadb-clients \
             meson \
             nettle \
             ninja \
@@ -224,6 +225,7 @@ jobs:
             libtalloc-devel \
             libxslt \
             meson \
+            mysql-devel \
             nettle-devel \
             ninja-build \
             openldap-devel \
@@ -361,6 +363,7 @@ jobs:
               libgcrypt \
               libxslt \
               meson \
+              mysql80-client \
               nettle \
               openldap26-client \
               perl5 \
@@ -403,6 +406,7 @@ jobs:
               libgcrypt \
               libxslt \
               meson \
+              mysql84-client \
               nettle \
               openldap26-client-2.6.8 \
               perl5 \
@@ -453,6 +457,7 @@ jobs:
               libgcrypt \
               libxslt \
               meson \
+              mysql-client \
               nettle \
               p5-Net-DBus \
               perl \
@@ -501,6 +506,7 @@ jobs:
               libnettle \
               libtalloc \
               libxslt \
+              mariadb-client \
               meson \
               openldap-client-2.6.7v0 \
               openpam \
@@ -581,6 +587,7 @@ jobs:
               libgcrypt \
               libxslt \
               meson \
+              mysql-client \
               nettle \
               talloc
           run: |

--- a/libatalk/cnid/meson.build
+++ b/libatalk/cnid/meson.build
@@ -11,7 +11,7 @@ endif
 if use_mysql_backend
     subdir('mysql')
     libcnid_libs += libcnid_mysql
-    libcnid_deps += mysqlclient
+    libcnid_deps += mysql_deps
 endif
 
 cnid_sources = ['cnid_init.c', 'cnid.c']

--- a/libatalk/cnid/mysql/meson.build
+++ b/libatalk/cnid/mysql/meson.build
@@ -4,6 +4,6 @@ libcnid_mysql = static_library(
     'cnid_mysql',
     libcnid_mysql_sources,
     include_directories: root_includes,
-    dependencies: mysqlclient,
+    dependencies: mysql_deps,
     install: false,
 )

--- a/meson.build
+++ b/meson.build
@@ -1534,16 +1534,23 @@ endif
 # Check for mysql CNID backend
 
 mysqlclient = dependency('mysqlclient', required: false)
+mariadb = dependency('mariadb', required: false)
 
-if not mysqlclient.found()
-    use_mysql_backend = false
-else
-    use_mysql_backend = (
-        mysqlclient.found()
-        and fs.exists(
-            mysqlclient.get_variable(pkgconfig: 'includedir') / 'mysql.h',
+use_mysql_backend = false
+
+if get_option('with-cnid-mysql-backend')
+    if mysqlclient.found()
+        mysql_deps = mysqlclient
+    else
+        mysql_deps = mariadb
+    endif
+    if mysql_deps.found()
+        use_mysql_backend = (
+            fs.exists(
+                mysql_deps.get_variable(pkgconfig: 'includedir') / 'mysql.h',
+            )
         )
-    )
+    endif
     if use_mysql_backend
         cnid_backends += ' mysql'
         cdata.set('CNID_BACKEND_MYSQL', 1)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -28,6 +28,12 @@ option(
     description: 'Compile LAST CNID scheme',
 )
 option(
+    'with-cnid-mysql-backend',
+    type: 'boolean',
+    value: true,
+    description: 'Compile MySQL CNID scheme',
+)
+option(
     'with-cracklib',
     type: 'boolean',
     value: true,
@@ -272,12 +278,6 @@ option(
     type: 'string',
     value: '',
     description: 'Set path to Netatalk lockfile',
-)
-option(
-    'with-mysql-config',
-    type: 'string',
-    value: 'mysql_config',
-    description: 'Set name of mysql-config binary',
 )
 option(
     'with-pam-path',


### PR DESCRIPTION
- When MySQL dependencies aren't available, fall back to MariaDB
- Introduce a `with-cnid-mysql-backend' option
- Remove obsolete `with-mysql-config' option
- Install *SQL dependencies in GitHub CI workflows

Note that the only platform where I failed to build the mysql backend, is Solaris 11. The stock mysql package is `mysql-57` which I think is a bit too old, and building mariadb from scratch in the CI workflow is too resource intensive and slow.