### PR TITLE
[2.4] meson: Introduce a with-init-dir option

### DIFF
--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -3,6 +3,14 @@ if get_option('with-init-style') == 'none'
     init_dirs += init_dir
 endif
 
+init_dir_override = get_option('with-init-dir')
+
+if init_dir_override != ''
+    init_dir = init_dir_override
+else
+    init_dir = ''
+endif
+
 if (
     get_option('with-init-style') == 'debian'
     or get_option('with-init-style') == 'debian-systemd'
@@ -11,7 +19,9 @@ if (
     or get_option('with-init-style') == 'suse-systemd'
     or get_option('with-init-style') == 'systemd'
 )
-    init_dir = '/usr/lib/systemd/system'
+    if init_dir_override == ''
+        init_dir = '/usr/lib/systemd/system'
+    endif
     init_dirs += init_dir
     service_data = [
         'a2boot',
@@ -44,7 +54,9 @@ if (
   get_option('with-init-style') == 'debian'
   or get_option('with-init-style') == 'debian-sysv'
 )
-    init_dir = '/etc/init.d'
+    if init_dir_override == ''
+        init_dir = '/etc/init.d'
+    endif
     init_dirs += init_dir
     custom_target(
         'debian_sysv',
@@ -68,7 +80,9 @@ if (
 endif
 
 if get_option('with-init-style') == 'netbsd'
-    init_dir = '/etc/rc.d'
+    if init_dir_override == ''
+        init_dir = '/etc/rc.d'
+    endif
     init_dirs += init_dir
     rc_scripts = [
         'rc.afpd',
@@ -93,7 +107,9 @@ if get_option('with-init-style') == 'netbsd'
 endif
 
 if get_option('with-init-style') == 'solaris'
-    init_dir = '/etc/init.d'
+    if init_dir_override == ''
+        init_dir = '/etc/init.d'
+    endif
     init_dirs += init_dir
     custom_target(
         'solaris',
@@ -130,7 +146,9 @@ if (
     get_option('with-init-style') == 'openrc'
     or get_option('with-init-style') == 'gentoo-openrc'
 )
-    init_dir = '/etc/init.d'
+    if init_dir_override == ''
+        init_dir = '/etc/init.d'
+    endif
     init_dirs += init_dir
     custom_target(
         'openrc',
@@ -153,7 +171,9 @@ if (
 endif
 
 if get_option('with-init-style') == 'macos-launchd'
-    init_dir = '/Library/LaunchDaemons'
+    if init_dir_override == ''
+        init_dir = '/Library/LaunchDaemons'
+    endif
     init_dirs += init_dir
     custom_target(
         'netatalkd',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -238,6 +238,12 @@ option(
     description: 'Set path to GSSAPI for Kerberos V UAM. Must contain lib and include dirs',
 )
 option(
+    'with-init-dir',
+    type: 'string',
+    value: '',
+    description: 'Set path to init system directory',
+)
+option(
     'with-ldap-path',
     type: 'string',
     value: '',


### PR DESCRIPTION
Backporting the with-init-dir meson option from 3.2