### PR TITLE
[3.2] meson: Ability to control the run-time linker path config file

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -43,7 +43,10 @@ endif
 
 install_data('README', install_dir: localstatedir / 'netatalk')
 
-if host_os == 'linux' and fs.exists('/etc/ld.so.conf.d')
+if (
+    fs.exists('/etc/ld.so.conf.d')
+    and get_option('with-ldsoconf')
+)
     configure_file(
         input: 'libatalk.conf.in',
         output: 'libatalk.conf',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -106,6 +106,12 @@ option(
     description: 'Enable LDAP support'
 )
 option(
+    'with-ldsoconf',
+    type: 'boolean',
+    value: true,
+    description: 'Enable custom library search path for the run-time linker',
+)
+option(
     'with-libiconv',
     type: 'boolean',
     value: true,


### PR DESCRIPTION
Introducing boolean meson build option `-Dwith-ldsoconf` ... when true, a /etc/ld.so.conf.d/libatalk.conf file is created with the custom run-time linker search path. When false, this file is not created. Default is true.