### PR TITLE
[3.2] meson: Look for libmariadb dependency to appease Fedora

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,8 +301,8 @@ jobs:
             libgcrypt-devel \
             libtalloc-devel \
             libtool \
+            mariadb-connector-c-devel \
             meson \
-            mysql-devel \
             ninja-build \
             openldap-devel \
             openssl-devel \

--- a/meson.build
+++ b/meson.build
@@ -1469,7 +1469,7 @@ endif
 # Check for mysql CNID backend
 
 mysqlclient = dependency('mysqlclient', required: false)
-mariadb = dependency('mariadb', required: false)
+mariadb = dependency('libmariadb', required: false)
 
 use_mysql_backend = false
 


### PR DESCRIPTION
Fedora doesn't expose a `mariadb` dependency, but only `libmariadb` when using the recommended `mariadb-connector-c-devel` package.