### PR TITLE
meson: Introduce option to control which manual l10n to build

### DIFF
--- a/doc/html.xsl.in
+++ b/doc/html.xsl.in
@@ -6,4 +6,5 @@
 	<xsl:param name="chunk.section.depth" select="0"/>
 	<xsl:param name="chunk.separate.lots" select="1"/>
 	<xsl:param name="toc.max.depth" select="2"/>
+	<xsl:param name="html.stylesheet" select="'netatalk.css'"/>
 </xsl:stylesheet>

--- a/doc/ja/html.xsl.in
+++ b/doc/ja/html.xsl.in
@@ -7,4 +7,5 @@
 	<xsl:param name="chunk.separate.lots" select="1"/>
 	<xsl:param name="toc.max.depth" select="2"/>
 	<xsl:param name="l10n.gentext.default.language">ja</xsl:param>
+	<xsl:param name="html.stylesheet" select="'../netatalk.css'"/>
 </xsl:stylesheet>

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -86,3 +86,8 @@ custom_target(
     install: true,
     install_dir: datadir / 'doc/netatalk/htmldocs',
 )
+
+install_data(
+    'netatalk.css',
+    install_dir: datadir / 'doc/netatalk/htmldocs',
+)

--- a/doc/manual/netatalk.css
+++ b/doc/manual/netatalk.css
@@ -1,0 +1,248 @@
+body {
+  font-family: Verdana, Geneva, Arial, Helvetica, sans-serif;
+  background-color: white;
+  font-size: 1em;
+  margin-top: 0px;
+  margin-left: 15px;
+  margin-right: 15px;
+}
+
+.pdparam{
+  font-family: Verdana, Geneva, Arial, Helvetica, sans-serif;
+  font-size: 12px;
+}
+
+td {
+  font-family: Verdana, Geneva, Arial, Helvetica, sans-serif;
+  font-size: 12px;
+}
+
+h1, h2, h3 {
+  font-size: 130%;
+  padding: 2px;
+  margin-top: 0px;
+}
+
+h1 {
+  background-color: #605e5e;
+  color: #FFFFFF;
+}
+
+h2 {
+  background-color: #424242;
+  color: #FFFFFF;
+  text-decoration: none;
+}
+
+h3 {
+  background-color: #330000;
+  color: #FFFFFF;
+}
+
+h4 {
+  color: #330000;
+  font-size: 120%;
+}
+
+h5 {
+  font-size: 100%;
+  color: #330000;
+}
+
+.term {
+  color: black;
+}
+
+tr.qandadiv td {
+  padding-top: 1em;
+}
+
+div.navheader {
+  font-size: 80%;
+  margin-top: 15px;
+}
+
+div.titlepage {
+  margin-top: 15px;
+}
+
+div.navheader th{
+  font-size: 100%;
+}
+
+div.navfooter {
+  font-size: 80%;
+}
+
+a:link {
+  color: #660000;
+}
+
+a:visited {
+  color: #CC0000;
+}
+
+a:active {
+  color: #FF0033;
+}
+
+tr.question {
+  color: #33C;
+  font-weight: bold;
+}
+
+tr.question td {
+  padding-top: 1em;
+}
+
+div.variablelist {
+  padding-left: 2em;
+  color: #33C;
+}
+
+p {
+  color: black;
+}
+
+div.caution, div.tip, div.important {
+  border: dashed 1px;
+  background-color: #EEEEFF;
+  width: 60em;
+  padding: 5px;
+}
+
+pre.programlisting, pre.screen {
+  border: #630 1px dashed;
+  color: #993300;
+  padding: 2px;
+  font-size: 100%;
+}
+div.warning {
+  border: dashed 1px;
+  background-color: #BFBFBF;
+  width: 60em;
+  padding: 5px;
+}
+
+div.note {
+  border: dashed 1px;
+  background-color: #f2f2f2;
+  width: 60em;
+  padding: 5px;
+}
+
+div.author {
+  padding-top: 1em;
+}
+
+div.revhistory table{
+  font-size: 12px;
+  border-collapse: collapse;
+  border-spacing: 0;
+  border: 0px;
+}
+
+div.revhistory tr {
+  border: 0px;
+}
+
+div.revhistory td {
+  border: 0px;
+}
+
+div.revhistory th {
+  border: 0px;
+}
+
+div.book, div.chapter, div.refentry {
+  font-size: 90%;
+}
+
+div.indexdiv {
+  font-size: 80%;
+}
+
+tt {
+  font-size: 80%;
+}
+
+/**
+ * netatalk
+ */
+/* definitions for the header */
+div#header {
+  margin-top: 0px;
+  margin-left: -15px;
+  margin-right: -15px;
+  height: 109px;
+  white-space: nowrap;
+  background-color: #424242;
+  background-image: url(/gfx/bg.gif);
+  background-repeat: no-repeat;
+  background-position: 380px 0px;
+}
+
+div#logo {
+  position: absolute;
+  margin-top: 0px;
+  margin-left: 25px;
+  width: 225px;
+  height: 109px;
+  padding: 0px;
+  background-image: url(/gfx/netatalklogo.gif);
+  background-repeat: no-repeat;
+}
+
+#logo img {
+  border: 0px;
+}
+
+div#menlinks {
+  position: absolute;
+  left: 272px;
+  top: 87px;
+  font-family: Geneva, Arial, Helvetica, sans-serif;
+  font-size: 12px;
+  font-weight: normal;
+  color: #FFFFFF;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+div#menlinks a, div#menlinks a:visited {
+  color: #FFFFFF;
+  margin-right: 15px;
+  text-decoration: none;
+}
+
+#menlinks img {
+  border: 0px;
+}
+
+.italic {
+  font-family: Geneva, Arial, Helvetica, sans-serif;
+  font-size: 11px;
+  font-style: italic;
+  font-weight: normal;
+  color: #000000;
+  text-decoration: none;
+}
+
+a, a:visited {
+  text-decoration: none;
+  color: #660000;
+}
+
+/* definitions for the footer */
+div.footer {
+  margin-left: 210px;
+  margin-top: 22px;
+  font-size: 75%;
+  width: 145px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.footer img {
+  padding-right: 5px;
+}

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -16,8 +16,6 @@ manual_stylesheet = configure_file(
     configuration: cdata,
 )
 
-
-
 if get_option('with-readmes')
     readmes = [
         'DEVELOPER',
@@ -35,6 +33,6 @@ endif
 subdir('manpages')
 subdir('manual')
 
-if get_option('with-manual') == 'www'
+if 'ja' in get_option('with-manual-l10n')
     subdir('ja')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -358,3 +358,12 @@ option(
     value: 'local',
     description: 'Build and install the html manual',
 )
+option(
+    'with-manual-l10n',
+    type: 'array',
+    choices: [
+        'ja',
+    ],
+    value: [],
+    description: 'Choose the localizations of the html manual to build',
+)


### PR DESCRIPTION
- New meson option `-Dwith-manual-l10n` which takes an array of locales (currently only one, `ja`). Default is empty array, which leads to only the English l10n being built.
- Brings over the netatalk.css stylesheet from the netatalk-homepage repo and uses it when building the manual for local consumption.