### PR TITLE
Add AppleTalk support back into afpd

### DIFF
--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -629,6 +629,17 @@
         </varlistentry>
 
         <varlistentry>
+          <term>appletalk = <replaceable>BOOLEAN</replaceable> (default:
+          <emphasis>no</emphasis>) <type>(G)</type></term>
+
+          <listitem>
+            <para>Enables support for AFP-over-Appletalk. This option requires
+            that your operating system supports the AppleTalk networking
+            protocol.</para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
           <term>cnid listen = <replaceable>ip address[:port] [ip
           address[:port] ...]</replaceable> <type>(G)</type></term>
 

--- a/etc/afpd/afp_asp.c
+++ b/etc/afpd/afp_asp.c
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 1997 Adrian Sun (asun@zoology.washington.edu)
+ * Copyright (c) 1990,1993 Regents of The University of Michigan.
+ * All Rights Reserved.  See COPYRIGHT.
+ *
+ * modified from main.c. this handles afp over asp. 
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#ifndef NO_DDP
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+#include <atalk/logger.h>
+#include <errno.h>
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif /* HAVE_SYS_TIME_H */
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif /* HAVE_SYS_STAT_H */
+
+#include <netatalk/endian.h>
+#include <atalk/atp.h>
+#include <atalk/asp.h>
+#include <atalk/compat.h>
+#include <atalk/util.h>
+#include <atalk/globals.h>
+
+#include "switch.h"
+#include "auth.h"
+#include "fork.h"
+#include "dircache.h"
+
+static AFPObj *child;
+
+static void afp_authprint_remove(AFPObj *);
+
+static void afp_asp_close(AFPObj *obj)
+{
+    ASP asp = obj->handle;
+
+    if ( obj->uid != geteuid() ) {
+        if (seteuid(obj->uid) < 0) {
+            LOG(log_error, logtype_afpd,
+			"afp_asp_close: can't seteuid back to %i from %i (%s)",
+			obj->uid, geteuid(), strerror(errno));
+        }
+        exit(EXITERR_SYS);
+    }
+    close_all_vol(obj);
+    if (obj->options.authprintdir) afp_authprint_remove(obj);
+
+    if (obj->logout)
+        (*obj->logout)();
+
+    LOG(log_note, logtype_afpd, "AFP statistics: %.2f KB read, %.2f KB written via ASP",
+        asp->read_count / 1024.0, asp->write_count / 1024.0);
+    asp_close( asp );
+}
+
+/* removes the authprint trailing when appropriate */
+static void afp_authprint_remove(AFPObj *obj)
+{
+    ASP asp = obj->handle;
+    char addr_filename[256];
+    char addr_filename_buff[256];
+    struct stat cap_st;
+
+    sprintf(addr_filename, "%s/net%d.%dnode%d", obj->options.authprintdir,
+                ntohs( asp->asp_sat.sat_addr.s_net )/256,
+                ntohs( asp->asp_sat.sat_addr.s_net )%256,
+                asp->asp_sat.sat_addr.s_node );
+
+    memset( addr_filename_buff, 0, 256 );
+
+    if (stat(addr_filename, &cap_st) == 0) {
+	if( S_ISREG(cap_st.st_mode) ) {
+	    int len;
+	    int capfd = open( addr_filename, O_RDONLY );
+	    if ((len = read( capfd, addr_filename_buff, 256 )) > 0) {
+		int file_pid;
+		char *p_filepid;
+		addr_filename_buff[len] = 0;
+		if ( (p_filepid = strrchr(addr_filename_buff, ':')) != NULL) {
+		    *p_filepid = '\0';
+		    p_filepid++;
+		    file_pid = atoi(p_filepid);
+		    if (file_pid == (int)getpid()) {
+			if(unlink(addr_filename) == 0) {
+			    LOG(log_info, logtype_afpd, "removed %s", addr_filename);
+			} else {
+			    LOG(log_info, logtype_afpd, "error removing %s: %s",
+				    addr_filename, strerror(errno));
+			}
+		    } else {
+			LOG(log_info, logtype_afpd, "%s belongs to another pid %d",
+			     addr_filename, file_pid );
+		    }
+		} else { /* no pid info */
+		    if (unlink(addr_filename) == 0) {
+			LOG(log_info, logtype_afpd, "removed %s", addr_filename );
+		    } else {
+			LOG(log_info, logtype_afpd, "error removing %s: %s",
+				addr_filename, strerror(errno));
+		    }
+		}
+	    } else {
+		LOG(log_info, logtype_afpd, "couldn't read data from %s", addr_filename );
+	    }
+        if (capfd != -1)
+            close(capfd);
+	} else {
+	    LOG(log_info, logtype_afpd, "%s is not a regular file", addr_filename );
+	}
+    } else {
+        LOG(log_info, logtype_afpd, "error stat'ing %s: %s",
+                   addr_filename, strerror(errno));
+    }
+}
+
+/* ------------------------
+ * SIGTERM
+*/
+static void afp_asp_die(const int sig)
+{
+    ASP asp = child->handle;
+
+    asp_attention(asp, AFPATTN_SHUTDOWN);
+    if ( asp_shutdown( asp ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_die: asp_shutdown: %s", strerror(errno) );
+    }
+
+    afp_asp_close(child);
+    if (sig == SIGTERM || sig == SIGALRM)
+        exit( 0 );
+    else
+        exit(sig);
+}
+
+/* -----------------------------
+ * SIGUSR1
+ */
+static void afp_asp_timedown(int sig _U_)
+{
+    struct sigaction	sv;
+    struct itimerval	it;
+
+    /* shutdown and don't reconnect. server going down in 5 minutes. */
+    asp_attention(child->handle, AFPATTN_SHUTDOWN | AFPATTN_NORECONNECT |
+                  AFPATTN_TIME(5));
+
+    it.it_interval.tv_sec = 0;
+    it.it_interval.tv_usec = 0;
+    it.it_value.tv_sec = 300;
+    it.it_value.tv_usec = 0;
+    if ( setitimer( ITIMER_REAL, &it, NULL ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_timedown: setitimer: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+
+    memset(&sv, 0, sizeof(sv));
+    sv.sa_handler = afp_asp_die;
+    sigemptyset( &sv.sa_mask );
+    sigaddset(&sv.sa_mask, SIGHUP);
+    sigaddset(&sv.sa_mask, SIGTERM);
+    sv.sa_flags = SA_RESTART;
+    if ( sigaction( SIGALRM, &sv, NULL ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_timedown: sigaction: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+
+    /* ignore myself */
+    sv.sa_handler = SIG_IGN;
+    sigemptyset( &sv.sa_mask );
+    sv.sa_flags = SA_RESTART;
+    if ( sigaction( SIGUSR1, &sv, NULL ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_timedown: sigaction SIGUSR1: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+}
+
+/* ---------------------------------
+ * SIGHUP reload configuration file
+*/
+extern volatile int reload_request;
+
+static void afp_asp_reload(int sig _U_)
+{
+    reload_request = 1;
+}
+
+/* ---------------------- */
+#ifdef SERVERTEXT
+static void afp_asp_getmesg (int sig _U_)
+{
+    readmessage(child);
+    asp_attention(child->handle, AFPATTN_MESG | AFPATTN_TIME(5));
+}
+#endif /* SERVERTEXT */
+
+/* ---------------------- */
+void afp_over_asp(AFPObj *obj)
+{
+    ASP asp;
+    struct sigaction  action;
+    int		func,  reply = 0;
+    int ccnt = 0;
+
+    AFPobj = obj;
+    obj->exit = afp_asp_die;
+    obj->reply = (int (*)()) asp_cmdreply;
+    obj->attention = (int (*)(void *, AFPUserBytes)) asp_attention;
+    child = obj;
+    asp = (ASP) obj->handle;
+
+    /* install signal handlers 
+     * With ASP tickle handler is done in the parent process
+    */
+    memset(&action, 0, sizeof(action));
+
+    /* install SIGHUP */
+    action.sa_handler = afp_asp_reload; 
+    sigemptyset( &action.sa_mask );
+    sigaddset(&action.sa_mask, SIGTERM);
+    sigaddset(&action.sa_mask, SIGUSR1);
+#ifdef SERVERTEXT
+    sigaddset(&action.sa_mask, SIGUSR2);
+#endif    
+    action.sa_flags = SA_RESTART;
+    if ( sigaction( SIGHUP, &action, NULL ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_over_asp: sigaction: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+
+    /*  install SIGTERM */
+    action.sa_handler = afp_asp_die;
+    sigemptyset( &action.sa_mask );
+    sigaddset(&action.sa_mask, SIGHUP);
+    sigaddset(&action.sa_mask, SIGUSR1);
+#ifdef SERVERTEXT
+    sigaddset(&action.sa_mask, SIGUSR2);
+#endif    
+    action.sa_flags = SA_RESTART;
+    if ( sigaction( SIGTERM, &action, NULL ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_over_asp: sigaction: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+
+#ifdef SERVERTEXT
+    /* Added for server message support */
+    action.sa_handler = afp_asp_getmesg;
+    sigemptyset( &action.sa_mask );
+    sigaddset(&action.sa_mask, SIGTERM);
+    sigaddset(&action.sa_mask, SIGUSR1);
+    sigaddset(&action.sa_mask, SIGHUP);
+    action.sa_flags = SA_RESTART;
+    if ( sigaction( SIGUSR2, &action, NULL) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_over_asp: sigaction: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+#endif /* SERVERTEXT */
+
+    /*  SIGUSR1 - set down in 5 minutes  */
+    action.sa_handler = afp_asp_timedown; 
+    sigemptyset( &action.sa_mask );
+    sigaddset(&action.sa_mask, SIGHUP);
+    sigaddset(&action.sa_mask, SIGTERM);
+#ifdef SERVERTEXT
+    sigaddset(&action.sa_mask, SIGUSR2);
+#endif    
+    action.sa_flags = SA_RESTART;
+    if ( sigaction( SIGUSR1, &action, NULL ) < 0 ) {
+        LOG(log_error, logtype_afpd, "afp_over_asp: sigaction: %s", strerror(errno) );
+        afp_asp_die(EXITERR_SYS);
+    }
+
+    if (dircache_init(obj->options.dircachesize) != 0) {
+        LOG(log_error, logtype_afpd, "afp_over_asp: dircache_init error");
+        afp_asp_die(EXITERR_SYS);
+    }
+
+    LOG(log_info, logtype_afpd, "session from %u.%u:%u on %u.%u:%u",
+        ntohs( asp->asp_sat.sat_addr.s_net ),
+        asp->asp_sat.sat_addr.s_node, asp->asp_sat.sat_port,
+        ntohs( atp_sockaddr( asp->asp_atp )->sat_addr.s_net ),
+        atp_sockaddr( asp->asp_atp )->sat_addr.s_node,
+        atp_sockaddr( asp->asp_atp )->sat_port );
+
+    while ((reply = asp_getrequest(asp))) {
+        if (reload_request) {
+            reload_request = 0;
+            load_volumes(child, LV_FORCE);
+        }
+        switch (reply) {
+        case ASPFUNC_CLOSE :
+            afp_asp_close(obj);
+            LOG(log_note, logtype_afpd, "done" );
+
+            return;
+            break;
+
+        case ASPFUNC_CMD :
+            func = (unsigned char) asp->commands[0];
+            LOG(log_debug9, logtype_afpd, "command: %d (%s)\n", func, AfpNum2name(func));
+
+            if ( afp_switch[ func ] != NULL ) {
+                /*
+                 * The function called from afp_switch is expected to
+                 * read its parameters out of buf, put its
+                 * results in replybuf (updating rbuflen), and
+                 * return an error code.
+                */
+                asp->datalen = ASP_DATASIZ;
+                reply = (*afp_switch[ func ])(obj,
+                                              asp->commands, asp->cmdlen,
+                                              asp->data, &asp->datalen);
+            } else {
+                LOG(log_error, logtype_afpd, "bad function %X", func );
+                asp->datalen = 0;
+                reply = AFPERR_NOOP;
+            }
+
+            LOG(log_debug9, logtype_afpd, "reply: %d, %d\n", reply, ccnt++ );
+
+            if ( asp_cmdreply( asp, reply ) < 0 ) {
+                LOG(log_error, logtype_afpd, "asp_cmdreply: %s", strerror(errno) );
+                afp_asp_die(EXITERR_CLNT);
+            }
+            break;
+
+        case ASPFUNC_WRITE :
+            func = (unsigned char) asp->commands[0];
+
+            LOG(log_debug9, logtype_afpd, "(write) command: %d\n", func );
+
+            if ( afp_switch[ func ] != NULL ) {
+                asp->datalen = ASP_DATASIZ;
+                reply = (*afp_switch[ func ])(obj,
+                                              asp->commands, asp->cmdlen,
+                                              asp->data, &asp->datalen);
+            } else {
+                LOG(log_error, logtype_afpd, "(write) bad function %X", func );
+                asp->datalen = 0;
+                reply = AFPERR_NOOP;
+            }
+
+            LOG(log_debug9, logtype_afpd, "(write) reply code: %d, %d\n", reply, ccnt++ );
+
+            if ( asp_wrtreply( asp, reply ) < 0 ) {
+                LOG(log_error, logtype_afpd, "asp_wrtreply: %s", strerror(errno) );
+                afp_asp_die(EXITERR_CLNT);
+            }
+            break;
+        default:
+            /*
+               * Bad asp packet.  Probably should have asp filter them,
+               * since they are typically things like out-of-order packet.
+               */
+            LOG(log_info, logtype_afpd, "main: asp_getrequest: %d", reply );
+            break;
+        }
+
+        if ( obj->options.flags & OPTION_DEBUG ) {
+            of_pforkdesc( stdout );
+            fflush( stdout );
+        }
+
+    }
+}
+
+#endif

--- a/etc/afpd/afp_config.c
+++ b/etc/afpd/afp_config.c
@@ -26,6 +26,8 @@
 #include <atalk/afp.h>
 #include <atalk/compat.h>
 #include <atalk/dsi.h>
+#include <atalk/atp.h>
+#include <atalk/asp.h>
 #include <atalk/errchk.h>
 #include <atalk/fce_api.h>
 #include <atalk/globals.h>
@@ -52,6 +54,25 @@
  */
 void configfree(AFPObj *obj, DSI *dsi)
 {
+#ifndef NO_DDP
+    /* just free the asp only resources and get out */
+    if (obj->proto == AFPPROTO_ASP)
+    {
+        obj->Obj = NULL;
+        obj->Type = NULL;
+        obj->Zone = NULL;
+        free(obj->Obj);
+        free(obj->Type);
+        free(obj->Zone);
+	if (obj->handle)
+        {
+            atp_close(((ASP) (obj->handle))->asp_atp);
+            free(obj->handle);
+        }
+        return;
+    }
+#endif /* no afp/asp */
+
     DSI *p, *q;
 
     if (!dsi) {
@@ -78,46 +99,142 @@ void configfree(AFPObj *obj, DSI *dsi)
     }
 }
 
+
 /*!
  * Get everything running
  */
-int configinit(AFPObj *obj)
+int configinit(AFPObj *dsi_obj, AFPObj *asp_obj)
 {
     EC_INIT;
     DSI *dsi = NULL;
-    DSI **next = &obj->dsi;
+    DSI **next = &dsi_obj->dsi;
     char *p = NULL, *q = NULL, *savep;
     const char *r;
     struct ifaddrs *ifaddr _U_, *ifa _U_;
     int family _U_, s _U_;
     static char interfaddr[NI_MAXHOST] _U_;
 
-    auth_load(obj, obj->options.uampath, obj->options.uamlist);
-    set_signature(&obj->options);
+    auth_load(dsi_obj, dsi_obj->options.uampath, dsi_obj->options.uamlist);
+    set_signature(&dsi_obj->options);
+    dsi_obj->proto = AFPPROTO_DSI;
+
 #ifdef HAVE_LDAP
     acl_ldap_freeconfig();
 #endif /* HAVE_LDAP */
 
+#ifndef NO_DDP
+    /* make sure the asp socket doesn't get opened if init isn't successful */
+    asp_obj->fd = -1;
+    /* if appletalk is enabled, set it up first */
+    if (asp_obj->options.flags & OPTION_DDP)
+    {
+        ATP atp;
+        ASP asp;
+        char* Obj, * Type = "AFPServer", * Zone = "*";
+        char* convname = NULL;
+
+        if ((atp = atp_open(ATADDR_ANYPORT, &asp_obj->options.ddpaddr)) == NULL) {
+            LOG(log_error, logtype_afpd, "main: atp_open: %s", strerror(errno));
+            goto serv_free_return;
+        }
+
+        if ((asp = asp_init(atp)) == NULL) {
+            LOG(log_error, logtype_afpd, "main: asp_init: %s", strerror(errno));
+            atp_close(atp);
+            goto serv_free_return;
+        }
+
+        /* register asp server */
+        Obj = (char*)asp_obj->options.hostname;
+        if (asp_obj->options.server && (size_t)-1 == (convert_string_allocate(asp_obj->options.unixcharset, asp_obj->options.maccharset,
+            asp_obj->options.server, strlen(asp_obj->options.server), &convname))) {
+            if ((convname = strdup(asp_obj->options.server)) == NULL) {
+                LOG(log_error, logtype_afpd, "malloc: %s", strerror(errno));
+                asp_close(asp);
+                goto serv_free_return;
+            }
+        }
+
+        if (nbp_name(convname, &Obj, &Type, &Zone)) {
+            LOG(log_error, logtype_afpd, "main: can't parse %s", asp_obj->options.server);
+            asp_close(asp);
+            goto serv_free_return;
+        }
+        if (convname)
+            free(convname);
+
+        /* dup Obj, Type and Zone as they get assigned to a single internal
+         * buffer by nbp_name */
+        if ((asp_obj->Obj = strdup(Obj)) == NULL) {
+            asp_close(asp);
+            goto serv_free_return;
+        }
+
+        if ((asp_obj->Type = strdup(Type)) == NULL) {
+            free(asp_obj->Obj);
+            asp_close(asp);
+            goto serv_free_return;
+        }
+
+        if ((asp_obj->Zone = strdup(Zone)) == NULL) {
+            free(asp_obj->Obj);
+            free(asp_obj->Type);
+            asp_close(asp);
+            goto serv_free_return;
+        }
+
+        /* make sure we're not registered */
+        nbp_unrgstr(Obj, Type, Zone, &asp_obj->options.ddpaddr);
+        if (nbp_rgstr(atp_sockaddr(atp), Obj, Type, Zone) < 0) {
+            LOG(log_error, logtype_afpd, "Can't register %s:%s@%s", Obj, Type, Zone);
+            free(asp_obj->Obj);
+            free(asp_obj->Type);
+            free(asp_obj->Zone);
+            asp_close(asp);
+            goto serv_free_return;
+        }
+
+        set_signature(&asp_obj->options);
+        asp_obj->proto = AFPPROTO_ASP;
+        asp_obj->fd = atp_fileno(atp);
+        asp_obj->handle = asp;
+
+    serv_free_return:
+        if (asp_obj->Obj)
+        {
+            LOG(log_note, logtype_afpd, "%s:%s@%s started on %u.%u:%u (%s)", Obj, Type, Zone,
+                ntohs(atp_sockaddr(atp)->sat_addr.s_net),
+                atp_sockaddr(atp)->sat_addr.s_node,
+                atp_sockaddr(atp)->sat_port, VERSION);
+        }
+        else
+        {
+            LOG(log_note, logtype_afpd, "AppleTalk support disabled. Is atalkd running?");
+        }
+
+    }
+#endif /* no afp/asp */
+
     LOG(log_debug, logtype_afpd, "DSIConfigInit: hostname: %s, listen: %s, interfaces: %s, port: %s",
-        obj->options.hostname,
-        obj->options.listen ? obj->options.listen : "-",
-        obj->options.interfaces ? obj->options.interfaces : "-",
-        obj->options.port);
+        dsi_obj->options.hostname,
+        dsi_obj->options.listen ? dsi_obj->options.listen : "-",
+        dsi_obj->options.interfaces ? dsi_obj->options.interfaces : "-",
+        dsi_obj->options.port);
 
     /*
      * Setup addresses we listen on from hostname and/or "afp listen" option
      */
-    if (obj->options.listen) {
-        EC_NULL( q = p = strdup(obj->options.listen) );
+    if (dsi_obj->options.listen) {
+        EC_NULL( q = p = strdup(dsi_obj->options.listen) );
         EC_NULL( p = strtok_r(p, ", ", &savep) );
         while (p) {
-            if ((dsi = dsi_init(obj, obj->options.hostname, p, obj->options.port)) == NULL)
+            if ((dsi = dsi_init(dsi_obj, dsi_obj->options.hostname, p, dsi_obj->options.port)) == NULL)
                 break;
 
-            status_init(obj, dsi);
+            status_init(dsi_obj, asp_obj, dsi);
             *next = dsi;
             next = &dsi->next;
-            dsi->AFPobj = obj;
+            dsi->AFPobj = dsi_obj;
 
             LOG(log_note, logtype_afpd, "Netatalk AFP/TCP listening on %s:%d",
                 getip_string((struct sockaddr *)&dsi->server),
@@ -136,7 +253,7 @@ int configinit(AFPObj *obj)
     * We use getifaddrs() instead of if_nameindex() because the latter appears still
     * to be unable to return ipv4 addresses
     */
-    if (obj->options.interfaces) {
+    if (dsi_obj->options.interfaces) {
 #ifndef HAVE_GETIFADDRS
         LOG(log_error, logtype_afpd, "option \"afp interfaces\" not supported");
 #else
@@ -145,7 +262,7 @@ int configinit(AFPObj *obj)
             EC_FAIL;
         }
 
-        EC_NULL( q = p = strdup(obj->options.interfaces) );
+        EC_NULL( q = p = strdup(dsi_obj->options.interfaces) );
         EC_NULL( p = strtok_r(p, ", ", &savep) );
         while (p) {
             for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
@@ -163,13 +280,13 @@ int configinit(AFPObj *obj)
                         continue;
                     }
 
-                    if ((dsi = dsi_init(obj, obj->options.hostname, interfaddr, obj->options.port)) == NULL)
+                    if ((dsi = dsi_init(dsi_obj, dsi_obj->options.hostname, interfaddr, dsi_obj->options.port)) == NULL)
                         continue;
 
-                    status_init(obj, dsi);
+                    status_init(dsi_obj, asp_obj, dsi);
                     *next = dsi;
                     next = &dsi->next;
-                    dsi->AFPobj = obj;
+                    dsi->AFPobj = dsi_obj;
 
                     LOG(log_note, logtype_afpd, "Netatalk AFP/TCP listening on interface %s with address %s:%d",
                         p,
@@ -189,12 +306,12 @@ int configinit(AFPObj *obj)
      * network interaces for determining an IP we can advertise in DSIStatus
      */
     if (dsi == NULL) {
-        if ((dsi = dsi_init(obj, obj->options.hostname, NULL, obj->options.port)) == NULL)
+        if ((dsi = dsi_init(dsi_obj, dsi_obj->options.hostname, NULL, dsi_obj->options.port)) == NULL)
             EC_FAIL_LOG("no suitable network address found, use \"afp listen\" or \"afp interfaces\"", 0);
-        status_init(obj, dsi);
+        status_init(dsi_obj, asp_obj, dsi);
         *next = dsi;
         next = &dsi->next;
-        dsi->AFPobj = obj;
+        dsi->AFPobj = dsi_obj;
 
         LOG(log_note, logtype_afpd, "Netatalk AFP/TCP listening on %s:%d",
             getip_string((struct sockaddr *)&dsi->server),
@@ -203,34 +320,34 @@ int configinit(AFPObj *obj)
 
 #ifdef HAVE_LDAP
     /* Parse afp.conf */
-    acl_ldap_readconfig(obj->iniconfig);
+    acl_ldap_readconfig(dsi_obj->iniconfig);
 #endif /* HAVE_LDAP */
 
-    if ((r = atalk_iniparser_getstring(obj->iniconfig, INISEC_GLOBAL, "fce listener", NULL))) {
+    if ((r = atalk_iniparser_getstring(dsi_obj->iniconfig, INISEC_GLOBAL, "fce listener", NULL))) {
 		LOG(log_note, logtype_afpd, "Adding FCE listener: %s", r);
 		fce_add_udp_socket(r);
     }
-    if ((r = atalk_iniparser_getstring(obj->iniconfig, INISEC_GLOBAL, "fce coalesce", NULL))) {
+    if ((r = atalk_iniparser_getstring(dsi_obj->iniconfig, INISEC_GLOBAL, "fce coalesce", NULL))) {
 		LOG(log_note, logtype_afpd, "Fce coalesce: %s", r);
 		fce_set_coalesce(r);
     }
-    if ((r = atalk_iniparser_getstring(obj->iniconfig, INISEC_GLOBAL, "fce events", NULL))) {
+    if ((r = atalk_iniparser_getstring(dsi_obj->iniconfig, INISEC_GLOBAL, "fce events", NULL))) {
 		LOG(log_note, logtype_afpd, "Fce events: %s", r);
 		fce_set_events(r);
     }
-    r = atalk_iniparser_getstring(obj->iniconfig, INISEC_GLOBAL, "fce version", "1");
+    r = atalk_iniparser_getstring(dsi_obj->iniconfig, INISEC_GLOBAL, "fce version", "1");
     LOG(log_debug, logtype_afpd, "Fce version: %s", r);
-    obj->fce_version = atoi(r);
+    dsi_obj->fce_version = atoi(r);
 
-    if ((r = atalk_iniparser_getstring(obj->iniconfig, INISEC_GLOBAL, "fce ignore names", ".DS_Store"))) {
-        obj->fce_ign_names = strdup(r);
+    if ((r = atalk_iniparser_getstring(dsi_obj->iniconfig, INISEC_GLOBAL, "fce ignore names", ".DS_Store"))) {
+        dsi_obj->fce_ign_names = strdup(r);
     }
-    if ((r = atalk_iniparser_getstring(obj->iniconfig, INISEC_GLOBAL, "fce ignore directories", NULL))) {
-            obj->fce_ign_directories = strdup(r);
+    if ((r = atalk_iniparser_getstring(dsi_obj->iniconfig, INISEC_GLOBAL, "fce ignore directories", NULL))) {
+            dsi_obj->fce_ign_directories = strdup(r);
     }
 
-    if ((r = atalk_iniparser_getstring(obj->iniconfig, INISEC_GLOBAL, "fce notify script", NULL))) {
-        obj->fce_notify_script = strdup(r);
+    if ((r = atalk_iniparser_getstring(dsi_obj->iniconfig, INISEC_GLOBAL, "fce notify script", NULL))) {
+        dsi_obj->fce_notify_script = strdup(r);
     }
 
 

--- a/etc/afpd/afp_config.h
+++ b/etc/afpd/afp_config.h
@@ -5,7 +5,7 @@
 #include <atalk/globals.h>
 #include <atalk/server_child.h>
 
-extern int configinit (AFPObj *);
+extern int configinit (AFPObj *, AFPObj *);
 extern void configfree (AFPObj *, DSI *);
 
 #endif

--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -109,7 +109,7 @@ static void afp_dsi_close(AFPObj *obj)
         (*obj->logout)();
     }
 
-    LOG(log_note, logtype_afpd, "AFP statistics: %.2f KB read, %.2f KB written",
+    LOG(log_note, logtype_afpd, "AFP statistics: %.2f KB read, %.2f KB written via DSI",
         dsi->read_count/1024.0, dsi->write_count/1024.0);
     log_dircache_stat();
 

--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -65,7 +65,15 @@ static void show_version( void )
 		printf( "%d.%d ", afp_versions[ i ].av_number/10, afp_versions[ i ].av_number%10);
 	}
 	puts( "" );
+	printf("        TCP/IP Support:\t");
+	puts("Yes");
 
+	printf("AppleTalk Support:\t");
+#ifdef NO_DDP
+	puts("No");
+#else
+	puts("Yes");
+#endif
 	printf( "         CNID backends:\t" );
 #ifdef CNID_BACKEND_DBD
 	printf( "dbd " );

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -1463,10 +1463,18 @@ int copyfile(struct vol *s_vol,
         }
         return AFPERR_EXIST;
     }
+    size_t copybuf_len = 0;
+    char* copybuf;
+
+    if (s_vol->v_obj->proto == AFPPROTO_DSI)
+    {
+        copybuf = s_vol->v_obj->dsi->commands;
+        copybuf_len = s_vol->v_obj->dsi->server_quantum;
+    }
 
     if (copy_fork(ADEID_DFORK, &add, adp,
-                         s_vol->v_obj->dsi->commands,
-                         s_vol->v_obj->dsi->server_quantum) != 0) {
+                         copybuf,
+                         copybuf_len) != 0) {
         err = errno;
         LOG(log_error, logtype_afpd, "copyfile('%s'): copy_fork: %s", src, strerror(errno));
     } else if (d_vol->vfs->vfs_copyfile(d_vol, sfd, src, dst) != AFP_OK) {

--- a/etc/afpd/fork.h
+++ b/etc/afpd/fork.h
@@ -62,6 +62,7 @@ extern int          of_rename    (const struct vol *,
                                           struct dir *, const char *,
                                           struct dir *, const char *);
 extern int          of_flush     (const struct vol *);
+extern void         of_pforkdesc (FILE *);
 extern int          of_stat      (const struct vol *vol, struct path *);
 extern int          of_statdir   (struct vol *vol, struct path *);
 extern int          of_closefork (const AFPObj *obj, struct ofork *ofork);

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -34,6 +34,12 @@ afpd_external_deps = [libgcrypt]
 afpd_internal_deps = []
 afpd_link_args = []
 
+if have_appletalk
+    afpd_sources += [
+        'afp_asp.c',
+    ]
+endif
+
 if have_spotlight
     afpd_sources += [
         'spotlight.c',

--- a/etc/afpd/messages.c
+++ b/etc/afpd/messages.c
@@ -53,7 +53,7 @@ void readmessage(AFPObj *obj)
     static int c;
     uint32_t maxmsgsize;
 
-    maxmsgsize = MIN(MAX(obj->dsi->attn_quantum, MAXMESGSIZE), MAXPATHLEN);
+    maxmsgsize = (obj->proto == AFPPROTO_DSI) ? MIN(MAX(obj->dsi->attn_quantum, MAXMESGSIZE), MAXPATHLEN) : MAXMESGSIZE;
 
     i=0;
     /* Construct file name SERVERTEXT/message.[pid] */
@@ -121,7 +121,7 @@ int afp_getsrvrmesg(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, siz
 
     *rbuflen = 0;
 
-    msgsize = MAX(obj->dsi->attn_quantum, MAXMESGSIZE);
+    msgsize = (obj->proto == AFPPROTO_DSI) ? MAX(obj->dsi->attn_quantum, MAXMESGSIZE) : MAXMESGSIZE;
 
     memcpy(&type, ibuf + 2, sizeof(type));
     memcpy(&bitmap, ibuf + 4, sizeof(bitmap));

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -62,6 +62,20 @@ static void of_unhash(struct ofork *of)
     }
 }
 
+void of_pforkdesc( FILE *f)
+{
+    int ofrefnum;
+
+    if (!oforks)
+        return;
+
+    for ( ofrefnum = 0; ofrefnum < nforks; ofrefnum++ ) {
+        if ( oforks[ ofrefnum ] != NULL ) {
+            fprintf( f, "%d <%s>\n", ofrefnum, of_name(oforks[ ofrefnum ]));
+        }
+    }
+}
+
 int of_flush(const struct vol *vol)
 {
     int refnum;

--- a/etc/afpd/status.h
+++ b/etc/afpd/status.h
@@ -2,6 +2,7 @@
 #define AFPD_STATUS_H 1
 
 #include <atalk/dsi.h>
+#include <atalk/asp.h>
 #include <atalk/globals.h>
 
 #include "afp_config.h"
@@ -33,9 +34,13 @@
 /* AFPSTATUS_MACHLEN is the number of characters for the MachineType. */
 #define AFPSTATUS_MACHLEN     16
 
-extern void status_versions (char * /*status*/, const DSI *);
+extern void status_versions (char * /*status*/,
+#ifndef NO_DDP
+	                         const ASP,
+#endif
+	                         const DSI *);
 extern void status_uams (char * /*status*/, const char * /*authlist*/);
-extern void status_init (AFPObj *, DSI *dsi);
+extern void status_init (AFPObj *, AFPObj *, DSI *dsi);
 extern void set_signature(struct afp_options *);
 
 /* FP functions */

--- a/etc/afpd/uam.c
+++ b/etc/afpd/uam.c
@@ -385,6 +385,10 @@ int uam_afpserver_option(void *private, const int what, void *option,
             *len = strlen(obj->options.hostname);
         break;
 
+    case UAM_OPTION_PROTOCOL:
+        *((int*)option) = obj->proto;
+        break;
+
     case UAM_OPTION_CLIENTNAME:
     {
         struct DSI *dsi = obj->dsi;

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -965,6 +965,10 @@ int  pollvoltime(AFPObj *obj)
     struct vol       *vol;
     struct timeval   tv;
     struct stat      st;
+    if (obj->proto == AFPPROTO_DSI)
+    {
+        obj->handle = obj->dsi;
+    }
 
     if (!(obj->afp_version > 21 && obj->options.flags & OPTION_SERVERNOTIF))
         return 0;
@@ -976,7 +980,7 @@ int  pollvoltime(AFPObj *obj)
         if ( (vol->v_flags & AFPVOL_OPEN)  && vol->v_mtime + 30 < tv.tv_sec) {
             if ( !stat( vol->v_path, &st ) && vol->v_mtime != st.st_mtime ) {
                 vol->v_mtime = st.st_mtime;
-                if (!obj->attention(obj->dsi, AFPATTN_NOTIFY | AFPATTN_VOLCHANGED))
+                if (!obj->attention(obj->handle, AFPATTN_NOTIFY | AFPATTN_VOLCHANGED))
                     return -1;
                 return 1;
             }
@@ -989,6 +993,10 @@ int  pollvoltime(AFPObj *obj)
 void setvoltime(AFPObj *obj, struct vol *vol)
 {
     struct timeval  tv;
+    if (obj->proto == AFPPROTO_DSI)
+    {
+        obj->handle = obj->dsi;
+    }
 
     if ( gettimeofday( &tv, NULL ) < 0 ) {
         LOG(log_error, logtype_afpd, "setvoltime(%s): gettimeofday: %s", vol->v_path, strerror(errno) );
@@ -1007,7 +1015,7 @@ void setvoltime(AFPObj *obj, struct vol *vol)
          * AFP 3.2 and above clients seem to be ok without so many notification
          */
         if (obj->afp_version < 32 && obj->options.flags & OPTION_SERVERNOTIF) {
-            obj->attention(obj->dsi, AFPATTN_NOTIFY | AFPATTN_VOLCHANGED);
+            obj->attention(obj->handle, AFPATTN_NOTIFY | AFPATTN_VOLCHANGED);
         }
     }
 }

--- a/include/atalk/uam.h
+++ b/include/atalk/uam.h
@@ -34,6 +34,7 @@
 #define UAM_OPTION_RANDNUM      (1 << 4) /* request a random number */
 #define UAM_OPTION_HOSTNAME     (1 << 5) /* get host name */
 #define UAM_OPTION_COOKIE       (1 << 6) /* cookie handle */
+#define UAM_OPTION_PROTOCOL	(1 << 7) /* DSI or ASP */
 #define UAM_OPTION_CLIENTNAME   (1 << 8) /* get client IP address */
 #define UAM_OPTION_KRB5SERVICE  (1 << 9) /* service name for krb5 principal */
 #define UAM_OPTION_MACCHARSET   (1 << 10) /* mac charset handle */

--- a/include/atalk/util.h
+++ b/include/atalk/util.h
@@ -176,6 +176,7 @@ struct asev_data {
     enum asev_fdtype fdtype;  /* IPC fd or listening socket fd                 */
     void            *private; /* pointer to AFPconfig for listening socket and *
                                * pointer to afp_child_t for IPC fd             */
+    int             protocol; /* protocol type ASP or DSI                      */
 };
 
 /**
@@ -189,7 +190,7 @@ struct asev {
 };
 
 extern struct asev *asev_init(int max);
-extern bool asev_add_fd(struct asev *sev, int fd, enum asev_fdtype fdtype, void *private);
+extern bool asev_add_fd(struct asev *sev, int fd, enum asev_fdtype fdtype, void *private, int protocol);
 extern bool asev_del_fd(struct asev *sev, int fd);
 
 extern int send_fd(int socket, int fd);

--- a/libatalk/adouble/ad_conv.c
+++ b/libatalk/adouble/ad_conv.c
@@ -148,6 +148,15 @@ static int ad_conv_v22ea_rf(const char *path, const struct stat *sp, const struc
     ad_init(&adea, vol);
     ad_init_old(&adv2, AD_VERSION2, adea.ad_options);
 
+    size_t copybuf_len = 0;
+    char* copybuf;
+
+    if (vol->v_obj->proto == AFPPROTO_DSI)
+    {
+        copybuf = vol->v_obj->dsi->commands;
+        copybuf_len = vol->v_obj->dsi->server_quantum;
+    }
+
     /* Open and lock adouble:v2 file */
     EC_ZERO( ad_open(&adv2, path, ADFLAGS_HF | ADFLAGS_RF | ADFLAGS_RDWR) );
 
@@ -158,8 +167,8 @@ static int ad_conv_v22ea_rf(const char *path, const struct stat *sp, const struc
         EC_ZERO_LOG( ad_open(&adea, path, ADFLAGS_RF|ADFLAGS_RDWR|ADFLAGS_CREATE|ADFLAGS_SETSHRMD, 0666) );
 
         EC_ZERO_LOG( copy_fork(ADEID_RFORK, &adea, &adv2,
-			       vol->v_obj->dsi->commands,
-			       vol->v_obj->dsi->server_quantum) );
+			       copybuf,
+			       copybuf_len) );
 
         adea.ad_rlen = adv2.ad_rlen;
         ad_flush(&adea);

--- a/libatalk/asp/asp_getsess.c
+++ b/libatalk/asp/asp_getsess.c
@@ -277,7 +277,10 @@ ASP asp_getsession(ASP asp, server_child_t *server_children,
 
 	default : /* parent process */
 	  /* we need atomic setting or pb with tickle_handler */
-      if (server_child_add(children, pid, (long)dummy)) {
+        /* TODO: This was "(long)dummy" in 2.x for 3rd parameter since we don't have IPC on ASP.
+        * Right now this throws an error in child_handler() in main.c, so setting to -1 to
+        * mitigate that. Original 2.x code wasn't checking IPC handles on close */
+      if (server_child_add(children, pid, -1 )) {
 	    if ((asp_ac_tmp = malloc(sizeof(struct asp_child))) == NULL) {
             kill(pid, SIGQUIT);
             break;

--- a/libatalk/util/logger.c
+++ b/libatalk/util/logger.c
@@ -87,6 +87,8 @@ UAM_MODULE_EXPORT logtype_conf_t type_configs[logtype_end_of_list_marker] = {
     DEFAULT_LOG_CONFIG, /* logtype_cnid */
     DEFAULT_LOG_CONFIG, /* logtype_afpd */
     DEFAULT_LOG_CONFIG, /* logtype_dsi */
+    DEFAULT_LOG_CONFIG, /* logtype_atalkd */
+    DEFAULT_LOG_CONFIG, /* logtype_papd */
     DEFAULT_LOG_CONFIG, /* logtype_uams */
     DEFAULT_LOG_CONFIG, /* logtype_fce */
     DEFAULT_LOG_CONFIG, /* logtype_ad */

--- a/libatalk/util/socket.c
+++ b/libatalk/util/socket.c
@@ -539,7 +539,8 @@ struct asev *asev_init(int max)
 bool asev_add_fd(struct asev *asev,
                  int fd,
                  enum asev_fdtype fdtype,
-                 void *private)
+                 void *private,
+		 int protocol)
 {
     if (asev == NULL) {
         return false;
@@ -553,6 +554,7 @@ bool asev_add_fd(struct asev *asev,
     asev->fdset[asev->used].events = POLLIN;
     asev->data[asev->used].fdtype = fdtype;
     asev->data[asev->used].private = private;
+    asev->data[asev->used].protocol = protocol;
     asev->used++;
 
     return true;
@@ -592,6 +594,7 @@ bool asev_del_fd(struct asev *asev, int fd)
                 asev->fdset[i].fd = -1;
                 asev->data[i].fdtype = 0;
                 asev->data[i].private = NULL;
+                asev->data[i].protocol = 0;
             } else {
                 /*
                  * Move down by one all subsequent elements

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -44,7 +44,7 @@
 
 /* Stuff from main.c which of cource can't be added as source to testbin */
 unsigned char nologin = 0;
-static AFPObj obj;
+static AFPObj obj, aspobj;
 #define ARGNUM 3
 static char *args[] = {"test", "-F", "test.conf"};
 /* Static variables */
@@ -64,7 +64,7 @@ int main()
     TEST( afp_options_parse_cmdline(&obj, 3, &args[0]) );
 
     TEST_int( afp_config_parse(&obj, NULL), 0);
-    TEST_int( configinit(&obj), 0);
+    TEST_int( configinit(&obj, &aspobj), 0);
     TEST( cnid_init() );
     TEST( load_volumes(&obj, LV_ALL) );
     TEST_int( dircache_init(8192), 0);


### PR DESCRIPTION
Fixes #1333 This pull request adds back support for Apple Session Protocol in afpd. This is very much a work in progress, but is  fully functional. Some legacy options like `authprintdir` and `ddpaddr` have not been enabled yet. To enable, add `appletalk = yes` under the `[global]` section of your `afp.conf`