### PR TITLE
[3.2] meson: Declare have_atfuncs globally to avoid failure later

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -290,6 +290,8 @@ at_functions = [
     'unlinkat',
 ]
 
+have_atfuncs = false
+
 foreach f : at_functions
     if cc.has_function(f)
         have_atfuncs = true


### PR DESCRIPTION
The build script expected the have_atfuncs check to always succeed. This change avoids an error when it fails.