### PR TITLE
meson: Install only one CNID README

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -56,8 +56,6 @@ endforeach
 
 install_data('README', install_dir: localstatedir / 'netatalk')
 
-install_data('README', install_dir: localstatedir / 'netatalk/CNID')
-
 if have_pam
     subdir('pam')
 endif


### PR DESCRIPTION
Installing the exact same README in a parent and child dir seems superfluous to me.