### PR TITLE
[2.4] Bump to WolfSSL 5.7.2 while reverting local modifications

### DIFF
--- a/include/wolfssl/error-ssl.h
+++ b/include/wolfssl/error-ssl.h
@@ -30,6 +30,10 @@
     extern "C" {
 #endif
 
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES_H
+    #include <wolfssl/debug-untrace-error-codes.h>
+#endif
+
 enum wolfSSL_ErrorCodes {
     INPUT_CASE_ERROR             = -301,   /* process input state error */
     PREFIX_ERROR                 = -302,   /* bad index to key rounds  */
@@ -211,6 +215,9 @@ enum wolfSSL_ErrorCodes {
 WOLFSSL_LOCAL
 void SetErrorString(int err, char* buff);
 
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES
+    #include <wolfssl/debug-trace-error-codes.h>
+#endif
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/include/wolfssl/internal.h
+++ b/include/wolfssl/internal.h
@@ -122,8 +122,10 @@
 #ifdef HAVE_CURVE448
     #include <wolfssl/wolfcrypt/curve448.h>
 #endif
-#ifdef HAVE_PQC
+#ifdef HAVE_FALCON
     #include <wolfssl/wolfcrypt/falcon.h>
+#endif
+#ifdef HAVE_DILITHIUM
     #include <wolfssl/wolfcrypt/dilithium.h>
 #endif
 #ifdef HAVE_HKDF
@@ -206,7 +208,12 @@
     #endif
 #elif defined(WOLFSSL_ZEPHYR)
     #ifndef SINGLE_THREADED
-        #include <zephyr/kernel.h>
+        #include <version.h>
+        #if KERNEL_VERSION_NUMBER >= 0x30100
+            #include <zephyr/kernel.h>
+        #else
+            #include <kernel.h>
+        #endif
     #endif
 #elif defined(WOLFSSL_TELIT_M2MB)
     /* do nothing */
@@ -343,7 +350,7 @@
         #endif
     #endif
 
-    #if !defined(NO_RSA) && !defined(NO_DES3)
+    #if !defined(NO_RSA) && !defined(NO_DES3) && !defined(NO_DES3_TLS_SUITES)
         #if !defined(NO_SHA)
             #if defined(WOLFSSL_STATIC_RSA)
                 #define BUILD_SSL_RSA_WITH_3DES_EDE_CBC_SHA
@@ -500,7 +507,7 @@
             #if defined(WOLFSSL_AES_256) && defined(HAVE_AES_CBC)
                 #define BUILD_TLS_DHE_RSA_WITH_AES_256_CBC_SHA
             #endif
-            #if !defined(NO_DES3)
+            #if !defined(NO_DES3) && !defined(NO_DES3_TLS_SUITES)
                 #define BUILD_TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
             #endif
         #endif
@@ -686,7 +693,8 @@
             #endif
         #endif
         #if !defined(NO_DES3) && !(defined(WSSL_HARDEN_TLS) && \
-                                           WSSL_HARDEN_TLS > 112)
+                                           WSSL_HARDEN_TLS > 112) && \
+            !defined(NO_DES3_TLS_SUITES)
             /* 3DES offers only 112 bits of security.
              * Using guidance from section 5.6.1
              * https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-57pt1r5.pdf */
@@ -1548,7 +1556,7 @@ enum Misc {
     MAXEARLYDATASZ_LEN = 4,     /* maxEarlyDataSz size in ticket */
 #endif
 #endif
-#ifdef HAVE_PQC
+#if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
     ENCRYPT_LEN     = 5120,     /* Allow 5k byte buffer for dilithium and
                                  * hybridization with other algs. */
 #else
@@ -1560,7 +1568,6 @@ enum Misc {
 #endif
     SIZEOF_SENDER   =  4,       /* clnt or srvr           */
     FINISHED_SZ     = 36,       /* WC_MD5_DIGEST_SIZE + WC_SHA_DIGEST_SIZE */
-    MAX_RECORD_SIZE = 16384,    /* 2^14, max size by standard */
     MAX_PLAINTEXT_SZ   = (1 << 14),        /* Max plaintext sz   */
     MAX_TLS_CIPHER_SZ  = (1 << 14) + 2048, /* Max TLS encrypted data sz */
 #ifdef WOLFSSL_TLS13
@@ -1726,10 +1733,12 @@ enum Misc {
     AEAD_LEN_OFFSET     = 11,  /* Auth Data: Length          */
     AEAD_AUTH_DATA_SZ   = 13,  /* Size of the data to authenticate */
     AEAD_NONCE_SZ       = 12,
-    AESGCM_IMP_IV_SZ    = 4,   /* Size of GCM/CCM AEAD implicit IV */
+    AESGCM_IMP_IV_SZ    = 4,   /* Size of GCM AEAD implicit IV */
+    AESCCM_IMP_IV_SZ    = 4,   /* Size of CCM AEAD implicit IV */
     AESGCM_EXP_IV_SZ    = 8,   /* Size of GCM/CCM AEAD explicit IV */
     AESGCM_NONCE_SZ     = AESGCM_EXP_IV_SZ + AESGCM_IMP_IV_SZ,
-    GCM_IMP_IV_SZ       = 4,   /* Size of GCM/CCM AEAD implicit IV */
+    GCM_IMP_IV_SZ       = 4,   /* Size of GCM AEAD implicit IV */
+    CCM_IMP_IV_SZ       = 4,   /* Size of CCM AEAD implicit IV */
     GCM_EXP_IV_SZ       = 8,   /* Size of GCM/CCM AEAD explicit IV */
     GCM_NONCE_SZ        = GCM_EXP_IV_SZ + GCM_IMP_IV_SZ,
 
@@ -1768,7 +1777,7 @@ enum Misc {
     ECDHE_SIZE          = 32,  /* ECDHE server size defaults to 256 bit */
 #endif
     MAX_EXPORT_ECC_SZ   = 256, /* Export ANSI X9.62 max future size */
-    MAX_CURVE_NAME_SZ   = 16,  /* Maximum size of curve name string */
+    MAX_CURVE_NAME_SZ   = 18,  /* Maximum size of curve name string */
 
     NEW_SA_MAJOR        = 8,   /* Most significant byte used with new sig algos */
     ED25519_SA_MAJOR    = 8,   /* Most significant byte for ED25519 */
@@ -1787,16 +1796,16 @@ enum Misc {
     FALCON_LEVEL5_SA_MINOR = 0xB1,
 
     DILITHIUM_LEVEL2_SA_MAJOR = 0xFE,
-    DILITHIUM_LEVEL2_SA_MINOR = 0xA0,
+    DILITHIUM_LEVEL2_SA_MINOR = 0xD0,
     DILITHIUM_LEVEL3_SA_MAJOR = 0xFE,
-    DILITHIUM_LEVEL3_SA_MINOR = 0xA3,
+    DILITHIUM_LEVEL3_SA_MINOR = 0xD1,
     DILITHIUM_LEVEL5_SA_MAJOR = 0xFE,
-    DILITHIUM_LEVEL5_SA_MINOR = 0xA5,
+    DILITHIUM_LEVEL5_SA_MINOR = 0xD2,
 
     MIN_RSA_SHA512_PSS_BITS = 512 * 2 + 8 * 8, /* Min key size */
     MIN_RSA_SHA384_PSS_BITS = 384 * 2 + 8 * 8, /* Min key size */
 
-#if defined(HAVE_PQC)
+#if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
     MAX_CERT_VERIFY_SZ = 6000,            /* For Dilithium */
 #elif defined(WOLFSSL_CERT_EXT)
     MAX_CERT_VERIFY_SZ = 2048,            /* For larger extensions */
@@ -1848,13 +1857,13 @@ enum Misc {
 
 #define WOLFSSL_NAMED_GROUP_IS_FFHDE(group) \
     (MIN_FFHDE_GROUP <= (group) && (group) <= MAX_FFHDE_GROUP)
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
 #define WOLFSSL_NAMED_GROUP_IS_PQC(group) \
     ((WOLFSSL_PQC_SIMPLE_MIN <= (group) && (group) <= WOLFSSL_PQC_SIMPLE_MAX) || \
      (WOLFSSL_PQC_HYBRID_MIN <= (group) && (group) <= WOLFSSL_PQC_HYBRID_MAX))
 #else
 #define WOLFSSL_NAMED_GROUP_IS_PQC(group)    ((void)(group), 0)
-#endif /* HAVE_PQC */
+#endif /* WOLFSSL_HAVE_KYBER */
 
 /* minimum Downgrade Minor version */
 #ifndef WOLFSSL_MIN_DOWNGRADE
@@ -1884,7 +1893,7 @@ enum Misc {
 
 /* number of items in the signature algo list */
 #ifndef WOLFSSL_MAX_SIGALGO
-#ifdef HAVE_PQC
+#if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
     /* If we are building with post-quantum algorithms, we likely want to
      * inter-op with OQS's OpenSSL and they send a lot more sigalgs.
      */
@@ -1913,12 +1922,14 @@ enum Misc {
 #endif
 #define MIN_ECCKEY_SZ (WOLFSSL_MIN_ECC_BITS / 8)
 
-#ifdef HAVE_PQC
+#ifdef HAVE_FALCON
 #ifndef MIN_FALCONKEY_SZ
-    #define MIN_FALCONKEY_SZ    897
+    #define MIN_FALCONKEY_SZ    1281
 #endif
+#endif
+#ifdef HAVE_DILITHIUM
 #ifndef MIN_DILITHIUMKEY_SZ
-    #define MIN_DILITHIUMKEY_SZ    1312
+    #define MIN_DILITHIUMKEY_SZ    2528
 #endif
 #endif
 
@@ -1961,7 +1972,7 @@ enum Misc {
 #endif
 
 #ifndef MAX_X509_SIZE
-    #if defined(HAVE_PQC)
+    #if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
         #define MAX_X509_SIZE   (8*1024) /* max static x509 buffer size; dilithium is big */
     #elif defined(WOLFSSL_HAPROXY)
         #define MAX_X509_SIZE   3072 /* max static x509 buffer size */
@@ -2169,17 +2180,22 @@ WOLFSSL_LOCAL int  DoServerHello(WOLFSSL* ssl, const byte* input, word32* inOutI
 WOLFSSL_LOCAL int  CompleteServerHello(WOLFSSL *ssl);
 WOLFSSL_LOCAL int  CheckVersion(WOLFSSL *ssl, ProtocolVersion pv);
 WOLFSSL_LOCAL int  PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo,
-                                   word32 hashSigAlgoSz);
+                                   word32 hashSigAlgoSz, int matchSuites);
 #if defined(WOLF_PRIVATE_KEY_ID) && !defined(NO_CHECK_PRIVATE_KEY)
 WOLFSSL_LOCAL int  CreateDevPrivateKey(void** pkey, byte* data, word32 length,
                                        int hsType, int label, int id,
                                        void* heap, int devId);
 #endif
-WOLFSSL_LOCAL int  DecodePrivateKey(WOLFSSL *ssl, word16* length);
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-WOLFSSL_LOCAL int  DecodeAltPrivateKey(WOLFSSL *ssl, word16* length);
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+WOLFSSL_LOCAL int wolfssl_priv_der_blind(WC_RNG* rng, DerBuffer* key,
+    DerBuffer** mask);
+WOLFSSL_LOCAL void wolfssl_priv_der_unblind(DerBuffer* key, DerBuffer* mask);
 #endif
-#ifdef WOLF_PRIVATE_KEY_ID
+WOLFSSL_LOCAL int  DecodePrivateKey(WOLFSSL *ssl, word32* length);
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+WOLFSSL_LOCAL int  DecodeAltPrivateKey(WOLFSSL *ssl, word32* length);
+#endif
+#if defined(WOLF_PRIVATE_KEY_ID) || defined(HAVE_PK_CALLBACKS)
 WOLFSSL_LOCAL int GetPrivateKeySigSize(WOLFSSL* ssl);
 #ifndef NO_ASN
     WOLFSSL_LOCAL int  InitSigPkCb(WOLFSSL* ssl, SignatureCtx* sigCtx);
@@ -2195,9 +2211,9 @@ WOLFSSL_LOCAL void FreeAsyncCtx(WOLFSSL* ssl, byte freeAsync);
 WOLFSSL_LOCAL void FreeKeyExchange(WOLFSSL* ssl);
 WOLFSSL_LOCAL void FreeSuites(WOLFSSL* ssl);
 WOLFSSL_LOCAL int  ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx, word32 totalSz);
-WOLFSSL_LOCAL int  MatchDomainName(const char* pattern, int len, const char* str);
+WOLFSSL_LOCAL int  MatchDomainName(const char* pattern, int len, const char* str, word32 strLen);
 #ifndef NO_CERTS
-WOLFSSL_LOCAL int  CheckForAltNames(DecodedCert* dCert, const char* domain, int* checkCN);
+WOLFSSL_LOCAL int  CheckForAltNames(DecodedCert* dCert, const char* domain, word32 domainLen, int* checkCN);
 WOLFSSL_LOCAL int  CheckIPAddr(DecodedCert* dCert, const char* ipasc);
 WOLFSSL_LOCAL void CopyDecodedName(WOLFSSL_X509_NAME* name, DecodedCert* dCert, int nameType);
 #endif
@@ -2273,6 +2289,8 @@ enum {
 
 
 /* determine maximum record size */
+#define MAX_RECORD_SIZE 16384  /* 2^14, max size by standard */
+
 #ifdef RECORD_SIZE
     /* user supplied value */
     #if RECORD_SIZE < 128 || RECORD_SIZE > MAX_RECORD_SIZE
@@ -2353,16 +2371,8 @@ typedef struct CipherSuite {
 #endif
 } CipherSuite;
 
-WOLFSSL_LOCAL void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig,
-                                         int haveRSAsig, int haveFalconSig,
-                                         int haveDilithiumSig, int haveAnon,
-                                         int tls1_2, int keySz);
-WOLFSSL_LOCAL void InitSuitesHashSigAlgo_ex(byte* hashSigAlgo, int haveECDSAsig,
-                                            int haveRSAsig, int haveFalconSig,
-                                            int haveDilithiumSig, int haveAnon,
-                                            int tls1_2, int keySz, word16* len);
 /* use wolfSSL_API visibility to be able to test in tests/api.c */
-WOLFSSL_API void InitSuitesHashSigAlgo_ex2(byte* hashSigAlgo, int have,
+WOLFSSL_API void InitSuitesHashSigAlgo(byte* hashSigAlgo, int have,
                                              int tls1_2, int keySz,
                                              word16* len);
 WOLFSSL_LOCAL int AllocateCtxSuites(WOLFSSL_CTX* ctx);
@@ -2631,8 +2641,10 @@ struct WOLFSSL_CERT_MANAGER {
                                         /* with CTX free.                    */
 #endif
     wolfSSL_Ref     ref;
-#ifdef HAVE_PQC
+#ifdef HAVE_FALCON
     short           minFalconKeySz;     /* minimum allowed Falcon key size */
+#endif
+#ifdef HAVE_DILITHIUM
     short           minDilithiumKeySz;  /* minimum allowed Dilithium key size */
 #endif
 #if defined(WOLFSSL_CUSTOM_OID) && defined(WOLFSSL_ASN_TEMPLATE) \
@@ -2683,6 +2695,14 @@ typedef struct ProcPeerCertArgs {
 } ProcPeerCertArgs;
 WOLFSSL_LOCAL int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl,
         int ret, ProcPeerCertArgs* args);
+WOLFSSL_LOCAL void DoCrlCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl,
+        ProcPeerCertArgs* args, int* outRet);
+
+WOLFSSL_LOCAL int SetupStoreCtxCallback(WOLFSSL_X509_STORE_CTX** store_pt,
+        WOLFSSL* ssl, WOLFSSL_CERT_MANAGER* cm, ProcPeerCertArgs* args,
+        int cert_err, void* heap, int* x509Free);
+WOLFSSL_LOCAL void CleanupStoreCtxCallback(WOLFSSL_X509_STORE_CTX* store,
+        WOLFSSL* ssl, void* heap, int x509Free);
 #endif /* !defined(NO_WOLFSSL_CLIENT) || !defined(WOLFSSL_NO_CLIENT_AUTH) */
 #endif /* !defined NO_CERTS */
 
@@ -2806,74 +2826,108 @@ typedef struct Options Options;
 /** TLS Extensions - RFC 6066 */
 #ifdef HAVE_TLS_EXTENSIONS
 
+#define TLSXT_SERVER_NAME                0x0000 /* a.k.a. SNI  */
+#define TLSXT_MAX_FRAGMENT_LENGTH        0x0001
+#define TLSXT_TRUSTED_CA_KEYS            0x0003
+#define TLSXT_TRUNCATED_HMAC             0x0004
+#define TLSXT_STATUS_REQUEST             0x0005 /* a.k.a. OCSP stapling   */
+#define TLSXT_SUPPORTED_GROUPS           0x000a /* a.k.a. Supported Curves */
+#define TLSXT_EC_POINT_FORMATS           0x000b
+#define TLSXT_SIGNATURE_ALGORITHMS       0x000d /* HELLO_EXT_SIG_ALGO */
+#define TLSXT_USE_SRTP                   0x000e /* 14 */
+#define TLSXT_APPLICATION_LAYER_PROTOCOL 0x0010 /* a.k.a. ALPN */
+#define TLSXT_STATUS_REQUEST_V2          0x0011 /* a.k.a. OCSP stapling v2 */
+#define TLSXT_CLIENT_CERTIFICATE         0x0013 /* RFC8446 */
+#define TLSXT_SERVER_CERTIFICATE         0x0014 /* RFC8446 */
+#define TLSXT_ENCRYPT_THEN_MAC           0x0016 /* RFC 7366 */
+#define TLSXT_EXTENDED_MASTER_SECRET     0x0017 /* HELLO_EXT_EXTMS */
+#define TLSXT_SESSION_TICKET             0x0023
+#define TLSXT_PRE_SHARED_KEY             0x0029
+#define TLSXT_EARLY_DATA                 0x002a
+#define TLSXT_SUPPORTED_VERSIONS         0x002b
+#define TLSXT_COOKIE                     0x002c
+#define TLSXT_PSK_KEY_EXCHANGE_MODES     0x002d
+#define TLSXT_CERTIFICATE_AUTHORITIES    0x002f
+#define TLSXT_POST_HANDSHAKE_AUTH        0x0031
+#define TLSXT_SIGNATURE_ALGORITHMS_CERT  0x0032
+#define TLSXT_KEY_SHARE                  0x0033
+#define TLSXT_CONNECTION_ID              0x0036
+#define TLSXT_KEY_QUIC_TP_PARAMS         0x0039 /* RFC 9001, ch. 8.2 */
+#define TLSXT_ECH                        0xfe0d /* from */
+                                                /* draft-ietf-tls-esni-13 */
+/* The 0xFF section is experimental/custom/personal use */
+#define TLSXT_CKS                        0xff92 /* X9.146 */
+#define TLSXT_RENEGOTIATION_INFO         0xff01
+#define TLSXT_KEY_QUIC_TP_PARAMS_DRAFT   0xffa5 /* from */
+                                                /* draft-ietf-quic-tls-27 */
+
 typedef enum {
 #ifdef HAVE_SNI
-    TLSX_SERVER_NAME                = 0x0000, /* a.k.a. SNI  */
+    TLSX_SERVER_NAME                = TLSXT_SERVER_NAME,
 #endif
-    TLSX_MAX_FRAGMENT_LENGTH        = 0x0001,
-    TLSX_TRUSTED_CA_KEYS            = 0x0003,
-    TLSX_TRUNCATED_HMAC             = 0x0004,
-    TLSX_STATUS_REQUEST             = 0x0005, /* a.k.a. OCSP stapling   */
-    TLSX_SUPPORTED_GROUPS           = 0x000a, /* a.k.a. Supported Curves */
-    TLSX_EC_POINT_FORMATS           = 0x000b,
+    TLSX_MAX_FRAGMENT_LENGTH        = TLSXT_MAX_FRAGMENT_LENGTH,
+    TLSX_TRUSTED_CA_KEYS            = TLSXT_TRUSTED_CA_KEYS,
+    TLSX_TRUNCATED_HMAC             = TLSXT_TRUNCATED_HMAC,
+    TLSX_STATUS_REQUEST             = TLSXT_STATUS_REQUEST,
+    TLSX_SUPPORTED_GROUPS           = TLSXT_SUPPORTED_GROUPS,
+    TLSX_EC_POINT_FORMATS           = TLSXT_EC_POINT_FORMATS,
 #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
-    TLSX_SIGNATURE_ALGORITHMS       = 0x000d, /* HELLO_EXT_SIG_ALGO */
+    TLSX_SIGNATURE_ALGORITHMS       = TLSXT_SIGNATURE_ALGORITHMS,
 #endif
 #ifdef WOLFSSL_SRTP
-    TLSX_USE_SRTP                   = 0x000e, /* 14 */
+    TLSX_USE_SRTP                   = TLSXT_USE_SRTP,
 #endif
-    TLSX_APPLICATION_LAYER_PROTOCOL = 0x0010, /* a.k.a. ALPN */
-    TLSX_STATUS_REQUEST_V2          = 0x0011, /* a.k.a. OCSP stapling v2 */
+    TLSX_APPLICATION_LAYER_PROTOCOL = TLSXT_APPLICATION_LAYER_PROTOCOL,
+    TLSX_STATUS_REQUEST_V2          = TLSXT_STATUS_REQUEST_V2,
 #ifdef HAVE_RPK
-    TLSX_CLIENT_CERTIFICATE_TYPE    = 0x0013, /* RFC8446 */
-    TLSX_SERVER_CERTIFICATE_TYPE    = 0x0014, /* RFC8446 */
+    TLSX_CLIENT_CERTIFICATE_TYPE    = TLSXT_CLIENT_CERTIFICATE,
+    TLSX_SERVER_CERTIFICATE_TYPE    = TLSXT_SERVER_CERTIFICATE,
 #endif
 #if defined(HAVE_ENCRYPT_THEN_MAC) && !defined(WOLFSSL_AEAD_ONLY)
-    TLSX_ENCRYPT_THEN_MAC           = 0x0016, /* RFC 7366 */
+    TLSX_ENCRYPT_THEN_MAC           = TLSXT_ENCRYPT_THEN_MAC,
 #endif
-    TLSX_EXTENDED_MASTER_SECRET     = 0x0017, /* HELLO_EXT_EXTMS */
-    TLSX_SESSION_TICKET             = 0x0023,
+    TLSX_EXTENDED_MASTER_SECRET     = TLSXT_EXTENDED_MASTER_SECRET,
+    TLSX_SESSION_TICKET             = TLSXT_SESSION_TICKET,
 #ifdef WOLFSSL_TLS13
     #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
-    TLSX_PRE_SHARED_KEY             = 0x0029,
+    TLSX_PRE_SHARED_KEY             = TLSXT_PRE_SHARED_KEY,
     #endif
     #ifdef WOLFSSL_EARLY_DATA
-    TLSX_EARLY_DATA                 = 0x002a,
+    TLSX_EARLY_DATA                 = TLSXT_EARLY_DATA,
     #endif
-    TLSX_SUPPORTED_VERSIONS         = 0x002b,
+    TLSX_SUPPORTED_VERSIONS         = TLSXT_SUPPORTED_VERSIONS,
     #ifdef WOLFSSL_SEND_HRR_COOKIE
-    TLSX_COOKIE                     = 0x002c,
+    TLSX_COOKIE                     = TLSXT_COOKIE,
     #endif
     #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
-    TLSX_PSK_KEY_EXCHANGE_MODES     = 0x002d,
+    TLSX_PSK_KEY_EXCHANGE_MODES     = TLSXT_PSK_KEY_EXCHANGE_MODES,
     #endif
     #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_CA_NAMES)
-    TLSX_CERTIFICATE_AUTHORITIES    = 0x002f,
+    TLSX_CERTIFICATE_AUTHORITIES    = TLSXT_CERTIFICATE_AUTHORITIES,
     #endif
     #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
-    TLSX_POST_HANDSHAKE_AUTH        = 0x0031,
+    TLSX_POST_HANDSHAKE_AUTH        = TLSXT_POST_HANDSHAKE_AUTH,
     #endif
     #if !defined(NO_CERTS) && !defined(WOLFSSL_NO_SIGALG)
-    TLSX_SIGNATURE_ALGORITHMS_CERT  = 0x0032,
+    TLSX_SIGNATURE_ALGORITHMS_CERT  = TLSXT_SIGNATURE_ALGORITHMS_CERT,
     #endif
-    TLSX_KEY_SHARE                  = 0x0033,
+    TLSX_KEY_SHARE                  = TLSXT_KEY_SHARE,
     #if defined(WOLFSSL_DTLS_CID)
-    TLSX_CONNECTION_ID              = 0x0036,
+    TLSX_CONNECTION_ID              = TLSXT_CONNECTION_ID,
     #endif /* defined(WOLFSSL_DTLS_CID) */
     #ifdef WOLFSSL_QUIC
-    TLSX_KEY_QUIC_TP_PARAMS         = 0x0039, /* RFC 9001, ch. 8.2 */
+    TLSX_KEY_QUIC_TP_PARAMS         = TLSXT_KEY_QUIC_TP_PARAMS,
     #endif
-    #ifdef WOLFSSL_DUAL_ALG_CERTS
-    TLSX_CKS                        = 0xff92, /* X9.146; ff indcates personal
-                                               * use and 92 is hex for 146. */
+    #ifdef HAVE_ECH
+    TLSX_ECH                        = TLSXT_ECH,
     #endif
 #endif
-    TLSX_RENEGOTIATION_INFO         = 0xff01,
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_DUAL_ALG_CERTS)
+    TLSX_CKS                        = TLSXT_CKS,
+#endif
+    TLSX_RENEGOTIATION_INFO         = TLSXT_RENEGOTIATION_INFO,
 #ifdef WOLFSSL_QUIC
-    TLSX_KEY_QUIC_TP_PARAMS_DRAFT   = 0xffa5, /* from draft-ietf-quic-tls-27 */
-#endif
-#if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
-    TLSX_ECH                        = 0xfe0d, /* from draft-ietf-tls-esni-13 */
+    TLSX_KEY_QUIC_TP_PARAMS_DRAFT   = TLSXT_KEY_QUIC_TP_PARAMS_DRAFT,
 #endif
 } TLSX_Type;
 
@@ -2986,9 +3040,9 @@ WOLFSSL_LOCAL int   TLSX_PopulateExtensions(WOLFSSL* ssl, byte isRequest);
 
 #if defined(WOLFSSL_TLS13) || !defined(NO_WOLFSSL_CLIENT)
 WOLFSSL_LOCAL int   TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType,
-                                         word16* pLength);
+                                         word32* pLength);
 WOLFSSL_LOCAL int   TLSX_WriteRequest(WOLFSSL* ssl, byte* output,
-                                       byte msgType, word16* pOffset);
+                                       byte msgType, word32* pOffset);
 #endif
 
 #if defined(WOLFSSL_TLS13) || !defined(NO_WOLFSSL_SERVER)
@@ -3044,7 +3098,7 @@ WOLFSSL_LOCAL int TLSX_UseSNI(TLSX** extensions, byte type, const void* data,
                                                        word16 size, void* heap);
 WOLFSSL_LOCAL byte TLSX_SNI_Status(TLSX* extensions, byte type);
 WOLFSSL_LOCAL word16 TLSX_SNI_GetRequest(TLSX* extensions, byte type,
-                                                                   void** data);
+                                                void** data, byte ignoreStatus);
 
 #ifndef NO_WOLFSSL_SERVER
 WOLFSSL_LOCAL void   TLSX_SNI_SetOptions(TLSX* extensions, byte type,
@@ -3140,11 +3194,17 @@ typedef struct CSRIv2 {
         OcspRequest ocsp[1 + MAX_CHAIN_DEPTH];
     } request;
     struct CSRIv2* next;
+    Signer *pendingSigners;
 } CertificateStatusRequestItemV2;
 
 WOLFSSL_LOCAL int   TLSX_UseCertificateStatusRequestV2(TLSX** extensions,
                          byte status_type, byte options, void* heap, int devId);
 #ifndef NO_CERTS
+WOLFSSL_LOCAL int TLSX_CSR2_IsMulti(TLSX *extensions);
+WOLFSSL_LOCAL int TLSX_CSR2_AddPendingSigner(TLSX *extensions, Signer *s);
+WOLFSSL_LOCAL Signer* TLSX_CSR2_GetPendingSigners(TLSX *extensions);
+WOLFSSL_LOCAL int TLSX_CSR2_ClearPendingCA(WOLFSSL *ssl);
+WOLFSSL_LOCAL int TLSX_CSR2_MergePendingCA(WOLFSSL* ssl);
 WOLFSSL_LOCAL int   TLSX_CSR2_InitRequests(TLSX* extensions, DecodedCert* cert,
                                                        byte isPeer, void* heap);
 #endif
@@ -3369,7 +3429,7 @@ typedef struct KeyShareEntry {
     word32                keyLen;    /* Key size (bytes)                  */
     byte*                 pubKey;    /* Public key                        */
     word32                pubKeyLen; /* Public key length                 */
-#if !defined(NO_DH) || defined(HAVE_PQC)
+#if !defined(NO_DH) || defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
     byte*                 privKey;   /* Private key - DH and PQ KEMs only */
     word32                privKeyLen;/* Only for PQ KEMs. */
 #endif
@@ -3575,7 +3635,10 @@ struct WOLFSSL_CTX {
     int         certChainCnt;
 #endif
     DerBuffer*  privateKey;
-    byte        privateKeyType:6;
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    DerBuffer*  privateKeyMask;             /* Mask of private key DER. */
+#endif
+    byte        privateKeyType;
     byte        privateKeyId:1;
     byte        privateKeyLabel:1;
     int         privateKeySz;
@@ -3583,8 +3646,14 @@ struct WOLFSSL_CTX {
 
 #ifdef WOLFSSL_DUAL_ALG_CERTS
     DerBuffer*  altPrivateKey;
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    DerBuffer*  altPrivateKeyMask;          /* Mask of alt private key DER. */
+#endif
     byte        altPrivateKeyType;
+    byte        altPrivateKeyId:1;
+    byte        altPrivateKeyLabel:1;
     int         altPrivateKeySz;
+    int         altPrivateKeyDevId;
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
 #ifdef OPENSSL_ALL
     WOLFSSL_EVP_PKEY* privateKeyPKey;
@@ -3693,8 +3762,10 @@ struct WOLFSSL_CTX {
 #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
     short       minEccKeySz;      /* minimum ECC key size */
 #endif
-#ifdef HAVE_PQC
+#ifdef HAVE_FALCON
     short       minFalconKeySz;   /* minimum Falcon key size */
+#endif
+#ifdef HAVE_DILITHIUM
     short       minDilithiumKeySz;/* minimum Dilithium key size */
 #endif
     unsigned long     mask;             /* store SSL_OP_ flags */
@@ -3989,6 +4060,7 @@ int ProcessOldClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                           word32 inSz, word16 sz);
 
 #ifndef NO_CERTS
+    WOLFSSL_LOCAL int AddSigner(WOLFSSL_CERT_MANAGER* cm, Signer *s);
     WOLFSSL_LOCAL
     int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify);
     WOLFSSL_LOCAL
@@ -4035,13 +4107,16 @@ enum KeyExchangeAlgorithm {
     ecc_static_diffie_hellman_kea       /* for verify suite only */
 };
 
-/* Used with InitSuitesHashSigAlgo_ex2 */
+/* Used with InitSuitesHashSigAlgo */
 #define SIG_ECDSA       0x01
 #define SIG_RSA         0x02
 #define SIG_SM2         0x04
 #define SIG_FALCON      0x08
 #define SIG_DILITHIUM   0x10
 #define SIG_ANON        0x20
+/* SIG_ANON is omitted by default */
+#define SIG_ALL         (SIG_ECDSA | SIG_RSA | SIG_SM2 | SIG_FALCON | \
+                         SIG_DILITHIUM)
 
 /* Supported Authentication Schemes */
 enum SignatureAlgorithm {
@@ -4407,6 +4482,10 @@ struct WOLFSSL_SESSION {
 #ifdef HAVE_EX_DATA
     WOLFSSL_CRYPTO_EX_DATA ex_data;
 #endif
+#ifdef HAVE_MAX_FRAGMENT
+    byte               mfl; /* max fragment length negotiated i.e.
+                             * WOLFSSL_MFL_2_8  (6) */
+#endif
     byte               isSetup:1;
 };
 
@@ -4548,15 +4627,24 @@ typedef struct Buffers {
 #ifndef NO_CERTS
     DerBuffer*      certificate;           /* WOLFSSL_CTX owns, unless we own */
     DerBuffer*      key;                   /* WOLFSSL_CTX owns, unless we own */
-    byte            keyType:6;             /* Type of key: RSA, ECC, Ed25519 */
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    DerBuffer*      keyMask;               /* Mask of private key DER. */
+#endif
+    byte            keyType;               /* Type of key */
     byte            keyId:1;               /* Key data is an id not data */
     byte            keyLabel:1;            /* Key data is a label not data */
     int             keySz;                 /* Size of RSA key */
     int             keyDevId;              /* Device Id for key */
 #ifdef WOLFSSL_DUAL_ALG_CERTS
     DerBuffer*      altKey;                /* WOLFSSL_CTX owns, unless we own */
-    byte            altKeyType;            /* Type of key: dilithium, falcon */
-    int             altKeySz;              /* Size of key */
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    DerBuffer*      altKeyMask;            /* Mask of alt private key DER. */
+#endif
+    byte            altKeyType;            /* Type of alt key */
+    byte            altKeyId:1;            /* Key data is an id not data */
+    byte            altKeyLabel:1;         /* Key data is a label not data */
+    int             altKeySz;              /* Size of alt key */
+    int             altKeyDevId;           /* Device Id for alt key */
 #endif
     DerBuffer*      certChain;             /* WOLFSSL_CTX owns, unless we own */
                  /* chain after self, in DER, with leading size for each cert */
@@ -4841,8 +4929,10 @@ struct Options {
 #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
     short           minEccKeySz;      /* minimum ECC key size */
 #endif
-#if defined(HAVE_PQC)
+#if defined(HAVE_FALCON)
     short           minFalconKeySz;   /* minimum Falcon key size */
+#endif
+#if defined(HAVE_DILITHIUM)
     short           minDilithiumKeySz;/* minimum Dilithium key size */
 #endif
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
@@ -5036,9 +5126,9 @@ struct WOLFSSL_X509 {
     int              pubKeyOID;
     DNS_entry*       altNamesNext;                   /* hint for retrieval */
 #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448) || \
-    defined(HAVE_PQC)
+    defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
     word32       pkCurveOID;
-#endif /* HAVE_ECC || HAVE_PQC */
+#endif
 #ifndef NO_CERTS
     DerBuffer*   derCert;                            /* may need  */
 #endif
@@ -5631,9 +5721,11 @@ struct WOLFSSL {
     curve448_key*   peerX448Key;
     byte            peerX448KeyPresent;
 #endif
-#ifdef HAVE_PQC
+#ifdef HAVE_FALCON
     falcon_key*     peerFalconKey;
     byte            peerFalconKeyPresent;
+#endif
+#ifdef HAVE_DILITHIUM
     dilithium_key*  peerDilithiumKey;
     byte            peerDilithiumKeyPresent;
 #endif
@@ -5861,6 +5953,10 @@ struct WOLFSSL {
 #ifdef HAVE_SECRET_CALLBACK
         SessionSecretCb sessionSecretCb;
         void*           sessionSecretCtx;
+        TicketParseCb   ticketParseCb;
+        void*           ticketParseCtx;
+        TlsSecretCb     tlsSecretCb;
+        void*           tlsSecretCtx;
     #ifdef WOLFSSL_TLS13
         Tls13SecretCb   tls13SecretCb;
         void*           tls13SecretCtx;
@@ -6110,16 +6206,11 @@ typedef struct {
     int name_len;
     const char *name;
     int nid;
+    word16 curve;
 } WOLF_EC_NIST_NAME;
 extern const WOLF_EC_NIST_NAME kNistCurves[];
-/* This is the longest and shortest curve name in the kNistCurves list. Note we
- * also have quantum-safe group names as well. */
-#define kNistCurves_MIN_NAME_LEN 5
-#ifdef HAVE_PQC
-#define kNistCurves_MAX_NAME_LEN 32
-#else
-#define kNistCurves_MAX_NAME_LEN 7
-#endif
+WOLFSSL_LOCAL int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx,
+        const char* names, byte curves_only);
 #endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
 
 /* internal functions */
@@ -6179,6 +6270,7 @@ WOLFSSL_LOCAL int DeriveKeys(WOLFSSL* ssl);
 WOLFSSL_LOCAL int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side);
 
 WOLFSSL_LOCAL int IsTLS(const WOLFSSL* ssl);
+WOLFSSL_LOCAL int IsTLS_ex(const ProtocolVersion pv);
 WOLFSSL_LOCAL int IsAtLeastTLSv1_2(const WOLFSSL* ssl);
 WOLFSSL_LOCAL int IsAtLeastTLSv1_3(ProtocolVersion pv);
 WOLFSSL_LOCAL int IsEncryptionOn(const WOLFSSL* ssl, int isSend);
@@ -6407,6 +6499,7 @@ WOLFSSL_LOCAL int cipherExtraData(WOLFSSL* ssl);
 WOLFSSL_LOCAL word32  LowResTimer(void);
 
 WOLFSSL_LOCAL int FindSuiteSSL(const WOLFSSL* ssl, byte* suite);
+WOLFSSL_LOCAL int FindSuite(const Suites* suites, byte first, byte second);
 
 WOLFSSL_LOCAL void DecodeSigAlg(const byte* input, byte* hashAlgo,
         byte* hsType);
@@ -6739,6 +6832,11 @@ WOLFSSL_LOCAL int wolfSSL_quic_keys_active(WOLFSSL* ssl, enum encrypt_side side)
 #if defined(SHOW_SECRETS) && defined(WOLFSSL_SSLKEYLOGFILE)
 WOLFSSL_LOCAL int tls13ShowSecrets(WOLFSSL* ssl, int id, const unsigned char* secret,
     int secretSz, void* ctx);
+#endif
+
+#if defined(SHOW_SECRETS)
+WOLFSSL_LOCAL int tlsShowSecrets(WOLFSSL* ssl, void* secret,
+        int secretSz, void* ctx);
 #endif
 
 /* Optional Pre-Master-Secret logging for Wireshark */

--- a/include/wolfssl/openssl/aes.h
+++ b/include/wolfssl/openssl/aes.h
@@ -1,0 +1,110 @@
+/* aes.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+
+/*  aes.h defines mini des openssl compatibility layer
+ *
+ */
+
+
+#ifndef WOLFSSL_AES_H_
+#define WOLFSSL_AES_H_
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifndef NO_AES
+#include <wolfssl/wolfcrypt/aes.h>
+
+#if !defined(WOLFSSL_NO_OPENSSL_AES_LOW_LEVEL_API) && \
+    defined(WC_AESFREE_IS_MANDATORY)
+#define WOLFSSL_NO_OPENSSL_AES_LOW_LEVEL_API
+#endif
+
+#ifndef WOLFSSL_NO_OPENSSL_AES_LOW_LEVEL_API
+
+#include <wolfssl/openssl/ssl.h> /* for size_t */
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+/* This structure wrapper is done because there is no aes_new function with
+ * OpenSSL compatibility layer. This makes code working with an AES structure
+ * to need the size of the structure. */
+typedef struct WOLFSSL_AES_KEY {
+    ALIGN16 void *buf[(sizeof(Aes) / sizeof(void *)) + 1];
+} WOLFSSL_AES_KEY;
+typedef WOLFSSL_AES_KEY AES_KEY;
+
+WOLFSSL_API int wolfSSL_AES_set_encrypt_key(
+    const unsigned char *key, const int bits, AES_KEY *aes);
+WOLFSSL_API int wolfSSL_AES_set_decrypt_key(
+    const unsigned char *key, const int bits, AES_KEY *aes);
+WOLFSSL_API void wolfSSL_AES_cbc_encrypt(
+    const unsigned char *in, unsigned char* out, size_t len, AES_KEY *key,
+    unsigned char* iv, const int enc);
+WOLFSSL_API void wolfSSL_AES_ecb_encrypt(
+    const unsigned char *in, unsigned char* out, AES_KEY *key, const int enc);
+WOLFSSL_API void wolfSSL_AES_cfb128_encrypt(
+    const unsigned char *in, unsigned char* out, size_t len, AES_KEY *key,
+    unsigned char* iv, int* num, const int enc);
+WOLFSSL_API int wolfSSL_AES_wrap_key(
+    AES_KEY *key, const unsigned char *iv, unsigned char *out,
+    const unsigned char *in, unsigned int inlen);
+WOLFSSL_API int wolfSSL_AES_unwrap_key(
+    AES_KEY *key, const unsigned char *iv, unsigned char *out,
+    const unsigned char *in, unsigned int inlen);
+
+#define AES_cbc_encrypt     wolfSSL_AES_cbc_encrypt
+#define AES_ecb_encrypt     wolfSSL_AES_ecb_encrypt
+#define AES_cfb128_encrypt  wolfSSL_AES_cfb128_encrypt
+#define AES_set_encrypt_key wolfSSL_AES_set_encrypt_key
+#define AES_set_decrypt_key wolfSSL_AES_set_decrypt_key
+#define AES_wrap_key        wolfSSL_AES_wrap_key
+#define AES_unwrap_key      wolfSSL_AES_unwrap_key
+
+#ifdef WOLFSSL_AES_DIRECT
+WOLFSSL_API void wolfSSL_AES_encrypt(
+    const unsigned char* input, unsigned char* output, AES_KEY *key);
+WOLFSSL_API void wolfSSL_AES_decrypt(
+    const unsigned char* input, unsigned char* output, AES_KEY *key);
+
+#define AES_encrypt         wolfSSL_AES_encrypt
+#define AES_decrypt         wolfSSL_AES_decrypt
+#endif /* WOLFSSL_AES_DIRECT */
+
+#ifndef AES_ENCRYPT
+#define AES_ENCRYPT AES_ENCRYPTION
+#endif
+#ifndef AES_DECRYPT
+#define AES_DECRYPT AES_DECRYPTION
+#endif
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+
+#endif /* !WOLFSSL_NO_OPENSSL_AES_LOW_LEVEL_API */
+
+#endif /* NO_AES */
+
+#endif /* WOLFSSL_AES_H_ */

--- a/include/wolfssl/openssl/asn1.h
+++ b/include/wolfssl/openssl/asn1.h
@@ -1,0 +1,192 @@
+/* asn1.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* asn1.h for openssl */
+
+#ifndef WOLFSSL_ASN1_H_
+#define WOLFSSL_ASN1_H_
+
+#include <wolfssl/openssl/ssl.h>
+
+#define ASN1_STRING_new       wolfSSL_ASN1_STRING_new
+#define ASN1_STRING_type_new  wolfSSL_ASN1_STRING_type_new
+#define ASN1_STRING_type      wolfSSL_ASN1_STRING_type
+#define ASN1_STRING_set       wolfSSL_ASN1_STRING_set
+#define ASN1_OCTET_STRING_set wolfSSL_ASN1_STRING_set
+#define ASN1_STRING_free      wolfSSL_ASN1_STRING_free
+
+#define ASN1_get_object       wolfSSL_ASN1_get_object
+#define d2i_ASN1_OBJECT       wolfSSL_d2i_ASN1_OBJECT
+#define c2i_ASN1_OBJECT       wolfSSL_c2i_ASN1_OBJECT
+
+#define V_ASN1_INTEGER                   0x02
+#define V_ASN1_OCTET_STRING              0x04 /* tag for ASN1_OCTET_STRING */
+#define V_ASN1_NEG                       0x100
+#define V_ASN1_NEG_INTEGER               (2 | V_ASN1_NEG)
+#define V_ASN1_NEG_ENUMERATED            (10 | V_ASN1_NEG)
+
+/* Type for ASN1_print_ex */
+# define ASN1_STRFLGS_ESC_2253           1
+# define ASN1_STRFLGS_ESC_CTRL           2
+# define ASN1_STRFLGS_ESC_MSB            4
+# define ASN1_STRFLGS_ESC_QUOTE          8
+# define ASN1_STRFLGS_UTF8_CONVERT       0x10
+# define ASN1_STRFLGS_IGNORE_TYPE        0x20
+# define ASN1_STRFLGS_SHOW_TYPE          0x40
+# define ASN1_STRFLGS_DUMP_ALL           0x80
+# define ASN1_STRFLGS_DUMP_UNKNOWN       0x100
+# define ASN1_STRFLGS_DUMP_DER           0x200
+# define ASN1_STRFLGS_RFC2253            (ASN1_STRFLGS_ESC_2253 | \
+                                          ASN1_STRFLGS_ESC_CTRL | \
+                                          ASN1_STRFLGS_ESC_MSB | \
+                                          ASN1_STRFLGS_UTF8_CONVERT | \
+                                          ASN1_STRFLGS_DUMP_UNKNOWN | \
+                                          ASN1_STRFLGS_DUMP_DER)
+
+#define MBSTRING_UTF8                    0x1000
+#define MBSTRING_ASC                     0x1001
+#define MBSTRING_BMP                     0x1002
+#define MBSTRING_UNIV                    0x1004
+
+#define ASN1_UTCTIME_print              wolfSSL_ASN1_UTCTIME_print
+#define ASN1_TIME_check                 wolfSSL_ASN1_TIME_check
+#define ASN1_TIME_diff                  wolfSSL_ASN1_TIME_diff
+#define ASN1_TIME_compare               wolfSSL_ASN1_TIME_compare
+#define ASN1_TIME_set                   wolfSSL_ASN1_TIME_set
+
+#define V_ASN1_EOC                      0
+#define V_ASN1_NULL                     5
+#define V_ASN1_OBJECT                   6
+#define V_ASN1_UTF8STRING               12
+#define V_ASN1_SEQUENCE                 16
+#define V_ASN1_SET                      17
+#define V_ASN1_PRINTABLESTRING          19
+#define V_ASN1_T61STRING                20
+#define V_ASN1_IA5STRING                22
+#define V_ASN1_UTCTIME                  23
+#define V_ASN1_GENERALIZEDTIME          24
+#define V_ASN1_UNIVERSALSTRING          28
+#define V_ASN1_BMPSTRING                30
+
+
+#define V_ASN1_CONSTRUCTED              0x20
+
+#define ASN1_STRING_FLAG_BITS_LEFT       0x008
+#define ASN1_STRING_FLAG_NDEF            0x010
+#define ASN1_STRING_FLAG_CONT            0x020
+#define ASN1_STRING_FLAG_MSTRING         0x040
+#define ASN1_STRING_FLAG_EMBED           0x080
+
+/* X.509 PKI size limits from RFC2459 (appendix A) */
+/* internally our limit is CTC_NAME_SIZE (64) - overridden with WC_CTC_NAME_SIZE */
+#define ub_name                    CTC_NAME_SIZE /* 32768 */
+#define ub_common_name             CTC_NAME_SIZE /* 64 */
+#define ub_locality_name           CTC_NAME_SIZE /* 128 */
+#define ub_state_name              CTC_NAME_SIZE /* 128 */
+#define ub_organization_name       CTC_NAME_SIZE /* 64 */
+#define ub_organization_unit_name  CTC_NAME_SIZE /* 64 */
+#define ub_title                   CTC_NAME_SIZE /* 64 */
+#define ub_email_address           CTC_NAME_SIZE /* 128 */
+
+
+WOLFSSL_API WOLFSSL_ASN1_INTEGER *wolfSSL_BN_to_ASN1_INTEGER(
+    const WOLFSSL_BIGNUM *bn, WOLFSSL_ASN1_INTEGER *ai);
+
+WOLFSSL_API void wolfSSL_ASN1_TYPE_set(WOLFSSL_ASN1_TYPE *a, int type, void *value);
+
+WOLFSSL_API int wolfSSL_ASN1_get_object(const unsigned char **in, long *len, int *tag,
+                                        int *cls, long inLen);
+
+WOLFSSL_API WOLFSSL_ASN1_OBJECT *wolfSSL_c2i_ASN1_OBJECT(WOLFSSL_ASN1_OBJECT **a,
+        const unsigned char **pp, long len);
+
+#ifdef OPENSSL_ALL
+/* IMPLEMENT_ASN1_FUNCTIONS is strictly for external use only. Internally
+ * we don't use this. Some projects use OpenSSL to implement ASN1 types and
+ * this section is only to provide those projects with ASN1 functionality. */
+typedef struct {
+    size_t offset;              /* Offset of this field in structure */
+    byte type;                  /* The type of the member as defined in
+                                 * WOLFSSL_ASN1_TYPES */
+} WOLFSSL_ASN1_TEMPLATE;
+
+typedef struct {
+    byte type;                              /* One of the ASN_Tags types */
+    const WOLFSSL_ASN1_TEMPLATE *members;   /* If SEQUENCE or CHOICE this
+                                             * contains the contents */
+    size_t mcount;                          /* Number of members if SEQUENCE
+                                             * or CHOICE */
+    size_t size;                            /* Structure size */
+} WOLFSSL_ASN1_ITEM;
+
+typedef enum {
+    WOLFSSL_X509_ALGOR_ASN1 = 0,
+    WOLFSSL_ASN1_BIT_STRING_ASN1,
+    WOLFSSL_ASN1_INTEGER_ASN1,
+} WOLFSSL_ASN1_TYPES;
+
+#define ASN1_SEQUENCE(type) \
+    static const WOLFSSL_ASN1_TEMPLATE type##_member_data[]
+
+#define ASN1_SIMPLE(type, member, member_type) \
+    { OFFSETOF(type, member), \
+        WOLFSSL_##member_type##_ASN1 }
+
+#define ASN1_SEQUENCE_END(type) \
+    ; \
+    const WOLFSSL_ASN1_ITEM type##_template_data = { \
+            ASN_SEQUENCE, \
+            type##_member_data, \
+            sizeof(type##_member_data) / sizeof(WOLFSSL_ASN1_TEMPLATE), \
+            sizeof(type) \
+    };
+
+WOLFSSL_API void *wolfSSL_ASN1_item_new(const WOLFSSL_ASN1_ITEM *tpl);
+WOLFSSL_API void wolfSSL_ASN1_item_free(void *val, const WOLFSSL_ASN1_ITEM *tpl);
+WOLFSSL_API int wolfSSL_ASN1_item_i2d(const void *src, byte **dest,
+                                      const WOLFSSL_ASN1_ITEM *tpl);
+
+/* Need function declaration otherwise compiler complains */
+/* // NOLINTBEGIN(readability-named-parameter) */
+#define IMPLEMENT_ASN1_FUNCTIONS(type) \
+    type *type##_new(void); \
+    type *type##_new(void){ \
+        return (type*)wolfSSL_ASN1_item_new(&type##_template_data); \
+    } \
+    void type##_free(type *t); \
+    void type##_free(type *t){ \
+        wolfSSL_ASN1_item_free(t, &type##_template_data); \
+    } \
+    int i2d_##type(type *src, byte **dest); \
+    int i2d_##type(type *src, byte **dest) \
+    { \
+        return wolfSSL_ASN1_item_i2d(src, dest, &type##_template_data);\
+    }
+/* // NOLINTEND(readability-named-parameter) */
+
+#endif /* OPENSSL_ALL */
+
+#define BN_to_ASN1_INTEGER          wolfSSL_BN_to_ASN1_INTEGER
+#define ASN1_TYPE_set               wolfSSL_ASN1_TYPE_set
+#define ASN1_TYPE_new               wolfSSL_ASN1_TYPE_new
+#define ASN1_TYPE_free              wolfSSL_ASN1_TYPE_free
+
+#endif /* WOLFSSL_ASN1_H_ */

--- a/include/wolfssl/openssl/bio.h
+++ b/include/wolfssl/openssl/bio.h
@@ -1,0 +1,189 @@
+/* bio.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* bio.h for openssl */
+
+
+#ifndef WOLFSSL_BIO_H_
+#define WOLFSSL_BIO_H_
+
+#include <wolfssl/openssl/ssl.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+
+#define BIO_FLAGS_BASE64_NO_NL WOLFSSL_BIO_FLAG_BASE64_NO_NL
+#define BIO_FLAGS_READ         WOLFSSL_BIO_FLAG_READ
+#define BIO_FLAGS_WRITE        WOLFSSL_BIO_FLAG_WRITE
+#define BIO_FLAGS_IO_SPECIAL   WOLFSSL_BIO_FLAG_IO_SPECIAL
+#define BIO_FLAGS_SHOULD_RETRY WOLFSSL_BIO_FLAG_RETRY
+
+#define BIO_new_fp                      wolfSSL_BIO_new_fp
+#if defined(OPENSSL_ALL) \
+    || defined(HAVE_STUNNEL) \
+    || defined(HAVE_LIGHTY) \
+    || defined(WOLFSSL_MYSQL_COMPATIBLE) \
+    || defined(WOLFSSL_HAPROXY) \
+    || defined(OPENSSL_EXTRA)
+#define BIO_new_file                    wolfSSL_BIO_new_file
+#endif
+#define BIO_new_fp                      wolfSSL_BIO_new_fp
+#define BIO_ctrl                        wolfSSL_BIO_ctrl
+#define BIO_ctrl_pending                wolfSSL_BIO_ctrl_pending
+#define BIO_wpending                    wolfSSL_BIO_wpending
+#define BIO_get_mem_ptr                 wolfSSL_BIO_get_mem_ptr
+#ifdef OPENSSL_ALL
+#define BIO_set_mem_buf                 wolfSSL_BIO_set_mem_buf
+#endif
+#define BIO_int_ctrl                    wolfSSL_BIO_int_ctrl
+#define BIO_reset                       wolfSSL_BIO_reset
+#define BIO_s_file                      wolfSSL_BIO_s_file
+#define BIO_s_bio                       wolfSSL_BIO_s_bio
+#define BIO_s_socket                    wolfSSL_BIO_s_socket
+#define BIO_s_accept                    wolfSSL_BIO_s_socket
+#define BIO_set_fd                      wolfSSL_BIO_set_fd
+#define BIO_set_close                   wolfSSL_BIO_set_close
+#define BIO_ctrl_reset_read_request     wolfSSL_BIO_ctrl_reset_read_request
+#define BIO_set_write_buf_size          wolfSSL_BIO_set_write_buf_size
+#define BIO_make_bio_pair               wolfSSL_BIO_make_bio_pair
+#define BIO_up_ref                      wolfSSL_BIO_up_ref
+
+#define BIO_new_fd                      wolfSSL_BIO_new_fd
+#define BIO_set_fp                      wolfSSL_BIO_set_fp
+#define BIO_get_fp                      wolfSSL_BIO_get_fp
+#define BIO_seek                        wolfSSL_BIO_seek
+#define BIO_tell                        wolfSSL_BIO_tell
+#define BIO_write_filename              wolfSSL_BIO_write_filename
+#define BIO_set_mem_eof_return          wolfSSL_BIO_set_mem_eof_return
+
+#define BIO_find_type wolfSSL_BIO_find_type
+#define BIO_next      wolfSSL_BIO_next
+#define BIO_gets      wolfSSL_BIO_gets
+#define BIO_puts      wolfSSL_BIO_puts
+
+#define BIO_should_retry                wolfSSL_BIO_should_retry
+#define BIO_should_read                 wolfSSL_BIO_should_read
+#define BIO_should_write                wolfSSL_BIO_should_write
+
+#define BIO_TYPE_FILE WOLFSSL_BIO_FILE
+#define BIO_TYPE_BIO  WOLFSSL_BIO_BIO
+#define BIO_TYPE_MEM  WOLFSSL_BIO_MEMORY
+#define BIO_TYPE_BASE64 WOLFSSL_BIO_BASE64
+
+#define BIO_vprintf wolfSSL_BIO_vprintf
+#define BIO_printf  wolfSSL_BIO_printf
+#define BIO_dump    wolfSSL_BIO_dump
+
+/* BIO info callback */
+#define BIO_CB_FREE   WOLFSSL_BIO_CB_FREE
+#define BIO_CB_READ   WOLFSSL_BIO_CB_READ
+#define BIO_CB_WRITE  WOLFSSL_BIO_CB_WRITE
+#define BIO_CB_PUTS   WOLFSSL_BIO_CB_PUTS
+#define BIO_CB_GETS   WOLFSSL_BIO_CB_GETS
+#define BIO_CB_CTRL   WOLFSSL_BIO_CB_CTRL
+#define BIO_CB_RETURN WOLFSSL_BIO_CB_RETURN
+
+#define BIO_set_callback         wolfSSL_BIO_set_callback
+#define BIO_get_callback         wolfSSL_BIO_get_callback
+#define BIO_set_callback_arg     wolfSSL_BIO_set_callback_arg
+#define BIO_get_callback_arg     wolfSSL_BIO_get_callback_arg
+
+/* BIO for 1.1.0 or later */
+#define BIO_set_init               wolfSSL_BIO_set_init
+#define BIO_get_data               wolfSSL_BIO_get_data
+#define BIO_set_data               wolfSSL_BIO_set_data
+#define BIO_get_shutdown           wolfSSL_BIO_get_shutdown
+#define BIO_set_shutdown           wolfSSL_BIO_set_shutdown
+
+#define BIO_get_fd                 wolfSSL_BIO_get_fd
+
+#define BIO_clear_flags            wolfSSL_BIO_clear_flags
+#define BIO_set_ex_data            wolfSSL_BIO_set_ex_data
+#define BIO_get_ex_data            wolfSSL_BIO_get_ex_data
+
+/* helper to set specific retry/read flags */
+#define BIO_set_retry_read(bio)\
+    wolfSSL_BIO_set_flags((bio), WOLFSSL_BIO_FLAG_RETRY | WOLFSSL_BIO_FLAG_READ)
+#define BIO_set_retry_write(bio)\
+    wolfSSL_BIO_set_flags((bio), WOLFSSL_BIO_FLAG_RETRY | WOLFSSL_BIO_FLAG_WRITE)
+
+#define BIO_clear_retry_flags      wolfSSL_BIO_clear_retry_flags
+
+#define BIO_meth_new               wolfSSL_BIO_meth_new
+#define BIO_meth_set_write         wolfSSL_BIO_meth_set_write
+#define BIO_meth_free              wolfSSL_BIO_meth_free
+#define BIO_meth_set_write         wolfSSL_BIO_meth_set_write
+#define BIO_meth_set_read          wolfSSL_BIO_meth_set_read
+#define BIO_meth_set_puts          wolfSSL_BIO_meth_set_puts
+#define BIO_meth_set_gets          wolfSSL_BIO_meth_set_gets
+#define BIO_meth_set_ctrl          wolfSSL_BIO_meth_set_ctrl
+#define BIO_meth_set_create        wolfSSL_BIO_meth_set_create
+#define BIO_meth_set_destroy       wolfSSL_BIO_meth_set_destroy
+
+#define BIO_snprintf               XSNPRINTF
+
+/* BIO CTRL */
+#define BIO_CTRL_RESET             1
+#define BIO_CTRL_EOF               2
+#define BIO_CTRL_INFO              3
+#define BIO_CTRL_SET               4
+#define BIO_CTRL_GET               5
+#define BIO_CTRL_PUSH              6
+#define BIO_CTRL_POP               7
+#define BIO_CTRL_GET_CLOSE         8
+#define BIO_CTRL_SET_CLOSE         9
+#define BIO_CTRL_PENDING           10
+#define BIO_CTRL_FLUSH             11
+#define BIO_CTRL_DUP               12
+#define BIO_CTRL_WPENDING          13
+
+#define BIO_C_SET_FILE_PTR              106
+#define BIO_C_GET_FILE_PTR              107
+#define BIO_C_SET_FILENAME              108
+#define BIO_C_SET_BUF_MEM               114
+#define BIO_C_GET_BUF_MEM_PTR           115
+#define BIO_C_FILE_SEEK                 128
+#define BIO_C_SET_BUF_MEM_EOF_RETURN    130
+#define BIO_C_SET_WRITE_BUF_SIZE        136
+#define BIO_C_MAKE_BIO_PAIR             138
+
+#define BIO_CTRL_DGRAM_QUERY_MTU   40
+
+#define BIO_FP_TEXT                0x00
+#define BIO_NOCLOSE                0x00
+#define BIO_CLOSE                  0x01
+
+#define BIO_FP_WRITE               0x04
+
+/* You shouldn't free up or change the data if BIO_FLAGS_MEM_RDONLY is set */
+#define BIO_FLAGS_MEM_RDONLY       0x200
+
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_BIO_H_ */

--- a/include/wolfssl/openssl/bn.h
+++ b/include/wolfssl/openssl/bn.h
@@ -40,7 +40,9 @@
 typedef struct WOLFSSL_BIGNUM {
     int neg;        /* openssh deference */
     void *internal; /* our big num */
+#if !defined(NO_BIG_INT) || defined(WOLFSSL_SP_MATH)
     mp_int mpi;
+#endif
 } WOLFSSL_BIGNUM;
 
 #define WOLFSSL_BN_ULONG unsigned long

--- a/include/wolfssl/openssl/bn.h
+++ b/include/wolfssl/openssl/bn.h
@@ -44,7 +44,7 @@ typedef struct WOLFSSL_BIGNUM {
 } WOLFSSL_BIGNUM;
 
 #define WOLFSSL_BN_ULONG unsigned long
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || defined(EMBEDDED_SSL)
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 #define BN_ULONG         WOLFSSL_BN_ULONG
 #endif
 
@@ -182,7 +182,7 @@ WOLFSSL_API WOLFSSL_BIGNUM *wolfSSL_BN_mod_inverse(
     WOLFSSL_BN_CTX *ctx);
 
 
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || defined(EMBEDDED_SSL)
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 
 #define BN_RAND_TOP_ANY     WOLFSSL_BN_RAND_TOP_ANY
 #define BN_RAND_TOP_ONE     WOLFSSL_BN_RAND_TOP_ONE
@@ -286,7 +286,7 @@ typedef WOLFSSL_BN_GENCB BN_GENCB;
 
 #define BN_prime_checks 0
 
-#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL || EMBEDDED_SSL */
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 
 
 #ifdef __cplusplus

--- a/include/wolfssl/openssl/buffer.h
+++ b/include/wolfssl/openssl/buffer.h
@@ -1,0 +1,54 @@
+/* buffer.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#ifndef WOLFSSL_BUFFER_H_
+#define WOLFSSL_BUFFER_H_
+
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/openssl/ssl.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+
+WOLFSSL_API WOLFSSL_BUF_MEM* wolfSSL_BUF_MEM_new(void);
+WOLFSSL_API int wolfSSL_BUF_MEM_grow(WOLFSSL_BUF_MEM* buf, size_t len);
+WOLFSSL_API int wolfSSL_BUF_MEM_grow_ex(WOLFSSL_BUF_MEM* buf, size_t len,
+        char zeroFill);
+WOLFSSL_API int wolfSSL_BUF_MEM_resize(WOLFSSL_BUF_MEM* buf, size_t len);
+WOLFSSL_API void wolfSSL_BUF_MEM_free(WOLFSSL_BUF_MEM* buf);
+
+
+#define BUF_MEM_new  wolfSSL_BUF_MEM_new
+#define BUF_MEM_grow wolfSSL_BUF_MEM_grow
+#define BUF_MEM_free wolfSSL_BUF_MEM_free
+
+#define BUF_strdup strdup
+#define BUF_strlcpy wc_strlcpy
+#define BUF_strlcat wc_strlcat
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_BUFFER_H_ */

--- a/include/wolfssl/openssl/cmac.h
+++ b/include/wolfssl/openssl/cmac.h
@@ -1,0 +1,62 @@
+/* cmac.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef WOLFSSL_CMAC_H_
+#define WOLFSSL_CMAC_H_
+
+#include <wolfssl/wolfcrypt/cmac.h>
+#include <wolfssl/openssl/compat_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct WOLFSSL_CMAC_CTX {
+    void* internal; /* internal Cmac object */
+    WOLFSSL_EVP_CIPHER_CTX* cctx;
+} WOLFSSL_CMAC_CTX;
+
+typedef WOLFSSL_CMAC_CTX CMAC_CTX;
+
+WOLFSSL_API WOLFSSL_CMAC_CTX* wolfSSL_CMAC_CTX_new(void);
+WOLFSSL_API void wolfSSL_CMAC_CTX_free(WOLFSSL_CMAC_CTX *ctx);
+WOLFSSL_API WOLFSSL_EVP_CIPHER_CTX* wolfSSL_CMAC_CTX_get0_cipher_ctx(
+    WOLFSSL_CMAC_CTX* ctx);
+WOLFSSL_API int wolfSSL_CMAC_Init(
+    WOLFSSL_CMAC_CTX* ctx, const void *key, size_t keyLen,
+    const WOLFSSL_EVP_CIPHER* cipher, WOLFSSL_ENGINE* engine);
+WOLFSSL_API int wolfSSL_CMAC_Update(
+    WOLFSSL_CMAC_CTX* ctx, const void* data, size_t len);
+WOLFSSL_API int wolfSSL_CMAC_Final(
+    WOLFSSL_CMAC_CTX* ctx, unsigned char* out, size_t* len);
+
+#define CMAC_CTX_new              wolfSSL_CMAC_CTX_new
+#define CMAC_CTX_free             wolfSSL_CMAC_CTX_free
+#define CMAC_CTX_get0_cipher_ctx  wolfSSL_CMAC_CTX_get0_cipher_ctx
+#define CMAC_Init                 wolfSSL_CMAC_Init
+#define CMAC_Update               wolfSSL_CMAC_Update
+#define CMAC_Final                wolfSSL_CMAC_Final
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_CMAC_H_ */

--- a/include/wolfssl/openssl/conf.h
+++ b/include/wolfssl/openssl/conf.h
@@ -1,0 +1,113 @@
+/* conf.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* conf.h for openSSL */
+
+#ifndef WOLFSSL_conf_H_
+#define WOLFSSL_conf_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/version.h>
+
+typedef struct WOLFSSL_CONF_VALUE {
+    char *section;
+    char *name;
+    char *value;
+} WOLFSSL_CONF_VALUE;
+
+/* ssl.h requires WOLFSSL_CONF_VALUE */
+#include <wolfssl/ssl.h>
+
+typedef struct WOLFSSL_CONF {
+    void *meth_data;
+    WOLF_LHASH_OF(WOLFSSL_CONF_VALUE) *data;
+} WOLFSSL_CONF;
+
+typedef WOLFSSL_CONF CONF;
+typedef WOLFSSL_CONF_VALUE CONF_VALUE;
+
+#ifdef OPENSSL_EXTRA
+
+WOLFSSL_API WOLFSSL_CONF_VALUE *wolfSSL_CONF_VALUE_new(void);
+WOLFSSL_API int wolfSSL_CONF_add_string(WOLFSSL_CONF *conf,
+        WOLFSSL_CONF_VALUE *section, WOLFSSL_CONF_VALUE *value);
+WOLFSSL_API void wolfSSL_X509V3_conf_free(WOLFSSL_CONF_VALUE *val);
+
+WOLFSSL_API WOLFSSL_CONF *wolfSSL_NCONF_new(void *meth);
+WOLFSSL_API char *wolfSSL_NCONF_get_string(const WOLFSSL_CONF *conf,
+        const char *group, const char *name);
+WOLFSSL_API int wolfSSL_NCONF_get_number(const CONF *conf, const char *group,
+        const char *name, long *result);
+WOLFSSL_API WOLFSSL_STACK *wolfSSL_NCONF_get_section(
+        const WOLFSSL_CONF *conf, const char *section);
+WOLFSSL_API int wolfSSL_NCONF_load(WOLFSSL_CONF *conf, const char *file, long *eline);
+WOLFSSL_API void wolfSSL_NCONF_free(WOLFSSL_CONF *conf);
+
+WOLFSSL_API WOLFSSL_CONF_VALUE *wolfSSL_lh_WOLFSSL_CONF_VALUE_retrieve(
+        WOLF_LHASH_OF(WOLFSSL_CONF_VALUE) *sk, WOLFSSL_CONF_VALUE *data);
+
+WOLFSSL_API int wolfSSL_CONF_modules_load(const WOLFSSL_CONF *cnf, const char *appname,
+                      unsigned long flags);
+WOLFSSL_API WOLFSSL_CONF_VALUE *wolfSSL_CONF_new_section(WOLFSSL_CONF *conf,
+        const char *section);
+WOLFSSL_API WOLFSSL_CONF_VALUE *wolfSSL_CONF_get_section(WOLFSSL_CONF *conf,
+        const char *section);
+
+WOLFSSL_API WOLFSSL_X509_EXTENSION* wolfSSL_X509V3_EXT_nconf_nid(WOLFSSL_CONF* conf,
+        WOLFSSL_X509V3_CTX *ctx, int nid, const char *value);
+WOLFSSL_API WOLFSSL_X509_EXTENSION* wolfSSL_X509V3_EXT_nconf(WOLFSSL_CONF *conf,
+        WOLFSSL_X509V3_CTX *ctx, const char *sName, const char *value);
+
+#define sk_CONF_VALUE_new               wolfSSL_sk_CONF_VALUE_new
+#define sk_CONF_VALUE_free              wolfSSL_sk_CONF_VALUE_free
+#define sk_CONF_VALUE_pop_free(a,b)     wolfSSL_sk_CONF_VALUE_free(a)
+#define sk_CONF_VALUE_num               wolfSSL_sk_CONF_VALUE_num
+#define sk_CONF_VALUE_value             wolfSSL_sk_CONF_VALUE_value
+
+#define lh_CONF_VALUE_retrieve          wolfSSL_lh_WOLFSSL_CONF_VALUE_retrieve
+#define lh_CONF_VALUE_insert            wolfSSL_sk_CONF_VALUE_push
+
+#define NCONF_new                       wolfSSL_NCONF_new
+#define NCONF_free                      wolfSSL_NCONF_free
+#define NCONF_get_string                wolfSSL_NCONF_get_string
+#define NCONF_get_section               wolfSSL_NCONF_get_section
+#define NCONF_get_number                wolfSSL_NCONF_get_number
+#define NCONF_load                      wolfSSL_NCONF_load
+
+#define CONF_modules_load               wolfSSL_CONF_modules_load
+#define _CONF_new_section               wolfSSL_CONF_new_section
+#define _CONF_get_section               wolfSSL_CONF_get_section
+
+#define X509V3_EXT_nconf_nid            wolfSSL_X509V3_EXT_nconf_nid
+#define X509V3_EXT_nconf                wolfSSL_X509V3_EXT_nconf
+#define X509V3_conf_free                wolfSSL_X509V3_conf_free
+
+#endif /* OPENSSL_EXTRA */
+
+#ifdef  __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_conf_H_ */

--- a/include/wolfssl/openssl/crypto.h
+++ b/include/wolfssl/openssl/crypto.h
@@ -1,0 +1,160 @@
+/* crypto.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* crypto.h for openSSL */
+
+#ifndef WOLFSSL_CRYPTO_H_
+#define WOLFSSL_CRYPTO_H_
+
+#include <wolfssl/openssl/compat_types.h>
+
+typedef struct WOLFSSL_INIT_SETTINGS {
+    char* appname;
+} WOLFSSL_INIT_SETTINGS;
+typedef WOLFSSL_INIT_SETTINGS OPENSSL_INIT_SETTINGS;
+
+typedef struct WOLFSSL_CRYPTO_THREADID {
+    int dummy;
+} WOLFSSL_CRYPTO_THREADID;
+typedef struct crypto_threadid_st   CRYPTO_THREADID;
+
+typedef struct CRYPTO_EX_DATA            CRYPTO_EX_DATA;
+
+#ifdef HAVE_EX_DATA
+typedef WOLFSSL_CRYPTO_EX_new CRYPTO_new_func;
+typedef WOLFSSL_CRYPTO_EX_dup CRYPTO_dup_func;
+typedef WOLFSSL_CRYPTO_EX_free CRYPTO_free_func;
+#endif
+
+#include <wolfssl/openssl/opensslv.h>
+#include <wolfssl/openssl/conf.h>
+
+#ifdef WOLFSSL_PREFIX
+#include "prefix_crypto.h"
+#endif
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+WOLFSSL_API const char*   wolfSSLeay_version(int type);
+WOLFSSL_API unsigned long wolfSSLeay(void);
+WOLFSSL_API unsigned long wolfSSL_OpenSSL_version_num(void);
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+WOLFSSL_API void wolfSSL_OPENSSL_free(void* p);
+#endif
+
+#ifdef OPENSSL_EXTRA
+WOLFSSL_API void *wolfSSL_OPENSSL_malloc(size_t a);
+WOLFSSL_API int wolfSSL_OPENSSL_hexchar2int(unsigned char c);
+WOLFSSL_API unsigned char *wolfSSL_OPENSSL_hexstr2buf(const char *str, long *len);
+
+WOLFSSL_API int wolfSSL_OPENSSL_init_crypto(word64 opts, const OPENSSL_INIT_SETTINGS *settings);
+#endif
+
+/* class index for wolfSSL_CRYPTO_get_ex_new_index */
+#define CRYPTO_EX_INDEX_SSL             WOLF_CRYPTO_EX_INDEX_SSL
+#define CRYPTO_EX_INDEX_SSL_CTX         WOLF_CRYPTO_EX_INDEX_SSL_CTX
+#define CRYPTO_EX_INDEX_SSL_SESSION     WOLF_CRYPTO_EX_INDEX_SSL_SESSION
+#define CRYPTO_EX_INDEX_X509            WOLF_CRYPTO_EX_INDEX_X509
+#define CRYPTO_EX_INDEX_X509_STORE      WOLF_CRYPTO_EX_INDEX_X509_STORE
+#define CRYPTO_EX_INDEX_X509_STORE_CTX  WOLF_CRYPTO_EX_INDEX_X509_STORE_CTX
+#define CRYPTO_EX_INDEX_DH              WOLF_CRYPTO_EX_INDEX_DH
+#define CRYPTO_EX_INDEX_DSA             WOLF_CRYPTO_EX_INDEX_DSA
+#define CRYPTO_EX_INDEX_EC_KEY          WOLF_CRYPTO_EX_INDEX_EC_KEY
+#define CRYPTO_EX_INDEX_RSA             WOLF_CRYPTO_EX_INDEX_RSA
+#define CRYPTO_EX_INDEX_ENGINE          WOLF_CRYPTO_EX_INDEX_ENGINE
+#define CRYPTO_EX_INDEX_UI              WOLF_CRYPTO_EX_INDEX_UI
+#define CRYPTO_EX_INDEX_BIO             WOLF_CRYPTO_EX_INDEX_BIO
+#define CRYPTO_EX_INDEX_APP             WOLF_CRYPTO_EX_INDEX_APP
+#define CRYPTO_EX_INDEX_UI_METHOD       WOLF_CRYPTO_EX_INDEX_UI_METHOD
+#define CRYPTO_EX_INDEX_DRBG            WOLF_CRYPTO_EX_INDEX_DRBG
+#define CRYPTO_EX_INDEX__COUNT          WOLF_CRYPTO_EX_INDEX__COUNT
+
+#define crypto_threadid_st          WOLFSSL_CRYPTO_THREADID
+#define CRYPTO_THREADID             WOLFSSL_CRYPTO_THREADID
+
+#define SSLeay_version wolfSSLeay_version
+#define SSLeay wolfSSLeay
+#define OpenSSL_version_num wolfSSL_OpenSSL_version_num
+#define SSLEAY_VERSION_NUMBER OPENSSL_VERSION_NUMBER
+#define SSLEAY_VERSION OPENSSL_VERSION
+
+#define CRYPTO_lock wc_LockMutex_ex
+
+/* this function was used to set the default malloc, free, and realloc */
+#define CRYPTO_malloc_init() 0 /* CRYPTO_malloc_init is not needed */
+
+#define OPENSSL_free wolfSSL_OPENSSL_free
+#define OPENSSL_malloc wolfSSL_OPENSSL_malloc
+#define OPENSSL_hexchar2int wolfSSL_OPENSSL_hexchar2int
+#define OPENSSL_hexstr2buf wolfSSL_OPENSSL_hexstr2buf
+
+#define OPENSSL_INIT_ENGINE_ALL_BUILTIN 0x00000001L
+#define OPENSSL_INIT_ADD_ALL_CIPHERS    0x00000004L
+#define OPENSSL_INIT_ADD_ALL_DIGESTS    0x00000008L
+#define OPENSSL_INIT_LOAD_CONFIG        0x00000040L
+
+#define OPENSSL_init_crypto wolfSSL_OPENSSL_init_crypto
+
+#ifdef WOLFSSL_OPENVPN
+# define OPENSSL_assert(e) \
+    if (!(e)) { \
+        fprintf(stderr, "%s:%d wolfSSL internal error: assertion failed: " #e, \
+                __FILE__, __LINE__); \
+        raise(SIGABRT); \
+        _exit(3); \
+    }
+#endif
+
+#if defined(OPENSSL_ALL) || defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
+    defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA) || defined(HAVE_EX_DATA)
+#define CRYPTO_set_mem_ex_functions      wolfSSL_CRYPTO_set_mem_ex_functions
+#define FIPS_mode                        wolfSSL_FIPS_mode
+#define FIPS_mode_set                    wolfSSL_FIPS_mode_set
+#define CRYPTO_THREADID_set_callback wolfSSL_THREADID_set_callback
+#define CRYPTO_THREADID_set_numeric wolfSSL_THREADID_set_numeric
+#define CRYPTO_THREADID_current      wolfSSL_THREADID_current
+#define CRYPTO_THREADID_hash         wolfSSL_THREADID_hash
+
+#define CRYPTO_r_lock wc_LockMutex_ex
+#define CRYPTO_unlock wc_LockMutex_ex
+
+#define CRYPTO_THREAD_lock wc_LockMutex
+#define CRYPTO_THREAD_r_lock wc_LockMutex
+#define CRYPTO_THREAD_unlock wc_UnLockMutex
+
+#define CRYPTO_THREAD_lock_new wc_InitAndAllocMutex
+#define CRYPTO_THREAD_read_lock wc_LockMutex
+#define CRYPTO_THREAD_write_lock wc_LockMutex
+#define CRYPTO_THREAD_lock_free wc_FreeMutex
+
+#define CRYPTO_get_ex_data wolfSSL_CRYPTO_get_ex_data
+#define CRYPTO_set_ex_data wolfSSL_CRYPTO_set_ex_data
+
+#endif /* OPENSSL_ALL || HAVE_STUNNEL || WOLFSSL_NGINX || WOLFSSL_HAPROXY || HAVE_EX_DATA */
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+
+#endif /* header */

--- a/include/wolfssl/openssl/des.h
+++ b/include/wolfssl/openssl/des.h
@@ -105,7 +105,6 @@ typedef WOLFSSL_DES_LONG DES_LONG;
 #define DES_ede3_cbc_encrypt  wolfSSL_DES_ede3_cbc_encrypt
 #define DES_cbc_cksum         wolfSSL_DES_cbc_cksum
 #define DES_check_key_parity  wolfSSL_DES_check_key_parity
-#define DES_KEY_SZ            (sizeof(DES_cblock))
 
 #ifdef __cplusplus
     } /* extern "C" */

--- a/include/wolfssl/openssl/dh.h
+++ b/include/wolfssl/openssl/dh.h
@@ -26,10 +26,7 @@
 #define WOLFSSL_DH_H_
 
 #include <wolfssl/openssl/bn.h>
-
-#ifndef EMBEDDED_SSL
 #include <wolfssl/openssl/opensslv.h>
-#endif
 
 #ifdef __cplusplus
     extern "C" {
@@ -78,7 +75,7 @@ WOLFSSL_API int wolfSSL_DH_set0_pqg(WOLFSSL_DH *dh, WOLFSSL_BIGNUM *p,
 
 WOLFSSL_API WOLFSSL_DH* wolfSSL_DH_get_2048_256(void);
 
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || defined(EMBEDDED_SSL)
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 
 typedef WOLFSSL_DH                   DH;
 
@@ -131,7 +128,7 @@ typedef WOLFSSL_DH                   DH;
 #define DH_GENERATOR_2 2
 #define DH_GENERATOR_5 5
 
-#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL || EMBEDDED_SSL */
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/include/wolfssl/openssl/dsa.h
+++ b/include/wolfssl/openssl/dsa.h
@@ -1,0 +1,157 @@
+/* dsa.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* dsa.h for openSSL */
+
+
+#ifndef WOLFSSL_DSA_H_
+#define WOLFSSL_DSA_H_
+
+#include <wolfssl/openssl/bn.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+typedef struct WOLFSSL_DSA_SIG {
+    WOLFSSL_BIGNUM *r;
+    WOLFSSL_BIGNUM *s;
+} WOLFSSL_DSA_SIG;
+
+#ifndef WOLFSSL_DSA_TYPE_DEFINED /* guard on redeclaration */
+typedef struct WOLFSSL_DSA            WOLFSSL_DSA;
+#define WOLFSSL_DSA_TYPE_DEFINED
+#endif
+
+struct WOLFSSL_DSA {
+    WOLFSSL_BIGNUM* p;
+    WOLFSSL_BIGNUM* q;
+    WOLFSSL_BIGNUM* g;
+    WOLFSSL_BIGNUM* pub_key;      /* our y */
+    WOLFSSL_BIGNUM* priv_key;     /* our x */
+    void*          internal;     /* our Dsa Key */
+    char           inSet;        /* internal set from external ? */
+    char           exSet;        /* external set from internal ? */
+};
+
+
+WOLFSSL_API WOLFSSL_DSA* wolfSSL_DSA_new(void);
+WOLFSSL_API void wolfSSL_DSA_free(WOLFSSL_DSA* dsa);
+#if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
+WOLFSSL_API int wolfSSL_DSA_print_fp(XFILE fp, WOLFSSL_DSA* dsa, int indent);
+#endif /* !NO_FILESYSTEM && NO_STDIO_FILESYSTEM */
+
+WOLFSSL_API int wolfSSL_DSA_generate_key(WOLFSSL_DSA* dsa);
+
+typedef void (*WOLFSSL_BN_CB)(int i, int j, void* exArg);
+WOLFSSL_API WOLFSSL_DSA* wolfSSL_DSA_generate_parameters(int bits,
+                   unsigned char* seed, int seedLen, int* counterRet,
+                   unsigned long* hRet, WOLFSSL_BN_CB cb, void* CBArg);
+WOLFSSL_API int wolfSSL_DSA_generate_parameters_ex(WOLFSSL_DSA* dsa, int bits,
+                   unsigned char* seed, int seedLen, int* counterRet,
+                   unsigned long* hRet, void* cb);
+
+WOLFSSL_API void wolfSSL_DSA_get0_pqg(const WOLFSSL_DSA *d, const WOLFSSL_BIGNUM **p,
+        const WOLFSSL_BIGNUM **q, const WOLFSSL_BIGNUM **g);
+WOLFSSL_API int wolfSSL_DSA_set0_pqg(WOLFSSL_DSA *d, WOLFSSL_BIGNUM *p,
+        WOLFSSL_BIGNUM *q, WOLFSSL_BIGNUM *g);
+
+WOLFSSL_API void wolfSSL_DSA_get0_key(const WOLFSSL_DSA *d,
+        const WOLFSSL_BIGNUM **pub_key, const WOLFSSL_BIGNUM **priv_key);
+WOLFSSL_API int wolfSSL_DSA_set0_key(WOLFSSL_DSA *d, WOLFSSL_BIGNUM *pub_key,
+        WOLFSSL_BIGNUM *priv_key);
+
+
+WOLFSSL_API int wolfSSL_DSA_LoadDer(
+    WOLFSSL_DSA* dsa, const unsigned char* derBuf, int derSz);
+
+WOLFSSL_API int wolfSSL_DSA_LoadDer_ex(
+    WOLFSSL_DSA* dsa, const unsigned char* derBuf, int derSz, int opt);
+
+WOLFSSL_API int wolfSSL_DSA_do_sign(
+    const unsigned char* d, unsigned char* sigRet, WOLFSSL_DSA* dsa);
+
+WOLFSSL_API int wolfSSL_DSA_do_verify(
+    const unsigned char* d, unsigned char* sig, WOLFSSL_DSA* dsa, int *dsacheck);
+
+WOLFSSL_API int wolfSSL_DSA_bits(const WOLFSSL_DSA *d);
+
+WOLFSSL_API WOLFSSL_DSA_SIG* wolfSSL_DSA_SIG_new(void);
+WOLFSSL_API void wolfSSL_DSA_SIG_free(WOLFSSL_DSA_SIG *sig);
+
+WOLFSSL_API void wolfSSL_DSA_SIG_get0(const WOLFSSL_DSA_SIG *sig,
+        const WOLFSSL_BIGNUM **r, const WOLFSSL_BIGNUM **s);
+WOLFSSL_API int wolfSSL_DSA_SIG_set0(WOLFSSL_DSA_SIG *sig, WOLFSSL_BIGNUM *r,
+        WOLFSSL_BIGNUM *s);
+
+WOLFSSL_API int wolfSSL_i2d_DSA_SIG(const WOLFSSL_DSA_SIG *sig, byte **out);
+WOLFSSL_API WOLFSSL_DSA_SIG* wolfSSL_d2i_DSA_SIG(WOLFSSL_DSA_SIG **sig,
+        const unsigned char **pp, long length);
+WOLFSSL_API WOLFSSL_DSA_SIG* wolfSSL_DSA_do_sign_ex(const unsigned char* digest,
+                                                    int inLen, WOLFSSL_DSA* dsa);
+WOLFSSL_API int wolfSSL_DSA_do_verify_ex(const unsigned char* digest, int digest_len,
+                                         WOLFSSL_DSA_SIG* sig, WOLFSSL_DSA* dsa);
+
+WOLFSSL_API int wolfSSL_i2d_DSAparams(
+    const WOLFSSL_DSA* dsa, unsigned char** out);
+WOLFSSL_API WOLFSSL_DSA* wolfSSL_d2i_DSAparams(
+    WOLFSSL_DSA** dsa, const unsigned char** der, long derLen);
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+
+typedef WOLFSSL_DSA                   DSA;
+
+#define WOLFSSL_DSA_LOAD_PRIVATE 1
+#define WOLFSSL_DSA_LOAD_PUBLIC  2
+
+#define DSA_new wolfSSL_DSA_new
+#define DSA_free wolfSSL_DSA_free
+#define DSA_print_fp wolfSSL_DSA_print_fp
+
+#define DSA_LoadDer                wolfSSL_DSA_LoadDer
+#define DSA_generate_key           wolfSSL_DSA_generate_key
+#define DSA_generate_parameters    wolfSSL_DSA_generate_parameters
+#define DSA_generate_parameters_ex wolfSSL_DSA_generate_parameters_ex
+#define DSA_get0_pqg               wolfSSL_DSA_get0_pqg
+#define DSA_set0_pqg               wolfSSL_DSA_set0_pqg
+#define DSA_get0_key               wolfSSL_DSA_get0_key
+#define DSA_set0_key               wolfSSL_DSA_set0_key
+
+#define DSA_SIG_new                wolfSSL_DSA_SIG_new
+#define DSA_SIG_free               wolfSSL_DSA_SIG_free
+#define DSA_SIG_get0               wolfSSL_DSA_SIG_get0
+#define DSA_SIG_set0               wolfSSL_DSA_SIG_set0
+#define i2d_DSA_SIG                wolfSSL_i2d_DSA_SIG
+#define d2i_DSA_SIG                wolfSSL_d2i_DSA_SIG
+#define DSA_do_sign                wolfSSL_DSA_do_sign_ex
+#define DSA_do_verify              wolfSSL_DSA_do_verify_ex
+#define i2d_DSAparams              wolfSSL_i2d_DSAparams
+#define d2i_DSAparams              wolfSSL_d2i_DSAparams
+
+#define DSA_SIG                    WOLFSSL_DSA_SIG
+
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* header */

--- a/include/wolfssl/openssl/ec.h
+++ b/include/wolfssl/openssl/ec.h
@@ -1,0 +1,414 @@
+/* ec.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* ec.h for openssl */
+
+#ifndef WOLFSSL_EC_H_
+#define WOLFSSL_EC_H_
+
+#include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/openssl/bn.h>
+#include <wolfssl/wolfcrypt/asn.h>
+#include <wolfssl/wolfcrypt/ecc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+/* Map OpenSSL NID value */
+enum {
+    POINT_CONVERSION_COMPRESSED = 2,
+    POINT_CONVERSION_UNCOMPRESSED = 4,
+
+#ifdef HAVE_ECC
+    /* Use OpenSSL NIDs. NIDs can be mapped to ecc_curve_id enum values by
+        calling NIDToEccEnum() in ssl.c */
+    NID_X9_62_prime192v1 = 409,
+    NID_X9_62_prime192v2 = 410,
+    NID_X9_62_prime192v3 = 411,
+    NID_X9_62_prime239v1 = 412,
+    NID_X9_62_prime239v2 = 413,
+    NID_X9_62_prime239v3 = 418, /* Previous value conflicted with AES128CBCb */
+    NID_X9_62_prime256v1 = 415,
+    NID_secp112r1 = 704,
+    NID_secp112r2 = 705,
+    NID_secp128r1 = 706,
+    NID_secp128r2 = 707,
+    NID_secp160r1 = 709,
+    NID_secp160r2 = 710,
+    NID_secp224r1 = 713,
+    NID_secp384r1 = 715,
+    NID_secp521r1 = 716,
+    NID_secp160k1 = 708,
+    NID_secp192k1 = 711,
+    NID_secp224k1 = 712,
+    NID_secp256k1 = 714,
+    NID_brainpoolP160r1 = 921,
+    NID_brainpoolP192r1 = 923,
+    NID_brainpoolP224r1 = 925,
+    NID_brainpoolP256r1 = 927,
+    NID_brainpoolP320r1 = 929,
+    NID_brainpoolP384r1 = 931,
+    NID_brainpoolP512r1 = 933,
+#endif
+
+#ifdef HAVE_ED448
+    NID_ED448 = ED448k,
+#endif
+#ifdef HAVE_ED25519
+    NID_ED25519 = ED25519k,
+#endif
+
+    OPENSSL_EC_EXPLICIT_CURVE  = 0x000,
+    OPENSSL_EC_NAMED_CURVE  = 0x001,
+};
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+#ifndef WOLFSSL_EC_TYPE_DEFINED /* guard on redeclaration */
+    typedef struct WOLFSSL_EC_KEY           WOLFSSL_EC_KEY;
+    typedef struct WOLFSSL_EC_POINT         WOLFSSL_EC_POINT;
+    typedef struct WOLFSSL_EC_GROUP         WOLFSSL_EC_GROUP;
+    typedef struct WOLFSSL_EC_BUILTIN_CURVE WOLFSSL_EC_BUILTIN_CURVE;
+    /* WOLFSSL_EC_METHOD is just an alias of WOLFSSL_EC_GROUP for now */
+    typedef struct WOLFSSL_EC_GROUP         WOLFSSL_EC_METHOD;
+
+    #define WOLFSSL_EC_TYPE_DEFINED
+#endif
+
+struct WOLFSSL_EC_POINT {
+    WOLFSSL_BIGNUM *X;
+    WOLFSSL_BIGNUM *Y;
+    WOLFSSL_BIGNUM *Z;
+
+    void*          internal;     /* our ECC point */
+    char           inSet;        /* internal set from external ? */
+    char           exSet;        /* external set from internal ? */
+};
+
+struct WOLFSSL_EC_GROUP {
+    int curve_idx; /* index of curve, used by WolfSSL as reference */
+    int curve_nid; /* NID of curve, used by OpenSSL/OpenSSH as reference */
+    int curve_oid; /* OID of curve, used by OpenSSL/OpenSSH as reference */
+};
+
+struct WOLFSSL_EC_KEY {
+    WOLFSSL_EC_GROUP *group;
+    WOLFSSL_EC_POINT *pub_key;
+    WOLFSSL_BIGNUM *priv_key;
+
+    void*          internal;     /* our ECC Key */
+    void*          heap;
+    unsigned char  form;         /* Either POINT_CONVERSION_UNCOMPRESSED or
+                                  * POINT_CONVERSION_COMPRESSED */
+    word16 pkcs8HeaderSz;
+
+    /* option bits */
+    byte inSet:1;                /* internal set from external ? */
+    byte exSet:1;                /* external set from internal ? */
+
+    wolfSSL_Ref ref;             /* Reference count information. */
+};
+
+struct WOLFSSL_EC_BUILTIN_CURVE {
+    int nid;
+    const char *comment;
+};
+
+#define WOLFSSL_EC_KEY_LOAD_PRIVATE 1
+#define WOLFSSL_EC_KEY_LOAD_PUBLIC  2
+
+typedef int point_conversion_form_t;
+
+WOLFSSL_API
+size_t wolfSSL_EC_get_builtin_curves(WOLFSSL_EC_BUILTIN_CURVE *r,size_t nitems);
+
+WOLFSSL_API
+WOLFSSL_EC_KEY *wolfSSL_EC_KEY_dup(const WOLFSSL_EC_KEY *src);
+WOLFSSL_API
+int wolfSSL_EC_KEY_up_ref(WOLFSSL_EC_KEY* key);
+
+WOLFSSL_API
+int wolfSSL_ECPoint_i2d(const WOLFSSL_EC_GROUP *curve,
+                        const WOLFSSL_EC_POINT *p,
+                        unsigned char *out, unsigned int *len);
+WOLFSSL_API
+int wolfSSL_ECPoint_d2i(const unsigned char *in, unsigned int len,
+                        const WOLFSSL_EC_GROUP *curve, WOLFSSL_EC_POINT *p);
+WOLFSSL_API
+size_t wolfSSL_EC_POINT_point2oct(const WOLFSSL_EC_GROUP *group,
+                                  const WOLFSSL_EC_POINT *p,
+                                  int form,
+                                  byte *buf, size_t len, WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API
+int wolfSSL_EC_POINT_oct2point(const WOLFSSL_EC_GROUP *group,
+                               WOLFSSL_EC_POINT *p, const unsigned char *buf,
+                               size_t len, WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API
+WOLFSSL_EC_KEY *wolfSSL_o2i_ECPublicKey(WOLFSSL_EC_KEY **a, const unsigned char **in,
+                                        long len);
+WOLFSSL_API
+int wolfSSL_i2o_ECPublicKey(const WOLFSSL_EC_KEY *in, unsigned char **out);
+WOLFSSL_API
+WOLFSSL_EC_KEY *wolfSSL_d2i_ECPrivateKey(WOLFSSL_EC_KEY **key, const unsigned char **in,
+                                         long len);
+WOLFSSL_API
+int wolfSSL_i2d_ECPrivateKey(const WOLFSSL_EC_KEY *in, unsigned char **out);
+WOLFSSL_API
+void wolfSSL_EC_KEY_set_conv_form(WOLFSSL_EC_KEY *eckey, int form);
+WOLFSSL_API
+point_conversion_form_t wolfSSL_EC_KEY_get_conv_form(const WOLFSSL_EC_KEY* key);
+WOLFSSL_API
+WOLFSSL_BIGNUM *wolfSSL_EC_POINT_point2bn(const WOLFSSL_EC_GROUP *group,
+                                          const WOLFSSL_EC_POINT *p,
+                                          int form,
+                                          WOLFSSL_BIGNUM *in, WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API
+int wolfSSL_EC_POINT_is_on_curve(const WOLFSSL_EC_GROUP *group,
+                                 const WOLFSSL_EC_POINT *point,
+                                 WOLFSSL_BN_CTX *ctx);
+
+WOLFSSL_API
+int wolfSSL_EC_KEY_LoadDer(WOLFSSL_EC_KEY* key,
+                           const unsigned char* der, int derSz);
+WOLFSSL_API
+int wolfSSL_EC_KEY_LoadDer_ex(WOLFSSL_EC_KEY* key,
+                              const unsigned char* der, int derSz, int opt);
+WOLFSSL_API
+void wolfSSL_EC_KEY_free(WOLFSSL_EC_KEY *key);
+WOLFSSL_API
+WOLFSSL_EC_POINT *wolfSSL_EC_KEY_get0_public_key(const WOLFSSL_EC_KEY *key);
+WOLFSSL_API
+const WOLFSSL_EC_GROUP *wolfSSL_EC_KEY_get0_group(const WOLFSSL_EC_KEY *key);
+WOLFSSL_API
+int wolfSSL_EC_KEY_set_private_key(WOLFSSL_EC_KEY *key,
+                                   const WOLFSSL_BIGNUM *priv_key);
+WOLFSSL_API
+WOLFSSL_BIGNUM *wolfSSL_EC_KEY_get0_private_key(const WOLFSSL_EC_KEY *key);
+WOLFSSL_API
+WOLFSSL_EC_KEY *wolfSSL_EC_KEY_new_by_curve_name(int nid);
+WOLFSSL_API const char* wolfSSL_EC_curve_nid2nist(int nid);
+WOLFSSL_API int wolfSSL_EC_curve_nist2nid(const char* name);
+WOLFSSL_API
+WOLFSSL_EC_KEY *wolfSSL_EC_KEY_new_ex(void* heap, int devId);
+WOLFSSL_API
+WOLFSSL_EC_KEY *wolfSSL_EC_KEY_new(void);
+WOLFSSL_API
+int wolfSSL_EC_KEY_set_group(WOLFSSL_EC_KEY *key, WOLFSSL_EC_GROUP *group);
+WOLFSSL_API
+int wolfSSL_EC_KEY_generate_key(WOLFSSL_EC_KEY *key);
+WOLFSSL_API
+void wolfSSL_EC_KEY_set_asn1_flag(WOLFSSL_EC_KEY *key, int asn1_flag);
+WOLFSSL_API
+int wolfSSL_EC_KEY_set_public_key(WOLFSSL_EC_KEY *key,
+                                  const WOLFSSL_EC_POINT *pub);
+WOLFSSL_API int wolfSSL_EC_KEY_check_key(const WOLFSSL_EC_KEY *key);
+#if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
+WOLFSSL_API int wolfSSL_EC_KEY_print_fp(XFILE fp, WOLFSSL_EC_KEY* key,
+                                         int indent);
+#endif /* !NO_FILESYSTEM && !NO_STDIO_FILESYSTEM */
+WOLFSSL_API int wolfSSL_ECDSA_size(const WOLFSSL_EC_KEY *key);
+WOLFSSL_API int wolfSSL_ECDSA_sign(int type, const unsigned char *digest,
+                                   int digestSz, unsigned char *sig,
+                                   unsigned int *sigSz, WOLFSSL_EC_KEY *key);
+WOLFSSL_API int wolfSSL_ECDSA_verify(int type, const unsigned char *digest,
+                                   int digestSz, const unsigned char *sig,
+                                   int sigSz, WOLFSSL_EC_KEY *key);
+
+
+#if defined HAVE_ECC && (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
+WOLFSSL_API int EccEnumToNID(int n);
+#endif
+
+WOLFSSL_API
+void wolfSSL_EC_GROUP_set_asn1_flag(WOLFSSL_EC_GROUP *group, int flag);
+WOLFSSL_API
+WOLFSSL_EC_GROUP *wolfSSL_EC_GROUP_new_by_curve_name(int nid);
+WOLFSSL_API
+int wolfSSL_EC_GROUP_cmp(const WOLFSSL_EC_GROUP *a, const WOLFSSL_EC_GROUP *b,
+                         WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API
+WOLFSSL_EC_GROUP *wolfSSL_EC_GROUP_dup(const WOLFSSL_EC_GROUP *src);
+WOLFSSL_API
+int wolfSSL_EC_GROUP_get_curve_name(const WOLFSSL_EC_GROUP *group);
+WOLFSSL_API
+int wolfSSL_EC_GROUP_get_degree(const WOLFSSL_EC_GROUP *group);
+WOLFSSL_API
+int wolfSSL_EC_GROUP_get_order(const WOLFSSL_EC_GROUP *group,
+                               WOLFSSL_BIGNUM *order, WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API
+int wolfSSL_EC_GROUP_order_bits(const WOLFSSL_EC_GROUP *group);
+WOLFSSL_API
+void wolfSSL_EC_GROUP_free(WOLFSSL_EC_GROUP *group);
+WOLFSSL_API
+const WOLFSSL_EC_METHOD* wolfSSL_EC_GROUP_method_of(
+                                                const WOLFSSL_EC_GROUP *group);
+WOLFSSL_API
+int wolfSSL_EC_METHOD_get_field_type(const WOLFSSL_EC_METHOD *meth);
+WOLFSSL_API
+WOLFSSL_EC_POINT *wolfSSL_EC_POINT_new(const WOLFSSL_EC_GROUP *group);
+WOLFSSL_LOCAL
+int ec_point_convert_to_affine(const WOLFSSL_EC_GROUP *group,
+    WOLFSSL_EC_POINT *point);
+WOLFSSL_API
+int wolfSSL_EC_POINT_get_affine_coordinates_GFp(const WOLFSSL_EC_GROUP *group,
+                                                const WOLFSSL_EC_POINT *p,
+                                                WOLFSSL_BIGNUM *x,
+                                                WOLFSSL_BIGNUM *y,
+                                                WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API
+int wolfSSL_EC_POINT_set_affine_coordinates_GFp(const WOLFSSL_EC_GROUP *group,
+                                                WOLFSSL_EC_POINT *point,
+                                                const WOLFSSL_BIGNUM *x,
+                                                const WOLFSSL_BIGNUM *y,
+                                                WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API
+int wolfSSL_EC_POINT_add(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *r,
+                         const WOLFSSL_EC_POINT *p1,
+                         const WOLFSSL_EC_POINT *p2, WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API
+int wolfSSL_EC_POINT_mul(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *r,
+                         const WOLFSSL_BIGNUM *n,
+                         const WOLFSSL_EC_POINT *q, const WOLFSSL_BIGNUM *m,
+                         WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API
+int wolfSSL_EC_POINT_invert(const WOLFSSL_EC_GROUP *group, WOLFSSL_EC_POINT *a,
+                            WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API
+void wolfSSL_EC_POINT_clear_free(WOLFSSL_EC_POINT *point);
+WOLFSSL_API
+int wolfSSL_EC_POINT_cmp(const WOLFSSL_EC_GROUP *group,
+                         const WOLFSSL_EC_POINT *a, const WOLFSSL_EC_POINT *b,
+                         WOLFSSL_BN_CTX *ctx);
+WOLFSSL_API int wolfSSL_EC_POINT_copy(WOLFSSL_EC_POINT *dest,
+                                      const WOLFSSL_EC_POINT *src);
+WOLFSSL_API
+void wolfSSL_EC_POINT_free(WOLFSSL_EC_POINT *point);
+WOLFSSL_API
+int wolfSSL_EC_POINT_is_at_infinity(const WOLFSSL_EC_GROUP *group,
+                                    const WOLFSSL_EC_POINT *a);
+
+#ifndef HAVE_SELFTEST
+WOLFSSL_API
+char* wolfSSL_EC_POINT_point2hex(const WOLFSSL_EC_GROUP* group,
+                                 const WOLFSSL_EC_POINT* point, int form,
+                                 WOLFSSL_BN_CTX* ctx);
+#endif
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+
+typedef WOLFSSL_EC_KEY                EC_KEY;
+typedef WOLFSSL_EC_GROUP              EC_GROUP;
+typedef WOLFSSL_EC_GROUP              EC_METHOD;
+typedef WOLFSSL_EC_POINT              EC_POINT;
+typedef WOLFSSL_EC_BUILTIN_CURVE      EC_builtin_curve;
+
+#ifndef HAVE_ECC
+#define OPENSSL_NO_EC
+#endif
+
+#define EC_KEY_new                      wolfSSL_EC_KEY_new
+#define EC_KEY_free                     wolfSSL_EC_KEY_free
+#define EC_KEY_up_ref                   wolfSSL_EC_KEY_up_ref
+#define EC_KEY_dup                      wolfSSL_EC_KEY_dup
+#define EC_KEY_get0_public_key          wolfSSL_EC_KEY_get0_public_key
+#define EC_KEY_get0_group               wolfSSL_EC_KEY_get0_group
+#define EC_KEY_set_private_key          wolfSSL_EC_KEY_set_private_key
+#define EC_KEY_get0_private_key         wolfSSL_EC_KEY_get0_private_key
+#define EC_KEY_new_by_curve_name        wolfSSL_EC_KEY_new_by_curve_name
+#define EC_KEY_set_group                wolfSSL_EC_KEY_set_group
+#define EC_KEY_generate_key             wolfSSL_EC_KEY_generate_key
+#define EC_KEY_set_asn1_flag            wolfSSL_EC_KEY_set_asn1_flag
+#define EC_KEY_set_public_key           wolfSSL_EC_KEY_set_public_key
+#define EC_KEY_check_key                wolfSSL_EC_KEY_check_key
+#define EC_KEY_print_fp                 wolfSSL_EC_KEY_print_fp
+
+#define ECDSA_size                      wolfSSL_ECDSA_size
+#define ECDSA_sign                      wolfSSL_ECDSA_sign
+#define ECDSA_verify                    wolfSSL_ECDSA_verify
+
+#define EC_GROUP_free                   wolfSSL_EC_GROUP_free
+#define EC_GROUP_set_asn1_flag          wolfSSL_EC_GROUP_set_asn1_flag
+#define EC_GROUP_new_by_curve_name      wolfSSL_EC_GROUP_new_by_curve_name
+#define EC_GROUP_cmp                    wolfSSL_EC_GROUP_cmp
+#define EC_GROUP_dup                    wolfSSL_EC_GROUP_dup
+#define EC_GROUP_get_curve_name         wolfSSL_EC_GROUP_get_curve_name
+#define EC_GROUP_get_degree             wolfSSL_EC_GROUP_get_degree
+#define EC_GROUP_get_order              wolfSSL_EC_GROUP_get_order
+#define EC_GROUP_order_bits             wolfSSL_EC_GROUP_order_bits
+#define EC_GROUP_method_of              wolfSSL_EC_GROUP_method_of
+#ifndef NO_WOLFSSL_STUB
+#define EC_GROUP_set_point_conversion_form(...) WC_DO_NOTHING
+#endif
+
+#define EC_METHOD_get_field_type        wolfSSL_EC_METHOD_get_field_type
+
+#define EC_POINT_new                    wolfSSL_EC_POINT_new
+#define EC_POINT_free                   wolfSSL_EC_POINT_free
+#define EC_POINT_get_affine_coordinates_GFp \
+                                     wolfSSL_EC_POINT_get_affine_coordinates_GFp
+#define EC_POINT_get_affine_coordinates \
+                                     wolfSSL_EC_POINT_get_affine_coordinates_GFp
+#define EC_POINT_set_affine_coordinates_GFp \
+                                     wolfSSL_EC_POINT_set_affine_coordinates_GFp
+#define EC_POINT_set_affine_coordinates \
+                                     wolfSSL_EC_POINT_set_affine_coordinates_GFp
+#define EC_POINT_add                    wolfSSL_EC_POINT_add
+#define EC_POINT_mul                    wolfSSL_EC_POINT_mul
+#define EC_POINT_invert                 wolfSSL_EC_POINT_invert
+#define EC_POINT_clear_free             wolfSSL_EC_POINT_clear_free
+#define EC_POINT_cmp                    wolfSSL_EC_POINT_cmp
+#define EC_POINT_copy                   wolfSSL_EC_POINT_copy
+#define EC_POINT_is_at_infinity         wolfSSL_EC_POINT_is_at_infinity
+
+#define EC_get_builtin_curves           wolfSSL_EC_get_builtin_curves
+
+#define ECPoint_i2d                     wolfSSL_ECPoint_i2d
+#define ECPoint_d2i                     wolfSSL_ECPoint_d2i
+#define EC_POINT_point2oct              wolfSSL_EC_POINT_point2oct
+#define EC_POINT_oct2point              wolfSSL_EC_POINT_oct2point
+#define EC_POINT_point2bn               wolfSSL_EC_POINT_point2bn
+#define EC_POINT_is_on_curve            wolfSSL_EC_POINT_is_on_curve
+#define o2i_ECPublicKey                 wolfSSL_o2i_ECPublicKey
+#define i2o_ECPublicKey                 wolfSSL_i2o_ECPublicKey
+#define i2d_EC_PUBKEY                   wolfSSL_i2o_ECPublicKey
+#define d2i_ECPrivateKey                wolfSSL_d2i_ECPrivateKey
+#define i2d_ECPrivateKey                wolfSSL_i2d_ECPrivateKey
+#define EC_KEY_set_conv_form            wolfSSL_EC_KEY_set_conv_form
+#define EC_KEY_get_conv_form            wolfSSL_EC_KEY_get_conv_form
+
+#ifndef HAVE_SELFTEST
+    #define EC_POINT_point2hex          wolfSSL_EC_POINT_point2hex
+#endif
+
+#define EC_POINT_dump                   wolfSSL_EC_POINT_dump
+#define EC_get_builtin_curves           wolfSSL_EC_get_builtin_curves
+
+#define EC_curve_nid2nist               wolfSSL_EC_curve_nid2nist
+#define EC_curve_nist2nid               wolfSSL_EC_curve_nist2nid
+
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* header */

--- a/include/wolfssl/openssl/ec.h
+++ b/include/wolfssl/openssl/ec.h
@@ -74,8 +74,14 @@ enum {
 #ifdef HAVE_ED448
     NID_ED448 = ED448k,
 #endif
+#ifdef HAVE_CURVE448
+    NID_X448 = X448k,
+#endif
 #ifdef HAVE_ED25519
     NID_ED25519 = ED25519k,
+#endif
+#ifdef HAVE_CURVE25519
+    NID_X25519 = X25519k,
 #endif
 
     OPENSSL_EC_EXPLICIT_CURVE  = 0x000,
@@ -137,6 +143,12 @@ struct WOLFSSL_EC_BUILTIN_CURVE {
 #define WOLFSSL_EC_KEY_LOAD_PUBLIC  2
 
 typedef int point_conversion_form_t;
+
+typedef struct WOLFSSL_EC_KEY_METHOD {
+    /* Not implemented */
+    /* Just here so that some C compilers don't complain. To be removed. */
+    void* dummy_member;
+} WOLFSSL_EC_KEY_METHOD;
 
 WOLFSSL_API
 size_t wolfSSL_EC_get_builtin_curves(WOLFSSL_EC_BUILTIN_CURVE *r,size_t nitems);
@@ -306,12 +318,29 @@ WOLFSSL_API
 int wolfSSL_EC_POINT_is_at_infinity(const WOLFSSL_EC_GROUP *group,
                                     const WOLFSSL_EC_POINT *a);
 
-#ifndef HAVE_SELFTEST
 WOLFSSL_API
 char* wolfSSL_EC_POINT_point2hex(const WOLFSSL_EC_GROUP* group,
                                  const WOLFSSL_EC_POINT* point, int form,
                                  WOLFSSL_BN_CTX* ctx);
-#endif
+WOLFSSL_API
+WOLFSSL_EC_POINT *wolfSSL_EC_POINT_hex2point
+                                (const WOLFSSL_EC_GROUP *group, const char *hex,
+                                    WOLFSSL_EC_POINT *p, WOLFSSL_BN_CTX *ctx);
+
+WOLFSSL_API const WOLFSSL_EC_KEY_METHOD *wolfSSL_EC_KEY_OpenSSL(void);
+WOLFSSL_API WOLFSSL_EC_KEY_METHOD *wolfSSL_EC_KEY_METHOD_new(
+        const WOLFSSL_EC_KEY_METHOD *meth);
+WOLFSSL_API void wolfSSL_EC_KEY_METHOD_free(WOLFSSL_EC_KEY_METHOD *meth);
+/* TODO when implementing change the types to the real callback signatures
+ * and use real parameter names */
+WOLFSSL_API void wolfSSL_EC_KEY_METHOD_set_init(WOLFSSL_EC_KEY_METHOD *meth,
+        void* a1, void* a2, void* a3, void* a4, void* a5, void* a6);
+WOLFSSL_API void wolfSSL_EC_KEY_METHOD_set_sign(WOLFSSL_EC_KEY_METHOD *meth,
+        void* a1, void* a2, void* a3);
+WOLFSSL_API const WOLFSSL_EC_KEY_METHOD *wolfSSL_EC_KEY_get_method(
+        const WOLFSSL_EC_KEY *key);
+WOLFSSL_API int wolfSSL_EC_KEY_set_method(WOLFSSL_EC_KEY *key,
+        const WOLFSSL_EC_KEY_METHOD *meth);
 
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 
@@ -320,6 +349,7 @@ typedef WOLFSSL_EC_GROUP              EC_GROUP;
 typedef WOLFSSL_EC_GROUP              EC_METHOD;
 typedef WOLFSSL_EC_POINT              EC_POINT;
 typedef WOLFSSL_EC_BUILTIN_CURVE      EC_builtin_curve;
+typedef WOLFSSL_EC_KEY_METHOD         EC_KEY_METHOD;
 
 #ifndef HAVE_ECC
 #define OPENSSL_NO_EC
@@ -395,15 +425,22 @@ typedef WOLFSSL_EC_BUILTIN_CURVE      EC_builtin_curve;
 #define EC_KEY_set_conv_form            wolfSSL_EC_KEY_set_conv_form
 #define EC_KEY_get_conv_form            wolfSSL_EC_KEY_get_conv_form
 
-#ifndef HAVE_SELFTEST
-    #define EC_POINT_point2hex          wolfSSL_EC_POINT_point2hex
-#endif
+#define EC_POINT_point2hex              wolfSSL_EC_POINT_point2hex
+#define EC_POINT_hex2point              wolfSSL_EC_POINT_hex2point
 
 #define EC_POINT_dump                   wolfSSL_EC_POINT_dump
 #define EC_get_builtin_curves           wolfSSL_EC_get_builtin_curves
 
 #define EC_curve_nid2nist               wolfSSL_EC_curve_nid2nist
 #define EC_curve_nist2nid               wolfSSL_EC_curve_nist2nid
+
+#define EC_KEY_OpenSSL                  wolfSSL_EC_KEY_OpenSSL
+#define EC_KEY_METHOD_new               wolfSSL_EC_KEY_METHOD_new
+#define EC_KEY_METHOD_free              wolfSSL_EC_KEY_METHOD_free
+#define EC_KEY_METHOD_set_init          wolfSSL_EC_KEY_METHOD_set_init
+#define EC_KEY_METHOD_set_sign          wolfSSL_EC_KEY_METHOD_set_sign
+#define EC_KEY_get_method               wolfSSL_EC_KEY_get_method
+#define EC_KEY_set_method               wolfSSL_EC_KEY_set_method
 
 #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 

--- a/include/wolfssl/openssl/ec25519.h
+++ b/include/wolfssl/openssl/ec25519.h
@@ -1,0 +1,46 @@
+/* ec25519.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* ec25519.h */
+
+#ifndef WOLFSSL_EC25519_H_
+#define WOLFSSL_EC25519_H_
+
+#include <wolfssl/openssl/compat_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WOLFSSL_API
+int wolfSSL_EC25519_generate_key(unsigned char *priv, unsigned int *privSz,
+                                 unsigned char *pub, unsigned int *pubSz);
+
+WOLFSSL_API
+int wolfSSL_EC25519_shared_key(unsigned char *shared, unsigned int *sharedSz,
+                               const unsigned char *priv, unsigned int privSz,
+                               const unsigned char *pub, unsigned int pubSz);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* header */

--- a/include/wolfssl/openssl/ec448.h
+++ b/include/wolfssl/openssl/ec448.h
@@ -1,0 +1,46 @@
+/* ec448.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* ec448.h */
+
+#ifndef WOLFSSL_EC448_H_
+#define WOLFSSL_EC448_H_
+
+#include <wolfssl/openssl/compat_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WOLFSSL_API
+int wolfSSL_EC448_generate_key(unsigned char *priv, unsigned int *privSz,
+                               unsigned char *pub, unsigned int *pubSz);
+
+WOLFSSL_API
+int wolfSSL_EC448_shared_key(unsigned char *shared, unsigned int *sharedSz,
+                             const unsigned char *priv, unsigned int privSz,
+                             const unsigned char *pub, unsigned int pubSz);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* header */

--- a/include/wolfssl/openssl/ecdh.h
+++ b/include/wolfssl/openssl/ecdh.h
@@ -1,0 +1,49 @@
+/* ecdh.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* ecdh.h for openssl */
+
+#ifndef WOLFSSL_ECDH_H_
+#define WOLFSSL_ECDH_H_
+
+#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/openssl/bn.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+WOLFSSL_API int wolfSSL_ECDH_compute_key(void *out, size_t outlen,
+                                         const WOLFSSL_EC_POINT *pub_key,
+                                         WOLFSSL_EC_KEY *ecdh,
+                                         void *(*KDF) (const void *in,
+                                                       size_t inlen,
+                                                       void *out,
+                                                       size_t *outlen));
+
+#define ECDH_compute_key wolfSSL_ECDH_compute_key
+
+#ifdef __cplusplus
+}  /* extern C */
+#endif
+
+#endif /* header */

--- a/include/wolfssl/openssl/ecdsa.h
+++ b/include/wolfssl/openssl/ecdsa.h
@@ -1,0 +1,81 @@
+/* ecdsa.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* ecdsa.h for openssl */
+
+#ifndef WOLFSSL_ECDSA_H_
+#define WOLFSSL_ECDSA_H_
+
+#include <wolfssl/openssl/bn.h>
+#include <wolfssl/openssl/ec.h>
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef WOLFSSL_ECDSA_TYPE_DEFINED /* guard on redeclaration */
+typedef struct WOLFSSL_ECDSA_SIG      WOLFSSL_ECDSA_SIG;
+#define WOLFSSL_ECDSA_TYPE_DEFINED
+#endif
+
+typedef WOLFSSL_ECDSA_SIG             ECDSA_SIG;
+
+struct WOLFSSL_ECDSA_SIG {
+    WOLFSSL_BIGNUM *r;
+    WOLFSSL_BIGNUM *s;
+};
+
+WOLFSSL_API void wolfSSL_ECDSA_SIG_free(WOLFSSL_ECDSA_SIG *sig);
+WOLFSSL_API WOLFSSL_ECDSA_SIG *wolfSSL_ECDSA_SIG_new(void);
+WOLFSSL_API void wolfSSL_ECDSA_SIG_get0(const WOLFSSL_ECDSA_SIG* sig,
+    const WOLFSSL_BIGNUM** r, const WOLFSSL_BIGNUM** s);
+WOLFSSL_API int wolfSSL_ECDSA_SIG_set0(WOLFSSL_ECDSA_SIG* sig, WOLFSSL_BIGNUM* r,
+    WOLFSSL_BIGNUM* s);
+WOLFSSL_API WOLFSSL_ECDSA_SIG *wolfSSL_ECDSA_do_sign(const unsigned char *dgst,
+                                                     int dgst_len,
+                                                     WOLFSSL_EC_KEY *eckey);
+WOLFSSL_API int wolfSSL_ECDSA_do_verify(const unsigned char *dgst,
+                                        int dgst_len,
+                                        const WOLFSSL_ECDSA_SIG *sig,
+                                        WOLFSSL_EC_KEY *eckey);
+
+WOLFSSL_API WOLFSSL_ECDSA_SIG *wolfSSL_d2i_ECDSA_SIG(WOLFSSL_ECDSA_SIG **sig,
+                                                     const unsigned char **pp,
+                                                     long len);
+WOLFSSL_API int wolfSSL_i2d_ECDSA_SIG(const WOLFSSL_ECDSA_SIG *sig,
+                                      unsigned char **pp);
+
+#define ECDSA_SIG_free         wolfSSL_ECDSA_SIG_free
+#define ECDSA_SIG_new          wolfSSL_ECDSA_SIG_new
+#define ECDSA_SIG_get0         wolfSSL_ECDSA_SIG_get0
+#define ECDSA_SIG_set0         wolfSSL_ECDSA_SIG_set0
+#define ECDSA_do_sign          wolfSSL_ECDSA_do_sign
+#define ECDSA_do_verify        wolfSSL_ECDSA_do_verify
+#define d2i_ECDSA_SIG          wolfSSL_d2i_ECDSA_SIG
+#define i2d_ECDSA_SIG          wolfSSL_i2d_ECDSA_SIG
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* header */
+

--- a/include/wolfssl/openssl/ed25519.h
+++ b/include/wolfssl/openssl/ed25519.h
@@ -1,0 +1,49 @@
+/* ed25519.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* ed25519.h */
+
+#ifndef WOLFSSL_ED25519_H_
+#define WOLFSSL_ED25519_H_
+
+#include <wolfssl/openssl/compat_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WOLFSSL_API
+int wolfSSL_ED25519_generate_key(unsigned char *priv, unsigned int *privSz,
+                                 unsigned char *pub, unsigned int *pubSz);
+WOLFSSL_API
+int wolfSSL_ED25519_sign(const unsigned char *msg, unsigned int msgSz,
+                         const unsigned char *priv, unsigned int privSz,
+                         unsigned char *sig, unsigned int *sigSz);
+WOLFSSL_API
+int wolfSSL_ED25519_verify(const unsigned char *msg, unsigned int msgSz,
+                           const unsigned char *pub, unsigned int pubSz,
+                           const unsigned char *sig, unsigned int sigSz);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* header */

--- a/include/wolfssl/openssl/ed448.h
+++ b/include/wolfssl/openssl/ed448.h
@@ -1,0 +1,49 @@
+/* ed448.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* ed448.h */
+
+#ifndef WOLFSSL_ED448_H_
+#define WOLFSSL_ED448_H_
+
+#include <wolfssl/openssl/compat_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+WOLFSSL_API
+int wolfSSL_ED448_generate_key(unsigned char *priv, unsigned int *privSz,
+                               unsigned char *pub, unsigned int *pubSz);
+WOLFSSL_API
+int wolfSSL_ED448_sign(const unsigned char *msg, unsigned int msgSz,
+                       const unsigned char *priv, unsigned int privSz,
+                       unsigned char *sig, unsigned int *sigSz);
+WOLFSSL_API
+int wolfSSL_ED448_verify(const unsigned char *msg, unsigned int msgSz,
+                         const unsigned char *pub, unsigned int pubSz,
+                         const unsigned char *sig, unsigned int sigSz);
+
+#ifdef __cplusplus
+}  /* extern "C" */
+#endif
+
+#endif /* header */

--- a/include/wolfssl/openssl/err.h
+++ b/include/wolfssl/openssl/err.h
@@ -24,7 +24,7 @@
 
 #include <wolfssl/wolfcrypt/logging.h>
 
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || defined(EMBEDDED_SSL)
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 /* err.h for openssl */
 #define ERR_load_ERR_strings             wolfSSL_ERR_load_ERR_strings
 #define ERR_load_crypto_strings          wolfSSL_ERR_load_crypto_strings
@@ -57,7 +57,7 @@
 #define SSLerr(f,r)  ERR_put_error(0,(f),(r),__FILE__,__LINE__)
 #define ECerr(f,r)   ERR_put_error(0,(f),(r),__FILE__,__LINE__)
 
-#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL || EMBEDDED_SSL */
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 
 #endif /* WOLFSSL_OPENSSL_ERR_ */
 

--- a/include/wolfssl/openssl/evp.h
+++ b/include/wolfssl/openssl/evp.h
@@ -1,0 +1,1285 @@
+/* evp.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+
+/*!
+    \file wolfssl/openssl/evp.h
+    \brief evp.h defines mini evp openssl compatibility layer
+ */
+
+
+#ifndef WOLFSSL_EVP_H_
+#define WOLFSSL_EVP_H_
+
+#include <wolfssl/wolfcrypt/types.h>
+
+#ifdef WOLFSSL_PREFIX
+#include "prefix_evp.h"
+#endif
+
+#ifndef NO_MD4
+    #include <wolfssl/openssl/md4.h>
+#endif
+#ifndef NO_MD5
+    #include <wolfssl/openssl/md5.h>
+#endif
+#include <wolfssl/openssl/sha.h>
+#include <wolfssl/openssl/sha3.h>
+#include <wolfssl/openssl/ripemd.h>
+#include <wolfssl/openssl/rsa.h>
+#include <wolfssl/openssl/dsa.h>
+#include <wolfssl/openssl/ec.h>
+#include <wolfssl/openssl/dh.h>
+#include <wolfssl/openssl/opensslv.h>
+#include <wolfssl/openssl/compat_types.h>
+
+#include <wolfssl/wolfcrypt/aes.h>
+#include <wolfssl/wolfcrypt/des3.h>
+#include <wolfssl/wolfcrypt/arc4.h>
+#include <wolfssl/wolfcrypt/chacha20_poly1305.h>
+#include <wolfssl/wolfcrypt/hmac.h>
+#include <wolfssl/wolfcrypt/pwdbased.h>
+#ifdef WOLFSSL_SM3
+    #include <wolfssl/wolfcrypt/sm3.h>
+#endif
+#ifdef WOLFSSL_SM4
+    #include <wolfssl/wolfcrypt/sm4.h>
+#endif
+
+#if defined(WOLFSSL_BASE64_ENCODE) || defined(WOLFSSL_BASE64_DECODE)
+#include <wolfssl/wolfcrypt/coding.h>
+#endif
+
+#ifdef HAVE_ARIA
+    #include <wolfssl/wolfcrypt/port/aria/aria-crypt.h>
+#endif
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+
+#ifndef NO_MD4
+    WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_md4(void);
+#endif
+#ifndef NO_MD5
+    WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_md5(void);
+#endif
+WOLFSSL_API void wolfSSL_EVP_set_pw_prompt(const char *prompt);
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_mdc2(void);
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_sha1(void);
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_sha224(void);
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_sha256(void);
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_sha384(void);
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_sha512(void);
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_shake128(void);
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_shake256(void);
+WOLFSSL_API const WOLFSSL_EVP_MD *wolfSSL_EVP_sha512_224(void);
+WOLFSSL_API const WOLFSSL_EVP_MD *wolfSSL_EVP_sha512_256(void);
+WOLFSSL_API const WOLFSSL_EVP_MD *wolfSSL_EVP_ripemd160(void);
+
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_sha3_224(void);
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_sha3_256(void);
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_sha3_384(void);
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_sha3_512(void);
+
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_sm3(void);
+
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_ecb(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_ecb(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_ecb(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_cbc(void);
+#if !defined(NO_AES) && (defined(HAVE_AES_CBC) || defined(WOLFSSL_AES_DIRECT))
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_cbc(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_cbc(void);
+#endif
+#ifndef NO_AES
+#ifdef WOLFSSL_AES_CFB
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_cfb1(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_cfb1(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_cfb1(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_cfb8(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_cfb8(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_cfb8(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_cfb128(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_cfb128(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_cfb128(void);
+#endif
+#ifdef WOLFSSL_AES_OFB
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_ofb(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_ofb(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_ofb(void);
+#endif
+#ifdef WOLFSSL_AES_XTS
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_xts(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_xts(void);
+#endif
+#endif /* NO_AES */
+#if !defined(NO_AES) && defined(HAVE_AESGCM)
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_gcm(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_gcm(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_gcm(void);
+#endif
+#if !defined(NO_AES) && defined(HAVE_AESCCM)
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_ccm(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_ccm(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_ccm(void);
+#endif
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_ctr(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_192_ctr(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_256_ctr(void);
+#if defined(HAVE_ARIA)
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aria_128_gcm(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aria_192_gcm(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aria_256_gcm(void);
+#endif
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_ecb(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_ede3_ecb(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_cbc(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_des_ede3_cbc(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_rc4(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_enc_null(void);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_rc2_cbc(void);
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_chacha20_poly1305(void);
+#endif
+#ifdef HAVE_CHACHA
+/* ChaCha IV + counter is set as one IV in EVP */
+#define WOLFSSL_EVP_CHACHA_IV_BYTES     (CHACHA_IV_BYTES + sizeof(word32))
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_chacha20(void);
+#endif
+#ifdef WOLFSSL_SM4_ECB
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_sm4_ecb(void);
+#endif
+#ifdef WOLFSSL_SM4_CBC
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_sm4_cbc(void);
+#endif
+#ifdef WOLFSSL_SM4_CTR
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_sm4_ctr(void);
+#endif
+#ifdef WOLFSSL_SM4_GCM
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_sm4_gcm(void);
+#endif
+#ifdef WOLFSSL_SM4_CCM
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_sm4_ccm(void);
+#endif
+
+typedef union {
+    #ifndef NO_MD4
+        WOLFSSL_MD4_CTX    md4;
+    #endif
+    #ifndef NO_MD5
+        WOLFSSL_MD5_CTX    md5;
+    #endif
+    #ifndef NO_SHA
+        WOLFSSL_SHA_CTX    sha;
+    #endif
+    #ifdef WOLFSSL_SHA224
+        WOLFSSL_SHA224_CTX sha224;
+    #endif
+    #ifndef NO_SHA256
+        WOLFSSL_SHA256_CTX sha256;
+    #endif
+    #ifdef WOLFSSL_SHA384
+        WOLFSSL_SHA384_CTX sha384;
+    #endif
+    #ifdef WOLFSSL_SHA512
+        WOLFSSL_SHA512_CTX sha512;
+    #endif
+    #ifdef WOLFSSL_RIPEMD
+        WOLFSSL_RIPEMD_CTX ripemd;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_224
+        WOLFSSL_SHA3_224_CTX sha3_224;
+    #endif
+    #ifndef WOLFSSL_NOSHA3_256
+        WOLFSSL_SHA3_256_CTX sha3_256;
+    #endif
+        WOLFSSL_SHA3_384_CTX sha3_384;
+    #ifndef WOLFSSL_NOSHA3_512
+        WOLFSSL_SHA3_512_CTX sha3_512;
+    #endif
+    #ifdef WOLFSSL_SM3
+        wc_Sm3               sm3;
+    #endif
+} WOLFSSL_Hasher;
+
+
+struct WOLFSSL_EVP_MD_CTX {
+    union {
+        WOLFSSL_Hasher digest;
+    #ifndef NO_HMAC
+        Hmac hmac;
+    #endif
+    } hash;
+    enum wc_HashType macType;
+    WOLFSSL_EVP_PKEY_CTX *pctx;
+#ifndef NO_HMAC
+    unsigned int isHMAC;
+#endif
+};
+
+
+typedef union {
+#ifndef NO_AES
+    Aes  aes;
+#ifdef WOLFSSL_AES_XTS
+    XtsAes xts;
+#endif
+#endif
+#ifdef HAVE_ARIA
+    wc_Aria aria;
+#endif
+#ifndef NO_DES3
+    Des  des;
+    Des3 des3;
+#endif
+    Arc4 arc4;
+#ifdef WOLFSSL_QT
+    int (*ctrl) (WOLFSSL_EVP_CIPHER_CTX *, int type, int arg, void *ptr);
+#endif
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+    ChaChaPoly_Aead chachaPoly;
+#endif
+#ifdef HAVE_CHACHA
+    ChaCha chacha;
+#endif
+#ifdef WOLFSSL_SM4
+    wc_Sm4 sm4;
+#endif
+} WOLFSSL_Cipher;
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+
+#define NID_aes_128_cbc                 419
+#define NID_aes_192_cbc                 423
+#define NID_aes_256_cbc                 427
+#define NID_aes_128_ccm                 896
+#define NID_aes_192_ccm                 899
+#define NID_aes_256_ccm                 902
+#define NID_aes_128_gcm                 895
+#define NID_aes_192_gcm                 898
+#define NID_aes_256_gcm                 901
+#define NID_aes_128_ctr                 904
+#define NID_aes_192_ctr                 905
+#define NID_aes_256_ctr                 906
+#define NID_aes_128_ecb                 418
+#define NID_aes_192_ecb                 422
+#define NID_aes_256_ecb                 426
+#define NID_des_cbc                     31
+#define NID_des_ecb                     29
+#define NID_des_ede3_cbc                44
+#define NID_des_ede3_ecb                33
+#define NID_aes_128_cfb1                650
+#define NID_aes_192_cfb1                651
+#define NID_aes_256_cfb1                652
+#define NID_aes_128_cfb8                653
+#define NID_aes_192_cfb8                654
+#define NID_aes_256_cfb8                655
+#define NID_aes_128_cfb128              421
+#define NID_aes_192_cfb128              425
+#define NID_aes_256_cfb128              429
+#define NID_aes_128_ofb                 420
+#define NID_aes_192_ofb                 424
+#define NID_aes_256_ofb                 428
+#define NID_aes_128_xts                 913
+#define NID_aes_256_xts                 914
+#define NID_camellia_128_cbc            751
+#define NID_camellia_256_cbc            753
+#define NID_chacha20_poly1305           1018
+#define NID_chacha20                    1019
+#define NID_sm4_ecb                     1133
+#define NID_sm4_cbc                     1134
+#define NID_sm4_ctr                     1139
+#define NID_sm4_gcm                     1248
+#define NID_sm4_ccm                     1249
+#define NID_md5WithRSA                  104
+#define NID_md2WithRSAEncryption        9
+#define NID_md5WithRSAEncryption        99
+#define NID_dsaWithSHA1                 113
+#define NID_dsaWithSHA1_2               70
+#define NID_sha1WithRSA                 115
+#define NID_sha1WithRSAEncryption       65
+#define NID_sha224WithRSAEncryption     671
+#define NID_sha256WithRSAEncryption     668
+#define NID_sha384WithRSAEncryption     669
+#define NID_sha512WithRSAEncryption     670
+#define NID_RSA_SHA3_224                1116
+#define NID_RSA_SHA3_256                1117
+#define NID_RSA_SHA3_384                1118
+#define NID_RSA_SHA3_512                1119
+#define NID_rsassaPss                   912
+#define NID_ecdsa_with_SHA1             416
+#define NID_ecdsa_with_SHA224           793
+#define NID_ecdsa_with_SHA256           794
+#define NID_ecdsa_with_SHA384           795
+#define NID_ecdsa_with_SHA512           796
+#define NID_ecdsa_with_SHA3_224         1112
+#define NID_ecdsa_with_SHA3_256         1113
+#define NID_ecdsa_with_SHA3_384         1114
+#define NID_ecdsa_with_SHA3_512         1115
+#define NID_dsa_with_SHA224             802
+#define NID_dsa_with_SHA256             803
+#define NID_sha3_224                    1096
+#define NID_sha3_256                    1097
+#define NID_sha3_384                    1098
+#define NID_sha3_512                    1099
+#define NID_blake2b512                  1056
+#define NID_blake2s256                  1057
+#define NID_shake128                    1100
+#define NID_shake256                    1101
+#define NID_sha1                        64
+#define NID_sha224                      675
+#define NID_sm3                         1143
+#define NID_md2                         77
+#define NID_md4                         257
+#define NID_md5                         40
+#define NID_hmac                        855
+#define NID_hmacWithSHA1                163
+#define NID_hmacWithSHA224              798
+#define NID_hmacWithSHA256              799
+#define NID_hmacWithSHA384              800
+#define NID_hmacWithSHA512              801
+#define NID_hkdf                        1036
+#define NID_cmac                        894
+#define NID_dhKeyAgreement              28
+#define NID_ffdhe2048                   1126
+#define NID_ffdhe3072                   1127
+#define NID_ffdhe4096                   1128
+#define NID_rc4                         5
+#define NID_bf_cbc                      91
+#define NID_bf_ecb                      92
+#define NID_bf_cfb64                    93
+#define NID_bf_ofb64                    94
+#define NID_cast5_cbc                   108
+#define NID_cast5_ecb                   109
+#define NID_cast5_cfb64                 110
+#define NID_cast5_ofb64                 111
+/* key exchange */
+#define NID_kx_rsa                      1037
+#define NID_kx_ecdhe                    1038
+#define NID_kx_dhe                      1039
+#define NID_kx_ecdhe_psk                1040
+#define NID_kx_dhe_psk                  1041
+#define NID_kx_rsa_psk                  1042
+#define NID_kx_psk                      1043
+#define NID_kx_srp                      1044
+#define NID_kx_gost                     1045
+#define NID_kx_any                      1063
+/* server authentication */
+#define NID_auth_rsa                    1046
+#define NID_auth_ecdsa                  1047
+#define NID_auth_psk                    1048
+#define NID_auth_dss                    1049
+#define NID_auth_srp                    1052
+#define NID_auth_null                   1054
+#define NID_auth_any                    1055
+/* Curve */
+#define NID_aria_128_gcm                1123
+#define NID_aria_192_gcm                1124
+#define NID_aria_256_gcm                1125
+#define NID_sm2                         1172
+
+#define NID_X9_62_id_ecPublicKey EVP_PKEY_EC
+#define NID_rsaEncryption        EVP_PKEY_RSA
+#define NID_dsa                  EVP_PKEY_DSA
+
+#define EVP_PKEY_OP_SIGN    (1 << 3)
+#define EVP_PKEY_OP_VERIFY  (1 << 5)
+#define EVP_PKEY_OP_ENCRYPT (1 << 6)
+#define EVP_PKEY_OP_DECRYPT (1 << 7)
+#define EVP_PKEY_OP_DERIVE  (1 << 8)
+
+#define EVP_PKEY_PRINT_INDENT_MAX    128
+
+enum {
+    AES_128_CBC_TYPE       = 1,
+    AES_192_CBC_TYPE       = 2,
+    AES_256_CBC_TYPE       = 3,
+    AES_128_CTR_TYPE       = 4,
+    AES_192_CTR_TYPE       = 5,
+    AES_256_CTR_TYPE       = 6,
+    AES_128_ECB_TYPE       = 7,
+    AES_192_ECB_TYPE       = 8,
+    AES_256_ECB_TYPE       = 9,
+    DES_CBC_TYPE           = 10,
+    DES_ECB_TYPE           = 11,
+    DES_EDE3_CBC_TYPE      = 12,
+    DES_EDE3_ECB_TYPE      = 13,
+    ARC4_TYPE              = 14,
+    NULL_CIPHER_TYPE       = 15,
+    EVP_PKEY_RSA           = 16,
+    EVP_PKEY_DSA           = 17,
+    EVP_PKEY_EC            = 18,
+    AES_128_GCM_TYPE       = 21,
+    AES_192_GCM_TYPE       = 22,
+    AES_256_GCM_TYPE       = 23,
+    EVP_PKEY_DH            = NID_dhKeyAgreement,
+    EVP_PKEY_HMAC          = NID_hmac,
+    EVP_PKEY_CMAC          = NID_cmac,
+    EVP_PKEY_HKDF          = NID_hkdf,
+    EVP_PKEY_FALCON        = 300, /* Randomly picked value. */
+    EVP_PKEY_DILITHIUM     = 301, /* Randomly picked value. */
+    AES_128_CFB1_TYPE      = 24,
+    AES_192_CFB1_TYPE      = 25,
+    AES_256_CFB1_TYPE      = 26,
+    AES_128_CFB8_TYPE      = 27,
+    AES_192_CFB8_TYPE      = 28,
+    AES_256_CFB8_TYPE      = 29,
+    AES_128_CFB128_TYPE    = 30,
+    AES_192_CFB128_TYPE    = 31,
+    AES_256_CFB128_TYPE    = 32,
+    AES_128_OFB_TYPE       = 33,
+    AES_192_OFB_TYPE       = 34,
+    AES_256_OFB_TYPE       = 35,
+    AES_128_XTS_TYPE       = 36,
+    AES_256_XTS_TYPE       = 37,
+    CHACHA20_POLY1305_TYPE = 38,
+    CHACHA20_TYPE          = 39,
+    AES_128_CCM_TYPE       = 40,
+    AES_192_CCM_TYPE       = 41,
+    AES_256_CCM_TYPE       = 42,
+    SM4_ECB_TYPE           = 43,
+    SM4_CBC_TYPE           = 44,
+    SM4_CTR_TYPE           = 45,
+    SM4_GCM_TYPE           = 46,
+    SM4_CCM_TYPE           = 47,
+    ARIA_128_GCM_TYPE      = 48,
+    ARIA_192_GCM_TYPE      = 49,
+    ARIA_256_GCM_TYPE      = 50
+};
+
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+
+#define WOLFSSL_EVP_BUF_SIZE 16
+struct WOLFSSL_EVP_CIPHER_CTX {
+    int            keyLen;         /* user may set for variable */
+    int            block_size;
+    unsigned long  flags;
+    unsigned char  enc;            /* if encrypt side, then true */
+    unsigned char  cipherType;
+#if !defined(NO_AES)
+    /* working iv pointer into cipher */
+    ALIGN16 unsigned char  iv[AES_BLOCK_SIZE];
+#elif defined(WOLFSSL_SM4)
+    ALIGN16 unsigned char  iv[SM4_BLOCK_SIZE];
+#elif defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+    ALIGN16 unsigned char  iv[CHACHA20_POLY1305_AEAD_IV_SIZE];
+#elif !defined(NO_DES3)
+    ALIGN16 unsigned char  iv[DES_BLOCK_SIZE];
+#endif
+    WOLFSSL_Cipher  cipher;
+    ALIGN16 byte buf[WOLFSSL_EVP_BUF_SIZE];
+    int  bufUsed;
+    ALIGN16 byte lastBlock[WOLFSSL_EVP_BUF_SIZE];
+    int  lastUsed;
+#if !defined(NO_AES) || !defined(NO_DES3) || defined(HAVE_AESGCM) || \
+    defined (WOLFSSL_AES_XTS) || (defined(HAVE_CHACHA) || \
+    defined(HAVE_POLY1305) || defined(HAVE_AESCCM)) || \
+    defined(WOLFSSL_SM4_GCM) || defined(WOLFSSL_SM4_CCM)
+#define HAVE_WOLFSSL_EVP_CIPHER_CTX_IV
+    int    ivSz;
+#if defined(HAVE_AESGCM) || defined(HAVE_AESCCM) || \
+    defined(WOLFSSL_SM4_GCM) || defined(WOLFSSL_SM4_CCM)
+    byte*   authBuffer;
+    int     authBufferLen;
+    byte*   authIn;
+    int     authInSz;
+#endif
+#if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
+    byte*   key;                 /* used in partial Init()s */
+#endif
+#if defined(HAVE_AESGCM) || defined(HAVE_AESCCM) || defined(HAVE_ARIA) || \
+    defined(WOLFSSL_SM4_GCM) || defined(WOLFSSL_SM4_CCM) || \
+    (defined(HAVE_CHACHA) && defined(HAVE_POLY1305))
+#if defined(HAVE_AESGCM) || defined(HAVE_AESCCM) || defined(HAVE_ARIA)
+    ALIGN16 unsigned char authTag[AES_BLOCK_SIZE];
+#elif defined(WOLFSSL_SM4_GCM) || defined(WOLFSSL_SM4_CCM)
+    ALIGN16 unsigned char authTag[SM4_BLOCK_SIZE];
+#else
+    ALIGN16 unsigned char authTag[CHACHA20_POLY1305_AEAD_AUTHTAG_SIZE];
+#endif
+    int     authTagSz;
+#endif
+#if defined(HAVE_AESGCM) || defined(HAVE_AESCCM) || \
+    defined(WOLFSSL_SM4_GCM) || defined(WOLFSSL_SM4_CCM)
+    byte    authIvGenEnable:1;
+    byte    authIncIv:1;
+#endif
+#endif
+};
+
+struct WOLFSSL_EVP_PKEY_CTX {
+    WOLFSSL_EVP_PKEY *pkey;
+    WOLFSSL_EVP_PKEY *peerKey;
+    int op; /* operation */
+    int padding;
+    int nbits;
+#ifdef HAVE_ECC
+    int curveNID;
+#endif
+#ifndef NO_RSA
+    const WOLFSSL_EVP_MD* md;
+#endif
+};
+
+struct WOLFSSL_ASN1_PCTX {
+    int dummy;
+};
+#if defined(WOLFSSL_BASE64_ENCODE) || defined(WOLFSSL_BASE64_DECODE)
+
+#define   BASE64_ENCODE_BLOCK_SIZE  48
+#define   BASE64_ENCODE_RESULT_BLOCK_SIZE 64
+#define   BASE64_DECODE_BLOCK_SIZE  4
+
+struct WOLFSSL_EVP_ENCODE_CTX {
+    void* heap;
+    int   remaining;     /* num of bytes in data[] */
+    byte  data[BASE64_ENCODE_BLOCK_SIZE];/* storage for unprocessed raw data */
+};
+typedef struct WOLFSSL_EVP_ENCODE_CTX WOLFSSL_EVP_ENCODE_CTX;
+
+WOLFSSL_API struct WOLFSSL_EVP_ENCODE_CTX* wolfSSL_EVP_ENCODE_CTX_new(void);
+WOLFSSL_API void wolfSSL_EVP_ENCODE_CTX_free(WOLFSSL_EVP_ENCODE_CTX* ctx);
+#endif /* WOLFSSL_BASE64_ENCODE || WOLFSSL_BASE64_DECODE */
+
+#if defined(WOLFSSL_BASE64_ENCODE)
+WOLFSSL_API void wolfSSL_EVP_EncodeInit(WOLFSSL_EVP_ENCODE_CTX* ctx);
+WOLFSSL_API int  wolfSSL_EVP_EncodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
+                 unsigned char*out, int *outl, const unsigned char*in, int inl);
+WOLFSSL_API void wolfSSL_EVP_EncodeFinal(WOLFSSL_EVP_ENCODE_CTX* ctx,
+                 unsigned char*out, int *outl);
+WOLFSSL_API int wolfSSL_EVP_EncodeBlock(unsigned char *out,
+                const unsigned char *in, int inLen);
+WOLFSSL_API int wolfSSL_EVP_DecodeBlock(unsigned char *out,
+                const unsigned char *in, int inLen);
+#endif /* WOLFSSL_BASE64_ENCODE */
+
+#if defined(WOLFSSL_BASE64_DECODE)
+WOLFSSL_API void wolfSSL_EVP_DecodeInit(WOLFSSL_EVP_ENCODE_CTX* ctx);
+WOLFSSL_API int  wolfSSL_EVP_DecodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
+                unsigned char*out, int *outl, const unsigned char*in, int inl);
+WOLFSSL_API int wolfSSL_EVP_DecodeFinal(WOLFSSL_EVP_ENCODE_CTX* ctx,
+                unsigned char*out, int *outl);
+#endif /* WOLFSSL_BASE64_DECODE */
+
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_blake2b512(void);
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_blake2s256(void);
+
+WOLFSSL_API void wolfSSL_EVP_init(void);
+WOLFSSL_API int  wolfSSL_EVP_MD_size(const WOLFSSL_EVP_MD* type);
+WOLFSSL_API int  wolfSSL_EVP_MD_type(const WOLFSSL_EVP_MD* type);
+WOLFSSL_API int  wolfSSL_EVP_MD_block_size(const WOLFSSL_EVP_MD* type);
+WOLFSSL_API int  wolfSSL_EVP_MD_pkey_type(const WOLFSSL_EVP_MD* type);
+
+WOLFSSL_API WOLFSSL_EVP_MD_CTX *wolfSSL_EVP_MD_CTX_new (void);
+WOLFSSL_API void                wolfSSL_EVP_MD_CTX_free(WOLFSSL_EVP_MD_CTX* ctx);
+WOLFSSL_API void wolfSSL_EVP_MD_CTX_init(WOLFSSL_EVP_MD_CTX* ctx);
+WOLFSSL_API int  wolfSSL_EVP_MD_CTX_cleanup(WOLFSSL_EVP_MD_CTX* ctx);
+WOLFSSL_API int  wolfSSL_EVP_MD_CTX_copy(WOLFSSL_EVP_MD_CTX *out, const WOLFSSL_EVP_MD_CTX *in);
+WOLFSSL_API int  wolfSSL_EVP_MD_CTX_copy_ex(WOLFSSL_EVP_MD_CTX *out, const WOLFSSL_EVP_MD_CTX *in);
+WOLFSSL_API int  wolfSSL_EVP_MD_CTX_type(const WOLFSSL_EVP_MD_CTX *ctx);
+WOLFSSL_API int  wolfSSL_EVP_MD_CTX_size(const WOLFSSL_EVP_MD_CTX *ctx);
+WOLFSSL_API int  wolfSSL_EVP_MD_CTX_block_size(const WOLFSSL_EVP_MD_CTX *ctx);
+WOLFSSL_API const WOLFSSL_EVP_MD *wolfSSL_EVP_MD_CTX_md(const WOLFSSL_EVP_MD_CTX *ctx);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_get_cipherbyname(const char *name);
+WOLFSSL_API const WOLFSSL_EVP_MD     *wolfSSL_EVP_get_digestbyname(const char *name);
+WOLFSSL_API int wolfSSL_EVP_CIPHER_nid(const WOLFSSL_EVP_CIPHER *cipher);
+
+WOLFSSL_API int wolfSSL_EVP_DigestInit(WOLFSSL_EVP_MD_CTX* ctx,
+                                     const WOLFSSL_EVP_MD* type);
+WOLFSSL_API int wolfSSL_EVP_DigestUpdate(WOLFSSL_EVP_MD_CTX* ctx, const void* data,
+                                       size_t sz);
+WOLFSSL_API int wolfSSL_EVP_DigestFinal(WOLFSSL_EVP_MD_CTX* ctx, unsigned char* md,
+                                      unsigned int* s);
+WOLFSSL_API int wolfSSL_EVP_DigestFinal_ex(WOLFSSL_EVP_MD_CTX* ctx,
+                                            unsigned char* md, unsigned int* s);
+WOLFSSL_API int wolfSSL_EVP_DigestSignUpdate(WOLFSSL_EVP_MD_CTX *ctx,
+                                             const void *d, unsigned int cnt);
+WOLFSSL_API int wolfSSL_EVP_DigestSignFinal(WOLFSSL_EVP_MD_CTX *ctx,
+                                            unsigned char *sig, size_t *siglen);
+WOLFSSL_API int wolfSSL_EVP_DigestVerifyUpdate(WOLFSSL_EVP_MD_CTX *ctx,
+                                               const void *d, size_t cnt);
+WOLFSSL_API int wolfSSL_EVP_DigestVerifyFinal(WOLFSSL_EVP_MD_CTX *ctx,
+                                              const unsigned char *sig,
+                                              size_t siglen);
+
+WOLFSSL_API int wolfSSL_EVP_BytesToKey(const WOLFSSL_EVP_CIPHER* type,
+                       const WOLFSSL_EVP_MD* md, const byte* salt,
+                       const byte* data, int sz, int count, byte* key, byte* iv);
+
+WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_init(WOLFSSL_EVP_CIPHER_CTX* ctx);
+WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_cleanup(WOLFSSL_EVP_CIPHER_CTX* ctx);
+WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_ctrl(WOLFSSL_EVP_CIPHER_CTX *ctx, \
+                                             int type, int arg, void *ptr);
+WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_iv_length(
+                                    const WOLFSSL_EVP_CIPHER_CTX* ctx);
+WOLFSSL_API int  wolfSSL_EVP_CIPHER_iv_length(const WOLFSSL_EVP_CIPHER* cipher);
+WOLFSSL_API int wolfSSL_EVP_Cipher_key_length(const WOLFSSL_EVP_CIPHER* c);
+
+
+WOLFSSL_API int  wolfSSL_EVP_CipherInit(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                    const WOLFSSL_EVP_CIPHER* type,
+                                    const unsigned char* key,
+                                    const unsigned char* iv,
+                                    int enc);
+WOLFSSL_API int wolfSSL_EVP_CipherUpdate(WOLFSSL_EVP_CIPHER_CTX *ctx,
+                                   unsigned char *out, int *outl,
+                                   const unsigned char *in, int inl);
+WOLFSSL_API int  wolfSSL_EVP_CipherFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
+                                   unsigned char *out, int *outl);
+WOLFSSL_API int  wolfSSL_EVP_CipherFinal_ex(WOLFSSL_EVP_CIPHER_CTX *ctx,
+                                   unsigned char *out, int *outl, int enc);
+WOLFSSL_API int  wolfSSL_EVP_EncryptFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
+                                   unsigned char *out, int *outl);
+WOLFSSL_API int  wolfSSL_EVP_EncryptFinal_ex(WOLFSSL_EVP_CIPHER_CTX *ctx,
+                                   unsigned char *out, int *outl);
+WOLFSSL_API int  wolfSSL_EVP_DecryptFinal(WOLFSSL_EVP_CIPHER_CTX *ctx,
+                                   unsigned char *out, int *outl);
+WOLFSSL_API int  wolfSSL_EVP_DecryptFinal_ex(WOLFSSL_EVP_CIPHER_CTX *ctx,
+                                   unsigned char *out, int *outl);
+WOLFSSL_API int  wolfSSL_EVP_DecryptFinal_legacy(WOLFSSL_EVP_CIPHER_CTX *ctx,
+                                   unsigned char *out, int *outl);
+
+WOLFSSL_API WOLFSSL_EVP_CIPHER_CTX *wolfSSL_EVP_CIPHER_CTX_new(void);
+WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_free(WOLFSSL_EVP_CIPHER_CTX *ctx);
+WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_reset(WOLFSSL_EVP_CIPHER_CTX *ctx);
+WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_nid(const WOLFSSL_EVP_CIPHER_CTX *ctx);
+WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_key_length(WOLFSSL_EVP_CIPHER_CTX* ctx);
+WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_set_key_length(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                                     int keylen);
+WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_set_iv_length(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                                     int ivLen);
+WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_set_iv(WOLFSSL_EVP_CIPHER_CTX* ctx, byte* iv,
+                                                     int ivLen);
+WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_get_iv(WOLFSSL_EVP_CIPHER_CTX* ctx, byte* iv,
+                                                     int ivLen);
+WOLFSSL_API int  wolfSSL_EVP_Cipher(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                          unsigned char* dst, unsigned char* src,
+                          unsigned int len);
+
+WOLFSSL_API const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_get_cipherbynid(int id);
+WOLFSSL_API const WOLFSSL_EVP_MD* wolfSSL_EVP_get_digestbynid(int id);
+WOLFSSL_API const WOLFSSL_EVP_CIPHER *wolfSSL_EVP_CIPHER_CTX_cipher(const WOLFSSL_EVP_CIPHER_CTX *ctx);
+
+WOLFSSL_API int wolfSSL_EVP_PKEY_assign_RSA(WOLFSSL_EVP_PKEY* pkey,
+                                            WOLFSSL_RSA* key);
+WOLFSSL_API int wolfSSL_EVP_PKEY_assign_EC_KEY(WOLFSSL_EVP_PKEY* pkey,
+                                               WOLFSSL_EC_KEY* key);
+WOLFSSL_API int wolfSSL_EVP_PKEY_assign_DSA(WOLFSSL_EVP_PKEY* pkey, WOLFSSL_DSA* key);
+WOLFSSL_API int wolfSSL_EVP_PKEY_assign_DH(WOLFSSL_EVP_PKEY* pkey, WOLFSSL_DH* key);
+WOLFSSL_API WOLFSSL_RSA* wolfSSL_EVP_PKEY_get0_RSA(WOLFSSL_EVP_PKEY *pkey);
+WOLFSSL_API WOLFSSL_DSA* wolfSSL_EVP_PKEY_get0_DSA(WOLFSSL_EVP_PKEY *pkey);
+WOLFSSL_API WOLFSSL_RSA* wolfSSL_EVP_PKEY_get1_RSA(WOLFSSL_EVP_PKEY* key);
+WOLFSSL_API WOLFSSL_DSA* wolfSSL_EVP_PKEY_get1_DSA(WOLFSSL_EVP_PKEY* key);
+WOLFSSL_API WOLFSSL_EC_KEY *wolfSSL_EVP_PKEY_get0_EC_KEY(WOLFSSL_EVP_PKEY *pkey);
+WOLFSSL_API WOLFSSL_EC_KEY *wolfSSL_EVP_PKEY_get1_EC_KEY(WOLFSSL_EVP_PKEY *key);
+WOLFSSL_API WOLFSSL_DH* wolfSSL_EVP_PKEY_get0_DH(WOLFSSL_EVP_PKEY* key);
+WOLFSSL_API WOLFSSL_DH* wolfSSL_EVP_PKEY_get1_DH(WOLFSSL_EVP_PKEY* key);
+WOLFSSL_API int wolfSSL_EVP_PKEY_set1_RSA(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_RSA *key);
+WOLFSSL_API int wolfSSL_EVP_PKEY_set1_DSA(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_DSA *key);
+WOLFSSL_API int wolfSSL_EVP_PKEY_set1_DH(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_DH *key);
+WOLFSSL_API int wolfSSL_EVP_PKEY_set1_EC_KEY(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_EC_KEY *key);
+WOLFSSL_API int wolfSSL_EVP_PKEY_assign(WOLFSSL_EVP_PKEY *pkey, int type, void *key);
+
+WOLFSSL_API const unsigned char* wolfSSL_EVP_PKEY_get0_hmac(const WOLFSSL_EVP_PKEY* pkey,
+        size_t* len);
+WOLFSSL_API int wolfSSL_EVP_PKEY_sign_init(WOLFSSL_EVP_PKEY_CTX *ctx);
+WOLFSSL_API int wolfSSL_EVP_PKEY_sign(WOLFSSL_EVP_PKEY_CTX *ctx,
+  unsigned char *sig, size_t *siglen, const unsigned char *tbs, size_t tbslen);
+WOLFSSL_API int wolfSSL_EVP_PKEY_verify_init(WOLFSSL_EVP_PKEY_CTX *ctx);
+WOLFSSL_API int wolfSSL_EVP_PKEY_verify(WOLFSSL_EVP_PKEY_CTX *ctx, const unsigned char *sig,
+  size_t siglen, const unsigned char *tbs, size_t tbslen);
+WOLFSSL_API int wolfSSL_EVP_PKEY_paramgen_init(WOLFSSL_EVP_PKEY_CTX *ctx);
+WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid(WOLFSSL_EVP_PKEY_CTX *ctx,
+        int nid);
+WOLFSSL_API int wolfSSL_EVP_PKEY_paramgen(WOLFSSL_EVP_PKEY_CTX* ctx,
+                                          WOLFSSL_EVP_PKEY** pkey);
+WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_set_ec_param_enc(WOLFSSL_EVP_PKEY_CTX *ctx,
+        int flag);
+WOLFSSL_API int wolfSSL_EVP_PKEY_keygen_init(WOLFSSL_EVP_PKEY_CTX *ctx);
+WOLFSSL_API int wolfSSL_EVP_PKEY_keygen(WOLFSSL_EVP_PKEY_CTX *ctx,
+  WOLFSSL_EVP_PKEY **ppkey);
+WOLFSSL_API int wolfSSL_EVP_PKEY_bits(const WOLFSSL_EVP_PKEY *pkey);
+#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
+WOLFSSL_API void wolfSSL_EVP_PKEY_CTX_free(WOLFSSL_EVP_PKEY_CTX *ctx);
+#else
+WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_free(WOLFSSL_EVP_PKEY_CTX *ctx);
+#endif
+WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_set_rsa_padding(WOLFSSL_EVP_PKEY_CTX *ctx, int padding);
+WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_set_signature_md(WOLFSSL_EVP_PKEY_CTX *ctx,
+    const WOLFSSL_EVP_MD* md);
+WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_set_rsa_keygen_bits(WOLFSSL_EVP_PKEY_CTX *ctx, int bits);
+
+WOLFSSL_API int wolfSSL_EVP_PKEY_derive_init(WOLFSSL_EVP_PKEY_CTX *ctx);
+WOLFSSL_API int wolfSSL_EVP_PKEY_derive_set_peer(WOLFSSL_EVP_PKEY_CTX *ctx, WOLFSSL_EVP_PKEY *peer);
+WOLFSSL_API int wolfSSL_EVP_PKEY_derive(WOLFSSL_EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen);
+
+WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_ctrl_str(WOLFSSL_EVP_PKEY_CTX *ctx,
+                          const char *name, const char *value);
+
+WOLFSSL_API int wolfSSL_EVP_PKEY_decrypt(WOLFSSL_EVP_PKEY_CTX *ctx,
+                     unsigned char *out, size_t *outlen,
+                     const unsigned char *in, size_t inlen);
+WOLFSSL_API int wolfSSL_EVP_PKEY_decrypt_init(WOLFSSL_EVP_PKEY_CTX *ctx);
+WOLFSSL_API int wolfSSL_EVP_PKEY_encrypt(WOLFSSL_EVP_PKEY_CTX *ctx,
+                     unsigned char *out, size_t *outlen,
+                     const unsigned char *in, size_t inlen);
+WOLFSSL_API int wolfSSL_EVP_PKEY_encrypt_init(WOLFSSL_EVP_PKEY_CTX *ctx);
+WOLFSSL_API WOLFSSL_EVP_PKEY *wolfSSL_EVP_PKEY_new(void);
+WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_ex(void* heap);
+WOLFSSL_API void wolfSSL_EVP_PKEY_free(WOLFSSL_EVP_PKEY* key);
+WOLFSSL_API int wolfSSL_EVP_PKEY_size(WOLFSSL_EVP_PKEY *pkey);
+WOLFSSL_API int wolfSSL_EVP_PKEY_copy_parameters(WOLFSSL_EVP_PKEY *to, const WOLFSSL_EVP_PKEY *from);
+WOLFSSL_API int wolfSSL_EVP_PKEY_missing_parameters(WOLFSSL_EVP_PKEY *pkey);
+WOLFSSL_API int wolfSSL_EVP_PKEY_cmp(const WOLFSSL_EVP_PKEY *a, const WOLFSSL_EVP_PKEY *b);
+WOLFSSL_API int wolfSSL_EVP_PKEY_type(int type);
+WOLFSSL_API int wolfSSL_EVP_PKEY_id(const WOLFSSL_EVP_PKEY *pkey);
+WOLFSSL_API int wolfSSL_EVP_PKEY_base_id(const WOLFSSL_EVP_PKEY *pkey);
+WOLFSSL_API int wolfSSL_EVP_PKEY_get_default_digest_nid(WOLFSSL_EVP_PKEY *pkey, int *pnid);
+WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKCS82PKEY(const WOLFSSL_PKCS8_PRIV_KEY_INFO* p8);
+WOLFSSL_API WOLFSSL_PKCS8_PRIV_KEY_INFO* wolfSSL_EVP_PKEY2PKCS8(const WOLFSSL_EVP_PKEY* pkey);
+
+WOLFSSL_API int wolfSSL_EVP_SignFinal(WOLFSSL_EVP_MD_CTX *ctx, unsigned char *sigret,
+                  unsigned int *siglen, WOLFSSL_EVP_PKEY *pkey);
+WOLFSSL_API int wolfSSL_EVP_SignInit(WOLFSSL_EVP_MD_CTX *ctx, const WOLFSSL_EVP_MD *type);
+WOLFSSL_API int wolfSSL_EVP_SignUpdate(WOLFSSL_EVP_MD_CTX *ctx, const void *data, size_t len);
+WOLFSSL_API int wolfSSL_EVP_VerifyFinal(WOLFSSL_EVP_MD_CTX *ctx,
+        const unsigned char* sig, unsigned int sig_len, WOLFSSL_EVP_PKEY *pkey);
+WOLFSSL_API int wolfSSL_EVP_VerifyInit(WOLFSSL_EVP_MD_CTX *ctx, const WOLFSSL_EVP_MD *type);
+WOLFSSL_API int wolfSSL_EVP_VerifyUpdate(WOLFSSL_EVP_MD_CTX *ctx, const void *data, size_t len);
+
+
+/* these next ones don't need real OpenSSL type, for OpenSSH compat only */
+WOLFSSL_API void* wolfSSL_EVP_X_STATE(const WOLFSSL_EVP_CIPHER_CTX* ctx);
+WOLFSSL_API int   wolfSSL_EVP_X_STATE_LEN(const WOLFSSL_EVP_CIPHER_CTX* ctx);
+
+WOLFSSL_API void  wolfSSL_3des_iv(WOLFSSL_EVP_CIPHER_CTX* ctx, int doset,
+                                unsigned char* iv, int len);
+WOLFSSL_API void  wolfSSL_aes_ctr_iv(WOLFSSL_EVP_CIPHER_CTX* ctx, int doset,
+                                unsigned char* iv, int len);
+
+WOLFSSL_API int  wolfSSL_StoreExternalIV(WOLFSSL_EVP_CIPHER_CTX* ctx);
+WOLFSSL_API int  wolfSSL_SetInternalIV(WOLFSSL_EVP_CIPHER_CTX* ctx);
+
+WOLFSSL_API int wolfSSL_EVP_CIPHER_CTX_block_size(const WOLFSSL_EVP_CIPHER_CTX *ctx);
+WOLFSSL_API int wolfSSL_EVP_CIPHER_block_size(const WOLFSSL_EVP_CIPHER *cipher);
+WOLFSSL_API unsigned long WOLFSSL_EVP_CIPHER_mode(const WOLFSSL_EVP_CIPHER *cipher);
+WOLFSSL_API unsigned long WOLFSSL_CIPHER_mode(const WOLFSSL_EVP_CIPHER *cipher);
+WOLFSSL_API unsigned long wolfSSL_EVP_CIPHER_flags(const WOLFSSL_EVP_CIPHER *cipher);
+WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_set_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags);
+WOLFSSL_API void wolfSSL_EVP_CIPHER_CTX_clear_flags(WOLFSSL_EVP_CIPHER_CTX *ctx, int flags);
+WOLFSSL_API unsigned long wolfSSL_EVP_CIPHER_CTX_flags(const WOLFSSL_EVP_CIPHER_CTX *ctx);
+WOLFSSL_API unsigned long wolfSSL_EVP_CIPHER_CTX_mode(const WOLFSSL_EVP_CIPHER_CTX *ctx);
+WOLFSSL_API int  wolfSSL_EVP_CIPHER_CTX_set_padding(WOLFSSL_EVP_CIPHER_CTX *c, int pad);
+WOLFSSL_API int  wolfSSL_EVP_add_digest(const WOLFSSL_EVP_MD *digest);
+WOLFSSL_API int  wolfSSL_EVP_add_cipher(const WOLFSSL_EVP_CIPHER *cipher);
+WOLFSSL_API void wolfSSL_EVP_cleanup(void);
+WOLFSSL_API int  wolfSSL_add_all_algorithms(void);
+WOLFSSL_API int  wolfSSL_OpenSSL_add_all_algorithms_conf(void);
+WOLFSSL_API int  wolfSSL_OpenSSL_add_all_algorithms_noconf(void);
+WOLFSSL_API int wolfSSL_EVP_read_pw_string(char*, int, const char*, int);
+
+WOLFSSL_API int wolfSSL_PKCS5_PBKDF2_HMAC_SHA1(const char * pass, int passlen,
+                                               const unsigned char * salt,
+                                               int saltlen, int iter,
+                                               int keylen, unsigned char *out);
+
+WOLFSSL_API int wolfSSL_PKCS5_PBKDF2_HMAC(const char *pass, int passlen,
+                                           const unsigned char *salt,
+                                           int saltlen, int iter,
+                                           const WOLFSSL_EVP_MD *digest,
+                                           int keylen, unsigned char *out);
+
+#if defined(HAVE_SCRYPT) && defined(HAVE_PBKDF2) && !defined(NO_PWDBASED) && \
+                                                    !defined(NO_SHA256)
+WOLFSSL_API int wolfSSL_EVP_PBE_scrypt(const char *pass, size_t passlen,
+                            const unsigned char *salt, size_t saltlen,
+                            word64 N, word64 r, word64 p,
+                            word64 maxmem, unsigned char *key, size_t keylen);
+#endif /* HAVE_SCRYPT && HAVE_PBKDF2 && !NO_PWDBASED && !NO_SHA256 */
+
+WOLFSSL_LOCAL int wolfSSL_EVP_get_hashinfo(const WOLFSSL_EVP_MD* evp,
+                                           int* pHash, int* pHashSz);
+
+WOLFSSL_API void wolfSSL_EVP_MD_do_all(void (*fn) (const WOLFSSL_EVP_MD *md,
+                                                   const char* from, const char* to,
+                                                   void* xx), void* args);
+
+#ifdef HAVE_HKDF
+WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_set_hkdf_md(WOLFSSL_EVP_PKEY_CTX* ctx,
+                                                 const WOLFSSL_EVP_MD* md);
+WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_set1_hkdf_salt(WOLFSSL_EVP_PKEY_CTX* ctx,
+                                                    const byte* salt,
+                                                    int saltSz);
+WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_set1_hkdf_key(WOLFSSL_EVP_PKEY_CTX* ctx,
+                                                   const byte* key, int keySz);
+WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_add1_hkdf_info(WOLFSSL_EVP_PKEY_CTX* ctx,
+                                                    const byte* info,
+                                                    int infoSz);
+WOLFSSL_API int wolfSSL_EVP_PKEY_CTX_hkdf_mode(WOLFSSL_EVP_PKEY_CTX* ctx,
+                                               int mode);
+#endif
+
+#define WOLFSSL_EVP_CIPH_MODE            0x0007
+#define WOLFSSL_EVP_CIPH_STREAM_CIPHER      0x0
+#define WOLFSSL_EVP_CIPH_ECB_MODE           0x1
+#define WOLFSSL_EVP_CIPH_CBC_MODE           0x2
+#define WOLFSSL_EVP_CIPH_CFB_MODE           0x3
+#define WOLFSSL_EVP_CIPH_OFB_MODE           0x4
+#define WOLFSSL_EVP_CIPH_CTR_MODE           0x5
+#define WOLFSSL_EVP_CIPH_GCM_MODE           0x6
+#define WOLFSSL_EVP_CIPH_CCM_MODE           0x7
+#define WOLFSSL_EVP_CIPH_XTS_MODE          0x10
+#define WOLFSSL_EVP_CIPH_FLAG_AEAD_CIPHER  0x20
+#define WOLFSSL_EVP_CIPH_NO_PADDING       0x100
+#define WOLFSSL_EVP_CIPH_VARIABLE_LENGTH  0x200
+#define WOLFSSL_EVP_CIPH_LOW_LEVEL_INITED 0x400
+#define WOLFSSL_EVP_CIPH_TYPE_INIT         0xff
+
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+
+/* EVP ENGINE API's */
+WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_mac_key(int type, WOLFSSL_ENGINE* e,
+                                          const unsigned char* key, int keylen);
+
+WOLFSSL_API WOLFSSL_EVP_PKEY* wolfSSL_EVP_PKEY_new_CMAC_key(WOLFSSL_ENGINE* e,
+                                          const unsigned char* priv, size_t len,
+                                          const WOLFSSL_EVP_CIPHER* cipher);
+
+WOLFSSL_API int wolfSSL_EVP_DigestInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
+                                     const WOLFSSL_EVP_MD* type,
+                                     WOLFSSL_ENGINE *impl);
+
+WOLFSSL_API int wolfSSL_EVP_DigestSignInit(WOLFSSL_EVP_MD_CTX *ctx,
+                                           WOLFSSL_EVP_PKEY_CTX **pctx,
+                                           const WOLFSSL_EVP_MD *type,
+                                           WOLFSSL_ENGINE *e,
+                                           WOLFSSL_EVP_PKEY *pkey);
+WOLFSSL_API int wolfSSL_EVP_DigestVerifyInit(WOLFSSL_EVP_MD_CTX *ctx,
+                                             WOLFSSL_EVP_PKEY_CTX **pctx,
+                                             const WOLFSSL_EVP_MD *type,
+                                             WOLFSSL_ENGINE *e,
+                                             WOLFSSL_EVP_PKEY *pkey);
+WOLFSSL_API int wolfSSL_EVP_Digest(const unsigned char* in, int inSz, unsigned char* out,
+                              unsigned int* outSz, const WOLFSSL_EVP_MD* evp,
+                              WOLFSSL_ENGINE* eng);
+WOLFSSL_API int  wolfSSL_EVP_CipherInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                    const WOLFSSL_EVP_CIPHER* type,
+                                    WOLFSSL_ENGINE *impl,
+                                    const unsigned char* key,
+                                    const unsigned char* iv,
+                                    int enc);
+WOLFSSL_API int  wolfSSL_EVP_EncryptInit(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                    const WOLFSSL_EVP_CIPHER* type,
+                                    const unsigned char* key,
+                                    const unsigned char* iv);
+WOLFSSL_API int  wolfSSL_EVP_EncryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                    const WOLFSSL_EVP_CIPHER* type,
+                                    WOLFSSL_ENGINE *impl,
+                                    const unsigned char* key,
+                                    const unsigned char* iv);
+WOLFSSL_API int  wolfSSL_EVP_DecryptInit(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                    const WOLFSSL_EVP_CIPHER* type,
+                                    const unsigned char* key,
+                                    const unsigned char* iv);
+WOLFSSL_API int  wolfSSL_EVP_DecryptInit_ex(WOLFSSL_EVP_CIPHER_CTX* ctx,
+                                    const WOLFSSL_EVP_CIPHER* type,
+                                    WOLFSSL_ENGINE *impl,
+                                    const unsigned char* key,
+                                    const unsigned char* iv);
+WOLFSSL_API WOLFSSL_EVP_PKEY_CTX *wolfSSL_EVP_PKEY_CTX_new(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_ENGINE *e);
+WOLFSSL_API WOLFSSL_EVP_PKEY_CTX *wolfSSL_EVP_PKEY_CTX_new_id(int id, WOLFSSL_ENGINE *e);
+WOLFSSL_API int wolfSSL_EVP_SignInit_ex(WOLFSSL_EVP_MD_CTX* ctx,
+                                     const WOLFSSL_EVP_MD* type,
+                                     WOLFSSL_ENGINE *impl);
+
+#define EVP_CIPH_STREAM_CIPHER    WOLFSSL_EVP_CIPH_STREAM_CIPHER
+#define EVP_CIPH_VARIABLE_LENGTH  WOLFSSL_EVP_CIPH_VARIABLE_LENGTH
+#define EVP_CIPH_ECB_MODE         WOLFSSL_EVP_CIPH_ECB_MODE
+#define EVP_CIPH_CBC_MODE         WOLFSSL_EVP_CIPH_CBC_MODE
+#define EVP_CIPH_CFB_MODE         WOLFSSL_EVP_CIPH_CFB_MODE
+#define EVP_CIPH_OFB_MODE         WOLFSSL_EVP_CIPH_OFB_MODE
+#define EVP_CIPH_CTR_MODE         WOLFSSL_EVP_CIPH_CTR_MODE
+#define EVP_CIPH_GCM_MODE         WOLFSSL_EVP_CIPH_GCM_MODE
+#define EVP_CIPH_CCM_MODE         WOLFSSL_EVP_CIPH_CCM_MODE
+#define EVP_CIPH_XTS_MODE         WOLFSSL_EVP_CIPH_XTS_MODE
+
+#define EVP_CIPH_FLAG_AEAD_CIPHER WOLFSSL_EVP_CIPH_FLAG_AEAD_CIPHER
+
+#ifndef NO_MD4
+    #define EVP_md4       wolfSSL_EVP_md4
+#endif
+#ifndef NO_MD5
+    #define EVP_md5       wolfSSL_EVP_md5
+#endif
+#define EVP_sha1          wolfSSL_EVP_sha1
+#define EVP_mdc2          wolfSSL_EVP_mdc2
+#define EVP_dds1          wolfSSL_EVP_sha1
+#define EVP_sha224        wolfSSL_EVP_sha224
+#define EVP_sha256        wolfSSL_EVP_sha256
+#define EVP_sha384        wolfSSL_EVP_sha384
+#define EVP_sha512        wolfSSL_EVP_sha512
+#define EVP_sha512_224    wolfSSL_EVP_sha512_224
+#define EVP_sha512_256    wolfSSL_EVP_sha512_256
+#define EVP_ripemd160     wolfSSL_EVP_ripemd160
+#define EVP_shake128      wolfSSL_EVP_shake128
+#define EVP_shake256      wolfSSL_EVP_shake256
+#define EVP_sm3           wolfSSL_EVP_sm3
+#define EVP_set_pw_prompt wolfSSL_EVP_set_pw_prompt
+
+#define EVP_sha3_224    wolfSSL_EVP_sha3_224
+#define EVP_sha3_256    wolfSSL_EVP_sha3_256
+#define EVP_sha3_384    wolfSSL_EVP_sha3_384
+#define EVP_sha3_512    wolfSSL_EVP_sha3_512
+
+#define EVP_aes_128_cbc       wolfSSL_EVP_aes_128_cbc
+#define EVP_aes_192_cbc       wolfSSL_EVP_aes_192_cbc
+#define EVP_aes_256_cbc       wolfSSL_EVP_aes_256_cbc
+#define EVP_aes_128_cfb1      wolfSSL_EVP_aes_128_cfb1
+#define EVP_aes_192_cfb1      wolfSSL_EVP_aes_192_cfb1
+#define EVP_aes_256_cfb1      wolfSSL_EVP_aes_256_cfb1
+#define EVP_aes_128_cfb8      wolfSSL_EVP_aes_128_cfb8
+#define EVP_aes_192_cfb8      wolfSSL_EVP_aes_192_cfb8
+#define EVP_aes_256_cfb8      wolfSSL_EVP_aes_256_cfb8
+#define EVP_aes_128_cfb128    wolfSSL_EVP_aes_128_cfb128
+#define EVP_aes_192_cfb128    wolfSSL_EVP_aes_192_cfb128
+#define EVP_aes_256_cfb128    wolfSSL_EVP_aes_256_cfb128
+#define EVP_aes_128_cfb       wolfSSL_EVP_aes_128_cfb128
+#define EVP_aes_192_cfb       wolfSSL_EVP_aes_192_cfb128
+#define EVP_aes_256_cfb       wolfSSL_EVP_aes_256_cfb128
+#define EVP_aes_128_ofb       wolfSSL_EVP_aes_128_ofb
+#define EVP_aes_192_ofb       wolfSSL_EVP_aes_192_ofb
+#define EVP_aes_256_ofb       wolfSSL_EVP_aes_256_ofb
+#define EVP_aes_128_xts       wolfSSL_EVP_aes_128_xts
+#define EVP_aes_256_xts       wolfSSL_EVP_aes_256_xts
+#define EVP_aes_128_gcm       wolfSSL_EVP_aes_128_gcm
+#define EVP_aes_192_gcm       wolfSSL_EVP_aes_192_gcm
+#define EVP_aes_256_gcm       wolfSSL_EVP_aes_256_gcm
+#define EVP_aes_128_ccm       wolfSSL_EVP_aes_128_ccm
+#define EVP_aes_192_ccm       wolfSSL_EVP_aes_192_ccm
+#define EVP_aes_256_ccm       wolfSSL_EVP_aes_256_ccm
+#define EVP_aes_128_ecb       wolfSSL_EVP_aes_128_ecb
+#define EVP_aes_192_ecb       wolfSSL_EVP_aes_192_ecb
+#define EVP_aes_256_ecb       wolfSSL_EVP_aes_256_ecb
+#define EVP_aes_128_ctr       wolfSSL_EVP_aes_128_ctr
+#define EVP_aes_192_ctr       wolfSSL_EVP_aes_192_ctr
+#define EVP_aes_256_ctr       wolfSSL_EVP_aes_256_ctr
+#define EVP_des_cbc           wolfSSL_EVP_des_cbc
+#define EVP_des_ecb           wolfSSL_EVP_des_ecb
+#define EVP_des_ede3_cbc      wolfSSL_EVP_des_ede3_cbc
+#define EVP_des_ede3_ecb      wolfSSL_EVP_des_ede3_ecb
+#define EVP_rc4               wolfSSL_EVP_rc4
+#define EVP_chacha20          wolfSSL_EVP_chacha20
+#define EVP_chacha20_poly1305 wolfSSL_EVP_chacha20_poly1305
+#define EVP_aria_128_gcm      wolfSSL_EVP_aria_128_gcm
+#define EVP_aria_192_gcm      wolfSSL_EVP_aria_192_gcm
+#define EVP_aria_256_gcm      wolfSSL_EVP_aria_256_gcm
+#define EVP_sm4_ecb           wolfSSL_EVP_sm4_ecb
+#define EVP_sm4_cbc           wolfSSL_EVP_sm4_cbc
+#define EVP_sm4_ctr           wolfSSL_EVP_sm4_ctr
+#define EVP_sm4_gcm           wolfSSL_EVP_sm4_gcm
+#define EVP_sm4_ccm           wolfSSL_EVP_sm4_ccm
+#define EVP_enc_null          wolfSSL_EVP_enc_null
+
+#define EVP_MD_size             wolfSSL_EVP_MD_size
+#define EVP_MD_pkey_type        wolfSSL_EVP_MD_pkey_type
+#define EVP_MD_CTX_new          wolfSSL_EVP_MD_CTX_new
+#define EVP_MD_CTX_create       wolfSSL_EVP_MD_CTX_new
+#define EVP_MD_CTX_free         wolfSSL_EVP_MD_CTX_free
+#define EVP_MD_CTX_destroy      wolfSSL_EVP_MD_CTX_free
+#define EVP_MD_CTX_init         wolfSSL_EVP_MD_CTX_init
+#define EVP_MD_CTX_cleanup      wolfSSL_EVP_MD_CTX_cleanup
+#define EVP_MD_CTX_reset        wolfSSL_EVP_MD_CTX_cleanup
+#define EVP_MD_CTX_md           wolfSSL_EVP_MD_CTX_md
+#define EVP_MD_CTX_type         wolfSSL_EVP_MD_CTX_type
+#define EVP_MD_CTX_size         wolfSSL_EVP_MD_CTX_size
+#define EVP_MD_CTX_block_size   wolfSSL_EVP_MD_CTX_block_size
+#define EVP_MD_block_size       wolfSSL_EVP_MD_block_size
+#define EVP_MD_type             wolfSSL_EVP_MD_type
+#ifndef NO_WOLFSSL_STUB
+#define EVP_MD_CTX_set_flags(...) WC_DO_NOTHING
+#endif
+
+#define EVP_Digest             wolfSSL_EVP_Digest
+#define EVP_DigestInit         wolfSSL_EVP_DigestInit
+#define EVP_DigestInit_ex      wolfSSL_EVP_DigestInit_ex
+#define EVP_DigestUpdate       wolfSSL_EVP_DigestUpdate
+#define EVP_DigestFinal        wolfSSL_EVP_DigestFinal
+#define EVP_DigestFinal_ex     wolfSSL_EVP_DigestFinal_ex
+#define EVP_DigestSignInit     wolfSSL_EVP_DigestSignInit
+#define EVP_DigestSignUpdate   wolfSSL_EVP_DigestSignUpdate
+#define EVP_DigestSignFinal    wolfSSL_EVP_DigestSignFinal
+#define EVP_DigestVerifyInit   wolfSSL_EVP_DigestVerifyInit
+#define EVP_DigestVerifyUpdate wolfSSL_EVP_DigestVerifyUpdate
+#define EVP_DigestVerifyFinal  wolfSSL_EVP_DigestVerifyFinal
+#define EVP_BytesToKey         wolfSSL_EVP_BytesToKey
+
+#define EVP_get_cipherbyname wolfSSL_EVP_get_cipherbyname
+#define EVP_get_digestbyname wolfSSL_EVP_get_digestbyname
+
+#define EVP_CIPHER_CTX_init           wolfSSL_EVP_CIPHER_CTX_init
+#define EVP_CIPHER_CTX_cleanup        wolfSSL_EVP_CIPHER_CTX_cleanup
+#define EVP_CIPHER_CTX_iv_length      wolfSSL_EVP_CIPHER_CTX_iv_length
+#define EVP_CIPHER_CTX_nid            wolfSSL_EVP_CIPHER_CTX_nid
+#define EVP_CIPHER_CTX_key_length     wolfSSL_EVP_CIPHER_CTX_key_length
+#define EVP_CIPHER_CTX_set_key_length wolfSSL_EVP_CIPHER_CTX_set_key_length
+#define EVP_CIPHER_CTX_set_iv_length  wolfSSL_EVP_CIPHER_CTX_set_iv_length
+#define EVP_CIPHER_CTX_mode           wolfSSL_EVP_CIPHER_CTX_mode
+#define EVP_CIPHER_CTX_cipher         wolfSSL_EVP_CIPHER_CTX_cipher
+
+#define EVP_CIPHER_iv_length          wolfSSL_EVP_CIPHER_iv_length
+#define EVP_CIPHER_key_length         wolfSSL_EVP_Cipher_key_length
+
+#define EVP_CipherInit                wolfSSL_EVP_CipherInit
+#define EVP_CipherInit_ex             wolfSSL_EVP_CipherInit_ex
+#define EVP_EncryptInit               wolfSSL_EVP_EncryptInit
+#define EVP_EncryptInit_ex            wolfSSL_EVP_EncryptInit_ex
+#define EVP_DecryptInit               wolfSSL_EVP_DecryptInit
+#define EVP_DecryptInit_ex            wolfSSL_EVP_DecryptInit_ex
+
+#define EVP_Cipher                    wolfSSL_EVP_Cipher
+#define EVP_CipherUpdate              wolfSSL_EVP_CipherUpdate
+#define EVP_EncryptUpdate             wolfSSL_EVP_CipherUpdate
+#define EVP_DecryptUpdate             wolfSSL_EVP_CipherUpdate
+#define EVP_CipherFinal               wolfSSL_EVP_CipherFinal
+#define EVP_CipherFinal_ex            wolfSSL_EVP_CipherFinal
+#define EVP_EncryptFinal              wolfSSL_EVP_CipherFinal
+#define EVP_EncryptFinal_ex           wolfSSL_EVP_CipherFinal
+#define EVP_DecryptFinal              wolfSSL_EVP_CipherFinal
+#define EVP_DecryptFinal_ex           wolfSSL_EVP_CipherFinal
+
+#define EVP_CIPHER_CTX_free           wolfSSL_EVP_CIPHER_CTX_free
+#define EVP_CIPHER_CTX_reset          wolfSSL_EVP_CIPHER_CTX_reset
+#define EVP_CIPHER_CTX_new            wolfSSL_EVP_CIPHER_CTX_new
+
+#define EVP_get_cipherbynid           wolfSSL_EVP_get_cipherbynid
+#define EVP_get_digestbynid           wolfSSL_EVP_get_digestbynid
+#define EVP_MD_nid                    wolfSSL_EVP_MD_type
+
+#define EVP_PKEY_assign                wolfSSL_EVP_PKEY_assign
+#define EVP_PKEY_assign_RSA            wolfSSL_EVP_PKEY_assign_RSA
+#define EVP_PKEY_assign_DSA            wolfSSL_EVP_PKEY_assign_DSA
+#define EVP_PKEY_assign_DH             wolfSSL_EVP_PKEY_assign_DH
+#define EVP_PKEY_assign_EC_KEY         wolfSSL_EVP_PKEY_assign_EC_KEY
+#define EVP_PKEY_get1_DSA              wolfSSL_EVP_PKEY_get1_DSA
+#define EVP_PKEY_set1_DSA              wolfSSL_EVP_PKEY_set1_DSA
+#define EVP_PKEY_get0_RSA              wolfSSL_EVP_PKEY_get0_RSA
+#define EVP_PKEY_get1_RSA              wolfSSL_EVP_PKEY_get1_RSA
+#define EVP_PKEY_set1_RSA              wolfSSL_EVP_PKEY_set1_RSA
+#define EVP_PKEY_set1_EC_KEY           wolfSSL_EVP_PKEY_set1_EC_KEY
+#define EVP_PKEY_get1_EC_KEY           wolfSSL_EVP_PKEY_get1_EC_KEY
+#define EVP_PKEY_set1_DH               wolfSSL_EVP_PKEY_set1_DH
+#define EVP_PKEY_get0_DH               wolfSSL_EVP_PKEY_get0_DH
+#define EVP_PKEY_get1_DH               wolfSSL_EVP_PKEY_get1_DH
+#define EVP_PKEY_get0_EC_KEY           wolfSSL_EVP_PKEY_get0_EC_KEY
+#define EVP_PKEY_get0_hmac             wolfSSL_EVP_PKEY_get0_hmac
+#define EVP_PKEY_new_mac_key           wolfSSL_EVP_PKEY_new_mac_key
+#define EVP_PKEY_new_CMAC_key          wolfSSL_EVP_PKEY_new_CMAC_key
+#define EVP_MD_CTX_copy                wolfSSL_EVP_MD_CTX_copy
+#define EVP_MD_CTX_copy_ex             wolfSSL_EVP_MD_CTX_copy_ex
+#define EVP_PKEY_sign_init             wolfSSL_EVP_PKEY_sign_init
+#define EVP_PKEY_sign                  wolfSSL_EVP_PKEY_sign
+#define EVP_PKEY_verify_init           wolfSSL_EVP_PKEY_verify_init
+#define EVP_PKEY_verify                wolfSSL_EVP_PKEY_verify
+#define EVP_PKEY_paramgen_init         wolfSSL_EVP_PKEY_paramgen_init
+#define EVP_PKEY_CTX_set_ec_param_enc  wolfSSL_EVP_PKEY_CTX_set_ec_param_enc
+#define EVP_PKEY_CTX_set_ec_paramgen_curve_nid wolfSSL_EVP_PKEY_CTX_set_ec_paramgen_curve_nid
+#define EVP_PKEY_paramgen              wolfSSL_EVP_PKEY_paramgen
+#define EVP_PKEY_keygen                wolfSSL_EVP_PKEY_keygen
+#define EVP_PKEY_keygen_init           wolfSSL_EVP_PKEY_keygen_init
+#define EVP_PKEY_bits                  wolfSSL_EVP_PKEY_bits
+#define EVP_PKEY_CTX_free              wolfSSL_EVP_PKEY_CTX_free
+#define EVP_PKEY_CTX_new               wolfSSL_EVP_PKEY_CTX_new
+#define EVP_PKEY_CTX_set_rsa_padding   wolfSSL_EVP_PKEY_CTX_set_rsa_padding
+#define EVP_PKEY_CTX_set_signature_md  wolfSSL_EVP_PKEY_CTX_set_signature_md
+#define EVP_PKEY_CTX_new_id            wolfSSL_EVP_PKEY_CTX_new_id
+#define EVP_PKEY_CTX_set_rsa_keygen_bits wolfSSL_EVP_PKEY_CTX_set_rsa_keygen_bits
+#define EVP_PKEY_derive_init           wolfSSL_EVP_PKEY_derive_init
+#define EVP_PKEY_derive_set_peer       wolfSSL_EVP_PKEY_derive_set_peer
+#define EVP_PKEY_derive                wolfSSL_EVP_PKEY_derive
+#define EVP_PKEY_decrypt               wolfSSL_EVP_PKEY_decrypt
+#define EVP_PKEY_decrypt_init          wolfSSL_EVP_PKEY_decrypt_init
+#define EVP_PKEY_encrypt               wolfSSL_EVP_PKEY_encrypt
+#define EVP_PKEY_encrypt_init          wolfSSL_EVP_PKEY_encrypt_init
+#define EVP_PKEY_new                   wolfSSL_EVP_PKEY_new
+#define EVP_PKEY_free                  wolfSSL_EVP_PKEY_free
+#define EVP_PKEY_up_ref                wolfSSL_EVP_PKEY_up_ref
+#define EVP_PKEY_size                  wolfSSL_EVP_PKEY_size
+#define EVP_PKEY_copy_parameters       wolfSSL_EVP_PKEY_copy_parameters
+#define EVP_PKEY_missing_parameters    wolfSSL_EVP_PKEY_missing_parameters
+#define EVP_PKEY_cmp                   wolfSSL_EVP_PKEY_cmp
+#define EVP_PKEY_type                  wolfSSL_EVP_PKEY_type
+#define EVP_PKEY_base_id               wolfSSL_EVP_PKEY_base_id
+#define EVP_PKEY_get_default_digest_nid wolfSSL_EVP_PKEY_get_default_digest_nid
+#define EVP_PKEY_id                    wolfSSL_EVP_PKEY_id
+#define EVP_PKEY_CTX_ctrl_str          wolfSSL_EVP_PKEY_CTX_ctrl_str
+#define EVP_PKCS82PKEY                 wolfSSL_EVP_PKCS82PKEY
+#define EVP_PKEY2PKCS8                 wolfSSL_EVP_PKEY2PKCS8
+#define EVP_SignFinal                  wolfSSL_EVP_SignFinal
+#define EVP_SignInit                   wolfSSL_EVP_SignInit
+#define EVP_SignInit_ex                wolfSSL_EVP_SignInit_ex
+#define EVP_SignUpdate                 wolfSSL_EVP_SignUpdate
+#define EVP_VerifyFinal                wolfSSL_EVP_VerifyFinal
+#define EVP_VerifyInit                 wolfSSL_EVP_VerifyInit
+#define EVP_VerifyUpdate               wolfSSL_EVP_VerifyUpdate
+
+#define EVP_CIPHER_CTX_ctrl        wolfSSL_EVP_CIPHER_CTX_ctrl
+#define EVP_CIPHER_CTX_block_size  wolfSSL_EVP_CIPHER_CTX_block_size
+#define EVP_CIPHER_block_size      wolfSSL_EVP_CIPHER_block_size
+#define EVP_CIPHER_flags           wolfSSL_EVP_CIPHER_flags
+#define EVP_CIPHER_CTX_set_flags   wolfSSL_EVP_CIPHER_CTX_set_flags
+#define EVP_CIPHER_CTX_clear_flags wolfSSL_EVP_CIPHER_CTX_clear_flags
+#define EVP_CIPHER_CTX_set_padding wolfSSL_EVP_CIPHER_CTX_set_padding
+#define EVP_CIPHER_CTX_flags       wolfSSL_EVP_CIPHER_CTX_flags
+#define EVP_CIPHER_CTX_set_iv      wolfSSL_EVP_CIPHER_CTX_set_iv
+#define EVP_CIPHER_CTX_get_iv      wolfSSL_EVP_CIPHER_CTX_get_iv
+#define EVP_add_digest             wolfSSL_EVP_add_digest
+#define EVP_add_cipher             wolfSSL_EVP_add_cipher
+#define EVP_cleanup                wolfSSL_EVP_cleanup
+#define EVP_read_pw_string         wolfSSL_EVP_read_pw_string
+#define EVP_rc2_cbc                wolfSSL_EVP_rc2_cbc
+
+#define OpenSSL_add_all_digests()  wolfSSL_EVP_init()
+#define OpenSSL_add_all_ciphers()  wolfSSL_EVP_init()
+#define OpenSSL_add_all_algorithms wolfSSL_add_all_algorithms
+#define OpenSSL_add_all_algorithms_noconf wolfSSL_OpenSSL_add_all_algorithms_noconf
+#define OpenSSL_add_all_algorithms_conf   wolfSSL_OpenSSL_add_all_algorithms_conf
+
+#define wolfSSL_OPENSSL_add_all_algorithms_noconf wolfSSL_OpenSSL_add_all_algorithms_noconf
+#define wolfSSL_OPENSSL_add_all_algorithms_conf   wolfSSL_OpenSSL_add_all_algorithms_conf
+
+/* provides older OpenSSL API compatibility  */
+#define OPENSSL_add_all_algorithms        OpenSSL_add_all_algorithms
+#define OPENSSL_add_all_algorithms_noconf OpenSSL_add_all_algorithms_noconf
+#define OPENSSL_add_all_algorithms_conf   OpenSSL_add_all_algorithms_conf
+
+#define NO_PADDING_BLOCK_SIZE      1
+
+#define PKCS5_PBKDF2_HMAC_SHA1     wolfSSL_PKCS5_PBKDF2_HMAC_SHA1
+#define PKCS5_PBKDF2_HMAC          wolfSSL_PKCS5_PBKDF2_HMAC
+#define EVP_PBE_scrypt             wolfSSL_EVP_PBE_scrypt
+
+/* OpenSSL compat. ctrl values */
+#define EVP_CTRL_INIT                  0x0
+#define EVP_CTRL_SET_KEY_LENGTH        0x1
+#define EVP_CTRL_SET_RC2_KEY_BITS      0x3  /* needed for qt compilation */
+
+#define EVP_CTRL_AEAD_SET_IVLEN        0x9
+#define EVP_CTRL_AEAD_GET_TAG          0x10
+#define EVP_CTRL_AEAD_SET_TAG          0x11
+#define EVP_CTRL_AEAD_SET_IV_FIXED     0x12
+#define EVP_CTRL_GCM_IV_GEN            0x13
+#define EVP_CTRL_GCM_SET_IVLEN         EVP_CTRL_AEAD_SET_IVLEN
+#define EVP_CTRL_GCM_GET_TAG           EVP_CTRL_AEAD_GET_TAG
+#define EVP_CTRL_GCM_SET_TAG           EVP_CTRL_AEAD_SET_TAG
+#define EVP_CTRL_GCM_SET_IV_FIXED      EVP_CTRL_AEAD_SET_IV_FIXED
+#define EVP_CTRL_CCM_SET_IVLEN         EVP_CTRL_AEAD_SET_IVLEN
+#define EVP_CTRL_CCM_GET_TAG           EVP_CTRL_AEAD_GET_TAG
+#define EVP_CTRL_CCM_SET_TAG           EVP_CTRL_AEAD_SET_TAG
+#define EVP_CTRL_CCM_SET_L             0x14
+#define EVP_CTRL_CCM_SET_MSGLEN        0x15
+
+#define EVP_PKEY_print_public           wolfSSL_EVP_PKEY_print_public
+#define EVP_PKEY_print_private(arg1, arg2, arg3, arg4) WC_DO_NOTHING
+
+#ifndef EVP_MAX_MD_SIZE
+    #define EVP_MAX_MD_SIZE   64     /* sha512 */
+#endif
+
+#ifndef EVP_MAX_KEY_LENGTH
+#define EVP_MAX_KEY_LENGTH    64
+#endif
+
+#ifndef EVP_MAX_IV_LENGTH
+#define EVP_MAX_IV_LENGTH     16
+#endif
+
+#ifndef EVP_MAX_BLOCK_LENGTH
+    #define EVP_MAX_BLOCK_LENGTH   32  /* 2 * blocklen(AES)? */
+    /* They define this as 32. Using the same value here. */
+#endif
+
+#ifndef EVP_MAX_IV_LENGTH
+    #define EVP_MAX_IV_LENGTH       16
+#endif
+
+
+#define EVP_R_BAD_DECRYPT               (-MIN_CODE_E + 100 + 1)
+#define EVP_R_BN_DECODE_ERROR           (-MIN_CODE_E + 100 + 2)
+#define EVP_R_DECODE_ERROR              (-MIN_CODE_E + 100 + 3)
+#define EVP_R_PRIVATE_KEY_DECODE_ERROR  (-MIN_CODE_E + 100 + 4)
+
+#define EVP_PKEY_NONE                   NID_undef
+#define EVP_PKEY_DH                     28
+#define EVP_CIPHER_mode                 WOLFSSL_EVP_CIPHER_mode
+/* WOLFSSL_EVP_CIPHER is just the string name of the cipher */
+#define EVP_CIPHER_name(x)              x
+#define EVP_MD_CTX_reset                wolfSSL_EVP_MD_CTX_cleanup
+/* WOLFSSL_EVP_MD is just the string name of the digest */
+#define EVP_MD_name(x)                  x
+#define EVP_CIPHER_nid                  wolfSSL_EVP_CIPHER_nid
+
+/* Base64 encoding/decoding APIs */
+#if defined(WOLFSSL_BASE64_ENCODE) || defined(WOLFSSL_BASE64_DECODE)
+#define EVP_ENCODE_CTX       WOLFSSL_EVP_ENCODE_CTX
+#define EVP_ENCODE_CTX_new   wolfSSL_EVP_ENCODE_CTX_new
+#define EVP_ENCODE_CTX_free  wolfSSL_EVP_ENCODE_CTX_free
+#endif /* WOLFSSL_BASE64_ENCODE || WOLFSSL_BASE64_DECODE*/
+#if defined(WOLFSSL_BASE64_ENCODE)
+#define EVP_EncodeInit       wolfSSL_EVP_EncodeInit
+#define EVP_EncodeUpdate     wolfSSL_EVP_EncodeUpdate
+#define EVP_EncodeFinal      wolfSSL_EVP_EncodeFinal
+#define EVP_EncodeBlock      wolfSSL_EVP_EncodeBlock
+#define EVP_DecodeBlock      wolfSSL_EVP_DecodeBlock
+#endif /* WOLFSSL_BASE64_ENCODE */
+#if defined(WOLFSSL_BASE64_DECODE)
+#define EVP_DecodeInit       wolfSSL_EVP_DecodeInit
+#define EVP_DecodeUpdate     wolfSSL_EVP_DecodeUpdate
+#define EVP_DecodeFinal      wolfSSL_EVP_DecodeFinal
+#endif /* WOLFSSL_BASE64_DECODE */
+
+#define EVP_blake2b512       wolfSSL_EVP_blake2b512
+#define EVP_blake2s256       wolfSSL_EVP_blake2s256
+#define EVP_MD_do_all        wolfSSL_EVP_MD_do_all
+
+#ifdef HAVE_HKDF
+#define EVP_PKEY_CTX_set_hkdf_md    wolfSSL_EVP_PKEY_CTX_set_hkdf_md
+#define EVP_PKEY_CTX_set1_hkdf_salt wolfSSL_EVP_PKEY_CTX_set1_hkdf_salt
+#define EVP_PKEY_CTX_set1_hkdf_key  wolfSSL_EVP_PKEY_CTX_set1_hkdf_key
+#define EVP_PKEY_CTX_add1_hkdf_info wolfSSL_EVP_PKEY_CTX_add1_hkdf_info
+#define EVP_PKEY_CTX_hkdf_mode      wolfSSL_EVP_PKEY_CTX_hkdf_mode
+#endif
+
+WOLFSSL_API void printPKEY(WOLFSSL_EVP_PKEY *k);
+
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+
+#include <wolfssl/openssl/objects.h>
+
+#endif /* WOLFSSL_EVP_H_ */

--- a/include/wolfssl/openssl/evp.h
+++ b/include/wolfssl/openssl/evp.h
@@ -401,6 +401,7 @@ typedef union {
 
 #define NID_X9_62_id_ecPublicKey EVP_PKEY_EC
 #define NID_rsaEncryption        EVP_PKEY_RSA
+#define NID_rsa                  EVP_PKEY_RSA
 #define NID_dsa                  EVP_PKEY_DSA
 
 #define EVP_PKEY_OP_SIGN    (1 << 3)

--- a/include/wolfssl/openssl/fips_rand.h
+++ b/include/wolfssl/openssl/fips_rand.h
@@ -1,0 +1,125 @@
+/* fips_rand.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* fips_rand.h for openSSL compatibility */
+
+#ifndef WOLFSSL_OPENSSL_FIPS_RAND_H_
+#define WOLFSSL_OPENSSL_FIPS_RAND_H_
+
+#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/wolfcrypt/random.h>
+
+#if !defined(WC_NO_RNG) && defined(HAVE_HASHDRBG)
+
+struct WOLFSSL_DRBG_CTX;
+
+typedef size_t (*drbg_entropy_get)(struct WOLFSSL_DRBG_CTX* ctx, unsigned char** pout,
+                                  int entropy, size_t min_len, size_t max_len);
+typedef void   (*drbg_entropy_clean)(struct WOLFSSL_DRBG_CTX* ctx, unsigned char* out,
+                                    size_t olen);
+typedef size_t (*drbg_nonce_get)(struct WOLFSSL_DRBG_CTX* ctx, unsigned char** pout,
+                                int entropy, size_t min_len, size_t max_len);
+typedef void   (*drbg_nonce_clean)(struct WOLFSSL_DRBG_CTX* ctx, unsigned char* out,
+                                  size_t olen);
+
+typedef struct WOLFSSL_DRBG_CTX {
+    WC_RNG* rng;
+    drbg_entropy_get entropy_get;
+    drbg_entropy_clean entropy_clean;
+    size_t entropy_blocklen;
+    drbg_nonce_get none_get;
+    drbg_nonce_clean nonce_clean;
+
+    int type;
+    int status;
+    int xflags;
+    void* app_data;
+} WOLFSSL_DRBG_CTX;
+
+#define DRBG_FLAG_CTR_USE_DF 0x1
+#define DRBG_FLAG_TEST       0x2
+
+#define DRBG_FLAG_NOERR      0x1
+#define DRBG_CUSTOM_RESEED   0x2
+
+#define DRBG_STATUS_UNINITIALISED 0
+#define DRBG_STATUS_READY         1
+#define DRBG_STATUS_RESEED        2
+#define DRBG_STATUS_ERROR         3
+
+WOLFSSL_API WOLFSSL_DRBG_CTX* wolfSSL_FIPS_drbg_new(int type,
+    unsigned int flags);
+
+WOLFSSL_API int wolfSSL_FIPS_drbg_init(WOLFSSL_DRBG_CTX *ctx,
+    int type, unsigned int flags);
+
+WOLFSSL_API int  wolfSSL_FIPS_drbg_instantiate(WOLFSSL_DRBG_CTX* ctx,
+    const unsigned char* pers, size_t perslen);
+
+WOLFSSL_API int  wolfSSL_FIPS_drbg_set_callbacks(WOLFSSL_DRBG_CTX* ctx,
+    drbg_entropy_get entropy_get, drbg_entropy_clean entropy_clean,
+    size_t entropy_blocklen,
+    drbg_nonce_get none_get, drbg_nonce_clean nonce_clean);
+
+WOLFSSL_API void wolfSSL_FIPS_rand_add(const void* buf, int num,
+    double entropy);
+WOLFSSL_API int  wolfSSL_FIPS_drbg_reseed(WOLFSSL_DRBG_CTX* ctx,
+    const unsigned char* adin, size_t adinlen);
+
+WOLFSSL_API int  wolfSSL_FIPS_drbg_generate(WOLFSSL_DRBG_CTX* ctx,
+    unsigned char* out, size_t outlen, int prediction_resistance,
+    const unsigned char* adin, size_t adinlen);
+
+WOLFSSL_API int  wolfSSL_FIPS_drbg_uninstantiate(WOLFSSL_DRBG_CTX *ctx);
+
+WOLFSSL_API void wolfSSL_FIPS_drbg_free(WOLFSSL_DRBG_CTX *ctx);
+
+WOLFSSL_API WOLFSSL_DRBG_CTX* wolfSSL_FIPS_get_default_drbg(void);
+
+WOLFSSL_API void wolfSSL_FIPS_get_timevec(unsigned char* buf,
+    unsigned long* pctr);
+
+WOLFSSL_API void* wolfSSL_FIPS_drbg_get_app_data(WOLFSSL_DRBG_CTX *ctx);
+
+WOLFSSL_API void  wolfSSL_FIPS_drbg_set_app_data(WOLFSSL_DRBG_CTX *ctx,
+    void *app_data);
+
+
+/* compatibility mapping */
+typedef WOLFSSL_DRBG_CTX DRBG_CTX;
+
+#define FIPS_drbg_init           wolfSSL_FIPS_drbg_init
+#define FIPS_drbg_new            wolfSSL_FIPS_drbg_new
+#define FIPS_drbg_instantiate    wolfSSL_FIPS_drbg_instantiate
+#define FIPS_drbg_set_callbacks  wolfSSL_FIPS_drbg_set_callbacks
+#define FIPS_rand_add            wolfSSL_FIPS_rand_add
+#define FIPS_drbg_reseed         wolfSSL_FIPS_drbg_reseed
+#define FIPS_drbg_generate       wolfSSL_FIPS_drbg_generate
+#define FIPS_drbg_uninstantiate  wolfSSL_FIPS_drbg_uninstantiate
+#define FIPS_drbg_free           wolfSSL_FIPS_drbg_free
+#define FIPS_get_default_drbg    wolfSSL_FIPS_get_default_drbg
+#define FIPS_get_timevec         wolfSSL_FIPS_get_timevec
+#define FIPS_drbg_get_app_data   wolfSSL_FIPS_drbg_get_app_data
+#define FIPS_drbg_set_app_data   wolfSSL_FIPS_drbg_set_app_data
+
+#endif /* !WC_NO_RNG && HAVE_HASHDRBG */
+
+#endif /* WOLFSSL_OPENSSL_FIPS_RAND_H_ */

--- a/include/wolfssl/openssl/hmac.h
+++ b/include/wolfssl/openssl/hmac.h
@@ -1,0 +1,94 @@
+/* hmac.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+
+/*  hmac.h defines mini hmac openssl compatibility layer
+ *
+ */
+
+
+#ifndef WOLFSSL_HMAC_H_
+#define WOLFSSL_HMAC_H_
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef WOLFSSL_PREFIX
+#include "prefix_hmac.h"
+#endif
+
+#include <wolfssl/openssl/compat_types.h>
+#include <wolfssl/openssl/opensslv.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+
+WOLFSSL_API unsigned char* wolfSSL_HMAC(const WOLFSSL_EVP_MD* evp_md,
+                               const void* key, int key_len,
+                               const unsigned char* d, int n, unsigned char* md,
+                               unsigned int* md_len);
+
+WOLFSSL_API WOLFSSL_HMAC_CTX* wolfSSL_HMAC_CTX_new(void);
+WOLFSSL_API int wolfSSL_HMAC_CTX_Init(WOLFSSL_HMAC_CTX* ctx);
+WOLFSSL_API int wolfSSL_HMAC_CTX_copy(WOLFSSL_HMAC_CTX* des,
+                                       WOLFSSL_HMAC_CTX* src);
+WOLFSSL_LOCAL int wolfSSL_HmacCopy(Hmac* des, Hmac* src);
+WOLFSSL_API int wolfSSL_HMAC_Init(WOLFSSL_HMAC_CTX* ctx, const void* key,
+                                 int keylen, const WOLFSSL_EVP_MD* type);
+WOLFSSL_API int wolfSSL_HMAC_Init_ex(WOLFSSL_HMAC_CTX* ctx, const void* key,
+                             int keylen, const WOLFSSL_EVP_MD* type, WOLFSSL_ENGINE* e);
+WOLFSSL_API int wolfSSL_HMAC_Update(WOLFSSL_HMAC_CTX* ctx,
+                                   const unsigned char* data, int len);
+WOLFSSL_API int wolfSSL_HMAC_Final(WOLFSSL_HMAC_CTX* ctx, unsigned char* hash,
+                                  unsigned int* len);
+WOLFSSL_API int wolfSSL_HMAC_cleanup(WOLFSSL_HMAC_CTX* ctx);
+WOLFSSL_API void wolfSSL_HMAC_CTX_cleanup(WOLFSSL_HMAC_CTX* ctx);
+WOLFSSL_API void wolfSSL_HMAC_CTX_free(WOLFSSL_HMAC_CTX* ctx);
+WOLFSSL_API size_t wolfSSL_HMAC_size(const WOLFSSL_HMAC_CTX *ctx);
+WOLFSSL_API const WOLFSSL_EVP_MD *wolfSSL_HMAC_CTX_get_md(const WOLFSSL_HMAC_CTX *ctx);
+
+typedef struct WOLFSSL_HMAC_CTX HMAC_CTX;
+
+#define HMAC(a,b,c,d,e,f,g) wolfSSL_HMAC((a),(b),(c),(d),(e),(f),(g))
+
+#define HMAC_CTX_new wolfSSL_HMAC_CTX_new
+#define HMAC_CTX_init wolfSSL_HMAC_CTX_Init
+#define HMAC_CTX_copy wolfSSL_HMAC_CTX_copy
+#define HMAC_CTX_free wolfSSL_HMAC_CTX_free
+#define HMAC_CTX_cleanup wolfSSL_HMAC_CTX_cleanup
+#define HMAC_CTX_reset wolfSSL_HMAC_cleanup
+#define HMAC_Init_ex  wolfSSL_HMAC_Init_ex
+#define HMAC_Init     wolfSSL_HMAC_Init
+#define HMAC_Update   wolfSSL_HMAC_Update
+#define HMAC_Final    wolfSSL_HMAC_Final
+#define HMAC_cleanup  wolfSSL_HMAC_cleanup
+#define HMAC_size     wolfSSL_HMAC_size
+#define HMAC_CTX_get_md wolfSSL_HMAC_CTX_get_md
+
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+
+
+#endif /* WOLFSSL_HMAC_H_ */

--- a/include/wolfssl/openssl/hmac.h
+++ b/include/wolfssl/openssl/hmac.h
@@ -45,7 +45,7 @@
 
 WOLFSSL_API unsigned char* wolfSSL_HMAC(const WOLFSSL_EVP_MD* evp_md,
                                const void* key, int key_len,
-                               const unsigned char* d, int n, unsigned char* md,
+                               const unsigned char* d, size_t n, unsigned char* md,
                                unsigned int* md_len);
 
 WOLFSSL_API WOLFSSL_HMAC_CTX* wolfSSL_HMAC_CTX_new(void);
@@ -69,7 +69,7 @@ WOLFSSL_API const WOLFSSL_EVP_MD *wolfSSL_HMAC_CTX_get_md(const WOLFSSL_HMAC_CTX
 
 typedef struct WOLFSSL_HMAC_CTX HMAC_CTX;
 
-#define HMAC(a,b,c,d,e,f,g) wolfSSL_HMAC((a),(b),(c),(d),(e),(f),(g))
+#define HMAC wolfSSL_HMAC
 
 #define HMAC_CTX_new wolfSSL_HMAC_CTX_new
 #define HMAC_CTX_init wolfSSL_HMAC_CTX_Init

--- a/include/wolfssl/openssl/kdf.h
+++ b/include/wolfssl/openssl/kdf.h
@@ -1,0 +1,37 @@
+/* kdf.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef WOLFSSL_KDF_H_
+#define WOLFSSL_KDF_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#define EVP_PKEY_HKDEF_MODE_EXTRACT_AND_EXPAND 0
+#define EVP_PKEY_HKDEF_MODE_EXTRACT_ONLY 1
+#define EVP_PKEY_HKDEF_MODE_EXPAND_ONLY 2
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_KDF_H_ */

--- a/include/wolfssl/openssl/lhash.h
+++ b/include/wolfssl/openssl/lhash.h
@@ -1,0 +1,64 @@
+/* lhash.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* lhash.h for openSSL */
+
+#ifndef WOLFSSL_lhash_H_
+#define WOLFSSL_lhash_H_
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#include <wolfssl/openssl/ssl.h>
+
+#ifdef OPENSSL_ALL
+#define IMPLEMENT_LHASH_HASH_FN(name, type) \
+    unsigned long wolfSSL_##name##_LHASH_HASH(const void *arg) \
+    {                                                          \
+        const type *a = arg;                                 \
+        return name##_hash(a);                                 \
+    }
+#define IMPLEMENT_LHASH_COMP_FN(name, type) \
+    int wolfSSL_##name##_LHASH_COMP(const void *p1, const void *p2) \
+    {                                                               \
+        const type *_p1 = p1;                                       \
+        const type *_p2 = p2;                                       \
+        return name##_cmp(_p1, _p2);                                \
+    }
+
+#define LHASH_HASH_FN(name) wolfSSL_##name##_LHASH_HASH
+#define LHASH_COMP_FN(name) wolfSSL_##name##_LHASH_COMP
+
+WOLFSSL_API unsigned long wolfSSL_LH_strhash(const char *str);
+
+WOLFSSL_API void *wolfSSL_lh_retrieve(WOLFSSL_STACK *sk, void *data);
+
+#define lh_strhash          wolfSSL_LH_strhash
+
+#endif
+
+
+#ifdef  __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_lhash_H_ */

--- a/include/wolfssl/openssl/modes.h
+++ b/include/wolfssl/openssl/modes.h
@@ -1,0 +1,45 @@
+/* modes.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+#ifndef WOLFSSL_OPENSSL_MODES_H
+#define WOLFSSL_OPENSSL_MODES_H
+
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/openssl/ssl.h>
+
+typedef void (*WOLFSSL_CBC128_CB) (const unsigned char *in,
+        unsigned char *out, size_t len, const void *key,
+        unsigned char *iv, int enc);
+
+WOLFSSL_API size_t wolfSSL_CRYPTO_cts128_encrypt(const unsigned char *in,
+        unsigned char *out, size_t len, const void *key,
+        unsigned char *iv, WOLFSSL_CBC128_CB cbc);
+WOLFSSL_API size_t wolfSSL_CRYPTO_cts128_decrypt(const unsigned char *in,
+        unsigned char *out, size_t len, const void *key,
+        unsigned char *iv, WOLFSSL_CBC128_CB cbc);
+
+#define WOLFSSL_CTS128_BLOCK_SZ         16
+
+/* Compatibility layer defines */
+#define CRYPTO_cts128_encrypt           wolfSSL_CRYPTO_cts128_encrypt
+#define CRYPTO_cts128_decrypt           wolfSSL_CRYPTO_cts128_decrypt
+#define cbc128_f                        WOLFSSL_CBC128_CB
+
+#endif /* WOLFSSL_OPENSSL_MODES_H */

--- a/include/wolfssl/openssl/objects.h
+++ b/include/wolfssl/openssl/objects.h
@@ -1,0 +1,78 @@
+/* objects.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#ifndef WOLFSSL_OBJECTS_H_
+#define WOLFSSL_OBJECTS_H_
+
+#include <wolfssl/wolfcrypt/types.h>
+#ifndef OPENSSL_EXTRA_SSL_GUARD
+#define OPENSSL_EXTRA_SSL_GUARD
+#include <wolfssl/ssl.h>
+#endif /* OPENSSL_EXTRA_SSL_GUARD */
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+
+#define OBJ_NAME_TYPE_UNDEF     WOLFSSL_OBJ_NAME_TYPE_UNDEF
+#define OBJ_NAME_TYPE_MD_METH   WOLFSSL_OBJ_NAME_TYPE_MD_METH
+#define OBJ_NAME_TYPE_CIPHER_METH   WOLFSSL_OBJ_NAME_TYPE_CIPHER_METH
+#define OBJ_NAME_TYPE_PKEY_METH     WOLFSSL_OBJ_NAME_TYPE_PKEY_METH
+#define OBJ_NAME_TYPE_COMP_METH     WOLFSSL_OBJ_NAME_TYPE_COMP_METH
+#define OBJ_NAME_TYPE_NUM           WOLFSSL_OBJ_NAME_TYPE_NUM
+#define OBJ_NAME_ALIAS              WOLFSSL_OBJ_NAME_ALIAS
+
+#define OBJ_nid2sn       wolfSSL_OBJ_nid2sn
+#define OBJ_obj2nid      wolfSSL_OBJ_obj2nid
+#define OBJ_sn2nid       wolfSSL_OBJ_sn2nid
+#define OBJ_length       wolfSSL_OBJ_length
+#define OBJ_get0_data    wolfSSL_OBJ_get0_data
+#define OBJ_nid2ln       wolfSSL_OBJ_nid2ln
+#define OBJ_ln2nid       wolfSSL_OBJ_ln2nid
+#define OBJ_txt2nid      wolfSSL_OBJ_txt2nid
+#define OBJ_txt2obj      wolfSSL_OBJ_txt2obj
+#define OBJ_nid2obj      wolfSSL_OBJ_nid2obj
+#define OBJ_obj2txt      wolfSSL_OBJ_obj2txt
+#define OBJ_cleanup      wolfSSL_OBJ_cleanup
+#define OBJ_cmp          wolfSSL_OBJ_cmp
+#define OBJ_create       wolfSSL_OBJ_create
+#define ASN1_OBJECT_free wolfSSL_ASN1_OBJECT_free
+#define OBJ_NAME_do_all  wolfSSL_OBJ_NAME_do_all
+#define i2t_ASN1_OBJECT  wolfSSL_i2t_ASN1_OBJECT
+
+/* not required for wolfSSL */
+#define OPENSSL_load_builtin_modules() WC_DO_NOTHING
+
+
+#define NID_ad_OCSP                     178
+#define NID_ad_ca_issuers               179
+
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_OBJECTS_H_ */

--- a/include/wolfssl/openssl/opensslv.h
+++ b/include/wolfssl/openssl/opensslv.h
@@ -25,10 +25,10 @@
 #define WOLFSSL_OPENSSLV_H_
 
 #include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/version.h>
 
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 
-#ifndef OPENSSL_VERSION_NUMBER
 /* api version compatibility */
 #if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x009070dfL) ||\
     defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x0090810fL) ||\
@@ -54,11 +54,8 @@
 #else
      #define OPENSSL_VERSION_NUMBER 0x0090810fL
 #endif
-#endif
 
-#ifndef OPENSSL_VERSION_TEXT
 #define OPENSSL_VERSION_TEXT             "wolfSSL " LIBWOLFSSL_VERSION_STRING
-#endif
 #define OPENSSL_VERSION                  0
 
 #ifndef OPENSSL_IS_WOLFSSL

--- a/include/wolfssl/openssl/opensslv.h
+++ b/include/wolfssl/openssl/opensslv.h
@@ -1,0 +1,70 @@
+/* opensslv.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* opensslv.h compatibility */
+
+#ifndef WOLFSSL_OPENSSLV_H_
+#define WOLFSSL_OPENSSLV_H_
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+
+#ifndef OPENSSL_VERSION_NUMBER
+/* api version compatibility */
+#if defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x009070dfL) ||\
+    defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x0090810fL) ||\
+    defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x10100000L) ||\
+    defined(OPENSSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x10001040L)
+     /* valid version */
+#elif defined(WOLFSSL_APACHE_HTTPD) || defined(HAVE_LIBEST) || \
+      defined(WOLFSSL_BIND) || defined(WOLFSSL_NGINX) || \
+      defined(WOLFSSL_RSYSLOG) || defined(WOLFSSL_KRB) || defined(HAVE_STUNNEL) || \
+      defined(WOLFSSL_OPENSSH)
+    /* For Apache httpd, Use 1.1.0 compatibility */
+     #define OPENSSL_VERSION_NUMBER 0x10100003L
+#elif defined(WOLFSSL_QT) || defined(WOLFSSL_PYTHON) || defined(WOLFSSL_KRB)
+    /* For Qt and Python 3.8.5 compatibility */
+     #define OPENSSL_VERSION_NUMBER 0x10101000L
+#elif defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_FFMPEG)
+     #define OPENSSL_VERSION_NUMBER 0x1010000fL
+#elif defined(OPENSSL_ALL) || defined(HAVE_LIGHTY) || \
+    defined(WOLFSSL_NGINX) || defined(WOLFSSL_OPENVPN)
+     /* version number can be increased for Lighty after compatibility for ECDH
+        is added */
+     #define OPENSSL_VERSION_NUMBER 0x10001040L
+#else
+     #define OPENSSL_VERSION_NUMBER 0x0090810fL
+#endif
+#endif
+
+#ifndef OPENSSL_VERSION_TEXT
+#define OPENSSL_VERSION_TEXT             "wolfSSL " LIBWOLFSSL_VERSION_STRING
+#endif
+#define OPENSSL_VERSION                  0
+
+#ifndef OPENSSL_IS_WOLFSSL
+#define OPENSSL_IS_WOLFSSL
+#endif
+
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+#endif /* header */

--- a/include/wolfssl/openssl/pem.h
+++ b/include/wolfssl/openssl/pem.h
@@ -1,0 +1,280 @@
+/* pem.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* pem.h for openssl */
+
+/*!
+    \file wolfssl/openssl/pem.h
+*/
+
+
+#ifndef WOLFSSL_PEM_H_
+#define WOLFSSL_PEM_H_
+
+#include <wolfssl/openssl/evp.h>
+#include <wolfssl/openssl/bio.h>
+#include <wolfssl/openssl/rsa.h>
+#include <wolfssl/openssl/dsa.h>
+#include <wolfssl/ssl.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+/* RSA */
+WOLFSSL_API
+int wolfSSL_PEM_write_bio_RSAPrivateKey(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa,
+                                        const WOLFSSL_EVP_CIPHER* cipher,
+                                        unsigned char* passwd, int len,
+                                        wc_pem_password_cb* cb, void* arg);
+WOLFSSL_API
+WOLFSSL_RSA* wolfSSL_PEM_read_bio_RSAPrivateKey(WOLFSSL_BIO* bio,
+        WOLFSSL_RSA** rsa, wc_pem_password_cb* cb, void* pass);
+
+WOLFSSL_API
+int wolfSSL_PEM_write_bio_RSA_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa);
+
+WOLFSSL_API
+WOLFSSL_RSA *wolfSSL_PEM_read_bio_RSA_PUBKEY(WOLFSSL_BIO* bio,
+                                             WOLFSSL_RSA** rsa,
+                                             wc_pem_password_cb* cb, void *u);
+
+WOLFSSL_API
+WOLFSSL_EC_GROUP* wolfSSL_PEM_read_bio_ECPKParameters(WOLFSSL_BIO* bio,
+                                                      WOLFSSL_EC_GROUP** group,
+                                                      wc_pem_password_cb* cb,
+                                                      void* pass);
+WOLFSSL_API
+int wolfSSL_PEM_write_mem_RSAPrivateKey(WOLFSSL_RSA* rsa,
+                                        const WOLFSSL_EVP_CIPHER* cipher,
+                                        unsigned char* passwd, int len,
+                                        unsigned char **pem, int *plen);
+#if !defined(NO_FILESYSTEM)
+WOLFSSL_API
+int wolfSSL_PEM_write_RSAPrivateKey(XFILE fp, WOLFSSL_RSA *rsa,
+                                    const WOLFSSL_EVP_CIPHER *enc,
+                                    unsigned char *kstr, int klen,
+                                    wc_pem_password_cb *cb, void *u);
+
+WOLFSSL_API
+WOLFSSL_RSA* wolfSSL_PEM_read_RSAPrivateKey(XFILE fp, WOLFSSL_RSA** rsa,
+                                            wc_pem_password_cb* cb, void* pass);
+
+WOLFSSL_API
+WOLFSSL_RSA *wolfSSL_PEM_read_RSAPublicKey(XFILE fp, WOLFSSL_RSA **x,
+                                           wc_pem_password_cb *cb, void *u);
+WOLFSSL_API
+int wolfSSL_PEM_write_RSAPublicKey(XFILE fp, WOLFSSL_RSA* key);
+
+WOLFSSL_API
+int wolfSSL_PEM_write_RSA_PUBKEY(XFILE fp, WOLFSSL_RSA *x);
+
+WOLFSSL_API
+WOLFSSL_RSA *wolfSSL_PEM_read_RSA_PUBKEY(XFILE fp, WOLFSSL_RSA** rsa,
+                                         wc_pem_password_cb* cb, void *pass);
+#endif /* NO_FILESYSTEM */
+
+/* DSA */
+WOLFSSL_API
+int wolfSSL_PEM_write_bio_DSAPrivateKey(WOLFSSL_BIO* bio,
+                                        WOLFSSL_DSA* dsa,
+                                        const WOLFSSL_EVP_CIPHER* cipher,
+                                        unsigned char* passwd, int len,
+                                        wc_pem_password_cb* cb, void* arg);
+
+WOLFSSL_API
+WOLFSSL_DSA* wolfSSL_PEM_read_bio_DSAPrivateKey(WOLFSSL_BIO* bio,
+                                                WOLFSSL_DSA** dsa,
+                                                wc_pem_password_cb* cb,
+                                                void *pass);
+
+WOLFSSL_API
+WOLFSSL_DSA *wolfSSL_PEM_read_bio_DSA_PUBKEY(WOLFSSL_BIO* bio,
+                                             WOLFSSL_DSA** dsa,
+                                             wc_pem_password_cb* cb,
+                                             void *pass);
+
+WOLFSSL_API
+int wolfSSL_PEM_write_bio_DSA_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_DSA* dsa);
+
+WOLFSSL_API
+int wolfSSL_PEM_write_mem_DSAPrivateKey(WOLFSSL_DSA* dsa,
+                                        const WOLFSSL_EVP_CIPHER* cipher,
+                                        unsigned char* passwd, int len,
+                                        unsigned char **pem, int *plen);
+#if !defined(NO_FILESYSTEM)
+WOLFSSL_API
+int wolfSSL_PEM_write_DSAPrivateKey(XFILE fp, WOLFSSL_DSA *dsa,
+                                    const WOLFSSL_EVP_CIPHER *enc,
+                                    unsigned char *kstr, int klen,
+                                    wc_pem_password_cb *cb, void *u);
+WOLFSSL_API
+int wolfSSL_PEM_write_DSA_PUBKEY(XFILE fp, WOLFSSL_DSA *x);
+#endif /* NO_FILESYSTEM */
+
+/* ECC */
+WOLFSSL_API
+int wolfSSL_PEM_write_bio_ECPrivateKey(WOLFSSL_BIO* bio, WOLFSSL_EC_KEY* ec,
+                                       const WOLFSSL_EVP_CIPHER* cipher,
+                                       unsigned char* passwd, int len,
+                                       wc_pem_password_cb* cb, void* arg);
+WOLFSSL_API
+WOLFSSL_EC_KEY* wolfSSL_PEM_read_bio_ECPrivateKey(WOLFSSL_BIO* bio,
+                                                  WOLFSSL_EC_KEY** ec,
+                                                  wc_pem_password_cb* cb,
+                                                  void *pass);
+WOLFSSL_API
+int wolfSSL_PEM_write_bio_EC_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_EC_KEY* ec);
+
+WOLFSSL_API
+int wolfSSL_PEM_write_mem_ECPrivateKey(WOLFSSL_EC_KEY* key,
+                                       const WOLFSSL_EVP_CIPHER* cipher,
+                                       unsigned char* passwd, int len,
+                                       unsigned char **pem, int *plen);
+#if !defined(NO_FILESYSTEM)
+WOLFSSL_API
+int wolfSSL_PEM_write_ECPrivateKey(XFILE fp, WOLFSSL_EC_KEY *key,
+                                   const WOLFSSL_EVP_CIPHER *enc,
+                                   unsigned char *kstr, int klen,
+                                   wc_pem_password_cb *cb, void *u);
+WOLFSSL_API
+int wolfSSL_PEM_write_EC_PUBKEY(XFILE fp, WOLFSSL_EC_KEY* key);
+#endif
+
+#ifndef NO_BIO
+WOLFSSL_API
+WOLFSSL_EC_KEY* wolfSSL_PEM_read_bio_EC_PUBKEY(WOLFSSL_BIO* bio,
+                                               WOLFSSL_EC_KEY** ec,
+                                               wc_pem_password_cb* cb,
+                                               void *pass);
+#endif /* !NO_BIO */
+
+/* EVP_KEY */
+WOLFSSL_API
+WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_bio_PrivateKey(WOLFSSL_BIO* bio,
+                                                  WOLFSSL_EVP_PKEY** key,
+                                                  wc_pem_password_cb* cb,
+                                                  void* pass);
+WOLFSSL_API
+WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_bio_PUBKEY(WOLFSSL_BIO* bio,
+                                              WOLFSSL_EVP_PKEY **key,
+                                              wc_pem_password_cb *cb,
+                                              void *pass);
+WOLFSSL_API
+int wolfSSL_PEM_write_bio_PrivateKey(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key,
+                                        const WOLFSSL_EVP_CIPHER* cipher,
+                                        unsigned char* passwd, int len,
+                                        wc_pem_password_cb* cb, void* arg);
+WOLFSSL_API
+int wolfSSL_PEM_write_bio_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key);
+
+
+WOLFSSL_API
+int wolfSSL_PEM_read_bio(WOLFSSL_BIO* bio, char **name, char **header,
+                         unsigned char **data, long *len);
+WOLFSSL_API
+int wolfSSL_PEM_write_bio(WOLFSSL_BIO *bio, const char *name,
+                          const char *header, const unsigned char *data,
+                          long len);
+#if !defined(NO_FILESYSTEM)
+WOLFSSL_API
+int wolfSSL_PEM_read(XFILE fp, char **name, char **header, unsigned char **data,
+                     long *len);
+WOLFSSL_API
+int wolfSSL_PEM_write(XFILE fp, const char *name, const char *header,
+                      const unsigned char *data, long len);
+#endif
+
+#if !defined(NO_FILESYSTEM)
+WOLFSSL_API
+WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_PUBKEY(XFILE fp, WOLFSSL_EVP_PKEY **x,
+                                          wc_pem_password_cb *cb, void *u);
+WOLFSSL_API
+WOLFSSL_X509 *wolfSSL_PEM_read_X509(XFILE fp, WOLFSSL_X509 **x,
+                                          wc_pem_password_cb *cb, void *u);
+WOLFSSL_API
+WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_PrivateKey(XFILE fp, WOLFSSL_EVP_PKEY **x,
+                                          wc_pem_password_cb *cb, void *u);
+
+WOLFSSL_API
+int wolfSSL_PEM_write_X509(XFILE fp, WOLFSSL_X509 *x);
+WOLFSSL_API
+int wolfSSL_PEM_write_DHparams(XFILE fp, WOLFSSL_DH* dh);
+#endif /* NO_FILESYSTEM */
+
+#define PEM_BUFSIZE WOLF_PEM_BUFSIZE
+
+#define PEM_read                        wolfSSL_PEM_read
+#define PEM_read_bio                    wolfSSL_PEM_read_bio
+#define PEM_write                       wolfSSL_PEM_write
+#define PEM_write_bio                   wolfSSL_PEM_write_bio
+
+#define PEM_read_X509                   wolfSSL_PEM_read_X509
+#define PEM_read_PrivateKey             wolfSSL_PEM_read_PrivateKey
+#define PEM_write_X509                  wolfSSL_PEM_write_X509
+#define PEM_write_bio_PrivateKey        wolfSSL_PEM_write_bio_PrivateKey
+#define PEM_write_bio_PKCS8PrivateKey   wolfSSL_PEM_write_bio_PKCS8PrivateKey
+#define PEM_write_PKCS8PrivateKey       wolfSSL_PEM_write_PKCS8PrivateKey
+
+/* DH */
+#define PEM_write_DHparams              wolfSSL_PEM_write_DHparams
+/* RSA */
+#define PEM_write_bio_RSAPrivateKey     wolfSSL_PEM_write_bio_RSAPrivateKey
+#define PEM_read_bio_RSAPrivateKey      wolfSSL_PEM_read_bio_RSAPrivateKey
+#define PEM_read_RSAPrivateKey          wolfSSL_PEM_read_RSAPrivateKey
+#define PEM_write_bio_RSA_PUBKEY        wolfSSL_PEM_write_bio_RSA_PUBKEY
+#define PEM_read_bio_RSA_PUBKEY         wolfSSL_PEM_read_bio_RSA_PUBKEY
+#define PEM_read_bio_RSAPublicKey       wolfSSL_PEM_read_bio_RSA_PUBKEY
+#define PEM_read_bio_ECPKParameters     wolfSSL_PEM_read_bio_ECPKParameters
+#define PEM_write_RSAPrivateKey         wolfSSL_PEM_write_RSAPrivateKey
+#define PEM_write_RSA_PUBKEY            wolfSSL_PEM_write_RSA_PUBKEY
+#define PEM_read_RSA_PUBKEY             wolfSSL_PEM_read_RSA_PUBKEY
+#define PEM_write_RSAPublicKey          wolfSSL_PEM_write_RSAPublicKey
+#define PEM_read_RSAPublicKey           wolfSSL_PEM_read_RSAPublicKey
+/* DSA */
+#define PEM_write_bio_DSAPrivateKey     wolfSSL_PEM_write_bio_DSAPrivateKey
+#define PEM_write_DSAPrivateKey         wolfSSL_PEM_write_DSAPrivateKey
+#define PEM_write_bio_DSA_PUBKEY        wolfSSL_PEM_write_bio_DSA_PUBKEY
+#define PEM_write_DSA_PUBKEY            wolfSSL_PEM_write_DSA_PUBKEY
+#define PEM_read_bio_DSAPrivateKey      wolfSSL_PEM_read_bio_DSAPrivateKey
+#define PEM_read_bio_DSA_PUBKEY         wolfSSL_PEM_read_bio_DSA_PUBKEY
+/* ECC */
+#define PEM_write_bio_ECPrivateKey      wolfSSL_PEM_write_bio_ECPrivateKey
+#define PEM_write_bio_EC_PUBKEY         wolfSSL_PEM_write_bio_EC_PUBKEY
+#define PEM_write_EC_PUBKEY             wolfSSL_PEM_write_EC_PUBKEY
+#define PEM_write_ECPrivateKey          wolfSSL_PEM_write_ECPrivateKey
+#define PEM_read_bio_ECPrivateKey       wolfSSL_PEM_read_bio_ECPrivateKey
+#define PEM_read_bio_EC_PUBKEY          wolfSSL_PEM_read_bio_EC_PUBKEY
+#ifndef NO_WOLFSSL_STUB
+#define PEM_write_bio_ECPKParameters(...) 0
+#endif
+/* EVP_KEY */
+#define PEM_read_bio_PrivateKey         wolfSSL_PEM_read_bio_PrivateKey
+#define PEM_read_PUBKEY                 wolfSSL_PEM_read_PUBKEY
+#define PEM_read_bio_PUBKEY             wolfSSL_PEM_read_bio_PUBKEY
+#define PEM_write_bio_PUBKEY            wolfSSL_PEM_write_bio_PUBKEY
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_PEM_H_ */
+

--- a/include/wolfssl/openssl/pkcs7.h
+++ b/include/wolfssl/openssl/pkcs7.h
@@ -1,0 +1,110 @@
+/* pkcs7.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* pkcs7.h for openSSL */
+
+
+#ifndef WOLFSSL_PKCS7_H_
+#define WOLFSSL_PKCS7_H_
+
+#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/wolfcrypt/pkcs7.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#if defined(OPENSSL_ALL) && defined(HAVE_PKCS7)
+
+#define PKCS7_TEXT             0x1
+#define PKCS7_NOCERTS          0x2
+#define PKCS7_DETACHED         0x40
+#define PKCS7_BINARY           0x80
+#define PKCS7_NOINTERN         0x0010
+#define PKCS7_NOVERIFY         0x0020
+#define PKCS7_STREAM           0x1000
+#define PKCS7_PARTIAL          0x4000
+
+typedef struct WOLFSSL_PKCS7
+{
+    PKCS7 pkcs7;
+    unsigned char* data;
+    int len;
+    int type;   /* from PKCS7_TYPES, for PKCS7_final() */
+    WOLFSSL_STACK* certs;
+} WOLFSSL_PKCS7;
+
+
+WOLFSSL_API PKCS7* wolfSSL_PKCS7_new(void);
+WOLFSSL_API PKCS7_SIGNED* wolfSSL_PKCS7_SIGNED_new(void);
+WOLFSSL_API void wolfSSL_PKCS7_free(PKCS7* p7);
+WOLFSSL_API void wolfSSL_PKCS7_SIGNED_free(PKCS7_SIGNED* p7);
+WOLFSSL_API PKCS7* wolfSSL_d2i_PKCS7(PKCS7** p7, const unsigned char** in,
+    int len);
+WOLFSSL_LOCAL PKCS7* wolfSSL_d2i_PKCS7_ex(PKCS7** p7, const unsigned char** in,
+    int len, byte* content, word32 contentSz);
+WOLFSSL_API PKCS7* wolfSSL_d2i_PKCS7_bio(WOLFSSL_BIO* bio, PKCS7** p7);
+WOLFSSL_API int wolfSSL_i2d_PKCS7_bio(WOLFSSL_BIO *bio, PKCS7 *p7);
+WOLFSSL_API int wolfSSL_i2d_PKCS7(PKCS7 *p7, unsigned char **out);
+WOLFSSL_API PKCS7* wolfSSL_PKCS7_sign(WOLFSSL_X509* signer,
+    WOLFSSL_EVP_PKEY* pkey, WOLFSSL_STACK* certs, WOLFSSL_BIO* in, int flags);
+WOLFSSL_API int wolfSSL_PKCS7_verify(PKCS7* p7, WOLFSSL_STACK* certs,
+    WOLFSSL_X509_STORE* store, WOLFSSL_BIO* in, WOLFSSL_BIO* out, int flags);
+WOLFSSL_API int wolfSSL_PKCS7_final(PKCS7* pkcs7, WOLFSSL_BIO* in, int flags);
+WOLFSSL_API int wolfSSL_PKCS7_encode_certs(PKCS7* p7, WOLFSSL_STACK* certs,
+                                           WOLFSSL_BIO* out);
+WOLFSSL_API WOLFSSL_STACK* wolfSSL_PKCS7_to_stack(PKCS7* pkcs7);
+WOLFSSL_API WOLFSSL_STACK* wolfSSL_PKCS7_get0_signers(PKCS7* p7,
+    WOLFSSL_STACK* certs, int flags);
+WOLFSSL_API int wolfSSL_PEM_write_bio_PKCS7(WOLFSSL_BIO* bio, PKCS7* p7);
+#if defined(HAVE_SMIME)
+WOLFSSL_API PKCS7* wolfSSL_SMIME_read_PKCS7(WOLFSSL_BIO* in, WOLFSSL_BIO** bcont);
+WOLFSSL_API int wolfSSL_SMIME_write_PKCS7(WOLFSSL_BIO* out, PKCS7* pkcs7,
+                                          WOLFSSL_BIO* in, int flags);
+#endif /* HAVE_SMIME */
+
+
+#define PKCS7_new                      wolfSSL_PKCS7_new
+#define PKCS7_SIGNED_new               wolfSSL_PKCS7_SIGNED_new
+#define PKCS7_free                     wolfSSL_PKCS7_free
+#define PKCS7_SIGNED_free              wolfSSL_PKCS7_SIGNED_free
+#define d2i_PKCS7                      wolfSSL_d2i_PKCS7
+#define d2i_PKCS7_bio                  wolfSSL_d2i_PKCS7_bio
+#define i2d_PKCS7_bio                  wolfSSL_i2d_PKCS7_bio
+#define i2d_PKCS7                      wolfSSL_i2d_PKCS7
+#define PKCS7_sign                     wolfSSL_PKCS7_sign
+#define PKCS7_verify                   wolfSSL_PKCS7_verify
+#define PKCS7_final                    wolfSSL_PKCS7_final
+#define PKCS7_get0_signers             wolfSSL_PKCS7_get0_signers
+#define PEM_write_bio_PKCS7            wolfSSL_PEM_write_bio_PKCS7
+#if defined(HAVE_SMIME)
+#define SMIME_read_PKCS7               wolfSSL_SMIME_read_PKCS7
+#define SMIME_write_PKCS7              wolfSSL_SMIME_write_PKCS7
+#endif /* HAVE_SMIME */
+
+#endif /* OPENSSL_ALL && HAVE_PKCS7 */
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_PKCS7_H_ */
+

--- a/include/wolfssl/openssl/rc4.h
+++ b/include/wolfssl/openssl/rc4.h
@@ -1,0 +1,59 @@
+/* rc4.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+
+/*  rc4.h defines mini des openssl compatibility layer
+ *
+ */
+
+#ifndef WOLFSSL_RC4_COMPAT_H_
+#define WOLFSSL_RC4_COMPAT_H_
+
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/openssl/ssl.h> /* included for size_t */
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+/* applications including wolfssl/openssl/rc4.h are expecting to have access to
+ * the size of RC4_KEY structures. */
+typedef struct WOLFSSL_RC4_KEY {
+    /* big enough for Arc4 from wolfssl/wolfcrypt/arc4.h */
+    void* holder[(272 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+} WOLFSSL_RC4_KEY;
+typedef WOLFSSL_RC4_KEY RC4_KEY;
+
+WOLFSSL_API void wolfSSL_RC4_set_key(WOLFSSL_RC4_KEY* key, int len,
+        const unsigned char* data);
+WOLFSSL_API void wolfSSL_RC4(WOLFSSL_RC4_KEY* key, size_t len,
+        const unsigned char* in, unsigned char* out);
+
+#define RC4         wolfSSL_RC4
+#define RC4_set_key wolfSSL_RC4_set_key
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_RC4_COMPAT_H_ */
+

--- a/include/wolfssl/openssl/ripemd.h
+++ b/include/wolfssl/openssl/ripemd.h
@@ -1,0 +1,58 @@
+/* ripemd.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* ripemd.h for openssl */
+
+
+#ifndef WOLFSSL_RIPEMD_H_
+#define WOLFSSL_RIPEMD_H_
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+
+typedef struct WOLFSSL_RIPEMD_CTX {
+    int holder[32];   /* big enough to hold wolfcrypt, but check on init */
+} WOLFSSL_RIPEMD_CTX;
+
+WOLFSSL_API void wolfSSL_RIPEMD_Init(WOLFSSL_RIPEMD_CTX*);
+WOLFSSL_API void wolfSSL_RIPEMD_Update(WOLFSSL_RIPEMD_CTX*, const void*,
+                                     unsigned long);
+WOLFSSL_API void wolfSSL_RIPEMD_Final(unsigned char*, WOLFSSL_RIPEMD_CTX*);
+
+
+typedef WOLFSSL_RIPEMD_CTX RIPEMD_CTX;
+
+#define RIPEMD_Init   wolfSSL_RIPEMD_Init
+#define RIPEMD_Update wolfSSL_RIPEMD_Update
+#define RIPEMD_Final  wolfSSL_RIPEMD_Final
+
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+
+#endif /* WOLFSSL_MD5_H_ */
+

--- a/include/wolfssl/openssl/rsa.h
+++ b/include/wolfssl/openssl/rsa.h
@@ -1,0 +1,249 @@
+/* rsa.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* rsa.h for openSSL */
+
+
+#ifndef WOLFSSL_RSA_H_
+#define WOLFSSL_RSA_H_
+
+#include <wolfssl/openssl/bn.h>
+#include <wolfssl/openssl/err.h>
+#include <wolfssl/wolfcrypt/types.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+/* Padding types */
+#define RSA_PKCS1_PADDING      0
+#define RSA_PKCS1_OAEP_PADDING 1
+#define RSA_PKCS1_PSS_PADDING  2
+#define RSA_NO_PADDING         3
+
+/* Emulate OpenSSL flags */
+#define RSA_METHOD_FLAG_NO_CHECK        (1 << 1)
+#define RSA_FLAG_CACHE_PUBLIC           (1 << 2)
+#define RSA_FLAG_CACHE_PRIVATE          (1 << 3)
+#define RSA_FLAG_BLINDING               (1 << 4)
+#define RSA_FLAG_THREAD_SAFE            (1 << 5)
+#define RSA_FLAG_EXT_PKEY               (1 << 6)
+#define RSA_FLAG_NO_BLINDING            (1 << 7)
+#define RSA_FLAG_NO_CONSTTIME           (1 << 8)
+
+/* Salt length same as digest length */
+#define RSA_PSS_SALTLEN_DIGEST   (-1)
+/* Old max salt length */
+#define RSA_PSS_SALTLEN_MAX_SIGN (-2)
+/* Verification only value to indicate to discover salt length. */
+#define RSA_PSS_SALTLEN_AUTO     (-2)
+/* Max salt length */
+#define RSA_PSS_SALTLEN_MAX      (-3)
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+typedef struct WOLFSSL_RSA_METHOD {
+    /* Flags of RSA key implementation. */
+    int flags;
+    /* Name of RSA key implementation. */
+    char *name;
+    /* RSA method dynamically allocated. */
+    word16 dynamic:1;
+} WOLFSSL_RSA_METHOD;
+
+#ifndef WOLFSSL_RSA_TYPE_DEFINED /* guard on redeclaration */
+#define WOLFSSL_RSA_TYPE_DEFINED
+/* RSA key compatible with OpenSSL. */
+typedef struct WOLFSSL_RSA {
+    WOLFSSL_BIGNUM* n;              /* Modulus. */
+    WOLFSSL_BIGNUM* e;              /* Public exponent. */
+    WOLFSSL_BIGNUM* d;              /* Private exponent. */
+    WOLFSSL_BIGNUM* p;              /* First prime. */
+    WOLFSSL_BIGNUM* q;              /* Second prime. */
+    WOLFSSL_BIGNUM* dmp1;           /* dP = d mod (p - 1) */
+    WOLFSSL_BIGNUM* dmq1;           /* dQ = d mod (q - 1) */
+    WOLFSSL_BIGNUM* iqmp;           /* u = (1 / q) mod p */
+    void* heap;                     /* Heap used for memory allocations. */
+    void* internal;                 /* wolfCrypt RSA key. */
+#if defined(OPENSSL_EXTRA)
+    const WOLFSSL_RSA_METHOD* meth; /* RSA method. */
+#endif
+#ifdef HAVE_EX_DATA
+    WOLFSSL_CRYPTO_EX_DATA ex_data;  /* external data */
+#endif
+    wolfSSL_Ref ref;                 /* Reference count information. */
+    word16 pkcs8HeaderSz;            /* Size of PKCS#8 header from decode. */
+    int flags;                       /* Flags of implementation. */
+
+    /* bits */
+    byte inSet:1;                    /* Internal set from external. */
+    byte exSet:1;                    /* External set from internal. */
+    byte ownRng:1;                   /* Rng needs to be free'd. */
+} WOLFSSL_RSA;
+#endif
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+typedef WOLFSSL_RSA                   RSA;
+typedef WOLFSSL_RSA_METHOD            RSA_METHOD;
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+WOLFSSL_API WOLFSSL_RSA* wolfSSL_RSA_new_ex(void* heap, int devId);
+WOLFSSL_API WOLFSSL_RSA* wolfSSL_RSA_new(void);
+WOLFSSL_API void        wolfSSL_RSA_free(WOLFSSL_RSA* rsa);
+
+WOLFSSL_API int wolfSSL_RSA_generate_key_ex(WOLFSSL_RSA* rsa, int bits,
+                                            WOLFSSL_BIGNUM* bn, void* cb);
+
+WOLFSSL_API int wolfSSL_RSA_blinding_on(WOLFSSL_RSA* rsa, WOLFSSL_BN_CTX* bn);
+WOLFSSL_API int wolfSSL_RSA_check_key(const WOLFSSL_RSA* rsa);
+WOLFSSL_API int wolfSSL_RSA_public_encrypt(int len, const unsigned char* fr,
+                                       unsigned char* to, WOLFSSL_RSA* rsa,
+                                       int padding);
+WOLFSSL_API int wolfSSL_RSA_private_decrypt(int len, const unsigned char* fr,
+                                       unsigned char* to, WOLFSSL_RSA* rsa,
+                                       int padding);
+WOLFSSL_API int wolfSSL_RSA_private_encrypt(int len, const unsigned char* in,
+                            unsigned char* out, WOLFSSL_RSA* rsa, int padding);
+
+WOLFSSL_API int wolfSSL_RSA_size(const WOLFSSL_RSA* rsa);
+WOLFSSL_API int wolfSSL_RSA_bits(const WOLFSSL_RSA* rsa);
+WOLFSSL_API int wolfSSL_RSA_sign(int type, const unsigned char* m,
+                               unsigned int mLen, unsigned char* sigRet,
+                               unsigned int* sigLen, WOLFSSL_RSA* rsa);
+WOLFSSL_API int wolfSSL_RSA_sign_ex(int type, const unsigned char* m,
+                               unsigned int mLen, unsigned char* sigRet,
+                               unsigned int* sigLen, WOLFSSL_RSA* rsa,
+                               int flag);
+WOLFSSL_API int wolfSSL_RSA_sign_generic_padding(int type, const unsigned char* m,
+                               unsigned int mLen, unsigned char* sigRet,
+                               unsigned int* sigLen, WOLFSSL_RSA* rsa, int flag,
+                               int padding);
+WOLFSSL_API int wolfSSL_RSA_verify(int type, const unsigned char* m,
+                               unsigned int mLen, const unsigned char* sig,
+                               unsigned int sigLen, WOLFSSL_RSA* rsa);
+WOLFSSL_API int wolfSSL_RSA_verify_ex(int type, const unsigned char* m,
+                               unsigned int mLen, const unsigned char* sig,
+                               unsigned int sigLen, WOLFSSL_RSA* rsa,
+                               int padding);
+WOLFSSL_API int wolfSSL_RSA_public_decrypt(int flen, const unsigned char* from,
+                               unsigned char* to, WOLFSSL_RSA* rsa, int padding);
+WOLFSSL_API int wolfSSL_RSA_GenAdd(WOLFSSL_RSA* rsa);
+WOLFSSL_API int wolfSSL_RSA_LoadDer(WOLFSSL_RSA* rsa,
+                               const unsigned char* derBuf, int derSz);
+WOLFSSL_API int wolfSSL_RSA_LoadDer_ex(WOLFSSL_RSA* rsa,
+                               const unsigned char* derBuf, int derSz, int opt);
+
+WOLFSSL_API WOLFSSL_RSA_METHOD *wolfSSL_RSA_meth_new(const char *name, int flags);
+WOLFSSL_API void wolfSSL_RSA_meth_free(WOLFSSL_RSA_METHOD *meth);
+WOLFSSL_API int wolfSSL_RSA_meth_set(WOLFSSL_RSA_METHOD *rsa, void* p);
+WOLFSSL_API int wolfSSL_RSA_set_method(WOLFSSL_RSA *rsa, WOLFSSL_RSA_METHOD *meth);
+WOLFSSL_API const WOLFSSL_RSA_METHOD* wolfSSL_RSA_get_method(const WOLFSSL_RSA *rsa);
+WOLFSSL_API const WOLFSSL_RSA_METHOD* wolfSSL_RSA_get_default_method(void);
+
+WOLFSSL_API void wolfSSL_RSA_get0_crt_params(const WOLFSSL_RSA *r,
+                                             const WOLFSSL_BIGNUM **dmp1,
+                                             const WOLFSSL_BIGNUM **dmq1,
+                                             const WOLFSSL_BIGNUM **iqmp);
+WOLFSSL_API int wolfSSL_RSA_set0_crt_params(WOLFSSL_RSA *r, WOLFSSL_BIGNUM *dmp1,
+                                            WOLFSSL_BIGNUM *dmq1, WOLFSSL_BIGNUM *iqmp);
+WOLFSSL_API void wolfSSL_RSA_get0_factors(const WOLFSSL_RSA *r, const WOLFSSL_BIGNUM **p,
+                                          const WOLFSSL_BIGNUM **q);
+WOLFSSL_API int wolfSSL_RSA_set0_factors(WOLFSSL_RSA *r, WOLFSSL_BIGNUM *p, WOLFSSL_BIGNUM *q);
+WOLFSSL_API void wolfSSL_RSA_get0_key(const WOLFSSL_RSA *r, const WOLFSSL_BIGNUM **n,
+                                      const WOLFSSL_BIGNUM **e, const WOLFSSL_BIGNUM **d);
+WOLFSSL_API int wolfSSL_RSA_set0_key(WOLFSSL_RSA *r, WOLFSSL_BIGNUM *n, WOLFSSL_BIGNUM *e,
+                                     WOLFSSL_BIGNUM *d);
+WOLFSSL_API int wolfSSL_RSA_flags(const WOLFSSL_RSA *r);
+WOLFSSL_API void wolfSSL_RSA_set_flags(WOLFSSL_RSA *r, int flags);
+WOLFSSL_API void wolfSSL_RSA_clear_flags(WOLFSSL_RSA *r, int flags);
+WOLFSSL_API int wolfSSL_RSA_test_flags(const WOLFSSL_RSA *r, int flags);
+
+WOLFSSL_API WOLFSSL_RSA* wolfSSL_RSAPublicKey_dup(WOLFSSL_RSA *rsa);
+
+WOLFSSL_API void* wolfSSL_RSA_get_ex_data(const WOLFSSL_RSA *rsa, int idx);
+WOLFSSL_API int wolfSSL_RSA_set_ex_data(WOLFSSL_RSA *rsa, int idx, void *data);
+#ifdef HAVE_EX_DATA_CLEANUP_HOOKS
+WOLFSSL_API int wolfSSL_RSA_set_ex_data_with_cleanup(
+    WOLFSSL_RSA *rsa,
+    int idx,
+    void *data,
+    wolfSSL_ex_data_cleanup_routine_t cleanup_routine);
+#endif
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+#define WOLFSSL_RSA_LOAD_PRIVATE 1
+#define WOLFSSL_RSA_LOAD_PUBLIC  2
+#define WOLFSSL_RSA_F4           0x10001L
+
+#define RSA_new  wolfSSL_RSA_new
+#define RSA_free wolfSSL_RSA_free
+
+#define RSA_generate_key_ex wolfSSL_RSA_generate_key_ex
+
+#define RSA_blinding_on     wolfSSL_RSA_blinding_on
+#define RSA_check_key       wolfSSL_RSA_check_key
+#define RSA_public_encrypt  wolfSSL_RSA_public_encrypt
+#define RSA_private_decrypt wolfSSL_RSA_private_decrypt
+#define RSA_private_encrypt wolfSSL_RSA_private_encrypt
+
+#define RSA_size           wolfSSL_RSA_size
+#define RSA_sign           wolfSSL_RSA_sign
+#define RSA_verify         wolfSSL_RSA_verify
+#define RSA_public_decrypt wolfSSL_RSA_public_decrypt
+
+#define RSA_meth_new            wolfSSL_RSA_meth_new
+#define RSA_meth_free           wolfSSL_RSA_meth_free
+#define RSA_meth_set_pub_enc    wolfSSL_RSA_meth_set
+#define RSA_meth_set_pub_dec    wolfSSL_RSA_meth_set
+#define RSA_meth_set_priv_enc   wolfSSL_RSA_meth_set
+#define RSA_meth_set_priv_dec   wolfSSL_RSA_meth_set
+#define RSA_meth_set_init       wolfSSL_RSA_meth_set
+#define RSA_meth_set_finish     wolfSSL_RSA_meth_set
+#define RSA_meth_set0_app_data  wolfSSL_RSA_meth_set
+#define RSA_get_default_method  wolfSSL_RSA_get_default_method
+#define RSA_get_method          wolfSSL_RSA_get_method
+#define RSA_set_method          wolfSSL_RSA_set_method
+#define RSA_get0_crt_params     wolfSSL_RSA_get0_crt_params
+#define RSA_set0_crt_params     wolfSSL_RSA_set0_crt_params
+#define RSA_get0_factors        wolfSSL_RSA_get0_factors
+#define RSA_set0_factors        wolfSSL_RSA_set0_factors
+#define RSA_get0_key            wolfSSL_RSA_get0_key
+#define RSA_set0_key            wolfSSL_RSA_set0_key
+#define RSA_flags               wolfSSL_RSA_flags
+#define RSA_set_flags           wolfSSL_RSA_set_flags
+#define RSA_clear_flags         wolfSSL_RSA_clear_flags
+#define RSA_test_flags          wolfSSL_RSA_test_flags
+
+#define RSAPublicKey_dup        wolfSSL_RSAPublicKey_dup
+#define RSA_get_ex_data        wolfSSL_RSA_get_ex_data
+#define RSA_set_ex_data        wolfSSL_RSA_set_ex_data
+
+#define RSA_get0_key       wolfSSL_RSA_get0_key
+
+#define RSA_F4             WOLFSSL_RSA_F4
+
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+#endif /* header */

--- a/include/wolfssl/openssl/sha.h
+++ b/include/wolfssl/openssl/sha.h
@@ -1,0 +1,331 @@
+/* sha.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* sha.h for openssl */
+
+
+#ifndef WOLFSSL_SHA_H_
+#define WOLFSSL_SHA_H_
+
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
+
+#ifdef WOLFSSL_PREFIX
+#include "prefix_sha.h"
+#endif
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+/* adder for HW crypto */
+#if defined(STM32_HASH)
+    #define CTX_SHA_HW_ADDER sizeof(STM32_HASH_Context)
+#elif defined(WOLFSSL_IMXRT1170_CAAM)
+    #define CTX_SHA_HW_ADDER (sizeof(caam_hash_ctx_t) + sizeof(caam_handle_t))
+#elif defined(WOLFSSL_ESP32) && \
+     !defined(NO_WOLFSSL_ESP32_CRYPT_HASH)
+    #define CTX_SHA_HW_ADDER sizeof(WC_ESP32SHA)
+#else
+    #define CTX_SHA_HW_ADDER 0
+#endif
+
+
+#ifndef NO_SHA
+typedef struct WOLFSSL_SHA_CTX {
+    /* big enough to hold wolfcrypt Sha, but check on init */
+    void* holder[(112 + WC_ASYNC_DEV_SIZE + CTX_SHA_HW_ADDER) / sizeof(void*)];
+#if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
+    void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
+#endif
+#ifdef WOLF_CRYPTO_CB
+    void* cryptocb_holder[(sizeof(int) + sizeof(void*) + 4) / sizeof(void*)];
+#endif
+} WOLFSSL_SHA_CTX;
+
+WOLFSSL_API int wolfSSL_SHA_Init(WOLFSSL_SHA_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA_Update(WOLFSSL_SHA_CTX* sha, const void* input,
+                           unsigned long sz);
+WOLFSSL_API int wolfSSL_SHA_Final(byte* input, WOLFSSL_SHA_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA_Transform(WOLFSSL_SHA_CTX* sha,
+                                         const unsigned char* data);
+/* SHA1 points to above, shouldn't use SHA0 ever */
+WOLFSSL_API int wolfSSL_SHA1_Init(WOLFSSL_SHA_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA1_Update(WOLFSSL_SHA_CTX* sha, const void* input,
+                            unsigned long sz);
+WOLFSSL_API int wolfSSL_SHA1_Final(byte* output, WOLFSSL_SHA_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA1_Transform(WOLFSSL_SHA_CTX* sha,
+                                          const unsigned char *data);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+enum {
+    SHA_DIGEST_LENGTH = 20
+};
+
+typedef WOLFSSL_SHA_CTX SHA_CTX;
+
+#define SHA_Init wolfSSL_SHA_Init
+#define SHA_Update wolfSSL_SHA_Update
+#define SHA_Final wolfSSL_SHA_Final
+#define SHA_Transform wolfSSL_SHA_Transform
+
+#if defined(NO_OLD_SHA_NAMES) && !defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_FIPS) || \
+    (defined(HAVE_FIPS_VERSION) && HAVE_FIPS_VERSION > 2))
+    /* SHA is only available in non-fips mode or fips version > 2 mode
+     * because of SHA enum in FIPS build. */
+    #define SHA wolfSSL_SHA1
+#endif
+
+#define SHA1_Init wolfSSL_SHA1_Init
+#define SHA1_Update wolfSSL_SHA1_Update
+#define SHA1_Final wolfSSL_SHA1_Final
+#define SHA1_Transform wolfSSL_SHA1_Transform
+
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+#endif /* !NO_SHA */
+
+
+#ifdef WOLFSSL_SHA224
+
+/* Using ALIGN16 because when AES-NI is enabled digest and buffer in Sha256
+ * struct are 16 byte aligned. Any dereference to those elements after casting
+ * to Sha224, is expected to also be 16 byte aligned addresses.  */
+typedef struct WOLFSSL_SHA224_CTX {
+    /* big enough to hold wolfcrypt Sha224, but check on init */
+    ALIGN16 void* holder[(274 + CTX_SHA_HW_ADDER + WC_ASYNC_DEV_SIZE) /
+        sizeof(void*)];
+#if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
+    ALIGN16 void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
+#endif
+#ifdef WOLF_CRYPTO_CB
+    ALIGN16 void* cryptocb_holder[(sizeof(int) + sizeof(void*) + 4) /
+        sizeof(void*)];
+#endif
+} WOLFSSL_SHA224_CTX;
+
+WOLFSSL_API int wolfSSL_SHA224_Init(WOLFSSL_SHA224_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA224_Update(WOLFSSL_SHA224_CTX* sha, const void* input,
+                           unsigned long sz);
+WOLFSSL_API int wolfSSL_SHA224_Final(byte* output, WOLFSSL_SHA224_CTX* sha);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+enum {
+    SHA224_DIGEST_LENGTH = 28
+};
+
+typedef WOLFSSL_SHA224_CTX SHA224_CTX;
+
+#define SHA224_Init   wolfSSL_SHA224_Init
+#define SHA224_Update wolfSSL_SHA224_Update
+#define SHA224_Final  wolfSSL_SHA224_Final
+#if defined(NO_OLD_SHA_NAMES) && !defined(HAVE_SELFTEST) && \
+    (!defined(HAVE_FIPS) || \
+    (defined(HAVE_FIPS_VERSION) && HAVE_FIPS_VERSION > 2))
+    /* SHA224 is only available in non-fips mode or fips version > 2 mode
+     * because of SHA224 enum in FIPS build. */
+    #define SHA224 wolfSSL_SHA224
+#endif
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+#endif /* WOLFSSL_SHA224 */
+
+#ifndef NO_SHA256
+/* Using ALIGN16 because when AES-NI is enabled digest and buffer in Sha256
+ * struct are 16 byte aligned. Any dereference to those elements after casting
+ * to Sha256, is expected to also be 16 byte aligned addresses.  */
+typedef struct WOLFSSL_SHA256_CTX {
+    /* big enough to hold wolfcrypt Sha256, but check on init */
+    ALIGN16 void* holder[(274 + CTX_SHA_HW_ADDER + WC_ASYNC_DEV_SIZE) /
+        sizeof(void*)];
+#if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
+    ALIGN16 void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
+#endif
+#ifdef WOLF_CRYPTO_CB
+    ALIGN16 void* cryptocb_holder[(sizeof(int) + sizeof(void*) + 4) /
+        sizeof(void*)];
+#endif
+} WOLFSSL_SHA256_CTX;
+
+WOLFSSL_API int wolfSSL_SHA256_Init(WOLFSSL_SHA256_CTX* sha256);
+WOLFSSL_API int wolfSSL_SHA256_Update(WOLFSSL_SHA256_CTX* sha, const void* input,
+                              unsigned long sz);
+WOLFSSL_API int wolfSSL_SHA256_Final(byte* output, WOLFSSL_SHA256_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA256_Transform(WOLFSSL_SHA256_CTX* sha256,
+                                                const unsigned char *data);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+enum {
+    SHA256_DIGEST_LENGTH = 32
+};
+
+typedef WOLFSSL_SHA256_CTX SHA256_CTX;
+
+#define SHA256_Init   wolfSSL_SHA256_Init
+#define SHA256_Update wolfSSL_SHA256_Update
+#define SHA256_Final  wolfSSL_SHA256_Final
+#define SHA256_Transform wolfSSL_SHA256_Transform
+
+/* "SHA256" has some conflicts
+ * If not FIPS and NO_OLD_SHA_NAMES defined
+ * If FIPS V3 or higher and NO_OLD_SHA_NAMES defined
+ * If FIPS V2 and NO_OLD_SHA256_NAMES defined
+ * If FIPS v1 not allowed
+ * If HAVE_SELFTEST not allowed
+ */
+#if !defined(HAVE_SELFTEST) && \
+    (defined(NO_OLD_SHA_NAMES) && !defined(HAVE_FIPS)) || \
+    (defined(NO_OLD_SHA_NAMES)    && defined(HAVE_FIPS) && \
+        defined(HAVE_FIPS_VERSION) && HAVE_FIPS_VERSION >= 3) || \
+    (defined(NO_OLD_SHA256_NAMES) && defined(HAVE_FIPS) && \
+        defined(HAVE_FIPS_VERSION) && HAVE_FIPS_VERSION == 2)
+
+    #define SHA256 wolfSSL_SHA256
+#endif
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+#endif /* !NO_SHA256 */
+
+#ifdef WOLFSSL_SHA384
+typedef struct WOLFSSL_SHA384_CTX {
+    /* big enough to hold wolfCrypt Sha384, but check on init */
+    void* holder[(288 + CTX_SHA_HW_ADDER + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+#if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
+    void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
+#endif
+#ifdef WOLF_CRYPTO_CB
+    void* cryptocb_holder[(sizeof(int) + sizeof(void*) + 4) / sizeof(void*)];
+#endif
+} WOLFSSL_SHA384_CTX;
+
+WOLFSSL_API int wolfSSL_SHA384_Init(WOLFSSL_SHA384_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA384_Update(WOLFSSL_SHA384_CTX* sha, const void* input,
+                           unsigned long sz);
+WOLFSSL_API int wolfSSL_SHA384_Final(byte* output, WOLFSSL_SHA384_CTX* sha);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+enum {
+    SHA384_DIGEST_LENGTH = 48
+};
+
+typedef WOLFSSL_SHA384_CTX SHA384_CTX;
+
+#define SHA384_Init   wolfSSL_SHA384_Init
+#define SHA384_Update wolfSSL_SHA384_Update
+#define SHA384_Final  wolfSSL_SHA384_Final
+#if defined(NO_OLD_SHA_NAMES) && !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+    /* SHA384 is only available in non-fips mode because of SHA384 enum in FIPS
+     * build. */
+    #define SHA384 wolfSSL_SHA384
+#endif
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+#endif /* WOLFSSL_SHA384 */
+
+#ifdef WOLFSSL_SHA512
+typedef struct WOLFSSL_SHA512_CTX {
+    /* big enough to hold wolfCrypt Sha384, but check on init */
+    void* holder[(288 + CTX_SHA_HW_ADDER + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+#if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
+    void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];
+#endif
+#ifdef WOLF_CRYPTO_CB
+    void* cryptocb_holder[(sizeof(int) + sizeof(void*) + 4) / sizeof(void*)];
+#endif
+} WOLFSSL_SHA512_CTX;
+
+WOLFSSL_API int wolfSSL_SHA512_Init(WOLFSSL_SHA512_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA512_Update(WOLFSSL_SHA512_CTX* sha,
+                                      const void* input, unsigned long sz);
+WOLFSSL_API int wolfSSL_SHA512_Final(byte* output, WOLFSSL_SHA512_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA512_Transform(WOLFSSL_SHA512_CTX* sha512,
+                                         const unsigned char* data);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+enum {
+    SHA512_DIGEST_LENGTH = 64
+};
+
+typedef WOLFSSL_SHA512_CTX SHA512_CTX;
+
+#define SHA512_Init   wolfSSL_SHA512_Init
+#define SHA512_Update wolfSSL_SHA512_Update
+#define SHA512_Final  wolfSSL_SHA512_Final
+#define SHA512_Transform wolfSSL_SHA512_Transform
+#if defined(NO_OLD_SHA_NAMES) && !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+    /* SHA512 is only available in non-fips mode because of SHA512 enum in FIPS
+     * build. */
+    #define SHA512 wolfSSL_SHA512
+#endif
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+#if !defined(WOLFSSL_NOSHA512_224)
+typedef struct WOLFSSL_SHA512_CTX WOLFSSL_SHA512_224_CTX;
+typedef WOLFSSL_SHA512_224_CTX SHA512_224_CTX;
+
+WOLFSSL_API int wolfSSL_SHA512_224_Init(WOLFSSL_SHA512_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA512_224_Update(WOLFSSL_SHA512_224_CTX* sha,
+                                        const void* input, unsigned long sz);
+WOLFSSL_API int wolfSSL_SHA512_224_Final(byte* output,
+                                         WOLFSSL_SHA512_224_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA512_224_Transform(WOLFSSL_SHA512_CTX* sha512,
+                                          const unsigned char* data);
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+#define SHA512_224_Init   wolfSSL_SHA512_224_Init
+#define SHA512_224_Update wolfSSL_SHA512_224_Update
+#define SHA512_224_Final  wolfSSL_SHA512_224_Final
+#define SHA512_224_Transform wolfSSL_SHA512_224_Transform
+
+#if defined(NO_OLD_SHA_NAMES) && !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+    #define SHA512_224 wolfSSL_SHA512_224
+#endif
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+#endif /* !WOLFSSL_NOSHA512_224 */
+
+#if !defined(WOLFSSL_NOSHA512_256)
+typedef struct WOLFSSL_SHA512_CTX WOLFSSL_SHA512_256_CTX;
+typedef WOLFSSL_SHA512_256_CTX SHA512_256_CTX;
+
+WOLFSSL_API int wolfSSL_SHA512_256_Init(WOLFSSL_SHA512_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA512_256_Update(WOLFSSL_SHA512_256_CTX* sha,
+                                        const void* input, unsigned long sz);
+WOLFSSL_API int wolfSSL_SHA512_256_Final(byte* output, WOLFSSL_SHA512_256_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA512_256_Transform(WOLFSSL_SHA512_CTX* sha512,
+                                          const unsigned char* data);
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+#define SHA512_256_Init   wolfSSL_SHA512_256_Init
+#define SHA512_256_Update wolfSSL_SHA512_256_Update
+#define SHA512_256_Final  wolfSSL_SHA512_256_Final
+#define SHA512_256_Transform wolfSSL_SHA512_256_Transform
+
+#if defined(NO_OLD_SHA_NAMES) && !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+    #define SHA512_256 wolfSSL_SHA512_256
+#endif
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+#endif /* !WOLFSSL_NOSHA512_256 */
+
+
+#endif /* WOLFSSL_SHA512 */
+
+
+
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+
+#endif /* WOLFSSL_SHA_H_ */

--- a/include/wolfssl/openssl/sha.h
+++ b/include/wolfssl/openssl/sha.h
@@ -27,7 +27,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/types.h>
-
+#include <wolfssl/wolfcrypt/sha256.h>
 #ifdef WOLFSSL_PREFIX
 #include "prefix_sha.h"
 #endif
@@ -151,7 +151,7 @@ typedef WOLFSSL_SHA224_CTX SHA224_CTX;
  * to Sha256, is expected to also be 16 byte aligned addresses.  */
 typedef struct WOLFSSL_SHA256_CTX {
     /* big enough to hold wolfcrypt Sha256, but check on init */
-    ALIGN16 void* holder[(274 + CTX_SHA_HW_ADDER + WC_ASYNC_DEV_SIZE) /
+    ALIGN16 void* holder[sizeof(wc_Sha256) /
         sizeof(void*)];
 #if defined(WOLFSSL_DEVCRYPTO_HASH) || defined(WOLFSSL_HASH_KEEP)
     ALIGN16 void* keephash_holder[sizeof(void*) + (2 * sizeof(unsigned int))];

--- a/include/wolfssl/openssl/sha3.h
+++ b/include/wolfssl/openssl/sha3.h
@@ -1,0 +1,153 @@
+/* sha3.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* sha3.h for openssl */
+
+
+#ifndef WOLFSSL_SHA3_H_
+#define WOLFSSL_SHA3_H_
+
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
+
+#ifdef WOLFSSL_PREFIX
+#include "prefix_sha.h"
+#endif
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+/* Using ALIGN16 because when AES-NI is enabled digest and buffer in Sha3
+ * struct are 16 byte aligned. Any dereference to those elements after casting
+ * to Sha3 is expected to also be 16 byte aligned addresses.  */
+struct WOLFSSL_SHA3_CTX {
+    /* big enough to hold wolfcrypt Sha3, but check on init */
+    ALIGN16 void* holder[(424 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+};
+
+#ifndef WOLFSSL_NOSHA3_224
+typedef struct WOLFSSL_SHA3_CTX WOLFSSL_SHA3_224_CTX;
+
+WOLFSSL_API int wolfSSL_SHA3_224_Init(WOLFSSL_SHA3_224_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA3_224_Update(WOLFSSL_SHA3_224_CTX* sha, const void* input,
+                           unsigned long sz);
+WOLFSSL_API int wolfSSL_SHA3_224_Final(unsigned char* output,
+                           WOLFSSL_SHA3_224_CTX* sha);
+
+enum {
+    SHA3_224_DIGEST_LENGTH = 28
+};
+
+typedef WOLFSSL_SHA3_224_CTX SHA3_224_CTX;
+
+#define SHA3_224_Init   wolfSSL_SHA3_224_Init
+#define SHA3_224_Update wolfSSL_SHA3_224_Update
+#define SHA3_224_Final  wolfSSL_SHA3_224_Final
+#if defined(NO_OLD_WC_NAMES) && !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+    #define SHA3_224 wolfSSL_SHA3_224
+#endif
+#endif /* WOLFSSL_NOSHA3_224 */
+
+
+#ifndef WOLFSSL_NOSHA3_256
+typedef struct WOLFSSL_SHA3_CTX WOLFSSL_SHA3_256_CTX;
+
+
+WOLFSSL_API int wolfSSL_SHA3_256_Init(WOLFSSL_SHA3_256_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA3_256_Update(WOLFSSL_SHA3_256_CTX* sha,
+                                        const void* input, unsigned long sz);
+WOLFSSL_API int wolfSSL_SHA3_256_Final(unsigned char* output,
+                                       WOLFSSL_SHA3_256_CTX* sha);
+
+enum {
+    SHA3_256_DIGEST_LENGTH = 32
+};
+
+
+typedef WOLFSSL_SHA3_256_CTX SHA3_256_CTX;
+
+#define SHA3_256_Init   wolfSSL_SHA3_256_Init
+#define SHA3_256_Update wolfSSL_SHA3_256_Update
+#define SHA3_256_Final  wolfSSL_SHA3_256_Final
+#if defined(NO_OLD_WC_NAMES) && !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+    #define SHA3_256 wolfSSL_SHA3_256
+#endif
+#endif /* WOLFSSL_NOSHA3_256 */
+
+
+typedef struct WOLFSSL_SHA3_CTX WOLFSSL_SHA3_384_CTX;
+
+WOLFSSL_API int wolfSSL_SHA3_384_Init(WOLFSSL_SHA3_384_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA3_384_Update(WOLFSSL_SHA3_384_CTX* sha,
+                                        const void* input, unsigned long sz);
+WOLFSSL_API int wolfSSL_SHA3_384_Final(unsigned char* output,
+                                       WOLFSSL_SHA3_384_CTX* sha);
+
+enum {
+    SHA3_384_DIGEST_LENGTH = 48
+};
+
+typedef WOLFSSL_SHA3_384_CTX SHA3_384_CTX;
+
+#define SHA3_384_Init   wolfSSL_SHA3_384_Init
+#define SHA3_384_Update wolfSSL_SHA3_384_Update
+#define SHA3_384_Final  wolfSSL_SHA3_384_Final
+#if defined(NO_OLD_WC_NAMES) && !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+    #define SHA3_384 wolfSSL_SHA3_384
+#endif
+
+
+#ifndef WOLFSSL_NOSHA3_512
+
+typedef struct WOLFSSL_SHA3_CTX WOLFSSL_SHA3_512_CTX;
+
+WOLFSSL_API int wolfSSL_SHA3_512_Init(WOLFSSL_SHA3_512_CTX* sha);
+WOLFSSL_API int wolfSSL_SHA3_512_Update(WOLFSSL_SHA3_512_CTX* sha,
+                                        const void* input, unsigned long sz);
+WOLFSSL_API int wolfSSL_SHA3_512_Final(unsigned char* output,
+                                       WOLFSSL_SHA3_512_CTX* sha);
+
+enum {
+    SHA3_512_DIGEST_LENGTH = 64
+};
+
+
+typedef WOLFSSL_SHA3_512_CTX SHA3_512_CTX;
+
+#define SHA3_512_Init   wolfSSL_SHA3_512_Init
+#define SHA3_512_Update wolfSSL_SHA3_512_Update
+#define SHA3_512_Final  wolfSSL_SHA3_512_Final
+#if defined(NO_OLD_WC_NAMES) && !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+    #define SHA3_512 wolfSSL_SHA3_512
+#endif
+#endif /* WOLFSSL_NOSHA3_512 */
+
+
+
+
+#ifdef __cplusplus
+    }  /* extern "C" */
+#endif
+
+
+#endif /* WOLFSSL_SHA3_H_ */
+

--- a/include/wolfssl/openssl/sha3.h
+++ b/include/wolfssl/openssl/sha3.h
@@ -27,6 +27,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 #include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/sha3.h>
 
 #ifdef WOLFSSL_PREFIX
 #include "prefix_sha.h"
@@ -41,7 +42,11 @@
  * to Sha3 is expected to also be 16 byte aligned addresses.  */
 struct WOLFSSL_SHA3_CTX {
     /* big enough to hold wolfcrypt Sha3, but check on init */
+#ifdef WOLFSSL_SHA3
+    ALIGN16 void* holder[sizeof(wc_Sha3)];
+#else
     ALIGN16 void* holder[(424 + WC_ASYNC_DEV_SIZE) / sizeof(void*)];
+#endif
 };
 
 #ifndef WOLFSSL_NOSHA3_224

--- a/include/wolfssl/openssl/ssl.h
+++ b/include/wolfssl/openssl/ssl.h
@@ -37,7 +37,6 @@
 #include <wolfssl/ssl.h>
 #endif /* OPENSSL_EXTRA_SSL_GUARD */
 
-#ifndef EMBEDDED_SSL
 #include <wolfssl/openssl/tls1.h>
 #ifndef WOLFCRYPT_ONLY
 #include <wolfssl/openssl/evp.h>
@@ -59,7 +58,6 @@
 #include <wolfssl/wolfcrypt/asn.h>
 
 #include <wolfssl/openssl/x509.h>
-#endif /* EMBEDDED_SSL */
 
 #ifdef __cplusplus
     extern "C" {
@@ -75,7 +73,7 @@
     #undef ASN1_INTEGER
 #endif
 
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || defined(EMBEDDED_SSL)
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 
 typedef WOLFSSL          SSL;
 typedef WOLFSSL_SESSION  SSL_SESSION;
@@ -1686,7 +1684,7 @@ typedef WOLFSSL_CONF_CTX SSL_CONF_CTX;
 #define SSL_CONF_cmd                    wolfSSL_CONF_cmd
 #define SSL_CONF_cmd_value_type         wolfSSL_CONF_cmd_value_type
 
-#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL || EMBEDDED_SSL */
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 
 
 #ifdef WOLFSSL_QUIC

--- a/include/wolfssl/openssl/ssl.h
+++ b/include/wolfssl/openssl/ssl.h
@@ -210,6 +210,7 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define i2d_PKCS8PrivateKey_bio         wolfSSL_PEM_write_bio_PKCS8PrivateKey
 #define PKCS8_PRIV_KEY_INFO_free        wolfSSL_EVP_PKEY_free
 #define d2i_PKCS12_fp                   wolfSSL_d2i_PKCS12_fp
+#define SSL_set_ecdh_auto               wolfSSL_set_ecdh_auto
 #define SSL_CTX_set_ecdh_auto           wolfSSL_CTX_set_ecdh_auto
 
 #define i2d_PUBKEY                      wolfSSL_i2d_PUBKEY
@@ -366,6 +367,8 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define SSL_SESSION_dup                 wolfSSL_SESSION_dup
 #define SSL_SESSION_free                wolfSSL_SESSION_free
 #define SSL_SESSION_set_cipher          wolfSSL_SESSION_set_cipher
+#define SSL_SESSION_get_max_fragment_length \
+                                        wolfSSL_SESSION_get_max_fragment_length
 #define SSL_is_init_finished            wolfSSL_is_init_finished
 
 #define SSL_SESSION_set1_id             wolfSSL_SESSION_set1_id
@@ -500,6 +503,8 @@ typedef STACK_OF(ACCESS_DESCRIPTION) AUTHORITY_INFO_ACCESS;
 #define X509_set_pubkey                 wolfSSL_X509_set_pubkey
 #define X509_set_notAfter               wolfSSL_X509_set_notAfter
 #define X509_set_notBefore              wolfSSL_X509_set_notBefore
+#define X509_set1_notAfter              wolfSSL_X509_set1_notAfter
+#define X509_set1_notBefore             wolfSSL_X509_set1_notBefore
 #define X509_set_serialNumber           wolfSSL_X509_set_serialNumber
 #define X509_set_version                wolfSSL_X509_set_version
 #define X509_REQ_set_version            wolfSSL_X509_set_version
@@ -634,6 +639,9 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 #define X509_V_FLAG_CRL_CHECK     WOLFSSL_CRL_CHECK
 #define X509_V_FLAG_CRL_CHECK_ALL WOLFSSL_CRL_CHECKALL
 
+#define X509_V_FLAG_PARTIAL_CHAIN 0
+#define X509_V_FLAG_TRUSTED_FIRST 0
+
 #define X509_V_FLAG_USE_CHECK_TIME WOLFSSL_USE_CHECK_TIME
 #define X509_V_FLAG_NO_CHECK_TIME  WOLFSSL_NO_CHECK_TIME
 #define X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT WOLFSSL_ALWAYS_CHECK_SUBJECT
@@ -674,10 +682,13 @@ typedef WOLFSSL_X509_NAME_ENTRY X509_NAME_ENTRY;
 wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_CTX_verify_cb)(c))
 #define X509_STORE_set_verify_cb_func(s, c) \
 wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_CTX_verify_cb)(c))
+#define X509_STORE_set_get_crl          wolfSSL_X509_STORE_set_get_crl
+#define X509_STORE_set_check_crl        wolfSSL_X509_STORE_set_check_crl
 
 
 #define X509_STORE_new                  wolfSSL_X509_STORE_new
 #define X509_STORE_free                 wolfSSL_X509_STORE_free
+#define X509_STORE_up_ref               wolfSSL_X509_STORE_up_ref
 #define X509_STORE_add_lookup           wolfSSL_X509_STORE_add_lookup
 #define X509_STORE_add_cert             wolfSSL_X509_STORE_add_cert
 #define X509_STORE_add_crl              wolfSSL_X509_STORE_add_crl
@@ -686,8 +697,10 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define X509_STORE_get_by_subject       wolfSSL_X509_STORE_get_by_subject
 #define X509_STORE_set_ex_data          wolfSSL_X509_STORE_set_ex_data
 #define X509_STORE_get_ex_data          wolfSSL_X509_STORE_get_ex_data
+#define X509_STORE_get0_param           wolfSSL_X509_STORE_get0_param
 #define X509_STORE_CTX_get1_issuer      wolfSSL_X509_STORE_CTX_get1_issuer
 #define X509_STORE_CTX_set_time         wolfSSL_X509_STORE_CTX_set_time
+#define X509_STORE_CTX_get0_param       wolfSSL_X509_STORE_CTX_get0_param
 #define X509_VERIFY_PARAM_new           wolfSSL_X509_VERIFY_PARAM_new
 #define X509_VERIFY_PARAM_free          wolfSSL_X509_VERIFY_PARAM_free
 #define X509_VERIFY_PARAM_set_flags     wolfSSL_X509_VERIFY_PARAM_set_flags
@@ -711,6 +724,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define d2i_X509_CRL_fp                 wolfSSL_d2i_X509_CRL_fp
 #define PEM_read_X509_CRL               wolfSSL_PEM_read_X509_CRL
 
+#define X509_CRL_dup                    wolfSSL_X509_CRL_dup
 #define X509_CRL_free                   wolfSSL_X509_CRL_free
 #define X509_CRL_get_lastUpdate         wolfSSL_X509_CRL_get_lastUpdate
 #define X509_CRL_get0_lastUpdate        wolfSSL_X509_CRL_get_lastUpdate
@@ -822,6 +836,10 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #define COMP_rle                        wolfSSL_COMP_rle
 #define SSL_COMP_add_compression_method wolfSSL_COMP_add_compression_method
 
+#define SSL_get_current_compression(ssl) 0
+#define SSL_get_current_expansion(ssl) 0
+#define SSL_COMP_get_name               wolfSSL_COMP_get_name
+
 #define SSL_get_ex_new_index            wolfSSL_get_ex_new_index
 #define RSA_get_ex_new_index            wolfSSL_get_ex_new_index
 
@@ -835,18 +853,21 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #ifndef NO_ASN_TIME
 #define ASN1_TIME_new                   wolfSSL_ASN1_TIME_new
 #define ASN1_UTCTIME_new                wolfSSL_ASN1_TIME_new
+#define ASN1_GENERALIZEDTIME_new        wolfSSL_ASN1_TIME_new
 #define ASN1_TIME_free                  wolfSSL_ASN1_TIME_free
 #define ASN1_UTCTIME_free               wolfSSL_ASN1_TIME_free
+#define ASN1_GENERALIZEDTIME_free       wolfSSL_ASN1_TIME_free
 #define ASN1_TIME_adj                   wolfSSL_ASN1_TIME_adj
 #define ASN1_TIME_print                 wolfSSL_ASN1_TIME_print
 #define ASN1_TIME_to_string             wolfSSL_ASN1_TIME_to_string
 #define ASN1_TIME_to_tm                 wolfSSL_ASN1_TIME_to_tm
 #define ASN1_TIME_to_generalizedtime    wolfSSL_ASN1_TIME_to_generalizedtime
+#define ASN1_UTCTIME_set                wolfSSL_ASN1_UTCTIME_set
 #endif
 #define ASN1_TIME_set                   wolfSSL_ASN1_TIME_set
 #define ASN1_TIME_set_string            wolfSSL_ASN1_TIME_set_string
+#define ASN1_GENERALIZEDTIME_set_string wolfSSL_ASN1_TIME_set_string
 #define ASN1_GENERALIZEDTIME_print      wolfSSL_ASN1_GENERALIZEDTIME_print
-#define ASN1_GENERALIZEDTIME_free       wolfSSL_ASN1_GENERALIZEDTIME_free
 
 #define ASN1_tag2str                    wolfSSL_ASN1_tag2str
 
@@ -916,7 +937,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 #endif
 #define SSL_set0_verify_cert_store      wolfSSL_set0_verify_cert_store
 #define SSL_set1_verify_cert_store      wolfSSL_set1_verify_cert_store
-#define SSL_CTX_get_cert_store(x)       wolfSSL_CTX_get_cert_store ((WOLFSSL_CTX*) (x))
+#define SSL_CTX_get_cert_store(x)       wolfSSL_CTX_get_cert_store ((x))
 #define SSL_get_client_CA_list          wolfSSL_get_client_CA_list
 #define SSL_set_client_CA_list          wolfSSL_set_client_CA_list
 #define SSL_get_ex_data_X509_STORE_CTX_idx wolfSSL_get_ex_data_X509_STORE_CTX_idx
@@ -937,7 +958,7 @@ wolfSSL_X509_STORE_set_verify_cb((WOLFSSL_X509_STORE *)(s), (WOLFSSL_X509_STORE_
 
 #define SSL_alert_type_string           wolfSSL_alert_type_string
 #define SSL_alert_desc_string           wolfSSL_alert_desc_string
-#define SSL_state_string                wolfSSL_state_string
+#define SSL_state_string                wolfSSL_state_string_long
 
 #define RSA_free                        wolfSSL_RSA_free
 #define RSA_generate_key                wolfSSL_RSA_generate_key
@@ -1212,6 +1233,7 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
 
 #define TLSEXT_STATUSTYPE_ocsp  1
 
+#define TLSEXT_max_fragment_length_DISABLED WOLFSSL_MFL_DISABLED
 #define TLSEXT_max_fragment_length_512   WOLFSSL_MFL_2_9
 #define TLSEXT_max_fragment_length_1024  WOLFSSL_MFL_2_10
 #define TLSEXT_max_fragment_length_2048  WOLFSSL_MFL_2_11
@@ -1336,6 +1358,10 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
 #define SSL_CONF_TYPE_STRING             WOLFSSL_CONF_TYPE_STRING
 #define SSL_CONF_TYPE_FILE               WOLFSSL_CONF_TYPE_FILE
 #define SSL_CONF_TYPE_DIR                WOLFSSL_CONF_TYPE_DIR
+
+#define OPENSSL_INIT_new                 wolfSSL_OPENSSL_INIT_new
+#define OPENSSL_INIT_free                wolfSSL_OPENSSL_INIT_free
+#define OPENSSL_INIT_set_config_appname  wolfSSL_OPENSSL_INIT_set_config_appname
 
 #if defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
     defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
@@ -1511,7 +1537,8 @@ typedef WOLFSSL_SRTP_PROTECTION_PROFILE      SRTP_PROTECTION_PROFILE;
 #define OPENSSL_STRING    WOLFSSL_STRING
 #define OPENSSL_CSTRING   WOLFSSL_STRING
 
-#define TLSEXT_TYPE_application_layer_protocol_negotiation    16
+#define TLSEXT_TYPE_application_layer_protocol_negotiation \
+    TLSXT_APPLICATION_LAYER_PROTOCOL
 
 #define OPENSSL_NPN_UNSUPPORTED 0
 #define OPENSSL_NPN_NEGOTIATED  1

--- a/include/wolfssl/openssl/stack.h
+++ b/include/wolfssl/openssl/stack.h
@@ -1,0 +1,61 @@
+/* stack.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* stack.h for openSSL */
+
+#ifndef WOLFSSL_STACK_H_
+#define WOLFSSL_STACK_H_
+
+#include <wolfssl/openssl/compat_types.h>
+#include <wolfssl/openssl/ssl.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+typedef void (*wolfSSL_sk_freefunc)(void *);
+
+WOLFSSL_API void wolfSSL_sk_GENERIC_pop_free(WOLFSSL_STACK* sk, wolfSSL_sk_freefunc f);
+WOLFSSL_API void wolfSSL_sk_GENERIC_free(WOLFSSL_STACK *sk);
+WOLFSSL_API int wolfSSL_sk_GENERIC_push(WOLFSSL_STACK *sk, void *data);
+WOLFSSL_API void wolfSSL_sk_pop_free(WOLFSSL_STACK *st, void (*func) (void *));
+WOLFSSL_API WOLFSSL_STACK *wolfSSL_sk_new_null(void);
+
+WOLFSSL_API int wolfSSL_sk_CIPHER_push(WOLFSSL_STACK *st,WOLFSSL_CIPHER *cipher);
+WOLFSSL_API WOLFSSL_CIPHER* wolfSSL_sk_CIPHER_pop(WOLF_STACK_OF(WOLFSSL_CIPHER)* sk);
+WOLFSSL_API WOLFSSL_STACK* wolfSSL_sk_new_cipher(void);
+
+#define OPENSSL_sk_free       wolfSSL_sk_free
+#define OPENSSL_sk_pop_free   wolfSSL_sk_pop_free
+#define OPENSSL_sk_new_null   wolfSSL_sk_new_null
+#define OPENSSL_sk_push       wolfSSL_sk_push
+
+/* provides older OpenSSL API compatibility  */
+#define sk_free         OPENSSL_sk_free
+#define sk_pop_free     OPENSSL_sk_pop_free
+#define sk_new_null     OPENSSL_sk_new_null
+#define sk_push         OPENSSL_sk_push
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif

--- a/include/wolfssl/openssl/tls1.h
+++ b/include/wolfssl/openssl/tls1.h
@@ -1,0 +1,52 @@
+/* tls1.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#ifndef WOLFSSL_OPENSSL_TLS1_H_
+#define WOLFSSL_OPENSSL_TLS1_H_
+
+#ifndef TLS1_VERSION
+#define TLS1_VERSION                    0x0301
+#endif
+
+#ifndef TLS1_1_VERSION
+#define TLS1_1_VERSION                  0x0302
+#endif
+
+#ifndef TLS1_2_VERSION
+#define TLS1_2_VERSION                  0x0303
+#endif
+
+#ifndef TLS1_3_VERSION
+#define TLS1_3_VERSION                  0x0304
+#endif
+
+#ifndef TLS_MAX_VERSION
+#define TLS_MAX_VERSION                 TLS1_3_VERSION
+#endif
+
+#ifdef WOLFSSL_QUIC
+/* from rfc9001 */
+#define TLSEXT_TYPE_quic_transport_parameters_draft   0xffa5
+#define TLSEXT_TYPE_quic_transport_parameters         0x0039
+#endif
+
+#endif /* WOLFSSL_OPENSSL_TLS1_H_ */

--- a/include/wolfssl/openssl/tls1.h
+++ b/include/wolfssl/openssl/tls1.h
@@ -45,8 +45,10 @@
 
 #ifdef WOLFSSL_QUIC
 /* from rfc9001 */
-#define TLSEXT_TYPE_quic_transport_parameters_draft   0xffa5
-#define TLSEXT_TYPE_quic_transport_parameters         0x0039
+#define TLSEXT_TYPE_quic_transport_parameters_draft   \
+    TLSXT_KEY_QUIC_TP_PARAMS_DRAFT
+#define TLSEXT_TYPE_quic_transport_parameters         \
+    TLSXT_KEY_QUIC_TP_PARAMS
 #endif
 
 #endif /* WOLFSSL_OPENSSL_TLS1_H_ */

--- a/include/wolfssl/openssl/txt_db.h
+++ b/include/wolfssl/openssl/txt_db.h
@@ -1,0 +1,60 @@
+/* txt_db.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifndef WOLFSSL_TXT_DB_H_
+#define WOLFSSL_TXT_DB_H_
+
+#include <wolfssl/openssl/ssl.h>
+
+#define WOLFSSL_TXT_DB_MAX_FIELDS 10
+
+struct WOLFSSL_TXT_DB {
+    int num_fields;
+    WOLF_STACK_OF(WOLFSSL_STRING) *data;
+    long error;
+    long arg1;
+    long arg2;
+    wolf_sk_hash_cb hash_fn[WOLFSSL_TXT_DB_MAX_FIELDS];
+};
+
+typedef struct WOLFSSL_TXT_DB WOLFSSL_TXT_DB;
+typedef int (*wolf_lh_compare_cb)(const void* a,
+                                  const void* b);
+
+WOLFSSL_API WOLFSSL_TXT_DB *wolfSSL_TXT_DB_read(WOLFSSL_BIO *in, int num);
+WOLFSSL_API long wolfSSL_TXT_DB_write(WOLFSSL_BIO  *out, WOLFSSL_TXT_DB *db);
+WOLFSSL_API int wolfSSL_TXT_DB_insert(WOLFSSL_TXT_DB *db, WOLFSSL_STRING *row);
+WOLFSSL_API void wolfSSL_TXT_DB_free(WOLFSSL_TXT_DB *db);
+WOLFSSL_API int wolfSSL_TXT_DB_create_index(WOLFSSL_TXT_DB *db, int field,
+        void* qual, wolf_sk_hash_cb hash, wolf_lh_compare_cb cmp);
+WOLFSSL_API WOLFSSL_STRING *wolfSSL_TXT_DB_get_by_index(WOLFSSL_TXT_DB *db,
+        int idx, WOLFSSL_STRING *value);
+
+#define TXT_DB                  WOLFSSL_TXT_DB
+
+#define TXT_DB_read             wolfSSL_TXT_DB_read
+#define TXT_DB_write            wolfSSL_TXT_DB_write
+#define TXT_DB_insert           wolfSSL_TXT_DB_insert
+#define TXT_DB_free             wolfSSL_TXT_DB_free
+#define TXT_DB_create_index     wolfSSL_TXT_DB_create_index
+#define TXT_DB_get_by_index     wolfSSL_TXT_DB_get_by_index
+
+#endif /* WOLFSSL_TXT_DB_H_ */

--- a/include/wolfssl/openssl/x509.h
+++ b/include/wolfssl/openssl/x509.h
@@ -1,0 +1,199 @@
+/* x509.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* x509.h for openssl */
+
+#ifndef WOLFSSL_OPENSSL_509_H_
+#define WOLFSSL_OPENSSL_509_H_
+
+#include <wolfssl/openssl/ssl.h>
+#include <wolfssl/openssl/crypto.h>
+#include <wolfssl/openssl/dh.h>
+#include <wolfssl/openssl/ec.h>
+#include <wolfssl/openssl/ecdsa.h>
+#include <wolfssl/openssl/pkcs7.h>
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+
+/* wolfSSL_X509_print_ex flags */
+#define X509_FLAG_COMPAT        (0UL)
+#define X509_FLAG_NO_HEADER     (1UL << 0)
+#define X509_FLAG_NO_VERSION    (1UL << 1)
+#define X509_FLAG_NO_SERIAL     (1UL << 2)
+#define X509_FLAG_NO_SIGNAME    (1UL << 3)
+#define X509_FLAG_NO_ISSUER     (1UL << 4)
+#define X509_FLAG_NO_VALIDITY   (1UL << 5)
+#define X509_FLAG_NO_SUBJECT    (1UL << 6)
+#define X509_FLAG_NO_PUBKEY     (1UL << 7)
+#define X509_FLAG_NO_EXTENSIONS (1UL << 8)
+#define X509_FLAG_NO_SIGDUMP    (1UL << 9)
+#define X509_FLAG_NO_AUX        (1UL << 10)
+#define X509_FLAG_NO_ATTRIBUTES (1UL << 11)
+#define X509_FLAG_NO_IDS        (1UL << 12)
+
+#define XN_FLAG_FN_SN           0
+#define XN_FLAG_ONELINE         0
+#define XN_FLAG_COMPAT          0
+#define XN_FLAG_RFC2253         1
+#define XN_FLAG_SEP_COMMA_PLUS  (1 << 16)
+#define XN_FLAG_SEP_CPLUS_SPC   (2 << 16)
+#define XN_FLAG_SEP_SPLUS_SPC   (3 << 16)
+#define XN_FLAG_SEP_MULTILINE   (4 << 16)
+#define XN_FLAG_SEP_MASK        (0xF << 16)
+#define XN_FLAG_DN_REV          (1 << 20)
+#define XN_FLAG_FN_LN           (1 << 21)
+#define XN_FLAG_FN_OID          (2 << 21)
+#define XN_FLAG_FN_NONE         (3 << 21)
+#define XN_FLAG_FN_MASK         (3 << 21)
+#define XN_FLAG_SPC_EQ          (1 << 23)
+#define XN_FLAG_DUMP_UNKNOWN_FIELDS (1 << 24)
+#define XN_FLAG_FN_ALIGN        (1 << 25)
+
+#define XN_FLAG_MULTILINE       0xFFFF
+
+/*
+ * All of these aren't actually used in wolfSSL. Some are included to
+ * satisfy OpenSSL compatibility consumers to prevent compilation errors.
+ * The list was taken from
+ * https://github.com/openssl/openssl/blob/master/include/openssl/x509_vfy.h.in
+ * One requirement for HAProxy is that the values should be literal constants.
+ */
+
+#define X509_V_OK                                       0
+#define X509_V_ERR_UNSPECIFIED                          1
+#define X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT            2
+#define X509_V_ERR_UNABLE_TO_GET_CRL                    3
+#define X509_V_ERR_UNABLE_TO_DECRYPT_CERT_SIGNATURE     4
+#define X509_V_ERR_UNABLE_TO_DECRYPT_CRL_SIGNATURE      5
+#define X509_V_ERR_UNABLE_TO_DECODE_ISSUER_PUBLIC_KEY   6
+#define X509_V_ERR_CERT_SIGNATURE_FAILURE               7
+#define X509_V_ERR_CRL_SIGNATURE_FAILURE                8
+#define X509_V_ERR_CERT_NOT_YET_VALID                   9
+#define X509_V_ERR_CERT_HAS_EXPIRED                     10
+#define X509_V_ERR_CRL_NOT_YET_VALID                    11
+#define X509_V_ERR_CRL_HAS_EXPIRED                      12
+#define X509_V_ERR_ERROR_IN_CERT_NOT_BEFORE_FIELD       13
+#define X509_V_ERR_ERROR_IN_CERT_NOT_AFTER_FIELD        14
+#define X509_V_ERR_ERROR_IN_CRL_LAST_UPDATE_FIELD       15
+#define X509_V_ERR_ERROR_IN_CRL_NEXT_UPDATE_FIELD       16
+#define X509_V_ERR_OUT_OF_MEM                           17
+#define X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT          18
+#define X509_V_ERR_SELF_SIGNED_CERT_IN_CHAIN            19
+#define X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY    20
+#define X509_V_ERR_UNABLE_TO_VERIFY_LEAF_SIGNATURE      21
+#define X509_V_ERR_CERT_CHAIN_TOO_LONG                  22
+#define X509_V_ERR_CERT_REVOKED                         23
+#define X509_V_ERR_NO_ISSUER_PUBLIC_KEY                 24
+#define X509_V_ERR_PATH_LENGTH_EXCEEDED                 25
+#define X509_V_ERR_INVALID_PURPOSE                      26
+#define X509_V_ERR_CERT_UNTRUSTED                       27
+#define X509_V_ERR_CERT_REJECTED                        28
+
+/* These are 'informational' when looking for issuer cert */
+#define X509_V_ERR_SUBJECT_ISSUER_MISMATCH              29
+#define X509_V_ERR_AKID_SKID_MISMATCH                   30
+#define X509_V_ERR_AKID_ISSUER_SERIAL_MISMATCH          31
+#define X509_V_ERR_KEYUSAGE_NO_CERTSIGN                 32
+#define X509_V_ERR_UNABLE_TO_GET_CRL_ISSUER             33
+#define X509_V_ERR_UNHANDLED_CRITICAL_EXTENSION         34
+#define X509_V_ERR_KEYUSAGE_NO_CRL_SIGN                 35
+#define X509_V_ERR_UNHANDLED_CRITICAL_CRL_EXTENSION     36
+#define X509_V_ERR_INVALID_NON_CA                       37
+#define X509_V_ERR_PROXY_PATH_LENGTH_EXCEEDED           38
+#define X509_V_ERR_KEYUSAGE_NO_DIGITAL_SIGNATURE        39
+#define X509_V_ERR_PROXY_CERTIFICATES_NOT_ALLOWED       40
+#define X509_V_ERR_INVALID_EXTENSION                    41
+#define X509_V_ERR_INVALID_POLICY_EXTENSION             42
+#define X509_V_ERR_NO_EXPLICIT_POLICY                   43
+#define X509_V_ERR_DIFFERENT_CRL_SCOPE                  44
+#define X509_V_ERR_UNSUPPORTED_EXTENSION_FEATURE        45
+#define X509_V_ERR_UNNESTED_RESOURCE                    46
+#define X509_V_ERR_PERMITTED_VIOLATION                  47
+#define X509_V_ERR_EXCLUDED_VIOLATION                   48
+#define X509_V_ERR_SUBTREE_MINMAX                       49
+/* The application is not happy */
+#define X509_V_ERR_APPLICATION_VERIFICATION             50
+#define X509_V_ERR_UNSUPPORTED_CONSTRAINT_TYPE          51
+#define X509_V_ERR_UNSUPPORTED_CONSTRAINT_SYNTAX        52
+#define X509_V_ERR_UNSUPPORTED_NAME_SYNTAX              53
+#define X509_V_ERR_CRL_PATH_VALIDATION_ERROR            54
+/* Another issuer check debug option */
+#define X509_V_ERR_PATH_LOOP                            55
+/* Suite B mode algorithm violation */
+#define X509_V_ERR_SUITE_B_INVALID_VERSION              56
+#define X509_V_ERR_SUITE_B_INVALID_ALGORITHM            57
+#define X509_V_ERR_SUITE_B_INVALID_CURVE                58
+#define X509_V_ERR_SUITE_B_INVALID_SIGNATURE_ALGORITHM  59
+#define X509_V_ERR_SUITE_B_LOS_NOT_ALLOWED              60
+#define X509_V_ERR_SUITE_B_CANNOT_SIGN_P_384_WITH_P_256 61
+/* Host, email and IP check errors */
+#define X509_V_ERR_HOSTNAME_MISMATCH                    62
+#define X509_V_ERR_EMAIL_MISMATCH                       63
+#define X509_V_ERR_IP_ADDRESS_MISMATCH                  64
+/* DANE TLSA errors */
+#define X509_V_ERR_DANE_NO_MATCH                        65
+/* security level errors */
+#define X509_V_ERR_EE_KEY_TOO_SMALL                     66
+#define X509_V_ERR_CA_KEY_TOO_SMALL                     67
+#define X509_V_ERR_CA_MD_TOO_WEAK                       68
+/* Caller error */
+#define X509_V_ERR_INVALID_CALL                         69
+/* Issuer lookup error */
+#define X509_V_ERR_STORE_LOOKUP                         70
+/* Certificate transparency */
+#define X509_V_ERR_NO_VALID_SCTS                        71
+
+#define X509_V_ERR_PROXY_SUBJECT_NAME_VIOLATION         72
+/* OCSP status errors */
+#define X509_V_ERR_OCSP_VERIFY_NEEDED                   73
+#define X509_V_ERR_OCSP_VERIFY_FAILED                   74
+#define X509_V_ERR_OCSP_CERT_UNKNOWN                    75
+
+#define X509_V_ERR_UNSUPPORTED_SIGNATURE_ALGORITHM      76
+#define X509_V_ERR_SIGNATURE_ALGORITHM_MISMATCH         77
+
+/* Errors in case a check in X509_V_FLAG_X509_STRICT mode fails */
+#define X509_V_ERR_SIGNATURE_ALGORITHM_INCONSISTENCY    78
+#define X509_V_ERR_INVALID_CA                           79
+#define X509_V_ERR_PATHLEN_INVALID_FOR_NON_CA           80
+#define X509_V_ERR_PATHLEN_WITHOUT_KU_KEY_CERT_SIGN     81
+#define X509_V_ERR_KU_KEY_CERT_SIGN_INVALID_FOR_NON_CA  82
+#define X509_V_ERR_ISSUER_NAME_EMPTY                    83
+#define X509_V_ERR_SUBJECT_NAME_EMPTY                   84
+#define X509_V_ERR_MISSING_AUTHORITY_KEY_IDENTIFIER     85
+#define X509_V_ERR_MISSING_SUBJECT_KEY_IDENTIFIER       86
+#define X509_V_ERR_EMPTY_SUBJECT_ALT_NAME               87
+#define X509_V_ERR_EMPTY_SUBJECT_SAN_NOT_CRITICAL       88
+#define X509_V_ERR_CA_BCONS_NOT_CRITICAL                89
+#define X509_V_ERR_AUTHORITY_KEY_IDENTIFIER_CRITICAL    90
+#define X509_V_ERR_SUBJECT_KEY_IDENTIFIER_CRITICAL      91
+#define X509_V_ERR_CA_CERT_MISSING_KEY_USAGE            92
+#define X509_V_ERR_EXTENSIONS_REQUIRE_VERSION_3         93
+#define X509_V_ERR_EC_KEY_EXPLICIT_PARAMS               94
+#define X509_R_CERT_ALREADY_IN_HASH_TABLE               101
+
+#define X509_EXTENSION_set_critical wolfSSL_X509_EXTENSION_set_critical
+#define X509_EXTENSION_set_object   wolfSSL_X509_EXTENSION_set_object
+#define X509_EXTENSION_set_data     wolfSSL_X509_EXTENSION_set_data
+
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+#endif /* WOLFSSL_OPENSSL_509_H_ */

--- a/include/wolfssl/openssl/x509.h
+++ b/include/wolfssl/openssl/x509.h
@@ -50,7 +50,6 @@
 #define X509_FLAG_NO_IDS        (1UL << 12)
 
 #define XN_FLAG_FN_SN           0
-#define XN_FLAG_ONELINE         0
 #define XN_FLAG_COMPAT          0
 #define XN_FLAG_RFC2253         1
 #define XN_FLAG_SEP_COMMA_PLUS  (1 << 16)
@@ -68,6 +67,7 @@
 #define XN_FLAG_FN_ALIGN        (1 << 25)
 
 #define XN_FLAG_MULTILINE       0xFFFF
+#define XN_FLAG_ONELINE (XN_FLAG_SEP_CPLUS_SPC | XN_FLAG_SPC_EQ | XN_FLAG_FN_SN)
 
 /*
  * All of these aren't actually used in wolfSSL. Some are included to

--- a/include/wolfssl/openssl/x509_vfy.h
+++ b/include/wolfssl/openssl/x509_vfy.h
@@ -1,0 +1,47 @@
+/* x509_vfy.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* x509_vfy.h for openSSL */
+
+#ifndef WOLFSSL_x509_vfy_H_
+#define WOLFSSL_x509_vfy_H_
+
+#include <wolfssl/openssl/compat_types.h>
+#include <wolfssl/openssl/x509v3.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#if defined(WOLFSSL_QT) || defined(OPENSSL_ALL)
+    WOLFSSL_API int wolfSSL_X509_STORE_CTX_set_purpose(WOLFSSL_X509_STORE_CTX *ctx, int purpose);
+    WOLFSSL_API void wolfSSL_X509_STORE_CTX_set_flags(WOLFSSL_X509_STORE_CTX *ctx,
+        unsigned long flags);
+#endif
+
+#define X509_STORE_CTX_set_purpose  wolfSSL_X509_STORE_CTX_set_purpose
+#define X509_STORE_CTX_set_flags    wolfSSL_X509_STORE_CTX_set_flags
+
+#ifdef  __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_x509_vfy_H_ */

--- a/include/wolfssl/openssl/x509v3.h
+++ b/include/wolfssl/openssl/x509v3.h
@@ -1,0 +1,176 @@
+/* x509v3.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+/* x509v3.h for openSSL */
+
+#ifndef WOLFSSL_x509v3_H
+#define WOLFSSL_x509v3_H
+
+#include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/openssl/compat_types.h>
+#include <wolfssl/openssl/conf.h>
+#include <wolfssl/openssl/bio.h>
+#include <wolfssl/openssl/ssl.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+
+#define EXFLAG_KUSAGE  0x2
+#define EXFLAG_XKUSAGE 0x4
+
+#define KU_DIGITAL_SIGNATURE    KEYUSE_DIGITAL_SIG
+#define KU_NON_REPUDIATION      KEYUSE_CONTENT_COMMIT
+#define KU_KEY_ENCIPHERMENT     KEYUSE_KEY_ENCIPHER
+#define KU_DATA_ENCIPHERMENT    KEYUSE_DATA_ENCIPHER
+#define KU_KEY_AGREEMENT        KEYUSE_KEY_AGREE
+#define KU_KEY_CERT_SIGN        KEYUSE_KEY_CERT_SIGN
+#define KU_CRL_SIGN             KEYUSE_CRL_SIGN
+#define KU_ENCIPHER_ONLY        KEYUSE_ENCIPHER_ONLY
+#define KU_DECIPHER_ONLY        KEYUSE_DECIPHER_ONLY
+
+#define XKU_SSL_SERVER 0x1
+#define XKU_SSL_CLIENT 0x2
+#define XKU_SMIME      0x4
+#define XKU_CODE_SIGN  0x8
+#define XKU_SGC        0x10
+#define XKU_OCSP_SIGN  0x20
+#define XKU_TIMESTAMP  0x40
+#define XKU_DVCS       0x80
+#define XKU_ANYEKU     0x100
+
+#define X509_PURPOSE_SSL_CLIENT       0
+#define X509_PURPOSE_SSL_SERVER       1
+
+#define NS_SSL_CLIENT                 WC_NS_SSL_CLIENT
+#define NS_SSL_SERVER                 WC_NS_SSL_SERVER
+
+/* Forward reference */
+
+#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x0090801fL
+typedef void *(*X509V3_EXT_D2I)(void *, const unsigned char **, long);
+#else
+typedef void *(*X509V3_EXT_D2I)(void *, unsigned char **, long);
+#endif
+typedef int (*X509V3_EXT_I2D) (void *, unsigned char **);
+typedef STACK_OF(CONF_VALUE) *(*X509V3_EXT_I2V) (
+                                struct WOLFSSL_v3_ext_method *method,
+                                void *ext, STACK_OF(CONF_VALUE) *extlist);
+typedef char *(*X509V3_EXT_I2S)(struct WOLFSSL_v3_ext_method *method, void *ext);
+typedef int (*X509V3_EXT_I2R) (struct WOLFSSL_v3_ext_method *method,
+                               void *ext, BIO *out, int indent);
+typedef struct WOLFSSL_v3_ext_method X509V3_EXT_METHOD;
+
+struct WOLFSSL_v3_ext_method {
+    int ext_nid;
+    int ext_flags;
+    void *usr_data;
+    X509V3_EXT_D2I d2i;
+    X509V3_EXT_I2D i2d;
+    X509V3_EXT_I2V i2v;
+    X509V3_EXT_I2S i2s;
+    X509V3_EXT_I2R i2r;
+};
+
+struct WOLFSSL_X509_EXTENSION {
+    WOLFSSL_ASN1_OBJECT *obj;
+    WOLFSSL_ASN1_BOOLEAN crit;
+    ASN1_OCTET_STRING value; /* DER format of extension */
+    WOLFSSL_v3_ext_method ext_method;
+    WOLFSSL_STACK* ext_sk; /* For extension specific data */
+};
+
+#define WOLFSSL_ASN1_BOOLEAN int
+#define GEN_OTHERNAME   0
+#define GEN_EMAIL       1
+#define GEN_DNS         2
+#define GEN_X400        3
+#define GEN_DIRNAME     4
+#define GEN_EDIPARTY    5
+#define GEN_URI         6
+#define GEN_IPADD       7
+#define GEN_RID         8
+#define GEN_IA5         9
+
+#define GENERAL_NAME       WOLFSSL_GENERAL_NAME
+
+#define X509V3_CTX         WOLFSSL_X509V3_CTX
+
+#define CTX_TEST           0x1
+
+typedef struct WOLFSSL_AUTHORITY_KEYID AUTHORITY_KEYID;
+typedef struct WOLFSSL_BASIC_CONSTRAINTS BASIC_CONSTRAINTS;
+typedef struct WOLFSSL_ACCESS_DESCRIPTION ACCESS_DESCRIPTION;
+typedef WOLF_STACK_OF(WOLFSSL_ACCESS_DESCRIPTION) WOLFSSL_AUTHORITY_INFO_ACCESS;
+
+WOLFSSL_API WOLFSSL_BASIC_CONSTRAINTS* wolfSSL_BASIC_CONSTRAINTS_new(void);
+WOLFSSL_API void wolfSSL_BASIC_CONSTRAINTS_free(WOLFSSL_BASIC_CONSTRAINTS *bc);
+WOLFSSL_API WOLFSSL_AUTHORITY_KEYID* wolfSSL_AUTHORITY_KEYID_new(void);
+WOLFSSL_API void wolfSSL_AUTHORITY_KEYID_free(WOLFSSL_AUTHORITY_KEYID *id);
+#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
+WOLFSSL_API const WOLFSSL_v3_ext_method* wolfSSL_X509V3_EXT_get(
+                                                    WOLFSSL_X509_EXTENSION* ex);
+#else
+WOLFSSL_API WOLFSSL_v3_ext_method* wolfSSL_X509V3_EXT_get(
+                                                    WOLFSSL_X509_EXTENSION* ex);
+#endif
+WOLFSSL_API void* wolfSSL_X509V3_EXT_d2i(WOLFSSL_X509_EXTENSION* ex);
+WOLFSSL_API char* wolfSSL_i2s_ASN1_STRING(WOLFSSL_v3_ext_method *method,
+                                          const WOLFSSL_ASN1_STRING *s);
+WOLFSSL_API int wolfSSL_X509V3_EXT_print(WOLFSSL_BIO *out,
+        WOLFSSL_X509_EXTENSION *ext, unsigned long flag, int indent);
+WOLFSSL_API int wolfSSL_X509V3_EXT_add_nconf(WOLFSSL_CONF *conf, WOLFSSL_X509V3_CTX *ctx,
+        const char *section, WOLFSSL_X509 *cert);
+WOLFSSL_API WOLFSSL_ASN1_STRING* wolfSSL_a2i_IPADDRESS(const char* ipa);
+
+#define BASIC_CONSTRAINTS_free    wolfSSL_BASIC_CONSTRAINTS_free
+#define AUTHORITY_KEYID_free      wolfSSL_AUTHORITY_KEYID_free
+#define SSL_CTX_get_cert_store(x) wolfSSL_CTX_get_cert_store ((WOLFSSL_CTX*) (x))
+#define ASN1_INTEGER              WOLFSSL_ASN1_INTEGER
+#define ASN1_OCTET_STRING         WOLFSSL_ASN1_STRING
+#define X509V3_EXT_get            wolfSSL_X509V3_EXT_get
+#define X509V3_EXT_d2i            wolfSSL_X509V3_EXT_d2i
+#define X509V3_EXT_add_nconf      wolfSSL_X509V3_EXT_add_nconf
+#ifndef NO_WOLFSSL_STUB
+#define X509V3_parse_list(...)    NULL
+#endif
+#define i2s_ASN1_OCTET_STRING     wolfSSL_i2s_ASN1_STRING
+#define a2i_IPADDRESS             wolfSSL_a2i_IPADDRESS
+#define X509V3_EXT_print          wolfSSL_X509V3_EXT_print
+#define X509V3_EXT_conf_nid       wolfSSL_X509V3_EXT_conf_nid
+#define X509V3_set_ctx            wolfSSL_X509V3_set_ctx
+#ifndef NO_WOLFSSL_STUB
+#define X509V3_set_nconf(...)     WC_DO_NOTHING
+#define X509V3_EXT_cleanup(...)   WC_DO_NOTHING
+#endif
+#define X509V3_set_ctx_test(ctx)  wolfSSL_X509V3_set_ctx(ctx, NULL, NULL, NULL, NULL, CTX_TEST)
+#define X509V3_set_ctx_nodb       wolfSSL_X509V3_set_ctx_nodb
+#define X509v3_get_ext_count      wolfSSL_sk_num
+
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
+
+#ifdef  __cplusplus
+}
+#endif
+
+#endif

--- a/include/wolfssl/openssl/x509v3.h
+++ b/include/wolfssl/openssl/x509v3.h
@@ -145,7 +145,7 @@ WOLFSSL_API WOLFSSL_ASN1_STRING* wolfSSL_a2i_IPADDRESS(const char* ipa);
 
 #define BASIC_CONSTRAINTS_free    wolfSSL_BASIC_CONSTRAINTS_free
 #define AUTHORITY_KEYID_free      wolfSSL_AUTHORITY_KEYID_free
-#define SSL_CTX_get_cert_store(x) wolfSSL_CTX_get_cert_store ((WOLFSSL_CTX*) (x))
+#define SSL_CTX_get_cert_store(x) wolfSSL_CTX_get_cert_store ((x))
 #define ASN1_INTEGER              WOLFSSL_ASN1_INTEGER
 #define ASN1_OCTET_STRING         WOLFSSL_ASN1_STRING
 #define X509V3_EXT_get            wolfSSL_X509V3_EXT_get

--- a/include/wolfssl/ssl.h
+++ b/include/wolfssl/ssl.h
@@ -37,6 +37,7 @@
 #include <wolfssl/wolfcrypt/logging.h>
 #include <wolfssl/wolfcrypt/memory.h>
 #include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/pkcs12.h>
 
 /* For the types */
 #include <wolfssl/openssl/compat_types.h>
@@ -152,8 +153,6 @@ typedef struct WOLFSSL_SOCKADDR     WOLFSSL_SOCKADDR;
 typedef struct WOLFSSL_CRL          WOLFSSL_CRL;
 typedef struct WOLFSSL_X509_STORE_CTX WOLFSSL_X509_STORE_CTX;
 
-typedef int (*WOLFSSL_X509_STORE_CTX_verify_cb)(int, WOLFSSL_X509_STORE_CTX *);
-
 typedef struct WOLFSSL_BY_DIR_HASH  WOLFSSL_BY_DIR_HASH;
 typedef struct WOLFSSL_BY_DIR_entry WOLFSSL_BY_DIR_entry;
 typedef struct WOLFSSL_BY_DIR       WOLFSSL_BY_DIR;
@@ -227,6 +226,12 @@ typedef struct WOLFSSL_DIST_POINT_NAME WOLFSSL_DIST_POINT_NAME;
 typedef struct WOLFSSL_DIST_POINT WOLFSSL_DIST_POINT;
 
 typedef struct WOLFSSL_CONF_CTX     WOLFSSL_CONF_CTX;
+
+typedef int (*WOLFSSL_X509_STORE_CTX_verify_cb)(int, WOLFSSL_X509_STORE_CTX *);
+typedef int (*WOLFSSL_X509_STORE_CTX_get_crl_cb)(WOLFSSL_X509_STORE_CTX *,
+        WOLFSSL_X509_CRL **, WOLFSSL_X509 *);
+typedef int (*WOLFSSL_X509_STORE_CTX_check_crl_cb)(WOLFSSL_X509_STORE_CTX *,
+        WOLFSSL_X509_CRL *);
 
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL) || defined(HAVE_CURL)
 
@@ -603,6 +608,7 @@ struct WOLFSSL_X509_STORE {
 #endif
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT)
     WOLFSSL_X509_STORE_CTX_verify_cb verify_cb;
+    WOLFSSL_X509_STORE_CTX_get_crl_cb get_crl_cb;
 #endif
 #ifdef HAVE_EX_DATA
     WOLFSSL_CRYPTO_EX_DATA ex_data;
@@ -704,6 +710,7 @@ struct WOLFSSL_X509_STORE_CTX {
     int   totalCerts;            /* number of peer cert buffers */
     WOLFSSL_BUFFER_INFO* certs;  /* peer certs */
     WOLFSSL_X509_STORE_CTX_verify_cb verify_cb; /* verify callback */
+    void* heap;
 };
 
 typedef char* WOLFSSL_STRING;
@@ -793,9 +800,9 @@ enum SNICbReturn {
  * functions should use this macro to fill this gap. Users who want them
  * to return the same return value as OpenSSL can define
  * WOLFSSL_ERR_CODE_OPENSSL.
- * Give item1 a variable that contains the potentially negative
+ * Give rc a variable that contains the potentially negative
  * wolfSSL-defined return value or the return value itself, and
- * give item2 the openSSL-defined return value.
+ * give fail_rc the openSSL-defined return value.
  * Note that this macro replaces only negative return values with the
  * specified value.
  * Since wolfSSL 4.7.0, the following functions use this macro:
@@ -804,11 +811,15 @@ enum SNICbReturn {
  * - wolfSSL_EVP_PKEY_cmp
  */
 #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
-    #define WS_RETURN_CODE(item1,item2) \
-      (((item1) < 0) ? (int)(item2) : (int)(item1))
+    #define WS_RETURN_CODE(rc, fail_rc) \
+      (((rc) < 0) ? (int)(fail_rc) : (int)(rc))
 #else
-    #define WS_RETURN_CODE(item1,item2)  (item1)
+    #define WS_RETURN_CODE(rc, fail_rc)  (rc)
 #endif
+#define WS_RC(rc) \
+    (((rc) == 1) ? 1 : 0)
+#define WC_TO_WS_RC(ret) \
+    (((ret) == 0) ? 1 : (ret))
 
 /* Maximum master key length (SECRET_LEN) */
 #define WOLFSSL_MAX_MASTER_KEY_LENGTH 48
@@ -1130,6 +1141,7 @@ WOLFSSL_API WOLFSSL_CTX* wolfSSL_CTX_new_ex(WOLFSSL_METHOD* method, void* heap);
 WOLFSSL_ABI WOLFSSL_API WOLFSSL_CTX* wolfSSL_CTX_new(WOLFSSL_METHOD* method);
 WOLFSSL_API int wolfSSL_CTX_up_ref(WOLFSSL_CTX* ctx);
 #ifdef OPENSSL_EXTRA
+WOLFSSL_API int wolfSSL_set_ecdh_auto(WOLFSSL* ssl, int onoff);
 WOLFSSL_API int wolfSSL_CTX_set_ecdh_auto(WOLFSSL_CTX* ctx, int onoff);
 WOLFSSL_API int wolfSSL_get_signature_nid(WOLFSSL* ssl, int* nid);
 WOLFSSL_API int wolfSSL_get_signature_type_nid(const WOLFSSL* ssl, int* nid);
@@ -1141,7 +1153,7 @@ WOLFSSL_API int  wolfSSL_CTX_set1_sigalgs_list(WOLFSSL_CTX* ctx,
 WOLFSSL_API int  wolfSSL_set1_sigalgs_list(WOLFSSL* ssl, const char* list);
 #endif
 WOLFSSL_ABI WOLFSSL_API WOLFSSL* wolfSSL_new(WOLFSSL_CTX* ctx);
-WOLFSSL_API WOLFSSL_CTX* wolfSSL_get_SSL_CTX(WOLFSSL* ssl);
+WOLFSSL_API WOLFSSL_CTX* wolfSSL_get_SSL_CTX(const WOLFSSL* ssl);
 WOLFSSL_API WOLFSSL_X509_VERIFY_PARAM* wolfSSL_CTX_get0_param(WOLFSSL_CTX* ctx);
 WOLFSSL_API WOLFSSL_X509_VERIFY_PARAM* wolfSSL_get0_param(WOLFSSL* ssl);
 WOLFSSL_API int wolfSSL_CTX_set1_param(WOLFSSL_CTX* ctx, WOLFSSL_X509_VERIFY_PARAM *vpm);
@@ -1177,6 +1189,21 @@ WOLFSSL_API int  wolfSSL_peek(WOLFSSL* ssl, void* data, int sz);
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_accept(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_CTX_mutual_auth(WOLFSSL_CTX* ctx, int req);
 WOLFSSL_API int  wolfSSL_mutual_auth(WOLFSSL* ssl, int req);
+
+WOLFSSL_API int  wolfSSL_CTX_set_groups(WOLFSSL_CTX* ctx, int* groups,
+                                        int count);
+WOLFSSL_API int  wolfSSL_set_groups(WOLFSSL* ssl, int* groups, int count);
+#if defined(OPENSSL_EXTRA) && defined(HAVE_SUPPORTED_CURVES)
+WOLFSSL_API int  wolfSSL_CTX_set1_groups(WOLFSSL_CTX* ctx, int* groups,
+                                        int count);
+WOLFSSL_API int  wolfSSL_set1_groups(WOLFSSL* ssl, int* groups, int count);
+
+#ifdef HAVE_ECC
+WOLFSSL_API int  wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, const char *list);
+WOLFSSL_API int  wolfSSL_set1_groups_list(WOLFSSL *ssl, const char *list);
+#endif
+#endif
+
 #ifdef WOLFSSL_TLS13
 WOLFSSL_API int  wolfSSL_send_hrr_cookie(WOLFSSL* ssl,
     const unsigned char* secret, unsigned int secretSz);
@@ -1194,20 +1221,6 @@ WOLFSSL_API int  wolfSSL_allow_post_handshake_auth(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_request_certificate(WOLFSSL* ssl);
 
 WOLFSSL_API int  wolfSSL_preferred_group(WOLFSSL* ssl);
-WOLFSSL_API int  wolfSSL_CTX_set_groups(WOLFSSL_CTX* ctx, int* groups,
-                                        int count);
-WOLFSSL_API int  wolfSSL_set_groups(WOLFSSL* ssl, int* groups, int count);
-
-#if defined(OPENSSL_EXTRA) && defined(HAVE_SUPPORTED_CURVES)
-WOLFSSL_API int  wolfSSL_CTX_set1_groups(WOLFSSL_CTX* ctx, int* groups,
-                                        int count);
-WOLFSSL_API int  wolfSSL_set1_groups(WOLFSSL* ssl, int* groups, int count);
-
-#ifdef HAVE_ECC
-WOLFSSL_API int  wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, const char *list);
-WOLFSSL_API int  wolfSSL_set1_groups_list(WOLFSSL *ssl, const char *list);
-#endif
-#endif
 
 WOLFSSL_API int  wolfSSL_connect_TLSv13(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_accept_TLSv13(WOLFSSL* ssl);
@@ -1236,6 +1249,7 @@ WOLFSSL_API unsigned int wolfSSL_SESSION_get_max_early_data(const WOLFSSL_SESSIO
 WOLFSSL_ABI WOLFSSL_API void wolfSSL_CTX_free(WOLFSSL_CTX* ctx);
 WOLFSSL_ABI WOLFSSL_API void wolfSSL_free(WOLFSSL* ssl);
 WOLFSSL_ABI WOLFSSL_API int  wolfSSL_shutdown(WOLFSSL* ssl);
+WOLFSSL_API int wolfSSL_SendUserCanceled(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_send(WOLFSSL* ssl, const void* data, int sz, int flags);
 WOLFSSL_API int  wolfSSL_recv(WOLFSSL* ssl, void* data, int sz, int flags);
 
@@ -1361,8 +1375,17 @@ WOLFSSL_ABI WOLFSSL_API long wolfSSL_CTX_set_session_cache_mode(WOLFSSL_CTX* ctx
 #ifdef HAVE_SECRET_CALLBACK
 typedef int (*SessionSecretCb)(WOLFSSL* ssl, void* secret, int* secretSz,
                                void* ctx);
-WOLFSSL_API int  wolfSSL_set_session_secret_cb(WOLFSSL* ssl, SessionSecretCb,
-                                               void*);
+/* This callback is used to set the master secret during resumption */
+WOLFSSL_API int  wolfSSL_set_session_secret_cb(WOLFSSL* ssl, SessionSecretCb cb,
+                                               void* ctx);
+typedef int (*TicketParseCb)(WOLFSSL *ssl, const unsigned char *data,
+                                            int len, void *ctx);
+WOLFSSL_API int wolfSSL_set_session_ticket_ext_cb(WOLFSSL* ssl,
+        TicketParseCb cb, void *ctx);
+typedef int (*TlsSecretCb)(WOLFSSL* ssl, void* secret, int secretSz,
+                               void* ctx);
+/* This callback is used to log the secret for TLS <= 1.2 */
+WOLFSSL_API int wolfSSL_set_secret_cb(WOLFSSL* ssl, TlsSecretCb cb, void* ctx);
 #ifdef WOLFSSL_TLS13
 typedef int (*Tls13SecretCb)(WOLFSSL* ssl, int id, const unsigned char* secret,
                              int secretSz, void* ctx);
@@ -1659,6 +1682,11 @@ WOLFSSL_API int  wolfSSL_set_session_id_context(WOLFSSL* ssl, const unsigned cha
 WOLFSSL_API void wolfSSL_set_connect_state(WOLFSSL* ssl);
 WOLFSSL_API void wolfSSL_set_accept_state(WOLFSSL* ssl);
 WOLFSSL_API int  wolfSSL_session_reused(WOLFSSL* ssl);
+#ifdef OPENSSL_EXTRA
+/* using unsigned char instead of uint8_t here to avoid stdint include */
+WOLFSSL_API unsigned char wolfSSL_SESSION_get_max_fragment_length(
+                                                      WOLFSSL_SESSION* session);
+#endif
 WOLFSSL_API int wolfSSL_SESSION_up_ref(WOLFSSL_SESSION* session);
 WOLFSSL_API WOLFSSL_SESSION* wolfSSL_SESSION_dup(WOLFSSL_SESSION* session);
 WOLFSSL_API WOLFSSL_SESSION* wolfSSL_SESSION_new(void);
@@ -1687,6 +1715,7 @@ WOLFSSL_API const char*  wolfSSL_SESSION_CIPHER_get_name(const WOLFSSL_SESSION* 
 WOLFSSL_API const char*  wolfSSL_get_cipher(WOLFSSL* ssl);
 WOLFSSL_API void wolfSSL_sk_CIPHER_free(WOLF_STACK_OF(WOLFSSL_CIPHER)* sk);
 WOLFSSL_API WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl);
+WOLFSSL_API int wolfSSL_SessionIsSetup(WOLFSSL_SESSION* session);
 
 WOLFSSL_API WOLFSSL_X509* wolfSSL_X509_new(void);
 WOLFSSL_API WOLFSSL_X509* wolfSSL_X509_new_ex(void* heap);
@@ -1866,6 +1895,10 @@ WOLFSSL_API void  wolfSSL_X509_STORE_CTX_set_verify_cb(WOLFSSL_X509_STORE_CTX *c
                                   WOLFSSL_X509_STORE_CTX_verify_cb verify_cb);
 WOLFSSL_API void wolfSSL_X509_STORE_set_verify_cb(WOLFSSL_X509_STORE *st,
                                  WOLFSSL_X509_STORE_CTX_verify_cb verify_cb);
+WOLFSSL_API void wolfSSL_X509_STORE_set_get_crl(WOLFSSL_X509_STORE *st,
+                            WOLFSSL_X509_STORE_CTX_get_crl_cb get_cb);
+WOLFSSL_API void wolfSSL_X509_STORE_set_check_crl(WOLFSSL_X509_STORE *st,
+        WOLFSSL_X509_STORE_CTX_check_crl_cb check_crl);
 WOLFSSL_API int wolfSSL_i2d_X509_NAME(WOLFSSL_X509_NAME* n,
                                                            unsigned char** out);
 WOLFSSL_API int wolfSSL_i2d_X509_NAME_canon(WOLFSSL_X509_NAME* name,
@@ -1927,8 +1960,12 @@ WOLFSSL_API int wolfSSL_X509_set_issuer_name(WOLFSSL_X509* cert,
 WOLFSSL_API int wolfSSL_X509_set_pubkey(WOLFSSL_X509* cert, WOLFSSL_EVP_PKEY* pkey);
 WOLFSSL_API int wolfSSL_X509_set_notAfter(WOLFSSL_X509* x509,
         const WOLFSSL_ASN1_TIME* t);
+WOLFSSL_API int wolfSSL_X509_set1_notAfter(WOLFSSL_X509* x509,
+        const WOLFSSL_ASN1_TIME *t);
 WOLFSSL_API int wolfSSL_X509_set_notBefore(WOLFSSL_X509* x509,
         const WOLFSSL_ASN1_TIME* t);
+WOLFSSL_API int wolfSSL_X509_set1_notBefore(WOLFSSL_X509* x509,
+        const WOLFSSL_ASN1_TIME *t);
 WOLFSSL_API WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notBefore(const WOLFSSL_X509* x509);
 WOLFSSL_API WOLFSSL_ASN1_TIME* wolfSSL_X509_get_notAfter(const WOLFSSL_X509* x509);
 WOLFSSL_API int wolfSSL_X509_set_serialNumber(WOLFSSL_X509* x509,
@@ -1985,6 +2022,8 @@ WOLFSSL_API void         wolfSSL_X509_STORE_free(WOLFSSL_X509_STORE* store);
 WOLFSSL_API int          wolfSSL_X509_STORE_up_ref(WOLFSSL_X509_STORE* store);
 WOLFSSL_API int          wolfSSL_X509_STORE_add_cert(
                                               WOLFSSL_X509_STORE* store, WOLFSSL_X509* x509);
+WOLFSSL_API WOLFSSL_X509_VERIFY_PARAM *wolfSSL_X509_STORE_get0_param(
+        const WOLFSSL_X509_STORE *ctx);
 WOLFSSL_API WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(
                                                    WOLFSSL_X509_STORE_CTX* ctx);
 WOLFSSL_API WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get1_chain(
@@ -1996,7 +2035,10 @@ WOLFSSL_API int wolfSSL_X509_STORE_set_flags(WOLFSSL_X509_STORE* store,
 WOLFSSL_API int          wolfSSL_X509_STORE_set_default_paths(WOLFSSL_X509_STORE* store);
 WOLFSSL_API int          wolfSSL_X509_STORE_get_by_subject(WOLFSSL_X509_STORE_CTX* ctx,
                                    int idx, WOLFSSL_X509_NAME* name, WOLFSSL_X509_OBJECT* obj);
+WOLFSSL_API WOLFSSL_X509_VERIFY_PARAM *wolfSSL_X509_STORE_CTX_get0_param(
+        WOLFSSL_X509_STORE_CTX *ctx);
 WOLFSSL_API WOLFSSL_X509_STORE_CTX* wolfSSL_X509_STORE_CTX_new(void);
+WOLFSSL_API WOLFSSL_X509_STORE_CTX* wolfSSL_X509_STORE_CTX_new_ex(void* heap);
 WOLFSSL_API int  wolfSSL_X509_STORE_CTX_init(WOLFSSL_X509_STORE_CTX* ctx,
                       WOLFSSL_X509_STORE* store, WOLFSSL_X509* x509, WOLF_STACK_OF(WOLFSSL_X509)*);
 WOLFSSL_API void wolfSSL_X509_STORE_CTX_free(WOLFSSL_X509_STORE_CTX* ctx);
@@ -2540,7 +2582,8 @@ enum { /* ssl Constants */
     WOLFSSL_FAILURE         =  0,   /* for some functions */
     WOLFSSL_SUCCESS         =  1,
 
-/* WOLFSSL_SHUTDOWN_NOT_DONE is returned by wolfSSL_shutdown when the other end
+/* WOLFSSL_SHUTDOWN_NOT_DONE is returned by wolfSSL_shutdown and
+ * wolfSSL_SendUserCanceled when the other end
  * of the connection has yet to send its close notify alert as part of the
  * bidirectional shutdown. To complete the shutdown, either keep calling
  * wolfSSL_shutdown until it returns WOLFSSL_SUCCESS or call wolfSSL_read until
@@ -2924,6 +2967,7 @@ WOLFSSL_API int wolfSSL_X509_REVOKED_get_serial_number(RevokedCert* rev,
                                                        byte* in, int* inOutSz);
 #endif
 #if defined(HAVE_CRL) && (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL))
+WOLFSSL_API WOLFSSL_X509_CRL* wolfSSL_X509_CRL_dup(const WOLFSSL_X509_CRL* crl);
 WOLFSSL_API void wolfSSL_X509_CRL_free(WOLFSSL_X509_CRL *crl);
 #endif
 
@@ -2964,7 +3008,6 @@ WOLFSSL_API int  wolfSSL_connect_cert(WOLFSSL* ssl);
 
 
 /* PKCS12 compatibility */
-typedef struct WC_PKCS12 WC_PKCS12;
 WOLFSSL_API WC_PKCS12* wolfSSL_d2i_PKCS12_bio(WOLFSSL_BIO* bio,
                                        WC_PKCS12** pkcs12);
 WOLFSSL_API int wolfSSL_i2d_PKCS12_bio(WOLFSSL_BIO *bio, WC_PKCS12 *pkcs12);
@@ -3096,6 +3139,17 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
                                                const unsigned char* in, long sz, int format);
     WOLFSSL_API int wolfSSL_CTX_use_certificate_chain_buffer(WOLFSSL_CTX* ctx,
                                                     const unsigned char* in, long sz);
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+    WOLFSSL_API int wolfSSL_CTX_use_AltPrivateKey_buffer(WOLFSSL_CTX* ctx,
+                                const unsigned char* in, long sz, int format);
+    WOLFSSL_API int wolfSSL_CTX_use_AltPrivateKey_id(WOLFSSL_CTX* ctx,
+                                const unsigned char* id, long sz,
+                                int devId, long keySz);
+    WOLFSSL_API int wolfSSL_CTX_use_AltPrivateKey_Id(WOLFSSL_CTX* ctx,
+                                const unsigned char* id, long sz, int devId);
+    WOLFSSL_API int wolfSSL_CTX_use_AltPrivateKey_Label(WOLFSSL_CTX* ctx,
+                                const char* label, int devId);
+#endif
 
     /* SSL versions */
     WOLFSSL_API int wolfSSL_use_certificate_buffer(WOLFSSL* ssl, const unsigned char* in,
@@ -3114,6 +3168,17 @@ WOLFSSL_API int wolfSSL_make_eap_keys(WOLFSSL* ssl, void* key, unsigned int len,
     WOLFSSL_API int wolfSSL_use_certificate_chain_buffer(WOLFSSL* ssl,
                                                const unsigned char* in, long sz);
     WOLFSSL_API int wolfSSL_UnloadCertsKeys(WOLFSSL* ssl);
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+    WOLFSSL_API int wolfSSL_use_AltPrivateKey_buffer(WOLFSSL* ssl,
+                                const unsigned char* in, long sz, int format);
+    WOLFSSL_API int wolfSSL_use_AltPrivateKey_id(WOLFSSL* ssl,
+                                const unsigned char* id, long sz,
+                                int devId, long keySz);
+    WOLFSSL_API int wolfSSL_use_AltPrivateKey_Id(WOLFSSL* ssl,
+                                const unsigned char* id, long sz, int devId);
+    WOLFSSL_API int wolfSSL_use_AltPrivateKey_Label(WOLFSSL* ssl,
+                                const char* label, int devId);
+#endif
 
     #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
         defined(KEEP_OUR_CERT)
@@ -3753,7 +3818,6 @@ WOLFSSL_API void* wolfSSL_CTX_GetHeap(WOLFSSL_CTX* ctx, WOLFSSL* ssl);
 /* SNI types */
 enum {
     WOLFSSL_SNI_HOST_NAME = 0,
-    WOLFSSL_SNI_HOST_NAME_OUTER = 0,
 };
 
 WOLFSSL_ABI WOLFSSL_API int wolfSSL_UseSNI(WOLFSSL* ssl, unsigned char type,
@@ -3858,6 +3922,7 @@ WOLFSSL_API int wolfSSL_ALPN_FreePeerProtocol(WOLFSSL* ssl, char **list);
 
 /* Fragment lengths */
 enum {
+    WOLFSSL_MFL_DISABLED = 0,
     WOLFSSL_MFL_2_9  = 1, /*  512 bytes */
     WOLFSSL_MFL_2_10 = 2, /* 1024 bytes */
     WOLFSSL_MFL_2_11 = 3, /* 2048 bytes */
@@ -4435,7 +4500,7 @@ WOLFSSL_API int wolfSSL_set0_verify_cert_store(WOLFSSL *ssl,
                                                        WOLFSSL_X509_STORE* str);
 WOLFSSL_API int wolfSSL_set1_verify_cert_store(WOLFSSL *ssl,
                                                        WOLFSSL_X509_STORE* str);
-WOLFSSL_API WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(WOLFSSL_CTX* ctx);
+WOLFSSL_API WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(const WOLFSSL_CTX* ctx);
 #endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL) || \
     defined(HAVE_SECRET_CALLBACK)
@@ -4531,7 +4596,7 @@ WOLFSSL_API WOLFSSL_X509_NAME_ENTRY *wolfSSL_X509_NAME_get_entry(WOLFSSL_X509_NA
 WOLFSSL_API void wolfSSL_X509_NAME_ENTRY_free(WOLFSSL_X509_NAME_ENTRY* ne);
 WOLFSSL_API WOLFSSL_X509_NAME_ENTRY* wolfSSL_X509_NAME_ENTRY_new(void);
 WOLFSSL_API void wolfSSL_X509_NAME_free(WOLFSSL_X509_NAME* name);
-WOLFSSL_API char wolfSSL_CTX_use_certificate(WOLFSSL_CTX* ctx, WOLFSSL_X509* x);
+WOLFSSL_API int wolfSSL_CTX_use_certificate(WOLFSSL_CTX* ctx, WOLFSSL_X509* x);
 WOLFSSL_API int wolfSSL_CTX_add0_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509);
 WOLFSSL_API int wolfSSL_CTX_add1_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509);
 WOLFSSL_API int wolfSSL_add0_chain_cert(WOLFSSL* ssl, WOLFSSL_X509* x509);
@@ -4815,14 +4880,17 @@ typedef int (*CallbackSniRecv)(WOLFSSL *ssl, int *ret, void* exArg);
 
 WOLFSSL_API void wolfSSL_CTX_set_servername_callback(WOLFSSL_CTX* ctx,
         CallbackSniRecv cb);
-WOLFSSL_API int wolfSSL_CTX_set_tlsext_servername_callback(WOLFSSL_CTX* ctx,
-        CallbackSniRecv cb);
 
 WOLFSSL_API int  wolfSSL_CTX_set_servername_arg(WOLFSSL_CTX* ctx, void* arg);
 #endif
 
-#if defined(OPENSSL_ALL) || defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) \
-    || defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA) || defined(HAVE_LIGHTY)
+#if defined(OPENSSL_ALL) || defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
+    defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA) || defined(HAVE_LIGHTY)
+
+#ifdef HAVE_SNI
+WOLFSSL_API int wolfSSL_CTX_set_tlsext_servername_callback(WOLFSSL_CTX* ctx,
+        CallbackSniRecv cb);
+#endif
 
 WOLFSSL_API void wolfSSL_ERR_remove_thread_state(void* pid);
 
@@ -4858,10 +4926,11 @@ WOLFSSL_API WOLFSSL_X509_CRL *wolfSSL_X509_OBJECT_get0_X509_CRL(WOLFSSL_X509_OBJ
 WOLFSSL_API void wolfSSL_sk_X509_pop_free(WOLF_STACK_OF(WOLFSSL_X509)* sk, void (*f) (WOLFSSL_X509*));
 #endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
 
-#if (defined(OPENSSL_EXTRA) || defined(HAVE_CURL)) && defined(HAVE_ECC)
+#if (defined(OPENSSL_EXTRA) || defined(HAVE_CURL)) && (defined(HAVE_ECC) || \
+    defined(HAVE_CURVE25519) || defined(HAVE_CURVE448))
 WOLFSSL_API int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, const char* names);
 WOLFSSL_API int wolfSSL_set1_curves_list(WOLFSSL* ssl, const char* names);
-#endif /* (OPENSSL_EXTRA || HAVE_CURL) && HAVE_ECC */
+#endif
 
 #if defined(OPENSSL_ALL) || \
     defined(HAVE_STUNNEL) || defined(WOLFSSL_MYSQL_COMPATIBLE) || \
@@ -4985,6 +5054,10 @@ WOLFSSL_API int wolfSSL_SSL_do_handshake(WOLFSSL *s);
 #ifdef OPENSSL_EXTRA
 WOLFSSL_API int wolfSSL_OPENSSL_init_ssl(word64 opts,
     const OPENSSL_INIT_SETTINGS *settings);
+WOLFSSL_API OPENSSL_INIT_SETTINGS* wolfSSL_OPENSSL_INIT_new(void);
+WOLFSSL_API void wolfSSL_OPENSSL_INIT_free(OPENSSL_INIT_SETTINGS* init);
+WOLFSSL_API int  wolfSSL_OPENSSL_INIT_set_config_appname(
+        OPENSSL_INIT_SETTINGS* init, char* appname);
 #endif
 #if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
 WOLFSSL_API int wolfSSL_SSL_in_init(const WOLFSSL* ssl);
@@ -5051,7 +5124,7 @@ WOLFSSL_API int PEM_write_bio_WOLFSSL_X509(WOLFSSL_BIO *bio,
 WOLFSSL_API long wolfSSL_CTX_get_tlsext_ticket_keys(WOLFSSL_CTX *ctx,
      unsigned char *keys, int keylen);
 WOLFSSL_API long wolfSSL_CTX_set_tlsext_ticket_keys(WOLFSSL_CTX *ctx,
-     unsigned char *keys, int keylen);
+     const void *keys_vp, int keylen);
 #endif
 
 WOLFSSL_API void wolfSSL_get0_alpn_selected(const WOLFSSL *ssl,
@@ -5134,6 +5207,7 @@ WOLFSSL_API int wolfSSL_i2a_ASN1_OBJECT(WOLFSSL_BIO *bp, WOLFSSL_ASN1_OBJECT *a)
 WOLFSSL_API int wolfSSL_i2d_ASN1_OBJECT(WOLFSSL_ASN1_OBJECT *a, unsigned char **pp);
 WOLFSSL_API void SSL_CTX_set_tmp_dh_callback(WOLFSSL_CTX *ctx, WOLFSSL_DH *(*dh) (WOLFSSL *ssl, int is_export, int keylength));
 WOLFSSL_API WOLF_STACK_OF(SSL_COMP) *SSL_COMP_get_compression_methods(void);
+WOLFSSL_API const char* wolfSSL_COMP_get_name(const void* comp);
 WOLFSSL_API int wolfSSL_X509_STORE_load_locations(WOLFSSL_X509_STORE *str, const char *file, const char *dir);
 WOLFSSL_API int wolfSSL_X509_STORE_add_crl(WOLFSSL_X509_STORE *ctx, WOLFSSL_X509_CRL *x);
 WOLFSSL_API int wolfSSL_sk_SSL_CIPHER_num(const WOLF_STACK_OF(WOLFSSL_CIPHER)* p);
@@ -5153,6 +5227,7 @@ WOLFSSL_API int wolfSSL_ASN1_TIME_get_length(const WOLFSSL_ASN1_TIME *t);
 WOLFSSL_API unsigned char* wolfSSL_ASN1_TIME_get_data(const WOLFSSL_ASN1_TIME *t);
 WOLFSSL_API WOLFSSL_ASN1_TIME *wolfSSL_ASN1_TIME_to_generalizedtime(WOLFSSL_ASN1_TIME *t,
                                                                 WOLFSSL_ASN1_TIME **out);
+WOLFSSL_API WOLFSSL_ASN1_TIME* wolfSSL_ASN1_UTCTIME_set(WOLFSSL_ASN1_TIME *s, time_t t);
 WOLFSSL_API int wolfSSL_i2c_ASN1_INTEGER(WOLFSSL_ASN1_INTEGER *a, unsigned char **pp);
 WOLFSSL_API int wolfSSL_a2i_ASN1_INTEGER(WOLFSSL_BIO *bio, WOLFSSL_ASN1_INTEGER *asn1,
         char *buf, int size);
@@ -5302,6 +5377,247 @@ WOLFSSL_API int wolfSSL_dtls_cid_get_tx(WOLFSSL* ssl, unsigned char* buffer,
 #define DTLS1_VERSION                    0xFEFF
 #define DTLS1_2_VERSION                  0xFEFD
 #define DTLS1_3_VERSION                  0xFEFC
+
+/* These minimums where determined whilst referencing their RFC specs. The
+ * values represent the minimum sizes of the data types in the required struct
+ * for the `extension_data` field. A length of 0 was assumed when necassary.
+ *
+ * Documents Used for the respective extension:
+ *  - https://datatracker.ietf.org/doc/html/rfc6066
+ *      - Server Name Indication (SNI)
+ *      - Maximum Fragment Length Negotiation (MFL)
+ *      - Trusted CA Indication (TCA)
+ *      - Certificate Status Request (CSR)
+ *      - Truncate HMAC (THM)
+ *  - https://datatracker.ietf.org/doc/html/rfc8446
+ *      - Early Data Indication (EDI)
+ *      - Pre-Shared Key (PSK)
+ *      - Pre-Shared Key Exchange Modes (PKM)
+ *      - Key Share (KS)
+ *      - Post-Handshake Authentication (PHA)
+ *      - Signature Algorithms (SA)
+ *      - Signature Algorithms Certificate (SAC)
+ *      - Support Groups (EC)
+ *      - Cookie (CKE)
+ *      - Supported Versions (SV)
+ *      - Certificate Authorities (CAN)
+ *  - https://datatracker.ietf.org/doc/html/rfc6961
+ *      - Certificate Status Request v2 (CSR2)
+ *  - https://datatracker.ietf.org/doc/rfc9146/
+ *      - Connection Identifier (CID)
+ *  - https://datatracker.ietf.org/doc/rfc7301/
+ *      - Application-Layer Protocol Negotiation (ALPN)
+ *  - https://datatracker.ietf.org/doc/html/rfc3711
+ *      - Secure Real-time Transport Protocol (SRTP)
+ *  - https://datatracker.ietf.org/doc/html/rfc7366
+ *      - Encrypt Then Mac (ETM)
+ *  - https://datatracker.ietf.org/doc/html/rfc7250
+ *      - Client Certificate Type (CCT)
+ *      - Server Certificate Type (SCT)
+ *  - https://datatracker.ietf.org/doc/draft-ietf-tls-esni/
+ *      - Encrypted Client Hello (ECH)
+ *  - https://datatracker.ietf.org/doc/html/rfc5746
+ *      - Secure Renegotiation (SCR)
+ *  - https://datatracker.ietf.org/doc/rfc4492/
+ *      - Point Frame (PF)
+ *  - https://datatracker.ietf.org/doc/rfc9000/
+ *      - QUIC (QTP)
+ *  - https://datatracker.ietf.org/doc/html/rfc5077
+ *      - Session Ticket (STK)
+ * Example:
+ *  For `WOLFSSL_CSR_MIN_SIZE_CLIENT = 5`, 5 was determined by looking at the
+ * struct below defined in its respective RFC.
+ * The below struct for `CertificateStatusRequest` is made up of the types:
+ *      `CertificateStatusType` is an enum with a max value of 255, thus its
+ *          length is 1 byte.
+ *      `OCSPStatusRequest` is a struct of the following:
+ *          - `responder_id_list`: which is 2 bytes
+ *          - `request_extensions`: which is 2 bytes
+ *      This then gives the minimum size/length of 5 bytes for this extension
+ *          for the client
+ *  struct {
+ *      CertificateStatusType status_type;
+ *      select (status_type) {
+ *          case ocsp: OCSPStatusRequest;
+ *      } request;
+ *  } CertificateStatusRequest;
+ *  enum { ocsp(1), (255) } CertificateStatusType;
+ *  struct {
+ *      ResponderID responder_id_list<0..2^16-1>;
+ *      Extensions  request_extensions;
+ *    } OCSPStatusRequest;
+ *    opaque ResponderID<1..2^16-1>;
+ *    opaque Extensions<0..2^16-1>;
+ */
+
+#ifndef WOLFSSL_SNI_MIN_SIZE_CLIENT
+    #define WOLFSSL_SNI_MIN_SIZE_CLIENT   4
+#endif
+#ifndef WOLFSSL_SNI_MIN_SIZE_SERVER
+    #define WOLFSSL_SNI_MIN_SIZE_SERVER   0
+#endif
+#ifndef WOLFSSL_EDI_MIN_SIZE_CLIENT
+    #define WOLFSSL_EDI_MIN_SIZE_CLIENT   0
+#endif
+#ifndef WOLFSSL_EDI_MIN_SIZE_SERVER
+    #define WOLFSSL_EDI_MIN_SIZE_SERVER   0
+#endif
+#ifndef WOLFSSL_TCA_MIN_SIZE_CLIENT
+    #define WOLFSSL_TCA_MIN_SIZE_CLIENT   2
+#endif
+#ifndef WOLFSSL_TCA_MIN_SIZE_SERVER
+    #define WOLFSSL_TCA_MIN_SIZE_SERVER   0
+#endif
+#ifndef WOLFSSL_CSR_MIN_SIZE_CLIENT
+    #define WOLFSSL_CSR_MIN_SIZE_CLIENT   5
+#endif
+#ifndef WOLFSSL_CSR_MIN_SIZE_SERVER
+    #define WOLFSSL_CSR_MIN_SIZE_SERVER   0
+#endif
+#ifndef WOLFSSL_PKM_MIN_SIZE_CLIENT
+    #define WOLFSSL_PKM_MIN_SIZE_CLIENT   1
+#endif
+#ifndef WOLFSSL_PKM_MIN_SIZE_SERVER
+    #define WOLFSSL_PKM_MIN_SIZE_SERVER   0
+#endif
+#ifndef WOLFSSL_CSR2_MIN_SIZE_CLIENT
+    #define WOLFSSL_CSR2_MIN_SIZE_CLIENT  7
+#endif
+#ifndef WOLFSSL_CSR2_MIN_SIZE_SERVER
+    #define WOLFSSL_CSR2_MIN_SIZE_SERVER  0
+#endif
+#ifndef WOLFSSL_CID_MIN_SIZE_CLIENT
+    #define WOLFSSL_CID_MIN_SIZE_CLIENT   1
+#endif
+#ifndef WOLFSSL_CID_MIN_SIZE_SERVER
+    #define WOLFSSL_CID_MIN_SIZE_SERVER   1
+#endif
+#ifndef WOLFSSL_ALPN_MIN_SIZE_CLIENT
+    #define WOLFSSL_ALPN_MIN_SIZE_CLIENT  2
+#endif
+#ifndef WOLFSSL_ALPN_MIN_SIZE_SERVER
+    #define WOLFSSL_ALPN_MIN_SIZE_SERVER  2
+#endif
+#ifndef WOLFSSL_SRTP_MIN_SIZE_CLIENT
+    #define WOLFSSL_SRTP_MIN_SIZE_CLIENT  3
+#endif
+#ifndef WOLFSSL_SRTP_MIN_SIZE_SERVER
+    #define WOLFSSL_SRTP_MIN_SIZE_SERVER  3
+#endif
+#ifndef WOLFSSL_KS_MIN_SIZE_CLIENT
+    #define WOLFSSL_KS_MIN_SIZE_CLIENT    1
+#endif
+#ifndef WOLFSSL_KS_MIN_SIZE_SERVER
+    #define WOLFSSL_KS_MIN_SIZE_SERVER    1
+#endif
+#ifndef WOLFSSL_ETM_MIN_SIZE_CLIENT
+    #define WOLFSSL_ETM_MIN_SIZE_CLIENT   0
+#endif
+#ifndef WOLFSSL_ETM_MIN_SIZE_SERVER
+    #define WOLFSSL_ETM_MIN_SIZE_SERVER   0
+#endif
+#ifndef WOLFSSL_PSK_MIN_SIZE_CLIENT
+    #define WOLFSSL_PSK_MIN_SIZE_CLIENT   2
+#endif
+#ifndef WOLFSSL_PSK_MIN_SIZE_SERVER
+    #define WOLFSSL_PSK_MIN_SIZE_SERVER   2
+#endif
+#ifndef WOLFSSL_CCT_MIN_SIZE_CLIENT
+    #define WOLFSSL_CCT_MIN_SIZE_CLIENT   1
+#endif
+#ifndef WOLFSSL_CCT_MIN_SIZE_SERVER
+    #define WOLFSSL_CCT_MIN_SIZE_SERVER   1
+#endif
+#ifndef WOLFSSL_SCT_MIN_SIZE_CLIENT
+    #define WOLFSSL_SCT_MIN_SIZE_CLIENT   1
+#endif
+#ifndef WOLFSSL_SCT_MIN_SIZE_SERVER
+    #define WOLFSSL_SCT_MIN_SIZE_SERVER   1
+#endif
+#ifndef WOLFSSL_PHA_MIN_SIZE_CLIENT
+    #define WOLFSSL_PHA_MIN_SIZE_CLIENT   0
+#endif
+#ifndef WOLFSSL_PHA_MIN_SIZE_SERVER
+    #define WOLFSSL_PHA_MIN_SIZE_SERVER   0
+#endif
+#ifndef WOLFSSL_THM_MIN_SIZE_CLIENT
+    #define WOLFSSL_THM_MIN_SIZE_CLIENT   0
+#endif
+#ifndef WOLFSSL_THM_MIN_SIZE_SERVER
+    #define WOLFSSL_THM_MIN_SIZE_SERVER   0
+#endif
+#ifndef WOLFSSL_SA_MIN_SIZE_CLIENT
+    #define WOLFSSL_SA_MIN_SIZE_CLIENT    2
+#endif
+#ifndef WOLFSSL_SA_MIN_SIZE_SERVER
+    #define WOLFSSL_SA_MIN_SIZE_SERVER    2
+#endif
+#ifndef WOLFSSL_SAC_MIN_SIZE_CLIENT
+    #define WOLFSSL_SAC_MIN_SIZE_CLIENT   2
+#endif
+#ifndef WOLFSSL_SAC_MIN_SIZE_SERVER
+    #define WOLFSSL_SAC_MIN_SIZE_SERVER   2
+#endif
+#ifndef WOLFSSL_EC_MIN_SIZE_CLIENT
+    #define WOLFSSL_EC_MIN_SIZE_CLIENT    2
+#endif
+#ifndef WOLFSSL_EC_MIN_SIZE_SERVER
+    #define WOLFSSL_EC_MIN_SIZE_SERVER    2
+#endif
+#ifndef WOLFSSL_ECH_MIN_SIZE_CLIENT
+    #define WOLFSSL_ECH_MIN_SIZE_CLIENT   1
+#endif
+#ifndef WOLFSSL_ECH_MIN_SIZE_SERVER
+    #define WOLFSSL_ECH_MIN_SIZE_SERVER   0
+#endif
+#ifndef WOLFSSL_MFL_MIN_SIZE_CLIENT
+    #define WOLFSSL_MFL_MIN_SIZE_CLIENT   1
+#endif
+#ifndef WOLFSSL_MFL_MIN_SIZE_SERVER
+    #define WOLFSSL_MFL_MIN_SIZE_SERVER   1
+#endif
+#ifndef WOLFSSL_CKE_MIN_SIZE_CLIENT
+    #define WOLFSSL_CKE_MIN_SIZE_CLIENT   3
+#endif
+#ifndef WOLFSSL_CKE_MIN_SIZE_SERVER
+    #define WOLFSSL_CKE_MIN_SIZE_SERVER   3
+#endif
+#ifndef WOLFSSL_SV_MIN_SIZE_CLIENT
+    #define WOLFSSL_SV_MIN_SIZE_CLIENT    2
+#endif
+#ifndef WOLFSSL_SV_MIN_SIZE_SERVER
+    #define WOLFSSL_SV_MIN_SIZE_SERVER    2
+#endif
+#ifndef WOLFSSL_SCR_MIN_SIZE_CLIENT
+    #define WOLFSSL_SCR_MIN_SIZE_CLIENT   1
+#endif
+#ifndef WOLFSSL_SCR_MIN_SIZE_SERVER
+    #define WOLFSSL_SCR_MIN_SIZE_SERVER   1
+#endif
+#ifndef WOLFSSL_PF_MIN_SIZE_CLIENT
+    #define WOLFSSL_PF_MIN_SIZE_CLIENT    1
+#endif
+#ifndef WOLFSSL_PF_MIN_SIZE_SERVER
+    #define WOLFSSL_PF_MIN_SIZE_SERVER    1
+#endif
+#ifndef WOLFSSL_CAN_MIN_SIZE_CLIENT
+    #define WOLFSSL_CAN_MIN_SIZE_CLIENT   3
+#endif
+#ifndef WOLFSSL_CAN_MIN_SIZE_SERVER
+    #define WOLFSSL_CAN_MIN_SIZE_SERVER   3
+#endif
+#ifndef WOLFSSL_QTP_MIN_SIZE_CLIENT
+    #define WOLFSSL_QTP_MIN_SIZE_CLIENT   0
+#endif
+#ifndef WOLFSSL_QTP_MIN_SIZE_SERVER
+    #define WOLFSSL_QTP_MIN_SIZE_SERVER   0
+#endif
+#ifndef WOLFSSL_STK_MIN_SIZE_CLIENT
+    #define WOLFSSL_STK_MIN_SIZE_CLIENT   0
+#endif
+#ifndef WOLFSSL_STK_MIN_SIZE_SERVER
+    #define WOLFSSL_STK_MIN_SIZE_SERVER   0
+#endif
 
 #ifdef __cplusplus
     }  /* extern "C" */

--- a/include/wolfssl/ssl.h
+++ b/include/wolfssl/ssl.h
@@ -386,7 +386,7 @@ struct WOLFSSL_EVP_PKEY {
     union {
         char* ptr; /* der format of key */
     } pkey;
-#if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || defined(EMBEDDED_SSL))
+#if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL))
     #ifndef NO_RSA
     WOLFSSL_RSA* rsa;
     #endif
@@ -413,7 +413,7 @@ struct WOLFSSL_EVP_PKEY {
     #if defined(WOLFSSL_CMAC) && !defined(NO_AES) && defined(WOLFSSL_AES_DIRECT)
     WOLFSSL_CMAC_CTX* cmacCtx;
     #endif
-#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL || EMBEDDED_SSL */
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 #ifdef HAVE_ECC
     int pkey_curve;
 #endif

--- a/include/wolfssl/version.h
+++ b/include/wolfssl/version.h
@@ -28,8 +28,8 @@
 extern "C" {
 #endif
 
-#define LIBWOLFSSL_VERSION_STRING "5.7.0"
-#define LIBWOLFSSL_VERSION_HEX 0x05007000
+#define LIBWOLFSSL_VERSION_STRING "5.7.2"
+#define LIBWOLFSSL_VERSION_HEX 0x05007002
 
 #ifdef __cplusplus
 }

--- a/include/wolfssl/wolfcrypt/aes.h
+++ b/include/wolfssl/wolfcrypt/aes.h
@@ -55,6 +55,11 @@ typedef struct Gcm {
 #endif /* GCM_TABLE */
 } Gcm;
 
+#if FIPS_VERSION3_GE(6,0,0)
+    extern const unsigned int wolfCrypt_FIPS_aes_ro_sanity[2];
+    WOLFSSL_LOCAL int wolfCrypt_FIPS_AES_sanity(void);
+#endif
+
 WOLFSSL_LOCAL void GenerateM0(Gcm* gcm);
 #ifdef WOLFSSL_ARMASM
 WOLFSSL_LOCAL void GMULT(byte* X, byte* Y);
@@ -256,7 +261,7 @@ struct Aes {
     ALIGN16 bs_word bs_key[15 * AES_BLOCK_SIZE * BS_WORD_SIZE];
 #endif
     word32  rounds;
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
+#ifdef WC_C_DYNAMIC_FALLBACK
     word32 key_C_fallback[60];
 #endif
     int     keylen;
@@ -400,14 +405,36 @@ struct Aes {
 #endif
 
 #ifdef WOLFSSL_AES_XTS
-typedef struct XtsAes {
-    Aes aes;
-#ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
-    Aes aes_decrypt;
+    #if FIPS_VERSION3_GE(6,0,0)
+        /* SP800-38E - Restrict data unit to 2^20 blocks per key. A block is
+         * AES_BLOCK_SIZE or 16-bytes (128-bits). So each key may only be used to
+         * protect up to 1,048,576 blocks of AES_BLOCK_SIZE (16,777,216 bytes)
+         */
+        #define FIPS_AES_XTS_MAX_BYTES_PER_TWEAK 16777216
+    #endif
+    struct XtsAes {
+        Aes aes;
+    #ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
+        Aes aes_decrypt;
+    #endif
+        Aes tweak;
+    };
+
+    #ifdef WOLFSSL_AESXTS_STREAM
+        struct XtsAesStreamData {
+            byte tweak_block[AES_BLOCK_SIZE];
+            word32 bytes_crypted_with_this_tweak;
+        };
+    #endif
+
+    #ifndef WC_AESXTS_TYPE_DEFINED
+        typedef struct XtsAes XtsAes;
+        typedef struct XtsAesStreamData XtsAesStreamData;
+        #define WC_AESXTS_TYPE_DEFINED
+    #endif
+
 #endif
-    Aes tweak;
-} XtsAes;
-#endif
+
 
 #if (!defined(WC_AESFREE_IS_MANDATORY)) &&                              \
     (defined(WC_DEBUG_CIPHER_LIFECYCLE) ||                              \
@@ -430,9 +457,15 @@ typedef struct XtsAes {
 #endif
 
 #ifdef HAVE_AESGCM
-typedef struct Gmac {
+struct Gmac {
     Aes aes;
-} Gmac;
+};
+
+#ifndef WC_AESGCM_TYPE_DEFINED
+    typedef struct Gmac Gmac;
+    #define WC_AESGCM_TYPE_DEFINED
+#endif
+
 #endif /* HAVE_AESGCM */
 #endif /* HAVE_FIPS */
 
@@ -657,6 +690,28 @@ WOLFSSL_API int wc_AesXtsEncryptConsecutiveSectors(XtsAes* aes,
 WOLFSSL_API int wc_AesXtsDecryptConsecutiveSectors(XtsAes* aes,
         byte* out, const byte* in, word32 sz, word64 sector,
         word32 sectorSz);
+
+#ifdef WOLFSSL_AESXTS_STREAM
+
+WOLFSSL_API int wc_AesXtsEncryptInit(XtsAes* aes, const byte* i, word32 iSz,
+         struct XtsAesStreamData *stream);
+
+WOLFSSL_API int wc_AesXtsDecryptInit(XtsAes* aes, const byte* i, word32 iSz,
+         struct XtsAesStreamData *stream);
+
+WOLFSSL_API int wc_AesXtsEncryptUpdate(XtsAes* aes, byte* out,
+         const byte* in, word32 sz, struct XtsAesStreamData *stream);
+
+WOLFSSL_API int wc_AesXtsDecryptUpdate(XtsAes* aes, byte* out,
+         const byte* in, word32 sz, struct XtsAesStreamData *stream);
+
+WOLFSSL_API int wc_AesXtsEncryptFinal(XtsAes* aes, byte* out,
+         const byte* in, word32 sz, struct XtsAesStreamData *stream);
+
+WOLFSSL_API int wc_AesXtsDecryptFinal(XtsAes* aes, byte* out,
+         const byte* in, word32 sz, struct XtsAesStreamData *stream);
+
+#endif /* WOLFSSL_AESXTS_STREAM */
 
 WOLFSSL_API int wc_AesXtsFree(XtsAes* aes);
 #endif

--- a/include/wolfssl/wolfcrypt/asn_public.h
+++ b/include/wolfssl/wolfcrypt/asn_public.h
@@ -218,9 +218,9 @@ enum Ctc_SigType {
     CTC_FALCON_LEVEL1 = 273,
     CTC_FALCON_LEVEL5 = 276,
 
-    CTC_DILITHIUM_LEVEL2     = 213,
-    CTC_DILITHIUM_LEVEL3     = 216,
-    CTC_DILITHIUM_LEVEL5     = 220,
+    CTC_DILITHIUM_LEVEL2     = 218,
+    CTC_DILITHIUM_LEVEL3     = 221,
+    CTC_DILITHIUM_LEVEL5     = 225,
 
     CTC_SPHINCS_FAST_LEVEL1  = 281,
     CTC_SPHINCS_FAST_LEVEL3  = 283,
@@ -516,7 +516,7 @@ typedef struct Cert {
 #endif
 #ifdef WOLFSSL_DUAL_ALG_CERTS
     /* These will not point to managed buffers. They will point to buffers that
-     * are managed by others. No cleanup neccessary. */
+     * are managed by others. No cleanup necessary. */
     /* Subject Alternative Public Key Info */
     byte *sapkiDer;
     int sapkiLen;
@@ -799,8 +799,7 @@ WOLFSSL_API int wc_DhPrivKeyToDer(DhKey* key, byte* out, word32* outSz);
      (defined(HAVE_CURVE25519) && defined(HAVE_CURVE25519_KEY_EXPORT)) || \
      (defined(HAVE_ED448)      && defined(HAVE_ED448_KEY_EXPORT)) || \
      (defined(HAVE_CURVE448)   && defined(HAVE_CURVE448_KEY_EXPORT)) || \
-     (defined(HAVE_PQC) && (defined(HAVE_FALCON) || \
-                            defined(HAVE_DILITHIUM) || defined(HAVE_SPHINCS))))
+     (defined(HAVE_FALCON) || defined(HAVE_DILITHIUM) || defined(HAVE_SPHINCS)))
     #define WC_ENABLE_ASYM_KEY_EXPORT
 #endif
 
@@ -809,8 +808,7 @@ WOLFSSL_API int wc_DhPrivKeyToDer(DhKey* key, byte* out, word32* outSz);
      (defined(HAVE_CURVE25519) && defined(HAVE_CURVE25519_KEY_IMPORT)) || \
      (defined(HAVE_ED448)      && defined(HAVE_ED448_KEY_IMPORT)) || \
      (defined(HAVE_CURVE448)   && defined(HAVE_CURVE448_KEY_IMPORT)) || \
-     (defined(HAVE_PQC) && (defined(HAVE_FALCON) || \
-                            defined(HAVE_DILITHIUM) || defined(HAVE_SPHINCS))))
+     (defined(HAVE_FALCON) || defined(HAVE_DILITHIUM) || defined(HAVE_SPHINCS)))
     #define WC_ENABLE_ASYM_KEY_IMPORT
 #endif
 

--- a/include/wolfssl/wolfcrypt/chacha.h
+++ b/include/wolfssl/wolfcrypt/chacha.h
@@ -77,7 +77,7 @@ enum {
 
 typedef struct ChaCha {
     word32 X[CHACHA_CHUNK_WORDS];           /* state of cipher */
-#ifdef HAVE_INTEL_AVX1
+#if defined(USE_INTEL_CHACHA_SPEEDUP)
     /* vpshufd reads 16 bytes but we only use bottom 4. */
     byte extra[12];
 #endif

--- a/include/wolfssl/wolfcrypt/cmac.h
+++ b/include/wolfssl/wolfcrypt/cmac.h
@@ -38,8 +38,7 @@
 #endif
 
 /* avoid redefinition of structs */
-#if !defined(HAVE_FIPS) || \
-    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))
+#if !defined(HAVE_FIPS) || FIPS_VERSION3_GE(2,0,0)
 
 #ifndef WC_CMAC_TYPE_DEFINED
     typedef struct Cmac Cmac;
@@ -81,6 +80,11 @@ typedef enum CmacType {
 
 #define WC_CMAC_TAG_MAX_SZ AES_BLOCK_SIZE
 #define WC_CMAC_TAG_MIN_SZ (AES_BLOCK_SIZE/4)
+
+#if FIPS_VERSION3_GE(6,0,0)
+    extern const unsigned int wolfCrypt_FIPS_cmac_ro_sanity[2];
+    WOLFSSL_LOCAL int wolfCrypt_FIPS_CMAC_sanity(void);
+#endif
 
 #endif /* HAVE_FIPS */
 

--- a/include/wolfssl/wolfcrypt/cryptocb.h
+++ b/include/wolfssl/wolfcrypt/cryptocb.h
@@ -71,7 +71,7 @@
 #if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
     #include <wolfssl/wolfcrypt/sha512.h>
 #endif
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
     #include <wolfssl/wolfcrypt/kyber.h>
 #ifdef WOLFSSL_WC_KYBER
     #include <wolfssl/wolfcrypt/wc_kyber.h>
@@ -79,10 +79,10 @@
     #include <wolfssl/wolfcrypt/ext_kyber.h>
 #endif
 #endif
-#if defined(HAVE_PQC) && defined(HAVE_DILITHIUM)
+#if defined(HAVE_DILITHIUM)
     #include <wolfssl/wolfcrypt/dilithium.h>
 #endif
-#if defined(HAVE_PQC) && defined(HAVE_FALCON)
+#if defined(HAVE_FALCON)
     #include <wolfssl/wolfcrypt/falcon.h>
 #endif
 
@@ -216,7 +216,7 @@ typedef struct wc_CryptoInfo {
                 byte         contextLen;
             } ed25519verify;
         #endif
-        #if defined(HAVE_PQC) && defined(WOLFSSL_HAVE_KYBER)
+        #if defined(WOLFSSL_HAVE_KYBER)
             struct {
                 WC_RNG*     rng;
                 int         size;
@@ -241,8 +241,7 @@ typedef struct wc_CryptoInfo {
                 int         type; /* enum wc_PqcKemType */
             } pqc_decaps;
         #endif
-        #if defined(HAVE_PQC) && \
-            (defined(HAVE_FALCON) || defined(HAVE_DILITHIUM))
+        #if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
             struct {
                 WC_RNG*     rng;
                 int         size;
@@ -400,6 +399,9 @@ typedef struct wc_CryptoInfo {
         #ifdef WOLFSSL_SHA512
             wc_Sha512* sha512;
         #endif
+        #ifdef WOLFSSL_SHA3
+            wc_Sha3* sha3;
+        #endif
             void* ctx;
 #if HAVE_ANONYMOUS_INLINE_AGGREGATES
         };
@@ -525,7 +527,7 @@ WOLFSSL_LOCAL int wc_CryptoCb_Ed25519Verify(const byte* sig, word32 sigLen,
     const byte* context, byte contextLen);
 #endif /* HAVE_ED25519 */
 
-#if defined(HAVE_PQC) && defined(WOLFSSL_HAVE_KYBER)
+#if defined(WOLFSSL_HAVE_KYBER)
 WOLFSSL_LOCAL int wc_CryptoCb_PqcKemGetDevId(int type, void* key);
 
 WOLFSSL_LOCAL int wc_CryptoCb_MakePqcKemKey(WC_RNG* rng, int type,
@@ -538,9 +540,9 @@ WOLFSSL_LOCAL int wc_CryptoCb_PqcEncapsulate(byte* ciphertext,
 WOLFSSL_LOCAL int wc_CryptoCb_PqcDecapsulate(const byte* ciphertext,
     word32 ciphertextLen, byte* sharedSecret, word32 sharedSecretLen,
     int type, void* key);
-#endif /* HAVE_PQC && WOLFSSL_HAVE_KYBER */
+#endif /* WOLFSSL_HAVE_KYBER */
 
-#if defined(HAVE_PQC) && (defined(HAVE_FALCON) || defined(HAVE_DILITHIUM))
+#if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
 WOLFSSL_LOCAL int wc_CryptoCb_PqcSigGetDevId(int type, void* key);
 
 WOLFSSL_LOCAL int wc_CryptoCb_MakePqcSignatureKey(WC_RNG* rng, int type,
@@ -554,7 +556,7 @@ WOLFSSL_LOCAL int wc_CryptoCb_PqcVerify(const byte* sig, word32 siglen,
 
 WOLFSSL_LOCAL int wc_CryptoCb_PqcSignatureCheckPrivKey(void* key, int type,
     const byte* pubKey, word32 pubKeySz);
-#endif /* HAVE_PQC && (HAVE_FALCON || HAVE_DILITHIUM) */
+#endif /* HAVE_FALCON || HAVE_DILITHIUM */
 
 #ifndef NO_AES
 #ifdef HAVE_AESGCM
@@ -620,6 +622,11 @@ WOLFSSL_LOCAL int wc_CryptoCb_Sha384Hash(wc_Sha384* sha384, const byte* in,
 #endif
 #ifdef WOLFSSL_SHA512
 WOLFSSL_LOCAL int wc_CryptoCb_Sha512Hash(wc_Sha512* sha512, const byte* in,
+    word32 inSz, byte* digest);
+#endif
+
+#ifdef WOLFSSL_SHA3
+WOLFSSL_LOCAL int wc_CryptoCb_Sha3Hash(wc_Sha3* sha3, int type, const byte* in,
     word32 inSz, byte* digest);
 #endif
 

--- a/include/wolfssl/wolfcrypt/dh.h
+++ b/include/wolfssl/wolfcrypt/dh.h
@@ -30,8 +30,7 @@
 
 #ifndef NO_DH
 
-#if defined(HAVE_FIPS) && \
-    defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
+#if FIPS_VERSION3_GE(2,0,0)
     #include <wolfssl/wolfcrypt/fips.h>
 #endif /* HAVE_FIPS_VERSION >= 2 */
 
@@ -118,6 +117,11 @@ enum {
             #define DH_MAX_SIZE 4096
         #endif
     #endif
+#endif
+
+#if FIPS_VERSION3_GE(6,0,0)
+    extern const unsigned int wolfCrypt_FIPS_dh_ro_sanity[2];
+    WOLFSSL_LOCAL int wolfCrypt_FIPS_DH_sanity(void);
 #endif
 
 #ifdef HAVE_PUBLIC_FFDHE

--- a/include/wolfssl/wolfcrypt/ecc.h
+++ b/include/wolfssl/wolfcrypt/ecc.h
@@ -31,8 +31,7 @@
 
 #ifdef HAVE_ECC
 
-#if defined(HAVE_FIPS) && \
-    defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
+#if FIPS_VERSION3_GE(2,0,0)
     #include <wolfssl/wolfcrypt/fips.h>
 #endif /* HAVE_FIPS_VERSION >= 2 */
 
@@ -83,6 +82,10 @@
     extern "C" {
 #endif
 
+#if FIPS_VERSION3_GE(6,0,0)
+    extern const unsigned int wolfCrypt_FIPS_ecc_ro_sanity[2];
+    WOLFSSL_LOCAL int wolfCrypt_FIPS_ECC_sanity(void);
+#endif
 
 /* Enable curve B parameter if needed */
 #if defined(HAVE_COMP_KEY) || defined(ECC_CACHE_CURVE)
@@ -131,6 +134,14 @@
     #endif
 #endif
 
+#if FIPS_VERSION3_GE(6,0,0)
+    #define WC_ECC_FIPS_SIG_MIN 224
+    #define WC_ECC_FIPS_GEN_MIN (WC_ECC_FIPS_SIG_MIN/8)
+#endif
+
+#ifdef WOLFSSL_SM2
+    #define WOLFSSL_SM2_KEY_BITS   256
+#endif
 
 /* calculate max ECC bytes */
 #if ((MAX_ECC_BITS * 2) % 8) == 0
@@ -209,13 +220,13 @@ typedef enum ecc_curve_id {
     ECC_CURVE_DEF = 0, /* NIST or SECP */
 
     /* NIST Prime Curves */
-    ECC_SECP192R1,
+    ECC_SECP192R1, /* 1 */
     ECC_PRIME192V2,
     ECC_PRIME192V3,
     ECC_PRIME239V1,
     ECC_PRIME239V2,
     ECC_PRIME239V3,
-    ECC_SECP256R1,
+    ECC_SECP256R1, /* 7 */
 
     /* SECP Curves */
     ECC_SECP112R1,
@@ -224,9 +235,9 @@ typedef enum ecc_curve_id {
     ECC_SECP128R2,
     ECC_SECP160R1,
     ECC_SECP160R2,
-    ECC_SECP224R1,
-    ECC_SECP384R1,
-    ECC_SECP521R1,
+    ECC_SECP224R1, /* 14 */
+    ECC_SECP384R1, /* 15 */
+    ECC_SECP521R1, /* 16 */
 
     /* Koblitz */
     ECC_SECP160K1,
@@ -286,7 +297,7 @@ typedef byte   ecc_oid_t;
 
 /* ECC set type defined a GF(p) curve */
 #ifndef WOLFSSL_ECC_CURVE_STATIC
-typedef struct ecc_set_type {
+struct ecc_set_type {
     int size;             /* The size of the curve in octets */
     int id;               /* id of this curve */
     const char* name;     /* name of this curve */
@@ -300,13 +311,13 @@ typedef struct ecc_set_type {
     word32      oidSz;
     word32      oidSum;    /* sum of encoded OID bytes */
     int         cofactor;
-} ecc_set_type;
+};
 #else
 #define MAX_ECC_NAME 16
 #define MAX_ECC_STRING ((MAX_ECC_BYTES * 2) + 2)
     /* The values are stored as text strings. */
 
-typedef struct ecc_set_type {
+struct ecc_set_type {
     int size;             /* The size of the curve in octets */
     int id;               /* id of this curve */
     char name[MAX_ECC_NAME];     /* name of this curve */
@@ -320,7 +331,7 @@ typedef struct ecc_set_type {
     word32      oidSz;
     word32      oidSum;    /* sum of encoded OID bytes */
     int         cofactor;
-} ecc_set_type;
+};
 #endif
 
 
@@ -430,10 +441,19 @@ typedef struct alt_fp_int {
     #define WC_ECCKEY_TYPE_DEFINED
 #endif
 
+#ifndef WC_ECCPOINT_TYPE_DEFINED
+    typedef struct ecc_point ecc_point;
+    #define WC_ECCPOINT_TYPE_DEFINED
+#endif
+
+#ifndef WC_ECCSET_TYPE_DEFINED
+    typedef struct ecc_set_type ecc_set_type;
+    #define WC_ECCSET_TYPE_DEFINED
+#endif
 
 /* A point on an ECC curve, stored in Jacobian format such that (x,y,z) =>
    (x/z^2, y/z^3, 1) when interpreted as affine */
-typedef struct {
+struct ecc_point {
 #ifndef ALT_ECC_SIZE
     mp_int x[1];        /* The x coordinate */
     mp_int y[1];        /* The y coordinate */
@@ -447,7 +467,7 @@ typedef struct {
 #if defined(WOLFSSL_SMALL_STACK_CACHE) && !defined(WOLFSSL_ECC_NO_SMALL_STACK)
     ecc_key* key;
 #endif
-} ecc_point;
+};
 
 /* ECC Flags */
 enum {
@@ -490,6 +510,17 @@ struct ecc_key {
     mp_int*   k;
     alt_fp_int ka[1];
 #endif
+#ifdef WOLFSSL_ECC_BLIND_K
+#ifndef ALT_ECC_SIZE
+    mp_int    kb[1];
+    mp_int    ku[1];
+#else
+    mp_int*   kb;
+    mp_int*   ku;
+    alt_fp_int kba[1];
+    alt_fp_int kua[1];
+#endif
+#endif
 
 #ifdef WOLFSSL_CAAM
     word32 blackKey;     /* address of key encrypted and in secure memory */
@@ -507,9 +538,6 @@ struct ecc_key {
 #if defined(PLUTON_CRYPTO_ECC) || defined(WOLF_CRYPTO_CB)
     void* devCtx;
     int devId;
-#endif
-#if defined(HAVE_PKCS11)
-    byte isPkcs11 : 1; /* indicate if PKCS11 is preferred */
 #endif
 #ifdef WOLFSSL_SILABS_SE_ACCEL
     sl_se_command_context_t  cmd_ctx;
@@ -590,7 +618,20 @@ struct ecc_key {
 #endif
 };
 
-#define wc_ecc_key_get_priv(key) ((key)->k)
+#ifndef WOLFSSL_ECC_BLIND_K
+#define ecc_get_k(key)              (key)->k
+#define ecc_blind_k(key, b)         (void)b
+#define ecc_blind_k_rng(key, rng)   0
+
+#define wc_ecc_key_get_priv(key)    (key)->k
+#else
+mp_int* ecc_get_k(ecc_key* key);
+void ecc_blind_k(ecc_key* key, mp_int* b);
+int ecc_blind_k_rng(ecc_key* key, WC_RNG* rng);
+
+WOLFSSL_API mp_int* wc_ecc_key_get_priv(ecc_key* key);
+#endif
+
 #define WOLFSSL_HAVE_ECC_KEY_GET_PRIV
 
 
@@ -945,6 +986,8 @@ WOLFSSL_API
 const byte* wc_ecc_ctx_get_own_salt(ecEncCtx* ctx);
 WOLFSSL_API
 int wc_ecc_ctx_set_peer_salt(ecEncCtx* ctx, const byte* salt);
+WOLFSSL_API
+int wc_ecc_ctx_set_own_salt(ecEncCtx* ctx, const byte* salt, word32 sz);
 WOLFSSL_API
 int wc_ecc_ctx_set_kdf_salt(ecEncCtx* ctx, const byte* salt, word32 sz);
 WOLFSSL_API

--- a/include/wolfssl/wolfcrypt/ed25519.h
+++ b/include/wolfssl/wolfcrypt/ed25519.h
@@ -45,6 +45,10 @@
     extern "C" {
 #endif
 
+#if FIPS_VERSION3_GE(6,0,0)
+    extern const unsigned int wolfCrypt_FIPS_ed25519_ro_sanity[2];
+    WOLFSSL_LOCAL int wolfCrypt_FIPS_ED25519_sanity(void);
+#endif
 
 /* info about EdDSA curve specifically ed25519, defined as an elliptic curve
    over GF(p) */
@@ -69,11 +73,6 @@ enum {
     Ed25519ctx = 0,
     Ed25519ph  = 1
 };
-
-#ifndef WC_ED25519KEY_TYPE_DEFINED
-    typedef struct ed25519_key ed25519_key;
-    #define WC_ED25519KEY_TYPE_DEFINED
-#endif
 
 /* ED25519 Flags */
 enum {
@@ -110,6 +109,11 @@ struct ed25519_key {
     int sha_clean_flag;
 #endif
 };
+
+#ifndef WC_ED25519KEY_TYPE_DEFINED
+    typedef struct ed25519_key ed25519_key;
+    #define WC_ED25519KEY_TYPE_DEFINED
+#endif
 
 
 WOLFSSL_API

--- a/include/wolfssl/wolfcrypt/error-crypt.h
+++ b/include/wolfssl/wolfcrypt/error-crypt.h
@@ -73,8 +73,8 @@ enum {
     VAR_STATE_CHANGE_E = -126,  /* var state modified by different thread */
     FIPS_DEGRADED_E    = -127,  /* FIPS Module in degraded mode */
 
-    /* -128 unused. */
-    /* -129 unused. */
+    FIPS_CODE_SZ_E     = -128,  /* Module CODE too big */
+    FIPS_DATA_SZ_E     = -129,  /* Module DATA too big */
 
     RSA_WRONG_TYPE_E   = -130,  /* RSA wrong block type for RSA function */
     RSA_BUFFER_E       = -131,  /* RSA buffer error, output too small or
@@ -107,12 +107,14 @@ enum {
     ASN_SIG_HASH_E     = -156,  /* ASN sig error, unsupported hash type */
     ASN_SIG_KEY_E      = -157,  /* ASN sig error, unsupported key type */
     ASN_DH_KEY_E       = -158,  /* ASN key init error, invalid input */
-    /* -159 unused. */
+    KDF_SRTP_KAT_FIPS_E = -159, /* SRTP-KDF Known Answer Test Failure */
     ASN_CRIT_EXT_E     = -160,  /* ASN unsupported critical extension */
     ASN_ALT_NAME_E     = -161,  /* ASN alternate name error */
     ASN_NO_PEM_HEADER  = -162,  /* ASN no PEM header found */
-
-    /* -163..-169 unused. */
+    ED25519_KAT_FIPS_E = -163,  /* Ed25519 Known answer test failure */
+    ED448_KAT_FIPS_E   = -164,  /* Ed448 Known answer test failure */
+    PBKDF2_KAT_FIPS_E  = -165,  /* PBKDF2 Known answer test failure */
+    /* -166..-169 unused. */
 
     ECC_BAD_ARG_E      = -170,  /* ECC input argument of wrong type */
     ASN_ECC_KEY_E      = -171,  /* ASN ECC bad input */
@@ -188,10 +190,11 @@ enum {
     WC_INIT_E           = -228,  /* wolfcrypt failed to initialize */
     SIG_VERIFY_E        = -229,  /* wolfcrypt signature verify error */
     BAD_COND_E          = -230,  /* Bad condition variable operation */
-    SIG_TYPE_E          = -231,  /* Signature Type not enabled/available */
+    SIG_TYPE_E          = -231,  /* Signature Type not enabled/available
+                                  * NOTE: 1024-bit sign disabled in FIPS mode */
     HASH_TYPE_E         = -232,  /* Hash Type not enabled/available */
 
-    /* -233 unused. */
+    FIPS_INVALID_VER_E  = -233,  /* Invalid FIPS Version defined */
 
     WC_KEY_SIZE_E       = -234,  /* Key size error, either too small or large */
     ASN_COUNTRY_SIZE_E  = -235,  /* ASN Cert Gen, invalid country code size */
@@ -289,6 +292,22 @@ enum {
 #else
 WOLFSSL_API void wc_ErrorString(int err, char* buff);
 WOLFSSL_ABI WOLFSSL_API const char* wc_GetErrorString(int error);
+#endif
+
+#if defined(WOLFSSL_DEBUG_TRACE_ERROR_CODES) && !defined(BUILDING_WOLFSSL)
+    #undef WOLFSSL_DEBUG_TRACE_ERROR_CODES
+#endif
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES
+    #define WC_NO_ERR_TRACE(label) (CONST_NUM_ERR_ ## label)
+    #ifndef WC_ERR_TRACE
+        #define WC_ERR_TRACE(label)                           \
+            ( fprintf(stderr,                                 \
+                      "ERR TRACE: %s L %d " #label " (%d)\n", \
+                      __FILE__, __LINE__, label), label)
+    #endif
+    #include <wolfssl/debug-trace-error-codes.h>
+#else
+    #define WC_NO_ERR_TRACE(label) (label)
 #endif
 
 #ifdef __cplusplus

--- a/include/wolfssl/wolfcrypt/hmac.h
+++ b/include/wolfssl/wolfcrypt/hmac.h
@@ -30,8 +30,7 @@
 
 #ifndef NO_HMAC
 
-#if defined(HAVE_FIPS) && \
-        defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
+#if FIPS_VERSION3_GE(2,0,0)
     #include <wolfssl/wolfcrypt/fips.h>
 #endif
 
@@ -39,9 +38,17 @@
     extern "C" {
 #endif
 
+#if FIPS_VERSION3_GE(6,0,0)
+    extern const unsigned int wolfCrypt_FIPS_hmac_ro_sanity[2];
+    WOLFSSL_LOCAL int wolfCrypt_FIPS_HMAC_sanity(void);
+#endif
+
+#if FIPS_VERSION3_GE(6,0,0)
+    #define FIPS_ALLOW_SHORT 1
+#endif
+
 /* avoid redefinition of structs */
-#if !defined(HAVE_FIPS) || \
-    (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2))
+#if !defined(HAVE_FIPS) || FIPS_VERSION3_GE(2,0,0)
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     #include <wolfssl/wolfcrypt/async.h>
@@ -184,7 +191,10 @@ struct Hmac {
 #endif /* HAVE_FIPS */
 
 /* does init */
-WOLFSSL_API int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 keySz);
+WOLFSSL_API int wc_HmacSetKey(Hmac* hmac, int type, const byte* key,
+                              word32 keySz);
+WOLFSSL_API int wc_HmacSetKey_ex(Hmac* hmac, int type, const byte* key,
+                                 word32 length, int allowFlag);
 WOLFSSL_API int wc_HmacUpdate(Hmac* hmac, const byte* in, word32 sz);
 WOLFSSL_API int wc_HmacFinal(Hmac* hmac, byte* out);
 #ifdef WOLFSSL_KCAPI_HMAC

--- a/include/wolfssl/wolfcrypt/kdf.h
+++ b/include/wolfssl/wolfcrypt/kdf.h
@@ -39,6 +39,11 @@
     extern "C" {
 #endif
 
+#if FIPS_VERSION3_GE(6,0,0)
+    extern const unsigned int wolfCrypt_FIPS_kdf_ro_sanity[2];
+    WOLFSSL_LOCAL int wolfCrypt_FIPS_KDF_sanity(void);
+#endif
+
 enum max_prf {
 #ifdef HAVE_FFDHE_8192
     MAX_PRF_HALF        = 516, /* Maximum half secret len */
@@ -132,6 +137,12 @@ WOLFSSL_API int wc_SSH_KDF(byte hashId, byte keyId,
 /* Length of index for SRTCP KDF. */
 #define WC_SRTCP_INDEX_LEN              4
 
+/* Indicators */
+enum {
+    WC_SRTCP_32BIT_IDX = 0,
+    WC_SRTCP_48BIT_IDX = 1,
+};
+
 /* Maximum length of salt that can be used with SRTP/SRTCP. */
 #define WC_SRTP_MAX_SALT    14
 
@@ -141,6 +152,9 @@ WOLFSSL_API int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt,
 WOLFSSL_API int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt,
     word32 saltSz, int kdrIdx, const byte* index, byte* key1, word32 key1Sz,
     byte* key2, word32 key2Sz, byte* key3, word32 key3Sz);
+WOLFSSL_API int wc_SRTCP_KDF_ex(const byte* key, word32 keySz, const byte* salt,
+    word32 saltSz, int kdrIdx, const byte* index, byte* key1, word32 key1Sz,
+    byte* key2, word32 key2Sz, byte* key3, word32 key3Sz, int idxLenIndicator);
 WOLFSSL_API int wc_SRTP_KDF_label(const byte* key, word32 keySz,
     const byte* salt, word32 saltSz, int kdrIdx, const byte* index, byte label,
     byte* outKey, word32 outKeySz);
@@ -152,6 +166,11 @@ WOLFSSL_API int wc_SRTP_KDF_kdr_to_idx(word32 kdr);
 
 #endif /* WC_SRTP_KDF */
 
+#ifdef WC_KDF_NIST_SP_800_56C
+WOLFSSL_API int wc_KDA_KDF_onestep(const byte* z, word32 zSz,
+    const byte* fixedInfo, word32 fixedInfoSz, word32 derivedSecretSz,
+    enum wc_HashType hashType, byte* output, word32 outputSz);
+#endif
 #ifdef __cplusplus
     } /* extern "C" */
 #endif

--- a/include/wolfssl/wolfcrypt/logging.h
+++ b/include/wolfssl/wolfcrypt/logging.h
@@ -181,6 +181,25 @@ WOLFSSL_API void wolfSSL_SetLoggingPrefix(const char* prefix);
     #define WOLFSSL_MSG_EX(...) WC_DO_NOTHING
 #endif
     WOLFSSL_API void WOLFSSL_MSG(const char* msg);
+#ifdef WOLFSSL_DEBUG_CODEPOINTS
+    WOLFSSL_API void WOLFSSL_MSG2(
+        const char *file, int line, const char* msg);
+    WOLFSSL_API void WOLFSSL_ENTER2(
+        const char *file, int line, const char* msg);
+    WOLFSSL_API void WOLFSSL_LEAVE2(
+        const char *file, int line, const char* msg, int ret);
+    #define WOLFSSL_MSG(msg) WOLFSSL_MSG2(__FILE__, __LINE__, msg)
+    #define WOLFSSL_ENTER(msg) WOLFSSL_ENTER2(__FILE__, __LINE__, msg)
+    #define WOLFSSL_LEAVE(msg, ret) WOLFSSL_LEAVE2(__FILE__, __LINE__, msg, ret)
+    #ifdef XVSNPRINTF
+        WOLFSSL_API void WOLFSSL_MSG_EX2(
+            const char *file, int line, const char* fmt, ...);
+        #define WOLFSSL_MSG_EX(fmt, args...) \
+                WOLFSSL_MSG_EX2(__FILE__, __LINE__, fmt, ## args)
+    #else
+        #define WOLFSSL_MSG_EX2(...) WC_DO_NOTHING
+    #endif
+#endif
     WOLFSSL_API void WOLFSSL_BUFFER(const byte* buffer, word32 length);
 
 #else

--- a/include/wolfssl/wolfcrypt/memory.h
+++ b/include/wolfssl/wolfcrypt/memory.h
@@ -101,48 +101,72 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
     #ifndef WOLFSSL_STATIC_ALIGN
         #define WOLFSSL_STATIC_ALIGN 16
     #endif
-    #ifndef WOLFMEM_MAX_BUCKETS
-        #define WOLFMEM_MAX_BUCKETS  9
+/* WOLFMEM_BUCKETS - list of the sizes of buckets in the pool
+ * WOLFMEM_DIST - list of quantities of buffers in the buckets
+ * WOLFMEM_DEF_BUCKETS - number of values in WOLFMEM_BUCKETS and WOLFMEM_DIST
+ * WOLFMEM_MAX_BUCKETS - size of the arrays used to store the buckets and
+ *     dists in the memory pool; defaults to WOLFMEM_DEF_BUCKETS
+ *
+ * The following defines provide a reasonable set of buckets in the memory
+ * pool for running wolfSSL on a Linux box. The bucket and dist lists below
+ * have nine items each, so WOLFMEM_DEF_BUCKETS is set to 9.
+ *
+ * If WOLFMEM_DEF_BUCKETS is less then WOLFMEM_MAX_BUCKETS, the unused values
+ * are set to zero and ignored. If WOLFMEM_MAX_BUCKETS is less than
+ * WOLFMEM_DEF_BUCKETS, not all the buckets will be created in the pool.
+ */
+    #ifndef WOLFMEM_DEF_BUCKETS
+        #define WOLFMEM_DEF_BUCKETS  9  /* number of default memory blocks */
     #endif
-    #define WOLFMEM_DEF_BUCKETS  9     /* number of default memory blocks */
+
+    #ifndef WOLFMEM_MAX_BUCKETS
+        #define WOLFMEM_MAX_BUCKETS  WOLFMEM_DEF_BUCKETS
+    #endif
+
+    #if WOLFMEM_MAX_BUCKETS < WOLFMEM_DEF_BUCKETS
+        #warning "ignoring excess buckets, MAX_BUCKETS less than DEF_BUCKETS"
+    #endif
+
     #ifndef WOLFMEM_IO_SZ
         #define WOLFMEM_IO_SZ        16992 /* 16 byte aligned */
     #endif
+
+    #ifndef LARGEST_MEM_BUCKET
+        #ifndef SESSION_CERTS
+            #define LARGEST_MEM_BUCKET 16128
+        #elif defined(OPENSSL_EXTRA)
+            #ifdef WOLFSSL_TLS13
+                #define LARGEST_MEM_BUCKET 30400
+            #else
+                #define LARGEST_MEM_BUCKET 25600
+            #endif
+        #elif defined(WOLFSSL_CERT_EXT)
+            /* certificate extensions requires 24k for the SSL struct */
+            #define LARGEST_MEM_BUCKET 24576
+        #else
+            /* increase 23k for object member of WOLFSSL_X509_NAME_ENTRY */
+            #define LARGEST_MEM_BUCKET 23440
+        #endif
+    #endif
+
     #ifndef WOLFMEM_BUCKETS
         #ifndef SESSION_CERTS
             /* default size of chunks of memory to separate into */
-            #ifndef LARGEST_MEM_BUCKET
-                #define LARGEST_MEM_BUCKET 16128
-            #endif
             #define WOLFMEM_BUCKETS 64,128,256,512,1024,2432,3456,4544,\
                                     LARGEST_MEM_BUCKET
-        #elif defined (OPENSSL_EXTRA)
+        #elif defined(OPENSSL_EXTRA)
             /* extra storage in structs for multiple attributes and order */
-            #ifndef LARGEST_MEM_BUCKET
-                #ifdef WOLFSSL_TLS13
-                    #define LARGEST_MEM_BUCKET 30400
-                #else
-                    #define LARGEST_MEM_BUCKET 25600
-                #endif
-            #endif
             #define WOLFMEM_BUCKETS 64,128,256,512,1024,2432,3360,4480,\
                                     LARGEST_MEM_BUCKET
-        #elif defined (WOLFSSL_CERT_EXT)
-            /* certificate extensions requires 24k for the SSL struct */
-            #ifndef LARGEST_MEM_BUCKET
-                #define LARGEST_MEM_BUCKET 24576
-            #endif
+        #elif defined(WOLFSSL_CERT_EXT)
             #define WOLFMEM_BUCKETS 64,128,256,512,1024,2432,3456,4544,\
                                     LARGEST_MEM_BUCKET
         #else
-            /* increase 23k for object member of WOLFSSL_X509_NAME_ENTRY */
-            #ifndef LARGEST_MEM_BUCKET
-                #define LARGEST_MEM_BUCKET 23440
-            #endif
             #define WOLFMEM_BUCKETS 64,128,256,512,1024,2432,3456,4544,\
                                     LARGEST_MEM_BUCKET
         #endif
     #endif
+
     #ifndef WOLFMEM_DIST
         #ifndef WOLFSSL_STATIC_MEMORY_SMALL
             #define WOLFMEM_DIST    49,10,6,14,5,6,9,1,1
@@ -190,7 +214,14 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
     typedef struct wc_Memory wc_Memory; /* internal structure for mem bucket */
     typedef struct WOLFSSL_HEAP {
         wc_Memory* ava[WOLFMEM_MAX_BUCKETS];
+    #ifndef WOLFSSL_STATIC_MEMORY_LEAN
         wc_Memory* io;                  /* list of buffers to use for IO */
+    #endif
+
+    #ifdef WOLFSSL_STATIC_MEMORY_LEAN
+        word16   sizeList[WOLFMEM_MAX_BUCKETS];/* memory sizes in ava list */
+        byte     distList[WOLFMEM_MAX_BUCKETS];/* general distribution */
+    #else
         word32     maxHa;               /* max concurrent handshakes */
         word32     curHa;
         word32     maxIO;               /* max concurrent IO connections */
@@ -199,10 +230,16 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
         word32     distList[WOLFMEM_MAX_BUCKETS];/* general distribution */
         word32     inUse; /* amount of memory currently in use */
         word32     ioUse;
+    #endif
+
+    #ifndef WOLFSSL_STATIC_MEMORY_LEAN
         word32     alloc; /* total number of allocs */
         word32     frAlc; /* total number of frees  */
         int        flag;
+    #endif
+    #ifndef SINGLE_THREADED
         wolfSSL_Mutex memory_mutex;
+    #endif
     } WOLFSSL_HEAP;
 
     /* structure passed into XMALLOC as heap hint
@@ -211,22 +248,41 @@ WOLFSSL_API int wolfSSL_GetAllocators(wolfSSL_Malloc_cb* mf,
     typedef struct WOLFSSL_HEAP_HINT {
         WOLFSSL_HEAP*           memory;
         WOLFSSL_MEM_CONN_STATS* stats;  /* hold individual connection stats */
+    #ifndef WOLFSSL_STATIC_MEMORY_LEAN
         wc_Memory*  outBuf; /* set if using fixed io buffers */
         wc_Memory*  inBuf;
         byte        haFlag; /* flag used for checking handshake count */
+    #endif
     } WOLFSSL_HEAP_HINT;
 
+    WOLFSSL_API void* wolfSSL_SetGlobalHeapHint(void* heap);
+    WOLFSSL_API void* wolfSSL_GetGlobalHeapHint(void);
+    WOLFSSL_API int wc_LoadStaticMemory_ex(WOLFSSL_HEAP_HINT** pHint,
+            unsigned int listSz, const unsigned int *sizeList,
+            const unsigned int *distList, unsigned char* buf, unsigned int sz,
+            int flag, int max);
+#ifdef WOLFSSL_STATIC_MEMORY_DEBUG_CALLBACK
+    #define WOLFSSL_DEBUG_MEMORY_ALLOC 0
+    #define WOLFSSL_DEBUG_MEMORY_FAIL  1
+    #define WOLFSSL_DEBUG_MEMORY_FREE  2
+    #define WOLFSSL_DEBUG_MEMORY_INIT  3
+
+
+    typedef void (*DebugMemoryCb)(size_t sz, int bucketSz, byte st, int type);
+    WOLFSSL_API void wolfSSL_SetDebugMemoryCb(DebugMemoryCb cb);
+#endif
     WOLFSSL_API int wc_LoadStaticMemory(WOLFSSL_HEAP_HINT** pHint,
             unsigned char* buf, unsigned int sz, int flag, int max);
+    WOLFSSL_API void wc_UnloadStaticMemory(WOLFSSL_HEAP_HINT* heap);
 
-    WOLFSSL_LOCAL int wolfSSL_init_memory_heap(WOLFSSL_HEAP* heap);
-    WOLFSSL_LOCAL int wolfSSL_load_static_memory(byte* buffer, word32 sz,
-                                                  int flag, WOLFSSL_HEAP* heap);
-    WOLFSSL_LOCAL int wolfSSL_GetMemStats(WOLFSSL_HEAP* heap,
+    WOLFSSL_API int wolfSSL_GetMemStats(WOLFSSL_HEAP* heap,
                                                       WOLFSSL_MEM_STATS* stats);
     WOLFSSL_LOCAL int SetFixedIO(WOLFSSL_HEAP* heap, wc_Memory** io);
     WOLFSSL_LOCAL int FreeFixedIO(WOLFSSL_HEAP* heap, wc_Memory** io);
 
+    WOLFSSL_API int wolfSSL_StaticBufferSz_ex(unsigned int listSz,
+            const unsigned int *sizeList, const unsigned int *distList,
+            byte* buffer, word32 sz, int flag);
     WOLFSSL_API int wolfSSL_StaticBufferSz(byte* buffer, word32 sz, int flag);
     WOLFSSL_API int wolfSSL_MemoryPaddingSz(void);
 #endif /* WOLFSSL_STATIC_MEMORY */
@@ -271,6 +327,9 @@ WOLFSSL_LOCAL int wc_debug_CipherLifecycleFree(void **CipherLifecycleTag,
     WOLFSSL_LOCAL int SAVE_VECTOR_REGISTERS2_fuzzer(void);
     #ifndef WC_DEBUG_VECTOR_REGISTERS_FUZZING_SEED
         #define WC_DEBUG_VECTOR_REGISTERS_FUZZING_SEED 0
+    #endif
+    #ifndef CAN_SAVE_VECTOR_REGISTERS
+        #define CAN_SAVE_VECTOR_REGISTERS() (SAVE_VECTOR_REGISTERS2_fuzzer() == 0)
     #endif
 #endif
 

--- a/include/wolfssl/wolfcrypt/misc.h
+++ b/include/wolfssl/wolfcrypt/misc.h
@@ -135,6 +135,8 @@ WOLFSSL_LOCAL byte ctSetLTE(int a, int b);
 WOLFSSL_LOCAL void ctMaskCopy(byte mask, byte* dst, byte* src, word16 size);
 WOLFSSL_LOCAL word32 MakeWordFromHash(const byte* hashID);
 WOLFSSL_LOCAL word32 HashObject(const byte* o, word32 len, int* error);
+WOLFSSL_LOCAL char* CopyString(const char* src, int srcLen, void* heap,
+        int type);
 
 WOLFSSL_LOCAL void w64Increment(w64wrapper *n);
 WOLFSSL_LOCAL void w64Decrement(w64wrapper *n);

--- a/include/wolfssl/wolfcrypt/pkcs12.h
+++ b/include/wolfssl/wolfcrypt/pkcs12.h
@@ -29,9 +29,7 @@
     extern "C" {
 #endif
 
-#ifndef WOLFSSL_TYPES_DEFINED /* do not redeclare from ssl.h */
-    typedef struct WC_PKCS12 WC_PKCS12;
-#endif
+typedef struct WC_PKCS12 WC_PKCS12;
 
 typedef struct WC_DerCertList { /* dereferenced in ssl.c */
     byte* buffer;
@@ -47,6 +45,7 @@ enum {
 };
 
 WOLFSSL_API WC_PKCS12* wc_PKCS12_new(void);
+WOLFSSL_API WC_PKCS12* wc_PKCS12_new_ex(void* heap);
 WOLFSSL_API void wc_PKCS12_free(WC_PKCS12* pkcs12);
 WOLFSSL_API int wc_d2i_PKCS12(const byte* der, word32 derSz, WC_PKCS12* pkcs12);
 #ifndef NO_FILESYSTEM
@@ -67,7 +66,7 @@ WOLFSSL_API WC_PKCS12* wc_PKCS12_create(char* pass, word32 passSz,
 WOLFSSL_LOCAL int wc_PKCS12_SetHeap(WC_PKCS12* pkcs12, void* heap);
 WOLFSSL_LOCAL void* wc_PKCS12_GetHeap(WC_PKCS12* pkcs12);
 
-WOLFSSL_LOCAL void wc_FreeCertList(WC_DerCertList* list, void* heap);
+WOLFSSL_API void wc_FreeCertList(WC_DerCertList* list, void* heap);
 
 #ifdef __cplusplus
     } /* extern "C" */

--- a/include/wolfssl/wolfcrypt/poly1305.h
+++ b/include/wolfssl/wolfcrypt/poly1305.h
@@ -48,7 +48,14 @@
 #define WC_HAS_GCC_4_4_64BIT
 #endif
 
-#if defined(WOLFSSL_X86_64_BUILD) && defined(USE_INTEL_SPEEDUP)
+#ifdef WOLFSSL_X86_64_BUILD
+#if defined(USE_INTEL_SPEEDUP) && !defined(NO_POLY1305_ASM)
+    #define USE_INTEL_POLY1305_SPEEDUP
+    #define HAVE_INTEL_AVX1
+#endif
+#endif
+
+#if defined(USE_INTEL_POLY1305_SPEEDUP)
 #elif (defined(WC_HAS_SIZEOF_INT128_64BIT) || defined(WC_HAS_MSVC_64BIT) ||  \
        defined(WC_HAS_GCC_4_4_64BIT))
 #define POLY130564
@@ -67,7 +74,7 @@ enum {
 
 /* Poly1305 state */
 typedef struct Poly1305 {
-#if defined(WOLFSSL_X86_64_BUILD) && defined(USE_INTEL_SPEEDUP)
+#ifdef USE_INTEL_POLY1305_SPEEDUP
     word64 r[3];
     word64 h[3];
     word64 pad[2];

--- a/include/wolfssl/wolfcrypt/pwdbased.h
+++ b/include/wolfssl/wolfcrypt/pwdbased.h
@@ -35,6 +35,10 @@
     extern "C" {
 #endif
 
+#if FIPS_VERSION3_GE(6,0,0)
+    extern const unsigned int wolfCrypt_FIPS_pbkdf_ro_sanity[2];
+    WOLFSSL_LOCAL int wolfCrypt_FIPS_PBKDF_sanity(void);
+#endif
 /*
  * hashType renamed to typeH to avoid shadowing global declaration here:
  * wolfssl/wolfcrypt/asn.h line 173 in enum Oid_Types

--- a/include/wolfssl/wolfcrypt/random.h
+++ b/include/wolfssl/wolfcrypt/random.h
@@ -30,13 +30,17 @@
 
 #include <wolfssl/wolfcrypt/types.h>
 
-#if defined(HAVE_FIPS) && \
-    defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
+#if FIPS_VERSION3_GE(2,0,0)
     #include <wolfssl/wolfcrypt/fips.h>
 #endif /* HAVE_FIPS_VERSION >= 2 */
 
 #ifdef __cplusplus
     extern "C" {
+#endif
+
+#if FIPS_VERSION3_GE(6,0,0)
+    extern const unsigned int wolfCrypt_FIPS_drbg_ro_sanity[2];
+    WOLFSSL_LOCAL int wolfCrypt_FIPS_DRBG_sanity(void);
 #endif
 
  /* Maximum generate block length */
@@ -242,8 +246,8 @@ WOLFSSL_API int  wc_FreeRng(WC_RNG* rng);
 #endif
 
 #ifdef HAVE_HASHDRBG
-    WOLFSSL_LOCAL int wc_RNG_DRBG_Reseed(WC_RNG* rng, const byte* entropy,
-                                        word32 entropySz);
+    WOLFSSL_API int wc_RNG_DRBG_Reseed(WC_RNG* rng, const byte* entropy,
+                                       word32 entropySz);
     WOLFSSL_API int wc_RNG_TestSeed(const byte* seed, word32 seedSz);
     WOLFSSL_API int wc_RNG_HealthTest(int reseed,
                                         const byte* entropyA, word32 entropyASz,

--- a/include/wolfssl/wolfcrypt/rsa.h
+++ b/include/wolfssl/wolfcrypt/rsa.h
@@ -97,6 +97,11 @@ RSA keys can be used to encrypt, decrypt, sign and verify data.
     extern "C" {
 #endif
 
+#if FIPS_VERSION3_GE(6,0,0)
+    extern const unsigned int wolfCrypt_FIPS_rsa_ro_sanity[2];
+    WOLFSSL_LOCAL int wolfCrypt_FIPS_RSA_sanity(void);
+#endif
+
 #ifndef RSA_MIN_SIZE
 #define RSA_MIN_SIZE 512
 #endif
@@ -134,6 +139,11 @@ RSA keys can be used to encrypt, decrypt, sign and verify data.
     #ifdef WOLFSSL_CERT_GEN
         #include <wolfssl/wolfcrypt/asn.h>
     #endif
+#endif
+
+#if FIPS_VERSION3_GE(6,0,0)
+    #define WC_RSA_FIPS_GEN_MIN 2048
+    #define WC_RSA_FIPS_SIG_MIN (WC_RSA_FIPS_GEN_MIN/8)
 #endif
 
 enum {
@@ -207,9 +217,6 @@ struct RsaKey {
     void* devCtx;
     int   devId;
 #endif
-#if defined(HAVE_PKCS11)
-    byte isPkcs11 : 1; /* indicate if PKCS11 is preferred */
-#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
     #ifdef WOLFSSL_CERT_GEN
@@ -235,8 +242,8 @@ struct RsaKey {
     char label[RSA_MAX_LABEL_LEN];
     int  labelLen;
 #endif
-#if defined(WOLFSSL_ASYNC_CRYPT) || !defined(WOLFSSL_RSA_VERIFY_INLINE) && \
-    !defined(WOLFSSL_NO_MALLOC)
+#if !defined(WOLFSSL_NO_MALLOC) && (defined(WOLFSSL_ASYNC_CRYPT) || \
+    (!defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_VERIFY_INLINE)))
     byte   dataIsAlloc;
 #endif
 #ifdef WC_RSA_NONBLOCK
@@ -434,18 +441,23 @@ WOLFSSL_API int wc_RsaExportKey(RsaKey* key,
                                           int nlen, int* isPrime);
 #endif
 
-WOLFSSL_LOCAL int wc_RsaPad_ex(const byte* input, word32 inputLen, byte* pkcsBlock,
-        word32 pkcsBlockLen, byte padValue, WC_RNG* rng, int padType,
-        enum wc_HashType hType, int mgf, byte* optLabel, word32 labelLen,
-        int saltLen, int bits, void* heap);
-WOLFSSL_LOCAL int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen, byte** out,
-                                   byte padValue, int padType, enum wc_HashType hType,
-                                   int mgf, byte* optLabel, word32 labelLen, int saltLen,
-                                   int bits, void* heap);
+WOLFSSL_API int wc_RsaPad_ex(const byte* input, word32 inputLen,
+    byte* pkcsBlock, word32 pkcsBlockLen, byte padValue,
+    WC_RNG* rng, int padType, enum wc_HashType hType, int mgf,
+    byte* optLabel, word32 labelLen, int saltLen, int bits, void* heap);
+WOLFSSL_API int wc_RsaUnPad_ex(byte* pkcsBlock, word32 pkcsBlockLen,
+    byte** out, byte padValue, int padType, enum wc_HashType hType, int mgf,
+    byte* optLabel, word32 labelLen, int saltLen, int bits, void* heap);
 
 WOLFSSL_LOCAL int wc_hash2mgf(enum wc_HashType hType);
 WOLFSSL_LOCAL int RsaFunctionCheckIn(const byte* in, word32 inLen, RsaKey* key,
     int checkSmallCt);
+
+WOLFSSL_API int wc_RsaPrivateKeyDecodeRaw(const byte* n, word32 nSz,
+        const byte* e, word32 eSz, const byte* d, word32 dSz,
+        const byte* u, word32 uSz, const byte* p, word32 pSz,
+        const byte* q, word32 qSz, const byte* dP, word32 dPSz,
+        const byte* dQ, word32 dQSz, RsaKey* key);
 
 #ifdef __cplusplus
     } /* extern "C" */

--- a/include/wolfssl/wolfcrypt/settings.h
+++ b/include/wolfssl/wolfcrypt/settings.h
@@ -1,6 +1,6 @@
 /* settings.h
  *
- * Copyright (C) 2006-2023 wolfSSL Inc.
+ * Copyright (C) 2006-2024 wolfSSL Inc.
  *
  * This file is part of wolfSSL.
  *
@@ -265,6 +265,23 @@
 /* Uncomment next line if using MAXQ108x */
 /* #define WOLFSSL_MAXQ108X */
 
+/* Check PLATFORMIO first, as it may define other known environments. */
+#ifdef PLATFORMIO
+    #ifdef ESP_PLATFORM
+        /* Turn on the wolfSSL ESPIDF flag for the PlatformIO ESP-IDF detect */
+        #define WOLFSSL_ESPIDF
+    #endif /* ESP_PLATFORM */
+
+    /* Ensure all PlatformIO boards have the wolfSSL user_setting.h enabled. */
+    #ifndef WOLFSSL_USER_SETTINGS
+        #define WOLFSSL_USER_SETTINGS
+    #endif /* WOLFSSL_USER_SETTINGS */
+
+    /* Similar to Arduino we have limited build control, so suppress warning */
+    #undef  WOLFSSL_IGNORE_FILE_WARN
+    #define WOLFSSL_IGNORE_FILE_WARN
+#endif
+
 #if defined(ARDUINO)
     /* Due to limited build control, we'll ignore file warnings. */
     /* See https://github.com/arduino/arduino-cli/issues/631     */
@@ -306,22 +323,61 @@
 
 #include <wolfssl/wolfcrypt/visibility.h>
 
-#define WOLFSSL_MAKE_FIPS_VERSION(major, minor) (((major) * 256) + (minor))
+/*------------------------------------------------------------*/
+#define WOLFSSL_MAKE_FIPS_VERSION3(major, minor, patch) \
+                                (((major) * 65536) + ((minor) * 256) + (patch))
+#define WOLFSSL_MAKE_FIPS_VERSION(major, minor) \
+                                  WOLFSSL_MAKE_FIPS_VERSION3(major, minor, 0)
+
 #if !defined(HAVE_FIPS)
-    #define WOLFSSL_FIPS_VERSION_CODE WOLFSSL_MAKE_FIPS_VERSION(0,0)
+    #define WOLFSSL_FIPS_VERSION_CODE WOLFSSL_MAKE_FIPS_VERSION3(0,0,0)
+    #define WOLFSSL_FIPS_VERSION2_CODE WOLFSSL_FIPS_VERSION_CODE
 #elif !defined(HAVE_FIPS_VERSION)
-    #define WOLFSSL_FIPS_VERSION_CODE WOLFSSL_MAKE_FIPS_VERSION(1,0)
+    #define WOLFSSL_FIPS_VERSION_CODE WOLFSSL_MAKE_FIPS_VERSION3(1,0,0)
+    #define WOLFSSL_FIPS_VERSION2_CODE WOLFSSL_FIPS_VERSION_CODE
 #elif !defined(HAVE_FIPS_VERSION_MINOR)
-    #define WOLFSSL_FIPS_VERSION_CODE WOLFSSL_MAKE_FIPS_VERSION(HAVE_FIPS_VERSION,0)
+    #define WOLFSSL_FIPS_VERSION_CODE \
+            WOLFSSL_MAKE_FIPS_VERSION3(HAVE_FIPS_VERSION,0,0)
+    #define WOLFSSL_FIPS_VERSION2_CODE WOLFSSL_FIPS_VERSION_CODE
+#elif !defined(HAVE_FIPS_VERSION_PATCH)
+    #define WOLFSSL_FIPS_VERSION_CODE \
+            WOLFSSL_MAKE_FIPS_VERSION3(HAVE_FIPS_VERSION, \
+                                       HAVE_FIPS_VERSION_MINOR, 0)
+    #define WOLFSSL_FIPS_VERSION2_CODE WOLFSSL_FIPS_VERSION_CODE
 #else
-    #define WOLFSSL_FIPS_VERSION_CODE WOLFSSL_MAKE_FIPS_VERSION(HAVE_FIPS_VERSION,HAVE_FIPS_VERSION_MINOR)
+    #define WOLFSSL_FIPS_VERSION_CODE \
+            WOLFSSL_MAKE_FIPS_VERSION3(HAVE_FIPS_VERSION,\
+                                       HAVE_FIPS_VERSION_MINOR, \
+                                       HAVE_FIPS_VERSION_PATCH)
+    #define WOLFSSL_FIPS_VERSION2_CODE \
+            WOLFSSL_MAKE_FIPS_VERSION3(HAVE_FIPS_VERSION,\
+                                       HAVE_FIPS_VERSION_MINOR, \
+                                       0)
 #endif
 
-#define FIPS_VERSION_LT(major,minor) (WOLFSSL_FIPS_VERSION_CODE < WOLFSSL_MAKE_FIPS_VERSION(major,minor))
-#define FIPS_VERSION_LE(major,minor) (WOLFSSL_FIPS_VERSION_CODE <= WOLFSSL_MAKE_FIPS_VERSION(major,minor))
-#define FIPS_VERSION_EQ(major,minor) (WOLFSSL_FIPS_VERSION_CODE == WOLFSSL_MAKE_FIPS_VERSION(major,minor))
-#define FIPS_VERSION_GE(major,minor) (WOLFSSL_FIPS_VERSION_CODE >= WOLFSSL_MAKE_FIPS_VERSION(major,minor))
-#define FIPS_VERSION_GT(major,minor) (WOLFSSL_FIPS_VERSION_CODE > WOLFSSL_MAKE_FIPS_VERSION(major,minor))
+#define FIPS_VERSION_LT(major,minor) \
+           (WOLFSSL_FIPS_VERSION2_CODE < WOLFSSL_MAKE_FIPS_VERSION(major,minor))
+#define FIPS_VERSION_LE(major,minor) \
+          (WOLFSSL_FIPS_VERSION2_CODE <= WOLFSSL_MAKE_FIPS_VERSION(major,minor))
+#define FIPS_VERSION_EQ(major,minor) \
+          (WOLFSSL_FIPS_VERSION2_CODE == WOLFSSL_MAKE_FIPS_VERSION(major,minor))
+#define FIPS_VERSION_GE(major,minor) \
+          (WOLFSSL_FIPS_VERSION2_CODE >= WOLFSSL_MAKE_FIPS_VERSION(major,minor))
+#define FIPS_VERSION_GT(major,minor) \
+           (WOLFSSL_FIPS_VERSION2_CODE > WOLFSSL_MAKE_FIPS_VERSION(major,minor))
+
+#define FIPS_VERSION3_LT(major,minor,patch) \
+    (WOLFSSL_FIPS_VERSION_CODE < WOLFSSL_MAKE_FIPS_VERSION3(major,minor,patch))
+#define FIPS_VERSION3_LE(major,minor,patch) \
+    (WOLFSSL_FIPS_VERSION_CODE <= WOLFSSL_MAKE_FIPS_VERSION3(major,minor,patch))
+#define FIPS_VERSION3_EQ(major,minor,patch) \
+    (WOLFSSL_FIPS_VERSION_CODE == WOLFSSL_MAKE_FIPS_VERSION3(major,minor,patch))
+#define FIPS_VERSION3_GE(major,minor,patch) \
+    (WOLFSSL_FIPS_VERSION_CODE >= WOLFSSL_MAKE_FIPS_VERSION3(major,minor,patch))
+#define FIPS_VERSION3_GT(major,minor,patch) \
+    (WOLFSSL_FIPS_VERSION_CODE > WOLFSSL_MAKE_FIPS_VERSION3(major,minor,patch))
+/*------------------------------------------------------------*/
+
 
 /* make sure old RNG name is used with CTaoCrypt FIPS */
 #ifdef HAVE_FIPS
@@ -332,7 +388,7 @@
          * system or other set of headers included by wolfSSL already defines
          * RNG. Examples are:
          * wolfEngine, wolfProvider and potentially other use-cases */
-        #ifndef RNG
+        #if !defined(RNG) && !defined(NO_OLD_RNGNAME)
             #define RNG WC_RNG
         #endif
     #endif
@@ -452,6 +508,9 @@
 
         /* WC_RSA_BLINDING takes up extra space! */
         #define WC_RSA_BLINDING
+
+        /* Cache Resistant features are  on by default, but has performance
+         * penalty on embedded systems. May not be needed here. Disabled: */
         #define WC_NO_CACHE_RESISTANT
     #endif /* !WOLFSSL_ESPIDF_NO_DEFAULT */
 
@@ -977,7 +1036,7 @@ extern void uITRON4_free(void *p) ;
 
 
 #if defined(WOLFSSL_LEANPSK) && !defined(XMALLOC_USER) && \
-        !defined(NO_WOLFSSL_MEMORY)
+        !defined(NO_WOLFSSL_MEMORY) && !defined(WOLFSSL_STATIC_MEMORY)
     #include <stdlib.h>
     #define XMALLOC(s, h, type)  ((void)(h), (void)(type), malloc((s)))
     #define XFREE(p, h, type)    ((void)(h), (void)(type), free((p)))
@@ -995,22 +1054,45 @@ extern void uITRON4_free(void *p) ;
 
 
 #ifdef FREERTOS
-    #include "FreeRTOS.h"
-    #include <task.h>
+
+    #ifdef PLATFORMIO
+        #include <freertos/FreeRTOS.h>
+        #include <freertos/task.h>
+    #else
+        #include "FreeRTOS.h"
+        #include <task.h>
+    #endif
 
     #if !defined(XMALLOC_USER) && !defined(NO_WOLFSSL_MEMORY) && \
         !defined(WOLFSSL_STATIC_MEMORY) && !defined(WOLFSSL_TRACK_MEMORY)
-        #define XMALLOC(s, h, type)  ((void)(h), (void)(type), pvPortMalloc((s)))
+
+        /* XMALLOC */
+        #if defined(WOLFSSL_ESPIDF) && \
+           (defined(DEBUG_WOLFSSL) || defined(DEBUG_WOLFSSL_MALLOC))
+            #include <wolfssl/wolfcrypt/port/Espressif/esp-sdk-lib.h>
+            #define XMALLOC(s, h, type)  \
+                           ((void)(h), (void)(type), wc_debug_pvPortMalloc( \
+                           (s), (__FILE__), (__LINE__), (__FUNCTION__) ))
+        #else
+            #define XMALLOC(s, h, type)  \
+                           ((void)(h), (void)(type), pvPortMalloc((s)))
+        #endif
+
+        /* XFREE */
         #define XFREE(p, h, type)    ((void)(h), (void)(type), vPortFree((p)))
+
+        /* XREALLOC */
         #if defined(WOLFSSL_ESPIDF)
-                /* In IDF, realloc(p, n) is equivalent to
-                 * heap_caps_realloc(p, s, MALLOC_CAP_8BIT)
-                 *  there's no pvPortRealloc available  */
-                #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), realloc((p), (n)))
-        /* FreeRTOS pvPortRealloc() implementation can be found here:
-         * https://github.com/wolfSSL/wolfssl-freertos/pull/3/files */
+            /* In the Espressif EDP-IDF, realloc(p, n) is equivalent to
+             *     heap_caps_realloc(p, s, MALLOC_CAP_8BIT)
+             * There's no pvPortRealloc available:  */
+            #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), realloc((p), (n)))
         #elif defined(USE_INTEGER_HEAP_MATH) || defined(OPENSSL_EXTRA)
-                #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), pvPortRealloc((p), (n)))
+            /* FreeRTOS pvPortRealloc() implementation can be found here:
+             * https://github.com/wolfSSL/wolfssl-freertos/pull/3/files */
+            #define XREALLOC(p, n, h, t) ((void)(h), (void)(t), pvPortRealloc((p), (n)))
+        #else
+            /* no XREALLOC available */
         #endif
     #endif
 
@@ -1034,7 +1116,11 @@ extern void uITRON4_free(void *p) ;
     #endif
 
     #ifndef SINGLE_THREADED
-        #include "semphr.h"
+        #ifdef PLATFORMIO
+            #include <freertos/semphr.h>
+        #else
+            #include "semphr.h"
+        #endif
     #endif
 #endif
 
@@ -1241,7 +1327,9 @@ extern void uITRON4_free(void *p) ;
     /* Copy data out of flash memory and into SRAM */
     #define XMEMCPY_P(pdest, psrc, size) memcpy_P((pdest), (psrc), (size))
 #else
+#ifndef FLASH_QUALIFIER
     #define FLASH_QUALIFIER
+#endif
 #endif
 
 #ifdef FREESCALE_MQX_5_0
@@ -2000,14 +2088,22 @@ extern void uITRON4_free(void *p) ;
 #endif /*(WOLFSSL_APACHE_MYNEWT)*/
 
 #ifdef WOLFSSL_ZEPHYR
+    #include <version.h>
+#if KERNEL_VERSION_NUMBER >= 0x30100
     #include <zephyr/kernel.h>
     #include <zephyr/sys/printk.h>
     #include <zephyr/sys/util.h>
+#else
+    #include <kernel.h>
+    #include <sys/printk.h>
+    #include <sys/util.h>
+#endif
     #include <stdlib.h>
 
     #define WOLFSSL_DH_CONST
     #define WOLFSSL_HAVE_MAX
     #define NO_WRITEV
+    #define NO_STDLIB_ISASCII
 
     #define USE_FLAT_BENCHMARK_H
     #define USE_FLAT_TEST_H
@@ -2692,7 +2788,9 @@ extern void uITRON4_free(void *p) ;
     #endif
 
     /* Enable ECC_CACHE_CURVE for ASYNC */
-    #if !defined(ECC_CACHE_CURVE)
+    #if !defined(ECC_CACHE_CURVE) && !defined(NO_ECC_CACHE_CURVE)
+        /* Enabled by default for increased async performance,
+         * but not required */
         #define ECC_CACHE_CURVE
     #endif
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -2718,9 +2816,6 @@ extern void uITRON4_free(void *p) ;
     #if !defined(WOLFSSL_SP_MATH_ALL) && !defined(USE_FAST_MATH) && \
         !defined(WOLFSSL_SP_MATH) && !defined(NO_BIG_INT)
          #error The static memory option is only supported for fast math or SP Math
-    #endif
-    #ifdef WOLFSSL_SMALL_STACK
-        #error static memory does not support small stack please undefine
     #endif
 #endif /* WOLFSSL_STATIC_MEMORY */
 
@@ -2833,6 +2928,9 @@ extern void uITRON4_free(void *p) ;
     #ifndef WOLFSSL_SP_DIV_WORD_HALF
         #define WOLFSSL_SP_DIV_WORD_HALF
     #endif
+    #ifdef __PIE__
+        #define WC_NO_INTERNAL_FUNCTION_POINTERS
+    #endif
 #endif
 
 
@@ -2864,6 +2962,9 @@ extern void uITRON4_free(void *p) ;
     #endif
     #ifndef HAVE_SNI
         #define HAVE_SNI
+    #endif
+    #ifndef WOLFSSL_RSA_KEY_CHECK
+        #define WOLFSSL_RSA_KEY_CHECK
     #endif
 #endif
 
@@ -3159,8 +3260,10 @@ extern void uITRON4_free(void *p) ;
 
 /* Do not allow using small stack with no malloc */
 #if defined(WOLFSSL_NO_MALLOC) && \
-    (defined(WOLFSSL_SMALL_STACK) || defined(WOLFSSL_SMALL_STACK_CACHE))
-    #error Small stack cannot be used with no malloc (WOLFSSL_NO_MALLOC)
+    (defined(WOLFSSL_SMALL_STACK) || defined(WOLFSSL_SMALL_STACK_CACHE)) && \
+    !defined(WOLFSSL_STATIC_MEMORY)
+    #error Small stack cannot be used with no malloc (WOLFSSL_NO_MALLOC) and \
+           without staticmemory (WOLFSSL_STATIC_MEMORY)
 #endif
 
 /* If malloc is disabled make sure it is also disabled in SP math */
@@ -3192,6 +3295,13 @@ extern void uITRON4_free(void *p) ;
  */
 #if defined(HAVE_POLY1305) && !defined(HAVE_ONE_TIME_AUTH)
     #define HAVE_ONE_TIME_AUTH
+#endif
+
+/* This is checked for in configure.ac, so might want to do it in here as well.
+ */
+#if defined(HAVE_SECURE_RENEGOTIATION) && defined(HAVE_RENEGOTIATION_INDICATION)
+    #error HAVE_RENEGOTIATION_INDICATION cannot be defined together with \
+           HAVE_SECURE_RENEGOTIATION
 #endif
 
 /* Check for insecure build combination:
@@ -3242,7 +3352,9 @@ extern void uITRON4_free(void *p) ;
 #ifdef HAVE_LIBOQS
 #define HAVE_PQC
 #define HAVE_FALCON
-#define HAVE_DILITHIUM
+#ifndef HAVE_DILITHIUM
+    #define HAVE_DILITHIUM
+#endif
 #ifndef WOLFSSL_NO_SPHINCS
     #define HAVE_SPHINCS
 #endif
@@ -3264,6 +3376,7 @@ extern void uITRON4_free(void *p) ;
 
 #if (defined(HAVE_LIBOQS) ||                                            \
      defined(WOLFSSL_WC_KYBER) ||                                       \
+     defined(WOLFSSL_WC_DILITHIUM) ||                                   \
      defined(HAVE_LIBXMSS) ||                                           \
      defined(HAVE_LIBLMS) ||                                            \
      defined(WOLFSSL_DUAL_ALG_CERTS)) &&                                \
@@ -3294,6 +3407,11 @@ extern void uITRON4_free(void *p) ;
     #error The SRTP extension requires DTLS
 #endif
 
+/* FIPS v5 and older doesn't support WOLF_PRIVATE_KEY_ID with PK callbacks */
+#if defined(HAVE_FIPS) && FIPS_VERSION_LT(5,3) && defined(HAVE_PK_CALLBACKS)
+    #define NO_WOLF_PRIVATE_KEY_ID
+#endif
+
 /* Are we using an external private key store like:
  *     PKCS11 / HSM / crypto callback / PK callback */
 #if !defined(WOLF_PRIVATE_KEY_ID) && !defined(NO_WOLF_PRIVATE_KEY_ID) && \
@@ -3312,9 +3430,17 @@ extern void uITRON4_free(void *p) ;
 
 /* (D)TLS v1.3 requires 64-bit number wrappers as does XMSS and LMS. */
 #if defined(WOLFSSL_TLS13) || defined(WOLFSSL_DTLS_DROP_STATS) || \
-    defined(WOLFSSL_WC_XMSS) || defined(WOLFSSL_WC_LMS)
+    (defined(WOLFSSL_WC_XMSS) && (!defined(WOLFSSL_XMSS_MAX_HEIGHT) || \
+    WOLFSSL_XMSS_MAX_HEIGHT > 32)) || (defined(WOLFSSL_WC_LMS) && \
+    !defined(WOLFSSL_LMS_VERIFY_ONLY))
     #undef WOLFSSL_W64_WRAPPER
     #define WOLFSSL_W64_WRAPPER
+#endif
+
+/* wc_xmss and wc_lms require these misc.c functions. */
+#if defined(WOLFSSL_WC_XMSS) || defined(WOLFSSL_WC_LMS)
+    #undef  WOLFSSL_NO_INT_ENCODE
+    #undef  WOLFSSL_NO_INT_DECODE
 #endif
 
 /* DTLS v1.3 requires AES ECB if using AES */
@@ -3434,8 +3560,30 @@ extern void uITRON4_free(void *p) ;
 #endif
 
 /* Some final sanity checks */
+#ifdef WOLFSSL_APPLE_HOMEKIT
+    #ifndef WOLFCRYPT_HAVE_SRP
+        #error "WOLFCRYPT_HAVE_SRP is required for Apple Homekit"
+    #endif
+    #ifndef HAVE_CHACHA
+        #error "HAVE_CHACHA is required for Apple Homekit"
+    #endif
+    #ifdef  USE_FAST_MATH
+        #ifdef FP_MAX_BITS
+            #if FP_MAX_BITS < (8192 * 2)
+                #error "HomeKit FP_MAX_BITS must at least (8192 * 2)"
+            #endif
+        #else
+            #error "HomeKit FP_MAX_BITS must be assigned a value (8192 * 2)"
+        #endif
+    #endif
+#endif
+
 #if defined(WOLFSSL_ESPIDF) && defined(ARDUINO)
     #error "Found both ESPIDF and ARDUINO. Pick one."
+#endif
+
+#if defined(HAVE_FIPS) && defined(HAVE_PKCS11)
+    #error "PKCS11 not allowed with FIPS enabled (Crypto outside boundary)"
 #endif
 
 #if defined(WOLFSSL_CAAM_BLOB)
@@ -3449,6 +3597,29 @@ extern void uITRON4_free(void *p) ;
         #error "HAVE_ED25519 requires WOLFSSL_SHA512"
     #endif
 #endif
+
+#if (defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)) && \
+    defined(OPENSSL_COEXIST)
+    #error "OPENSSL_EXTRA can not be defined with OPENSSL_COEXIST"
+#endif
+
+#if !defined(NO_DSA) && defined(NO_SHA)
+    #error "Please disable DSA if disabling SHA-1"
+#endif
+
+/* if configure.ac turned on this feature, HAVE_ENTROPY_MEMUSE will be set,
+ * also define HAVE_WOLFENTROPY */
+#ifdef HAVE_ENTROPY_MEMUSE
+    #ifndef HAVE_WOLFENTROPY
+        #define HAVE_WOLFENTROPY
+    #endif
+#elif defined(HAVE_WOLFENTROPY)
+    /* else if user_settings.h only defined HAVE_WOLFENTROPY
+     * also define HAVE_ENTROPY_MEMUSE */
+    #ifndef HAVE_ENTROPY_MEMUSE
+        #define HAVE_ENTROPY_MEMUSE
+    #endif
+#endif /* HAVE_ENTROPY_MEMUSE */
 
 #ifdef __cplusplus
     }   /* extern "C" */

--- a/include/wolfssl/wolfcrypt/sha256.h
+++ b/include/wolfssl/wolfcrypt/sha256.h
@@ -32,8 +32,7 @@
 
 #ifndef NO_SHA256
 
-#if defined(HAVE_FIPS) && \
-    defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
+#if FIPS_VERSION3_GE(2,0,0)
     #include <wolfssl/wolfcrypt/fips.h>
 #endif /* HAVE_FIPS_VERSION >= 2 */
 
@@ -59,6 +58,11 @@
 
 #ifdef __cplusplus
     extern "C" {
+#endif
+
+#if FIPS_VERSION3_GE(6,0,0)
+    extern const unsigned int wolfCrypt_FIPS_sha256_ro_sanity[2];
+    WOLFSSL_LOCAL int wolfCrypt_FIPS_SHA256_sanity(void);
 #endif
 
 /* avoid redefinition of structs */
@@ -175,13 +179,23 @@ struct wc_Sha256 {
 #elif defined(WOLFSSL_HAVE_PSA) && !defined(WOLFSSL_PSA_NO_HASH)
     psa_hash_operation_t psa_ctx;
 #else
+#ifdef WC_64BIT_CPU
     /* alignment on digest and buffer speeds up ARMv8 crypto operations */
     ALIGN16 word32  digest[WC_SHA256_DIGEST_SIZE / sizeof(word32)];
     ALIGN16 word32  buffer[WC_SHA256_BLOCK_SIZE  / sizeof(word32)];
+#else
+    word32  digest[WC_SHA256_DIGEST_SIZE / sizeof(word32)];
+    word32  buffer[WC_SHA256_BLOCK_SIZE  / sizeof(word32)];
+#endif
     word32  buffLen;   /* in bytes          */
     word32  loLen;     /* length in bytes   */
     word32  hiLen;     /* length in bytes   */
     void*   heap;
+
+#ifdef WC_C_DYNAMIC_FALLBACK
+    int sha_method;
+#endif
+
 #endif
 #ifdef WOLFSSL_PIC32MZ_HASH
     hashUpdCache cache; /* cache for updates */

--- a/include/wolfssl/wolfcrypt/sha3.h
+++ b/include/wolfssl/wolfcrypt/sha3.h
@@ -1,0 +1,234 @@
+/* sha3.h
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#ifndef WOLF_CRYPT_SHA3_H
+#define WOLF_CRYPT_SHA3_H
+
+#include <wolfssl/wolfcrypt/types.h>
+
+#ifdef WOLFSSL_SHA3
+
+#ifdef HAVE_FIPS
+    /* for fips @wc_fips */
+    #include <wolfssl/wolfcrypt/fips.h>
+#endif
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#if FIPS_VERSION3_GE(6,0,0)
+    extern const unsigned int wolfCrypt_FIPS_sha3_ro_sanity[2];
+    WOLFSSL_LOCAL int wolfCrypt_FIPS_SHA3_sanity(void);
+#endif
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    #include <wolfssl/wolfcrypt/async.h>
+#endif
+
+/* in bytes */
+enum {
+    /* SHAKE-128 */
+    WC_SHA3_128_COUNT        = 21,
+
+    WC_SHA3_224              = WC_HASH_TYPE_SHA3_224,
+    WC_SHA3_224_DIGEST_SIZE  = 28,
+    WC_SHA3_224_COUNT        = 18,
+
+    WC_SHA3_256              = WC_HASH_TYPE_SHA3_256,
+    WC_SHA3_256_DIGEST_SIZE  = 32,
+    WC_SHA3_256_COUNT        = 17,
+
+    WC_SHA3_384              = WC_HASH_TYPE_SHA3_384,
+    WC_SHA3_384_DIGEST_SIZE  = 48,
+    WC_SHA3_384_COUNT        = 13,
+
+    WC_SHA3_512              = WC_HASH_TYPE_SHA3_512,
+    WC_SHA3_512_DIGEST_SIZE  = 64,
+    WC_SHA3_512_COUNT        =  9,
+
+    #ifdef WOLFSSL_SHAKE128
+        WC_SHAKE128          = WC_HASH_TYPE_SHAKE128,
+    #endif
+    #ifdef WOLFSSL_SHAKE256
+        WC_SHAKE256          = WC_HASH_TYPE_SHAKE256,
+    #endif
+
+#if !defined(HAVE_SELFTEST) || \
+    defined(HAVE_SELFTEST_VERSION) && (HAVE_SELFTEST_VERSION >= 2)
+    /* These values are used for HMAC, not SHA-3 directly.
+     * They come from from FIPS PUB 202. */
+    WC_SHA3_128_BLOCK_SIZE = 168,
+    WC_SHA3_224_BLOCK_SIZE = 144,
+    WC_SHA3_256_BLOCK_SIZE = 136,
+    WC_SHA3_384_BLOCK_SIZE = 104,
+    WC_SHA3_512_BLOCK_SIZE = 72,
+#endif
+
+    WOLF_ENUM_DUMMY_LAST_ELEMENT(WC_SHA3)
+};
+
+#ifndef NO_OLD_WC_NAMES
+    #define SHA3_224             WC_SHA3_224
+    #define SHA3_224_DIGEST_SIZE WC_SHA3_224_DIGEST_SIZE
+    #define SHA3_256             WC_SHA3_256
+    #define SHA3_256_DIGEST_SIZE WC_SHA3_256_DIGEST_SIZE
+    #define SHA3_384             WC_SHA3_384
+    #define SHA3_384_DIGEST_SIZE WC_SHA3_384_DIGEST_SIZE
+    #define SHA3_512             WC_SHA3_512
+    #define SHA3_512_DIGEST_SIZE WC_SHA3_512_DIGEST_SIZE
+    #define Sha3 wc_Sha3
+    #ifdef WOLFSSL_SHAKE128
+        #define SHAKE128             WC_SHAKE128
+    #endif
+    #ifdef WOLFSSL_SHAKE256
+        #define SHAKE256             WC_SHAKE256
+    #endif
+#endif
+
+
+
+#ifdef WOLFSSL_XILINX_CRYPT
+    #include "wolfssl/wolfcrypt/port/xilinx/xil-sha3.h"
+#elif defined(WOLFSSL_AFALG_XILINX_SHA3)
+    #include <wolfssl/wolfcrypt/port/af_alg/afalg_hash.h>
+#else
+
+/* Sha3 digest */
+struct wc_Sha3 {
+    /* State data that is processed for each block. */
+    word64 s[25];
+    /* Unprocessed message data. */
+    byte   t[200];
+    /* Index into unprocessed data to place next message byte. */
+    byte   i;
+
+    void*  heap;
+
+#ifdef WOLF_CRYPTO_CB
+    int    devId;
+#endif
+
+#ifdef WC_C_DYNAMIC_FALLBACK
+    void (*sha3_block)(word64 *s);
+    void (*sha3_block_n)(word64 *s, const byte* data, word32 n,
+        word64 c);
+#endif
+
+#ifdef WOLFSSL_ASYNC_CRYPT
+    WC_ASYNC_DEV asyncDev;
+#endif /* WOLFSSL_ASYNC_CRYPT */
+#ifdef WOLFSSL_HASH_FLAGS
+    word32 flags; /* enum wc_HashFlags in hash.h */
+#endif
+};
+
+#ifndef WC_SHA3_TYPE_DEFINED
+    typedef struct wc_Sha3 wc_Sha3;
+    #define WC_SHA3_TYPE_DEFINED
+#endif
+
+#endif
+
+#if defined(WOLFSSL_SHAKE128) || defined(WOLFSSL_SHAKE256)
+    #ifndef WC_SHAKE_TYPE_DEFINED
+        typedef wc_Sha3 wc_Shake;
+        #define WC_SHAKE_TYPE_DEFINED
+    #endif
+#endif
+
+WOLFSSL_API int wc_InitSha3_224(wc_Sha3* sha3, void* heap, int devId);
+WOLFSSL_API int wc_Sha3_224_Update(wc_Sha3* sha3, const byte* data, word32 len);
+WOLFSSL_API int wc_Sha3_224_Final(wc_Sha3* sha3, byte* hash);
+WOLFSSL_API void wc_Sha3_224_Free(wc_Sha3* sha3);
+WOLFSSL_API int wc_Sha3_224_GetHash(wc_Sha3* sha3, byte* hash);
+WOLFSSL_API int wc_Sha3_224_Copy(wc_Sha3* src, wc_Sha3* dst);
+
+WOLFSSL_API int wc_InitSha3_256(wc_Sha3* sha3, void* heap, int devId);
+WOLFSSL_API int wc_Sha3_256_Update(wc_Sha3* sha3, const byte* data, word32 len);
+WOLFSSL_API int wc_Sha3_256_Final(wc_Sha3* sha3, byte* hash);
+WOLFSSL_API void wc_Sha3_256_Free(wc_Sha3* sha3);
+WOLFSSL_API int wc_Sha3_256_GetHash(wc_Sha3* sha3, byte* hash);
+WOLFSSL_API int wc_Sha3_256_Copy(wc_Sha3* src, wc_Sha3* dst);
+
+WOLFSSL_API int wc_InitSha3_384(wc_Sha3* sha3, void* heap, int devId);
+WOLFSSL_API int wc_Sha3_384_Update(wc_Sha3* sha3, const byte* data, word32 len);
+WOLFSSL_API int wc_Sha3_384_Final(wc_Sha3* sha3, byte* hash);
+WOLFSSL_API void wc_Sha3_384_Free(wc_Sha3* sha3);
+WOLFSSL_API int wc_Sha3_384_GetHash(wc_Sha3* sha3, byte* hash);
+WOLFSSL_API int wc_Sha3_384_Copy(wc_Sha3* src, wc_Sha3* dst);
+
+WOLFSSL_API int wc_InitSha3_512(wc_Sha3* sha3, void* heap, int devId);
+WOLFSSL_API int wc_Sha3_512_Update(wc_Sha3* sha3, const byte* data, word32 len);
+WOLFSSL_API int wc_Sha3_512_Final(wc_Sha3* sha3, byte* hash);
+WOLFSSL_API void wc_Sha3_512_Free(wc_Sha3* sha3);
+WOLFSSL_API int wc_Sha3_512_GetHash(wc_Sha3* sha3, byte* hash);
+WOLFSSL_API int wc_Sha3_512_Copy(wc_Sha3* src, wc_Sha3* dst);
+
+#ifdef WOLFSSL_SHAKE128
+WOLFSSL_API int wc_InitShake128(wc_Shake* shake, void* heap, int devId);
+WOLFSSL_API int wc_Shake128_Update(wc_Shake* shake, const byte* data, word32 len);
+WOLFSSL_API int wc_Shake128_Final(wc_Shake* shake, byte* hash, word32 hashLen);
+WOLFSSL_API int wc_Shake128_Absorb(wc_Shake* shake, const byte* data,
+    word32 len);
+WOLFSSL_API int wc_Shake128_SqueezeBlocks(wc_Shake* shake, byte* out,
+    word32 blockCnt);
+WOLFSSL_API void wc_Shake128_Free(wc_Shake* shake);
+WOLFSSL_API int wc_Shake128_Copy(wc_Shake* src, wc_Sha3* dst);
+#endif
+
+#ifdef WOLFSSL_SHAKE256
+WOLFSSL_API int wc_InitShake256(wc_Shake* shake, void* heap, int devId);
+WOLFSSL_API int wc_Shake256_Update(wc_Shake* shake, const byte* data, word32 len);
+WOLFSSL_API int wc_Shake256_Final(wc_Shake* shake, byte* hash, word32 hashLen);
+WOLFSSL_API int wc_Shake256_Absorb(wc_Shake* shake, const byte* data,
+    word32 len);
+WOLFSSL_API int wc_Shake256_SqueezeBlocks(wc_Shake* shake, byte* out,
+    word32 blockCnt);
+WOLFSSL_API void wc_Shake256_Free(wc_Shake* shake);
+WOLFSSL_API int wc_Shake256_Copy(wc_Shake* src, wc_Sha3* dst);
+#endif
+
+#ifdef WOLFSSL_HASH_FLAGS
+    WOLFSSL_API int wc_Sha3_SetFlags(wc_Sha3* sha3, word32 flags);
+    WOLFSSL_API int wc_Sha3_GetFlags(wc_Sha3* sha3, word32* flags);
+#endif
+
+#ifdef USE_INTEL_SPEEDUP
+WOLFSSL_LOCAL void sha3_block_n_bmi2(word64* s, const byte* data, word32 n,
+    word64 c);
+WOLFSSL_LOCAL void sha3_block_bmi2(word64* s);
+WOLFSSL_LOCAL void sha3_block_avx2(word64* s);
+WOLFSSL_LOCAL void BlockSha3(word64 *s);
+#endif
+#if defined(WOLFSSL_ARMASM) && (defined(__arm__) || \
+    defined(WOLFSSL_ARMASM_CRYPTO_SHA3))
+WOLFSSL_LOCAL void BlockSha3(word64 *s);
+#endif
+
+#ifdef __cplusplus
+    } /* extern "C" */
+#endif
+
+#endif /* WOLFSSL_SHA3 */
+#endif /* WOLF_CRYPT_SHA3_H */
+

--- a/include/wolfssl/wolfcrypt/sha512.h
+++ b/include/wolfssl/wolfcrypt/sha512.h
@@ -32,13 +32,17 @@
 #if defined(WOLFSSL_SHA512) || defined(WOLFSSL_SHA384)
 
 
-#if defined(HAVE_FIPS) && \
-    defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
+#if FIPS_VERSION3_GE(2,0,0)
     #include <wolfssl/wolfcrypt/fips.h>
 #endif /* HAVE_FIPS_VERSION >= 2 */
 
 #ifdef __cplusplus
     extern "C" {
+#endif
+
+#if FIPS_VERSION3_GE(6,0,0)
+    extern const unsigned int wolfCrypt_FIPS_sha512_ro_sanity[2];
+    WOLFSSL_LOCAL int wolfCrypt_FIPS_SHA512_sanity(void);
 #endif
 
 /* avoid redefinition of structs */
@@ -147,15 +151,20 @@ struct wc_Sha512 {
 #ifdef USE_INTEL_SPEEDUP
     const byte* data;
 #endif
+#ifdef WC_C_DYNAMIC_FALLBACK
+    int sha_method;
+#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     WC_ASYNC_DEV asyncDev;
 #endif /* WOLFSSL_ASYNC_CRYPT */
 #ifdef WOLFSSL_SMALL_STACK_CACHE
     word64* W;
 #endif
+
 #if defined(WOLFSSL_ESP32_CRYPT) && \
    !defined(NO_WOLFSSL_ESP32_CRYPT_HASH) && \
-   !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512)
+    (!defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA512) || \
+     !defined(NO_WOLFSSL_ESP32_CRYPT_HASH_SHA384))
     WC_ESP32SHA ctx;
 #endif
 #if defined(WOLFSSL_SILABS_SE_ACCEL)

--- a/include/wolfssl/wolfcrypt/sp_int.h
+++ b/include/wolfssl/wolfcrypt/sp_int.h
@@ -695,9 +695,11 @@ typedef struct sp_ecc_ctx {
 #define sp_clamp(a)                                               \
     do {                                                          \
         int ii;                                                   \
-        for (ii = (int)(a)->used - 1; ii >= 0 && (a)->dp[ii] == 0; ii--) { \
+        if ((a)->used > 0) {                                      \
+            for (ii = (int)(a)->used - 1; ii >= 0 && (a)->dp[ii] == 0; ii--) { \
+            }                                                     \
+            (a)->used = (unsigned int)ii + 1;                     \
         }                                                         \
-        (a)->used = (unsigned int)ii + 1;                         \
     } while (0)
 
 /* Check the compiled and linked math implementation are the same.
@@ -996,6 +998,9 @@ MP_API int sp_submod_ct(const sp_int* a, const sp_int* b, const sp_int* m,
 MP_API int sp_addmod_ct(const sp_int* a, const sp_int* b, const sp_int* m,
     sp_int* r);
 #endif
+#if defined(WOLFSSL_SP_MATH_ALL) && defined(HAVE_ECC)
+MP_API void sp_xor_ct(const sp_int* a, const sp_int* b, int len, sp_int* r);
+#endif
 
 MP_API int sp_lshd(sp_int* a, int s);
 #ifdef WOLFSSL_SP_MATH_ALL
@@ -1144,6 +1149,7 @@ WOLFSSL_LOCAL void sp_memzero_check(sp_int* sp);
 #define mp_submod                           sp_submod
 #define mp_addmod_ct                        sp_addmod_ct
 #define mp_submod_ct                        sp_submod_ct
+#define mp_xor_ct                           sp_xor_ct
 #define mp_lshd                             sp_lshd
 #define mp_rshd                             sp_rshd
 #define mp_div                              sp_div

--- a/include/wolfssl/wolfcrypt/types.h
+++ b/include/wolfssl/wolfcrypt/types.h
@@ -303,7 +303,8 @@ typedef struct w64wrapper {
     #ifndef WARN_UNUSED_RESULT
         #if defined(WOLFSSL_LINUXKM) && defined(__must_check)
             #define WARN_UNUSED_RESULT __must_check
-        #elif defined(__GNUC__) && (__GNUC__ >= 4)
+        #elif (defined(__GNUC__) && (__GNUC__ >= 4)) || \
+            (defined(__IAR_SYSTEMS_ICC__) && (__VER__ >= 9040001))
             #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
         #else
             #define WARN_UNUSED_RESULT
@@ -311,7 +312,7 @@ typedef struct w64wrapper {
     #endif /* WARN_UNUSED_RESULT */
 
     #ifndef WC_MAYBE_UNUSED
-        #if (defined(__GNUC__) && (__GNUC__ >= 4)) || defined(__clang__)
+        #if (defined(__GNUC__) && (__GNUC__ >= 4)) || defined(__clang__) || defined(__IAR_SYSTEMS_ICC__)
             #define WC_MAYBE_UNUSED __attribute__((unused))
         #else
             #define WC_MAYBE_UNUSED
@@ -429,6 +430,9 @@ typedef struct w64wrapper {
     #define XSTR_SIZEOF(x) (sizeof(x) - 1) /* -1 to not count the null char */
 
     #define XELEM_CNT(x) (sizeof((x))/sizeof(*(x)))
+
+    #define WC_SAFE_SUM_WORD32(in1, in2, out) ((in2) <= 0xffffffffU - (in1) ? \
+                ((out) = (in1) + (in2), 1) : ((out) = 0xffffffffU, 0))
 
     /* idea to add global alloc override by Moises Guimaraes  */
     /* default to libc stuff */
@@ -589,7 +593,7 @@ typedef struct w64wrapper {
     #endif
 
     #define WC_DECLARE_HEAP_ARRAY(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE, HEAP) \
-        VAR_TYPE* VAR_NAME[VAR_ITEMS]; \
+        VAR_TYPE* VAR_NAME[VAR_ITEMS] = { NULL, }; \
         int idx##VAR_NAME = 0, inner_idx_##VAR_NAME
     #define WC_HEAP_ARRAY_ARG(VAR_NAME, VAR_TYPE, VAR_ITEMS, VAR_SIZE) \
         VAR_TYPE* VAR_NAME[VAR_ITEMS]
@@ -766,7 +770,7 @@ typedef struct w64wrapper {
                 defined(WOLFSSL_ZEPHYR) || defined(MICROCHIP_PIC24)
             /* XC32 version < 1.0 does not support strncasecmp. */
             #define USE_WOLF_STRNCASECMP
-            #define XSTRNCASECMP(s1,s2) wc_strncasecmp(s1,s2)
+            #define XSTRNCASECMP(s1,s2,n) wc_strncasecmp((s1),(s2),(n))
         #elif defined(USE_WINDOWS_API) || defined(FREERTOS_TCP_WINSIM)
             #define XSTRNCASECMP(s1,s2,n) _strnicmp((s1),(s2),(n))
         #else
@@ -820,6 +824,10 @@ typedef struct w64wrapper {
                         return ret;
                     }
                 #define XSNPRINTF _xsnprintf_
+            #elif defined(FREESCALE_MQX)
+                /* see wc_port.h for fio.h and nio.h includes.  MQX does not
+                   have stdio.h available, so it needs its own section. */
+                #define XSNPRINTF snprintf
             #elif defined(WOLF_C89)
                 #include <stdio.h>
                 #define XSPRINTF sprintf
@@ -1208,14 +1216,14 @@ typedef struct w64wrapper {
         WC_PK_TYPE_CURVE25519_KEYGEN = 16,
         WC_PK_TYPE_RSA_GET_SIZE = 17,
         #define _WC_PK_TYPE_MAX WC_PK_TYPE_RSA_GET_SIZE
-    #if defined(HAVE_PQC) && defined(WOLFSSL_HAVE_KYBER)
+    #if defined(WOLFSSL_HAVE_KYBER)
         WC_PK_TYPE_PQC_KEM_KEYGEN = 18,
         WC_PK_TYPE_PQC_KEM_ENCAPS = 19,
         WC_PK_TYPE_PQC_KEM_DECAPS = 20,
         #undef _WC_PK_TYPE_MAX
         #define _WC_PK_TYPE_MAX WC_PK_TYPE_PQC_KEM_DECAPS
     #endif
-    #if defined(HAVE_PQC) && (defined(HAVE_DILITHIUM) || defined(HAVE_FALCON))
+    #if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
         WC_PK_TYPE_PQC_SIG_KEYGEN = 21,
         WC_PK_TYPE_PQC_SIG_SIGN = 22,
         WC_PK_TYPE_PQC_SIG_VERIFY = 23,
@@ -1226,7 +1234,7 @@ typedef struct w64wrapper {
         WC_PK_TYPE_MAX = _WC_PK_TYPE_MAX
     };
 
-    #if defined(HAVE_PQC)
+#if defined(WOLFSSL_HAVE_KYBER)
     /* Post quantum KEM algorithms */
     enum wc_PqcKemType {
         WC_PQC_KEM_TYPE_NONE = 0,
@@ -1238,7 +1246,9 @@ typedef struct w64wrapper {
     #endif
         WC_PQC_KEM_TYPE_MAX = _WC_PQC_KEM_TYPE_MAX
     };
+#endif
 
+#if defined(HAVE_DILITHIUM) || defined(HAVE_FALCON)
     /* Post quantum signature algorithms */
     enum wc_PqcSignatureType {
         WC_PQC_SIG_TYPE_NONE = 0,
@@ -1255,7 +1265,7 @@ typedef struct w64wrapper {
     #endif
         WC_PQC_SIG_TYPE_MAX = _WC_PQC_SIG_TYPE_MAX
     };
-    #endif
+#endif
 
     /* settings detection for compile vs runtime math incompatibilities */
     enum {
@@ -1397,6 +1407,20 @@ typedef struct w64wrapper {
         #endif
         typedef void*            THREAD_TYPE;
         #define WOLFSSL_THREAD
+    #elif defined(WOLFSSL_USER_THREADING)
+        /* User can define user specific threading types
+         *  THREAD_RETURN
+         *  TREAD_TYPE
+         *  WOLFSSL_THREAD
+         * e.g.
+         *  typedef unsigned int  THREAD_RETURN;
+         *  typedef size_t        THREAD_TYPE;
+         *  #define WOLFSSL_THREAD void
+         *
+         * User can also implement their own wolfSSL_NewThread(),
+         * wolfSSL_JoinThread() and wolfSSL_Cond signaling if they want.
+         * Otherwise, those functions are omitted.
+        */
     #elif defined(WOLFSSL_MDK_ARM) || defined(WOLFSSL_KEIL_TCP_NET) || \
           defined(FREESCALE_MQX)
         typedef unsigned int  THREAD_RETURN;
@@ -1419,6 +1443,7 @@ typedef struct w64wrapper {
             k_thread_stack_t* threadStack;
         } THREAD_TYPE;
         #define WOLFSSL_THREAD
+        extern void* wolfsslThreadHeapHint;
     #elif defined(NETOS)
         typedef UINT        THREAD_RETURN;
         typedef struct {
@@ -1632,6 +1657,9 @@ typedef struct w64wrapper {
     #endif
     #ifndef SAVE_VECTOR_REGISTERS2
         #define SAVE_VECTOR_REGISTERS2() 0
+    #endif
+    #ifndef CAN_SAVE_VECTOR_REGISTERS
+        #define CAN_SAVE_VECTOR_REGISTERS() 1
     #endif
     #ifndef WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL
         #define WC_DEBUG_SET_VECTOR_REGISTERS_RETVAL(x) WC_DO_NOTHING

--- a/include/wolfssl/wolfcrypt/wc_port.h
+++ b/include/wolfssl/wolfcrypt/wc_port.h
@@ -80,7 +80,7 @@
             #endif
         #endif /* WOLFSSL_SGX */
     #endif
-    #ifndef SINGLE_THREADED
+    #if !defined(SINGLE_THREADED) && !defined(_WIN32_WCE)
         #include <process.h>
     #endif
 #elif defined(THREADX)
@@ -145,13 +145,20 @@
 #elif defined(WOLFSSL_APACHE_MYNEWT)
     /* do nothing */
 #elif defined(WOLFSSL_ZEPHYR)
+    #include <version.h>
     #ifndef SINGLE_THREADED
         #ifndef CONFIG_PTHREAD_IPC
             #error "Need CONFIG_PTHREAD_IPC for threading"
         #endif
+    #if KERNEL_VERSION_NUMBER >= 0x30100
         #include <zephyr/kernel.h>
         #include <zephyr/posix/posix_types.h>
         #include <zephyr/posix/pthread.h>
+    #else
+        #include <kernel.h>
+        #include <posix/posix_types.h>
+        #include <posix/pthread.h>
+    #endif
     #endif
 #elif defined(WOLFSSL_TELIT_M2MB)
 
@@ -335,7 +342,11 @@
 #endif
 #elif defined(_MSC_VER)
     /* Use MSVC compiler intrinsics for atomic ops */
-    #include <intrin.h>
+    #ifdef _WIN32_WCE
+        #include <armintr.h>
+    #else
+        #include <intrin.h>
+    #endif
     typedef volatile long wolfSSL_Atomic_Int;
     #define WOLFSSL_ATOMIC_OPS
 #endif
@@ -702,16 +713,23 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define XFGETS     fgets
     #define XFPRINTF   fprintf
     #define XFFLUSH    fflush
+    #define XFEOF(fp)  feof(fp)
+    #define XFERROR(fp) ferror(fp)
+    #define XCLEARERR(fp) clearerr(fp)
 
     #if !defined(NO_WOLFSSL_DIR)\
         && !defined(WOLFSSL_NUCLEUS) && !defined(WOLFSSL_NUCLEUS_1_2)
         #if defined(USE_WINDOWS_API)
+            #include <io.h>
             #include <sys/stat.h>
             #ifndef XSTAT
                 #define XSTAT       _stat
             #endif
             #define XS_ISREG(s) (s & _S_IFREG)
             #define SEPARATOR_CHAR ';'
+            #define XWRITE      _write
+            #define XREAD       _read
+            #define XALTHOMEVARNAME "USERPROFILE"
 
         #elif defined(ARDUINO)
             #ifndef XSTAT
@@ -765,6 +783,15 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #endif
     #ifndef MAX_PATH
         #define MAX_PATH (260 + 1)
+    #endif
+    #ifndef XFEOF
+        #define XFEOF(fp)  0
+    #endif
+    #ifndef XFERROR
+        #define XFERROR(fp) 0
+    #endif
+    #ifndef XCLEARERR
+        #define XCLEARERR(fp) WC_DO_NOTHING
     #endif
 
     WOLFSSL_LOCAL int wc_FileLoad(const char* fname, unsigned char** buf,
@@ -999,8 +1026,13 @@ WOLFSSL_ABI WOLFSSL_API int wolfCrypt_Cleanup(void);
     #define USE_WOLF_TIME_T
 
 #elif defined(WOLFSSL_ZEPHYR)
+    #include <version.h>
     #ifndef _POSIX_C_SOURCE
-        #include <zephyr/posix/time.h>
+        #if KERNEL_VERSION_NUMBER >= 0x30100
+            #include <zephyr/posix/time.h>
+        #else
+            #include <posix/time.h>
+        #endif
     #else
         #include <time.h>
     #endif

--- a/include/wolfssl/wolfio.h
+++ b/include/wolfssl/wolfio.h
@@ -129,7 +129,18 @@
         #include <lwip-socket.h>
         #include <errno.h>
     #elif defined(WOLFSSL_ZEPHYR)
-        #include <zephyr/net/socket.h>
+        #include <version.h>
+        #if KERNEL_VERSION_NUMBER >= 0x30100
+            #include <zephyr/net/socket.h>
+            #ifdef CONFIG_POSIX_API
+                #include <zephyr/posix/sys/socket.h>
+            #endif
+        #else
+            #include <net/socket.h>
+            #ifdef CONFIG_POSIX_API
+                #include <posix/sys/socket.h>
+            #endif
+        #endif
     #elif defined(MICROCHIP_PIC32)
         #include <sys/errno.h>
     #elif defined(HAVE_NETX)
@@ -139,6 +150,8 @@
         #include <sys/fcltypes.h>
         #include <fclerrno.h>
         #include <fclfcntl.h>
+    #elif defined(WOLFSSL_EMNET)
+        #include <IP/IP.h>
     #elif !defined(WOLFSSL_NO_SOCK)
         #include <sys/types.h>
         #include <errno.h>
@@ -206,7 +219,8 @@
     #define SOCKET_ECONNREFUSED SYS_NET_ECONNREFUSED
     #define SOCKET_ECONNABORTED SYS_NET_ECONNABORTED
 #elif defined(FREESCALE_MQX) || defined(FREESCALE_KSDK_MQX)
-    #if MQX_USE_IO_OLD
+    #if (defined(MQX_USE_IO_OLD) && MQX_USE_IO_OLD) || \
+        defined(FREESCALE_MQX_5_0)
         /* RTCS old I/O doesn't have an EWOULDBLOCK */
         #define SOCKET_EWOULDBLOCK  EAGAIN
         #define SOCKET_EAGAIN       EAGAIN
@@ -293,7 +307,7 @@
     #define SOCKET_ECONNREFUSED ERR_CONN
     #define SOCKET_ECONNABORTED ERR_ABRT
 #elif defined(WOLFSSL_EMNET)
-    #include <IP/IP.h>
+    #define XSOCKLENT           int
     #define SOCKET_EWOULDBLOCK  IP_ERR_WOULD_BLOCK
     #define SOCKET_EAGAIN       IP_ERR_WOULD_BLOCK
     #define SOCKET_ECONNRESET   IP_ERR_CONN_RESET

--- a/libatalk/ssl/src/bio.c
+++ b/libatalk/ssl/src/bio.c
@@ -24,12 +24,11 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
-//#if defined(OPENSSL_EXTRA) && !defined(_WIN32)
+#if defined(OPENSSL_EXTRA) && !defined(_WIN32)
     /* turn on GNU extensions for XVASPRINTF with wolfSSL_BIO_printf */
-//    #undef  _GNU_SOURCE
-//    #define _GNU_SOURCE
-//#endif
-
+    #undef  _GNU_SOURCE
+    #define _GNU_SOURCE
+#endif
 
 #if !defined(WOLFSSL_BIO_INCLUDED)
     #ifndef WOLFSSL_IGNORE_FILE_WARN
@@ -51,7 +50,7 @@
  */
 static int wolfSSL_BIO_BASE64_read(WOLFSSL_BIO* bio, void* buf, int len)
 {
-    word32 frmtSz = len;
+    word32 frmtSz = (word32)len;
 
     WOLFSSL_ENTER("wolfSSL_BIO_BASE64_read");
 
@@ -78,6 +77,8 @@ static int wolfSSL_BIO_BIO_read(WOLFSSL_BIO* bio, void* buf, int len)
     if (buf == NULL || len == 0)
         return 0;
 
+    /* default no retry */
+    bio->flags &= ~(WOLFSSL_BIO_FLAG_READ|WOLFSSL_BIO_FLAG_RETRY);
     sz1 = wolfSSL_BIO_nread(bio, &pt, len);
     if (sz1 > 0) {
         XMEMCPY(buf, pt, sz1);
@@ -92,8 +93,10 @@ static int wolfSSL_BIO_BIO_read(WOLFSSL_BIO* bio, void* buf, int len)
             }
         }
     }
-    if (sz1 == 0)
+    if (sz1 == 0) {
+        bio->flags |= WOLFSSL_BIO_FLAG_READ|WOLFSSL_BIO_FLAG_RETRY;
         sz1 = -1;
+    }
 
     return sz1;
 }
@@ -176,7 +179,7 @@ static int wolfSSL_BIO_MEMORY_read(WOLFSSL_BIO* bio, void* buf, int len)
                 WOLFSSL_MSG("wolfSSL_BUF_MEM_resize error");
                 return WOLFSSL_BIO_ERROR;
             }
-            bio->mem_buf->length = bio->wrSz;
+            bio->mem_buf->length = (size_t)bio->wrSz;
             bio->ptr = bio->mem_buf->data;
         }
     }
@@ -234,13 +237,13 @@ static int wolfSSL_BIO_MD_read(WOLFSSL_BIO* bio, void* buf, int sz)
 {
     if (wolfSSL_EVP_MD_CTX_type((WOLFSSL_EVP_MD_CTX*)bio->ptr) == NID_hmac) {
         if (wolfSSL_EVP_DigestSignUpdate((WOLFSSL_EVP_MD_CTX*)bio->ptr, buf,
-                        sz) != WOLFSSL_SUCCESS)
+                        (unsigned int)sz) != WOLFSSL_SUCCESS)
         {
             return WOLFSSL_FATAL_ERROR;
         }
     }
     else {
-        if (wolfSSL_EVP_DigestUpdate((WOLFSSL_EVP_MD_CTX*)bio->ptr, buf, sz)
+        if (wolfSSL_EVP_DigestUpdate((WOLFSSL_EVP_MD_CTX*)bio->ptr, buf, (size_t)sz)
                 != WOLFSSL_SUCCESS) {
             return WOLFSSL_FATAL_ERROR;
         }
@@ -306,12 +309,12 @@ int wolfSSL_BIO_read(WOLFSSL_BIO* bio, void* buf, int len)
             case WOLFSSL_BIO_FILE:
             #ifndef NO_FILESYSTEM
                 if (bio->ptr) {
-                    ret = (int)XFREAD(buf, 1, len, (XFILE)bio->ptr);
+                    ret = (int)XFREAD(buf, 1, (size_t)len, (XFILE)bio->ptr);
                 }
                 else {
-                #if !defined(USE_WINDOWS_API) && !defined(NO_WOLFSSL_DIR) && \
+                #if defined(XREAD) && !defined(NO_WOLFSSL_DIR) && \
                     !defined(WOLFSSL_NUCLEUS) && !defined(WOLFSSL_NUCLEUS_1_2)
-                    ret = (int)XREAD(bio->num, buf, len);
+                    ret = (int)XREAD(bio->num, buf, (size_t)len);
                 #else
                     WOLFSSL_MSG("No file pointer and XREAD not enabled");
                     ret = NOT_COMPILED_IN;
@@ -400,7 +403,7 @@ static int wolfSSL_BIO_BASE64_write(WOLFSSL_BIO* bio, const void* data,
     /* get the encoded length */
     if (bio->flags & WOLFSSL_BIO_FLAG_BASE64_NO_NL) {
         if (Base64_Encode_NoNl((const byte*)data, inLen, NULL,
-                    &sz) != LENGTH_ONLY_E) {
+                    &sz) != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             WOLFSSL_MSG("Error with base64 get length");
             return WOLFSSL_FATAL_ERROR;
         }
@@ -449,7 +452,7 @@ static int wolfSSL_BIO_BASE64_write(WOLFSSL_BIO* bio, const void* data,
 
     (void)heap;
 
-    return inLen;
+    return (int)inLen;
 }
 #endif /* WOLFSSL_BASE64_ENCODE */
 
@@ -503,8 +506,11 @@ static int wolfSSL_BIO_BIO_write(WOLFSSL_BIO* bio, const void* data,
     if (bio == NULL || data == NULL || len == 0)
         return 0;
 
+    /* default no retry */
+    bio->flags &= ~(WOLFSSL_BIO_FLAG_WRITE|WOLFSSL_BIO_FLAG_RETRY);
     sz1 = wolfSSL_BIO_nwrite(bio, &buf, len);
     if (sz1 == 0) {
+        bio->flags |= WOLFSSL_BIO_FLAG_WRITE|WOLFSSL_BIO_FLAG_RETRY;
         WOLFSSL_MSG("No room left to write");
         return WOLFSSL_BIO_ERROR;
     }
@@ -522,6 +528,8 @@ static int wolfSSL_BIO_BIO_write(WOLFSSL_BIO* bio, const void* data,
         if (sz2 > 0) {
             XMEMCPY(buf, data, sz2);
             sz1 += sz2;
+            if (len > sz2)
+                bio->flags |= WOLFSSL_BIO_FLAG_WRITE|WOLFSSL_BIO_FLAG_RETRY;
         }
     }
 
@@ -592,12 +600,12 @@ static int wolfSSL_BIO_MD_write(WOLFSSL_BIO* bio, const void* data, int len)
 
     if (wolfSSL_EVP_MD_CTX_type((WOLFSSL_EVP_MD_CTX*)bio->ptr) == NID_hmac) {
         if (wolfSSL_EVP_DigestSignUpdate((WOLFSSL_EVP_MD_CTX*)bio->ptr, data,
-                    len) != WOLFSSL_SUCCESS) {
+                    (unsigned int)len) != WOLFSSL_SUCCESS) {
             ret = WOLFSSL_BIO_ERROR;
         }
     }
     else {
-        if (wolfSSL_EVP_DigestUpdate((WOLFSSL_EVP_MD_CTX*)bio->ptr, data, len)
+        if (wolfSSL_EVP_DigestUpdate((WOLFSSL_EVP_MD_CTX*)bio->ptr, data, (size_t)len)
                 != WOLFSSL_SUCCESS) {
             ret =  WOLFSSL_BIO_ERROR;
         }
@@ -653,7 +661,7 @@ int wolfSSL_BIO_write(WOLFSSL_BIO* bio, const void* data, int len)
                 if (ret > 0) {
                     /* change so that data is formatted buffer */
                     data = frmt;
-                    len  = frmtSz;
+                    len  = (int)frmtSz;
                 }
             #else
                 WOLFSSL_MSG("WOLFSSL_BIO_BASE64 used without "
@@ -671,12 +679,12 @@ int wolfSSL_BIO_write(WOLFSSL_BIO* bio, const void* data, int len)
             case WOLFSSL_BIO_FILE:
             #ifndef NO_FILESYSTEM
                 if (bio->ptr) {
-                    ret = (int)XFWRITE(data, 1, len, (XFILE)bio->ptr);
+                    ret = (int)XFWRITE(data, 1, (size_t)len, (XFILE)bio->ptr);
                 }
                 else {
-                #if !defined(USE_WINDOWS_API) && !defined(NO_WOLFSSL_DIR) && \
+                #if defined(XWRITE) && !defined(NO_WOLFSSL_DIR) && \
                     !defined(WOLFSSL_NUCLEUS) && !defined(WOLFSSL_NUCLEUS_1_2)
-                    ret = (int)XWRITE(bio->num, data, len);
+                    ret = (int)XWRITE(bio->num, data, (size_t)len);
                 #else
                     WOLFSSL_MSG("No file pointer and XWRITE not enabled");
                     ret = NOT_COMPILED_IN;
@@ -973,7 +981,7 @@ int wolfSSL_BIO_gets(WOLFSSL_BIO* bio, char* buf, int sz)
                 ret = wolfSSL_EVP_DigestFinal((WOLFSSL_EVP_MD_CTX*)bio->ptr,
                         (unsigned char*)buf, &szOut);
                 if (ret == WOLFSSL_SUCCESS) {
-                    ret = szOut;
+                    ret = (int)szOut;
                 }
             }
             break;
@@ -1258,8 +1266,8 @@ int wolfSSL_BIO_set_write_buf_size(WOLFSSL_BIO *bio, long size)
     bio->rdIdx = 0;
     if (bio->mem_buf != NULL) {
         bio->mem_buf->data = (char*)bio->ptr;
-        bio->mem_buf->length = bio->num;
-        bio->mem_buf->max = bio->num;
+        bio->mem_buf->length = (size_t)bio->num;
+        bio->mem_buf->max = (size_t)bio->num;
     }
 
     return WOLFSSL_SUCCESS;
@@ -1609,7 +1617,12 @@ int wolfSSL_BIO_write_filename(WOLFSSL_BIO *bio, char *name)
             XFCLOSE((XFILE)bio->ptr);
         }
 
-        bio->ptr = XFOPEN(name, "w");
+        /* 'b' flag is ignored on POSIX targets, but on Windows it assures
+         * inhibition of LF<->CRLF rewriting, so that there is consistency
+         * between the size and contents of the representation in memory and on
+         * disk.
+         */
+        bio->ptr = XFOPEN(name, "wb");
         if (((XFILE)bio->ptr) == XBADFILE) {
             return WOLFSSL_FAILURE;
         }
@@ -2638,7 +2651,7 @@ int wolfSSL_BIO_flush(WOLFSSL_BIO* bio)
             len = (int)XSTRLEN((const char*)buf) + 1;
         }
 
-        if (len > 0 && wolfSSL_BUF_MEM_resize(bio->mem_buf, len) == 0) {
+        if (len > 0 && wolfSSL_BUF_MEM_resize(bio->mem_buf, (size_t)len) == 0) {
             wolfSSL_BIO_free(bio);
             return NULL;
         }

--- a/libatalk/ssl/src/conf.c
+++ b/libatalk/ssl/src/conf.c
@@ -1599,4 +1599,33 @@ int wolfSSL_CONF_cmd_value_type(WOLFSSL_CONF_CTX *cctx, const char *cmd)
  * END OF CONF API
  ******************************************************************************/
 
+#if defined(OPENSSL_EXTRA)
+OPENSSL_INIT_SETTINGS* wolfSSL_OPENSSL_INIT_new(void)
+{
+    OPENSSL_INIT_SETTINGS* init = (OPENSSL_INIT_SETTINGS*)XMALLOC(
+            sizeof(OPENSSL_INIT_SETTINGS), NULL, DYNAMIC_TYPE_OPENSSL);
+
+    return init;
+}
+
+void wolfSSL_OPENSSL_INIT_free(OPENSSL_INIT_SETTINGS* init)
+{
+    XFREE(init, NULL, DYNAMIC_TYPE_OPENSSL);
+}
+
+#ifndef NO_WOLFSSL_STUB
+int wolfSSL_OPENSSL_INIT_set_config_appname(OPENSSL_INIT_SETTINGS* init,
+        char* appname)
+{
+    (void)init;
+    (void)appname;
+    WOLFSSL_STUB("OPENSSL_INIT_set_config_appname");
+    return WOLFSSL_SUCCESS;
+}
+#endif
+
+#endif /* OPENSSL_EXTRA */
+
+
+
 #endif /* WOLFSSL_CONF_INCLUDED */

--- a/libatalk/ssl/src/internal.c
+++ b/libatalk/ssl/src/internal.c
@@ -149,7 +149,7 @@
 #endif
 
 
-#define ERROR_OUT(err, eLabel) { ret = (err); goto eLabel; }
+#define ERROR_OUT(err, eLabel) { ret = (int)(err); goto eLabel; }
 
 #ifdef _MSC_VER
     /* disable for while(0) cases at the .c level for now */
@@ -264,6 +264,49 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
 #endif
 
 #endif /* !WOLFSSL_NO_TLS12 */
+
+
+#if !defined(NO_CERT) && defined(WOLFSSL_BLIND_PRIVATE_KEY)
+int wolfssl_priv_der_blind(WC_RNG* rng, DerBuffer* key, DerBuffer** mask)
+{
+    int ret = 0;
+    WC_RNG local_rng;
+
+    if (key != NULL) {
+        if (*mask != NULL) {
+            FreeDer(mask);
+        }
+        ret = AllocDer(mask, key->length, key->type, key->heap);
+        if ((ret == 0) && (rng == NULL)) {
+            if (wc_InitRng(&local_rng) != 0) {
+                ret = RNG_FAILURE_E;
+            }
+            else {
+                rng = &local_rng;
+            }
+        }
+        if (ret == 0) {
+             ret = wc_RNG_GenerateBlock(rng, (*mask)->buffer, (*mask)->length);
+        }
+        if (ret == 0) {
+            xorbuf(key->buffer, (*mask)->buffer, (*mask)->length);
+        }
+
+        if (rng == &local_rng) {
+            wc_FreeRng(rng);
+        }
+    }
+
+    return ret;
+}
+
+void wolfssl_priv_der_unblind(DerBuffer* key, DerBuffer* mask)
+{
+    if (key != NULL) {
+        xorbuf(key->buffer, mask->buffer, mask->length);
+    }
+}
+#endif
 
 
 #if defined(WOLFSSL_RENESAS_FSPSM_TLS) || defined(WOLFSSL_RENESAS_TSIP_TLS)
@@ -517,6 +560,22 @@ int IsTLS(const WOLFSSL* ssl)
 {
     if (ssl->version.major == SSLv3_MAJOR && ssl->version.minor >=TLSv1_MINOR)
         return 1;
+#ifdef WOLFSSL_DTLS
+    if (ssl->version.major == DTLS_MAJOR)
+        return 1;
+#endif
+
+    return 0;
+}
+
+int IsTLS_ex(const ProtocolVersion pv)
+{
+    if (pv.major == SSLv3_MAJOR && pv.minor >=TLSv1_MINOR)
+        return 1;
+#ifdef WOLFSSL_DTLS
+    if (pv.major == DTLS_MAJOR)
+        return 1;
+#endif
 
     return 0;
 }
@@ -2108,7 +2167,7 @@ int wolfSSL_session_export_internal(WOLFSSL* ssl, byte* buf, word32* sz,
         }
     }
 
-    if (ret != 0 && ret != LENGTH_ONLY_E && buf != NULL) {
+    if (ret != 0 && ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E) && buf != NULL) {
         /*in a fail case clear the buffer which could contain partial key info*/
         XMEMSET(buf, 0, *sz);
     }
@@ -2169,7 +2228,6 @@ int InitSSL_Side(WOLFSSL* ssl, word16 side)
         ssl->options.haveECC  = 1;      /* server turns on with ECC key cert */
     }
 #endif
-#ifdef HAVE_PQC
 #ifdef HAVE_FALCON
     if (ssl->options.side == WOLFSSL_CLIENT_END) {
         ssl->options.haveFalconSig  = 1; /* always on client side */
@@ -2180,7 +2238,6 @@ int InitSSL_Side(WOLFSSL* ssl, word16 side)
         ssl->options.haveDilithiumSig  = 1; /* always on client side */
     }
 #endif /* HAVE_DILITHIUM */
-#endif /* HAVE_PQC */
 
 #if defined(HAVE_EXTENDED_MASTER) && !defined(NO_WOLFSSL_CLIENT)
     if (ssl->options.side == WOLFSSL_CLIENT_END) {
@@ -2251,6 +2308,9 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
 
 #ifndef NO_CERTS
     ctx->privateKeyDevId = INVALID_DEVID;
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+    ctx->altPrivateKeyDevId = INVALID_DEVID;
+#endif
 #endif
 
 #ifndef NO_DH
@@ -2264,14 +2324,12 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
     ctx->minEccKeySz  = MIN_ECCKEY_SZ;
     ctx->eccTempKeySz = ECDHE_SIZE;
 #endif
-#ifdef HAVE_PQC
 #ifdef HAVE_FALCON
     ctx->minFalconKeySz = MIN_FALCONKEY_SZ;
 #endif /* HAVE_FALCON */
 #ifdef HAVE_DILITHIUM
     ctx->minDilithiumKeySz = MIN_DILITHIUMKEY_SZ;
 #endif /* HAVE_DILITHIUM */
-#endif /* HAVE_PQC */
     ctx->verifyDepth = MAX_CHAIN_DEPTH;
 #ifdef OPENSSL_EXTRA
     ctx->cbioFlag = WOLFSSL_CBIO_NONE;
@@ -2335,7 +2393,6 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
     wolfSSL_CTX_set_server_cert_type(ctx, NULL, 0); /* set to default */
 #endif /* HAVE_RPK */
 
-#ifdef HAVE_PQC
 #ifdef HAVE_FALCON
     if (method->side == WOLFSSL_CLIENT_END)
         ctx->haveFalconSig = 1;        /* always on client side */
@@ -2346,7 +2403,6 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
         ctx->haveDilithiumSig = 1;     /* always on client side */
                                        /* server can turn on by loading key */
 #endif /* HAVE_DILITHIUM */
-#endif /* HAVE_PQC */
 #ifdef HAVE_ECC
     if (method->side == WOLFSSL_CLIENT_END) {
         ctx->haveECDSAsig  = 1;        /* always on client side */
@@ -2398,22 +2454,27 @@ int InitSSL_Ctx(WOLFSSL_CTX* ctx, WOLFSSL_METHOD* method, void* heap)
         return MEMORY_E;
     }
     XMEMSET(ctx->param, 0, sizeof(WOLFSSL_X509_VERIFY_PARAM));
+
     /* WOLFSSL_X509_LOOKUP */
-    if ((ctx->x509_store.lookup.dirs =
-                            (WOLFSSL_BY_DIR*)XMALLOC(sizeof(WOLFSSL_BY_DIR),
-                            heap, DYNAMIC_TYPE_OPENSSL)) == NULL) {
-        WOLFSSL_MSG("ctx-x509_store.lookup.dir memory allocation error");
-        XFREE(ctx->param, heap, DYNAMIC_TYPE_OPENSSL);
-        ctx->param = NULL;
+    if ((ctx->x509_store.lookup.dirs = (WOLFSSL_BY_DIR*)XMALLOC(
+                           sizeof(WOLFSSL_BY_DIR),
+                           heap, DYNAMIC_TYPE_OPENSSL)) == NULL) {
+        WOLFSSL_MSG("ctx->x509_store.lookup.dirs: allocation error");
         return MEMORY_E;
     }
     XMEMSET(ctx->x509_store.lookup.dirs, 0, sizeof(WOLFSSL_BY_DIR));
+
+    /* param */
+    if ((ctx->x509_store.param = (WOLFSSL_X509_VERIFY_PARAM*)XMALLOC(
+                           sizeof(WOLFSSL_X509_VERIFY_PARAM),
+                           heap, DYNAMIC_TYPE_OPENSSL)) == NULL) {
+        WOLFSSL_MSG("ctx->x509_store.param: allocation error");
+        return MEMORY_E;
+    }
+    XMEMSET(ctx->x509_store.param, 0, sizeof(WOLFSSL_X509_VERIFY_PARAM));
+
     if (wc_InitMutex(&ctx->x509_store.lookup.dirs->lock) != 0) {
         WOLFSSL_MSG("Bad mutex init");
-        XFREE(ctx->param, heap, DYNAMIC_TYPE_OPENSSL);
-        ctx->param = NULL;
-        XFREE(ctx->x509_store.lookup.dirs, heap, DYNAMIC_TYPE_OPENSSL);
-        ctx->x509_store.lookup.dirs = NULL;
         WOLFSSL_ERROR_VERBOSE(BAD_MUTEX_E);
         return BAD_MUTEX_E;
     }
@@ -2585,11 +2646,17 @@ void SSL_CtxResourceFree(WOLFSSL_CTX* ctx)
         ForceZero(ctx->privateKey->buffer, ctx->privateKey->length);
     }
     FreeDer(&ctx->privateKey);
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    FreeDer(&ctx->privateKeyMask);
+#endif
 #ifdef WOLFSSL_DUAL_ALG_CERTS
     if (ctx->altPrivateKey != NULL && ctx->altPrivateKey->buffer != NULL) {
         ForceZero(ctx->altPrivateKey->buffer, ctx->altPrivateKey->length);
     }
     FreeDer(&ctx->altPrivateKey);
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    FreeDer(&ctx->altPrivateKeyMask);
+#endif
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
 #ifdef OPENSSL_ALL
     wolfSSL_EVP_PKEY_free(ctx->privateKeyPKey);
@@ -2659,6 +2726,11 @@ void SSL_CtxResourceFree(WOLFSSL_CTX* ctx)
     if (ctx->param) {
         XFREE(ctx->param, heapAtCTXInit, DYNAMIC_TYPE_OPENSSL);
         ctx->param = NULL;
+    }
+
+    if (ctx->x509_store.param) {
+        XFREE(ctx->x509_store.param, heapAtCTXInit, DYNAMIC_TYPE_OPENSSL);
+        ctx->x509_store.param = NULL;
     }
 
     if (ctx->x509_store.lookup.dirs) {
@@ -2732,7 +2804,7 @@ void FreeSSL_Ctx(WOLFSSL_CTX* ctx)
     if (ret < 0) {
         /* check error state, if mutex error code then mutex init failed but
          * CTX was still malloc'd */
-        if (ctx->err == CTX_INIT_MUTEX_E) {
+        if (ctx->err == WC_NO_ERR_TRACE(CTX_INIT_MUTEX_E)) {
             SSL_CtxResourceFree(ctx);
             XFREE(ctx, heap, DYNAMIC_TYPE_CTX);
         #ifdef WOLFSSL_STATIC_MEMORY
@@ -2996,7 +3068,6 @@ static WC_INLINE void AddSuiteHashSigAlgo(byte* hashSigAlgo, byte macAlgo,
         }
         else
     #endif
-    #ifdef HAVE_PQC
     #ifdef HAVE_FALCON
         if (sigAlgo == falcon_level1_sa_algo) {
             ADD_HASH_SIG_ALGO(hashSigAlgo, inOutIdx,
@@ -3026,7 +3097,6 @@ static WC_INLINE void AddSuiteHashSigAlgo(byte* hashSigAlgo, byte macAlgo,
         }
         else
     #endif /* HAVE_DILITHIUM */
-    #endif /* HAVE_PQC */
 #ifdef WC_RSA_PSS
         if (sigAlgo == rsa_pss_sa_algo) {
             /* RSA PSS is sig then mac */
@@ -3045,7 +3115,7 @@ static WC_INLINE void AddSuiteHashSigAlgo(byte* hashSigAlgo, byte macAlgo,
     }
 }
 
-void InitSuitesHashSigAlgo_ex2(byte* hashSigAlgo, int haveSig, int tls1_2,
+void InitSuitesHashSigAlgo(byte* hashSigAlgo, int haveSig, int tls1_2,
     int keySz, word16* len)
 {
     word16 idx = 0;
@@ -3087,7 +3157,6 @@ void InitSuitesHashSigAlgo_ex2(byte* hashSigAlgo, int haveSig, int tls1_2,
             &idx);
     }
 #endif
-#if defined(HAVE_PQC)
 #ifdef HAVE_FALCON
     if (haveSig & SIG_FALCON) {
         AddSuiteHashSigAlgo(hashSigAlgo, no_mac, falcon_level1_sa_algo, keySz,
@@ -3106,7 +3175,6 @@ void InitSuitesHashSigAlgo_ex2(byte* hashSigAlgo, int haveSig, int tls1_2,
             keySz, &idx);
     }
 #endif /* HAVE_DILITHIUM */
-#endif /* HAVE_PQC */
     if (haveSig & SIG_RSA) {
     #ifdef WC_RSA_PSS
         if (tls1_2) {
@@ -3150,30 +3218,6 @@ void InitSuitesHashSigAlgo_ex2(byte* hashSigAlgo, int haveSig, int tls1_2,
 #endif
 
     *len = idx;
-}
-
-void InitSuitesHashSigAlgo(Suites* suites, int haveECDSAsig, int haveRSAsig,
-    int haveFalconSig, int haveDilithiumSig, int haveAnon, int tls1_2,
-    int keySz)
-{
-    InitSuitesHashSigAlgo_ex(suites->hashSigAlgo, haveECDSAsig, haveRSAsig,
-            haveFalconSig, haveDilithiumSig, haveAnon, tls1_2, keySz,
-            &suites->hashSigAlgoSz);
-}
-
-void InitSuitesHashSigAlgo_ex(byte* hashSigAlgo, int haveECDSAsig,
-    int haveRSAsig, int haveFalconSig, int haveDilithiumSig, int haveAnon,
-    int tls1_2, int keySz, word16* len)
-{
-    int have = 0;
-
-    if (haveECDSAsig)     have |= SIG_ECDSA;
-    if (haveRSAsig)       have |= SIG_RSA;
-    if (haveFalconSig)    have |= SIG_FALCON;
-    if (haveDilithiumSig) have |= SIG_DILITHIUM;
-    if (haveAnon)         have |= SIG_ANON;
-
-    InitSuitesHashSigAlgo_ex2(hashSigAlgo, have, tls1_2, keySz, len);
 }
 
 int AllocateCtxSuites(WOLFSSL_CTX* ctx)
@@ -3238,6 +3282,7 @@ void InitSuites(Suites* suites, ProtocolVersion pv, int keySz, word16 haveRSA,
     (void)haveStaticRSA;
     (void)haveStaticECC;
     (void)haveECC;
+    (void)haveECDSAsig;
     (void)side;
     (void)haveRSA;    /* some builds won't read */
     (void)haveRSAsig; /* non ecc builds won't read */
@@ -4262,18 +4307,27 @@ void InitSuites(Suites* suites, ProtocolVersion pv, int keySz, word16 haveRSA,
     suites->suiteSz = idx;
 
     if (suites->hashSigAlgoSz == 0) {
-        int haveSig = 0;
-        haveSig |= (haveRSAsig | haveRSA) ? SIG_RSA : 0;
-        haveSig |= (haveECDSAsig | haveECC) ? SIG_ECDSA : 0;
-    #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
-        haveSig |= (haveECDSAsig | haveECC) ? SIG_SM2 : 0;
-    #endif
-        haveSig |= haveFalconSig ? SIG_FALCON : 0;
-        haveSig |= haveDilithiumSig ? SIG_DILITHIUM : 0;
-        haveSig &= ~SIG_ANON;
-        InitSuitesHashSigAlgo_ex2(suites->hashSigAlgo, haveSig, tls1_2, keySz,
+        InitSuitesHashSigAlgo(suites->hashSigAlgo, SIG_ALL, tls1_2, keySz,
             &suites->hashSigAlgoSz);
     }
+
+    /* Moved to the end as we set some of the vars but never use them */
+    (void)tls;  /* shut up compiler */
+    (void)tls1_2;
+    (void)dtls;
+    (void)haveDH;
+    (void)havePSK;
+    (void)haveStaticRSA;
+    (void)haveStaticECC;
+    (void)haveECC;
+    (void)haveECDSAsig;
+    (void)side;
+    (void)haveRSA;    /* some builds won't read */
+    (void)haveRSAsig; /* non ecc builds won't read */
+    (void)haveAnon;   /* anon ciphers optional */
+    (void)haveNull;
+    (void)haveFalconSig;
+    (void)haveDilithiumSig;
 }
 
 #if !defined(NO_WOLFSSL_SERVER) || !defined(NO_CERTS) || \
@@ -4331,13 +4385,17 @@ void DecodeSigAlg(const byte* input, byte* hashAlgo, byte* hsType)
             }
             break;
     #endif
-#ifdef HAVE_PQC
+#if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
         case PQC_SA_MAJOR:
-            /* Hash performed as part of sign/verify operation. */
+            /* Hash performed as part of sign/verify operation.
+             * However, if we want a dual alg signature with a
+             * classic algorithm as alternative, we need an explicit
+             * hash algo here.
+             */
     #ifdef HAVE_FALCON
             if (input[1] == FALCON_LEVEL1_SA_MINOR) {
                 *hsType = falcon_level1_sa_algo;
-                *hashAlgo = sha512_mac;
+                *hashAlgo = sha256_mac;
             }
             else if (input[1] == FALCON_LEVEL5_SA_MINOR) {
                 *hsType = falcon_level5_sa_algo;
@@ -4347,11 +4405,11 @@ void DecodeSigAlg(const byte* input, byte* hashAlgo, byte* hsType)
     #ifdef HAVE_DILITHIUM
             if (input[1] == DILITHIUM_LEVEL2_SA_MINOR) {
                 *hsType = dilithium_level2_sa_algo;
-                *hashAlgo = sha512_mac;
+                *hashAlgo = sha256_mac;
             }
             else if (input[1] == DILITHIUM_LEVEL3_SA_MINOR) {
                 *hsType = dilithium_level3_sa_algo;
-                *hashAlgo = sha512_mac;
+                *hashAlgo = sha384_mac;
             }
             else if (input[1] == DILITHIUM_LEVEL5_SA_MINOR) {
                 *hsType = dilithium_level5_sa_algo;
@@ -4852,14 +4910,14 @@ int RsaSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (key && ret == WC_PENDING_E) {
+    if (key && ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
 
     /* For positive response return in outSz */
     if (ret > 0) {
-        *outSz = ret;
+        *outSz = (word32)ret;
         ret = 0;
     }
 
@@ -4872,7 +4930,7 @@ int RsaSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 int RsaVerify(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, int sigAlgo,
               int hashAlgo, RsaKey* key, buffer* keyBufInfo)
 {
-    int ret = SIG_VERIFY_E;
+    int ret = WC_NO_ERR_TRACE(SIG_VERIFY_E);
 
 #ifdef HAVE_PK_CALLBACKS
     const byte* keyBuf = NULL;
@@ -4928,7 +4986,7 @@ int RsaVerify(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, int sigAlgo,
         !defined(WOLFSSL_RENESAS_TSIP_TLS)
     else
     #else
-    if (!ssl->ctx->RsaVerifyCb || ret == CRYPTOCB_UNAVAILABLE)
+    if (!ssl->ctx->RsaVerifyCb || ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
     #endif
 #endif /*HAVE_PK_CALLBACKS */
     {
@@ -4937,7 +4995,7 @@ int RsaVerify(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, int sigAlgo,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5010,7 +5068,7 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
                                            TypeHash(hashAlgo), mgf,
                                            keyBuf, keySz, ctx);
             if (ret > 0) {
-                ret = wc_RsaPSS_CheckPadding(plain, plainSz, out, ret,
+                ret = wc_RsaPSS_CheckPadding(plain, plainSz, out, (word32)ret,
                                              hashType);
                 if (ret != 0) {
                     ret = VERIFY_CERT_ERROR;
@@ -5028,7 +5086,7 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
                 ret = wc_RsaPSS_CheckPadding(plain, plainSz, out, ret,
                                              hashType);
     #else
-                ret = wc_RsaPSS_CheckPadding_ex(plain, plainSz, out, ret,
+                ret = wc_RsaPSS_CheckPadding_ex(plain, plainSz, out, (word32)ret,
                                                 hashType, -1,
                                                 mp_count_bits(&key->n));
     #endif
@@ -5075,7 +5133,7 @@ int VerifyRsaSign(WOLFSSL* ssl, byte* verifySig, word32 sigSz,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (key && ret == WC_PENDING_E) {
+    if (key && ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5135,7 +5193,7 @@ int RsaDec(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, word32* outSz,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5155,7 +5213,7 @@ int RsaDec(WOLFSSL* ssl, byte* in, word32 inSz, byte** out, word32* outSz,
 int RsaEnc(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out, word32* outSz,
     RsaKey* key, buffer* keyBufInfo)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 #ifdef HAVE_PK_CALLBACKS
     const byte* keyBuf = NULL;
     word32 keySz = 0;
@@ -5187,7 +5245,7 @@ int RsaEnc(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out, word32* outSz,
         !defined(WOLFSSL_RENESAS_TSIP_TLS)
     else
     #else
-    if (!ssl->ctx->RsaEncCb || ret == CRYPTOCB_UNAVAILABLE)
+    if (!ssl->ctx->RsaEncCb || ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
     #endif
 #endif /* HAVE_PK_CALLBACKS */
     {
@@ -5196,14 +5254,14 @@ int RsaEnc(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out, word32* outSz,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
 
     /* For positive response return in outSz */
     if (ret > 0) {
-        *outSz = ret;
+        *outSz = (word32)ret;
         ret = 0;
     }
 
@@ -5256,7 +5314,7 @@ int EccSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
         ret = ssl->ctx->EccSignCb(ssl, in, inSz, out, outSz, keyBuf,
             keySz, ctx);
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
-        if (ret == CRYPTOCB_UNAVAILABLE) {
+        if (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
             ret = wc_ecc_sign_hash(in, inSz, out, outSz, ssl->rng, key);
         }
 #endif /* WOLFSSL_RENESAS_TSIP_TLS */
@@ -5269,7 +5327,7 @@ int EccSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (key && ret == WC_PENDING_E) {
+    if (key && ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5282,7 +5340,7 @@ int EccSign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 int EccVerify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* out,
     word32 outSz, ecc_key* key, buffer* keyBufInfo)
 {
-    int ret = SIG_VERIFY_E;
+    int ret = WC_NO_ERR_TRACE(SIG_VERIFY_E);
 #ifdef HAVE_PK_CALLBACKS
     const byte* keyBuf = NULL;
     word32 keySz = 0;
@@ -5316,7 +5374,7 @@ int EccVerify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* out,
         !defined(WOLFSSL_MAXQ108X)
     else
     #else
-    if (!ssl->ctx->EccVerifyCb || ret == CRYPTOCB_UNAVAILABLE)
+    if (!ssl->ctx->EccVerifyCb || ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
     #endif
 #endif /* HAVE_PK_CALLBACKS  */
     {
@@ -5325,7 +5383,7 @@ int EccVerify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* out,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
     else
@@ -5398,7 +5456,7 @@ int EccSharedSecret(WOLFSSL* ssl, ecc_key* priv_key, ecc_key* pub_key,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5457,7 +5515,7 @@ int EccMakeKey(WOLFSSL* ssl, ecc_key* key, ecc_key* peer)
 #ifdef HAVE_PK_CALLBACKS
     if (ssl->ctx->EccKeyGenCb) {
         void* ctx = wolfSSL_GetEccKeyGenCtx(ssl);
-        ret = ssl->ctx->EccKeyGenCb(ssl, key, keySz, ecc_curve, ctx);
+        ret = ssl->ctx->EccKeyGenCb(ssl, key, (unsigned int)keySz, ecc_curve, ctx);
     }
     else
 #endif
@@ -5475,7 +5533,7 @@ int EccMakeKey(WOLFSSL* ssl, ecc_key* key, ecc_key* peer)
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5515,7 +5573,7 @@ int Sm2wSm3Verify(WOLFSSL* ssl, const byte* id, word32 idSz, const byte* sig,
     word32 sigSz, const byte* msg, word32 msgSz, ecc_key* key,
     buffer* keyBufInfo)
 {
-    int ret = SIG_VERIFY_E;
+    int ret = WC_NO_ERR_TRACE(SIG_VERIFY_E);
     byte hash[WC_SM3_DIGEST_SIZE];
 
     (void)ssl;
@@ -5638,7 +5696,7 @@ int Ed25519Sign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5712,7 +5770,7 @@ int Ed25519Verify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* msg,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
     else
@@ -5738,7 +5796,6 @@ int Ed25519Verify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* msg,
      */
     static int X25519GetKey(WOLFSSL* ssl, curve25519_key** otherKey)
     {
-        int ret = NO_PEER_KEY;
         struct curve25519_key* tmpKey = NULL;
 
         if (ssl == NULL || otherKey == NULL) {
@@ -5761,10 +5818,11 @@ int Ed25519Verify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* msg,
 
         if (tmpKey) {
             *otherKey = (curve25519_key *)tmpKey;
-            ret = 0;
+            return 0;
         }
-
-        return ret;
+        else {
+            return NO_PEER_KEY;
+        }
     }
 #endif /* HAVE_PK_CALLBACKS */
 
@@ -5808,7 +5866,7 @@ static int X25519SharedSecret(WOLFSSL* ssl, curve25519_key* priv_key,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &priv_key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5854,7 +5912,7 @@ static int X25519MakeKey(WOLFSSL* ssl, curve25519_key* key,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -5962,7 +6020,7 @@ int Ed448Sign(WOLFSSL* ssl, const byte* in, word32 inSz, byte* out,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -6036,7 +6094,7 @@ int Ed448Verify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* msg,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
     else
@@ -6062,7 +6120,6 @@ int Ed448Verify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* msg,
      */
     static int X448GetKey(WOLFSSL* ssl, curve448_key** otherKey)
     {
-        int ret = NO_PEER_KEY;
         struct curve448_key* tmpKey = NULL;
 
         if (ssl == NULL || otherKey == NULL) {
@@ -6084,10 +6141,11 @@ int Ed448Verify(WOLFSSL* ssl, const byte* in, word32 inSz, const byte* msg,
 
         if (tmpKey) {
             *otherKey = (curve448_key *)tmpKey;
-            ret = 0;
+            return 0;
         }
-
-        return ret;
+        else {
+            return NO_PEER_KEY;
+        }
     }
 #endif /* HAVE_PK_CALLBACKS */
 
@@ -6132,7 +6190,7 @@ static int X448SharedSecret(WOLFSSL* ssl, curve448_key* priv_key,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &priv_key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -6177,7 +6235,7 @@ static int X448MakeKey(WOLFSSL* ssl, curve448_key* key, curve448_key* peer)
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &key->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -6214,7 +6272,7 @@ int DhGenKeyPair(WOLFSSL* ssl, DhKey* dhKey,
         ret = ssl->ctx->DhGenerateKeyPairCb(dhKey, ssl->rng, priv, privSz,
                                             pub, pubSz);
     }
-    if (ret == NOT_COMPILED_IN)
+    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
 #endif
     {
         PRIVATE_KEY_UNLOCK();
@@ -6224,7 +6282,7 @@ int DhGenKeyPair(WOLFSSL* ssl, DhKey* dhKey,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &dhKey->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -6294,7 +6352,7 @@ int DhAgree(WOLFSSL* ssl, DhKey* dhKey,
 
     /* Handle async pending response */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl, &dhKey->asyncDev);
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -6704,14 +6762,12 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 #ifdef HAVE_ECC
     ssl->options.minEccKeySz = ctx->minEccKeySz;
 #endif
-#ifdef HAVE_PQC
 #ifdef HAVE_FALCON
     ssl->options.minFalconKeySz = ctx->minFalconKeySz;
 #endif /* HAVE_FALCON */
 #ifdef HAVE_DILITHIUM
     ssl->options.minDilithiumKeySz = ctx->minDilithiumKeySz;
 #endif /* HAVE_DILITHIUM */
-#endif /* HAVE_PQC */
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
     ssl->options.verifyDepth = ctx->verifyDepth;
 #endif
@@ -6754,16 +6810,50 @@ int SetSSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
 #ifdef WOLFSSL_TLS13
     ssl->buffers.certChainCnt = ctx->certChainCnt;
 #endif
+#ifndef WOLFSSL_BLIND_PRIVATE_KEY
     ssl->buffers.key      = ctx->privateKey;
+#else
+    if (ctx->privateKey != NULL) {
+        AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
+            ctx->privateKey->length, ctx->privateKey->type,
+            ctx->privateKey->heap);
+        ssl->buffers.weOwnKey = 1;
+        /* Blind the private key for the SSL with new random mask. */
+        wolfssl_priv_der_unblind(ssl->buffers.key, ctx->privateKeyMask);
+        ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.key,
+            &ssl->buffers.keyMask);
+        if (ret != 0) {
+            return ret;
+        }
+    }
+#endif
     ssl->buffers.keyType  = ctx->privateKeyType;
     ssl->buffers.keyId    = ctx->privateKeyId;
     ssl->buffers.keyLabel = ctx->privateKeyLabel;
     ssl->buffers.keySz    = ctx->privateKeySz;
     ssl->buffers.keyDevId = ctx->privateKeyDevId;
 #ifdef WOLFSSL_DUAL_ALG_CERTS
-    ssl->buffers.altKey     = ctx->altPrivateKey;
-    ssl->buffers.altKeySz   = ctx->altPrivateKeySz;
-    ssl->buffers.altKeyType = ctx->altPrivateKeyType;
+#ifndef WOLFSSL_BLIND_PRIVATE_KEY
+    ssl->buffers.altKey   = ctx->altPrivateKey;
+#else
+    if (ctx->altPrivateKey != NULL) {
+        AllocCopyDer(&ssl->buffers.altkey, ctx->altPrivateKey->buffer,
+            ctx->altPrivateKey->length, ctx->altPrivateKey->type,
+            ctx->altPrivateKey->heap);
+        /* Blind the private key for the SSL with new random mask. */
+        wolfssl_priv_der_unblind(ssl->buffers.altKey, ctx->altPrivateKeyMask);
+        ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.altKey,
+            &ssl->buffers.altKeyMask);
+        if (ret != 0) {
+            return ret;
+        }
+    }
+#endif
+    ssl->buffers.altKeyType  = ctx->altPrivateKeyType;
+    ssl->buffers.altKeyId    = ctx->altPrivateKeyId;
+    ssl->buffers.altKeyLabel = ctx->altPrivateKeyLabel;
+    ssl->buffers.altKeySz    = ctx->altPrivateKeySz;
+    ssl->buffers.altKeyDevId = ctx->altPrivateKeyDevId;
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
 #endif
 #if !defined(WOLFSSL_NO_CLIENT_AUTH) && \
@@ -6951,7 +7041,7 @@ void FreeHandshakeHashes(WOLFSSL* ssl)
 int InitHandshakeHashesAndCopy(WOLFSSL* ssl, HS_Hashes* source,
   HS_Hashes** destination)
 {
-    int ret = 0;
+    int ret;
     HS_Hashes* tmpHashes;
 
     if (source == NULL)
@@ -6961,7 +7051,11 @@ int InitHandshakeHashesAndCopy(WOLFSSL* ssl, HS_Hashes* source,
     tmpHashes = ssl->hsHashes;
     ssl->hsHashes = NULL;
 
-    InitHandshakeHashes(ssl);
+    ret = InitHandshakeHashes(ssl);
+    if (ret != 0) {
+        WOLFSSL_MSG_EX("InitHandshakeHashes failed. err = %d", ret);
+        return ret;
+    }
 
     *destination = ssl->hsHashes;
     ssl->hsHashes = tmpHashes;
@@ -6969,50 +7063,50 @@ int InitHandshakeHashesAndCopy(WOLFSSL* ssl, HS_Hashes* source,
   /* now copy the source contents to the destination */
 #ifndef NO_OLD_TLS
     #ifndef NO_SHA
-        ret = wc_ShaCopy(&source->hashSha, &(*destination)->hashSha);
+    ret = wc_ShaCopy(&source->hashSha, &(*destination)->hashSha);
     #endif
     #ifndef NO_MD5
-        if (ret == 0)
-            ret = wc_Md5Copy(&source->hashMd5, &(*destination)->hashMd5);
+    if (ret == 0)
+        ret = wc_Md5Copy(&source->hashMd5, &(*destination)->hashMd5);
     #endif
     #endif /* !NO_OLD_TLS */
     #ifndef NO_SHA256
-        if (ret == 0)
-            ret = wc_Sha256Copy(&source->hashSha256,
-                &(*destination)->hashSha256);
+    if (ret == 0)
+        ret = wc_Sha256Copy(&source->hashSha256,
+            &(*destination)->hashSha256);
     #endif
     #ifdef WOLFSSL_SHA384
-        if (ret == 0)
-            ret = wc_Sha384Copy(&source->hashSha384,
-                &(*destination)->hashSha384);
+    if (ret == 0)
+        ret = wc_Sha384Copy(&source->hashSha384,
+            &(*destination)->hashSha384);
     #endif
     #ifdef WOLFSSL_SHA512
-        if (ret == 0)
-            ret = wc_Sha512Copy(&source->hashSha512,
-                &(*destination)->hashSha512);
+    if (ret == 0)
+        ret = wc_Sha512Copy(&source->hashSha512,
+            &(*destination)->hashSha512);
     #endif
     #ifdef WOLFSSL_SM3
-        if (ret == 0)
-            ret = wc_Sm3Copy(&source->hashSm3,
-                &(*destination)->hashSm3);
+    if (ret == 0)
+        ret = wc_Sm3Copy(&source->hashSm3,
+            &(*destination)->hashSm3);
     #endif
     #if (defined(HAVE_ED25519) || defined(HAVE_ED448) || \
          (defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3))) && \
         !defined(WOLFSSL_NO_CLIENT_AUTH)
-        if (ret == 0 && source->messages != NULL) {
-            (*destination)->messages = (byte*)XMALLOC(source->length, ssl->heap,
-                DYNAMIC_TYPE_HASHES);
-            (*destination)->length = source->length;
-            (*destination)->prevLen = source->prevLen;
+    if (ret == 0 && source->messages != NULL) {
+        (*destination)->messages = (byte*)XMALLOC(source->length, ssl->heap,
+            DYNAMIC_TYPE_HASHES);
+        (*destination)->length = source->length;
+        (*destination)->prevLen = source->prevLen;
 
-            if ((*destination)->messages == NULL) {
-                ret = MEMORY_E;
-            }
-            else {
-                XMEMCPY((*destination)->messages, source->messages,
-                    source->length);
-            }
+        if ((*destination)->messages == NULL) {
+            ret = MEMORY_E;
         }
+        else {
+            XMEMCPY((*destination)->messages, source->messages,
+                source->length);
+        }
+    }
     #endif
 
     return ret;
@@ -7139,6 +7233,8 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         ssl_hint = ((WOLFSSL_HEAP_HINT*)(ssl->heap));
         ctx_hint = ((WOLFSSL_HEAP_HINT*)(ctx->heap));
 
+        ssl_hint->memory = ctx_hint->memory;
+    #ifndef WOLFSSL_STATIC_MEMORY_LEAN
         /* lock and check IO count / handshake count */
         if (wc_LockMutex(&(ctx_hint->memory->memory_mutex)) != 0) {
             WOLFSSL_MSG("Bad memory_mutex lock");
@@ -7166,7 +7262,6 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
         }
         ctx_hint->memory->curIO++;
         ctx_hint->memory->curHa++;
-        ssl_hint->memory = ctx_hint->memory;
         ssl_hint->haFlag = 1;
         wc_UnLockMutex(&(ctx_hint->memory->memory_mutex));
 
@@ -7202,6 +7297,7 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
             }
             wc_UnLockMutex(&(ctx_hint->memory->memory_mutex));
         }
+    #endif /* !WOLFSSL_STATIC_MEMORY_LEAN */
     #ifdef WOLFSSL_HEAP_TEST
         }
     #endif
@@ -7573,6 +7669,9 @@ int InitSSL(WOLFSSL* ssl, WOLFSSL_CTX* ctx, int writeDup)
     defined(WOLFSSL_SSLKEYLOGFILE) && defined(WOLFSSL_TLS13)
     (void)wolfSSL_set_tls13_secret_cb(ssl, tls13ShowSecrets, NULL);
 #endif
+#if defined(HAVE_SECRET_CALLBACK) && defined(SHOW_SECRETS)
+    (void)wolfSSL_set_secret_cb(ssl, tlsShowSecrets, NULL);
+#endif
 #ifdef WOLFSSL_DUAL_ALG_CERTS
     ssl->sigSpec = ctx->sigSpec;
     ssl->sigSpecSz = ctx->sigSpecSz;
@@ -7647,7 +7746,6 @@ void FreeKey(WOLFSSL* ssl, int type, void** pKey)
                 wc_curve448_free((curve448_key*)*pKey);
                 break;
         #endif /* HAVE_CURVE448 */
-        #if defined(HAVE_PQC)
         #if defined(HAVE_FALCON)
             case DYNAMIC_TYPE_FALCON:
                 wc_falcon_free((falcon_key*)*pKey);
@@ -7658,7 +7756,6 @@ void FreeKey(WOLFSSL* ssl, int type, void** pKey)
                 wc_dilithium_free((dilithium_key*)*pKey);
                 break;
         #endif /* HAVE_DILITHIUM */
-        #endif /* HAVE_PQC */
         #ifndef NO_DH
             case DYNAMIC_TYPE_DH:
                 wc_FreeDhKey((DhKey*)*pKey);
@@ -7676,7 +7773,7 @@ void FreeKey(WOLFSSL* ssl, int type, void** pKey)
 
 int AllocKey(WOLFSSL* ssl, int type, void** pKey)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     int sz = 0;
 #ifdef HAVE_ECC
     ecc_key* eccKey;
@@ -7695,7 +7792,7 @@ int AllocKey(WOLFSSL* ssl, int type, void** pKey)
         WOLFSSL_MSG("Key already present!");
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* allow calling this again for async reentry */
-        if (ssl->error == WC_PENDING_E) {
+        if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             return 0;
         }
     #endif
@@ -7734,7 +7831,6 @@ int AllocKey(WOLFSSL* ssl, int type, void** pKey)
             sz = sizeof(curve448_key);
             break;
     #endif /* HAVE_CURVE448 */
-    #if defined(HAVE_PQC)
     #if defined(HAVE_FALCON)
         case DYNAMIC_TYPE_FALCON:
             sz = sizeof(falcon_key);
@@ -7745,7 +7841,6 @@ int AllocKey(WOLFSSL* ssl, int type, void** pKey)
             sz = sizeof(dilithium_key);
             break;
     #endif /* HAVE_DILITHIUM */
-    #endif /* HAVE_PQC */
     #ifndef NO_DH
         case DYNAMIC_TYPE_DH:
             sz = sizeof(DhKey);
@@ -7809,7 +7904,6 @@ int AllocKey(WOLFSSL* ssl, int type, void** pKey)
             ret = 0;
             break;
     #endif /* HAVE_CURVE448 */
-    #if defined(HAVE_PQC)
     #if defined(HAVE_FALCON)
         case DYNAMIC_TYPE_FALCON:
             wc_falcon_init_ex((falcon_key*)*pKey, ssl->heap, ssl->devId);
@@ -7822,7 +7916,6 @@ int AllocKey(WOLFSSL* ssl, int type, void** pKey)
             ret = 0;
             break;
     #endif /* HAVE_DILITHIUM */
-    #endif /* HAVE_PQC */
     #ifdef HAVE_CURVE448
         case DYNAMIC_TYPE_CURVE448:
             wc_curve448_init((curve448_key*)*pKey);
@@ -7848,8 +7941,7 @@ int AllocKey(WOLFSSL* ssl, int type, void** pKey)
 
 #if !defined(NO_RSA) || defined(HAVE_ECC) || defined(HAVE_ED25519) || \
     defined(HAVE_CURVE25519) || defined(HAVE_ED448) || \
-    defined(HAVE_CURVE448) || (defined(HAVE_PQC) && defined(HAVE_FALCON)) || \
-    (defined(HAVE_PQC) && defined(HAVE_DILITHIUM))
+    defined(HAVE_CURVE448) || defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
 static int ReuseKey(WOLFSSL* ssl, int type, void* pKey)
 {
     int ret = 0;
@@ -7895,12 +7987,18 @@ static int ReuseKey(WOLFSSL* ssl, int type, void* pKey)
             ret = wc_curve448_init((curve448_key*)pKey);
             break;
     #endif /* HAVE_CURVE448 */
-    #if defined(HAVE_PQC) && defined(HAVE_FALCON)
+    #if defined(HAVE_FALCON)
         case DYNAMIC_TYPE_FALCON:
             wc_falcon_free((falcon_key*)pKey);
             ret = wc_falcon_init((falcon_key*)pKey);
             break;
-    #endif /* HAVE_PQC && HAVE_FALCON */
+    #endif /* HAVE_FALCON */
+    #if defined(HAVE_DILITHIUM)
+        case DYNAMIC_TYPE_DILITHIUM:
+            wc_dilithium_free((dilithium_key*)pKey);
+            ret = wc_dilithium_init((dilithium_key*)pKey);
+            break;
+    #endif /* HAVE_DILITHIUM */
     #ifndef NO_DH
         case DYNAMIC_TYPE_DH:
             wc_FreeDhKey((DhKey*)pKey);
@@ -8194,7 +8292,7 @@ void SSL_ResourceFree(WOLFSSL* ssl)
         }
     #endif
 #endif
-#if defined(HAVE_PQC) && defined(HAVE_FALCON)
+#if defined(HAVE_FALCON)
     FreeKey(ssl, DYNAMIC_TYPE_FALCON, (void**)&ssl->peerFalconKey);
     ssl->peerFalconKeyPresent = 0;
 #endif
@@ -8277,14 +8375,17 @@ void SSL_ResourceFree(WOLFSSL* ssl)
     /* avoid dereferencing a test value */
     if (ssl->heap != (void*)WOLFSSL_HEAP_TEST) {
     #endif
+        void* heap = ssl->ctx ? ssl->ctx->heap : ssl->heap;
+    #ifndef WOLFSSL_STATIC_MEMORY_LEAN
         WOLFSSL_HEAP_HINT* ssl_hint = (WOLFSSL_HEAP_HINT*)ssl->heap;
         WOLFSSL_HEAP*      ctx_heap;
-        void* heap = ssl->ctx ? ssl->ctx->heap : ssl->heap;
 
         ctx_heap = ssl_hint->memory;
+    #ifndef SINGLE_THREADED
         if (wc_LockMutex(&(ctx_heap->memory_mutex)) != 0) {
             WOLFSSL_MSG("Bad memory_mutex lock");
         }
+    #endif
         ctx_heap->curIO--;
         if (FreeFixedIO(ctx_heap, &(ssl_hint->outBuf)) != 1) {
             WOLFSSL_MSG("Error freeing fixed output buffer");
@@ -8292,15 +8393,20 @@ void SSL_ResourceFree(WOLFSSL* ssl)
         if (FreeFixedIO(ctx_heap, &(ssl_hint->inBuf)) != 1) {
             WOLFSSL_MSG("Error freeing fixed output buffer");
         }
-        if (ssl_hint->haFlag && ctx_heap->curHa > 0) { /* check if handshake count has been decreased*/
+
+        /* check if handshake count has been decreased*/
+        if (ssl_hint->haFlag && ctx_heap->curHa > 0) {
             ctx_heap->curHa--;
         }
+    #ifndef SINGLE_THREADED
         wc_UnLockMutex(&(ctx_heap->memory_mutex));
+    #endif
 
         /* check if tracking stats */
         if (ctx_heap->flag & WOLFMEM_TRACK_STATS) {
             XFREE(ssl_hint->stats, heap, DYNAMIC_TYPE_SSL);
         }
+    #endif /* !WOLFSSL_STATIC_MEMORY_LEAN */
         XFREE(ssl->heap, heap, DYNAMIC_TYPE_SSL);
     #ifdef WOLFSSL_HEAP_TEST
     }
@@ -8437,10 +8543,10 @@ void FreeHandshakeResources(WOLFSSL* ssl)
         FreeKey(ssl, DYNAMIC_TYPE_ED448, (void**)&ssl->peerEd448Key);
         ssl->peerEd448KeyPresent = 0;
 #endif /* HAVE_ED448 */
-#if defined(HAVE_PQC) && defined(HAVE_FALCON)
+#if defined(HAVE_FALCON)
         FreeKey(ssl, DYNAMIC_TYPE_FALCON, (void**)&ssl->peerFalconKey);
         ssl->peerFalconKeyPresent = 0;
-#endif /* HAVE_PQC */
+#endif /* HAVE_FALCON */
     }
 
 #ifdef HAVE_ECC
@@ -8503,8 +8609,14 @@ void FreeHandshakeResources(WOLFSSL* ssl)
     }
 #endif /* !NO_DH */
 
-#ifndef NO_CERTS
-    wolfSSL_UnloadCertsKeys(ssl);
+#if !defined(NO_CERTS) && !defined(OPENSSL_EXTRA) && \
+    !defined(WOLFSSL_WPAS_SMALL)
+#ifndef WOLFSSL_POST_HANDSHAKE_AUTH
+    if (ssl->options.side != WOLFSSL_CLIENT_END)
+#endif
+    {
+        wolfSSL_UnloadCertsKeys(ssl);
+    }
 #endif
 #ifdef HAVE_PK_CALLBACKS
 #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_POST_HANDSHAKE_AUTH)
@@ -8562,14 +8674,20 @@ void FreeHandshakeResources(WOLFSSL* ssl)
         WOLFSSL_HEAP*      ctx_heap;
 
         ctx_heap = ssl_hint->memory;
+    #ifndef SINGLE_THREADED
         if (wc_LockMutex(&(ctx_heap->memory_mutex)) != 0) {
             WOLFSSL_MSG("Bad memory_mutex lock");
         }
+    #endif
+    #ifndef WOLFSSL_STATIC_MEMORY_LEAN
         if (ctx_heap->curHa > 0) {
             ctx_heap->curHa--;
         }
         ssl_hint->haFlag = 0; /* set to zero since handshake has been dec */
+    #endif
+    #ifndef SINGLE_THREADED
         wc_UnLockMutex(&(ctx_heap->memory_mutex));
+    #endif
     #ifdef WOLFSSL_HEAP_TEST
     }
     #endif
@@ -9422,7 +9540,7 @@ int DtlsMsgPoolSend(WOLFSSL* ssl, int sendOnlyFirstPacket)
                 int    inputSz, sendSz;
 
                 input = pool->raw;
-                inputSz = pool->sz;
+                inputSz = (int)pool->sz;
                 sendSz = inputSz + cipherExtraData(ssl);
 
 #ifdef HAVE_SECURE_RENEGOTIATION
@@ -9686,7 +9804,12 @@ ProtocolVersion MakeDTLSv1_3(void)
 
 #elif defined(FREERTOS)
 
-    #include "task.h"
+    #ifdef PLATFORMIO
+        #include <freertos/FreeRTOS.h>
+        #include <freertos/task.h>
+    #else
+        #include "task.h"
+    #endif
 
     unsigned int LowResTimer(void)
     {
@@ -9768,7 +9891,12 @@ ProtocolVersion MakeDTLSv1_3(void)
 
     word32 LowResTimer(void)
     {
-        return k_uptime_get() / 1000;
+        int64_t t;
+    #if defined(CONFIG_ARCH_POSIX)
+        k_cpu_idle();
+    #endif
+        t = k_uptime_get(); /* returns current uptime in milliseconds */
+        return (word32)(t / 1000);
     }
 
 #elif defined(WOLFSSL_LINUXKM)
@@ -9861,7 +9989,7 @@ int HashRaw(WOLFSSL* ssl, const byte* data, int sz)
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_StoreMessage(ssl, data, sz);
-    if (ret != 0 && ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != 0 && ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         return ret;
     }
 #endif /* WOLFSSL_RENESAS_TSIP_TLS */
@@ -9876,7 +10004,7 @@ int HashRaw(WOLFSSL* ssl, const byte* data, int sz)
 
     if (IsAtLeastTLSv1_2(ssl)) {
     #ifndef NO_SHA256
-        ret = wc_Sha256Update(&ssl->hsHashes->hashSha256, data, sz);
+        ret = wc_Sha256Update(&ssl->hsHashes->hashSha256, data, (word32)sz);
         if (ret != 0)
             return ret;
     #ifdef WOLFSSL_DEBUG_TLS
@@ -9886,7 +10014,7 @@ int HashRaw(WOLFSSL* ssl, const byte* data, int sz)
     #endif
     #endif
     #ifdef WOLFSSL_SHA384
-        ret = wc_Sha384Update(&ssl->hsHashes->hashSha384, data, sz);
+        ret = wc_Sha384Update(&ssl->hsHashes->hashSha384, data, (word32)sz);
         if (ret != 0)
             return ret;
     #ifdef WOLFSSL_DEBUG_TLS
@@ -9896,7 +10024,7 @@ int HashRaw(WOLFSSL* ssl, const byte* data, int sz)
     #endif
     #endif
     #ifdef WOLFSSL_SHA512
-        ret = wc_Sha512Update(&ssl->hsHashes->hashSha512, data, sz);
+        ret = wc_Sha512Update(&ssl->hsHashes->hashSha512, data, (word32)sz);
         if (ret != 0)
             return ret;
     #ifdef WOLFSSL_DEBUG_TLS
@@ -10444,7 +10572,7 @@ void ShrinkInputBuffer(WOLFSSL* ssl, int forcedFree)
     ssl->buffers.inputBuffer.dynamicFlag = 0;
     ssl->buffers.inputBuffer.offset      = 0;
     ssl->buffers.inputBuffer.idx = 0;
-    ssl->buffers.inputBuffer.length = usedLength;
+    ssl->buffers.inputBuffer.length = (word32)usedLength;
 }
 
 int SendBuffered(WOLFSSL* ssl)
@@ -10561,8 +10689,7 @@ static WC_INLINE int GrowOutputBuffer(WOLFSSL* ssl, int size)
 #else
     const byte align = WOLFSSL_GENERAL_ALIGNMENT;
 #endif
-    int newSz = size + ssl->buffers.outputBuffer.idx +
-                ssl->buffers.outputBuffer.length;
+    word32 newSz;
 
 #if WOLFSSL_GENERAL_ALIGNMENT > 0
     /* the encrypted data will be offset from the front of the buffer by
@@ -10573,7 +10700,15 @@ static WC_INLINE int GrowOutputBuffer(WOLFSSL* ssl, int size)
         align *= 2;
 #endif
 
-    tmp = (byte*)XMALLOC(newSz + align, ssl->heap, DYNAMIC_TYPE_OUT_BUFFER);
+    if (! WC_SAFE_SUM_WORD32(ssl->buffers.outputBuffer.idx,
+                             ssl->buffers.outputBuffer.length, newSz))
+        return BUFFER_E;
+    if (! WC_SAFE_SUM_WORD32(newSz, (word32)size, newSz))
+        return BUFFER_E;
+    if (! WC_SAFE_SUM_WORD32(newSz, align, newSz))
+        return BUFFER_E;
+    tmp = (byte*)XMALLOC(newSz, ssl->heap, DYNAMIC_TYPE_OUT_BUFFER);
+    newSz -= align;
     WOLFSSL_MSG("growing output buffer");
 
     if (tmp == NULL)
@@ -10692,7 +10827,7 @@ int GrowInputBuffer(WOLFSSL* ssl, int size, int usedLength)
     ssl->buffers.inputBuffer.buffer = tmp;
     ssl->buffers.inputBuffer.bufferSize = size + usedLength;
     ssl->buffers.inputBuffer.idx    = 0;
-    ssl->buffers.inputBuffer.length = usedLength;
+    ssl->buffers.inputBuffer.length = (word32)usedLength;
 
     return 0;
 }
@@ -10996,7 +11131,7 @@ static int MsgCheckBoundary(const WOLFSSL* ssl, byte type,
  * @param ssl   The current connection
  * @param type  The enum HandShakeType of the current message
  * @param msgSz Size of the current message
- * @return
+ * @return int (less than 0 on fail, 0 on success)
  */
 int EarlySanityCheckMsgReceived(WOLFSSL* ssl, byte type, word32 msgSz)
 {
@@ -11152,7 +11287,9 @@ static int GetDtlsRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
         /* version 1.3 already negotiated */
         if (ssl->options.tls1_3) {
             ret = GetDtls13RecordHeader(ssl, inOutIdx, rh, size);
-            if (ret == 0 || ret != SEQUENCE_ERROR || ret != DTLS_CID_ERROR)
+            if (ret == 0 ||
+                ret != WC_NO_ERR_TRACE(SEQUENCE_ERROR) ||
+                ret != WC_NO_ERR_TRACE(DTLS_CID_ERROR))
                 return ret;
         }
 
@@ -11174,7 +11311,7 @@ static int GetDtlsRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
     if (ssl->buffers.inputBuffer.length - *inOutIdx < DTLS_RECORD_HEADER_SZ) {
         ret = GetInputData(ssl, DTLS_RECORD_HEADER_SZ);
         /* Check if Dtls13RtxTimeout(ssl) returned socket error */
-        if (ret == SOCKET_ERROR_E)
+        if (ret == WC_NO_ERR_TRACE(SOCKET_ERROR_E))
             return ret;
         if (ret != 0)
             return LENGTH_ERROR;
@@ -11243,7 +11380,13 @@ static int GetRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
             ssl->fuzzerCb(ssl, ssl->buffers.inputBuffer.buffer + *inOutIdx,
                           RECORD_HEADER_SZ, FUZZ_HEAD, ssl->fuzzerCtx);
 #endif
-        XMEMCPY(rh, ssl->buffers.inputBuffer.buffer + *inOutIdx, RECORD_HEADER_SZ);
+        /* Set explicitly rather than make assumptions on struct layout */
+        rh->type      = ssl->buffers.inputBuffer.buffer[*inOutIdx];
+        rh->pvMajor   = ssl->buffers.inputBuffer.buffer[*inOutIdx + 1];
+        rh->pvMinor   = ssl->buffers.inputBuffer.buffer[*inOutIdx + 2];
+        rh->length[0] = ssl->buffers.inputBuffer.buffer[*inOutIdx + 3];
+        rh->length[1] = ssl->buffers.inputBuffer.buffer[*inOutIdx + 4];
+
         *inOutIdx += RECORD_HEADER_SZ;
         ato16(rh->length, size);
     }
@@ -11306,7 +11449,20 @@ static int GetRecordHeader(WOLFSSL* ssl, word32* inOutIdx,
             }
         }
 #endif /* WOLFSSL_DTLS13 */
-        else {
+        /* Don't care about protocol version being lower than expected on alerts
+         * sent back before version negotitation. */
+        else if (!(ssl->options.side == WOLFSSL_CLIENT_END &&
+                            ssl->options.connectState == CLIENT_HELLO_SENT &&
+                            rh->type == alert &&
+                            rh->pvMajor == ssl->version.major &&
+        #ifdef WOLFSSL_DTLS
+                            ((ssl->options.dtls && rh->pvMinor == DTLS_MINOR) ||
+                             (!ssl->options.dtls &&
+                              rh->pvMinor < ssl->version.minor))
+        #else
+                            rh->pvMinor < ssl->version.minor
+        #endif
+                   )) {
             WOLFSSL_MSG("SSL version error");
             WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
             return VERSION_ERROR;              /* only use requested version */
@@ -12243,53 +12399,77 @@ int CipherRequires(byte first, byte second, int requirement)
    *.z.com matches y.z.com but not x.y.z.com
 
    return 1 on success */
-int MatchDomainName(const char* pattern, int len, const char* str)
+int MatchDomainName(const char* pattern, int patternLen, const char* str,
+                    word32 strLen)
 {
     int ret = 0;
 
-    if (pattern == NULL || str == NULL || len <= 0)
+    if (pattern == NULL || str == NULL || patternLen <= 0 || strLen == 0)
         return 0;
 
-    while (len > 0) {
-
-        char p = (char)XTOLOWER((unsigned char)*pattern++);
+    while (patternLen > 0) {
+        /* Get the next pattern char to evaluate */
+        char p = (char)XTOLOWER((unsigned char)*pattern);
         if (p == '\0')
             break;
 
+        pattern++;
+
         if (p == '*') {
             char s;
+            /* We will always match '*' */
+            patternLen--;
 
-            while (--len > 0) {
+            /* Consume any extra '*' chars until the next non '*' char. */
+            while (patternLen > 0) {
                 p = (char)XTOLOWER((unsigned char)*pattern);
                 pattern++;
+                if (p == '\0' && patternLen > 0)
+                    return 0;
                 if (p != '*')
                     break;
+
+                patternLen--;
             }
 
-            if (len == 0)
-                p = '\0';
+            /* Consume str until we reach next char in pattern after '*' or
+             * end of string */
+            while (strLen > 0) {
+                s = (char)XTOLOWER((unsigned char) *str);
+                str++;
+                strLen--;
 
-            while ( (s = (char)XTOLOWER((unsigned char) *str)) != '\0') {
-                if (s == p)
+                /* p is next char in pattern after '*', or '*' if '*' is the
+                 * last char in the pattern (in which case patternLen is 1) */
+                if ( ((s == p) && (patternLen > 0))) {
+                    /* We had already counted the '*' as matched, this means
+                     * we also matched the next non '*' char in pattern */
+                    patternLen--;
                     break;
+                }
+
+                /* If strlen is 0, we have consumed the entire string. Count that
+                 * as a match of '*' */
+                if (strLen == 0) {
+                    break;
+                }
+
                 if (s == '.')
                     return 0;
-                str++;
             }
         }
         else {
+            /* Simple case, pattern match exactly */
             if (p != (char)XTOLOWER((unsigned char) *str))
                 return 0;
-        }
 
-
-        if (len > 0) {
             str++;
-            len--;
+            strLen--;
+            patternLen--;
         }
     }
 
-    if (*str == '\0' && len == 0) {
+    if (strLen == 0 && patternLen == 0) {
         ret = 1; /* success */
     }
 
@@ -12301,14 +12481,16 @@ int MatchDomainName(const char* pattern, int len, const char* str)
  * Fail if there are wild patterns and they didn't match.
  * Check the common name if no alternative names matched.
  *
- * dCert    Decoded cert to get the alternative names from.
- * domain   Domain name to compare against.
- * checkCN  Whether to check the common name.
- * returns  1 : match was found.
- *          0 : no match found.
- *         -1 : No matches and wild pattern match failed.
+ * dCert     Decoded cert to get the alternative names from.
+ * domain    Domain name to compare against.
+ * domainLen Length of the domain name.
+ * checkCN   Whether to check the common name.
+ * returns   1 : match was found.
+ *           0 : no match found.
+ *          -1 : No matches and wild pattern match failed.
  */
-int CheckForAltNames(DecodedCert* dCert, const char* domain, int* checkCN)
+int CheckForAltNames(DecodedCert* dCert, const char* domain, word32 domainLen,
+                     int* checkCN)
 {
     int match = 0;
     DNS_entry* altName = NULL;
@@ -12336,10 +12518,10 @@ int CheckForAltNames(DecodedCert* dCert, const char* domain, int* checkCN)
 #endif /* OPENSSL_ALL || WOLFSSL_IP_ALT_NAME */
         {
             buf = altName->name;
-            len = altName->len;
+            len = (word32)altName->len;
         }
 
-        if (MatchDomainName(buf, len, domain)) {
+        if (MatchDomainName(buf, (int)len, domain, domainLen)) {
             match = 1;
             if (checkCN != NULL) {
                 *checkCN = 0;
@@ -12371,12 +12553,11 @@ int CheckForAltNames(DecodedCert* dCert, const char* domain, int* checkCN)
 int CheckHostName(DecodedCert* dCert, const char *domainName, size_t domainNameLen)
 {
     int checkCN;
-    int ret = DOMAIN_NAME_MISMATCH;
+    int ret = WC_NO_ERR_TRACE(DOMAIN_NAME_MISMATCH);
 
-    /* Assume name is NUL terminated. */
-    (void)domainNameLen;
-
-    if (CheckForAltNames(dCert, domainName, &checkCN) != 1) {
+    if (CheckForAltNames(dCert, domainName, (word32)domainNameLen,
+                                            &checkCN) != 1) {
+        ret = DOMAIN_NAME_MISMATCH;
         WOLFSSL_MSG("DomainName match on alt names failed");
     }
     else {
@@ -12386,10 +12567,11 @@ int CheckHostName(DecodedCert* dCert, const char *domainName, size_t domainNameL
 #ifndef WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY
     if (checkCN == 1) {
         if (MatchDomainName(dCert->subjectCN, dCert->subjectCNLen,
-                            domainName) == 1) {
+                            domainName, (word32)domainNameLen) == 1) {
             ret = 0;
         }
         else {
+            ret = DOMAIN_NAME_MISMATCH;
             WOLFSSL_MSG("DomainName match on common name failed");
         }
     }
@@ -12412,7 +12594,7 @@ static void AddSessionCertToChain(WOLFSSL_X509_CHAIN* chain,
 {
    if (chain->count < MAX_CHAIN_DEPTH &&
                                certSz < MAX_X509_SIZE) {
-        chain->certs[chain->count].length = certSz;
+        chain->certs[chain->count].length = (int)certSz;
         XMEMCPY(chain->certs[chain->count].buffer, certBuf, certSz);
         chain->count++;
     }
@@ -12426,13 +12608,20 @@ static void AddSessionCertToChain(WOLFSSL_X509_CHAIN* chain,
     defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 void CopyDecodedName(WOLFSSL_X509_NAME* name, DecodedCert* dCert, int nameType)
 {
+    if (name->dynamicName) {
+        XFREE(name->name, name->heap, DYNAMIC_TYPE_X509);
+        name->name = name->staticName;
+        name->dynamicName = 0;
+    }
+
     if (nameType == SUBJECT) {
         XSTRNCPY(name->name, dCert->subject, ASN_NAME_MAX);
         name->name[ASN_NAME_MAX - 1] = '\0';
         name->sz = (int)XSTRLEN(name->name) + 1;
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY)
         name->rawLen = min(dCert->subjectRawLen, ASN_NAME_MAX);
-        XMEMCPY(name->raw, dCert->subjectRaw, name->rawLen);
+        if (name->rawLen > 0)
+            XMEMCPY(name->raw, dCert->subjectRaw, name->rawLen);
 #endif
     }
     else {
@@ -12442,59 +12631,44 @@ void CopyDecodedName(WOLFSSL_X509_NAME* name, DecodedCert* dCert, int nameType)
 #if (defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY)) \
     && (defined(HAVE_PKCS7) || defined(WOLFSSL_CERT_EXT))
         name->rawLen = min(dCert->issuerRawLen, ASN_NAME_MAX);
-        if (name->rawLen) {
+        if (name->rawLen > 0) {
             XMEMCPY(name->raw, dCert->issuerRaw, name->rawLen);
         }
 #endif
     }
 }
 
-
-#if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
-    !defined(IGNORE_NAME_CONSTRAINTS)
-/* copies over additional alt names such as dirName
- * returns 0 on success
- */
-static int CopyAdditionalAltNames(DNS_entry** to, DNS_entry* from, int type,
-        void* heap)
+static int CopyAltNames(DNS_entry** to, DNS_entry* from, int type, void* heap)
 {
-    DNS_entry* cur = from;
+    /* Copy from to the beginning of to */
+    DNS_entry** prev_next = to;
+    DNS_entry* next;
 
     if (to == NULL) {
         return BAD_FUNC_ARG;
     }
 
-    while (cur != NULL) {
-        if (cur->type == type) {
-            DNS_entry* dnsEntry;
-            int strLen = cur->len;
+    next = *to;
 
-            dnsEntry = AltNameNew(heap);
-            if (dnsEntry == NULL) {
-                WOLFSSL_MSG("\tOut of Memory");
-                return MEMORY_E;
-            }
+    for (; from != NULL; from = from->next) {
+        DNS_entry* dnsEntry;
 
-            dnsEntry->type = type;
-            dnsEntry->name = (char*)XMALLOC(strLen + 1, heap,
-                    DYNAMIC_TYPE_ALTNAME);
-            if (dnsEntry->name == NULL) {
-                WOLFSSL_MSG("\tOut of Memory");
-                XFREE(dnsEntry, heap, DYNAMIC_TYPE_ALTNAME);
-                return MEMORY_E;
-            }
-            dnsEntry->len = strLen;
-            XMEMCPY(dnsEntry->name, cur->name, strLen);
-            dnsEntry->name[strLen] = '\0';
+        if (type != -1 && from->type != type)
+            continue;
 
-            dnsEntry->next = *to;
-            *to = dnsEntry;
+        dnsEntry = AltNameDup(from, heap);
+        if (dnsEntry == NULL) {
+            WOLFSSL_MSG("\tOut of Memory");
+            return MEMORY_E;
         }
-        cur = cur->next;
+
+        dnsEntry->next = next;
+        *prev_next = dnsEntry;
+        prev_next = &dnsEntry->next;
     }
+
     return 0;
 }
-#endif /* OPENSSL_EXTRA */
 
 #ifdef WOLFSSL_CERT_REQ
 static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
@@ -12609,8 +12783,6 @@ static int CopyREQAttributes(WOLFSSL_X509* x509, DecodedCert* dCert)
 #endif /* WOLFSSL_CERT_REQ */
 
 /* Copy parts X509 needs from Decoded cert, 0 on success */
-/* The same DecodedCert cannot be copied to WOLFSSL_X509 twice otherwise the
- * altNames pointers could be free'd by second x509 still active by first */
 int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
 {
     int ret = 0;
@@ -12690,7 +12862,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
     {
         int minSz;
         if (dCert->beforeDateLen > 0) {
-            minSz = min(dCert->beforeDate[1], MAX_DATE_SZ);
+            minSz = (int)min(dCert->beforeDate[1], MAX_DATE_SZ);
             x509->notBefore.type = dCert->beforeDate[0];
             x509->notBefore.length = minSz;
             XMEMCPY(x509->notBefore.data, &dCert->beforeDate[2], minSz);
@@ -12698,7 +12870,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
         else
             x509->notBefore.length = 0;
         if (dCert->afterDateLen > 0) {
-            minSz = min(dCert->afterDate[1], MAX_DATE_SZ);
+            minSz = (int)min(dCert->afterDate[1], MAX_DATE_SZ);
             x509->notAfter.type = dCert->afterDate[0];
             x509->notAfter.length = minSz;
             XMEMCPY(x509->notAfter.data, &dCert->afterDate[2], minSz);
@@ -12711,7 +12883,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
         x509->pubKey.buffer = (byte*)XMALLOC(
                         dCert->pubKeySize, x509->heap, DYNAMIC_TYPE_PUBLIC_KEY);
         if (x509->pubKey.buffer != NULL) {
-            x509->pubKeyOID = dCert->keyOID;
+            x509->pubKeyOID = (int)dCert->keyOID;
             x509->pubKey.length = dCert->pubKeySize;
             XMEMCPY(x509->pubKey.buffer, dCert->publicKey, dCert->pubKeySize);
         }
@@ -12719,7 +12891,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
             ret = MEMORY_E;
 #if defined(OPENSSL_ALL)
         if (ret == 0) {
-            x509->key.pubKeyOID = dCert->keyOID;
+            x509->key.pubKeyOID = (int)dCert->keyOID;
 
             if (!x509->key.algor) {
                 x509->key.algor = wolfSSL_X509_ALGOR_new();
@@ -12757,7 +12929,7 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
         else {
             XMEMCPY(x509->sig.buffer, dCert->signature, dCert->sigLength);
             x509->sig.length = dCert->sigLength;
-            x509->sigOID = dCert->signatureOID;
+            x509->sigOID = (int)dCert->signatureOID;
         }
 #if defined(OPENSSL_ALL)
         wolfSSL_ASN1_OBJECT_free(x509->algor.algorithm);
@@ -12781,19 +12953,21 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
         }
     }
 
-    x509->altNames       = dCert->altNames;
-    dCert->weOwnAltNames = 0;
+    /* add alt names from dCert to X509 */
+    if (CopyAltNames(&x509->altNames, dCert->altNames, -1, x509->heap) != 0) {
+        return MEMORY_E;
+    }
 #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
     !defined(IGNORE_NAME_CONSTRAINTS)
     /* add copies of email names from dCert to X509 */
-    if (CopyAdditionalAltNames(&x509->altNames, dCert->altEmailNames,
+    if (CopyAltNames(&x509->altNames, dCert->altEmailNames,
                 ASN_RFC822_TYPE, x509->heap) != 0) {
         return MEMORY_E;
     }
 #endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 #if defined(OPENSSL_EXTRA) && !defined(IGNORE_NAME_CONSTRAINTS)
     /* add copies of alternate directory names from dCert to X509 */
-    if (CopyAdditionalAltNames(&x509->altNames, dCert->altDirNames,
+    if (CopyAltNames(&x509->altNames, dCert->altDirNames,
                 ASN_DIR_TYPE, x509->heap) != 0) {
         return MEMORY_E;
     }
@@ -12963,23 +13137,40 @@ int CopyDecodedToX509(WOLFSSL_X509* x509, DecodedCert* dCert)
     /* Copy over alternative sig and pubkey. In this case we will allocate new
      * buffers for them as we have no knowledge of when the DecodedCert is
      * freed. */
-    x509->sapkiDer = (byte*)XMALLOC(dCert->sapkiLen, x509->heap,
-                                    DYNAMIC_TYPE_X509_EXT);
-    x509->altSigAlgDer = (byte*)XMALLOC(dCert->altSigAlgLen, x509->heap,
+    if (dCert->extSapkiSet) {
+        x509->sapkiDer = (byte*)XMALLOC(dCert->sapkiLen, x509->heap,
                                         DYNAMIC_TYPE_X509_EXT);
-    x509->altSigValDer = (byte*)XMALLOC(dCert->altSigValLen, x509->heap,
-                                        DYNAMIC_TYPE_X509_EXT);
-    if ((x509->sapkiDer != NULL) && (x509->altSigAlgDer != NULL) &&
-        (x509->altSigValDer != NULL)) {
-        XMEMCPY(x509->sapkiDer, dCert->sapkiDer, dCert->sapkiLen);
-        XMEMCPY(x509->altSigAlgDer, dCert->altSigAlgDer, dCert->altSigAlgLen);
-        XMEMCPY(x509->altSigValDer, dCert->altSigValDer, dCert->altSigValLen);
-        x509->sapkiLen = dCert->sapkiLen;
-        x509->altSigAlgLen = dCert->altSigAlgLen;
-        x509->altSigValLen = dCert->altSigValLen;
+        if (x509->sapkiDer != NULL) {
+            XMEMCPY(x509->sapkiDer, dCert->sapkiDer, dCert->sapkiLen);
+            x509->sapkiLen = dCert->sapkiLen;
+        }
+        else {
+            ret = MEMORY_E;
+        }
     }
-    else {
-        ret = MEMORY_E;
+    if (dCert->extAltSigAlgSet) {
+        x509->altSigAlgDer = (byte*)XMALLOC(dCert->altSigAlgLen, x509->heap,
+                                            DYNAMIC_TYPE_X509_EXT);
+        if (x509->altSigAlgDer != NULL) {
+            XMEMCPY(x509->altSigAlgDer, dCert->altSigAlgDer,
+                    dCert->altSigAlgLen);
+            x509->altSigAlgLen = dCert->altSigAlgLen;
+        }
+        else {
+            ret = MEMORY_E;
+        }
+    }
+    if (dCert->extAltSigValSet) {
+        x509->altSigValDer = (byte*)XMALLOC(dCert->altSigValLen, x509->heap,
+                                            DYNAMIC_TYPE_X509_EXT);
+        if (x509->altSigValDer != NULL) {
+            XMEMCPY(x509->altSigValDer, dCert->altSigValDer,
+                    dCert->altSigValLen);
+            x509->altSigValLen = dCert->altSigValLen;
+        }
+        else {
+            ret = MEMORY_E;
+        }
     }
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
 
@@ -13095,7 +13286,7 @@ static int ProcessCSR(WOLFSSL* ssl, byte* input, word32* inOutIdx,
        const unsigned char* keyDer, unsigned int keySz,
        int* result, void* ctx)
     {
-        int ret = NOT_COMPILED_IN;
+        int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
         WOLFSSL* ssl = (WOLFSSL*)ctx;
 
         if (ssl && ssl->ctx->EccVerifyCb) {
@@ -13110,7 +13301,7 @@ static int ProcessCSR(WOLFSSL* ssl, byte* input, word32* inOutIdx,
        unsigned char** out, const unsigned char* keyDer, unsigned int keySz,
        void* ctx)
     {
-        int ret = NOT_COMPILED_IN;
+        int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
         WOLFSSL* ssl = (WOLFSSL*)ctx;
 
         if (ssl && ssl->ctx->RsaVerifyCb) {
@@ -13172,24 +13363,26 @@ void DoCertFatalAlert(WOLFSSL* ssl, int ret)
 
     /* Determine alert reason */
     alertWhy = bad_certificate;
-    if (ret == ASN_AFTER_DATE_E || ret == ASN_BEFORE_DATE_E) {
+    if (ret == WC_NO_ERR_TRACE(ASN_AFTER_DATE_E) ||
+        ret == WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E)) {
         alertWhy = certificate_expired;
     }
-    else if (ret == ASN_NO_SIGNER_E || ret == ASN_PATHLEN_INV_E ||
-            ret == ASN_PATHLEN_SIZE_E) {
+    else if (ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E) ||
+             ret == WC_NO_ERR_TRACE(ASN_PATHLEN_INV_E) ||
+             ret == WC_NO_ERR_TRACE(ASN_PATHLEN_SIZE_E)) {
         alertWhy = unknown_ca;
     }
 #ifdef OPENSSL_EXTRA
-    else if (ret == CRL_CERT_REVOKED) {
+    else if (ret == WC_NO_ERR_TRACE(CRL_CERT_REVOKED)) {
         alertWhy = certificate_revoked;
     }
 #endif
 #if defined(HAVE_RPK)
-    else if (ret == UNSUPPORTED_CERTIFICATE) {
+    else if (ret == WC_NO_ERR_TRACE(UNSUPPORTED_CERTIFICATE)) {
         alertWhy = unsupported_certificate;
     }
 #endif /* HAVE_RPK */
-    else if (ret == NO_PEER_CERT) {
+    else if (ret == WC_NO_ERR_TRACE(NO_PEER_CERT)) {
 #ifdef WOLFSSL_TLS13
         if (ssl->options.tls1_3) {
             alertWhy = certificate_required;
@@ -13206,6 +13399,167 @@ void DoCertFatalAlert(WOLFSSL* ssl, int ret)
     ssl->options.isClosed = 1;
 }
 
+
+int SetupStoreCtxCallback(WOLFSSL_X509_STORE_CTX** store_pt,
+        WOLFSSL* ssl, WOLFSSL_CERT_MANAGER* cm, ProcPeerCertArgs* args,
+        int cert_err, void* heap, int* x509Free)
+{
+    WOLFSSL_X509_STORE_CTX* store = NULL;
+    char* domain = NULL;
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    WOLFSSL_X509* x509 = NULL;
+#endif
+
+    *x509Free = 0;
+
+    store = wolfSSL_X509_STORE_CTX_new_ex(heap);
+    if (store == NULL)
+        goto mem_error;
+    domain = (char*)XMALLOC(ASN_NAME_MAX, heap, DYNAMIC_TYPE_STRING);
+    if (domain == NULL)
+        goto mem_error;
+
+    domain[0] = '\0';
+
+    /* build subject CN as string to return in store */
+    if (args->dCertInit && args->dCert && args->dCert->subjectCN) {
+        int subjectCNLen = args->dCert->subjectCNLen;
+        if (subjectCNLen > ASN_NAME_MAX-1)
+            subjectCNLen = ASN_NAME_MAX-1;
+        if (subjectCNLen > 0) {
+            XMEMCPY(domain, args->dCert->subjectCN, subjectCNLen);
+            domain[subjectCNLen] = '\0';
+        }
+    }
+
+#ifndef OPENSSL_COMPATIBLE_DEFAULTS
+    store->error = cert_err;
+#else
+    store->error = GetX509Error(cert_err);
+#endif
+    store->error_depth = args->certIdx;
+    store->discardSessionCerts = 0;
+    store->domain = domain;
+    if (ssl != NULL) {
+        if (ssl->verifyCbCtx != NULL) {
+            /* Use the WOLFSSL user context if set */
+            store->userCtx = ssl->verifyCbCtx;
+        }
+        else {
+            /* Else use the WOLFSSL_CTX user context */
+            store->userCtx = ssl->ctx->verifyCbCtx;
+        }
+    }
+    else {
+        store->userCtx = cm;
+    }
+    store->certs = args->certs;
+    store->totalCerts = args->totalCerts;
+#if defined(HAVE_EX_DATA) && \
+    (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL))
+    if (wolfSSL_CRYPTO_set_ex_data(&store->ex_data, 0, ssl)
+            != WOLFSSL_SUCCESS) {
+        WOLFSSL_MSG("Failed to store ssl context in WOLFSSL_X509_STORE_CTX");
+    }
+#endif
+
+    if (ssl != NULL) {
+#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
+        store->store = SSL_STORE(ssl);
+#if defined(OPENSSL_EXTRA)
+        store->depth = args->count;
+        /* Overwrite with non-default param values in SSL */
+        if (ssl->param) {
+            if (ssl->param->check_time)
+                store->param->check_time = ssl->param->check_time;
+
+            if (ssl->param->flags)
+                store->param->flags = ssl->param->flags;
+#ifdef WOLFSSL_LOCAL_X509_STORE
+            else if (SSL_STORE(ssl) && SSL_STORE(ssl)->param &&
+                    SSL_STORE(ssl)->param->flags)
+                store->param->flags = SSL_STORE(ssl)->param->flags;
+#endif
+
+
+            if (ssl->param->hostName[0])
+                XMEMCPY(store->param->hostName, ssl->param->hostName,
+                        WOLFSSL_HOST_NAME_MAX);
+
+        }
+#endif /* defined(OPENSSL_EXTRA) */
+#endif /* defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)*/
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    #ifdef KEEP_PEER_CERT
+        if (args->certIdx == 0) {
+            FreeX509(&ssl->peerCert);
+            InitX509(&ssl->peerCert, 0, ssl->heap);
+            if (CopyDecodedToX509(&ssl->peerCert, args->dCert) == 0)
+                WOLFSSL_MSG("Unable to copy to ssl->peerCert");
+            store->current_cert = &ssl->peerCert; /* use existing X509 */
+        }
+        else
+    #endif
+        {
+            x509 = wolfSSL_X509_new_ex(heap);
+            if (x509 == NULL)
+                goto mem_error;
+            if (CopyDecodedToX509(x509, args->dCert) == 0) {
+                store->current_cert = x509;
+                *x509Free = 1;
+            }
+            else {
+                goto mem_error;
+            }
+        }
+#endif
+#ifdef SESSION_CERTS
+        store->sesChain = &ssl->session->chain;
+#endif
+    }
+    *store_pt = store;
+    return 0;
+mem_error:
+    if (store != NULL)
+        wolfSSL_X509_STORE_CTX_free(store);
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    if (x509 != NULL)
+        wolfSSL_X509_free(x509);
+#endif
+    if (domain != NULL)
+        XFREE(domain, heap, DYNAMIC_TYPE_STRING);
+    return MEMORY_E;
+}
+
+void CleanupStoreCtxCallback(WOLFSSL_X509_STORE_CTX* store,
+        WOLFSSL* ssl, void* heap, int x509Free)
+{
+    (void)ssl;
+    (void)x509Free;
+
+#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
+    wolfSSL_sk_X509_pop_free(store->chain, NULL);
+    store->chain = NULL;
+#endif
+#ifdef SESSION_CERTS
+    if ((ssl != NULL) && (store->discardSessionCerts)) {
+        WOLFSSL_MSG("Verify callback requested discard sess certs");
+        ssl->session->chain.count = 0;
+    #ifdef WOLFSSL_ALT_CERT_CHAINS
+        ssl->session->altChain.count = 0;
+    #endif
+    }
+#endif /* SESSION_CERTS */
+    XFREE(store->domain, heap, DYNAMIC_TYPE_STRING);
+    store->domain = NULL;
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    if (x509Free)
+        wolfSSL_X509_free(store->current_cert);
+    store->current_cert = NULL;
+#endif
+    wolfSSL_X509_STORE_CTX_free(store);
+}
+
 /* WOLFSSL_ALWAYS_VERIFY_CB: Use verify callback for success or failure cases */
 /* WOLFSSL_VERIFY_CB_ALL_CERTS: Issue callback for all intermediate certificates */
 
@@ -13214,10 +13568,10 @@ void DoCertFatalAlert(WOLFSSL* ssl, int ret)
  * store->error_depth member to determine index (0=peer, >1 intermediates)
  */
 
-int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
+int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int cert_err,
                                                         ProcPeerCertArgs* args)
 {
-    int verify_ok = 0, use_cb = 0;
+    int verify_ok = 0, use_cb = 0, ret = cert_err;
     void *heap;
 
     if (cm == NULL) {
@@ -13227,12 +13581,12 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
     heap = (ssl != NULL) ? ssl->heap : cm->heap;
 
     /* Determine if verify was okay */
-    if (ret == 0) {
+    if (cert_err == 0) {
         verify_ok = 1;
     }
 
     /* Determine if verify callback should be used */
-    if (ret != 0) {
+    if (cert_err != 0) {
         if ((ssl != NULL) && (!ssl->options.verifyNone)) {
             use_cb = 1; /* always report errors */
         }
@@ -13257,8 +13611,9 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
                 ssl->param && ssl->param->hostName[0]) {
             /* If altNames names is present, then subject common name is ignored */
             if (args->dCert->altNames != NULL) {
-                if (CheckForAltNames(args->dCert, ssl->param->hostName, NULL) != 1) {
-                    if (ret == 0) {
+                if (CheckForAltNames(args->dCert, ssl->param->hostName,
+                    (word32)XSTRLEN(ssl->param->hostName), NULL) != 1) {
+                    if (cert_err == 0) {
                         ret = DOMAIN_NAME_MISMATCH;
                         WOLFSSL_ERROR_VERBOSE(ret);
                     }
@@ -13267,10 +13622,12 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
         #ifndef WOLFSSL_HOSTNAME_VERIFY_ALT_NAME_ONLY
             else {
                 if (args->dCert->subjectCN) {
-                    if (MatchDomainName(args->dCert->subjectCN,
-                                        args->dCert->subjectCNLen,
-                                        ssl->param->hostName) == 0) {
-                        if (ret == 0) {
+                    if (MatchDomainName(
+                            args->dCert->subjectCN,
+                            args->dCert->subjectCNLen,
+                            ssl->param->hostName,
+                            (word32)XSTRLEN(ssl->param->hostName)) == 0) {
+                        if (cert_err == 0) {
                             ret = DOMAIN_NAME_MISMATCH;
                             WOLFSSL_ERROR_VERBOSE(ret);
                         }
@@ -13279,7 +13636,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
             }
         #else
             else {
-                if (ret == 0) {
+                if (cert_err == 0) {
                     ret = DOMAIN_NAME_MISMATCH;
                     WOLFSSL_ERROR_VERBOSE(ret);
                 }
@@ -13291,7 +13648,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
         if ((args->dCertInit != 0) && (args->dCert != NULL) && (ssl != NULL) &&
             (ssl->param != NULL) && (XSTRLEN(ssl->param->ipasc) > 0)) {
             if (CheckIPAddr(args->dCert, ssl->param->ipasc) != 0) {
-                if (ret == 0) {
+                if (cert_err == 0) {
                     ret = IPADDR_MISMATCH;
                     WOLFSSL_ERROR_VERBOSE(ret);
                 }
@@ -13304,163 +13661,30 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
     #ifdef OPENSSL_ALL
         || (ssl->ctx->verifyCertCb != NULL)
     #endif
+    #if defined(WOLFSSL_LOCAL_X509_STORE) && \
+        (defined(OPENSSL_ALL) || defined(WOLFSSL_QT))
+        || (SSL_STORE(ssl) != NULL && SSL_STORE(ssl)->verify_cb != NULL)
+    #endif
         ))
     #ifndef NO_WOLFSSL_CM_VERIFY
         || (cm->verifyCallback != NULL)
     #endif
         ) {
         int verifyFail = 0;
-    #ifdef WOLFSSL_SMALL_STACK
-        WOLFSSL_X509_STORE_CTX* store;
-        #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-        WOLFSSL_X509* x509;
-        #endif
-        char* domain = NULL;
-    #else
-        WOLFSSL_X509_STORE_CTX store[1];
-        #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-        WOLFSSL_X509           x509[1];
-        #endif
-        char domain[ASN_NAME_MAX];
-    #endif
-    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+        WOLFSSL_X509_STORE_CTX* store = NULL;
         int x509Free = 0;
-    #endif
+        int setupRet = SetupStoreCtxCallback(&store, ssl, cm, args, cert_err,
+                heap, &x509Free);
 
-    #ifdef WOLFSSL_SMALL_STACK
-        store = (WOLFSSL_X509_STORE_CTX*)XMALLOC(
-            sizeof(WOLFSSL_X509_STORE_CTX), heap, DYNAMIC_TYPE_X509_STORE);
-        if (store == NULL) {
-            return MEMORY_E;
-        }
-        #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-        x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), heap,
-            DYNAMIC_TYPE_X509);
-        if (x509 == NULL) {
-            XFREE(store, heap, DYNAMIC_TYPE_X509_STORE);
-            return MEMORY_E;
-        }
-        #endif
-        domain = (char*)XMALLOC(ASN_NAME_MAX, heap, DYNAMIC_TYPE_STRING);
-        if (domain == NULL) {
-            XFREE(store, heap, DYNAMIC_TYPE_X509_STORE);
-            #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-            XFREE(x509, heap, DYNAMIC_TYPE_X509);
-            #endif
-            return MEMORY_E;
-        }
-    #endif /* WOLFSSL_SMALL_STACK */
+        if (setupRet != 0)
+            return setupRet;
 
-        XMEMSET(store, 0, sizeof(WOLFSSL_X509_STORE_CTX));
-    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-        XMEMSET(x509, 0, sizeof(WOLFSSL_X509));
-    #endif
-        domain[0] = '\0';
-
-        /* build subject CN as string to return in store */
-        if (args->dCertInit && args->dCert && args->dCert->subjectCN) {
-            int subjectCNLen = args->dCert->subjectCNLen;
-            if (subjectCNLen > ASN_NAME_MAX-1)
-                subjectCNLen = ASN_NAME_MAX-1;
-            if (subjectCNLen > 0) {
-                XMEMCPY(domain, args->dCert->subjectCN, subjectCNLen);
-                domain[subjectCNLen] = '\0';
-            }
-        }
-
-#ifndef OPENSSL_COMPATIBLE_DEFAULTS
-        store->error = ret;
-#else
-        store->error = GetX509Error(ret);
-#endif
-        store->error_depth = args->certIdx;
-        store->discardSessionCerts = 0;
-        store->domain = domain;
-        if (ssl != NULL) {
-            if (ssl->verifyCbCtx != NULL) {
-                /* Use the WOLFSSL user context if set */
-                store->userCtx = ssl->verifyCbCtx;
-            }
-            else {
-                /* Else use the WOLFSSL_CTX user context */
-                store->userCtx = ssl->ctx->verifyCbCtx;
-            }
-        }
-        else {
-            store->userCtx = cm;
-        }
-        store->certs = args->certs;
-        store->totalCerts = args->totalCerts;
-    #if defined(HAVE_EX_DATA) && \
-        (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL))
-        if (wolfSSL_CRYPTO_set_ex_data(&store->ex_data, 0, ssl)
-                != WOLFSSL_SUCCESS) {
-            WOLFSSL_MSG("Failed to store ssl context in WOLFSSL_X509_STORE_CTX");
-        }
-    #endif
-
-        if (ssl != NULL) {
-    #if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)
-            store->store = SSL_STORE(ssl);
-    #if defined(OPENSSL_EXTRA)
-            store->depth = args->count;
-            store->param = (WOLFSSL_X509_VERIFY_PARAM*)XMALLOC(
-                            sizeof(WOLFSSL_X509_VERIFY_PARAM),
-                            heap, DYNAMIC_TYPE_OPENSSL);
-            if (store->param == NULL) {
-        #ifdef WOLFSSL_SMALL_STACK
-                XFREE(domain, heap, DYNAMIC_TYPE_STRING);
-            #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-                XFREE(x509, heap, DYNAMIC_TYPE_X509);
-            #endif
-                XFREE(store, heap, DYNAMIC_TYPE_X509_STORE);
-        #endif
-                return MEMORY_E;
-            }
-            XMEMSET(store->param, 0, sizeof(WOLFSSL_X509_VERIFY_PARAM));
-            /* Overwrite with non-default param values in SSL */
-            if (ssl->param) {
-                if (ssl->param->check_time)
-                    store->param->check_time = ssl->param->check_time;
-
-                if (ssl->param->flags)
-                    store->param->flags = ssl->param->flags;
-
-                if (ssl->param->hostName[0])
-                    XMEMCPY(store->param->hostName, ssl->param->hostName,
-                            WOLFSSL_HOST_NAME_MAX);
-
-            }
-    #endif /* defined(OPENSSL_EXTRA) */
-    #endif /* defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER)*/
-    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-        #ifdef KEEP_PEER_CERT
-            if (args->certIdx == 0) {
-                store->current_cert = &ssl->peerCert; /* use existing X509 */
-            }
-            else
-        #endif
-            {
-                InitX509(x509, 0, heap);
-                if (CopyDecodedToX509(x509, args->dCert) == 0) {
-                    store->current_cert = x509;
-                    x509Free = 1;
-                }
-                else {
-                    FreeX509(x509);
-                }
-            }
-    #endif
-    #ifdef SESSION_CERTS
-            store->sesChain = &ssl->session->chain;
-    #endif
-        }
     #ifndef NO_WOLFSSL_CM_VERIFY
         /* non-zero return code indicates failure override */
         if (cm->verifyCallback != NULL) {
             store->userCtx = cm;
             if (cm->verifyCallback(verify_ok, store)) {
-                if (ret != 0) {
+                if (cert_err != 0) {
                     WOLFSSL_MSG("Verify CM callback overriding error!");
                     ret = 0;
                 }
@@ -13476,7 +13700,7 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
             /* non-zero return code indicates failure override */
             if (ssl->ctx->verifyCertCb) {
                 if (ssl->ctx->verifyCertCb(store, ssl->ctx->verifyCertCbArg)) {
-                    if (ret != 0) {
+                    if (cert_err != 0) {
                         WOLFSSL_MSG("Verify Cert callback overriding error!");
                         ret = 0;
                     }
@@ -13486,11 +13710,10 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
                 }
             }
     #endif
-
             /* non-zero return code indicates failure override */
             if (ssl->verifyCallback) {
                 if (ssl->verifyCallback(verify_ok, store)) {
-                    if (ret != 0) {
+                    if (cert_err != 0) {
                         WOLFSSL_MSG("Verify callback overriding error!");
                         ret = 0;
                     }
@@ -13499,11 +13722,25 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
                     verifyFail = 1;
                 }
             }
+#if defined(WOLFSSL_LOCAL_X509_STORE) && \
+    (defined(OPENSSL_ALL) || defined(WOLFSSL_QT))
+            if (SSL_STORE(ssl) != NULL && SSL_STORE(ssl)->verify_cb != NULL) {
+                if (SSL_STORE(ssl)->verify_cb(verify_ok, store)) {
+                    if (cert_err != 0) {
+                        WOLFSSL_MSG("Store Verify callback overriding error!");
+                        ret = 0;
+                    }
+                }
+                else {
+                    verifyFail = 1;
+                }
+            }
+#endif
         }
 
         if (verifyFail) {
             /* induce error if one not present */
-            if (ret == 0) {
+            if (cert_err == 0) {
                 ret = VERIFY_CERT_ERROR;
                 WOLFSSL_ERROR_VERBOSE(ret);
             }
@@ -13511,42 +13748,57 @@ int DoVerifyCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl, int ret,
             /* mark as verify error */
             args->verifyErr = 1;
         }
-    #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-        if (x509Free) {
-            FreeX509(x509);
-        }
-    #endif
-    #if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-        wolfSSL_sk_X509_pop_free(store->chain, NULL);
-        store->chain = NULL;
-    #endif
-    #ifdef SESSION_CERTS
-        if ((ssl != NULL) && (store->discardSessionCerts)) {
-            WOLFSSL_MSG("Verify callback requested discard sess certs");
-            ssl->session->chain.count = 0;
-        #ifdef WOLFSSL_ALT_CERT_CHAINS
-            ssl->session->altChain.count = 0;
-        #endif
-        }
-    #endif /* SESSION_CERTS */
-#ifdef OPENSSL_EXTRA
-        if ((ssl != NULL) && (store->param)) {
-            XFREE(store->param, heap, DYNAMIC_TYPE_OPENSSL);
-        }
-#endif
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(domain, heap, DYNAMIC_TYPE_STRING);
-        #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-        XFREE(x509, heap, DYNAMIC_TYPE_X509);
-        #endif
-        XFREE(store, heap, DYNAMIC_TYPE_X509_STORE);
-    #endif
+        CleanupStoreCtxCallback(store, ssl, heap, x509Free);
     }
 
     (void)heap;
 
     return ret;
 }
+
+#ifdef HAVE_CRL
+void DoCrlCallback(WOLFSSL_CERT_MANAGER* cm, WOLFSSL* ssl,
+        ProcPeerCertArgs* args, int* outRet)
+{
+#if defined(WOLFSSL_LOCAL_X509_STORE) && \
+    (defined(OPENSSL_ALL) || defined(WOLFSSL_QT))
+    int ret = 0;
+    void* heap = (ssl != NULL) ? ssl->heap : cm->heap;
+    WOLFSSL_X509_STORE* cert_store = (ssl != NULL) ? SSL_STORE(ssl) : NULL;
+
+    if (cert_store != NULL && cert_store->get_crl_cb != NULL) {
+        WOLFSSL_CRL* userCrl = NULL;
+        WOLFSSL_X509_STORE_CTX* store = NULL;
+        int x509Free = 0;
+
+        ret = SetupStoreCtxCallback(&store, ssl, cm, args, 0, heap,
+                &x509Free);
+        if (ret != 0) {
+            *outRet = ret;
+            return;
+        }
+
+        ret = cert_store->get_crl_cb(store, &userCrl, store->current_cert);
+        if (ret == 1 && userCrl != NULL) {
+            /* Point to current cm to be able to verify CRL */
+            userCrl->cm = SSL_CM(ssl);
+            *outRet = CheckCertCRL(userCrl, args->dCert);
+        }
+        else
+            *outRet = CRL_MISSING;
+
+        if (userCrl != NULL)
+            wolfSSL_X509_CRL_free(userCrl);
+        CleanupStoreCtxCallback(store, ssl, heap, x509Free);
+    }
+#else
+    (void)cm;
+    (void)ssl;
+    (void)args;
+    (void)outRet;
+#endif
+}
+#endif
 
 static void FreeProcPeerCertArgs(WOLFSSL* ssl, void* pArgs)
 {
@@ -13618,7 +13870,7 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
     #if defined(NO_SHA) && !defined(NO_SHA256)
         retHash = wc_Sha256Hash((const byte*)pbuf, len, dgt);
     #elif !defined(NO_SHA)
-        retHash = wc_ShaHash((const byte*)pbuf, len, dgt);
+        retHash = wc_ShaHash((const byte*)pbuf, (word32)len, dgt);
     #endif
         if (retHash == 0) {
             /* 4 bytes in little endian as unsigned long */
@@ -13688,7 +13940,7 @@ int LoadCertByIssuer(WOLFSSL_X509_STORE* store, X509_NAME* issuer, int type)
 
         for (; suffix < MAX_SUFFIX; suffix++) {
             /* /folder-path/<hash>.(r)N[0..9] */
-            if (XSNPRINTF(filename, len, "%s/%08lx.%s%d", entry->dir_name,
+            if (XSNPRINTF(filename, (size_t)len, "%s/%08lx.%s%d", entry->dir_name,
                                                        hash, post, suffix)
                 >= len)
             {
@@ -13783,6 +14035,7 @@ static int ProcessPeerCertParse(WOLFSSL* ssl, ProcPeerCertArgs* args,
     buffer* cert;
     byte* subjectHash = NULL;
     int alreadySigner = 0;
+    Signer *extraSigners = NULL;
 #if defined(HAVE_RPK)
     int cType;
 #endif
@@ -13813,7 +14066,7 @@ PRAGMA_GCC_DIAG_POP
     /* check if returning from non-blocking OCSP */
     /* skip this section because cert is already initialized and parsed */
 #ifdef WOLFSSL_NONBLOCK_OCSP
-    if (args->lastErr == OCSP_WANT_READ) {
+    if (args->lastErr == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
         args->lastErr = 0; /* clear error */
         return 0;
     }
@@ -13843,7 +14096,7 @@ PRAGMA_GCC_DIAG_POP
         }
 
         /* perform cert parsing and signature check */
-        sigRet = CheckCertSignature(cert->buffer, cert->length,
+        sigRet = wc_CheckCertSignature(cert->buffer, cert->length,
                                          ssl->heap, SSL_CM(ssl));
         /* fail on errors here after the ParseCertRelative call, so dCert is populated */
 
@@ -13884,9 +14137,13 @@ PRAGMA_GCC_DIAG_POP
             return ret;
     #endif
     }
-
+#ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
+    if (verify != NO_VERIFY && TLSX_CSR2_IsMulti(ssl->extensions)) {
+        extraSigners = TLSX_CSR2_GetPendingSigners(ssl->extensions);
+    }
+#endif
     /* Parse Certificate */
-    ret = ParseCertRelative(args->dCert, certType, verify, SSL_CM(ssl));
+    ret = ParseCertRelative(args->dCert, certType, verify, SSL_CM(ssl), extraSigners);
 
 #if defined(HAVE_RPK)
     /* if cert type has negotiated with peer, confirm the cert received has
@@ -13919,7 +14176,9 @@ PRAGMA_GCC_DIAG_POP
 #endif /* HAVE_RPK */
 
     /* perform below checks for date failure cases */
-    if (ret == 0 || ret == ASN_BEFORE_DATE_E || ret == ASN_AFTER_DATE_E) {
+    if (ret == 0 ||
+        ret == WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E) ||
+        ret == WC_NO_ERR_TRACE(ASN_AFTER_DATE_E)) {
         /* get subject and determine if already loaded */
     #ifndef NO_SKID
         if (args->dCert->extAuthKeyIdSet)
@@ -13929,39 +14188,6 @@ PRAGMA_GCC_DIAG_POP
             subjectHash = args->dCert->subjectHash;
         alreadySigner = AlreadySigner(SSL_CM(ssl), subjectHash);
     }
-
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-    if ((ret == 0) && (args->dCert->sapkiDer != NULL)) {
-#ifndef WOLFSSL_SMALL_STACK
-        byte der[MAX_CERT_VERIFY_SZ];
-#else
-        byte *der = (byte*)XMALLOC(MAX_CERT_VERIFY_SZ, ssl->heap,
-                                   DYNAMIC_TYPE_DCERT);
-        if (der == NULL) {
-            ret = MEMORY_E;
-        }
-#endif /* ! WOLFSSL_SMALL_STACK */
-
-        if (ret == 0) {
-            ret = wc_GeneratePreTBS(args->dCert, der, MAX_CERT_VERIFY_SZ);
-
-            if (ret > 0) {
-                ret = wc_ConfirmAltSignature(der, ret,
-                    args->dCert->sapkiDer, args->dCert->sapkiLen,
-                    args->dCert->sapkiOID,
-                    args->dCert->altSigValDer, args->dCert->altSigValLen,
-                    args->dCert->altSigAlgOID, ssl->heap);
-            }
-#ifdef WOLFSSL_SMALL_STACK
-            XFREE(der, ssl->heap, DYNAMIC_TYPE_DCERT);
-#endif /* WOLFSSL_SMALL_STACK */
-
-            if (ret == 0) {
-               WOLFSSL_MSG("Alternative signature has been verified!");
-            }
-        }
-    }
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
 
 #ifdef WOLFSSL_SMALL_CERT_VERIFY
     /* get signature check failures from above */
@@ -13975,7 +14201,7 @@ PRAGMA_GCC_DIAG_POP
         *pAlreadySigner = alreadySigner;
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ret = wolfSSL_AsyncPush(ssl,
             args->dCert->sigCtx.asyncDev);
     }
@@ -13987,7 +14213,7 @@ PRAGMA_GCC_DIAG_POP
      * original return code is returned. */
     if (ssl->ctx && ssl->ctx->ProcessPeerCertCb) {
         int new_ret = ssl->ctx->ProcessPeerCertCb(ssl, args->dCert);
-        if (new_ret != NOT_COMPILED_IN) {
+        if (new_ret != WC_NO_ERR_TRACE(NOT_COMPILED_IN)) {
             ret = new_ret;
         }
     }
@@ -14056,7 +14282,6 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
             }
             break;
     #endif /* HAVE_ED448 */
-    #if defined(HAVE_PQC)
     #if defined(HAVE_FALCON)
         case FALCON_LEVEL1k:
             if (ssl->options.minFalconKeySz < 0 ||
@@ -14075,7 +14300,6 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
             }
             break;
     #endif /* HAVE_FALCON */
-    #endif /* HAVE_PQC */
     #if defined(HAVE_DILITHIUM)
         case DILITHIUM_LEVEL2k:
             if (ssl->options.minDilithiumKeySz < 0 ||
@@ -14113,10 +14337,12 @@ static int ProcessPeerCertCheckKey(WOLFSSL* ssl, ProcPeerCertArgs* args)
 }
 
 #ifdef HAVE_CRL
-static int ProcessPeerCertsChainCRLCheck(WOLFSSL_CERT_MANAGER* cm, Signer* ca)
+static int ProcessPeerCertsChainCRLCheck(WOLFSSL* ssl, ProcPeerCertArgs* args)
 {
     Signer* prev = NULL;
     int ret = 0;
+    WOLFSSL_CERT_MANAGER* cm = SSL_CM(ssl);
+    Signer* ca = args->dCert->ca;
     /* End loop if no more issuers found or if we have
      * found a self signed cert (ca == prev) */
     for (; ret == 0 && ca != NULL && ca != prev;
@@ -14124,7 +14350,12 @@ static int ProcessPeerCertsChainCRLCheck(WOLFSSL_CERT_MANAGER* cm, Signer* ca)
         ret = CheckCertCRL_ex(cm->crl, ca->issuerNameHash, NULL, 0,
                 ca->serialHash, NULL, 0, NULL);
         if (ret != 0)
+            DoCrlCallback(cm, ssl, args, &ret);
+        if (ret != 0){
+            WOLFSSL_ERROR_VERBOSE(ret);
+            WOLFSSL_MSG("\tCRL check not ok");
             break;
+        }
     }
     return ret;
 }
@@ -14145,6 +14376,9 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     byte* subjectHash = NULL;
     int alreadySigner = 0;
 
+#if defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
+    int addToPendingCAs = 0;
+#endif
     WOLFSSL_ENTER("ProcessPeerCerts");
 
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
@@ -14158,7 +14392,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     args = (ProcPeerCertArgs*)ssl->async->args;
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             goto exit_ppc;
@@ -14166,11 +14400,11 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     else
 #endif /* WOLFSSL_ASYNC_CRYPT */
 #ifdef WOLFSSL_NONBLOCK_OCSP
-    if (ssl->error == OCSP_WANT_READ) {
+    if (ssl->error == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
         /* Re-entry after non-blocking OCSP */
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* if async operationg not pending, reset error code */
-        if (ret == WC_NO_PENDING_E)
+        if (ret == WC_NO_ERR_TRACE(WC_NO_PENDING_E))
             ret = 0;
     #endif
     }
@@ -14288,7 +14522,25 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 ERROR_OUT(BUFFER_ERROR, exit_ppc);
             }
             c24to32(input + args->idx, &listSz);
-            args->idx += OPAQUE24_LEN;
+#ifdef HAVE_RPK
+            /*
+             * If this is RPK from the peer, then single cert (if TLS1.2).
+             * So, ListSz location is same as CertSz location, so fake
+             * we have just seen this ListSz.
+             */
+            if (!IsAtLeastTLSv1_3(ssl->version) &&
+                ((ssl->options.side == WOLFSSL_SERVER_END &&
+                  ssl->options.rpkState.received_ClientCertTypeCnt == 1 &&
+                  ssl->options.rpkState.received_ClientCertTypes[0] == WOLFSSL_CERT_TYPE_RPK) ||
+                 (ssl->options.side == WOLFSSL_CLIENT_END &&
+                  ssl->options.rpkState.received_ServerCertTypeCnt == 1 &&
+                  ssl->options.rpkState.received_ServerCertTypes[0] == WOLFSSL_CERT_TYPE_RPK))) {
+                listSz += OPAQUE24_LEN;
+            } else
+#endif /* HAVE_RPK */
+            {
+                args->idx += OPAQUE24_LEN;
+            }
             if (listSz > MAX_CERTIFICATE_SZ) {
                 ERROR_OUT(BUFFER_ERROR, exit_ppc);
             }
@@ -14488,7 +14740,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     (defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT)) && \
     !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR) && \
     !defined(NO_STDIO_FILESYSTEM)
-                    if (ret == ASN_NO_SIGNER_E || ret == ASN_SELF_SIGNED_E) {
+                    if (ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E) ||
+                        ret == WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E)) {
                         WOLFSSL_MSG("try to load certificate if hash dir is set");
                         ret = LoadCertByIssuer(SSL_STORE(ssl),
                            (WOLFSSL_X509_NAME*)args->dCert->issuerName,
@@ -14508,14 +14761,15 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     }
 #endif
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (ret == WC_PENDING_E)
+                    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                         goto exit_ppc;
                 #endif
                     if (ret == 0) {
                         ret = ProcessPeerCertCheckKey(ssl, args);
                     }
-                    else if (ret == ASN_PARSE_E || ret == BUFFER_E ||
-                             ret == MEMORY_E) {
+                    else if (ret == WC_NO_ERR_TRACE(ASN_PARSE_E) ||
+                             ret == WC_NO_ERR_TRACE(BUFFER_E) ||
+                             ret == WC_NO_ERR_TRACE(MEMORY_E)) {
                         WOLFSSL_MSG(
                             "Got Peer cert ASN PARSE_E, BUFFER E, MEMORY_E");
                         ERROR_OUT(ret, exit_ppc);
@@ -14550,9 +14804,11 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     if (ret == 0) {
                 #ifdef HAVE_OCSP
                     #ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
-                        if (ssl->status_request_v2) {
+                        addToPendingCAs = 0;
+                        if (ssl->status_request_v2 && TLSX_CSR2_IsMulti(ssl->extensions)) {
                             ret = TLSX_CSR2_InitRequests(ssl->extensions,
                                                     args->dCert, 0, ssl->heap);
+                            addToPendingCAs = 1;
                         }
                         else /* skips OCSP and force CRL check */
                     #endif /* HAVE_CERTIFICATE_STATUS_REQUEST_V2 */
@@ -14562,7 +14818,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             ret = CheckCertOCSP_ex(SSL_CM(ssl)->ocsp,
                                                     args->dCert, ssl);
                         #ifdef WOLFSSL_NONBLOCK_OCSP
-                            if (ret == OCSP_WANT_READ) {
+                            if (ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
                                 args->lastErr = ret;
                                 goto exit_ppc;
                             }
@@ -14586,7 +14842,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                    responder, do a CRL lookup. If any other
                                    error, skip the CRL lookup and fail the
                                    certificate. */
-                                doCrlLookup = (ret == OCSP_CERT_UNKNOWN);
+                                doCrlLookup = (ret == WC_NO_ERR_TRACE(OCSP_CERT_UNKNOWN));
                             }
                         #endif /* HAVE_OCSP */
 
@@ -14599,19 +14855,21 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                  * same WOULD_BLOCK error code as OCSP's I/O
                                  * callback, and it is enabling it using the
                                  * same flag. */
-                                if (ret == OCSP_WANT_READ) {
+                                if (ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
                                     args->lastErr = ret;
                                     goto exit_ppc;
                                 }
                             #endif
+                                if (ret != 0)
+                                    DoCrlCallback(SSL_CM(ssl), ssl, args, &ret);
                                 if (ret != 0) {
                                     WOLFSSL_ERROR_VERBOSE(ret);
                                     WOLFSSL_MSG("\tCRL check not ok");
                                 }
                                 if (ret == 0 &&
                                         args->certIdx == args->totalCerts-1) {
-                                    ret = ProcessPeerCertsChainCRLCheck(
-                                            SSL_CM(ssl), args->dCert->ca);
+                                    ret = ProcessPeerCertsChainCRLCheck(ssl,
+                                            args);
                                     if (ret != 0) {
                                         WOLFSSL_ERROR_VERBOSE(ret);
                                         WOLFSSL_MSG("\tCRL chain check not ok");
@@ -14640,7 +14898,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         chain mode only requires that the peer certificate
                         validate to a trusted CA */
                     if (ret != 0 && args->dCert->isCA) {
-                        if (ret == ASN_NO_SIGNER_E || ret == ASN_SELF_SIGNED_E) {
+                        if (ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E) ||
+                            ret == WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E)) {
                             if (!ssl->options.usingAltCertChain) {
                                 WOLFSSL_MSG("Trying alternate cert chain");
                                 ssl->options.usingAltCertChain = 1;
@@ -14663,7 +14922,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                      * for a CA cert to fail validation here, as we will verify
                      * the entire chain when we hit the peer (leaf) cert */
                     if ((ssl->ctx->doAppleNativeCertValidationFlag)
-                        && (ret == ASN_NO_SIGNER_E)) {
+                        && (ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E))) {
 
                         WOLFSSL_MSG("Bypassing errors to allow for Apple native"
                                     " CA validation");
@@ -14681,8 +14940,9 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     /* Do verify callback */
                     ret = DoVerifyCallback(SSL_CM(ssl), ssl, ret, args);
                     if (ssl->options.verifyNone &&
-                              (ret == CRL_MISSING || ret == CRL_CERT_REVOKED ||
-                               ret == CRL_CERT_DATE_ERR)) {
+                              (ret == WC_NO_ERR_TRACE(CRL_MISSING) ||
+                               ret == WC_NO_ERR_TRACE(CRL_CERT_REVOKED) ||
+                               ret == WC_NO_ERR_TRACE(CRL_CERT_DATE_ERR))) {
                         WOLFSSL_MSG("Ignoring CRL problem based on verify setting");
                         ret = ssl->error = 0;
                     }
@@ -14693,6 +14953,67 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         skipAddCA = 1;
                     }
                 #endif
+#if defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
+                    if (ret == 0 && addToPendingCAs && !alreadySigner) {
+#ifdef WOLFSSL_SMALL_STACK
+                        DecodedCert *dCertAdd = NULL;
+#else
+                        DecodedCert dCertAdd[1];
+#endif
+                        int dCertAdd_inited = 0;
+                        DerBuffer *derBuffer = NULL;
+                        buffer* cert = &args->certs[args->certIdx];
+                        Signer *s = NULL;
+
+#ifdef WOLFSSL_SMALL_STACK
+                        dCertAdd = (DecodedCert *)
+                            XMALLOC(sizeof(*dCertAdd), ssl->heap,
+                                    DYNAMIC_TYPE_TMP_BUFFER);
+                        if (dCertAdd == NULL) {
+                            ret = MEMORY_E;
+                            goto exit_req_v2;
+                        }
+#endif
+                        InitDecodedCert(dCertAdd, cert->buffer, cert->length,
+                                        ssl->heap);
+                        dCertAdd_inited = 1;
+                        ret = ParseCert(dCertAdd, CA_TYPE, NO_VERIFY,
+                                        SSL_CM(ssl));
+                        if (ret != 0) {
+                            goto exit_req_v2;
+                        }
+                        ret = AllocDer(&derBuffer, cert->length, CA_TYPE, ssl->heap);
+                        if (ret != 0 || derBuffer == NULL) {
+                            goto exit_req_v2;
+                        }
+                        XMEMCPY(derBuffer->buffer, cert->buffer, cert->length);
+                        s = MakeSigner(SSL_CM(ssl)->heap);
+                        if (s == NULL) {
+                            ret = MEMORY_E;
+                            goto exit_req_v2;
+                        }
+                        ret = FillSigner(s, dCertAdd, CA_TYPE, derBuffer);
+                        if (ret != 0) {
+                            goto exit_req_v2;
+                        }
+                        skipAddCA = 1;
+                        ret = TLSX_CSR2_AddPendingSigner(ssl->extensions, s);
+
+                    exit_req_v2:
+                        if (s && (ret != 0))
+                            FreeSigner(s, SSL_CM(ssl)->heap);
+                        if (derBuffer)
+                            FreeDer(&derBuffer);
+                        if (dCertAdd_inited)
+                            FreeDecodedCert(dCertAdd);
+#ifdef WOLFSSL_SMALL_STACK
+                        if (dCertAdd)
+                            XFREE(dCertAdd, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+                        if (ret != 0)
+                            goto exit_ppc;
+                    }
+#endif /* HAVE_CERTIFICATE_STATUS_REQUEST_V2 */
 
                     /* If valid CA then add to Certificate Manager */
                     if (ret == 0 && args->dCert->isCA &&
@@ -14775,7 +15096,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     (defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_EXT)) && \
     !defined(NO_FILESYSTEM) && !defined(NO_WOLFSSL_DIR) && \
     !defined(NO_STDIO_FILESYSTEM)
-                    if (ret == ASN_NO_SIGNER_E || ret == ASN_SELF_SIGNED_E) {
+                    if (ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E) ||
+                        ret == WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E)) {
                         int lastErr = ret; /* save error from last time */
                         WOLFSSL_MSG("try to load certificate if hash dir is set");
                         ret = LoadCertByIssuer(SSL_STORE(ssl),
@@ -14796,7 +15118,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     }
 #endif
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret == WC_PENDING_E)
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                     goto exit_ppc;
             #endif
                 if (ret == 0) {
@@ -14853,8 +15175,10 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         args->fatal = 0;
                     }
                 }
-                else if (ret == ASN_PARSE_E || ret == BUFFER_E ||
-                         ret == MEMORY_E || ret == BAD_FUNC_ARG) {
+                else if (ret == WC_NO_ERR_TRACE(ASN_PARSE_E) ||
+                         ret == WC_NO_ERR_TRACE(BUFFER_E) ||
+                         ret == WC_NO_ERR_TRACE(MEMORY_E) ||
+                         ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
                     WOLFSSL_MSG("Got Peer cert ASN_PARSE_E, BUFFER_E, MEMORY_E,"
                                 " BAD_FUNC_ARG");
                 #if defined(WOLFSSL_EXTRA_ALERTS) || defined(OPENSSL_EXTRA) || \
@@ -14872,11 +15196,11 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
                     #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
                     if (ssl->peerVerifyRet == 0) { /* Return first cert error here */
-                        if (ret == ASN_BEFORE_DATE_E) {
+                        if (ret == WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E)) {
                             ssl->peerVerifyRet =
                            (unsigned long)WOLFSSL_X509_V_ERR_CERT_NOT_YET_VALID;
                         }
-                        else if (ret == ASN_AFTER_DATE_E) {
+                        else if (ret == WC_NO_ERR_TRACE(ASN_AFTER_DATE_E)) {
                             ssl->peerVerifyRet =
                             (unsigned long)WOLFSSL_X509_V_ERR_CERT_HAS_EXPIRED;
                         }
@@ -15014,11 +15338,11 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         ret = CheckCertOCSP_ex(SSL_CM(ssl)->ocsp,
                                                     args->dCert, ssl);
                     #ifdef WOLFSSL_NONBLOCK_OCSP
-                        if (ret == OCSP_WANT_READ) {
+                        if (ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
                             goto exit_ppc;
                         }
                     #endif
-                        doLookup = (ret == OCSP_CERT_UNKNOWN);
+                        doLookup = (ret == WC_NO_ERR_TRACE(OCSP_CERT_UNKNOWN));
                         if (ret != 0) {
                             WOLFSSL_MSG("\tOCSP Lookup not ok");
                             args->fatal = 0;
@@ -15044,10 +15368,12 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                          * same WOULD_BLOCK error code as OCSP's I/O
                          * callback, and it is enabling it using the
                          * same flag. */
-                        if (ret == OCSP_WANT_READ) {
+                        if (ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
                             goto exit_ppc;
                         }
                     #endif
+                        if (ret != 0)
+                            DoCrlCallback(SSL_CM(ssl), ssl, args, &ret);
                         if (ret != 0) {
                             WOLFSSL_MSG("\tCRL check not ok");
                             args->fatal = 0;
@@ -15066,8 +15392,7 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                             SSL_CM(ssl)->crlCheckAll && args->totalCerts == 1) {
                         /* Check the entire cert chain */
                         if (args->dCert->ca != NULL) {
-                            ret = ProcessPeerCertsChainCRLCheck(SSL_CM(ssl),
-                                    args->dCert->ca);
+                            ret = ProcessPeerCertsChainCRLCheck(ssl, args);
                             if (ret != 0) {
                                 WOLFSSL_ERROR_VERBOSE(ret);
                                 WOLFSSL_MSG("\tCRL chain check not ok");
@@ -15087,28 +15412,11 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 if (args->fatal == 0) {
                     int copyRet = 0;
 
-                    #ifdef WOLFSSL_POST_HANDSHAKE_AUTH
-                        if (ssl->options.handShakeDone) {
-                            FreeX509(&ssl->peerCert);
-                            InitX509(&ssl->peerCert, 0, ssl->heap);
-                        }
-                        else
-                    #endif
-                    #ifdef HAVE_SECURE_RENEGOTIATION
-                        if (ssl->secure_renegotiation &&
-                                           ssl->secure_renegotiation->enabled) {
-                            /* free old peer cert */
-                            FreeX509(&ssl->peerCert);
-                            InitX509(&ssl->peerCert, 0, ssl->heap);
-                        }
-                        else
-                    #endif
-                        {
-                        }
-
-                    /* set X509 format for peer cert */
+                    /* free old peer cert */
+                    FreeX509(&ssl->peerCert);
+                    InitX509(&ssl->peerCert, 0, ssl->heap);
                     copyRet = CopyDecodedToX509(&ssl->peerCert, args->dCert);
-                    if (copyRet == MEMORY_E) {
+                    if (copyRet == WC_NO_ERR_TRACE(MEMORY_E)) {
                         args->fatal = 1;
                     }
                 }
@@ -15209,6 +15517,9 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     if (args->dCert->altNames) {
                         if (CheckForAltNames(args->dCert,
                                 (char*)ssl->buffers.domainName.buffer,
+                                (ssl->buffers.domainName.buffer == NULL ? 0 :
+                                (word32)XSTRLEN(
+                                (const char *)ssl->buffers.domainName.buffer)),
                                 NULL) != 1) {
                             WOLFSSL_MSG("DomainName match on alt names failed");
                             /* try to get peer key still */
@@ -15218,9 +15529,14 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     }
                     else {
                         if (MatchDomainName(
-                                 args->dCert->subjectCN,
-                                 args->dCert->subjectCNLen,
-                                 (char*)ssl->buffers.domainName.buffer) == 0) {
+                                args->dCert->subjectCN,
+                                args->dCert->subjectCNLen,
+                                (char*)ssl->buffers.domainName.buffer,
+                                (ssl->buffers.domainName.buffer == NULL ? 0 :
+                                (word32)XSTRLEN(
+                                (const char *)ssl->buffers.domainName.buffer)
+                                )) == 0)
+                        {
                             WOLFSSL_MSG("DomainName match on common name failed");
                             ret = DOMAIN_NAME_MISMATCH;
                             WOLFSSL_ERROR_VERBOSE(ret);
@@ -15230,10 +15546,15 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     /* Old behavior. */
                     if (MatchDomainName(args->dCert->subjectCN,
                                 args->dCert->subjectCNLen,
-                                (char*)ssl->buffers.domainName.buffer) == 0) {
+                                (char*)ssl->buffers.domainName.buffer,
+                                (ssl->buffers.domainName.buffer == NULL ? 0 :
+                                (word32)XSTRLEN(ssl->buffers.domainName.buffer))) == 0)
+                    {
                         WOLFSSL_MSG("DomainName match on common name failed");
                         if (CheckForAltNames(args->dCert,
                                  (char*)ssl->buffers.domainName.buffer,
+                                 (ssl->buffers.domainName.buffer == NULL ? 0 :
+                                 (word32)XSTRLEN(ssl->buffers.domainName.buffer)),
                                  NULL) != 1) {
                             WOLFSSL_MSG(
                                 "DomainName match on alt names failed too");
@@ -15525,7 +15846,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         break;
                     }
                 #endif /* HAVE_ED448 && HAVE_ED448_KEY_IMPORT */
-                #if defined(HAVE_PQC)
                 #if defined(HAVE_FALCON)
                     case FALCON_LEVEL1k:
                     case FALCON_LEVEL5k:
@@ -15575,7 +15895,8 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         break;
                     }
                 #endif /* HAVE_FALCON */
-                #if defined(HAVE_DILITHIUM)
+                #if defined(HAVE_DILITHIUM) && \
+                    !defined(WOLFSSL_DILITHIUM_NO_VERIFY)
                     case DILITHIUM_LEVEL2k:
                     case DILITHIUM_LEVEL3k:
                     case DILITHIUM_LEVEL5k:
@@ -15628,7 +15949,6 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                         break;
                     }
                 #endif /* HAVE_DILITHIUM */
-                #endif /* HAVE_PQC */
                     default:
                         break;
                 }
@@ -15687,8 +16007,9 @@ int ProcessPeerCerts(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             ret = DoVerifyCallback(SSL_CM(ssl), ssl, ret, args);
 
             if (ssl->options.verifyNone &&
-                              (ret == CRL_MISSING || ret == CRL_CERT_REVOKED ||
-                               ret == CRL_CERT_DATE_ERR)) {
+                              (ret == WC_NO_ERR_TRACE(CRL_MISSING) ||
+                               ret == WC_NO_ERR_TRACE(CRL_CERT_REVOKED) ||
+                               ret == WC_NO_ERR_TRACE(CRL_CERT_DATE_ERR))) {
                 WOLFSSL_MSG("Ignoring CRL problem based on verify setting");
                 ret = ssl->error = 0;
             }
@@ -15735,7 +16056,8 @@ exit_ppc:
 
 
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-    if (ret == WC_PENDING_E || ret == OCSP_WANT_READ) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) ||
+        ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) {
         /* Mark message as not received so it can process again */
         ssl->msgsReceived.got_certificate = 0;
 
@@ -15781,7 +16103,8 @@ static int DoCertificate(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     /* Reset the session cert chain count in case the session resume failed,
      * do not reset if we are resuming after an async wait */
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-    if (ssl->error != OCSP_WANT_READ && ssl->error != WC_PENDING_E)
+    if (ssl->error != WC_NO_ERR_TRACE(OCSP_WANT_READ) &&
+        ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
 #endif
     {
         ssl->session->chain.count = 0;
@@ -15810,6 +16133,7 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     int    ret = 0;
     byte   status_type;
     word32 status_length;
+    int endCertificateOK = 0;
 
     WOLFSSL_START(WC_FUNC_CERTIFICATE_STATUS_DO);
     WOLFSSL_ENTER("DoCertificateStatus");
@@ -15833,6 +16157,7 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         /* WOLFSSL_CSR_OCSP overlaps with WOLFSSL_CSR2_OCSP */
         case WOLFSSL_CSR2_OCSP:
             ret = ProcessCSR(ssl, input, inOutIdx, status_length);
+            endCertificateOK = (ret == 0);
             break;
 
     #endif
@@ -15843,6 +16168,7 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             OcspRequest* request;
             word32 list_length = status_length;
             byte   idx = 0;
+            Signer *pendingCAs = NULL;
 
             #ifdef WOLFSSL_SMALL_STACK
                 CertStatus*   status;
@@ -15854,14 +16180,12 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 OcspResponse response[1];
             #endif
 
-            do {
-                if (ssl->status_request_v2) {
-                    ssl->status_request_v2 = 0;
-                    break;
-                }
-
+            if (!ssl->status_request_v2)
                 return BUFFER_ERROR;
-            } while(0);
+
+            ssl->status_request_v2 = 0;
+
+            pendingCAs = TLSX_CSR2_GetPendingSigners(ssl->extensions);
 
             #ifdef WOLFSSL_SMALL_STACK
                 status = (CertStatus*)XMALLOC(sizeof(CertStatus), ssl->heap,
@@ -15901,23 +16225,27 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                 if (status_length) {
                     InitOcspResponse(response, single, status, input +*inOutIdx,
                                      status_length, ssl->heap);
-
+                    response->pendingCAs = pendingCAs;
                     if ((OcspResponseDecode(response, SSL_CM(ssl), ssl->heap,
                                                                         0) != 0)
                     ||  (response->responseStatus != OCSP_SUCCESSFUL)
                     ||  (response->single->status->status != CERT_GOOD))
                         ret = BAD_CERTIFICATE_STATUS_ERROR;
 
-                    while (ret == 0) {
+                    if (ret == 0) {
                         request = (OcspRequest*)TLSX_CSR2_GetRequest(
-                                ssl->extensions, status_type, idx++);
+                                ssl->extensions, status_type, idx);
 
-                        if (request == NULL)
+                        if (request == NULL) {
                             ret = BAD_CERTIFICATE_STATUS_ERROR;
-                        else if (CompareOcspReqResp(request, response) == 0)
-                            break;
-                        else if (idx == 1) /* server cert must be OK */
+                        }
+                        else if (CompareOcspReqResp(request, response) != 0) {
                             ret = BAD_CERTIFICATE_STATUS_ERROR;
+                        }
+                        else {
+                            if (idx == 0) /* server cert must be OK */
+                                endCertificateOK = 1;
+                        }
                     }
 
                     /* only frees 'single' if single->isDynamic is set */
@@ -15926,6 +16254,7 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                     *inOutIdx   += status_length;
                     list_length -= status_length;
                 }
+                idx++;
             }
 
             ssl->status_request_v2 = 0;
@@ -15944,6 +16273,20 @@ static int DoCertificateStatus(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         default:
             ret = BUFFER_ERROR;
     }
+
+    /* end certificate MUST be present */
+    if (endCertificateOK == 0)
+        ret = BAD_CERTIFICATE_STATUS_ERROR;
+#if defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
+    if (ret == 0) {
+        if (TLSX_CSR2_MergePendingCA(ssl) < 0) {
+            WOLFSSL_MSG("Failed to merge pending CAs");
+        }
+    }
+    else {
+        TLSX_CSR2_ClearPendingCA(ssl);
+    }
+#endif
 
     if (ret != 0) {
         WOLFSSL_ERROR_VERBOSE(ret);
@@ -16348,44 +16691,6 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                 WOLFSSL_ERROR_VERBOSE(OUT_OF_ORDER_E);
                 return OUT_OF_ORDER_E;
             }
-#if defined(HAVE_CERTIFICATE_STATUS_REQUEST) || \
-                                     defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
-            if (ssl->msgsReceived.got_certificate_status == 0) {
-                int csrRet = 0;
-#ifdef HAVE_CERTIFICATE_STATUS_REQUEST
-                if (csrRet == 0 && ssl->status_request) {
-                    WOLFSSL_MSG("No CertificateStatus before ServerKeyExchange");
-                    csrRet = TLSX_CSR_ForceRequest(ssl);
-                }
-#endif
-#ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
-                if (csrRet == 0 && ssl->status_request_v2) {
-                    WOLFSSL_MSG("No CertificateStatus before ServerKeyExchange");
-                    csrRet = TLSX_CSR2_ForceRequest(ssl);
-                }
-#endif
-                if (csrRet != 0) {
-                    /* Error out if OCSP lookups are enabled and failed or if
-                     * the user requires stapling. */
-                    if (SSL_CM(ssl)->ocspEnabled || SSL_CM(ssl)->ocspMustStaple)
-                        return csrRet;
-                }
-                /* Check that a status request extension was seen as the
-                 * CertificateStatus wasn't when an OCSP staple is required.
-                 */
-                if (
-#ifdef HAVE_CERTIFICATE_STATUS_REQUEST
-                     !ssl->status_request &&
-#endif
-#ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
-                     !ssl->status_request_v2 &&
-#endif
-                                                 SSL_CM(ssl)->ocspMustStaple) {
-                    WOLFSSL_ERROR_VERBOSE(OCSP_CERT_UNKNOWN);
-                    return OCSP_CERT_UNKNOWN;
-                }
-            }
-#endif
 
             break;
 #endif
@@ -16458,6 +16763,54 @@ static int SanityCheckMsgReceived(WOLFSSL* ssl, byte type)
                     return OUT_OF_ORDER_E;
                 }
             }
+#if defined(HAVE_CERTIFICATE_STATUS_REQUEST) || \
+                                     defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
+            if (ssl->msgsReceived.got_certificate_status == 0) {
+                int csrRet = 0;
+#ifdef HAVE_CERTIFICATE_STATUS_REQUEST
+                if (csrRet == 0 && ssl->status_request) {
+                    WOLFSSL_MSG("No CertificateStatus before ServerHelloDone");
+                    csrRet = TLSX_CSR_ForceRequest(ssl);
+                }
+#endif
+#ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
+                if (csrRet == 0 && ssl->status_request_v2) {
+                    WOLFSSL_MSG("No CertificateStatus before ServerHelloDone");
+                    csrRet = TLSX_CSR2_ForceRequest(ssl);
+                }
+                if (ssl->status_request_v2) {
+                    if (csrRet == 0) {
+                        if (TLSX_CSR2_MergePendingCA(ssl) < 0) {
+                            WOLFSSL_MSG("Failed to merge pending CAs");
+                        }
+                    }
+                    else {
+                        TLSX_CSR2_ClearPendingCA(ssl);
+                    }
+                }
+#endif
+                if (csrRet != 0) {
+                    /* Error out if OCSP lookups are enabled and failed or if
+                     * the user requires stapling. */
+                    if (SSL_CM(ssl)->ocspEnabled || SSL_CM(ssl)->ocspMustStaple)
+                        return csrRet;
+                }
+                /* Check that a status request extension was seen as the
+                 * CertificateStatus wasn't when an OCSP staple is required.
+                 */
+                if (
+#ifdef HAVE_CERTIFICATE_STATUS_REQUEST
+                     !ssl->status_request &&
+#endif
+#ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
+                     !ssl->status_request_v2 &&
+#endif
+                                                 SSL_CM(ssl)->ocspMustStaple) {
+                    WOLFSSL_ERROR_VERBOSE(OCSP_CERT_UNKNOWN);
+                    return OCSP_CERT_UNKNOWN;
+                }
+            }
+#endif
             break;
 #endif
 
@@ -16734,7 +17087,7 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
             && ssl->error != OCSP_WANT_READ
     #endif
     ) {
-        ret = HashInput(ssl, input + *inOutIdx, size);
+        ret = HashInput(ssl, input + *inOutIdx, (int)size);
         if (ret != 0) {
             WOLFSSL_MSG("Incomplete handshake hashes");
             return ret;
@@ -16827,7 +17180,8 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                                IsAtLeastTLSv1_3(ssl->version)) {
 
         #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-            if (ret != WC_PENDING_E && ret != OCSP_WANT_READ)
+            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E) &&
+                ret != WC_NO_ERR_TRACE(OCSP_WANT_READ))
         #endif
             {
                 ssl->options.cacheMessages = 0;
@@ -16909,7 +17263,8 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         if (ssl->options.resuming || !ssl->options.verifyPeer || \
                      !IsAtLeastTLSv1_2(ssl) || IsAtLeastTLSv1_3(ssl->version)) {
         #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-            if (ret != WC_PENDING_E && ret != OCSP_WANT_READ)
+            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E) &&
+                ret != WC_NO_ERR_TRACE(OCSP_WANT_READ))
         #endif
             {
                 ssl->options.cacheMessages = 0;
@@ -16975,7 +17330,8 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
     /* if async, offset index so this msg will be processed again */
-    if ((ret == WC_PENDING_E || ret == OCSP_WANT_READ) && *inOutIdx > 0) {
+    if ((ret == WC_NO_ERR_TRACE(WC_PENDING_E) ||
+         ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) && *inOutIdx > 0) {
         *inOutIdx -= HANDSHAKE_HEADER_SZ;
     #ifdef WOLFSSL_DTLS
         if (ssl->options.dtls) {
@@ -16985,7 +17341,8 @@ int DoHandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     }
 
     /* make sure async error is cleared */
-    if (ret == 0 && (ssl->error == WC_PENDING_E || ssl->error == OCSP_WANT_READ)) {
+    if (ret == 0 && (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E) ||
+                     ssl->error == WC_NO_ERR_TRACE(OCSP_WANT_READ))) {
         ssl->error = 0;
     }
 #endif /* WOLFSSL_ASYNC_CRYPT || WOLFSSL_NONBLOCK_OCSP */
@@ -17108,7 +17465,7 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         }
 
     #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ssl->error != WC_PENDING_E)
+        if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
     #endif
         {
             /* for async this copy was already done, do not replace, since
@@ -17128,7 +17485,7 @@ static int DoHandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                      ssl->arrays->pendingMsgSz - idx,
                                      ssl->arrays->pendingMsgSz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 /* setup to process fragment again */
                 ssl->arrays->pendingMsgOffset -= inputLength;
                 *inOutIdx -= inputLength;
@@ -17160,43 +17517,41 @@ int SendFatalAlertOnly(WOLFSSL *ssl, int error)
 
     switch (error) {
         /* not fatal errors */
-    case WANT_WRITE:
-    case WANT_READ:
-    case ZERO_RETURN:
+    case WC_NO_ERR_TRACE(WANT_WRITE):
+    case WC_NO_ERR_TRACE(WANT_READ):
+    case WC_NO_ERR_TRACE(ZERO_RETURN):
 #ifdef WOLFSSL_NONBLOCK_OCSP
-    case OCSP_WANT_READ:
+    case WC_NO_ERR_TRACE(OCSP_WANT_READ):
 #endif
 #ifdef WOLFSSL_ASYNC_CRYPT
-    case WC_PENDING_E:
+    case WC_NO_ERR_TRACE(WC_PENDING_E):
 #endif
         return 0;
 
     /* peer already disconnected and ssl is possibly in bad state
      * don't try to send an alert */
-    case SOCKET_ERROR_E:
+    case WC_NO_ERR_TRACE(SOCKET_ERROR_E):
         return error;
 
-    case BUFFER_ERROR:
-    case ASN_PARSE_E:
-    case COMPRESSION_ERROR:
+    case WC_NO_ERR_TRACE(BUFFER_ERROR):
+    case WC_NO_ERR_TRACE(ASN_PARSE_E):
+    case WC_NO_ERR_TRACE(COMPRESSION_ERROR):
         why = decode_error;
         break;
-    case MATCH_SUITE_ERROR:
-        why = illegal_parameter;
-        break;
-    case VERIFY_FINISHED_ERROR:
-    case SIG_VERIFY_E:
+    case WC_NO_ERR_TRACE(VERIFY_FINISHED_ERROR):
+    case WC_NO_ERR_TRACE(SIG_VERIFY_E):
         why = decrypt_error;
         break;
-    case DUPLICATE_MSG_E:
-    case NO_CHANGE_CIPHER_E:
-    case OUT_OF_ORDER_E:
+    case WC_NO_ERR_TRACE(DUPLICATE_MSG_E):
+    case WC_NO_ERR_TRACE(NO_CHANGE_CIPHER_E):
+    case WC_NO_ERR_TRACE(OUT_OF_ORDER_E):
         why = unexpected_message;
         break;
-    case ECC_OUT_OF_RANGE_E:
+    case WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E):
         why = bad_record_mac;
         break;
-    case VERSION_ERROR:
+    case WC_NO_ERR_TRACE(MATCH_SUITE_ERROR):
+    case WC_NO_ERR_TRACE(VERSION_ERROR):
     default:
         why = handshake_failure;
         break;
@@ -17680,12 +18035,12 @@ int DtlsMsgDrain(WOLFSSL* ssl)
             DtlsTxMsgListClean(ssl);
         }
         else if (!IsAtLeastTLSv1_3(ssl->version)) {
-            if (SendFatalAlertOnly(ssl, ret) == SOCKET_ERROR_E) {
+            if (SendFatalAlertOnly(ssl, ret) == WC_NO_ERR_TRACE(SOCKET_ERROR_E)) {
                 ret = SOCKET_ERROR_E;
             }
         }
     #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             break;
         }
     #endif
@@ -18034,7 +18389,7 @@ static int Poly1305TagOld(WOLFSSL* ssl, byte* additional, const byte* out,
 
     /* add cipher info and then its length */
     XMEMSET(padding, 0, sizeof(padding));
-    if ((ret = wc_Poly1305Update(ssl->auth.poly1305, out, msglen)) != 0)
+    if ((ret = wc_Poly1305Update(ssl->auth.poly1305, out, (word32)msglen)) != 0)
         return ret;
 
     /* 32 bit size of cipher to 64 bit endian */
@@ -18419,7 +18774,7 @@ int ChachaAEADDecrypt(WOLFSSL* ssl, byte* plain, const byte* input,
             return ret;
         }
         if ((ret = wc_Poly1305_MAC(ssl->auth.poly1305, add,
-                          sizeof(add), input, msgLen, tag, sizeof(tag))) != 0) {
+                          sizeof(add), input, (word32)msgLen, tag, sizeof(tag))) != 0) {
             ForceZero(poly, sizeof(poly));
         #ifdef WOLFSSL_CHECK_MEM_ZERO
             wc_MemZero_Check(poly, CHACHA20_256_KEY_SIZE);
@@ -18443,7 +18798,7 @@ int ChachaAEADDecrypt(WOLFSSL* ssl, byte* plain, const byte* input,
 
     /* if the tag was good decrypt message */
     if ((ret = wc_Chacha_Process(ssl->decrypt.chacha, plain,
-                                                           input, msgLen)) != 0)
+                                                           input, (word32)msgLen)) != 0)
         return ret;
 
     #ifdef CHACHA_AEAD_TEST
@@ -18542,7 +18897,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
 
             ret = wc_Des3_CbcEncrypt(ssl->encrypt.des3, out, input, sz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E && asyncOkay) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) && asyncOkay) {
                 ret = wolfSSL_AsyncPush(ssl, asyncDev);
             }
         #endif
@@ -18560,7 +18915,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
         #endif
             ret = wc_AesCbcEncrypt(ssl->encrypt.aes, out, input, sz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E && asyncOkay) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) && asyncOkay) {
                 ret = wolfSSL_AsyncPush(ssl, asyncDev);
             }
         #endif
@@ -18631,7 +18986,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
                          ssl->encrypt.additional, AEAD_AUTH_DATA_SZ);
             }
 
-            if (ret == NOT_COMPILED_IN)
+            if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
         #endif /* HAVE_PK_CALLBACKS */
             {
                 ret = aes_auth_fn(ssl->encrypt.aes,
@@ -18644,7 +18999,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
             }
 
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E && asyncOkay) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) && asyncOkay) {
                 ret = wolfSSL_AsyncPush(ssl, asyncDev);
             }
         #endif
@@ -18734,7 +19089,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
         #endif
             ret = wc_Sm4CbcEncrypt(ssl->encrypt.sm4, out, input, sz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E && asyncOkay) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) && asyncOkay) {
                 ret = wolfSSL_AsyncPush(ssl, asyncDev);
             }
         #endif
@@ -18798,7 +19153,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
                     ssl->encrypt.additional, AEAD_AUTH_DATA_SZ);
 
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E && asyncOkay) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) && asyncOkay) {
                 ret = wolfSSL_AsyncPush(ssl, asyncDev);
             }
         #endif
@@ -18828,7 +19183,7 @@ static WC_INLINE int EncryptDo(WOLFSSL* ssl, byte* out, const byte* input,
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     /* if async is not okay, then block */
-    if (ret == WC_PENDING_E && !asyncOkay) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) && !asyncOkay) {
         ret = wc_AsyncWait(ret, asyncDev, event_flags);
     }
 #endif
@@ -18842,7 +19197,7 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
     int ret = 0;
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ssl->error == WC_PENDING_E) {
+    if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ssl->error = 0; /* clear async */
     }
 #endif
@@ -18935,7 +19290,7 @@ static WC_INLINE int Encrypt(WOLFSSL* ssl, byte* out, const byte* input,
 
         #ifdef WOLFSSL_ASYNC_CRYPT
             /* If pending, then leave and return will resume below */
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 return ret;
             }
         #endif
@@ -19031,7 +19386,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
 
             ret = wc_Des3_CbcDecrypt(ssl->decrypt.des3, plain, input, sz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 ret = wolfSSL_AsyncPush(ssl, &ssl->decrypt.des3->asyncDev);
             }
         #endif
@@ -19049,7 +19404,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
         #endif
             ret = wc_AesCbcDecrypt(ssl->decrypt.aes, plain, input, sz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 ret = wolfSSL_AsyncPush(ssl, &ssl->decrypt.aes->asyncDev);
             }
         #endif
@@ -19115,7 +19470,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
                         ssl->decrypt.additional, AEAD_AUTH_DATA_SZ);
             }
 
-            if (ret == NOT_COMPILED_IN)
+            if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
         #endif /* HAVE_PK_CALLBACKS */
             {
                 if ((ret = aes_auth_fn(ssl->decrypt.aes,
@@ -19127,7 +19482,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
                             ssl->specs.aead_mac_size,
                             ssl->decrypt.additional, AEAD_AUTH_DATA_SZ)) < 0) {
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (ret == WC_PENDING_E) {
+                    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                         ret = wolfSSL_AsyncPush(ssl,
                                                 &ssl->decrypt.aes->asyncDev);
                     }
@@ -19213,7 +19568,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
         #endif
             ret = wc_Sm4CbcDecrypt(ssl->decrypt.sm4, plain, input, sz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 ret = wolfSSL_AsyncPush(ssl, &ssl->decrypt.aes->asyncDev);
             }
         #endif
@@ -19274,7 +19629,7 @@ static WC_INLINE int DecryptDo(WOLFSSL* ssl, byte* plain, const byte* input,
                         ssl->specs.aead_mac_size,
                         ssl->decrypt.additional, AEAD_AUTH_DATA_SZ)) < 0) {
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret == WC_PENDING_E) {
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                     ret = wolfSSL_AsyncPush(ssl,
                                             &ssl->decrypt.sm4->asyncDev);
                 }
@@ -19314,9 +19669,9 @@ static int DecryptTls(WOLFSSL* ssl, byte* plain, const byte* input, word16 sz)
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfSSL_AsyncPop(ssl, &ssl->decrypt.state);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* check for still pending */
-        if (ret == WC_PENDING_E)
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
             return ret;
 
         ssl->error = 0; /* clear async */
@@ -19431,7 +19786,7 @@ static int DecryptTls(WOLFSSL* ssl, byte* plain, const byte* input, word16 sz)
 
         #ifdef WOLFSSL_ASYNC_CRYPT
             /* If pending, leave and return below */
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 return ret;
             }
         #endif
@@ -20076,7 +20431,7 @@ int DoApplicationData(WOLFSSL* ssl, byte* input, word32* inOutIdx, int sniff)
         idx += rawSz;
 
         ssl->buffers.clearOutputBuffer.buffer = rawData;
-        ssl->buffers.clearOutputBuffer.length = dataSz;
+        ssl->buffers.clearOutputBuffer.length = (unsigned int)dataSz;
     }
 
     idx += ssl->keys.padSz;
@@ -20445,14 +20800,14 @@ static int GetInputData(WOLFSSL *ssl, word32 size)
 
     /* remove processed data */
     ssl->buffers.inputBuffer.idx    = 0;
-    ssl->buffers.inputBuffer.length = usedLength;
+    ssl->buffers.inputBuffer.length = (word32)usedLength;
 
     /* read data from network */
     do {
         int in = wolfSSLReceive(ssl,
                      ssl->buffers.inputBuffer.buffer +
                      ssl->buffers.inputBuffer.length,
-                     inSz);
+                     (word32)inSz);
         if (in == WANT_READ)
             return WANT_READ;
 
@@ -20503,7 +20858,7 @@ static WC_INLINE int VerifyMacEnc(WOLFSSL* ssl, const byte* input, word32 msgSz,
     }
 
     ret  = ssl->hmac(ssl, verify, input, msgSz - digestSz, -1, content, 1, PEER_ORDER);
-    ret |= ConstantCompare(verify, input + msgSz - digestSz, digestSz);
+    ret |= ConstantCompare(verify, input + msgSz - digestSz, (int)digestSz);
     if (ret != 0) {
         WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
         return VERIFY_MAC_ERROR;
@@ -20543,12 +20898,14 @@ static WC_INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
                 void* ctx = wolfSSL_GetVerifyMacCtx(ssl);
                 ret = ssl->ctx->VerifyMacCb(ssl, input,
                            (msgSz - ivExtra) - digestSz - pad - 1,
-                           digestSz, content, ctx);
-                if (ret != 0 && ret != PROTOCOLCB_UNAVAILABLE) {
+                           digestSz, (word32)content, ctx);
+                if (ret != 0 &&
+                    ret != WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE)) {
                     return ret;
                 }
             }
-            if (!ssl->ctx->VerifyMacCb || ret == PROTOCOLCB_UNAVAILABLE)
+            if (!ssl->ctx->VerifyMacCb ||
+                ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
 #endif
             ret = TimingPadVerify(ssl, input, pad, digestSz, msgSz - ivExtra,
                                   content);
@@ -20569,9 +20926,9 @@ static WC_INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
             }
             (void)PadCheck(dummy, (byte)pad, MAX_PAD_SIZE);  /* timing only */
             ret = ssl->hmac(ssl, verify, input, msgSz - digestSz - pad - 1,
-                            pad, content, 1, PEER_ORDER);
+                            (int)pad, content, 1, PEER_ORDER);
             if (ConstantCompare(verify, input + msgSz - digestSz - pad - 1,
-                                digestSz) != 0) {
+                                (int)digestSz) != 0) {
                 WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
                 return VERIFY_MAC_ERROR;
             }
@@ -20584,7 +20941,7 @@ static WC_INLINE int VerifyMac(WOLFSSL* ssl, const byte* input, word32 msgSz,
     else if (ssl->specs.cipher_type == stream) {
         ret = ssl->hmac(ssl, verify, input, msgSz - digestSz, -1, content, 1,
                         PEER_ORDER);
-        if (ConstantCompare(verify, input + msgSz - digestSz, digestSz) != 0) {
+        if (ConstantCompare(verify, input + msgSz - digestSz, (int)digestSz) != 0) {
             WOLFSSL_ERROR_VERBOSE(VERIFY_MAC_ERROR);
             return VERIFY_MAC_ERROR;
         }
@@ -20640,7 +20997,8 @@ static int DtlsShouldDrop(WOLFSSL* ssl, int retcode)
     }
 
     if ((ssl->options.handShakeDone && retcode != 0)
-        || retcode == SEQUENCE_ERROR || retcode == DTLS_CID_ERROR) {
+        || retcode == WC_NO_ERR_TRACE(SEQUENCE_ERROR)
+        || retcode == WC_NO_ERR_TRACE(DTLS_CID_ERROR)) {
         WOLFSSL_MSG_EX("Silently dropping DTLS message: %d", retcode);
         return 1;
     }
@@ -20700,7 +21058,8 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
     #ifdef WOLFSSL_NONBLOCK_OCSP
         && ssl->error != OCSP_WANT_READ
     #endif
-        && (allowSocketErr != 1 || ssl->error != SOCKET_ERROR_E)
+        && (allowSocketErr != 1 ||
+            ssl->error != WC_NO_ERR_TRACE(SOCKET_ERROR_E))
     ) {
         WOLFSSL_MSG("ProcessReply retry in error state, not allowed");
         return ssl->error;
@@ -20711,7 +21070,8 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
 #if defined(WOLFSSL_CHECK_ALERT_ON_ERR) && \
     (defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP))
     if (allowSocketErr == 1 && \
-        (ssl->error == WC_PENDING_E || ssl->error == OCSP_WANT_READ)) {
+        (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E) ||
+         ssl->error == WC_NO_ERR_TRACE(OCSP_WANT_READ))) {
         return ssl->error;
     }
 #endif
@@ -20770,7 +21130,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
 
             /* get header or return error */
             if (!ssl->options.dtls) {
-                if ((ret = GetInputData(ssl, readSz)) < 0)
+                if ((ret = GetInputData(ssl, (word32)readSz)) < 0)
                     return ret;
             } else {
             #ifdef WOLFSSL_DTLS
@@ -20778,7 +21138,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                 used = ssl->buffers.inputBuffer.length -
                        ssl->buffers.inputBuffer.idx;
                 if (used < readSz) {
-                    if ((ret = GetInputData(ssl, readSz)) < 0)
+                    if ((ret = GetInputData(ssl, (word32)readSz)) < 0)
                         return ret;
                 }
             #endif
@@ -20892,7 +21252,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
 #endif
             if (ret != 0) {
                 switch (ret) {
-                case VERSION_ERROR:
+                case WC_NO_ERR_TRACE(VERSION_ERROR):
                     /* send alert per RFC5246 Appendix E. Backward
                      * Compatibility */
                     if (ssl->options.side == WOLFSSL_CLIENT_END)
@@ -20900,7 +21260,7 @@ int ProcessReplyEx(WOLFSSL* ssl, int allowSocketErr)
                             wolfssl_alert_protocol_version);
                     break;
 #ifdef HAVE_MAX_FRAGMENT
-                case LENGTH_ERROR:
+                case WC_NO_ERR_TRACE(LENGTH_ERROR):
                     SendAlert(ssl, alert_fatal, record_overflow);
                     break;
 #endif /* HAVE_MAX_FRAGMENT */
@@ -20987,7 +21347,7 @@ default:
                                    ssl->buffers.inputBuffer.idx,
                                    ssl->curSize, ssl->curRL.type);
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret == WC_PENDING_E)
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                     return ret;
             #endif
                 if (ret < 0) {
@@ -21134,7 +21494,7 @@ default:
                 }
 
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret == WC_PENDING_E)
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                     return ret;
             #endif
 
@@ -21218,7 +21578,7 @@ default:
                                     ssl->curSize, ssl->curRL.type,
                                     &ssl->keys.padSz);
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (ret == WC_PENDING_E)
+                    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                         return ret;
                 #endif
                     if (ret < 0) {
@@ -21369,14 +21729,15 @@ default:
                                 ssl->buffers.inputBuffer.buffer,
                                 &ssl->buffers.inputBuffer.idx,
                                 ssl->buffers.inputBuffer.length);
-                            if (ret == 0 || ret == WC_PENDING_E) {
+                            if (ret == 0 ||
+                                ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                                 /* Reset timeout as we have received a valid
                                  * DTLS handshake message */
                                 ssl->dtls_timeout = ssl->dtls_timeout_init;
                             }
                             else {
                                 if (SendFatalAlertOnly(ssl, ret)
-                                        == SOCKET_ERROR_E) {
+                                        == WC_NO_ERR_TRACE(SOCKET_ERROR_E)) {
                                     ret = SOCKET_ERROR_E;
                                 }
                             }
@@ -21417,7 +21778,8 @@ default:
                                             &ssl->buffers.inputBuffer.idx,
                                             ssl->buffers.inputBuffer.length);
                         if (ret != 0) {
-                            if (SendFatalAlertOnly(ssl, ret) == SOCKET_ERROR_E)
+                            if (SendFatalAlertOnly(ssl, ret) ==
+                                WC_NO_ERR_TRACE(SOCKET_ERROR_E))
                                 ret = SOCKET_ERROR_E;
                         }
 #else
@@ -21457,7 +21819,7 @@ default:
                      * Current message should have been DtlsMsgStore'ed and
                      * should be processed with DtlsMsgDrain */
                             && (!ssl->options.dtls
-                                || ret != WC_PENDING_E)
+                                || ret != WC_NO_ERR_TRACE(WC_PENDING_E))
 #endif
                     ) {
                         WOLFSSL_ERROR(ret);
@@ -21570,7 +21932,8 @@ default:
                         /* Check for duplicate CCS message in DTLS mode.
                          * DTLS allows for duplicate messages, and it should be
                          * skipped. Also skip if out of order. */
-                            if (ret != DUPLICATE_MSG_E && ret != OUT_OF_ORDER_E)
+                            if (ret != WC_NO_ERR_TRACE(DUPLICATE_MSG_E) &&
+                                ret != WC_NO_ERR_TRACE(OUT_OF_ORDER_E))
                                 return ret;
                             /* Reset error */
                             ret = 0;
@@ -21665,7 +22028,7 @@ default:
                         defined(HAVE_SECURE_RENEGOTIATION)
                         /* Not really an error. We will return after cleaning
                          * up the processReply state. */
-                        if (ret != APP_DATA_READY)
+                        if (ret != WC_NO_ERR_TRACE(APP_DATA_READY))
                     #endif
                             return ret;
                     }
@@ -21794,7 +22157,7 @@ default:
 #endif
 #if defined(WOLFSSL_DTLS13) || defined(HAVE_SECURE_RENEGOTIATION)
             /* Signal to user that we have application data ready to read */
-            if (ret == APP_DATA_READY)
+            if (ret == WC_NO_ERR_TRACE(APP_DATA_READY))
                 return ret;
 #endif
             /* It is safe to shrink the input buffer here now. local vars will
@@ -21868,7 +22231,7 @@ int SendChangeCipher(WOLFSSL* ssl)
         input[0] = 1;  /* turn it on */
     #ifdef WOLFSSL_DTLS
         if (IsDtlsNotSctpMode(ssl) &&
-                (ret = DtlsMsgPoolSave(ssl, input, inputSz, change_cipher_hs)) != 0) {
+                (ret = DtlsMsgPoolSave(ssl, input, (word32)inputSz, change_cipher_hs)) != 0) {
             return ret;
         }
     #endif
@@ -21881,7 +22244,7 @@ int SendChangeCipher(WOLFSSL* ssl)
     #ifdef WOLFSSL_DTLS
     else {
         if (IsDtlsNotSctpMode(ssl)) {
-            if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, change_cipher_hs)) != 0)
+            if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, change_cipher_hs)) != 0)
                 return ret;
             DtlsSEQIncrement(ssl, CUR_ORDER);
         }
@@ -21985,7 +22348,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret = wc_Md5Final(&md5, result);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* TODO: Make non-blocking */
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             ret = wc_AsyncWait(ret, &md5.asyncDev, WC_ASYNC_FLAG_NONE);
         }
     #endif
@@ -22005,7 +22368,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret =  wc_Md5Final(&md5, digest);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* TODO: Make non-blocking */
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             ret = wc_AsyncWait(ret, &md5.asyncDev, WC_ASYNC_FLAG_NONE);
         }
     #endif
@@ -22035,7 +22398,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret = wc_ShaFinal(&sha, result);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* TODO: Make non-blocking */
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             ret = wc_AsyncWait(ret, &sha.asyncDev, WC_ASYNC_FLAG_NONE);
         }
     #endif
@@ -22055,7 +22418,7 @@ static int SSL_hmac(WOLFSSL* ssl, byte* digest, const byte* in, word32 sz,
         ret =  wc_ShaFinal(&sha, digest);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* TODO: Make non-blocking */
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             ret = wc_AsyncWait(ret, &sha.asyncDev, WC_ASYNC_FLAG_NONE);
         }
     #endif
@@ -22288,7 +22651,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
         args = &ssl->async->buildArgs;
 
         ret = wolfSSL_AsyncPop(ssl, &ssl->options.buildMsgState);
-        if (ret != WC_NO_PENDING_E) {
+        if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
             /* Check for error */
             if (ret < 0)
                 goto exit_buildmsg;
@@ -22302,7 +22665,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
 
     /* Reset state */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_NO_PENDING_E)
+    if (ret == WC_NO_ERR_TRACE(WC_NO_PENDING_E))
 #endif
     {
         ret = 0;
@@ -22531,7 +22894,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
             {
                 if (ssl->ctx->MacEncryptCb) {
                     ret = ssl->ctx->MacEncryptCb(ssl, output + args->idx,
-                                    output + args->headerSz + args->ivSz, inSz,
+                                    output + args->headerSz + args->ivSz, (unsigned int)inSz,
                                     type, 0, output + args->headerSz,
                                     output + args->headerSz, args->size,
                                     ssl->MacEncryptCtx);
@@ -22563,7 +22926,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
                 #endif
 
                     ret = ssl->hmac(ssl, hmac,
-                                     output + args->headerSz + args->ivSz, inSz,
+                                     output + args->headerSz + args->ivSz, (word32)inSz,
                                      -1, type, 0, epochOrder);
                     XMEMCPY(output + args->idx, hmac, args->digestSz);
 
@@ -22575,7 +22938,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
             #endif
                 {
                     ret = ssl->hmac(ssl, output + args->idx, output +
-                                args->headerSz + args->ivSz, inSz, -1, type, 0, epochOrder);
+                                args->headerSz + args->ivSz, (word32)inSz, -1, type, 0, epochOrder);
                 }
             }
         #endif /* WOLFSSL_AEAD_ONLY */
@@ -22636,7 +22999,7 @@ int BuildMessage(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
 
             if (ret != 0) {
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret != WC_PENDING_E)
+                if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
             #endif
                 {
                     /* Zeroize plaintext. */
@@ -22713,7 +23076,7 @@ exit_buildmsg:
     WOLFSSL_LEAVE("BuildMessage", ret);
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         return ret;
     }
 #endif
@@ -22728,7 +23091,7 @@ exit_buildmsg:
 
     /* return sz on success */
     if (ret == 0) {
-        ret = args->sz;
+        ret = (int)args->sz;
     }
     else {
         WOLFSSL_ERROR_VERBOSE(ret);
@@ -22925,7 +23288,7 @@ static int CreateOcspRequest(WOLFSSL* ssl, OcspRequest* request,
 
     InitDecodedCert(cert, certData, length, ssl->heap);
     /* TODO: Setup async support here */
-    ret = ParseCertRelative(cert, CERT_TYPE, VERIFY, SSL_CM(ssl));
+    ret = ParseCertRelative(cert, CERT_TYPE, VERIFY, SSL_CM(ssl), NULL);
     if (ret != 0) {
         WOLFSSL_MSG("ParseCert failed");
     }
@@ -23022,9 +23385,9 @@ int CreateOcspResponse(WOLFSSL* ssl, OcspRequest** ocspRequest,
                                ssl->heap);
 
         /* Suppressing, not critical */
-        if (ret == OCSP_CERT_REVOKED ||
-            ret == OCSP_CERT_UNKNOWN ||
-            ret == OCSP_LOOKUP_FAIL) {
+        if (ret == WC_NO_ERR_TRACE(OCSP_CERT_REVOKED) ||
+            ret == WC_NO_ERR_TRACE(OCSP_CERT_UNKNOWN) ||
+            ret == WC_NO_ERR_TRACE(OCSP_LOOKUP_FAIL)) {
             ret = 0;
         }
     }
@@ -23076,6 +23439,9 @@ int SendCertificate(WOLFSSL* ssl)
     int    ret = 0;
     word32 certSz, certChainSz, headerSz, listSz, payloadSz;
     word32 length, maxFragment;
+#ifdef HAVE_RPK
+    int    usingRpkTls12 = 0;
+#endif /* HAVE_RPK */
 
     WOLFSSL_START(WC_FUNC_CERTIFICATE_SEND);
     WOLFSSL_ENTER("SendCertificate");
@@ -23084,6 +23450,21 @@ int SendCertificate(WOLFSSL* ssl)
         WOLFSSL_MSG("Not sending certificate msg. Using PSK or ANON cipher.");
         return 0;  /* not needed */
     }
+
+#ifdef HAVE_RPK
+    if (!IsAtLeastTLSv1_3(ssl->version)) {
+        /* If this is (D)TLS1.2 and RPK, then single cert, not list. */
+        if (ssl->options.side == WOLFSSL_SERVER_END) {
+            if (ssl->options.rpkState.sending_ServerCertTypeCnt == 1 &&
+                ssl->options.rpkState.sending_ServerCertTypes[0] == WOLFSSL_CERT_TYPE_RPK)
+                usingRpkTls12 = 1;
+        } else if (ssl->options.side == WOLFSSL_CLIENT_END) {
+            if (ssl->options.rpkState.sending_ClientCertTypeCnt == 1 &&
+                ssl->options.rpkState.sending_ClientCertTypes[0] == WOLFSSL_CERT_TYPE_RPK)
+                usingRpkTls12 = 1;
+        }
+    }
+#endif /* HAVE_RPK */
 
     if (ssl->options.sendVerify == SEND_BLANK_CERT) {
     #ifdef OPENSSL_EXTRA
@@ -23107,10 +23488,19 @@ int SendCertificate(WOLFSSL* ssl)
             return BUFFER_ERROR;
         }
         certSz = ssl->buffers.certificate->length;
-        headerSz = 2 * CERT_HEADER_SZ;
+#ifdef HAVE_RPK
+        if (usingRpkTls12) {
+            headerSz = 1 * CERT_HEADER_SZ;
+            listSz = certSz;
+        } else {
+#endif /* HAVE_RPK */
+            headerSz = 2 * CERT_HEADER_SZ;
+            listSz = certSz + CERT_HEADER_SZ;
+#ifdef HAVE_RPK
+        }
+#endif /* HAVE_RPK */
         /* list + cert size */
         length = certSz + headerSz;
-        listSz = certSz + CERT_HEADER_SZ;
 
         /* may need to send rest of chain, already has leading size(s) */
         if (certSz && ssl->buffers.certChain) {
@@ -23129,7 +23519,7 @@ int SendCertificate(WOLFSSL* ssl)
 
     maxFragment = MAX_RECORD_SIZE;
 
-    maxFragment = wolfSSL_GetMaxFragSize(ssl, maxFragment);
+    maxFragment = (word32)wolfSSL_GetMaxFragSize(ssl, (int)maxFragment);
 
     while (length > 0 && ret == 0) {
         byte*  output = NULL;
@@ -23203,12 +23593,18 @@ int SendCertificate(WOLFSSL* ssl)
             }
 
             /* list total */
-            c32to24(listSz, output + i);
-            if (ssl->options.dtls || !IsEncryptionOn(ssl, 1))
-                HashRaw(ssl, output + i, CERT_HEADER_SZ);
-            i += CERT_HEADER_SZ;
-            length -= CERT_HEADER_SZ;
-            fragSz -= CERT_HEADER_SZ;
+#ifdef HAVE_RPK
+            if (!usingRpkTls12) {
+#endif /* HAVE_RPK */
+                c32to24(listSz, output + i);
+                if (ssl->options.dtls || !IsEncryptionOn(ssl, 1))
+                    HashRaw(ssl, output + i, CERT_HEADER_SZ);
+                i += CERT_HEADER_SZ;
+                length -= CERT_HEADER_SZ;
+                fragSz -= CERT_HEADER_SZ;
+#ifdef HAVE_RPK
+            }
+#endif /* HAVE_RPK */
             if (certSz) {
                 c32to24(certSz, output + i);
                 if (ssl->options.dtls || !IsEncryptionOn(ssl, 1))
@@ -23218,10 +23614,10 @@ int SendCertificate(WOLFSSL* ssl)
                 fragSz -= CERT_HEADER_SZ;
 
                 if (ssl->options.dtls || !IsEncryptionOn(ssl, 1)) {
-                    HashRaw(ssl, ssl->buffers.certificate->buffer, certSz);
+                    HashRaw(ssl, ssl->buffers.certificate->buffer, (int)certSz);
                     if (certChainSz)
                         HashRaw(ssl, ssl->buffers.certChain->buffer,
-                                      certChainSz);
+                                      (int)certChainSz);
                 }
             }
         }
@@ -23260,7 +23656,7 @@ int SendCertificate(WOLFSSL* ssl)
 
         if (IsEncryptionOn(ssl, 1)) {
             byte* input = NULL;
-            int   inputSz = i; /* build msg adds rec hdr */
+            int   inputSz = (int)i; /* build msg adds rec hdr */
             int   recordHeaderSz = RECORD_HEADER_SZ;
 
             if (ssl->options.dtls)
@@ -23289,7 +23685,7 @@ int SendCertificate(WOLFSSL* ssl)
                                                               handshake, 1, 0, 0, CUR_ORDER);
             else /* DTLS 1.2 has to ignore fragmentation in hashing so we need to
                   * calculate the hash ourselves above */ {
-                if ((ret = DtlsMsgPoolSave(ssl, input, inputSz, certificate)) != 0) {
+                if ((ret = DtlsMsgPoolSave(ssl, input, (word32)inputSz, certificate)) != 0) {
                     XFREE(input, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
                     return ret;
                 }
@@ -23304,10 +23700,10 @@ int SendCertificate(WOLFSSL* ssl)
                 return sendSz;
         }
         else {
-            sendSz = i;
+            sendSz = (int)i;
         #ifdef WOLFSSL_DTLS
             if (IsDtlsNotSctpMode(ssl)) {
-                if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, certificate)) != 0)
+                if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, certificate)) != 0)
                     return ret;
             }
             if (ssl->options.dtls)
@@ -23420,7 +23816,7 @@ int SendCertificateRequest(WOLFSSL* ssl)
     /* get output buffer */
     output = GetOutputBuffer(ssl);
 
-    AddHeaders(output, reqSz, certificate_request, ssl);
+    AddHeaders(output, (word32)reqSz, certificate_request, ssl);
 
     /* write to output */
     output[i++] = (byte)typeTotal;  /* # of types */
@@ -23487,7 +23883,7 @@ int SendCertificateRequest(WOLFSSL* ssl)
 
         if (IsEncryptionOn(ssl, 1)) {
             byte* input = NULL;
-            int   inputSz = i; /* build msg adds rec hdr */
+            int   inputSz = (int)i; /* build msg adds rec hdr */
             int   recordHeaderSz = RECORD_HEADER_SZ;
 
             if (ssl->options.dtls)
@@ -23506,7 +23902,7 @@ int SendCertificateRequest(WOLFSSL* ssl)
             XMEMCPY(input, output + recordHeaderSz, inputSz);
             #ifdef WOLFSSL_DTLS
             if (IsDtlsNotSctpMode(ssl) &&
-                    (ret = DtlsMsgPoolSave(ssl, input, inputSz, certificate_request)) != 0) {
+                    (ret = DtlsMsgPoolSave(ssl, input, (word32)inputSz, certificate_request)) != 0) {
                 XFREE(input, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
                 return ret;
             }
@@ -23518,10 +23914,10 @@ int SendCertificateRequest(WOLFSSL* ssl)
             if (sendSz < 0)
                 return sendSz;
         } else {
-            sendSz = i;
+            sendSz = (int)i;
             #ifdef WOLFSSL_DTLS
                 if (IsDtlsNotSctpMode(ssl)) {
-                    if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, certificate_request)) != 0)
+                    if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, certificate_request)) != 0)
                         return ret;
                 }
                 if (ssl->options.dtls)
@@ -23565,6 +23961,7 @@ static int BuildCertificateStatus(WOLFSSL* ssl, byte type, buffer* status,
     byte*  output  = NULL;
     word32 idx     = RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ;
     word32 length  = ENUM_LEN;
+    word32 headerSz= idx;
     int    sendSz  = 0;
     int    ret     = 0;
     int    i       = 0;
@@ -23584,88 +23981,42 @@ static int BuildCertificateStatus(WOLFSSL* ssl, byte type, buffer* status,
         default:
             return 0;
     }
+#ifdef WOLFSSL_DTLS
+    if (ssl->options.dtls) {
+        headerSz = idx = DTLS_RECORD_HEADER_SZ + DTLS_HANDSHAKE_HEADER_SZ;
+        sendSz  = idx + length;
 
-    sendSz = idx + length;
+    } else
+#endif
+    sendSz = (int)(idx + length);
 
     if (ssl->keys.encryptionOn)
         sendSz += MAX_MSG_EXTRA;
 
-    /* Set this in case CheckAvailableSize returns a WANT_WRITE so that state
-     * is not advanced yet */
-    ssl->options.buildingMsg = 1;
+    output =(byte*)XMALLOC(sendSz, ssl->heap, DYNAMIC_TYPE_OCSP);
+    if (output == NULL)
+        return MEMORY_E;
 
-    if ((ret = CheckAvailableSize(ssl, sendSz)) == 0) {
-        output = GetOutputBuffer(ssl);
+    AddHeaders(output, length, certificate_status, ssl);
 
-        AddHeaders(output, length, certificate_status, ssl);
+    output[idx++] = type;
 
-        output[idx++] = type;
-
-        if (type == WOLFSSL_CSR2_OCSP_MULTI) {
-            c32to24(length - (ENUM_LEN + OPAQUE24_LEN), output + idx);
-            idx += OPAQUE24_LEN;
-        }
-
-        for (i = 0; i < count; i++) {
-            c32to24(status[i].length, output + idx);
-            idx += OPAQUE24_LEN;
-
-            XMEMCPY(output + idx, status[i].buffer, status[i].length);
-            idx += status[i].length;
-        }
-
-        if (IsEncryptionOn(ssl, 1)) {
-            byte* input;
-            int   inputSz = idx; /* build msg adds rec hdr */
-            int   recordHeaderSz = RECORD_HEADER_SZ;
-
-            if (ssl->options.dtls)
-                recordHeaderSz += DTLS_RECORD_EXTRA;
-            inputSz -= recordHeaderSz;
-            input = (byte*)XMALLOC(inputSz, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
-            if (input == NULL)
-                return MEMORY_E;
-
-            XMEMCPY(input, output + recordHeaderSz, inputSz);
-            #ifdef WOLFSSL_DTLS
-                ret = DtlsMsgPoolSave(ssl, input, inputSz, certificate_status);
-            #endif
-            if (ret == 0)
-                sendSz = BuildMessage(ssl, output, sendSz, input, inputSz,
-                                      handshake, 1, 0, 0, CUR_ORDER);
-            XFREE(input, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
-
-            if (sendSz < 0)
-                ret = sendSz;
-        }
-        else {
-            #ifdef WOLFSSL_DTLS
-                if (ret == 0 && IsDtlsNotSctpMode(ssl))
-                    ret = DtlsMsgPoolSave(ssl, output, sendSz, certificate_status);
-                if (ret == 0 && ssl->options.dtls)
-                    DtlsSEQIncrement(ssl, CUR_ORDER);
-            #endif
-            ret = HashOutput(ssl, output, sendSz, 0);
-        }
-
-    #if defined(WOLFSSL_CALLBACKS) || defined(OPENSSL_EXTRA)
-        if (ret == 0 && ssl->hsInfoOn)
-            AddPacketName(ssl, "CertificateStatus");
-        if (ret == 0 && ssl->toInfoOn) {
-            ret = AddPacketInfo(ssl, "CertificateStatus", handshake, output,
-                    sendSz, WRITE_PROTO, 0, ssl->heap);
-            if (ret != 0)
-                return ret;
-        }
-    #endif
-
-        if (ret == 0) {
-            ssl->options.buildingMsg = 0;
-            ssl->buffers.outputBuffer.length += sendSz;
-            if (!ssl->options.groupMessages)
-                ret = SendBuffered(ssl);
-        }
+    if (type == WOLFSSL_CSR2_OCSP_MULTI) {
+        c32to24(length - (ENUM_LEN + OPAQUE24_LEN), output + idx);
+        idx += OPAQUE24_LEN;
     }
+
+    for (i = 0; i < count; i++) {
+        c32to24(status[i].length, output + idx);
+        idx += OPAQUE24_LEN;
+
+        XMEMCPY(output + idx, status[i].buffer, status[i].length);
+        idx += status[i].length;
+    }
+    /* Send Message. Handled message fragmentation in the function if needed */
+    ret = SendHandshakeMsg(ssl, output, (sendSz - headerSz), certificate_status,
+                "Certificate Status");
+    XFREE(output, ssl->heap, DYNAMIC_TYPE_OCSP);
 
     WOLFSSL_LEAVE("BuildCertificateStatus", ret);
     return ret;
@@ -23718,7 +24069,8 @@ int SendCertificateStatus(WOLFSSL* ssl)
             }
 
             /* Let's not error out the connection if we can't verify our cert */
-            if (ret == ASN_SELF_SIGNED_E || ret == ASN_NO_SIGNER_E)
+            if (ret == WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E) ||
+                ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E))
                 ret = 0;
 
             if (response.buffer) {
@@ -23801,9 +24153,9 @@ int SendCertificateStatus(WOLFSSL* ssl)
                                         request, &responses[i + 1], ssl->heap);
 
                             /* Suppressing, not critical */
-                            if (ret == OCSP_CERT_REVOKED ||
-                                ret == OCSP_CERT_UNKNOWN ||
-                                ret == OCSP_LOOKUP_FAIL) {
+                            if (ret == WC_NO_ERR_TRACE(OCSP_CERT_REVOKED) ||
+                                ret == WC_NO_ERR_TRACE(OCSP_CERT_UNKNOWN) ||
+                                ret == WC_NO_ERR_TRACE(OCSP_LOOKUP_FAIL)) {
                                 ret = 0;
                             }
 
@@ -23827,9 +24179,9 @@ int SendCertificateStatus(WOLFSSL* ssl)
                                            request, &responses[++i], ssl->heap);
 
                     /* Suppressing, not critical */
-                    if (ret == OCSP_CERT_REVOKED ||
-                        ret == OCSP_CERT_UNKNOWN ||
-                        ret == OCSP_LOOKUP_FAIL) {
+                    if (ret == WC_NO_ERR_TRACE(OCSP_CERT_REVOKED) ||
+                        ret == WC_NO_ERR_TRACE(OCSP_CERT_UNKNOWN) ||
+                        ret == WC_NO_ERR_TRACE(OCSP_LOOKUP_FAIL)) {
                         ret = 0;
                     }
                 }
@@ -23850,7 +24202,8 @@ int SendCertificateStatus(WOLFSSL* ssl)
             }
 
             /* Let's not error out the connection if we can't verify our cert */
-            if (ret == ASN_SELF_SIGNED_E || ret == ASN_NO_SIGNER_E)
+            if (ret == WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E) ||
+                ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E))
                 ret = 0;
 
             break;
@@ -24104,7 +24457,8 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
     }
 
     /* don't allow write after decrypt or mac error */
-    if (ssl->error == VERIFY_MAC_ERROR || ssl->error == DECRYPT_ERROR) {
+    if (ssl->error == WC_NO_ERR_TRACE(VERIFY_MAC_ERROR) ||
+        ssl->error == WC_NO_ERR_TRACE(DECRYPT_ERROR)) {
         /* For DTLS allow these possible errors and allow the session
             to continue despite them */
         if (ssl->options.dtls) {
@@ -24143,7 +24497,7 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
         if ( (err = wolfSSL_negotiate(ssl)) != WOLFSSL_SUCCESS) {
         #ifdef WOLFSSL_ASYNC_CRYPT
             /* if async would block return WANT_WRITE */
-            if (ssl->error == WC_PENDING_E) {
+            if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 return WOLFSSL_CBIO_ERR_WANT_WRITE;
             }
         #endif
@@ -24160,8 +24514,8 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
         WOLFSSL_MSG("output buffer was full, trying to send again");
         if ( (ssl->error = SendBuffered(ssl)) < 0) {
             WOLFSSL_ERROR(ssl->error);
-            if (ssl->error == SOCKET_ERROR_E && (ssl->options.connReset ||
-                                                 ssl->options.isClosed)) {
+            if (ssl->error == WC_NO_ERR_TRACE(SOCKET_ERROR_E) &&
+                (ssl->options.connReset || ssl->options.isClosed)) {
                 ssl->error = SOCKET_PEER_CLOSED_E;
                 WOLFSSL_ERROR(ssl->error);
                 return 0;  /* peer reset or closed */
@@ -24307,7 +24661,7 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
         }
         if (sendSz < 0) {
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (sendSz == WC_PENDING_E)
+            if (sendSz == WC_NO_ERR_TRACE(WC_PENDING_E))
                 ssl->error = sendSz;
         #endif
             return BUILD_MSG_ERROR;
@@ -24324,8 +24678,8 @@ int SendData(WOLFSSL* ssl, const void* data, int sz)
                doesn't present like WANT_WRITE */
             ssl->buffers.plainSz  = buffSz;
             ssl->buffers.prevSent = sent;
-            if (ssl->error == SOCKET_ERROR_E && (ssl->options.connReset ||
-                                                 ssl->options.isClosed)) {
+            if (ssl->error == WC_NO_ERR_TRACE(SOCKET_ERROR_E) &&
+                (ssl->options.connReset || ssl->options.isClosed)) {
                 ssl->error = SOCKET_PEER_CLOSED_E;
                 WOLFSSL_ERROR(ssl->error);
                 return 0;  /* peer reset or closed */
@@ -24361,9 +24715,9 @@ int ReceiveData(WOLFSSL* ssl, byte* output, int sz, int peek)
     if (ssl->options.dtls) {
         /* In DTLS mode, we forgive some errors and allow the session
          * to continue despite them. */
-        if (ssl->error == VERIFY_MAC_ERROR ||
-            ssl->error == DECRYPT_ERROR ||
-            ssl->error == DTLS_SIZE_ERROR) {
+        if (ssl->error == WC_NO_ERR_TRACE(VERIFY_MAC_ERROR) ||
+            ssl->error == WC_NO_ERR_TRACE(DECRYPT_ERROR) ||
+            ssl->error == WC_NO_ERR_TRACE(DTLS_SIZE_ERROR)) {
 
             ssl->error = 0;
         }
@@ -24395,7 +24749,7 @@ int ReceiveData(WOLFSSL* ssl, byte* output, int sz, int peek)
             if ( (err = wolfSSL_negotiate(ssl)) != WOLFSSL_SUCCESS) {
             #ifdef WOLFSSL_ASYNC_CRYPT
                 /* if async would block return WANT_WRITE */
-                if (ssl->error == WC_PENDING_E) {
+                if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                     return WOLFSSL_CBIO_ERR_WANT_READ;
                 }
             #endif
@@ -24422,7 +24776,7 @@ startScr:
                 WOLFSSL_MSG("Zero return, no more data coming");
                 return 0; /* no more data coming */
             }
-            if (ssl->error == SOCKET_ERROR_E) {
+            if (ssl->error == WC_NO_ERR_TRACE(SOCKET_ERROR_E)) {
                 if (ssl->options.connReset || ssl->options.isClosed) {
                     WOLFSSL_MSG("Peer reset or closed, connection done");
                     ssl->error = SOCKET_PEER_CLOSED_E;
@@ -24458,7 +24812,7 @@ startScr:
                 if ( (err = wolfSSL_negotiate(ssl)) != WOLFSSL_SUCCESS) {
                 #ifdef WOLFSSL_ASYNC_CRYPT
                     /* if async would block return WANT_WRITE */
-                    if (ssl->error == WC_PENDING_E) {
+                    if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                         return WOLFSSL_CBIO_ERR_WANT_READ;
                     }
                 #endif
@@ -24633,6 +24987,11 @@ static int SendAlert_ex(WOLFSSL* ssl, int severity, int type)
 #endif /* WOLFSSL_DTLS13 */
             {
                 AddRecordHeader(output, ALERT_SIZE, alert, ssl, CUR_ORDER);
+#ifdef WOLFSSL_DTLS
+                /* AddRecordHeader doesn't increment the seq number */
+                if (ssl->options.dtls)
+                    DtlsSEQIncrement(ssl, CUR_ORDER);
+#endif
             }
 
         output += RECORD_HEADER_SZ;
@@ -24722,6 +25081,10 @@ int SendAlert(WOLFSSL* ssl, int severity, int type)
 
     return SendAlert_ex(ssl, severity, type);
 }
+
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES_H
+#include <wolfssl/debug-untrace-error-codes.h>
+#endif
 
 const char* wolfSSL_ERR_reason_error_string(unsigned long e)
 {
@@ -25261,6 +25624,10 @@ const char* wolfSSL_ERR_reason_error_string(unsigned long e)
 #endif /* NO_ERROR_STRINGS */
 }
 
+#ifdef WOLFSSL_DEBUG_TRACE_ERROR_CODES
+#include <wolfssl/debug-trace-error-codes.h>
+#endif
+
 const char* wolfSSL_ERR_func_error_string(unsigned long e)
 {
     (void)e;
@@ -25299,7 +25666,7 @@ const char* wolfSSL_ERR_lib_error_string(unsigned long e)
 
 void SetErrorString(int error, char* str)
 {
-    XSTRNCPY(str, wolfSSL_ERR_reason_error_string(error), WOLFSSL_MAX_ERROR_SZ);
+    XSTRNCPY(str, wolfSSL_ERR_reason_error_string((unsigned long)error), WOLFSSL_MAX_ERROR_SZ);
     str[WOLFSSL_MAX_ERROR_SZ-1] = 0;
 }
 
@@ -26202,7 +26569,7 @@ const char* wolfSSL_get_cipher_name_iana(WOLFSSL* ssl)
 int GetCipherSuiteFromName(const char* name, byte* cipherSuite0,
                            byte* cipherSuite, int* flags)
 {
-    int           ret = BAD_FUNC_ARG;
+    int           ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     int           i;
     unsigned long len;
     const char*   nameDelim;
@@ -26273,8 +26640,11 @@ static int ParseCipherList(Suites* suites,
         return 0;
     }
 
-    if (next[0] == 0 || XSTRCMP(next, "ALL") == 0 ||
-        XSTRCMP(next, "DEFAULT") == 0 || XSTRCMP(next, "HIGH") == 0) {
+    if (next[0] == '\0' ||
+        XSTRCMP(next, "ALL") == 0 ||
+        XSTRCMP(next, "DEFAULT") == 0 ||
+        XSTRCMP(next, "HIGH") == 0)
+    {
         /* Add all ciphersuites except anonymous and null ciphers. Prefer RSA */
 #ifndef NO_RSA
         haveRSA = 1;
@@ -26286,7 +26656,8 @@ static int ParseCipherList(Suites* suites,
                 0,
 #endif
                 haveRSA, 1, 1, !haveRSA, 1, haveRSA, !haveRSA, 1, 1, 0, 0,
-                side);
+                side
+        );
         return 1; /* wolfSSL default */
     }
 
@@ -26306,6 +26677,8 @@ static int ParseCipherList(Suites* suites,
             if (length > currLen) {
                 length = currLen;
             }
+            if (currLen == 0)
+                break;
         }
 
     #if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
@@ -26336,7 +26709,7 @@ static int ParseCipherList(Suites* suites,
                         substrCurrent[length] = '\0';
                     }
                     else {
-                        length = (int)XSTRLEN(substrCurrent);
+                        length = (word32)XSTRLEN(substrCurrent);
                     }
 
                     /* check if is a public key type */
@@ -26559,14 +26932,12 @@ static int ParseCipherList(Suites* suites,
                                                              defined(HAVE_ED448)
                     haveSig |= SIG_ECDSA;
                 #endif
-                #if defined(HAVE_PQC)
                 #ifdef HAVE_FALCON
                     haveSig |= SIG_FALCON;
                 #endif /* HAVE_FALCON */
                 #ifdef HAVE_DILITHIUM
                     haveSig |= SIG_DILITHIUM;
                 #endif /* HAVE_DILITHIUM */
-                #endif /* HAVE_PQC */
                 }
                 else
             #ifdef BUILD_TLS_SM4_GCM_SM3
@@ -26629,7 +27000,7 @@ static int ParseCipherList(Suites* suites,
             }
         }
     }
-    while (next++); /* ++ needed to skip ':' */
+    while (next++); /* increment to skip ':' */
 
     if (ret) {
         int keySz = 0;
@@ -26659,7 +27030,7 @@ static int ParseCipherList(Suites* suites,
     #endif
         {
             suites->suiteSz   = (word16)idx;
-            InitSuitesHashSigAlgo_ex2(suites->hashSigAlgo, haveSig, 1, keySz,
+            InitSuitesHashSigAlgo(suites->hashSigAlgo, haveSig, 1, keySz,
                  &suites->hashSigAlgoSz);
         }
 
@@ -26678,7 +27049,9 @@ static int ParseCipherList(Suites* suites,
         suites->setSuites = 1;
     }
 
+#ifdef NO_CERTS
     (void)privateKeySz;
+#endif
 
     return ret;
 }
@@ -26796,14 +27169,12 @@ int SetCipherListFromBytes(WOLFSSL_CTX* ctx, Suites* suites, const byte* list,
         #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
             haveECDSAsig = 1;
         #endif
-        #if defined(HAVE_PQC)
         #ifdef HAVE_FALCON
             haveFalconSig = 1;
         #endif /* HAVE_FALCON */
         #ifdef HAVE_DILITHIUM
             haveDilithiumSig = 1;
         #endif /* HAVE_DILITHIUM */
-        #endif /* HAVE_PQC */
         }
         else
     #endif /* WOLFSSL_TLS13 */
@@ -26843,7 +27214,7 @@ int SetCipherListFromBytes(WOLFSSL_CTX* ctx, Suites* suites, const byte* list,
         haveSig |= haveFalconSig ? SIG_FALCON : 0;
         haveSig |= haveDilithiumSig ? SIG_DILITHIUM : 0;
         haveSig |= haveAnon ? SIG_ANON : 0;
-        InitSuitesHashSigAlgo_ex2(suites->hashSigAlgo, haveSig, 1, keySz,
+        InitSuitesHashSigAlgo(suites->hashSigAlgo, haveSig, 1, keySz,
             &suites->hashSigAlgoSz);
 #ifdef HAVE_RENEGOTIATION_INDICATION
         if (ctx->method->side == WOLFSSL_CLIENT_END) {
@@ -27044,7 +27415,6 @@ static int MatchSigAlgo(WOLFSSL* ssl, int sigAlgo)
         return sigAlgo == ed448_sa_algo;
     }
 #endif
-#ifdef HAVE_PQC
 #ifdef HAVE_FALCON
     if (ssl->pkCurveOID == CTC_FALCON_LEVEL1) {
         /* Certificate has Falcon level 1 key, only match with Falcon level 1
@@ -27071,7 +27441,6 @@ static int MatchSigAlgo(WOLFSSL* ssl, int sigAlgo)
         return sigAlgo == dilithium_level5_sa_algo;
     }
 #endif /* HAVE_DILITHIUM */
-#endif /* HAVE_PQC */
 #ifdef WC_RSA_PSS
     /* RSA certificate and PSS sig alg. */
     if (ssl->options.sigAlgo == rsa_sa_algo) {
@@ -27122,10 +27491,43 @@ static byte MinHashAlgo(WOLFSSL* ssl)
     return sha_mac;
 }
 
-int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
+/* Check if a given peer hashSigAlgo is supported in our ssl->suites or
+ * ssl->ctx->suites.
+ *
+ * Returns 1 on match.
+ * Returns 0 otherwise.
+ * */
+static int SupportedHashSigAlgo(WOLFSSL* ssl, const byte * hashSigAlgo)
+{
+    const Suites * suites = NULL;
+    word32         i = 0;
+
+    if (ssl == NULL || hashSigAlgo == NULL) {
+        return 0;
+    }
+
+    suites = WOLFSSL_SUITES(ssl);
+
+    if (suites == NULL || suites->hashSigAlgoSz == 0) {
+        return 0;
+    }
+
+    for (i = 0; (i+1) < suites->hashSigAlgoSz; i += HELLO_EXT_SIGALGO_SZ) {
+        if (XMEMCMP(&suites->hashSigAlgo[i], hashSigAlgo,
+                    HELLO_EXT_SIGALGO_SZ) == 0) {
+            /* Match found. */
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz,
+                    int matchSuites)
 {
     word32 i;
-    int ret = MATCH_SUITE_ERROR;
+    int ret = WC_NO_ERR_TRACE(MATCH_SUITE_ERROR);
     byte minHash;
 
     /* set defaults */
@@ -27163,6 +27565,14 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
         if (!MatchSigAlgo(ssl, sigAlgo))
             continue;
 
+        if (matchSuites) {
+            /* Keep looking if peer algorithm isn't supported in our ssl->suites
+             * or ssl->ctx->suites. */
+            if (!SupportedHashSigAlgo(ssl, &hashSigAlgo[i])) {
+                continue;
+            }
+        }
+
     #ifdef HAVE_ED25519
         if (ssl->pkCurveOID == ECC_ED25519_OID) {
             /* Matched Ed25519 - set chosen and finished. */
@@ -27181,7 +27591,6 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
             break;
         }
     #endif
-    #if defined(HAVE_PQC)
     #if defined(HAVE_FALCON)
         if (ssl->pkCurveOID == CTC_FALCON_LEVEL1 ||
             ssl->pkCurveOID == CTC_FALCON_LEVEL5 ) {
@@ -27203,7 +27612,6 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
             break;
         }
     #endif /* HAVE_DILITHIUM */
-    #endif /* HAVE_PQC */
 
     #if defined(WOLFSSL_ECDSA_MATCH_HASH) && defined(USE_ECDSA_KEYSZ_HASH_ALGO)
         #error "WOLFSSL_ECDSA_MATCH_HASH and USE_ECDSA_KEYSZ_HASH_ALGO cannot "
@@ -27564,7 +27972,7 @@ int PickHashSigAlgo(WOLFSSL* ssl, const byte* hashSigAlgo, word32 hashSigAlgoSz)
 int CreateDevPrivateKey(void** pkey, byte* data, word32 length, int hsType,
                         int label, int id, void* heap, int devId)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 
     if (hsType == DYNAMIC_TYPE_RSA) {
 #ifndef NO_RSA
@@ -27579,7 +27987,7 @@ int CreateDevPrivateKey(void** pkey, byte* data, word32 length, int hsType,
             ret = wc_InitRsaKey_Label(rsaKey, (char*)data, heap, devId);
         }
         else if (id) {
-            ret = wc_InitRsaKey_Id(rsaKey, data, length, heap, devId);
+            ret = wc_InitRsaKey_Id(rsaKey, data, (int)length, heap, devId);
         }
         if (ret == 0) {
             *pkey = (void*)rsaKey;
@@ -27602,7 +28010,7 @@ int CreateDevPrivateKey(void** pkey, byte* data, word32 length, int hsType,
             ret = wc_ecc_init_label(ecKey, (char*)data, heap, devId);
         }
         else if (id) {
-            ret = wc_ecc_init_id(ecKey, data, length, heap, devId);
+            ret = wc_ecc_init_id(ecKey, data, (int)length, heap, devId);
         }
         if (ret == 0) {
             *pkey = (void*)ecKey;
@@ -27613,7 +28021,7 @@ int CreateDevPrivateKey(void** pkey, byte* data, word32 length, int hsType,
 #endif
     }
     else if (hsType == DYNAMIC_TYPE_DILITHIUM) {
-#if defined(HAVE_PQC) && defined(HAVE_DILITHIUM)
+#if defined(HAVE_DILITHIUM)
         dilithium_key* dilithiumKey;
 
         dilithiumKey = (dilithium_key*)XMALLOC(sizeof(dilithium_key), heap,
@@ -27638,7 +28046,7 @@ int CreateDevPrivateKey(void** pkey, byte* data, word32 length, int hsType,
 #endif
     }
     else if (hsType == DYNAMIC_TYPE_FALCON) {
-#if defined(HAVE_PQC) && defined(HAVE_FALCON)
+#if defined(HAVE_FALCON)
         falcon_key* falconKey;
 
         falconKey = (falcon_key*)XMALLOC(sizeof(falcon_key), heap,
@@ -27676,9 +28084,9 @@ int CreateDevPrivateKey(void** pkey, byte* data, word32 length, int hsType,
  * length  The length of a signature.
  * returns 0 on success, otherwise failure.
  */
-int DecodePrivateKey(WOLFSSL *ssl, word16* length)
+int DecodePrivateKey(WOLFSSL *ssl, word32* length)
 {
-    int      ret = BAD_FUNC_ARG;
+    int      ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     int      keySz;
     word32   idx;
 
@@ -27691,7 +28099,7 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
             || wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)
         #endif
         ) {
-            *length = (word16)GetPrivateKeySigSize(ssl);
+            *length = (word32)GetPrivateKeySigSize(ssl);
             return 0;
         }
         else
@@ -27709,9 +28117,12 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
             ssl->hsType = DYNAMIC_TYPE_RSA;
         else if (ssl->buffers.keyType == ecc_dsa_sa_algo)
             ssl->hsType = DYNAMIC_TYPE_ECC;
-        else if (ssl->buffers.keyType == falcon_level5_sa_algo)
+        else if ((ssl->buffers.keyType == falcon_level1_sa_algo) ||
+                 (ssl->buffers.keyType == falcon_level5_sa_algo))
             ssl->hsType = DYNAMIC_TYPE_FALCON;
-        else if (ssl->buffers.keyType == dilithium_level5_sa_algo)
+        else if ((ssl->buffers.keyType == dilithium_level2_sa_algo) ||
+                 (ssl->buffers.keyType == dilithium_level3_sa_algo) ||
+                 (ssl->buffers.keyType == dilithium_level5_sa_algo))
             ssl->hsType = DYNAMIC_TYPE_DILITHIUM;
         ret = AllocKey(ssl, ssl->hsType, &ssl->hsKey);
         if (ret != 0) {
@@ -27738,7 +28149,7 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
                 }
 
                 /* Return the maximum signature length. */
-                *length = (word16)ssl->buffers.keySz;
+                *length = (word32)ssl->buffers.keySz;
             }
     #else
             ret = NOT_COMPILED_IN;
@@ -27764,14 +28175,15 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
                 }
 
                 /* Return the maximum signature length. */
-                *length = (word16)wc_ecc_sig_size_calc(ssl->buffers.keySz);
+                *length = (word32)wc_ecc_sig_size_calc(ssl->buffers.keySz);
             }
     #else
             ret = NOT_COMPILED_IN;
     #endif
         }
-        else if (ssl->buffers.keyType == falcon_level5_sa_algo) {
-    #if defined(HAVE_PQC) && defined(HAVE_FALCON)
+        else if ((ssl->buffers.keyType == falcon_level1_sa_algo) ||
+                 (ssl->buffers.keyType == falcon_level5_sa_algo)) {
+    #if defined(HAVE_FALCON)
             if (ssl->buffers.keyLabel) {
                 ret = wc_falcon_init_label((falcon_key*)ssl->hsKey,
                                            (char*)ssl->buffers.key->buffer,
@@ -27784,20 +28196,30 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
                                         ssl->buffers.keyDevId);
             }
             if (ret == 0) {
+                if (ssl->buffers.keyType == falcon_level1_sa_algo) {
+                    ret = wc_falcon_set_level((falcon_key*)ssl->hsKey, 1);
+                }
+                else if (ssl->buffers.keyType == falcon_level5_sa_algo) {
+                    ret = wc_falcon_set_level((falcon_key*)ssl->hsKey, 5);
+                }
+            }
+            if (ret == 0) {
                 if (ssl->buffers.keySz < ssl->options.minFalconKeySz) {
                     WOLFSSL_MSG("Falcon key size too small");
                     ERROR_OUT(FALCON_KEY_SIZE_E, exit_dpk);
                 }
 
                 /* Return the maximum signature length. */
-                *length = (word16)wc_falcon_sig_size((falcon_key*)ssl->hsKey);
+                *length = wc_falcon_sig_size((falcon_key*)ssl->hsKey);
             }
     #else
             ret = NOT_COMPILED_IN;
     #endif
         }
-        else if (ssl->buffers.keyType == dilithium_level5_sa_algo) {
-    #if defined(HAVE_PQC) && defined(HAVE_DILITHIUM)
+        else if ((ssl->buffers.keyType == dilithium_level2_sa_algo) ||
+                 (ssl->buffers.keyType == dilithium_level3_sa_algo) ||
+                 (ssl->buffers.keyType == dilithium_level5_sa_algo)) {
+    #if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN)
             if (ssl->buffers.keyLabel) {
                 ret = wc_dilithium_init_label((dilithium_key*)ssl->hsKey,
                                               (char*)ssl->buffers.key->buffer,
@@ -27810,13 +28232,24 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
                                         ssl->buffers.keyDevId);
             }
             if (ret == 0) {
+                if (ssl->buffers.keyType == dilithium_level2_sa_algo) {
+                    ret = wc_dilithium_set_level((dilithium_key*)ssl->hsKey, 2);
+                }
+                else if (ssl->buffers.keyType == dilithium_level3_sa_algo) {
+                    ret = wc_dilithium_set_level((dilithium_key*)ssl->hsKey, 3);
+                }
+                else if (ssl->buffers.keyType == dilithium_level5_sa_algo) {
+                    ret = wc_dilithium_set_level((dilithium_key*)ssl->hsKey, 5);
+                }
+            }
+            if (ret == 0) {
                 if (ssl->buffers.keySz < ssl->options.minDilithiumKeySz) {
                     WOLFSSL_MSG("Dilithium key size too small");
                     ERROR_OUT(DILITHIUM_KEY_SIZE_E, exit_dpk);
                 }
 
                 /* Return the maximum signature length. */
-                *length = (word16)wc_dilithium_sig_size(
+                *length = wc_dilithium_sig_size(
                                     (dilithium_key*)ssl->hsKey);
             }
     #else
@@ -27870,7 +28303,7 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
             }
 
             /* Return the maximum signature length. */
-            *length = (word16)keySz;
+            *length = (word32)keySz;
 
             goto exit_dpk;
         }
@@ -27919,6 +28352,12 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
                                      ssl->buffers.key->length);
         }
     #endif
+    #ifdef WOLFSSL_SM2
+        if ((ret == 0) && (ssl->buffers.keyType == sm2_sa_algo)) {
+            ret = wc_ecc_set_curve((ecc_key*)ssl->hsKey,
+                WOLFSSL_SM2_KEY_BITS / 8, ECC_SM2P256V1);
+        }
+    #endif
         if (ret == 0) {
             WOLFSSL_MSG("Using ECC private key");
 
@@ -27930,7 +28369,7 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
             }
 
             /* Return the maximum signature length. */
-            *length = (word16)wc_ecc_sig_size((ecc_key*)ssl->hsKey);
+            *length = (word32)wc_ecc_sig_size((ecc_key*)ssl->hsKey);
 
             goto exit_dpk;
         }
@@ -28050,7 +28489,6 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
         }
     }
 #endif /* HAVE_ED448 && HAVE_ED448_KEY_IMPORT */
-#if defined(HAVE_PQC)
 #if defined(HAVE_FALCON)
     #if !defined(NO_RSA) || defined(HAVE_ECC)
         FreeKey(ssl, ssl->hsType, (void**)&ssl->hsKey);
@@ -28104,19 +28542,21 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
             WOLFSSL_MSG("Using Falcon private key");
 
             /* Check it meets the minimum Falcon key size requirements. */
-            if (FALCON_MAX_KEY_SIZE < ssl->options.minFalconKeySz) {
+            keySz = wc_falcon_size((falcon_key*)ssl->hsKey);
+            if (keySz < ssl->options.minFalconKeySz) {
                 WOLFSSL_MSG("Falcon key size too small");
                 ERROR_OUT(FALCON_KEY_SIZE_E, exit_dpk);
             }
 
             /* Return the maximum signature length. */
-            *length = FALCON_MAX_SIG_SIZE;
+            *length = wc_falcon_sig_size((falcon_key*)ssl->hsKey);
 
             goto exit_dpk;
         }
     }
 #endif /* HAVE_FALCON */
-#if defined(HAVE_DILITHIUM)
+#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
+    !defined(WOLFSSL_DILITHIUM_NO_ASN1)
     #if !defined(NO_RSA) || defined(HAVE_ECC)
         FreeKey(ssl, ssl->hsType, (void**)&ssl->hsKey);
     #endif
@@ -28168,26 +28608,27 @@ int DecodePrivateKey(WOLFSSL *ssl, word16* length)
         /* Set start of data to beginning of buffer. */
         idx = 0;
         /* Decode the key assuming it is a Dilithium private key. */
-        ret = wc_dilithium_import_private_only(ssl->buffers.key->buffer,
-                                               ssl->buffers.key->length,
-                                               (dilithium_key*)ssl->hsKey);
+        ret = wc_Dilithium_PrivateKeyDecode(ssl->buffers.key->buffer,
+                                            &idx,
+                                            (dilithium_key*)ssl->hsKey,
+                                            ssl->buffers.key->length);
         if (ret == 0) {
             WOLFSSL_MSG("Using Dilithium private key");
 
             /* Check it meets the minimum Dilithium key size requirements. */
-            if (DILITHIUM_MAX_KEY_SIZE < ssl->options.minDilithiumKeySz) {
+            keySz = wc_dilithium_size((dilithium_key*)ssl->hsKey);
+            if (keySz < ssl->options.minDilithiumKeySz) {
                 WOLFSSL_MSG("Dilithium key size too small");
                 ERROR_OUT(DILITHIUM_KEY_SIZE_E, exit_dpk);
             }
 
             /* Return the maximum signature length. */
-            *length = DILITHIUM_MAX_SIG_SIZE;
+            *length = wc_dilithium_sig_size((dilithium_key*)ssl->hsKey);
 
             goto exit_dpk;
         }
     }
 #endif /* HAVE_DILITHIUM */
-#endif /* HAVE_PQC */
 
     (void)idx;
     (void)keySz;
@@ -28201,12 +28642,15 @@ exit_dpk:
     return ret;
 }
 
-#if defined(HAVE_PQC) && defined(WOLFSSL_DUAL_ALG_CERTS)
-/* This is just like the above, but only consider Falcon and Dilthium and
- * only for the alternative key; not the native key. */
-int DecodeAltPrivateKey(WOLFSSL *ssl, word16* length)
+#if defined(WOLFSSL_DUAL_ALG_CERTS)
+/* This is just like the above, but only consider RSA, ECC, Falcon and
+ * Dilthium; Furthermore, use the alternative key, not the native key.
+ */
+int DecodeAltPrivateKey(WOLFSSL *ssl, word32* length)
 {
-    int      ret = BAD_FUNC_ARG;
+    int      ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
+    int      keySz;
+    word32   idx;
 
     /* make sure alt private key exists */
     if (ssl->buffers.altKey == NULL || ssl->buffers.altKey->buffer == NULL) {
@@ -28214,8 +28658,282 @@ int DecodeAltPrivateKey(WOLFSSL *ssl, word16* length)
         ERROR_OUT(NO_PRIVATE_KEY, exit_dapk);
     }
 
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    wolfssl_priv_der_unblind(ssl->buffers.altKey, ssl->buffers.altKeyMask);
+#endif
+
+#ifdef WOLF_PRIVATE_KEY_ID
+    if (ssl->buffers.altKeyDevId != INVALID_DEVID &&
+        (ssl->buffers.altKeyId || ssl->buffers.altKeyLabel)) {
+        if (ssl->buffers.altKeyType == rsa_sa_algo)
+            ssl->hsAltType = DYNAMIC_TYPE_RSA;
+        else if (ssl->buffers.altKeyType == ecc_dsa_sa_algo)
+            ssl->hsAltType = DYNAMIC_TYPE_ECC;
+        else if ((ssl->buffers.altKeyType == falcon_level1_sa_algo) ||
+                 (ssl->buffers.altKeyType == falcon_level5_sa_algo))
+            ssl->hsAltType = DYNAMIC_TYPE_FALCON;
+        else if ((ssl->buffers.altKeyType == dilithium_level2_sa_algo) ||
+                 (ssl->buffers.altKeyType == dilithium_level3_sa_algo) ||
+                 (ssl->buffers.altKeyType == dilithium_level5_sa_algo))
+            ssl->hsAltType = DYNAMIC_TYPE_DILITHIUM;
+        ret = AllocKey(ssl, ssl->hsAltType, &ssl->hsAltKey);
+        if (ret != 0) {
+            goto exit_dapk;
+        }
+
+        if (ssl->buffers.altKeyType == rsa_sa_algo) {
+    #ifndef NO_RSA
+            if (ssl->buffers.altKeyLabel) {
+                ret = wc_InitRsaKey_Label((RsaKey*)ssl->hsAltKey,
+                                          (char*)ssl->buffers.altKey->buffer,
+                                          ssl->heap, ssl->buffers.altKeyDevId);
+            }
+            else if (ssl->buffers.altKeyId) {
+                ret = wc_InitRsaKey_Id((RsaKey*)ssl->hsAltKey,
+                                       ssl->buffers.altKey->buffer,
+                                       ssl->buffers.altKey->length, ssl->heap,
+                                       ssl->buffers.altKeyDevId);
+            }
+            if (ret == 0) {
+                if (ssl->buffers.altKeySz < ssl->options.minRsaKeySz) {
+                    WOLFSSL_MSG("RSA key size too small");
+                    ERROR_OUT(RSA_KEY_SIZE_E, exit_dapk);
+                }
+
+                /* Return the maximum signature length. */
+                *length = ssl->buffers.altKeySz;
+            }
+    #else
+            ret = NOT_COMPILED_IN;
+    #endif
+        }
+        else if (ssl->buffers.altKeyType == ecc_dsa_sa_algo) {
+    #ifdef HAVE_ECC
+            if (ssl->buffers.altKeyLabel) {
+                ret = wc_ecc_init_label((ecc_key*)ssl->hsAltKey,
+                                        (char*)ssl->buffers.altKey->buffer,
+                                        ssl->heap, ssl->buffers.altKeyDevId);
+            }
+            else if (ssl->buffers.altKeyId) {
+                ret = wc_ecc_init_id((ecc_key*)ssl->hsAltKey,
+                                     ssl->buffers.altKey->buffer,
+                                     ssl->buffers.altKey->length, ssl->heap,
+                                     ssl->buffers.altKeyDevId);
+            }
+            if (ret == 0) {
+                if (ssl->buffers.altKeySz < ssl->options.minEccKeySz) {
+                    WOLFSSL_MSG("ECC key size too small");
+                    ERROR_OUT(ECC_KEY_SIZE_E, exit_dapk);
+                }
+
+                /* Return the maximum signature length. */
+                *length = wc_ecc_sig_size_calc(ssl->buffers.altKeySz);
+            }
+    #else
+            ret = NOT_COMPILED_IN;
+    #endif
+        }
+        else if ((ssl->buffers.altKeyType == falcon_level1_sa_algo) ||
+                 (ssl->buffers.altKeyType == falcon_level5_sa_algo)) {
+    #if defined(HAVE_FALCON)
+            if (ssl->buffers.altKeyLabel) {
+                ret = wc_falcon_init_label((falcon_key*)ssl->hsAltKey,
+                                           (char*)ssl->buffers.altKey->buffer,
+                                           ssl->heap, ssl->buffers.altKeyDevId);
+            }
+            else if (ssl->buffers.altKeyId) {
+                ret = wc_falcon_init_id((falcon_key*)ssl->hsAltKey,
+                                        ssl->buffers.altKey->buffer,
+                                        ssl->buffers.altKey->length, ssl->heap,
+                                        ssl->buffers.altKeyDevId);
+            }
+            if (ret == 0) {
+                if (ssl->buffers.altKeyType == falcon_level1_sa_algo) {
+                    ret = wc_falcon_set_level((falcon_key*)ssl->hsAltKey, 1);
+                }
+                else if (ssl->buffers.altKeyType == falcon_level5_sa_algo) {
+                    ret = wc_falcon_set_level((falcon_key*)ssl->hsAltKey, 5);
+                }
+            }
+            if (ret == 0) {
+                if (ssl->buffers.altKeySz < ssl->options.minFalconKeySz) {
+                    WOLFSSL_MSG("Falcon key size too small");
+                    ERROR_OUT(FALCON_KEY_SIZE_E, exit_dapk);
+                }
+
+                /* Return the maximum signature length. */
+                *length = wc_falcon_sig_size((falcon_key*)ssl->hsAltKey);
+            }
+    #else
+            ret = NOT_COMPILED_IN;
+    #endif
+        }
+        else if ((ssl->buffers.altKeyType == dilithium_level2_sa_algo) ||
+                 (ssl->buffers.altKeyType == dilithium_level3_sa_algo) ||
+                 (ssl->buffers.altKeyType == dilithium_level5_sa_algo)) {
+    #if defined(HAVE_DILITHIUM)
+            if (ssl->buffers.altKeyLabel) {
+                ret = wc_dilithium_init_label((dilithium_key*)ssl->hsAltKey,
+                                        (char*)ssl->buffers.altKey->buffer,
+                                        ssl->heap, ssl->buffers.altKeyDevId);
+            }
+            else if (ssl->buffers.altKeyId) {
+                ret = wc_dilithium_init_id((dilithium_key*)ssl->hsAltKey,
+                                        ssl->buffers.altKey->buffer,
+                                        ssl->buffers.altKey->length, ssl->heap,
+                                        ssl->buffers.altKeyDevId);
+            }
+            if (ret == 0) {
+                if (ssl->buffers.altKeyType == dilithium_level2_sa_algo) {
+                    ret = wc_dilithium_set_level(
+                                        (dilithium_key*)ssl->hsAltKey, 2);
+                }
+                else if (ssl->buffers.altKeyType == dilithium_level3_sa_algo) {
+                    ret = wc_dilithium_set_level(
+                                        (dilithium_key*)ssl->hsAltKey, 3);
+                }
+                else if (ssl->buffers.altKeyType == dilithium_level5_sa_algo) {
+                    ret = wc_dilithium_set_level(
+                                        (dilithium_key*)ssl->hsAltKey, 5);
+                }
+            }
+            if (ret == 0) {
+                if (ssl->buffers.altKeySz < ssl->options.minDilithiumKeySz) {
+                    WOLFSSL_MSG("Dilithium key size too small");
+                    ERROR_OUT(DILITHIUM_KEY_SIZE_E, exit_dapk);
+                }
+
+                /* Return the maximum signature length. */
+                *length = wc_dilithium_sig_size(
+                                    (dilithium_key*)ssl->hsAltKey);
+            }
+    #else
+            ret = NOT_COMPILED_IN;
+    #endif
+        }
+        goto exit_dapk;
+    }
+#endif /* WOLF_PRIVATE_KEY_ID */
+
+#ifndef NO_RSA
+    if (ssl->buffers.altKeyType == rsa_sa_algo ||
+        ssl->buffers.altKeyType == 0) {
+        ssl->hsAltType = DYNAMIC_TYPE_RSA;
+        ret = AllocKey(ssl, ssl->hsAltType, &ssl->hsAltKey);
+        if (ret != 0) {
+            goto exit_dapk;
+        }
+
+        WOLFSSL_MSG("Trying RSA private key");
+
+        /* Set start of data to beginning of buffer. */
+        idx = 0;
+        /* Decode the key assuming it is an RSA private key. */
+        ret = wc_RsaPrivateKeyDecode(ssl->buffers.altKey->buffer, &idx,
+                    (RsaKey*)ssl->hsAltKey, ssl->buffers.altKey->length);
+    #ifdef WOLF_PRIVATE_KEY_ID
+        /* if using external key then allow using a public key */
+        if (ret != 0 && (ssl->devId != INVALID_DEVID
+        #ifdef HAVE_PK_CALLBACKS
+            || wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)
+        #endif
+        )) {
+            WOLFSSL_MSG("Trying RSA public key with crypto callbacks");
+            idx = 0;
+            ret = wc_RsaPublicKeyDecode(ssl->buffers.altKey->buffer, &idx,
+                        (RsaKey*)ssl->hsAltKey, ssl->buffers.altKey->length);
+        }
+    #endif
+        if (ret == 0) {
+            WOLFSSL_MSG("Using RSA private key");
+
+            /* It worked so check it meets minimum key size requirements. */
+            keySz = wc_RsaEncryptSize((RsaKey*)ssl->hsAltKey);
+            if (keySz < 0) { /* check if keySz has error case */
+                ERROR_OUT(keySz, exit_dapk);
+            }
+
+            if (keySz < ssl->options.minRsaKeySz) {
+                WOLFSSL_MSG("RSA key size too small");
+                ERROR_OUT(RSA_KEY_SIZE_E, exit_dapk);
+            }
+
+            /* Return the maximum signature length. */
+            *length = keySz;
+
+            goto exit_dapk;
+        }
+    }
+#endif /* !NO_RSA */
+
+#ifdef HAVE_ECC
+#ifndef NO_RSA
+    FreeKey(ssl, ssl->hsAltType, (void**)&ssl->hsAltKey);
+#endif /* !NO_RSA */
+
+    if (ssl->buffers.altKeyType == ecc_dsa_sa_algo ||
+        ssl->buffers.altKeyType == 0
+    #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
+         || ssl->buffers.altKeyType == sm2_sa_algo
+    #endif
+        ) {
+        ssl->hsAltType = DYNAMIC_TYPE_ECC;
+        ret = AllocKey(ssl, ssl->hsAltType, &ssl->hsAltKey);
+        if (ret != 0) {
+            goto exit_dapk;
+        }
+
+    #ifndef NO_RSA
+        WOLFSSL_MSG("Trying ECC private key, RSA didn't work");
+    #else
+        WOLFSSL_MSG("Trying ECC private key");
+    #endif
+
+        /* Set start of data to beginning of buffer. */
+        idx = 0;
+        /* Decode the key assuming it is an ECC private key. */
+        ret = wc_EccPrivateKeyDecode(ssl->buffers.altKey->buffer, &idx,
+                                     (ecc_key*)ssl->hsAltKey,
+                                     ssl->buffers.altKey->length);
+    #ifdef WOLF_PRIVATE_KEY_ID
+        /* if using external key then allow using a public key */
+        if (ret != 0 && (ssl->devId != INVALID_DEVID
+        #ifdef HAVE_PK_CALLBACKS
+            || wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)
+        #endif
+        )) {
+            WOLFSSL_MSG("Trying ECC public key with crypto callbacks");
+            idx = 0;
+            ret = wc_EccPublicKeyDecode(ssl->buffers.altKey->buffer, &idx,
+                                     (ecc_key*)ssl->hsAltKey,
+                                     ssl->buffers.altKey->length);
+        }
+    #endif
+        if (ret == 0) {
+            WOLFSSL_MSG("Using ECC private key");
+
+            /* Check it meets the minimum ECC key size requirements. */
+            keySz = wc_ecc_size((ecc_key*)ssl->hsAltKey);
+            if (keySz < ssl->options.minEccKeySz) {
+                WOLFSSL_MSG("ECC key size too small");
+                ERROR_OUT(ECC_KEY_SIZE_E, exit_dapk);
+            }
+
+            /* Return the maximum signature length. */
+            *length = wc_ecc_sig_size((ecc_key*)ssl->hsAltKey);
+
+            goto exit_dapk;
+        }
+    }
+#endif
+#if defined(HAVE_FALCON)
+    #if !defined(NO_RSA) || defined(HAVE_ECC)
+        FreeKey(ssl, ssl->hsAltType, (void**)&ssl->hsAltKey);
+    #endif
+
     if (ssl->buffers.altKeyType == falcon_level1_sa_algo ||
-        ssl->buffers.altKeyType == falcon_level5_sa_algo) {
+        ssl->buffers.altKeyType == falcon_level5_sa_algo ||
+        ssl->buffers.altKeyType == 0) {
 
         ssl->hsAltType = DYNAMIC_TYPE_FALCON;
         ret = AllocKey(ssl, ssl->hsAltType, &ssl->hsAltKey);
@@ -28230,14 +28948,25 @@ int DecodeAltPrivateKey(WOLFSSL *ssl, word16* length)
             ret = wc_falcon_set_level((falcon_key*)ssl->hsAltKey, 5);
         }
         else {
+            /* What if ssl->buffers.keyType is 0? We might want to do something
+             * more graceful here. */
             ret = ALGO_ID_E;
         }
 
         if (ret != 0) {
             goto exit_dapk;
         }
-        WOLFSSL_MSG("Trying Falcon private key");
 
+        #if defined(HAVE_ECC)
+            WOLFSSL_MSG("Trying Falcon private key, ECC didn't work");
+        #elif !defined(NO_RSA)
+            WOLFSSL_MSG("Trying Falcon private key, RSA didn't work");
+        #else
+            WOLFSSL_MSG("Trying Falcon private key");
+        #endif
+
+        /* Set start of data to beginning of buffer. */
+        idx = 0;
         /* Decode the key assuming it is a Falcon private key. */
         ret = wc_falcon_import_private_only(ssl->buffers.altKey->buffer,
                                             ssl->buffers.altKey->length,
@@ -28246,21 +28975,28 @@ int DecodeAltPrivateKey(WOLFSSL *ssl, word16* length)
             WOLFSSL_MSG("Using Falcon private key");
 
             /* Check it meets the minimum Falcon key size requirements. */
-            if (FALCON_MAX_KEY_SIZE < ssl->options.minFalconKeySz) {
+            keySz = wc_falcon_size((falcon_key*)ssl->hsAltKey);
+            if (keySz < ssl->options.minFalconKeySz) {
                 WOLFSSL_MSG("Falcon key size too small");
                 ERROR_OUT(FALCON_KEY_SIZE_E, exit_dapk);
             }
 
+            /* Return the maximum signature length. */
             *length = wc_falcon_sig_size((falcon_key*)ssl->hsAltKey);
 
             goto exit_dapk;
         }
     }
-    FreeKey(ssl, ssl->hsAltType, (void**)&ssl->hsAltKey);
+#endif /* HAVE_FALCON */
+#if defined(HAVE_DILITHIUM)
+    #if !defined(NO_RSA) || defined(HAVE_ECC)
+        FreeKey(ssl, ssl->hsAltType, (void**)&ssl->hsAltKey);
+    #endif
 
     if (ssl->buffers.altKeyType == dilithium_level2_sa_algo ||
         ssl->buffers.altKeyType == dilithium_level3_sa_algo ||
-        ssl->buffers.altKeyType == dilithium_level5_sa_algo) {
+        ssl->buffers.altKeyType == dilithium_level5_sa_algo ||
+        ssl->buffers.altKeyType == 0) {
 
         ssl->hsAltType = DYNAMIC_TYPE_DILITHIUM;
         ret = AllocKey(ssl, ssl->hsAltType, &ssl->hsAltKey);
@@ -28278,6 +29014,8 @@ int DecodeAltPrivateKey(WOLFSSL *ssl, word16* length)
             ret = wc_dilithium_set_level((dilithium_key*)ssl->hsAltKey, 5);
         }
         else {
+            /* What if ssl->buffers.keyType is 0? We might want to do something
+             * more graceful here. */
             ret = ALGO_ID_E;
         }
 
@@ -28285,35 +29023,63 @@ int DecodeAltPrivateKey(WOLFSSL *ssl, word16* length)
             goto exit_dapk;
         }
 
-        WOLFSSL_MSG("Trying Dilithium private key");
+        #if defined(HAVE_FALCON)
+            WOLFSSL_MSG("Trying Dilithium private key, Falcon didn't work");
+        #elif defined(HAVE_ECC)
+            WOLFSSL_MSG("Trying Dilithium private key, ECC didn't work");
+        #elif !defined(NO_RSA)
+            WOLFSSL_MSG("Trying Dilithium private key, RSA didn't work");
+        #else
+            WOLFSSL_MSG("Trying Dilithium private key");
+        #endif
 
+        /* Set start of data to beginning of buffer. */
+        idx = 0;
         /* Decode the key assuming it is a Dilithium private key. */
-        ret = wc_dilithium_import_private_only(ssl->buffers.altKey->buffer,
-                                               ssl->buffers.altKey->length,
-                                               (dilithium_key*)ssl->hsAltKey);
+        ret = wc_Dilithium_PrivateKeyDecode(ssl->buffers.altKey->buffer,
+                                            &idx,
+                                            (dilithium_key*)ssl->hsAltKey,
+                                            ssl->buffers.altKey->length);
         if (ret == 0) {
             WOLFSSL_MSG("Using Dilithium private key");
 
             /* Check it meets the minimum Dilithium key size requirements. */
-            if (DILITHIUM_MAX_KEY_SIZE < ssl->options.minDilithiumKeySz) {
+            keySz = wc_dilithium_size((dilithium_key*)ssl->hsAltKey);
+            if (keySz < ssl->options.minDilithiumKeySz) {
                 WOLFSSL_MSG("Dilithium key size too small");
                 ERROR_OUT(DILITHIUM_KEY_SIZE_E, exit_dapk);
             }
 
+            /* Return the maximum signature length. */
             *length = wc_dilithium_sig_size((dilithium_key*)ssl->hsAltKey);
 
             goto exit_dapk;
         }
     }
+#endif /* HAVE_DILITHIUM */
+
+    (void)idx;
+    (void)keySz;
+    (void)length;
 
 exit_dapk:
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    if (ret == 0) {
+        ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.altKey,
+            &ssl->buffers.altKeyMask);
+    }
+    else {
+        wolfssl_priv_der_unblind(ssl->buffers.key, ssl->buffers.keyMask);
+    }
+#endif
+
     if (ret != 0) {
         WOLFSSL_ERROR_VERBOSE(ret);
     }
 
     return ret;
 }
-#endif /* HAVE_PQC && WOLFSSL_DUAL_ALG_CERTS */
+#endif /* WOLFSSL_DUAL_ALG_CERTS */
 #endif /* WOLFSSL_TLS13 || !NO_WOLFSSL_CLIENT */
 
 #if defined(WOLFSSL_TLS13) && !defined(WOLFSSL_NO_TLS12)
@@ -28384,7 +29150,7 @@ static int SigAlgoCachesMsgs(int sigAlgo)
 }
 
 static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
-    const byte* data, int sz, byte sigAlgo)
+    const byte* data, word32 sz, byte sigAlgo)
 {
     int ret = 0;
     int digest_sz = wc_HashGetDigestSize(hashType);
@@ -28394,11 +29160,16 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
     }
 
     if (ret == 0) {
+        word32 new_size = SEED_LEN;
         /* buffer for signature */
-        ssl->buffers.sig.buffer = (byte*)XMALLOC(SEED_LEN + sz, ssl->heap,
-                                                        DYNAMIC_TYPE_SIGNATURE);
-        if (ssl->buffers.sig.buffer == NULL) {
+        if (! WC_SAFE_SUM_WORD32(new_size, sz, new_size))
             ret = MEMORY_E;
+        else {
+            ssl->buffers.sig.buffer = (byte*)XMALLOC(new_size, ssl->heap,
+                                                        DYNAMIC_TYPE_SIGNATURE);
+            if (ssl->buffers.sig.buffer == NULL) {
+                ret = MEMORY_E;
+            }
         }
     }
     if (ret == 0) {
@@ -28477,7 +29248,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
         int                sendSz;
         int                idSz;
         int                ret;
-        word16             extSz = 0;
+        word32             extSz = 0;
         const Suites*      suites;
 
         if (ssl == NULL) {
@@ -28526,7 +29297,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
         }
 #endif
         length = VERSION_SZ + RAN_LEN
-               + idSz + ENUM_LEN
+               + (word32)idSz + ENUM_LEN
                + SUITE_LEN
                + COMP_LEN + ENUM_LEN;
 #ifndef NO_FORCE_SCR_SAME_SUITE
@@ -28556,7 +29327,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
         if (extSz != 0)
             length += extSz + HELLO_EXT_SZ_SZ;
 #endif
-        sendSz = length + HANDSHAKE_HEADER_SZ + RECORD_HEADER_SZ;
+        sendSz = (int)length + HANDSHAKE_HEADER_SZ + RECORD_HEADER_SZ;
 
         if (ssl->arrays == NULL) {
             return BAD_FUNC_ARG;
@@ -28566,7 +29337,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
         if (ssl->options.dtls) {
             length += ENUM_LEN;   /* cookie */
             if (ssl->arrays->cookieSz != 0) length += ssl->arrays->cookieSz;
-            sendSz  = length + DTLS_HANDSHAKE_HEADER_SZ + DTLS_RECORD_HEADER_SZ;
+            sendSz  = (int)length + DTLS_HANDSHAKE_HEADER_SZ + DTLS_RECORD_HEADER_SZ;
             idx    += DTLS_HANDSHAKE_EXTRA + DTLS_RECORD_EXTRA;
         }
 #endif
@@ -28697,7 +29468,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
 
         if (IsEncryptionOn(ssl, 1)) {
             byte* input;
-            int   inputSz = idx; /* build msg adds rec hdr */
+            int   inputSz = (int)idx; /* build msg adds rec hdr */
             int   recordHeaderSz = RECORD_HEADER_SZ;
 
             if (ssl->options.dtls)
@@ -28710,7 +29481,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             XMEMCPY(input, output + recordHeaderSz, inputSz);
             #ifdef WOLFSSL_DTLS
             if (IsDtlsNotSctpMode(ssl) &&
-                    (ret = DtlsMsgPoolSave(ssl, input, inputSz, client_hello)) != 0) {
+                    (ret = DtlsMsgPoolSave(ssl, input, (word32)inputSz, client_hello)) != 0) {
                 XFREE(input, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
                 return ret;
             }
@@ -28724,7 +29495,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
         } else {
             #ifdef WOLFSSL_DTLS
                 if (IsDtlsNotSctpMode(ssl)) {
-                    if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, client_hello)) != 0)
+                    if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, client_hello)) != 0)
                         return ret;
                 }
                 if (ssl->options.dtls)
@@ -28818,6 +29589,9 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             if (!ssl->options.downgrade ||
                     ssl->options.minDowngrade <= DTLSv1_3_MINOR)
                 return VERSION_ERROR;
+
+            /* Cannot be DTLS1.3 as HELLO_VERIFY_REQUEST */
+            ssl->options.tls1_3 = 0;
         }
 #endif /* defined(WOLFSSL_DTLS13) && defined(WOLFSSL_TLS13) */
 
@@ -29419,7 +30193,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             if ((len > size) || ((*inOutIdx - begin) + len > size))
                 return BUFFER_ERROR;
 
-            if (PickHashSigAlgo(ssl, input + *inOutIdx, len) != 0 &&
+            if (PickHashSigAlgo(ssl, input + *inOutIdx, len, 0) != 0 &&
                                              ssl->buffers.certificate &&
                                              ssl->buffers.certificate->buffer) {
             #ifdef HAVE_PK_CALLBACKS
@@ -29592,7 +30366,7 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
 
     static int CheckCurveId(int tlsCurveId)
     {
-        int ret = ECC_CURVE_ERROR;
+        int ret = WC_NO_ERR_TRACE(ECC_CURVE_ERROR);
 
         switch (tlsCurveId) {
     #if (defined(HAVE_ECC160) || defined(HAVE_ALL_CURVES)) && ECC_MIN_KEY_SZ <= 160
@@ -29660,7 +30434,9 @@ static int HashSkeData(WOLFSSL* ssl, enum wc_HashType hashType,
             case WOLFSSL_ECC_SECP521R1: return ECC_SECP521R1_OID;
         #endif /* !NO_ECC_SECP */
     #endif
-            default: break;
+            default:
+                ret = WC_NO_ERR_TRACE(ECC_CURVE_ERROR);
+                break;
         }
 
         return ret;
@@ -29986,7 +30762,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
     args = (DskeArgs*)ssl->async->args;
 
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             goto exit_dske;
@@ -30038,7 +30814,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     }
 
                     /* get PSK server hint from the wire */
-                    srvHintLen = min(length, MAX_PSK_ID_LEN);
+                    srvHintLen = (int)min(length, MAX_PSK_ID_LEN);
                     XMEMCPY(ssl->arrays->server_hint, input + args->idx,
                                                                     srvHintLen);
                     ssl->arrays->server_hint[srvHintLen] = '\0'; /* null term */
@@ -30081,7 +30857,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     if ((curveOid = CheckCurveId(b)) < 0) {
                         ERROR_OUT(ECC_CURVE_ERROR, exit_dske);
                     }
-                    ssl->ecdhCurveOID = curveOid;
+                    ssl->ecdhCurveOID = (word32)curveOid;
                 #if defined(WOLFSSL_TLS13) || defined(HAVE_FFDHE)
                     ssl->namedGroup = 0;
                 #endif
@@ -30112,9 +30888,9 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                 input + args->idx, length,
                                 EC25519_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                            if (ret == BUFFER_E)
+                            if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                 SendAlert(ssl, alert_fatal, decode_error);
-                            else if (ret == ECC_OUT_OF_RANGE_E)
+                            else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                 SendAlert(ssl, alert_fatal, bad_record_mac);
                             else {
                                 SendAlert(ssl, alert_fatal, illegal_parameter);
@@ -30155,9 +30931,9 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                 input + args->idx, length,
                                 EC448_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                            if (ret == BUFFER_E)
+                            if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                 SendAlert(ssl, alert_fatal, decode_error);
-                            else if (ret == ECC_OUT_OF_RANGE_E)
+                            else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                 SendAlert(ssl, alert_fatal, bad_record_mac);
                             else {
                                 SendAlert(ssl, alert_fatal, illegal_parameter);
@@ -30192,7 +30968,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                         }
                     }
 
-                    curveId = wc_ecc_get_oid(curveOid, NULL, NULL);
+                    curveId = wc_ecc_get_oid((word32)curveOid, NULL, NULL);
                     if (wc_ecc_import_x963_ex(input + args->idx, length,
                                         ssl->peerEccKey, curveId) != 0) {
                     #ifdef WOLFSSL_EXTRA_ALERTS
@@ -30225,7 +31001,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     }
 
                     /* get PSK server hint from the wire */
-                    srvHintLen = min(length, MAX_PSK_ID_LEN);
+                    srvHintLen = (int)min(length, MAX_PSK_ID_LEN);
                     XMEMCPY(ssl->arrays->server_hint, input + args->idx,
                                                                 srvHintLen);
                     ssl->arrays->server_hint[srvHintLen] = '\0'; /* null term */
@@ -30258,7 +31034,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     }
 
                     /* get PSK server hint from the wire */
-                    srvHintLen = min(length, MAX_PSK_ID_LEN);
+                    srvHintLen = (int)min(length, MAX_PSK_ID_LEN);
                     XMEMCPY(ssl->arrays->server_hint, input + args->idx,
                                                                     srvHintLen);
                     ssl->arrays->server_hint[srvHintLen] = '\0'; /* null term */
@@ -30281,7 +31057,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     if ((curveOid = CheckCurveId(b)) < 0) {
                         ERROR_OUT(ECC_CURVE_ERROR, exit_dske);
                     }
-                    ssl->ecdhCurveOID = curveOid;
+                    ssl->ecdhCurveOID = (word32)curveOid;
 
                     length = input[args->idx++];
                     if ((args->idx - args->begin) + length > size) {
@@ -30309,9 +31085,9 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                 input + args->idx, length,
                                 EC25519_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                            if (ret == BUFFER_E)
+                            if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                 SendAlert(ssl, alert_fatal, decode_error);
-                            else if (ret == ECC_OUT_OF_RANGE_E)
+                            else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                 SendAlert(ssl, alert_fatal, bad_record_mac);
                             else {
                                 SendAlert(ssl, alert_fatal, illegal_parameter);
@@ -30352,9 +31128,9 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                 input + args->idx, length,
                                 EC448_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                            if (ret == BUFFER_E)
+                            if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                 SendAlert(ssl, alert_fatal, decode_error);
-                            else if (ret == ECC_OUT_OF_RANGE_E)
+                            else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                 SendAlert(ssl, alert_fatal, bad_record_mac);
                             else {
                                 SendAlert(ssl, alert_fatal, illegal_parameter);
@@ -30389,7 +31165,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                         }
                     }
 
-                    curveId = wc_ecc_get_oid(curveOid, NULL, NULL);
+                    curveId = wc_ecc_get_oid((word32)curveOid, NULL, NULL);
                     if (wc_ecc_import_x963_ex(input + args->idx, length,
                         ssl->peerEccKey, curveId) != 0) {
                         ERROR_OUT(ECC_PEERKEY_ERROR, exit_dske);
@@ -30434,14 +31210,14 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                     ERROR_OUT(NOT_COMPILED_IN, exit_dske);
             #else
                     enum wc_HashType hashType;
-                    word16 verifySz;
+                    word32 verifySz;
                     byte sigAlgo;
 
                     if (ssl->options.usingAnon_cipher) {
                         break;
                     }
 
-                    verifySz = (word16)(args->idx - args->begin);
+                    verifySz = (args->idx - args->begin);
                     if (verifySz > MAX_DH_SZ) {
                         ERROR_OUT(BUFFER_ERROR, exit_dske);
                     }
@@ -30450,6 +31226,15 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                         if ((args->idx - args->begin) + ENUM_LEN + ENUM_LEN >
                                                                         size) {
                             ERROR_OUT(BUFFER_ERROR, exit_dske);
+                        }
+
+                        /* Check if hashSigAlgo in Server Key Exchange is supported
+                         * in our ssl->suites or ssl->ctx->suites. */
+                        if (!SupportedHashSigAlgo(ssl, &input[args->idx])) {
+                        #ifdef WOLFSSL_EXTRA_ALERTS
+                            SendAlert(ssl, alert_fatal, handshake_failure);
+                        #endif
+                            ERROR_OUT(MATCH_SUITE_ERROR, exit_dske);
                         }
 
                         DecodeSigAlg(&input[args->idx], &ssl->options.peerHashAlgo,
@@ -30650,7 +31435,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                 ret = 0;
                             }
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            if (ret != WC_PENDING_E)
+                            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         #endif
                             {
                                 /* peerRsaKey */
@@ -30678,7 +31463,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                                     (ssl->buffers.sig.length - SEED_LEN));
                             }
                         #endif /* HAVE_PK_CALLBACKS */
-                            if (ret == NOT_COMPILED_IN) {
+                            if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN)) {
                             #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
                                 if (ssl->options.peerSigAlgo == sm2_sa_algo) {
                                     ret = Sm2wSm3Verify(ssl,
@@ -30712,7 +31497,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                             }
 
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            if (ret != WC_PENDING_E)
+                            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         #endif
                             {
                                 /* peerEccDsaKey */
@@ -30742,7 +31527,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                             );
 
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            if (ret != WC_PENDING_E)
+                            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         #endif
                             {
                                 /* peerEccDsaKey */
@@ -30772,7 +31557,7 @@ static int DoServerKeyExchange(WOLFSSL* ssl, const byte* input,
                             );
 
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            if (ret != WC_PENDING_E)
+                            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         #endif
                             {
                                 /* peerEccDsaKey */
@@ -30989,7 +31774,7 @@ exit_dske:
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     /* Handle async operation */
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         /* Mark message as not received so it can process again */
         ssl->msgsReceived.got_server_key_exchange = 0;
 
@@ -31070,7 +31855,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             goto exit_scke;
@@ -31370,11 +32155,13 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         void* ctx = wolfSSL_GetGenPreMasterCtx(ssl);
                         ret = ssl->ctx->GenPreMasterCb(ssl,
                             ssl->arrays->preMasterSecret, ENCRYPT_LEN, ctx);
-                        if (ret != 0 && ret != PROTOCOLCB_UNAVAILABLE) {
+                        if (ret != 0 &&
+                            ret != WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE)) {
                             goto exit_scke;
                         }
                     }
-                    if (!ssl->ctx->GenPreMasterCb || ret == PROTOCOLCB_UNAVAILABLE)
+                    if (!ssl->ctx->GenPreMasterCb ||
+                        ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
                     #endif
                     {
                         /* build PreMasterSecret with RNG data */
@@ -31469,7 +32256,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         MAX_PSK_ID_LEN, ssl->arrays->psk_key, MAX_PSK_KEY_LEN);
                     if (ssl->arrays->psk_keySz == 0 ||
                             (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                        (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                        (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                         ERROR_OUT(PSK_KEY_ERROR, exit_scke);
                     }
 
@@ -31514,7 +32301,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         MAX_PSK_ID_LEN, ssl->arrays->psk_key, MAX_PSK_KEY_LEN);
                     if (ssl->arrays->psk_keySz == 0 ||
                             (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                        (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                        (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                         ERROR_OUT(PSK_KEY_ERROR, exit_scke);
                     }
 
@@ -31597,7 +32384,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         MAX_PSK_ID_LEN, ssl->arrays->psk_key, MAX_PSK_KEY_LEN);
                     if (ssl->arrays->psk_keySz == 0 ||
                             (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                        (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                        (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                         ERROR_OUT(PSK_KEY_ERROR, exit_scke);
                     }
 
@@ -31872,7 +32659,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
                         WOLFSSL_CLIENT_END
                     );
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (ret != WC_PENDING_E)
+                    if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                 #endif
                     {
                         FreeKey(ssl, DYNAMIC_TYPE_ECC,
@@ -32104,7 +32891,7 @@ int SendClientKeyExchange(WOLFSSL* ssl)
             }
 
             idx = HANDSHAKE_HEADER_SZ + RECORD_HEADER_SZ;
-            args->sendSz = args->encSz + tlsSz + idx;
+            args->sendSz = (int)(args->encSz + tlsSz + idx);
 
         #ifdef WOLFSSL_DTLS
             if (ssl->options.dtls) {
@@ -32237,7 +33024,7 @@ exit_scke:
 
 #ifdef WOLFSSL_ASYNC_IO
     /* Handle async operation */
-    if (ret == WC_PENDING_E || ret == WANT_WRITE) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E) || ret == WANT_WRITE) {
         if (ssl->options.buildingMsg)
             return ret;
         /* If we have completed all states then we will not enter this function
@@ -32285,7 +33072,7 @@ typedef struct ScvArgs {
     word32 sigSz;
     int    sendSz;
     int    inputSz;
-    word16 length;
+    word32 length;
     byte   sigAlgo;
 } ScvArgs;
 
@@ -32321,6 +33108,10 @@ int SendCertificateVerify(WOLFSSL* ssl)
     WOLFSSL_START(WC_FUNC_CERTIFICATE_VERIFY_SEND);
     WOLFSSL_ENTER("SendCertificateVerify");
 
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    wolfssl_priv_der_unblind(ssl->buffers.key, ssl->buffers.keyMask);
+#endif
+
 #ifdef WOLFSSL_ASYNC_IO
     if (ssl->async == NULL) {
         ssl->async = (struct WOLFSSL_ASYNC*)
@@ -32333,10 +33124,10 @@ int SendCertificateVerify(WOLFSSL* ssl)
     args = (ScvArgs*)ssl->async->args;
 #ifdef WOLFSSL_ASYNC_CRYPT
     /* BuildMessage does its own Pop */
-    if (ssl->error != WC_PENDING_E ||
+    if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E) ||
             ssl->options.asyncState != TLS_ASYNC_END)
         ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             goto exit_scv;
@@ -32367,6 +33158,10 @@ int SendCertificateVerify(WOLFSSL* ssl)
         case TLS_ASYNC_BEGIN:
         {
             if (ssl->options.sendVerify == SEND_BLANK_CERT) {
+            #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+                wolfssl_priv_der_unblind(ssl->buffers.key,
+                    ssl->buffers.keyMask);
+            #endif
                 return 0;  /* sent blank cert, can't verify */
             }
 
@@ -32504,7 +33299,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
                 }
 
                 /* prepend hdr */
-                c16toa(args->length, args->verify + args->extraSz);
+                c16toa((word16)args->length, args->verify + args->extraSz);
             }
             #ifdef WC_RSA_PSS
             else if (args->sigAlgo == rsa_pss_sa_algo) {
@@ -32514,7 +33309,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
                 args->sigSz = ENCRYPT_LEN;
 
                 /* prepend hdr */
-                c16toa(args->length, args->verify + args->extraSz);
+                c16toa((word16)args->length, args->verify + args->extraSz);
             }
             #endif
         #endif /* !NO_RSA */
@@ -32693,7 +33488,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
         #endif
                     args->length = (word16)ssl->buffers.sig.length;
                     /* prepend hdr */
-                    c16toa(args->length, args->verify + args->extraSz);
+                    c16toa((word16)args->length, args->verify + args->extraSz);
                     XMEMCPY(args->verify + args->extraSz + VERIFY_HEADER,
                             ssl->buffers.sig.buffer, ssl->buffers.sig.length);
                     break;
@@ -32722,7 +33517,7 @@ int SendCertificateVerify(WOLFSSL* ssl)
                     );
 
                     /* free temporary buffer now */
-                    if (ret != WC_PENDING_E) {
+                    if (ret != WC_NO_ERR_TRACE(WC_PENDING_E)) {
                         XFREE(args->verifySig, ssl->heap, DYNAMIC_TYPE_SIGNATURE);
                         args->verifySig = NULL;
                     }
@@ -32771,6 +33566,15 @@ int SendCertificateVerify(WOLFSSL* ssl)
     } /* switch(ssl->options.asyncState) */
 
 exit_scv:
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    if (ret == 0) {
+        ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.key,
+            &ssl->buffers.keyMask);
+    }
+    else {
+        wolfssl_priv_der_unblind(ssl->buffers.key, ssl->buffers.keyMask);
+    }
+#endif
 
     WOLFSSL_LEAVE("SendCertificateVerify", ret);
     WOLFSSL_END(WC_FUNC_CERTIFICATE_VERIFY_SEND);
@@ -32934,7 +33738,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
 #ifndef NO_CERTS
 
-#ifdef WOLF_PRIVATE_KEY_ID
+#if defined(WOLF_PRIVATE_KEY_ID) || defined(HAVE_PK_CALLBACKS)
     int GetPrivateKeySigSize(WOLFSSL* ssl)
     {
         int sigSz = 0;
@@ -32975,7 +33779,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
         return sigSz;
     }
-#endif /* HAVE_PK_CALLBACKS */
+#endif /* WOLF_PRIVATE_KEY_ID || HAVE_PK_CALLBACKS */
 
 #endif /* NO_CERTS */
 
@@ -33067,29 +33871,47 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     int TranslateErrorToAlert(int err)
     {
         switch (err) {
-            case BUFFER_ERROR:
+            case WC_NO_ERR_TRACE(BUFFER_ERROR):
                 return decode_error;
-            case EXT_NOT_ALLOWED:
-            case PEER_KEY_ERROR:
-            case ECC_PEERKEY_ERROR:
-            case BAD_KEY_SHARE_DATA:
-            case PSK_KEY_ERROR:
-            case INVALID_PARAMETER:
-            case HRR_COOKIE_ERROR:
-            case BAD_BINDER:
+            case WC_NO_ERR_TRACE(EXT_NOT_ALLOWED):
+            case WC_NO_ERR_TRACE(PEER_KEY_ERROR):
+            case WC_NO_ERR_TRACE(ECC_PEERKEY_ERROR):
+            case WC_NO_ERR_TRACE(BAD_KEY_SHARE_DATA):
+            case WC_NO_ERR_TRACE(PSK_KEY_ERROR):
+            case WC_NO_ERR_TRACE(INVALID_PARAMETER):
+            case WC_NO_ERR_TRACE(HRR_COOKIE_ERROR):
+            case WC_NO_ERR_TRACE(BAD_BINDER):
                 return illegal_parameter;
-            case INCOMPLETE_DATA:
+            case WC_NO_ERR_TRACE(INCOMPLETE_DATA):
                 return missing_extension;
-            case MATCH_SUITE_ERROR:
-            case MISSING_HANDSHAKE_DATA:
+            case WC_NO_ERR_TRACE(MATCH_SUITE_ERROR):
+            case WC_NO_ERR_TRACE(MISSING_HANDSHAKE_DATA):
                 return handshake_failure;
-            case VERSION_ERROR:
+            case WC_NO_ERR_TRACE(VERSION_ERROR):
                 return wolfssl_alert_protocol_version;
             default:
                 return invalid_alert;
         }
     }
 
+    /* search suites for specific one, idx on success, negative on error */
+    int FindSuite(const Suites* suites, byte first, byte second)
+    {
+        int i;
+
+        if (suites == NULL || suites->suiteSz == 0) {
+            WOLFSSL_MSG("Suites pointer error or suiteSz 0");
+            return SUITES_ERROR;
+        }
+
+        for (i = 0; i < suites->suiteSz-1; i += SUITE_LEN) {
+            if (suites->suites[i]   == first &&
+                suites->suites[i+1] == second )
+                return i;
+        }
+
+        return MATCH_SUITE_ERROR;
+    }
 
 #ifndef NO_WOLFSSL_SERVER
 
@@ -33278,7 +34100,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
         if (IsEncryptionOn(ssl, 1)) {
             byte* input;
-            int   inputSz = idx; /* build msg adds rec hdr */
+            int   inputSz = (int)idx; /* build msg adds rec hdr */
             int   recordHeaderSz = RECORD_HEADER_SZ;
 
             if (ssl->options.dtls)
@@ -33291,7 +34113,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             XMEMCPY(input, output + recordHeaderSz, inputSz);
             #ifdef WOLFSSL_DTLS
             if (IsDtlsNotSctpMode(ssl) &&
-                    (ret = DtlsMsgPoolSave(ssl, input, inputSz, server_hello)) != 0) {
+                    (ret = DtlsMsgPoolSave(ssl, input, (word32)inputSz, server_hello)) != 0) {
                 XFREE(input, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
                 return ret;
             }
@@ -33305,7 +34127,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         } else {
             #ifdef WOLFSSL_DTLS
                 if (IsDtlsNotSctpMode(ssl)) {
-                    if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, server_hello)) != 0)
+                    if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, server_hello)) != 0)
                         return ret;
                 }
                 if (ssl->options.dtls)
@@ -33377,7 +34199,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     #if defined(HAVE_ECC) || defined(HAVE_CURVE25519) || defined(HAVE_CURVE448)
         word32 exportSz;
     #endif
-        int    sendSz;
+        word32 sendSz;
         int    inputSz;
     } SskeArgs;
 
@@ -33416,6 +34238,10 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         WOLFSSL_START(WC_FUNC_SERVER_KEY_EXCHANGE_SEND);
         WOLFSSL_ENTER("SendServerKeyExchange");
 
+    #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+        wolfssl_priv_der_unblind(ssl->buffers.key, ssl->buffers.keyMask);
+    #endif
+
     #ifdef WOLFSSL_ASYNC_IO
         if (ssl->async == NULL) {
             ssl->async = (struct WOLFSSL_ASYNC*)
@@ -33428,7 +34254,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         args = (SskeArgs*)ssl->async->args;
     #ifdef WOLFSSL_ASYNC_CRYPT
         ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-        if (ret != WC_NO_PENDING_E) {
+        if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
             /* Check for error */
             if (ret < 0)
                 goto exit_sske;
@@ -33718,7 +34544,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             if (ssl->eccTempKeyPresent == 0) {
                                 ret = X25519MakeKey(ssl,
                                         (curve25519_key*)ssl->eccTempKey, NULL);
-                                if (ret == 0 || ret == WC_PENDING_E) {
+                                if (ret == 0 ||
+                                    ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                                     ssl->eccTempKeyPresent =
                                         DYNAMIC_TYPE_CURVE25519;
                                 }
@@ -33745,7 +34572,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                             if (ssl->eccTempKeyPresent == 0) {
                                 ret = X448MakeKey(ssl,
                                           (curve448_key*)ssl->eccTempKey, NULL);
-                                if (ret == 0 || ret == WC_PENDING_E) {
+                                if (ret == 0 ||
+                                    ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                                     ssl->eccTempKeyPresent =
                                         DYNAMIC_TYPE_CURVE448;
                                 }
@@ -33770,7 +34598,8 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
                         if (ssl->eccTempKeyPresent == 0) {
                             ret = EccMakeKey(ssl, ssl->eccTempKey, NULL);
-                            if (ret == 0 || ret == WC_PENDING_E) {
+                            if (ret == 0 ||
+                                ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                                 ssl->eccTempKeyPresent = DYNAMIC_TYPE_ECC;
                             }
                         }
@@ -34094,7 +34923,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         if (ssl->buffers.key == NULL) {
                         #ifdef HAVE_PK_CALLBACKS
                             if (wolfSSL_CTX_IsPrivatePkSet(ssl->ctx)) {
-                                args->tmpSigSz = GetPrivateKeySigSize(ssl);
+                                args->tmpSigSz = (word32)GetPrivateKeySigSize(ssl);
                                 if (args->tmpSigSz == 0) {
                                     ERROR_OUT(NO_PRIVATE_KEY, exit_sske);
                                 }
@@ -34111,7 +34940,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         #endif
                             case rsa_sa_algo:
                             {
-                                word16 keySz;
+                                word32 keySz;
 
                                 ssl->buffers.keyType = rsa_sa_algo;
                                 ret = DecodePrivateKey(ssl, &keySz);
@@ -34129,9 +34958,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         #endif
                             case ecc_dsa_sa_algo:
                             {
-                                word16 keySz;
+                                word32 keySz;
 
-                                ssl->buffers.keyType = ecc_dsa_sa_algo;
+                                ssl->buffers.keyType = ssl->options.sigAlgo;
                                 ret = DecodePrivateKey(ssl, &keySz);
                                 if (ret != 0) {
                                     goto exit_sske;
@@ -34144,7 +34973,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         #ifdef HAVE_ED25519
                             case ed25519_sa_algo:
                             {
-                                word16 keySz;
+                                word32 keySz;
 
                                 ssl->buffers.keyType = ed25519_sa_algo;
                                 ret = DecodePrivateKey(ssl, &keySz);
@@ -34160,7 +34989,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         #ifdef HAVE_ED448
                             case ed448_sa_algo:
                             {
-                                word16 keySz;
+                                word32 keySz;
 
                                 ssl->buffers.keyType = ed448_sa_algo;
                                 ret = DecodePrivateKey(ssl, &keySz);
@@ -34363,7 +35192,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                         preSigSz  = args->length;
 
                         if (!ssl->options.usingAnon_cipher) {
-                            word16 keySz = 0;
+                            word32 keySz = 0;
 
                             /* sig length */
                             args->length += LENGTH_SZ;
@@ -34972,6 +35801,16 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
     exit_sske:
 
+    #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+        if (ret == 0) {
+            ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.key,
+                &ssl->buffers.keyMask);
+        }
+        else {
+            wolfssl_priv_der_unblind(ssl->buffers.key, ssl->buffers.keyMask);
+        }
+    #endif
+
         WOLFSSL_LEAVE("SendServerKeyExchange", ret);
         WOLFSSL_END(WC_FUNC_SERVER_KEY_EXCHANGE_SEND);
 
@@ -35008,30 +35847,6 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
         return ret;
     }
-
-#if defined(HAVE_SERVER_RENEGOTIATION_INFO) || defined(HAVE_FALLBACK_SCSV) || \
-                                                            defined(OPENSSL_ALL)
-
-    /* search suites for specific one, idx on success, negative on error */
-    static int FindSuite(Suites* suites, byte first, byte second)
-    {
-        int i;
-
-        if (suites == NULL || suites->suiteSz == 0) {
-            WOLFSSL_MSG("Suites pointer error or suiteSz 0");
-            return SUITES_ERROR;
-        }
-
-        for (i = 0; i < suites->suiteSz-1; i += SUITE_LEN) {
-            if (suites->suites[i]   == first &&
-                suites->suites[i+1] == second )
-                return i;
-        }
-
-        return MATCH_SUITE_ERROR;
-    }
-
-#endif
 
 #endif /* !WOLFSSL_NO_TLS12 */
 
@@ -35142,7 +35957,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             int ret = TLSX_KeyShare_Choose(ssl, extensions, first, second,
                                            &cs->clientKSE, &searched);
 
-            if (ret == MEMORY_E) {
+            if (ret == WC_NO_ERR_TRACE(MEMORY_E)) {
                 WOLFSSL_MSG("TLSX_KeyShare_Choose() failed in "
                             "VerifyServerSuite() with MEMORY_E");
                 return 0;
@@ -35157,7 +35972,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 cs->doHelloRetry = 1;
             }
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E)
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                 return ret;
         #endif
             if (!cs->doHelloRetry && ret != 0)
@@ -35224,7 +36039,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             for (i = 0; i < suites->suiteSz; i += 2) {
                 for (j = 0; j < peerSuites->suiteSz; j += 2) {
                     ret = CompareSuites(ssl, suites, peerSuites, i, j, cs, extensions);
-                    if (ret != MATCH_SUITE_ERROR)
+                    if (ret != WC_NO_ERR_TRACE(MATCH_SUITE_ERROR))
                         return ret;
                 }
             }
@@ -35234,7 +36049,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             for (j = 0; j < peerSuites->suiteSz; j += 2) {
                 for (i = 0; i < suites->suiteSz; i += 2) {
                     ret = CompareSuites(ssl, suites, peerSuites, i, j, cs, extensions);
-                    if (ret != MATCH_SUITE_ERROR)
+                    if (ret != WC_NO_ERR_TRACE(MATCH_SUITE_ERROR))
                         return ret;
                 }
             }
@@ -35273,7 +36088,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         if (ret != 0)
             return ret;
         ret = PickHashSigAlgo(ssl, peerSuites->hashSigAlgo,
-                                         peerSuites->hashSigAlgoSz);
+                              peerSuites->hashSigAlgoSz, 1);
         if (ret != 0)
             return ret;
 
@@ -35525,6 +36340,47 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     {
         int ret = 0;
         WOLFSSL_SESSION* session;
+
+#ifdef HAVE_SECRET_CALLBACK
+        if (ssl->sessionSecretCb != NULL
+#ifdef HAVE_SESSION_TICKET
+                && ssl->session->ticketLen > 0
+#endif
+                ) {
+            int secretSz = SECRET_LEN;
+            WOLFSSL_MSG("Calling session secret callback");
+            ret = wc_RNG_GenerateBlock(ssl->rng, ssl->arrays->serverRandom,
+                                       RAN_LEN);
+            if (ret == 0) {
+                ret = ssl->sessionSecretCb(ssl, ssl->arrays->masterSecret,
+                                              &secretSz, ssl->sessionSecretCtx);
+                if (secretSz != SECRET_LEN)
+                    ret = SESSION_SECRET_CB_E;
+            }
+            if (ret == 0)
+                ret = MatchSuite(ssl, clSuites);
+            if (ret == 0) {
+                #ifdef NO_OLD_TLS
+                    ret = DeriveTlsKeys(ssl);
+                #else
+                    #ifndef NO_TLS
+                        if (ssl->options.tls)
+                            ret = DeriveTlsKeys(ssl);
+                    #endif
+                        if (!ssl->options.tls)
+                            ret = DeriveKeys(ssl);
+                #endif
+                /* SERVER: peer auth based on session secret. */
+                ssl->options.peerAuthGood = (ret == 0);
+                ssl->options.clientState = CLIENT_KEYEXCHANGE_COMPLETE;
+            }
+            if (ret != 0)
+                WOLFSSL_ERROR_VERBOSE(ret);
+            WOLFSSL_LEAVE("HandleTlsResumption", ret);
+            return ret;
+        }
+#endif /* HAVE_SECRET_CALLBACK */
+
     #ifdef HAVE_SESSION_TICKET
         if (ssl->options.useTicket == 1) {
             session = ssl->session;
@@ -35595,7 +36451,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                 ret = SetCipherSpecs(ssl);
                 if (ret == 0) {
                     ret = PickHashSigAlgo(ssl, clSuites->hashSigAlgo,
-                                               clSuites->hashSigAlgoSz);
+                                          clSuites->hashSigAlgoSz, 0);
                 }
             }
             else if (ret == 0) {
@@ -35671,7 +36527,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
                     /* propagate socket errors to avoid re-calling send alert */
                     err = SendAlert(ssl, alert_fatal, alertType);
-                    if (err == SOCKET_ERROR_E)
+                    if (err == WC_NO_ERR_TRACE(SOCKET_ERROR_E))
                         ret = SOCKET_ERROR_E;
                 }
                 *inOutIdx += helloSz;
@@ -35979,8 +36835,12 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
             /* check for TLS_EMPTY_RENEGOTIATION_INFO_SCSV suite */
             ret = TLSX_AddEmptyRenegotiationInfo(&ssl->extensions, ssl->heap);
-            if (ret != WOLFSSL_SUCCESS)
+            if (ret != WOLFSSL_SUCCESS) {
+                ret = SECURE_RENEGOTIATION_E;
                 goto out;
+            } else {
+                ret = 0;
+            }
 
             extension = TLSX_Find(ssl->extensions, TLSX_RENEGOTIATION_INFO);
             if (extension) {
@@ -36184,6 +37044,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ssl->options.haveSessionId = 1;
 
         /* ProcessOld uses same resume code */
+        WOLFSSL_MSG_EX("ssl->options.resuming %d", ssl->options.resuming);
         if (ssl->options.resuming) {
             ret = HandleTlsResumption(ssl, clSuites);
             if (ret != 0)
@@ -36315,7 +37176,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         args = (DcvArgs*)ssl->async->args;
 
         ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-        if (ret != WC_NO_PENDING_E) {
+        if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
             /* Check for error */
             if (ret < 0)
                 goto exit_dcv;
@@ -36480,9 +37341,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
                     );
                     if (ret >= 0) {
                         if (ssl->options.peerSigAlgo == rsa_sa_algo)
-                            args->sendSz = ret;
+                            args->sendSz = (word32)ret;
                         else {
-                            args->sigSz = ret;
+                            args->sigSz = (word32)ret;
                             args->sendSz = ssl->buffers.digest.length;
                         }
                         ret = 0;
@@ -36568,7 +37429,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
             #ifdef WOLFSSL_ASYNC_CRYPT
                 /* handle async pending */
-                if (ret == WC_PENDING_E)
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                     goto exit_dcv;
             #endif
 
@@ -36706,7 +37567,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* Handle async operation */
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             /* Mark message as not received so it can process again */
             ssl->msgsReceived.got_certificate_verify = 0;
 
@@ -36714,9 +37575,9 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
     #endif /* WOLFSSL_ASYNC_CRYPT */
     #ifdef WOLFSSL_EXTRA_ALERTS
-        if (ret == BUFFER_ERROR)
+        if (ret == WC_NO_ERR_TRACE(BUFFER_ERROR))
             SendAlert(ssl, alert_fatal, decode_error);
-        else if (ret == SIG_VERIFY_E)
+        else if (ret == WC_NO_ERR_TRACE(SIG_VERIFY_E))
             SendAlert(ssl, alert_fatal, decrypt_error);
         else if (ret != 0)
             SendAlert(ssl, alert_fatal, bad_certificate);
@@ -36798,7 +37659,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             XMEMCPY(input, output + recordHeaderSz, inputSz);
             #ifdef WOLFSSL_DTLS
             if (IsDtlsNotSctpMode(ssl) &&
-                    (ret = DtlsMsgPoolSave(ssl, input, inputSz, server_hello_done)) != 0) {
+                    (ret = DtlsMsgPoolSave(ssl, input, (word32)inputSz, server_hello_done)) != 0) {
                 XFREE(input, ssl->heap, DYNAMIC_TYPE_IN_BUFFER);
                 return ret;
             }
@@ -36812,7 +37673,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         } else {
             #ifdef WOLFSSL_DTLS
                 if (IsDtlsNotSctpMode(ssl)) {
-                    if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, server_hello_done)) != 0)
+                    if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, server_hello_done)) != 0)
                         return ret;
                 }
                 if (ssl->options.dtls)
@@ -36929,7 +37790,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         it = (InternalTicket*)et->enc_ticket;
 
     #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ssl->error != WC_PENDING_E)
+        if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
     #endif
         {
             XMEMSET(et, 0, sizeof(*et));
@@ -37036,7 +37897,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
         if (ret != WOLFSSL_TICKET_RET_OK) {
 #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 return ret;
             }
 #endif
@@ -37157,7 +38018,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
         if (ret != WOLFSSL_TICKET_RET_OK) {
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 return ret;
             }
         #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -37443,7 +38304,7 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #endif
         if (sess == NULL) {
             ret = TlsSessionCacheGetAndRdLock(id, &sess, &freeCtx->row,
-                    ssl->options.side);
+                    (byte)ssl->options.side);
             if (ret != 0)
                 sess = NULL;
         }
@@ -37565,6 +38426,22 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         WOLFSSL_START(WC_FUNC_TICKET_DO);
         WOLFSSL_ENTER("DoClientTicket");
 
+#ifdef HAVE_SECRET_CALLBACK
+        if (ssl->ticketParseCb != NULL) {
+            decryptRet = WOLFSSL_TICKET_RET_OK;
+            if (!ssl->ticketParseCb(ssl, input, len, ssl->ticketParseCtx)) {
+                /* Failure kills the connection */
+                decryptRet = WOLFSSL_TICKET_RET_FATAL;
+            }
+            else {
+                if (wolfSSL_set_SessionTicket(ssl, input, len) !=
+                        WOLFSSL_SUCCESS)
+                    decryptRet = WOLFSSL_TICKET_RET_REJECT;
+            }
+            goto cleanup;
+        }
+        else
+#endif
 #ifdef WOLFSSL_TLS13
         if (len == ID_LEN && IsAtLeastTLSv1_3(ssl->version)) {
             /* This is a stateful ticket. We can be sure about this because
@@ -37579,7 +38456,11 @@ static int DoSessionTicket(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
         else
 #endif
+        if (len >= sizeof(*it))
             decryptRet = DoDecryptTicket(ssl, input, len, &it);
+        else
+            WOLFSSL_MSG("Ticket is smaller than InternalTicket. Rejecting.");
+
 
         if (decryptRet != WOLFSSL_TICKET_RET_OK &&
                 decryptRet != WOLFSSL_TICKET_RET_CREATE) {
@@ -37655,7 +38536,7 @@ cleanup:
         }
 
         length += ssl->session->ticketLen;
-        sendSz = length + HANDSHAKE_HEADER_SZ + RECORD_HEADER_SZ;
+        sendSz = (int)length + HANDSHAKE_HEADER_SZ + RECORD_HEADER_SZ;
 
         if (!ssl->options.dtls) {
             if (IsEncryptionOn(ssl, 1) && ssl->options.handShakeDone)
@@ -37697,7 +38578,7 @@ cleanup:
 
         if (IsEncryptionOn(ssl, 1) && ssl->options.handShakeDone) {
             byte* input;
-            int   inputSz = idx; /* build msg adds rec hdr */
+            int   inputSz = (int)idx; /* build msg adds rec hdr */
             int   recordHeaderSz = RECORD_HEADER_SZ;
 
             if (ssl->options.dtls)
@@ -37718,7 +38599,7 @@ cleanup:
         else {
             #ifdef WOLFSSL_DTLS
             if (ssl->options.dtls) {
-                if ((ret = DtlsMsgPoolSave(ssl, output, sendSz, session_ticket)) != 0)
+                if ((ret = DtlsMsgPoolSave(ssl, output, (word32)sendSz, session_ticket)) != 0)
                     return ret;
 
                 DtlsSEQIncrement(ssl, CUR_ORDER);
@@ -38135,6 +39016,10 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
 
     WOLFSSL_ENTER("DefTicketEncCb");
 
+    if ((!enc) && (inLen != sizeof(InternalTicket))) {
+        return BUFFER_E;
+    }
+
     /* Check we have setup the RNG, name and primary key. */
     if (keyCtx->expirary[0] == 0) {
 #ifndef SINGLE_THREADED
@@ -38372,7 +39257,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
             ssl->keys.dtls_sequence_number_hi = ssl->keys.curSeq_hi;
             ssl->keys.dtls_sequence_number_lo = ssl->keys.curSeq_lo;
         }
-        AddHeaders(output, length, hello_verify_request, ssl);
+        AddHeaders(output, (word32)length, hello_verify_request, ssl);
 
         output[idx++] = DTLS_MAJOR;
         output[idx++] = DTLS_MINOR;
@@ -38456,6 +39341,10 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
         WOLFSSL_START(WC_FUNC_CLIENT_KEY_EXCHANGE_DO);
         WOLFSSL_ENTER("DoClientKeyExchange");
 
+    #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+        wolfssl_priv_der_unblind(ssl->buffers.key, ssl->buffers.keyMask);
+    #endif
+
     #ifdef WOLFSSL_ASYNC_CRYPT
         if (ssl->async == NULL) {
             ssl->async = (struct WOLFSSL_ASYNC*)
@@ -38467,7 +39356,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
         args = (DckeArgs*)ssl->async->args;
 
         ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-        if (ret != WC_NO_PENDING_E) {
+        if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
             /* Check for error */
             if (ret < 0)
                 goto exit_dcke;
@@ -38611,7 +39500,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                 #ifndef NO_RSA
                     case rsa_kea:
                     {
-                        word16 keySz;
+                        word32 keySz;
 
                         ssl->buffers.keyType = rsa_sa_algo;
                         ret = DecodePrivateKey(ssl, &keySz);
@@ -38689,7 +39578,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
 
                         if (ssl->arrays->psk_keySz == 0 ||
                             (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                        (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                        (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                         #if defined(WOLFSSL_EXTRA_ALERTS) || \
                             defined(WOLFSSL_PSK_IDENTITY_ALERT)
                             SendAlert(ssl, alert_fatal,
@@ -38731,7 +39620,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                         if (ssl->specs.static_ecdh &&
                                           ssl->ecdhCurveOID != ECC_X25519_OID &&
                                           ssl->ecdhCurveOID != ECC_X448_OID) {
-                            word16 keySz;
+                            word32 keySz;
 
                             ssl->buffers.keyType = ecc_dsa_sa_algo;
                             ret = DecodePrivateKey(ssl, &keySz);
@@ -38781,9 +39670,9 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                                     input + args->idx, args->length,
                                     EC25519_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                                if (ret == BUFFER_E)
+                                if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                     SendAlert(ssl, alert_fatal, decode_error);
-                                else if (ret == ECC_OUT_OF_RANGE_E)
+                                else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                     SendAlert(ssl, alert_fatal, bad_record_mac);
                                 else {
                                     SendAlert(ssl, alert_fatal,
@@ -38838,9 +39727,9 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                                     input + args->idx, args->length,
                                     EC448_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                                if (ret == BUFFER_E)
+                                if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                     SendAlert(ssl, alert_fatal, decode_error);
-                                else if (ret == ECC_OUT_OF_RANGE_E)
+                                else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                     SendAlert(ssl, alert_fatal, bad_record_mac);
                                 else {
                                     SendAlert(ssl, alert_fatal,
@@ -38906,7 +39795,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                             ERROR_OUT(ECC_PEERKEY_ERROR, exit_dcke);
                         }
 
-                        ssl->arrays->preMasterSz = private_key->dp->size;
+                        ssl->arrays->preMasterSz = (word32)private_key->dp->size;
 
                         ssl->peerEccKeyPresent = 1;
 
@@ -39083,9 +39972,9 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                                     input + args->idx, args->length,
                                     EC25519_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                                if (ret == BUFFER_E)
+                                if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                     SendAlert(ssl, alert_fatal, decode_error);
-                                else if (ret == ECC_OUT_OF_RANGE_E)
+                                else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                     SendAlert(ssl, alert_fatal, bad_record_mac);
                                 else {
                                     SendAlert(ssl, alert_fatal,
@@ -39142,9 +40031,9 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                                     input + args->idx, args->length,
                                     EC448_LITTLE_ENDIAN)) != 0) {
                         #ifdef WOLFSSL_EXTRA_ALERTS
-                                if (ret == BUFFER_E)
+                                if (ret == WC_NO_ERR_TRACE(BUFFER_E))
                                     SendAlert(ssl, alert_fatal, decode_error);
-                                else if (ret == ECC_OUT_OF_RANGE_E)
+                                else if (ret == WC_NO_ERR_TRACE(ECC_OUT_OF_RANGE_E))
                                     SendAlert(ssl, alert_fatal, bad_record_mac);
                                 else {
                                     SendAlert(ssl, alert_fatal,
@@ -39245,10 +40134,10 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                          *       RSA_BUFFER_E, RSA_PAD_E and RSA_PRIVATE_ERROR
                          */
                     #ifdef WOLFSSL_ASYNC_CRYPT
-                        if (ret == WC_PENDING_E)
+                        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                             goto exit_dcke;
                     #endif
-                        if (ret == BAD_FUNC_ARG)
+                        if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
                             goto exit_dcke;
 
                         lenErrMask = 0 - (SECRET_LEN != args->sigSz);
@@ -39311,7 +40200,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                             WOLFSSL_SERVER_END
                         );
                     #ifdef WOLFSSL_ASYNC_CRYPT
-                        if (ret != WC_PENDING_E)
+                        if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                     #endif
                         {
                             FreeKey(ssl, DYNAMIC_TYPE_ECC,
@@ -39367,7 +40256,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                                 WOLFSSL_SERVER_END
                             );
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            if (ret != WC_PENDING_E)
+                            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         #endif
                             {
                                 FreeKey(ssl, DYNAMIC_TYPE_CURVE25519,
@@ -39388,7 +40277,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
                                 WOLFSSL_SERVER_END
                             );
                         #ifdef WOLFSSL_ASYNC_CRYPT
-                            if (ret != WC_PENDING_E)
+                            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         #endif
                             {
                                 FreeKey(ssl, DYNAMIC_TYPE_CURVE448,
@@ -39532,7 +40421,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
 
                         if (ssl->arrays->psk_keySz == 0 ||
                             (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                        (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                        (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                         #if defined(WOLFSSL_EXTRA_ALERTS) || \
                             defined(WOLFSSL_PSK_IDENTITY_ALERT)
                             SendAlert(ssl, alert_fatal,
@@ -39578,7 +40467,7 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
 
                         if (ssl->arrays->psk_keySz == 0 ||
                             (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                        (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                        (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                             ERROR_OUT(PSK_KEY_ERROR, exit_dcke);
                         }
                         /* SERVER: Pre-shared Key for peer authentication. */
@@ -39650,11 +40539,21 @@ static int DefTicketEncCb(WOLFSSL* ssl, byte key_name[WOLFSSL_TICKET_NAME_SZ],
 
     exit_dcke:
 
+    #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+        if (ret == 0) {
+            ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.key,
+                &ssl->buffers.keyMask);
+        }
+        else {
+            wolfssl_priv_der_unblind(ssl->buffers.key, ssl->buffers.keyMask);
+        }
+    #endif
+
         WOLFSSL_LEAVE("DoClientKeyExchange", ret);
         WOLFSSL_END(WC_FUNC_CLIENT_KEY_EXCHANGE_DO);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* Handle async operation */
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             /* Mark message as not received so it can process again */
             ssl->msgsReceived.got_client_key_exchange = 0;
 
@@ -39746,7 +40645,8 @@ int wolfSSL_AsyncPop(WOLFSSL* ssl, byte* state)
         event = &asyncDev->event;
 
         ret = wolfAsync_EventPop(event, WOLF_EVENT_TYPE_ASYNC_WOLFSSL);
-        if (ret != WC_NO_PENDING_E && ret != WC_PENDING_E) {
+        if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E) &&
+            ret != WC_NO_ERR_TRACE(WC_PENDING_E)) {
             /* advance key share state if doesn't need called again */
             if (state && (asyncDev->event.flags & WC_ASYNC_FLAG_CALL_AGAIN) == 0) {
                 (*state)++;
@@ -39759,7 +40659,7 @@ int wolfSSL_AsyncPop(WOLFSSL* ssl, byte* state)
     #if (defined(WOLF_CRYPTO_CB) || defined(HAVE_PK_CALLBACKS)) && \
         !defined(WOLFSSL_ASYNC_CRYPT_SW) && !defined(HAVE_INTEL_QA) && \
         !defined(HAVE_CAVIUM)
-        else if (ret == WC_PENDING_E) {
+        else if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             /* Allow the underlying crypto API to be called again to trigger the
              * crypto or PK callback. The actual callback must be called, since
              * the completion is not detected in the poll like Intel QAT or

--- a/libatalk/ssl/src/keys.c
+++ b/libatalk/ssl/src/keys.c
@@ -105,7 +105,7 @@ int SetCipherSpecs(WOLFSSL* ssl)
  * @param cipherSuite  [in]
  * @param specs        [out] CipherSpecs
  * @param opts         [in/out] Options can be NULL
- * @return
+ * @return int (less than 0 on fail, 0 on success)
  */
 int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
                       CipherSpecs* specs, Options* opts)
@@ -672,7 +672,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         specs->static_ecdh           = 0;
         specs->key_size              = AES_128_KEY_SIZE;
         specs->block_size            = AES_BLOCK_SIZE;
-        specs->iv_size               = AESGCM_IMP_IV_SZ;
+        specs->iv_size               = AESCCM_IMP_IV_SZ;
         specs->aead_mac_size         = AES_CCM_16_AUTH_SZ;
 
         break;
@@ -690,7 +690,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         specs->static_ecdh           = 0;
         specs->key_size              = AES_128_KEY_SIZE;
         specs->block_size            = AES_BLOCK_SIZE;
-        specs->iv_size               = AESGCM_IMP_IV_SZ;
+        specs->iv_size               = AESCCM_IMP_IV_SZ;
         specs->aead_mac_size         = AES_CCM_8_AUTH_SZ;
 
         break;
@@ -708,7 +708,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         specs->static_ecdh           = 0;
         specs->key_size              = AES_256_KEY_SIZE;
         specs->block_size            = AES_BLOCK_SIZE;
-        specs->iv_size               = AESGCM_IMP_IV_SZ;
+        specs->iv_size               = AESCCM_IMP_IV_SZ;
         specs->aead_mac_size         = AES_CCM_8_AUTH_SZ;
 
         break;
@@ -1069,7 +1069,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         specs->static_ecdh           = 0;
         specs->key_size              = AES_128_KEY_SIZE;
         specs->block_size            = AES_BLOCK_SIZE;
-        specs->iv_size               = AESGCM_IMP_IV_SZ;
+        specs->iv_size               = AESCCM_IMP_IV_SZ;
         specs->aead_mac_size         = AES_CCM_8_AUTH_SZ;
 
         break;
@@ -1087,7 +1087,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         specs->static_ecdh           = 0;
         specs->key_size              = AES_256_KEY_SIZE;
         specs->block_size            = AES_BLOCK_SIZE;
-        specs->iv_size               = AESGCM_IMP_IV_SZ;
+        specs->iv_size               = AESCCM_IMP_IV_SZ;
         specs->aead_mac_size         = AES_CCM_8_AUTH_SZ;
 
         break;
@@ -1105,7 +1105,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         specs->static_ecdh           = 0;
         specs->key_size              = AES_128_KEY_SIZE;
         specs->block_size            = AES_BLOCK_SIZE;
-        specs->iv_size               = AESGCM_IMP_IV_SZ;
+        specs->iv_size               = AESCCM_IMP_IV_SZ;
         specs->aead_mac_size         = AES_CCM_8_AUTH_SZ;
 
         if (opts != NULL)
@@ -1125,7 +1125,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         specs->static_ecdh           = 0;
         specs->key_size              = AES_256_KEY_SIZE;
         specs->block_size            = AES_BLOCK_SIZE;
-        specs->iv_size               = AESGCM_IMP_IV_SZ;
+        specs->iv_size               = AESCCM_IMP_IV_SZ;
         specs->aead_mac_size         = AES_CCM_8_AUTH_SZ;
 
         if (opts != NULL)
@@ -1145,7 +1145,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         specs->static_ecdh           = 0;
         specs->key_size              = AES_128_KEY_SIZE;
         specs->block_size            = AES_BLOCK_SIZE;
-        specs->iv_size               = AESGCM_IMP_IV_SZ;
+        specs->iv_size               = AESCCM_IMP_IV_SZ;
         specs->aead_mac_size         = AES_CCM_16_AUTH_SZ;
 
         if (opts != NULL)
@@ -1165,7 +1165,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         specs->static_ecdh           = 0;
         specs->key_size              = AES_256_KEY_SIZE;
         specs->block_size            = AES_BLOCK_SIZE;
-        specs->iv_size               = AESGCM_IMP_IV_SZ;
+        specs->iv_size               = AESCCM_IMP_IV_SZ;
         specs->aead_mac_size         = AES_CCM_16_AUTH_SZ;
 
         if (opts != NULL)
@@ -1185,7 +1185,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         specs->static_ecdh           = 0;
         specs->key_size              = AES_128_KEY_SIZE;
         specs->block_size            = AES_BLOCK_SIZE;
-        specs->iv_size               = AESGCM_IMP_IV_SZ;
+        specs->iv_size               = AESCCM_IMP_IV_SZ;
         specs->aead_mac_size         = AES_CCM_16_AUTH_SZ;
 
         if (opts != NULL)
@@ -1205,7 +1205,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         specs->static_ecdh           = 0;
         specs->key_size              = AES_256_KEY_SIZE;
         specs->block_size            = AES_BLOCK_SIZE;
-        specs->iv_size               = AESGCM_IMP_IV_SZ;
+        specs->iv_size               = AESCCM_IMP_IV_SZ;
         specs->aead_mac_size         = AES_CCM_16_AUTH_SZ;
 
         if (opts != NULL)
@@ -1330,7 +1330,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
             specs->static_ecdh           = 0;
             specs->key_size              = AES_128_KEY_SIZE;
             specs->block_size            = AES_BLOCK_SIZE;
-            specs->iv_size               = AESGCM_NONCE_SZ;
+            specs->iv_size               = AESCCM_NONCE_SZ;
             specs->aead_mac_size         = AES_CCM_16_AUTH_SZ;
 
             break;
@@ -1348,7 +1348,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
             specs->static_ecdh           = 0;
             specs->key_size              = AES_128_KEY_SIZE;
             specs->block_size            = AES_BLOCK_SIZE;
-            specs->iv_size               = AESGCM_NONCE_SZ;
+            specs->iv_size               = AESCCM_NONCE_SZ;
             specs->aead_mac_size         = AES_CCM_8_AUTH_SZ;
 
             break;
@@ -1440,7 +1440,7 @@ int GetCipherSpec(word16 side, byte cipherSuite0, byte cipherSuite,
         specs->static_ecdh           = 0;
         specs->key_size              = SM4_KEY_SIZE;
         specs->block_size            = SM4_BLOCK_SIZE;
-        specs->iv_size               = GCM_IMP_IV_SZ;
+        specs->iv_size               = CCM_IMP_IV_SZ;
         specs->aead_mac_size         = SM4_CCM_AUTH_SZ;
 
         break;
@@ -3561,7 +3561,8 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
         void* ctx = wolfSSL_GetEncryptKeysCtx(ssl);
         ret = ssl->ctx->EncryptKeysCb(ssl, ctx);
     }
-    if (!ssl->ctx->EncryptKeysCb || ret == PROTOCOLCB_UNAVAILABLE)
+    if (!ssl->ctx->EncryptKeysCb ||
+        ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
 #endif
     {
         ret = SetKeys(wc_encrypt, wc_decrypt, keys, &ssl->specs, ssl->options.side,
@@ -3668,7 +3669,8 @@ int SetKeysSide(WOLFSSL* ssl, enum encrypt_side side)
 /* TLS can call too */
 int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
 {
-    int sz, i = 0;
+    size_t sz;
+    int i = 0;
     Keys* keys = &ssl->keys;
 #ifdef WOLFSSL_DTLS
     /* In case of DTLS, ssl->keys is updated here */
@@ -3712,7 +3714,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
             XMEMCPY(keys->client_write_MAC_secret,&keyData[i], sz);
             XMEMCPY(keys->server_write_MAC_secret,&keyData[i], sz);
     #endif
-            i += sz;
+            i += (int)sz;
         }
         sz = ssl->specs.key_size;
     #ifdef WOLFSSL_DTLS
@@ -3725,7 +3727,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
     #endif
         XMEMCPY(keys->client_write_key, &keyData[i], sz);
         XMEMCPY(keys->server_write_key, &keyData[i], sz);
-        i += sz;
+        i += (int)sz;
 
         sz = ssl->specs.iv_size;
     #ifdef WOLFSSL_DTLS
@@ -3767,7 +3769,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
         #endif
             XMEMCPY(keys->client_write_MAC_secret,&keyData[i], sz);
     #endif
-            i += sz;
+            i += (int)sz;
         }
         if (side & PROVISION_SERVER) {
     #ifndef WOLFSSL_AEAD_ONLY
@@ -3778,7 +3780,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
         #endif
             XMEMCPY(keys->server_write_MAC_secret,&keyData[i], sz);
     #endif
-            i += sz;
+            i += (int)sz;
         }
     }
     sz = ssl->specs.key_size;
@@ -3789,7 +3791,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
                     keys->client_write_key, sz);
     #endif
         XMEMCPY(keys->client_write_key, &keyData[i], sz);
-        i += sz;
+        i += (int)sz;
     }
     if (side & PROVISION_SERVER) {
     #ifdef WOLFSSL_DTLS
@@ -3798,7 +3800,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
                     keys->server_write_key, sz);
     #endif
         XMEMCPY(keys->server_write_key, &keyData[i], sz);
-        i += sz;
+        i += (int)sz;
     }
 
     sz = ssl->specs.iv_size;
@@ -3809,7 +3811,7 @@ int StoreKeys(WOLFSSL* ssl, const byte* keyData, int side)
                     keys->client_write_IV, sz);
     #endif
         XMEMCPY(keys->client_write_IV, &keyData[i], sz);
-        i += sz;
+        i += (int)sz;
     }
     if (side & PROVISION_SERVER) {
     #ifdef WOLFSSL_DTLS

--- a/libatalk/ssl/src/pk.c
+++ b/libatalk/ssl/src/pk.c
@@ -25,10 +25,6 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#ifdef EMBEDDED_SSL
-#include <wolfssl/openssl/dh.h>
-#endif
-
  #include <wolfssl/internal.h>
 #ifndef WC_NO_RNG
     #include <wolfssl/wolfcrypt/random.h>
@@ -6174,7 +6170,7 @@ WOLFSSL_DH *wolfSSL_DSA_dup_DH(const WOLFSSL_DSA *dsa)
 
 #ifndef NO_DH
 
-#if defined(OPENSSL_EXTRA) || defined(EMBEDDED_SSL)
+#ifdef OPENSSL_EXTRA
 
 /*
  * DH constructor/deconstructor APIs
@@ -7705,10 +7701,10 @@ int wolfSSL_PEM_write_DHparams(XFILE fp, WOLFSSL_DH* dh)
  * DH get/set APIs
  */
 
-#if defined (OPENSSL_EXTRA) || defined(EMBEDDED_SSL)
+#ifdef OPENSSL_EXTRA
 
 #if defined(WOLFSSL_QT) || defined(OPENSSL_ALL) \
-    || defined(WOLFSSL_OPENSSH) || defined(OPENSSL_EXTRA) || defined(EMBEDDED_SSL)
+    || defined(WOLFSSL_OPENSSH) || defined(OPENSSL_EXTRA)
 
 /* Set the members of DhKey into WOLFSSL_DH
  * Specify elements to set via the 2nd parameter
@@ -7925,7 +7921,7 @@ void wolfSSL_DH_get0_pqg(const WOLFSSL_DH *dh, const WOLFSSL_BIGNUM **p,
 
 #if !defined(HAVE_FIPS) || (defined(HAVE_FIPS) && !defined(WOLFSSL_DH_EXTRA)) \
  || (defined(HAVE_FIPS_VERSION) && FIPS_VERSION_GT(2,0))
-#if defined(OPENSSL_ALL) || defined(EMBEDDED_SSL) || \
+#if defined(OPENSSL_ALL) || \
     defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
 /* Sets the parameters p, g and optionally q into the DH key.
  *
@@ -8029,7 +8025,7 @@ int wolfSSL_DH_set_length(WOLFSSL_DH *dh, long len)
 
     return ret;
 }
-#endif /* OPENSSL_ALL || EMBEDDED_SSL || (v1.1.0 or later) */
+#endif /* OPENSSL_ALL || (v1.1.0 or later) */
 #endif
 
 /* Get the public and private keys requested.
@@ -8109,7 +8105,7 @@ int wolfSSL_DH_set0_key(WOLFSSL_DH *dh, WOLFSSL_BIGNUM *pub_key,
     return ret;
 }
 
-#endif /* OPENSSL_EXTRA || EMBEDDED_SSL */
+#endif /* OPENSSL_EXTRA */
 
 /*
  * DH check APIs
@@ -8358,7 +8354,7 @@ int wolfSSL_DH_generate_parameters_ex(WOLFSSL_DH* dh, int prime_len,
         * HAVE_LIGHTY || WOLFSSL_HAPROXY || WOLFSSL_OPENSSH ||
         * HAVE_SBLIM_SFCB)) */
 
-#if defined(OPENSSL_EXTRA) || defined(EMBEDDED_SSL)
+#ifdef OPENSSL_EXTRA
 
 #if !defined(HAVE_FIPS) || (defined(HAVE_FIPS) && !defined(WOLFSSL_DH_EXTRA)) \
  || (defined(HAVE_FIPS_VERSION) && FIPS_VERSION_GT(2,0))
@@ -8615,7 +8611,7 @@ int wolfSSL_DH_compute_key(unsigned char* key, const WOLFSSL_BIGNUM* otherPub,
 #endif /* !HAVE_FIPS || (HAVE_FIPS && !WOLFSSL_DH_EXTRA) ||
         * HAVE_FIPS_VERSION > 2 */
 
-#endif /* OPENSSL_EXTRA || EMBEDDED_SSL */
+#endif /* OPENSSL_EXTRA */
 
 #endif /* NO_DH */
 

--- a/libatalk/ssl/src/pk.c
+++ b/libatalk/ssl/src/pk.c
@@ -25,13 +25,19 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
- #include <wolfssl/internal.h>
+#include <wolfssl/internal.h>
 #ifndef WC_NO_RNG
     #include <wolfssl/wolfcrypt/random.h>
 #endif
 
 #ifdef HAVE_ECC
     #include <wolfssl/wolfcrypt/ecc.h>
+    #ifdef HAVE_SELFTEST
+        /* point compression types. */
+        #define ECC_POINT_COMP_EVEN 0x02
+        #define ECC_POINT_COMP_ODD  0x03
+        #define ECC_POINT_UNCOMP    0x04
+    #endif
 #endif
 #ifndef WOLFSSL_HAVE_ECC_KEY_GET_PRIV
     /* FIPS build has replaced ecc.h. */
@@ -47,14 +53,6 @@
 
 #ifndef NO_RSA
     #include <wolfssl/wolfcrypt/rsa.h>
-#endif
-
-#if defined(OPENSSL_EXTRA) && !defined(NO_BIO) && defined(WOLFSSL_KEY_GEN) && \
-    (defined(HAVE_ECC) || (!defined(NO_DSA) && !defined(HAVE_SELFTEST)))
-/* Forward declaration for wolfSSL_PEM_write_bio_DSA_PUBKEY.
- * Implementation in ssl.c.
- */
-static int pem_write_bio_pubkey(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key);
 #endif
 
 /*******************************************************************************
@@ -167,8 +165,7 @@ static int pem_read_bio_key(WOLFSSL_BIO* bio, wc_pem_password_cb* cb,
         /* Write left over data back to BIO if not a file BIO */
         if ((ret > 0) && ((memSz - ret) > 0) &&
                  (bio->type != WOLFSSL_BIO_FILE)) {
-            int res;
-            res = wolfSSL_BIO_write(bio, mem + ret, memSz - ret);
+            int res = wolfSSL_BIO_write(bio, mem + ret, memSz - ret);
             if (res != memSz - ret) {
                 WOLFSSL_ERROR_MSG("Unable to write back excess data");
                 if (res < 0) {
@@ -180,7 +177,7 @@ static int pem_read_bio_key(WOLFSSL_BIO* bio, wc_pem_password_cb* cb,
             }
         }
         if (alloced) {
-            XFREE(mem, NULL, DYNAMIC_TYPE_OPENSSL);
+            XFREE(mem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         }
     }
 
@@ -229,33 +226,36 @@ static int pem_read_file_key(XFILE fp, wc_pem_password_cb* cb, void* pass,
  * @param [in]  heap   Heap hint for dynamic memory allocation.
  * @param [out] out    Allocated buffer containing PEM.
  * @param [out] outSz  Size of PEM encoding.
- * @return  WOLFSSL_FAILURE on error.
- * @return  WOLFSSL_SUCCESS on success.
+ * @return  1 on success.
+ * @return  0 on error.
  */
 static int der_to_pem_alloc(const unsigned char* der, int derSz, int type,
     void* heap, byte** out, int* outSz)
 {
-    int ret = WOLFSSL_SUCCESS;
+    int ret = 1;
     int pemSz;
     byte* pem = NULL;
 
     (void)heap;
 
+    /* Convert DER to PEM - to get size. */
     pemSz = wc_DerToPem(der, (word32)derSz, NULL, 0, type);
     if (pemSz < 0) {
-        ret = WOLFSSL_FAILURE;
+        ret = 0;
     }
 
-    if (ret == WOLFSSL_SUCCESS) {
+    if (ret == 1) {
+        /* Allocate memory for PEM to be encoded into. */
         pem = (byte*)XMALLOC((size_t)pemSz, heap, DYNAMIC_TYPE_TMP_BUFFER);
         if (pem == NULL) {
-            ret = WOLFSSL_FAILURE;
+            ret = 0;
         }
     }
 
-    if ((ret == WOLFSSL_SUCCESS) && (wc_DerToPem(der, (word32)derSz, pem,
-            (word32)pemSz, type) < 0)) {
-        ret = WOLFSSL_FAILURE;
+    /* Convert DER to PEM. */
+    if ((ret == 1) && (wc_DerToPem(der, (word32)derSz, pem, (word32)pemSz,
+            type) < 0)) {
+        ret = 0;
         XFREE(pem, heap, DYNAMIC_TYPE_TMP_BUFFER);
         pem = NULL;
     }
@@ -272,8 +272,8 @@ static int der_to_pem_alloc(const unsigned char* der, int derSz, int type,
  * @param [in]      derSz  Size of DER data in bytes.
  * @param [in, out] bio    BIO object to write with.
  * @param [in]      type   Type of key being encoded.
- * @return  WOLFSSL_FAILURE on error.
- * @return  WOLFSSL_SUCCESS on success.
+ * @return  1 on success.
+ * @return  0 on error.
  */
 static int der_write_to_bio_as_pem(const unsigned char* der, int derSz,
     WOLFSSL_BIO* bio, int type)
@@ -283,11 +283,11 @@ static int der_write_to_bio_as_pem(const unsigned char* der, int derSz,
     byte* pem = NULL;
 
     ret = der_to_pem_alloc(der, derSz, type, bio->heap, &pem, &pemSz);
-    if (ret == WOLFSSL_SUCCESS) {
+    if (ret == 1) {
         int len = wolfSSL_BIO_write(bio, pem, pemSz);
         if (len != pemSz) {
             WOLFSSL_ERROR_MSG("Unable to write full PEM to BIO");
-            ret = WOLFSSL_FAILURE;
+            ret = 0;
         }
     }
 
@@ -308,8 +308,8 @@ static int der_write_to_bio_as_pem(const unsigned char* der, int derSz,
  * @param [in] fp     File pointer to write with.
  * @param [in] type   Type of key being encoded.
  * @param [in] heap   Heap hint for dynamic memory allocation.
- * @return  WOLFSSL_FAILURE on error.
- * @return  WOLFSSL_SUCCESS on success.
+ * @return  1 on success.
+ * @return  0 on error.
  */
 static int der_write_to_file_as_pem(const unsigned char* der, int derSz,
     XFILE fp, int type, void* heap)
@@ -319,11 +319,11 @@ static int der_write_to_file_as_pem(const unsigned char* der, int derSz,
     byte* pem = NULL;
 
     ret = der_to_pem_alloc(der, derSz, type, heap, &pem, &pemSz);
-    if (ret == WOLFSSL_SUCCESS) {
+    if (ret == 1) {
         int len = (int)XFWRITE(pem, 1, (size_t)pemSz, fp);
         if (len != pemSz) {
             WOLFSSL_ERROR_MSG("Unable to write full PEM to BIO");
-            ret = WOLFSSL_FAILURE;
+            ret = 0;
         }
     }
 
@@ -333,9 +333,153 @@ static int der_write_to_file_as_pem(const unsigned char* der, int derSz,
 #endif
 #endif
 
+#if defined(WOLFSSL_KEY_GEN) && defined(WOLFSSL_PEM_TO_DER)
+/* Encrypt private key into PEM format.
+ *
+ * DER is encrypted in place.
+ *
+ * @param [in]  der         DER encoding of private key.
+ * @param [in]  derSz       Size of DER in bytes.
+ * @param [in]  cipher      EVP cipher.
+ * @param [in]  passwd      Password to use with encryption.
+ * @param [in]  passedSz    Size of password in bytes.
+ * @param [out] cipherInfo  PEM cipher information lines.
+ * @param [in]  maxDerSz    Maximum size of DER buffer.
+ * @return  1 on success.
+ * @return  0 on error.
+ */
+int EncryptDerKey(byte *der, int *derSz, const EVP_CIPHER* cipher,
+    unsigned char* passwd, int passwdSz, byte **cipherInfo, int maxDerSz)
+{
+    int ret = 0;
+    int paddingSz = 0;
+    word32 idx;
+    word32 cipherInfoSz;
+#ifdef WOLFSSL_SMALL_STACK
+    EncryptedInfo* info = NULL;
+#else
+    EncryptedInfo  info[1];
+#endif
+
+    WOLFSSL_ENTER("EncryptDerKey");
+
+    /* Validate parameters. */
+    if ((der == NULL) || (derSz == NULL) || (cipher == NULL) ||
+            (passwd == NULL) || (cipherInfo == NULL)) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    #ifdef WOLFSSL_SMALL_STACK
+    if (ret == 0) {
+        /* Allocate encrypted info. */
+        info = (EncryptedInfo*)XMALLOC(sizeof(EncryptedInfo), NULL,
+            DYNAMIC_TYPE_ENCRYPTEDINFO);
+        if (info == NULL) {
+            WOLFSSL_MSG("malloc failed");
+            ret = 0;
+        }
+    }
+    #endif
+    if (ret == 0) {
+        /* Clear the encrypted info and set name. */
+        XMEMSET(info, 0, sizeof(EncryptedInfo));
+        XSTRNCPY(info->name, cipher, NAME_SZ - 1);
+        info->name[NAME_SZ - 1] = '\0'; /* null term */
+
+        /* Get encrypted info from name. */
+        ret = wc_EncryptedInfoGet(info, info->name);
+        if (ret != 0) {
+            WOLFSSL_MSG("unsupported cipher");
+        }
+    }
+
+    if (ret == 0) {
+        /* Generate a random salt. */
+        if (wolfSSL_RAND_bytes(info->iv, info->ivSz) != 1) {
+            WOLFSSL_MSG("generate iv failed");
+            ret = -1;
+        }
+    }
+
+    if (ret == 0) {
+        /* Calculate padding size - always a padding block. */
+        paddingSz = info->ivSz - ((*derSz) % info->ivSz);
+        /* Check der is big enough. */
+        if (maxDerSz < (*derSz) + paddingSz) {
+            WOLFSSL_MSG("not enough DER buffer allocated");
+            ret = BAD_FUNC_ARG;
+        }
+    }
+    if (ret == 0) {
+        /* Set padding bytes to padding length. */
+        XMEMSET(der + (*derSz), (byte)paddingSz, paddingSz);
+        /* Add padding to DER size. */
+        (*derSz) += (int)paddingSz;
+
+        /* Encrypt DER buffer. */
+        ret = wc_BufferKeyEncrypt(info, der, (word32)*derSz, passwd, passwdSz, WC_MD5);
+        if (ret != 0) {
+            WOLFSSL_MSG("encrypt key failed");
+        }
+    }
+
+    if (ret == 0) {
+        /* Create cipher info : 'cipher_name,Salt(hex)' */
+        cipherInfoSz = (word32)(2 * info->ivSz + XSTRLEN(info->name) + 2);
+        /* Allocate memory for PEM encryption lines. */
+        *cipherInfo = (byte*)XMALLOC(cipherInfoSz, NULL, DYNAMIC_TYPE_STRING);
+        if (*cipherInfo == NULL) {
+            WOLFSSL_MSG("malloc failed");
+            ret = MEMORY_E;
+        }
+    }
+    if (ret == 0) {
+        /* Copy in name and add on comma. */
+        XSTRLCPY((char*)*cipherInfo, info->name, cipherInfoSz);
+        XSTRLCAT((char*)*cipherInfo, ",", cipherInfoSz);
+
+        /* Find end of string. */
+        idx = (word32)XSTRLEN((char*)*cipherInfo);
+        /* Calculate remaining bytes. */
+        cipherInfoSz -= idx;
+
+        /* Encode IV into PEM encryption lines. */
+        ret = Base16_Encode(info->iv, info->ivSz, *cipherInfo + idx,
+            &cipherInfoSz);
+        if (ret != 0) {
+            WOLFSSL_MSG("Base16_Encode failed");
+            XFREE(*cipherInfo, NULL, DYNAMIC_TYPE_STRING);
+            *cipherInfo = NULL;
+        }
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    /* Free dynamically allocated info. */
+    XFREE(info, NULL, DYNAMIC_TYPE_ENCRYPTEDINFO);
+#endif
+    return ret == 0;
+}
+#endif /* WOLFSSL_KEY_GEN || WOLFSSL_PEM_TO_DER */
+
+
 #if defined(WOLFSSL_KEY_GEN) && \
     (defined(WOLFSSL_PEM_TO_DER) || defined(WOLFSSL_DER_TO_PEM)) && \
     (!defined(NO_RSA) || defined(HAVE_ECC))
+/* Encrypt the DER in PEM format.
+ *
+ * @param [in]  der       DER encoded private key.
+ * @param [in]  derSz     Size of DER in bytes.
+ * @param [in]  cipher    EVP cipher.
+ * @param [in]  passwd    Password to use in encryption.
+ * @param [in]  passwdSz  Size of password in bytes.
+ * @param [in]  type      PEM type of write out.
+ * @param [in]  heap      Dynamic memory hint.
+ * @param [out] out       Allocated buffer containing PEM encoding.
+ *                        heap was NULL and dynamic type is DYNAMIC_TYPE_KEY.
+ * @param [out] outSz     Size of PEM encoding in bytes.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
 static int der_to_enc_pem_alloc(unsigned char* der, int derSz,
     const EVP_CIPHER *cipher, unsigned char *passwd, int passwdSz, int type,
     void* heap, byte** out, int* outSz)
@@ -736,8 +880,11 @@ static int wolfssl_print_number(WOLFSSL_BIO* bio, mp_int* num, const char* name,
 
 #endif /* XSNPRINTF && !NO_BIO && !NO_RSA */
 
-#if !defined(NO_RSA) || (!defined(NO_DH) && !defined(NO_CERTS) && \
-    defined(HAVE_FIPS) && !FIPS_VERSION_GT(2,0)) || defined(HAVE_ECC)
+#endif /* OPENSSL_EXTRA */
+
+#if !defined(NO_CERTS) || (defined(OPENSSL_EXTRA) && (!defined(NO_RSA) || \
+    (!defined(NO_DH) && defined(HAVE_FIPS) && !FIPS_VERSION_GT(2,0)) || \
+    defined(HAVE_ECC)))
 
 /* Uses the DER SEQUENCE to determine size of DER data.
  *
@@ -765,9 +912,7 @@ static int wolfssl_der_length(const unsigned char* seq, int len)
     return ret;
 }
 
-#endif /* !NO_RSA */
-
-#endif /* OPENSSL_EXTRA */
+#endif
 
 /*******************************************************************************
  * START OF RSA API
@@ -1659,7 +1804,7 @@ int wolfSSL_RSA_LoadDer_ex(WOLFSSL_RSA* rsa, const unsigned char* derBuf,
             rsa->pkcs8HeaderSz = (word16)idx;
         }
         /* When decoding and not PKCS#8, return will be ASN_PARSE_E. */
-        else if (res != ASN_PARSE_E) {
+        else if (res != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
             /* Something went wrong while decoding. */
             WOLFSSL_ERROR_MSG("Unexpected error with trying to remove PKCS#8 "
                               "header");
@@ -1787,7 +1932,7 @@ int wolfSSL_PEM_write_bio_RSA_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_RSA* rsa)
         ret = 0;
     }
     if ((ret == 1) && (der_write_to_bio_as_pem(derBuf, derSz, bio,
-            PUBLICKEY_TYPE) != WOLFSSL_SUCCESS)) {
+            PUBLICKEY_TYPE) != 1)) {
         ret = 0;
     }
 
@@ -1832,7 +1977,7 @@ static int wolfssl_pem_write_rsa_public_key(XFILE fp, WOLFSSL_RSA* rsa,
         ret = 0;
     }
     if ((ret == 1) && (der_write_to_file_as_pem(derBuf, derSz, fp, type,
-            rsa->heap) != WOLFSSL_SUCCESS)) {
+            rsa->heap) != 1)) {
         ret = 0;
     }
 
@@ -2559,7 +2704,7 @@ int SetRsaInternal(WOLFSSL_RSA* rsa)
         }
 
         /* Copy down d mod q-1 if available. */
-        if ((ret == 1) && (rsa->dmp1 != NULL) &&
+        if ((ret == 1) && (rsa->dmq1 != NULL) &&
                 (wolfssl_bn_get_value(rsa->dmq1, &key->dQ) != 1)) {
             WOLFSSL_ERROR_MSG("rsa dQ key error");
             ret = -1;
@@ -3239,7 +3384,7 @@ WOLFSSL_RSA* wolfSSL_RSA_generate_key(int bits, unsigned long e,
         ret = wolfssl_rsa_generate_key_native(rsa, bits, bn, NULL);
     #ifdef HAVE_FIPS
         /* Keep trying if failed to find a prime. */
-        if (ret == PRIME_GEN_E) {
+        if (ret == WC_NO_ERR_TRACE(PRIME_GEN_E)) {
             continue;
         }
     #endif
@@ -3290,7 +3435,7 @@ int wolfSSL_RSA_generate_key_ex(WOLFSSL_RSA* rsa, int bits, WOLFSSL_BIGNUM* e,
             int gen_ret = wolfssl_rsa_generate_key_native(rsa, bits, e, cb);
         #ifdef HAVE_FIPS
             /* Keep trying again if public key value didn't work. */
-            if (gen_ret == PRIME_GEN_E) {
+            if (gen_ret == WC_NO_ERR_TRACE(PRIME_GEN_E)) {
                 continue;
             }
         #endif
@@ -3419,7 +3564,7 @@ int wolfSSL_RSA_padding_add_PKCS1_PSS(WOLFSSL_RSA *rsa, unsigned char *em,
     if (ret == 1) {
         /* Get length of RSA key - encrypted message length. */
         emLen = wolfSSL_RSA_size(rsa);
-        if (ret <= 0) {
+        if (emLen <= 0) {
             WOLFSSL_ERROR_MSG("wolfSSL_RSA_size error");
             ret = 0;
         }
@@ -5468,7 +5613,7 @@ int wolfSSL_DSA_do_verify_ex(const unsigned char* digest, int digest_len,
 }
 #endif /* !HAVE_SELFTEST */
 
-WOLFSSL_API int wolfSSL_i2d_DSAparams(const WOLFSSL_DSA* dsa,
+int wolfSSL_i2d_DSAparams(const WOLFSSL_DSA* dsa,
     unsigned char** out)
 {
     int ret = 0;
@@ -5485,7 +5630,7 @@ WOLFSSL_API int wolfSSL_i2d_DSAparams(const WOLFSSL_DSA* dsa,
     if (ret == 0) {
         key = (DsaKey*)dsa->internal;
         ret = wc_DsaKeyToParamsDer_ex(key, NULL, &derLen);
-        if (ret == LENGTH_ONLY_E) {
+        if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             ret = 0;
         }
     }
@@ -5577,99 +5722,115 @@ WOLFSSL_DSA* wolfSSL_d2i_DSAparams(WOLFSSL_DSA** dsa, const unsigned char** der,
  * Returns 1 or 0
  */
 int wolfSSL_PEM_write_bio_DSAPrivateKey(WOLFSSL_BIO* bio, WOLFSSL_DSA* dsa,
-                                       const EVP_CIPHER* cipher,
-                                       unsigned char* passwd, int len,
-                                       wc_pem_password_cb* cb, void* arg)
+    const EVP_CIPHER* cipher, unsigned char* passwd, int passwdSz,
+    wc_pem_password_cb* cb, void* arg)
 {
-    int ret = 0, der_max_len = 0, derSz = 0;
-    byte *derBuf;
-    WOLFSSL_EVP_PKEY* pkey;
+    int ret = 1;
+    byte *pem = NULL;
+    int pLen = 0;
 
     WOLFSSL_ENTER("wolfSSL_PEM_write_bio_DSAPrivateKey");
 
-    if (bio == NULL || dsa == NULL) {
+    (void)cb;
+    (void)arg;
+
+    /* Validate parameters. */
+    if ((bio == NULL) || (dsa == NULL)) {
         WOLFSSL_MSG("Bad Function Arguments");
-        return 0;
+        ret = 0;
     }
 
-    pkey = wolfSSL_EVP_PKEY_new_ex(bio->heap);
-    if (pkey == NULL) {
-        WOLFSSL_MSG("wolfSSL_EVP_PKEY_new_ex failed");
-        return 0;
+    if (ret == 1) {
+        ret = wolfSSL_PEM_write_mem_DSAPrivateKey(dsa, cipher, passwd, passwdSz,
+            &pem, &pLen);
     }
 
-    pkey->type   = EVP_PKEY_DSA;
-    pkey->dsa    = dsa;
-    pkey->ownDsa = 0;
-
-    /* 4 > size of pub, priv, p, q, g + ASN.1 additional information */
-    der_max_len = MAX_DSA_PRIVKEY_SZ;
-
-    derBuf = (byte*)XMALLOC((size_t)der_max_len, bio->heap,
-        DYNAMIC_TYPE_TMP_BUFFER);
-    if (derBuf == NULL) {
-        WOLFSSL_MSG("Malloc failed");
-        wolfSSL_EVP_PKEY_free(pkey);
-        return 0;
+    /* Write PEM to BIO. */
+    if ((ret == 1) && (wolfSSL_BIO_write(bio, pem, pLen) != pLen)) {
+        WOLFSSL_ERROR_MSG("DSA private key BIO write failed");
+        ret = 0;
     }
 
-    /* convert key to der format */
-    derSz = wc_DsaKeyToDer((DsaKey*)dsa->internal, derBuf, (word32)der_max_len);
-    if (derSz < 0) {
-        WOLFSSL_MSG("wc_DsaKeyToDer failed");
-        XFREE(derBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        wolfSSL_EVP_PKEY_free(pkey);
-        return 0;
-    }
-
-    pkey->pkey.ptr = (char*)XMALLOC((size_t)derSz, bio->heap,
-        DYNAMIC_TYPE_TMP_BUFFER);
-    if (pkey->pkey.ptr == NULL) {
-        WOLFSSL_MSG("key malloc failed");
-        XFREE(derBuf, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
-        wolfSSL_EVP_PKEY_free(pkey);
-        return 0;
-    }
-
-    /* add der info to the evp key */
-    pkey->pkey_sz = derSz;
-    XMEMCPY(pkey->pkey.ptr, derBuf, (size_t)derSz);
-    XFREE(derBuf, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
-
-    ret = wolfSSL_PEM_write_bio_PrivateKey(bio, pkey, cipher, passwd, len,
-                                        cb, arg);
-    wolfSSL_EVP_PKEY_free(pkey);
-
+    XFREE(pem, NULL, DYNAMIC_TYPE_KEY);
     return ret;
 }
 
 #ifndef HAVE_SELFTEST
+/* Encode the DSA public key as DER.
+ *
+ * @param [in]  key   DSA key to encode.
+ * @param [out] der   Pointer through which buffer is returned.
+ * @param [in]  heap  Heap hint.
+ * @return  Size of encoding on success.
+ * @return  0 on error.
+ */
+static int wolfssl_dsa_key_to_pubkey_der(WOLFSSL_DSA* key, unsigned char** der,
+    void* heap)
+{
+    int sz;
+    unsigned char* buf = NULL;
+
+    /* Use maximum encoded size to allocate. */
+    sz = MAX_DSA_PUBKEY_SZ;
+    /* Allocate memory to hold encoding. */
+    buf = (byte*)XMALLOC((size_t)sz, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (buf == NULL) {
+        WOLFSSL_MSG("malloc failed");
+        sz = 0;
+    }
+    if (sz > 0) {
+        /* Encode public key to DER using wolfSSL.  */
+        sz = wc_DsaKeyToPublicDer((DsaKey*)key->internal, buf, (word32)sz);
+        if (sz < 0) {
+            WOLFSSL_MSG("wc_DsaKeyToPublicDer failed");
+            sz = 0;
+        }
+    }
+
+    /* Return buffer on success. */
+    if (sz > 0) {
+        *der = buf;
+    }
+    else {
+        /* Dispose of any dynamically allocated data not returned. */
+        XFREE(buf, heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+
+    return sz;
+}
+
 /* Takes a DSA public key and writes it out to a WOLFSSL_BIO
  * Returns 1 or 0
  */
 int wolfSSL_PEM_write_bio_DSA_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_DSA* dsa)
 {
-    int ret = 0;
-    WOLFSSL_EVP_PKEY* pkey;
+    int ret = 1;
+    unsigned char* derBuf = NULL;
+    int derSz = 0;
+
     WOLFSSL_ENTER("wolfSSL_PEM_write_bio_DSA_PUBKEY");
 
-    if (bio == NULL || dsa == NULL) {
-        WOLFSSL_MSG("Bad function arguments");
+    /* Validate parameters. */
+    if ((bio == NULL) || (dsa == NULL)) {
+        WOLFSSL_MSG("Bad Function Arguments");
         return 0;
     }
 
-    pkey = wolfSSL_EVP_PKEY_new_ex(bio->heap);
-    if (pkey == NULL) {
-        WOLFSSL_MSG("wolfSSL_EVP_PKEY_new_ex failed");
-        return 0;
+    /* Encode public key in EC key as DER. */
+    derSz = wolfssl_dsa_key_to_pubkey_der(dsa, &derBuf, bio->heap);
+    if (derSz == 0) {
+        ret = 0;
     }
 
-    pkey->type   = EVP_PKEY_DSA;
-    pkey->dsa    = dsa;
-    pkey->ownDsa = 0;
+    /* Write out to BIO the PEM encoding of the DSA public key. */
+    if ((ret == 1) && (der_write_to_bio_as_pem(derBuf, derSz, bio,
+            PUBLICKEY_TYPE) != 1)) {
+        ret = 0;
+    }
 
-    ret = pem_write_bio_pubkey(bio, pkey);
-    wolfSSL_EVP_PKEY_free(pkey);
+    /* Dispose of any dynamically allocated data. */
+    XFREE(derBuf, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+
     return ret;
 }
 #endif /* HAVE_SELFTEST */
@@ -7305,7 +7466,7 @@ int wolfSSL_i2d_DHparams(const WOLFSSL_DH *dh, unsigned char **out)
             *out += len;
         }
         /* An error occurred unless only length returned. */
-        else if (ret != LENGTH_ONLY_E) {
+        else if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             err = 1;
         }
     }
@@ -7455,7 +7616,7 @@ static WOLFSSL_DH *wolfssl_dhparams_read_pem(WOLFSSL_DH **dh,
     }
     if (memAlloced) {
         /* PEM data no longer needed.  */
-        XFREE(pem, NULL, DYNAMIC_TYPE_PEM);
+        XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     }
 
     if (!err) {
@@ -7610,7 +7771,7 @@ static int wolfssl_dhparams_to_der(WOLFSSL_DH* dh, unsigned char** out,
         /* Use wolfSSL API to get length of DER encode DH parameters. */
         key = (DhKey*)dh->internal;
         ret = wc_DhParamsToDer(key, NULL, &derSz);
-        if (ret != LENGTH_ONLY_E) {
+        if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             WOLFSSL_ERROR_MSG("Failed to get size of DH params");
             err = 1;
         }
@@ -7681,7 +7842,7 @@ int wolfSSL_PEM_write_DHparams(XFILE fp, WOLFSSL_DH* dh)
         }
     }
     if ((ret == 1) && (der_write_to_file_as_pem(derBuf, derSz, fp,
-            DH_PARAM_TYPE, NULL) != WOLFSSL_SUCCESS)) {
+            DH_PARAM_TYPE, NULL) != 1)) {
         ret = 0;
     }
 
@@ -8569,7 +8730,7 @@ int wolfSSL_DH_compute_key(unsigned char* key, const WOLFSSL_BIGNUM* otherPub,
     if (ret == 0) {
         /* Get the public key into the array. */
         pubSz  = wolfSSL_BN_bn2bin(otherPub, pub);
-        if (privSz <= 0) {
+        if (pubSz <= 0) {
             ret = -1;
         }
     }
@@ -9715,7 +9876,6 @@ void wolfSSL_EC_POINT_dump(const char *msg, const WOLFSSL_EC_POINT *point)
 #endif
 }
 
-#ifndef HAVE_SELFTEST
 /* Convert EC point to hex string that as either uncompressed or compressed.
  *
  * ECC point compression types were not included in selftest ecc.h
@@ -9828,7 +9988,100 @@ char* wolfSSL_EC_POINT_point2hex(const WOLFSSL_EC_GROUP* group,
     return hex;
 }
 
-#endif /* HAVE_SELFTEST */
+static size_t hex_to_bytes(const char *hex, unsigned char *output, size_t sz)
+{
+    word32 i;
+    for (i = 0; i < sz; i++) {
+        signed char ch1, ch2;
+        ch1 = HexCharToByte(hex[i * 2]);
+        ch2 = HexCharToByte(hex[i * 2 + 1]);
+        if ((ch1 < 0) || (ch2 < 0)) {
+            WOLFSSL_MSG("hex_to_bytes: syntax error");
+            return 0;
+        }
+        output[i] = (unsigned char)((ch1 << 4) + ch2);
+    }
+    return sz;
+}
+
+WOLFSSL_EC_POINT* wolfSSL_EC_POINT_hex2point(const EC_GROUP *group,
+            const char *hex, WOLFSSL_EC_POINT*p, WOLFSSL_BN_CTX *ctx)
+{
+    /* for uncompressed mode */
+    size_t str_sz;
+    BIGNUM *Gx  = NULL;
+    BIGNUM *Gy  = NULL;
+    char   strGx[MAX_ECC_BYTES * 2 + 1];
+
+    /* for compressed mode */
+    int    key_sz;
+    byte   *octGx = (byte *)strGx; /* octGx[MAX_ECC_BYTES] */
+
+    int p_alloc = 0;
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_EC_POINT_hex2point");
+
+    if (group == NULL || hex == NULL || ctx == NULL)
+        return NULL;
+
+    if (p == NULL) {
+        if ((p = wolfSSL_EC_POINT_new(group)) == NULL) {
+            WOLFSSL_MSG("wolfSSL_EC_POINT_new");
+            goto err;
+        }
+        p_alloc = 1;
+    }
+
+    key_sz = (wolfSSL_EC_GROUP_get_degree(group) + 7) / 8;
+    if (hex[0] ==  '0' && hex[1] == '4') { /* uncompressed mode */
+        str_sz = key_sz * 2;
+
+        XMEMSET(strGx, 0x0, str_sz + 1);
+        XMEMCPY(strGx, hex + 2, str_sz);
+
+        if (wolfSSL_BN_hex2bn(&Gx, strGx) == 0)
+            goto err;
+
+        if (wolfSSL_BN_hex2bn(&Gy, hex + 2 + str_sz) == 0)
+            goto err;
+
+        ret = wolfSSL_EC_POINT_set_affine_coordinates_GFp
+                                            (group, p, Gx, Gy, ctx);
+
+        if (ret != WOLFSSL_SUCCESS) {
+            WOLFSSL_MSG("wolfSSL_EC_POINT_set_affine_coordinates_GFp");
+            goto err;
+        }
+    }
+    else if (hex[0] == '0' && (hex[1] == '2' || hex[1] == '3')) {
+        size_t sz = XSTRLEN(hex + 2) / 2;
+        /* compressed mode */
+        octGx[0] = ECC_POINT_COMP_ODD;
+        if (hex_to_bytes(hex + 2, octGx + 1, sz) != sz) {
+            goto err;
+        }
+        if (wolfSSL_ECPoint_d2i(octGx, key_sz + 1, group, p)
+                                            != WOLFSSL_SUCCESS) {
+            goto err;
+        }
+    }
+    else
+        goto err;
+
+    wolfSSL_BN_free(Gx);
+    wolfSSL_BN_free(Gy);
+    return p;
+
+err:
+    wolfSSL_BN_free(Gx);
+    wolfSSL_BN_free(Gy);
+    if (p_alloc) {
+        EC_POINT_free(p);
+    }
+    return NULL;
+
+}
 
 /* Encode the EC point as an uncompressed point in DER.
  *
@@ -9871,7 +10124,8 @@ int wolfSSL_ECPoint_i2d(const WOLFSSL_EC_GROUP *group,
         int ret = wc_ecc_export_point_der(group->curve_idx,
             (ecc_point*)point->internal, out, len);
         /* Check return. When out is NULL, return will be length only error. */
-        if ((ret != MP_OKAY) && ((out != NULL) || (ret != LENGTH_ONLY_E))) {
+        if ((ret != MP_OKAY) && ((out != NULL) ||
+                                 (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)))) {
             WOLFSSL_MSG("wolfSSL_ECPoint_i2d wc_ecc_export_point_der failed");
             res = 0;
         }
@@ -11549,7 +11803,8 @@ static int wolfssl_ec_key_int_copy(ecc_key* dst, const ecc_key* src)
 
     if (ret == 0) {
         /* Copy private key. */
-        ret = mp_copy(wc_ecc_key_get_priv(src), wc_ecc_key_get_priv(dst));
+        ret = mp_copy(wc_ecc_key_get_priv((ecc_key*)src),
+            wc_ecc_key_get_priv(dst));
         if (ret != MP_OKAY) {
             WOLFSSL_MSG("mp_copy error");
         }
@@ -12005,7 +12260,7 @@ int wolfSSL_EC_KEY_LoadDer_ex(WOLFSSL_EC_KEY* key, const unsigned char* derBuf,
             res = 1;
         }
         /* Error out on parsing error. */
-        else if (ret != ASN_PARSE_E) {
+        else if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
             WOLFSSL_MSG("Unexpected error with trying to remove PKCS8 header");
             res = -1;
         }
@@ -12076,12 +12331,9 @@ int wolfSSL_EC_KEY_LoadDer_ex(WOLFSSL_EC_KEY* key, const unsigned char* derBuf,
  * EC key PEM APIs
  */
 
-#if (defined(WOLFSSL_KEY_GEN) && !defined(NO_FILESYSTEM)) || \
-    (!defined(NO_BIO) && (defined(WOLFSSL_KEY_GEN) || \
-     defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT)))
+#ifdef HAVE_ECC_KEY_EXPORT
+#if defined(WOLFSSL_KEY_GEN) && (!defined(NO_FILESYSTEM) || !defined(NO_BIO))
 /* Encode the EC public key as DER.
- *
- * Also used by pem_write_pubkey().
  *
  * @param [in]  key   EC key to encode.
  * @param [out] der   Pointer through which buffer is returned.
@@ -12175,6 +12427,7 @@ int wolfSSL_PEM_write_EC_PUBKEY(XFILE fp, WOLFSSL_EC_KEY* key)
 
     return ret;
 }
+#endif
 #endif
 
 #ifndef NO_BIO
@@ -12302,7 +12555,7 @@ WOLFSSL_EC_KEY* wolfSSL_PEM_read_bio_ECPrivateKey(WOLFSSL_BIO* bio,
 }
 #endif /* !NO_BIO */
 
-#if defined(WOLFSSL_KEY_GEN)
+#if defined(WOLFSSL_KEY_GEN) && defined(HAVE_ECC_KEY_EXPORT)
 #ifndef NO_BIO
 /* Write out the EC public key as PEM to the BIO.
  *
@@ -12331,7 +12584,7 @@ int wolfSSL_PEM_write_bio_EC_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_EC_KEY* ec)
         ret = 0;
     }
 
-    /* Write out to BIO the PEM encoding of the EC private key. */
+    /* Write out to BIO the PEM encoding of the EC public key. */
     if ((ret == 1) && (der_write_to_bio_as_pem(derBuf, derSz, bio,
             ECC_PUBLICKEY_TYPE) != 1)) {
         ret = 0;
@@ -12534,7 +12787,7 @@ int wolfSSL_PEM_write_ECPrivateKey(XFILE fp, WOLFSSL_EC_KEY *ec,
 }
 
 #endif /* NO_FILESYSTEM */
-#endif /* defined(WOLFSSL_KEY_GEN) */
+#endif /* WOLFSSL_KEY_GEN && HAVE_ECC_KEY_EXPORT */
 
 /*
  * EC key print APIs
@@ -13106,13 +13359,17 @@ int wolfSSL_EC_KEY_generate_key(WOLFSSL_EC_KEY *key)
         /* Check if we know which internal curve index to use. */
         if (key->group->curve_idx < 0) {
             /* Generate key using the default curve. */
+#if FIPS_VERSION3_GE(6,0,0)
+            key->group->curve_idx = ECC_SECP256R1; /* FIPS default to 256 */
+#else
             key->group->curve_idx = ECC_CURVE_DEF;
+#endif
         }
 
         /* Create a random number generator. */
         rng = wolfssl_make_rng(tmpRng, &initTmpRng);
         if (rng == NULL) {
-            WOLFSSL_MSG("wolfSSL_EC_KEY_generate_key failed to set RNG");
+            WOLFSSL_MSG("wolfSSL_EC_KEY_generate_key failed to make RNG");
             res = 0;
         }
     }
@@ -13120,11 +13377,30 @@ int wolfSSL_EC_KEY_generate_key(WOLFSSL_EC_KEY *key)
         /* NIDToEccEnum returns -1 for invalid NID so if key->group->curve_nid
          * is 0 then pass ECC_CURVE_DEF as arg */
         int eccEnum = key->group->curve_nid ?
+#if FIPS_VERSION3_GE(6,0,0)
+            NIDToEccEnum(key->group->curve_nid) : ECC_SECP256R1;
+#else
             NIDToEccEnum(key->group->curve_nid) : ECC_CURVE_DEF;
+#endif
         /* Get the internal EC key. */
         ecc_key* ecKey = (ecc_key*)key->internal;
         /* Make the key using internal API. */
-        int ret = wc_ecc_make_key_ex(rng, 0, ecKey, eccEnum);
+        int ret = 0;
+
+#if FIPS_VERSION3_GE(6,0,0)
+        /* In the case of FIPS only allow key generation with approved curves */
+        if (eccEnum != ECC_SECP256R1 && eccEnum != ECC_SECP224R1 &&
+            eccEnum != ECC_SECP384R1 && eccEnum != ECC_SECP521R1) {
+            WOLFSSL_MSG("Unsupported curve selected in FIPS mode");
+            res = 0;
+        }
+        if (res == 1) {
+#endif
+        ret  = wc_ecc_make_key_ex(rng, 0, ecKey, eccEnum);
+#if FIPS_VERSION3_GE(6,0,0)
+        }
+#endif
+
     #if defined(WOLFSSL_ASYNC_CRYPT)
         /* Wait on asynchronouse operation. */
         ret = wc_AsyncWait(ret, &ecKey->asyncDev, WC_ASYNC_FLAG_NONE);
@@ -13383,6 +13659,7 @@ WOLFSSL_ECDSA_SIG* wolfSSL_d2i_ECDSA_SIG(WOLFSSL_ECDSA_SIG** sig,
 int wolfSSL_i2d_ECDSA_SIG(const WOLFSSL_ECDSA_SIG *sig, unsigned char **pp)
 {
     word32 len = 0;
+    int    update_p = 1;
 
     /* Validate parameter. */
     if (sig != NULL) {
@@ -13402,6 +13679,17 @@ int wolfSSL_i2d_ECDSA_SIG(const WOLFSSL_ECDSA_SIG *sig, unsigned char **pp)
         /* Add in the length of the SEQUENCE. */
         len += (word32)1 + ASN_LEN_SIZE(len);
 
+        #ifdef WOLFSSL_I2D_ECDSA_SIG_ALLOC
+        if ((pp != NULL) && (*pp == NULL)) {
+            *pp = (unsigned char *)XMALLOC(len, NULL, DYNAMIC_TYPE_OPENSSL);
+            if (*pp != NULL) {
+                WOLFSSL_MSG("malloc error");
+                return 0;
+            }
+            update_p = 0;
+        }
+        #endif
+
         /* Encode only if there is a buffer to encode into. */
         if ((pp != NULL) && (*pp != NULL)) {
             /* Encode using the internal representations of r and s. */
@@ -13410,7 +13698,7 @@ int wolfSSL_i2d_ECDSA_SIG(const WOLFSSL_ECDSA_SIG *sig, unsigned char **pp)
                 /* No bytes encoded. */
                 len = 0;
             }
-            else {
+            else if (update_p) {
                 /* Update pointer to after encoding. */
                 *pp += len;
             }
@@ -13861,12 +14149,2311 @@ int wolfSSL_ECDH_compute_key(void *out, size_t outLen,
 
 /* End ECDH */
 
+#ifndef NO_WOLFSSL_STUB
+const WOLFSSL_EC_KEY_METHOD *wolfSSL_EC_KEY_OpenSSL(void)
+{
+    WOLFSSL_STUB("wolfSSL_EC_KEY_OpenSSL");
+
+    return NULL;
+}
+
+WOLFSSL_EC_KEY_METHOD *wolfSSL_EC_KEY_METHOD_new(
+        const WOLFSSL_EC_KEY_METHOD *meth)
+{
+    WOLFSSL_STUB("wolfSSL_EC_KEY_METHOD_new");
+
+    (void)meth;
+
+    return NULL;
+}
+
+void wolfSSL_EC_KEY_METHOD_free(WOLFSSL_EC_KEY_METHOD *meth)
+{
+    WOLFSSL_STUB("wolfSSL_EC_KEY_METHOD_free");
+
+    (void)meth;
+}
+
+void wolfSSL_EC_KEY_METHOD_set_init(WOLFSSL_EC_KEY_METHOD *meth,
+        void* a1, void* a2, void* a3, void* a4, void* a5, void* a6)
+{
+    WOLFSSL_STUB("wolfSSL_EC_KEY_METHOD_set_init");
+
+    (void)meth;
+    (void)a1;
+    (void)a2;
+    (void)a3;
+    (void)a4;
+    (void)a5;
+    (void)a6;
+}
+
+void wolfSSL_EC_KEY_METHOD_set_sign(WOLFSSL_EC_KEY_METHOD *meth,
+        void* a1, void* a2, void* a3)
+{
+    WOLFSSL_STUB("wolfSSL_EC_KEY_METHOD_set_sign");
+
+    (void)meth;
+    (void)a1;
+    (void)a2;
+    (void)a3;
+}
+
+const WOLFSSL_EC_KEY_METHOD *wolfSSL_EC_KEY_get_method(
+        const WOLFSSL_EC_KEY *key)
+{
+    WOLFSSL_STUB("wolfSSL_EC_KEY_get_method");
+
+    (void)key;
+
+    return NULL;
+}
+
+int wolfSSL_EC_KEY_set_method(WOLFSSL_EC_KEY *key,
+        const WOLFSSL_EC_KEY_METHOD *meth)
+{
+    WOLFSSL_STUB("wolfSSL_EC_KEY_set_method");
+
+    (void)key;
+    (void)meth;
+
+    return 0;
+}
+
+#endif /* !NO_WOLFSSL_STUB */
+
 #endif /* OPENSSL_EXTRA */
 
 #endif /* HAVE_ECC */
 
 /*******************************************************************************
  * END OF EC API
+ ******************************************************************************/
+
+/*******************************************************************************
+ * START OF EC25519 API
+ ******************************************************************************/
+
+#if defined(OPENSSL_EXTRA) && defined(HAVE_CURVE25519)
+
+/* Generate an EC25519 key pair.
+ *
+ * Output keys are in little endian format.
+ *
+ * @param [out]     priv    EC25519 private key data.
+ * @param [in, out] privSz  On in, the size of priv in bytes.
+ *                          On out, the length of the private key data in bytes.
+ * @param [out]     pub     EC25519 public key data.
+ * @param [in, out] pubSz   On in, the size of pub in bytes.
+ *                          On out, the length of the public key data in bytes.
+ * @return  1 on success
+ * @return  0 on failure.
+ */
+int wolfSSL_EC25519_generate_key(unsigned char *priv, unsigned int *privSz,
+    unsigned char *pub, unsigned int *pubSz)
+{
+#ifdef WOLFSSL_KEY_GEN
+    int res = 1;
+    int initTmpRng = 0;
+    WC_RNG *rng = NULL;
+#ifdef WOLFSSL_SMALL_STACK
+    WC_RNG *tmpRng = NULL;
+#else
+    WC_RNG tmpRng[1];
+#endif
+    curve25519_key key;
+
+    WOLFSSL_ENTER("wolfSSL_EC25519_generate_key");
+
+    /* Validate parameters. */
+    if ((priv == NULL) || (privSz == NULL) || (*privSz < CURVE25519_KEYSIZE) ||
+            (pub == NULL) || (pubSz == NULL) || (*pubSz < CURVE25519_KEYSIZE)) {
+        WOLFSSL_MSG("Bad arguments");
+        res = 0;
+    }
+
+    if (res) {
+        /* Create a random number generator. */
+        rng = wolfssl_make_rng(tmpRng, &initTmpRng);
+        if (rng == NULL) {
+            WOLFSSL_MSG("wolfSSL_EC_KEY_generate_key failed to make RNG");
+            res = 0;
+        }
+    }
+
+    /* Initialize a Curve25519 key. */
+    if (res && (wc_curve25519_init(&key) != 0)) {
+        WOLFSSL_MSG("wc_curve25519_init failed");
+        res = 0;
+    }
+    if (res) {
+        /* Make a Curve25519 key pair. */
+        int ret = wc_curve25519_make_key(rng, CURVE25519_KEYSIZE, &key);
+        if (ret != MP_OKAY) {
+            WOLFSSL_MSG("wc_curve25519_make_key failed");
+            res = 0;
+        }
+        if (res) {
+            /* Export Curve25519 key pair to buffers. */
+            ret = wc_curve25519_export_key_raw_ex(&key, priv, privSz, pub,
+                pubSz, EC25519_LITTLE_ENDIAN);
+            if (ret != MP_OKAY) {
+                WOLFSSL_MSG("wc_curve25519_export_key_raw_ex failed");
+                res = 0;
+            }
+        }
+
+        /* Dispose of key. */
+        wc_curve25519_free(&key);
+    }
+
+    if (initTmpRng) {
+        wc_FreeRng(rng);
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(rng, NULL, DYNAMIC_TYPE_RNG);
+    #endif
+    }
+
+    return res;
+#else
+    WOLFSSL_MSG("No Key Gen built in");
+
+    (void)priv;
+    (void)privSz;
+    (void)pub;
+    (void)pubSz;
+
+    return 0;
+#endif /* WOLFSSL_KEY_GEN */
+}
+
+/* Compute a shared secret from private and public EC25519 keys.
+ *
+ * Input and output keys are in little endian format
+ *
+ * @param [out]     shared    Shared secret buffer.
+ * @param [in, out] sharedSz  On in, the size of shared in bytes.
+ *                            On out, the length of the secret in bytes.
+ * @param [in]      priv      EC25519 private key data.
+ * @param [in]      privSz    Length of the private key data in bytes.
+ * @param [in]      pub       EC25519 public key data.
+ * @param [in]      pubSz     Length of the public key data in bytes.
+ * @return  1 on success
+ * @return  0 on failure.
+ */
+int wolfSSL_EC25519_shared_key(unsigned char *shared, unsigned int *sharedSz,
+    const unsigned char *priv, unsigned int privSz, const unsigned char *pub,
+    unsigned int pubSz)
+{
+#ifdef WOLFSSL_KEY_GEN
+    int res = 1;
+    curve25519_key privkey;
+    curve25519_key pubkey;
+
+    WOLFSSL_ENTER("wolfSSL_EC25519_shared_key");
+
+    /* Validate parameters. */
+    if ((shared == NULL) || (sharedSz == NULL) ||
+            (*sharedSz < CURVE25519_KEYSIZE) || (priv == NULL) ||
+            (privSz < CURVE25519_KEYSIZE) || (pub == NULL) ||
+            (pubSz < CURVE25519_KEYSIZE)) {
+        WOLFSSL_MSG("Bad arguments");
+        res = 0;
+    }
+
+    /* Initialize private key object. */
+    if (res && (wc_curve25519_init(&privkey) != 0)) {
+        WOLFSSL_MSG("wc_curve25519_init privkey failed");
+        res = 0;
+    }
+    if (res) {
+        /* Initialize public key object. */
+        if (wc_curve25519_init(&pubkey) != MP_OKAY) {
+            WOLFSSL_MSG("wc_curve25519_init pubkey failed");
+            res = 0;
+        }
+        if (res) {
+            /* Import our private key. */
+            int ret = wc_curve25519_import_private_ex(priv, privSz, &privkey,
+                EC25519_LITTLE_ENDIAN);
+            if (ret != 0) {
+                WOLFSSL_MSG("wc_curve25519_import_private_ex failed");
+                res = 0;
+            }
+
+            if (res) {
+                /* Import peer's public key. */
+                ret = wc_curve25519_import_public_ex(pub, pubSz, &pubkey,
+                    EC25519_LITTLE_ENDIAN);
+                if (ret != 0) {
+                    WOLFSSL_MSG("wc_curve25519_import_public_ex failed");
+                    res = 0;
+                }
+            }
+            if (res) {
+                /* Compute shared secret. */
+                ret = wc_curve25519_shared_secret_ex(&privkey, &pubkey, shared,
+                    sharedSz, EC25519_LITTLE_ENDIAN);
+                if (ret != 0) {
+                    WOLFSSL_MSG("wc_curve25519_shared_secret_ex failed");
+                    res = 0;
+                }
+            }
+
+            wc_curve25519_free(&pubkey);
+        }
+        wc_curve25519_free(&privkey);
+    }
+
+    return res;
+#else
+    WOLFSSL_MSG("No Key Gen built in");
+
+    (void)shared;
+    (void)sharedSz;
+    (void)priv;
+    (void)privSz;
+    (void)pub;
+    (void)pubSz;
+
+    return 0;
+#endif /* WOLFSSL_KEY_GEN */
+}
+#endif /* OPENSSL_EXTRA && HAVE_CURVE25519 */
+
+/*******************************************************************************
+ * END OF EC25519 API
+ ******************************************************************************/
+
+/*******************************************************************************
+ * START OF ED25519 API
+ ******************************************************************************/
+
+#if defined(OPENSSL_EXTRA) && defined(HAVE_ED25519)
+/* Generate an ED25519 key pair.
+ *
+ * Output keys are in little endian format.
+ *
+ * @param [out]     priv    ED25519 private key data.
+ * @param [in, out] privSz  On in, the size of priv in bytes.
+ *                          On out, the length of the private key data in bytes.
+ * @param [out]     pub     ED25519 public key data.
+ * @param [in, out] pubSz   On in, the size of pub in bytes.
+ *                          On out, the length of the public key data in bytes.
+ * @return  1 on success
+ * @return  0 on failure.
+ */
+int wolfSSL_ED25519_generate_key(unsigned char *priv, unsigned int *privSz,
+    unsigned char *pub, unsigned int *pubSz)
+{
+#if defined(WOLFSSL_KEY_GEN) && defined(HAVE_ED25519_KEY_EXPORT)
+    int res = 1;
+    int initTmpRng = 0;
+    WC_RNG *rng = NULL;
+#ifdef WOLFSSL_SMALL_STACK
+    WC_RNG *tmpRng = NULL;
+#else
+    WC_RNG tmpRng[1];
+#endif
+    ed25519_key key;
+
+    WOLFSSL_ENTER("wolfSSL_ED25519_generate_key");
+
+    /* Validate parameters. */
+    if ((priv == NULL) || (privSz == NULL) ||
+            (*privSz < ED25519_PRV_KEY_SIZE) || (pub == NULL) ||
+            (pubSz == NULL) || (*pubSz < ED25519_PUB_KEY_SIZE)) {
+        WOLFSSL_MSG("Bad arguments");
+        res = 0;
+    }
+
+    if (res) {
+        /* Create a random number generator. */
+        rng = wolfssl_make_rng(tmpRng, &initTmpRng);
+        if (rng == NULL) {
+            WOLFSSL_MSG("wolfSSL_EC_KEY_generate_key failed to make RNG");
+            res = 0;
+        }
+    }
+
+    /* Initialize an Ed25519 key. */
+    if (res && (wc_ed25519_init(&key) != 0)) {
+        WOLFSSL_MSG("wc_ed25519_init failed");
+        res = 0;
+    }
+    if (res) {
+        /* Make an Ed25519 key pair. */
+        int ret = wc_ed25519_make_key(rng, ED25519_KEY_SIZE, &key);
+        if (ret != 0) {
+            WOLFSSL_MSG("wc_ed25519_make_key failed");
+            res = 0;
+        }
+        if (res) {
+            /* Export Curve25519 key pair to buffers. */
+            ret = wc_ed25519_export_key(&key, priv, privSz, pub, pubSz);
+            if (ret != 0) {
+                WOLFSSL_MSG("wc_ed25519_export_key failed");
+                res = 0;
+            }
+        }
+
+        wc_ed25519_free(&key);
+    }
+
+    if (initTmpRng) {
+        wc_FreeRng(rng);
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(rng, NULL, DYNAMIC_TYPE_RNG);
+    #endif
+    }
+
+    return res;
+#else
+#ifndef WOLFSSL_KEY_GEN
+    WOLFSSL_MSG("No Key Gen built in");
+#else
+    WOLFSSL_MSG("No ED25519 key export built in");
+#endif
+
+    (void)priv;
+    (void)privSz;
+    (void)pub;
+    (void)pubSz;
+
+    return 0;
+#endif /* WOLFSSL_KEY_GEN && HAVE_ED25519_KEY_EXPORT */
+}
+
+/* Sign a message with Ed25519 using the private key.
+ *
+ * Input and output keys are in little endian format.
+ * Priv is a buffer containing private and public part of key.
+ *
+ * @param [in]      msg     Message to be signed.
+ * @param [in]      msgSz   Length of message in bytes.
+ * @param [in]      priv    ED25519 private key data.
+ * @param [in]      privSz  Length in bytes of private key data.
+ * @param [out]     sig     Signature buffer.
+ * @param [in, out] sigSz   On in, the length of the signature buffer in bytes.
+ *                          On out, the length of the signature in bytes.
+ * @return  1 on success
+ * @return  0 on failure.
+ */
+int wolfSSL_ED25519_sign(const unsigned char *msg, unsigned int msgSz,
+    const unsigned char *priv, unsigned int privSz, unsigned char *sig,
+    unsigned int *sigSz)
+{
+#if defined(HAVE_ED25519_SIGN) && defined(WOLFSSL_KEY_GEN) && \
+    defined(HAVE_ED25519_KEY_IMPORT)
+    ed25519_key key;
+    int res = 1;
+
+    WOLFSSL_ENTER("wolfSSL_ED25519_sign");
+
+    /* Validate parameters. */
+    if ((priv == NULL) || (privSz != ED25519_PRV_KEY_SIZE) ||
+            (msg == NULL) || (sig == NULL) || (sigSz == NULL) ||
+            (*sigSz < ED25519_SIG_SIZE)) {
+        WOLFSSL_MSG("Bad arguments");
+        res = 0;
+    }
+
+    /* Initialize Ed25519 key. */
+    if (res && (wc_ed25519_init(&key) != 0)) {
+        WOLFSSL_MSG("wc_curve25519_init failed");
+        res = 0;
+    }
+    if (res) {
+        /* Import private and public key. */
+        int ret = wc_ed25519_import_private_key(priv, privSz / 2,
+            priv + (privSz / 2), ED25519_PUB_KEY_SIZE, &key);
+        if (ret != 0) {
+            WOLFSSL_MSG("wc_ed25519_import_private failed");
+            res = 0;
+        }
+
+        if (res) {
+            /* Sign message with Ed25519. */
+            ret = wc_ed25519_sign_msg(msg, msgSz, sig, sigSz, &key);
+            if (ret != 0) {
+                WOLFSSL_MSG("wc_curve25519_shared_secret_ex failed");
+                res = 0;
+            }
+        }
+
+        wc_ed25519_free(&key);
+    }
+
+    return res;
+#else
+#if !defined(HAVE_ED25519_SIGN)
+    WOLFSSL_MSG("No ED25519 sign built in");
+#elif !defined(WOLFSSL_KEY_GEN)
+    WOLFSSL_MSG("No Key Gen built in");
+#elif !defined(HAVE_ED25519_KEY_IMPORT)
+    WOLFSSL_MSG("No ED25519 Key import built in");
+#endif
+
+    (void)msg;
+    (void)msgSz;
+    (void)priv;
+    (void)privSz;
+    (void)sig;
+    (void)sigSz;
+
+    return 0;
+#endif /* HAVE_ED25519_SIGN && WOLFSSL_KEY_GEN && HAVE_ED25519_KEY_IMPORT */
+}
+
+/* Verify a message with Ed25519 using the public key.
+ *
+ * Input keys are in little endian format.
+ *
+ * @param [in] msg     Message to be verified.
+ * @param [in] msgSz   Length of message in bytes.
+ * @param [in] pub     ED25519 public key data.
+ * @param [in] privSz  Length in bytes of public key data.
+ * @param [in] sig     Signature buffer.
+ * @param [in] sigSz   Length of the signature in bytes.
+ * @return  1 on success
+ * @return  0 on failure.
+ */
+int wolfSSL_ED25519_verify(const unsigned char *msg, unsigned int msgSz,
+    const unsigned char *pub, unsigned int pubSz, const unsigned char *sig,
+    unsigned int sigSz)
+{
+#if defined(HAVE_ED25519_VERIFY) && defined(WOLFSSL_KEY_GEN) && \
+    defined(HAVE_ED25519_KEY_IMPORT)
+    ed25519_key key;
+    int res = 1;
+
+    WOLFSSL_ENTER("wolfSSL_ED25519_verify");
+
+    /* Validate parameters. */
+    if ((pub == NULL) || (pubSz != ED25519_PUB_KEY_SIZE) || (msg == NULL) ||
+            (sig == NULL) || (sigSz != ED25519_SIG_SIZE)) {
+        WOLFSSL_MSG("Bad arguments");
+        res = 0;
+    }
+
+    /* Initialize Ed25519 key. */
+    if (res && (wc_ed25519_init(&key) != 0)) {
+        WOLFSSL_MSG("wc_curve25519_init failed");
+        res = 0;
+    }
+    if (res) {
+        /* Import public key. */
+        int ret = wc_ed25519_import_public(pub, pubSz, &key);
+        if (ret != 0) {
+            WOLFSSL_MSG("wc_ed25519_import_public failed");
+            res = 0;
+        }
+
+        if (res) {
+            int check = 0;
+
+            /* Verify signature with message and public key. */
+            ret = wc_ed25519_verify_msg((byte*)sig, sigSz, msg, msgSz, &check,
+                &key);
+            /* Check for errors in verification process. */
+            if (ret != 0) {
+                WOLFSSL_MSG("wc_ed25519_verify_msg failed");
+                res = 0;
+            }
+            /* Check signature is valid. */
+            else if (!check) {
+                WOLFSSL_MSG("wc_ed25519_verify_msg failed (signature invalid)");
+                res = 0;
+            }
+        }
+
+        wc_ed25519_free(&key);
+    }
+
+    return res;
+#else
+#if !defined(HAVE_ED25519_VERIFY)
+    WOLFSSL_MSG("No ED25519 verify built in");
+#elif !defined(WOLFSSL_KEY_GEN)
+    WOLFSSL_MSG("No Key Gen built in");
+#elif !defined(HAVE_ED25519_KEY_IMPORT)
+    WOLFSSL_MSG("No ED25519 Key import built in");
+#endif
+
+    (void)msg;
+    (void)msgSz;
+    (void)pub;
+    (void)pubSz;
+    (void)sig;
+    (void)sigSz;
+
+    return 0;
+#endif /* HAVE_ED25519_VERIFY && WOLFSSL_KEY_GEN && HAVE_ED25519_KEY_IMPORT */
+}
+
+#endif /* OPENSSL_EXTRA && HAVE_ED25519 */
+
+/*******************************************************************************
+ * END OF ED25519 API
+ ******************************************************************************/
+
+/*******************************************************************************
+ * START OF EC448 API
+ ******************************************************************************/
+
+#if defined(OPENSSL_EXTRA) && defined(HAVE_CURVE448)
+/* Generate an EC448 key pair.
+ *
+ * Output keys are in little endian format.
+ *
+ * @param [out]     priv    EC448 private key data.
+ * @param [in, out] privSz  On in, the size of priv in bytes.
+ *                          On out, the length of the private key data in bytes.
+ * @param [out]     pub     EC448 public key data.
+ * @param [in, out] pubSz   On in, the size of pub in bytes.
+ *                          On out, the length of the public key data in bytes.
+ * @return  1 on success
+ * @return  0 on failure.
+ */
+int wolfSSL_EC448_generate_key(unsigned char *priv, unsigned int *privSz,
+                               unsigned char *pub, unsigned int *pubSz)
+{
+#ifdef WOLFSSL_KEY_GEN
+    int res = 1;
+    int initTmpRng = 0;
+    WC_RNG *rng = NULL;
+#ifdef WOLFSSL_SMALL_STACK
+    WC_RNG *tmpRng = NULL;
+#else
+    WC_RNG tmpRng[1];
+#endif
+    curve448_key key;
+
+    WOLFSSL_ENTER("wolfSSL_EC448_generate_key");
+
+    /* Validate parameters. */
+    if ((priv == NULL) || (privSz == NULL) || (*privSz < CURVE448_KEY_SIZE) ||
+            (pub == NULL) || (pubSz == NULL) || (*pubSz < CURVE448_KEY_SIZE)) {
+        WOLFSSL_MSG("Bad arguments");
+        res = 0;
+    }
+
+    if (res) {
+        /* Create a random number generator. */
+        rng = wolfssl_make_rng(tmpRng, &initTmpRng);
+        if (rng == NULL) {
+            WOLFSSL_MSG("wolfSSL_EC_KEY_generate_key failed to make RNG");
+            res = 0;
+        }
+    }
+
+    /* Initialize a Curve448 key. */
+    if (res && (wc_curve448_init(&key) != 0)) {
+        WOLFSSL_MSG("wc_curve448_init failed");
+        res = 0;
+    }
+    if (res) {
+        /* Make a Curve448 key pair. */
+        int ret = wc_curve448_make_key(rng, CURVE448_KEY_SIZE, &key);
+        if (ret != 0) {
+            WOLFSSL_MSG("wc_curve448_make_key failed");
+            res = 0;
+        }
+        if (res) {
+            /* Export Curve448 key pair to buffers. */
+            ret = wc_curve448_export_key_raw_ex(&key, priv, privSz, pub, pubSz,
+                EC448_LITTLE_ENDIAN);
+            if (ret != 0) {
+                WOLFSSL_MSG("wc_curve448_export_key_raw_ex failed");
+                res = 0;
+            }
+        }
+
+        /* Dispose of key. */
+        wc_curve448_free(&key);
+    }
+
+    if (initTmpRng) {
+        wc_FreeRng(rng);
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(rng, NULL, DYNAMIC_TYPE_RNG);
+    #endif
+    }
+
+    return res;
+#else
+    WOLFSSL_MSG("No Key Gen built in");
+
+    (void)priv;
+    (void)privSz;
+    (void)pub;
+    (void)pubSz;
+
+    return 0;
+#endif /* WOLFSSL_KEY_GEN */
+}
+
+/* Compute a shared secret from private and public EC448 keys.
+ *
+ * Input and output keys are in little endian format
+ *
+ * @param [out]     shared    Shared secret buffer.
+ * @param [in, out] sharedSz  On in, the size of shared in bytes.
+ *                            On out, the length of the secret in bytes.
+ * @param [in]      priv      EC448 private key data.
+ * @param [in]      privSz    Length of the private key data in bytes.
+ * @param [in]      pub       EC448 public key data.
+ * @param [in]      pubSz     Length of the public key data in bytes.
+ * @return  1 on success
+ * @return  0 on failure.
+ */
+int wolfSSL_EC448_shared_key(unsigned char *shared, unsigned int *sharedSz,
+                             const unsigned char *priv, unsigned int privSz,
+                             const unsigned char *pub, unsigned int pubSz)
+{
+#ifdef WOLFSSL_KEY_GEN
+    int res = 1;
+    curve448_key privkey;
+    curve448_key pubkey;
+
+    WOLFSSL_ENTER("wolfSSL_EC448_shared_key");
+
+    /* Validate parameters. */
+    if ((shared == NULL) || (sharedSz == NULL) ||
+            (*sharedSz < CURVE448_KEY_SIZE) || (priv == NULL) ||
+            (privSz < CURVE448_KEY_SIZE) || (pub == NULL) ||
+            (pubSz < CURVE448_KEY_SIZE)) {
+        WOLFSSL_MSG("Bad arguments");
+        res = 0;
+    }
+
+    /* Initialize private key object. */
+    if (res && (wc_curve448_init(&privkey) != 0)) {
+        WOLFSSL_MSG("wc_curve448_init privkey failed");
+        res = 0;
+    }
+    if (res) {
+        /* Initialize public key object. */
+        if (wc_curve448_init(&pubkey) != MP_OKAY) {
+            WOLFSSL_MSG("wc_curve448_init pubkey failed");
+            res = 0;
+        }
+        if (res) {
+            /* Import our private key. */
+            int ret = wc_curve448_import_private_ex(priv, privSz, &privkey,
+                EC448_LITTLE_ENDIAN);
+            if (ret != 0) {
+                WOLFSSL_MSG("wc_curve448_import_private_ex failed");
+                res = 0;
+            }
+
+            if (res) {
+                /* Import peer's public key. */
+                ret = wc_curve448_import_public_ex(pub, pubSz, &pubkey,
+                    EC448_LITTLE_ENDIAN);
+                if (ret != 0) {
+                    WOLFSSL_MSG("wc_curve448_import_public_ex failed");
+                    res = 0;
+                }
+            }
+            if (res) {
+                /* Compute shared secret. */
+                ret = wc_curve448_shared_secret_ex(&privkey, &pubkey, shared,
+                    sharedSz, EC448_LITTLE_ENDIAN);
+                if (ret != 0) {
+                    WOLFSSL_MSG("wc_curve448_shared_secret_ex failed");
+                    res = 0;
+                }
+            }
+
+            wc_curve448_free(&pubkey);
+        }
+        wc_curve448_free(&privkey);
+    }
+
+    return res;
+#else
+    WOLFSSL_MSG("No Key Gen built in");
+
+    (void)shared;
+    (void)sharedSz;
+    (void)priv;
+    (void)privSz;
+    (void)pub;
+    (void)pubSz;
+
+    return 0;
+#endif /* WOLFSSL_KEY_GEN */
+}
+#endif /* OPENSSL_EXTRA && HAVE_CURVE448 */
+
+/*******************************************************************************
+ * END OF EC448 API
+ ******************************************************************************/
+
+/*******************************************************************************
+ * START OF ED448 API
+ ******************************************************************************/
+
+#if defined(OPENSSL_EXTRA) && defined(HAVE_ED448)
+/* Generate an ED448 key pair.
+ *
+ * Output keys are in little endian format.
+ *
+ * @param [out]     priv    ED448 private key data.
+ * @param [in, out] privSz  On in, the size of priv in bytes.
+ *                          On out, the length of the private key data in bytes.
+ * @param [out]     pub     ED448 public key data.
+ * @param [in, out] pubSz   On in, the size of pub in bytes.
+ *                          On out, the length of the public key data in bytes.
+ * @return  1 on success
+ * @return  0 on failure.
+ */
+int wolfSSL_ED448_generate_key(unsigned char *priv, unsigned int *privSz,
+    unsigned char *pub, unsigned int *pubSz)
+{
+#if defined(WOLFSSL_KEY_GEN) && defined(HAVE_ED448_KEY_EXPORT)
+    int res = 1;
+    int initTmpRng = 0;
+    WC_RNG *rng = NULL;
+#ifdef WOLFSSL_SMALL_STACK
+    WC_RNG *tmpRng = NULL;
+#else
+    WC_RNG tmpRng[1];
+#endif
+    ed448_key key;
+
+    WOLFSSL_ENTER("wolfSSL_ED448_generate_key");
+
+    /* Validate parameters. */
+    if ((priv == NULL) || (privSz == NULL) ||
+            (*privSz < ED448_PRV_KEY_SIZE) || (pub == NULL) ||
+            (pubSz == NULL) || (*pubSz < ED448_PUB_KEY_SIZE)) {
+        WOLFSSL_MSG("Bad arguments");
+        res = 0;
+    }
+
+    if (res) {
+        /* Create a random number generator. */
+        rng = wolfssl_make_rng(tmpRng, &initTmpRng);
+        if (rng == NULL) {
+            WOLFSSL_MSG("wolfSSL_EC_KEY_generate_key failed to make RNG");
+            res = 0;
+        }
+    }
+
+    /* Initialize an Ed448 key. */
+    if (res && (wc_ed448_init(&key) != 0)) {
+        WOLFSSL_MSG("wc_ed448_init failed");
+        res = 0;
+    }
+    if (res) {
+        /* Make an Ed448 key pair. */
+        int ret = wc_ed448_make_key(rng, ED448_KEY_SIZE, &key);
+        if (ret != 0) {
+            WOLFSSL_MSG("wc_ed448_make_key failed");
+            res = 0;
+        }
+        if (res) {
+            /* Export Curve448 key pair to buffers. */
+            ret = wc_ed448_export_key(&key, priv, privSz, pub, pubSz);
+            if (ret != 0) {
+                WOLFSSL_MSG("wc_ed448_export_key failed");
+                res = 0;
+            }
+        }
+
+        wc_ed448_free(&key);
+    }
+
+    if (initTmpRng) {
+        wc_FreeRng(rng);
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(rng, NULL, DYNAMIC_TYPE_RNG);
+    #endif
+    }
+
+    return res;
+#else
+#ifndef WOLFSSL_KEY_GEN
+    WOLFSSL_MSG("No Key Gen built in");
+#else
+    WOLFSSL_MSG("No ED448 key export built in");
+#endif
+
+    (void)priv;
+    (void)privSz;
+    (void)pub;
+    (void)pubSz;
+
+    return 0;
+#endif /* WOLFSSL_KEY_GEN && HAVE_ED448_KEY_EXPORT */
+}
+
+/* Sign a message with Ed448 using the private key.
+ *
+ * Input and output keys are in little endian format.
+ * Priv is a buffer containing private and public part of key.
+ *
+ * @param [in]      msg     Message to be signed.
+ * @param [in]      msgSz   Length of message in bytes.
+ * @param [in]      priv    ED448 private key data.
+ * @param [in]      privSz  Length in bytes of private key data.
+ * @param [out]     sig     Signature buffer.
+ * @param [in, out] sigSz   On in, the length of the signature buffer in bytes.
+ *                          On out, the length of the signature in bytes.
+ * @return  1 on success
+ * @return  0 on failure.
+ */
+int wolfSSL_ED448_sign(const unsigned char *msg, unsigned int msgSz,
+    const unsigned char *priv, unsigned int privSz, unsigned char *sig,
+    unsigned int *sigSz)
+{
+#if defined(HAVE_ED448_SIGN) && defined(WOLFSSL_KEY_GEN) && \
+    defined(HAVE_ED448_KEY_IMPORT)
+    ed448_key key;
+    int res = 1;
+
+    WOLFSSL_ENTER("wolfSSL_ED448_sign");
+
+    /* Validate parameters. */
+    if ((priv == NULL) || (privSz != ED448_PRV_KEY_SIZE) ||
+            (msg == NULL) || (sig == NULL) || (sigSz == NULL) ||
+            (*sigSz < ED448_SIG_SIZE)) {
+        WOLFSSL_MSG("Bad arguments");
+        res = 0;
+    }
+
+    /* Initialize Ed448 key. */
+    if (res && (wc_ed448_init(&key) != 0)) {
+        WOLFSSL_MSG("wc_curve448_init failed");
+        res = 0;
+    }
+    if (res) {
+        /* Import private and public key. */
+        int ret = wc_ed448_import_private_key(priv, privSz / 2,
+            priv + (privSz / 2), ED448_PUB_KEY_SIZE, &key);
+        if (ret != 0) {
+            WOLFSSL_MSG("wc_ed448_import_private failed");
+            res = 0;
+        }
+
+        if (res) {
+            /* Sign message with Ed448 - no context. */
+            ret = wc_ed448_sign_msg(msg, msgSz, sig, sigSz, &key, NULL, 0);
+            if (ret != 0) {
+                WOLFSSL_MSG("wc_curve448_shared_secret_ex failed");
+                res = 0;
+            }
+        }
+
+        wc_ed448_free(&key);
+    }
+
+    return res;
+#else
+#if !defined(HAVE_ED448_SIGN)
+    WOLFSSL_MSG("No ED448 sign built in");
+#elif !defined(WOLFSSL_KEY_GEN)
+    WOLFSSL_MSG("No Key Gen built in");
+#elif !defined(HAVE_ED448_KEY_IMPORT)
+    WOLFSSL_MSG("No ED448 Key import built in");
+#endif
+
+    (void)msg;
+    (void)msgSz;
+    (void)priv;
+    (void)privSz;
+    (void)sig;
+    (void)sigSz;
+
+    return 0;
+#endif /* HAVE_ED448_SIGN && WOLFSSL_KEY_GEN && HAVE_ED448_KEY_IMPORT */
+}
+
+/* Verify a message with Ed448 using the public key.
+ *
+ * Input keys are in little endian format.
+ *
+ * @param [in] msg     Message to be verified.
+ * @param [in] msgSz   Length of message in bytes.
+ * @param [in] pub     ED448 public key data.
+ * @param [in] privSz  Length in bytes of public key data.
+ * @param [in] sig     Signature buffer.
+ * @param [in] sigSz   Length of the signature in bytes.
+ * @return  1 on success
+ * @return  0 on failure.
+ */
+int wolfSSL_ED448_verify(const unsigned char *msg, unsigned int msgSz,
+    const unsigned char *pub, unsigned int pubSz, const unsigned char *sig,
+    unsigned int sigSz)
+{
+#if defined(HAVE_ED448_VERIFY) && defined(WOLFSSL_KEY_GEN) && \
+    defined(HAVE_ED448_KEY_IMPORT)
+    ed448_key key;
+    int res = 1;
+
+    WOLFSSL_ENTER("wolfSSL_ED448_verify");
+
+    /* Validate parameters. */
+    if ((pub == NULL) || (pubSz != ED448_PUB_KEY_SIZE) || (msg == NULL) ||
+            (sig == NULL) || (sigSz != ED448_SIG_SIZE)) {
+        WOLFSSL_MSG("Bad arguments");
+        res = 0;
+    }
+
+    /* Initialize Ed448 key. */
+    if (res && (wc_ed448_init(&key) != 0)) {
+        WOLFSSL_MSG("wc_curve448_init failed");
+        res = 0;
+    }
+    if (res) {
+        /* Import public key. */
+        int ret = wc_ed448_import_public(pub, pubSz, &key);
+        if (ret != 0) {
+            WOLFSSL_MSG("wc_ed448_import_public failed");
+            res = 0;
+        }
+
+        if (res) {
+            int check = 0;
+
+            /* Verify signature with message and public key - no context. */
+            ret = wc_ed448_verify_msg((byte*)sig, sigSz, msg, msgSz, &check,
+                &key, NULL, 0);
+            /* Check for errors in verification process. */
+            if (ret != 0) {
+                WOLFSSL_MSG("wc_ed448_verify_msg failed");
+                res = 0;
+            }
+            /* Check signature is valid. */
+            else if (!check) {
+                WOLFSSL_MSG("wc_ed448_verify_msg failed (signature invalid)");
+                res = 0;
+            }
+        }
+
+        wc_ed448_free(&key);
+    }
+
+    return res;
+#else
+#if !defined(HAVE_ED448_VERIFY)
+    WOLFSSL_MSG("No ED448 verify built in");
+#elif !defined(WOLFSSL_KEY_GEN)
+    WOLFSSL_MSG("No Key Gen built in");
+#elif !defined(HAVE_ED448_KEY_IMPORT)
+    WOLFSSL_MSG("No ED448 Key import built in");
+#endif
+
+    (void)msg;
+    (void)msgSz;
+    (void)pub;
+    (void)pubSz;
+    (void)sig;
+    (void)sigSz;
+
+    return 0;
+#endif /* HAVE_ED448_VERIFY && WOLFSSL_KEY_GEN && HAVE_ED448_KEY_IMPORT */
+}
+#endif /* OPENSSL_EXTRA && HAVE_ED448 */
+
+/*******************************************************************************
+ * END OF ED448 API
+ ******************************************************************************/
+
+/*******************************************************************************
+ * START OF GENERIC PUBLIC KEY PEM APIs
+ ******************************************************************************/
+
+#ifdef OPENSSL_EXTRA
+/* Sets default callback password for PEM.
+ *
+ * @param [out] buf       Buffer to hold password.
+ * @param [in]  num       Number of characters in buffer.
+ * @param [in]  rwFlag    Read/write flag. Ignored.
+ * @param [in]  userData  User data - assumed to be default password.
+ * @return  Password size on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_PEM_def_callback(char* buf, int num, int rwFlag, void* userData)
+{
+    int sz = 0;
+
+    WOLFSSL_ENTER("wolfSSL_PEM_def_callback");
+
+    (void)rwFlag;
+
+    /* We assume that the user passes a default password as userdata */
+    if ((buf != NULL) && (userData != NULL)) {
+        sz = (int)XSTRLEN((const char*)userData);
+        sz = (int)min((word32)sz, (word32)num);
+        XMEMCPY(buf, userData, sz);
+    }
+    else {
+        WOLFSSL_MSG("Error, default password cannot be created.");
+    }
+
+    return sz;
+}
+
+#ifndef NO_BIO
+/* Writes a public key to a WOLFSSL_BIO encoded in PEM format.
+ *
+ * @param [in] bio  BIO to write to.
+ * @param [in] key  Public key to write in PEM format.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_PEM_write_bio_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key)
+{
+    int ret = 0;
+
+    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_PUBKEY");
+
+    if ((bio != NULL) && (key != NULL)) {
+        switch (key->type) {
+#if defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)
+            case EVP_PKEY_RSA:
+                ret = wolfSSL_PEM_write_bio_RSA_PUBKEY(bio, key->rsa);
+                break;
+#endif /* WOLFSSL_KEY_GEN && !NO_RSA */
+#if !defined(NO_DSA) && !defined(HAVE_SELFTEST) && \
+    (defined(WOLFSSL_KEY_GEN) || defined(WOLFSSL_CERT_GEN))
+            case EVP_PKEY_DSA:
+                ret = wolfSSL_PEM_write_bio_DSA_PUBKEY(bio, key->dsa);
+                break;
+#endif /* !NO_DSA && !HAVE_SELFTEST && (WOLFSSL_KEY_GEN || WOLFSSL_CERT_GEN) */
+#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT) && \
+    defined(WOLFSSL_KEY_GEN)
+            case EVP_PKEY_EC:
+                ret = wolfSSL_PEM_write_bio_EC_PUBKEY(bio, key->ecc);
+                break;
+#endif /* HAVE_ECC && HAVE_ECC_KEY_EXPORT */
+#if !defined(NO_DH) && (defined(WOLFSSL_QT) || defined(OPENSSL_ALL))
+            case EVP_PKEY_DH:
+                /* DH public key not supported. */
+                WOLFSSL_MSG("Writing DH PUBKEY not supported!");
+                break;
+#endif /* !NO_DH && (WOLFSSL_QT || OPENSSL_ALL) */
+            default:
+                /* Key type not supported. */
+                WOLFSSL_MSG("Unknown Key type!");
+                break;
+        }
+    }
+
+    return ret;
+}
+
+/* Writes a private key to a WOLFSSL_BIO encoded in PEM format.
+ *
+ * @param [in] bio     BIO to write to.
+ * @param [in] key     Public key to write in PEM format.
+ * @param [in] cipher  Encryption cipher to use.
+ * @param [in] passwd  Password to use when encrypting.
+ * @param [in] len     Length of password.
+ * @param [in] cb      Password callback.
+ * @param [in] arg     Password callback argument.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_PEM_write_bio_PrivateKey(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key,
+    const WOLFSSL_EVP_CIPHER* cipher, unsigned char* passwd, int len,
+    wc_pem_password_cb* cb, void* arg)
+{
+    int ret = 1;
+
+    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_PrivateKey");
+
+    (void)cipher;
+    (void)passwd;
+    (void)len;
+    (void)cb;
+    (void)arg;
+
+    /* Validate parameters. */
+    if ((bio == NULL) || (key == NULL)) {
+        WOLFSSL_MSG("Bad Function Arguments");
+        ret = 0;
+    }
+
+    if (ret == 1) {
+    #ifdef WOLFSSL_KEY_GEN
+        switch (key->type) {
+        #ifndef NO_RSA
+            case EVP_PKEY_RSA:
+                /* Write using RSA specific API. */
+                ret = wolfSSL_PEM_write_bio_RSAPrivateKey(bio, key->rsa,
+                    cipher, passwd, len, cb, arg);
+                break;
+        #endif
+        #ifndef NO_DSA
+            case EVP_PKEY_DSA:
+                /* Write using DSA specific API. */
+                ret = wolfSSL_PEM_write_bio_DSAPrivateKey(bio, key->dsa,
+                    cipher, passwd, len, cb, arg);
+                break;
+        #endif
+        #ifdef HAVE_ECC
+            case EVP_PKEY_EC:
+            #if defined(HAVE_ECC_KEY_EXPORT)
+                /* Write using EC specific API. */
+                ret = wolfSSL_PEM_write_bio_ECPrivateKey(bio, key->ecc,
+                    cipher, passwd, len, cb, arg);
+            #else
+                ret = der_write_to_bio_as_pem((byte*)key->pkey.ptr,
+                    key->pkey_sz, bio, EC_PRIVATEKEY_TYPE);
+            #endif
+                break;
+        #endif
+        #ifndef NO_DH
+            case EVP_PKEY_DH:
+                /* Write using generic API with DH type. */
+                ret = der_write_to_bio_as_pem((byte*)key->pkey.ptr,
+                    key->pkey_sz, bio, DH_PRIVATEKEY_TYPE);
+                break;
+        #endif
+            default:
+                WOLFSSL_MSG("Unknown Key type!");
+                ret = 0;
+                break;
+        }
+    #else
+        int type = 0;
+
+        switch (key->type) {
+        #ifndef NO_DSA
+            case EVP_PKEY_DSA:
+                type = DSA_PRIVATEKEY_TYPE;
+                break;
+        #endif
+        #ifdef HAVE_ECC
+            case EVP_PKEY_EC:
+                type = ECC_PRIVATEKEY_TYPE;
+                break;
+        #endif
+        #ifndef NO_DH
+            case EVP_PKEY_DH:
+                type = DH_PRIVATEKEY_TYPE;
+                break;
+        #endif
+        #ifndef NO_RSA
+            case EVP_PKEY_RSA:
+                type = PRIVATEKEY_TYPE;
+                break;
+        #endif
+            default:
+                ret = 0;
+                break;
+        }
+        if (ret == 1) {
+            /* Write using generic API with generic type. */
+            ret = der_write_to_bio_as_pem((byte*)key->pkey.ptr, key->pkey_sz,
+                bio, type);
+        }
+    #endif
+    }
+
+    return ret;
+}
+#endif /* !NO_BIO */
+
+#ifndef NO_BIO
+/* Create a private key object from the data in the BIO.
+ *
+ * @param [in]      bio   BIO to read from.
+ * @param [in, out] key   Public key object. Object used if passed in.
+ * @param [in]      cb    Password callback.
+ * @param [in]      arg   Password callback argument.
+ * @return  A WOLFSSL_EVP_PKEY object on success.
+ * @return  NULL on failure.
+ */
+WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_bio_PUBKEY(WOLFSSL_BIO* bio,
+    WOLFSSL_EVP_PKEY **key, wc_pem_password_cb *cb, void *arg)
+{
+    int err = 0;
+    WOLFSSL_EVP_PKEY* pkey = NULL;
+    DerBuffer* der = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_PEM_read_bio_PUBKEY");
+
+    if (bio == NULL) {
+        err = 1;
+    }
+
+    /* Read the PEM public key from the BIO and convert to DER. */
+    if ((!err) && (pem_read_bio_key(bio, cb, arg, PUBLICKEY_TYPE, NULL,
+            &der) < 0)) {
+        err = 1;
+    }
+
+    if (!err) {
+        const unsigned char* ptr = der->buffer;
+
+        /* Use key passed in if set. */
+        if ((key != NULL) && (*key != NULL)) {
+            pkey = *key;
+        }
+
+        /* Convert DER data to a public key object. */
+        if (wolfSSL_d2i_PUBKEY(&pkey, &ptr, der->length) == NULL) {
+            WOLFSSL_MSG("Error loading DER buffer into WOLFSSL_EVP_PKEY");
+            pkey = NULL;
+            err = 1;
+        }
+    }
+
+    /* Return the key if possible. */
+    if ((!err) && (key != NULL) && (pkey != NULL)) {
+        *key = pkey;
+    }
+    /* Dispose of the DER encoding. */
+    FreeDer(&der);
+
+    WOLFSSL_LEAVE("wolfSSL_PEM_read_bio_PUBKEY", 0);
+
+    return pkey;
+}
+
+/* Create a private key object from the data in the BIO.
+ *
+ * @param [in]      bio   BIO to read from.
+ * @param [in, out] key   Private key object. Object used if passed in.
+ * @param [in]      cb    Password callback.
+ * @param [in]      arg   Password callback argument.
+ * @return  A WOLFSSL_EVP_PKEY object on success.
+ * @return  NULL on failure.
+ */
+WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_bio_PrivateKey(WOLFSSL_BIO* bio,
+    WOLFSSL_EVP_PKEY** key, wc_pem_password_cb* cb, void* arg)
+{
+    int err = 0;
+    WOLFSSL_EVP_PKEY* pkey = NULL;
+    DerBuffer* der = NULL;
+    int keyFormat = 0;
+
+    WOLFSSL_ENTER("wolfSSL_PEM_read_bio_PrivateKey");
+
+    /* Validate parameters. */
+    if (bio == NULL) {
+        err = 1;
+    }
+
+    /* Read the PEM private key from the BIO and convert to DER. */
+    if ((!err) && (pem_read_bio_key(bio, cb, arg, PRIVATEKEY_TYPE, &keyFormat,
+            &der) < 0)) {
+        err = 1;
+    }
+
+    if (!err) {
+        const unsigned char* ptr = der->buffer;
+        int type = -1;
+
+        /* Set key type based on format returned. */
+        switch (keyFormat) {
+            /* No key format set - default to RSA. */
+            case 0:
+            case RSAk:
+                type = EVP_PKEY_RSA;
+                break;
+            case DSAk:
+                type = EVP_PKEY_DSA;
+                break;
+            case ECDSAk:
+                type = EVP_PKEY_EC;
+                break;
+            case DHk:
+                type = EVP_PKEY_DH;
+                break;
+            default:
+                break;
+        }
+
+        /* Use key passed in if set. */
+        if ((key != NULL) && (*key != NULL)) {
+            pkey = *key;
+        }
+
+        /* Convert DER data to a private key object. */
+        if (wolfSSL_d2i_PrivateKey(type, &pkey, &ptr, der->length) == NULL) {
+            WOLFSSL_MSG("Error loading DER buffer into WOLFSSL_EVP_PKEY");
+            pkey = NULL;
+            err = 1;
+        }
+    }
+
+    /* Return the key if possible. */
+    if ((!err) && (key != NULL) && (pkey != NULL)) {
+        *key = pkey;
+    }
+    /* Dispose of the DER encoding. */
+    FreeDer(&der);
+
+    WOLFSSL_LEAVE("wolfSSL_PEM_read_bio_PrivateKey", err);
+
+    return pkey;
+}
+#endif /* !NO_BIO */
+
+#if !defined(NO_FILESYSTEM)
+/* Create a private key object from the data in a file.
+ *
+ * @param [in]      fp    File pointer.
+ * @param [in, out] key   Public key object. Object used if passed in.
+ * @param [in]      cb    Password callback.
+ * @param [in]      arg   Password callback argument.
+ * @return  A WOLFSSL_EVP_PKEY object on success.
+ * @return  NULL on failure.
+ */
+WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_PUBKEY(XFILE fp, WOLFSSL_EVP_PKEY **key,
+    wc_pem_password_cb *cb, void *arg)
+{
+    int err = 0;
+    WOLFSSL_EVP_PKEY* pkey = NULL;
+    DerBuffer* der = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_PEM_read_PUBKEY");
+
+    /* Validate parameters. */
+    if (fp == XBADFILE) {
+        err = 1;
+    }
+
+    /* Read the PEM public key from the file and convert to DER. */
+    if ((!err) && ((pem_read_file_key(fp, cb, arg, PUBLICKEY_TYPE, NULL,
+            &der) < 0) || (der == NULL))) {
+        err = 1;
+    }
+    if (!err) {
+        const unsigned char* ptr = der->buffer;
+
+        /* Use key passed in if set. */
+        if ((key != NULL) && (*key != NULL)) {
+            pkey = *key;
+        }
+
+        /* Convert DER data to a public key object. */
+        if (wolfSSL_d2i_PUBKEY(&pkey, &ptr, der->length) == NULL) {
+            WOLFSSL_MSG("Error loading DER buffer into WOLFSSL_EVP_PKEY");
+            pkey = NULL;
+            err = 1;
+        }
+    }
+
+    /* Return the key if possible. */
+    if ((!err) && (key != NULL) && (pkey != NULL)) {
+        *key = pkey;
+    }
+    /* Dispose of the DER encoding. */
+    FreeDer(&der);
+
+    WOLFSSL_LEAVE("wolfSSL_PEM_read_PUBKEY", 0);
+
+    return pkey;
+}
+
+#ifndef NO_CERTS
+/* Create a private key object from the data in a file.
+ *
+ * @param [in]      fp    File pointer.
+ * @param [in, out] key   Private key object. Object used if passed in.
+ * @param [in]      cb    Password callback.
+ * @param [in]      arg   Password callback argument.
+ * @return  A WOLFSSL_EVP_PKEY object on success.
+ * @return  NULL on failure.
+ */
+WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_PrivateKey(XFILE fp, WOLFSSL_EVP_PKEY **key,
+    wc_pem_password_cb *cb, void *arg)
+{
+    int err = 0;
+    WOLFSSL_EVP_PKEY* pkey = NULL;
+    DerBuffer* der = NULL;
+    int keyFormat = 0;
+
+    WOLFSSL_ENTER("wolfSSL_PEM_read_PrivateKey");
+
+    /* Validate parameters. */
+    if (fp == XBADFILE) {
+        err = 1;
+    }
+
+    /* Read the PEM private key from the file and convert to DER. */
+    if ((!err) && (pem_read_file_key(fp, cb, arg, PRIVATEKEY_TYPE, &keyFormat,
+            &der)) < 0) {
+        err = 1;
+    }
+
+    if (!err) {
+        const unsigned char* ptr = der->buffer;
+        int type = -1;
+
+        /* Set key type based on format returned. */
+        switch (keyFormat) {
+            /* No key format set - default to RSA. */
+            case 0:
+            case RSAk:
+                type = EVP_PKEY_RSA;
+                break;
+            case DSAk:
+                type = EVP_PKEY_DSA;
+                break;
+            case ECDSAk:
+                type = EVP_PKEY_EC;
+                break;
+            case DHk:
+                type = EVP_PKEY_DH;
+                break;
+            default:
+                break;
+        }
+
+        /* Use key passed in if set. */
+        if ((key != NULL) && (*key != NULL)) {
+            pkey = *key;
+        }
+
+        /* Convert DER data to a private key object. */
+        if (wolfSSL_d2i_PrivateKey(type, &pkey, &ptr, der->length) == NULL) {
+            WOLFSSL_MSG("Error loading DER buffer into WOLFSSL_EVP_PKEY");
+            pkey = NULL;
+            err = 1;
+        }
+    }
+
+    /* Return the key if possible. */
+    if ((!err) && (key != NULL) && (pkey != NULL)) {
+        *key = pkey;
+    }
+    /* Dispose of the DER encoding. */
+    FreeDer(&der);
+
+    WOLFSSL_LEAVE("wolfSSL_PEM_read_PrivateKey", 0);
+
+    return pkey;
+}
+#endif /* !NO_CERTS */
+#endif /* !NO_FILESYSTEM */
+
+#ifndef NO_CERTS
+
+#if !defined(NO_BIO) || !defined(NO_FILESYSTEM)
+#define PEM_BEGIN              "-----BEGIN "
+#define PEM_BEGIN_SZ           11
+#define PEM_END                "-----END "
+#define PEM_END_SZ             9
+#define PEM_HDR_FIN            "-----"
+#define PEM_HDR_FIN_SZ         5
+#define PEM_HDR_FIN_EOL_NEWLINE   "-----\n"
+#define PEM_HDR_FIN_EOL_NULL_TERM "-----\0"
+#define PEM_HDR_FIN_EOL_SZ     6
+
+/* Find strings and return middle offsets.
+ *
+ * Find first string in pem as a prefix and then locate second string as a
+ * postfix.
+ * len returning with 0 indicates not found.
+ *
+ * @param [in]  pem      PEM data.
+ * @param [in]  pemLen   Length of PEM data.
+ * @param [in]  idx      Current index.
+ * @param [in]  prefix   First string to find.
+ * @param [in]  postfix  Second string to find after first.
+ * @param [out] start    Start index of data between strings.
+ * @param [out] len      Length of data between strings.
+ */
+static void pem_find_pattern(char* pem, int pemLen, int idx, const char* prefix,
+    const char* postfix, int* start, int* len)
+{
+    int prefixLen = (int)XSTRLEN(prefix);
+    int postfixLen = (int)XSTRLEN(postfix);
+
+    *start = *len = 0;
+    /* Find prefix part. */
+    for (; idx < pemLen - prefixLen; idx++) {
+        if ((pem[idx] == prefix[0]) &&
+                (XMEMCMP(pem + idx, prefix, prefixLen) == 0)) {
+            idx += prefixLen;
+            *start = idx;
+            break;
+        }
+    }
+    /* Find postfix part. */
+    for (; idx < pemLen - postfixLen; idx++) {
+        if ((pem[idx] == postfix[0]) &&
+                (XMEMCMP(pem + idx, postfix, postfixLen) == 0)) {
+            *len = idx - *start;
+            break;
+        }
+    }
+}
+
+/* Parse out content type name, any encryption headers and DER encoding.
+ *
+ * @param [in]  pem     PEM data.
+ * @param [in]  pemLen  Length of PEM data.
+ * @param [out] name    Name of content type.
+ * @param [out] header  Encryption headers.
+ * @param [out] data    DER encoding from PEM.
+ * @param [out] len     Length of DER data.
+ * @return  0 on success.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ * @return  ASN_NO_PEM_HEADER when no header found or different names found.
+ */
+static int pem_read_data(char* pem, int pemLen, char **name, char **header,
+    unsigned char **data, long *len)
+{
+    int ret = 0;
+    int start;
+    int nameLen;
+    int startHdr = 0;
+    int hdrLen = 0;
+    int startEnd = 0;
+    int endLen;
+
+    *name = NULL;
+    *header = NULL;
+
+    /* Find header. */
+    pem_find_pattern(pem, pemLen, 0, PEM_BEGIN, PEM_HDR_FIN, &start, &nameLen);
+    /* Allocate memory for header name. */
+    *name = (char*)XMALLOC(nameLen + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (*name == NULL) {
+        ret = MEMORY_E;
+    }
+    if (ret == 0) {
+        /* Put in header name. */
+        (*name)[nameLen] = '\0';
+        if (nameLen == 0) {
+            ret = ASN_NO_PEM_HEADER;
+        }
+        else {
+            XMEMCPY(*name, pem + start, nameLen);
+        }
+    }
+    if (ret == 0) {
+        /* Find encryption headers after header. */
+        start += nameLen + PEM_HDR_FIN_SZ;
+        pem_find_pattern(pem, pemLen, start, "\n", "\n\n", &startHdr, &hdrLen);
+        if (hdrLen > 0) {
+            /* Include first of two '\n' characters. */
+            hdrLen++;
+        }
+        /* Allocate memory for encryption header string. */
+        *header = (char*)XMALLOC(hdrLen + 1, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (*header == NULL) {
+            ret = MEMORY_E;
+        }
+    }
+    if (ret == 0) {
+        /* Put in encryption header string. */
+        (*header)[hdrLen] = '\0';
+        if (hdrLen > 0) {
+            XMEMCPY(*header, pem + startHdr, hdrLen);
+            start = startHdr + hdrLen + 1;
+        }
+
+        /* Find footer. */
+        pem_find_pattern(pem, pemLen, start, PEM_END, PEM_HDR_FIN, &startEnd,
+            &endLen);
+        /* Validate header name and footer name are the same. */
+        if ((endLen != nameLen) ||
+                 (XMEMCMP(*name, pem + startEnd, nameLen) != 0)) {
+            ret = ASN_NO_PEM_HEADER;
+        }
+    }
+    if (ret == 0) {
+        unsigned char* der = (unsigned char*)pem;
+        word32 derLen;
+
+        /* Convert PEM body to DER. */
+        derLen = (word32)(startEnd - PEM_END_SZ - start);
+        ret = Base64_Decode(der + start, derLen, der, &derLen);
+        if (ret == 0) {
+            /* Return the DER data. */
+            *data = der;
+            *len = derLen;
+        }
+    }
+
+    return ret;
+}
+
+/* Encode the DER data in PEM format into a newly allocated buffer.
+ *
+ * @param [in]  name       Header/footer name.
+ * @param [in]  header     Encryption header.
+ * @param [in]  data       DER data.
+ * @param [in]  len        Length of DER data.
+ * @param [out] pemOut     PEM encoded data.
+ * @param [out] pemOutLen  Length of PEM encoded data.
+ * @return  0 on success.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+static int pem_write_data(const char *name, const char *header,
+    const unsigned char *data, long len, char** pemOut, word32* pemOutLen)
+{
+    int ret = 0;
+    int nameLen;
+    int headerLen;
+    char* pem = NULL;
+    word32 pemLen;
+    word32 derLen = (word32)len;
+    byte* p;
+
+    nameLen = (int)XSTRLEN(name);
+    headerLen = (int)XSTRLEN(header);
+
+    /* DER encode for PEM. */
+    pemLen  = (derLen + 2) / 3 * 4;
+    pemLen += (pemLen + 63) / 64;
+    /* Header */
+    pemLen += PEM_BEGIN_SZ + nameLen + PEM_HDR_FIN_EOL_SZ;
+    if (headerLen > 0) {
+        /* Encryption lines plus extra carriage return. */
+        pemLen += headerLen + 1;
+    }
+    /* Trailer */
+    pemLen += PEM_END_SZ + nameLen + PEM_HDR_FIN_EOL_SZ;
+
+    pem = (char*)XMALLOC(pemLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (pem == NULL) {
+        ret = MEMORY_E;
+    }
+    p = (byte*)pem;
+
+    if (ret == 0) {
+        /* Add header. */
+        XMEMCPY(p, PEM_BEGIN, PEM_BEGIN_SZ);
+        p += PEM_BEGIN_SZ;
+        XMEMCPY(p, name, nameLen);
+        p += nameLen;
+        XMEMCPY(p, PEM_HDR_FIN_EOL_NEWLINE, PEM_HDR_FIN_EOL_SZ);
+        p += PEM_HDR_FIN_EOL_SZ;
+
+        if (headerLen > 0) {
+            /* Add encryption header. */
+            XMEMCPY(p, header, headerLen);
+            p += headerLen;
+            /* Blank line after a header and before body. */
+            *(p++) = '\n';
+        }
+
+        /* Add DER data as PEM. */
+        pemLen -= (word32)((size_t)p - (size_t)pem);
+        ret = Base64_Encode(data, derLen, p, &pemLen);
+    }
+    if (ret == 0) {
+        p += pemLen;
+
+        /* Add trailer. */
+        XMEMCPY(p, PEM_END, PEM_END_SZ);
+        p += PEM_END_SZ;
+        XMEMCPY(p, name, nameLen);
+        p += nameLen;
+        XMEMCPY(p, PEM_HDR_FIN_EOL_NEWLINE, PEM_HDR_FIN_EOL_SZ);
+        p += PEM_HDR_FIN_EOL_SZ;
+
+        /* Return buffer and length of data. */
+        *pemOut = pem;
+        *pemOutLen = (word32)((size_t)p - (size_t)pem);
+    }
+
+    return ret;
+}
+#endif /* !NO_BIO || !NO_FILESYSTEM */
+
+#ifndef NO_BIO
+/* Read PEM encoded data from a BIO.
+ *
+ * Reads the entire contents in.
+ *
+ * @param [in]  bio     BIO to read from.
+ * @param [out] name    Name of content type.
+ * @param [out] header  Encryption headers.
+ * @param [out] data    DER encoding from PEM.
+ * @param [out] len     Length of DER data.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_PEM_read_bio(WOLFSSL_BIO* bio, char **name, char **header,
+    unsigned char **data, long *len)
+{
+    int res = 1;
+    char* pem = NULL;
+    int pemLen = 0;
+    int memAlloced = 1;
+
+    /* Validate parameters. */
+    if ((bio == NULL) || (name == NULL) || (header == NULL) || (data == NULL) ||
+            (len == NULL)) {
+        res = 0;
+    }
+
+    /* Load all the data from the BIO. */
+    if ((res == 1) && (wolfssl_read_bio(bio, &pem, &pemLen, &memAlloced) !=
+             0)) {
+        res = 0;
+    }
+    if ((res == 1) && (!memAlloced)) {
+        /* Need to return allocated memory - make sure it is allocated. */
+        char* p = (char*)XMALLOC(pemLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (p == NULL) {
+            res = 0;
+        }
+        else {
+            /* Copy the data into new buffer. */
+            XMEMCPY(p, pem, pemLen);
+            pem = p;
+        }
+    }
+
+    /* Read the PEM data. */
+    if ((res == 1) && (pem_read_data(pem, pemLen, name, header, data, len) !=
+            0)) {
+        /* Dispose of any allocated memory. */
+        XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(*name, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(*header, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        *name = NULL;
+        *header = NULL;
+        res = 0;
+    }
+
+    return res;
+}
+
+/* Encode the DER data in PEM format into a BIO.
+ *
+ * @param [in] bio     BIO to write to.
+ * @param [in] name    Header/footer name.
+ * @param [in] header  Encryption header.
+ * @param [in] data    DER data.
+ * @param [in] len     Length of DER data.
+ * @return  0 on failure.
+ */
+int wolfSSL_PEM_write_bio(WOLFSSL_BIO* bio, const char *name,
+    const char *header, const unsigned char *data, long len)
+{
+    int err = 0;
+    char* pem = NULL;
+    word32 pemLen = 0;
+
+    /* Validate parameters. */
+    if ((bio == NULL) || (name == NULL) || (header == NULL) || (data == NULL)) {
+        err = BAD_FUNC_ARG;
+    }
+
+    /* Encode into a buffer. */
+    if (!err) {
+        err = pem_write_data(name, header, data, len, &pem, &pemLen);
+    }
+
+    /* Write PEM into BIO. */
+    if ((!err) && (wolfSSL_BIO_write(bio, pem, (int)pemLen) != (int)pemLen)) {
+        err = IO_FAILED_E;
+    }
+
+    XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    return (!err) ? pemLen : 0;
+}
+#endif /* !NO_BIO */
+
+#if !defined(NO_FILESYSTEM)
+/* Read PEM encoded data from a file.
+ *
+ * Reads the entire contents in.
+ *
+ * @param [in]  bio     BIO to read from.
+ * @param [out] name    Name of content type.
+ * @param [out] header  Encryption headers.
+ * @param [out] data    DER encoding from PEM.
+ * @param [out] len     Length of DER data.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_PEM_read(XFILE fp, char **name, char **header, unsigned char **data,
+    long *len)
+{
+    int res = 1;
+    char* pem = NULL;
+    int pemLen = 0;
+
+    /* Validate parameters. */
+    if ((fp == XBADFILE) || (name == NULL) || (header == NULL) ||
+            (data == NULL) || (len == NULL)) {
+        res = 0;
+    }
+
+    /* Load all the data from the file. */
+    if ((res == 1) && (wolfssl_read_file(fp, &pem, &pemLen) != 0)) {
+        res = 0;
+    }
+
+    /* Read the PEM data. */
+    if ((res == 1) && (pem_read_data(pem, pemLen, name, header, data, len) !=
+            0)) {
+        /* Dispose of any allocated memory. */
+        XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(*name, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(*header, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        *name = NULL;
+        *header = NULL;
+        res = 0;
+    }
+
+    return res;
+}
+
+/* Encode the DER data in PEM format into a file.
+ *
+ * @param [in] fp      File pointer to write to.
+ * @param [in] name    Header/footer name.
+ * @param [in] header  Encryption header.
+ * @param [in] data    DER data.
+ * @param [in] len     Length of DER data.
+ * @return  0 on success.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+int wolfSSL_PEM_write(XFILE fp, const char *name, const char *header,
+    const unsigned char *data, long len)
+{
+    int err = 0;
+    char* pem = NULL;
+    word32 pemLen = 0;
+
+    /* Validate parameters. */
+    if ((fp == XBADFILE) || (name == NULL) || (header == NULL) ||
+            (data == NULL)) {
+        err = 1;
+    }
+
+    /* Encode into a buffer. */
+    if ((!err) && (pem_write_data(name, header, data, len, &pem, &pemLen) !=
+            0)) {
+        pemLen = 0;
+        err = 1;
+    }
+
+    /* Write PEM to a file. */
+    if ((!err) && (XFWRITE(pem, 1, pemLen, fp) != pemLen)) {
+        pemLen = 0;
+    }
+
+    XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    return (int)pemLen;
+}
+#endif
+
+/* Get EVP cipher info from encryption header string.
+ *
+ * @param [in]  header  Encryption header.
+ * @param [out] cipher  EVP Cipher info.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_PEM_get_EVP_CIPHER_INFO(const char* header, EncryptedInfo* cipher)
+{
+    int res = 1;
+
+    /* Validate parameters. */
+    if ((header == NULL) || (cipher == NULL)) {
+        res = 0;
+    }
+
+    if (res == 1) {
+        XMEMSET(cipher, 0, sizeof(*cipher));
+
+        if (wc_EncryptedInfoParse(cipher, &header, XSTRLEN(header)) != 0) {
+            res = 0;
+        }
+    }
+
+    return res;
+}
+
+/* Apply cipher to DER data.
+ *
+ * @param [in]      cipher  EVP cipher info.
+ * @param [in, out] data    On in, encrypted DER data.
+ *                          On out, unencrypted DER data.
+ * @param [in, out] len     On in, length of encrypted DER data.
+ *                          On out, length of unencrypted DER data.
+ * @param [in]      cb      Password callback.
+ * @param [in]      ctx     Context for password callback.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_PEM_do_header(EncryptedInfo* cipher, unsigned char* data, long* len,
+    wc_pem_password_cb* cb, void* ctx)
+{
+    int ret = 1;
+    char password[NAME_SZ];
+    int passwordSz = 0;
+
+    /* Validate parameters. */
+    if ((cipher == NULL) || (data == NULL) || (len == NULL) || (cb == NULL)) {
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        /* Get password and length. */
+        passwordSz = cb(password, sizeof(password), PEM_PASS_READ, ctx);
+        if (passwordSz < 0) {
+            ret = 0;
+        }
+    }
+
+    if (ret == 1) {
+        /* Decrypt the data using password and MD5. */
+        if (wc_BufferKeyDecrypt(cipher, data, (word32)*len, (byte*)password,
+                passwordSz, WC_MD5) != 0) {
+            ret = WOLFSSL_FAILURE;
+        }
+    }
+
+    if (passwordSz > 0) {
+        /* Ensure password is erased from memory. */
+        ForceZero(password, (word32)passwordSz);
+    }
+
+    return ret;
+}
+
+#endif /* !NO_CERTS */
+#endif /* OPENSSL_EXTRA */
+
+#ifdef OPENSSL_ALL
+#if !defined(NO_PWDBASED) && defined(HAVE_PKCS8)
+
+#if !defined(NO_BIO) || (!defined(NO_FILESYSTEM) && \
+    !defined(NO_STDIO_FILESYSTEM))
+/* Encrypt the key into a buffer using PKCS$8 and a password.
+ *
+ * @param [in]      pkey      Private key to encrypt.
+ * @param [in]      enc       EVP cipher.
+ * @param [in]      passwd    Password to encrypt with.
+ * @param [in]      passwdSz  Number of bytes in password.
+ * @param [in]      key       Buffer to hold encrypted key.
+ * @param [in, out] keySz     On in, size of buffer in bytes.
+ *                            On out, size of encrypted key in bytes.
+ * @return  0 on success.
+ * @return  BAD_FUNC_ARG when EVP cipher not supported.
+ */
+static int pem_pkcs8_encrypt(WOLFSSL_EVP_PKEY* pkey,
+    const WOLFSSL_EVP_CIPHER* enc, char* passwd, int passwdSz, byte* key,
+    word32* keySz)
+{
+    int ret;
+    WC_RNG rng;
+
+    /* Initialize a new random number generator. */
+    ret = wc_InitRng(&rng);
+    if (ret == 0) {
+        int encAlgId = 0;
+
+        /* Convert EVP cipher to a support encryption id. */
+    #ifndef NO_DES3
+        if (enc == EVP_DES_CBC) {
+            encAlgId = DESb;
+        }
+        else if (enc == EVP_DES_EDE3_CBC) {
+            encAlgId = DES3b;
+        }
+        else
+    #endif
+#if !defined(NO_AES) && defined(HAVE_AES_CBC)
+    #ifdef WOLFSSL_AES_128
+        if (enc == EVP_AES_128_CBC) {
+            encAlgId = AES128CBCb;
+        }
+        else
+     #endif
+    #ifdef WOLFSSL_AES_256
+        if (enc == EVP_AES_256_CBC) {
+            encAlgId = AES256CBCb;
+        }
+        else
+     #endif
+#endif
+        {
+            ret = BAD_FUNC_ARG;
+        }
+
+        if (ret == 0) {
+            /* Encrypt private into buffer. */
+            ret = TraditionalEnc((byte*)pkey->pkey.ptr, pkey->pkey_sz,
+                key, keySz, passwd, passwdSz, PKCS5, PBES2, encAlgId,
+                NULL, 0, WC_PKCS12_ITT_DEFAULT, &rng, NULL);
+            if (ret > 0) {
+                *keySz = (word32)ret;
+            }
+        }
+        /* Dispose of random number generator. */
+        wc_FreeRng(&rng);
+    }
+
+    return ret;
+}
+
+/* Encode private key in PKCS#8 format.
+ *
+ * @param [in]      pkey   Private key.
+ * @param [out]     key    Buffer to hold encoding.
+ * @param [in, out] keySz  On in, size of buffer in bytes.
+ * @param                  On out, size of encoded key in bytes.
+ * @return  0 on success.
+ */
+static int pem_pkcs8_encode(WOLFSSL_EVP_PKEY* pkey, byte* key, word32* keySz)
+{
+    int ret = 0;
+    int algId;
+    const byte* curveOid;
+    word32 oidSz;
+
+    /* Get the details of the private key. */
+#ifdef HAVE_ECC
+    if (pkey->type == EVP_PKEY_EC) {
+        /* ECC private and get curve OID information. */
+        algId = ECDSAk;
+        ret = wc_ecc_get_oid(pkey->ecc->group->curve_oid, &curveOid,
+            &oidSz);
+    }
+    else
+#endif
+    if (pkey->type == EVP_PKEY_RSA) {
+        /* RSA private has no curve information. */
+        algId = RSAk;
+        curveOid = NULL;
+        oidSz = 0;
+    }
+    else {
+        ret = NOT_COMPILED_IN;
+    }
+
+    if (ret >= 0) {
+        /* Encode private key in PKCS#8 format. */
+        ret = wc_CreatePKCS8Key(key, keySz, (byte*)pkey->pkey.ptr,
+            pkey->pkey_sz, algId, curveOid, oidSz);
+    }
+
+    return ret;
+}
+
+/* Write PEM encoded, PKCS#8 formatted private key to BIO.
+ *
+ * @param [out] pem       Buffer holding PEM encoding.
+ * @param [out] pemSz     Size of data in buffer in bytes.
+ * @param [in]  pkey      Private key to write.
+ * @param [in]  enc       Encryption information to use. May be NULL.
+ * @param [in]  passwd    Password to use when encrypting. May be NULL.
+ * @param [in]  passwdSz  Size of password in bytes.
+ * @param [in]  cb        Password callback. Used when passwd is NULL. May be
+ *                        NULL.
+ * @param [in]  ctx       Context for password callback.
+ * @return  Length of PEM encoding on success.
+ * @return  0 on failure.
+ */
+static int pem_write_mem_pkcs8privatekey(byte** pem, int* pemSz,
+    WOLFSSL_EVP_PKEY* pkey, const WOLFSSL_EVP_CIPHER* enc, char* passwd,
+    int passwdSz, wc_pem_password_cb* cb, void* ctx)
+{
+    int res = 1;
+    int ret = 0;
+    char password[NAME_SZ];
+    byte* key = NULL;
+    word32 keySz;
+    int type = PKCS8_PRIVATEKEY_TYPE;
+
+    /* Validate parameters. */
+    if (pkey == NULL) {
+        res = 0;
+    }
+
+    if (res == 1) {
+        /* Guestimate key size and PEM size. */
+        if (pem_pkcs8_encode(pkey, NULL, &keySz) != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
+            res = 0;
+        }
+    }
+    if (res == 1) {
+        if (enc != NULL) {
+            /* Add on enough for extra DER data when encrypting. */
+            keySz += 128;
+        }
+        /* PEM encoding size from DER size. */
+        *pemSz  = (int)(keySz + 2) / 3 * 4;
+        *pemSz += (*pemSz + 63) / 64;
+        /* Header and footer. */
+        if (enc != NULL) {
+            /* Name is: 'ENCRYPTED PRIVATE KEY'. */
+            *pemSz += 74;
+        }
+        else {
+            /* Name is: 'PRIVATE KEY'. */
+            *pemSz += 54;
+        }
+
+        /* Allocate enough memory to hold PEM encoded encrypted key. */
+        *pem = (byte*)XMALLOC((size_t)*pemSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (*pem == NULL) {
+            res = 0;
+        }
+        else {
+            /* Use end of PEM buffer for key data. */
+            key = *pem + *pemSz - keySz;
+        }
+    }
+
+    if ((res == 1) && (enc != NULL)) {
+        /* Set type for PEM. */
+        type = PKCS8_ENC_PRIVATEKEY_TYPE;
+
+        if (passwd == NULL) {
+            /* Get the password by using callback. */
+            passwdSz = cb(password, sizeof(password), 1, ctx);
+            if (passwdSz < 0) {
+                res = 0;
+            }
+            passwd = password;
+        }
+
+        if (res == 1) {
+            /* Encrypt the private key. */
+            ret = pem_pkcs8_encrypt(pkey, enc, passwd, passwdSz, key, &keySz);
+            if (ret <= 0) {
+                res = 0;
+            }
+        }
+
+        /* Zeroize the password from memory. */
+        if ((password == passwd) && (passwdSz > 0)) {
+            ForceZero(password, (word32)passwdSz);
+        }
+    }
+    else if ((res == 1) && (enc == NULL)) {
+        /* Set type for PEM. */
+        type = PKCS8_PRIVATEKEY_TYPE;
+
+        /* Encode private key in PKCS#8 format. */
+        ret = pem_pkcs8_encode(pkey, key, &keySz);
+        if (ret < 0) {
+            res = 0;
+        }
+    }
+
+    if (res == 1) {
+        /* Encode PKCS#8 formatted key to PEM. */
+        ret = wc_DerToPemEx(key, keySz, *pem, (word32)*pemSz, NULL, type);
+        if (ret < 0) {
+            res = 0;
+        }
+        else {
+            *pemSz = ret;
+        }
+    }
+
+    /* Return appropriate return code. */
+    return (res == 0) ? 0 : ret;
+
+}
+#endif /* !NO_BIO || (!NO_FILESYSTEM && !NO_STDIO_FILESYSTEM) */
+
+#ifndef NO_BIO
+/* Write PEM encoded, PKCS#8 formatted private key to BIO.
+ *
+ * TODO: OpenSSL returns 1 and 0 only.
+ *
+ * @param [in] bio       BIO to write to.
+ * @param [in] pkey      Private key to write.
+ * @param [in] enc       Encryption information to use. May be NULL.
+ * @param [in] passwd    Password to use when encrypting. May be NULL.
+ * @param [in] passwdSz  Size of password in bytes.
+ * @param [in] cb        Password callback. Used when passwd is NULL. May be
+ *                       NULL.
+ * @param [in] ctx       Context for password callback.
+ * @return  Length of PEM encoding on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_PEM_write_bio_PKCS8PrivateKey(WOLFSSL_BIO* bio,
+    WOLFSSL_EVP_PKEY* pkey, const WOLFSSL_EVP_CIPHER* enc, char* passwd,
+    int passwdSz, wc_pem_password_cb* cb, void* ctx)
+{
+    byte* pem = NULL;
+    int pemSz = 0;
+    int res = 1;
+
+    /* Validate parameters. */
+    if (bio == NULL) {
+        res = 0;
+    }
+    if (res == 1) {
+        /* Write private key to memory. */
+        res = pem_write_mem_pkcs8privatekey(&pem, &pemSz, pkey, enc, passwd,
+            passwdSz, cb, ctx);
+    }
+
+    /* Write encoded key to BIO. */
+    if ((res >= 1) && (wolfSSL_BIO_write(bio, pem, pemSz) != pemSz)) {
+        res = 0;
+    }
+
+    /* Dispose of dynamically allocated memory (pem and key). */
+    XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    return res;
+}
+#endif /* !NO_BIO */
+
+#if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
+/* Write PEM encoded, PKCS#8 formatted private key to BIO.
+ *
+ * TODO: OpenSSL returns 1 and 0 only.
+ *
+ * @param [in] f         File pointer.
+ * @param [in] pkey      Private key to write.
+ * @param [in] enc       Encryption information to use. May be NULL.
+ * @param [in] passwd    Password to use when encrypting. May be NULL.
+ * @param [in] passwdSz  Size of password in bytes.
+ * @param [in] cb        Password callback. Used when passwd is NULL. May be
+ *                       NULL.
+ * @param [in] ctx       Context for password callback.
+ * @return  Length of PEM encoding on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_PEM_write_PKCS8PrivateKey(XFILE f, WOLFSSL_EVP_PKEY* pkey,
+    const WOLFSSL_EVP_CIPHER* enc, char* passwd, int passwdSz,
+    wc_pem_password_cb* cb, void* ctx)
+{
+    byte* pem = NULL;
+    int pemSz = 0;
+    int res = 1;
+
+    /* Validate parameters. */
+    if (f == XBADFILE) {
+        res = 0;
+    }
+    if (res == 1) {
+        /* Write private key to memory. */
+        res = pem_write_mem_pkcs8privatekey(&pem, &pemSz, pkey, enc, passwd,
+            passwdSz, cb, ctx);
+    }
+
+    /* Write encoded key to file. */
+    if ((res >= 1) && (XFWRITE(pem, 1, (size_t)pemSz, f) != (size_t)pemSz)) {
+        res = 0;
+    }
+
+    /* Dispose of dynamically allocated memory (pem and key). */
+    XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    return res;
+}
+#endif /* !NO_FILESYSTEM && !NO_STDIO_FILESYSTEM */
+
+#endif /* !NO_PWDBASED && HAVE_PKCS8 */
+#endif /* OPENSSL_ALL */
+
+/*******************************************************************************
+ * END OF GENERIC PUBLIC KEY PEM APIs
  ******************************************************************************/
 
 #endif /* !WOLFSSL_PK_INCLUDED */

--- a/libatalk/ssl/src/ssl.c
+++ b/libatalk/ssl/src/ssl.c
@@ -25,11 +25,11 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
-#if defined(OPENSSL_EXTRA) && !defined(_WIN32)
+//#if defined(OPENSSL_EXTRA) && !defined(_WIN32)
     /* turn on GNU extensions for XISASCII */
-    #undef  _GNU_SOURCE
-    #define _GNU_SOURCE
-#endif
+//    #undef  _GNU_SOURCE
+//    #define _GNU_SOURCE
+//#endif
 
 #if !defined(WOLFCRYPT_ONLY) || defined(OPENSSL_EXTRA) || \
     defined(OPENSSL_EXTRA_X509_SMALL)
@@ -17602,7 +17602,7 @@ cleanup:
 #endif /* WOLFSSL_ENCRYPTED_KEYS */
 
 
-#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(HAVE_MEMCACHED) || defined(EMBEDDED_SSL)
+#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || defined(HAVE_MEMCACHED)
     unsigned long wolfSSL_ERR_get_error(void)
     {
         WOLFSSL_ENTER("wolfSSL_ERR_get_error");
@@ -18563,7 +18563,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     }
 #endif /* OPENSSL_EXTRA */
 
-#if defined(OPENSSL_EXTRA) || defined(EMBEDDED_SSL)
+#ifdef OPENSSL_EXTRA
     void wolfSSL_ERR_free_strings(void)
     {
         /* handled internally */
@@ -18574,7 +18574,7 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
         /* nothing to do here */
     }
 
-#endif /* OPENSSL_EXTRA || EMBEDDED_SSL */
+#endif /* OPENSSL_EXTRA */
 
 #if defined(OPENSSL_EXTRA) || defined(DEBUG_WOLFSSL_VERBOSE) || \
     defined(HAVE_CURL)
@@ -28154,15 +28154,6 @@ void* wolfSSL_SESSION_get_ex_data(const WOLFSSL_SESSION* session, int idx)
 }
 #endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL || HAVE_EX_DATA */
 
-#ifdef EMBEDDED_SSL
-void wolfSSL_ERR_load_crypto_strings(void)
-{
-    WOLFSSL_ENTER("wolfSSL_ERR_load_crypto_strings");
-    /* Do nothing */
-    return;
-}
-#endif
-
 /* Note: This is a huge section of API's - through
  *       wolfSSL_X509_OBJECT_get0_X509_CRL */
 #if defined(OPENSSL_ALL) || (defined(OPENSSL_EXTRA) && \
@@ -28250,14 +28241,12 @@ int wolfSSL_ERR_load_ERR_strings(void)
     return WOLFSSL_SUCCESS;
 }
 
-#ifndef EMBEDDED_SSL
 void wolfSSL_ERR_load_crypto_strings(void)
 {
     WOLFSSL_ENTER("wolfSSL_ERR_load_crypto_strings");
     /* Do nothing */
     return;
 }
-#endif
 
 int wolfSSL_FIPS_mode(void)
 {

--- a/libatalk/ssl/src/ssl.c
+++ b/libatalk/ssl/src/ssl.c
@@ -25,11 +25,11 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
-//#if defined(OPENSSL_EXTRA) && !defined(_WIN32)
+#if defined(OPENSSL_EXTRA) && !defined(_WIN32)
     /* turn on GNU extensions for XISASCII */
-//    #undef  _GNU_SOURCE
-//    #define _GNU_SOURCE
-//#endif
+    #undef  _GNU_SOURCE
+    #define _GNU_SOURCE
+#endif
 
 #if !defined(WOLFCRYPT_ONLY) || defined(OPENSSL_EXTRA) || \
     defined(OPENSSL_EXTRA_X509_SMALL)
@@ -54,7 +54,8 @@
     #if defined(NO_DH) && !defined(HAVE_ECC) && !defined(WOLFSSL_STATIC_RSA) \
                 && !defined(WOLFSSL_STATIC_DH) && !defined(WOLFSSL_STATIC_PSK) \
                 && !defined(HAVE_CURVE25519) && !defined(HAVE_CURVE448)
-        #error "No cipher suites defined because DH disabled, ECC disabled, and no static suites defined. Please see top of README"
+        #error "No cipher suites defined because DH disabled, ECC disabled, "
+               "and no static suites defined. Please see top of README"
     #endif
     #ifdef WOLFSSL_CERT_GEN
         /* need access to Cert struct for creating certificate */
@@ -115,14 +116,15 @@
     #include <wolfssl/wolfcrypt/curve25519.h>
     #include <wolfssl/wolfcrypt/ed25519.h>
     #include <wolfssl/wolfcrypt/curve448.h>
-    #if defined(HAVE_PQC)
     #if defined(HAVE_FALCON)
         #include <wolfssl/wolfcrypt/falcon.h>
     #endif /* HAVE_FALCON */
     #if defined(HAVE_DILITHIUM)
         #include <wolfssl/wolfcrypt/dilithium.h>
     #endif /* HAVE_DILITHIUM */
-    #endif /* HAVE_PQC */
+    #if defined(HAVE_SPHINCS)
+        #include <wolfssl/wolfcrypt/sphincs.h>
+    #endif /* HAVE_SPHINCS */
     #if defined(OPENSSL_ALL) || defined(HAVE_STUNNEL)
         #ifdef HAVE_OCSP
             #include <wolfssl/openssl/ocsp.h>
@@ -137,12 +139,6 @@
         && !defined(WC_NO_RNG)
         #include <wolfssl/wolfcrypt/srp.h>
     #endif
-    #if defined(HAVE_FIPS) || defined(HAVE_SELFTEST)
-        #include <wolfssl/wolfcrypt/pkcs7.h>
-    #endif
-    #if defined(OPENSSL_ALL) && defined(HAVE_PKCS7)
-        #include <wolfssl/openssl/pkcs7.h>
-    #endif /* OPENSSL_ALL && HAVE_PKCS7 */
 #endif
 
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
@@ -159,25 +155,6 @@
     #include <wolfssl/wolfcrypt/dh.h>
 #endif
 #endif /* !WOLFCRYPT_ONLY || OPENSSL_EXTRA */
-
-#ifdef WOLFSSL_SYS_CA_CERTS
-
-#ifdef _WIN32
-    #include <windows.h>
-    #include <wincrypt.h>
-
-    /* mingw gcc does not support pragma comment, and the
-     * linking with crypt32 is handled in configure.ac */
-    #if !defined(__MINGW32__) && !defined(__MINGW64__)
-        #pragma comment(lib, "crypt32")
-    #endif
-#endif
-
-#if defined(__APPLE__) && defined(HAVE_SECURITY_SECTRUSTSETTINGS_H)
-#include <Security/SecTrustSettings.h>
-#endif
-
-#endif /* WOLFSSL_SYS_CA_CERTS */
 
 /*
  * OPENSSL_COMPATIBLE_DEFAULTS:
@@ -215,6 +192,9 @@
 #ifndef WOLFCRYPT_ONLY
 #define WOLFSSL_SSL_CERTMAN_INCLUDED
 #include "src/ssl_certman.c"
+
+#define WOLFSSL_SSL_SESS_INCLUDED
+#include "src/ssl_sess.c"
 #endif
 
 #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
@@ -307,9 +287,10 @@ int wc_OBJ_sn2nid(const char *sn)
 
 #define HAVE_GLOBAL_RNG /* consolidate flags for using globalRNG */
 static WC_RNG globalRNG;
-static int initGlobalRNG = 0;
+static volatile int initGlobalRNG = 0;
 
-static WC_MAYBE_UNUSED wolfSSL_Mutex globalRNGMutex WOLFSSL_MUTEX_INITIALIZER_CLAUSE(globalRNGMutex);
+static WC_MAYBE_UNUSED wolfSSL_Mutex globalRNGMutex
+    WOLFSSL_MUTEX_INITIALIZER_CLAUSE(globalRNGMutex);
 #ifndef WOLFSSL_MUTEX_INITIALIZER
 static int globalRNGMutex_valid = 0;
 #endif
@@ -408,7 +389,8 @@ WC_RNG* wolfssl_make_rng(WC_RNG* rng, int* local)
      *                OPENSSL_EXTRA where RAND callbacks are not used */
     #ifndef WOLFSSL_NO_OPENSSL_RAND_CB
         static const WOLFSSL_RAND_METHOD* gRandMethods = NULL;
-        static wolfSSL_Mutex gRandMethodMutex WOLFSSL_MUTEX_INITIALIZER_CLAUSE(gRandMethodMutex);
+        static wolfSSL_Mutex gRandMethodMutex
+            WOLFSSL_MUTEX_INITIALIZER_CLAUSE(gRandMethodMutex);
         #ifndef WOLFSSL_MUTEX_INITIALIZER
         static int gRandMethodsInit = 0;
         #endif
@@ -427,47 +409,6 @@ WC_RNG* wolfssl_make_rng(WC_RNG* rng, int* local)
 #include "src/pk.c"
 
 #include <wolfssl/wolfcrypt/hpke.h>
-
-#if defined(OPENSSL_EXTRA) && defined(HAVE_ECC)
-const WOLF_EC_NIST_NAME kNistCurves[] = {
-    {XSTR_SIZEOF("P-192"),   "P-192",   NID_X9_62_prime192v1},
-    {XSTR_SIZEOF("P-256"),   "P-256",   NID_X9_62_prime256v1},
-    {XSTR_SIZEOF("P-112"),   "P-112",   NID_secp112r1},
-    {XSTR_SIZEOF("P-112-2"), "P-112-2", NID_secp112r2},
-    {XSTR_SIZEOF("P-128"),   "P-128",   NID_secp128r1},
-    {XSTR_SIZEOF("P-128-2"), "P-128-2", NID_secp128r2},
-    {XSTR_SIZEOF("P-160"),   "P-160",   NID_secp160r1},
-    {XSTR_SIZEOF("P-160-2"), "P-160-2", NID_secp160r2},
-    {XSTR_SIZEOF("P-224"),   "P-224",   NID_secp224r1},
-    {XSTR_SIZEOF("P-384"),   "P-384",   NID_secp384r1},
-    {XSTR_SIZEOF("P-521"),   "P-521",   NID_secp521r1},
-    {XSTR_SIZEOF("K-160"),   "K-160",   NID_secp160k1},
-    {XSTR_SIZEOF("K-192"),   "K-192",   NID_secp192k1},
-    {XSTR_SIZEOF("K-224"),   "K-224",   NID_secp224k1},
-    {XSTR_SIZEOF("K-256"),   "K-256",   NID_secp256k1},
-    {XSTR_SIZEOF("B-160"),   "B-160",   NID_brainpoolP160r1},
-    {XSTR_SIZEOF("B-192"),   "B-192",   NID_brainpoolP192r1},
-    {XSTR_SIZEOF("B-224"),   "B-224",   NID_brainpoolP224r1},
-    {XSTR_SIZEOF("B-256"),   "B-256",   NID_brainpoolP256r1},
-    {XSTR_SIZEOF("B-320"),   "B-320",   NID_brainpoolP320r1},
-    {XSTR_SIZEOF("B-384"),   "B-384",   NID_brainpoolP384r1},
-    {XSTR_SIZEOF("B-512"),   "B-512",   NID_brainpoolP512r1},
-#ifdef HAVE_PQC
-    {XSTR_SIZEOF("KYBER_LEVEL1"), "KYBER_LEVEL1", WOLFSSL_KYBER_LEVEL1},
-    {XSTR_SIZEOF("KYBER_LEVEL3"), "KYBER_LEVEL3", WOLFSSL_KYBER_LEVEL3},
-    {XSTR_SIZEOF("KYBER_LEVEL5"), "KYBER_LEVEL5", WOLFSSL_KYBER_LEVEL5},
-#ifdef HAVE_LIBOQS
-    {XSTR_SIZEOF("P256_KYBER_LEVEL1"), "P256_KYBER_LEVEL1", WOLFSSL_P256_KYBER_LEVEL1},
-    {XSTR_SIZEOF("P384_KYBER_LEVEL3"), "P384_KYBER_LEVEL3", WOLFSSL_P384_KYBER_LEVEL3},
-    {XSTR_SIZEOF("P521_KYBER_LEVEL5"), "P521_KYBER_LEVEL5", WOLFSSL_P521_KYBER_LEVEL5},
-#endif
-#endif
-#ifdef WOLFSSL_SM2
-    {XSTR_SIZEOF("SM2"),     "SM2",     NID_sm2},
-#endif
-    {0, NULL, 0},
-};
-#endif
 
 #if defined(WOLFSSL_TLS13) && defined(HAVE_ECH)
 /* create the hpke key and ech config to send to clients */
@@ -1037,7 +978,7 @@ int GetEchConfigsEx(WOLFSSL_EchConfig* configs, byte* output, word32* outputLen)
             workingOutputLen = *outputLen - totalLen;
 
         /* only error we break on, other 2 we need to keep finding length */
-        if (ret == BAD_FUNC_ARG)
+        if (ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG))
             return BAD_FUNC_ARG;
 
         workingConfig = workingConfig->next;
@@ -1067,209 +1008,11 @@ int GetEchConfigsEx(WOLFSSL_EchConfig* configs, byte* output, word32* outputLen)
 #include <wolfssl/wolfcrypt/port/Renesas/renesas_cmn.h>
 #endif
 
-#ifdef WOLFSSL_SESSION_EXPORT
-/* Used to import a serialized TLS session.
- * WARNING: buf contains sensitive information about the state and is best to be
- *          encrypted before storing if stored.
- *
- * @param ssl WOLFSSL structure to import the session into
- * @param buf serialized session
- * @param sz  size of buffer 'buf'
- * @return the number of bytes read from buffer 'buf'
- */
-int wolfSSL_tls_import(WOLFSSL* ssl, const unsigned char* buf, unsigned int sz)
-{
-    if (ssl == NULL || buf == NULL) {
-        return BAD_FUNC_ARG;
-    }
-    return wolfSSL_session_import_internal(ssl, buf, sz, WOLFSSL_EXPORT_TLS);
-}
-
-
-/* Used to export a serialized TLS session.
- * WARNING: buf contains sensitive information about the state and is best to be
- *          encrypted before storing if stored.
- *
- * @param ssl WOLFSSL structure to export the session from
- * @param buf output of serialized session
- * @param sz  size in bytes set in 'buf'
- * @return the number of bytes written into buffer 'buf'
- */
-int wolfSSL_tls_export(WOLFSSL* ssl, unsigned char* buf, unsigned int* sz)
-{
-    if (ssl == NULL || sz == NULL) {
-        return BAD_FUNC_ARG;
-    }
-    return wolfSSL_session_export_internal(ssl, buf, sz, WOLFSSL_EXPORT_TLS);
-}
-
-#ifdef WOLFSSL_DTLS
-int wolfSSL_dtls_import(WOLFSSL* ssl, const unsigned char* buf, unsigned int sz)
-{
-    WOLFSSL_ENTER("wolfSSL_session_import");
-
-    if (ssl == NULL || buf == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    /* sanity checks on buffer and protocol are done in internal function */
-    return wolfSSL_session_import_internal(ssl, buf, sz, WOLFSSL_EXPORT_DTLS);
-}
-
-
-/* Sets the function to call for serializing the session. This function is
- * called right after the handshake is completed. */
-int wolfSSL_CTX_dtls_set_export(WOLFSSL_CTX* ctx, wc_dtls_export func)
-{
-
-    WOLFSSL_ENTER("wolfSSL_CTX_dtls_set_export");
-
-    /* purposefully allow func to be NULL */
-    if (ctx == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    ctx->dtls_export = func;
-
-    return WOLFSSL_SUCCESS;
-}
-
-
-/* Sets the function in WOLFSSL struct to call for serializing the session. This
- * function is called right after the handshake is completed. */
-int wolfSSL_dtls_set_export(WOLFSSL* ssl, wc_dtls_export func)
-{
-
-    WOLFSSL_ENTER("wolfSSL_dtls_set_export");
-
-    /* purposefully allow func to be NULL */
-    if (ssl == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    ssl->dtls_export = func;
-
-    return WOLFSSL_SUCCESS;
-}
-
-
-/* This function allows for directly serializing a session rather than using
- * callbacks. It has less overhead by removing a temporary buffer and gives
- * control over when the session gets serialized. When using callbacks the
- * session is always serialized immediately after the handshake is finished.
- *
- * buf is the argument to contain the serialized session
- * sz  is the size of the buffer passed in
- * ssl is the WOLFSSL struct to serialize
- * returns the size of serialized session on success, 0 on no action, and
- *         negative value on error */
-int wolfSSL_dtls_export(WOLFSSL* ssl, unsigned char* buf, unsigned int* sz)
-{
-    WOLFSSL_ENTER("wolfSSL_dtls_export");
-
-    if (ssl == NULL || sz == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    if (buf == NULL) {
-        *sz = MAX_EXPORT_BUFFER;
-        return 0;
-    }
-
-    /* if not DTLS do nothing */
-    if (!ssl->options.dtls) {
-        WOLFSSL_MSG("Currently only DTLS export is supported");
-        return 0;
-    }
-
-    /* copy over keys, options, and dtls state struct */
-    return wolfSSL_session_export_internal(ssl, buf, sz, WOLFSSL_EXPORT_DTLS);
-}
-
-
-/* This function is similar to wolfSSL_dtls_export but only exports the portion
- * of the WOLFSSL structure related to the state of the connection, i.e. peer
- * sequence number, epoch, AEAD state etc.
- *
- * buf is the argument to contain the serialized state, if null then set "sz" to
- *     buffer size required
- * sz  is the size of the buffer passed in
- * ssl is the WOLFSSL struct to serialize
- * returns the size of serialized session on success, 0 on no action, and
- *         negative value on error */
-int wolfSSL_dtls_export_state_only(WOLFSSL* ssl, unsigned char* buf,
-        unsigned int* sz)
-{
-    WOLFSSL_ENTER("wolfSSL_dtls_export_state_only");
-
-    if (ssl == NULL || sz == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    if (buf == NULL) {
-        *sz = MAX_EXPORT_STATE_BUFFER;
-        return 0;
-    }
-
-    /* if not DTLS do nothing */
-    if (!ssl->options.dtls) {
-        WOLFSSL_MSG("Currently only DTLS export state is supported");
-        return 0;
-    }
-
-    /* copy over keys, options, and dtls state struct */
-    return wolfSSL_dtls_export_state_internal(ssl, buf, *sz);
-}
-
-
-/* returns 0 on success */
-int wolfSSL_send_session(WOLFSSL* ssl)
-{
-    int ret;
-    byte* buf;
-    word32 bufSz = MAX_EXPORT_BUFFER;
-
-    WOLFSSL_ENTER("wolfSSL_send_session");
-
-    if (ssl == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    buf = (byte*)XMALLOC(bufSz, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
-    if (buf == NULL) {
-        return MEMORY_E;
-    }
-
-    /* if not DTLS do nothing */
-    if (!ssl->options.dtls) {
-        XFREE(buf, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
-        WOLFSSL_MSG("Currently only DTLS export is supported");
-        return 0;
-    }
-
-    /* copy over keys, options, and dtls state struct */
-    ret = wolfSSL_session_export_internal(ssl, buf, &bufSz, WOLFSSL_EXPORT_DTLS);
-    if (ret < 0) {
-        XFREE(buf, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
-        return ret;
-    }
-
-    /* if no error ret has size of buffer */
-    ret = ssl->dtls_export(ssl, buf, ret, NULL);
-    if (ret != WOLFSSL_SUCCESS) {
-        XFREE(buf, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
-        return ret;
-    }
-
-    XFREE(buf, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
-    return 0;
-}
-#endif /* WOLFSSL_DTLS */
-#endif /* WOLFSSL_SESSION_EXPORT */
-
 /* prevent multiple mutex initializations */
 static volatile WOLFSSL_GLOBAL int initRefCount = 0;
-static WOLFSSL_GLOBAL wolfSSL_Mutex inits_count_mutex WOLFSSL_MUTEX_INITIALIZER_CLAUSE(inits_count_mutex); /* init ref count mutex */
+/* init ref count mutex */
+static WOLFSSL_GLOBAL wolfSSL_Mutex inits_count_mutex
+    WOLFSSL_MUTEX_INITIALIZER_CLAUSE(inits_count_mutex);
 #ifndef WOLFSSL_MUTEX_INITIALIZER
 static WOLFSSL_GLOBAL int inits_count_mutex_valid = 0;
 #endif
@@ -1339,8 +1082,8 @@ WOLFSSL_CTX* wolfSSL_CTX_new_ex(WOLFSSL_METHOD* method, void* heap)
         wolfSSL_CTX_set_verify(ctx, SSL_VERIFY_NONE, NULL);
         wolfSSL_CTX_set_mode(ctx, SSL_MODE_AUTO_RETRY);
         if (wolfSSL_CTX_set_min_proto_version(ctx,
-                                              (method->version.major == DTLS_MAJOR) ?
-                                               DTLS1_VERSION : SSL3_VERSION) != WOLFSSL_SUCCESS ||
+                (method->version.major == DTLS_MAJOR) ?
+                DTLS1_VERSION : SSL3_VERSION) != WOLFSSL_SUCCESS ||
 #ifdef HAVE_ANON
                 wolfSSL_CTX_allow_anon_cipher(ctx) != WOLFSSL_SUCCESS ||
 #endif
@@ -1610,8 +1353,8 @@ static int DupSSL(WOLFSSL* dup, WOLFSSL* ssl)
 #ifdef HAVE_ONE_TIME_AUTH
 #ifdef HAVE_POLY1305
     if (ssl->auth.setup && ssl->auth.poly1305 != NULL) {
-        dup->auth.poly1305 =
-            (Poly1305*)XMALLOC(sizeof(Poly1305), dup->heap, DYNAMIC_TYPE_CIPHER);
+        dup->auth.poly1305 = (Poly1305*)XMALLOC(sizeof(Poly1305), dup->heap,
+            DYNAMIC_TYPE_CIPHER);
         if (dup->auth.poly1305 == NULL)
             return MEMORY_E;
         dup->auth.setup = 1;
@@ -1945,7 +1688,7 @@ const char* wolfSSL_get_shared_ciphers(WOLFSSL* ssl, char* buf, int len)
         return NULL;
 
     cipher = wolfSSL_get_cipher_name_iana(ssl);
-    len = min(len, (int)(XSTRLEN(cipher) + 1));
+    len = (int)min((word32)len, (int)(XSTRLEN(cipher) + 1));
     XMEMCPY(buf, cipher, len);
     return buf;
 }
@@ -2218,10 +1961,12 @@ int wolfSSL_dtls_set_mtu(WOLFSSL* ssl, word16 newMtu)
 static const WOLFSSL_SRTP_PROTECTION_PROFILE gSrtpProfiles[] = {
     /* AES CCM 128, Salt:112-bits, Auth HMAC-SHA1 Tag: 80-bits
      * (master_key:128bits + master_salt:112bits) * 2 = 480 bits (60) */
-    {"SRTP_AES128_CM_SHA1_80", SRTP_AES128_CM_SHA1_80, (((128 + 112) * 2) / 8) },
+    {"SRTP_AES128_CM_SHA1_80", SRTP_AES128_CM_SHA1_80,
+     (((128 + 112) * 2) / 8) },
     /* AES CCM 128, Salt:112-bits, Auth HMAC-SHA1 Tag: 32-bits
      * (master_key:128bits + master_salt:112bits) * 2 = 480 bits (60) */
-    {"SRTP_AES128_CM_SHA1_32", SRTP_AES128_CM_SHA1_32, (((128 + 112) * 2) / 8) },
+    {"SRTP_AES128_CM_SHA1_32", SRTP_AES128_CM_SHA1_32,
+     (((128 + 112) * 2) / 8) },
     /* NULL Cipher, Salt:112-bits, Auth HMAC-SHA1 Tag 80-bits */
     {"SRTP_NULL_SHA1_80", SRTP_NULL_SHA1_80, ((112 * 2) / 8)},
     /* NULL Cipher, Salt:112-bits, Auth HMAC-SHA1 Tag 32-bits */
@@ -2348,7 +2093,7 @@ int wolfSSL_export_dtls_srtp_keying_material(WOLFSSL* ssl,
         return EXT_MISSING;
     }
     if (out == NULL) {
-        *olen = profile->kdfBits;
+        *olen = (size_t)profile->kdfBits;
         return LENGTH_ONLY_E;
     }
 
@@ -2465,7 +2210,8 @@ int wolfSSL_set_secret(WOLFSSL* ssl, word16 epoch,
 
     if (ret == 0) {
         XMEMCPY(ssl->arrays->preMasterSecret, preMasterSecret, preMasterSz);
-        XMEMSET(ssl->arrays->preMasterSecret + preMasterSz, 0, ENCRYPT_LEN - preMasterSz);
+        XMEMSET(ssl->arrays->preMasterSecret + preMasterSz, 0,
+            ENCRYPT_LEN - preMasterSz);
         ssl->arrays->preMasterSz = preMasterSz;
         XMEMCPY(ssl->arrays->clientRandom, clientRandom, RAN_LEN);
         XMEMCPY(ssl->arrays->serverRandom, serverRandom, RAN_LEN);
@@ -2716,7 +2462,8 @@ int wolfSSL_GetObjectSize(void)
 #ifdef WOLFSSL_SM4
     printf("\tsizeof sm4          = %lu\n", (unsigned long)sizeof(Sm4));
 #endif
-    printf("sizeof cipher specs     = %lu\n", (unsigned long)sizeof(CipherSpecs));
+    printf("sizeof cipher specs     = %lu\n", (unsigned long)
+        sizeof(CipherSpecs));
     printf("sizeof keys             = %lu\n", (unsigned long)sizeof(Keys));
     printf("sizeof Hashes(2)        = %lu\n", (unsigned long)sizeof(Hashes));
 #ifndef NO_MD5
@@ -2749,10 +2496,13 @@ int wolfSSL_GetObjectSize(void)
 #ifdef HAVE_ECC
     printf("sizeof ecc_key          = %lu\n", (unsigned long)sizeof(ecc_key));
 #endif
-    printf("sizeof WOLFSSL_CIPHER    = %lu\n", (unsigned long)sizeof(WOLFSSL_CIPHER));
-    printf("sizeof WOLFSSL_SESSION   = %lu\n", (unsigned long)sizeof(WOLFSSL_SESSION));
+    printf("sizeof WOLFSSL_CIPHER    = %lu\n", (unsigned long)
+        sizeof(WOLFSSL_CIPHER));
+    printf("sizeof WOLFSSL_SESSION   = %lu\n", (unsigned long)
+        sizeof(WOLFSSL_SESSION));
     printf("sizeof WOLFSSL           = %lu\n", (unsigned long)sizeof(WOLFSSL));
-    printf("sizeof WOLFSSL_CTX       = %lu\n", (unsigned long)sizeof(WOLFSSL_CTX));
+    printf("sizeof WOLFSSL_CTX       = %lu\n", (unsigned long)
+        sizeof(WOLFSSL_CTX));
 #endif
 
     return sizeof(WOLFSSL);
@@ -2772,13 +2522,11 @@ int wolfSSL_METHOD_GetObjectSize(void)
 
 #ifdef WOLFSSL_STATIC_MEMORY
 
-int wolfSSL_CTX_load_static_memory(WOLFSSL_CTX** ctx, wolfSSL_method_func method,
-                                   unsigned char* buf, unsigned int sz,
-                                   int flag, int maxSz)
+int wolfSSL_CTX_load_static_memory(WOLFSSL_CTX** ctx,
+    wolfSSL_method_func method, unsigned char* buf, unsigned int sz, int flag,
+    int maxSz)
 {
-    WOLFSSL_HEAP*      heap;
-    WOLFSSL_HEAP_HINT* hint;
-    word32 idx = 0;
+    WOLFSSL_HEAP_HINT* hint = NULL;
 
     if (ctx == NULL || buf == NULL) {
         return BAD_FUNC_ARG;
@@ -2788,61 +2536,29 @@ int wolfSSL_CTX_load_static_memory(WOLFSSL_CTX** ctx, wolfSSL_method_func method
         return BAD_FUNC_ARG;
     }
 
-    if (*ctx == NULL || (*ctx)->heap == NULL) {
-        if (sizeof(WOLFSSL_HEAP) + sizeof(WOLFSSL_HEAP_HINT) > sz - idx) {
-            return BUFFER_E; /* not enough memory for structures */
-        }
-        heap = (WOLFSSL_HEAP*)buf;
-        idx += sizeof(WOLFSSL_HEAP);
-        if (wolfSSL_init_memory_heap(heap) != 0) {
-            return WOLFSSL_FAILURE;
-        }
-        hint = (WOLFSSL_HEAP_HINT*)(buf + idx);
-        idx += sizeof(WOLFSSL_HEAP_HINT);
-        XMEMSET(hint, 0, sizeof(WOLFSSL_HEAP_HINT));
-        hint->memory = heap;
+    /* If there is a heap already, capture it in hint. */
+    if (*ctx && (*ctx)->heap != NULL) {
+        hint = (*ctx)->heap;
+    }
 
-        if (*ctx && (*ctx)->heap == NULL) {
+    if (wc_LoadStaticMemory(&hint, buf, sz, flag, maxSz)) {
+        WOLFSSL_MSG("Error loading static memory");
+        return WOLFSSL_FAILURE;
+    }
+
+    if (*ctx) {
+        if ((*ctx)->heap == NULL) {
             (*ctx)->heap = (void*)hint;
         }
     }
     else {
-#ifdef WOLFSSL_HEAP_TEST
-        /* do not load in memory if test has been set */
-        if ((*ctx)->heap == (void*)WOLFSSL_HEAP_TEST) {
-            return WOLFSSL_SUCCESS;
-        }
-#endif
-        hint = (WOLFSSL_HEAP_HINT*)((*ctx)->heap);
-        heap = hint->memory;
-    }
-
-    if (wolfSSL_load_static_memory(buf + idx, sz - idx, flag, heap) != 1) {
-        WOLFSSL_MSG("Error partitioning memory");
-        return WOLFSSL_FAILURE;
-    }
-
-    /* create ctx if needed */
-    if (*ctx == NULL) {
+        /* create ctx if needed */
         *ctx = wolfSSL_CTX_new_ex(method(hint), hint);
         if (*ctx == NULL) {
             WOLFSSL_MSG("Error creating ctx");
             return WOLFSSL_FAILURE;
         }
     }
-
-    /* determine what max applies too */
-    if (flag & WOLFMEM_IO_POOL || flag & WOLFMEM_IO_POOL_FIXED) {
-        heap->maxIO = maxSz;
-    }
-    else { /* general memory used in handshakes */
-        heap->maxHa = maxSz;
-    }
-
-    heap->flag |= flag;
-
-    (void)maxSz;
-    (void)method;
 
     return WOLFSSL_SUCCESS;
 }
@@ -2855,6 +2571,7 @@ int wolfSSL_is_static_memory(WOLFSSL* ssl, WOLFSSL_MEM_CONN_STATS* mem_stats)
     }
     WOLFSSL_ENTER("wolfSSL_is_static_memory");
 
+#ifndef WOLFSSL_STATIC_MEMORY_LEAN
     /* fill out statistics if wanted and WOLFMEM_TRACK_STATS flag */
     if (mem_stats != NULL && ssl->heap != NULL) {
         WOLFSSL_HEAP_HINT* hint = ((WOLFSSL_HEAP_HINT*)(ssl->heap));
@@ -2863,7 +2580,9 @@ int wolfSSL_is_static_memory(WOLFSSL* ssl, WOLFSSL_MEM_CONN_STATS* mem_stats)
             XMEMCPY(mem_stats, hint->stats, sizeof(WOLFSSL_MEM_CONN_STATS));
         }
     }
+#endif
 
+    (void)mem_stats;
     return (ssl->heap) ? 1 : 0;
 }
 
@@ -2875,6 +2594,7 @@ int wolfSSL_CTX_is_static_memory(WOLFSSL_CTX* ctx, WOLFSSL_MEM_STATS* mem_stats)
     }
     WOLFSSL_ENTER("wolfSSL_CTX_is_static_memory");
 
+#ifndef WOLFSSL_STATIC_MEMORY_LEAN
     /* fill out statistics if wanted */
     if (mem_stats != NULL && ctx->heap != NULL) {
         WOLFSSL_HEAP* heap = ((WOLFSSL_HEAP_HINT*)(ctx->heap))->memory;
@@ -2882,7 +2602,9 @@ int wolfSSL_CTX_is_static_memory(WOLFSSL_CTX* ctx, WOLFSSL_MEM_STATS* mem_stats)
             return MEMORY_E;
         }
     }
+#endif
 
+    (void)mem_stats;
     return (ctx->heap) ? 1 : 0;
 }
 
@@ -2922,13 +2644,15 @@ int wolfSSL_GetOutputSize(WOLFSSL* ssl, int inSz)
     if (inSz > maxSize)
         return INPUT_SIZE_E;
 
-    return BuildMessage(ssl, NULL, 0, NULL, inSz, application_data, 0, 1, 0, CUR_ORDER);
+    return BuildMessage(ssl, NULL, 0, NULL, inSz, application_data, 0, 1, 0,
+        CUR_ORDER);
 }
 
 
 #ifdef HAVE_ECC
 int wolfSSL_CTX_SetMinEccKey_Sz(WOLFSSL_CTX* ctx, short keySz)
 {
+    WOLFSSL_ENTER("wolfSSL_CTX_SetMinEccKey_Sz");
     if (ctx == NULL || keySz < 0 || keySz % 8 != 0) {
         WOLFSSL_MSG("Key size must be divisible by 8 or ctx was null");
         return BAD_FUNC_ARG;
@@ -2944,6 +2668,7 @@ int wolfSSL_CTX_SetMinEccKey_Sz(WOLFSSL_CTX* ctx, short keySz)
 
 int wolfSSL_SetMinEccKey_Sz(WOLFSSL* ssl, short keySz)
 {
+    WOLFSSL_ENTER("wolfSSL_SetMinEccKey_Sz");
     if (ssl == NULL || keySz < 0 || keySz % 8 != 0) {
         WOLFSSL_MSG("Key size must be divisible by 8 or ssl was null");
         return BAD_FUNC_ARG;
@@ -2983,138 +2708,6 @@ int wolfSSL_SetMinRsaKey_Sz(WOLFSSL* ssl, short keySz)
 
 #ifndef NO_DH
 
-#ifdef OPENSSL_EXTRA
-long wolfSSL_set_tmp_dh(WOLFSSL *ssl, WOLFSSL_DH *dh)
-{
-    int pSz, gSz;
-    byte *p, *g;
-    int ret = 0;
-
-    WOLFSSL_ENTER("wolfSSL_set_tmp_dh");
-
-    if (!ssl || !dh)
-        return BAD_FUNC_ARG;
-
-    /* Get needed size for p and g */
-    pSz = wolfSSL_BN_bn2bin(dh->p, NULL);
-    gSz = wolfSSL_BN_bn2bin(dh->g, NULL);
-
-    if (pSz <= 0 || gSz <= 0)
-        return -1;
-
-    p = (byte*)XMALLOC(pSz, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-    if (!p)
-        return MEMORY_E;
-
-    g = (byte*)XMALLOC(gSz, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-    if (!g) {
-        XFREE(p, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-        return MEMORY_E;
-    }
-
-    pSz = wolfSSL_BN_bn2bin(dh->p, p);
-    gSz = wolfSSL_BN_bn2bin(dh->g, g);
-
-    if (pSz >= 0 && gSz >= 0) /* Conversion successful */
-        ret = wolfSSL_SetTmpDH(ssl, p, pSz, g, gSz);
-
-    XFREE(p, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-    XFREE(g, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-
-    return pSz > 0 && gSz > 0 ? ret : -1;
-}
-#endif /* OPENSSL_EXTRA */
-
-/* server Diffie-Hellman parameters, WOLFSSL_SUCCESS on ok */
-int wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
-                    const unsigned char* g, int gSz)
-{
-    WOLFSSL_ENTER("wolfSSL_SetTmpDH");
-
-    if (ssl == NULL || p == NULL || g == NULL)
-        return BAD_FUNC_ARG;
-
-    if ((word16)pSz < ssl->options.minDhKeySz)
-        return DH_KEY_SIZE_E;
-    if ((word16)pSz > ssl->options.maxDhKeySz)
-        return DH_KEY_SIZE_E;
-
-    /* this function is for server only */
-    if (ssl->options.side == WOLFSSL_CLIENT_END)
-        return SIDE_ERROR;
-
-    #if !defined(WOLFSSL_OLD_PRIME_CHECK) && !defined(HAVE_FIPS) && \
-        !defined(HAVE_SELFTEST)
-        ssl->options.dhKeyTested = 0;
-        ssl->options.dhDoKeyTest = 1;
-    #endif
-
-    if (ssl->buffers.serverDH_P.buffer && ssl->buffers.weOwnDH) {
-        XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-        ssl->buffers.serverDH_P.buffer = NULL;
-    }
-    if (ssl->buffers.serverDH_G.buffer && ssl->buffers.weOwnDH) {
-        XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-        ssl->buffers.serverDH_G.buffer = NULL;
-    }
-
-    ssl->buffers.weOwnDH = 1;  /* SSL owns now */
-    ssl->buffers.serverDH_P.buffer = (byte*)XMALLOC(pSz, ssl->heap,
-                                                    DYNAMIC_TYPE_PUBLIC_KEY);
-    if (ssl->buffers.serverDH_P.buffer == NULL)
-            return MEMORY_E;
-
-    ssl->buffers.serverDH_G.buffer = (byte*)XMALLOC(gSz, ssl->heap,
-                                                    DYNAMIC_TYPE_PUBLIC_KEY);
-    if (ssl->buffers.serverDH_G.buffer == NULL) {
-        XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-        ssl->buffers.serverDH_P.buffer = NULL;
-        return MEMORY_E;
-    }
-
-    ssl->buffers.serverDH_P.length = pSz;
-    ssl->buffers.serverDH_G.length = gSz;
-
-    XMEMCPY(ssl->buffers.serverDH_P.buffer, p, pSz);
-    XMEMCPY(ssl->buffers.serverDH_G.buffer, g, gSz);
-
-    ssl->options.haveDH = 1;
-
-    if (ssl->options.side != WOLFSSL_NEITHER_END) {
-        word16 havePSK;
-        word16 haveRSA;
-        int    keySz   = 0;
-        int    ret;
-
-    #ifndef NO_PSK
-        havePSK = ssl->options.havePSK;
-    #else
-        havePSK = 0;
-    #endif
-    #ifdef NO_RSA
-        haveRSA = 0;
-    #else
-        haveRSA = 1;
-    #endif
-    #ifndef NO_CERTS
-        keySz = ssl->buffers.keySz;
-    #endif
-        ret = AllocateSuites(ssl);
-        if (ret != 0)
-            return ret;
-        InitSuites(ssl->suites, ssl->version, keySz, haveRSA, havePSK,
-                   ssl->options.haveDH, ssl->options.haveECDSAsig,
-                   ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
-                   ssl->options.haveFalconSig, ssl->options.haveDilithiumSig,
-                   ssl->options.useAnon, TRUE, ssl->options.side);
-    }
-
-    WOLFSSL_LEAVE("wolfSSL_SetTmpDH", 0);
-
-    return WOLFSSL_SUCCESS;
-}
-
-
 #if !defined(WOLFSSL_OLD_PRIME_CHECK) && !defined(HAVE_FIPS) && \
     !defined(HAVE_SELFTEST)
 /* Enables or disables the session's DH key prime test. */
@@ -3134,82 +2727,6 @@ int wolfSSL_SetEnableDhKeyTest(WOLFSSL* ssl, int enable)
     return WOLFSSL_SUCCESS;
 }
 #endif
-
-
-/* server ctx Diffie-Hellman parameters, WOLFSSL_SUCCESS on ok */
-int wolfSSL_CTX_SetTmpDH(WOLFSSL_CTX* ctx, const unsigned char* p, int pSz,
-                         const unsigned char* g, int gSz)
-{
-    WOLFSSL_ENTER("wolfSSL_CTX_SetTmpDH");
-    if (ctx == NULL || p == NULL || g == NULL) return BAD_FUNC_ARG;
-
-    if ((word16)pSz < ctx->minDhKeySz)
-        return DH_KEY_SIZE_E;
-    if ((word16)pSz > ctx->maxDhKeySz)
-        return DH_KEY_SIZE_E;
-
-    #if !defined(WOLFSSL_OLD_PRIME_CHECK) && !defined(HAVE_FIPS) && \
-        !defined(HAVE_SELFTEST)
-    {
-        WC_RNG rng;
-        int error, freeKey = 0;
-    #ifdef WOLFSSL_SMALL_STACK
-        DhKey *checkKey = (DhKey*)XMALLOC(sizeof(DhKey), NULL, DYNAMIC_TYPE_DH);
-        if (checkKey == NULL)
-            return MEMORY_E;
-    #else
-        DhKey checkKey[1];
-    #endif
-
-        error = wc_InitRng(&rng);
-        if (!error)
-            error = wc_InitDhKey(checkKey);
-        if (!error) {
-            freeKey = 1;
-            error = wc_DhSetCheckKey(checkKey,
-                                 p, pSz, g, gSz, NULL, 0, 0, &rng);
-        }
-        if (freeKey)
-            wc_FreeDhKey(checkKey);
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(checkKey, NULL, DYNAMIC_TYPE_DH);
-    #endif
-        wc_FreeRng(&rng);
-        if (error)
-            return error;
-
-        ctx->dhKeyTested = 1;
-    }
-    #endif
-
-    XFREE(ctx->serverDH_P.buffer, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-    ctx->serverDH_P.buffer = NULL;
-    XFREE(ctx->serverDH_G.buffer, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-    ctx->serverDH_G.buffer = NULL;
-
-    ctx->serverDH_P.buffer = (byte*)XMALLOC(pSz, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-    if (ctx->serverDH_P.buffer == NULL)
-       return MEMORY_E;
-
-    ctx->serverDH_G.buffer = (byte*)XMALLOC(gSz, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-    if (ctx->serverDH_G.buffer == NULL) {
-        XFREE(ctx->serverDH_P.buffer, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-        ctx->serverDH_P.buffer = NULL;
-        return MEMORY_E;
-    }
-
-    ctx->serverDH_P.length = pSz;
-    ctx->serverDH_G.length = gSz;
-
-    XMEMCPY(ctx->serverDH_P.buffer, p, pSz);
-    XMEMCPY(ctx->serverDH_G.buffer, g, gSz);
-
-    ctx->haveDH = 1;
-
-    WOLFSSL_LEAVE("wolfSSL_CTX_SetTmpDH", 0);
-    return WOLFSSL_SUCCESS;
-}
-
 
 int wolfSSL_CTX_SetMinDhKey_Sz(WOLFSSL_CTX* ctx, word16 keySz_bits)
 {
@@ -3549,7 +3066,7 @@ word16 wolfSSL_SNI_GetRequest(WOLFSSL* ssl, byte type, void** data)
         *data = NULL;
 
     if (ssl && ssl->extensions)
-        return TLSX_SNI_GetRequest(ssl->extensions, type, data);
+        return TLSX_SNI_GetRequest(ssl->extensions, type, data, 0);
 
     return 0;
 }
@@ -3750,11 +3267,11 @@ static int isValidCurveGroup(word16 name)
         case WOLFSSL_FFDHE_6144:
         case WOLFSSL_FFDHE_8192:
 
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
         case WOLFSSL_KYBER_LEVEL1:
         case WOLFSSL_KYBER_LEVEL3:
         case WOLFSSL_KYBER_LEVEL5:
-    #ifdef HAVE_LIBOQS
+    #if defined(WOLFSSL_WC_KYBER) || defined(HAVE_LIBOQS)
         case WOLFSSL_P256_KYBER_LEVEL1:
         case WOLFSSL_P384_KYBER_LEVEL3:
         case WOLFSSL_P521_KYBER_LEVEL5:
@@ -3794,7 +3311,7 @@ int wolfSSL_CTX_UseSupportedCurve(WOLFSSL_CTX* ctx, word16 name)
 #endif /* NO_TLS */
 }
 
-#if defined(OPENSSL_EXTRA) && defined(WOLFSSL_TLS13)
+#if defined(OPENSSL_EXTRA)
 int  wolfSSL_CTX_set1_groups(WOLFSSL_CTX* ctx, int* groups,
                                         int count)
 {
@@ -3812,7 +3329,7 @@ int  wolfSSL_CTX_set1_groups(WOLFSSL_CTX* ctx, int* groups,
 #ifdef HAVE_ECC
         else {
             /* groups may be populated with curve NIDs */
-            int oid = nid2oid(groups[i], oidCurveType);
+            int oid = (int)nid2oid(groups[i], oidCurveType);
             int name = (int)GetCurveByOID(oid);
             if (name == 0) {
                 WOLFSSL_MSG("Invalid group name");
@@ -3847,7 +3364,7 @@ int  wolfSSL_set1_groups(WOLFSSL* ssl, int* groups, int count)
 #ifdef HAVE_ECC
         else {
             /* groups may be populated with curve NIDs */
-            int oid = nid2oid(groups[i], oidCurveType);
+            int oid = (int)nid2oid(groups[i], oidCurveType);
             int name = (int)GetCurveByOID(oid);
             if (name == 0) {
                 WOLFSSL_MSG("Invalid group name");
@@ -3865,7 +3382,7 @@ int  wolfSSL_set1_groups(WOLFSSL* ssl, int* groups, int count)
     return wolfSSL_set_groups(ssl, _groups, count) == WOLFSSL_SUCCESS ?
             WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
 }
-#endif /* OPENSSL_EXTRA && WOLFSSL_TLS13 */
+#endif /* OPENSSL_EXTRA */
 #endif /* HAVE_SUPPORTED_CURVES */
 
 /* Application-Layer Protocol Negotiation */
@@ -3906,7 +3423,8 @@ int wolfSSL_UseALPN(WOLFSSL* ssl, char *protocol_name_list,
         return MEMORY_ERROR;
     }
 
-    token = (char **)XMALLOC(sizeof(char *) * (WOLFSSL_MAX_ALPN_NUMBER+1), ssl->heap, DYNAMIC_TYPE_ALPN);
+    token = (char **)XMALLOC(sizeof(char *) * (WOLFSSL_MAX_ALPN_NUMBER+1),
+        ssl->heap, DYNAMIC_TYPE_ALPN);
     if (token == NULL) {
         XFREE(list, ssl->heap, DYNAMIC_TYPE_ALPN);
         WOLFSSL_MSG("Memory failure");
@@ -4012,12 +3530,14 @@ int wolfSSL_ALPN_FreePeerProtocol(WOLFSSL* ssl, char **list)
 /* user is forcing ability to use secure renegotiation, we discourage it */
 int wolfSSL_UseSecureRenegotiation(WOLFSSL* ssl)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 #if defined(NO_TLS)
     (void)ssl;
 #else
     if (ssl)
         ret = TLSX_UseSecureRenegotiation(&ssl->extensions, ssl->heap);
+    else
+        ret = BAD_FUNC_ARG;
 
     if (ret == WOLFSSL_SUCCESS) {
         TLSX* extension = TLSX_Find(ssl->extensions, TLSX_RENEGOTIATION_INFO);
@@ -4339,7 +3859,8 @@ int wolfSSL_set_SessionTicket(WOLFSSL* ssl, const byte* buf,
             }
         }
         else { /* Ticket requires dynamic ticket storage */
-            if (ssl->session->ticketLen < bufSz) { /* is dyn buffer big enough */
+            /* is dyn buffer big enough */
+            if (ssl->session->ticketLen < bufSz) {
                 if (ssl->session->ticketLenAlloc > 0) {
                     XFREE(ssl->session->ticket, ssl->session->heap,
                           DYNAMIC_TYPE_SESSION_TICK);
@@ -4452,6 +3973,25 @@ int wolfSSL_recv(WOLFSSL* ssl, void* data, int sz, int flags)
 }
 #endif
 
+int wolfSSL_SendUserCanceled(WOLFSSL* ssl)
+{
+    int ret = WOLFSSL_FAILURE;
+    WOLFSSL_ENTER("wolfSSL_recv");
+
+    if (ssl != NULL) {
+        ssl->error = SendAlert(ssl, alert_warning, user_canceled);
+        if (ssl->error < 0) {
+            WOLFSSL_ERROR(ssl->error);
+        }
+        else {
+            ret = wolfSSL_shutdown(ssl);
+        }
+    }
+
+    WOLFSSL_LEAVE("wolfSSL_SendUserCanceled", ret);
+
+    return ret;
+}
 
 /* WOLFSSL_SUCCESS on ok */
 WOLFSSL_ABI
@@ -4499,13 +4039,14 @@ int wolfSSL_shutdown(WOLFSSL* ssl)
         /* call wolfSSL_shutdown again for bidirectional shutdown */
         if (ssl->options.sentNotify && !ssl->options.closeNotify) {
             ret = ProcessReply(ssl);
-            if ((ret == ZERO_RETURN) || (ret == SOCKET_ERROR_E)) {
+            if ((ret == ZERO_RETURN) ||
+                (ret == WC_NO_ERR_TRACE(SOCKET_ERROR_E))) {
                 /* simulate OpenSSL behavior */
                 ssl->options.shutdownDone = 1;
                 /* Clear error */
                 ssl->error = WOLFSSL_ERROR_NONE;
                 ret = WOLFSSL_SUCCESS;
-            } else if (ret == MEMORY_E) {
+            } else if (ret == WC_NO_ERR_TRACE(MEMORY_E)) {
                 ret = WOLFSSL_FATAL_ERROR;
             } else if (ssl->error == WOLFSSL_ERROR_NONE) {
                 ret = WOLFSSL_SHUTDOWN_NOT_DONE;
@@ -4563,14 +4104,10 @@ int wolfSSL_get_error(WOLFSSL* ssl, int ret)
     else if (ssl->error == ZERO_RETURN || ssl->options.shutdownDone)
         return WOLFSSL_ERROR_ZERO_RETURN;       /* convert to OpenSSL type */
 #ifdef OPENSSL_EXTRA
-    else if (ssl->error == SOCKET_PEER_CLOSED_E)
+    else if (ssl->error == WC_NO_ERR_TRACE(SOCKET_PEER_CLOSED_E))
         return WOLFSSL_ERROR_SYSCALL;           /* convert to OpenSSL type */
 #endif
-#if defined(WOLFSSL_HAPROXY)
-    return GetX509Error(ssl->error);
-#else
-    return (ssl->error);
-#endif
+    return ssl->error;
 }
 
 
@@ -5709,14 +5246,15 @@ int AddTrustedPeer(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int verify)
         #endif
             XMEMCPY(peerCert->subjectNameHash, cert->subjectHash,
                     SIGNER_DIGEST_SIZE);
-            peerCert->next    = NULL; /* If Key Usage not set, all uses valid. */
+            /* If Key Usage not set, all uses valid. */
+            peerCert->next    = NULL;
             cert->subjectCN = 0;
         #ifndef IGNORE_NAME_CONSTRAINTS
             cert->permittedNames = NULL;
             cert->excludedNames = NULL;
         #endif
 
-            row = TrustedPeerHashSigner(peerCert->subjectNameHash);
+            row = (int)TrustedPeerHashSigner(peerCert->subjectNameHash);
 
             if (wc_LockMutex(&cm->tpLock) == 0) {
                 peerCert->next = cm->tpTable[row];
@@ -5745,6 +5283,38 @@ int AddTrustedPeer(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int verify)
 }
 #endif /* WOLFSSL_TRUST_PEER_CERT */
 
+int AddSigner(WOLFSSL_CERT_MANAGER* cm, Signer *s)
+{
+    byte*   subjectHash;
+    Signer* signers;
+    word32  row;
+
+    if (cm == NULL || s == NULL)
+        return BAD_FUNC_ARG;
+
+#ifndef NO_SKID
+    subjectHash = s->subjectKeyIdHash;
+#else
+    subjectHash = s->subjectNameHash;
+#endif
+
+    if (AlreadySigner(cm, subjectHash)) {
+        FreeSigner(s, cm->heap);
+        return 0;
+    }
+
+    row = HashSigner(subjectHash);
+
+    if (wc_LockMutex(&cm->caLock) != 0)
+        return BAD_MUTEX_E;
+
+    signers = cm->caTable[row];
+    s->next = signers;
+    cm->caTable[row] = s;
+
+    wc_UnLockMutex(&cm->caLock);
+    return 0;
+}
 
 /* owns der, internal now uses too */
 /* type flag ids from user or from chain received during verify
@@ -5830,7 +5400,6 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
                 }
                 break;
             #endif /* HAVE_ED448 */
-            #if defined(HAVE_PQC)
             #if defined(HAVE_FALCON)
             case FALCON_LEVEL1k:
                 if (cm->minFalconKeySz < 0 ||
@@ -5870,7 +5439,6 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
                 }
                 break;
             #endif /* HAVE_DILITHIUM */
-            #endif /* HAVE_PQC */
 
             default:
                 WOLFSSL_MSG("\tNo key size check done on CA");
@@ -5901,62 +5469,8 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
         if (!signer)
             ret = MEMORY_ERROR;
     }
-#if defined(WOLFSSL_AKID_NAME) || defined(HAVE_CRL)
-    if (ret == 0 && signer != NULL)
-        ret = CalcHashId(cert->serial, cert->serialSz, signer->serialHash);
-#endif
     if (ret == 0 && signer != NULL) {
-    #ifdef WOLFSSL_SIGNER_DER_CERT
-        ret = AllocDer(&signer->derCert, der->length, der->type, NULL);
-    }
-    if (ret == 0 && signer != NULL) {
-        XMEMCPY(signer->derCert->buffer, der->buffer, der->length);
-    #endif
-        signer->keyOID         = cert->keyOID;
-        if (cert->pubKeyStored) {
-            signer->publicKey      = cert->publicKey;
-            signer->pubKeySize     = cert->pubKeySize;
-        }
-
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-        signer->sapkiDer = cert->sapkiDer;
-        signer->sapkiLen = cert->sapkiLen;
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-
-        if (cert->subjectCNStored) {
-            signer->nameLen        = cert->subjectCNLen;
-            signer->name           = cert->subjectCN;
-        }
-        signer->maxPathLen     = cert->maxPathLen;
-        signer->selfSigned     = cert->selfSigned;
-    #ifndef IGNORE_NAME_CONSTRAINTS
-        signer->permittedNames = cert->permittedNames;
-        signer->excludedNames  = cert->excludedNames;
-    #endif
-    #ifndef NO_SKID
-        XMEMCPY(signer->subjectKeyIdHash, cert->extSubjKeyId,
-                SIGNER_DIGEST_SIZE);
-    #endif
-        XMEMCPY(signer->subjectNameHash, cert->subjectHash,
-                SIGNER_DIGEST_SIZE);
-    #if defined(HAVE_OCSP) || defined(HAVE_CRL)
-        XMEMCPY(signer->issuerNameHash, cert->issuerHash,
-                SIGNER_DIGEST_SIZE);
-    #endif
-    #ifdef HAVE_OCSP
-        XMEMCPY(signer->subjectKeyHash, cert->subjectKeyHash,
-                KEYID_SIZE);
-    #endif
-        signer->keyUsage = cert->extKeyUsageSet ? cert->extKeyUsage
-                                                : 0xFFFF;
-        signer->next    = NULL; /* If Key Usage not set, all uses valid. */
-        cert->publicKey = 0;    /* in case lock fails don't free here.   */
-        cert->subjectCN = 0;
-    #ifndef IGNORE_NAME_CONSTRAINTS
-        cert->permittedNames = NULL;
-        cert->excludedNames = NULL;
-    #endif
-        signer->type = (byte)type;
+        ret = FillSigner(signer, cert, type, der);
 
     #ifndef NO_SKID
         row = HashSigner(signer->subjectKeyIdHash);
@@ -5964,7 +5478,8 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
         row = HashSigner(signer->subjectNameHash);
     #endif
 
-        if (wc_LockMutex(&cm->caLock) == 0) {
+
+        if (ret == 0 && wc_LockMutex(&cm->caLock) == 0) {
             signer->next = cm->caTable[row];
             cm->caTable[row] = signer;   /* takes ownership */
             wc_UnLockMutex(&cm->caLock);
@@ -6018,191 +5533,6 @@ int AddCA(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer, int type, int verify)
 #endif /* !NO_CERTS */
 
 
-#ifndef NO_SESSION_CACHE
-
-    /* basic config gives a cache with 33 sessions, adequate for clients and
-       embedded servers
-
-       TITAN_SESSION_CACHE allows just over 2 million sessions, for servers
-       with titanic amounts of memory with long session ID timeouts and high
-       levels of traffic.
-
-       ENABLE_SESSION_CACHE_ROW_LOCK: Allows row level locking for increased
-       performance with large session caches
-
-       HUGE_SESSION_CACHE yields 65,791 sessions, for servers under heavy load,
-       allows over 13,000 new sessions per minute or over 200 new sessions per
-       second
-
-       BIG_SESSION_CACHE yields 20,027 sessions
-
-       MEDIUM_SESSION_CACHE allows 1055 sessions, adequate for servers that
-       aren't under heavy load, basically allows 200 new sessions per minute
-
-       SMALL_SESSION_CACHE only stores 6 sessions, good for embedded clients
-       or systems where the default of is too much RAM.
-       SessionCache takes about 2K, ClientCache takes about 3Kbytes
-
-       MICRO_SESSION_CACHE only stores 1 session, good for embedded clients
-       or systems where memory is at a premium.
-       SessionCache takes about 400 bytes, ClientCache takes 576 bytes
-
-       default SESSION_CACHE stores 33 sessions (no XXX_SESSION_CACHE defined)
-       SessionCache takes about 13K bytes, ClientCache takes 17K bytes
-    */
-    #if defined(TITAN_SESSION_CACHE)
-        #define SESSIONS_PER_ROW 31
-        #define SESSION_ROWS 64937
-        #ifndef ENABLE_SESSION_CACHE_ROW_LOCK
-            #define ENABLE_SESSION_CACHE_ROW_LOCK
-        #endif
-    #elif defined(HUGE_SESSION_CACHE)
-        #define SESSIONS_PER_ROW 11
-        #define SESSION_ROWS 5981
-    #elif defined(BIG_SESSION_CACHE)
-        #define SESSIONS_PER_ROW 7
-        #define SESSION_ROWS 2861
-    #elif defined(MEDIUM_SESSION_CACHE)
-        #define SESSIONS_PER_ROW 5
-        #define SESSION_ROWS 211
-    #elif defined(SMALL_SESSION_CACHE)
-        #define SESSIONS_PER_ROW 2
-        #define SESSION_ROWS 3
-    #elif defined(MICRO_SESSION_CACHE)
-        #define SESSIONS_PER_ROW 1
-        #define SESSION_ROWS 1
-    #else
-        #define SESSIONS_PER_ROW 3
-        #define SESSION_ROWS 11
-    #endif
-    #define INVALID_SESSION_ROW (-1)
-
-    #ifdef NO_SESSION_CACHE_ROW_LOCK
-        #undef ENABLE_SESSION_CACHE_ROW_LOCK
-    #endif
-
-    typedef struct SessionRow {
-        int nextIdx;                           /* where to place next one   */
-        int totalCount;                        /* sessions ever on this row */
-#ifdef SESSION_CACHE_DYNAMIC_MEM
-        WOLFSSL_SESSION* Sessions[SESSIONS_PER_ROW];
-        void* heap;
-#else
-        WOLFSSL_SESSION Sessions[SESSIONS_PER_ROW];
-#endif
-
-    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-        /* not included in import/export */
-        wolfSSL_RwLock row_lock;
-        int lock_valid;
-    #endif
-    } SessionRow;
-    #define SIZEOF_SESSION_ROW (sizeof(WOLFSSL_SESSION) + (sizeof(int) * 2))
-
-    static WOLFSSL_GLOBAL SessionRow SessionCache[SESSION_ROWS];
-
-    #if defined(WOLFSSL_SESSION_STATS) && defined(WOLFSSL_PEAK_SESSIONS)
-        static WOLFSSL_GLOBAL word32 PeakSessions;
-    #endif
-
-    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-    #define SESSION_ROW_RD_LOCK(row)   wc_LockRwLock_Rd(&(row)->row_lock)
-    #define SESSION_ROW_WR_LOCK(row)   wc_LockRwLock_Wr(&(row)->row_lock)
-    #define SESSION_ROW_UNLOCK(row)    wc_UnLockRwLock(&(row)->row_lock);
-    #else
-    static WOLFSSL_GLOBAL wolfSSL_RwLock session_lock; /* SessionCache lock */
-    static WOLFSSL_GLOBAL int session_lock_valid = 0;
-    #define SESSION_ROW_RD_LOCK(row)   wc_LockRwLock_Rd(&session_lock)
-    #define SESSION_ROW_WR_LOCK(row)   wc_LockRwLock_Wr(&session_lock)
-    #define SESSION_ROW_UNLOCK(row)    wc_UnLockRwLock(&session_lock);
-    #endif
-
-    #if !defined(NO_SESSION_CACHE_REF) && defined(NO_CLIENT_CACHE)
-    #error ClientCache is required when not using NO_SESSION_CACHE_REF
-    #endif
-
-    #ifndef NO_CLIENT_CACHE
-
-        #ifndef CLIENT_SESSIONS_MULTIPLIER
-            #ifdef NO_SESSION_CACHE_REF
-                #define CLIENT_SESSIONS_MULTIPLIER 1
-            #else
-                /* ClientSession objects are lightweight (compared to
-                 * WOLFSSL_SESSION) so to decrease chance that user will reuse
-                 * the wrong session, increase the ClientCache size. This will
-                 * make the entire ClientCache about the size of one
-                 * WOLFSSL_SESSION object. */
-                #define CLIENT_SESSIONS_MULTIPLIER 8
-            #endif
-        #endif
-        #define CLIENT_SESSIONS_PER_ROW \
-                                (SESSIONS_PER_ROW * CLIENT_SESSIONS_MULTIPLIER)
-        #define CLIENT_SESSION_ROWS (SESSION_ROWS * CLIENT_SESSIONS_MULTIPLIER)
-
-        #if CLIENT_SESSIONS_PER_ROW > 65535
-        #error CLIENT_SESSIONS_PER_ROW too big
-        #endif
-        #if CLIENT_SESSION_ROWS > 65535
-        #error CLIENT_SESSION_ROWS too big
-        #endif
-
-        struct ClientSession {
-            word16 serverRow;            /* SessionCache Row id */
-            word16 serverIdx;            /* SessionCache Idx (column) */
-            word32 sessionIDHash;
-        };
-    #ifndef WOLFSSL_CLIENT_SESSION_DEFINED
-        typedef struct ClientSession ClientSession;
-        #define WOLFSSL_CLIENT_SESSION_DEFINED
-    #endif
-
-        typedef struct ClientRow {
-            int nextIdx;                /* where to place next one   */
-            int totalCount;             /* sessions ever on this row */
-            ClientSession Clients[CLIENT_SESSIONS_PER_ROW];
-        } ClientRow;
-
-        static WOLFSSL_GLOBAL ClientRow ClientCache[CLIENT_SESSION_ROWS];
-                                                     /* Client Cache */
-                                                     /* uses session mutex */
-
-        static WOLFSSL_GLOBAL wolfSSL_Mutex clisession_mutex WOLFSSL_MUTEX_INITIALIZER_CLAUSE(clisession_mutex); /* ClientCache mutex */
-        #ifndef WOLFSSL_MUTEX_INITIALIZER
-        static WOLFSSL_GLOBAL int clisession_mutex_valid = 0;
-        #endif
-    #endif /* !NO_CLIENT_CACHE */
-
-    void EvictSessionFromCache(WOLFSSL_SESSION* session)
-    {
-#ifdef HAVE_EX_DATA
-        int save_ownExData = session->ownExData;
-        session->ownExData = 1; /* Make sure ex_data access doesn't lead back
-                                 * into the cache. */
-#endif
-#if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
-        if (session->rem_sess_cb != NULL) {
-            session->rem_sess_cb(NULL, session);
-            session->rem_sess_cb = NULL;
-        }
-#endif
-        ForceZero(session->masterSecret, SECRET_LEN);
-        XMEMSET(session->sessionID, 0, ID_LEN);
-        session->sessionIDSz = 0;
-#ifdef HAVE_SESSION_TICKET
-        if (session->ticketLenAlloc > 0) {
-            XFREE(session->ticket, NULL, DYNAMIC_TYPE_SESSION_TICK);
-            session->ticket = session->staticTicket;
-            session->ticketLen = 0;
-            session->ticketLenAlloc = 0;
-        }
-#endif
-#ifdef HAVE_EX_DATA
-        session->ownExData = save_ownExData;
-#endif
-    }
-
-#endif /* !NO_SESSION_CACHE */
-
 #if defined(OPENSSL_EXTRA) && !defined(WOLFSSL_NO_OPENSSL_RAND_CB)
 static int wolfSSL_RAND_InitMutex(void);
 #endif
@@ -6244,13 +5574,13 @@ int wolfSSL_Init(void)
         return BAD_MUTEX_E;
     }
 
-    #if FIPS_VERSION_GE(5,1)
+#if FIPS_VERSION_GE(5,1)
     if ((ret == WOLFSSL_SUCCESS) && (initRefCount == 0)) {
         ret = wolfCrypt_SetPrivateKeyReadEnable_fips(1, WC_KEYTYPE_ALL);
         if (ret == 0)
             ret = WOLFSSL_SUCCESS;
     }
-    #endif
+#endif
 
     if ((ret == WOLFSSL_SUCCESS) && (initRefCount == 0)) {
         /* Initialize crypto for use with TLS connection */
@@ -6340,11 +5670,13 @@ int wolfSSL_Init(void)
     if (ret == WOLFSSL_SUCCESS) {
         initRefCount++;
     }
+    else {
+        initRefCount = 1; /* Force cleanup */
+    }
 
     wc_UnLockMutex(&inits_count_mutex);
 
     if (ret != WOLFSSL_SUCCESS) {
-        initRefCount = 1; /* Force cleanup */
         (void)wolfSSL_Cleanup(); /* Ignore any error from cleanup */
     }
 
@@ -6352,1769 +5684,10 @@ int wolfSSL_Init(void)
 }
 
 
+#define WOLFSSL_SSL_LOAD_INCLUDED
+#include <src/ssl_load.c>
+
 #ifndef NO_CERTS
-
-/* process user cert chain to pass during the handshake */
-static int ProcessUserChain(WOLFSSL_CTX* ctx, const unsigned char* buff,
-                         long sz, int format, int type, WOLFSSL* ssl,
-                         long* used, EncryptedInfo* info, int verify)
-{
-    int ret = 0;
-    void* heap = wolfSSL_CTX_GetHeap(ctx, ssl);
-
-    if ((type == CA_TYPE) && (ctx == NULL)) {
-        WOLFSSL_MSG("Need context for CA load");
-        return BAD_FUNC_ARG;
-    }
-
-    /* we may have a user cert chain, try to consume */
-    if ((type == CERT_TYPE || type == CHAIN_CERT_TYPE || type == CA_TYPE) &&
-            (info->consumed < sz)) {
-    #ifdef WOLFSSL_SMALL_STACK
-        byte   staticBuffer[1];                 /* force heap usage */
-    #else
-        byte   staticBuffer[FILE_BUFFER_SIZE];  /* tmp chain buffer */
-    #endif
-        byte*  chainBuffer = staticBuffer;
-        int    dynamicBuffer = 0;
-        word32 bufferSz;
-        long   consumed = info->consumed;
-        word32 idx = 0;
-        int    gotOne = 0;
-    #ifdef WOLFSSL_TLS13
-        int cnt = 0;
-    #endif
-
-        /* Calculate max possible size, including max headers */
-        bufferSz = (word32)(sz - consumed) + (CERT_HEADER_SZ * MAX_CHAIN_DEPTH);
-        if (bufferSz > sizeof(staticBuffer)) {
-            WOLFSSL_MSG("Growing Tmp Chain Buffer");
-            /* will shrink to actual size */
-            chainBuffer = (byte*)XMALLOC(bufferSz, heap, DYNAMIC_TYPE_FILE);
-            if (chainBuffer == NULL) {
-                return MEMORY_E;
-            }
-            dynamicBuffer = 1;
-        }
-
-        WOLFSSL_MSG("Processing Cert Chain");
-        while (consumed < sz) {
-            DerBuffer* part = NULL;
-            word32 remain = (word32)(sz - consumed);
-            info->consumed = 0;
-
-            if (format == WOLFSSL_FILETYPE_PEM) {
-            #ifdef WOLFSSL_PEM_TO_DER
-                ret = PemToDer(buff + consumed, remain, type, &part,
-                               heap, info, NULL);
-            #else
-                ret = NOT_COMPILED_IN;
-            #endif
-            }
-            else {
-                int length = remain;
-                if (format == WOLFSSL_FILETYPE_ASN1) {
-                    /* get length of der (read sequence) */
-                    word32 inOutIdx = 0;
-                    if (GetSequence(buff + consumed, &inOutIdx, &length,
-                            remain) < 0) {
-                        ret = ASN_NO_PEM_HEADER;
-                    }
-                    length += inOutIdx; /* include leading sequence */
-                }
-                info->consumed = length;
-                if (ret == 0) {
-                    ret = AllocDer(&part, length, type, heap);
-                    if (ret == 0) {
-                        XMEMCPY(part->buffer, buff + consumed, length);
-                    }
-                }
-            }
-            if (ret == 0) {
-                gotOne = 1;
-#ifdef WOLFSSL_TLS13
-                cnt++;
-#endif
-                if ((idx + part->length + CERT_HEADER_SZ) > bufferSz) {
-                    WOLFSSL_MSG("   Cert Chain bigger than buffer. "
-                                "Consider increasing MAX_CHAIN_DEPTH");
-                    ret = BUFFER_E;
-                }
-                else {
-                    c32to24(part->length, &chainBuffer[idx]);
-                    idx += CERT_HEADER_SZ;
-                    XMEMCPY(&chainBuffer[idx], part->buffer, part->length);
-                    idx += part->length;
-                    consumed  += info->consumed;
-                    if (used)
-                        *used += info->consumed;
-                }
-
-                /* add CA's to certificate manager */
-                if (ret == 0 && type == CA_TYPE) {
-                    /* verify CA unless user set to no verify */
-                    ret = AddCA(ctx->cm, &part, WOLFSSL_USER_CA, verify);
-                    if (ret == WOLFSSL_SUCCESS) {
-                        ret = 0; /* converted success case */
-                    }
-                    gotOne = 0; /* don't exit loop for CA type */
-                }
-            }
-
-            FreeDer(&part);
-
-            if (ret == ASN_NO_PEM_HEADER && gotOne) {
-                WOLFSSL_MSG("We got one good cert, so stuff at end ok");
-                break;
-            }
-
-            if (ret < 0) {
-                WOLFSSL_MSG("   Error in Cert in Chain");
-                if (dynamicBuffer)
-                    XFREE(chainBuffer, heap, DYNAMIC_TYPE_FILE);
-                return ret;
-            }
-            WOLFSSL_MSG("   Consumed another Cert in Chain");
-        }
-        WOLFSSL_MSG("Finished Processing Cert Chain");
-
-        /* only retain actual size used */
-        ret = 0;
-        if (idx > 0) {
-            if (ssl) {
-                if (ssl->buffers.weOwnCertChain) {
-                    FreeDer(&ssl->buffers.certChain);
-                }
-                ret = AllocDer(&ssl->buffers.certChain, idx, type, heap);
-                if (ret == 0) {
-                    XMEMCPY(ssl->buffers.certChain->buffer, chainBuffer,
-                            idx);
-                    ssl->buffers.weOwnCertChain = 1;
-                }
-            #ifdef WOLFSSL_TLS13
-                ssl->buffers.certChainCnt = cnt;
-            #endif
-            } else if (ctx) {
-                FreeDer(&ctx->certChain);
-                ret = AllocDer(&ctx->certChain, idx, type, heap);
-                if (ret == 0) {
-                    XMEMCPY(ctx->certChain->buffer, chainBuffer, idx);
-                }
-            #ifdef WOLFSSL_TLS13
-                ctx->certChainCnt = cnt;
-            #endif
-            }
-        }
-
-        if (dynamicBuffer)
-            XFREE(chainBuffer, heap, DYNAMIC_TYPE_FILE);
-    }
-
-    return ret;
-}
-
-#ifndef NO_RSA
-#if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && \
-    (HAVE_FIPS_VERSION > 2))
-static int ProcessBufferTryDecodeRsa(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
-    DerBuffer* der, int* keySz, word32* idx, int* resetSuites, int* keyFormat,
-    int devId)
-{
-    int ret;
-
-    (void)devId;
-
-    *idx = 0;
-    ret = wc_RsaPrivateKeyValidate(der->buffer, idx, keySz, der->length);
-#ifdef WOLF_PRIVATE_KEY_ID
-    if ((ret != 0) && (devId != INVALID_DEVID
-    #ifdef HAVE_PK_CALLBACKS
-            || ((ssl == NULL) ? wolfSSL_CTX_IsPrivatePkSet(ctx) :
-                                wolfSSL_CTX_IsPrivatePkSet(ssl->ctx))
-    #endif
-    )) {
-        word32 nSz;
-
-        /* if using crypto or PK callbacks, try public key decode */
-        *idx = 0;
-        ret = wc_RsaPublicKeyDecode_ex(der->buffer, idx, der->length, NULL,
-            &nSz, NULL, NULL);
-        if (ret == 0) {
-            *keySz = (int)nSz;
-        }
-    }
-#endif
-    if (ret != 0) {
-    #if !defined(HAVE_ECC) && !defined(HAVE_ED25519) && \
-        !defined(HAVE_ED448) && !defined(HAVE_PQC)
-        WOLFSSL_MSG("RSA decode failed and other algorithms "
-                    "not enabled to try");
-        ret = WOLFSSL_BAD_FILE;
-    #else
-        if (*keyFormat == 0) {
-            /* Format unknown so keep trying. */
-            ret = 0; /* continue trying other algorithms */
-        }
-    #endif
-    }
-    else {
-        /* check that the size of the RSA key is enough */
-        int minRsaSz = ssl ? ssl->options.minRsaKeySz : ctx->minRsaKeySz;
-        if (*keySz < minRsaSz) {
-            ret = RSA_KEY_SIZE_E;
-            WOLFSSL_MSG("Private Key size too small");
-        }
-
-        if (ssl) {
-            ssl->buffers.keyType = rsa_sa_algo;
-            ssl->buffers.keySz = *keySz;
-        }
-        else {
-            ctx->privateKeyType = rsa_sa_algo;
-            ctx->privateKeySz = *keySz;
-        }
-
-        *keyFormat = RSAk;
-
-        if (ssl && ssl->options.side == WOLFSSL_SERVER_END) {
-            ssl->options.haveStaticECC = 0;
-            *resetSuites = 1;
-        }
-    }
-
-    return ret;
-}
-#else
-static int ProcessBufferTryDecodeRsa(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
-    DerBuffer* der, int* keySz, word32* idx, int* resetSuites, int* keyFormat,
-    void* heap, int devId)
-{
-    int ret;
-
-    /* make sure RSA key can be used */
-#ifdef WOLFSSL_SMALL_STACK
-    RsaKey* key;
-#else
-    RsaKey  key[1];
-#endif
-
-#ifdef WOLFSSL_SMALL_STACK
-    key = (RsaKey*)XMALLOC(sizeof(RsaKey), heap, DYNAMIC_TYPE_RSA);
-    if (key == NULL)
-        return MEMORY_E;
-#endif
-
-    ret = wc_InitRsaKey_ex(key, heap, devId);
-    if (ret == 0) {
-        *idx = 0;
-        ret = wc_RsaPrivateKeyDecode(der->buffer, idx, key, der->length);
-    #ifdef WOLF_PRIVATE_KEY_ID
-        if (ret != 0 && (devId != INVALID_DEVID
-        #ifdef HAVE_PK_CALLBACKS
-            || ((ssl == NULL) ? wolfSSL_CTX_IsPrivatePkSet(ctx) :
-                                wolfSSL_CTX_IsPrivatePkSet(ssl->ctx))
-        #endif
-        )) {
-            /* if using crypto or PK callbacks, try public key decode */
-            *idx = 0;
-            ret = wc_RsaPublicKeyDecode(der->buffer, idx, key, der->length);
-        }
-    #endif
-        if (ret != 0) {
-        #if !defined(HAVE_ECC) && !defined(HAVE_ED25519) && \
-            !defined(HAVE_ED448) && !defined(HAVE_PQC)
-            WOLFSSL_MSG("RSA decode failed and other algorithms "
-                        "not enabled to try");
-            ret = WOLFSSL_BAD_FILE;
-        #else
-            if (*keyFormat == 0) {
-                /* Format unknown so keep trying. */
-                ret = 0; /* continue trying other algorithms */
-            }
-        #endif
-        }
-        else {
-            /* check that the size of the RSA key is enough */
-            int minRsaSz = ssl ? ssl->options.minRsaKeySz : ctx->minRsaKeySz;
-            *keySz = wc_RsaEncryptSize((RsaKey*)key);
-            if (*keySz < minRsaSz) {
-                ret = RSA_KEY_SIZE_E;
-                WOLFSSL_MSG("Private Key size too small");
-            }
-
-            if (ssl) {
-                ssl->buffers.keyType = rsa_sa_algo;
-                ssl->buffers.keySz = *keySz;
-            }
-            else {
-                ctx->privateKeyType = rsa_sa_algo;
-                ctx->privateKeySz = *keySz;
-            }
-
-            *keyFormat = RSAk;
-
-            if (ssl && ssl->options.side == WOLFSSL_SERVER_END) {
-                ssl->options.haveStaticECC = 0;
-                *resetSuites = 1;
-            }
-        }
-
-        wc_FreeRsaKey(key);
-    }
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(key, heap, DYNAMIC_TYPE_RSA);
-#endif
-
-    return ret;
-}
-#endif
-#endif /* !NO_RSA */
-
-#ifdef HAVE_ECC
-static int ProcessBufferTryDecodeEcc(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
-    DerBuffer* der, int* keySz, word32* idx, int* resetSuites, int* keyFormat,
-    void* heap, int devId)
-{
-    int ret = 0;
-    /* make sure ECC key can be used */
-#ifdef WOLFSSL_SMALL_STACK
-    ecc_key* key;
-#else
-    ecc_key  key[1];
-#endif
-
-#ifdef WOLFSSL_SMALL_STACK
-    key = (ecc_key*)XMALLOC(sizeof(ecc_key), heap, DYNAMIC_TYPE_ECC);
-    if (key == NULL)
-        return MEMORY_E;
-#endif
-
-    if (wc_ecc_init_ex(key, heap, devId) == 0) {
-        *idx = 0;
-        ret = wc_EccPrivateKeyDecode(der->buffer, idx, key, der->length);
-    #ifdef WOLF_PRIVATE_KEY_ID
-        if (ret != 0 && (devId != INVALID_DEVID
-        #ifdef HAVE_PK_CALLBACKS
-            || ((ssl == NULL) ? wolfSSL_CTX_IsPrivatePkSet(ctx) :
-                                wolfSSL_CTX_IsPrivatePkSet(ssl->ctx))
-        #endif
-        )) {
-            /* if using crypto or PK callbacks, try public key decode */
-            *idx = 0;
-            ret = wc_EccPublicKeyDecode(der->buffer, idx, key, der->length);
-        }
-    #endif
-        if (ret == 0) {
-            /* check for minimum ECC key size and then free */
-            int minKeySz = ssl ? ssl->options.minEccKeySz : ctx->minEccKeySz;
-            *keySz = wc_ecc_size(key);
-            if (*keySz < minKeySz) {
-                WOLFSSL_MSG("ECC private key too small");
-                ret = ECC_KEY_SIZE_E;
-            }
-
-            *keyFormat = ECDSAk;
-            if (ssl) {
-                ssl->options.haveStaticECC = 1;
-                ssl->buffers.keyType = ecc_dsa_sa_algo;
-            #ifdef WOLFSSL_SM2
-                if (key->dp->id == ECC_SM2P256V1)
-                    ssl->buffers.keyType = sm2_sa_algo;
-                else
-            #endif
-                    ssl->buffers.keyType = ecc_dsa_sa_algo;
-                ssl->buffers.keySz = *keySz;
-            }
-            else {
-                ctx->haveStaticECC = 1;
-                ctx->privateKeyType = ecc_dsa_sa_algo;
-            #ifdef WOLFSSL_SM2
-                if (key->dp->id == ECC_SM2P256V1)
-                    ctx->privateKeyType = sm2_sa_algo;
-                else
-            #endif
-                    ctx->privateKeyType = ecc_dsa_sa_algo;
-                ctx->privateKeySz = *keySz;
-            }
-
-            if (ssl && ssl->options.side == WOLFSSL_SERVER_END) {
-                *resetSuites = 1;
-            }
-        }
-        else if (*keyFormat == 0) {
-            ret = 0; /* continue trying other algorithms */
-        }
-
-        wc_ecc_free(key);
-    }
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(key, heap, DYNAMIC_TYPE_ECC);
-#endif
-    return ret;
-}
-#endif /* HAVE_ECC */
-
-#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
-static int ProcessBufferTryDecodeEd25519(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
-    DerBuffer* der, int* keySz, word32* idx, int* resetSuites, int* keyFormat,
-    void* heap, int devId)
-{
-    int ret;
-    /* make sure Ed25519 key can be used */
-#ifdef WOLFSSL_SMALL_STACK
-    ed25519_key* key;
-#else
-    ed25519_key  key[1];
-#endif
-
-#ifdef WOLFSSL_SMALL_STACK
-    key = (ed25519_key*)XMALLOC(sizeof(ed25519_key), heap,
-                                                          DYNAMIC_TYPE_ED25519);
-    if (key == NULL)
-        return MEMORY_E;
-#endif
-
-    ret = wc_ed25519_init_ex(key, heap, devId);
-    if (ret == 0) {
-        *idx = 0;
-        ret = wc_Ed25519PrivateKeyDecode(der->buffer, idx, key, der->length);
-    #ifdef WOLF_PRIVATE_KEY_ID
-        if (ret != 0 && (devId != INVALID_DEVID
-        #ifdef HAVE_PK_CALLBACKS
-            || ((ssl == NULL) ? wolfSSL_CTX_IsPrivatePkSet(ctx) :
-                                wolfSSL_CTX_IsPrivatePkSet(ssl->ctx))
-        #endif
-        )) {
-            /* if using crypto or PK callbacks, try public key decode */
-            *idx = 0;
-            ret = wc_Ed25519PublicKeyDecode(der->buffer, idx, key, der->length);
-        }
-    #endif
-        if (ret == 0) {
-            /* check for minimum key size and then free */
-            int minKeySz = ssl ? ssl->options.minEccKeySz : ctx->minEccKeySz;
-            *keySz = ED25519_KEY_SIZE;
-            if (*keySz < minKeySz) {
-                WOLFSSL_MSG("ED25519 private key too small");
-                ret = ECC_KEY_SIZE_E;
-            }
-            if (ret == 0) {
-                if (ssl) {
-                    ssl->buffers.keyType = ed25519_sa_algo;
-                    ssl->buffers.keySz = *keySz;
-                }
-                else {
-                    ctx->privateKeyType = ed25519_sa_algo;
-                    ctx->privateKeySz = *keySz;
-                }
-
-                *keyFormat = ED25519k;
-                if (ssl != NULL) {
-#if !defined(WOLFSSL_NO_CLIENT_AUTH) && !defined(NO_ED25519_CLIENT_AUTH)
-                    /* ED25519 requires caching enabled for tracking message
-                     * hash used in EdDSA_Update for signing */
-                    ssl->options.cacheMessages = 1;
-#endif
-                    if (ssl->options.side == WOLFSSL_SERVER_END) {
-                        *resetSuites = 1;
-                    }
-                }
-            }
-        }
-        else if (*keyFormat == 0) {
-            ret = 0; /* continue trying other algorithms */
-        }
-
-        wc_ed25519_free(key);
-    }
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(key, heap, DYNAMIC_TYPE_ED25519);
-#endif
-    return ret;
-}
-#endif /* HAVE_ED25519 && HAVE_ED25519_KEY_IMPORT */
-
-#if defined(HAVE_ED448) && defined(HAVE_ED448_KEY_IMPORT)
-static int ProcessBufferTryDecodeEd448(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
-    DerBuffer* der, int* keySz, word32* idx, int* resetSuites, int* keyFormat,
-    void* heap, int devId)
-{
-    int ret;
-    /* make sure Ed448 key can be used */
-#ifdef WOLFSSL_SMALL_STACK
-    ed448_key* key = NULL;
-#else
-    ed448_key  key[1];
-#endif
-
-#ifdef WOLFSSL_SMALL_STACK
-    key = (ed448_key*)XMALLOC(sizeof(ed448_key), heap, DYNAMIC_TYPE_ED448);
-    if (key == NULL)
-        return MEMORY_E;
-#endif
-
-    ret = wc_ed448_init_ex(key, heap, devId);
-    if (ret == 0) {
-        *idx = 0;
-        ret = wc_Ed448PrivateKeyDecode(der->buffer, idx, key, der->length);
-    #ifdef WOLF_PRIVATE_KEY_ID
-        if (ret != 0 && (devId != INVALID_DEVID
-        #ifdef HAVE_PK_CALLBACKS
-            || ((ssl == NULL) ? wolfSSL_CTX_IsPrivatePkSet(ctx) :
-                                wolfSSL_CTX_IsPrivatePkSet(ssl->ctx))
-        #endif
-        )) {
-            /* if using crypto or PK callbacks, try public key decode */
-            *idx = 0;
-            ret = wc_Ed448PublicKeyDecode(der->buffer, idx, key, der->length);
-        }
-    #endif
-        if (ret == 0) {
-            /* check for minimum key size and then free */
-            int minKeySz = ssl ? ssl->options.minEccKeySz : ctx->minEccKeySz;
-            *keySz = ED448_KEY_SIZE;
-            if (*keySz < minKeySz) {
-                WOLFSSL_MSG("ED448 private key too small");
-                ret = ECC_KEY_SIZE_E;
-            }
-        }
-        if (ret == 0) {
-            if (ssl) {
-                ssl->buffers.keyType = ed448_sa_algo;
-                ssl->buffers.keySz = *keySz;
-            }
-            else if (ctx) {
-                ctx->privateKeyType = ed448_sa_algo;
-                ctx->privateKeySz = *keySz;
-            }
-
-            *keyFormat = ED448k;
-            if (ssl != NULL) {
-                /* ED448 requires caching enabled for tracking message
-                 * hash used in EdDSA_Update for signing */
-                ssl->options.cacheMessages = 1;
-                if (ssl->options.side == WOLFSSL_SERVER_END) {
-                    *resetSuites = 1;
-                }
-            }
-        }
-        else if (*keyFormat == 0) {
-            ret = 0; /* continue trying other algorithms */
-        }
-
-        wc_ed448_free(key);
-    }
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(key, heap, DYNAMIC_TYPE_ED448);
-#endif
-    return ret;
-}
-#endif /* HAVE_ED448 && HAVE_ED448_KEY_IMPORT */
-
-#if defined(HAVE_PQC)
-#if defined(HAVE_FALCON)
-static int ProcessBufferTryDecodeFalcon(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
-    DerBuffer* der, int* keySz, word32* idx, int* resetSuites, int* keyFormat,
-    void* heap, int type)
-{
-    int ret;
-    /* make sure Falcon key can be used */
-    falcon_key* key = (falcon_key*)XMALLOC(sizeof(falcon_key), heap,
-                                           DYNAMIC_TYPE_FALCON);
-    (void) type;
-    if (key == NULL) {
-        return MEMORY_E;
-    }
-    ret = wc_falcon_init(key);
-    if (ret == 0) {
-        if (*keyFormat == FALCON_LEVEL1k) {
-            ret = wc_falcon_set_level(key, 1);
-        }
-        else if (*keyFormat == FALCON_LEVEL5k) {
-            ret = wc_falcon_set_level(key, 5);
-        }
-        else {
-            /* What if *keyformat is 0? We might want to do something more
-             * graceful here. */
-            wc_falcon_free(key);
-            ret = ALGO_ID_E;
-        }
-    }
-
-    if (ret == 0) {
-        *idx = 0;
-        ret = wc_falcon_import_private_only(der->buffer, der->length, key);
-        if (ret == 0) {
-            /* check for minimum key size and then free */
-            int minKeySz = ssl ? ssl->options.minFalconKeySz :
-                                 ctx->minFalconKeySz;
-            *keySz = FALCON_MAX_KEY_SIZE;
-            if (*keySz < minKeySz) {
-                WOLFSSL_MSG("Falcon private key too small");
-                ret = FALCON_KEY_SIZE_E;
-            }
-            if (ssl) {
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-                if (type == ALT_PRIVATEKEY_TYPE) {
-                    if (*keyFormat == FALCON_LEVEL1k) {
-                        ssl->buffers.altKeyType = falcon_level1_sa_algo;
-                    }
-                    else {
-                        ssl->buffers.altKeyType = falcon_level5_sa_algo;
-                    }
-                    ssl->buffers.altKeySz = *keySz;
-                }
-                else
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-                {
-                    if (*keyFormat == FALCON_LEVEL1k) {
-                        ssl->buffers.keyType = falcon_level1_sa_algo;
-                    }
-                    else {
-                        ssl->buffers.keyType = falcon_level5_sa_algo;
-                    }
-                    ssl->buffers.keySz = *keySz;
-                }
-            }
-            else {
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-                if (type == ALT_PRIVATEKEY_TYPE) {
-                    if (*keyFormat == FALCON_LEVEL1k) {
-                        ctx->altPrivateKeyType = falcon_level1_sa_algo;
-                    }
-                    else {
-                        ctx->altPrivateKeyType = falcon_level5_sa_algo;
-                    }
-                    ctx->altPrivateKeySz = *keySz;
-                }
-                else
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-                {
-                    if (*keyFormat == FALCON_LEVEL1k) {
-                        ctx->privateKeyType = falcon_level1_sa_algo;
-                    }
-                    else {
-                        ctx->privateKeyType = falcon_level5_sa_algo;
-                    }
-                    ctx->privateKeySz = *keySz;
-                }
-            }
-
-            if (ssl && ssl->options.side == WOLFSSL_SERVER_END) {
-                *resetSuites = 1;
-            }
-        }
-        else if (*keyFormat == 0) {
-            ret = 0; /* continue trying other algorithms */
-        }
-
-        wc_falcon_free(key);
-    }
-    XFREE(key, heap, DYNAMIC_TYPE_FALCON);
-    return ret;
-}
-#endif
-
-#if defined(HAVE_DILITHIUM)
-static int ProcessBufferTryDecodeDilithium(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
-    DerBuffer* der, int* keySz, word32* idx, int* resetSuites, int* keyFormat,
-    void* heap, int type)
-{
-    int ret;
-    /* make sure Dilithium key can be used */
-    dilithium_key* key = (dilithium_key*)XMALLOC(sizeof(dilithium_key), heap,
-                                                 DYNAMIC_TYPE_DILITHIUM);
-    (void) type;
-    if (key == NULL) {
-        return MEMORY_E;
-    }
-    ret = wc_dilithium_init(key);
-    if (ret == 0) {
-        if (*keyFormat == DILITHIUM_LEVEL2k) {
-            ret = wc_dilithium_set_level(key, 2);
-        }
-        else if (*keyFormat == DILITHIUM_LEVEL3k) {
-            ret = wc_dilithium_set_level(key, 3);
-        }
-        else if (*keyFormat == DILITHIUM_LEVEL5k) {
-            ret = wc_dilithium_set_level(key, 5);
-        }
-        else {
-            /* What if *keyformat is 0? We might want to do something more
-             * graceful here. */
-            wc_dilithium_free(key);
-            ret = ALGO_ID_E;
-        }
-    }
-
-    if (ret == 0) {
-        *idx = 0;
-        ret = wc_dilithium_import_private_only(der->buffer, der->length, key);
-        if (ret == 0) {
-            /* check for minimum key size and then free */
-            int minKeySz = ssl ? ssl->options.minDilithiumKeySz :
-                                 ctx->minDilithiumKeySz;
-            *keySz = DILITHIUM_MAX_KEY_SIZE;
-            if (*keySz < minKeySz) {
-                WOLFSSL_MSG("Dilithium private key too small");
-                ret = DILITHIUM_KEY_SIZE_E;
-            }
-            if (ssl) {
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-                if (type == ALT_PRIVATEKEY_TYPE) {
-                    if (*keyFormat == DILITHIUM_LEVEL2k) {
-                        ssl->buffers.altKeyType = dilithium_level2_sa_algo;
-                    }
-                    else if (*keyFormat == DILITHIUM_LEVEL3k) {
-                        ssl->buffers.altKeyType = dilithium_level3_sa_algo;
-                    }
-                    else if (*keyFormat == DILITHIUM_LEVEL5k) {
-                        ssl->buffers.altKeyType = dilithium_level5_sa_algo;
-                    }
-                    ssl->buffers.altKeySz = *keySz;
-                }
-                else
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-                {
-                    if (*keyFormat == DILITHIUM_LEVEL2k) {
-                        ssl->buffers.keyType = dilithium_level2_sa_algo;
-                    }
-                    else if (*keyFormat == DILITHIUM_LEVEL3k) {
-                        ssl->buffers.keyType = dilithium_level3_sa_algo;
-                    }
-                    else if (*keyFormat == DILITHIUM_LEVEL5k) {
-                        ssl->buffers.keyType = dilithium_level5_sa_algo;
-                    }
-                    ssl->buffers.keySz = *keySz;
-                }
-            }
-            else {
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-                if (type == ALT_PRIVATEKEY_TYPE) {
-                    if (*keyFormat == DILITHIUM_LEVEL2k) {
-                        ctx->altPrivateKeyType = dilithium_level2_sa_algo;
-                    }
-                    else if (*keyFormat == DILITHIUM_LEVEL3k) {
-                        ctx->altPrivateKeyType = dilithium_level3_sa_algo;
-                    }
-                    else if (*keyFormat == DILITHIUM_LEVEL5k) {
-                        ctx->altPrivateKeyType = dilithium_level5_sa_algo;
-                    }
-                    ctx->altPrivateKeySz = *keySz;
-                }
-                else
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-                {
-                    if (*keyFormat == DILITHIUM_LEVEL2k) {
-                        ctx->privateKeyType = dilithium_level2_sa_algo;
-                    }
-                    else if (*keyFormat == DILITHIUM_LEVEL3k) {
-                        ctx->privateKeyType = dilithium_level3_sa_algo;
-                    }
-                    else if (*keyFormat == DILITHIUM_LEVEL5k) {
-                        ctx->privateKeyType = dilithium_level5_sa_algo;
-                    }
-                    ctx->privateKeySz = *keySz;
-                }
-            }
-
-            if (ssl && ssl->options.side == WOLFSSL_SERVER_END) {
-                *resetSuites = 1;
-            }
-        }
-        else if (*keyFormat == 0) {
-            ret = 0; /* continue trying other algorithms */
-        }
-
-        wc_dilithium_free(key);
-    }
-    XFREE(key, heap, DYNAMIC_TYPE_DILITHIUM);
-
-    return ret;
-}
-#endif /* HAVE_DILITHIUM */
-#endif /* HAVE_PQC */
-
-static int ProcessBufferTryDecode(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
-    DerBuffer* der, int* keySz, word32* idx, int* resetSuites, int* keyFormat,
-    void* heap, int devId, int type)
-{
-    int ret = 0;
-
-    (void)heap;
-    (void)devId;
-    (void)type;
-
-    if (ctx == NULL && ssl == NULL)
-        return BAD_FUNC_ARG;
-    if (!der || !keySz || !idx || !resetSuites || !keyFormat)
-        return BAD_FUNC_ARG;
-
-#ifndef NO_RSA
-    if ((*keyFormat == 0 || *keyFormat == RSAk)) {
-#if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && \
-    (HAVE_FIPS_VERSION > 2))
-        ret = ProcessBufferTryDecodeRsa(ctx, ssl, der, keySz, idx, resetSuites,
-            keyFormat, devId);
-#else
-        ret = ProcessBufferTryDecodeRsa(ctx, ssl, der, keySz, idx, resetSuites,
-            keyFormat, heap, devId);
-#endif
-        if (ret != 0)
-            return ret;
-    }
-#endif
-#ifdef HAVE_ECC
-    if ((*keyFormat == 0) || (*keyFormat == ECDSAk)
-    #ifdef WOLFSSL_SM2
-        || (*keyFormat == SM2k)
-    #endif
-        ) {
-        ret = ProcessBufferTryDecodeEcc(ctx, ssl, der, keySz, idx, resetSuites,
-            keyFormat, heap, devId);
-        if (ret != 0)
-            return ret;
-    }
-#endif /* HAVE_ECC */
-#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
-    if ((*keyFormat == 0 || *keyFormat == ED25519k)) {
-        ret = ProcessBufferTryDecodeEd25519(ctx, ssl, der, keySz, idx,
-            resetSuites, keyFormat, heap, devId);
-        if (ret != 0)
-            return ret;
-    }
-#endif /* HAVE_ED25519 && HAVE_ED25519_KEY_IMPORT */
-#if defined(HAVE_ED448) && defined(HAVE_ED448_KEY_IMPORT)
-    if ((*keyFormat == 0 || *keyFormat == ED448k)) {
-        ret = ProcessBufferTryDecodeEd448(ctx, ssl, der, keySz, idx,
-            resetSuites, keyFormat, heap, devId);
-        if (ret != 0)
-            return ret;
-    }
-#endif /* HAVE_ED448 && HAVE_ED448_KEY_IMPORT */
-#if defined(HAVE_PQC)
-#if defined(HAVE_FALCON)
-    if (((*keyFormat == 0) || (*keyFormat == FALCON_LEVEL1k) ||
-         (*keyFormat == FALCON_LEVEL5k))) {
-        ret = ProcessBufferTryDecodeFalcon(ctx, ssl, der, keySz, idx,
-            resetSuites, keyFormat, heap, type);
-        if (ret != 0)
-            return ret;
-    }
-#endif /* HAVE_FALCON */
-#if defined(HAVE_DILITHIUM)
-    if ((*keyFormat == 0) ||
-        (*keyFormat == DILITHIUM_LEVEL2k) ||
-        (*keyFormat == DILITHIUM_LEVEL3k) ||
-        (*keyFormat == DILITHIUM_LEVEL5k)) {
-        ret = ProcessBufferTryDecodeDilithium(ctx, ssl, der, keySz, idx,
-            resetSuites, keyFormat, heap, type);
-        if (ret != 0) {
-            return ret;
-        }
-    }
-#endif /* HAVE_DILITHIUM */
-#endif /* HAVE_PQC */
-    return ret;
-}
-
-/* process the buffer buff, length sz, into ctx of format and type
-   used tracks bytes consumed, userChain specifies a user cert chain
-   to pass during the handshake */
-int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
-                         long sz, int format, int type, WOLFSSL* ssl,
-                         long* used, int userChain, int verify)
-{
-    DerBuffer*    der = NULL;
-    int           ret = 0;
-    int           done = 0;
-    int           keyFormat = 0;
-    int           resetSuites = 0;
-    void*         heap = wolfSSL_CTX_GetHeap(ctx, ssl);
-    int           devId = wolfSSL_CTX_GetDevId(ctx, ssl);
-    word32        idx = 0;
-    int           keySz = 0;
-#if (defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_PWDBASED)) || \
-     defined(HAVE_PKCS8)
-    word32        algId = 0;
-#endif
-#ifdef WOLFSSL_SMALL_STACK
-    EncryptedInfo* info = NULL;
-#else
-    EncryptedInfo  info[1];
-#endif
-
-    (void)devId;
-    (void)idx;
-    (void)keySz;
-
-    if (used)
-        *used = sz;     /* used bytes default to sz, PEM chain may shorten*/
-
-    /* check args */
-    if (format != WOLFSSL_FILETYPE_ASN1 && format != WOLFSSL_FILETYPE_PEM)
-        return WOLFSSL_BAD_FILETYPE;
-
-    if (ctx == NULL && ssl == NULL)
-        return BAD_FUNC_ARG;
-
-    /* This API does not handle CHAIN_CERT_TYPE */
-    if (type == CHAIN_CERT_TYPE)
-        return BAD_FUNC_ARG;
-
-#ifdef WOLFSSL_SMALL_STACK
-    info = (EncryptedInfo*)XMALLOC(sizeof(EncryptedInfo), heap,
-                                   DYNAMIC_TYPE_ENCRYPTEDINFO);
-    if (info == NULL)
-        return MEMORY_E;
-#endif
-
-    XMEMSET(info, 0, sizeof(EncryptedInfo));
-#if defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_PWDBASED)
-    if (ctx) {
-        info->passwd_cb       = ctx->passwd_cb;
-        info->passwd_userdata = ctx->passwd_userdata;
-    }
-#endif
-
-    if (format == WOLFSSL_FILETYPE_PEM) {
-    #ifdef WOLFSSL_PEM_TO_DER
-        ret = PemToDer(buff, sz, type, &der, heap, info, &keyFormat);
-    #else
-        ret = NOT_COMPILED_IN;
-    #endif
-    }
-    else {
-        /* ASN1 (DER) */
-        int length = (int)sz;
-        word32 inOutIdx = 0;
-        /* get length of der (read sequence or octet string) */
-        if (GetSequence(buff, &inOutIdx, &length, (word32)sz) >= 0) {
-            length += inOutIdx; /* include leading sequence */
-        }
-        /* get length using octet string (allowed for private key types) */
-        else if (type == PRIVATEKEY_TYPE &&
-                    GetOctetString(buff, &inOutIdx, &length, (word32)sz) >= 0) {
-            length += inOutIdx; /* include leading oct string */
-        }
-        else {
-            ret = ASN_PARSE_E;
-        }
-
-        info->consumed = length;
-
-        if (ret == 0) {
-            ret = AllocDer(&der, (word32)length, type, heap);
-            if (ret == 0) {
-                XMEMCPY(der->buffer, buff, length);
-            }
-
-        #ifdef HAVE_PKCS8
-            /* if private key try and remove PKCS8 header */
-            if (ret == 0 && type == PRIVATEKEY_TYPE) {
-                if ((ret = ToTraditional_ex(der->buffer, der->length,
-                                                                 &algId)) > 0) {
-                    /* Found PKCS8 header */
-                    /* ToTraditional_ex moves buff and returns adjusted length */
-                    der->length = ret;
-                    keyFormat = algId;
-                }
-                ret = 0; /* failures should be ignored */
-            }
-        #endif
-        }
-    }
-
-    if (used) {
-        *used = info->consumed;
-    }
-
-    /* process user chain */
-    if (ret >= 0) {
-        /* Chain should have server cert first, then intermediates, then root.
-         * First certificate in chain is processed below after ProcessUserChain
-         *   and is loaded into ssl->buffers.certificate.
-         * Remainder are processed using ProcessUserChain and are loaded into
-         *   ssl->buffers.certChain. */
-        if (userChain) {
-            ret = ProcessUserChain(ctx, buff, sz, format, CHAIN_CERT_TYPE, ssl,
-                                   used, info, verify);
-            if (ret == ASN_NO_PEM_HEADER) { /* Additional chain is optional */
-                unsigned long pemErr = 0;
-                CLEAR_ASN_NO_PEM_HEADER_ERROR(pemErr);
-                ret = 0;
-            }
-        }
-    }
-
-    /* info is only used for private key with DER or PEM, so free now */
-    if (ret < 0 || type != PRIVATEKEY_TYPE) {
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(info, heap, DYNAMIC_TYPE_ENCRYPTEDINFO);
-    #endif
-    }
-
-    /* check for error */
-    if (ret < 0) {
-        FreeDer(&der);
-        done = 1;
-    }
-
-    if (done == 1) {
-        /* No operation, just skip the next section */
-    }
-    /* Handle DER owner */
-    else if (type == CA_TYPE) {
-        if (ctx == NULL) {
-            WOLFSSL_MSG("Need context for CA load");
-            FreeDer(&der);
-            return BAD_FUNC_ARG;
-        }
-        /* verify CA unless user set to no verify */
-        ret = AddCA(ctx->cm, &der, WOLFSSL_USER_CA, verify);
-        done = 1;
-    }
-#ifdef WOLFSSL_TRUST_PEER_CERT
-    else if (type == TRUSTED_PEER_TYPE) {
-        /* add trusted peer cert. der is freed within */
-        if (ctx != NULL)
-            ret = AddTrustedPeer(ctx->cm, &der, verify);
-        else {
-            SSL_CM_WARNING(ssl);
-            ret = AddTrustedPeer(SSL_CM(ssl), &der, verify);
-        }
-        if (ret != WOLFSSL_SUCCESS) {
-            WOLFSSL_MSG("Error adding trusted peer");
-        }
-        done = 1;
-    }
-#endif /* WOLFSSL_TRUST_PEER_CERT */
-    else if (type == CERT_TYPE) {
-        if (ssl != NULL) {
-             /* Make sure previous is free'd */
-            if (ssl->buffers.weOwnCert) {
-                FreeDer(&ssl->buffers.certificate);
-            #ifdef KEEP_OUR_CERT
-                wolfSSL_X509_free(ssl->ourCert);
-                ssl->ourCert = NULL;
-            #endif
-            }
-            ssl->buffers.certificate = der;
-        #ifdef KEEP_OUR_CERT
-            ssl->keepCert = 1; /* hold cert for ssl lifetime */
-        #endif
-            ssl->buffers.weOwnCert = 1;
-        }
-        else if (ctx != NULL) {
-            FreeDer(&ctx->certificate); /* Make sure previous is free'd */
-        #ifdef KEEP_OUR_CERT
-            if (ctx->ourCert) {
-                if (ctx->ownOurCert)
-                    wolfSSL_X509_free(ctx->ourCert);
-                ctx->ourCert = NULL;
-            }
-        #endif
-            ctx->certificate = der;
-        }
-    }
-    else if (type == PRIVATEKEY_TYPE) {
-        if (ssl != NULL) {
-             /* Make sure previous is free'd */
-            if (ssl->buffers.weOwnKey) {
-                ForceZero(ssl->buffers.key->buffer, ssl->buffers.key->length);
-                FreeDer(&ssl->buffers.key);
-            }
-            ssl->buffers.key = der;
-#ifdef WOLFSSL_CHECK_MEM_ZERO
-            wc_MemZero_Add("SSL Buffers key", der->buffer, der->length);
-#endif
-            ssl->buffers.weOwnKey = 1;
-        }
-        else if (ctx != NULL) {
-            if (ctx->privateKey != NULL && ctx->privateKey->buffer != NULL) {
-                ForceZero(ctx->privateKey->buffer, ctx->privateKey->length);
-            }
-            FreeDer(&ctx->privateKey);
-            ctx->privateKey = der;
-#ifdef WOLFSSL_CHECK_MEM_ZERO
-            wc_MemZero_Add("CTX private key", der->buffer, der->length);
-#endif
-        }
-    }
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-    else if (type == ALT_PRIVATEKEY_TYPE) {
-        if (ssl != NULL) {
-             /* Make sure previous is free'd */
-            if (ssl->buffers.weOwnAltKey) {
-                ForceZero(ssl->buffers.altKey->buffer,
-                          ssl->buffers.altKey->length);
-                FreeDer(&ssl->buffers.altKey);
-            }
-            ssl->buffers.altKey = der;
-#ifdef WOLFSSL_CHECK_MEM_ZERO
-            wc_MemZero_Add("SSL Buffers key", der->buffer, der->length);
-#endif
-            ssl->buffers.weOwnAltKey = 1;
-        }
-        else if (ctx != NULL) {
-            if (ctx->altPrivateKey != NULL &&
-                ctx->altPrivateKey->buffer != NULL) {
-                ForceZero(ctx->altPrivateKey->buffer,
-                          ctx->altPrivateKey->length);
-            }
-            FreeDer(&ctx->altPrivateKey);
-            ctx->altPrivateKey = der;
-#ifdef WOLFSSL_CHECK_MEM_ZERO
-            wc_MemZero_Add("CTX private key", der->buffer, der->length);
-#endif
-        }
-    }
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-    else {
-        FreeDer(&der);
-        return WOLFSSL_BAD_CERTTYPE;
-    }
-
-    if (done == 1) {
-        /* No operation, just skip the next section */
-    }
-    else if (type == PRIVATEKEY_TYPE
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-             || type == ALT_PRIVATEKEY_TYPE
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-            ) {
-        ret = ProcessBufferTryDecode(ctx, ssl, der, &keySz, &idx, &resetSuites,
-                &keyFormat, heap, devId, type);
-
-    #if defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_PWDBASED)
-        /* for WOLFSSL_FILETYPE_PEM, PemToDer manages the decryption */
-        /* If private key type PKCS8 header wasn't already removed (algoId == 0) */
-        if ((ret != 0 || keyFormat == 0)
-            && format != WOLFSSL_FILETYPE_PEM && info->passwd_cb && algId == 0)
-        {
-            int   passwordSz = NAME_SZ;
-        #ifndef WOLFSSL_SMALL_STACK
-            char  password[NAME_SZ];
-        #else
-            char* password = (char*)XMALLOC(passwordSz, heap, DYNAMIC_TYPE_STRING);
-            if (password == NULL) {
-                XFREE(info, heap, DYNAMIC_TYPE_ENCRYPTEDINFO);
-                FreeDer(&der);
-                return MEMORY_E;
-            }
-        #endif
-            /* get password */
-            ret = info->passwd_cb(password, passwordSz, PEM_PASS_READ,
-                info->passwd_userdata);
-            if (ret >= 0) {
-                passwordSz = ret;
-            #ifdef WOLFSSL_CHECK_MEM_ZERO
-                wc_MemZero_Add("ProcessBuffer password", password, passwordSz);
-            #endif
-
-                /* PKCS8 decrypt */
-                ret = ToTraditionalEnc(der->buffer, der->length,
-                                       password, passwordSz, &algId);
-                if (ret >= 0) {
-                    ForceZero(der->buffer + ret, der->length - ret);
-                    der->length = ret;
-                }
-                /* ignore failures and try parsing as unencrypted */
-
-                ForceZero(password, passwordSz);
-            }
-
-        #ifdef WOLFSSL_SMALL_STACK
-            XFREE(password, heap, DYNAMIC_TYPE_STRING);
-        #elif defined(WOLFSSL_CHECK_MEM_ZERO)
-            wc_MemZero_Check(password, NAME_SZ);
-        #endif
-            ret = ProcessBufferTryDecode(ctx, ssl, der, &keySz, &idx,
-                &resetSuites, &keyFormat, heap, devId, type);
-        }
-    #endif /* WOLFSSL_ENCRYPTED_KEYS && !NO_PWDBASED */
-
-        if (ret != 0) {
-        #ifdef WOLFSSL_SMALL_STACK
-            XFREE(info, heap, DYNAMIC_TYPE_ENCRYPTEDINFO);
-        #endif
-            return ret;
-        }
-        if (keyFormat == 0) {
-#ifdef OPENSSL_EXTRA
-            /* Reaching this point probably means that the
-             * decryption password is wrong */
-            if (info->passwd_cb)
-                EVPerr(0, EVP_R_BAD_DECRYPT);
-#endif
-        #ifdef WOLFSSL_SMALL_STACK
-            XFREE(info, heap, DYNAMIC_TYPE_ENCRYPTEDINFO);
-        #endif
-            WOLFSSL_ERROR(WOLFSSL_BAD_FILE);
-            return WOLFSSL_BAD_FILE;
-        }
-
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(info, heap, DYNAMIC_TYPE_ENCRYPTEDINFO);
-    #endif
-
-        (void)devId;
-    }
-    else if (type == CERT_TYPE) {
-    #ifdef WOLFSSL_SMALL_STACK
-        DecodedCert* cert;
-    #else
-        DecodedCert  cert[1];
-    #endif
-    #ifdef WOLF_PRIVATE_KEY_ID
-        int keyType = 0;
-    #endif
-
-    #ifdef WOLFSSL_SMALL_STACK
-        cert = (DecodedCert*)XMALLOC(sizeof(DecodedCert), heap,
-                                     DYNAMIC_TYPE_DCERT);
-        if (cert == NULL)
-            return MEMORY_E;
-    #endif
-
-        WOLFSSL_MSG("Checking cert signature type");
-        InitDecodedCert_ex(cert, der->buffer, der->length, heap, devId);
-
-        if (DecodeToKey(cert, 0) < 0) {
-            WOLFSSL_MSG("Decode to key failed");
-            FreeDecodedCert(cert);
-        #ifdef WOLFSSL_SMALL_STACK
-            XFREE(cert, heap, DYNAMIC_TYPE_DCERT);
-        #endif
-            return WOLFSSL_BAD_FILE;
-        }
-#if defined(HAVE_RPK)
-        if (ssl) {
-            ssl->options.rpkState.isRPKLoaded = 0;
-            if (cert->isRPK) {
-                ssl->options.rpkState.isRPKLoaded = 1;
-            }
-        }
-        else if (ctx) {
-            ctx->rpkState.isRPKLoaded = 0;
-            if (cert->isRPK) {
-                ctx->rpkState.isRPKLoaded = 1;
-            }
-        }
-#endif /* HAVE_RPK */
-
-        if (ssl) {
-            if (ssl->options.side == WOLFSSL_SERVER_END)
-                resetSuites = 1;
-        }
-        else if (ctx && ctx->method->side == WOLFSSL_SERVER_END) {
-            resetSuites = 1;
-        }
-        if (ssl && ssl->ctx->haveECDSAsig) {
-            WOLFSSL_MSG("SSL layer setting cert, CTX had ECDSA, turning off");
-            ssl->options.haveECDSAsig = 0;   /* may turn back on next */
-        }
-
-        switch (cert->signatureOID) {
-            case CTC_SHAwECDSA:
-            case CTC_SHA256wECDSA:
-            case CTC_SHA384wECDSA:
-            case CTC_SHA512wECDSA:
-            case CTC_ED25519:
-            case CTC_ED448:
-        #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
-            case CTC_SM3wSM2:
-        #endif
-                WOLFSSL_MSG("ECDSA/ED25519/ED448 cert signature");
-                if (ssl)
-                    ssl->options.haveECDSAsig = 1;
-                else if (ctx)
-                    ctx->haveECDSAsig = 1;
-                break;
-            case CTC_FALCON_LEVEL1:
-            case CTC_FALCON_LEVEL5:
-                WOLFSSL_MSG("Falcon cert signature");
-                if (ssl)
-                    ssl->options.haveFalconSig = 1;
-                else if (ctx)
-                    ctx->haveFalconSig = 1;
-                break;
-            case CTC_DILITHIUM_LEVEL2:
-            case CTC_DILITHIUM_LEVEL3:
-            case CTC_DILITHIUM_LEVEL5:
-                WOLFSSL_MSG("Dilithium cert signature");
-                if (ssl)
-                    ssl->options.haveDilithiumSig = 1;
-                else if (ctx)
-                    ctx->haveDilithiumSig = 1;
-                break;
-            default:
-                WOLFSSL_MSG("Not ECDSA cert signature");
-                break;
-        }
-
-    #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448) || \
-        (defined(HAVE_PQC) && defined(HAVE_LIBOQS)) || !defined(NO_RSA)
-        if (ssl) {
-        #if defined(HAVE_ECC) || defined(HAVE_ED25519) || \
-            (defined(HAVE_CURVE448) && defined(HAVE_ED448))
-            ssl->pkCurveOID = cert->pkCurveOID;
-        #endif
-        #ifndef WC_STRICT_SIG
-            if (cert->keyOID == ECDSAk) {
-                ssl->options.haveECC = 1;
-            }
-            #ifndef NO_RSA
-            else if (cert->keyOID == RSAk) {
-                ssl->options.haveRSA = 1;
-            }
-            #ifdef WC_RSA_PSS
-            else if (cert->keyOID == RSAPSSk) {
-                ssl->options.haveRSA = 1;
-            }
-            #endif
-            #endif
-            #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
-                else if (cert->keyOID == SM2k) {
-                    ssl->options.haveECC = 1;
-                }
-            #endif
-            #ifdef HAVE_ED25519
-                else if (cert->keyOID == ED25519k) {
-                    ssl->options.haveECC = 1;
-                }
-            #endif
-            #ifdef HAVE_ED448
-                else if (cert->keyOID == ED448k) {
-                    ssl->options.haveECC = 1;
-                }
-            #endif
-            #ifdef HAVE_PQC
-            #ifdef HAVE_FALCON
-                else if (cert->keyOID == FALCON_LEVEL1k ||
-                         cert->keyOID == FALCON_LEVEL5k) {
-                    ssl->options.haveFalconSig = 1;
-                }
-            #endif /* HAVE_FALCON */
-            #ifdef HAVE_DILITHIUM
-                else if (cert->keyOID == DILITHIUM_LEVEL2k ||
-                         cert->keyOID == DILITHIUM_LEVEL3k ||
-                         cert->keyOID == DILITHIUM_LEVEL5k) {
-                    ssl->options.haveDilithiumSig = 1;
-                }
-            #endif /* HAVE_DILITHIUM */
-            #endif /* HAVE_PQC */
-        #else
-            ssl->options.haveECC = ssl->options.haveECDSAsig;
-        #endif
-        }
-        else if (ctx) {
-        #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
-            ctx->pkCurveOID = cert->pkCurveOID;
-        #endif
-        #ifndef WC_STRICT_SIG
-            if (cert->keyOID == ECDSAk) {
-                ctx->haveECC = 1;
-            }
-            #ifndef NO_RSA
-            else if (cert->keyOID == RSAk) {
-                ctx->haveRSA = 1;
-            }
-            #ifdef WC_RSA_PSS
-            else if (cert->keyOID == RSAPSSk) {
-                ctx->haveRSA = 1;
-            }
-            #endif
-            #endif
-            #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
-            else if (cert->keyOID == SM2k) {
-                ctx->haveECC = 1;
-            }
-            #endif
-            #ifdef HAVE_ED25519
-                else if (cert->keyOID == ED25519k) {
-                    ctx->haveECC = 1;
-                }
-            #endif
-            #ifdef HAVE_ED448
-                else if (cert->keyOID == ED448k) {
-                    ctx->haveECC = 1;
-                }
-            #endif
-            #ifdef HAVE_PQC
-            #ifdef HAVE_FALCON
-                else if (cert->keyOID == FALCON_LEVEL1k ||
-                         cert->keyOID == FALCON_LEVEL5k) {
-                    ctx->haveFalconSig = 1;
-                }
-            #endif /* HAVE_FALCON */
-            #ifdef HAVE_DILITHIUM
-                else if (cert->keyOID == DILITHIUM_LEVEL2k ||
-                         cert->keyOID == DILITHIUM_LEVEL3k ||
-                         cert->keyOID == DILITHIUM_LEVEL5k) {
-                    ctx->haveDilithiumSig = 1;
-                }
-            #endif /* HAVE_DILITHIUM */
-            #endif /* HAVE_PQC */
-        #else
-            ctx->haveECC = ctx->haveECDSAsig;
-        #endif
-        }
-    #endif
-
-        /* check key size of cert unless specified not to */
-        switch (cert->keyOID) {
-        #ifndef NO_RSA
-            #ifdef WC_RSA_PSS
-            case RSAPSSk:
-            #endif
-            case RSAk:
-            #ifdef WOLF_PRIVATE_KEY_ID
-                keyType = rsa_sa_algo;
-            #endif
-                /* Determine RSA key size by parsing public key */
-                idx = 0;
-                ret = wc_RsaPublicKeyDecode_ex(cert->publicKey, &idx,
-                    cert->pubKeySize, NULL, (word32*)&keySz, NULL, NULL);
-                if (ret < 0)
-                    break;
-
-                if (ssl && !ssl->options.verifyNone) {
-                    if (ssl->options.minRsaKeySz < 0 ||
-                          keySz < (int)ssl->options.minRsaKeySz ||
-                          keySz > (RSA_MAX_SIZE / 8)) {
-                        ret = RSA_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate RSA key size too small");
-                    }
-                }
-                else if (ctx && !ctx->verifyNone) {
-                    if (ctx->minRsaKeySz < 0 ||
-                            keySz < (int)ctx->minRsaKeySz ||
-                            keySz > (RSA_MAX_SIZE / 8)) {
-                        ret = RSA_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate RSA key size too small");
-                    }
-                }
-                break;
-        #endif /* !NO_RSA */
-        #ifdef HAVE_ECC
-            case ECDSAk:
-            #ifdef WOLF_PRIVATE_KEY_ID
-                keyType = ecc_dsa_sa_algo;
-            #endif
-                /* Determine ECC key size based on curve */
-            #ifdef WOLFSSL_CUSTOM_CURVES
-                if (cert->pkCurveOID == 0 && cert->pkCurveSize != 0) {
-                    keySz = cert->pkCurveSize * 8;
-                }
-                else
-            #endif
-                {
-                    keySz = wc_ecc_get_curve_size_from_id(
-                        wc_ecc_get_oid(cert->pkCurveOID, NULL, NULL));
-                }
-
-                if (ssl && !ssl->options.verifyNone) {
-                    if (ssl->options.minEccKeySz < 0 ||
-                          keySz < (int)ssl->options.minEccKeySz) {
-                        ret = ECC_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate ECC key size error");
-                    }
-                }
-                else if (ctx && !ctx->verifyNone) {
-                    if (ctx->minEccKeySz < 0 ||
-                                  keySz < (int)ctx->minEccKeySz) {
-                        ret = ECC_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate ECC key size error");
-                    }
-                }
-                break;
-        #endif /* HAVE_ECC */
-        #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
-            case SM2k:
-            #ifdef WOLF_PRIVATE_KEY_ID
-                keyType = sm2_sa_algo;
-            #endif
-                /* Determine ECC key size based on curve */
-                keySz = wc_ecc_get_curve_size_from_id(
-                    wc_ecc_get_oid(cert->pkCurveOID, NULL, NULL));
-                if (ssl && !ssl->options.verifyNone) {
-                    if (ssl->options.minEccKeySz < 0 ||
-                          keySz < (int)ssl->options.minEccKeySz) {
-                        ret = ECC_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate Ed key size error");
-                    }
-                }
-                else if (ctx && !ctx->verifyNone) {
-                    if (ctx->minEccKeySz < 0 ||
-                                  keySz < (int)ctx->minEccKeySz) {
-                        ret = ECC_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate ECC key size error");
-                    }
-                }
-                break;
-        #endif /* HAVE_ED25519 */
-        #ifdef HAVE_ED25519
-            case ED25519k:
-            #ifdef WOLF_PRIVATE_KEY_ID
-                keyType = ed25519_sa_algo;
-            #endif
-                /* ED25519 is fixed key size */
-                keySz = ED25519_KEY_SIZE;
-                if (ssl && !ssl->options.verifyNone) {
-                    if (ssl->options.minEccKeySz < 0 ||
-                          keySz < (int)ssl->options.minEccKeySz) {
-                        ret = ECC_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate Ed key size error");
-                    }
-                }
-                else if (ctx && !ctx->verifyNone) {
-                    if (ctx->minEccKeySz < 0 ||
-                                  keySz < (int)ctx->minEccKeySz) {
-                        ret = ECC_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate ECC key size error");
-                    }
-                }
-                break;
-        #endif /* HAVE_ED25519 */
-        #ifdef HAVE_ED448
-            case ED448k:
-            #ifdef WOLF_PRIVATE_KEY_ID
-                keyType = ed448_sa_algo;
-            #endif
-                /* ED448 is fixed key size */
-                keySz = ED448_KEY_SIZE;
-                if (ssl && !ssl->options.verifyNone) {
-                    if (ssl->options.minEccKeySz < 0 ||
-                          keySz < (int)ssl->options.minEccKeySz) {
-                        ret = ECC_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate Ed key size error");
-                    }
-                }
-                else if (ctx && !ctx->verifyNone) {
-                    if (ctx->minEccKeySz < 0 ||
-                                  keySz < (int)ctx->minEccKeySz) {
-                        ret = ECC_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate ECC key size error");
-                    }
-                }
-                break;
-        #endif /* HAVE_ED448 */
-        #if defined(HAVE_PQC)
-        #if defined(HAVE_FALCON)
-            case FALCON_LEVEL1k:
-            case FALCON_LEVEL5k:
-            #ifdef WOLF_PRIVATE_KEY_ID
-                keyType = falcon_level5_sa_algo;
-            #endif
-                /* Falcon is fixed key size */
-                keySz = FALCON_MAX_KEY_SIZE;
-                if (ssl && !ssl->options.verifyNone) {
-                    if (ssl->options.minFalconKeySz < 0 ||
-                          keySz < (int)ssl->options.minFalconKeySz) {
-                        ret = FALCON_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate Falcon key size error");
-                    }
-                }
-                else if (ctx && !ctx->verifyNone) {
-                    if (ctx->minFalconKeySz < 0 ||
-                                  keySz < (int)ctx->minFalconKeySz) {
-                        ret = FALCON_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate Falcon key size error");
-                    }
-                }
-                break;
-        #endif /* HAVE_FALCON */
-        #if defined(HAVE_DILITHIUM)
-            case DILITHIUM_LEVEL2k:
-            case DILITHIUM_LEVEL3k:
-            case DILITHIUM_LEVEL5k:
-            #ifdef WOLF_PRIVATE_KEY_ID
-                keyType = dilithium_level5_sa_algo;
-            #endif
-                /* Dilithium is fixed key size */
-                keySz = DILITHIUM_MAX_KEY_SIZE;
-                if (ssl && !ssl->options.verifyNone) {
-                    if (ssl->options.minDilithiumKeySz < 0 ||
-                          keySz < (int)ssl->options.minDilithiumKeySz) {
-                        ret = DILITHIUM_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate Dilithium key size error");
-                    }
-                }
-                else if (ctx && !ctx->verifyNone) {
-                    if (ctx->minDilithiumKeySz < 0 ||
-                                  keySz < (int)ctx->minDilithiumKeySz) {
-                        ret = DILITHIUM_KEY_SIZE_E;
-                        WOLFSSL_MSG("Certificate Dilithium key size error");
-                    }
-                }
-                break;
-        #endif /* HAVE_DILITHIUM */
-        #endif /* HAVE_PQC */
-
-            default:
-                WOLFSSL_MSG("No key size check done on certificate");
-                break; /* do no check if not a case for the key */
-        }
-
-    #ifdef WOLF_PRIVATE_KEY_ID
-        if (ssl != NULL) {
-            ssl->buffers.keyType = (byte)keyType;
-            ssl->buffers.keySz = keySz;
-        }
-        else if (ctx != NULL) {
-            ctx->privateKeyType = (byte)keyType;
-            ctx->privateKeySz = keySz;
-        }
-    #endif
-
-        FreeDecodedCert(cert);
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(cert, heap, DYNAMIC_TYPE_DCERT);
-    #endif
-
-        if (ret != 0) {
-            done = 1;
-        }
-    }
-
-    if (done == 1) {
-    #if !defined(NO_WOLFSSL_CM_VERIFY) && (!defined(NO_WOLFSSL_CLIENT) || \
-                                           !defined(WOLFSSL_NO_CLIENT_AUTH))
-        if ((type == CA_TYPE) || (type == CERT_TYPE)) {
-            /* Call to over-ride status */
-            if ((ctx != NULL) && (ctx->cm != NULL) &&
-                (ctx->cm->verifyCallback != NULL)) {
-                ret = CM_VerifyBuffer_ex(ctx->cm, buff,
-                        sz, format, (ret == WOLFSSL_SUCCESS ? 0 : ret));
-            }
-        }
-    #endif /* NO_WOLFSSL_CM_VERIFY */
-
-        return ret;
-    }
-
-
-    if (ssl && resetSuites) {
-        word16 havePSK = 0;
-        word16 haveRSA = 0;
-
-    #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
-        if (ssl->options.havePSK) {
-            havePSK = 1;
-        }
-    #endif
-    #ifndef NO_RSA
-        haveRSA = 1;
-    #endif
-        keySz = ssl->buffers.keySz;
-
-        if (AllocateSuites(ssl) != 0)
-            return WOLFSSL_FAILURE;
-        /* let's reset suites */
-        InitSuites(ssl->suites, ssl->version, keySz, haveRSA,
-                   havePSK, ssl->options.haveDH, ssl->options.haveECDSAsig,
-                   ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
-                   ssl->options.haveFalconSig, ssl->options.haveDilithiumSig,
-                   ssl->options.useAnon, TRUE, ssl->options.side);
-    }
-    else if (ctx && resetSuites) {
-        word16 havePSK = 0;
-        word16 haveRSA = 0;
-
-    #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
-        if (ctx->havePSK) {
-            havePSK = 1;
-        }
-    #endif
-    #ifndef NO_RSA
-        haveRSA = 1;
-    #endif
-        keySz = ctx->privateKeySz;
-
-        if (AllocateCtxSuites(ctx) != 0)
-            return WOLFSSL_FAILURE;
-        /* let's reset suites */
-        InitSuites(ctx->suites, ctx->method->version, keySz, haveRSA,
-                   havePSK, ctx->haveDH, ctx->haveECDSAsig,
-                   ctx->haveECC, TRUE, ctx->haveStaticECC,
-                   ctx->haveFalconSig, ctx->haveDilithiumSig,
-#ifdef HAVE_ANON
-                   ctx->useAnon,
-#else
-                   FALSE,
-#endif
-                   TRUE, ctx->method->side);
-    }
-
-    return WOLFSSL_SUCCESS;
-}
-
-
-/* CA PEM file for verification, may have multiple/chain certs to process */
-static int ProcessChainBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff,
-                        long sz, int format, int type, WOLFSSL* ssl, int verify)
-{
-    long used   = 0;
-    int  ret    = 0;
-    int  gotOne = 0;
-
-    WOLFSSL_MSG("Processing CA PEM file");
-    while (used < sz) {
-        long consumed = 0;
-
-        ret = ProcessBuffer(ctx, buff + used, sz - used, format, type, ssl,
-                            &consumed, 0, verify);
-
-        if (ret == MEMORY_E) {
-            return ret;
-        }
-        else if (ret < 0) {
-#if defined(WOLFSSL_WPAS) && defined(HAVE_CRL)
-            DerBuffer*    der = NULL;
-            EncryptedInfo info;
-
-            WOLFSSL_MSG("Trying a CRL");
-            if (PemToDer(buff + used, sz - used, CRL_TYPE, &der, NULL, &info,
-                                                                   NULL) == 0) {
-                WOLFSSL_MSG("   Processed a CRL");
-                wolfSSL_CertManagerLoadCRLBuffer(ctx->cm, der->buffer,
-                                            der->length, WOLFSSL_FILETYPE_ASN1);
-                FreeDer(&der);
-                used += info.consumed;
-                continue;
-            }
-#endif
-
-            if (consumed > 0) { /* Made progress in file */
-                WOLFSSL_ERROR(ret);
-                WOLFSSL_MSG("CA Parse failed, with progress in file.");
-                WOLFSSL_MSG("Search for other certs in file");
-            }
-            else {
-                WOLFSSL_MSG("CA Parse failed, no progress in file.");
-                WOLFSSL_MSG("Do not continue search for other certs in file");
-                break;
-            }
-        }
-        else {
-            WOLFSSL_MSG("   Processed a CA");
-            gotOne = 1;
-        }
-        used += consumed;
-    }
-
-    if (gotOne) {
-        WOLFSSL_MSG("Processed at least one valid CA. Other stuff OK");
-        return WOLFSSL_SUCCESS;
-    }
-    return ret;
-}
-
 
 #ifdef HAVE_CRL
 
@@ -8216,7 +5789,6 @@ int wolfSSL_SetOCSP_Cb(WOLFSSL* ssl,
         return BAD_FUNC_ARG;
 }
 
-
 int wolfSSL_CTX_EnableOCSP(WOLFSSL_CTX* ctx, int options)
 {
     WOLFSSL_ENTER("wolfSSL_CTX_EnableOCSP");
@@ -8295,556 +5867,10 @@ int wolfSSL_CTX_DisableOCSPMustStaple(WOLFSSL_CTX* ctx)
     else
         return BAD_FUNC_ARG;
 }
-#endif /* HAVE_CERTIFICATE_STATUS_REQUEST || HAVE_CERTIFICATE_STATUS_REQUEST_V2 */
+#endif /* HAVE_CERTIFICATE_STATUS_REQUEST || \
+        * HAVE_CERTIFICATE_STATUS_REQUEST_V2 */
 
 #endif /* HAVE_OCSP */
-
-/* macro to get verify settings for AddCA */
-#define GET_VERIFY_SETTING_CTX(ctx) \
-    ((ctx) && (ctx)->verifyNone ? NO_VERIFY : VERIFY)
-#define GET_VERIFY_SETTING_SSL(ssl) \
-    ((ssl)->options.verifyNone ? NO_VERIFY : VERIFY)
-
-#ifndef NO_FILESYSTEM
-
-/* process a file with name fname into ctx of format and type
-   userChain specifies a user certificate chain to pass during handshake */
-int ProcessFile(WOLFSSL_CTX* ctx, const char* fname, int format, int type,
-                WOLFSSL* ssl, int userChain, WOLFSSL_CRL* crl, int verify)
-{
-#ifdef WOLFSSL_SMALL_STACK
-    byte   staticBuffer[1]; /* force heap usage */
-#else
-    byte   staticBuffer[FILE_BUFFER_SIZE];
-#endif
-    byte*  myBuffer = staticBuffer;
-    int    dynamic = 0;
-    int    ret;
-    long   sz = 0;
-    XFILE  file;
-    void*  heapHint = wolfSSL_CTX_GetHeap(ctx, ssl);
-#ifndef NO_CODING
-    const char* header = NULL;
-    const char* footer = NULL;
-#endif
-
-    (void)crl;
-    (void)heapHint;
-
-    if (fname == NULL) return WOLFSSL_BAD_FILE;
-
-    file = XFOPEN(fname, "rb");
-    if (file == XBADFILE) return WOLFSSL_BAD_FILE;
-    if (XFSEEK(file, 0, XSEEK_END) != 0) {
-        XFCLOSE(file);
-        return WOLFSSL_BAD_FILE;
-    }
-    sz = XFTELL(file);
-    if (XFSEEK(file, 0, XSEEK_SET) != 0) {
-        XFCLOSE(file);
-        return WOLFSSL_BAD_FILE;
-    }
-
-    if (sz > MAX_WOLFSSL_FILE_SIZE || sz <= 0) {
-        WOLFSSL_MSG("ProcessFile file size error");
-        XFCLOSE(file);
-        return WOLFSSL_BAD_FILE;
-    }
-
-    if (sz > (long)sizeof(staticBuffer)) {
-        WOLFSSL_MSG("Getting dynamic buffer");
-        myBuffer = (byte*)XMALLOC(sz, heapHint, DYNAMIC_TYPE_FILE);
-        if (myBuffer == NULL) {
-            XFCLOSE(file);
-            return WOLFSSL_BAD_FILE;
-        }
-        dynamic = 1;
-    }
-
-    if ((size_t)XFREAD(myBuffer, 1, sz, file) != (size_t)sz)
-        ret = WOLFSSL_BAD_FILE;
-    else {
-        /* Try to detect type by parsing cert header and footer */
-        if (type == DETECT_CERT_TYPE) {
-#ifndef NO_CODING
-            if (wc_PemGetHeaderFooter(CA_TYPE, &header, &footer) == 0 &&
-               (XSTRNSTR((char*)myBuffer, header, (int)sz) != NULL)) {
-                type = CA_TYPE;
-            }
-#ifdef HAVE_CRL
-            else if (wc_PemGetHeaderFooter(CRL_TYPE, &header, &footer) == 0 &&
-                    (XSTRNSTR((char*)myBuffer, header, (int)sz) != NULL)) {
-                type = CRL_TYPE;
-            }
-#endif
-            else if (wc_PemGetHeaderFooter(CERT_TYPE, &header, &footer) == 0 &&
-                    (XSTRNSTR((char*)myBuffer, header, (int)sz) != NULL)) {
-                type = CERT_TYPE;
-            }
-            else
-#endif
-            {
-                WOLFSSL_MSG("Failed to detect certificate type");
-                if (dynamic)
-                    XFREE(myBuffer, heapHint, DYNAMIC_TYPE_FILE);
-                XFCLOSE(file);
-                return WOLFSSL_BAD_CERTTYPE;
-            }
-        }
-        if ((type == CA_TYPE || type == TRUSTED_PEER_TYPE)
-                                          && format == WOLFSSL_FILETYPE_PEM) {
-            ret = ProcessChainBuffer(ctx, myBuffer, sz, format, type, ssl,
-                                     verify);
-        }
-#ifdef HAVE_CRL
-        else if (type == CRL_TYPE)
-            ret = BufferLoadCRL(crl, myBuffer, sz, format, verify);
-#endif
-        else
-            ret = ProcessBuffer(ctx, myBuffer, sz, format, type, ssl, NULL,
-                                userChain, verify);
-    }
-
-    XFCLOSE(file);
-    if (dynamic)
-        XFREE(myBuffer, heapHint, DYNAMIC_TYPE_FILE);
-
-    return ret;
-}
-
-/* loads file then loads each file in path, no c_rehash */
-int wolfSSL_CTX_load_verify_locations_ex(WOLFSSL_CTX* ctx, const char* file,
-                                     const char* path, word32 flags)
-{
-    int ret = WOLFSSL_SUCCESS;
-#ifndef NO_WOLFSSL_DIR
-    int successCount = 0;
-#endif
-    int verify;
-
-    WOLFSSL_MSG("wolfSSL_CTX_load_verify_locations_ex");
-
-    if (ctx == NULL || (file == NULL && path == NULL)) {
-        return WOLFSSL_FAILURE;
-    }
-
-    verify = GET_VERIFY_SETTING_CTX(ctx);
-    if (flags & WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY)
-        verify = VERIFY_SKIP_DATE;
-
-    if (file) {
-        ret = ProcessFile(ctx, file, WOLFSSL_FILETYPE_PEM, CA_TYPE, NULL, 0,
-                          NULL, verify);
-#ifndef NO_WOLFSSL_DIR
-        if (ret == WOLFSSL_SUCCESS)
-            successCount++;
-#endif
-#if defined(WOLFSSL_TRUST_PEER_CERT) && defined(OPENSSL_COMPATIBLE_DEFAULTS)
-        ret = wolfSSL_CTX_trust_peer_cert(ctx, file, WOLFSSL_FILETYPE_PEM);
-        if (ret != WOLFSSL_SUCCESS) {
-            WOLFSSL_MSG("wolfSSL_CTX_trust_peer_cert error");
-        }
-#endif
-    }
-
-    if (ret == WOLFSSL_SUCCESS && path) {
-#ifndef NO_WOLFSSL_DIR
-        char* name = NULL;
-        int fileRet;
-        int failCount = 0;
-    #ifdef WOLFSSL_SMALL_STACK
-        ReadDirCtx* readCtx;
-        readCtx = (ReadDirCtx*)XMALLOC(sizeof(ReadDirCtx), ctx->heap,
-                                                       DYNAMIC_TYPE_DIRCTX);
-        if (readCtx == NULL)
-            return MEMORY_E;
-    #else
-        ReadDirCtx readCtx[1];
-    #endif
-
-        /* try to load each regular file in path */
-        fileRet = wc_ReadDirFirst(readCtx, path, &name);
-        while (fileRet == 0 && name) {
-            WOLFSSL_MSG(name); /* log file name */
-            ret = ProcessFile(ctx, name, WOLFSSL_FILETYPE_PEM, CA_TYPE,
-                              NULL, 0, NULL, verify);
-            if (ret != WOLFSSL_SUCCESS) {
-                /* handle flags for ignoring errors, skipping expired certs or
-                   by PEM certificate header error */
-                if ( (flags & WOLFSSL_LOAD_FLAG_IGNORE_ERR) ||
-                    ((flags & WOLFSSL_LOAD_FLAG_PEM_CA_ONLY) &&
-                       (ret == ASN_NO_PEM_HEADER))) {
-                    /* Do not fail here if a certificate fails to load,
-                       continue to next file */
-                    unsigned long err = 0;
-                    CLEAR_ASN_NO_PEM_HEADER_ERROR(err);
-    #if defined(WOLFSSL_QT)
-                    ret = WOLFSSL_SUCCESS;
-    #endif
-                }
-                else {
-                    WOLFSSL_ERROR(ret);
-                    WOLFSSL_MSG("Load CA file failed, continuing");
-                    failCount++;
-                }
-            }
-            else {
-    #if defined(WOLFSSL_TRUST_PEER_CERT) && defined(OPENSSL_COMPATIBLE_DEFAULTS)
-                ret = wolfSSL_CTX_trust_peer_cert(ctx, file, WOLFSSL_FILETYPE_PEM);
-                if (ret != WOLFSSL_SUCCESS) {
-                    WOLFSSL_MSG("wolfSSL_CTX_trust_peer_cert error. Ignoring"
-                            "this error.");
-                }
-    #endif
-                successCount++;
-            }
-            fileRet = wc_ReadDirNext(readCtx, path, &name);
-        }
-        wc_ReadDirClose(readCtx);
-
-        /* pass directory read failure to response code */
-        if (fileRet != WC_READDIR_NOFILE) {
-            ret = fileRet;
-    #if defined(WOLFSSL_QT) || defined(WOLFSSL_IGNORE_BAD_CERT_PATH)
-            if (ret == BAD_PATH_ERROR &&
-                flags & WOLFSSL_LOAD_FLAG_IGNORE_BAD_PATH_ERR) {
-               /* QSslSocket always loads certs in system folder
-                * when it is initialized.
-                * Compliant with OpenSSL when flag sets.
-                */
-                ret = WOLFSSL_SUCCESS;
-            }
-            else {
-                /* qssl socket wants to know errors. */
-                WOLFSSL_ERROR(ret);
-            }
-    #endif
-        }
-        /* report failure if no files were loaded or there were failures */
-        else if (successCount == 0 || failCount > 0) {
-            /* use existing error code if exists */
-    #if defined(WOLFSSL_QT)
-            /* compliant with OpenSSL when flag sets*/
-            if (!(flags & WOLFSSL_LOAD_FLAG_IGNORE_ZEROFILE))
-    #endif
-            {
-                ret = WOLFSSL_FAILURE;
-            }
-        }
-        else {
-            ret = WOLFSSL_SUCCESS;
-        }
-
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(readCtx, ctx->heap, DYNAMIC_TYPE_DIRCTX);
-    #endif
-#else
-        ret = NOT_COMPILED_IN;
-        (void)flags;
-#endif
-    }
-
-    return ret;
-}
-
-WOLFSSL_ABI
-int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX* ctx, const char* file,
-                                     const char* path)
-{
-    int ret = wolfSSL_CTX_load_verify_locations_ex(ctx, file, path,
-        WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS);
-
-    return WS_RETURN_CODE(ret,WOLFSSL_FAILURE);
-}
-
-#ifdef WOLFSSL_SYS_CA_CERTS
-
-#ifdef USE_WINDOWS_API
-
-static int LoadSystemCaCertsWindows(WOLFSSL_CTX* ctx, byte* loaded)
-{
-    int ret = WOLFSSL_SUCCESS;
-    word32 i;
-    HANDLE handle = NULL;
-    PCCERT_CONTEXT certCtx = NULL;
-    LPCSTR storeNames[2] = {"ROOT", "CA"};
-    HCRYPTPROV_LEGACY hProv = (HCRYPTPROV_LEGACY)NULL;
-
-    if (ctx == NULL || loaded == NULL) {
-        ret = WOLFSSL_FAILURE;
-    }
-
-    for (i = 0; ret == WOLFSSL_SUCCESS &&
-         i < sizeof(storeNames)/sizeof(*storeNames); ++i) {
-        handle = CertOpenSystemStoreA(hProv, storeNames[i]);
-        if (handle != NULL) {
-            while ((certCtx = CertEnumCertificatesInStore(handle, certCtx))
-                   != NULL) {
-                if (certCtx->dwCertEncodingType == X509_ASN_ENCODING) {
-                    if (ProcessBuffer(ctx, certCtx->pbCertEncoded,
-                          certCtx->cbCertEncoded, WOLFSSL_FILETYPE_ASN1,
-                          CA_TYPE, NULL, NULL, 0,
-                          GET_VERIFY_SETTING_CTX(ctx)) == WOLFSSL_SUCCESS) {
-                        /*
-                         * Set "loaded" as long as we've loaded one CA
-                         * cert.
-                         */
-                        *loaded = 1;
-                    }
-                }
-            }
-        }
-        else {
-            WOLFSSL_MSG_EX("Failed to open cert store %s.", storeNames[i]);
-        }
-
-        if (handle != NULL && !CertCloseStore(handle, 0)) {
-            WOLFSSL_MSG_EX("Failed to close cert store %s.", storeNames[i]);
-            ret = WOLFSSL_FAILURE;
-        }
-    }
-
-    return ret;
-}
-
-#elif defined(__APPLE__)
-
-#if defined(HAVE_SECURITY_SECTRUSTSETTINGS_H) \
-  && !defined(WOLFSSL_APPLE_NATIVE_CERT_VALIDATION)
-/*
- * Manually obtains certificates from the system trust store and loads them
- * directly into wolfSSL "the old way".
- *
- * As of MacOS 14.0 we are still able to use this method to access system
- * certificates. Accessibility of this API is indicated by the presence of the
- * Security/SecTrustSettings.h header. In the likely event that Apple removes
- * access to this API on Macs, this function should be removed and the
- * DoAppleNativeCertValidation() routine should be used for all devices.
- */
-static int LoadSystemCaCertsMac(WOLFSSL_CTX* ctx, byte* loaded)
-{
-    int ret = WOLFSSL_SUCCESS;
-    word32 i;
-    const unsigned int trustDomains[] = {
-        kSecTrustSettingsDomainUser,
-        kSecTrustSettingsDomainAdmin,
-        kSecTrustSettingsDomainSystem
-    };
-    CFArrayRef certs;
-    OSStatus stat;
-    CFIndex numCerts;
-    CFDataRef der;
-    CFIndex j;
-
-    if (ctx == NULL || loaded == NULL) {
-        ret = WOLFSSL_FAILURE;
-    }
-
-    for (i = 0; ret == WOLFSSL_SUCCESS &&
-         i < sizeof(trustDomains)/sizeof(*trustDomains); ++i) {
-        stat = SecTrustSettingsCopyCertificates(
-            (SecTrustSettingsDomain)trustDomains[i], &certs);
-        if (stat == errSecSuccess) {
-            numCerts = CFArrayGetCount(certs);
-            for (j = 0; j < numCerts; ++j) {
-                der = SecCertificateCopyData((SecCertificateRef)
-                          CFArrayGetValueAtIndex(certs, j));
-                if (der != NULL) {
-                    if (ProcessBuffer(ctx, CFDataGetBytePtr(der),
-                          CFDataGetLength(der), WOLFSSL_FILETYPE_ASN1,
-                          CA_TYPE, NULL, NULL, 0,
-                          GET_VERIFY_SETTING_CTX(ctx)) == WOLFSSL_SUCCESS) {
-                        /*
-                         * Set "loaded" as long as we've loaded one CA
-                         * cert.
-                         */
-                        *loaded = 1;
-                    }
-
-                    CFRelease(der);
-                }
-            }
-
-            CFRelease(certs);
-        }
-        else if (stat == errSecNoTrustSettings) {
-            WOLFSSL_MSG_EX("No trust settings for domain %d, moving to next "
-                "domain.", trustDomains[i]);
-        }
-        else {
-            WOLFSSL_MSG_EX("SecTrustSettingsCopyCertificates failed with"
-                " status %d.", stat);
-            ret = WOLFSSL_FAILURE;
-            break;
-        }
-    }
-
-    return ret;
-}
-#endif /* defined(HAVE_SECURITY_SECTRUSTSETTINGS_H) */
-
-#else
-
-/* Potential system CA certs directories on Linux/Unix distros. */
-static const char* systemCaDirs[] = {
-#if defined(__ANDROID__) || defined(ANDROID)
-    "/system/etc/security/cacerts"      /* Android */
-#else
-    "/etc/ssl/certs",                   /* Debian, Ubuntu, Gentoo, others */
-    "/etc/pki/ca-trust/source/anchors", /* Fedora, RHEL */
-    "/etc/pki/tls/certs"                /* Older RHEL */
-#endif
-};
-
-const char** wolfSSL_get_system_CA_dirs(word32* num)
-{
-    const char** ret;
-
-    if (num == NULL) {
-        ret = NULL;
-    }
-    else {
-        ret = systemCaDirs;
-        *num = sizeof(systemCaDirs)/sizeof(*systemCaDirs);
-    }
-
-    return ret;
-}
-
-static int LoadSystemCaCertsNix(WOLFSSL_CTX* ctx, byte* loaded) {
-    int ret = WOLFSSL_SUCCESS;
-    word32 i;
-
-    if (ctx == NULL || loaded == NULL) {
-        ret = WOLFSSL_FAILURE;
-    }
-
-    for (i = 0; ret == WOLFSSL_SUCCESS &&
-         i < sizeof(systemCaDirs)/sizeof(*systemCaDirs); ++i) {
-        WOLFSSL_MSG_EX("Attempting to load system CA certs from %s.",
-            systemCaDirs[i]);
-        /*
-         * We want to keep trying to load more CAs even if one cert in
-         * the directory is bad and can't be used (e.g. if one is expired),
-         * so we use WOLFSSL_LOAD_FLAG_IGNORE_ERR.
-         */
-        if (wolfSSL_CTX_load_verify_locations_ex(ctx, NULL, systemCaDirs[i],
-                WOLFSSL_LOAD_FLAG_IGNORE_ERR) != WOLFSSL_SUCCESS) {
-            WOLFSSL_MSG_EX("Failed to load CA certs from %s, trying "
-                "next possible location.", systemCaDirs[i]);
-        }
-        else {
-            WOLFSSL_MSG_EX("Loaded CA certs from %s.",
-                systemCaDirs[i]);
-            *loaded = 1;
-            /* Stop searching after we've loaded one directory. */
-            break;
-        }
-    }
-
-    return ret;
-}
-
-#endif
-
-int wolfSSL_CTX_load_system_CA_certs(WOLFSSL_CTX* ctx)
-{
-    int ret;
-    byte loaded = 0;
-
-    WOLFSSL_ENTER("wolfSSL_CTX_load_system_CA_certs");
-
-#ifdef USE_WINDOWS_API
-
-    ret = LoadSystemCaCertsWindows(ctx, &loaded);
-
-#elif defined(__APPLE__)
-
-#if defined(HAVE_SECURITY_SECTRUSTSETTINGS_H) \
-  && !defined(WOLFSSL_APPLE_NATIVE_CERT_VALIDATION)
-    /* As of MacOS 14.0 we are still able to access system certificates and
-     * load them manually into wolfSSL "the old way". Accessibility of this API
-     * is indicated by the presence of the Security/SecTrustSettings.h header */
-    ret = LoadSystemCaCertsMac(ctx, &loaded);
-#elif defined(WOLFSSL_APPLE_NATIVE_CERT_VALIDATION)
-    /* For other Apple devices, Apple has removed the ability to obtain
-     * certificates from the trust store, so we can't use wolfSSL's built-in
-     * certificate validation mechanisms anymore. We instead must call into the
-     * Security Framework APIs to authenticate peer certificates when received.
-     * (see src/internal.c:DoAppleNativeCertValidation()).
-     * Thus, there is no CA "loading" required, but to keep behavior consistent
-     * with the current API (not using system CA certs unless this function has
-     * been called), we simply set a flag indicating that the new apple trust
-     * verification routine should be used later */
-    ctx->doAppleNativeCertValidationFlag = 1;
-    ret = WOLFSSL_SUCCESS;
-    loaded = 1;
-
-#if FIPS_VERSION_GE(2,0) /* Gate back to cert 3389 FIPS modules */
-#warning "Cryptographic operations may occur outside the FIPS module boundary" \
-         "Please review FIPS claims for cryptography on this Apple device"
-#endif /* FIPS_VERSION_GE(2,0) */
-
-#else
-/* HAVE_SECURITY_SECXXX_H macros are set by autotools or CMake when searching
- * system for the required SDK headers. If building with user_settings.h, you
- * will need to manually define WOLFSSL_APPLE_NATIVE_CERT_VALIDATION
- * and ensure the appropriate Security.framework headers and libraries are
- * visible to your compiler */
-#error "WOLFSSL_SYS_CA_CERTS on Apple devices requires Security.framework" \
-       " header files to be detected, or a manual override with" \
-       " WOLFSSL_APPLE_NATIVE_CERT_VALIDATION"
-#endif
-
-#else
-
-    ret = LoadSystemCaCertsNix(ctx, &loaded);
-
-#endif
-
-    if (ret == WOLFSSL_SUCCESS && !loaded) {
-        ret = WOLFSSL_BAD_PATH;
-    }
-
-    WOLFSSL_LEAVE("wolfSSL_CTX_load_system_CA_certs", ret);
-
-    return ret;
-}
-
-#endif /* WOLFSSL_SYS_CA_CERTS */
-
-#ifdef WOLFSSL_TRUST_PEER_CERT
-/* Used to specify a peer cert to match when connecting
-    ctx : the ctx structure to load in peer cert
-    file: the string name of cert file
-    type: type of format such as PEM/DER
- */
-int wolfSSL_CTX_trust_peer_cert(WOLFSSL_CTX* ctx, const char* file, int type)
-{
-    WOLFSSL_ENTER("wolfSSL_CTX_trust_peer_cert");
-
-    if (ctx == NULL || file == NULL) {
-        return WOLFSSL_FAILURE;
-    }
-
-    return ProcessFile(ctx, file, type, TRUSTED_PEER_TYPE, NULL, 0, NULL,
-                       GET_VERIFY_SETTING_CTX(ctx));
-}
-
-int wolfSSL_trust_peer_cert(WOLFSSL* ssl, const char* file, int type)
-{
-    WOLFSSL_ENTER("wolfSSL_trust_peer_cert");
-
-    if (ssl == NULL || file == NULL) {
-        return WOLFSSL_FAILURE;
-    }
-
-    return ProcessFile(NULL, file, type, TRUSTED_PEER_TYPE, ssl, 0, NULL,
-                       GET_VERIFY_SETTING_SSL(ssl));
-}
-#endif /* WOLFSSL_TRUST_PEER_CERT */
-
-#endif /* NO_FILESYSTEM */
 
 #ifdef HAVE_CRL
 
@@ -8894,7 +5920,6 @@ int wolfSSL_LoadCRLFile(WOLFSSL* ssl, const char* file, int type)
         return BAD_FUNC_ARG;
 }
 #endif
-
 
 int wolfSSL_SetCRL_Cb(WOLFSSL* ssl, CbMissingCRL cb)
 {
@@ -8987,77 +6012,6 @@ int wolfSSL_CTX_SetCRL_IOCb(WOLFSSL_CTX* ctx, CbCrlIO cb)
 #endif /* HAVE_CRL */
 
 
-#ifndef NO_FILESYSTEM
-
-
-#ifdef WOLFSSL_DER_LOAD
-
-/* Add format parameter to allow DER load of CA files */
-int wolfSSL_CTX_der_load_verify_locations(WOLFSSL_CTX* ctx, const char* file,
-                                          int format)
-{
-    WOLFSSL_ENTER("wolfSSL_CTX_der_load_verify_locations");
-    if (ctx == NULL || file == NULL)
-        return WOLFSSL_FAILURE;
-
-    if (ProcessFile(ctx, file, format, CA_TYPE, NULL, 0, NULL,
-                    GET_VERIFY_SETTING_CTX(ctx)) == WOLFSSL_SUCCESS) {
-        return WOLFSSL_SUCCESS;
-    }
-
-    return WOLFSSL_FAILURE;
-}
-
-#endif /* WOLFSSL_DER_LOAD */
-
-
-
-WOLFSSL_ABI
-int wolfSSL_CTX_use_certificate_file(WOLFSSL_CTX* ctx, const char* file,
-                                     int format)
-{
-    WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_file");
-
-    if (ProcessFile(ctx, file, format, CERT_TYPE, NULL, 0, NULL,
-                    GET_VERIFY_SETTING_CTX(ctx)) == WOLFSSL_SUCCESS) {
-        return WOLFSSL_SUCCESS;
-    }
-
-    return WOLFSSL_FAILURE;
-}
-
-
-WOLFSSL_ABI
-int wolfSSL_CTX_use_PrivateKey_file(WOLFSSL_CTX* ctx, const char* file,
-                                    int format)
-{
-    WOLFSSL_ENTER("wolfSSL_CTX_use_PrivateKey_file");
-
-    if (ProcessFile(ctx, file, format, PRIVATEKEY_TYPE, NULL, 0, NULL,
-                    GET_VERIFY_SETTING_CTX(ctx)) == WOLFSSL_SUCCESS) {
-        return WOLFSSL_SUCCESS;
-    }
-
-    return WOLFSSL_FAILURE;
-}
-
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-int wolfSSL_CTX_use_AltPrivateKey_file(WOLFSSL_CTX* ctx, const char* file,
-                                       int format)
-{
-    WOLFSSL_ENTER("wolfSSL_CTX_use_AltPrivateKey_file");
-
-    if (ProcessFile(ctx, file, format, ALT_PRIVATEKEY_TYPE, NULL, 0, NULL,
-                    GET_VERIFY_SETTING_CTX(ctx)) == WOLFSSL_SUCCESS) {
-        return WOLFSSL_SUCCESS;
-    }
-
-    return WOLFSSL_FAILURE;
-}
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-#endif /* NO_FILESYSTEM */
-
-
 /* Sets the max chain depth when verifying a certificate chain. Default depth
  * is set to MAX_CHAIN_DEPTH.
  *
@@ -9103,131 +6057,135 @@ long wolfSSL_CTX_get_verify_depth(WOLFSSL_CTX* ctx)
 #endif
 }
 
+#ifndef NO_CHECK_PRIVATE_KEY
 
-#ifndef NO_FILESYSTEM
-
-
-WOLFSSL_ABI
-int wolfSSL_CTX_use_certificate_chain_file(WOLFSSL_CTX* ctx, const char* file)
+#ifdef WOLF_PRIVATE_KEY_ID
+/* Check private against public in certificate for match using external
+ * device with given devId */
+static int check_cert_key_dev(word32 keyOID, byte* privKey, word32 privSz,
+    const byte* pubKey, word32 pubSz, int label, int id, void* heap, int devId)
 {
-    /* process up to MAX_CHAIN_DEPTH plus subject cert */
-    WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_chain_file");
+    int ret = 0;
+    int type = 0;
+    void *pkey = NULL;
 
-    if (ProcessFile(ctx, file, WOLFSSL_FILETYPE_PEM, CERT_TYPE, NULL, 1, NULL,
-                    GET_VERIFY_SETTING_CTX(ctx)) == WOLFSSL_SUCCESS) {
-        return WOLFSSL_SUCCESS;
+    if (privKey == NULL) {
+        return MISSING_KEY;
     }
 
-   return WOLFSSL_FAILURE;
-}
-
-
-int wolfSSL_CTX_use_certificate_chain_file_format(WOLFSSL_CTX* ctx,
-                                                  const char* file, int format)
-{
-    /* process up to MAX_CHAIN_DEPTH plus subject cert */
-    WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_chain_file_format");
-
-    if (ProcessFile(ctx, file, format, CERT_TYPE, NULL, 1, NULL,
-                    GET_VERIFY_SETTING_CTX(ctx)) == WOLFSSL_SUCCESS) {
-        return WOLFSSL_SUCCESS;
+#ifndef NO_RSA
+    if (keyOID == RSAk) {
+        type = DYNAMIC_TYPE_RSA;
     }
-
-   return WOLFSSL_FAILURE;
-}
-
-
-#ifndef NO_DH
-
-/* server Diffie-Hellman parameters */
-static int wolfSSL_SetTmpDH_file_wrapper(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
-                                        const char* fname, int format)
-{
-#ifdef WOLFSSL_SMALL_STACK
-    byte   staticBuffer[1]; /* force heap usage */
-#else
-    byte   staticBuffer[FILE_BUFFER_SIZE];
+#ifdef WC_RSA_PSS
+    if (keyOID == RSAPSSk) {
+        type = DYNAMIC_TYPE_RSA;
+    }
 #endif
-    byte*  myBuffer = staticBuffer;
-    int    dynamic = 0;
-    int    ret;
-    long   sz = 0;
-    XFILE  file;
-
-    if (ctx == NULL || fname == NULL)
-        return BAD_FUNC_ARG;
-
-    file = XFOPEN(fname, "rb");
-    if (file == XBADFILE) return WOLFSSL_BAD_FILE;
-    if(XFSEEK(file, 0, XSEEK_END) != 0) {
-        XFCLOSE(file);
-        return WOLFSSL_BAD_FILE;
+#endif
+#ifdef HAVE_ECC
+    if (keyOID == ECDSAk) {
+        type = DYNAMIC_TYPE_ECC;
     }
-    sz = XFTELL(file);
-    if(XFSEEK(file, 0, XSEEK_SET) != 0) {
-        XFCLOSE(file);
-        return WOLFSSL_BAD_FILE;
+#endif
+#if defined(HAVE_DILITHIUM)
+    if ((keyOID == DILITHIUM_LEVEL2k) ||
+        (keyOID == DILITHIUM_LEVEL3k) ||
+        (keyOID == DILITHIUM_LEVEL5k)) {
+        type = DYNAMIC_TYPE_DILITHIUM;
     }
-
-    if (sz > MAX_WOLFSSL_FILE_SIZE || sz <= 0) {
-        WOLFSSL_MSG("SetTmpDH file size error");
-        XFCLOSE(file);
-        return WOLFSSL_BAD_FILE;
+#endif
+#if defined(HAVE_FALCON)
+    if ((keyOID == FALCON_LEVEL1k) ||
+        (keyOID == FALCON_LEVEL5k)) {
+        type = DYNAMIC_TYPE_FALCON;
     }
+#endif
 
-    if (sz > (long)sizeof(staticBuffer)) {
-        WOLFSSL_MSG("Getting dynamic buffer");
-        myBuffer = (byte*) XMALLOC(sz, ctx->heap, DYNAMIC_TYPE_FILE);
-        if (myBuffer == NULL) {
-            XFCLOSE(file);
-            return WOLFSSL_BAD_FILE;
+    ret = CreateDevPrivateKey(&pkey, privKey, privSz, type, label, id,
+                              heap, devId);
+    #ifdef WOLF_CRYPTO_CB
+    if (ret == 0) {
+        #ifndef NO_RSA
+        if (keyOID == RSAk
+        #ifdef WC_RSA_PSS
+            || keyOID == RSAPSSk
+        #endif
+            ) {
+            ret = wc_CryptoCb_RsaCheckPrivKey((RsaKey*)pkey, pubKey, pubSz);
         }
-        dynamic = 1;
+        #endif
+        #ifdef HAVE_ECC
+        if (keyOID == ECDSAk) {
+            ret = wc_CryptoCb_EccCheckPrivKey((ecc_key*)pkey, pubKey, pubSz);
+        }
+        #endif
+        #if defined(HAVE_DILITHIUM)
+        if ((keyOID == DILITHIUM_LEVEL2k) ||
+            (keyOID == DILITHIUM_LEVEL3k) ||
+            (keyOID == DILITHIUM_LEVEL5k)) {
+            ret = wc_CryptoCb_PqcSignatureCheckPrivKey(pkey,
+                                        WC_PQC_SIG_TYPE_DILITHIUM,
+                                        pubKey, pubSz);
+        }
+        #endif
+        #if defined(HAVE_FALCON)
+        if ((keyOID == FALCON_LEVEL1k) ||
+            (keyOID == FALCON_LEVEL5k)) {
+            ret = wc_CryptoCb_PqcSignatureCheckPrivKey(pkey,
+                                        WC_PQC_SIG_TYPE_FALCON,
+                                        pubKey, pubSz);
+        }
+        #endif
     }
-
-    if ((size_t)XFREAD(myBuffer, 1, sz, file) != (size_t)sz)
-        ret = WOLFSSL_BAD_FILE;
-    else {
-        if (ssl)
-            ret = wolfSSL_SetTmpDH_buffer(ssl, myBuffer, sz, format);
-        else
-            ret = wolfSSL_CTX_SetTmpDH_buffer(ctx, myBuffer, sz, format);
+    #else
+        /* devId was set, don't check, for now */
+        /* TODO: Add callback for private key check? */
+        (void) pubKey;
+        (void) pubSz;
+    #endif
+    if (pkey != NULL) {
+    #ifndef NO_RSA
+        if (keyOID == RSAk
+        #ifdef WC_RSA_PSS
+            || keyOID == RSAPSSk
+        #endif
+            ) {
+            wc_FreeRsaKey((RsaKey*)pkey);
+        }
+    #endif
+    #ifdef HAVE_ECC
+        if (keyOID == ECDSAk) {
+            wc_ecc_free((ecc_key*)pkey);
+        }
+    #endif
+    #if defined(HAVE_DILITHIUM)
+        if ((keyOID == DILITHIUM_LEVEL2k) ||
+            (keyOID == DILITHIUM_LEVEL3k) ||
+            (keyOID == DILITHIUM_LEVEL5k)) {
+            wc_dilithium_free((dilithium_key*)pkey);
+        }
+    #endif
+    #if defined(HAVE_FALCON)
+        if ((keyOID == FALCON_LEVEL1k) ||
+            (keyOID == FALCON_LEVEL5k)) {
+            wc_falcon_free((falcon_key*)pkey);
+        }
+    #endif
+        XFREE(pkey, heap, type);
     }
-
-    XFCLOSE(file);
-    if (dynamic)
-        XFREE(myBuffer, ctx->heap, DYNAMIC_TYPE_FILE);
 
     return ret;
 }
+#endif /* WOLF_PRIVATE_KEY_ID */
 
-/* server Diffie-Hellman parameters */
-int wolfSSL_SetTmpDH_file(WOLFSSL* ssl, const char* fname, int format)
-{
-    if (ssl == NULL)
-        return BAD_FUNC_ARG;
-
-    return wolfSSL_SetTmpDH_file_wrapper(ssl->ctx, ssl, fname, format);
-}
-
-
-/* server Diffie-Hellman parameters */
-int wolfSSL_CTX_SetTmpDH_file(WOLFSSL_CTX* ctx, const char* fname, int format)
-{
-    return wolfSSL_SetTmpDH_file_wrapper(ctx, NULL, fname, format);
-}
-
-#endif /* NO_DH */
-
-#endif /* NO_FILESYSTEM */
-
-#ifndef NO_CHECK_PRIVATE_KEY
 /* Check private against public in certificate for match
  *
  * Returns WOLFSSL_SUCCESS on good private key
  *         WOLFSSL_FAILURE if mismatched */
-static int check_cert_key(DerBuffer* cert, DerBuffer* key, void* heap,
-    int devId, int isKeyLabel, int isKeyId)
+static int check_cert_key(DerBuffer* cert, DerBuffer* key, DerBuffer* altKey,
+    void* heap, int devId, int isKeyLabel, int isKeyId, int altDevId,
+    int isAltKeyLabel, int isAltKeyId)
 {
 #ifdef WOLFSSL_SMALL_STACK
     DecodedCert* der = NULL;
@@ -9245,7 +6203,7 @@ static int check_cert_key(DerBuffer* cert, DerBuffer* key, void* heap,
     }
 
 #ifdef WOLFSSL_SMALL_STACK
-    der = (DecodedCert*)XMALLOC(sizeof(DecodedCert), NULL, DYNAMIC_TYPE_DCERT);
+    der = (DecodedCert*)XMALLOC(sizeof(DecodedCert), heap, DYNAMIC_TYPE_DCERT);
     if (der == NULL)
         return MEMORY_E;
 #endif
@@ -9253,10 +6211,10 @@ static int check_cert_key(DerBuffer* cert, DerBuffer* key, void* heap,
     size = cert->length;
     buff = cert->buffer;
     InitDecodedCert_ex(der, buff, size, heap, devId);
-    if (ParseCertRelative(der, CERT_TYPE, NO_VERIFY, NULL) != 0) {
+    if (ParseCertRelative(der, CERT_TYPE, NO_VERIFY, NULL, NULL) != 0) {
         FreeDecodedCert(der);
     #ifdef WOLFSSL_SMALL_STACK
-        XFREE(der, NULL, DYNAMIC_TYPE_DCERT);
+        XFREE(der, heap, DYNAMIC_TYPE_DCERT);
     #endif
         return WOLFSSL_FAILURE;
     }
@@ -9265,111 +6223,10 @@ static int check_cert_key(DerBuffer* cert, DerBuffer* key, void* heap,
     buff = key->buffer;
 #ifdef WOLF_PRIVATE_KEY_ID
     if (devId != INVALID_DEVID) {
-        int type = 0;
-        void *pkey = NULL;
-
-    #ifndef NO_RSA
-        if (der->keyOID == RSAk) {
-            type = DYNAMIC_TYPE_RSA;
-        }
-    #ifdef WC_RSA_PSS
-        if (der->keyOID == RSAPSSk) {
-            type = DYNAMIC_TYPE_RSA;
-        }
-    #endif
-    #endif
-    #ifdef HAVE_ECC
-        if (der->keyOID == ECDSAk) {
-            type = DYNAMIC_TYPE_ECC;
-        }
-    #endif
-    #if defined(HAVE_PQC) && defined(HAVE_DILITHIUM)
-        if ((der->keyOID == DILITHIUM_LEVEL2k) ||
-            (der->keyOID == DILITHIUM_LEVEL3k) ||
-            (der->keyOID == DILITHIUM_LEVEL5k)) {
-            type = DYNAMIC_TYPE_DILITHIUM;
-        }
-    #endif
-    #if defined(HAVE_PQC) && defined(HAVE_FALCON)
-        if ((der->keyOID == FALCON_LEVEL1k) ||
-            (der->keyOID == FALCON_LEVEL5k)) {
-            type = DYNAMIC_TYPE_FALCON;
-        }
-    #endif
-
-        ret = CreateDevPrivateKey(&pkey, buff, size, type,
-                                  isKeyLabel, isKeyId, heap, devId);
-        #ifdef WOLF_CRYPTO_CB
-        if (ret == 0) {
-            #ifndef NO_RSA
-            if (der->keyOID == RSAk
-            #ifdef WC_RSA_PSS
-                || der->keyOID == RSAPSSk
-            #endif
-                ) {
-                ret = wc_CryptoCb_RsaCheckPrivKey((RsaKey*)pkey,
-                                               der->publicKey, der->pubKeySize);
-            }
-            #endif
-            #ifdef HAVE_ECC
-            if (der->keyOID == ECDSAk) {
-                ret = wc_CryptoCb_EccCheckPrivKey((ecc_key*)pkey,
-                                               der->publicKey, der->pubKeySize);
-            }
-            #endif
-            #if defined(HAVE_PQC) && defined(HAVE_DILITHIUM)
-            if ((der->keyOID == DILITHIUM_LEVEL2k) ||
-                (der->keyOID == DILITHIUM_LEVEL3k) ||
-                (der->keyOID == DILITHIUM_LEVEL5k)) {
-                ret = wc_CryptoCb_PqcSignatureCheckPrivKey(pkey,
-                                            WC_PQC_SIG_TYPE_DILITHIUM,
-                                            der->publicKey, der->pubKeySize);
-            }
-            #endif
-            #if defined(HAVE_PQC) && defined(HAVE_FALCON)
-            if ((der->keyOID == FALCON_LEVEL1k) ||
-                (der->keyOID == FALCON_LEVEL5k)) {
-                ret = wc_CryptoCb_PqcSignatureCheckPrivKey(pkey,
-                                            WC_PQC_SIG_TYPE_FALCON,
-                                            der->publicKey, der->pubKeySize);
-            }
-            #endif
-        }
-        #else
-            /* devId was set, don't check, for now */
-            /* TODO: Add callback for private key check? */
-        #endif
-        if (pkey != NULL) {
-        #ifndef NO_RSA
-            if (der->keyOID == RSAk
-            #ifdef WC_RSA_PSS
-                || der->keyOID == RSAPSSk
-            #endif
-                ) {
-                wc_FreeRsaKey((RsaKey*)pkey);
-            }
-        #endif
-        #ifdef HAVE_ECC
-            if (der->keyOID == ECDSAk) {
-                wc_ecc_free((ecc_key*)pkey);
-            }
-        #endif
-        #if defined(HAVE_PQC) && defined(HAVE_DILITHIUM)
-            if ((der->keyOID == DILITHIUM_LEVEL2k) ||
-                (der->keyOID == DILITHIUM_LEVEL3k) ||
-                (der->keyOID == DILITHIUM_LEVEL5k)) {
-                wc_dilithium_free((dilithium_key*)pkey);
-            }
-        #endif
-        #if defined(HAVE_PQC) && defined(HAVE_FALCON)
-            if ((der->keyOID == FALCON_LEVEL1k) ||
-                (der->keyOID == FALCON_LEVEL5k)) {
-                wc_falcon_free((falcon_key*)pkey);
-            }
-        #endif
-            XFREE(pkey, heap, type);
-        }
-        if (ret != CRYPTOCB_UNAVAILABLE) {
+        ret = check_cert_key_dev(der->keyOID, buff, size, der->publicKey,
+                                 der->pubKeySize, isKeyLabel, isKeyId, heap,
+                                 devId);
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
             ret = (ret == 0) ? WOLFSSL_SUCCESS: WOLFSSL_FAILURE;
         }
     }
@@ -9378,20 +6235,86 @@ static int check_cert_key(DerBuffer* cert, DerBuffer* key, void* heap,
         ret = CRYPTOCB_UNAVAILABLE;
     }
 
-    if (ret == CRYPTOCB_UNAVAILABLE)
+    if (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
 #endif /* WOLF_PRIVATE_KEY_ID */
     {
-        ret = wc_CheckPrivateKeyCert(buff, size, der);
+        ret = wc_CheckPrivateKeyCert(buff, size, der, 0);
         ret = (ret == 1) ? WOLFSSL_SUCCESS: WOLFSSL_FAILURE;
     }
+
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+    if (ret == WOLFSSL_SUCCESS && der->extSapkiSet && der->sapkiDer != NULL) {
+        /* Certificate contains an alternative public key. Hence, we also
+         * need an alternative private key. */
+        if (altKey == NULL) {
+            ret = MISSING_KEY;
+            buff = NULL;
+            size = 0;
+        }
+        else {
+            size = altKey->length;
+            buff = altKey->buffer;
+        }
+#ifdef WOLF_PRIVATE_KEY_ID
+        if (ret == WOLFSSL_SUCCESS && altDevId != INVALID_DEVID) {
+            /* We have to decode the public key first */
+            word32 idx = 0;
+            /* Dilithium has the largest public key at the moment */
+            word32 pubKeyLen = DILITHIUM_MAX_PUB_KEY_SIZE;
+            byte* decodedPubKey = (byte*)XMALLOC(pubKeyLen, heap,
+                                            DYNAMIC_TYPE_PUBLIC_KEY);
+            if (decodedPubKey == NULL) {
+                ret = MEMORY_E;
+            }
+            if (ret == WOLFSSL_SUCCESS) {
+                if (der->sapkiOID == RSAk || der->sapkiOID == ECDSAk) {
+                    /* Simply copy the data */
+                    XMEMCPY(decodedPubKey, der->sapkiDer, der->sapkiLen);
+                    pubKeyLen = der->sapkiLen;
+                    ret = 0;
+                }
+                else {
+                    ret = DecodeAsymKeyPublic(der->sapkiDer, &idx,
+                                              der->sapkiLen, decodedPubKey,
+                                              &pubKeyLen, der->sapkiOID);
+                }
+            }
+            if (ret == 0) {
+                ret = check_cert_key_dev(der->sapkiOID, buff, size,
+                                         decodedPubKey, pubKeyLen,
+                                         isAltKeyLabel, isAltKeyId,
+                                         heap, altDevId);
+            }
+            XFREE(decodedPubKey, heap, DYNAMIC_TYPE_PUBLIC_KEY);
+            if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
+                ret = (ret == 0) ? WOLFSSL_SUCCESS: WOLFSSL_FAILURE;
+            }
+        }
+        else {
+            /* fall through if unavailable */
+            ret = CRYPTOCB_UNAVAILABLE;
+        }
+
+        if (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
+#endif /* WOLF_PRIVATE_KEY_ID */
+        {
+            ret = wc_CheckPrivateKeyCert(buff, size, der, 1);
+            ret = (ret == 1) ? WOLFSSL_SUCCESS: WOLFSSL_FAILURE;
+        }
+    }
+#endif /* WOLFSSL_DUAL_ALG_CERTS */
     FreeDecodedCert(der);
 #ifdef WOLFSSL_SMALL_STACK
-    XFREE(der, NULL, DYNAMIC_TYPE_DCERT);
+    XFREE(der, heap, DYNAMIC_TYPE_DCERT);
 #endif
 
     (void)devId;
     (void)isKeyLabel;
     (void)isKeyId;
+    (void)altKey;
+    (void)altDevId;
+    (void)isAltKeyLabel;
+    (void)isAltKeyId;
 
     return ret;
 }
@@ -9404,11 +6327,54 @@ static int check_cert_key(DerBuffer* cert, DerBuffer* key, void* heap,
  *         WOLFSSL_FAILURE if mismatched. */
 int wolfSSL_CTX_check_private_key(const WOLFSSL_CTX* ctx)
 {
+    int res;
+
     if (ctx == NULL) {
         return WOLFSSL_FAILURE;
     }
-    return check_cert_key(ctx->certificate, ctx->privateKey, ctx->heap,
-        ctx->privateKeyDevId, ctx->privateKeyLabel, ctx->privateKeyId);
+
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    wolfssl_priv_der_unblind(ctx->privateKey, ctx->privateKeyMask);
+    wolfssl_priv_der_unblind(ctx->altPrivateKey, ctx->altPrivateKeyMask);
+#endif
+    res = check_cert_key(ctx->certificate, ctx->privateKey, ctx->altPrivateKey,
+            ctx->heap, ctx->privateKeyDevId, ctx->privateKeyLabel,
+            ctx->privateKeyId, ctx->altPrivateKeyDevId, ctx->altPrivateKeyLabel,
+            ctx->altPrivateKeyId) != 0;
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    {
+        int ret;
+        ret = wolfssl_priv_der_blind(NULL, ctx->privateKey,
+            (DerBuffer**)&ctx->privateKeyMask);
+        if (ret == 0) {
+            ret = wolfssl_priv_der_blind(NULL, ctx->altPrivateKey,
+                (DerBuffer**)&ctx->altPrivateKeyMask);
+        }
+        if (ret != 0) {
+            res = WOLFSSL_FAILURE;
+        }
+    }
+#endif
+#else
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    wolfssl_priv_der_unblind(ctx->privateKey, ctx->privateKeyMask);
+#endif
+    res = check_cert_key(ctx->certificate, ctx->privateKey, NULL, ctx->heap,
+            ctx->privateKeyDevId, ctx->privateKeyLabel, ctx->privateKeyId,
+            INVALID_DEVID, 0, 0);
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    {
+        int ret = wolfssl_priv_der_blind(NULL, ctx->privateKey,
+            (DerBuffer**)&ctx->privateKeyMask);
+        if (ret != 0) {
+            res = WOLFSSL_FAILURE;
+        }
+    }
+#endif
+#endif
+
+    return res;
 }
 #endif /* !NO_CHECK_PRIVATE_KEY */
 
@@ -9419,6 +6385,7 @@ int wolfSSL_CTX_check_private_key(const WOLFSSL_CTX* ctx)
  */
 WOLFSSL_EVP_PKEY* wolfSSL_CTX_get0_privatekey(const WOLFSSL_CTX* ctx)
 {
+    WOLFSSL_EVP_PKEY* res;
     const unsigned char *key;
     int type;
 
@@ -9455,24 +6422,634 @@ WOLFSSL_EVP_PKEY* wolfSSL_CTX_get0_privatekey(const WOLFSSL_CTX* ctx)
 
     key = ctx->privateKey->buffer;
 
-    if (ctx->privateKeyPKey != NULL)
-        return ctx->privateKeyPKey;
-    else
-        return wolfSSL_d2i_PrivateKey(type,
+    if (ctx->privateKeyPKey != NULL) {
+        res = ctx->privateKeyPKey;
+    }
+    else {
+    #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+        wolfssl_priv_der_unblind(ctx->privateKey, ctx->privateKeyMask);
+    #endif
+        res = wolfSSL_d2i_PrivateKey(type,
                 (WOLFSSL_EVP_PKEY**)&ctx->privateKeyPKey, &key,
                 (long)ctx->privateKey->length);
+    #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+        wolfssl_priv_der_unblind(ctx->privateKey, ctx->privateKeyMask);
+    #endif
+    }
+
+    return res;
 }
 #endif
 
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
 
+#if !defined(NO_RSA)
+static int d2iTryRsaKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
+    long memSz, int priv)
+{
+    WOLFSSL_EVP_PKEY* pkey;
+    word32 keyIdx = 0;
+    int isRsaKey;
+    int ret = 1;
+#ifndef WOLFSSL_SMALL_STACK
+    RsaKey rsa[1];
+#else
+    RsaKey *rsa = (RsaKey*)XMALLOC(sizeof(RsaKey), NULL, DYNAMIC_TYPE_RSA);
+    if (rsa == NULL)
+        return 0;
+#endif
+
+    XMEMSET(rsa, 0, sizeof(RsaKey));
+
+    if (wc_InitRsaKey(rsa, NULL) != 0) {
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(rsa, NULL, DYNAMIC_TYPE_RSA);
+    #endif
+        return 0;
+    }
+    /* test if RSA key */
+    if (priv) {
+        isRsaKey =
+            (wc_RsaPrivateKeyDecode(mem, &keyIdx, rsa, (word32)memSz) == 0);
+    }
+    else {
+        isRsaKey =
+            (wc_RsaPublicKeyDecode(mem, &keyIdx, rsa, (word32)memSz) == 0);
+    }
+    wc_FreeRsaKey(rsa);
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(rsa, NULL, DYNAMIC_TYPE_RSA);
+#endif
+
+    if (!isRsaKey) {
+        return -1;
+    }
+
+    if (*out != NULL) {
+        pkey = *out;
+    }
+    else {
+        pkey = wolfSSL_EVP_PKEY_new();
+        if (pkey == NULL) {
+            WOLFSSL_MSG("RSA wolfSSL_EVP_PKEY_new error");
+            return 0;
+        }
+    }
+
+    pkey->pkey_sz = (int)keyIdx;
+    pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
+            priv ? DYNAMIC_TYPE_PRIVATE_KEY :
+                   DYNAMIC_TYPE_PUBLIC_KEY);
+    if (pkey->pkey.ptr == NULL) {
+        ret = 0;
+    }
+    if (ret == 1) {
+        XMEMCPY(pkey->pkey.ptr, mem, keyIdx);
+        pkey->type = EVP_PKEY_RSA;
+
+        pkey->ownRsa = 1;
+        pkey->rsa = wolfssl_rsa_d2i(NULL, mem, memSz,
+            priv ? WOLFSSL_RSA_LOAD_PRIVATE : WOLFSSL_RSA_LOAD_PUBLIC);
+        if (pkey->rsa == NULL) {
+            ret = 0;
+        }
+    }
+
+    if (ret == 1) {
+        *out = pkey;
+    }
+
+    if ((ret == 0) && (*out == NULL)) {
+        wolfSSL_EVP_PKEY_free(pkey);
+    }
+    return ret;
+}
+#endif /* !NO_RSA */
+
+#if defined(HAVE_ECC) && defined(OPENSSL_EXTRA)
+static int d2iTryEccKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
+    long memSz, int priv)
+{
+    WOLFSSL_EVP_PKEY* pkey;
+    word32  keyIdx = 0;
+    int     isEccKey;
+    int     ret = 1;
+#ifndef WOLFSSL_SMALL_STACK
+    ecc_key ecc[1];
+#else
+    ecc_key *ecc = (ecc_key*)XMALLOC(sizeof(ecc_key), NULL,
+        DYNAMIC_TYPE_ECC);
+    if (ecc == NULL)
+        return 0;
+#endif
+
+    XMEMSET(ecc, 0, sizeof(ecc_key));
+
+    if (wc_ecc_init(ecc) != 0) {
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(ecc, NULL, DYNAMIC_TYPE_ECC);
+    #endif
+        return 0;
+    }
+
+    if (priv) {
+        isEccKey =
+            (wc_EccPrivateKeyDecode(mem, &keyIdx, ecc, (word32)memSz) == 0);
+    }
+    else {
+        isEccKey =
+            (wc_EccPublicKeyDecode(mem, &keyIdx, ecc, (word32)memSz) == 0);
+    }
+    wc_ecc_free(ecc);
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(ecc, NULL, DYNAMIC_TYPE_ECC);
+#endif
+
+    if (!isEccKey) {
+        return -1;
+    }
+
+    if (*out != NULL) {
+        pkey = *out;
+    }
+    else {
+        pkey = wolfSSL_EVP_PKEY_new();
+        if (pkey == NULL) {
+            WOLFSSL_MSG("ECC wolfSSL_EVP_PKEY_new error");
+            return 0;
+        }
+    }
+
+    pkey->pkey_sz = (int)keyIdx;
+    pkey->pkey.ptr = (char*)XMALLOC(keyIdx, NULL,
+            priv ? DYNAMIC_TYPE_PRIVATE_KEY :
+                   DYNAMIC_TYPE_PUBLIC_KEY);
+    if (pkey->pkey.ptr == NULL) {
+        ret = 0;
+    }
+    if (ret == 1) {
+        XMEMCPY(pkey->pkey.ptr, mem, keyIdx);
+        pkey->type = EVP_PKEY_EC;
+
+        pkey->ownEcc = 1;
+        pkey->ecc = wolfSSL_EC_KEY_new();
+        if (pkey->ecc == NULL) {
+            ret = 0;
+        }
+    }
+    if ((ret == 1) && (wolfSSL_EC_KEY_LoadDer_ex(pkey->ecc,
+            (const unsigned char*)pkey->pkey.ptr,
+            pkey->pkey_sz, priv ? WOLFSSL_RSA_LOAD_PRIVATE
+                                : WOLFSSL_RSA_LOAD_PUBLIC) != 1)) {
+        ret = 0;
+    }
+    if (ret == 1) {
+        *out = pkey;
+    }
+
+    if ((ret == 0) && (*out == NULL)) {
+        wolfSSL_EVP_PKEY_free(pkey);
+    }
+    return ret;
+}
+#endif /* HAVE_ECC && OPENSSL_EXTRA */
+
+#if !defined(NO_DSA)
+static int d2iTryDsaKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
+    long memSz, int priv)
+{
+    WOLFSSL_EVP_PKEY* pkey;
+    word32 keyIdx = 0;
+    int     isDsaKey;
+    int     ret = 1;
+#ifndef WOLFSSL_SMALL_STACK
+    DsaKey dsa[1];
+#else
+    DsaKey *dsa = (DsaKey*)XMALLOC(sizeof(DsaKey), NULL, DYNAMIC_TYPE_DSA);
+    if (dsa == NULL)
+        return 0;
+#endif
+
+    XMEMSET(dsa, 0, sizeof(DsaKey));
+
+    if (wc_InitDsaKey(dsa) != 0) {
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(dsa, NULL, DYNAMIC_TYPE_DSA);
+    #endif
+        return 0;
+    }
+
+    if (priv) {
+        isDsaKey =
+            (wc_DsaPrivateKeyDecode(mem, &keyIdx, dsa, (word32)memSz) == 0);
+    }
+    else {
+        isDsaKey =
+            (wc_DsaPublicKeyDecode(mem, &keyIdx, dsa, (word32)memSz) == 0);
+    }
+    wc_FreeDsaKey(dsa);
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(dsa, NULL, DYNAMIC_TYPE_DSA);
+#endif
+
+    /* test if DSA key */
+    if (!isDsaKey) {
+        return -1;
+    }
+
+    if (*out != NULL) {
+        pkey = *out;
+    }
+    else {
+        pkey = wolfSSL_EVP_PKEY_new();
+        if (pkey == NULL) {
+            WOLFSSL_MSG("DSA wolfSSL_EVP_PKEY_new error");
+            return 0;
+        }
+    }
+
+    pkey->pkey_sz = (int)keyIdx;
+    pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
+            priv ? DYNAMIC_TYPE_PRIVATE_KEY :
+                   DYNAMIC_TYPE_PUBLIC_KEY);
+    if (pkey->pkey.ptr == NULL) {
+        ret = 0;
+    }
+    if (ret == 1) {
+        XMEMCPY(pkey->pkey.ptr, mem, keyIdx);
+        pkey->type = EVP_PKEY_DSA;
+
+        pkey->ownDsa = 1;
+        pkey->dsa = wolfSSL_DSA_new();
+        if (pkey->dsa == NULL) {
+            ret = 0;
+        }
+    }
+
+    if ((ret == 1) && (wolfSSL_DSA_LoadDer_ex(pkey->dsa,
+            (const unsigned char*)pkey->pkey.ptr,
+            pkey->pkey_sz, priv ? WOLFSSL_RSA_LOAD_PRIVATE
+                                : WOLFSSL_RSA_LOAD_PUBLIC) != 1)) {
+        ret = 0;
+    }
+    if (ret == 1) {
+        *out = pkey;
+    }
+
+    if ((ret == 0) && (*out == NULL)) {
+        wolfSSL_EVP_PKEY_free(pkey);
+    }
+    return ret;
+}
+#endif /* NO_DSA */
+
+#if !defined(NO_DH) && (defined(WOLFSSL_QT) || defined(OPENSSL_ALL))
+#if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && \
+    (HAVE_FIPS_VERSION > 2))
+static int d2iTryDhKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
+    long memSz, int priv)
+{
+    WOLFSSL_EVP_PKEY* pkey;
+    int isDhKey;
+    word32 keyIdx = 0;
+    int ret = 1;
+#ifndef WOLFSSL_SMALL_STACK
+    DhKey dh[1];
+#else
+    DhKey *dh = (DhKey*)XMALLOC(sizeof(DhKey), NULL, DYNAMIC_TYPE_DH);
+    if (dh == NULL)
+        return 0;
+#endif
+
+    XMEMSET(dh, 0, sizeof(DhKey));
+
+    if (wc_InitDhKey(dh) != 0) {
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(dh, NULL, DYNAMIC_TYPE_DH);
+    #endif
+        return 0;
+    }
+
+    isDhKey = (wc_DhKeyDecode(mem, &keyIdx, dh, (word32)memSz) == 0);
+    wc_FreeDhKey(dh);
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(dh, NULL, DYNAMIC_TYPE_DH);
+#endif
+
+    /* test if DH key */
+    if (!isDhKey) {
+        return -1;
+    }
+
+    if (*out != NULL) {
+        pkey = *out;
+    }
+    else {
+        pkey = wolfSSL_EVP_PKEY_new();
+        if (pkey == NULL) {
+            WOLFSSL_MSG("DH wolfSSL_EVP_PKEY_new error");
+            return 0;
+        }
+    }
+
+    pkey->pkey_sz = (int)memSz;
+    pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
+            priv ? DYNAMIC_TYPE_PRIVATE_KEY :
+                   DYNAMIC_TYPE_PUBLIC_KEY);
+    if (pkey->pkey.ptr == NULL) {
+        ret = 0;
+    }
+    if (ret == 1) {
+        XMEMCPY(pkey->pkey.ptr, mem, memSz);
+        pkey->type = EVP_PKEY_DH;
+
+        pkey->ownDh = 1;
+        pkey->dh = wolfSSL_DH_new();
+        if (pkey->dh == NULL) {
+            ret = 0;
+        }
+    }
+
+    if ((ret == 1) && (wolfSSL_DH_LoadDer(pkey->dh,
+                (const unsigned char*)pkey->pkey.ptr,
+                pkey->pkey_sz) != WOLFSSL_SUCCESS)) {
+        ret = 0;
+    }
+    if (ret == 1) {
+        *out = pkey;
+    }
+
+    if ((ret == 0) && (*out == NULL)) {
+        wolfSSL_EVP_PKEY_free(pkey);
+    }
+    return ret;
+}
+#endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
+#endif /* !NO_DH && (WOLFSSL_QT || OPENSSL_ALL) */
+
+#if !defined(NO_DH) && defined(OPENSSL_EXTRA) && defined(WOLFSSL_DH_EXTRA)
+#if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && \
+        (HAVE_FIPS_VERSION > 2))
+static int d2iTryAltDhKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
+    long memSz, int priv)
+{
+    WOLFSSL_EVP_PKEY* pkey;
+    word32  keyIdx = 0;
+    DhKey*  key = NULL;
+    int elements;
+    int ret;
+#ifndef WOLFSSL_SMALL_STACK
+    DhKey  dh[1];
+#else
+    DhKey* dh = (DhKey*)XMALLOC(sizeof(DhKey), NULL, DYNAMIC_TYPE_DH);
+    if (dh == NULL)
+        return 0;
+#endif
+    XMEMSET(dh, 0, sizeof(DhKey));
+
+    /* test if DH-public key */
+    if (wc_InitDhKey(dh) != 0) {
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(dh, NULL, DYNAMIC_TYPE_DH);
+#endif
+        return 0;
+    }
+
+    ret = wc_DhKeyDecode(mem, &keyIdx, dh, (word32)memSz);
+    wc_FreeDhKey(dh);
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(dh, NULL, DYNAMIC_TYPE_DH);
+#endif
+
+    if (ret != 0) {
+        return -1;
+    }
+
+    if (*out != NULL) {
+        pkey = *out;
+    }
+    else {
+        pkey = wolfSSL_EVP_PKEY_new();
+        if (pkey == NULL) {
+            return 0;
+        }
+    }
+
+    ret = 1;
+    pkey->type     = EVP_PKEY_DH;
+    pkey->pkey_sz  = (int)memSz;
+    pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
+            priv ? DYNAMIC_TYPE_PRIVATE_KEY :
+                   DYNAMIC_TYPE_PUBLIC_KEY);
+    if (pkey->pkey.ptr == NULL) {
+        ret = 0;
+    }
+    if (ret == 1) {
+        XMEMCPY(pkey->pkey.ptr, mem, memSz);
+        pkey->ownDh = 1;
+        pkey->dh = wolfSSL_DH_new();
+        if (pkey->dh == NULL) {
+            ret = 0;
+        }
+    }
+
+    if (ret == 1) {
+        key = (DhKey*)pkey->dh->internal;
+
+        keyIdx = 0;
+        if (wc_DhKeyDecode(mem, &keyIdx, key, (word32)memSz) != 0) {
+            ret = 0;
+        }
+    }
+
+    if (ret == 1) {
+        elements = ELEMENT_P | ELEMENT_G | ELEMENT_Q | ELEMENT_PUB;
+        if (priv) {
+            elements |= ELEMENT_PRV;
+        }
+        if (SetDhExternal_ex(pkey->dh, elements) != WOLFSSL_SUCCESS ) {
+            ret = 0;
+        }
+    }
+    if (ret == 1) {
+        *out = pkey;
+    }
+
+    if ((ret == 0) && (*out == NULL)) {
+        wolfSSL_EVP_PKEY_free(pkey);
+    }
+    return ret;
+}
+#endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
+#endif /* !NO_DH &&  OPENSSL_EXTRA && WOLFSSL_DH_EXTRA */
+
+#ifdef HAVE_FALCON
+static int d2iTryFalconKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
+    long memSz, int priv)
+{
+    WOLFSSL_EVP_PKEY* pkey;
+    int isFalcon = 0;
+#ifndef WOLFSSL_SMALL_STACK
+    falcon_key falcon[1];
+#else
+    falcon_key *falcon = (falcon_key *)XMALLOC(sizeof(falcon_key), NULL,
+                                              DYNAMIC_TYPE_FALCON);
+    if (falcon == NULL) {
+        return 0;
+    }
+#endif
+
+    if (wc_falcon_init(falcon) != 0) {
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(falcon, NULL, DYNAMIC_TYPE_FALCON);
+    #endif
+        return 0;
+    }
+
+    /* test if Falcon key */
+    if (priv) {
+        /* Try level 1 */
+        isFalcon = ((wc_falcon_set_level(falcon, 1) == 0) &&
+                    (wc_falcon_import_private_only(mem, (word32)memSz,
+                                                   falcon) == 0));
+        if (!isFalcon) {
+            /* Try level 5 */
+            isFalcon = ((wc_falcon_set_level(falcon, 5) == 0) &&
+                        (wc_falcon_import_private_only(mem, (word32)memSz,
+                                                       falcon) == 0));
+        }
+    }
+    else {
+        /* Try level 1 */
+        isFalcon = ((wc_falcon_set_level(falcon, 1) == 0) &&
+                    (wc_falcon_import_public(mem, (word32)memSz, falcon) == 0));
+
+        if (!isFalcon) {
+            /* Try level 5 */
+            isFalcon = ((wc_falcon_set_level(falcon, 5) == 0) &&
+                        (wc_falcon_import_public(mem, (word32)memSz,
+                                                 falcon) == 0));
+        }
+    }
+    wc_falcon_free(falcon);
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(falcon, NULL, DYNAMIC_TYPE_FALCON);
+#endif
+
+    if (!isFalcon) {
+        return -1;
+    }
+
+    if (*out != NULL) {
+        pkey = *out;
+    }
+    else {
+        /* Create a fake Falcon EVP_PKEY. In the future, we might integrate
+         * Falcon into the compatibility layer. */
+        pkey = wolfSSL_EVP_PKEY_new();
+        if (pkey == NULL) {
+            WOLFSSL_MSG("Falcon wolfSSL_EVP_PKEY_new error");
+            return 0;
+        }
+    }
+    pkey->type = EVP_PKEY_FALCON;
+    pkey->pkey.ptr = NULL;
+    pkey->pkey_sz = 0;
+
+    *out = pkey;
+    return 1;
+
+}
+#endif /* HAVE_FALCON */
+
+#ifdef HAVE_DILITHIUM
+static int d2iTryDilithiumKey(WOLFSSL_EVP_PKEY** out, const unsigned char* mem,
+    long memSz, int priv)
+{
+    WOLFSSL_EVP_PKEY* pkey;
+    int isDilithium = 0;
+#ifndef WOLFSSL_SMALL_STACK
+    dilithium_key dilithium[1];
+#else
+    dilithium_key *dilithium = (dilithium_key *)
+        XMALLOC(sizeof(dilithium_key), NULL, DYNAMIC_TYPE_DILITHIUM);
+    if (dilithium == NULL) {
+        return 0;
+    }
+#endif
+
+    if (wc_dilithium_init(dilithium) != 0) {
+    #ifdef WOLFSSL_SMALL_STACK
+        XFREE(dilithium, NULL, DYNAMIC_TYPE_DILITHIUM);
+    #endif
+        return 0;
+    }
+
+    /* Test if Dilithium key. Try all levels. */
+    if (priv) {
+        isDilithium = ((wc_dilithium_set_level(dilithium, 2) == 0) &&
+                       (wc_dilithium_import_private(mem,
+                          (word32)memSz, dilithium) == 0));
+        if (!isDilithium) {
+            isDilithium = ((wc_dilithium_set_level(dilithium, 3) == 0) &&
+                           (wc_dilithium_import_private(mem,
+                              (word32)memSz, dilithium) == 0));
+        }
+        if (!isDilithium) {
+            isDilithium = ((wc_dilithium_set_level(dilithium, 5) == 0) &&
+                           (wc_dilithium_import_private(mem,
+                              (word32)memSz, dilithium) == 0));
+        }
+    }
+    else {
+        isDilithium = ((wc_dilithium_set_level(dilithium, 2) == 0) &&
+                       (wc_dilithium_import_public(mem, (word32)memSz,
+                          dilithium) == 0));
+        if (!isDilithium) {
+            isDilithium = ((wc_dilithium_set_level(dilithium, 3) == 0) &&
+                           (wc_dilithium_import_public(mem, (word32)memSz,
+                              dilithium) == 0));
+        }
+        if (!isDilithium) {
+            isDilithium = ((wc_dilithium_set_level(dilithium, 5) == 0) &&
+                           (wc_dilithium_import_public(mem, (word32)memSz,
+                              dilithium) == 0));
+        }
+    }
+    wc_dilithium_free(dilithium);
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(dilithium, NULL, DYNAMIC_TYPE_DILITHIUM);
+#endif
+
+    if (!isDilithium) {
+        return -1;
+    }
+
+    if (*out != NULL) {
+        pkey = *out;
+    }
+    else {
+        /* Create a fake Dilithium EVP_PKEY. In the future, we might
+         * integrate Dilithium into the compatibility layer. */
+        pkey = wolfSSL_EVP_PKEY_new();
+        if (pkey == NULL) {
+            WOLFSSL_MSG("Dilithium wolfSSL_EVP_PKEY_new error");
+            return 0;
+        }
+    }
+    pkey->type = EVP_PKEY_DILITHIUM;
+    pkey->pkey.ptr = NULL;
+    pkey->pkey_sz = 0;
+
+    *out = pkey;
+    return 1;
+}
+#endif /* HAVE_DILITHIUM */
+
 static WOLFSSL_EVP_PKEY* d2iGenericKey(WOLFSSL_EVP_PKEY** out,
     const unsigned char** in, long inSz, int priv)
 {
-
     WOLFSSL_EVP_PKEY* pkey = NULL;
-    const unsigned char* mem;
-    long memSz = inSz;
 
     WOLFSSL_ENTER("d2iGenericKey");
 
@@ -9480,480 +7057,77 @@ static WOLFSSL_EVP_PKEY* d2iGenericKey(WOLFSSL_EVP_PKEY** out,
         WOLFSSL_MSG("Bad argument");
         return NULL;
     }
-    mem = *in;
 
-    #if !defined(NO_RSA)
-    {
-        word32 keyIdx = 0;
-        int isRsaKey;
-    #ifdef WOLFSSL_SMALL_STACK
-        RsaKey *rsa = (RsaKey*)XMALLOC(sizeof(RsaKey), NULL, DYNAMIC_TYPE_RSA);
-        if (rsa == NULL)
-            return NULL;
-    #else
-        RsaKey rsa[1];
-    #endif
-        XMEMSET(rsa, 0, sizeof(RsaKey));
-
-        /* test if RSA key */
-        if (priv)
-            isRsaKey = wc_InitRsaKey(rsa, NULL) == 0 &&
-                wc_RsaPrivateKeyDecode(mem, &keyIdx, rsa, (word32)memSz) == 0;
-        else
-            isRsaKey = wc_InitRsaKey(rsa, NULL) == 0 &&
-                wc_RsaPublicKeyDecode(mem, &keyIdx, rsa, (word32)memSz) == 0;
-        wc_FreeRsaKey(rsa);
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(rsa, NULL, DYNAMIC_TYPE_RSA);
-    #endif
-
-        if (isRsaKey) {
-            pkey = wolfSSL_EVP_PKEY_new();
-            if (pkey != NULL) {
-                pkey->pkey_sz = keyIdx;
-                pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
-                        priv ? DYNAMIC_TYPE_PRIVATE_KEY :
-                               DYNAMIC_TYPE_PUBLIC_KEY);
-                if (pkey->pkey.ptr == NULL) {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-                XMEMCPY(pkey->pkey.ptr, mem, keyIdx);
-                pkey->type = EVP_PKEY_RSA;
-                if (out != NULL) {
-                    *out = pkey;
-                }
-
-                pkey->ownRsa = 1;
-                pkey->rsa = wolfssl_rsa_d2i(NULL, mem, inSz,
-                    priv ? WOLFSSL_RSA_LOAD_PRIVATE : WOLFSSL_RSA_LOAD_PUBLIC);
-                if (pkey->rsa == NULL) {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-
-                return pkey;
-            }
-            else {
-                WOLFSSL_MSG("RSA wolfSSL_EVP_PKEY_new error");
-            }
-        }
+    if ((out != NULL) && (*out != NULL)) {
+        pkey = *out;
     }
-    #endif /* NO_RSA */
 
-    #if defined(HAVE_ECC) && defined(OPENSSL_EXTRA)
-    {
-        word32  keyIdx = 0;
-        int     isEccKey;
-    #ifdef WOLFSSL_SMALL_STACK
-        ecc_key *ecc = (ecc_key*)XMALLOC(sizeof(ecc_key), NULL, DYNAMIC_TYPE_ECC);
-        if (ecc == NULL)
-            return NULL;
-    #else
-        ecc_key ecc[1];
-    #endif
-        XMEMSET(ecc, 0, sizeof(ecc_key));
-
-        if (priv)
-            isEccKey = wc_ecc_init(ecc) == 0 &&
-                wc_EccPrivateKeyDecode(mem, &keyIdx, ecc, (word32)memSz) == 0;
-        else
-            isEccKey = wc_ecc_init(ecc) == 0 &&
-                wc_EccPublicKeyDecode(mem, &keyIdx, ecc, (word32)memSz) == 0;
-        wc_ecc_free(ecc);
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(ecc, NULL, DYNAMIC_TYPE_ECC);
-    #endif
-
-        if (isEccKey) {
-            pkey = wolfSSL_EVP_PKEY_new();
-            if (pkey != NULL) {
-                pkey->pkey_sz = keyIdx;
-                pkey->pkey.ptr = (char*)XMALLOC(keyIdx, NULL,
-                        priv ? DYNAMIC_TYPE_PRIVATE_KEY :
-                               DYNAMIC_TYPE_PUBLIC_KEY);
-                if (pkey->pkey.ptr == NULL) {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-                XMEMCPY(pkey->pkey.ptr, mem, keyIdx);
-                pkey->type = EVP_PKEY_EC;
-                if (out != NULL) {
-                    *out = pkey;
-                }
-
-                pkey->ownEcc = 1;
-                pkey->ecc = wolfSSL_EC_KEY_new();
-                if (pkey->ecc == NULL) {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-
-                if (wolfSSL_EC_KEY_LoadDer_ex(pkey->ecc,
-                        (const unsigned char*)pkey->pkey.ptr,
-                        pkey->pkey_sz, priv ? WOLFSSL_RSA_LOAD_PRIVATE
-                                            : WOLFSSL_RSA_LOAD_PUBLIC) != 1) {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-
-                return pkey;
-            }
-            else {
-                WOLFSSL_MSG("ECC wolfSSL_EVP_PKEY_new error");
-            }
-        }
+#if !defined(NO_RSA)
+    if (d2iTryRsaKey(&pkey, *in, inSz, priv) >= 0) {
+        ;
     }
-    #endif /* HAVE_ECC && OPENSSL_EXTRA */
-
-    #if !defined(NO_DSA)
-    {
-        word32 keyIdx = 0;
-        int     isDsaKey;
-    #ifdef WOLFSSL_SMALL_STACK
-        DsaKey *dsa = (DsaKey*)XMALLOC(sizeof(DsaKey), NULL, DYNAMIC_TYPE_DSA);
-        if (dsa == NULL)
-            return NULL;
-    #else
-        DsaKey dsa[1];
-    #endif
-        XMEMSET(dsa, 0, sizeof(DsaKey));
-
-        if (priv)
-            isDsaKey = wc_InitDsaKey(dsa) == 0 &&
-                wc_DsaPrivateKeyDecode(mem, &keyIdx, dsa, (word32)memSz) == 0;
-        else
-            isDsaKey = wc_InitDsaKey(dsa) == 0 &&
-                wc_DsaPublicKeyDecode(mem, &keyIdx, dsa, (word32)memSz) == 0;
-        wc_FreeDsaKey(dsa);
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(dsa, NULL, DYNAMIC_TYPE_DSA);
-    #endif
-
-        /* test if DSA key */
-        if (isDsaKey) {
-            pkey = wolfSSL_EVP_PKEY_new();
-
-            if (pkey != NULL) {
-                pkey->pkey_sz = keyIdx;
-                pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
-                        priv ? DYNAMIC_TYPE_PRIVATE_KEY :
-                               DYNAMIC_TYPE_PUBLIC_KEY);
-                if (pkey->pkey.ptr == NULL) {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-                XMEMCPY(pkey->pkey.ptr, mem, keyIdx);
-                pkey->type = EVP_PKEY_DSA;
-                if (out != NULL) {
-                    *out = pkey;
-                }
-
-                pkey->ownDsa = 1;
-                pkey->dsa = wolfSSL_DSA_new();
-                if (pkey->dsa == NULL) {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-
-                if (wolfSSL_DSA_LoadDer_ex(pkey->dsa,
-                        (const unsigned char*)pkey->pkey.ptr,
-                        pkey->pkey_sz, priv ? WOLFSSL_RSA_LOAD_PRIVATE
-                                            : WOLFSSL_RSA_LOAD_PUBLIC) != 1) {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-
-                return pkey;
-            }
-            else {
-                WOLFSSL_MSG("DSA wolfSSL_EVP_PKEY_new error");
-            }
-        }
+    else
+#endif /* NO_RSA */
+#if defined(HAVE_ECC) && defined(OPENSSL_EXTRA)
+    if (d2iTryEccKey(&pkey, *in, inSz, priv) >= 0) {
+        ;
     }
-    #endif /* NO_DSA */
+    else
+#endif /* HAVE_ECC && OPENSSL_EXTRA */
+#if !defined(NO_DSA)
+    if (d2iTryDsaKey(&pkey, *in, inSz, priv) >= 0) {
+        ;
+    }
+    else
+#endif /* NO_DSA */
+#if !defined(NO_DH) && (defined(WOLFSSL_QT) || defined(OPENSSL_ALL))
+#if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && \
+    (HAVE_FIPS_VERSION > 2))
+    if (d2iTryDhKey(&pkey, *in, inSz, priv) >= 0) {
+        ;
+    }
+    else
+#endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
+#endif /* !NO_DH && (WOLFSSL_QT || OPENSSL_ALL) */
 
-    #if !defined(NO_DH) && (defined(WOLFSSL_QT) || defined(OPENSSL_ALL))
-    #if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && \
+#if !defined(NO_DH) && defined(OPENSSL_EXTRA) && defined(WOLFSSL_DH_EXTRA)
+#if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && \
         (HAVE_FIPS_VERSION > 2))
-    {
-        int isDhKey;
-        word32 keyIdx = 0;
-    #ifdef WOLFSSL_SMALL_STACK
-        DhKey *dh = (DhKey*)XMALLOC(sizeof(DhKey), NULL, DYNAMIC_TYPE_DH);
-        if (dh == NULL)
-            return NULL;
-    #else
-        DhKey dh[1];
-    #endif
-        XMEMSET(dh, 0, sizeof(DhKey));
-
-        isDhKey = wc_InitDhKey(dh) == 0 &&
-                  wc_DhKeyDecode(mem, &keyIdx, dh, (word32)memSz) == 0;
-        wc_FreeDhKey(dh);
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(dh, NULL, DYNAMIC_TYPE_DH);
-    #endif
-
-        /* test if DH key */
-        if (isDhKey) {
-            pkey = wolfSSL_EVP_PKEY_new();
-
-            if (pkey != NULL) {
-                pkey->pkey_sz = (int)memSz;
-                pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
-                        priv ? DYNAMIC_TYPE_PRIVATE_KEY :
-                               DYNAMIC_TYPE_PUBLIC_KEY);
-                if (pkey->pkey.ptr == NULL) {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-                XMEMCPY(pkey->pkey.ptr, mem, memSz);
-                pkey->type = EVP_PKEY_DH;
-                if (out != NULL) {
-                    *out = pkey;
-                }
-
-                pkey->ownDh = 1;
-                pkey->dh = wolfSSL_DH_new();
-                if (pkey->dh == NULL) {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-
-                if (wolfSSL_DH_LoadDer(pkey->dh,
-                            (const unsigned char*)pkey->pkey.ptr,
-                            pkey->pkey_sz) != WOLFSSL_SUCCESS) {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-
-                return pkey;
-            }
-            else {
-                WOLFSSL_MSG("DH wolfSSL_EVP_PKEY_new error");
-            }
-        }
+    if (d2iTryAltDhKey(&pkey, *in, inSz, priv) >= 0) {
+        ;
     }
-    #endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
-    #endif /* !NO_DH && (WOLFSSL_QT || OPENSSL_ALL) */
+    else
+#endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
+#endif /* !NO_DH &&  OPENSSL_EXTRA && WOLFSSL_DH_EXTRA */
 
-    #if !defined(NO_DH) && defined(OPENSSL_EXTRA) && defined(WOLFSSL_DH_EXTRA)
-    #if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && \
-            (HAVE_FIPS_VERSION > 2))
-    {
-        word32  keyIdx = 0;
-        DhKey*  key = NULL;
-        int ret;
-    #ifdef WOLFSSL_SMALL_STACK
-        DhKey* dh = (DhKey*)XMALLOC(sizeof(DhKey), NULL, DYNAMIC_TYPE_DH);
-        if (dh == NULL)
-            return NULL;
-    #else
-        DhKey  dh[1];
-    #endif
-        XMEMSET(dh, 0, sizeof(DhKey));
-
-        /* test if DH-public key */
-        if (wc_InitDhKey(dh) != 0)
-            return NULL;
-
-        ret = wc_DhKeyDecode(mem, &keyIdx, dh, (word32)memSz);
-        wc_FreeDhKey(dh);
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(dh, NULL, DYNAMIC_TYPE_DH);
-    #endif
-
-        if (ret == 0) {
-            pkey = wolfSSL_EVP_PKEY_new();
-            if (pkey != NULL) {
-                pkey->type     = EVP_PKEY_DH;
-                pkey->pkey_sz  = (int)memSz;
-                pkey->pkey.ptr = (char*)XMALLOC(memSz, NULL,
-                        priv ? DYNAMIC_TYPE_PRIVATE_KEY :
-                               DYNAMIC_TYPE_PUBLIC_KEY);
-                if (pkey->pkey.ptr == NULL) {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-                XMEMCPY(pkey->pkey.ptr, mem, memSz);
-                if (out != NULL) {
-                    *out = pkey;
-                }
-                pkey->ownDh = 1;
-                pkey->dh = wolfSSL_DH_new();
-                if (pkey->dh == NULL) {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-
-                key = (DhKey*)pkey->dh->internal;
-
-                keyIdx = 0;
-                if (wc_DhKeyDecode(mem, &keyIdx, key, (word32)memSz) == 0)
-                {
-                    int elements = ELEMENT_P | ELEMENT_G | ELEMENT_Q |
-                                   ELEMENT_PUB;
-                    if (priv)
-                        elements |= ELEMENT_PRV;
-                    if(SetDhExternal_ex(pkey->dh, elements)
-                            == WOLFSSL_SUCCESS ) {
-                        return pkey;
-                    }
-                }
-                else {
-                    wolfSSL_EVP_PKEY_free(pkey);
-                    return NULL;
-                }
-            }
-        }
+#ifdef HAVE_FALCON
+    if (d2iTryFalconKey(&pkey, *in, inSz, priv) >= 0) {
+        ;
     }
-    #endif /* !HAVE_FIPS || HAVE_FIPS_VERSION > 2 */
-    #endif /* !NO_DH &&  OPENSSL_EXTRA && WOLFSSL_DH_EXTRA */
-
-    #ifdef HAVE_PQC
-    #ifdef HAVE_FALCON
-    {
-        int isFalcon = 0;
-    #ifdef WOLFSSL_SMALL_STACK
-        falcon_key *falcon = (falcon_key *)XMALLOC(sizeof(falcon_key), NULL,
-                                                  DYNAMIC_TYPE_FALCON);
-        if (falcon == NULL) {
-            return NULL;
-        }
-    #else
-        falcon_key falcon[1];
-    #endif
-
-        if (wc_falcon_init(falcon) == 0) {
-            /* test if Falcon key */
-            if (priv) {
-                /* Try level 1 */
-                isFalcon = wc_falcon_set_level(falcon, 1) == 0 &&
-                           wc_falcon_import_private_only(mem, (word32)memSz,
-                                                         falcon) == 0;
-                if (!isFalcon) {
-                    /* Try level 5 */
-                    isFalcon = wc_falcon_set_level(falcon, 5) == 0 &&
-                               wc_falcon_import_private_only(mem, (word32)memSz,
-                                                             falcon) == 0;
-                }
-            } else {
-                /* Try level 1 */
-                isFalcon = wc_falcon_set_level(falcon, 1) == 0 &&
-                           wc_falcon_import_public(mem, (word32)memSz, falcon)
-                           == 0;
-
-                if (!isFalcon) {
-                    /* Try level 5 */
-                    isFalcon = wc_falcon_set_level(falcon, 5) == 0 &&
-                               wc_falcon_import_public(mem, (word32)memSz,
-                                                       falcon) == 0;
-                }
-            }
-            wc_falcon_free(falcon);
-        }
-
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(falcon, NULL, DYNAMIC_TYPE_FALCON);
-    #endif
-        if (isFalcon) {
-            /* Create a fake Falcon EVP_PKEY. In the future, we might integrate
-             * Falcon into the compatibility layer. */
-            pkey = wolfSSL_EVP_PKEY_new();
-            if (pkey == NULL) {
-                WOLFSSL_MSG("Falcon wolfSSL_EVP_PKEY_new error");
-                return NULL;
-            }
-            pkey->type = EVP_PKEY_FALCON;
-            pkey->pkey.ptr = NULL;
-            pkey->pkey_sz = 0;
-            return pkey;
-        }
-
+    else
+#endif /* HAVE_FALCON */
+#ifdef HAVE_DILITHIUM
+    if (d2iTryDilithiumKey(&pkey, *in, inSz, priv) >= 0) {
+        ;
     }
-    #endif /* HAVE_FALCON */
-    #ifdef HAVE_DILITHIUM
+    else
+#endif /* HAVE_DILITHIUM */
     {
-        int isDilithium = 0;
-    #ifdef WOLFSSL_SMALL_STACK
-        dilithium_key *dilithium = (dilithium_key *)
-            XMALLOC(sizeof(dilithium_key), NULL, DYNAMIC_TYPE_DILITHIUM);
-        if (dilithium == NULL) {
-            return NULL;
-        }
-    #else
-        dilithium_key dilithium[1];
-    #endif
-
-        if (wc_dilithium_init(dilithium) == 0) {
-            /* Test if Dilithium key. Try all levels. */
-            if (priv) {
-                isDilithium = wc_dilithium_set_level(dilithium, 2) == 0 &&
-                              wc_dilithium_import_private_only(mem,
-                                  (word32)memSz, dilithium) == 0;
-                if (!isDilithium) {
-                    isDilithium = wc_dilithium_set_level(dilithium, 3) == 0 &&
-                                  wc_dilithium_import_private_only(mem,
-                                      (word32)memSz, dilithium) == 0;
-                }
-                if (!isDilithium) {
-                    isDilithium = wc_dilithium_set_level(dilithium, 5) == 0 &&
-                                  wc_dilithium_import_private_only(mem,
-                                      (word32)memSz, dilithium) == 0;
-                }
-            } else {
-                isDilithium = wc_dilithium_set_level(dilithium, 2) == 0 &&
-                              wc_dilithium_import_public(mem, (word32)memSz,
-                                  dilithium) == 0;
-                if (!isDilithium) {
-                    isDilithium = wc_dilithium_set_level(dilithium, 3) == 0 &&
-                                  wc_dilithium_import_public(mem, (word32)memSz,
-                                      dilithium) == 0;
-                }
-                if (!isDilithium) {
-                    isDilithium = wc_dilithium_set_level(dilithium, 5) == 0 &&
-                                  wc_dilithium_import_public(mem, (word32)memSz,
-                                      dilithium) == 0;
-                }
-            }
-            wc_dilithium_free(dilithium);
-        }
-
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(dilithium, NULL, DYNAMIC_TYPE_DILITHIUM);
-    #endif
-        if (isDilithium) {
-            /* Create a fake Dilithium EVP_PKEY. In the future, we might
-             * integrate Dilithium into the compatibility layer. */
-            pkey = wolfSSL_EVP_PKEY_new();
-            if (pkey == NULL) {
-                WOLFSSL_MSG("Dilithium wolfSSL_EVP_PKEY_new error");
-                return NULL;
-            }
-            pkey->type = EVP_PKEY_DILITHIUM;
-            pkey->pkey.ptr = NULL;
-            pkey->pkey_sz = 0;
-            return pkey;
-        }
-
-    }
-    #endif /* HAVE_DILITHIUM */
-    #endif /* HAVE_PQC */
-
-    if (pkey == NULL) {
         WOLFSSL_MSG("wolfSSL_d2i_PUBKEY couldn't determine key type");
     }
 
+    if ((pkey != NULL) && (out != NULL)) {
+        *out = pkey;
+    }
     return pkey;
-
 }
 #endif /* OPENSSL_EXTRA || WPA_SMALL */
 
 #ifdef OPENSSL_EXTRA
 
 WOLFSSL_PKCS8_PRIV_KEY_INFO* wolfSSL_d2i_PKCS8_PKEY(
-    WOLFSSL_PKCS8_PRIV_KEY_INFO** pkey, const unsigned char** keyBuf, long keyLen)
+    WOLFSSL_PKCS8_PRIV_KEY_INFO** pkey, const unsigned char** keyBuf,
+    long keyLen)
 {
     WOLFSSL_PKCS8_PRIV_KEY_INFO* pkcs8 = NULL;
 #ifdef WOLFSSL_PEM_TO_DER
@@ -9978,7 +7152,8 @@ WOLFSSL_PKCS8_PRIV_KEY_INFO* wolfSSL_d2i_PKCS8_PKEY(
         /* Verify this is PKCS8 Key */
         word32 inOutIdx = 0;
         word32 algId;
-        ret = ToTraditionalInline_ex(der->buffer, &inOutIdx, der->length, &algId);
+        ret = ToTraditionalInline_ex(der->buffer, &inOutIdx, der->length,
+            &algId);
         if (ret >= 0) {
             ret = 0; /* good DER */
         }
@@ -9997,7 +7172,7 @@ WOLFSSL_PKCS8_PRIV_KEY_INFO* wolfSSL_d2i_PKCS8_PKEY(
     }
     if (ret == 0) {
         XMEMCPY(pkcs8->pkey.ptr, der->buffer, der->length);
-        pkcs8->pkey_sz = der->length;
+        pkcs8->pkey_sz = (int)der->length;
     }
 
     FreeDer(&der);
@@ -10124,7 +7299,8 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PUBKEY(WOLFSSL_EVP_PKEY** out,
     !defined(NO_PWDBASED)
 
 /* helper function to get raw pointer to DER buffer from WOLFSSL_EVP_PKEY */
-static int wolfSSL_EVP_PKEY_get_der(const WOLFSSL_EVP_PKEY* key, unsigned char** der)
+static int wolfSSL_EVP_PKEY_get_der(const WOLFSSL_EVP_PKEY* key,
+    unsigned char** der)
 {
     int sz;
     word16 pkcs8HeaderSz;
@@ -10203,7 +7379,7 @@ static WOLFSSL_EVP_PKEY* _d2i_PublicKey(int type, WOLFSSL_EVP_PKEY** out,
             (void)idx; /* not used */
         }
         else {
-            if (ret != ASN_PARSE_E) {
+            if (ret != WC_NO_ERR_TRACE(ASN_PARSE_E)) {
                 WOLFSSL_MSG("Unexpected error with trying to remove PKCS8 "
                     "header");
                 return NULL;
@@ -10437,87 +7613,57 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_id(int type, WOLFSSL_EVP_PKEY** out,
  *         WOLFSSL_FAILURE if mismatched. */
 int wolfSSL_check_private_key(const WOLFSSL* ssl)
 {
+    int res = WOLFSSL_SUCCESS;
+
     if (ssl == NULL) {
         return WOLFSSL_FAILURE;
     }
-    return check_cert_key(ssl->buffers.certificate, ssl->buffers.key, ssl->heap,
-        ssl->buffers.keyDevId, ssl->buffers.keyLabel, ssl->buffers.keyId);
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    wolfssl_priv_der_unblind(ssl->buffers.key, ssl->buffers.keyMask);
+    wolfssl_priv_der_unblind(ssl->buffers.altKey, ssl->buffers.altKeyMask);
+#endif
+    res = check_cert_key(ssl->buffers.certificate, ssl->buffers.key,
+        ssl->buffers.altKey, ssl->heap, ssl->buffers.keyDevId,
+        ssl->buffers.keyLabel, ssl->buffers.keyId, ssl->buffers.altKeyDevId,
+        ssl->buffers.altKeyLabel, ssl->buffers.altKeyId);
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    if (res == WOLFSSL_SUCCESS) {
+        int ret;
+        ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.key,
+            (DerBuffer**)&ssl->buffers.keyMask);
+        if (ret == 0) {
+            ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.altKey,
+                (DerBuffer**)&ssl->buffers.altKeyMask);
+        }
+        if (ret != 0) {
+            res = WOLFSSL_FAILURE;
+        }
+    }
+#endif
+#else
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    wolfssl_priv_der_unblind(ssl->buffers.key, ssl->buffers.keyMask);
+#endif
+    res = check_cert_key(ssl->buffers.certificate, ssl->buffers.key, NULL,
+        ssl->heap, ssl->buffers.keyDevId, ssl->buffers.keyLabel,
+        ssl->buffers.keyId, INVALID_DEVID, 0, 0);
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    if (res == WOLFSSL_SUCCESS) {
+        int ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.key,
+            (DerBuffer**)&ssl->buffers.keyMask);
+        if (ret != 0) {
+            res = WOLFSSL_FAILURE;
+        }
+    }
+#endif
+#endif
+
+    return res;
 }
 #endif /* !NO_CHECK_PRIVATE_KEY */
 
 #endif /* !NO_CERTS */
-
-int wolfSSL_use_PrivateKey(WOLFSSL* ssl, WOLFSSL_EVP_PKEY* pkey)
-{
-    WOLFSSL_ENTER("wolfSSL_use_PrivateKey");
-    if (ssl == NULL || pkey == NULL ) {
-        return WOLFSSL_FAILURE;
-    }
-
-    return wolfSSL_use_PrivateKey_buffer(ssl, (unsigned char*)pkey->pkey.ptr,
-                                         pkey->pkey_sz, WOLFSSL_FILETYPE_ASN1);
-}
-
-
-int wolfSSL_use_PrivateKey_ASN1(int pri, WOLFSSL* ssl, const unsigned char* der,
-                                long derSz)
-{
-    WOLFSSL_ENTER("wolfSSL_use_PrivateKey_ASN1");
-    if (ssl == NULL || der == NULL ) {
-        return WOLFSSL_FAILURE;
-    }
-
-    (void)pri; /* type of private key */
-    return wolfSSL_use_PrivateKey_buffer(ssl, der, derSz, WOLFSSL_FILETYPE_ASN1);
-}
-/******************************************************************************
-* wolfSSL_CTX_use_PrivateKey_ASN1 - loads a private key buffer into the SSL ctx
-*
-* RETURNS:
-* returns WOLFSSL_SUCCESS on success, otherwise returns WOLFSSL_FAILURE
-*/
-
-int wolfSSL_CTX_use_PrivateKey_ASN1(int pri, WOLFSSL_CTX* ctx,
-                                            unsigned char* der, long derSz)
-{
-    WOLFSSL_ENTER("wolfSSL_CTX_use_PrivateKey_ASN1");
-    if (ctx == NULL || der == NULL ) {
-        return WOLFSSL_FAILURE;
-    }
-
-    (void)pri; /* type of private key */
-    return wolfSSL_CTX_use_PrivateKey_buffer(ctx, der, derSz, WOLFSSL_FILETYPE_ASN1);
-}
-
-
-#ifndef NO_RSA
-int wolfSSL_use_RSAPrivateKey_ASN1(WOLFSSL* ssl, unsigned char* der, long derSz)
-{
-    WOLFSSL_ENTER("wolfSSL_use_RSAPrivateKey_ASN1");
-    if (ssl == NULL || der == NULL ) {
-        return WOLFSSL_FAILURE;
-    }
-
-    return wolfSSL_use_PrivateKey_buffer(ssl, der, derSz, WOLFSSL_FILETYPE_ASN1);
-}
-#endif
-
-int wolfSSL_use_certificate(WOLFSSL* ssl, WOLFSSL_X509* x509)
-{
-    long idx = 0;
-
-    WOLFSSL_ENTER("wolfSSL_use_certificate");
-    if (x509 != NULL && ssl != NULL && x509->derCert != NULL) {
-        if (ProcessBuffer(NULL, x509->derCert->buffer, x509->derCert->length,
-                          WOLFSSL_FILETYPE_ASN1, CERT_TYPE, ssl, &idx, 0,
-                          GET_VERIFY_SETTING_SSL(ssl)) == WOLFSSL_SUCCESS) {
-            return WOLFSSL_SUCCESS;
-        }
-    }
-
-    (void)idx;
-    return WOLFSSL_FAILURE;
-}
 
 #endif /* OPENSSL_EXTRA */
 
@@ -10560,14 +7706,14 @@ WOLFSSL_API int wolfSSL_CTX_set_client_cert_type(WOLFSSL_CTX* ctx,
         return WOLFSSL_SUCCESS;
     }
 
-    if (!isArrayUnique(buf, bufLen))
+    if (!isArrayUnique(buf, (size_t)bufLen))
         return BAD_FUNC_ARG;
 
     for (i = 0; i < bufLen; i++){
         if (buf[i] != WOLFSSL_CERT_TYPE_RPK && buf[i] != WOLFSSL_CERT_TYPE_X509)
             return BAD_FUNC_ARG;
 
-        ctx->rpkConfig.preferred_ClientCertTypes[i] = buf[i];
+        ctx->rpkConfig.preferred_ClientCertTypes[i] = (byte)buf[i];
     }
     ctx->rpkConfig.preferred_ClientCertTypeCnt = bufLen;
 
@@ -10595,14 +7741,14 @@ WOLFSSL_API int wolfSSL_CTX_set_server_cert_type(WOLFSSL_CTX* ctx,
         return WOLFSSL_SUCCESS;
     }
 
-    if (!isArrayUnique(buf, bufLen))
+    if (!isArrayUnique(buf, (size_t)bufLen))
         return BAD_FUNC_ARG;
 
     for (i = 0; i < bufLen; i++){
         if (buf[i] != WOLFSSL_CERT_TYPE_RPK && buf[i] != WOLFSSL_CERT_TYPE_X509)
             return BAD_FUNC_ARG;
 
-        ctx->rpkConfig.preferred_ServerCertTypes[i] = buf[i];
+        ctx->rpkConfig.preferred_ServerCertTypes[i] = (byte)buf[i];
     }
     ctx->rpkConfig.preferred_ServerCertTypeCnt = bufLen;
 
@@ -10632,14 +7778,14 @@ WOLFSSL_API int wolfSSL_set_client_cert_type(WOLFSSL* ssl,
         return WOLFSSL_SUCCESS;
     }
 
-    if (!isArrayUnique(buf, bufLen))
+    if (!isArrayUnique(buf, (size_t)bufLen))
         return BAD_FUNC_ARG;
 
     for (i = 0; i < bufLen; i++){
         if (buf[i] != WOLFSSL_CERT_TYPE_RPK && buf[i] != WOLFSSL_CERT_TYPE_X509)
             return BAD_FUNC_ARG;
 
-        ssl->options.rpkConfig.preferred_ClientCertTypes[i] = buf[i];
+        ssl->options.rpkConfig.preferred_ClientCertTypes[i] = (byte)buf[i];
     }
     ssl->options.rpkConfig.preferred_ClientCertTypeCnt = bufLen;
 
@@ -10669,14 +7815,14 @@ WOLFSSL_API int wolfSSL_set_server_cert_type(WOLFSSL* ssl,
         return WOLFSSL_SUCCESS;
     }
 
-    if (!isArrayUnique(buf, bufLen))
+    if (!isArrayUnique(buf, (size_t)bufLen))
         return BAD_FUNC_ARG;
 
     for (i = 0; i < bufLen; i++){
         if (buf[i] != WOLFSSL_CERT_TYPE_RPK && buf[i] != WOLFSSL_CERT_TYPE_X509)
             return BAD_FUNC_ARG;
 
-        ssl->options.rpkConfig.preferred_ServerCertTypes[i] = buf[i];
+        ssl->options.rpkConfig.preferred_ServerCertTypes[i] = (byte)buf[i];
     }
     ssl->options.rpkConfig.preferred_ServerCertTypeCnt = bufLen;
 
@@ -10747,103 +7893,13 @@ WOLFSSL_API int wolfSSL_get_negotiated_server_cert_type(WOLFSSL* ssl, int* tp)
 
 #endif /* HAVE_RPK */
 
-int wolfSSL_use_certificate_ASN1(WOLFSSL* ssl, const unsigned char* der,
-                                 int derSz)
-{
-    long idx = 0;
-
-    WOLFSSL_ENTER("wolfSSL_use_certificate_ASN1");
-    if (der != NULL && ssl != NULL) {
-        if (ProcessBuffer(NULL, der, derSz, WOLFSSL_FILETYPE_ASN1, CERT_TYPE,
-                ssl, &idx, 0, GET_VERIFY_SETTING_SSL(ssl)) == WOLFSSL_SUCCESS) {
-            return WOLFSSL_SUCCESS;
-        }
-    }
-
-    (void)idx;
-    return WOLFSSL_FAILURE;
-}
-
-#ifndef NO_FILESYSTEM
-
-WOLFSSL_ABI
-int wolfSSL_use_certificate_file(WOLFSSL* ssl, const char* file, int format)
-{
-    WOLFSSL_ENTER("wolfSSL_use_certificate_file");
-
-    if (ssl == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    if (ProcessFile(ssl->ctx, file, format, CERT_TYPE,
-                ssl, 0, NULL, GET_VERIFY_SETTING_SSL(ssl)) == WOLFSSL_SUCCESS) {
-        return WOLFSSL_SUCCESS;
-    }
-
-    return WOLFSSL_FAILURE;
-}
-
-
-WOLFSSL_ABI
-int wolfSSL_use_PrivateKey_file(WOLFSSL* ssl, const char* file, int format)
-{
-    WOLFSSL_ENTER("wolfSSL_use_PrivateKey_file");
-
-    if (ssl == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    if (ProcessFile(ssl->ctx, file, format, PRIVATEKEY_TYPE,
-                ssl, 0, NULL, GET_VERIFY_SETTING_SSL(ssl)) == WOLFSSL_SUCCESS) {
-        return WOLFSSL_SUCCESS;
-    }
-
-    return WOLFSSL_FAILURE;
-}
-
-
-WOLFSSL_ABI
-int wolfSSL_use_certificate_chain_file(WOLFSSL* ssl, const char* file)
-{
-    /* process up to MAX_CHAIN_DEPTH plus subject cert */
-    WOLFSSL_ENTER("wolfSSL_use_certificate_chain_file");
-
-    if (ssl == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    if (ProcessFile(ssl->ctx, file, WOLFSSL_FILETYPE_PEM, CERT_TYPE,
-               ssl, 1, NULL, GET_VERIFY_SETTING_SSL(ssl)) == WOLFSSL_SUCCESS) {
-        return WOLFSSL_SUCCESS;
-    }
-
-   return WOLFSSL_FAILURE;
-}
-
-int wolfSSL_use_certificate_chain_file_format(WOLFSSL* ssl, const char* file,
-                                              int format)
-{
-    /* process up to MAX_CHAIN_DEPTH plus subject cert */
-    WOLFSSL_ENTER("wolfSSL_use_certificate_chain_file_format");
-
-    if (ssl == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    if (ProcessFile(ssl->ctx, file, format, CERT_TYPE, ssl, 1,
-                    NULL, GET_VERIFY_SETTING_SSL(ssl)) == WOLFSSL_SUCCESS) {
-        return WOLFSSL_SUCCESS;
-    }
-    return WOLFSSL_FAILURE;
-}
-
-#endif /* !NO_FILESYSTEM */
-
 #ifdef HAVE_ECC
 
 /* Set Temp CTX EC-DHE size in octets, can be 14 - 66 (112 - 521 bit) */
 int wolfSSL_CTX_SetTmpEC_DHE_Sz(WOLFSSL_CTX* ctx, word16 sz)
 {
+    WOLFSSL_ENTER("wolfSSL_CTX_SetTmpEC_DHE_Sz");
+
     if (ctx == NULL)
         return BAD_FUNC_ARG;
 
@@ -10878,6 +7934,8 @@ int wolfSSL_CTX_SetTmpEC_DHE_Sz(WOLFSSL_CTX* ctx, word16 sz)
 /* Set Temp SSL EC-DHE size in octets, can be 14 - 66 (112 - 521 bit) */
 int wolfSSL_SetTmpEC_DHE_Sz(WOLFSSL* ssl, word16 sz)
 {
+    WOLFSSL_ENTER("wolfSSL_SetTmpEC_DHE_Sz");
+
     if (ssl == NULL)
         return BAD_FUNC_ARG;
 
@@ -10896,78 +7954,6 @@ int wolfSSL_SetTmpEC_DHE_Sz(WOLFSSL* ssl, word16 sz)
 
 #endif /* HAVE_ECC */
 
-
-#ifdef OPENSSL_EXTRA
-
-#ifndef NO_FILESYSTEM
-int wolfSSL_CTX_use_RSAPrivateKey_file(WOLFSSL_CTX* ctx,const char* file,
-                                   int format)
-{
-    WOLFSSL_ENTER("wolfSSL_CTX_use_RSAPrivateKey_file");
-
-    return wolfSSL_CTX_use_PrivateKey_file(ctx, file, format);
-}
-
-
-int wolfSSL_use_RSAPrivateKey_file(WOLFSSL* ssl, const char* file, int format)
-{
-    WOLFSSL_ENTER("wolfSSL_use_RSAPrivateKey_file");
-
-    return wolfSSL_use_PrivateKey_file(ssl, file, format);
-}
-#endif /* NO_FILESYSTEM */
-
-
-/* Copies the master secret over to out buffer. If outSz is 0 returns the size
- * of master secret.
- *
- * ses : a session from completed TLS/SSL handshake
- * out : buffer to hold copy of master secret
- * outSz : size of out buffer
- * returns : number of bytes copied into out buffer on success
- *           less then or equal to 0 is considered a failure case
- */
-int wolfSSL_SESSION_get_master_key(const WOLFSSL_SESSION* ses,
-        unsigned char* out, int outSz)
-{
-    int size;
-
-    ses = ClientSessionToSession(ses);
-
-    if (outSz == 0) {
-        return SECRET_LEN;
-    }
-
-    if (ses == NULL || out == NULL || outSz < 0) {
-        return 0;
-    }
-
-    if (outSz > SECRET_LEN) {
-        size = SECRET_LEN;
-    }
-    else {
-        size = outSz;
-    }
-
-    XMEMCPY(out, ses->masterSecret, size);
-    return size;
-}
-
-
-int wolfSSL_SESSION_get_master_key_length(const WOLFSSL_SESSION* ses)
-{
-    (void)ses;
-    return SECRET_LEN;
-}
-
-#ifdef WOLFSSL_EARLY_DATA
-unsigned int wolfSSL_SESSION_get_max_early_data(const WOLFSSL_SESSION *session)
-{
-    return session->maxEarlyDataSz;
-}
-#endif /* WOLFSSL_EARLY_DATA */
-
-#endif /* OPENSSL_EXTRA */
 
 typedef struct {
     byte verifyPeer:1;
@@ -11067,7 +8053,7 @@ void wolfSSL_set_verify_result(WOLFSSL *ssl, long v)
 
 #if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || \
     defined(OPENSSL_ALL)
-    ssl->peerVerifyRet = v;
+    ssl->peerVerifyRet = (unsigned long)v;
 #else
     (void)v;
     WOLFSSL_STUB("wolfSSL_set_verify_result");
@@ -11110,7 +8096,8 @@ int wolfSSL_set_post_handshake_auth(WOLFSSL* ssl, int val)
     }
     return (ret == 0) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
 }
-#endif /* OPENSSL_EXTRA && !NO_CERTS && WOLFSSL_TLS13 && WOLFSSL_POST_HANDSHAKE_AUTH */
+#endif /* OPENSSL_EXTRA && !NO_CERTS && WOLFSSL_TLS13 &&
+        * WOLFSSL_POST_HANDSHAKE_AUTH */
 
 /* store user ctx for verify callback */
 void wolfSSL_SetCertCbCtx(WOLFSSL* ssl, void* ctx)
@@ -11207,499 +8194,6 @@ int wolfSSL_CTX_get_cert_cache_memsize(WOLFSSL_CTX* ctx)
 #endif /* !NO_CERTS */
 
 
-#ifndef NO_SESSION_CACHE
-
-WOLFSSL_ABI
-WOLFSSL_SESSION* wolfSSL_get_session(WOLFSSL* ssl)
-{
-    WOLFSSL_ENTER("wolfSSL_get_session");
-    if (ssl) {
-#ifdef NO_SESSION_CACHE_REF
-        return ssl->session;
-#else
-        if (ssl->options.side == WOLFSSL_CLIENT_END) {
-            /* On the client side we want to return a persistent reference for
-             * backwards compatibility. */
-#ifndef NO_CLIENT_CACHE
-            if (ssl->clientSession) {
-                return (WOLFSSL_SESSION*)ssl->clientSession;
-            }
-            else {
-                /* Try to add a ClientCache entry to associate with the current
-                 * session. Ignore any session cache options. */
-                int err;
-                const byte* id = ssl->session->sessionID;
-                byte idSz = ssl->session->sessionIDSz;
-                if (ssl->session->haveAltSessionID) {
-                    id = ssl->session->altSessionID;
-                    idSz = ID_LEN;
-                }
-                err = AddSessionToCache(ssl->ctx, ssl->session, id, idSz,
-                        NULL, ssl->session->side,
-                #ifdef HAVE_SESSION_TICKET
-                        ssl->session->ticketLen > 0,
-                #else
-                        0,
-                #endif
-                        &ssl->clientSession);
-                if (err == 0) {
-                    return (WOLFSSL_SESSION*)ssl->clientSession;
-                }
-            }
-#endif
-        }
-        else {
-            return ssl->session;
-        }
-#endif
-    }
-
-    return NULL;
-}
-
-/* The get1 version requires caller to call SSL_SESSION_free */
-WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl)
-{
-    WOLFSSL_SESSION* sess = NULL;
-    WOLFSSL_ENTER("wolfSSL_get1_session");
-    if (ssl != NULL) {
-        sess = ssl->session;
-        if (sess != NULL) {
-            /* increase reference count if allocated session */
-            if (sess->type == WOLFSSL_SESSION_TYPE_HEAP) {
-                if (wolfSSL_SESSION_up_ref(sess) != WOLFSSL_SUCCESS)
-                    sess = NULL;
-            }
-        }
-    }
-    return sess;
-}
-
-
-/*
- * Sets the session object to use when establishing a TLS/SSL session using
- * the ssl object. Therefore, this function must be called before
- * wolfSSL_connect. The session object to use can be obtained in a previous
- * TLS/SSL connection using wolfSSL_get_session.
- *
- * This function rejects the session if it has been expired when this function
- * is called. Note that this expiration check is wolfSSL specific and differs
- * from OpenSSL return code behavior.
- *
- * By default, wolfSSL_set_session returns WOLFSSL_SUCCESS on successfully
- * setting the session, WOLFSSL_FAILURE on failure due to the session cache
- * being disabled, or the session has expired.
- *
- * To match OpenSSL return code behavior when session is expired, define
- * OPENSSL_EXTRA and WOLFSSL_ERROR_CODE_OPENSSL. This behavior will return
- * WOLFSSL_SUCCESS even when the session is expired and rejected.
- */
-WOLFSSL_ABI
-int wolfSSL_set_session(WOLFSSL* ssl, WOLFSSL_SESSION* session)
-{
-    WOLFSSL_ENTER("wolfSSL_set_session");
-    if (session)
-        return wolfSSL_SetSession(ssl, session);
-
-    return WOLFSSL_FAILURE;
-}
-
-
-#ifndef NO_CLIENT_CACHE
-
-/* Associate client session with serverID, find existing or store for saving
-   if newSession flag on, don't reuse existing session
-   WOLFSSL_SUCCESS on ok */
-int wolfSSL_SetServerID(WOLFSSL* ssl, const byte* id, int len, int newSession)
-{
-    WOLFSSL_SESSION* session = NULL;
-    byte idHash[SERVER_ID_LEN];
-
-    WOLFSSL_ENTER("wolfSSL_SetServerID");
-
-    if (ssl == NULL || id == NULL || len <= 0)
-        return BAD_FUNC_ARG;
-
-    if (len > SERVER_ID_LEN) {
-#if defined(NO_SHA) && !defined(NO_SHA256)
-        if (wc_Sha256Hash(id, len, idHash) != 0)
-            return WOLFSSL_FAILURE;
-#else
-        if (wc_ShaHash(id, len, idHash) != 0)
-            return WOLFSSL_FAILURE;
-#endif
-        id = idHash;
-        len = SERVER_ID_LEN;
-    }
-
-    if (newSession == 0) {
-        session = wolfSSL_GetSessionClient(ssl, id, len);
-        if (session) {
-            if (wolfSSL_SetSession(ssl, session) != WOLFSSL_SUCCESS) {
-            #ifdef HAVE_EXT_CACHE
-                wolfSSL_FreeSession(ssl->ctx, session);
-            #endif
-                WOLFSSL_MSG("wolfSSL_SetSession failed");
-                session = NULL;
-            }
-        }
-    }
-
-    if (session == NULL) {
-        WOLFSSL_MSG("Valid ServerID not cached already");
-
-        ssl->session->idLen = (word16)len;
-        XMEMCPY(ssl->session->serverID, id, len);
-    }
-#ifdef HAVE_EXT_CACHE
-    else {
-        wolfSSL_FreeSession(ssl->ctx, session);
-    }
-#endif
-
-    return WOLFSSL_SUCCESS;
-}
-
-#endif /* !NO_CLIENT_CACHE */
-
-/* TODO: Add SESSION_CACHE_DYNAMIC_MEM support for PERSIST_SESSION_CACHE.
- * Need a count of current sessions to get an accurate memsize (totalCount is
- * not decremented when sessions are removed).
- * Need to determine ideal layout for mem/filesave.
- * Also need mem/filesave checking to ensure not restoring non DYNAMIC_MEM cache.
- */
-#if defined(PERSIST_SESSION_CACHE) && !defined(SESSION_CACHE_DYNAMIC_MEM)
-
-/* for persistence, if changes to layout need to increment and modify
-   save_session_cache() and restore_session_cache and memory versions too */
-#define WOLFSSL_CACHE_VERSION 2
-
-/* Session Cache Header information */
-typedef struct {
-    int version;     /* cache layout version id */
-    int rows;        /* session rows */
-    int columns;     /* session columns */
-    int sessionSz;   /* sizeof WOLFSSL_SESSION */
-} cache_header_t;
-
-/* current persistence layout is:
-
-   1) cache_header_t
-   2) SessionCache
-   3) ClientCache
-
-   update WOLFSSL_CACHE_VERSION if change layout for the following
-   PERSISTENT_SESSION_CACHE functions
-*/
-
-/* get how big the the session cache save buffer needs to be */
-int wolfSSL_get_session_cache_memsize(void)
-{
-    int sz  = (int)(sizeof(SessionCache) + sizeof(cache_header_t));
-#ifndef NO_CLIENT_CACHE
-    sz += (int)(sizeof(ClientCache));
-#endif
-    return sz;
-}
-
-
-/* Persist session cache to memory */
-int wolfSSL_memsave_session_cache(void* mem, int sz)
-{
-    int i;
-    cache_header_t cache_header;
-    SessionRow*    row  = (SessionRow*)((byte*)mem + sizeof(cache_header));
-
-    WOLFSSL_ENTER("wolfSSL_memsave_session_cache");
-
-    if (sz < wolfSSL_get_session_cache_memsize()) {
-        WOLFSSL_MSG("Memory buffer too small");
-        return BUFFER_E;
-    }
-
-    cache_header.version   = WOLFSSL_CACHE_VERSION;
-    cache_header.rows      = SESSION_ROWS;
-    cache_header.columns   = SESSIONS_PER_ROW;
-    cache_header.sessionSz = (int)sizeof(WOLFSSL_SESSION);
-    XMEMCPY(mem, &cache_header, sizeof(cache_header));
-
-#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
-    if (SESSION_ROW_RD_LOCK(row) != 0) {
-        WOLFSSL_MSG("Session cache mutex lock failed");
-        return BAD_MUTEX_E;
-    }
-#endif
-    for (i = 0; i < cache_header.rows; ++i) {
-    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-        if (SESSION_ROW_RD_LOCK(&SessionCache[i]) != 0) {
-            WOLFSSL_MSG("Session row cache mutex lock failed");
-            return BAD_MUTEX_E;
-        }
-    #endif
-
-        XMEMCPY(row++, &SessionCache[i], SIZEOF_SESSION_ROW);
-    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-        SESSION_ROW_UNLOCK(&SessionCache[i]);
-    #endif
-    }
-#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
-    SESSION_ROW_UNLOCK(row);
-#endif
-
-#ifndef NO_CLIENT_CACHE
-    if (wc_LockMutex(&clisession_mutex) != 0) {
-        WOLFSSL_MSG("Client cache mutex lock failed");
-        return BAD_MUTEX_E;
-    }
-    XMEMCPY(row, ClientCache, sizeof(ClientCache));
-    wc_UnLockMutex(&clisession_mutex);
-#endif
-
-    WOLFSSL_LEAVE("wolfSSL_memsave_session_cache", WOLFSSL_SUCCESS);
-
-    return WOLFSSL_SUCCESS;
-}
-
-
-/* Restore the persistent session cache from memory */
-int wolfSSL_memrestore_session_cache(const void* mem, int sz)
-{
-    int    i;
-    cache_header_t cache_header;
-    SessionRow*    row  = (SessionRow*)((byte*)mem + sizeof(cache_header));
-
-    WOLFSSL_ENTER("wolfSSL_memrestore_session_cache");
-
-    if (sz < wolfSSL_get_session_cache_memsize()) {
-        WOLFSSL_MSG("Memory buffer too small");
-        return BUFFER_E;
-    }
-
-    XMEMCPY(&cache_header, mem, sizeof(cache_header));
-    if (cache_header.version   != WOLFSSL_CACHE_VERSION ||
-        cache_header.rows      != SESSION_ROWS ||
-        cache_header.columns   != SESSIONS_PER_ROW ||
-        cache_header.sessionSz != (int)sizeof(WOLFSSL_SESSION)) {
-
-        WOLFSSL_MSG("Session cache header match failed");
-        return CACHE_MATCH_ERROR;
-    }
-
-#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
-    if (SESSION_ROW_WR_LOCK(&SessionCache[0]) != 0) {
-        WOLFSSL_MSG("Session cache mutex lock failed");
-        return BAD_MUTEX_E;
-    }
-#endif
-    for (i = 0; i < cache_header.rows; ++i) {
-    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-        if (SESSION_ROW_WR_LOCK(&SessionCache[i]) != 0) {
-            WOLFSSL_MSG("Session row cache mutex lock failed");
-            return BAD_MUTEX_E;
-        }
-    #endif
-
-        XMEMCPY(&SessionCache[i], row++, SIZEOF_SESSION_ROW);
-    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-        SESSION_ROW_UNLOCK(&SessionCache[i]);
-    #endif
-    }
-#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
-    SESSION_ROW_UNLOCK(&SessionCache[0]);
-#endif
-
-#ifndef NO_CLIENT_CACHE
-    if (wc_LockMutex(&clisession_mutex) != 0) {
-        WOLFSSL_MSG("Client cache mutex lock failed");
-        return BAD_MUTEX_E;
-    }
-    XMEMCPY(ClientCache, row, sizeof(ClientCache));
-    wc_UnLockMutex(&clisession_mutex);
-#endif
-
-    WOLFSSL_LEAVE("wolfSSL_memrestore_session_cache", WOLFSSL_SUCCESS);
-
-    return WOLFSSL_SUCCESS;
-}
-
-#if !defined(NO_FILESYSTEM)
-
-/* Persist session cache to file */
-/* doesn't use memsave because of additional memory use */
-int wolfSSL_save_session_cache(const char *fname)
-{
-    XFILE  file;
-    int    ret;
-    int    rc = WOLFSSL_SUCCESS;
-    int    i;
-    cache_header_t cache_header;
-
-    WOLFSSL_ENTER("wolfSSL_save_session_cache");
-
-    file = XFOPEN(fname, "w+b");
-    if (file == XBADFILE) {
-        WOLFSSL_MSG("Couldn't open session cache save file");
-        return WOLFSSL_BAD_FILE;
-    }
-    cache_header.version   = WOLFSSL_CACHE_VERSION;
-    cache_header.rows      = SESSION_ROWS;
-    cache_header.columns   = SESSIONS_PER_ROW;
-    cache_header.sessionSz = (int)sizeof(WOLFSSL_SESSION);
-
-    /* cache header */
-    ret = (int)XFWRITE(&cache_header, sizeof cache_header, 1, file);
-    if (ret != 1) {
-        WOLFSSL_MSG("Session cache header file write failed");
-        XFCLOSE(file);
-        return FWRITE_ERROR;
-    }
-
-#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
-    if (SESSION_ROW_RD_LOCK(&SessionCache[0]) != 0) {
-        WOLFSSL_MSG("Session cache mutex lock failed");
-        XFCLOSE(file);
-        return BAD_MUTEX_E;
-    }
-#endif
-    /* session cache */
-    for (i = 0; i < cache_header.rows; ++i) {
-    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-        if (SESSION_ROW_RD_LOCK(&SessionCache[i]) != 0) {
-            WOLFSSL_MSG("Session row cache mutex lock failed");
-            XFCLOSE(file);
-            return BAD_MUTEX_E;
-        }
-    #endif
-
-        ret = (int)XFWRITE(&SessionCache[i], SIZEOF_SESSION_ROW, 1, file);
-    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-        SESSION_ROW_UNLOCK(&SessionCache[i]);
-    #endif
-        if (ret != 1) {
-            WOLFSSL_MSG("Session cache member file write failed");
-            rc = FWRITE_ERROR;
-            break;
-        }
-    }
-#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
-    SESSION_ROW_UNLOCK(&SessionCache[0]);
-#endif
-
-#ifndef NO_CLIENT_CACHE
-    /* client cache */
-    if (wc_LockMutex(&clisession_mutex) != 0) {
-        WOLFSSL_MSG("Client cache mutex lock failed");
-        XFCLOSE(file);
-        return BAD_MUTEX_E;
-    }
-    ret = (int)XFWRITE(ClientCache, sizeof(ClientCache), 1, file);
-    if (ret != 1) {
-        WOLFSSL_MSG("Client cache member file write failed");
-        rc = FWRITE_ERROR;
-    }
-    wc_UnLockMutex(&clisession_mutex);
-#endif /* !NO_CLIENT_CACHE */
-
-    XFCLOSE(file);
-    WOLFSSL_LEAVE("wolfSSL_save_session_cache", rc);
-
-    return rc;
-}
-
-
-/* Restore the persistent session cache from file */
-/* doesn't use memstore because of additional memory use */
-int wolfSSL_restore_session_cache(const char *fname)
-{
-    XFILE  file;
-    int    rc = WOLFSSL_SUCCESS;
-    int    ret;
-    int    i;
-    cache_header_t cache_header;
-
-    WOLFSSL_ENTER("wolfSSL_restore_session_cache");
-
-    file = XFOPEN(fname, "rb");
-    if (file == XBADFILE) {
-        WOLFSSL_MSG("Couldn't open session cache save file");
-        return WOLFSSL_BAD_FILE;
-    }
-    /* cache header */
-    ret = (int)XFREAD(&cache_header, sizeof(cache_header), 1, file);
-    if (ret != 1) {
-        WOLFSSL_MSG("Session cache header file read failed");
-        XFCLOSE(file);
-        return FREAD_ERROR;
-    }
-    if (cache_header.version   != WOLFSSL_CACHE_VERSION ||
-        cache_header.rows      != SESSION_ROWS ||
-        cache_header.columns   != SESSIONS_PER_ROW ||
-        cache_header.sessionSz != (int)sizeof(WOLFSSL_SESSION)) {
-
-        WOLFSSL_MSG("Session cache header match failed");
-        XFCLOSE(file);
-        return CACHE_MATCH_ERROR;
-    }
-
-#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
-    if (SESSION_ROW_WR_LOCK(&SessionCache[0]) != 0) {
-        WOLFSSL_MSG("Session cache mutex lock failed");
-        XFCLOSE(file);
-        return BAD_MUTEX_E;
-    }
-#endif
-    /* session cache */
-    for (i = 0; i < cache_header.rows; ++i) {
-    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-        if (SESSION_ROW_WR_LOCK(&SessionCache[i]) != 0) {
-            WOLFSSL_MSG("Session row cache mutex lock failed");
-            XFCLOSE(file);
-            return BAD_MUTEX_E;
-        }
-    #endif
-
-        ret = (int)XFREAD(&SessionCache[i], SIZEOF_SESSION_ROW, 1, file);
-    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-        SESSION_ROW_UNLOCK(&SessionCache[i]);
-    #endif
-        if (ret != 1) {
-            WOLFSSL_MSG("Session cache member file read failed");
-            XMEMSET(SessionCache, 0, sizeof SessionCache);
-            rc = FREAD_ERROR;
-            break;
-        }
-    }
-#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
-    SESSION_ROW_UNLOCK(&SessionCache[0]);
-#endif
-
-#ifndef NO_CLIENT_CACHE
-    /* client cache */
-    if (wc_LockMutex(&clisession_mutex) != 0) {
-        WOLFSSL_MSG("Client cache mutex lock failed");
-        XFCLOSE(file);
-        return BAD_MUTEX_E;
-    }
-    ret = (int)XFREAD(ClientCache, sizeof(ClientCache), 1, file);
-    if (ret != 1) {
-        WOLFSSL_MSG("Client cache member file read failed");
-        XMEMSET(ClientCache, 0, sizeof ClientCache);
-        rc = FREAD_ERROR;
-    }
-    wc_UnLockMutex(&clisession_mutex);
-#endif /* !NO_CLIENT_CACHE */
-
-    XFCLOSE(file);
-    WOLFSSL_LEAVE("wolfSSL_restore_session_cache", rc);
-
-    return rc;
-}
-
-#endif /* !NO_FILESYSTEM */
-#endif /* PERSIST_SESSION_CACHE && !SESSION_CACHE_DYNAMIC_MEM */
-#endif /* NO_SESSION_CACHE */
-
-
 void wolfSSL_load_error_strings(void)
 {
     /* compatibility only */
@@ -11722,7 +8216,7 @@ int wolfSSL_set_session_secret_cb(WOLFSSL* ssl, SessionSecretCb cb, void* ctx)
 {
     WOLFSSL_ENTER("wolfSSL_set_session_secret_cb");
     if (ssl == NULL)
-        return WOLFSSL_FATAL_ERROR;
+        return WOLFSSL_FAILURE;
 
     ssl->sessionSecretCb = cb;
     ssl->sessionSecretCtx = ctx;
@@ -11735,86 +8229,97 @@ int wolfSSL_set_session_secret_cb(WOLFSSL* ssl, SessionSecretCb cb, void* ctx)
     return WOLFSSL_SUCCESS;
 }
 
-#endif
-
-
-#ifndef NO_SESSION_CACHE
-
-/* on by default if built in but allow user to turn off */
-WOLFSSL_ABI
-long wolfSSL_CTX_set_session_cache_mode(WOLFSSL_CTX* ctx, long mode)
+int wolfSSL_set_session_ticket_ext_cb(WOLFSSL* ssl, TicketParseCb cb,
+        void *ctx)
 {
-    WOLFSSL_ENTER("wolfSSL_CTX_set_session_cache_mode");
-
-    if (ctx == NULL)
+    WOLFSSL_ENTER("wolfSSL_set_session_ticket_ext_cb");
+    if (ssl == NULL)
         return WOLFSSL_FAILURE;
 
-    if (mode == WOLFSSL_SESS_CACHE_OFF) {
-        ctx->sessionCacheOff = 1;
-#ifdef HAVE_EXT_CACHE
-        ctx->internalCacheOff = 1;
-        ctx->internalCacheLookupOff = 1;
-#endif
-    }
-
-    if ((mode & WOLFSSL_SESS_CACHE_NO_AUTO_CLEAR) != 0)
-        ctx->sessionCacheFlushOff = 1;
-
-#ifdef HAVE_EXT_CACHE
-    /* WOLFSSL_SESS_CACHE_NO_INTERNAL activates both if's */
-    if ((mode & WOLFSSL_SESS_CACHE_NO_INTERNAL_STORE) != 0)
-        ctx->internalCacheOff = 1;
-    if ((mode & WOLFSSL_SESS_CACHE_NO_INTERNAL_LOOKUP) != 0)
-        ctx->internalCacheLookupOff = 1;
-#endif
+    ssl->ticketParseCb = cb;
+    ssl->ticketParseCtx = ctx;
 
     return WOLFSSL_SUCCESS;
 }
 
-#ifdef OPENSSL_EXTRA
-/* Get the session cache mode for CTX
- *
- * ctx  WOLFSSL_CTX struct to get cache mode from
- *
- * Returns a bit mask that has the session cache mode */
-long wolfSSL_CTX_get_session_cache_mode(WOLFSSL_CTX* ctx)
+int wolfSSL_set_secret_cb(WOLFSSL* ssl, TlsSecretCb cb, void* ctx)
 {
-    long m = 0;
+    WOLFSSL_ENTER("wolfSSL_set_secret_cb");
+    if (ssl == NULL)
+        return WOLFSSL_FATAL_ERROR;
 
-    WOLFSSL_ENTER("wolfSSL_CTX_get_session_cache_mode");
+    ssl->tlsSecretCb = cb;
+    ssl->tlsSecretCtx = ctx;
 
-    if (ctx == NULL) {
-        return m;
+    return WOLFSSL_SUCCESS;
+}
+
+#ifdef SHOW_SECRETS
+int tlsShowSecrets(WOLFSSL* ssl, void* secret, int secretSz,
+        void* ctx)
+{
+    /* Wireshark Pre-Master-Secret Format:
+     *  CLIENT_RANDOM <clientrandom> <mastersecret>
+     */
+    const char* CLIENT_RANDOM_LABEL = "CLIENT_RANDOM";
+    int i, pmsPos = 0;
+    char pmsBuf[13 + 1 + 64 + 1 + 96 + 1 + 1];
+    byte clientRandom[RAN_LEN];
+    int clientRandomSz;
+
+    (void)ctx;
+
+    clientRandomSz = (int)wolfSSL_get_client_random(ssl, clientRandom,
+        sizeof(clientRandom));
+
+    if (clientRandomSz <= 0) {
+        printf("Error getting server random %d\n", clientRandomSz);
+        return BAD_FUNC_ARG;
     }
 
-    if (ctx->sessionCacheOff != 1) {
-        m |= WOLFSSL_SESS_CACHE_SERVER;
+    XSNPRINTF(&pmsBuf[pmsPos], sizeof(pmsBuf) - pmsPos, "%s ",
+        CLIENT_RANDOM_LABEL);
+    pmsPos += XSTRLEN(CLIENT_RANDOM_LABEL) + 1;
+    for (i = 0; i < clientRandomSz; i++) {
+        XSNPRINTF(&pmsBuf[pmsPos], sizeof(pmsBuf) - pmsPos, "%02x",
+            clientRandom[i]);
+        pmsPos += 2;
     }
+    XSNPRINTF(&pmsBuf[pmsPos], sizeof(pmsBuf) - pmsPos, " ");
+    pmsPos += 1;
+    for (i = 0; i < secretSz; i++) {
+        XSNPRINTF(&pmsBuf[pmsPos], sizeof(pmsBuf) - pmsPos, "%02x",
+            ((byte*)secret)[i]);
+        pmsPos += 2;
+    }
+    XSNPRINTF(&pmsBuf[pmsPos], sizeof(pmsBuf) - pmsPos, "\n");
+    pmsPos += 1;
 
-    if (ctx->sessionCacheFlushOff == 1) {
-        m |= WOLFSSL_SESS_CACHE_NO_AUTO_CLEAR;
-    }
+    /* print master secret */
+    puts(pmsBuf);
 
-#ifdef HAVE_EXT_CACHE
-    if (ctx->internalCacheOff == 1) {
-        m |= WOLFSSL_SESS_CACHE_NO_INTERNAL_STORE;
+    #if !defined(NO_FILESYSTEM) && defined(WOLFSSL_SSLKEYLOGFILE)
+    {
+        FILE* f = XFOPEN(WOLFSSL_SSLKEYLOGFILE_OUTPUT, "a");
+        if (f != XBADFILE) {
+            XFWRITE(pmsBuf, 1, pmsPos, f);
+            XFCLOSE(f);
+        }
     }
-    if (ctx->internalCacheLookupOff == 1) {
-        m |= WOLFSSL_SESS_CACHE_NO_INTERNAL_LOOKUP;
-    }
+    #endif
+    return 0;
+}
+#endif /* SHOW_SECRETS */
+
 #endif
 
-    return m;
-}
-#endif /* OPENSSL_EXTRA */
-
-#endif /* NO_SESSION_CACHE */
 
 #ifdef OPENSSL_EXTRA
 
 /*
  * check if the list has TLS13 and pre-TLS13 suites
  * @param list cipher suite list that user want to set
+ *         (caller required to check for NULL)
  * @return mixed: 0, only pre-TLS13: 1, only TLS13: 2
  */
 static int CheckcipherList(const char* list)
@@ -11837,6 +8342,9 @@ static int CheckcipherList(const char* list)
 
         current_length = (!next) ? (word32)XSTRLEN(current)
                                  : (word32)(next - current);
+        if (current_length == 0) {
+            break;
+        }
 
         if (current_length < length) {
             length = current_length;
@@ -11844,8 +8352,10 @@ static int CheckcipherList(const char* list)
         XMEMCPY(name, current, length);
         name[length] = 0;
 
-        if (XSTRCMP(name, "ALL") == 0 || XSTRCMP(name, "DEFAULT") == 0 ||
-                XSTRCMP(name, "HIGH") == 0) {
+        if (XSTRCMP(name, "ALL") == 0 ||
+            XSTRCMP(name, "DEFAULT") == 0 ||
+            XSTRCMP(name, "HIGH") == 0)
+        {
             findTLSv13Suites = 1;
             findbeforeSuites = 1;
             break;
@@ -11873,7 +8383,7 @@ static int CheckcipherList(const char* list)
                 subStrNext = XSTRSTR(subStr, "+");
 
                 if ((XSTRCMP(subStr, "ECDHE") == 0) ||
-                        (XSTRCMP(subStr, "RSA") == 0)) {
+                    (XSTRCMP(subStr, "RSA") == 0)) {
                     return 0;
                 }
 
@@ -11889,7 +8399,7 @@ static int CheckcipherList(const char* list)
             return 0;
         }
     }
-    while (next++); /* ++ needed to skip ':' */
+    while (next++); /* increment to skip ':' */
 
     if (findTLSv13Suites == 0 && findbeforeSuites == 1) {
         ret = 1;/* only before TLSv13 suites */
@@ -12120,7 +8630,8 @@ static const struct ForbiddenLabels {
     {TLS_PRF_LABEL_CLIENT_FINISHED, XSTR_SIZEOF(TLS_PRF_LABEL_CLIENT_FINISHED)},
     {TLS_PRF_LABEL_SERVER_FINISHED, XSTR_SIZEOF(TLS_PRF_LABEL_SERVER_FINISHED)},
     {TLS_PRF_LABEL_MASTER_SECRET, XSTR_SIZEOF(TLS_PRF_LABEL_MASTER_SECRET)},
-    {TLS_PRF_LABEL_EXT_MASTER_SECRET, XSTR_SIZEOF(TLS_PRF_LABEL_EXT_MASTER_SECRET)},
+    {TLS_PRF_LABEL_EXT_MASTER_SECRET,
+     XSTR_SIZEOF(TLS_PRF_LABEL_EXT_MASTER_SECRET)},
     {TLS_PRF_LABEL_KEY_EXPANSION, XSTR_SIZEOF(TLS_PRF_LABEL_KEY_EXPANSION)},
     {NULL, 0},
 };
@@ -12209,8 +8720,9 @@ int wolfSSL_export_keying_material(WOLFSSL *ssl,
 
     PRIVATE_KEY_UNLOCK();
     if (wc_PRF_TLS(out, (word32)outLen, ssl->arrays->masterSecret, SECRET_LEN,
-            (byte*)label, (word32)labelLen, seed, seedLen, IsAtLeastTLSv1_2(ssl),
-            ssl->specs.mac_algorithm, ssl->heap, ssl->devId) != 0) {
+            (byte*)label, (word32)labelLen, seed, seedLen,
+            IsAtLeastTLSv1_2(ssl), ssl->specs.mac_algorithm, ssl->heap,
+            ssl->devId) != 0) {
         WOLFSSL_MSG("wc_PRF_TLS error");
         PRIVATE_KEY_LOCK();
         XFREE(seed, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -12322,7 +8834,8 @@ int wolfSSL_DTLSv1_handle_timeout(WOLFSSL* ssl)
 #endif
 
 #ifndef NO_WOLFSSL_STUB
-void wolfSSL_DTLSv1_set_initial_timeout_duration(WOLFSSL* ssl, word32 duration_ms)
+void wolfSSL_DTLSv1_set_initial_timeout_duration(WOLFSSL* ssl,
+    word32 duration_ms)
 {
     WOLFSSL_STUB("SSL_DTLSv1_set_initial_timeout_duration");
     (void)ssl;
@@ -12337,7 +8850,8 @@ int wolfSSL_dtls_set_timeout_init(WOLFSSL* ssl, int timeout)
         return BAD_FUNC_ARG;
 
     if (timeout > ssl->dtls_timeout_max) {
-        WOLFSSL_MSG("Can't set dtls timeout init greater than dtls timeout max");
+        WOLFSSL_MSG("Can't set dtls timeout init greater than dtls timeout "
+                    "max");
         return BAD_FUNC_ARG;
     }
 
@@ -12524,6 +9038,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         return m;
     }
 
+    #ifndef NO_OLD_TLS
     #ifdef WOLFSSL_ALLOW_SSLV3
     WOLFSSL_METHOD* wolfSSLv3_method(void)
     {
@@ -12544,6 +9059,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
 
         return m;
     }
+    #endif
     #endif
 #endif /* OPENSSL_EXTRA || WOLFSSL_EITHER_SIDE */
 
@@ -12589,7 +9105,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         (void)heap;
         WOLFSSL_ENTER("wolfSSLv23_client_method_ex");
         if (method) {
-    #if !defined(NO_SHA256) || defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)
+    #if !defined(NO_SHA256) || defined(WOLFSSL_SHA384) || \
+        defined(WOLFSSL_SHA512)
         #if defined(WOLFSSL_TLS13)
             InitSSL_Method(method, MakeTLSv1_3());
         #elif !defined(WOLFSSL_NO_TLS12)
@@ -12613,7 +9130,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
     WOLFSSL_ABI
     int wolfSSL_connect(WOLFSSL* ssl)
     {
-    #if !(defined(WOLFSSL_NO_TLS12) && defined(NO_OLD_TLS) && defined(WOLFSSL_TLS13))
+    #if !(defined(WOLFSSL_NO_TLS12) && defined(NO_OLD_TLS) && \
+          defined(WOLFSSL_TLS13))
         int neededState;
         byte advanceState;
     #endif
@@ -12646,7 +9164,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
     #endif
     #endif /* OPENSSL_EXTRA || WOLFSSL_EITHER_SIDE */
 
-    #if defined(WOLFSSL_NO_TLS12) && defined(NO_OLD_TLS) && defined(WOLFSSL_TLS13)
+    #if defined(WOLFSSL_NO_TLS12) && defined(NO_OLD_TLS) && \
+        defined(WOLFSSL_TLS13)
         return wolfSSL_connect_TLSv13(ssl);
     #else
         #ifdef WOLFSSL_TLS13
@@ -12720,8 +9239,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                 if (ssl->fragOffset == 0 && !ssl->options.buildingMsg) {
                     if (advanceState) {
                         ssl->options.connectState++;
-                        WOLFSSL_MSG("connect state: "
-                                    "Advanced from last buffered fragment send");
+                        WOLFSSL_MSG("connect state: Advanced from last "
+                                    "buffered fragment send");
                     #ifdef WOLFSSL_ASYNC_IO
                         /* Cleanup async */
                         FreeAsyncCtx(ssl, 0);
@@ -12913,7 +9432,7 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                 #endif
 #ifdef WOLFSSL_EXTRA_ALERTS
                     if (ssl->error == NO_PEER_KEY ||
-                        ssl->error == PSK_KEY_ERROR) {
+                        ssl->error == WC_NO_ERR_TRACE(PSK_KEY_ERROR)) {
                         SendAlert(ssl, alert_fatal, handshake_failure);
                     }
 #endif
@@ -13022,7 +9541,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         #if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_SECURE_RENEGOTIATION)
             /* This may be necessary in async so that we don't try to
              * renegotiate again */
-            if (ssl->secure_renegotiation && ssl->secure_renegotiation->startScr) {
+            if (ssl->secure_renegotiation &&
+                    ssl->secure_renegotiation->startScr) {
                 ssl->secure_renegotiation->startScr = 0;
             }
         #endif /* WOLFSSL_ASYNC_CRYPT && HAVE_SECURE_RENEGOTIATION */
@@ -13091,7 +9611,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
         (void)heap;
         WOLFSSL_ENTER("wolfSSLv23_server_method_ex");
         if (method) {
-    #if !defined(NO_SHA256) || defined(WOLFSSL_SHA384) || defined(WOLFSSL_SHA512)
+    #if !defined(NO_SHA256) || defined(WOLFSSL_SHA384) || \
+        defined(WOLFSSL_SHA512)
         #ifdef WOLFSSL_TLS13
             InitSSL_Method(method, MakeTLSv1_3());
         #elif !defined(WOLFSSL_NO_TLS12)
@@ -13118,7 +9639,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
     WOLFSSL_ABI
     int wolfSSL_accept(WOLFSSL* ssl)
     {
-#if !(defined(WOLFSSL_NO_TLS12) && defined(NO_OLD_TLS) && defined(WOLFSSL_TLS13))
+#if !(defined(WOLFSSL_NO_TLS12) && defined(NO_OLD_TLS) && \
+    defined(WOLFSSL_TLS13))
         word16 havePSK = 0;
         word16 haveAnon = 0;
         word16 haveMcast = 0;
@@ -13279,8 +9801,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                         ssl->options.acceptState == TICKET_SENT ||
                         ssl->options.acceptState == CHANGE_CIPHER_SENT) {
                         ssl->options.acceptState++;
-                        WOLFSSL_MSG("accept state: "
-                                    "Advanced from last buffered fragment send");
+                        WOLFSSL_MSG("accept state: Advanced from last "
+                                    "buffered fragment send");
                     #ifdef WOLFSSL_ASYNC_IO
                         /* Cleanup async */
                         FreeAsyncCtx(ssl, 0);
@@ -13408,7 +9930,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
                     if (ssl->options.verifyPeer) {
                         if ( (ssl->error = SendCertificateRequest(ssl)) != 0) {
                         #ifdef WOLFSSL_CHECK_ALERT_ON_ERR
-                            ProcessReplyEx(ssl, 1); /* See if an alert was sent. */
+                            /* See if an alert was sent. */
+                            ProcessReplyEx(ssl, 1);
                         #endif
                             WOLFSSL_ERROR(ssl->error);
                             return WOLFSSL_FATAL_ERROR;
@@ -13551,7 +10074,8 @@ int wolfSSL_DTLS_SetCookieSecret(WOLFSSL* ssl,
 #if defined(WOLFSSL_ASYNC_CRYPT) && defined(HAVE_SECURE_RENEGOTIATION)
             /* This may be necessary in async so that we don't try to
              * renegotiate again */
-            if (ssl->secure_renegotiation && ssl->secure_renegotiation->startScr) {
+            if (ssl->secure_renegotiation &&
+                    ssl->secure_renegotiation->startScr) {
                 ssl->secure_renegotiation->startScr = 0;
             }
 #endif /* WOLFSSL_ASYNC_CRYPT && HAVE_SECURE_RENEGOTIATION */
@@ -13703,7 +10227,8 @@ int wolfSSL_Cleanup(void)
 #endif /* !NO_SESSION_CACHE */
 
 #ifndef WOLFSSL_MUTEX_INITIALIZER
-    if ((inits_count_mutex_valid == 1) && (wc_FreeMutex(&inits_count_mutex) != 0)) {
+    if ((inits_count_mutex_valid == 1) &&
+            (wc_FreeMutex(&inits_count_mutex) != 0)) {
         if (ret == WOLFSSL_SUCCESS)
             ret = BAD_MUTEX_E;
     }
@@ -13757,1711 +10282,6 @@ int wolfSSL_Cleanup(void)
 
     return ret;
 }
-
-void SetupSession(WOLFSSL* ssl)
-{
-    WOLFSSL_SESSION* session = ssl->session;
-
-    WOLFSSL_ENTER("SetupSession");
-
-    if (!IsAtLeastTLSv1_3(ssl->version) && ssl->arrays != NULL) {
-        /* Make sure the session ID is available when the user calls any
-         * get_session API */
-        if (!session->haveAltSessionID) {
-            XMEMCPY(session->sessionID, ssl->arrays->sessionID, ID_LEN);
-            session->sessionIDSz = ssl->arrays->sessionIDSz;
-        }
-        else {
-            XMEMCPY(session->sessionID, session->altSessionID, ID_LEN);
-            session->sessionIDSz = ID_LEN;
-        }
-    }
-    session->side = (byte)ssl->options.side;
-    if (!IsAtLeastTLSv1_3(ssl->version) && ssl->arrays != NULL)
-        XMEMCPY(session->masterSecret, ssl->arrays->masterSecret, SECRET_LEN);
-    session->haveEMS = ssl->options.haveEMS;
-#ifdef WOLFSSL_SESSION_ID_CTX
-    /* If using compatibility layer then check for and copy over session context
-     * id. */
-    if (ssl->sessionCtxSz > 0 && ssl->sessionCtxSz < ID_LEN) {
-        XMEMCPY(ssl->session->sessionCtx, ssl->sessionCtx, ssl->sessionCtxSz);
-        session->sessionCtxSz = ssl->sessionCtxSz;
-    }
-#endif
-    session->timeout = ssl->timeout;
-#ifndef NO_ASN_TIME
-    session->bornOn  = LowResTimer();
-#endif
-#if defined(SESSION_CERTS) || (defined(WOLFSSL_TLS13) && \
-                               defined(HAVE_SESSION_TICKET))
-    session->version = ssl->version;
-#endif
-#if defined(SESSION_CERTS) || !defined(NO_RESUME_SUITE_CHECK) || \
-                        (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
-    session->cipherSuite0 = ssl->options.cipherSuite0;
-    session->cipherSuite = ssl->options.cipherSuite;
-#endif
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-    session->peerVerifyRet = (byte)ssl->peerVerifyRet;
-#endif
-    session->isSetup = 1;
-}
-
-#ifndef NO_SESSION_CACHE
-
-WOLFSSL_ABI
-void wolfSSL_flush_sessions(WOLFSSL_CTX* ctx, long tm)
-{
-    /* static table now, no flushing needed */
-    (void)ctx;
-    (void)tm;
-}
-
-void wolfSSL_CTX_flush_sessions(WOLFSSL_CTX* ctx, long tm)
-{
-    int i, j;
-    byte id[ID_LEN];
-
-    (void)ctx;
-    XMEMSET(id, 0, ID_LEN);
-    WOLFSSL_ENTER("wolfSSL_flush_sessions");
-    for (i = 0; i < SESSION_ROWS; ++i) {
-        if (SESSION_ROW_WR_LOCK(&SessionCache[i]) != 0) {
-            WOLFSSL_MSG("Session cache mutex lock failed");
-            return;
-        }
-        for (j = 0; j < SESSIONS_PER_ROW; j++) {
-#ifdef SESSION_CACHE_DYNAMIC_MEM
-            WOLFSSL_SESSION* s = SessionCache[i].Sessions[j];
-#else
-            WOLFSSL_SESSION* s = &SessionCache[i].Sessions[j];
-#endif
-            if (
-#ifdef SESSION_CACHE_DYNAMIC_MEM
-                s != NULL &&
-#endif
-                XMEMCMP(s->sessionID, id, ID_LEN) != 0 &&
-                s->bornOn + s->timeout < (word32)tm
-                )
-            {
-                EvictSessionFromCache(s);
-#ifdef SESSION_CACHE_DYNAMIC_MEM
-                XFREE(s, s->heap, DYNAMIC_TYPE_SESSION);
-                SessionCache[i].Sessions[j] = NULL;
-#endif
-            }
-        }
-        SESSION_ROW_UNLOCK(&SessionCache[i]);
-    }
-}
-
-
-/* set ssl session timeout in seconds */
-WOLFSSL_ABI
-int wolfSSL_set_timeout(WOLFSSL* ssl, unsigned int to)
-{
-    if (ssl == NULL)
-        return BAD_FUNC_ARG;
-
-    if (to == 0)
-        to = WOLFSSL_SESSION_TIMEOUT;
-    ssl->timeout = to;
-
-    return WOLFSSL_SUCCESS;
-}
-
-
-/**
- * Sets ctx session timeout in seconds.
- * The timeout value set here should be reflected in the
- * "session ticket lifetime hint" if this API works in the openssl compat-layer.
- * Therefore wolfSSL_CTX_set_TicketHint is called internally.
- * Arguments:
- *  - ctx  WOLFSSL_CTX object which the timeout is set to
- *  - to   timeout value in second
- * Returns:
- *  WOLFSSL_SUCCESS on success, BAD_FUNC_ARG on failure.
- *  When WOLFSSL_ERROR_CODE_OPENSSL is defined, returns previous timeout value
- *  on success, BAD_FUNC_ARG on failure.
- */
-WOLFSSL_ABI
-int wolfSSL_CTX_set_timeout(WOLFSSL_CTX* ctx, unsigned int to)
-{
-    #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
-    word32 prev_timeout = 0;
-    #endif
-
-    int ret = WOLFSSL_SUCCESS;
-    (void)ret;
-
-    if (ctx == NULL)
-        ret = BAD_FUNC_ARG;
-
-    if (ret == WOLFSSL_SUCCESS) {
-    #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
-        prev_timeout = ctx->timeout;
-    #endif
-        if (to == 0) {
-            ctx->timeout = WOLFSSL_SESSION_TIMEOUT;
-        }
-        else {
-            ctx->timeout = to;
-        }
-    }
-#if defined(OPENSSL_EXTRA) && defined(HAVE_SESSION_TICKET) && \
-   !defined(NO_WOLFSSL_SERVER)
-    if (ret == WOLFSSL_SUCCESS) {
-        if (to == 0) {
-            ret = wolfSSL_CTX_set_TicketHint(ctx, SESSION_TICKET_HINT_DEFAULT);
-        }
-        else {
-            ret = wolfSSL_CTX_set_TicketHint(ctx, to);
-        }
-    }
-#endif /* OPENSSL_EXTRA && HAVE_SESSION_TICKET && !NO_WOLFSSL_SERVER */
-
-#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
-    if (ret == WOLFSSL_SUCCESS) {
-        return prev_timeout;
-    }
-    else {
-        return ret;
-    }
-#else
-    return ret;
-#endif /* WOLFSSL_ERROR_CODE_OPENSSL */
-}
-
-
-#ifndef NO_CLIENT_CACHE
-
-/* Get Session from Client cache based on id/len, return NULL on failure */
-WOLFSSL_SESSION* wolfSSL_GetSessionClient(WOLFSSL* ssl, const byte* id, int len)
-{
-    WOLFSSL_SESSION* ret = NULL;
-    word32          row;
-    int             idx;
-    int             count;
-    int             error = 0;
-    ClientSession*  clSess;
-
-    WOLFSSL_ENTER("wolfSSL_GetSessionClient");
-
-    if (ssl->ctx->sessionCacheOff) {
-        WOLFSSL_MSG("Session Cache off");
-        return NULL;
-    }
-
-    if (ssl->options.side == WOLFSSL_SERVER_END)
-        return NULL;
-
-    len = min(SERVER_ID_LEN, (word32)len);
-
-    /* Do not access ssl->ctx->get_sess_cb from here. It is using a different
-     * set of ID's */
-
-    row = HashObject(id, len, &error) % CLIENT_SESSION_ROWS;
-    if (error != 0) {
-        WOLFSSL_MSG("Hash session failed");
-        return NULL;
-    }
-
-    if (wc_LockMutex(&clisession_mutex) != 0) {
-        WOLFSSL_MSG("Client cache mutex lock failed");
-        return NULL;
-    }
-
-    /* start from most recently used */
-    count = min((word32)ClientCache[row].totalCount, CLIENT_SESSIONS_PER_ROW);
-    idx = ClientCache[row].nextIdx - 1;
-    if (idx < 0 || idx >= CLIENT_SESSIONS_PER_ROW) {
-        idx = CLIENT_SESSIONS_PER_ROW - 1; /* if back to front, the previous was end */
-    }
-    clSess = ClientCache[row].Clients;
-
-    for (; count > 0; --count) {
-        WOLFSSL_SESSION* current;
-        SessionRow* sessRow;
-
-        if (clSess[idx].serverRow >= SESSION_ROWS) {
-            WOLFSSL_MSG("Client cache serverRow invalid");
-            break;
-        }
-
-        /* lock row */
-        sessRow = &SessionCache[clSess[idx].serverRow];
-        if (SESSION_ROW_RD_LOCK(sessRow) != 0) {
-            WOLFSSL_MSG("Session cache row lock failure");
-            break;
-        }
-
-#ifdef SESSION_CACHE_DYNAMIC_MEM
-        current = sessRow->Sessions[clSess[idx].serverIdx];
-#else
-        current = &sessRow->Sessions[clSess[idx].serverIdx];
-#endif
-        if (current && XMEMCMP(current->serverID, id, len) == 0) {
-            WOLFSSL_MSG("Found a serverid match for client");
-            if (LowResTimer() < (current->bornOn + current->timeout)) {
-                WOLFSSL_MSG("Session valid");
-                ret = current;
-                SESSION_ROW_UNLOCK(sessRow);
-                break;
-            } else {
-                WOLFSSL_MSG("Session timed out");  /* could have more for id */
-            }
-        } else {
-            WOLFSSL_MSG("ServerID not a match from client table");
-        }
-        SESSION_ROW_UNLOCK(sessRow);
-
-        idx = idx > 0 ? idx - 1 : CLIENT_SESSIONS_PER_ROW - 1;
-    }
-
-    wc_UnLockMutex(&clisession_mutex);
-
-    return ret;
-}
-
-#endif /* !NO_CLIENT_CACHE */
-
-static int SslSessionCacheOff(const WOLFSSL* ssl, const WOLFSSL_SESSION* session)
-{
-    (void)session;
-    return ssl->options.sessionCacheOff
-    #if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_FORCE_CACHE_ON_TICKET)
-                && session->ticketLen == 0
-    #endif
-                ;
-}
-
-#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_TLS13) &&                  \
-    defined(WOLFSSL_TICKET_NONCE_MALLOC) && \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-/**
- * SessionTicketNoncePrealloc() - prealloc a buffer for ticket nonces
- * @output: [in] pointer to WOLFSSL_SESSION object that will soon be a
- * destination of a session duplication
- * @buf: [out] address of the preallocated buf
- * @len: [out] len of the preallocated buf
- *
- * prealloc a buffer that will likely suffice to contain a ticket nonce. It's
- * used when copying session under lock, when syscalls need to be avoided. If
- * output already has a dynamic buffer, it's reused.
- */
-static int SessionTicketNoncePrealloc(byte** buf, byte* len, void *heap)
-{
-    (void)heap;
-
-    *buf = (byte*)XMALLOC(PREALLOC_SESSION_TICKET_NONCE_LEN, heap,
-        DYNAMIC_TYPE_SESSION_TICK);
-    if (*buf == NULL) {
-        WOLFSSL_MSG("Failed to preallocate ticket nonce buffer");
-        *len = 0;
-        return 1;
-    }
-
-    *len = PREALLOC_SESSION_TICKET_NONCE_LEN;
-    return 0;
-}
-#endif /* HAVE_SESSION_TICKET && WOLFSSL_TLS13 */
-
-static int wolfSSL_DupSessionEx(const WOLFSSL_SESSION* input,
-    WOLFSSL_SESSION* output, int avoidSysCalls, byte* ticketNonceBuf,
-    byte* ticketNonceLen, byte* preallocUsed);
-
-void TlsSessionCacheUnlockRow(word32 row)
-{
-    SessionRow* sessRow;
-
-    sessRow = &SessionCache[row];
-    (void)sessRow;
-    SESSION_ROW_UNLOCK(sessRow);
-}
-
-/* Don't use this function directly. Use TlsSessionCacheGetAndRdLock and
- * TlsSessionCacheGetAndWrLock to fully utilize compiler const support. */
-static int TlsSessionCacheGetAndLock(const byte *id,
-    const WOLFSSL_SESSION **sess, word32 *lockedRow, byte readOnly, byte side)
-{
-    SessionRow *sessRow;
-    const WOLFSSL_SESSION *s;
-    word32 row;
-    int count;
-    int error;
-    int idx;
-
-    *sess = NULL;
-    row = HashObject(id, ID_LEN, &error) % SESSION_ROWS;
-    if (error != 0)
-        return error;
-    sessRow = &SessionCache[row];
-    if (readOnly)
-        error = SESSION_ROW_RD_LOCK(sessRow);
-    else
-        error = SESSION_ROW_WR_LOCK(sessRow);
-    if (error != 0)
-        return FATAL_ERROR;
-
-    /* start from most recently used */
-    count = min((word32)sessRow->totalCount, SESSIONS_PER_ROW);
-    idx = sessRow->nextIdx - 1;
-    if (idx < 0 || idx >= SESSIONS_PER_ROW) {
-        idx = SESSIONS_PER_ROW - 1; /* if back to front, the previous was end */
-    }
-    for (; count > 0; --count) {
-#ifdef SESSION_CACHE_DYNAMIC_MEM
-        s = sessRow->Sessions[idx];
-#else
-        s = &sessRow->Sessions[idx];
-#endif
-        if (s && XMEMCMP(s->sessionID, id, ID_LEN) == 0 && s->side == side) {
-            *sess = s;
-            break;
-        }
-        idx = idx > 0 ? idx - 1 : SESSIONS_PER_ROW - 1;
-    }
-    if (*sess == NULL) {
-        SESSION_ROW_UNLOCK(sessRow);
-    }
-    else {
-        *lockedRow = row;
-    }
-
-    return 0;
-}
-
-static int CheckSessionMatch(const WOLFSSL* ssl, const WOLFSSL_SESSION* sess)
-{
-    if (ssl == NULL || sess == NULL)
-        return 0;
-#ifdef OPENSSL_EXTRA
-    if (ssl->sessionCtxSz > 0 && (ssl->sessionCtxSz != sess->sessionCtxSz ||
-           XMEMCMP(ssl->sessionCtx, sess->sessionCtx, sess->sessionCtxSz) != 0))
-        return 0;
-#endif
-#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)
-    if (IsAtLeastTLSv1_3(ssl->version) != IsAtLeastTLSv1_3(sess->version))
-        return 0;
-#endif
-    return 1;
-}
-
-int TlsSessionCacheGetAndRdLock(const byte *id, const WOLFSSL_SESSION **sess,
-        word32 *lockedRow, byte side)
-{
-    return TlsSessionCacheGetAndLock(id, sess, lockedRow, 1, side);
-}
-
-int TlsSessionCacheGetAndWrLock(const byte *id, WOLFSSL_SESSION **sess,
-        word32 *lockedRow, byte side)
-{
-    return TlsSessionCacheGetAndLock(id, (const WOLFSSL_SESSION**)sess,
-            lockedRow, 0, side);
-}
-
-int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output)
-{
-    const WOLFSSL_SESSION* sess = NULL;
-    const byte*  id = NULL;
-    word32       row;
-    int          error = 0;
-#ifdef HAVE_SESSION_TICKET
-#ifndef WOLFSSL_SMALL_STACK
-    byte         tmpTicket[PREALLOC_SESSION_TICKET_LEN];
-#else
-    byte*        tmpTicket = NULL;
-#endif
-#ifdef WOLFSSL_TLS13
-    byte *preallocNonce = NULL;
-    byte preallocNonceLen = 0;
-    byte preallocNonceUsed = 0;
-#endif /* WOLFSSL_TLS13 */
-    byte         tmpBufSet = 0;
-#endif
-#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-    WOLFSSL_X509* peer = NULL;
-#endif
-    byte         bogusID[ID_LEN];
-    byte         bogusIDSz = 0;
-
-    WOLFSSL_ENTER("wolfSSL_GetSessionFromCache");
-
-    if (output == NULL) {
-        WOLFSSL_MSG("NULL output");
-        return WOLFSSL_FAILURE;
-    }
-
-    if (SslSessionCacheOff(ssl, ssl->session))
-        return WOLFSSL_FAILURE;
-
-    if (ssl->options.haveSessionId == 0 && !ssl->session->haveAltSessionID)
-        return WOLFSSL_FAILURE;
-
-#ifdef HAVE_SESSION_TICKET
-    if (ssl->options.side == WOLFSSL_SERVER_END && ssl->options.useTicket == 1)
-        return WOLFSSL_FAILURE;
-#endif
-
-    XMEMSET(bogusID, 0, sizeof(bogusID));
-    if (!IsAtLeastTLSv1_3(ssl->version) && ssl->arrays != NULL
-            && !ssl->session->haveAltSessionID)
-        id = ssl->arrays->sessionID;
-    else if (ssl->session->haveAltSessionID) {
-        id = ssl->session->altSessionID;
-        /* We want to restore the bogus ID for TLS compatibility */
-        if (output == ssl->session) {
-            XMEMCPY(bogusID, ssl->session->sessionID, ID_LEN);
-            bogusIDSz = ssl->session->sessionIDSz;
-        }
-    }
-    else
-        id = ssl->session->sessionID;
-
-
-#ifdef HAVE_EXT_CACHE
-    if (ssl->ctx->get_sess_cb != NULL) {
-        int copy = 0;
-        int found = 0;
-        WOLFSSL_SESSION* extSess;
-        /* Attempt to retrieve the session from the external cache. */
-        WOLFSSL_MSG("Calling external session cache");
-        extSess = ssl->ctx->get_sess_cb(ssl, (byte*)id, ID_LEN, &copy);
-        if ((extSess != NULL)
-                && CheckSessionMatch(ssl, extSess)
-            ) {
-            WOLFSSL_MSG("Session found in external cache");
-            found = 1;
-
-            error = wolfSSL_DupSession(extSess, output, 0);
-#ifdef HAVE_EX_DATA
-            extSess->ownExData = 1;
-            output->ownExData = 0;
-#endif
-            /* We want to restore the bogus ID for TLS compatibility */
-            if (ssl->session->haveAltSessionID &&
-                    output == ssl->session) {
-                XMEMCPY(ssl->session->sessionID, bogusID, ID_LEN);
-                ssl->session->sessionIDSz = bogusIDSz;
-            }
-        }
-        /* If copy not set then free immediately */
-        if (extSess != NULL && !copy)
-            wolfSSL_FreeSession(ssl->ctx, extSess);
-        if (found)
-            return error;
-        WOLFSSL_MSG("Session not found in external cache");
-    }
-
-    if (ssl->options.internalCacheLookupOff) {
-        WOLFSSL_MSG("Internal cache lookup turned off");
-        return WOLFSSL_FAILURE;
-    }
-#endif
-
-#ifdef HAVE_SESSION_TICKET
-    if (output->ticket == NULL ||
-            output->ticketLenAlloc < PREALLOC_SESSION_TICKET_LEN) {
-#ifdef WOLFSSL_SMALL_STACK
-        tmpTicket = (byte*)XMALLOC(PREALLOC_SESSION_TICKET_LEN, output->heap,
-                DYNAMIC_TYPE_TMP_BUFFER);
-        if (tmpTicket == NULL) {
-            WOLFSSL_MSG("tmpTicket malloc failed");
-            return WOLFSSL_FAILURE;
-        }
-#endif
-        if (output->ticketLenAlloc)
-            XFREE(output->ticket, output->heap, DYNAMIC_TYPE_SESSION_TICK);
-        output->ticket = tmpTicket; /* cppcheck-suppress autoVariables
-                                     */
-        output->ticketLenAlloc = PREALLOC_SESSION_TICKET_LEN;
-        output->ticketLen = 0;
-        tmpBufSet = 1;
-    }
-#endif
-
-#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-    if (output->peer != NULL) {
-        wolfSSL_X509_free(output->peer);
-        output->peer = NULL;
-    }
-#endif
-
-#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET) &&                  \
-    defined(WOLFSSL_TICKET_NONCE_MALLOC) &&                                    \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-    if (output->ticketNonce.data != output->ticketNonce.dataStatic) {
-        XFREE(output->ticketNonce.data, output->heap,
-            DYNAMIC_TYPE_SESSION_TICK);
-        output->ticketNonce.data = output->ticketNonce.dataStatic;
-        output->ticketNonce.len = 0;
-    }
-    error = SessionTicketNoncePrealloc(&preallocNonce, &preallocNonceLen,
-        output->heap);
-    if (error != 0) {
-        if (tmpBufSet) {
-            output->ticket = output->staticTicket;
-            output->ticketLenAlloc = 0;
-        }
-#ifdef WOLFSSL_SMALL_STACK
-        if (tmpTicket != NULL)
-            XFREE(tmpTicket, output->heap, DYNAMIC_TYPE_TMP_BUFFER);
-#endif
-        return WOLFSSL_FAILURE;
-    }
-#endif /* WOLFSSL_TLS13 && HAVE_SESSION_TICKET*/
-
-    /* init to avoid clang static analyzer false positive */
-    row = 0;
-    error = TlsSessionCacheGetAndRdLock(id, &sess, &row, (byte)ssl->options.side);
-    error = (error == 0) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
-    if (error != WOLFSSL_SUCCESS || sess == NULL) {
-        WOLFSSL_MSG("Get Session from cache failed");
-        error = WOLFSSL_FAILURE;
-#ifdef HAVE_SESSION_TICKET
-        if (tmpBufSet) {
-            output->ticket = output->staticTicket;
-            output->ticketLenAlloc = 0;
-        }
-#ifdef WOLFSSL_TLS13
-        if (preallocNonce != NULL) {
-            XFREE(preallocNonce, output->heap, DYNAMIC_TYPE_SESSION_TICK);
-            preallocNonce = NULL;
-        }
-#endif /* WOLFSSL_TLS13 */
-#ifdef WOLFSSL_SMALL_STACK
-        if (tmpTicket != NULL) {
-            XFREE(tmpTicket, output->heap, DYNAMIC_TYPE_TMP_BUFFER);
-            tmpTicket = NULL;
-        }
-#endif
-#endif
-    }
-    else {
-        if (!CheckSessionMatch(ssl, sess)) {
-            WOLFSSL_MSG("Invalid session: can't be used in this context");
-            TlsSessionCacheUnlockRow(row);
-            error = WOLFSSL_FAILURE;
-        }
-        else if (LowResTimer() >= (sess->bornOn + sess->timeout)) {
-            WOLFSSL_SESSION* wrSess = NULL;
-            WOLFSSL_MSG("Invalid session: timed out");
-            sess = NULL;
-            TlsSessionCacheUnlockRow(row);
-            /* Attempt to get a write lock */
-            error = TlsSessionCacheGetAndWrLock(id, &wrSess, &row,
-                    (byte)ssl->options.side);
-            if (error == 0 && wrSess != NULL) {
-                EvictSessionFromCache(wrSess);
-                TlsSessionCacheUnlockRow(row);
-            }
-            error = WOLFSSL_FAILURE;
-        }
-    }
-
-    /* mollify confused cppcheck nullPointer warning. */
-    if (sess == NULL)
-        error = WOLFSSL_FAILURE;
-
-    if (error == WOLFSSL_SUCCESS) {
-#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_TLS13)
-        error = wolfSSL_DupSessionEx(sess, output, 1,
-            preallocNonce, &preallocNonceLen, &preallocNonceUsed);
-#else
-        error = wolfSSL_DupSession(sess, output, 1);
-#endif /* HAVE_SESSION_TICKET && WOLFSSL_TLS13 */
-#ifdef HAVE_EX_DATA
-        output->ownExData = !sess->ownExData; /* Session may own ex_data */
-#endif
-        TlsSessionCacheUnlockRow(row);
-    }
-
-    /* We want to restore the bogus ID for TLS compatibility */
-    if (ssl->session->haveAltSessionID &&
-            output == ssl->session) {
-        XMEMCPY(ssl->session->sessionID, bogusID, ID_LEN);
-        ssl->session->sessionIDSz = bogusIDSz;
-    }
-
-#ifdef HAVE_SESSION_TICKET
-    if (tmpBufSet) {
-        if (error == WOLFSSL_SUCCESS) {
-            if (output->ticketLen > SESSION_TICKET_LEN) {
-                output->ticket = (byte*)XMALLOC(output->ticketLen, output->heap,
-                        DYNAMIC_TYPE_SESSION_TICK);
-                if (output->ticket == NULL) {
-                    error = WOLFSSL_FAILURE;
-                    output->ticket = output->staticTicket;
-                    output->ticketLenAlloc = 0;
-                    output->ticketLen = 0;
-                }
-            }
-            else {
-                output->ticket = output->staticTicket;
-                output->ticketLenAlloc = 0;
-            }
-        }
-        else {
-            output->ticket = output->staticTicket;
-            output->ticketLenAlloc = 0;
-            output->ticketLen = 0;
-        }
-        if (error == WOLFSSL_SUCCESS) {
-            XMEMCPY(output->ticket, tmpTicket, output->ticketLen);
-        }
-    }
-#ifdef WOLFSSL_SMALL_STACK
-    if (tmpTicket != NULL)
-        XFREE(tmpTicket, output->heap, DYNAMIC_TYPE_TMP_BUFFER);
-#endif
-
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-    if (error == WOLFSSL_SUCCESS && preallocNonceUsed) {
-        if (preallocNonceLen < PREALLOC_SESSION_TICKET_NONCE_LEN) {
-            /* buffer bigger than needed */
-#ifndef XREALLOC
-            output->ticketNonce.data = (byte*)XMALLOC(preallocNonceLen,
-                output->heap, DYNAMIC_TYPE_SESSION_TICK);
-            if (output->ticketNonce.data != NULL)
-                XMEMCPY(output->ticketNonce.data, preallocNonce,
-                    preallocNonceLen);
-            XFREE(preallocNonce, output->heap, DYNAMIC_TYPE_SESSION_TICK);
-            preallocNonce = NULL;
-#else
-            output->ticketNonce.data = XREALLOC(preallocNonce,
-                preallocNonceLen, output->heap, DYNAMIC_TYPE_SESSION_TICK);
-            if (output->ticketNonce.data != NULL) {
-                /* don't free the reallocated pointer */
-                preallocNonce = NULL;
-            }
-#endif /* !XREALLOC */
-            if (output->ticketNonce.data == NULL) {
-                output->ticketNonce.data = output->ticketNonce.dataStatic;
-                output->ticketNonce.len = 0;
-                error = WOLFSSL_FAILURE;
-                /* preallocNonce will be free'd after the if */
-            }
-        }
-        else {
-            output->ticketNonce.data = preallocNonce;
-            output->ticketNonce.len = preallocNonceLen;
-            preallocNonce = NULL;
-        }
-    }
-    if (preallocNonce != NULL)
-        XFREE(preallocNonce, output->heap, DYNAMIC_TYPE_SESSION_TICK);
-#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
-
-#endif
-
-#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-    if (peer != NULL) {
-        wolfSSL_X509_free(peer);
-    }
-#endif
-
-    return error;
-}
-
-WOLFSSL_SESSION* wolfSSL_GetSession(WOLFSSL* ssl, byte* masterSecret,
-        byte restoreSessionCerts)
-{
-    WOLFSSL_SESSION* ret = NULL;
-
-    (void)restoreSessionCerts; /* Kept for compatibility */
-
-    if (wolfSSL_GetSessionFromCache(ssl, ssl->session) == WOLFSSL_SUCCESS) {
-        ret = ssl->session;
-    }
-    else {
-        WOLFSSL_MSG("wolfSSL_GetSessionFromCache did not return a session");
-    }
-
-    if (ret != NULL && masterSecret != NULL)
-        XMEMCPY(masterSecret, ret->masterSecret, SECRET_LEN);
-
-    return ret;
-}
-
-int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session)
-{
-    SessionRow* sessRow = NULL;
-    int ret = WOLFSSL_SUCCESS;
-
-    session = ClientSessionToSession(session);
-
-    if (ssl == NULL || session == NULL || !session->isSetup) {
-        WOLFSSL_MSG("ssl or session NULL or not set up");
-        return WOLFSSL_FAILURE;
-    }
-
-    /* We need to lock the session as the first step if its in the cache */
-    if (session->type == WOLFSSL_SESSION_TYPE_CACHE) {
-        if (session->cacheRow < SESSION_ROWS) {
-            sessRow = &SessionCache[session->cacheRow];
-            if (SESSION_ROW_RD_LOCK(sessRow) != 0) {
-                WOLFSSL_MSG("Session row lock failed");
-                return WOLFSSL_FAILURE;
-            }
-        }
-    }
-
-    if (ret == WOLFSSL_SUCCESS && ssl->options.side != WOLFSSL_NEITHER_END &&
-            (byte)ssl->options.side != session->side) {
-        WOLFSSL_MSG("Setting session for wrong role");
-        ret = WOLFSSL_FAILURE;
-    }
-
-    if (ret == WOLFSSL_SUCCESS) {
-        if (ssl->session == session) {
-            WOLFSSL_MSG("ssl->session and session same");
-        }
-        else if (session->type != WOLFSSL_SESSION_TYPE_CACHE) {
-            if (wolfSSL_SESSION_up_ref(session) == WOLFSSL_SUCCESS) {
-                wolfSSL_FreeSession(ssl->ctx, ssl->session);
-                ssl->session = session;
-            }
-            else
-                ret = WOLFSSL_FAILURE;
-        }
-        else {
-            ret = wolfSSL_DupSession(session, ssl->session, 0);
-            if (ret != WOLFSSL_SUCCESS)
-                WOLFSSL_MSG("Session duplicate failed");
-        }
-    }
-
-    /* Let's copy over the altSessionID for local cache purposes */
-    if (ret == WOLFSSL_SUCCESS && session->haveAltSessionID &&
-            ssl->session != session) {
-        ssl->session->haveAltSessionID = 1;
-        XMEMCPY(ssl->session->altSessionID, session->altSessionID, ID_LEN);
-    }
-
-    if (sessRow != NULL) {
-        SESSION_ROW_UNLOCK(sessRow);
-        sessRow = NULL;
-    }
-
-    /* Note: the `session` variable cannot be used below, since the row is
-     * un-locked */
-
-    if (ret != WOLFSSL_SUCCESS)
-        return ret;
-
-#ifdef WOLFSSL_SESSION_ID_CTX
-    /* check for application context id */
-    if (ssl->sessionCtxSz > 0) {
-        if (XMEMCMP(ssl->sessionCtx, ssl->session->sessionCtx, ssl->sessionCtxSz)) {
-            /* context id did not match! */
-            WOLFSSL_MSG("Session context did not match");
-            return WOLFSSL_FAILURE;
-        }
-    }
-#endif /* WOLFSSL_SESSION_ID_CTX */
-
-    if (LowResTimer() >= (ssl->session->bornOn + ssl->session->timeout)) {
-#if !defined(OPENSSL_EXTRA) || !defined(WOLFSSL_ERROR_CODE_OPENSSL)
-        return WOLFSSL_FAILURE;  /* session timed out */
-#else /* defined(OPENSSL_EXTRA) && defined(WOLFSSL_ERROR_CODE_OPENSSL) */
-        WOLFSSL_MSG("Session is expired but return success for "
-                    "OpenSSL compatibility");
-#endif
-    }
-    ssl->options.resuming = 1;
-    ssl->options.haveEMS = ssl->session->haveEMS;
-
-#if defined(SESSION_CERTS) || (defined(WOLFSSL_TLS13) && \
-                           defined(HAVE_SESSION_TICKET))
-    ssl->version              = ssl->session->version;
-    if (IsAtLeastTLSv1_3(ssl->version))
-        ssl->options.tls1_3 = 1;
-#endif
-#if defined(SESSION_CERTS) || !defined(NO_RESUME_SUITE_CHECK) || \
-                    (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
-    ssl->options.cipherSuite0 = ssl->session->cipherSuite0;
-    ssl->options.cipherSuite  = ssl->session->cipherSuite;
-#endif
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-    ssl->peerVerifyRet = (unsigned long)ssl->session->peerVerifyRet;
-#endif
-
-    return WOLFSSL_SUCCESS;
-}
-
-
-#ifdef WOLFSSL_SESSION_STATS
-static int get_locked_session_stats(word32* active, word32* total,
-                                    word32* peak);
-#endif
-
-#ifndef NO_CLIENT_CACHE
-ClientSession* AddSessionToClientCache(int side, int row, int idx, byte* serverID,
-                            word16 idLen, const byte* sessionID,
-                            word16 useTicket)
-{
-    int error = -1;
-    word32 clientRow = 0, clientIdx = 0;
-    ClientSession* ret = NULL;
-
-    (void)useTicket;
-    if (side == WOLFSSL_CLIENT_END
-            && row != INVALID_SESSION_ROW
-            && (idLen
-#ifdef HAVE_SESSION_TICKET
-                || useTicket == 1
-#endif
-                || serverID != NULL
-                )) {
-
-        WOLFSSL_MSG("Trying to add client cache entry");
-
-        if (idLen) {
-            clientRow = HashObject(serverID,
-                    idLen, &error) % CLIENT_SESSION_ROWS;
-        }
-        else if (serverID != NULL) {
-            clientRow = HashObject(sessionID,
-                    ID_LEN, &error) % CLIENT_SESSION_ROWS;
-        }
-        else {
-            error = -1;
-        }
-        if (error == 0 && wc_LockMutex(&clisession_mutex) == 0) {
-            clientIdx = ClientCache[clientRow].nextIdx;
-            if (clientIdx < CLIENT_SESSIONS_PER_ROW) {
-                ClientCache[clientRow].Clients[clientIdx].serverRow =
-                                                                (word16)row;
-                ClientCache[clientRow].Clients[clientIdx].serverIdx =
-                                                                (word16)idx;
-                if (sessionID != NULL) {
-                    word32 sessionIDHash = HashObject(sessionID, ID_LEN,
-                                                      &error);
-                    if (error == 0) {
-                        ClientCache[clientRow].Clients[clientIdx].sessionIDHash
-                            = sessionIDHash;
-                    }
-                }
-            }
-            else {
-                error = -1;
-                ClientCache[clientRow].nextIdx = 0; /* reset index as safety */
-                WOLFSSL_MSG("Invalid client cache index! "
-                            "Possible corrupted memory");
-            }
-            if (error == 0) {
-                WOLFSSL_MSG("Adding client cache entry");
-
-                ret = &ClientCache[clientRow].Clients[clientIdx];
-
-                if (ClientCache[clientRow].totalCount < CLIENT_SESSIONS_PER_ROW)
-                    ClientCache[clientRow].totalCount++;
-                ClientCache[clientRow].nextIdx++;
-                ClientCache[clientRow].nextIdx %= CLIENT_SESSIONS_PER_ROW;
-            }
-
-            wc_UnLockMutex(&clisession_mutex);
-        }
-        else {
-            WOLFSSL_MSG("Hash session or lock failed");
-        }
-    }
-    else {
-        WOLFSSL_MSG("Skipping client cache");
-    }
-
-    return ret;
-}
-#endif /* !NO_CLIENT_CACHE */
-
-/**
- * For backwards compatibility, this API needs to be used in *ALL* functions
- * that access the WOLFSSL_SESSION members directly.
- *
- * This API checks if the passed in session is actually a ClientSession object
- * and returns the matching session cache object. Otherwise just return the
- * input. ClientSession objects only occur in the ClientCache. They are not
- * allocated anywhere else.
- */
-WOLFSSL_SESSION* ClientSessionToSession(const WOLFSSL_SESSION* session)
-{
-    WOLFSSL_ENTER("ClientSessionToSession");
-#ifdef NO_SESSION_CACHE_REF
-    return (WOLFSSL_SESSION*)session;
-#else
-#ifndef NO_CLIENT_CACHE
-    if (session == NULL)
-        return NULL;
-    /* Check if session points into ClientCache */
-    if ((byte*)session >= (byte*)ClientCache &&
-            /* Cast to byte* to make pointer arithmetic work per byte */
-            (byte*)session < ((byte*)ClientCache) + sizeof(ClientCache)) {
-        ClientSession* clientSession = (ClientSession*)session;
-        SessionRow* sessRow = NULL;
-        WOLFSSL_SESSION* cacheSession = NULL;
-        word32 sessionIDHash = 0;
-        int error = 0;
-        session = NULL; /* Default to NULL for failure case */
-        if (wc_LockMutex(&clisession_mutex) != 0) {
-            WOLFSSL_MSG("Client cache mutex lock failed");
-            return NULL;
-        }
-        if (clientSession->serverRow >= SESSION_ROWS ||
-                clientSession->serverIdx >= SESSIONS_PER_ROW) {
-            WOLFSSL_MSG("Client cache serverRow or serverIdx invalid");
-            error = -1;
-        }
-        /* Prevent memory access before clientSession->serverRow and
-         * clientSession->serverIdx are sanitized. */
-        XFENCE();
-        if (error == 0) {
-            /* Lock row */
-            sessRow = &SessionCache[clientSession->serverRow];
-            error = SESSION_ROW_RD_LOCK(sessRow);
-            if (error != 0) {
-                WOLFSSL_MSG("Session cache row lock failure");
-                sessRow = NULL;
-            }
-        }
-        if (error == 0) {
-#ifdef SESSION_CACHE_DYNAMIC_MEM
-            cacheSession = sessRow->Sessions[clientSession->serverIdx];
-#else
-            cacheSession = &sessRow->Sessions[clientSession->serverIdx];
-#endif
-            if (cacheSession && cacheSession->sessionIDSz == 0) {
-                cacheSession = NULL;
-                WOLFSSL_MSG("Session cache entry not set");
-                error = -1;
-            }
-        }
-        if (error == 0) {
-            /* Calculate the hash of the session ID */
-            sessionIDHash = HashObject(cacheSession->sessionID, ID_LEN,
-                    &error);
-        }
-        if (error == 0) {
-            /* Check the session ID hash matches */
-            error = clientSession->sessionIDHash != sessionIDHash;
-            if (error != 0)
-                WOLFSSL_MSG("session ID hash don't match");
-        }
-        if (error == 0) {
-            /* Hashes match */
-            session = cacheSession;
-            WOLFSSL_MSG("Found session cache matching client session object");
-        }
-        if (sessRow != NULL) {
-            SESSION_ROW_UNLOCK(sessRow);
-        }
-        wc_UnLockMutex(&clisession_mutex);
-        return (WOLFSSL_SESSION*)session;
-    }
-    else {
-        /* Plain WOLFSSL_SESSION object */
-        return (WOLFSSL_SESSION*)session;
-    }
-#else
-    return (WOLFSSL_SESSION*)session;
-#endif
-#endif
-}
-
-int AddSessionToCache(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* addSession,
-        const byte* id, byte idSz, int* sessionIndex, int side,
-        word16 useTicket, ClientSession** clientCacheEntry)
-{
-    WOLFSSL_SESSION* cacheSession = NULL;
-    SessionRow* sessRow = NULL;
-    word32 idx = 0;
-#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-    WOLFSSL_X509* cachePeer = NULL;
-    WOLFSSL_X509* addPeer = NULL;
-#endif
-#ifdef HAVE_SESSION_TICKET
-    byte*  cacheTicBuff = NULL;
-    byte   ticBuffUsed = 0;
-    byte*  ticBuff = NULL;
-    int    ticLen  = 0;
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-    byte *preallocNonce = NULL;
-    byte preallocNonceLen = 0;
-    byte preallocNonceUsed = 0;
-    byte *toFree = NULL;
-#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC */
-#endif /* HAVE_SESSION_TICKET */
-    int ret = 0;
-    int row;
-    int i;
-    int overwrite = 0;
-    (void)ctx;
-    (void)sessionIndex;
-    (void)useTicket;
-    (void)clientCacheEntry;
-
-    WOLFSSL_ENTER("AddSessionToCache");
-
-    if (idSz == 0) {
-        WOLFSSL_MSG("AddSessionToCache idSz == 0");
-        return BAD_FUNC_ARG;
-    }
-
-    addSession = ClientSessionToSession(addSession);
-    if (addSession == NULL) {
-        WOLFSSL_MSG("AddSessionToCache is NULL");
-        return MEMORY_E;
-    }
-
-#ifdef HAVE_SESSION_TICKET
-    ticLen = addSession->ticketLen;
-    /* Alloc Memory here to avoid syscalls during lock */
-    if (ticLen > SESSION_TICKET_LEN) {
-        ticBuff = (byte*)XMALLOC(ticLen, NULL,
-                DYNAMIC_TYPE_SESSION_TICK);
-        if (ticBuff == NULL) {
-            return MEMORY_E;
-        }
-    }
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-    if (addSession->ticketNonce.data != addSession->ticketNonce.dataStatic) {
-        /* use the AddSession->heap even if the buffer maybe saved in
-         * CachedSession objects. CachedSession heap and AddSession heap should
-         * be the same */
-        preallocNonce = (byte*)XMALLOC(addSession->ticketNonce.len,
-            addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
-        if (preallocNonce == NULL) {
-            if (ticBuff != NULL)
-                XFREE(ticBuff, addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
-            return MEMORY_E;
-        }
-        preallocNonceLen = addSession->ticketNonce.len;
-    }
-#endif /* WOLFSSL_TLS13 && WOLFSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3) */
-#endif /* HAVE_SESSION_TICKET */
-
-    /* Find a position for the new session in cache and use that */
-    /* Use the session object in the cache for external cache if required */
-    row = (int)(HashObject(id, ID_LEN, &ret) % SESSION_ROWS);
-    if (ret != 0) {
-        WOLFSSL_MSG("Hash session failed");
-    #ifdef HAVE_SESSION_TICKET
-        XFREE(ticBuff, NULL, DYNAMIC_TYPE_SESSION_TICK);
-    #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC)
-        XFREE(preallocNonce, addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
-    #endif
-    #endif
-        return ret;
-    }
-
-    sessRow = &SessionCache[row];
-    if (SESSION_ROW_WR_LOCK(sessRow) != 0) {
-    #ifdef HAVE_SESSION_TICKET
-        XFREE(ticBuff, NULL, DYNAMIC_TYPE_SESSION_TICK);
-    #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC)
-        XFREE(preallocNonce, addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
-    #endif
-    #endif
-        WOLFSSL_MSG("Session row lock failed");
-        return BAD_MUTEX_E;
-    }
-
-    for (i = 0; i < SESSIONS_PER_ROW && i < sessRow->totalCount; i++) {
-#ifdef SESSION_CACHE_DYNAMIC_MEM
-        cacheSession = sessRow->Sessions[i];
-#else
-        cacheSession = &sessRow->Sessions[i];
-#endif
-        if (cacheSession && XMEMCMP(id,
-                cacheSession->sessionID, ID_LEN) == 0 &&
-                cacheSession->side == side) {
-            WOLFSSL_MSG("Session already exists. Overwriting.");
-            overwrite = 1;
-            idx = i;
-            break;
-        }
-    }
-
-    if (!overwrite)
-        idx = sessRow->nextIdx;
-#ifdef SESSION_INDEX
-    if (sessionIndex != NULL)
-        *sessionIndex = (row << SESSIDX_ROW_SHIFT) | idx;
-#endif
-
-#ifdef SESSION_CACHE_DYNAMIC_MEM
-    cacheSession = sessRow->Sessions[idx];
-    if (cacheSession == NULL) {
-        cacheSession = (WOLFSSL_SESSION*) XMALLOC(sizeof(WOLFSSL_SESSION),
-                                         sessRow->heap, DYNAMIC_TYPE_SESSION);
-        if (cacheSession == NULL) {
-        #ifdef HAVE_SESSION_TICKET
-            XFREE(ticBuff, NULL, DYNAMIC_TYPE_SESSION_TICK);
-        #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC)
-            XFREE(preallocNonce, addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
-        #endif
-        #endif
-            SESSION_ROW_UNLOCK(sessRow);
-            return MEMORY_E;
-        }
-        XMEMSET(cacheSession, 0, sizeof(WOLFSSL_SESSION));
-        sessRow->Sessions[idx] = cacheSession;
-    }
-#else
-    cacheSession = &sessRow->Sessions[idx];
-#endif
-
-#ifdef HAVE_EX_DATA
-    if (overwrite) {
-        /* Figure out who owns the ex_data */
-        if (cacheSession->ownExData) {
-            /* Prioritize cacheSession copy */
-            XMEMCPY(&addSession->ex_data, &cacheSession->ex_data,
-                    sizeof(WOLFSSL_CRYPTO_EX_DATA));
-        }
-        /* else will be copied in wolfSSL_DupSession call */
-    }
-    else if (cacheSession->ownExData) {
-        crypto_ex_cb_free_data(cacheSession, crypto_ex_cb_ctx_session,
-                               &cacheSession->ex_data);
-        cacheSession->ownExData = 0;
-    }
-#endif
-
-    if (!overwrite)
-        EvictSessionFromCache(cacheSession);
-
-    cacheSession->type = WOLFSSL_SESSION_TYPE_CACHE;
-    cacheSession->cacheRow = row;
-
-#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-    /* Save the peer field to free after unlocking the row */
-    if (cacheSession->peer != NULL)
-        cachePeer = cacheSession->peer;
-    cacheSession->peer = NULL;
-#endif
-#ifdef HAVE_SESSION_TICKET
-    /* If we can reuse the existing buffer in cacheSession then we won't touch
-     * ticBuff at all making it a very cheap malloc/free. The page on a modern
-     * OS will most likely not even be allocated to the process. */
-    if (ticBuff != NULL && cacheSession->ticketLenAlloc < ticLen) {
-        /* Save pointer only if separately allocated */
-        if (cacheSession->ticket != cacheSession->staticTicket)
-            cacheTicBuff = cacheSession->ticket;
-        ticBuffUsed = 1;
-        cacheSession->ticket = ticBuff;
-        cacheSession->ticketLenAlloc = (word16) ticLen;
-    }
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-    /* cache entry never used */
-    if (cacheSession->ticketNonce.data == NULL)
-        cacheSession->ticketNonce.data = cacheSession->ticketNonce.dataStatic;
-
-    if (cacheSession->ticketNonce.data !=
-            cacheSession->ticketNonce.dataStatic) {
-        toFree = cacheSession->ticketNonce.data;
-        cacheSession->ticketNonce.data = cacheSession->ticketNonce.dataStatic;
-        cacheSession->ticketNonce.len = 0;
-    }
-#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
-#endif
-#ifdef SESSION_CERTS
-    if (overwrite &&
-            addSession->chain.count == 0 &&
-            cacheSession->chain.count > 0) {
-        /* Copy in the certs from the session */
-        addSession->chain.count = cacheSession->chain.count;
-        XMEMCPY(addSession->chain.certs, cacheSession->chain.certs,
-                sizeof(x509_buffer) * cacheSession->chain.count);
-    }
-#endif /* SESSION_CERTS */
-#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-    /* Don't copy the peer cert into cache */
-    addPeer = addSession->peer;
-    addSession->peer = NULL;
-#endif
-    cacheSession->heap = NULL;
-    /* Copy data into the cache object */
-#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_TLS13) &&                  \
-    defined(WOLFSSL_TICKET_NONCE_MALLOC) &&                                   \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-    ret = wolfSSL_DupSessionEx(addSession, cacheSession, 1, preallocNonce,
-        &preallocNonceLen, &preallocNonceUsed) == WOLFSSL_FAILURE;
-#else
-    ret = wolfSSL_DupSession(addSession, cacheSession, 1) == WOLFSSL_FAILURE;
-#endif /* HAVE_SESSION_TICKET && WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC
-          && FIPS_VERSION_GE(5,3)*/
-#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-    addSession->peer = addPeer;
-#endif
-
-    if (ret == 0) {
-        if (!overwrite) {
-            /* Increment the totalCount and the nextIdx */
-            if (sessRow->totalCount < SESSIONS_PER_ROW)
-                sessRow->totalCount++;
-            sessRow->nextIdx = (sessRow->nextIdx + 1) % SESSIONS_PER_ROW;
-        }
-        if (id != addSession->sessionID) {
-            /* ssl->session->sessionID may contain the bogus ID or we want the
-             * ID from the arrays object */
-            XMEMCPY(cacheSession->sessionID, id, ID_LEN);
-            cacheSession->sessionIDSz = ID_LEN;
-        }
-#if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
-        if (ctx->rem_sess_cb != NULL)
-            cacheSession->rem_sess_cb = ctx->rem_sess_cb;
-#endif
-#ifdef HAVE_EX_DATA
-        /* The session in cache now owns the ex_data */
-        addSession->ownExData = 0;
-        cacheSession->ownExData = 1;
-#endif
-#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_TLS13) &&                  \
-    defined(WOLFSSL_TICKET_NONCE_MALLOC) &&                                    \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-        if (preallocNonce != NULL && preallocNonceUsed) {
-            cacheSession->ticketNonce.data = preallocNonce;
-            cacheSession->ticketNonce.len = preallocNonceLen;
-            preallocNonce = NULL;
-            preallocNonceLen = 0;
-        }
-#endif /* HAVE_SESSION_TICKET && WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC
-        * && FIPS_VERSION_GE(5,3)*/
-    }
-#ifdef HAVE_SESSION_TICKET
-    else if (ticBuffUsed) {
-        /* Error occurred. Need to clean up the ticket buffer. */
-        cacheSession->ticket = cacheSession->staticTicket;
-        cacheSession->ticketLenAlloc = 0;
-        cacheSession->ticketLen = 0;
-    }
-#endif
-    SESSION_ROW_UNLOCK(sessRow);
-    cacheSession = NULL; /* Can't access after unlocked */
-
-#ifndef NO_CLIENT_CACHE
-    if (ret == 0 && clientCacheEntry != NULL) {
-        ClientSession* clientCache = AddSessionToClientCache(side, row, idx,
-                addSession->serverID, addSession->idLen, id, useTicket);
-        if (clientCache != NULL)
-            *clientCacheEntry = clientCache;
-    }
-#endif
-
-#ifdef HAVE_SESSION_TICKET
-    if (ticBuff != NULL && !ticBuffUsed)
-        XFREE(ticBuff, NULL, DYNAMIC_TYPE_SESSION_TICK);
-    XFREE(cacheTicBuff, NULL, DYNAMIC_TYPE_SESSION_TICK);
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&         \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-    XFREE(preallocNonce, addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
-    XFREE(toFree, addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
-#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
-#endif
-
-#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-    if (cachePeer != NULL) {
-        wolfSSL_X509_free(cachePeer);
-        cachePeer = NULL; /* Make sure not use after this point */
-    }
-#endif
-
-    return ret;
-}
-
-void AddSession(WOLFSSL* ssl)
-{
-    int    error = 0;
-    const byte* id = NULL;
-    byte idSz = 0;
-    WOLFSSL_SESSION* session = ssl->session;
-
-    (void)error;
-
-    WOLFSSL_ENTER("AddSession");
-
-    if (SslSessionCacheOff(ssl, session)) {
-        WOLFSSL_MSG("Cache off");
-        return;
-    }
-
-    if (session->haveAltSessionID) {
-        id = session->altSessionID;
-        idSz = ID_LEN;
-    }
-    else {
-        id = session->sessionID;
-        idSz = session->sessionIDSz;
-    }
-
-    /* Do this only for the client because if the server doesn't have an ID at
-     * this point, it won't on resumption. */
-    if (idSz == 0 && ssl->options.side == WOLFSSL_CLIENT_END) {
-        WC_RNG* rng = NULL;
-        if (ssl->rng != NULL)
-            rng = ssl->rng;
-#if defined(HAVE_GLOBAL_RNG) && defined(OPENSSL_EXTRA)
-        else if (initGlobalRNG == 1 || wolfSSL_RAND_Init() == WOLFSSL_SUCCESS) {
-            rng = &globalRNG;
-        }
-#endif
-        if (wc_RNG_GenerateBlock(rng, ssl->session->altSessionID,
-                ID_LEN) != 0)
-            return;
-        ssl->session->haveAltSessionID = 1;
-        id = ssl->session->altSessionID;
-        idSz = ID_LEN;
-    }
-
-#ifdef HAVE_EXT_CACHE
-    if (!ssl->options.internalCacheOff)
-#endif
-    {
-        /* Try to add the session to internal cache or external cache
-        if a new_sess_cb is set. Its ok if we don't succeed. */
-        (void)AddSessionToCache(ssl->ctx, session, id, idSz,
-#ifdef SESSION_INDEX
-                &ssl->sessionIndex,
-#else
-                NULL,
-#endif
-                ssl->options.side,
-#ifdef HAVE_SESSION_TICKET
-                ssl->options.useTicket,
-#else
-                0,
-#endif
-#ifdef NO_SESSION_CACHE_REF
-                NULL
-#else
-                (ssl->options.side == WOLFSSL_CLIENT_END) ?
-                        &ssl->clientSession : NULL
-#endif
-                        );
-    }
-
-#ifdef HAVE_EXT_CACHE
-    if (error == 0 && ssl->ctx->new_sess_cb != NULL) {
-        int cbRet = 0;
-        wolfSSL_SESSION_up_ref(session);
-        cbRet = ssl->ctx->new_sess_cb(ssl, session);
-        if (cbRet == 0)
-            wolfSSL_FreeSession(ssl->ctx, session);
-    }
-#endif
-
-#if defined(WOLFSSL_SESSION_STATS) && defined(WOLFSSL_PEAK_SESSIONS)
-    if (error == 0) {
-        word32 active = 0;
-
-        error = get_locked_session_stats(&active, NULL, NULL);
-        if (error == WOLFSSL_SUCCESS) {
-            error = 0;  /* back to this function ok */
-
-            if (PeakSessions < active) {
-                PeakSessions = active;
-            }
-        }
-    }
-#endif /* WOLFSSL_SESSION_STATS && WOLFSSL_PEAK_SESSIONS */
-    (void)error;
-}
-
-
-#ifdef SESSION_INDEX
-
-int wolfSSL_GetSessionIndex(WOLFSSL* ssl)
-{
-    WOLFSSL_ENTER("wolfSSL_GetSessionIndex");
-    WOLFSSL_LEAVE("wolfSSL_GetSessionIndex", ssl->sessionIndex);
-    return ssl->sessionIndex;
-}
-
-
-int wolfSSL_GetSessionAtIndex(int idx, WOLFSSL_SESSION* session)
-{
-    int row, col, result = WOLFSSL_FAILURE;
-    SessionRow* sessRow;
-    WOLFSSL_SESSION* cacheSession;
-
-    WOLFSSL_ENTER("wolfSSL_GetSessionAtIndex");
-
-    session = ClientSessionToSession(session);
-
-    row = idx >> SESSIDX_ROW_SHIFT;
-    col = idx & SESSIDX_IDX_MASK;
-
-    if (session == NULL ||
-            row < 0 || row >= SESSION_ROWS || col >= SESSIONS_PER_ROW) {
-        return WOLFSSL_FAILURE;
-    }
-
-    sessRow = &SessionCache[row];
-    if (SESSION_ROW_RD_LOCK(sessRow) != 0) {
-        return BAD_MUTEX_E;
-    }
-
-#ifdef SESSION_CACHE_DYNAMIC_MEM
-    cacheSession = sessRow->Sessions[col];
-#else
-    cacheSession = &sessRow->Sessions[col];
-#endif
-    if (cacheSession) {
-        XMEMCPY(session, cacheSession, sizeof(WOLFSSL_SESSION));
-        result = WOLFSSL_SUCCESS;
-    }
-    else {
-        result = WOLFSSL_FAILURE;
-    }
-
-    SESSION_ROW_UNLOCK(sessRow);
-
-    WOLFSSL_LEAVE("wolfSSL_GetSessionAtIndex", result);
-    return result;
-}
-
-#endif /* SESSION_INDEX */
-
-#if defined(SESSION_CERTS)
-
-WOLFSSL_X509_CHAIN* wolfSSL_SESSION_get_peer_chain(WOLFSSL_SESSION* session)
-{
-    WOLFSSL_X509_CHAIN* chain = NULL;
-
-    WOLFSSL_ENTER("wolfSSL_SESSION_get_peer_chain");
-
-    session = ClientSessionToSession(session);
-
-    if (session)
-        chain = &session->chain;
-
-    WOLFSSL_LEAVE("wolfSSL_SESSION_get_peer_chain", chain ? 1 : 0);
-    return chain;
-}
-
-
-#ifdef OPENSSL_EXTRA
-/* gets the peer certificate associated with the session passed in
- * returns null on failure, the caller should not free the returned pointer */
-WOLFSSL_X509* wolfSSL_SESSION_get0_peer(WOLFSSL_SESSION* session)
-{
-    WOLFSSL_ENTER("wolfSSL_SESSION_get_peer_chain");
-
-    session = ClientSessionToSession(session);
-    if (session) {
-        int count;
-
-        count = wolfSSL_get_chain_count(&session->chain);
-        if (count < 1 || count >= MAX_CHAIN_DEPTH) {
-            WOLFSSL_MSG("bad count found");
-            return NULL;
-        }
-
-        if (session->peer == NULL) {
-            session->peer = wolfSSL_get_chain_X509(&session->chain, 0);
-        }
-        return session->peer;
-    }
-    WOLFSSL_MSG("No session passed in");
-
-    return NULL;
-}
-#endif /* OPENSSL_EXTRA */
-#endif /* SESSION_INDEX && SESSION_CERTS */
-
-
-#ifdef WOLFSSL_SESSION_STATS
-
-static int get_locked_session_stats(word32* active, word32* total, word32* peak)
-{
-    int result = WOLFSSL_SUCCESS;
-    int i;
-    int count;
-    int idx;
-    word32 now   = 0;
-    word32 seen  = 0;
-    word32 ticks = LowResTimer();
-
-    WOLFSSL_ENTER("get_locked_session_stats");
-
-#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
-    SESSION_ROW_RD_LOCK(&SessionCache[0]);
-#endif
-    for (i = 0; i < SESSION_ROWS; i++) {
-        SessionRow* row = &SessionCache[i];
-    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-        if (SESSION_ROW_RD_LOCK(row) != 0) {
-            WOLFSSL_MSG("Session row cache mutex lock failed");
-            return BAD_MUTEX_E;
-        }
-    #endif
-
-        seen += row->totalCount;
-
-        if (active == NULL) {
-            SESSION_ROW_UNLOCK(row);
-            continue;
-        }
-
-        count = min((word32)row->totalCount, SESSIONS_PER_ROW);
-        idx   = row->nextIdx - 1;
-        if (idx < 0 || idx >= SESSIONS_PER_ROW) {
-            idx = SESSIONS_PER_ROW - 1; /* if back to front previous was end */
-        }
-
-        for (; count > 0; --count) {
-            /* if not expired then good */
-#ifdef SESSION_CACHE_DYNAMIC_MEM
-            if (row->Sessions[idx] &&
-                ticks < (row->Sessions[idx]->bornOn +
-                            row->Sessions[idx]->timeout) )
-#else
-            if (ticks < (row->Sessions[idx].bornOn +
-                            row->Sessions[idx].timeout) )
-#endif
-            {
-                now++;
-            }
-
-            idx = idx > 0 ? idx - 1 : SESSIONS_PER_ROW - 1;
-        }
-
-    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
-        SESSION_ROW_UNLOCK(row);
-    #endif
-    }
-#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
-    SESSION_ROW_UNLOCK(&SessionCache[0]);
-#endif
-
-    if (active) {
-        *active = now;
-    }
-    if (total) {
-        *total = seen;
-    }
-
-#ifdef WOLFSSL_PEAK_SESSIONS
-    if (peak) {
-        *peak = PeakSessions;
-    }
-#else
-    (void)peak;
-#endif
-
-    WOLFSSL_LEAVE("get_locked_session_stats", result);
-
-    return result;
-}
-
-
-/* return WOLFSSL_SUCCESS on ok */
-int wolfSSL_get_session_stats(word32* active, word32* total, word32* peak,
-                              word32* maxSessions)
-{
-    int result = WOLFSSL_SUCCESS;
-
-    WOLFSSL_ENTER("wolfSSL_get_session_stats");
-
-    if (maxSessions) {
-        *maxSessions = SESSIONS_PER_ROW * SESSION_ROWS;
-
-        if (active == NULL && total == NULL && peak == NULL)
-            return result;  /* we're done */
-    }
-
-    /* user must provide at least one query value */
-    if (active == NULL && total == NULL && peak == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    result = get_locked_session_stats(active, total, peak);
-
-    WOLFSSL_LEAVE("wolfSSL_get_session_stats", result);
-
-    return result;
-}
-
-#endif /* WOLFSSL_SESSION_STATS */
-
-
-    #ifdef PRINT_SESSION_STATS
-
-    /* WOLFSSL_SUCCESS on ok */
-    int wolfSSL_PrintSessionStats(void)
-    {
-        word32 totalSessionsSeen = 0;
-        word32 totalSessionsNow = 0;
-        word32 peak = 0;
-        word32 maxSessions = 0;
-        int    i;
-        int    ret;
-        double E;               /* expected freq */
-        double chiSquare = 0;
-
-        ret = wolfSSL_get_session_stats(&totalSessionsNow, &totalSessionsSeen,
-                                        &peak, &maxSessions);
-        if (ret != WOLFSSL_SUCCESS)
-            return ret;
-        printf("Total Sessions Seen = %u\n", totalSessionsSeen);
-        printf("Total Sessions Now  = %u\n", totalSessionsNow);
-#ifdef WOLFSSL_PEAK_SESSIONS
-        printf("Peak  Sessions      = %u\n", peak);
-#endif
-        printf("Max   Sessions      = %u\n", maxSessions);
-
-        E = (double)totalSessionsSeen / SESSION_ROWS;
-
-        for (i = 0; i < SESSION_ROWS; i++) {
-            double diff = SessionCache[i].totalCount - E;
-            diff *= diff;                /* square    */
-            diff /= E;                   /* normalize */
-
-            chiSquare += diff;
-        }
-        printf("  chi-square = %5.1f, d.f. = %d\n", chiSquare,
-                                                     SESSION_ROWS - 1);
-        #if (SESSION_ROWS == 11)
-            printf(" .05 p value =  18.3, chi-square should be less\n");
-        #elif (SESSION_ROWS == 211)
-            printf(".05 p value  = 244.8, chi-square should be less\n");
-        #elif (SESSION_ROWS == 5981)
-            printf(".05 p value  = 6161.0, chi-square should be less\n");
-        #elif (SESSION_ROWS == 3)
-            printf(".05 p value  =   6.0, chi-square should be less\n");
-        #elif (SESSION_ROWS == 2861)
-            printf(".05 p value  = 2985.5, chi-square should be less\n");
-        #endif
-        printf("\n");
-
-        return ret;
-    }
-
-    #endif /* SESSION_STATS */
-
-#else  /* NO_SESSION_CACHE */
-
-WOLFSSL_SESSION* ClientSessionToSession(const WOLFSSL_SESSION* session)
-{
-    return (WOLFSSL_SESSION*)session;
-}
-
-/* No session cache version */
-WOLFSSL_SESSION* wolfSSL_GetSession(WOLFSSL* ssl, byte* masterSecret,
-        byte restoreSessionCerts)
-{
-    (void)ssl;
-    (void)masterSecret;
-    (void)restoreSessionCerts;
-
-    return NULL;
-}
-
-#endif /* NO_SESSION_CACHE */
 
 
 /* call before SSL_connect, if verifying will add name check to
@@ -15944,391 +10764,7 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
 #endif /* HAVE_ANON */
 
-
 #ifndef NO_CERTS
-/* used to be defined on NO_FILESYSTEM only, but are generally useful */
-
-    int wolfSSL_CTX_load_verify_buffer_ex(WOLFSSL_CTX* ctx,
-                                         const unsigned char* in,
-                                         long sz, int format, int userChain,
-                                         word32 flags)
-    {
-        int verify;
-        int ret = WOLFSSL_FAILURE;
-
-        WOLFSSL_ENTER("wolfSSL_CTX_load_verify_buffer_ex");
-
-        verify = GET_VERIFY_SETTING_CTX(ctx);
-        if (flags & WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY)
-            verify = VERIFY_SKIP_DATE;
-
-        if (format == WOLFSSL_FILETYPE_PEM)
-            ret = ProcessChainBuffer(ctx, in, sz, format, CA_TYPE, NULL,
-                                      verify);
-        else
-            ret = ProcessBuffer(ctx, in, sz, format, CA_TYPE, NULL, NULL,
-                                 userChain, verify);
-#if defined(WOLFSSL_TRUST_PEER_CERT) && defined(OPENSSL_COMPATIBLE_DEFAULTS)
-        if (ret == WOLFSSL_SUCCESS)
-            ret = wolfSSL_CTX_trust_peer_buffer(ctx, in, sz, format);
-#endif
-
-        WOLFSSL_LEAVE("wolfSSL_CTX_load_verify_buffer_ex", ret);
-        return ret;
-    }
-
-    /* wolfSSL extension allows DER files to be loaded from buffers as well */
-    int wolfSSL_CTX_load_verify_buffer(WOLFSSL_CTX* ctx,
-                                       const unsigned char* in,
-                                       long sz, int format)
-    {
-        return wolfSSL_CTX_load_verify_buffer_ex(ctx, in, sz, format, 0,
-            WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS);
-    }
-
-    int wolfSSL_CTX_load_verify_chain_buffer_format(WOLFSSL_CTX* ctx,
-                                       const unsigned char* in,
-                                       long sz, int format)
-    {
-        return wolfSSL_CTX_load_verify_buffer_ex(ctx, in, sz, format, 1,
-            WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS);
-    }
-
-
-#ifdef WOLFSSL_TRUST_PEER_CERT
-    int wolfSSL_CTX_trust_peer_buffer(WOLFSSL_CTX* ctx,
-                                       const unsigned char* in,
-                                       long sz, int format)
-    {
-        int verify;
-        WOLFSSL_ENTER("wolfSSL_CTX_trust_peer_buffer");
-
-        /* sanity check on arguments */
-        if (sz < 0 || in == NULL || ctx == NULL) {
-            return BAD_FUNC_ARG;
-        }
-
-        #if (WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS & WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY)
-            verify = VERIFY_SKIP_DATE;
-        #else
-            verify = GET_VERIFY_SETTING_CTX(ctx);
-        #endif
-
-        if (format == WOLFSSL_FILETYPE_PEM)
-            return ProcessChainBuffer(ctx, in, sz, format, TRUSTED_PEER_TYPE,
-                                      NULL, verify);
-        else
-            return ProcessBuffer(ctx, in, sz, format, TRUSTED_PEER_TYPE, NULL,
-                                 NULL, 0, verify);
-    }
-#endif /* WOLFSSL_TRUST_PEER_CERT */
-
-
-    int wolfSSL_CTX_use_certificate_buffer(WOLFSSL_CTX* ctx,
-                                 const unsigned char* in, long sz, int format)
-    {
-        int ret = WOLFSSL_FAILURE;
-
-        WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_buffer");
-        ret = ProcessBuffer(ctx, in, sz, format, CERT_TYPE, NULL, NULL, 0,
-                             GET_VERIFY_SETTING_CTX(ctx));
-        WOLFSSL_LEAVE("wolfSSL_CTX_use_certificate_buffer", ret);
-        return ret;
-    }
-
-
-    int wolfSSL_CTX_use_PrivateKey_buffer(WOLFSSL_CTX* ctx,
-                                 const unsigned char* in, long sz, int format)
-    {
-        int ret = WOLFSSL_FAILURE;
-
-        WOLFSSL_ENTER("wolfSSL_CTX_use_PrivateKey_buffer");
-        ret = ProcessBuffer(ctx, in, sz, format, PRIVATEKEY_TYPE, NULL, NULL,
-                             0, GET_VERIFY_SETTING_CTX(ctx));
-        WOLFSSL_LEAVE("wolfSSL_CTX_use_PrivateKey_buffer", ret);
-        return ret;
-    }
-
-#ifdef WOLF_PRIVATE_KEY_ID
-    int wolfSSL_CTX_use_PrivateKey_id(WOLFSSL_CTX* ctx, const unsigned char* id,
-                                      long sz, int devId, long keySz)
-    {
-        int ret = wolfSSL_CTX_use_PrivateKey_Id(ctx, id, sz, devId);
-
-        if (ret == WOLFSSL_SUCCESS)
-            ctx->privateKeySz = (word32)keySz;
-
-        return ret;
-    }
-
-    int wolfSSL_CTX_use_PrivateKey_Id(WOLFSSL_CTX* ctx, const unsigned char* id,
-                                      long sz, int devId)
-    {
-        int ret = WOLFSSL_FAILURE;
-
-        FreeDer(&ctx->privateKey);
-        if (AllocDer(&ctx->privateKey, (word32)sz, PRIVATEKEY_TYPE,
-                                                              ctx->heap) == 0) {
-            XMEMCPY(ctx->privateKey->buffer, id, sz);
-            ctx->privateKeyId = 1;
-            if (devId != INVALID_DEVID)
-                ctx->privateKeyDevId = devId;
-            else
-                ctx->privateKeyDevId = ctx->devId;
-
-            ret = WOLFSSL_SUCCESS;
-        }
-
-        return ret;
-    }
-
-    int wolfSSL_CTX_use_PrivateKey_Label(WOLFSSL_CTX* ctx, const char* label,
-                                         int devId)
-    {
-        int ret = WOLFSSL_FAILURE;
-        word32 sz = (word32)XSTRLEN(label) + 1;
-
-        FreeDer(&ctx->privateKey);
-        if (AllocDer(&ctx->privateKey, (word32)sz, PRIVATEKEY_TYPE,
-                                                              ctx->heap) == 0) {
-            XMEMCPY(ctx->privateKey->buffer, label, sz);
-            ctx->privateKeyLabel = 1;
-            if (devId != INVALID_DEVID)
-                ctx->privateKeyDevId = devId;
-            else
-                ctx->privateKeyDevId = ctx->devId;
-
-            ret = WOLFSSL_SUCCESS;
-        }
-
-        return ret;
-    }
-#endif /* WOLF_PRIVATE_KEY_ID */
-
-    int wolfSSL_CTX_use_certificate_chain_buffer_format(WOLFSSL_CTX* ctx,
-                                 const unsigned char* in, long sz, int format)
-    {
-        WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_chain_buffer_format");
-        return ProcessBuffer(ctx, in, sz, format, CERT_TYPE, NULL, NULL, 1,
-                             GET_VERIFY_SETTING_CTX(ctx));
-    }
-
-    int wolfSSL_CTX_use_certificate_chain_buffer(WOLFSSL_CTX* ctx,
-                                 const unsigned char* in, long sz)
-    {
-        return wolfSSL_CTX_use_certificate_chain_buffer_format(ctx, in, sz,
-                                                            WOLFSSL_FILETYPE_PEM);
-    }
-
-
-#ifndef NO_DH
-
-    /* server wrapper for ctx or ssl Diffie-Hellman parameters */
-    static int wolfSSL_SetTmpDH_buffer_wrapper(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
-                                               const unsigned char* buf,
-                                               long sz, int format)
-    {
-        DerBuffer* der = NULL;
-        int    ret      = 0;
-        word32 pSz = MAX_DH_SIZE;
-        word32 gSz = MAX_DH_SIZE;
-    #ifdef WOLFSSL_SMALL_STACK
-        byte*  p = NULL;
-        byte*  g = NULL;
-    #else
-        byte   p[MAX_DH_SIZE];
-        byte   g[MAX_DH_SIZE];
-    #endif
-
-        if (ctx == NULL || buf == NULL)
-            return BAD_FUNC_ARG;
-
-        ret = AllocDer(&der, 0, DH_PARAM_TYPE, ctx->heap);
-        if (ret != 0) {
-            return ret;
-        }
-        der->buffer = (byte*)buf;
-        der->length = (word32)sz;
-
-    #ifdef WOLFSSL_SMALL_STACK
-        p = (byte*)XMALLOC(pSz, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
-        g = (byte*)XMALLOC(gSz, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
-
-        if (p == NULL || g == NULL) {
-            XFREE(p, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
-            XFREE(g, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
-            return MEMORY_E;
-        }
-    #endif
-
-        if (format != WOLFSSL_FILETYPE_ASN1 && format != WOLFSSL_FILETYPE_PEM)
-            ret = WOLFSSL_BAD_FILETYPE;
-        else {
-            if (format == WOLFSSL_FILETYPE_PEM) {
-#ifdef WOLFSSL_PEM_TO_DER
-                FreeDer(&der);
-                ret = PemToDer(buf, sz, DH_PARAM_TYPE, &der, ctx->heap,
-                               NULL, NULL);
-                if (ret < 0) {
-                    /* Also try X9.42 format */
-                    ret = PemToDer(buf, sz, X942_PARAM_TYPE, &der, ctx->heap,
-                               NULL, NULL);
-                }
-    #ifdef WOLFSSL_WPAS
-        #ifndef NO_DSA
-                if (ret < 0) {
-                    ret = PemToDer(buf, sz, DSA_PARAM_TYPE, &der, ctx->heap,
-                               NULL, NULL);
-                }
-        #endif
-    #endif /* WOLFSSL_WPAS */
-#else
-                ret = NOT_COMPILED_IN;
-#endif /* WOLFSSL_PEM_TO_DER */
-            }
-
-            if (ret == 0) {
-                if (wc_DhParamsLoad(der->buffer, der->length, p, &pSz, g, &gSz) < 0)
-                    ret = WOLFSSL_BAD_FILETYPE;
-                else if (ssl)
-                    ret = wolfSSL_SetTmpDH(ssl, p, pSz, g, gSz);
-                else
-                    ret = wolfSSL_CTX_SetTmpDH(ctx, p, pSz, g, gSz);
-            }
-        }
-
-        FreeDer(&der);
-
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(p, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
-        XFREE(g, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
-    #endif
-
-        return ret;
-    }
-
-
-    /* server Diffie-Hellman parameters, WOLFSSL_SUCCESS on ok */
-    int wolfSSL_SetTmpDH_buffer(WOLFSSL* ssl, const unsigned char* buf, long sz,
-                               int format)
-    {
-        if (ssl == NULL)
-            return BAD_FUNC_ARG;
-
-        return wolfSSL_SetTmpDH_buffer_wrapper(ssl->ctx, ssl, buf, sz, format);
-    }
-
-
-    /* server ctx Diffie-Hellman parameters, WOLFSSL_SUCCESS on ok */
-    int wolfSSL_CTX_SetTmpDH_buffer(WOLFSSL_CTX* ctx, const unsigned char* buf,
-                                   long sz, int format)
-    {
-        return wolfSSL_SetTmpDH_buffer_wrapper(ctx, NULL, buf, sz, format);
-    }
-
-#endif /* NO_DH */
-
-
-    int wolfSSL_use_certificate_buffer(WOLFSSL* ssl,
-                                 const unsigned char* in, long sz, int format)
-    {
-        WOLFSSL_ENTER("wolfSSL_use_certificate_buffer");
-        if (ssl == NULL)
-            return BAD_FUNC_ARG;
-
-        return ProcessBuffer(ssl->ctx, in, sz, format, CERT_TYPE, ssl, NULL, 0,
-                             GET_VERIFY_SETTING_SSL(ssl));
-    }
-
-
-    int wolfSSL_use_PrivateKey_buffer(WOLFSSL* ssl,
-                                 const unsigned char* in, long sz, int format)
-    {
-        WOLFSSL_ENTER("wolfSSL_use_PrivateKey_buffer");
-        if (ssl == NULL)
-            return BAD_FUNC_ARG;
-
-        return ProcessBuffer(ssl->ctx, in, sz, format, PRIVATEKEY_TYPE,
-                             ssl, NULL, 0, GET_VERIFY_SETTING_SSL(ssl));
-    }
-
-#ifdef WOLF_PRIVATE_KEY_ID
-    int wolfSSL_use_PrivateKey_id(WOLFSSL* ssl, const unsigned char* id,
-                                  long sz, int devId, long keySz)
-    {
-        int ret = wolfSSL_use_PrivateKey_Id(ssl, id, sz, devId);
-
-        if (ret == WOLFSSL_SUCCESS)
-            ssl->buffers.keySz = (word32)keySz;
-
-        return ret;
-    }
-
-    int wolfSSL_use_PrivateKey_Id(WOLFSSL* ssl, const unsigned char* id,
-                                  long sz, int devId)
-    {
-        int ret = WOLFSSL_FAILURE;
-
-        if (ssl->buffers.weOwnKey)
-            FreeDer(&ssl->buffers.key);
-        if (AllocDer(&ssl->buffers.key, (word32)sz, PRIVATEKEY_TYPE,
-                                                            ssl->heap) == 0) {
-            XMEMCPY(ssl->buffers.key->buffer, id, sz);
-            ssl->buffers.weOwnKey = 1;
-            ssl->buffers.keyId = 1;
-            if (devId != INVALID_DEVID)
-                ssl->buffers.keyDevId = devId;
-            else
-                ssl->buffers.keyDevId = ssl->devId;
-
-            ret = WOLFSSL_SUCCESS;
-        }
-
-        return ret;
-    }
-
-    int wolfSSL_use_PrivateKey_Label(WOLFSSL* ssl, const char* label, int devId)
-    {
-        int ret = WOLFSSL_FAILURE;
-        word32 sz = (word32)XSTRLEN(label) + 1;
-
-        if (ssl->buffers.weOwnKey)
-            FreeDer(&ssl->buffers.key);
-        if (AllocDer(&ssl->buffers.key, (word32)sz, PRIVATEKEY_TYPE,
-                                                            ssl->heap) == 0) {
-            XMEMCPY(ssl->buffers.key->buffer, label, sz);
-            ssl->buffers.weOwnKey = 1;
-            ssl->buffers.keyLabel = 1;
-            if (devId != INVALID_DEVID)
-                ssl->buffers.keyDevId = devId;
-            else
-                ssl->buffers.keyDevId = ssl->devId;
-
-            ret = WOLFSSL_SUCCESS;
-        }
-
-        return ret;
-    }
-#endif /* WOLF_PRIVATE_KEY_ID */
-
-    int wolfSSL_use_certificate_chain_buffer_format(WOLFSSL* ssl,
-                                 const unsigned char* in, long sz, int format)
-    {
-        WOLFSSL_ENTER("wolfSSL_use_certificate_chain_buffer_format");
-        if (ssl == NULL)
-            return BAD_FUNC_ARG;
-
-        return ProcessBuffer(ssl->ctx, in, sz, format, CERT_TYPE,
-                             ssl, NULL, 1, GET_VERIFY_SETTING_SSL(ssl));
-    }
-
-    int wolfSSL_use_certificate_chain_buffer(WOLFSSL* ssl,
-                                 const unsigned char* in, long sz)
-    {
-        return wolfSSL_use_certificate_chain_buffer_format(ssl, in, sz,
-                                                            WOLFSSL_FILETYPE_PEM);
-    }
-
 
     /* unload any certs or keys that SSL owns, leave CTX as is
        WOLFSSL_SUCCESS on ok */
@@ -16359,6 +10795,9 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             WOLFSSL_MSG("Unloading key");
             ForceZero(ssl->buffers.key->buffer, ssl->buffers.key->length);
             FreeDer(&ssl->buffers.key);
+        #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+            FreeDer(&ssl->buffers.keyMask);
+        #endif
             ssl->buffers.weOwnKey = 0;
         }
 
@@ -16367,6 +10806,9 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             WOLFSSL_MSG("Unloading alt key");
             ForceZero(ssl->buffers.altKey->buffer, ssl->buffers.altKey->length);
             FreeDer(&ssl->buffers.altKey);
+        #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+            FreeDer(&ssl->buffers.altKeyMask);
+        #endif
             ssl->buffers.weOwnAltKey = 0;
         }
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
@@ -16463,20 +10905,6 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             return WOLFSSL_FATAL_ERROR;
         }
         return WOLFSSL_SUCCESS;
-    }
-
-   /* returns previous set cache size which stays constant */
-    long wolfSSL_CTX_sess_set_cache_size(WOLFSSL_CTX* ctx, long sz)
-    {
-        /* cache size fixed at compile time in wolfSSL */
-        (void)ctx;
-        (void)sz;
-        WOLFSSL_MSG("session cache is set at compile time");
-        #ifndef NO_SESSION_CACHE
-            return (long)(SESSIONS_PER_ROW * SESSION_ROWS);
-        #else
-            return 0;
-        #endif
     }
 
 #endif
@@ -16795,7 +11223,8 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
         WOLFSSL_ENTER("wolfSSL_CTX_get_client_CA_list");
 
         if (ctx == NULL) {
-            WOLFSSL_MSG("Bad argument passed to wolfSSL_CTX_get_client_CA_list");
+            WOLFSSL_MSG("Bad argument passed to "
+                        "wolfSSL_CTX_get_client_CA_list");
             return NULL;
         }
 
@@ -16843,7 +11272,8 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
             return WOLFSSL_FAILURE;
         }
 
-        if (wolfSSL_sk_X509_NAME_push(ctx->client_ca_names, nameCopy) != WOLFSSL_SUCCESS) {
+        if (wolfSSL_sk_X509_NAME_push(ctx->client_ca_names, nameCopy) !=
+                WOLFSSL_SUCCESS) {
             WOLFSSL_MSG("wolfSSL_sk_X509_NAME_push error");
             wolfSSL_X509_NAME_free(nameCopy);
             return WOLFSSL_FAILURE;
@@ -16855,7 +11285,8 @@ int wolfSSL_set_compression(WOLFSSL* ssl)
 
     #ifndef NO_BIO
         #if !defined(NO_RSA) && !defined(NO_CERTS)
-        WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_load_client_CA_file(const char* fname)
+        WOLF_STACK_OF(WOLFSSL_X509_NAME)* wolfSSL_load_client_CA_file(
+            const char* fname)
         {
             /* The webserver build is using this to load a CA into the server
              * for client authentication as an option. Have this return NULL in
@@ -16933,75 +11364,6 @@ cleanup:
 #endif /* OPENSSL_EXTRA || WOLFSSL_EXTRA */
 
 #ifdef OPENSSL_EXTRA
-
-    #ifdef WOLFSSL_SYS_CA_CERTS
-    /*
-     * This is an OpenSSL compatibility layer function, but it doesn't mirror
-     * the exact functionality of its OpenSSL counterpart. We don't support the
-     * notion of an "OpenSSL directory". This function will attempt to load the
-     * environment variables SSL_CERT_DIR and SSL_CERT_FILE, if either are found,
-     * they will be loaded. Otherwise, it will act as a wrapper around our
-     * native wolfSSL_CTX_load_system_CA_certs function. This function does
-     * conform to OpenSSL's return value conventions.
-     */
-    int wolfSSL_CTX_set_default_verify_paths(WOLFSSL_CTX* ctx)
-    {
-        int ret;
-#ifdef XGETENV
-        char* certDir;
-        char* certFile;
-        word32 flags;
-#endif
-
-        WOLFSSL_ENTER("wolfSSL_CTX_set_default_verify_paths");
-
-#ifdef XGETENV
-        certDir = XGETENV("SSL_CERT_DIR");
-        certFile = XGETENV("SSL_CERT_FILE");
-        flags = WOLFSSL_LOAD_FLAG_PEM_CA_ONLY;
-
-        if (certDir || certFile) {
-            if (certDir) {
-               /*
-                * We want to keep trying to load more CAs even if one cert in
-                * the directory is bad and can't be used (e.g. if one is expired),
-                * so we use WOLFSSL_LOAD_FLAG_IGNORE_ERR.
-                */
-                flags |= WOLFSSL_LOAD_FLAG_IGNORE_ERR;
-            }
-
-            ret = wolfSSL_CTX_load_verify_locations_ex(ctx, certFile, certDir,
-                    flags);
-            if (ret != WOLFSSL_SUCCESS) {
-                WOLFSSL_MSG_EX("Failed to load CA certs from SSL_CERT_FILE: %s"
-                                " SSL_CERT_DIR: %s. Error: %d", certFile,
-                                certDir, ret);
-                return WOLFSSL_FAILURE;
-            }
-            return ret;
-        }
-#endif
-
-#ifdef NO_FILESYSTEM
-        WOLFSSL_MSG("wolfSSL_CTX_set_default_verify_paths not supported"
-                    " with NO_FILESYSTEM enabled");
-        ret = WOLFSSL_FATAL_ERROR;
-#else
-        ret = wolfSSL_CTX_load_system_CA_certs(ctx);
-        if (ret == WOLFSSL_BAD_PATH) {
-            /*
-             * OpenSSL doesn't treat the lack of a system CA cert directory as a
-             * failure. We do the same here.
-             */
-            ret = WOLFSSL_SUCCESS;
-        }
-#endif
-
-        WOLFSSL_LEAVE("wolfSSL_CTX_set_default_verify_paths", ret);
-
-        return ret;
-    }
-    #endif /* WOLFSSL_SYS_CA_CERTS */
 
     #if defined(WOLFCRYPT_HAVE_SRP) && !defined(NO_SHA256) \
         && !defined(WC_NO_RNG)
@@ -17191,7 +11553,8 @@ cleanup:
 
 #endif /* OPENSSL_EXTRA */
 
-#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_EXTRA) || \
+    defined(WOLFSSL_WPAS_SMALL)
 
     /* store keys returns WOLFSSL_SUCCESS or -1 on error */
     int wolfSSL_get_keys(WOLFSSL* ssl, unsigned char** ms, unsigned int* msLen,
@@ -17273,8 +11636,8 @@ cleanup:
         if (ssl == NULL)
             return 0;
 
-        /* Can't use ssl->options.connectState and ssl->options.acceptState because
-         * they differ in meaning for TLS <=1.2 and 1.3 */
+        /* Can't use ssl->options.connectState and ssl->options.acceptState
+         * because they differ in meaning for TLS <=1.2 and 1.3 */
         if (ssl->options.handShakeState == HANDSHAKE_DONE)
             return 1;
 
@@ -17382,7 +11745,8 @@ cleanup:
     }
 #endif /* OPENSSL_EXTRA */
 
-#if !defined(NO_CERTS) && (defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL))
+#if !defined(NO_CERTS) && (defined(OPENSSL_EXTRA) || \
+    defined(WOLFSSL_WPAS_SMALL))
 
 #if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
     /**
@@ -17441,7 +11805,7 @@ cleanup:
     }
 #endif /* SESSION_CERTS && OPENSSL_EXTRA */
 
-    WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(WOLFSSL_CTX* ctx)
+    WOLFSSL_X509_STORE* wolfSSL_CTX_get_cert_store(const WOLFSSL_CTX* ctx)
     {
         if (ctx == NULL) {
             return NULL;
@@ -17449,7 +11813,7 @@ cleanup:
 
         if (ctx->x509_store_pt != NULL)
             return ctx->x509_store_pt;
-        return &ctx->x509_store;
+        return &((WOLFSSL_CTX*)ctx)->x509_store;
     }
 
     void wolfSSL_CTX_set_cert_store(WOLFSSL_CTX* ctx, WOLFSSL_X509_STORE* str)
@@ -17480,7 +11844,8 @@ cleanup:
     }
 
 #ifdef OPENSSL_ALL
-    int wolfSSL_CTX_set1_verify_cert_store(WOLFSSL_CTX* ctx, WOLFSSL_X509_STORE* str)
+    int wolfSSL_CTX_set1_verify_cert_store(WOLFSSL_CTX* ctx,
+        WOLFSSL_X509_STORE* str)
     {
         WOLFSSL_ENTER("wolfSSL_CTX_set1_verify_cert_store");
 
@@ -18742,59 +13107,6 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     }
 #endif
 
-#ifdef WOLFSSL_SESSION_ID_CTX
-    /* Storing app session context id, this value is inherited by WOLFSSL
-     * objects created from WOLFSSL_CTX. Any session that is imported with a
-     * different session context id will be rejected.
-     *
-     * ctx         structure to set context in
-     * sid_ctx     value of context to set
-     * sid_ctx_len length of sid_ctx buffer
-     *
-     * Returns WOLFSSL_SUCCESS in success case and WOLFSSL_FAILURE when failing
-     */
-    int wolfSSL_CTX_set_session_id_context(WOLFSSL_CTX* ctx,
-                                           const unsigned char* sid_ctx,
-                                           unsigned int sid_ctx_len)
-    {
-        WOLFSSL_ENTER("wolfSSL_CTX_set_session_id_context");
-
-        /* No application specific context needed for wolfSSL */
-        if (sid_ctx_len > ID_LEN || ctx == NULL || sid_ctx == NULL) {
-            return WOLFSSL_FAILURE;
-        }
-        XMEMCPY(ctx->sessionCtx, sid_ctx, sid_ctx_len);
-        ctx->sessionCtxSz = (byte)sid_ctx_len;
-
-        return WOLFSSL_SUCCESS;
-    }
-
-
-
-    /* Storing app session context id. Any session that is imported with a
-     * different session context id will be rejected.
-     *
-     * ssl  structure to set context in
-     * id   value of context to set
-     * len  length of sid_ctx buffer
-     *
-     * Returns WOLFSSL_SUCCESS in success case and WOLFSSL_FAILURE when failing
-     */
-    int wolfSSL_set_session_id_context(WOLFSSL* ssl, const unsigned char* id,
-                                   unsigned int len)
-    {
-        WOLFSSL_ENTER("wolfSSL_set_session_id_context");
-
-        if (len > ID_LEN || ssl == NULL || id == NULL) {
-            return WOLFSSL_FAILURE;
-        }
-        XMEMCPY(ssl->sessionCtx, id, len);
-        ssl->sessionCtxSz = (byte)len;
-
-        return WOLFSSL_SUCCESS;
-    }
-#endif
-
 #ifdef OPENSSL_EXTRA
 
     #ifndef NO_WOLFSSL_STUB
@@ -18828,17 +13140,6 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     #endif
 
 
-    long wolfSSL_CTX_sess_get_cache_size(WOLFSSL_CTX* ctx)
-    {
-        (void)ctx;
-        #ifndef NO_SESSION_CACHE
-            return (long)(SESSIONS_PER_ROW * SESSION_ROWS);
-        #else
-            return 0;
-        #endif
-    }
-
-
     /* returns the unsigned error value and increments the pointer into the
      * error queue.
      *
@@ -18850,7 +13151,8 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
     #ifdef WOLFSSL_HAVE_ERROR_QUEUE
         int ret = wc_PullErrorNode(file, NULL, line);
         if (ret < 0) {
-            if (ret == BAD_STATE_E) return 0; /* no errors in queue */
+            if (ret == WC_NO_ERR_TRACE(BAD_STATE_E))
+                return 0; /* no errors in queue */
             WOLFSSL_MSG("Issue getting error node");
             WOLFSSL_LEAVE("wolfSSL_ERR_get_error_line", ret);
             ret = 0 - ret; /* return absolute value of error */
@@ -18962,7 +13264,8 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
 
         ret = wc_PullErrorNode(file, data, line);
         if (ret < 0) {
-            if (ret == BAD_STATE_E) return 0; /* no errors in queue */
+            if (ret == WC_NO_ERR_TRACE(BAD_STATE_E))
+                return 0; /* no errors in queue */
             WOLFSSL_MSG("Error with pulling error node!");
             WOLFSSL_LEAVE("wolfSSL_ERR_get_error_line_data", ret);
             ret = 0 - ret; /* return absolute value of error */
@@ -19015,8 +13318,8 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
 
         /* Create a DecodedCert object and copy fields into WOLFSSL_X509 object.
          */
-        InitDecodedCert(cert, (byte*)in, len, NULL);
-        if ((ret = ParseCertRelative(cert, CERT_TYPE, 0, NULL)) == 0) {
+        InitDecodedCert(cert, (byte*)in, (word32)len, NULL);
+        if ((ret = ParseCertRelative(cert, CERT_TYPE, 0, NULL, NULL)) == 0) {
         /* Check if x509 was not previously initialized by wolfSSL_X509_new() */
             if (x509->dynamicMemory != TRUE)
                 InitX509(x509, 0, NULL);
@@ -19059,7 +13362,8 @@ size_t wolfSSL_get_client_random(const WOLFSSL* ssl, unsigned char* out,
 
 #if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
 /* Return stack of peer certs.
- * Caller does not need to free return. The stack is Free'd when WOLFSSL* ssl is.
+ * Caller does not need to free return. The stack is Free'd when WOLFSSL* ssl
+ * is.
  */
 WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_get_peer_cert_chain(const WOLFSSL* ssl)
 {
@@ -19635,532 +13939,6 @@ int wolfSSL_session_reused(WOLFSSL* ssl)
     return resuming;
 }
 
-/* return a new malloc'd session with default settings on success */
-WOLFSSL_SESSION* wolfSSL_NewSession(void* heap)
-{
-    WOLFSSL_SESSION* ret = NULL;
-
-    WOLFSSL_ENTER("wolfSSL_NewSession");
-
-    ret = (WOLFSSL_SESSION*)XMALLOC(sizeof(WOLFSSL_SESSION), heap,
-            DYNAMIC_TYPE_SESSION);
-    if (ret != NULL) {
-        int err;
-        XMEMSET(ret, 0, sizeof(WOLFSSL_SESSION));
-        wolfSSL_RefInit(&ret->ref, &err);
-    #ifdef WOLFSSL_REFCNT_ERROR_RETURN
-        if (err != 0) {
-            WOLFSSL_MSG("Error setting up session reference mutex");
-            XFREE(ret, ret->heap, DYNAMIC_TYPE_SESSION);
-            return NULL;
-        }
-    #else
-        (void)err;
-    #endif
-#ifndef NO_SESSION_CACHE
-        ret->cacheRow = INVALID_SESSION_ROW; /* not in cache */
-#endif
-        ret->type = WOLFSSL_SESSION_TYPE_HEAP;
-        ret->heap = heap;
-#ifdef WOLFSSL_CHECK_MEM_ZERO
-        wc_MemZero_Add("SESSION master secret", ret->masterSecret, SECRET_LEN);
-        wc_MemZero_Add("SESSION id", ret->sessionID, ID_LEN);
-#endif
-    #ifdef HAVE_SESSION_TICKET
-        ret->ticket = ret->staticTicket;
-        #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&  \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-        ret->ticketNonce.data = ret->ticketNonce.dataStatic;
-        #endif
-    #endif
-#ifdef HAVE_EX_DATA
-        ret->ownExData = 1;
-        if (crypto_ex_cb_ctx_session != NULL) {
-            crypto_ex_cb_setup_new_data(ret, crypto_ex_cb_ctx_session,
-                    &ret->ex_data);
-        }
-#endif
-    }
-    return ret;
-}
-
-
-WOLFSSL_SESSION* wolfSSL_SESSION_new_ex(void* heap)
-{
-    return wolfSSL_NewSession(heap);
-}
-
-WOLFSSL_SESSION* wolfSSL_SESSION_new(void)
-{
-    return wolfSSL_SESSION_new_ex(NULL);
-}
-
-/* add one to session reference count
- * return WOLFSSL_SUCCESS on success and WOLFSSL_FAILURE on error */
-int wolfSSL_SESSION_up_ref(WOLFSSL_SESSION* session)
-{
-    int ret;
-
-    session = ClientSessionToSession(session);
-
-    if (session == NULL || session->type != WOLFSSL_SESSION_TYPE_HEAP)
-        return WOLFSSL_FAILURE;
-
-    wolfSSL_RefInc(&session->ref, &ret);
-#ifdef WOLFSSL_REFCNT_ERROR_RETURN
-    if (ret != 0) {
-        WOLFSSL_MSG("Failed to lock session mutex");
-        return WOLFSSL_FAILURE;
-    }
-#else
-    (void)ret;
-#endif
-
-    return WOLFSSL_SUCCESS;
-}
-
-/**
- * Deep copy the contents from input to output.
- * @param input         The source of the copy.
- * @param output        The destination of the copy.
- * @param avoidSysCalls If true, then system calls will be avoided or an error
- *                      will be returned if it is not possible to proceed
- *                      without a system call. This is useful for fetching
- *                      sessions from cache. When a cache row is locked, we
- *                      don't want to block other threads with long running
- *                      system calls.
- * @param ticketNonceBuf If not null and @avoidSysCalls is true, the copy of the
- *                      ticketNonce will happen in this pre allocated buffer
- * @param ticketNonceLen @ticketNonceBuf len as input, used length on output
- * @param ticketNonceUsed if @ticketNonceBuf was used to copy the ticket noncet
- * @return              WOLFSSL_SUCCESS on success
- *                      WOLFSSL_FAILURE on failure
- */
-static int wolfSSL_DupSessionEx(const WOLFSSL_SESSION* input,
-    WOLFSSL_SESSION* output, int avoidSysCalls, byte* ticketNonceBuf,
-    byte* ticketNonceLen, byte* preallocUsed)
-{
-#ifdef HAVE_SESSION_TICKET
-    int   ticLenAlloc = 0;
-    byte *ticBuff = NULL;
-#endif
-    const size_t copyOffset = OFFSETOF(WOLFSSL_SESSION, heap) + sizeof(input->heap);
-    int ret = WOLFSSL_SUCCESS;
-
-    (void)avoidSysCalls;
-    (void)ticketNonceBuf;
-    (void)ticketNonceLen;
-    (void)preallocUsed;
-
-    input = ClientSessionToSession(input);
-    output = ClientSessionToSession(output);
-
-    if (input == NULL || output == NULL || input == output) {
-        WOLFSSL_MSG("input or output are null or same");
-        return WOLFSSL_FAILURE;
-    }
-
-#ifdef HAVE_SESSION_TICKET
-    if (output->ticket != output->staticTicket) {
-        ticBuff = output->ticket;
-        ticLenAlloc = output->ticketLenAlloc;
-    }
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-        /* free the data, it would be better to reuse the buffer but this
-         * maintain the code simpler. A smart allocator should reuse the free'd
-         * buffer in the next malloc without much performance penalties. */
-    if (output->ticketNonce.data != output->ticketNonce.dataStatic) {
-
-        /*  Callers that avoid syscall should never calls this with
-         * output->tickeNonce.data being a dynamic buffer.*/
-        if (avoidSysCalls) {
-            WOLFSSL_MSG("can't avoid syscalls with dynamic TicketNonce buffer");
-            return WOLFSSL_FAILURE;
-        }
-
-        XFREE(output->ticketNonce.data,
-            output->heap, DYNAMIC_TYPE_SESSION_TICK);
-        output->ticketNonce.data = output->ticketNonce.dataStatic;
-        output->ticketNonce.len = 0;
-    }
-#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
-#endif /* HAVE_SESSION_TICKET */
-
-#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-    if (output->peer != NULL) {
-        if (avoidSysCalls) {
-            WOLFSSL_MSG("Can't free cert when avoiding syscalls");
-            return WOLFSSL_FAILURE;
-        }
-        wolfSSL_X509_free(output->peer);
-        output->peer = NULL;
-    }
-#endif
-
-    XMEMCPY((byte*)output + copyOffset, (byte*)input + copyOffset,
-            sizeof(WOLFSSL_SESSION) - copyOffset);
-
-#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_TLS13) &&                  \
-    defined(WOLFSSL_TICKET_NONCE_MALLOC) &&                                    \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-    /* fix pointer to static after the copy  */
-    output->ticketNonce.data = output->ticketNonce.dataStatic;
-#endif
-    /* Set sane values for copy */
-#ifndef NO_SESSION_CACHE
-    if (output->type != WOLFSSL_SESSION_TYPE_CACHE)
-        output->cacheRow = INVALID_SESSION_ROW;
-#endif
-#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-    if (input->peer != NULL && input->peer->dynamicMemory) {
-        if (wolfSSL_X509_up_ref(input->peer) != WOLFSSL_SUCCESS) {
-            WOLFSSL_MSG("Can't increase peer cert ref count");
-            output->peer = NULL;
-        }
-    }
-    else if (!avoidSysCalls)
-        output->peer = wolfSSL_X509_dup(input->peer);
-    else
-        /* output->peer is not that important to copy */
-        output->peer = NULL;
-#endif
-#ifdef HAVE_SESSION_TICKET
-    if (input->ticketLen > SESSION_TICKET_LEN) {
-        /* Need dynamic buffer */
-        if (ticBuff == NULL || ticLenAlloc < input->ticketLen) {
-            /* allocate new one */
-            byte* tmp;
-            if (avoidSysCalls) {
-                WOLFSSL_MSG("Failed to allocate memory for ticket when avoiding"
-                        " syscalls");
-                output->ticket = ticBuff;
-                output->ticketLenAlloc = (word16) ticLenAlloc;
-                output->ticketLen = 0;
-                ret = WOLFSSL_FAILURE;
-            }
-            else {
-#ifdef WOLFSSL_NO_REALLOC
-                tmp = (byte*)XMALLOC(input->ticketLen,
-                        output->heap, DYNAMIC_TYPE_SESSION_TICK);
-                XFREE(ticBuff, output->heap, DYNAMIC_TYPE_SESSION_TICK);
-                ticBuff = NULL;
-#else
-                tmp = (byte*)XREALLOC(ticBuff, input->ticketLen,
-                        output->heap, DYNAMIC_TYPE_SESSION_TICK);
-#endif /* WOLFSSL_NO_REALLOC */
-                if (tmp == NULL) {
-                    WOLFSSL_MSG("Failed to allocate memory for ticket");
-#ifndef WOLFSSL_NO_REALLOC
-                    XFREE(ticBuff, output->heap, DYNAMIC_TYPE_SESSION_TICK);
-                    ticBuff = NULL;
-#endif /* WOLFSSL_NO_REALLOC */
-                    output->ticket = NULL;
-                    output->ticketLen = 0;
-                    output->ticketLenAlloc = 0;
-                    ret = WOLFSSL_FAILURE;
-                }
-                else {
-                    ticBuff = tmp;
-                    ticLenAlloc = input->ticketLen;
-                }
-            }
-        }
-        if (ticBuff != NULL && ret == WOLFSSL_SUCCESS) {
-            XMEMCPY(ticBuff, input->ticket, input->ticketLen);
-            output->ticket = ticBuff;
-            output->ticketLenAlloc = (word16) ticLenAlloc;
-        }
-    }
-    else {
-        /* Default ticket to non dynamic */
-        if (avoidSysCalls) {
-            /* Try to use ticBuf if available. Caller can later move it to
-             * the static buffer. */
-            if (ticBuff != NULL) {
-                if (ticLenAlloc >= input->ticketLen) {
-                    output->ticket = ticBuff;
-                    output->ticketLenAlloc = ticLenAlloc;
-                }
-                else {
-                    WOLFSSL_MSG("ticket dynamic buffer too small but we are "
-                                "avoiding system calls");
-                    ret = WOLFSSL_FAILURE;
-                    output->ticket = ticBuff;
-                    output->ticketLenAlloc = (word16) ticLenAlloc;
-                    output->ticketLen = 0;
-                }
-            }
-            else {
-                output->ticket = output->staticTicket;
-                output->ticketLenAlloc = 0;
-            }
-        }
-        else {
-            if (ticBuff != NULL)
-                XFREE(ticBuff, output->heap, DYNAMIC_TYPE_SESSION_TICK);
-            output->ticket = output->staticTicket;
-            output->ticketLenAlloc = 0;
-        }
-        if (input->ticketLenAlloc > 0 && ret == WOLFSSL_SUCCESS) {
-            /* Shouldn't happen as session should have placed this in
-             * the static buffer */
-            XMEMCPY(output->ticket, input->ticket,
-                    input->ticketLen);
-        }
-    }
-    ticBuff = NULL;
-
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-    if (preallocUsed != NULL)
-        *preallocUsed = 0;
-
-    if (input->ticketNonce.len > MAX_TICKET_NONCE_STATIC_SZ &&
-        ret == WOLFSSL_SUCCESS) {
-        /* TicketNonce does not fit in the static buffer */
-        if (!avoidSysCalls) {
-            output->ticketNonce.data = (byte*)XMALLOC(input->ticketNonce.len,
-                output->heap, DYNAMIC_TYPE_SESSION_TICK);
-
-            if (output->ticketNonce.data == NULL) {
-                WOLFSSL_MSG("Failed to allocate space for ticket nonce");
-                output->ticketNonce.data = output->ticketNonce.dataStatic;
-                output->ticketNonce.len = 0;
-                ret = WOLFSSL_FAILURE;
-            }
-            else {
-                output->ticketNonce.len = input->ticketNonce.len;
-                XMEMCPY(output->ticketNonce.data, input->ticketNonce.data,
-                    input->ticketNonce.len);
-                ret = WOLFSSL_SUCCESS;
-            }
-        }
-        /* we can't do syscalls. Use prealloc buffers if provided from the
-         * caller. */
-        else if (ticketNonceBuf != NULL &&
-                 *ticketNonceLen >= input->ticketNonce.len) {
-            XMEMCPY(ticketNonceBuf, input->ticketNonce.data,
-                input->ticketNonce.len);
-            *ticketNonceLen = input->ticketNonce.len;
-            if (preallocUsed != NULL)
-                *preallocUsed = 1;
-            ret = WOLFSSL_SUCCESS;
-        }
-        else {
-            WOLFSSL_MSG("TicketNonce bigger than static buffer, and we can't "
-                        "do syscalls");
-            ret = WOLFSSL_FAILURE;
-        }
-    }
-#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
-
-#endif /* HAVE_SESSION_TICKET */
-
-#ifdef HAVE_EX_DATA
-    if (input->type != WOLFSSL_SESSION_TYPE_CACHE &&
-            output->type != WOLFSSL_SESSION_TYPE_CACHE) {
-        /* Not called with cache as that passes ownership of ex_data */
-        ret = crypto_ex_cb_dup_data(&input->ex_data, &output->ex_data,
-                                    crypto_ex_cb_ctx_session);
-    }
-#endif
-
-    return ret;
-}
-
-/**
- * Deep copy the contents from input to output.
- * @param input         The source of the copy.
- * @param output        The destination of the copy.
- * @param avoidSysCalls If true, then system calls will be avoided or an error
- *                      will be returned if it is not possible to proceed
- *                      without a system call. This is useful for fetching
- *                      sessions from cache. When a cache row is locked, we
- *                      don't want to block other threads with long running
- *                      system calls.
- * @return              WOLFSSL_SUCCESS on success
- *                      WOLFSSL_FAILURE on failure
- */
-int wolfSSL_DupSession(const WOLFSSL_SESSION* input, WOLFSSL_SESSION* output,
-        int avoidSysCalls)
-{
-    return wolfSSL_DupSessionEx(input, output, avoidSysCalls, NULL, NULL, NULL);
-}
-
-WOLFSSL_SESSION* wolfSSL_SESSION_dup(WOLFSSL_SESSION* session)
-{
-    WOLFSSL_SESSION* copy;
-
-    WOLFSSL_ENTER("wolfSSL_SESSION_dup");
-
-    session = ClientSessionToSession(session);
-    if (session == NULL)
-        return NULL;
-
-#ifdef HAVE_SESSION_TICKET
-    if (session->ticketLenAlloc > 0 && !session->ticket) {
-        WOLFSSL_MSG("Session dynamic flag is set but ticket pointer is null");
-        return NULL;
-    }
-#endif
-
-    copy = wolfSSL_NewSession(session->heap);
-    if (copy != NULL &&
-            wolfSSL_DupSession(session, copy, 0) != WOLFSSL_SUCCESS) {
-        wolfSSL_FreeSession(NULL, copy);
-        copy = NULL;
-    }
-    return copy;
-}
-
-void wolfSSL_FreeSession(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* session)
-{
-    session = ClientSessionToSession(session);
-    if (session == NULL)
-        return;
-
-    (void)ctx;
-
-    WOLFSSL_ENTER("wolfSSL_FreeSession");
-
-    if (session->ref.count > 0) {
-        int ret;
-        int isZero;
-        wolfSSL_RefDec(&session->ref, &isZero, &ret);
-        (void)ret;
-        if (!isZero) {
-            return;
-        }
-        wolfSSL_RefFree(&session->ref);
-    }
-
-    WOLFSSL_MSG("wolfSSL_FreeSession full free");
-
-#ifdef HAVE_EX_DATA
-    if (session->ownExData) {
-        crypto_ex_cb_free_data(session, crypto_ex_cb_ctx_session,
-                &session->ex_data);
-    }
-#endif
-
-#ifdef HAVE_EX_DATA_CLEANUP_HOOKS
-    wolfSSL_CRYPTO_cleanup_ex_data(&session->ex_data);
-#endif
-
-#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
-    if (session->peer) {
-        wolfSSL_X509_free(session->peer);
-        session->peer = NULL;
-    }
-#endif
-
-#ifdef HAVE_SESSION_TICKET
-    if (session->ticketLenAlloc > 0) {
-        XFREE(session->ticket, session->heap, DYNAMIC_TYPE_SESSION_TICK);
-        session->ticket = session->staticTicket;
-        session->ticketLen = 0;
-        session->ticketLenAlloc = 0;
-    }
-#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-    if (session->ticketNonce.data != session->ticketNonce.dataStatic) {
-        XFREE(session->ticketNonce.data, session->heap,
-            DYNAMIC_TYPE_SESSION_TICK);
-        session->ticketNonce.data = session->ticketNonce.dataStatic;
-        session->ticketNonce.len = 0;
-    }
-#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
-#endif
-
-#ifdef HAVE_EX_DATA_CLEANUP_HOOKS
-    wolfSSL_CRYPTO_cleanup_ex_data(&session->ex_data);
-#endif
-
-    /* Make sure masterSecret is zeroed. */
-    ForceZero(session->masterSecret, SECRET_LEN);
-    /* Session ID is sensitive information too. */
-    ForceZero(session->sessionID, ID_LEN);
-
-    if (session->type == WOLFSSL_SESSION_TYPE_HEAP) {
-        XFREE(session, session->heap, DYNAMIC_TYPE_SESSION);
-    }
-}
-
-/* DO NOT use this API internally. Use wolfSSL_FreeSession directly instead
- * and pass in the ctx parameter if possible (like from ssl->ctx). */
-void wolfSSL_SESSION_free(WOLFSSL_SESSION* session)
-{
-    session = ClientSessionToSession(session);
-    wolfSSL_FreeSession(NULL, session);
-}
-
-#ifndef NO_SESSION_CACHE
-int wolfSSL_CTX_add_session(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* session)
-{
-    int    error = 0;
-    const byte* id = NULL;
-    byte idSz = 0;
-
-    WOLFSSL_ENTER("wolfSSL_CTX_add_session");
-
-    session = ClientSessionToSession(session);
-    if (session == NULL)
-        return WOLFSSL_FAILURE;
-
-    /* Session cache is global */
-    (void)ctx;
-
-    if (session->haveAltSessionID) {
-        id = session->altSessionID;
-        idSz = ID_LEN;
-    }
-    else {
-        id = session->sessionID;
-        idSz = session->sessionIDSz;
-    }
-
-    error = AddSessionToCache(ctx, session, id, idSz,
-            NULL, session->side,
-#ifdef HAVE_SESSION_TICKET
-            session->ticketLen > 0,
-#else
-            0,
-#endif
-            NULL);
-
-    return error == 0 ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
-}
-#endif
-
-#if defined(OPENSSL_EXTRA) || defined(HAVE_EXT_CACHE)
-
-/**
-* set cipher to WOLFSSL_SESSION from WOLFSSL_CIPHER
-* @param session  a pointer to WOLFSSL_SESSION structure
-* @param cipher   a function pointer to WOLFSSL_CIPHER
-* @return WOLFSSL_SUCCESS on success, otherwise WOLFSSL_FAILURE
-*/
-int wolfSSL_SESSION_set_cipher(WOLFSSL_SESSION* session,
-                                            const WOLFSSL_CIPHER* cipher)
-{
-    WOLFSSL_ENTER("wolfSSL_SESSION_set_cipher");
-
-    session = ClientSessionToSession(session);
-    /* sanity check */
-    if (session == NULL || cipher == NULL) {
-        WOLFSSL_MSG("bad argument");
-        return WOLFSSL_FAILURE;
-    }
-    session->cipherSuite0 = cipher->cipherSuite0;
-    session->cipherSuite  = cipher->cipherSuite;
-
-    WOLFSSL_LEAVE("wolfSSL_SESSION_set_cipher", WOLFSSL_SUCCESS);
-    return WOLFSSL_SUCCESS;
-}
-#endif /* OPENSSL_EXTRA || HAVE_EXT_CACHE */
-
-
 /* helper function that takes in a protocol version struct and returns string */
 static const char* wolfSSL_internal_get_version(const ProtocolVersion* version)
 {
@@ -20296,25 +14074,6 @@ const char*  wolfSSL_CIPHER_get_version(const WOLFSSL_CIPHER* cipher)
     return wolfSSL_get_version(cipher->ssl);
 }
 
-const char* wolfSSL_SESSION_CIPHER_get_name(const WOLFSSL_SESSION* session)
-{
-    session = ClientSessionToSession(session);
-    if (session == NULL) {
-        return NULL;
-    }
-
-#if defined(SESSION_CERTS) || !defined(NO_RESUME_SUITE_CHECK) || \
-                        (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
-    #if !defined(WOLFSSL_CIPHER_INTERNALNAME) && !defined(NO_ERROR_STRINGS)
-        return GetCipherNameIana(session->cipherSuite0, session->cipherSuite);
-    #else
-        return GetCipherNameInternal(session->cipherSuite0, session->cipherSuite);
-    #endif
-#else
-    return NULL;
-#endif
-}
-
 const char* wolfSSL_get_cipher(WOLFSSL* ssl)
 {
     WOLFSSL_ENTER("wolfSSL_get_cipher");
@@ -20328,14 +14087,14 @@ const char* wolfSSL_get_cipher_name(WOLFSSL* ssl)
     return wolfSSL_get_cipher_name_internal(ssl);
 }
 
-const char* wolfSSL_get_cipher_name_from_suite(const byte cipherSuite0,
-    const byte cipherSuite)
+const char* wolfSSL_get_cipher_name_from_suite(byte cipherSuite0,
+    byte cipherSuite)
 {
     return GetCipherNameInternal(cipherSuite0, cipherSuite);
 }
 
-const char* wolfSSL_get_cipher_name_iana_from_suite(const byte cipherSuite0,
-        const byte cipherSuite)
+const char* wolfSSL_get_cipher_name_iana_from_suite(byte cipherSuite0,
+        byte cipherSuite)
 {
     return GetCipherNameIana(cipherSuite0, cipherSuite);
 }
@@ -20470,7 +14229,7 @@ const char* wolfSSL_get_curve_name(WOLFSSL* ssl)
     if (ssl == NULL)
         return NULL;
 
-#if defined(WOLFSSL_TLS13) && defined(HAVE_PQC)
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_HAVE_KYBER)
     /* Check for post-quantum groups. Return now because we do not want the ECC
      * check to override this result in the case of a hybrid. */
     if (IsAtLeastTLSv1_3(ssl->version)) {
@@ -20495,20 +14254,26 @@ const char* wolfSSL_get_curve_name(WOLFSSL* ssl)
     #ifdef WOLFSSL_KYBER512
         case WOLFSSL_KYBER_LEVEL1:
             return "KYBER_LEVEL1";
+        case WOLFSSL_P256_KYBER_LEVEL1:
+            return "P256_KYBER_LEVEL1";
     #endif
     #ifdef WOLFSSL_KYBER768
         case WOLFSSL_KYBER_LEVEL3:
             return "KYBER_LEVEL3";
+        case WOLFSSL_P384_KYBER_LEVEL3:
+            return "P384_KYBER_LEVEL3";
     #endif
     #ifdef WOLFSSL_KYBER1024
         case WOLFSSL_KYBER_LEVEL5:
             return "KYBER_LEVEL5";
+        case WOLFSSL_P521_KYBER_LEVEL5:
+            return "P521_KYBER_LEVEL5";
     #endif
 #endif
         }
     }
+#endif /* WOLFSSL_TLS13 && WOLFSSL_HAVE_KYBER */
 
-#endif /* WOLFSSL_TLS13 && HAVE_PQC */
 #ifdef HAVE_FFDHE
     if (ssl->namedGroup != 0) {
         cName = wolfssl_ffdhe_name(ssl->namedGroup);
@@ -21145,26 +14910,6 @@ int wolfSSL_OCSP_parse_url(char* url, char** host, char** port, char** path,
 #endif
 
 #ifndef NO_WOLFSSL_STUB
-void wolfSSL_RAND_screen(void)
-{
-    WOLFSSL_STUB("RAND_screen");
-}
-#endif
-
-
-
-int wolfSSL_RAND_load_file(const char* fname, long len)
-{
-    (void)fname;
-    /* wolfCrypt provides enough entropy internally or will report error */
-    if (len == -1)
-        return 1024;
-    else
-        return (int)len;
-}
-
-
-#ifndef NO_WOLFSSL_STUB
 WOLFSSL_COMP_METHOD* wolfSSL_COMP_zlib(void)
 {
     WOLFSSL_STUB("COMP_zlib");
@@ -21187,6 +14932,17 @@ int wolfSSL_COMP_add_compression_method(int method, void* data)
     (void)data;
     WOLFSSL_STUB("COMP_add_compression_method");
     return 0;
+}
+#endif
+
+#ifndef NO_WOLFSSL_STUB
+const char* wolfSSL_COMP_get_name(const void* comp)
+{
+    static const char ret[] = "not supported";
+
+    (void)comp;
+    WOLFSSL_STUB("wolfSSL_COMP_get_name");
+    return ret;
 }
 #endif
 
@@ -21283,12 +15039,12 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
         /* In this case, there was no buffered DER at all. This could be the
          * case where the key that was passed in was generated. So now we
          * have to create the local DER. */
-        local_derSz = wolfSSL_i2d_ECPrivateKey(key->ecc, &local_der);
+        local_derSz = (word32)wolfSSL_i2d_ECPrivateKey(key->ecc, &local_der);
         if (local_derSz == 0) {
             ret = WOLFSSL_FATAL_ERROR;
         }
     } else {
-        local_derSz = ret;
+        local_derSz = (word32)ret;
         ret = 0;
     }
 
@@ -21313,7 +15069,7 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
     }
 
     if (ret == 0) {
-        pub_derSz = wc_EccPublicKeyDerSize(eccKey, 0);
+        pub_derSz = (word32)wc_EccPublicKeyDerSize(eccKey, 0);
         if ((int)pub_derSz <= 0) {
             ret = WOLFSSL_FAILURE;
         }
@@ -21329,7 +15085,7 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
     }
 
     if (ret == 0) {
-        pub_derSz = wc_EccPublicKeyToDer(eccKey, pub_der, pub_derSz, 0);
+        pub_derSz = (word32)wc_EccPublicKeyToDer(eccKey, pub_der, pub_derSz, 0);
         if ((int)pub_derSz <= 0) {
             ret = WOLFSSL_FATAL_ERROR;
         }
@@ -21366,7 +15122,7 @@ int wolfSSL_i2d_PublicKey(const WOLFSSL_EVP_PKEY *key, unsigned char **der)
 #endif /* HAVE_ECC */
 
     if (ret == 0) {
-        return pub_derSz;
+        return (int)pub_derSz;
     }
 
     return ret;
@@ -21494,9 +15250,9 @@ int wolfSSL_ERR_GET_LIB(unsigned long err)
 
     value = (err & 0xFFFFFFL);
     switch (value) {
-    case -SSL_R_HTTP_REQUEST:
+    case -WC_NO_ERR_TRACE(PARSE_ERROR):
         return ERR_LIB_SSL;
-    case -ASN_NO_PEM_HEADER:
+    case -WC_NO_ERR_TRACE(ASN_NO_PEM_HEADER):
     case PEM_R_NO_START_LINE:
     case PEM_R_PROBLEMS_GETTING_PASSWORD:
     case PEM_R_BAD_PASSWORD_READ:
@@ -21932,29 +15688,6 @@ const char* wolfSSL_state_string_long(const WOLFSSL* ssl)
     }
 }
 
-/*
- * Sets default PEM callback password if null is passed into
- * the callback parameter of a PEM_read_bio_* function.
- *
- * Returns callback phrase size on success or WOLFSSL_FAILURE otherwise.
- */
-int wolfSSL_PEM_def_callback(char* name, int num, int w, void* key)
-{
-    (void)w;
-    WOLFSSL_ENTER("wolfSSL_PEM_def_callback");
-
-    /* We assume that the user passes a default password as userdata */
-    if (key) {
-        int sz = (int)XSTRLEN((const char*)key);
-        sz = (sz > num) ? num : sz;
-        XMEMCPY(name, key, sz);
-        return sz;
-    } else {
-        WOLFSSL_MSG("Error, default password cannot be created.");
-        return WOLFSSL_FAILURE;
-    }
-}
-
 #endif /* OPENSSL_EXTRA */
 
 static long wolf_set_options(long old_op, long op)
@@ -22011,6 +15744,24 @@ static long wolf_set_options(long old_op, long op)
     return old_op | op;
 }
 
+static int FindHashSig(const Suites* suites, byte first, byte second)
+{
+    word16 i;
+
+    if (suites == NULL || suites->hashSigAlgoSz == 0) {
+        WOLFSSL_MSG("Suites pointer error or suiteSz 0");
+        return SUITES_ERROR;
+    }
+
+    for (i = 0; i < suites->hashSigAlgoSz-1; i += 2) {
+        if (suites->hashSigAlgo[i]   == first &&
+            suites->hashSigAlgo[i+1] == second )
+            return i;
+    }
+
+    return MATCH_SUITE_ERROR;
+}
+
 long wolfSSL_set_options(WOLFSSL* ssl, long op)
 {
     word16 haveRSA = 1;
@@ -22026,21 +15777,25 @@ long wolfSSL_set_options(WOLFSSL* ssl, long op)
     ssl->options.mask = wolf_set_options(ssl->options.mask, op);
 
     if ((ssl->options.mask & WOLFSSL_OP_NO_TLSv1_3) == WOLFSSL_OP_NO_TLSv1_3) {
+        WOLFSSL_MSG("Disabling TLS 1.3");
         if (ssl->version.minor == TLSv1_3_MINOR)
             ssl->version.minor = TLSv1_2_MINOR;
     }
 
     if ((ssl->options.mask & WOLFSSL_OP_NO_TLSv1_2) == WOLFSSL_OP_NO_TLSv1_2) {
+        WOLFSSL_MSG("Disabling TLS 1.2");
         if (ssl->version.minor == TLSv1_2_MINOR)
             ssl->version.minor = TLSv1_1_MINOR;
     }
 
     if ((ssl->options.mask & WOLFSSL_OP_NO_TLSv1_1) == WOLFSSL_OP_NO_TLSv1_1) {
+        WOLFSSL_MSG("Disabling TLS 1.1");
         if (ssl->version.minor == TLSv1_1_MINOR)
             ssl->version.minor = TLSv1_MINOR;
     }
 
     if ((ssl->options.mask & WOLFSSL_OP_NO_TLSv1) == WOLFSSL_OP_NO_TLSv1) {
+        WOLFSSL_MSG("Disabling TLS 1.0");
         if (ssl->version.minor == TLSv1_MINOR)
             ssl->version.minor = SSLv3_MINOR;
     }
@@ -22074,11 +15829,52 @@ long wolfSSL_set_options(WOLFSSL* ssl, long op)
     if (ssl->options.side != WOLFSSL_NEITHER_END) {
         if (AllocateSuites(ssl) != 0)
             return 0;
-        InitSuites(ssl->suites, ssl->version, keySz, haveRSA, havePSK,
-                   ssl->options.haveDH, ssl->options.haveECDSAsig,
-                   ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
-                   ssl->options.haveFalconSig, ssl->options.haveDilithiumSig,
-                   ssl->options.useAnon, TRUE, ssl->options.side);
+        if (!ssl->suites->setSuites) {
+            InitSuites(ssl->suites, ssl->version, keySz, haveRSA,
+                       havePSK, ssl->options.haveDH, ssl->options.haveECDSAsig,
+                       ssl->options.haveECC, TRUE, ssl->options.haveStaticECC,
+                       ssl->options.haveFalconSig,
+                       ssl->options.haveDilithiumSig, ssl->options.useAnon,
+                       TRUE, ssl->options.side);
+        }
+        else {
+            /* Only preserve overlapping suites */
+            Suites tmpSuites;
+            word16 in, out, haveECDSAsig = 0;
+            word16 haveStaticECC = ssl->options.haveStaticECC;
+#ifdef NO_RSA
+            haveECDSAsig = 1;
+            haveStaticECC = 1;
+#endif
+            XMEMSET(&tmpSuites, 0, sizeof(Suites));
+            /* Get all possible ciphers and sigalgs for the version. Following
+             * options limit the allowed ciphers so let's try to get as many as
+             * possible.
+             * - haveStaticECC turns off haveRSA
+             * - haveECDSAsig turns off haveRSAsig */
+            InitSuites(&tmpSuites, ssl->version, 0, 1, 1, 1, haveECDSAsig, 1, 1,
+                    haveStaticECC, 1, 1, 1, 1, ssl->options.side);
+            for (in = 0, out = 0; in < ssl->suites->suiteSz; in += SUITE_LEN) {
+                if (FindSuite(&tmpSuites, ssl->suites->suites[in],
+                        ssl->suites->suites[in+1]) >= 0) {
+                    ssl->suites->suites[out] = ssl->suites->suites[in];
+                    ssl->suites->suites[out+1] = ssl->suites->suites[in+1];
+                    out += SUITE_LEN;
+                }
+            }
+            ssl->suites->suiteSz = out;
+            for (in = 0, out = 0; in < ssl->suites->hashSigAlgoSz; in += 2) {
+                if (FindHashSig(&tmpSuites, ssl->suites->hashSigAlgo[in],
+                    ssl->suites->hashSigAlgo[in+1]) >= 0) {
+                    ssl->suites->hashSigAlgo[out] =
+                            ssl->suites->hashSigAlgo[in];
+                    ssl->suites->hashSigAlgo[out+1] =
+                            ssl->suites->hashSigAlgo[in+1];
+                    out += 2;
+                }
+            }
+            ssl->suites->hashSigAlgoSz = out;
+        }
     }
 
     return ssl->options.mask;
@@ -22161,47 +15957,6 @@ long wolfSSL_set_tlsext_debug_arg(WOLFSSL* ssl, void *arg)
 }
 #endif /* HAVE_PK_CALLBACKS */
 
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_NGINX)
-const unsigned char *wolfSSL_SESSION_get0_id_context(
-                      const WOLFSSL_SESSION *sess, unsigned int *sid_ctx_length)
-{
-    return wolfSSL_SESSION_get_id((WOLFSSL_SESSION *)sess, sid_ctx_length);
-}
-int wolfSSL_SESSION_set1_id(WOLFSSL_SESSION *s,
-                                 const unsigned char *sid, unsigned int sid_len)
-{
-    if (s == NULL) {
-        return WOLFSSL_FAILURE;
-    }
-    if (sid_len > ID_LEN) {
-        return WOLFSSL_FAILURE;
-    }
-    s->sessionIDSz = sid_len;
-    if (sid != s->sessionID) {
-        XMEMCPY(s->sessionID, sid, sid_len);
-    }
-    return WOLFSSL_SUCCESS;
-}
-
-int wolfSSL_SESSION_set1_id_context(WOLFSSL_SESSION *s,
-                         const unsigned char *sid_ctx, unsigned int sid_ctx_len)
-{
-    if (s == NULL) {
-        return WOLFSSL_FAILURE;
-    }
-    if (sid_ctx_len > ID_LEN) {
-        return WOLFSSL_FAILURE;
-    }
-    s->sessionCtxSz = sid_ctx_len;
-    if (sid_ctx != s->sessionCtx) {
-        XMEMCPY(s->sessionCtx, sid_ctx, sid_ctx_len);
-    }
-
-    return WOLFSSL_SUCCESS;
-}
-
-#endif
-
 /*** TBD ***/
 #ifndef NO_WOLFSSL_STUB
 int wolfSSL_sk_SSL_COMP_zero(WOLFSSL_STACK* st)
@@ -22223,8 +15978,8 @@ long wolfSSL_set_tlsext_status_type(WOLFSSL *s, int type)
     }
 
     if (type == TLSEXT_STATUSTYPE_ocsp){
-        int r = TLSX_UseCertificateStatusRequest(&s->extensions, (byte)type, 0, s,
-                                                             s->heap, s->devId);
+        int r = TLSX_UseCertificateStatusRequest(&s->extensions, (byte)type, 0,
+            s, s->heap, s->devId);
         return (long)r;
     } else {
         WOLFSSL_MSG(
@@ -22572,117 +16327,7 @@ long wolfSSL_CTX_sess_timeouts(WOLFSSL_CTX* ctx)
 }
 #endif
 
-
-/* Return the total number of sessions */
-long wolfSSL_CTX_sess_number(WOLFSSL_CTX* ctx)
-{
-    word32 total = 0;
-
-    WOLFSSL_ENTER("wolfSSL_CTX_sess_number");
-    (void)ctx;
-
-#if defined(WOLFSSL_SESSION_STATS) && !defined(NO_SESSION_CACHE)
-    if (wolfSSL_get_session_stats(NULL, &total, NULL, NULL) != WOLFSSL_SUCCESS) {
-        WOLFSSL_MSG("Error getting session stats");
-    }
-#else
-    WOLFSSL_MSG("Please use macro WOLFSSL_SESSION_STATS for session stats");
-#endif
-
-    return (long)total;
-}
-
-
 #ifndef NO_CERTS
-long wolfSSL_CTX_add_extra_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
-{
-    byte* chain = NULL;
-    int   derSz;
-    const byte* der;
-    int   ret;
-    DerBuffer *derBuffer = NULL;
-
-    WOLFSSL_ENTER("wolfSSL_CTX_add_extra_chain_cert");
-
-    if (ctx == NULL || x509 == NULL) {
-        WOLFSSL_MSG("Bad Argument");
-        return WOLFSSL_FAILURE;
-    }
-
-    der = wolfSSL_X509_get_der(x509, &derSz);
-    if (der == NULL || derSz <= 0) {
-        WOLFSSL_MSG("Error getting X509 DER");
-        return WOLFSSL_FAILURE;
-    }
-
-    if (ctx->certificate == NULL) {
-        WOLFSSL_ENTER("wolfSSL_use_certificate_chain_buffer_format");
-
-        /* Process buffer makes first certificate the leaf. */
-        ret = ProcessBuffer(ctx, der, derSz, WOLFSSL_FILETYPE_ASN1, CERT_TYPE,
-                            NULL, NULL, 1, GET_VERIFY_SETTING_CTX(ctx));
-        if (ret != WOLFSSL_SUCCESS) {
-            WOLFSSL_LEAVE("wolfSSL_CTX_add_extra_chain_cert", ret);
-            return WOLFSSL_FAILURE;
-        }
-    }
-    else {
-        long chainSz = 0;
-        int  idx = 0;
-
-        /* TODO: Do this elsewhere. */
-        ret = AllocDer(&derBuffer, derSz, CERT_TYPE, ctx->heap);
-        if (ret != 0) {
-            WOLFSSL_MSG("Memory Error");
-            return WOLFSSL_FAILURE;
-        }
-        XMEMCPY(derBuffer->buffer, der, derSz);
-        ret = AddCA(ctx->cm, &derBuffer, WOLFSSL_USER_CA,
-            GET_VERIFY_SETTING_CTX(ctx));
-        if (ret != WOLFSSL_SUCCESS) {
-            WOLFSSL_LEAVE("wolfSSL_CTX_add_extra_chain_cert", ret);
-            return WOLFSSL_FAILURE;
-        }
-
-        /* adding cert to existing chain */
-        if (ctx->certChain != NULL && ctx->certChain->length > 0) {
-            chainSz += ctx->certChain->length;
-        }
-        chainSz += OPAQUE24_LEN + derSz;
-
-        chain = (byte*)XMALLOC(chainSz, ctx->heap, DYNAMIC_TYPE_DER);
-        if (chain == NULL) {
-            WOLFSSL_MSG("Memory Error");
-            return WOLFSSL_FAILURE;
-        }
-
-        if (ctx->certChain != NULL && ctx->certChain->length > 0) {
-            XMEMCPY(chain, ctx->certChain->buffer, ctx->certChain->length);
-            idx = ctx->certChain->length;
-        }
-        c32to24(derSz, chain + idx);
-        idx += OPAQUE24_LEN;
-        XMEMCPY(chain + idx, der, derSz);
-        idx += derSz;
-#ifdef WOLFSSL_TLS13
-        ctx->certChainCnt++;
-#endif
-
-        FreeDer(&ctx->certChain);
-        ret = AllocDer(&ctx->certChain, idx, CERT_TYPE, ctx->heap);
-        if (ret == 0) {
-            XMEMCPY(ctx->certChain->buffer, chain, idx);
-        }
-    }
-
-    /* on success WOLFSSL_X509 memory is responsibility of ctx */
-    wolfSSL_X509_free(x509);
-    if (chain != NULL)
-        XFREE(chain, ctx->heap, DYNAMIC_TYPE_DER);
-
-    return WOLFSSL_SUCCESS;
-}
-
 
 long wolfSSL_CTX_set_tlsext_status_arg(WOLFSSL_CTX* ctx, void* arg)
 {
@@ -23194,579 +16839,6 @@ int wolfSSL_sk_SSL_COMP_num(WOLF_STACK_OF(WOLFSSL_COMP)* sk)
 
 #endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
 
-#if !defined(NO_SESSION_CACHE) && (defined(OPENSSL_EXTRA) || \
-        defined(HAVE_EXT_CACHE))
-/* stunnel 4.28 needs
- *
- * Callback that is called if a session tries to resume but could not find
- * the session to resume it.
- */
-void wolfSSL_CTX_sess_set_get_cb(WOLFSSL_CTX* ctx,
-                    WOLFSSL_SESSION*(*f)(WOLFSSL*, const unsigned char*, int, int*))
-{
-    if (ctx == NULL)
-        return;
-
-#ifdef HAVE_EXT_CACHE
-    ctx->get_sess_cb = f;
-#else
-    (void)f;
-#endif
-}
-
-void wolfSSL_CTX_sess_set_new_cb(WOLFSSL_CTX* ctx,
-                             int (*f)(WOLFSSL*, WOLFSSL_SESSION*))
-{
-    if (ctx == NULL)
-        return;
-
-#ifdef HAVE_EXT_CACHE
-    ctx->new_sess_cb = f;
-#else
-    (void)f;
-#endif
-}
-
-void wolfSSL_CTX_sess_set_remove_cb(WOLFSSL_CTX* ctx, void (*f)(WOLFSSL_CTX*,
-                                                        WOLFSSL_SESSION*))
-{
-    if (ctx == NULL)
-        return;
-
-#if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
-    ctx->rem_sess_cb = f;
-#else
-    (void)f;
-#endif
-}
-
-
-/*
- *
- * Note: It is expected that the importing and exporting function have been
- *       built with the same settings. For example if session tickets was
- *       enabled with the wolfSSL library exporting a session then it is
- *       expected to be turned on with the wolfSSL library importing the session.
- */
-int wolfSSL_i2d_SSL_SESSION(WOLFSSL_SESSION* sess, unsigned char** p)
-{
-    int size = 0;
-#ifdef HAVE_EXT_CACHE
-    int idx = 0;
-#ifdef SESSION_CERTS
-    int i;
-#endif
-
-    WOLFSSL_ENTER("wolfSSL_i2d_SSL_SESSION");
-
-    sess = ClientSessionToSession(sess);
-    if (sess == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    /* side | bornOn | timeout | sessionID len | sessionID | masterSecret |
-     * haveEMS  */
-    size += OPAQUE8_LEN + OPAQUE32_LEN + OPAQUE32_LEN + OPAQUE8_LEN +
-            sess->sessionIDSz + SECRET_LEN + OPAQUE8_LEN;
-    /* altSessionID */
-    size += OPAQUE8_LEN + (sess->haveAltSessionID ? ID_LEN : 0);
-#ifdef SESSION_CERTS
-    /* Peer chain */
-    size += OPAQUE8_LEN;
-    for (i = 0; i < sess->chain.count; i++)
-        size += OPAQUE16_LEN + sess->chain.certs[i].length;
-#endif
-#if defined(SESSION_CERTS) || (defined(WOLFSSL_TLS13) && \
-                               defined(HAVE_SESSION_TICKET))
-    /* Protocol version */
-    size += OPAQUE16_LEN;
-#endif
-#if defined(SESSION_CERTS) || !defined(NO_RESUME_SUITE_CHECK) || \
-                        (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
-    /* cipher suite */
-    size += OPAQUE16_LEN;
-#endif
-#ifndef NO_CLIENT_CACHE
-    /* ServerID len | ServerID */
-    size += OPAQUE16_LEN + sess->idLen;
-#endif
-#ifdef WOLFSSL_SESSION_ID_CTX
-    /* session context ID len | session context ID */
-    size += OPAQUE8_LEN + sess->sessionCtxSz;
-#endif
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-    /* peerVerifyRet */
-    size += OPAQUE8_LEN;
-#endif
-#ifdef WOLFSSL_TLS13
-    /* namedGroup */
-    size += OPAQUE16_LEN;
-#endif
-#if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
-#ifdef WOLFSSL_TLS13
-#ifdef WOLFSSL_32BIT_MILLI_TIME
-    /* ticketSeen | ticketAdd */
-    size += OPAQUE32_LEN + OPAQUE32_LEN;
-#else
-    /* ticketSeen Hi 32 bits | ticketSeen Lo 32 bits | ticketAdd */
-    size += OPAQUE32_LEN + OPAQUE32_LEN + OPAQUE32_LEN;
-#endif
-    /* ticketNonce */
-    size += OPAQUE8_LEN + sess->ticketNonce.len;
-#endif
-#ifdef WOLFSSL_EARLY_DATA
-    size += OPAQUE32_LEN;
-#endif
-#endif
-#ifdef HAVE_SESSION_TICKET
-    /* ticket len | ticket */
-    size += OPAQUE16_LEN + sess->ticketLen;
-#endif
-
-    if (p != NULL) {
-        unsigned char *data;
-
-        if (*p == NULL)
-            *p = (unsigned char*)XMALLOC(size, NULL, DYNAMIC_TYPE_OPENSSL);
-        if (*p == NULL)
-            return 0;
-        data = *p;
-
-        data[idx++] = sess->side;
-        c32toa(sess->bornOn, data + idx); idx += OPAQUE32_LEN;
-        c32toa(sess->timeout, data + idx); idx += OPAQUE32_LEN;
-        data[idx++] = sess->sessionIDSz;
-        XMEMCPY(data + idx, sess->sessionID, sess->sessionIDSz);
-        idx += sess->sessionIDSz;
-        XMEMCPY(data + idx, sess->masterSecret, SECRET_LEN); idx += SECRET_LEN;
-        data[idx++] = (byte)sess->haveEMS;
-        data[idx++] = sess->haveAltSessionID ? ID_LEN : 0;
-        if (sess->haveAltSessionID) {
-            XMEMCPY(data + idx, sess->altSessionID, ID_LEN);
-            idx += ID_LEN;
-        }
-#ifdef SESSION_CERTS
-        data[idx++] = (byte)sess->chain.count;
-        for (i = 0; i < sess->chain.count; i++) {
-            c16toa((word16)sess->chain.certs[i].length, data + idx);
-            idx += OPAQUE16_LEN;
-            XMEMCPY(data + idx, sess->chain.certs[i].buffer,
-                    sess->chain.certs[i].length);
-            idx += sess->chain.certs[i].length;
-        }
-#endif
-#if defined(SESSION_CERTS) || (defined(WOLFSSL_TLS13) && \
-                               defined(HAVE_SESSION_TICKET))
-        data[idx++] = sess->version.major;
-        data[idx++] = sess->version.minor;
-#endif
-#if defined(SESSION_CERTS) || !defined(NO_RESUME_SUITE_CHECK) || \
-                        (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
-        data[idx++] = sess->cipherSuite0;
-        data[idx++] = sess->cipherSuite;
-#endif
-#ifndef NO_CLIENT_CACHE
-        c16toa(sess->idLen, data + idx); idx += OPAQUE16_LEN;
-        XMEMCPY(data + idx, sess->serverID, sess->idLen);
-        idx += sess->idLen;
-#endif
-#ifdef WOLFSSL_SESSION_ID_CTX
-        data[idx++] = sess->sessionCtxSz;
-        XMEMCPY(data + idx, sess->sessionCtx, sess->sessionCtxSz);
-        idx += sess->sessionCtxSz;
-#endif
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-        data[idx++] = sess->peerVerifyRet;
-#endif
-#ifdef WOLFSSL_TLS13
-        c16toa(sess->namedGroup, data + idx);
-        idx += OPAQUE16_LEN;
-#endif
-#if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
-#ifdef WOLFSSL_TLS13
-#ifdef WOLFSSL_32BIT_MILLI_TIME
-        c32toa(sess->ticketSeen, data + idx);
-        idx += OPAQUE32_LEN;
-#else
-        c32toa((word32)(sess->ticketSeen >> 32), data + idx);
-        idx += OPAQUE32_LEN;
-        c32toa((word32)sess->ticketSeen, data + idx);
-        idx += OPAQUE32_LEN;
-#endif
-        c32toa(sess->ticketAdd, data + idx);
-        idx += OPAQUE32_LEN;
-        data[idx++] = sess->ticketNonce.len;
-        XMEMCPY(data + idx, sess->ticketNonce.data, sess->ticketNonce.len);
-        idx += sess->ticketNonce.len;
-#endif
-#ifdef WOLFSSL_EARLY_DATA
-        c32toa(sess->maxEarlyDataSz, data + idx);
-        idx += OPAQUE32_LEN;
-#endif
-#endif
-#ifdef HAVE_SESSION_TICKET
-        c16toa(sess->ticketLen, data + idx); idx += OPAQUE16_LEN;
-        XMEMCPY(data + idx, sess->ticket, sess->ticketLen);
-        idx += sess->ticketLen;
-#endif
-    }
-#endif
-
-    (void)sess;
-    (void)p;
-#ifdef HAVE_EXT_CACHE
-    (void)idx;
-#endif
-
-    return size;
-}
-
-
-/* TODO: no function to free new session.
- *
- * Note: It is expected that the importing and exporting function have been
- *       built with the same settings. For example if session tickets was
- *       enabled with the wolfSSL library exporting a session then it is
- *       expected to be turned on with the wolfSSL library importing the session.
- */
-WOLFSSL_SESSION* wolfSSL_d2i_SSL_SESSION(WOLFSSL_SESSION** sess,
-                                const unsigned char** p, long i)
-{
-    WOLFSSL_SESSION* s = NULL;
-    int ret = 0;
-#if defined(HAVE_EXT_CACHE)
-    int idx = 0;
-    byte* data;
-#ifdef SESSION_CERTS
-    int j;
-    word16 length;
-#endif
-#endif /* HAVE_EXT_CACHE */
-
-    (void)p;
-    (void)i;
-    (void)ret;
-    (void)sess;
-
-#ifdef HAVE_EXT_CACHE
-    if (p == NULL || *p == NULL)
-        return NULL;
-
-    s = wolfSSL_SESSION_new();
-    if (s == NULL)
-        return NULL;
-
-    idx = 0;
-    data = (byte*)*p;
-
-    /* side | bornOn | timeout | sessionID len */
-    if (i < OPAQUE8_LEN + OPAQUE32_LEN + OPAQUE32_LEN + OPAQUE8_LEN) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    s->side = data[idx++];
-    ato32(data + idx, &s->bornOn); idx += OPAQUE32_LEN;
-    ato32(data + idx, &s->timeout); idx += OPAQUE32_LEN;
-    s->sessionIDSz = data[idx++];
-
-    /* sessionID | secret | haveEMS | haveAltSessionID */
-    if (i - idx < s->sessionIDSz + SECRET_LEN + OPAQUE8_LEN + OPAQUE8_LEN) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    XMEMCPY(s->sessionID, data + idx, s->sessionIDSz);
-    idx  += s->sessionIDSz;
-    XMEMCPY(s->masterSecret, data + idx, SECRET_LEN); idx += SECRET_LEN;
-    s->haveEMS = data[idx++];
-    if (data[idx] != ID_LEN && data[idx] != 0) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    s->haveAltSessionID = data[idx++] == ID_LEN;
-
-    /* altSessionID */
-    if (s->haveAltSessionID) {
-        if (i - idx < ID_LEN) {
-            ret = BUFFER_ERROR;
-            goto end;
-        }
-        XMEMCPY(s->altSessionID, data + idx, ID_LEN); idx += ID_LEN;
-    }
-
-#ifdef SESSION_CERTS
-    /* Certificate chain */
-    if (i - idx == 0) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    s->chain.count = data[idx++];
-    for (j = 0; j < s->chain.count; j++) {
-        if (i - idx < OPAQUE16_LEN) {
-            ret = BUFFER_ERROR;
-            goto end;
-        }
-        ato16(data + idx, &length); idx += OPAQUE16_LEN;
-        s->chain.certs[j].length = length;
-        if (i - idx < length) {
-            ret = BUFFER_ERROR;
-            goto end;
-        }
-        XMEMCPY(s->chain.certs[j].buffer, data + idx, length);
-        idx += length;
-    }
-#endif
-#if defined(SESSION_CERTS) || (defined(WOLFSSL_TLS13) && \
-                               defined(HAVE_SESSION_TICKET))
-    /* Protocol Version */
-    if (i - idx < OPAQUE16_LEN) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    s->version.major = data[idx++];
-    s->version.minor = data[idx++];
-#endif
-#if defined(SESSION_CERTS) || !defined(NO_RESUME_SUITE_CHECK) || \
-                        (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
-    /* Cipher suite */
-    if (i - idx < OPAQUE16_LEN) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    s->cipherSuite0 = data[idx++];
-    s->cipherSuite = data[idx++];
-#endif
-#ifndef NO_CLIENT_CACHE
-    /* ServerID len */
-    if (i - idx < OPAQUE16_LEN) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    ato16(data + idx, &s->idLen); idx += OPAQUE16_LEN;
-
-    /* ServerID */
-    if (i - idx < s->idLen) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    XMEMCPY(s->serverID, data + idx, s->idLen); idx += s->idLen;
-#endif
-#ifdef WOLFSSL_SESSION_ID_CTX
-    /* byte for length of session context ID */
-    if (i - idx < OPAQUE8_LEN) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    s->sessionCtxSz = data[idx++];
-
-    /* app session context ID */
-    if (i - idx < s->sessionCtxSz) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    XMEMCPY(s->sessionCtx, data + idx, s->sessionCtxSz); idx += s->sessionCtxSz;
-#endif
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-    /* byte for peerVerifyRet */
-    if (i - idx < OPAQUE8_LEN) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    s->peerVerifyRet = data[idx++];
-#endif
-#ifdef WOLFSSL_TLS13
-    if (i - idx < OPAQUE16_LEN) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    ato16(data + idx, &s->namedGroup);
-    idx += OPAQUE16_LEN;
-#endif
-#if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
-#ifdef WOLFSSL_TLS13
-    if (i - idx < (OPAQUE32_LEN * 2)) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-#ifdef WOLFSSL_32BIT_MILLI_TIME
-    ato32(data + idx, &s->ticketSeen);
-    idx += OPAQUE32_LEN;
-#else
-    {
-        word32 seenHi, seenLo;
-
-        ato32(data + idx, &seenHi);
-        idx += OPAQUE32_LEN;
-        ato32(data + idx, &seenLo);
-        idx += OPAQUE32_LEN;
-        s->ticketSeen = ((sword64)seenHi << 32) + seenLo;
-    }
-#endif
-    ato32(data + idx, &s->ticketAdd);
-    idx += OPAQUE32_LEN;
-    if (i - idx < OPAQUE8_LEN) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    s->ticketNonce.len = data[idx++];
-
-    if (i - idx < s->ticketNonce.len) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-#if defined(WOLFSSL_TICKET_NONCE_MALLOC) &&                     \
-    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
-    ret = SessionTicketNoncePopulate(s, data + idx, s->ticketNonce.len);
-    if (ret != 0)
-        goto end;
-#else
-    if (s->ticketNonce.len > MAX_TICKET_NONCE_STATIC_SZ) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    XMEMCPY(s->ticketNonce.data, data + idx, s->ticketNonce.len);
-#endif /* defined(WOLFSSL_TICKET_NONCE_MALLOC) && FIPS_VERSION_GE(5,3) */
-
-    idx += s->ticketNonce.len;
-#endif
-#ifdef WOLFSSL_EARLY_DATA
-    if (i - idx < OPAQUE32_LEN) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    ato32(data + idx, &s->maxEarlyDataSz);
-    idx += OPAQUE32_LEN;
-#endif
-#endif
-#ifdef HAVE_SESSION_TICKET
-    /* ticket len */
-    if (i - idx < OPAQUE16_LEN) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    ato16(data + idx, &s->ticketLen); idx += OPAQUE16_LEN;
-
-    /* Dispose of ol dynamic ticket and ensure space for new ticket. */
-    if (s->ticketLenAlloc > 0) {
-        XFREE(s->ticket, NULL, DYNAMIC_TYPE_SESSION_TICK);
-    }
-    if (s->ticketLen <= SESSION_TICKET_LEN)
-        s->ticket = s->staticTicket;
-    else {
-        s->ticket = (byte*)XMALLOC(s->ticketLen, NULL,
-                                   DYNAMIC_TYPE_SESSION_TICK);
-        if (s->ticket == NULL) {
-            ret = MEMORY_ERROR;
-            goto end;
-        }
-        s->ticketLenAlloc = (word16)s->ticketLen;
-    }
-
-    /* ticket */
-    if (i - idx < s->ticketLen) {
-        ret = BUFFER_ERROR;
-        goto end;
-    }
-    XMEMCPY(s->ticket, data + idx, s->ticketLen); idx += s->ticketLen;
-#endif
-    (void)idx;
-
-    if (sess != NULL) {
-        *sess = s;
-    }
-
-    s->isSetup = 1;
-
-    *p += idx;
-
-end:
-    if (ret != 0 && (sess == NULL || *sess != s)) {
-        wolfSSL_FreeSession(NULL, s);
-        s = NULL;
-    }
-#endif /* HAVE_EXT_CACHE */
-    return s;
-}
-
-/* Check if there is a session ticket associated with this WOLFSSL_SESSION.
- *
- * sess - pointer to WOLFSSL_SESSION struct
- *
- * Returns 1 if has session ticket, otherwise 0 */
-int wolfSSL_SESSION_has_ticket(const WOLFSSL_SESSION* sess)
-{
-    WOLFSSL_ENTER("wolfSSL_SESSION_has_ticket");
-#ifdef HAVE_SESSION_TICKET
-    sess = ClientSessionToSession(sess);
-    if (sess) {
-        if ((sess->ticketLen > 0) && (sess->ticket != NULL)) {
-            return WOLFSSL_SUCCESS;
-        }
-    }
-#else
-    (void)sess;
-#endif
-    return WOLFSSL_FAILURE;
-}
-
-unsigned long wolfSSL_SESSION_get_ticket_lifetime_hint(
-                  const WOLFSSL_SESSION* sess)
-{
-    WOLFSSL_ENTER("wolfSSL_SESSION_get_ticket_lifetime_hint");
-    sess = ClientSessionToSession(sess);
-    if (sess) {
-        return sess->timeout;
-    }
-    return 0;
-}
-
-long wolfSSL_SESSION_get_timeout(const WOLFSSL_SESSION* sess)
-{
-    long timeout = 0;
-    WOLFSSL_ENTER("wolfSSL_SESSION_get_timeout");
-    sess = ClientSessionToSession(sess);
-    if (sess)
-        timeout = sess->timeout;
-    return timeout;
-}
-
-long wolfSSL_SSL_SESSION_set_timeout(WOLFSSL_SESSION* ses, long t)
-{
-    word32 tmptime;
-
-    ses = ClientSessionToSession(ses);
-    if (ses == NULL || t < 0) {
-        return BAD_FUNC_ARG;
-    }
-
-    tmptime = t & 0xFFFFFFFF;
-    ses->timeout = tmptime;
-
-    return WOLFSSL_SUCCESS;
-}
-
-long wolfSSL_SESSION_get_time(const WOLFSSL_SESSION* sess)
-{
-    long bornOn = 0;
-    WOLFSSL_ENTER("wolfSSL_SESSION_get_time");
-    sess = ClientSessionToSession(sess);
-    if (sess)
-        bornOn = sess->bornOn;
-    return bornOn;
-}
-
-long wolfSSL_SESSION_set_time(WOLFSSL_SESSION *ses, long t)
-{
-
-    ses = ClientSessionToSession(ses);
-    if (ses == NULL || t < 0) {
-        return 0;
-    }
-    ses->bornOn = (word32)t;
-    return t;
-}
-
-#endif /* !NO_SESSION_CACHE && OPENSSL_EXTRA || HAVE_EXT_CACHE */
-
 #ifdef OPENSSL_EXTRA
 
 #if defined(HAVE_EX_DATA) && !defined(NO_FILESYSTEM)
@@ -23818,7 +16890,7 @@ int wolfSSL_cmp_peer_cert_to_file(WOLFSSL* ssl, const char *fname)
 
         if ((myBuffer != NULL) &&
             (sz > 0) &&
-            (XFREAD(myBuffer, 1, sz, file) == (size_t)sz) &&
+            (XFREAD(myBuffer, 1, (size_t)sz, file) == (size_t)sz) &&
             (PemToDer(myBuffer, (long)sz, CERT_TYPE,
                       &fileDer, ctx->heap, NULL, NULL) == 0) &&
             (fileDer->length != 0) &&
@@ -23846,50 +16918,50 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
 #ifndef NO_CERTS
     /* oidCertExtType */
     { NID_basic_constraints, BASIC_CA_OID, oidCertExtType, "basicConstraints",
-                                                "X509v3 Basic Constraints"},
+      "X509v3 Basic Constraints"},
     { NID_subject_alt_name, ALT_NAMES_OID, oidCertExtType, "subjectAltName",
-                                         "X509v3 Subject Alternative Name"},
-    { NID_crl_distribution_points, CRL_DIST_OID, oidCertExtType, "crlDistributionPoints",
-                                          "X509v3 CRL Distribution Points"},
+      "X509v3 Subject Alternative Name"},
+    { NID_crl_distribution_points, CRL_DIST_OID, oidCertExtType,
+      "crlDistributionPoints", "X509v3 CRL Distribution Points"},
     { NID_info_access, AUTH_INFO_OID, oidCertExtType, "authorityInfoAccess",
-                                            "Authority Information Access"},
+      "Authority Information Access"},
     { NID_authority_key_identifier, AUTH_KEY_OID, oidCertExtType,
-               "authorityKeyIdentifier", "X509v3 Authority Key Identifier"},
+      "authorityKeyIdentifier", "X509v3 Authority Key Identifier"},
     { NID_subject_key_identifier, SUBJ_KEY_OID, oidCertExtType,
-                   "subjectKeyIdentifier", "X509v3 Subject Key Identifier"},
+      "subjectKeyIdentifier", "X509v3 Subject Key Identifier"},
     { NID_key_usage, KEY_USAGE_OID, oidCertExtType, "keyUsage",
-                                                        "X509v3 Key Usage"},
+      "X509v3 Key Usage"},
     { NID_inhibit_any_policy, INHIBIT_ANY_OID, oidCertExtType,
-                           "inhibitAnyPolicy", "X509v3 Inhibit Any Policy"},
+      "inhibitAnyPolicy", "X509v3 Inhibit Any Policy"},
     { NID_ext_key_usage, EXT_KEY_USAGE_OID, oidCertExtType,
-                           "extendedKeyUsage", "X509v3 Extended Key Usage"},
+      "extendedKeyUsage", "X509v3 Extended Key Usage"},
     { NID_name_constraints, NAME_CONS_OID, oidCertExtType,
-                              "nameConstraints", "X509v3 Name Constraints"},
+      "nameConstraints", "X509v3 Name Constraints"},
     { NID_certificate_policies, CERT_POLICY_OID, oidCertExtType,
-                      "certificatePolicies", "X509v3 Certificate Policies"},
+      "certificatePolicies", "X509v3 Certificate Policies"},
 
     /* oidCertAuthInfoType */
     { NID_ad_OCSP, AIA_OCSP_OID, oidCertAuthInfoType, "OCSP",
-                                            "OCSP"},
+      "OCSP"},
     { NID_ad_ca_issuers, AIA_CA_ISSUER_OID, oidCertAuthInfoType,
-                                                 "caIssuers", "CA Issuers"},
+      "caIssuers", "CA Issuers"},
 
     /* oidCertPolicyType */
     { NID_any_policy, CP_ANY_OID, oidCertPolicyType, "anyPolicy",
-                                                       "X509v3 Any Policy"},
+      "X509v3 Any Policy"},
 
     /* oidCertAltNameType */
     { NID_hw_name_oid, HW_NAME_OID, oidCertAltNameType, "Hardware name",""},
 
     /* oidCertKeyUseType */
     { NID_anyExtendedKeyUsage, EKU_ANY_OID, oidCertKeyUseType,
-                           "anyExtendedKeyUsage", "Any Extended Key Usage"},
+      "anyExtendedKeyUsage", "Any Extended Key Usage"},
     { EKU_SERVER_AUTH_OID, EKU_SERVER_AUTH_OID, oidCertKeyUseType,
-                             "serverAuth", "TLS Web Server Authentication"},
+      "serverAuth", "TLS Web Server Authentication"},
     { EKU_CLIENT_AUTH_OID, EKU_CLIENT_AUTH_OID, oidCertKeyUseType,
-                             "clientAuth", "TLS Web Client Authentication"},
+      "clientAuth", "TLS Web Client Authentication"},
     { EKU_OCSP_SIGN_OID, EKU_OCSP_SIGN_OID, oidCertKeyUseType,
-                                             "OCSPSigning", "OCSP Signing"},
+      "OCSPSigning", "OCSP Signing"},
 
     /* oidCertNameType */
     { NID_commonName, NID_commonName, oidCertNameType, "CN", "commonName"},
@@ -23897,31 +16969,32 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
     { NID_surname, NID_surname, oidCertNameType, "SN", "surname"},
 #endif
     { NID_serialNumber, NID_serialNumber, oidCertNameType, "serialNumber",
-                                                            "serialNumber"},
+      "serialNumber"},
     { NID_userId, NID_userId, oidCertNameType, "UID", "userid"},
     { NID_countryName, NID_countryName, oidCertNameType, "C", "countryName"},
     { NID_localityName, NID_localityName, oidCertNameType, "L", "localityName"},
     { NID_stateOrProvinceName, NID_stateOrProvinceName, oidCertNameType, "ST",
-                                                        "stateOrProvinceName"},
+      "stateOrProvinceName"},
     { NID_streetAddress, NID_streetAddress, oidCertNameType, "street",
-                                                        "streetAddress"},
+      "streetAddress"},
     { NID_organizationName, NID_organizationName, oidCertNameType, "O",
-                                                        "organizationName"},
+      "organizationName"},
     { NID_organizationalUnitName, NID_organizationalUnitName, oidCertNameType,
-                                                "OU", "organizationalUnitName"},
+      "OU", "organizationalUnitName"},
     { NID_emailAddress, NID_emailAddress, oidCertNameType, "emailAddress",
-                                                            "emailAddress"},
+      "emailAddress"},
     { NID_domainComponent, NID_domainComponent, oidCertNameType, "DC",
-                                                            "domainComponent"},
+      "domainComponent"},
     { NID_favouriteDrink, NID_favouriteDrink, oidCertNameType, "favouriteDrink",
-                                                            "favouriteDrink"},
-    { NID_businessCategory, NID_businessCategory, oidCertNameType, "businessCategory",
-                                                            "businessCategory"},
-    { NID_jurisdictionCountryName, NID_jurisdictionCountryName, oidCertNameType, "jurisdictionC",
-                                                            "jurisdictionCountryName"},
+      "favouriteDrink"},
+    { NID_businessCategory, NID_businessCategory, oidCertNameType,
+      "businessCategory", "businessCategory"},
+    { NID_jurisdictionCountryName, NID_jurisdictionCountryName, oidCertNameType,
+      "jurisdictionC", "jurisdictionCountryName"},
     { NID_jurisdictionStateOrProvinceName, NID_jurisdictionStateOrProvinceName,
-            oidCertNameType, "jurisdictionST", "jurisdictionStateOrProvinceName"},
-    { NID_postalCode, NID_postalCode, oidCertNameType, "postalCode", "postalCode"},
+      oidCertNameType, "jurisdictionST", "jurisdictionStateOrProvinceName"},
+    { NID_postalCode, NID_postalCode, oidCertNameType, "postalCode",
+      "postalCode"},
     { NID_userId, NID_userId, oidCertNameType, "UID", "userId"},
 
 #if defined(WOLFSSL_CERT_REQ) || defined(WOLFSSL_CERT_NAME_ALL)
@@ -23987,54 +17060,54 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
         #ifndef NO_SHA
         { NID_dsaWithSHA1, CTC_SHAwDSA, oidSigType, "DSA-SHA1", "dsaWithSHA1"},
         { NID_dsa_with_SHA256, CTC_SHA256wDSA, oidSigType, "dsa_with_SHA256",
-                                                        "dsa_with_SHA256"},
+          "dsa_with_SHA256"},
         #endif
     #endif /* NO_DSA */
     #ifndef NO_RSA
         #ifdef WOLFSSL_MD2
         { NID_md2WithRSAEncryption, CTC_MD2wRSA, oidSigType, "RSA-MD2",
-                                                        "md2WithRSAEncryption"},
+          "md2WithRSAEncryption"},
         #endif
         #ifndef NO_MD5
         { NID_md5WithRSAEncryption, CTC_MD5wRSA, oidSigType, "RSA-MD5",
-                                                        "md5WithRSAEncryption"},
+          "md5WithRSAEncryption"},
         #endif
         #ifndef NO_SHA
         { NID_sha1WithRSAEncryption, CTC_SHAwRSA, oidSigType, "RSA-SHA1",
-                                                       "sha1WithRSAEncryption"},
+          "sha1WithRSAEncryption"},
         #endif
         #ifdef WOLFSSL_SHA224
         { NID_sha224WithRSAEncryption, CTC_SHA224wRSA, oidSigType, "RSA-SHA224",
-                                                     "sha224WithRSAEncryption"},
+          "sha224WithRSAEncryption"},
         #endif
         #ifndef NO_SHA256
         { NID_sha256WithRSAEncryption, CTC_SHA256wRSA, oidSigType, "RSA-SHA256",
-                                                     "sha256WithRSAEncryption"},
+          "sha256WithRSAEncryption"},
         #endif
         #ifdef WOLFSSL_SHA384
         { NID_sha384WithRSAEncryption, CTC_SHA384wRSA, oidSigType, "RSA-SHA384",
-                                                     "sha384WithRSAEncryption"},
+          "sha384WithRSAEncryption"},
         #endif
         #ifdef WOLFSSL_SHA512
         { NID_sha512WithRSAEncryption, CTC_SHA512wRSA, oidSigType, "RSA-SHA512",
-                                                     "sha512WithRSAEncryption"},
+          "sha512WithRSAEncryption"},
         #endif
         #ifdef WOLFSSL_SHA3
         #ifndef WOLFSSL_NOSHA3_224
         { NID_RSA_SHA3_224, CTC_SHA3_224wRSA, oidSigType, "RSA-SHA3-224",
-                                                     "sha3-224WithRSAEncryption"},
+          "sha3-224WithRSAEncryption"},
         #endif
         #ifndef WOLFSSL_NOSHA3_256
         { NID_RSA_SHA3_256, CTC_SHA3_256wRSA, oidSigType, "RSA-SHA3-256",
-                                                     "sha3-256WithRSAEncryption"},
+          "sha3-256WithRSAEncryption"},
         #endif
         #ifndef WOLFSSL_NOSHA3_384
         { NID_RSA_SHA3_384, CTC_SHA3_384wRSA, oidSigType, "RSA-SHA3-384",
-                                                     "sha3-384WithRSAEncryption"},
+          "sha3-384WithRSAEncryption"},
         #endif
         #ifndef WOLFSSL_NOSHA3_512
         { NID_RSA_SHA3_512, CTC_SHA3_512wRSA, oidSigType, "RSA-SHA3-512",
-                                                     "sha3-512WithRSAEncryption"},
+          "sha3-512WithRSAEncryption"},
         #endif
         #endif
         #ifdef WC_RSA_PSS
@@ -24043,36 +17116,41 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
     #endif /* NO_RSA */
     #ifdef HAVE_ECC
         #ifndef NO_SHA
-        { NID_ecdsa_with_SHA1, CTC_SHAwECDSA, oidSigType, "ecdsa-with-SHA1", "shaWithECDSA"},
+        { NID_ecdsa_with_SHA1, CTC_SHAwECDSA, oidSigType, "ecdsa-with-SHA1",
+          "shaWithECDSA"},
         #endif
         #ifdef WOLFSSL_SHA224
-        { NID_ecdsa_with_SHA224, CTC_SHA224wECDSA, oidSigType, "ecdsa-with-SHA224","sha224WithECDSA"},
+        { NID_ecdsa_with_SHA224, CTC_SHA224wECDSA, oidSigType,
+          "ecdsa-with-SHA224","sha224WithECDSA"},
         #endif
         #ifndef NO_SHA256
-        { NID_ecdsa_with_SHA256, CTC_SHA256wECDSA, oidSigType, "ecdsa-with-SHA256","sha256WithECDSA"},
+        { NID_ecdsa_with_SHA256, CTC_SHA256wECDSA, oidSigType,
+          "ecdsa-with-SHA256","sha256WithECDSA"},
         #endif
         #ifdef WOLFSSL_SHA384
-        { NID_ecdsa_with_SHA384, CTC_SHA384wECDSA, oidSigType, "ecdsa-with-SHA384","sha384WithECDSA"},
+        { NID_ecdsa_with_SHA384, CTC_SHA384wECDSA, oidSigType,
+          "ecdsa-with-SHA384","sha384WithECDSA"},
         #endif
         #ifdef WOLFSSL_SHA512
-        { NID_ecdsa_with_SHA512, CTC_SHA512wECDSA, oidSigType, "ecdsa-with-SHA512","sha512WithECDSA"},
+        { NID_ecdsa_with_SHA512, CTC_SHA512wECDSA, oidSigType,
+          "ecdsa-with-SHA512","sha512WithECDSA"},
         #endif
         #ifdef WOLFSSL_SHA3
         #ifndef WOLFSSL_NOSHA3_224
-        { NID_ecdsa_with_SHA3_224, CTC_SHA3_224wECDSA, oidSigType, "id-ecdsa-with-SHA3-224",
-                "ecdsa_with_SHA3-224"},
+        { NID_ecdsa_with_SHA3_224, CTC_SHA3_224wECDSA, oidSigType,
+          "id-ecdsa-with-SHA3-224", "ecdsa_with_SHA3-224"},
         #endif
         #ifndef WOLFSSL_NOSHA3_256
-        { NID_ecdsa_with_SHA3_256, CTC_SHA3_256wECDSA, oidSigType, "id-ecdsa-with-SHA3-256",
-                "ecdsa_with_SHA3-256"},
+        { NID_ecdsa_with_SHA3_256, CTC_SHA3_256wECDSA, oidSigType,
+          "id-ecdsa-with-SHA3-256", "ecdsa_with_SHA3-256"},
         #endif
         #ifndef WOLFSSL_NOSHA3_384
-        { NID_ecdsa_with_SHA3_384, CTC_SHA3_384wECDSA, oidSigType, "id-ecdsa-with-SHA3-384",
-                "ecdsa_with_SHA3-384"},
+        { NID_ecdsa_with_SHA3_384, CTC_SHA3_384wECDSA, oidSigType,
+          "id-ecdsa-with-SHA3-384", "ecdsa_with_SHA3-384"},
         #endif
         #ifndef WOLFSSL_NOSHA3_512
-        { NID_ecdsa_with_SHA3_512, CTC_SHA3_512wECDSA, oidSigType, "id-ecdsa-with-SHA3-512",
-                "ecdsa_with_SHA3-512"},
+        { NID_ecdsa_with_SHA3_512, CTC_SHA3_512wECDSA, oidSigType,
+          "id-ecdsa-with-SHA3-512", "ecdsa_with_SHA3-512"},
         #endif
         #endif
     #endif /* HAVE_ECC */
@@ -24082,7 +17160,8 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
         { NID_dsa, DSAk, oidKeyType, "DSA", "dsaEncryption"},
     #endif /* NO_DSA */
     #ifndef NO_RSA
-        { NID_rsaEncryption, RSAk, oidKeyType, "rsaEncryption", "rsaEncryption"},
+        { NID_rsaEncryption, RSAk, oidKeyType, "rsaEncryption",
+          "rsaEncryption"},
     #ifdef WC_RSA_PSS
         { NID_rsassaPss, RSAPSSk, oidKeyType, "RSASSA-PSS", "rsassaPss"},
     #endif
@@ -24092,7 +17171,8 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
                                                         "id-ecPublicKey"},
     #endif /* HAVE_ECC */
     #ifndef NO_DH
-        { NID_dhKeyAgreement, DHk, oidKeyType, "dhKeyAgreement", "dhKeyAgreement"},
+        { NID_dhKeyAgreement, DHk, oidKeyType, "dhKeyAgreement",
+          "dhKeyAgreement"},
     #endif
     #ifdef HAVE_ED448
         { NID_ED448, ED448k,  oidKeyType, "ED448", "ED448"},
@@ -24100,7 +17180,6 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
     #ifdef HAVE_ED25519
         { NID_ED25519, ED25519k,  oidKeyType, "ED25519", "ED25519"},
     #endif
-    #ifdef HAVE_PQC
     #ifdef HAVE_FALCON
         { CTC_FALCON_LEVEL1, FALCON_LEVEL1k,  oidKeyType, "Falcon Level 1",
                                                           "Falcon Level 1"},
@@ -24115,45 +17194,71 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
         { CTC_DILITHIUM_LEVEL5, DILITHIUM_LEVEL5k,  oidKeyType,
           "Dilithium Level 5", "Dilithium Level 5"},
     #endif /* HAVE_DILITHIUM */
-    #endif /* HAVE_PQC */
 
         /* oidCurveType */
     #ifdef HAVE_ECC
-        { NID_X9_62_prime192v1, ECC_SECP192R1_OID, oidCurveType, "prime192v1", "prime192v1"},
-        { NID_X9_62_prime192v2, ECC_PRIME192V2_OID, oidCurveType, "prime192v2", "prime192v2"},
-        { NID_X9_62_prime192v3, ECC_PRIME192V3_OID, oidCurveType, "prime192v3", "prime192v3"},
+        { NID_X9_62_prime192v1, ECC_SECP192R1_OID, oidCurveType, "prime192v1",
+          "prime192v1"},
+        { NID_X9_62_prime192v2, ECC_PRIME192V2_OID, oidCurveType, "prime192v2",
+          "prime192v2"},
+        { NID_X9_62_prime192v3, ECC_PRIME192V3_OID, oidCurveType, "prime192v3",
+          "prime192v3"},
 
-        { NID_X9_62_prime239v1, ECC_PRIME239V1_OID, oidCurveType, "prime239v1", "prime239v1"},
-        { NID_X9_62_prime239v2, ECC_PRIME239V2_OID, oidCurveType, "prime239v2", "prime239v2"},
-        { NID_X9_62_prime239v3, ECC_PRIME239V3_OID, oidCurveType, "prime239v3", "prime239v3"},
+        { NID_X9_62_prime239v1, ECC_PRIME239V1_OID, oidCurveType, "prime239v1",
+          "prime239v1"},
+        { NID_X9_62_prime239v2, ECC_PRIME239V2_OID, oidCurveType, "prime239v2",
+          "prime239v2"},
+        { NID_X9_62_prime239v3, ECC_PRIME239V3_OID, oidCurveType, "prime239v3",
+          "prime239v3"},
 
-        { NID_X9_62_prime256v1, ECC_SECP256R1_OID, oidCurveType, "prime256v1", "prime256v1"},
+        { NID_X9_62_prime256v1, ECC_SECP256R1_OID, oidCurveType, "prime256v1",
+          "prime256v1"},
 
-        { NID_secp112r1, ECC_SECP112R1_OID,  oidCurveType, "secp112r1", "secp112r1"},
-        { NID_secp112r2, ECC_SECP112R2_OID,  oidCurveType, "secp112r2", "secp112r2"},
+        { NID_secp112r1, ECC_SECP112R1_OID,  oidCurveType, "secp112r1",
+          "secp112r1"},
+        { NID_secp112r2, ECC_SECP112R2_OID,  oidCurveType, "secp112r2",
+          "secp112r2"},
 
-        { NID_secp128r1, ECC_SECP128R1_OID,  oidCurveType, "secp128r1", "secp128r1"},
-        { NID_secp128r2, ECC_SECP128R2_OID,  oidCurveType, "secp128r2", "secp128r2"},
+        { NID_secp128r1, ECC_SECP128R1_OID,  oidCurveType, "secp128r1",
+          "secp128r1"},
+        { NID_secp128r2, ECC_SECP128R2_OID,  oidCurveType, "secp128r2",
+          "secp128r2"},
 
-        { NID_secp160r1, ECC_SECP160R1_OID,  oidCurveType, "secp160r1", "secp160r1"},
-        { NID_secp160r2, ECC_SECP160R2_OID,  oidCurveType, "secp160r2", "secp160r2"},
+        { NID_secp160r1, ECC_SECP160R1_OID,  oidCurveType, "secp160r1",
+          "secp160r1"},
+        { NID_secp160r2, ECC_SECP160R2_OID,  oidCurveType, "secp160r2",
+          "secp160r2"},
 
-        { NID_secp224r1, ECC_SECP224R1_OID,  oidCurveType, "secp224r1", "secp224r1"},
-        { NID_secp384r1, ECC_SECP384R1_OID,  oidCurveType, "secp384r1", "secp384r1"},
-        { NID_secp521r1, ECC_SECP521R1_OID,  oidCurveType, "secp521r1", "secp521r1"},
+        { NID_secp224r1, ECC_SECP224R1_OID,  oidCurveType, "secp224r1",
+          "secp224r1"},
+        { NID_secp384r1, ECC_SECP384R1_OID,  oidCurveType, "secp384r1",
+          "secp384r1"},
+        { NID_secp521r1, ECC_SECP521R1_OID,  oidCurveType, "secp521r1",
+          "secp521r1"},
 
-        { NID_secp160k1, ECC_SECP160K1_OID,  oidCurveType, "secp160k1", "secp160k1"},
-        { NID_secp192k1, ECC_SECP192K1_OID,  oidCurveType, "secp192k1", "secp192k1"},
-        { NID_secp224k1, ECC_SECP224K1_OID,  oidCurveType, "secp224k1", "secp224k1"},
-        { NID_secp256k1, ECC_SECP256K1_OID,  oidCurveType, "secp256k1", "secp256k1"},
+        { NID_secp160k1, ECC_SECP160K1_OID,  oidCurveType, "secp160k1",
+          "secp160k1"},
+        { NID_secp192k1, ECC_SECP192K1_OID,  oidCurveType, "secp192k1",
+          "secp192k1"},
+        { NID_secp224k1, ECC_SECP224K1_OID,  oidCurveType, "secp224k1",
+          "secp224k1"},
+        { NID_secp256k1, ECC_SECP256K1_OID,  oidCurveType, "secp256k1",
+          "secp256k1"},
 
-        { NID_brainpoolP160r1, ECC_BRAINPOOLP160R1_OID,  oidCurveType, "brainpoolP160r1", "brainpoolP160r1"},
-        { NID_brainpoolP192r1, ECC_BRAINPOOLP192R1_OID,  oidCurveType, "brainpoolP192r1", "brainpoolP192r1"},
-        { NID_brainpoolP224r1, ECC_BRAINPOOLP224R1_OID,  oidCurveType, "brainpoolP224r1", "brainpoolP224r1"},
-        { NID_brainpoolP256r1, ECC_BRAINPOOLP256R1_OID,  oidCurveType, "brainpoolP256r1", "brainpoolP256r1"},
-        { NID_brainpoolP320r1, ECC_BRAINPOOLP320R1_OID,  oidCurveType, "brainpoolP320r1", "brainpoolP320r1"},
-        { NID_brainpoolP384r1, ECC_BRAINPOOLP384R1_OID,  oidCurveType, "brainpoolP384r1", "brainpoolP384r1"},
-        { NID_brainpoolP512r1, ECC_BRAINPOOLP512R1_OID,  oidCurveType, "brainpoolP512r1", "brainpoolP512r1"},
+        { NID_brainpoolP160r1, ECC_BRAINPOOLP160R1_OID,  oidCurveType,
+          "brainpoolP160r1", "brainpoolP160r1"},
+        { NID_brainpoolP192r1, ECC_BRAINPOOLP192R1_OID,  oidCurveType,
+          "brainpoolP192r1", "brainpoolP192r1"},
+        { NID_brainpoolP224r1, ECC_BRAINPOOLP224R1_OID,  oidCurveType,
+          "brainpoolP224r1", "brainpoolP224r1"},
+        { NID_brainpoolP256r1, ECC_BRAINPOOLP256R1_OID,  oidCurveType,
+          "brainpoolP256r1", "brainpoolP256r1"},
+        { NID_brainpoolP320r1, ECC_BRAINPOOLP320R1_OID,  oidCurveType,
+          "brainpoolP320r1", "brainpoolP320r1"},
+        { NID_brainpoolP384r1, ECC_BRAINPOOLP384R1_OID,  oidCurveType,
+          "brainpoolP384r1", "brainpoolP384r1"},
+        { NID_brainpoolP512r1, ECC_BRAINPOOLP512R1_OID,  oidCurveType,
+          "brainpoolP512r1", "brainpoolP512r1"},
 
     #ifdef WOLFSSL_SM2
         { NID_sm2, ECC_SM2P256V1_OID, oidCurveType, "sm2", "sm2"},
@@ -24175,15 +17280,15 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
         { NID_des3, DES3b, oidBlkType, "DES-EDE3-CBC", "des-ede3-cbc"},
     #endif /* !NO_DES3 */
     #if defined(HAVE_CHACHA) && defined(HAVE_POLY1305)
-        { NID_chacha20_poly1305, NID_chacha20_poly1305, oidBlkType, "ChaCha20-Poly1305", "chacha20-poly1305"},
+        { NID_chacha20_poly1305, NID_chacha20_poly1305, oidBlkType,
+          "ChaCha20-Poly1305", "chacha20-poly1305"},
     #endif
 
         /* oidOcspType */
     #ifdef HAVE_OCSP
-        { NID_id_pkix_OCSP_basic, OCSP_BASIC_OID, oidOcspType, "basicOCSPResponse",
-                                                         "Basic OCSP Response"},
-        { OCSP_NONCE_OID, OCSP_NONCE_OID, oidOcspType, "Nonce",
-                                                                  "OCSP Nonce"},
+        { NID_id_pkix_OCSP_basic, OCSP_BASIC_OID, oidOcspType,
+          "basicOCSPResponse", "Basic OCSP Response"},
+        { OCSP_NONCE_OID, OCSP_NONCE_OID, oidOcspType, "Nonce", "OCSP Nonce"},
     #endif /* HAVE_OCSP */
 
     #ifndef NO_PWDBASED
@@ -24192,22 +17297,25 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
 
         /* oidPBEType */
         { PBE_SHA1_RC4_128, PBE_SHA1_RC4_128, oidPBEType,
-                                 "PBE-SHA1-RC4-128", "pbeWithSHA1And128BitRC4"},
+          "PBE-SHA1-RC4-128", "pbeWithSHA1And128BitRC4"},
         { PBE_SHA1_DES, PBE_SHA1_DES, oidPBEType, "PBE-SHA1-DES",
-                                                       "pbeWithSHA1AndDES-CBC"},
+          "pbeWithSHA1AndDES-CBC"},
         { PBE_SHA1_DES3, PBE_SHA1_DES3, oidPBEType, "PBE-SHA1-3DES",
-                                            "pbeWithSHA1And3-KeyTripleDES-CBC"},
+          "pbeWithSHA1And3-KeyTripleDES-CBC"},
     #endif
 
         /* oidKeyWrapType */
     #ifdef WOLFSSL_AES_128
-        { AES128_WRAP, AES128_WRAP, oidKeyWrapType, "AES-128 wrap", "aes128-wrap"},
+        { AES128_WRAP, AES128_WRAP, oidKeyWrapType, "AES-128 wrap",
+          "aes128-wrap"},
     #endif
     #ifdef WOLFSSL_AES_192
-        { AES192_WRAP, AES192_WRAP, oidKeyWrapType, "AES-192 wrap", "aes192-wrap"},
+        { AES192_WRAP, AES192_WRAP, oidKeyWrapType, "AES-192 wrap",
+          "aes192-wrap"},
     #endif
     #ifdef WOLFSSL_AES_256
-        { AES256_WRAP, AES256_WRAP, oidKeyWrapType, "AES-256 wrap", "aes256-wrap"},
+        { AES256_WRAP, AES256_WRAP, oidKeyWrapType, "AES-256 wrap",
+          "aes256-wrap"},
     #endif
 
     #ifndef NO_PKCS7
@@ -24215,27 +17323,32 @@ const WOLFSSL_ObjectInfo wolfssl_object_info[] = {
         /* oidCmsKeyAgreeType */
             #ifndef NO_SHA
         { dhSinglePass_stdDH_sha1kdf_scheme, dhSinglePass_stdDH_sha1kdf_scheme,
-                oidCmsKeyAgreeType, "dhSinglePass-stdDH-sha1kdf-scheme", "dhSinglePass-stdDH-sha1kdf-scheme"},
+          oidCmsKeyAgreeType, "dhSinglePass-stdDH-sha1kdf-scheme",
+          "dhSinglePass-stdDH-sha1kdf-scheme"},
             #endif
             #ifdef WOLFSSL_SHA224
         { dhSinglePass_stdDH_sha224kdf_scheme,
-                dhSinglePass_stdDH_sha224kdf_scheme, oidCmsKeyAgreeType,
-                "dhSinglePass-stdDH-sha224kdf-scheme", "dhSinglePass-stdDH-sha224kdf-scheme"},
+          dhSinglePass_stdDH_sha224kdf_scheme, oidCmsKeyAgreeType,
+          "dhSinglePass-stdDH-sha224kdf-scheme",
+          "dhSinglePass-stdDH-sha224kdf-scheme"},
             #endif
             #ifndef NO_SHA256
         { dhSinglePass_stdDH_sha256kdf_scheme,
-                        dhSinglePass_stdDH_sha256kdf_scheme, oidCmsKeyAgreeType,
-                        "dhSinglePass-stdDH-sha256kdf-scheme", "dhSinglePass-stdDH-sha256kdf-scheme"},
+          dhSinglePass_stdDH_sha256kdf_scheme, oidCmsKeyAgreeType,
+          "dhSinglePass-stdDH-sha256kdf-scheme",
+          "dhSinglePass-stdDH-sha256kdf-scheme"},
             #endif
             #ifdef WOLFSSL_SHA384
         { dhSinglePass_stdDH_sha384kdf_scheme,
-                        dhSinglePass_stdDH_sha384kdf_scheme, oidCmsKeyAgreeType,
-                        "dhSinglePass-stdDH-sha384kdf-scheme", "dhSinglePass-stdDH-sha384kdf-scheme"},
+          dhSinglePass_stdDH_sha384kdf_scheme, oidCmsKeyAgreeType,
+          "dhSinglePass-stdDH-sha384kdf-scheme",
+          "dhSinglePass-stdDH-sha384kdf-scheme"},
             #endif
             #ifdef WOLFSSL_SHA512
         { dhSinglePass_stdDH_sha512kdf_scheme,
-                        dhSinglePass_stdDH_sha512kdf_scheme, oidCmsKeyAgreeType,
-                        "dhSinglePass-stdDH-sha512kdf-scheme", "dhSinglePass-stdDH-sha512kdf-scheme"},
+          dhSinglePass_stdDH_sha512kdf_scheme, oidCmsKeyAgreeType,
+          "dhSinglePass-stdDH-sha512kdf-scheme",
+          "dhSinglePass-stdDH-sha512kdf-scheme"},
             #endif
         #endif
     #endif
@@ -24307,15 +17420,16 @@ unsigned char *wolfSSL_OPENSSL_hexstr2buf(const char *str, long *len)
             continue;
         }
 
-        srcDigitHigh = wolfSSL_OPENSSL_hexchar2int(str[srcIdx++]);
-        srcDigitLow = wolfSSL_OPENSSL_hexchar2int(str[srcIdx++]);
+        srcDigitHigh = wolfSSL_OPENSSL_hexchar2int((unsigned char)str[srcIdx++]);
+        srcDigitLow = wolfSSL_OPENSSL_hexchar2int((unsigned char)str[srcIdx++]);
         if (srcDigitHigh < 0 || srcDigitLow < 0) {
             WOLFSSL_MSG("Invalid hex character.");
             XFREE(targetBuf, NULL, DYNAMIC_TYPE_OPENSSL);
             return NULL;
         }
 
-        targetBuf[targetIdx++] = (unsigned char)((srcDigitHigh << 4) | srcDigitLow);
+        targetBuf[targetIdx++] = (unsigned char)((srcDigitHigh << 4) |
+                                                  srcDigitLow       );
     }
 
     if (len != NULL)
@@ -24331,296 +17445,13 @@ int wolfSSL_OPENSSL_init_ssl(word64 opts, const OPENSSL_INIT_SETTINGS *settings)
     return wolfSSL_library_init();
 }
 
-int wolfSSL_OPENSSL_init_crypto(word64 opts, const OPENSSL_INIT_SETTINGS* settings)
+int wolfSSL_OPENSSL_init_crypto(word64 opts,
+    const OPENSSL_INIT_SETTINGS* settings)
 {
     (void)opts;
     (void)settings;
     return wolfSSL_library_init();
 }
-
-#if defined(WOLFSSL_KEY_GEN) && defined(WOLFSSL_PEM_TO_DER)
-
-int EncryptDerKey(byte *der, int *derSz, const EVP_CIPHER* cipher,
-                  unsigned char* passwd, int passwdSz, byte **cipherInfo,
-                  int maxDerSz)
-{
-    int ret, paddingSz;
-    word32 idx, cipherInfoSz;
-#ifdef WOLFSSL_SMALL_STACK
-    EncryptedInfo* info = NULL;
-#else
-    EncryptedInfo  info[1];
-#endif
-
-    WOLFSSL_ENTER("EncryptDerKey");
-
-    if (der == NULL || derSz == NULL || cipher == NULL ||
-        passwd == NULL || cipherInfo == NULL)
-        return BAD_FUNC_ARG;
-
-#ifdef WOLFSSL_SMALL_STACK
-    info = (EncryptedInfo*)XMALLOC(sizeof(EncryptedInfo), NULL,
-                                   DYNAMIC_TYPE_ENCRYPTEDINFO);
-    if (info == NULL) {
-        WOLFSSL_MSG("malloc failed");
-        return WOLFSSL_FAILURE;
-    }
-#endif
-
-    XMEMSET(info, 0, sizeof(EncryptedInfo));
-
-    /* set the cipher name on info */
-    XSTRNCPY(info->name, cipher, NAME_SZ-1);
-    info->name[NAME_SZ-1] = '\0'; /* null term */
-
-    ret = wc_EncryptedInfoGet(info, info->name);
-    if (ret != 0) {
-        WOLFSSL_MSG("unsupported cipher");
-    #ifdef WOLFSSL_SMALL_STACK
-        XFREE(info, NULL, DYNAMIC_TYPE_ENCRYPTEDINFO);
-    #endif
-        return WOLFSSL_FAILURE;
-    }
-
-    /* Generate a random salt */
-    if (wolfSSL_RAND_bytes(info->iv, info->ivSz) != WOLFSSL_SUCCESS) {
-        WOLFSSL_MSG("generate iv failed");
-#ifdef WOLFSSL_SMALL_STACK
-        XFREE(info, NULL, DYNAMIC_TYPE_ENCRYPTEDINFO);
-#endif
-        return WOLFSSL_FAILURE;
-    }
-
-    /* add the padding before encryption */
-    paddingSz = ((*derSz)/info->ivSz + 1) * info->ivSz - (*derSz);
-    if (paddingSz == 0)
-        paddingSz = info->ivSz;
-    if (maxDerSz < *derSz + paddingSz) {
-        WOLFSSL_MSG("not enough DER buffer allocated");
-#ifdef WOLFSSL_SMALL_STACK
-        XFREE(info, NULL, DYNAMIC_TYPE_ENCRYPTEDINFO);
-#endif
-        return WOLFSSL_FAILURE;
-    }
-    XMEMSET(der+(*derSz), (byte)paddingSz, paddingSz);
-    (*derSz) += paddingSz;
-
-    /* encrypt buffer */
-    if (wc_BufferKeyEncrypt(info, der, *derSz, passwd, passwdSz, WC_MD5) != 0) {
-        WOLFSSL_MSG("encrypt key failed");
-#ifdef WOLFSSL_SMALL_STACK
-        XFREE(info, NULL, DYNAMIC_TYPE_ENCRYPTEDINFO);
-#endif
-        return WOLFSSL_FAILURE;
-    }
-
-    /* create cipher info : 'cipher_name,Salt(hex)' */
-    cipherInfoSz = (word32)(2*info->ivSz + XSTRLEN(info->name) + 2);
-    *cipherInfo = (byte*)XMALLOC(cipherInfoSz, NULL,
-                                DYNAMIC_TYPE_STRING);
-    if (*cipherInfo == NULL) {
-        WOLFSSL_MSG("malloc failed");
-#ifdef WOLFSSL_SMALL_STACK
-        XFREE(info, NULL, DYNAMIC_TYPE_ENCRYPTEDINFO);
-#endif
-        return WOLFSSL_FAILURE;
-    }
-    XSTRLCPY((char*)*cipherInfo, info->name, cipherInfoSz);
-    XSTRLCAT((char*)*cipherInfo, ",", cipherInfoSz);
-
-    idx = (word32)XSTRLEN((char*)*cipherInfo);
-    cipherInfoSz -= idx;
-    ret = Base16_Encode(info->iv, info->ivSz, *cipherInfo+idx, &cipherInfoSz);
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(info, NULL, DYNAMIC_TYPE_ENCRYPTEDINFO);
-#endif
-    if (ret != 0) {
-        WOLFSSL_MSG("Base16_Encode failed");
-        XFREE(*cipherInfo, NULL, DYNAMIC_TYPE_STRING);
-        return WOLFSSL_FAILURE;
-    }
-
-    return WOLFSSL_SUCCESS;
-}
-#endif /* WOLFSSL_KEY_GEN || WOLFSSL_PEM_TO_DER */
-
-#if !defined(NO_BIO)
-static int pem_write_pubkey(WOLFSSL_EVP_PKEY* key, void* heap, byte** derBuf,
-    int* derSz)
-{
-    byte* buf = NULL;
-    int sz = 0;
-
-    (void)heap;
-
-    if (key == NULL) {
-        WOLFSSL_MSG("Bad parameters");
-        return WOLFSSL_FAILURE;
-    }
-
-    switch (key->type) {
-#if defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)
-        case EVP_PKEY_RSA:
-            if ((sz = wolfSSL_RSA_To_Der(key->rsa, &buf, 1, heap))
-                    < 0) {
-                WOLFSSL_MSG("wolfSSL_RSA_To_Der failed");
-                break;
-            }
-            break;
-#endif /* WOLFSSL_KEY_GEN && !NO_RSA */
-#if !defined(NO_DSA) && !defined(HAVE_SELFTEST) && (defined(WOLFSSL_KEY_GEN) || \
-        defined(WOLFSSL_CERT_GEN))
-        case EVP_PKEY_DSA:
-            if (key->dsa == NULL) {
-                WOLFSSL_MSG("key->dsa is null");
-                break;
-            }
-            sz = MAX_DSA_PUBKEY_SZ;
-            buf = (byte*)XMALLOC(sz, heap, DYNAMIC_TYPE_TMP_BUFFER);
-            if (buf == NULL) {
-                WOLFSSL_MSG("malloc failed");
-                break;
-            }
-            /* Key to DER */
-            sz = wc_DsaKeyToPublicDer((DsaKey*)key->dsa->internal, buf, sz);
-            if (sz < 0) {
-                WOLFSSL_MSG("wc_DsaKeyToDer failed");
-                break;
-            }
-            break;
-#endif /* !NO_DSA && !HAVE_SELFTEST && (WOLFSSL_KEY_GEN || WOLFSSL_CERT_GEN) */
-#if defined(HAVE_ECC) && defined(HAVE_ECC_KEY_EXPORT)
-        case EVP_PKEY_EC:
-        {
-            if (key->ecc == NULL) {
-                WOLFSSL_MSG("key->ecc is null");
-                break;
-            }
-            if ((sz = wolfssl_ec_key_to_pubkey_der(key->ecc, &buf, heap)) <=
-                    0) {
-                WOLFSSL_MSG("wolfssl_ec_key_to_pubkey_der failed");
-                break;
-            }
-            break;
-        }
-#endif /* HAVE_ECC && HAVE_ECC_KEY_EXPORT */
-#if !defined(NO_DH) && (defined(WOLFSSL_QT) || defined(OPENSSL_ALL))
-        case EVP_PKEY_DH:
-            WOLFSSL_MSG("Writing DH PUBKEY not supported!");
-            break;
-#endif /* !NO_DH && (WOLFSSL_QT || OPENSSL_ALL) */
-        default:
-            WOLFSSL_MSG("Unknown Key type!");
-            break;
-    }
-
-    if (buf == NULL || sz <= 0) {
-        if (buf != NULL)
-            XFREE(buf, heap, DYNAMIC_TYPE_DER);
-        return WOLFSSL_FAILURE;
-    }
-
-    *derBuf = buf;
-    *derSz = sz;
-    return WOLFSSL_SUCCESS;
-}
-#endif
-
-#ifndef NO_BIO
-static int pem_write_bio_pubkey(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key)
-{
-    int ret;
-    int derSz = 0;
-    byte* derBuf = NULL;
-
-    ret = pem_write_pubkey(key, bio->heap, &derBuf, &derSz);
-    if (ret == WOLFSSL_SUCCESS) {
-        ret = der_write_to_bio_as_pem(derBuf, derSz, bio, PUBLICKEY_TYPE);
-        XFREE(derBuf, bio->heap, DYNAMIC_TYPE_DER);
-    }
-
-    return ret;
-}
-
-/* Takes a public key and writes it out to a WOLFSSL_BIO
- * Returns WOLFSSL_SUCCESS or WOLFSSL_FAILURE
- */
-int wolfSSL_PEM_write_bio_PUBKEY(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key)
-{
-    int ret;
-
-    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_PUBKEY");
-
-    if ((bio == NULL) || (key == NULL)) {
-        ret = WOLFSSL_FAILURE;
-    }
-    else {
-        ret = pem_write_bio_pubkey(bio, key);
-    }
-
-    return ret;
-}
-
-/* Takes a private key and writes it out to a WOLFSSL_BIO
- * Returns WOLFSSL_SUCCESS or WOLFSSL_FAILURE
- */
-int wolfSSL_PEM_write_bio_PrivateKey(WOLFSSL_BIO* bio, WOLFSSL_EVP_PKEY* key,
-                                     const WOLFSSL_EVP_CIPHER* cipher,
-                                     unsigned char* passwd, int len,
-                                     wc_pem_password_cb* cb, void* arg)
-{
-    byte* keyDer;
-    int type;
-
-    (void)cipher;
-    (void)passwd;
-    (void)len;
-    (void)cb;
-    (void)arg;
-
-    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_PrivateKey");
-
-    if (bio == NULL || key == NULL) {
-        WOLFSSL_MSG("Bad Function Arguments");
-        return WOLFSSL_FAILURE;
-    }
-
-    keyDer = (byte*)key->pkey.ptr;
-
-    switch (key->type) {
-#ifndef NO_RSA
-        case EVP_PKEY_RSA:
-            type = PRIVATEKEY_TYPE;
-            break;
-#endif
-
-#ifndef NO_DSA
-        case EVP_PKEY_DSA:
-            type = DSA_PRIVATEKEY_TYPE;
-            break;
-#endif
-
-#ifdef HAVE_ECC
-        case EVP_PKEY_EC:
-            type = ECC_PRIVATEKEY_TYPE;
-            break;
-#endif
-
-#if !defined(NO_DH) && (defined(WOLFSSL_QT) || defined(OPENSSL_ALL))
-        case EVP_PKEY_DH:
-            type = DH_PRIVATEKEY_TYPE;
-            break;
-#endif
-
-        default:
-            WOLFSSL_MSG("Unknown Key type!");
-            type = PRIVATEKEY_TYPE;
-    }
-
-    return der_write_to_bio_as_pem(keyDer, key->pkey_sz, bio, type);
-}
-#endif /* !NO_BIO */
 
 /* Colon separated list of <public key>+<digest> algorithms.
  * Replaces list in context.
@@ -24816,217 +17647,27 @@ int wolfSSL_get_peer_signature_type_nid(const WOLFSSL* ssl, int* nid)
 #ifdef HAVE_ECC
 
 #if defined(WOLFSSL_TLS13) && defined(HAVE_SUPPORTED_CURVES)
-static int populate_groups(int* groups, int max_count, const char *list)
-{
-    const char *end;
-    int count = 0;
-    const WOLF_EC_NIST_NAME* nist_name;
-
-    if (!groups || !list) {
-        return -1;
-    }
-
-    for (end = list; ; list = ++end) {
-        int len;
-
-        if (count > max_count) {
-            WOLFSSL_MSG("Too many curves in list");
-            return -1;
-        }
-        while (*end != ':' && *end != '\0') end++;
-        len = (int)(end - list); /* end points to char after end
-                                  * of curve name so no need for -1 */
-        if ((len < kNistCurves_MIN_NAME_LEN) ||
-                (len > kNistCurves_MAX_NAME_LEN)) {
-            WOLFSSL_MSG("Unrecognized curve name in list");
-            return -1;
-        }
-        for (nist_name = kNistCurves; nist_name->name != NULL; nist_name++) {
-            if (len == nist_name->name_len &&
-                    XSTRNCMP(list, nist_name->name, nist_name->name_len) == 0) {
-                break;
-            }
-        }
-        if (!nist_name->name) {
-            WOLFSSL_MSG("Unrecognized curve name in list");
-            return -1;
-        }
-        groups[count++] = nist_name->nid;
-        if (*end == '\0') break;
-    }
-
-    return count;
-}
-
 int wolfSSL_CTX_set1_groups_list(WOLFSSL_CTX *ctx, const char *list)
 {
-    int groups[WOLFSSL_MAX_GROUP_COUNT];
-    int count = 0;
-
     if (!ctx || !list) {
         return WOLFSSL_FAILURE;
     }
 
-    if ((count = populate_groups(groups,
-            WOLFSSL_MAX_GROUP_COUNT, list)) == -1) {
-        return WOLFSSL_FAILURE;
-    }
-
-    return wolfSSL_CTX_set1_groups(ctx, groups, count);
+    return set_curves_list(NULL, ctx, list, 0);
 }
 
 int wolfSSL_set1_groups_list(WOLFSSL *ssl, const char *list)
 {
-    int groups[WOLFSSL_MAX_GROUP_COUNT];
-    int count = 0;
-
     if (!ssl || !list) {
         return WOLFSSL_FAILURE;
     }
 
-    if ((count = populate_groups(groups,
-            WOLFSSL_MAX_GROUP_COUNT, list)) == -1) {
-        return WOLFSSL_FAILURE;
-    }
-
-    return wolfSSL_set1_groups(ssl, groups, count);
+    return set_curves_list(ssl, NULL, list, 0);
 }
 #endif /* WOLFSSL_TLS13 */
 
 #endif /* HAVE_ECC */
 
-#ifndef NO_BIO
-WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_bio_PrivateKey(WOLFSSL_BIO* bio,
-                                                  WOLFSSL_EVP_PKEY** key,
-                                                  wc_pem_password_cb* cb,
-                                                  void* pass)
-{
-    WOLFSSL_EVP_PKEY* pkey = NULL;
-    DerBuffer*         der = NULL;
-    int             keyFormat = 0;
-
-    WOLFSSL_ENTER("wolfSSL_PEM_read_bio_PrivateKey");
-
-    if (bio == NULL)
-        return pkey;
-
-    if (pem_read_bio_key(bio, cb, pass, PRIVATEKEY_TYPE, &keyFormat, &der)
-            >= 0) {
-        const unsigned char* ptr = der->buffer;
-        int                  type = -1;
-
-        if (keyFormat) {
-            /* keyFormat is Key_Sum enum */
-            if (keyFormat == RSAk)
-                type = EVP_PKEY_RSA;
-            else if (keyFormat == ECDSAk)
-                type = EVP_PKEY_EC;
-            else if (keyFormat == DSAk)
-                type = EVP_PKEY_DSA;
-            else if (keyFormat == DHk)
-                type = EVP_PKEY_DH;
-        }
-        else {
-            /* Default to RSA if format is not set */
-            type = EVP_PKEY_RSA;
-        }
-
-        /* handle case where reuse is attempted */
-        if (key != NULL && *key != NULL)
-            pkey = *key;
-
-        wolfSSL_d2i_PrivateKey(type, &pkey, &ptr, der->length);
-        if (pkey == NULL) {
-            WOLFSSL_MSG("Error loading DER buffer into WOLFSSL_EVP_PKEY");
-        }
-    }
-
-    FreeDer(&der);
-
-    if (key != NULL && pkey != NULL)
-        *key = pkey;
-
-    WOLFSSL_LEAVE("wolfSSL_PEM_read_bio_PrivateKey", 0);
-
-    return pkey;
-}
-
-WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_bio_PUBKEY(WOLFSSL_BIO* bio,
-                                              WOLFSSL_EVP_PKEY **key,
-                                              wc_pem_password_cb *cb,
-                                              void *pass)
-{
-    WOLFSSL_EVP_PKEY* pkey = NULL;
-    DerBuffer*        der = NULL;
-    int               keyFormat = 0;
-
-    WOLFSSL_ENTER("wolfSSL_PEM_read_bio_PUBKEY");
-
-    if (bio == NULL)
-        return pkey;
-
-    if (pem_read_bio_key(bio, cb, pass, PUBLICKEY_TYPE, &keyFormat, &der)
-            >= 0) {
-        const unsigned char* ptr = der->buffer;
-
-        /* handle case where reuse is attempted */
-        if (key != NULL && *key != NULL)
-            pkey = *key;
-
-        wolfSSL_d2i_PUBKEY(&pkey, &ptr, der->length);
-        if (pkey == NULL) {
-            WOLFSSL_MSG("Error loading DER buffer into WOLFSSL_EVP_PKEY");
-        }
-    }
-
-    FreeDer(&der);
-
-    if (key != NULL && pkey != NULL)
-        *key = pkey;
-
-    WOLFSSL_LEAVE("wolfSSL_PEM_read_bio_PUBKEY", 0);
-
-    return pkey;
-}
-#endif /* !NO_BIO */
-
-#if !defined(NO_FILESYSTEM)
-WOLFSSL_EVP_PKEY *wolfSSL_PEM_read_PUBKEY(XFILE fp, WOLFSSL_EVP_PKEY **key,
-                                          wc_pem_password_cb *cb, void *pass)
-{
-    WOLFSSL_EVP_PKEY* pkey = NULL;
-    DerBuffer*        der = NULL;
-    int               keyFormat = 0;
-
-    WOLFSSL_ENTER("wolfSSL_PEM_read_PUBKEY");
-
-    if ((pem_read_file_key(fp, cb, pass, PUBLICKEY_TYPE, &keyFormat, &der)
-            >= 0) && (der != NULL)) {
-        const unsigned char* ptr = der->buffer;
-
-        /* handle case where reuse is attempted */
-        if ((key != NULL) && (*key != NULL)) {
-            pkey = *key;
-        }
-
-        if ((wolfSSL_d2i_PUBKEY(&pkey, &ptr, der->length) == NULL) ||
-                (pkey == NULL)) {
-            WOLFSSL_MSG("Error loading DER buffer into WOLFSSL_EVP_PKEY");
-            pkey = NULL;
-        }
-    }
-
-    FreeDer(&der);
-
-    if ((key != NULL) && (pkey != NULL)) {
-        *key = pkey;
-    }
-
-    WOLFSSL_LEAVE("wolfSSL_PEM_read_PUBKEY", 0);
-
-    return pkey;
-}
-#endif /* NO_FILESYSTEM */
 #endif /* OPENSSL_EXTRA */
 
 #ifdef WOLFSSL_ALT_CERT_CHAINS
@@ -25111,7 +17752,7 @@ WOLFSSL_X509* wolfSSL_get_chain_X509(WOLFSSL_X509_CHAIN* chain, int idx)
 #endif
 
     WOLFSSL_ENTER("wolfSSL_get_chain_X509");
-    if (chain != NULL) {
+    if (chain != NULL && idx < MAX_CHAIN_DEPTH) {
     #ifdef WOLFSSL_SMALL_STACK
         cert = (DecodedCert*)XMALLOC(sizeof(DecodedCert), NULL,
                                                        DYNAMIC_TYPE_DCERT);
@@ -25121,7 +17762,7 @@ WOLFSSL_X509* wolfSSL_get_chain_X509(WOLFSSL_X509_CHAIN* chain, int idx)
             InitDecodedCert(cert, chain->certs[idx].buffer,
                                   chain->certs[idx].length, NULL);
 
-            if ((ret = ParseCertRelative(cert, CERT_TYPE, 0, NULL)) != 0) {
+            if ((ret = ParseCertRelative(cert, CERT_TYPE, 0, NULL, NULL)) != 0) {
                 WOLFSSL_MSG("Failed to parse cert");
             }
             else {
@@ -25182,7 +17823,7 @@ int  wolfSSL_get_chain_cert_pem(WOLFSSL_X509_CHAIN* chain, int idx,
     /* Null output buffer return size needed in outLen */
     if(!buf) {
         if(Base64_Encode(chain->certs[idx].buffer, chain->certs[idx].length,
-                    NULL, &szNeeded) != LENGTH_ONLY_E)
+                    NULL, &szNeeded) != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
             return WOLFSSL_FAILURE;
         *outLen = szNeeded + headerLen + footerLen;
         return LENGTH_ONLY_E;
@@ -25222,20 +17863,6 @@ int  wolfSSL_get_chain_cert_pem(WOLFSSL_X509_CHAIN* chain, int idx,
     return WOLFSSL_FAILURE;
 #endif /* WOLFSSL_PEM_TO_DER || WOLFSSL_DER_TO_PEM */
 }
-
-
-/* get session ID */
-WOLFSSL_ABI
-const byte* wolfSSL_get_sessionID(const WOLFSSL_SESSION* session)
-{
-    WOLFSSL_ENTER("wolfSSL_get_sessionID");
-    session = ClientSessionToSession(session);
-    if (session)
-        return session->sessionID;
-
-    return NULL;
-}
-
 
 #endif /* SESSION_CERTS */
 
@@ -25320,7 +17947,8 @@ void* wolfSSL_GetEccVerifyCtx(WOLFSSL* ssl)
     return NULL;
 }
 
-void wolfSSL_CTX_SetEccSharedSecretCb(WOLFSSL_CTX* ctx, CallbackEccSharedSecret cb)
+void wolfSSL_CTX_SetEccSharedSecretCb(WOLFSSL_CTX* ctx,
+    CallbackEccSharedSecret cb)
 {
     if (ctx)
         ctx->EccSharedSecretCb = cb;
@@ -25544,7 +18172,8 @@ void  wolfSSL_CTX_SetRsaPssSignCb(WOLFSSL_CTX* ctx, CallbackRsaPssSign cb)
     if (ctx)
         ctx->RsaPssSignCb = cb;
 }
-void  wolfSSL_CTX_SetRsaPssSignCheckCb(WOLFSSL_CTX* ctx, CallbackRsaPssVerify cb)
+void  wolfSSL_CTX_SetRsaPssSignCheckCb(WOLFSSL_CTX* ctx,
+    CallbackRsaPssVerify cb)
 {
     if (ctx)
         ctx->RsaPssSignCheckCb = cb;
@@ -25640,7 +18269,8 @@ void* wolfSSL_GetGenPreMasterCtx(WOLFSSL* ssl)
 }
 
 /* callback for master secret generation */
-void  wolfSSL_CTX_SetGenMasterSecretCb(WOLFSSL_CTX* ctx, CallbackGenMasterSecret cb)
+void  wolfSSL_CTX_SetGenMasterSecretCb(WOLFSSL_CTX* ctx,
+    CallbackGenMasterSecret cb)
 {
     if (ctx)
         ctx->GenMasterCb = cb;
@@ -25837,427 +18467,6 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
 
 #if (defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)) && \
     !defined(WOLFCRYPT_ONLY)
-#ifndef NO_CERTS
-
-#if defined(OPENSSL_ALL) || defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
-
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
-#if !defined(NO_FILESYSTEM)
-    WOLFSSL_EVP_PKEY* wolfSSL_PEM_read_PrivateKey(XFILE fp,
-        WOLFSSL_EVP_PKEY **key, wc_pem_password_cb *cb, void *pass)
-    {
-        WOLFSSL_EVP_PKEY* pkey = NULL;
-        DerBuffer*         der = NULL;
-        int             keyFormat = 0;
-
-        WOLFSSL_ENTER("wolfSSL_PEM_read_PrivateKey");
-
-        if (pem_read_file_key(fp, cb, pass, PRIVATEKEY_TYPE, &keyFormat,
-                                                                   &der) >= 0) {
-            const unsigned char* ptr = der->buffer;
-            int                  type = -1;
-
-            if (keyFormat) {
-                /* keyFormat is Key_Sum enum */
-                if (keyFormat == RSAk)
-                    type = EVP_PKEY_RSA;
-                else if (keyFormat == ECDSAk)
-                    type = EVP_PKEY_EC;
-                else if (keyFormat == DSAk)
-                    type = EVP_PKEY_DSA;
-                else if (keyFormat == DHk)
-                    type = EVP_PKEY_DH;
-            }
-            else {
-                /* Default to RSA if format is not set */
-                type = EVP_PKEY_RSA;
-            }
-
-            /* handle case where reuse is attempted */
-            if (key != NULL && *key != NULL)
-                pkey = *key;
-
-            wolfSSL_d2i_PrivateKey(type, &pkey, &ptr, der->length);
-            if (pkey == NULL) {
-                WOLFSSL_MSG("Error loading DER buffer into WOLFSSL_EVP_PKEY");
-            }
-        }
-
-        FreeDer(&der);
-
-        if (key != NULL && pkey != NULL)
-            *key = pkey;
-
-        WOLFSSL_LEAVE("wolfSSL_PEM_read_PrivateKey", 0);
-
-        return pkey;
-    }
-#endif
-#endif
-
-#endif /* OPENSSL_ALL || OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL*/
-
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
-
-    #define PEM_BEGIN              "-----BEGIN "
-    #define PEM_BEGIN_SZ           11
-    #define PEM_END                "-----END "
-    #define PEM_END_SZ             9
-    #define PEM_HDR_FIN            "-----"
-    #define PEM_HDR_FIN_SZ         5
-    #define PEM_HDR_FIN_EOL_NEWLINE   "-----\n"
-    #define PEM_HDR_FIN_EOL_NULL_TERM "-----\0"
-    #define PEM_HDR_FIN_EOL_SZ     6
-
-#ifndef NO_BIO
-
-    int wolfSSL_PEM_read_bio(WOLFSSL_BIO* bio, char **name, char **header,
-                             unsigned char **data, long *len)
-    {
-        int ret = WOLFSSL_SUCCESS;
-        char pem[256];
-        int pemLen;
-        char* p;
-        char* nameStr = NULL;
-        int nameLen = 0;
-        char* headerStr = NULL;
-        int headerFound = 0;
-        unsigned char* der = NULL;
-        word32 derLen = 0;
-
-        if (bio == NULL || name == NULL || header == NULL || data == NULL ||
-                                                                  len == NULL) {
-            return WOLFSSL_FAILURE;
-        }
-
-        /* Find header line. */
-        pem[sizeof(pem) - 1] = '\0';
-        while ((pemLen = wolfSSL_BIO_gets(bio, pem, sizeof(pem) - 1)) > 0) {
-            if (XSTRNCMP(pem, PEM_BEGIN, PEM_BEGIN_SZ) == 0)
-                break;
-        }
-        if (pemLen <= 0)
-            ret = WOLFSSL_FAILURE;
-        /* Have a header line. */
-        if (ret == WOLFSSL_SUCCESS) {
-            while (pem[pemLen - 1] == '\r' || pem[pemLen - 1] == '\n')
-                pemLen--;
-            pem[pemLen] = '\0';
-            if (XSTRNCMP(pem + pemLen - PEM_HDR_FIN_SZ, PEM_HDR_FIN,
-                                                         PEM_HDR_FIN_SZ) != 0) {
-                ret = WOLFSSL_FAILURE;
-            }
-        }
-
-        /* Get out name. */
-        if (ret == WOLFSSL_SUCCESS) {
-            nameLen = pemLen - PEM_BEGIN_SZ - PEM_HDR_FIN_SZ;
-            nameStr = (char*)XMALLOC(nameLen + 1, NULL,
-                                                       DYNAMIC_TYPE_TMP_BUFFER);
-            if (nameStr == NULL)
-                ret = WOLFSSL_FAILURE;
-        }
-        if (ret == WOLFSSL_SUCCESS) {
-            int headerLen;
-
-            XSTRNCPY(nameStr, pem + PEM_BEGIN_SZ, nameLen);
-            nameStr[nameLen] = '\0';
-
-            /* Get header of PEM - encryption header. */
-            headerLen = 0;
-            while ((pemLen = wolfSSL_BIO_gets(bio, pem, sizeof(pem) - 1)) > 0) {
-                while (pemLen > 0 && (pem[pemLen - 1] == '\r' ||
-                                                     pem[pemLen - 1] == '\n')) {
-                    pemLen--;
-                }
-                pem[pemLen++] = '\n';
-                pem[pemLen] = '\0';
-
-                /* Header separator is a blank line. */
-                if (pem[0] == '\n') {
-                    headerFound = 1;
-                    break;
-                }
-
-                /* Didn't find a blank line - no header. */
-                if (XSTRNCMP(pem, PEM_END, PEM_END_SZ) == 0) {
-                    der = (unsigned char*)headerStr;
-                    derLen = headerLen;
-                    /* Empty header - empty string. */
-                    headerStr = (char*)XMALLOC(1, NULL,
-                                                       DYNAMIC_TYPE_TMP_BUFFER);
-                    if (headerStr == NULL)
-                        ret = WOLFSSL_FAILURE;
-                    else
-                        headerStr[0] = '\0';
-                    break;
-                }
-
-                p = (char*)XREALLOC(headerStr, headerLen + pemLen + 1, NULL,
-                                                       DYNAMIC_TYPE_TMP_BUFFER);
-                if (p == NULL) {
-                    ret = WOLFSSL_FAILURE;
-                    break;
-                }
-
-                headerStr = p;
-                XMEMCPY(headerStr + headerLen, pem, pemLen + 1);
-                headerLen += pemLen;
-            }
-            if (pemLen <= 0)
-                ret = WOLFSSL_FAILURE;
-        }
-
-        /* Get body of PEM - if there was a header */
-        if (ret == WOLFSSL_SUCCESS && headerFound) {
-            derLen = 0;
-            while ((pemLen = wolfSSL_BIO_gets(bio, pem, sizeof(pem) - 1)) > 0) {
-                while (pemLen > 0 && (pem[pemLen - 1] == '\r' ||
-                                                     pem[pemLen - 1] == '\n')) {
-                    pemLen--;
-                }
-                pem[pemLen++] = '\n';
-                pem[pemLen] = '\0';
-
-                if (XSTRNCMP(pem, PEM_END, PEM_END_SZ) == 0)
-                    break;
-
-                p = (char*)XREALLOC(der, derLen + pemLen + 1, NULL,
-                                                       DYNAMIC_TYPE_TMP_BUFFER);
-                if (p == NULL) {
-                    ret = WOLFSSL_FAILURE;
-                    break;
-                }
-
-                der = (unsigned char*)p;
-                XMEMCPY(der + derLen, pem, pemLen + 1);
-                derLen += pemLen;
-            }
-            if (pemLen <= 0)
-                ret = WOLFSSL_FAILURE;
-        }
-
-        /* Check trailer. */
-        if (ret == WOLFSSL_SUCCESS) {
-            if (XSTRNCMP(pem + PEM_END_SZ, nameStr, nameLen) != 0)
-                ret = WOLFSSL_FAILURE;
-        }
-        if (ret == WOLFSSL_SUCCESS) {
-            if (XSTRNCMP(pem + PEM_END_SZ + nameLen,
-                    PEM_HDR_FIN_EOL_NEWLINE,
-                    PEM_HDR_FIN_EOL_SZ) != 0 &&
-                XSTRNCMP(pem + PEM_END_SZ + nameLen,
-                        PEM_HDR_FIN_EOL_NULL_TERM,
-                        PEM_HDR_FIN_EOL_SZ) != 0) {
-                ret = WOLFSSL_FAILURE;
-            }
-        }
-
-        /* Base64 decode body. */
-        if (ret == WOLFSSL_SUCCESS) {
-            if (Base64_Decode(der, derLen, der, &derLen) != 0)
-                ret = WOLFSSL_FAILURE;
-        }
-
-        if (ret == WOLFSSL_SUCCESS) {
-            *name = nameStr;
-            *header = headerStr;
-            *data = der;
-            *len = derLen;
-            nameStr = NULL;
-            headerStr = NULL;
-            der = NULL;
-        }
-
-        if (nameStr != NULL)
-            XFREE(nameStr, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        if (headerStr != NULL)
-            XFREE(headerStr, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        if (der != NULL)
-            XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-
-        return ret;
-    }
-
-    int wolfSSL_PEM_write_bio(WOLFSSL_BIO* bio, const char *name,
-                              const char *header, const unsigned char *data,
-                              long len)
-    {
-        int err = 0;
-        int outSz = 0;
-        int nameLen;
-        int headerLen;
-        byte* pem = NULL;
-        word32 pemLen;
-        word32 derLen = (word32)len;
-
-        if (bio == NULL || name == NULL || header == NULL || data == NULL)
-            return 0;
-
-        nameLen = (int)XSTRLEN(name);
-        headerLen = (int)XSTRLEN(header);
-
-        pemLen = (derLen + 2) / 3 * 4;
-        pemLen += (pemLen + 63) / 64;
-
-        pem = (byte*)XMALLOC(pemLen, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        err = pem == NULL;
-        if (!err)
-            err = Base64_Encode(data, derLen, pem, &pemLen) != 0;
-
-        if (!err) {
-            err = wolfSSL_BIO_write(bio, PEM_BEGIN, PEM_BEGIN_SZ) !=
-                                                              (int)PEM_BEGIN_SZ;
-        }
-        if (!err)
-            err = wolfSSL_BIO_write(bio, name, nameLen) != nameLen;
-        if (!err) {
-            err = wolfSSL_BIO_write(bio, PEM_HDR_FIN_EOL_NEWLINE,
-                    PEM_HDR_FIN_EOL_SZ) != (int)PEM_HDR_FIN_EOL_SZ;
-        }
-        if (!err && headerLen > 0) {
-            err = wolfSSL_BIO_write(bio, header, headerLen) != headerLen;
-            /* Blank line after a header and before body. */
-            if (!err)
-                err = wolfSSL_BIO_write(bio, "\n", 1) != 1;
-            headerLen++;
-        }
-        if (!err)
-            err = wolfSSL_BIO_write(bio, pem, pemLen) != (int)pemLen;
-        if (!err)
-            err = wolfSSL_BIO_write(bio, PEM_END, PEM_END_SZ) !=
-                                                                (int)PEM_END_SZ;
-        if (!err)
-            err = wolfSSL_BIO_write(bio, name, nameLen) != nameLen;
-        if (!err) {
-            err = wolfSSL_BIO_write(bio, PEM_HDR_FIN_EOL_NEWLINE,
-                    PEM_HDR_FIN_EOL_SZ) != (int)PEM_HDR_FIN_EOL_SZ;
-        }
-
-        if (!err) {
-            outSz = PEM_BEGIN_SZ + nameLen + PEM_HDR_FIN_EOL_SZ + headerLen +
-                             pemLen + PEM_END_SZ + nameLen + PEM_HDR_FIN_EOL_SZ;
-        }
-
-        if (pem != NULL)
-            XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-
-        return outSz;
-    }
-
-#if !defined(NO_FILESYSTEM)
-    int wolfSSL_PEM_read(XFILE fp, char **name, char **header,
-                         unsigned char **data, long *len)
-    {
-        int ret;
-        WOLFSSL_BIO* bio;
-
-        if (name == NULL || header == NULL || data == NULL || len == NULL)
-            return WOLFSSL_FAILURE;
-
-        bio = wolfSSL_BIO_new_fp(fp, BIO_NOCLOSE);
-        if (bio == NULL)
-            return 0;
-
-        ret = wolfSSL_PEM_read_bio(bio, name, header, data, len);
-
-        if (bio != NULL)
-            wolfSSL_BIO_free(bio);
-
-        return ret;
-    }
-
-    int wolfSSL_PEM_write(XFILE fp, const char *name, const char *header,
-                          const unsigned char *data, long len)
-    {
-        int ret;
-        WOLFSSL_BIO* bio;
-
-        if (name == NULL || header == NULL || data == NULL)
-            return 0;
-
-        bio = wolfSSL_BIO_new_fp(fp, BIO_NOCLOSE);
-        if (bio == NULL)
-            return 0;
-
-        ret = wolfSSL_PEM_write_bio(bio, name, header, data, len);
-
-        if (bio != NULL)
-            wolfSSL_BIO_free(bio);
-
-        return ret;
-    }
-#endif
-#endif /* !NO_BIO */
-
-    int wolfSSL_PEM_get_EVP_CIPHER_INFO(const char* header,
-                                        EncryptedInfo* cipher)
-    {
-        if (header == NULL || cipher == NULL)
-            return WOLFSSL_FAILURE;
-
-        XMEMSET(cipher, 0, sizeof(*cipher));
-
-        if (wc_EncryptedInfoParse(cipher, &header, XSTRLEN(header)) != 0)
-            return WOLFSSL_FAILURE;
-
-        return WOLFSSL_SUCCESS;
-    }
-
-    int wolfSSL_PEM_do_header(EncryptedInfo* cipher, unsigned char* data,
-                              long* len, wc_pem_password_cb* callback,
-                              void* ctx)
-    {
-        int ret = WOLFSSL_SUCCESS;
-        char password[NAME_SZ];
-        int passwordSz;
-
-        if (cipher == NULL || data == NULL || len == NULL || callback == NULL)
-            return WOLFSSL_FAILURE;
-
-        passwordSz = callback(password, sizeof(password), PEM_PASS_READ, ctx);
-        if (passwordSz < 0)
-            ret = WOLFSSL_FAILURE;
-
-        if (ret == WOLFSSL_SUCCESS) {
-            if (wc_BufferKeyDecrypt(cipher, data, (word32)*len, (byte*)password,
-                                                     passwordSz, WC_MD5) != 0) {
-                ret = WOLFSSL_FAILURE;
-            }
-        }
-
-        if (passwordSz > 0)
-            XMEMSET(password, 0, passwordSz);
-
-        return ret;
-    }
-
-#ifndef NO_BIO
-    /*
-     * bp : bio to read X509 from
-     * x  : x509 to write to
-     * cb : password call back for reading PEM
-     * u  : password
-     * _AUX is for working with a trusted X509 certificate
-     */
-    WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX(WOLFSSL_BIO *bp,
-                               WOLFSSL_X509 **x, wc_pem_password_cb *cb,
-                               void *u)
-    {
-        WOLFSSL_ENTER("wolfSSL_PEM_read_bio_X509");
-
-        /* AUX info is; trusted/rejected uses, friendly name, private key id,
-         * and potentially a stack of "other" info. wolfSSL does not store
-         * friendly name or private key id yet in WOLFSSL_X509 for human
-         * readability and does not support extra trusted/rejected uses for
-         * root CA. */
-        return wolfSSL_PEM_read_bio_X509(bp, x, cb, u);
-    }
-#endif /* !NO_BIO */
-
-
-#endif /* OPENSSL_EXTRA || OPENSSL_ALL */
-#endif /* !NO_CERTS */
 
     /* NID variables are dependent on compatibility header files currently
      *
@@ -26301,14 +18510,14 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
             WOLFSSL_MSG("NID not in table");
         #ifdef WOLFSSL_QT
             sName = NULL;
-            type = id;
+            type = (word32)id;
         #else
             return NULL;
         #endif
         }
 
     #ifdef HAVE_ECC
-         if (type == 0 && wc_ecc_get_oid(id, &oid, &oidSz) > 0) {
+         if (type == 0 && wc_ecc_get_oid((word32)id, &oid, &oidSz) > 0) {
              type = oidCurveType;
          }
     #endif /* HAVE_ECC */
@@ -26320,7 +18529,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
             }
         }
 
-        oid = OidFromId(id, type, &oidSz);
+        oid = OidFromId((word32)id, type, &oidSz);
 
         /* set object ID to buffer */
         if (obj == NULL){
@@ -26332,7 +18541,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
         }
         obj->nid     = nid;
         obj->type    = id;
-        obj->grp     = type;
+        obj->grp     = (int)type;
 
         obj->sName[0] = '\0';
         if (sName != NULL) {
@@ -26357,10 +18566,10 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
                     wolfSSL_ASN1_OBJECT_free(obj);
                     return NULL;
                 }
-                obj->dynamic |= WOLFSSL_ASN1_DYNAMIC_DATA ;
+                obj->dynamic |= WOLFSSL_ASN1_DYNAMIC_DATA;
             }
             else {
-                obj->dynamic &= ~WOLFSSL_ASN1_DYNAMIC_DATA ;
+                obj->dynamic &= ~WOLFSSL_ASN1_DYNAMIC_DATA;
             }
         }
         XMEMCPY((byte*)obj->obj, objBuf, obj->objSz);
@@ -26480,12 +18689,12 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
         else if (a->type == GEN_DNS || a->type == GEN_EMAIL ||
                  a->type == GEN_URI) {
             bufSz = (int)XSTRLEN((const char*)a->obj);
-            XMEMCPY(buf, a->obj, min(bufSz, bufLen));
+            XMEMCPY(buf, a->obj, min((word32)bufSz, (word32)bufLen));
         }
         else if ((bufSz = wolfssl_obj2txt_numeric(buf, bufLen, a)) > 0) {
             if ((desc = oid_translate_num_to_str(buf))) {
                 bufSz = (int)XSTRLEN(desc);
-                bufSz = min(bufSz, bufLen - 1);
+                bufSz = (int)min((word32)bufSz,(word32) bufLen - 1);
                 XMEMCPY(buf, desc, bufSz);
             }
         }
@@ -26525,224 +18734,6 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
     defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(HAVE_STUNNEL) || \
     defined(WOLFSSL_NGINX) || defined(HAVE_POCO_LIB) || \
     defined(WOLFSSL_HAPROXY)
-    char wolfSSL_CTX_use_certificate(WOLFSSL_CTX *ctx, WOLFSSL_X509 *x)
-    {
-        int ret;
-
-        WOLFSSL_ENTER("wolfSSL_CTX_use_certificate");
-        if (!ctx || !x || !x->derCert) {
-            WOLFSSL_MSG("Bad parameter");
-            return WOLFSSL_FAILURE;
-        }
-
-        FreeDer(&ctx->certificate); /* Make sure previous is free'd */
-        ret = AllocDer(&ctx->certificate, x->derCert->length, CERT_TYPE,
-                       ctx->heap);
-        if (ret != 0)
-            return WOLFSSL_FAILURE;
-
-        XMEMCPY(ctx->certificate->buffer, x->derCert->buffer,
-                x->derCert->length);
-#ifdef KEEP_OUR_CERT
-        if (ctx->ourCert != NULL && ctx->ownOurCert) {
-            wolfSSL_X509_free(ctx->ourCert);
-        }
-        #ifndef WOLFSSL_X509_STORE_CERTS
-        ctx->ourCert = x;
-        if (wolfSSL_X509_up_ref(x) != 1) {
-            return WOLFSSL_FAILURE;
-        }
-        #else
-        ctx->ourCert = wolfSSL_X509_d2i_ex(NULL, x->derCert->buffer,
-            x->derCert->length, ctx->heap);
-        if(ctx->ourCert == NULL){
-            return WOLFSSL_FAILURE;
-        }
-        #endif
-
-        /* We own the cert because either we up its reference counter
-         * or we create our own copy of the cert object. */
-        ctx->ownOurCert = 1;
-#endif
-
-        /* Update the available options with public keys. */
-        switch (x->pubKeyOID) {
-    #ifndef NO_RSA
-        #ifdef WC_RSA_PSS
-            case RSAPSSk:
-        #endif
-            case RSAk:
-                ctx->haveRSA = 1;
-                break;
-    #endif
-        #ifdef HAVE_ED25519
-            case ED25519k:
-        #endif
-        #ifdef HAVE_ED448
-            case ED448k:
-        #endif
-            case ECDSAk:
-                ctx->haveECC = 1;
-        #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
-                ctx->pkCurveOID = x->pkCurveOID;
-        #endif
-                break;
-        }
-
-        return WOLFSSL_SUCCESS;
-    }
-
-    static int PushCertToDerBuffer(DerBuffer** inOutDer, int weOwn,
-            byte* cert, word32 certSz, void* heap)
-    {
-        int ret;
-        DerBuffer* inChain = NULL;
-        DerBuffer* der = NULL;
-        word32 len = 0;
-        if (inOutDer == NULL)
-            return BAD_FUNC_ARG;
-        inChain = *inOutDer;
-        if (inChain != NULL)
-            len = inChain->length;
-        ret = AllocDer(&der, len + CERT_HEADER_SZ + certSz, CERT_TYPE,
-                heap);
-        if (ret != 0) {
-            WOLFSSL_MSG("AllocDer error");
-            return ret;
-        }
-        if (inChain != NULL)
-            XMEMCPY(der->buffer, inChain->buffer, len);
-        c32to24(certSz, der->buffer + len);
-        XMEMCPY(der->buffer + len + CERT_HEADER_SZ, cert, certSz);
-        if (weOwn)
-            FreeDer(inOutDer);
-        *inOutDer = der;
-        return WOLFSSL_SUCCESS;
-    }
-
-    /**
-     * wolfSSL_CTX_add1_chain_cert makes a copy of the cert so we free it
-     * on success
-     */
-    int wolfSSL_CTX_add0_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
-    {
-        WOLFSSL_ENTER("wolfSSL_CTX_add0_chain_cert");
-        if (wolfSSL_CTX_add1_chain_cert(ctx, x509) != WOLFSSL_SUCCESS) {
-            return WOLFSSL_FAILURE;
-        }
-        wolfSSL_X509_free(x509);
-        return WOLFSSL_SUCCESS;
-    }
-
-    int wolfSSL_CTX_add1_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
-    {
-        int ret;
-        WOLFSSL_ENTER("wolfSSL_CTX_add1_chain_cert");
-        if (ctx == NULL || x509 == NULL || x509->derCert == NULL) {
-            return WOLFSSL_FAILURE;
-        }
-
-        if (ctx->certificate == NULL)
-            ret = (int)wolfSSL_CTX_use_certificate(ctx, x509);
-        else {
-            if (wolfSSL_X509_up_ref(x509) != WOLFSSL_SUCCESS) {
-                WOLFSSL_MSG("wolfSSL_X509_up_ref error");
-                return WOLFSSL_FAILURE;
-            }
-            ret = wolfSSL_CTX_load_verify_buffer(ctx, x509->derCert->buffer,
-                x509->derCert->length, WOLFSSL_FILETYPE_ASN1);
-            if (ret == WOLFSSL_SUCCESS) {
-                /* push to ctx->certChain */
-                ret = PushCertToDerBuffer(&ctx->certChain, 1,
-                    x509->derCert->buffer, x509->derCert->length, ctx->heap);
-            }
-            /* Store cert to free it later */
-            if (ret == WOLFSSL_SUCCESS && ctx->x509Chain == NULL) {
-                ctx->x509Chain = wolfSSL_sk_X509_new_null();
-                if (ctx->x509Chain == NULL) {
-                    WOLFSSL_MSG("wolfSSL_sk_X509_new_null error");
-                    ret =  WOLFSSL_FAILURE;
-                }
-            }
-            if (ret == WOLFSSL_SUCCESS &&
-                    wolfSSL_sk_X509_push(ctx->x509Chain, x509)
-                        != WOLFSSL_SUCCESS) {
-                WOLFSSL_MSG("wolfSSL_sk_X509_push error");
-                ret = WOLFSSL_FAILURE;
-            }
-            if (ret != WOLFSSL_SUCCESS)
-                wolfSSL_X509_free(x509); /* Decrease ref counter */
-        }
-
-        return (ret == WOLFSSL_SUCCESS) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
-    }
-
-#ifdef KEEP_OUR_CERT
-    int wolfSSL_add0_chain_cert(WOLFSSL* ssl, WOLFSSL_X509* x509)
-    {
-        int ret;
-
-        WOLFSSL_ENTER("wolfSSL_add0_chain_cert");
-
-        if (ssl == NULL || ssl->ctx == NULL || x509 == NULL ||
-                x509->derCert == NULL)
-            return WOLFSSL_FAILURE;
-
-        if (ssl->buffers.certificate == NULL) {
-            ret = wolfSSL_use_certificate(ssl, x509);
-            /* Store cert to free it later */
-            if (ret == WOLFSSL_SUCCESS) {
-                if (ssl->buffers.weOwnCert)
-                    wolfSSL_X509_free(ssl->ourCert);
-                ssl->ourCert = x509;
-                ssl->buffers.weOwnCert = 1;
-            }
-        }
-        else {
-            ret = PushCertToDerBuffer(&ssl->buffers.certChain,
-                    ssl->buffers.weOwnCertChain, x509->derCert->buffer,
-                    x509->derCert->length, ssl->heap);
-            if (ret == WOLFSSL_SUCCESS) {
-                ssl->buffers.weOwnCertChain = 1;
-                /* Store cert to free it later */
-                if (ssl->ourCertChain == NULL) {
-                    ssl->ourCertChain = wolfSSL_sk_X509_new_null();
-                    if (ssl->ourCertChain == NULL) {
-                        WOLFSSL_MSG("wolfSSL_sk_X509_new_null error");
-                        return WOLFSSL_FAILURE;
-                    }
-                }
-                if (wolfSSL_sk_X509_push(ssl->ourCertChain, x509)
-                        != WOLFSSL_SUCCESS) {
-                    WOLFSSL_MSG("wolfSSL_sk_X509_push error");
-                    return WOLFSSL_FAILURE;
-                }
-            }
-        }
-        return ret == WOLFSSL_SUCCESS ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
-    }
-
-    int wolfSSL_add1_chain_cert(WOLFSSL* ssl, WOLFSSL_X509* x509)
-    {
-        int ret;
-
-        WOLFSSL_ENTER("wolfSSL_add1_chain_cert");
-        if (ssl == NULL || ssl->ctx == NULL || x509 == NULL ||
-                x509->derCert == NULL)
-            return WOLFSSL_FAILURE;
-
-        if (wolfSSL_X509_up_ref(x509) != WOLFSSL_SUCCESS) {
-            WOLFSSL_MSG("wolfSSL_X509_up_ref error");
-            return WOLFSSL_FAILURE;
-        }
-        ret = wolfSSL_add0_chain_cert(ssl, x509);
-        /* Decrease ref counter on error */
-        if (ret != WOLFSSL_SUCCESS)
-            wolfSSL_X509_free(x509);
-        return ret;
-    }
-#endif
-
     /* Return the corresponding short name for the nid <n>.
      * or NULL if short name can't be found.
      */
@@ -26796,7 +18787,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
             err = 1;
         }
         if (err == 0) {
-            ret = len;
+            ret = (size_t)len;
         }
 
         WOLFSSL_LEAVE("wolfSSL_OBJ_length", (int)ret);
@@ -26861,7 +18852,7 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
         if (o->nid > 0)
             return o->nid;
         if ((ret = GetObjectId(o->obj, &idx, &oid, o->grp, o->objSz)) < 0) {
-            if (ret == ASN_OBJECT_ID_E) {
+            if (ret == WC_NO_ERR_TRACE(ASN_OBJECT_ID_E)) {
                 /* Put ASN object tag in front and try again */
                 int len = SetObjectId(o->objSz, NULL) + o->objSz;
                 byte* buf = (byte*)XMALLOC(len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -27069,8 +19060,8 @@ void* wolfSSL_GetHKDFExtractCtx(WOLFSSL* ssl)
                 wolfSSL_ASN1_OBJECT_free(obj);
                 return NULL;
             }
-            obj->dynamic |= WOLFSSL_ASN1_DYNAMIC_DATA ;
-            i = SetObjectId(outSz, (byte*)obj->obj);
+            obj->dynamic |= WOLFSSL_ASN1_DYNAMIC_DATA;
+            i = SetObjectId((int)outSz, (byte*)obj->obj);
             XMEMCPY((byte*)obj->obj + i, out, outSz);
             obj->objSz = i + outSz;
             return obj;
@@ -27160,53 +19151,6 @@ unsigned long wolfSSL_ERR_peek_last_error_line(const char **file, int *line)
     return (unsigned long)(0 - NOT_COMPILED_IN);
 #endif
 }
-
-
-#ifndef NO_CERTS
-int wolfSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *pkey)
-{
-    WOLFSSL_ENTER("wolfSSL_CTX_use_PrivateKey");
-
-    if (ctx == NULL || pkey == NULL) {
-        return WOLFSSL_FAILURE;
-    }
-
-    switch (pkey->type) {
-#if defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)
-    case EVP_PKEY_RSA:
-        WOLFSSL_MSG("populating RSA key");
-        if (PopulateRSAEvpPkeyDer(pkey) != WOLFSSL_SUCCESS)
-            return WOLFSSL_FAILURE;
-        break;
-#endif /* (WOLFSSL_KEY_GEN || OPENSSL_EXTRA) && !NO_RSA */
-#if !defined(HAVE_SELFTEST) && (defined(WOLFSSL_KEY_GEN) || \
-        defined(WOLFSSL_CERT_GEN)) && !defined(NO_DSA)
-    case EVP_PKEY_DSA:
-        break;
-#endif /* !HAVE_SELFTEST && (WOLFSSL_KEY_GEN || WOLFSSL_CERT_GEN) && !NO_DSA */
-#ifdef HAVE_ECC
-    case EVP_PKEY_EC:
-        WOLFSSL_MSG("populating ECC key");
-        if (ECC_populate_EVP_PKEY(pkey, pkey->ecc)
-                != WOLFSSL_SUCCESS)
-            return WOLFSSL_FAILURE;
-        break;
-#endif
-    default:
-        return WOLFSSL_FAILURE;
-    }
-
-    if (pkey->pkey.ptr != NULL) {
-        /* ptr for WOLFSSL_EVP_PKEY struct is expected to be DER format */
-        return wolfSSL_CTX_use_PrivateKey_buffer(ctx,
-                                       (const unsigned char*)pkey->pkey.ptr,
-                                       pkey->pkey_sz, SSL_FILETYPE_ASN1);
-    }
-
-    WOLFSSL_MSG("wolfSSL private key not set");
-    return BAD_FUNC_ARG;
-}
-#endif /* !NO_CERTS */
 
 #endif /* OPENSSL_EXTRA */
 
@@ -27518,50 +19462,6 @@ void* wolfSSL_get_ex_data(const WOLFSSL* ssl, int idx)
 #if defined(HAVE_LIGHTY) || defined(HAVE_STUNNEL) \
     || defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(OPENSSL_EXTRA)
 
-#if defined(OPENSSL_EXTRA) && !defined(NO_DH)
-/* Initialize ctx->dh with dh's params. Return WOLFSSL_SUCCESS on ok */
-long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL_DH* dh)
-{
-    int pSz, gSz;
-    byte *p, *g;
-    int ret=0;
-
-    WOLFSSL_ENTER("wolfSSL_CTX_set_tmp_dh");
-
-    if(!ctx || !dh)
-        return BAD_FUNC_ARG;
-
-    /* Get needed size for p and g */
-    pSz = wolfSSL_BN_bn2bin(dh->p, NULL);
-    gSz = wolfSSL_BN_bn2bin(dh->g, NULL);
-
-    if(pSz <= 0 || gSz <= 0)
-        return WOLFSSL_FATAL_ERROR;
-
-    p = (byte*)XMALLOC(pSz, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-    if(!p)
-        return MEMORY_E;
-
-    g = (byte*)XMALLOC(gSz, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-    if(!g) {
-        XFREE(p, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-        return MEMORY_E;
-    }
-
-    pSz = wolfSSL_BN_bn2bin(dh->p, p);
-    gSz = wolfSSL_BN_bn2bin(dh->g, g);
-
-    if(pSz >= 0 && gSz >= 0) /* Conversion successful */
-        ret = wolfSSL_CTX_SetTmpDH(ctx, p, pSz, g, gSz);
-
-    XFREE(p, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-    XFREE(g, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
-
-    return pSz > 0 && gSz > 0 ? ret : WOLFSSL_FATAL_ERROR;
-}
-#endif /* OPENSSL_EXTRA && !NO_DH */
-
-
 /* returns the enum value associated with handshake state
  *
  * ssl the WOLFSSL structure to get state of
@@ -27597,18 +19497,32 @@ void wolfSSL_certs_clear(WOLFSSL* ssl)
 #ifdef WOLFSSL_TLS13
     ssl->buffers.certChainCnt = 0;
 #endif
-    if (ssl->buffers.weOwnKey)
+    if (ssl->buffers.weOwnKey) {
         FreeDer(&ssl->buffers.key);
+    #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+        FreeDer(&ssl->buffers.keyMask);
+    #endif
+    }
     ssl->buffers.key      = NULL;
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    ssl->buffers.keyMask  = NULL;
+#endif
     ssl->buffers.keyType  = 0;
     ssl->buffers.keyId    = 0;
     ssl->buffers.keyLabel = 0;
     ssl->buffers.keySz    = 0;
     ssl->buffers.keyDevId = 0;
 #ifdef WOLFSSL_DUAL_ALG_CERTS
-    if (ssl->buffers.weOwnAltKey)
+    if (ssl->buffers.weOwnAltKey) {
         FreeDer(&ssl->buffers.altKey);
-    ssl->buffers.altKey   = NULL;
+    #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+        FreeDer(&ssl->buffers.altKeyMask);
+    #endif
+    }
+    ssl->buffers.altKey     = NULL;
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    ssl->buffers.altKeyMask = NULL;
+#endif
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
 }
 #endif
@@ -27623,7 +19537,8 @@ long wolfSSL_ctrl(WOLFSSL* ssl, int cmd, long opt, void* pt)
         return BAD_FUNC_ARG;
 
     switch (cmd) {
-        #if defined(WOLFSSL_NGINX) || defined(WOLFSSL_QT) || defined(OPENSSL_ALL)
+        #if defined(WOLFSSL_NGINX) || defined(WOLFSSL_QT) || \
+            defined(OPENSSL_ALL)
         #ifdef HAVE_SNI
         case SSL_CTRL_SET_TLSEXT_HOSTNAME:
             WOLFSSL_MSG("Entering Case: SSL_CTRL_SET_TLSEXT_HOSTNAME.");
@@ -27785,7 +19700,7 @@ long wolfSSL_CTX_ctrl(WOLFSSL_CTX* ctx, int cmd, long opt, void* pt)
     return ret;
 }
 
-#ifndef WOLFSSL_NO_STUB
+#ifndef NO_WOLFSSL_STUB
 long wolfSSL_CTX_callback_ctrl(WOLFSSL_CTX* ctx, int cmd, void (*fp)(void))
 {
     (void) ctx;
@@ -27795,7 +19710,7 @@ long wolfSSL_CTX_callback_ctrl(WOLFSSL_CTX* ctx, int cmd, void (*fp)(void))
     return WOLFSSL_FAILURE;
 
 }
-#endif /* WOLFSSL_NO_STUB */
+#endif /* NO_WOLFSSL_STUB */
 
 #ifndef NO_WOLFSSL_STUB
 long wolfSSL_CTX_clear_extra_chain_certs(WOLFSSL_CTX* ctx)
@@ -27814,64 +19729,6 @@ VerifyCallback wolfSSL_get_verify_callback(WOLFSSL* ssl)
     }
     return NULL;
 }
-
-/* Adds the ASN1 certificate to the user ctx.
-Returns WOLFSSL_SUCCESS if no error, returns WOLFSSL_FAILURE otherwise.*/
-int wolfSSL_CTX_use_certificate_ASN1(WOLFSSL_CTX *ctx, int derSz,
-                                                       const unsigned char *der)
-{
-    WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_ASN1");
-    if (der != NULL && ctx != NULL) {
-        if (wolfSSL_CTX_use_certificate_buffer(ctx, der, derSz,
-                                      WOLFSSL_FILETYPE_ASN1) == WOLFSSL_SUCCESS) {
-            return WOLFSSL_SUCCESS;
-        }
-
-    }
-    return WOLFSSL_FAILURE;
-}
-
-
-#if defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)
-/* Adds the rsa private key to the user ctx.
-Returns WOLFSSL_SUCCESS if no error, returns WOLFSSL_FAILURE otherwise.*/
-int wolfSSL_CTX_use_RSAPrivateKey(WOLFSSL_CTX* ctx, WOLFSSL_RSA* rsa)
-{
-    int ret;
-    int derSize;
-    unsigned char *maxDerBuf;
-    unsigned char* key = NULL;
-
-    WOLFSSL_ENTER("wolfSSL_CTX_use_RSAPrivateKey");
-
-    if (ctx == NULL || rsa == NULL) {
-        WOLFSSL_MSG("one or more inputs were NULL");
-        return BAD_FUNC_ARG;
-    }
-    maxDerBuf = (unsigned char*)XMALLOC(4096, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (maxDerBuf == NULL) {
-        WOLFSSL_MSG("Malloc failure");
-        return MEMORY_E;
-    }
-    key = maxDerBuf;
-    /* convert RSA struct to der encoded buffer and get the size */
-    if ((derSize = wolfSSL_i2d_RSAPrivateKey(rsa, &key)) <= 0) {
-        WOLFSSL_MSG("wolfSSL_i2d_RSAPrivateKey() failure");
-        XFREE(maxDerBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        return WOLFSSL_FAILURE;
-    }
-    ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx, (const unsigned char*)maxDerBuf,
-                                                    derSize, SSL_FILETYPE_ASN1);
-    if (ret != WOLFSSL_SUCCESS) {
-        WOLFSSL_MSG("wolfSSL_CTX_USE_PrivateKey_buffer() failure");
-        XFREE(maxDerBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        return WOLFSSL_FAILURE;
-    }
-    XFREE(maxDerBuf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    return ret;
-}
-#endif /* WOLFSSL_KEY_GEN && !NO_RSA */
-
 
 #ifndef NO_BIO
 /* Converts EVP_PKEY data from a bio buffer to a WOLFSSL_EVP_PKEY structure.
@@ -27909,7 +19766,8 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_bio(WOLFSSL_BIO* bio,
         int derLength;
 
         /* Determines key type and returns the new private EVP_PKEY object */
-        if ((key = wolfSSL_d2i_PrivateKey_EVP(NULL, &mem, (long)memSz)) == NULL) {
+        if ((key = wolfSSL_d2i_PrivateKey_EVP(NULL, &mem, (long)memSz)) ==
+                NULL) {
             WOLFSSL_MSG("wolfSSL_d2i_PrivateKey_EVP() failure");
             XFREE(mem, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
             return NULL;
@@ -27961,8 +19819,9 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_bio(WOLFSSL_BIO* bio,
 #endif /* OPENSSL_ALL || WOLFSSL_ASIO || WOLFSSL_HAPROXY || WOLFSSL_QT */
 
 
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_ASIO) || defined(WOLFSSL_HAPROXY) || \
-    defined(WOLFSSL_NGINX) || defined(WOLFSSL_QT) || defined(WOLFSSL_WPAS_SMALL)
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_ASIO) || \
+    defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_NGINX) || \
+    defined(WOLFSSL_QT) || defined(WOLFSSL_WPAS_SMALL)
 
 /* Converts a DER encoded private key to a WOLFSSL_EVP_PKEY structure.
  * returns a pointer to a new WOLFSSL_EVP_PKEY structure on success and NULL
@@ -27974,13 +19833,15 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PrivateKey_EVP(WOLFSSL_EVP_PKEY** out,
     return d2iGenericKey(out, (const unsigned char**)in, inSz, 1);
 }
 
-#endif /* OPENSSL_ALL || WOLFSSL_ASIO || WOLFSSL_HAPROXY || WOLFSSL_QT || WOLFSSL_WPAS_SMALL*/
+#endif /* OPENSSL_ALL || WOLFSSL_ASIO || WOLFSSL_HAPROXY || WOLFSSL_QT ||
+        * WOLFSSL_WPAS_SMALL*/
 
 
 /* stunnel compatibility functions*/
-#if defined(OPENSSL_ALL) || (defined(OPENSSL_EXTRA) && (defined(HAVE_STUNNEL) || \
-                             defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY) || \
-                             defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_OPENSSH)))
+#if defined(OPENSSL_ALL) || (defined(OPENSSL_EXTRA) && \
+    (defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
+     defined(HAVE_LIGHTY) || defined(WOLFSSL_HAPROXY) || \
+     defined(WOLFSSL_OPENSSH)))
 void wolfSSL_ERR_remove_thread_state(void* pid)
 {
     (void) pid;
@@ -27998,178 +19859,12 @@ void wolfSSL_print_all_errors_fp(XFILE fp)
 #endif /* OPENSSL_ALL || OPENSSL_EXTRA || HAVE_STUNNEL || WOLFSSL_NGINX ||
     HAVE_LIGHTY || WOLFSSL_HAPROXY || WOLFSSL_OPENSSH */
 
-
-#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL) || \
-    defined(HAVE_EX_DATA)
-
-#if defined(HAVE_EX_DATA) && !defined(NO_SESSION_CACHE)
-static void SESSION_ex_data_cache_update(WOLFSSL_SESSION* session, int idx,
-        void* data, byte get, void** getRet, int* setRet)
-{
-    int row;
-    int i;
-    int error = 0;
-    SessionRow* sessRow = NULL;
-    const byte* id;
-    byte foundCache = 0;
-
-    if (getRet != NULL)
-        *getRet = NULL;
-    if (setRet != NULL)
-        *setRet = WOLFSSL_FAILURE;
-
-    id = session->sessionID;
-    if (session->haveAltSessionID)
-        id = session->altSessionID;
-
-    row = (int)(HashObject(id, ID_LEN, &error) % SESSION_ROWS);
-    if (error != 0) {
-        WOLFSSL_MSG("Hash session failed");
-        return;
-    }
-
-    sessRow = &SessionCache[row];
-    if (get)
-        error = SESSION_ROW_RD_LOCK(sessRow);
-    else
-        error = SESSION_ROW_WR_LOCK(sessRow);
-    if (error != 0) {
-        WOLFSSL_MSG("Session row lock failed");
-        return;
-    }
-
-    for (i = 0; i < SESSIONS_PER_ROW && i < sessRow->totalCount; i++) {
-        WOLFSSL_SESSION* cacheSession;
-#ifdef SESSION_CACHE_DYNAMIC_MEM
-        cacheSession = sessRow->Sessions[i];
-#else
-        cacheSession = &sessRow->Sessions[i];
-#endif
-        if (cacheSession &&
-                XMEMCMP(id, cacheSession->sessionID, ID_LEN) == 0
-                && session->side == cacheSession->side
-        #if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)
-                && (IsAtLeastTLSv1_3(session->version) ==
-                    IsAtLeastTLSv1_3(cacheSession->version))
-        #endif
-            ) {
-            if (get) {
-                if (getRet) {
-                    *getRet = wolfSSL_CRYPTO_get_ex_data(
-                        &cacheSession->ex_data, idx);
-                }
-            }
-            else {
-                if (setRet) {
-                    *setRet = wolfSSL_CRYPTO_set_ex_data(
-                        &cacheSession->ex_data, idx, data);
-                }
-            }
-            foundCache = 1;
-            break;
-        }
-    }
-    SESSION_ROW_UNLOCK(sessRow);
-    /* If we don't have a session in cache then clear the ex_data and
-     * own it */
-    if (!foundCache) {
-        XMEMSET(&session->ex_data, 0, sizeof(WOLFSSL_CRYPTO_EX_DATA));
-        session->ownExData = 1;
-        if (!get) {
-            *setRet = wolfSSL_CRYPTO_set_ex_data(&session->ex_data, idx,
-                    data);
-        }
-    }
-
-}
-#endif
-
-int wolfSSL_SESSION_set_ex_data(WOLFSSL_SESSION* session, int idx, void* data)
-{
-    int ret = WOLFSSL_FAILURE;
-    WOLFSSL_ENTER("wolfSSL_SESSION_set_ex_data");
-#ifdef HAVE_EX_DATA
-    session = ClientSessionToSession(session);
-    if (session != NULL) {
-#ifndef NO_SESSION_CACHE
-        if (!session->ownExData) {
-            /* Need to update in cache */
-            SESSION_ex_data_cache_update(session, idx, data, 0, NULL, &ret);
-        }
-        else
-#endif
-        {
-            ret = wolfSSL_CRYPTO_set_ex_data(&session->ex_data, idx, data);
-        }
-    }
-#else
-    (void)session;
-    (void)idx;
-    (void)data;
-#endif
-    return ret;
-}
-
-#ifdef HAVE_EX_DATA_CLEANUP_HOOKS
-int wolfSSL_SESSION_set_ex_data_with_cleanup(
-    WOLFSSL_SESSION* session,
-    int idx,
-    void* data,
-    wolfSSL_ex_data_cleanup_routine_t cleanup_routine)
-{
-    WOLFSSL_ENTER("wolfSSL_SESSION_set_ex_data_with_cleanup");
-    session = ClientSessionToSession(session);
-    if(session != NULL) {
-        return wolfSSL_CRYPTO_set_ex_data_with_cleanup(&session->ex_data, idx,
-                                                       data, cleanup_routine);
-    }
-    return WOLFSSL_FAILURE;
-}
-#endif /* HAVE_EX_DATA_CLEANUP_HOOKS */
-
-void* wolfSSL_SESSION_get_ex_data(const WOLFSSL_SESSION* session, int idx)
-{
-    void* ret = NULL;
-    WOLFSSL_ENTER("wolfSSL_SESSION_get_ex_data");
-#ifdef HAVE_EX_DATA
-    session = ClientSessionToSession(session);
-    if (session != NULL) {
-#ifndef NO_SESSION_CACHE
-        if (!session->ownExData) {
-            /* Need to retrieve the data from the session cache */
-            SESSION_ex_data_cache_update((WOLFSSL_SESSION*)session, idx, NULL,
-                                         1, &ret, NULL);
-        }
-        else
-#endif
-        {
-            ret = wolfSSL_CRYPTO_get_ex_data(&session->ex_data, idx);
-        }
-    }
-#else
-    (void)session;
-    (void)idx;
-#endif
-    return ret;
-}
-#endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL || HAVE_EX_DATA */
-
 /* Note: This is a huge section of API's - through
  *       wolfSSL_X509_OBJECT_get0_X509_CRL */
 #if defined(OPENSSL_ALL) || (defined(OPENSSL_EXTRA) && \
     (defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
     defined(HAVE_LIGHTY) || defined(WOLFSSL_HAPROXY) || \
     defined(WOLFSSL_OPENSSH) || defined(HAVE_SBLIM_SFCB)))
-#ifdef HAVE_EX_DATA
-int wolfSSL_SESSION_get_ex_new_index(long ctx_l,void* ctx_ptr,
-        WOLFSSL_CRYPTO_EX_new* new_func, WOLFSSL_CRYPTO_EX_dup* dup_func,
-        WOLFSSL_CRYPTO_EX_free* free_func)
-{
-    WOLFSSL_ENTER("wolfSSL_SESSION_get_ex_new_index");
-    return wolfssl_get_ex_new_index(WOLF_CRYPTO_EX_INDEX_SSL_SESSION, ctx_l,
-            ctx_ptr, new_func, dup_func, free_func);
-}
-#endif
 
 #if defined(USE_WOLFSSL_MEMORY) && !defined(WOLFSSL_DEBUG_MEMORY) && \
     !defined(WOLFSSL_STATIC_MEMORY)
@@ -28337,17 +20032,17 @@ int wolfSSL_set_tlsext_host_name(WOLFSSL* ssl, const char* host_name)
     return ret;
 }
 
-
-#ifndef NO_WOLFSSL_SERVER
+/* May be called by server to get the requested accepted name and by the client
+ * to get the requested name. */
 const char * wolfSSL_get_servername(WOLFSSL* ssl, byte type)
 {
     void * serverName = NULL;
     if (ssl == NULL)
         return NULL;
-    TLSX_SNI_GetRequest(ssl->extensions, type, &serverName);
+    TLSX_SNI_GetRequest(ssl->extensions, type, &serverName,
+            !wolfSSL_is_server(ssl));
     return (const char *)serverName;
 }
-#endif /* NO_WOLFSSL_SERVER */
 #endif /* HAVE_SNI */
 
 WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
@@ -28375,6 +20070,13 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
     if (ssl->ctx == ctx)
         return ssl->ctx;
 
+    if (ctx->suites == NULL) {
+        /* suites */
+        if (AllocateCtxSuites(ctx) != 0)
+            return NULL;
+        InitSSL_CTX_Suites(ctx);
+    }
+
     wolfSSL_RefInc(&ctx->ref, &ret);
 #ifdef WOLFSSL_REFCNT_ERROR_RETURN
     if (ret != 0) {
@@ -28396,7 +20098,22 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
 #ifdef WOLFSSL_TLS13
     ssl->buffers.certChainCnt = ctx->certChainCnt;
 #endif
+#ifndef WOLFSSL_BLIND_PRIVATE_KEY
     ssl->buffers.key      = ctx->privateKey;
+#else
+    if (ctx->privateKey != NULL) {
+        AllocCopyDer(&ssl->buffers.key, ctx->privateKey->buffer,
+            ctx->privateKey->length, ctx->privateKey->type,
+            ctx->privateKey->heap);
+        /* Blind the private key for the SSL with new random mask. */
+        wolfssl_priv_der_unblind(ssl->buffers.key, ctx->privateKeyMask);
+        ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.key,
+            &ssl->buffers.keyMask);
+        if (ret != 0) {
+            return ret;
+        }
+    }
+#endif
     ssl->buffers.keyType  = ctx->privateKeyType;
     ssl->buffers.keyId    = ctx->privateKeyId;
     ssl->buffers.keyLabel = ctx->privateKeyLabel;
@@ -28411,7 +20128,22 @@ WOLFSSL_CTX* wolfSSL_set_SSL_CTX(WOLFSSL* ssl, WOLFSSL_CTX* ctx)
     ssl->options.haveFalconSig    = ctx->haveFalconSig;
     ssl->options.haveDilithiumSig = ctx->haveDilithiumSig;
 #ifdef WOLFSSL_DUAL_ALG_CERTS
-    ssl->buffers.altKey     = ctx->altPrivateKey;
+#ifndef WOLFSSL_BLIND_PRIVATE_KEY
+    ssl->buffers.altKey   = ctx->altPrivateKey;
+#else
+    if (ctx->altPrivateKey != NULL) {
+        AllocCopyDer(&ssl->buffers.altkey, ctx->altPrivateKey->buffer,
+            ctx->altPrivateKey->length, ctx->altPrivateKey->type,
+            ctx->altPrivateKey->heap);
+        /* Blind the private key for the SSL with new random mask. */
+        wolfssl_priv_der_unblind(ssl->buffers.altKey, ctx->altPrivateKeyMask);
+        ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.altKey,
+            &ssl->buffers.altKeyMask);
+        if (ret != 0) {
+            return ret;
+        }
+    }
+#endif
     ssl->buffers.altKeySz   = ctx->altPrivateKeySz;
     ssl->buffers.altKeyType = ctx->altPrivateKeyType;
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
@@ -28435,16 +20167,9 @@ VerifyCallback wolfSSL_CTX_get_verify_callback(WOLFSSL_CTX* ctx)
     return NULL;
 }
 
-
 #ifdef HAVE_SNI
-
-void wolfSSL_CTX_set_servername_callback(WOLFSSL_CTX* ctx, CallbackSniRecv cb)
-{
-    WOLFSSL_ENTER("wolfSSL_CTX_set_servername_callback");
-    if (ctx)
-        ctx->sniRecvCb = cb;
-}
-
+/* this is a compatibily function, consider using
+ * wolfSSL_CTX_set_servername_callback */
 int wolfSSL_CTX_set_tlsext_servername_callback(WOLFSSL_CTX* ctx,
                                                CallbackSniRecv cb)
 {
@@ -28456,18 +20181,7 @@ int wolfSSL_CTX_set_tlsext_servername_callback(WOLFSSL_CTX* ctx,
     return WOLFSSL_FAILURE;
 }
 
-int wolfSSL_CTX_set_servername_arg(WOLFSSL_CTX* ctx, void* arg)
-{
-    WOLFSSL_ENTER("wolfSSL_CTX_set_servername_arg");
-    if (ctx) {
-        ctx->sniRecvCbArg = arg;
-        return WOLFSSL_SUCCESS;
-    }
-    return WOLFSSL_FAILURE;
-}
-
 #endif /* HAVE_SNI */
-
 
 #ifndef NO_BIO
 void wolfSSL_ERR_load_BIO_strings(void) {
@@ -28503,6 +20217,27 @@ void wolfSSL_THREADID_set_numeric(void* id, unsigned long val)
         * HAVE_LIGHTY || WOLFSSL_HAPROXY || WOLFSSL_OPENSSH ||
         * HAVE_SBLIM_SFCB)) */
 
+#ifdef HAVE_SNI
+
+void wolfSSL_CTX_set_servername_callback(WOLFSSL_CTX* ctx, CallbackSniRecv cb)
+{
+    WOLFSSL_ENTER("wolfSSL_CTX_set_servername_callback");
+    if (ctx)
+        ctx->sniRecvCb = cb;
+}
+
+
+int wolfSSL_CTX_set_servername_arg(WOLFSSL_CTX* ctx, void* arg)
+{
+    WOLFSSL_ENTER("wolfSSL_CTX_set_servername_arg");
+    if (ctx) {
+        ctx->sniRecvCbArg = arg;
+        return WOLFSSL_SUCCESS;
+    }
+    return WOLFSSL_FAILURE;
+}
+
+#endif /* HAVE_SNI */
 
 #if defined(OPENSSL_EXTRA)
 
@@ -28574,225 +20309,11 @@ int wolfSSL_version(WOLFSSL* ssl)
     return WOLFSSL_FAILURE;
 }
 
-WOLFSSL_CTX* wolfSSL_get_SSL_CTX(WOLFSSL* ssl)
+WOLFSSL_CTX* wolfSSL_get_SSL_CTX(const WOLFSSL* ssl)
 {
     WOLFSSL_ENTER("wolfSSL_get_SSL_CTX");
     return ssl->ctx;
 }
-
-#if defined(OPENSSL_ALL) || \
-    defined(OPENSSL_EXTRA) || defined(HAVE_STUNNEL) || \
-    defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
-
-const byte* wolfSSL_SESSION_get_id(const WOLFSSL_SESSION* sess,
-        unsigned int* idLen)
-{
-    WOLFSSL_ENTER("wolfSSL_SESSION_get_id");
-    sess = ClientSessionToSession(sess);
-    if (sess == NULL || idLen == NULL) {
-        WOLFSSL_MSG("Bad func args. Please provide idLen");
-        return NULL;
-    }
-#ifdef HAVE_SESSION_TICKET
-    if (sess->haveAltSessionID) {
-        *idLen = ID_LEN;
-        return sess->altSessionID;
-    }
-#endif
-    *idLen = sess->sessionIDSz;
-    return sess->sessionID;
-}
-
-#if (defined(HAVE_SESSION_TICKET) || defined(SESSION_CERTS)) && \
-    !defined(NO_FILESYSTEM)
-
-#ifndef NO_BIO
-
-#if defined(SESSION_CERTS) || \
-   (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
-/* returns a pointer to the protocol used by the session */
-static const char* wolfSSL_SESSION_get_protocol(const WOLFSSL_SESSION* in)
-{
-    in = ClientSessionToSession(in);
-    return wolfSSL_internal_get_version((ProtocolVersion*)&in->version);
-}
-#endif
-
-/* returns true (non 0) if the session has EMS (extended master secret) */
-static int wolfSSL_SESSION_haveEMS(const WOLFSSL_SESSION* in)
-{
-    in = ClientSessionToSession(in);
-    if (in == NULL)
-        return 0;
-    return in->haveEMS;
-}
-
-#if defined(HAVE_SESSION_TICKET)
-/* prints out the ticket to bio passed in
- * return WOLFSSL_SUCCESS on success
- */
-static int wolfSSL_SESSION_print_ticket(WOLFSSL_BIO* bio,
-        const WOLFSSL_SESSION* in, const char* tab)
-{
-    unsigned short i, j, z, sz;
-    short tag = 0;
-    byte* pt;
-
-
-    in = ClientSessionToSession(in);
-    if (in == NULL || bio == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-    sz = in->ticketLen;
-    pt = in->ticket;
-
-    if (wolfSSL_BIO_printf(bio, "%s\n", (sz == 0)? " NONE": "") <= 0)
-        return WOLFSSL_FAILURE;
-
-    for (i = 0; i < sz;) {
-        char asc[16];
-        XMEMSET(asc, 0, sizeof(asc));
-
-        if (sz - i < 16) {
-            if (wolfSSL_BIO_printf(bio, "%s%04X -", tab, tag + (sz - i)) <= 0)
-                return WOLFSSL_FAILURE;
-        }
-        else {
-            if (wolfSSL_BIO_printf(bio, "%s%04X -", tab, tag) <= 0)
-                return WOLFSSL_FAILURE;
-        }
-        for (j = 0; i < sz && j < 8; j++,i++) {
-            asc[j] =  ((pt[i])&0x6f)>='A'?((pt[i])&0x6f):'.';
-            if (wolfSSL_BIO_printf(bio, " %02X", pt[i]) <= 0)
-                return WOLFSSL_FAILURE;
-        }
-
-        if (i < sz) {
-            asc[j] =  ((pt[i])&0x6f)>='A'?((pt[i])&0x6f):'.';
-            if (wolfSSL_BIO_printf(bio, "-%02X", pt[i]) <= 0)
-                return WOLFSSL_FAILURE;
-            j++;
-            i++;
-        }
-
-        for (; i < sz && j < 16; j++,i++) {
-            asc[j] =  ((pt[i])&0x6f)>='A'?((pt[i])&0x6f):'.';
-            if (wolfSSL_BIO_printf(bio, " %02X", pt[i]) <= 0)
-                return WOLFSSL_FAILURE;
-        }
-
-        /* pad out spacing */
-        for (z = j; z < 17; z++) {
-            if (wolfSSL_BIO_printf(bio, "   ") <= 0)
-                return WOLFSSL_FAILURE;
-        }
-
-        for (z = 0; z < j; z++) {
-            if (wolfSSL_BIO_printf(bio, "%c", asc[z]) <= 0)
-                return WOLFSSL_FAILURE;
-        }
-        if (wolfSSL_BIO_printf(bio, "\n") <= 0)
-            return WOLFSSL_FAILURE;
-
-        tag += 16;
-    }
-    return WOLFSSL_SUCCESS;
-}
-#endif /* HAVE_SESSION_TICKET */
-
-
-/* prints out the session information in human readable form
- * return WOLFSSL_SUCCESS on success
- */
-int wolfSSL_SESSION_print(WOLFSSL_BIO *bp, const WOLFSSL_SESSION *session)
-{
-    const unsigned char* pt;
-    unsigned char buf[SECRET_LEN];
-    unsigned int sz = 0, i;
-    int ret;
-
-    session = ClientSessionToSession(session);
-    if (session == NULL) {
-        return WOLFSSL_FAILURE;
-    }
-
-    if (wolfSSL_BIO_printf(bp, "%s\n", "SSL-Session:") <= 0)
-        return WOLFSSL_FAILURE;
-
-#if defined(SESSION_CERTS) || (defined(WOLFSSL_TLS13) && \
-                               defined(HAVE_SESSION_TICKET))
-    if (wolfSSL_BIO_printf(bp, "    Protocol  : %s\n",
-            wolfSSL_SESSION_get_protocol(session)) <= 0)
-        return WOLFSSL_FAILURE;
-#endif
-
-    if (wolfSSL_BIO_printf(bp, "    Cipher    : %s\n",
-            wolfSSL_SESSION_CIPHER_get_name(session)) <= 0)
-        return WOLFSSL_FAILURE;
-
-    pt = wolfSSL_SESSION_get_id(session, &sz);
-    if (wolfSSL_BIO_printf(bp, "    Session-ID: ") <= 0)
-        return WOLFSSL_FAILURE;
-
-    for (i = 0; i < sz; i++) {
-        if (wolfSSL_BIO_printf(bp, "%02X", pt[i]) <= 0)
-            return WOLFSSL_FAILURE;
-    }
-    if (wolfSSL_BIO_printf(bp, "\n") <= 0)
-        return WOLFSSL_FAILURE;
-
-    if (wolfSSL_BIO_printf(bp, "    Session-ID-ctx: \n") <= 0)
-        return WOLFSSL_FAILURE;
-
-    ret = wolfSSL_SESSION_get_master_key(session, buf, sizeof(buf));
-    if (wolfSSL_BIO_printf(bp, "    Master-Key: ") <= 0)
-        return WOLFSSL_FAILURE;
-
-    if (ret > 0) {
-        sz = (unsigned int)ret;
-        for (i = 0; i < sz; i++) {
-            if (wolfSSL_BIO_printf(bp, "%02X", buf[i]) <= 0)
-                return WOLFSSL_FAILURE;
-        }
-    }
-    if (wolfSSL_BIO_printf(bp, "\n") <= 0)
-        return WOLFSSL_FAILURE;
-
-    /* @TODO PSK identity hint and SRP */
-
-    if (wolfSSL_BIO_printf(bp, "    TLS session ticket:") <= 0)
-        return WOLFSSL_FAILURE;
-
-#ifdef HAVE_SESSION_TICKET
-    if (wolfSSL_SESSION_print_ticket(bp, session, "    ") != WOLFSSL_SUCCESS)
-        return WOLFSSL_FAILURE;
-#endif
-
-#if !defined(NO_SESSION_CACHE) && (defined(OPENSSL_EXTRA) || \
-        defined(HAVE_EXT_CACHE))
-    if (wolfSSL_BIO_printf(bp, "    Start Time: %ld\n",
-                wolfSSL_SESSION_get_time(session)) <= 0)
-        return WOLFSSL_FAILURE;
-
-    if (wolfSSL_BIO_printf(bp, "    Timeout   : %ld (sec)\n",
-            wolfSSL_SESSION_get_timeout(session)) <= 0)
-        return WOLFSSL_FAILURE;
-#endif /* !NO_SESSION_CACHE && OPENSSL_EXTRA || HAVE_EXT_CACHE */
-
-    /* @TODO verify return code print */
-
-    if (wolfSSL_BIO_printf(bp, "    Extended master secret: %s\n",
-            (wolfSSL_SESSION_haveEMS(session) == 0)? "no" : "yes") <= 0)
-        return WOLFSSL_FAILURE;
-
-    return WOLFSSL_SUCCESS;
-}
-
-#endif /* !NO_BIO */
-#endif /* (HAVE_SESSION_TICKET || SESSION_CERTS) && !NO_FILESYSTEM */
-
-#endif /* OPENSSL_ALL || OPENSSL_EXTRA || HAVE_STUNNEL || WOLFSSL_NGINX || WOLFSSL_HAPROXY */
 
 #if defined(OPENSSL_ALL) || (defined(OPENSSL_EXTRA) && defined(HAVE_STUNNEL)) \
     || defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(WOLFSSL_NGINX)
@@ -28864,709 +20385,6 @@ int wolfSSL_CTX_get_verify_mode(const WOLFSSL_CTX* ctx)
 }
 
 #endif
-#if defined(OPENSSL_EXTRA) && defined(HAVE_CURVE25519)
-/* return 1 if success, 0 if error
- * output keys are little endian format
- */
-int wolfSSL_EC25519_generate_key(unsigned char *priv, unsigned int *privSz,
-                                 unsigned char *pub, unsigned int *pubSz)
-{
-#ifndef WOLFSSL_KEY_GEN
-    WOLFSSL_MSG("No Key Gen built in");
-    (void) priv;
-    (void) privSz;
-    (void) pub;
-    (void) pubSz;
-    return WOLFSSL_FAILURE;
-#else /* WOLFSSL_KEY_GEN */
-    int ret = WOLFSSL_FAILURE;
-    int initTmpRng = 0;
-    WC_RNG *rng = NULL;
-#ifdef WOLFSSL_SMALL_STACK
-    WC_RNG *tmpRNG = NULL;
-#else
-    WC_RNG tmpRNG[1];
-#endif
-
-    WOLFSSL_ENTER("wolfSSL_EC25519_generate_key");
-
-    if (priv == NULL || privSz == NULL || *privSz < CURVE25519_KEYSIZE ||
-        pub == NULL || pubSz == NULL || *pubSz < CURVE25519_KEYSIZE) {
-        WOLFSSL_MSG("Bad arguments");
-        return WOLFSSL_FAILURE;
-    }
-
-#ifdef WOLFSSL_SMALL_STACK
-    tmpRNG = (WC_RNG*)XMALLOC(sizeof(WC_RNG), NULL, DYNAMIC_TYPE_RNG);
-    if (tmpRNG == NULL)
-        return WOLFSSL_FAILURE;
-#endif
-    if (wc_InitRng(tmpRNG) == 0) {
-        rng = tmpRNG;
-        initTmpRng = 1;
-    }
-    else {
-        WOLFSSL_MSG("Bad RNG Init, trying global");
-        if (initGlobalRNG == 0)
-            WOLFSSL_MSG("Global RNG no Init");
-        else
-            rng = &globalRNG;
-    }
-
-    if (rng) {
-        curve25519_key key;
-
-        if (wc_curve25519_init(&key) != MP_OKAY)
-            WOLFSSL_MSG("wc_curve25519_init failed");
-        else if (wc_curve25519_make_key(rng, CURVE25519_KEYSIZE, &key)!=MP_OKAY)
-            WOLFSSL_MSG("wc_curve25519_make_key failed");
-        /* export key pair */
-        else if (wc_curve25519_export_key_raw_ex(&key, priv, privSz, pub,
-                                                 pubSz, EC25519_LITTLE_ENDIAN)
-                 != MP_OKAY)
-            WOLFSSL_MSG("wc_curve25519_export_key_raw_ex failed");
-        else
-            ret = WOLFSSL_SUCCESS;
-
-        wc_curve25519_free(&key);
-    }
-
-    if (initTmpRng)
-        wc_FreeRng(tmpRNG);
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(tmpRNG, NULL, DYNAMIC_TYPE_RNG);
-#endif
-
-    return ret;
-#endif /* WOLFSSL_KEY_GEN */
-}
-
-/* return 1 if success, 0 if error
- * input and output keys are little endian format
- */
-int wolfSSL_EC25519_shared_key(unsigned char *shared, unsigned int *sharedSz,
-                               const unsigned char *priv, unsigned int privSz,
-                               const unsigned char *pub, unsigned int pubSz)
-{
-#ifndef WOLFSSL_KEY_GEN
-    WOLFSSL_MSG("No Key Gen built in");
-    (void) shared;
-    (void) sharedSz;
-    (void) priv;
-    (void) privSz;
-    (void) pub;
-    (void) pubSz;
-    return WOLFSSL_FAILURE;
-#else /* WOLFSSL_KEY_GEN */
-    int ret = WOLFSSL_FAILURE;
-    curve25519_key privkey, pubkey;
-
-    WOLFSSL_ENTER("wolfSSL_EC25519_shared_key");
-
-    if (shared == NULL || sharedSz == NULL || *sharedSz < CURVE25519_KEYSIZE ||
-        priv == NULL || privSz < CURVE25519_KEYSIZE ||
-        pub == NULL || pubSz < CURVE25519_KEYSIZE) {
-        WOLFSSL_MSG("Bad arguments");
-        return WOLFSSL_FAILURE;
-    }
-
-    /* import private key */
-    if (wc_curve25519_init(&privkey) != MP_OKAY) {
-        WOLFSSL_MSG("wc_curve25519_init privkey failed");
-        return ret;
-    }
-    if (wc_curve25519_import_private_ex(priv, privSz, &privkey,
-                                        EC25519_LITTLE_ENDIAN) != MP_OKAY) {
-        WOLFSSL_MSG("wc_curve25519_import_private_ex failed");
-        wc_curve25519_free(&privkey);
-        return ret;
-    }
-
-    /* import public key */
-    if (wc_curve25519_init(&pubkey) != MP_OKAY) {
-        WOLFSSL_MSG("wc_curve25519_init pubkey failed");
-        wc_curve25519_free(&privkey);
-        return ret;
-    }
-    if (wc_curve25519_import_public_ex(pub, pubSz, &pubkey,
-                                       EC25519_LITTLE_ENDIAN) != MP_OKAY) {
-        WOLFSSL_MSG("wc_curve25519_import_public_ex failed");
-        wc_curve25519_free(&privkey);
-        wc_curve25519_free(&pubkey);
-        return ret;
-    }
-
-    if (wc_curve25519_shared_secret_ex(&privkey, &pubkey,
-                                       shared, sharedSz,
-                                       EC25519_LITTLE_ENDIAN) != MP_OKAY)
-        WOLFSSL_MSG("wc_curve25519_shared_secret_ex failed");
-    else
-        ret = WOLFSSL_SUCCESS;
-
-    wc_curve25519_free(&privkey);
-    wc_curve25519_free(&pubkey);
-
-    return ret;
-#endif /* WOLFSSL_KEY_GEN */
-}
-#endif /* OPENSSL_EXTRA && HAVE_CURVE25519 */
-
-#if defined(OPENSSL_EXTRA) && defined(HAVE_ED25519)
-/* return 1 if success, 0 if error
- * output keys are little endian format
- */
-int wolfSSL_ED25519_generate_key(unsigned char *priv, unsigned int *privSz,
-                                 unsigned char *pub, unsigned int *pubSz)
-{
-#ifndef WOLFSSL_KEY_GEN
-    WOLFSSL_MSG("No Key Gen built in");
-    (void) priv;
-    (void) privSz;
-    (void) pub;
-    (void) pubSz;
-    return WOLFSSL_FAILURE;
-#elif !defined(HAVE_ED25519_KEY_EXPORT)
-    WOLFSSL_MSG("No ED25519 key export built in");
-    (void) priv;
-    (void) privSz;
-    (void) pub;
-    (void) pubSz;
-    return WOLFSSL_FAILURE;
-#else /* WOLFSSL_KEY_GEN && HAVE_ED25519_KEY_EXPORT */
-    int ret = WOLFSSL_FAILURE;
-    int initTmpRng = 0;
-    WC_RNG *rng = NULL;
-#ifdef WOLFSSL_SMALL_STACK
-    WC_RNG *tmpRNG = NULL;
-#else
-    WC_RNG tmpRNG[1];
-#endif
-
-    WOLFSSL_ENTER("wolfSSL_ED25519_generate_key");
-
-    if (priv == NULL || privSz == NULL || *privSz < ED25519_PRV_KEY_SIZE ||
-        pub == NULL || pubSz == NULL || *pubSz < ED25519_PUB_KEY_SIZE) {
-        WOLFSSL_MSG("Bad arguments");
-        return WOLFSSL_FAILURE;
-    }
-
-#ifdef WOLFSSL_SMALL_STACK
-    tmpRNG = (WC_RNG*)XMALLOC(sizeof(WC_RNG), NULL, DYNAMIC_TYPE_RNG);
-    if (tmpRNG == NULL)
-        return WOLFSSL_FATAL_ERROR;
-#endif
-    if (wc_InitRng(tmpRNG) == 0) {
-        rng = tmpRNG;
-        initTmpRng = 1;
-    }
-    else {
-        WOLFSSL_MSG("Bad RNG Init, trying global");
-        if (initGlobalRNG == 0)
-            WOLFSSL_MSG("Global RNG no Init");
-        else
-            rng = &globalRNG;
-    }
-
-    if (rng) {
-        ed25519_key key;
-
-        if (wc_ed25519_init(&key) != MP_OKAY)
-            WOLFSSL_MSG("wc_ed25519_init failed");
-        else if (wc_ed25519_make_key(rng, ED25519_KEY_SIZE, &key)!=MP_OKAY)
-            WOLFSSL_MSG("wc_ed25519_make_key failed");
-        /* export private key */
-        else if (wc_ed25519_export_key(&key, priv, privSz, pub, pubSz)!=MP_OKAY)
-            WOLFSSL_MSG("wc_ed25519_export_key failed");
-        else
-            ret = WOLFSSL_SUCCESS;
-
-        wc_ed25519_free(&key);
-    }
-
-    if (initTmpRng)
-        wc_FreeRng(tmpRNG);
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(tmpRNG, NULL, DYNAMIC_TYPE_RNG);
-#endif
-
-    return ret;
-#endif /* WOLFSSL_KEY_GEN && HAVE_ED25519_KEY_EXPORT */
-}
-
-/* return 1 if success, 0 if error
- * input and output keys are little endian format
- * priv is a buffer containing private and public part of key
- */
-int wolfSSL_ED25519_sign(const unsigned char *msg, unsigned int msgSz,
-                         const unsigned char *priv, unsigned int privSz,
-                         unsigned char *sig, unsigned int *sigSz)
-{
-#if !defined(HAVE_ED25519_SIGN) || !defined(WOLFSSL_KEY_GEN) || !defined(HAVE_ED25519_KEY_IMPORT)
-#if !defined(HAVE_ED25519_SIGN)
-    WOLFSSL_MSG("No ED25519 sign built in");
-#elif !defined(WOLFSSL_KEY_GEN)
-     WOLFSSL_MSG("No Key Gen built in");
-#elif !defined(HAVE_ED25519_KEY_IMPORT)
-     WOLFSSL_MSG("No ED25519 Key import built in");
-#endif
-    (void) msg;
-    (void) msgSz;
-    (void) priv;
-    (void) privSz;
-    (void) sig;
-    (void) sigSz;
-    return WOLFSSL_FAILURE;
-#else /* HAVE_ED25519_SIGN && WOLFSSL_KEY_GEN && HAVE_ED25519_KEY_IMPORT */
-    ed25519_key key;
-    int ret = WOLFSSL_FAILURE;
-
-    WOLFSSL_ENTER("wolfSSL_ED25519_sign");
-
-    if (priv == NULL || privSz != ED25519_PRV_KEY_SIZE ||
-        msg == NULL || sig == NULL || *sigSz < ED25519_SIG_SIZE) {
-        WOLFSSL_MSG("Bad arguments");
-        return WOLFSSL_FAILURE;
-    }
-
-    /* import key */
-    if (wc_ed25519_init(&key) != MP_OKAY) {
-        WOLFSSL_MSG("wc_curve25519_init failed");
-        return ret;
-    }
-    if (wc_ed25519_import_private_key(priv, privSz/2,
-                                      priv+(privSz/2), ED25519_PUB_KEY_SIZE,
-                                      &key) != MP_OKAY){
-        WOLFSSL_MSG("wc_ed25519_import_private failed");
-        wc_ed25519_free(&key);
-        return ret;
-    }
-
-    if (wc_ed25519_sign_msg(msg, msgSz, sig, sigSz, &key) != MP_OKAY)
-        WOLFSSL_MSG("wc_curve25519_shared_secret_ex failed");
-    else
-        ret = WOLFSSL_SUCCESS;
-
-    wc_ed25519_free(&key);
-
-    return ret;
-#endif /* HAVE_ED25519_SIGN && WOLFSSL_KEY_GEN && HAVE_ED25519_KEY_IMPORT */
-}
-
-/* return 1 if success, 0 if error
- * input and output keys are little endian format
- * pub is a buffer containing public part of key
- */
-int wolfSSL_ED25519_verify(const unsigned char *msg, unsigned int msgSz,
-                           const unsigned char *pub, unsigned int pubSz,
-                           const unsigned char *sig, unsigned int sigSz)
-{
-#if !defined(HAVE_ED25519_VERIFY) || !defined(WOLFSSL_KEY_GEN) || !defined(HAVE_ED25519_KEY_IMPORT)
-#if !defined(HAVE_ED25519_VERIFY)
-    WOLFSSL_MSG("No ED25519 verify built in");
-#elif !defined(WOLFSSL_KEY_GEN)
-     WOLFSSL_MSG("No Key Gen built in");
-#elif !defined(HAVE_ED25519_KEY_IMPORT)
-     WOLFSSL_MSG("No ED25519 Key import built in");
-#endif
-    (void) msg;
-    (void) msgSz;
-    (void) pub;
-    (void) pubSz;
-    (void) sig;
-    (void) sigSz;
-    return WOLFSSL_FAILURE;
-#else /* HAVE_ED25519_VERIFY && WOLFSSL_KEY_GEN && HAVE_ED25519_KEY_IMPORT */
-    ed25519_key key;
-    int ret = WOLFSSL_FAILURE, check = 0;
-
-    WOLFSSL_ENTER("wolfSSL_ED25519_verify");
-
-    if (pub == NULL || pubSz != ED25519_PUB_KEY_SIZE ||
-        msg == NULL || sig == NULL || sigSz != ED25519_SIG_SIZE) {
-        WOLFSSL_MSG("Bad arguments");
-        return WOLFSSL_FAILURE;
-    }
-
-    /* import key */
-    if (wc_ed25519_init(&key) != MP_OKAY) {
-        WOLFSSL_MSG("wc_curve25519_init failed");
-        return ret;
-    }
-    if (wc_ed25519_import_public(pub, pubSz, &key) != MP_OKAY){
-        WOLFSSL_MSG("wc_ed25519_import_public failed");
-        wc_ed25519_free(&key);
-        return ret;
-    }
-
-    if ((ret = wc_ed25519_verify_msg((byte*)sig, sigSz, msg, msgSz,
-                                     &check, &key)) != MP_OKAY) {
-        WOLFSSL_MSG("wc_ed25519_verify_msg failed");
-    }
-    else if (!check)
-        WOLFSSL_MSG("wc_ed25519_verify_msg failed (signature invalid)");
-    else
-        ret = WOLFSSL_SUCCESS;
-
-    wc_ed25519_free(&key);
-
-    return ret;
-#endif /* HAVE_ED25519_VERIFY && WOLFSSL_KEY_GEN && HAVE_ED25519_KEY_IMPORT */
-}
-
-#endif /* OPENSSL_EXTRA && HAVE_ED25519 */
-
-#if defined(OPENSSL_EXTRA) && defined(HAVE_CURVE448)
-/* return 1 if success, 0 if error
- * output keys are little endian format
- */
-int wolfSSL_EC448_generate_key(unsigned char *priv, unsigned int *privSz,
-                               unsigned char *pub, unsigned int *pubSz)
-{
-#ifndef WOLFSSL_KEY_GEN
-    WOLFSSL_MSG("No Key Gen built in");
-    (void) priv;
-    (void) privSz;
-    (void) pub;
-    (void) pubSz;
-    return WOLFSSL_FAILURE;
-#else /* WOLFSSL_KEY_GEN */
-    int ret = WOLFSSL_FAILURE;
-    int initTmpRng = 0;
-    WC_RNG *rng = NULL;
-#ifdef WOLFSSL_SMALL_STACK
-    WC_RNG *tmpRNG = NULL;
-#else
-    WC_RNG tmpRNG[1];
-#endif
-
-    WOLFSSL_ENTER("wolfSSL_EC448_generate_key");
-
-    if (priv == NULL || privSz == NULL || *privSz < CURVE448_KEY_SIZE ||
-        pub == NULL || pubSz == NULL || *pubSz < CURVE448_KEY_SIZE) {
-        WOLFSSL_MSG("Bad arguments");
-        return WOLFSSL_FAILURE;
-    }
-
-#ifdef WOLFSSL_SMALL_STACK
-    tmpRNG = (WC_RNG*)XMALLOC(sizeof(WC_RNG), NULL, DYNAMIC_TYPE_RNG);
-    if (tmpRNG == NULL)
-        return WOLFSSL_FAILURE;
-#endif
-    if (wc_InitRng(tmpRNG) == 0) {
-        rng = tmpRNG;
-        initTmpRng = 1;
-    }
-    else {
-        WOLFSSL_MSG("Bad RNG Init, trying global");
-        if (initGlobalRNG == 0)
-            WOLFSSL_MSG("Global RNG no Init");
-        else
-            rng = &globalRNG;
-    }
-
-    if (rng) {
-        curve448_key key;
-
-        if (wc_curve448_init(&key) != MP_OKAY)
-            WOLFSSL_MSG("wc_curve448_init failed");
-        else if (wc_curve448_make_key(rng, CURVE448_KEY_SIZE, &key)!=MP_OKAY)
-            WOLFSSL_MSG("wc_curve448_make_key failed");
-        /* export key pair */
-        else if (wc_curve448_export_key_raw_ex(&key, priv, privSz, pub, pubSz,
-                                               EC448_LITTLE_ENDIAN)
-                 != MP_OKAY)
-            WOLFSSL_MSG("wc_curve448_export_key_raw_ex failed");
-        else
-            ret = WOLFSSL_SUCCESS;
-
-        wc_curve448_free(&key);
-    }
-
-    if (initTmpRng)
-        wc_FreeRng(tmpRNG);
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(tmpRNG, NULL, DYNAMIC_TYPE_RNG);
-#endif
-
-    return ret;
-#endif /* WOLFSSL_KEY_GEN */
-}
-
-/* return 1 if success, 0 if error
- * input and output keys are little endian format
- */
-int wolfSSL_EC448_shared_key(unsigned char *shared, unsigned int *sharedSz,
-                             const unsigned char *priv, unsigned int privSz,
-                             const unsigned char *pub, unsigned int pubSz)
-{
-#ifndef WOLFSSL_KEY_GEN
-    WOLFSSL_MSG("No Key Gen built in");
-    (void) shared;
-    (void) sharedSz;
-    (void) priv;
-    (void) privSz;
-    (void) pub;
-    (void) pubSz;
-    return WOLFSSL_FAILURE;
-#else /* WOLFSSL_KEY_GEN */
-    int ret = WOLFSSL_FAILURE;
-    curve448_key privkey, pubkey;
-
-    WOLFSSL_ENTER("wolfSSL_EC448_shared_key");
-
-    if (shared == NULL || sharedSz == NULL || *sharedSz < CURVE448_KEY_SIZE ||
-            priv == NULL || privSz < CURVE448_KEY_SIZE ||
-            pub == NULL || pubSz < CURVE448_KEY_SIZE) {
-        WOLFSSL_MSG("Bad arguments");
-        return WOLFSSL_FAILURE;
-    }
-
-    /* import private key */
-    if (wc_curve448_init(&privkey) != MP_OKAY) {
-        WOLFSSL_MSG("wc_curve448_init privkey failed");
-        return ret;
-    }
-    if (wc_curve448_import_private_ex(priv, privSz, &privkey,
-                                      EC448_LITTLE_ENDIAN) != MP_OKAY) {
-        WOLFSSL_MSG("wc_curve448_import_private_ex failed");
-        wc_curve448_free(&privkey);
-        return ret;
-    }
-
-    /* import public key */
-    if (wc_curve448_init(&pubkey) != MP_OKAY) {
-        WOLFSSL_MSG("wc_curve448_init pubkey failed");
-        wc_curve448_free(&privkey);
-        return ret;
-    }
-    if (wc_curve448_import_public_ex(pub, pubSz, &pubkey,
-                                     EC448_LITTLE_ENDIAN) != MP_OKAY) {
-        WOLFSSL_MSG("wc_curve448_import_public_ex failed");
-        wc_curve448_free(&privkey);
-        wc_curve448_free(&pubkey);
-        return ret;
-    }
-
-    if (wc_curve448_shared_secret_ex(&privkey, &pubkey, shared, sharedSz,
-                                     EC448_LITTLE_ENDIAN) != MP_OKAY)
-        WOLFSSL_MSG("wc_curve448_shared_secret_ex failed");
-    else
-        ret = WOLFSSL_SUCCESS;
-
-    wc_curve448_free(&privkey);
-    wc_curve448_free(&pubkey);
-
-    return ret;
-#endif /* WOLFSSL_KEY_GEN */
-}
-#endif /* OPENSSL_EXTRA && HAVE_CURVE448 */
-
-#if defined(OPENSSL_EXTRA) && defined(HAVE_ED448)
-/* return 1 if success, 0 if error
- * output keys are little endian format
- */
-int wolfSSL_ED448_generate_key(unsigned char *priv, unsigned int *privSz,
-                               unsigned char *pub, unsigned int *pubSz)
-{
-#ifndef WOLFSSL_KEY_GEN
-    WOLFSSL_MSG("No Key Gen built in");
-    (void) priv;
-    (void) privSz;
-    (void) pub;
-    (void) pubSz;
-    return WOLFSSL_FAILURE;
-#elif !defined(HAVE_ED448_KEY_EXPORT)
-    WOLFSSL_MSG("No ED448 key export built in");
-    (void) priv;
-    (void) privSz;
-    (void) pub;
-    (void) pubSz;
-    return WOLFSSL_FAILURE;
-#else /* WOLFSSL_KEY_GEN && HAVE_ED448_KEY_EXPORT */
-    int ret = WOLFSSL_FAILURE;
-    int initTmpRng = 0;
-    WC_RNG *rng = NULL;
-#ifdef WOLFSSL_SMALL_STACK
-    WC_RNG *tmpRNG = NULL;
-#else
-    WC_RNG tmpRNG[1];
-#endif
-
-    WOLFSSL_ENTER("wolfSSL_ED448_generate_key");
-
-    if (priv == NULL || privSz == NULL || *privSz < ED448_PRV_KEY_SIZE ||
-            pub == NULL || pubSz == NULL || *pubSz < ED448_PUB_KEY_SIZE) {
-        WOLFSSL_MSG("Bad arguments");
-        return WOLFSSL_FAILURE;
-    }
-
-#ifdef WOLFSSL_SMALL_STACK
-    tmpRNG = (WC_RNG*)XMALLOC(sizeof(WC_RNG), NULL, DYNAMIC_TYPE_RNG);
-    if (tmpRNG == NULL)
-        return WOLFSSL_FATAL_ERROR;
-#endif
-    if (wc_InitRng(tmpRNG) == 0) {
-        rng = tmpRNG;
-        initTmpRng = 1;
-    }
-    else {
-        WOLFSSL_MSG("Bad RNG Init, trying global");
-        if (initGlobalRNG == 0)
-            WOLFSSL_MSG("Global RNG no Init");
-        else
-            rng = &globalRNG;
-    }
-
-    if (rng) {
-        ed448_key key;
-
-        if (wc_ed448_init(&key) != MP_OKAY)
-            WOLFSSL_MSG("wc_ed448_init failed");
-        else if (wc_ed448_make_key(rng, ED448_KEY_SIZE, &key) != MP_OKAY)
-            WOLFSSL_MSG("wc_ed448_make_key failed");
-        /* export private key */
-        else if (wc_ed448_export_key(&key, priv, privSz, pub, pubSz) != MP_OKAY)
-            WOLFSSL_MSG("wc_ed448_export_key failed");
-        else
-            ret = WOLFSSL_SUCCESS;
-
-        wc_ed448_free(&key);
-    }
-
-    if (initTmpRng)
-        wc_FreeRng(tmpRNG);
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(tmpRNG, NULL, DYNAMIC_TYPE_RNG);
-#endif
-
-    return ret;
-#endif /* WOLFSSL_KEY_GEN && HAVE_ED448_KEY_EXPORT */
-}
-
-/* return 1 if success, 0 if error
- * input and output keys are little endian format
- * priv is a buffer containing private and public part of key
- */
-int wolfSSL_ED448_sign(const unsigned char *msg, unsigned int msgSz,
-                       const unsigned char *priv, unsigned int privSz,
-                       unsigned char *sig, unsigned int *sigSz)
-{
-#if !defined(HAVE_ED448_SIGN) || !defined(WOLFSSL_KEY_GEN) || !defined(HAVE_ED448_KEY_IMPORT)
-#if !defined(HAVE_ED448_SIGN)
-    WOLFSSL_MSG("No ED448 sign built in");
-#elif !defined(WOLFSSL_KEY_GEN)
-    WOLFSSL_MSG("No Key Gen built in");
-#elif !defined(HAVE_ED448_KEY_IMPORT)
-    WOLFSSL_MSG("No ED448 Key import built in");
-#endif
-    (void) msg;
-    (void) msgSz;
-    (void) priv;
-    (void) privSz;
-    (void) sig;
-    (void) sigSz;
-    return WOLFSSL_FAILURE;
-#else /* HAVE_ED448_SIGN && WOLFSSL_KEY_GEN && HAVE_ED448_KEY_IMPORT */
-    ed448_key key;
-    int ret = WOLFSSL_FAILURE;
-
-    WOLFSSL_ENTER("wolfSSL_ED448_sign");
-
-    if (priv == NULL || privSz != ED448_PRV_KEY_SIZE || msg == NULL ||
-            sig == NULL || *sigSz < ED448_SIG_SIZE) {
-        WOLFSSL_MSG("Bad arguments");
-        return WOLFSSL_FAILURE;
-    }
-
-    /* import key */
-    if (wc_ed448_init(&key) != MP_OKAY) {
-        WOLFSSL_MSG("wc_curve448_init failed");
-        return ret;
-    }
-    if (wc_ed448_import_private_key(priv, privSz/2, priv+(privSz/2),
-                                    ED448_PUB_KEY_SIZE, &key) != MP_OKAY){
-        WOLFSSL_MSG("wc_ed448_import_private failed");
-        wc_ed448_free(&key);
-        return ret;
-    }
-
-    if (wc_ed448_sign_msg(msg, msgSz, sig, sigSz, &key, NULL, 0) != MP_OKAY)
-        WOLFSSL_MSG("wc_curve448_shared_secret_ex failed");
-    else
-        ret = WOLFSSL_SUCCESS;
-
-    wc_ed448_free(&key);
-
-    return ret;
-#endif /* HAVE_ED448_SIGN && WOLFSSL_KEY_GEN && HAVE_ED448_KEY_IMPORT */
-}
-
-/* return 1 if success, 0 if error
- * input and output keys are little endian format
- * pub is a buffer containing public part of key
- */
-int wolfSSL_ED448_verify(const unsigned char *msg, unsigned int msgSz,
-                         const unsigned char *pub, unsigned int pubSz,
-                         const unsigned char *sig, unsigned int sigSz)
-{
-#if !defined(HAVE_ED448_VERIFY) || !defined(WOLFSSL_KEY_GEN) || !defined(HAVE_ED448_KEY_IMPORT)
-#if !defined(HAVE_ED448_VERIFY)
-    WOLFSSL_MSG("No ED448 verify built in");
-#elif !defined(WOLFSSL_KEY_GEN)
-    WOLFSSL_MSG("No Key Gen built in");
-#elif !defined(HAVE_ED448_KEY_IMPORT)
-    WOLFSSL_MSG("No ED448 Key import built in");
-#endif
-    (void) msg;
-    (void) msgSz;
-    (void) pub;
-    (void) pubSz;
-    (void) sig;
-    (void) sigSz;
-    return WOLFSSL_FAILURE;
-#else /* HAVE_ED448_VERIFY && WOLFSSL_KEY_GEN && HAVE_ED448_KEY_IMPORT */
-    ed448_key key;
-    int ret = WOLFSSL_FAILURE, check = 0;
-
-    WOLFSSL_ENTER("wolfSSL_ED448_verify");
-
-    if (pub == NULL || pubSz != ED448_PUB_KEY_SIZE || msg == NULL ||
-            sig == NULL || sigSz != ED448_SIG_SIZE) {
-        WOLFSSL_MSG("Bad arguments");
-        return WOLFSSL_FAILURE;
-    }
-
-    /* import key */
-    if (wc_ed448_init(&key) != MP_OKAY) {
-        WOLFSSL_MSG("wc_curve448_init failed");
-        return ret;
-    }
-    if (wc_ed448_import_public(pub, pubSz, &key) != MP_OKAY){
-        WOLFSSL_MSG("wc_ed448_import_public failed");
-        wc_ed448_free(&key);
-        return ret;
-    }
-
-    if ((ret = wc_ed448_verify_msg((byte*)sig, sigSz, msg, msgSz, &check,
-                                   &key, NULL, 0)) != MP_OKAY) {
-        WOLFSSL_MSG("wc_ed448_verify_msg failed");
-    }
-    else if (!check)
-        WOLFSSL_MSG("wc_ed448_verify_msg failed (signature invalid)");
-    else
-        ret = WOLFSSL_SUCCESS;
-
-    wc_ed448_free(&key);
-
-    return ret;
-#endif /* HAVE_ED448_VERIFY && WOLFSSL_KEY_GEN */
-}
-
-#endif /* OPENSSL_EXTRA && HAVE_ED448 */
 
 #ifdef WOLFSSL_JNI
 
@@ -29628,12 +20446,12 @@ int wolfSSL_AsyncPoll(WOLFSSL* ssl, WOLF_EVENT_FLAG flags)
 static int peek_ignore_err(int err)
 {
   switch(err) {
-    case -WANT_READ:
-    case -WANT_WRITE:
-    case -ZERO_RETURN:
+    case -WC_NO_ERR_TRACE(WANT_READ):
+    case -WC_NO_ERR_TRACE(WANT_WRITE):
+    case -WC_NO_ERR_TRACE(ZERO_RETURN):
     case -WOLFSSL_ERROR_ZERO_RETURN:
-    case -SOCKET_PEER_CLOSED_E:
-    case -SOCKET_ERROR_E:
+    case -WC_NO_ERR_TRACE(SOCKET_PEER_CLOSED_E):
+    case -WC_NO_ERR_TRACE(SOCKET_ERROR_E):
       return 1;
     default:
       return 0;
@@ -29648,15 +20466,15 @@ unsigned long wolfSSL_ERR_peek_error_line_data(const char **file, int *line,
     WOLFSSL_ENTER("wolfSSL_ERR_peek_error_line_data");
     err = wc_PeekErrorNodeLineData(file, line, data, flags, peek_ignore_err);
 
-    if (err == -ASN_NO_PEM_HEADER)
+    if (err == -WC_NO_ERR_TRACE(ASN_NO_PEM_HEADER))
         return (ERR_LIB_PEM << 24) | PEM_R_NO_START_LINE;
 #ifdef OPENSSL_ALL
     /* PARSE_ERROR is returned if an HTTP request is detected. */
-    else if (err == -SSL_R_HTTP_REQUEST)
+    else if (err == -WC_NO_ERR_TRACE(PARSE_ERROR))
         return (ERR_LIB_SSL << 24) | -SSL_R_HTTP_REQUEST;
 #endif
 #if defined(OPENSSL_ALL) && defined(WOLFSSL_PYTHON)
-    else if (err == ASN1_R_HEADER_TOO_LONG)
+    else if (err == WC_NO_ERR_TRACE(ASN1_R_HEADER_TOO_LONG))
         return (ERR_LIB_ASN1 << 24) | ASN1_R_HEADER_TOO_LONG;
 #endif
   return err;
@@ -29807,7 +20625,7 @@ WOLF_STACK_OF(WOLFSSL_CIPHER) *wolfSSL_get_ciphers_compat(const WOLFSSL *ssl)
                             add->data.cipher.cipherSuite0 &&
                             cipher_names[j].cipherSuite ==
                                     add->data.cipher.cipherSuite) {
-                        add->data.cipher.offset = j;
+                        add->data.cipher.offset = (unsigned long)j;
                         break;
                     }
                 }
@@ -29833,8 +20651,9 @@ WOLF_STACK_OF(WOLFSSL_CIPHER) *wolfSSL_get_ciphers_compat(const WOLFSSL *ssl)
 }
 #endif /* OPENSSL_ALL || WOLFSSL_NGINX || WOLFSSL_HAPROXY */
 
-#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) \
-    || defined(OPENSSL_EXTRA) || defined(HAVE_LIGHTY) || defined(HAVE_SECRET_CALLBACK)
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || \
+    defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA) || \
+    defined(HAVE_LIGHTY) || defined(HAVE_SECRET_CALLBACK)
 long wolfSSL_SSL_CTX_get_timeout(const WOLFSSL_CTX *ctx)
 {
     WOLFSSL_ENTER("wolfSSL_SSL_CTX_get_timeout");
@@ -29868,86 +20687,11 @@ int wolfSSL_SSL_CTX_set_tmp_ecdh(WOLFSSL_CTX *ctx, WOLFSSL_EC_KEY *ecdh)
     if (ctx == NULL || ecdh == NULL)
         return BAD_FUNC_ARG;
 
-    ctx->ecdhCurveOID = ecdh->group->curve_oid;
+    ctx->ecdhCurveOID = (word32)ecdh->group->curve_oid;
 
     return WOLFSSL_SUCCESS;
 }
 #endif
-#ifndef NO_SESSION_CACHE
-int wolfSSL_SSL_CTX_remove_session(WOLFSSL_CTX *ctx, WOLFSSL_SESSION *s)
-{
-#if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
-    int rem_called = FALSE;
-#endif
-
-    WOLFSSL_ENTER("wolfSSL_SSL_CTX_remove_session");
-
-    s = ClientSessionToSession(s);
-    if (ctx == NULL || s == NULL)
-        return BAD_FUNC_ARG;
-
-#ifdef HAVE_EXT_CACHE
-    if (!ctx->internalCacheOff)
-#endif
-    {
-        const byte* id;
-        WOLFSSL_SESSION *sess = NULL;
-        word32 row = 0;
-        int ret;
-
-        id = s->sessionID;
-        if (s->haveAltSessionID)
-            id = s->altSessionID;
-
-        ret = TlsSessionCacheGetAndWrLock(id, &sess, &row, ctx->method->side);
-        if (ret == 0 && sess != NULL) {
-#if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
-            if (sess->rem_sess_cb != NULL) {
-                rem_called = TRUE;
-            }
-#endif
-            /* Call this before changing ownExData so that calls to ex_data
-             * don't try to access the SessionCache again. */
-            EvictSessionFromCache(sess);
-#ifdef HAVE_EX_DATA
-            if (sess->ownExData) {
-                /* Most recent version of ex data is in cache. Copy it
-                 * over so the user can free it. */
-                XMEMCPY(&s->ex_data, &sess->ex_data,
-                        sizeof(WOLFSSL_CRYPTO_EX_DATA));
-                s->ownExData = 1;
-                sess->ownExData = 0;
-            }
-#endif
-#ifdef SESSION_CACHE_DYNAMIC_MEM
-            {
-                /* Find and clear entry. Row is locked so we are good to go. */
-                int idx;
-                for (idx = 0; idx < SESSIONS_PER_ROW; idx++) {
-                    if (sess == SessionCache[row].Sessions[idx]) {
-                        XFREE(sess, sess->heap, DYNAMIC_TYPE_SESSION);
-                        SessionCache[row].Sessions[idx] = NULL;
-                        break;
-                    }
-                }
-            }
-#endif
-            TlsSessionCacheUnlockRow(row);
-        }
-    }
-
-#if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
-    if (ctx->rem_sess_cb != NULL && !rem_called) {
-        ctx->rem_sess_cb(ctx, s);
-    }
-#endif
-
-    /* s cannot be resumed at this point */
-    s->timeout = 0;
-
-    return 0;
-}
-#endif /* !NO_SESSION_CACHE */
 #ifndef NO_BIO
 BIO *wolfSSL_SSL_get_rbio(const WOLFSSL *s)
 {
@@ -30044,17 +20788,6 @@ int wolfSSL_SSL_in_connect_init(WOLFSSL* ssl)
     return ssl->options.acceptState > ACCEPT_BEGIN &&
         ssl->options.acceptState < ACCEPT_THIRD_REPLY_DONE;
 }
-
-#ifndef NO_SESSION_CACHE
-
-WOLFSSL_SESSION *wolfSSL_SSL_get0_session(const WOLFSSL *ssl)
-{
-    WOLFSSL_ENTER("wolfSSL_SSL_get0_session");
-
-    return ssl->session;
-}
-
-#endif /* NO_SESSION_CACHE */
 
 #if defined(HAVE_SESSION_TICKET) && !defined(NO_WOLFSSL_SERVER)
 /* Expected return values from implementations of OpenSSL ticket key callback.
@@ -30272,8 +21005,9 @@ long wolfSSL_CTX_get_tlsext_ticket_keys(WOLFSSL_CTX *ctx,
  *          correct length.
  */
 long wolfSSL_CTX_set_tlsext_ticket_keys(WOLFSSL_CTX *ctx,
-     unsigned char *keys, int keylen)
+     const void *keys_vp, int keylen)
 {
+    const byte* keys = (const byte*)keys_vp;
     if (ctx == NULL || keys == NULL) {
         return WOLFSSL_FAILURE;
     }
@@ -30339,7 +21073,8 @@ int wolfSSL_get_ocsp_producedDate(
     if (XSTRLEN((char *)ssl->ocspProducedDate) >= producedDate_space)
         return BUFFER_E;
 
-    XSTRNCPY((char *)producedDate, (const char *)ssl->ocspProducedDate, producedDate_space);
+    XSTRNCPY((char *)producedDate, (const char *)ssl->ocspProducedDate,
+        producedDate_space);
     *producedDateFormat = ssl->ocspProducedDateFormat;
 
     return 0;
@@ -30366,7 +21101,8 @@ int wolfSSL_get_ocsp_producedDate_tm(WOLFSSL *ssl, struct tm *produced_tm) {
 
 #if defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || \
     defined(OPENSSL_EXTRA) || defined(OPENSSL_ALL)
-int wolfSSL_CTX_get_extra_chain_certs(WOLFSSL_CTX* ctx, WOLF_STACK_OF(X509)** chain)
+int wolfSSL_CTX_get_extra_chain_certs(WOLFSSL_CTX* ctx,
+    WOLF_STACK_OF(X509)** chain)
 {
     word32         idx;
     word32         length;
@@ -30401,7 +21137,7 @@ int wolfSSL_CTX_get_extra_chain_certs(WOLFSSL_CTX* ctx, WOLF_STACK_OF(X509)** ch
 
         /* Create a new X509 from DER encoded data. */
         node->data.x509 = wolfSSL_X509_d2i_ex(NULL,
-            ctx->certChain->buffer + idx, length, ctx->heap);
+            ctx->certChain->buffer + idx, (int)length, ctx->heap);
         if (node->data.x509 == NULL) {
             XFREE(node, NULL, DYNAMIC_TYPE_OPENSSL);
             /* Return as much of the chain as we created. */
@@ -30534,8 +21270,8 @@ void wolfSSL_sk_WOLFSSL_STRING_free(WOLF_STACK_OF(WOLFSSL_STRING)* sk)
     }
 }
 
-WOLFSSL_STRING wolfSSL_sk_WOLFSSL_STRING_value(WOLF_STACK_OF(WOLFSSL_STRING)* strings,
-    int idx)
+WOLFSSL_STRING wolfSSL_sk_WOLFSSL_STRING_value(
+    WOLF_STACK_OF(WOLFSSL_STRING)* strings, int idx)
 {
     for (; idx > 0 && strings != NULL; idx--)
         strings = strings->next;
@@ -30655,8 +21391,8 @@ void wolfSSL_CTX_set_next_proto_select_cb(WOLFSSL_CTX *s,
     WOLFSSL_STUB("wolfSSL_CTX_set_next_proto_select_cb");
 }
 
-void wolfSSL_get0_next_proto_negotiated(const WOLFSSL *s, const unsigned char **data,
-                                    unsigned *len)
+void wolfSSL_get0_next_proto_negotiated(const WOLFSSL *s,
+    const unsigned char **data, unsigned *len)
 {
     (void)s;
     (void)data;
@@ -30670,25 +21406,86 @@ void wolfSSL_get0_next_proto_negotiated(const WOLFSSL *s, const unsigned char **
 #if defined(OPENSSL_EXTRA) || defined(HAVE_CURL)
 int wolfSSL_curve_is_disabled(const WOLFSSL* ssl, word16 curve_id)
 {
-    if (curve_id >= WOLFSSL_FFDHE_START) {
-        /* DH parameters are never disabled. */
-        return 0;
+    int ret = 0;
+
+    WOLFSSL_ENTER("wolfSSL_curve_is_disabled");
+    WOLFSSL_MSG_EX("wolfSSL_curve_is_disabled checking for %d", curve_id);
+
+    /* (curve_id >= WOLFSSL_FFDHE_START) - DH parameters are never disabled. */
+    if (curve_id < WOLFSSL_FFDHE_START) {
+        if (curve_id > WOLFSSL_ECC_MAX_AVAIL) {
+            WOLFSSL_MSG("Curve id out of supported range");
+            /* Disabled if not in valid range. */
+            ret = 1;
+        }
+        else if (curve_id >= 32) {
+            /* 0 is for invalid and 1-14 aren't used otherwise. */
+            ret = (ssl->disabledCurves & (1U << (curve_id - 32))) != 0;
+        }
+        else {
+            ret = (ssl->disabledCurves & (1U << curve_id)) != 0;
+        }
     }
-    if (curve_id > WOLFSSL_ECC_MAX_AVAIL) {
-        WOLFSSL_MSG("Curve id out of supported range");
-        /* Disabled if not in valid range. */
-        return 1;
-    }
-    if (curve_id >= 32) {
-        /* 0 is for invalid and 1-14 aren't used otherwise. */
-        return (ssl->disabledCurves & (1U << (curve_id - 32))) != 0;
-    }
-    return (ssl->disabledCurves & (1U << curve_id)) != 0;
+
+    WOLFSSL_LEAVE("wolfSSL_curve_is_disabled", ret);
+    return ret;
 }
 
 #if (defined(HAVE_ECC) || \
     defined(HAVE_CURVE25519) || defined(HAVE_CURVE448))
-static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
+#define CURVE_NAME(c) XSTR_SIZEOF((c)), (c)
+
+const WOLF_EC_NIST_NAME kNistCurves[] = {
+#ifdef HAVE_ECC
+    {CURVE_NAME("P-160"),   NID_secp160r1, WOLFSSL_ECC_SECP160R1},
+    {CURVE_NAME("P-160-2"), NID_secp160r2, WOLFSSL_ECC_SECP160R2},
+    {CURVE_NAME("P-192"),   NID_X9_62_prime192v1, WOLFSSL_ECC_SECP192R1},
+    {CURVE_NAME("P-224"),   NID_secp224r1, WOLFSSL_ECC_SECP224R1},
+    {CURVE_NAME("P-256"),   NID_X9_62_prime256v1, WOLFSSL_ECC_SECP256R1},
+    {CURVE_NAME("P-384"),   NID_secp384r1, WOLFSSL_ECC_SECP384R1},
+    {CURVE_NAME("P-521"),   NID_secp521r1, WOLFSSL_ECC_SECP521R1},
+    {CURVE_NAME("K-160"),   NID_secp160k1, WOLFSSL_ECC_SECP160K1},
+    {CURVE_NAME("K-192"),   NID_secp192k1, WOLFSSL_ECC_SECP192K1},
+    {CURVE_NAME("K-224"),   NID_secp224k1, WOLFSSL_ECC_SECP224R1},
+    {CURVE_NAME("K-256"),   NID_secp256k1, WOLFSSL_ECC_SECP256K1},
+    {CURVE_NAME("B-256"),   NID_brainpoolP256r1, WOLFSSL_ECC_BRAINPOOLP256R1},
+    {CURVE_NAME("B-384"),   NID_brainpoolP384r1, WOLFSSL_ECC_BRAINPOOLP384R1},
+    {CURVE_NAME("B-512"),   NID_brainpoolP512r1, WOLFSSL_ECC_BRAINPOOLP512R1},
+#endif
+#ifdef HAVE_CURVE25519
+    {CURVE_NAME("X25519"),  NID_X25519, WOLFSSL_ECC_X25519},
+#endif
+#ifdef HAVE_CURVE448
+    {CURVE_NAME("X448"),    NID_X448, WOLFSSL_ECC_X448},
+#endif
+#ifdef WOLFSSL_HAVE_KYBER
+    {CURVE_NAME("KYBER_LEVEL1"), WOLFSSL_KYBER_LEVEL1, WOLFSSL_KYBER_LEVEL1},
+    {CURVE_NAME("KYBER_LEVEL3"), WOLFSSL_KYBER_LEVEL3, WOLFSSL_KYBER_LEVEL1},
+    {CURVE_NAME("KYBER_LEVEL5"), WOLFSSL_KYBER_LEVEL5, WOLFSSL_KYBER_LEVEL1},
+#if (defined(WOLFSSL_WC_KYBER) || defined(HAVE_LIBOQS)) && defined(HAVE_ECC)
+    {CURVE_NAME("P256_KYBER_LEVEL1"), WOLFSSL_P256_KYBER_LEVEL1, WOLFSSL_P256_KYBER_LEVEL1},
+    {CURVE_NAME("P384_KYBER_LEVEL3"), WOLFSSL_P384_KYBER_LEVEL3, WOLFSSL_P256_KYBER_LEVEL1},
+    {CURVE_NAME("P521_KYBER_LEVEL5"), WOLFSSL_P521_KYBER_LEVEL5, WOLFSSL_P256_KYBER_LEVEL1},
+#endif
+#endif
+#ifdef WOLFSSL_SM2
+    {CURVE_NAME("SM2"),     NID_sm2, WOLFSSL_ECC_SM2P256V1},
+#endif
+#ifdef HAVE_ECC
+    /* Alternative curve names */
+    {CURVE_NAME("prime256v1"), NID_X9_62_prime256v1, WOLFSSL_ECC_SECP256R1},
+    {CURVE_NAME("secp256r1"),  NID_X9_62_prime256v1, WOLFSSL_ECC_SECP256R1},
+    {CURVE_NAME("secp384r1"),  NID_secp384r1, WOLFSSL_ECC_SECP384R1},
+    {CURVE_NAME("secp521r1"),  NID_secp521r1, WOLFSSL_ECC_SECP521R1},
+#endif
+#ifdef WOLFSSL_SM2
+    {CURVE_NAME("sm2p256v1"),  NID_sm2, WOLFSSL_ECC_SM2P256V1},
+#endif
+    {0, NULL, 0, 0},
+};
+
+int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names,
+        byte curves_only)
 {
     int idx, start = 0, len, i, ret = WOLFSSL_FAILURE;
     word16 curve;
@@ -30701,6 +21498,7 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
 #else
     int groups[WOLFSSL_MAX_GROUP_COUNT];
 #endif
+    const WOLF_EC_NIST_NAME* nist_name;
 
 #ifdef WOLFSSL_SMALL_STACK
     groups = (int*)XMALLOC(sizeof(int)*WOLFSSL_MAX_GROUP_COUNT,
@@ -30720,46 +21518,19 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
             goto leave;
 
         XMEMCPY(name, names + start, len);
-        name[len++] = 0;
+        name[len] = 0;
+        curve = WOLFSSL_NAMED_GROUP_INVALID;
 
-        /* Use XSTRNCMP to avoid valgrind error. */
-        if ((XSTRNCMP(name, "prime256v1", len) == 0) ||
-            (XSTRNCMP(name, "secp256r1", len) == 0) ||
-            (XSTRNCMP(name, "P-256", len) == 0))
-        {
-            curve = WOLFSSL_ECC_SECP256R1;
+        for (nist_name = kNistCurves; nist_name->name != NULL; nist_name++) {
+            if (len == nist_name->name_len &&
+                    XSTRNCMP(name, nist_name->name, len) == 0) {
+                curve = nist_name->curve;
+                break;
+            }
         }
-        else if ((XSTRNCMP(name, "secp384r1", len) == 0) ||
-                 (XSTRNCMP(name, "P-384", len) == 0))
-        {
-            curve = WOLFSSL_ECC_SECP384R1;
-        }
-        else if ((XSTRNCMP(name, "secp521r1", len) == 0) ||
-                 (XSTRNCMP(name, "P-521", len) == 0))
-        {
-            curve = WOLFSSL_ECC_SECP521R1;
-        }
-    #ifdef WOLFSSL_SM2
-        else if ((XSTRNCMP(name, "sm2p256v1", len) == 0) ||
-                 (XSTRNCMP(name, "SM2", len) == 0))
-        {
-            curve = WOLFSSL_ECC_SM2P256V1;
-        }
-    #endif
-    #ifdef HAVE_CURVE25519
-        else if (XSTRNCMP(name, "X25519", len) == 0)
-        {
-            curve = WOLFSSL_ECC_X25519;
-        }
-    #endif
-    #ifdef HAVE_CURVE448
-        else if (XSTRNCMP(name, "X448", len) == 0)
-        {
-            curve = WOLFSSL_ECC_X448;
-        }
-    #endif
-        else {
-        #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST)
+
+        if (curve == WOLFSSL_NAMED_GROUP_INVALID) {
+        #if !defined(HAVE_FIPS) && !defined(HAVE_SELFTEST) && defined(HAVE_ECC)
             int   nret;
             const ecc_set_type *eccSet;
 
@@ -30782,7 +21553,8 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
         #endif
         }
 
-        if (curve >= WOLFSSL_ECC_MAX_AVAIL) {
+        if ((curves_only && curve >= WOLFSSL_ECC_MAX_AVAIL) ||
+                curve == WOLFSSL_NAMED_GROUP_INVALID) {
             WOLFSSL_MSG("curve value is not supported");
             goto leave;
         }
@@ -30810,7 +21582,10 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
     for (i = 0; i < groups_len; ++i) {
         /* Switch the bit to off and therefore is enabled. */
         curve = (word16)groups[i];
-        if (curve >= 32) {
+        if (curve >= 64) {
+            WC_DO_NOTHING;
+        }
+        else if (curve >= 32) {
             /* 0 is for invalid and 1-14 aren't used otherwise. */
             disabled &= ~(1U << (curve - 32));
         }
@@ -30818,7 +21593,7 @@ static int set_curves_list(WOLFSSL* ssl, WOLFSSL_CTX *ctx, const char* names)
             disabled &= ~(1U << curve);
         }
     #ifdef HAVE_SUPPORTED_CURVES
-    #if defined(WOLFSSL_TLS13) && !defined(WOLFSSL_OLD_SET_CURVES_LIST)
+    #if !defined(WOLFSSL_OLD_SET_CURVES_LIST)
         /* using the wolfSSL API to set the groups, this will populate
          * (ssl|ctx)->groups and reset any TLSX_SUPPORTED_GROUPS.
          * The order in (ssl|ctx)->groups will then be respected
@@ -30859,20 +21634,22 @@ leave:
 
 int wolfSSL_CTX_set1_curves_list(WOLFSSL_CTX* ctx, const char* names)
 {
+    WOLFSSL_ENTER("wolfSSL_CTX_set1_curves_list");
     if (ctx == NULL || names == NULL) {
         WOLFSSL_MSG("ctx or names was NULL");
         return WOLFSSL_FAILURE;
     }
-    return set_curves_list(NULL, ctx, names);
+    return set_curves_list(NULL, ctx, names, 1);
 }
 
 int wolfSSL_set1_curves_list(WOLFSSL* ssl, const char* names)
 {
+    WOLFSSL_ENTER("wolfSSL_set1_curves_list");
     if (ssl == NULL || names == NULL) {
         WOLFSSL_MSG("ssl or names was NULL");
         return WOLFSSL_FAILURE;
     }
-    return set_curves_list(ssl, NULL, names);
+    return set_curves_list(ssl, NULL, names, 1);
 }
 #endif /* (HAVE_ECC || HAVE_CURVE25519 || HAVE_CURVE448) */
 #endif /* OPENSSL_EXTRA || HAVE_CURL */
@@ -30948,7 +21725,8 @@ int wolfSSL_set_msg_callback_arg(WOLFSSL *ssl, void* arg)
     return WOLFSSL_SUCCESS;
 }
 
-void *wolfSSL_OPENSSL_memdup(const void *data, size_t siz, const char* file, int line)
+void *wolfSSL_OPENSSL_memdup(const void *data, size_t siz, const char* file,
+    int line)
 {
     void *ret;
     (void)file;
@@ -31080,7 +21858,7 @@ int wolfSSL_set_alpn_protos(WOLFSSL* ssl,
     /* clears out all current ALPN extensions set */
     TLSX_Remove(&ssl->extensions, TLSX_APPLICATION_LAYER_PROTOCOL, ssl->heap);
 
-    if ((sz = wolfSSL_BIO_get_mem_data(bio, &pt)) > 0) {
+    if ((sz = (unsigned int)wolfSSL_BIO_get_mem_data(bio, &pt)) > 0) {
         wolfSSL_UseALPN(ssl, pt, sz, (byte) alpn_opt);
     }
     wolfSSL_BIO_free(bio);
@@ -31890,150 +22668,6 @@ void wolfSSL_ERR_remove_state(unsigned long id)
 #ifdef OPENSSL_ALL
 
 #if !defined(NO_BIO) && !defined(NO_PWDBASED) && defined(HAVE_PKCS8)
-int wolfSSL_PEM_write_bio_PKCS8PrivateKey(WOLFSSL_BIO* bio,
-                                          WOLFSSL_EVP_PKEY* pkey,
-                                          const WOLFSSL_EVP_CIPHER* enc,
-                                          char* passwd, int passwdSz,
-                                          wc_pem_password_cb* cb, void* ctx)
-{
-    int ret = 0;
-    char password[NAME_SZ];
-    byte* key = NULL;
-    word32 keySz;
-    byte* pem = NULL;
-    int pemSz = 0;
-    int type = PKCS8_PRIVATEKEY_TYPE;
-    const byte* curveOid;
-    word32 oidSz;
-
-    if (bio == NULL || pkey == NULL)
-        return -1;
-
-    keySz = pkey->pkey_sz + 128;
-    key = (byte*)XMALLOC(keySz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (key == NULL)
-        ret = MEMORY_E;
-
-    if (ret == 0 && enc != NULL && passwd == NULL) {
-        passwdSz = cb(password, sizeof(password), 1, ctx);
-        if (passwdSz < 0)
-            ret = WOLFSSL_FAILURE;
-        passwd = password;
-    }
-
-    if (ret == 0 && enc != NULL) {
-        WC_RNG rng;
-        ret = wc_InitRng(&rng);
-        if (ret == 0) {
-            int encAlgId = 0;
-        #ifndef NO_DES3
-            if (enc == EVP_DES_CBC)
-                encAlgId = DESb;
-            else if (enc == EVP_DES_EDE3_CBC)
-                encAlgId = DES3b;
-            else
-        #endif
-        #if !defined(NO_AES) && defined(HAVE_AES_CBC)
-            #ifdef WOLFSSL_AES_256
-            if (enc == EVP_AES_256_CBC)
-                encAlgId = AES256CBCb;
-            else
-            #endif
-        #endif
-                ret = -1;
-            if (ret == 0) {
-                ret = TraditionalEnc((byte*)pkey->pkey.ptr, pkey->pkey_sz, key,
-                                       &keySz, passwd, passwdSz, PKCS5, PBES2,
-                                       encAlgId, NULL, 0, WC_PKCS12_ITT_DEFAULT,
-                                       &rng, NULL);
-                if (ret > 0) {
-                    keySz = ret;
-                    ret = 0;
-                }
-            }
-            wc_FreeRng(&rng);
-        }
-        type = PKCS8_ENC_PRIVATEKEY_TYPE;
-    }
-    if (ret == 0 && enc == NULL) {
-        int algId;
-        type = PKCS8_PRIVATEKEY_TYPE;
-    #ifdef HAVE_ECC
-        if (pkey->type == EVP_PKEY_EC) {
-            algId = ECDSAk;
-            ret = wc_ecc_get_oid(pkey->ecc->group->curve_oid, &curveOid,
-                                                                        &oidSz);
-        }
-        else
-    #endif
-        {
-            algId = RSAk;
-            curveOid = NULL;
-            oidSz = 0;
-        }
-
-    #ifdef HAVE_ECC
-        if (ret >= 0)
-    #endif
-        {
-            ret = wc_CreatePKCS8Key(key, &keySz, (byte*)pkey->pkey.ptr,
-                                         pkey->pkey_sz, algId, curveOid, oidSz);
-            keySz = ret;
-        }
-    }
-
-    if (password == passwd)
-        XMEMSET(password, 0, passwdSz);
-
-    if (ret >= 0) {
-        pemSz = 2 * keySz + 2 * 64;
-        pem = (byte*)XMALLOC(pemSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        if (pem == NULL)
-            ret = MEMORY_E;
-    }
-
-    if (ret >= 0)
-        ret = wc_DerToPemEx(key, keySz, pem, pemSz, NULL, type);
-
-    if (key != NULL)
-        XFREE(key, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-
-    if (ret >= 0) {
-        if (wolfSSL_BIO_write(bio, pem, ret) != ret)
-            ret = -1;
-    }
-
-    if (pem != NULL)
-        XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-
-    return ret < 0 ? 0 : ret;
-
-}
-
-#if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
-int wolfSSL_PEM_write_PKCS8PrivateKey(XFILE f, WOLFSSL_EVP_PKEY* pkey,
-    const WOLFSSL_EVP_CIPHER* enc, char* passwd, int passwdSz,
-    wc_pem_password_cb* cb, void* ctx)
-{
-    int ret = WOLFSSL_SUCCESS;
-    BIO *b;
-
-    WOLFSSL_ENTER("wolfSSL_PEM_write_PKCS8PrivateKey");
-
-    b = wolfSSL_BIO_new_fp(f, BIO_NOCLOSE);
-    if (b == NULL) {
-        ret = WOLFSSL_FAILURE;
-    }
-    if (ret == WOLFSSL_SUCCESS) {
-        ret = wolfSSL_PEM_write_bio_PKCS8PrivateKey(b, pkey, enc, passwd,
-                passwdSz, cb, ctx);
-    }
-
-    wolfSSL_BIO_free(b);
-
-    return ret;
-}
-#endif /* !NO_FILESYSTEM && !NO_STDIO_FILESYSTEM */
 
 static int bio_get_data(WOLFSSL_BIO* bio, byte** data)
 {
@@ -32089,13 +22723,13 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_PKCS8PrivateKey_bio(WOLFSSL_BIO* bio,
             passwordSz);
     #endif
 
-        ret = ToTraditionalEnc(der, len, password, passwordSz, &algId);
+        ret = ToTraditionalEnc(der, (word32)len, password, passwordSz, &algId);
         if (ret < 0) {
             XFREE(der, bio->heap, DYNAMIC_TYPE_OPENSSL);
             return NULL;
         }
 
-        ForceZero(password, passwordSz);
+        ForceZero(password, (word32)passwordSz);
     #ifdef WOLFSSL_CHECK_MEM_ZERO
         wc_MemZero_Check(password, passwordSz);
     #endif
@@ -32126,7 +22760,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_d2i_AutoPrivateKey(WOLFSSL_EVP_PKEY** pkey,
     /* Take off PKCS#8 wrapper if found. */
     if ((len = ToTraditionalInline_ex(der, &idx, keyLen, &algId)) >= 0) {
         der += idx;
-        keyLen = len;
+        keyLen = (word32)len;
     }
     idx = 0;
     len = 0;
@@ -32214,7 +22848,8 @@ int wolfSSL_StaticEphemeralKeyLoad(WOLFSSL* ssl, int keyAlgo, void* keyPtr)
             if (der != NULL) {
                 ecc_key* key = (ecc_key*)keyPtr;
                 WOLFSSL_MSG("Using static ECDH key");
-                ret = wc_EccPrivateKeyDecode(der->buffer, &idx, key, der->length);
+                ret = wc_EccPrivateKeyDecode(der->buffer, &idx, key,
+                    der->length);
             }
             break;
     #endif
@@ -32348,8 +22983,8 @@ static int SetStaticEphemeralKey(WOLFSSL_CTX* ctx,
                 curve25519_key x25519Key;
                 ret = wc_curve25519_init_ex(&x25519Key, heap, INVALID_DEVID);
                 if (ret == 0) {
-                    ret = wc_Curve25519PrivateKeyDecode(keyBuf, &idx, &x25519Key,
-                        keySz);
+                    ret = wc_Curve25519PrivateKeyDecode(keyBuf, &idx,
+                        &x25519Key, keySz);
                     if (ret == 0)
                         keyAlgo = WC_PK_TYPE_CURVE25519;
                     wc_curve25519_free(&x25519Key);
@@ -32582,6 +23217,17 @@ unsigned long wolfSSL_THREADID_hash(const WOLFSSL_CRYPTO_THREADID* id)
     (void)id;
     return 0UL;
 }
+/* wolfSSL_set_ecdh_auto is provided as compatible API with
+ * SSL_set_ecdh_auto to enable auto ecdh curve selection functionality.
+ * Since this functionality is enabled by default in wolfSSL,
+ * this API exists as a stub.
+ */
+int wolfSSL_set_ecdh_auto(WOLFSSL* ssl, int onoff)
+{
+    (void)ssl;
+    (void)onoff;
+    return WOLFSSL_SUCCESS;
+}
 /* wolfSSL_CTX_set_ecdh_auto is provided as compatible API with
  * SSL_CTX_set_ecdh_auto to enable auto ecdh curve selection functionality.
  * Since this functionality is enabled by default in wolfSSL,
@@ -32617,36 +23263,14 @@ int wolfSSL_CTX_get_security_level(const WOLFSSL_CTX* ctx)
     return 0;
 }
 
-
-/**
- * Determine whether a WOLFSSL_SESSION object can be used for resumption
- * @param s  a pointer to WOLFSSL_SESSION structure
- * @return return 1 if session is resumable, otherwise 0.
- */
-int wolfSSL_SESSION_is_resumable(const WOLFSSL_SESSION *s)
-{
-    s = ClientSessionToSession(s);
-    if (s == NULL)
-        return 0;
-
-#ifdef HAVE_SESSION_TICKET
-    if (s->ticketLen > 0)
-        return 1;
-#endif
-
-    if (s->sessionIDSz > 0)
-        return 1;
-
-    return 0;
-}
-
 #if defined(OPENSSL_EXTRA) && defined(HAVE_SECRET_CALLBACK)
 /*
  * This API accepts a user callback which puts key-log records into
  * a KEY LOGFILE. The callback is stored into a CTX and propagated to
  * each SSL object on its creation timing.
  */
-void wolfSSL_CTX_set_keylog_callback(WOLFSSL_CTX* ctx, wolfSSL_CTX_keylog_cb_func cb)
+void wolfSSL_CTX_set_keylog_callback(WOLFSSL_CTX* ctx,
+    wolfSSL_CTX_keylog_cb_func cb)
 {
     WOLFSSL_ENTER("wolfSSL_CTX_set_keylog_callback");
   /* stores the callback into WOLFSSL_CTX */
@@ -32667,7 +23291,7 @@ wolfSSL_CTX_keylog_cb_func wolfSSL_CTX_get_keylog_callback(
 
 #endif /* OPENSSL_EXTRA */
 
-#ifndef NO_CERT
+#ifndef NO_CERTS
 #define WOLFSSL_X509_INCLUDED
 #include "src/x509.c"
 #endif
@@ -32675,9 +23299,10 @@ wolfSSL_CTX_keylog_cb_func wolfSSL_CTX_get_keylog_callback(
 /*******************************************************************************
  * START OF standard C library wrapping APIs
  ******************************************************************************/
-#if defined(OPENSSL_ALL) || (defined(OPENSSL_EXTRA) && (defined(HAVE_STUNNEL) || \
-                             defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY) || \
-                             defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_OPENSSH)))
+#if defined(OPENSSL_ALL) || (defined(OPENSSL_EXTRA) && \
+    (defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
+     defined(HAVE_LIGHTY) || defined(WOLFSSL_HAPROXY) || \
+     defined(WOLFSSL_OPENSSH)))
 #ifndef NO_WOLFSSL_STUB
 int wolfSSL_CRYPTO_set_mem_ex_functions(void *(*m) (size_t, const char *, int),
                                 void *(*r) (void *, size_t, const char *,
@@ -32731,9 +23356,10 @@ void *wolfSSL_CRYPTO_malloc(size_t num, const char *file, int line)
 /*******************************************************************************
  * START OF EX_DATA APIs
  ******************************************************************************/
-#if defined(OPENSSL_ALL) || (defined(OPENSSL_EXTRA) && (defined(HAVE_STUNNEL) || \
-                             defined(WOLFSSL_NGINX) || defined(HAVE_LIGHTY) || \
-                             defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_OPENSSH)))
+#if defined(OPENSSL_ALL) || (defined(OPENSSL_EXTRA) && \
+    (defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
+     defined(HAVE_LIGHTY) || defined(WOLFSSL_HAPROXY) || \
+     defined(WOLFSSL_OPENSSH)))
 void wolfSSL_CRYPTO_cleanup_all_ex_data(void){
     WOLFSSL_ENTER("CRYPTO_cleanup_all_ex_data");
 }
@@ -32754,7 +23380,8 @@ void* wolfSSL_CRYPTO_get_ex_data(const WOLFSSL_CRYPTO_EX_DATA* ex_data, int idx)
     return NULL;
 }
 
-int wolfSSL_CRYPTO_set_ex_data(WOLFSSL_CRYPTO_EX_DATA* ex_data, int idx, void *data)
+int wolfSSL_CRYPTO_set_ex_data(WOLFSSL_CRYPTO_EX_DATA* ex_data, int idx,
+    void *data)
 {
     WOLFSSL_ENTER("wolfSSL_CRYPTO_set_ex_data");
 #ifdef MAX_EX_DATA
@@ -32884,7 +23511,7 @@ int wolfSSL_BUF_MEM_grow_ex(WOLFSSL_BUF_MEM* buf, size_t len,
     }
     buf->data = tmp;
 
-    buf->max = mx;
+    buf->max = (size_t)mx;
     if (zeroFill)
         XMEMSET(&buf->data[buf->length], 0, len - buf->length);
     buf->length = len;
@@ -32926,7 +23553,7 @@ int wolfSSL_BUF_MEM_resize(WOLFSSL_BUF_MEM* buf, size_t len)
 
     buf->data = tmp;
     buf->length = len;
-    buf->max = mx;
+    buf->max = (size_t)mx;
 
     return (int)len;
 }
@@ -33064,9 +23691,18 @@ const char* wolfSSL_RAND_file_name(char* fname, unsigned long len)
         const char ap[] = "/.rnd";
 
         WOLFSSL_MSG("Environment variable RANDFILE not set");
+
         if ((rt = XGETENV("HOME")) == NULL) {
+            #ifdef XALTHOMEVARNAME
+            if ((rt = XGETENV(XALTHOMEVARNAME)) == NULL) {
+                WOLFSSL_MSG("Environment variable HOME and " XALTHOMEVARNAME
+                            " not set");
+                return NULL;
+            }
+            #else
             WOLFSSL_MSG("Environment variable HOME not set");
             return NULL;
+            #endif
         }
 
         if (len > XSTRLEN(rt) + XSTRLEN(ap)) {
@@ -33076,7 +23712,7 @@ const char* wolfSSL_RAND_file_name(char* fname, unsigned long len)
             return fname;
         }
         else {
-            WOLFSSL_MSG("HOME too large for buffer");
+            WOLFSSL_MSG("Path too large for buffer");
             return NULL;
         }
     }
@@ -33131,7 +23767,7 @@ int wolfSSL_RAND_write_file(const char* fname)
             return 0;
         }
 
-        if (wc_RNG_GenerateBlock(&globalRNG, buf, bytes) != 0) {
+        if (wc_RNG_GenerateBlock(&globalRNG, buf, (word32)bytes) != 0) {
             WOLFSSL_MSG("Error generating random buffer");
             bytes = 0;
         }
@@ -33148,12 +23784,12 @@ int wolfSSL_RAND_write_file(const char* fname)
                 bytes = 0;
             }
             else {
-                size_t bytes_written = XFWRITE(buf, 1, bytes, f);
+                size_t bytes_written = XFWRITE(buf, 1, (size_t)bytes, f);
                 bytes = (int)bytes_written;
                 XFCLOSE(f);
             }
         }
-        ForceZero(buf, bytes);
+        ForceZero(buf, (word32)bytes);
     #ifdef WOLFSSL_SMALL_STACK
         XFREE(buf, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     #elif defined(WOLFSSL_CHECK_MEM_ZERO)
@@ -33168,8 +23804,9 @@ int wolfSSL_RAND_write_file(const char* fname)
 #ifndef FREERTOS_TCP
 
 /* These constant values are protocol values made by egd */
-#if defined(USE_WOLFSSL_IO) && !defined(USE_WINDOWS_API) && !defined(HAVE_FIPS) && \
-    defined(HAVE_HASHDRBG) && !defined(NETOS) && defined(HAVE_SYS_UN_H)
+#if defined(USE_WOLFSSL_IO) && !defined(USE_WINDOWS_API) && \
+    !defined(HAVE_FIPS) && defined(HAVE_HASHDRBG) && !defined(NETOS) && \
+    defined(HAVE_SYS_UN_H)
     #define WOLFSSL_EGD_NBLOCK 0x01
     #include <sys/un.h>
 #endif
@@ -33316,7 +23953,7 @@ int wolfSSL_RAND_egd(const char* nm)
     close(fd);
 
     if (ret == WOLFSSL_SUCCESS) {
-        return bytes;
+        return (int)bytes;
     }
     else {
         return ret;
@@ -33357,7 +23994,8 @@ void wolfSSL_RAND_Cleanup(void)
 #endif
 }
 
-/* returns WOLFSSL_SUCCESS if the bytes generated are valid otherwise WOLFSSL_FAILURE */
+/* returns WOLFSSL_SUCCESS if the bytes generated are valid otherwise
+ * WOLFSSL_FAILURE */
 int wolfSSL_RAND_pseudo_bytes(unsigned char* buf, int num)
 {
     int ret;
@@ -33407,7 +24045,8 @@ int wolfSSL_RAND_pseudo_bytes(unsigned char* buf, int num)
     return ret;
 }
 
-/* returns WOLFSSL_SUCCESS if the bytes generated are valid otherwise WOLFSSL_FAILURE */
+/* returns WOLFSSL_SUCCESS if the bytes generated are valid otherwise
+ * WOLFSSL_FAILURE */
 int wolfSSL_RAND_bytes(unsigned char* buf, int num)
 {
     int     ret = 0;
@@ -33445,11 +24084,19 @@ int wolfSSL_RAND_bytes(unsigned char* buf, int num)
             WOLFSSL_MSG("Bad Lock Mutex rng");
             return ret;
         }
-
-        rng = &globalRNG;
-        used_global = 1;
+        /* the above access to initGlobalRNG is racey -- recheck it now that we
+         * have the lock.
+         */
+        if (initGlobalRNG) {
+            rng = &globalRNG;
+            used_global = 1;
+        }
+        else {
+            wc_UnLockMutex(&globalRNGMutex);
+        }
     }
-    else
+
+    if (used_global == 0)
 #endif
     {
     #ifdef WOLFSSL_SMALL_STACK
@@ -33477,7 +24124,7 @@ int wolfSSL_RAND_bytes(unsigned char* buf, int num)
         }
 
         if (ret == 0 && num)
-            ret = wc_RNG_GenerateBlock(rng, buf, num);
+            ret = wc_RNG_GenerateBlock(rng, buf, (word32)num);
 
         if (ret != 0)
             WOLFSSL_MSG("Bad wc_RNG_GenerateBlock");
@@ -33529,7 +24176,8 @@ int wolfSSL_RAND_poll(void)
     int wolfSSL_RAND_set_rand_method(const WOLFSSL_RAND_METHOD *methods)
     {
     #ifndef WOLFSSL_NO_OPENSSL_RAND_CB
-        if (wolfSSL_RAND_InitMutex() == 0 && wc_LockMutex(&gRandMethodMutex) == 0) {
+        if (wolfSSL_RAND_InitMutex() == 0 &&
+                wc_LockMutex(&gRandMethodMutex) == 0) {
             gRandMethods = methods;
             wc_UnLockMutex(&gRandMethodMutex);
             return WOLFSSL_SUCCESS;
@@ -33545,7 +24193,8 @@ int wolfSSL_RAND_poll(void)
     {
         int ret = WOLFSSL_SUCCESS;
     #ifndef WOLFSSL_NO_OPENSSL_RAND_CB
-        if (wolfSSL_RAND_InitMutex() == 0 && wc_LockMutex(&gRandMethodMutex) == 0) {
+        if (wolfSSL_RAND_InitMutex() == 0 &&
+                wc_LockMutex(&gRandMethodMutex) == 0) {
             if (gRandMethods && gRandMethods->status)
                 ret = gRandMethods->status();
             wc_UnLockMutex(&gRandMethodMutex);
@@ -33562,7 +24211,8 @@ int wolfSSL_RAND_poll(void)
     void wolfSSL_RAND_add(const void* add, int len, double entropy)
     {
     #ifndef WOLFSSL_NO_OPENSSL_RAND_CB
-        if (wolfSSL_RAND_InitMutex() == 0 && wc_LockMutex(&gRandMethodMutex) == 0) {
+        if (wolfSSL_RAND_InitMutex() == 0 &&
+                wc_LockMutex(&gRandMethodMutex) == 0) {
             if (gRandMethods && gRandMethods->add) {
                 /* callback has return code, but RAND_add does not */
                 (void)gRandMethods->add(add, len, entropy);
@@ -33577,6 +24227,24 @@ int wolfSSL_RAND_poll(void)
         (void)entropy;
     #endif
     }
+
+
+#ifndef NO_WOLFSSL_STUB
+void wolfSSL_RAND_screen(void)
+{
+    WOLFSSL_STUB("RAND_screen");
+}
+#endif
+
+int wolfSSL_RAND_load_file(const char* fname, long len)
+{
+    (void)fname;
+    /* wolfCrypt provides enough entropy internally or will report error */
+    if (len == -1)
+        return 1024;
+    else
+        return (int)len;
+}
 
 #endif /* OPENSSL_EXTRA */
 
@@ -33946,2082 +24614,8 @@ void wolfSSL_aes_ctr_iv(WOLFSSL_EVP_CIPHER_CTX* ctx, int doset,
 #define WOLFSSL_X509_STORE_INCLUDED
 #include <src/x509_str.c>
 
-/*******************************************************************************
- * START OF PKCS7 APIs
- ******************************************************************************/
-#ifdef HAVE_PKCS7
-
-#ifdef OPENSSL_ALL
-PKCS7* wolfSSL_PKCS7_new(void)
-{
-    WOLFSSL_PKCS7* pkcs7;
-    int ret = 0;
-
-    pkcs7 = (WOLFSSL_PKCS7*)XMALLOC(sizeof(WOLFSSL_PKCS7), NULL,
-                                    DYNAMIC_TYPE_PKCS7);
-    if (pkcs7 != NULL) {
-        XMEMSET(pkcs7, 0, sizeof(WOLFSSL_PKCS7));
-        ret = wc_PKCS7_Init(&pkcs7->pkcs7, NULL, INVALID_DEVID);
-    }
-
-    if (ret != 0 && pkcs7 != NULL) {
-        XFREE(pkcs7, NULL, DYNAMIC_TYPE_PKCS7);
-        pkcs7 = NULL;
-    }
-
-    return (PKCS7*)pkcs7;
-}
-
-/******************************************************************************
-* wolfSSL_PKCS7_SIGNED_new - allocates PKCS7 and initialize it for a signed data
-*
-* RETURNS:
-* returns pointer to the PKCS7 structure on success, otherwise returns NULL
-*/
-PKCS7_SIGNED* wolfSSL_PKCS7_SIGNED_new(void)
-{
-    byte signedData[]= { 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x07, 0x02};
-    PKCS7* pkcs7 = NULL;
-
-    if ((pkcs7 = wolfSSL_PKCS7_new()) == NULL)
-        return NULL;
-    pkcs7->contentOID = SIGNED_DATA;
-    if ((wc_PKCS7_SetContentType(pkcs7, signedData, sizeof(signedData))) < 0) {
-        if (pkcs7) {
-            wolfSSL_PKCS7_free(pkcs7);
-            return NULL;
-        }
-    }
-    return pkcs7;
-}
-
-void wolfSSL_PKCS7_free(PKCS7* pkcs7)
-{
-    WOLFSSL_PKCS7* p7 = (WOLFSSL_PKCS7*)pkcs7;
-
-    if (p7 != NULL) {
-        if (p7->data != NULL)
-            XFREE(p7->data, NULL, DYNAMIC_TYPE_PKCS7);
-        wc_PKCS7_Free(&p7->pkcs7);
-        if (p7->certs)
-            wolfSSL_sk_pop_free(p7->certs, NULL);
-        XFREE(p7, NULL, DYNAMIC_TYPE_PKCS7);
-    }
-}
-
-void wolfSSL_PKCS7_SIGNED_free(PKCS7_SIGNED* p7)
-{
-    wolfSSL_PKCS7_free(p7);
-    return;
-}
-
-/**
- * Convert DER/ASN.1 encoded signedData structure to internal PKCS7
- * structure. Note, does not support detached content.
- *
- * p7 - pointer to set to address of newly created PKCS7 structure on return
- * in - pointer to pointer of DER/ASN.1 data
- * len - length of input data, bytes
- *
- * Returns newly allocated and populated PKCS7 structure or NULL on error.
- */
-PKCS7* wolfSSL_d2i_PKCS7(PKCS7** p7, const unsigned char** in, int len)
-{
-    return wolfSSL_d2i_PKCS7_ex(p7, in, len, NULL, 0);
-}
-
-/* This internal function is only decoding and setting up the PKCS7 struct. It
-* does not verify the PKCS7 signature.
-*
-* RETURNS:
-* returns pointer to a PKCS7 structure on success, otherwise returns NULL
-*/
-static PKCS7* wolfSSL_d2i_PKCS7_only(PKCS7** p7, const unsigned char** in,
-    int len, byte* content, word32 contentSz)
-{
-    WOLFSSL_PKCS7* pkcs7 = NULL;
-
-    WOLFSSL_ENTER("wolfSSL_d2i_PKCS7_ex");
-
-    if (in == NULL || *in == NULL || len < 0)
-        return NULL;
-
-    if ((pkcs7 = (WOLFSSL_PKCS7*)wolfSSL_PKCS7_new()) == NULL)
-        return NULL;
-
-    pkcs7->len = len;
-    pkcs7->data = (byte*)XMALLOC(pkcs7->len, NULL, DYNAMIC_TYPE_PKCS7);
-    if (pkcs7->data == NULL) {
-        wolfSSL_PKCS7_free((PKCS7*)pkcs7);
-        return NULL;
-    }
-    XMEMCPY(pkcs7->data, *in, pkcs7->len);
-
-    if (content != NULL) {
-        pkcs7->pkcs7.content = content;
-        pkcs7->pkcs7.contentSz = contentSz;
-    }
-
-    if (p7 != NULL)
-        *p7 = (PKCS7*)pkcs7;
-    *in += pkcs7->len;
-    return (PKCS7*)pkcs7;
-}
-
-
-/*****************************************************************************
-* wolfSSL_d2i_PKCS7_ex - Converts the given unsigned char buffer of size len
-* into a PKCS7 object.  Optionally, accepts a byte buffer of content which
-* is stored as the PKCS7 object's content, to support detached signatures.
-* @param content The content which is signed, in case the signature is
-*                detached.  Ignored if NULL.
-* @param contentSz The size of the passed in content.
-*
-* RETURNS:
-* returns pointer to a PKCS7 structure on success, otherwise returns NULL
-*/
-PKCS7* wolfSSL_d2i_PKCS7_ex(PKCS7** p7, const unsigned char** in, int len,
-        byte* content, word32 contentSz)
-{
-    WOLFSSL_PKCS7* pkcs7 = NULL;
-
-    WOLFSSL_ENTER("wolfSSL_d2i_PKCS7_ex");
-
-    if (in == NULL || *in == NULL || len < 0)
-        return NULL;
-
-    pkcs7 = (WOLFSSL_PKCS7*)wolfSSL_d2i_PKCS7_only(p7, in, len, content,
-            contentSz);
-    if (pkcs7 != NULL) {
-        if (wc_PKCS7_VerifySignedData(&pkcs7->pkcs7, pkcs7->data, pkcs7->len)
-                                                                         != 0) {
-            WOLFSSL_MSG("wc_PKCS7_VerifySignedData failed");
-            wolfSSL_PKCS7_free((PKCS7*)pkcs7);
-            if (p7 != NULL) {
-                *p7 = NULL;
-            }
-            return NULL;
-        }
-    }
-
-    return (PKCS7*)pkcs7;
-}
-
-
-/**
- * This API was added as a helper function for libest. It
- * extracts a stack of certificates from the pkcs7 object.
- * @param pkcs7 PKCS7 parameter object
- * @return WOLFSSL_STACK_OF(WOLFSSL_X509)*
- */
-WOLFSSL_STACK* wolfSSL_PKCS7_to_stack(PKCS7* pkcs7)
-{
-    int i;
-    WOLFSSL_PKCS7* p7 = (WOLFSSL_PKCS7*)pkcs7;
-    WOLF_STACK_OF(WOLFSSL_X509)* ret = NULL;
-
-    WOLFSSL_ENTER("wolfSSL_PKCS7_to_stack");
-
-    if (!p7) {
-        WOLFSSL_MSG("Bad parameter");
-        return NULL;
-    }
-
-    if (p7->certs)
-        return p7->certs;
-
-    for (i = 0; i < MAX_PKCS7_CERTS && p7->pkcs7.cert[i]; i++) {
-        WOLFSSL_X509* x509 = wolfSSL_X509_d2i_ex(NULL, p7->pkcs7.cert[i],
-            p7->pkcs7.certSz[i], pkcs7->heap);
-        if (!ret)
-            ret = wolfSSL_sk_X509_new_null();
-        if (x509) {
-            if (wolfSSL_sk_X509_push(ret, x509) != WOLFSSL_SUCCESS) {
-                wolfSSL_X509_free(x509);
-                WOLFSSL_MSG("wolfSSL_sk_X509_push error");
-                goto error;
-            }
-        }
-        else {
-            WOLFSSL_MSG("wolfSSL_X509_d2i error");
-            goto error;
-        }
-    }
-
-    /* Save stack to free later */
-    if (p7->certs)
-        wolfSSL_sk_pop_free(p7->certs, NULL);
-    p7->certs = ret;
-
-    return ret;
-error:
-    if (ret) {
-        wolfSSL_sk_pop_free(ret, NULL);
-    }
-    return NULL;
-}
-
-/**
- * Return stack of signers contained in PKCS7 cert.
- * Notes:
- * - Currently only PKCS#7 messages with a single signer cert is supported.
- * - Returned WOLFSSL_STACK must be freed by caller.
- *
- * pkcs7 - PKCS7 struct to retrieve signer certs from.
- * certs - currently unused
- * flags - flags to control function behavior.
- *
- * Return WOLFSSL_STACK of signers on success, NULL on error.
- */
-WOLFSSL_STACK* wolfSSL_PKCS7_get0_signers(PKCS7* pkcs7, WOLFSSL_STACK* certs,
-                                          int flags)
-{
-    WOLFSSL_X509* x509 = NULL;
-    WOLFSSL_STACK* signers = NULL;
-    WOLFSSL_PKCS7* p7 = (WOLFSSL_PKCS7*)pkcs7;
-
-    if (p7 == NULL)
-        return NULL;
-
-    /* Only PKCS#7 messages with a single cert that is the verifying certificate
-     * is supported.
-     */
-    if (flags & PKCS7_NOINTERN) {
-        WOLFSSL_MSG("PKCS7_NOINTERN flag not supported");
-        return NULL;
-    }
-
-    signers = wolfSSL_sk_X509_new_null();
-    if (signers == NULL)
-        return NULL;
-
-    if (wolfSSL_d2i_X509(&x509, (const byte**)&p7->pkcs7.singleCert,
-                         p7->pkcs7.singleCertSz) == NULL) {
-        wolfSSL_sk_X509_pop_free(signers, NULL);
-        return NULL;
-    }
-
-    if (wolfSSL_sk_X509_push(signers, x509) != WOLFSSL_SUCCESS) {
-        wolfSSL_sk_X509_pop_free(signers, NULL);
-        return NULL;
-    }
-
-    (void)certs;
-
-    return signers;
-}
-
-#ifndef NO_BIO
-
-PKCS7* wolfSSL_d2i_PKCS7_bio(WOLFSSL_BIO* bio, PKCS7** p7)
-{
-    WOLFSSL_PKCS7* pkcs7;
-    int ret;
-
-    WOLFSSL_ENTER("wolfSSL_d2i_PKCS7_bio");
-
-    if (bio == NULL)
-        return NULL;
-
-    if ((pkcs7 = (WOLFSSL_PKCS7*)wolfSSL_PKCS7_new()) == NULL)
-        return NULL;
-
-    pkcs7->len = wolfSSL_BIO_get_len(bio);
-    pkcs7->data = (byte*)XMALLOC(pkcs7->len, NULL, DYNAMIC_TYPE_PKCS7);
-    if (pkcs7->data == NULL) {
-        wolfSSL_PKCS7_free((PKCS7*)pkcs7);
-        return NULL;
-    }
-
-    if ((ret = wolfSSL_BIO_read(bio, pkcs7->data, pkcs7->len)) <= 0) {
-        wolfSSL_PKCS7_free((PKCS7*)pkcs7);
-        return NULL;
-    }
-    /* pkcs7->len may change if using b64 for example */
-    pkcs7->len = ret;
-
-    if (wc_PKCS7_VerifySignedData(&pkcs7->pkcs7, pkcs7->data, pkcs7->len)
-                                                                         != 0) {
-        WOLFSSL_MSG("wc_PKCS7_VerifySignedData failed");
-        wolfSSL_PKCS7_free((PKCS7*)pkcs7);
-        return NULL;
-    }
-
-    if (p7 != NULL)
-        *p7 = (PKCS7*)pkcs7;
-    return (PKCS7*)pkcs7;
-}
-
-int wolfSSL_i2d_PKCS7(PKCS7 *p7, unsigned char **out)
-{
-    byte* output = NULL;
-    int localBuf = 0;
-    int len;
-    WC_RNG rng;
-    int ret = WOLFSSL_FAILURE;
-    WOLFSSL_ENTER("wolfSSL_i2d_PKCS7");
-
-    if (!out || !p7) {
-        WOLFSSL_MSG("Bad parameter");
-        return WOLFSSL_FAILURE;
-    }
-
-    if (!p7->rng) {
-        if (wc_InitRng(&rng) != 0) {
-            WOLFSSL_MSG("wc_InitRng error");
-            return WOLFSSL_FAILURE;
-        }
-        p7->rng = &rng; /* cppcheck-suppress autoVariables
-                         */
-    }
-
-    if ((len = wc_PKCS7_EncodeSignedData(p7, NULL, 0)) < 0) {
-        WOLFSSL_MSG("wc_PKCS7_EncodeSignedData error");
-        goto cleanup;
-    }
-
-    if (*out == NULL) {
-        output = (byte*)XMALLOC(len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-        if (!output) {
-            WOLFSSL_MSG("malloc error");
-            goto cleanup;
-        }
-        localBuf = 1;
-    }
-    else {
-        output = *out;
-    }
-
-    if ((len = wc_PKCS7_EncodeSignedData(p7, output, len)) < 0) {
-        WOLFSSL_MSG("wc_PKCS7_EncodeSignedData error");
-        goto cleanup;
-    }
-
-    ret = len;
-cleanup:
-    if (p7->rng == &rng) {
-        wc_FreeRng(&rng);
-        p7->rng = NULL;
-    }
-    if (ret == WOLFSSL_FAILURE && localBuf && output)
-        XFREE(output, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    if (ret != WOLFSSL_FAILURE)
-        *out = output;
-    return ret;
-}
-
-int wolfSSL_i2d_PKCS7_bio(WOLFSSL_BIO *bio, PKCS7 *p7)
-{
-    byte* output = NULL;
-    int len;
-    int ret = WOLFSSL_FAILURE;
-    WOLFSSL_ENTER("wolfSSL_i2d_PKCS7_bio");
-
-    if (!bio || !p7) {
-        WOLFSSL_MSG("Bad parameter");
-        return WOLFSSL_FAILURE;
-    }
-
-    if ((len = wolfSSL_i2d_PKCS7(p7, &output)) == WOLFSSL_FAILURE) {
-        WOLFSSL_MSG("wolfSSL_i2d_PKCS7 error");
-        goto cleanup;
-    }
-
-    if (wolfSSL_BIO_write(bio, output, len) <= 0) {
-        WOLFSSL_MSG("wolfSSL_BIO_write error");
-        goto cleanup;
-    }
-
-    ret = WOLFSSL_SUCCESS;
-cleanup:
-    if (output)
-        XFREE(output, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    return ret;
-}
-
-/**
- * Creates and returns a PKCS7 signedData structure.
- *
- * Inner content type is set to DATA to match OpenSSL behavior.
- *
- * signer   - certificate to sign bundle with
- * pkey     - private key matching signer
- * certs    - optional additional set of certificates to include
- * in       - input data to be signed
- * flags    - optional set of flags to control sign behavior
- *
- *    PKCS7_BINARY   - Do not translate input data to MIME canonical
- *                     format (\r\n line endings), thus preventing corruption of
- *                     binary content.
- *    PKCS7_TEXT     - Prepend MIME headers for text/plain to content.
- *    PKCS7_DETACHED - Set signature detached, omit content from output bundle.
- *    PKCS7_STREAM   - initialize PKCS7 struct for signing, do not read data.
- *
- * Flags not currently supported:
- *    PKCS7_NOCERTS  - Do not include the signer cert in the output bundle.
- *    PKCS7_PARTIAL  - Allow for PKCS7_sign() to be only partially set up,
- *                     then signers etc to be added separately before
- *                     calling PKCS7_final().
- *
- * Returns valid PKCS7 structure pointer, or NULL if an error occurred.
- */
-PKCS7* wolfSSL_PKCS7_sign(WOLFSSL_X509* signer, WOLFSSL_EVP_PKEY* pkey,
-        WOLFSSL_STACK* certs, WOLFSSL_BIO* in, int flags)
-{
-    int err = 0;
-    WOLFSSL_PKCS7* p7 = NULL;
-    WOLFSSL_STACK* cert = certs;
-
-    WOLFSSL_ENTER("wolfSSL_PKCS7_sign");
-
-    if (flags & PKCS7_NOCERTS) {
-        WOLFSSL_MSG("PKCS7_NOCERTS flag not yet supported");
-        err = 1;
-    }
-
-    if (flags & PKCS7_PARTIAL) {
-        WOLFSSL_MSG("PKCS7_PARTIAL flag not yet supported");
-        err = 1;
-    }
-
-    if ((err == 0) && (signer == NULL || signer->derCert == NULL ||
-                       signer->derCert->length == 0)) {
-        WOLFSSL_MSG("Bad function arg, signer is NULL or incomplete");
-        err = 1;
-    }
-
-    if ((err == 0) && (pkey == NULL || pkey->pkey.ptr == NULL ||
-                       pkey->pkey_sz <= 0)) {
-        WOLFSSL_MSG("Bad function arg, pkey is NULL or incomplete");
-        err = 1;
-    }
-
-    if ((err == 0) && (in == NULL) && !(flags & PKCS7_STREAM)) {
-        WOLFSSL_MSG("input data required unless PKCS7_STREAM used");
-        err = 1;
-    }
-
-    if ((err == 0) && ((p7 = (WOLFSSL_PKCS7*)wolfSSL_PKCS7_new()) == NULL)) {
-        WOLFSSL_MSG("Error allocating new WOLFSSL_PKCS7");
-        err = 1;
-    }
-
-    /* load signer certificate */
-    if (err == 0) {
-        if (wc_PKCS7_InitWithCert(&p7->pkcs7, signer->derCert->buffer,
-                                  signer->derCert->length) != 0) {
-            WOLFSSL_MSG("Failed to load signer certificate");
-            err = 1;
-        }
-    }
-
-    /* set signer private key, data types, defaults */
-    if (err == 0) {
-        p7->pkcs7.privateKey = (byte*)pkey->pkey.ptr;
-        p7->pkcs7.privateKeySz = pkey->pkey_sz;
-        p7->pkcs7.contentOID = DATA;  /* inner content default is DATA */
-        p7->pkcs7.hashOID = SHA256h;  /* default to SHA-256 hash type */
-        p7->type = SIGNED_DATA;       /* PKCS7_final switches on type */
-    }
-
-    /* add additional chain certs if provided */
-    while (cert && (err == 0)) {
-        if (cert->data.x509 != NULL && cert->data.x509->derCert != NULL) {
-            if (wc_PKCS7_AddCertificate(&p7->pkcs7,
-                                cert->data.x509->derCert->buffer,
-                                cert->data.x509->derCert->length) != 0) {
-                WOLFSSL_MSG("Error in wc_PKCS7_AddCertificate");
-                err = 1;
-            }
-        }
-        cert = cert->next;
-    }
-
-    if ((err == 0) && (flags & PKCS7_DETACHED)) {
-        if (wc_PKCS7_SetDetached(&p7->pkcs7, 1) != 0) {
-            WOLFSSL_MSG("Failed to set signature detached");
-            err = 1;
-        }
-    }
-
-    if ((err == 0) && (flags & PKCS7_STREAM)) {
-        /* if streaming, return before finalizing */
-        return (PKCS7*)p7;
-    }
-
-    if ((err == 0) && (wolfSSL_PKCS7_final((PKCS7*)p7, in, flags) != 1)) {
-        WOLFSSL_MSG("Error calling wolfSSL_PKCS7_final");
-        err = 1;
-    }
-
-    if ((err != 0) && (p7 != NULL)) {
-        wolfSSL_PKCS7_free((PKCS7*)p7);
-        p7 = NULL;
-    }
-
-    return (PKCS7*)p7;
-}
-
-#ifdef HAVE_SMIME
-
-#ifndef MAX_MIME_LINE_LEN
-    #define MAX_MIME_LINE_LEN 1024
-#endif
-
-/**
- * Copy input BIO to output BIO, but convert all line endings to CRLF (\r\n),
- * used by PKCS7_final().
- *
- * in  - input WOLFSSL_BIO to be converted
- * out - output WOLFSSL_BIO to hold copy of in, with line endings adjusted
- *
- * Return 0 on success, negative on error
- */
-static int wolfSSL_BIO_to_MIME_crlf(WOLFSSL_BIO* in, WOLFSSL_BIO* out)
-{
-    int ret = 0;
-    int lineLen = 0;
-    word32 canonLineLen = 0;
-    char* canonLine = NULL;
-#ifdef WOLFSSL_SMALL_STACK
-    char* line = NULL;
-#else
-    char line[MAX_MIME_LINE_LEN];
-#endif
-
-    if (in == NULL || out == NULL) {
-        return BAD_FUNC_ARG;
-    }
-
-#ifdef WOLFSSL_SMALL_STACK
-    line = (char*)XMALLOC(MAX_MIME_LINE_LEN, in->heap,
-                          DYNAMIC_TYPE_TMP_BUFFER);
-    if (line == NULL) {
-        return MEMORY_E;
-    }
-#endif
-    XMEMSET(line, 0, MAX_MIME_LINE_LEN);
-
-    while ((lineLen = wolfSSL_BIO_gets(in, line, MAX_MIME_LINE_LEN)) > 0) {
-
-        if (line[lineLen - 1] == '\r' || line[lineLen - 1] == '\n') {
-            canonLineLen = (word32)lineLen;
-            if ((canonLine = wc_MIME_single_canonicalize(
-                                line, &canonLineLen)) == NULL) {
-                ret = -1;
-                break;
-            }
-
-            /* remove trailing null */
-            if (canonLineLen >= 1 && canonLine[canonLineLen-1] == '\0') {
-                canonLineLen--;
-            }
-
-            if (wolfSSL_BIO_write(out, canonLine, (int)canonLineLen) < 0) {
-                ret = -1;
-                break;
-            }
-            XFREE(canonLine, NULL, DYNAMIC_TYPE_PKCS7);
-            canonLine = NULL;
-        }
-        else {
-            /* no line ending in current line, write direct to out */
-            if (wolfSSL_BIO_write(out, line, lineLen) < 0) {
-                ret = -1;
-                break;
-            }
-        }
-    }
-
-    if (canonLine != NULL) {
-        XFREE(canonLine, NULL, DYNAMIC_TYPE_PKCS7);
-    }
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(line, in->heap, DYNAMIC_TYPE_TMP_BUFFER);
-#endif
-
-    return ret;
-}
-
-#endif /* HAVE_SMIME */
-
-/* Used by both PKCS7_final() and PKCS7_verify() */
-static const char contTypeText[] = "Content-Type: text/plain\r\n\r\n";
-
-/**
- * Finalize PKCS7 structure, currently supports signedData only.
- *
- * Does not generate final bundle (ie: signedData), but finalizes
- * the PKCS7 structure in preparation for a output function to be called next.
- *
- * pkcs7 - initialized PKCS7 structure, populated with signer, etc
- * in    - input data
- * flags - flags to control PKCS7 behavior. Other flags except those noted
- *         below are ignored:
- *
- *    PKCS7_BINARY - Do not translate input data to MIME canonical
- *                   format (\r\n line endings), thus preventing corruption of
- *                   binary content.
- *    PKCS7_TEXT   - Prepend MIME headers for text/plain to content.
- *
- * Returns 1 on success, 0 on error
- */
-int wolfSSL_PKCS7_final(PKCS7* pkcs7, WOLFSSL_BIO* in, int flags)
-{
-    int ret = 1;
-    int memSz = 0;
-    unsigned char* mem = NULL;
-    WOLFSSL_PKCS7* p7 = (WOLFSSL_PKCS7*)pkcs7;
-    WOLFSSL_BIO* data = NULL;
-
-    WOLFSSL_ENTER("wolfSSL_PKCS7_final");
-
-    if (p7 == NULL || in == NULL) {
-        WOLFSSL_MSG("Bad input args to PKCS7_final");
-        ret = 0;
-    }
-
-    if (ret == 1) {
-        if ((data = wolfSSL_BIO_new(wolfSSL_BIO_s_mem())) == NULL) {
-            WOLFSSL_MSG("Error in wolfSSL_BIO_new");
-            ret = 0;
-        }
-    }
-
-    /* prepend Content-Type header if PKCS7_TEXT */
-    if ((ret == 1) && (flags & PKCS7_TEXT)) {
-        if (wolfSSL_BIO_write(data, contTypeText,
-                              (int)XSTR_SIZEOF(contTypeText)) < 0) {
-            WOLFSSL_MSG("Error prepending Content-Type header");
-            ret = 0;
-        }
-    }
-
-    /* convert line endings to CRLF if !PKCS7_BINARY */
-    if (ret == 1) {
-        if (flags & PKCS7_BINARY) {
-
-            /* no CRLF conversion, direct copy content */
-            if ((memSz = wolfSSL_BIO_get_len(in)) <= 0) {
-                ret = 0;
-            }
-            if (ret == 1) {
-                mem = (unsigned char*)XMALLOC(memSz, in->heap,
-                                              DYNAMIC_TYPE_TMP_BUFFER);
-                if (mem == NULL) {
-                    WOLFSSL_MSG("Failed to allocate memory for input data");
-                    ret = 0;
-                }
-            }
-
-            if (ret == 1) {
-                if (wolfSSL_BIO_read(in, mem, memSz) != memSz) {
-                    WOLFSSL_MSG("Error reading from input BIO");
-                    ret = 0;
-                }
-                else if (wolfSSL_BIO_write(data, mem, memSz) < 0) {
-                    ret = 0;
-                }
-            }
-
-            if (mem != NULL) {
-                XFREE(mem, in->heap, DYNAMIC_TYPE_TMP_BUFFER);
-            }
-        }
-        else {
-    #ifdef HAVE_SMIME
-            /* convert content line endings to CRLF */
-            if (wolfSSL_BIO_to_MIME_crlf(in, data) != 0) {
-                WOLFSSL_MSG("Error converting line endings to CRLF");
-                ret = 0;
-            }
-            else {
-                p7->pkcs7.contentCRLF = 1;
-            }
-    #else
-            WOLFSSL_MSG("Without PKCS7_BINARY requires wolfSSL to be built "
-                        "with HAVE_SMIME");
-            ret = 0;
-    #endif
-        }
-    }
-
-    if ((ret == 1) && ((memSz = wolfSSL_BIO_get_mem_data(data, &mem)) < 0)) {
-        WOLFSSL_MSG("Error in wolfSSL_BIO_get_mem_data");
-        ret = 0;
-    }
-
-    if (ret == 1) {
-        if (p7->data != NULL) {
-            XFREE(p7->data, NULL, DYNAMIC_TYPE_PKCS7);
-        }
-        p7->data = (byte*)XMALLOC(memSz, NULL, DYNAMIC_TYPE_PKCS7);
-        if (p7->data == NULL) {
-            ret = 0;
-        }
-        else {
-            XMEMCPY(p7->data, mem, memSz);
-            p7->len = memSz;
-        }
-    }
-
-    if (ret == 1) {
-        p7->pkcs7.content = p7->data;
-        p7->pkcs7.contentSz = p7->len;
-    }
-
-    if (data != NULL) {
-        wolfSSL_BIO_free(data);
-    }
-
-    return ret;
-}
-
-int wolfSSL_PKCS7_verify(PKCS7* pkcs7, WOLFSSL_STACK* certs,
-        WOLFSSL_X509_STORE* store, WOLFSSL_BIO* in, WOLFSSL_BIO* out, int flags)
-{
-    int i, ret = 0;
-    unsigned char* mem = NULL;
-    int memSz = 0;
-    WOLFSSL_PKCS7* p7 = (WOLFSSL_PKCS7*)pkcs7;
-    int contTypeLen;
-    WOLFSSL_X509* signer = NULL;
-    WOLFSSL_STACK* signers = NULL;
-
-    WOLFSSL_ENTER("wolfSSL_PKCS7_verify");
-
-    if (pkcs7 == NULL)
-        return WOLFSSL_FAILURE;
-
-    if (in != NULL) {
-        if ((memSz = wolfSSL_BIO_get_mem_data(in, &mem)) < 0)
-            return WOLFSSL_FAILURE;
-
-        p7->pkcs7.content = mem;
-        p7->pkcs7.contentSz = memSz;
-    }
-
-    /* certs is the list of certificates to find the cert with issuer/serial. */
-    (void)certs;
-    /* store is the certificate store to use to verify signer certificate
-     * associated with the signers.
-     */
-    (void)store;
-
-    ret = wc_PKCS7_VerifySignedData(&p7->pkcs7, p7->data, p7->len);
-    if (ret != 0)
-        return WOLFSSL_FAILURE;
-
-    if ((flags & PKCS7_NOVERIFY) != PKCS7_NOVERIFY) {
-        /* Verify signer certificates */
-        if (store == NULL || store->cm == NULL) {
-            WOLFSSL_MSG("No store or store certs, but PKCS7_NOVERIFY not set");
-            return WOLFSSL_FAILURE;
-        }
-
-        signers = wolfSSL_PKCS7_get0_signers(pkcs7, certs, flags);
-        if (signers == NULL) {
-            WOLFSSL_MSG("No signers found to verify");
-            return WOLFSSL_FAILURE;
-        }
-        for (i = 0; i < wolfSSL_sk_X509_num(signers); i++) {
-            signer = wolfSSL_sk_X509_value(signers, i);
-
-            if (wolfSSL_CertManagerVerifyBuffer(store->cm,
-                        signer->derCert->buffer,
-                        signer->derCert->length,
-                        WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS) {
-                WOLFSSL_MSG("Failed to verify signer certificate");
-                wolfSSL_sk_X509_pop_free(signers, NULL);
-                return WOLFSSL_FAILURE;
-            }
-        }
-        wolfSSL_sk_X509_pop_free(signers, NULL);
-    }
-
-    if (flags & PKCS7_TEXT) {
-        /* strip MIME header for text/plain, otherwise error */
-        contTypeLen = XSTR_SIZEOF(contTypeText);
-        if ((p7->pkcs7.contentSz < (word32)contTypeLen) ||
-            (XMEMCMP(p7->pkcs7.content, contTypeText, contTypeLen) != 0)) {
-            WOLFSSL_MSG("Error PKCS7 Content-Type not found with PKCS7_TEXT");
-            return WOLFSSL_FAILURE;
-        }
-        p7->pkcs7.content += contTypeLen;
-        p7->pkcs7.contentSz -= contTypeLen;
-    }
-
-    if (out != NULL) {
-        wolfSSL_BIO_write(out, p7->pkcs7.content, p7->pkcs7.contentSz);
-    }
-
-    WOLFSSL_LEAVE("wolfSSL_PKCS7_verify", WOLFSSL_SUCCESS);
-
-    return WOLFSSL_SUCCESS;
-}
-
-/**
- * This API was added as a helper function for libest. It
- * encodes a stack of certificates to pkcs7 format.
- * @param pkcs7 PKCS7 parameter object
- * @param certs WOLFSSL_STACK_OF(WOLFSSL_X509)*
- * @param out   Output bio
- * @return WOLFSSL_SUCCESS on success and WOLFSSL_FAILURE on failure
- */
-int wolfSSL_PKCS7_encode_certs(PKCS7* pkcs7, WOLFSSL_STACK* certs,
-        WOLFSSL_BIO* out)
-{
-    int ret;
-    WOLFSSL_PKCS7* p7;
-    WOLFSSL_ENTER("wolfSSL_PKCS7_encode_certs");
-
-    if (!pkcs7 || !certs || !out) {
-        WOLFSSL_MSG("Bad parameter");
-        return WOLFSSL_FAILURE;
-    }
-
-    p7 = (WOLFSSL_PKCS7*)pkcs7;
-
-    /* take ownership of certs */
-    p7->certs = certs;
-    /* TODO: takes ownership even on failure below but not on above failure. */
-
-    if (pkcs7->certList) {
-        WOLFSSL_MSG("wolfSSL_PKCS7_encode_certs called multiple times on same "
-                    "struct");
-        return WOLFSSL_FAILURE;
-    }
-
-    if (certs) {
-        /* Save some of the values */
-        int hashOID = pkcs7->hashOID;
-        byte version = pkcs7->version;
-
-        if (!certs->data.x509 || !certs->data.x509->derCert) {
-            WOLFSSL_MSG("Missing cert");
-            return WOLFSSL_FAILURE;
-        }
-
-        if (wc_PKCS7_InitWithCert(pkcs7, certs->data.x509->derCert->buffer,
-                                      certs->data.x509->derCert->length) != 0) {
-            WOLFSSL_MSG("wc_PKCS7_InitWithCert error");
-            return WOLFSSL_FAILURE;
-        }
-        certs = certs->next;
-
-        pkcs7->hashOID = hashOID;
-        pkcs7->version = version;
-    }
-
-    /* Add the certs to the PKCS7 struct */
-    while (certs) {
-        if (!certs->data.x509 || !certs->data.x509->derCert) {
-            WOLFSSL_MSG("Missing cert");
-            return WOLFSSL_FAILURE;
-        }
-        if (wc_PKCS7_AddCertificate(pkcs7, certs->data.x509->derCert->buffer,
-                                      certs->data.x509->derCert->length) != 0) {
-            WOLFSSL_MSG("wc_PKCS7_AddCertificate error");
-            return WOLFSSL_FAILURE;
-        }
-        certs = certs->next;
-    }
-
-    if (wc_PKCS7_SetSignerIdentifierType(pkcs7, DEGENERATE_SID) != 0) {
-        WOLFSSL_MSG("wc_PKCS7_SetSignerIdentifierType error");
-        return WOLFSSL_FAILURE;
-    }
-
-    ret = wolfSSL_i2d_PKCS7_bio(out, pkcs7);
-
-    return ret;
-}
-
-/******************************************************************************
-* wolfSSL_PEM_write_bio_PKCS7 - writes the PKCS7 data to BIO
-*
-* RETURNS:
-* returns WOLFSSL_SUCCESS on success, otherwise returns WOLFSSL_FAILURE
-*/
-int wolfSSL_PEM_write_bio_PKCS7(WOLFSSL_BIO* bio, PKCS7* p7)
-{
-#ifdef WOLFSSL_SMALL_STACK
-    byte* outputHead;
-    byte* outputFoot;
-#else
-    byte outputHead[2048];
-    byte outputFoot[2048];
-#endif
-    word32 outputHeadSz = 2048;
-    word32 outputFootSz = 2048;
-    word32 outputSz = 0;
-    byte*  output = NULL;
-    byte*  pem = NULL;
-    int    pemSz = -1;
-    enum wc_HashType hashType;
-    byte hashBuf[WC_MAX_DIGEST_SIZE];
-    word32 hashSz = -1;
-
-    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_PKCS7");
-
-    if (bio == NULL || p7 == NULL)
-        return WOLFSSL_FAILURE;
-
-#ifdef WOLFSSL_SMALL_STACK
-    outputHead = (byte*)XMALLOC(outputHeadSz, bio->heap,
-        DYNAMIC_TYPE_TMP_BUFFER);
-    if (outputHead == NULL)
-        return MEMORY_E;
-
-    outputFoot = (byte*)XMALLOC(outputFootSz, bio->heap,
-        DYNAMIC_TYPE_TMP_BUFFER);
-    if (outputFoot == NULL)
-        goto error;
-
-#endif
-
-    XMEMSET(hashBuf, 0, WC_MAX_DIGEST_SIZE);
-    XMEMSET(outputHead, 0, outputHeadSz);
-    XMEMSET(outputFoot, 0, outputFootSz);
-
-    hashType = wc_OidGetHash(p7->hashOID);
-    hashSz = wc_HashGetDigestSize(hashType);
-    if (hashSz > WC_MAX_DIGEST_SIZE)
-        goto error;
-
-    /* only SIGNED_DATA is supported */
-    switch (p7->contentOID) {
-        case SIGNED_DATA:
-            break;
-        default:
-            WOLFSSL_MSG("Unknown PKCS#7 Type");
-            goto error;
-    };
-
-    if ((wc_PKCS7_EncodeSignedData_ex(p7, hashBuf, hashSz,
-        outputHead, &outputHeadSz, outputFoot, &outputFootSz)) != 0)
-        goto error;
-
-    outputSz = outputHeadSz + p7->contentSz + outputFootSz;
-    output = (byte*)XMALLOC(outputSz, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
-
-    if (!output)
-        goto error;
-
-    XMEMSET(output, 0, outputSz);
-    outputSz = 0;
-    XMEMCPY(&output[outputSz], outputHead, outputHeadSz);
-    outputSz += outputHeadSz;
-    XMEMCPY(&output[outputSz], p7->content, p7->contentSz);
-    outputSz += p7->contentSz;
-    XMEMCPY(&output[outputSz], outputFoot, outputFootSz);
-    outputSz += outputFootSz;
-
-    /* get PEM size */
-    pemSz = wc_DerToPemEx(output, outputSz, NULL, 0, NULL, CERT_TYPE);
-    if (pemSz < 0)
-        goto error;
-
-    pemSz++; /* for '\0'*/
-
-    /* create PEM buffer and convert from DER to PEM*/
-    if ((pem = (byte*)XMALLOC(pemSz, bio->heap, DYNAMIC_TYPE_TMP_BUFFER))
-                                                                        == NULL)
-        goto error;
-
-    XMEMSET(pem, 0, pemSz);
-
-    if (wc_DerToPemEx(output, outputSz, pem, pemSz, NULL, CERT_TYPE) < 0) {
-        goto error;
-    }
-    if ((wolfSSL_BIO_write(bio, pem, pemSz) == pemSz)) {
-        XFREE(output, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(pem, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
-#ifdef WOLFSSL_SMALL_STACK
-        XFREE(outputHead, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
-        XFREE(outputFoot, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
-#endif
-        return WOLFSSL_SUCCESS;
-    }
-
-error:
-#ifdef WOLFSSL_SMALL_STACK
-    if (outputHead) {
-        XFREE(outputHead, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
-    }
-    if (outputFoot) {
-        XFREE(outputFoot, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
-    }
-#endif
-    if (output) {
-        XFREE(output, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
-    }
-    if (pem) {
-        XFREE(pem, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
-    }
-    return WOLFSSL_FAILURE;
-}
-
-#ifdef HAVE_SMIME
-/*****************************************************************************
-* wolfSSL_SMIME_read_PKCS7 - Reads the given S/MIME message and parses it into
-* a PKCS7 object. In case of a multipart message, stores the signed data in
-* bcont.
-*
-* RETURNS:
-* returns pointer to a PKCS7 structure on success, otherwise returns NULL
-*/
-PKCS7* wolfSSL_SMIME_read_PKCS7(WOLFSSL_BIO* in,
-        WOLFSSL_BIO** bcont)
-{
-    MimeHdr* allHdrs = NULL;
-    MimeHdr* curHdr = NULL;
-    MimeParam* curParam = NULL;
-    int inLen = 0;
-    byte* bcontMem = NULL;
-    int bcontMemSz = 0;
-    int sectionLen = 0;
-    int ret = -1;
-    char* section = NULL;
-    char* canonLine = NULL;
-    char* canonSection = NULL;
-    PKCS7* pkcs7 = NULL;
-    word32 outLen = 0;
-    word32 canonLineLen = 0;
-    byte* out = NULL;
-    byte* outHead = NULL;
-
-    int canonPos = 0;
-    int lineLen = 0;
-    int remainLen = 0;
-    byte isEnd = 0;
-    size_t canonSize = 0;
-    size_t boundLen = 0;
-    char* boundary = NULL;
-
-    static const char kContType[] = "Content-Type";
-    static const char kCTE[] = "Content-Transfer-Encoding";
-    static const char kMultSigned[] = "multipart/signed";
-    static const char kAppPkcsSign[] = "application/pkcs7-signature";
-    static const char kAppXPkcsSign[] = "application/x-pkcs7-signature";
-    static const char kAppPkcs7Mime[] = "application/pkcs7-mime";
-    static const char kAppXPkcs7Mime[] = "application/x-pkcs7-mime";
-
-    WOLFSSL_ENTER("wolfSSL_SMIME_read_PKCS7");
-
-    if (in == NULL || bcont == NULL) {
-        goto error;
-    }
-    inLen = wolfSSL_BIO_get_len(in);
-    if (inLen <= 0) {
-        goto error;
-    }
-    remainLen = wolfSSL_BIO_get_len(in);
-    if (remainLen <= 0) {
-        goto error;
-    }
-
-    section = (char*)XMALLOC(remainLen+1, NULL, DYNAMIC_TYPE_PKCS7);
-    if (section == NULL) {
-        goto error;
-    }
-    lineLen = wolfSSL_BIO_gets(in, section, remainLen);
-    if (lineLen <= 0) {
-        goto error;
-    }
-    while (isEnd == 0 && remainLen > 0) {
-        sectionLen += lineLen;
-        remainLen -= lineLen;
-        lineLen = wolfSSL_BIO_gets(in, &section[sectionLen], remainLen);
-        if (lineLen <= 0) {
-            goto error;
-        }
-        /* Line with just newline signals end of headers. */
-        if ((lineLen==2 && !XSTRNCMP(&section[sectionLen],
-                                     "\r\n", 2)) ||
-            (lineLen==1 && (section[sectionLen] == '\r' ||
-                            section[sectionLen] == '\n'))) {
-            isEnd = 1;
-        }
-    }
-    section[sectionLen] = '\0';
-    ret = wc_MIME_parse_headers(section, sectionLen, &allHdrs);
-    if (ret < 0) {
-        WOLFSSL_MSG("Parsing MIME headers failed.");
-        goto error;
-    }
-    isEnd = 0;
-    section[0] = '\0';
-    sectionLen = 0;
-
-    curHdr = wc_MIME_find_header_name(kContType, allHdrs);
-    if (curHdr && !XSTRNCMP(curHdr->body, kMultSigned,
-                            XSTR_SIZEOF(kMultSigned))) {
-        curParam = wc_MIME_find_param_attr("protocol", curHdr->params);
-        if (curParam && (!XSTRNCMP(curParam->value, kAppPkcsSign,
-                                   XSTR_SIZEOF(kAppPkcsSign)) ||
-                         !XSTRNCMP(curParam->value, kAppXPkcsSign,
-                                   XSTR_SIZEOF(kAppXPkcsSign)))) {
-            curParam = wc_MIME_find_param_attr("boundary", curHdr->params);
-            if (curParam == NULL) {
-                goto error;
-            }
-
-            boundLen = XSTRLEN(curParam->value) + 2;
-            boundary = (char*)XMALLOC(boundLen+1, NULL, DYNAMIC_TYPE_PKCS7);
-            if (boundary == NULL) {
-                goto error;
-            }
-            XMEMSET(boundary, 0, (word32)(boundLen+1));
-            boundary[0] = boundary[1] = '-';
-            XSTRNCPY(&boundary[2], curParam->value, boundLen-2);
-
-            /* Parse up to first boundary, ignore everything here. */
-            lineLen = wolfSSL_BIO_gets(in, section, remainLen);
-            if (lineLen <= 0) {
-                goto error;
-            }
-            while (XSTRNCMP(&section[sectionLen], boundary, boundLen) &&
-                   remainLen > 0) {
-                sectionLen += lineLen;
-                remainLen -= lineLen;
-                lineLen = wolfSSL_BIO_gets(in, &section[sectionLen],
-                                           remainLen);
-                if (lineLen <= 0) {
-                    goto error;
-                }
-            }
-
-            section[0] = '\0';
-            sectionLen = 0;
-            canonSize = remainLen + 1;
-            canonSection = (char*)XMALLOC(canonSize, NULL,
-                                          DYNAMIC_TYPE_PKCS7);
-            if (canonSection == NULL) {
-                goto error;
-            }
-
-            lineLen = wolfSSL_BIO_gets(in, section, remainLen);
-            if (lineLen < 0) {
-                goto error;
-            }
-            while (XSTRNCMP(&section[sectionLen], boundary, boundLen) &&
-                            remainLen > 0) {
-                canonLineLen = lineLen;
-                canonLine = wc_MIME_single_canonicalize(&section[sectionLen],
-                                                        &canonLineLen);
-                if (canonLine == NULL) {
-                    goto error;
-                }
-                /* If line endings were added, the initial length may be
-                 * exceeded. */
-                if ((canonPos + canonLineLen) >= canonSize) {
-                    canonSize = canonPos + canonLineLen;
-                    canonSection = (char*)XREALLOC(canonSection, canonSize,
-                                                   NULL, DYNAMIC_TYPE_PKCS7);
-                    if (canonSection == NULL) {
-                        goto error;
-                    }
-                }
-                XMEMCPY(&canonSection[canonPos], canonLine,
-                        (int)canonLineLen - 1);
-                canonPos += canonLineLen - 1;
-                XFREE(canonLine, NULL, DYNAMIC_TYPE_PKCS7);
-                canonLine = NULL;
-
-                sectionLen += lineLen;
-                remainLen -= lineLen;
-
-                lineLen = wolfSSL_BIO_gets(in, &section[sectionLen],
-                                           remainLen);
-                if (lineLen <= 0) {
-                    goto error;
-                }
-            }
-
-            if (canonPos > 0) {
-                canonPos--;
-            }
-
-            /* Strip the final trailing newline.  Support \r, \n or \r\n. */
-            if (canonSection[canonPos] == '\n') {
-                if (canonPos > 0) {
-                    canonPos--;
-                }
-            }
-
-            if (canonSection[canonPos] == '\r') {
-                if (canonPos > 0) {
-                    canonPos--;
-                }
-            }
-
-            canonSection[canonPos+1] = '\0';
-
-            *bcont = wolfSSL_BIO_new(wolfSSL_BIO_s_mem());
-            ret = wolfSSL_BIO_write(*bcont, canonSection,
-                                    canonPos + 1);
-            if (ret != (canonPos+1)) {
-                goto error;
-            }
-            if ((bcontMemSz = wolfSSL_BIO_get_mem_data(*bcont, &bcontMem))
-                                                                          < 0) {
-                goto error;
-            }
-            XFREE(canonSection, NULL, DYNAMIC_TYPE_PKCS7);
-            canonSection = NULL;
-
-            wc_MIME_free_hdrs(allHdrs);
-            allHdrs = NULL;
-            section[0] = '\0';
-            sectionLen = 0;
-            lineLen = wolfSSL_BIO_gets(in, section, remainLen);
-            if (lineLen <= 0) {
-                goto error;
-            }
-            while (isEnd == 0 && remainLen > 0) {
-                sectionLen += lineLen;
-                remainLen -= lineLen;
-                lineLen = wolfSSL_BIO_gets(in, &section[sectionLen],
-                                           remainLen);
-                if (lineLen <= 0) {
-                    goto error;
-                }
-                /* Line with just newline signals end of headers. */
-                if ((lineLen==2 && !XSTRNCMP(&section[sectionLen],
-                                             "\r\n", 2)) ||
-                    (lineLen==1 && (section[sectionLen] == '\r' ||
-                                    section[sectionLen] == '\n'))) {
-                    isEnd = 1;
-                }
-            }
-            section[sectionLen] = '\0';
-            ret = wc_MIME_parse_headers(section, sectionLen, &allHdrs);
-            if (ret < 0) {
-                WOLFSSL_MSG("Parsing MIME headers failed.");
-                goto error;
-            }
-            curHdr = wc_MIME_find_header_name(kContType, allHdrs);
-            if (curHdr == NULL || (XSTRNCMP(curHdr->body, kAppPkcsSign,
-                                   XSTR_SIZEOF(kAppPkcsSign)) &&
-                                   XSTRNCMP(curHdr->body, kAppXPkcsSign,
-                                   XSTR_SIZEOF(kAppXPkcsSign)))) {
-                WOLFSSL_MSG("S/MIME headers not found inside "
-                            "multipart message.\n");
-                goto error;
-            }
-
-            section[0] = '\0';
-            sectionLen = 0;
-            lineLen = wolfSSL_BIO_gets(in, section, remainLen);
-            while (XSTRNCMP(&section[sectionLen], boundary, boundLen) &&
-                   remainLen > 0) {
-                sectionLen += lineLen;
-                remainLen -= lineLen;
-                lineLen = wolfSSL_BIO_gets(in, &section[sectionLen],
-                                           remainLen);
-                if (lineLen <= 0) {
-                    goto error;
-                }
-            }
-
-            XFREE(boundary, NULL, DYNAMIC_TYPE_PKCS7);
-            boundary = NULL;
-        }
-    }
-    else if (curHdr && (!XSTRNCMP(curHdr->body, kAppPkcs7Mime,
-                                  XSTR_SIZEOF(kAppPkcs7Mime)) ||
-                        !XSTRNCMP(curHdr->body, kAppXPkcs7Mime,
-                                  XSTR_SIZEOF(kAppXPkcs7Mime)))) {
-        sectionLen = wolfSSL_BIO_get_len(in);
-        if (sectionLen <= 0) {
-            goto error;
-        }
-        ret = wolfSSL_BIO_read(in, section, sectionLen);
-        if (ret < 0 || ret != sectionLen) {
-            WOLFSSL_MSG("Error reading input BIO.");
-            goto error;
-        }
-    }
-    else {
-        WOLFSSL_MSG("S/MIME headers not found.");
-        goto error;
-    }
-
-    curHdr = wc_MIME_find_header_name(kCTE, allHdrs);
-    if (curHdr == NULL) {
-        WOLFSSL_MSG("Content-Transfer-Encoding header not found, "
-                    "assuming base64 encoding.");
-    }
-    else if (XSTRNCMP(curHdr->body, "base64", XSTRLEN("base64"))) {
-        WOLFSSL_MSG("S/MIME encodings other than base64 are not "
-                    "currently supported.\n");
-        goto error;
-    }
-
-    if (section == NULL || sectionLen <= 0) {
-        goto error;
-    }
-    outLen = ((sectionLen*3+3)/4)+1;
-    out = (byte*)XMALLOC(outLen*sizeof(byte), NULL, DYNAMIC_TYPE_PKCS7);
-    outHead = out;
-    if (outHead == NULL) {
-        goto error;
-    }
-    /* Strip trailing newlines. */
-    while ((sectionLen > 0) &&
-           (section[sectionLen-1] == '\r' || section[sectionLen-1] == '\n')) {
-        sectionLen--;
-    }
-    section[sectionLen] = '\0';
-    ret = Base64_Decode((const byte*)section, sectionLen, out, &outLen);
-    if (ret < 0) {
-        WOLFSSL_MSG("Error base64 decoding S/MIME message.");
-        goto error;
-    }
-    pkcs7 = wolfSSL_d2i_PKCS7_only(NULL, (const unsigned char**)&out, outLen,
-        bcontMem, bcontMemSz);
-
-    wc_MIME_free_hdrs(allHdrs);
-    XFREE(outHead, NULL, DYNAMIC_TYPE_PKCS7);
-    XFREE(section, NULL, DYNAMIC_TYPE_PKCS7);
-
-    return pkcs7;
-
-error:
-    wc_MIME_free_hdrs(allHdrs);
-    XFREE(boundary, NULL, DYNAMIC_TYPE_PKCS7);
-    XFREE(outHead, NULL, DYNAMIC_TYPE_PKCS7);
-    XFREE(section, NULL, DYNAMIC_TYPE_PKCS7);
-    if (canonSection != NULL)
-        XFREE(canonSection, NULL, DYNAMIC_TYPE_PKCS7);
-    if (canonLine != NULL)
-        XFREE(canonLine, NULL, DYNAMIC_TYPE_PKCS7);
-    if (bcont) {
-        wolfSSL_BIO_free(*bcont);
-        *bcont = NULL; /* reset 'bcount' pointer to NULL on failure */
-    }
-
-    return NULL;
-}
-
-/* Convert hash algo OID (from Hash_Sum in asn.h) to SMIME string equivalent.
- * Returns hash algorithm string or "unknown" if not found */
-static const char* wolfSSL_SMIME_HashOIDToString(int hashOID)
-{
-    switch (hashOID) {
-        case MD5h:
-            return "md5";
-        case SHAh:
-            return "sha1";
-        case SHA224h:
-            return "sha-224";
-        case SHA256h:
-            return "sha-256";
-        case SHA384h:
-            return "sha-384";
-        case SHA512h:
-            return "sha-512";
-        case SHA3_224h:
-            return "sha3-224";
-        case SHA3_384h:
-            return "sha3-384";
-        case SHA3_512h:
-            return "sha3-512";
-        default:
-            break;
-    }
-
-    return "unknown";
-}
-
-/* Convert PKCS#7 type (from PKCS7_TYPES in pkcs7.h) to SMIME string.
- * RFC2633 only defines signed-data, enveloped-data, certs-only.
- * Returns string on success, NULL on unknown type. */
-static const char* wolfSSL_SMIME_PKCS7TypeToString(int type)
-{
-    switch (type) {
-        case SIGNED_DATA:
-            return "signed-data";
-        case ENVELOPED_DATA:
-            return "enveloped-data";
-        default:
-            break;
-    }
-
-    return NULL;
-}
-
-/**
- * Convert PKCS7 structure to SMIME format, adding necessary headers.
- *
- * Handles generation of PKCS7 bundle (ie: signedData). PKCS7 structure
- * should be set up beforehand with PKCS7_sign/final/etc. Output is always
- * Base64 encoded.
- *
- * out   - output BIO for SMIME formatted data to be placed
- * pkcs7 - input PKCS7 structure, initialized and set up
- * in    - input content to be encoded into PKCS7
- * flags - flags to control behavior of PKCS7 generation
- *
- * Returns 1 on success, 0 or negative on failure
- */
-int wolfSSL_SMIME_write_PKCS7(WOLFSSL_BIO* out, PKCS7* pkcs7, WOLFSSL_BIO* in,
-                              int flags)
-{
-    int i;
-    int ret = 1;
-    WOLFSSL_PKCS7* p7 = (WOLFSSL_PKCS7*)pkcs7;
-    byte* p7out = NULL;
-    int len = 0;
-
-    char boundary[33]; /* 32 chars + \0 */
-    byte* sigBase64 = NULL;
-    word32 sigBase64Len = 0;
-    const char* p7TypeString = NULL;
-
-    static const char alphanum[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-
-    if (out == NULL || p7 == NULL) {
-        WOLFSSL_MSG("Bad function arguments");
-        return 0;
-    }
-
-    if (in != NULL && (p7->pkcs7.content == NULL || p7->pkcs7.contentSz == 0 ||
-                       p7->pkcs7.contentCRLF == 0)) {
-        /* store and adjust content line endings for CRLF if needed */
-        if (wolfSSL_PKCS7_final((PKCS7*)p7, in, flags) != 1) {
-            ret = 0;
-        }
-    }
-
-    if (ret > 0) {
-        /* Generate signedData bundle, DER in output (dynamic) */
-        if ((len = wolfSSL_i2d_PKCS7((PKCS7*)p7, &p7out)) == WOLFSSL_FAILURE) {
-            WOLFSSL_MSG("Error in wolfSSL_i2d_PKCS7");
-            ret = 0;
-        }
-    }
-
-    /* Base64 encode signedData bundle */
-    if (ret > 0) {
-        if (Base64_Encode(p7out, len, NULL, &sigBase64Len) != LENGTH_ONLY_E) {
-            ret = 0;
-        }
-        else {
-            sigBase64 = (byte*)XMALLOC(sigBase64Len, NULL,
-                                       DYNAMIC_TYPE_TMP_BUFFER);
-            if (sigBase64 == NULL) {
-                ret = 0;
-            }
-        }
-    }
-
-    if (ret > 0) {
-        XMEMSET(sigBase64, 0, sigBase64Len);
-        if (Base64_Encode(p7out, len, sigBase64, &sigBase64Len) < 0) {
-            WOLFSSL_MSG("Error in Base64_Encode of signature");
-            ret = 0;
-        }
-    }
-
-    /* build up SMIME message */
-    if (ret > 0) {
-        if (flags & PKCS7_DETACHED) {
-
-            /* generate random boundary */
-            if (initGlobalRNG == 0 && wolfSSL_RAND_Init() != WOLFSSL_SUCCESS) {
-                WOLFSSL_MSG("No RNG to use");
-                ret = 0;
-            }
-
-            /* no need to generate random byte for null terminator (size-1) */
-            if ((ret > 0) && (wc_RNG_GenerateBlock(&globalRNG, (byte*)boundary,
-                                  sizeof(boundary) - 1 ) != 0)) {
-                    WOLFSSL_MSG("Error in wc_RNG_GenerateBlock");
-                    ret = 0;
-            }
-
-            if (ret > 0) {
-                for (i = 0; i < (int)sizeof(boundary) - 1; i++) {
-                    boundary[i] =
-                        alphanum[boundary[i] % XSTR_SIZEOF(alphanum)];
-                }
-                boundary[sizeof(boundary)-1] = 0;
-            }
-
-            if (ret > 0) {
-                /* S/MIME header beginning */
-                ret = wolfSSL_BIO_printf(out,
-                        "MIME-Version: 1.0\n"
-                        "Content-Type: multipart/signed; "
-                        "protocol=\"application/x-pkcs7-signature\"; "
-                        "micalg=\"%s\"; "
-                        "boundary=\"----%s\"\n\n"
-                        "This is an S/MIME signed message\n\n"
-                        "------%s\n",
-                        wolfSSL_SMIME_HashOIDToString(p7->pkcs7.hashOID),
-                        boundary, boundary);
-            }
-
-            if (ret > 0) {
-                /* S/MIME content */
-                ret = wolfSSL_BIO_write(out,
-                        p7->pkcs7.content, p7->pkcs7.contentSz);
-            }
-
-            if (ret > 0) {
-                /* S/SMIME header end boundary */
-                ret = wolfSSL_BIO_printf(out,
-                        "\n------%s\n", boundary);
-            }
-
-            if (ret > 0) {
-                /* Signature and header */
-                ret = wolfSSL_BIO_printf(out,
-                        "Content-Type: application/x-pkcs7-signature; "
-                        "name=\"smime.p7s\"\n"
-                        "Content-Transfer-Encoding: base64\n"
-                        "Content-Disposition: attachment; "
-                        "filename=\"smime.p7s\"\n\n"
-                        "%.*s\n" /* Base64 encoded signature */
-                        "------%s--\n\n",
-                        sigBase64Len, sigBase64,
-                        boundary);
-            }
-        }
-        else {
-            p7TypeString = wolfSSL_SMIME_PKCS7TypeToString(p7->type);
-            if (p7TypeString == NULL) {
-                WOLFSSL_MSG("Unsupported PKCS7 SMIME type");
-                ret = 0;
-            }
-
-            if (ret > 0) {
-                /* not detached */
-                ret = wolfSSL_BIO_printf(out,
-                        "MIME-Version: 1.0\n"
-                        "Content-Disposition: attachment; "
-                        "filename=\"smime.p7m\"\n"
-                        "Content-Type: application/x-pkcs7-mime; "
-                        "smime-type=%s; name=\"smime.p7m\"\n"
-                        "Content-Transfer-Encoding: base64\n\n"
-                        "%.*s\n" /* signature */,
-                        p7TypeString, sigBase64Len, sigBase64);
-            }
-        }
-    }
-
-    if (p7out != NULL) {
-        XFREE(p7out, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
-    if (sigBase64 != NULL) {
-        XFREE(sigBase64, NULL, DYNAMIC_TYPE_TMP_BUFFER);
-    }
-
-    if (ret > 0) {
-        return WOLFSSL_SUCCESS;
-    }
-
-    return WOLFSSL_FAILURE;
-}
-
-#endif /* HAVE_SMIME */
-#endif /* !NO_BIO */
-#endif /* OPENSSL_ALL */
-
-#endif /* HAVE_PKCS7 */
-/*******************************************************************************
- * END OF PKCS7 APIs
- ******************************************************************************/
-
-/*******************************************************************************
- * START OF PKCS12 APIs
- ******************************************************************************/
-#ifdef OPENSSL_EXTRA
-
-/* no-op function. Was initially used for adding encryption algorithms available
- * for PKCS12 */
-void wolfSSL_PKCS12_PBE_add(void)
-{
-    WOLFSSL_ENTER("wolfSSL_PKCS12_PBE_add");
-}
-
-#if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
-WOLFSSL_X509_PKCS12 *wolfSSL_d2i_PKCS12_fp(XFILE fp,
-        WOLFSSL_X509_PKCS12 **pkcs12)
-{
-    WOLFSSL_ENTER("wolfSSL_d2i_PKCS12_fp");
-    return (WOLFSSL_X509_PKCS12 *)wolfSSL_d2i_X509_fp_ex(fp, (void **)pkcs12,
-        PKCS12_TYPE);
-}
-#endif /* !NO_FILESYSTEM */
-
-#endif /* OPENSSL_EXTRA */
-
-#if defined(HAVE_PKCS12)
-
-#ifdef OPENSSL_EXTRA
-
-#if !defined(NO_ASN) && !defined(NO_PWDBASED)
-
-#ifndef NO_BIO
-WC_PKCS12* wolfSSL_d2i_PKCS12_bio(WOLFSSL_BIO* bio, WC_PKCS12** pkcs12)
-{
-    WC_PKCS12* localPkcs12 = NULL;
-    unsigned char* mem = NULL;
-    long memSz;
-    int ret = -1;
-
-    WOLFSSL_ENTER("wolfSSL_d2i_PKCS12_bio");
-
-    if (bio == NULL) {
-        WOLFSSL_MSG("Bad Function Argument bio is NULL");
-        return NULL;
-    }
-
-    memSz = wolfSSL_BIO_get_len(bio);
-    if (memSz <= 0) {
-        return NULL;
-    }
-    mem = (unsigned char*)XMALLOC(memSz, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
-    if (mem == NULL) {
-        return NULL;
-    }
-
-    if (mem != NULL) {
-        localPkcs12 = wc_PKCS12_new();
-        if (localPkcs12 == NULL) {
-            WOLFSSL_MSG("Memory error");
-        }
-    }
-
-    if (mem != NULL && localPkcs12 != NULL) {
-        if (wolfSSL_BIO_read(bio, mem, (int)memSz) == memSz) {
-            ret = wc_d2i_PKCS12(mem, (word32)memSz, localPkcs12);
-            if (ret < 0) {
-                WOLFSSL_MSG("Failed to get PKCS12 sequence");
-            }
-        }
-        else {
-            WOLFSSL_MSG("Failed to get data from bio struct");
-        }
-    }
-
-    /* cleanup */
-    if (mem != NULL)
-        XFREE(mem, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
-    if (ret < 0 && localPkcs12 != NULL) {
-        wc_PKCS12_free(localPkcs12);
-        localPkcs12 = NULL;
-    }
-    if (pkcs12 != NULL)
-        *pkcs12 = localPkcs12;
-
-    return localPkcs12;
-}
-
-/* Converts the PKCS12 to DER format and outputs it into bio.
- *
- * bio is the structure to hold output DER
- * pkcs12 structure to create DER from
- *
- * return 1 for success or 0 if an error occurs
- */
-int wolfSSL_i2d_PKCS12_bio(WOLFSSL_BIO *bio, WC_PKCS12 *pkcs12)
-{
-    int ret = WOLFSSL_FAILURE;
-
-    WOLFSSL_ENTER("wolfSSL_i2d_PKCS12_bio");
-
-    if ((bio != NULL) && (pkcs12 != NULL)) {
-        word32 certSz = 0;
-        byte *certDer = NULL;
-
-        certSz = wc_i2d_PKCS12(pkcs12, &certDer, NULL);
-        if ((certSz > 0) && (certDer != NULL)) {
-            if (wolfSSL_BIO_write(bio, certDer, certSz) == (int)certSz) {
-                ret = WOLFSSL_SUCCESS;
-            }
-        }
-
-        if (certDer != NULL) {
-            XFREE(certDer, NULL, DYNAMIC_TYPE_PKCS);
-        }
-    }
-
-    return ret;
-}
-#endif /* !NO_BIO */
-
-/* Creates a new WC_PKCS12 structure
- *
- * pass  password to use
- * name  friendlyName to use
- * pkey  private key to go into PKCS12 bundle
- * cert  certificate to go into PKCS12 bundle
- * ca    extra certificates that can be added to bundle. Can be NULL
- * keyNID  type of encryption to use on the key (-1 means no encryption)
- * certNID type of encryption to use on the certificate
- * itt     number of iterations with encryption
- * macItt  number of iterations with mac creation
- * keyType flag for signature and/or encryption key
- *
- * returns a pointer to a new WC_PKCS12 structure on success and NULL on fail
- */
-WC_PKCS12* wolfSSL_PKCS12_create(char* pass, char* name, WOLFSSL_EVP_PKEY* pkey,
-        WOLFSSL_X509* cert, WOLF_STACK_OF(WOLFSSL_X509)* ca, int keyNID,
-        int certNID, int itt, int macItt, int keyType)
-{
-    WC_PKCS12* pkcs12;
-    WC_DerCertList* list = NULL;
-    word32 passSz;
-    byte* keyDer = NULL;
-    word32 keyDerSz;
-    byte* certDer;
-    int certDerSz;
-
-    WOLFSSL_ENTER("wolfSSL_PKCS12_create");
-
-    if (pass == NULL || pkey == NULL || cert == NULL) {
-        WOLFSSL_LEAVE("wolfSSL_PKCS12_create", BAD_FUNC_ARG);
-        return NULL;
-    }
-    passSz = (word32)XSTRLEN(pass);
-
-    keyDer = (byte*)pkey->pkey.ptr;
-    keyDerSz = pkey->pkey_sz;
-
-    certDer = (byte*)wolfSSL_X509_get_der(cert, &certDerSz);
-    if (certDer == NULL) {
-        return NULL;
-    }
-
-    if (ca != NULL) {
-        unsigned long numCerts = ca->num;
-        WOLFSSL_STACK* sk = ca;
-
-        while (numCerts > 0 && sk != NULL) {
-            byte* curDer;
-            WC_DerCertList* cur;
-            int   curDerSz = 0;
-
-            cur = (WC_DerCertList*)XMALLOC(sizeof(WC_DerCertList), NULL,
-                    DYNAMIC_TYPE_PKCS);
-            if (cur == NULL) {
-                wc_FreeCertList(list, NULL);
-                return NULL;
-            }
-
-            curDer = (byte*)wolfSSL_X509_get_der(sk->data.x509, &curDerSz);
-            if (curDer == NULL || curDerSz < 0) {
-                XFREE(cur, NULL, DYNAMIC_TYPE_PKCS);
-                wc_FreeCertList(list, NULL);
-                return NULL;
-            }
-
-            cur->buffer = (byte*)XMALLOC(curDerSz, NULL, DYNAMIC_TYPE_PKCS);
-            if (cur->buffer == NULL) {
-                XFREE(cur, NULL, DYNAMIC_TYPE_PKCS);
-                wc_FreeCertList(list, NULL);
-                return NULL;
-            }
-            XMEMCPY(cur->buffer, curDer, curDerSz);
-            cur->bufferSz = curDerSz;
-            cur->next = list;
-            list = cur;
-
-            sk = sk->next;
-            numCerts--;
-        }
-    }
-
-    pkcs12 = wc_PKCS12_create(pass, passSz, name, keyDer, keyDerSz,
-            certDer, certDerSz, list, keyNID, certNID, itt, macItt,
-            keyType, NULL);
-
-    if (ca != NULL) {
-        wc_FreeCertList(list, NULL);
-    }
-
-    return pkcs12;
-}
-
-
-/* return WOLFSSL_SUCCESS on success, WOLFSSL_FAILURE on failure */
-int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
-          WOLFSSL_EVP_PKEY** pkey, WOLFSSL_X509** cert,
-          WOLF_STACK_OF(WOLFSSL_X509)** ca)
-{
-    void* heap = NULL;
-    int ret;
-    byte* certData = NULL;
-    word32 certDataSz;
-    byte* pk = NULL;
-    word32 pkSz;
-    WC_DerCertList* certList = NULL;
-#ifdef WOLFSSL_SMALL_STACK
-    DecodedCert *DeCert;
-#else
-    DecodedCert DeCert[1];
-#endif
-
-    WOLFSSL_ENTER("wolfSSL_PKCS12_parse");
-
-    /* make sure we init return args */
-    if (pkey) *pkey = NULL;
-    if (cert) *cert = NULL;
-    if (ca)   *ca = NULL;
-
-    if (pkcs12 == NULL || psw == NULL || pkey == NULL || cert == NULL) {
-        WOLFSSL_MSG("Bad argument value");
-        return WOLFSSL_FAILURE;
-    }
-
-    heap  = wc_PKCS12_GetHeap(pkcs12);
-
-    if (ca == NULL) {
-        ret = wc_PKCS12_parse(pkcs12, psw, &pk, &pkSz, &certData, &certDataSz,
-            NULL);
-    }
-    else {
-        ret = wc_PKCS12_parse(pkcs12, psw, &pk, &pkSz, &certData, &certDataSz,
-            &certList);
-    }
-    if (ret < 0) {
-        WOLFSSL_LEAVE("wolfSSL_PKCS12_parse", ret);
-        return WOLFSSL_FAILURE;
-    }
-
-#ifdef WOLFSSL_SMALL_STACK
-    DeCert = (DecodedCert *)XMALLOC(sizeof(*DeCert), heap,
-                                    DYNAMIC_TYPE_DCERT);
-    if (DeCert == NULL) {
-        WOLFSSL_MSG("out of memory");
-        return WOLFSSL_FAILURE;
-    }
-#endif
-
-    /* Decode cert and place in X509 stack struct */
-    if (certList != NULL) {
-        WC_DerCertList* current = certList;
-
-        *ca = (WOLF_STACK_OF(WOLFSSL_X509)*)XMALLOC(
-            sizeof(WOLF_STACK_OF(WOLFSSL_X509)), heap, DYNAMIC_TYPE_X509);
-        if (*ca == NULL) {
-            if (pk != NULL) {
-                XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
-            }
-            if (certData != NULL) {
-                XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
-            }
-            /* Free up WC_DerCertList and move on */
-            while (current != NULL) {
-                WC_DerCertList* next = current->next;
-
-                XFREE(current->buffer, heap, DYNAMIC_TYPE_PKCS);
-                XFREE(current, heap, DYNAMIC_TYPE_PKCS);
-                current = next;
-            }
-            ret = WOLFSSL_FAILURE;
-            goto out;
-        }
-        XMEMSET(*ca, 0, sizeof(WOLF_STACK_OF(WOLFSSL_X509)));
-
-        /* add list of DER certs as X509's to stack */
-        while (current != NULL) {
-            WC_DerCertList*  toFree = current;
-            WOLFSSL_X509* x509;
-
-            x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), heap,
-                DYNAMIC_TYPE_X509);
-            InitX509(x509, 1, heap);
-            InitDecodedCert(DeCert, current->buffer, current->bufferSz, heap);
-            if (ParseCertRelative(DeCert, CERT_TYPE, NO_VERIFY, NULL) != 0) {
-                WOLFSSL_MSG("Issue with parsing certificate");
-                FreeDecodedCert(DeCert);
-                wolfSSL_X509_free(x509);
-            }
-            else {
-                if (CopyDecodedToX509(x509, DeCert) != 0) {
-                    WOLFSSL_MSG("Failed to copy decoded cert");
-                    FreeDecodedCert(DeCert);
-                    wolfSSL_X509_free(x509);
-                    wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
-                    if (pk != NULL) {
-                        XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
-                    }
-                    if (certData != NULL) {
-                        XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
-                    }
-                    /* Free up WC_DerCertList */
-                    while (current != NULL) {
-                        WC_DerCertList* next = current->next;
-
-                        XFREE(current->buffer, heap, DYNAMIC_TYPE_PKCS);
-                        XFREE(current, heap, DYNAMIC_TYPE_PKCS);
-                        current = next;
-                    }
-                    ret = WOLFSSL_FAILURE;
-                    goto out;
-                }
-                FreeDecodedCert(DeCert);
-
-                if (wolfSSL_sk_X509_push(*ca, x509) != 1) {
-                    WOLFSSL_MSG("Failed to push x509 onto stack");
-                    wolfSSL_X509_free(x509);
-                    wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
-                    if (pk != NULL) {
-                        XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
-                    }
-                    if (certData != NULL) {
-                        XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
-                    }
-
-                    /* Free up WC_DerCertList */
-                    while (current != NULL) {
-                        WC_DerCertList* next = current->next;
-
-                        XFREE(current->buffer, heap, DYNAMIC_TYPE_PKCS);
-                        XFREE(current, heap, DYNAMIC_TYPE_PKCS);
-                        current = next;
-                    }
-                    ret = WOLFSSL_FAILURE;
-                    goto out;
-                }
-            }
-            current = current->next;
-            XFREE(toFree->buffer, heap, DYNAMIC_TYPE_PKCS);
-            XFREE(toFree, heap, DYNAMIC_TYPE_PKCS);
-        }
-    }
-
-
-    /* Decode cert and place in X509 struct */
-    if (certData != NULL) {
-        *cert = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), heap,
-            DYNAMIC_TYPE_X509);
-        if (*cert == NULL) {
-            if (pk != NULL) {
-                XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
-            }
-            if (ca != NULL) {
-                wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
-            }
-            XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
-            ret = WOLFSSL_FAILURE;
-            goto out;
-        }
-        InitX509(*cert, 1, heap);
-        InitDecodedCert(DeCert, certData, certDataSz, heap);
-        if (ParseCertRelative(DeCert, CERT_TYPE, NO_VERIFY, NULL) != 0) {
-            WOLFSSL_MSG("Issue with parsing certificate");
-        }
-        if (CopyDecodedToX509(*cert, DeCert) != 0) {
-            WOLFSSL_MSG("Failed to copy decoded cert");
-            FreeDecodedCert(DeCert);
-            if (pk != NULL) {
-                XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
-            }
-            if (ca != NULL) {
-                wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
-            }
-            wolfSSL_X509_free(*cert); *cert = NULL;
-            XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
-            ret = WOLFSSL_FAILURE;
-            goto out;
-        }
-        FreeDecodedCert(DeCert);
-        XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
-    }
-
-
-    /* get key type */
-    ret = BAD_STATE_E;
-    if (pk != NULL) { /* decode key if present */
-        *pkey = wolfSSL_EVP_PKEY_new_ex(heap);
-        if (*pkey == NULL) {
-            wolfSSL_X509_free(*cert); *cert = NULL;
-            if (ca != NULL) {
-                wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
-            }
-            XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
-            ret = WOLFSSL_FAILURE;
-            goto out;
-        }
-
-    #ifndef NO_RSA
-        {
-            const unsigned char* pt = pk;
-            if (wolfSSL_d2i_PrivateKey(EVP_PKEY_RSA, pkey, &pt, pkSz) !=
-                    NULL) {
-                ret = 0;
-            }
-        }
-    #endif /* NO_RSA */
-
-    #ifdef HAVE_ECC
-        if (ret != 0) { /* if is in fail state check if ECC key */
-            const unsigned char* pt = pk;
-            if (wolfSSL_d2i_PrivateKey(EVP_PKEY_EC, pkey, &pt, pkSz) !=
-                    NULL) {
-                ret = 0;
-            }
-        }
-    #endif /* HAVE_ECC */
-        if (pk != NULL)
-            XFREE(pk, heap, DYNAMIC_TYPE_PKCS);
-        if (ret != 0) { /* if is in fail state and no PKEY then fail */
-            wolfSSL_X509_free(*cert); *cert = NULL;
-            if (ca != NULL) {
-                wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
-            }
-            wolfSSL_EVP_PKEY_free(*pkey); *pkey = NULL;
-            WOLFSSL_MSG("Bad PKCS12 key format");
-            ret = WOLFSSL_FAILURE;
-            goto out;
-        }
-
-        if (pkey != NULL && *pkey != NULL) {
-            (*pkey)->save_type = 0;
-        }
-    }
-
-    (void)ret;
-    (void)ca;
-
-    ret = WOLFSSL_SUCCESS;
-
-out:
-
-#ifdef WOLFSSL_SMALL_STACK
-    XFREE(DeCert, heap, DYNAMIC_TYPE_DCERT);
-#endif
-
-    return ret;
-}
-
-int wolfSSL_PKCS12_verify_mac(WC_PKCS12 *pkcs12, const char *psw,
-        int pswLen)
-{
-    WOLFSSL_ENTER("wolfSSL_PKCS12_verify_mac");
-
-    if (!pkcs12) {
-        return WOLFSSL_FAILURE;
-    }
-
-    return wc_PKCS12_verify_ex(pkcs12, (const byte*)psw, pswLen) == 0 ?
-            WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
-}
-
-#endif /* !NO_ASN && !NO_PWDBASED */
-
-#endif /* OPENSSL_EXTRA */
-
-#endif /* HAVE_PKCS12 */
-/*******************************************************************************
- * END OF PKCS12 APIs
- ******************************************************************************/
+#define WOLFSSL_SSL_P7P12_INCLUDED
+#include <src/ssl_p7p12.c>
 
 #endif /* !NO_CERTS */
 
@@ -36036,7 +24630,7 @@ int wolfSSL_FIPS_drbg_init(WOLFSSL_DRBG_CTX *ctx, int type, unsigned int flags)
     if (ctx != NULL) {
         XMEMSET(ctx, 0, sizeof(WOLFSSL_DRBG_CTX));
         ctx->type = type;
-        ctx->xflags = flags;
+        ctx->xflags = (int)flags;
         ctx->status = DRBG_STATUS_UNINITIALISED;
         ret = WOLFSSL_SUCCESS;
     }

--- a/libatalk/ssl/src/ssl_asn1.c
+++ b/libatalk/ssl/src/ssl_asn1.c
@@ -247,6 +247,11 @@ static int wolfssl_i2d_asn1_item(void** item, int type, byte* buf)
             len = 0;
     }
 
+    if (len < 0) {
+        len = 0; /* wolfSSL_i2d_ASN1_INTEGER can return a value less than 0
+                  * on error */
+    }
+
     return len;
 }
 
@@ -974,7 +979,8 @@ static int wolfssl_a2i_asn1_integer_clear_to_eol(char* str, int len, int* cont)
     nLen = 1;
     for (i = 0; i < len; i++) {
         /* Check if character is a hexadecimal character. */
-        if (Base16_Decode((const byte*)str + i, 1, &num, &nLen) == ASN_INPUT_E)
+        if (Base16_Decode((const byte*)str + i, 1, &num, &nLen) ==
+            WC_NO_ERR_TRACE(ASN_INPUT_E))
         {
             /* Found end of hexadecimal characters, return count. */
             len = i;
@@ -2997,7 +3003,7 @@ void wolfSSL_ASN1_GENERALIZEDTIME_free(WOLFSSL_ASN1_TIME* asn1Time)
 {
     WOLFSSL_ENTER("wolfSSL_ASN1_GENERALIZEDTIME_free");
     if (asn1Time != NULL) {
-        XMEMSET(asn1Time->data, 0, sizeof(asn1Time->data));
+        XFREE(asn1Time, NULL, DYNAMIC_TYPE_OPENSSL);
     }
 }
 
@@ -3509,14 +3515,17 @@ WOLFSSL_ASN1_TIME* wolfSSL_ASN1_TIME_to_generalizedtime(WOLFSSL_ASN1_TIME *t,
     if (ret != NULL) {
         /* Set the ASN.1 type and length of string. */
         ret->type = V_ASN1_GENERALIZEDTIME;
-        ret->length = ASN_GENERALIZED_TIME_SIZE;
 
         if (t->type == V_ASN1_GENERALIZEDTIME) {
+            ret->length = ASN_GENERALIZED_TIME_SIZE;
+
             /* Just copy as data already appropriately formatted. */
             XMEMCPY(ret->data, t->data, ASN_GENERALIZED_TIME_SIZE);
         }
         else {
             /* Convert UTC TIME to GENERALIZED TIME. */
+            ret->length = t->length + 2; /* Add two extra year digits */
+
             if (t->data[0] >= '5') {
                 /* >= 50 is 1900s.  */
                 ret->data[0] = '1'; ret->data[1] = '9';
@@ -3526,13 +3535,39 @@ WOLFSSL_ASN1_TIME* wolfSSL_ASN1_TIME_to_generalizedtime(WOLFSSL_ASN1_TIME *t,
                 ret->data[0] = '2'; ret->data[1] = '0';
             }
             /* Append rest of the data as it is the same. */
-            XMEMCPY(&ret->data[2], t->data, ASN_UTC_TIME_SIZE);
+            XMEMCPY(&ret->data[2], t->data, t->length);
         }
 
         /* Check for pointer to return result through. */
         if (out != NULL) {
             *out = ret;
         }
+    }
+
+    return ret;
+}
+
+WOLFSSL_ASN1_TIME* wolfSSL_ASN1_UTCTIME_set(WOLFSSL_ASN1_TIME *s, time_t t)
+{
+    WOLFSSL_ASN1_TIME* ret = s;
+
+    WOLFSSL_ENTER("wolfSSL_ASN1_UTCTIME_set");
+
+    if (ret == NULL) {
+        ret = wolfSSL_ASN1_TIME_new();
+        if (ret == NULL)
+            return NULL;
+    }
+
+    ret->length = GetFormattedTime(&t, ret->data, sizeof(ret->data));
+    if (ret->length + 1 != ASN_UTC_TIME_SIZE) {
+        /* Either snprintf error or t can't be represented in UTC format */
+        if (ret != s)
+            wolfSSL_ASN1_TIME_free(ret);
+        ret = NULL;
+    }
+    else {
+        ret->type = V_ASN1_UTCTIME;
     }
 
     return ret;

--- a/libatalk/ssl/src/ssl_bn.c
+++ b/libatalk/ssl/src/ssl_bn.c
@@ -25,7 +25,7 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
- #include <wolfssl/internal.h>
+#include <wolfssl/internal.h>
 #ifndef WC_NO_RNG
     #include <wolfssl/wolfcrypt/random.h>
 #endif

--- a/libatalk/ssl/src/ssl_bn.c
+++ b/libatalk/ssl/src/ssl_bn.c
@@ -25,10 +25,6 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#ifdef EMBEDDED_SSL
-#include <wolfssl/openssl/bn.h>
-#endif
-
  #include <wolfssl/internal.h>
 #ifndef WC_NO_RNG
     #include <wolfssl/wolfcrypt/random.h>
@@ -83,7 +79,7 @@ static int wolfssl_bn_set_neg(WOLFSSL_BIGNUM* bn, int neg)
 }
 #endif /* OPENSSL_EXTRA && !NO_ASN */
 
-#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL) || defined(EMBEDDED_SSL)
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
 /* Get the internal representation value into an MP integer.
  *
  * When calling wolfssl_bn_get_value, mpi should be cleared by caller if no
@@ -307,9 +303,9 @@ void wolfSSL_BN_clear(WOLFSSL_BIGNUM* bn)
         mp_forcezero((mp_int*)bn->internal);
     }
 }
-#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL || EMBEDDED_SSL */
+#endif /* OPENSSL_EXTRA || OPENSSL_EXTRA_X509_SMALL */
 
-#if defined(OPENSSL_EXTRA) || defined(EMBEDDED_SSL)
+#ifdef OPENSSL_EXTRA
 
 static WOLFSSL_BIGNUM* bn_one = NULL;
 
@@ -2430,7 +2426,7 @@ void wolfSSL_BN_CTX_start(WOLFSSL_BN_CTX *ctx)
 }
 #endif
 
-#endif /* OPENSSL_EXTRA || EMBEDDED_SSL */
+#endif /* OPENSSL_EXTRA */
 
 #endif /* !WOLFSSL_SSL_BN_INCLUDED */
 

--- a/libatalk/ssl/src/ssl_certman.c
+++ b/libatalk/ssl/src/ssl_certman.c
@@ -141,14 +141,12 @@ WOLFSSL_CERT_MANAGER* wolfSSL_CertManagerNew_ex(void* heap)
     #ifdef HAVE_ECC
         cm->minEccKeySz = MIN_ECCKEY_SZ;
     #endif
-    #ifdef HAVE_PQC
     #ifdef HAVE_FALCON
         cm->minFalconKeySz = MIN_FALCONKEY_SZ;
     #endif /* HAVE_FALCON */
     #ifdef HAVE_DILITHIUM
         cm->minDilithiumKeySz = MIN_DILITHIUMKEY_SZ;
     #endif /* HAVE_DILITHIUM */
-    #endif /* HAVE_PQC */
 
         /* Set heap hint to use in certificate manager operations. */
         cm->heap = heap;
@@ -700,7 +698,7 @@ int CM_VerifyBuffer_ex(WOLFSSL_CERT_MANAGER* cm, const unsigned char* buff,
 
         /* Parse DER into decoded certificate fields and verify signature
          * against a known CA. */
-        ret = ParseCertRelative(cert, CERT_TYPE, VERIFY, cm);
+        ret = ParseCertRelative(cert, CERT_TYPE, VERIFY, cm, NULL);
      }
 
 #ifdef HAVE_CRL
@@ -1819,7 +1817,7 @@ int wolfSSL_CertManagerCheckCRL(WOLFSSL_CERT_MANAGER* cm,
             InitDecodedCert(cert, der, (word32)sz, NULL);
 
             /* Parse certificate and perform CRL checks. */
-            ret = ParseCertRelative(cert, CERT_TYPE, VERIFY_CRL, cm);
+            ret = ParseCertRelative(cert, CERT_TYPE, VERIFY_CRL, cm, NULL);
             if (ret != 0) {
                 WOLFSSL_MSG("ParseCert failed");
             }
@@ -2291,7 +2289,7 @@ int wolfSSL_CertManagerCheckOCSP(WOLFSSL_CERT_MANAGER* cm,
             InitDecodedCert(cert, der, (word32)sz, NULL);
 
             /* Parse certificate and perform CRL checks. */
-            ret = ParseCertRelative(cert, CERT_TYPE, VERIFY_OCSP, cm);
+            ret = ParseCertRelative(cert, CERT_TYPE, VERIFY_OCSP, cm, NULL);
             if (ret != 0) {
                 WOLFSSL_MSG("ParseCert failed");
             }

--- a/libatalk/ssl/src/ssl_crypto.c
+++ b/libatalk/ssl/src/ssl_crypto.c
@@ -1966,7 +1966,7 @@ int wolfSSL_HMAC_cleanup(WOLFSSL_HMAC_CTX* ctx)
  * @return  NULL on failure.
  */
 unsigned char* wolfSSL_HMAC(const WOLFSSL_EVP_MD* evp_md, const void* key,
-    int key_len, const unsigned char* data, int len, unsigned char* md,
+    int key_len, const unsigned char* data, size_t len, unsigned char* md,
     unsigned int* md_len)
 {
     unsigned char* ret = NULL;
@@ -2000,7 +2000,7 @@ unsigned char* wolfSSL_HMAC(const WOLFSSL_EVP_MD* evp_md, const void* key,
 #endif
     if (rc == 0)  {
         /* Get the HMAC output length. */
-        hmacLen = wolfssl_mac_len((unsigned char)type);
+        hmacLen = (int)wolfssl_mac_len((unsigned char)type);
         /* 0 indicates the digest is not supported. */
         if (hmacLen == 0) {
             rc = BAD_FUNC_ARG;
@@ -2009,16 +2009,16 @@ unsigned char* wolfSSL_HMAC(const WOLFSSL_EVP_MD* evp_md, const void* key,
     /* Initialize the wolfSSL HMAC object. */
     if ((rc == 0) && (wc_HmacInit(hmac, heap, INVALID_DEVID) == 0)) {
         /* Set the key into the wolfSSL HMAC object. */
-        rc = wc_HmacSetKey(hmac, type, (const byte*)key, key_len);
+        rc = wc_HmacSetKey(hmac, type, (const byte*)key, (word32)key_len);
         if (rc == 0) {
            /* Update the wolfSSL HMAC object with data. */
-            rc = wc_HmacUpdate(hmac, data, len);
+            rc = wc_HmacUpdate(hmac, data, (word32)len);
         }
         /* Finalize the wolfSSL HMAC object. */
         if ((rc == 0) && (wc_HmacFinal(hmac, md) == 0)) {
             /* Return the length of the HMAC output if required. */
             if (md_len != NULL) {
-                *md_len = hmacLen;
+                *md_len = (unsigned int)hmacLen;
             }
             /* Set the buffer to return. */
             ret = md;
@@ -2269,7 +2269,7 @@ int wolfSSL_CMAC_Final(WOLFSSL_CMAC_CTX* ctx, unsigned char* out, size_t* len)
             len32 = (word32)blockSize;
             /* Return size if required. */
             if (len != NULL) {
-                *len = blockSize;
+                *len = (size_t)blockSize;
             }
         }
     }

--- a/libatalk/ssl/src/ssl_crypto.c
+++ b/libatalk/ssl/src/ssl_crypto.c
@@ -26,10 +26,6 @@
 
 #include <wolfssl/wolfcrypt/settings.h>
 
-#ifdef EMBEDDED_SSL
-#include <wolfssl/openssl/des.h>
-#endif
-
 #ifndef WOLFSSL_SSL_CRYPTO_INCLUDED
     #ifndef WOLFSSL_IGNORE_FILE_WARN
         #warning ssl_crypto.c does not need to be compiled separately from ssl.c
@@ -2307,7 +2303,7 @@ int wolfSSL_CMAC_Final(WOLFSSL_CMAC_CTX* ctx, unsigned char* out, size_t* len)
  * START OF DES API
  ******************************************************************************/
 
-#if defined(OPENSSL_EXTRA) || defined(EMBEDDED_SSL)
+#ifdef OPENSSL_EXTRA
 #ifndef NO_DES3
 /* Set parity of the DES key.
  *
@@ -2909,7 +2905,7 @@ void wolfSSL_DES_ecb_encrypt(WOLFSSL_DES_cblock* in, WOLFSSL_DES_cblock* out,
 }
 #endif
 #endif /* NO_DES3 */
-#endif /* OPENSSL_EXTRA || EMBEDDED_SSL */
+#endif /* OPENSSL_EXTRA */
 
 /*******************************************************************************
  * END OF DES API

--- a/libatalk/ssl/src/ssl_load.c
+++ b/libatalk/ssl/src/ssl_load.c
@@ -1,0 +1,5831 @@
+/* ssl_load.c
+ *
+ * Copyright (C) 2006-2023 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+/*
+ * WOLFSSL_SYS_CA_CERTS
+ *     Enables ability to load system CA certs from the OS via
+ *     wolfSSL_CTX_load_system_CA_certs.
+ */
+
+#ifdef WOLFSSL_SYS_CA_CERTS
+
+#ifdef _WIN32
+    #include <windows.h>
+    #include <wincrypt.h>
+
+    /* mingw gcc does not support pragma comment, and the
+     * linking with crypt32 is handled in configure.ac */
+    #if !defined(__MINGW32__) && !defined(__MINGW64__)
+        #pragma comment(lib, "crypt32")
+    #endif
+#endif
+
+#if defined(__APPLE__) && defined(HAVE_SECURITY_SECTRUSTSETTINGS_H)
+#include <Security/SecTrustSettings.h>
+#endif
+
+#endif /* WOLFSSL_SYS_CA_CERTS */
+
+#if !defined(WOLFSSL_SSL_LOAD_INCLUDED)
+    #ifndef WOLFSSL_IGNORE_FILE_WARN
+        #warning ssl_load.c does not need to be compiled separately from ssl.c
+    #endif
+#else
+
+#if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
+    /* PSK field of context when it exists. */
+    #define CTX_HAVE_PSK(ctx)   (ctx)->havePSK
+    /* PSK field of ssl when it exists. */
+    #define SSL_HAVE_PSK(ssl)   (ssl)->options.havePSK
+#else
+    /* Have PSK value when no field. */
+    #define CTX_HAVE_PSK(ctx)   0
+    /* Have PSK value when no field. */
+    #define SSL_HAVE_PSK(ssl)   0
+#endif
+#ifdef NO_RSA
+    /* Boolean for RSA available. */
+    #define WOLFSSL_HAVE_RSA    0
+#else
+    /* Boolean for RSA available. */
+    #define WOLFSSL_HAVE_RSA    1
+#endif
+#ifndef NO_CERTS
+    /* Private key size from ssl. */
+    #define SSL_KEY_SZ(ssl)     (ssl)->buffers.keySz
+#else
+    /* Private key size not available. */
+    #define SSL_KEY_SZ(ssl)     0
+#endif
+#ifdef HAVE_ANON
+    /* Anonymous ciphersuite allowed field in context. */
+    #define CTX_USE_ANON(ctx)   (ctx)->useAnon
+#else
+    /* Anonymous ciphersuite allowed field not in context. */
+    #define CTX_USE_ANON(ctx)   0
+#endif
+
+#ifdef HAVE_PK_CALLBACKS
+    #define WOLFSSL_IS_PRIV_PK_SET(ctx, ssl)                            \
+        wolfSSL_CTX_IsPrivatePkSet(((ssl) == NULL) ? (ctx) : (ssl)->ctx)
+#else
+    #define WOLFSSL_IS_PRIV_PK_SET(ctx, ssl)    0
+#endif
+
+/* Get the heap from the context or the ssl depending on which is available. */
+#define WOLFSSL_HEAP(ctx, ssl)                                              \
+    (((ctx) != NULL) ? (ctx)->heap : (((ssl) != NULL) ? (ssl)->heap : NULL))
+
+
+#ifndef NO_CERTS
+
+/* Get DER encoding from data in a buffer as a DerBuffer.
+ *
+ * @param [in]      buff    Buffer containing data.
+ * @param [in]      len     Length of data in buffer.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @param [in]      type    Type of data:
+ *                            CERT_TYPE, CA_TYPE, TRUSTED_PEER_TYPE,
+ *                            PRIVATEKEY_TYPE or ALT_PRIVATEKEY_TYPE.
+ * @param [in, out] info    Info for encryption.
+ * @param [in]      heap    Dynamic memory allocation hint.
+ * @param [out]     der     Holds DER encoded data.
+ * @param [out]     algId   Algorithm identifier for private keys.
+ * @return  0 on success.
+ * @return  NOT_COMPILED_IN when format is PEM and PEM not supported.
+ * @return  ASN_PARSE_E when format is ASN.1 and invalid DER encoding.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+static int DataToDerBuffer(const unsigned char* buff, word32 len, int format,
+    int type, EncryptedInfo* info, void* heap, DerBuffer** der, int* algId)
+{
+    int ret;
+
+    info->consumed = 0;
+
+    /* Data in buffer has PEM format - extract DER data. */
+    if (format == WOLFSSL_FILETYPE_PEM) {
+    #ifdef WOLFSSL_PEM_TO_DER
+        ret = PemToDer(buff, len, type, der, heap, info, algId);
+        if (ret != 0) {
+            FreeDer(der);
+        }
+    #else
+        ret = NOT_COMPILED_IN;
+    #endif
+    }
+    /* Data in buffer is ASN.1 format - get first SEQ or OCT into der. */
+    else {
+        int length;
+        word32 inOutIdx = 0;
+
+        /* Get length of SEQ including header. */
+        if ((info->consumed = wolfssl_der_length(buff, (int)len)) > 0) {
+            ret = 0;
+        }
+        /* Private keys may be wrapped in OCT when PKCS#8 wrapper removed.
+         * TODO: is this really needed? */
+        else if ((type == PRIVATEKEY_TYPE) &&
+                (GetOctetString(buff, &inOutIdx, &length, len) >= 0)) {
+            /* Include octet string DER header. */
+            info->consumed = length + inOutIdx;
+            ret = 0;
+        }
+        else {
+            ret = ASN_PARSE_E;
+        }
+
+        if (info->consumed > (int)len) {
+            ret = ASN_PARSE_E;
+        }
+        if (ret == 0) {
+            ret = AllocCopyDer(der, buff, (word32)info->consumed, type, heap);
+        }
+    }
+
+    return ret;
+}
+
+/* Process a user's certificate.
+ *
+ * Puts the 3-byte length before certificate data as required for TLS.
+ * CA certificates are added to the certificate manager.
+ *
+ * @param [in]      cm           Certificate manager.
+ * @param [in, out] pDer         DER encoded data.
+ * @param [in]      type         Type of data. Valid values:
+ *                                 CERT_TYPE, CA_TYPE or TRUSTED_PEER_TYPE.
+ * @param [in]      verify       How to verify certificate.
+ * @param [out]     chainBuffer  Buffer to hold chain of certificates.
+ * @param [in, out] pIdx         On in, current index into chainBuffer.
+ *                               On out, index after certificate added.
+ * @param [in]      bufferSz     Size of buffer in bytes.
+ * @return  0 on success.
+ * @return  BUFFER_E if chain buffer not big enough to hold certificate.
+ */
+static int ProcessUserCert(WOLFSSL_CERT_MANAGER* cm, DerBuffer** pDer,
+    int type, int verify, byte* chainBuffer, word32* pIdx, word32 bufferSz)
+{
+    int ret = 0;
+    word32 idx = *pIdx;
+    DerBuffer* der = *pDer;
+
+    /* Check there is space for certificate in chainBuffer. */
+    if ((ret == 0) && ((idx + der->length + CERT_HEADER_SZ) > bufferSz)) {
+        WOLFSSL_MSG("   Cert Chain bigger than buffer. "
+                    "Consider increasing MAX_CHAIN_DEPTH");
+        ret = BUFFER_E;
+    }
+    if (ret == 0) {
+        /* 3-byte length. */
+        c32to24(der->length, &chainBuffer[idx]);
+        idx += CERT_HEADER_SZ;
+        /* Add complete DER encoded certificate. */
+        XMEMCPY(&chainBuffer[idx], der->buffer, der->length);
+        idx += der->length;
+
+        if (type == CA_TYPE) {
+            /* Add CA to certificate manager */
+            ret = AddCA(cm, pDer, WOLFSSL_USER_CA, verify);
+            if (ret == 1) {
+                ret = 0;
+            }
+        }
+    }
+
+    /* Update the index into chainBuffer. */
+    *pIdx = idx;
+    return ret;
+}
+
+/* Store the certificate chain buffer aganst WOLFSSL_CTX or WOLFSSL object.
+ *
+ * @param [in, out] ctx          SSL context object.
+ * @param [in, out] ssl          SSL object.
+ * @param [in]      chainBuffer  Buffer containing chain of certificates.
+ * @param [in]      len          Length, in bytes, of data in buffer.
+ * @param [in]      cnt          Number of certificates in chain.
+ * @param [in]      type         Type of data. Valid values:
+ *                                 CERT_TYPE, CA_TYPE or CHAIN_CERT_TYPE.
+ * @param [in]      heap         Dynamic memory allocation hint.
+ * @return  0 on success.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+static int ProcessUserChainRetain(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    const byte* chainBuffer, word32 len, int cnt, int type, void* heap)
+{
+    int ret = 0;
+
+    (void)cnt;
+
+    /* Store in SSL object if available. */
+    if (ssl != NULL) {
+        /* Dispose of old chain if not reference to context's. */
+        if (ssl->buffers.weOwnCertChain) {
+            FreeDer(&ssl->buffers.certChain);
+        }
+        /* Allocate and copy the buffer into SSL object. */
+        ret = AllocCopyDer(&ssl->buffers.certChain, chainBuffer, len, type,
+            heap);
+        ssl->buffers.weOwnCertChain = (ret == 0);
+    #ifdef WOLFSSL_TLS13
+        /* Update count of certificates in chain. */
+        ssl->buffers.certChainCnt = cnt;
+    #endif
+    }
+    /* Store in SSL context object if available. */
+    else if (ctx != NULL) {
+        /* Dispose of old chain and allocate and copy in new chain. */
+        FreeDer(&ctx->certChain);
+        /* Allocate and copy the buffer into SSL context object. */
+        ret = AllocCopyDer(&ctx->certChain, chainBuffer, len, type, heap);
+    #ifdef WOLFSSL_TLS13
+        /* Update count of certificates in chain. */
+        ctx->certChainCnt = cnt;
+    #endif
+    }
+
+    return ret;
+}
+
+/* Process user cert chain to pass during the TLS handshake.
+ *
+ * If not a certificate type then data is ignored.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      buff    Buffer holding certificates.
+ * @param [in]      sz      Length of data in buffer.
+ * @param [in]      format  Format of the certificate:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1
+ * @param [in]      type    Type of certificate:
+ *                            CA_TYPE, CERT_TYPE or CHAIN_CERT_TYPE
+ * @param [out]     used    Number of bytes from buff used.
+ * @param [in, out] info    Encryption information.
+ * @param [in]      verify  How to verify certificate.
+ * @return  0 on success.
+ * @return  BAD_FUNC_ARG when type is CA_TYPE and ctx is NULL.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+static int ProcessUserChain(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    const unsigned char* buff, long sz, int format, int type, long* used,
+    EncryptedInfo* info, int verify)
+{
+    int ret = 0;
+    void* heap = WOLFSSL_HEAP(ctx, ssl);
+
+    WOLFSSL_ENTER("ProcessUserChain");
+
+    /* Validate parameters. */
+    if ((type == CA_TYPE) && (ctx == NULL)) {
+        WOLFSSL_MSG("Need context for CA load");
+        ret = BAD_FUNC_ARG;
+    }
+
+    /* Ignore non-certificate types. */
+    if ((ret == 0) && (type != CERT_TYPE) && (type != CHAIN_CERT_TYPE) &&
+            (type != CA_TYPE)) {
+        WOLFSSL_MSG("File type not a certificate");
+    }
+    /* Check we haven't consumed all the data. */
+    else if ((ret == 0) && (info->consumed >= sz)) {
+        WOLFSSL_MSG("Already consumed data");
+    }
+    else if (ret == 0) {
+    #ifndef WOLFSSL_SMALL_STACK
+        byte stackBuffer[FILE_BUFFER_SIZE];
+    #endif
+        StaticBuffer chain;
+        long   consumed = info->consumed;
+        word32 idx = 0;
+        int    gotOne = 0;
+        int    cnt = 0;
+        /* Calculate max possible size, including max headers */
+        long   maxSz = (sz - consumed) + (CERT_HEADER_SZ * MAX_CHAIN_DEPTH);
+
+        /* Setup buffer to hold chain. */
+    #ifdef WOLFSSL_SMALL_STACK
+        static_buffer_init(&chain);
+    #else
+        static_buffer_init(&chain, stackBuffer, FILE_BUFFER_SIZE);
+    #endif
+        /* Make buffer big enough to support maximum size. */
+        ret = static_buffer_set_size(&chain, (word32)maxSz, heap,
+            DYNAMIC_TYPE_FILE);
+
+        WOLFSSL_MSG("Processing Cert Chain");
+        /* Keep parsing certificates will data available. */
+        while ((ret == 0) && (consumed < sz)) {
+            DerBuffer* part = NULL;
+
+            /* Get a certificate as DER. */
+            ret = DataToDerBuffer(buff + consumed, (word32)(sz - consumed),
+                format, type, info, heap, &part, NULL);
+            if (ret == 0) {
+                /* Process the user certificate. */
+                ret = ProcessUserCert(ctx->cm, &part, type, verify,
+                   chain.buffer, &idx, (word32)maxSz);
+            }
+            /* PEM may have trailing data that can be ignored. */
+            if ((ret == WC_NO_ERR_TRACE(ASN_NO_PEM_HEADER)) && gotOne) {
+                WOLFSSL_MSG("We got one good cert, so stuff at end ok");
+                ret = 0;
+                break;
+            }
+            /* Certificate data handled. */
+            FreeDer(&part);
+
+            if (ret == 0) {
+                /* Update consumed length. */
+                consumed += info->consumed;
+                WOLFSSL_MSG("   Consumed another Cert in Chain");
+                /* Update whether we got a user certificate. */
+                gotOne |= (type != CA_TYPE);
+                /* Update count of certificates added to chain. */
+                cnt++;
+            }
+        }
+        if (used != NULL) {
+            /* Return the total consumed length. */
+            *used = consumed;
+        }
+
+        /* Check whether there is data in the chain buffer. */
+        if ((ret == 0) && (idx > 0)) {
+            /* Put the chain buffer against the SSL or SSL context object. */
+            ret = ProcessUserChainRetain(ctx, ssl, chain.buffer, idx, cnt, type,
+                heap);
+        }
+
+        /* Dispose of chain buffer. */
+        static_buffer_free(&chain, heap, DYNAMIC_TYPE_FILE);
+    }
+
+    WOLFSSL_LEAVE("ProcessUserChain", ret);
+    return ret;
+}
+
+#ifndef NO_RSA
+#if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && \
+    (HAVE_FIPS_VERSION > 2))
+/* See if DER data is an RSA private key.
+ *
+ * Checks size meets minimum RSA key size.
+ * This implementation uses less dynamic memory.
+ *
+ * @param [in, out] ctx        SSL context object.
+ * @param [in, out] ssl        SSL object.
+ * @param [in]      der        DER encoding.
+ * @param [in, out] keyFormat  On in, expected format. 0 means unknown.
+ * @param [in]      devId      Device identifier.
+ * @param [out]     keyType    Type of key.
+ * @param [out]     keySize    Size of key.
+ * @return  0 on success or not an RSA key and format unknown.
+ * @return  RSA_KEY_SIZE_E when key size doesn't meet minimum required.
+ */
+static int ProcessBufferTryDecodeRsa(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DerBuffer* der, int* keyFormat, int devId, byte* keyType, int* keySize)
+{
+    int ret;
+    word32 idx;
+    int keySz = 0;
+
+    (void)devId;
+
+    /* Validate we have an RSA private key and get key size. */
+    idx = 0;
+    ret = wc_RsaPrivateKeyValidate(der->buffer, &idx, &keySz, der->length);
+#ifdef WOLF_PRIVATE_KEY_ID
+    /* If that didn't work then maybe a public key if device ID or callback. */
+    if ((ret != 0) && ((devId != INVALID_DEVID) ||
+            WOLFSSL_IS_PRIV_PK_SET(ctx, ssl))) {
+        word32 nSz;
+
+        /* Decode as an RSA public key. */
+        idx = 0;
+        ret = wc_RsaPublicKeyDecode_ex(der->buffer, &idx, der->length, NULL,
+            &nSz, NULL, NULL);
+        if (ret == 0) {
+            keySz = (int)nSz;
+        }
+    }
+#endif
+    if (ret == 0) {
+        /* Get the minimum RSA key size from SSL or SSL context object. */
+        int minRsaSz = ssl ? ssl->options.minRsaKeySz : ctx->minRsaKeySz;
+
+        /* Format, type and size are known. */
+        *keyFormat = RSAk;
+        *keyType = rsa_sa_algo;
+        *keySize = keySz;
+
+        /* Check that the size of the RSA key is enough. */
+        if (keySz < minRsaSz) {
+            WOLFSSL_MSG("Private Key size too small");
+            ret = RSA_KEY_SIZE_E;
+        }
+         /* No static ECC key possible. */
+        if ((ssl != NULL) && (ssl->options.side == WOLFSSL_SERVER_END)) {
+             ssl->options.haveStaticECC = 0;
+        }
+    }
+    /* Not an RSA key but check whether we know what it is. */
+    else if (*keyFormat == 0) {
+        WOLFSSL_MSG("Not an RSA key");
+        /* Format unknown so keep trying. */
+        ret = 0;
+    }
+
+    return ret;
+}
+#else
+/* See if DER data is an RSA private key.
+ *
+ * Checks size meets minimum RSA key size.
+ * This implementation uses more dynamic memory but supports older FIPS.
+ *
+ * @param [in, out] ctx        SSL context object.
+ * @param [in, out] ssl        SSL object.
+ * @param [in]      der        DER encoding.
+ * @param [in, out] keyFormat  On in, expected format. 0 means unknown.
+ * @param [in]      heap       Dynamic memory allocation hint.
+ * @param [in]      devId      Device identifier.
+ * @param [out]     keyType    Type of key.
+ * @param [out]     keySize    Size of key.
+ * @return  0 on success or not an RSA key and format unknown.
+ * @return  RSA_KEY_SIZE_E when key size doesn't meet minimum required.
+ */
+static int ProcessBufferTryDecodeRsa(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DerBuffer* der, int* keyFormat, void* heap, int devId, byte* keyType,
+    int* keySize)
+{
+    int ret;
+    word32 idx;
+    /* make sure RSA key can be used */
+#ifdef WOLFSSL_SMALL_STACK
+    RsaKey* key;
+#else
+    RsaKey  key[1];
+#endif
+
+#ifdef WOLFSSL_SMALL_STACK
+    /* Allocate an RSA key to parse into so we can get size. */
+    key = (RsaKey*)XMALLOC(sizeof(RsaKey), heap, DYNAMIC_TYPE_RSA);
+    if (key == NULL)
+        return MEMORY_E;
+#endif
+
+    /* Initialize the RSA key. */
+    ret = wc_InitRsaKey_ex(key, heap, devId);
+    if (ret == 0) {
+        /* Check we have an RSA private key. */
+        idx = 0;
+        ret = wc_RsaPrivateKeyDecode(der->buffer, &idx, key, der->length);
+    #ifdef WOLF_PRIVATE_KEY_ID
+        /* If that didn't work then maybe a public key if device ID or callback.
+         */
+        if ((ret != 0) && ((devId != INVALID_DEVID) ||
+                WOLFSSL_IS_PRIV_PK_SET(ctx, ssl))) {
+            /* If that didn't work then maybe a public key if device ID or
+             * callback. */
+            idx = 0;
+            ret = wc_RsaPublicKeyDecode(der->buffer, &idx, key, der->length);
+        }
+    #endif
+        if (ret == 0) {
+            /* Get the minimum RSA key size from SSL or SSL context object. */
+            int minRsaSz = ssl ? ssl->options.minRsaKeySz : ctx->minRsaKeySz;
+            int keySz = wc_RsaEncryptSize((RsaKey*)key);
+
+            /* Format is known. */
+            *keyFormat = RSAk;
+            *keyType = rsa_sa_algo;
+            *keySize = keySz;
+
+            /* Check that the size of the RSA key is enough. */
+            if (keySz < minRsaSz) {
+                WOLFSSL_MSG("Private Key size too small");
+                ret = RSA_KEY_SIZE_E;
+            }
+            /* No static ECC key possible. */
+            if ((ssl != NULL) && (ssl->options.side == WOLFSSL_SERVER_END)) {
+                 ssl->options.haveStaticECC = 0;
+            }
+        }
+        /* Not an RSA key but check whether we know what it is. */
+        else if (*keyFormat == 0) {
+            WOLFSSL_MSG("Not an RSA key");
+            /* Format unknown so keep trying. */
+            ret = 0;
+        }
+
+        /* Free dynamically allocated data in key. */
+        wc_FreeRsaKey(key);
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    /* Dispose of allocated key. */
+    XFREE(key, heap, DYNAMIC_TYPE_RSA);
+#endif
+
+    return ret;
+}
+#endif
+#endif /* !NO_RSA */
+
+#ifdef HAVE_ECC
+/* See if DER data is an ECC private key.
+ *
+ * Checks size meets minimum ECC key size.
+ *
+ * @param [in, out] ctx        SSL context object.
+ * @param [in, out] ssl        SSL object.
+ * @param [in]      der        DER encoding.
+ * @param [in, out] keyFormat  On in, expected format. 0 means unknown.
+ * @param [in]      heap       Dynamic memory allocation hint.
+ * @param [in]      devId      Device identifier.
+ * @param [out]     keyType    Type of key.
+ * @param [out]     keySize    Size of key.
+ * @return  0 on success or not an ECC key and format unknown.
+ * @return  ECC_KEY_SIZE_E when ECC key size doesn't meet minimum required.
+ */
+static int ProcessBufferTryDecodeEcc(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DerBuffer* der, int* keyFormat, void* heap, int devId, byte* keyType,
+    int* keySize)
+{
+    int ret = 0;
+    word32 idx;
+    /* make sure ECC key can be used */
+#ifdef WOLFSSL_SMALL_STACK
+    ecc_key* key;
+#else
+    ecc_key  key[1];
+#endif
+
+#ifdef WOLFSSL_SMALL_STACK
+    /* Allocate an ECC key to parse into. */
+    key = (ecc_key*)XMALLOC(sizeof(ecc_key), heap, DYNAMIC_TYPE_ECC);
+    if (key == NULL)
+        return MEMORY_E;
+#endif
+
+    /* Initialize ECC key. */
+    if (wc_ecc_init_ex(key, heap, devId) == 0) {
+        /* Decode as an ECC private key. */
+        idx = 0;
+        ret = wc_EccPrivateKeyDecode(der->buffer, &idx, key, der->length);
+    #ifdef WOLF_PRIVATE_KEY_ID
+        /* If that didn't work then maybe a public key if device ID or callback.
+         */
+        if ((ret != 0) && ((devId != INVALID_DEVID) ||
+                WOLFSSL_IS_PRIV_PK_SET(ctx, ssl))) {
+            /* Decode as an ECC public key. */
+            idx = 0;
+            ret = wc_EccPublicKeyDecode(der->buffer, &idx, key, der->length);
+        }
+    #endif
+    #ifdef WOLFSSL_SM2
+        if (*keyFormat == SM2k) {
+            ret = wc_ecc_set_curve(key, WOLFSSL_SM2_KEY_BITS / 8,
+                ECC_SM2P256V1);
+        }
+    #endif
+        if (ret == 0) {
+            /* Get the minimum ECC key size from SSL or SSL context object. */
+            int minKeySz = ssl ? ssl->options.minEccKeySz : ctx->minEccKeySz;
+            int keySz = wc_ecc_size(key);
+
+            /* Format is known. */
+            *keyFormat = ECDSAk;
+        #ifdef WOLFSSL_SM2
+            if (key->dp->id == ECC_SM2P256V1) {
+                *keyType = sm2_sa_algo;
+            }
+            else
+        #endif
+            {
+                *keyType = ecc_dsa_sa_algo;
+            }
+            *keySize = keySz;
+
+            /* Check that the size of the ECC key is enough. */
+            if (keySz < minKeySz) {
+                WOLFSSL_MSG("ECC private key too small");
+                ret = ECC_KEY_SIZE_E;
+            }
+            /* Static ECC key possible. */
+            if (ssl) {
+                ssl->options.haveStaticECC = 1;
+            }
+            else {
+                ctx->haveStaticECC = 1;
+            }
+        }
+        /* Not an ECC key but check whether we know what it is. */
+        else if (*keyFormat == 0) {
+            WOLFSSL_MSG("Not an ECC key");
+            /* Format unknown so keep trying. */
+            ret = 0;
+        }
+
+        /* Free dynamically allocated data in key. */
+        wc_ecc_free(key);
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    /* Dispose of allocated key. */
+    XFREE(key, heap, DYNAMIC_TYPE_ECC);
+#endif
+    return ret;
+}
+#endif /* HAVE_ECC */
+
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
+/* See if DER data is an Ed25519 private key.
+ *
+ * Checks size meets minimum ECC key size.
+ *
+ * @param [in, out] ctx        SSL context object.
+ * @param [in, out] ssl        SSL object.
+ * @param [in]      der        DER encoding.
+ * @param [in, out] keyFormat  On in, expected format. 0 means unknown.
+ * @param [in]      heap       Dynamic memory allocation hint.
+ * @param [in]      devId      Device identifier.
+ * @param [out]     keyType    Type of key.
+ * @param [out]     keySize    Size of key.
+ * @return  0 on success or not an Ed25519 key and format unknown.
+ * @return  ECC_KEY_SIZE_E when key size doesn't meet minimum required.
+ */
+static int ProcessBufferTryDecodeEd25519(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DerBuffer* der, int* keyFormat, void* heap, int devId, byte* keyType,
+    int* keySize)
+{
+    int ret;
+    word32 idx;
+    /* make sure Ed25519 key can be used */
+#ifdef WOLFSSL_SMALL_STACK
+    ed25519_key* key;
+#else
+    ed25519_key  key[1];
+#endif
+
+#ifdef WOLFSSL_SMALL_STACK
+    /* Allocate an Ed25519 key to parse into. */
+    key = (ed25519_key*)XMALLOC(sizeof(ed25519_key), heap,
+        DYNAMIC_TYPE_ED25519);
+    if (key == NULL)
+        return MEMORY_E;
+#endif
+
+    /* Initialize Ed25519 key. */
+    ret = wc_ed25519_init_ex(key, heap, devId);
+    if (ret == 0) {
+        /* Decode as an Ed25519 private key. */
+        idx = 0;
+        ret = wc_Ed25519PrivateKeyDecode(der->buffer, &idx, key, der->length);
+    #ifdef WOLF_PRIVATE_KEY_ID
+        /* If that didn't work then maybe a public key if device ID or callback.
+         */
+        if ((ret != 0) && ((devId != INVALID_DEVID) ||
+                WOLFSSL_IS_PRIV_PK_SET(ctx, ssl))) {
+            /* Decode as an Ed25519 public key. */
+            idx = 0;
+            ret = wc_Ed25519PublicKeyDecode(der->buffer, &idx, key,
+                der->length);
+        }
+    #endif
+        if (ret == 0) {
+            /* Get the minimum ECC key size from SSL or SSL context object. */
+            int minKeySz = ssl ? ssl->options.minEccKeySz : ctx->minEccKeySz;
+
+            /* Format is known. */
+            *keyFormat = ED25519k;
+            *keyType = ed25519_sa_algo;
+            *keySize = ED25519_KEY_SIZE;
+
+            /* Check that the size of the ECC key is enough. */
+            if (ED25519_KEY_SIZE < minKeySz) {
+                WOLFSSL_MSG("ED25519 private key too small");
+                ret = ECC_KEY_SIZE_E;
+            }
+            if (ssl != NULL) {
+#if !defined(WOLFSSL_NO_CLIENT_AUTH) && !defined(NO_ED25519_CLIENT_AUTH)
+                /* Ed25519 requires caching enabled for tracking message
+                 * hash used in EdDSA_Update for signing */
+                ssl->options.cacheMessages = 1;
+#endif
+            }
+        }
+        /* Not an Ed25519 key but check whether we know what it is. */
+        else if (*keyFormat == 0) {
+            WOLFSSL_MSG("Not an Ed25519 key");
+            /* Format unknown so keep trying. */
+            ret = 0;
+        }
+
+        /* Free dynamically allocated data in key. */
+        wc_ed25519_free(key);
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    /* Dispose of allocated key. */
+    XFREE(key, heap, DYNAMIC_TYPE_ED25519);
+#endif
+    return ret;
+}
+#endif /* HAVE_ED25519 && HAVE_ED25519_KEY_IMPORT */
+
+#if defined(HAVE_ED448) && defined(HAVE_ED448_KEY_IMPORT)
+/* See if DER data is an Ed448 private key.
+ *
+ * Checks size meets minimum ECC key size.
+ *
+ * @param [in, out] ctx        SSL context object.
+ * @param [in, out] ssl        SSL object.
+ * @param [in]      der        DER encoding.
+ * @param [in, out] keyFormat  On in, expected format. 0 means unknown.
+ * @param [in]      heap       Dynamic memory allocation hint.
+ * @param [in]      devId      Device identifier.
+ * @param [out]     keyType    Type of key.
+ * @param [out]     keySize    Size of key.
+ * @return  0 on success or not an Ed448 key and format unknown.
+ * @return  ECC_KEY_SIZE_E when key size doesn't meet minimum required.
+ */
+static int ProcessBufferTryDecodeEd448(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DerBuffer* der, int* keyFormat, void* heap, int devId, byte* keyType,
+    int* keySize)
+{
+    int ret;
+    word32 idx;
+    /* make sure Ed448 key can be used */
+#ifdef WOLFSSL_SMALL_STACK
+    ed448_key* key = NULL;
+#else
+    ed448_key  key[1];
+#endif
+
+#ifdef WOLFSSL_SMALL_STACK
+    /* Allocate an Ed448 key to parse into. */
+    key = (ed448_key*)XMALLOC(sizeof(ed448_key), heap, DYNAMIC_TYPE_ED448);
+    if (key == NULL)
+        return MEMORY_E;
+#endif
+
+    /* Initialize Ed448 key. */
+    ret = wc_ed448_init_ex(key, heap, devId);
+    if (ret == 0) {
+        /* Decode as an Ed448 private key. */
+        idx = 0;
+        ret = wc_Ed448PrivateKeyDecode(der->buffer, &idx, key, der->length);
+    #ifdef WOLF_PRIVATE_KEY_ID
+        /* If that didn't work then maybe a public key if device ID or callback.
+         */
+        if ((ret != 0) && ((devId != INVALID_DEVID) ||
+                WOLFSSL_IS_PRIV_PK_SET(ctx, ssl))) {
+            /* Decode as an Ed448 public key. */
+            idx = 0;
+            ret = wc_Ed448PublicKeyDecode(der->buffer, &idx, key, der->length);
+        }
+    #endif
+        if (ret == 0) {
+            /* Get the minimum ECC key size from SSL or SSL context object. */
+            int minKeySz = ssl ? ssl->options.minEccKeySz : ctx->minEccKeySz;
+
+            /* Format is known. */
+            *keyFormat = ED448k;
+            *keyType = ed448_sa_algo;
+            *keySize = ED448_KEY_SIZE;
+
+            /* Check that the size of the ECC key is enough. */
+            if (ED448_KEY_SIZE < minKeySz) {
+                WOLFSSL_MSG("ED448 private key too small");
+                ret = ECC_KEY_SIZE_E;
+            }
+            if (ssl != NULL) {
+                /* Ed448 requires caching enabled for tracking message
+                 * hash used in EdDSA_Update for signing */
+                ssl->options.cacheMessages = 1;
+            }
+        }
+        /* Not an Ed448 key but check whether we know what it is. */
+        else if (*keyFormat == 0) {
+            WOLFSSL_MSG("Not an Ed448 key");
+            /* Format unknown so keep trying. */
+            ret = 0;
+        }
+
+        /* Free dynamically allocated data in key. */
+        wc_ed448_free(key);
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    /* Dispose of allocated key. */
+    XFREE(key, heap, DYNAMIC_TYPE_ED448);
+#endif
+    return ret;
+}
+#endif /* HAVE_ED448 && HAVE_ED448_KEY_IMPORT */
+
+#if defined(HAVE_FALCON)
+/* See if DER data is an Falcon private key.
+ *
+ * Checks size meets minimum Falcon key size.
+ *
+ * @param [in, out] ctx        SSL context object.
+ * @param [in, out] ssl        SSL object.
+ * @param [in]      der        DER encoding.
+ * @param [in, out] keyFormat  On in, expected format. 0 means unknown.
+ * @param [in]      heap       Dynamic memory allocation hint.
+ * @param [in]      devId      Device identifier.
+ * @param [out]     keyType    Type of key.
+ * @param [out]     keySize    Size of key.
+ * @return  0 on success or not an Falcon key and format unknown.
+ * @return  FALCON_KEY_SIZE_E when key size doesn't meet minimum required.
+ */
+static int ProcessBufferTryDecodeFalcon(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DerBuffer* der, int* keyFormat, void* heap, byte* keyType, int* keySize)
+{
+    int ret;
+    falcon_key* key;
+
+    /* Allocate a Falcon key to parse into. */
+    key = (falcon_key*)XMALLOC(sizeof(falcon_key), heap, DYNAMIC_TYPE_FALCON);
+    if (key == NULL) {
+        return MEMORY_E;
+    }
+
+    /* Initialize Falcon key. */
+    ret = wc_falcon_init(key);
+    if (ret == 0) {
+        /* Set up key to parse the format specified. */
+        if (*keyFormat == FALCON_LEVEL1k) {
+            ret = wc_falcon_set_level(key, 1);
+        }
+        else if (*keyFormat == FALCON_LEVEL5k) {
+            ret = wc_falcon_set_level(key, 5);
+        }
+        else {
+            /* What if *keyformat is 0? We might want to do something more
+             * graceful here. */
+            /* TODO: get the size of the private key for different formats and
+             * compare with DER length. */
+            wc_falcon_free(key);
+            ret = ALGO_ID_E;
+        }
+    }
+
+    if (ret == 0) {
+        /* Decode as a Falcon private key. */
+        ret = wc_falcon_import_private_only(der->buffer, der->length, key);
+        if (ret == 0) {
+            /* Get the minimum Falcon key size from SSL or SSL context object.
+             */
+            int minKeySz = ssl ? ssl->options.minFalconKeySz :
+                                 ctx->minFalconKeySz;
+
+            /* Format is known. */
+            if (*keyFormat == FALCON_LEVEL1k) {
+                *keyType = falcon_level1_sa_algo;
+                *keySize = FALCON_LEVEL1_KEY_SIZE;
+            }
+            else {
+                *keyType = falcon_level5_sa_algo;
+                *keySize = FALCON_LEVEL5_KEY_SIZE;
+            }
+
+            /* Check that the size of the Falcon key is enough. */
+            if (*keySize < minKeySz) {
+                WOLFSSL_MSG("Falcon private key too small");
+                ret = FALCON_KEY_SIZE_E;
+            }
+        }
+        /* Not a Falcon key but check whether we know what it is. */
+        else if (*keyFormat == 0) {
+            WOLFSSL_MSG("Not a Falcon key");
+            /* Format unknown so keep trying. */
+            ret = 0;
+        }
+
+        /* Free dynamically allocated data in key. */
+        wc_falcon_free(key);
+    }
+
+    /* Dispose of allocated key. */
+    XFREE(key, heap, DYNAMIC_TYPE_FALCON);
+    return ret;
+}
+#endif
+
+#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
+    !defined(WOLFSSL_DILITHIUM_NO_ASN1)
+/* See if DER data is an Dilithium private key.
+ *
+ * Checks size meets minimum Falcon key size.
+ *
+ * @param [in, out] ctx        SSL context object.
+ * @param [in, out] ssl        SSL object.
+ * @param [in]      der        DER encoding.
+ * @param [in, out] keyFormat  On in, expected format. 0 means unknown.
+ * @param [in]      heap       Dynamic memory allocation hint.
+ * @param [in]      devId      Device identifier.
+ * @param [out]     keyType    Type of key.
+ * @param [out]     keySize    Size of key.
+ * @return  0 on success or not a Dilithium key and format unknown.
+ * @return  DILITHIUM_KEY_SIZE_E when key size doesn't meet minimum required.
+ */
+static int ProcessBufferTryDecodeDilithium(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DerBuffer* der, int* keyFormat, void* heap, byte* keyType, int* keySize)
+{
+    int ret;
+    word32 idx;
+    dilithium_key* key;
+
+    /* Allocate a Dilithium key to parse into. */
+    key = (dilithium_key*)XMALLOC(sizeof(dilithium_key), heap,
+        DYNAMIC_TYPE_DILITHIUM);
+    if (key == NULL) {
+        return MEMORY_E;
+    }
+
+    /* Initialize Dilithium key. */
+    ret = wc_dilithium_init(key);
+    if (ret == 0) {
+        /* Set up key to parse the format specified. */
+        if (*keyFormat == DILITHIUM_LEVEL2k) {
+            ret = wc_dilithium_set_level(key, 2);
+        }
+        else if (*keyFormat == DILITHIUM_LEVEL3k) {
+            ret = wc_dilithium_set_level(key, 3);
+        }
+        else if (*keyFormat == DILITHIUM_LEVEL5k) {
+            ret = wc_dilithium_set_level(key, 5);
+        }
+        else {
+            /* What if *keyformat is 0? We might want to do something more
+             * graceful here. */
+            /* TODO: get the size of the private key for different formats and
+             * compare with DER length. */
+            wc_dilithium_free(key);
+            ret = ALGO_ID_E;
+        }
+    }
+
+    if (ret == 0) {
+        /* Decode as a Dilithium private key. */
+        idx = 0;
+        ret = wc_Dilithium_PrivateKeyDecode(der->buffer, &idx, key, der->length);
+        if (ret == 0) {
+            /* Get the minimum Dilithium key size from SSL or SSL context
+             * object. */
+            int minKeySz = ssl ? ssl->options.minDilithiumKeySz :
+                                 ctx->minDilithiumKeySz;
+
+            /* Format is known. */
+            if (*keyFormat == DILITHIUM_LEVEL2k) {
+                *keyType = dilithium_level2_sa_algo;
+                *keySize = DILITHIUM_LEVEL2_KEY_SIZE;
+            }
+            else if (*keyFormat == DILITHIUM_LEVEL3k) {
+                *keyType = dilithium_level3_sa_algo;
+                *keySize = DILITHIUM_LEVEL3_KEY_SIZE;
+            }
+            else if (*keyFormat == DILITHIUM_LEVEL5k) {
+                *keyType = dilithium_level5_sa_algo;
+                *keySize = DILITHIUM_LEVEL5_KEY_SIZE;
+            }
+
+            /* Check that the size of the Dilithium key is enough. */
+            if (*keySize < minKeySz) {
+                WOLFSSL_MSG("Dilithium private key too small");
+                ret = DILITHIUM_KEY_SIZE_E;
+            }
+        }
+        /* Not a Dilithium key but check whether we know what it is. */
+        else if (*keyFormat == 0) {
+            WOLFSSL_MSG("Not a Dilithium key");
+            /* Format unknown so keep trying. */
+            ret = 0;
+        }
+
+        /* Free dynamically allocated data in key. */
+        wc_dilithium_free(key);
+    }
+
+    /* Dispose of allocated key. */
+    XFREE(key, heap, DYNAMIC_TYPE_DILITHIUM);
+    return ret;
+}
+#endif /* HAVE_DILITHIUM */
+
+/* Try to decode DER data is a known private key.
+ *
+ * Checks size meets minimum for key type.
+ *
+ * @param [in, out] ctx        SSL context object.
+ * @param [in, out] ssl        SSL object.
+ * @param [in]      der        DER encoding.
+ * @param [in, out] keyFormat  On in, expected format. 0 means unknown.
+ * @param [in]      heap       Dynamic memory allocation hint.
+ * @param [out]     type       Type of key:
+ *                               PRIVATEKEY_TYPE or ALT_PRIVATEKEY_TYPE.
+ * @return  0 on success.
+ * @return  BAD_FUNC_ARG when der or keyFormat is NULL.
+ * @return  BAD_FUNC_ARG when ctx and ssl are NULL.
+ * @return  WOLFSSL_BAD_FILE when unable to identify the key format.
+ */
+static int ProcessBufferTryDecode(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DerBuffer* der, int* keyFormat, void* heap, int type)
+{
+    int ret = 0;
+    int devId = wolfSSL_CTX_GetDevId(ctx, ssl);
+    byte* keyType = NULL;
+    int* keySz = NULL;
+
+    (void)heap;
+    (void)devId;
+    (void)type;
+
+    /* Validate parameters. */
+    if ((der == NULL) || (keyFormat == NULL)) {
+        ret = BAD_FUNC_ARG;
+    }
+    /* Must have an SSL context or SSL object to use. */
+    if ((ret == 0) && (ctx == NULL) && (ssl == NULL)) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (ret == 0) {
+        /* Determine where to put key type and size in SSL or context object. */
+    #ifdef WOLFSSL_DUAL_ALG_CERTS
+        if (type == ALT_PRIVATEKEY_TYPE) {
+            if (ssl != NULL) {
+                keyType = &ssl->buffers.altKeyType;
+                keySz = &ssl->buffers.altKeySz;
+            }
+            else {
+                keyType = &ctx->altPrivateKeyType;
+                keySz = &ctx->altPrivateKeySz;
+            }
+        }
+        else
+    #endif
+        /* Type is PRIVATEKEY_TYPE. */
+        if (ssl != NULL) {
+            keyType = &ssl->buffers.keyType;
+            keySz = &ssl->buffers.keySz;
+        }
+        else {
+            keyType = &ctx->privateKeyType;
+            keySz = &ctx->privateKeySz;
+        }
+    }
+
+#ifndef NO_RSA
+    /* Try RSA if key format is RSA or yet unknown. */
+    if ((ret == 0) && ((*keyFormat == 0) || (*keyFormat == RSAk))) {
+#if !defined(HAVE_FIPS) || (defined(HAVE_FIPS_VERSION) && \
+    (HAVE_FIPS_VERSION > 2))
+        ret = ProcessBufferTryDecodeRsa(ctx, ssl, der, keyFormat, devId,
+            keyType, keySz);
+#else
+        ret = ProcessBufferTryDecodeRsa(ctx, ssl, der, keyFormat, heap, devId,
+            keyType, keySz);
+#endif
+    }
+#endif
+#ifdef HAVE_ECC
+    /* Try ECC if key format is ECDSA or SM2, or yet unknown. */
+    if ((ret == 0) && ((*keyFormat == 0) || (*keyFormat == ECDSAk)
+    #ifdef WOLFSSL_SM2
+        || (*keyFormat == SM2k)
+    #endif
+        )) {
+        ret = ProcessBufferTryDecodeEcc(ctx, ssl, der, keyFormat, heap, devId,
+            keyType, keySz);
+    }
+#endif /* HAVE_ECC */
+#if defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT)
+    /* Try Ed25519 if key format is Ed25519 or yet unknown. */
+    if ((ret == 0) && ((*keyFormat == 0 || *keyFormat == ED25519k))) {
+        ret = ProcessBufferTryDecodeEd25519(ctx, ssl, der, keyFormat, heap,
+            devId, keyType, keySz);
+    }
+#endif /* HAVE_ED25519 && HAVE_ED25519_KEY_IMPORT */
+#if defined(HAVE_ED448) && defined(HAVE_ED448_KEY_IMPORT)
+    /* Try Ed448 if key format is Ed448 or yet unknown. */
+    if ((ret == 0) && ((*keyFormat == 0 || *keyFormat == ED448k))) {
+        ret = ProcessBufferTryDecodeEd448(ctx, ssl, der, keyFormat, heap, devId,
+            keyType, keySz);
+    }
+#endif /* HAVE_ED448 && HAVE_ED448_KEY_IMPORT */
+#if defined(HAVE_FALCON)
+    /* Try Falcon if key format is Falcon level 1k or 5k or yet unknown. */
+    if ((ret == 0) && ((*keyFormat == 0) || (*keyFormat == FALCON_LEVEL1k) ||
+            (*keyFormat == FALCON_LEVEL5k))) {
+        ret = ProcessBufferTryDecodeFalcon(ctx, ssl, der, keyFormat, heap,
+            keyType, keySz);
+    }
+#endif /* HAVE_FALCON */
+#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
+    !defined(WOLFSSL_DILITHIUM_NO_ASN1)
+    /* Try Falcon if key format is Dilithium level 2k, 3k or 5k or yet unknown.
+     */
+    if ((ret == 0) && ((*keyFormat == 0) || (*keyFormat == DILITHIUM_LEVEL2k) ||
+            (*keyFormat == DILITHIUM_LEVEL3k) ||
+            (*keyFormat == DILITHIUM_LEVEL5k))) {
+        ret = ProcessBufferTryDecodeDilithium(ctx, ssl, der, keyFormat, heap,
+            keyType, keySz);
+    }
+#endif /* HAVE_DILITHIUM */
+
+    /* Check we know the format. */
+    if ((ret == 0) && (*keyFormat == 0)) {
+        WOLFSSL_MSG("Not a supported key type");
+        /* Not supported key format. */
+        ret = WOLFSSL_BAD_FILE;
+    }
+
+    return ret;
+}
+
+#if defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_PWDBASED)
+/* Decrypt PKCS#8 private key.
+ *
+ * @param [in] info   Encryption information.
+ * @param [in] der    DER encoded data.
+ * @param [in] heap   Dynamic memory allocation hint.
+ * @return  0 on success.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+static int ProcessBufferPrivPkcs8Dec(EncryptedInfo* info, DerBuffer* der,
+    void* heap)
+{
+    int ret = 0;
+    word32 algId;
+    int   passwordSz = NAME_SZ;
+#ifndef WOLFSSL_SMALL_STACK
+    char  password[NAME_SZ];
+#else
+    char* password;
+#endif
+
+    (void)heap;
+#ifdef WOLFSSL_SMALL_STACK
+    /* Allocate memory for password. */
+    password = (char*)XMALLOC(passwordSz, heap, DYNAMIC_TYPE_STRING);
+    if (password == NULL) {
+        ret = MEMORY_E;
+    }
+#endif
+
+    if (ret == 0) {
+        /* Get password. */
+        ret = info->passwd_cb(password, passwordSz, PEM_PASS_READ,
+            info->passwd_userdata);
+    }
+    if (ret >= 0) {
+        /* Returned value is password size. */
+        passwordSz = ret;
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Add("ProcessBuffer password", password, passwordSz);
+    #endif
+
+        /* Decrypt PKCS#8 private key inline and get algorithm id. */
+        ret = ToTraditionalEnc(der->buffer, der->length, password, passwordSz,
+            &algId);
+    }
+    if (ret >= 0) {
+        /* Zero out encrypted data not overwritten. */
+        ForceZero(der->buffer + ret, der->length - ret);
+        /* Set decrypted data length. */
+        der->length = (word32)ret;
+    }
+
+    /* Ensure password is zeroized. */
+    ForceZero(password, (word32)passwordSz);
+#ifdef WOLFSSL_SMALL_STACK
+    /* Dispose of password memory. */
+    XFREE(password, heap, DYNAMIC_TYPE_STRING);
+#elif defined(WOLFSSL_CHECK_MEM_ZERO)
+    wc_MemZero_Check(password, NAME_SZ);
+#endif
+    return ret;
+}
+#endif /* WOLFSSL_ENCRYPTED_KEYS && !NO_PWDBASED */
+
+/* Put the DER into the SSL or SSL context object.
+ *
+ * Precondition: ctx or ssl is not NULL.
+ * Precondition: Must be a private key type.
+ *
+ * @param [in, out] ctx  SSL context object.
+ * @param [in, out] ssl  SSL object.
+ * @param [in]      der  DER encoding.
+ * @return  0 on success.
+ */
+static int ProcessBufferPrivKeyHandleDer(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DerBuffer** der, int type)
+{
+    int ret = 0;
+
+    (void)type;
+
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+    if (type == ALT_PRIVATEKEY_TYPE) {
+        /* Put in alternate private key fields of objects. */
+        if (ssl != NULL) {
+            /* Dispose of previous key if not context's. */
+            if (ssl->buffers.weOwnAltKey) {
+                FreeDer(&ssl->buffers.altKey);
+            #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+                FreeDer(&ssl->buffers.altKeyMask);
+            #endif
+            }
+            ssl->buffers.altKeyId = 0;
+            ssl->buffers.altKeyLabel = 0;
+            ssl->buffers.altKeyDevId = INVALID_DEVID;
+            /* Store key by reference and own it. */
+            ssl->buffers.altKey = *der;
+        #ifdef WOLFSSL_CHECK_MEM_ZERO
+            wc_MemZero_Add("SSL Buffers key", (*der)->buffer, (*der)->length);
+        #endif
+            ssl->buffers.weOwnAltKey = 1;
+        }
+        else if (ctx != NULL) {
+            /* Dispose of previous key. */
+            FreeDer(&ctx->altPrivateKey);
+            ctx->altPrivateKeyId = 0;
+            ctx->altPrivateKeyLabel = 0;
+            ctx->altPrivateKeyDevId = INVALID_DEVID;
+            /* Store key by reference. */
+            ctx->altPrivateKey = *der;
+        #ifdef WOLFSSL_CHECK_MEM_ZERO
+            wc_MemZero_Add("CTX private key", (*der)->buffer, (*der)->length);
+        #endif
+        }
+    }
+    else
+#endif /* WOLFSSL_DUAL_ALG_CERTS */
+    if (ssl != NULL) {
+        /* Dispose of previous key if not context's. */
+        if (ssl->buffers.weOwnKey) {
+            FreeDer(&ssl->buffers.key);
+        #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+            FreeDer(&ssl->buffers.keyMask);
+        #endif
+        }
+        ssl->buffers.keyId = 0;
+        ssl->buffers.keyLabel = 0;
+        ssl->buffers.keyDevId = INVALID_DEVID;
+        /* Store key by reference and own it. */
+        ssl->buffers.key = *der;
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Add("SSL Buffers key", (*der)->buffer, (*der)->length);
+    #endif
+        ssl->buffers.weOwnKey = 1;
+    }
+    else if (ctx != NULL) {
+        /* Dispose of previous key. */
+        FreeDer(&ctx->privateKey);
+        ctx->privateKeyId = 0;
+        ctx->privateKeyLabel = 0;
+        ctx->privateKeyDevId = INVALID_DEVID;
+        /* Store key by reference. */
+        ctx->privateKey = *der;
+    #ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Add("CTX private key", (*der)->buffer, (*der)->length);
+    #endif
+    }
+
+    return ret;
+}
+
+/* Decode private key.
+ *
+ * Precondition: ctx or ssl is not NULL.
+ * Precondition: Must be a private key type.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      der     DER encoding.
+ * @param [in]      format  Original format of data.
+ * @param [in]      info    Encryption information.
+ * @param [in]      heap    Dynamic memory allocation hint.
+ * @param [in]      type    Type of data:
+ *                            PRIVATEKEY_TYPE or ALT_PRIVATEKEY_TYPE.
+ * @param [in]      algId   Algorithm id of key.
+ * @return  0 on success.
+ * @return  WOLFSSL_BAD_FILE when not able to decode.
+ */
+static int ProcessBufferPrivateKey(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DerBuffer* der, int format, EncryptedInfo* info, void* heap, int type,
+    int algId)
+{
+    int ret;
+#if (defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_PWDBASED)) || \
+     defined(HAVE_PKCS8)
+    word32 p8AlgId = 0;
+#endif
+
+    (void)info;
+    (void)format;
+
+#ifdef HAVE_PKCS8
+    /* Try and remove PKCS8 header and get algorithm id. */
+    ret = ToTraditional_ex(der->buffer, der->length, &p8AlgId);
+    if (ret > 0) {
+        /* Header stripped inline. */
+        der->length = (word32)ret;
+        algId = p8AlgId;
+    }
+#endif
+
+    /* Put the data into the SSL or SSL context object. */
+    ret = ProcessBufferPrivKeyHandleDer(ctx, ssl, &der, type);
+    if (ret == 0) {
+        /* Try to decode the DER data. */
+        ret = ProcessBufferTryDecode(ctx, ssl, der, &algId, heap, type);
+    }
+
+#if defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_PWDBASED)
+    /* If private key type PKCS8 header wasn't already removed (algId == 0). */
+    if (((ret != 0) || (algId == 0)) && (format != WOLFSSL_FILETYPE_PEM) &&
+            (info->passwd_cb != NULL) && (algId == 0)) {
+        /* Try to decrypt DER data as a PKCS#8 private key. */
+        ret = ProcessBufferPrivPkcs8Dec(info, der, heap);
+        if (ret >= 0) {
+            /* Try to decode decrypted data.  */
+            ret = ProcessBufferTryDecode(ctx, ssl, der, &algId, heap, type);
+        }
+    }
+#endif /* WOLFSSL_ENCRYPTED_KEYS && !NO_PWDBASED */
+
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+    if (type == ALT_PRIVATEKEY_TYPE) {
+        if (ssl != NULL) {
+            ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.altKey,
+                &ssl->buffers.altKeyMask);
+        }
+        else {
+            ret = wolfssl_priv_der_blind(NULL, ctx->altPrivateKey,
+                &ctx->altPrivateKeyMask);
+        }
+    }
+    else
+#endif
+    if (ssl != NULL) {
+        ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.key,
+            &ssl->buffers.keyMask);
+    }
+    else {
+        ret = wolfssl_priv_der_blind(NULL, ctx->privateKey,
+            &ctx->privateKeyMask);
+    }
+#endif
+
+    /* Check if we were able to determine algorithm id. */
+    if ((ret == 0) && (algId == 0)) {
+    #ifdef OPENSSL_EXTRA
+        /* Decryption password is probably wrong. */
+        if (info->passwd_cb) {
+            EVPerr(0, EVP_R_BAD_DECRYPT);
+        }
+    #endif
+        WOLFSSL_ERROR(WOLFSSL_BAD_FILE);
+        /* Unable to decode DER data. */
+        ret = WOLFSSL_BAD_FILE;
+    }
+
+    return ret;
+}
+
+/* Use the key OID to determine have options.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      keyOID  OID for public/private key.
+ */
+static void wolfssl_set_have_from_key_oid(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    int keyOID)
+{
+    /* Set which private key algorithm available based on key OID. */
+    switch (keyOID) {
+        case ECDSAk:
+    #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
+        case SM2k:
+    #endif
+    #ifdef HAVE_ED25519
+        case ED25519k:
+    #endif
+    #ifdef HAVE_ED448
+        case ED448k:
+    #endif
+            if (ssl != NULL) {
+                ssl->options.haveECC = 1;
+            }
+            else {
+                ctx->haveECC = 1;
+            }
+            break;
+    #ifndef NO_RSA
+        case RSAk:
+        #ifdef WC_RSA_PSS
+        case RSAPSSk:
+        #endif
+            if (ssl != NULL) {
+                ssl->options.haveRSA = 1;
+            }
+            else {
+                ctx->haveRSA = 1;
+            }
+            break;
+    #endif
+    #ifdef HAVE_FALCON
+        case FALCON_LEVEL1k:
+        case FALCON_LEVEL5k:
+            if (ssl != NULL) {
+                ssl->options.haveFalconSig = 1;
+            }
+            else {
+                ctx->haveFalconSig = 1;
+            }
+            break;
+    #endif /* HAVE_FALCON */
+    #ifdef HAVE_DILITHIUM
+        case DILITHIUM_LEVEL2k:
+        case DILITHIUM_LEVEL3k:
+        case DILITHIUM_LEVEL5k:
+            if (ssl != NULL) {
+                ssl->options.haveDilithiumSig = 1;
+            }
+            else {
+                ctx->haveDilithiumSig = 1;
+            }
+            break;
+    #endif /* HAVE_DILITHIUM */
+        default:
+            WOLFSSL_MSG("Cert key not supported");
+            break;
+        }
+}
+
+/* Set which private key algorithm we have against SSL or SSL context object.
+ *
+ * Precondition: ctx or ssl is not NULL.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      cert    Decode certificate.
+ */
+static void ProcessBufferCertSetHave(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DecodedCert* cert)
+{
+    if (ssl != NULL) {
+        /* Reset signatures we have in SSL. */
+        ssl->options.haveECDSAsig = 0;
+        ssl->options.haveFalconSig = 0;
+        ssl->options.haveDilithiumSig = 0;
+    }
+
+    /* Set which signature we have based on the type in the cert. */
+    switch (cert->signatureOID) {
+        case CTC_SHAwECDSA:
+        case CTC_SHA256wECDSA:
+        case CTC_SHA384wECDSA:
+        case CTC_SHA512wECDSA:
+    #ifdef HAVE_ED25519
+        case CTC_ED25519:
+    #endif
+    #ifdef HAVE_ED448
+        case CTC_ED448:
+    #endif
+    #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
+        case CTC_SM3wSM2:
+    #endif
+            WOLFSSL_MSG("ECDSA/ED25519/ED448 cert signature");
+            if (ssl) {
+                ssl->options.haveECDSAsig = 1;
+            }
+            else if (ctx) {
+                ctx->haveECDSAsig = 1;
+            }
+            break;
+    #ifdef HAVE_FALCON
+        case CTC_FALCON_LEVEL1:
+        case CTC_FALCON_LEVEL5:
+            WOLFSSL_MSG("Falcon cert signature");
+            if (ssl) {
+                ssl->options.haveFalconSig = 1;
+            }
+            else if (ctx) {
+                ctx->haveFalconSig = 1;
+            }
+            break;
+    #endif
+    #ifdef HAVE_DILITHIUM
+        case CTC_DILITHIUM_LEVEL2:
+        case CTC_DILITHIUM_LEVEL3:
+        case CTC_DILITHIUM_LEVEL5:
+            WOLFSSL_MSG("Dilithium cert signature");
+            if (ssl) {
+                ssl->options.haveDilithiumSig = 1;
+            }
+            else if (ctx) {
+                ctx->haveDilithiumSig = 1;
+            }
+            break;
+    #endif
+        default:
+            WOLFSSL_MSG("Cert signature not supported");
+            break;
+    }
+
+#if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448) || \
+    defined(HAVE_FALCON) || defined(HAVE_DILITHIUM) || !defined(NO_RSA)
+    #if defined(HAVE_ECC) || defined(HAVE_ED25519) || defined(HAVE_ED448)
+    /* Set the private key curve OID. */
+    if (ssl != NULL) {
+        ssl->pkCurveOID = cert->pkCurveOID;
+    }
+    else if (ctx) {
+        ctx->pkCurveOID = cert->pkCurveOID;
+    }
+    #endif
+#ifndef WC_STRICT_SIG
+    wolfssl_set_have_from_key_oid(ctx, ssl, cert->keyOID);
+#else
+    /* Set whether ECC is available based on signature available. */
+    if (ssl != NULL) {
+        ssl->options.haveECC = ssl->options.haveECDSAsig;
+    }
+    else if (ctx) {
+        ctx->haveECC = ctx->haveECDSAsig;
+    }
+#endif /* !WC_STRICT_SIG */
+#endif
+}
+
+/* Check key size is valid.
+ *
+ * Precondition: ctx or ssl is not NULL.
+ *
+ * @param [in] min    Minimum key size.
+ * @param [in] max    Maximum key size.
+ * @param [in] keySz  Key size.
+ * @param [in] err    Error value to return when key size is invalid.
+ * @return  0 on success.
+ * @return  err when verifying and min is less than 0 or key size is invalid.
+ */
+#define CHECK_KEY_SZ(min, max, keySz, err)                                     \
+    (((min) < 0) || ((keySz) < (min)) || ((keySz) > (max))) ? (err) : 0
+
+/* Check public key in certificate.
+ *
+ * @param [in, out] ctx   SSL context object.
+ * @param [in, out] ssl   SSL object.
+ * @param [in]      cert  Certificate object.
+ * @return  0 on success.
+ * @return  Non-zero when an error occurred.
+ */
+static int ProcessBufferCertPublicKey(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DecodedCert* cert, int checkKeySz)
+{
+    int ret = 0;
+    byte keyType = 0;
+    int keySz = 0;
+#ifndef NO_RSA
+    word32 idx;
+#endif
+
+    /* Get key size and check unless not verifying. */
+    switch (cert->keyOID) {
+#ifndef NO_RSA
+    #ifdef WC_RSA_PSS
+        case RSAPSSk:
+    #endif
+        case RSAk:
+            keyType = rsa_sa_algo;
+            /* Determine RSA key size by parsing public key */
+            idx = 0;
+            ret = wc_RsaPublicKeyDecode_ex(cert->publicKey, &idx,
+                cert->pubKeySize, NULL, (word32*)&keySz, NULL, NULL);
+            if ((ret == 0) && checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minRsaKeySz :
+                    ctx->minRsaKeySz, RSA_MAX_SIZE / 8, keySz, RSA_KEY_SIZE_E);
+            }
+            break;
+#endif /* !NO_RSA */
+    #ifdef HAVE_ECC
+        case ECDSAk:
+            keyType = ecc_dsa_sa_algo;
+            /* Determine ECC key size based on curve */
+        #ifdef WOLFSSL_CUSTOM_CURVES
+            if ((cert->pkCurveOID == 0) && (cert->pkCurveSize != 0)) {
+                keySz = cert->pkCurveSize;
+            }
+            else
+        #endif
+            {
+                keySz = wc_ecc_get_curve_size_from_id(wc_ecc_get_oid(
+                    cert->pkCurveOID, NULL, NULL));
+            }
+
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minEccKeySz :
+                     ctx->minEccKeySz, (MAX_ECC_BITS + 7) / 8, keySz,
+                     ECC_KEY_SIZE_E);
+            }
+            break;
+    #endif /* HAVE_ECC */
+    #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
+        case SM2k:
+            keyType = sm2_sa_algo;
+            /* Determine ECC key size based on curve */
+            keySz = WOLFSSL_SM2_KEY_BITS / 8;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minEccKeySz :
+                    ctx->minEccKeySz, (MAX_ECC_BITS + 7) / 8, keySz,
+                    ECC_KEY_SIZE_E);
+            }
+            break;
+    #endif /* HAVE_ED25519 */
+    #ifdef HAVE_ED25519
+        case ED25519k:
+            keyType = ed25519_sa_algo;
+            /* ED25519 is fixed key size */
+            keySz = ED25519_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minEccKeySz :
+                    ctx->minEccKeySz, ED25519_KEY_SIZE, keySz, ECC_KEY_SIZE_E);
+            }
+            break;
+    #endif /* HAVE_ED25519 */
+    #ifdef HAVE_ED448
+        case ED448k:
+            keyType = ed448_sa_algo;
+            /* ED448 is fixed key size */
+            keySz = ED448_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minEccKeySz :
+                    ctx->minEccKeySz, ED448_KEY_SIZE, keySz, ECC_KEY_SIZE_E);
+            }
+            break;
+    #endif /* HAVE_ED448 */
+    #if defined(HAVE_FALCON)
+        case FALCON_LEVEL1k:
+            keyType = falcon_level1_sa_algo;
+            /* Falcon is fixed key size */
+            keySz = FALCON_LEVEL1_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minFalconKeySz :
+                    ctx->minFalconKeySz, FALCON_MAX_KEY_SIZE, keySz,
+                    FALCON_KEY_SIZE_E);
+            }
+            break;
+        case FALCON_LEVEL5k:
+            keyType = falcon_level5_sa_algo;
+            /* Falcon is fixed key size */
+            keySz = FALCON_LEVEL5_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minFalconKeySz :
+                    ctx->minFalconKeySz, FALCON_MAX_KEY_SIZE, keySz,
+                    FALCON_KEY_SIZE_E);
+            }
+            break;
+    #endif /* HAVE_FALCON */
+    #if defined(HAVE_DILITHIUM)
+        case DILITHIUM_LEVEL2k:
+            keyType = dilithium_level2_sa_algo;
+            /* Dilithium is fixed key size */
+            keySz = DILITHIUM_LEVEL2_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minDilithiumKeySz :
+                    ctx->minDilithiumKeySz, DILITHIUM_MAX_KEY_SIZE, keySz,
+                    DILITHIUM_KEY_SIZE_E);
+            }
+            break;
+        case DILITHIUM_LEVEL3k:
+            keyType = dilithium_level3_sa_algo;
+            /* Dilithium is fixed key size */
+            keySz = DILITHIUM_LEVEL3_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minDilithiumKeySz :
+                    ctx->minDilithiumKeySz, DILITHIUM_MAX_KEY_SIZE, keySz,
+                    DILITHIUM_KEY_SIZE_E);
+            }
+            break;
+        case DILITHIUM_LEVEL5k:
+            keyType = dilithium_level5_sa_algo;
+            /* Dilithium is fixed key size */
+            keySz = DILITHIUM_LEVEL5_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minDilithiumKeySz :
+                    ctx->minDilithiumKeySz, DILITHIUM_MAX_KEY_SIZE, keySz,
+                    DILITHIUM_KEY_SIZE_E);
+            }
+            break;
+    #endif /* HAVE_DILITHIUM */
+
+        default:
+            WOLFSSL_MSG("No key size check done on public key in certificate");
+            break;
+    }
+
+    /* Store the type and key size as there may not be a private key set. */
+    if (ssl != NULL) {
+        ssl->buffers.keyType = keyType;
+        ssl->buffers.keySz = keySz;
+    }
+    else {
+        ctx->privateKeyType = keyType;
+        ctx->privateKeySz = keySz;
+    }
+
+    return ret;
+}
+
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+static int ProcessBufferCertAltPublicKey(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DecodedCert* cert, int checkKeySz)
+{
+    int ret = 0;
+    void* heap = WOLFSSL_HEAP(ctx, ssl);
+    byte keyType = 0;
+    int keySz = 0;
+#ifndef NO_RSA
+    word32 idx;
+#endif
+
+    /* Check alternative key size of cert. */
+    switch (cert->sapkiOID) {
+        /* No OID set. */
+        case 0:
+            if (cert->sapkiLen != 0) {
+                /* Have the alternative key data but no OID. */
+                ret = NOT_COMPILED_IN;
+            }
+            break;
+
+#ifndef NO_RSA
+    #ifdef WC_RSA_PSS
+        case RSAPSSk:
+    #endif
+        case RSAk:
+            keyType = rsa_sa_algo;
+            /* Determine RSA key size by parsing public key */
+            idx = 0;
+            ret = wc_RsaPublicKeyDecode_ex(cert->sapkiDer, &idx,
+                cert->sapkiLen, NULL, (word32*)&keySz, NULL, NULL);
+            if ((ret == 0) && checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minRsaKeySz :
+                    ctx->minRsaKeySz, RSA_MAX_SIZE / 8, keySz, RSA_KEY_SIZE_E);
+            }
+            break;
+#endif /* !NO_RSA */
+    #ifdef HAVE_ECC
+        case ECDSAk:
+        {
+        #ifdef WOLFSSL_SMALL_STACK
+            ecc_key* temp_key = NULL;
+        #else
+            ecc_key temp_key[1];
+        #endif
+            keyType = ecc_dsa_sa_algo;
+
+        #ifdef WOLFSSL_SMALL_STACK
+            temp_key = (ecc_key*)XMALLOC(sizeof(ecc_key), heap,
+                DYNAMIC_TYPE_ECC);
+            if (temp_key == NULL) {
+                ret = MEMORY_E;
+            }
+        #endif
+
+            /* Determine ECC key size. We have to decode the sapki for
+             * that. */
+            if (ret == 0) {
+                ret = wc_ecc_init_ex(temp_key, heap, INVALID_DEVID);
+                if (ret == 0) {
+                    idx = 0;
+                    ret = wc_EccPublicKeyDecode(cert->sapkiDer, &idx, temp_key,
+                        cert->sapkiLen);
+                    if (ret == 0) {
+                        keySz = wc_ecc_size(temp_key);
+                    }
+                    wc_ecc_free(temp_key);
+                }
+            }
+        #ifdef WOLFSSL_SMALL_STACK
+            XFREE(temp_key, heap, DYNAMIC_TYPE_ECC);
+        #endif
+
+            if ((ret == 0) && checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minEccKeySz :
+                     ctx->minEccKeySz, (MAX_ECC_BITS + 7) / 8, keySz,
+                     ECC_KEY_SIZE_E);
+            }
+            break;
+        }
+    #endif /* HAVE_ECC */
+    #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
+        case SM2k:
+            keyType = sm2_sa_algo;
+            /* Determine ECC key size based on curve */
+            keySz = WOLFSSL_SM2_KEY_BITS / 8;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minEccKeySz :
+                    ctx->minEccKeySz, (MAX_ECC_BITS + 7) / 8, keySz,
+                    ECC_KEY_SIZE_E);
+            }
+            break;
+    #endif /* HAVE_ED25519 */
+    #ifdef HAVE_ED25519
+        case ED25519k:
+            keyType = ed25519_sa_algo;
+            /* ED25519 is fixed key size */
+            keySz = ED25519_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minEccKeySz :
+                    ctx->minEccKeySz, ED25519_KEY_SIZE, keySz, ECC_KEY_SIZE_E);
+            }
+            break;
+    #endif /* HAVE_ED25519 */
+    #ifdef HAVE_ED448
+        case ED448k:
+            keyType = ed448_sa_algo;
+            /* ED448 is fixed key size */
+            keySz = ED448_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minEccKeySz :
+                    ctx->minEccKeySz, ED448_KEY_SIZE, keySz, ECC_KEY_SIZE_E);
+            }
+            break;
+    #endif /* HAVE_ED448 */
+    #if defined(HAVE_FALCON)
+        case FALCON_LEVEL1k:
+            keyType = falcon_level1_sa_algo;
+            /* Falcon is fixed key size */
+            keySz = FALCON_LEVEL1_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minFalconKeySz :
+                    ctx->minFalconKeySz, FALCON_MAX_KEY_SIZE, keySz,
+                    FALCON_KEY_SIZE_E);
+            }
+            break;
+        case FALCON_LEVEL5k:
+            keyType = falcon_level5_sa_algo;
+            /* Falcon is fixed key size */
+            keySz = FALCON_LEVEL5_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minFalconKeySz :
+                    ctx->minFalconKeySz, FALCON_MAX_KEY_SIZE, keySz,
+                    FALCON_KEY_SIZE_E);
+            }
+            break;
+    #endif /* HAVE_FALCON */
+    #if defined(HAVE_DILITHIUM)
+        case DILITHIUM_LEVEL2k:
+            keyType = dilithium_level2_sa_algo;
+            /* Dilithium is fixed key size */
+            keySz = DILITHIUM_LEVEL2_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minDilithiumKeySz :
+                    ctx->minDilithiumKeySz, DILITHIUM_MAX_KEY_SIZE, keySz,
+                    DILITHIUM_KEY_SIZE_E);
+            }
+            break;
+        case DILITHIUM_LEVEL3k:
+            keyType = dilithium_level3_sa_algo;
+            /* Dilithium is fixed key size */
+            keySz = DILITHIUM_LEVEL3_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minDilithiumKeySz :
+                    ctx->minDilithiumKeySz, DILITHIUM_MAX_KEY_SIZE, keySz,
+                    DILITHIUM_KEY_SIZE_E);
+            }
+            break;
+        case DILITHIUM_LEVEL5k:
+            keyType = dilithium_level5_sa_algo;
+            /* Dilithium is fixed key size */
+            keySz = DILITHIUM_LEVEL5_KEY_SIZE;
+            if (checkKeySz) {
+                ret = CHECK_KEY_SZ(ssl ? ssl->options.minDilithiumKeySz :
+                    ctx->minDilithiumKeySz, DILITHIUM_MAX_KEY_SIZE, keySz,
+                    DILITHIUM_KEY_SIZE_E);
+            }
+            break;
+    #endif /* HAVE_DILITHIUM */
+
+        default:
+            /* In this case, there was an OID that we didn't recognize.
+             * This is an error. Use not compiled in because likely the
+             * given algorithm was not enabled. */
+            ret = NOT_COMPILED_IN;
+            WOLFSSL_MSG("No alt key size check done on certificate");
+            break;
+    }
+
+    if (ssl != NULL) {
+        ssl->buffers.altKeyType = (byte)keyType;
+        ssl->buffers.altKeySz = keySz;
+    }
+    else if (ctx != NULL) {
+        ctx->altPrivateKeyType = (byte)keyType;
+        ctx->altPrivateKeySz = keySz;
+    }
+
+    return ret;
+}
+#endif /* WOLFSSL_DUAL_ALG_CERTS */
+
+/* Parse the certificate and pull out information for TLS handshake.
+ *
+ * @param [in, out] ctx   SSL context object.
+ * @param [in, out] ssl   SSL object.
+ * @param [in]      der   DER encoded X509 certificate.
+ * @return  0 on success.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ * @return  WOLFSSL_BAD_FILE when decoding certificate fails.
+ */
+static int ProcessBufferCert(WOLFSSL_CTX* ctx, WOLFSSL* ssl, DerBuffer* der)
+{
+    int ret = 0;
+    void* heap = WOLFSSL_HEAP(ctx, ssl);
+#if defined(HAVE_RPK)
+    RpkState* rpkState = ssl ? &ssl->options.rpkState : &ctx->rpkState;
+#endif
+#ifdef WOLFSSL_SMALL_STACK
+    DecodedCert* cert;
+#else
+    DecodedCert  cert[1];
+#endif
+
+#ifdef WOLFSSL_SMALL_STACK
+    /* Allocate memory for certificate to be decoded into. */
+    cert = (DecodedCert*)XMALLOC(sizeof(DecodedCert), heap, DYNAMIC_TYPE_DCERT);
+    if (cert == NULL) {
+        ret = MEMORY_E;
+    }
+
+    if (ret == 0)
+#endif
+    {
+        /* Get device id from SSL context or SSL object. */
+        int devId = wolfSSL_CTX_GetDevId(ctx, ssl);
+
+        WOLFSSL_MSG("Checking cert signature type");
+        /* Initialize certificate object. */
+        InitDecodedCert_ex(cert, der->buffer, der->length, heap, devId);
+
+        /* Decode up to and including public key. */
+        if (DecodeToKey(cert, 0) < 0) {
+            WOLFSSL_MSG("Decode to key failed");
+            ret = WOLFSSL_BAD_FILE;
+        }
+        if (ret == 0) {
+            int checkKeySz = 1;
+
+        #if defined(HAVE_RPK)
+            /* Store whether the crtificate is a raw public key. */
+            rpkState->isRPKLoaded = cert->isRPK;
+        #endif /* HAVE_RPK */
+
+            /* Set which private key algorithm we have. */
+            ProcessBufferCertSetHave(ctx, ssl, cert);
+
+            /* Don't check if verification is disabled for SSL. */
+            if ((ssl != NULL) && ssl->options.verifyNone) {
+                checkKeySz = 0;
+            }
+            /* Don't check if no SSL object verification is disabled for SSL
+             * context. */
+            else if ((ssl == NULL) && ctx->verifyNone) {
+                checkKeySz = 0;
+            }
+
+            /* Check public key size. */
+            ret = ProcessBufferCertPublicKey(ctx, ssl, cert, checkKeySz);
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
+            if (ret == 0) {
+                ret = ProcessBufferCertAltPublicKey(ctx, ssl, cert, checkKeySz);
+            }
+        #endif
+        }
+    }
+
+    /* Dispose of dynamic memory in certificate object. */
+    FreeDecodedCert(cert);
+#ifdef WOLFSSL_SMALL_STACK
+    /* Dispose of certificate object. */
+    XFREE(cert, heap, DYNAMIC_TYPE_DCERT);
+#endif
+    return ret;
+}
+
+/* Handle storing the DER encoding of the certificate.
+ *
+ * Do not free der outside of this function.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      der     DER encoded certificate.
+ * @param [in]      type    Type of data:
+ *                            CERT_TYPE, CA_TYPE or TRUSTED_PEER_TYPE.
+ * @param [in]      verify  What verification to do.
+ * @return  0 on success.
+ * @return  BAD_FUNC_ARG when type is CA_TYPE and ctx is NULL.
+ * @return  WOLFSSL_BAD_CERTTYPE when data type is not supported.
+ */
+static int ProcessBufferCertHandleDer(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    DerBuffer* der, int type, int verify)
+{
+    int ret = 0;
+
+    /* CA certificate to verify with. */
+    if (type == CA_TYPE) {
+        /* verify CA unless user set to no verify */
+        ret = AddCA(ctx->cm, &der, WOLFSSL_USER_CA, verify);
+        if (ret == 1) {
+            ret = 0;
+        }
+    }
+#ifdef WOLFSSL_TRUST_PEER_CERT
+    /* Trusted certificate to verify peer with. */
+    else if (type == TRUSTED_PEER_TYPE) {
+        WOLFSSL_CERT_MANAGER* cm;
+
+        /* Get certificate manager to add certificate to. */
+        if (ctx != NULL) {
+            cm = ctx->cm;
+        }
+        else {
+            SSL_CM_WARNING(ssl);
+            cm = SSL_CM(ssl);
+        }
+        /* Add certificate as a trusted peer. */
+        ret = AddTrustedPeer(cm, &der, verify);
+        if (ret != 1) {
+            WOLFSSL_MSG("Error adding trusted peer");
+        }
+    }
+#endif /* WOLFSSL_TRUST_PEER_CERT */
+    /* Leaf certificate - our certificate. */
+    else if (type == CERT_TYPE) {
+        if (ssl != NULL) {
+            /* Free previous certificate if we own it. */
+            if (ssl->buffers.weOwnCert) {
+                FreeDer(&ssl->buffers.certificate);
+            #ifdef KEEP_OUR_CERT
+                /* Dispose of X509 version of certificate. */
+                wolfSSL_X509_free(ssl->ourCert);
+                ssl->ourCert = NULL;
+            #endif
+            }
+            /* Store certificate as ours. */
+            ssl->buffers.certificate = der;
+        #ifdef KEEP_OUR_CERT
+            ssl->keepCert = 1; /* hold cert for ssl lifetime */
+        #endif
+            /* We have to free the certificate buffer. */
+            ssl->buffers.weOwnCert = 1;
+            /* ourCert is created on demand. */
+        }
+        else if (ctx != NULL) {
+            /* Free previous certificate. */
+            FreeDer(&ctx->certificate); /* Make sure previous is free'd */
+        #ifdef KEEP_OUR_CERT
+            /* Dispose of X509 version of certificate if we own it. */
+            if (ctx->ownOurCert) {
+                wolfSSL_X509_free(ctx->ourCert);
+            }
+            ctx->ourCert = NULL;
+        #endif
+            /* Store certificate as ours. */
+            ctx->certificate = der;
+            /* ourCert is created on demand. */
+        }
+    }
+    else {
+        /* Dispose of DER buffer. */
+        FreeDer(&der);
+        /* Not a certificate type supported. */
+        ret = WOLFSSL_BAD_CERTTYPE;
+    }
+
+    return ret;
+}
+
+/* Process certificate based on type.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      buff    Buffer holding original data.
+ * @param [in]      sz      Size of data in buffer.
+ * @param [in]      der     DER encoding of certificate.
+ * @param [in]      format  Format of data.
+ * @param [in]      type    Type of data:
+ *                            CERT_TYPE, CA_TYPE or TRUSTED_PEER_TYPE.
+ * @param [in]      verify  What verification to do.
+ * @return  0 on success.
+ * @return  WOLFSSL_FATAL_ERROR on failure.
+ */
+static int ProcessBufferCertTypes(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    const unsigned char* buff, long sz, DerBuffer* der, int format, int type,
+    int verify)
+{
+    int ret;
+
+    (void)buff;
+    (void)sz;
+    (void)format;
+
+    ret = ProcessBufferCertHandleDer(ctx, ssl, der, type, verify);
+    if ((ret == 0) && (type == CERT_TYPE)) {
+        /* Process leaf certificate. */
+        ret = ProcessBufferCert(ctx, ssl, der);
+    }
+#if !defined(NO_WOLFSSL_CM_VERIFY) && (!defined(NO_WOLFSSL_CLIENT) || \
+    !defined(WOLFSSL_NO_CLIENT_AUTH))
+    /* Hand bad CA or user certificate to callback. */
+    if ((ret < 0) && ((type == CA_TYPE) || (type == CERT_TYPE))) {
+        /* Check for verification callback that may override error. */
+        if ((ctx != NULL) && (ctx->cm != NULL) &&
+                (ctx->cm->verifyCallback != NULL)) {
+            /* Verify and use callback. */
+            ret = CM_VerifyBuffer_ex(ctx->cm, buff, sz, format, ret);
+            /* Convert error. */
+            if (ret == 0) {
+                ret = WOLFSSL_FATAL_ERROR;
+            }
+            if (ret == 1) {
+                ret = 0;
+            }
+        }
+    }
+#endif /* NO_WOLFSSL_CM_VERIFY */
+
+    return ret;
+}
+
+/* Reset the cipher suites based on updated private key or certificate.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      type    Type of certificate.
+ * @return  0 on success.
+ * @return  WOLFSSL_FATAL_ERROR when allocation fails.
+ */
+static int ProcessBufferResetSuites(WOLFSSL_CTX* ctx, WOLFSSL* ssl, int type)
+{
+    int ret = 0;
+
+    /* Reset suites of SSL object. */
+    if (ssl != NULL) {
+        if (ssl->options.side == WOLFSSL_SERVER_END) {
+            /* Allocate memory for suites. */
+            if (AllocateSuites(ssl) != 0) {
+                ret = WOLFSSL_FATAL_ERROR;
+            }
+            else {
+                /* Determine cipher suites based on what we have. */
+                InitSuites(ssl->suites, ssl->version, ssl->buffers.keySz,
+                    WOLFSSL_HAVE_RSA, SSL_HAVE_PSK(ssl), ssl->options.haveDH,
+                    ssl->options.haveECDSAsig, ssl->options.haveECC, TRUE,
+                    ssl->options.haveStaticECC, ssl->options.haveFalconSig,
+                    ssl->options.haveDilithiumSig, ssl->options.useAnon, TRUE,
+                    ssl->options.side);
+            }
+        }
+    }
+    /* Reset suites of SSL context object. */
+    else if ((type == CERT_TYPE) && (ctx->method->side == WOLFSSL_SERVER_END)) {
+        /* Allocate memory for suites. */
+        if (AllocateCtxSuites(ctx) != 0) {
+            ret = WOLFSSL_FATAL_ERROR;
+        }
+        else {
+            /* Determine cipher suites based on what we have. */
+            InitSuites(ctx->suites, ctx->method->version, ctx->privateKeySz,
+                WOLFSSL_HAVE_RSA, CTX_HAVE_PSK(ctx), ctx->haveDH,
+                ctx->haveECDSAsig, ctx->haveECC, TRUE, ctx->haveStaticECC,
+                ctx->haveFalconSig, ctx->haveDilithiumSig, CTX_USE_ANON(ctx),
+                TRUE, ctx->method->side);
+        }
+    }
+
+    return ret;
+}
+
+#ifndef WOLFSSL_DUAL_ALG_CERTS
+    /* Determine whether the type is for a private key. */
+    #define IS_PRIVKEY_TYPE(type) ((type) == PRIVATEKEY_TYPE)
+#else
+    /* Determine whether the type is for a private key. */
+    #define IS_PRIVKEY_TYPE(type) (((type) == PRIVATEKEY_TYPE) ||   \
+                                   ((type) == ALT_PRIVATEKEY_TYPE))
+#endif
+
+/* Process a buffer of data.
+ *
+ * Data type is a private key or a certificate.
+ * The format can be ASN.1 (DER) or PEM.
+ *
+ * @param [in, out] ctx        SSL context object.
+ * @param [in]      buff       Buffer holding data.
+ * @param [in]      sz         Size of data in buffer.
+ * @param [in]      format     Format of data:
+ *                               WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @param [in]      type       Type of data:
+ *                               CERT_TYPE, CA_TYPE, TRUSTED_PEER_TYPE,
+ *                               PRIVATEKEY_TYPE or ALT_PRIVATEKEY_TYPE.
+ * @param [in, out] ssl        SSL object.
+ * @param [out]     used       Number of bytes consumed.
+ * @param [in[      userChain  Whether this certificate is for user's chain.
+ * @param [in]      verify     How to verify certificate.
+ * @return  1 on success.
+ * @return  Less than 1 on failure.
+ */
+int ProcessBuffer(WOLFSSL_CTX* ctx, const unsigned char* buff, long sz,
+    int format, int type, WOLFSSL* ssl, long* used, int userChain, int verify)
+{
+    DerBuffer*    der = NULL;
+    int           ret = 0;
+    void*         heap = WOLFSSL_HEAP(ctx, ssl);
+#ifdef WOLFSSL_SMALL_STACK
+    EncryptedInfo* info = NULL;
+#else
+    EncryptedInfo  info[1];
+#endif
+    int           algId = 0;
+
+    WOLFSSL_ENTER("ProcessBuffer");
+
+    /* Check data format is supported. */
+    if ((format != WOLFSSL_FILETYPE_ASN1) && (format != WOLFSSL_FILETYPE_PEM)) {
+        ret = WOLFSSL_BAD_FILETYPE;
+    }
+    /* Need an object to store certificate into. */
+    if ((ret == 0) && (ctx == NULL) && (ssl == NULL)) {
+        ret = BAD_FUNC_ARG;
+    }
+    /* CA certificates go into the SSL context object. */
+    if ((ret == 0) && (ctx == NULL) && (type == CA_TYPE)) {
+        ret = BAD_FUNC_ARG;
+    }
+    /* This API does not handle CHAIN_CERT_TYPE */
+    if ((ret == 0) && (type == CHAIN_CERT_TYPE)) {
+        ret = BAD_FUNC_ARG;
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    if (ret == 0) {
+        /* Allocate memory for encryption information. */
+        info = (EncryptedInfo*)XMALLOC(sizeof(EncryptedInfo), heap,
+            DYNAMIC_TYPE_ENCRYPTEDINFO);
+        if (info == NULL) {
+            ret = MEMORY_E;
+        }
+    }
+#endif
+    if (ret == 0) {
+        /* Initialize encryption information. */
+        XMEMSET(info, 0, sizeof(EncryptedInfo));
+    #if defined(WOLFSSL_ENCRYPTED_KEYS) && !defined(NO_PWDBASED)
+        if (ctx != NULL) {
+            info->passwd_cb       = ctx->passwd_cb;
+            info->passwd_userdata = ctx->passwd_userdata;
+        }
+    #endif
+
+        /* Get the DER data for a private key or certificate. */
+        ret = DataToDerBuffer(buff, (word32)sz, format, type, info, heap, &der,
+            &algId);
+        if (used != NULL) {
+            /* Update to amount used/consumed. */
+            *used = info->consumed;
+        }
+    #ifdef WOLFSSL_SMALL_STACK
+        if (ret != 0) {
+             /* Info no longer needed as loading failed. */
+             XFREE(info, heap, DYNAMIC_TYPE_ENCRYPTEDINFO);
+        }
+    #endif
+    }
+
+    if ((ret == 0) && IS_PRIVKEY_TYPE(type)) {
+        /* Process the private key. */
+        ret = ProcessBufferPrivateKey(ctx, ssl, der, format, info, heap, type,
+            algId);
+    #ifdef WOLFSSL_SMALL_STACK
+        /* Info no longer needed - keep max memory usage down. */
+        XFREE(info, heap, DYNAMIC_TYPE_ENCRYPTEDINFO);
+    #endif
+    }
+    else if (ret == 0) {
+        /* Processing a cerificate. */
+        if (userChain) {
+            /* Take original buffer and add to user chain to send in TLS
+             * handshake. */
+            ret = ProcessUserChain(ctx, ssl, buff, sz, format, type, used, info,
+                verify);
+            /* Additional chain is optional */
+            if (ret == WC_NO_ERR_TRACE(ASN_NO_PEM_HEADER)) {
+                unsigned long pemErr = 0;
+                CLEAR_ASN_NO_PEM_HEADER_ERROR(pemErr);
+                ret = 0;
+            }
+        }
+
+    #ifdef WOLFSSL_SMALL_STACK
+        /* Info no longer needed - keep max memory usage down. */
+        XFREE(info, heap, DYNAMIC_TYPE_ENCRYPTEDINFO);
+    #endif
+
+        if (ret == 0) {
+            /* Process the different types of certificates. */
+            ret = ProcessBufferCertTypes(ctx, ssl, buff, sz, der, format, type,
+                verify);
+        }
+        else {
+            FreeDer(&der);
+        }
+    }
+
+    /* Reset suites if this is a private key or user certificate. */
+    if ((ret == 0) && ((type == PRIVATEKEY_TYPE) || (type == CERT_TYPE))) {
+        ret = ProcessBufferResetSuites(ctx, ssl, type);
+    }
+
+    /* Convert return code. */
+    if (ret == 0) {
+        ret = 1;
+    }
+    else if (ret == WOLFSSL_FATAL_ERROR) {
+        ret = 0;
+    }
+    WOLFSSL_LEAVE("ProcessBuffer", ret);
+    return ret;
+}
+
+#if defined(WOLFSSL_WPAS) && defined(HAVE_CRL)
+/* Try to parse data as a PEM CRL.
+ *
+ * @param [in]  ctx       SSL context object.
+ * @param [in]  buff      Buffer containing potential CRL in PEM format.
+ * @param [in]  sz        Amount of data in buffer remaining.
+ * @param [out] consumed  Number of bytes in buffer was the CRL.
+ * @return  0 on success.
+ */
+static int ProcessChainBufferCRL(WOLFSSL_CTX* ctx, const unsigned char* buff,
+    long sz, long* consumed)
+{
+    int           ret;
+    DerBuffer*    der = NULL;
+    EncryptedInfo info;
+
+    WOLFSSL_MSG("Trying a CRL");
+    ret = PemToDer(buff, sz, CRL_TYPE, &der, NULL, &info, NULL);
+    if (ret == 0) {
+        WOLFSSL_MSG("   Processed a CRL");
+        wolfSSL_CertManagerLoadCRLBuffer(ctx->cm, der->buffer, der->length,
+            WOLFSSL_FILETYPE_ASN1);
+        FreeDer(&der);
+        *consumed = info.consumed;
+    }
+
+    return ret;
+}
+#endif
+
+/* Process all chain certificates (and CRLs) in the PEM data.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      buff    Buffer containing PEM data.
+ * @param [in]      sz      Size of data in buffer.
+ * @param [in]      type    Type of data.
+ * @param [in]      verify  How to verify certificate.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+static int ProcessChainBuffer(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    const unsigned char* buff, long sz, int type, int verify)
+{
+    int  ret    = 0;
+    long used   = 0;
+    int  gotOne = 0;
+
+    WOLFSSL_MSG("Processing CA PEM file");
+    /* Keep processing file while no errors and data to parse. */
+    while ((ret >= 0) && (used < sz)) {
+        long consumed = 0;
+
+        /* Process the buffer. */
+        ret = ProcessBuffer(ctx, buff + used, sz - used, WOLFSSL_FILETYPE_PEM,
+            type, ssl, &consumed, 0, verify);
+        /* Memory allocation failure is fatal. */
+        if (ret == WC_NO_ERR_TRACE(MEMORY_E)) {
+            gotOne = 0;
+        }
+        /* Other error parsing. */
+        else if (ret < 0) {
+#if defined(WOLFSSL_WPAS) && defined(HAVE_CRL)
+            /* Try parsing a CRL. */
+            if (ProcessChainBufferCRL(ctx, buff + used, sz - used,
+                    &consumed) == 0) {
+                ret = 0;
+            }
+            else
+#endif
+            /* Check whether we made progress. */
+            if (consumed > 0) {
+                WOLFSSL_ERROR(ret);
+                WOLFSSL_MSG("CA Parse failed, with progress in file.");
+                WOLFSSL_MSG("Search for other certs in file");
+                /* Check if we have more data to parse to recover. */
+                if (used + consumed < sz) {
+                    ret = 0;
+                }
+            }
+            else {
+                /* No progress in parsing being made - stop here. */
+                WOLFSSL_MSG("CA Parse failed, no progress in file.");
+                WOLFSSL_MSG("Do not continue search for other certs in file");
+            }
+        }
+        else {
+            /* Got a certificate out. */
+            WOLFSSL_MSG("   Processed a CA");
+            gotOne = 1;
+        }
+        /* Update used count. */
+        used += consumed;
+    }
+
+    /* May have other unparsable data but did we get a certificate? */
+    if (gotOne) {
+        WOLFSSL_MSG("Processed at least one valid CA. Other stuff OK");
+        ret = 1;
+    }
+    return ret;
+}
+
+
+/* Get verify settings for AddCA from SSL context. */
+#define GET_VERIFY_SETTING_CTX(ctx) \
+    ((ctx) && (ctx)->verifyNone ? NO_VERIFY : VERIFY)
+/* Get verify settings for AddCA from SSL. */
+#define GET_VERIFY_SETTING_SSL(ssl) \
+    ((ssl)->options.verifyNone ? NO_VERIFY : VERIFY)
+
+#ifndef NO_FILESYSTEM
+
+/* Process data from a file as private keys, CRL or certificates.
+ *
+ * @param [in, out] ctx        SSL context object.
+ * @param [in]      fname      Name of file to read.
+ * @param [in]      format     Format of data:
+ *                               WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @param [in]      type       Type of data:
+ *                               CERT_TYPE, CA_TYPE, TRUSTED_PEER_TYPE,
+ *                               PRIVATEKEY_TYPE or ALT_PRIVATEKEY_TYPE.
+ * @param [in, out] ssl        SSL object.
+ * @param [in]      userChain  Whether file contains chain of certificates.
+ * @param [in, out] crl        CRL object to load data into.
+ * @param [in]      verify     How to verify certificates.
+ * @return  1 on success.
+ * @return  WOLFSSL_BAD_FILE when reading the file fails.
+ * @return  WOLFSSL_BAD_CERTTYPE when unable to detect certificate type.
+ */
+int ProcessFile(WOLFSSL_CTX* ctx, const char* fname, int format, int type,
+    WOLFSSL* ssl, int userChain, WOLFSSL_CRL* crl, int verify)
+{
+    int    ret = 0;
+#ifndef WOLFSSL_SMALL_STACK
+    byte   stackBuffer[FILE_BUFFER_SIZE];
+#endif
+    StaticBuffer content;
+    long   sz = 0;
+    void*  heap = WOLFSSL_HEAP(ctx, ssl);
+
+    (void)crl;
+    (void)heap;
+
+#ifdef WOLFSSL_SMALL_STACK
+    static_buffer_init(&content);
+#else
+    static_buffer_init(&content, stackBuffer, FILE_BUFFER_SIZE);
+#endif
+
+    /* Read file into static buffer. */
+    ret = wolfssl_read_file_static(fname, &content, heap, DYNAMIC_TYPE_FILE,
+        &sz);
+    if ((ret == 0) && (type == DETECT_CERT_TYPE) &&
+            (format != WOLFSSL_FILETYPE_PEM)) {
+        WOLFSSL_MSG("Cannot detect certificate type when not PEM");
+        ret = WOLFSSL_BAD_CERTTYPE;
+    }
+    /* Try to detect type by parsing cert header and footer. */
+    if ((ret == 0) && (type == DETECT_CERT_TYPE)) {
+#if !defined(NO_CODING) && !defined(WOLFSSL_NO_PEM)
+        const char* header = NULL;
+        const char* footer = NULL;
+
+        /* Look for CA header and footer - same as CERT_TYPE. */
+        if (wc_PemGetHeaderFooter(CA_TYPE, &header, &footer) == 0 &&
+                (XSTRNSTR((char*)content.buffer, header, (word32)sz) != NULL)) {
+            type = CA_TYPE;
+        }
+#ifdef HAVE_CRL
+        /* Look for CRL header and footer. */
+        else if (wc_PemGetHeaderFooter(CRL_TYPE, &header, &footer) == 0 &&
+                (XSTRNSTR((char*)content.buffer, header, (word32)sz) != NULL)) {
+            type = CRL_TYPE;
+        }
+#endif
+        /* Look for cert header and footer - same as CA_TYPE. */
+        else if (wc_PemGetHeaderFooter(CERT_TYPE, &header, &footer) == 0 &&
+                (XSTRNSTR((char*)content.buffer, header, (word32)sz) !=
+                    NULL)) {
+            type = CERT_TYPE;
+        }
+        else
+#endif
+        {
+            /* Not a header that we support. */
+            WOLFSSL_MSG("Failed to detect certificate type");
+            ret = WOLFSSL_BAD_CERTTYPE;
+        }
+    }
+    if (ret == 0) {
+        /* When CA or trusted peer and PEM - process as a chain buffer. */
+        if (((type == CA_TYPE) || (type == TRUSTED_PEER_TYPE)) &&
+                (format == WOLFSSL_FILETYPE_PEM)) {
+            ret = ProcessChainBuffer(ctx, ssl, content.buffer, sz, type,
+                verify);
+        }
+#ifdef HAVE_CRL
+        else if (type == CRL_TYPE) {
+            /* Load the CRL. */
+            ret = BufferLoadCRL(crl, content.buffer, sz, format, verify);
+        }
+#endif
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+        else if (type == PRIVATEKEY_TYPE) {
+            /* When support for dual algorithm certificates is enabled, the
+             * private key file may contain both the primary and the
+             * alternative private key. Hence, we have to parse both of them.
+             */
+            long consumed = 0;
+
+            ret = ProcessBuffer(ctx, content.buffer, sz, format, type, ssl,
+                &consumed, userChain, verify);
+            if ((ret == 1) && (consumed < sz)) {
+                ret = ProcessBuffer(ctx, content.buffer + consumed,
+                    sz - consumed, format, ALT_PRIVATEKEY_TYPE, ssl, NULL, 0,
+                    verify);
+            }
+        }
+#endif
+        else {
+            /* Load all other certificate types. */
+            ret = ProcessBuffer(ctx, content.buffer, sz, format, type, ssl,
+                NULL, userChain, verify);
+        }
+    }
+
+    /* Dispose of dynamically allocated data. */
+    static_buffer_free(&content, heap, DYNAMIC_TYPE_FILE);
+    return ret;
+}
+
+#ifndef NO_WOLFSSL_DIR
+/* Load file when filename is in the path.
+ *
+ * @param [in, out] ctx           SSL context object.
+ * @param [in]      name          Name of file.
+ * @param [in]      verify        How to verify a certificate.
+ * @param [in]      flags         Flags representing options for loading.
+ * @param [in, out] failCount     Number of files that failed to load.
+ * @param [in, out] successCount  Number of files successfully loaded.
+ * @return  1 on success.
+ * @return  Not 1 when loading PEM certificate failed.
+ */
+static int wolfssl_ctx_load_path_file(WOLFSSL_CTX* ctx, const char* name,
+    int verify, int flags, int* failCount, int* successCount)
+{
+    int ret;
+
+    /* Attempt to load file as a CA. */
+    ret = ProcessFile(ctx, name, WOLFSSL_FILETYPE_PEM, CA_TYPE, NULL, 0, NULL,
+        verify);
+    if (ret != 1) {
+        /* When ignoring errors or loading PEM only and no PEM. don't fail. */
+        if ((flags & WOLFSSL_LOAD_FLAG_IGNORE_ERR) ||
+                ((flags & WOLFSSL_LOAD_FLAG_PEM_CA_ONLY) &&
+                 (ret == WC_NO_ERR_TRACE(ASN_NO_PEM_HEADER)))) {
+            unsigned long err = 0;
+            CLEAR_ASN_NO_PEM_HEADER_ERROR(err);
+        #if defined(WOLFSSL_QT)
+            ret = 1;
+        #endif
+        }
+        else {
+            WOLFSSL_ERROR(ret);
+            WOLFSSL_MSG("Load CA file failed, continuing");
+            /* Add to fail count. */
+            (*failCount)++;
+        }
+    }
+    else {
+    #if defined(WOLFSSL_TRUST_PEER_CERT) && defined(OPENSSL_COMPATIBLE_DEFAULTS)
+        /* Try loading as a trusted peer certificate. */
+        ret = wolfSSL_CTX_trust_peer_cert(ctx, name, WOLFSSL_FILETYPE_PEM);
+        if (ret != 1) {
+            WOLFSSL_MSG("wolfSSL_CTX_trust_peer_cert error. "
+                        "Ignoring this error.");
+        }
+    #endif
+        /* Add to success count. */
+        (*successCount)++;
+    }
+
+    return ret;
+}
+
+/* Load PEM formatted CA files from a path.
+ *
+ * @param [in, out] ctx           SSL context object.
+ * @param [in]      path          Path to directory to read.
+ * @param [in]      flags         Flags representing options for loading.
+ * @param [in]      verify        How to verify a certificate.
+ * @param [in]      successCount  Number of files successfully loaded.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+static int wolfssl_ctx_load_path(WOLFSSL_CTX* ctx, const char* path,
+    word32 flags, int verify, int successCount)
+{
+    int ret = 1;
+    char* name = NULL;
+    int fileRet;
+    int failCount = 0;
+#ifdef WOLFSSL_SMALL_STACK
+    ReadDirCtx* readCtx;
+#else
+    ReadDirCtx readCtx[1];
+#endif
+
+#ifdef WOLFSSL_SMALL_STACK
+    /* Allocate memory for directory reading context. */
+    readCtx = (ReadDirCtx*)XMALLOC(sizeof(ReadDirCtx), ctx->heap,
+        DYNAMIC_TYPE_DIRCTX);
+    if (readCtx == NULL) {
+        ret = MEMORY_E;
+    }
+#endif
+
+    if (ret == 1) {
+        /* Get name of first file in path. */
+        fileRet = wc_ReadDirFirst(readCtx, path, &name);
+        /* While getting filename doesn't fail and name returned, process file.
+         */
+        while ((fileRet == 0) && (name != NULL)) {
+            WOLFSSL_MSG(name);
+            /* Load file. */
+            ret = wolfssl_ctx_load_path_file(ctx, name, verify, (int)flags,
+                &failCount, &successCount);
+            /* Get next filenmae. */
+            fileRet = wc_ReadDirNext(readCtx, path, &name);
+        }
+        /* Cleanup directory reading context. */
+        wc_ReadDirClose(readCtx);
+
+        /* When not WOLFSSL_QT, ret is always overwritten. */
+        (void)ret;
+
+        /* Return real directory read failure error codes. */
+        if (fileRet != WC_READDIR_NOFILE) {
+            ret = fileRet;
+        #if defined(WOLFSSL_QT) || defined(WOLFSSL_IGNORE_BAD_CERT_PATH)
+            /* Ignore bad path error when flag set. */
+            if ((ret == WC_NO_ERR_TRACE(BAD_PATH_ERROR)) &&
+                    (flags & WOLFSSL_LOAD_FLAG_IGNORE_BAD_PATH_ERR)) {
+               /* QSslSocket always loads certs in system folder
+                * when it is initialized.
+                * Compliant with OpenSSL when flag set.
+                */
+                ret = 1;
+            }
+            else {
+                /* qssl socket wants to know errors. */
+                WOLFSSL_ERROR(ret);
+            }
+        #endif
+        }
+        /* Report failure if no files successfully loaded or there were
+         * failures. */
+        else if ((successCount == 0) || (failCount > 0)) {
+            /* Use existing error code if exists. */
+        #if defined(WOLFSSL_QT)
+            /* Compliant with OpenSSL when flag set. */
+            if (!(flags & WOLFSSL_LOAD_FLAG_IGNORE_ZEROFILE))
+        #endif
+            {
+                /* Return 0 when no files loaded. */
+                ret = 0;
+            }
+        }
+        else {
+            /* We loaded something so it is a success. */
+            ret = 1;
+        }
+
+    #ifdef WOLFSSL_SMALL_STACK
+        /* Dispose of dynamically allocated memory. */
+        XFREE(readCtx, ctx->heap, DYNAMIC_TYPE_DIRCTX);
+    #endif
+    }
+
+    return ret;
+}
+#endif
+
+/* Load a file and/or files in path
+ *
+ * No c_rehash.
+ *
+ * @param [in, out] ctx    SSL context object.
+ * @param [in]      file   Name of file to load. May be NULL.
+ * @param [in]      path   Path to directory containing PEM CA files.
+ *                         May be NULL.
+ * @param [in]      flags  Flags representing options for loading.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  NOT_COMPILED_IN when directory reading not supported and path is
+ *          not NULL.
+ * @return  Other negative on error.
+ */
+int wolfSSL_CTX_load_verify_locations_ex(WOLFSSL_CTX* ctx, const char* file,
+    const char* path, word32 flags)
+{
+    int ret = 1;
+#ifndef NO_WOLFSSL_DIR
+    int successCount = 0;
+#endif
+    int verify = WOLFSSL_VERIFY_DEFAULT;
+
+    WOLFSSL_MSG("wolfSSL_CTX_load_verify_locations_ex");
+
+    /* Validate parameters. */
+    if ((ctx == NULL) || ((file == NULL) && (path == NULL))) {
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        /* Get setting on how to verify certificates. */
+        verify = GET_VERIFY_SETTING_CTX(ctx);
+        /* Overwrite setting when flag set. */
+        if (flags & WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY) {
+            verify = VERIFY_SKIP_DATE;
+        }
+
+        if (file != NULL) {
+            /* Load the PEM formatted CA file. */
+            ret = ProcessFile(ctx, file, WOLFSSL_FILETYPE_PEM, CA_TYPE, NULL, 0,
+                NULL, verify);
+    #ifndef NO_WOLFSSL_DIR
+            if (ret == 1) {
+                /* Include success in overall count. */
+                successCount++;
+            }
+    #endif
+    #if defined(WOLFSSL_TRUST_PEER_CERT) && defined(OPENSSL_COMPATIBLE_DEFAULTS)
+            /* Load CA as a trusted peer certificate. */
+            ret = wolfSSL_CTX_trust_peer_cert(ctx, file, WOLFSSL_FILETYPE_PEM);
+            if (ret != 1) {
+                WOLFSSL_MSG("wolfSSL_CTX_trust_peer_cert error");
+            }
+    #endif
+        }
+    }
+
+    if ((ret == 1) && (path != NULL)) {
+#ifndef NO_WOLFSSL_DIR
+        /* Load CA files form path. */
+        ret = wolfssl_ctx_load_path(ctx, path, flags, verify, successCount);
+#else
+        /* Loading a path not supported. */
+        ret = NOT_COMPILED_IN;
+        (void)flags;
+#endif
+    }
+
+    return ret;
+}
+
+/* Load a file and/or files in path
+ *
+ * No c_rehash.
+ *
+ * @param [in, out] ctx    SSL context object.
+ * @param [in]      file   Name of file to load. May be NULL.
+ * @param [in]      path   Path to directory containing PEM CA files.
+ *                         May be NULL.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+WOLFSSL_ABI
+int wolfSSL_CTX_load_verify_locations(WOLFSSL_CTX* ctx, const char* file,
+                                     const char* path)
+{
+    /* Load using default flags/options. */
+    int ret = wolfSSL_CTX_load_verify_locations_ex(ctx, file, path,
+        WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS);
+
+    /* Return 1 on success or 0 on failure. */
+    return WS_RETURN_CODE(ret, 0);
+}
+
+#ifdef WOLFSSL_SYS_CA_CERTS
+
+#ifdef USE_WINDOWS_API
+
+/* Load CA certificate from Windows store.
+ *
+ * Assumes loaded is 0.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [out]     loaded  Whether CA certificates were loaded.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+static int LoadSystemCaCertsWindows(WOLFSSL_CTX* ctx, byte* loaded)
+{
+    int ret = 1;
+    word32 i;
+    HANDLE handle = NULL;
+    PCCERT_CONTEXT certCtx = NULL;
+    LPCSTR storeNames[2] = {"ROOT", "CA"};
+    HCRYPTPROV_LEGACY hProv = (HCRYPTPROV_LEGACY)NULL;
+
+    if ((ctx == NULL) || (loaded == NULL)) {
+        ret = 0;
+    }
+
+    for (i = 0; (ret == 1) && (i < sizeof(storeNames)/sizeof(*storeNames));
+         ++i) {
+        handle = CertOpenSystemStoreA(hProv, storeNames[i]);
+        if (handle != NULL) {
+            while ((certCtx = CertEnumCertificatesInStore(handle, certCtx))
+                   != NULL) {
+                if (certCtx->dwCertEncodingType == X509_ASN_ENCODING) {
+                    if (ProcessBuffer(ctx, certCtx->pbCertEncoded,
+                          certCtx->cbCertEncoded, WOLFSSL_FILETYPE_ASN1,
+                          CA_TYPE, NULL, NULL, 0,
+                          GET_VERIFY_SETTING_CTX(ctx)) == 1) {
+                        /*
+                         * Set "loaded" as long as we've loaded one CA
+                         * cert.
+                         */
+                        *loaded = 1;
+                    }
+                }
+            }
+        }
+        else {
+            WOLFSSL_MSG_EX("Failed to open cert store %s.", storeNames[i]);
+        }
+
+        if (handle != NULL && !CertCloseStore(handle, 0)) {
+            WOLFSSL_MSG_EX("Failed to close cert store %s.", storeNames[i]);
+            ret = 0;
+        }
+    }
+
+    return ret;
+}
+
+#elif defined(__APPLE__)
+
+#if defined(HAVE_SECURITY_SECTRUSTSETTINGS_H) \
+  && !defined(WOLFSSL_APPLE_NATIVE_CERT_VALIDATION)
+/* Manually obtains certificates from the system trust store and loads them
+ * directly into wolfSSL "the old way".
+ *
+ * As of MacOS 14.0 we are still able to use this method to access system
+ * certificates. Accessibility of this API is indicated by the presence of the
+ * Security/SecTrustSettings.h header. In the likely event that Apple removes
+ * access to this API on Macs, this function should be removed and the
+ * DoAppleNativeCertValidation() routine should be used for all devices.
+ *
+ * Assumes loaded is 0.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [out]     loaded  Whether CA certificates were loaded.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+static int LoadSystemCaCertsMac(WOLFSSL_CTX* ctx, byte* loaded)
+{
+    int ret = 1;
+    word32 i;
+    const unsigned int trustDomains[] = {
+        kSecTrustSettingsDomainUser,
+        kSecTrustSettingsDomainAdmin,
+        kSecTrustSettingsDomainSystem
+    };
+    CFArrayRef certs;
+    OSStatus stat;
+    CFIndex numCerts;
+    CFDataRef der;
+    CFIndex j;
+
+    if ((ctx == NULL) || (loaded == NULL)) {
+        ret = 0;
+    }
+
+    for (i = 0; (ret == 1) && (i < sizeof(trustDomains)/sizeof(*trustDomains));
+         ++i) {
+        stat = SecTrustSettingsCopyCertificates(
+            (SecTrustSettingsDomain)trustDomains[i], &certs);
+        if (stat == errSecSuccess) {
+            numCerts = CFArrayGetCount(certs);
+            for (j = 0; j < numCerts; ++j) {
+                der = SecCertificateCopyData((SecCertificateRef)
+                          CFArrayGetValueAtIndex(certs, j));
+                if (der != NULL) {
+                    if (ProcessBuffer(ctx, CFDataGetBytePtr(der),
+                          CFDataGetLength(der), WOLFSSL_FILETYPE_ASN1,
+                          CA_TYPE, NULL, NULL, 0,
+                          GET_VERIFY_SETTING_CTX(ctx)) == 1) {
+                        /*
+                         * Set "loaded" as long as we've loaded one CA
+                         * cert.
+                         */
+                        *loaded = 1;
+                    }
+
+                    CFRelease(der);
+                }
+            }
+
+            CFRelease(certs);
+        }
+        else if (stat == errSecNoTrustSettings) {
+            WOLFSSL_MSG_EX("No trust settings for domain %d, moving to next "
+                "domain.", trustDomains[i]);
+        }
+        else {
+            WOLFSSL_MSG_EX("SecTrustSettingsCopyCertificates failed with"
+                " status %d.", stat);
+            ret = 0;
+            break;
+        }
+    }
+
+    return ret;
+}
+#endif /* defined(HAVE_SECURITY_SECTRUSTSETTINGS_H) */
+
+#else
+
+/* Potential system CA certs directories on Linux/Unix distros. */
+static const char* systemCaDirs[] = {
+#if defined(__ANDROID__) || defined(ANDROID)
+    "/system/etc/security/cacerts"      /* Android */
+#else
+    "/etc/ssl/certs",                   /* Debian, Ubuntu, Gentoo, others */
+    "/etc/pki/ca-trust/source/anchors", /* Fedora, RHEL */
+    "/etc/pki/tls/certs"                /* Older RHEL */
+#endif
+};
+
+/* Get CA directory list.
+ *
+ * @param [out] num  Number of CA directories.
+ * @return  CA directory list.
+ * @return  NULL when num is NULL.
+ */
+const char** wolfSSL_get_system_CA_dirs(word32* num)
+{
+    const char** ret;
+
+    /* Validate parameters. */
+    if (num == NULL) {
+        ret = NULL;
+    }
+    else {
+        ret = systemCaDirs;
+        *num = sizeof(systemCaDirs)/sizeof(*systemCaDirs);
+    }
+
+    return ret;
+}
+
+/* Load CA certificate from default system directories.
+ *
+ * Assumes loaded is 0.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [out]     loaded  Whether CA certificates were loaded.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+static int LoadSystemCaCertsNix(WOLFSSL_CTX* ctx, byte* loaded) {
+    int ret = 1;
+    word32 i;
+
+    if ((ctx == NULL) || (loaded == NULL)) {
+        ret = 0;
+    }
+
+    for (i = 0; (ret == 1) && (i < sizeof(systemCaDirs)/sizeof(*systemCaDirs));
+         ++i) {
+        WOLFSSL_MSG_EX("Attempting to load system CA certs from %s.",
+            systemCaDirs[i]);
+        /*
+         * We want to keep trying to load more CA certs even if one cert in
+         * the directory is bad and can't be used (e.g. if one is expired),
+         * so we use WOLFSSL_LOAD_FLAG_IGNORE_ERR.
+         */
+        if (wolfSSL_CTX_load_verify_locations_ex(ctx, NULL, systemCaDirs[i],
+                WOLFSSL_LOAD_FLAG_IGNORE_ERR) != 1) {
+            WOLFSSL_MSG_EX("Failed to load CA certs from %s, trying "
+                "next possible location.", systemCaDirs[i]);
+        }
+        else {
+            WOLFSSL_MSG_EX("Loaded CA certs from %s.",
+                systemCaDirs[i]);
+            *loaded = 1;
+            /* Stop searching after we've loaded one directory. */
+            break;
+        }
+    }
+
+    return ret;
+}
+
+#endif
+
+/* Load CA certificates from system defined locations.
+ *
+ * @param [in, out] ctx  SSL context object.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  WOLFSSL_BAD_PATH when no error but no certificates loaded.
+ */
+int wolfSSL_CTX_load_system_CA_certs(WOLFSSL_CTX* ctx)
+{
+    int ret;
+    byte loaded = 0;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_load_system_CA_certs");
+
+#ifdef USE_WINDOWS_API
+
+    ret = LoadSystemCaCertsWindows(ctx, &loaded);
+
+#elif defined(__APPLE__)
+
+#if defined(HAVE_SECURITY_SECTRUSTSETTINGS_H) \
+  && !defined(WOLFSSL_APPLE_NATIVE_CERT_VALIDATION)
+    /* As of MacOS 14.0 we are still able to access system certificates and
+     * load them manually into wolfSSL "the old way". Accessibility of this API
+     * is indicated by the presence of the Security/SecTrustSettings.h header */
+    ret = LoadSystemCaCertsMac(ctx, &loaded);
+#elif defined(WOLFSSL_APPLE_NATIVE_CERT_VALIDATION)
+    /* For other Apple devices, Apple has removed the ability to obtain
+     * certificates from the trust store, so we can't use wolfSSL's built-in
+     * certificate validation mechanisms anymore. We instead must call into the
+     * Security Framework APIs to authenticate peer certificates when received.
+     * (see src/internal.c:DoAppleNativeCertValidation()).
+     * Thus, there is no CA "loading" required, but to keep behavior consistent
+     * with the current API (not using system CA certs unless this function has
+     * been called), we simply set a flag indicating that the new apple trust
+     * verification routine should be used later */
+    ctx->doAppleNativeCertValidationFlag = 1;
+    ret = 1;
+    loaded = 1;
+
+#if FIPS_VERSION_GE(2,0) /* Gate back to cert 3389 FIPS modules */
+#warning "Cryptographic operations may occur outside the FIPS module boundary" \
+         "Please review FIPS claims for cryptography on this Apple device"
+#endif /* FIPS_VERSION_GE(2,0) */
+
+#else
+/* HAVE_SECURITY_SECXXX_H macros are set by autotools or CMake when searching
+ * system for the required SDK headers. If building with user_settings.h, you
+ * will need to manually define WOLFSSL_APPLE_NATIVE_CERT_VALIDATION
+ * and ensure the appropriate Security.framework headers and libraries are
+ * visible to your compiler */
+#error "WOLFSSL_SYS_CA_CERTS on Apple devices requires Security.framework" \
+       " header files to be detected, or a manual override with" \
+       " WOLFSSL_APPLE_NATIVE_CERT_VALIDATION"
+#endif
+
+#else
+
+    ret = LoadSystemCaCertsNix(ctx, &loaded);
+
+#endif
+
+    /* If we didn't fail but didn't load then we error out. */
+    if ((ret == 1) && (!loaded)) {
+        ret = WOLFSSL_BAD_PATH;
+    }
+
+    WOLFSSL_LEAVE("wolfSSL_CTX_load_system_CA_certs", ret);
+
+    return ret;
+}
+
+#endif /* WOLFSSL_SYS_CA_CERTS */
+
+#ifdef WOLFSSL_TRUST_PEER_CERT
+/* Load a trusted peer certificate into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      file    Name of peer certificate file.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 when ctx or file is NULL.
+ */
+int wolfSSL_CTX_trust_peer_cert(WOLFSSL_CTX* ctx, const char* file, int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_trust_peer_cert");
+
+    /* Validate parameters. */
+    if ((ctx == NULL) || (file == NULL)) {
+        ret = 0;
+    }
+    else {
+        ret = ProcessFile(ctx, file, format, TRUSTED_PEER_TYPE, NULL, 0, NULL,
+            GET_VERIFY_SETTING_CTX(ctx));
+    }
+
+    return ret;
+}
+
+/* Load a trusted peer certificate into SSL.
+ *
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      file    Name of peer certificate file.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 when ssl or file is NULL.
+ */
+int wolfSSL_trust_peer_cert(WOLFSSL* ssl, const char* file, int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_trust_peer_cert");
+
+    /* Validate parameters. */
+    if ((ssl == NULL) || (file == NULL)) {
+        ret = 0;
+    }
+    else {
+        ret = ProcessFile(NULL, file, format, TRUSTED_PEER_TYPE, ssl, 0, NULL,
+            GET_VERIFY_SETTING_SSL(ssl));
+    }
+
+    return ret;
+}
+#endif /* WOLFSSL_TRUST_PEER_CERT */
+
+
+#ifdef WOLFSSL_DER_LOAD
+
+/* Load a CA certificate into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      file    Name of peer certificate file.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_CTX_der_load_verify_locations(WOLFSSL_CTX* ctx, const char* file,
+    int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_der_load_verify_locations");
+
+    /* Validate parameters. */
+    if ((ctx == NULL) || (file == NULL)) {
+        ret = 0;
+    }
+    else {
+        ret = ProcessFile(ctx, file, format, CA_TYPE, NULL, 0, NULL,
+            GET_VERIFY_SETTING_CTX(ctx));
+    }
+
+    /* Return 1 on success or 0 on failure. */
+    return WS_RC(ret);
+}
+
+#endif /* WOLFSSL_DER_LOAD */
+
+
+/* Load a user certificate into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      file    Name of user certificate file.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+WOLFSSL_ABI
+int wolfSSL_CTX_use_certificate_file(WOLFSSL_CTX* ctx, const char* file,
+    int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_file");
+
+    ret = ProcessFile(ctx, file, format, CERT_TYPE, NULL, 0, NULL,
+        GET_VERIFY_SETTING_CTX(ctx));
+
+    /* Return 1 on success or 0 on failure. */
+    return WS_RC(ret);
+}
+
+
+/* Load a private key into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      file    Name of private key file.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+WOLFSSL_ABI
+int wolfSSL_CTX_use_PrivateKey_file(WOLFSSL_CTX* ctx, const char* file,
+    int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_use_PrivateKey_file");
+
+    ret = ProcessFile(ctx, file, format, PRIVATEKEY_TYPE, NULL, 0, NULL,
+        GET_VERIFY_SETTING_CTX(ctx));
+
+    /* Return 1 on success or 0 on failure. */
+    return WS_RC(ret);
+}
+
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+/* Load an alternative private key into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      file    Name of private key file.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_CTX_use_AltPrivateKey_file(WOLFSSL_CTX* ctx, const char* file,
+    int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_use_AltPrivateKey_file");
+
+    ret = ProcessFile(ctx, file, format, ALT_PRIVATEKEY_TYPE, NULL, 0, NULL,
+        GET_VERIFY_SETTING_CTX(ctx));
+
+    /* Return 1 on success or 0 on failure. */
+    return WS_RC(ret);
+}
+#endif /* WOLFSSL_DUAL_ALG_CERTS */
+
+
+/* Load a PEM certificate chain into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      file    Name of PEM certificate chain file.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+WOLFSSL_ABI
+int wolfSSL_CTX_use_certificate_chain_file(WOLFSSL_CTX* ctx, const char* file)
+{
+    int ret;
+
+    /* process up to MAX_CHAIN_DEPTH plus subject cert */
+    WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_chain_file");
+
+    ret = ProcessFile(ctx, file, WOLFSSL_FILETYPE_PEM, CERT_TYPE, NULL, 1, NULL,
+        GET_VERIFY_SETTING_CTX(ctx));
+
+    /* Return 1 on success or 0 on failure. */
+    return WS_RC(ret);
+}
+
+/* Load certificate chain into SSL context.
+ *
+ * Processes up to MAX_CHAIN_DEPTH plus subject cert.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      file    Name of private key file.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_CTX_use_certificate_chain_file_format(WOLFSSL_CTX* ctx,
+     const char* file, int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_chain_file_format");
+
+    ret = ProcessFile(ctx, file, format, CERT_TYPE, NULL, 1, NULL,
+        GET_VERIFY_SETTING_CTX(ctx));
+
+    /* Return 1 on success or 0 on failure. */
+    return WS_RC(ret);
+}
+
+#endif /* NO_FILESYSTEM */
+
+#ifdef OPENSSL_EXTRA
+
+/* Load a private key into SSL.
+ *
+ * @param [in, out] ssl   SSL object.
+ * @param [in]      pkey  EVP private key.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_use_PrivateKey(WOLFSSL* ssl, WOLFSSL_EVP_PKEY* pkey)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_use_PrivateKey");
+
+    /* Validate parameters. */
+    if ((ssl == NULL) || (pkey == NULL)) {
+        ret = 0;
+    }
+    else {
+        /* Get DER encoded key data from EVP private key. */
+        ret = wolfSSL_use_PrivateKey_buffer(ssl, (unsigned char*)pkey->pkey.ptr,
+            pkey->pkey_sz, WOLFSSL_FILETYPE_ASN1);
+    }
+
+    return ret;
+}
+
+/* Load a DER encoded private key in a buffer into SSL.
+ *
+ * @param [in]      pri    Indicates type of private key. Ignored.
+ * @param [in, out] ssl    SSL object.
+ * @param [in]      der    Buffer holding DER encoded private key.
+ * @param [in]      derSz  Size of data in bytes.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_use_PrivateKey_ASN1(int pri, WOLFSSL* ssl, const unsigned char* der,
+    long derSz)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_use_PrivateKey_ASN1");
+
+    (void)pri;
+
+    /* Validate parameters. */
+    if ((ssl == NULL) || (der == NULL)) {
+        ret = 0;
+    }
+    else {
+        ret = wolfSSL_use_PrivateKey_buffer(ssl, der, derSz,
+            WOLFSSL_FILETYPE_ASN1);
+    }
+
+    return ret;
+}
+
+/* Load a DER encoded private key in a buffer into SSL context.
+ *
+ * @param [in]      pri    Indicates type of private key. Ignored.
+ * @param [in, out] ctx    SSL context object.
+ * @param [in]      der    Buffer holding DER encoded private key.
+ * @param [in]      derSz  Size of data in bytes.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_CTX_use_PrivateKey_ASN1(int pri, WOLFSSL_CTX* ctx,
+    unsigned char* der, long derSz)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_use_PrivateKey_ASN1");
+
+    (void)pri;
+
+    /* Validate parameters. */
+    if ((ctx == NULL) || (der == NULL)) {
+        ret = 0;
+    }
+    else {
+        ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx, der, derSz,
+            WOLFSSL_FILETYPE_ASN1);
+    }
+
+    return ret;
+}
+
+
+#ifndef NO_RSA
+/* Load a DER encoded RSA private key in a buffer into SSL.
+ *
+ * @param [in, out] ssl    SSL object.
+ * @param [in]      der    Buffer holding DER encoded RSA private key.
+ * @param [in]      derSz  Size of data in bytes.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_use_RSAPrivateKey_ASN1(WOLFSSL* ssl, unsigned char* der, long derSz)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_use_RSAPrivateKey_ASN1");
+
+    /* Validate parameters. */
+    if ((ssl == NULL) || (der == NULL)) {
+        ret = 0;
+    }
+    else {
+        ret = wolfSSL_use_PrivateKey_buffer(ssl, der, derSz,
+            WOLFSSL_FILETYPE_ASN1);
+    }
+
+    return ret;
+}
+#endif
+
+/* Load a certificate into SSL.
+ *
+ * @param [in, out] ssl   SSL object.
+ * @param [in]      x509  X509 certificate object.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_use_certificate(WOLFSSL* ssl, WOLFSSL_X509* x509)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_use_certificate");
+
+    /* Validate parameters. */
+    if ((ssl == NULL) || (x509 == NULL) || (x509->derCert == NULL)) {
+        ret = 0;
+    }
+    else {
+        long idx = 0;
+
+        /* Get DER encoded certificate data from X509 object. */
+        ret = ProcessBuffer(NULL, x509->derCert->buffer, x509->derCert->length,
+            WOLFSSL_FILETYPE_ASN1, CERT_TYPE, ssl, &idx, 0,
+            GET_VERIFY_SETTING_SSL(ssl));
+    }
+
+    /* Return 1 on success or 0 on failure. */
+    return WS_RC(ret);
+}
+
+#endif /* OPENSSL_EXTRA */
+
+/* Load a DER encoded certificate in a buffer into SSL.
+ *
+ * @param [in, out] ssl    SSL object.
+ * @param [in]      der    Buffer holding DER encoded certificate.
+ * @param [in]      derSz  Size of data in bytes.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_use_certificate_ASN1(WOLFSSL* ssl, const unsigned char* der,
+    int derSz)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_use_certificate_ASN1");
+
+    /* Validate parameters. */
+    if ((ssl == NULL) || (der == NULL)) {
+        ret = 0;
+    }
+    else {
+        long idx = 0;
+
+        ret = ProcessBuffer(NULL, der, derSz, WOLFSSL_FILETYPE_ASN1, CERT_TYPE,
+            ssl, &idx, 0, GET_VERIFY_SETTING_SSL(ssl));
+    }
+
+    /* Return 1 on success or 0 on failure. */
+    return WS_RC(ret);
+}
+
+#ifndef NO_FILESYSTEM
+
+/* Load a certificate from a file into SSL.
+ *
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      file    Name of file.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  BAD_FUNC_ARG when ssl is NULL.
+ */
+WOLFSSL_ABI
+int wolfSSL_use_certificate_file(WOLFSSL* ssl, const char* file, int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_use_certificate_file");
+
+    /* Validate parameters. */
+    if (ssl == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+        ret = ProcessFile(ssl->ctx, file, format, CERT_TYPE, ssl, 0, NULL,
+            GET_VERIFY_SETTING_SSL(ssl));
+        /* Return 1 on success or 0 on failure. */
+        ret = WS_RC(ret);
+    }
+
+    return ret;
+}
+
+
+/* Load a private key from a file into SSL.
+ *
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      file    Name of file.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  BAD_FUNC_ARG when ssl is NULL.
+ */
+WOLFSSL_ABI
+int wolfSSL_use_PrivateKey_file(WOLFSSL* ssl, const char* file, int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_use_PrivateKey_file");
+
+    /* Validate parameters. */
+    if (ssl == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+        ret = ProcessFile(ssl->ctx, file, format, PRIVATEKEY_TYPE, ssl, 0, NULL,
+            GET_VERIFY_SETTING_SSL(ssl));
+        /* Return 1 on success or 0 on failure. */
+        ret = WS_RC(ret);
+    }
+
+    return ret;
+}
+
+
+/* Load a PEM encoded certificate chain from a file into SSL.
+ *
+ * Process up to MAX_CHAIN_DEPTH plus subject cert.
+ *
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      file    Name of file.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  BAD_FUNC_ARG when ssl is NULL.
+ */
+WOLFSSL_ABI
+int wolfSSL_use_certificate_chain_file(WOLFSSL* ssl, const char* file)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_use_certificate_chain_file");
+
+    /* Validate parameters. */
+    if (ssl == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+        ret = ProcessFile(ssl->ctx, file, WOLFSSL_FILETYPE_PEM, CERT_TYPE, ssl,
+            1, NULL, GET_VERIFY_SETTING_SSL(ssl));
+        /* Return 1 on success or 0 on failure. */
+        ret = WS_RC(ret);
+    }
+
+   return ret;
+}
+
+/* Load a certificate chain from a file into SSL.
+ *
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      file    Name of file.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  BAD_FUNC_ARG when ssl is NULL.
+ */
+int wolfSSL_use_certificate_chain_file_format(WOLFSSL* ssl, const char* file,
+    int format)
+{
+    int ret;
+
+    /* process up to MAX_CHAIN_DEPTH plus subject cert */
+    WOLFSSL_ENTER("wolfSSL_use_certificate_chain_file_format");
+
+    /* Validate parameters. */
+    if (ssl == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+        ret = ProcessFile(ssl->ctx, file, format, CERT_TYPE, ssl, 1, NULL,
+            GET_VERIFY_SETTING_SSL(ssl));
+        /* Return 1 on success or 0 on failure. */
+        ret = WS_RC(ret);
+    }
+
+    return ret;
+}
+
+#endif /* !NO_FILESYSTEM */
+
+#ifdef OPENSSL_EXTRA
+
+#ifndef NO_FILESYSTEM
+/* Load an RSA private key from a file into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      file    Name of file.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_CTX_use_RSAPrivateKey_file(WOLFSSL_CTX* ctx,const char* file,
+    int format)
+{
+    WOLFSSL_ENTER("wolfSSL_CTX_use_RSAPrivateKey_file");
+
+    return wolfSSL_CTX_use_PrivateKey_file(ctx, file, format);
+}
+
+/* Load an RSA private key from a file into SSL.
+ *
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      file    Name of file.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  BAD_FUNC_ARG when ssl is NULL.
+ */
+int wolfSSL_use_RSAPrivateKey_file(WOLFSSL* ssl, const char* file, int format)
+{
+    WOLFSSL_ENTER("wolfSSL_use_RSAPrivateKey_file");
+
+    return wolfSSL_use_PrivateKey_file(ssl, file, format);
+}
+#endif /* NO_FILESYSTEM */
+
+#endif /* OPENSSL_EXTRA */
+
+/* Load a buffer of certificate/s into SSL context.
+ *
+ * @param [in, out] ctx        SSL context object.
+ * @param [in]      in         Buffer holding certificate or private key.
+ * @param [in]      sz         Length of data in buffer in bytes.
+ * @param [in]      format     Format of data:
+ *                               WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @param [in]      userChain  Whether file contains chain of certificates.
+ * @param [in]      flags      Flags representing options for loading.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  Negative on error.
+ */
+int wolfSSL_CTX_load_verify_buffer_ex(WOLFSSL_CTX* ctx, const unsigned char* in,
+    long sz, int format, int userChain, word32 flags)
+{
+    int ret;
+    int verify;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_load_verify_buffer_ex");
+
+    /* Get setting on how to verify certificates. */
+    verify = GET_VERIFY_SETTING_CTX(ctx);
+    /* Overwrite setting when flag set. */
+    if (flags & WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY) {
+        verify = VERIFY_SKIP_DATE;
+    }
+
+    /* When PEM, treat as certificate chain of CA certificates. */
+    if (format == WOLFSSL_FILETYPE_PEM) {
+        ret = ProcessChainBuffer(ctx, NULL, in, sz, CA_TYPE, verify);
+    }
+    /* When DER, load the CA certificate. */
+    else {
+        ret = ProcessBuffer(ctx, in, sz, format, CA_TYPE, NULL, NULL,
+            userChain, verify);
+    }
+#if defined(WOLFSSL_TRUST_PEER_CERT) && defined(OPENSSL_COMPATIBLE_DEFAULTS)
+    if (ret == 1) {
+        /* Load certificate/s as trusted peer certificate. */
+        ret = wolfSSL_CTX_trust_peer_buffer(ctx, in, sz, format);
+    }
+#endif
+
+    WOLFSSL_LEAVE("wolfSSL_CTX_load_verify_buffer_ex", ret);
+    return ret;
+}
+
+/* Load a buffer of certificate/s into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      in      Buffer holding certificate or private key.
+ * @param [in]      sz      Length of data in buffer in bytes.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  Negative on error.
+ */
+int wolfSSL_CTX_load_verify_buffer(WOLFSSL_CTX* ctx, const unsigned char* in,
+    long sz, int format)
+{
+    return wolfSSL_CTX_load_verify_buffer_ex(ctx, in, sz, format, 0,
+        WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS);
+}
+
+/* Load a buffer of certificate chain into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      in      Buffer holding certificate chain.
+ * @param [in]      sz      Length of data in buffer in bytes.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  Negative on error.
+ */
+int wolfSSL_CTX_load_verify_chain_buffer_format(WOLFSSL_CTX* ctx,
+    const unsigned char* in, long sz, int format)
+{
+    return wolfSSL_CTX_load_verify_buffer_ex(ctx, in, sz, format, 1,
+        WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS);
+}
+
+
+#ifdef WOLFSSL_TRUST_PEER_CERT
+/* Load a buffer of certificate/s into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      in      Buffer holding certificate/s.
+ * @param [in]      sz      Length of data in buffer in bytes.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  BAD_FUNC_ARG when ctx or in is NULL, or sz is less than zero.
+ */
+int wolfSSL_CTX_trust_peer_buffer(WOLFSSL_CTX* ctx, const unsigned char* in,
+    long sz, int format)
+{
+    int ret;
+    int verify;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_trust_peer_buffer");
+
+    /* Validate parameters. */
+    if ((ctx == NULL) || (in == NULL) || (sz < 0)) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+    #if WOLFSSL_LOAD_VERIFY_DEFAULT_FLAGS & WOLFSSL_LOAD_FLAG_DATE_ERR_OKAY
+        verify = VERIFY_SKIP_DATE;
+    #else
+        verify = GET_VERIFY_SETTING_CTX(ctx);
+    #endif
+
+        /* When PEM, treat as certificate chain of trusted peer certificates. */
+        if (format == WOLFSSL_FILETYPE_PEM) {
+            ret = ProcessChainBuffer(ctx, NULL, in, sz, TRUSTED_PEER_TYPE,
+                verify);
+        }
+        /* When DER, load the trusted peer certificate. */
+        else {
+            ret = ProcessBuffer(ctx, in, sz, format, TRUSTED_PEER_TYPE, NULL,
+                NULL, 0, verify);
+        }
+    }
+
+    return ret;
+}
+#endif /* WOLFSSL_TRUST_PEER_CERT */
+
+/* Load a certificate in a buffer into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      in      Buffer holding certificate.
+ * @param [in]      sz      Size of data in bytes.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  Negative on error.
+ */
+int wolfSSL_CTX_use_certificate_buffer(WOLFSSL_CTX* ctx,
+    const unsigned char* in, long sz, int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_buffer");
+    ret = ProcessBuffer(ctx, in, sz, format, CERT_TYPE, NULL, NULL, 0,
+        GET_VERIFY_SETTING_CTX(ctx));
+    WOLFSSL_LEAVE("wolfSSL_CTX_use_certificate_buffer", ret);
+
+    return ret;
+}
+
+/* Load a private key in a buffer into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      in      Buffer holding private key.
+ * @param [in]      sz      Size of data in bytes.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  Negative on error.
+ */
+int wolfSSL_CTX_use_PrivateKey_buffer(WOLFSSL_CTX* ctx, const unsigned char* in,
+    long sz, int format)
+{
+    int ret;
+    long consumed = 0;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_use_PrivateKey_buffer");
+
+    ret = ProcessBuffer(ctx, in, sz, format, PRIVATEKEY_TYPE, NULL, &consumed,
+        0, GET_VERIFY_SETTING_CTX(ctx));
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+    if ((ret == 1) && (consumed < sz)) {
+        /* When support for dual algorithm certificates is enabled, the
+         * buffer may contain both the primary and the alternative
+         * private key. Hence, we have to parse both of them.
+         */
+        ret = ProcessBuffer(ctx, in + consumed, sz - consumed, format,
+            ALT_PRIVATEKEY_TYPE, NULL, NULL, 0, GET_VERIFY_SETTING_CTX(ctx));
+    }
+#endif
+
+    (void)consumed;
+
+    WOLFSSL_LEAVE("wolfSSL_CTX_use_PrivateKey_buffer", ret);
+    return ret;
+}
+
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+int wolfSSL_CTX_use_AltPrivateKey_buffer(WOLFSSL_CTX* ctx,
+    const unsigned char* in, long sz, int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_use_AltPrivateKey_buffer");
+    ret = ProcessBuffer(ctx, in, sz, format, ALT_PRIVATEKEY_TYPE, NULL,
+        NULL, 0, GET_VERIFY_SETTING_CTX(ctx));
+    WOLFSSL_LEAVE("wolfSSL_CTX_use_AltPrivateKey_buffer", ret);
+
+    return ret;
+}
+#endif /* WOLFSSL_DUAL_ALG_CERTS */
+
+#ifdef WOLF_PRIVATE_KEY_ID
+/* Load the id of a private key into SSL context.
+ *
+ * @param [in, out] ctx    SSL context object.
+ * @param [in]      id     Buffer holding id.
+ * @param [in]      sz     Size of data in bytes.
+ * @param [in]      devId  Device identifier.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_CTX_use_PrivateKey_Id(WOLFSSL_CTX* ctx, const unsigned char* id,
+    long sz, int devId)
+{
+    int ret = 1;
+
+    /* Dispose of old private key and allocate and copy in id. */
+    FreeDer(&ctx->privateKey);
+    if (AllocCopyDer(&ctx->privateKey, id, (word32)sz, PRIVATEKEY_TYPE,
+            ctx->heap) != 0) {
+        ret = 0;
+    }
+    if (ret == 1) {
+        /* Private key is an id. */
+        ctx->privateKeyId = 1;
+        ctx->privateKeyLabel = 0;
+        /* Set private key device id to be one passed in or for SSL context. */
+        if (devId != INVALID_DEVID) {
+            ctx->privateKeyDevId = devId;
+        }
+        else {
+            ctx->privateKeyDevId = ctx->devId;
+        }
+
+    #ifdef WOLFSSL_DUAL_ALG_CERTS
+        /* Set the ID for the alternative key, too. User can still override that
+         * afterwards. */
+        ret = wolfSSL_CTX_use_AltPrivateKey_Id(ctx, id, sz, devId);
+    #endif
+    }
+
+    return ret;
+}
+
+/* Load the id of a private key into SSL context and set key size.
+ *
+ * @param [in, out] ctx    SSL context object.
+ * @param [in]      id     Buffer holding id.
+ * @param [in]      sz     Size of data in bytes.
+ * @param [in]      devId  Device identifier.
+ * @param [in]      keySz  Size of key.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_CTX_use_PrivateKey_id(WOLFSSL_CTX* ctx, const unsigned char* id,
+    long sz, int devId, long keySz)
+{
+    int ret = wolfSSL_CTX_use_PrivateKey_Id(ctx, id, sz, devId);
+    if (ret == 1) {
+        /* Set the key size which normally is calculated during decoding. */
+        ctx->privateKeySz = (int)keySz;
+    }
+
+    return ret;
+}
+
+/* Load the label name of a private key into SSL context.
+ *
+ * @param [in, out] ctx    SSL context object.
+ * @param [in]      label  Buffer holding label.
+ * @param [in]      devId  Device identifier.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_CTX_use_PrivateKey_Label(WOLFSSL_CTX* ctx, const char* label,
+    int devId)
+{
+    int ret = 1;
+    word32 sz = (word32)XSTRLEN(label) + 1;
+
+    /* Dispose of old private key and allocate and copy in label. */
+    FreeDer(&ctx->privateKey);
+    if (AllocCopyDer(&ctx->privateKey, (const byte*)label, (word32)sz,
+            PRIVATEKEY_TYPE, ctx->heap) != 0) {
+        ret = 0;
+    }
+    if (ret == 1) {
+        /* Private key is a label. */
+        ctx->privateKeyId = 0;
+        ctx->privateKeyLabel = 1;
+        /* Set private key device id to be one passed in or for SSL context. */
+        if (devId != INVALID_DEVID) {
+            ctx->privateKeyDevId = devId;
+        }
+        else {
+            ctx->privateKeyDevId = ctx->devId;
+        }
+
+    #ifdef WOLFSSL_DUAL_ALG_CERTS
+        /* Set the ID for the alternative key, too. User can still override that
+         * afterwards. */
+        ret = wolfSSL_CTX_use_AltPrivateKey_Label(ctx, label, devId);
+    #endif
+    }
+
+    return ret;
+}
+
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+int wolfSSL_CTX_use_AltPrivateKey_Id(WOLFSSL_CTX* ctx, const unsigned char* id,
+    long sz, int devId)
+{
+    int ret = 1;
+
+    if ((ctx == NULL) || (id == NULL)) {
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        FreeDer(&ctx->altPrivateKey);
+        if (AllocDer(&ctx->altPrivateKey, (word32)sz, ALT_PRIVATEKEY_TYPE,
+                ctx->heap) != 0) {
+            ret = 0;
+        }
+    }
+    if (ret == 1) {
+        XMEMCPY(ctx->altPrivateKey->buffer, id, sz);
+        ctx->altPrivateKeyId = 1;
+        if (devId != INVALID_DEVID) {
+            ctx->altPrivateKeyDevId = devId;
+        }
+        else {
+            ctx->altPrivateKeyDevId = ctx->devId;
+        }
+    }
+
+    return ret;
+}
+
+int wolfSSL_CTX_use_AltPrivateKey_id(WOLFSSL_CTX* ctx, const unsigned char* id,
+    long sz, int devId, long keySz)
+{
+    int ret = wolfSSL_CTX_use_AltPrivateKey_Id(ctx, id, sz, devId);
+    if (ret == 1) {
+        ctx->altPrivateKeySz = (word32)keySz;
+    }
+
+    return ret;
+}
+
+int wolfSSL_CTX_use_AltPrivateKey_Label(WOLFSSL_CTX* ctx, const char* label,
+    int devId)
+{
+    int ret = 1;
+    word32 sz;
+
+    if ((ctx == NULL) || (label == NULL)) {
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        sz = (word32)XSTRLEN(label) + 1;
+        FreeDer(&ctx->altPrivateKey);
+        if (AllocDer(&ctx->altPrivateKey, (word32)sz, ALT_PRIVATEKEY_TYPE,
+                ctx->heap) != 0) {
+            ret = 0;
+        }
+    }
+    if (ret == 1) {
+        XMEMCPY(ctx->altPrivateKey->buffer, label, sz);
+        ctx->altPrivateKeyLabel = 1;
+        if (devId != INVALID_DEVID) {
+            ctx->altPrivateKeyDevId = devId;
+        }
+        else {
+            ctx->altPrivateKeyDevId = ctx->devId;
+        }
+    }
+
+    return ret;
+}
+#endif /* WOLFSSL_DUAL_ALG_CERTS */
+#endif /* WOLF_PRIVATE_KEY_ID */
+
+/* Load a certificate chain in a buffer into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      in      Buffer holding DER encoded certificate chain.
+ * @param [in]      sz      Size of data in bytes.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  Negative on error.
+ */
+int wolfSSL_CTX_use_certificate_chain_buffer_format(WOLFSSL_CTX* ctx,
+    const unsigned char* in, long sz, int format)
+{
+    WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_chain_buffer_format");
+    return ProcessBuffer(ctx, in, sz, format, CERT_TYPE, NULL, NULL, 1,
+        GET_VERIFY_SETTING_CTX(ctx));
+}
+
+/* Load a PEM encoded certificate chain in a buffer into SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      in      Buffer holding DER encoded certificate chain.
+ * @param [in]      sz      Size of data in bytes.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  Negative on error.
+ */
+int wolfSSL_CTX_use_certificate_chain_buffer(WOLFSSL_CTX* ctx,
+    const unsigned char* in, long sz)
+{
+    return wolfSSL_CTX_use_certificate_chain_buffer_format(ctx, in, sz,
+        WOLFSSL_FILETYPE_PEM);
+}
+
+/* Load a user certificate in a buffer into SSL.
+ *
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      in      Buffer holding user certificate.
+ * @param [in]      sz      Size of data in bytes.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  BAD_FUNC_ARG when ssl is NULL.
+ */
+int wolfSSL_use_certificate_buffer(WOLFSSL* ssl, const unsigned char* in,
+    long sz, int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_use_certificate_buffer");
+
+    /* Validate parameters. */
+    if (ssl == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+        ret = ProcessBuffer(ssl->ctx, in, sz, format, CERT_TYPE, ssl, NULL, 0,
+            GET_VERIFY_SETTING_SSL(ssl));
+    }
+
+    return ret;
+}
+
+/* Load a private key in a buffer into SSL.
+ *
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      in      Buffer holding private key.
+ * @param [in]      sz      Size of data in bytes.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  BAD_FUNC_ARG when ssl is NULL.
+ */
+int wolfSSL_use_PrivateKey_buffer(WOLFSSL* ssl, const unsigned char* in,
+    long sz, int format)
+{
+    int ret;
+    long consumed = 0;
+
+    WOLFSSL_ENTER("wolfSSL_use_PrivateKey_buffer");
+
+    /* Validate parameters. */
+    if (ssl == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+        ret = ProcessBuffer(ssl->ctx, in, sz, format, PRIVATEKEY_TYPE, ssl,
+            &consumed, 0, GET_VERIFY_SETTING_SSL(ssl));
+    #ifdef WOLFSSL_DUAL_ALG_CERTS
+        if ((ret == 1) && (consumed < sz)) {
+            /* When support for dual algorithm certificates is enabled, the
+             * buffer may contain both the primary and the alternative
+             * private key. Hence, we have to parse both of them.
+             */
+            ret = ProcessBuffer(ssl->ctx, in + consumed, sz - consumed, format,
+                ALT_PRIVATEKEY_TYPE, ssl, NULL, 0, GET_VERIFY_SETTING_SSL(ssl));
+        }
+    #endif
+    }
+
+    return ret;
+}
+
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+int wolfSSL_use_AltPrivateKey_buffer(WOLFSSL* ssl, const unsigned char* in,
+    long sz, int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_use_AltPrivateKey_buffer");
+    ret = ProcessBuffer(ssl->ctx, in, sz, format, ALT_PRIVATEKEY_TYPE, ssl,
+        NULL, 0, GET_VERIFY_SETTING_SSL(ssl));
+    WOLFSSL_LEAVE("wolfSSL_use_AltPrivateKey_buffer", ret);
+
+    return ret;
+}
+#endif /* WOLFSSL_DUAL_ALG_CERTS */
+
+#ifdef WOLF_PRIVATE_KEY_ID
+/* Load the id of a private key into SSL.
+ *
+ * @param [in, out] ssl    SSL object.
+ * @param [in]      id     Buffer holding id.
+ * @param [in]      sz     Size of data in bytes.
+ * @param [in]      devId  Device identifier.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_use_PrivateKey_Id(WOLFSSL* ssl, const unsigned char* id,
+                              long sz, int devId)
+{
+    int ret = 1;
+
+    /* Dispose of old private key if owned and allocate and copy in id. */
+    if (ssl->buffers.weOwnKey) {
+        FreeDer(&ssl->buffers.key);
+    #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+        FreeDer(&ssl->buffers.keyMask);
+    #endif
+    }
+    if (AllocCopyDer(&ssl->buffers.key, id, (word32)sz, PRIVATEKEY_TYPE,
+            ssl->heap) != 0) {
+        ret = 0;
+    }
+    if (ret == 1) {
+        /* Buffer now ours. */
+        ssl->buffers.weOwnKey = 1;
+        /* Private key is an id. */
+        ssl->buffers.keyId = 1;
+        ssl->buffers.keyLabel = 0;
+        /* Set private key device id to be one passed in or for SSL. */
+        if (devId != INVALID_DEVID) {
+            ssl->buffers.keyDevId = devId;
+        }
+        else {
+            ssl->buffers.keyDevId = ssl->devId;
+        }
+
+    #ifdef WOLFSSL_DUAL_ALG_CERTS
+        /* Set the ID for the alternative key, too. User can still override that
+         * afterwards. */
+        ret = wolfSSL_use_AltPrivateKey_Id(ssl, id, sz, devId);
+    #endif
+    }
+
+    return ret;
+}
+
+/* Load the id of a private key into SSL and set key size.
+ *
+ * @param [in, out] ssl    SSL object.
+ * @param [in]      id     Buffer holding id.
+ * @param [in]      sz     Size of data in bytes.
+ * @param [in]      devId  Device identifier.
+ * @param [in]      keySz  Size of key.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_use_PrivateKey_id(WOLFSSL* ssl, const unsigned char* id,
+    long sz, int devId, long keySz)
+{
+    int ret = wolfSSL_use_PrivateKey_Id(ssl, id, sz, devId);
+    if (ret == 1) {
+        /* Set the key size which normally is calculated during decoding. */
+        ssl->buffers.keySz = (int)keySz;
+    }
+
+    return ret;
+}
+
+/* Load the label name of a private key into SSL.
+ *
+ * @param [in, out] ssl    SSL object.
+ * @param [in]      label  Buffer holding label.
+ * @param [in]      devId  Device identifier.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_use_PrivateKey_Label(WOLFSSL* ssl, const char* label, int devId)
+{
+    int ret = 1;
+    word32 sz = (word32)XSTRLEN(label) + 1;
+
+    /* Dispose of old private key if owned and allocate and copy in label. */
+    if (ssl->buffers.weOwnKey) {
+        FreeDer(&ssl->buffers.key);
+    #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+        FreeDer(&ssl->buffers.keyMask);
+    #endif
+    }
+    if (AllocCopyDer(&ssl->buffers.key, (const byte*)label, (word32)sz,
+            PRIVATEKEY_TYPE, ssl->heap) != 0) {
+        ret = 0;
+    }
+    if (ret == 1) {
+        /* Buffer now ours. */
+        ssl->buffers.weOwnKey = 1;
+        /* Private key is a label. */
+        ssl->buffers.keyId = 0;
+        ssl->buffers.keyLabel = 1;
+        /* Set private key device id to be one passed in or for SSL. */
+        if (devId != INVALID_DEVID) {
+            ssl->buffers.keyDevId = devId;
+        }
+        else {
+            ssl->buffers.keyDevId = ssl->devId;
+        }
+
+    #ifdef WOLFSSL_DUAL_ALG_CERTS
+        /* Set the label for the alternative key, too. User can still override
+         * that afterwards. */
+        ret = wolfSSL_use_AltPrivateKey_Label(ssl, label, devId);
+    #endif
+    }
+
+    return ret;
+}
+
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+int wolfSSL_use_AltPrivateKey_Id(WOLFSSL* ssl, const unsigned char* id, long sz,
+    int devId)
+{
+    int ret = 1;
+
+    if ((ssl == NULL) || (id == NULL)) {
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        if (ssl->buffers.weOwnAltKey) {
+            FreeDer(&ssl->buffers.altKey);
+        #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+            FreeDer(&ssl->buffers.altKeyMask);
+        #endif
+        }
+        if (AllocDer(&ssl->buffers.altKey, (word32)sz, ALT_PRIVATEKEY_TYPE,
+                ssl->heap) == 0) {
+            ret = 0;
+        }
+    }
+    if (ret == 1) {
+        XMEMCPY(ssl->buffers.altKey->buffer, id, sz);
+        ssl->buffers.weOwnAltKey = 1;
+        ssl->buffers.altKeyId = 1;
+        if (devId != INVALID_DEVID) {
+            ssl->buffers.altKeyDevId = devId;
+        }
+        else {
+            ssl->buffers.altKeyDevId = ssl->devId;
+        }
+    }
+
+    return ret;
+}
+
+int wolfSSL_use_AltPrivateKey_id(WOLFSSL* ssl, const unsigned char* id, long sz,
+    int devId, long keySz)
+{
+    int ret = wolfSSL_use_AltPrivateKey_Id(ssl, id, sz, devId);
+    if (ret == 1) {
+        ssl->buffers.altKeySz = (word32)keySz;
+    }
+
+    return ret;
+}
+
+int wolfSSL_use_AltPrivateKey_Label(WOLFSSL* ssl, const char* label, int devId)
+{
+    int ret = 1;
+    word32 sz;
+
+    if ((ssl == NULL) || (label == NULL)) {
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        sz = (word32)XSTRLEN(label) + 1;
+        if (ssl->buffers.weOwnAltKey) {
+            FreeDer(&ssl->buffers.altKey);
+        #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+            FreeDer(&ssl->buffers.altKeyMask);
+        #endif
+        }
+        if (AllocDer(&ssl->buffers.altKey, (word32)sz, ALT_PRIVATEKEY_TYPE,
+                ssl->heap) == 0) {
+            ret = 0;
+        }
+    }
+    if (ret == 1) {
+        XMEMCPY(ssl->buffers.altKey->buffer, label, sz);
+        ssl->buffers.weOwnAltKey = 1;
+        ssl->buffers.altKeyLabel = 1;
+        if (devId != INVALID_DEVID) {
+            ssl->buffers.altKeyDevId = devId;
+        }
+        else {
+            ssl->buffers.altKeyDevId = ssl->devId;
+        }
+    }
+
+    return ret;
+}
+#endif /* WOLFSSL_DUAL_ALG_CERTS */
+#endif /* WOLF_PRIVATE_KEY_ID */
+
+/* Load a certificate chain in a buffer into SSL.
+ *
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      in      Buffer holding DER encoded certificate chain.
+ * @param [in]      sz      Size of data in bytes.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  BAD_FUNC_ARG when ssl is NULL.
+ */
+int wolfSSL_use_certificate_chain_buffer_format(WOLFSSL* ssl,
+    const unsigned char* in, long sz, int format)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_use_certificate_chain_buffer_format");
+
+    /* Validate parameters. */
+    if (ssl == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+    else {
+        ret = ProcessBuffer(ssl->ctx, in, sz, format, CERT_TYPE, ssl, NULL, 1,
+            GET_VERIFY_SETTING_SSL(ssl));
+    }
+
+    return ret;
+}
+
+/* Load a PEM encoded certificate chain in a buffer into SSL.
+ *
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      in      Buffer holding DER encoded certificate chain.
+ * @param [in]      sz      Size of data in bytes.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  Negative on error.
+ */
+int wolfSSL_use_certificate_chain_buffer(WOLFSSL* ssl, const unsigned char* in,
+    long sz)
+{
+    return wolfSSL_use_certificate_chain_buffer_format(ssl, in, sz,
+        WOLFSSL_FILETYPE_PEM);
+}
+
+#if defined(OPENSSL_EXTRA) || defined(HAVE_LIGHTY) || \
+    defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(HAVE_STUNNEL) || \
+    defined(WOLFSSL_NGINX) || defined(HAVE_POCO_LIB) || \
+    defined(WOLFSSL_HAPROXY)
+/* Add certificate to chain.
+ *
+ * @param [in, out] chain   Buffer holding encoded certificate for TLS.
+ * @param [in]      weOwn   Indicates we need to free chain if repleced.
+ * @param [in]      cert    Buffer holding DER encoded certificate.
+ * @param [in]      certSz  Size of DER encoded certificate in bytes.
+ * @param [in]      heap    Dynamic memory allocation hint.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+static int wolfssl_add_to_chain(DerBuffer** chain, int weOwn, const byte* cert,
+    word32 certSz, void* heap)
+{
+    int res = 1;
+    int ret;
+    DerBuffer* oldChain = *chain;
+    DerBuffer* newChain = NULL;
+    word32 len = 0;
+
+    if (oldChain != NULL) {
+        /* Get length of previous chain. */
+        len = oldChain->length;
+    }
+    /* Allocate DER buffer bug enough to hold old and new certificates. */
+    ret = AllocDer(&newChain, len + CERT_HEADER_SZ + certSz, CERT_TYPE, heap);
+    if (ret != 0) {
+        WOLFSSL_MSG("AllocDer error");
+        res = 0;
+    }
+
+    if (res == 1) {
+        if (oldChain != NULL) {
+            /* Place old chain in new buffer. */
+            XMEMCPY(newChain->buffer, oldChain->buffer, len);
+        }
+        /* Append length and DER encoded certificate. */
+        c32to24(certSz, newChain->buffer + len);
+        XMEMCPY(newChain->buffer + len + CERT_HEADER_SZ, cert, certSz);
+
+        /* Dispose of old chain if we own it. */
+        if (weOwn) {
+            FreeDer(chain);
+        }
+        /* Replace chain. */
+        *chain = newChain;
+    }
+
+    return res;
+}
+#endif
+
+#ifdef OPENSSL_EXTRA
+
+/* Add a certificate to end of chain sent in TLS handshake.
+ *
+ * @param [in, out] ctx    SSL context.
+ * @param [in]      der    Buffer holding DER encoded certificate.
+ * @param [in]      derSz  Size of data in buffer.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+static int wolfssl_ctx_add_to_chain(WOLFSSL_CTX* ctx, const byte* der,
+    int derSz)
+{
+    int res = 1;
+    int ret;
+    DerBuffer* derBuffer = NULL;
+
+    /* Create a DER buffer from DER encoding. */
+    ret = AllocCopyDer(&derBuffer, der, (word32)derSz, CERT_TYPE, ctx->heap);
+    if (ret != 0) {
+        WOLFSSL_MSG("Memory Error");
+        res = 0;
+    }
+    if (res == 1) {
+        /* Add a user CA certificate to the certificate manager. */
+        res = AddCA(ctx->cm, &derBuffer, WOLFSSL_USER_CA,
+            GET_VERIFY_SETTING_CTX(ctx));
+        if (res != 1) {
+            res = 0;
+        }
+    }
+
+    if (res == 1) {
+         /* Add chain to DER buffer. */
+         res = wolfssl_add_to_chain(&ctx->certChain, 1, der, (word32)derSz, ctx->heap);
+    #ifdef WOLFSSL_TLS13
+        /* Update count of certificates. */
+        ctx->certChainCnt++;
+    #endif
+    }
+
+    return res;
+}
+
+/* Add a certificate to chain sent in TLS handshake.
+ *
+ * @param [in, out] ctx   SSL context.
+ * @param [in]      x509  X509 certificate object.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+long wolfSSL_CTX_add_extra_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
+{
+    int   ret = 1;
+    int   derSz = 0;
+    const byte* der = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_add_extra_chain_cert");
+
+    /* Validate parameters. */
+    if ((ctx == NULL) || (x509 == NULL)) {
+        WOLFSSL_MSG("Bad Argument");
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        /* Get the DER encoding of the certificate from the X509 object. */
+        der = wolfSSL_X509_get_der(x509, &derSz);
+        /* Validate buffer. */
+        if ((der == NULL) || (derSz <= 0)) {
+            WOLFSSL_MSG("Error getting X509 DER");
+            ret = 0;
+        }
+    }
+
+    if ((ret == 1) && (ctx->certificate == NULL)) {
+        WOLFSSL_ENTER("wolfSSL_use_certificate_chain_buffer_format");
+
+        /* Process buffer makes first certificate the leaf. */
+        ret = ProcessBuffer(ctx, der, derSz, WOLFSSL_FILETYPE_ASN1, CERT_TYPE,
+            NULL, NULL, 1, GET_VERIFY_SETTING_CTX(ctx));
+        if (ret != 1) {
+            ret = 0;
+        }
+    }
+    else if (ret == 1) {
+        /* Add certificate to existing chain. */
+        ret = wolfssl_ctx_add_to_chain(ctx, der, derSz);
+    }
+
+    if (ret == 1) {
+        /* On success WOLFSSL_X509 memory is responsibility of SSL context. */
+        wolfSSL_X509_free(x509);
+    }
+
+    WOLFSSL_LEAVE("wolfSSL_CTX_add_extra_chain_cert", ret);
+    return ret;
+}
+
+#endif /* OPENSSL_EXTRA */
+
+#if defined(OPENSSL_EXTRA) || defined(HAVE_LIGHTY) || \
+    defined(WOLFSSL_MYSQL_COMPATIBLE) || defined(HAVE_STUNNEL) || \
+    defined(WOLFSSL_NGINX) || defined(HAVE_POCO_LIB) || \
+    defined(WOLFSSL_HAPROXY)
+/* Load a certificate into SSL context.
+ *
+ * @param [in, out] ctx   SSL context object.
+ * @param [in]      x509  X509 certificate object.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_CTX_use_certificate(WOLFSSL_CTX *ctx, WOLFSSL_X509 *x)
+{
+    int res = 1;
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_use_certificate");
+
+    /* Validate parameters. */
+    if ((ctx == NULL) || (x == NULL) || (x->derCert == NULL)) {
+        WOLFSSL_MSG("Bad parameter");
+        res = 0;
+    }
+
+    if (res == 1) {
+        /* Replace certificate buffer with one holding the new certificate. */
+        FreeDer(&ctx->certificate);
+        ret = AllocCopyDer(&ctx->certificate, x->derCert->buffer,
+            x->derCert->length, CERT_TYPE, ctx->heap);
+        if (ret != 0) {
+            res = 0;
+        }
+    }
+
+#ifdef KEEP_OUR_CERT
+    if (res == 1) {
+        /* Dispose of our certificate if it is ours. */
+        if ((ctx->ourCert != NULL) && ctx->ownOurCert) {
+            wolfSSL_X509_free(ctx->ourCert);
+        }
+    #ifndef WOLFSSL_X509_STORE_CERTS
+        /* Keep a reference to the new certificate. */
+        ctx->ourCert = x;
+        if (wolfSSL_X509_up_ref(x) != 1) {
+            res = 0;
+        }
+    #else
+        /* Keep a copy of the new certificate. */
+        ctx->ourCert = wolfSSL_X509_d2i_ex(NULL, x->derCert->buffer,
+            x->derCert->length, ctx->heap);
+        if (ctx->ourCert == NULL) {
+            res = 0;
+        }
+    #endif
+        /* Now own our certificate. */
+        ctx->ownOurCert = 1;
+    }
+#endif
+
+    if (res == 1) {
+        /* Set have options based on public key OID. */
+        wolfssl_set_have_from_key_oid(ctx, NULL, x->pubKeyOID);
+    }
+
+    return res;
+}
+
+/* Add the certificate to the chain in the SSL context and own the X509 object.
+ *
+ * @param [in, out] ctx   SSL context object.
+ * @param [in]      x509  X509 certificate object.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_CTX_add0_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
+{
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_add0_chain_cert");
+
+    /* Add certificate to chain and copy or up reference it. */
+    ret = wolfSSL_CTX_add1_chain_cert(ctx, x509);
+    if (ret == 1) {
+        /* Down reference or free original now as we own certificate. */
+        wolfSSL_X509_free(x509);
+    }
+
+    return ret;
+}
+
+/* Add the certificate to the chain in the SSL context.
+ *
+ * X509 object copied or up referenced.
+ *
+ * @param [in, out] ctx   SSL context object.
+ * @param [in]      x509  X509 certificate object.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_CTX_add1_chain_cert(WOLFSSL_CTX* ctx, WOLFSSL_X509* x509)
+{
+    int ret = 1;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_add1_chain_cert");
+
+    /* Validate parameters. */
+    if ((ctx == NULL) || (x509 == NULL) || (x509->derCert == NULL)) {
+        ret = 0;
+    }
+
+    /* Check if we already have set a certificate. */
+    if ((ret == 1) && (ctx->certificate == NULL)) {
+        /* Use the certificate. */
+        ret = wolfSSL_CTX_use_certificate(ctx, x509);
+    }
+    /* Increate reference count as we will store it. */
+    else if ((ret == 1) && ((ret = wolfSSL_X509_up_ref(x509)) == 1)) {
+        /* Load the DER encoding. */
+        ret = wolfSSL_CTX_load_verify_buffer(ctx, x509->derCert->buffer,
+            x509->derCert->length, WOLFSSL_FILETYPE_ASN1);
+        if (ret == 1) {
+            /* Add DER encoding to chain. */
+            ret = wolfssl_add_to_chain(&ctx->certChain, 1,
+                x509->derCert->buffer, x509->derCert->length, ctx->heap);
+        }
+        /* Store cert in stack to free it later. */
+        if ((ret == 1) && (ctx->x509Chain == NULL)) {
+            /* Create a stack for certificates. */
+            ctx->x509Chain = wolfSSL_sk_X509_new_null();
+            if (ctx->x509Chain == NULL) {
+                WOLFSSL_MSG("wolfSSL_sk_X509_new_null error");
+                ret = 0;
+            }
+        }
+        if (ret == 1) {
+            /* Push the X509 object onto stack. */
+            ret = wolfSSL_sk_X509_push(ctx->x509Chain, x509);
+        }
+
+        if (ret != 1) {
+            /* Decrease reference count on error as we didn't store it. */
+            wolfSSL_X509_free(x509);
+        }
+    }
+
+    return WS_RC(ret);
+}
+
+#ifdef KEEP_OUR_CERT
+/* Add the certificate to the chain in the SSL and own the X509 object.
+ *
+ * @param [in, out] ssl   SSL object.
+ * @param [in]      x509  X509 certificate object.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_add0_chain_cert(WOLFSSL* ssl, WOLFSSL_X509* x509)
+{
+    int ret = 1;
+
+    WOLFSSL_ENTER("wolfSSL_add0_chain_cert");
+
+    /* Validate parameters. */
+    if ((ssl == NULL) || (ssl->ctx == NULL) || (x509 == NULL) ||
+            (x509->derCert == NULL)) {
+        ret = 0;
+    }
+
+    /* Check if we already have set a certificate. */
+    if ((ret == 1) && (ssl->buffers.certificate == NULL)) {
+        /* Use the certificate. */
+        ret = wolfSSL_use_certificate(ssl, x509);
+        if (ret == 1) {
+            /* Dispose of old certificate if we own it. */
+            if (ssl->buffers.weOwnCert) {
+                wolfSSL_X509_free(ssl->ourCert);
+            }
+            /* Store cert to free it later. */
+            ssl->ourCert = x509;
+            ssl->buffers.weOwnCert = 1;
+        }
+    }
+    else if (ret == 1) {
+        /* Add DER encoding to chain. */
+        ret = wolfssl_add_to_chain(&ssl->buffers.certChain,
+            ssl->buffers.weOwnCertChain, x509->derCert->buffer,
+            x509->derCert->length, ssl->heap);
+        if (ret == 1) {
+            /* We now own cert chain. */
+            ssl->buffers.weOwnCertChain = 1;
+            /* Create a stack to put certificate into. */
+            if (ssl->ourCertChain == NULL) {
+                ssl->ourCertChain = wolfSSL_sk_X509_new_null();
+                if (ssl->ourCertChain == NULL) {
+                    WOLFSSL_MSG("wolfSSL_sk_X509_new_null error");
+                    ret = 0;
+                }
+            }
+        }
+        if (ret == 1) {
+            /* Push X509 object onto stack to be freed. */
+            ret = wolfSSL_sk_X509_push(ssl->ourCertChain, x509);
+            if (ret != 1) {
+                /* Free it now on error. */
+                wolfSSL_X509_free(x509);
+            }
+        }
+    }
+    return WS_RC(ret);
+}
+
+/* Add the certificate to the chain in the SSL.
+ *
+ * X509 object is up referenced.
+ *
+ * @param [in, out] ssl   SSL object.
+ * @param [in]      x509  X509 certificate object.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_add1_chain_cert(WOLFSSL* ssl, WOLFSSL_X509* x509)
+{
+    int ret = 1;
+
+    WOLFSSL_ENTER("wolfSSL_add1_chain_cert");
+
+    /* Validate parameters. */
+    if ((ssl == NULL) || (ssl->ctx == NULL) || (x509 == NULL) ||
+            (x509->derCert == NULL)) {
+        ret = 0;
+    }
+
+    /* Increase reference count on X509 object before adding. */
+    if ((ret == 1) && ((ret == wolfSSL_X509_up_ref(x509)) == 1)) {
+        /* Add this to the chain. */
+        if ((ret = wolfSSL_add0_chain_cert(ssl, x509)) != 1) {
+            /* Decrease reference count on error as not stored. */
+            wolfSSL_X509_free(x509);
+        }
+    }
+
+    return ret;
+}
+#endif /* KEEP_OUR_CERT */
+#endif /* OPENSSL_EXTRA, HAVE_LIGHTY, WOLFSSL_MYSQL_COMPATIBLE, HAVE_STUNNEL,
+          WOLFSSL_NGINX, HAVE_POCO_LIB, WOLFSSL_HAPROXY */
+
+#ifdef OPENSSL_EXTRA
+
+/* Load a private key into SSL context.
+ *
+ * @param [in, out] ctx   SSL context object.
+ * @param [in]      pkey  EVP private key.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_CTX_use_PrivateKey(WOLFSSL_CTX *ctx, WOLFSSL_EVP_PKEY *pkey)
+{
+    int ret = 1;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_use_PrivateKey");
+
+    /* Validate parameters. */
+    if ((ctx == NULL) || (pkey == NULL) || (pkey->pkey.ptr == NULL)) {
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        switch (pkey->type) {
+    #if defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)
+        case EVP_PKEY_RSA:
+            WOLFSSL_MSG("populating RSA key");
+            ret = PopulateRSAEvpPkeyDer(pkey);
+            break;
+    #endif /* (WOLFSSL_KEY_GEN || OPENSSL_EXTRA) && !NO_RSA */
+    #if !defined(HAVE_SELFTEST) && (defined(WOLFSSL_KEY_GEN) || \
+            defined(WOLFSSL_CERT_GEN)) && !defined(NO_DSA)
+        case EVP_PKEY_DSA:
+            break;
+    #endif /* !HAVE_SELFTEST && (WOLFSSL_KEY_GEN || WOLFSSL_CERT_GEN) &&
+            * !NO_DSA */
+    #ifdef HAVE_ECC
+        case EVP_PKEY_EC:
+            WOLFSSL_MSG("populating ECC key");
+            ret = ECC_populate_EVP_PKEY(pkey, pkey->ecc);
+            break;
+    #endif
+        default:
+            ret = 0;
+        }
+    }
+
+    if (ret == 1) {
+        /* ptr for WOLFSSL_EVP_PKEY struct is expected to be DER format */
+        ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx,
+            (const unsigned char*)pkey->pkey.ptr, pkey->pkey_sz,
+            SSL_FILETYPE_ASN1);
+    }
+
+    return ret;
+}
+
+#endif /* OPENSSL_EXTRA */
+
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_ASIO) || \
+    defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_QT)
+/* Load a DER encoded certificate in a buffer into SSL context.
+ *
+ * @param [in, out] ctx    SSL context object.
+ * @param [in]      der    Buffer holding DER encoded certificate.
+ * @param [in]      derSz  Size of data in bytes.
+ * @return  1 on success.
+ * @return  0 on failure.
+ */
+int wolfSSL_CTX_use_certificate_ASN1(WOLFSSL_CTX *ctx, int derSz,
+    const unsigned char *der)
+{
+    int ret = 1;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_use_certificate_ASN1");
+
+    /* Validate parameters. */
+    if ((ctx == NULL) || (der == NULL)) {
+        ret = 0;
+    }
+    /* Load DER encoded cerificate into SSL context. */
+    if ((ret == 1) && (wolfSSL_CTX_use_certificate_buffer(ctx, der, derSz,
+            WOLFSSL_FILETYPE_ASN1) != 1)) {
+        ret = 0;
+    }
+
+    return ret;
+}
+
+#if defined(WOLFSSL_KEY_GEN) && !defined(NO_RSA)
+/* Load an RSA private key into SSL context.
+ *
+ * @param [in, out] ctx   SSL context object.
+ * @param [in]      rsa   RSA private key.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  BAD_FUNC_ARG when ctx or rsa is NULL.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+int wolfSSL_CTX_use_RSAPrivateKey(WOLFSSL_CTX* ctx, WOLFSSL_RSA* rsa)
+{
+    int ret = 1;
+    int derSize;
+    unsigned char* der = NULL;
+    unsigned char* p;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_use_RSAPrivateKey");
+
+    /* Validate parameters. */
+    if ((ctx == NULL) || (rsa == NULL)) {
+        WOLFSSL_MSG("one or more inputs were NULL");
+        ret = BAD_FUNC_ARG;
+    }
+
+    /* Get DER encoding size. */
+    if ((ret == 1) && ((derSize = wolfSSL_i2d_RSAPrivateKey(rsa, NULL)) <= 0)) {
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        /* Allocate memory to hold DER encoding.. */
+        der = (unsigned char*)XMALLOC(derSize, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (der == NULL) {
+            WOLFSSL_MSG("Malloc failure");
+            ret = MEMORY_E;
+        }
+    }
+
+    if (ret == 1) {
+        /* Pointer passed in is modified.. */
+        p = der;
+        /* Encode the RSA key as DER into buffer and get size. */
+        if ((derSize = wolfSSL_i2d_RSAPrivateKey(rsa, &p)) <= 0) {
+            WOLFSSL_MSG("wolfSSL_i2d_RSAPrivateKey() failure");
+            ret = 0;
+        }
+    }
+
+    if (ret == 1) {
+        /* Load DER encoded cerificate into SSL context. */
+        ret = wolfSSL_CTX_use_PrivateKey_buffer(ctx, der, derSize,
+            SSL_FILETYPE_ASN1);
+        if (ret != WOLFSSL_SUCCESS) {
+            WOLFSSL_MSG("wolfSSL_CTX_USE_PrivateKey_buffer() failure");
+            ret = 0;
+        }
+    }
+
+    /* Dispos of dynamically allocated data. */
+    XFREE(der, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    return ret;
+}
+#endif /* WOLFSSL_KEY_GEN && !NO_RSA */
+
+#endif /* OPENSSL_ALL || WOLFSSL_ASIO || WOLFSSL_HAPROXY || WOLFSSL_QT */
+
+#endif /* !NO_CERTS */
+
+#ifdef OPENSSL_EXTRA
+
+/* Use the default paths to look for CA certificate.
+ *
+ * This is an OpenSSL compatibility layer function, but it doesn't mirror
+ * the exact functionality of its OpenSSL counterpart. We don't support the
+ * notion of an "OpenSSL directory". This function will attempt to load the
+ * environment variables SSL_CERT_DIR and SSL_CERT_FILE, if either are
+ * found, they will be loaded. Otherwise, it will act as a wrapper around
+ * our native wolfSSL_CTX_load_system_CA_certs function. This function does
+ * conform to OpenSSL's return value conventions.
+ *
+ * @param [in] ctx  SSL context object.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  WOLFSSL_FATAL_ERROR when using a filesystem is not supported.
+ */
+int wolfSSL_CTX_set_default_verify_paths(WOLFSSL_CTX* ctx)
+{
+    int ret;
+#ifdef XGETENV
+    char* certDir;
+    char* certFile;
+    word32 flags;
+#elif !defined(WOLFSSL_SYS_CA_CERTS)
+    (void)ctx;
+#endif
+
+    WOLFSSL_ENTER("wolfSSL_CTX_set_default_verify_paths");
+
+#ifdef XGETENV
+    certDir = XGETENV("SSL_CERT_DIR");
+    certFile = XGETENV("SSL_CERT_FILE");
+    flags = WOLFSSL_LOAD_FLAG_PEM_CA_ONLY;
+
+    if ((certDir != NULL) || (certFile != NULL)) {
+        if (certDir != NULL) {
+           /* We want to keep trying to load more CA certs even if one cert in
+            * the directory is bad and can't be used (e.g. if one is
+            * expired), so we use WOLFSSL_LOAD_FLAG_IGNORE_ERR.
+            */
+            flags |= WOLFSSL_LOAD_FLAG_IGNORE_ERR;
+        }
+
+        /* Load CA certificates from environment variable locations. */
+        ret = wolfSSL_CTX_load_verify_locations_ex(ctx, certFile, certDir,
+            flags);
+        if (ret != 1) {
+            WOLFSSL_MSG_EX("Failed to load CA certs from SSL_CERT_FILE: %s"
+                            " SSL_CERT_DIR: %s. Error: %d", certFile,
+                            certDir, ret);
+            ret = 0;
+        }
+    }
+    else
+#endif
+
+    {
+    #ifdef NO_FILESYSTEM
+        WOLFSSL_MSG("wolfSSL_CTX_set_default_verify_paths not supported"
+                    " with NO_FILESYSTEM enabled");
+        ret = WOLFSSL_FATAL_ERROR;
+    #elif defined(WOLFSSL_SYS_CA_CERTS)
+        /* Load the system CA certificates. */
+        ret = wolfSSL_CTX_load_system_CA_certs(ctx);
+        if (ret == WOLFSSL_BAD_PATH) {
+            /* OpenSSL doesn't treat the lack of a system CA cert directory as a
+             * failure. We do the same here.
+             */
+            ret = 1;
+        }
+    #else
+        /* OpenSSL's implementation of this API does not require loading the
+           system CA cert directory.  Allow skipping this without erroring out. */
+        ret = 1;
+    #endif
+    }
+
+    WOLFSSL_LEAVE("wolfSSL_CTX_set_default_verify_paths", ret);
+
+    return ret;
+}
+
+#endif /* OPENSSL_EXTRA */
+
+#ifndef NO_DH
+
+/* Set the temporary DH parameters against the SSL.
+ *
+ * @param [in, out] ssl   SSL object.
+ * @param [in]      p     Buffer holding prime.
+ * @param [in]      pSz   Length of prime in bytes.
+ * @param [in]      g     Buffer holding generator.
+ * @param [in]      gSz   Length of generator in bytes.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  DH_KEY_SIZE_E when the prime is too short or long.
+ * @return  SIDE_ERROR when the SSL is for a client.
+ */
+static int wolfssl_set_tmp_dh(WOLFSSL* ssl, unsigned char* p, int pSz,
+    unsigned char* g, int gSz)
+{
+    int ret = 1;
+
+    /* Check the size of the prime meets the requirements of the SSL. */
+    if (((word16)pSz < ssl->options.minDhKeySz) ||
+            ((word16)pSz > ssl->options.maxDhKeySz)) {
+        ret = DH_KEY_SIZE_E;
+    }
+    /* Only able to set DH parameters on server. */
+    if ((ret == 1) && (ssl->options.side == WOLFSSL_CLIENT_END)) {
+        ret = SIDE_ERROR;
+    }
+
+    if (ret == 1) {
+    #if !defined(WOLFSSL_OLD_PRIME_CHECK) && !defined(HAVE_FIPS) && \
+        !defined(HAVE_SELFTEST)
+        /* New DH parameters not tested for validity. */
+        ssl->options.dhKeyTested = 0;
+        /* New DH parameters must be tested for validity before use. */
+        ssl->options.dhDoKeyTest = 1;
+    #endif
+
+        /* Dispose of old DH parameters if we own it. */
+        if (ssl->buffers.weOwnDH) {
+            XFREE(ssl->buffers.serverDH_P.buffer, ssl->heap,
+                DYNAMIC_TYPE_PUBLIC_KEY);
+            XFREE(ssl->buffers.serverDH_G.buffer, ssl->heap,
+                DYNAMIC_TYPE_PUBLIC_KEY);
+        }
+
+        /* Assign the buffers and lengths to SSL. */
+        ssl->buffers.serverDH_P.buffer = p;
+        ssl->buffers.serverDH_G.buffer = g;
+        ssl->buffers.serverDH_P.length = (unsigned int)pSz;
+        ssl->buffers.serverDH_G.length = (unsigned int)gSz;
+        /* We own the buffers. */
+        ssl->buffers.weOwnDH = 1;
+        /* We have a DH parameters to use. */
+        ssl->options.haveDH = 1;
+    }
+
+    /* Allocate space for cipher suites. */
+    if ((ret == 1) && (AllocateSuites(ssl) != 0)) {
+        ssl->buffers.serverDH_P.buffer = NULL;
+        ssl->buffers.serverDH_G.buffer = NULL;
+        ret = 0;
+    }
+    if (ret == 1) {
+        /* Reset the cipher suites based on having a DH parameters now. */
+        InitSuites(ssl->suites, ssl->version, SSL_KEY_SZ(ssl),
+            WOLFSSL_HAVE_RSA, SSL_HAVE_PSK(ssl), ssl->options.haveDH,
+            ssl->options.haveECDSAsig, ssl->options.haveECC, TRUE,
+            ssl->options.haveStaticECC, ssl->options.haveFalconSig,
+            ssl->options.haveDilithiumSig, ssl->options.useAnon, TRUE,
+            ssl->options.side);
+    }
+
+    return ret;
+}
+
+/* Set the temporary DH parameters against the SSL.
+ *
+ * @param [in, out] ssl   SSL object.
+ * @param [in]      p     Buffer holding prime.
+ * @param [in]      pSz   Length of prime in bytes.
+ * @param [in]      g     Buffer holding generator.
+ * @param [in]      gSz   Length of generator in bytes.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  DH_KEY_SIZE_E when the prime is too short or long.
+ * @return  SIDE_ERROR when the SSL is for a client.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+int wolfSSL_SetTmpDH(WOLFSSL* ssl, const unsigned char* p, int pSz,
+    const unsigned char* g, int gSz)
+{
+    int ret = 1;
+    byte* pAlloc = NULL;
+    byte* gAlloc = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_SetTmpDH");
+
+    /* Validate parameters. */
+    if ((ssl == NULL) || (p == NULL) || (g == NULL)) {
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        /* Allocate buffers for p and g to be assigned into SSL. */
+        pAlloc = (byte*)XMALLOC(pSz, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        gAlloc = (byte*)XMALLOC(gSz, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        if ((pAlloc == NULL) || (gAlloc == NULL)) {
+            ret = MEMORY_E;
+        }
+    }
+    if (ret == 1) {
+        /* Copy p and g into allocated buffers. */
+        XMEMCPY(pAlloc, p, pSz);
+        XMEMCPY(gAlloc, g, gSz);
+        /* Set the buffers into SSL. */
+        ret = wolfssl_set_tmp_dh(ssl, pAlloc, pSz, gAlloc, gSz);
+    }
+
+    if (ret != 1 && ssl != NULL) {
+        /* Free the allocated buffers if not assigned into SSL. */
+        XFREE(pAlloc, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        XFREE(gAlloc, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+    }
+
+    WOLFSSL_LEAVE("wolfSSL_SetTmpDH", ret);
+    return ret;
+}
+
+#if !defined(WOLFSSL_OLD_PRIME_CHECK) && !defined(HAVE_FIPS) && \
+    !defined(HAVE_SELFTEST)
+/* Check the DH parameters is valid.
+ *
+ * @param [in]      p     Buffer holding prime.
+ * @param [in]      pSz   Length of prime in bytes.
+ * @param [in]      g     Buffer holding generator.
+ * @param [in]      gSz   Length of generator in bytes.
+ * @return  1 on success.
+ * @return  DH_CHECK_PUB_E when p is not a prime.
+ * @return  BAD_FUNC_ARG when p or g is NULL, or pSz or gSz is 0.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+static int wolfssl_check_dh_key(unsigned char* p, int pSz, unsigned char* g,
+    int gSz)
+{
+    WC_RNG rng;
+    int ret = 0;
+#ifndef WOLFSSL_SMALL_STACK
+    DhKey checkKey[1];
+#else
+    DhKey *checkKey;
+#endif
+
+#ifdef WOLFSSL_SMALL_STACK
+    checkKey = (DhKey*)XMALLOC(sizeof(DhKey), NULL, DYNAMIC_TYPE_DH);
+    if (checkKey == NULL) {
+        ret = MEMORY_E;
+    }
+#endif
+    /* Initialize a new random number generator. */
+    if ((ret == 0) && ((ret = wc_InitRng(&rng)) == 0)) {
+        /* Initialize a DH object. */
+        if ((ret = wc_InitDhKey(checkKey)) == 0) {
+            /* Check DH parameters. */
+            ret = wc_DhSetCheckKey(checkKey, p, (word32)pSz, g, gSz, NULL, 0, 0, &rng);
+            /* Dispose of DH object. */
+            wc_FreeDhKey(checkKey);
+        }
+        /* Dispose of random number generator. */
+        wc_FreeRng(&rng);
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    /* Dispose of dynamically allocated data. */
+    XFREE(checkKey, NULL, DYNAMIC_TYPE_DH);
+#endif
+    /* Convert wolfCrypt return code to 1 on success and ret on failure. */
+    return WC_TO_WS_RC(ret);
+}
+#endif
+
+/* Set the temporary DH parameters against the SSL context.
+ *
+ * @param [in, out] ctx   SSL context object.
+ * @param [in]      p     Buffer holding prime.
+ * @param [in]      pSz   Length of prime in bytes.
+ * @param [in]      g     Buffer holding generator.
+ * @param [in]      gSz   Length of generator in bytes.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  DH_KEY_SIZE_E when the prime is too short or long.
+ * @return  SIDE_ERROR when the SSL is for a client.
+ * @return  BAD_FUNC_ARG when ctx, p or g is NULL.
+ * @return  DH_CHECK_PUB_E when p is not a prime.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+static int wolfssl_ctx_set_tmp_dh(WOLFSSL_CTX* ctx, unsigned char* p, int pSz,
+    unsigned char* g, int gSz)
+{
+    int ret = 1;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_SetTmpDH");
+
+    /* Check the size of the prime meets the requirements of the SSL context. */
+    if (((word16)pSz < ctx->minDhKeySz) || ((word16)pSz > ctx->maxDhKeySz)) {
+        ret = DH_KEY_SIZE_E;
+    }
+
+#if !defined(WOLFSSL_OLD_PRIME_CHECK) && !defined(HAVE_FIPS) && \
+    !defined(HAVE_SELFTEST)
+    if (ret == 1) {
+        /* Test DH parameters for validity. */
+        ret = wolfssl_check_dh_key(p, pSz, g, gSz);
+        /* Record as whether tested based on result of validity test. */
+        ctx->dhKeyTested = (ret == 1);
+    }
+#endif
+
+    if (ret == 1) {
+        /* Dispose of old DH parameters. */
+        XFREE(ctx->serverDH_P.buffer, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        XFREE(ctx->serverDH_G.buffer, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        /* Assign the buffers and lengths to SSL context. */
+        ctx->serverDH_P.buffer = p;
+        ctx->serverDH_G.buffer = g;
+        ctx->serverDH_P.length = (unsigned int)pSz;
+        ctx->serverDH_G.length = (unsigned int)gSz;
+        /* We have a DH parameters to use. */
+        ctx->haveDH = 1;
+    }
+
+    WOLFSSL_LEAVE("wolfSSL_CTX_SetTmpDH", 0);
+    return ret;
+}
+
+/* Set the temporary DH parameters against the SSL context.
+ *
+ * @param [in, out] ctx   SSL context object.
+ * @param [in]      p     Buffer holding prime.
+ * @param [in]      pSz   Length of prime in bytes.
+ * @param [in]      g     Buffer holding generator.
+ * @param [in]      gSz   Length of generator in bytes.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  DH_KEY_SIZE_E when the prime is too short or long.
+ * @return  SIDE_ERROR when the SSL is for a client.
+ * @return  BAD_FUNC_ARG when ctx, p or g is NULL.
+ * @return  DH_CHECK_PUB_E when p is not a prime.
+ */
+int wolfSSL_CTX_SetTmpDH(WOLFSSL_CTX* ctx, const unsigned char* p, int pSz,
+                         const unsigned char* g, int gSz)
+{
+    int ret = 1;
+    byte* pAlloc = NULL;
+    byte* gAlloc = NULL;
+
+    /* Validate parameters. */
+    if ((ctx == NULL) || (p == NULL) || (g == NULL)) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (ret == 1) {
+        /* Allocate buffers for p and g to be assigned into SSL context. */
+        pAlloc = (byte*)XMALLOC(pSz, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        gAlloc = (byte*)XMALLOC(gSz, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        if ((pAlloc == NULL) || (gAlloc == NULL)) {
+            XFREE(pAlloc, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+            pAlloc = NULL;
+            XFREE(gAlloc, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+            gAlloc = NULL;
+            ret = MEMORY_E;
+        }
+    }
+
+    if (ret == 1) {
+        /* Copy p and g into allocated buffers. */
+        XMEMCPY(pAlloc, p, pSz);
+        XMEMCPY(gAlloc, g, gSz);
+        /* Set the buffers into SSL context. */
+        ret = wolfssl_ctx_set_tmp_dh(ctx, pAlloc, pSz, gAlloc, gSz);
+    }
+
+    if (ret != 1) {
+        /* Free the allocated buffers if not assigned into SSL context. */
+        if (pAlloc)
+            XFREE(pAlloc, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        if (gAlloc)
+            XFREE(gAlloc, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+    }
+    return ret;
+}
+
+#ifdef OPENSSL_EXTRA
+/* Set the temporary DH parameters against the SSL.
+ *
+ * @param [in, out] ssl  SSL object.
+ * @param [in]      dh   DH object.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  WOLFSSL_FATAL_ERROR on failure.
+ * @return  BAD_FUNC_ARG when ssl or dh is NULL.
+ * @return  DH_KEY_SIZE_E when the prime is too short or long.
+ * @return  SIDE_ERROR when the SSL is for a client.
+ */
+long wolfSSL_set_tmp_dh(WOLFSSL *ssl, WOLFSSL_DH *dh)
+{
+    int ret = 1;
+    byte* p = NULL;
+    byte* g = NULL;
+    int pSz = 0;
+    int gSz = 0;
+
+    WOLFSSL_ENTER("wolfSSL_set_tmp_dh");
+
+    /* Validate parameters. */
+    if ((ssl == NULL) || (dh == NULL)) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (ret == 1) {
+        /* Get needed size for p and g. */
+        pSz = wolfSSL_BN_bn2bin(dh->p, NULL);
+        gSz = wolfSSL_BN_bn2bin(dh->g, NULL);
+        /* Validate p and g size. */
+        if ((pSz <= 0) || (gSz <= 0)) {
+            ret = WOLFSSL_FATAL_ERROR;
+        }
+    }
+
+    if (ret == 1) {
+        /* Allocate buffers for p and g to be assigned into SSL. */
+        p = (byte*)XMALLOC(pSz, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        g = (byte*)XMALLOC(gSz, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        if ((p == NULL) || (g == NULL)) {
+            ret = MEMORY_E;
+        }
+    }
+    if (ret == 1) {
+        /* Encode p and g and get sizes. */
+        pSz = wolfSSL_BN_bn2bin(dh->p, p);
+        gSz = wolfSSL_BN_bn2bin(dh->g, g);
+        /* Check encoding worked. */
+        if ((pSz <= 0) || (gSz <= 0)) {
+            ret = WOLFSSL_FATAL_ERROR;
+        }
+    }
+    if (ret == 1) {
+        /* Set the buffers into SSL. */
+        ret = wolfssl_set_tmp_dh(ssl, p, pSz, g, gSz);
+    }
+
+    if (ret != 1 && ssl != NULL) {
+        /* Free the allocated buffers if not assigned into SSL. */
+        XFREE(p, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        XFREE(g, ssl->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+    }
+    return ret;
+}
+
+/* Set the temporary DH parameters object against the SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      dh      DH object.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  DH_KEY_SIZE_E when the prime is too short or long.
+ * @return  SIDE_ERROR when the SSL is for a client.
+ * @return  BAD_FUNC_ARG when ctx, p or g is NULL.
+ * @return  DH_CHECK_PUB_E when p is not a prime.
+ */
+long wolfSSL_CTX_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL_DH* dh)
+{
+    int ret = 1;
+    int pSz = 0;
+    int gSz = 0;
+    byte* p = NULL;
+    byte* g = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_set_tmp_dh");
+
+    /* Validate parameters. */
+    if ((ctx == NULL) || (dh == NULL)) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (ret == 1) {
+        /* Get needed size for p and g. */
+        pSz = wolfSSL_BN_bn2bin(dh->p, NULL);
+        gSz = wolfSSL_BN_bn2bin(dh->g, NULL);
+        /* Validate p and g size. */
+        if ((pSz <= 0) || (gSz <= 0)) {
+            ret = WOLFSSL_FATAL_ERROR;
+        }
+    }
+
+    if (ret == 1) {
+        /* Allocate buffers for p and g to be assigned into SSL. */
+        p = (byte*)XMALLOC(pSz, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        g = (byte*)XMALLOC(gSz, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        if ((p == NULL) || (g == NULL)) {
+            ret = MEMORY_E;
+        }
+    }
+
+    if (ret == 1) {
+        /* Encode p and g and get sizes. */
+        pSz = wolfSSL_BN_bn2bin(dh->p, p);
+        gSz = wolfSSL_BN_bn2bin(dh->g, g);
+        /* Check encoding worked. */
+        if ((pSz < 0) && (gSz < 0)) {
+            ret = WOLFSSL_FATAL_ERROR;
+        }
+    }
+    if (ret == 1) {
+        /* Set the buffers into SSL context. */
+        ret = wolfssl_ctx_set_tmp_dh(ctx, p, pSz, g, gSz);
+    }
+
+    if (ret != 1 && ctx != NULL) {
+        /* Free the allocated buffers if not assigned into SSL. */
+        XFREE(p, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        XFREE(g, ctx->heap, DYNAMIC_TYPE_PUBLIC_KEY);
+    }
+    return ret;
+}
+
+#endif /* OPENSSL_EXTRA */
+
+#ifndef NO_CERTS
+
+/* Set the temporary DH parameters against the SSL context or SSL.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      buf     Buffer holding encoded DH parameters.
+ * @param [in]      sz      Size of encoded DH parameters.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  0 on failure.
+ * @return  BAD_FUNC_ARG when ctx and ssl NULL or buf is NULL.
+ * @return  NOT_COMPLED_IN when format is PEM but PEM is not supported.
+ * @return  WOLFSSL_BAD_FILETYPE if format is not supported.
+ */
+static int ws_ctx_ssl_set_tmp_dh(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    const unsigned char* buf, long sz, int format)
+{
+    DerBuffer* der = NULL;
+    int res = 1;
+    int ret;
+    /* p and g size to allocate set to maximum valid size. */
+    word32 pSz = MAX_DH_SIZE;
+    word32 gSz = MAX_DH_SIZE;
+    byte* p = NULL;
+    byte* g = NULL;
+    void* heap = WOLFSSL_HEAP(ctx, ssl);
+
+    /* Validate parameters. */
+    if (((ctx == NULL) && (ssl == NULL)) || (buf == NULL)) {
+        res = BAD_FUNC_ARG;
+    }
+    /* Check format is supported. */
+    if ((res == 1) && (format != WOLFSSL_FILETYPE_ASN1)) {
+        if (format != WOLFSSL_FILETYPE_PEM) {
+            res = WOLFSSL_BAD_FILETYPE;
+        }
+    #ifndef WOLFSSL_PEM_TO_DER
+        else {
+            res = NOT_COMPILED_IN;
+        }
+    #endif
+    }
+
+    /* PemToDer allocates its own DER buffer. */
+    if ((res == 1) && (format != WOLFSSL_FILETYPE_PEM)) {
+        /* Create an empty DER buffer. */
+        ret = AllocDer(&der, 0, DH_PARAM_TYPE, heap);
+        if (ret == 0) {
+            /* Assign encoded DH parameters to DER buffer. */
+            der->buffer = (byte*)buf;
+            der->length = (word32)sz;
+        }
+        else {
+            res = ret;
+        }
+    }
+
+    if (res == 1) {
+        /* Allocate enough memory to p and g to support valid use cases. */
+        p = (byte*)XMALLOC(pSz, heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        g = (byte*)XMALLOC(gSz, heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        if ((p == NULL) || (g == NULL)) {
+            res = MEMORY_E;
+        }
+    }
+
+#ifdef WOLFSSL_PEM_TO_DER
+    if ((res == 1) && (format == WOLFSSL_FILETYPE_PEM)) {
+        /* Convert from PEM to DER. */
+        /* Try converting DH parameters from PEM to DER. */
+        ret = PemToDer(buf, sz, DH_PARAM_TYPE, &der, heap, NULL, NULL);
+        if (ret < 0) {
+            /* Otherwise, try converting X9.43 format DH parameters. */
+            ret = PemToDer(buf, sz, X942_PARAM_TYPE, &der, heap, NULL, NULL);
+        }
+    #if defined(WOLFSSL_WPAS) && !defined(NO_DSA)
+        if (ret < 0) {
+            /* Otherwise, try converting DSA parameters. */
+            ret = PemToDer(buf, sz, DSA_PARAM_TYPE, &der, heap, NULL, NULL);
+        }
+    #endif /* WOLFSSL_WPAS && !NO_DSA */
+       if (ret < 0) {
+           /* Return error from conversion. */
+           res = ret;
+       }
+    }
+#endif /* WOLFSSL_PEM_TO_DER */
+
+    if (res == 1) {
+        /* Get the p and g from the DER encoded parameters. */
+        if (wc_DhParamsLoad(der->buffer, der->length, p, &pSz, g, &gSz) < 0) {
+            res = WOLFSSL_BAD_FILETYPE;
+        }
+        else if (ssl != NULL) {
+            /* Set p and g into SSL. */
+            res = wolfssl_set_tmp_dh(ssl, p, (int)pSz, g, gSz);
+        }
+        else {
+            /* Set p and g into SSL context. */
+            res = wolfssl_ctx_set_tmp_dh(ctx, p, (int)pSz, g, gSz);
+        }
+    }
+
+    /* Dispose of the DER buffer. */
+    FreeDer(&der);
+    if (res != 1) {
+        /* Free the allocated buffers if not assigned into SSL or context. */
+        XFREE(p, heap, DYNAMIC_TYPE_PUBLIC_KEY);
+        XFREE(g, heap, DYNAMIC_TYPE_PUBLIC_KEY);
+    }
+    return res;
+}
+
+
+/* Set the temporary DH parameters against the SSL.
+ *
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      buf     Buffer holding encoded DH parameters.
+ * @param [in]      sz      Size of encoded DH parameters.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  BAD_FUNC_ARG when ssl or buf is NULL.
+ * @return  NOT_COMPLED_IN when format is PEM but PEM is not supported.
+ * @return  WOLFSSL_BAD_FILETYPE if format is not supported.
+ */
+int wolfSSL_SetTmpDH_buffer(WOLFSSL* ssl, const unsigned char* buf, long sz,
+    int format)
+{
+    return ws_ctx_ssl_set_tmp_dh(NULL, ssl, buf, sz, format);
+}
+
+
+/* Set the temporary DH parameters against the SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      buf     Buffer holding encoded DH parameters.
+ * @param [in]      sz      Size of encoded DH parameters.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  BAD_FUNC_ARG when ctx or buf is NULL.
+ * @return  NOT_COMPLED_IN when format is PEM but PEM is not supported.
+ * @return  WOLFSSL_BAD_FILETYPE if format is not supported.
+ */
+int wolfSSL_CTX_SetTmpDH_buffer(WOLFSSL_CTX* ctx, const unsigned char* buf,
+    long sz, int format)
+{
+    return ws_ctx_ssl_set_tmp_dh(ctx, NULL, buf, sz, format);
+}
+
+#ifndef NO_FILESYSTEM
+
+/* Set the temporary DH parameters file against the SSL context or SSL.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      fname   Name of file to load.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  BAD_FUNC_ARG when ctx and ssl NULL or fname is NULL.
+ * @return  NOT_COMPLED_IN when format is PEM but PEM is not supported.
+ * @return  WOLFSSL_BAD_FILETYPE if format is not supported.
+ */
+static int ws_ctx_ssl_set_tmp_dh_file(WOLFSSL_CTX* ctx, WOLFSSL* ssl,
+    const char* fname, int format)
+{
+    int    res = 1;
+    int    ret;
+#ifndef WOLFSSL_SMALL_STACK
+    byte   stackBuffer[FILE_BUFFER_SIZE];
+#endif
+    StaticBuffer dhFile;
+    long   sz = 0;
+    void*  heap = WOLFSSL_HEAP(ctx, ssl);
+
+    /* Setup buffer to hold file contents. */
+#ifdef WOLFSSL_SMALL_STACK
+    static_buffer_init(&dhFile);
+#else
+    static_buffer_init(&dhFile, stackBuffer, FILE_BUFFER_SIZE);
+#endif
+
+    /* Validate parameters. */
+    if (((ctx == NULL) && (ssl == NULL)) || (fname == NULL)) {
+        res = BAD_FUNC_ARG;
+    }
+
+    if (res == 1) {
+        /* Read file into static buffer. */
+        ret = wolfssl_read_file_static(fname, &dhFile, heap, DYNAMIC_TYPE_FILE,
+            &sz);
+        if (ret != 0) {
+            res = ret;
+        }
+    }
+    if (res == 1) {
+        if (ssl != NULL) {
+            /* Set encoded DH parameters into SSL. */
+            res = wolfSSL_SetTmpDH_buffer(ssl, dhFile.buffer, sz, format);
+        }
+        else {
+            /* Set encoded DH parameters into SSL context. */
+            res = wolfSSL_CTX_SetTmpDH_buffer(ctx, dhFile.buffer, sz, format);
+        }
+    }
+
+    /* Dispose of any dynamically allocated data. */
+    static_buffer_free(&dhFile, heap, DYNAMIC_TYPE_FILE);
+    return res;
+}
+
+/* Set the temporary DH parameters file against the SSL.
+ *
+ * @param [in, out] ssl     SSL object.
+ * @param [in]      fname   Name of file to load.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  BAD_FUNC_ARG when ssl or fname is NULL.
+ * @return  NOT_COMPLED_IN when format is PEM but PEM is not supported.
+ * @return  WOLFSSL_BAD_FILETYPE if format is not supported.
+ */
+int wolfSSL_SetTmpDH_file(WOLFSSL* ssl, const char* fname, int format)
+{
+    return ws_ctx_ssl_set_tmp_dh_file(NULL, ssl, fname, format);
+}
+
+
+/* Set the temporary DH parameters file against the SSL context.
+ *
+ * @param [in, out] ctx     SSL context object.
+ * @param [in]      fname   Name of file to load.
+ * @param [in]      format  Format of data:
+ *                            WOLFSSL_FILETYPE_PEM or WOLFSSL_FILETYPE_ASN1.
+ * @return  1 on success.
+ * @return  BAD_FUNC_ARG when ctx or fname is NULL.
+ * @return  NOT_COMPLED_IN when format is PEM but PEM is not supported.
+ * @return  WOLFSSL_BAD_FILETYPE if format is not supported.
+ */
+int wolfSSL_CTX_SetTmpDH_file(WOLFSSL_CTX* ctx, const char* fname, int format)
+{
+    return ws_ctx_ssl_set_tmp_dh_file(ctx, NULL, fname, format);
+}
+
+#endif /* NO_FILESYSTEM */
+
+#endif /* NO_CERTS */
+
+#endif /* !NO_DH */
+
+#endif /* !WOLFSSL_SSL_LOAD_INCLUDED */
+

--- a/libatalk/ssl/src/ssl_misc.c
+++ b/libatalk/ssl/src/ssl_misc.c
@@ -24,6 +24,8 @@
 #endif
 
 #include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/types.h>
+#include <wolfssl/wolfcrypt/error-crypt.h>
 
 #if !defined(WOLFSSL_SSL_MISC_INCLUDED)
     #ifndef WOLFSSL_IGNORE_FILE_WARN
@@ -54,7 +56,7 @@ static int wolfssl_read_bio_file(WOLFSSL_BIO* bio, char** data)
     char* p;
 
     /* Allocate buffer to hold a chunk of data. */
-    mem = (char*)XMALLOC(READ_BIO_FILE_CHUNK, bio->heap, DYNAMIC_TYPE_OPENSSL);
+    mem = (char*)XMALLOC(READ_BIO_FILE_CHUNK, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (mem == NULL) {
         WOLFSSL_ERROR_MSG("Memory allocation error");
         ret = MEMORY_E;
@@ -86,8 +88,8 @@ static int wolfssl_read_bio_file(WOLFSSL_BIO* bio, char** data)
             }
             else {
                 /* No space left for more data to be read - add a chunk. */
-                p = (char*)XREALLOC(mem, ret + READ_BIO_FILE_CHUNK, bio->heap,
-                    DYNAMIC_TYPE_OPENSSL);
+                p = (char*)XREALLOC(mem, ret + READ_BIO_FILE_CHUNK, NULL,
+                    DYNAMIC_TYPE_TMP_BUFFER);
                 if (p == NULL) {
                     sz = MEMORY_E;
                     break;
@@ -103,7 +105,7 @@ static int wolfssl_read_bio_file(WOLFSSL_BIO* bio, char** data)
         }
         if ((sz < 0) || (ret == 0)) {
             /* Dispose of memory on error or no data read. */
-            XFREE(mem, bio->heap, DYNAMIC_TYPE_OPENSSL);
+            XFREE(mem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
             mem = NULL;
             /* Return error. */
             ret = sz;
@@ -129,14 +131,14 @@ static int wolfssl_read_bio_len(WOLFSSL_BIO* bio, int sz, char** data)
     char* mem;
 
     /* Allocate buffer to hold data. */
-    mem = (char*)XMALLOC((size_t)sz, bio->heap, DYNAMIC_TYPE_OPENSSL);
+    mem = (char*)XMALLOC((size_t)sz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
     if (mem == NULL) {
         WOLFSSL_ERROR_MSG("Memory allocation error");
         ret = MEMORY_E;
     }
     else if ((ret = wolfSSL_BIO_read(bio, mem, sz)) != sz) {
         /* Pending data not read. */
-        XFREE(mem, bio->heap, DYNAMIC_TYPE_OPENSSL);
+        XFREE(mem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         mem = NULL;
         ret = MEMORY_E;
     }
@@ -206,9 +208,7 @@ static int wolfssl_read_bio(WOLFSSL_BIO* bio, char** data, int* dataSz,
 #endif /* OPENSSL_EXTRA && !WOLFCRYPT_ONLY */
 
 #if (defined(OPENSSL_EXTRA) || defined(PERSIST_CERT_CACHE) || \
-     (!defined(NO_CERTS) && (!defined(NO_WOLFSSL_CLIENT) || \
-      !defined(WOLFSSL_NO_CLIENT_AUTH)))) && !defined(WOLFCRYPT_ONLY) && \
-    !defined(NO_FILESYSTEM)
+     !defined(NO_CERTS)) && !defined(WOLFCRYPT_ONLY) && !defined(NO_FILESYSTEM)
 /* Read all the data from a file.
  *
  * @param [in]  fp          File pointer to read with.
@@ -299,5 +299,204 @@ static int wolfssl_read_file(XFILE fp, char** data, int* dataSz)
 }
 #endif /* (OPENSSL_EXTRA || PERSIST_CERT_CACHE) && !WOLFCRYPT_ONLY &&
         * !NO_FILESYSTEM */
+
+#if !defined(WOLFCRYPT_ONLY) && !defined(NO_CERTS)
+
+#ifdef WOLFSSL_SMALL_STACK
+
+/* Buffer and size with no stack buffer. */
+typedef struct {
+    /* Dynamically allocated buffer. */
+    byte* buffer;
+    /* Size of buffer in bytes. */
+    word32 sz;
+} StaticBuffer;
+
+/* Initialize static buffer.
+ *
+ * @param [in, out] sb  Static buffer.
+ */
+static void static_buffer_init(StaticBuffer* sb)
+{
+    sb->buffer = NULL;
+    sb->sz = 0;
+}
+
+/* Set the size of the buffer.
+ *
+ * Can only set size once.
+ *
+ * @param [in] sb    Static buffer.
+ * @param [in] len   Length required.
+ * @param [in] heap  Dynamic memory allocation hint.
+ * @param [in] type  Type of dynamic memory.
+ * @return  0 on success.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+static int static_buffer_set_size(StaticBuffer* sb, word32 len, void* heap,
+    int type)
+{
+    int ret = 0;
+
+    (void)heap;
+    (void)type;
+
+    sb->buffer = (byte*)XMALLOC(len, heap, type);
+    if (sb->buffer == NULL) {
+        ret = MEMORY_E;
+    }
+    else {
+        sb->sz = len;
+    }
+
+    return ret;
+}
+
+/* Dispose of dynamically allocated buffer.
+ *
+ * @param [in] sb    Static buffer.
+ * @param [in] heap  Dynamic memory allocation hint.
+ * @param [in] type  Type of dynamic memory.
+ */
+static void static_buffer_free(StaticBuffer* sb, void* heap, int type)
+{
+    (void)heap;
+    (void)type;
+    XFREE(sb->buffer, heap, type);
+}
+
+#else
+
+/* Buffer and size with stack buffer set and option to dynamically allocate. */
+typedef struct {
+    /* Stack or heap buffer. */
+    byte* buffer;
+    /* Size of buffer in bytes. */
+    word32 sz;
+    /* Indicates whether the buffer was dynamically allocated. */
+    int dyn;
+} StaticBuffer;
+
+/* Initialize static buffer.
+ *
+ * @param [in, out] sb           Static buffer.
+ * @param [in]      stackBuffer  Buffer allocated on the stack.
+ * @param [in]      len          Length of stack buffer.
+ */
+static void static_buffer_init(StaticBuffer* sb, byte* stackBuffer, word32 len)
+{
+    sb->buffer = stackBuffer;
+    sb->sz = len;
+    sb->dyn = 0;
+}
+
+/* Set the size of the buffer.
+ *
+ * Pre: Buffer on the stack set with its size.
+ * Can only set size once.
+ *
+ * @param [in] sb    Static buffer.
+ * @param [in] len   Length required.
+ * @param [in] heap  Dynamic memory allocation hint.
+ * @param [in] type  Type of dynamic memory.
+ * @return  0 on success.
+ * @return  MEMORY_E when dynamic memory allocation fails.
+ */
+static int static_buffer_set_size(StaticBuffer* sb, word32 len, void* heap,
+    int type)
+{
+    int ret = 0;
+
+    (void)heap;
+    (void)type;
+
+    if (len > sb->sz) {
+        byte* buff = (byte*)XMALLOC(len, heap, type);
+        if (buff == NULL) {
+            ret = MEMORY_E;
+        }
+        else {
+            sb->buffer = buff;
+            sb->sz = len;
+            sb->dyn = 1;
+        }
+    }
+
+    return ret;
+}
+
+/* Dispose of dynamically allocated buffer.
+ *
+ * @param [in] sb    Static buffer.
+ * @param [in] heap  Dynamic memory allocation hint.
+ * @param [in] type  Type of dynamic memory.
+ */
+static void static_buffer_free(StaticBuffer* sb, void* heap, int type)
+{
+    (void)heap;
+    (void)type;
+
+    if (sb->dyn) {
+        XFREE(sb->buffer, heap, type);
+    }
+}
+
+#endif /* WOLFSSL_SMALL_STACK */
+
+#ifndef NO_FILESYSTEM
+
+/* Read all the data from a file into content.
+ *
+ * @param [in]      fname    File pointer to read with.
+ * @param [in, out] content  Read data in an allocated buffer.
+ * @param [in]      heap     Dynamic memory allocation hint.
+ * @param [in]      type     Type of dynamic memory.
+ * @param [out]     size     Amount of data read in bytes.
+ * @return  0 on success.
+ * @return  WOLFSSL_BAD_FILE when reading fails.
+ * @return  MEMORY_E when memory allocation fails.
+ */
+static int wolfssl_read_file_static(const char* fname, StaticBuffer* content,
+    void* heap, int type, long* size)
+{
+    int ret = 0;
+    XFILE file = XBADFILE;
+    long sz = 0;
+
+    /* Check filename is usable. */
+    if (fname == NULL) {
+        ret = WOLFSSL_BAD_FILE;
+    }
+    /* Open file for reading. */
+    if ((ret == 0) && ((file = XFOPEN(fname, "rb")) == XBADFILE)) {
+        ret = WOLFSSL_BAD_FILE;
+    }
+    if (ret == 0) {
+        /* Get length of file. */
+        ret = wolfssl_file_len(file, &sz);
+    }
+    if (ret == 0) {
+        /* Set the buffer to be big enough to hold all data. */
+        ret = static_buffer_set_size(content, (word32)sz, heap, type);
+    }
+    /* Read data from file. */
+    if ((ret == 0) && ((size_t)XFREAD(content->buffer, 1, (size_t)sz, file) !=
+            (size_t)sz)) {
+        ret = WOLFSSL_BAD_FILE;
+    }
+
+    /* Close file if opened. */
+    if (file != XBADFILE) {
+        XFCLOSE(file);
+    }
+    /* Return size read. */
+    *size = sz;
+    return ret;
+}
+
+#endif /* !NO_FILESYSTEM */
+
+#endif /* !WOLFCRYPT_ONLY && !NO_CERTS */
+
 #endif /* !WOLFSSL_SSL_MISC_INCLUDED */
 

--- a/libatalk/ssl/src/ssl_p7p12.c
+++ b/libatalk/ssl/src/ssl_p7p12.c
@@ -1,0 +1,2123 @@
+/* ssl_p7p12.c
+ *
+ * Copyright (C) 2006-2024 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#if defined(OPENSSL_EXTRA) && (defined(HAVE_FIPS) || defined(HAVE_SELFTEST))
+    #include <wolfssl/wolfcrypt/pkcs7.h>
+#endif
+#if defined(OPENSSL_ALL) && defined(HAVE_PKCS7)
+    #include <wolfssl/openssl/pkcs7.h>
+#endif
+
+#if !defined(WOLFSSL_SSL_P7P12_INCLUDED)
+    #ifndef WOLFSSL_IGNORE_FILE_WARN
+        #warning ssl_p7p12.c does not need to be compiled separately from ssl.c
+    #endif
+#else
+
+#if !defined(WOLFCRYPT_ONLY) && !defined(NO_CERTS)
+
+/*******************************************************************************
+ * START OF PKCS7 APIs
+ ******************************************************************************/
+#ifdef HAVE_PKCS7
+
+#ifdef OPENSSL_ALL
+PKCS7* wolfSSL_PKCS7_new(void)
+{
+    WOLFSSL_PKCS7* pkcs7;
+    int ret = 0;
+
+    pkcs7 = (WOLFSSL_PKCS7*)XMALLOC(sizeof(WOLFSSL_PKCS7), NULL,
+                                    DYNAMIC_TYPE_PKCS7);
+    if (pkcs7 != NULL) {
+        XMEMSET(pkcs7, 0, sizeof(WOLFSSL_PKCS7));
+        ret = wc_PKCS7_Init(&pkcs7->pkcs7, NULL, INVALID_DEVID);
+    }
+
+    if (ret != 0 && pkcs7 != NULL) {
+        XFREE(pkcs7, NULL, DYNAMIC_TYPE_PKCS7);
+        pkcs7 = NULL;
+    }
+
+    return (PKCS7*)pkcs7;
+}
+
+/******************************************************************************
+* wolfSSL_PKCS7_SIGNED_new - allocates PKCS7 and initialize it for a signed data
+*
+* RETURNS:
+* returns pointer to the PKCS7 structure on success, otherwise returns NULL
+*/
+PKCS7_SIGNED* wolfSSL_PKCS7_SIGNED_new(void)
+{
+    byte signedData[]= { 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x07, 0x02};
+    PKCS7* pkcs7 = NULL;
+
+    if ((pkcs7 = wolfSSL_PKCS7_new()) == NULL)
+        return NULL;
+    pkcs7->contentOID = SIGNED_DATA;
+    if ((wc_PKCS7_SetContentType(pkcs7, signedData, sizeof(signedData))) < 0) {
+        if (pkcs7) {
+            wolfSSL_PKCS7_free(pkcs7);
+            return NULL;
+        }
+    }
+    return pkcs7;
+}
+
+void wolfSSL_PKCS7_free(PKCS7* pkcs7)
+{
+    WOLFSSL_PKCS7* p7 = (WOLFSSL_PKCS7*)pkcs7;
+
+    if (p7 != NULL) {
+        if (p7->data != NULL)
+            XFREE(p7->data, NULL, DYNAMIC_TYPE_PKCS7);
+        wc_PKCS7_Free(&p7->pkcs7);
+        if (p7->certs)
+            wolfSSL_sk_pop_free(p7->certs, NULL);
+        XFREE(p7, NULL, DYNAMIC_TYPE_PKCS7);
+    }
+}
+
+void wolfSSL_PKCS7_SIGNED_free(PKCS7_SIGNED* p7)
+{
+    wolfSSL_PKCS7_free(p7);
+    return;
+}
+
+/**
+ * Convert DER/ASN.1 encoded signedData structure to internal PKCS7
+ * structure. Note, does not support detached content.
+ *
+ * p7 - pointer to set to address of newly created PKCS7 structure on return
+ * in - pointer to pointer of DER/ASN.1 data
+ * len - length of input data, bytes
+ *
+ * Returns newly allocated and populated PKCS7 structure or NULL on error.
+ */
+PKCS7* wolfSSL_d2i_PKCS7(PKCS7** p7, const unsigned char** in, int len)
+{
+    return wolfSSL_d2i_PKCS7_ex(p7, in, len, NULL, 0);
+}
+
+/* This internal function is only decoding and setting up the PKCS7 struct. It
+* does not verify the PKCS7 signature.
+*
+* RETURNS:
+* returns pointer to a PKCS7 structure on success, otherwise returns NULL
+*/
+static PKCS7* wolfSSL_d2i_PKCS7_only(PKCS7** p7, const unsigned char** in,
+    int len, byte* content, word32 contentSz)
+{
+    WOLFSSL_PKCS7* pkcs7 = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_d2i_PKCS7_ex");
+
+    if (in == NULL || *in == NULL || len < 0)
+        return NULL;
+
+    if ((pkcs7 = (WOLFSSL_PKCS7*)wolfSSL_PKCS7_new()) == NULL)
+        return NULL;
+
+    pkcs7->len = len;
+    pkcs7->data = (byte*)XMALLOC(pkcs7->len, NULL, DYNAMIC_TYPE_PKCS7);
+    if (pkcs7->data == NULL) {
+        wolfSSL_PKCS7_free((PKCS7*)pkcs7);
+        return NULL;
+    }
+    XMEMCPY(pkcs7->data, *in, pkcs7->len);
+
+    if (content != NULL) {
+        pkcs7->pkcs7.content = content;
+        pkcs7->pkcs7.contentSz = contentSz;
+    }
+
+    if (p7 != NULL)
+        *p7 = (PKCS7*)pkcs7;
+    *in += pkcs7->len;
+    return (PKCS7*)pkcs7;
+}
+
+
+/*****************************************************************************
+* wolfSSL_d2i_PKCS7_ex - Converts the given unsigned char buffer of size len
+* into a PKCS7 object.  Optionally, accepts a byte buffer of content which
+* is stored as the PKCS7 object's content, to support detached signatures.
+* @param content The content which is signed, in case the signature is
+*                detached.  Ignored if NULL.
+* @param contentSz The size of the passed in content.
+*
+* RETURNS:
+* returns pointer to a PKCS7 structure on success, otherwise returns NULL
+*/
+PKCS7* wolfSSL_d2i_PKCS7_ex(PKCS7** p7, const unsigned char** in, int len,
+        byte* content, word32 contentSz)
+{
+    WOLFSSL_PKCS7* pkcs7 = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_d2i_PKCS7_ex");
+
+    if (in == NULL || *in == NULL || len < 0)
+        return NULL;
+
+    pkcs7 = (WOLFSSL_PKCS7*)wolfSSL_d2i_PKCS7_only(p7, in, len, content,
+            contentSz);
+    if (pkcs7 != NULL) {
+        if (wc_PKCS7_VerifySignedData(&pkcs7->pkcs7, pkcs7->data, pkcs7->len)
+                                                                         != 0) {
+            WOLFSSL_MSG("wc_PKCS7_VerifySignedData failed");
+            wolfSSL_PKCS7_free((PKCS7*)pkcs7);
+            if (p7 != NULL) {
+                *p7 = NULL;
+            }
+            return NULL;
+        }
+    }
+
+    return (PKCS7*)pkcs7;
+}
+
+
+/**
+ * This API was added as a helper function for libest. It
+ * extracts a stack of certificates from the pkcs7 object.
+ * @param pkcs7 PKCS7 parameter object
+ * @return WOLFSSL_STACK_OF(WOLFSSL_X509)*
+ */
+WOLFSSL_STACK* wolfSSL_PKCS7_to_stack(PKCS7* pkcs7)
+{
+    int i;
+    WOLFSSL_PKCS7* p7 = (WOLFSSL_PKCS7*)pkcs7;
+    WOLF_STACK_OF(WOLFSSL_X509)* ret = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_PKCS7_to_stack");
+
+    if (!p7) {
+        WOLFSSL_MSG("Bad parameter");
+        return NULL;
+    }
+
+    if (p7->certs)
+        return p7->certs;
+
+    for (i = 0; i < MAX_PKCS7_CERTS && p7->pkcs7.cert[i]; i++) {
+        WOLFSSL_X509* x509 = wolfSSL_X509_d2i_ex(NULL, p7->pkcs7.cert[i],
+            p7->pkcs7.certSz[i], pkcs7->heap);
+        if (!ret)
+            ret = wolfSSL_sk_X509_new_null();
+        if (x509) {
+            if (wolfSSL_sk_X509_push(ret, x509) != WOLFSSL_SUCCESS) {
+                wolfSSL_X509_free(x509);
+                WOLFSSL_MSG("wolfSSL_sk_X509_push error");
+                goto error;
+            }
+        }
+        else {
+            WOLFSSL_MSG("wolfSSL_X509_d2i error");
+            goto error;
+        }
+    }
+
+    /* Save stack to free later */
+    if (p7->certs)
+        wolfSSL_sk_pop_free(p7->certs, NULL);
+    p7->certs = ret;
+
+    return ret;
+error:
+    if (ret) {
+        wolfSSL_sk_pop_free(ret, NULL);
+    }
+    return NULL;
+}
+
+/**
+ * Return stack of signers contained in PKCS7 cert.
+ * Notes:
+ * - Currently only PKCS#7 messages with a single signer cert is supported.
+ * - Returned WOLFSSL_STACK must be freed by caller.
+ *
+ * pkcs7 - PKCS7 struct to retrieve signer certs from.
+ * certs - currently unused
+ * flags - flags to control function behavior.
+ *
+ * Return WOLFSSL_STACK of signers on success, NULL on error.
+ */
+WOLFSSL_STACK* wolfSSL_PKCS7_get0_signers(PKCS7* pkcs7, WOLFSSL_STACK* certs,
+                                          int flags)
+{
+    WOLFSSL_X509* x509 = NULL;
+    WOLFSSL_STACK* signers = NULL;
+    WOLFSSL_PKCS7* p7 = (WOLFSSL_PKCS7*)pkcs7;
+
+    if (p7 == NULL)
+        return NULL;
+
+    /* Only PKCS#7 messages with a single cert that is the verifying certificate
+     * is supported.
+     */
+    if (flags & PKCS7_NOINTERN) {
+        WOLFSSL_MSG("PKCS7_NOINTERN flag not supported");
+        return NULL;
+    }
+
+    signers = wolfSSL_sk_X509_new_null();
+    if (signers == NULL)
+        return NULL;
+
+    if (wolfSSL_d2i_X509(&x509, (const byte**)&p7->pkcs7.singleCert,
+                         p7->pkcs7.singleCertSz) == NULL) {
+        wolfSSL_sk_X509_pop_free(signers, NULL);
+        return NULL;
+    }
+
+    if (wolfSSL_sk_X509_push(signers, x509) != WOLFSSL_SUCCESS) {
+        wolfSSL_sk_X509_pop_free(signers, NULL);
+        return NULL;
+    }
+
+    (void)certs;
+
+    return signers;
+}
+
+#ifndef NO_BIO
+
+PKCS7* wolfSSL_d2i_PKCS7_bio(WOLFSSL_BIO* bio, PKCS7** p7)
+{
+    WOLFSSL_PKCS7* pkcs7;
+    int ret;
+
+    WOLFSSL_ENTER("wolfSSL_d2i_PKCS7_bio");
+
+    if (bio == NULL)
+        return NULL;
+
+    if ((pkcs7 = (WOLFSSL_PKCS7*)wolfSSL_PKCS7_new()) == NULL)
+        return NULL;
+
+    pkcs7->len = wolfSSL_BIO_get_len(bio);
+    pkcs7->data = (byte*)XMALLOC(pkcs7->len, NULL, DYNAMIC_TYPE_PKCS7);
+    if (pkcs7->data == NULL) {
+        wolfSSL_PKCS7_free((PKCS7*)pkcs7);
+        return NULL;
+    }
+
+    if ((ret = wolfSSL_BIO_read(bio, pkcs7->data, pkcs7->len)) <= 0) {
+        wolfSSL_PKCS7_free((PKCS7*)pkcs7);
+        return NULL;
+    }
+    /* pkcs7->len may change if using b64 for example */
+    pkcs7->len = ret;
+
+    if (wc_PKCS7_VerifySignedData(&pkcs7->pkcs7, pkcs7->data, pkcs7->len)
+                                                                         != 0) {
+        WOLFSSL_MSG("wc_PKCS7_VerifySignedData failed");
+        wolfSSL_PKCS7_free((PKCS7*)pkcs7);
+        return NULL;
+    }
+
+    if (p7 != NULL)
+        *p7 = (PKCS7*)pkcs7;
+    return (PKCS7*)pkcs7;
+}
+
+int wolfSSL_i2d_PKCS7(PKCS7 *p7, unsigned char **out)
+{
+    byte* output = NULL;
+    int localBuf = 0;
+    int len;
+    WC_RNG rng;
+    int ret = WOLFSSL_FAILURE;
+    WOLFSSL_ENTER("wolfSSL_i2d_PKCS7");
+
+    if (!out || !p7) {
+        WOLFSSL_MSG("Bad parameter");
+        return WOLFSSL_FAILURE;
+    }
+
+    if (!p7->rng) {
+        if (wc_InitRng(&rng) != 0) {
+            WOLFSSL_MSG("wc_InitRng error");
+            return WOLFSSL_FAILURE;
+        }
+        p7->rng = &rng; /* cppcheck-suppress autoVariables
+                         */
+    }
+
+    if ((len = wc_PKCS7_EncodeSignedData(p7, NULL, 0)) < 0) {
+        WOLFSSL_MSG("wc_PKCS7_EncodeSignedData error");
+        goto cleanup;
+    }
+
+    if (*out == NULL) {
+        output = (byte*)XMALLOC(len, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+        if (!output) {
+            WOLFSSL_MSG("malloc error");
+            goto cleanup;
+        }
+        localBuf = 1;
+    }
+    else {
+        output = *out;
+    }
+
+    if ((len = wc_PKCS7_EncodeSignedData(p7, output, (word32)len)) < 0) {
+        WOLFSSL_MSG("wc_PKCS7_EncodeSignedData error");
+        goto cleanup;
+    }
+
+    ret = len;
+cleanup:
+    if (p7->rng == &rng) {
+        wc_FreeRng(&rng);
+        p7->rng = NULL;
+    }
+    if (ret == WOLFSSL_FAILURE && localBuf && output)
+        XFREE(output, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    if (ret != WOLFSSL_FAILURE)
+        *out = output;
+    return ret;
+}
+
+int wolfSSL_i2d_PKCS7_bio(WOLFSSL_BIO *bio, PKCS7 *p7)
+{
+    byte* output = NULL;
+    int len;
+    int ret = WOLFSSL_FAILURE;
+    WOLFSSL_ENTER("wolfSSL_i2d_PKCS7_bio");
+
+    if (!bio || !p7) {
+        WOLFSSL_MSG("Bad parameter");
+        return WOLFSSL_FAILURE;
+    }
+
+    if ((len = wolfSSL_i2d_PKCS7(p7, &output)) == WOLFSSL_FAILURE) {
+        WOLFSSL_MSG("wolfSSL_i2d_PKCS7 error");
+        goto cleanup;
+    }
+
+    if (wolfSSL_BIO_write(bio, output, len) <= 0) {
+        WOLFSSL_MSG("wolfSSL_BIO_write error");
+        goto cleanup;
+    }
+
+    ret = WOLFSSL_SUCCESS;
+cleanup:
+    if (output)
+        XFREE(output, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    return ret;
+}
+
+/**
+ * Creates and returns a PKCS7 signedData structure.
+ *
+ * Inner content type is set to DATA to match OpenSSL behavior.
+ *
+ * signer   - certificate to sign bundle with
+ * pkey     - private key matching signer
+ * certs    - optional additional set of certificates to include
+ * in       - input data to be signed
+ * flags    - optional set of flags to control sign behavior
+ *
+ *    PKCS7_BINARY   - Do not translate input data to MIME canonical
+ *                     format (\r\n line endings), thus preventing corruption of
+ *                     binary content.
+ *    PKCS7_TEXT     - Prepend MIME headers for text/plain to content.
+ *    PKCS7_DETACHED - Set signature detached, omit content from output bundle.
+ *    PKCS7_STREAM   - initialize PKCS7 struct for signing, do not read data.
+ *
+ * Flags not currently supported:
+ *    PKCS7_NOCERTS  - Do not include the signer cert in the output bundle.
+ *    PKCS7_PARTIAL  - Allow for PKCS7_sign() to be only partially set up,
+ *                     then signers etc to be added separately before
+ *                     calling PKCS7_final().
+ *
+ * Returns valid PKCS7 structure pointer, or NULL if an error occurred.
+ */
+PKCS7* wolfSSL_PKCS7_sign(WOLFSSL_X509* signer, WOLFSSL_EVP_PKEY* pkey,
+        WOLFSSL_STACK* certs, WOLFSSL_BIO* in, int flags)
+{
+    int err = 0;
+    WOLFSSL_PKCS7* p7 = NULL;
+    WOLFSSL_STACK* cert = certs;
+
+    WOLFSSL_ENTER("wolfSSL_PKCS7_sign");
+
+    if (flags & PKCS7_NOCERTS) {
+        WOLFSSL_MSG("PKCS7_NOCERTS flag not yet supported");
+        err = 1;
+    }
+
+    if (flags & PKCS7_PARTIAL) {
+        WOLFSSL_MSG("PKCS7_PARTIAL flag not yet supported");
+        err = 1;
+    }
+
+    if ((err == 0) && (signer == NULL || signer->derCert == NULL ||
+                       signer->derCert->length == 0)) {
+        WOLFSSL_MSG("Bad function arg, signer is NULL or incomplete");
+        err = 1;
+    }
+
+    if ((err == 0) && (pkey == NULL || pkey->pkey.ptr == NULL ||
+                       pkey->pkey_sz <= 0)) {
+        WOLFSSL_MSG("Bad function arg, pkey is NULL or incomplete");
+        err = 1;
+    }
+
+    if ((err == 0) && (in == NULL) && !(flags & PKCS7_STREAM)) {
+        WOLFSSL_MSG("input data required unless PKCS7_STREAM used");
+        err = 1;
+    }
+
+    if ((err == 0) && ((p7 = (WOLFSSL_PKCS7*)wolfSSL_PKCS7_new()) == NULL)) {
+        WOLFSSL_MSG("Error allocating new WOLFSSL_PKCS7");
+        err = 1;
+    }
+
+    /* load signer certificate */
+    if (err == 0) {
+        if (wc_PKCS7_InitWithCert(&p7->pkcs7, signer->derCert->buffer,
+                                  signer->derCert->length) != 0) {
+            WOLFSSL_MSG("Failed to load signer certificate");
+            err = 1;
+        }
+    }
+
+    /* set signer private key, data types, defaults */
+    if (err == 0) {
+        p7->pkcs7.privateKey = (byte*)pkey->pkey.ptr;
+        p7->pkcs7.privateKeySz = (word32)pkey->pkey_sz;
+        p7->pkcs7.contentOID = DATA;  /* inner content default is DATA */
+        p7->pkcs7.hashOID = SHA256h;  /* default to SHA-256 hash type */
+        p7->type = SIGNED_DATA;       /* PKCS7_final switches on type */
+    }
+
+    /* add additional chain certs if provided */
+    while (cert && (err == 0)) {
+        if (cert->data.x509 != NULL && cert->data.x509->derCert != NULL) {
+            if (wc_PKCS7_AddCertificate(&p7->pkcs7,
+                                cert->data.x509->derCert->buffer,
+                                cert->data.x509->derCert->length) != 0) {
+                WOLFSSL_MSG("Error in wc_PKCS7_AddCertificate");
+                err = 1;
+            }
+        }
+        cert = cert->next;
+    }
+
+    if ((err == 0) && (flags & PKCS7_DETACHED)) {
+        if (wc_PKCS7_SetDetached(&p7->pkcs7, 1) != 0) {
+            WOLFSSL_MSG("Failed to set signature detached");
+            err = 1;
+        }
+    }
+
+    if ((err == 0) && (flags & PKCS7_STREAM)) {
+        /* if streaming, return before finalizing */
+        return (PKCS7*)p7;
+    }
+
+    if ((err == 0) && (wolfSSL_PKCS7_final((PKCS7*)p7, in, flags) != 1)) {
+        WOLFSSL_MSG("Error calling wolfSSL_PKCS7_final");
+        err = 1;
+    }
+
+    if ((err != 0) && (p7 != NULL)) {
+        wolfSSL_PKCS7_free((PKCS7*)p7);
+        p7 = NULL;
+    }
+
+    return (PKCS7*)p7;
+}
+
+#ifdef HAVE_SMIME
+
+#ifndef MAX_MIME_LINE_LEN
+    #define MAX_MIME_LINE_LEN 1024
+#endif
+
+/**
+ * Copy input BIO to output BIO, but convert all line endings to CRLF (\r\n),
+ * used by PKCS7_final().
+ *
+ * in  - input WOLFSSL_BIO to be converted
+ * out - output WOLFSSL_BIO to hold copy of in, with line endings adjusted
+ *
+ * Return 0 on success, negative on error
+ */
+static int wolfSSL_BIO_to_MIME_crlf(WOLFSSL_BIO* in, WOLFSSL_BIO* out)
+{
+    int ret = 0;
+    int lineLen = 0;
+    word32 canonLineLen = 0;
+    char* canonLine = NULL;
+#ifdef WOLFSSL_SMALL_STACK
+    char* line = NULL;
+#else
+    char line[MAX_MIME_LINE_LEN];
+#endif
+
+    if (in == NULL || out == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    line = (char*)XMALLOC(MAX_MIME_LINE_LEN, in->heap,
+                          DYNAMIC_TYPE_TMP_BUFFER);
+    if (line == NULL) {
+        return MEMORY_E;
+    }
+#endif
+    XMEMSET(line, 0, MAX_MIME_LINE_LEN);
+
+    while ((lineLen = wolfSSL_BIO_gets(in, line, MAX_MIME_LINE_LEN)) > 0) {
+
+        if (line[lineLen - 1] == '\r' || line[lineLen - 1] == '\n') {
+            canonLineLen = (word32)lineLen;
+            if ((canonLine = wc_MIME_single_canonicalize(
+                                line, &canonLineLen)) == NULL) {
+                ret = -1;
+                break;
+            }
+
+            /* remove trailing null */
+            if (canonLineLen >= 1 && canonLine[canonLineLen-1] == '\0') {
+                canonLineLen--;
+            }
+
+            if (wolfSSL_BIO_write(out, canonLine, (int)canonLineLen) < 0) {
+                ret = -1;
+                break;
+            }
+            XFREE(canonLine, NULL, DYNAMIC_TYPE_PKCS7);
+            canonLine = NULL;
+        }
+        else {
+            /* no line ending in current line, write direct to out */
+            if (wolfSSL_BIO_write(out, line, lineLen) < 0) {
+                ret = -1;
+                break;
+            }
+        }
+    }
+
+    if (canonLine != NULL) {
+        XFREE(canonLine, NULL, DYNAMIC_TYPE_PKCS7);
+    }
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(line, in->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+
+    return ret;
+}
+
+#endif /* HAVE_SMIME */
+
+/* Used by both PKCS7_final() and PKCS7_verify() */
+static const char contTypeText[] = "Content-Type: text/plain\r\n\r\n";
+
+/**
+ * Finalize PKCS7 structure, currently supports signedData only.
+ *
+ * Does not generate final bundle (ie: signedData), but finalizes
+ * the PKCS7 structure in preparation for a output function to be called next.
+ *
+ * pkcs7 - initialized PKCS7 structure, populated with signer, etc
+ * in    - input data
+ * flags - flags to control PKCS7 behavior. Other flags except those noted
+ *         below are ignored:
+ *
+ *    PKCS7_BINARY - Do not translate input data to MIME canonical
+ *                   format (\r\n line endings), thus preventing corruption of
+ *                   binary content.
+ *    PKCS7_TEXT   - Prepend MIME headers for text/plain to content.
+ *
+ * Returns 1 on success, 0 on error
+ */
+int wolfSSL_PKCS7_final(PKCS7* pkcs7, WOLFSSL_BIO* in, int flags)
+{
+    int ret = 1;
+    int memSz = 0;
+    unsigned char* mem = NULL;
+    WOLFSSL_PKCS7* p7 = (WOLFSSL_PKCS7*)pkcs7;
+    WOLFSSL_BIO* data = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_PKCS7_final");
+
+    if (p7 == NULL || in == NULL) {
+        WOLFSSL_MSG("Bad input args to PKCS7_final");
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        if ((data = wolfSSL_BIO_new(wolfSSL_BIO_s_mem())) == NULL) {
+            WOLFSSL_MSG("Error in wolfSSL_BIO_new");
+            ret = 0;
+        }
+    }
+
+    /* prepend Content-Type header if PKCS7_TEXT */
+    if ((ret == 1) && (flags & PKCS7_TEXT)) {
+        if (wolfSSL_BIO_write(data, contTypeText,
+                              (int)XSTR_SIZEOF(contTypeText)) < 0) {
+            WOLFSSL_MSG("Error prepending Content-Type header");
+            ret = 0;
+        }
+    }
+
+    /* convert line endings to CRLF if !PKCS7_BINARY */
+    if (ret == 1) {
+        if (flags & PKCS7_BINARY) {
+
+            /* no CRLF conversion, direct copy content */
+            if ((memSz = wolfSSL_BIO_get_len(in)) <= 0) {
+                ret = 0;
+            }
+            if (ret == 1) {
+                mem = (unsigned char*)XMALLOC(memSz, in->heap,
+                                              DYNAMIC_TYPE_TMP_BUFFER);
+                if (mem == NULL) {
+                    WOLFSSL_MSG("Failed to allocate memory for input data");
+                    ret = 0;
+                }
+            }
+
+            if (ret == 1) {
+                if (wolfSSL_BIO_read(in, mem, memSz) != memSz) {
+                    WOLFSSL_MSG("Error reading from input BIO");
+                    ret = 0;
+                }
+                else if (wolfSSL_BIO_write(data, mem, memSz) < 0) {
+                    ret = 0;
+                }
+            }
+
+            if (mem != NULL) {
+                XFREE(mem, in->heap, DYNAMIC_TYPE_TMP_BUFFER);
+            }
+        }
+        else {
+    #ifdef HAVE_SMIME
+            /* convert content line endings to CRLF */
+            if (wolfSSL_BIO_to_MIME_crlf(in, data) != 0) {
+                WOLFSSL_MSG("Error converting line endings to CRLF");
+                ret = 0;
+            }
+            else {
+                p7->pkcs7.contentCRLF = 1;
+            }
+    #else
+            WOLFSSL_MSG("Without PKCS7_BINARY requires wolfSSL to be built "
+                        "with HAVE_SMIME");
+            ret = 0;
+    #endif
+        }
+    }
+
+    if ((ret == 1) && ((memSz = wolfSSL_BIO_get_mem_data(data, &mem)) < 0)) {
+        WOLFSSL_MSG("Error in wolfSSL_BIO_get_mem_data");
+        ret = 0;
+    }
+
+    if (ret == 1) {
+        if (p7->data != NULL) {
+            XFREE(p7->data, NULL, DYNAMIC_TYPE_PKCS7);
+        }
+        p7->data = (byte*)XMALLOC(memSz, NULL, DYNAMIC_TYPE_PKCS7);
+        if (p7->data == NULL) {
+            ret = 0;
+        }
+        else {
+            XMEMCPY(p7->data, mem, memSz);
+            p7->len = memSz;
+        }
+    }
+
+    if (ret == 1) {
+        p7->pkcs7.content = p7->data;
+        p7->pkcs7.contentSz = (word32)p7->len;
+    }
+
+    if (data != NULL) {
+        wolfSSL_BIO_free(data);
+    }
+
+    return ret;
+}
+
+int wolfSSL_PKCS7_verify(PKCS7* pkcs7, WOLFSSL_STACK* certs,
+        WOLFSSL_X509_STORE* store, WOLFSSL_BIO* in, WOLFSSL_BIO* out, int flags)
+{
+    int i, ret = 0;
+    unsigned char* mem = NULL;
+    int memSz = 0;
+    WOLFSSL_PKCS7* p7 = (WOLFSSL_PKCS7*)pkcs7;
+    int contTypeLen;
+    WOLFSSL_X509* signer = NULL;
+    WOLFSSL_STACK* signers = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_PKCS7_verify");
+
+    if (pkcs7 == NULL)
+        return WOLFSSL_FAILURE;
+
+    if (in != NULL) {
+        if ((memSz = wolfSSL_BIO_get_mem_data(in, &mem)) < 0)
+            return WOLFSSL_FAILURE;
+
+        p7->pkcs7.content = mem;
+        p7->pkcs7.contentSz = (word32)memSz;
+    }
+
+    /* certs is the list of certificates to find the cert with issuer/serial. */
+    (void)certs;
+    /* store is the certificate store to use to verify signer certificate
+     * associated with the signers.
+     */
+    (void)store;
+
+    ret = wc_PKCS7_VerifySignedData(&p7->pkcs7, p7->data, p7->len);
+    if (ret != 0)
+        return WOLFSSL_FAILURE;
+
+    if ((flags & PKCS7_NOVERIFY) != PKCS7_NOVERIFY) {
+        /* Verify signer certificates */
+        if (store == NULL || store->cm == NULL) {
+            WOLFSSL_MSG("No store or store certs, but PKCS7_NOVERIFY not set");
+            return WOLFSSL_FAILURE;
+        }
+
+        signers = wolfSSL_PKCS7_get0_signers(pkcs7, certs, flags);
+        if (signers == NULL) {
+            WOLFSSL_MSG("No signers found to verify");
+            return WOLFSSL_FAILURE;
+        }
+        for (i = 0; i < wolfSSL_sk_X509_num(signers); i++) {
+            signer = wolfSSL_sk_X509_value(signers, i);
+
+            if (wolfSSL_CertManagerVerifyBuffer(store->cm,
+                        signer->derCert->buffer,
+                        signer->derCert->length,
+                        WOLFSSL_FILETYPE_ASN1) != WOLFSSL_SUCCESS) {
+                WOLFSSL_MSG("Failed to verify signer certificate");
+                wolfSSL_sk_X509_pop_free(signers, NULL);
+                return WOLFSSL_FAILURE;
+            }
+        }
+        wolfSSL_sk_X509_pop_free(signers, NULL);
+    }
+
+    if (flags & PKCS7_TEXT) {
+        /* strip MIME header for text/plain, otherwise error */
+        contTypeLen = XSTR_SIZEOF(contTypeText);
+        if ((p7->pkcs7.contentSz < (word32)contTypeLen) ||
+            (XMEMCMP(p7->pkcs7.content, contTypeText, contTypeLen) != 0)) {
+            WOLFSSL_MSG("Error PKCS7 Content-Type not found with PKCS7_TEXT");
+            return WOLFSSL_FAILURE;
+        }
+        p7->pkcs7.content += contTypeLen;
+        p7->pkcs7.contentSz -= contTypeLen;
+    }
+
+    if (out != NULL) {
+        wolfSSL_BIO_write(out, p7->pkcs7.content, p7->pkcs7.contentSz);
+    }
+
+    WOLFSSL_LEAVE("wolfSSL_PKCS7_verify", WOLFSSL_SUCCESS);
+
+    return WOLFSSL_SUCCESS;
+}
+
+/**
+ * This API was added as a helper function for libest. It
+ * encodes a stack of certificates to pkcs7 format.
+ * @param pkcs7 PKCS7 parameter object
+ * @param certs WOLFSSL_STACK_OF(WOLFSSL_X509)*
+ * @param out   Output bio
+ * @return WOLFSSL_SUCCESS on success and WOLFSSL_FAILURE on failure
+ */
+int wolfSSL_PKCS7_encode_certs(PKCS7* pkcs7, WOLFSSL_STACK* certs,
+        WOLFSSL_BIO* out)
+{
+    int ret;
+    WOLFSSL_PKCS7* p7;
+    WOLFSSL_ENTER("wolfSSL_PKCS7_encode_certs");
+
+    if (!pkcs7 || !certs || !out) {
+        WOLFSSL_MSG("Bad parameter");
+        return WOLFSSL_FAILURE;
+    }
+
+    p7 = (WOLFSSL_PKCS7*)pkcs7;
+
+    /* take ownership of certs */
+    p7->certs = certs;
+    /* TODO: takes ownership even on failure below but not on above failure. */
+
+    if (pkcs7->certList) {
+        WOLFSSL_MSG("wolfSSL_PKCS7_encode_certs called multiple times on same "
+                    "struct");
+        return WOLFSSL_FAILURE;
+    }
+
+    if (certs) {
+        /* Save some of the values */
+        int hashOID = pkcs7->hashOID;
+        byte version = pkcs7->version;
+
+        if (!certs->data.x509 || !certs->data.x509->derCert) {
+            WOLFSSL_MSG("Missing cert");
+            return WOLFSSL_FAILURE;
+        }
+
+        if (wc_PKCS7_InitWithCert(pkcs7, certs->data.x509->derCert->buffer,
+                                      certs->data.x509->derCert->length) != 0) {
+            WOLFSSL_MSG("wc_PKCS7_InitWithCert error");
+            return WOLFSSL_FAILURE;
+        }
+        certs = certs->next;
+
+        pkcs7->hashOID = hashOID;
+        pkcs7->version = version;
+    }
+
+    /* Add the certs to the PKCS7 struct */
+    while (certs) {
+        if (!certs->data.x509 || !certs->data.x509->derCert) {
+            WOLFSSL_MSG("Missing cert");
+            return WOLFSSL_FAILURE;
+        }
+        if (wc_PKCS7_AddCertificate(pkcs7, certs->data.x509->derCert->buffer,
+                                      certs->data.x509->derCert->length) != 0) {
+            WOLFSSL_MSG("wc_PKCS7_AddCertificate error");
+            return WOLFSSL_FAILURE;
+        }
+        certs = certs->next;
+    }
+
+    if (wc_PKCS7_SetSignerIdentifierType(pkcs7, DEGENERATE_SID) != 0) {
+        WOLFSSL_MSG("wc_PKCS7_SetSignerIdentifierType error");
+        return WOLFSSL_FAILURE;
+    }
+
+    ret = wolfSSL_i2d_PKCS7_bio(out, pkcs7);
+
+    return ret;
+}
+
+/******************************************************************************
+* wolfSSL_PEM_write_bio_PKCS7 - writes the PKCS7 data to BIO
+*
+* RETURNS:
+* returns WOLFSSL_SUCCESS on success, otherwise returns WOLFSSL_FAILURE
+*/
+int wolfSSL_PEM_write_bio_PKCS7(WOLFSSL_BIO* bio, PKCS7* p7)
+{
+#ifdef WOLFSSL_SMALL_STACK
+    byte* outputHead;
+    byte* outputFoot;
+#else
+    byte outputHead[2048];
+    byte outputFoot[2048];
+#endif
+    word32 outputHeadSz = 2048;
+    word32 outputFootSz = 2048;
+    word32 outputSz = 0;
+    byte*  output = NULL;
+    byte*  pem = NULL;
+    int    pemSz = -1;
+    enum wc_HashType hashType;
+    byte hashBuf[WC_MAX_DIGEST_SIZE];
+    word32 hashSz = -1;
+
+    WOLFSSL_ENTER("wolfSSL_PEM_write_bio_PKCS7");
+
+    if (bio == NULL || p7 == NULL)
+        return WOLFSSL_FAILURE;
+
+#ifdef WOLFSSL_SMALL_STACK
+    outputHead = (byte*)XMALLOC(outputHeadSz, bio->heap,
+        DYNAMIC_TYPE_TMP_BUFFER);
+    if (outputHead == NULL)
+        return MEMORY_E;
+
+    outputFoot = (byte*)XMALLOC(outputFootSz, bio->heap,
+        DYNAMIC_TYPE_TMP_BUFFER);
+    if (outputFoot == NULL)
+        goto error;
+
+#endif
+
+    XMEMSET(hashBuf, 0, WC_MAX_DIGEST_SIZE);
+    XMEMSET(outputHead, 0, outputHeadSz);
+    XMEMSET(outputFoot, 0, outputFootSz);
+
+    hashType = wc_OidGetHash(p7->hashOID);
+    hashSz = (word32)wc_HashGetDigestSize(hashType);
+    if (hashSz > WC_MAX_DIGEST_SIZE)
+        goto error;
+
+    /* only SIGNED_DATA is supported */
+    switch (p7->contentOID) {
+        case SIGNED_DATA:
+            break;
+        default:
+            WOLFSSL_MSG("Unknown PKCS#7 Type");
+            goto error;
+    };
+
+    if ((wc_PKCS7_EncodeSignedData_ex(p7, hashBuf, hashSz,
+        outputHead, &outputHeadSz, outputFoot, &outputFootSz)) != 0)
+        goto error;
+
+    outputSz = outputHeadSz + p7->contentSz + outputFootSz;
+    output = (byte*)XMALLOC(outputSz, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+
+    if (!output)
+        goto error;
+
+    XMEMSET(output, 0, outputSz);
+    outputSz = 0;
+    XMEMCPY(&output[outputSz], outputHead, outputHeadSz);
+    outputSz += outputHeadSz;
+    XMEMCPY(&output[outputSz], p7->content, p7->contentSz);
+    outputSz += p7->contentSz;
+    XMEMCPY(&output[outputSz], outputFoot, outputFootSz);
+    outputSz += outputFootSz;
+
+    /* get PEM size */
+    pemSz = wc_DerToPemEx(output, outputSz, NULL, 0, NULL, CERT_TYPE);
+    if (pemSz < 0)
+        goto error;
+
+    pemSz++; /* for '\0'*/
+
+    /* create PEM buffer and convert from DER to PEM*/
+    if ((pem = (byte*)XMALLOC(pemSz, bio->heap, DYNAMIC_TYPE_TMP_BUFFER))
+                                                                        == NULL)
+        goto error;
+
+    XMEMSET(pem, 0, pemSz);
+
+    if (wc_DerToPemEx(output, outputSz, pem, (word32)pemSz, NULL, CERT_TYPE) < 0) {
+        goto error;
+    }
+    if ((wolfSSL_BIO_write(bio, pem, pemSz) == pemSz)) {
+        XFREE(output, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(pem, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#ifdef WOLFSSL_SMALL_STACK
+        XFREE(outputHead, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        XFREE(outputFoot, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+        return WOLFSSL_SUCCESS;
+    }
+
+error:
+#ifdef WOLFSSL_SMALL_STACK
+    if (outputHead) {
+        XFREE(outputHead, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (outputFoot) {
+        XFREE(outputFoot, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+#endif
+    if (output) {
+        XFREE(output, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (pem) {
+        XFREE(pem, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    return WOLFSSL_FAILURE;
+}
+
+#ifdef HAVE_SMIME
+/*****************************************************************************
+* wolfSSL_SMIME_read_PKCS7 - Reads the given S/MIME message and parses it into
+* a PKCS7 object. In case of a multipart message, stores the signed data in
+* bcont.
+*
+* RETURNS:
+* returns pointer to a PKCS7 structure on success, otherwise returns NULL
+*/
+PKCS7* wolfSSL_SMIME_read_PKCS7(WOLFSSL_BIO* in,
+        WOLFSSL_BIO** bcont)
+{
+    MimeHdr* allHdrs = NULL;
+    MimeHdr* curHdr = NULL;
+    MimeParam* curParam = NULL;
+    int inLen = 0;
+    byte* bcontMem = NULL;
+    int bcontMemSz = 0;
+    int sectionLen = 0;
+    int ret = -1;
+    char* section = NULL;
+    char* canonLine = NULL;
+    char* canonSection = NULL;
+    PKCS7* pkcs7 = NULL;
+    word32 outLen = 0;
+    word32 canonLineLen = 0;
+    byte* out = NULL;
+    byte* outHead = NULL;
+
+    int canonPos = 0;
+    int lineLen = 0;
+    int remainLen = 0;
+    byte isEnd = 0;
+    size_t canonSize = 0;
+    size_t boundLen = 0;
+    char* boundary = NULL;
+
+    static const char kContType[] = "Content-Type";
+    static const char kCTE[] = "Content-Transfer-Encoding";
+    static const char kMultSigned[] = "multipart/signed";
+    static const char kAppPkcsSign[] = "application/pkcs7-signature";
+    static const char kAppXPkcsSign[] = "application/x-pkcs7-signature";
+    static const char kAppPkcs7Mime[] = "application/pkcs7-mime";
+    static const char kAppXPkcs7Mime[] = "application/x-pkcs7-mime";
+
+    WOLFSSL_ENTER("wolfSSL_SMIME_read_PKCS7");
+
+    if (in == NULL || bcont == NULL) {
+        goto error;
+    }
+    inLen = wolfSSL_BIO_get_len(in);
+    if (inLen <= 0) {
+        goto error;
+    }
+    remainLen = wolfSSL_BIO_get_len(in);
+    if (remainLen <= 0) {
+        goto error;
+    }
+
+    section = (char*)XMALLOC(remainLen+1, NULL, DYNAMIC_TYPE_PKCS7);
+    if (section == NULL) {
+        goto error;
+    }
+    lineLen = wolfSSL_BIO_gets(in, section, remainLen);
+    if (lineLen <= 0) {
+        goto error;
+    }
+    while (isEnd == 0 && remainLen > 0) {
+        sectionLen += lineLen;
+        remainLen -= lineLen;
+        lineLen = wolfSSL_BIO_gets(in, &section[sectionLen], remainLen);
+        if (lineLen <= 0) {
+            goto error;
+        }
+        /* Line with just newline signals end of headers. */
+        if ((lineLen==2 && !XSTRNCMP(&section[sectionLen],
+                                     "\r\n", 2)) ||
+            (lineLen==1 && (section[sectionLen] == '\r' ||
+                            section[sectionLen] == '\n'))) {
+            isEnd = 1;
+        }
+    }
+    section[sectionLen] = '\0';
+    ret = wc_MIME_parse_headers(section, sectionLen, &allHdrs);
+    if (ret < 0) {
+        WOLFSSL_MSG("Parsing MIME headers failed.");
+        goto error;
+    }
+    isEnd = 0;
+    section[0] = '\0';
+    sectionLen = 0;
+
+    curHdr = wc_MIME_find_header_name(kContType, allHdrs);
+    if (curHdr && !XSTRNCMP(curHdr->body, kMultSigned,
+                            XSTR_SIZEOF(kMultSigned))) {
+        curParam = wc_MIME_find_param_attr("protocol", curHdr->params);
+        if (curParam && (!XSTRNCMP(curParam->value, kAppPkcsSign,
+                                   XSTR_SIZEOF(kAppPkcsSign)) ||
+                         !XSTRNCMP(curParam->value, kAppXPkcsSign,
+                                   XSTR_SIZEOF(kAppXPkcsSign)))) {
+            curParam = wc_MIME_find_param_attr("boundary", curHdr->params);
+            if (curParam == NULL) {
+                goto error;
+            }
+
+            boundLen = XSTRLEN(curParam->value) + 2;
+            boundary = (char*)XMALLOC(boundLen+1, NULL, DYNAMIC_TYPE_PKCS7);
+            if (boundary == NULL) {
+                goto error;
+            }
+            XMEMSET(boundary, 0, (word32)(boundLen+1));
+            boundary[0] = boundary[1] = '-';
+            XSTRNCPY(&boundary[2], curParam->value, boundLen-2);
+
+            /* Parse up to first boundary, ignore everything here. */
+            lineLen = wolfSSL_BIO_gets(in, section, remainLen);
+            if (lineLen <= 0) {
+                goto error;
+            }
+            while (XSTRNCMP(&section[sectionLen], boundary, boundLen) &&
+                   remainLen > 0) {
+                sectionLen += lineLen;
+                remainLen -= lineLen;
+                lineLen = wolfSSL_BIO_gets(in, &section[sectionLen],
+                                           remainLen);
+                if (lineLen <= 0) {
+                    goto error;
+                }
+            }
+
+            section[0] = '\0';
+            sectionLen = 0;
+            canonSize = (size_t)remainLen + 1;
+            canonSection = (char*)XMALLOC(canonSize, NULL,
+                                          DYNAMIC_TYPE_PKCS7);
+            if (canonSection == NULL) {
+                goto error;
+            }
+
+            lineLen = wolfSSL_BIO_gets(in, section, remainLen);
+            if (lineLen < 0) {
+                goto error;
+            }
+            while (XSTRNCMP(&section[sectionLen], boundary, boundLen) &&
+                            remainLen > 0) {
+                canonLineLen = (word32)lineLen;
+                canonLine = wc_MIME_single_canonicalize(&section[sectionLen],
+                                                        &canonLineLen);
+                if (canonLine == NULL) {
+                    goto error;
+                }
+                /* If line endings were added, the initial length may be
+                 * exceeded. */
+                if ((canonPos + canonLineLen) >= canonSize) {
+                    canonSize = canonPos + canonLineLen;
+                    canonSection = (char*)XREALLOC(canonSection, canonSize,
+                                                   NULL, DYNAMIC_TYPE_PKCS7);
+                    if (canonSection == NULL) {
+                        goto error;
+                    }
+                }
+                XMEMCPY(&canonSection[canonPos], canonLine,
+                        (int)canonLineLen - 1);
+                canonPos += canonLineLen - 1;
+                XFREE(canonLine, NULL, DYNAMIC_TYPE_PKCS7);
+                canonLine = NULL;
+
+                sectionLen += lineLen;
+                remainLen -= lineLen;
+
+                lineLen = wolfSSL_BIO_gets(in, &section[sectionLen],
+                                           remainLen);
+                if (lineLen <= 0) {
+                    goto error;
+                }
+            }
+
+            if (canonPos > 0) {
+                canonPos--;
+            }
+
+            /* Strip the final trailing newline.  Support \r, \n or \r\n. */
+            if (canonSection[canonPos] == '\n') {
+                if (canonPos > 0) {
+                    canonPos--;
+                }
+            }
+
+            if (canonSection[canonPos] == '\r') {
+                if (canonPos > 0) {
+                    canonPos--;
+                }
+            }
+
+            canonSection[canonPos+1] = '\0';
+
+            *bcont = wolfSSL_BIO_new(wolfSSL_BIO_s_mem());
+            ret = wolfSSL_BIO_write(*bcont, canonSection,
+                                    canonPos + 1);
+            if (ret != (canonPos+1)) {
+                goto error;
+            }
+            if ((bcontMemSz = wolfSSL_BIO_get_mem_data(*bcont, &bcontMem))
+                                                                          < 0) {
+                goto error;
+            }
+            XFREE(canonSection, NULL, DYNAMIC_TYPE_PKCS7);
+            canonSection = NULL;
+
+            wc_MIME_free_hdrs(allHdrs);
+            allHdrs = NULL;
+            section[0] = '\0';
+            sectionLen = 0;
+            lineLen = wolfSSL_BIO_gets(in, section, remainLen);
+            if (lineLen <= 0) {
+                goto error;
+            }
+            while (isEnd == 0 && remainLen > 0) {
+                sectionLen += lineLen;
+                remainLen -= lineLen;
+                lineLen = wolfSSL_BIO_gets(in, &section[sectionLen],
+                                           remainLen);
+                if (lineLen <= 0) {
+                    goto error;
+                }
+                /* Line with just newline signals end of headers. */
+                if ((lineLen==2 && !XSTRNCMP(&section[sectionLen],
+                                             "\r\n", 2)) ||
+                    (lineLen==1 && (section[sectionLen] == '\r' ||
+                                    section[sectionLen] == '\n'))) {
+                    isEnd = 1;
+                }
+            }
+            section[sectionLen] = '\0';
+            ret = wc_MIME_parse_headers(section, sectionLen, &allHdrs);
+            if (ret < 0) {
+                WOLFSSL_MSG("Parsing MIME headers failed.");
+                goto error;
+            }
+            curHdr = wc_MIME_find_header_name(kContType, allHdrs);
+            if (curHdr == NULL || (XSTRNCMP(curHdr->body, kAppPkcsSign,
+                                   XSTR_SIZEOF(kAppPkcsSign)) &&
+                                   XSTRNCMP(curHdr->body, kAppXPkcsSign,
+                                   XSTR_SIZEOF(kAppXPkcsSign)))) {
+                WOLFSSL_MSG("S/MIME headers not found inside "
+                            "multipart message.\n");
+                goto error;
+            }
+
+            section[0] = '\0';
+            sectionLen = 0;
+            lineLen = wolfSSL_BIO_gets(in, section, remainLen);
+            while (XSTRNCMP(&section[sectionLen], boundary, boundLen) &&
+                   remainLen > 0) {
+                sectionLen += lineLen;
+                remainLen -= lineLen;
+                lineLen = wolfSSL_BIO_gets(in, &section[sectionLen],
+                                           remainLen);
+                if (lineLen <= 0) {
+                    goto error;
+                }
+            }
+
+            XFREE(boundary, NULL, DYNAMIC_TYPE_PKCS7);
+            boundary = NULL;
+        }
+    }
+    else if (curHdr && (!XSTRNCMP(curHdr->body, kAppPkcs7Mime,
+                                  XSTR_SIZEOF(kAppPkcs7Mime)) ||
+                        !XSTRNCMP(curHdr->body, kAppXPkcs7Mime,
+                                  XSTR_SIZEOF(kAppXPkcs7Mime)))) {
+        sectionLen = wolfSSL_BIO_get_len(in);
+        if (sectionLen <= 0) {
+            goto error;
+        }
+        ret = wolfSSL_BIO_read(in, section, sectionLen);
+        if (ret < 0 || ret != sectionLen) {
+            WOLFSSL_MSG("Error reading input BIO.");
+            goto error;
+        }
+    }
+    else {
+        WOLFSSL_MSG("S/MIME headers not found.");
+        goto error;
+    }
+
+    curHdr = wc_MIME_find_header_name(kCTE, allHdrs);
+    if (curHdr == NULL) {
+        WOLFSSL_MSG("Content-Transfer-Encoding header not found, "
+                    "assuming base64 encoding.");
+    }
+    else if (XSTRNCMP(curHdr->body, "base64", XSTRLEN("base64"))) {
+        WOLFSSL_MSG("S/MIME encodings other than base64 are not "
+                    "currently supported.\n");
+        goto error;
+    }
+
+    if (section == NULL || sectionLen <= 0) {
+        goto error;
+    }
+    outLen = (word32)((sectionLen*3+3)/4)+1;
+    out = (byte*)XMALLOC(outLen*sizeof(byte), NULL, DYNAMIC_TYPE_PKCS7);
+    outHead = out;
+    if (outHead == NULL) {
+        goto error;
+    }
+    /* Strip trailing newlines. */
+    while ((sectionLen > 0) &&
+           (section[sectionLen-1] == '\r' || section[sectionLen-1] == '\n')) {
+        sectionLen--;
+    }
+    section[sectionLen] = '\0';
+    ret = Base64_Decode((const byte*)section, (word32)sectionLen, out, &outLen);
+    if (ret < 0) {
+        WOLFSSL_MSG("Error base64 decoding S/MIME message.");
+        goto error;
+    }
+    pkcs7 = wolfSSL_d2i_PKCS7_only(NULL, (const unsigned char**)&out, (int)outLen,
+        bcontMem, (word32)bcontMemSz);
+
+    wc_MIME_free_hdrs(allHdrs);
+    XFREE(outHead, NULL, DYNAMIC_TYPE_PKCS7);
+    XFREE(section, NULL, DYNAMIC_TYPE_PKCS7);
+
+    return pkcs7;
+
+error:
+    wc_MIME_free_hdrs(allHdrs);
+    XFREE(boundary, NULL, DYNAMIC_TYPE_PKCS7);
+    XFREE(outHead, NULL, DYNAMIC_TYPE_PKCS7);
+    XFREE(section, NULL, DYNAMIC_TYPE_PKCS7);
+    if (canonSection != NULL)
+        XFREE(canonSection, NULL, DYNAMIC_TYPE_PKCS7);
+    if (canonLine != NULL)
+        XFREE(canonLine, NULL, DYNAMIC_TYPE_PKCS7);
+    if (bcont) {
+        wolfSSL_BIO_free(*bcont);
+        *bcont = NULL; /* reset 'bcount' pointer to NULL on failure */
+    }
+
+    return NULL;
+}
+
+/* Convert hash algo OID (from Hash_Sum in asn.h) to SMIME string equivalent.
+ * Returns hash algorithm string or "unknown" if not found */
+static const char* wolfSSL_SMIME_HashOIDToString(int hashOID)
+{
+    switch (hashOID) {
+        case MD5h:
+            return "md5";
+        case SHAh:
+            return "sha1";
+        case SHA224h:
+            return "sha-224";
+        case SHA256h:
+            return "sha-256";
+        case SHA384h:
+            return "sha-384";
+        case SHA512h:
+            return "sha-512";
+        case SHA3_224h:
+            return "sha3-224";
+        case SHA3_384h:
+            return "sha3-384";
+        case SHA3_512h:
+            return "sha3-512";
+        default:
+            break;
+    }
+
+    return "unknown";
+}
+
+/* Convert PKCS#7 type (from PKCS7_TYPES in pkcs7.h) to SMIME string.
+ * RFC2633 only defines signed-data, enveloped-data, certs-only.
+ * Returns string on success, NULL on unknown type. */
+static const char* wolfSSL_SMIME_PKCS7TypeToString(int type)
+{
+    switch (type) {
+        case SIGNED_DATA:
+            return "signed-data";
+        case ENVELOPED_DATA:
+            return "enveloped-data";
+        default:
+            break;
+    }
+
+    return NULL;
+}
+
+/**
+ * Convert PKCS7 structure to SMIME format, adding necessary headers.
+ *
+ * Handles generation of PKCS7 bundle (ie: signedData). PKCS7 structure
+ * should be set up beforehand with PKCS7_sign/final/etc. Output is always
+ * Base64 encoded.
+ *
+ * out   - output BIO for SMIME formatted data to be placed
+ * pkcs7 - input PKCS7 structure, initialized and set up
+ * in    - input content to be encoded into PKCS7
+ * flags - flags to control behavior of PKCS7 generation
+ *
+ * Returns 1 on success, 0 or negative on failure
+ */
+int wolfSSL_SMIME_write_PKCS7(WOLFSSL_BIO* out, PKCS7* pkcs7, WOLFSSL_BIO* in,
+                              int flags)
+{
+    int i;
+    int ret = 1;
+    WOLFSSL_PKCS7* p7 = (WOLFSSL_PKCS7*)pkcs7;
+    byte* p7out = NULL;
+    int len = 0;
+
+    char boundary[33]; /* 32 chars + \0 */
+    byte* sigBase64 = NULL;
+    word32 sigBase64Len = 0;
+    const char* p7TypeString = NULL;
+
+    static const char alphanum[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    if (out == NULL || p7 == NULL) {
+        WOLFSSL_MSG("Bad function arguments");
+        return 0;
+    }
+
+    if (in != NULL && (p7->pkcs7.content == NULL || p7->pkcs7.contentSz == 0 ||
+                       p7->pkcs7.contentCRLF == 0)) {
+        /* store and adjust content line endings for CRLF if needed */
+        if (wolfSSL_PKCS7_final((PKCS7*)p7, in, flags) != 1) {
+            ret = 0;
+        }
+    }
+
+    if (ret > 0) {
+        /* Generate signedData bundle, DER in output (dynamic) */
+        if ((len = wolfSSL_i2d_PKCS7((PKCS7*)p7, &p7out)) == WOLFSSL_FAILURE) {
+            WOLFSSL_MSG("Error in wolfSSL_i2d_PKCS7");
+            ret = 0;
+        }
+    }
+
+    /* Base64 encode signedData bundle */
+    if (ret > 0) {
+        if (Base64_Encode(p7out, (word32)len, NULL, &sigBase64Len) !=
+            WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
+            ret = 0;
+        }
+        else {
+            sigBase64 = (byte*)XMALLOC(sigBase64Len, NULL,
+                                       DYNAMIC_TYPE_TMP_BUFFER);
+            if (sigBase64 == NULL) {
+                ret = 0;
+            }
+        }
+    }
+
+    if (ret > 0) {
+        XMEMSET(sigBase64, 0, sigBase64Len);
+        if (Base64_Encode(p7out, (word32)len, sigBase64, &sigBase64Len) < 0) {
+            WOLFSSL_MSG("Error in Base64_Encode of signature");
+            ret = 0;
+        }
+    }
+
+    /* build up SMIME message */
+    if (ret > 0) {
+        if (flags & PKCS7_DETACHED) {
+
+            /* generate random boundary */
+            if (initGlobalRNG == 0 && wolfSSL_RAND_Init() != WOLFSSL_SUCCESS) {
+                WOLFSSL_MSG("No RNG to use");
+                ret = 0;
+            }
+
+            /* no need to generate random byte for null terminator (size-1) */
+            if ((ret > 0) && (wc_RNG_GenerateBlock(&globalRNG, (byte*)boundary,
+                                  sizeof(boundary) - 1 ) != 0)) {
+                    WOLFSSL_MSG("Error in wc_RNG_GenerateBlock");
+                    ret = 0;
+            }
+
+            if (ret > 0) {
+                for (i = 0; i < (int)sizeof(boundary) - 1; i++) {
+                    boundary[i] =
+                        alphanum[boundary[i] % XSTR_SIZEOF(alphanum)];
+                }
+                boundary[sizeof(boundary)-1] = 0;
+            }
+
+            if (ret > 0) {
+                /* S/MIME header beginning */
+                ret = wolfSSL_BIO_printf(out,
+                        "MIME-Version: 1.0\n"
+                        "Content-Type: multipart/signed; "
+                        "protocol=\"application/x-pkcs7-signature\"; "
+                        "micalg=\"%s\"; "
+                        "boundary=\"----%s\"\n\n"
+                        "This is an S/MIME signed message\n\n"
+                        "------%s\n",
+                        wolfSSL_SMIME_HashOIDToString(p7->pkcs7.hashOID),
+                        boundary, boundary);
+            }
+
+            if (ret > 0) {
+                /* S/MIME content */
+                ret = wolfSSL_BIO_write(out,
+                        p7->pkcs7.content, p7->pkcs7.contentSz);
+            }
+
+            if (ret > 0) {
+                /* S/SMIME header end boundary */
+                ret = wolfSSL_BIO_printf(out,
+                        "\n------%s\n", boundary);
+            }
+
+            if (ret > 0) {
+                /* Signature and header */
+                ret = wolfSSL_BIO_printf(out,
+                        "Content-Type: application/x-pkcs7-signature; "
+                        "name=\"smime.p7s\"\n"
+                        "Content-Transfer-Encoding: base64\n"
+                        "Content-Disposition: attachment; "
+                        "filename=\"smime.p7s\"\n\n"
+                        "%.*s\n" /* Base64 encoded signature */
+                        "------%s--\n\n",
+                        sigBase64Len, sigBase64,
+                        boundary);
+            }
+        }
+        else {
+            p7TypeString = wolfSSL_SMIME_PKCS7TypeToString(p7->type);
+            if (p7TypeString == NULL) {
+                WOLFSSL_MSG("Unsupported PKCS7 SMIME type");
+                ret = 0;
+            }
+
+            if (ret > 0) {
+                /* not detached */
+                ret = wolfSSL_BIO_printf(out,
+                        "MIME-Version: 1.0\n"
+                        "Content-Disposition: attachment; "
+                        "filename=\"smime.p7m\"\n"
+                        "Content-Type: application/x-pkcs7-mime; "
+                        "smime-type=%s; name=\"smime.p7m\"\n"
+                        "Content-Transfer-Encoding: base64\n\n"
+                        "%.*s\n" /* signature */,
+                        p7TypeString, sigBase64Len, sigBase64);
+            }
+        }
+    }
+
+    if (p7out != NULL) {
+        XFREE(p7out, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+    if (sigBase64 != NULL) {
+        XFREE(sigBase64, NULL, DYNAMIC_TYPE_TMP_BUFFER);
+    }
+
+    if (ret > 0) {
+        return WOLFSSL_SUCCESS;
+    }
+
+    return WOLFSSL_FAILURE;
+}
+
+#endif /* HAVE_SMIME */
+#endif /* !NO_BIO */
+#endif /* OPENSSL_ALL */
+
+#endif /* HAVE_PKCS7 */
+/*******************************************************************************
+ * END OF PKCS7 APIs
+ ******************************************************************************/
+
+/*******************************************************************************
+ * START OF PKCS12 APIs
+ ******************************************************************************/
+#ifdef OPENSSL_EXTRA
+
+/* no-op function. Was initially used for adding encryption algorithms available
+ * for PKCS12 */
+void wolfSSL_PKCS12_PBE_add(void)
+{
+    WOLFSSL_ENTER("wolfSSL_PKCS12_PBE_add");
+}
+
+#if !defined(NO_FILESYSTEM) && !defined(NO_STDIO_FILESYSTEM)
+WOLFSSL_X509_PKCS12 *wolfSSL_d2i_PKCS12_fp(XFILE fp,
+        WOLFSSL_X509_PKCS12 **pkcs12)
+{
+    WOLFSSL_ENTER("wolfSSL_d2i_PKCS12_fp");
+    return (WOLFSSL_X509_PKCS12 *)wolfSSL_d2i_X509_fp_ex(fp, (void **)pkcs12,
+        PKCS12_TYPE);
+}
+#endif /* !NO_FILESYSTEM */
+
+#endif /* OPENSSL_EXTRA */
+
+#if defined(HAVE_PKCS12)
+
+#ifdef OPENSSL_EXTRA
+
+#if !defined(NO_ASN) && !defined(NO_PWDBASED)
+
+#ifndef NO_BIO
+WC_PKCS12* wolfSSL_d2i_PKCS12_bio(WOLFSSL_BIO* bio, WC_PKCS12** pkcs12)
+{
+    WC_PKCS12* localPkcs12 = NULL;
+    unsigned char* mem = NULL;
+    long memSz;
+    int ret = -1;
+
+    WOLFSSL_ENTER("wolfSSL_d2i_PKCS12_bio");
+
+    if (bio == NULL) {
+        WOLFSSL_MSG("Bad Function Argument bio is NULL");
+        return NULL;
+    }
+
+    memSz = wolfSSL_BIO_get_len(bio);
+    if (memSz <= 0) {
+        return NULL;
+    }
+    mem = (unsigned char*)XMALLOC(memSz, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (mem == NULL) {
+        return NULL;
+    }
+
+    if (mem != NULL) {
+        localPkcs12 = wc_PKCS12_new_ex(bio->heap);
+        if (localPkcs12 == NULL) {
+            WOLFSSL_MSG("Memory error");
+        }
+    }
+
+    if (mem != NULL && localPkcs12 != NULL) {
+        if (wolfSSL_BIO_read(bio, mem, (int)memSz) == memSz) {
+            ret = wc_d2i_PKCS12(mem, (word32)memSz, localPkcs12);
+            if (ret < 0) {
+                WOLFSSL_MSG("Failed to get PKCS12 sequence");
+            }
+        }
+        else {
+            WOLFSSL_MSG("Failed to get data from bio struct");
+        }
+    }
+
+    /* cleanup */
+    if (mem != NULL)
+        XFREE(mem, bio->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (ret < 0 && localPkcs12 != NULL) {
+        wc_PKCS12_free(localPkcs12);
+        localPkcs12 = NULL;
+    }
+    if (pkcs12 != NULL)
+        *pkcs12 = localPkcs12;
+
+    return localPkcs12;
+}
+
+/* Converts the PKCS12 to DER format and outputs it into bio.
+ *
+ * bio is the structure to hold output DER
+ * pkcs12 structure to create DER from
+ *
+ * return 1 for success or 0 if an error occurs
+ */
+int wolfSSL_i2d_PKCS12_bio(WOLFSSL_BIO *bio, WC_PKCS12 *pkcs12)
+{
+    int ret = WOLFSSL_FAILURE;
+
+    WOLFSSL_ENTER("wolfSSL_i2d_PKCS12_bio");
+
+    if ((bio != NULL) && (pkcs12 != NULL)) {
+        word32 certSz = 0;
+        byte *certDer = NULL;
+
+        certSz = (word32)wc_i2d_PKCS12(pkcs12, &certDer, NULL);
+        if ((certSz > 0) && (certDer != NULL)) {
+            if (wolfSSL_BIO_write(bio, certDer, (int)certSz) == (int)certSz) {
+                ret = WOLFSSL_SUCCESS;
+            }
+        }
+
+        if (certDer != NULL) {
+            XFREE(certDer, NULL, DYNAMIC_TYPE_PKCS);
+        }
+    }
+
+    return ret;
+}
+#endif /* !NO_BIO */
+
+/* Creates a new WC_PKCS12 structure
+ *
+ * pass  password to use
+ * name  friendlyName to use
+ * pkey  private key to go into PKCS12 bundle
+ * cert  certificate to go into PKCS12 bundle
+ * ca    extra certificates that can be added to bundle. Can be NULL
+ * keyNID  type of encryption to use on the key (-1 means no encryption)
+ * certNID type of encryption to use on the certificate
+ * itt     number of iterations with encryption
+ * macItt  number of iterations with mac creation
+ * keyType flag for signature and/or encryption key
+ *
+ * returns a pointer to a new WC_PKCS12 structure on success and NULL on fail
+ */
+WC_PKCS12* wolfSSL_PKCS12_create(char* pass, char* name, WOLFSSL_EVP_PKEY* pkey,
+        WOLFSSL_X509* cert, WOLF_STACK_OF(WOLFSSL_X509)* ca, int keyNID,
+        int certNID, int itt, int macItt, int keyType)
+{
+    WC_PKCS12* pkcs12;
+    WC_DerCertList* list = NULL;
+    word32 passSz;
+    byte* keyDer = NULL;
+    word32 keyDerSz;
+    byte* certDer;
+    int certDerSz;
+
+    WOLFSSL_ENTER("wolfSSL_PKCS12_create");
+
+    if (pass == NULL || pkey == NULL || cert == NULL) {
+        WOLFSSL_LEAVE("wolfSSL_PKCS12_create", BAD_FUNC_ARG);
+        return NULL;
+    }
+    passSz = (word32)XSTRLEN(pass);
+
+    keyDer = (byte*)pkey->pkey.ptr;
+    keyDerSz = (word32)pkey->pkey_sz;
+
+    certDer = (byte*)wolfSSL_X509_get_der(cert, &certDerSz);
+    if (certDer == NULL) {
+        return NULL;
+    }
+
+    if (ca != NULL) {
+        unsigned long numCerts = ca->num;
+        WOLFSSL_STACK* sk = ca;
+
+        while (numCerts > 0 && sk != NULL) {
+            byte* curDer;
+            WC_DerCertList* cur;
+            int   curDerSz = 0;
+
+            cur = (WC_DerCertList*)XMALLOC(sizeof(WC_DerCertList), NULL,
+                    DYNAMIC_TYPE_PKCS);
+            if (cur == NULL) {
+                wc_FreeCertList(list, NULL);
+                return NULL;
+            }
+
+            curDer = (byte*)wolfSSL_X509_get_der(sk->data.x509, &curDerSz);
+            if (curDer == NULL || curDerSz < 0) {
+                XFREE(cur, NULL, DYNAMIC_TYPE_PKCS);
+                wc_FreeCertList(list, NULL);
+                return NULL;
+            }
+
+            cur->buffer = (byte*)XMALLOC(curDerSz, NULL, DYNAMIC_TYPE_PKCS);
+            if (cur->buffer == NULL) {
+                XFREE(cur, NULL, DYNAMIC_TYPE_PKCS);
+                wc_FreeCertList(list, NULL);
+                return NULL;
+            }
+            XMEMCPY(cur->buffer, curDer, curDerSz);
+            cur->bufferSz = (word32)curDerSz;
+            cur->next = list;
+            list = cur;
+
+            sk = sk->next;
+            numCerts--;
+        }
+    }
+
+    pkcs12 = wc_PKCS12_create(pass, passSz, name, keyDer, keyDerSz,
+            certDer, (word32)certDerSz, list, keyNID, certNID, itt, macItt,
+            keyType, NULL);
+
+    if (ca != NULL) {
+        wc_FreeCertList(list, NULL);
+    }
+
+    return pkcs12;
+}
+
+
+/* return WOLFSSL_SUCCESS on success, WOLFSSL_FAILURE on failure */
+int wolfSSL_PKCS12_parse(WC_PKCS12* pkcs12, const char* psw,
+          WOLFSSL_EVP_PKEY** pkey, WOLFSSL_X509** cert,
+          WOLF_STACK_OF(WOLFSSL_X509)** ca)
+{
+    void* heap = NULL;
+    int ret;
+    byte* certData = NULL;
+    word32 certDataSz;
+    byte* pk = NULL;
+    word32 pkSz;
+    WC_DerCertList* certList = NULL;
+#ifdef WOLFSSL_SMALL_STACK
+    DecodedCert *DeCert;
+#else
+    DecodedCert DeCert[1];
+#endif
+
+    WOLFSSL_ENTER("wolfSSL_PKCS12_parse");
+
+    /* make sure we init return args */
+    if (pkey) *pkey = NULL;
+    if (cert) *cert = NULL;
+    if (ca)   *ca = NULL;
+
+    if (pkcs12 == NULL || psw == NULL || pkey == NULL || cert == NULL) {
+        WOLFSSL_MSG("Bad argument value");
+        return WOLFSSL_FAILURE;
+    }
+
+    heap  = wc_PKCS12_GetHeap(pkcs12);
+
+    if (ca == NULL) {
+        ret = wc_PKCS12_parse(pkcs12, psw, &pk, &pkSz, &certData, &certDataSz,
+            NULL);
+    }
+    else {
+        ret = wc_PKCS12_parse(pkcs12, psw, &pk, &pkSz, &certData, &certDataSz,
+            &certList);
+    }
+    if (ret < 0) {
+        WOLFSSL_LEAVE("wolfSSL_PKCS12_parse", ret);
+        return WOLFSSL_FAILURE;
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    DeCert = (DecodedCert *)XMALLOC(sizeof(*DeCert), heap,
+                                    DYNAMIC_TYPE_DCERT);
+    if (DeCert == NULL) {
+        WOLFSSL_MSG("out of memory");
+        return WOLFSSL_FAILURE;
+    }
+#endif
+
+    /* Decode cert and place in X509 stack struct */
+    if (certList != NULL) {
+        WC_DerCertList* current = certList;
+
+        *ca = (WOLF_STACK_OF(WOLFSSL_X509)*)XMALLOC(
+            sizeof(WOLF_STACK_OF(WOLFSSL_X509)), heap, DYNAMIC_TYPE_X509);
+        if (*ca == NULL) {
+            if (pk != NULL) {
+                XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
+            }
+            if (certData != NULL) {
+                XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
+            }
+            /* Free up WC_DerCertList and move on */
+            while (current != NULL) {
+                WC_DerCertList* next = current->next;
+
+                XFREE(current->buffer, heap, DYNAMIC_TYPE_PKCS);
+                XFREE(current, heap, DYNAMIC_TYPE_PKCS);
+                current = next;
+            }
+            ret = WOLFSSL_FAILURE;
+            goto out;
+        }
+        XMEMSET(*ca, 0, sizeof(WOLF_STACK_OF(WOLFSSL_X509)));
+
+        /* add list of DER certs as X509's to stack */
+        while (current != NULL) {
+            WC_DerCertList*  toFree = current;
+            WOLFSSL_X509* x509;
+
+            x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), heap,
+                DYNAMIC_TYPE_X509);
+            InitX509(x509, 1, heap);
+            InitDecodedCert(DeCert, current->buffer, current->bufferSz, heap);
+            if (ParseCertRelative(DeCert, CERT_TYPE, NO_VERIFY, NULL, NULL) != 0) {
+                WOLFSSL_MSG("Issue with parsing certificate");
+                FreeDecodedCert(DeCert);
+                wolfSSL_X509_free(x509);
+            }
+            else {
+                if (CopyDecodedToX509(x509, DeCert) != 0) {
+                    WOLFSSL_MSG("Failed to copy decoded cert");
+                    FreeDecodedCert(DeCert);
+                    wolfSSL_X509_free(x509);
+                    wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
+                    if (pk != NULL) {
+                        XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
+                    }
+                    if (certData != NULL) {
+                        XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
+                    }
+                    /* Free up WC_DerCertList */
+                    while (current != NULL) {
+                        WC_DerCertList* next = current->next;
+
+                        XFREE(current->buffer, heap, DYNAMIC_TYPE_PKCS);
+                        XFREE(current, heap, DYNAMIC_TYPE_PKCS);
+                        current = next;
+                    }
+                    ret = WOLFSSL_FAILURE;
+                    goto out;
+                }
+                FreeDecodedCert(DeCert);
+
+                if (wolfSSL_sk_X509_push(*ca, x509) != 1) {
+                    WOLFSSL_MSG("Failed to push x509 onto stack");
+                    wolfSSL_X509_free(x509);
+                    wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
+                    if (pk != NULL) {
+                        XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
+                    }
+                    if (certData != NULL) {
+                        XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
+                    }
+
+                    /* Free up WC_DerCertList */
+                    while (current != NULL) {
+                        WC_DerCertList* next = current->next;
+
+                        XFREE(current->buffer, heap, DYNAMIC_TYPE_PKCS);
+                        XFREE(current, heap, DYNAMIC_TYPE_PKCS);
+                        current = next;
+                    }
+                    ret = WOLFSSL_FAILURE;
+                    goto out;
+                }
+            }
+            current = current->next;
+            XFREE(toFree->buffer, heap, DYNAMIC_TYPE_PKCS);
+            XFREE(toFree, heap, DYNAMIC_TYPE_PKCS);
+        }
+    }
+
+
+    /* Decode cert and place in X509 struct */
+    if (certData != NULL) {
+        *cert = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), heap,
+            DYNAMIC_TYPE_X509);
+        if (*cert == NULL) {
+            if (pk != NULL) {
+                XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
+            }
+            if (ca != NULL) {
+                wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
+            }
+            XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
+            ret = WOLFSSL_FAILURE;
+            goto out;
+        }
+        InitX509(*cert, 1, heap);
+        InitDecodedCert(DeCert, certData, certDataSz, heap);
+        if (ParseCertRelative(DeCert, CERT_TYPE, NO_VERIFY, NULL, NULL) != 0) {
+            WOLFSSL_MSG("Issue with parsing certificate");
+        }
+        if (CopyDecodedToX509(*cert, DeCert) != 0) {
+            WOLFSSL_MSG("Failed to copy decoded cert");
+            FreeDecodedCert(DeCert);
+            if (pk != NULL) {
+                XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
+            }
+            if (ca != NULL) {
+                wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
+            }
+            wolfSSL_X509_free(*cert); *cert = NULL;
+            XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
+            ret = WOLFSSL_FAILURE;
+            goto out;
+        }
+        FreeDecodedCert(DeCert);
+        XFREE(certData, heap, DYNAMIC_TYPE_PKCS);
+    }
+
+
+    /* get key type */
+    ret = BAD_STATE_E;
+    if (pk != NULL) { /* decode key if present */
+        *pkey = wolfSSL_EVP_PKEY_new_ex(heap);
+        if (*pkey == NULL) {
+            wolfSSL_X509_free(*cert); *cert = NULL;
+            if (ca != NULL) {
+                wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
+            }
+            XFREE(pk, heap, DYNAMIC_TYPE_PUBLIC_KEY);
+            ret = WOLFSSL_FAILURE;
+            goto out;
+        }
+
+    #ifndef NO_RSA
+        {
+            const unsigned char* pt = pk;
+            if (wolfSSL_d2i_PrivateKey(EVP_PKEY_RSA, pkey, &pt, pkSz) !=
+                    NULL) {
+                ret = 0;
+            }
+        }
+    #endif /* NO_RSA */
+
+    #ifdef HAVE_ECC
+        if (ret != 0) { /* if is in fail state check if ECC key */
+            const unsigned char* pt = pk;
+            if (wolfSSL_d2i_PrivateKey(EVP_PKEY_EC, pkey, &pt, pkSz) !=
+                    NULL) {
+                ret = 0;
+            }
+        }
+    #endif /* HAVE_ECC */
+        if (pk != NULL)
+            XFREE(pk, heap, DYNAMIC_TYPE_PKCS);
+        if (ret != 0) { /* if is in fail state and no PKEY then fail */
+            wolfSSL_X509_free(*cert); *cert = NULL;
+            if (ca != NULL) {
+                wolfSSL_sk_X509_pop_free(*ca, NULL); *ca = NULL;
+            }
+            wolfSSL_EVP_PKEY_free(*pkey); *pkey = NULL;
+            WOLFSSL_MSG("Bad PKCS12 key format");
+            ret = WOLFSSL_FAILURE;
+            goto out;
+        }
+
+        if (pkey != NULL && *pkey != NULL) {
+            (*pkey)->save_type = 0;
+        }
+    }
+
+    (void)ret;
+    (void)ca;
+
+    ret = WOLFSSL_SUCCESS;
+
+out:
+
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(DeCert, heap, DYNAMIC_TYPE_DCERT);
+#endif
+
+    return ret;
+}
+
+int wolfSSL_PKCS12_verify_mac(WC_PKCS12 *pkcs12, const char *psw,
+        int pswLen)
+{
+    WOLFSSL_ENTER("wolfSSL_PKCS12_verify_mac");
+
+    if (!pkcs12) {
+        return WOLFSSL_FAILURE;
+    }
+
+    return wc_PKCS12_verify_ex(pkcs12, (const byte*)psw, (word32)pswLen) == 0 ?
+            WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
+}
+
+#endif /* !NO_ASN && !NO_PWDBASED */
+
+#endif /* OPENSSL_EXTRA */
+
+#endif /* HAVE_PKCS12 */
+/*******************************************************************************
+ * END OF PKCS12 APIs
+ ******************************************************************************/
+
+#endif /* !WOLFCRYPT_ONLY && !NO_CERTS */
+
+#endif /* !WOLFSSL_SSL_P7P12_INCLUDED */

--- a/libatalk/ssl/src/ssl_sess.c
+++ b/libatalk/ssl/src/ssl_sess.c
@@ -1,0 +1,4567 @@
+/* ssl_sess.c
+ *
+ * Copyright (C) 2006-2024 wolfSSL Inc.
+ *
+ * This file is part of wolfSSL.
+ *
+ * wolfSSL is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * wolfSSL is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA
+ */
+
+
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
+#include <wolfssl/wolfcrypt/settings.h>
+
+#if !defined(WOLFSSL_SSL_SESS_INCLUDED)
+    #ifndef WOLFSSL_IGNORE_FILE_WARN
+        #warning ssl_sess.c does not need to be compiled separately from ssl.c
+    #endif
+#else
+
+#ifndef NO_SESSION_CACHE
+
+    /* basic config gives a cache with 33 sessions, adequate for clients and
+       embedded servers
+
+       TITAN_SESSION_CACHE allows just over 2 million sessions, for servers
+       with titanic amounts of memory with long session ID timeouts and high
+       levels of traffic.
+
+       ENABLE_SESSION_CACHE_ROW_LOCK: Allows row level locking for increased
+       performance with large session caches
+
+       HUGE_SESSION_CACHE yields 65,791 sessions, for servers under heavy load,
+       allows over 13,000 new sessions per minute or over 200 new sessions per
+       second
+
+       BIG_SESSION_CACHE yields 20,027 sessions
+
+       MEDIUM_SESSION_CACHE allows 1055 sessions, adequate for servers that
+       aren't under heavy load, basically allows 200 new sessions per minute
+
+       SMALL_SESSION_CACHE only stores 6 sessions, good for embedded clients
+       or systems where the default of is too much RAM.
+       SessionCache takes about 2K, ClientCache takes about 3Kbytes
+
+       MICRO_SESSION_CACHE only stores 1 session, good for embedded clients
+       or systems where memory is at a premium.
+       SessionCache takes about 400 bytes, ClientCache takes 576 bytes
+
+       default SESSION_CACHE stores 33 sessions (no XXX_SESSION_CACHE defined)
+       SessionCache takes about 13K bytes, ClientCache takes 17K bytes
+    */
+    #if defined(TITAN_SESSION_CACHE)
+        #define SESSIONS_PER_ROW 31
+        #define SESSION_ROWS 64937
+        #ifndef ENABLE_SESSION_CACHE_ROW_LOCK
+            #define ENABLE_SESSION_CACHE_ROW_LOCK
+        #endif
+    #elif defined(HUGE_SESSION_CACHE)
+        #define SESSIONS_PER_ROW 11
+        #define SESSION_ROWS 5981
+    #elif defined(BIG_SESSION_CACHE)
+        #define SESSIONS_PER_ROW 7
+        #define SESSION_ROWS 2861
+    #elif defined(MEDIUM_SESSION_CACHE)
+        #define SESSIONS_PER_ROW 5
+        #define SESSION_ROWS 211
+    #elif defined(SMALL_SESSION_CACHE)
+        #define SESSIONS_PER_ROW 2
+        #define SESSION_ROWS 3
+    #elif defined(MICRO_SESSION_CACHE)
+        #define SESSIONS_PER_ROW 1
+        #define SESSION_ROWS 1
+    #else
+        #define SESSIONS_PER_ROW 3
+        #define SESSION_ROWS 11
+    #endif
+    #define INVALID_SESSION_ROW (-1)
+
+    #ifdef NO_SESSION_CACHE_ROW_LOCK
+        #undef ENABLE_SESSION_CACHE_ROW_LOCK
+    #endif
+
+    typedef struct SessionRow {
+        int nextIdx;                           /* where to place next one   */
+        int totalCount;                        /* sessions ever on this row */
+#ifdef SESSION_CACHE_DYNAMIC_MEM
+        WOLFSSL_SESSION* Sessions[SESSIONS_PER_ROW];
+        void* heap;
+#else
+        WOLFSSL_SESSION Sessions[SESSIONS_PER_ROW];
+#endif
+
+    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
+        /* not included in import/export */
+        wolfSSL_RwLock row_lock;
+        int lock_valid;
+    #endif
+    } SessionRow;
+    #define SIZEOF_SESSION_ROW (sizeof(WOLFSSL_SESSION) + (sizeof(int) * 2))
+
+    static WOLFSSL_GLOBAL SessionRow SessionCache[SESSION_ROWS];
+
+    #if defined(WOLFSSL_SESSION_STATS) && defined(WOLFSSL_PEAK_SESSIONS)
+        static WOLFSSL_GLOBAL word32 PeakSessions;
+    #endif
+
+    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
+    #define SESSION_ROW_RD_LOCK(row)   wc_LockRwLock_Rd(&(row)->row_lock)
+    #define SESSION_ROW_WR_LOCK(row)   wc_LockRwLock_Wr(&(row)->row_lock)
+    #define SESSION_ROW_UNLOCK(row)    wc_UnLockRwLock(&(row)->row_lock);
+    #else
+    static WOLFSSL_GLOBAL wolfSSL_RwLock session_lock; /* SessionCache lock */
+    static WOLFSSL_GLOBAL int session_lock_valid = 0;
+    #define SESSION_ROW_RD_LOCK(row)   wc_LockRwLock_Rd(&session_lock)
+    #define SESSION_ROW_WR_LOCK(row)   wc_LockRwLock_Wr(&session_lock)
+    #define SESSION_ROW_UNLOCK(row)    wc_UnLockRwLock(&session_lock);
+    #endif
+
+    #if !defined(NO_SESSION_CACHE_REF) && defined(NO_CLIENT_CACHE)
+    #error ClientCache is required when not using NO_SESSION_CACHE_REF
+    #endif
+
+    #ifndef NO_CLIENT_CACHE
+
+        #ifndef CLIENT_SESSIONS_MULTIPLIER
+            #ifdef NO_SESSION_CACHE_REF
+                #define CLIENT_SESSIONS_MULTIPLIER 1
+            #else
+                /* ClientSession objects are lightweight (compared to
+                 * WOLFSSL_SESSION) so to decrease chance that user will reuse
+                 * the wrong session, increase the ClientCache size. This will
+                 * make the entire ClientCache about the size of one
+                 * WOLFSSL_SESSION object. */
+                #define CLIENT_SESSIONS_MULTIPLIER 8
+            #endif
+        #endif
+        #define CLIENT_SESSIONS_PER_ROW \
+                                (SESSIONS_PER_ROW * CLIENT_SESSIONS_MULTIPLIER)
+        #define CLIENT_SESSION_ROWS (SESSION_ROWS * CLIENT_SESSIONS_MULTIPLIER)
+
+        #if CLIENT_SESSIONS_PER_ROW > 65535
+        #error CLIENT_SESSIONS_PER_ROW too big
+        #endif
+        #if CLIENT_SESSION_ROWS > 65535
+        #error CLIENT_SESSION_ROWS too big
+        #endif
+
+        struct ClientSession {
+            word16 serverRow;            /* SessionCache Row id */
+            word16 serverIdx;            /* SessionCache Idx (column) */
+            word32 sessionIDHash;
+        };
+    #ifndef WOLFSSL_CLIENT_SESSION_DEFINED
+        typedef struct ClientSession ClientSession;
+        #define WOLFSSL_CLIENT_SESSION_DEFINED
+    #endif
+
+        typedef struct ClientRow {
+            int nextIdx;                /* where to place next one   */
+            int totalCount;             /* sessions ever on this row */
+            ClientSession Clients[CLIENT_SESSIONS_PER_ROW];
+        } ClientRow;
+
+        static WOLFSSL_GLOBAL ClientRow ClientCache[CLIENT_SESSION_ROWS];
+                                                     /* Client Cache */
+                                                     /* uses session mutex */
+
+        /* ClientCache mutex */
+        static WOLFSSL_GLOBAL wolfSSL_Mutex clisession_mutex
+            WOLFSSL_MUTEX_INITIALIZER_CLAUSE(clisession_mutex);
+        #ifndef WOLFSSL_MUTEX_INITIALIZER
+        static WOLFSSL_GLOBAL int clisession_mutex_valid = 0;
+        #endif
+    #endif /* !NO_CLIENT_CACHE */
+
+    void EvictSessionFromCache(WOLFSSL_SESSION* session)
+    {
+#ifdef HAVE_EX_DATA
+        int save_ownExData = session->ownExData;
+        session->ownExData = 1; /* Make sure ex_data access doesn't lead back
+                                 * into the cache. */
+#endif
+#if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
+        if (session->rem_sess_cb != NULL) {
+            session->rem_sess_cb(NULL, session);
+            session->rem_sess_cb = NULL;
+        }
+#endif
+        ForceZero(session->masterSecret, SECRET_LEN);
+        XMEMSET(session->sessionID, 0, ID_LEN);
+        session->sessionIDSz = 0;
+#ifdef HAVE_SESSION_TICKET
+        if (session->ticketLenAlloc > 0) {
+            XFREE(session->ticket, NULL, DYNAMIC_TYPE_SESSION_TICK);
+            session->ticket = session->staticTicket;
+            session->ticketLen = 0;
+            session->ticketLenAlloc = 0;
+        }
+#endif
+#ifdef HAVE_EX_DATA
+        session->ownExData = save_ownExData;
+#endif
+
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET) &&                  \
+    defined(WOLFSSL_TICKET_NONCE_MALLOC) &&                                    \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+        if ((session->ticketNonce.data != NULL) &&
+            (session->ticketNonce.data != session->ticketNonce.dataStatic))
+        {
+            XFREE(session->ticketNonce.data, NULL, DYNAMIC_TYPE_SESSION_TICK);
+            session->ticketNonce.data = NULL;
+        }
+#endif
+    }
+
+WOLFSSL_ABI
+WOLFSSL_SESSION* wolfSSL_get_session(WOLFSSL* ssl)
+{
+    WOLFSSL_ENTER("wolfSSL_get_session");
+    if (ssl) {
+#ifdef NO_SESSION_CACHE_REF
+        return ssl->session;
+#else
+        if (ssl->options.side == WOLFSSL_CLIENT_END) {
+            /* On the client side we want to return a persistent reference for
+             * backwards compatibility. */
+#ifndef NO_CLIENT_CACHE
+            if (ssl->clientSession) {
+                return (WOLFSSL_SESSION*)ssl->clientSession;
+            }
+            else {
+                /* Try to add a ClientCache entry to associate with the current
+                 * session. Ignore any session cache options. */
+                int err;
+                const byte* id = ssl->session->sessionID;
+                byte idSz = ssl->session->sessionIDSz;
+                if (ssl->session->haveAltSessionID) {
+                    id = ssl->session->altSessionID;
+                    idSz = ID_LEN;
+                }
+                err = AddSessionToCache(ssl->ctx, ssl->session, id, idSz,
+                        NULL, ssl->session->side,
+                #ifdef HAVE_SESSION_TICKET
+                        ssl->session->ticketLen > 0,
+                #else
+                        0,
+                #endif
+                        &ssl->clientSession);
+                if (err == 0) {
+                    return (WOLFSSL_SESSION*)ssl->clientSession;
+                }
+            }
+#endif
+        }
+        else {
+            return ssl->session;
+        }
+#endif
+    }
+
+    return NULL;
+}
+
+/* The get1 version requires caller to call SSL_SESSION_free */
+WOLFSSL_SESSION* wolfSSL_get1_session(WOLFSSL* ssl)
+{
+    WOLFSSL_SESSION* sess = NULL;
+    WOLFSSL_ENTER("wolfSSL_get1_session");
+    if (ssl != NULL) {
+        sess = ssl->session;
+        if (sess != NULL) {
+            /* increase reference count if allocated session */
+            if (sess->type == WOLFSSL_SESSION_TYPE_HEAP) {
+                if (wolfSSL_SESSION_up_ref(sess) != WOLFSSL_SUCCESS)
+                    sess = NULL;
+            }
+        }
+    }
+    return sess;
+}
+
+/* session is a private struct, return if it is setup or not */
+WOLFSSL_API int wolfSSL_SessionIsSetup(WOLFSSL_SESSION* session)
+{
+    if (session != NULL)
+        return session->isSetup;
+    return 0;
+}
+
+/*
+ * Sets the session object to use when establishing a TLS/SSL session using
+ * the ssl object. Therefore, this function must be called before
+ * wolfSSL_connect. The session object to use can be obtained in a previous
+ * TLS/SSL connection using wolfSSL_get_session.
+ *
+ * This function rejects the session if it has been expired when this function
+ * is called. Note that this expiration check is wolfSSL specific and differs
+ * from OpenSSL return code behavior.
+ *
+ * By default, wolfSSL_set_session returns WOLFSSL_SUCCESS on successfully
+ * setting the session, WOLFSSL_FAILURE on failure due to the session cache
+ * being disabled, or the session has expired.
+ *
+ * To match OpenSSL return code behavior when session is expired, define
+ * OPENSSL_EXTRA and WOLFSSL_ERROR_CODE_OPENSSL. This behavior will return
+ * WOLFSSL_SUCCESS even when the session is expired and rejected.
+ */
+WOLFSSL_ABI
+int wolfSSL_set_session(WOLFSSL* ssl, WOLFSSL_SESSION* session)
+{
+    WOLFSSL_ENTER("wolfSSL_set_session");
+    if (session)
+        return wolfSSL_SetSession(ssl, session);
+
+    return WOLFSSL_FAILURE;
+}
+
+
+#ifndef NO_CLIENT_CACHE
+
+/* Associate client session with serverID, find existing or store for saving
+   if newSession flag on, don't reuse existing session
+   WOLFSSL_SUCCESS on ok */
+int wolfSSL_SetServerID(WOLFSSL* ssl, const byte* id, int len, int newSession)
+{
+    WOLFSSL_SESSION* session = NULL;
+    byte idHash[SERVER_ID_LEN];
+
+    WOLFSSL_ENTER("wolfSSL_SetServerID");
+
+    if (ssl == NULL || id == NULL || len <= 0)
+        return BAD_FUNC_ARG;
+
+    if (len > SERVER_ID_LEN) {
+#if defined(NO_SHA) && !defined(NO_SHA256)
+        if (wc_Sha256Hash(id, len, idHash) != 0)
+            return WOLFSSL_FAILURE;
+#else
+        if (wc_ShaHash(id, (word32)len, idHash) != 0)
+            return WOLFSSL_FAILURE;
+#endif
+        id = idHash;
+        len = SERVER_ID_LEN;
+    }
+
+    if (newSession == 0) {
+        session = wolfSSL_GetSessionClient(ssl, id, len);
+        if (session) {
+            if (wolfSSL_SetSession(ssl, session) != WOLFSSL_SUCCESS) {
+            #ifdef HAVE_EXT_CACHE
+                wolfSSL_FreeSession(ssl->ctx, session);
+            #endif
+                WOLFSSL_MSG("wolfSSL_SetSession failed");
+                session = NULL;
+            }
+        }
+    }
+
+    if (session == NULL) {
+        WOLFSSL_MSG("Valid ServerID not cached already");
+
+        ssl->session->idLen = (word16)len;
+        XMEMCPY(ssl->session->serverID, id, len);
+    }
+#ifdef HAVE_EXT_CACHE
+    else {
+        wolfSSL_FreeSession(ssl->ctx, session);
+    }
+#endif
+
+    return WOLFSSL_SUCCESS;
+}
+
+#endif /* !NO_CLIENT_CACHE */
+
+/* TODO: Add SESSION_CACHE_DYNAMIC_MEM support for PERSIST_SESSION_CACHE.
+ * Need a count of current sessions to get an accurate memsize (totalCount is
+ * not decremented when sessions are removed).
+ * Need to determine ideal layout for mem/filesave.
+ * Also need mem/filesave checking to ensure not restoring non DYNAMIC_MEM
+ * cache.
+ */
+#if defined(PERSIST_SESSION_CACHE) && !defined(SESSION_CACHE_DYNAMIC_MEM)
+
+/* for persistence, if changes to layout need to increment and modify
+   save_session_cache() and restore_session_cache and memory versions too */
+#define WOLFSSL_CACHE_VERSION 2
+
+/* Session Cache Header information */
+typedef struct {
+    int version;     /* cache layout version id */
+    int rows;        /* session rows */
+    int columns;     /* session columns */
+    int sessionSz;   /* sizeof WOLFSSL_SESSION */
+} cache_header_t;
+
+/* current persistence layout is:
+
+   1) cache_header_t
+   2) SessionCache
+   3) ClientCache
+
+   update WOLFSSL_CACHE_VERSION if change layout for the following
+   PERSISTENT_SESSION_CACHE functions
+*/
+
+/* get how big the the session cache save buffer needs to be */
+int wolfSSL_get_session_cache_memsize(void)
+{
+    int sz  = (int)(sizeof(SessionCache) + sizeof(cache_header_t));
+#ifndef NO_CLIENT_CACHE
+    sz += (int)(sizeof(ClientCache));
+#endif
+    return sz;
+}
+
+
+/* Persist session cache to memory */
+int wolfSSL_memsave_session_cache(void* mem, int sz)
+{
+    int i;
+    cache_header_t cache_header;
+    SessionRow*    row  = (SessionRow*)((byte*)mem + sizeof(cache_header));
+
+    WOLFSSL_ENTER("wolfSSL_memsave_session_cache");
+
+    if (sz < wolfSSL_get_session_cache_memsize()) {
+        WOLFSSL_MSG("Memory buffer too small");
+        return BUFFER_E;
+    }
+
+    cache_header.version   = WOLFSSL_CACHE_VERSION;
+    cache_header.rows      = SESSION_ROWS;
+    cache_header.columns   = SESSIONS_PER_ROW;
+    cache_header.sessionSz = (int)sizeof(WOLFSSL_SESSION);
+    XMEMCPY(mem, &cache_header, sizeof(cache_header));
+
+#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
+    if (SESSION_ROW_RD_LOCK(row) != 0) {
+        WOLFSSL_MSG("Session cache mutex lock failed");
+        return BAD_MUTEX_E;
+    }
+#endif
+    for (i = 0; i < cache_header.rows; ++i) {
+    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
+        if (SESSION_ROW_RD_LOCK(&SessionCache[i]) != 0) {
+            WOLFSSL_MSG("Session row cache mutex lock failed");
+            return BAD_MUTEX_E;
+        }
+    #endif
+
+        XMEMCPY(row++, &SessionCache[i], SIZEOF_SESSION_ROW);
+    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
+        SESSION_ROW_UNLOCK(&SessionCache[i]);
+    #endif
+    }
+#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
+    SESSION_ROW_UNLOCK(row);
+#endif
+
+#ifndef NO_CLIENT_CACHE
+    if (wc_LockMutex(&clisession_mutex) != 0) {
+        WOLFSSL_MSG("Client cache mutex lock failed");
+        return BAD_MUTEX_E;
+    }
+    XMEMCPY(row, ClientCache, sizeof(ClientCache));
+    wc_UnLockMutex(&clisession_mutex);
+#endif
+
+    WOLFSSL_LEAVE("wolfSSL_memsave_session_cache", WOLFSSL_SUCCESS);
+
+    return WOLFSSL_SUCCESS;
+}
+
+
+/* Restore the persistent session cache from memory */
+int wolfSSL_memrestore_session_cache(const void* mem, int sz)
+{
+    int    i;
+    cache_header_t cache_header;
+    SessionRow*    row  = (SessionRow*)((byte*)mem + sizeof(cache_header));
+
+    WOLFSSL_ENTER("wolfSSL_memrestore_session_cache");
+
+    if (sz < wolfSSL_get_session_cache_memsize()) {
+        WOLFSSL_MSG("Memory buffer too small");
+        return BUFFER_E;
+    }
+
+    XMEMCPY(&cache_header, mem, sizeof(cache_header));
+    if (cache_header.version   != WOLFSSL_CACHE_VERSION ||
+        cache_header.rows      != SESSION_ROWS ||
+        cache_header.columns   != SESSIONS_PER_ROW ||
+        cache_header.sessionSz != (int)sizeof(WOLFSSL_SESSION)) {
+
+        WOLFSSL_MSG("Session cache header match failed");
+        return CACHE_MATCH_ERROR;
+    }
+
+#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
+    if (SESSION_ROW_WR_LOCK(&SessionCache[0]) != 0) {
+        WOLFSSL_MSG("Session cache mutex lock failed");
+        return BAD_MUTEX_E;
+    }
+#endif
+    for (i = 0; i < cache_header.rows; ++i) {
+    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
+        if (SESSION_ROW_WR_LOCK(&SessionCache[i]) != 0) {
+            WOLFSSL_MSG("Session row cache mutex lock failed");
+            return BAD_MUTEX_E;
+        }
+    #endif
+
+        XMEMCPY(&SessionCache[i], row++, SIZEOF_SESSION_ROW);
+    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
+        SESSION_ROW_UNLOCK(&SessionCache[i]);
+    #endif
+    }
+#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
+    SESSION_ROW_UNLOCK(&SessionCache[0]);
+#endif
+
+#ifndef NO_CLIENT_CACHE
+    if (wc_LockMutex(&clisession_mutex) != 0) {
+        WOLFSSL_MSG("Client cache mutex lock failed");
+        return BAD_MUTEX_E;
+    }
+    XMEMCPY(ClientCache, row, sizeof(ClientCache));
+    wc_UnLockMutex(&clisession_mutex);
+#endif
+
+    WOLFSSL_LEAVE("wolfSSL_memrestore_session_cache", WOLFSSL_SUCCESS);
+
+    return WOLFSSL_SUCCESS;
+}
+
+#if !defined(NO_FILESYSTEM)
+
+/* Persist session cache to file */
+/* doesn't use memsave because of additional memory use */
+int wolfSSL_save_session_cache(const char *fname)
+{
+    XFILE  file;
+    int    ret;
+    int    rc = WOLFSSL_SUCCESS;
+    int    i;
+    cache_header_t cache_header;
+
+    WOLFSSL_ENTER("wolfSSL_save_session_cache");
+
+    file = XFOPEN(fname, "w+b");
+    if (file == XBADFILE) {
+        WOLFSSL_MSG("Couldn't open session cache save file");
+        return WOLFSSL_BAD_FILE;
+    }
+    cache_header.version   = WOLFSSL_CACHE_VERSION;
+    cache_header.rows      = SESSION_ROWS;
+    cache_header.columns   = SESSIONS_PER_ROW;
+    cache_header.sessionSz = (int)sizeof(WOLFSSL_SESSION);
+
+    /* cache header */
+    ret = (int)XFWRITE(&cache_header, sizeof cache_header, 1, file);
+    if (ret != 1) {
+        WOLFSSL_MSG("Session cache header file write failed");
+        XFCLOSE(file);
+        return FWRITE_ERROR;
+    }
+
+#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
+    if (SESSION_ROW_RD_LOCK(&SessionCache[0]) != 0) {
+        WOLFSSL_MSG("Session cache mutex lock failed");
+        XFCLOSE(file);
+        return BAD_MUTEX_E;
+    }
+#endif
+    /* session cache */
+    for (i = 0; i < cache_header.rows; ++i) {
+    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
+        if (SESSION_ROW_RD_LOCK(&SessionCache[i]) != 0) {
+            WOLFSSL_MSG("Session row cache mutex lock failed");
+            XFCLOSE(file);
+            return BAD_MUTEX_E;
+        }
+    #endif
+
+        ret = (int)XFWRITE(&SessionCache[i], SIZEOF_SESSION_ROW, 1, file);
+    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
+        SESSION_ROW_UNLOCK(&SessionCache[i]);
+    #endif
+        if (ret != 1) {
+            WOLFSSL_MSG("Session cache member file write failed");
+            rc = FWRITE_ERROR;
+            break;
+        }
+    }
+#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
+    SESSION_ROW_UNLOCK(&SessionCache[0]);
+#endif
+
+#ifndef NO_CLIENT_CACHE
+    /* client cache */
+    if (wc_LockMutex(&clisession_mutex) != 0) {
+        WOLFSSL_MSG("Client cache mutex lock failed");
+        XFCLOSE(file);
+        return BAD_MUTEX_E;
+    }
+    ret = (int)XFWRITE(ClientCache, sizeof(ClientCache), 1, file);
+    if (ret != 1) {
+        WOLFSSL_MSG("Client cache member file write failed");
+        rc = FWRITE_ERROR;
+    }
+    wc_UnLockMutex(&clisession_mutex);
+#endif /* !NO_CLIENT_CACHE */
+
+    XFCLOSE(file);
+    WOLFSSL_LEAVE("wolfSSL_save_session_cache", rc);
+
+    return rc;
+}
+
+
+/* Restore the persistent session cache from file */
+/* doesn't use memstore because of additional memory use */
+int wolfSSL_restore_session_cache(const char *fname)
+{
+    XFILE  file;
+    int    rc = WOLFSSL_SUCCESS;
+    int    ret;
+    int    i;
+    cache_header_t cache_header;
+
+    WOLFSSL_ENTER("wolfSSL_restore_session_cache");
+
+    file = XFOPEN(fname, "rb");
+    if (file == XBADFILE) {
+        WOLFSSL_MSG("Couldn't open session cache save file");
+        return WOLFSSL_BAD_FILE;
+    }
+    /* cache header */
+    ret = (int)XFREAD(&cache_header, sizeof(cache_header), 1, file);
+    if (ret != 1) {
+        WOLFSSL_MSG("Session cache header file read failed");
+        XFCLOSE(file);
+        return FREAD_ERROR;
+    }
+    if (cache_header.version   != WOLFSSL_CACHE_VERSION ||
+        cache_header.rows      != SESSION_ROWS ||
+        cache_header.columns   != SESSIONS_PER_ROW ||
+        cache_header.sessionSz != (int)sizeof(WOLFSSL_SESSION)) {
+
+        WOLFSSL_MSG("Session cache header match failed");
+        XFCLOSE(file);
+        return CACHE_MATCH_ERROR;
+    }
+
+#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
+    if (SESSION_ROW_WR_LOCK(&SessionCache[0]) != 0) {
+        WOLFSSL_MSG("Session cache mutex lock failed");
+        XFCLOSE(file);
+        return BAD_MUTEX_E;
+    }
+#endif
+    /* session cache */
+    for (i = 0; i < cache_header.rows; ++i) {
+    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
+        if (SESSION_ROW_WR_LOCK(&SessionCache[i]) != 0) {
+            WOLFSSL_MSG("Session row cache mutex lock failed");
+            XFCLOSE(file);
+            return BAD_MUTEX_E;
+        }
+    #endif
+
+        ret = (int)XFREAD(&SessionCache[i], SIZEOF_SESSION_ROW, 1, file);
+    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
+        SESSION_ROW_UNLOCK(&SessionCache[i]);
+    #endif
+        if (ret != 1) {
+            WOLFSSL_MSG("Session cache member file read failed");
+            XMEMSET(SessionCache, 0, sizeof SessionCache);
+            rc = FREAD_ERROR;
+            break;
+        }
+    }
+#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
+    SESSION_ROW_UNLOCK(&SessionCache[0]);
+#endif
+
+#ifndef NO_CLIENT_CACHE
+    /* client cache */
+    if (wc_LockMutex(&clisession_mutex) != 0) {
+        WOLFSSL_MSG("Client cache mutex lock failed");
+        XFCLOSE(file);
+        return BAD_MUTEX_E;
+    }
+    ret = (int)XFREAD(ClientCache, sizeof(ClientCache), 1, file);
+    if (ret != 1) {
+        WOLFSSL_MSG("Client cache member file read failed");
+        XMEMSET(ClientCache, 0, sizeof ClientCache);
+        rc = FREAD_ERROR;
+    }
+    wc_UnLockMutex(&clisession_mutex);
+#endif /* !NO_CLIENT_CACHE */
+
+    XFCLOSE(file);
+    WOLFSSL_LEAVE("wolfSSL_restore_session_cache", rc);
+
+    return rc;
+}
+
+#endif /* !NO_FILESYSTEM */
+#endif /* PERSIST_SESSION_CACHE && !SESSION_CACHE_DYNAMIC_MEM */
+
+
+/* on by default if built in but allow user to turn off */
+WOLFSSL_ABI
+long wolfSSL_CTX_set_session_cache_mode(WOLFSSL_CTX* ctx, long mode)
+{
+    WOLFSSL_ENTER("wolfSSL_CTX_set_session_cache_mode");
+
+    if (ctx == NULL)
+        return WOLFSSL_FAILURE;
+
+    if (mode == WOLFSSL_SESS_CACHE_OFF) {
+        ctx->sessionCacheOff = 1;
+#ifdef HAVE_EXT_CACHE
+        ctx->internalCacheOff = 1;
+        ctx->internalCacheLookupOff = 1;
+#endif
+    }
+
+    if ((mode & WOLFSSL_SESS_CACHE_NO_AUTO_CLEAR) != 0)
+        ctx->sessionCacheFlushOff = 1;
+
+#ifdef HAVE_EXT_CACHE
+    /* WOLFSSL_SESS_CACHE_NO_INTERNAL activates both if's */
+    if ((mode & WOLFSSL_SESS_CACHE_NO_INTERNAL_STORE) != 0)
+        ctx->internalCacheOff = 1;
+    if ((mode & WOLFSSL_SESS_CACHE_NO_INTERNAL_LOOKUP) != 0)
+        ctx->internalCacheLookupOff = 1;
+#endif
+
+    return WOLFSSL_SUCCESS;
+}
+
+#ifdef OPENSSL_EXTRA
+#ifdef HAVE_MAX_FRAGMENT
+/* return the max fragment size set when handshake was negotiated */
+unsigned char wolfSSL_SESSION_get_max_fragment_length(WOLFSSL_SESSION* session)
+{
+    session = ClientSessionToSession(session);
+    if (session == NULL) {
+        return 0;
+    }
+
+    return session->mfl;
+}
+#endif
+
+
+/* Get the session cache mode for CTX
+ *
+ * ctx  WOLFSSL_CTX struct to get cache mode from
+ *
+ * Returns a bit mask that has the session cache mode */
+long wolfSSL_CTX_get_session_cache_mode(WOLFSSL_CTX* ctx)
+{
+    long m = 0;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_get_session_cache_mode");
+
+    if (ctx == NULL) {
+        return m;
+    }
+
+    if (ctx->sessionCacheOff != 1) {
+        m |= WOLFSSL_SESS_CACHE_SERVER;
+    }
+
+    if (ctx->sessionCacheFlushOff == 1) {
+        m |= WOLFSSL_SESS_CACHE_NO_AUTO_CLEAR;
+    }
+
+#ifdef HAVE_EXT_CACHE
+    if (ctx->internalCacheOff == 1) {
+        m |= WOLFSSL_SESS_CACHE_NO_INTERNAL_STORE;
+    }
+    if (ctx->internalCacheLookupOff == 1) {
+        m |= WOLFSSL_SESS_CACHE_NO_INTERNAL_LOOKUP;
+    }
+#endif
+
+    return m;
+}
+#endif /* OPENSSL_EXTRA */
+
+#endif /* !NO_SESSION_CACHE */
+
+#ifndef NO_SESSION_CACHE
+
+WOLFSSL_ABI
+void wolfSSL_flush_sessions(WOLFSSL_CTX* ctx, long tm)
+{
+    /* static table now, no flushing needed */
+    (void)ctx;
+    (void)tm;
+}
+
+void wolfSSL_CTX_flush_sessions(WOLFSSL_CTX* ctx, long tm)
+{
+    int i, j;
+    byte id[ID_LEN];
+
+    (void)ctx;
+    XMEMSET(id, 0, ID_LEN);
+    WOLFSSL_ENTER("wolfSSL_flush_sessions");
+    for (i = 0; i < SESSION_ROWS; ++i) {
+        if (SESSION_ROW_WR_LOCK(&SessionCache[i]) != 0) {
+            WOLFSSL_MSG("Session cache mutex lock failed");
+            return;
+        }
+        for (j = 0; j < SESSIONS_PER_ROW; j++) {
+#ifdef SESSION_CACHE_DYNAMIC_MEM
+            WOLFSSL_SESSION* s = SessionCache[i].Sessions[j];
+#else
+            WOLFSSL_SESSION* s = &SessionCache[i].Sessions[j];
+#endif
+            if (
+#ifdef SESSION_CACHE_DYNAMIC_MEM
+                s != NULL &&
+#endif
+                XMEMCMP(s->sessionID, id, ID_LEN) != 0 &&
+                s->bornOn + s->timeout < (word32)tm
+                )
+            {
+                EvictSessionFromCache(s);
+#ifdef SESSION_CACHE_DYNAMIC_MEM
+                XFREE(s, s->heap, DYNAMIC_TYPE_SESSION);
+                SessionCache[i].Sessions[j] = NULL;
+#endif
+            }
+        }
+        SESSION_ROW_UNLOCK(&SessionCache[i]);
+    }
+}
+
+
+/* set ssl session timeout in seconds */
+WOLFSSL_ABI
+int wolfSSL_set_timeout(WOLFSSL* ssl, unsigned int to)
+{
+    if (ssl == NULL)
+        return BAD_FUNC_ARG;
+
+    if (to == 0)
+        to = WOLFSSL_SESSION_TIMEOUT;
+    ssl->timeout = to;
+
+    return WOLFSSL_SUCCESS;
+}
+
+
+/**
+ * Sets ctx session timeout in seconds.
+ * The timeout value set here should be reflected in the
+ * "session ticket lifetime hint" if this API works in the openssl compat-layer.
+ * Therefore wolfSSL_CTX_set_TicketHint is called internally.
+ * Arguments:
+ *  - ctx  WOLFSSL_CTX object which the timeout is set to
+ *  - to   timeout value in second
+ * Returns:
+ *  WOLFSSL_SUCCESS on success, BAD_FUNC_ARG on failure.
+ *  When WOLFSSL_ERROR_CODE_OPENSSL is defined, returns previous timeout value
+ *  on success, BAD_FUNC_ARG on failure.
+ */
+WOLFSSL_ABI
+int wolfSSL_CTX_set_timeout(WOLFSSL_CTX* ctx, unsigned int to)
+{
+    #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    word32 prev_timeout = 0;
+    #endif
+
+    int ret = WOLFSSL_SUCCESS;
+    (void)ret;
+
+    if (ctx == NULL)
+        ret = BAD_FUNC_ARG;
+
+    if (ret == WOLFSSL_SUCCESS) {
+    #if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+        prev_timeout = ctx->timeout;
+    #endif
+        if (to == 0) {
+            ctx->timeout = WOLFSSL_SESSION_TIMEOUT;
+        }
+        else {
+            ctx->timeout = to;
+        }
+    }
+#if defined(OPENSSL_EXTRA) && defined(HAVE_SESSION_TICKET) && \
+   !defined(NO_WOLFSSL_SERVER)
+    if (ret == WOLFSSL_SUCCESS) {
+        if (to == 0) {
+            ret = wolfSSL_CTX_set_TicketHint(ctx, SESSION_TICKET_HINT_DEFAULT);
+        }
+        else {
+            ret = wolfSSL_CTX_set_TicketHint(ctx, (int)to);
+        }
+    }
+#endif /* OPENSSL_EXTRA && HAVE_SESSION_TICKET && !NO_WOLFSSL_SERVER */
+
+#if defined(WOLFSSL_ERROR_CODE_OPENSSL)
+    if (ret == WOLFSSL_SUCCESS) {
+        return (int)prev_timeout;
+    }
+    else {
+        return ret;
+    }
+#else
+    return ret;
+#endif /* WOLFSSL_ERROR_CODE_OPENSSL */
+}
+
+
+#ifndef NO_CLIENT_CACHE
+
+/* Get Session from Client cache based on id/len, return NULL on failure */
+WOLFSSL_SESSION* wolfSSL_GetSessionClient(WOLFSSL* ssl, const byte* id, int len)
+{
+    WOLFSSL_SESSION* ret = NULL;
+    word32          row;
+    int             idx;
+    int             count;
+    int             error = 0;
+    ClientSession*  clSess;
+
+    WOLFSSL_ENTER("wolfSSL_GetSessionClient");
+
+    if (ssl->ctx->sessionCacheOff) {
+        WOLFSSL_MSG("Session Cache off");
+        return NULL;
+    }
+
+    if (ssl->options.side == WOLFSSL_SERVER_END)
+        return NULL;
+
+    len = (int)min(SERVER_ID_LEN, (word32)len);
+
+    /* Do not access ssl->ctx->get_sess_cb from here. It is using a different
+     * set of ID's */
+
+    row = HashObject(id, (word32)len, &error) % CLIENT_SESSION_ROWS;
+    if (error != 0) {
+        WOLFSSL_MSG("Hash session failed");
+        return NULL;
+    }
+
+    if (wc_LockMutex(&clisession_mutex) != 0) {
+        WOLFSSL_MSG("Client cache mutex lock failed");
+        return NULL;
+    }
+
+    /* start from most recently used */
+    count = (int)min((word32)ClientCache[row].totalCount, CLIENT_SESSIONS_PER_ROW);
+    idx = ClientCache[row].nextIdx - 1;
+    if (idx < 0 || idx >= CLIENT_SESSIONS_PER_ROW) {
+        /* if back to front, the previous was end */
+        idx = CLIENT_SESSIONS_PER_ROW - 1;
+    }
+    clSess = ClientCache[row].Clients;
+
+    for (; count > 0; --count) {
+        WOLFSSL_SESSION* current;
+        SessionRow* sessRow;
+
+        if (clSess[idx].serverRow >= SESSION_ROWS) {
+            WOLFSSL_MSG("Client cache serverRow invalid");
+            break;
+        }
+
+        /* lock row */
+        sessRow = &SessionCache[clSess[idx].serverRow];
+        if (SESSION_ROW_RD_LOCK(sessRow) != 0) {
+            WOLFSSL_MSG("Session cache row lock failure");
+            break;
+        }
+
+#ifdef SESSION_CACHE_DYNAMIC_MEM
+        current = sessRow->Sessions[clSess[idx].serverIdx];
+#else
+        current = &sessRow->Sessions[clSess[idx].serverIdx];
+#endif
+        if (current && XMEMCMP(current->serverID, id, len) == 0) {
+            WOLFSSL_MSG("Found a serverid match for client");
+            if (LowResTimer() < (current->bornOn + current->timeout)) {
+                WOLFSSL_MSG("Session valid");
+                ret = current;
+                SESSION_ROW_UNLOCK(sessRow);
+                break;
+            } else {
+                WOLFSSL_MSG("Session timed out");  /* could have more for id */
+            }
+        } else {
+            WOLFSSL_MSG("ServerID not a match from client table");
+        }
+        SESSION_ROW_UNLOCK(sessRow);
+
+        idx = idx > 0 ? idx - 1 : CLIENT_SESSIONS_PER_ROW - 1;
+    }
+
+    wc_UnLockMutex(&clisession_mutex);
+
+    return ret;
+}
+
+#endif /* !NO_CLIENT_CACHE */
+
+static int SslSessionCacheOff(const WOLFSSL* ssl,
+    const WOLFSSL_SESSION* session)
+{
+    (void)session;
+    return ssl->options.sessionCacheOff
+    #if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_FORCE_CACHE_ON_TICKET)
+                && session->ticketLen == 0
+    #endif
+                ;
+}
+
+#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_TLS13) &&                  \
+    defined(WOLFSSL_TICKET_NONCE_MALLOC) && \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+/**
+ * SessionTicketNoncePrealloc() - prealloc a buffer for ticket nonces
+ * @output: [in] pointer to WOLFSSL_SESSION object that will soon be a
+ * destination of a session duplication
+ * @buf: [out] address of the preallocated buf
+ * @len: [out] len of the preallocated buf
+ *
+ * prealloc a buffer that will likely suffice to contain a ticket nonce. It's
+ * used when copying session under lock, when syscalls need to be avoided. If
+ * output already has a dynamic buffer, it's reused.
+ */
+static int SessionTicketNoncePrealloc(byte** buf, byte* len, void *heap)
+{
+    (void)heap;
+
+    *buf = (byte*)XMALLOC(PREALLOC_SESSION_TICKET_NONCE_LEN, heap,
+        DYNAMIC_TYPE_SESSION_TICK);
+    if (*buf == NULL) {
+        WOLFSSL_MSG("Failed to preallocate ticket nonce buffer");
+        *len = 0;
+        return 1;
+    }
+
+    *len = PREALLOC_SESSION_TICKET_NONCE_LEN;
+    return 0;
+}
+#endif /* HAVE_SESSION_TICKET && WOLFSSL_TLS13 */
+
+static int wolfSSL_DupSessionEx(const WOLFSSL_SESSION* input,
+    WOLFSSL_SESSION* output, int avoidSysCalls, byte* ticketNonceBuf,
+    byte* ticketNonceLen, byte* preallocUsed);
+
+void TlsSessionCacheUnlockRow(word32 row)
+{
+    SessionRow* sessRow;
+
+    sessRow = &SessionCache[row];
+    (void)sessRow;
+    SESSION_ROW_UNLOCK(sessRow);
+}
+
+/* Don't use this function directly. Use TlsSessionCacheGetAndRdLock and
+ * TlsSessionCacheGetAndWrLock to fully utilize compiler const support. */
+static int TlsSessionCacheGetAndLock(const byte *id,
+    const WOLFSSL_SESSION **sess, word32 *lockedRow, byte readOnly, byte side)
+{
+    SessionRow *sessRow;
+    const WOLFSSL_SESSION *s;
+    word32 row;
+    int count;
+    int error;
+    int idx;
+
+    *sess = NULL;
+    row = HashObject(id, ID_LEN, &error) % SESSION_ROWS;
+    if (error != 0)
+        return error;
+    sessRow = &SessionCache[row];
+    if (readOnly)
+        error = SESSION_ROW_RD_LOCK(sessRow);
+    else
+        error = SESSION_ROW_WR_LOCK(sessRow);
+    if (error != 0)
+        return FATAL_ERROR;
+
+    /* start from most recently used */
+    count = (int)min((word32)sessRow->totalCount, SESSIONS_PER_ROW);
+    idx = sessRow->nextIdx - 1;
+    if (idx < 0 || idx >= SESSIONS_PER_ROW) {
+        idx = SESSIONS_PER_ROW - 1; /* if back to front, the previous was end */
+    }
+    for (; count > 0; --count) {
+#ifdef SESSION_CACHE_DYNAMIC_MEM
+        s = sessRow->Sessions[idx];
+#else
+        s = &sessRow->Sessions[idx];
+#endif
+        if (s && XMEMCMP(s->sessionID, id, ID_LEN) == 0 && s->side == side) {
+            *sess = s;
+            break;
+        }
+        idx = idx > 0 ? idx - 1 : SESSIONS_PER_ROW - 1;
+    }
+    if (*sess == NULL) {
+        SESSION_ROW_UNLOCK(sessRow);
+    }
+    else {
+        *lockedRow = row;
+    }
+
+    return 0;
+}
+
+static int CheckSessionMatch(const WOLFSSL* ssl, const WOLFSSL_SESSION* sess)
+{
+    if (ssl == NULL || sess == NULL)
+        return 0;
+#ifdef OPENSSL_EXTRA
+    if (ssl->sessionCtxSz > 0 && (ssl->sessionCtxSz != sess->sessionCtxSz ||
+           XMEMCMP(ssl->sessionCtx, sess->sessionCtx, sess->sessionCtxSz) != 0))
+        return 0;
+#endif
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)
+    if (IsAtLeastTLSv1_3(ssl->version) != IsAtLeastTLSv1_3(sess->version))
+        return 0;
+#endif
+    return 1;
+}
+
+int TlsSessionCacheGetAndRdLock(const byte *id, const WOLFSSL_SESSION **sess,
+        word32 *lockedRow, byte side)
+{
+    return TlsSessionCacheGetAndLock(id, sess, lockedRow, 1, side);
+}
+
+int TlsSessionCacheGetAndWrLock(const byte *id, WOLFSSL_SESSION **sess,
+        word32 *lockedRow, byte side)
+{
+    return TlsSessionCacheGetAndLock(id, (const WOLFSSL_SESSION**)sess,
+            lockedRow, 0, side);
+}
+
+int wolfSSL_GetSessionFromCache(WOLFSSL* ssl, WOLFSSL_SESSION* output)
+{
+    const WOLFSSL_SESSION* sess = NULL;
+    const byte*  id = NULL;
+    word32       row;
+    int          error = 0;
+#ifdef HAVE_SESSION_TICKET
+#ifndef WOLFSSL_SMALL_STACK
+    byte         tmpTicket[PREALLOC_SESSION_TICKET_LEN];
+#else
+    byte*        tmpTicket = NULL;
+#endif
+#ifdef WOLFSSL_TLS13
+    byte *preallocNonce = NULL;
+    byte preallocNonceLen = 0;
+    byte preallocNonceUsed = 0;
+#endif /* WOLFSSL_TLS13 */
+    byte         tmpBufSet = 0;
+#endif
+#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
+    WOLFSSL_X509* peer = NULL;
+#endif
+    byte         bogusID[ID_LEN];
+    byte         bogusIDSz = 0;
+
+    WOLFSSL_ENTER("wolfSSL_GetSessionFromCache");
+
+    if (output == NULL) {
+        WOLFSSL_MSG("NULL output");
+        return WOLFSSL_FAILURE;
+    }
+
+    if (SslSessionCacheOff(ssl, ssl->session))
+        return WOLFSSL_FAILURE;
+
+    if (ssl->options.haveSessionId == 0 && !ssl->session->haveAltSessionID)
+        return WOLFSSL_FAILURE;
+
+#ifdef HAVE_SESSION_TICKET
+    if (ssl->options.side == WOLFSSL_SERVER_END && ssl->options.useTicket == 1)
+        return WOLFSSL_FAILURE;
+#endif
+
+    XMEMSET(bogusID, 0, sizeof(bogusID));
+    if (!IsAtLeastTLSv1_3(ssl->version) && ssl->arrays != NULL
+            && !ssl->session->haveAltSessionID)
+        id = ssl->arrays->sessionID;
+    else if (ssl->session->haveAltSessionID) {
+        id = ssl->session->altSessionID;
+        /* We want to restore the bogus ID for TLS compatibility */
+        if (output == ssl->session) {
+            XMEMCPY(bogusID, ssl->session->sessionID, ID_LEN);
+            bogusIDSz = ssl->session->sessionIDSz;
+        }
+    }
+    else
+        id = ssl->session->sessionID;
+
+
+#ifdef HAVE_EXT_CACHE
+    if (ssl->ctx->get_sess_cb != NULL) {
+        int copy = 0;
+        int found = 0;
+        WOLFSSL_SESSION* extSess;
+        /* Attempt to retrieve the session from the external cache. */
+        WOLFSSL_MSG("Calling external session cache");
+        extSess = ssl->ctx->get_sess_cb(ssl, (byte*)id, ID_LEN, &copy);
+        if ((extSess != NULL)
+                && CheckSessionMatch(ssl, extSess)
+            ) {
+            WOLFSSL_MSG("Session found in external cache");
+            found = 1;
+
+            error = wolfSSL_DupSession(extSess, output, 0);
+#ifdef HAVE_EX_DATA
+            extSess->ownExData = 1;
+            output->ownExData = 0;
+#endif
+            /* We want to restore the bogus ID for TLS compatibility */
+            if (ssl->session->haveAltSessionID &&
+                    output == ssl->session) {
+                XMEMCPY(ssl->session->sessionID, bogusID, ID_LEN);
+                ssl->session->sessionIDSz = bogusIDSz;
+            }
+        }
+        /* If copy not set then free immediately */
+        if (extSess != NULL && !copy)
+            wolfSSL_FreeSession(ssl->ctx, extSess);
+        if (found)
+            return error;
+        WOLFSSL_MSG("Session not found in external cache");
+    }
+
+    if (ssl->options.internalCacheLookupOff) {
+        WOLFSSL_MSG("Internal cache lookup turned off");
+        return WOLFSSL_FAILURE;
+    }
+#endif
+
+#ifdef HAVE_SESSION_TICKET
+    if (output->ticket == NULL ||
+            output->ticketLenAlloc < PREALLOC_SESSION_TICKET_LEN) {
+#ifdef WOLFSSL_SMALL_STACK
+        tmpTicket = (byte*)XMALLOC(PREALLOC_SESSION_TICKET_LEN, output->heap,
+                DYNAMIC_TYPE_TMP_BUFFER);
+        if (tmpTicket == NULL) {
+            WOLFSSL_MSG("tmpTicket malloc failed");
+            return WOLFSSL_FAILURE;
+        }
+#endif
+        if (output->ticketLenAlloc)
+            XFREE(output->ticket, output->heap, DYNAMIC_TYPE_SESSION_TICK);
+        output->ticket = tmpTicket; /* cppcheck-suppress autoVariables
+                                     */
+        output->ticketLenAlloc = PREALLOC_SESSION_TICKET_LEN;
+        output->ticketLen = 0;
+        tmpBufSet = 1;
+    }
+#endif
+
+#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
+    if (output->peer != NULL) {
+        wolfSSL_X509_free(output->peer);
+        output->peer = NULL;
+    }
+#endif
+
+#if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET) &&                  \
+    defined(WOLFSSL_TICKET_NONCE_MALLOC) &&                                    \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+    if (output->ticketNonce.data != output->ticketNonce.dataStatic) {
+        XFREE(output->ticketNonce.data, output->heap,
+            DYNAMIC_TYPE_SESSION_TICK);
+        output->ticketNonce.data = output->ticketNonce.dataStatic;
+        output->ticketNonce.len = 0;
+    }
+    error = SessionTicketNoncePrealloc(&preallocNonce, &preallocNonceLen,
+        output->heap);
+    if (error != 0) {
+        if (tmpBufSet) {
+            output->ticket = output->staticTicket;
+            output->ticketLenAlloc = 0;
+        }
+#ifdef WOLFSSL_SMALL_STACK
+        if (tmpTicket != NULL)
+            XFREE(tmpTicket, output->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+        return WOLFSSL_FAILURE;
+    }
+#endif /* WOLFSSL_TLS13 && HAVE_SESSION_TICKET*/
+
+    /* init to avoid clang static analyzer false positive */
+    row = 0;
+    error = TlsSessionCacheGetAndRdLock(id, &sess, &row,
+        (byte)ssl->options.side);
+    error = (error == 0) ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
+    if (error != WOLFSSL_SUCCESS || sess == NULL) {
+        WOLFSSL_MSG("Get Session from cache failed");
+        error = WOLFSSL_FAILURE;
+#ifdef HAVE_SESSION_TICKET
+        if (tmpBufSet) {
+            output->ticket = output->staticTicket;
+            output->ticketLenAlloc = 0;
+        }
+#ifdef WOLFSSL_TLS13
+        if (preallocNonce != NULL) {
+            XFREE(preallocNonce, output->heap, DYNAMIC_TYPE_SESSION_TICK);
+            preallocNonce = NULL;
+        }
+#endif /* WOLFSSL_TLS13 */
+#ifdef WOLFSSL_SMALL_STACK
+        if (tmpTicket != NULL) {
+            XFREE(tmpTicket, output->heap, DYNAMIC_TYPE_TMP_BUFFER);
+            tmpTicket = NULL;
+        }
+#endif
+#endif
+    }
+    else {
+        if (!CheckSessionMatch(ssl, sess)) {
+            WOLFSSL_MSG("Invalid session: can't be used in this context");
+            TlsSessionCacheUnlockRow(row);
+            error = WOLFSSL_FAILURE;
+        }
+        else if (LowResTimer() >= (sess->bornOn + sess->timeout)) {
+            WOLFSSL_SESSION* wrSess = NULL;
+            WOLFSSL_MSG("Invalid session: timed out");
+            sess = NULL;
+            TlsSessionCacheUnlockRow(row);
+            /* Attempt to get a write lock */
+            error = TlsSessionCacheGetAndWrLock(id, &wrSess, &row,
+                    (byte)ssl->options.side);
+            if (error == 0 && wrSess != NULL) {
+                EvictSessionFromCache(wrSess);
+                TlsSessionCacheUnlockRow(row);
+            }
+            error = WOLFSSL_FAILURE;
+        }
+    }
+
+    /* mollify confused cppcheck nullPointer warning. */
+    if (sess == NULL)
+        error = WOLFSSL_FAILURE;
+
+    if (error == WOLFSSL_SUCCESS) {
+#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_TLS13)
+        error = wolfSSL_DupSessionEx(sess, output, 1,
+            preallocNonce, &preallocNonceLen, &preallocNonceUsed);
+#else
+        error = wolfSSL_DupSession(sess, output, 1);
+#endif /* HAVE_SESSION_TICKET && WOLFSSL_TLS13 */
+#ifdef HAVE_EX_DATA
+        output->ownExData = !sess->ownExData; /* Session may own ex_data */
+#endif
+        TlsSessionCacheUnlockRow(row);
+    }
+
+    /* We want to restore the bogus ID for TLS compatibility */
+    if (ssl->session->haveAltSessionID &&
+            output == ssl->session) {
+        XMEMCPY(ssl->session->sessionID, bogusID, ID_LEN);
+        ssl->session->sessionIDSz = bogusIDSz;
+    }
+
+#ifdef HAVE_SESSION_TICKET
+    if (tmpBufSet) {
+        if (error == WOLFSSL_SUCCESS) {
+            if (output->ticketLen > SESSION_TICKET_LEN) {
+                output->ticket = (byte*)XMALLOC(output->ticketLen, output->heap,
+                        DYNAMIC_TYPE_SESSION_TICK);
+                if (output->ticket == NULL) {
+                    error = WOLFSSL_FAILURE;
+                    output->ticket = output->staticTicket;
+                    output->ticketLenAlloc = 0;
+                    output->ticketLen = 0;
+                }
+            }
+            else {
+                output->ticket = output->staticTicket;
+                output->ticketLenAlloc = 0;
+            }
+        }
+        else {
+            output->ticket = output->staticTicket;
+            output->ticketLenAlloc = 0;
+            output->ticketLen = 0;
+        }
+        if (error == WOLFSSL_SUCCESS) {
+            XMEMCPY(output->ticket, tmpTicket, output->ticketLen);
+        }
+    }
+#ifdef WOLFSSL_SMALL_STACK
+    if (tmpTicket != NULL)
+        XFREE(tmpTicket, output->heap, DYNAMIC_TYPE_TMP_BUFFER);
+#endif
+
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+    if (error == WOLFSSL_SUCCESS && preallocNonceUsed) {
+        if (preallocNonceLen < PREALLOC_SESSION_TICKET_NONCE_LEN) {
+            /* buffer bigger than needed */
+#ifndef XREALLOC
+            output->ticketNonce.data = (byte*)XMALLOC(preallocNonceLen,
+                output->heap, DYNAMIC_TYPE_SESSION_TICK);
+            if (output->ticketNonce.data != NULL)
+                XMEMCPY(output->ticketNonce.data, preallocNonce,
+                    preallocNonceLen);
+            XFREE(preallocNonce, output->heap, DYNAMIC_TYPE_SESSION_TICK);
+            preallocNonce = NULL;
+#else
+            output->ticketNonce.data = (byte*)XREALLOC(preallocNonce,
+                preallocNonceLen, output->heap, DYNAMIC_TYPE_SESSION_TICK);
+            if (output->ticketNonce.data != NULL) {
+                /* don't free the reallocated pointer */
+                preallocNonce = NULL;
+            }
+#endif /* !XREALLOC */
+            if (output->ticketNonce.data == NULL) {
+                output->ticketNonce.data = output->ticketNonce.dataStatic;
+                output->ticketNonce.len = 0;
+                error = WOLFSSL_FAILURE;
+                /* preallocNonce will be free'd after the if */
+            }
+        }
+        else {
+            output->ticketNonce.data = preallocNonce;
+            output->ticketNonce.len = preallocNonceLen;
+            preallocNonce = NULL;
+        }
+    }
+    if (preallocNonce != NULL)
+        XFREE(preallocNonce, output->heap, DYNAMIC_TYPE_SESSION_TICK);
+#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
+
+#endif
+
+#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
+    if (peer != NULL) {
+        wolfSSL_X509_free(peer);
+    }
+#endif
+
+    return error;
+}
+
+WOLFSSL_SESSION* wolfSSL_GetSession(WOLFSSL* ssl, byte* masterSecret,
+        byte restoreSessionCerts)
+{
+    WOLFSSL_SESSION* ret = NULL;
+
+    (void)restoreSessionCerts; /* Kept for compatibility */
+
+    if (wolfSSL_GetSessionFromCache(ssl, ssl->session) == WOLFSSL_SUCCESS) {
+        ret = ssl->session;
+    }
+    else {
+        WOLFSSL_MSG("wolfSSL_GetSessionFromCache did not return a session");
+    }
+
+    if (ret != NULL && masterSecret != NULL)
+        XMEMCPY(masterSecret, ret->masterSecret, SECRET_LEN);
+
+    return ret;
+}
+
+int wolfSSL_SetSession(WOLFSSL* ssl, WOLFSSL_SESSION* session)
+{
+    SessionRow* sessRow = NULL;
+    int ret = WOLFSSL_SUCCESS;
+
+    session = ClientSessionToSession(session);
+
+    if (ssl == NULL || session == NULL || !session->isSetup) {
+        WOLFSSL_MSG("ssl or session NULL or not set up");
+        return WOLFSSL_FAILURE;
+    }
+
+    /* We need to lock the session as the first step if its in the cache */
+    if (session->type == WOLFSSL_SESSION_TYPE_CACHE) {
+        if (session->cacheRow < SESSION_ROWS) {
+            sessRow = &SessionCache[session->cacheRow];
+            if (SESSION_ROW_RD_LOCK(sessRow) != 0) {
+                WOLFSSL_MSG("Session row lock failed");
+                return WOLFSSL_FAILURE;
+            }
+        }
+    }
+
+    if (ret == WOLFSSL_SUCCESS && ssl->options.side != WOLFSSL_NEITHER_END &&
+            (byte)ssl->options.side != session->side) {
+        WOLFSSL_MSG("Setting session for wrong role");
+        ret = WOLFSSL_FAILURE;
+    }
+
+    if (ret == WOLFSSL_SUCCESS) {
+        if (ssl->session == session) {
+            WOLFSSL_MSG("ssl->session and session same");
+        }
+        else if (session->type != WOLFSSL_SESSION_TYPE_CACHE) {
+            if (wolfSSL_SESSION_up_ref(session) == WOLFSSL_SUCCESS) {
+                wolfSSL_FreeSession(ssl->ctx, ssl->session);
+                ssl->session = session;
+            }
+            else
+                ret = WOLFSSL_FAILURE;
+        }
+        else {
+            ret = wolfSSL_DupSession(session, ssl->session, 0);
+            if (ret != WOLFSSL_SUCCESS)
+                WOLFSSL_MSG("Session duplicate failed");
+        }
+    }
+
+    /* Let's copy over the altSessionID for local cache purposes */
+    if (ret == WOLFSSL_SUCCESS && session->haveAltSessionID &&
+            ssl->session != session) {
+        ssl->session->haveAltSessionID = 1;
+        XMEMCPY(ssl->session->altSessionID, session->altSessionID, ID_LEN);
+    }
+
+    if (sessRow != NULL) {
+        SESSION_ROW_UNLOCK(sessRow);
+        sessRow = NULL;
+    }
+
+    /* Note: the `session` variable cannot be used below, since the row is
+     * un-locked */
+
+    if (ret != WOLFSSL_SUCCESS)
+        return ret;
+
+#ifdef WOLFSSL_SESSION_ID_CTX
+    /* check for application context id */
+    if (ssl->sessionCtxSz > 0) {
+        if (XMEMCMP(ssl->sessionCtx, ssl->session->sessionCtx,
+                ssl->sessionCtxSz)) {
+            /* context id did not match! */
+            WOLFSSL_MSG("Session context did not match");
+            return WOLFSSL_FAILURE;
+        }
+    }
+#endif /* WOLFSSL_SESSION_ID_CTX */
+
+    if (LowResTimer() >= (ssl->session->bornOn + ssl->session->timeout)) {
+#if !defined(OPENSSL_EXTRA) || !defined(WOLFSSL_ERROR_CODE_OPENSSL)
+        return WOLFSSL_FAILURE;  /* session timed out */
+#else /* defined(OPENSSL_EXTRA) && defined(WOLFSSL_ERROR_CODE_OPENSSL) */
+        WOLFSSL_MSG("Session is expired but return success for "
+                    "OpenSSL compatibility");
+#endif
+    }
+    ssl->options.resuming = 1;
+    ssl->options.haveEMS = ssl->session->haveEMS;
+
+#if defined(SESSION_CERTS) || (defined(WOLFSSL_TLS13) && \
+                           defined(HAVE_SESSION_TICKET))
+    ssl->version              = ssl->session->version;
+    if (IsAtLeastTLSv1_3(ssl->version))
+        ssl->options.tls1_3 = 1;
+#endif
+#if defined(SESSION_CERTS) || !defined(NO_RESUME_SUITE_CHECK) || \
+                    (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
+    ssl->options.cipherSuite0 = ssl->session->cipherSuite0;
+    ssl->options.cipherSuite  = ssl->session->cipherSuite;
+#endif
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    ssl->peerVerifyRet = (unsigned long)ssl->session->peerVerifyRet;
+#endif
+
+    return WOLFSSL_SUCCESS;
+}
+
+
+#ifdef WOLFSSL_SESSION_STATS
+static int get_locked_session_stats(word32* active, word32* total,
+                                    word32* peak);
+#endif
+
+#ifndef NO_CLIENT_CACHE
+ClientSession* AddSessionToClientCache(int side, int row, int idx,
+    byte* serverID, word16 idLen, const byte* sessionID, word16 useTicket)
+{
+    int error = -1;
+    word32 clientRow = 0, clientIdx = 0;
+    ClientSession* ret = NULL;
+
+    (void)useTicket;
+    if (side == WOLFSSL_CLIENT_END
+            && row != INVALID_SESSION_ROW
+            && (idLen
+#ifdef HAVE_SESSION_TICKET
+                || useTicket == 1
+#endif
+                || serverID != NULL
+                )) {
+
+        WOLFSSL_MSG("Trying to add client cache entry");
+
+        if (idLen) {
+            clientRow = HashObject(serverID,
+                    idLen, &error) % CLIENT_SESSION_ROWS;
+        }
+        else if (serverID != NULL) {
+            clientRow = HashObject(sessionID,
+                    ID_LEN, &error) % CLIENT_SESSION_ROWS;
+        }
+        else {
+            error = -1;
+        }
+        if (error == 0 && wc_LockMutex(&clisession_mutex) == 0) {
+            clientIdx = (word32)ClientCache[clientRow].nextIdx;
+            if (clientIdx < CLIENT_SESSIONS_PER_ROW) {
+                ClientCache[clientRow].Clients[clientIdx].serverRow =
+                                                                (word16)row;
+                ClientCache[clientRow].Clients[clientIdx].serverIdx =
+                                                                (word16)idx;
+                if (sessionID != NULL) {
+                    word32 sessionIDHash = HashObject(sessionID, ID_LEN,
+                                                      &error);
+                    if (error == 0) {
+                        ClientCache[clientRow].Clients[clientIdx].sessionIDHash
+                            = sessionIDHash;
+                    }
+                }
+            }
+            else {
+                error = -1;
+                ClientCache[clientRow].nextIdx = 0; /* reset index as safety */
+                WOLFSSL_MSG("Invalid client cache index! "
+                            "Possible corrupted memory");
+            }
+            if (error == 0) {
+                WOLFSSL_MSG("Adding client cache entry");
+
+                ret = &ClientCache[clientRow].Clients[clientIdx];
+
+                if (ClientCache[clientRow].totalCount < CLIENT_SESSIONS_PER_ROW)
+                    ClientCache[clientRow].totalCount++;
+                ClientCache[clientRow].nextIdx++;
+                ClientCache[clientRow].nextIdx %= CLIENT_SESSIONS_PER_ROW;
+            }
+
+            wc_UnLockMutex(&clisession_mutex);
+        }
+        else {
+            WOLFSSL_MSG("Hash session or lock failed");
+        }
+    }
+    else {
+        WOLFSSL_MSG("Skipping client cache");
+    }
+
+    return ret;
+}
+#endif /* !NO_CLIENT_CACHE */
+
+/**
+ * For backwards compatibility, this API needs to be used in *ALL* functions
+ * that access the WOLFSSL_SESSION members directly.
+ *
+ * This API checks if the passed in session is actually a ClientSession object
+ * and returns the matching session cache object. Otherwise just return the
+ * input. ClientSession objects only occur in the ClientCache. They are not
+ * allocated anywhere else.
+ */
+WOLFSSL_SESSION* ClientSessionToSession(const WOLFSSL_SESSION* session)
+{
+    WOLFSSL_ENTER("ClientSessionToSession");
+#ifdef NO_SESSION_CACHE_REF
+    return (WOLFSSL_SESSION*)session;
+#else
+#ifndef NO_CLIENT_CACHE
+    if (session == NULL)
+        return NULL;
+    /* Check if session points into ClientCache */
+    if ((byte*)session >= (byte*)ClientCache &&
+            /* Cast to byte* to make pointer arithmetic work per byte */
+            (byte*)session < ((byte*)ClientCache) + sizeof(ClientCache)) {
+        ClientSession* clientSession = (ClientSession*)session;
+        SessionRow* sessRow = NULL;
+        WOLFSSL_SESSION* cacheSession = NULL;
+        word32 sessionIDHash = 0;
+        int error = 0;
+        session = NULL; /* Default to NULL for failure case */
+        if (wc_LockMutex(&clisession_mutex) != 0) {
+            WOLFSSL_MSG("Client cache mutex lock failed");
+            return NULL;
+        }
+        if (clientSession->serverRow >= SESSION_ROWS ||
+                clientSession->serverIdx >= SESSIONS_PER_ROW) {
+            WOLFSSL_MSG("Client cache serverRow or serverIdx invalid");
+            error = -1;
+        }
+        /* Prevent memory access before clientSession->serverRow and
+         * clientSession->serverIdx are sanitized. */
+        XFENCE();
+        if (error == 0) {
+            /* Lock row */
+            sessRow = &SessionCache[clientSession->serverRow];
+            error = SESSION_ROW_RD_LOCK(sessRow);
+            if (error != 0) {
+                WOLFSSL_MSG("Session cache row lock failure");
+                sessRow = NULL;
+            }
+        }
+        if (error == 0) {
+#ifdef SESSION_CACHE_DYNAMIC_MEM
+            cacheSession = sessRow->Sessions[clientSession->serverIdx];
+#else
+            cacheSession = &sessRow->Sessions[clientSession->serverIdx];
+#endif
+            if (cacheSession && cacheSession->sessionIDSz == 0) {
+                cacheSession = NULL;
+                WOLFSSL_MSG("Session cache entry not set");
+                error = -1;
+            }
+        }
+        if (error == 0) {
+            /* Calculate the hash of the session ID */
+            sessionIDHash = HashObject(cacheSession->sessionID, ID_LEN,
+                    &error);
+        }
+        if (error == 0) {
+            /* Check the session ID hash matches */
+            error = clientSession->sessionIDHash != sessionIDHash;
+            if (error != 0)
+                WOLFSSL_MSG("session ID hashes don't match");
+        }
+        if (error == 0) {
+            /* Hashes match */
+            session = cacheSession;
+            WOLFSSL_MSG("Found session cache matching client session object");
+        }
+        if (sessRow != NULL) {
+            SESSION_ROW_UNLOCK(sessRow);
+        }
+        wc_UnLockMutex(&clisession_mutex);
+        return (WOLFSSL_SESSION*)session;
+    }
+    else {
+        /* Plain WOLFSSL_SESSION object */
+        return (WOLFSSL_SESSION*)session;
+    }
+#else
+    return (WOLFSSL_SESSION*)session;
+#endif
+#endif
+}
+
+int AddSessionToCache(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* addSession,
+        const byte* id, byte idSz, int* sessionIndex, int side,
+        word16 useTicket, ClientSession** clientCacheEntry)
+{
+    WOLFSSL_SESSION* cacheSession = NULL;
+    SessionRow* sessRow = NULL;
+    word32 idx = 0;
+#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
+    WOLFSSL_X509* cachePeer = NULL;
+    WOLFSSL_X509* addPeer = NULL;
+#endif
+#ifdef HAVE_SESSION_TICKET
+    byte*  cacheTicBuff = NULL;
+    byte   ticBuffUsed = 0;
+    byte*  ticBuff = NULL;
+    int    ticLen  = 0;
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+    byte *preallocNonce = NULL;
+    byte preallocNonceLen = 0;
+    byte preallocNonceUsed = 0;
+    byte *toFree = NULL;
+#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC */
+#endif /* HAVE_SESSION_TICKET */
+    int ret = 0;
+    int row;
+    int i;
+    int overwrite = 0;
+    (void)ctx;
+    (void)sessionIndex;
+    (void)useTicket;
+    (void)clientCacheEntry;
+
+    WOLFSSL_ENTER("AddSessionToCache");
+
+    if (idSz == 0) {
+        WOLFSSL_MSG("AddSessionToCache idSz == 0");
+        return BAD_FUNC_ARG;
+    }
+
+    addSession = ClientSessionToSession(addSession);
+    if (addSession == NULL) {
+        WOLFSSL_MSG("AddSessionToCache is NULL");
+        return MEMORY_E;
+    }
+
+#ifdef HAVE_SESSION_TICKET
+    ticLen = addSession->ticketLen;
+    /* Alloc Memory here to avoid syscalls during lock */
+    if (ticLen > SESSION_TICKET_LEN) {
+        ticBuff = (byte*)XMALLOC(ticLen, NULL,
+                DYNAMIC_TYPE_SESSION_TICK);
+        if (ticBuff == NULL) {
+            return MEMORY_E;
+        }
+    }
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+    if (addSession->ticketNonce.data != addSession->ticketNonce.dataStatic) {
+        /* use the AddSession->heap even if the buffer maybe saved in
+         * CachedSession objects. CachedSession heap and AddSession heap should
+         * be the same */
+        preallocNonce = (byte*)XMALLOC(addSession->ticketNonce.len,
+            addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
+        if (preallocNonce == NULL) {
+            if (ticBuff != NULL)
+                XFREE(ticBuff, addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
+            return MEMORY_E;
+        }
+        preallocNonceLen = addSession->ticketNonce.len;
+    }
+#endif /* WOLFSSL_TLS13 && WOLFSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3) */
+#endif /* HAVE_SESSION_TICKET */
+
+    /* Find a position for the new session in cache and use that */
+    /* Use the session object in the cache for external cache if required */
+    row = (int)(HashObject(id, ID_LEN, &ret) % SESSION_ROWS);
+    if (ret != 0) {
+        WOLFSSL_MSG("Hash session failed");
+    #ifdef HAVE_SESSION_TICKET
+        XFREE(ticBuff, NULL, DYNAMIC_TYPE_SESSION_TICK);
+    #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC)
+        XFREE(preallocNonce, addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
+    #endif
+    #endif
+        return ret;
+    }
+
+    sessRow = &SessionCache[row];
+    if (SESSION_ROW_WR_LOCK(sessRow) != 0) {
+    #ifdef HAVE_SESSION_TICKET
+        XFREE(ticBuff, NULL, DYNAMIC_TYPE_SESSION_TICK);
+    #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC)
+        XFREE(preallocNonce, addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
+    #endif
+    #endif
+        WOLFSSL_MSG("Session row lock failed");
+        return BAD_MUTEX_E;
+    }
+
+    for (i = 0; i < SESSIONS_PER_ROW && i < sessRow->totalCount; i++) {
+#ifdef SESSION_CACHE_DYNAMIC_MEM
+        cacheSession = sessRow->Sessions[i];
+#else
+        cacheSession = &sessRow->Sessions[i];
+#endif
+        if (cacheSession && XMEMCMP(id,
+                cacheSession->sessionID, ID_LEN) == 0 &&
+                cacheSession->side == side) {
+            WOLFSSL_MSG("Session already exists. Overwriting.");
+            overwrite = 1;
+            idx = (word32)i;
+            break;
+        }
+    }
+
+    if (!overwrite)
+        idx = (word32)sessRow->nextIdx;
+#ifdef SESSION_INDEX
+    if (sessionIndex != NULL)
+        *sessionIndex = (row << SESSIDX_ROW_SHIFT) | idx;
+#endif
+
+#ifdef SESSION_CACHE_DYNAMIC_MEM
+    cacheSession = sessRow->Sessions[idx];
+    if (cacheSession == NULL) {
+        cacheSession = (WOLFSSL_SESSION*) XMALLOC(sizeof(WOLFSSL_SESSION),
+                                         sessRow->heap, DYNAMIC_TYPE_SESSION);
+        if (cacheSession == NULL) {
+        #ifdef HAVE_SESSION_TICKET
+            XFREE(ticBuff, NULL, DYNAMIC_TYPE_SESSION_TICK);
+        #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC)
+            XFREE(preallocNonce, addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
+        #endif
+        #endif
+            SESSION_ROW_UNLOCK(sessRow);
+            return MEMORY_E;
+        }
+        XMEMSET(cacheSession, 0, sizeof(WOLFSSL_SESSION));
+        sessRow->Sessions[idx] = cacheSession;
+    }
+#else
+    cacheSession = &sessRow->Sessions[idx];
+#endif
+
+#ifdef HAVE_EX_DATA
+    if (overwrite) {
+        /* Figure out who owns the ex_data */
+        if (cacheSession->ownExData) {
+            /* Prioritize cacheSession copy */
+            XMEMCPY(&addSession->ex_data, &cacheSession->ex_data,
+                    sizeof(WOLFSSL_CRYPTO_EX_DATA));
+        }
+        /* else will be copied in wolfSSL_DupSession call */
+    }
+    else if (cacheSession->ownExData) {
+        crypto_ex_cb_free_data(cacheSession, crypto_ex_cb_ctx_session,
+                               &cacheSession->ex_data);
+        cacheSession->ownExData = 0;
+    }
+#endif
+
+    if (!overwrite)
+        EvictSessionFromCache(cacheSession);
+
+    cacheSession->type = WOLFSSL_SESSION_TYPE_CACHE;
+    cacheSession->cacheRow = row;
+
+#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
+    /* Save the peer field to free after unlocking the row */
+    if (cacheSession->peer != NULL)
+        cachePeer = cacheSession->peer;
+    cacheSession->peer = NULL;
+#endif
+#ifdef HAVE_SESSION_TICKET
+    /* If we can reuse the existing buffer in cacheSession then we won't touch
+     * ticBuff at all making it a very cheap malloc/free. The page on a modern
+     * OS will most likely not even be allocated to the process. */
+    if (ticBuff != NULL && cacheSession->ticketLenAlloc < ticLen) {
+        /* Save pointer only if separately allocated */
+        if (cacheSession->ticket != cacheSession->staticTicket)
+            cacheTicBuff = cacheSession->ticket;
+        ticBuffUsed = 1;
+        cacheSession->ticket = ticBuff;
+        cacheSession->ticketLenAlloc = (word16) ticLen;
+    }
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+    /* cache entry never used */
+    if (cacheSession->ticketNonce.data == NULL)
+        cacheSession->ticketNonce.data = cacheSession->ticketNonce.dataStatic;
+
+    if (cacheSession->ticketNonce.data !=
+            cacheSession->ticketNonce.dataStatic) {
+        toFree = cacheSession->ticketNonce.data;
+        cacheSession->ticketNonce.data = cacheSession->ticketNonce.dataStatic;
+        cacheSession->ticketNonce.len = 0;
+    }
+#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
+#endif
+#ifdef SESSION_CERTS
+    if (overwrite &&
+            addSession->chain.count == 0 &&
+            cacheSession->chain.count > 0) {
+        /* Copy in the certs from the session */
+        addSession->chain.count = cacheSession->chain.count;
+        XMEMCPY(addSession->chain.certs, cacheSession->chain.certs,
+                sizeof(x509_buffer) * cacheSession->chain.count);
+    }
+#endif /* SESSION_CERTS */
+#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
+    /* Don't copy the peer cert into cache */
+    addPeer = addSession->peer;
+    addSession->peer = NULL;
+#endif
+    cacheSession->heap = NULL;
+    /* Copy data into the cache object */
+#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_TLS13) &&                  \
+    defined(WOLFSSL_TICKET_NONCE_MALLOC) &&                                   \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+    ret = wolfSSL_DupSessionEx(addSession, cacheSession, 1, preallocNonce,
+        &preallocNonceLen, &preallocNonceUsed) == WOLFSSL_FAILURE;
+#else
+    ret = wolfSSL_DupSession(addSession, cacheSession, 1) == WOLFSSL_FAILURE;
+#endif /* HAVE_SESSION_TICKET && WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC
+          && FIPS_VERSION_GE(5,3)*/
+#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
+    addSession->peer = addPeer;
+#endif
+
+    if (ret == 0) {
+        if (!overwrite) {
+            /* Increment the totalCount and the nextIdx */
+            if (sessRow->totalCount < SESSIONS_PER_ROW)
+                sessRow->totalCount++;
+            sessRow->nextIdx = (sessRow->nextIdx + 1) % SESSIONS_PER_ROW;
+        }
+        if (id != addSession->sessionID) {
+            /* ssl->session->sessionID may contain the bogus ID or we want the
+             * ID from the arrays object */
+            XMEMCPY(cacheSession->sessionID, id, ID_LEN);
+            cacheSession->sessionIDSz = ID_LEN;
+        }
+#if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
+        if (ctx->rem_sess_cb != NULL)
+            cacheSession->rem_sess_cb = ctx->rem_sess_cb;
+#endif
+#ifdef HAVE_EX_DATA
+        /* The session in cache now owns the ex_data */
+        addSession->ownExData = 0;
+        cacheSession->ownExData = 1;
+#endif
+#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_TLS13) &&                  \
+    defined(WOLFSSL_TICKET_NONCE_MALLOC) &&                                    \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+        if (preallocNonce != NULL && preallocNonceUsed) {
+            cacheSession->ticketNonce.data = preallocNonce;
+            cacheSession->ticketNonce.len = preallocNonceLen;
+            preallocNonce = NULL;
+            preallocNonceLen = 0;
+        }
+#endif /* HAVE_SESSION_TICKET && WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC
+        * && FIPS_VERSION_GE(5,3)*/
+    }
+#ifdef HAVE_SESSION_TICKET
+    else if (ticBuffUsed) {
+        /* Error occurred. Need to clean up the ticket buffer. */
+        cacheSession->ticket = cacheSession->staticTicket;
+        cacheSession->ticketLenAlloc = 0;
+        cacheSession->ticketLen = 0;
+    }
+#endif
+    SESSION_ROW_UNLOCK(sessRow);
+    cacheSession = NULL; /* Can't access after unlocked */
+
+#ifndef NO_CLIENT_CACHE
+    if (ret == 0 && clientCacheEntry != NULL) {
+        ClientSession* clientCache = AddSessionToClientCache(side, row, (int)idx,
+                addSession->serverID, addSession->idLen, id, useTicket);
+        if (clientCache != NULL)
+            *clientCacheEntry = clientCache;
+    }
+#endif
+
+#ifdef HAVE_SESSION_TICKET
+    if (ticBuff != NULL && !ticBuffUsed)
+        XFREE(ticBuff, NULL, DYNAMIC_TYPE_SESSION_TICK);
+    XFREE(cacheTicBuff, NULL, DYNAMIC_TYPE_SESSION_TICK);
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&         \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+    XFREE(preallocNonce, addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
+    XFREE(toFree, addSession->heap, DYNAMIC_TYPE_SESSION_TICK);
+#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
+#endif
+
+#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
+    if (cachePeer != NULL) {
+        wolfSSL_X509_free(cachePeer);
+        cachePeer = NULL; /* Make sure not use after this point */
+    }
+#endif
+
+    return ret;
+}
+
+void AddSession(WOLFSSL* ssl)
+{
+    int    error = 0;
+    const byte* id = NULL;
+    byte idSz = 0;
+    WOLFSSL_SESSION* session = ssl->session;
+
+    (void)error;
+
+    WOLFSSL_ENTER("AddSession");
+
+    if (SslSessionCacheOff(ssl, session)) {
+        WOLFSSL_MSG("Cache off");
+        return;
+    }
+
+    if (session->haveAltSessionID) {
+        id = session->altSessionID;
+        idSz = ID_LEN;
+    }
+    else {
+        id = session->sessionID;
+        idSz = session->sessionIDSz;
+    }
+
+    /* Do this only for the client because if the server doesn't have an ID at
+     * this point, it won't on resumption. */
+    if (idSz == 0 && ssl->options.side == WOLFSSL_CLIENT_END) {
+        WC_RNG* rng = NULL;
+        if (ssl->rng != NULL)
+            rng = ssl->rng;
+#if defined(HAVE_GLOBAL_RNG) && defined(OPENSSL_EXTRA)
+        else if (initGlobalRNG == 1 || wolfSSL_RAND_Init() == WOLFSSL_SUCCESS) {
+            rng = &globalRNG;
+        }
+#endif
+        if (wc_RNG_GenerateBlock(rng, ssl->session->altSessionID,
+                ID_LEN) != 0)
+            return;
+        ssl->session->haveAltSessionID = 1;
+        id = ssl->session->altSessionID;
+        idSz = ID_LEN;
+    }
+
+#ifdef HAVE_EXT_CACHE
+    if (!ssl->options.internalCacheOff)
+#endif
+    {
+        /* Try to add the session to internal cache or external cache
+        if a new_sess_cb is set. Its ok if we don't succeed. */
+        (void)AddSessionToCache(ssl->ctx, session, id, idSz,
+#ifdef SESSION_INDEX
+                &ssl->sessionIndex,
+#else
+                NULL,
+#endif
+                ssl->options.side,
+#ifdef HAVE_SESSION_TICKET
+                ssl->options.useTicket,
+#else
+                0,
+#endif
+#ifdef NO_SESSION_CACHE_REF
+                NULL
+#else
+                (ssl->options.side == WOLFSSL_CLIENT_END) ?
+                        &ssl->clientSession : NULL
+#endif
+                        );
+    }
+
+#ifdef HAVE_EXT_CACHE
+    if (error == 0 && ssl->ctx->new_sess_cb != NULL) {
+        int cbRet = 0;
+        wolfSSL_SESSION_up_ref(session);
+        cbRet = ssl->ctx->new_sess_cb(ssl, session);
+        if (cbRet == 0)
+            wolfSSL_FreeSession(ssl->ctx, session);
+    }
+#endif
+
+#if defined(WOLFSSL_SESSION_STATS) && defined(WOLFSSL_PEAK_SESSIONS)
+    if (error == 0) {
+        word32 active = 0;
+
+        error = get_locked_session_stats(&active, NULL, NULL);
+        if (error == WOLFSSL_SUCCESS) {
+            error = 0;  /* back to this function ok */
+
+            if (PeakSessions < active) {
+                PeakSessions = active;
+            }
+        }
+    }
+#endif /* WOLFSSL_SESSION_STATS && WOLFSSL_PEAK_SESSIONS */
+    (void)error;
+}
+
+
+#ifdef SESSION_INDEX
+
+int wolfSSL_GetSessionIndex(WOLFSSL* ssl)
+{
+    WOLFSSL_ENTER("wolfSSL_GetSessionIndex");
+    WOLFSSL_LEAVE("wolfSSL_GetSessionIndex", ssl->sessionIndex);
+    return ssl->sessionIndex;
+}
+
+
+int wolfSSL_GetSessionAtIndex(int idx, WOLFSSL_SESSION* session)
+{
+    int row, col, result = WOLFSSL_FAILURE;
+    SessionRow* sessRow;
+    WOLFSSL_SESSION* cacheSession;
+
+    WOLFSSL_ENTER("wolfSSL_GetSessionAtIndex");
+
+    session = ClientSessionToSession(session);
+
+    row = idx >> SESSIDX_ROW_SHIFT;
+    col = idx & SESSIDX_IDX_MASK;
+
+    if (session == NULL ||
+            row < 0 || row >= SESSION_ROWS || col >= SESSIONS_PER_ROW) {
+        return WOLFSSL_FAILURE;
+    }
+
+    sessRow = &SessionCache[row];
+    if (SESSION_ROW_RD_LOCK(sessRow) != 0) {
+        return BAD_MUTEX_E;
+    }
+
+#ifdef SESSION_CACHE_DYNAMIC_MEM
+    cacheSession = sessRow->Sessions[col];
+#else
+    cacheSession = &sessRow->Sessions[col];
+#endif
+    if (cacheSession) {
+        XMEMCPY(session, cacheSession, sizeof(WOLFSSL_SESSION));
+        result = WOLFSSL_SUCCESS;
+    }
+    else {
+        result = WOLFSSL_FAILURE;
+    }
+
+    SESSION_ROW_UNLOCK(sessRow);
+
+    WOLFSSL_LEAVE("wolfSSL_GetSessionAtIndex", result);
+    return result;
+}
+
+#endif /* SESSION_INDEX */
+
+#if defined(SESSION_CERTS)
+
+WOLFSSL_X509_CHAIN* wolfSSL_SESSION_get_peer_chain(WOLFSSL_SESSION* session)
+{
+    WOLFSSL_X509_CHAIN* chain = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_SESSION_get_peer_chain");
+
+    session = ClientSessionToSession(session);
+
+    if (session)
+        chain = &session->chain;
+
+    WOLFSSL_LEAVE("wolfSSL_SESSION_get_peer_chain", chain ? 1 : 0);
+    return chain;
+}
+
+
+#ifdef OPENSSL_EXTRA
+/* gets the peer certificate associated with the session passed in
+ * returns null on failure, the caller should not free the returned pointer */
+WOLFSSL_X509* wolfSSL_SESSION_get0_peer(WOLFSSL_SESSION* session)
+{
+    WOLFSSL_ENTER("wolfSSL_SESSION_get_peer_chain");
+
+    session = ClientSessionToSession(session);
+    if (session) {
+        int count;
+
+        count = wolfSSL_get_chain_count(&session->chain);
+        if (count < 1 || count >= MAX_CHAIN_DEPTH) {
+            WOLFSSL_MSG("bad count found");
+            return NULL;
+        }
+
+        if (session->peer == NULL) {
+            session->peer = wolfSSL_get_chain_X509(&session->chain, 0);
+        }
+        return session->peer;
+    }
+    WOLFSSL_MSG("No session passed in");
+
+    return NULL;
+}
+#endif /* OPENSSL_EXTRA */
+#endif /* SESSION_INDEX && SESSION_CERTS */
+
+
+#ifdef WOLFSSL_SESSION_STATS
+
+static int get_locked_session_stats(word32* active, word32* total, word32* peak)
+{
+    int result = WOLFSSL_SUCCESS;
+    int i;
+    int count;
+    int idx;
+    word32 now   = 0;
+    word32 seen  = 0;
+    word32 ticks = LowResTimer();
+
+    WOLFSSL_ENTER("get_locked_session_stats");
+
+#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
+    SESSION_ROW_RD_LOCK(&SessionCache[0]);
+#endif
+    for (i = 0; i < SESSION_ROWS; i++) {
+        SessionRow* row = &SessionCache[i];
+    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
+        if (SESSION_ROW_RD_LOCK(row) != 0) {
+            WOLFSSL_MSG("Session row cache mutex lock failed");
+            return BAD_MUTEX_E;
+        }
+    #endif
+
+        seen += row->totalCount;
+
+        if (active == NULL) {
+            SESSION_ROW_UNLOCK(row);
+            continue;
+        }
+
+        count = min((word32)row->totalCount, SESSIONS_PER_ROW);
+        idx   = row->nextIdx - 1;
+        if (idx < 0 || idx >= SESSIONS_PER_ROW) {
+            idx = SESSIONS_PER_ROW - 1; /* if back to front previous was end */
+        }
+
+        for (; count > 0; --count) {
+            /* if not expired then good */
+#ifdef SESSION_CACHE_DYNAMIC_MEM
+            if (row->Sessions[idx] &&
+                ticks < (row->Sessions[idx]->bornOn +
+                            row->Sessions[idx]->timeout) )
+#else
+            if (ticks < (row->Sessions[idx].bornOn +
+                            row->Sessions[idx].timeout) )
+#endif
+            {
+                now++;
+            }
+
+            idx = idx > 0 ? idx - 1 : SESSIONS_PER_ROW - 1;
+        }
+
+    #ifdef ENABLE_SESSION_CACHE_ROW_LOCK
+        SESSION_ROW_UNLOCK(row);
+    #endif
+    }
+#ifndef ENABLE_SESSION_CACHE_ROW_LOCK
+    SESSION_ROW_UNLOCK(&SessionCache[0]);
+#endif
+
+    if (active) {
+        *active = now;
+    }
+    if (total) {
+        *total = seen;
+    }
+
+#ifdef WOLFSSL_PEAK_SESSIONS
+    if (peak) {
+        *peak = PeakSessions;
+    }
+#else
+    (void)peak;
+#endif
+
+    WOLFSSL_LEAVE("get_locked_session_stats", result);
+
+    return result;
+}
+
+
+/* return WOLFSSL_SUCCESS on ok */
+int wolfSSL_get_session_stats(word32* active, word32* total, word32* peak,
+                              word32* maxSessions)
+{
+    int result = WOLFSSL_SUCCESS;
+
+    WOLFSSL_ENTER("wolfSSL_get_session_stats");
+
+    if (maxSessions) {
+        *maxSessions = SESSIONS_PER_ROW * SESSION_ROWS;
+
+        if (active == NULL && total == NULL && peak == NULL)
+            return result;  /* we're done */
+    }
+
+    /* user must provide at least one query value */
+    if (active == NULL && total == NULL && peak == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    result = get_locked_session_stats(active, total, peak);
+
+    WOLFSSL_LEAVE("wolfSSL_get_session_stats", result);
+
+    return result;
+}
+
+#endif /* WOLFSSL_SESSION_STATS */
+
+
+    #ifdef PRINT_SESSION_STATS
+
+    /* WOLFSSL_SUCCESS on ok */
+    int wolfSSL_PrintSessionStats(void)
+    {
+        word32 totalSessionsSeen = 0;
+        word32 totalSessionsNow = 0;
+        word32 peak = 0;
+        word32 maxSessions = 0;
+        int    i;
+        int    ret;
+        double E;               /* expected freq */
+        double chiSquare = 0;
+
+        ret = wolfSSL_get_session_stats(&totalSessionsNow, &totalSessionsSeen,
+                                        &peak, &maxSessions);
+        if (ret != WOLFSSL_SUCCESS)
+            return ret;
+        printf("Total Sessions Seen = %u\n", totalSessionsSeen);
+        printf("Total Sessions Now  = %u\n", totalSessionsNow);
+#ifdef WOLFSSL_PEAK_SESSIONS
+        printf("Peak  Sessions      = %u\n", peak);
+#endif
+        printf("Max   Sessions      = %u\n", maxSessions);
+
+        E = (double)totalSessionsSeen / SESSION_ROWS;
+
+        for (i = 0; i < SESSION_ROWS; i++) {
+            double diff = SessionCache[i].totalCount - E;
+            diff *= diff;                /* square    */
+            diff /= E;                   /* normalize */
+
+            chiSquare += diff;
+        }
+        printf("  chi-square = %5.1f, d.f. = %d\n", chiSquare,
+                                                     SESSION_ROWS - 1);
+        #if (SESSION_ROWS == 11)
+            printf(" .05 p value =  18.3, chi-square should be less\n");
+        #elif (SESSION_ROWS == 211)
+            printf(".05 p value  = 244.8, chi-square should be less\n");
+        #elif (SESSION_ROWS == 5981)
+            printf(".05 p value  = 6161.0, chi-square should be less\n");
+        #elif (SESSION_ROWS == 3)
+            printf(".05 p value  =   6.0, chi-square should be less\n");
+        #elif (SESSION_ROWS == 2861)
+            printf(".05 p value  = 2985.5, chi-square should be less\n");
+        #endif
+        printf("\n");
+
+        return ret;
+    }
+
+    #endif /* SESSION_STATS */
+
+#else  /* NO_SESSION_CACHE */
+
+WOLFSSL_SESSION* ClientSessionToSession(const WOLFSSL_SESSION* session)
+{
+    return (WOLFSSL_SESSION*)session;
+}
+
+/* No session cache version */
+WOLFSSL_SESSION* wolfSSL_GetSession(WOLFSSL* ssl, byte* masterSecret,
+        byte restoreSessionCerts)
+{
+    (void)ssl;
+    (void)masterSecret;
+    (void)restoreSessionCerts;
+
+    return NULL;
+}
+
+#endif /* NO_SESSION_CACHE */
+
+#ifdef OPENSSL_EXTRA
+
+   /* returns previous set cache size which stays constant */
+    long wolfSSL_CTX_sess_set_cache_size(WOLFSSL_CTX* ctx, long sz)
+    {
+        /* cache size fixed at compile time in wolfSSL */
+        (void)ctx;
+        (void)sz;
+        WOLFSSL_MSG("session cache is set at compile time");
+        #ifndef NO_SESSION_CACHE
+            return (long)(SESSIONS_PER_ROW * SESSION_ROWS);
+        #else
+            return 0;
+        #endif
+    }
+
+
+    long wolfSSL_CTX_sess_get_cache_size(WOLFSSL_CTX* ctx)
+    {
+        (void)ctx;
+        #ifndef NO_SESSION_CACHE
+            return (long)(SESSIONS_PER_ROW * SESSION_ROWS);
+        #else
+            return 0;
+        #endif
+    }
+
+#endif
+
+#ifndef NO_SESSION_CACHE
+int wolfSSL_CTX_add_session(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* session)
+{
+    int    error = 0;
+    const byte* id = NULL;
+    byte idSz = 0;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_add_session");
+
+    session = ClientSessionToSession(session);
+    if (session == NULL)
+        return WOLFSSL_FAILURE;
+
+    /* Session cache is global */
+    (void)ctx;
+
+    if (session->haveAltSessionID) {
+        id = session->altSessionID;
+        idSz = ID_LEN;
+    }
+    else {
+        id = session->sessionID;
+        idSz = session->sessionIDSz;
+    }
+
+    error = AddSessionToCache(ctx, session, id, idSz,
+            NULL, session->side,
+#ifdef HAVE_SESSION_TICKET
+            session->ticketLen > 0,
+#else
+            0,
+#endif
+            NULL);
+
+    return error == 0 ? WOLFSSL_SUCCESS : WOLFSSL_FAILURE;
+}
+#endif
+
+#if !defined(NO_SESSION_CACHE) && (defined(OPENSSL_EXTRA) || \
+        defined(HAVE_EXT_CACHE))
+/* stunnel 4.28 needs
+ *
+ * Callback that is called if a session tries to resume but could not find
+ * the session to resume it.
+ */
+void wolfSSL_CTX_sess_set_get_cb(WOLFSSL_CTX* ctx,
+    WOLFSSL_SESSION*(*f)(WOLFSSL*, const unsigned char*, int, int*))
+{
+    if (ctx == NULL)
+        return;
+
+#ifdef HAVE_EXT_CACHE
+    ctx->get_sess_cb = f;
+#else
+    (void)f;
+#endif
+}
+
+void wolfSSL_CTX_sess_set_new_cb(WOLFSSL_CTX* ctx,
+                             int (*f)(WOLFSSL*, WOLFSSL_SESSION*))
+{
+    if (ctx == NULL)
+        return;
+
+#ifdef HAVE_EXT_CACHE
+    ctx->new_sess_cb = f;
+#else
+    (void)f;
+#endif
+}
+
+void wolfSSL_CTX_sess_set_remove_cb(WOLFSSL_CTX* ctx, void (*f)(WOLFSSL_CTX*,
+                                                        WOLFSSL_SESSION*))
+{
+    if (ctx == NULL)
+        return;
+
+#if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
+    ctx->rem_sess_cb = f;
+#else
+    (void)f;
+#endif
+}
+
+
+/*
+ *
+ * Note: It is expected that the importing and exporting function have been
+ *       built with the same settings. For example if session tickets was
+ *       enabled with the wolfSSL library exporting a session then it is
+ *       expected to be turned on with the wolfSSL library importing the
+ *       session.
+ */
+int wolfSSL_i2d_SSL_SESSION(WOLFSSL_SESSION* sess, unsigned char** p)
+{
+    int size = 0;
+#ifdef HAVE_EXT_CACHE
+    int idx = 0;
+#ifdef SESSION_CERTS
+    int i;
+#endif
+
+    WOLFSSL_ENTER("wolfSSL_i2d_SSL_SESSION");
+
+    sess = ClientSessionToSession(sess);
+    if (sess == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* side | bornOn | timeout | sessionID len | sessionID | masterSecret |
+     * haveEMS  */
+    size += OPAQUE8_LEN + OPAQUE32_LEN + OPAQUE32_LEN + OPAQUE8_LEN +
+            sess->sessionIDSz + SECRET_LEN + OPAQUE8_LEN;
+    /* altSessionID */
+    size += OPAQUE8_LEN + (sess->haveAltSessionID ? ID_LEN : 0);
+#ifdef SESSION_CERTS
+    /* Peer chain */
+    size += OPAQUE8_LEN;
+    for (i = 0; i < sess->chain.count; i++)
+        size += OPAQUE16_LEN + sess->chain.certs[i].length;
+#endif
+#if defined(SESSION_CERTS) || (defined(WOLFSSL_TLS13) && \
+                               defined(HAVE_SESSION_TICKET))
+    /* Protocol version */
+    size += OPAQUE16_LEN;
+#endif
+#if defined(SESSION_CERTS) || !defined(NO_RESUME_SUITE_CHECK) || \
+                        (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
+    /* cipher suite */
+    size += OPAQUE16_LEN;
+#endif
+#ifndef NO_CLIENT_CACHE
+    /* ServerID len | ServerID */
+    size += OPAQUE16_LEN + sess->idLen;
+#endif
+#ifdef WOLFSSL_SESSION_ID_CTX
+    /* session context ID len | session context ID */
+    size += OPAQUE8_LEN + sess->sessionCtxSz;
+#endif
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    /* peerVerifyRet */
+    size += OPAQUE8_LEN;
+#endif
+#ifdef WOLFSSL_TLS13
+    /* namedGroup */
+    size += OPAQUE16_LEN;
+#endif
+#if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
+#ifdef WOLFSSL_TLS13
+#ifdef WOLFSSL_32BIT_MILLI_TIME
+    /* ticketSeen | ticketAdd */
+    size += OPAQUE32_LEN + OPAQUE32_LEN;
+#else
+    /* ticketSeen Hi 32 bits | ticketSeen Lo 32 bits | ticketAdd */
+    size += OPAQUE32_LEN + OPAQUE32_LEN + OPAQUE32_LEN;
+#endif
+    /* ticketNonce */
+    size += OPAQUE8_LEN + sess->ticketNonce.len;
+#endif
+#ifdef WOLFSSL_EARLY_DATA
+    size += OPAQUE32_LEN;
+#endif
+#endif
+#ifdef HAVE_SESSION_TICKET
+    /* ticket len | ticket */
+    size += OPAQUE16_LEN + sess->ticketLen;
+#endif
+
+    if (p != NULL) {
+        unsigned char *data;
+
+        if (*p == NULL)
+            *p = (unsigned char*)XMALLOC(size, NULL, DYNAMIC_TYPE_OPENSSL);
+        if (*p == NULL)
+            return 0;
+        data = *p;
+
+        data[idx++] = sess->side;
+        c32toa(sess->bornOn, data + idx); idx += OPAQUE32_LEN;
+        c32toa(sess->timeout, data + idx); idx += OPAQUE32_LEN;
+        data[idx++] = sess->sessionIDSz;
+        XMEMCPY(data + idx, sess->sessionID, sess->sessionIDSz);
+        idx += sess->sessionIDSz;
+        XMEMCPY(data + idx, sess->masterSecret, SECRET_LEN); idx += SECRET_LEN;
+        data[idx++] = (byte)sess->haveEMS;
+        data[idx++] = sess->haveAltSessionID ? ID_LEN : 0;
+        if (sess->haveAltSessionID) {
+            XMEMCPY(data + idx, sess->altSessionID, ID_LEN);
+            idx += ID_LEN;
+        }
+#ifdef SESSION_CERTS
+        data[idx++] = (byte)sess->chain.count;
+        for (i = 0; i < sess->chain.count; i++) {
+            c16toa((word16)sess->chain.certs[i].length, data + idx);
+            idx += OPAQUE16_LEN;
+            XMEMCPY(data + idx, sess->chain.certs[i].buffer,
+                    sess->chain.certs[i].length);
+            idx += sess->chain.certs[i].length;
+        }
+#endif
+#if defined(SESSION_CERTS) || (defined(WOLFSSL_TLS13) && \
+                               defined(HAVE_SESSION_TICKET))
+        data[idx++] = sess->version.major;
+        data[idx++] = sess->version.minor;
+#endif
+#if defined(SESSION_CERTS) || !defined(NO_RESUME_SUITE_CHECK) || \
+                        (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
+        data[idx++] = sess->cipherSuite0;
+        data[idx++] = sess->cipherSuite;
+#endif
+#ifndef NO_CLIENT_CACHE
+        c16toa(sess->idLen, data + idx); idx += OPAQUE16_LEN;
+        XMEMCPY(data + idx, sess->serverID, sess->idLen);
+        idx += sess->idLen;
+#endif
+#ifdef WOLFSSL_SESSION_ID_CTX
+        data[idx++] = sess->sessionCtxSz;
+        XMEMCPY(data + idx, sess->sessionCtx, sess->sessionCtxSz);
+        idx += sess->sessionCtxSz;
+#endif
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+        data[idx++] = sess->peerVerifyRet;
+#endif
+#ifdef WOLFSSL_TLS13
+        c16toa(sess->namedGroup, data + idx);
+        idx += OPAQUE16_LEN;
+#endif
+#if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
+#ifdef WOLFSSL_TLS13
+#ifdef WOLFSSL_32BIT_MILLI_TIME
+        c32toa(sess->ticketSeen, data + idx);
+        idx += OPAQUE32_LEN;
+#else
+        c32toa((word32)(sess->ticketSeen >> 32), data + idx);
+        idx += OPAQUE32_LEN;
+        c32toa((word32)sess->ticketSeen, data + idx);
+        idx += OPAQUE32_LEN;
+#endif
+        c32toa(sess->ticketAdd, data + idx);
+        idx += OPAQUE32_LEN;
+        data[idx++] = sess->ticketNonce.len;
+        XMEMCPY(data + idx, sess->ticketNonce.data, sess->ticketNonce.len);
+        idx += sess->ticketNonce.len;
+#endif
+#ifdef WOLFSSL_EARLY_DATA
+        c32toa(sess->maxEarlyDataSz, data + idx);
+        idx += OPAQUE32_LEN;
+#endif
+#endif
+#ifdef HAVE_SESSION_TICKET
+        c16toa(sess->ticketLen, data + idx); idx += OPAQUE16_LEN;
+        XMEMCPY(data + idx, sess->ticket, sess->ticketLen);
+        idx += sess->ticketLen;
+#endif
+    }
+#endif
+
+    (void)sess;
+    (void)p;
+#ifdef HAVE_EXT_CACHE
+    (void)idx;
+#endif
+
+    return size;
+}
+
+
+/* TODO: no function to free new session.
+ *
+ * Note: It is expected that the importing and exporting function have been
+ *       built with the same settings. For example if session tickets was
+ *       enabled with the wolfSSL library exporting a session then it is
+ *       expected to be turned on with the wolfSSL library importing the
+ *       session.
+ */
+WOLFSSL_SESSION* wolfSSL_d2i_SSL_SESSION(WOLFSSL_SESSION** sess,
+                                const unsigned char** p, long i)
+{
+    WOLFSSL_SESSION* s = NULL;
+    int ret = 0;
+#if defined(HAVE_EXT_CACHE)
+    int idx = 0;
+    byte* data;
+#ifdef SESSION_CERTS
+    int j;
+    word16 length;
+#endif
+#endif /* HAVE_EXT_CACHE */
+
+    (void)p;
+    (void)i;
+    (void)ret;
+    (void)sess;
+
+#ifdef HAVE_EXT_CACHE
+    if (p == NULL || *p == NULL)
+        return NULL;
+
+    s = wolfSSL_SESSION_new();
+    if (s == NULL)
+        return NULL;
+
+    idx = 0;
+    data = (byte*)*p;
+
+    /* side | bornOn | timeout | sessionID len */
+    if (i < OPAQUE8_LEN + OPAQUE32_LEN + OPAQUE32_LEN + OPAQUE8_LEN) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    s->side = data[idx++];
+    ato32(data + idx, &s->bornOn); idx += OPAQUE32_LEN;
+    ato32(data + idx, &s->timeout); idx += OPAQUE32_LEN;
+    s->sessionIDSz = data[idx++];
+
+    /* sessionID | secret | haveEMS | haveAltSessionID */
+    if (i - idx < s->sessionIDSz + SECRET_LEN + OPAQUE8_LEN + OPAQUE8_LEN) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    XMEMCPY(s->sessionID, data + idx, s->sessionIDSz);
+    idx  += s->sessionIDSz;
+    XMEMCPY(s->masterSecret, data + idx, SECRET_LEN); idx += SECRET_LEN;
+    s->haveEMS = data[idx++];
+    if (data[idx] != ID_LEN && data[idx] != 0) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    s->haveAltSessionID = data[idx++] == ID_LEN;
+
+    /* altSessionID */
+    if (s->haveAltSessionID) {
+        if (i - idx < ID_LEN) {
+            ret = BUFFER_ERROR;
+            goto end;
+        }
+        XMEMCPY(s->altSessionID, data + idx, ID_LEN); idx += ID_LEN;
+    }
+
+#ifdef SESSION_CERTS
+    /* Certificate chain */
+    if (i - idx == 0) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    s->chain.count = data[idx++];
+    for (j = 0; j < s->chain.count; j++) {
+        if (i - idx < OPAQUE16_LEN) {
+            ret = BUFFER_ERROR;
+            goto end;
+        }
+        ato16(data + idx, &length); idx += OPAQUE16_LEN;
+        s->chain.certs[j].length = length;
+        if (i - idx < length) {
+            ret = BUFFER_ERROR;
+            goto end;
+        }
+        XMEMCPY(s->chain.certs[j].buffer, data + idx, length);
+        idx += length;
+    }
+#endif
+#if defined(SESSION_CERTS) || (defined(WOLFSSL_TLS13) && \
+                               defined(HAVE_SESSION_TICKET))
+    /* Protocol Version */
+    if (i - idx < OPAQUE16_LEN) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    s->version.major = data[idx++];
+    s->version.minor = data[idx++];
+#endif
+#if defined(SESSION_CERTS) || !defined(NO_RESUME_SUITE_CHECK) || \
+                        (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
+    /* Cipher suite */
+    if (i - idx < OPAQUE16_LEN) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    s->cipherSuite0 = data[idx++];
+    s->cipherSuite = data[idx++];
+#endif
+#ifndef NO_CLIENT_CACHE
+    /* ServerID len */
+    if (i - idx < OPAQUE16_LEN) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    ato16(data + idx, &s->idLen); idx += OPAQUE16_LEN;
+
+    /* ServerID */
+    if (i - idx < s->idLen) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    XMEMCPY(s->serverID, data + idx, s->idLen); idx += s->idLen;
+#endif
+#ifdef WOLFSSL_SESSION_ID_CTX
+    /* byte for length of session context ID */
+    if (i - idx < OPAQUE8_LEN) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    s->sessionCtxSz = data[idx++];
+
+    /* app session context ID */
+    if (i - idx < s->sessionCtxSz) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    XMEMCPY(s->sessionCtx, data + idx, s->sessionCtxSz); idx += s->sessionCtxSz;
+#endif
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    /* byte for peerVerifyRet */
+    if (i - idx < OPAQUE8_LEN) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    s->peerVerifyRet = data[idx++];
+#endif
+#ifdef WOLFSSL_TLS13
+    if (i - idx < OPAQUE16_LEN) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    ato16(data + idx, &s->namedGroup);
+    idx += OPAQUE16_LEN;
+#endif
+#if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
+#ifdef WOLFSSL_TLS13
+    if (i - idx < (OPAQUE32_LEN * 2)) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+#ifdef WOLFSSL_32BIT_MILLI_TIME
+    ato32(data + idx, &s->ticketSeen);
+    idx += OPAQUE32_LEN;
+#else
+    {
+        word32 seenHi, seenLo;
+
+        ato32(data + idx, &seenHi);
+        idx += OPAQUE32_LEN;
+        ato32(data + idx, &seenLo);
+        idx += OPAQUE32_LEN;
+        s->ticketSeen = ((sword64)seenHi << 32) + seenLo;
+    }
+#endif
+    ato32(data + idx, &s->ticketAdd);
+    idx += OPAQUE32_LEN;
+    if (i - idx < OPAQUE8_LEN) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    s->ticketNonce.len = data[idx++];
+
+    if (i - idx < s->ticketNonce.len) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+#if defined(WOLFSSL_TICKET_NONCE_MALLOC) &&                     \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+    ret = SessionTicketNoncePopulate(s, data + idx, s->ticketNonce.len);
+    if (ret != 0)
+        goto end;
+#else
+    if (s->ticketNonce.len > MAX_TICKET_NONCE_STATIC_SZ) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    XMEMCPY(s->ticketNonce.data, data + idx, s->ticketNonce.len);
+#endif /* defined(WOLFSSL_TICKET_NONCE_MALLOC) && FIPS_VERSION_GE(5,3) */
+
+    idx += s->ticketNonce.len;
+#endif
+#ifdef WOLFSSL_EARLY_DATA
+    if (i - idx < OPAQUE32_LEN) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    ato32(data + idx, &s->maxEarlyDataSz);
+    idx += OPAQUE32_LEN;
+#endif
+#endif
+#ifdef HAVE_SESSION_TICKET
+    /* ticket len */
+    if (i - idx < OPAQUE16_LEN) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    ato16(data + idx, &s->ticketLen); idx += OPAQUE16_LEN;
+
+    /* Dispose of ol dynamic ticket and ensure space for new ticket. */
+    if (s->ticketLenAlloc > 0) {
+        XFREE(s->ticket, NULL, DYNAMIC_TYPE_SESSION_TICK);
+    }
+    if (s->ticketLen <= SESSION_TICKET_LEN)
+        s->ticket = s->staticTicket;
+    else {
+        s->ticket = (byte*)XMALLOC(s->ticketLen, NULL,
+                                   DYNAMIC_TYPE_SESSION_TICK);
+        if (s->ticket == NULL) {
+            ret = MEMORY_ERROR;
+            goto end;
+        }
+        s->ticketLenAlloc = (word16)s->ticketLen;
+    }
+
+    /* ticket */
+    if (i - idx < s->ticketLen) {
+        ret = BUFFER_ERROR;
+        goto end;
+    }
+    XMEMCPY(s->ticket, data + idx, s->ticketLen); idx += s->ticketLen;
+#endif
+    (void)idx;
+
+    if (sess != NULL) {
+        *sess = s;
+    }
+
+    s->isSetup = 1;
+
+    *p += idx;
+
+end:
+    if (ret != 0 && (sess == NULL || *sess != s)) {
+        wolfSSL_FreeSession(NULL, s);
+        s = NULL;
+    }
+#endif /* HAVE_EXT_CACHE */
+    return s;
+}
+
+/* Check if there is a session ticket associated with this WOLFSSL_SESSION.
+ *
+ * sess - pointer to WOLFSSL_SESSION struct
+ *
+ * Returns 1 if has session ticket, otherwise 0 */
+int wolfSSL_SESSION_has_ticket(const WOLFSSL_SESSION* sess)
+{
+    WOLFSSL_ENTER("wolfSSL_SESSION_has_ticket");
+#ifdef HAVE_SESSION_TICKET
+    sess = ClientSessionToSession(sess);
+    if (sess) {
+        if ((sess->ticketLen > 0) && (sess->ticket != NULL)) {
+            return WOLFSSL_SUCCESS;
+        }
+    }
+#else
+    (void)sess;
+#endif
+    return WOLFSSL_FAILURE;
+}
+
+unsigned long wolfSSL_SESSION_get_ticket_lifetime_hint(
+                  const WOLFSSL_SESSION* sess)
+{
+    WOLFSSL_ENTER("wolfSSL_SESSION_get_ticket_lifetime_hint");
+    sess = ClientSessionToSession(sess);
+    if (sess) {
+        return sess->timeout;
+    }
+    return 0;
+}
+
+long wolfSSL_SESSION_get_timeout(const WOLFSSL_SESSION* sess)
+{
+    long timeout = 0;
+    WOLFSSL_ENTER("wolfSSL_SESSION_get_timeout");
+    sess = ClientSessionToSession(sess);
+    if (sess)
+        timeout = sess->timeout;
+    return timeout;
+}
+
+long wolfSSL_SSL_SESSION_set_timeout(WOLFSSL_SESSION* ses, long t)
+{
+    word32 tmptime;
+
+    ses = ClientSessionToSession(ses);
+    if (ses == NULL || t < 0) {
+        return BAD_FUNC_ARG;
+    }
+
+    tmptime = t & 0xFFFFFFFF;
+    ses->timeout = tmptime;
+
+    return WOLFSSL_SUCCESS;
+}
+
+long wolfSSL_SESSION_get_time(const WOLFSSL_SESSION* sess)
+{
+    long bornOn = 0;
+    WOLFSSL_ENTER("wolfSSL_SESSION_get_time");
+    sess = ClientSessionToSession(sess);
+    if (sess)
+        bornOn = sess->bornOn;
+    return bornOn;
+}
+
+long wolfSSL_SESSION_set_time(WOLFSSL_SESSION *ses, long t)
+{
+
+    ses = ClientSessionToSession(ses);
+    if (ses == NULL || t < 0) {
+        return 0;
+    }
+    ses->bornOn = (word32)t;
+    return t;
+}
+
+#endif /* !NO_SESSION_CACHE && OPENSSL_EXTRA || HAVE_EXT_CACHE */
+
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL) || \
+    defined(HAVE_EX_DATA)
+
+#if defined(HAVE_EX_DATA) && !defined(NO_SESSION_CACHE)
+static void SESSION_ex_data_cache_update(WOLFSSL_SESSION* session, int idx,
+        void* data, byte get, void** getRet, int* setRet)
+{
+    int row;
+    int i;
+    int error = 0;
+    SessionRow* sessRow = NULL;
+    const byte* id;
+    byte foundCache = 0;
+
+    if (getRet != NULL)
+        *getRet = NULL;
+    if (setRet != NULL)
+        *setRet = WOLFSSL_FAILURE;
+
+    id = session->sessionID;
+    if (session->haveAltSessionID)
+        id = session->altSessionID;
+
+    row = (int)(HashObject(id, ID_LEN, &error) % SESSION_ROWS);
+    if (error != 0) {
+        WOLFSSL_MSG("Hash session failed");
+        return;
+    }
+
+    sessRow = &SessionCache[row];
+    if (get)
+        error = SESSION_ROW_RD_LOCK(sessRow);
+    else
+        error = SESSION_ROW_WR_LOCK(sessRow);
+    if (error != 0) {
+        WOLFSSL_MSG("Session row lock failed");
+        return;
+    }
+
+    for (i = 0; i < SESSIONS_PER_ROW && i < sessRow->totalCount; i++) {
+        WOLFSSL_SESSION* cacheSession;
+#ifdef SESSION_CACHE_DYNAMIC_MEM
+        cacheSession = sessRow->Sessions[i];
+#else
+        cacheSession = &sessRow->Sessions[i];
+#endif
+        if (cacheSession &&
+                XMEMCMP(id, cacheSession->sessionID, ID_LEN) == 0
+                && session->side == cacheSession->side
+        #if defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET)
+                && (IsAtLeastTLSv1_3(session->version) ==
+                    IsAtLeastTLSv1_3(cacheSession->version))
+        #endif
+            ) {
+            if (get) {
+                if (getRet) {
+                    *getRet = wolfSSL_CRYPTO_get_ex_data(
+                        &cacheSession->ex_data, idx);
+                }
+            }
+            else {
+                if (setRet) {
+                    *setRet = wolfSSL_CRYPTO_set_ex_data(
+                        &cacheSession->ex_data, idx, data);
+                }
+            }
+            foundCache = 1;
+            break;
+        }
+    }
+    SESSION_ROW_UNLOCK(sessRow);
+    /* If we don't have a session in cache then clear the ex_data and
+     * own it */
+    if (!foundCache) {
+        XMEMSET(&session->ex_data, 0, sizeof(WOLFSSL_CRYPTO_EX_DATA));
+        session->ownExData = 1;
+        if (!get) {
+            *setRet = wolfSSL_CRYPTO_set_ex_data(&session->ex_data, idx,
+                    data);
+        }
+    }
+
+}
+#endif
+
+#endif
+
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) \
+    || defined(OPENSSL_EXTRA) || defined(HAVE_LIGHTY)
+
+#ifndef NO_SESSION_CACHE
+int wolfSSL_SSL_CTX_remove_session(WOLFSSL_CTX *ctx, WOLFSSL_SESSION *s)
+{
+#if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
+    int rem_called = FALSE;
+#endif
+
+    WOLFSSL_ENTER("wolfSSL_SSL_CTX_remove_session");
+
+    s = ClientSessionToSession(s);
+    if (ctx == NULL || s == NULL)
+        return BAD_FUNC_ARG;
+
+#ifdef HAVE_EXT_CACHE
+    if (!ctx->internalCacheOff)
+#endif
+    {
+        const byte* id;
+        WOLFSSL_SESSION *sess = NULL;
+        word32 row = 0;
+        int ret;
+
+        id = s->sessionID;
+        if (s->haveAltSessionID)
+            id = s->altSessionID;
+
+        ret = TlsSessionCacheGetAndWrLock(id, &sess, &row, ctx->method->side);
+        if (ret == 0 && sess != NULL) {
+#if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
+            if (sess->rem_sess_cb != NULL) {
+                rem_called = TRUE;
+            }
+#endif
+            /* Call this before changing ownExData so that calls to ex_data
+             * don't try to access the SessionCache again. */
+            EvictSessionFromCache(sess);
+#ifdef HAVE_EX_DATA
+            if (sess->ownExData) {
+                /* Most recent version of ex data is in cache. Copy it
+                 * over so the user can free it. */
+                XMEMCPY(&s->ex_data, &sess->ex_data,
+                        sizeof(WOLFSSL_CRYPTO_EX_DATA));
+                s->ownExData = 1;
+                sess->ownExData = 0;
+            }
+#endif
+#ifdef SESSION_CACHE_DYNAMIC_MEM
+            {
+                /* Find and clear entry. Row is locked so we are good to go. */
+                int idx;
+                for (idx = 0; idx < SESSIONS_PER_ROW; idx++) {
+                    if (sess == SessionCache[row].Sessions[idx]) {
+                        XFREE(sess, sess->heap, DYNAMIC_TYPE_SESSION);
+                        SessionCache[row].Sessions[idx] = NULL;
+                        break;
+                    }
+                }
+            }
+#endif
+            TlsSessionCacheUnlockRow(row);
+        }
+    }
+
+#if defined(HAVE_EXT_CACHE) || defined(HAVE_EX_DATA)
+    if (ctx->rem_sess_cb != NULL && !rem_called) {
+        ctx->rem_sess_cb(ctx, s);
+    }
+#endif
+
+    /* s cannot be resumed at this point */
+    s->timeout = 0;
+
+    return 0;
+}
+
+WOLFSSL_SESSION *wolfSSL_SSL_get0_session(const WOLFSSL *ssl)
+{
+    WOLFSSL_ENTER("wolfSSL_SSL_get0_session");
+
+    return ssl->session;
+}
+
+#endif /* NO_SESSION_CACHE */
+
+#endif /* OPENSSL_ALL || WOLFSSL_NGINX || WOLFSSL_HAPROXY ||
+    OPENSSL_EXTRA || HAVE_LIGHTY */
+
+#ifdef WOLFSSL_SESSION_EXPORT
+/* Used to import a serialized TLS session.
+ * WARNING: buf contains sensitive information about the state and is best to be
+ *          encrypted before storing if stored.
+ *
+ * @param ssl WOLFSSL structure to import the session into
+ * @param buf serialized session
+ * @param sz  size of buffer 'buf'
+ * @return the number of bytes read from buffer 'buf'
+ */
+int wolfSSL_tls_import(WOLFSSL* ssl, const unsigned char* buf, unsigned int sz)
+{
+    if (ssl == NULL || buf == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    return wolfSSL_session_import_internal(ssl, buf, sz, WOLFSSL_EXPORT_TLS);
+}
+
+
+/* Used to export a serialized TLS session.
+ * WARNING: buf contains sensitive information about the state and is best to be
+ *          encrypted before storing if stored.
+ *
+ * @param ssl WOLFSSL structure to export the session from
+ * @param buf output of serialized session
+ * @param sz  size in bytes set in 'buf'
+ * @return the number of bytes written into buffer 'buf'
+ */
+int wolfSSL_tls_export(WOLFSSL* ssl, unsigned char* buf, unsigned int* sz)
+{
+    if (ssl == NULL || sz == NULL) {
+        return BAD_FUNC_ARG;
+    }
+    return wolfSSL_session_export_internal(ssl, buf, sz, WOLFSSL_EXPORT_TLS);
+}
+
+#ifdef WOLFSSL_DTLS
+int wolfSSL_dtls_import(WOLFSSL* ssl, const unsigned char* buf, unsigned int sz)
+{
+    WOLFSSL_ENTER("wolfSSL_session_import");
+
+    if (ssl == NULL || buf == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    /* sanity checks on buffer and protocol are done in internal function */
+    return wolfSSL_session_import_internal(ssl, buf, sz, WOLFSSL_EXPORT_DTLS);
+}
+
+
+/* Sets the function to call for serializing the session. This function is
+ * called right after the handshake is completed. */
+int wolfSSL_CTX_dtls_set_export(WOLFSSL_CTX* ctx, wc_dtls_export func)
+{
+
+    WOLFSSL_ENTER("wolfSSL_CTX_dtls_set_export");
+
+    /* purposefully allow func to be NULL */
+    if (ctx == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    ctx->dtls_export = func;
+
+    return WOLFSSL_SUCCESS;
+}
+
+/* Sets the function in WOLFSSL struct to call for serializing the session. This
+ * function is called right after the handshake is completed. */
+int wolfSSL_dtls_set_export(WOLFSSL* ssl, wc_dtls_export func)
+{
+
+    WOLFSSL_ENTER("wolfSSL_dtls_set_export");
+
+    /* purposefully allow func to be NULL */
+    if (ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    ssl->dtls_export = func;
+
+    return WOLFSSL_SUCCESS;
+}
+
+
+/* This function allows for directly serializing a session rather than using
+ * callbacks. It has less overhead by removing a temporary buffer and gives
+ * control over when the session gets serialized. When using callbacks the
+ * session is always serialized immediately after the handshake is finished.
+ *
+ * buf is the argument to contain the serialized session
+ * sz  is the size of the buffer passed in
+ * ssl is the WOLFSSL struct to serialize
+ * returns the size of serialized session on success, 0 on no action, and
+ *         negative value on error */
+int wolfSSL_dtls_export(WOLFSSL* ssl, unsigned char* buf, unsigned int* sz)
+{
+    WOLFSSL_ENTER("wolfSSL_dtls_export");
+
+    if (ssl == NULL || sz == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (buf == NULL) {
+        *sz = MAX_EXPORT_BUFFER;
+        return 0;
+    }
+
+    /* if not DTLS do nothing */
+    if (!ssl->options.dtls) {
+        WOLFSSL_MSG("Currently only DTLS export is supported");
+        return 0;
+    }
+
+    /* copy over keys, options, and dtls state struct */
+    return wolfSSL_session_export_internal(ssl, buf, sz, WOLFSSL_EXPORT_DTLS);
+}
+
+
+/* This function is similar to wolfSSL_dtls_export but only exports the portion
+ * of the WOLFSSL structure related to the state of the connection, i.e. peer
+ * sequence number, epoch, AEAD state etc.
+ *
+ * buf is the argument to contain the serialized state, if null then set "sz" to
+ *     buffer size required
+ * sz  is the size of the buffer passed in
+ * ssl is the WOLFSSL struct to serialize
+ * returns the size of serialized session on success, 0 on no action, and
+ *         negative value on error */
+int wolfSSL_dtls_export_state_only(WOLFSSL* ssl, unsigned char* buf,
+        unsigned int* sz)
+{
+    WOLFSSL_ENTER("wolfSSL_dtls_export_state_only");
+
+    if (ssl == NULL || sz == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (buf == NULL) {
+        *sz = MAX_EXPORT_STATE_BUFFER;
+        return 0;
+    }
+
+    /* if not DTLS do nothing */
+    if (!ssl->options.dtls) {
+        WOLFSSL_MSG("Currently only DTLS export state is supported");
+        return 0;
+    }
+
+    /* copy over keys, options, and dtls state struct */
+    return wolfSSL_dtls_export_state_internal(ssl, buf, *sz);
+}
+
+
+/* returns 0 on success */
+int wolfSSL_send_session(WOLFSSL* ssl)
+{
+    int ret;
+    byte* buf;
+    word32 bufSz = MAX_EXPORT_BUFFER;
+
+    WOLFSSL_ENTER("wolfSSL_send_session");
+
+    if (ssl == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    buf = (byte*)XMALLOC(bufSz, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    if (buf == NULL) {
+        return MEMORY_E;
+    }
+
+    /* if not DTLS do nothing */
+    if (!ssl->options.dtls) {
+        XFREE(buf, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        WOLFSSL_MSG("Currently only DTLS export is supported");
+        return 0;
+    }
+
+    /* copy over keys, options, and dtls state struct */
+    ret = wolfSSL_session_export_internal(ssl, buf, &bufSz,
+        WOLFSSL_EXPORT_DTLS);
+    if (ret < 0) {
+        XFREE(buf, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        return ret;
+    }
+
+    /* if no error ret has size of buffer */
+    ret = ssl->dtls_export(ssl, buf, ret, NULL);
+    if (ret != WOLFSSL_SUCCESS) {
+        XFREE(buf, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
+        return ret;
+    }
+
+    XFREE(buf, ssl->heap, DYNAMIC_TYPE_TMP_BUFFER);
+    return 0;
+}
+#endif /* WOLFSSL_DTLS */
+#endif /* WOLFSSL_SESSION_EXPORT */
+
+#ifdef OPENSSL_EXTRA
+
+/* Copies the master secret over to out buffer. If outSz is 0 returns the size
+ * of master secret.
+ *
+ * ses : a session from completed TLS/SSL handshake
+ * out : buffer to hold copy of master secret
+ * outSz : size of out buffer
+ * returns : number of bytes copied into out buffer on success
+ *           less then or equal to 0 is considered a failure case
+ */
+int wolfSSL_SESSION_get_master_key(const WOLFSSL_SESSION* ses,
+        unsigned char* out, int outSz)
+{
+    int size;
+
+    ses = ClientSessionToSession(ses);
+
+    if (outSz == 0) {
+        return SECRET_LEN;
+    }
+
+    if (ses == NULL || out == NULL || outSz < 0) {
+        return 0;
+    }
+
+    if (outSz > SECRET_LEN) {
+        size = SECRET_LEN;
+    }
+    else {
+        size = outSz;
+    }
+
+    XMEMCPY(out, ses->masterSecret, size);
+    return size;
+}
+
+
+int wolfSSL_SESSION_get_master_key_length(const WOLFSSL_SESSION* ses)
+{
+    (void)ses;
+    return SECRET_LEN;
+}
+
+#ifdef WOLFSSL_EARLY_DATA
+unsigned int wolfSSL_SESSION_get_max_early_data(const WOLFSSL_SESSION *session)
+{
+    return session->maxEarlyDataSz;
+}
+#endif /* WOLFSSL_EARLY_DATA */
+
+#endif /* OPENSSL_EXTRA */
+
+void SetupSession(WOLFSSL* ssl)
+{
+    WOLFSSL_SESSION* session = ssl->session;
+
+    WOLFSSL_ENTER("SetupSession");
+
+    if (!IsAtLeastTLSv1_3(ssl->version) && ssl->arrays != NULL) {
+        /* Make sure the session ID is available when the user calls any
+         * get_session API */
+        if (!session->haveAltSessionID) {
+            XMEMCPY(session->sessionID, ssl->arrays->sessionID, ID_LEN);
+            session->sessionIDSz = ssl->arrays->sessionIDSz;
+        }
+        else {
+            XMEMCPY(session->sessionID, session->altSessionID, ID_LEN);
+            session->sessionIDSz = ID_LEN;
+        }
+    }
+    session->side = (byte)ssl->options.side;
+    if (!IsAtLeastTLSv1_3(ssl->version) && ssl->arrays != NULL)
+        XMEMCPY(session->masterSecret, ssl->arrays->masterSecret, SECRET_LEN);
+    session->haveEMS = ssl->options.haveEMS;
+#ifdef WOLFSSL_SESSION_ID_CTX
+    /* If using compatibility layer then check for and copy over session context
+     * id. */
+    if (ssl->sessionCtxSz > 0 && ssl->sessionCtxSz < ID_LEN) {
+        XMEMCPY(ssl->session->sessionCtx, ssl->sessionCtx, ssl->sessionCtxSz);
+        session->sessionCtxSz = ssl->sessionCtxSz;
+    }
+#endif
+    session->timeout = ssl->timeout;
+#ifndef NO_ASN_TIME
+    session->bornOn  = LowResTimer();
+#endif
+#if defined(SESSION_CERTS) || (defined(WOLFSSL_TLS13) && \
+                               defined(HAVE_SESSION_TICKET))
+    session->version = ssl->version;
+#endif
+#if defined(SESSION_CERTS) || !defined(NO_RESUME_SUITE_CHECK) || \
+                        (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
+    session->cipherSuite0 = ssl->options.cipherSuite0;
+    session->cipherSuite = ssl->options.cipherSuite;
+#endif
+#if defined(OPENSSL_EXTRA) || defined(OPENSSL_EXTRA_X509_SMALL)
+    session->peerVerifyRet = (byte)ssl->peerVerifyRet;
+#endif
+    session->isSetup = 1;
+}
+
+#ifdef WOLFSSL_SESSION_ID_CTX
+    /* Storing app session context id, this value is inherited by WOLFSSL
+     * objects created from WOLFSSL_CTX. Any session that is imported with a
+     * different session context id will be rejected.
+     *
+     * ctx         structure to set context in
+     * sid_ctx     value of context to set
+     * sid_ctx_len length of sid_ctx buffer
+     *
+     * Returns WOLFSSL_SUCCESS in success case and WOLFSSL_FAILURE when failing
+     */
+    int wolfSSL_CTX_set_session_id_context(WOLFSSL_CTX* ctx,
+                                           const unsigned char* sid_ctx,
+                                           unsigned int sid_ctx_len)
+    {
+        WOLFSSL_ENTER("wolfSSL_CTX_set_session_id_context");
+
+        /* No application specific context needed for wolfSSL */
+        if (sid_ctx_len > ID_LEN || ctx == NULL || sid_ctx == NULL) {
+            return WOLFSSL_FAILURE;
+        }
+        XMEMCPY(ctx->sessionCtx, sid_ctx, sid_ctx_len);
+        ctx->sessionCtxSz = (byte)sid_ctx_len;
+
+        return WOLFSSL_SUCCESS;
+    }
+
+
+
+    /* Storing app session context id. Any session that is imported with a
+     * different session context id will be rejected.
+     *
+     * ssl  structure to set context in
+     * id   value of context to set
+     * len  length of sid_ctx buffer
+     *
+     * Returns WOLFSSL_SUCCESS in success case and WOLFSSL_FAILURE when failing
+     */
+    int wolfSSL_set_session_id_context(WOLFSSL* ssl, const unsigned char* id,
+                                   unsigned int len)
+    {
+        WOLFSSL_ENTER("wolfSSL_set_session_id_context");
+
+        if (len > ID_LEN || ssl == NULL || id == NULL) {
+            return WOLFSSL_FAILURE;
+        }
+        XMEMCPY(ssl->sessionCtx, id, len);
+        ssl->sessionCtxSz = (byte)len;
+
+        return WOLFSSL_SUCCESS;
+    }
+#endif
+
+/* return a new malloc'd session with default settings on success */
+WOLFSSL_SESSION* wolfSSL_NewSession(void* heap)
+{
+    WOLFSSL_SESSION* ret = NULL;
+
+    WOLFSSL_ENTER("wolfSSL_NewSession");
+
+    ret = (WOLFSSL_SESSION*)XMALLOC(sizeof(WOLFSSL_SESSION), heap,
+            DYNAMIC_TYPE_SESSION);
+    if (ret != NULL) {
+        int err;
+        XMEMSET(ret, 0, sizeof(WOLFSSL_SESSION));
+        wolfSSL_RefInit(&ret->ref, &err);
+    #ifdef WOLFSSL_REFCNT_ERROR_RETURN
+        if (err != 0) {
+            WOLFSSL_MSG("Error setting up session reference mutex");
+            XFREE(ret, ret->heap, DYNAMIC_TYPE_SESSION);
+            return NULL;
+        }
+    #else
+        (void)err;
+    #endif
+#ifndef NO_SESSION_CACHE
+        ret->cacheRow = INVALID_SESSION_ROW; /* not in cache */
+#endif
+        ret->type = WOLFSSL_SESSION_TYPE_HEAP;
+        ret->heap = heap;
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+        wc_MemZero_Add("SESSION master secret", ret->masterSecret, SECRET_LEN);
+        wc_MemZero_Add("SESSION id", ret->sessionID, ID_LEN);
+#endif
+    #ifdef HAVE_SESSION_TICKET
+        ret->ticket = ret->staticTicket;
+        #if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&  \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+        ret->ticketNonce.data = ret->ticketNonce.dataStatic;
+        #endif
+    #endif
+#ifdef HAVE_EX_DATA
+        ret->ownExData = 1;
+        if (crypto_ex_cb_ctx_session != NULL) {
+            crypto_ex_cb_setup_new_data(ret, crypto_ex_cb_ctx_session,
+                    &ret->ex_data);
+        }
+#endif
+    }
+    return ret;
+}
+
+
+WOLFSSL_SESSION* wolfSSL_SESSION_new_ex(void* heap)
+{
+    return wolfSSL_NewSession(heap);
+}
+
+WOLFSSL_SESSION* wolfSSL_SESSION_new(void)
+{
+    return wolfSSL_SESSION_new_ex(NULL);
+}
+
+/* add one to session reference count
+ * return WOLFSSL_SUCCESS on success and WOLFSSL_FAILURE on error */
+int wolfSSL_SESSION_up_ref(WOLFSSL_SESSION* session)
+{
+    int ret;
+
+    session = ClientSessionToSession(session);
+
+    if (session == NULL || session->type != WOLFSSL_SESSION_TYPE_HEAP)
+        return WOLFSSL_FAILURE;
+
+    wolfSSL_RefInc(&session->ref, &ret);
+#ifdef WOLFSSL_REFCNT_ERROR_RETURN
+    if (ret != 0) {
+        WOLFSSL_MSG("Failed to lock session mutex");
+        return WOLFSSL_FAILURE;
+    }
+#else
+    (void)ret;
+#endif
+
+    return WOLFSSL_SUCCESS;
+}
+
+/**
+ * Deep copy the contents from input to output.
+ * @param input         The source of the copy.
+ * @param output        The destination of the copy.
+ * @param avoidSysCalls If true, then system calls will be avoided or an error
+ *                      will be returned if it is not possible to proceed
+ *                      without a system call. This is useful for fetching
+ *                      sessions from cache. When a cache row is locked, we
+ *                      don't want to block other threads with long running
+ *                      system calls.
+ * @param ticketNonceBuf If not null and @avoidSysCalls is true, the copy of the
+ *                      ticketNonce will happen in this pre allocated buffer
+ * @param ticketNonceLen @ticketNonceBuf len as input, used length on output
+ * @param ticketNonceUsed if @ticketNonceBuf was used to copy the ticket noncet
+ * @return              WOLFSSL_SUCCESS on success
+ *                      WOLFSSL_FAILURE on failure
+ */
+static int wolfSSL_DupSessionEx(const WOLFSSL_SESSION* input,
+    WOLFSSL_SESSION* output, int avoidSysCalls, byte* ticketNonceBuf,
+    byte* ticketNonceLen, byte* preallocUsed)
+{
+#ifdef HAVE_SESSION_TICKET
+    int   ticLenAlloc = 0;
+    byte *ticBuff = NULL;
+#endif
+    const size_t copyOffset = OFFSETOF(WOLFSSL_SESSION, heap) +
+        sizeof(input->heap);
+    int ret = WOLFSSL_SUCCESS;
+
+    (void)avoidSysCalls;
+    (void)ticketNonceBuf;
+    (void)ticketNonceLen;
+    (void)preallocUsed;
+
+    input = ClientSessionToSession(input);
+    output = ClientSessionToSession(output);
+
+    if (input == NULL || output == NULL || input == output) {
+        WOLFSSL_MSG("input or output are null or same");
+        return WOLFSSL_FAILURE;
+    }
+
+#ifdef HAVE_SESSION_TICKET
+    if (output->ticket != output->staticTicket) {
+        ticBuff = output->ticket;
+        ticLenAlloc = output->ticketLenAlloc;
+    }
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+        /* free the data, it would be better to reuse the buffer but this
+         * maintain the code simpler. A smart allocator should reuse the free'd
+         * buffer in the next malloc without much performance penalties. */
+    if (output->ticketNonce.data != output->ticketNonce.dataStatic) {
+
+        /*  Callers that avoid syscall should never calls this with
+         * output->tickeNonce.data being a dynamic buffer.*/
+        if (avoidSysCalls) {
+            WOLFSSL_MSG("can't avoid syscalls with dynamic TicketNonce buffer");
+            return WOLFSSL_FAILURE;
+        }
+
+        XFREE(output->ticketNonce.data,
+            output->heap, DYNAMIC_TYPE_SESSION_TICK);
+        output->ticketNonce.data = output->ticketNonce.dataStatic;
+        output->ticketNonce.len = 0;
+    }
+#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
+#endif /* HAVE_SESSION_TICKET */
+
+#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
+    if (output->peer != NULL) {
+        if (avoidSysCalls) {
+            WOLFSSL_MSG("Can't free cert when avoiding syscalls");
+            return WOLFSSL_FAILURE;
+        }
+        wolfSSL_X509_free(output->peer);
+        output->peer = NULL;
+    }
+#endif
+
+    XMEMCPY((byte*)output + copyOffset, (byte*)input + copyOffset,
+            sizeof(WOLFSSL_SESSION) - copyOffset);
+
+#if defined(HAVE_SESSION_TICKET) && defined(WOLFSSL_TLS13) &&                  \
+    defined(WOLFSSL_TICKET_NONCE_MALLOC) &&                                    \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+    /* fix pointer to static after the copy  */
+    output->ticketNonce.data = output->ticketNonce.dataStatic;
+#endif
+    /* Set sane values for copy */
+#ifndef NO_SESSION_CACHE
+    if (output->type != WOLFSSL_SESSION_TYPE_CACHE)
+        output->cacheRow = INVALID_SESSION_ROW;
+#endif
+#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
+    if (input->peer != NULL && input->peer->dynamicMemory) {
+        if (wolfSSL_X509_up_ref(input->peer) != WOLFSSL_SUCCESS) {
+            WOLFSSL_MSG("Can't increase peer cert ref count");
+            output->peer = NULL;
+        }
+    }
+    else if (!avoidSysCalls)
+        output->peer = wolfSSL_X509_dup(input->peer);
+    else
+        /* output->peer is not that important to copy */
+        output->peer = NULL;
+#endif
+#ifdef HAVE_SESSION_TICKET
+    if (input->ticketLen > SESSION_TICKET_LEN) {
+        /* Need dynamic buffer */
+        if (ticBuff == NULL || ticLenAlloc < input->ticketLen) {
+            /* allocate new one */
+            byte* tmp;
+            if (avoidSysCalls) {
+                WOLFSSL_MSG("Failed to allocate memory for ticket when avoiding"
+                        " syscalls");
+                output->ticket = ticBuff;
+                output->ticketLenAlloc = (word16) ticLenAlloc;
+                output->ticketLen = 0;
+                ret = WOLFSSL_FAILURE;
+            }
+            else {
+#ifdef WOLFSSL_NO_REALLOC
+                tmp = (byte*)XMALLOC(input->ticketLen,
+                        output->heap, DYNAMIC_TYPE_SESSION_TICK);
+                XFREE(ticBuff, output->heap, DYNAMIC_TYPE_SESSION_TICK);
+                ticBuff = NULL;
+#else
+                tmp = (byte*)XREALLOC(ticBuff, input->ticketLen,
+                        output->heap, DYNAMIC_TYPE_SESSION_TICK);
+#endif /* WOLFSSL_NO_REALLOC */
+                if (tmp == NULL) {
+                    WOLFSSL_MSG("Failed to allocate memory for ticket");
+#ifndef WOLFSSL_NO_REALLOC
+                    XFREE(ticBuff, output->heap, DYNAMIC_TYPE_SESSION_TICK);
+                    ticBuff = NULL;
+#endif /* WOLFSSL_NO_REALLOC */
+                    output->ticket = NULL;
+                    output->ticketLen = 0;
+                    output->ticketLenAlloc = 0;
+                    ret = WOLFSSL_FAILURE;
+                }
+                else {
+                    ticBuff = tmp;
+                    ticLenAlloc = input->ticketLen;
+                }
+            }
+        }
+        if (ticBuff != NULL && ret == WOLFSSL_SUCCESS) {
+            XMEMCPY(ticBuff, input->ticket, input->ticketLen);
+            output->ticket = ticBuff;
+            output->ticketLenAlloc = (word16) ticLenAlloc;
+        }
+    }
+    else {
+        /* Default ticket to non dynamic */
+        if (avoidSysCalls) {
+            /* Try to use ticBuf if available. Caller can later move it to
+             * the static buffer. */
+            if (ticBuff != NULL) {
+                if (ticLenAlloc >= input->ticketLen) {
+                    output->ticket = ticBuff;
+                    output->ticketLenAlloc = ticLenAlloc;
+                }
+                else {
+                    WOLFSSL_MSG("ticket dynamic buffer too small but we are "
+                                "avoiding system calls");
+                    ret = WOLFSSL_FAILURE;
+                    output->ticket = ticBuff;
+                    output->ticketLenAlloc = (word16) ticLenAlloc;
+                    output->ticketLen = 0;
+                }
+            }
+            else {
+                output->ticket = output->staticTicket;
+                output->ticketLenAlloc = 0;
+            }
+        }
+        else {
+            if (ticBuff != NULL)
+                XFREE(ticBuff, output->heap, DYNAMIC_TYPE_SESSION_TICK);
+            output->ticket = output->staticTicket;
+            output->ticketLenAlloc = 0;
+        }
+        if (input->ticketLenAlloc > 0 && ret == WOLFSSL_SUCCESS) {
+            /* Shouldn't happen as session should have placed this in
+             * the static buffer */
+            XMEMCPY(output->ticket, input->ticket,
+                    input->ticketLen);
+        }
+    }
+    ticBuff = NULL;
+
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+    if (preallocUsed != NULL)
+        *preallocUsed = 0;
+
+    if (input->ticketNonce.len > MAX_TICKET_NONCE_STATIC_SZ &&
+        ret == WOLFSSL_SUCCESS) {
+        /* TicketNonce does not fit in the static buffer */
+        if (!avoidSysCalls) {
+            output->ticketNonce.data = (byte*)XMALLOC(input->ticketNonce.len,
+                output->heap, DYNAMIC_TYPE_SESSION_TICK);
+
+            if (output->ticketNonce.data == NULL) {
+                WOLFSSL_MSG("Failed to allocate space for ticket nonce");
+                output->ticketNonce.data = output->ticketNonce.dataStatic;
+                output->ticketNonce.len = 0;
+                ret = WOLFSSL_FAILURE;
+            }
+            else {
+                output->ticketNonce.len = input->ticketNonce.len;
+                XMEMCPY(output->ticketNonce.data, input->ticketNonce.data,
+                    input->ticketNonce.len);
+                ret = WOLFSSL_SUCCESS;
+            }
+        }
+        /* we can't do syscalls. Use prealloc buffers if provided from the
+         * caller. */
+        else if (ticketNonceBuf != NULL &&
+                 *ticketNonceLen >= input->ticketNonce.len) {
+            XMEMCPY(ticketNonceBuf, input->ticketNonce.data,
+                input->ticketNonce.len);
+            *ticketNonceLen = input->ticketNonce.len;
+            if (preallocUsed != NULL)
+                *preallocUsed = 1;
+            ret = WOLFSSL_SUCCESS;
+        }
+        else {
+            WOLFSSL_MSG("TicketNonce bigger than static buffer, and we can't "
+                        "do syscalls");
+            ret = WOLFSSL_FAILURE;
+        }
+    }
+#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
+
+#endif /* HAVE_SESSION_TICKET */
+
+#ifdef HAVE_EX_DATA
+    if (input->type != WOLFSSL_SESSION_TYPE_CACHE &&
+            output->type != WOLFSSL_SESSION_TYPE_CACHE) {
+        /* Not called with cache as that passes ownership of ex_data */
+        ret = crypto_ex_cb_dup_data(&input->ex_data, &output->ex_data,
+                                    crypto_ex_cb_ctx_session);
+    }
+#endif
+
+    return ret;
+}
+
+/**
+ * Deep copy the contents from input to output.
+ * @param input         The source of the copy.
+ * @param output        The destination of the copy.
+ * @param avoidSysCalls If true, then system calls will be avoided or an error
+ *                      will be returned if it is not possible to proceed
+ *                      without a system call. This is useful for fetching
+ *                      sessions from cache. When a cache row is locked, we
+ *                      don't want to block other threads with long running
+ *                      system calls.
+ * @return              WOLFSSL_SUCCESS on success
+ *                      WOLFSSL_FAILURE on failure
+ */
+int wolfSSL_DupSession(const WOLFSSL_SESSION* input, WOLFSSL_SESSION* output,
+        int avoidSysCalls)
+{
+    return wolfSSL_DupSessionEx(input, output, avoidSysCalls, NULL, NULL, NULL);
+}
+
+WOLFSSL_SESSION* wolfSSL_SESSION_dup(WOLFSSL_SESSION* session)
+{
+    WOLFSSL_SESSION* copy;
+
+    WOLFSSL_ENTER("wolfSSL_SESSION_dup");
+
+    session = ClientSessionToSession(session);
+    if (session == NULL)
+        return NULL;
+
+#ifdef HAVE_SESSION_TICKET
+    if (session->ticketLenAlloc > 0 && !session->ticket) {
+        WOLFSSL_MSG("Session dynamic flag is set but ticket pointer is null");
+        return NULL;
+    }
+#endif
+
+    copy = wolfSSL_NewSession(session->heap);
+    if (copy != NULL &&
+            wolfSSL_DupSession(session, copy, 0) != WOLFSSL_SUCCESS) {
+        wolfSSL_FreeSession(NULL, copy);
+        copy = NULL;
+    }
+    return copy;
+}
+
+void wolfSSL_FreeSession(WOLFSSL_CTX* ctx, WOLFSSL_SESSION* session)
+{
+    session = ClientSessionToSession(session);
+    if (session == NULL)
+        return;
+
+    (void)ctx;
+
+    WOLFSSL_ENTER("wolfSSL_FreeSession");
+
+    if (session->ref.count > 0) {
+        int ret;
+        int isZero;
+        wolfSSL_RefDec(&session->ref, &isZero, &ret);
+        (void)ret;
+        if (!isZero) {
+            return;
+        }
+        wolfSSL_RefFree(&session->ref);
+    }
+
+    WOLFSSL_MSG("wolfSSL_FreeSession full free");
+
+#ifdef HAVE_EX_DATA
+    if (session->ownExData) {
+        crypto_ex_cb_free_data(session, crypto_ex_cb_ctx_session,
+                &session->ex_data);
+    }
+#endif
+
+#ifdef HAVE_EX_DATA_CLEANUP_HOOKS
+    wolfSSL_CRYPTO_cleanup_ex_data(&session->ex_data);
+#endif
+
+#if defined(SESSION_CERTS) && defined(OPENSSL_EXTRA)
+    if (session->peer) {
+        wolfSSL_X509_free(session->peer);
+        session->peer = NULL;
+    }
+#endif
+
+#ifdef HAVE_SESSION_TICKET
+    if (session->ticketLenAlloc > 0) {
+        XFREE(session->ticket, session->heap, DYNAMIC_TYPE_SESSION_TICK);
+        session->ticket = session->staticTicket;
+        session->ticketLen = 0;
+        session->ticketLenAlloc = 0;
+    }
+#if defined(WOLFSSL_TLS13) && defined(WOLFSSL_TICKET_NONCE_MALLOC) &&          \
+    (!defined(HAVE_FIPS) || (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3)))
+    if (session->ticketNonce.data != session->ticketNonce.dataStatic) {
+        XFREE(session->ticketNonce.data, session->heap,
+            DYNAMIC_TYPE_SESSION_TICK);
+        session->ticketNonce.data = session->ticketNonce.dataStatic;
+        session->ticketNonce.len = 0;
+    }
+#endif /* WOLFSSL_TLS13 && WOLFSSL_TICKET_NONCE_MALLOC && FIPS_VERSION_GE(5,3)*/
+#endif
+
+#ifdef HAVE_EX_DATA_CLEANUP_HOOKS
+    wolfSSL_CRYPTO_cleanup_ex_data(&session->ex_data);
+#endif
+
+    /* Make sure masterSecret is zeroed. */
+    ForceZero(session->masterSecret, SECRET_LEN);
+    /* Session ID is sensitive information too. */
+    ForceZero(session->sessionID, ID_LEN);
+
+    if (session->type == WOLFSSL_SESSION_TYPE_HEAP) {
+        XFREE(session, session->heap, DYNAMIC_TYPE_SESSION);
+    }
+}
+
+/* DO NOT use this API internally. Use wolfSSL_FreeSession directly instead
+ * and pass in the ctx parameter if possible (like from ssl->ctx). */
+void wolfSSL_SESSION_free(WOLFSSL_SESSION* session)
+{
+    session = ClientSessionToSession(session);
+    wolfSSL_FreeSession(NULL, session);
+}
+
+#if defined(OPENSSL_EXTRA) || defined(HAVE_EXT_CACHE)
+
+/**
+* set cipher to WOLFSSL_SESSION from WOLFSSL_CIPHER
+* @param session  a pointer to WOLFSSL_SESSION structure
+* @param cipher   a function pointer to WOLFSSL_CIPHER
+* @return WOLFSSL_SUCCESS on success, otherwise WOLFSSL_FAILURE
+*/
+int wolfSSL_SESSION_set_cipher(WOLFSSL_SESSION* session,
+                                            const WOLFSSL_CIPHER* cipher)
+{
+    WOLFSSL_ENTER("wolfSSL_SESSION_set_cipher");
+
+    session = ClientSessionToSession(session);
+    /* sanity check */
+    if (session == NULL || cipher == NULL) {
+        WOLFSSL_MSG("bad argument");
+        return WOLFSSL_FAILURE;
+    }
+    session->cipherSuite0 = cipher->cipherSuite0;
+    session->cipherSuite  = cipher->cipherSuite;
+
+    WOLFSSL_LEAVE("wolfSSL_SESSION_set_cipher", WOLFSSL_SUCCESS);
+    return WOLFSSL_SUCCESS;
+}
+#endif /* OPENSSL_EXTRA || HAVE_EXT_CACHE */
+
+const char* wolfSSL_SESSION_CIPHER_get_name(const WOLFSSL_SESSION* session)
+{
+    session = ClientSessionToSession(session);
+    if (session == NULL) {
+        return NULL;
+    }
+
+#if defined(SESSION_CERTS) || !defined(NO_RESUME_SUITE_CHECK) || \
+                        (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
+    #if !defined(WOLFSSL_CIPHER_INTERNALNAME) && !defined(NO_ERROR_STRINGS)
+        return GetCipherNameIana(session->cipherSuite0, session->cipherSuite);
+    #else
+        return GetCipherNameInternal(session->cipherSuite0,
+            session->cipherSuite);
+    #endif
+#else
+    return NULL;
+#endif
+}
+
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_HAPROXY) || defined(WOLFSSL_NGINX)
+const unsigned char *wolfSSL_SESSION_get0_id_context(
+                      const WOLFSSL_SESSION *sess, unsigned int *sid_ctx_length)
+{
+    return wolfSSL_SESSION_get_id((WOLFSSL_SESSION *)sess, sid_ctx_length);
+}
+int wolfSSL_SESSION_set1_id(WOLFSSL_SESSION *s,
+                                 const unsigned char *sid, unsigned int sid_len)
+{
+    if (s == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+    if (sid_len > ID_LEN) {
+        return WOLFSSL_FAILURE;
+    }
+    s->sessionIDSz = sid_len;
+    if (sid != s->sessionID) {
+        XMEMCPY(s->sessionID, sid, sid_len);
+    }
+    return WOLFSSL_SUCCESS;
+}
+
+int wolfSSL_SESSION_set1_id_context(WOLFSSL_SESSION *s,
+                         const unsigned char *sid_ctx, unsigned int sid_ctx_len)
+{
+    if (s == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+    if (sid_ctx_len > ID_LEN) {
+        return WOLFSSL_FAILURE;
+    }
+    s->sessionCtxSz = sid_ctx_len;
+    if (sid_ctx != s->sessionCtx) {
+        XMEMCPY(s->sessionCtx, sid_ctx, sid_ctx_len);
+    }
+
+    return WOLFSSL_SUCCESS;
+}
+
+#endif
+
+#ifdef OPENSSL_EXTRA
+
+/* Return the total number of sessions */
+long wolfSSL_CTX_sess_number(WOLFSSL_CTX* ctx)
+{
+    word32 total = 0;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_sess_number");
+    (void)ctx;
+
+#if defined(WOLFSSL_SESSION_STATS) && !defined(NO_SESSION_CACHE)
+    if (wolfSSL_get_session_stats(NULL, &total, NULL, NULL) !=
+            WOLFSSL_SUCCESS) {
+        WOLFSSL_MSG("Error getting session stats");
+    }
+#else
+    WOLFSSL_MSG("Please use macro WOLFSSL_SESSION_STATS for session stats");
+#endif
+
+    return (long)total;
+}
+
+#endif
+
+#ifdef SESSION_CERTS
+
+/* get session ID */
+WOLFSSL_ABI
+const byte* wolfSSL_get_sessionID(const WOLFSSL_SESSION* session)
+{
+    WOLFSSL_ENTER("wolfSSL_get_sessionID");
+    session = ClientSessionToSession(session);
+    if (session)
+        return session->sessionID;
+
+    return NULL;
+}
+
+#endif
+
+#if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL) || \
+    defined(HAVE_EX_DATA)
+
+int wolfSSL_SESSION_set_ex_data(WOLFSSL_SESSION* session, int idx, void* data)
+{
+    int ret = WOLFSSL_FAILURE;
+    WOLFSSL_ENTER("wolfSSL_SESSION_set_ex_data");
+#ifdef HAVE_EX_DATA
+    session = ClientSessionToSession(session);
+    if (session != NULL) {
+#ifndef NO_SESSION_CACHE
+        if (!session->ownExData) {
+            /* Need to update in cache */
+            SESSION_ex_data_cache_update(session, idx, data, 0, NULL, &ret);
+        }
+        else
+#endif
+        {
+            ret = wolfSSL_CRYPTO_set_ex_data(&session->ex_data, idx, data);
+        }
+    }
+#else
+    (void)session;
+    (void)idx;
+    (void)data;
+#endif
+    return ret;
+}
+
+#ifdef HAVE_EX_DATA_CLEANUP_HOOKS
+int wolfSSL_SESSION_set_ex_data_with_cleanup(
+    WOLFSSL_SESSION* session,
+    int idx,
+    void* data,
+    wolfSSL_ex_data_cleanup_routine_t cleanup_routine)
+{
+    WOLFSSL_ENTER("wolfSSL_SESSION_set_ex_data_with_cleanup");
+    session = ClientSessionToSession(session);
+    if(session != NULL) {
+        return wolfSSL_CRYPTO_set_ex_data_with_cleanup(&session->ex_data, idx,
+                                                       data, cleanup_routine);
+    }
+    return WOLFSSL_FAILURE;
+}
+#endif /* HAVE_EX_DATA_CLEANUP_HOOKS */
+
+void* wolfSSL_SESSION_get_ex_data(const WOLFSSL_SESSION* session, int idx)
+{
+    void* ret = NULL;
+    WOLFSSL_ENTER("wolfSSL_SESSION_get_ex_data");
+#ifdef HAVE_EX_DATA
+    session = ClientSessionToSession(session);
+    if (session != NULL) {
+#ifndef NO_SESSION_CACHE
+        if (!session->ownExData) {
+            /* Need to retrieve the data from the session cache */
+            SESSION_ex_data_cache_update((WOLFSSL_SESSION*)session, idx, NULL,
+                                         1, &ret, NULL);
+        }
+        else
+#endif
+        {
+            ret = wolfSSL_CRYPTO_get_ex_data(&session->ex_data, idx);
+        }
+    }
+#else
+    (void)session;
+    (void)idx;
+#endif
+    return ret;
+}
+#endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL || HAVE_EX_DATA */
+
+#if defined(OPENSSL_ALL) || (defined(OPENSSL_EXTRA) && \
+    (defined(HAVE_STUNNEL) || defined(WOLFSSL_NGINX) || \
+    defined(HAVE_LIGHTY) || defined(WOLFSSL_HAPROXY) || \
+    defined(WOLFSSL_OPENSSH) || defined(HAVE_SBLIM_SFCB)))
+#ifdef HAVE_EX_DATA
+int wolfSSL_SESSION_get_ex_new_index(long ctx_l,void* ctx_ptr,
+        WOLFSSL_CRYPTO_EX_new* new_func, WOLFSSL_CRYPTO_EX_dup* dup_func,
+        WOLFSSL_CRYPTO_EX_free* free_func)
+{
+    WOLFSSL_ENTER("wolfSSL_SESSION_get_ex_new_index");
+    return wolfssl_get_ex_new_index(WOLF_CRYPTO_EX_INDEX_SSL_SESSION, ctx_l,
+            ctx_ptr, new_func, dup_func, free_func);
+}
+#endif
+#endif
+
+
+#if defined(OPENSSL_ALL) || \
+    defined(OPENSSL_EXTRA) || defined(HAVE_STUNNEL) || \
+    defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY)
+
+const byte* wolfSSL_SESSION_get_id(const WOLFSSL_SESSION* sess,
+        unsigned int* idLen)
+{
+    WOLFSSL_ENTER("wolfSSL_SESSION_get_id");
+    sess = ClientSessionToSession(sess);
+    if (sess == NULL || idLen == NULL) {
+        WOLFSSL_MSG("Bad func args. Please provide idLen");
+        return NULL;
+    }
+#ifdef HAVE_SESSION_TICKET
+    if (sess->haveAltSessionID) {
+        *idLen = ID_LEN;
+        return sess->altSessionID;
+    }
+#endif
+    *idLen = sess->sessionIDSz;
+    return sess->sessionID;
+}
+
+#if (defined(HAVE_SESSION_TICKET) || defined(SESSION_CERTS)) && \
+    !defined(NO_FILESYSTEM)
+
+#ifndef NO_BIO
+
+#if defined(SESSION_CERTS) || \
+   (defined(WOLFSSL_TLS13) && defined(HAVE_SESSION_TICKET))
+static const char* wolfSSL_internal_get_version(const ProtocolVersion* version);
+
+/* returns a pointer to the protocol used by the session */
+static const char* wolfSSL_SESSION_get_protocol(const WOLFSSL_SESSION* in)
+{
+    in = ClientSessionToSession(in);
+    return wolfSSL_internal_get_version((ProtocolVersion*)&in->version);
+}
+#endif
+
+/* returns true (non 0) if the session has EMS (extended master secret) */
+static int wolfSSL_SESSION_haveEMS(const WOLFSSL_SESSION* in)
+{
+    in = ClientSessionToSession(in);
+    if (in == NULL)
+        return 0;
+    return in->haveEMS;
+}
+
+#if defined(HAVE_SESSION_TICKET)
+/* prints out the ticket to bio passed in
+ * return WOLFSSL_SUCCESS on success
+ */
+static int wolfSSL_SESSION_print_ticket(WOLFSSL_BIO* bio,
+        const WOLFSSL_SESSION* in, const char* tab)
+{
+    unsigned short i, j, z, sz;
+    short tag = 0;
+    byte* pt;
+
+
+    in = ClientSessionToSession(in);
+    if (in == NULL || bio == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+    sz = in->ticketLen;
+    pt = in->ticket;
+
+    if (wolfSSL_BIO_printf(bio, "%s\n", (sz == 0)? " NONE": "") <= 0)
+        return WOLFSSL_FAILURE;
+
+    for (i = 0; i < sz;) {
+        char asc[16];
+        XMEMSET(asc, 0, sizeof(asc));
+
+        if (sz - i < 16) {
+            if (wolfSSL_BIO_printf(bio, "%s%04X -", tab, tag + (sz - i)) <= 0)
+                return WOLFSSL_FAILURE;
+        }
+        else {
+            if (wolfSSL_BIO_printf(bio, "%s%04X -", tab, tag) <= 0)
+                return WOLFSSL_FAILURE;
+        }
+        for (j = 0; i < sz && j < 8; j++,i++) {
+            asc[j] =  ((pt[i])&0x6f)>='A'?((pt[i])&0x6f):'.';
+            if (wolfSSL_BIO_printf(bio, " %02X", pt[i]) <= 0)
+                return WOLFSSL_FAILURE;
+        }
+
+        if (i < sz) {
+            asc[j] =  ((pt[i])&0x6f)>='A'?((pt[i])&0x6f):'.';
+            if (wolfSSL_BIO_printf(bio, "-%02X", pt[i]) <= 0)
+                return WOLFSSL_FAILURE;
+            j++;
+            i++;
+        }
+
+        for (; i < sz && j < 16; j++,i++) {
+            asc[j] =  ((pt[i])&0x6f)>='A'?((pt[i])&0x6f):'.';
+            if (wolfSSL_BIO_printf(bio, " %02X", pt[i]) <= 0)
+                return WOLFSSL_FAILURE;
+        }
+
+        /* pad out spacing */
+        for (z = j; z < 17; z++) {
+            if (wolfSSL_BIO_printf(bio, "   ") <= 0)
+                return WOLFSSL_FAILURE;
+        }
+
+        for (z = 0; z < j; z++) {
+            if (wolfSSL_BIO_printf(bio, "%c", asc[z]) <= 0)
+                return WOLFSSL_FAILURE;
+        }
+        if (wolfSSL_BIO_printf(bio, "\n") <= 0)
+            return WOLFSSL_FAILURE;
+
+        tag += 16;
+    }
+    return WOLFSSL_SUCCESS;
+}
+#endif /* HAVE_SESSION_TICKET */
+
+
+/* prints out the session information in human readable form
+ * return WOLFSSL_SUCCESS on success
+ */
+int wolfSSL_SESSION_print(WOLFSSL_BIO *bp, const WOLFSSL_SESSION *session)
+{
+    const unsigned char* pt;
+    unsigned char buf[SECRET_LEN];
+    unsigned int sz = 0, i;
+    int ret;
+
+    session = ClientSessionToSession(session);
+    if (session == NULL) {
+        return WOLFSSL_FAILURE;
+    }
+
+    if (wolfSSL_BIO_printf(bp, "%s\n", "SSL-Session:") <= 0)
+        return WOLFSSL_FAILURE;
+
+#if defined(SESSION_CERTS) || (defined(WOLFSSL_TLS13) && \
+                               defined(HAVE_SESSION_TICKET))
+    if (wolfSSL_BIO_printf(bp, "    Protocol  : %s\n",
+            wolfSSL_SESSION_get_protocol(session)) <= 0)
+        return WOLFSSL_FAILURE;
+#endif
+
+    if (wolfSSL_BIO_printf(bp, "    Cipher    : %s\n",
+            wolfSSL_SESSION_CIPHER_get_name(session)) <= 0)
+        return WOLFSSL_FAILURE;
+
+    pt = wolfSSL_SESSION_get_id(session, &sz);
+    if (wolfSSL_BIO_printf(bp, "    Session-ID: ") <= 0)
+        return WOLFSSL_FAILURE;
+
+    for (i = 0; i < sz; i++) {
+        if (wolfSSL_BIO_printf(bp, "%02X", pt[i]) <= 0)
+            return WOLFSSL_FAILURE;
+    }
+    if (wolfSSL_BIO_printf(bp, "\n") <= 0)
+        return WOLFSSL_FAILURE;
+
+    if (wolfSSL_BIO_printf(bp, "    Session-ID-ctx: \n") <= 0)
+        return WOLFSSL_FAILURE;
+
+    ret = wolfSSL_SESSION_get_master_key(session, buf, sizeof(buf));
+    if (wolfSSL_BIO_printf(bp, "    Master-Key: ") <= 0)
+        return WOLFSSL_FAILURE;
+
+    if (ret > 0) {
+        sz = (unsigned int)ret;
+        for (i = 0; i < sz; i++) {
+            if (wolfSSL_BIO_printf(bp, "%02X", buf[i]) <= 0)
+                return WOLFSSL_FAILURE;
+        }
+    }
+    if (wolfSSL_BIO_printf(bp, "\n") <= 0)
+        return WOLFSSL_FAILURE;
+
+    /* @TODO PSK identity hint and SRP */
+
+    if (wolfSSL_BIO_printf(bp, "    TLS session ticket:") <= 0)
+        return WOLFSSL_FAILURE;
+
+#ifdef HAVE_SESSION_TICKET
+    if (wolfSSL_SESSION_print_ticket(bp, session, "    ") != WOLFSSL_SUCCESS)
+        return WOLFSSL_FAILURE;
+#endif
+
+#if !defined(NO_SESSION_CACHE) && (defined(OPENSSL_EXTRA) || \
+        defined(HAVE_EXT_CACHE))
+    if (wolfSSL_BIO_printf(bp, "    Start Time: %ld\n",
+                wolfSSL_SESSION_get_time(session)) <= 0)
+        return WOLFSSL_FAILURE;
+
+    if (wolfSSL_BIO_printf(bp, "    Timeout   : %ld (sec)\n",
+            wolfSSL_SESSION_get_timeout(session)) <= 0)
+        return WOLFSSL_FAILURE;
+#endif /* !NO_SESSION_CACHE && OPENSSL_EXTRA || HAVE_EXT_CACHE */
+
+    /* @TODO verify return code print */
+
+    if (wolfSSL_BIO_printf(bp, "    Extended master secret: %s\n",
+            (wolfSSL_SESSION_haveEMS(session) == 0)? "no" : "yes") <= 0)
+        return WOLFSSL_FAILURE;
+
+    return WOLFSSL_SUCCESS;
+}
+
+#endif /* !NO_BIO */
+#endif /* (HAVE_SESSION_TICKET || SESSION_CERTS) && !NO_FILESYSTEM */
+
+#endif /* OPENSSL_ALL || OPENSSL_EXTRA || HAVE_STUNNEL || WOLFSSL_NGINX ||
+        * WOLFSSL_HAPROXY */
+
+#ifdef OPENSSL_EXTRA
+/**
+ * Determine whether a WOLFSSL_SESSION object can be used for resumption
+ * @param s  a pointer to WOLFSSL_SESSION structure
+ * @return return 1 if session is resumable, otherwise 0.
+ */
+int wolfSSL_SESSION_is_resumable(const WOLFSSL_SESSION *s)
+{
+    s = ClientSessionToSession(s);
+    if (s == NULL)
+        return 0;
+
+#ifdef HAVE_SESSION_TICKET
+    if (s->ticketLen > 0)
+        return 1;
+#endif
+
+    if (s->sessionIDSz > 0)
+        return 1;
+
+    return 0;
+}
+#endif /* OPENSSL_EXTRA */
+
+#endif /* !WOLFSSL_SSL_SESS_INCLUDED */
+

--- a/libatalk/ssl/src/tls.c
+++ b/libatalk/ssl/src/tls.c
@@ -48,7 +48,7 @@
 #ifdef HAVE_CURVE448
     #include <wolfssl/wolfcrypt/curve448.h>
 #endif
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
     #include <wolfssl/wolfcrypt/kyber.h>
 #ifdef WOLFSSL_WC_KYBER
     #include <wolfssl/wolfcrypt/wc_kyber.h>
@@ -212,7 +212,8 @@ int BuildTlsFinished(WOLFSSL* ssl, Hashes* hashes, const byte* sender)
             ret = ssl->ctx->TlsFinishedCb(ssl, side, handshake_hash, hashSz,
                                           (byte*)hashes, ctx);
         }
-        if (!ssl->ctx->TlsFinishedCb || ret == PROTOCOLCB_UNAVAILABLE)
+        if (!ssl->ctx->TlsFinishedCb ||
+            ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
 #endif
         {
             PRIVATE_KEY_UNLOCK();
@@ -299,6 +300,98 @@ ProtocolVersion MakeTLSv1_3(void)
     return pv;
 }
 #endif
+
+#if defined(HAVE_SUPPORTED_CURVES)
+/* Sets the key exchange groups in rank order on a context.
+ *
+ * ctx     SSL/TLS context object.
+ * groups  Array of groups.
+ * count   Number of groups in array.
+ * returns BAD_FUNC_ARG when ctx or groups is NULL, not using TLS v1.3 or
+ * count is greater than WOLFSSL_MAX_GROUP_COUNT and WOLFSSL_SUCCESS on success.
+ */
+int wolfSSL_CTX_set_groups(WOLFSSL_CTX* ctx, int* groups, int count)
+{
+    int ret, i;
+
+    WOLFSSL_ENTER("wolfSSL_CTX_set_groups");
+    if (ctx == NULL || groups == NULL || count > WOLFSSL_MAX_GROUP_COUNT)
+        return BAD_FUNC_ARG;
+    if (!IsTLS_ex(ctx->method->version))
+        return BAD_FUNC_ARG;
+
+    #ifdef WOLFSSL_TLS13
+    ctx->numGroups = 0;
+    #endif
+    #if !defined(NO_TLS)
+    TLSX_Remove(&ctx->extensions, TLSX_SUPPORTED_GROUPS, ctx->heap);
+    #endif /* !NO_TLS */
+    for (i = 0; i < count; i++) {
+        /* Call to wolfSSL_CTX_UseSupportedCurve also checks if input groups
+         * are valid */
+        if ((ret = wolfSSL_CTX_UseSupportedCurve(ctx, (word16)groups[i]))
+                != WOLFSSL_SUCCESS) {
+    #if !defined(NO_TLS)
+            TLSX_Remove(&ctx->extensions, TLSX_SUPPORTED_GROUPS, ctx->heap);
+    #endif /* !NO_TLS */
+            return ret;
+        }
+        #ifdef WOLFSSL_TLS13
+        ctx->group[i] = (word16)groups[i];
+        #endif
+    }
+    #ifdef WOLFSSL_TLS13
+    ctx->numGroups = (byte)count;
+    #endif
+
+    return WOLFSSL_SUCCESS;
+}
+
+/* Sets the key exchange groups in rank order.
+ *
+ * ssl     SSL/TLS object.
+ * groups  Array of groups.
+ * count   Number of groups in array.
+ * returns BAD_FUNC_ARG when ssl or groups is NULL, not using TLS v1.3 or
+ * count is greater than WOLFSSL_MAX_GROUP_COUNT and WOLFSSL_SUCCESS on success.
+ */
+int wolfSSL_set_groups(WOLFSSL* ssl, int* groups, int count)
+{
+    int ret, i;
+
+    WOLFSSL_ENTER("wolfSSL_set_groups");
+    if (ssl == NULL || groups == NULL || count > WOLFSSL_MAX_GROUP_COUNT)
+        return BAD_FUNC_ARG;
+    if (!IsTLS_ex(ssl->version))
+        return BAD_FUNC_ARG;
+
+    #ifdef WOLFSSL_TLS13
+    ssl->numGroups = 0;
+    #endif
+    #if !defined(NO_TLS)
+    TLSX_Remove(&ssl->extensions, TLSX_SUPPORTED_GROUPS, ssl->heap);
+    #endif /* !NO_TLS */
+    for (i = 0; i < count; i++) {
+        /* Call to wolfSSL_UseSupportedCurve also checks if input groups
+                 * are valid */
+        if ((ret = wolfSSL_UseSupportedCurve(ssl, (word16)groups[i]))
+                != WOLFSSL_SUCCESS) {
+    #if !defined(NO_TLS)
+            TLSX_Remove(&ssl->extensions, TLSX_SUPPORTED_GROUPS, ssl->heap);
+    #endif /* !NO_TLS */
+            return ret;
+        }
+        #ifdef WOLFSSL_TLS13
+        ssl->group[i] = (word16)groups[i];
+        #endif
+    }
+    #ifdef WOLFSSL_TLS13
+    ssl->numGroups = (byte)count;
+    #endif
+
+    return WOLFSSL_SUCCESS;
+}
+#endif /* HAVE_SUPPORTED_CURVES */
 
 #ifndef WOLFSSL_NO_TLS12
 
@@ -396,9 +489,10 @@ int DeriveTlsKeys(WOLFSSL* ssl)
             void* ctx = wolfSSL_GetGenSessionKeyCtx(ssl);
             ret = ssl->ctx->GenSessionKeyCb(ssl, ctx);
         }
-        if (!ssl->ctx->GenSessionKeyCb || ret == PROTOCOLCB_UNAVAILABLE)
+        if (!ssl->ctx->GenSessionKeyCb ||
+            ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
 #endif
-        ret = _DeriveTlsKeys(key_dig, key_dig_len,
+        ret = _DeriveTlsKeys(key_dig, (word32)key_dig_len,
                          ssl->arrays->masterSecret, SECRET_LEN,
                          ssl->arrays->serverRandom, ssl->arrays->clientRandom,
                          IsAtLeastTLSv1_2(ssl), ssl->specs.mac_algorithm,
@@ -576,7 +670,8 @@ int MakeTlsMasterSecret(WOLFSSL* ssl)
             void* ctx = wolfSSL_GetGenMasterSecretCtx(ssl);
             ret = ssl->ctx->GenMasterCb(ssl, ctx);
         }
-        if (!ssl->ctx->GenMasterCb || ret == PROTOCOLCB_UNAVAILABLE)
+        if (!ssl->ctx->GenMasterCb ||
+            ret == WC_NO_ERR_TRACE(PROTOCOLCB_UNAVAILABLE))
 #endif
         {
             ret = _MakeTlsMasterSecret(ssl->arrays->masterSecret,
@@ -586,47 +681,13 @@ int MakeTlsMasterSecret(WOLFSSL* ssl)
                       ssl->specs.mac_algorithm, ssl->heap, ssl->devId);
         }
     }
+#ifdef HAVE_SECRET_CALLBACK
+    if (ret == 0 && ssl->tlsSecretCb != NULL) {
+        ret = ssl->tlsSecretCb(ssl, ssl->arrays->masterSecret,
+                SECRET_LEN, ssl->tlsSecretCtx);
+    }
+#endif /* HAVE_SECRET_CALLBACK */
     if (ret == 0) {
-    #ifdef SHOW_SECRETS
-        /* Wireshark Pre-Master-Secret Format:
-         *  CLIENT_RANDOM <clientrandom> <mastersecret>
-         */
-        const char* CLIENT_RANDOM_LABEL = "CLIENT_RANDOM";
-        int i, pmsPos = 0;
-        char pmsBuf[13 + 1 + 64 + 1 + 96 + 1 + 1];
-
-        XSNPRINTF(&pmsBuf[pmsPos], sizeof(pmsBuf) - pmsPos, "%s ",
-            CLIENT_RANDOM_LABEL);
-        pmsPos += XSTRLEN(CLIENT_RANDOM_LABEL) + 1;
-        for (i = 0; i < RAN_LEN; i++) {
-            XSNPRINTF(&pmsBuf[pmsPos], sizeof(pmsBuf) - pmsPos, "%02x",
-                ssl->arrays->clientRandom[i]);
-            pmsPos += 2;
-        }
-        XSNPRINTF(&pmsBuf[pmsPos], sizeof(pmsBuf) - pmsPos, " ");
-        pmsPos += 1;
-        for (i = 0; i < SECRET_LEN; i++) {
-            XSNPRINTF(&pmsBuf[pmsPos], sizeof(pmsBuf) - pmsPos, "%02x",
-                ssl->arrays->masterSecret[i]);
-            pmsPos += 2;
-        }
-        XSNPRINTF(&pmsBuf[pmsPos], sizeof(pmsBuf) - pmsPos, "\n");
-        pmsPos += 1;
-
-        /* print master secret */
-        puts(pmsBuf);
-
-        #if !defined(NO_FILESYSTEM) && defined(WOLFSSL_SSLKEYLOGFILE)
-        {
-            FILE* f = XFOPEN(WOLFSSL_SSLKEYLOGFILE_OUTPUT, "a");
-            if (f != XBADFILE) {
-                XFWRITE(pmsBuf, 1, pmsPos, f);
-                XFCLOSE(f);
-            }
-        }
-        #endif
-    #endif /* SHOW_SECRETS */
-
         ret = DeriveTlsKeys(ssl);
     }
 
@@ -724,7 +785,7 @@ int wolfSSL_SetTlsHmacInner(WOLFSSL* ssl, byte* inner, word32 sz, int content,
  */
 static int Hmac_HashUpdate(Hmac* hmac, const byte* data, word32 sz)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (hmac->macType) {
     #ifndef NO_SHA
@@ -758,6 +819,7 @@ static int Hmac_HashUpdate(Hmac* hmac, const byte* data, word32 sz)
     #endif /* WOLFSSL_SM3 */
 
         default:
+            ret = BAD_FUNC_ARG;
             break;
     }
 
@@ -772,7 +834,7 @@ static int Hmac_HashUpdate(Hmac* hmac, const byte* data, word32 sz)
  */
 static int Hmac_HashFinalRaw(Hmac* hmac, unsigned char* hash)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (hmac->macType) {
     #ifndef NO_SHA
@@ -806,6 +868,7 @@ static int Hmac_HashFinalRaw(Hmac* hmac, unsigned char* hash)
     #endif /* WOLFSSL_SM3 */
 
         default:
+            ret = BAD_FUNC_ARG;
             break;
     }
 
@@ -820,7 +883,7 @@ static int Hmac_HashFinalRaw(Hmac* hmac, unsigned char* hash)
  */
 static int Hmac_OuterHash(Hmac* hmac, unsigned char* mac)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     wc_HashAlg hash;
     enum wc_HashType hashType = (enum wc_HashType)hmac->macType;
     int digestSz = wc_HashGetDigestSize(hashType);
@@ -829,12 +892,16 @@ static int Hmac_OuterHash(Hmac* hmac, unsigned char* mac)
     if ((digestSz >= 0) && (blockSz >= 0)) {
         ret = wc_HashInit(&hash, hashType);
     }
+    else {
+        ret = BAD_FUNC_ARG;
+    }
+
     if (ret == 0) {
         ret = wc_HashUpdate(&hash, hashType, (byte*)hmac->opad,
-            blockSz);
+            (word32)blockSz);
         if (ret == 0)
             ret = wc_HashUpdate(&hash, hashType, (byte*)hmac->innerHash,
-                digestSz);
+                (word32)digestSz);
         if (ret == 0)
             ret = wc_HashFinal(&hash, hashType, mac);
         wc_HashFree(&hash, hashType);
@@ -942,7 +1009,7 @@ static int Hmac_UpdateFinal_CT(Hmac* hmac, byte* digest, const byte* in,
     c32toa(realLen >> ((sizeof(word32) * 8) - 3), lenBytes);
     c32toa(realLen << 3, lenBytes + sizeof(word32));
 
-    ret = Hmac_HashUpdate(hmac, (unsigned char*)hmac->ipad, blockSz);
+    ret = Hmac_HashUpdate(hmac, (unsigned char*)hmac->ipad, (word32)blockSz);
     if (ret != 0)
         return ret;
 
@@ -961,7 +1028,7 @@ static int Hmac_UpdateFinal_CT(Hmac* hmac, byte* digest, const byte* in,
         safeBlocks = 0;
 
     XMEMSET(digest, 0, macLen);
-    k = safeBlocks * blockSz;
+    k = (unsigned int)(safeBlocks * blockSz);
     for (i = safeBlocks; i < blocks; i++) {
         unsigned char hashBlock[WC_MAX_BLOCK_SIZE];
         unsigned char isEocBlock = ctMaskEq(i, eocBlock);
@@ -989,7 +1056,7 @@ static int Hmac_UpdateFinal_CT(Hmac* hmac, byte* digest, const byte* in,
             hashBlock[j] = b;
         }
 
-        ret = Hmac_HashUpdate(hmac, hashBlock, blockSz);
+        ret = Hmac_HashUpdate(hmac, hashBlock, (word32)blockSz);
         if (ret != 0)
             return ret;
         ret = Hmac_HashFinalRaw(hmac, hashBlock);
@@ -1099,9 +1166,9 @@ static int Hmac_UpdateFinal(Hmac* hmac, byte* digest, const byte* in,
     maxSz &= ~(0 - (maxSz >> 31));
 
     /* Calculate #blocks processed in HMAC for max and real data. */
-    blocks      = maxSz >> blockBits;
+    blocks      = (int)(maxSz >> blockBits);
     blocks     += ((maxSz + padSz) % blockSz) < padSz;
-    msgBlocks   = realSz >> blockBits;
+    msgBlocks   = (int)(realSz >> blockBits);
     /* #Extra blocks to process. */
     blocks -= msgBlocks + ((((realSz + padSz) % blockSz) < padSz) ? 1 : 0);
     /* Calculate whole blocks. */
@@ -1110,8 +1177,8 @@ static int Hmac_UpdateFinal(Hmac* hmac, byte* digest, const byte* in,
     ret = wc_HmacUpdate(hmac, header, WOLFSSL_TLS_HMAC_INNER_SZ);
     if (ret == 0) {
         /* Fill the rest of the block with any available data. */
-        word32 currSz = ctMaskLT(msgSz, blockSz) & msgSz;
-        currSz |= ctMaskGTE(msgSz, blockSz) & blockSz;
+        word32 currSz = ctMaskLT((int)msgSz, blockSz) & msgSz;
+        currSz |= ctMaskGTE((int)msgSz, blockSz) & blockSz;
         currSz -= WOLFSSL_TLS_HMAC_INNER_SZ;
         currSz &= ~(0 - (currSz >> 31));
         ret = wc_HmacUpdate(hmac, in, currSz);
@@ -2349,12 +2416,13 @@ int TLSX_UseSNI(TLSX** extensions, byte type, const void* data, word16 size,
 #ifndef NO_WOLFSSL_SERVER
 
 /** Tells the SNI requested by the client. */
-word16 TLSX_SNI_GetRequest(TLSX* extensions, byte type, void** data)
+word16 TLSX_SNI_GetRequest(TLSX* extensions, byte type, void** data,
+        byte ignoreStatus)
 {
     TLSX* extension = TLSX_Find(extensions, TLSX_SERVER_NAME);
     SNI* sni = TLSX_SNI_Find(extension ? (SNI*)extension->data : NULL, type);
 
-    if (sni && sni->status != WOLFSSL_SNI_NO_MATCH) {
+    if (sni && (ignoreStatus || sni->status != WOLFSSL_SNI_NO_MATCH)) {
         switch (sni->type) {
             case WOLFSSL_SNI_HOST_NAME:
                 if (data) {
@@ -2929,6 +2997,9 @@ static int TLSX_MFL_Parse(WOLFSSL* ssl, const byte* input, word16 length,
             WOLFSSL_ERROR_VERBOSE(UNKNOWN_MAX_FRAG_LEN_E);
             return UNKNOWN_MAX_FRAG_LEN_E;
     }
+    if (ssl->session != NULL) {
+        ssl->session->mfl = *input;
+    }
 
 #ifndef NO_WOLFSSL_SERVER
     if (isRequest) {
@@ -3329,7 +3400,8 @@ static int TLSX_CSR_Parse(WOLFSSL* ssl, const byte* input, word16 length,
                 XFREE(cert, ssl->heap, DYNAMIC_TYPE_DCERT);
                 /* Let's not error out the connection if we can't verify our
                  * cert */
-                if (ret == ASN_SELF_SIGNED_E || ret == ASN_NO_SIGNER_E)
+                if (ret == WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E) ||
+                    ret == WC_NO_ERR_TRACE(ASN_NO_SIGNER_E))
                     ret = 0;
                 return ret;
             }
@@ -3507,10 +3579,20 @@ int TLSX_UseCertificateStatusRequest(TLSX** extensions, byte status_type,
 
 #ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
 
+static void TLSX_CSR2_FreePendingSigners(Signer *s, void* heap)
+{
+    Signer* next;
+    while(s) {
+        next = s->next;
+        FreeSigner(s, heap);
+        s = next;
+    }
+}
 static void TLSX_CSR2_FreeAll(CertificateStatusRequestItemV2* csr2, void* heap)
 {
     CertificateStatusRequestItemV2* next;
 
+    TLSX_CSR2_FreePendingSigners(csr2->pendingSigners, heap);
     for (; csr2; csr2 = next) {
         next = csr2->next;
 
@@ -3781,6 +3863,83 @@ static int TLSX_CSR2_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     return 0;
 }
 
+static CertificateStatusRequestItemV2* TLSX_CSR2_GetMulti(TLSX *extensions)
+{
+    TLSX* extension = TLSX_Find(extensions, TLSX_STATUS_REQUEST_V2);
+    CertificateStatusRequestItemV2* csr2 = extension ?
+        (CertificateStatusRequestItemV2*)extension->data : NULL;
+
+    for (; csr2; csr2 = csr2->next) {
+        if (csr2->status_type == WOLFSSL_CSR2_OCSP_MULTI)
+            return csr2;
+    }
+    return NULL;
+}
+
+int TLSX_CSR2_IsMulti(TLSX *extensions)
+{
+    return TLSX_CSR2_GetMulti(extensions) != NULL;
+}
+
+int TLSX_CSR2_AddPendingSigner(TLSX *extensions, Signer *s)
+{
+    CertificateStatusRequestItemV2* csr2;
+
+    csr2 = TLSX_CSR2_GetMulti(extensions);
+    if (!csr2)
+        return -1;
+
+    s->next = csr2->pendingSigners;
+    csr2->pendingSigners = s;
+    return 0;
+}
+
+Signer* TLSX_CSR2_GetPendingSigners(TLSX *extensions)
+{
+    CertificateStatusRequestItemV2* csr2;
+
+    csr2 = TLSX_CSR2_GetMulti(extensions);
+    if (!csr2)
+        return NULL;
+
+    return csr2->pendingSigners;
+}
+
+int TLSX_CSR2_ClearPendingCA(WOLFSSL *ssl)
+{
+    CertificateStatusRequestItemV2* csr2;
+
+    csr2 = TLSX_CSR2_GetMulti(ssl->extensions);
+    if (csr2 == NULL)
+        return 0;
+
+    TLSX_CSR2_FreePendingSigners(csr2->pendingSigners, SSL_CM(ssl)->heap);
+    csr2->pendingSigners = NULL;
+    return 0;
+}
+
+int TLSX_CSR2_MergePendingCA(WOLFSSL* ssl)
+{
+    CertificateStatusRequestItemV2* csr2;
+    Signer *s, *next;
+    int r = 0;
+
+    csr2 = TLSX_CSR2_GetMulti(ssl->extensions);
+    if (csr2 == NULL)
+        return 0;
+
+    s = csr2->pendingSigners;
+    while (s != NULL) {
+        next = s->next;
+        r = AddSigner(SSL_CM(ssl), s);
+        if (r != 0)
+            FreeSigner(s, SSL_CM(ssl)->heap);
+        s = next;
+    }
+    csr2->pendingSigners = NULL;
+    return r;
+}
+
 int TLSX_CSR2_InitRequests(TLSX* extensions, DecodedCert* cert, byte isPeer,
                                                                      void* heap)
 {
@@ -3862,10 +4021,10 @@ int TLSX_CSR2_ForceRequest(WOLFSSL* ssl)
                 /* followed by */
 
             case WOLFSSL_CSR2_OCSP_MULTI:
-                if (SSL_CM(ssl)->ocspEnabled) {
-                    csr2->request.ocsp[0].ssl = ssl;
+                if (SSL_CM(ssl)->ocspEnabled && csr2->requests >= 1) {
+                    csr2->request.ocsp[csr2->requests-1].ssl = ssl;
                     return CheckOcspRequest(SSL_CM(ssl)->ocsp,
-                                          &csr2->request.ocsp[0], NULL, NULL);
+                                          &csr2->request.ocsp[csr2->requests-1], NULL, NULL);
                 }
                 else {
                     WOLFSSL_ERROR_VERBOSE(OCSP_LOOKUP_FAIL);
@@ -3963,7 +4122,7 @@ int TLSX_UseCertificateStatusRequestV2(TLSX** extensions, byte status_type,
 #ifdef HAVE_SUPPORTED_CURVES
 
 #if !defined(HAVE_ECC) && !defined(HAVE_CURVE25519) && !defined(HAVE_CURVE448) \
-                       && !defined(HAVE_FFDHE) && !defined(HAVE_PQC)
+                       && !defined(HAVE_FFDHE) && !defined(WOLFSSL_HAVE_KYBER)
 #error Elliptic Curves Extension requires Elliptic Curve Cryptography or liboqs groups. \
        Use --enable-ecc and/or --enable-liboqs in the configure script or \
        define HAVE_ECC. Alternatively use FFDHE for DH cipher suites.
@@ -4031,7 +4190,7 @@ static void TLSX_PointFormat_FreeAll(PointFormat* list, void* heap)
 static int TLSX_SupportedCurve_Append(SupportedCurve* list, word16 name,
                                                                      void* heap)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     while (list) {
         if (list->name == name) {
@@ -4052,7 +4211,7 @@ static int TLSX_SupportedCurve_Append(SupportedCurve* list, word16 name,
 
 static int TLSX_PointFormat_Append(PointFormat* list, byte format, void* heap)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     while (list) {
         if (list->format == format) {
@@ -4339,7 +4498,7 @@ int TLSX_SupportedCurve_Parse(const WOLFSSL* ssl, const byte* input,
         ret = TLSX_UseSupportedCurve(extensions, name, ssl->heap);
         /* If it is BAD_FUNC_ARG then it is a group we do not support, but
          * that is fine. */
-        if (ret != WOLFSSL_SUCCESS && ret != BAD_FUNC_ARG) {
+        if (ret != WOLFSSL_SUCCESS && ret != WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
             return ret;
         }
     }
@@ -4709,6 +4868,7 @@ int TLSX_ValidateSupportedCurves(const WOLFSSL* ssl, byte first, byte second,
     int             ephmSuite = 0;
     word16          octets    = 0; /* according to 'ecc_set_type ecc_sets[];' */
     int             key       = 0; /* validate key       */
+    int             foundCurve = 0; /* Found at least one supported curve */
 
     (void)oid;
 
@@ -4870,6 +5030,8 @@ int TLSX_ValidateSupportedCurves(const WOLFSSL* ssl, byte first, byte second,
             default: continue; /* unsupported curve */
         }
 
+        foundCurve = 1;
+
     #ifdef HAVE_ECC
         /* Set default Oid */
         if (defOid == 0 && ssl->eccTempKeySz <= octets && defSz > octets) {
@@ -5013,6 +5175,10 @@ int TLSX_ValidateSupportedCurves(const WOLFSSL* ssl, byte first, byte second,
             }
         }
     }
+
+    /* Check we found at least one supported curve */
+    if (!foundCurve)
+        return 0;
 
     *ecdhCurveOID = ssl->ecdhCurveOID;
     /* Choose the default if it is at the required strength. */
@@ -5237,7 +5403,7 @@ static word16 TLSX_SecureRenegotiation_Write(SecureRenegotiation* data,
 static int TLSX_SecureRenegotiation_Parse(WOLFSSL* ssl, const byte* input,
                                           word16 length, byte isRequest)
 {
-    int ret = SECURE_RENEGOTIATION_E;
+    int ret = WC_NO_ERR_TRACE(SECURE_RENEGOTIATION_E);
 
     if (length >= OPAQUE8_LEN) {
         if (isRequest) {
@@ -5247,7 +5413,7 @@ static int TLSX_SecureRenegotiation_Parse(WOLFSSL* ssl, const byte* input,
                 if (ret == WOLFSSL_SUCCESS)
                     ret = 0;
             }
-            if (ret != 0 && ret != SECURE_RENEGOTIATION_E) {
+            if (ret != 0 && ret != WC_NO_ERR_TRACE(SECURE_RENEGOTIATION_E)) {
             }
             else if (ssl->secure_renegotiation == NULL) {
             }
@@ -5317,6 +5483,12 @@ static int TLSX_SecureRenegotiation_Parse(WOLFSSL* ssl, const byte* input,
             }
         #endif
         }
+        else {
+            ret = SECURE_RENEGOTIATION_E;
+        }
+    }
+    else {
+        ret = SECURE_RENEGOTIATION_E;
     }
 
     if (ret != 0) {
@@ -5510,7 +5682,7 @@ static int TLSX_SessionTicket_Parse(WOLFSSL* ssl, const byte* input,
                 WOLFSSL_MSG("Process client ticket rejected, not using");
                 ssl->options.rejectTicket = 1;
                 ret = 0;  /* not fatal */
-            } else if (ret == VERSION_ERROR) {
+            } else if (ret == WC_NO_ERR_TRACE(VERSION_ERROR)) {
                 WOLFSSL_MSG("Process client ticket rejected, bad TLS version");
                 ssl->options.rejectTicket = 1;
                 ret = 0;  /* not fatal */
@@ -5812,7 +5984,7 @@ static void TLSX_UseSRTP_Free(TlsxSrtp *srtp, void* heap)
 static int TLSX_UseSRTP_Parse(WOLFSSL* ssl, const byte* input, word16 length,
     byte isRequest)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     word16 profile_len = 0;
     word16 profile_value = 0;
     word16 offset = 0;
@@ -6120,8 +6292,12 @@ static int TLSX_SupportedVersions_Write(void* data, byte* output,
 #ifdef WOLFSSL_DTLS13
     if (ssl->options.dtls) {
         tls13minor = (byte)DTLSv1_3_MINOR;
+    #ifndef WOLFSSL_NO_TLS12
         tls12minor = (byte)DTLSv1_2_MINOR;
+    #endif
+    #ifndef NO_OLD_TLS
         tls11minor = (byte)DTLS_MINOR;
+    #endif
         isDtls = 1;
     }
 #endif /* WOLFSSL_DTLS13 */
@@ -7181,7 +7357,7 @@ static int TLSX_KeyShare_GenDhKey(WOLFSSL *ssl, KeyShareEntry* kse)
                     kse->pubKey, &kse->pubKeyLen /* public */
                 );
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret == WC_PENDING_E) {
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                     return ret;
                 }
             #endif
@@ -7494,7 +7670,7 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
 
         #if defined(WOLFSSL_RENESAS_TSIP_TLS)
             ret = tsip_Tls13GenEccKeyPair(ssl, kse);
-            if (ret != CRYPTOCB_UNAVAILABLE) {
+            if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
                 return ret;
             }
         #endif
@@ -7511,7 +7687,7 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
                 if (ret == 0) {
             #ifdef WOLFSSL_ASYNC_CRYPT
                     /* Detect when private key generation is done */
-                    if (ssl->error == WC_PENDING_E &&
+                    if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E) &&
                             eccKey->type == ECC_PRIVATEKEY) {
                         ret = 0; /* ECC Key Generation is done */
                     }
@@ -7526,7 +7702,7 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
                     }
                 }
             #ifdef WOLFSSL_ASYNC_CRYPT
-                if (ret == WC_PENDING_E)
+                if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                     return ret;
             #endif
             }
@@ -7585,7 +7761,7 @@ static int TLSX_KeyShare_GenEccKey(WOLFSSL *ssl, KeyShareEntry* kse)
     return ret;
 }
 
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
 static int kyber_id2type(int id, int *type)
 {
     int ret = 0;
@@ -7689,7 +7865,7 @@ static int TLSX_KeyShare_GenPqcKey(WOLFSSL *ssl, KeyShareEntry* kse)
 
     findEccPqc(&ecc_group, &oqs_group, kse->group);
     ret = kyber_id2type(oqs_group, &type);
-    if (ret == NOT_COMPILED_IN) {
+    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN)) {
         WOLFSSL_MSG("Invalid Kyber algorithm specified.");
         ret = BAD_FUNC_ARG;
     }
@@ -7788,7 +7964,7 @@ static int TLSX_KeyShare_GenPqcKey(WOLFSSL *ssl, KeyShareEntry* kse)
 
     return ret;
 }
-#endif /* HAVE_PQC */
+#endif /* WOLFSSL_HAVE_KYBER */
 
 /* Generate a secret/key using the key share entry.
  *
@@ -7805,7 +7981,7 @@ int TLSX_KeyShare_GenKey(WOLFSSL *ssl, KeyShareEntry *kse)
         ret = TLSX_KeyShare_GenX25519Key(ssl, kse);
     else if (kse->group == WOLFSSL_ECC_X448)
         ret = TLSX_KeyShare_GenX448Key(ssl, kse);
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
     else if (WOLFSSL_NAMED_GROUP_IS_PQC(kse->group))
         ret = TLSX_KeyShare_GenPqcKey(ssl, kse);
 #endif
@@ -7843,7 +8019,7 @@ static void TLSX_KeyShare_FreeAll(KeyShareEntry* list, void* heap)
             wc_curve448_free((curve448_key*)current->key);
 #endif
         }
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
         else if (WOLFSSL_NAMED_GROUP_IS_PQC(current->group)) {
             if (current->key != NULL) {
                 ForceZero((byte*)current->key, current->keyLen);
@@ -8050,7 +8226,7 @@ static int TLSX_KeyShare_ProcessDh(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
             NULL, 0
         );
     #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ret == WC_PENDING_E) {
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             return ret;
         }
     #endif
@@ -8322,7 +8498,7 @@ static int TLSX_KeyShare_ProcessEcc(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
         }
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
         ret = tsip_Tls13GenSharedSecret(ssl, keyShareEntry);
-        if (ret != CRYPTOCB_UNAVAILABLE) {
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
             return ret;
         }
         ret = 0;
@@ -8364,7 +8540,7 @@ static int TLSX_KeyShare_ProcessEcc(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
             ssl->options.side
         );
     #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ret == WC_PENDING_E)
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
             return ret;
     #endif
     }
@@ -8398,7 +8574,7 @@ static int TLSX_KeyShare_ProcessEcc(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
     return ret;
 }
 
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
 /* Process the Kyber key share extension on the client side.
  *
  * ssl            The SSL/TLS object.
@@ -8437,7 +8613,7 @@ static int TLSX_KeyShare_ProcessPqc(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
         XMEMCPY(ssl->arrays->preMasterSecret, keyShareEntry->ke,
                 keyShareEntry->keLen);
         ssl->arrays->preMasterSz = keyShareEntry->keLen;
-        XFREE(keyShareEntry->ke, ssl->heap, DYNAMIC_TYPE_SECRET)
+        XFREE(keyShareEntry->ke, ssl->heap, DYNAMIC_TYPE_SECRET);
         keyShareEntry->ke = NULL;
         keyShareEntry->keLen = 0;
         return 0;
@@ -8567,7 +8743,7 @@ static int TLSX_KeyShare_ProcessPqc(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
     wc_KyberKey_Free(kem);
     return ret;
 }
-#endif /* HAVE_PQC */
+#endif /* WOLFSSL_HAVE_KYBER */
 
 /* Process the key share extension on the client side.
  *
@@ -8593,7 +8769,7 @@ static int TLSX_KeyShare_Process(WOLFSSL* ssl, KeyShareEntry* keyShareEntry)
         ret = TLSX_KeyShare_ProcessX25519(ssl, keyShareEntry);
     else if (keyShareEntry->group == WOLFSSL_ECC_X448)
         ret = TLSX_KeyShare_ProcessX448(ssl, keyShareEntry);
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
     else if (WOLFSSL_NAMED_GROUP_IS_PQC(keyShareEntry->group))
         ret = TLSX_KeyShare_ProcessPqc(ssl, keyShareEntry);
 #endif
@@ -8644,7 +8820,7 @@ static int TLSX_KeyShareEntry_Parse(const WOLFSSL* ssl, const byte* input,
     if (keLen > length - offset)
         return BUFFER_ERROR;
 
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
     if (WOLFSSL_NAMED_GROUP_IS_PQC(group) &&
         ssl->options.side == WOLFSSL_SERVER_END) {
         /* For KEMs, the public key is not stored. Casting away const because
@@ -8823,7 +8999,7 @@ int TLSX_KeyShare_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 
         /* Not in list sent if there isn't a private key. */
         if (keyShareEntry == NULL || (keyShareEntry->key == NULL
-        #if !defined(NO_DH) || defined(HAVE_PQC)
+        #if !defined(NO_DH) || defined(WOLFSSL_HAVE_KYBER)
             && keyShareEntry->privKey == NULL
         #endif
         )) {
@@ -8845,7 +9021,7 @@ int TLSX_KeyShare_Parse(WOLFSSL* ssl, const byte* input, word16 length,
 
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* only perform find and clear TLSX if not returning from async */
-        if (ssl->error != WC_PENDING_E)
+        if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
     #endif
         {
             /* Check the selected group was supported by ClientHello extensions. */
@@ -8915,7 +9091,7 @@ static int TLSX_KeyShare_New(KeyShareEntry** list, int group, void *heap,
     return 0;
 }
 
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
 static int server_generate_pqc_ciphertext(WOLFSSL* ssl,
     KeyShareEntry* keyShareEntry, byte* data, word16 len)
 {
@@ -9076,7 +9252,7 @@ static int server_generate_pqc_ciphertext(WOLFSSL* ssl,
     wc_KyberKey_Free(kem);
     return ret;
 }
-#endif /* HAVE_PQC */
+#endif /* WOLFSSL_HAVE_KYBER */
 
 /* Use the data to create a new key share object in the extensions.
  *
@@ -9125,7 +9301,7 @@ int TLSX_KeyShare_Use(const WOLFSSL* ssl, word16 group, word16 len, byte* data,
     }
 
 
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
     if (WOLFSSL_NAMED_GROUP_IS_PQC(group) &&
         ssl->options.side == WOLFSSL_SERVER_END) {
         ret = server_generate_pqc_ciphertext((WOLFSSL*)ssl, keyShareEntry, data,
@@ -9292,16 +9468,19 @@ static int TLSX_KeyShare_IsSupported(int namedGroup)
             break;
         #endif
     #endif
-    #ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
     #ifdef WOLFSSL_WC_KYBER
         #ifdef WOLFSSL_KYBER512
             case WOLFSSL_KYBER_LEVEL1:
+            case WOLFSSL_P256_KYBER_LEVEL1:
         #endif
         #ifdef WOLFSSL_KYBER768
             case WOLFSSL_KYBER_LEVEL3:
+            case WOLFSSL_P384_KYBER_LEVEL3:
         #endif
         #ifdef WOLFSSL_KYBER1024
             case WOLFSSL_KYBER_LEVEL5:
+            case WOLFSSL_P521_KYBER_LEVEL5:
         #endif
                 break;
     #elif defined(HAVE_LIBOQS)
@@ -9316,7 +9495,7 @@ static int TLSX_KeyShare_IsSupported(int namedGroup)
             int id;
             findEccPqc(NULL, &namedGroup, namedGroup);
             ret = kyber_id2type(namedGroup, &id);
-            if (ret == NOT_COMPILED_IN) {
+            if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN)) {
                 return 0;
             }
 
@@ -9329,7 +9508,7 @@ static int TLSX_KeyShare_IsSupported(int namedGroup)
         case WOLFSSL_KYBER_LEVEL1:
             break;
     #endif
-    #endif /* HAVE_PQC */
+#endif
         default:
             return 0;
     }
@@ -9378,12 +9557,15 @@ static const word16 preferredGroup[] = {
 #ifdef WOLFSSL_WC_KYBER
     #ifdef WOLFSSL_KYBER512
     WOLFSSL_KYBER_LEVEL1,
+    WOLFSSL_P256_KYBER_LEVEL1,
     #endif
     #ifdef WOLFSSL_KYBER768
     WOLFSSL_KYBER_LEVEL3,
+    WOLFSSL_P384_KYBER_LEVEL3,
     #endif
     #ifdef WOLFSSL_KYBER1024
     WOLFSSL_KYBER_LEVEL5,
+    WOLFSSL_P521_KYBER_LEVEL5,
     #endif
 #elif defined(HAVE_LIBOQS)
     /* These require a runtime call to TLSX_KeyShare_IsSupported to use */
@@ -9487,7 +9669,7 @@ int TLSX_KeyShare_SetSupported(const WOLFSSL* ssl, TLSX** extensions)
         kse = (KeyShareEntry*)extension->data;
         /* We should not be computing keys if we are only going to advertise
          * our choice here. */
-        if (kse != NULL && kse->lastRet == WC_PENDING_E) {
+        if (kse != NULL && kse->lastRet == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             WOLFSSL_ERROR_VERBOSE(BAD_KEY_SHARE_DATA);
             return BAD_KEY_SHARE_DATA;
         }
@@ -9583,7 +9765,7 @@ int TLSX_CKS_Parse(WOLFSSL* ssl, byte* input, word16 length,
             case WOLFSSL_CKS_SIGSPEC_EXTERNAL:
             default:
                 /* All other values (including external) are not. */
-                return WOLFSSL_NOT_IMPLEMENTED;
+                return BAD_FUNC_ARG;
         }
     }
 
@@ -9618,7 +9800,7 @@ int TLSX_CKS_Parse(WOLFSSL* ssl, byte* input, word16 length,
         for (j = 0; j < length; j++) {
             if (ssl->sigSpec[i] == input[j]) {
                 /* Got the match, set to this one. */
-                ret = wolfSSL_UseCKS(ssl, &ssl->peerSigSpec[i], 1);
+                ret = wolfSSL_UseCKS(ssl, &ssl->sigSpec[i], 1);
                 if (ret == WOLFSSL_SUCCESS) {
                     ret = TLSX_UseCKS(&ssl->extensions, ssl, ssl->heap);
                     TLSX_SetResponse(ssl, TLSX_CKS);
@@ -9659,16 +9841,20 @@ int TLSX_KeyShare_Choose(const WOLFSSL *ssl, TLSX* extensions,
 
     if (extension && extension->resp == 1) {
         /* Outside of the async case this path should not be taken. */
-        int ret = INCOMPLETE_DATA;
+        int ret = WC_NO_ERR_TRACE(INCOMPLETE_DATA);
     #ifdef WOLFSSL_ASYNC_CRYPT
         /* in async case make sure key generation is finalized */
         KeyShareEntry* serverKSE = (KeyShareEntry*)extension->data;
-        if (serverKSE && serverKSE->lastRet == WC_PENDING_E) {
+        if (serverKSE && serverKSE->lastRet == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             if (ssl->options.serverState == SERVER_HELLO_RETRY_REQUEST_COMPLETE)
                 *searched = 1;
             ret = TLSX_KeyShare_GenKey((WOLFSSL*)ssl, serverKSE);
         }
+        else
     #endif
+        {
+            ret = INCOMPLETE_DATA;
+        }
         return ret;
     }
 
@@ -9697,7 +9883,7 @@ int TLSX_KeyShare_Choose(const WOLFSSL *ssl, TLSX* extensions,
         if (!WOLFSSL_NAMED_GROUP_IS_FFHDE(clientKSE->group)) {
             /* Check max value supported. */
             if (clientKSE->group > WOLFSSL_ECC_MAX) {
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
                 if (!WOLFSSL_NAMED_GROUP_IS_PQC(clientKSE->group))
 #endif
                     continue;
@@ -9743,7 +9929,7 @@ int TLSX_KeyShare_Setup(WOLFSSL *ssl, KeyShareEntry* clientKSE)
             serverKSE = (KeyShareEntry*)extension->data;
             if (serverKSE != NULL) {
                 /* in async case make sure key generation is finalized */
-                if (serverKSE->lastRet == WC_PENDING_E)
+                if (serverKSE->lastRet == WC_NO_ERR_TRACE(WC_PENDING_E))
                     return TLSX_KeyShare_GenKey((WOLFSSL*)ssl, serverKSE);
                 else if (serverKSE->lastRet == 0)
                     return 0;
@@ -9762,7 +9948,7 @@ int TLSX_KeyShare_Setup(WOLFSSL *ssl, KeyShareEntry* clientKSE)
         return ret;
 
     if (clientKSE->key == NULL) {
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
         if (WOLFSSL_NAMED_GROUP_IS_PQC(clientKSE->group)) {
             /* Going to need the public key (AKA ciphertext). */
             serverKSE->pubKey = clientKSE->pubKey;
@@ -9855,7 +10041,7 @@ int TLSX_KeyShare_DeriveSecret(WOLFSSL *ssl)
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfSSL_AsyncPop(ssl, NULL);
     /* Check for error */
-    if (ret != WC_NO_PENDING_E && ret < 0) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E) && ret < 0) {
         return ret;
     }
 #endif
@@ -11212,8 +11398,10 @@ static int TLSX_ClientCertificateType_GetSize(WOLFSSL* ssl, byte msgType)
         ret = (int)(OPAQUE8_LEN + cnt * OPAQUE8_LEN);
     }
     else if (msgType == server_hello || msgType == encrypted_extensions) {
-        /* sever side */
+        /* server side */
         cnt = ssl->options.rpkState.sending_ClientCertTypeCnt;/* must be one */
+        if (cnt != 1)
+            return SANITY_MSG_E;
         ret = OPAQUE8_LEN;
     }
     else {
@@ -11668,7 +11856,7 @@ static int TLSX_ECH_Write(WOLFSSL_ECH* ech, byte* writeBuf, word16* offset)
         /* get size then write */
         ret = GetEchConfigsEx(ech->echConfig, NULL, &configsLen);
 
-        if (ret != LENGTH_ONLY_E)
+        if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
             return ret;
 
         ret = GetEchConfigsEx(ech->echConfig, writeBuf, &configsLen);
@@ -11805,7 +11993,7 @@ static int TLSX_ECH_GetSize(WOLFSSL_ECH* ech)
         /* get the size of the raw configs */
         ret = GetEchConfigsEx(ech->echConfig, NULL, &size);
 
-        if (ret != LENGTH_ONLY_E)
+        if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
             return ret;
     }
     else if (ech->type == ECH_TYPE_INNER)
@@ -11888,7 +12076,7 @@ static int TLSX_ExtractEch(WOLFSSL_ECH* ech, WOLFSSL_EchConfig* echConfig,
     if (ret == 0)
         ret = GetEchConfig(echConfig, NULL, &rawConfigLen);
 
-    if (ret == LENGTH_ONLY_E)
+    if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         ret = 0;
 
     /* create info */
@@ -12130,7 +12318,7 @@ int TLSX_FinalizeEch(WOLFSSL_ECH* ech, byte* aad, word32 aadLen)
 
             /* seal the payload */
             ret = wc_HpkeSealBase(ech->hpke, ech->ephemeralKey, receiverPubkey,
-                info, infoLen, aadCopy, aadLen, ech->innerClientHello,
+                info, (word32)infoLen, aadCopy, aadLen, ech->innerClientHello,
                 ech->innerClientHelloLen - ech->hpke->Nt,
                 ech->outerClientPayload);
 
@@ -12984,21 +13172,30 @@ static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions)
         #endif
 #endif
 
-#ifdef HAVE_PQC
+#ifdef WOLFSSL_HAVE_KYBER
 #ifdef WOLFSSL_WC_KYBER
 #ifdef WOLFSSL_KYBER512
     if (ret == WOLFSSL_SUCCESS)
         ret = TLSX_UseSupportedCurve(extensions, WOLFSSL_KYBER_LEVEL1,
+                                     ssl->heap);
+    if (ret == WOLFSSL_SUCCESS)
+        ret = TLSX_UseSupportedCurve(extensions, WOLFSSL_P256_KYBER_LEVEL1,
                                      ssl->heap);
 #endif
 #ifdef WOLFSSL_KYBER768
     if (ret == WOLFSSL_SUCCESS)
         ret = TLSX_UseSupportedCurve(extensions, WOLFSSL_KYBER_LEVEL3,
                                      ssl->heap);
+    if (ret == WOLFSSL_SUCCESS)
+        ret = TLSX_UseSupportedCurve(extensions, WOLFSSL_P384_KYBER_LEVEL3,
+                                     ssl->heap);
 #endif
 #ifdef WOLFSSL_KYBER768
     if (ret == WOLFSSL_SUCCESS)
         ret = TLSX_UseSupportedCurve(extensions, WOLFSSL_KYBER_LEVEL5,
+                                     ssl->heap);
+    if (ret == WOLFSSL_SUCCESS)
+        ret = TLSX_UseSupportedCurve(extensions, WOLFSSL_P521_KYBER_LEVEL5,
                                      ssl->heap);
 #endif
 #elif defined(HAVE_LIBOQS)
@@ -13021,7 +13218,7 @@ static int TLSX_PopulateSupportedGroups(WOLFSSL* ssl, TLSX** extensions)
 #elif defined(HAVE_PQM4)
     ret = TLSX_UseSupportedCurve(extensions, WOLFSSL_KYBER_LEVEL1, ssl->heap);
 #endif /* HAVE_LIBOQS */
-#endif /* HAVE_PQC */
+#endif /* WOLFSSL_HAVE_KYBER */
 
     (void)ssl;
     (void)extensions;
@@ -13240,7 +13437,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
                 ret = SetCipherSpecs(ssl);
                 if (ret != 0)
                     return ret;
-                now = TimeNowInMilliseconds();
+                now = (word64)TimeNowInMilliseconds();
                 if (now == 0)
                     return GETTIME_ERROR;
             #ifdef WOLFSSL_32BIT_MILLI_TIME
@@ -13371,7 +13568,7 @@ int TLSX_PopulateExtensions(WOLFSSL* ssl, byte isServer)
                     ssl->arrays->psk_keySz == 0 ||
                 #endif
                          (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-                     (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+                     (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
                 #ifndef OPENSSL_EXTRA
                     ret = PSK_KEY_ERROR;
                 #endif
@@ -13570,7 +13767,7 @@ static int TLSX_GetSizeWithEch(WOLFSSL* ssl, byte* semaphore, byte msgType,
 #endif
 
 /** Tells the buffered size of extensions to be sent into the client hello. */
-int TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType, word16* pLength)
+int TLSX_GetRequestSize(WOLFSSL* ssl, byte msgType, word32* pLength)
 {
     int ret = 0;
     word16 length = 0;
@@ -13800,7 +13997,7 @@ static int TLSX_WriteWithEch(WOLFSSL* ssl, byte* output, byte* semaphore,
 #endif
 
 /** Writes the extensions to be sent into the client hello. */
-int TLSX_WriteRequest(WOLFSSL* ssl, byte* output, byte msgType, word16* pOffset)
+int TLSX_WriteRequest(WOLFSSL* ssl, byte* output, byte msgType, word32* pOffset)
 {
     int ret = 0;
     word16 offset = 0;
@@ -14294,6 +14491,143 @@ int TLSX_ParseVersion(WOLFSSL* ssl, const byte* input, word16 length,
     return ret;
 }
 #endif
+/* Jump Table to check minimum size values for client case in TLSX_Parse */
+#ifndef NO_WOLFSSL_SERVER
+static word16 TLSX_GetMinSize_Client(word16* type)
+{
+    switch (*type) {
+        case TLSXT_SERVER_NAME:
+            return WOLFSSL_SNI_MIN_SIZE_CLIENT;
+        case TLSXT_EARLY_DATA:
+            return WOLFSSL_EDI_MIN_SIZE_CLIENT;
+        case TLSXT_MAX_FRAGMENT_LENGTH:
+            return WOLFSSL_MFL_MIN_SIZE_CLIENT;
+        case TLSXT_TRUSTED_CA_KEYS:
+            return WOLFSSL_TCA_MIN_SIZE_CLIENT;
+        case TLSXT_TRUNCATED_HMAC:
+            return WOLFSSL_THM_MIN_SIZE_CLIENT;
+        case TLSXT_STATUS_REQUEST:
+            return WOLFSSL_CSR_MIN_SIZE_CLIENT;
+        case TLSXT_SUPPORTED_GROUPS:
+            return WOLFSSL_EC_MIN_SIZE_CLIENT;
+        case TLSXT_EC_POINT_FORMATS:
+            return WOLFSSL_PF_MIN_SIZE_CLIENT;
+        case TLSXT_SIGNATURE_ALGORITHMS:
+            return WOLFSSL_SA_MIN_SIZE_CLIENT;
+        case TLSXT_USE_SRTP:
+            return WOLFSSL_SRTP_MIN_SIZE_CLIENT;
+        case TLSXT_APPLICATION_LAYER_PROTOCOL:
+            return WOLFSSL_ALPN_MIN_SIZE_CLIENT;
+        case TLSXT_STATUS_REQUEST_V2:
+            return WOLFSSL_CSR2_MIN_SIZE_CLIENT;
+        case TLSXT_CLIENT_CERTIFICATE:
+            return WOLFSSL_CCT_MIN_SIZE_CLIENT;
+        case TLSXT_SERVER_CERTIFICATE:
+            return WOLFSSL_SCT_MIN_SIZE_CLIENT;
+        case TLSXT_ENCRYPT_THEN_MAC:
+            return WOLFSSL_ETM_MIN_SIZE_CLIENT;
+        case TLSXT_SESSION_TICKET:
+            return WOLFSSL_STK_MIN_SIZE_CLIENT;
+        case TLSXT_PRE_SHARED_KEY:
+            return WOLFSSL_PSK_MIN_SIZE_CLIENT;
+        case TLSXT_COOKIE:
+            return WOLFSSL_CKE_MIN_SIZE_CLIENT;
+        case TLSXT_PSK_KEY_EXCHANGE_MODES:
+            return WOLFSSL_PKM_MIN_SIZE_CLIENT;
+        case TLSXT_CERTIFICATE_AUTHORITIES:
+            return WOLFSSL_CAN_MIN_SIZE_CLIENT;
+        case TLSXT_POST_HANDSHAKE_AUTH:
+            return WOLFSSL_PHA_MIN_SIZE_CLIENT;
+        case TLSXT_SIGNATURE_ALGORITHMS_CERT:
+            return WOLFSSL_SA_MIN_SIZE_CLIENT;
+        case TLSXT_KEY_SHARE:
+            return WOLFSSL_KS_MIN_SIZE_CLIENT;
+        case TLSXT_CONNECTION_ID:
+            return WOLFSSL_CID_MIN_SIZE_CLIENT;
+        case TLSXT_RENEGOTIATION_INFO:
+            return WOLFSSL_SCR_MIN_SIZE_CLIENT;
+        case TLSXT_KEY_QUIC_TP_PARAMS_DRAFT:
+            return WOLFSSL_QTP_MIN_SIZE_CLIENT;
+        case TLSXT_ECH:
+            return WOLFSSL_ECH_MIN_SIZE_CLIENT;
+        default:
+            return 0;
+    }
+}
+    #define TLSX_GET_MIN_SIZE_CLIENT TLSX_GetMinSize_Client
+#else
+    #define TLSX_GET_MIN_SIZE_CLIENT(...) 0
+#endif
+
+
+#ifndef NO_WOLFSSL_CLIENT
+/* Jump Table to check minimum size values for server case in TLSX_Parse */
+static word16 TLSX_GetMinSize_Server(const word16 *type)
+{
+    switch (*type) {
+        case TLSXT_SERVER_NAME:
+            return WOLFSSL_SNI_MIN_SIZE_SERVER;
+        case TLSXT_EARLY_DATA:
+            return WOLFSSL_EDI_MIN_SIZE_SERVER;
+        case TLSXT_MAX_FRAGMENT_LENGTH:
+            return WOLFSSL_MFL_MIN_SIZE_SERVER;
+        case TLSXT_TRUSTED_CA_KEYS:
+            return WOLFSSL_TCA_MIN_SIZE_SERVER;
+        case TLSXT_TRUNCATED_HMAC:
+            return WOLFSSL_THM_MIN_SIZE_SERVER;
+        case TLSXT_STATUS_REQUEST:
+            return WOLFSSL_CSR_MIN_SIZE_SERVER;
+        case TLSXT_SUPPORTED_GROUPS:
+            return WOLFSSL_EC_MIN_SIZE_SERVER;
+        case TLSXT_EC_POINT_FORMATS:
+            return WOLFSSL_PF_MIN_SIZE_SERVER;
+        case TLSXT_SIGNATURE_ALGORITHMS:
+            return WOLFSSL_SA_MIN_SIZE_SERVER;
+        case TLSXT_USE_SRTP:
+            return WOLFSSL_SRTP_MIN_SIZE_SERVER;
+        case TLSXT_APPLICATION_LAYER_PROTOCOL:
+            return WOLFSSL_ALPN_MIN_SIZE_SERVER;
+        case TLSXT_STATUS_REQUEST_V2:
+            return WOLFSSL_CSR2_MIN_SIZE_SERVER;
+        case TLSXT_CLIENT_CERTIFICATE:
+            return WOLFSSL_CCT_MIN_SIZE_SERVER;
+        case TLSXT_SERVER_CERTIFICATE:
+            return WOLFSSL_SCT_MIN_SIZE_SERVER;
+        case TLSXT_ENCRYPT_THEN_MAC:
+            return WOLFSSL_ETM_MIN_SIZE_SERVER;
+        case TLSXT_SESSION_TICKET:
+            return WOLFSSL_STK_MIN_SIZE_SERVER;
+        case TLSXT_PRE_SHARED_KEY:
+            return WOLFSSL_PSK_MIN_SIZE_SERVER;
+        case TLSXT_COOKIE:
+            return WOLFSSL_CKE_MIN_SIZE_SERVER;
+        case TLSXT_PSK_KEY_EXCHANGE_MODES:
+            return WOLFSSL_PKM_MIN_SIZE_SERVER;
+        case TLSXT_CERTIFICATE_AUTHORITIES:
+            return WOLFSSL_CAN_MIN_SIZE_SERVER;
+        case TLSXT_POST_HANDSHAKE_AUTH:
+            return WOLFSSL_PHA_MIN_SIZE_SERVER;
+        case TLSXT_SIGNATURE_ALGORITHMS_CERT:
+            return WOLFSSL_SA_MIN_SIZE_SERVER;
+        case TLSXT_KEY_SHARE:
+            return WOLFSSL_KS_MIN_SIZE_SERVER;
+        case TLSXT_CONNECTION_ID:
+            return WOLFSSL_CID_MIN_SIZE_SERVER;
+        case TLSXT_RENEGOTIATION_INFO:
+            return WOLFSSL_SCR_MIN_SIZE_SERVER;
+        case TLSXT_KEY_QUIC_TP_PARAMS_DRAFT:
+            return WOLFSSL_QTP_MIN_SIZE_SERVER;
+        case TLSXT_ECH:
+            return WOLFSSL_ECH_MIN_SIZE_SERVER;
+        default:
+            return 0;
+    }
+}
+    #define TLSX_GET_MIN_SIZE_SERVER TLSX_GetMinSize_Server
+#else
+    #define TLSX_GET_MIN_SIZE_SERVER(...) 0
+#endif
+
 
 /** Parses a buffer of TLS extensions. */
 int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
@@ -14356,6 +14690,29 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
 
         if (length - offset < size)
             return BUFFER_ERROR;
+
+        /* Check minimum size required for TLSX, even if disabled */
+        switch (msgType) {
+            #ifndef NO_WOLFSSL_SERVER
+            case client_hello:
+                if (size < TLSX_GET_MIN_SIZE_CLIENT(&type)){
+                    WOLFSSL_MSG("Minimum TLSX Size Requirement not Satisfied");
+                    return BUFFER_ERROR;
+                }
+            break;
+            #endif
+            #ifndef NO_WOLFSSL_CLIENT
+            case server_hello:
+            case hello_retry_request:
+                if (size < TLSX_GET_MIN_SIZE_SERVER(&type)){
+                    WOLFSSL_MSG("Minimum TLSX Size Requirement not Satisfied");
+                    return BUFFER_ERROR;
+                }
+            break;
+            #endif
+            default:
+            break;
+        }
 
         switch (type) {
 #ifdef HAVE_SNI
@@ -14914,13 +15271,20 @@ int TLSX_Parse(WOLFSSL* ssl, const byte* input, word16 length, byte msgType,
     }
 
 #ifdef HAVE_EXTENDED_MASTER
-    if (IsAtLeastTLSv1_3(ssl->version) && msgType == hello_retry_request) {
+    if (IsAtLeastTLSv1_3(ssl->version) &&
+        (msgType == hello_retry_request || msgType == hello_verify_request)) {
         /* Don't change EMS status until server_hello received.
          * Second ClientHello must have same extensions.
          */
     }
     else if (!isRequest && ssl->options.haveEMS && !pendingEMS)
         ssl->options.haveEMS = 0;
+#endif
+#if defined(WOLFSSL_TLS13) && !defined(NO_PSK)
+    if (IsAtLeastTLSv1_3(ssl->version) && msgType == server_hello &&
+        IS_OFF(seenType, TLSX_ToSemaphore(TLSX_KEY_SHARE))) {
+        ssl->options.noPskDheKe = 1;
+    }
 #endif
 
     if (ret == 0)

--- a/libatalk/ssl/src/tls13.c
+++ b/libatalk/ssl/src/tls13.c
@@ -189,7 +189,7 @@ static const byte
 
 #ifndef NO_CERTS
 #if !defined(NO_RSA) || defined(HAVE_ECC) || defined(HAVE_ED25519) || \
-    defined(HAVE_ED448) || defined(HAVE_PQC)
+    defined(HAVE_ED448) || defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
 
 static WC_INLINE int GetMsgHash(WOLFSSL* ssl, byte* hash);
 
@@ -205,7 +205,7 @@ static int Tls13HKDFExpandLabel(WOLFSSL* ssl, byte* okm, word32 okmLen,
                                 const byte* info, word32 infoLen,
                                 int digest)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 
 #if defined(HAVE_PK_CALLBACKS)
     if (ssl->ctx && ssl->ctx->HKDFExpandLabelCb) {
@@ -216,7 +216,7 @@ static int Tls13HKDFExpandLabel(WOLFSSL* ssl, byte* okm, word32 okmLen,
                                           WOLFSSL_CLIENT_END /* ignored */);
     }
 
-    if (ret != NOT_COMPILED_IN)
+    if (ret != WC_NO_ERR_TRACE(NOT_COMPILED_IN))
         return ret;
 #endif
     (void)ssl;
@@ -257,7 +257,7 @@ static int Tls13HKDFExpandKeyLabel(WOLFSSL* ssl, byte* okm, word32 okmLen,
                                          info, infoLen,
                                          digest, side);
     }
-    if (ret != NOT_COMPILED_IN)
+    if (ret != WC_NO_ERR_TRACE(NOT_COMPILED_IN))
         return ret;
 #endif
 
@@ -308,14 +308,14 @@ static int DeriveKeyMsg(WOLFSSL* ssl, byte* output, int outputLen,
     const byte* protocol;
     word32      protocolLen;
     int         digestAlg = -1;
-    int         ret = BAD_FUNC_ARG;
+    int         ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (hashAlgo) {
 #ifndef NO_WOLFSSL_SHA256
         case sha256_mac:
             ret = wc_InitSha256_ex(&digest.sha256, ssl->heap, ssl->devId);
             if (ret == 0) {
-                    ret = wc_Sha256Update(&digest.sha256, msg, msgLen);
+                    ret = wc_Sha256Update(&digest.sha256, msg, (word32)msgLen);
                 if (ret == 0)
                     ret = wc_Sha256Final(&digest.sha256, hash);
                 wc_Sha256Free(&digest.sha256);
@@ -328,7 +328,7 @@ static int DeriveKeyMsg(WOLFSSL* ssl, byte* output, int outputLen,
         case sha384_mac:
             ret = wc_InitSha384_ex(&digest.sha384, ssl->heap, ssl->devId);
             if (ret == 0) {
-                ret = wc_Sha384Update(&digest.sha384, msg, msgLen);
+                ret = wc_Sha384Update(&digest.sha384, msg, (word32)msgLen);
                 if (ret == 0)
                     ret = wc_Sha384Final(&digest.sha384, hash);
                 wc_Sha384Free(&digest.sha384);
@@ -341,7 +341,7 @@ static int DeriveKeyMsg(WOLFSSL* ssl, byte* output, int outputLen,
         case sha512_mac:
             ret = wc_InitSha512_ex(&digest.sha512, ssl->heap, ssl->devId);
             if (ret == 0) {
-                ret = wc_Sha512Update(&digest.sha512, msg, msgLen);
+                ret = wc_Sha512Update(&digest.sha512, msg, (word32)msgLen);
                 if (ret == 0)
                     ret = wc_Sha512Final(&digest.sha512, hash);
                 wc_Sha512Free(&digest.sha512);
@@ -354,7 +354,7 @@ static int DeriveKeyMsg(WOLFSSL* ssl, byte* output, int outputLen,
         case sm3_mac:
             ret = wc_InitSm3(&digest.sm3, ssl->heap, ssl->devId);
             if (ret == 0) {
-                ret = wc_Sm3Update(&digest.sm3, msg, msgLen);
+                ret = wc_Sm3Update(&digest.sm3, msg, (word32)msgLen);
                 if (ret == 0)
                     ret = wc_Sm3Final(&digest.sm3, hash);
                 wc_Sm3Free(&digest.sm3);
@@ -364,6 +364,7 @@ static int DeriveKeyMsg(WOLFSSL* ssl, byte* output, int outputLen,
             break;
 #endif
         default:
+            ret = BAD_FUNC_ARG;
             digestAlg = -1;
             break;
     }
@@ -392,9 +393,9 @@ static int DeriveKeyMsg(WOLFSSL* ssl, byte* output, int outputLen,
             return VERSION_ERROR;
     }
     if (outputLen == -1)
-        outputLen = hashSz;
+        outputLen = (int)hashSz;
 
-    ret = Tls13HKDFExpandLabel(ssl, output, outputLen, secret, hashSz,
+    ret = Tls13HKDFExpandLabel(ssl, output, (word32)outputLen, secret, hashSz,
                                protocol, protocolLen, label, labelLen,
                                hash, hashSz, digestAlg);
     return ret;
@@ -481,7 +482,7 @@ int Tls13DeriveKey(WOLFSSL* ssl, byte* output, int outputLen,
 #endif /* WOLFSSL_DTLS13 */
 
     if (outputLen == -1) {
-        outputLen = hashSz;
+        outputLen = (int)hashSz;
     }
     if (includeMsgs) {
         hashOutSz = hashSz;
@@ -496,7 +497,7 @@ int Tls13DeriveKey(WOLFSSL* ssl, byte* output, int outputLen,
     }
 
     PRIVATE_KEY_UNLOCK();
-    ret = Tls13HKDFExpandKeyLabel(ssl, output, outputLen, secret, hashSz,
+    ret = Tls13HKDFExpandKeyLabel(ssl, output, (word32)outputLen, secret, hashSz,
                                   protocol, protocolLen, label, labelLen,
                                   hash, hashOutSz, digestAlg, side);
     PRIVATE_KEY_LOCK();
@@ -973,7 +974,7 @@ int Tls13_Exporter(WOLFSSL* ssl, unsigned char *out, size_t outLen,
 {
     int                 ret;
     enum wc_HashType    hashType = WC_HASH_TYPE_NONE;
-    int                 hashLen = 0;
+    word32              hashLen = 0;
     byte                hashOut[WC_MAX_DIGEST_SIZE];
     const byte*         emptyHash = NULL;
     byte                firstExpand[WC_MAX_DIGEST_SIZE];
@@ -1124,7 +1125,7 @@ static int Tls13_HKDF_Extract(WOLFSSL *ssl, byte* prk, const byte* salt,
     void *cb_ctx = ssl->HkdfExtractCtx;
     CallbackHKDFExtract cb = ssl->ctx->HkdfExtractCb;
     if (cb != NULL) {
-        ret = cb(prk, salt, saltLen, ikm, ikmLen, digest, cb_ctx);
+        ret = cb(prk, salt, (word32)saltLen, ikm, (word32)ikmLen, digest, cb_ctx);
     }
     else
 #endif
@@ -1137,7 +1138,7 @@ static int Tls13_HKDF_Extract(WOLFSSL *ssl, byte* prk, const byte* salt,
     {
     #if !defined(HAVE_FIPS) || \
         (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3))
-        ret = wc_Tls13_HKDF_Extract_ex(prk, salt, saltLen, ikm, ikmLen, digest,
+        ret = wc_Tls13_HKDF_Extract_ex(prk, salt, (word32)saltLen, ikm, (word32)ikmLen, digest,
             ssl->heap, ssl->devId);
     #else
         ret = wc_Tls13_HKDF_Extract(prk, salt, saltLen, ikm, ikmLen, digest);
@@ -1161,13 +1162,13 @@ int DeriveEarlySecret(WOLFSSL* ssl)
     }
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13DeriveEarlySecret(ssl);
-    if (ret != CRYPTOCB_UNAVAILABLE)
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
         return ret;
 #endif
     PRIVATE_KEY_UNLOCK();
 #if defined(HAVE_SESSION_TICKET) || !defined(NO_PSK)
     ret = Tls13_HKDF_Extract(ssl, ssl->arrays->secret, NULL, 0,
-            ssl->arrays->psk_key, ssl->arrays->psk_keySz,
+            ssl->arrays->psk_key, (int)ssl->arrays->psk_keySz,
             mac2hash(ssl->specs.mac_algorithm));
 #else
     ret = Tls13_HKDF_Extract(ssl, ssl->arrays->secret, NULL, 0,
@@ -1197,7 +1198,7 @@ int DeriveHandshakeSecret(WOLFSSL* ssl)
     }
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13DeriveHandshakeSecret(ssl);
-    if (ret != CRYPTOCB_UNAVAILABLE)
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
         return ret;
 #endif
 
@@ -1210,7 +1211,7 @@ int DeriveHandshakeSecret(WOLFSSL* ssl)
     PRIVATE_KEY_UNLOCK();
     ret = Tls13_HKDF_Extract(ssl, ssl->arrays->preMasterSecret,
             key, ssl->specs.hash_size,
-            ssl->arrays->preMasterSecret, ssl->arrays->preMasterSz,
+            ssl->arrays->preMasterSecret, (int)ssl->arrays->preMasterSz,
             mac2hash(ssl->specs.mac_algorithm));
     PRIVATE_KEY_LOCK();
 
@@ -1232,7 +1233,7 @@ int DeriveMasterSecret(WOLFSSL* ssl)
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13DeriveMasterSecret(ssl);
-    if (ret != CRYPTOCB_UNAVAILABLE)
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
         return ret;
 #endif
 
@@ -1355,7 +1356,7 @@ static int BuildTls13HandshakeHmac(WOLFSSL* ssl, byte* key, byte* hash,
 #endif
     int  hashType = WC_SHA256;
     int  hashSz = WC_SHA256_DIGEST_SIZE;
-    int  ret = BAD_FUNC_ARG;
+    int  ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     if (ssl == NULL || key == NULL || hash == NULL) {
         return BAD_FUNC_ARG;
@@ -1392,6 +1393,7 @@ static int BuildTls13HandshakeHmac(WOLFSSL* ssl, byte* key, byte* hash,
             break;
     #endif /* WOLFSSL_SM3 */
         default:
+            ret = BAD_FUNC_ARG;
             break;
     }
     if (ret != 0)
@@ -1416,7 +1418,7 @@ static int BuildTls13HandshakeHmac(WOLFSSL* ssl, byte* key, byte* hash,
     if (ret == 0) {
         ret = wc_HmacSetKey(verifyHmac, hashType, key, ssl->specs.hash_size);
         if (ret == 0)
-            ret = wc_HmacUpdate(verifyHmac, hash, hashSz);
+            ret = wc_HmacUpdate(verifyHmac, hash, (word32)hashSz);
         if (ret == 0)
             ret = wc_HmacFinal(verifyHmac, hash);
         wc_HmacFree(verifyHmac);
@@ -1432,7 +1434,7 @@ static int BuildTls13HandshakeHmac(WOLFSSL* ssl, byte* key, byte* hash,
 #endif
 
     if (pHashSz)
-        *pHashSz = hashSz;
+        *pHashSz = (word32)hashSz;
 
     return ret;
 }
@@ -1466,7 +1468,7 @@ static const byte writeIVLabel[WRITE_IV_LABEL_SZ+1]   = "iv";
  */
 int DeriveTls13Keys(WOLFSSL* ssl, int secret, int side, int store)
 {
-    int   ret = BAD_FUNC_ARG; /* Assume failure */
+    int   ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG); /* Assume failure */
     int   i = 0;
 #ifdef WOLFSSL_SMALL_STACK
     byte* key_dig;
@@ -1477,10 +1479,10 @@ int DeriveTls13Keys(WOLFSSL* ssl, int secret, int side, int store)
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13DeriveKeys(ssl, secret, side);
-    if (ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         return ret;
     }
-    ret = BAD_FUNC_ARG; /* Assume failure */
+    ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG); /* Assume failure */
 #endif
 
 #ifdef WOLFSSL_SMALL_STACK
@@ -1553,6 +1555,7 @@ int DeriveTls13Keys(WOLFSSL* ssl, int secret, int side, int store)
             break;
 
         default:
+            ret = BAD_FUNC_ARG;
             break;
     }
 
@@ -1633,7 +1636,7 @@ int DeriveTls13Keys(WOLFSSL* ssl, int secret, int side, int store)
 #endif /* WOLFSSL_DTLS13 */
 
 end:
-    ForceZero(key_dig, i);
+    ForceZero(key_dig, (word32)i);
 #ifdef WOLFSSL_SMALL_STACK
     XFREE(key_dig, ssl->heap, DYNAMIC_TYPE_DIGEST);
 #elif defined(WOLFSSL_CHECK_MEM_ZERO)
@@ -1910,10 +1913,12 @@ end:
 #elif defined(WOLFSSL_ZEPHYR)
     word32 TimeNowInMilliseconds(void)
     {
+        int64_t t;
     #if defined(CONFIG_ARCH_POSIX)
         k_cpu_idle();
     #endif
-        return (word32)k_uptime_get() / 1000;
+        t = k_uptime_get(); /* returns current uptime in milliseconds */
+        return (word32)t;
     }
 
 #else
@@ -2201,10 +2206,12 @@ end:
 #elif defined(WOLFSSL_ZEPHYR)
     sword64 TimeNowInMilliseconds(void)
     {
+        int64_t t;
     #if defined(CONFIG_ARCH_POSIX)
         k_cpu_idle();
     #endif
-        return (sword64)k_uptime_get() / 1000;
+        t = k_uptime_get(); /* returns current uptime in milliseconds */
+        return (sword64)t;
     }
 
 #else
@@ -2567,13 +2574,13 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
     (void)nonceSz;
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ssl->error == WC_PENDING_E) {
+    if (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ssl->error = 0; /* clear async */
     }
 #endif
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13AesEncrypt(ssl, output, input, dataSz);
-    if (ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         if (ret > 0) {
             ret = 0; /* tsip_Tls13AesEncrypt returns output size */
         }
@@ -2646,7 +2653,7 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
                                   output + dataSz, macSz,
                                   aad, aadSz);
                     }
-                    if (ret == NOT_COMPILED_IN)
+                    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
                 #endif
                     {
 
@@ -2688,7 +2695,7 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
                                   output + dataSz, macSz,
                                   aad, aadSz);
                     }
-                    if (ret == NOT_COMPILED_IN)
+                    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
                 #endif
                     {
                 #if ((defined(HAVE_FIPS) || defined(HAVE_SELFTEST)) && \
@@ -2750,7 +2757,7 @@ static int EncryptTls13(WOLFSSL* ssl, byte* output, const byte* input,
             ssl->encrypt.state = CIPHER_STATE_END;
 
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 /* if async is not okay, then block */
                 if (!asyncOkay) {
                     ret = wc_AsyncWait(ret, asyncDev, event_flags);
@@ -2952,7 +2959,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13AesDecrypt(ssl, output, input, sz);
 
-    if (ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         #ifndef WOLFSSL_EARLY_DATA
         if (ret < 0) {
             ret = VERIFY_MAC_ERROR;
@@ -2965,9 +2972,9 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfSSL_AsyncPop(ssl, &ssl->decrypt.state);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* check for still pending */
-        if (ret == WC_PENDING_E)
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
             return ret;
 
         ssl->error = 0; /* clear async */
@@ -3048,7 +3055,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
                                   (byte *)(input + dataSz), macSz,
                                   aad, aadSz);
                     }
-                    if (ret == NOT_COMPILED_IN)
+                    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
                 #endif
                     {
 
@@ -3057,7 +3064,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
                             input + dataSz, macSz, aad, aadSz);
 
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                        if (ret == WC_PENDING_E) {
+                        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                             ret = wolfSSL_AsyncPush(ssl,
                                 &ssl->decrypt.aes->asyncDev);
                         }
@@ -3087,14 +3094,14 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
                                   (byte *)(input + dataSz), macSz,
                                   aad, aadSz);
                     }
-                    if (ret == NOT_COMPILED_IN)
+                    if (ret == WC_NO_ERR_TRACE(NOT_COMPILED_IN))
                 #endif
                     {
                         ret = wc_AesCcmDecrypt(ssl->decrypt.aes, output, input,
                             dataSz, ssl->decrypt.nonce, nonceSz,
                             input + dataSz, macSz, aad, aadSz);
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                        if (ret == WC_PENDING_E) {
+                        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                             ret = wolfSSL_AsyncPush(ssl,
                                 &ssl->decrypt.aes->asyncDev);
                         }
@@ -3144,7 +3151,7 @@ int DecryptTls13(WOLFSSL* ssl, byte* output, const byte* input, word16 sz,
 
         #ifdef WOLFSSL_ASYNC_CRYPT
             /* If pending, leave now */
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 return ret;
             }
         #endif
@@ -3242,7 +3249,7 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
         args = (BuildMsg13Args*)ssl->async->args;
 
         ret = wolfSSL_AsyncPop(ssl, &ssl->options.buildMsgState);
-        if (ret != WC_NO_PENDING_E) {
+        if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
             /* Check for error */
             if (ret < 0)
                 goto exit_buildmsg;
@@ -3256,7 +3263,7 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
 
     /* Reset state */
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_NO_PENDING_E)
+    if (ret == WC_NO_ERR_TRACE(WC_NO_PENDING_E))
 #endif
     {
         ret = 0;
@@ -3269,7 +3276,7 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
             args->headerSz = Dtls13GetRlHeaderLength(ssl, 1);
 #endif /* WOLFSSL_DTLS13 */
 
-        args->sz = args->headerSz + inSz;
+        args->sz = args->headerSz + (word32)inSz;
         args->idx  = args->headerSz;
 
     #ifdef WOLFSSL_ASYNC_CRYPT
@@ -3299,7 +3306,7 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
             args->sz += ssl->specs.aead_mac_size;
 
             if (sizeOnly)
-                return args->sz;
+                return (int)args->sz;
 
             if (args->sz > (word32)outSz) {
                 WOLFSSL_MSG("Oops, want to write past output buffer size");
@@ -3324,8 +3331,8 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
 
             /* TLS v1.3 can do in place encryption. */
             if (input != output + args->idx)
-                XMEMCPY(output + args->idx, input, inSz);
-            args->idx += inSz;
+                XMEMCPY(output + args->idx, input, (size_t)inSz);
+            args->idx += (word32)inSz;
 
             ssl->options.buildMsgState = BUILD_MSG_HASH;
         }
@@ -3334,7 +3341,7 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
         case BUILD_MSG_HASH:
         {
             if (hashOutput) {
-                ret = HashOutput(ssl, output, args->headerSz + inSz, 0);
+                ret = HashOutput(ssl, output, (int)args->headerSz + inSz, 0);
                 if (ret != 0)
                     goto exit_buildmsg;
             }
@@ -3353,8 +3360,8 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
                 /* QUIC does not use encryption of the TLS Record Layer.
                  * Return the original length + added headers
                  * and restore it in the record header. */
-                AddTls13RecordHeader(output, inSz, type, ssl);
-                ret = args->headerSz + inSz;
+                AddTls13RecordHeader(output, (word32)inSz, (byte)type, ssl);
+                ret = (int)args->headerSz + inSz;
                 goto exit_buildmsg;
             }
 #endif
@@ -3364,7 +3371,7 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
                 byte* mac = output + args->idx;
                 output += args->headerSz;
 
-                ret = ssl->ctx->MacEncryptCb(ssl, mac, output, inSz, type, 0,
+                ret = ssl->ctx->MacEncryptCb(ssl, mac, output, (unsigned int)inSz, (byte)type, 0,
                         output, output, args->size, ssl->MacEncryptCtx);
             }
             else
@@ -3376,7 +3383,7 @@ int BuildTls13Message(WOLFSSL* ssl, byte* output, int outSz, const byte* input,
                                    (word16)args->headerSz, asyncOkay);
                 if (ret != 0) {
                 #ifdef WOLFSSL_ASYNC_CRYPT
-                    if (ret != WC_PENDING_E)
+                    if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                 #endif
                     {
                         /* Zeroize plaintext. */
@@ -3402,7 +3409,7 @@ exit_buildmsg:
     WOLFSSL_LEAVE("BuildTls13Message", ret);
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         return ret;
     }
 #endif
@@ -3412,7 +3419,7 @@ exit_buildmsg:
 
     /* return sz on success */
     if (ret == 0) {
-        ret = args->sz;
+        ret = (int)args->sz;
     }
     else {
         WOLFSSL_ERROR_VERBOSE(ret);
@@ -3950,7 +3957,7 @@ static int SetupPskKey(WOLFSSL* ssl, PreSharedKey* psk, int clientHello)
         }
         if (ssl->arrays->psk_keySz == 0 ||
                 (ssl->arrays->psk_keySz > MAX_PSK_KEY_LEN &&
-            (int)ssl->arrays->psk_keySz != USE_HW_PSK)) {
+            (int)ssl->arrays->psk_keySz != WC_NO_ERR_TRACE(USE_HW_PSK))) {
             WOLFSSL_ERROR_VERBOSE(PSK_KEY_ERROR);
             return PSK_KEY_ERROR;
         }
@@ -4019,7 +4026,7 @@ static int WritePSKBinders(WOLFSSL* ssl, byte* output, word32 idx)
             idx - Dtls13GetRlHeaderLength(ssl, 0));
     else
 #endif /* WOLFSSL_DTLS13 */
-        ret = HashOutput(ssl, output, idx, 0);
+        ret = HashOutput(ssl, output, (int)idx, 0);
 
     if (ret != 0)
         return ret;
@@ -4167,7 +4174,7 @@ static int EchHashHelloInner(WOLFSSL* ssl, WOLFSSL_ECH* ech)
     /* hash the body */
     if (ret == 0) {
         ret = HashRaw(ssl, ech->innerClientHello,
-              ech->innerClientHelloLen - ech->paddingLen - ech->hpke->Nt);
+              (int)(ech->innerClientHelloLen - ech->paddingLen - ech->hpke->Nt));
     }
 
     /* swap hsHashes back */
@@ -4234,7 +4241,7 @@ typedef struct Sch13Args {
     byte*  output;
     word32 idx;
     int    sendSz;
-    word16 length;
+    word32 length;
 #if defined(HAVE_ECH)
     int clientRandomOffset;
     int preXLength;
@@ -4312,7 +4319,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
     args = (Sch13Args*)ssl->async->args;
 
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             return ret;
@@ -4419,7 +4426,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
 
         /* set the type to inner */
         args->ech->type = ECH_TYPE_INNER;
-        args->preXLength = args->length;
+        args->preXLength = (int)args->length;
 
         /* get size for inner */
         ret = TLSX_GetRequestSize(ssl, client_hello, &args->length);
@@ -4430,16 +4437,16 @@ int SendTls13ClientHello(WOLFSSL* ssl)
         args->ech->type = 0;
         /* set innerClientHelloLen to ClientHelloInner + padding + tag */
         args->ech->paddingLen = 31 - ((args->length - 1) % 32);
-        args->ech->innerClientHelloLen = args->length +
-            args->ech->paddingLen + args->ech->hpke->Nt;
+        args->ech->innerClientHelloLen = (word16)(args->length +
+            args->ech->paddingLen + args->ech->hpke->Nt);
         /* set the length back to before we computed ClientHelloInner size */
-        args->length = args->preXLength;
+        args->length = (word32)args->preXLength;
     }
 #endif
 
     {
 #ifdef WOLFSSL_DTLS_CH_FRAG
-        int maxFrag = wolfSSL_GetMaxFragSize(ssl, MAX_RECORD_SIZE);
+        word16 maxFrag = wolfSSL_GetMaxFragSize(ssl, MAX_RECORD_SIZE);
         word16 lenWithoutExts = args->length;
 #endif
 
@@ -4470,7 +4477,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
     }
 
     /* Total message size. */
-    args->sendSz = args->length + HANDSHAKE_HEADER_SZ + RECORD_HEADER_SZ;
+    args->sendSz = (int)(args->length + HANDSHAKE_HEADER_SZ + RECORD_HEADER_SZ);
 
 #ifdef WOLFSSL_DTLS13
     if (ssl->options.dtls)
@@ -4510,7 +4517,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
         XMEMCPY(args->output + args->idx, ssl->arrays->clientRandom, RAN_LEN);
 
 #if defined(HAVE_ECH)
-    args->clientRandomOffset = args->idx;
+    args->clientRandomOffset = (int)args->idx;
 #endif
 
     args->idx += RAN_LEN;
@@ -4619,7 +4626,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
     if (ssl->options.useEch == 1) {
         ret = TLSX_FinalizeEch(args->ech,
             args->output + RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ,
-            args->sendSz - (RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ));
+            (word32)(args->sendSz - (RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ)));
 
         if (ret != 0)
             return ret;
@@ -4653,7 +4660,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
 
             /* compute the outer hash */
             if (ret == 0)
-                ret = HashOutput(ssl, args->output, args->idx, 0);
+                ret = HashOutput(ssl, args->output, (int)args->idx, 0);
         }
     }
     if (ret != 0)
@@ -4680,7 +4687,7 @@ int SendTls13ClientHello(WOLFSSL* ssl)
     }
 #endif /* WOLFSSL_DTLS13 */
 
-    ssl->buffers.outputBuffer.length += args->sendSz;
+    ssl->buffers.outputBuffer.length += (word32)args->sendSz;
 
     /* Advance state and proceed */
     ssl->options.asyncState = TLS_ASYNC_END;
@@ -4817,7 +4824,7 @@ static int EchCheckAcceptance(WOLFSSL* ssl, const byte* input,
         PRIVATE_KEY_UNLOCK();
     #if !defined(HAVE_FIPS) || \
         (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3))
-        ret = wc_HKDF_Extract_ex(digestType, zeros, digestSize,
+        ret = wc_HKDF_Extract_ex(digestType, zeros, (word32)digestSize,
             ssl->arrays->clientRandomInner, RAN_LEN, expandLabelPrk,
             ssl->heap, ssl->devId);
     #else
@@ -4831,10 +4838,10 @@ static int EchCheckAcceptance(WOLFSSL* ssl, const byte* input,
         PRIVATE_KEY_UNLOCK();
         ret = Tls13HKDFExpandKeyLabel(ssl,
             acceptConfirmation, ECH_ACCEPT_CONFIRMATION_SZ,
-            expandLabelPrk, digestSize,
+            expandLabelPrk, (word32)digestSize,
             tls13ProtocolLabel, TLS13_PROTOCOL_LABEL_SZ,
             echAcceptConfirmationLabel, ECH_ACCEPT_CONFIRMATION_LABEL_SZ,
-            transcriptEchConf, digestSize, digestType, WOLFSSL_SERVER_END);
+            transcriptEchConf, (word32)digestSize, digestType, WOLFSSL_SERVER_END);
         PRIVATE_KEY_LOCK();
     }
     if (ret == 0) {
@@ -4955,7 +4962,7 @@ static int EchWriteAcceptance(WOLFSSL* ssl, byte* output,
         PRIVATE_KEY_UNLOCK();
     #if !defined(HAVE_FIPS) || \
         (defined(FIPS_VERSION_GE) && FIPS_VERSION_GE(5,3))
-        ret = wc_HKDF_Extract_ex(digestType, zeros, digestSize,
+        ret = wc_HKDF_Extract_ex(digestType, zeros, (word32)digestSize,
             ssl->arrays->clientRandom, RAN_LEN, expandLabelPrk,
             ssl->heap, ssl->devId);
     #else
@@ -4971,10 +4978,10 @@ static int EchWriteAcceptance(WOLFSSL* ssl, byte* output,
         ret = Tls13HKDFExpandKeyLabel(ssl,
             output + serverRandomOffset + RAN_LEN - ECH_ACCEPT_CONFIRMATION_SZ,
                 ECH_ACCEPT_CONFIRMATION_SZ,
-            expandLabelPrk, digestSize,
+            expandLabelPrk, (word32)digestSize,
             tls13ProtocolLabel, TLS13_PROTOCOL_LABEL_SZ,
             echAcceptConfirmationLabel, ECH_ACCEPT_CONFIRMATION_LABEL_SZ,
-            transcriptEchConf, digestSize, digestType, WOLFSSL_SERVER_END);
+            transcriptEchConf, (word32)digestSize, digestType, WOLFSSL_SERVER_END);
         PRIVATE_KEY_LOCK();
     }
 
@@ -5055,10 +5062,10 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     args = (Dsh13Args*)ssl->async->args;
 
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0) {
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 /* Mark message as not received so it can process again */
                 ssl->msgsReceived.got_server_hello = 0;
             }
@@ -5169,7 +5176,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     /* Server random - keep for debugging. */
     XMEMCPY(ssl->arrays->serverRandom, input + args->idx, RAN_LEN);
 #if defined(HAVE_ECH)
-    args->serverRandomOffset = args->idx;
+    args->serverRandomOffset = (int)args->idx;
 #endif
     args->idx += RAN_LEN;
 
@@ -5285,6 +5292,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             }
 
             ssl->version.minor = args->pv.minor;
+            ssl->options.tls1_3 = 0;
 
 #ifdef WOLFSSL_DTLS13
             if (ssl->options.dtls) {
@@ -5318,14 +5326,15 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     /* restore message type */
     *extMsgType = args->extMsgType;
 
-    if (args->totalExtSz > 0) {
-        /* Parse and handle extensions. */
+    /* Parse and handle extensions, unless lower than TLS1.3. In that case,
+     * extensions will be parsed in DoServerHello. */
+    if (args->totalExtSz > 0 && IsAtLeastTLSv1_3(ssl->version)) {
         ret = TLSX_Parse(ssl, input + args->idx, args->totalExtSz,
             *extMsgType, NULL);
         if (ret != 0) {
         #ifdef WOLFSSL_ASYNC_CRYPT
             /* Handle async operation */
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 /* Mark message as not received so it can process again */
                 ssl->msgsReceived.got_server_hello = 0;
             }
@@ -5338,7 +5347,9 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             ssl->msgsReceived.got_hello_retry_request = 1;
             ssl->msgsReceived.got_server_hello = 0;
         }
+    }
 
+    if (args->totalExtSz > 0) {
         args->idx += args->totalExtSz;
     }
 
@@ -5347,7 +5358,9 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         DtlsCIDOnExtensionsParsed(ssl);
 #endif /* WOLFSSL_DTLS_CID */
 
-    *inOutIdx = args->idx;
+    if (IsAtLeastTLSv1_3(ssl->version)) {
+        *inOutIdx = args->idx;
+    }
 
     ssl->options.serverState = SERVER_HELLO_COMPLETE;
 
@@ -5386,9 +5399,12 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         }
 
         /* Force client hello version 1.2 to work for static RSA. */
-        ssl->chVersion.minor = TLSv1_2_MINOR;
+        if (ssl->options.dtls)
+            ssl->chVersion.minor = DTLSv1_2_MINOR;
+        else
+            ssl->chVersion.minor = TLSv1_2_MINOR;
         /* Complete TLS v1.2 processing of ServerHello. */
-        ret = CompleteServerHello(ssl);
+        ret = DoServerHello(ssl, input, inOutIdx, helloSz);
 #else
         WOLFSSL_MSG("Client using higher version, fatal error");
         WOLFSSL_ERROR_VERBOSE(VERSION_ERROR);
@@ -5457,7 +5473,7 @@ int DoTls13ServerHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 #if defined(HAVE_ECH)
     /* check for acceptConfirmation and HashInput with 8 0 bytes */
     if (ssl->options.useEch == 1) {
-        ret = EchCheckAcceptance(ssl, input, args->serverRandomOffset, helloSz);
+        ret = EchCheckAcceptance(ssl, input, args->serverRandomOffset, (int)helloSz);
         if (ret != 0)
             return ret;
     }
@@ -5724,7 +5740,7 @@ static int DoTls13CertificateRequest(WOLFSSL* ssl, const byte* input,
         #endif
             ) {
         if (PickHashSigAlgo(ssl, peerSuites.hashSigAlgo,
-                                               peerSuites.hashSigAlgoSz) != 0) {
+                            peerSuites.hashSigAlgoSz, 0) != 0) {
             WOLFSSL_ERROR_VERBOSE(INVALID_PARAMETER);
             return INVALID_PARAMETER;
         }
@@ -5847,7 +5863,7 @@ int FindPskSuite(const WOLFSSL* ssl, PreSharedKey* psk, byte* psk_key,
     }
     if (*found) {
         if (*psk_keySz > MAX_PSK_KEY_LEN &&
-            *((int*)psk_keySz) != USE_HW_PSK) {
+            *((int*)psk_keySz) != WC_NO_ERR_TRACE(USE_HW_PSK)) {
             WOLFSSL_MSG("Key len too long in FindPsk()");
             ret = PSK_KEY_ERROR;
             WOLFSSL_ERROR_VERBOSE(ret);
@@ -6001,7 +6017,7 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 inputSz,
         }
 
         #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ret == WC_PENDING_E)
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
             return ret;
         #endif
 
@@ -6052,7 +6068,7 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 inputSz,
                 return ret;
 
             /* Hash data up to binders for deriving binders in PSK extension. */
-            ret = HashInput(ssl, input, inputSz);
+            ret = HashInput(ssl, input, (int)inputSz);
             if (ret < 0)
                 return ret;
 
@@ -6068,7 +6084,7 @@ static int DoPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 inputSz,
             if (ret != 0)
                 return ret;
 
-            ret = HashInput(ssl, input, inputSz);
+            ret = HashInput(ssl, input, (int)inputSz);
             if (ret < 0)
                 return ret;
 
@@ -6164,7 +6180,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         if (usingPSK)
             *usingPSK = 0;
         /* Hash data up to binders for deriving binders in PSK extension. */
-        ret = HashInput(ssl, input,  helloSz);
+        ret = HashInput(ssl, input,  (int)helloSz);
         return ret;
     }
 
@@ -6201,7 +6217,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
         if (ret != 0) {
 #ifdef HAVE_SESSION_TICKET
 #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret != WC_PENDING_E)
+            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
 #endif
                 CleanupClientTickets((PreSharedKey*)ext->data);
 #endif
@@ -6231,7 +6247,7 @@ static int CheckPreSharedKeys(WOLFSSL* ssl, const byte* input, word32 helloSz,
     else {
         /* No suitable PSK found, Hash the complete ClientHello,
          * as caller expect it after we return */
-        ret = HashInput(ssl, input,  helloSz);
+        ret = HashInput(ssl, input,  (int)helloSz);
     }
     if (ret != 0)
         return ret;
@@ -6684,7 +6700,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     args = (Dch13Args*)ssl->async->args;
 
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0) {
             goto exit_dch;
@@ -6810,7 +6826,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
 
         realMinor = ssl->version.minor;
         ssl->version.minor = args->pv.minor;
-        ret = HashInput(ssl, input + args->begin, helloSz);
+        ret = HashInput(ssl, input + args->begin, (int)helloSz);
         ssl->version.minor = realMinor;
         if (ret == 0) {
             ret = DoClientHello(ssl, input, inOutIdx, helloSz);
@@ -7048,7 +7064,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     if (!args->usingPSK) {
         if ((ret = MatchSuite(ssl, args->clSuites)) < 0) {
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret != WC_PENDING_E)
+            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
         #endif
                 WOLFSSL_MSG("Unsupported cipher suite, ClientHello 1.3");
             goto exit_dch;
@@ -7065,7 +7081,7 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
             if (ssl->options.serverState == SERVER_HELLO_RETRY_REQUEST_COMPLETE)
                 ERROR_OUT(INVALID_PARAMETER, exit_dch);
             ssl->options.serverState = SERVER_HELLO_RETRY_REQUEST_COMPLETE;
-            if (ret != WC_PENDING_E)
+            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                 ret = 0; /* for hello_retry return 0 */
         }
         if (ret != 0)
@@ -7087,7 +7103,8 @@ int DoTls13ClientHello(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
     TLSX* extension = TLSX_Find(ssl->extensions, TLSX_KEY_SHARE);
     if (extension != NULL && extension->resp == 1) {
         KeyShareEntry* serverKSE = (KeyShareEntry*)extension->data;
-        if (serverKSE != NULL && serverKSE->lastRet == WC_PENDING_E) {
+        if (serverKSE != NULL &&
+            serverKSE->lastRet == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             ret = TLSX_KeyShare_GenKey(ssl, serverKSE);
             if (ret != 0)
                 goto exit_dch;
@@ -7220,7 +7237,7 @@ exit_dch:
     WOLFSSL_LEAVE("DoTls13ClientHello", ret);
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         ssl->msgsReceived.got_client_hello = 0;
         return ret;
     }
@@ -7298,7 +7315,7 @@ int SendTls13ServerHello(WOLFSSL* ssl, byte extMsgType)
     ret = TLSX_GetResponseSize(ssl, extMsgType, &length);
     if (ret != 0)
         return ret;
-    sendSz = idx + length;
+    sendSz = (int)(idx + length);
 
     /* Check buffers are big enough and grow if needed. */
     if ((ret = CheckAvailableSize(ssl, sendSz)) != 0)
@@ -7537,7 +7554,7 @@ static int SendTls13EncryptedExtensions(WOLFSSL* ssl)
     if (ret != 0)
         return ret;
 
-    sendSz = idx + length;
+    sendSz = (int)(idx + length);
     /* Encryption always on. */
     sendSz += MAX_MSG_EXTRA;
 
@@ -7622,13 +7639,9 @@ static int SendTls13CertificateRequest(WOLFSSL* ssl, byte* reqCtx,
     int    ret;
     int    sendSz;
     word32 i;
-    word16 reqSz;
+    word32 reqSz;
     word16 hashSigAlgoSz = 0;
     SignatureAlgorithms* sa;
-    int haveSig = SIG_RSA | SIG_ECDSA | SIG_FALCON | SIG_DILITHIUM;
-#if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
-    haveSig |= SIG_SM2;
-#endif
 
     WOLFSSL_START(WC_FUNC_CERTIFICATE_REQUEST_SEND);
     WOLFSSL_ENTER("SendTls13CertificateRequest");
@@ -7639,12 +7652,12 @@ static int SendTls13CertificateRequest(WOLFSSL* ssl, byte* reqCtx,
         return SIDE_ERROR;
 
     /* Get the length of the hashSigAlgo buffer */
-    InitSuitesHashSigAlgo_ex2(NULL, haveSig, 1, ssl->buffers.keySz,
+    InitSuitesHashSigAlgo(NULL, SIG_ALL, 1, ssl->buffers.keySz,
         &hashSigAlgoSz);
     sa = TLSX_SignatureAlgorithms_New(ssl, hashSigAlgoSz, ssl->heap);
     if (sa == NULL)
         return MEMORY_ERROR;
-    InitSuitesHashSigAlgo_ex2(sa->hashSigAlgo, haveSig, 1, ssl->buffers.keySz,
+    InitSuitesHashSigAlgo(sa->hashSigAlgo, SIG_ALL, 1, ssl->buffers.keySz,
         &hashSigAlgoSz);
     ret = TLSX_Push(&ssl->extensions, TLSX_SIGNATURE_ALGORITHMS, sa, ssl->heap);
     if (ret != 0) {
@@ -7663,7 +7676,7 @@ static int SendTls13CertificateRequest(WOLFSSL* ssl, byte* reqCtx,
     if (ret != 0)
         return ret;
 
-    sendSz = i + reqSz;
+    sendSz = (int)(i + reqSz);
     /* Always encrypted and make room for padding. */
     sendSz += MAX_MSG_EXTRA;
 
@@ -7738,7 +7751,7 @@ static int SendTls13CertificateRequest(WOLFSSL* ssl, byte* reqCtx,
 
 #ifndef NO_CERTS
 #if !defined(NO_RSA) || defined(HAVE_ECC) || defined(HAVE_ED25519) || \
-    defined(HAVE_ED448) || defined(HAVE_PQC)
+    defined(HAVE_ED448) || defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
 /* Encode the signature algorithm into buffer.
  *
  * hashalgo  The hash algorithm.
@@ -7783,8 +7796,7 @@ static WC_INLINE void EncodeSigAlg(byte hashAlgo, byte hsType, byte* output)
             output[1] = hashAlgo;
             break;
 #endif
-#ifdef HAVE_PQC
-        #ifdef HAVE_FALCON
+#ifdef HAVE_FALCON
         case falcon_level1_sa_algo:
             output[0] = FALCON_LEVEL1_SA_MAJOR;
             output[1] = FALCON_LEVEL1_SA_MINOR;
@@ -7793,8 +7805,8 @@ static WC_INLINE void EncodeSigAlg(byte hashAlgo, byte hsType, byte* output)
             output[0] = FALCON_LEVEL5_SA_MAJOR;
             output[1] = FALCON_LEVEL5_SA_MINOR;
             break;
-        #endif
-        #ifdef HAVE_DILITHIUM
+#endif
+#ifdef HAVE_DILITHIUM
         case dilithium_level2_sa_algo:
             output[0] = DILITHIUM_LEVEL2_SA_MAJOR;
             output[1] = DILITHIUM_LEVEL2_SA_MINOR;
@@ -7807,7 +7819,6 @@ static WC_INLINE void EncodeSigAlg(byte hashAlgo, byte hsType, byte* output)
             output[0] = DILITHIUM_LEVEL5_SA_MAJOR;
             output[1] = DILITHIUM_LEVEL5_SA_MINOR;
             break;
-        #endif
 #endif
         default:
             break;
@@ -7821,9 +7832,19 @@ static WC_INLINE void EncodeSigAlg(byte hashAlgo, byte hsType, byte* output)
 #define HYBRID_RSA3072_DILITHIUM_LEVEL2_SA_MINOR 0xA2
 #define HYBRID_P384_DILITHIUM_LEVEL3_SA_MINOR    0xA4
 #define HYBRID_P521_DILITHIUM_LEVEL5_SA_MINOR    0xA6
-#define HYBRID_P256_FALCON_LEVEL1_SA_MINOR       0x0C
-#define HYBRID_RSA3072_FALCON_LEVEL1_SA_MINOR    0x0D
-#define HYBRID_P521_FALCON_LEVEL5_SA_MINOR       0x0F
+#define HYBRID_P256_FALCON_LEVEL1_SA_MINOR       0xAF
+#define HYBRID_RSA3072_FALCON_LEVEL1_SA_MINOR    0xB0
+#define HYBRID_P521_FALCON_LEVEL5_SA_MINOR       0xB2
+
+/* Custom defined ones for PQC first */
+#define HYBRID_DILITHIUM_LEVEL2_P256_SA_MINOR    0xD1
+#define HYBRID_DILITHIUM_LEVEL2_RSA3072_SA_MINOR 0xD2
+#define HYBRID_DILITHIUM_LEVEL3_P384_SA_MINOR    0xD3
+#define HYBRID_DILITHIUM_LEVEL5_P521_SA_MINOR    0xD4
+#define HYBRID_FALCON_LEVEL1_P256_SA_MINOR       0xD5
+#define HYBRID_FALCON_LEVEL1_RSA3072_SA_MINOR    0xD6
+#define HYBRID_FALCON_LEVEL5_P521_SA_MINOR       0xD7
+
 
 static void EncodeDualSigAlg(byte sigAlg, byte altSigAlg, byte* output)
 {
@@ -7846,14 +7867,45 @@ static void EncodeDualSigAlg(byte sigAlg, byte altSigAlg, byte* output)
              altSigAlg == dilithium_level5_sa_algo) {
         output[1] = HYBRID_P521_DILITHIUM_LEVEL5_SA_MINOR;
     }
-    else if (sigAlg == ecc_dsa_sa_algo && altSigAlg == falcon_level1_sa_algo) {
+    else if (sigAlg == ecc_dsa_sa_algo &&
+             altSigAlg == falcon_level1_sa_algo) {
         output[1] = HYBRID_P256_FALCON_LEVEL1_SA_MINOR;
     }
-    else if (sigAlg == rsa_pss_sa_algo && altSigAlg == falcon_level1_sa_algo) {
+    else if (sigAlg == rsa_pss_sa_algo &&
+             altSigAlg == falcon_level1_sa_algo) {
         output[1] = HYBRID_RSA3072_FALCON_LEVEL1_SA_MINOR;
     }
-    else if (sigAlg == ecc_dsa_sa_algo && altSigAlg == falcon_level5_sa_algo) {
+    else if (sigAlg == ecc_dsa_sa_algo &&
+             altSigAlg == falcon_level5_sa_algo) {
         output[1] = HYBRID_P521_FALCON_LEVEL5_SA_MINOR;
+    }
+    else if (sigAlg == dilithium_level2_sa_algo &&
+             altSigAlg == ecc_dsa_sa_algo) {
+        output[1] = HYBRID_DILITHIUM_LEVEL2_P256_SA_MINOR;
+    }
+    else if (sigAlg == dilithium_level2_sa_algo &&
+             altSigAlg == rsa_pss_sa_algo) {
+        output[1] = HYBRID_DILITHIUM_LEVEL2_RSA3072_SA_MINOR;
+    }
+    else if (sigAlg == dilithium_level3_sa_algo &&
+             altSigAlg == ecc_dsa_sa_algo) {
+        output[1] = HYBRID_DILITHIUM_LEVEL3_P384_SA_MINOR;
+    }
+    else if (sigAlg == dilithium_level5_sa_algo &&
+             altSigAlg == ecc_dsa_sa_algo) {
+        output[1] = HYBRID_DILITHIUM_LEVEL5_P521_SA_MINOR;
+    }
+    else if (sigAlg == falcon_level1_sa_algo &&
+             altSigAlg == ecc_dsa_sa_algo) {
+        output[1] = HYBRID_FALCON_LEVEL1_P256_SA_MINOR;
+    }
+    else if (sigAlg == falcon_level1_sa_algo &&
+             altSigAlg == rsa_pss_sa_algo) {
+        output[1] = HYBRID_FALCON_LEVEL1_RSA3072_SA_MINOR;
+    }
+    else if (sigAlg == falcon_level5_sa_algo &&
+             altSigAlg == ecc_dsa_sa_algo) {
+        output[1] = HYBRID_FALCON_LEVEL5_P521_SA_MINOR;
     }
 
     if (output[1] != 0x0) {
@@ -7910,7 +7962,7 @@ static WC_INLINE int DecodeTls13SigAlg(byte* input, byte* hashAlgo,
             else
                 ret = INVALID_PARAMETER;
             break;
-#ifdef HAVE_PQC
+#if defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
         case PQC_SA_MAJOR:
 #if defined(HAVE_FALCON)
             if (input[1] == FALCON_LEVEL1_SA_MINOR) {
@@ -7972,38 +8024,73 @@ static WC_INLINE int DecodeTls13HybridSigAlg(byte* input, byte* hashAlg,
 
     if (input[1] == HYBRID_P256_DILITHIUM_LEVEL2_SA_MINOR) {
         *sigAlg = ecc_dsa_sa_algo;
-        *hashAlg = 4; /* WC_HASH_TYPE_SHA? Reviewer? */
+        *hashAlg = sha256_mac;
         *altSigAlg = dilithium_level2_sa_algo;
     }
     else if (input[1] == HYBRID_RSA3072_DILITHIUM_LEVEL2_SA_MINOR) {
         *sigAlg = rsa_pss_sa_algo;
-        *hashAlg = 4;
+        *hashAlg = sha256_mac;
         *altSigAlg = dilithium_level2_sa_algo;
     }
     else if (input[1] == HYBRID_P384_DILITHIUM_LEVEL3_SA_MINOR) {
         *sigAlg = ecc_dsa_sa_algo;
-        *hashAlg = 5;
+        *hashAlg = sha384_mac;
         *altSigAlg = dilithium_level3_sa_algo;
     }
     else if (input[1] == HYBRID_P521_DILITHIUM_LEVEL5_SA_MINOR) {
         *sigAlg = ecc_dsa_sa_algo;
-        *hashAlg = 6;
+        *hashAlg = sha512_mac;
         *altSigAlg = dilithium_level5_sa_algo;
     }
     else if (input[1] == HYBRID_P256_FALCON_LEVEL1_SA_MINOR) {
         *sigAlg = ecc_dsa_sa_algo;
-        *hashAlg = 4;
+        *hashAlg = sha256_mac;
         *altSigAlg = falcon_level1_sa_algo;
     }
     else if (input[1] == HYBRID_RSA3072_FALCON_LEVEL1_SA_MINOR) {
         *sigAlg = rsa_pss_sa_algo;
-        *hashAlg = 4;
+        *hashAlg = sha256_mac;
         *altSigAlg = falcon_level1_sa_algo;
     }
     else if (input[1] == HYBRID_P521_FALCON_LEVEL5_SA_MINOR) {
         *sigAlg = ecc_dsa_sa_algo;
-        *hashAlg = 6;
+        *hashAlg = sha512_mac;
         *altSigAlg = falcon_level5_sa_algo;
+    }
+    else if (input[1] == HYBRID_DILITHIUM_LEVEL2_P256_SA_MINOR) {
+        *sigAlg = dilithium_level2_sa_algo;
+        *hashAlg = sha256_mac;
+        *altSigAlg = ecc_dsa_sa_algo;
+    }
+    else if (input[1] == HYBRID_DILITHIUM_LEVEL2_RSA3072_SA_MINOR) {
+        *sigAlg = dilithium_level2_sa_algo;
+        *hashAlg = sha256_mac;
+        *altSigAlg = rsa_pss_sa_algo;
+    }
+    else if (input[1] == HYBRID_DILITHIUM_LEVEL3_P384_SA_MINOR) {
+        *sigAlg = dilithium_level3_sa_algo;
+        *hashAlg = sha384_mac;
+        *altSigAlg = ecc_dsa_sa_algo;
+    }
+    else if (input[1] == HYBRID_DILITHIUM_LEVEL5_P521_SA_MINOR) {
+        *sigAlg = dilithium_level5_sa_algo;
+        *hashAlg = sha512_mac;
+        *altSigAlg = ecc_dsa_sa_algo;
+    }
+    else if (input[1] == HYBRID_FALCON_LEVEL1_P256_SA_MINOR) {
+        *sigAlg = falcon_level1_sa_algo;
+        *hashAlg = sha256_mac;
+        *altSigAlg = ecc_dsa_sa_algo;
+    }
+    else if (input[1] == HYBRID_FALCON_LEVEL1_RSA3072_SA_MINOR) {
+        *sigAlg = falcon_level1_sa_algo;
+        *hashAlg = sha256_mac;
+        *altSigAlg = rsa_pss_sa_algo;
+    }
+    else if (input[1] == HYBRID_FALCON_LEVEL5_P521_SA_MINOR) {
+        *sigAlg = falcon_level5_sa_algo;
+        *hashAlg = sha512_mac;
+        *altSigAlg = ecc_dsa_sa_algo;
     }
     else {
         return INVALID_PARAMETER;
@@ -8118,7 +8205,7 @@ int CreateRSAEncodedSig(byte* sig, byte* sigData, int sigDataSz,
 {
     Digest digest;
     int    hashSz = 0;
-    int    ret = BAD_FUNC_ARG;
+    int    ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     byte*  hash;
 
     (void)sigAlgo;
@@ -8131,7 +8218,7 @@ int CreateRSAEncodedSig(byte* sig, byte* sigData, int sigDataSz,
         case sha256_mac:
             ret = wc_InitSha256(&digest.sha256);
             if (ret == 0) {
-                ret = wc_Sha256Update(&digest.sha256, sigData, sigDataSz);
+                ret = wc_Sha256Update(&digest.sha256, sigData, (word32)sigDataSz);
                 if (ret == 0)
                     ret = wc_Sha256Final(&digest.sha256, hash);
                 wc_Sha256Free(&digest.sha256);
@@ -8143,7 +8230,7 @@ int CreateRSAEncodedSig(byte* sig, byte* sigData, int sigDataSz,
         case sha384_mac:
             ret = wc_InitSha384(&digest.sha384);
             if (ret == 0) {
-                ret = wc_Sha384Update(&digest.sha384, sigData, sigDataSz);
+                ret = wc_Sha384Update(&digest.sha384, sigData, (word32)sigDataSz);
                 if (ret == 0)
                     ret = wc_Sha384Final(&digest.sha384, hash);
                 wc_Sha384Free(&digest.sha384);
@@ -8155,7 +8242,7 @@ int CreateRSAEncodedSig(byte* sig, byte* sigData, int sigDataSz,
         case sha512_mac:
             ret = wc_InitSha512(&digest.sha512);
             if (ret == 0) {
-                ret = wc_Sha512Update(&digest.sha512, sigData, sigDataSz);
+                ret = wc_Sha512Update(&digest.sha512, sigData, (word32)sigDataSz);
                 if (ret == 0)
                     ret = wc_Sha512Final(&digest.sha512, hash);
                 wc_Sha512Free(&digest.sha512);
@@ -8163,6 +8250,10 @@ int CreateRSAEncodedSig(byte* sig, byte* sigData, int sigDataSz,
             hashSz = WC_SHA512_DIGEST_SIZE;
             break;
 #endif
+       default:
+            ret = BAD_FUNC_ARG;
+            break;
+
     }
 
     if (ret != 0)
@@ -8184,7 +8275,7 @@ static int CreateECCEncodedSig(byte* sigData, int sigDataSz, int hashAlgo)
 {
     Digest digest;
     int    hashSz = 0;
-    int    ret = BAD_FUNC_ARG;
+    int    ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     /* Digest the signature data. */
     switch (hashAlgo) {
@@ -8192,7 +8283,7 @@ static int CreateECCEncodedSig(byte* sigData, int sigDataSz, int hashAlgo)
         case sha256_mac:
             ret = wc_InitSha256(&digest.sha256);
             if (ret == 0) {
-                ret = wc_Sha256Update(&digest.sha256, sigData, sigDataSz);
+                ret = wc_Sha256Update(&digest.sha256, sigData, (word32)sigDataSz);
                 if (ret == 0)
                     ret = wc_Sha256Final(&digest.sha256, sigData);
                 wc_Sha256Free(&digest.sha256);
@@ -8204,7 +8295,7 @@ static int CreateECCEncodedSig(byte* sigData, int sigDataSz, int hashAlgo)
         case sha384_mac:
             ret = wc_InitSha384(&digest.sha384);
             if (ret == 0) {
-                ret = wc_Sha384Update(&digest.sha384, sigData, sigDataSz);
+                ret = wc_Sha384Update(&digest.sha384, sigData, (word32)sigDataSz);
                 if (ret == 0)
                     ret = wc_Sha384Final(&digest.sha384, sigData);
                 wc_Sha384Free(&digest.sha384);
@@ -8216,7 +8307,7 @@ static int CreateECCEncodedSig(byte* sigData, int sigDataSz, int hashAlgo)
         case sha512_mac:
             ret = wc_InitSha512(&digest.sha512);
             if (ret == 0) {
-                ret = wc_Sha512Update(&digest.sha512, sigData, sigDataSz);
+                ret = wc_Sha512Update(&digest.sha512, sigData, (word32)sigDataSz);
                 if (ret == 0)
                     ret = wc_Sha512Final(&digest.sha512, sigData);
                 wc_Sha512Free(&digest.sha512);
@@ -8225,6 +8316,7 @@ static int CreateECCEncodedSig(byte* sigData, int sigDataSz, int hashAlgo)
             break;
 #endif
         default:
+            ret = BAD_FUNC_ARG;
             break;
     }
 
@@ -8270,7 +8362,7 @@ static int CheckRSASignature(WOLFSSL* ssl, int sigAlgo, int hashAlgo,
                                   sigAlgo, hashAlgo);
         if (ret < 0)
             return ret;
-        sigSz = ret;
+        sigSz = (word32)ret;
 
         ret = wc_RsaPSS_CheckPadding(sigData, sigSz, decSig, decSigSz,
                                      hashType);
@@ -8420,7 +8512,7 @@ static int SendTls13Certificate(WOLFSSL* ssl)
     else {
         if (!ssl->buffers.certificate) {
             WOLFSSL_MSG("Send Cert missing certificate buffer");
-            return BUFFER_ERROR;
+            return NO_CERT_ERROR;
         }
         /* Certificate Data */
         certSz = ssl->buffers.certificate->length;
@@ -8468,7 +8560,7 @@ static int SendTls13Certificate(WOLFSSL* ssl)
     if (ssl->fragOffset != 0)
         length -= (ssl->fragOffset + headerSz);
 
-    maxFragment = wolfSSL_GetMaxFragSize(ssl, MAX_RECORD_SIZE);
+    maxFragment = (word32)wolfSSL_GetMaxFragSize(ssl, MAX_RECORD_SIZE);
 
     while (length > 0 && ret == 0) {
         byte*  output = NULL;
@@ -8653,7 +8745,8 @@ static int SendTls13Certificate(WOLFSSL* ssl)
 }
 
 #if (!defined(NO_RSA) || defined(HAVE_ECC) || defined(HAVE_ED25519) || \
-     defined(HAVE_ED448) || defined(HAVE_PQC)) && \
+     defined(HAVE_ED448) || defined(HAVE_FALCON) || \
+     defined(HAVE_DILITHIUM)) && \
     (!defined(NO_WOLFSSL_SERVER) || !defined(WOLFSSL_NO_CLIENT_AUTH))
 typedef struct Scv13Args {
     byte*  output; /* not allocated */
@@ -8668,7 +8761,9 @@ typedef struct Scv13Args {
     word16 sigDataSz;
 #ifdef WOLFSSL_DUAL_ALG_CERTS
     byte   altSigAlgo;
-    word16 altSigLen;    /* Only used in the case of both native and alt. */
+    word32 altSigLen;    /* Only used in the case of both native and alt. */
+    byte*  altSigData;
+    word16 altSigDataSz;
 #endif
 } Scv13Args;
 
@@ -8682,6 +8777,12 @@ static void FreeScv13Args(WOLFSSL* ssl, void* pArgs)
         XFREE(args->sigData, ssl->heap, DYNAMIC_TYPE_SIGNATURE);
         args->sigData = NULL;
     }
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+    if (args && args->altSigData != NULL) {
+        XFREE(args->altSigData, ssl->heap, DYNAMIC_TYPE_SIGNATURE);
+        args->altSigData = NULL;
+    }
+#endif
 }
 
 /* handle generation TLS v1.3 certificate_verify (15) */
@@ -8697,7 +8798,10 @@ static void FreeScv13Args(WOLFSSL* ssl, void* pArgs)
 static int SendTls13CertificateVerify(WOLFSSL* ssl)
 {
     int ret = 0;
-    buffer* sig = &ssl->buffers.sig;
+#ifndef NO_RSA
+    /* Use this as a temporary buffer for RSA signature verification. */
+    buffer* rsaSigBuf = &ssl->buffers.sig;
+#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     Scv13Args* args = NULL;
     WOLFSSL_ASSERT_SIZEOF_GE(ssl->async->args, *args);
@@ -8712,11 +8816,15 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
     WOLFSSL_START(WC_FUNC_CERTIFICATE_VERIFY_SEND);
     WOLFSSL_ENTER("SendTls13CertificateVerify");
 
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    wolfssl_priv_der_unblind(ssl->buffers.key, ssl->buffers.keyMask);
+#endif
+
     ssl->options.buildingMsg = 1;
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13SendCertVerify(ssl);
-    if (ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         goto exit_scv;
     }
     ret = 0;
@@ -8742,7 +8850,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
     args = (Scv13Args*)ssl->async->args;
 
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             goto exit_scv;
@@ -8764,6 +8872,10 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
         case TLS_ASYNC_BEGIN:
         {
             if (ssl->options.sendVerify == SEND_BLANK_CERT) {
+            #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+                wolfssl_priv_der_unblind(ssl->buffers.key,
+                    ssl->buffers.keyMask);
+            #endif
                 return 0;  /* sent blank cert, can't verify */
             }
 
@@ -8786,9 +8898,9 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
 
         case TLS_ASYNC_BUILD:
         {
-            int rem = ssl->buffers.outputBuffer.bufferSize
+            int rem = (int)(ssl->buffers.outputBuffer.bufferSize
               - ssl->buffers.outputBuffer.length
-              - RECORD_HEADER_SZ - HANDSHAKE_HEADER_SZ;
+              - RECORD_HEADER_SZ - HANDSHAKE_HEADER_SZ);
 
             /* idx is used to track verify pointer offset to output */
             args->idx = RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ;
@@ -8813,11 +8925,10 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
             }
             else {
 #ifdef WOLFSSL_DUAL_ALG_CERTS
-                if (wolfSSL_is_server(ssl) &&
-                    ssl->sigSpec != NULL &&
+                if (ssl->sigSpec != NULL &&
                     *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_ALTERNATIVE) {
                     /* In the case of alternative, we swap in the alt. */
-                    if (ssl->ctx->altPrivateKey == NULL) {
+                    if (ssl->buffers.altKey == NULL) {
                         ERROR_OUT(NO_PRIVATE_KEY, exit_scv);
                     }
                     ssl->buffers.keyType = ssl->buffers.altKeyType;
@@ -8825,26 +8936,29 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                     /* If we own it, free key before overriding it. */
                     if (ssl->buffers.weOwnKey) {
                         FreeDer(&ssl->buffers.key);
+                    #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+                        FreeDer(&ssl->buffers.keyMask);
+                    #endif
                     }
 
-                    /* Transfer ownership. ssl->ctx always owns the alt private
-                     * key. */
-                    ssl->buffers.key = ssl->ctx->altPrivateKey;
-                    ssl->ctx->altPrivateKey = NULL;
-                    ssl->buffers.weOwnKey = 1;
-                    ssl->buffers.weOwnAltKey = 0;
+                    /* Swap keys */
+                    ssl->buffers.key     = ssl->buffers.altKey;
+                #ifdef WOLFSSL_BLIND_PRIVATE_KEY
+                    ssl->buffers.keyMask = ssl->buffers.altKeyMask;
+                #endif
+                    ssl->buffers.weOwnKey = ssl->buffers.weOwnAltKey;
                 }
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
-                ret = DecodePrivateKey(ssl, &args->length);
+                ret = DecodePrivateKey(ssl, &args->sigLen);
                 if (ret != 0)
                     goto exit_scv;
             }
 
-            if (rem < 0 || args->length > rem) {
+            if (rem < 0 || (int)args->sigLen > rem) {
                 ERROR_OUT(BUFFER_E, exit_scv);
             }
 
-            if (args->length == 0) {
+            if (args->sigLen == 0) {
                 ERROR_OUT(NO_PRIVATE_KEY, exit_scv);
             }
 
@@ -8872,8 +8986,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
             else if (ssl->hsType == DYNAMIC_TYPE_ED448)
                 args->sigAlgo = ed448_sa_algo;
         #endif
-        #if defined(HAVE_PQC)
-            #if defined(HAVE_FALCON)
+        #if defined(HAVE_FALCON)
             else if (ssl->hsType == DYNAMIC_TYPE_FALCON) {
                 falcon_key* fkey = (falcon_key*)ssl->hsKey;
                 byte level = 0;
@@ -8890,8 +9003,8 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                     ERROR_OUT(ALGO_ID_E, exit_scv);
                 }
             }
-            #endif /* HAVE_FALCON */
-            #if defined(HAVE_DILITHIUM)
+        #endif /* HAVE_FALCON */
+        #if defined(HAVE_DILITHIUM)
             else if (ssl->hsType == DYNAMIC_TYPE_DILITHIUM) {
                 dilithium_key* fkey = (dilithium_key*)ssl->hsKey;
                 byte level = 0;
@@ -8911,13 +9024,12 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                     ERROR_OUT(ALGO_ID_E, exit_scv);
                 }
             }
-            #endif /* HAVE_DILITHIUM */
-        #endif /* HAVE_PQC */
+        #endif /* HAVE_DILITHIUM */
             else {
                 ERROR_OUT(ALGO_ID_E, exit_scv);
             }
 
-#ifdef WOLFSSL_DUAL_ALG_CERTS
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
             if (ssl->peerSigSpec == NULL) {
                 /* The peer did not respond. We didn't send CKS or they don't
                  * support it. Either way, we do not need to handle dual
@@ -8926,8 +9038,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 ssl->sigSpecSz = 0;
             }
 
-            if (wolfSSL_is_server(ssl) &&
-                ssl->sigSpec != NULL &&
+            if (ssl->sigSpec != NULL &&
                 *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
                 /* The native was already decoded. Now we need to do the
                  * alternative. Note that no swap was done because this case is
@@ -8936,21 +9047,27 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                     ERROR_OUT(NO_PRIVATE_KEY, exit_scv);
                 }
 
-                if (ssl->buffers.altKeyType == falcon_level1_sa_algo ||
+                /* After this call, args->altSigLen has the length we need for
+                 * the alternative signature. */
+                ret = DecodeAltPrivateKey(ssl, &args->altSigLen);
+                if (ret != 0)
+                    goto exit_scv;
+
+                if (ssl->buffers.altKeyType == ecc_dsa_sa_algo ||
+                    ssl->buffers.altKeyType == falcon_level1_sa_algo ||
                     ssl->buffers.altKeyType == falcon_level5_sa_algo ||
                     ssl->buffers.altKeyType == dilithium_level2_sa_algo ||
                     ssl->buffers.altKeyType == dilithium_level3_sa_algo ||
                     ssl->buffers.altKeyType == dilithium_level5_sa_algo) {
                     args->altSigAlgo = ssl->buffers.altKeyType;
                 }
+                else if (ssl->buffers.altKeyType == rsa_sa_algo &&
+                         ssl->hsAltType == DYNAMIC_TYPE_RSA) {
+                    args->altSigAlgo = rsa_pss_sa_algo;
+                }
                 else {
                     ERROR_OUT(ALGO_ID_E, exit_scv);
                 }
-                /* After this call, args->altSigLen has the length we need for
-                 * the alternative signature. */
-                ret = DecodeAltPrivateKey(ssl, &args->altSigLen);
-                if (ret != 0)
-                    goto exit_scv;
 
                 EncodeDualSigAlg(args->sigAlgo, args->altSigAlgo, args->verify);
                 if (args->verify[0] == 0) {
@@ -8958,57 +9075,79 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 }
             }
             else
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
+        #endif /* WOLFSSL_DUAL_ALG_CERTS */
                 EncodeSigAlg(ssl->options.hashAlgo, args->sigAlgo,
                              args->verify);
 
             if (args->sigData == NULL) {
-                if (ssl->hsType == DYNAMIC_TYPE_RSA) {
-                    int sigLen = MAX_SIG_DATA_SZ;
-                    if (args->length > MAX_SIG_DATA_SZ)
-                        sigLen = args->length;
-                    args->sigData = (byte*)XMALLOC(sigLen, ssl->heap,
-                                                            DYNAMIC_TYPE_SIGNATURE);
+                word32 sigLen = MAX_SIG_DATA_SZ;
+                if ((ssl->hsType == DYNAMIC_TYPE_RSA) &&
+                    (args->sigLen > MAX_SIG_DATA_SZ)) {
+                    /* We store the RSA signature in the sigData buffer
+                     * temporarily, hence its size must be fitting. */
+                    sigLen = args->sigLen;
                 }
-                else {
-                    args->sigData = (byte*)XMALLOC(MAX_SIG_DATA_SZ, ssl->heap,
-                                                            DYNAMIC_TYPE_SIGNATURE);
-                }
+                args->sigData = (byte*)XMALLOC(sigLen, ssl->heap,
+                                                    DYNAMIC_TYPE_SIGNATURE);
                 if (args->sigData == NULL) {
                     ERROR_OUT(MEMORY_E, exit_scv);
                 }
             }
+
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
+            if ((ssl->sigSpec != NULL) &&
+                (*ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) &&
+                (args->altSigData == NULL)) {
+                word32 sigLen = MAX_SIG_DATA_SZ;
+                if (ssl->hsAltType == DYNAMIC_TYPE_RSA &&
+                    args->altSigLen > MAX_SIG_DATA_SZ) {
+                    /* We store the RSA signature in the sigData buffer
+                     * temporarily, hence its size must be fitting. */
+                    sigLen = args->altSigLen;
+                }
+                args->altSigData = (byte*)XMALLOC(sigLen, ssl->heap,
+                                                    DYNAMIC_TYPE_SIGNATURE);
+                if (args->altSigData == NULL) {
+                    ERROR_OUT(MEMORY_E, exit_scv);
+                }
+            }
+        #endif /* WOLFSSL_DUAL_ALG_CERTS */
 
             /* Create the data to be signed. */
             ret = CreateSigData(ssl, args->sigData, &args->sigDataSz, 0);
             if (ret != 0)
                 goto exit_scv;
 
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
+            if ((ssl->sigSpec != NULL) &&
+                (*ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH)) {
+                XMEMCPY(args->altSigData, args->sigData, args->sigDataSz);
+                args->altSigDataSz = args->sigDataSz;
+            }
+        #endif /* WOLFSSL_DUAL_ALG_CERTS */
+
         #ifndef NO_RSA
             if (ssl->hsType == DYNAMIC_TYPE_RSA) {
                 /* build encoded signature buffer */
-                sig->length = WC_MAX_DIGEST_SIZE;
-                sig->buffer = (byte*)XMALLOC(sig->length, ssl->heap,
-                                                        DYNAMIC_TYPE_SIGNATURE);
-                if (sig->buffer == NULL) {
+                rsaSigBuf->length = WC_MAX_DIGEST_SIZE;
+                rsaSigBuf->buffer = (byte*)XMALLOC(rsaSigBuf->length, ssl->heap,
+                                                   DYNAMIC_TYPE_SIGNATURE);
+                if (rsaSigBuf->buffer == NULL) {
                     ERROR_OUT(MEMORY_E, exit_scv);
                 }
 
-                ret = CreateRSAEncodedSig(sig->buffer, args->sigData,
+                ret = CreateRSAEncodedSig(rsaSigBuf->buffer, args->sigData,
                     args->sigDataSz, args->sigAlgo, ssl->options.hashAlgo);
                 if (ret < 0)
                     goto exit_scv;
-                sig->length = ret;
+                rsaSigBuf->length = (unsigned int)ret;
                 ret = 0;
-
-                /* Maximum size of RSA Signature. */
-                args->sigLen = args->length;
             }
         #endif /* !NO_RSA */
         #ifdef HAVE_ECC
             if (ssl->hsType == DYNAMIC_TYPE_ECC) {
-                sig->length = args->sendSz - args->idx - HASH_SIG_SIZE -
-                              VERIFY_HEADER;
+                args->sigLen = args->sendSz - args->idx - HASH_SIG_SIZE -
+                               VERIFY_HEADER;
             #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
                 if (ssl->buffers.keyType != sm2_sa_algo)
             #endif
@@ -9028,7 +9167,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 if (ret < 0) {
                     ERROR_OUT(ret, exit_scv);
                 }
-                sig->length = ED25519_SIG_SIZE;
+                args->sigLen = ED25519_SIG_SIZE;
             }
         #endif /* HAVE_ED25519 */
         #ifdef HAVE_ED448
@@ -9037,22 +9176,57 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 if (ret < 0) {
                     ERROR_OUT(ret, exit_scv);
                 }
-                sig->length = ED448_SIG_SIZE;
+                args->sigLen = ED448_SIG_SIZE;
             }
 
         #endif /* HAVE_ED448 */
-        #if defined(HAVE_PQC)
-            #if defined(HAVE_FALCON)
+        #if defined(HAVE_FALCON)
             if (ssl->hsType == DYNAMIC_TYPE_FALCON) {
-                sig->length = FALCON_MAX_SIG_SIZE;
+                args->sigLen = FALCON_MAX_SIG_SIZE;
             }
-            #endif
-            #if defined(HAVE_DILITHIUM)
+        #endif /* HAVE_FALCON */
+        #if defined(HAVE_DILITHIUM)
             if (ssl->hsType == DYNAMIC_TYPE_DILITHIUM) {
-                sig->length = DILITHIUM_MAX_SIG_SIZE;
+                args->sigLen = DILITHIUM_MAX_SIG_SIZE;
             }
-            #endif
-        #endif /* HAVE_PQC */
+        #endif /* HAVE_DILITHIUM */
+
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
+            if (ssl->sigSpec != NULL &&
+                *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
+
+            #ifndef NO_RSA
+                if (ssl->hsAltType == DYNAMIC_TYPE_RSA) {
+                    /* build encoded signature buffer */
+                    rsaSigBuf->length = WC_MAX_DIGEST_SIZE;
+                    rsaSigBuf->buffer = (byte*)XMALLOC(rsaSigBuf->length,
+                                                       ssl->heap,
+                                                       DYNAMIC_TYPE_SIGNATURE);
+                    if (rsaSigBuf->buffer == NULL) {
+                        ERROR_OUT(MEMORY_E, exit_scv);
+                    }
+
+                    ret = CreateRSAEncodedSig(rsaSigBuf->buffer,
+                                    args->altSigData, args->altSigDataSz,
+                                    args->altSigAlgo, ssl->options.hashAlgo);
+                    if (ret < 0)
+                        goto exit_scv;
+                    rsaSigBuf->length = ret;
+                    ret = 0;
+                }
+            #endif /* !NO_RSA */
+            #ifdef HAVE_ECC
+                if (ssl->hsAltType == DYNAMIC_TYPE_ECC) {
+                    ret = CreateECCEncodedSig(args->altSigData,
+                            args->altSigDataSz, ssl->options.hashAlgo);
+                    if (ret < 0)
+                        goto exit_scv;
+                    args->altSigDataSz = (word16)ret;
+                    ret = 0;
+                }
+            #endif /* HAVE_ECC */
+            }
+        #endif /* WOLFSSL_DUAL_ALG_CERTS */
 
             /* Advance state and proceed */
             ssl->options.asyncState = TLS_ASYNC_DO;
@@ -9061,21 +9235,30 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
 
         case TLS_ASYNC_DO:
         {
+            byte* sigOut = args->verify + HASH_SIG_SIZE + VERIFY_HEADER;
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
+            if (ssl->sigSpec != NULL &&
+                *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
+                /* As we have two signatures in the message, we store
+                 * the length of each before the actual signature. This
+                 * is necessary, as we could have two algorithms with
+                 * variable length signatures. */
+                sigOut += OPAQUE16_LEN;
+            }
+        #endif
         #ifdef HAVE_ECC
             if (ssl->hsType == DYNAMIC_TYPE_ECC) {
             #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
                 if (ssl->buffers.keyType == sm2_sa_algo) {
                     ret = Sm2wSm3Sign(ssl, TLS13_SM2_SIG_ID,
                         TLS13_SM2_SIG_ID_SZ, args->sigData, args->sigDataSz,
-                        args->verify + HASH_SIG_SIZE + VERIFY_HEADER,
-                        (word32*)&sig->length, (ecc_key*)ssl->hsKey, NULL);
+                        sigOut, &args->sigLen, (ecc_key*)ssl->hsKey, NULL);
                 }
                 else
             #endif
                 {
                     ret = EccSign(ssl, args->sigData, args->sigDataSz,
-                        args->verify + HASH_SIG_SIZE + VERIFY_HEADER,
-                        (word32*)&sig->length, (ecc_key*)ssl->hsKey,
+                        sigOut, &args->sigLen, (ecc_key*)ssl->hsKey,
                 #ifdef HAVE_PK_CALLBACKS
                         ssl->buffers.key
                 #else
@@ -9083,127 +9266,60 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 #endif
                     );
                 }
-
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-                if (wolfSSL_is_server(ssl) &&
-                    ssl->sigSpec != NULL &&
-                    *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
-                    if (ssl->hsAltType == DYNAMIC_TYPE_DILITHIUM) {
-                        /* note the + sig->length; we are appending. */
-                        ret = wc_dilithium_sign_msg(
-                                  args->sigData, args->sigDataSz,
-                                  args->verify + HASH_SIG_SIZE +
-                                  VERIFY_HEADER + sig->length,
-                                  (word32*)&args->altSigLen,
-                                  (dilithium_key*)ssl->hsAltKey, ssl->rng);
-
-                    }
-                    else if (ssl->hsAltType == DYNAMIC_TYPE_FALCON) {
-                        /* note the sig->length; we are appending. */
-                        ret = wc_falcon_sign_msg(args->sigData, args->sigDataSz,
-                                                 args->verify + HASH_SIG_SIZE +
-                                                 VERIFY_HEADER + sig->length,
-                                                 (word32*)&args->altSigLen,
-                                                 (falcon_key*)ssl->hsAltKey,
-                                                 ssl->rng);
-                    }
-                }
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-                args->length = (word16)sig->length;
+                args->length = (word16)args->sigLen;
             }
         #endif /* HAVE_ECC */
         #ifdef HAVE_ED25519
             if (ssl->hsType == DYNAMIC_TYPE_ED25519) {
                 ret = Ed25519Sign(ssl, args->sigData, args->sigDataSz,
-                    args->verify + HASH_SIG_SIZE + VERIFY_HEADER,
-                    (word32*)&sig->length, (ed25519_key*)ssl->hsKey,
+                    sigOut, &args->sigLen, (ed25519_key*)ssl->hsKey,
             #ifdef HAVE_PK_CALLBACKS
                     ssl->buffers.key
             #else
                     NULL
             #endif
                 );
-                args->length = (word16)sig->length;
+                args->length = (word16)args->sigLen;
             }
         #endif
         #ifdef HAVE_ED448
             if (ssl->hsType == DYNAMIC_TYPE_ED448) {
                 ret = Ed448Sign(ssl, args->sigData, args->sigDataSz,
-                    args->verify + HASH_SIG_SIZE + VERIFY_HEADER,
-                    (word32*)&sig->length, (ed448_key*)ssl->hsKey,
+                    sigOut, &args->sigLen, (ed448_key*)ssl->hsKey,
             #ifdef HAVE_PK_CALLBACKS
                     ssl->buffers.key
             #else
                     NULL
             #endif
                 );
-                args->length = (word16)sig->length;
+                args->length = (word16)args->sigLen;
             }
         #endif
-        #if defined(HAVE_PQC)
-            #if defined(HAVE_FALCON)
+        #if defined(HAVE_FALCON)
             if (ssl->hsType == DYNAMIC_TYPE_FALCON) {
                 ret = wc_falcon_sign_msg(args->sigData, args->sigDataSz,
-                                         args->verify + HASH_SIG_SIZE +
-                                         VERIFY_HEADER, (word32*)&sig->length,
+                                         sigOut, &args->sigLen,
                                          (falcon_key*)ssl->hsKey, ssl->rng);
-                args->length = (word16)sig->length;
+                args->length = (word16)args->sigLen;
             }
-            #endif
-            #if defined(HAVE_DILITHIUM)
+        #endif /* HAVE_FALCON */
+        #if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN)
             if (ssl->hsType == DYNAMIC_TYPE_DILITHIUM) {
                 ret = wc_dilithium_sign_msg(args->sigData, args->sigDataSz,
-                                         args->verify + HASH_SIG_SIZE +
-                                         VERIFY_HEADER, (word32*)&sig->length,
+                                         sigOut, &args->sigLen,
                                          (dilithium_key*)ssl->hsKey, ssl->rng);
-                args->length = (word16)sig->length;
+                args->length = (word16)args->sigLen;
             }
-            #endif
-        #endif /* HAVE_PQC */
+        #endif /* HAVE_DILITHIUM */
         #ifndef NO_RSA
             if (ssl->hsType == DYNAMIC_TYPE_RSA) {
-                ret = RsaSign(ssl, sig->buffer, (word32)sig->length,
-                    args->verify + HASH_SIG_SIZE + VERIFY_HEADER, &args->sigLen,
-                    args->sigAlgo, ssl->options.hashAlgo,
-                    (RsaKey*)ssl->hsKey,
-                    ssl->buffers.key
-                );
-
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-                /* In the case of RSA, we need to do the CKS both case here
-                 * BEFORE args->sigData is overwritten!! We keep the sig
-                 * separate and then append later so we don't interfere with the
-                 * checks below. */
-                if (wolfSSL_is_server(ssl) &&
-                    ssl->sigSpec != NULL &&
-                    *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
-                    if (ssl->hsAltType == DYNAMIC_TYPE_DILITHIUM) {
-                        /* note the + args->sigLen; we are appending. */
-                        ret = wc_dilithium_sign_msg(args->sigData,
-                                  args->sigDataSz,
-                                  args->verify + HASH_SIG_SIZE + VERIFY_HEADER +
-                                  args->sigLen,
-                                  (word32*)&args->altSigLen,
-                                  (dilithium_key*)ssl->hsAltKey, ssl->rng);
-                    }
-                    else if (ssl->hsAltType == DYNAMIC_TYPE_FALCON) {
-                        /* note the + args->sigLen; we are appending. */
-                        ret = wc_falcon_sign_msg(args->sigData, args->sigDataSz,
-                                                 args->verify + HASH_SIG_SIZE +
-                                                 VERIFY_HEADER + args->sigLen,
-                                                 (word32*)&args->altSigLen,
-                                                 (falcon_key*)ssl->hsAltKey,
-                                                 ssl->rng);
-                    }
-                }
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-
+                ret = RsaSign(ssl, rsaSigBuf->buffer, (word32)rsaSigBuf->length,
+                              sigOut, &args->sigLen, args->sigAlgo,
+                              ssl->options.hashAlgo, (RsaKey*)ssl->hsKey,
+                              ssl->buffers.key);
                 if (ret == 0) {
                     args->length = (word16)args->sigLen;
-
-                    XMEMCPY(args->sigData,
-                        args->verify + HASH_SIG_SIZE + VERIFY_HEADER,
-                        args->sigLen);
+                    XMEMCPY(args->sigData, sigOut, args->sigLen);
                 }
             }
         #endif /* !NO_RSA */
@@ -9213,10 +9329,76 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                 goto exit_scv;
             }
 
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-            /* Add in length of the alt sig which will be appended to the sig */
-            args->length += args->altSigLen;
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
+            if (ssl->sigSpec != NULL &&
+                *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
+                /* Add signature length for the first signature. */
+                c16toa((word16)args->sigLen, sigOut - OPAQUE16_LEN);
+                args->length += OPAQUE16_LEN;
+
+                /* Advance our pointer to where we store the alt signature.
+                 * We also add additional space for the length field of the
+                 * second signature. */
+                sigOut += args->sigLen + OPAQUE16_LEN;
+
+                /* Generate the alternative signature */
+            #ifdef HAVE_ECC
+                if (ssl->hsAltType == DYNAMIC_TYPE_ECC) {
+                    ret = EccSign(ssl, args->altSigData, args->altSigDataSz,
+                                  sigOut, &args->altSigLen,
+                                  (ecc_key*)ssl->hsAltKey,
+                    #ifdef HAVE_PK_CALLBACKS
+                                  ssl->buffers.altKey
+                    #else
+                                  NULL
+                    #endif
+                                  );
+                }
+            #endif /* HAVE_ECC */
+            #ifndef NO_RSA
+                if (ssl->hsAltType == DYNAMIC_TYPE_RSA) {
+                    ret = RsaSign(ssl, rsaSigBuf->buffer,
+                                  (word32)rsaSigBuf->length, sigOut,
+                                  &args->altSigLen, args->altSigAlgo,
+                                  ssl->options.hashAlgo, (RsaKey*)ssl->hsAltKey,
+                                  ssl->buffers.altKey);
+
+                    if (ret == 0) {
+                        XMEMCPY(args->altSigData, sigOut, args->altSigLen);
+                    }
+                }
+            #endif /* !NO_RSA */
+            #if defined(HAVE_FALCON)
+                if (ssl->hsAltType == DYNAMIC_TYPE_FALCON) {
+                    ret = wc_falcon_sign_msg(args->altSigData,
+                                             args->altSigDataSz, sigOut,
+                                             &args->altSigLen,
+                                             (falcon_key*)ssl->hsAltKey,
+                                             ssl->rng);
+                }
+            #endif /* HAVE_FALCON */
+            #if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN)
+                if (ssl->hsAltType == DYNAMIC_TYPE_DILITHIUM) {
+                    ret = wc_dilithium_sign_msg(args->altSigData,
+                                                args->altSigDataSz, sigOut,
+                                                &args->altSigLen,
+                                                (dilithium_key*)ssl->hsAltKey,
+                                                ssl->rng);
+                }
+            #endif /* HAVE_DILITHIUM */
+
+                /* Check for error */
+                if (ret != 0) {
+                    goto exit_scv;
+                }
+
+                /* Add signature length for the alternative signature. */
+                c16toa((word16)args->altSigLen, sigOut - OPAQUE16_LEN);
+
+                /* Add length of the alt sig to the total length */
+                args->length += args->altSigLen + OPAQUE16_LEN;
+            }
+        #endif /* WOLFSSL_DUAL_ALG_CERTS */
 
             /* Add signature length. */
             c16toa(args->length, args->verify + HASH_SIG_SIZE);
@@ -9232,38 +9414,72 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
             if (ssl->hsType == DYNAMIC_TYPE_RSA) {
                 /* check for signature faults */
                 ret = VerifyRsaSign(ssl, args->sigData, args->sigLen,
-                    sig->buffer, (word32)sig->length, args->sigAlgo,
+                    rsaSigBuf->buffer, (word32)rsaSigBuf->length, args->sigAlgo,
                     ssl->options.hashAlgo, (RsaKey*)ssl->hsKey,
-                    ssl->buffers.key
-                );
+                    ssl->buffers.key);
             }
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
+            if (ssl->sigSpec != NULL &&
+                *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH &&
+                ssl->hsAltType == DYNAMIC_TYPE_RSA) {
+                /* check for signature faults */
+                ret = VerifyRsaSign(ssl, args->altSigData, args->altSigLen,
+                        rsaSigBuf->buffer, (word32)rsaSigBuf->length,
+                        args->altSigAlgo, ssl->options.hashAlgo,
+                        (RsaKey*)ssl->hsAltKey, ssl->buffers.altKey);
+            }
+        #endif /* WOLFSSL_DUAL_ALG_CERTS */
         #endif /* !NO_RSA */
         #if defined(HAVE_ECC) && defined(WOLFSSL_CHECK_SIG_FAULTS)
             if (ssl->hsType == DYNAMIC_TYPE_ECC) {
+                byte* sigOut = args->verify + HASH_SIG_SIZE + VERIFY_HEADER;
+            #ifdef WOLFSSL_DUAL_ALG_CERTS
+                if (ssl->sigSpec != NULL &&
+                    *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
+                    /* Add our length offset. */
+                    sigOut += OPAQUE16_LEN;
+                }
+            #endif
             #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
                 if (ssl->buffers.keyType == sm2_sa_algo) {
                     ret = Sm2wSm3Verify(ssl, TLS13_SM2_SIG_ID,
                         TLS13_SM2_SIG_ID_SZ,
-                        args->verify + HASH_SIG_SIZE + VERIFY_HEADER,
-                        sig->length, args->sigData, args->sigDataSz,
+                        sigOut, args->sigLen, args->sigData, args->sigDataSz,
                         (ecc_key*)ssl->hsKey, NULL);
                 }
                 else
             #endif
                 {
-                    ret = EccVerify(ssl,
-                        args->verify + HASH_SIG_SIZE + VERIFY_HEADER,
-                        sig->length, args->sigData, args->sigDataSz,
-                        (ecc_key*)ssl->hsKey,
+                    ret = EccVerify(ssl, sigOut, args->sigLen,
+                            args->sigData, args->sigDataSz,
+                            (ecc_key*)ssl->hsKey,
                 #ifdef HAVE_PK_CALLBACKS
-                        ssl->buffers.key
+                            ssl->buffers.key
                 #else
-                        NULL
+                            NULL
                 #endif
-                    );
+                            );
                 }
             }
-        #endif
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
+            if (ssl->sigSpec != NULL &&
+                *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH &&
+                ssl->hsAltType == DYNAMIC_TYPE_ECC) {
+                /* check for signature faults */
+                byte* sigOut = args->verify + HASH_SIG_SIZE + VERIFY_HEADER +
+                                args->sigLen + OPAQUE16_LEN + OPAQUE16_LEN;
+                ret = EccVerify(ssl, sigOut, args->altSigLen,
+                        args->altSigData, args->altSigDataSz,
+                        (ecc_key*)ssl->hsAltKey,
+            #ifdef HAVE_PK_CALLBACKS
+                        ssl->buffers.altKey
+            #else
+                        NULL
+            #endif
+                        );
+            }
+        #endif /* WOLFSSL_DUAL_ALG_CERTS */
+        #endif /* HAVE_ECC && WOLFSSL_CHECK_SIG_FAULTS */
 
             /* Check for error */
             if (ret != 0) {
@@ -9282,7 +9498,7 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
                             VERIFY_HEADER, certificate_verify, ssl);
 
             args->sendSz = RECORD_HEADER_SZ + HANDSHAKE_HEADER_SZ +
-                                   args->length + HASH_SIG_SIZE + VERIFY_HEADER;
+                                args->length + HASH_SIG_SIZE + VERIFY_HEADER;
 #ifdef WOLFSSL_DTLS13
             if (ssl->options.dtls)
                 args->sendSz += recordLayerHdrExtra + DTLS_HANDSHAKE_EXTRA;
@@ -9346,13 +9562,22 @@ static int SendTls13CertificateVerify(WOLFSSL* ssl)
     } /* switch(ssl->options.asyncState) */
 
 exit_scv:
+#ifdef WOLFSSL_BLIND_PRIVATE_KEY
+    if (ret == 0) {
+        ret = wolfssl_priv_der_blind(ssl->rng, ssl->buffers.key,
+            &ssl->buffers.keyMask);
+    }
+    else {
+        wolfssl_priv_der_unblind(ssl->buffers.key, ssl->buffers.keyMask);
+    }
+#endif
 
     WOLFSSL_LEAVE("SendTls13CertificateVerify", ret);
     WOLFSSL_END(WC_FUNC_CERTIFICATE_VERIFY_SEND);
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     /* Handle async operation */
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         return ret;
     }
 #endif /* WOLFSSL_ASYNC_CRYPT */
@@ -9442,8 +9667,8 @@ typedef struct Dcv13Args {
 #ifdef WOLFSSL_DUAL_ALG_CERTS
     byte   altSigAlgo;
     byte*  altSigData;
-    word16 altSigDataSz;
-    word16 altSignatureSz;
+    word32 altSigDataSz;
+    word32 altSignatureSz;
     byte   altPeerAuthGood;
 #endif
 } Dcv13Args;
@@ -9466,6 +9691,59 @@ static void FreeDcv13Args(WOLFSSL* ssl, void* pArgs)
 }
 
 #ifdef WOLFSSL_DUAL_ALG_CERTS
+#ifndef NO_RSA
+/* ssl->peerCert->sapkiDer is the alternative public key. Hopefully it is a
+ * RSA public key. Convert it into a usable public key. */
+static int decodeRsaKey(WOLFSSL* ssl)
+{
+    int keyRet;
+    word32 tmpIdx = 0;
+
+    if (ssl->peerRsaKeyPresent)
+        return INVALID_PARAMETER;
+
+    keyRet = AllocKey(ssl, DYNAMIC_TYPE_RSA, (void**)&ssl->peerRsaKey);
+    if (keyRet != 0)
+        return PEER_KEY_ERROR;
+
+    ssl->peerRsaKeyPresent = 1;
+    keyRet = wc_RsaPublicKeyDecode(ssl->peerCert.sapkiDer, &tmpIdx,
+                                   ssl->peerRsaKey,
+                                   ssl->peerCert.sapkiLen);
+    if (keyRet != 0)
+        return PEER_KEY_ERROR;
+
+    return 0;
+}
+#endif /* !NO_RSA */
+
+#ifdef HAVE_ECC
+/* ssl->peerCert->sapkiDer is the alternative public key. Hopefully it is a
+ * ECC public key. Convert it into a usable public key. */
+static int decodeEccKey(WOLFSSL* ssl)
+{
+    int keyRet;
+    word32 tmpIdx = 0;
+
+    if (ssl->peerEccDsaKeyPresent)
+        return INVALID_PARAMETER;
+
+    keyRet = AllocKey(ssl, DYNAMIC_TYPE_ECC, (void**)&ssl->peerEccDsaKey);
+    if (keyRet != 0)
+        return PEER_KEY_ERROR;
+
+    ssl->peerEccDsaKeyPresent = 1;
+    keyRet = wc_EccPublicKeyDecode(ssl->peerCert.sapkiDer, &tmpIdx,
+                                   ssl->peerEccDsaKey,
+                                   ssl->peerCert.sapkiLen);
+    if (keyRet != 0)
+        return PEER_KEY_ERROR;
+
+    return 0;
+}
+#endif /* HAVE_ECC */
+
+#ifdef HAVE_DILITHIUM
 /* ssl->peerCert->sapkiDer is the alternative public key. Hopefully it is a
  * dilithium public key. Convert it into a usable public key. */
 static int decodeDilithiumKey(WOLFSSL* ssl, int level)
@@ -9482,10 +9760,6 @@ static int decodeDilithiumKey(WOLFSSL* ssl, int level)
         return PEER_KEY_ERROR;
 
     ssl->peerDilithiumKeyPresent = 1;
-    keyRet = wc_dilithium_init(ssl->peerDilithiumKey);
-    if (keyRet != 0)
-        return PEER_KEY_ERROR;
-
     keyRet = wc_dilithium_set_level(ssl->peerDilithiumKey, level);
     if (keyRet != 0)
         return PEER_KEY_ERROR;
@@ -9498,7 +9772,9 @@ static int decodeDilithiumKey(WOLFSSL* ssl, int level)
 
     return 0;
 }
+#endif /* HAVE_DILITHIUM */
 
+#ifdef HAVE_FALCON
 /* ssl->peerCert->sapkiDer is the alternative public key. Hopefully it is a
  * falcon public key. Convert it into a usable public key. */
 static int decodeFalconKey(WOLFSSL* ssl, int level)
@@ -9514,10 +9790,6 @@ static int decodeFalconKey(WOLFSSL* ssl, int level)
         return PEER_KEY_ERROR;
 
     ssl->peerFalconKeyPresent = 1;
-    keyRet = wc_falcon_init(ssl->peerFalconKey);
-    if (keyRet != 0)
-        return PEER_KEY_ERROR;
-
     keyRet = wc_falcon_set_level(ssl->peerFalconKey, level);
     if (keyRet != 0)
         return PEER_KEY_ERROR;
@@ -9530,7 +9802,8 @@ static int decodeFalconKey(WOLFSSL* ssl, int level)
 
     return 0;
 }
-#endif
+#endif /* HAVE_FALCON */
+#endif /* WOLFSSL_DUAL_ALG_CERTS */
 
 /* handle processing TLS v1.3 certificate_verify (15) */
 /* Parse and handle a TLS v1.3 CertificateVerify message.
@@ -9547,7 +9820,11 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                                     word32* inOutIdx, word32 totalSz)
 {
     int         ret = 0;
-    buffer*     sig = &ssl->buffers.sig;
+    byte*       sig = NULL;
+#ifndef NO_RSA
+    /* Use this as a temporary buffer for RSA signature verification. */
+    buffer*     rsaSigBuf = &ssl->buffers.sig;
+#endif
 #ifdef WOLFSSL_ASYNC_CRYPT
     Dcv13Args* args = NULL;
     WOLFSSL_ASSERT_SIZEOF_GE(ssl->async->args, *args);
@@ -9560,7 +9837,7 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     ret = tsip_Tls13CertificateVerify(ssl, input, inOutIdx, totalSz);
-    if (ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         goto exit_dcv;
     }
     ret = 0;
@@ -9577,7 +9854,7 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
     args = (Dcv13Args*)ssl->async->args;
 
     ret = wolfSSL_AsyncPop(ssl, &ssl->options.asyncState);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             goto exit_dcv;
@@ -9634,8 +9911,7 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
             /* If no CKS extension or either native or alternative, then just
              * get a normal sigalgo.  But if BOTH, then get the native and alt
              * sig algos. */
-            if (wolfSSL_is_server(ssl) ||
-                ssl->sigSpec == NULL ||
+            if (ssl->sigSpec == NULL ||
                 *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_NATIVE ||
                 *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_ALTERNATIVE) {
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
@@ -9669,8 +9945,7 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
             }
 
 #ifdef WOLFSSL_DUAL_ALG_CERTS
-            if (!wolfSSL_is_server(ssl) &&
-                (ssl->sigSpec != NULL) &&
+            if ((ssl->sigSpec != NULL) &&
                 (*ssl->sigSpec != WOLFSSL_CKS_SIGSPEC_NATIVE)) {
 
                 word16 sa;
@@ -9680,6 +9955,17 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                     sa = args->altSigAlgo;
 
                 switch(sa) {
+            #ifndef NO_RSA
+                case rsa_pss_sa_algo:
+                    ret = decodeRsaKey(ssl);
+                    break;
+            #endif
+            #ifdef HAVE_ECC
+                case ecc_dsa_sa_algo:
+                    ret = decodeEccKey(ssl);
+                    break;
+            #endif
+            #ifdef HAVE_DILITHIUM
                 case dilithium_level2_sa_algo:
                     ret = decodeDilithiumKey(ssl, 2);
                     break;
@@ -9689,70 +9975,62 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                 case dilithium_level5_sa_algo:
                     ret = decodeDilithiumKey(ssl, 5);
                     break;
+            #endif
+            #ifdef HAVE_FALCON
                 case falcon_level1_sa_algo:
                     ret = decodeFalconKey(ssl, 1);
                     break;
                 case falcon_level5_sa_algo:
                     ret = decodeFalconKey(ssl, 5);
                     break;
+            #endif
                 default:
                     ERROR_OUT(PEER_KEY_ERROR, exit_dcv);
-                    break;
                 }
 
                 if (ret != 0)
                     ERROR_OUT(ret, exit_dcv);
 
                 if (*ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_ALTERNATIVE) {
-                    /* Now swap in the alternative. We only support hybrid certs
-                     * where native is RSA or ECC so check that either of those
-                     * are present and then remove it. */
-                    if (ssl->peerRsaKeyPresent &&
-                        ssl->peerEccDsaKeyPresent) {
-                        /* They shouldn't both be present. */
-                        ERROR_OUT(PEER_KEY_ERROR, exit_dcv);
-                    }
-                    else if (ssl->peerRsaKeyPresent) {
+                    /* Now swap in the alternative by removing the native.
+                     * sa contains the alternative signature type. */
+                #ifndef NO_RSA
+                    if (ssl->peerRsaKeyPresent && sa != rsa_pss_sa_algo) {
                         FreeKey(ssl, DYNAMIC_TYPE_RSA,
                                 (void**)&ssl->peerRsaKey);
                         ssl->peerRsaKeyPresent = 0;
                     }
-                    else if (ssl->peerEccDsaKeyPresent) {
+                #endif
+                #ifdef HAVE_ECC
+                    else if (ssl->peerEccDsaKeyPresent &&
+                             sa != ecc_dsa_sa_algo) {
                         FreeKey(ssl, DYNAMIC_TYPE_ECC,
                                 (void**)&ssl->peerEccDsaKey);
                         ssl->peerEccDsaKeyPresent = 0;
                     }
+                #endif
+                #ifdef HAVE_DILITHIUM
+                    else if (ssl->peerDilithiumKeyPresent &&
+                             sa != dilithium_level2_sa_algo &&
+                             sa != dilithium_level3_sa_algo &&
+                             sa != dilithium_level5_sa_algo) {
+                        FreeKey(ssl, DYNAMIC_TYPE_DILITHIUM,
+                                (void**)&ssl->peerDilithiumKey);
+                        ssl->peerDilithiumKeyPresent = 0;
+                    }
+                #endif
+                #ifdef HAVE_FALCON
+                    else if (ssl->peerFalconKeyPresent &&
+                             sa != falcon_level1_sa_algo &&
+                             sa != falcon_level5_sa_algo) {
+                        FreeKey(ssl, DYNAMIC_TYPE_FALCON,
+                                (void**)&ssl->peerFalconKey);
+                        ssl->peerFalconKeyPresent = 0;
+                    }
+                #endif
                     else {
-                        ERROR_OUT(WOLFSSL_NOT_IMPLEMENTED, exit_dcv);
-                    }
-                }
-                else if (*ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
-                    /* Use alternative public key to figure out the expected
-                     * alt sig size. We only support Post-quantum key as SAPKI.
-                     */
-                    switch(sa) {
-                    case dilithium_level2_sa_algo:
-                    case dilithium_level3_sa_algo:
-                    case dilithium_level5_sa_algo:
-                        ret = wc_dilithium_sig_size(ssl->peerDilithiumKey);
-                        break;
-                    case falcon_level1_sa_algo:
-                    case falcon_level5_sa_algo:
-                        ret = wc_falcon_sig_size(ssl->peerFalconKey);
-                        break;
-                    default:
-                        ERROR_OUT(PEER_KEY_ERROR, exit_dcv);
-                        break;
-                    }
-
-                    if (ret <= 0) {
                         ERROR_OUT(PEER_KEY_ERROR, exit_dcv);
                     }
-                    args->altSignatureSz = ret;
-                    ret = 0;
-                }
-                else {
-                    ERROR_OUT(WOLFSSL_NOT_IMPLEMENTED, exit_dcv);
                 }
             }
 #endif /* WOLFSSL_DUAL_ALG_CERTS */
@@ -9788,7 +10066,7 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                                                       ssl->peerEccDsaKeyPresent;
             }
         #endif
-        #ifdef HAVE_PQC
+        #ifdef HAVE_FALCON
             if (ssl->options.peerSigAlgo == falcon_level1_sa_algo) {
                 WOLFSSL_MSG("Peer sent Falcon Level 1 sig");
                 validSigAlgo = (ssl->peerFalconKey != NULL) &&
@@ -9799,6 +10077,8 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                 validSigAlgo = (ssl->peerFalconKey != NULL) &&
                                ssl->peerFalconKeyPresent;
             }
+        #endif
+        #ifdef HAVE_DILITHIUM
             if (ssl->options.peerSigAlgo == dilithium_level2_sa_algo) {
                 WOLFSSL_MSG("Peer sent Dilithium Level 2 sig");
                 validSigAlgo = (ssl->peerDilithiumKey != NULL) &&
@@ -9831,61 +10111,89 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                 ERROR_OUT(SIG_VERIFY_E, exit_dcv);
             }
 
-            sig->length = args->sz;
+            args->sigSz = args->sz;
 #ifdef WOLFSSL_DUAL_ALG_CERTS
-            if (!wolfSSL_is_server(ssl) &&
-                ssl->sigSpec != NULL &&
+            if (ssl->sigSpec != NULL &&
                 *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
-                /* If its RSA, we only hybridize with RSA3072 which has a sig
-                 * size of 384. For ECC, this is actually encoded as an RFC5912
-                 * formatted signature which means we can use the ASN APIs to
-                 * figure out the length. Note that some post-quantum sig algs
-                 * have variable length signatures (Falcon). That is why we
-                 * don't do:
-                 *   sig->length -= args->altSignatureSz; */
-                #define RSA3072_SIG_LEN 384
-                if (ssl->options.peerSigAlgo == rsa_pss_sa_algo) {
-                    sig->length = RSA3072_SIG_LEN;
-                }
-                else if (ssl->options.peerSigAlgo == ecc_dsa_sa_algo) {
-                    word32 tmpIdx = args->idx;
-                    sig->length = wc_SignatureGetSize(WC_SIGNATURE_TYPE_ECC,
-                                      ssl->peerEccDsaKey,
-                                      sizeof(*ssl->peerEccDsaKey));
-                    if (GetSequence(input, &tmpIdx, (int*)&sig->length,
-                                    args->sz) < 0) {
-                        ERROR_OUT(SIG_VERIFY_E, exit_dcv);
-                    }
-                    /* We have to increment by the size of the header. */
-                    sig->length += tmpIdx - args->idx;
-                }
-                else {
-                    ERROR_OUT(WOLFSSL_NOT_IMPLEMENTED, exit_dcv);
+                /* In case we received two signatures, both of them are encoded
+                 * with their size as 16-bit integeter prior in memory. Hence,
+                 * we can decode both lengths here now. */
+                word32 tmpIdx = args->idx;
+                word16 tmpSz = 0;
+                ato16(input + tmpIdx, &tmpSz);
+                args->sigSz = tmpSz;
+
+                tmpIdx += OPAQUE16_LEN + args->sigSz;
+                ato16(input + tmpIdx, &tmpSz);
+                args->altSignatureSz = tmpSz;
+
+                if (args->sz != (args->sigSz + args->altSignatureSz +
+                                    OPAQUE16_LEN + OPAQUE16_LEN)) {
+                    ERROR_OUT(BUFFER_ERROR, exit_dcv);
                 }
             }
-#endif
+#endif /* WOLFSSL_DUAL_ALG_CERTS */
 
-            sig->buffer = (byte*)XMALLOC(sig->length, ssl->heap,
+        #if !defined(NO_RSA) && defined(WC_RSA_PSS)
+            /* In case we have to verify an RSA signature, we have to store the
+             * signature in the 'rsaSigBuf' structure for further processing.
+             */
+            if (ssl->peerRsaKey != NULL && ssl->peerRsaKeyPresent != 0) {
+                word32 sigSz = args->sigSz;
+                sig = input + args->idx;
+            #ifdef WOLFSSL_DUAL_ALG_CERTS
+                /* Check if our alternative signature was RSA */
+                if (ssl->sigSpec != NULL &&
+                    *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
+                    if (ssl->options.peerSigAlgo != rsa_pss_sa_algo) {
+                        /* We have to skip the first signature (length field
+                         * and signature itself) and the length field of the
+                         * alternative signature. */
+                        sig += OPAQUE16_LEN + OPAQUE16_LEN + args->sigSz;
+                        sigSz = args->altSignatureSz;
+                    }
+                    else {
+                        /* We have to skip the length field */
+                        sig += OPAQUE16_LEN;
+                    }
+                }
+            #endif
+                rsaSigBuf->buffer = (byte*)XMALLOC(sigSz, ssl->heap,
                                          DYNAMIC_TYPE_SIGNATURE);
+                if (rsaSigBuf->buffer == NULL) {
+                    ERROR_OUT(MEMORY_E, exit_dcv);
+                }
+                rsaSigBuf->length = sigSz;
+                XMEMCPY(rsaSigBuf->buffer, sig, rsaSigBuf->length);
+            }
+        #endif /* !NO_RSA && WC_RSA_PSS */
 
-            if (sig->buffer == NULL) {
+            args->sigData = (byte*)XMALLOC(MAX_SIG_DATA_SZ, ssl->heap,
+                                                    DYNAMIC_TYPE_SIGNATURE);
+            if (args->sigData == NULL) {
                 ERROR_OUT(MEMORY_E, exit_dcv);
             }
 
-            XMEMCPY(sig->buffer, input + args->idx, sig->length);
-        #ifdef HAVE_ECC
-            if (ssl->peerEccDsaKeyPresent) {
-                WOLFSSL_MSG("Doing ECC peer cert verify");
+            ret = CreateSigData(ssl, args->sigData, &args->sigDataSz, 1);
+            if (ret < 0)
+                goto exit_dcv;
 
-                args->sigData = (byte*)XMALLOC(MAX_SIG_DATA_SZ, ssl->heap,
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
+            if ((ssl->sigSpec != NULL) &&
+                (*ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH)) {
+                args->altSigData = (byte*)XMALLOC(MAX_SIG_DATA_SZ, ssl->heap,
                                                         DYNAMIC_TYPE_SIGNATURE);
-                if (args->sigData == NULL) {
+                if (args->altSigData == NULL) {
                     ERROR_OUT(MEMORY_E, exit_dcv);
                 }
+                XMEMCPY(args->altSigData, args->sigData, args->sigDataSz);
+                args->altSigDataSz = args->sigDataSz;
+            }
+        #endif /* WOLFSSL_DUAL_ALG_CERTS */
 
-                ret = CreateSigData(ssl, args->sigData, &args->sigDataSz, 1);
-                if (ret != 0)
-                    goto exit_dcv;
+        #ifdef HAVE_ECC
+            if ((ssl->options.peerSigAlgo == ecc_dsa_sa_algo) &&
+                (ssl->peerEccDsaKeyPresent)) {
             #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
                 if (ssl->options.peerSigAlgo != sm2_sa_algo)
             #endif
@@ -9898,68 +10206,21 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                     ret = 0;
                 }
             }
-        #endif
-        #ifdef HAVE_ED25519
-            if (ssl->peerEd25519KeyPresent) {
-                WOLFSSL_MSG("Doing ED25519 peer cert verify");
 
-                args->sigData = (byte*)XMALLOC(MAX_SIG_DATA_SZ, ssl->heap,
-                                                        DYNAMIC_TYPE_SIGNATURE);
-                if (args->sigData == NULL) {
-                    ERROR_OUT(MEMORY_E, exit_dcv);
-                }
-
-                ret = CreateSigData(ssl, args->sigData, &args->sigDataSz, 1);
-                if (ret < 0)
-                    goto exit_dcv;
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
+            if ((ssl->sigSpec != NULL) &&
+                (*ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) &&
+                (args->altSigAlgo == ecc_dsa_sa_algo) &&
+                (ssl->peerEccDsaKeyPresent)) {
+                ret = CreateECCEncodedSig(args->altSigData,
+                        args->altSigDataSz, ssl->options.peerHashAlgo);
+                    if (ret < 0)
+                        goto exit_dcv;
+                    args->altSigDataSz = (word16)ret;
+                    ret = 0;
             }
-        #endif
-        #ifdef HAVE_ED448
-            if (ssl->peerEd448KeyPresent) {
-                WOLFSSL_MSG("Doing ED448 peer cert verify");
-
-                args->sigData = (byte*)XMALLOC(MAX_SIG_DATA_SZ, ssl->heap,
-                                                        DYNAMIC_TYPE_SIGNATURE);
-                if (args->sigData == NULL) {
-                    ERROR_OUT(MEMORY_E, exit_dcv);
-                }
-
-                ret = CreateSigData(ssl, args->sigData, &args->sigDataSz, 1);
-                if (ret < 0)
-                    goto exit_dcv;
-            }
-       #endif
-       #ifdef HAVE_PQC
-            if (ssl->peerFalconKeyPresent || ssl->peerDilithiumKeyPresent) {
-                word16 sigDataSz;
-                byte *sigData = (byte*)XMALLOC(MAX_SIG_DATA_SZ, ssl->heap,
-                                                        DYNAMIC_TYPE_SIGNATURE);
-                if (sigData == NULL) {
-                    ERROR_OUT(MEMORY_E, exit_dcv);
-                }
-
-                ret = CreateSigData(ssl, sigData, &sigDataSz, 1);
-                if (ret < 0) {
-                    goto exit_dcv;
-                }
-
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-                if (!wolfSSL_is_server(ssl) &&
-                    ssl->sigSpec != NULL &&
-                    *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
-                    /* In this case (BOTH), the pq sig is the alternative. */
-                    args->altSigData = sigData;
-                    args->altSigDataSz = sigDataSz;
-                }
-                else
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-                {
-                    args->sigData = sigData;
-                    args->sigDataSz = sigDataSz;
-                }
-                ret = 0;
-            }
-       #endif
+        #endif /* WOLFSSL_DUAL_ALG_CERTS */
+        #endif /* HAVE_ECC */
 
             /* Advance state and proceed */
             ssl->options.asyncState = TLS_ASYNC_DO;
@@ -9968,35 +10229,52 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
 
         case TLS_ASYNC_DO:
         {
+            sig = input + args->idx;
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
+            if (ssl->sigSpec != NULL &&
+                *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
+                /* As we have two signatures in the message, we stored
+                 * the length of each before the actual signature. This
+                 * is necessary, as we could have two algorithms with
+                 * variable length signatures. */
+                sig += OPAQUE16_LEN;
+            }
+        #endif
         #ifndef NO_RSA
-            if (ssl->peerRsaKey != NULL && ssl->peerRsaKeyPresent != 0) {
-                ret = RsaVerify(ssl, sig->buffer, (word32)sig->length, &args->output,
-                    ssl->options.peerSigAlgo, ssl->options.peerHashAlgo, ssl->peerRsaKey,
+            if ((ssl->options.peerSigAlgo == rsa_pss_sa_algo) &&
+                (ssl->peerRsaKey != NULL) && (ssl->peerRsaKeyPresent != 0)) {
+                WOLFSSL_MSG("Doing RSA peer cert verify");
+                ret = RsaVerify(ssl, rsaSigBuf->buffer,
+                                (word32)rsaSigBuf->length, &args->output,
+                                ssl->options.peerSigAlgo,
+                                ssl->options.peerHashAlgo, ssl->peerRsaKey,
                 #ifdef HAVE_PK_CALLBACKS
-                    &ssl->buffers.peerRsaKey
+                                &ssl->buffers.peerRsaKey
                 #else
-                    NULL
+                                NULL
                 #endif
-                );
+                                );
                 if (ret >= 0) {
-                    args->sendSz = ret;
+                    args->sendSz = (word32)ret;
                     ret = 0;
                 }
             }
         #endif /* !NO_RSA */
         #ifdef HAVE_ECC
-            if (ssl->peerEccDsaKeyPresent) {
+            if ((ssl->options.peerSigAlgo == ecc_dsa_sa_algo) &&
+                (ssl->peerEccDsaKeyPresent)) {
             #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
                 if (ssl->options.peerSigAlgo == sm2_sa_algo) {
                     ret = Sm2wSm3Verify(ssl, TLS13_SM2_SIG_ID,
-                        TLS13_SM2_SIG_ID_SZ, input + args->idx, args->sz,
+                        TLS13_SM2_SIG_ID_SZ, sig, args->sigSz,
                         args->sigData, args->sigDataSz,
                         ssl->peerEccDsaKey, NULL);
                 }
                 else
             #endif
                 {
-                    ret = EccVerify(ssl, input + args->idx, sig->length,
+                    WOLFSSL_MSG("Doing ECC peer cert verify");
+                    ret = EccVerify(ssl, sig, args->sigSz,
                         args->sigData, args->sigDataSz,
                         ssl->peerEccDsaKey,
                     #ifdef HAVE_PK_CALLBACKS
@@ -10004,21 +10282,24 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                     #else
                         NULL
                     #endif
-                    );
+                        );
                 }
 
                 if (ret >= 0) {
                     /* CLIENT/SERVER: data verified with public key from
                      * certificate. */
                     ssl->options.peerAuthGood = 1;
+
                     FreeKey(ssl, DYNAMIC_TYPE_ECC, (void**)&ssl->peerEccDsaKey);
                     ssl->peerEccDsaKeyPresent = 0;
                 }
             }
         #endif /* HAVE_ECC */
         #ifdef HAVE_ED25519
-            if (ssl->peerEd25519KeyPresent) {
-                ret = Ed25519Verify(ssl, input + args->idx, args->sz,
+            if ((ssl->options.peerSigAlgo == ed25519_sa_algo) &&
+                (ssl->peerEd25519KeyPresent)) {
+                WOLFSSL_MSG("Doing ED25519 peer cert verify");
+                ret = Ed25519Verify(ssl, sig, args->sigSz,
                     args->sigData, args->sigDataSz,
                     ssl->peerEd25519Key,
                 #ifdef HAVE_PK_CALLBACKS
@@ -10026,7 +10307,7 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                 #else
                     NULL
                 #endif
-                );
+                    );
 
                 if (ret >= 0) {
                     /* CLIENT/SERVER: data verified with public key from
@@ -10039,8 +10320,10 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
             }
         #endif
         #ifdef HAVE_ED448
-            if (ssl->peerEd448KeyPresent) {
-                ret = Ed448Verify(ssl, input + args->idx, args->sz,
+            if ((ssl->options.peerSigAlgo == ed448_sa_algo) &&
+                (ssl->peerEd448KeyPresent)) {
+                WOLFSSL_MSG("Doing ED448 peer cert verify");
+                ret = Ed448Verify(ssl, sig, args->sigSz,
                     args->sigData, args->sigDataSz,
                     ssl->peerEd448Key,
                 #ifdef HAVE_PK_CALLBACKS
@@ -10060,103 +10343,158 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                 }
             }
         #endif
-        #if defined(HAVE_PQC) && defined(HAVE_FALCON)
-            if (ssl->peerFalconKeyPresent) {
+        #if defined(HAVE_FALCON)
+            if (((ssl->options.peerSigAlgo == falcon_level1_sa_algo) ||
+                 (ssl->options.peerSigAlgo == falcon_level5_sa_algo)) &&
+                (ssl->peerFalconKeyPresent)) {
                 int res = 0;
-                byte *sigIn = input + args->idx;
-                word32 sigInLen = args->sz;
-                byte *sigData = args->sigData;
-                word32 sigDataSz = args->sigDataSz;
                 WOLFSSL_MSG("Doing Falcon peer cert verify");
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-                if (!wolfSSL_is_server(ssl) &&
-                    ssl->sigSpec != NULL &&
-                    *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
-                    /* Note: + sig->length; we are skipping the native sig. */
-                    sigIn = input + args->idx + sig->length;
-                    sigInLen = args->sz - sig->length;
-
-                    /* For RSA, something different was verified. */
-                    if (ssl->peerRsaKeyPresent) {
-                        sigData = args->altSigData;
-                        sigDataSz = args->altSigDataSz;
-                    }
-                }
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-                ret = wc_falcon_verify_msg(sigIn, sigInLen,
-                                           sigData, sigDataSz,
+                ret = wc_falcon_verify_msg(sig, args->sigSz,
+                                           args->sigData, args->sigDataSz,
                                            &res, ssl->peerFalconKey);
 
                 if ((ret >= 0) && (res == 1)) {
                     /* CLIENT/SERVER: data verified with public key from
                      * certificate. */
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-                    if (!wolfSSL_is_server(ssl) &&
-                        ssl->sigSpec != NULL &&
-                        *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
-                        args->altPeerAuthGood = 1;
-                    }
-                    else
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-                        ssl->options.peerAuthGood = 1;
+                    ssl->options.peerAuthGood = 1;
 
                     FreeKey(ssl, DYNAMIC_TYPE_FALCON,
                                                    (void**)&ssl->peerFalconKey);
                     ssl->peerFalconKeyPresent = 0;
                 }
             }
-        #endif /* HAVE_PQC && HAVE_FALCON */
-        #if defined(HAVE_PQC) && defined(HAVE_DILITHIUM)
-            if (ssl->peerDilithiumKeyPresent) {
+        #endif /* HAVE_FALCON */
+        #if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_VERIFY)
+            if (((ssl->options.peerSigAlgo == dilithium_level2_sa_algo) ||
+                 (ssl->options.peerSigAlgo == dilithium_level3_sa_algo) ||
+                 (ssl->options.peerSigAlgo == dilithium_level5_sa_algo)) &&
+                (ssl->peerDilithiumKeyPresent)) {
                 int res = 0;
-                byte *sigIn = input + args->idx;
-                word32 sigInLen = args->sz;
-                byte *sigData = args->sigData;
-                word32 sigDataSz = args->sigDataSz;
                 WOLFSSL_MSG("Doing Dilithium peer cert verify");
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-                if (!wolfSSL_is_server(ssl) &&
-                    ssl->sigSpec != NULL &&
-                    *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
-                    /* Go backwards from the end of the signature the size of
-                     * the alt sig to find the beginning of the alt sig. */
-                    sigIn = input + args->idx + args->sz - args->altSignatureSz;
-                    sigInLen = args->altSignatureSz;
-                    /* For RSA, something different was verified. */
-                    if (ssl->peerRsaKeyPresent) {
-                        sigData = args->altSigData;
-                        sigDataSz = args->altSigDataSz;
-                    }
-                }
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-                ret = wc_dilithium_verify_msg(sigIn, sigInLen,
-                                              sigData, sigDataSz,
+                ret = wc_dilithium_verify_msg(sig, args->sigSz,
+                                              args->sigData, args->sigDataSz,
                                               &res, ssl->peerDilithiumKey);
 
                 if ((ret >= 0) && (res == 1)) {
                     /* CLIENT/SERVER: data verified with public key from
                      * certificate. */
-#ifdef WOLFSSL_DUAL_ALG_CERTS
-                    if (!wolfSSL_is_server(ssl) &&
-                        ssl->sigSpec != NULL &&
-                        *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
-                        args->altPeerAuthGood = 1;
-                    }
-                    else
-#endif /* WOLFSSL_DUAL_ALG_CERTS */
-                        ssl->options.peerAuthGood = 1;
+                    ssl->options.peerAuthGood = 1;
 
                     FreeKey(ssl, DYNAMIC_TYPE_DILITHIUM,
                             (void**)&ssl->peerDilithiumKey);
                     ssl->peerDilithiumKeyPresent = 0;
                 }
             }
-        #endif /* HAVE_PQC && HAVE_DILITHIUM */
+        #endif /* HAVE_DILITHIUM */
 
             /* Check for error */
             if (ret != 0) {
                 goto exit_dcv;
             }
+
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
+            if (ssl->sigSpec != NULL &&
+                *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
+                /* Move forward to the alternative signature. */
+                sig += args->sigSz + OPAQUE16_LEN;
+
+                /* Verify the alternative signature */
+            #ifndef NO_RSA
+                if ((args->altSigAlgo == rsa_pss_sa_algo) &&
+                    (ssl->peerRsaKey != NULL) &&
+                    (ssl->peerRsaKeyPresent != 0)) {
+                    WOLFSSL_MSG("Doing RSA peer cert alt verify");
+                    ret = RsaVerify(ssl, rsaSigBuf->buffer,
+                                    (word32)rsaSigBuf->length,
+                                    &args->output, args->altSigAlgo,
+                                    ssl->options.peerHashAlgo, ssl->peerRsaKey,
+                    #ifdef HAVE_PK_CALLBACKS
+                                    &ssl->buffers.peerRsaKey
+                    #else
+                                    NULL
+                    #endif
+                                    );
+                    if (ret >= 0) {
+                        args->sendSz = ret;
+                        ret = 0;
+                    }
+                }
+            #endif /* !NO_RSA */
+            #ifdef HAVE_ECC
+                if ((args->altSigAlgo == ecc_dsa_sa_algo) &&
+                    (ssl->peerEccDsaKeyPresent)) {
+                    WOLFSSL_MSG("Doing ECC peer cert alt verify");
+                    ret = EccVerify(ssl, sig, args->altSignatureSz,
+                                args->altSigData, args->altSigDataSz,
+                                ssl->peerEccDsaKey,
+                    #ifdef HAVE_PK_CALLBACKS
+                                &ssl->buffers.peerEccDsaKey
+                    #else
+                                NULL
+                    #endif
+                                );
+
+                    if (ret >= 0) {
+                        /* CLIENT/SERVER: data verified with public key from
+                        * certificate. */
+                        args->altPeerAuthGood = 1;
+
+                        FreeKey(ssl, DYNAMIC_TYPE_ECC,
+                                                (void**)&ssl->peerEccDsaKey);
+                        ssl->peerEccDsaKeyPresent = 0;
+                    }
+                }
+            #endif /* HAVE_ECC */
+            #if defined(HAVE_FALCON)
+                if (((args->altSigAlgo == falcon_level1_sa_algo) ||
+                     (args->altSigAlgo == falcon_level5_sa_algo)) &&
+                    (ssl->peerFalconKeyPresent)) {
+                    int res = 0;
+                    WOLFSSL_MSG("Doing Falcon peer cert alt verify");
+                    ret = wc_falcon_verify_msg(sig, args->altSignatureSz,
+                                        args->altSigData, args->altSigDataSz,
+                                        &res, ssl->peerFalconKey);
+
+                    if ((ret >= 0) && (res == 1)) {
+                        /* CLIENT/SERVER: data verified with public key from
+                        * certificate. */
+                        args->altPeerAuthGood = 1;
+
+                        FreeKey(ssl, DYNAMIC_TYPE_FALCON,
+                                                (void**)&ssl->peerFalconKey);
+                        ssl->peerFalconKeyPresent = 0;
+                    }
+                }
+            #endif /* HAVE_FALCON */
+            #if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_VERIFY)
+                if (((args->altSigAlgo == dilithium_level2_sa_algo) ||
+                     (args->altSigAlgo == dilithium_level3_sa_algo) ||
+                     (args->altSigAlgo == dilithium_level5_sa_algo)) &&
+                    (ssl->peerDilithiumKeyPresent)) {
+                    int res = 0;
+                    WOLFSSL_MSG("Doing Dilithium peer cert alt verify");
+                    ret = wc_dilithium_verify_msg(sig, args->altSignatureSz,
+                                        args->altSigData, args->altSigDataSz,
+                                        &res, ssl->peerDilithiumKey);
+
+                    if ((ret >= 0) && (res == 1)) {
+                        /* CLIENT/SERVER: data verified with public key from
+                        * certificate. */
+                        args->altPeerAuthGood = 1;
+
+                        FreeKey(ssl, DYNAMIC_TYPE_DILITHIUM,
+                                            (void**)&ssl->peerDilithiumKey);
+                        ssl->peerDilithiumKeyPresent = 0;
+                    }
+                }
+            #endif /* HAVE_DILITHIUM */
+
+                /* Check for error */
+                if (ret != 0) {
+                    goto exit_dcv;
+                }
+            }
+        #endif /* WOLFSSL_DUAL_ALG_CERTS */
 
             /* Advance state and proceed */
             ssl->options.asyncState = TLS_ASYNC_VERIFY;
@@ -10167,7 +10505,16 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
         {
         #if !defined(NO_RSA) && defined(WC_RSA_PSS)
             if (ssl->peerRsaKey != NULL && ssl->peerRsaKeyPresent != 0) {
-                ret = CheckRSASignature(ssl, ssl->options.peerSigAlgo,
+                int sigAlgo = ssl->options.peerSigAlgo;
+            #ifdef WOLFSSL_DUAL_ALG_CERTS
+                /* Check if our alternative signature was RSA */
+                if (ssl->sigSpec != NULL &&
+                    *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH &&
+                    ssl->options.peerSigAlgo != rsa_pss_sa_algo) {
+                    sigAlgo = args->altSigAlgo;
+                }
+            #endif
+                ret = CheckRSASignature(ssl, sigAlgo,
                         ssl->options.peerHashAlgo, args->output, args->sendSz);
                 if (ret != 0)
                     goto exit_dcv;
@@ -10176,7 +10523,16 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
                  * certificate. */
                 ssl->peerRsaKeyPresent = 0;
                 FreeKey(ssl, DYNAMIC_TYPE_RSA, (void**)&ssl->peerRsaKey);
-                ssl->options.peerAuthGood = 1;
+            #ifdef WOLFSSL_DUAL_ALG_CERTS
+                /* Check if our alternative signature was RSA */
+                if (ssl->sigSpec != NULL &&
+                    *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH &&
+                    ssl->options.peerSigAlgo != rsa_pss_sa_algo) {
+                    args->altPeerAuthGood = 1;
+                }
+                else
+            #endif
+                    ssl->options.peerAuthGood = 1;
             }
         #endif /* !NO_RSA && WC_RSA_PSS */
 
@@ -10188,8 +10544,7 @@ static int DoTls13CertificateVerify(WOLFSSL* ssl, byte* input,
         case TLS_ASYNC_FINALIZE:
         {
 #ifdef WOLFSSL_DUAL_ALG_CERTS
-            if (!wolfSSL_is_server(ssl) &&
-                ssl->options.peerAuthGood &&
+            if (ssl->options.peerAuthGood &&
                 ssl->sigSpec != NULL &&
                 *ssl->sigSpec == WOLFSSL_CKS_SIGSPEC_BOTH) {
                 ssl->options.peerAuthGood = args->altPeerAuthGood;
@@ -10230,7 +10585,7 @@ exit_dcv:
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     /* Handle async operation */
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         /* Mark message as not received so it can process again */
         ssl->msgsReceived.got_certificate_verify = 0;
 
@@ -10241,7 +10596,7 @@ exit_dcv:
     if (ret != 0) {
         WOLFSSL_ERROR_VERBOSE(ret);
 
-        if (ret != INVALID_PARAMETER) {
+        if (ret != WC_NO_ERR_TRACE(INVALID_PARAMETER)) {
             SendAlert(ssl, alert_fatal, decrypt_error);
         }
     }
@@ -10315,11 +10670,11 @@ int DoTls13Finished(WOLFSSL* ssl, const byte* input, word32* inOutIdx,
         ssl->options.serverState = SERVER_FINISHED_COMPLETE;
         return ret;
     }
-    if (ret == VERIFY_FINISHED_ERROR) {
+    if (ret == WC_NO_ERR_TRACE(VERIFY_FINISHED_ERROR)) {
         SendAlert(ssl, alert_fatal, decrypt_error);
         return ret;
     }
-    if (ret != CRYPTOCB_UNAVAILABLE) {
+    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
         /* other errors */
         return ret;
     }
@@ -10487,12 +10842,12 @@ static int SendTls13Finished(WOLFSSL* ssl)
         input = output + Dtls13GetRlHeaderLength(ssl, 1);
 #endif /* WOLFSSL_DTLS13 */
 
-    AddTls13HandShakeHeader(input, finishedSz, 0, finishedSz, finished, ssl);
+    AddTls13HandShakeHeader(input, (word32)finishedSz, 0, finishedSz, finished, ssl);
 
 #if defined(WOLFSSL_RENESAS_TSIP_TLS)
     if (ssl->options.side == WOLFSSL_CLIENT_END) {
         ret = tsip_Tls13SendFinished(ssl, output, outputSz, input, 1);
-        if (ret != CRYPTOCB_UNAVAILABLE) {
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
             return ret;
         }
         ret = 0;
@@ -10919,7 +11274,7 @@ static int SendTls13EndOfEarlyData(WOLFSSL* ssl)
     WOLFSSL_ENTER("SendTls13EndOfEarlyData");
 
     length = 0;
-    sendSz = idx + length + MAX_MSG_EXTRA;
+    sendSz = (int)(idx + length + MAX_MSG_EXTRA);
     ssl->options.buildingMsg = 1;
 
     /* Check buffers are big enough and grow if needed. */
@@ -11329,7 +11684,7 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
     }
     else
     #ifdef WOLFSSL_ASYNC_CRYPT
-        if (ssl->error != WC_PENDING_E)
+        if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
     #endif
     {
             ssl->session->ticketNonce.data[0]++;
@@ -11375,7 +11730,7 @@ static int SendTls13NewSessionTicket(WOLFSSL* ssl)
     /* Nonce */
     length += TICKET_NONCE_LEN_SZ + DEF_TICKET_NONCE_SZ;
 
-    sendSz = idx + length + MAX_MSG_EXTRA;
+    sendSz = (int)(idx + length + MAX_MSG_EXTRA);
 
     /* Check buffers are big enough and grow if needed. */
     if ((ret = CheckAvailableSize(ssl, sendSz)) != 0)
@@ -12009,7 +12364,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     /* sanity check msg received */
     if ((ret = SanityCheckTls13MsgReceived(ssl, type)) != 0) {
         WOLFSSL_MSG("Sanity Check on handshake message type received failed");
-        if (ret == VERSION_ERROR)
+        if (ret == WC_NO_ERR_TRACE(VERSION_ERROR))
             SendAlert(ssl, alert_fatal, wolfssl_alert_protocol_version);
         else
             SendAlert(ssl, alert_fatal, unexpected_message);
@@ -12117,7 +12472,8 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         #endif
                ) {
         #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_NONBLOCK_OCSP)
-            if (ret != WC_PENDING_E && ret != OCSP_WANT_READ)
+            if (ret != WC_NO_ERR_TRACE(WC_PENDING_E) &&
+                ret != WC_NO_ERR_TRACE(OCSP_WANT_READ))
         #endif
             {
                 ssl->options.cacheMessages = 0;
@@ -12174,7 +12530,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 #endif
 
 #if !defined(NO_RSA) || defined(HAVE_ECC) || defined(HAVE_ED25519) || \
-    defined(HAVE_ED448) || defined(HAVE_PQC)
+    defined(HAVE_ED448) || defined(HAVE_FALCON) || defined(HAVE_DILITHIUM)
     case certificate_verify:
         WOLFSSL_MSG("processing certificate verify");
         ret = DoTls13CertificateVerify(ssl, input, inOutIdx, size);
@@ -12206,7 +12562,8 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 #if defined(WOLFSSL_ASYNC_CRYPT) || defined(WOLFSSL_ASYNC_IO)
     /* if async, offset index so this msg will be processed again */
     /* NOTE: check this now before other calls can overwrite ret */
-    if ((ret == WC_PENDING_E || ret == OCSP_WANT_READ) && *inOutIdx > 0) {
+    if ((ret == WC_NO_ERR_TRACE(WC_PENDING_E) ||
+         ret == WC_NO_ERR_TRACE(OCSP_WANT_READ)) && *inOutIdx > 0) {
         /* DTLS always stores a message in a buffer when async is enable, so we
          * don't need to adjust for the extra bytes here (*inOutIdx is always
          * == 0) */
@@ -12214,13 +12571,15 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
     }
 
     /* make sure async error is cleared */
-    if (ret == 0 && (ssl->error == WC_PENDING_E || ssl->error == OCSP_WANT_READ)) {
+    if (ret == 0 &&
+        (ssl->error == WC_NO_ERR_TRACE(WC_PENDING_E) ||
+         ssl->error == WC_NO_ERR_TRACE(OCSP_WANT_READ))) {
         ssl->error = 0;
     }
 #endif
     if (ret == 0 && type != client_hello && type != session_ticket &&
                                                            type != key_update) {
-        ret = HashInput(ssl, input + inIdx, size);
+        ret = HashInput(ssl, input + inIdx, (int)size);
     }
 
     alertType = TranslateErrorToAlert(ret);
@@ -12233,7 +12592,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
         tmp = SendAlert(ssl, alert_fatal, alertType);
         /* propagate socket error instead of tls error to be sure the error is
          * not ignored by DTLS code */
-        if (tmp == SOCKET_ERROR_E)
+        if (tmp == WC_NO_ERR_TRACE(SOCKET_ERROR_E))
             ret = SOCKET_ERROR_E;
     }
 
@@ -12330,7 +12689,7 @@ int DoTls13HandShakeMsgType(WOLFSSL* ssl, byte* input, word32* inOutIdx,
 
                 if (wolfSSL_connect_TLSv13(ssl) != WOLFSSL_SUCCESS) {
                     ret = ssl->error;
-                    if (ret != WC_PENDING_E)
+                    if (ret != WC_NO_ERR_TRACE(WC_PENDING_E))
                         ret = POST_HAND_AUTH_ERROR;
                 }
             }
@@ -12475,7 +12834,7 @@ int DoTls13HandShakeMsg(WOLFSSL* ssl, byte* input, word32* inOutIdx,
                                 ssl->arrays->pendingMsgSz - HANDSHAKE_HEADER_SZ,
                                 ssl->arrays->pendingMsgSz);
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 /* setup to process fragment again */
                 ssl->arrays->pendingMsgOffset -= inputLength;
                 *inOutIdx -= inputLength + ssl->keys.padSz;
@@ -12808,8 +13167,8 @@ int wolfSSL_connect_TLSv13(WOLFSSL* ssl)
         case FIRST_REPLY_THIRD:
         #if (!defined(NO_CERTS) && (!defined(NO_RSA) || defined(HAVE_ECC) || \
              defined(HAVE_ED25519) || defined(HAVE_ED448) || \
-             defined(HAVE_PQC))) && (!defined(NO_WOLFSSL_SERVER) || \
-             !defined(WOLFSSL_NO_CLIENT_AUTH))
+             defined(HAVE_FALCON) || defined(HAVE_DILITHIUM))) && \
+             (!defined(NO_WOLFSSL_SERVER) || !defined(WOLFSSL_NO_CLIENT_AUTH))
             if (!ssl->options.resuming && ssl->options.sendVerify) {
                 ssl->error = SendTls13CertificateVerify(ssl);
                 if (ssl->error != 0) {
@@ -13020,14 +13379,14 @@ int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group)
 
 #ifdef WOLFSSL_ASYNC_CRYPT
     ret = wolfSSL_AsyncPop(ssl, NULL);
-    if (ret != WC_NO_PENDING_E) {
+    if (ret != WC_NO_ERR_TRACE(WC_NO_PENDING_E)) {
         /* Check for error */
         if (ret < 0)
             return ret;
     }
 #endif
 
-#ifdef HAVE_PQC
+#if defined(WOLFSSL_HAVE_KYBER)
     if (WOLFSSL_NAMED_GROUP_IS_PQC(group)) {
 
         if (ssl->ctx != NULL && ssl->ctx->method != NULL &&
@@ -13036,10 +13395,11 @@ int wolfSSL_UseKeyShare(WOLFSSL* ssl, word16 group)
         }
 
         if (ssl->options.side == WOLFSSL_SERVER_END) {
-            /* If I am the server of a KEM connection, do not do keygen because I'm
-             * going to encapsulate with the client's public key. Note that I might
-             * be the client and ssl->option.side has not been properly set yet. In
-             * that case the KeyGen operation will be deferred to connection time. */
+            /* If I am the server of a KEM connection, do not do keygen because
+             * I'm going to encapsulate with the client's public key. Note that
+             * I might be the client and ssl->option.side has not been properly
+             * set yet. In that case the KeyGen operation will be deferred to
+             * connection time. */
             return WOLFSSL_SUCCESS;
         }
     }
@@ -13388,86 +13748,6 @@ int wolfSSL_preferred_group(WOLFSSL* ssl)
 #endif
 }
 #endif
-
-#if defined(HAVE_SUPPORTED_CURVES)
-/* Sets the key exchange groups in rank order on a context.
- *
- * ctx     SSL/TLS context object.
- * groups  Array of groups.
- * count   Number of groups in array.
- * returns BAD_FUNC_ARG when ctx or groups is NULL, not using TLS v1.3 or
- * count is greater than WOLFSSL_MAX_GROUP_COUNT and WOLFSSL_SUCCESS on success.
- */
-int wolfSSL_CTX_set_groups(WOLFSSL_CTX* ctx, int* groups, int count)
-{
-    int ret, i;
-
-    WOLFSSL_ENTER("wolfSSL_CTX_set_groups");
-    if (ctx == NULL || groups == NULL || count > WOLFSSL_MAX_GROUP_COUNT)
-        return BAD_FUNC_ARG;
-    if (!IsAtLeastTLSv1_3(ctx->method->version))
-        return BAD_FUNC_ARG;
-
-    ctx->numGroups = 0;
-    #if !defined(NO_TLS)
-    TLSX_Remove(&ctx->extensions, TLSX_SUPPORTED_GROUPS, ctx->heap);
-    #endif /* !NO_TLS */
-    for (i = 0; i < count; i++) {
-        /* Call to wolfSSL_CTX_UseSupportedCurve also checks if input groups
-         * are valid */
-        if ((ret = wolfSSL_CTX_UseSupportedCurve(ctx, (word16)groups[i]))
-                != WOLFSSL_SUCCESS) {
-    #if !defined(NO_TLS)
-            TLSX_Remove(&ctx->extensions, TLSX_SUPPORTED_GROUPS, ctx->heap);
-    #endif /* !NO_TLS */
-            return ret;
-        }
-        ctx->group[i] = (word16)groups[i];
-    }
-    ctx->numGroups = (byte)count;
-
-    return WOLFSSL_SUCCESS;
-}
-
-/* Sets the key exchange groups in rank order.
- *
- * ssl     SSL/TLS object.
- * groups  Array of groups.
- * count   Number of groups in array.
- * returns BAD_FUNC_ARG when ssl or groups is NULL, not using TLS v1.3 or
- * count is greater than WOLFSSL_MAX_GROUP_COUNT and WOLFSSL_SUCCESS on success.
- */
-int wolfSSL_set_groups(WOLFSSL* ssl, int* groups, int count)
-{
-    int ret, i;
-
-    WOLFSSL_ENTER("wolfSSL_set_groups");
-    if (ssl == NULL || groups == NULL || count > WOLFSSL_MAX_GROUP_COUNT)
-        return BAD_FUNC_ARG;
-    if (!IsAtLeastTLSv1_3(ssl->version))
-        return BAD_FUNC_ARG;
-
-    ssl->numGroups = 0;
-    #if !defined(NO_TLS)
-    TLSX_Remove(&ssl->extensions, TLSX_SUPPORTED_GROUPS, ssl->heap);
-    #endif /* !NO_TLS */
-    for (i = 0; i < count; i++) {
-        /* Call to wolfSSL_UseSupportedCurve also checks if input groups
-                 * are valid */
-        if ((ret = wolfSSL_UseSupportedCurve(ssl, (word16)groups[i]))
-                != WOLFSSL_SUCCESS) {
-    #if !defined(NO_TLS)
-            TLSX_Remove(&ssl->extensions, TLSX_SUPPORTED_GROUPS, ssl->heap);
-    #endif /* !NO_TLS */
-            return ret;
-        }
-        ssl->group[i] = (word16)groups[i];
-    }
-    ssl->numGroups = (byte)count;
-
-    return WOLFSSL_SUCCESS;
-}
-#endif /* HAVE_SUPPORTED_CURVES */
 
 #ifndef NO_PSK
 /* Set the PSK callback, that is passed the cipher suite, for a client to use
@@ -14030,7 +14310,8 @@ int wolfSSL_accept_TLSv13(WOLFSSL* ssl)
 
         case TLS13_CERT_SENT :
 #if !defined(NO_CERTS) && (!defined(NO_RSA) || defined(HAVE_ECC) || \
-     defined(HAVE_ED25519) || defined(HAVE_ED448) || defined(HAVE_PQC))
+     defined(HAVE_ED25519) || defined(HAVE_ED448) || defined(HAVE_FALCON) || \
+     defined(HAVE_DILITHIUM))
             if (!ssl->options.resuming && ssl->options.sendVerify) {
                 if ((ssl->error = SendTls13CertificateVerify(ssl)) != 0) {
                     WOLFSSL_ERROR(ssl->error);
@@ -14314,7 +14595,7 @@ int wolfSSL_write_early_data(WOLFSSL* ssl, const void* data, int sz, int* outSz)
         return SIDE_ERROR;
 
     if (ssl->options.handShakeState == NULL_STATE) {
-        if (ssl->error != WC_PENDING_E)
+        if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
             ssl->earlyData = expecting_early_data;
         ret = wolfSSL_connect_TLSv13(ssl);
         if (ret != WOLFSSL_SUCCESS)
@@ -14378,7 +14659,7 @@ int wolfSSL_read_early_data(WOLFSSL* ssl, void* data, int sz, int* outSz)
         return SIDE_ERROR;
 
     if (ssl->options.handShakeState == NULL_STATE) {
-        if (ssl->error != WC_PENDING_E)
+        if (ssl->error != WC_NO_ERR_TRACE(WC_PENDING_E))
             ssl->earlyData = expecting_early_data;
         /* this used to be: ret = wolfSSL_accept_TLSv13(ssl);
          * However, wolfSSL_accept_TLSv13() expects a certificate to
@@ -14474,6 +14755,7 @@ int tls13ShowSecrets(WOLFSSL* ssl, int id, const unsigned char* secret,
 
     if (clientRandomSz <= 0) {
         printf("Error getting server random %d\n", clientRandomSz);
+        return BAD_FUNC_ARG;
     }
 
 #if 0

--- a/libatalk/ssl/src/wolfio.c
+++ b/libatalk/ssl/src/wolfio.c
@@ -78,11 +78,15 @@
             #elif !defined(DEVKITPRO) && !defined(WOLFSSL_PICOTCP) \
                     && !defined(WOLFSSL_CONTIKI) && !defined(WOLFSSL_WICED) \
                     && !defined(WOLFSSL_GNRC) && !defined(WOLFSSL_RIOT_OS)
-                #include <netdb.h>
+                #ifdef HAVE_NETDB_H
+                    #include <netdb.h>
+                #endif
                 #ifdef __PPU
                     #include <netex/errno.h>
                 #else
-                    #include <sys/ioctl.h>
+                    #ifdef HAVE_SYS_IOCTL_H
+                        #include <sys/ioctl.h>
+                    #endif
                 #endif
             #endif
         #endif
@@ -149,6 +153,11 @@ static WC_INLINE int TranslateReturnCode(int old, int sd)
         if (errno == RTCSERR_TCP_TIMED_OUT)
             errno = SOCKET_EAGAIN;
     }
+#elif defined(WOLFSSL_EMNET)
+    if (old < 0) { /* SOCKET_ERROR */
+        /* Get the real socket error */
+        IP_SOCK_getsockopt(sd, SOL_SOCKET, SO_ERROR, &old, (int)sizeof(old));
+    }
 #endif
 
     return old;
@@ -162,7 +171,7 @@ static WC_INLINE int wolfSSL_LastError(int err)
     return WSAGetLastError();
 #elif defined(EBSNET)
     return xn_getlasterror();
-#elif defined(WOLFSSL_LINUXKM)
+#elif defined(WOLFSSL_LINUXKM) || defined(WOLFSSL_EMNET)
     return err; /* Return provided error value */
 #elif defined(FUSION_RTOS)
     #include <fclerrno.h>
@@ -554,7 +563,7 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
                 start = LowResTimer();
             }
             else {
-                dtls_timeout -= LowResTimer() - start;
+                dtls_timeout -= (int) (LowResTimer() - start);
                 start = LowResTimer();
                 if (dtls_timeout < 0 || dtls_timeout > DTLS_TIMEOUT_MAX)
                     return WOLFSSL_CBIO_ERR_TIMEOUT;
@@ -604,7 +613,7 @@ int EmbedReceiveFrom(WOLFSSL *ssl, char *buf, int sz, void *ctx)
         }
 #endif /* !NO_ASN_TIME */
 
-        recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, sz, ssl->rflags,
+        recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, (size_t)sz, ssl->rflags,
             (SOCKADDR*)peer, peer != NULL ? &peerSz : NULL);
 
         /* From the RECV(2) man page
@@ -712,7 +721,7 @@ int EmbedSendTo(WOLFSSL* ssl, char *buf, int sz, void *ctx)
 #endif
     }
 
-    sent = (int)DTLS_SENDTO_FUNCTION(sd, buf, sz, ssl->wflags,
+    sent = (int)DTLS_SENDTO_FUNCTION(sd, buf, (size_t)sz, ssl->wflags,
             (const SOCKADDR*)peer, peerSz);
 
     sent = TranslateReturnCode(sent, sd);
@@ -739,7 +748,7 @@ int EmbedReceiveFromMcast(WOLFSSL *ssl, char *buf, int sz, void *ctx)
 
     WOLFSSL_ENTER("EmbedReceiveFromMcast");
 
-    recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, sz, ssl->rflags, NULL, NULL);
+    recvd = (int)DTLS_RECVFROM_FUNCTION(sd, buf, (size_t)sz, ssl->rflags, NULL, NULL);
 
     recvd = TranslateReturnCode(recvd, sd);
 
@@ -783,7 +792,7 @@ int EmbedGenerateCookie(WOLFSSL* ssl, byte *buf, int sz, void *ctx)
 
     if (sz > WC_SHA256_DIGEST_SIZE)
         sz = WC_SHA256_DIGEST_SIZE;
-    XMEMCPY(buf, digest, sz);
+    XMEMCPY(buf, digest, (size_t)sz);
 
     return sz;
 }
@@ -977,7 +986,7 @@ int wolfIO_Recv(SOCKET_T sd, char *buf, int sz, int rdFlags)
 {
     int recvd;
 
-    recvd = (int)RECV_FUNCTION(sd, buf, sz, rdFlags);
+    recvd = (int)RECV_FUNCTION(sd, buf, (size_t)sz, rdFlags);
     recvd = TranslateReturnCode(recvd, (int)sd);
 
     return recvd;
@@ -987,7 +996,7 @@ int wolfIO_Send(SOCKET_T sd, char *buf, int sz, int wrFlags)
 {
     int sent;
 
-    sent = (int)SEND_FUNCTION(sd, buf, sz, wrFlags);
+    sent = (int)SEND_FUNCTION(sd, buf, (size_t)sz, wrFlags);
     sent = TranslateReturnCode(sent, (int)sd);
 
     return sent;
@@ -1079,9 +1088,9 @@ int wolfIO_Send(SOCKET_T sd, char *buf, int sz, int wrFlags)
     }
 #endif /* HAVE_IO_TIMEOUT */
 
-static int wolfIO_Word16ToString(char* d, word16 number)
+static word32 wolfIO_Word16ToString(char* d, word16 number)
 {
-    int i = 0;
+    word32 i = 0;
     word16 order = 10000;
     word16 digit;
 
@@ -1096,7 +1105,7 @@ static int wolfIO_Word16ToString(char* d, word16 number)
             if (i > 0 || digit != 0)
                 d[i++] = (char)digit + '0';
             if (digit != 0)
-                number %= digit * order;
+                number = (word16) (number % (digit * order));
 
             order = (order > 1) ? order / 10 : 0;
         }
@@ -1111,7 +1120,7 @@ int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
 #ifdef HAVE_SOCKADDR
     int ret = 0;
     SOCKADDR_S addr;
-    int sockaddr_len;
+    socklen_t sockaddr_len;
 #if defined(HAVE_GETADDRINFO)
     /* use getaddrinfo */
     ADDRINFO hints;
@@ -1175,7 +1184,7 @@ int wolfIO_TcpConnect(SOCKET_T* sockfd, const char* ip, word16 port, int to_sec)
     }
 
     sockaddr_len = answer->ai_addrlen;
-    XMEMCPY(&addr, answer->ai_addr, sockaddr_len);
+    XMEMCPY(&addr, answer->ai_addr, (size_t)sockaddr_len);
     freeaddrinfo(answer);
 #elif defined(WOLFSSL_USE_POPEN_HOST) && !defined(WOLFSSL_IPV6)
     {
@@ -1338,7 +1347,7 @@ int wolfIO_TcpBind(SOCKET_T* sockfd, word16 port)
 #ifdef HAVE_SOCKADDR
     int ret = 0;
     SOCKADDR_S addr;
-    int sockaddr_len = sizeof(SOCKADDR_IN);
+    socklen_t sockaddr_len = sizeof(SOCKADDR_IN);
     SOCKADDR_IN *sin = (SOCKADDR_IN *)&addr;
 
     if (sockfd == NULL || port < 1) {
@@ -1469,7 +1478,7 @@ int wolfIO_DecodeUrl(const char* url, int urlSz, char* outName, char* outPath,
 
             for (j = 0; j < i; j++) {
                 if (port[j] < '0' || port[j] > '9') return -1;
-                bigPort = (bigPort * 10) + (port[j] - '0');
+                bigPort = (bigPort * 10) + (word32)(port[j] - '0');
             }
             if (outPort)
                 *outPort = (word16)bigPort;
@@ -1524,7 +1533,7 @@ static int wolfIO_HttpProcessResponseBuf(int sfd, byte **recvBuf,
         return MEMORY_E;
     }
 
-    newRecvBuf = (byte*)XMALLOC(newRecvSz, heap, dynType);
+    newRecvBuf = (byte*)XMALLOC((size_t)newRecvSz, heap, dynType);
     if (newRecvBuf == NULL) {
         WOLFSSL_MSG("wolfIO_HttpProcessResponseBuf malloc failed");
         return MEMORY_E;
@@ -1532,7 +1541,7 @@ static int wolfIO_HttpProcessResponseBuf(int sfd, byte **recvBuf,
 
     /* if buffer already exists, then we are growing it */
     if (*recvBuf) {
-        XMEMCPY(&newRecvBuf[pos], *recvBuf, *recvBufSz);
+        XMEMCPY(&newRecvBuf[pos], *recvBuf, (size_t) *recvBufSz);
         XFREE(*recvBuf, heap, dynType);
         pos += *recvBufSz;
         *recvBuf = NULL;
@@ -1541,7 +1550,7 @@ static int wolfIO_HttpProcessResponseBuf(int sfd, byte **recvBuf,
     /* copy the remainder of the httpBuf into the respBuf */
     if (len != 0) {
         if (pos + len <= newRecvSz) {
-            XMEMCPY(&newRecvBuf[pos], start, len);
+            XMEMCPY(&newRecvBuf[pos], start, (size_t)len);
             pos += len;
         }
         else {
@@ -1603,6 +1612,11 @@ int wolfIO_HttpProcessResponse(int sfd, const char** appStrList,
 
         /* read data if no \r\n or first time */
         if ((start == NULL) || (end == NULL)) {
+            if (httpBufSz < len + 1) {
+                return BUFFER_ERROR; /* can't happen, but Coverity thinks it
+                                      * can.
+                                      */
+            }
             result = wolfIO_Recv(sfd, (char*)httpBuf+len, httpBufSz-len-1, 0);
             if (result > 0) {
                 len += result;
@@ -1625,7 +1639,7 @@ int wolfIO_HttpProcessResponse(int sfd, const char** appStrList,
         /* handle incomplete rx */
         if (end == NULL) {
             if (len != 0)
-                XMEMMOVE(httpBuf, start, len);
+                XMEMMOVE(httpBuf, start, (size_t)len);
             start = end = NULL;
         }
         /* when start is "\r\n" */
@@ -1751,7 +1765,7 @@ int wolfIO_HttpBuildRequest(const char *reqType, const char *domainName,
     return wolfIO_HttpBuildRequest_ex(reqType, domainName, path, pathLen, reqSz, contentType, "", buf, bufSize);
 }
 
-    int wolfIO_HttpBuildRequest_ex(const char *reqType, const char *domainName,
+int wolfIO_HttpBuildRequest_ex(const char *reqType, const char *domainName,
                                 const char *path, int pathLen, int reqSz, const char *contentType,
                                 const char *exHdrs, byte *buf, int bufSize)
     {
@@ -1793,7 +1807,7 @@ int wolfIO_HttpBuildRequest(const char *reqType, const char *domainName,
     maxLen =
         reqTypeLen +
         blankStrLen +
-        pathLen +
+        (word32)pathLen +
         http11StrLen +
         hostStrLen +
         domainNameLen +
@@ -1804,46 +1818,46 @@ int wolfIO_HttpBuildRequest(const char *reqType, const char *domainName,
         singleCrLfStrLen +
         exHdrsLen +
         doubleCrLfStrLen +
-        1 /* null term */;
+        (word32)1 /* null term */;
     if (maxLen > (word32)bufSize)
         return 0;
 
-    XSTRNCPY((char*)buf, reqType, bufSize);
-    buf += reqTypeLen; bufSize -= reqTypeLen;
-    XSTRNCPY((char*)buf, blankStr, bufSize);
-    buf += blankStrLen; bufSize -= blankStrLen;
-    XSTRNCPY((char*)buf, path, bufSize);
-    buf += pathLen; bufSize -= pathLen;
-    XSTRNCPY((char*)buf, http11Str, bufSize);
-    buf += http11StrLen; bufSize -= http11StrLen;
+    XSTRNCPY((char*)buf, reqType, (size_t)bufSize);
+    buf += reqTypeLen; bufSize -= (int)reqTypeLen;
+    XSTRNCPY((char*)buf, blankStr, (size_t)bufSize);
+    buf += blankStrLen; bufSize -= (int)blankStrLen;
+    XSTRNCPY((char*)buf, path, (size_t)bufSize);
+    buf += pathLen; bufSize -= (int)pathLen;
+    XSTRNCPY((char*)buf, http11Str, (size_t)bufSize);
+    buf += http11StrLen; bufSize -= (int)http11StrLen;
     if (domainNameLen > 0) {
-        XSTRNCPY((char*)buf, hostStr, bufSize);
-        buf += hostStrLen; bufSize -= hostStrLen;
-        XSTRNCPY((char*)buf, domainName, bufSize);
-        buf += domainNameLen; bufSize -= domainNameLen;
+        XSTRNCPY((char*)buf, hostStr, (size_t)bufSize);
+        buf += hostStrLen; bufSize -= (int)hostStrLen;
+        XSTRNCPY((char*)buf, domainName, (size_t)bufSize);
+        buf += domainNameLen; bufSize -= (int)domainNameLen;
     }
     if (reqSz > 0 && reqSzStrLen > 0) {
-        XSTRNCPY((char*)buf, contentLenStr, bufSize);
-        buf += contentLenStrLen; bufSize -= contentLenStrLen;
-        XSTRNCPY((char*)buf, reqSzStr, bufSize);
-        buf += reqSzStrLen; bufSize -= reqSzStrLen;
+        XSTRNCPY((char*)buf, contentLenStr, (size_t)bufSize);
+        buf += contentLenStrLen; bufSize -= (int)contentLenStrLen;
+        XSTRNCPY((char*)buf, reqSzStr, (size_t)bufSize);
+        buf += reqSzStrLen; bufSize -= (int)reqSzStrLen;
     }
     if (contentTypeLen > 0) {
-        XSTRNCPY((char*)buf, contentTypeStr, bufSize);
-        buf += contentTypeStrLen; bufSize -= contentTypeStrLen;
-        XSTRNCPY((char*)buf, contentType, bufSize);
-        buf += contentTypeLen; bufSize -= contentTypeLen;
+        XSTRNCPY((char*)buf, contentTypeStr, (size_t)bufSize);
+        buf += contentTypeStrLen; bufSize -= (int)contentTypeStrLen;
+        XSTRNCPY((char*)buf, contentType, (size_t)bufSize);
+        buf += contentTypeLen; bufSize -= (int)contentTypeLen;
     }
     if (exHdrsLen > 0)
     {
-        XSTRNCPY((char *)buf, singleCrLfStr, bufSize);
+        XSTRNCPY((char *)buf, singleCrLfStr, (size_t)bufSize);
         buf += singleCrLfStrLen;
-        bufSize -= singleCrLfStrLen;
-        XSTRNCPY((char *)buf, exHdrs, bufSize);
+        bufSize -= (int)singleCrLfStrLen;
+        XSTRNCPY((char *)buf, exHdrs, (size_t)bufSize);
         buf += exHdrsLen;
-        bufSize -= exHdrsLen;
+        bufSize -= (int)exHdrsLen;
     }
-    XSTRNCPY((char*)buf, doubleCrLfStr, bufSize);
+    XSTRNCPY((char*)buf, doubleCrLfStr, (size_t)bufSize);
     buf += doubleCrLfStrLen;
 
 #ifdef WOLFIO_DEBUG
@@ -1920,7 +1934,7 @@ int EmbedOcspLookup(void* ctx, const char* url, int urlSz,
         /* Note, the library uses the EmbedOcspRespFree() callback to
          * free this buffer. */
         int   httpBufSz = HTTP_SCRATCH_BUFFER_SIZE;
-        byte* httpBuf   = (byte*)XMALLOC(httpBufSz, ctx, DYNAMIC_TYPE_OCSP);
+        byte* httpBuf   = (byte*)XMALLOC((size_t)httpBufSz, ctx, DYNAMIC_TYPE_OCSP);
 
         if (httpBuf == NULL) {
             WOLFSSL_MSG("Unable to create OCSP response buffer");
@@ -2027,7 +2041,7 @@ int EmbedCrlLookup(WOLFSSL_CRL* crl, const char* url, int urlSz)
     }
     else {
         int   httpBufSz = HTTP_SCRATCH_BUFFER_SIZE;
-        byte* httpBuf   = (byte*)XMALLOC(httpBufSz, crl->heap,
+        byte* httpBuf   = (byte*)XMALLOC((size_t)httpBufSz, crl->heap,
                                                               DYNAMIC_TYPE_CRL);
         if (httpBuf == NULL) {
             WOLFSSL_MSG("Unable to create CRL response buffer");

--- a/libatalk/ssl/src/x509.c
+++ b/libatalk/ssl/src/x509.c
@@ -177,19 +177,19 @@ int wolfSSL_X509_get_ext_count(const WOLFSSL_X509* passedCert)
             goto out;
         }
 
-        if (GetLength(input, &idx, &length, sz) < 0) {
+        if (GetLength(input, &idx, &length, (word32)sz) < 0) {
             WOLFSSL_MSG("\tfail: invalid length");
             goto out;
         }
     }
 
-    if (GetSequence(input, &idx, &length, sz) < 0) {
+    if (GetSequence(input, &idx, &length, (word32)sz) < 0) {
         WOLFSSL_MSG("\tfail: should be a SEQUENCE (1)");
         goto out;
     }
 
     while (idx < (word32)sz) {
-        if (GetSequence(input, &idx, &length, sz) < 0) {
+        if (GetSequence(input, &idx, &length, (word32)sz) < 0) {
             WOLFSSL_MSG("\tfail: should be a SEQUENCE");
             FreeDecodedCert(cert);
             return WOLFSSL_FAILURE;
@@ -643,7 +643,7 @@ static int wolfssl_dns_entry_othername_to_gn(DNS_entry* dns,
         wolfSSL_ASN1_OBJECT_free(obj);
         goto err;
     }
-    wolfSSL_ASN1_STRING_set(str, p, (word32)len);
+    wolfSSL_ASN1_STRING_set(str, p, (int)len);
 
     /* Wrap string in a WOLFSSL_ASN1_TYPE. */
     type = wolfSSL_ASN1_TYPE_new();
@@ -839,7 +839,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
             return NULL;
         }
 
-        if (GetLength(input, &idx, &length, sz) < 0) {
+        if (GetLength(input, &idx, &length, (word32)sz) < 0) {
             WOLFSSL_MSG("\tfail: invalid length");
             wolfSSL_X509_EXTENSION_free(ext);
             FreeDecodedCert(cert);
@@ -850,7 +850,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
         }
     }
 
-    if (GetSequence(input, &idx, &length, sz) < 0) {
+    if (GetSequence(input, &idx, &length, (word32)sz) < 0) {
         WOLFSSL_MSG("\tfail: should be a SEQUENCE (1)");
         wolfSSL_X509_EXTENSION_free(ext);
         FreeDecodedCert(cert);
@@ -863,7 +863,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
     while (idx < (word32)sz) {
         oid = 0;
 
-        if (GetSequence(input, &idx, &length, sz) < 0) {
+        if (GetSequence(input, &idx, &length, (word32)sz) < 0) {
             WOLFSSL_MSG("\tfail: should be a SEQUENCE");
             wolfSSL_X509_EXTENSION_free(ext);
             FreeDecodedCert(cert);
@@ -874,7 +874,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
         }
 
         tmpIdx = idx;
-        ret = GetObjectId(input, &idx, &oid, oidCertExtType, sz);
+        ret = GetObjectId(input, &idx, &oid, oidCertExtType, (word32)sz);
         if (ret < 0) {
             WOLFSSL_MSG("\tfail: OBJECT ID");
             wolfSSL_X509_EXTENSION_free(ext);
@@ -895,11 +895,11 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
         }
         /* extCount == loc. Now get the extension. */
         /* Check if extension has been set */
-        isSet = wolfSSL_X509_ext_isSet_by_NID((WOLFSSL_X509*)x509, nid);
+        isSet = wolfSSL_X509_ext_isSet_by_NID((WOLFSSL_X509*)x509, (int)nid);
 
-        if (wolfSSL_OBJ_nid2ln(nid) != NULL) {
+        if (wolfSSL_OBJ_nid2ln((int)nid) != NULL) {
             /* This is NOT an unknown OID. */
-            ext->obj = wolfSSL_OBJ_nid2obj(nid);
+            ext->obj = wolfSSL_OBJ_nid2obj((int)nid);
             if (ext->obj == NULL) {
                 WOLFSSL_MSG("\tfail: Invalid OBJECT");
                 wolfSSL_X509_EXTENSION_free(ext);
@@ -912,7 +912,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
         }
 
         if (ext->obj) {
-            ext->obj->nid = nid;
+            ext->obj->nid = (int)nid;
         }
 
         switch (oid) {
@@ -929,7 +929,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
                 #endif
                     return NULL;
                 }
-                a->length = x509->pathLength;
+                a->length = (int)x509->pathLength;
 
                 /* Save ASN1_INTEGER in x509 extension */
                 ext->obj->pathlen = a;
@@ -972,7 +972,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
                         return NULL;
                     }
                     obj->obj = (byte*)x509->authInfoCaIssuer;
-                    obj->objSz = x509->authInfoCaIssuerSz;
+                    obj->objSz = (unsigned int)x509->authInfoCaIssuerSz;
                     obj->grp = oidCertAuthInfoType;
                     obj->nid = NID_ad_ca_issuers;
 
@@ -1007,7 +1007,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
                         return NULL;
                     }
                     obj->obj = x509->authInfo;
-                    obj->objSz = x509->authInfoSz;
+                    obj->objSz = (unsigned int)x509->authInfoSz;
                     obj->grp = oidCertAuthInfoType;
                     obj->nid = NID_ad_OCSP;
 
@@ -1132,7 +1132,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
                  *  parsed oid for access in later function calls */
 
                 /* Get OID from input */
-                if (GetASNObjectId(input, &idx, &length, sz) != 0) {
+                if (GetASNObjectId(input, &idx, &length, (word32)sz) != 0) {
                     WOLFSSL_MSG("Failed to Get ASN Object Id");
                     wolfSSL_X509_EXTENSION_free(ext);
                     FreeDecodedCert(cert);
@@ -1171,7 +1171,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
                     }
                 }
 
-                ext->obj->objSz = objSz;
+                ext->obj->objSz = (unsigned int)objSz;
                 if(((ext->obj->dynamic & WOLFSSL_ASN1_DYNAMIC_DATA) != 0) ||
                    (ext->obj->obj == NULL)) {
                         ext->obj->obj =(byte*)XREALLOC((byte*)ext->obj->obj,
@@ -1215,7 +1215,7 @@ WOLFSSL_X509_EXTENSION* wolfSSL_X509_set_ext(WOLFSSL_X509* x509, int loc)
 
                 tmpIdx++;
 
-                if (GetLength(input, &tmpIdx, &length, sz) <= 0) {
+                if (GetLength(input, &tmpIdx, &length, (word32)sz) <= 0) {
                     WOLFSSL_MSG("Error: Invalid Input Length.");
                     wolfSSL_ASN1_OBJECT_free(ext->obj);
                     wolfSSL_X509_EXTENSION_free(ext);
@@ -1283,7 +1283,7 @@ static int asn1_string_copy_to_buffer(WOLFSSL_ASN1_STRING* str, byte** buf,
             WOLFSSL_MSG("malloc error");
             return WOLFSSL_FAILURE;
         }
-        *len = str->length;
+        *len = (word32)str->length;
         XMEMCPY(*buf, str->data, str->length);
     }
 
@@ -1418,7 +1418,7 @@ int wolfSSL_X509_add_ext(WOLFSSL_X509 *x509, WOLFSSL_X509_EXTENSION *ext, int lo
             x509->isCa = (byte)ext->obj->ca;
             x509->basicConstCrit = (byte)ext->crit;
             if (ext->obj->pathlen)
-                x509->pathLength = ext->obj->pathlen->length;
+                x509->pathLength = (word32)ext->obj->pathlen->length;
             x509->basicConstSet = 1;
         }
         break;
@@ -1545,7 +1545,7 @@ int wolfSSL_X509V3_EXT_print(WOLFSSL_BIO *out, WOLFSSL_X509_EXTENSION *ext,
                         WOLFSSL_MSG("Memory error");
                         return rc;
                     }
-                    valLen = XSNPRINTF(val, len, "%*s%s", indent, "",
+                    valLen = XSNPRINTF(val, (size_t)len, "%*s%s", indent, "",
                             str->strData);
                     if ((valLen < 0) || (valLen >= len)
                             || ((tmpLen + valLen) >= tmpSz)) {
@@ -2108,13 +2108,13 @@ int wolfSSL_X509_get_ext_by_NID(const WOLFSSL_X509* x509, int nid, int lastPos)
             goto out;
         }
 
-        if (GetLength(input, &idx, &length, sz) < 0) {
+        if (GetLength(input, &idx, &length, (word32)sz) < 0) {
             WOLFSSL_MSG("\tfail: invalid length");
             goto out;
         }
     }
 
-    if (GetSequence(input, &idx, &length, sz) < 0) {
+    if (GetSequence(input, &idx, &length, (word32)sz) < 0) {
         WOLFSSL_MSG("\tfail: should be a SEQUENCE (1)");
         goto out;
     }
@@ -2122,13 +2122,13 @@ int wolfSSL_X509_get_ext_by_NID(const WOLFSSL_X509* x509, int nid, int lastPos)
     while (idx < (word32)sz) {
         oid = 0;
 
-        if (GetSequence(input, &idx, &length, sz) < 0) {
+        if (GetSequence(input, &idx, &length, (word32)sz) < 0) {
             WOLFSSL_MSG("\tfail: should be a SEQUENCE");
             goto out;
         }
 
         tmpIdx = idx;
-        ret = GetObjectId(input, &idx, &oid, oidCertExtType, sz);
+        ret = GetObjectId(input, &idx, &oid, oidCertExtType, (word32)sz);
         if (ret < 0) {
             WOLFSSL_MSG("\tfail: OBJECT ID");
             goto out;
@@ -2138,7 +2138,7 @@ int wolfSSL_X509_get_ext_by_NID(const WOLFSSL_X509* x509, int nid, int lastPos)
 
         if (extCount >= loc) {
             /* extCount >= loc. Now check if extension has been set */
-            isSet = wolfSSL_X509_ext_isSet_by_NID((WOLFSSL_X509*)x509, foundNID);
+            isSet = wolfSSL_X509_ext_isSet_by_NID((WOLFSSL_X509*)x509, (int)foundNID);
 
             if (isSet && ((word32)nid == foundNID)) {
                 found = 1;
@@ -2218,7 +2218,7 @@ void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509, int nid, int* c,
                     wolfSSL_BASIC_CONSTRAINTS_free(bc);
                     return NULL;
                 }
-                a->length = x509->pathLength;
+                a->length = (int)x509->pathLength;
 
 #if defined(OPENSSL_ALL) || defined(WOLFSSL_QT) || \
         defined(WOLFSSL_APACHE_HTTPD)
@@ -2395,7 +2395,7 @@ void* wolfSSL_X509_get_ext_d2i(const WOLFSSL_X509* x509, int nid, int* c,
                 obj->type  = AUTH_INFO_OID;
                 obj->grp   = oidCertExtType;
                 obj->obj   = x509->authInfo;
-                obj->objSz = x509->authInfoSz;
+                obj->objSz = (unsigned int)x509->authInfoSz;
             }
             else {
                 WOLFSSL_MSG("No Auth Info set");
@@ -2684,7 +2684,7 @@ int wolfSSL_X509_add_altname_ex(WOLFSSL_X509* x509, const char* name,
 
     newAltName->next = x509->altNames;
     newAltName->type = type;
-    newAltName->len = nameSz;
+    newAltName->len = (int)nameSz;
     newAltName->name = nameCopy;
     x509->altNames = newAltName;
 
@@ -3296,7 +3296,7 @@ char* wolfSSL_X509_NAME_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
         return NULL;
     }
 
-    copySz = min(sz, name->sz);
+    copySz = (int)min((word32)sz, (word32)name->sz);
 
     WOLFSSL_ENTER("wolfSSL_X509_NAME_oneline");
     if (!name->sz) return in;
@@ -3362,7 +3362,7 @@ static unsigned long X509NameHash(WOLFSSL_X509_NAME* name,
                 ((unsigned long)digest[1] <<  8) |
                 ((unsigned long)digest[0]));
     }
-    else if (rc == HASH_TYPE_E) {
+    else if (rc == WC_NO_ERR_TRACE(HASH_TYPE_E)) {
         WOLFSSL_ERROR_MSG("Hash function not compiled in");
     }
     else {
@@ -3500,7 +3500,7 @@ char* wolfSSL_X509_get_name_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
                 WOLFSSL_MSG("Memory error");
                 return NULL;
             }
-            if ((strLen = XSNPRINTF(str, strSz, "%s=%s, ", sn, buf))
+            if ((strLen = XSNPRINTF(str, (size_t)strSz, "%s=%s, ", sn, buf))
                 >= strSz)
             {
                 WOLFSSL_MSG("buffer overrun");
@@ -3518,7 +3518,7 @@ char* wolfSSL_X509_get_name_oneline(WOLFSSL_X509_NAME* name, char* in, int sz)
                 WOLFSSL_MSG("Memory error");
                 return NULL;
             }
-            if ((strLen = XSNPRINTF(str, strSz, "%s=%s", sn, buf)) >= strSz) {
+            if ((strLen = XSNPRINTF(str, (size_t)strSz, "%s=%s", sn, buf)) >= strSz) {
                 WOLFSSL_MSG("buffer overrun");
                 XFREE(str, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 return NULL;
@@ -3608,11 +3608,11 @@ static WOLFSSL_X509* d2i_X509orX509REQ(WOLFSSL_X509** x509,
             return NULL;
     #endif
 
-        InitDecodedCert(cert, (byte*)in, len, heap);
+        InitDecodedCert(cert, (byte*)in, (word32)len, heap);
     #ifdef WOLFSSL_CERT_REQ
         cert->isCSR = (byte)req;
     #endif
-        if (ParseCertRelative(cert, type, 0, NULL) == 0) {
+        if (ParseCertRelative(cert, type, 0, NULL, NULL) == 0) {
             newX509 = wolfSSL_X509_new_ex(heap);
             if (newX509 != NULL) {
                 if (CopyDecodedToX509(newX509, cert) != 0) {
@@ -3732,7 +3732,7 @@ int wolfSSL_X509_get_signature(WOLFSSL_X509* x509,
 
     if (buf != NULL)
         XMEMCPY(buf, x509->sig.buffer, x509->sig.length);
-    *bufSz = x509->sig.length;
+    *bufSz = (int)x509->sig.length;
 
     return WOLFSSL_SUCCESS;
 }
@@ -3780,7 +3780,7 @@ int wolfSSL_X509_get_pubkey_buffer(WOLFSSL_X509* x509,
 
     der = wolfSSL_X509_get_der(x509, &derSz);
     if (der != NULL) {
-        InitDecodedCert(cert, der, derSz, NULL);
+        InitDecodedCert(cert, der, (word32)derSz, NULL);
         ret = wc_GetPubX509(cert, 0, &badDate);
         if (ret >= 0) {
             word32 idx = cert->srcIdx;
@@ -3938,12 +3938,12 @@ const unsigned char* wolfSSL_X509_get_tbs(WOLFSSL_X509* x509, int* outSz)
         return NULL;
     }
 
-    if (GetSequence(der, &idx, &len, sz) < 0) {
+    if (GetSequence(der, &idx, &len, (word32)sz) < 0) {
         return NULL;
     }
     tbs = der + idx;
     tmpIdx = idx;
-    if (GetSequence(der, &idx, &len, sz) < 0) {
+    if (GetSequence(der, &idx, &len, (word32)sz) < 0) {
         return NULL;
     }
     *outSz = len + (idx - tmpIdx);
@@ -5119,7 +5119,7 @@ WOLFSSL_X509* wolfSSL_X509_d2i_fp(WOLFSSL_X509** x509, XFILE file)
 
         fileBuffer = (byte*)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE);
         if (fileBuffer != NULL) {
-            int ret = (int)XFREAD(fileBuffer, 1, sz, file);
+            int ret = (int)XFREAD(fileBuffer, 1, (size_t)sz, file);
             if (ret == sz) {
                 newX509 = wolfSSL_X509_d2i(NULL, fileBuffer, (int)sz);
             }
@@ -5189,7 +5189,7 @@ WOLFSSL_X509* wolfSSL_X509_load_certificate_file(const char* fname, int format)
         dynamic = 1;
     }
 
-    ret = (int)XFREAD(fileBuffer, 1, sz, file);
+    ret = (int)XFREAD(fileBuffer, 1, (size_t)sz, file);
     if (ret != sz) {
         XFCLOSE(file);
         if (dynamic)
@@ -5254,7 +5254,7 @@ static WOLFSSL_X509* loadX509orX509REQFromBuffer(
     #endif
         {
             InitDecodedCert(cert, der->buffer, der->length, NULL);
-            ret = ParseCertRelative(cert, type, 0, NULL);
+            ret = ParseCertRelative(cert, type, 0, NULL, NULL);
             if (ret == 0) {
                 x509 = (WOLFSSL_X509*)XMALLOC(sizeof(WOLFSSL_X509), NULL,
                                                              DYNAMIC_TYPE_X509);
@@ -5451,7 +5451,7 @@ int wolfSSL_X509_NAME_get_text_by_NID(WOLFSSL_X509_NAME* name,
 
     /* buf is not NULL from above */
     if (text != NULL) {
-        textSz = min(textSz + 1, len); /* + 1 to account for null char */
+        textSz = (int)min((word32)textSz + 1, (word32)len); /* + 1 to account for null char */
         if (textSz > 0) {
             XMEMCPY(buf, text, textSz - 1);
             buf[textSz - 1] = '\0';
@@ -5495,7 +5495,7 @@ WOLFSSL_EVP_PKEY* wolfSSL_X509_get_pubkey(WOLFSSL_X509* x509)
                 return NULL;
             }
             XMEMCPY(key->pkey.ptr, x509->pubKey.buffer, x509->pubKey.length);
-            key->pkey_sz = x509->pubKey.length;
+            key->pkey_sz = (int)x509->pubKey.length;
 
             #ifdef HAVE_ECC
                 key->pkey_curve = (int)x509->pkCurveOID;
@@ -5735,8 +5735,8 @@ int wolfSSL_X509_cmp(const WOLFSSL_X509 *a, const WOLFSSL_X509 *b)
 
         if (x509 != NULL) {
             if (x509->authKeyIdSet) {
-                copySz = min(dstLen != NULL ? *dstLen : 0,
-                             (int)x509->authKeyIdSz);
+                copySz = (int)min(dstLen != NULL ? (word32)*dstLen : 0,
+                                  x509->authKeyIdSz);
                 id = x509->authKeyId;
             }
 
@@ -5762,8 +5762,8 @@ int wolfSSL_X509_cmp(const WOLFSSL_X509 *a, const WOLFSSL_X509 *b)
 
         if (x509 != NULL) {
             if (x509->subjKeyIdSet) {
-                copySz = min(dstLen != NULL ? *dstLen : 0,
-                                                        (int)x509->subjKeyIdSz);
+                copySz = (int)min(dstLen != NULL ? (word32) *dstLen : 0,
+                                  x509->subjKeyIdSz);
                 id = x509->subjKeyId;
             }
 
@@ -7079,7 +7079,7 @@ void wolfSSL_X509_get0_signature(const WOLFSSL_ASN1_BIT_STRING **psig,
 #if defined(OPENSSL_EXTRA) || defined(WOLFSSL_WPAS_SMALL)
 const char* wolfSSL_X509_verify_cert_error_string(long err)
 {
-    return wolfSSL_ERR_reason_error_string(err);
+    return wolfSSL_ERR_reason_error_string((unsigned long)err);
 }
 #endif /* OPENSSL_EXTRA || WOLFSSL_WPAS_SMALL */
 
@@ -7526,10 +7526,23 @@ int wolfSSL_i2d_X509(WOLFSSL_X509* x509, unsigned char** out)
 int wc_GeneratePreTBS(DecodedCert* cert, byte *der, int derSz) {
     int ret = 0;
     WOLFSSL_X509 *x = NULL;
+    byte certOwnsAltNames = 0;
+    byte certIsCSR = 0;
 
     if ((cert == NULL) || (der == NULL) || (derSz <= 0)) {
         return BAD_FUNC_ARG;
     }
+
+    /* The call to CopyDecodedToX509() transfers ownership of the altNames in
+     * the DecodedCert to the temporary X509 object, causing the list to be
+     * freed in wolfSSL_X509_free(). As this is an unintended side-effect, we
+     * have to save the ownerFlag here and transfer ownership back to the
+     * DecodedCert prior to freeing the X509 object. */
+    certOwnsAltNames = cert->weOwnAltNames;
+
+#ifdef WOLFSSL_CERT_REQ
+    certIsCSR = cert->isCSR;
+#endif
 
     x = wolfSSL_X509_new();
     if (x == NULL) {
@@ -7539,21 +7552,27 @@ int wc_GeneratePreTBS(DecodedCert* cert, byte *der, int derSz) {
         ret = CopyDecodedToX509(x, cert);
     }
 
+    /* CopyDecodedToX509() clears cert->weOwnAltNames. Restore it. */
+    cert->weOwnAltNames = certOwnsAltNames;
+
     if (ret == 0) {
         /* Remove the altsigval extension. */
         XFREE(x->altSigValDer, x->heap, DYNAMIC_TYPE_X509_EXT);
         x->altSigValDer = NULL;
-        x->altSigValDer = 0;
+        x->altSigValLen = 0;
         /* Remove sigOID so it won't be encoded. */
         x->sigOID = 0;
         /* We now have a PreTBS. Encode it. */
-        ret = wolfssl_x509_make_der(x, 0, der, &derSz, 0);
+        ret = wolfssl_x509_make_der(x, certIsCSR, der, &derSz, 0);
         if (ret == WOLFSSL_SUCCESS) {
             ret = derSz;
         }
     }
 
     if (x != NULL) {
+        /* Safe the altNames list from being freed unitentionally. */
+        x->altNames = NULL;
+
         wolfSSL_X509_free(x);
     }
 
@@ -7683,11 +7702,11 @@ static int verifyX509orX509REQ(WOLFSSL_X509* x509, WOLFSSL_EVP_PKEY* pkey, int r
 
 #ifdef WOLFSSL_CERT_REQ
     if (req)
-        ret = CheckCSRSignaturePubKey(der, derSz, x509->heap,
+        ret = CheckCSRSignaturePubKey(der, (word32)derSz, x509->heap,
                 (unsigned char*)pkey->pkey.ptr, pkey->pkey_sz, type);
     else
 #endif
-        ret = CheckCertSignaturePubKey(der, derSz, x509->heap,
+        ret = CheckCertSignaturePubKey(der, (word32)derSz, x509->heap,
                 (unsigned char*)pkey->pkey.ptr, pkey->pkey_sz, type);
     if (ret == 0) {
         return WOLFSSL_SUCCESS;
@@ -7739,7 +7758,7 @@ static void *wolfSSL_d2i_X509_fp_ex(XFILE file, void **x509, int type)
 
     fileBuffer = (byte *)XMALLOC(sz, NULL, DYNAMIC_TYPE_FILE);
     if (fileBuffer != NULL) {
-        if ((long)XFREAD(fileBuffer, 1, sz, file) != sz) {
+        if ((long)XFREAD(fileBuffer, 1, (size_t)sz, file) != sz) {
             WOLFSSL_MSG("File read failed");
             goto err_exit;
         }
@@ -7761,7 +7780,7 @@ static void *wolfSSL_d2i_X509_fp_ex(XFILE file, void **x509, int type)
             if ((newx509 = wc_PKCS12_new()) == NULL) {
                 goto err_exit;
             }
-            if (wc_d2i_PKCS12(fileBuffer, (int)sz, (WC_PKCS12*)newx509) < 0) {
+            if (wc_d2i_PKCS12(fileBuffer, (word32)sz, (WC_PKCS12*)newx509) < 0) {
                 goto err_exit;
             }
         }
@@ -8217,7 +8236,8 @@ int wolfSSL_X509_CRL_get_signature(WOLFSSL_X509_CRL* crl,
 {
     WOLFSSL_ENTER("wolfSSL_X509_CRL_get_signature");
 
-    if (crl == NULL || crl->crlList == NULL || bufSz == NULL)
+    if (crl == NULL || crl->crlList == NULL ||
+        crl->crlList->signature == NULL || bufSz == NULL)
         return BAD_FUNC_ARG;
 
     if (buf != NULL)
@@ -8408,7 +8428,7 @@ static int X509CRLPrintExtensions(WOLFSSL_BIO* bio, WOLFSSL_X509_CRL* crl,
                 }
                 tmp[0] = '\0';
             }
-            if (XSNPRINTF(val, valSz, ":%02X", crl->crlList->extAuthKeyId[i])
+            if (XSNPRINTF(val, (size_t)valSz, ":%02X", crl->crlList->extAuthKeyId[i])
                 >= valSz)
             {
                 WOLFSSL_MSG("buffer overrun");
@@ -8794,7 +8814,7 @@ static int wolfSSL_X509_VERIFY_PARAM_inherit(WOLFSSL_X509_VERIFY_PARAM *to,
     if (isOverWrite ||
         (from->hostName[0] != 0 && (to->hostName[0] == 0 || isDefault))) {
             if (!(ret = wolfSSL_X509_VERIFY_PARAM_set1_host(to, from->hostName,
-                (int)XSTRLEN(from->hostName))))
+                (unsigned int)XSTRLEN(from->hostName))))
                 return ret;
         to->hostFlags = from->hostFlags;
     }
@@ -9196,7 +9216,7 @@ WOLFSSL_ASN1_INTEGER* wolfSSL_X509_get_serialNumber(WOLFSSL_X509* x509)
             wolfSSL_ASN1_INTEGER_free(a);
             return NULL;
         }
-        a->dataMax   = x509->serialSz + 2;
+        a->dataMax   = (unsigned int)x509->serialSz + 2;
         a->isDynamic = 1;
     } else {
         /* Use array instead of dynamic memory */
@@ -9722,7 +9742,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
 
         if (ret > 0) {
             /* strip off sequence, this gets added on certificate creation */
-            ret = GetSequence(der, &idx, &length, ret);
+            ret = GetSequence(der, &idx, &length, (word32)ret);
         }
 
         if (ret > 0) {
@@ -9765,7 +9785,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
     #ifdef WOLFSSL_CERT_EXT
             if (req->subjKeyIdSz != 0) {
                 XMEMCPY(cert->skid, req->subjKeyId, req->subjKeyIdSz);
-                cert->skidSz = req->subjKeyIdSz;
+                cert->skidSz = (int)req->subjKeyIdSz;
             }
             if (req->keyUsageSet)
                 cert->keyUsage = req->keyUsage;
@@ -9847,7 +9867,7 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
         }
 
         out[0] = (byte) t->type;
-        sz = SetLength(t->length, out + 1) + 1;  /* gen tag */
+        sz = (int)SetLength((word32)t->length, out + 1) + 1;  /* gen tag */
         for (i = 0; i < t->length; i++) {
             out[sz + i] = t->data[i];
         }
@@ -10172,6 +10192,15 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
     #ifndef NO_DSA
         DsaKey* dsa = NULL;
     #endif
+    #if defined(HAVE_FALCON)
+        falcon_key* falcon = NULL;
+    #endif
+    #if defined(HAVE_DILITHIUM)
+        dilithium_key* dilithium = NULL;
+    #endif
+    #if defined(HAVE_SPHINCS)
+        sphincs_key* sphincs = NULL;
+    #endif
         WC_RNG rng;
         word32 idx = 0;
 
@@ -10298,6 +10327,148 @@ WOLF_STACK_OF(WOLFSSL_X509)* wolfSSL_X509_chain_up_ref(
             key = (void*)dsa;
         }
     #endif
+    #if defined(HAVE_FALCON)
+        if ((x509->pubKeyOID == FALCON_LEVEL1k) ||
+            (x509->pubKeyOID == FALCON_LEVEL5k)) {
+            falcon = (falcon_key*)XMALLOC(sizeof(falcon_key), NULL,
+                                          DYNAMIC_TYPE_FALCON);
+            if (falcon == NULL) {
+                WOLFSSL_MSG("Failed to allocate memory for falcon_key");
+                XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
+                return WOLFSSL_FAILURE;
+            }
+
+            ret = wc_falcon_init(falcon);
+            if (ret != 0) {
+                XFREE(falcon, NULL, DYNAMIC_TYPE_FALCON);
+                XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
+                return ret;
+            }
+
+            if (x509->pubKeyOID == FALCON_LEVEL1k) {
+                type = FALCON_LEVEL1_TYPE;
+                wc_falcon_set_level(falcon, 1);
+            }
+            else if (x509->pubKeyOID == FALCON_LEVEL5k) {
+                type = FALCON_LEVEL5_TYPE;
+                wc_falcon_set_level(falcon, 5);
+            }
+
+            ret = wc_Falcon_PublicKeyDecode(x509->pubKey.buffer, &idx, falcon,
+                                            x509->pubKey.length);
+            if (ret != 0) {
+                WOLFSSL_ERROR_VERBOSE(ret);
+                wc_falcon_free(falcon);
+                XFREE(falcon, NULL, DYNAMIC_TYPE_FALCON);
+                XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
+                return ret;
+            }
+            key = (void*)falcon;
+        }
+    #endif
+    #if defined(HAVE_DILITHIUM)
+        if ((x509->pubKeyOID == DILITHIUM_LEVEL2k) ||
+            (x509->pubKeyOID == DILITHIUM_LEVEL3k) ||
+            (x509->pubKeyOID == DILITHIUM_LEVEL5k)) {
+            dilithium = (dilithium_key*)XMALLOC(sizeof(dilithium_key), NULL,
+                                          DYNAMIC_TYPE_DILITHIUM);
+            if (dilithium == NULL) {
+                WOLFSSL_MSG("Failed to allocate memory for dilithium_key");
+                XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
+                return WOLFSSL_FAILURE;
+            }
+
+            ret = wc_dilithium_init(dilithium);
+            if (ret != 0) {
+                XFREE(dilithium, NULL, DYNAMIC_TYPE_DILITHIUM);
+                XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
+                return ret;
+            }
+
+            if (x509->pubKeyOID == DILITHIUM_LEVEL2k) {
+                type = DILITHIUM_LEVEL2_TYPE;
+                wc_dilithium_set_level(dilithium, 2);
+            }
+            else if (x509->pubKeyOID == DILITHIUM_LEVEL3k) {
+                type = DILITHIUM_LEVEL3_TYPE;
+                wc_dilithium_set_level(dilithium, 3);
+            }
+            else if (x509->pubKeyOID == DILITHIUM_LEVEL5k) {
+                type = DILITHIUM_LEVEL5_TYPE;
+                wc_dilithium_set_level(dilithium, 5);
+            }
+
+            ret = wc_Dilithium_PublicKeyDecode(x509->pubKey.buffer, &idx,
+                                    dilithium, x509->pubKey.length);
+            if (ret != 0) {
+                WOLFSSL_ERROR_VERBOSE(ret);
+                wc_dilithium_free(dilithium);
+                XFREE(dilithium, NULL, DYNAMIC_TYPE_DILITHIUM);
+                XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
+                return ret;
+            }
+            key = (void*)dilithium;
+        }
+    #endif
+    #if defined(HAVE_SPHINCS)
+        if ((x509->pubKeyOID == SPHINCS_FAST_LEVEL1k) ||
+            (x509->pubKeyOID == SPHINCS_FAST_LEVEL3k) ||
+            (x509->pubKeyOID == SPHINCS_FAST_LEVEL5k) ||
+            (x509->pubKeyOID == SPHINCS_SMALL_LEVEL1k) ||
+            (x509->pubKeyOID == SPHINCS_SMALL_LEVEL3k) ||
+            (x509->pubKeyOID == SPHINCS_SMALL_LEVEL5k)) {
+            sphincs = (sphincs_key*)XMALLOC(sizeof(sphincs_key), NULL,
+                                          DYNAMIC_TYPE_SPHINCS);
+            if (sphincs == NULL) {
+                WOLFSSL_MSG("Failed to allocate memory for sphincs_key");
+                XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
+                return WOLFSSL_FAILURE;
+            }
+
+            ret = wc_sphincs_init(sphincs);
+            if (ret != 0) {
+                XFREE(sphincs, NULL, DYNAMIC_TYPE_SPHINCS);
+                XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
+                return ret;
+            }
+
+            if (x509->pubKeyOID == SPHINCS_FAST_LEVEL1k) {
+                type = SPHINCS_FAST_LEVEL1_TYPE;
+                wc_sphincs_set_level_and_optim(sphincs, 1, FAST_VARIANT);
+            }
+            else if (x509->pubKeyOID == SPHINCS_FAST_LEVEL3k) {
+                type = SPHINCS_FAST_LEVEL3_TYPE;
+                wc_sphincs_set_level_and_optim(sphincs, 3, FAST_VARIANT);
+            }
+            else if (x509->pubKeyOID == SPHINCS_FAST_LEVEL3k) {
+                type = SPHINCS_FAST_LEVEL5_TYPE;
+                wc_sphincs_set_level_and_optim(sphincs, 5, FAST_VARIANT);
+            }
+            else if (x509->pubKeyOID == SPHINCS_SMALL_LEVEL1k) {
+                type = SPHINCS_SMALL_LEVEL1_TYPE;
+                wc_sphincs_set_level_and_optim(sphincs, 1, SMALL_VARIANT);
+            }
+            else if (x509->pubKeyOID == SPHINCS_SMALL_LEVEL3k) {
+                type = SPHINCS_SMALL_LEVEL3_TYPE;
+                wc_sphincs_set_level_and_optim(sphincs, 3, SMALL_VARIANT);
+            }
+            else if (x509->pubKeyOID == SPHINCS_SMALL_LEVEL3k) {
+                type = SPHINCS_SMALL_LEVEL5_TYPE;
+                wc_sphincs_set_level_and_optim(sphincs, 5, SMALL_VARIANT);
+            }
+
+            ret = wc_Sphincs_PublicKeyDecode(x509->pubKey.buffer, &idx, sphincs,
+                                             x509->pubKey.length);
+            if (ret != 0) {
+                WOLFSSL_ERROR_VERBOSE(ret);
+                wc_sphincs_free(sphincs);
+                XFREE(sphincs, NULL, DYNAMIC_TYPE_SPHINCS);
+                XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
+                return ret;
+            }
+            key = (void*)sphincs;
+        }
+    #endif
         if (key == NULL) {
             WOLFSSL_MSG("No public key found for certificate");
             XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
@@ -10398,6 +10569,32 @@ cleanup:
             XFREE(dsa, NULL, DYNAMIC_TYPE_DSA);
         }
     #endif
+    #if defined(HAVE_FALCON)
+        if ((x509->pubKeyOID == FALCON_LEVEL1k) ||
+            (x509->pubKeyOID == FALCON_LEVEL5k)) {
+            wc_falcon_free(falcon);
+            XFREE(falcon, NULL, DYNAMIC_TYPE_FALCON);
+        }
+    #endif
+    #if defined(HAVE_DILITHIUM)
+        if ((x509->pubKeyOID == DILITHIUM_LEVEL2k) ||
+            (x509->pubKeyOID == DILITHIUM_LEVEL3k) ||
+            (x509->pubKeyOID == DILITHIUM_LEVEL5k)) {
+            wc_dilithium_free(dilithium);
+            XFREE(dilithium, NULL, DYNAMIC_TYPE_DILITHIUM);
+        }
+    #endif
+    #if defined(HAVE_SPHINCS)
+        if ((x509->pubKeyOID == SPHINCS_FAST_LEVEL1k) ||
+            (x509->pubKeyOID == SPHINCS_FAST_LEVEL3k) ||
+            (x509->pubKeyOID == SPHINCS_FAST_LEVEL5k) ||
+            (x509->pubKeyOID == SPHINCS_SMALL_LEVEL1k) ||
+            (x509->pubKeyOID == SPHINCS_SMALL_LEVEL3k) ||
+            (x509->pubKeyOID == SPHINCS_SMALL_LEVEL5k)) {
+            wc_sphincs_free(sphincs);
+            XFREE(sphincs, NULL, DYNAMIC_TYPE_SPHINCS);
+        }
+    #endif
         XFREE(cert, NULL, DYNAMIC_TYPE_CERT);
 
         return ret;
@@ -10449,7 +10646,7 @@ cleanup:
         ret = wc_InitRng(&rng);
         if (ret != 0)
             return ret;
-        ret = wc_SignCert_ex(certBodySz, sigType, der, derSz, type, key, &rng);
+        ret = wc_SignCert_ex(certBodySz, sigType, der, (word32)derSz, type, key, &rng);
         wc_FreeRng(&rng);
         if (ret < 0) {
             WOLFSSL_LEAVE("wolfSSL_X509_resign_cert", ret);
@@ -10463,20 +10660,20 @@ cleanup:
             int    len = 0;
 
             /* Read top level sequence */
-            if (GetSequence(der, &idx, &len, derSz) < 0) {
+            if (GetSequence(der, &idx, &len, (word32)derSz) < 0) {
                 WOLFSSL_MSG("GetSequence error");
                 return WOLFSSL_FATAL_ERROR;
             }
             /* Move idx to signature */
             idx += certBodySz;
             /* Read signature algo sequence */
-            if (GetSequence(der, &idx, &len, derSz) < 0) {
+            if (GetSequence(der, &idx, &len, (word32)derSz) < 0) {
                 WOLFSSL_MSG("GetSequence error");
                 return WOLFSSL_FATAL_ERROR;
             }
             idx += len;
             /* Read signature bit string */
-            if (CheckBitString(der, &idx, &len, derSz, 0, NULL) != 0) {
+            if (CheckBitString(der, &idx, &len, (word32)derSz, 0, NULL) != 0) {
                 WOLFSSL_MSG("CheckBitString error");
                 return WOLFSSL_FATAL_ERROR;
             }
@@ -10495,7 +10692,7 @@ cleanup:
                 return WOLFSSL_FATAL_ERROR;
             }
             XMEMCPY(x509->sig.buffer, der + idx, len);
-            x509->sig.length = len;
+            x509->sig.length = (unsigned int)len;
         }
 
         /* Put in the new certificate encoding into the x509 object. */
@@ -10506,10 +10703,10 @@ cleanup:
             type = CERTREQ_TYPE;
         }
     #endif
-        if (AllocDer(&x509->derCert, derSz, type, NULL) != 0)
+        if (AllocDer(&x509->derCert, (word32)derSz, type, NULL) != 0)
             return WOLFSSL_FATAL_ERROR;
         XMEMCPY(x509->derCert->buffer, der, derSz);
-        x509->derCert->length = derSz;
+        x509->derCert->length = (word32)derSz;
 
         return ret;
     }
@@ -10833,7 +11030,7 @@ int wolfSSL_i2d_X509_NAME(WOLFSSL_X509_NAME* name, unsigned char** out)
     }
 
     /* header */
-    idx = SetSequence(totalBytes, temp);
+    idx = (int)SetSequence((word32)totalBytes, temp);
     if (totalBytes + idx > ASN_NAME_MAX) {
 #ifdef WOLFSSL_SMALL_STACK
         XFREE(names, NULL, DYNAMIC_TYPE_TMP_BUFFER);
@@ -10861,7 +11058,7 @@ int wolfSSL_i2d_X509_NAME(WOLFSSL_X509_NAME* name, unsigned char** out)
     }
     output = *out;
 
-    idx = SetSequence(totalBytes, output);
+    idx = (int)SetSequence((word32)totalBytes, output);
     totalBytes += idx;
     for (i = 0; i < MAX_NAME_ENTRIES; i++) {
         if (names[i].used) {
@@ -10982,7 +11179,7 @@ cleanup:
         _x = (x->name && *x->name) ? x->name : x->staticName;
         _y = (y->name && *y->name) ? y->name : y->staticName;
 
-        return XSTRNCMP(_x, _y, x->sz); /* y sz is the same */
+        return XSTRNCASECMP(_x, _y, x->sz); /* y sz is the same */
     }
 
 #ifndef NO_BIO
@@ -11085,6 +11282,27 @@ cleanup:
         return loadX509orX509REQFromPemBio(bp, x, cb, u, CERT_TYPE);
     }
 
+    /*
+     * bp : bio to read X509 from
+     * x  : x509 to write to
+     * cb : password call back for reading PEM
+     * u  : password
+     * _AUX is for working with a trusted X509 certificate
+     */
+    WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_AUX(WOLFSSL_BIO *bp,
+                               WOLFSSL_X509 **x, wc_pem_password_cb *cb,
+                               void *u)
+    {
+        WOLFSSL_ENTER("wolfSSL_PEM_read_bio_X509");
+
+        /* AUX info is; trusted/rejected uses, friendly name, private key id,
+         * and potentially a stack of "other" info. wolfSSL does not store
+         * friendly name or private key id yet in WOLFSSL_X509 for human
+         * readability and does not support extra trusted/rejected uses for
+         * root CA. */
+        return wolfSSL_PEM_read_bio_X509(bp, x, cb, u);
+    }
+
 #ifdef WOLFSSL_CERT_REQ
     WOLFSSL_X509 *wolfSSL_PEM_read_bio_X509_REQ(WOLFSSL_BIO *bp, WOLFSSL_X509 **x,
                                                 wc_pem_password_cb *cb, void *u)
@@ -11158,7 +11376,7 @@ cleanup:
         if((PemToDer(pem, pemSz, CRL_TYPE, &der, NULL, NULL, NULL)) < 0) {
             goto err;
         }
-        derSz = der->length;
+        derSz = (int)der->length;
         if((crl = wolfSSL_d2i_X509_CRL(x, der->buffer, derSz)) == NULL) {
             goto err;
         }
@@ -11231,7 +11449,7 @@ err:
         if (pem == NULL)
             return NULL;
 
-        if ((int)XFREAD((char *)pem, 1, pemSz, fp) != pemSz)
+        if ((int)XFREAD((char *)pem, 1, (size_t)pemSz, fp) != pemSz)
             goto err_exit;
 
         switch (type) {
@@ -11244,7 +11462,7 @@ err:
             case CRL_TYPE:
                 if ((PemToDer(pem, pemSz, CRL_TYPE, &der, NULL, NULL, NULL)) < 0)
                     goto err_exit;
-                derSz = der->length;
+                derSz = (int)der->length;
                 newx509 = (void*)wolfSSL_d2i_X509_CRL((WOLFSSL_X509_CRL **)x,
                     (const unsigned char *)der->buffer, derSz);
                 if (newx509 == NULL)
@@ -11480,8 +11698,9 @@ err:
                         "-----BEGIN X509 CRL-----")) {
                 /* We have a crl */
                 WOLFSSL_MSG("Parsing crl");
-                if((PemToDer((const unsigned char*) header, footerEnd - header,
-                        CRL_TYPE, &der, NULL, NULL, NULL)) < 0) {
+                if((PemToDer((const unsigned char*) header,
+                        (long)(footerEnd - header), CRL_TYPE, &der, NULL, NULL,
+                        NULL)) < 0) {
                     WOLFSSL_MSG("PemToDer error");
                     goto err;
                 }
@@ -11895,7 +12114,6 @@ WOLFSSL_ASN1_OBJECT* wolfSSL_X509_NAME_ENTRY_get_object(
     static int RebuildFullName(WOLFSSL_X509_NAME* name)
     {
         int totalLen = 0, i, idx, entryCount = 0;
-        char* fullName;
 
         if (name == NULL)
             return BAD_FUNC_ARG;
@@ -11915,23 +12133,26 @@ WOLFSSL_ASN1_OBJECT* wolfSSL_X509_NAME_ENTRY_get_object(
             }
         }
 
-        fullName = (char*)XMALLOC(totalLen + 1, name->heap, DYNAMIC_TYPE_X509);
-        if (fullName == NULL)
-            return MEMORY_E;
-
-        idx = 0;
-        entryCount = AddAllEntry(name, fullName, totalLen, &idx);
-        if (entryCount < 0) {
-            XFREE(fullName, name->heap, DYNAMIC_TYPE_X509);
-            return entryCount;
-        }
-
         if (name->dynamicName) {
             XFREE(name->name, name->heap, DYNAMIC_TYPE_X509);
+            name->name = name->staticName;
+            name->dynamicName = 0;
         }
-        fullName[idx] = '\0';
-        name->name = fullName;
-        name->dynamicName = 1;
+
+        if (totalLen >= ASN_NAME_MAX) {
+            name->name = (char*)XMALLOC(totalLen + 1, name->heap,
+                    DYNAMIC_TYPE_X509);
+            if (name->name == NULL)
+                return MEMORY_E;
+            name->dynamicName = 1;
+        }
+
+        idx = 0;
+        entryCount = AddAllEntry(name, name->name, totalLen, &idx);
+        if (entryCount < 0)
+            return entryCount;
+
+        name->name[idx] = '\0';
         name->sz = idx + 1; /* size includes null terminator */
         name->entrySz = entryCount;
 
@@ -12208,7 +12429,7 @@ int wolfSSL_PEM_write_bio_X509_REQ(WOLFSSL_BIO *bp, WOLFSSL_X509 *x)
     }
 
     /* get PEM size */
-    pemSz = wc_DerToPemEx(der, derSz, NULL, 0, NULL, CERTREQ_TYPE);
+    pemSz = wc_DerToPemEx(der, (word32)derSz, NULL, 0, NULL, CERTREQ_TYPE);
     if (pemSz < 0) {
         return WOLFSSL_FAILURE;
     }
@@ -12218,7 +12439,7 @@ int wolfSSL_PEM_write_bio_X509_REQ(WOLFSSL_BIO *bp, WOLFSSL_X509 *x)
     if (pem == NULL) {
         return WOLFSSL_FAILURE;
     }
-    if (wc_DerToPemEx(der, derSz, pem, pemSz, NULL, CERTREQ_TYPE) < 0) {
+    if (wc_DerToPemEx(der, (word32)derSz, pem, pemSz, NULL, CERTREQ_TYPE) < 0) {
         XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return WOLFSSL_FAILURE;
     }
@@ -12258,7 +12479,7 @@ int wolfSSL_PEM_write_bio_X509_AUX(WOLFSSL_BIO *bp, WOLFSSL_X509 *x)
     }
 
     /* get PEM size */
-    pemSz = wc_DerToPemEx(der, derSz, NULL, 0, NULL, CERT_TYPE);
+    pemSz = wc_DerToPemEx(der, (word32)derSz, NULL, 0, NULL, CERT_TYPE);
     if (pemSz < 0) {
         return WOLFSSL_FAILURE;
     }
@@ -12268,7 +12489,7 @@ int wolfSSL_PEM_write_bio_X509_AUX(WOLFSSL_BIO *bp, WOLFSSL_X509 *x)
     if (pem == NULL) {
         return WOLFSSL_FAILURE;
     }
-    if (wc_DerToPemEx(der, derSz, pem, pemSz, NULL, CERT_TYPE) < 0) {
+    if (wc_DerToPemEx(der, (word32)derSz, pem, pemSz, NULL, CERT_TYPE) < 0) {
         XFREE(pem, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         return WOLFSSL_FAILURE;
     }
@@ -12306,7 +12527,7 @@ int wolfSSL_PEM_write_bio_X509(WOLFSSL_BIO *bio, WOLFSSL_X509 *cert)
     }
 
     /* get PEM size */
-    pemSz = wc_DerToPemEx(der, derSz, NULL, 0, NULL, CERT_TYPE);
+    pemSz = wc_DerToPemEx(der, (word32)derSz, NULL, 0, NULL, CERT_TYPE);
     if (pemSz < 0) {
         goto error;
     }
@@ -12316,7 +12537,7 @@ int wolfSSL_PEM_write_bio_X509(WOLFSSL_BIO *bio, WOLFSSL_X509 *cert)
     if (pem == NULL) {
         goto error;
     }
-    if (wc_DerToPemEx(der, derSz, pem, pemSz, NULL, CERT_TYPE) < 0) {
+    if (wc_DerToPemEx(der, (word32)derSz, pem, pemSz, NULL, CERT_TYPE) < 0) {
         goto error;
     }
 
@@ -12631,6 +12852,7 @@ WOLF_STACK_OF(WOLFSSL_X509_NAME) *wolfSSL_dup_CA_list(
         if (name == NULL || WOLFSSL_SUCCESS != wolfSSL_sk_X509_NAME_push(copy, name)) {
             WOLFSSL_MSG("Memory error");
             wolfSSL_sk_X509_NAME_pop_free(copy, wolfSSL_X509_NAME_free);
+            wolfSSL_X509_NAME_free(name);
             return NULL;
         }
     }
@@ -12752,6 +12974,14 @@ static int get_dn_attr_by_nid(int n, const char** buf)
             str = "UID";
             len = 3;
             break;
+        case NID_serialNumber:
+            str = "serialNumber";
+            len = 12;
+            break;
+        case NID_title:
+            str = "title";
+            len = 5;
+            break;
         default:
             WOLFSSL_MSG("Attribute type not found");
             str = NULL;
@@ -12816,7 +13046,7 @@ static int wolfSSL_EscapeString_RFC2253(char* in, word32 inSz,
     }
     out[outIdx] = '\0';
 
-    return outIdx;
+    return (int)outIdx;
 }
 
 /*
@@ -12831,6 +13061,7 @@ static int wolfSSL_EscapeString_RFC2253(char* in, word32 inSz,
  *                                RFC22523 currently implemented.
  *              XN_FLAG_DN_REV  - print name reversed. Automatically done by
  *                                XN_FLAG_RFC2253.
+ *              XN_FLAG_SPC_EQ  - spaces before and after '=' character
  *
  * Returns WOLFSSL_SUCCESS (1) on success, WOLFSSL_FAILURE (0) on failure.
  */
@@ -12838,6 +13069,8 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
                 int indent, unsigned long flags)
 {
     int i, count = 0, nameStrSz = 0, escapeSz = 0;
+    int eqSpace  = 0;
+    char eqStr[4];
     char* tmp = NULL;
     char* nameStr = NULL;
     const char *buf = NULL;
@@ -12849,6 +13082,15 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
 
     if ((name == NULL) || (name->sz == 0) || (bio == NULL))
         return WOLFSSL_FAILURE;
+
+    XMEMSET(eqStr, 0, sizeof(eqStr));
+    if (flags & XN_FLAG_SPC_EQ) {
+        eqSpace = 2;
+        XSTRNCPY(eqStr, " = ", 4);
+    }
+    else {
+        XSTRNCPY(eqStr, "=", 4);
+    }
 
     for (i = 0; i < indent; i++) {
         if (wolfSSL_BIO_write(bio, " ", 1) != 1)
@@ -12894,14 +13136,15 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
         if (len == 0 || buf == NULL)
             return WOLFSSL_FAILURE;
 
-        tmpSz = nameStrSz + len + 4; /* + 4 for '=', comma space and '\0'*/
+        /* + 4 for '=', comma space and '\0'*/
+        tmpSz = nameStrSz + len + 4 + eqSpace;
         tmp = (char*)XMALLOC(tmpSz, NULL, DYNAMIC_TYPE_TMP_BUFFER);
         if (tmp == NULL) {
             return WOLFSSL_FAILURE;
         }
 
         if (i < count - 1) {
-            if (XSNPRINTF(tmp, tmpSz, "%s=%s, ", buf, nameStr)
+            if (XSNPRINTF(tmp, (size_t)tmpSz, "%s%s%s, ", buf, eqStr, nameStr)
                 >= tmpSz)
             {
                 WOLFSSL_MSG("buffer overrun");
@@ -12909,17 +13152,17 @@ int wolfSSL_X509_NAME_print_ex(WOLFSSL_BIO* bio, WOLFSSL_X509_NAME* name,
                 return WOLFSSL_FAILURE;
             }
 
-            tmpSz = len + nameStrSz + 3; /* 3 for '=', comma space */
+            tmpSz = len + nameStrSz + 3 + eqSpace; /* 3 for '=', comma space */
         }
         else {
-            if (XSNPRINTF(tmp, tmpSz, "%s=%s", buf, nameStr)
+            if (XSNPRINTF(tmp, (size_t)tmpSz, "%s%s%s", buf, eqStr, nameStr)
                 >= tmpSz)
             {
                 WOLFSSL_MSG("buffer overrun");
                 XFREE(tmp, NULL, DYNAMIC_TYPE_TMP_BUFFER);
                 return WOLFSSL_FAILURE;
             }
-            tmpSz = len + nameStrSz + 1; /* 1 for '=' */
+            tmpSz = len + nameStrSz + 1 + eqSpace; /* 1 for '=' */
             if (bio->type != WOLFSSL_BIO_FILE && bio->type != WOLFSSL_BIO_MEMORY)
                 ++tmpSz; /* include the terminating null when not writing to a
                           * file.
@@ -13123,6 +13366,7 @@ int wolfSSL_X509_check_host(WOLFSSL_X509 *x, const char *chk, size_t chklen,
                     unsigned int flags, char **peername)
 {
     int         ret;
+    size_t      i;
 #ifdef WOLFSSL_SMALL_STACK
     DecodedCert *dCert;
 #else
@@ -13159,9 +13403,25 @@ int wolfSSL_X509_check_host(WOLFSSL_X509 *x, const char *chk, size_t chklen,
 #endif
 
     InitDecodedCert(dCert, x->derCert->buffer, x->derCert->length, NULL);
-    ret = ParseCertRelative(dCert, CERT_TYPE, 0, NULL);
+    ret = ParseCertRelative(dCert, CERT_TYPE, 0, NULL, NULL);
     if (ret != 0) {
         goto out;
+    }
+
+    /* Replicate openssl behavior for checklen */
+    if (chklen == 0) {
+        chklen = (size_t)(XSTRLEN(chk));
+    }
+    else {
+        for (i = 0; i < (chklen > 1 ? chklen - 1 : chklen); i++) {
+            if (chk[i] == '\0') {
+                ret = -1;
+                goto out;
+            }
+        }
+    }
+    if (chklen > 1 && (chk[chklen - 1] == '\0')) {
+        chklen--;
     }
 
     ret = CheckHostName(dCert, (char *)chk, chklen);
@@ -13214,7 +13474,7 @@ int wolfSSL_X509_check_ip_asc(WOLFSSL_X509 *x, const char *ipasc,
 
     if (ret == WOLFSSL_SUCCESS) {
         InitDecodedCert(dCert, x->derCert->buffer, x->derCert->length, NULL);
-        ret = ParseCertRelative(dCert, CERT_TYPE, 0, NULL);
+        ret = ParseCertRelative(dCert, CERT_TYPE, 0, NULL, NULL);
         if (ret != 0) {
             ret = WOLFSSL_FAILURE;
         }
@@ -13353,7 +13613,7 @@ static int x509GetIssuerFromCM(WOLFSSL_X509 **issuer, WOLFSSL_CERT_MANAGER* cm,
 
     /* Use existing CA retrieval APIs that use DecodedCert. */
     InitDecodedCert(cert, x->derCert->buffer, x->derCert->length, cm->heap);
-    if (ParseCertRelative(cert, CERT_TYPE, 0, NULL) == 0
+    if (ParseCertRelative(cert, CERT_TYPE, 0, NULL, NULL) == 0
             && !cert->selfSigned) {
     #ifndef NO_SKID
         if (cert->extAuthKeyIdSet)
@@ -13516,7 +13776,7 @@ int wolfSSL_X509_get_signature_nid(const WOLFSSL_X509 *x)
     if (x == NULL)
         return 0;
 
-    return oid2nid(x->sigOID, oidSigType);
+    return oid2nid((word32)x->sigOID, oidSigType);
 }
 #endif  /* OPENSSL_EXTRA */
 
@@ -13700,6 +13960,16 @@ int wolfSSL_X509_set_notBefore(WOLFSSL_X509* x509, const WOLFSSL_ASN1_TIME* t)
     return WOLFSSL_SUCCESS;
 }
 
+int wolfSSL_X509_set1_notAfter(WOLFSSL_X509* x509, const WOLFSSL_ASN1_TIME *t)
+{
+    return wolfSSL_X509_set_notAfter(x509, t);
+}
+
+int wolfSSL_X509_set1_notBefore(WOLFSSL_X509* x509, const WOLFSSL_ASN1_TIME *t)
+{
+    return wolfSSL_X509_set_notBefore(x509, t);
+}
+
 int wolfSSL_X509_set_serialNumber(WOLFSSL_X509* x509, WOLFSSL_ASN1_INTEGER* s)
 {
     WOLFSSL_ENTER("wolfSSL_X509_set_serialNumber");
@@ -13748,7 +14018,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
             if (p == NULL)
                 return WOLFSSL_FAILURE;
 
-            if ((derSz = wc_RsaKeyToPublicDer(rsa, p, derSz)) <= 0) {
+            if ((derSz = wc_RsaKeyToPublicDer(rsa, p, (word32)derSz)) <= 0) {
                 XFREE(p, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
                 return WOLFSSL_FAILURE;
             }
@@ -13772,7 +14042,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
             if (p == NULL)
                 return WOLFSSL_FAILURE;
 
-            if ((derSz = wc_DsaKeyToPublicDer(dsa, p, derSz)) <= 0) {
+            if ((derSz = wc_DsaKeyToPublicDer(dsa, p, (word32)derSz)) <= 0) {
                 XFREE(p, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
                 return WOLFSSL_FAILURE;
             }
@@ -13797,7 +14067,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
             if (p == NULL)
                 return WOLFSSL_FAILURE;
 
-            if ((derSz = wc_EccPublicKeyToDer(ecc, p, derSz, 1)) <= 0) {
+            if ((derSz = wc_EccPublicKeyToDer(ecc, p, (word32)derSz, 1)) <= 0) {
                 XFREE(p, cert->heap, DYNAMIC_TYPE_PUBLIC_KEY);
                 return WOLFSSL_FAILURE;
             }
@@ -13809,7 +14079,7 @@ int wolfSSL_X509_set_pubkey(WOLFSSL_X509 *cert, WOLFSSL_EVP_PKEY *pkey)
         return WOLFSSL_FAILURE;
     }
     cert->pubKey.buffer = p;
-    cert->pubKey.length = derSz;
+    cert->pubKey.length = (unsigned int)derSz;
 
     return WOLFSSL_SUCCESS;
 }
@@ -14014,7 +14284,7 @@ static int regenX509REQDerBuffer(WOLFSSL_X509* x509)
 
     if (wolfssl_x509_make_der(x509, 1, der, &derSz, 0) == WOLFSSL_SUCCESS) {
         FreeDer(&x509->derCert);
-        if (AllocDer(&x509->derCert, derSz, CERT_TYPE, x509->heap) == 0) {
+        if (AllocDer(&x509->derCert, (word32)derSz, CERT_TYPE, x509->heap) == 0) {
             XMEMCPY(x509->derCert->buffer, der, derSz);
             ret = WOLFSSL_SUCCESS;
         }
@@ -14353,7 +14623,7 @@ void wolfSSL_X509_ATTRIBUTE_free(WOLFSSL_X509_ATTRIBUTE* attr)
 }
 #endif
 
-#endif /* !NO_CERT */
+#endif /* !NO_CERTS */
 
 #endif /* !WOLFCRYPT_ONLY */
 

--- a/libatalk/ssl/src/x509_str.c
+++ b/libatalk/ssl/src/x509_str.c
@@ -40,27 +40,59 @@
  * START OF X509_STORE_CTX APIs
  ******************************************************************************/
 
-#ifdef OPENSSL_EXTRA
-
-WOLFSSL_X509_STORE_CTX* wolfSSL_X509_STORE_CTX_new(void)
+/* This API is necessary outside of OPENSSL_EXTRA because it is used in
+ * SetupStoreCtxCallback */
+WOLFSSL_X509_STORE_CTX* wolfSSL_X509_STORE_CTX_new_ex(void* heap)
 {
     WOLFSSL_X509_STORE_CTX* ctx;
-    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_new");
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_new_ex");
 
-    ctx = (WOLFSSL_X509_STORE_CTX*)XMALLOC(sizeof(WOLFSSL_X509_STORE_CTX), NULL,
+    ctx = (WOLFSSL_X509_STORE_CTX*)XMALLOC(sizeof(WOLFSSL_X509_STORE_CTX), heap,
                                     DYNAMIC_TYPE_X509_CTX);
     if (ctx != NULL) {
-        ctx->param = NULL;
+        XMEMSET(ctx, 0, sizeof(WOLFSSL_X509_STORE_CTX));
+        ctx->heap = heap;
+#ifdef OPENSSL_EXTRA
         if (wolfSSL_X509_STORE_CTX_init(ctx, NULL, NULL, NULL) !=
                 WOLFSSL_SUCCESS) {
-            XFREE(ctx, NULL, DYNAMIC_TYPE_X509_CTX);
+            XFREE(ctx, heap, DYNAMIC_TYPE_X509_CTX);
             ctx = NULL;
         }
+#endif
     }
 
     return ctx;
 }
 
+/* This API is necessary outside of OPENSSL_EXTRA because it is used in
+ * SetupStoreCtxCallback */
+/* free's extra data */
+void wolfSSL_X509_STORE_CTX_free(WOLFSSL_X509_STORE_CTX* ctx)
+{
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_free");
+    if (ctx != NULL) {
+#ifdef HAVE_EX_DATA_CLEANUP_HOOKS
+        wolfSSL_CRYPTO_cleanup_ex_data(&ctx->ex_data);
+#endif
+
+#ifdef OPENSSL_EXTRA
+        if (ctx->param != NULL) {
+            XFREE(ctx->param, ctx->heap, DYNAMIC_TYPE_OPENSSL);
+            ctx->param = NULL;
+        }
+#endif
+
+        XFREE(ctx, ctx->heap, DYNAMIC_TYPE_X509_CTX);
+    }
+}
+
+#ifdef OPENSSL_EXTRA
+
+WOLFSSL_X509_STORE_CTX* wolfSSL_X509_STORE_CTX_new(void)
+{
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_new");
+    return wolfSSL_X509_STORE_CTX_new_ex(NULL);
+}
 
 int wolfSSL_X509_STORE_CTX_init(WOLFSSL_X509_STORE_CTX* ctx,
      WOLFSSL_X509_STORE* store, WOLFSSL_X509* x509,
@@ -134,35 +166,17 @@ int wolfSSL_X509_STORE_CTX_init(WOLFSSL_X509_STORE_CTX* ctx,
         if (ctx->param == NULL) {
             ctx->param = (WOLFSSL_X509_VERIFY_PARAM*)XMALLOC(
                            sizeof(WOLFSSL_X509_VERIFY_PARAM),
-                           NULL, DYNAMIC_TYPE_OPENSSL);
+                           ctx->heap, DYNAMIC_TYPE_OPENSSL);
             if (ctx->param == NULL){
                 WOLFSSL_MSG("wolfSSL_X509_STORE_CTX_init failed");
                 return WOLFSSL_FAILURE;
             }
+            XMEMSET(ctx->param, 0, sizeof(*ctx->param));
         }
 
         return WOLFSSL_SUCCESS;
     }
     return WOLFSSL_FAILURE;
-}
-
-
-/* free's extra data */
-void wolfSSL_X509_STORE_CTX_free(WOLFSSL_X509_STORE_CTX* ctx)
-{
-    WOLFSSL_ENTER("wolfSSL_X509_STORE_CTX_free");
-    if (ctx != NULL) {
-#ifdef HAVE_EX_DATA_CLEANUP_HOOKS
-        wolfSSL_CRYPTO_cleanup_ex_data(&ctx->ex_data);
-#endif
-
-        if (ctx->param != NULL) {
-            XFREE(ctx->param, NULL, DYNAMIC_TYPE_OPENSSL);
-            ctx->param = NULL;
-        }
-
-        XFREE(ctx, NULL, DYNAMIC_TYPE_X509_CTX);
-    }
 }
 
 /* Its recommended to use a full free -> init cycle of all the objects
@@ -173,7 +187,7 @@ void wolfSSL_X509_STORE_CTX_cleanup(WOLFSSL_X509_STORE_CTX* ctx)
     if (ctx != NULL) {
 
         if (ctx->param != NULL) {
-            XFREE(ctx->param, NULL, DYNAMIC_TYPE_OPENSSL);
+            XFREE(ctx->param, ctx->heap, DYNAMIC_TYPE_OPENSSL);
             ctx->param = NULL;
         }
 
@@ -194,24 +208,27 @@ void wolfSSL_X509_STORE_CTX_trusted_stack(WOLFSSL_X509_STORE_CTX *ctx, WOLF_STAC
 int GetX509Error(int e)
 {
     switch (e) {
-        case ASN_BEFORE_DATE_E:
+        case WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E):
             return WOLFSSL_X509_V_ERR_CERT_NOT_YET_VALID;
-        case ASN_AFTER_DATE_E:
+        case WC_NO_ERR_TRACE(ASN_AFTER_DATE_E):
             return WOLFSSL_X509_V_ERR_CERT_HAS_EXPIRED;
-        case ASN_NO_SIGNER_E: /* get issuer error if no CA found locally */
+        case WC_NO_ERR_TRACE(ASN_NO_SIGNER_E):
+            /* get issuer error if no CA found locally */
             return WOLFSSL_X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY;
-        case ASN_SELF_SIGNED_E:
+        case WC_NO_ERR_TRACE(ASN_SELF_SIGNED_E):
             return WOLFSSL_X509_V_ERR_DEPTH_ZERO_SELF_SIGNED_CERT;
-        case ASN_PATHLEN_INV_E:
-        case ASN_PATHLEN_SIZE_E:
+        case WC_NO_ERR_TRACE(ASN_PATHLEN_INV_E):
+        case WC_NO_ERR_TRACE(ASN_PATHLEN_SIZE_E):
             return WOLFSSL_X509_V_ERR_PATH_LENGTH_EXCEEDED;
-        case ASN_SIG_OID_E:
-        case ASN_SIG_CONFIRM_E:
-        case ASN_SIG_HASH_E:
-        case ASN_SIG_KEY_E:
+        case WC_NO_ERR_TRACE(ASN_SIG_OID_E):
+        case WC_NO_ERR_TRACE(ASN_SIG_CONFIRM_E):
+        case WC_NO_ERR_TRACE(ASN_SIG_HASH_E):
+        case WC_NO_ERR_TRACE(ASN_SIG_KEY_E):
             return WOLFSSL_X509_V_ERR_CERT_SIGNATURE_FAILURE;
-        case CRL_CERT_REVOKED:
+        case WC_NO_ERR_TRACE(CRL_CERT_REVOKED):
             return WOLFSSL_X509_V_ERR_CERT_REVOKED;
+        case WC_NO_ERR_TRACE(CRL_MISSING):
+            return X509_V_ERR_UNABLE_TO_GET_CRL;
         case 0:
         case 1:
             return 0;
@@ -254,7 +271,8 @@ int wolfSSL_X509_verify_cert(WOLFSSL_X509_STORE_CTX* ctx)
         SetupStoreCtxError(ctx, ret);
 
     #ifndef NO_ASN_TIME
-        if (ret != ASN_BEFORE_DATE_E && ret != ASN_AFTER_DATE_E) {
+        if (ret != WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E) &&
+            ret != WC_NO_ERR_TRACE(ASN_AFTER_DATE_E)) {
             /* wolfSSL_CertManagerVerifyBuffer only returns ASN_AFTER_DATE_E or
              ASN_BEFORE_DATE_E if there are no additional errors found in the
              cert. Therefore, check if the cert is expired or not yet valid
@@ -504,39 +522,19 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(WOLFSSL_X509_STORE_CTX* ctx)
     /* if chain is null but sesChain is available then populate stack */
     if (ctx->chain == NULL && ctx->sesChain != NULL) {
         int i;
+        int error = 0;
         WOLFSSL_X509_CHAIN* c = ctx->sesChain;
-        WOLFSSL_STACK*     sk = (WOLFSSL_STACK*)XMALLOC(sizeof(WOLFSSL_STACK),
-                                    NULL, DYNAMIC_TYPE_X509);
+        WOLFSSL_STACK*     sk = wolfSSL_sk_new_node(ctx->heap);
 
-        if (sk == NULL) {
+        if (sk == NULL)
             return NULL;
-        }
-
-        XMEMSET(sk, 0, sizeof(WOLFSSL_STACK));
-
-        for (i = 0; i < c->count && i < MAX_CHAIN_DEPTH; i++) {
-            WOLFSSL_X509* x509 = wolfSSL_get_chain_X509(c, i);
-
-            if (x509 == NULL) {
-                WOLFSSL_MSG("Unable to get x509 from chain");
-                wolfSSL_sk_X509_pop_free(sk, NULL);
-                return NULL;
-            }
-
-            if (wolfSSL_sk_X509_push(sk, x509) != WOLFSSL_SUCCESS) {
-                WOLFSSL_MSG("Unable to load x509 into stack");
-                wolfSSL_sk_X509_pop_free(sk, NULL);
-                wolfSSL_X509_free(x509);
-                return NULL;
-            }
-        }
 
 #if defined(WOLFSSL_NGINX) || defined(WOLFSSL_HAPROXY) || defined(OPENSSL_EXTRA)
         /* add CA used to verify top of chain to the list */
         if (c->count > 0) {
             WOLFSSL_X509* x509 = wolfSSL_get_chain_X509(c, c->count - 1);
+            WOLFSSL_X509* issuer = NULL;
             if (x509 != NULL) {
-                WOLFSSL_X509* issuer = NULL;
                 if (wolfSSL_X509_STORE_CTX_get1_issuer(&issuer, ctx, x509)
                         == WOLFSSL_SUCCESS) {
                     /* check that the certificate being looked up is not self
@@ -545,24 +543,47 @@ WOLFSSL_STACK* wolfSSL_X509_STORE_CTX_get_chain(WOLFSSL_X509_STORE_CTX* ctx)
                                 &x509->subject) != 0) {
                         if (wolfSSL_sk_X509_push(sk, issuer) != WOLFSSL_SUCCESS) {
                             WOLFSSL_MSG("Unable to load CA x509 into stack");
-                            wolfSSL_sk_X509_pop_free(sk, NULL);
-                            wolfSSL_X509_free(issuer);
-                            return NULL;
+                            error = 1;
                         }
                     }
                     else {
                         WOLFSSL_MSG("Certificate is self signed");
-                        if (issuer != NULL)
-                            wolfSSL_X509_free(issuer);
+                        wolfSSL_X509_free(issuer);
                     }
                 }
                 else {
-                    wolfSSL_X509_free(x509);
                     WOLFSSL_MSG("Could not find CA for certificate");
                 }
             }
+            wolfSSL_X509_free(x509);
+            if (error) {
+                wolfSSL_sk_X509_pop_free(sk, NULL);
+                wolfSSL_X509_free(issuer);
+                return NULL;
+            }
         }
 #endif
+
+        for (i = c->count - 1; i >= 0; i--) {
+            WOLFSSL_X509* x509 = wolfSSL_get_chain_X509(c, i);
+
+            if (x509 == NULL) {
+                WOLFSSL_MSG("Unable to get x509 from chain");
+                error = 1;
+                break;
+            }
+
+            if (wolfSSL_sk_X509_push(sk, x509) != WOLFSSL_SUCCESS) {
+                WOLFSSL_MSG("Unable to load x509 into stack");
+                wolfSSL_X509_free(x509);
+                error = 1;
+                break;
+            }
+        }
+        if (error) {
+            wolfSSL_sk_X509_pop_free(sk, NULL);
+            return NULL;
+        }
         ctx->chain = sk;
     }
 #endif /* SESSION_CERTS */
@@ -611,6 +632,14 @@ int wolfSSL_X509_STORE_get_by_subject(WOLFSSL_X509_STORE_CTX* ctx, int idx,
 }
 #endif
 
+WOLFSSL_X509_VERIFY_PARAM *wolfSSL_X509_STORE_CTX_get0_param(
+        WOLFSSL_X509_STORE_CTX *ctx)
+{
+    if (ctx == NULL)
+        return NULL;
+
+    return ctx->param;
+}
 
 #endif /* OPENSSL_EXTRA */
 
@@ -935,14 +964,33 @@ int wolfSSL_X509_STORE_set_ex_data_with_cleanup(
 #ifdef OPENSSL_EXTRA
 
 #if defined(WOLFSSL_QT) || defined(OPENSSL_ALL)
-    void wolfSSL_X509_STORE_set_verify_cb(WOLFSSL_X509_STORE *st,
-                                 WOLFSSL_X509_STORE_CTX_verify_cb verify_cb)
-    {
-        WOLFSSL_ENTER("wolfSSL_X509_STORE_set_verify_cb");
-        if (st != NULL) {
-            st->verify_cb = verify_cb;
-        }
+void wolfSSL_X509_STORE_set_verify_cb(WOLFSSL_X509_STORE *st,
+        WOLFSSL_X509_STORE_CTX_verify_cb verify_cb)
+{
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_set_verify_cb");
+    if (st != NULL) {
+        st->verify_cb = verify_cb;
     }
+}
+
+void wolfSSL_X509_STORE_set_get_crl(WOLFSSL_X509_STORE *st,
+        WOLFSSL_X509_STORE_CTX_get_crl_cb get_cb)
+{
+    WOLFSSL_ENTER("wolfSSL_X509_STORE_set_get_crl");
+    if (st != NULL) {
+        st->get_crl_cb = get_cb;
+    }
+}
+
+#ifndef NO_WOLFSSL_STUB
+void wolfSSL_X509_STORE_set_check_crl(WOLFSSL_X509_STORE *st,
+        WOLFSSL_X509_STORE_CTX_check_crl_cb check_crl)
+{
+    (void)st;
+    (void)check_crl;
+    WOLFSSL_STUB("wolfSSL_X509_STORE_set_check_crl (not implemented)");
+}
+#endif
 #endif /* WOLFSSL_QT || OPENSSL_ALL */
 
 WOLFSSL_X509_LOOKUP* wolfSSL_X509_STORE_add_lookup(WOLFSSL_X509_STORE* store,
@@ -1327,6 +1375,17 @@ err_cleanup:
     return NULL;
 }
 #endif /* OPENSSL_ALL */
+
+#if defined(OPENSSL_EXTRA) || defined(HAVE_WEBSERVER) || \
+    defined(WOLFSSL_WPAS_SMALL)
+WOLFSSL_X509_VERIFY_PARAM *wolfSSL_X509_STORE_get0_param(
+        const WOLFSSL_X509_STORE *ctx)
+{
+    if (ctx == NULL)
+        return NULL;
+    return ctx->param;
+}
+#endif
 
 /*******************************************************************************
  * END OF X509_STORE APIs

--- a/libatalk/ssl/wolfcrypt/src/aes.c
+++ b/libatalk/ssl/wolfcrypt/src/aes.c
@@ -39,15 +39,13 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
 
 /* Tip: Locate the software cipher modes by searching for "Software AES" */
 
-#if defined(HAVE_FIPS) && \
-    defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
-
+#if FIPS_VERSION3_GE(2,0,0)
     /* set NO_WRAPPERS before headers, use direct internal f()s not wrappers */
     #define FIPS_NO_WRAPPERS
 
     #ifdef USE_WINDOWS_API
-        #pragma code_seg(".fipsA$g")
-        #pragma const_seg(".fipsB$g")
+        #pragma code_seg(".fipsA$b")
+        #pragma const_seg(".fipsB$b")
     #endif
 #endif
 
@@ -97,7 +95,7 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
     #include <wolfcrypt/src/misc.c>
 #endif
 
-#ifndef WOLFSSL_ARMASM
+#if !defined(WOLFSSL_ARMASM) && !defined(WOLFSSL_RISCV_ASM)
 
 #ifdef WOLFSSL_IMX6_CAAM_BLOB
     /* case of possibly not using hardware acceleration for AES but using key
@@ -112,6 +110,15 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
 #ifdef _MSC_VER
     /* 4127 warning constant while(1)  */
     #pragma warning(disable: 4127)
+#endif
+
+#if FIPS_VERSION3_GE(6,0,0)
+    const unsigned int wolfCrypt_FIPS_aes_ro_sanity[2] =
+                                                     { 0x1a2b3c4d, 0x00000002 };
+    int wolfCrypt_FIPS_AES_sanity(void)
+    {
+        return 0;
+    }
 #endif
 
 /* Define AES implementation includes and functions */
@@ -720,7 +727,8 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
                 return MEMORY_E;
 #endif
 
-            if (AES_set_encrypt_key_AESNI(userKey,bits,temp_key) == BAD_FUNC_ARG) {
+            if (AES_set_encrypt_key_AESNI(userKey,bits,temp_key)
+                == WC_NO_ERR_TRACE(BAD_FUNC_ARG)) {
 #ifdef WOLFSSL_SMALL_STACK
                 XFREE(temp_key, aes->heap, DYNAMIC_TYPE_AES);
 #endif
@@ -959,6 +967,9 @@ block cipher mechanism that uses n-bit binary string parameter key with 128-bits
     #endif
 #elif defined(WOLFSSL_HAVE_PSA) && !defined(WOLFSSL_PSA_NO_AES)
 /* implemented in wolfcrypt/src/port/psa/psa_aes.c */
+
+#elif defined(WOLFSSL_RISCV_ASM)
+/* implemented in wolfcrypt/src/port/risc-v/riscv-64-aes.c */
 
 #else
 
@@ -1908,6 +1919,7 @@ static word32 GetTable8_4(const byte* t, byte o0, byte o1, byte o2, byte o3)
      ((word32)(t)[o2] <<  8) | ((word32)(t)[o3] <<  0))
 #endif
 
+#ifndef HAVE_CUDA
 /* Encrypt a block using AES.
  *
  * @param [in]  aes       AES object.
@@ -1922,7 +1934,7 @@ static void AesEncrypt_C(Aes* aes, const byte* inBlock, byte* outBlock,
     word32 t0, t1, t2, t3;
     const word32* rk;
 
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
+#ifdef WC_C_DYNAMIC_FALLBACK
     rk = aes->key_C_fallback;
 #else
     rk = aes->key;
@@ -2208,6 +2220,11 @@ static void AesEncryptBlocks_C(Aes* aes, const byte* in, byte* out, word32 sz)
     }
 }
 #endif
+#else
+extern void AesEncrypt_C(Aes* aes, const byte* inBlock, byte* outBlock,
+        word32 r);
+extern void AesEncryptBlocks_C(Aes* aes, const byte* in, byte* out, word32 sz);
+#endif /* HAVE_CUDA */
 
 #else
 
@@ -2703,6 +2720,7 @@ static void bs_encrypt(bs_word* state, bs_word* rk, word32 r)
     bs_inv_transpose(state, trans);
 }
 
+#ifndef HAVE_CUDA
 /* Encrypt a block using AES.
  *
  * @param [in]  aes       AES object.
@@ -2754,6 +2772,11 @@ static void AesEncryptBlocks_C(Aes* aes, const byte* in, byte* out, word32 sz)
     }
 }
 #endif
+#else
+extern void AesEncrypt_C(Aes* aes, const byte* inBlock, byte* outBlock,
+        word32 r);
+extern void AesEncryptBlocks_C(Aes* aes, const byte* in, byte* out, word32 sz);
+#endif /* HAVE_CUDA */
 
 #endif /* !WC_AES_BITSLICED */
 
@@ -2926,7 +2949,7 @@ static void AesDecrypt_C(Aes* aes, const byte* inBlock, byte* outBlock,
     word32 t0, t1, t2, t3;
     const word32* rk;
 
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
+#ifdef WC_C_DYNAMIC_FALLBACK
     rk = aes->key_C_fallback;
 #else
     rk = aes->key;
@@ -4066,7 +4089,7 @@ static WARN_UNUSED_RESULT int wc_AesDecrypt(
  */
 static void AesSetKey_C(Aes* aes, const byte* key, word32 keySz, int dir)
 {
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
+#ifdef WC_C_DYNAMIC_FALLBACK
     word32* rk = aes->key_C_fallback;
 #else
     word32* rk = aes->key;
@@ -4227,7 +4250,7 @@ static void AesSetKey_C(Aes* aes, const byte* key, word32 keySz, int dir)
     if (dir == AES_DECRYPTION) {
         unsigned int j;
 
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
+#ifdef WC_C_DYNAMIC_FALLBACK
         rk = aes->key_C_fallback;
 #else
         rk = aes->key;
@@ -4298,6 +4321,7 @@ static void AesSetKey_C(Aes* aes, const byte* key, word32 keySz, int dir)
 
 #endif /* NEED_AES_TABLES */
 
+#ifndef WOLFSSL_RISCV_ASM
     /* Software AES - SetKey */
     static WARN_UNUSED_RESULT int wc_AesSetKeyLocal(
         Aes* aes, const byte* userKey, word32 keylen, const byte* iv, int dir,
@@ -4436,11 +4460,11 @@ static void AesSetKey_C(Aes* aes, const byte* key, word32 keySz, int dir)
         if (ret != 0)
             return ret;
 
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
+#ifdef WC_C_DYNAMIC_FALLBACK
 #ifdef NEED_AES_TABLES
         AesSetKey_C(aes, userKey, keylen, dir);
 #endif /* NEED_AES_TABLES */
-#endif /* WC_AES_C_DYNAMIC_FALLBACK */
+#endif /* WC_C_DYNAMIC_FALLBACK */
 
     #ifdef WOLFSSL_AESNI
         aes->use_aesni = 0;
@@ -4469,13 +4493,13 @@ static void AesSetKey_C(Aes* aes, const byte* key, word32 keySz, int dir)
                 if (ret == 0)
                     aes->use_aesni = 1;
                 else {
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
+#ifdef WC_C_DYNAMIC_FALLBACK
                     ret = 0;
 #endif
                 }
                 return ret;
             } else {
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
+#ifdef WC_C_DYNAMIC_FALLBACK
                 return 0;
 #else
                 return ret;
@@ -4611,6 +4635,7 @@ static void AesSetKey_C(Aes* aes, const byte* key, word32 keySz, int dir)
         return wc_AesSetKeyLocal(aes, userKey, keylen, iv, dir, 1);
 
     } /* wc_AesSetKey() */
+#endif
 
     #if defined(WOLFSSL_AES_DIRECT) || defined(WOLFSSL_AES_COUNTER)
         /* AES-CTR and AES-DIRECT need to use this for key setup */
@@ -4661,7 +4686,7 @@ int wc_AesSetIV(Aes* aes, const byte* iv)
 
 #ifdef WOLFSSL_AESNI
 
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
+#ifdef WC_C_DYNAMIC_FALLBACK
 
 #define VECTOR_REGISTERS_PUSH { \
         int orig_use_aesni = aes->use_aesni;                         \
@@ -5490,7 +5515,7 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         #endif
         {
             int crypto_cb_ret = wc_CryptoCb_AesCbcEncrypt(aes, out, in, sz);
-            if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+            if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 return crypto_cb_ret;
             /* fall-through when unavailable */
         }
@@ -5659,7 +5684,7 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
         #endif
         {
             int crypto_cb_ret = wc_CryptoCb_AesCbcDecrypt(aes, out, in, sz);
-            if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+            if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 return crypto_cb_ret;
             /* fall-through when unavailable */
         }
@@ -6037,6 +6062,8 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
             int ret = 0;
             word32 processed;
 
+            XMEMSET(scratch, 0, sizeof(scratch));
+
             if (aes == NULL || out == NULL || in == NULL) {
                 return BAD_FUNC_ARG;
             }
@@ -6047,7 +6074,7 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
             #endif
             {
                 int crypto_cb_ret = wc_CryptoCb_AesCtrEncrypt(aes, out, in, sz);
-                if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+                if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                     return crypto_cb_ret;
                 /* fall-through when unavailable */
             }
@@ -6144,13 +6171,13 @@ int wc_AesCbcEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
                 return BAD_FUNC_ARG;
             }
 
-            return wc_AesSetKeyLocal(aes, key, len, iv, dir, 0);
+            return wc_AesSetKey(aes, key, len, iv, dir);
         }
 
     #endif /* NEED_AES_CTR_SOFT */
 
 #endif /* WOLFSSL_AES_COUNTER */
-#endif /* !WOLFSSL_ARMASM */
+#endif /* !WOLFSSL_ARMASM && ! WOLFSSL_RISCV_ASM */
 
 
 /*
@@ -6199,6 +6226,9 @@ static WC_INLINE void IncCtr(byte* ctr, word32 ctrSz)
 
 #ifdef WOLFSSL_ARMASM
     /* implementation is located in wolfcrypt/src/port/arm/armv8-aes.c */
+
+#elif defined(WOLFSSL_RISCV_ASM)
+    /* implemented in wolfcrypt/src/port/risc-v/riscv-64-aes.c */
 
 #elif defined(WOLFSSL_AFALG)
     /* implemented in wolfcrypt/src/port/afalg/afalg_aes.c */
@@ -6381,7 +6411,7 @@ int wc_AesGcmSetKey(Aes* aes, const byte* key, word32 len)
     if (!((len == 16) || (len == 24) || (len == 32)))
         return BAD_FUNC_ARG;
 
-    if (aes == NULL) {
+    if (aes == NULL || key == NULL) {
 #ifdef WOLFSSL_IMX6_CAAM_BLOB
         ForceZero(local, sizeof(local));
 #endif
@@ -8295,7 +8325,7 @@ int wc_AesGcmEncrypt(Aes* aes, byte* out, const byte* in, word32 sz,
         int crypto_cb_ret =
             wc_CryptoCb_AesGcmEncrypt(aes, out, in, sz, iv, ivSz, authTag,
                                       authTagSz, authIn, authInSz);
-        if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+        if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return crypto_cb_ret;
         /* fall-through when unavailable */
     }
@@ -8838,7 +8868,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
 {
     int ret;
 #ifdef WOLFSSL_AESNI
-    int res = AES_GCM_AUTH_E;
+    int res = WC_NO_ERR_TRACE(AES_GCM_AUTH_E);
 #endif
 
     /* argument checks */
@@ -8859,7 +8889,7 @@ int wc_AesGcmDecrypt(Aes* aes, byte* out, const byte* in, word32 sz,
         int crypto_cb_ret =
             wc_CryptoCb_AesGcmDecrypt(aes, out, in, sz, iv, ivSz,
                                       authTag, authTagSz, authIn, authInSz);
-        if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+        if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return crypto_cb_ret;
         /* fall-through when unavailable */
     }
@@ -10457,6 +10487,9 @@ int wc_AesCcmCheckTagSize(int sz)
 #ifdef WOLFSSL_ARMASM
     /* implementation located in wolfcrypt/src/port/arm/armv8-aes.c */
 
+#elif defined(WOLFSSL_RISCV_ASM)
+    /* implementation located in wolfcrypt/src/port/risc-v/riscv-64-aes.c */
+
 #elif defined(HAVE_COLDFIRE_SEC)
     #error "Coldfire SEC doesn't currently support AES-CCM mode"
 
@@ -10728,6 +10761,11 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
             authTagSz > AES_BLOCK_SIZE)
         return BAD_FUNC_ARG;
 
+    /* Sanity check on authIn to prevent segfault in xorbuf() where
+     * variable 'in' is dereferenced as the mask 'm' in misc.c */
+    if (authIn == NULL && authInSz > 0)
+        return BAD_FUNC_ARG;
+
     /* sanity check on tag size */
     if (wc_AesCcmCheckTagSize((int)authTagSz) != 0) {
         return BAD_FUNC_ARG;
@@ -10741,7 +10779,7 @@ int wc_AesCcmEncrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
         int crypto_cb_ret =
             wc_CryptoCb_AesCcmEncrypt(aes, out, in, inSz, nonce, nonceSz,
                                       authTag, authTagSz, authIn, authInSz);
-        if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+        if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return crypto_cb_ret;
         /* fall-through when unavailable */
     }
@@ -10870,6 +10908,11 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
         authTagSz > AES_BLOCK_SIZE)
         return BAD_FUNC_ARG;
 
+    /* Sanity check on authIn to prevent segfault in xorbuf() where
+     * variable 'in' is dereferenced as the mask 'm' in misc.c */
+    if (authIn == NULL && authInSz > 0)
+        return BAD_FUNC_ARG;
+
     /* sanity check on tag size */
     if (wc_AesCcmCheckTagSize((int)authTagSz) != 0) {
         return BAD_FUNC_ARG;
@@ -10883,7 +10926,7 @@ int  wc_AesCcmDecrypt(Aes* aes, byte* out, const byte* in, word32 inSz,
         int crypto_cb_ret =
             wc_CryptoCb_AesCcmDecrypt(aes, out, in, inSz, nonce, nonceSz,
             authTag, authTagSz, authIn, authInSz);
-        if (crypto_cb_ret != CRYPTOCB_UNAVAILABLE)
+        if (crypto_cb_ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return crypto_cb_ret;
         /* fall-through when unavailable */
     }
@@ -11354,6 +11397,9 @@ int wc_AesGetKeySize(Aes* aes, word32* keySize)
 #elif defined(WOLFSSL_DEVCRYPTO_AES)
     /* implemented in wolfcrypt/src/port/devcrypt/devcrypto_aes.c */
 
+#elif defined(WOLFSSL_RISCV_ASM)
+    /* implemented in wolfcrypt/src/port/riscv/riscv-64-aes.c */
+
 #elif defined(WOLFSSL_SCE) && !defined(WOLFSSL_SCE_NO_AES)
 
 /* Software AES - ECB */
@@ -11388,7 +11434,7 @@ static WARN_UNUSED_RESULT int _AesEcbEncrypt(
     #endif
     {
         ret = wc_CryptoCb_AesEcbEncrypt(aes, out, in, sz);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         ret = 0;
         /* fall-through when unavailable */
@@ -11428,6 +11474,7 @@ static WARN_UNUSED_RESULT int _AesEcbEncrypt(
     return ret;
 }
 
+#ifdef HAVE_AES_DECRYPT
 static WARN_UNUSED_RESULT int _AesEcbDecrypt(
     Aes* aes, byte* out, const byte* in, word32 sz)
 {
@@ -11439,7 +11486,7 @@ static WARN_UNUSED_RESULT int _AesEcbDecrypt(
     #endif
     {
         ret = wc_CryptoCb_AesEcbDecrypt(aes, out, in, sz);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         ret = 0;
         /* fall-through when unavailable */
@@ -11478,6 +11525,7 @@ static WARN_UNUSED_RESULT int _AesEcbDecrypt(
 
     return ret;
 }
+#endif
 
 int wc_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
@@ -11490,6 +11538,7 @@ int wc_AesEcbEncrypt(Aes* aes, byte* out, const byte* in, word32 sz)
     return _AesEcbEncrypt(aes, out, in, sz);
 }
 
+#ifdef HAVE_AES_DECRYPT
 int wc_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 {
     if ((in == NULL) || (out == NULL) || (aes == NULL))
@@ -11500,6 +11549,7 @@ int wc_AesEcbDecrypt(Aes* aes, byte* out, const byte* in, word32 sz)
 
     return _AesEcbDecrypt(aes, out, in, sz);
 }
+#endif /* HAVE_AES_DECRYPT */
 #endif
 #endif /* HAVE_AES_ECB */
 
@@ -11863,7 +11913,7 @@ static WARN_UNUSED_RESULT int wc_AesFeedbackCFB1(
     }
 
     if (ret == 0) {
-        if (bit > 0 && bit < 7) {
+        if (bit >= 0 && bit < 7) {
             out[0] = cur;
         }
     }
@@ -12313,11 +12363,15 @@ int wc_AesXtsSetKeyNoInit(XtsAes* aes, const byte* key, word32 len, int dir)
         return BAD_FUNC_ARG;
     }
 
-    keySz = len/2;
-    if (keySz != AES_128_KEY_SIZE && keySz != AES_256_KEY_SIZE) {
+    if ((len != (AES_128_KEY_SIZE*2)) &&
+        (len != (AES_192_KEY_SIZE*2)) &&
+        (len != (AES_256_KEY_SIZE*2)))
+    {
         WOLFSSL_MSG("Unsupported key size");
         return WC_KEY_SIZE_E;
     }
+
+    keySz = len/2;
 
 #ifdef HAVE_FIPS
     if (XMEMCMP(key, key + keySz, keySz) == 0) {
@@ -12350,7 +12404,7 @@ int wc_AesXtsSetKeyNoInit(XtsAes* aes, const byte* key, word32 len, int dir)
 
 #ifdef WOLFSSL_AESNI
     if (ret == 0) {
-        /* With WC_AES_C_DYNAMIC_FALLBACK, the main and tweak keys could have
+        /* With WC_C_DYNAMIC_FALLBACK, the main and tweak keys could have
          * conflicting _aesni status, but the AES-XTS asm implementations need
          * them to all be AESNI.  If any aren't, disable AESNI on all.
          */
@@ -12363,7 +12417,7 @@ int wc_AesXtsSetKeyNoInit(XtsAes* aes, const byte* key, word32 len, int dir)
               (dir == AES_ENCRYPTION_AND_DECRYPTION))
              && (aes->aes_decrypt.use_aesni != aes->tweak.use_aesni)))
         {
-        #ifdef WC_AES_C_DYNAMIC_FALLBACK
+        #ifdef WC_C_DYNAMIC_FALLBACK
             aes->aes.use_aesni = 0;
             aes->aes_decrypt.use_aesni = 0;
             aes->tweak.use_aesni = 0;
@@ -12373,7 +12427,7 @@ int wc_AesXtsSetKeyNoInit(XtsAes* aes, const byte* key, word32 len, int dir)
         }
     #else /* !WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS */
         if (aes->aes.use_aesni != aes->tweak.use_aesni) {
-        #ifdef WC_AES_C_DYNAMIC_FALLBACK
+        #ifdef WC_C_DYNAMIC_FALLBACK
             aes->aes.use_aesni = 0;
             aes->tweak.use_aesni = 0;
         #else
@@ -12502,12 +12556,28 @@ void AES_XTS_encrypt_aesni(const unsigned char *in, unsigned char *out, word32 s
                      const unsigned char* i, const unsigned char* key,
                      const unsigned char* key2, int nr)
                      XASM_LINK("AES_XTS_encrypt_aesni");
+#ifdef WOLFSSL_AESXTS_STREAM
+void AES_XTS_init_aesni(unsigned char* i, const unsigned char* tweak_key,
+                     int tweak_nr)
+                     XASM_LINK("AES_XTS_init_aesni");
+void AES_XTS_encrypt_update_aesni(const unsigned char *in, unsigned char *out, word32 sz,
+                     const unsigned char* key, unsigned char *i, int nr)
+                     XASM_LINK("AES_XTS_encrypt_update_aesni");
+#endif
 #ifdef HAVE_INTEL_AVX1
 void AES_XTS_encrypt_avx1(const unsigned char *in, unsigned char *out,
-                          word32 sz, const unsigned char* i,
-                          const unsigned char* key, const unsigned char* key2,
-                          int nr)
-                          XASM_LINK("AES_XTS_encrypt_avx1");
+                     word32 sz, const unsigned char* i,
+                     const unsigned char* key, const unsigned char* key2,
+                     int nr)
+                     XASM_LINK("AES_XTS_encrypt_avx1");
+#ifdef WOLFSSL_AESXTS_STREAM
+void AES_XTS_init_avx1(unsigned char* i, const unsigned char* tweak_key,
+                     int tweak_nr)
+                     XASM_LINK("AES_XTS_init_avx1");
+void AES_XTS_encrypt_update_avx1(const unsigned char *in, unsigned char *out, word32 sz,
+                     const unsigned char* key, unsigned char *i, int nr)
+                     XASM_LINK("AES_XTS_encrypt_update_avx1");
+#endif
 #endif /* HAVE_INTEL_AVX1 */
 
 #ifdef HAVE_AES_DECRYPT
@@ -12515,12 +12585,22 @@ void AES_XTS_decrypt_aesni(const unsigned char *in, unsigned char *out, word32 s
                      const unsigned char* i, const unsigned char* key,
                      const unsigned char* key2, int nr)
                      XASM_LINK("AES_XTS_decrypt_aesni");
+#ifdef WOLFSSL_AESXTS_STREAM
+void AES_XTS_decrypt_update_aesni(const unsigned char *in, unsigned char *out, word32 sz,
+                     const unsigned char* key, unsigned char *i, int nr)
+                     XASM_LINK("AES_XTS_decrypt_update_aesni");
+#endif
 #ifdef HAVE_INTEL_AVX1
 void AES_XTS_decrypt_avx1(const unsigned char *in, unsigned char *out,
-                          word32 sz, const unsigned char* i,
-                          const unsigned char* key, const unsigned char* key2,
-                          int nr)
-                          XASM_LINK("AES_XTS_decrypt_avx1");
+                     word32 sz, const unsigned char* i,
+                     const unsigned char* key, const unsigned char* key2,
+                     int nr)
+                     XASM_LINK("AES_XTS_decrypt_avx1");
+#ifdef WOLFSSL_AESXTS_STREAM
+void AES_XTS_decrypt_update_avx1(const unsigned char *in, unsigned char *out, word32 sz,
+                     const unsigned char* key, unsigned char *i, int nr)
+                     XASM_LINK("AES_XTS_decrypt_update_avx1");
+#endif
 #endif /* HAVE_INTEL_AVX1 */
 #endif /* HAVE_AES_DECRYPT */
 
@@ -12558,15 +12638,23 @@ static WARN_UNUSED_RESULT int _AesXtsHelper(
     }
 
     xorbuf(out, in, totalSz);
+#ifndef WOLFSSL_RISCV_ASM
     if (dir == AES_ENCRYPTION) {
         return _AesEcbEncrypt(aes, out, out, totalSz);
     }
     else {
         return _AesEcbDecrypt(aes, out, out, totalSz);
     }
+#else
+    if (dir == AES_ENCRYPTION) {
+        return wc_AesEcbEncrypt(aes, out, out, totalSz);
+    }
+    else {
+        return wc_AesEcbDecrypt(aes, out, out, totalSz);
+    }
+#endif
 }
 #endif /* HAVE_AES_ECB */
-
 
 /* AES with XTS mode. (XTS) XEX encryption with Tweak and cipher text Stealing.
  *
@@ -12579,27 +12667,63 @@ static WARN_UNUSED_RESULT int _AesXtsHelper(
  * returns 0 on success
  */
 /* Software AES - XTS Encrypt  */
+
+static int AesXtsEncryptUpdate_sw(XtsAes* xaes, byte* out, const byte* in,
+                                  word32 sz,
+                                  byte *i);
 static int AesXtsEncrypt_sw(XtsAes* xaes, byte* out, const byte* in, word32 sz,
         const byte* i)
+{
+    int ret;
+    byte tweak_block[AES_BLOCK_SIZE];
+
+    ret = wc_AesEncryptDirect(&xaes->tweak, tweak_block, i);
+    if (ret != 0)
+        return ret;
+
+    return AesXtsEncryptUpdate_sw(xaes, out, in, sz, tweak_block);
+}
+
+#ifdef WOLFSSL_AESXTS_STREAM
+
+/* Block-streaming AES-XTS tweak setup.
+ *
+ * xaes  AES keys to use for block encrypt/decrypt
+ * i     readwrite value to use for tweak
+ *
+ * returns 0 on success
+ */
+static int AesXtsInitTweak_sw(XtsAes* xaes, byte* i) {
+    return wc_AesEncryptDirect(&xaes->tweak, i, i);
+}
+
+#endif /* WOLFSSL_AESXTS_STREAM */
+
+/* Block-streaming AES-XTS.
+ *
+ * Supply block-aligned input data with successive calls.  Final call need not
+ * be block aligned.
+ *
+ * xaes  AES keys to use for block encrypt/decrypt
+ * out   output buffer to hold cipher text
+ * in    input plain text buffer to encrypt
+ * sz    size of both out and in buffers
+ *
+ * returns 0 on success
+ */
+/* Software AES - XTS Encrypt  */
+static int AesXtsEncryptUpdate_sw(XtsAes* xaes, byte* out, const byte* in,
+                                  word32 sz,
+                                  byte *i)
 {
     int ret = 0;
     word32 blocks = (sz / AES_BLOCK_SIZE);
     Aes *aes = &xaes->aes;
-    Aes *tweak = &xaes->tweak;
-    byte tmp[AES_BLOCK_SIZE];
-
-    XMEMSET(tmp, 0, AES_BLOCK_SIZE); /* set to 0's in case of improper AES
-                                      * key setup passed to encrypt direct*/
-
-    ret = wc_AesEncryptDirect(tweak, tmp, i);
-
-    if (ret != 0)
-        return ret;
 
 #ifdef HAVE_AES_ECB
     /* encrypt all of buffer at once when possible */
     if (in != out) { /* can not handle inline */
-        XMEMCPY(out, tmp, AES_BLOCK_SIZE);
+        XMEMCPY(out, i, AES_BLOCK_SIZE);
         if ((ret = _AesXtsHelper(aes, out, in, sz, AES_ENCRYPTION)) != 0)
             return ret;
     }
@@ -12616,23 +12740,23 @@ static int AesXtsEncrypt_sw(XtsAes* xaes, byte* out, const byte* in, word32 sz,
             byte buf[AES_BLOCK_SIZE];
 
             XMEMCPY(buf, in, AES_BLOCK_SIZE);
-            xorbuf(buf, tmp, AES_BLOCK_SIZE);
+            xorbuf(buf, i, AES_BLOCK_SIZE);
             ret = wc_AesEncryptDirect(aes, out, buf);
             if (ret != 0)
                 return ret;
         }
-        xorbuf(out, tmp, AES_BLOCK_SIZE);
+        xorbuf(out, i, AES_BLOCK_SIZE);
 
         /* multiply by shift left and propagate carry */
         for (j = 0; j < AES_BLOCK_SIZE; j++) {
             byte tmpC;
 
-            tmpC   = (tmp[j] >> 7) & 0x01;
-            tmp[j] = (byte)((tmp[j] << 1) + carry);
+            tmpC   = (i[j] >> 7) & 0x01;
+            i[j] = (byte)((i[j] << 1) + carry);
             carry  = tmpC;
         }
         if (carry) {
-            tmp[0] ^= GF_XTS;
+            i[0] ^= GF_XTS;
         }
 
         in  += AES_BLOCK_SIZE;
@@ -12661,10 +12785,10 @@ static int AesXtsEncrypt_sw(XtsAes* xaes, byte* out, const byte* in, word32 sz,
             XMEMCPY(out, buf2, sz);
         }
 
-        xorbuf(buf, tmp, AES_BLOCK_SIZE);
+        xorbuf(buf, i, AES_BLOCK_SIZE);
         ret = wc_AesEncryptDirect(aes, out - AES_BLOCK_SIZE, buf);
         if (ret == 0)
-            xorbuf(out - AES_BLOCK_SIZE, tmp, AES_BLOCK_SIZE);
+            xorbuf(out - AES_BLOCK_SIZE, i, AES_BLOCK_SIZE);
     }
 
     return ret;
@@ -12693,6 +12817,17 @@ int wc_AesXtsEncrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
         return BAD_FUNC_ARG;
     }
 
+#if FIPS_VERSION3_GE(6,0,0)
+    /* SP800-38E - Restrict data unit to 2^20 blocks per key. A block is
+     * AES_BLOCK_SIZE or 16-bytes (128-bits). So each key may only be used to
+     * protect up to 1,048,576 blocks of AES_BLOCK_SIZE (16,777,216 bytes)
+     */
+    if (sz > FIPS_AES_XTS_MAX_BYTES_PER_TWEAK) {
+        WOLFSSL_MSG("Request exceeds allowed bytes per SP800-38E");
+        return BAD_FUNC_ARG;
+    }
+#endif
+
     aes = &xaes->aes;
 
     if (aes->keylen == 0) {
@@ -12711,19 +12846,8 @@ int wc_AesXtsEncrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
 
     {
 #ifdef WOLFSSL_AESNI
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
-        int orig_use_aesni = aes->use_aesni;
-#endif
-
-        if (aes->use_aesni && ((ret = SAVE_VECTOR_REGISTERS2()) != 0)) {
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
-            aes->use_aesni = 0;
-            xaes->tweak.use_aesni = 0;
-#else
-            return ret;
-#endif
-        }
         if (aes->use_aesni) {
+            SAVE_VECTOR_REGISTERS(return _svr_ret;);
 #if defined(HAVE_INTEL_AVX1)
             if (IS_INTEL_AVX1(intel_flags)) {
                 AES_XTS_encrypt_avx1(in, out, sz, i,
@@ -12741,27 +12865,211 @@ int wc_AesXtsEncrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
                                       (int)aes->rounds);
                 ret = 0;
             }
+            RESTORE_VECTOR_REGISTERS();
         }
         else
 #endif
         {
             ret = AesXtsEncrypt_sw(xaes, out, in, sz, i);
         }
-
-#ifdef WOLFSSL_AESNI
-        if (aes->use_aesni)
-            RESTORE_VECTOR_REGISTERS();
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
-        else if (orig_use_aesni) {
-            aes->use_aesni = orig_use_aesni;
-            xaes->tweak.use_aesni = orig_use_aesni;
-        }
-#endif
-#endif
     }
 
     return ret;
 }
+
+#ifdef WOLFSSL_AESXTS_STREAM
+
+/* Block-streaming AES-XTS.
+ *
+ * xaes  AES keys to use for block encrypt/decrypt
+ * i     readwrite value to use for tweak
+ * iSz   size of i buffer, should always be AES_BLOCK_SIZE but having this input
+ *       adds a sanity check on how the user calls the function.
+ *
+ * returns 0 on success
+ */
+int wc_AesXtsEncryptInit(XtsAes* xaes, const byte* i, word32 iSz,
+                         struct XtsAesStreamData *stream)
+{
+    int ret;
+
+    Aes *aes;
+
+    if ((xaes == NULL) || (i == NULL) || (stream == NULL)) {
+        return BAD_FUNC_ARG;
+    }
+
+    if (iSz < AES_BLOCK_SIZE) {
+        return BAD_FUNC_ARG;
+    }
+
+    aes = &xaes->aes;
+
+    if (aes->keylen == 0) {
+        WOLFSSL_MSG("wc_AesXtsEncrypt called with unset encryption key.");
+        return BAD_FUNC_ARG;
+    }
+
+    XMEMCPY(stream->tweak_block, i, AES_BLOCK_SIZE);
+    stream->bytes_crypted_with_this_tweak = 0;
+
+    {
+#ifdef WOLFSSL_AESNI
+        if (aes->use_aesni) {
+            SAVE_VECTOR_REGISTERS(return _svr_ret;);
+#if defined(HAVE_INTEL_AVX1)
+            if (IS_INTEL_AVX1(intel_flags)) {
+                AES_XTS_init_avx1(stream->tweak_block,
+                                  (const byte*)xaes->tweak.key,
+                                  (int)xaes->tweak.rounds);
+                ret = 0;
+            }
+            else
+#endif
+            {
+                AES_XTS_init_aesni(stream->tweak_block,
+                                   (const byte*)xaes->tweak.key,
+                                   (int)xaes->tweak.rounds);
+                ret = 0;
+            }
+            RESTORE_VECTOR_REGISTERS();
+        }
+        else
+#endif /* WOLFSSL_AESNI */
+        {
+            ret = AesXtsInitTweak_sw(xaes, stream->tweak_block);
+        }
+    }
+
+    return ret;
+}
+
+/* Block-streaming AES-XTS
+ *
+ * Note that sz must be >= AES_BLOCK_SIZE in each call, and must be a multiple
+ * of AES_BLOCK_SIZE in each call to wc_AesXtsEncryptUpdate().
+ * wc_AesXtsEncryptFinal() can handle any length >= AES_BLOCK_SIZE.
+ *
+ * xaes  AES keys to use for block encrypt/decrypt
+ * out   output buffer to hold cipher text
+ * in    input plain text buffer to encrypt
+ * sz    size of both out and in buffers -- must be >= AES_BLOCK_SIZE.
+ * i     value to use for tweak
+ * iSz   size of i buffer, should always be AES_BLOCK_SIZE but having this input
+ *       adds a sanity check on how the user calls the function.
+ *
+ * returns 0 on success
+ */
+static int AesXtsEncryptUpdate(XtsAes* xaes, byte* out, const byte* in, word32 sz,
+                           struct XtsAesStreamData *stream)
+{
+    int ret;
+
+#ifdef WOLFSSL_AESNI
+    Aes *aes;
+#endif
+
+    if (xaes == NULL || out == NULL || in == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef WOLFSSL_AESNI
+    aes = &xaes->aes;
+#endif
+
+    if (sz < AES_BLOCK_SIZE) {
+        WOLFSSL_MSG("Plain text input too small for encryption");
+        return BAD_FUNC_ARG;
+    }
+
+    if (stream->bytes_crypted_with_this_tweak & ((word32)AES_BLOCK_SIZE - 1U))
+    {
+        WOLFSSL_MSG("Call to AesXtsEncryptUpdate after previous finalizing call");
+        return BAD_FUNC_ARG;
+    }
+
+#ifndef WC_AESXTS_STREAM_NO_REQUEST_ACCOUNTING
+    (void)WC_SAFE_SUM_WORD32(stream->bytes_crypted_with_this_tweak, sz,
+                             stream->bytes_crypted_with_this_tweak);
+#endif
+#if FIPS_VERSION3_GE(6,0,0)
+    /* SP800-38E - Restrict data unit to 2^20 blocks per key. A block is
+     * AES_BLOCK_SIZE or 16-bytes (128-bits). So each key may only be used to
+     * protect up to 1,048,576 blocks of AES_BLOCK_SIZE (16,777,216 bytes)
+     */
+    if (stream->bytes_crypted_with_this_tweak >
+        FIPS_AES_XTS_MAX_BYTES_PER_TWEAK)
+    {
+        WOLFSSL_MSG("Request exceeds allowed bytes per SP800-38E");
+        return BAD_FUNC_ARG;
+    }
+#endif
+    {
+#ifdef WOLFSSL_AESNI
+        if (aes->use_aesni) {
+            SAVE_VECTOR_REGISTERS(return _svr_ret;);
+#if defined(HAVE_INTEL_AVX1)
+            if (IS_INTEL_AVX1(intel_flags)) {
+                AES_XTS_encrypt_update_avx1(in, out, sz,
+                                            (const byte*)aes->key,
+                                            stream->tweak_block,
+                                            (int)aes->rounds);
+                ret = 0;
+            }
+            else
+#endif
+            {
+                AES_XTS_encrypt_update_aesni(in, out, sz,
+                                            (const byte*)aes->key,
+                                            stream->tweak_block,
+                                            (int)aes->rounds);
+                ret = 0;
+            }
+            RESTORE_VECTOR_REGISTERS();
+        }
+        else
+#endif /* WOLFSSL_AESNI */
+        {
+            ret = AesXtsEncryptUpdate_sw(xaes, out, in, sz, stream->tweak_block);
+        }
+    }
+
+    return ret;
+}
+
+int wc_AesXtsEncryptUpdate(XtsAes* xaes, byte* out, const byte* in, word32 sz,
+                           struct XtsAesStreamData *stream)
+{
+    if (stream == NULL)
+        return BAD_FUNC_ARG;
+    if (sz & ((word32)AES_BLOCK_SIZE - 1U))
+        return BAD_FUNC_ARG;
+    return AesXtsEncryptUpdate(xaes, out, in, sz, stream);
+}
+
+int wc_AesXtsEncryptFinal(XtsAes* xaes, byte* out, const byte* in, word32 sz,
+                           struct XtsAesStreamData *stream)
+{
+    int ret;
+    if (stream == NULL)
+        return BAD_FUNC_ARG;
+    if (sz > 0)
+        ret = AesXtsEncryptUpdate(xaes, out, in, sz, stream);
+    else
+        ret = 0;
+    /* force the count odd, to assure error on attempt to AesXtsEncryptUpdate()
+     * after finalization.
+     */
+    stream->bytes_crypted_with_this_tweak |= 1U;
+    ForceZero(stream->tweak_block, AES_BLOCK_SIZE);
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Check(stream->tweak_block, AES_BLOCK_SIZE);
+#endif
+    return ret;
+}
+
+#endif /* WOLFSSL_AESXTS_STREAM */
+
 
 /* Same process as encryption but use aes_decrypt key.
  *
@@ -12774,8 +13082,41 @@ int wc_AesXtsEncrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
  * returns 0 on success
  */
 /* Software AES - XTS Decrypt */
+
+static int AesXtsDecryptUpdate_sw(XtsAes* xaes, byte* out, const byte* in,
+                                  word32 sz, byte *i);
+
 static int AesXtsDecrypt_sw(XtsAes* xaes, byte* out, const byte* in, word32 sz,
         const byte* i)
+{
+    int ret;
+    byte tweak_block[AES_BLOCK_SIZE];
+
+    ret = wc_AesEncryptDirect(&xaes->tweak, tweak_block, i);
+    if (ret != 0)
+        return ret;
+
+    return AesXtsDecryptUpdate_sw(xaes, out, in, sz, tweak_block);
+}
+
+/* Block-streaming AES-XTS.
+ *
+ * Same process as encryption but use decrypt key.
+ *
+ * Supply block-aligned input data with successive calls.  Final call need not
+ * be block aligned.
+ *
+ * xaes  AES keys to use for block encrypt/decrypt
+ * out   output buffer to hold plain text
+ * in    input cipher text buffer to decrypt
+ * sz    size of both out and in buffers
+ * i     value to use for tweak
+ *
+ * returns 0 on success
+ */
+/* Software AES - XTS Decrypt */
+static int AesXtsDecryptUpdate_sw(XtsAes* xaes, byte* out, const byte* in,
+                                  word32 sz, byte *i)
 {
     int ret = 0;
     word32 blocks = (sz / AES_BLOCK_SIZE);
@@ -12784,18 +13125,9 @@ static int AesXtsDecrypt_sw(XtsAes* xaes, byte* out, const byte* in, word32 sz,
 #else
     Aes *aes = &xaes->aes;
 #endif
-    Aes *tweak = &xaes->tweak;
     word32 j;
     byte carry = 0;
-    byte tmp[AES_BLOCK_SIZE];
     byte stl = (sz % AES_BLOCK_SIZE);
-
-    XMEMSET(tmp, 0, AES_BLOCK_SIZE); /* set to 0's in case of improper AES
-                                      * key setup passed to decrypt direct*/
-
-    ret = wc_AesEncryptDirect(tweak, tmp, i);
-    if (ret != 0)
-        return ret;
 
     /* if Stealing then break out of loop one block early to handle special
      * case */
@@ -12806,7 +13138,7 @@ static int AesXtsDecrypt_sw(XtsAes* xaes, byte* out, const byte* in, word32 sz,
 #ifdef HAVE_AES_ECB
     /* decrypt all of buffer at once when possible */
     if (in != out) { /* can not handle inline */
-        XMEMCPY(out, tmp, AES_BLOCK_SIZE);
+        XMEMCPY(out, i, AES_BLOCK_SIZE);
         if ((ret = _AesXtsHelper(aes, out, in, sz, AES_DECRYPTION)) != 0)
             return ret;
     }
@@ -12820,23 +13152,23 @@ static int AesXtsDecrypt_sw(XtsAes* xaes, byte* out, const byte* in, word32 sz,
             byte buf[AES_BLOCK_SIZE];
 
             XMEMCPY(buf, in, AES_BLOCK_SIZE);
-            xorbuf(buf, tmp, AES_BLOCK_SIZE);
+            xorbuf(buf, i, AES_BLOCK_SIZE);
             ret = wc_AesDecryptDirect(aes, out, buf);
             if (ret != 0)
                 return ret;
         }
-        xorbuf(out, tmp, AES_BLOCK_SIZE);
+        xorbuf(out, i, AES_BLOCK_SIZE);
 
         /* multiply by shift left and propagate carry */
         for (j = 0; j < AES_BLOCK_SIZE; j++) {
             byte tmpC;
 
-            tmpC   = (tmp[j] >> 7) & 0x01;
-            tmp[j] = (byte)((tmp[j] << 1) + carry);
+            tmpC   = (i[j] >> 7) & 0x01;
+            i[j] = (byte)((i[j] << 1) + carry);
             carry  = tmpC;
         }
         if (carry) {
-            tmp[0] ^= GF_XTS;
+            i[0] ^= GF_XTS;
         }
         carry = 0;
 
@@ -12855,8 +13187,8 @@ static int AesXtsDecrypt_sw(XtsAes* xaes, byte* out, const byte* in, word32 sz,
         for (j = 0; j < AES_BLOCK_SIZE; j++) {
             byte tmpC;
 
-            tmpC   = (tmp[j] >> 7) & 0x01;
-            tmp2[j] = (byte)((tmp[j] << 1) + carry);
+            tmpC   = (i[j] >> 7) & 0x01;
+            tmp2[j] = (byte)((i[j] << 1) + carry);
             carry  = tmpC;
         }
         if (carry) {
@@ -12884,11 +13216,11 @@ static int AesXtsDecrypt_sw(XtsAes* xaes, byte* out, const byte* in, word32 sz,
         XMEMCPY(buf, in,   sz);
         XMEMCPY(out, tmp2, sz);
 
-        xorbuf(buf, tmp, AES_BLOCK_SIZE);
+        xorbuf(buf, i, AES_BLOCK_SIZE);
         ret = wc_AesDecryptDirect(aes, tmp2, buf);
         if (ret != 0)
             return ret;
-        xorbuf(tmp2, tmp, AES_BLOCK_SIZE);
+        xorbuf(tmp2, i, AES_BLOCK_SIZE);
         XMEMCPY(out - AES_BLOCK_SIZE, tmp2, AES_BLOCK_SIZE);
     }
 
@@ -12923,6 +13255,14 @@ int wc_AesXtsDecrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
     aes = &xaes->aes;
 #endif
 
+/* FIPS TODO: SP800-38E - Restrict data unit to 2^20 blocks per key. A block is
+ * AES_BLOCK_SIZE or 16-bytes (128-bits). So each key may only be used to
+ * protect up to 1,048,576 blocks of AES_BLOCK_SIZE (16,777,216 bytes or
+ * 134,217,728-bits) Add helpful printout and message along with BAD_FUNC_ARG
+ * return whenever sz / AES_BLOCK_SIZE > 1,048,576 or equal to that and sz is
+ * not a sequence of complete blocks.
+ */
+
     if (aes->keylen == 0) {
         WOLFSSL_MSG("wc_AesXtsDecrypt called with unset decryption key.");
         return BAD_FUNC_ARG;
@@ -12939,19 +13279,8 @@ int wc_AesXtsDecrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
 
     {
 #ifdef WOLFSSL_AESNI
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
-        int orig_use_aesni = aes->use_aesni;
-#endif
-
-        if (aes->use_aesni && ((ret = SAVE_VECTOR_REGISTERS2() != 0))) {
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
-            aes->use_aesni = 0;
-            xaes->tweak.use_aesni = 0;
-#else
-            return ret;
-#endif
-        }
         if (aes->use_aesni) {
+            SAVE_VECTOR_REGISTERS(return _svr_ret;);
 #if defined(HAVE_INTEL_AVX1)
             if (IS_INTEL_AVX1(intel_flags)) {
                 AES_XTS_decrypt_avx1(in, out, sz, i,
@@ -12969,6 +13298,7 @@ int wc_AesXtsDecrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
                                       (int)aes->rounds);
                 ret = 0;
             }
+            RESTORE_VECTOR_REGISTERS();
         }
         else
 #endif
@@ -12976,20 +13306,198 @@ int wc_AesXtsDecrypt(XtsAes* xaes, byte* out, const byte* in, word32 sz,
             ret = AesXtsDecrypt_sw(xaes, out, in, sz, i);
         }
 
-#ifdef WOLFSSL_AESNI
-        if (aes->use_aesni)
-            RESTORE_VECTOR_REGISTERS();
-#ifdef WC_AES_C_DYNAMIC_FALLBACK
-        else if (orig_use_aesni) {
-            aes->use_aesni = orig_use_aesni;
-            xaes->tweak.use_aesni = orig_use_aesni;
-        }
-#endif
-#endif
-
         return ret;
     }
 }
+
+#ifdef WOLFSSL_AESXTS_STREAM
+
+/* Same process as encryption but Aes key is AES_DECRYPTION type.
+ *
+ * xaes  AES keys to use for block encrypt/decrypt
+ * i     readwrite value to use for tweak
+ * iSz   size of i buffer, should always be AES_BLOCK_SIZE but having this input
+ *       adds a sanity check on how the user calls the function.
+ *
+ * returns 0 on success
+ */
+int wc_AesXtsDecryptInit(XtsAes* xaes, const byte* i, word32 iSz,
+                         struct XtsAesStreamData *stream)
+{
+    int ret;
+    Aes *aes;
+
+    if (xaes == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
+    aes = &xaes->aes_decrypt;
+#else
+    aes = &xaes->aes;
+#endif
+
+    if (aes->keylen == 0) {
+        WOLFSSL_MSG("wc_AesXtsDecrypt called with unset decryption key.");
+        return BAD_FUNC_ARG;
+    }
+
+    if (iSz < AES_BLOCK_SIZE) {
+        return BAD_FUNC_ARG;
+    }
+
+    XMEMCPY(stream->tweak_block, i, AES_BLOCK_SIZE);
+    stream->bytes_crypted_with_this_tweak = 0;
+
+    {
+#ifdef WOLFSSL_AESNI
+        if (aes->use_aesni) {
+            SAVE_VECTOR_REGISTERS(return _svr_ret;);
+#if defined(HAVE_INTEL_AVX1)
+            if (IS_INTEL_AVX1(intel_flags)) {
+                AES_XTS_init_avx1(stream->tweak_block,
+                                  (const byte*)xaes->tweak.key,
+                                  (int)xaes->tweak.rounds);
+                ret = 0;
+            }
+            else
+#endif
+            {
+                AES_XTS_init_aesni(stream->tweak_block,
+                                   (const byte*)xaes->tweak.key,
+                                   (int)xaes->tweak.rounds);
+                ret = 0;
+            }
+            RESTORE_VECTOR_REGISTERS();
+        }
+        else
+#endif /* WOLFSSL_AESNI */
+        {
+            ret = AesXtsInitTweak_sw(xaes, stream->tweak_block);
+        }
+
+    }
+
+    return ret;
+}
+
+/* Block-streaming AES-XTS
+ *
+ * Note that sz must be >= AES_BLOCK_SIZE in each call, and must be a multiple
+ * of AES_BLOCK_SIZE in each call to wc_AesXtsDecryptUpdate().
+ * wc_AesXtsDecryptFinal() can handle any length >= AES_BLOCK_SIZE.
+ *
+ * xaes  AES keys to use for block encrypt/decrypt
+ * out   output buffer to hold plain text
+ * in    input cipher text buffer to decrypt
+ * sz    size of both out and in buffers
+ * i     tweak buffer of size AES_BLOCK_SIZE.
+ *
+ * returns 0 on success
+ */
+static int AesXtsDecryptUpdate(XtsAes* xaes, byte* out, const byte* in, word32 sz,
+                           struct XtsAesStreamData *stream)
+{
+    int ret;
+#ifdef WOLFSSL_AESNI
+    Aes *aes;
+#endif
+
+    if (xaes == NULL || out == NULL || in == NULL) {
+        return BAD_FUNC_ARG;
+    }
+
+#ifdef WOLFSSL_AESNI
+#ifdef WC_AES_XTS_SUPPORT_SIMULTANEOUS_ENC_AND_DEC_KEYS
+    aes = &xaes->aes_decrypt;
+#else
+    aes = &xaes->aes;
+#endif
+#endif
+
+    if (sz < AES_BLOCK_SIZE) {
+        WOLFSSL_MSG("Cipher text input too small for decryption");
+        return BAD_FUNC_ARG;
+    }
+
+    if (stream->bytes_crypted_with_this_tweak & ((word32)AES_BLOCK_SIZE - 1U))
+    {
+        WOLFSSL_MSG("Call to AesXtsDecryptUpdate after previous finalizing call");
+        return BAD_FUNC_ARG;
+    }
+
+#ifndef WC_AESXTS_STREAM_NO_REQUEST_ACCOUNTING
+    (void)WC_SAFE_SUM_WORD32(stream->bytes_crypted_with_this_tweak, sz,
+                             stream->bytes_crypted_with_this_tweak);
+#endif
+
+    {
+#ifdef WOLFSSL_AESNI
+        if (aes->use_aesni) {
+            SAVE_VECTOR_REGISTERS(return _svr_ret;);
+#if defined(HAVE_INTEL_AVX1)
+            if (IS_INTEL_AVX1(intel_flags)) {
+                AES_XTS_decrypt_update_avx1(in, out, sz,
+                                            (const byte*)aes->key,
+                                            stream->tweak_block,
+                                            (int)aes->rounds);
+                ret = 0;
+            }
+            else
+#endif
+            {
+                AES_XTS_decrypt_update_aesni(in, out, sz,
+                                             (const byte*)aes->key,
+                                             stream->tweak_block,
+                                             (int)aes->rounds);
+                ret = 0;
+            }
+            RESTORE_VECTOR_REGISTERS();
+        }
+        else
+#endif /* WOLFSSL_AESNI */
+        {
+            ret = AesXtsDecryptUpdate_sw(xaes, out, in, sz,
+                                         stream->tweak_block);
+        }
+    }
+
+    return ret;
+}
+
+int wc_AesXtsDecryptUpdate(XtsAes* xaes, byte* out, const byte* in, word32 sz,
+                           struct XtsAesStreamData *stream)
+{
+    if (stream == NULL)
+        return BAD_FUNC_ARG;
+    if (sz & ((word32)AES_BLOCK_SIZE - 1U))
+        return BAD_FUNC_ARG;
+    return AesXtsDecryptUpdate(xaes, out, in, sz, stream);
+}
+
+int wc_AesXtsDecryptFinal(XtsAes* xaes, byte* out, const byte* in, word32 sz,
+                           struct XtsAesStreamData *stream)
+{
+    int ret;
+    if (stream == NULL)
+        return BAD_FUNC_ARG;
+    if (sz > 0)
+        ret = AesXtsDecryptUpdate(xaes, out, in, sz, stream);
+    else
+        ret = 0;
+    ForceZero(stream->tweak_block, AES_BLOCK_SIZE);
+    /* force the count odd, to assure error on attempt to AesXtsEncryptUpdate()
+     * after finalization.
+     */
+    stream->bytes_crypted_with_this_tweak |= 1U;
+#ifdef WOLFSSL_CHECK_MEM_ZERO
+    wc_MemZero_Check(stream->tweak_block, AES_BLOCK_SIZE);
+#endif
+    return ret;
+}
+
+#endif /* WOLFSSL_AESXTS_STREAM */
+
 #endif /* !WOLFSSL_ARMASM || WOLFSSL_ARMASM_NO_HW_CRYPTO */
 
 /* Same as wc_AesXtsEncryptSector but the sector gets incremented by one every

--- a/libatalk/ssl/wolfcrypt/src/asn.c
+++ b/libatalk/ssl/wolfcrypt/src/asn.c
@@ -166,16 +166,14 @@ ASN Options:
     #include <wolfssl/wolfcrypt/curve448.h>
 #endif
 
-#ifdef HAVE_PQC
-    #if defined(HAVE_FALCON)
+#if defined(HAVE_FALCON)
     #include <wolfssl/wolfcrypt/falcon.h>
-    #endif
-    #if defined(HAVE_DILITHIUM)
+#endif
+#if defined(HAVE_DILITHIUM)
     #include <wolfssl/wolfcrypt/dilithium.h>
-    #endif
-    #if defined(HAVE_SPHINCS)
+#endif
+#if defined(HAVE_SPHINCS)
     #include <wolfssl/wolfcrypt/sphincs.h>
-    #endif
 #endif
 
 #ifdef WOLFSSL_QNX_CAAM
@@ -1203,14 +1201,14 @@ static int GetASN_ObjectId(const byte* input, word32 idx, int length)
     /* OID data must be at least 3 bytes. */
     if (length < 3) {
     #ifdef WOLFSSL_DEBUG_ASN_TEMPLATE
-        WOLFSSL_MSG_VSNPRINTF("OID length must be 3 or more: %d", len);
+        WOLFSSL_MSG_VSNPRINTF("OID length must be 3 or more: %d", length);
     #else
         WOLFSSL_MSG("OID length less than 3");
     #endif
         ret = ASN_PARSE_E;
     }
-    /* Last octet of a subidentifier has bit 8 clear. Last octet must be last
-     * of a subidentifier. Ensure last octet hasn't got top bit set indicating.
+    /* Last octet of a sub-identifier has bit 8 clear. Last octet must be last
+     * of a subidentifier. Ensure last octet hasn't got top bit set.
      */
     else if ((input[(int)idx + length - 1] & 0x80) != 0x00) {
         WOLFSSL_MSG("OID last octet has top bit set");
@@ -3496,7 +3494,7 @@ int CheckBitString(const byte* input, word32* inOutIdx, int* len,
 #else
     ASNGetData dataASN[bitStringASN_Length];
     int ret;
-    int bits;
+    int bits = 0;
 
     /* Parse BIT_STRING and check validity of unused bits. */
     XMEMSET(dataASN, 0, sizeof(dataASN));
@@ -3534,7 +3532,7 @@ int CheckBitString(const byte* input, word32* inOutIdx, int* len,
     ((defined(HAVE_ED25519) || defined(HAVE_ED448)) && \
      (defined(WOLFSSL_CERT_GEN) || defined(WOLFSSL_KEY_GEN) || \
       defined(OPENSSL_EXTRA))) || \
-    (defined(WC_ENABLE_ASYM_KEY_EXPORT) && !defined(NO_CERT)) || \
+    (defined(WC_ENABLE_ASYM_KEY_EXPORT) && !defined(NO_CERTS)) || \
     (!defined(NO_DSA) && !defined(HAVE_SELFTEST) && defined(WOLFSSL_KEY_GEN)) || \
     (!defined(NO_DH) && defined(WOLFSSL_DH_EXTRA))
 
@@ -4200,7 +4198,6 @@ static word32 SetBitString16Bit(word16 val, byte* output)
 #ifdef HAVE_ED448
     static const byte sigEd448Oid[] = {43, 101, 113};
 #endif /* HAVE_ED448 */
-#ifdef HAVE_PQC
 #ifdef HAVE_FALCON
     /* Falcon Level 1: 1 3 9999 3 6 */
     static const byte sigFalcon_Level1Oid[] = {43, 206, 15, 3, 6};
@@ -4209,17 +4206,17 @@ static word32 SetBitString16Bit(word16 val, byte* output)
     static const byte sigFalcon_Level5Oid[] = {43, 206, 15, 3, 9};
 #endif /* HAVE_FACON */
 #ifdef HAVE_DILITHIUM
-    /* Dilithium Level 2: 1.3.6.1.4.1.2.267.7.4.4 */
+    /* Dilithium Level 2: 1.3.6.1.4.1.2.267.12.4.4 */
     static const byte sigDilithium_Level2Oid[] =
-        {43, 6, 1, 4, 1, 2, 130, 11, 7, 4, 4};
+        {43, 6, 1, 4, 1, 2, 130, 11, 12, 4, 4};
 
-    /* Dilithium Level 3: 1.3.6.1.4.1.2.267.7.6.5 */
+    /* Dilithium Level 3: 1.3.6.1.4.1.2.267.12.6.5 */
     static const byte sigDilithium_Level3Oid[] =
-        {43, 6, 1, 4, 1, 2, 130, 11, 7, 6, 5};
+        {43, 6, 1, 4, 1, 2, 130, 11, 12, 6, 5};
 
-    /* Dilithium Level 5: 1.3.6.1.4.1.2.267.7.8.7 */
+    /* Dilithium Level 5: 1.3.6.1.4.1.2.267.12.8.7 */
     static const byte sigDilithium_Level5Oid[] =
-        {43, 6, 1, 4, 1, 2, 130, 11, 7, 8, 7};
+        {43, 6, 1, 4, 1, 2, 130, 11, 12, 8, 7};
 #endif /* HAVE_DILITHIUM */
 #ifdef HAVE_SPHINCS
     /* Sphincs Fast Level 1: 1 3 9999 6 7 4 */
@@ -4246,7 +4243,6 @@ static word32 SetBitString16Bit(word16 val, byte* output)
     static const byte sigSphincsSmall_Level5Oid[] =
         {43, 206, 15, 6, 9, 7};
 #endif /* HAVE_SPHINCS */
-#endif /* HAVE_PQC */
 
 /* keyType */
 #ifndef NO_DSA
@@ -4276,7 +4272,6 @@ static word32 SetBitString16Bit(word16 val, byte* output)
 #ifndef NO_DH
     static const byte keyDhOid[] = {42, 134, 72, 134, 247, 13, 1, 3, 1};
 #endif /* !NO_DH */
-#ifdef HAVE_PQC
 #ifdef HAVE_FALCON
     /* Falcon Level 1: 1 3 9999 3 6 */
     static const byte keyFalcon_Level1Oid[] = {43, 206, 15, 3, 6};
@@ -4285,17 +4280,17 @@ static word32 SetBitString16Bit(word16 val, byte* output)
     static const byte keyFalcon_Level5Oid[] = {43, 206, 15, 3, 9};
 #endif /* HAVE_FALCON */
 #ifdef HAVE_DILITHIUM
-    /* Dilithium Level 2: 1.3.6.1.4.1.2.267.7.4.4 */
+    /* Dilithium Level 2: 1.3.6.1.4.1.2.267.12.4.4 */
     static const byte keyDilithium_Level2Oid[] =
-        {43, 6, 1, 4, 1, 2, 130, 11, 7, 4, 4};
+        {43, 6, 1, 4, 1, 2, 130, 11, 12, 4, 4};
 
-    /* Dilithium Level 3: 1.3.6.1.4.1.2.267.7.6.5 */
+    /* Dilithium Level 3: 1.3.6.1.4.1.2.267.12.6.5 */
     static const byte keyDilithium_Level3Oid[] =
-        {43, 6, 1, 4, 1, 2, 130, 11, 7, 6, 5};
+        {43, 6, 1, 4, 1, 2, 130, 11, 12, 6, 5};
 
-    /* Dilithium Level 5: 1.3.6.1.4.1.2.267.7.8.7 */
+    /* Dilithium Level 5: 1.3.6.1.4.1.2.267.12.8.7 */
     static const byte keyDilithium_Level5Oid[] =
-        {43, 6, 1, 4, 1, 2, 130, 11, 7, 8, 7};
+        {43, 6, 1, 4, 1, 2, 130, 11, 12, 8, 7};
 #endif /* HAVE_DILITHIUM */
 #ifdef HAVE_SPHINCS
     /* Sphincs Fast Level 1: 1 3 9999 6 7 4 */
@@ -4322,7 +4317,6 @@ static word32 SetBitString16Bit(word16 val, byte* output)
     static const byte keySphincsSmall_Level5Oid[] =
         {43, 206, 15, 6, 9, 7};
 #endif /* HAVE_SPHINCS */
-#endif /* HAVE_PQC */
 
 /* curveType */
 #ifdef HAVE_ECC
@@ -4830,7 +4824,6 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                     *oidSz = sizeof(sigEd448Oid);
                     break;
                 #endif
-                #ifdef HAVE_PQC
                 #ifdef HAVE_FALCON
                 case CTC_FALCON_LEVEL1:
                     oid = sigFalcon_Level1Oid;
@@ -4881,7 +4874,6 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                     *oidSz = sizeof(sigSphincsSmall_Level5Oid);
                     break;
                 #endif /* HAVE_SPHINCS */
-                #endif /* HAVE_PQC */
                 default:
                     break;
             }
@@ -4943,7 +4935,6 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                     *oidSz = sizeof(keyDhOid);
                     break;
                 #endif /* !NO_DH */
-                #ifdef HAVE_PQC
                 #ifdef HAVE_FALCON
                 case FALCON_LEVEL1k:
                     oid = keyFalcon_Level1Oid;
@@ -4994,7 +4985,6 @@ const byte* OidFromId(word32 id, word32 type, word32* oidSz)
                     *oidSz = sizeof(keySphincsSmall_Level5Oid);
                     break;
                 #endif /* HAVE_SPHINCS */
-                #endif /* HAVE_PQC */
                 default:
                     break;
             }
@@ -5875,7 +5865,7 @@ static int GetOID(const byte* input, word32* inOutIdx, word32* oid,
     const byte* checkOid = NULL;
     word32 checkOidSz;
 #endif /* NO_VERIFY_OID */
-#ifdef HAVE_PQC
+#if defined(HAVE_SPHINCS)
     word32 found_collision = 0;
 #endif
     (void)oidType;
@@ -5887,7 +5877,7 @@ static int GetOID(const byte* input, word32* inOutIdx, word32* oid,
     actualOidSz = (word32)length;
 #endif /* NO_VERIFY_OID */
 
-#if defined(HAVE_PQC) && defined(HAVE_LIBOQS) && defined(HAVE_SPHINCS)
+#if defined(HAVE_SPHINCS)
     /* Since we are summing it up, there could be collisions...and indeed there
      * are: SPHINCS_FAST_LEVEL1 and SPHINCS_FAST_LEVEL3.
      *
@@ -5901,7 +5891,7 @@ static int GetOID(const byte* input, word32* inOutIdx, word32* oid,
                sizeof(sigSphincsFast_Level3Oid)) == 0) {
         found_collision = SPHINCS_FAST_LEVEL3k;
     }
-#endif /* HAVE_PQC */
+#endif /* HAVE_SPHINCS */
 
     /* Sum it up for now. */
     while (length--) {
@@ -5910,11 +5900,11 @@ static int GetOID(const byte* input, word32* inOutIdx, word32* oid,
         idx++;
     }
 
-#ifdef HAVE_PQC
+#ifdef HAVE_SPHINCS
     if (found_collision) {
         *oid = found_collision;
     }
-#endif /* HAVE_PQC */
+#endif /* HAVE_SPHINCS */
 
     /* Return the index after the OID data. */
     *inOutIdx = idx;
@@ -6933,7 +6923,7 @@ int ToTraditionalInline_ex(const byte* input, word32* inOutIdx, word32 sz,
 
     ret = GetOctetString(input, &idx, &length, sz);
     if (ret < 0) {
-        if (ret == BUFFER_E)
+        if (ret == WC_NO_ERR_TRACE(BUFFER_E))
             return ASN_PARSE_E;
         /* Some private keys don't expect an octet string */
         WOLFSSL_MSG("Couldn't find Octet string");
@@ -7227,7 +7217,7 @@ int wc_CreatePKCS8Key(byte* out, word32* outSz, byte* key, word32 keySz,
     return (int)(tmpSz + sz);
 #else
     DECL_ASNSETDATA(dataASN, pkcs8KeyASN_Length);
-    int sz;
+    int sz = 0;
     int ret = 0;
     word32 keyIdx = 0;
     word32 tmpAlgId = 0;
@@ -7565,7 +7555,6 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
     }
     else
     #endif /* HAVE_ED448 && HAVE_ED448_KEY_IMPORT && !NO_ASN_CRYPT */
-    #if defined(HAVE_PQC)
     #if defined(HAVE_FALCON)
     if ((ks == FALCON_LEVEL1k) || (ks == FALCON_LEVEL5k)) {
     #ifdef WOLFSSL_SMALL_STACK
@@ -7627,7 +7616,8 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
     }
     else
     #endif /* HAVE_FALCON */
-    #if defined(HAVE_DILITHIUM)
+#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
+    !defined(WOLFSSL_DILITHIUM_NO_VERIFY) && !defined(WOLFSSL_DILITHIUM_NO_ASN1)
     if ((ks == DILITHIUM_LEVEL2k) ||
         (ks == DILITHIUM_LEVEL3k) ||
         (ks == DILITHIUM_LEVEL5k)) {
@@ -7685,7 +7675,7 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
     #endif
     }
     else
-    #endif /* HAVE_DILITHIUM */
+#endif /* HAVE_DILITHIUM && !WOLFSSL_DILITHIUM_VERIFY_ONLY */
     #if defined(HAVE_SPHINCS)
     if ((ks == SPHINCS_FAST_LEVEL1k) ||
         (ks == SPHINCS_FAST_LEVEL3k) ||
@@ -7757,7 +7747,6 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
     }
     else
     #endif /* HAVE_SPHINCS */
-    #endif /* HAVE_PQC */
     {
         ret = 0;
     }
@@ -7770,17 +7759,59 @@ int wc_CheckPrivateKey(const byte* privKey, word32 privKeySz,
  * return 1 (true) on match
  * return 0 or negative value on failure/error
  *
- * key   : buffer holding DER format key
- * keySz : size of key buffer
- * der   : a initialized and parsed DecodedCert holding a certificate */
-int wc_CheckPrivateKeyCert(const byte* key, word32 keySz, DecodedCert* der)
+ * key      : buffer holding DER format key
+ * keySz    : size of key buffer
+ * der      : a initialized and parsed DecodedCert holding a certificate
+ * checkAlt : indicate if we check primary or alternative key
+ */
+int wc_CheckPrivateKeyCert(const byte* key, word32 keySz, DecodedCert* der,
+                           int checkAlt)
 {
+    int ret = 0;
+
     if (key == NULL || der == NULL) {
         return BAD_FUNC_ARG;
     }
 
-    return wc_CheckPrivateKey(key, keySz, der->publicKey,
-            der->pubKeySize, (enum Key_Sum) der->keyOID);
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+    if (checkAlt && der->sapkiDer != NULL) {
+        /* We have to decode the public key first */
+        word32 idx = 0;
+        /* Dilithium has the largest public key at the moment */
+        word32 pubKeyLen = DILITHIUM_MAX_PUB_KEY_SIZE;
+        byte* decodedPubKey = (byte*)XMALLOC(pubKeyLen, NULL,
+                                             DYNAMIC_TYPE_PUBLIC_KEY);
+        if (decodedPubKey == NULL) {
+            ret = MEMORY_E;
+        }
+        if (ret == 0) {
+            if (der->sapkiOID == RSAk || der->sapkiOID == ECDSAk) {
+                /* Simply copy the data */
+                XMEMCPY(decodedPubKey, der->sapkiDer, der->sapkiLen);
+                pubKeyLen = der->sapkiLen;
+            }
+            else {
+                ret = DecodeAsymKeyPublic(der->sapkiDer, &idx, der->sapkiLen,
+                                          decodedPubKey, &pubKeyLen,
+                                          der->sapkiOID);
+            }
+        }
+        if (ret == 0) {
+            ret = wc_CheckPrivateKey(key, keySz, decodedPubKey, pubKeyLen,
+                                     (enum Key_Sum) der->sapkiOID);
+        }
+        XFREE(decodedPubKey, NULL, DYNAMIC_TYPE_PUBLIC_KEY);
+    }
+    else
+#endif
+    {
+        ret = wc_CheckPrivateKey(key, keySz, der->publicKey,
+                der->pubKeySize, (enum Key_Sum) der->keyOID);
+    }
+
+    (void)checkAlt;
+
+    return ret;
 }
 
 #endif /* HAVE_PKCS12 || !NO_CHECK_PRIVATE_KEY */
@@ -8060,7 +8091,6 @@ int wc_GetKeyOID(byte* key, word32 keySz, const byte** curveOID, word32* oidSz,
         XFREE(ed448, heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
 #endif /* HAVE_ED448 && HAVE_ED448_KEY_IMPORT && !NO_ASN_CRYPT */
-#if defined(HAVE_PQC)
 #if defined(HAVE_FALCON)
     if (*algoID == 0) {
         falcon_key *falcon = (falcon_key *)XMALLOC(sizeof(*falcon), heap,
@@ -8096,7 +8126,8 @@ int wc_GetKeyOID(byte* key, word32 keySz, const byte** curveOID, word32* oidSz,
         XFREE(falcon, heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
 #endif /* HAVE_FALCON */
-#if defined(HAVE_DILITHIUM)
+#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_SIGN) && \
+    !defined(WOLFSSL_DILITHIUM_NO_VERIFY) && !defined(WOLFSSL_DILITHIUM_NO_ASN1)
     if (*algoID == 0) {
         dilithium_key *dilithium = (dilithium_key *)XMALLOC(sizeof(*dilithium),
              heap, DYNAMIC_TYPE_TMP_BUFFER);
@@ -8142,7 +8173,7 @@ int wc_GetKeyOID(byte* key, word32 keySz, const byte** curveOID, word32* oidSz,
         }
         XFREE(dilithium, heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
-#endif /* HAVE_DILITHIUM */
+#endif /* HAVE_DILITHIUM && !WOLFSSL_DILITHIUM_VERIFY_ONLY */
 #if defined(HAVE_SPHINCS)
     if (*algoID == 0) {
         sphincs_key *sphincs = (sphincs_key *)XMALLOC(sizeof(*sphincs),
@@ -8220,7 +8251,6 @@ int wc_GetKeyOID(byte* key, word32 keySz, const byte** curveOID, word32* oidSz,
         XFREE(sphincs, heap, DYNAMIC_TYPE_TMP_BUFFER);
     }
 #endif /* HAVE_SPHINCS */
-#endif /* HAVE_PQC */
 
     /* if flag is not set then this is not a key that we understand. */
     if (*algoID == 0) {
@@ -8605,7 +8635,7 @@ int TraditionalEnc(byte* key, word32 keySz, byte* out, word32* outSz,
     if (ret == 0) {
         ret = wc_CreatePKCS8Key(NULL, &pkcs8KeySz, key, keySz, algId, curveOid,
                                                                     curveOidSz);
-        if (ret == LENGTH_ONLY_E)
+        if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E))
             ret = 0;
     }
     if (ret == 0) {
@@ -8861,7 +8891,7 @@ exit_dc:
     DECL_ASNGETDATA(dataASN, pbes2ParamsASN_Length);
     int    ret = 0;
     int    id = 0;
-    int    version;
+    int    version = 0;
     word32 idx = 0;
     word32 pIdx = 0;
     word32 iterations = 0;
@@ -9915,7 +9945,7 @@ int wc_DhKeyDecode(const byte* input, word32* inOutIdx, DhKey* key, word32 inSz)
     #if !defined(HAVE_FIPS) || \
         (defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION > 2))
     /* If ASN_DH_KEY_E: Check if input started at beginning of key */
-    if (ret == ASN_DH_KEY_E) {
+    if (ret == WC_NO_ERR_TRACE(ASN_DH_KEY_E)) {
         *inOutIdx = temp;
 
         /* the version (0) - private only (for public skip) */
@@ -10076,7 +10106,7 @@ int wc_DhKeyToDer(DhKey* key, byte* output, word32* outSz, int exportPriv)
     /* DH Parameters sequence with P and G */
     total = 0;
     ret = wc_DhParamsToDer(key, NULL, &total);
-    if (ret != LENGTH_ONLY_E)
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E))
         return ret;
     idx += total;
 
@@ -10725,7 +10755,7 @@ int wc_DsaPrivateKeyDecode(const byte* input, word32* inOutIdx, DsaKey* key,
         }
     }
     /* An alternate pass if default certificate fails parsing */
-    if (ret == ASN_PARSE_E) {
+    if (ret == WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         *inOutIdx = (word32)temp;
         if (GetMyVersion(input, inOutIdx, &version, inSz) < 0)
             return ASN_PARSE_E;
@@ -11366,6 +11396,47 @@ DNS_entry* AltNameNew(void* heap)
     return ret;
 }
 
+DNS_entry* AltNameDup(DNS_entry* from, void* heap)
+{
+    DNS_entry* ret;
+
+    ret = AltNameNew(heap);
+    if (ret == NULL) {
+        WOLFSSL_MSG("\tOut of Memory");
+        return NULL;
+    }
+
+    ret->type = from->type;
+    ret->len = from->len;
+
+
+    ret->name = CopyString(from->name, from->len, heap, DYNAMIC_TYPE_ALTNAME);
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
+    ret->ipString = CopyString(from->ipString, 0, heap, DYNAMIC_TYPE_ALTNAME);
+#endif
+#ifdef OPENSSL_ALL
+    ret->ridString = CopyString(from->ridString, 0, heap, DYNAMIC_TYPE_ALTNAME);
+#endif
+    if (ret->name == NULL
+#if defined(OPENSSL_ALL) || defined(WOLFSSL_IP_ALT_NAME)
+            || (from->ipString != NULL && ret->ipString == NULL)
+#endif
+#ifdef OPENSSL_ALL
+            || (from->ridString != NULL && ret->ridString == NULL)
+#endif
+            ) {
+        WOLFSSL_MSG("\tOut of Memory");
+        FreeAltNames(ret, heap);
+        return NULL;
+    }
+
+#ifdef WOLFSSL_FPKI
+    ret->oidSum = from->oidSum;
+#endif
+
+    return ret;
+}
+
 
 #ifndef IGNORE_NAME_CONSTRAINTS
 
@@ -11471,8 +11542,8 @@ static int GetCertHeader(DecodedCert* cert)
 }
 #endif
 
-#if defined(HAVE_ED25519) || defined(HAVE_ED448) || (defined(HAVE_PQC) && \
-    defined(HAVE_LIBOQS))
+#if defined(HAVE_ED25519) || defined(HAVE_ED448) || defined(HAVE_FALCON) || \
+    defined(HAVE_DILITHIUM) || defined(HAVE_SPHINCS)
 /* Store the key data under the BIT_STRING in dynamically allocated data.
  *
  * @param [in, out] cert    Certificate object.
@@ -11717,7 +11788,7 @@ static int SetEccPublicKey(byte* output, ecc_key* key, int outLen,
     #endif
         PRIVATE_KEY_LOCK();
         /* LENGTH_ONLY_E on success. */
-        if (ret == LENGTH_ONLY_E) {
+        if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             ret = 0;
         }
     }
@@ -12545,7 +12616,6 @@ static int GetCertKey(DecodedCert* cert, const byte* source, word32* inOutIdx,
             ret = StoreKey(cert, source, &srcIdx, maxIdx);
             break;
     #endif /* HAVE_ED448 */
-    #if defined(HAVE_PQC) && defined(HAVE_LIBOQS)
     #ifdef HAVE_FALCON
         case FALCON_LEVEL1k:
             cert->pkCurveOID = FALCON_LEVEL1k;
@@ -12596,7 +12666,6 @@ static int GetCertKey(DecodedCert* cert, const byte* source, word32* inOutIdx,
             ret = StoreKey(cert, source, &srcIdx, maxIdx);
             break;
     #endif /* HAVE_SPHINCS */
-    #endif /* HAVE_PQC */
     #ifndef NO_DSA
         case DSAk:
             cert->publicKey = source + pubIdx;
@@ -13834,6 +13903,18 @@ static int GetCertName(DecodedCert* cert, char* full, byte* hash, int nameType,
                 return ASN_PARSE_E;
             }
 
+        #ifndef WOLFSSL_NO_ASN_STRICT
+            /* RFC 5280 section 4.1.2.4 lists a DirecotryString as being
+             * 1..MAX in length */
+            if (strLen < 1) {
+                WOLFSSL_MSG("Non conforming DirectoryString of length 0 was"
+                            " found");
+                WOLFSSL_MSG("Use WOLFSSL_NO_ASN_STRICT if wanting to allow"
+                            " empty DirectoryString's");
+                return ASN_PARSE_E;
+            }
+        #endif
+
             if (id == ASN_COMMON_NAME) {
                 if (nameType == SUBJECT) {
                     cert->subjectCN = (char *)&input[srcIdx];
@@ -14388,7 +14469,7 @@ static int GetCertName(DecodedCert* cert, char* full, byte* hash, int nameType,
     DECL_ASNGETDATA(dataASN, rdnASN_Length);
     int    ret = 0;
     word32 idx = 0;
-    int    len;
+    int    len = 0;
     word32 srcIdx = *inOutIdx;
 #ifdef WOLFSSL_X509_NAME_AVAILABLE
     WOLFSSL_X509_NAME* dName = NULL;
@@ -14463,6 +14544,18 @@ static int GetCertName(DecodedCert* cert, char* full, byte* hash, int nameType,
 
                 /* Get string reference. */
                 GetASN_GetRef(&dataASN[RDNASN_IDX_ATTR_VAL], &str, &strLen);
+
+            #ifndef WOLFSSL_NO_ASN_STRICT
+                /* RFC 5280 section 4.1.2.4 lists a DirecotryString as being
+                 * 1..MAX in length */
+                if (ret == 0 && strLen < 1) {
+                    WOLFSSL_MSG("Non conforming DirectoryString of length 0 was"
+                                " found");
+                    WOLFSSL_MSG("Use WOLFSSL_NO_ASN_STRICT if wanting to allow"
+                                " empty DirectoryString's");
+                    ret = ASN_PARSE_E;
+                }
+            #endif
 
                 /* Convert BER tag to a OpenSSL type. */
                 switch (tag) {
@@ -15585,8 +15678,15 @@ int DecodeToKey(DecodedCert* cert, int verify)
     int ret;
     int badDate = 0;
 
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+    /* Call internal version and decode completely to also handle extensions.
+     * This is required to parse a potential alternative public key in the
+     * SubjectAlternativeKey extension. */
+    ret = DecodeCertInternal(cert, verify, NULL, &badDate, 0, 0);
+#else
     /* Call internal version and stop after public key. */
     ret = DecodeCertInternal(cert, verify, NULL, &badDate, 0, 1);
+#endif
     /* Always return date errors. */
     if (ret == 0) {
         ret = badDate;
@@ -15893,7 +15993,6 @@ static WC_INLINE int IsSigAlgoECC(word32 algoOID)
         #ifdef HAVE_CURVE448
               || (algoOID == X448k)
         #endif
-        #ifdef HAVE_PQC
         #ifdef HAVE_FACON
               || (algoOID == FALCON_LEVEL1k)
               || (algoOID == FALCON_LEVEL5k)
@@ -15911,7 +16010,6 @@ static WC_INLINE int IsSigAlgoECC(word32 algoOID)
               || (algoOID == SPHINCS_SMALL_LEVEL3k)
               || (algoOID == SPHINCS_SMALL_LEVEL5k)
         #endif
-        #endif /* HAVE_PQC */
     );
 }
 
@@ -16090,7 +16188,7 @@ word32 wc_EncodeSignature(byte* out, const byte* digest, word32 digSz,
 #else
     DECL_ASNSETDATA(dataASN, digestInfoASN_Length);
     int ret = 0;
-    int sz;
+    int sz = 0;
     unsigned char dgst[WC_MAX_DIGEST_SIZE];
 
     CALLOC_ASNSETDATA(dataASN, digestInfoASN_Length, ret, NULL);
@@ -16229,7 +16327,6 @@ void FreeSignatureCtx(SignatureCtx* sigCtx)
                 sigCtx->key.ed448 = NULL;
                 break;
         #endif /* HAVE_ED448 */
-        #if defined(HAVE_PQC)
         #if defined(HAVE_FALCON)
             case FALCON_LEVEL1k:
             case FALCON_LEVEL5k:
@@ -16262,7 +16359,6 @@ void FreeSignatureCtx(SignatureCtx* sigCtx)
                 sigCtx->key.sphincs = NULL;
                 break;
         #endif /* HAVE_SPHINCS */
-        #endif /* HAVE_PQC  */
             default:
                 break;
         } /* switch (keyOID) */
@@ -16408,7 +16504,6 @@ static int HashForSignature(const byte* buf, word32 bufSz, word32 sigOID,
              */
             break;
     #endif
-    #ifdef HAVE_PQC
     #ifdef HAVE_FALCON
         case CTC_FALCON_LEVEL1:
         case CTC_FALCON_LEVEL5:
@@ -16432,7 +16527,6 @@ static int HashForSignature(const byte* buf, word32 bufSz, word32 sigOID,
             /* Hashes done in signing operation. */
             break;
     #endif
-    #endif /* HAVE_PQC */
 
         default:
             ret = HASH_TYPE_E;
@@ -16812,7 +16906,6 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     break;
                 }
             #endif
-            #if defined(HAVE_PQC)
             #if defined(HAVE_FALCON)
                 case FALCON_LEVEL1k:
                 {
@@ -16869,7 +16962,9 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     break;
                 }
             #endif /* HAVE_FALCON */
-            #if defined(HAVE_DILITHIUM)
+            #if defined(HAVE_DILITHIUM) && \
+                !defined(WOLFSSL_DILITHIUM_NO_VERIFY) && \
+                !defined(WOLFSSL_DILITHIUM_NO_ASN1)
                 case DILITHIUM_LEVEL2k:
                 {
                     word32 idx = 0;
@@ -17110,7 +17205,6 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     break;
                 }
             #endif /* HAVE_SPHINCS */
-            #endif /* HAVE_PQC */
                 default:
                     WOLFSSL_MSG("Verify Key type unknown");
                     ret = ASN_UNKNOWN_OID_E;
@@ -17162,7 +17256,8 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     !defined(WOLFSSL_RENESAS_TSIP_TLS)
                     else
                 #else
-                    if (!sigCtx->pkCbRsa || ret == CRYPTOCB_UNAVAILABLE)
+                    if (!sigCtx->pkCbRsa ||
+                        ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 #endif /* WOLFSSL_RENESAS_FSPSM_TLS */
                 #endif /* HAVE_PK_CALLBACKS */
                     {
@@ -17236,7 +17331,8 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     !defined(WOLFSSL_RENESAS_TSIP_TLS)
                     else
                 #else
-                    if (!sigCtx->pkCbEcc || ret == CRYPTOCB_UNAVAILABLE)
+                    if (!sigCtx->pkCbEcc ||
+                        ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 #endif /* WOLFSSL_RENESAS_FSPSM_TLS */
                 #endif /* HAVE_PK_CALLBACKS */
                     {
@@ -17264,7 +17360,6 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     break;
                 }
             #endif
-            #if defined(HAVE_PQC)
             #if defined(HAVE_FALCON)
                 case FALCON_LEVEL1k:
                 case FALCON_LEVEL5k:
@@ -17275,7 +17370,7 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     break;
                 }
             #endif /* HAVE_FALCON */
-            #if defined(HAVE_DILITHIUM)
+            #if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_VERIFY)
                 case DILITHIUM_LEVEL2k:
                 case DILITHIUM_LEVEL3k:
                 case DILITHIUM_LEVEL5k:
@@ -17300,13 +17395,12 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     break;
                 }
             #endif /* HAVE_SPHINCS */
-            #endif /* HAVE_PQC */
                 default:
                     break;
             }  /* switch (keyOID) */
 
         #ifdef WOLFSSL_ASYNC_CRYPT
-            if (ret == WC_PENDING_E) {
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 goto exit_cs;
             }
         #endif
@@ -17453,7 +17547,6 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     break;
                 }
             #endif /* HAVE_ED448 */
-            #ifdef HAVE_PQC
             #ifdef HAVE_FALCON
                 case FALCON_LEVEL1k:
                 {
@@ -17583,7 +17676,6 @@ static int ConfirmSignature(SignatureCtx* sigCtx,
                     break;
                 }
             #endif /* HAVE_SPHINCS */
-            #endif /* HAVE_PQC */
                 default:
                     break;
             }  /* switch (keyOID) */
@@ -17605,7 +17697,7 @@ exit_cs:
     WOLFSSL_LEAVE("ConfirmSignature", ret);
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E)
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
         return ret;
 #endif
 
@@ -18202,6 +18294,7 @@ static int DecodeGeneralName(const byte* input, word32* inOutIdx, byte tag,
     }
     #endif /* WOLFSSL_QT || OPENSSL_ALL */
 
+    #ifdef OPENSSL_ALL
     /* GeneralName choice: registeredID */
     else if (tag == (ASN_CONTEXT_SPECIFIC | ASN_RID_TYPE)) {
         ret = SetDNSEntry(cert, (const char*)(input + idx), len,
@@ -18210,6 +18303,7 @@ static int DecodeGeneralName(const byte* input, word32* inOutIdx, byte tag,
             idx += (word32)len;
         }
     }
+    #endif
 #endif /* IGNORE_NAME_CONSTRAINTS */
 #if defined(WOLFSSL_SEP) || defined(WOLFSSL_FPKI)
     /* GeneralName choice: otherName */
@@ -18852,6 +18946,7 @@ static int DecodeAltNames(const byte* input, word32 sz, DecodedCert* cert)
     word32 idx = 0;
     int length = 0;
     int ret = 0;
+    word32 numNames = 0;
 
     WOLFSSL_ENTER("DecodeAltNames");
 
@@ -18883,6 +18978,13 @@ static int DecodeAltNames(const byte* input, word32 sz, DecodedCert* cert)
 
     while ((ret == 0) && (idx < sz)) {
         ASNGetData dataASN[altNameASN_Length];
+
+        numNames++;
+        if (numNames > WOLFSSL_MAX_ALT_NAMES) {
+            WOLFSSL_MSG("\tToo many subject alternative names");
+            ret = ASN_ALT_NAME_E;
+            break;
+        }
 
         /* Clear dynamic data items. */
         XMEMSET(dataASN, 0, sizeof(dataASN));
@@ -19751,7 +19853,7 @@ static int DecodeExtKeyUsage(const byte* input, word32 sz, DecodedCert* cert)
 
     while (idx < (word32)sz) {
         ret = GetObjectId(input, &idx, &oid, oidCertKeyUseType, sz);
-        if (ret == ASN_UNKNOWN_OID_E)
+        if (ret == WC_NO_ERR_TRACE(ASN_UNKNOWN_OID_E))
             continue;
         else if (ret < 0)
             return ret;
@@ -19831,7 +19933,7 @@ static int DecodeExtKeyUsage(const byte* input, word32 sz, DecodedCert* cert)
         ret = GetASN_Items(keyPurposeIdASN, dataASN, keyPurposeIdASN_Length, 0,
                            input, &idx, sz);
         /* Skip unknown OIDs. */
-        if (ret == ASN_UNKNOWN_OID_E) {
+        if (ret == WC_NO_ERR_TRACE(ASN_UNKNOWN_OID_E)) {
             ret = 0;
         }
         else if (ret == 0) {
@@ -19994,13 +20096,16 @@ static int DecodeSubtreeGeneralName(const byte* input, word32 sz, byte tag,
  * @param [in]      input  Buffer holding data.
  * @param [in]      sz     Size of data in buffer.
  * @param [in, out] head   Linked list of subtree names.
+ * @param [in]      limit  If > 0, limit on number of tree
+ *                         entries to  process, exceeding
+ *                         is an error.
  * @param [in]      heap   Dynamic memory hint.
  * @return  0 on success.
  * @return  MEMORY_E when dynamic memory allocation fails.
  * @return  ASN_PARSE_E when SEQUENCE is not found as expected.
  */
 static int DecodeSubtree(const byte* input, word32 sz, Base_entry** head,
-                         void* heap)
+                         word32 limit, void* heap)
 {
 #ifndef WOLFSSL_ASN_TEMPLATE
     word32 idx = 0;
@@ -20078,6 +20183,7 @@ static int DecodeSubtree(const byte* input, word32 sz, Base_entry** head,
     DECL_ASNGETDATA(dataASN, subTreeASN_Length);
     word32 idx = 0;
     int ret = 0;
+    word32 cnt = 0;
 
     (void)heap;
 
@@ -20087,6 +20193,14 @@ static int DecodeSubtree(const byte* input, word32 sz, Base_entry** head,
     while ((ret == 0) && (idx < (word32)sz)) {
         byte minVal = 0;
         byte maxVal = 0;
+        if (limit > 0) {
+            cnt++;
+            if (cnt > limit) {
+                WOLFSSL_MSG("too many name constraints");
+                ret = ASN_NAME_INVALID_E;
+                break;
+            }
+        }
 
         /* Clear dynamic data and set choice for GeneralName and location to
          * store minimum and maximum.
@@ -20185,7 +20299,7 @@ static int DecodeNameConstraints(const byte* input, word32 sz,
         }
 
         if (DecodeSubtree(input + idx, (word32)length, subtree,
-                cert->heap) < 0) {
+                WOLFSSL_MAX_NAME_CONSTRAINTS, cert->heap) < 0) {
             WOLFSSL_MSG("\terror parsing subtree");
             return ASN_PARSE_E;
         }
@@ -20212,7 +20326,8 @@ static int DecodeNameConstraints(const byte* input, word32 sz,
             ret = DecodeSubtree(
                     dataASN[NAMECONSTRAINTSASN_IDX_PERMIT].data.ref.data,
                     dataASN[NAMECONSTRAINTSASN_IDX_PERMIT].data.ref.length,
-                    &cert->permittedNames, cert->heap);
+                    &cert->permittedNames, WOLFSSL_MAX_NAME_CONSTRAINTS,
+                    cert->heap);
         }
     }
     if (ret == 0) {
@@ -20221,7 +20336,8 @@ static int DecodeNameConstraints(const byte* input, word32 sz,
             ret = DecodeSubtree(
                     dataASN[NAMECONSTRAINTSASN_IDX_EXCLUDE].data.ref.data,
                     dataASN[NAMECONSTRAINTSASN_IDX_EXCLUDE].data.ref.length,
-                    &cert->excludedNames, cert->heap);
+                    &cert->excludedNames, WOLFSSL_MAX_NAME_CONSTRAINTS,
+                    cert->heap);
         }
     }
 
@@ -21072,7 +21188,13 @@ static int DecodeExtensionType(const byte* input, word32 length, word32 oid,
                 ret = ASN_PARSE_E;
             }
         #else
-            WOLFSSL_MSG("Certificate Policy extension not supported yet.");
+            WOLFSSL_MSG("Certificate Policy extension not supported.");
+            #ifndef WOLFSSL_NO_ASN_STRICT
+            if (critical) {
+                WOLFSSL_ERROR_VERBOSE(ASN_CRIT_EXT_E);
+                ret = ASN_CRIT_EXT_E;
+            }
+            #endif
         #endif
             break;
 
@@ -21335,7 +21457,7 @@ static int DecodeCertExtensions(DecodedCert* cert)
 
         ret = DecodeExtensionType(input + idx, (word32)length, oid, critical,
             cert, NULL);
-        if (ret == ASN_CRIT_EXT_E) {
+        if (ret == WC_NO_ERR_TRACE(ASN_CRIT_EXT_E)) {
             ret = 0;
             criticalFail = 1;
         }
@@ -21425,7 +21547,7 @@ end:
         }
         /* Don't fail criticality until all other extensions have been checked.
          */
-        if (ret == ASN_CRIT_EXT_E) {
+        if (ret == WC_NO_ERR_TRACE(ASN_CRIT_EXT_E)) {
             criticalRet = ASN_CRIT_EXT_E;
             ret = 0;
         }
@@ -21670,9 +21792,9 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
     DECL_ASNGETDATA(dataASN, x509CertASN_Length);
     int ret = 0;
     int badDate = 0;
-    byte version;
+    byte version = 0;
     word32 idx;
-    word32 serialSz;
+    word32 serialSz = 0;
     const unsigned char* issuer = NULL;
     word32 issuerSz = 0;
     const unsigned char* subject = NULL;
@@ -21755,6 +21877,19 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
         /* Set fields extracted from data. */
         cert->version = version;
         cert->serialSz = (int)serialSz;
+
+    #if !defined(WOLFSSL_NO_ASN_STRICT) && !defined(WOLFSSL_PYTHON)
+        /* RFC 5280 section 4.1.2.2 states that non-conforming CAs may issue
+         * a negative or zero serial number and should be handled gracefully.
+         * Since it is a non-conforming CA that issues a serial of 0 then we
+         * treat it as an error here. */
+        if (cert->serialSz == 1 && cert->serial[0] == 0) {
+            WOLFSSL_MSG("Error serial number of 0, use WOLFSSL_NO_ASN_STRICT "
+                "if wanted");
+            ret = ASN_PARSE_E;
+        }
+    #endif
+
         cert->signatureOID = dataASN[X509CERTASN_IDX_TBS_ALGOID_OID].data.oid.sum;
         cert->keyOID = dataASN[X509CERTASN_IDX_TBS_SPUBKEYINFO_ALGO_OID].data.oid.sum;
         cert->certBegin = dataASN[X509CERTASN_IDX_TBS_SEQ].offset;
@@ -21948,7 +22083,7 @@ static int DecodeCertInternal(DecodedCert* cert, int verify, int* criticalExt,
         /* Decode the extension data starting at [3]. */
         ret = DecodeCertExtensions(cert);
         if (criticalExt != NULL) {
-            if (ret == ASN_CRIT_EXT_E) {
+            if (ret == WC_NO_ERR_TRACE(ASN_CRIT_EXT_E)) {
                 /* Return critical extension not recognized. */
                 *criticalExt = ret;
                 ret = 0;
@@ -22139,7 +22274,7 @@ static int DecodeCertReqAttrValue(DecodedCert* cert, int* criticalExt,
 
             /* Decode and validate extensions. */
             ret = DecodeCertExtensions(cert);
-            if (ret == ASN_CRIT_EXT_E) {
+            if (ret == WC_NO_ERR_TRACE(ASN_CRIT_EXT_E)) {
                 /* Return critical extension not recognized. */
                 *criticalExt = ret;
                 ret = 0;
@@ -22366,7 +22501,7 @@ int ParseCert(DecodedCert* cert, int type, int verify, void* cm)
     char* ptr;
 #endif
 
-    ret = ParseCertRelative(cert, type, verify, cm);
+    ret = ParseCertRelative(cert, type, verify, cm, NULL);
     if (ret < 0)
         return ret;
 
@@ -23119,9 +23254,7 @@ static int CheckCertSignature_ex(const byte* cert, word32 certSz, void* heap,
 #endif /* WOLFSSL_ASN_TEMPLATE */
 }
 
-#ifdef OPENSSL_EXTRA
-/* Call CheckCertSignature_ex using a public key buffer for verification
- */
+/* Call CheckCertSignature_ex using a public key buffer for verification */
 int CheckCertSignaturePubKey(const byte* cert, word32 certSz, void* heap,
         const byte* pubKey, word32 pubKeySz, int pubKeyOID)
 {
@@ -23129,6 +23262,7 @@ int CheckCertSignaturePubKey(const byte* cert, word32 certSz, void* heap,
             pubKey, pubKeySz, pubKeyOID, 0);
 }
 
+/* Call CheckCertSignature_ex using a public key and oid */
 int wc_CheckCertSigPubKey(const byte* cert, word32 certSz, void* heap,
         const byte* pubKey, word32 pubKeySz, int pubKeyOID)
 {
@@ -23144,15 +23278,12 @@ int CheckCSRSignaturePubKey(const byte* cert, word32 certSz, void* heap,
             pubKey, pubKeySz, pubKeyOID, 1);
 }
 #endif /* WOLFSSL_CERT_REQ */
-#endif /* OPENSSL_EXTRA */
-#ifdef WOLFSSL_SMALL_CERT_VERIFY
-/* Call CheckCertSignature_ex using a certificate manager (cm)
- */
-int CheckCertSignature(const byte* cert, word32 certSz, void* heap, void* cm)
+
+/* Call CheckCertSignature_ex using a certificate manager (cm) */
+int wc_CheckCertSignature(const byte* cert, word32 certSz, void* heap, void* cm)
 {
     return CheckCertSignature_ex(cert, certSz, heap, cm, NULL, 0, 0, 0);
 }
-#endif /* WOLFSSL_SMALL_CERT_VERIFY */
 #endif /* WOLFSSL_SMALL_CERT_VERIFY || OPENSSL_EXTRA */
 
 #if (defined(HAVE_ED25519) && defined(HAVE_ED25519_KEY_IMPORT) || \
@@ -23257,8 +23388,18 @@ int wc_CertGetPubKey(const byte* cert, word32 certSz,
     return ret;
 }
 #endif
+Signer* findSignerByName(Signer *list, byte *hash)
+{
+    Signer *s;
+    for (s = list; s != NULL; s = s->next) {
+        if (XMEMCMP(s->subjectNameHash, hash, SIGNER_DIGEST_SIZE) == 0) {
+            return s;
+        }
+    }
+    return NULL;
+}
 
-int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
+int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm, Signer *extraCAList)
 {
     int    ret = 0;
 #ifndef WOLFSSL_ASN_TEMPLATE
@@ -23271,6 +23412,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
     int    idx = 0;
 #endif
     byte*  sce_tsip_encRsaKeyIdx;
+    (void)extraCAList;
 
     if (cert == NULL) {
         return BAD_FUNC_ARG;
@@ -23286,7 +23428,8 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
         cert->badDate = 0;
         cert->criticalExt = 0;
         if ((ret = DecodeToKey(cert, verify)) < 0) {
-            if (ret == ASN_BEFORE_DATE_E || ret == ASN_AFTER_DATE_E) {
+            if (ret == WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E) ||
+                ret == WC_NO_ERR_TRACE(ASN_AFTER_DATE_E)) {
                 cert->badDate = ret;
                 if (verify == VERIFY_SKIP_DATE)
                     ret = 0;
@@ -23449,7 +23592,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
                         cert->extensionsIdx = cert->srcIdx; /* for potential later use */
 
                         if ((ret = DecodeCertExtensions(cert)) < 0) {
-                            if (ret == ASN_CRIT_EXT_E) {
+                            if (ret == WC_NO_ERR_TRACE(ASN_CRIT_EXT_E)) {
                                 cert->criticalExt = ret;
                             }
                             else {
@@ -23483,7 +23626,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
             cert->extensionsIdx = cert->srcIdx;   /* for potential later use */
 
             if ((ret = DecodeCertExtensions(cert)) < 0) {
-                if (ret == ASN_CRIT_EXT_E)
+                if (ret == WC_NO_ERR_TRACE(ASN_CRIT_EXT_E))
                     cert->criticalExt = ret;
                 else
                     return ret;
@@ -23536,7 +23679,8 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
 #endif
         {
             ret = DecodeCert(cert, verify, &cert->criticalExt);
-            if (ret == ASN_BEFORE_DATE_E || ret == ASN_AFTER_DATE_E) {
+            if (ret == WC_NO_ERR_TRACE(ASN_BEFORE_DATE_E) ||
+                ret == WC_NO_ERR_TRACE(ASN_AFTER_DATE_E)) {
                 cert->badDate = ret;
                 if (verify == VERIFY_SKIP_DATE)
                     ret = 0;
@@ -23587,8 +23731,13 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
         if (!cert->selfSigned || (verify != NO_VERIFY && type != CA_TYPE &&
                                                    type != TRUSTED_PEER_TYPE)) {
             cert->ca = NULL;
+#ifdef HAVE_CERTIFICATE_STATUS_REQUEST_V2
+        if (extraCAList != NULL) {
+            cert->ca = findSignerByName(extraCAList, cert->issuerHash);
+        }
+#endif
     #ifndef NO_SKID
-            if (cert->extAuthKeyIdSet) {
+            if (cert->ca == NULL && cert->extAuthKeyIdSet) {
                 cert->ca = GetCA(cm, cert->extAuthKeyId);
         #ifdef WOLFSSL_AKID_NAME
                 if (cert->ca == NULL) {
@@ -23733,13 +23882,19 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
         if (cert->ca) {
             if (verify == VERIFY || verify == VERIFY_OCSP ||
                                                  verify == VERIFY_SKIP_DATE) {
+                word32 keyOID = cert->ca->keyOID;
+            #if defined(WOLFSSL_SM2) && defined(WOLFSSL_SM3)
+                if (cert->selfSigned && (cert->signatureOID == CTC_SM3wSM2)) {
+                    keyOID = SM2k;
+                }
+            #endif
                 /* try to confirm/verify signature */
                 if ((ret = ConfirmSignature(&cert->sigCtx,
                         cert->source + cert->certBegin,
                         cert->sigIndex - cert->certBegin,
                         cert->ca->publicKey, cert->ca->pubKeySize,
-                        cert->ca->keyOID, cert->signature,
-                        cert->sigLength, cert->signatureOID,
+                        keyOID, cert->signature, cert->sigLength,
+                        cert->signatureOID,
                     #ifdef WC_RSA_PSS
                         cert->source + cert->sigParamsIndex,
                         cert->sigParamsLength,
@@ -23747,12 +23902,50 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
                         NULL, 0,
                     #endif
                         sce_tsip_encRsaKeyIdx)) != 0) {
-                    if (ret != WC_PENDING_E) {
+                    if (ret != WC_NO_ERR_TRACE(WC_PENDING_E)) {
                         WOLFSSL_MSG("Confirm signature failed");
                     }
                     WOLFSSL_ERROR_VERBOSE(ret);
                     return ret;
                 }
+
+            #ifdef WOLFSSL_DUAL_ALG_CERTS
+                if ((ret == 0) && cert->extAltSigAlgSet &&
+                    cert->extAltSigValSet) {
+                #ifndef WOLFSSL_SMALL_STACK
+                    byte der[MAX_CERT_VERIFY_SZ];
+                #else
+                    byte *der = (byte*)XMALLOC(MAX_CERT_VERIFY_SZ, cert->heap,
+                                            DYNAMIC_TYPE_DCERT);
+                    if (der == NULL) {
+                        ret = MEMORY_E;
+                    } else
+                #endif /* ! WOLFSSL_SMALL_STACK */
+                    {
+                        ret = wc_GeneratePreTBS(cert, der, MAX_CERT_VERIFY_SZ);
+
+                        if (ret > 0) {
+                            ret = ConfirmSignature(&cert->sigCtx, der, ret,
+                                    cert->ca->sapkiDer, cert->ca->sapkiLen,
+                                    cert->ca->sapkiOID, cert->altSigValDer,
+                                    cert->altSigValLen, cert->altSigAlgOID,
+                                    NULL, 0, NULL);
+                        }
+                #ifdef WOLFSSL_SMALL_STACK
+                        XFREE(der, cert->heap, DYNAMIC_TYPE_DCERT);
+                #endif /* WOLFSSL_SMALL_STACK */
+
+                        if (ret != 0) {
+                            WOLFSSL_MSG("Confirm alternative signature failed");
+                            WOLFSSL_ERROR_VERBOSE(ret);
+                            return ret;
+                        }
+                        else {
+                            WOLFSSL_MSG("Alt signature has been verified!");
+                        }
+                    }
+                }
+            #endif /* WOLFSSL_DUAL_ALG_CERTS */
             }
         #ifndef IGNORE_NAME_CONSTRAINTS
             if (verify == VERIFY || verify == VERIFY_OCSP ||
@@ -23769,6 +23962,7 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
         }
 #ifdef WOLFSSL_CERT_REQ
         else if (type == CERTREQ_TYPE) {
+            /* try to confirm/verify signature */
             if ((ret = ConfirmSignature(&cert->sigCtx,
                     cert->source + cert->certBegin,
                     cert->sigIndex - cert->certBegin,
@@ -23781,12 +23975,50 @@ int ParseCertRelative(DecodedCert* cert, int type, int verify, void* cm)
                     NULL, 0,
                 #endif
                     sce_tsip_encRsaKeyIdx)) != 0) {
-                if (ret != WC_PENDING_E) {
+                if (ret != WC_NO_ERR_TRACE(WC_PENDING_E)) {
                     WOLFSSL_MSG("Confirm signature failed");
                 }
                 WOLFSSL_ERROR_VERBOSE(ret);
                 return ret;
             }
+
+        #ifdef WOLFSSL_DUAL_ALG_CERTS
+            if ((ret == 0) && cert->extAltSigAlgSet &&
+                cert->extAltSigValSet) {
+            #ifndef WOLFSSL_SMALL_STACK
+                byte der[MAX_CERT_VERIFY_SZ];
+            #else
+                byte *der = (byte*)XMALLOC(MAX_CERT_VERIFY_SZ, cert->heap,
+                                        DYNAMIC_TYPE_DCERT);
+                if (der == NULL) {
+                    ret = MEMORY_E;
+                } else
+            #endif /* ! WOLFSSL_SMALL_STACK */
+                {
+                    ret = wc_GeneratePreTBS(cert, der, MAX_CERT_VERIFY_SZ);
+
+                    if (ret > 0) {
+                        ret = ConfirmSignature(&cert->sigCtx, der, ret,
+                                cert->sapkiDer, cert->sapkiLen,
+                                cert->sapkiOID, cert->altSigValDer,
+                                cert->altSigValLen, cert->altSigAlgOID,
+                                NULL, 0, NULL);
+                    }
+            #ifdef WOLFSSL_SMALL_STACK
+                    XFREE(der, cert->heap, DYNAMIC_TYPE_DCERT);
+            #endif /* WOLFSSL_SMALL_STACK */
+
+                    if (ret != 0) {
+                        WOLFSSL_MSG("Confirm alternative signature failed");
+                        WOLFSSL_ERROR_VERBOSE(ret);
+                        return ret;
+                    }
+                    else {
+                        WOLFSSL_MSG("Alt signature has been verified!");
+                    }
+                }
+            }
+        #endif /* WOLFSSL_DUAL_ALG_CERTS */
         }
 #endif
         else {
@@ -23824,6 +24056,89 @@ exit_pcr:
     return ret;
 }
 
+int FillSigner(Signer* signer, DecodedCert* cert, int type, DerBuffer *der)
+{
+    int ret = 0;
+
+    if (signer == NULL || cert == NULL)
+        return BAD_FUNC_ARG;
+
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+    if (ret == 0 && signer != NULL) {
+        if (cert->extSapkiSet && cert->sapkiLen > 0) {
+            /* Allocated space for alternative public key. */
+            signer->sapkiDer = (byte*)XMALLOC(cert->sapkiLen, cert->heap,
+                                              DYNAMIC_TYPE_PUBLIC_KEY);
+            if (signer->sapkiDer == NULL) {
+                ret = MEMORY_E;
+            }
+            else {
+                XMEMCPY(signer->sapkiDer, cert->sapkiDer, cert->sapkiLen);
+                signer->sapkiLen = cert->sapkiLen;
+                signer->sapkiOID = cert->sapkiOID;
+            }
+        }
+    }
+#endif /* WOLFSSL_DUAL_ALG_CERTS */
+
+#if defined(WOLFSSL_AKID_NAME) || defined(HAVE_CRL)
+    if (ret == 0 && signer != NULL)
+        ret = CalcHashId(cert->serial, (word32)cert->serialSz,
+                         signer->serialHash);
+#endif
+    if (ret == 0 && signer != NULL) {
+    #ifdef WOLFSSL_SIGNER_DER_CERT
+        ret = AllocDer(&signer->derCert, der->length, der->type, NULL);
+    }
+    if (ret == 0 && signer != NULL) {
+        XMEMCPY(signer->derCert->buffer, der->buffer, der->length);
+    #else
+    (void)der;
+    #endif
+        signer->keyOID         = cert->keyOID;
+        if (cert->pubKeyStored) {
+            signer->publicKey      = cert->publicKey;
+            signer->pubKeySize     = cert->pubKeySize;
+        }
+
+        if (cert->subjectCNStored) {
+            signer->nameLen        = cert->subjectCNLen;
+            signer->name           = cert->subjectCN;
+        }
+        signer->maxPathLen     = cert->maxPathLen;
+        signer->selfSigned     = cert->selfSigned;
+    #ifndef IGNORE_NAME_CONSTRAINTS
+        signer->permittedNames = cert->permittedNames;
+        signer->excludedNames  = cert->excludedNames;
+    #endif
+    #ifndef NO_SKID
+        XMEMCPY(signer->subjectKeyIdHash, cert->extSubjKeyId,
+                SIGNER_DIGEST_SIZE);
+    #endif
+        XMEMCPY(signer->subjectNameHash, cert->subjectHash,
+                SIGNER_DIGEST_SIZE);
+    #if defined(HAVE_OCSP) || defined(HAVE_CRL)
+        XMEMCPY(signer->issuerNameHash, cert->issuerHash,
+                SIGNER_DIGEST_SIZE);
+    #endif
+    #ifdef HAVE_OCSP
+        XMEMCPY(signer->subjectKeyHash, cert->subjectKeyHash,
+                KEYID_SIZE);
+    #endif
+        signer->keyUsage = cert->extKeyUsageSet ? cert->extKeyUsage
+                                                : 0xFFFF;
+        signer->next    = NULL; /* If Key Usage not set, all uses valid. */
+        cert->publicKey = 0;    /* in case lock fails don't free here.   */
+        cert->subjectCN = 0;
+    #ifndef IGNORE_NAME_CONSTRAINTS
+        cert->permittedNames = NULL;
+        cert->excludedNames = NULL;
+    #endif
+        signer->type = (byte)type;
+    }
+    return ret;
+}
+
 /* Create and init an new signer */
 Signer* MakeSigner(void* heap)
 {
@@ -23852,6 +24167,9 @@ void FreeSigner(Signer* signer, void* heap)
     (void)heap;
     XFREE(signer->name, heap, DYNAMIC_TYPE_SUBJECT_CN);
     XFREE((void*)signer->publicKey, heap, DYNAMIC_TYPE_PUBLIC_KEY);
+#ifdef WOLFSSL_DUAL_ALG_CERTS
+    XFREE(signer->sapkiDer, heap, DYNAMIC_TYPE_PUBLIC_KEY);
+#endif
 #ifndef IGNORE_NAME_CONSTRAINTS
     if (signer->permittedNames)
         FreeNameSubtrees(signer->permittedNames, heap);
@@ -24080,7 +24398,7 @@ int wc_GetSerialNumber(const byte* input, word32* inOutIdx,
 
 int AllocDer(DerBuffer** pDer, word32 length, int type, void* heap)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     if (pDer) {
         int dynType = 0;
         DerBuffer* der;
@@ -24111,18 +24429,31 @@ int AllocDer(DerBuffer** pDer, word32 length, int type, void* heap)
         der->buffer = (byte*)der + sizeof(DerBuffer);
         der->length = length;
         ret = 0; /* Success */
+    } else {
+        ret = BAD_FUNC_ARG;
     }
+    return ret;
+}
+
+int AllocCopyDer(DerBuffer** pDer, const unsigned char* buff, word32 length,
+    int type, void* heap)
+{
+    int ret = AllocDer(pDer, length, type, heap);
+    if (ret == 0) {
+        XMEMCPY((*pDer)->buffer, buff, length);
+    }
+
     return ret;
 }
 
 void FreeDer(DerBuffer** pDer)
 {
-    if (pDer && *pDer)
-    {
+    if (pDer && *pDer) {
         DerBuffer* der = (DerBuffer*)*pDer;
 
         /* ForceZero private keys */
-        if (der->type == PRIVATEKEY_TYPE && der->buffer != NULL) {
+        if (((der->type == PRIVATEKEY_TYPE) ||
+             (der->type == ALT_PRIVATEKEY_TYPE)) && der->buffer != NULL) {
             ForceZero(der->buffer, der->length);
         }
         der->buffer = NULL;
@@ -24198,7 +24529,6 @@ wcchar END_PUB_KEY          = "-----END PUBLIC KEY-----";
     wcchar BEGIN_EDDSA_PRIV = "-----BEGIN EDDSA PRIVATE KEY-----";
     wcchar END_EDDSA_PRIV   = "-----END EDDSA PRIVATE KEY-----";
 #endif
-#if defined(HAVE_PQC)
 #if defined(HAVE_FALCON)
     wcchar BEGIN_FALCON_LEVEL1_PRIV  = "-----BEGIN FALCON_LEVEL1 PRIVATE KEY-----";
     wcchar END_FALCON_LEVEL1_PRIV    = "-----END FALCON_LEVEL1 PRIVATE KEY-----";
@@ -24228,7 +24558,6 @@ wcchar END_PUB_KEY          = "-----END PUBLIC KEY-----";
     wcchar BEGIN_SPHINCS_SMALL_LEVEL5_PRIV = "-----BEGIN SPHINCS_SMALL_LEVEL5 PRIVATE KEY-----";
     wcchar END_SPHINCS_SMALL_LEVEL5_PRIV   = "-----END SPHINCS_SMALL_LEVEL5 PRIVATE KEY-----";
 #endif /* HAVE_SPHINCS */
-#endif /* HAVE_PQC */
 
 const int pem_struct_min_sz = XSTR_SIZEOF("-----BEGIN X509 CRL-----"
                                              "-----END X509 CRL-----");
@@ -24248,7 +24577,7 @@ static WC_INLINE const char* SkipEndOfLineChars(const char* line,
 
 int wc_PemGetHeaderFooter(int type, const char** header, const char** footer)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (type) {
         case CA_TYPE:       /* same as below */
@@ -24336,7 +24665,6 @@ int wc_PemGetHeaderFooter(int type, const char** header, const char** footer)
             ret = 0;
             break;
     #endif
-#ifdef HAVE_PQC
 #ifdef HAVE_FALCON
         case FALCON_LEVEL1_TYPE:
             if (header) *header = BEGIN_FALCON_LEVEL1_PRIV;
@@ -24398,7 +24726,6 @@ int wc_PemGetHeaderFooter(int type, const char** header, const char** footer)
             ret = 0;
             break;
 #endif /* HAVE_SPHINCS */
-#endif /* HAVE_PQC */
         case PUBLICKEY_TYPE:
         case ECC_PUBLICKEY_TYPE:
             if (header) *header = BEGIN_PUB_KEY;
@@ -24424,6 +24751,7 @@ int wc_PemGetHeaderFooter(int type, const char** header, const char** footer)
             ret = 0;
             break;
         default:
+            ret = BAD_FUNC_ARG;
             break;
     }
     return ret;
@@ -24726,7 +25054,7 @@ int wc_DerToPemEx(const byte* der, word32 derSz, byte* output, word32 outSz,
 #endif
         outLen = 0;
         if ((err = Base64_Encode(der, derSz, NULL, (word32*)&outLen))
-                != LENGTH_ONLY_E) {
+                != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
             WOLFSSL_ERROR_VERBOSE(err);
             return err;
         }
@@ -25670,7 +25998,7 @@ static DNS_entry* FindAltName(struct DecodedCert* cert, int nameType,
 /* returns 0 on success */
 int wc_GetUUIDFromCert(struct DecodedCert* cert, byte* uuid, word32* uuidSz)
 {
-    int ret = ALT_NAME_E;
+    int ret = WC_NO_ERR_TRACE(ALT_NAME_E);
     DNS_entry* id = NULL;
 
     do {
@@ -25707,7 +26035,7 @@ int wc_GetUUIDFromCert(struct DecodedCert* cert, byte* uuid, word32* uuidSz)
 /* returns 0 on success */
 int wc_GetFASCNFromCert(struct DecodedCert* cert, byte* fascn, word32* fascnSz)
 {
-    int ret = ALT_NAME_E;
+    int ret = WC_NO_ERR_TRACE(ALT_NAME_E);
     DNS_entry* id = NULL;
 
     do {
@@ -25917,6 +26245,7 @@ int wc_RsaKeyToPublicDer_ex(RsaKey* key, byte* output, word32 inLen,
 
 #endif /* !NO_RSA && (WOLFSSL_CERT_GEN || WOLFSSL_KCAPI_RSA ||
             ((OPENSSL_EXTRA || WOLFSSL_KEY_GEN))) */
+#endif /* NO_CERTS */
 
 #if (defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA) || \
      defined(WOLFSSL_KCAPI_RSA) || defined(WOLFSSL_SE050)) && \
@@ -25937,11 +26266,16 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
 {
 #ifndef WOLFSSL_ASN_TEMPLATE
     int ret = 0, i;
+    int mpSz;
     word32 seqSz = 0, verSz = 0, intTotalLen = 0, outLen = 0;
     word32 sizes[RSA_INTS];
     byte  seq[MAX_SEQ_SZ];
     byte  ver[MAX_VERSION_SZ];
+    mp_int* keyInt;
+#ifndef WOLFSSL_NO_MALLOC
+    word32 rawLen;
     byte* tmps[RSA_INTS];
+#endif
 
     if (key == NULL)
         return BAD_FUNC_ARG;
@@ -25949,18 +26283,18 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
     if (key->type != RSA_PRIVATE)
         return BAD_FUNC_ARG;
 
+#ifndef WOLFSSL_NO_MALLOC
     for (i = 0; i < RSA_INTS; i++)
         tmps[i] = NULL;
+#endif
 
     /* write all big ints from key to DER tmps */
     for (i = 0; i < RSA_INTS; i++) {
-        mp_int* keyInt = GetRsaInt(key, i);
-        int mpSz;
-        word32 rawLen;
-
+        keyInt = GetRsaInt(key, i);
         ret = mp_unsigned_bin_size(keyInt);
         if (ret < 0)
-            return ret;
+            break;
+#ifndef WOLFSSL_NO_MALLOC
         rawLen = (word32)ret + 1;
         ret = 0;
         if (output != NULL) {
@@ -25971,8 +26305,11 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
                 break;
             }
         }
-
         mpSz = SetASNIntMP(keyInt, MAX_RSA_INT_SZ, tmps[i]);
+#else
+        ret = 0;
+        mpSz = SetASNIntMP(keyInt, MAX_RSA_INT_SZ, NULL);
+#endif
         if (mpSz < 0) {
             ret = mpSz;
             break;
@@ -26004,15 +26341,33 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
         j += verSz;
 
         for (i = 0; i < RSA_INTS; i++) {
+/* copy from tmps if we have malloc, otherwise re-export with buffer */
+#ifndef WOLFSSL_NO_MALLOC
             XMEMCPY(output + j, tmps[i], sizes[i]);
             j += sizes[i];
+#else
+            keyInt = GetRsaInt(key, i);
+            ret = mp_unsigned_bin_size(keyInt);
+            if (ret < 0)
+                break;
+            ret = 0;
+            /* This won't overrun output due to the outLen check above */
+            mpSz = SetASNIntMP(keyInt, MAX_RSA_INT_SZ, output + j);
+            if (mpSz < 0) {
+                ret = mpSz;
+                break;
+            }
+            j += mpSz;
+#endif
         }
     }
 
+#ifndef WOLFSSL_NO_MALLOC
     for (i = 0; i < RSA_INTS; i++) {
         if (tmps[i])
             XFREE(tmps[i], key->heap, DYNAMIC_TYPE_RSA);
     }
+#endif
 
     if (ret == 0)
         ret = (int)outLen;
@@ -26061,6 +26416,7 @@ int wc_RsaKeyToDer(RsaKey* key, byte* output, word32 inLen)
 
 #endif /* (WOLFSSL_KEY_GEN || OPENSSL_EXTRA) && !NO_RSA */
 
+#ifndef NO_CERTS
 
 #ifdef WOLFSSL_CERT_GEN
 
@@ -26321,7 +26677,7 @@ static int wc_SetCert_LoadDer(Cert* cert, const byte* der, word32 derSz,
             InitDecodedCert_ex((DecodedCert*)cert->decodedCert, der, derSz,
                     cert->heap, devId);
             ret = ParseCertRelative((DecodedCert*)cert->decodedCert,
-                    CERT_TYPE, 0, NULL);
+                    CERT_TYPE, 0, NULL, NULL);
             if (ret >= 0) {
                 cert->der = (byte*)der;
             }
@@ -27565,6 +27921,17 @@ static int EncodeName(EncodedName* name, const char* nameStr,
         ret = BAD_FUNC_ARG;
     }
 
+#ifdef WOLFSSL_CUSTOM_OID
+    if (ret == 0 && type == ASN_CUSTOM_NAME) {
+        if (cname == NULL || cname->custom.oidSz == 0) {
+            name->used = 0;
+            return 0;
+        }
+    }
+#else
+    (void)cname;
+#endif
+
     CALLOC_ASNSETDATA(dataASN, rdnASN_Length, ret, NULL);
     if (ret == 0) {
         nameSz = (word32)XSTRLEN(nameStr);
@@ -28164,7 +28531,8 @@ int SetName(byte* output, word32 outputSz, CertName* name)
 static int EncodePublicKey(int keyType, byte* output, int outLen,
                            RsaKey* rsaKey, ecc_key* eccKey,
                            ed25519_key* ed25519Key, ed448_key* ed448Key,
-                           DsaKey* dsaKey)
+                           DsaKey* dsaKey, falcon_key* falconKey,
+                           dilithium_key* dilithiumKey, sphincs_key* sphincsKey)
 {
     int ret = 0;
 
@@ -28174,6 +28542,9 @@ static int EncodePublicKey(int keyType, byte* output, int outLen,
     (void)ed25519Key;
     (void)ed448Key;
     (void)dsaKey;
+    (void)falconKey;
+    (void)dilithiumKey;
+    (void)sphincsKey;
 
     switch (keyType) {
     #ifndef NO_RSA
@@ -28209,6 +28580,41 @@ static int EncodePublicKey(int keyType, byte* output, int outLen,
             }
             break;
     #endif
+    #if defined(HAVE_FALCON)
+        case FALCON_LEVEL1_KEY:
+        case FALCON_LEVEL5_KEY:
+            ret = wc_Falcon_PublicKeyToDer(falconKey, output,
+                                           (word32)outLen, 1);
+            if (ret <= 0) {
+                ret = PUBLIC_KEY_E;
+            }
+            break;
+    #endif /* HAVE_FALCON */
+    #if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_ASN1)
+        case DILITHIUM_LEVEL2_KEY:
+        case DILITHIUM_LEVEL3_KEY:
+        case DILITHIUM_LEVEL5_KEY:
+            ret = wc_Dilithium_PublicKeyToDer(dilithiumKey, output,
+                                              (word32)outLen, 1);
+            if (ret <= 0) {
+                ret = PUBLIC_KEY_E;
+            }
+            break;
+    #endif /* HAVE_DILITHIUM */
+    #if defined(HAVE_SPHINCS)
+        case SPHINCS_FAST_LEVEL1_KEY:
+        case SPHINCS_FAST_LEVEL3_KEY:
+        case SPHINCS_FAST_LEVEL5_KEY:
+        case SPHINCS_SMALL_LEVEL1_KEY:
+        case SPHINCS_SMALL_LEVEL3_KEY:
+        case SPHINCS_SMALL_LEVEL5_KEY:
+            ret = wc_Sphincs_PublicKeyToDer(sphincsKey, output,
+                                            (word32)outLen, 1);
+            if (ret <= 0) {
+                ret = PUBLIC_KEY_E;
+            }
+            break;
+    #endif /* HAVE_SPHINCS */
         default:
             ret = PUBLIC_KEY_E;
             break;
@@ -28997,7 +29403,6 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
     }
 #endif
 
-#if defined(HAVE_PQC)
 #if defined(HAVE_FALCON)
     if ((cert->keyType == FALCON_LEVEL1_KEY) ||
         (cert->keyType == FALCON_LEVEL5_KEY)) {
@@ -29009,7 +29414,7 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
                                      (word32)sizeof(der->publicKey), 1);
     }
 #endif /* HAVE_FALCON */
-#if defined(HAVE_DILITHIUM)
+#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_ASN1)
     if ((cert->keyType == DILITHIUM_LEVEL2_KEY) ||
         (cert->keyType == DILITHIUM_LEVEL3_KEY) ||
         (cert->keyType == DILITHIUM_LEVEL5_KEY)) {
@@ -29036,7 +29441,6 @@ static int EncodeCert(Cert* cert, DerCert* der, RsaKey* rsaKey, ecc_key* eccKey,
                                       (word32)sizeof(der->publicKey), 1);
     }
 #endif /* HAVE_SPHINCS */
-#endif /* HAVE_PQC */
 
     if (der->publicKeySz <= 0)
         return PUBLIC_KEY_E;
@@ -29542,7 +29946,6 @@ static int MakeSignature(CertSignCtx* certSignCtx, const byte* buf, word32 sz,
         }
     #endif /* HAVE_ED448 && HAVE_ED448_SIGN */
 
-    #if defined(HAVE_PQC)
     #if defined(HAVE_FALCON)
         if (!rsaKey && !eccKey && !ed25519Key && !ed448Key && falconKey) {
             word32 outSz = sigSz;
@@ -29569,7 +29972,6 @@ static int MakeSignature(CertSignCtx* certSignCtx, const byte* buf, word32 sz,
                 ret = outSz;
         }
     #endif /* HAVE_SPHINCS */
-    #endif /* HAVE_PQC */
 
         break;
     }
@@ -29577,7 +29979,7 @@ static int MakeSignature(CertSignCtx* certSignCtx, const byte* buf, word32 sz,
 exit_ms:
 
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         return ret;
     }
 #endif
@@ -29786,7 +30188,6 @@ static int MakeAnyCert(Cert* cert, byte* derBuffer, word32 derSz,
         cert->keyType = ED25519_KEY;
     else if (ed448Key)
         cert->keyType = ED448_KEY;
-#ifdef HAVE_PQC
 #ifdef HAVE_FALCON
     else if ((falconKey != NULL) && (falconKey->level == 1))
         cert->keyType = FALCON_LEVEL1_KEY;
@@ -29821,7 +30222,6 @@ static int MakeAnyCert(Cert* cert, byte* derBuffer, word32 derSz,
              && (sphincsKey->optim == SMALL_VARIANT))
         cert->keyType = SPHINCS_SMALL_LEVEL5_KEY;
 #endif /* HAVE_SPHINCS */
-#endif /* HAVE_PQC */
     else
         return BAD_FUNC_ARG;
 
@@ -29881,7 +30281,6 @@ static int MakeAnyCert(Cert* cert, byte* derBuffer, word32 derSz,
         else if (ed448Key) {
             cert->keyType = ED448_KEY;
         }
-#ifdef HAVE_PQC
 #ifdef HAVE_FALCON
         else if ((falconKey != NULL) && (falconKey->level == 1)) {
             cert->keyType = FALCON_LEVEL1_KEY;
@@ -29927,7 +30326,6 @@ static int MakeAnyCert(Cert* cert, byte* derBuffer, word32 derSz,
             cert->keyType = SPHINCS_SMALL_LEVEL5_KEY;
         }
 #endif /* HAVE_SPHINCS */
-#endif /* HAVE_PQC */
         else {
             ret = BAD_FUNC_ARG;
         }
@@ -29975,7 +30373,8 @@ static int MakeAnyCert(Cert* cert, byte* derBuffer, word32 derSz,
     if (ret >= 0) {
         /* Calculate public key encoding size. */
         ret = EncodePublicKey(cert->keyType, NULL, 0, rsaKey,
-            eccKey, ed25519Key, ed448Key, dsaKey);
+                eccKey, ed25519Key, ed448Key, dsaKey, falconKey,
+                dilithiumKey, sphincsKey);
         publicKeySz = (word32)ret;
     }
     if (ret >= 0) {
@@ -30155,7 +30554,8 @@ static int MakeAnyCert(Cert* cert, byte* derBuffer, word32 derSz,
                            .data.buffer.data,
             (int)dataASN[X509CERTASN_IDX_TBS_SPUBKEYINFO_SEQ]
                            .data.buffer.length,
-            rsaKey, eccKey, ed25519Key, ed448Key, dsaKey);
+            rsaKey, eccKey, ed25519Key, ed448Key, dsaKey,
+            falconKey, dilithiumKey, sphincsKey);
     }
     if ((ret >= 0) && (!dataASN[X509CERTASN_IDX_TBS_EXT_SEQ].noOut)) {
         /* Encode extensions into buffer. */
@@ -30235,6 +30635,7 @@ int wc_MakeCert(Cert* cert, byte* derBuffer, word32 derSz, RsaKey* rsaKey,
     return MakeAnyCert(cert, derBuffer, derSz, rsaKey, eccKey, rng, NULL, NULL,
                        NULL, NULL, NULL, NULL);
 }
+
 
 #ifdef WOLFSSL_CERT_REQ
 
@@ -30499,7 +30900,6 @@ static int EncodeCertReq(Cert* cert, DerCert* der, RsaKey* rsaKey,
             (word32)sizeof(der->publicKey), 1);
     }
 #endif
-#if defined(HAVE_PQC)
 #if defined(HAVE_FALCON)
     if ((cert->keyType == FALCON_LEVEL1_KEY) ||
         (cert->keyType == FALCON_LEVEL5_KEY)) {
@@ -30509,7 +30909,7 @@ static int EncodeCertReq(Cert* cert, DerCert* der, RsaKey* rsaKey,
             der->publicKey, (word32)sizeof(der->publicKey), 1);
     }
 #endif
-#if defined(HAVE_DILITHIUM)
+#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_ASN1)
     if ((cert->keyType == DILITHIUM_LEVEL2_KEY) ||
         (cert->keyType == DILITHIUM_LEVEL3_KEY) ||
         (cert->keyType == DILITHIUM_LEVEL5_KEY)) {
@@ -30532,7 +30932,6 @@ static int EncodeCertReq(Cert* cert, DerCert* der, RsaKey* rsaKey,
             der->publicKey, (word32)sizeof(der->publicKey), 1);
     }
 #endif
-#endif /* HAVE_PQC */
 
     if (der->publicKeySz <= 0)
         return PUBLIC_KEY_E;
@@ -30858,7 +31257,6 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
         cert->keyType = ED25519_KEY;
     else if (ed448Key)
         cert->keyType = ED448_KEY;
-#ifdef HAVE_PQC
 #ifdef HAVE_FALCON
     else if ((falconKey != NULL) && (falconKey->level == 1))
         cert->keyType = FALCON_LEVEL1_KEY;
@@ -30893,7 +31291,6 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
              && (sphincsKey->optim == SMALL_VARIANT))
         cert->keyType = SPHINCS_SMALL_LEVEL5_KEY;
 #endif /* HAVE_SPHINCS */
-#endif /* HAVE_PQC */
     else
         return BAD_FUNC_ARG;
 
@@ -30954,7 +31351,6 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
         else if (ed448Key != NULL) {
             cert->keyType = ED448_KEY;
         }
-#ifdef HAVE_PQC
 #ifdef HAVE_FALCON
         else if ((falconKey != NULL) && (falconKey->level == 1)) {
             cert->keyType = FALCON_LEVEL1_KEY;
@@ -31000,7 +31396,6 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
             cert->keyType = SPHINCS_SMALL_LEVEL5_KEY;
         }
 #endif /* HAVE_SPHINCS */
-#endif /* HAVE_PQC */
         else {
             ret = BAD_FUNC_ARG;
         }
@@ -31022,7 +31417,8 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
     if (ret >= 0) {
         /* Determine encode public key size. */
          ret = EncodePublicKey(cert->keyType, NULL, 0, rsaKey,
-             eccKey, ed25519Key, ed448Key, dsaKey);
+             eccKey, ed25519Key, ed448Key, dsaKey, falconKey,
+             dilithiumKey, sphincsKey);
          publicKeySz = (word32)ret;
     }
     if (ret >= 0) {
@@ -31136,7 +31532,8 @@ static int MakeCertReq(Cert* cert, byte* derBuffer, word32 derSz,
         ret = EncodePublicKey(cert->keyType,
             (byte*)dataASN[CERTREQBODYASN_IDX_SPUBKEYINFO_SEQ].data.buffer.data,
             (int)dataASN[CERTREQBODYASN_IDX_SPUBKEYINFO_SEQ].data.buffer.length,
-            rsaKey, eccKey, ed25519Key, ed448Key, dsaKey);
+            rsaKey, eccKey, ed25519Key, ed448Key, dsaKey, falconKey,
+            dilithiumKey, sphincsKey);
     }
     if ((ret >= 0 && derBuffer != NULL) &&
             (!dataASN[CERTREQBODYASN_IDX_EXT_BODY].noOut)) {
@@ -31266,7 +31663,7 @@ static int SignCert(int requestSz, int sType, byte* buf, word32 buffSz,
         MAX_ENCODED_SIG_SZ, rsaKey, eccKey, ed25519Key, ed448Key,
         falconKey, dilithiumKey, sphincsKey, rng, (word32)sType, heap);
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (sigSz == WC_PENDING_E) {
+    if (sigSz == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         /* Not free'ing certSignCtx->sig here because it could still be in use
          * with async operations. */
         return sigSz;
@@ -31379,7 +31776,7 @@ int wc_MakeSigWithBitStr(byte *sig, int sigSz, int sType, byte* buf,
         MAX_ENCODED_SIG_SZ, rsaKey, eccKey, ed25519Key, ed448Key,
         falconKey, dilithiumKey, sphincsKey, rng, (word32)sType, heap);
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (ret == WC_PENDING_E) {
+    if (ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
         /* Not free'ing certSignCtx->sig here because it could still be in use
          * with async operations. */
         return ret;
@@ -31387,6 +31784,8 @@ int wc_MakeSigWithBitStr(byte *sig, int sigSz, int sType, byte* buf,
 #endif
 
     if (ret <= 0) {
+        XFREE(certSignCtx->sig, heap, DYNAMIC_TYPE_TMP_BUFFER);
+        certSignCtx->sig = NULL;
         return ret;
     }
 
@@ -31459,6 +31858,7 @@ int wc_SignCert(int requestSz, int sType, byte* buf, word32 buffSz,
     return SignCert(requestSz, sType, buf, buffSz, rsaKey, eccKey, NULL, NULL,
                     NULL, NULL, NULL, rng);
 }
+
 
 WOLFSSL_ABI
 int wc_MakeSelfCert(Cert* cert, byte* buf, word32 buffSz,
@@ -31536,14 +31936,13 @@ static int SetKeyIdFromPublicKey(Cert *cert, RsaKey *rsakey, ecc_key *eckey,
         bufferSz = wc_Ed448PublicKeyToDer(ed448Key, buf, MAX_PUBLIC_KEY_SZ, 0);
     }
 #endif
-#if defined(HAVE_PQC)
 #if defined(HAVE_FALCON)
     if (falconKey != NULL) {
         bufferSz = wc_Falcon_PublicKeyToDer(falconKey, buf, MAX_PUBLIC_KEY_SZ,
                                             0);
     }
 #endif
-#if defined(HAVE_DILITHIUM)
+#if defined(HAVE_DILITHIUM) && !defined(WOLFSSL_DILITHIUM_NO_ASN1)
     if (dilithiumKey != NULL) {
         bufferSz = wc_Dilithium_PublicKeyToDer(dilithiumKey, buf,
                                                MAX_PUBLIC_KEY_SZ, 0);
@@ -31555,7 +31954,6 @@ static int SetKeyIdFromPublicKey(Cert *cert, RsaKey *rsakey, ecc_key *eckey,
                                                MAX_PUBLIC_KEY_SZ, 0);
     }
 #endif
-#endif /* HAVE_PQC */
 
     if (bufferSz <= 0) {
         XFREE(buf, cert->heap, DYNAMIC_TYPE_TMP_BUFFER);
@@ -32023,7 +32421,7 @@ static int SetAltNamesFromCert(Cert* cert, const byte* der, int derSz,
 #endif
 
     InitDecodedCert_ex(decoded, der, (word32)derSz, NULL, devId);
-    ret = ParseCertRelative(decoded, CA_TYPE, NO_VERIFY, 0);
+    ret = ParseCertRelative(decoded, CA_TYPE, NO_VERIFY, 0, NULL);
 
     if (ret < 0) {
         WOLFSSL_MSG("ParseCertRelative error");
@@ -32222,7 +32620,7 @@ static int SetNameFromCert(CertName* cn, const byte* der, int derSz, int devId)
 #endif
 
     InitDecodedCert_ex(decoded, der, (word32)derSz, NULL, devId);
-    ret = ParseCertRelative(decoded, CA_TYPE, NO_VERIFY, 0);
+    ret = ParseCertRelative(decoded, CA_TYPE, NO_VERIFY, 0, NULL);
 
     if (ret < 0) {
         WOLFSSL_MSG("ParseCertRelative error");
@@ -34075,7 +34473,7 @@ int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *inLen,
         PRIVATE_KEY_UNLOCK();
         ret = wc_ecc_export_x963(key, NULL, &pubSz);
         PRIVATE_KEY_LOCK();
-        if (ret != LENGTH_ONLY_E) {
+        if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         #ifndef WOLFSSL_NO_MALLOC
             XFREE(prv, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
         #endif
@@ -34173,7 +34571,8 @@ int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *inLen,
     return (int)totalSz;
 #else
     DECL_ASNSETDATA(dataASN, eccKeyASN_Length);
-    word32 privSz, pubSz;
+    word32 privSz = 0;
+    word32 pubSz = 0;
     int sz = 0;
     int ret = 0;
     int curveIdSz = 0;
@@ -34198,7 +34597,7 @@ int wc_BuildEccKeyDer(ecc_key* key, byte* output, word32 *inLen,
             PRIVATE_KEY_UNLOCK();
             ret = wc_ecc_export_x963(key, NULL, &pubSz);
             PRIVATE_KEY_LOCK();
-            if (ret == LENGTH_ONLY_E)
+            if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E))
                 ret = 0;
         }
     }
@@ -34300,7 +34699,7 @@ int wc_EccKeyDerSize(ecc_key* key, int pub)
 
     ret = wc_BuildEccKeyDer(key, NULL, &sz, pub, 1);
 
-    if (ret != LENGTH_ONLY_E) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
         return ret;
     }
     return (int)sz;
@@ -34367,7 +34766,7 @@ static int eccToPKCS8(ecc_key* key, byte* output, word32* outLen,
     /* get pkcs8 expected output size */
     ret = wc_CreatePKCS8Key(NULL, &pkcs8Sz, tmpDer, tmpDerSz, algoID,
                             curveOID, oidSz);
-    if (ret != LENGTH_ONLY_E) {
+    if (ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
     #ifndef WOLFSSL_NO_MALLOC
         XFREE(tmpDer, key->heap, DYNAMIC_TYPE_TMP_BUFFER);
     #endif
@@ -34467,13 +34866,11 @@ enum {
     || (defined(HAVE_CURVE25519) && defined(HAVE_CURVE25519_KEY_IMPORT)) \
     || (defined(HAVE_ED448) && defined(HAVE_ED448_KEY_IMPORT)) \
     || (defined(HAVE_CURVE448) && defined(HAVE_CURVE448_KEY_IMPORT)) \
-    || (defined(HAVE_PQC) && defined(HAVE_FALCON)) \
-    || (defined(HAVE_PQC) && defined(HAVE_DILITHIUM)) \
-    || (defined(HAVE_PQC) && defined(HAVE_SPHINCS)))
+    || defined(HAVE_FALCON) || defined(HAVE_DILITHIUM) || defined(HAVE_SPHINCS))
 
-int DecodeAsymKey(const byte* input, word32* inOutIdx, word32 inSz,
-    byte* privKey, word32* privKeyLen,
-    byte* pubKey, word32* pubKeyLen, int keyType)
+int DecodeAsymKey_Assign(const byte* input, word32* inOutIdx, word32 inSz,
+    const byte** privKey, word32* privKeyLen,
+    const byte** pubKey, word32* pubKeyLen, int keyType)
 {
 #ifndef WOLFSSL_ASN_TEMPLATE
     word32 oid;
@@ -34528,12 +34925,9 @@ int DecodeAsymKey(const byte* input, word32* inOutIdx, word32 inSz,
         endKeyIdx = (int)*inOutIdx;
     }
 
-    if ((word32)privSz > *privKeyLen)
-        return BUFFER_E;
-
     if (endKeyIdx == (int)*inOutIdx) {
         *privKeyLen = (word32)privSz;
-        XMEMCPY(privKey, priv, *privKeyLen);
+        *privKey = priv;
         if (pubKeyLen != NULL)
             *pubKeyLen = 0;
     }
@@ -34547,17 +34941,14 @@ int DecodeAsymKey(const byte* input, word32* inOutIdx, word32 inSz,
             return ASN_PARSE_E;
         }
 
-        if ((word32)pubSz > *pubKeyLen)
-            return BUFFER_E;
-
         pub = input + *inOutIdx;
         *inOutIdx += (word32)pubSz;
 
         *privKeyLen = (word32)privSz;
-        XMEMCPY(privKey, priv, *privKeyLen);
+        *privKey = priv;
         *pubKeyLen = (word32)pubSz;
         if (pubKey != NULL)
-            XMEMCPY(pubKey, pub, *pubKeyLen);
+            *pubKey = pub;
     }
     if (endKeyIdx != (int)*inOutIdx)
         return ASN_PARSE_E;
@@ -34581,33 +34972,22 @@ int DecodeAsymKey(const byte* input, word32* inOutIdx, word32 inSz,
             }
         }
     }
-    /* Check the private value length is correct. */
-    if ((ret == 0) && dataASN[EDKEYASN_IDX_PKEY_CURVEPKEY].data.ref.length
-            > *privKeyLen) {
-        ret = ASN_PARSE_E;
+    if (ret == 0) {
+        /* Import private value. */
+        *privKeyLen = dataASN[EDKEYASN_IDX_PKEY_CURVEPKEY].data.ref.length;
+        *privKey = dataASN[EDKEYASN_IDX_PKEY_CURVEPKEY].data.ref.data;
     }
     if ((ret == 0) && dataASN[EDKEYASN_IDX_PUBKEY].tag == 0) {
-        *privKeyLen = dataASN[EDKEYASN_IDX_PKEY_CURVEPKEY].data.ref.length;
-        XMEMCPY(privKey, dataASN[EDKEYASN_IDX_PKEY_CURVEPKEY].data.ref.data,
-                *privKeyLen);
+        /* Set public length to 0 as not seen. */
         if (pubKeyLen != NULL)
             *pubKeyLen = 0;
     }
-    else if ((ret == 0) &&
-             (pubKeyLen != NULL) &&
-             (dataASN[EDKEYASN_IDX_PUBKEY].data.ref.length > *pubKeyLen)) {
-        ret = ASN_PARSE_E;
-    }
     else if (ret == 0) {
-        /* Import private and public value. */
-        *privKeyLen = dataASN[EDKEYASN_IDX_PKEY_CURVEPKEY].data.ref.length;
-        XMEMCPY(privKey, dataASN[EDKEYASN_IDX_PKEY_CURVEPKEY].data.ref.data,
-                *privKeyLen);
+        /* Import public value. */
         if (pubKeyLen != NULL)
             *pubKeyLen = dataASN[EDKEYASN_IDX_PUBKEY].data.ref.length;
         if (pubKey != NULL && pubKeyLen != NULL)
-            XMEMCPY(pubKey, dataASN[EDKEYASN_IDX_PUBKEY].data.ref.data,
-                    *pubKeyLen);
+            *pubKey = dataASN[EDKEYASN_IDX_PUBKEY].data.ref.data;
     }
 
     FREE_ASNGETDATA(dataASN, NULL);
@@ -34615,8 +34995,46 @@ int DecodeAsymKey(const byte* input, word32* inOutIdx, word32 inSz,
 #endif /* WOLFSSL_ASN_TEMPLATE */
 }
 
-int DecodeAsymKeyPublic(const byte* input, word32* inOutIdx, word32 inSz,
+int DecodeAsymKey(const byte* input, word32* inOutIdx, word32 inSz,
+    byte* privKey, word32* privKeyLen,
     byte* pubKey, word32* pubKeyLen, int keyType)
+{
+    int ret = 0;
+    const byte* privKeyPtr = NULL;
+    const byte* pubKeyPtr = NULL;
+    word32 privKeyPtrLen = 0;
+    word32 pubKeyPtrLen = 0;
+
+    if (privKey == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (ret == 0) {
+        ret = DecodeAsymKey_Assign(input, inOutIdx, inSz, &privKeyPtr,
+            &privKeyPtrLen, &pubKeyPtr, &pubKeyPtrLen, keyType);
+    }
+    if ((ret == 0) && (privKeyPtrLen > *privKeyLen)) {
+        ret = BUFFER_E;
+    }
+    if ((ret == 0) && (pubKeyLen != NULL) && (pubKeyPtrLen > *pubKeyLen)) {
+        ret = BUFFER_E;
+    }
+    if ((ret == 0) && (privKeyPtr != NULL)) {
+        XMEMCPY(privKey, privKeyPtr, privKeyPtrLen);
+        *privKeyLen = privKeyPtrLen;
+    }
+    if ((ret == 0) && (pubKey != NULL) && (pubKeyPtr != NULL)) {
+        XMEMCPY(pubKey, pubKeyPtr, pubKeyPtrLen);
+    }
+    if ((ret == 0) && (pubKeyLen != NULL)) {
+        *pubKeyLen = pubKeyPtrLen;
+    }
+
+    return ret;
+}
+
+int DecodeAsymKeyPublic_Assign(const byte* input, word32* inOutIdx, word32 inSz,
+    const byte** pubKey, word32* pubKeyLen, int keyType)
 {
     int ret = 0;
 #ifndef WOLFSSL_ASN_TEMPLATE
@@ -34649,17 +35067,13 @@ int DecodeAsymKeyPublic(const byte* input, word32* inOutIdx, word32 inSz,
     if (ret != 0)
         return ret;
 
-    /* check that the value found is not too large for pubKey buffer */
-    if ((word32)length > *pubKeyLen)
-        return ASN_PARSE_E;
-
     /* check that input buffer is exhausted */
     if (*inOutIdx + (word32)length != inSz)
         return ASN_PARSE_E;
 
     /* This is the raw point data compressed or uncompressed. */
     *pubKeyLen = (word32)length;
-    XMEMCPY(pubKey, input + *inOutIdx, *pubKeyLen);
+    *pubKey = input + *inOutIdx;
 #else
     len = inSz - *inOutIdx;
 
@@ -34680,11 +35094,6 @@ int DecodeAsymKeyPublic(const byte* input, word32* inOutIdx, word32 inSz,
         if (*inOutIdx != inSz)
             ret = ASN_PARSE_E;
     }
-    /* Check the public value length is correct. */
-    if ((ret == 0) &&
-            (dataASN[EDPUBKEYASN_IDX_PUBKEY].data.ref.length > *pubKeyLen)) {
-        ret = ASN_PARSE_E;
-    }
     /* Check that the all the buffer was used. */
     if ((ret == 0) &&
             (GetASNItem_Length(dataASN[EDPUBKEYASN_IDX_SEQ], input) != len)) {
@@ -34692,12 +35101,37 @@ int DecodeAsymKeyPublic(const byte* input, word32* inOutIdx, word32 inSz,
     }
     if (ret == 0) {
         *pubKeyLen = dataASN[EDPUBKEYASN_IDX_PUBKEY].data.ref.length;
-        XMEMCPY(pubKey, dataASN[EDPUBKEYASN_IDX_PUBKEY].data.ref.data,
-                *pubKeyLen);
+        *pubKey = dataASN[EDPUBKEYASN_IDX_PUBKEY].data.ref.data;
     }
 
     FREE_ASNGETDATA(dataASN, NULL);
 #endif /* WOLFSSL_ASN_TEMPLATE */
+    return ret;
+}
+
+int DecodeAsymKeyPublic(const byte* input, word32* inOutIdx, word32 inSz,
+    byte* pubKey, word32* pubKeyLen, int keyType)
+{
+    int ret = 0;
+    const byte* pubKeyPtr = NULL;
+    word32 pubKeyPtrLen = 0;
+
+    if (pubKey == NULL) {
+        ret = BAD_FUNC_ARG;
+    }
+
+    if (ret == 0) {
+        ret = DecodeAsymKeyPublic_Assign(input, inOutIdx, inSz, &pubKeyPtr,
+            &pubKeyPtrLen, keyType);
+    }
+    if ((ret == 0) && (pubKeyPtrLen > *pubKeyLen)) {
+        ret = BUFFER_E;
+    }
+    if ((ret == 0) && (pubKeyPtr != NULL)) {
+        XMEMCPY(pubKey, pubKeyPtr, pubKeyPtrLen);
+        *pubKeyLen = pubKeyPtrLen;
+    }
+
     return ret;
 }
 #endif
@@ -35135,7 +35569,7 @@ int wc_Curve448PublicKeyToDer(curve448_key* key, byte* output, word32 inLen,
     byte   pubKey[CURVE448_PUB_KEY_SIZE];
     word32 pubKeyLen = (word32)sizeof(pubKey);
 
-    if (key == NULL || output == NULL) {
+    if (key == NULL) {
         return BAD_FUNC_ARG;
     }
 
@@ -36125,7 +36559,7 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
             /* Don't verify if we don't have access to Cert Manager. */
             ret = ParseCertRelative(cert, CERT_TYPE,
                                     noVerify ? NO_VERIFY : VERIFY_OCSP_CERT,
-                                    cm);
+                                    cm, resp->pendingCAs);
             if (ret < 0) {
                 WOLFSSL_MSG("\tOCSP Responder certificate parsing failed");
                 break;
@@ -36184,7 +36618,11 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
         #else
             ca = GetCA(cm, resp->single->issuerHash);
         #endif
-
+#if defined(HAVE_CERTIFICATE_STATUS_V2)
+        if (ca == NULL && resp->pendingCAs != NULL) {
+            ca = findSignerByName(resp->pendingCAs, resp->single->issuerHash);
+        }
+#endif
         if (ca) {
             SignatureCtx sigCtx;
             InitSignatureCtx(&sigCtx, heap, INVALID_DEVID);
@@ -36282,7 +36720,7 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
         /* Parse the certificate and don't verify if we don't have access to
          * Cert Manager. */
         ret = ParseCertRelative(cert, CERT_TYPE, noVerify ? NO_VERIFY : VERIFY,
-                cm);
+                cm, resp->pendingCAs);
         if (ret < 0) {
             WOLFSSL_MSG("\tOCSP Responder certificate parsing failed");
         }
@@ -36321,6 +36759,13 @@ static int DecodeBasicOcspResponse(byte* source, word32* ioIndex,
     #else
         ca = GetCA(cm, resp->single->issuerHash);
     #endif
+
+    #if defined(HAVE_CERTIFICATE_STATUS_REQUEST_V2)
+        if (ca == NULL && resp->pendingCAs != NULL) {
+            ca = findSignerByName(resp->pendingCAs, resp->single->issuerHash);
+        }
+    #endif
+
         if (ca) {
             SignatureCtx sigCtx;
 
@@ -36378,6 +36823,7 @@ void InitOcspResponse(OcspResponse* resp, OcspEntry* single, CertStatus* status,
     resp->source         = source;
     resp->maxIdx         = inSz;
     resp->heap           = heap;
+    resp->pendingCAs     = NULL;
 }
 
 void FreeOcspResponse(OcspResponse* resp)
@@ -37413,7 +37859,7 @@ int VerifyCRL_Signature(SignatureCtx* sigCtx, const byte* toBeSigned,
     InitSignatureCtx(sigCtx, heap, INVALID_DEVID);
     if (ConfirmSignature(sigCtx, toBeSigned, tbsSz, ca->publicKey,
                          ca->pubKeySize, ca->keyOID, signature, sigSz,
-                         signatureOID, sigParams, sigParamsSz, NULL) != 0) {
+                         signatureOID, sigParams, (word32)sigParamsSz, NULL) != 0) {
         WOLFSSL_MSG("CRL Confirm signature failed");
         WOLFSSL_ERROR_VERBOSE(ASN_CRL_CONFIRM_E);
         return ASN_CRL_CONFIRM_E;
@@ -38137,7 +38583,7 @@ end:
                     buff);
             dcrl->sigParamsIndex =
                 dataASN[CRLASN_IDX_SIGALGO_PARAMS].offset;
-            dcrl->sigParamsLength = sigParamsSz;
+            dcrl->sigParamsLength = (word32)sigParamsSz;
         }
     #endif
 
@@ -39011,7 +39457,7 @@ static void PrintObjectIdText(Asn1* asn1, Asn1PrintOptions* opts)
 
     /* Get the OID value for the OBJECT_ID. */
     if (GetObjectId(asn1->data + asn1->offset, &i, &oid, oidIgnoreType,
-            asn1->item.len + 2) == ASN_PARSE_E) {
+            asn1->item.len + 2) == WC_NO_ERR_TRACE(ASN_PARSE_E)) {
         known = 0;
     }
     else

--- a/libatalk/ssl/wolfcrypt/src/coding.c
+++ b/libatalk/ssl/wolfcrypt/src/coding.c
@@ -181,7 +181,7 @@ int Base64_Decode(const byte* in, word32 inLen, byte* out, word32* outLen)
         byte e1, e2, e3, e4;
 
         if ((ret = Base64_SkipNewline(in, &inLen, &j)) != 0) {
-            if (ret == BUFFER_E) {
+            if (ret == WC_NO_ERR_TRACE(BUFFER_E)) {
                 /* Running out of buffer here is not an error */
                 break;
             }

--- a/libatalk/ssl/wolfcrypt/src/des3.c
+++ b/libatalk/ssl/wolfcrypt/src/des3.c
@@ -38,8 +38,8 @@
     #define FIPS_NO_WRAPPERS
 
     #ifdef USE_WINDOWS_API
-        #pragma code_seg(".fipsA$i")
-        #pragma const_seg(".fipsB$i")
+        #pragma code_seg(".fipsA$d")
+        #pragma const_seg(".fipsB$d")
     #endif
 #endif
 
@@ -1602,7 +1602,7 @@
     #ifdef WOLF_CRYPTO_CB
         if (des->devId != INVALID_DEVID) {
             int ret = wc_CryptoCb_Des3Encrypt(des, out, in, sz);
-            if (ret != CRYPTOCB_UNAVAILABLE)
+            if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 return ret;
             /* fall-through when unavailable */
         }
@@ -1653,7 +1653,7 @@
     #ifdef WOLF_CRYPTO_CB
         if (des->devId != INVALID_DEVID) {
             int ret = wc_CryptoCb_Des3Decrypt(des, out, in, sz);
-            if (ret != CRYPTOCB_UNAVAILABLE)
+            if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 return ret;
             /* fall-through when unavailable */
         }

--- a/libatalk/ssl/wolfcrypt/src/dh.c
+++ b/libatalk/ssl/wolfcrypt/src/dh.c
@@ -35,8 +35,8 @@
     #define FIPS_NO_WRAPPERS
 
     #ifdef USE_WINDOWS_API
-        #pragma code_seg(".fipsA$m")
-        #pragma const_seg(".fipsB$m")
+        #pragma code_seg(".fipsA$e")
+        #pragma const_seg(".fipsB$e")
     #endif
 #endif
 
@@ -53,6 +53,15 @@
 #else
     #define WOLFSSL_MISC_INCLUDED
     #include <wolfcrypt/src/misc.c>
+#endif
+
+#if FIPS_VERSION3_GE(6,0,0)
+    const unsigned int wolfCrypt_FIPS_dh_ro_sanity[2] =
+                                                     { 0x1a2b3c4d, 0x00000004 };
+    int wolfCrypt_FIPS_DH_sanity(void)
+    {
+        return 0;
+    }
 #endif
 
 #if defined(WOLFSSL_LINUXKM) && !defined(WOLFSSL_SP_ASM)
@@ -2931,6 +2940,14 @@ int wc_DhGenerateParams(WC_RNG *rng, int modSz, DhKey *dh)
     if (ret == 0) {
         /* modulus size in bytes */
         modSz /= WOLFSSL_BIT_SIZE;
+
+        if ((word32)modSz < groupSz) {
+            WOLFSSL_MSG("DH modSz was too small");
+            ret = BAD_FUNC_ARG;
+        }
+    }
+
+    if (ret == 0) {
         bufSz = (word32)modSz - groupSz;
 
         /* allocate ram */

--- a/libatalk/ssl/wolfcrypt/src/evp.c
+++ b/libatalk/ssl/wolfcrypt/src/evp.c
@@ -711,8 +711,19 @@ static int evpCipherBlock(WOLFSSL_EVP_CIPHER_CTX *ctx,
 static int wolfSSL_EVP_CipherUpdate_GCM_AAD(WOLFSSL_EVP_CIPHER_CTX *ctx,
         const unsigned char *in, int inl) {
     if (in && inl > 0) {
-        byte* tmp = (byte*)XREALLOC(ctx->authIn,
+        byte* tmp;
+    #ifdef WOLFSSL_NO_REALLOC
+        tmp = (byte*)XMALLOC((size_t)(ctx->authInSz + inl), NULL,
+                DYNAMIC_TYPE_OPENSSL);
+        if (tmp != NULL) {
+            XMEMCPY(tmp, ctx->authIn, (size_t)ctx->authInSz);
+            XFREE(ctx->authIn, NULL, DYNAMIC_TYPE_OPENSSL);
+            ctx->authIn = NULL;
+        }
+    #else
+        tmp = (byte*)XREALLOC(ctx->authIn,
                 (size_t)(ctx->authInSz + inl), NULL, DYNAMIC_TYPE_OPENSSL);
+    #endif
         if (tmp) {
             ctx->authIn = tmp;
             XMEMCPY(ctx->authIn + ctx->authInSz, in, (size_t)inl);
@@ -745,9 +756,19 @@ static int wolfSSL_EVP_CipherUpdate_GCM(WOLFSSL_EVP_CIPHER_CTX *ctx,
             /* Buffer input for one-shot API */
             if (inl > 0) {
                 byte* tmp;
+            #ifdef WOLFSSL_NO_REALLOC
+                tmp = (byte*)XMALLOC((size_t)(ctx->authBufferLen + inl), NULL,
+                        DYNAMIC_TYPE_OPENSSL);
+                if (tmp != NULL) {
+                    XMEMCPY(tmp, ctx->authBuffer, (size_t)ctx->authBufferLen);
+                    XFREE(ctx->authBuffer, NULL, DYNAMIC_TYPE_OPENSSL);
+                    ctx->authBuffer = NULL;
+                }
+            #else
                 tmp = (byte*)XREALLOC(ctx->authBuffer,
                         (size_t)(ctx->authBufferLen + inl), NULL,
                         DYNAMIC_TYPE_OPENSSL);
+            #endif
                 if (tmp) {
                     XMEMCPY(tmp + ctx->authBufferLen, in, (size_t)inl);
                     ctx->authBufferLen += inl;
@@ -817,8 +838,19 @@ static int wolfSSL_EVP_CipherUpdate_GCM(WOLFSSL_EVP_CIPHER_CTX *ctx,
 static int wolfSSL_EVP_CipherUpdate_CCM_AAD(WOLFSSL_EVP_CIPHER_CTX *ctx,
         const unsigned char *in, int inl) {
     if (in && inl > 0) {
-        byte* tmp = (byte*)XREALLOC(ctx->authIn,
+        byte* tmp;
+    #ifdef WOLFSSL_NO_REALLOC
+        tmp = (byte*)XMALLOC((size_t)(ctx->authInSz + inl), NULL,
+                DYNAMIC_TYPE_OPENSSL);
+        if (tmp != NULL) {
+            XMEMCPY(tmp, ctx->authIn, (size_t)ctx->authInSz);
+            XFREE(ctx->authIn, NULL, DYNAMIC_TYPE_OPENSSL);
+            ctx->authIn = NULL;
+        }
+    #else
+        tmp = (byte*)XREALLOC(ctx->authIn,
                 (size_t)(ctx->authInSz + inl), NULL, DYNAMIC_TYPE_OPENSSL);
+    #endif
         if (tmp) {
             ctx->authIn = tmp;
             XMEMCPY(ctx->authIn + ctx->authInSz, in, (size_t)inl);
@@ -843,9 +875,19 @@ static int wolfSSL_EVP_CipherUpdate_CCM(WOLFSSL_EVP_CIPHER_CTX *ctx,
         /* Buffer input for one-shot API */
         if (inl > 0) {
             byte* tmp;
+        #ifdef WOLFSSL_NO_REALLOC
+            tmp = (byte*)XMALLOC((size_t)(ctx->authBufferLen + inl), NULL,
+                    DYNAMIC_TYPE_OPENSSL);
+            if (tmp != NULL) {
+                XMEMCPY(tmp, ctx->authBuffer, (size_t)ctx->authBufferLen);
+                XFREE(ctx->authBuffer, NULL, DYNAMIC_TYPE_OPENSSL);
+                ctx->authBuffer = NULL;
+            }
+        #else
             tmp = (byte*)XREALLOC(ctx->authBuffer,
                     (size_t)(ctx->authBufferLen + inl), NULL,
                     DYNAMIC_TYPE_OPENSSL);
+        #endif
             if (tmp) {
                 XMEMCPY(tmp + ctx->authBufferLen, in, (size_t)inl);
                 ctx->authBufferLen += inl;
@@ -875,8 +917,19 @@ static int wolfSSL_EVP_CipherUpdate_AriaGCM_AAD(WOLFSSL_EVP_CIPHER_CTX *ctx,
         const unsigned char *in, int inl)
 {
     if (in && inl > 0) {
-        byte* tmp = (byte*)XREALLOC(ctx->authIn,
+        byte* tmp;
+    #ifdef WOLFSSL_NO_REALLOC
+        tmp = (byte*)XMALLOC((size_t)ctx->authInSz + inl, NULL,
+                DYNAMIC_TYPE_OPENSSL);
+        if (tmp != NULL) {
+            XMEMCPY(tmp, ctx->authIn, (size_t)ctx->authInSz);
+            XFREE(ctx->authIn, NULL, DYNAMIC_TYPE_OPENSSL);
+            ctx->authIn = NULL;
+        }
+    #else
+        tmp = (byte*)XREALLOC(ctx->authIn,
                 (size_t)ctx->authInSz + inl, NULL, DYNAMIC_TYPE_OPENSSL);
+    #endif
         if (tmp) {
             ctx->authIn = tmp;
             XMEMCPY(ctx->authIn + ctx->authInSz, in, (size_t)inl);
@@ -905,9 +958,18 @@ static int wolfSSL_EVP_CipherUpdate_AriaGCM(WOLFSSL_EVP_CIPHER_CTX *ctx,
             if (ctx->enc == 0) { /* Append extra space for the tag */
                 size = WC_ARIA_GCM_GET_CIPHERTEXT_SIZE(size);
             }
-            tmp = (byte*)XREALLOC(ctx->authBuffer,
-                    (size_t)size, NULL,
-                    DYNAMIC_TYPE_OPENSSL);
+        #ifdef WOLFSSL_NO_REALLOC
+            tmp = (byte*)XMALLOC((size_t)size, NULL,
+                DYNAMIC_TYPE_OPENSSL);
+            if (tmp != NULL) {
+                XMEMCPY(tmp, ctx->authBuffer, (size_t)ctx->authBufferLen);
+                XFREE(ctx->authBuffer, NULL, DYNAMIC_TYPE_OPENSSL);
+                ctx->authBuffer = NULL;
+            }
+        #else
+            tmp = (byte*)XREALLOC(ctx->authBuffer, (size_t)size, NULL,
+                DYNAMIC_TYPE_OPENSSL);
+        #endif
             if (tmp) {
                 XMEMCPY(tmp + ctx->authBufferLen, in, (size_t)inl);
                 ctx->authBufferLen += inl;
@@ -2693,9 +2755,19 @@ int wolfSSL_EVP_PKEY_CTX_add1_hkdf_info(WOLFSSL_EVP_PKEY_CTX* ctx,
     if (ret == WOLFSSL_SUCCESS && info != NULL && infoSz > 0) {
         unsigned char* p;
         /* If there's already info in the buffer, append. */
+    #ifdef WOLFSSL_NO_REALLOC
+        p = (byte*)XMALLOC((size_t)(ctx->pkey->hkdfInfoSz + (word32)infoSz), NULL,
+            DYNAMIC_TYPE_INFO);
+        if (p != NULL) {
+            XMEMCPY(p, ctx->pkey->hkdfInfo, (size_t)ctx->pkey->hkdfInfoSz);
+            XFREE(ctx->pkey->hkdfInfo, NULL, DYNAMIC_TYPE_INFO);
+            ctx->pkey->hkdfInfo = NULL;
+        }
+    #else
         p = (byte*)XREALLOC(ctx->pkey->hkdfInfo,
             (size_t)(ctx->pkey->hkdfInfoSz + (word32)infoSz), NULL,
             DYNAMIC_TYPE_INFO);
+    #endif
         if (p == NULL) {
             WOLFSSL_MSG("Failed to reallocate larger HKDF info buffer.");
             ret = WOLFSSL_FAILURE;
@@ -3211,6 +3283,8 @@ int wolfSSL_EVP_PKEY_bits(const WOLFSSL_EVP_PKEY *pkey)
     if (pkey == NULL) return 0;
     WOLFSSL_ENTER("wolfSSL_EVP_PKEY_bits");
     if ((bytes = wolfSSL_EVP_PKEY_size((WOLFSSL_EVP_PKEY*)pkey)) ==0) return 0;
+    if (bytes < 0)
+        return 0;
     return bytes*8;
 }
 
@@ -4275,23 +4349,39 @@ static int wolfssl_evp_digest_pk_final(WOLFSSL_EVP_MD_CTX *ctx,
     int  ret;
 
     if (ctx->isHMAC) {
-        Hmac hmacCopy;
-
-        if (wolfSSL_HmacCopy(&hmacCopy, &ctx->hash.hmac) != WOLFSSL_SUCCESS)
+#ifdef WOLFSSL_SMALL_STACK
+        Hmac *hmacCopy = (Hmac *)XMALLOC(sizeof(Hmac), NULL, DYNAMIC_TYPE_OPENSSL);
+        if (hmacCopy == NULL)
             return WOLFSSL_FAILURE;
-        ret = wc_HmacFinal(&hmacCopy, md) == 0;
-        wc_HmacFree(&hmacCopy);
+#else
+        Hmac hmacCopy[1];
+#endif
+        ret = wolfSSL_HmacCopy(hmacCopy, &ctx->hash.hmac);
+        if (ret == WOLFSSL_SUCCESS)
+            ret = wc_HmacFinal(hmacCopy, md) == 0;
+        wc_HmacFree(hmacCopy);
+#ifdef WOLFSSL_SMALL_STACK
+        XFREE(hmacCopy, NULL, DYNAMIC_TYPE_OPENSSL);
+#endif
         return ret;
     }
     else {
-        WOLFSSL_EVP_MD_CTX ctxCopy;
-        wolfSSL_EVP_MD_CTX_init(&ctxCopy);
-
-        if (wolfSSL_EVP_MD_CTX_copy_ex(&ctxCopy, ctx) != WOLFSSL_SUCCESS)
+#ifdef WOLFSSL_SMALL_STACK
+        WOLFSSL_EVP_MD_CTX *ctxCopy = (WOLFSSL_EVP_MD_CTX *)XMALLOC(sizeof(WOLFSSL_EVP_MD_CTX), NULL, DYNAMIC_TYPE_OPENSSL);
+        if (ctxCopy == NULL)
             return WOLFSSL_FAILURE;
+#else
+        WOLFSSL_EVP_MD_CTX ctxCopy[1];
+#endif
+        wolfSSL_EVP_MD_CTX_init(ctxCopy);
 
-        ret = wolfSSL_EVP_DigestFinal(&ctxCopy, md, mdlen);
-        wolfSSL_EVP_MD_CTX_cleanup(&ctxCopy);
+        ret = wolfSSL_EVP_MD_CTX_copy_ex(ctxCopy, ctx);
+        if (ret == WOLFSSL_SUCCESS)
+            ret = wolfSSL_EVP_DigestFinal(ctxCopy, md, mdlen);
+        wolfSSL_EVP_MD_CTX_cleanup(ctxCopy);
+#ifdef WOLFSSL_SMALL_STACK
+        XFREE(ctxCopy, NULL, DYNAMIC_TYPE_OPENSSL);
+#endif
         return ret;
     }
 }
@@ -5468,7 +5558,7 @@ void wolfSSL_EVP_init(void)
     #endif /* HAVE_AES_CBC */
 
     #ifdef WOLFSSL_AES_CFB
-#if !defined(HAVE_SELFTEST) && !defined(HAVE_FIPS)
+#if !defined(HAVE_SELFTEST) && (!defined(HAVE_FIPS) || FIPS_VERSION3_GE(6,0,0))
     #ifdef WOLFSSL_AES_128
     const WOLFSSL_EVP_CIPHER* wolfSSL_EVP_aes_128_cfb1(void)
     {
@@ -8465,7 +8555,7 @@ void wolfSSL_EVP_init(void)
         }
 
         if (ret < 0) {
-            if (ret == AES_GCM_AUTH_E) {
+            if (ret == WC_NO_ERR_TRACE(AES_GCM_AUTH_E)) {
                 WOLFSSL_MSG("wolfSSL_EVP_Cipher failure: bad AES-GCM tag.");
             }
             WOLFSSL_MSG("wolfSSL_EVP_Cipher failure");
@@ -8543,7 +8633,7 @@ static int PopulateRSAEvpPkeyDer(WOLFSSL_EVP_PKEY *pkey)
             if (key->pkcs8HeaderSz) {
                 ret = wc_CreatePKCS8Key(NULL, &pkcs8Sz, NULL, (word32)derSz,
                     RSAk, NULL, 0);
-                if (ret == LENGTH_ONLY_E)
+                if (ret == WC_NO_ERR_TRACE(LENGTH_ONLY_E))
                     ret = 0;
             }
         #endif
@@ -8917,7 +9007,7 @@ int wolfSSL_EVP_PKEY_set1_DH(WOLFSSL_EVP_PKEY *pkey, WOLFSSL_DH *key)
         ret = wc_DhParamsToDer(dhkey,NULL,&derSz);
     }
 
-    if (derSz == 0 || ret != LENGTH_ONLY_E) {
+    if (derSz == 0 || ret != WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
        WOLFSSL_MSG("Failed to get size of DH Key");
        return WOLFSSL_FAILURE;
     }
@@ -9060,7 +9150,7 @@ static int ECC_populate_EVP_PKEY(EVP_PKEY* pkey, WOLFSSL_EC_KEY *key)
 #ifdef HAVE_PKCS8
         if (key->pkcs8HeaderSz) {
             /* when key has pkcs8 header the pkey should too */
-            if (wc_EccKeyToPKCS8(ecc, NULL, (word32*)&derSz) == LENGTH_ONLY_E) {
+            if (wc_EccKeyToPKCS8(ecc, NULL, (word32*)&derSz) == WC_NO_ERR_TRACE(LENGTH_ONLY_E)) {
                 derBuf = (byte*)XMALLOC((size_t)derSz, pkey->heap,
                     DYNAMIC_TYPE_OPENSSL);
                 if (derBuf) {
@@ -9112,8 +9202,17 @@ static int ECC_populate_EVP_PKEY(EVP_PKEY* pkey, WOLFSSL_EC_KEY *key)
     }
     else if (ecc->type == ECC_PUBLICKEY) {
         if ((derSz = wc_EccPublicKeyDerSize(ecc, 1)) > 0) {
-            derBuf = (byte*)XREALLOC(pkey->pkey.ptr, (size_t)derSz, NULL,
+        #ifdef WOLFSSL_NO_REALLOC
+            derBuf = (byte*)XMALLOC((size_t)derSz, pkey->heap, DYNAMIC_TYPE_OPENSSL);
+            if (derBuf != NULL) {
+                XMEMCPY(derBuf, pkey->pkey.ptr, (size_t)pkey->pkey_sz);
+                XFREE(pkey->pkey.ptr, pkey->heap, DYNAMIC_TYPE_OPENSSL);
+                pkey->pkey.ptr = NULL;
+            }
+        #else
+            derBuf = (byte*)XREALLOC(pkey->pkey.ptr, (size_t)derSz, pkey->heap,
                     DYNAMIC_TYPE_OPENSSL);
+        #endif
             if (derBuf != NULL) {
                 pkey->pkey.ptr = (char*)derBuf;
                 if ((derSz = wc_EccPublicKeyToDer(ecc, derBuf, (word32)derSz,
@@ -9205,7 +9304,7 @@ const WOLFSSL_EVP_MD* wolfSSL_EVP_ripemd160(void)
 
 int wolfSSL_EVP_MD_pkey_type(const WOLFSSL_EVP_MD* type)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     WOLFSSL_ENTER("wolfSSL_EVP_MD_pkey_type");
 
@@ -9228,6 +9327,9 @@ int wolfSSL_EVP_MD_pkey_type(const WOLFSSL_EVP_MD* type)
         else if (XSTRCMP(type, "SHA512") == 0) {
             ret = NID_sha512WithRSAEncryption;
         }
+    }
+    else {
+        ret = BAD_FUNC_ARG;
     }
 
     WOLFSSL_LEAVE("wolfSSL_EVP_MD_pkey_type", ret);
@@ -12432,7 +12534,7 @@ int  wolfSSL_EVP_DecodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
             (word32)(BASE64_DECODE_BLOCK_SIZE - ctx->remaining), (word32)inl);
 
         for ( i = 0; cpySz > 0 && inLen > 0; i++) {
-            if (Base64_SkipNewline(in, &inLen, &j) == ASN_INPUT_E) {
+            if (Base64_SkipNewline(in, &inLen, &j) == WC_NO_ERR_TRACE(ASN_INPUT_E)) {
                 return -1;  /* detected an illegal char in input */
             }
             c = in[j++];
@@ -12472,7 +12574,7 @@ int  wolfSSL_EVP_DecodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
      */
     while (inLen > 3) {
         if ((res = Base64_SkipNewline(in, &inLen, &j)) != 0) {
-            if (res == BUFFER_E) {
+            if (res == WC_NO_ERR_TRACE(BUFFER_E)) {
                 break;
             }
             else {
@@ -12486,7 +12588,7 @@ int  wolfSSL_EVP_DecodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
         }
         inLen--;
         if ((res = Base64_SkipNewline(in, &inLen, &j)) != 0) {
-            if (res == BUFFER_E) {
+            if (res == WC_NO_ERR_TRACE(BUFFER_E)) {
                 break;
             }
             else {
@@ -12497,7 +12599,7 @@ int  wolfSSL_EVP_DecodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
         e[1] = in[j++];
         inLen--;
         if ((res = Base64_SkipNewline(in, &inLen, &j)) != 0) {
-            if (res == BUFFER_E) {
+            if (res == WC_NO_ERR_TRACE(BUFFER_E)) {
                 break;
             }
             else {
@@ -12508,7 +12610,7 @@ int  wolfSSL_EVP_DecodeUpdate(WOLFSSL_EVP_ENCODE_CTX* ctx,
         e[2] = in[j++];
         inLen--;
         if ((res = Base64_SkipNewline(in, &inLen, &j)) != 0) {
-            if (res == BUFFER_E) {
+            if (res == WC_NO_ERR_TRACE(BUFFER_E)) {
                 break;
             }
             else {
@@ -12615,8 +12717,10 @@ int  wolfSSL_EVP_DecodeFinal(WOLFSSL_EVP_ENCODE_CTX* ctx,
         inLen = (word32)ctx->remaining;
         if ((res = Base64_SkipNewline(ctx->data, &inLen, &j)) != 0) {
             *outl = 0;
-            if (res == BUFFER_E) /* means no valid data to decode in buffer */
+            if (res == WC_NO_ERR_TRACE(BUFFER_E)) {
+                /* means no valid data to decode in buffer */
                 return  1; /* returns as success with no output */
+            }
             else
                 return -1;
         }

--- a/libatalk/ssl/wolfcrypt/src/hash.c
+++ b/libatalk/ssl/wolfcrypt/src/hash.c
@@ -145,7 +145,7 @@ enum wc_HashType wc_HashTypeConvert(int hashType)
 
 int wc_HashGetOID(enum wc_HashType hash_type)
 {
-    int oid = HASH_TYPE_E; /* Default to hash type error */
+    int oid = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
     switch(hash_type)
     {
         case WC_HASH_TYPE_MD2:
@@ -317,7 +317,7 @@ enum wc_HashType wc_OidGetHash(int oid)
 /* Get Hash digest size */
 int wc_HashGetDigestSize(enum wc_HashType hash_type)
 {
-    int dig_size = HASH_TYPE_E; /* Default to hash type error */
+    int dig_size = WC_NO_ERR_TRACE(HASH_TYPE_E);
     switch(hash_type)
     {
         case WC_HASH_TYPE_MD2:
@@ -436,7 +436,7 @@ int wc_HashGetDigestSize(enum wc_HashType hash_type)
 /* Get Hash block size */
 int wc_HashGetBlockSize(enum wc_HashType hash_type)
 {
-    int block_size = HASH_TYPE_E; /* Default to hash type error */
+    int block_size = WC_NO_ERR_TRACE(HASH_TYPE_E);
     switch (hash_type)
     {
         case WC_HASH_TYPE_MD2:
@@ -555,7 +555,7 @@ int wc_HashGetBlockSize(enum wc_HashType hash_type)
 int wc_Hash_ex(enum wc_HashType hash_type, const byte* data,
     word32 data_len, byte* hash, word32 hash_len, void* heap, int devId)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
     int dig_size;
 
     /* Validate hash buffer size */
@@ -689,7 +689,7 @@ int wc_Hash(enum wc_HashType hash_type, const byte* data,
 int wc_HashInit_ex(wc_HashAlg* hash, enum wc_HashType type, void* heap,
     int devId)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
 
     if (hash == NULL)
         return BAD_FUNC_ARG;
@@ -801,7 +801,7 @@ int wc_HashInit(wc_HashAlg* hash, enum wc_HashType type)
 int wc_HashUpdate(wc_HashAlg* hash, enum wc_HashType type, const byte* data,
                   word32 dataSz)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
 
     if (hash == NULL || (data == NULL && dataSz > 0))
         return BAD_FUNC_ARG;
@@ -904,7 +904,7 @@ int wc_HashUpdate(wc_HashAlg* hash, enum wc_HashType type, const byte* data,
 
 int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type, byte* out)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
 
     if (hash == NULL || out == NULL)
         return BAD_FUNC_ARG;
@@ -1007,7 +1007,7 @@ int wc_HashFinal(wc_HashAlg* hash, enum wc_HashType type, byte* out)
 
 int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
 
     if (hash == NULL)
         return BAD_FUNC_ARG;
@@ -1124,7 +1124,7 @@ int wc_HashFree(wc_HashAlg* hash, enum wc_HashType type)
 #ifdef WOLFSSL_HASH_FLAGS
 int wc_HashSetFlags(wc_HashAlg* hash, enum wc_HashType type, word32 flags)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
 
     if (hash == NULL)
         return BAD_FUNC_ARG;
@@ -1203,7 +1203,7 @@ int wc_HashSetFlags(wc_HashAlg* hash, enum wc_HashType type, word32 flags)
 }
 int wc_HashGetFlags(wc_HashAlg* hash, enum wc_HashType type, word32* flags)
 {
-    int ret = HASH_TYPE_E; /* Default to hash type error */
+    int ret = WC_NO_ERR_TRACE(HASH_TYPE_E); /* Default to hash type error */
 
     if (hash == NULL)
         return BAD_FUNC_ARG;

--- a/libatalk/ssl/wolfcrypt/src/hmac.c
+++ b/libatalk/ssl/wolfcrypt/src/hmac.c
@@ -30,15 +30,13 @@
 
 #ifndef NO_HMAC
 
-#if defined(HAVE_FIPS) && \
-    defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
-
+#if FIPS_VERSION3_GE(2,0,0)
     /* set NO_WRAPPERS before headers, use direct internal f()s not wrappers */
     #define FIPS_NO_WRAPPERS
 
     #ifdef USE_WINDOWS_API
-        #pragma code_seg(".fipsA$b")
-        #pragma const_seg(".fipsB$b")
+        #pragma code_seg(".fipsA$g")
+        #pragma const_seg(".fipsB$g")
     #endif
 #endif
 
@@ -64,6 +62,14 @@
     #define wc_HmacFinal   wc_HmacFinal_Software
 #endif
 
+#if FIPS_VERSION3_GE(6,0,0)
+    const unsigned int wolfCrypt_FIPS_hmac_ro_sanity[2] =
+                                                     { 0x1a2b3c4d, 0x00000008 };
+    int wolfCrypt_FIPS_HMAC_sanity(void)
+    {
+        return 0;
+    }
+#endif
 
 int wc_HmacSizeByType(int type)
 {
@@ -237,7 +243,8 @@ int _InitHmac(Hmac* hmac, int type, void* heap)
 }
 
 
-int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
+int wc_HmacSetKey_ex(Hmac* hmac, int type, const byte* key, word32 length,
+                     int allowFlag)
 {
 #ifndef WOLFSSL_MAXQ108X
     byte*  ip;
@@ -259,7 +266,7 @@ int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
         return BAD_FUNC_ARG;
     }
 
-#ifndef HAVE_FIPS
+#if !defined(HAVE_FIPS) || FIPS_VERSION3_GE(6,0,0)
     /* if set key has already been run then make sure and free existing */
     /* This is for async and PIC32MZ situations, and just normally OK,
        provided the user calls wc_HmacInit() first. That function is not
@@ -277,12 +284,40 @@ int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
     if (ret != 0)
         return ret;
 
-#ifdef HAVE_FIPS
-    if (length < HMAC_FIPS_MIN_KEY) {
-        WOLFSSL_ERROR_VERBOSE(HMAC_MIN_KEYLEN_E);
-        return HMAC_MIN_KEYLEN_E;
+    /* Regarding the password length:
+     * SP800-107r1 ss 5.3.2 states: "An HMAC key shall have a security strength
+     * that meets or exceeds the security strength required to protect the data
+     * over which the HMAC is computed" then refers to SP800-133 for HMAC keys
+     * generation.
+     *
+     * SP800-133r2 ss 6.2.3 states: "When a key is generated from a password,
+     * the entropy provided (and thus, the maximum security strength that can be
+     * supported by the generated key) shall be considered to be zero unless the
+     * password is generated using an approved RBG"
+     *
+     * wolfSSL Notes: The statement from SP800-133r2 applies to
+     * all password lengths. Any human generated password is considered to have
+     * 0 security strength regardless of length, there is no minimum length that
+     * is OK or will provide any amount of security strength other than 0. If
+     * a security strength is required users shall generate random passwords
+     * using a FIPS approved RBG of sufficient length that any HMAC key
+     * generated from that password can claim to inherit the needed security
+     * strength from that input.
+     */
+
+    /* In light of the above, Loosen past restriction that limited passwords to
+     * no less than 14-bytes to allow for shorter Passwords.
+     * User needs to pass true (non-zero) to override historical behavior that
+     * prevented use of any password less than 14-bytes. ALL non-RBG generated
+     * passwords shall inherit a security strength of zero
+     * (no security strength)
+     */
+    if (!allowFlag) {
+        if (length < HMAC_FIPS_MIN_KEY) {
+            WOLFSSL_ERROR_VERBOSE(HMAC_MIN_KEYLEN_E);
+            return HMAC_MIN_KEYLEN_E;
+        }
     }
-#endif
 
 #ifdef WOLF_CRYPTO_CB
     hmac->keyRaw = key; /* use buffer directly */
@@ -564,6 +599,16 @@ int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
 #endif /* WOLFSSL_MAXQ108X */
 }
 
+int wc_HmacSetKey(Hmac* hmac, int type, const byte* key, word32 length)
+{
+    int allowFlag;
+    #if defined(HAVE_FIPS)
+        allowFlag = 0; /* default false for FIPS cases */
+    #else
+        allowFlag = 1; /* default true for all non-FIPS cases */
+    #endif
+    return wc_HmacSetKey_ex(hmac, type, key, length, allowFlag);
+}
 
 static int HmacKeyInnerHash(Hmac* hmac)
 {
@@ -666,7 +711,7 @@ int wc_HmacUpdate(Hmac* hmac, const byte* msg, word32 length)
 #ifdef WOLF_CRYPTO_CB
     if (hmac->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_Hmac(hmac, hmac->macType, msg, length, NULL);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
         ret = 0; /* reset error code */
@@ -775,7 +820,7 @@ int wc_HmacFinal(Hmac* hmac, byte* hash)
 #ifdef WOLF_CRYPTO_CB
     if (hmac->devId != INVALID_DEVID) {
         ret = wc_CryptoCb_Hmac(hmac, hmac->macType, NULL, 0, hash);
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable */
     }
@@ -1230,7 +1275,12 @@ int wolfSSL_GetHmacMaxSize(void)
 
         ret = wc_HmacInit(myHmac, heap, devId);
         if (ret == 0) {
+        #if FIPS_VERSION3_GE(6,0,0)
+            ret = wc_HmacSetKey_ex(myHmac, type, localSalt, saltSz,
+                                   FIPS_ALLOW_SHORT);
+        #else
             ret = wc_HmacSetKey(myHmac, type, localSalt, saltSz);
+        #endif
             if (ret == 0)
                 ret = wc_HmacUpdate(myHmac, inKey, inKeySz);
             if (ret == 0)
@@ -1311,7 +1361,12 @@ int wolfSSL_GetHmacMaxSize(void)
             word32 tmpSz = (n == 1) ? 0 : hashSz;
             word32 left = outSz - outIdx;
 
+        #if FIPS_VERSION3_GE(6,0,0)
+            ret = wc_HmacSetKey_ex(myHmac, type, inKey, inKeySz,
+                                   FIPS_ALLOW_SHORT);
+        #else
             ret = wc_HmacSetKey(myHmac, type, inKey, inKeySz);
+        #endif
             if (ret != 0)
                 break;
             ret = wc_HmacUpdate(myHmac, tmp, tmpSz);

--- a/libatalk/ssl/wolfcrypt/src/kdf.c
+++ b/libatalk/ssl/wolfcrypt/src/kdf.c
@@ -30,15 +30,13 @@
 
 #ifndef NO_KDF
 
-#if defined(HAVE_FIPS) && \
-    defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 5)
-
+#if FIPS_VERSION3_GE(5,0,0)
     /* set NO_WRAPPERS before headers, use direct internal f()s not wrappers */
     #define FIPS_NO_WRAPPERS
 
     #ifdef USE_WINDOWS_API
-        #pragma code_seg(".fipsA$m")
-        #pragma const_seg(".fipsB$m")
+        #pragma code_seg(".fipsA$h")
+        #pragma const_seg(".fipsB$h")
     #endif
 #endif
 
@@ -56,6 +54,14 @@
 #include <wolfssl/wolfcrypt/aes.h>
 #endif
 
+#if FIPS_VERSION3_GE(6,0,0)
+    const unsigned int wolfCrypt_FIPS_kdf_ro_sanity[2] =
+                                                     { 0x1a2b3c4d, 0x00000009 };
+    int wolfCrypt_FIPS_KDF_sanity(void)
+    {
+        return 0;
+    }
+#endif
 
 #if defined(WOLFSSL_HAVE_PRF) && !defined(NO_HMAC)
 
@@ -300,6 +306,16 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
 {
     int ret = 0;
 
+#ifdef WOLFSSL_DEBUG_TLS
+    WOLFSSL_MSG("  secret");
+    WOLFSSL_BUFFER(secret, secLen);
+    WOLFSSL_MSG("  label");
+    WOLFSSL_BUFFER(label, labLen);
+    WOLFSSL_MSG("  seed");
+    WOLFSSL_BUFFER(seed, seedLen);
+#endif
+
+
     if (useAtLeastSha256) {
     #ifdef WOLFSSL_SMALL_STACK
         byte* labelSeed;
@@ -343,6 +359,12 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
         ret = BAD_FUNC_ARG;
 #endif
     }
+
+#ifdef WOLFSSL_DEBUG_TLS
+    WOLFSSL_MSG("  digest");
+    WOLFSSL_BUFFER(digest, digLen);
+    WOLFSSL_MSG_EX("hash_type %d", hash_type);
+#endif
 
     return ret;
 }
@@ -542,14 +564,14 @@ int wc_PRF_TLS(byte* digest, word32 digLen, const byte* secret, word32 secLen,
         const byte* info, word32 infoLen, int digest, void* heap)
     {
         int    ret = 0;
-        int    idx = 0;
-        int    len;
+        word32 idx = 0;
+        size_t len;
         byte   *data;
 
         (void)heap;
         /* okmLen (2) + protocol|label len (1) + info len(1) + protocollen +
          * labellen + infolen */
-        len = 4 + protocolLen + labelLen + infoLen;
+        len = 4U + protocolLen + labelLen + infoLen;
 
         data = (byte*)XMALLOC(len, heap, DYNAMIC_TYPE_TMP_BUFFER);
         if (data == NULL)
@@ -637,7 +659,7 @@ typedef union {
 static
 int _HashInit(byte hashId, _hash* hash)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (hashId) {
     #ifndef NO_SHA
@@ -662,6 +684,9 @@ int _HashInit(byte hashId, _hash* hash)
             ret = wc_InitSha512(&hash->sha512);
             break;
     #endif /* WOLFSSL_SHA512 */
+        default:
+            ret = BAD_FUNC_ARG;
+            break;
     }
 
     return ret;
@@ -671,7 +696,7 @@ static
 int _HashUpdate(byte hashId, _hash* hash,
         const byte* data, word32 dataSz)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (hashId) {
     #ifndef NO_SHA
@@ -696,6 +721,9 @@ int _HashUpdate(byte hashId, _hash* hash,
             ret = wc_Sha512Update(&hash->sha512, data, dataSz);
             break;
     #endif /* WOLFSSL_SHA512 */
+        default:
+            ret = BAD_FUNC_ARG;
+            break;
     }
 
     return ret;
@@ -704,7 +732,7 @@ int _HashUpdate(byte hashId, _hash* hash,
 static
 int _HashFinal(byte hashId, _hash* hash, byte* digest)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     switch (hashId) {
     #ifndef NO_SHA
@@ -729,6 +757,9 @@ int _HashFinal(byte hashId, _hash* hash, byte* digest)
             ret = wc_Sha512Final(&hash->sha512, digest);
             break;
     #endif /* WOLFSSL_SHA512 */
+        default:
+            ret = BAD_FUNC_ARG;
+            break;
     }
 
     return ret;
@@ -936,7 +967,7 @@ static void wc_srtp_kdf_first_block(const byte* salt, word32 saltSz, int kdrIdx,
  * @param [in]      aes      AES object to encrypt with.
  * @return  0 on success.
  */
-static int wc_srtp_kdf_derive_key(byte* block, byte indexSz, byte label,
+static int wc_srtp_kdf_derive_key(byte* block, int indexSz, byte label,
         byte* key, word32 keySz, Aes* aes)
 {
     int i;
@@ -1093,9 +1124,9 @@ int wc_SRTP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
  * @return  MEMORY_E on dynamic memory allocation failure.
  * @return  0 on success.
  */
-int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
+int wc_SRTCP_KDF_ex(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
         int kdrIdx, const byte* index, byte* key1, word32 key1Sz, byte* key2,
-        word32 key2Sz, byte* key3, word32 key3Sz)
+        word32 key2Sz, byte* key3, word32 key3Sz, int idxLenIndicator)
 {
     int ret = 0;
     byte block[AES_BLOCK_SIZE];
@@ -1105,6 +1136,15 @@ int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
     Aes aes[1];
 #endif
     int aes_inited = 0;
+    int idxLen;
+
+    if (idxLenIndicator == WC_SRTCP_32BIT_IDX) {
+        idxLen = WC_SRTCP_INDEX_LEN;
+    } else if (idxLenIndicator == WC_SRTCP_48BIT_IDX) {
+        idxLen = WC_SRTP_INDEX_LEN;
+    } else {
+        return BAD_FUNC_ARG; /* bad or invalid idxLenIndicator */
+    }
 
     /* Validate parameters. */
     if ((key == NULL) || (keySz > AES_256_KEY_SIZE) || (salt == NULL) ||
@@ -1136,23 +1176,22 @@ int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
 
     /* Calculate first block that can be used in each derivation. */
     if (ret == 0) {
-        wc_srtp_kdf_first_block(salt, saltSz, kdrIdx, index, WC_SRTCP_INDEX_LEN,
-            block);
+        wc_srtp_kdf_first_block(salt, saltSz, kdrIdx, index, idxLen, block);
     }
 
     /* Calculate first key if required. */
     if ((ret == 0) && (key1 != NULL)) {
-        ret = wc_srtp_kdf_derive_key(block, WC_SRTCP_INDEX_LEN,
+        ret = wc_srtp_kdf_derive_key(block, idxLen,
             WC_SRTCP_LABEL_ENCRYPTION, key1, key1Sz, aes);
     }
     /* Calculate second key if required. */
     if ((ret == 0) && (key2 != NULL)) {
-        ret = wc_srtp_kdf_derive_key(block, WC_SRTCP_INDEX_LEN,
+        ret = wc_srtp_kdf_derive_key(block, idxLen,
             WC_SRTCP_LABEL_MSG_AUTH, key2, key2Sz, aes);
     }
     /* Calculate third key if required. */
     if ((ret == 0) && (key3 != NULL)) {
-        ret = wc_srtp_kdf_derive_key(block, WC_SRTCP_INDEX_LEN,
+        ret = wc_srtp_kdf_derive_key(block, idxLen,
             WC_SRTCP_LABEL_SALT, key3, key3Sz, aes);
     }
 
@@ -1164,6 +1203,15 @@ int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
     return ret;
 }
 
+int wc_SRTCP_KDF(const byte* key, word32 keySz, const byte* salt, word32 saltSz,
+        int kdrIdx, const byte* index, byte* key1, word32 key1Sz, byte* key2,
+        word32 key2Sz, byte* key3, word32 key3Sz)
+{
+    /* The default 32-bit IDX expected by many implementations */
+    return wc_SRTCP_KDF_ex(key, keySz, salt, saltSz, kdrIdx, index,
+                           key1, key1Sz, key2, key2Sz, key3, key3Sz,
+                           WC_SRTCP_32BIT_IDX);
+}
 /* Derive key with label using SRTP KDF algorithm.
  *
  * SP 800-135 (RFC 3711).
@@ -1349,5 +1397,105 @@ int wc_SRTP_KDF_kdr_to_idx(word32 kdr)
     return idx;
 }
 #endif /* WC_SRTP_KDF */
+
+#ifdef WC_KDF_NIST_SP_800_56C
+static int wc_KDA_KDF_iteration(const byte* z, word32 zSz, word32 counter,
+    const byte* fixedInfo, word32 fixedInfoSz, enum wc_HashType hashType,
+    byte* output)
+{
+    byte counterBuf[4];
+    wc_HashAlg hash;
+    int ret;
+
+    ret = wc_HashInit(&hash, hashType);
+    if (ret != 0)
+        return ret;
+    c32toa(counter, counterBuf);
+    ret = wc_HashUpdate(&hash, hashType, counterBuf, 4);
+    if (ret == 0) {
+        ret = wc_HashUpdate(&hash, hashType, z, zSz);
+    }
+    if (ret == 0 && fixedInfoSz > 0) {
+        ret = wc_HashUpdate(&hash, hashType, fixedInfo, fixedInfoSz);
+    }
+    if (ret == 0) {
+        ret = wc_HashFinal(&hash, hashType, output);
+    }
+    wc_HashFree(&hash, hashType);
+    return ret;
+}
+
+/**
+ * \brief Performs the single-step key derivation function (KDF) as specified in
+ * SP800-56C option 1.
+ *
+ * \param [in] z The input keying material.
+ * \param [in] zSz The size of the input keying material.
+ * \param [in] fixedInfo The fixed information to be included in the KDF.
+ * \param [in] fixedInfoSz The size of the fixed information.
+ * \param [in] derivedSecretSz The desired size of the derived secret.
+ * \param [in] hashType The hash algorithm to be used in the KDF.
+ * \param [out] output The buffer to store the derived secret.
+ * \param [in] outputSz The size of the output buffer.
+ *
+ * \return 0 if the KDF operation is successful.
+ * \return BAD_FUNC_ARG if the input parameters are invalid.
+ * \return negative error code if the KDF operation fails.
+ */
+int wc_KDA_KDF_onestep(const byte* z, word32 zSz, const byte* fixedInfo,
+    word32 fixedInfoSz, word32 derivedSecretSz, enum wc_HashType hashType,
+    byte* output, word32 outputSz)
+{
+    byte hashTempBuf[WC_MAX_DIGEST_SIZE];
+    word32 counter, outIdx;
+    int hashOutSz;
+    int ret;
+
+    if (output == NULL || outputSz < derivedSecretSz)
+        return BAD_FUNC_ARG;
+    if (z == NULL || zSz == 0 || (fixedInfoSz > 0 && fixedInfo == NULL))
+        return BAD_FUNC_ARG;
+    if (derivedSecretSz == 0)
+        return BAD_FUNC_ARG;
+
+    hashOutSz = wc_HashGetDigestSize(hashType);
+    if (hashOutSz == WC_NO_ERR_TRACE(HASH_TYPE_E))
+        return BAD_FUNC_ARG;
+
+    /* According to SP800_56C, table 1, the max input size (max_H_inputBits)
+     * depends on the HASH algo. The smaller value in the table is (2**64-1)/8.
+     * This is larger than the possible length using word32 integers. */
+
+    counter = 1;
+    outIdx = 0;
+    ret = 0;
+
+    /* According to SP800_56C the number of iterations shall not be greater than
+     * 2**32-1. This is not possible using word32 integers.*/
+    while (outIdx + hashOutSz <= derivedSecretSz) {
+        ret = wc_KDA_KDF_iteration(z, zSz, counter, fixedInfo, fixedInfoSz,
+            hashType, output + outIdx);
+        if (ret != 0)
+            break;
+        counter++;
+        outIdx += hashOutSz;
+    }
+
+    if (ret == 0 && outIdx < derivedSecretSz) {
+        ret = wc_KDA_KDF_iteration(z, zSz, counter, fixedInfo, fixedInfoSz,
+            hashType, hashTempBuf);
+        if (ret == 0) {
+            XMEMCPY(output + outIdx, hashTempBuf, derivedSecretSz - outIdx);
+        }
+        ForceZero(hashTempBuf, hashOutSz);
+    }
+
+    if (ret != 0) {
+        ForceZero(output, derivedSecretSz);
+    }
+
+    return ret;
+}
+#endif /* WC_KDF_NIST_SP_800_56C */
 
 #endif /* NO_KDF */

--- a/libatalk/ssl/wolfcrypt/src/logging.c
+++ b/libatalk/ssl/wolfcrypt/src/logging.c
@@ -126,7 +126,10 @@ THREAD_LS_T void *StackSizeCheck_stackOffsetPointer = 0;
 
 /* Set these to default values initially. */
 static wolfSSL_Logging_cb log_function = NULL;
-static int loggingEnabled = 0;
+#ifndef WOLFSSL_LOGGINGENABLED_DEFAULT
+#define WOLFSSL_LOGGINGENABLED_DEFAULT 0
+#endif
+static int loggingEnabled = WOLFSSL_LOGGINGENABLED_DEFAULT;
 THREAD_LS_T const char* log_prefix = NULL;
 
 #if defined(WOLFSSL_APACHE_MYNEWT)
@@ -276,8 +279,11 @@ void WOLFSSL_TIME(int count)
 #include <wolfssl/wolfcrypt/mem_track.h>
 #endif
 
-static void wolfssl_log(const int logLevel, const char *const logMessage)
+static void wolfssl_log(const int logLevel, const char* const file_name,
+                        int line_number, const char* const logMessage)
 {
+    (void)file_name;
+    (void)line_number;
     if (log_function)
         log_function(logLevel, logMessage);
     else {
@@ -286,46 +292,103 @@ static void wolfssl_log(const int logLevel, const char *const logMessage)
 #elif defined(ARDUINO)
         wolfSSL_Arduino_Serial_Print(logMessage);
 #elif defined(WOLFSSL_LOG_PRINTF)
-        printf("%s\n", logMessage);
+        if (file_name != NULL)
+            printf("[%s L %d] %s\n", file_name, line_number, logMessage);
+        else
+            printf("%s\n", logMessage);
 #elif defined(THREADX) && !defined(THREADX_NO_DC_PRINTF)
-        dc_log_printf("%s\n", logMessage);
+        if (file_name != NULL)
+            dc_log_printf("[%s L %d] %s\n", file_name, line_number, logMessage);
+        else
+            dc_log_printf("%s\n", logMessage);
 #elif defined(WOLFSSL_DEOS)
-        printf("%s\r\n", logMessage);
+        if (file_name != NULL)
+            printf("[%s L %d] %s\r\n", file_name, line_number, logMessage);
+        else
+            printf("%s\r\n", logMessage);
 #elif defined(MICRIUM)
-        BSP_Ser_Printf("%s\r\n", logMessage);
+        if (file_name != NULL)
+            BSP_Ser_Printf("[%s L %d] %s\r\n",
+                           file_name, line_number, logMessage);
+        else
+            BSP_Ser_Printf("%s\r\n", logMessage);
 #elif defined(WOLFSSL_MDK_ARM)
         fflush(stdout) ;
-        printf("%s\n", logMessage);
+        if (file_name != NULL)
+            printf("[%s L %d] %s\n", file_name, line_number, logMessage);
+        else
+            printf("%s\n", logMessage);
         fflush(stdout) ;
 #elif defined(WOLFSSL_UTASKER)
         fnDebugMsg((char*)logMessage);
         fnDebugMsg("\r\n");
 #elif defined(MQX_USE_IO_OLD)
-        fprintf(_mqxio_stderr, "%s\n", logMessage);
+        if (file_name != NULL)
+            fprintf(_mqxio_stderr, "[%s L %d] %s\n",
+                    file_name, line_number, logMessage);
+        else
+            fprintf(_mqxio_stderr, "%s\n", logMessage);
 #elif defined(WOLFSSL_APACHE_MYNEWT)
-        LOG_DEBUG(&mynewt_log, LOG_MODULE_DEFAULT, "%s\n", logMessage);
+        if (file_name != NULL)
+            LOG_DEBUG(&mynewt_log, LOG_MODULE_DEFAULT, "[%s L %d] %s\n",
+                      file_name, line_number, logMessage);
+        else
+            LOG_DEBUG(&mynewt_log, LOG_MODULE_DEFAULT, "%s\n", logMessage);
 #elif defined(WOLFSSL_ESPIDF)
-        ESP_LOGI("wolfssl", "%s", logMessage);
+        if (file_name != NULL)
+            ESP_LOGI("wolfssl", "[%s L %d] %s",
+                     file_name, line_number, logMessage);
+        else
+            ESP_LOGI("wolfssl", "%s", logMessage);
 #elif defined(WOLFSSL_ZEPHYR)
-        printk("%s\n", logMessage);
+        if (file_name != NULL)
+            printk("[%s L %d] %s\n", file_name, line_number, logMessage);
+        else
+            printk("%s\n", logMessage);
 #elif defined(WOLFSSL_TELIT_M2MB)
-        M2M_LOG_INFO("%s\n", logMessage);
+        if (file_name != NULL)
+            M2M_LOG_INFO("[%s L %d] %s\n", file_name, line_number, logMessage);
+        else
+            M2M_LOG_INFO("%s\n", logMessage);
 #elif defined(WOLFSSL_ANDROID_DEBUG)
-        __android_log_print(ANDROID_LOG_VERBOSE, "[wolfSSL]", "%s", logMessage);
+        if (file_name != NULL)
+            __android_log_print(ANDROID_LOG_VERBOSE, "[wolfSSL]", "[%s L %d] %s",
+                                file_name, line_number, logMessage);
+        else
+            __android_log_print(ANDROID_LOG_VERBOSE, "[wolfSSL]", "%s",
+                                logMessage);
 #elif defined(WOLFSSL_XILINX)
-        xil_printf("%s\r\n", logMessage);
+        if (file_name != NULL)
+            xil_printf("[%s L %d] %s\r\n", file_name, line_number, logMessage);
+        else
+            xil_printf("%s\r\n", logMessage);
 #elif defined(WOLFSSL_LINUXKM)
-        printk("%s\n", logMessage);
+        if (file_name != NULL)
+            printk("[%s L %d] %s\n", file_name, line_number, logMessage);
+        else
+            printk("%s\n", logMessage);
 #elif defined(WOLFSSL_RENESAS_RA6M4)
-        myprintf("%s\n", logMessage);
+        if (file_name != NULL)
+            myprintf("[%s L %d] %s\n", file_name, line_number, logMessage);
+        else
+            myprintf("%s\n", logMessage);
 #elif defined(STACK_SIZE_CHECKPOINT_MSG) && \
       defined(HAVE_STACK_SIZE_VERBOSE) && defined(HAVE_STACK_SIZE_VERBOSE_LOG)
         STACK_SIZE_CHECKPOINT_MSG(logMessage);
 #else
-        if (log_prefix != NULL)
-            fprintf(stderr, "[%s]: %s\n", log_prefix, logMessage);
-        else
-            fprintf(stderr, "%s\n", logMessage);
+        if (log_prefix != NULL) {
+            if (file_name != NULL)
+                fprintf(stderr, "[%s]: [%s L %d] %s\n",
+                        log_prefix, file_name, line_number, logMessage);
+            else
+                fprintf(stderr, "[%s]: %s\n", log_prefix, logMessage);
+        } else {
+            if (file_name != NULL)
+                fprintf(stderr, "[%s L %d] %s\n",
+                        file_name, line_number, logMessage);
+            else
+                fprintf(stderr, "%s\n", logMessage);
+        }
 #endif
     }
 }
@@ -337,6 +400,7 @@ static void wolfssl_log(const int logLevel, const char *const logMessage)
 #ifndef WOLFSSL_MSG_EX_BUF_SZ
 #define WOLFSSL_MSG_EX_BUF_SZ 100
 #endif
+#undef WOLFSSL_MSG_EX /* undo WOLFSSL_DEBUG_CODEPOINTS wrapper */
 #ifdef __clang__
 /* tell clang argument 1 is format */
 __attribute__((__format__ (__printf__, 1, 0)))
@@ -351,16 +415,42 @@ void WOLFSSL_MSG_EX(const char* fmt, ...)
         written = XVSNPRINTF(msg, sizeof(msg), fmt, args);
         va_end(args);
         if (written > 0)
-            wolfssl_log(INFO_LOG , msg);
+            wolfssl_log(INFO_LOG, NULL, 0, msg);
+    }
+}
+
+#ifdef WOLFSSL_DEBUG_CODEPOINTS
+void WOLFSSL_MSG_EX2(const char *file, int line, const char* fmt, ...)
+{
+    if (loggingEnabled) {
+        char msg[WOLFSSL_MSG_EX_BUF_SZ];
+        int written;
+        va_list args;
+        va_start(args, fmt);
+        written = XVSNPRINTF(msg, sizeof(msg), fmt, args);
+        va_end(args);
+        if (written > 0)
+            wolfssl_log(INFO_LOG, file, line, msg);
     }
 }
 #endif
 
+#endif
+
+#undef WOLFSSL_MSG /* undo WOLFSSL_DEBUG_CODEPOINTS wrapper */
 void WOLFSSL_MSG(const char* msg)
 {
     if (loggingEnabled)
-        wolfssl_log(INFO_LOG , msg);
+        wolfssl_log(INFO_LOG, NULL, 0, msg);
 }
+
+#ifdef WOLFSSL_DEBUG_CODEPOINTS
+void WOLFSSL_MSG2(const char *file, int line, const char* msg)
+{
+    if (loggingEnabled)
+        wolfssl_log(INFO_LOG, file, line, msg);
+}
+#endif
 
 #ifndef LINE_LEN
 #define LINE_LEN 16
@@ -375,7 +465,7 @@ void WOLFSSL_BUFFER(const byte* buffer, word32 length)
     }
 
     if (!buffer) {
-        wolfssl_log(INFO_LOG, "\tNULL");
+        wolfssl_log(INFO_LOG, NULL, 0, "\tNULL");
         return;
     }
 
@@ -405,32 +495,66 @@ void WOLFSSL_BUFFER(const byte* buffer, word32 length)
             }
         }
 
-        wolfssl_log(INFO_LOG, line);
+        wolfssl_log(INFO_LOG, NULL, 0, line);
         buffer += LINE_LEN;
         buflen -= LINE_LEN;
     }
 }
 
-
+#undef WOLFSSL_ENTER /* undo WOLFSSL_DEBUG_CODEPOINTS wrapper */
 void WOLFSSL_ENTER(const char* msg)
 {
     if (loggingEnabled) {
         char buffer[WOLFSSL_MAX_ERROR_SZ];
         XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Entering %s", msg);
-        wolfssl_log(ENTER_LOG , buffer);
+        wolfssl_log(ENTER_LOG, NULL, 0, buffer);
     }
 }
 
+#ifdef WOLFSSL_DEBUG_CODEPOINTS
+void WOLFSSL_ENTER2(const char *file, int line, const char* msg)
+{
+    if (loggingEnabled) {
+        char buffer[WOLFSSL_MAX_ERROR_SZ];
+        XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Entering %s", msg);
+        wolfssl_log(ENTER_LOG, file, line, buffer);
+    }
+}
+#endif
 
+#undef WOLFSSL_LEAVE /* undo WOLFSSL_DEBUG_CODEPOINTS wrapper */
 void WOLFSSL_LEAVE(const char* msg, int ret)
 {
     if (loggingEnabled) {
         char buffer[WOLFSSL_MAX_ERROR_SZ];
         XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Leaving %s, return %d",
                 msg, ret);
-        wolfssl_log(LEAVE_LOG , buffer);
+        wolfssl_log(LEAVE_LOG, NULL, 0, buffer);
     }
 }
+
+#ifdef WOLFSSL_DEBUG_CODEPOINTS
+void WOLFSSL_LEAVE2(const char *file, int line, const char* msg, int ret)
+{
+    if (loggingEnabled) {
+        char buffer[WOLFSSL_MAX_ERROR_SZ];
+        XSNPRINTF(buffer, sizeof(buffer), "wolfSSL Leaving %s, return %d",
+                msg, ret);
+        wolfssl_log(LEAVE_LOG, file, line, buffer);
+    }
+}
+#endif
+
+#ifdef WOLFSSL_DEBUG_CODEPOINTS
+    /* restore the wrappers */
+    #define WOLFSSL_MSG(msg) WOLFSSL_MSG2(__FILE__, __LINE__, msg)
+    #define WOLFSSL_ENTER(msg) WOLFSSL_ENTER2(__FILE__, __LINE__, msg)
+    #define WOLFSSL_LEAVE(msg, ret) WOLFSSL_LEAVE2(__FILE__, __LINE__, msg, ret)
+    #ifdef XVSNPRINTF
+        #define WOLFSSL_MSG_EX(fmt, args...) \
+                WOLFSSL_MSG_EX2(__FILE__, __LINE__, fmt, ## args)
+    #endif
+#endif
 
 WOLFSSL_API int WOLFSSL_IS_DEBUG_ON(void)
 {
@@ -714,7 +838,7 @@ unsigned long wc_PeekErrorNodeLineData(const char **file, int *line,
 
     while (1) {
         int ret = wc_PeekErrorNode(0, file, NULL, line);
-        if (ret == BAD_STATE_E) {
+        if (ret == WC_NO_ERR_TRACE(BAD_STATE_E)) {
             WOLFSSL_MSG("Issue peeking at error node in queue");
             return 0;
         }
@@ -744,7 +868,7 @@ unsigned long wc_GetErrorNodeErr(void)
 
     ret = wc_PullErrorNode(NULL, NULL, NULL);
     if (ret < 0) {
-        if (ret == BAD_STATE_E) {
+        if (ret == WC_NO_ERR_TRACE(BAD_STATE_E)) {
             ret = 0; /* no errors in queue */
         }
         else {
@@ -1230,7 +1354,9 @@ unsigned long wc_PeekErrorNodeLineData(const char **file, int *line,
     idx = getErrorNodeCurrentIdx();
     while (1) {
         int ret = peekErrorNode(idx, file, NULL, line);
-        if (ret == BAD_MUTEX_E || ret == BAD_FUNC_ARG || ret == BAD_STATE_E) {
+        if (ret == WC_NO_ERR_TRACE(BAD_MUTEX_E) ||
+            ret == WC_NO_ERR_TRACE(BAD_FUNC_ARG) ||
+            ret == WC_NO_ERR_TRACE(BAD_STATE_E)) {
             ERRQ_UNLOCK();
             WOLFSSL_MSG("Issue peeking at error node in queue");
             return 0;
@@ -1263,7 +1389,7 @@ unsigned long wc_GetErrorNodeErr(void)
 
     ret = pullErrorNode(NULL, NULL, NULL);
     if (ret < 0) {
-        if (ret == BAD_STATE_E) {
+        if (ret == WC_NO_ERR_TRACE(BAD_STATE_E)) {
             ret = 0; /* no errors in queue */
         }
         else {
@@ -1483,7 +1609,7 @@ void WOLFSSL_ERROR(int error)
 #endif
 {
 #ifdef WOLFSSL_ASYNC_CRYPT
-    if (error != WC_PENDING_E)
+    if (error != WC_NO_ERR_TRACE(WC_PENDING_E))
 #endif
     {
         char buffer[WOLFSSL_MAX_ERROR_SZ];
@@ -1501,7 +1627,8 @@ void WOLFSSL_ERROR(int error)
             #if defined(OPENSSL_EXTRA) && !defined(WOLFCRYPT_ONLY)
             /* If running in compatibility mode do not add want read and
                want right to error queue */
-            if (error != WANT_READ && error != WANT_WRITE) {
+            if (error != WC_NO_ERR_TRACE(WANT_READ) &&
+                error != WC_NO_ERR_TRACE(WANT_WRITE)) {
             #endif
             if (error < 0)
                 error = error - (2 * error); /* get absolute value */
@@ -1531,7 +1658,7 @@ void WOLFSSL_ERROR(int error)
 
     #ifdef DEBUG_WOLFSSL
         if (loggingEnabled)
-            wolfssl_log(ERROR_LOG , buffer);
+            wolfssl_log(ERROR_LOG, NULL, 0, buffer);
     #endif
     }
 }
@@ -1540,7 +1667,7 @@ void WOLFSSL_ERROR_MSG(const char* msg)
 {
 #ifdef DEBUG_WOLFSSL
     if (loggingEnabled)
-        wolfssl_log(ERROR_LOG , msg);
+        wolfssl_log(ERROR_LOG, NULL, 0, msg);
 #else
     (void)msg;
 #endif

--- a/libatalk/ssl/wolfcrypt/src/misc.c
+++ b/libatalk/ssl/wolfcrypt/src/misc.c
@@ -1001,6 +1001,25 @@ WC_MISC_STATIC WC_INLINE word32 HashObject(const byte* o, word32 len,
 #endif /* WOLFCRYPT_ONLY && !NO_HASH_WRAPPER &&
         * (!NO_SESSION_CACHE || HAVE_SESSION_TICKET) */
 
+WC_MISC_STATIC WC_INLINE char* CopyString(const char* src, int srcLen,
+        void* heap, int type) {
+    char* dst = NULL;
+
+    if (src == NULL)
+        return NULL;
+
+    if (srcLen <= 0)
+        srcLen = (int)XSTRLEN(src);
+
+    dst = (char*)XMALLOC((size_t)srcLen + 1, heap, type);
+    if (dst != NULL) {
+        XMEMCPY(dst, src, (size_t)srcLen);
+        dst[srcLen] = '\0';
+    }
+
+    return dst;
+}
+
 #endif /* !WOLFSSL_MISC_INCLUDED && !NO_INLINE */
 
 #endif /* WOLF_CRYPT_MISC_C */

--- a/libatalk/ssl/wolfcrypt/src/pwdbased.c
+++ b/libatalk/ssl/wolfcrypt/src/pwdbased.c
@@ -28,6 +28,16 @@
 
 #ifndef NO_PWDBASED
 
+#if FIPS_VERSION3_GE(6,0,0)
+    /* set NO_WRAPPERS before headers, use direct internal f()s not wrappers */
+    #define FIPS_NO_WRAPPERS
+
+       #ifdef USE_WINDOWS_API
+               #pragma code_seg(".fipsA$h")
+               #pragma const_seg(".fipsB$h")
+       #endif
+#endif
+
 #include <wolfssl/wolfcrypt/pwdbased.h>
 #include <wolfssl/wolfcrypt/hmac.h>
 #include <wolfssl/wolfcrypt/hash.h>
@@ -41,6 +51,17 @@
     #include <wolfcrypt/src/misc.c>
 #endif
 
+#if FIPS_VERSION3_GE(6,0,0)
+    #ifdef DEBUG_WOLFSSL
+        #include <wolfssl/wolfcrypt/logging.h>
+    #endif
+    const unsigned int wolfCrypt_FIPS_pbkdf_ro_sanity[2] =
+                                                     { 0x1a2b3c4d, 0x00000010 };
+    int wolfCrypt_FIPS_PBKDF_sanity(void)
+    {
+        return 0;
+    }
+#endif
 
 #ifdef HAVE_PBKDF1
 
@@ -165,6 +186,7 @@ int wc_PBKDF1_ex(byte* key, int keyLen, byte* iv, int ivLen,
 int wc_PBKDF1(byte* output, const byte* passwd, int pLen, const byte* salt,
            int sLen, int iterations, int kLen, int hashType)
 {
+
     return wc_PBKDF1_ex(output, kLen, NULL, 0,
         passwd, pLen, salt, sLen, iterations, hashType, NULL);
 }
@@ -191,6 +213,24 @@ int wc_PBKDF2_ex(byte* output, const byte* passwd, int pLen, const byte* salt,
         return BAD_FUNC_ARG;
     }
 
+#if FIPS_VERSION3_GE(6,0,0)
+    /* Per SP800-132 section 5 "The kLen value shall be at least 112 bits in
+     * length", ensure the returned bits for the derived master key are at a
+     * minimum 14-bytes or 112-bits after stretching and strengthening
+     * (iterations) */
+    if (kLen < HMAC_FIPS_MIN_KEY/8)
+        return BAD_LENGTH_E;
+#endif
+
+#if FIPS_VERSION3_GE(6,0,0) && defined(DEBUG_WOLFSSL)
+    /* SP800-132 section 5.2 recommends an iteration count of 1000 but this is
+     * not strictly enforceable and is listed in Appendix B Table 1 as a
+     * non-testable requirement. wolfCrypt will log it when appropriate but
+     * take no action */
+    if (iterations < 1000) {
+        WOLFSSL_MSG("WARNING: Iteration < 1,000, see SP800-132 section 5.2");
+    }
+#endif
     if (iterations <= 0)
         iterations = 1;
 
@@ -214,7 +254,17 @@ int wc_PBKDF2_ex(byte* output, const byte* passwd, int pLen, const byte* salt,
     if (ret == 0) {
         word32 i = 1;
         /* use int hashType here, since HMAC FIPS uses the old unique value */
+    #if FIPS_VERSION3_GE(6,0,0)
+        {
+            /* Allow passwords that are less than 14-bytes for compatibility
+             * / interoperability, only since module v6.0.0 */
+            int allowShortPasswd = 1;
+            ret = wc_HmacSetKey_ex(hmac, hashType, passwd, (word32)pLen,
+                                   allowShortPasswd);
+        }
+    #else
         ret = wc_HmacSetKey(hmac, hashType, passwd, (word32)pLen);
+    #endif
 
         while (ret == 0 && kLen) {
             int currentLen;

--- a/libatalk/ssl/wolfcrypt/src/rsa.c
+++ b/libatalk/ssl/wolfcrypt/src/rsa.c
@@ -35,15 +35,13 @@ RSA keys can be used to encrypt, decrypt, sign and verify data.
 
 #ifndef NO_RSA
 
-#if defined(HAVE_FIPS) && \
-    defined(HAVE_FIPS_VERSION) && (HAVE_FIPS_VERSION >= 2)
-
+#if FIPS_VERSION3_GE(2,0,0)
     /* set NO_WRAPPERS before headers, use direct internal f()s not wrappers */
     #define FIPS_NO_WRAPPERS
 
        #ifdef USE_WINDOWS_API
-               #pragma code_seg(".fipsA$e")
-               #pragma const_seg(".fipsB$e")
+               #pragma code_seg(".fipsA$j")
+               #pragma const_seg(".fipsB$j")
        #endif
 #endif
 
@@ -108,6 +106,14 @@ RSA Key Size Configuration:
     #include <wolfcrypt/src/misc.c>
 #endif
 
+#if FIPS_VERSION3_GE(6,0,0)
+    const unsigned int wolfCrypt_FIPS_rsa_ro_sanity[2] =
+                                                     { 0x1a2b3c4d, 0x00000012 };
+    int wolfCrypt_FIPS_RSA_sanity(void)
+    {
+        return 0;
+    }
+#endif
 
 enum {
     RSA_STATE_NONE = 0,
@@ -121,22 +127,25 @@ enum {
     RSA_STATE_DECRYPT_RES
 };
 
-
 static void wc_RsaCleanup(RsaKey* key)
 {
-#if !defined(WOLFSSL_RSA_VERIFY_INLINE) && !defined(WOLFSSL_NO_MALLOC)
-    if (key && key->data) {
+#if !defined(WOLFSSL_NO_MALLOC) && (defined(WOLFSSL_ASYNC_CRYPT) || \
+    (!defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_VERIFY_INLINE)))
+    if (key != NULL) {
+    #ifndef WOLFSSL_RSA_PUBLIC_ONLY
+        /* if private operation zero temp buffer */
+        if ((key->data != NULL && key->dataLen > 0) &&
+            (key->type == RSA_PRIVATE_DECRYPT ||
+             key->type == RSA_PRIVATE_ENCRYPT)) {
+            ForceZero(key->data, key->dataLen);
+        }
+    #endif
         /* make sure any allocated memory is free'd */
         if (key->dataIsAlloc) {
-        #ifndef WOLFSSL_RSA_PUBLIC_ONLY
-            if (key->type == RSA_PRIVATE_DECRYPT ||
-                key->type == RSA_PRIVATE_ENCRYPT) {
-                ForceZero(key->data, key->dataLen);
-            }
-        #endif
             XFREE(key->data, key->heap, DYNAMIC_TYPE_WOLF_BIGINT);
             key->dataIsAlloc = 0;
         }
+
         key->data = NULL;
         key->dataLen = 0;
     }
@@ -148,29 +157,21 @@ static void wc_RsaCleanup(RsaKey* key)
 int wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId)
 {
     int ret      = 0;
-#if defined(HAVE_PKCS11)
-    int isPkcs11 = 0;
-#endif
 
     if (key == NULL) {
         return BAD_FUNC_ARG;
     }
-
-#if defined(HAVE_PKCS11)
-    if (key->isPkcs11) {
-        isPkcs11 = 1;
-    }
-#endif
 
     XMEMSET(key, 0, sizeof(RsaKey));
 
     key->type = RSA_TYPE_UNKNOWN;
     key->state = RSA_STATE_NONE;
     key->heap = heap;
-#if !defined(WOLFSSL_RSA_VERIFY_INLINE) && !defined(WOLFSSL_NO_MALLOC)
+#if !defined(WOLFSSL_NO_MALLOC) && (defined(WOLFSSL_ASYNC_CRYPT) || \
+    (!defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_VERIFY_INLINE)))
     key->dataIsAlloc = 0;
-    key->data = NULL;
 #endif
+    key->data = NULL;
     key->dataLen = 0;
 #ifdef WC_RSA_BLINDING
     key->rng = NULL;
@@ -188,19 +189,18 @@ int wc_InitRsaKey_ex(RsaKey* key, void* heap, int devId)
     #endif
 
     #ifdef WC_ASYNC_ENABLE_RSA
-        #if defined(HAVE_PKCS11)
-            if (!isPkcs11)
+        #ifdef WOLF_CRYPTO_CB
+        /* prefer crypto callback */
+        if (key->devId != INVALID_DEVID)
         #endif
-            {
-                /* handle as async */
-                ret = wolfAsync_DevCtxInit(&key->asyncDev,
-                        WOLFSSL_ASYNC_MARKER_RSA, key->heap, devId);
-                if (ret != 0)
-                    return ret;
-            }
+        {
+            /* handle as async */
+            ret = wolfAsync_DevCtxInit(&key->asyncDev,
+                    WOLFSSL_ASYNC_MARKER_RSA, key->heap, devId);
+            if (ret != 0)
+                return ret;
+        }
     #endif /* WC_ASYNC_ENABLE_RSA */
-#elif defined(HAVE_PKCS11)
-    (void)isPkcs11;
 #endif /* WOLFSSL_ASYNC_CRYPT */
 
 #ifndef WOLFSSL_RSA_PUBLIC_ONLY
@@ -273,14 +273,6 @@ int wc_InitRsaKey_Id(RsaKey* key, unsigned char* id, int len, void* heap,
         ret = BAD_FUNC_ARG;
     if (ret == 0 && (len < 0 || len > RSA_MAX_ID_LEN))
         ret = BUFFER_E;
-
-#if defined(HAVE_PKCS11)
-    if (ret == 0) {
-        XMEMSET(key, 0, sizeof(RsaKey));
-        key->isPkcs11 = 1;
-    }
-#endif
-
     if (ret == 0)
         ret = wc_InitRsaKey_ex(key, heap, devId);
     if (ret == 0 && id != NULL && len != 0) {
@@ -310,14 +302,6 @@ int wc_InitRsaKey_Label(RsaKey* key, const char* label, void* heap, int devId)
         if (labelLen == 0 || labelLen > RSA_MAX_LABEL_LEN)
             ret = BUFFER_E;
     }
-
-#if defined(HAVE_PKCS11)
-    if (ret == 0) {
-        XMEMSET(key, 0, sizeof(RsaKey));
-        key->isPkcs11 = 1;
-    }
-#endif
-
     if (ret == 0)
         ret = wc_InitRsaKey_ex(key, heap, devId);
     if (ret == 0) {
@@ -648,13 +632,13 @@ static int _ifc_pairwise_consistency_test(RsaKey* key, WC_RNG* rng)
 #ifdef WOLFSSL_ASYNC_CRYPT
     /* Do blocking async calls here, caller does not support WC_PENDING_E */
     do {
-        if (ret == WC_PENDING_E)
+        if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
             ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
         if (ret >= 0)
 #endif
             ret = wc_RsaSSL_Sign((const byte*)msg, msgLen, sig, sigLen, key, rng);
 #ifdef WOLFSSL_ASYNC_CRYPT
-    } while (ret == WC_PENDING_E);
+    } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
 #endif
 
     if (ret > 0) {
@@ -662,13 +646,13 @@ static int _ifc_pairwise_consistency_test(RsaKey* key, WC_RNG* rng)
 #ifdef WOLFSSL_ASYNC_CRYPT
         /* Do blocking async calls here, caller does not support WC_PENDING_E */
         do {
-            if (ret == WC_PENDING_E)
+            if (ret == WC_NO_ERR_TRACE(WC_PENDING_E))
                 ret = wc_AsyncWait(ret, &key->asyncDev, WC_ASYNC_FLAG_CALL_AGAIN);
             if (ret >= 0)
 #endif
                 ret = wc_RsaSSL_VerifyInline(sig, sigLen, &plain, key);
 #ifdef WOLFSSL_ASYNC_CRYPT
-        } while (ret == WC_PENDING_E);
+        } while (ret == WC_NO_ERR_TRACE(WC_PENDING_E));
 #endif
     }
 
@@ -689,13 +673,17 @@ static int _ifc_pairwise_consistency_test(RsaKey* key, WC_RNG* rng)
 
 int wc_CheckRsaKey(RsaKey* key)
 {
-    DECL_MP_INT_SIZE_DYN(tmp, mp_bitsused(&key->n), RSA_MAX_SIZE);
 #ifdef WOLFSSL_SMALL_STACK
     WC_RNG *rng = NULL;
 #else
     WC_RNG rng[1];
 #endif
     int ret = 0;
+    DECL_MP_INT_SIZE_DYN(tmp, (key)? mp_bitsused(&key->n) : 0, RSA_MAX_SIZE);
+
+    if (key == NULL) {
+        return BAD_FUNC_ARG;
+    }
 
 #ifdef WOLFSSL_CAAM
     /* can not perform these checks on an encrypted key */
@@ -725,11 +713,6 @@ int wc_CheckRsaKey(RsaKey* key)
     if (ret == 0) {
         if (INIT_MP_INT_SIZE(tmp, mp_bitsused(&key->n)) != MP_OKAY)
             ret = MP_INIT_E;
-    }
-
-    if (ret == 0) {
-        if (key == NULL)
-            ret = BAD_FUNC_ARG;
     }
 
     if (ret == 0)
@@ -1805,7 +1788,7 @@ static int RsaUnPad_PSS(byte *pkcsBlock, unsigned int pkcsBlockLen,
 static int RsaUnPad(const byte *pkcsBlock, unsigned int pkcsBlockLen,
                     byte **output, byte padValue)
 {
-    int    ret = BAD_FUNC_ARG;
+    int    ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
     word16 i;
 
     if (output == NULL || pkcsBlockLen < 2 || pkcsBlockLen > 0xFFFF) {
@@ -2794,7 +2777,7 @@ static int wc_RsaFunctionSync(const byte* in, word32 inLen, byte* out,
 
 #ifdef WOLFSSL_HAVE_SP_RSA
     ret = RsaFunction_SP(in, inLen, out, outLen, type, key, rng);
-    if (ret != WC_KEY_SIZE_E)
+    if (ret != WC_NO_ERR_TRACE(WC_KEY_SIZE_E))
         return ret;
 #endif /* WOLFSSL_HAVE_SP_RSA */
 
@@ -2948,7 +2931,7 @@ int wc_RsaDirect(byte* in, word32 inLen, byte* out, word32* outSz,
             key->dataLen = *outSz;
 
             ret = wc_RsaFunction(in, inLen, out, &key->dataLen, type, key, rng);
-            if (ret >= 0 || ret == WC_PENDING_E) {
+            if (ret >= 0 || ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
                 key->state = (type == RSA_PRIVATE_ENCRYPT ||
                     type == RSA_PUBLIC_ENCRYPT) ? RSA_STATE_ENCRYPT_RES:
                                                   RSA_STATE_DECRYPT_RES;
@@ -3146,12 +3129,12 @@ static int wc_RsaFunction_ex(const byte* in, word32 inLen, byte* out,
     {
         ret = wc_CryptoCb_Rsa(in, inLen, out, outLen, type, key, rng);
         #ifndef WOLF_CRYPTO_CB_ONLY_RSA
-        if (ret != CRYPTOCB_UNAVAILABLE)
+        if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             return ret;
         /* fall-through when unavailable and try using software */
         #endif
         #ifdef WOLF_CRYPTO_CB_ONLY_RSA
-        if (ret == CRYPTOCB_UNAVAILABLE) {
+        if (ret == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
             return NO_VALID_DEVID;
         }
         return ret;
@@ -3203,7 +3186,7 @@ static int wc_RsaFunction_ex(const byte* in, word32 inLen, byte* out,
         && ret != FP_WOULDBLOCK
     #endif
     ) {
-        if (ret == MP_EXPTMOD_E) {
+        if (ret == WC_NO_ERR_TRACE(MP_EXPTMOD_E)) {
             /* This can happen due to incorrectly set FP_MAX_BITS or missing XREALLOC */
             WOLFSSL_MSG("RSA_FUNCTION MP_EXPTMOD_E: memory/config problem");
         }
@@ -3339,8 +3322,8 @@ static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
             if (key->devId != INVALID_DEVID) {
                 /* SCE supports 1024 and 2048 bits */
                 ret = wc_CryptoCb_Rsa(in, inLen, out,
-                                    outLen, rsa_type, key, rng);
-                if (ret != CRYPTOCB_UNAVAILABLE)
+                                    &outLen, rsa_type, key, rng);
+                if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                     return ret;
                 /* fall-through when unavailable */
                 ret = 0; /* reset error code and try using software */
@@ -3365,7 +3348,7 @@ static int RsaPublicEncryptEx(const byte* in, word32 inLen, byte* out,
         ret = wc_RsaFunction(out, (word32)sz, out, &key->dataLen, rsa_type, key,
                              rng);
 
-        if (ret >= 0 || ret == WC_PENDING_E) {
+        if (ret >= 0 || ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             key->state = RSA_STATE_ENCRYPT_RES;
         }
         if (ret < 0) {
@@ -3425,7 +3408,7 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
                             byte* label, word32 labelSz, int saltLen,
                             WC_RNG* rng)
 {
-    int ret = RSA_WRONG_TYPE_E;
+    int ret = WC_NO_ERR_TRACE(RSA_WRONG_TYPE_E);
     byte* pad = NULL;
 
     if (in == NULL || inLen == 0 || out == NULL || key == NULL) {
@@ -3496,8 +3479,8 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
            #ifdef WOLF_CRYPTO_CB
                 if (key->devId != INVALID_DEVID) {
                     ret = wc_CryptoCb_Rsa(in, inLen, out,
-                                        outLen, rsa_type, key, rng);
-                    if (ret != CRYPTOCB_UNAVAILABLE)
+                                        &outLen, rsa_type, key, rng);
+                    if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                       return ret;
                     /* fall-through when unavailable */
                     ret = 0; /* reset error code and try using software */
@@ -3525,6 +3508,7 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
                 break;
             }
             XMEMCPY(key->data, in, inLen);
+            key->dataLen = inLen;
         }
         else {
             key->dataIsAlloc = 0;
@@ -3546,7 +3530,7 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
                                               rng, pad_type != WC_RSA_OAEP_PAD);
 #endif
 
-        if (ret >= 0 || ret == WC_PENDING_E) {
+        if (ret >= 0 || ret == WC_NO_ERR_TRACE(WC_PENDING_E)) {
             key->state = RSA_STATE_DECRYPT_UNPAD;
         }
         if (ret < 0) {
@@ -3558,13 +3542,13 @@ static int RsaPrivateDecryptEx(const byte* in, word32 inLen, byte* out,
     case RSA_STATE_DECRYPT_UNPAD:
 #if !defined(WOLFSSL_RSA_VERIFY_ONLY) && !defined(WOLFSSL_RSA_VERIFY_INLINE) && \
     !defined(WOLFSSL_NO_MALLOC)
-        ret = wc_RsaUnPad_ex(key->data, key->dataLen, &pad, pad_value, pad_type,
-                             hash, mgf, label, labelSz, saltLen,
-                             mp_count_bits(&key->n), key->heap);
+        ret = wc_RsaUnPad_ex(key->data,
+            key->dataLen, &pad, pad_value, pad_type, hash, mgf,
+            label, labelSz, saltLen, mp_count_bits(&key->n), key->heap);
 #else
-        ret = wc_RsaUnPad_ex(out, key->dataLen, &pad, pad_value, pad_type, hash,
-                             mgf, label, labelSz, saltLen,
-                             mp_count_bits(&key->n), key->heap);
+        ret = wc_RsaUnPad_ex(out,
+            key->dataLen, &pad, pad_value, pad_type, hash, mgf, label,
+            labelSz, saltLen, mp_count_bits(&key->n), key->heap);
 #endif
         if (rsa_type == RSA_PUBLIC_DECRYPT && ret > (int)outLen) {
             ret = RSA_BUFFER_E;
@@ -4033,7 +4017,10 @@ int wc_RsaPSS_CheckPadding_ex2(const byte* in, word32 inSz, byte* sig,
 
     /* Sig = Salt | Exp Hash */
     if (ret == 0) {
-        if (sigSz != inSz + (word32)saltLen) {
+        word32 totalSz;
+        if ((WC_SAFE_SUM_WORD32(inSz, (word32)saltLen, totalSz) == 0) ||
+            (sigSz != totalSz))
+        {
             ret = PSS_SALTLEN_E;
         }
     }
@@ -4259,7 +4246,7 @@ int wc_RsaEncryptSize(const RsaKey* key)
 
 #ifdef WOLF_CRYPTO_CB
     if (ret == 0 && key->devId != INVALID_DEVID) {
-        if (wc_CryptoCb_RsaGetSize(key, &ret) == CRYPTOCB_UNAVAILABLE) {
+        if (wc_CryptoCb_RsaGetSize(key, &ret) == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE)) {
             ret = 2048/8; /* hardware handles, use 2048-bit as default */
         }
     }
@@ -4326,7 +4313,7 @@ int wc_RsaExportKey(RsaKey* key,
                     byte* d, word32* dSz, byte* p, word32* pSz,
                     byte* q, word32* qSz)
 {
-    int ret = BAD_FUNC_ARG;
+    int ret = WC_NO_ERR_TRACE(BAD_FUNC_ARG);
 
     if (key && e && eSz && n && nSz && d && dSz && p && pSz && q && qSz)
         ret = 0;
@@ -4531,7 +4518,8 @@ static int _CheckProbablePrime(mp_int* p, mp_int* q, mp_int* e, int nlen,
 
     if (q != NULL) {
         int valid = 0;
-        /* 5.4 - check that |p-q| <= (2^(1/2))(2^((nlen/2)-1)) */
+        /* 5.4 (186-4) 5.5 (186-5) -
+         * check that |p-q| <= (2^(1/2))(2^((nlen/2)-1)) */
         ret = wc_CompareDiffPQ(p, q, nlen, &valid);
         if ((ret != MP_OKAY) || (!valid)) goto notOkay;
         prime = q;
@@ -4539,14 +4527,15 @@ static int _CheckProbablePrime(mp_int* p, mp_int* q, mp_int* e, int nlen,
     else
         prime = p;
 
-    /* 4.4,5.5 - Check that prime >= (2^(1/2))(2^((nlen/2)-1))
+    /* 4.4,5.5 (186-4) 4.4,5.4 (186-5) -
+     * Check that prime >= (2^(1/2))(2^((nlen/2)-1))
      *           This is a comparison against lowerBound */
     ret = mp_read_unsigned_bin(tmp1, lower_bound, (word32)nlen/16);
     if (ret != MP_OKAY) goto notOkay;
     ret = mp_cmp(prime, tmp1);
     if (ret == MP_LT) goto exit;
 
-    /* 4.5,5.6 - Check that GCD(p-1, e) == 1 */
+    /* 4.5,5.6 (186-4 & 186-5) - Check that GCD(p-1, e) == 1 */
     ret = mp_sub_d(prime, 1, tmp1);  /* tmp1 = prime-1 */
     if (ret != MP_OKAY) goto notOkay;
 #ifdef WOLFSSL_CHECK_MEM_ZERO
@@ -4721,7 +4710,12 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
 #endif /* WOLFSSL_SMALL_STACK */
     int i, failCount, isPrime = 0;
     word32 primeSz;
+#ifndef WOLFSSL_NO_MALLOC
     byte* buf = NULL;
+#else
+    /* RSA_MAX_SIZE is the size of n in bits. */
+    byte buf[RSA_MAX_SIZE/16];
+#endif
 #endif /* !WOLFSSL_CRYPTOCELL && !WOLFSSL_SE050 */
     int err;
 
@@ -4780,12 +4774,12 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
     {
         err = wc_CryptoCb_MakeRsaKey(key, size, e, rng);
         #ifndef WOLF_CRYPTO_CB_ONLY_RSA
-        if (err != CRYPTOCB_UNAVAILABLE)
+        if (err != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             goto out;
         /* fall-through when unavailable */
         #endif
         #ifdef WOLF_CRYPTO_CB_ONLY_RSA
-        if (err == CRYPTOCB_UNAVAILABLE)
+        if (err == WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
             err = NO_VALID_DEVID;
             goto out;
         }
@@ -4827,12 +4821,14 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
     primeSz = (word32)size / 16; /* size is the size of n in bits.
                             primeSz is in bytes. */
 
+#ifndef WOLFSSL_NO_MALLOC
     /* allocate buffer to work with */
     if (err == MP_OKAY) {
         buf = (byte*)XMALLOC(primeSz, key->heap, DYNAMIC_TYPE_RSA);
         if (buf == NULL)
             err = MEMORY_E;
     }
+#endif
 
     SAVE_VECTOR_REGISTERS(err = _svr_ret;);
 
@@ -4935,10 +4931,14 @@ int wc_MakeRsaKey(RsaKey* key, int size, long e, WC_RNG* rng)
     if (err == MP_OKAY && !isPrime)
         err = PRIME_GEN_E;
 
+#ifndef WOLFSSL_NO_MALLOC
     if (buf) {
         ForceZero(buf, primeSz);
         XFREE(buf, key->heap, DYNAMIC_TYPE_RSA);
     }
+#else
+    ForceZero(buf, primeSz);
+#endif
 
     if (err == MP_OKAY && mp_cmp(p, q) < 0) {
         err = mp_copy(p, tmp1);
@@ -5155,5 +5155,116 @@ int wc_RsaSetNonBlockTime(RsaKey* key, word32 maxBlockUs, word32 cpuMHz)
 }
 #endif /* WC_RSA_NONBLOCK_TIME */
 #endif /* WC_RSA_NONBLOCK */
+
+#ifndef WOLFSSL_RSA_PUBLIC_ONLY
+
+#if defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA) || !defined(RSA_LOW_MEM)
+/*
+ * Calculate  y = d mod(x-1)
+ */
+static int CalcDX(mp_int* y, mp_int* x, mp_int* d)
+{
+    int err;
+#ifndef WOLFSSL_SMALL_STACK
+    mp_int  m[1];
+#else
+    mp_int* m = (mp_int*)XMALLOC(sizeof(mp_int), NULL, DYNAMIC_TYPE_WOLF_BIGINT);
+    if (m == NULL)
+        return MEMORY_E;
+#endif
+
+    err = mp_init(m);
+    if (err == MP_OKAY) {
+        err = mp_sub_d(x, 1, m);
+        if (err == MP_OKAY)
+            err = mp_mod(d, m, y);
+        mp_forcezero(m);
+    }
+
+#ifdef WOLFSSL_SMALL_STACK
+    XFREE(m, NULL, DYNAMIC_TYPE_WOLF_BIGINT);
+#endif
+
+    return err;
+}
+#endif
+
+int wc_RsaPrivateKeyDecodeRaw(const byte* n, word32 nSz,
+        const byte* e, word32 eSz, const byte* d, word32 dSz,
+        const byte* u, word32 uSz, const byte* p, word32 pSz,
+        const byte* q, word32 qSz, const byte* dP, word32 dPSz,
+        const byte* dQ, word32 dQSz, RsaKey* key)
+{
+    int err = MP_OKAY;
+
+    if (n == NULL || nSz == 0 || e == NULL || eSz == 0
+            || d == NULL || dSz == 0 || p == NULL || pSz == 0
+            || q == NULL || qSz == 0 || key == NULL) {
+        err = BAD_FUNC_ARG;
+    }
+
+#if defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA) || !defined(RSA_LOW_MEM)
+    if (err == MP_OKAY) {
+        if ((u == NULL || uSz == 0)
+                || (dP != NULL && dPSz == 0)
+                || (dQ != NULL && dQSz == 0)) {
+            err = BAD_FUNC_ARG;
+        }
+    }
+#else
+    (void)u;
+    (void)uSz;
+    (void)dP;
+    (void)dPSz;
+    (void)dQ;
+    (void)dQSz;
+#endif
+
+    if (err == MP_OKAY)
+        err = mp_read_unsigned_bin(&key->n, n, nSz);
+    if (err == MP_OKAY)
+        err = mp_read_unsigned_bin(&key->e, e, eSz);
+    if (err == MP_OKAY)
+        err = mp_read_unsigned_bin(&key->d, d, dSz);
+    if (err == MP_OKAY)
+        err = mp_read_unsigned_bin(&key->p, p, pSz);
+    if (err == MP_OKAY)
+        err = mp_read_unsigned_bin(&key->q, q, qSz);
+#if defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA) || !defined(RSA_LOW_MEM)
+    if (err == MP_OKAY)
+        err = mp_read_unsigned_bin(&key->u, u, uSz);
+    if (err == MP_OKAY) {
+        if (dP != NULL)
+            err = mp_read_unsigned_bin(&key->dP, dP, dPSz);
+        else
+            err = CalcDX(&key->dP, &key->p, &key->d);
+    }
+    if (err == MP_OKAY) {
+        if (dQ != NULL)
+            err = mp_read_unsigned_bin(&key->dQ, dQ, dQSz);
+        else
+            err = CalcDX(&key->dQ, &key->q, &key->d);
+    }
+#endif
+
+    if (err == MP_OKAY) {
+        key->type = RSA_PRIVATE;
+    }
+    else {
+        mp_clear(&key->n);
+        mp_clear(&key->e);
+        mp_clear(&key->d);
+        mp_clear(&key->p);
+        mp_clear(&key->q);
+#if defined(WOLFSSL_KEY_GEN) || defined(OPENSSL_EXTRA) || !defined(RSA_LOW_MEM)
+        mp_clear(&key->u);
+        mp_clear(&key->dP);
+        mp_clear(&key->dQ);
+#endif
+    }
+
+    return err;
+}
+#endif /* WOLFSSL_RSA_PUBLIC_ONLY */
 
 #endif /* NO_RSA */

--- a/libatalk/ssl/wolfcrypt/src/sha256.c
+++ b/libatalk/ssl/wolfcrypt/src/sha256.c
@@ -71,8 +71,8 @@ on the specific device platform.
     #define FIPS_NO_WRAPPERS
 
     #ifdef USE_WINDOWS_API
-        #pragma code_seg(".fipsA$d")
-        #pragma const_seg(".fipsB$d")
+        #pragma code_seg(".fipsA$l")
+        #pragma const_seg(".fipsB$l")
     #endif
 #endif
 
@@ -141,6 +141,14 @@ on the specific device platform.
     #include <wolfssl/wolfcrypt/port/nxp/se050_port.h>
 #endif
 
+#if FIPS_VERSION3_GE(6,0,0)
+    const unsigned int wolfCrypt_FIPS_sha256_ro_sanity[2] =
+                                                     { 0x1a2b3c4d, 0x00000014 };
+    int wolfCrypt_FIPS_SHA256_sanity(void)
+    {
+        return 0;
+    }
+#endif
 
 #if defined(WOLFSSL_X86_64_BUILD) && defined(USE_INTEL_SPEEDUP)
     #if defined(__GNUC__) && ((__GNUC__ < 4) || \
@@ -168,8 +176,7 @@ on the specific device platform.
     #define HAVE_INTEL_RORX
 #endif
 
-
-#if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
+#if defined(LITTLE_ENDIAN_ORDER)
     #if ( defined(CONFIG_IDF_TARGET_ESP32C2) || \
           defined(CONFIG_IDF_TARGET_ESP8684) || \
           defined(CONFIG_IDF_TARGET_ESP32C3) || \
@@ -182,20 +189,28 @@ on the specific device platform.
          * depending on if HW is active or not. */
         #define SHA256_REV_BYTES(ctx) \
             (esp_sha_need_byte_reversal(ctx))
+    #elif defined(FREESCALE_MMCAU_SHA)
+        #define SHA256_REV_BYTES(ctx)       1 /* reverse needed on final */
     #endif
 #endif
 #ifndef SHA256_REV_BYTES
-    #if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA)
+    #if defined(LITTLE_ENDIAN_ORDER)
         #define SHA256_REV_BYTES(ctx)       1
     #else
         #define SHA256_REV_BYTES(ctx)       0
     #endif
 #endif
-#if defined(LITTLE_ENDIAN_ORDER) && !defined(FREESCALE_MMCAU_SHA) && \
+#if defined(LITTLE_ENDIAN_ORDER) && \
         defined(WOLFSSL_X86_64_BUILD) && defined(USE_INTEL_SPEEDUP) && \
         (defined(HAVE_INTEL_AVX1) || defined(HAVE_INTEL_AVX2))
-    #define SHA256_UPDATE_REV_BYTES(ctx) \
-        (!IS_INTEL_AVX1(intel_flags) && !IS_INTEL_AVX2(intel_flags))
+    #ifdef WC_C_DYNAMIC_FALLBACK
+        #define SHA256_UPDATE_REV_BYTES(ctx) (sha256->sha_method == SHA256_C)
+    #else
+        #define SHA256_UPDATE_REV_BYTES(ctx) \
+            (!IS_INTEL_AVX1(intel_flags) && !IS_INTEL_AVX2(intel_flags))
+    #endif
+#elif defined(FREESCALE_MMCAU_SHA)
+    #define SHA256_UPDATE_REV_BYTES(ctx)    0 /* reverse not needed on update */
 #else
     #define SHA256_UPDATE_REV_BYTES(ctx)    SHA256_REV_BYTES(ctx)
 #endif
@@ -217,6 +232,15 @@ on the specific device platform.
     (!defined(WOLFSSL_HAVE_PSA) || defined(WOLFSSL_PSA_NO_HASH)) && \
     !defined(WOLFSSL_RENESAS_RX64_HASH)
 
+#if defined(WOLFSSL_X86_64_BUILD) && defined(USE_INTEL_SPEEDUP) && \
+    (defined(HAVE_INTEL_AVX1) || defined(HAVE_INTEL_AVX2))
+#ifdef WC_C_DYNAMIC_FALLBACK
+    #define SHA256_SETTRANSFORM_ARGS int *sha_method
+#else
+    #define SHA256_SETTRANSFORM_ARGS void
+#endif
+static void Sha256_SetTransform(SHA256_SETTRANSFORM_ARGS);
+#endif
 
 static int InitSha256(wc_Sha256* sha256)
 {
@@ -240,6 +264,17 @@ static int InitSha256(wc_Sha256* sha256)
     sha256->msg  = NULL;
     sha256->len  = 0;
     sha256->used = 0;
+#endif
+
+#if defined(WOLFSSL_X86_64_BUILD) && defined(USE_INTEL_SPEEDUP) && \
+    (defined(HAVE_INTEL_AVX1) || defined(HAVE_INTEL_AVX2))
+    /* choose best Transform function under this runtime environment */
+#ifdef WC_C_DYNAMIC_FALLBACK
+    sha256->sha_method = 0;
+    Sha256_SetTransform(&sha256->sha_method);
+#else
+    Sha256_SetTransform();
+#endif
 #endif
 
 #ifdef WOLF_CRYPTO_CB
@@ -360,25 +395,205 @@ static int InitSha256(wc_Sha256* sha256)
     }  /* extern "C" */
 #endif
 
+    static word32 intel_flags = 0;
+
+#if defined(WC_C_DYNAMIC_FALLBACK) && !defined(WC_NO_INTERNAL_FUNCTION_POINTERS)
+    #define WC_NO_INTERNAL_FUNCTION_POINTERS
+#endif
+
+#ifdef WC_NO_INTERNAL_FUNCTION_POINTERS
+
+    enum sha_methods { SHA256_UNSET = 0, SHA256_AVX1_SHA, SHA256_AVX2,
+                       SHA256_AVX1_RORX, SHA256_AVX1_NOSHA, SHA256_AVX2_RORX,
+                       SHA256_SSE2, SHA256_C };
+
+#ifndef WC_C_DYNAMIC_FALLBACK
+    static enum sha_methods sha_method = SHA256_UNSET;
+#endif
+
+    static void Sha256_SetTransform(SHA256_SETTRANSFORM_ARGS)
+    {
+    #ifdef WC_C_DYNAMIC_FALLBACK
+        #define SHA_METHOD (*sha_method)
+    #else
+        #define SHA_METHOD sha_method
+    #endif
+        if (SHA_METHOD != SHA256_UNSET)
+            return;
+
+    #ifdef WC_C_DYNAMIC_FALLBACK
+        if (! CAN_SAVE_VECTOR_REGISTERS()) {
+            SHA_METHOD = SHA256_C;
+            return;
+        }
+    #endif
+
+        if (intel_flags == 0)
+            intel_flags = cpuid_get_flags();
+
+        if (IS_INTEL_SHA(intel_flags)) {
+        #ifdef HAVE_INTEL_AVX1
+            if (IS_INTEL_AVX1(intel_flags)) {
+                SHA_METHOD = SHA256_AVX1_SHA;
+            }
+            else
+        #endif
+            {
+                SHA_METHOD = SHA256_SSE2;
+            }
+        }
+        else
+    #ifdef HAVE_INTEL_AVX2
+        if (IS_INTEL_AVX2(intel_flags)) {
+        #ifdef HAVE_INTEL_RORX
+            if (IS_INTEL_BMI2(intel_flags)) {
+                SHA_METHOD = SHA256_AVX2_RORX;
+            }
+            else
+        #endif
+            {
+                SHA_METHOD = SHA256_AVX2;
+            }
+        }
+        else
+    #endif
+    #ifdef HAVE_INTEL_AVX1
+        if (IS_INTEL_AVX1(intel_flags)) {
+        #ifdef HAVE_INTEL_RORX
+            if (IS_INTEL_BMI2(intel_flags)) {
+                SHA_METHOD = SHA256_AVX1_RORX;
+            }
+            else
+        #endif
+            {
+                SHA_METHOD = SHA256_AVX1_NOSHA;
+            }
+        }
+        else
+    #endif
+        {
+            SHA_METHOD = SHA256_C;
+        }
+    #undef SHA_METHOD
+    }
+
+    static WC_INLINE int inline_XTRANSFORM(wc_Sha256* S, const byte* D) {
+    #ifdef WC_C_DYNAMIC_FALLBACK
+        #define SHA_METHOD (S->sha_method)
+    #else
+        #define SHA_METHOD sha_method
+    #endif
+        int ret;
+
+        if (SHA_METHOD == SHA256_C)
+            return Transform_Sha256(S, D);
+        SAVE_VECTOR_REGISTERS(return _svr_ret;);
+        switch (SHA_METHOD) {
+        case SHA256_AVX2:
+            ret = Transform_Sha256_AVX2(S, D);
+            break;
+        case SHA256_AVX2_RORX:
+            ret = Transform_Sha256_AVX2_RORX(S, D);
+            break;
+        case SHA256_AVX1_SHA:
+            ret = Transform_Sha256_AVX1_Sha(S, D);
+            break;
+        case SHA256_AVX1_NOSHA:
+            ret = Transform_Sha256_AVX1(S, D);
+            break;
+        case SHA256_AVX1_RORX:
+            ret = Transform_Sha256_AVX1_RORX(S, D);
+            break;
+        case SHA256_SSE2:
+            ret = Transform_Sha256_SSE2_Sha(S, D);
+            break;
+        case SHA256_C:
+        case SHA256_UNSET:
+        default:
+            ret = Transform_Sha256(S, D);
+            break;
+        }
+        RESTORE_VECTOR_REGISTERS();
+        return ret;
+    #undef SHA_METHOD
+    }
+#define XTRANSFORM(...) inline_XTRANSFORM(__VA_ARGS__)
+
+    static WC_INLINE int inline_XTRANSFORM_LEN(wc_Sha256* S, const byte* D, word32 L) {
+    #ifdef WC_C_DYNAMIC_FALLBACK
+        #define SHA_METHOD (S->sha_method)
+    #else
+        #define SHA_METHOD sha_method
+    #endif
+        int ret;
+        SAVE_VECTOR_REGISTERS(return _svr_ret;);
+        switch (SHA_METHOD) {
+        case SHA256_AVX2:
+            ret = Transform_Sha256_AVX2_Len(S, D, L);
+            break;
+        case SHA256_AVX2_RORX:
+            ret = Transform_Sha256_AVX2_RORX_Len(S, D, L);
+            break;
+        case SHA256_AVX1_SHA:
+            ret = Transform_Sha256_AVX1_Sha_Len(S, D, L);
+            break;
+        case SHA256_AVX1_NOSHA:
+            ret = Transform_Sha256_AVX1_Len(S, D, L);
+            break;
+        case SHA256_AVX1_RORX:
+            ret = Transform_Sha256_AVX1_RORX_Len(S, D, L);
+            break;
+        case SHA256_SSE2:
+            ret = Transform_Sha256_SSE2_Sha_Len(S, D, L);
+            break;
+        case SHA256_C:
+        case SHA256_UNSET:
+        default:
+            ret = 0;
+            break;
+        }
+        RESTORE_VECTOR_REGISTERS();
+        return ret;
+    #undef SHA_METHOD
+    }
+#define XTRANSFORM_LEN(...) inline_XTRANSFORM_LEN(__VA_ARGS__)
+
+#else /* !WC_NO_INTERNAL_FUNCTION_POINTERS */
+
     static int (*Transform_Sha256_p)(wc_Sha256* sha256, const byte* data);
                                                        /* = _Transform_Sha256 */
     static int (*Transform_Sha256_Len_p)(wc_Sha256* sha256, const byte* data,
                                          word32 len);
                                                                     /* = NULL */
     static int transform_check = 0;
-    static word32 intel_flags;
     static int Transform_Sha256_is_vectorized = 0;
 
     static WC_INLINE int inline_XTRANSFORM(wc_Sha256* S, const byte* D) {
         int ret;
+    #ifdef WOLFSSL_LINUXKM
+        if (Transform_Sha256_is_vectorized)
+            SAVE_VECTOR_REGISTERS(return _svr_ret;);
+    #endif
         ret = (*Transform_Sha256_p)(S, D);
+    #ifdef WOLFSSL_LINUXKM
+        if (Transform_Sha256_is_vectorized)
+            RESTORE_VECTOR_REGISTERS();
+    #endif
         return ret;
     }
 #define XTRANSFORM(...) inline_XTRANSFORM(__VA_ARGS__)
 
     static WC_INLINE int inline_XTRANSFORM_LEN(wc_Sha256* S, const byte* D, word32 L) {
         int ret;
+    #ifdef WOLFSSL_LINUXKM
+        if (Transform_Sha256_is_vectorized)
+            SAVE_VECTOR_REGISTERS(return _svr_ret;);
+    #endif
         ret = (*Transform_Sha256_Len_p)(S, D, L);
+    #ifdef WOLFSSL_LINUXKM
+        if (Transform_Sha256_is_vectorized)
+            RESTORE_VECTOR_REGISTERS();
+    #endif
         return ret;
     }
 #define XTRANSFORM_LEN(...) inline_XTRANSFORM_LEN(__VA_ARGS__)
@@ -452,6 +667,8 @@ static int InitSha256(wc_Sha256* sha256)
         transform_check = 1;
     }
 
+#endif /* !WC_NO_INTERNAL_FUNCTION_POINTERS */
+
 #if !defined(WOLFSSL_KCAPI_HASH)
     int wc_InitSha256_ex(wc_Sha256* sha256, void* heap, int devId)
     {
@@ -471,9 +688,6 @@ static int InitSha256(wc_Sha256* sha256)
         ret = InitSha256(sha256);
         if (ret != 0)
             return ret;
-
-        /* choose best Transform function under this runtime environment */
-        Sha256_SetTransform();
 
     #if defined(WOLFSSL_ASYNC_CRYPT) && defined(WC_ASYNC_ENABLE_SHA256)
         ret = wolfAsync_DevCtxInit(&sha256->asyncDev,
@@ -617,7 +831,14 @@ static int InitSha256(wc_Sha256* sha256)
     {
         int ret = 0;
 
-        if (sha256 == NULL || (data == NULL && len > 0)) {
+        if (sha256 == NULL) {
+            return BAD_FUNC_ARG;
+        }
+        if (data == NULL && len == 0) {
+            /* valid, but do nothing */
+            return 0;
+        }
+        if (data == NULL) {
             return BAD_FUNC_ARG;
         }
 
@@ -668,6 +889,17 @@ static int InitSha256(wc_Sha256* sha256)
 
     int wc_Sha256Update(wc_Sha256* sha256, const byte* data, word32 len)
     {
+        if (sha256 == NULL) {
+            return BAD_FUNC_ARG;
+        }
+        if (data == NULL && len == 0) {
+            /* valid, but do nothing */
+            return 0;
+        }
+        if (data == NULL) {
+            return BAD_FUNC_ARG;
+        }
+
         return se050_hash_update(&sha256->se050Ctx, data, len);
     }
 
@@ -1151,7 +1383,15 @@ static int InitSha256(wc_Sha256* sha256)
     #ifdef XTRANSFORM_LEN
         #if defined(WOLFSSL_X86_64_BUILD) && defined(USE_INTEL_SPEEDUP) && \
                           (defined(HAVE_INTEL_AVX1) || defined(HAVE_INTEL_AVX2))
+
+        #ifdef WC_C_DYNAMIC_FALLBACK
+        if (sha256->sha_method != SHA256_C)
+        #elif defined(WC_NO_INTERNAL_FUNCTION_POINTERS)
+        if (sha_method != SHA256_C)
+        #else
         if (Transform_Sha256_Len_p != NULL)
+        #endif
+
         #endif
         {
             if (len >= WC_SHA256_BLOCK_SIZE) {
@@ -1259,7 +1499,7 @@ static int InitSha256(wc_Sha256* sha256)
         #endif
         {
             int ret = wc_CryptoCb_Sha256Hash(sha256, data, len, NULL);
-            if (ret != CRYPTOCB_UNAVAILABLE)
+            if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 return ret;
             /* fall-through when unavailable */
         }
@@ -1387,7 +1627,11 @@ static int InitSha256(wc_Sha256* sha256)
         /* Kinetis requires only these bytes reversed */
         #if defined(WOLFSSL_X86_64_BUILD) && defined(USE_INTEL_SPEEDUP) && \
                           (defined(HAVE_INTEL_AVX1) || defined(HAVE_INTEL_AVX2))
+        #ifdef WC_C_DYNAMIC_FALLBACK
+        if (sha256->sha_method != SHA256_C)
+        #else
         if (IS_INTEL_AVX1(intel_flags) || IS_INTEL_AVX2(intel_flags))
+        #endif
         #endif
         {
             ByteReverseWords(
@@ -1456,7 +1700,7 @@ static int InitSha256(wc_Sha256* sha256)
         #endif
         {
             ret = wc_CryptoCb_Sha256Hash(sha256, NULL, 0, hash);
-            if (ret != CRYPTOCB_UNAVAILABLE)
+            if (ret != WC_NO_ERR_TRACE(CRYPTOCB_UNAVAILABLE))
                 return ret;
             /* fall-through when unavailable */
         }
@@ -1732,10 +1976,18 @@ static int InitSha256(wc_Sha256* sha256)
         sha224->loLen   = 0;
         sha224->hiLen   = 0;
 
+    #ifdef WC_C_DYNAMIC_FALLBACK
+        sha224->sha_method = 0;
+    #endif
+
     #if defined(WOLFSSL_X86_64_BUILD) && defined(USE_INTEL_SPEEDUP) && \
                           (defined(HAVE_INTEL_AVX1) || defined(HAVE_INTEL_AVX2))
         /* choose best Transform function under this runtime environment */
+    #ifdef WC_C_DYNAMIC_FALLBACK
+        Sha256_SetTransform(&sha224->sha_method);
+    #else
         Sha256_SetTransform();
+    #endif
     #endif
     #ifdef WOLFSSL_HASH_FLAGS
         sha224->flags = 0;

--- a/libatalk/ssl/wolfcrypt/src/sp_int.c
+++ b/libatalk/ssl/wolfcrypt/src/sp_int.c
@@ -8097,6 +8097,27 @@ int sp_submod_ct(const sp_int* a, const sp_int* b, const sp_int* m, sp_int* r)
 }
 #endif /* WOLFSSL_SP_MATH_ALL && HAVE_ECC */
 
+#if defined(WOLFSSL_SP_MATH_ALL) && defined(HAVE_ECC) && \
+    defined(WOLFSSL_ECC_BLIND_K)
+void sp_xor_ct(const sp_int* a, const sp_int* b, int len, sp_int* r)
+{
+    if ((a != NULL) && (b != NULL) && (r != NULL)) {
+        unsigned int i;
+
+        r->used = (len * 8 + SP_WORD_SIZE - 1) / SP_WORD_SIZE;
+        for (i = 0; i < r->used; i++) {
+            r->dp[i] = a->dp[i] ^ b->dp[i];
+        }
+        i = (len * 8) % SP_WORD_SIZE;
+        if (i > 0) {
+            r->dp[r->used - 1] &= ((sp_int_digit)1 << i) - 1;
+        }
+        /* Remove leading zeros. */
+        sp_clamp_ct(r);
+    }
+}
+#endif
+
 /********************
  * Shifting functoins
  ********************/

--- a/libatalk/ssl/wolfcrypt/src/wc_encrypt.c
+++ b/libatalk/ssl/wolfcrypt/src/wc_encrypt.c
@@ -244,7 +244,7 @@ int wc_Des3_CbcDecryptWithKey(byte* out, const byte* in, word32 sz,
 int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
     const byte* password, int passwordSz, int hashType)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 #ifdef WOLFSSL_SMALL_STACK
     byte* key      = NULL;
 #else
@@ -318,7 +318,7 @@ int wc_BufferKeyDecrypt(EncryptedInfo* info, byte* der, word32 derSz,
 int wc_BufferKeyEncrypt(EncryptedInfo* info, byte* der, word32 derSz,
     const byte* password, int passwordSz, int hashType)
 {
-    int ret = NOT_COMPILED_IN;
+    int ret = WC_NO_ERR_TRACE(NOT_COMPILED_IN);
 #ifdef WOLFSSL_SMALL_STACK
     byte* key      = NULL;
 #else
@@ -545,9 +545,15 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
 
                 ret =  wc_PKCS12_PBKDF(key, unicodePasswd, idx, salt, saltSz,
                                     iterations, (int)derivedLen, typeH, 1);
+                if (ret < 0)
+                    break;
                 if (id != PBE_SHA1_RC4_128) {
-                    ret += wc_PKCS12_PBKDF(cbcIv, unicodePasswd, idx, salt,
+                    i = ret;
+                    ret = wc_PKCS12_PBKDF(cbcIv, unicodePasswd, idx, salt,
                                     saltSz, iterations, 8, typeH, 2);
+                    if (ret < 0)
+                        break;
+                    ret += i;
                 }
                 break;
             }
@@ -658,15 +664,21 @@ int wc_CryptKey(const char* password, int passwordSz, byte* salt,
                                                             AES_ENCRYPTION);
                     }
                     else {
+                    #ifdef HAVE_AES_DECRYPT
                         ret = wc_AesSetKey(aes, key, derivedLen, cbcIv,
                                                             AES_DECRYPTION);
+                    #else
+                        ret = NOT_COMPILED_IN;
+                    #endif
                     }
                 }
                 if (ret == 0) {
                     if (enc)
                         ret = wc_AesCbcEncrypt(aes, input, input, (word32)length);
+                    #ifdef HAVE_AES_DECRYPT
                     else
                         ret = wc_AesCbcDecrypt(aes, input, input, (word32)length);
+                    #endif
                 }
                 if (free_aes)
                     wc_AesFree(aes);

--- a/libatalk/ssl/wolfcrypt/src/wolfmath.c
+++ b/libatalk/ssl/wolfcrypt/src/wolfmath.c
@@ -167,7 +167,8 @@ int get_rand_digit(WC_RNG* rng, mp_digit* d)
     return wc_RNG_GenerateBlock(rng, (byte*)d, sizeof(mp_digit));
 }
 
-#if defined(WC_RSA_BLINDING) || defined(WOLFCRYPT_HAVE_SAKKE)
+#if defined(WC_RSA_BLINDING) || defined(WOLFCRYPT_HAVE_SAKKE) || \
+    defined(WOLFSSL_ECC_BLIND_K)
 int mp_rand(mp_int* a, int digits, WC_RNG* rng)
 {
     int ret = 0;
@@ -221,7 +222,7 @@ int mp_rand(mp_int* a, int digits, WC_RNG* rng)
 
     return ret;
 }
-#endif /* WC_RSA_BLINDING || WOLFCRYPT_HAVE_SAKKE */
+#endif /* WC_RSA_BLINDING || WOLFCRYPT_HAVE_SAKKE || WOLFSSL_ECC_BLIND_K */
 #endif /* !WC_NO_RNG */
 
 #if defined(HAVE_ECC) || defined(WOLFSSL_EXPORT_INT)

--- a/meson_config.h
+++ b/meson_config.h
@@ -825,7 +825,9 @@
 
 /* WolfSSL configuration */
 
+#define HAVE_AESGCM
 #define HAVE_DH_DEFAULT_PARAMS
+#define HAVE_TLS_EXTENSIONS
 #define NO_CPUID
 #define NO_DO178
 #define NO_DSA
@@ -840,9 +842,10 @@
 #define NO_RC4
 #define NO_SHA
 #define NO_WOLFSSL_MEMORY
+#define OPENSSL_ALL
+#define OPENSSL_EXTRA
 #define TFM_TIMING_RESISTANT
 #define WC_NO_ASYNC_THREADING
-#define WC_NO_RSA_OAEP
 #define WC_RSA_BLINDING
 #define WC_RSA_PSS
 #define WOLFSSL_DES_ECB


### PR DESCRIPTION
Distribute unmodified C code of the core WolfSSL library, rather than the previous attempt at minimizing it.

This makes maintenance of our bundled WolfSSL fork a LOT easier than before, with the tradeoff of distributing more code and building more symbols.

An additional tradeoff is a handful of (harmless) redefined macro compiler warnings like `warning: "_GNU_SOURCE" redefined`. They have been reported upstream.