### PR TITLE
Restore AppleTalk functionality in afpd

### DIFF
--- a/etc/afpd/afp_asp.c
+++ b/etc/afpd/afp_asp.c
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 1997 Adrian Sun (asun@zoology.washington.edu)
+ * Copyright (c) 1990,1993 Regents of The University of Michigan.
+ * All Rights Reserved.  See COPYRIGHT.
+ *
+ * modified from main.c. this handles afp over asp.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#ifndef NO_DDP
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <atalk/logger.h>
+#include <errno.h>
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif /* HAVE_SYS_TIME_H */
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif /* HAVE_SYS_STAT_H */
+
+#include <netatalk/endian.h>
+#include <atalk/atp.h>
+#include <atalk/asp.h>
+#include <atalk/compat.h>
+#include <atalk/util.h>
+#include <atalk/globals.h>
+
+#include "switch.h"
+#include "auth.h"
+#include "fork.h"
+#include "dircache.h"
+
+static AFPObj *child;
+
+static void afp_asp_close(AFPObj *obj)
+{
+    ASP asp = obj->handle;
+
+    if ( obj->uid != geteuid() ) {
+        if (seteuid(obj->uid) < 0) {
+            LOG(log_error, logtype_afpd,
+			"afp_asp_close: can't seteuid back to %i from %i (%s)",
+			obj->uid, geteuid(), strerror(errno));
+        }
+        exit(EXITERR_SYS);
+    }
+    close_all_vol(obj);
+
+    if (obj->logout)
+        (*obj->logout)();
+
+    LOG(log_info, logtype_afpd, "%.2fKB read, %.2fKB written",
+        asp->read_count / 1024.0, asp->write_count / 1024.0);
+    asp_close( asp );
+}
+
+/* ------------------------
+ * SIGTERM
+*/
+static void afp_asp_die(const int sig)
+{
+    ASP asp = child->handle;
+
+    asp_attention(asp, AFPATTN_SHUTDOWN);
+    if ( asp_shutdown( asp ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_die: asp_shutdown: %s", strerror(errno) );
+    }
+
+    afp_asp_close(child);
+    if (sig == SIGTERM || sig == SIGALRM)
+        exit( 0 );
+    else
+        exit(sig);
+}
+
+/* -----------------------------
+ * SIGUSR1
+ */
+static void afp_asp_timedown(int sig _U_)
+{
+    struct sigaction	sv;
+    struct itimerval	it;
+
+    /* shutdown and don't reconnect. server going down in 5 minutes. */
+    asp_attention(child->handle, AFPATTN_SHUTDOWN | AFPATTN_NORECONNECT |
+                  AFPATTN_TIME(5));
+
+    it.it_interval.tv_sec = 0;
+    it.it_interval.tv_usec = 0;
+    it.it_value.tv_sec = 300;
+    it.it_value.tv_usec = 0;
+    if ( setitimer( ITIMER_REAL, &it, NULL ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_timedown: setitimer: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+
+    memset(&sv, 0, sizeof(sv));
+    sv.sa_handler = afp_asp_die;
+    sigemptyset( &sv.sa_mask );
+    sigaddset(&sv.sa_mask, SIGHUP);
+    sigaddset(&sv.sa_mask, SIGTERM);
+    sv.sa_flags = SA_RESTART;
+    if ( sigaction( SIGALRM, &sv, NULL ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_timedown: sigaction: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+
+    /* ignore myself */
+    sv.sa_handler = SIG_IGN;
+    sigemptyset( &sv.sa_mask );
+    sv.sa_flags = SA_RESTART;
+    if ( sigaction( SIGUSR1, &sv, NULL ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_timedown: sigaction SIGUSR1: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+}
+
+/* ---------------------------------
+ * SIGHUP reload configuration file
+*/
+extern volatile int reload_request;
+
+static void afp_asp_reload(int sig _U_)
+{
+    reload_request = 1;
+}
+
+/* ---------------------- */
+#ifdef SERVERTEXT
+static void afp_asp_getmesg (int sig _U_)
+{
+    readmessage(child);
+    asp_attention(child->handle, AFPATTN_MESG | AFPATTN_TIME(5));
+}
+#endif /* SERVERTEXT */
+
+/* ---------------------- */
+void afp_over_asp(AFPObj *obj)
+{
+    ASP asp;
+    struct sigaction  action;
+    int		func,  reply = 0;
+    int ccnt = 0;
+
+    AFPobj = obj;
+    obj->exit = afp_asp_die;
+    obj->reply = (int (*)()) asp_cmdreply;
+    obj->attention = (int (*)(void *, AFPUserBytes)) asp_attention;
+    child = obj;
+    asp = (ASP) obj->handle;
+
+    /* install signal handlers
+     * With ASP tickle handler is done in the parent process
+    */
+    memset(&action, 0, sizeof(action));
+
+    /* install SIGHUP */
+    action.sa_handler = afp_asp_reload;
+    sigemptyset( &action.sa_mask );
+    sigaddset(&action.sa_mask, SIGTERM);
+    sigaddset(&action.sa_mask, SIGUSR1);
+#ifdef SERVERTEXT
+    sigaddset(&action.sa_mask, SIGUSR2);
+#endif
+    action.sa_flags = SA_RESTART;
+    if ( sigaction( SIGHUP, &action, NULL ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_over_asp: sigaction: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+
+    /*  install SIGTERM */
+    action.sa_handler = afp_asp_die;
+    sigemptyset( &action.sa_mask );
+    sigaddset(&action.sa_mask, SIGHUP);
+    sigaddset(&action.sa_mask, SIGUSR1);
+#ifdef SERVERTEXT
+    sigaddset(&action.sa_mask, SIGUSR2);
+#endif
+    action.sa_flags = SA_RESTART;
+    if ( sigaction( SIGTERM, &action, NULL ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_over_asp: sigaction: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+
+#ifdef SERVERTEXT
+    /* Added for server message support */
+    action.sa_handler = afp_asp_getmesg;
+    sigemptyset( &action.sa_mask );
+    sigaddset(&action.sa_mask, SIGTERM);
+    sigaddset(&action.sa_mask, SIGUSR1);
+    sigaddset(&action.sa_mask, SIGHUP);
+    action.sa_flags = SA_RESTART;
+    if ( sigaction( SIGUSR2, &action, NULL) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_over_asp: sigaction: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+#endif /* SERVERTEXT */
+
+    /*  SIGUSR1 - set down in 5 minutes  */
+    action.sa_handler = afp_asp_timedown;
+    sigemptyset( &action.sa_mask );
+    sigaddset(&action.sa_mask, SIGHUP);
+    sigaddset(&action.sa_mask, SIGTERM);
+#ifdef SERVERTEXT
+    sigaddset(&action.sa_mask, SIGUSR2);
+#endif
+    action.sa_flags = SA_RESTART;
+    if ( sigaction( SIGUSR1, &action, NULL ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_over_asp: sigaction: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+
+    if (dircache_init(obj->options.dircachesize) != 0) {
+        LOG(log_error, logtype_afpd, "afp_over_asp: dircache_init error");
+        afp_asp_die(EXITERR_SYS);
+    }
+
+    LOG(log_info, logtype_afpd, "session from %u.%u:%u on %u.%u:%u",
+        ntohs( asp->asp_sat.sat_addr.s_net ),
+        asp->asp_sat.sat_addr.s_node, asp->asp_sat.sat_port,
+        ntohs( atp_sockaddr( asp->asp_atp )->sat_addr.s_net ),
+        atp_sockaddr( asp->asp_atp )->sat_addr.s_node,
+        atp_sockaddr( asp->asp_atp )->sat_port );
+
+    while ((reply = asp_getrequest(asp))) {
+        if (reload_request) {
+            reload_request = 0;
+            load_volumes(child);
+        }
+        switch (reply) {
+        case ASPFUNC_CLOSE :
+            afp_asp_close(obj);
+            LOG(log_info, logtype_afpd, "done" );
+
+            return;
+            break;
+
+        case ASPFUNC_CMD :
+            func = (unsigned char) asp->commands[0];
+            LOG(log_debug9, logtype_afpd, "command: %d (%s)\n", func, AfpNum2name(func));
+
+            if ( afp_switch[ func ] != NULL ) {
+                /*
+                 * The function called from afp_switch is expected to
+                 * read its parameters out of buf, put its
+                 * results in replybuf (updating rbuflen), and
+                 * return an error code.
+                */
+                asp->datalen = ASP_DATASIZ;
+                reply = (*afp_switch[ func ])(obj,
+                                              asp->commands, asp->cmdlen,
+                                              asp->data, &asp->datalen);
+            } else {
+                LOG(log_error, logtype_afpd, "bad function %X", func );
+                asp->datalen = 0;
+                reply = AFPERR_NOOP;
+            }
+
+            LOG(log_debug9, logtype_afpd, "reply: %d, %d\n", reply, ccnt++ );
+
+            if ( asp_cmdreply( asp, reply ) < 0 ) {
+                LOG(log_error, logtype_afpd, "asp_cmdreply: %s", strerror(errno) );
+                afp_asp_die(EXITERR_CLNT);
+            }
+            break;
+
+        case ASPFUNC_WRITE :
+            func = (unsigned char) asp->commands[0];
+
+            LOG(log_debug9, logtype_afpd, "(write) command: %d\n", func );
+
+            if ( afp_switch[ func ] != NULL ) {
+                asp->datalen = ASP_DATASIZ;
+                reply = (*afp_switch[ func ])(obj,
+                                              asp->commands, asp->cmdlen,
+                                              asp->data, &asp->datalen);
+            } else {
+                LOG(log_error, logtype_afpd, "(write) bad function %X", func );
+                asp->datalen = 0;
+                reply = AFPERR_NOOP;
+            }
+
+            LOG(log_debug9, logtype_afpd, "(write) reply code: %d, %d\n", reply, ccnt++ );
+
+            if ( asp_wrtreply( asp, reply ) < 0 ) {
+                LOG(log_error, logtype_afpd, "asp_wrtreply: %s", strerror(errno) );
+                afp_asp_die(EXITERR_CLNT);
+            }
+            break;
+        default:
+            /*
+               * Bad asp packet.  Probably should have asp filter them,
+               * since they are typically things like out-of-order packet.
+               */
+            LOG(log_info, logtype_afpd, "main: asp_getrequest: %d", reply );
+            break;
+        }
+
+        if ( obj->options.flags & OPTION_DEBUG ) {
+            of_pforkdesc( stdout );
+            fflush( stdout );
+        }
+
+    }
+}
+
+#endif

--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -65,6 +65,15 @@ static void show_version( void )
 		printf( "%d.%d ", afp_versions[ i ].av_number/10, afp_versions[ i ].av_number%10);
 	}
 	puts( "" );
+  printf( "        TCP/IP Support:\t" );
+  puts( "Yes" );
+
+	printf( "AppleTalk Support:\t" );
+#ifdef NO_DDP
+	puts( "No" );
+#else
+	puts( "Yes" );
+#endif
 
 	printf( "         CNID backends:\t" );
 #ifdef CNID_BACKEND_DBD
@@ -173,6 +182,10 @@ static void show_paths( void )
 {
 	printf( "              afp.conf:\t%s\n", _PATH_CONFDIR "afp.conf");
 	printf( "           extmap.conf:\t%s\n", _PATH_CONFDIR "extmap.conf");
+#ifndef NO_DDP
+	printf( "           atalkd.conf:\t%s\n", _PATH_CONFDIR "atalkd.conf");
+	printf( "             papd.conf:\t%s\n", _PATH_CONFDIR "papd.conf");
+#endif
 	printf( "       state directory:\t%s\n", _PATH_STATEDIR);
 	printf( "    afp_signature.conf:\t%s\n", _PATH_STATEDIR "afp_signature.conf");
 	printf( "      afp_voluuid.conf:\t%s\n", _PATH_STATEDIR "afp_voluuid.conf");

--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -58,7 +58,7 @@ static struct uam_obj uam_changepw = {"", "", 0, {{NULL, NULL, NULL, NULL}}, &ua
 static struct uam_obj *afp_uam = NULL;
 
 
-void status_versions( char *data, const DSI *dsi)
+void status_versions(char *data, const ASP asp, const DSI *dsi)
 {
     char                *start = data;
     uint16_t           status;
@@ -68,6 +68,7 @@ void status_versions( char *data, const DSI *dsi)
     num = sizeof( afp_versions ) / sizeof( afp_versions[ 0 ] );
 
     for ( i = 0; i < num; i++ ) {
+        if ( !asp && (afp_versions[ i ].av_number <= 21)) continue;
         if ( !dsi && (afp_versions[ i ].av_number >= 22)) continue;
         count++;
     }
@@ -75,6 +76,7 @@ void status_versions( char *data, const DSI *dsi)
     *data++ = count;
 
     for ( i = 0; i < num; i++ ) {
+        if ( !asp && (afp_versions[ i ].av_number <= 21)) continue;
         if ( !dsi && (afp_versions[ i ].av_number >= 22)) continue;
         len = strlen( afp_versions[ i ].av_name );
         *data++ = len;

--- a/etc/afpd/desktop.c
+++ b/etc/afpd/desktop.c
@@ -21,9 +21,12 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/uio.h>
+#include <netatalk/at.h>
 
 #include <atalk/adouble.h>
 #include <atalk/afp.h>
+#include <atalk/atp.h>
+#include <atalk/asp.h>
 #include <atalk/bstradd.h>
 #include <atalk/bstrlib.h>
 #include <atalk/dsi.h>
@@ -322,6 +325,7 @@ static int iconopen(struct vol *vol, u_char creator[ 4 ], int flags, int mode)
 int afp_addicon(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t *rbuflen)
 {
     struct vol		*vol;
+    struct iovec	iov[ 2 ];
     u_char		fcreator[ 4 ], imh[ 12 ], irh[ 12 ], *p;
     int			itype, cc = AFP_OK, iovcnt = 0;
     size_t 		buflen;
@@ -417,29 +421,64 @@ addicon_err:
         return cc;
     }
 
-    DSI *dsi = obj->dsi;
+    switch (obj->proto) {
+    case AFPPROTO_ASP:
+        buflen = bsize;
+        if ((asp_wrtcont(obj->handle, rbuf, &buflen) < 0) || buflen != bsize)
+            return( AFPERR_PARAM );
 
-    iovcnt = dsi_writeinit(dsi, rbuf, buflen);
-
-    /* add headers at end of file */
-    if ((cc == 0) && (write(si.sdt_fd, imh, sizeof(imh)) < 0)) {
-        LOG(log_error, logtype_afpd, "afp_addicon(%s): write: %s", icon_dtfile(vol, fcreator), strerror(errno));
-        dsi_writeflush(dsi);
-        return AFPERR_PARAM;
-    }
-
-    if ((cc = write(si.sdt_fd, rbuf, iovcnt)) < 0) {
-        LOG(log_error, logtype_afpd, "afp_addicon(%s): write: %s", icon_dtfile(vol, fcreator), strerror(errno));
-        dsi_writeflush(dsi);
-        return AFPERR_PARAM;
-    }
-
-    while ((iovcnt = dsi_write(dsi, rbuf, buflen))) {
-        if ((cc = write(si.sdt_fd, rbuf, iovcnt)) < 0) {
-            LOG(log_error, logtype_afpd, "afp_addicon(%s): write: %s", icon_dtfile(vol, fcreator), strerror(errno));
-            dsi_writeflush(dsi);
-            return AFPERR_PARAM;
+        /*
+         * We're at the end of the file, add the headers, etc.  */
+        if ( cc == 0 ) {
+            iov[ 0 ].iov_base = (caddr_t)imh;
+            iov[ 0 ].iov_len = sizeof( imh );
+            iov[ 1 ].iov_base = rbuf;
+            iov[ 1 ].iov_len = bsize;
+            iovcnt = 2;
         }
+
+        /*
+         * We found an icon to replace.
+         */
+        if ( cc > 0 ) {
+            iov[ 0 ].iov_base = rbuf;
+            iov[ 0 ].iov_len = bsize;
+            iovcnt = 1;
+        }
+
+        if ( writev( si.sdt_fd, iov, iovcnt ) < 0 ) {
+            LOG(log_error, logtype_afpd, "afp_addicon(%s): writev: %s", icon_dtfile(vol, fcreator), strerror(errno) );
+            return( AFPERR_PARAM );
+        }
+        break;
+    case AFPPROTO_DSI:
+        {
+            DSI *dsi = obj->dsi;
+
+            iovcnt = dsi_writeinit(dsi, rbuf, buflen);
+
+            /* add headers at end of file */
+            if ((cc == 0) && (write(si.sdt_fd, imh, sizeof(imh)) < 0)) {
+                LOG(log_error, logtype_afpd, "afp_addicon(%s): write: %s", icon_dtfile(vol, fcreator), strerror(errno));
+                dsi_writeflush(dsi);
+                return AFPERR_PARAM;
+            }
+
+            if ((cc = write(si.sdt_fd, rbuf, iovcnt)) < 0) {
+                LOG(log_error, logtype_afpd, "afp_addicon(%s): write: %s", icon_dtfile(vol, fcreator), strerror(errno));
+                dsi_writeflush(dsi);
+                return AFPERR_PARAM;
+            }
+
+            while ((iovcnt = dsi_write(dsi, rbuf, buflen))) {
+                if ((cc = write(si.sdt_fd, rbuf, iovcnt)) < 0) {
+                    LOG(log_error, logtype_afpd, "afp_addicon(%s): write: %s", icon_dtfile(vol, fcreator), strerror(errno));
+                    dsi_writeflush(dsi);
+                    return AFPERR_PARAM;
+                }
+            }
+        }
+        break;
     }
 
     close( si.sdt_fd );

--- a/etc/afpd/fork.h
+++ b/etc/afpd/fork.h
@@ -62,6 +62,7 @@ extern int          of_rename    (const struct vol *,
                                           struct dir *, const char *,
                                           struct dir *, const char *);
 extern int          of_flush     (const struct vol *);
+extern void         of_pforkdesc (FILE *);
 extern int          of_stat      (const struct vol *vol, struct path *);
 extern int          of_statdir   (struct vol *vol, struct path *);
 extern int          of_closefork (const AFPObj *obj, struct ofork *ofork);

--- a/etc/afpd/main.c
+++ b/etc/afpd/main.c
@@ -22,6 +22,8 @@
 
 #include <atalk/adouble.h>
 #include <atalk/afp.h>
+#include <atalk/atp.h>
+#include <atalk/asp.h>
 #include <atalk/compat.h>
 #include <atalk/dsi.h>
 #include <atalk/errchk.h>
@@ -98,6 +100,8 @@ static bool reset_listening_sockets(const AFPObj *config)
 /* ------------------ */
 static void afp_goaway(int sig)
 {
+    asp_kill(sig);
+
     switch( sig ) {
 
     case SIGTERM:

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -34,6 +34,12 @@ afpd_external_deps = [libgcrypt]
 afpd_internal_deps = []
 afpd_link_args = []
 
+if have_appletalk
+    afpd_sources += [
+        'afp_asp.c',
+    ]
+endif
+
 if have_spotlight
     afpd_sources += [
         'spotlight.c',

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -62,6 +62,20 @@ static void of_unhash(struct ofork *of)
     }
 }
 
+void of_pforkdesc(FILE *f)
+{
+    int ofrefnum;
+
+    if (!oforks)
+        return;
+
+    for ( ofrefnum = 0; ofrefnum < nforks; ofrefnum++ ) {
+        if ( oforks[ ofrefnum ] != NULL ) {
+            fprintf( f, "%d <%s>\n", ofrefnum, of_name(oforks[ ofrefnum ]));
+        }
+    }
+}
+
 int of_flush(const struct vol *vol)
 {
     int refnum;

--- a/etc/afpd/status.h
+++ b/etc/afpd/status.h
@@ -1,6 +1,7 @@
 #ifndef AFPD_STATUS_H
 #define AFPD_STATUS_H 1
 
+#include <atalk/asp.h>
 #include <atalk/dsi.h>
 #include <atalk/globals.h>
 
@@ -33,9 +34,10 @@
 /* AFPSTATUS_MACHLEN is the number of characters for the MachineType. */
 #define AFPSTATUS_MACHLEN     16
 
-extern void status_versions (char * /*status*/, const DSI *);
+extern void status_versions (char * /*status*/, const ASP, const DSI *);
 extern void status_uams (char * /*status*/, const char * /*authlist*/);
 extern void status_init (AFPObj *, DSI *dsi);
+// TODO: Replace the above with extern void status_init (AFPConfig *, AFPConfig *, const struct afp_options *);
 extern void set_signature(struct afp_options *);
 
 /* FP functions */

--- a/etc/afpd/uam.c
+++ b/etc/afpd/uam.c
@@ -26,6 +26,7 @@
 #include <unistd.h>
 
 #include <atalk/afp.h>
+#include <atalk/asp.h>
 #include <atalk/bstrlib.h>
 #include <atalk/dsi.h>
 #include <atalk/globals.h>

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -24,6 +24,7 @@
 
 #include <atalk/adouble.h>
 #include <atalk/afp.h>
+#include <atalk/asp.h>
 #include <atalk/bstradd.h>
 #include <atalk/bstrlib.h>
 

--- a/include/atalk/aep.h
+++ b/include/atalk/aep.h
@@ -24,10 +24,7 @@
 #ifndef _ATALK_AEP_H
 #define _ATALK_AEP_H 1
 
-#ifndef NO_DDP
-
 #define AEPOP_REQUEST	1
 #define AEPOP_REPLY	2
 
-#endif  /* NO_DDP */
 #endif

--- a/include/atalk/asp.h
+++ b/include/atalk/asp.h
@@ -24,8 +24,6 @@
 #ifndef _ATALK_ASP_H
 #define _ATALK_ASP_H 1
 
-#ifndef NO_DDP
-
 #include <sys/types.h>
 #include <sys/types.h>
 #include <netatalk/endian.h>
@@ -103,5 +101,4 @@ extern void asp_kill        (int);
 extern int asp_tickle      (ASP, const uint8_t, struct sockaddr_at *);
 extern void asp_stop_tickle (void);
 
-#endif  /* NO_DDP */
 #endif

--- a/include/atalk/atp.h
+++ b/include/atalk/atp.h
@@ -24,8 +24,6 @@
 #ifndef _ATALK_ATP_H
 #define _ATALK_ATP_H 1
 
-#ifndef NO_DDP
-
 #include <sys/types.h>
 #include <sys/types.h>
 #include <sys/time.h>
@@ -190,5 +188,4 @@ extern int		atp_rsel  (ATP, struct sockaddr_at *, int);
 extern int		atp_rreq  (ATP, struct atp_block *);
 extern int		atp_sresp (ATP, struct atp_block *);
 
-#endif  /* NO_DDP */
 #endif

--- a/include/atalk/ddp.h
+++ b/include/atalk/ddp.h
@@ -24,8 +24,6 @@
 #ifndef _ATALK_DDP_H
 #define _ATALK_DDP_H 1
 
-#ifndef NO_DDP
-
 #define DDPTYPE_RTMPRD	1
 #define DDPTYPE_NBP	2
 #define DDPTYPE_ATP	3
@@ -34,5 +32,4 @@
 #define DDPTYPE_ZIP	6
 #define DDPTYPE_ADSP	7
 
-#endif /* NO_DDP */
 #endif

--- a/include/atalk/globals.h
+++ b/include/atalk/globals.h
@@ -16,6 +16,7 @@
 #include <sys/param.h>
 #include <sys/types.h>
 
+#include <netatalk/at.h>
 #include <atalk/afp.h>
 #include <atalk/compat.h>
 #include <atalk/iniparser.h>
@@ -102,6 +103,8 @@ struct afp_options {
     uint32_t server_quantum;
     int dsireadbuf; /* scale factor for sizefof(dsi->buffer) = server_quantum * dsireadbuf */
     char *hostname;
+    char *server;
+    struct at_addr ddpaddr;
     char *listen, *interfaces, *port;
     char *Cnid_srv, *Cnid_port;
     char *configfile;
@@ -145,11 +148,14 @@ struct afp_options {
 };
 
 typedef struct AFPObj {
+    int proto;
+    void *handle;               /* either (DSI *) or (ASP *) */
     const char *cmdlineconfigfile;
     int cmdlineflags;
     const void *signature;
     struct DSI *dsi;
     struct afp_options options;
+    char *Obj, *Type, *Zone;
     dictionary *iniconfig;
     char username[MAXUSERLEN];
     /* to prevent confusion, only use these in afp_* calls */
@@ -202,6 +208,7 @@ extern const char *AfpErr2name(int err);
 /* directory.c */
 extern struct dir rootParent;
 
+extern void afp_over_asp (AFPObj *);
 extern void afp_over_dsi (AFPObj *);
 extern void afp_over_dsi_sighandlers(AFPObj *obj);
 #endif /* globals.h */

--- a/include/atalk/nbp.h
+++ b/include/atalk/nbp.h
@@ -24,8 +24,6 @@
 #ifndef _ATALK_NBP_H
 #define _ATALK_NBP_H 1
 
-#ifndef NO_DDP
-
 #define NBP_UNRGSTR_4ARGS 1
 #define ATP_OPEN_2ARGS 1
 
@@ -102,5 +100,4 @@ extern int nbp_rgstr (struct sockaddr_at *,
 extern int nbp_unrgstr (const char *, const char *, const char *,
 			    const struct at_addr *);
 
-#endif  /* NO_DDP */
 #endif

--- a/include/atalk/netddp.h
+++ b/include/atalk/netddp.h
@@ -11,8 +11,6 @@
 #ifndef _ATALK_NETDDP_H
 #define _ATALK_NETDDP_H 1
 
-#ifndef NO_DDP
-
 #include <sys/types.h>
 #include <sys/types.h>
 #include <sys/socket.h>
@@ -27,6 +25,4 @@ extern int netddp_open   (struct sockaddr_at *, struct sockaddr_at *);
 #define netddp_sendto    sendto
 #define netddp_recvfrom  recvfrom
 
-#endif  /* NO_DDP */
 #endif /* netddp.h */
-

--- a/include/atalk/pap.h
+++ b/include/atalk/pap.h
@@ -24,8 +24,6 @@
 #ifndef _ATALK_PAP_H
 #define _ATALK_PAP_H 1
 
-#ifndef NO_DDP
-
 #define PAP_OPEN	1
 #define PAP_OPENREPLY	2
 #define PAP_READ	3
@@ -39,5 +37,4 @@
 #define PAP_MAXDATA	512
 #define PAP_MAXQUANTUM	8
 
-#endif  /* NO_DDP */
 #endif

--- a/include/atalk/util.h
+++ b/include/atalk/util.h
@@ -91,9 +91,7 @@ extern void freeifacelist(char **);
 
 #define diatolower(x)     _dialowermap[(unsigned char) (x)]
 #define diatoupper(x)     _diacasemap[(unsigned char) (x)]
-#ifndef NO_DDP 
 extern int atalk_aton(char*, struct at_addr*);
-#endif
 extern void bprint        (char *, int);
 extern int strdiacasecmp  (const char *, const char *);
 extern int strndiacasecmp (const char *, const char *, size_t);

--- a/include/atalk/zip.h
+++ b/include/atalk/zip.h
@@ -25,8 +25,6 @@
 #ifndef _ATALK_ZIP_H
 #define _ATALK_ZIP_H 1
 
-#ifndef NO_DDP
-
 #include <netatalk/endian.h>
 
 struct ziphdr {
@@ -57,5 +55,4 @@ struct zipreplent {
 #define ZIPGNI_INVALID	0x80
 #define ZIPGNI_ONEZONE	0x20
 
-#endif  /* NO_DDP */
 #endif

--- a/libatalk/util/atalk_addr.c
+++ b/libatalk/util/atalk_addr.c
@@ -2,8 +2,6 @@
 #include "config.h"
 #endif
 
-#ifndef NO_DDP
-
 #include <sys/types.h>
 #include <netatalk/at.h>
 #include <netatalk/endian.h>
@@ -118,5 +116,3 @@ int atalk_aton(char* cp, struct at_addr* addr)
 	}
 	return (1);
 }
-
-#endif  /* NO_DDP */

--- a/libatalk/util/logger.c
+++ b/libatalk/util/logger.c
@@ -59,6 +59,8 @@ Netatalk 2001 (c)
   "CNID",                            \
   "AFPDaemon",                       \
   "DSI",                             \
+  "ATalkDaemon",                     \
+  "PAPDaemon",                       \
   "UAMS",                            \
   "FCE",                             \
   "ad",                              \
@@ -87,6 +89,8 @@ UAM_MODULE_EXPORT logtype_conf_t type_configs[logtype_end_of_list_marker] = {
     DEFAULT_LOG_CONFIG, /* logtype_cnid */
     DEFAULT_LOG_CONFIG, /* logtype_afpd */
     DEFAULT_LOG_CONFIG, /* logtype_dsi */
+    DEFAULT_LOG_CONFIG, /* logtype_atalkd */
+    DEFAULT_LOG_CONFIG, /* logtype_papd */
     DEFAULT_LOG_CONFIG, /* logtype_uams */
     DEFAULT_LOG_CONFIG, /* logtype_fce */
     DEFAULT_LOG_CONFIG, /* logtype_ad */
@@ -530,4 +534,3 @@ void setuplog(const char *logstr, const char *logfile, const bool log_us_timesta
 
     free(save);
 }
-

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2025,7 +2025,7 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     EC_INIT;
     dictionary *config;
     struct afp_options *options = &AFPObj->options;
-    int c _U_;
+    char *c;
     const char *p;
     char *q, *r;
     char val[MAXVAL];
@@ -2123,6 +2123,9 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     options->disconnected   = atalk_iniparser_getint   (config, INISEC_GLOBAL, "disconnect time",24);
     options->splice_size    = atalk_iniparser_getint   (config, INISEC_GLOBAL, "splice size",    64*1024);
     options->sparql_limit   = atalk_iniparser_getint   (config, INISEC_GLOBAL, "sparql results limit", 0);
+
+    c = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "ddp address", "");
+    atalk_aton(c, &options->ddpaddr);
 
     p = atalk_iniparser_getstring(config, INISEC_GLOBAL, "map acls", "rights");
     if (STRCMP(p, ==, "rights"))

--- a/sys/netatalk/at.h
+++ b/sys/netatalk/at.h
@@ -11,8 +11,6 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#ifndef NO_DDP
-
 #if defined(__linux__) /* pull in the linux header */
 #include <sys/socket.h>
 #include <asm/types.h>
@@ -126,6 +124,4 @@ extern struct protosw	atalksw[];
 #endif /* KERNEL */
 
 #endif /* __linux__ */
-#endif /* NO_DDP */
 #endif /* __AT_HEADER__ */
-


### PR DESCRIPTION
Very much a work in progress, but putting up this PR since the code compiles at least. (Although the tests are failing on some platforms.)

A few memos...

I chose not to port over srvloc, authprintdir or icon features. Maybe for later.

Mostly not touched desktop.c, volume.c, and uam.c yet because code has moved around alot.

The big commit where all the AppleTalk stuff got removed first is https://github.com/Netatalk/netatalk/commit/be96d276348da0a7e66eeec844b306e8a5fa8fac which served as a good reference.

The AFPobj struct got rejigged a lot, removing AppleTalk functionality when the ini parsing was rewritten https://github.com/Netatalk/netatalk/commit/df7560dfdb12b06090dc4b2c6e88d0858930b591#diff-ad0729adb892a8c3518ab325a752d53b59c6778afe97b76a32207d2c99bbb0d3

This was renamed: `afp_options->ipaddr` -> `afp_options->listen`

Two commits dealing with old charsets that we should check if they should be reverted: https://github.com/Netatalk/netatalk/commit/778588234ea038cae2ae0ca3cce1c61773154df4 https://github.com/Netatalk/netatalk/commit/f6f22820647c9654afa07c30a4d05441609b1f82