### PR TITLE
meson: Install FreeBSD init script into correct location

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,11 +418,11 @@ jobs:
               -Dwith-pgp-uam=true
             meson compile -C build
             meson install -C build
-            /etc/rc.d/netatalk start
+            /usr/local/etc/rc.d/netatalk start
             sleep 2
             /usr/local/bin/asip-status localhost
-            /etc/rc.d/netatalk stop
-            /etc/rc.d/netatalk disable
+            /usr/local/etc/rc.d/netatalk stop
+            /usr/local/etc/rc.d/netatalk disable
             ninja -C build uninstall
 
   build-netbsd:

--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -50,7 +50,7 @@ if (
 endif
 
 if init_style == 'freebsd'
-    init_dir = '/etc/rc.d'
+    init_dir = '/usr/local/etc/rc.d'
     init_dirs += init_dir
     configure_file(
         input: 'rc.freebsd.tmpl',
@@ -63,7 +63,7 @@ if init_style == 'freebsd'
     if get_option('with-init-hooks')
         meson.add_install_script(
             find_program('sh'),
-            '/etc/rc.d/netatalk',
+            '/usr/local/etc/rc.d/netatalk',
             'enable',
         )
     endif


### PR DESCRIPTION
Non-system base packages should install their init scripts into `/usr/local/etc/rc.d` on FreeBSD.