### PR TITLE
[3.2] meson: Control the MySQL CNID backend, and support MariaDB

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ env:
     libglib2.0-dev \
     libkrb5-dev \
     libldap2-dev \
-    libmysqlclient-dev \
+    libmariadb-dev \
     libpam0g-dev \
     libssl-dev \
     libtalloc-dev \
@@ -96,6 +96,7 @@ jobs:
             libtool \
             libtracker \
             linux-pam-dev \
+            mariadb-dev \
             meson \
             ninja \
             openldap-dev \
@@ -155,6 +156,7 @@ jobs:
             gcc \
             libtool \
             make \
+            mariadb-clients \
             meson \
             ninja \
             pkgconfig \
@@ -300,6 +302,7 @@ jobs:
             libtalloc-devel \
             libtool \
             meson \
+            mysql-devel \
             ninja-build \
             openldap-devel \
             openssl-devel \
@@ -504,6 +507,7 @@ jobs:
               libgcrypt \
               libtool \
               meson \
+              mysql80-client \
               openldap26-client \
               perl5 \
               pkgconf \
@@ -556,6 +560,7 @@ jobs:
               libressl \
               libtool \
               meson \
+              mysql84-client \
               openldap26-client-2.6.8 \
               pkgconf \
               talloc \
@@ -623,6 +628,7 @@ jobs:
               libressl \
               libtool \
               meson \
+              mysql-client \
               p5-Net-DBus \
               perl \
               pkg-config \
@@ -686,6 +692,7 @@ jobs:
               libgcrypt \
               libtalloc \
               libtool \
+              mariadb-client \
               meson \
               openldap-client-2.6.6v0 \
               openpam \
@@ -797,6 +804,7 @@ jobs:
               libevent \
               libgcrypt \
               meson \
+              mysql-client \
               talloc
           run: |
             set -e

--- a/libatalk/cnid/meson.build
+++ b/libatalk/cnid/meson.build
@@ -11,7 +11,7 @@ endif
 if use_mysql_backend
     subdir('mysql')
     libcnid_libs += libcnid_mysql
-    libcnid_deps += mysqlclient
+    libcnid_deps += mysql_deps
 endif
 
 cnid_sources = ['cnid_init.c', 'cnid.c']

--- a/libatalk/cnid/mysql/meson.build
+++ b/libatalk/cnid/mysql/meson.build
@@ -4,6 +4,6 @@ libcnid_mysql = static_library(
     'cnid_mysql',
     libcnid_mysql_sources,
     include_directories: root_includes,
-    dependencies: mysqlclient,
+    dependencies: mysql_deps,
     install: false,
 )

--- a/meson.build
+++ b/meson.build
@@ -1469,16 +1469,23 @@ endif
 # Check for mysql CNID backend
 
 mysqlclient = dependency('mysqlclient', required: false)
+mariadb = dependency('mariadb', required: false)
 
-if not mysqlclient.found()
-    use_mysql_backend = false
-else
-    use_mysql_backend = (
-        mysqlclient.found()
-        and fs.exists(
-            mysqlclient.get_variable(pkgconfig: 'includedir') / 'mysql.h',
+use_mysql_backend = false
+
+if get_option('with-cnid-mysql-backend')
+    if mysqlclient.found()
+        mysql_deps = mysqlclient
+    else
+        mysql_deps = mariadb
+    endif
+    if mysql_deps.found()
+        use_mysql_backend = (
+            fs.exists(
+                mysql_deps.get_variable(pkgconfig: 'includedir') / 'mysql.h',
+            )
         )
-    )
+    endif
     if use_mysql_backend
         cnid_backends += ' mysql'
         cdata.set('CNID_BACKEND_MYSQL', 1)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -28,6 +28,12 @@ option(
     description: 'Compile LAST CNID scheme',
 )
 option(
+    'with-cnid-mysql-backend',
+    type: 'boolean',
+    value: true,
+    description: 'Compile MySQL CNID scheme',
+)
+option(
     'with-cracklib',
     type: 'boolean',
     value: true,
@@ -254,12 +260,6 @@ option(
     type: 'string',
     value: '',
     description: 'Set path to Netatalk lockfile',
-)
-option(
-    'with-mysql-config',
-    type: 'string',
-    value: 'mysql_config',
-    description: 'Set name of mysql-config binary',
 )
 option(
     'with-pam-path',


### PR DESCRIPTION
- When MySQL dependencies aren't available, fall back to MariaDB
- Introduce a `with-cnid-mysql-backend' option
- Remove obsolete `with-mysql-config' option
- Install *SQL dependencies in GitHub CI workflows