### PR TITLE
[3.2] meson: Introduce option to control which manual l10n to build

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -10,6 +10,9 @@ manual_stylesheet = configure_file(
     configuration: cdata,
 )
 
-subdir('ja')
 subdir('manpages')
 subdir('manual')
+
+if 'ja' in get_option('with-manual-l10n')
+    subdir('ja')
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -340,3 +340,12 @@ option(
     value: 'dbd',
     description: 'Set default DID scheme',
 )
+option(
+    'with-manual-l10n',
+    type: 'array',
+    choices: [
+        'ja',
+    ],
+    value: [],
+    description: 'Choose the localizations of the html manual to build',
+)


### PR DESCRIPTION
New option `-Dwith-manual-l10n=ja` to build the Japanese manual localization. Defaults to none.