### PR TITLE
[3.2] meson: Allow ldconfig to run unprivileged during setup

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -41,8 +41,6 @@ else
     install_data('netatalk-dbus.conf', install_dir: dbus_sysconfpath)
 endif
 
-install_data('README', install_dir: localstatedir / 'netatalk')
-
 if (
     fs.exists('/etc/ld.so.conf.d')
     and get_option('with-ldsoconf')
@@ -56,6 +54,7 @@ if (
     )
 endif
 
+install_data('README', install_dir: localstatedir / 'netatalk')
 install_data('README', install_dir: localstatedir / 'netatalk/CNID')
 
 if have_pam

--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -57,10 +57,10 @@ libatalk = library(
 if host_os == 'linux' and get_option('with-install-hooks')
     ldconfig = find_program('ldconfig', required: false)
     if ldconfig.found()
-        if run_command(ldconfig, '-v', check: false).returncode() == 0
+        if run_command(ldconfig, '-N', '-X', check: false).returncode() == 0
             meson.add_install_script(ldconfig, '-v', skip_if_destdir: true)
         else
-            warning('You may have to take steps for netatalk to find the libatalk shared library.')
+            warning('You may have to run ldconfig manually for netatalk to find the libatalk shared library.')
         endif
     endif
  endif


### PR DESCRIPTION
Should fix the issue of ldconfig not being run as an install hook on Debian Bookworm.