### PR TITLE
[2.4] meson: Introduce a with-lockfile-path option

### DIFF
--- a/include/atalk/paths.h
+++ b/include/atalk/paths.h
@@ -13,13 +13,13 @@
 /* lock file path. this should be re-organized a bit. */
 #if ! defined (_PATH_LOCKDIR)
 #  if defined (FHS_COMPATIBILITY) || defined (__NetBSD__) || defined (__OpenBSD__) || defined (__APPLE__)
-#    define _PATH_LOCKDIR	"/var/run/"
+#    define _PATH_LOCKDIR	"/var/run"
 #  elif defined (BSD4_4)
-#      define _PATH_LOCKDIR	"/var/spool/lock/"
+#      define _PATH_LOCKDIR	"/var/spool/lock"
 #  elif defined (__linux__)
-#    define _PATH_LOCKDIR	"/var/lock/"
+#    define _PATH_LOCKDIR	"/var/lock"
 #  else
-#    define _PATH_LOCKDIR	"/var/spool/locks/"
+#    define _PATH_LOCKDIR	"/var/spool/locks"
 #  endif
 #endif
 
@@ -40,9 +40,9 @@
 #define _PATH_ATALKDEBUG	"/tmp/atalkd.debug"
 #define _PATH_ATALKDTMP		"atalkd.tmp"
 #if defined (FHS_COMPATIBILITY) || defined (__NetBSD__) || defined (__OpenBSD__)
-#  define _PATH_ATALKDLOCK	ATALKPATHCAT(_PATH_LOCKDIR,"atalkd.pid")
+#  define _PATH_ATALKDLOCK	ATALKPATHCAT(_PATH_LOCKDIR,"/atalkd.pid")
 #else
-#  define _PATH_ATALKDLOCK	ATALKPATHCAT(_PATH_LOCKDIR,"atalkd")
+#  define _PATH_ATALKDLOCK	ATALKPATHCAT(_PATH_LOCKDIR,"/atalkd")
 #endif
 
 /*
@@ -50,29 +50,29 @@
  */
 #define _PATH_TMPPAGEORDER	"/tmp/psorderXXXXXX"
 #if defined (FHS_COMPATIBILITY) || defined (__NetBSD__) || defined (__OpenBSD__)
-#  define _PATH_PAPDLOCK	ATALKPATHCAT(_PATH_LOCKDIR,"papd.pid")
+#  define _PATH_PAPDLOCK	ATALKPATHCAT(_PATH_LOCKDIR,"/papd.pid")
 #else
-#  define _PATH_PAPDLOCK	ATALKPATHCAT(_PATH_LOCKDIR,"papd")
+#  define _PATH_PAPDLOCK	ATALKPATHCAT(_PATH_LOCKDIR,"/papd")
 #endif
 
 /*
  * afpd paths
  */
 #define _PATH_AFPTKT		"/tmp/AFPtktXXXXXX"
-#define _PATH_AFP_IPC       ATALKPATHCAT(_PATH_LOCKDIR,"afpd_ipc")
+#define _PATH_AFP_IPC       ATALKPATHCAT(_PATH_LOCKDIR,"/afpd_ipc")
 #if defined (FHS_COMPATIBILITY) || defined (__NetBSD__) || defined (__OpenBSD__)
-#  define _PATH_AFPDLOCK	ATALKPATHCAT(_PATH_LOCKDIR,"afpd.pid")
+#  define _PATH_AFPDLOCK	ATALKPATHCAT(_PATH_LOCKDIR,"/afpd.pid")
 #else
-#  define _PATH_AFPDLOCK	ATALKPATHCAT(_PATH_LOCKDIR,"afpd")
+#  define _PATH_AFPDLOCK	ATALKPATHCAT(_PATH_LOCKDIR,"/afpd")
 #endif
 
 /*
  * cnid_metad paths
  */
 #if defined (FHS_COMPATIBILITY) || defined (__NetBSD__) || defined (__OpenBSD__)
-#  define _PATH_CNID_METAD_LOCK	ATALKPATHCAT(_PATH_LOCKDIR,"cnid_metad.pid")
+#  define _PATH_CNID_METAD_LOCK	ATALKPATHCAT(_PATH_LOCKDIR,"/cnid_metad.pid")
 #else
-#  define _PATH_CNID_METAD_LOCK	ATALKPATHCAT(_PATH_LOCKDIR,"cnid_metad")
+#  define _PATH_CNID_METAD_LOCK	ATALKPATHCAT(_PATH_LOCKDIR,"/cnid_metad")
 #endif
 
 #endif /* atalk/paths.h */

--- a/meson.build
+++ b/meson.build
@@ -68,6 +68,12 @@ if host_os == 'linux'
     netatalk_common_flags += '-D_GNU_SOURCE'
 endif
 
+lockfile_path = get_option('with-lockfile-path')
+
+if lockfile_path != ''
+    netatalk_common_flags += '-D_PATH_LOCKDIR="' + lockfile_path + '"'
+endif
+
 add_global_arguments(netatalk_common_flags, language: 'c')
 
 netatalk_common_link_args = []

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -256,6 +256,12 @@ option(
     description: 'Set path to libiconv installation. Must contain lib and include dirs',
 )
 option(
+    'with-lockfile-path',
+    type: 'string',
+    value: '',
+    description: 'Set path to the Netatalk daemon lockfile directory',
+)
+option(
     'with-pam-path',
     type: 'string',
     value: '',


### PR DESCRIPTION
Use with-lockfile-path to set a lockfile path that is not defined in paths.h

This leverages the special `-D_PATH_LOCKDIR` compiler flag that is only in 2.x (refactored away in 3.x and later)