### PR TITLE
GitHub CI: Build with system provided WolfSSL library

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,9 @@ jobs:
         run: |
           pacman -Sy --noconfirm \
             avahi \
+            cmark-gfm \
             cracklib \
+            cups \
             db \
             docbook-xsl \
             gcc \
@@ -373,7 +375,8 @@ jobs:
               py39-tkinter \
               talloc \
               tracker3 \
-              wget
+              wget \
+              wolfssl
           run: |
             set -e
             wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
@@ -413,7 +416,8 @@ jobs:
               pkgconf \
               talloc \
               tracker3 \
-              wget
+              wget \
+              wolfssl
           run: |
             set -e
             wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
@@ -539,7 +543,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          brew install berkeley-db cmark-gfm docbook-xsl libxslt meson mysql talloc
+          brew install berkeley-db cmark-gfm docbook-xsl libxslt meson mysql talloc wolfssl
           wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
       - name: Configure
         run: |


### PR DESCRIPTION
DragonflyBSD, FreeBSD, and macOS (Homebrew) ship WolfSSL libraries that are compatible with Netatalk 4.x.

Adding to Debian/Ubuntu for a total of 5 known OSes that provide native WolfSSL support.