### PR TITLE
[2.4] Enable building with WolfSSL 5.7.2

### DIFF
--- a/bin/afppasswd/afppasswd.c
+++ b/bin/afppasswd/afppasswd.c
@@ -70,6 +70,10 @@
 #define HEXPASSWDLEN 16
 #define PASSWDLEN 8
 
+#ifndef DES_KEY_SZ
+#define DES_KEY_SZ (sizeof(DES_cblock))
+#endif
+
 static char buf[MAXPATHLEN + 1];
 
 /* if newpwd is null, convert buf from hex to binary. if newpwd isn't

--- a/bin/afppasswd/afppasswd.c
+++ b/bin/afppasswd/afppasswd.c
@@ -41,6 +41,7 @@
 #if defined(EMBEDDED_SSL) || defined(WOLFSSL_DHX)
 #if defined(WOLFSSL_DHX)
 #include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/settings.h>
 #endif
 #include <wolfssl/openssl/des.h>
 #elif defined(OPENSSL_DHX)

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -26,6 +26,7 @@
 #if defined(EMBEDDED_SSL) || defined(WOLFSSL_DHX)
 #if defined(WOLFSSL_DHX)
 #include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/settings.h>
 #endif
 #include <openssl/cast.h>
 #include <wolfssl/openssl/bn.h>

--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -31,6 +31,7 @@
 #if defined(EMBEDDED_SSL) || defined(WOLFSSL_DHX)
 #if defined(WOLFSSL_DHX)
 #include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/settings.h>
 #endif
 #include <openssl/cast.h>
 #include <wolfssl/openssl/bn.h>

--- a/etc/uams/uams_pgp.c
+++ b/etc/uams/uams_pgp.c
@@ -25,6 +25,7 @@
 #if defined(EMBEDDED_SSL) || defined(WOLFSSL_DHX)
 #if defined(WOLFSSL_DHX)
 #include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/settings.h>
 #endif
 #include <openssl/cast.h>
 #include <wolfssl/openssl/bn.h>

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -32,6 +32,7 @@
 #if defined(EMBEDDED_SSL) || defined(WOLFSSL_DHX)
 #if defined(WOLFSSL_DHX)
 #include <wolfssl/options.h>
+#include <wolfssl/wolfcrypt/settings.h>
 #endif
 #include <wolfssl/openssl/des.h>
 #elif defined(OPENSSL_DHX)

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -129,6 +129,10 @@ home_passwd_fail:
  *
  * key file: 
  * key (in hex) */
+#ifndef DES_KEY_SZ
+#define DES_KEY_SZ (sizeof(DES_cblock))
+#endif
+
 #define PASSWD_ILLEGAL '*'
 #define unhex(x)  (isdigit(x) ? (x) - '0' : toupper(x) + 10 - 'A')
 static int afppasswd(const struct passwd *pwd, 


### PR DESCRIPTION
Fixes for compiler errors when building against a shared WolfSSL 5.7.2 library