### PR TITLE
[2.4] meson: Enable rpath and disable ldsoconf by default

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -108,7 +108,7 @@ option(
 option(
     'with-ldsoconf',
     type: 'boolean',
-    value: true,
+    value: false,
     description: 'Enable custom library search path for the run-time linker',
 )
 option(
@@ -156,7 +156,7 @@ option(
 option(
     'with-rpath',
     type: 'boolean',
-    value: false,
+    value: true,
     description: 'Enable RPATH/RUNPATH',
 )
 option(


### PR DESCRIPTION
Changing the Meson config defaults for these two flags.