### PR TITLE
[2.4] meson: Allow ldconfig to run unprivileged during setup

### DIFF
--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -63,10 +63,10 @@ libatalk = library(
 if host_os == 'linux' and get_option('with-install-hooks')
     ldconfig = find_program('ldconfig', required: false)
     if ldconfig.found()
-        if run_command(ldconfig, '-v', check: false).returncode() == 0
+        if run_command(ldconfig, '-N', '-X', check: false).returncode() == 0
             meson.add_install_script(ldconfig, '-v', skip_if_destdir: true)
         else
-            warning('You may have to take steps for netatalk to find the libatalk shared library.')
+            warning('You may have to run ldconfig manually for netatalk to find the libatalk shared library.')
         endif
     endif
  endif


### PR DESCRIPTION
Should fix the issue of ldconfig not being run as an install hook on Debian Bookworm.