### PR TITLE
[3.2] meson: Implement with-init-dir option

### DIFF
--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -3,6 +3,14 @@ if get_option('with-init-style') == 'none'
     init_dirs += init_dir
 endif
 
+init_dir_override = get_option('with-init-dir')
+
+if init_dir_override != ''
+    init_dir = init_dir_override
+else
+    init_dir = ''
+endif
+
 if (
     get_option('with-init-style') == 'debian'
     or get_option('with-init-style') == 'debian-systemd'
@@ -11,7 +19,9 @@ if (
     or get_option('with-init-style') == 'suse-systemd'
     or get_option('with-init-style') == 'systemd'
 )
-    init_dir = '/usr/lib/systemd/system'
+    if init_dir_override == ''
+        init_dir = '/usr/lib/systemd/system'
+    endif
     init_dirs += init_dir
     custom_target(
         'systemd',
@@ -31,7 +41,9 @@ if (
   get_option('with-init-style') == 'debian'
   or get_option('with-init-style') == 'debian-sysv'
 )
-    init_dir = '/etc/init.d'
+    if init_dir_override == ''
+        init_dir = '/etc/init.d'
+    endif
     init_dirs += init_dir
     custom_target(
         'debian_sysv',
@@ -55,7 +67,9 @@ if (
 endif
 
 if get_option('with-init-style') == 'freebsd'
-    init_dir = '/usr/local/etc/rc.d'
+    if init_dir_override == ''
+        init_dir = '/usr/local/etc/rc.d'
+    endif
     init_dirs += init_dir
     custom_target(
         'freebsd',
@@ -77,7 +91,9 @@ if get_option('with-init-style') == 'freebsd'
 endif
 
 if get_option('with-init-style') == 'netbsd'
-    init_dir = '/etc/rc.d'
+    if init_dir_override == ''
+        init_dir = '/etc/rc.d'
+    endif
     init_dirs += init_dir
     custom_target(
         'netbsd',
@@ -92,7 +108,9 @@ if get_option('with-init-style') == 'netbsd'
 endif
 
 if get_option('with-init-style') == 'openbsd'
-    init_dir = '/etc/rc.d'
+    if init_dir_override == ''
+        init_dir = '/etc/rc.d'
+    endif
     init_dirs += init_dir
     custom_target(
         'freebsd',
@@ -114,7 +132,9 @@ if get_option('with-init-style') == 'openbsd'
 endif
 
 if get_option('with-init-style') == 'solaris'
-    init_dir = '/lib/svc/manifest/network'
+    if init_dir_override == ''
+        init_dir = '/lib/svc/manifest/network'
+    endif
     init_dirs += init_dir
     custom_target(
         'solaris',
@@ -138,7 +158,9 @@ if (
     get_option('with-init-style') == 'openrc'
     or get_option('with-init-style') == 'gentoo-openrc'
 )
-    init_dir = '/etc/init.d'
+    if init_dir_override == ''
+        init_dir = '/etc/init.d'
+    endif
     init_dirs += init_dir
     custom_target(
         'openrc',
@@ -161,7 +183,9 @@ if (
 endif
 
 if get_option('with-init-style') == 'macos-launchd'
-    init_dir = '/Library/LaunchDaemons'
+    if init_dir_override == ''
+        init_dir = '/Library/LaunchDaemons'
+    endif
     init_dirs += init_dir
     custom_target(
         'netatalkd',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -234,7 +234,7 @@ option(
 option(
     'with-init-dir',
     type: 'string',
-    value: 'none',
+    value: '',
     description: 'Set path to OS specific init directory',
 )
 option(


### PR DESCRIPTION
The `with-init-dir` build system option overrides the default that's hard coded in this build script.

One known shortcoming is that it cannot be used with the `debian` init style since this applies both to sysv and systemd dirs which will break things.