### PR TITLE
Docker: Ship a docker-compose.yml sample file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,4 @@ libatalk/unicode/utf16_casetable.h
 
 # Temporary build files
 build/**
-docker-compose.yml
 UnicodeData.txt

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -21,31 +21,20 @@ The former option is more secure, but you will have to manually specify the IP a
 It is recommended to set up either a bind mount, or a Docker managed volume for persistent storage.
 Without this, the shared volume be stored in volatile storage that is lost upon container shutdown.
 
-Sample `docker-compose.yml` with docker managed volume and Zeroconf
+You can use the sample [docker-compose.yml](https://github.com/Netatalk/netatalk/blob/main/docker-compose.yml) that is distributed with this source code.
+
+Below follows a sample `docker run` command. Substitute `/path/to/share` with an actual path on your file system with appropriate permissions, and `AFP_USER` and `AFP_PASS` with the appropriate user and password.
 
 ```
-services:
-  netatalk:
-    image: netatalk3:latest
-    network_mode: "host"
-    cap_add:
-      - NET_ADMIN
-    volumes:
-      - afpshare:/mnt/afpshare
-      - afpbackup:/mnt/afpbackup
-      - /var/run/dbus:/var/run/dbus
-    environment:
-      - "AFP_USER=atalk"
-      - "AFP_PASS=atalk"
-volumes:
-  afpshare:
-  afpbackup:
-```
-
-Sample `docker run` command. Substitute `/path/to/share` with an actual path on your file system with appropriate permissions.
-
-```
-docker run --rm --network host --cap-add=NET_ADMIN --volume "/path/to/share:/mnt/afpshare" --volume "/path/to/backup:/mnt/afpbackup" --volume "/var/run/dbus:/var/run/dbus" --env AFP_USER=atalk --env AFP_PASS=atalk --name netatalk netatalk3:latest
+docker run --rm \
+  --network host \
+  --cap-add=NET_ADMIN \
+  --volume "/path/to/share:/mnt/afpshare" \
+  --volume "/path/to/backup:/mnt/afpbackup" \
+  --volume "/var/run/dbus:/var/run/dbus" \
+  --env AFP_USER= \
+  --env AFP_PASS= \
+  --name netatalk netatalk3:latest
 ```
 
 ## Constraints

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,7 +66,7 @@ RUN meson setup build \
     -Dwith-dtrace=false \
     -Dwith-embedded-ssl=true \
     -Dwith-init-style=none \
-    -Dwith-manual=false \
+    -Dwith-manual=none \
     -Dwith-pgp-uam=false \
     -Dwith-quota=false \
     -Dwith-tcp-wrappers=false \

--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -22,33 +22,40 @@ set -eo pipefail
 
 echo "*** Setting up users and groups"
 
-if [ ! -z "${AFP_USER}" ]; then
-    if [ ! -z "${AFP_UID}" ]; then
-        uidcmd="-u ${AFP_UID}"
-    fi
-    if [ ! -z "${AFP_GID}" ]; then
-        gidcmd="-g ${AFP_GID}"
-    fi
-    if [ ! -z "${AFP_GROUP}" ]; then
-        groupcmd="-G ${AFP_GROUP}"
-        addgroup ${gidcmd} ${AFP_GROUP} || true 2> /dev/null
-    fi
-    adduser ${uidcmd} ${groupcmd} --no-create-home --disabled-password "${AFP_USER}" || true 2> /dev/null
-
-    echo "${AFP_USER}:${AFP_PASS}" | chpasswd
-
-    # Creating credentials for the RandNum UAM
-    set +e
-    if [ -f "/usr/local/etc/netatalk/afppasswd" ]; then
-    	rm -f /usr/local/etc/netatalk/afppasswd
-    fi
-    afppasswd -c
-    afppasswd -a -f -w "${AFP_PASS}" "${AFP_USER}"
-    if [ $? -ne 0 ]; then
-        echo "NOTE: Use a password of 8 chars or less to authenticate with Mac OS 8 or earlier clients"
-    fi
-    set -e
+if [ -z "${AFP_USER}" ]; then
+    echo "ERROR: AFP_USER needs to be set to use this Docker container."
+    exit 1
 fi
+if [ -z "${AFP_PASS}" ]; then
+    echo "ERROR: AFP_PASS needs to be set to use this Docker container."
+    exit 1
+fi
+
+if [ ! -z "${AFP_UID}" ]; then
+    uidcmd="-u ${AFP_UID}"
+fi
+if [ ! -z "${AFP_GID}" ]; then
+    gidcmd="-g ${AFP_GID}"
+fi
+if [ ! -z "${AFP_GROUP}" ]; then
+    groupcmd="-G ${AFP_GROUP}"
+    addgroup ${gidcmd} ${AFP_GROUP} || true 2> /dev/null
+fi
+adduser ${uidcmd} ${groupcmd} --no-create-home --disabled-password "${AFP_USER}" || true 2> /dev/null
+
+echo "${AFP_USER}:${AFP_PASS}" | chpasswd
+
+# Creating credentials for the RandNum UAM
+set +e
+if [ -f "/usr/local/etc/netatalk/afppasswd" ]; then
+	rm -f /usr/local/etc/netatalk/afppasswd
+fi
+afppasswd -c
+afppasswd -a -f -w "${AFP_PASS}" "${AFP_USER}"
+if [ $? -ne 0 ]; then
+    echo "NOTE: Use a password of 8 chars or less to authenticate with Mac OS 8 or earlier clients"
+fi
+set -e
 
 echo "*** Configuring shared volume"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  netatalk:
+    image: netatalk/netatalk3:latest
+    network_mode: "host"
+    cap_add:
+      - NET_ADMIN
+    volumes:
+      - afpshare:/mnt/afpshare
+      - afpbackup:/mnt/afpbackup
+      - /var/run/dbus:/var/run/dbus
+    environment:
+      - "AFP_USER="
+      - "AFP_PASS="
+volumes:
+  afpshare:
+  afpbackup:


### PR DESCRIPTION
Ship a sample docker-compose.yml that was previously in the Docker readme. Add a warning to entry script that warns when using the default password.