### PR TITLE
docker: Add entry script step to clean up any residual lock file

### DIFF
--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -105,6 +105,11 @@ valid users = ${AFP_USER}
 EOF
 fi
 
+if [ -f "/var/lock/netatalk" ]; then
+    echo "*** Removing residual lock file"
+    rm -f /var/lock/netatalk
+fi
+
 echo "*** Starting AFP server"
 
 # Prevent afpd from forking with '-d' parameter, to maintain container lifecycle


### PR DESCRIPTION
Avoiding a corner case fail state when a residual lock file prevents netatalk from starting up.