### PR TITLE
Add Back Legacy Options

### DIFF
--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -2198,6 +2198,17 @@
         </varlistentry>
 
         <varlistentry>
+          <term>legacy volume size = <replaceable>BOOLEAN</replaceable> (default:
+          <emphasis>no</emphasis>) <type>(V)</type></term>
+
+          <listitem>
+            <para>Limit disk size reporting to 2GB for legacy clients. This can
+            be used for older Macintoshes running System 7.1 or earlier and
+            using newer AppleShare clients.</para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
           <term>network ids = <replaceable>BOOLEAN</replaceable> (default:
           <emphasis>yes</emphasis>) <type>(V)</type></term>
 
@@ -2216,6 +2227,18 @@
             <para>A non-zero return code from preexec close the volume being
             immediately, preventing clients to mount/see the volume in
             question.</para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
+          <term>prodos = <replaceable>BOOLEAN</replaceable> (default:
+          <emphasis>no</emphasis>) <type>(V)</type></term>
+
+          <listitem>
+            <para>Enable ProDOS support. This option should only be enabled
+            for volumes you expect to netboot an Apple II from. In addition to
+            setting the boot flag on the volume, it restricts the volume free
+            space shown to 32MB.</para>
           </listitem>
         </varlistentry>
 

--- a/include/atalk/volume.h
+++ b/include/atalk/volume.h
@@ -125,6 +125,8 @@ typedef enum {
 #define AFPVOL_CHMOD_PRESERVE_ACL (1 << 9) /* try to preserve ACLs */
 #define AFPVOL_CHMOD_IGNORE (1 << 10) /* try to preserve ACLs */
 #define AFPVOL_FORCE_STICKY_XATTR (1 << 11) /* write metadata xattr as root on sticky dirs */
+#define AFPVOL_LIMITSIZE (1 << 12)  /* limit size for older macs */
+#define AFPVOL_A2VOL     (1 << 13)   /* prodos volume */
 #define AFPVOL_NOSTAT    (1 << 16)  /* advertise the volume even if we can't stat() it
                                      * maybe because it will be mounted later in preexec */
 #define AFPVOL_UNIX_PRIV (1 << 17)  /* support unix privileges */

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -918,6 +918,10 @@ static struct vol *creatvol(AFPObj *obj,
         volume->v_flags |= AFPVOL_RO;
     if (getoption_bool(obj->iniconfig, section, "invisible dots", preset, 0))
         volume->v_flags |= AFPVOL_INV_DOTS;
+    if (getoption_bool(obj->iniconfig, section, "legacy volume size", preset, 0))
+        volume->v_flags |= AFPVOL_LIMITSIZE;
+    if (getoption_bool(obj->iniconfig, section, "prodos", preset, 0))
+        volume->v_flags |= AFPVOL_A2VOL;
     if (!getoption_bool(obj->iniconfig, section, "stat vol", preset, 1))
         volume->v_flags |= AFPVOL_NOSTAT;
     if (getoption_bool(obj->iniconfig, section, "unix priv", preset, 1))


### PR DESCRIPTION
Adds back the limit volume size and ProDOS options from Netatalk 2.x. Update man page. Fixes #1332 