### PR TITLE
meson: Allow selecting multiple init styles

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,6 +189,7 @@ jobs:
           meson setup build \
             -Dwith-appletalk=true \
             -Dwith-init-hooks=false \
+            -Dwith-init-style=debian-sysv,systemd \
             -Dwith-pkgconfdir-path=/etc/netatalk \
             -Dwith-tests=true
       - name: Build
@@ -245,7 +246,7 @@ jobs:
           meson setup build \
             -Dwith-appletalk=true \
             -Dwith-init-hooks=false \
-            -Dwith-init-style=redhat-systemd \
+            -Dwith-init-style=systemd \
             -Dwith-tests=true
       - name: Build
         run: meson compile -C build
@@ -302,7 +303,7 @@ jobs:
             -Dwith-appletalk=true \
             -Dwith-docbook-path=/usr/share/xml/docbook/stylesheet/nwalsh/1.79.2 \
             -Dwith-init-hooks=false \
-            -Dwith-init-style=suse-systemd \
+            -Dwith-init-style=systemd \
             -Dwith-tests=true
       - name: Build
         run: meson compile -C build

--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -1,4 +1,4 @@
-if init_style == 'none'
+if 'none' in init_style
     init_dirs += 'none'
 endif
 
@@ -10,45 +10,7 @@ else
     init_dir = ''
 endif
 
-if (
-    init_style == 'debian'
-    or init_style == 'debian-systemd'
-    or init_style == 'gentoo-systemd'
-    or init_style == 'redhat-systemd'
-    or init_style == 'suse-systemd'
-    or init_style == 'systemd'
-)
-    if init_dir_override == ''
-        init_dir = '/usr/lib/systemd/system'
-    endif
-    init_dirs += init_dir
-    service_data = ['netatalk']
-    if have_appletalk
-        service_data += [
-            'a2boot',
-            'atalkd',
-            'papd',
-            'timelord',
-        ]
-    endif
-    foreach service : service_data
-        configure_file(
-            input: 'systemd.' + service + '.service.in',
-            output: service + '.service',
-            configuration: cdata,
-            install: true,
-            install_dir: init_dir,
-        )
-    endforeach
-    if get_option('with-init-hooks')
-        meson.add_install_script(find_program('systemctl'), 'daemon-reload')
-    endif
-endif
-
-if (
-  init_style == 'debian'
-  or init_style == 'debian-sysv'
-)
+if 'debian-sysv' in init_style
     if init_dir_override == ''
         init_dir = '/etc/init.d'
     endif
