### PR TITLE
Make largefile mandatory, and clean up Meson controlled features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -419,8 +419,8 @@ jobs:
             set -e
             wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
             meson setup build \
-              -Dwith-appletalk=true \
-              -Dpkg_config_path=/usr/local/libdata/pkgconfig
+              -Dpkg_config_path=/usr/local/libdata/pkgconfig \
+              -Dwith-appletalk=true
             meson compile -C build
             meson install -C build
             /usr/local/etc/rc.d/netatalk start
@@ -468,8 +468,8 @@ jobs:
           run: |
             set -e
             meson setup build \
-              -Dwith-appletalk=true \
               -Dpkg_config_path=/usr/pkg/lib/pkgconfig \
+              -Dwith-appletalk=true \
               -Dwith-dtrace=false \
               -Dwith-tests=true
             meson compile -C build
@@ -518,7 +518,8 @@ jobs:
             set -e
             wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
             meson setup build \
-              -Dpkg_config_path=/usr/local/lib/pkgconfig
+              -Dpkg_config_path=/usr/local/lib/pkgconfig \
+              -Dwith-appletalk=true
             meson compile -C build
             meson install -C build
             rcctl -d start netatalk
@@ -544,6 +545,7 @@ jobs:
       - name: Configure
         run: |
           meson setup build \
+            -Dwith-appletalk=true \
             -Dwith-tests=true
       - name: Build
         run: meson compile -C build
@@ -594,8 +596,8 @@ jobs:
             export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
             wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
             meson setup build \
-              -Dwith-appletalk=true \
               -Dpkg_config_path=/opt/local/lib/pkgconfig \
+              -Dwith-appletalk=true \
               -Dwith-ldap-path=/opt/local
             meson compile -C build
             meson install -C build
@@ -634,8 +636,8 @@ jobs:
             set -e
             wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
             meson setup build \
-              -Dwith-appletalk=true \
               -Dpkg_config_path=/usr/lib/amd64/pkgconfig \
+              -Dwith-appletalk=true \
               -Dwith-docbook-path=/usr/share/sgml/docbook/xsl-stylesheets \
               -Dwith-tests=true
             meson compile -C build

--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -9,6 +9,7 @@
 #endif /* HAVE_CONFIG_H */
 
 #include <errno.h>
+#include <gcrypt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -21,10 +22,6 @@
 #ifdef HAVE_PAM_PAM_APPL_H
 #include <pam/pam_appl.h>
 #endif
-
-#ifdef HAVE_LIBGCRYPT
-#include <gcrypt.h>
-#endif /* HAVE_LIBGCRYPT */
 
 #include <atalk/afp.h>
 #include <atalk/globals.h>

--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -8,8 +8,6 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if defined (USE_PAM) && defined (UAM_DHX2)
-
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -963,5 +961,3 @@ UAM_MODULE_EXPORT struct uam_export uams_dhx2_pam = {
     UAM_MODULE_VERSION,
     uam_setup, uam_cleanup
 };
-
-#endif /* USE_PAM && UAM_DHX2 */

--- a/etc/uams/uams_dhx2_passwd.c
+++ b/etc/uams/uams_dhx2_passwd.c
@@ -9,8 +9,6 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#ifdef UAM_DHX2
-
 #include <arpa/inet.h>
 #include <errno.h>
 #include <pwd.h>
@@ -627,6 +625,3 @@ UAM_MODULE_EXPORT struct uam_export uams_dhx2_passwd = {
     UAM_MODULE_VERSION,
     uam_setup, uam_cleanup
 };
-
-#endif /* UAM_DHX2 */
-

--- a/etc/uams/uams_dhx2_passwd.c
+++ b/etc/uams/uams_dhx2_passwd.c
@@ -11,6 +11,7 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
+#include <gcrypt.h>
 #include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -21,10 +22,6 @@
 
 #ifdef HAVE_CRYPT_H
 #include <crypt.h>
