### PR TITLE
[3.2] meson: Use modern linker flag for rpath, remove dtag override

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -352,12 +352,6 @@ else
     rpath_libdir = ''
 endif
 
-if host_os == 'linux'
-    enable_dtags = true
-else
-    enable_dtags = false
-endif
-
 #
 # Check for the Berkeley DB library
 #
@@ -436,11 +430,7 @@ else
 endif
 
 if enable_rpath
-    bdb_link_args += '-R' + bdb_libdir
-endif
-
-if enable_dtags
-    bdb_link_args += '-Wl,--enable-new-dtags'
+    bdb_link_args += '-Wl,-rpath,' + bdb_libdir
 endif
 
 if bdb_header != ''
@@ -510,10 +500,7 @@ crypto = dependency('libcrypto', required: false)
 libtls = dependency('libtls', required: false)
 
 if enable_rpath and crypto.found()
-    ssl_link_args += ['-R' / crypto.get_variable(pkgconfig: 'libdir')]
-    if enable_dtags
-        ssl_link_args += '-Wl,--enable-new-dtags'
-    endif
+    ssl_link_args += ['-Wl,-rpath,' / crypto.get_variable(pkgconfig: 'libdir')]
 endif
 
 wolfssl = dependency('wolfssl', required: false)
@@ -992,7 +979,7 @@ libgcrypt_link_args = []
 if libgcrypt_path != ''
     libgcrypt_link_args += ['-L' + libgcrypt_path / 'lib', '-lgcrypt']
     if enable_rpath
-        libgcrypt_link_args += ['-R' + libgcrypt_path / 'lib']
+        libgcrypt_link_args += ['-Wl,-rpath,' + libgcrypt_path / 'lib']
     endif
     libgcrypt = declare_dependency(
         link_args: libgcrypt_link_args,
@@ -1312,7 +1299,7 @@ ldap_link_args = []
 if ldap_path != ''
     ldap_link_args += ['-L' + ldap_path / 'lib', '-lldap']
     if enable_rpath
-        ldap_link_args += ['-R' + ldap_path / 'lib']
+        ldap_link_args += ['-Wl,-rpath,' + ldap_path / 'lib']
     endif
     ldap = declare_dependency(
         link_args: ldap_link_args,
@@ -1378,7 +1365,7 @@ libiconv_link_args = []
 if iconv_path != ''
     libiconv_link_args += ['-L' + iconv_path / 'lib', '-liconv']
     if enable_rpath
-        libiconv_link_args += ['-R' + iconv_path / 'lib']
+        libiconv_link_args += ['-Wl,-rpath,' + iconv_path / 'lib']
     endif
     iconv = declare_dependency(
         link_args: libiconv_link_args,
@@ -1615,7 +1602,7 @@ else
     if pam_path != '' and pam_dir != '/'
         pam_link_args += ['-L' + pam_path / 'lib', '-lpam']
         if enable_rpath
-            pam_link_args += ['-R' + pam_path / 'lib']
+            pam_link_args += ['-Wl,-rpath,' + pam_path / 'lib']
         endif
         pam = declare_dependency(
             link_args: pam_link_args,


### PR DESCRIPTION
Contemporary gcc fails with the old -R linker argument. Moreover, the "new dtags" override is redundant these days.