### PR TITLE
meson: Refresh the dynamic linker cache when installing on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,8 @@ jobs:
         run: cd build && meson test
       - name: Install
         run: meson install -C build
+      - name: Start netatalk
+        run: /usr/local/sbin/netatalk -V
       - name: Uninstall
         run: ninja -C build uninstall
 
@@ -168,6 +170,8 @@ jobs:
         run: cd build && meson test
       - name: Install
         run: meson install -C build
+      - name: Start netatalk
+        run: /usr/local/sbin/netatalk -V
       - name: Uninstall
         run: ninja -C build uninstall
 
@@ -196,6 +200,8 @@ jobs:
         run: cd build && meson test
       - name: Install
         run: meson install -C build
+      - name: Start netatalk
+        run: /usr/local/sbin/netatalk -V
       - name: Uninstall
         run: ninja -C build uninstall
 
@@ -251,6 +257,8 @@ jobs:
         run: cd build && meson test
       - name: Install
         run: sudo meson install -C build
+      - name: Start netatalk
+        run: /usr/local/sbin/netatalk -V
       - name: Uninstall
         run: sudo ninja -C build uninstall
 
@@ -307,6 +315,8 @@ jobs:
         run: cd build && meson test
       - name: Install
         run: meson install -C build
+      - name: Start netatalk
+        run: /usr/local/sbin/netatalk -V
       - name: Uninstall
         run: ninja -C build uninstall
 
@@ -381,6 +391,7 @@ jobs:
               -Dwith-appletalk=true
             meson compile -C build
             meson install -C build
+            /usr/local/sbin/netatalk -V
             ninja -C build uninstall
 
   build-freebsd:

--- a/config/libatalk.conf.in
+++ b/config/libatalk.conf.in
@@ -1,0 +1,2 @@
+# The location of the libatalk shared library for the dynamic linker cache
+@libdir@

--- a/config/meson.build
+++ b/config/meson.build
@@ -54,6 +54,16 @@ foreach file : static_conf_files
     endif
 endforeach
 
+if host_os == 'linux' and fs.exists('/etc/ld.so.conf.d')
+    configure_file(
+        input: 'libatalk.conf.in',
+        output: 'libatalk.conf',
+        configuration: cdata,
+        install: true,
+        install_dir: '/etc/ld.so.conf.d',
+    )
+endif
+
 install_data('README', install_dir: localstatedir / 'netatalk/CNID')
 
 if have_pam

--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -10,7 +10,18 @@ subdir('unicode')
 subdir('vfs')
 
 libatalk_deps = []
-libatalk_libs = []
+libatalk_libs = [
+    libacl,
+    libadouble,
+    libbstring,
+    libcnid,
+    libcompat,
+    libdsi,
+    libiniparser,
+    libunicode,
+    libutil,
+    libvfs,
+]
 libatalk_sources = []
 
 if have_acls
@@ -44,20 +55,19 @@ libatalk = library(
     libatalk_sources,
     include_directories: root_includes,
     dependencies: [libatalk_deps, libcnid_deps],
-    link_whole: [
-        libacl,
-        libadouble,
-        libatalk_libs,
-        libbstring,
-        libcnid,
-        libcompat,
-        libdsi,
-        libiniparser,
-        libunicode,
-        libutil,
-        libvfs,
-    ],
+    link_whole: libatalk_libs,
     version: '19.0.0',
     soversion: '19',
     install: true,
 )
+
+if host_os == 'linux' and get_option('with-install-hooks')
+    ldconfig = find_program('ldconfig', required: false)
+    if ldconfig.found()
+        if run_command(ldconfig, '-v', check: false).returncode() == 0
+            meson.add_install_script(ldconfig, '-v', skip_if_destdir: true)
+        else
+            warning('You may have to take steps for netatalk to find the libatalk shared library.')
+        endif
+    endif
+ endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -85,7 +85,13 @@ option(
     'with-init-hooks',
     type: 'boolean',
     value: true,
-    description: 'Enable install hooks for OS specific init system',
+    description: 'Enable install hooks for the configured init system',
+)
+option(
+    'with-install-hooks',
+    type: 'boolean',
+    value: true,
+    description: 'Enable OS specific install hooks',
 )
 option(
     'with-kerberos',


### PR DESCRIPTION
- Run ldconfig on glib based Linux as an install hook, so that the libatalk shared library path can be cached.
- Install a config file to `/etc/ld.so.conf.d` if needed to enable ldconfig to find libatalk.
- Introduce a `-Dwith-install-hooks` boolean option to disable this, if running in a non-privileged mode.
- In the CI workflow: run netatalk -V on OSes that lack an init system.