-#endif
-
-#ifdef HAVE_LIBGCRYPT
-#include <gcrypt.h>
 #endif
 
 #ifdef SHADOWPW

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -9,8 +9,6 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#if defined(USE_PAM) && defined(UAM_DHX)
-
 #include <arpa/inet.h>
 #include <errno.h>
 #include <stdio.h>
@@ -767,5 +765,3 @@ UAM_MODULE_EXPORT struct uam_export uams_dhx_pam = {
   UAM_MODULE_VERSION,
   uam_setup, uam_cleanup
 };
-
-#endif /* USE_PAM && UAM_DHX */

--- a/etc/uams/uams_pgp.c
+++ b/etc/uams/uams_pgp.c
@@ -9,8 +9,6 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#ifdef UAM_PGP
-
 #include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -194,5 +192,3 @@ UAM_MODULE_EXPORT struct uam_export uams_pgp = {
   UAM_MODULE_VERSION,
   uam_setup, uam_cleanup
 };
-
-#endif /* UAM_PGP */

--- a/meson.build
+++ b/meson.build
@@ -1101,15 +1101,10 @@ endif
 
 have_libgcrypt = libgcrypt.found()
 
-if have_libgcrypt
-    cdata.set('HAVE_LIBGCRYPT', 1)
-else
-    have_libgcrypt = false
-    if not libgcrypt.found()
-        error(
-            'Libgcrypt library required for DHX2 UAM! Please install version 1.2.3 or later',
-        )
-    endif
+if not have_libgcrypt
+    error(
+        'Libgcrypt library required for DHX2 UAM! Please install version 1.2.3 or later',
+    )
 endif
 
 #

--- a/meson.build
+++ b/meson.build
@@ -1831,37 +1831,29 @@ cdata.set('PATH_NETATALK_LOCK', '"' + lockfile + '"')
 # Check for largefle support
 #
 
-enable_largefile = get_option('with-largefile')
+# needed for Linux, Solaris...
+file_offset_bits_test = cc.compiles(
+    '''
+    #if !defined(_FILE_OFFSET_BITS) || (_FILE_OFFSET_BITS != 64)
+        #error "Large-file support was not enabled"
+    #endif
+    ''',
+)
 
-if not enable_largefile
-    have_largefile = false
-else
-    # needed for Linux, Solaris...
-    file_offset_bits_test = cc.compiles(
-        '''
-        #if !defined(_FILE_OFFSET_BITS) || (_FILE_OFFSET_BITS != 64)
-            #error "Large-file support was not enabled"
-        #endif
-        ''',
-    )
+# Needed for AIX, macOS
+large_files_test = cc.sizeof('off_t') == 8
 
-    # Needed for AIX, macOS
-    large_files_test = cc.sizeof('off_t') == 8
-
-    have_largefile = file_offset_bits_test or large_files_test
-    if have_largefile
-        cdata.set('HAVE_LARGEFILE_SUPPORT', 1)
-        if file_offset_bits_test
-            cdata.set('_FILE_OFFSET_BITS', 64)
-        else
-            if large_files_test
-                cdata.set('_LARGE_FILES', 1)
-            endif
-        endif
+have_largefile = file_offset_bits_test or large_files_test
+if have_largefile
+    if file_offset_bits_test
+        cdata.set('_FILE_OFFSET_BITS', 64)
     else
-        have_largefile = false
-        warning('Largefile support requested but not available on this platform')
+        if large_files_test
+            cdata.set('_LARGE_FILES', 1)
+        endif
     endif
+else
+    error('Largefile support required but not available on this platform')
 endif
 
 #

--- a/meson.build
+++ b/meson.build
@@ -612,7 +612,6 @@ if (have_wolfssl or have_embedded_ssl) and nettle.found()
     if enable_rpath
         ssl_link_args += ['-R' / nettle.get_variable(pkgconfig: 'libdir')]
     endif
-    cdata.set('UAM_DHX', 1)
     ssl_deps += nettle
     if have_wolfssl and not have_ssl_override
         have_embedded_ssl = false
@@ -1104,7 +1103,6 @@ have_libgcrypt = libgcrypt.found()
 
 if have_libgcrypt
     cdata.set('HAVE_LIBGCRYPT', 1)