@@ -85,7 +47,7 @@ if (
     endif
 endif
 
-if init_style == 'freebsd'
+if 'freebsd' in init_style
     if init_dir_override == ''
         init_dir = '/usr/local/etc/rc.d'
     endif
@@ -107,115 +69,7 @@ if init_style == 'freebsd'
     endif
 endif
 
-if init_style == 'netbsd'
-    if init_dir_override == ''
-        init_dir = '/etc/rc.d'
-    endif
-    init_dirs += init_dir
-    service_data = ['netatalk']
-    if have_appletalk
-        service_data += [
-            'a2boot',
-            'atalkd',
-            'papd',
-            'timelord',
-        ]
-    endif
-    foreach service : service_data
-        configure_file(
-            input: 'netbsd.' + service + '.in',
-            output: service,
-            configuration: cdata,
-            install: true,
-            install_dir: init_dir,
-            install_mode: 'rwxr-xr-x',
-        )
-    endforeach
-endif
-
-if init_style == 'openbsd'
-    if init_dir_override == ''
-        init_dir = '/etc/rc.d'
-    endif
-    init_dirs += init_dir
-    configure_file(
-        input: 'openbsd.netatalk.in',
-        output: 'netatalk',
-        configuration: cdata,
-        install: true,
-        install_dir: init_dir,
-        install_mode: 'rwxr-xr-x',
-    )
-    if get_option('with-init-hooks')
-        meson.add_install_script(
-            find_program('rcctl'),
-            '-d', 'enable',
-            'netatalk',
-        )
-    endif
-endif
-
-if init_style == 'solaris'
-    if init_dir_override == ''
-        init_dir = '/lib/svc/manifest/network'
-    endif
-    init_dirs += init_dir
-    configure_file(
-        input: 'solaris.netatalk.xml.in',
-        output: 'netatalk.xml',
-        configuration: cdata,
-        install: true,
-        install_dir: init_dir,
-    )
-    if get_option('with-init-hooks')
-        meson.add_install_script(
-            find_program('svccfg'),
-            'import',
-            '/lib/svc/manifest/network/netatalk.xml',
-        )
-    endif
-endif
-
-if (
-    init_style == 'openrc'
-    or init_style == 'gentoo-openrc'
-)
-    if init_dir_override == ''
-        init_dir = '/etc/init.d'
-    endif
-    init_dirs += init_dir
-    service_data = ['netatalk']
-    if have_appletalk
-        service_data += [
-            'a2boot',
-            'atalkd',
-            'papd',
-            'timelord',
-        ]
-    endif
-    foreach service : service_data
-        configure_file(
-            input: 'openrc.' + service + '.in',
-            output: service,
-            configuration: cdata,
-            install: true,
-            install_dir: init_dir,
-            install_mode: 'rwxr-xr-x',
-        )
-    endforeach
-    if get_option('with-init-hooks')
-        foreach service : service_data
-            meson.add_install_script(
-                find_program('rc-update'),
-                'add',
-                service,
-                'default',
-            )
-        endforeach
-    endif
-endif
-
-if init_style == 'macos-launchd'
+if 'macos-launchd' in init_style
     if init_dir_override == ''
         init_dir = '/Library/LaunchDaemons'
     endif
@@ -251,5 +105,138 @@ if init_style == 'macos-launchd'
             'load',
             '-w', init_dir / 'io.netatalk.daemon.plist',
         )
+    endif
+endif
+
+if 'netbsd' in init_style
+    if init_dir_override == ''
+        init_dir = '/etc/rc.d'
+    endif
+    init_dirs += init_dir
+    service_data = ['netatalk']
+    if have_appletalk
+        service_data += [
+            'a2boot',
+            'atalkd',
+            'papd',
+            'timelord',
+        ]
+    endif
+    foreach service : service_data
+        configure_file(
+            input: 'netbsd.' + service + '.in',
+            output: service,
+            configuration: cdata,
+            install: true,
+            install_dir: init_dir,
+            install_mode: 'rwxr-xr-x',
+        )
+    endforeach
+endif
+
+if 'openbsd' in init_style
+    if init_dir_override == ''
+        init_dir = '/etc/rc.d'
+    endif
+    init_dirs += init_dir
+    configure_file(
+        input: 'openbsd.netatalk.in',
+        output: 'netatalk',
+        configuration: cdata,
+        install: true,
+        install_dir: init_dir,
+        install_mode: 'rwxr-xr-x',
+    )
+    if get_option('with-init-hooks')
+        meson.add_install_script(
+            find_program('rcctl'),
+            '-d', 'enable',
+            'netatalk',
+        )
+    endif
+endif
+
+if 'openrc' in init_style
+    if init_dir_override == ''
+        init_dir = '/etc/init.d'
+    endif
+    init_dirs += init_dir
+    service_data = ['netatalk']
+    if have_appletalk
+        service_data += [
+            'a2boot',
+            'atalkd',
+            'papd',
+            'timelord',
+        ]
+    endif
+    foreach service : service_data
+        configure_file(
+            input: 'openrc.' + service + '.in',
+            output: service,
+            configuration: cdata,
+            install: true,
+            install_dir: init_dir,
+            install_mode: 'rwxr-xr-x',
+        )
+    endforeach
+    if get_option('with-init-hooks')
+        foreach service : service_data
+            meson.add_install_script(
+                find_program('rc-update'),
+                'add',
+                service,
+                'default',
+            )
+        endforeach
+    endif
+endif
+
+if 'solaris' in init_style
+    if init_dir_override == ''
+        init_dir = '/lib/svc/manifest/network'
+    endif
+    init_dirs += init_dir
+    configure_file(
+        input: 'solaris.netatalk.xml.in',
+        output: 'netatalk.xml',
+        configuration: cdata,
+        install: true,
+        install_dir: init_dir,
+    )
+    if get_option('with-init-hooks')
+        meson.add_install_script(
+            find_program('svccfg'),
+            'import',
+            '/lib/svc/manifest/network/netatalk.xml',
+        )
+    endif
+endif
+
+if 'systemd' in init_style
+    if init_dir_override == ''
+        init_dir = '/usr/lib/systemd/system'
+    endif
+    init_dirs += init_dir
+    service_data = ['netatalk']
+    if have_appletalk
+        service_data += [
+            'a2boot',
+            'atalkd',
+            'papd',
+            'timelord',
+        ]
+    endif
+    foreach service : service_data
+        configure_file(
+            input: 'systemd.' + service + '.service.in',
+            output: service + '.service',
+            configuration: cdata,
+            install: true,
+            install_dir: init_dir,
+        )
+    endforeach
+    if get_option('with-init-hooks')
+        meson.add_install_script(find_program('systemctl'), 'daemon-reload')
     endif
 endif

