### PR TITLE
[3.2] meson: Install htmldocs into htmldocs subdir

### DIFF
--- a/doc/ja/manual/meson.build
+++ b/doc/ja/manual/meson.build
@@ -68,5 +68,5 @@ manual_gen = custom_target(
         '@INPUT@',
     ],
     install: true,
-    install_dir: datadir / 'doc/netatalk/ja',
+    install_dir: datadir / 'doc/netatalk/htmldocs/ja',
 )

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -68,5 +68,5 @@ manual_gen = custom_target(
         '@INPUT@',
     ],
     install: true,
-    install_dir: datadir / 'doc/netatalk',
+    install_dir: datadir / 'doc/netatalk/htmldocs',
 )


### PR DESCRIPTION
Previously, all generated html pages were interspersed with other docs. This allows for a cleaner separation.