### PR TITLE
[2.4] meson: Correctly install AppleTalk headers and etc2ps.sh

### DIFF
--- a/etc/psf/meson.build
+++ b/etc/psf/meson.build
@@ -32,6 +32,12 @@ executable(
     install_rpath: rpath_libdir,
 )
 
+install_data(
+    'etc2ps.sh',
+    install_dir: libexecdir,
+    install_mode: 'rwxr-xr-x',
+)
+
 install_data('pagecount.ps', install_dir: datadir / 'netatalk')
 
 psf_symlinks = [

--- a/include/atalk/meson.build
+++ b/include/atalk/meson.build
@@ -19,6 +19,8 @@ headers = [
     'netddp.h',
     'pap.h',
     'paths.h',
+    'queue.h',
+    'rtmp.h',
     'server_child.h',
     'server_ipc.h',
     'uam.h',

--- a/sys/netatalk/meson.build
+++ b/sys/netatalk/meson.build
@@ -7,7 +7,7 @@ netatalk_headers = [
     'phase2.h',
 ]
 
-if use_glibc_at_header
+if not use_glibc_at_header
     netatalk_headers += 'at.h'
 endif
 


### PR DESCRIPTION
Three files that were overlooked when setting up the Meson build system, plus flipped logic for installing at.h