--- a/meson.build
+++ b/meson.build
@@ -1954,21 +1954,21 @@ endif
 init_style = get_option('with-init-style')
 init_dirs = []
 
-if init_style == 'auto'
+if 'auto' in init_style
     if uname_stdout.to_lower().contains('debian') or uname_stdout.to_lower().contains('ubuntu')
-        init_style = 'debian-systemd'
+        init_style = ['systemd']
     elif host_os == 'freebsd'
-        init_style = 'freebsd'
+        init_style = ['freebsd']
     elif host_os == 'netbsd'
-        init_style = 'netbsd'
+        init_style = ['netbsd']
     elif host_os == 'openbsd'
-        init_style = 'openbsd'
+        init_style = ['openbsd']
     elif host_os == 'darwin'
-        init_style = 'macos-launchd'
+        init_style = ['macos-launchd']
     elif host_os == 'sunos'
-        init_style = 'solaris'
+        init_style = ['solaris']
     else
-        init_style = 'none'
+        init_style = ['none']
     endif
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -172,12 +172,6 @@ option(
     description: 'Enable checking for a valid shell',
 )
 option(
-    'with-spooldir',
-    type: 'string',
-    value: '',
-    description: 'Set path for spooldir used for CUPS support',
-)
-option(
     'with-spotlight',
     type: 'boolean',
     value: true,
@@ -298,6 +292,12 @@ option(
     description: 'Set path to the package conf dir that overrides sysconfdir',
 )
 option(
+    'with-spooldir',
+    type: 'string',
+    value: '',
+    description: 'Set path for spooldir used for CUPS support',
+)
+option(
     'with-tracker-install-prefix',
     type: 'string',
     value: '',
@@ -322,7 +322,7 @@ option(
     description: 'Set path to UnicodeData.txt',
 )
 
-# The following options set the preferred init-style and default CNID backend:
+# The following options offer a choice from pre-defined selections
 
 option(
     'with-cnid-default-backend',
@@ -333,30 +333,24 @@ option(
         'mysql',
     ],
     value: 'dbd',
-    description: 'Set default DID scheme',
+    description: 'Set default CNID scheme',
 )
 option(
     'with-init-style',
-    type: 'combo',
+    type: 'array',
     choices: [
         'none',
         'auto',
-        'debian',
-        'debian-systemd',
         'debian-sysv',
         'freebsd',
-        'gentoo-openrc',
-        'gentoo-systemd',
         'macos-launchd',
         'netbsd',
         'openbsd',
         'openrc',
-        'redhat-systemd',
         'solaris',
-        'suse-systemd',
         'systemd',
     ],
-    value: 'auto',
+    value: ['auto'],
     description: 'Use OS specific init config',
 )
 option(


### PR DESCRIPTION
This turns the `-Dwith-init-style` from the combo type to the array type. It takes a list of options like this:

```
-Dwith-init-style=openrc,systemd
```

Note that you cannot use `-Dwith-init-dir` when you select multiple init styles since it will affect all of them.

As part of the changeset, I also remove the platform variants of cross-platform init systems (openrc and systemd) because they all behave the same now with the same standard paths. If a future OS uses a different path, you the with-init-dir override.