### PR TITLE
[2.4] meson: Refresh the dynamic linker cache when installing on Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,8 @@ jobs:
         run: make check
       - name: Autotools - Install
         run: make install
+      - name: Autotools - Start netatalk
+        run: /usr/local/sbin/afpd -V
       - name: Autotools - Uninstall
         run: make uninstall
       - name: Meson - Configure
@@ -123,6 +125,8 @@ jobs:
         run: cd build && meson test
       - name: Meson - Install
         run: meson install -C build
+      - name: Meson - Start netatalk
+        run: /usr/local/sbin/afpd -V
       - name: Meson - Uninstall
         run: ninja -C build uninstall
 
@@ -160,6 +164,8 @@ jobs:
         run: make check
       - name: Autotools - Install
         run: make install
+      - name: Autotools - Start netatalk
+        run: /usr/local/sbin/afpd -V
       - name: Autotools - Uninstall
         run: make uninstall
       - name: Meson - Configure
@@ -174,6 +180,8 @@ jobs:
         run: cd build && meson test
       - name: Meson - Install
         run: meson install -C build
+      - name: Meson - Start netatalk
+        run: /usr/local/sbin/afpd -V
       - name: Meson - Uninstall
         run: ninja -C build uninstall
 
@@ -205,6 +213,8 @@ jobs:
         run: make check
       - name: Autotools - Install
         run: make install
+      - name: Autotools - Start netatalk
+        run: /usr/local/sbin/afpd -V
       - name: Autotools - Uninstall
         run: make uninstall
       - name: Meson - Configure
@@ -221,6 +231,8 @@ jobs:
         run: cd build && meson test
       - name: Meson - Install
         run: meson install -C build
+      - name: Meson - Start netatalk
+        run: /usr/local/sbin/afpd -V
       - name: Meson - Uninstall
         run: ninja -C build uninstall
 
@@ -268,6 +280,8 @@ jobs:
         run: make check
       - name: Autotools - Install
         run: sudo make install
+      - name: Autotools - Start netatalk
+        run: /usr/local/sbin/afpd -V
       - name: Autotools - Uninstall
         run: sudo make uninstall
       - name: Meson - Configure
@@ -283,6 +297,8 @@ jobs:
         run: cd build && meson test
       - name: Meson - Install
         run: sudo meson install -C build
+      - name: Meson - Start netatalk
+        run: /usr/local/sbin/afpd -V
       - name: Meson - Uninstall
         run: sudo ninja -C build uninstall
 
@@ -335,6 +351,8 @@ jobs:
         run: make check
       - name: Autotools - Install
         run: make install
+      - name: Autotools - Start netatalk
+        run: /usr/local/sbin/afpd -V
       - name: Autotools - Uninstall
         run: make uninstall
       - name: Meson - Configure
@@ -349,6 +367,8 @@ jobs:
         run: cd build && meson test
       - name: Meson - Install
         run: meson install -C build
+      - name: Meson - Start netatalk
+        run: /usr/local/sbin/afpd -V
       - name: Meson - Uninstall
         run: ninja -C build uninstall
 
@@ -501,11 +521,13 @@ jobs:
               MAKE=gmake
             gmake -j2
             gmake install
+            /usr/local/sbin/afpd -V
             gmake uninstall
             echo "Building with Meson"
             meson setup build
             meson compile -C build
             meson install -C build
+            /usr/local/sbin/afpd -V
             ninja -C build uninstall
 
   build-freebsd:

--- a/config/libatalk.conf.in
+++ b/config/libatalk.conf.in
@@ -1,0 +1,2 @@
+# The location of the libatalk shared library for the dynamic linker cache
+@libdir@

--- a/config/meson.build
+++ b/config/meson.build
@@ -55,6 +55,16 @@ foreach file : conf_files
     endif
 endforeach
 
+if host_os == 'linux' and fs.exists('/etc/ld.so.conf.d')
+    configure_file(
+        input: 'libatalk.conf.in',
+        output: 'libatalk.conf',
+        configuration: cdata,
+        install: true,
+        install_dir: '/etc/ld.so.conf.d',
+    )
+endif
+
 if have_pam
     subdir('pam')
 endif

--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -59,3 +59,14 @@ libatalk = library(
     soversion: '0',
     install: true,
 )
+
+if host_os == 'linux' and get_option('with-install-hooks')
+    ldconfig = find_program('ldconfig', required: false)
+    if ldconfig.found()
+        if run_command(ldconfig, '-v', check: false).returncode() == 0
+            meson.add_install_script(ldconfig, '-v', skip_if_destdir: true)
+        else
+            warning('You may have to take steps for netatalk to find the libatalk shared library.')
+        endif
+    endif
+ endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -73,7 +73,13 @@ option(
     'with-init-hooks',
     type: 'boolean',
     value: true,
-    description: 'Enable install hooks for OS specific init system',
+    description: 'Enable install hooks for the configured init system',
+)
+option(
+    'with-install-hooks',
+    type: 'boolean',
+    value: true,
+    description: 'Enable OS specific install hooks',
 )
 option(
     'with-kerberos',


### PR DESCRIPTION
- Run ldconfig on glib based Linux as an install hook, so that the libatalk shared library path can be cached.
- Install a config file to `/etc/ld.so.conf.d` if needed to enable ldconfig to find libatalk.
- Introduce a `-Dwith-install-hooks` boolean option to disable this, if running in a non-privileged mode.
- In the CI workflow: run netatalk -V on OSes that lack an init system.