-    cdata.set('UAM_DHX2', 1)
 else
     have_libgcrypt = false
     if not libgcrypt.found()
@@ -1286,9 +1284,8 @@ enable_pgp_uam = get_option('with-pgp-uam')
 if not enable_pgp_uam
     have_pgp_uam = false
 else
-    have_pgp_uam = have_ssl
-    if have_pgp_uam
-        cdata.set('UAM_PGP', 1)
+    if have_ssl
+        have_pgp_uam = have_ssl
     else
         have_pgp_uam = false
         warning(
@@ -1726,7 +1723,6 @@ else
     )
 
     if have_pam
-        cdata.set('USE_PAM', 1)
         uams_options += 'PAM '
         pampath = pam_dir / 'etc/pam.d'
         # Debian/SuSE
@@ -2132,11 +2128,8 @@ elif host_os.contains('netbsd')
     cdata.set('BSD4_4', 1)
     cdata.set('NETBSD', 1)
     cdata.set('OPEN_NOFOLLOW_ERRNO', 'EFTYPE')
-    cdata.set('UAM_DHX', 1) # NetBSD does not have crypt.h, uses unistd.h
 elif host_os.contains('openbsd')
     cdata.set('BSD4_4', 1)
-    cdata.set('UAM_DHX', 1) # OpenBSD does not have crypt.h, uses unistd.h
-    cdata.set('NO_DDP', 1)
 elif host_os.contains('sunos')
     cdata.set('__EXTENSIONS__', 1)
     cdata.set('__svr4__', 1)

--- a/meson_config.h
+++ b/meson_config.h
@@ -130,10 +130,6 @@
 /* Define if support for dbus-glib was found */
 #mesondefine HAVE_DBUS_GLIB
 
-/* Define to 1 if you have the declaration of `cygwin_conv_path', and to 0 if
-   you don't. */
-#mesondefine HAVE_DECL_CYGWIN_CONV_PATH
-
 /* Define to 1 if you have the `dirfd' function. */
 #mesondefine HAVE_DIRFD
 
@@ -316,9 +312,6 @@
 
 /* Define if libdlloader will be built on this platform */
 #mesondefine HAVE_LIBDLLOADER
-
-/* Define if the DHX2 modules should be built with libgcrypt */
-#mesondefine HAVE_LIBGCRYPT
 
 /* define if you have libquota */
 #mesondefine HAVE_LIBQUOTA

--- a/meson_config.h
+++ b/meson_config.h
@@ -647,20 +647,8 @@
 /* Path to Tracker */
 #mesondefine TRACKER_PREFIX
 
-/* Define if the DHX UAM modules should be compiled */
-#mesondefine UAM_DHX
-
-/* Define if the DHX2 UAM modules should be compiled */
-#mesondefine UAM_DHX2
-
-/* Define if the PGP UAM module should be compiled */
-#mesondefine UAM_PGP
-
 /* Define if cracklib should be used */
 #mesondefine USE_CRACKLIB
-
-/* Define to enable PAM support */
-#mesondefine USE_PAM
 
 /* Define to enable Zeroconf support */
 #mesondefine USE_ZEROCONF

--- a/meson_config.h
+++ b/meson_config.h
@@ -295,9 +295,6 @@
 /* Define to 1 if you have the <langinfo.h> header file. */
 #mesondefine HAVE_LANGINFO_H
 
-/* LARGEFILE support */
-#mesondefine HAVE_LARGEFILE_SUPPORT
-
 /* Whether LDAP is available */
 #mesondefine HAVE_LDAP
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -100,12 +100,6 @@ option(
     description: 'Enable build of Kerberos V UAM module',
 )
 option(
-    'with-largefile',
-    type: 'boolean',
-    value: true,
-    description: 'Enable support for large files',
-)
-option(
     'with-ldap',
     type: 'boolean',
     value: true,


### PR DESCRIPTION
- Building of DHX/DHX2/PGP/PAM UAMs are controlled by Meson flags now, so the C macros aren't needed
- The largefile fallbacks are long gone from the codebase, so let's make largefile mandatory