### PR TITLE
Flesh out CNID README and put it in the proper subdir

### DIFF
--- a/config/README
+++ b/config/README
@@ -1,1 +1,2 @@
-This directory contains modifiable Netatalk configuration files and the CNID databases.
+This directory contains CNID (Catalog Node ID) databases where Netatalk stores
+records of shared files and folders.

--- a/config/meson.build
+++ b/config/meson.build
@@ -54,7 +54,7 @@ foreach file : static_conf_files
     endif
 endforeach
 
-install_data('README', install_dir: localstatedir / 'netatalk')
+install_data('README', install_dir: localstatedir / 'netatalk/CNID')
 
 if have_pam
     subdir('pam')


### PR DESCRIPTION
This partially reverts https://github.com/Netatalk/netatalk/pull/1367 because it turns out we rely on the build system to create the CNID subdir used to store CNID databases.