### PR TITLE
[3.2] meson: Enable rpath and disable ldsoconf by default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -4,11 +4,13 @@ Changes in 3.2.7
        GitHub #1396
        New boolean Meson option: `-Dwith-ldsoconf'
        When set to false, do not create /etc/ld.so.conf.d/libatalk.conf
+* BREAKING: meson: Enable rpath by default, while disabling ldsoconf
+       by default, GitHub #1417
 * FIX: meson: Allow ldconfig to run unprivileged during setup, GitHub #1407
-* FIX: Docker: Add entry script step to clean up any residual lock file,
+* FIX: docker: Add entry script step to clean up any residual lock file,
        GitHub #1412
-* NEW: Docker: Ship a docker-compose.yml sample file, GitHub #1414
-* NEW: Docker: Check for AFP_USER and AFP_PASS when launching container,
+* NEW: docker: Ship a docker-compose.yml sample file, GitHub #1414
+* NEW: docker: Check for AFP_USER and AFP_PASS when launching container,
        GitHub #1415
 
 Changes in 3.2.6

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -108,7 +108,7 @@ option(
 option(
     'with-ldsoconf',
     type: 'boolean',
-    value: true,
+    value: false,
     description: 'Enable custom library search path for the run-time linker',
 )
 option(
@@ -150,7 +150,7 @@ option(
 option(
     'with-rpath',
     type: 'boolean',
-    value: false,
+    value: true,
     description: 'Enable RPATH/RUNPATH',
 )
 option(


### PR DESCRIPTION
Changing the Meson config defaults for these two flags.