### PR TITLE
[2.4] meson: Do not define rpath with a linker argument

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -405,16 +405,10 @@ compiler_64_bit_mode = run_command(
 # Check whether to enable rpath (the default on Solaris and NetBSD)
 #
 
-if host_os == 'sunos' or host_os == 'netbsd'
-    enable_rpath = true
-else
-    enable_rpath = get_option('with-rpath')
-endif
+rpath_libdir = ''
 
-if enable_rpath
+if host_os == 'sunos' or host_os == 'netbsd' or get_option('with-rpath')
     rpath_libdir = libdir
-else
-    rpath_libdir = ''
 endif
 
 #
@@ -946,9 +940,6 @@ libgcrypt_link_args = []
 
 if libgcrypt_path != ''
     libgcrypt_link_args += ['-L' + libgcrypt_path / 'lib', '-lgcrypt']
-    if enable_rpath
-        libgcrypt_link_args += ['-Wl,-rpath,' + libgcrypt_path / 'lib']
-    endif
     libgcrypt = declare_dependency(
         link_args: libgcrypt_link_args,
         include_directories: include_directories(libgcrypt_path / 'include'),
@@ -1199,9 +1190,6 @@ ldap_link_args = []
 
 if ldap_path != ''
     ldap_link_args += ['-L' + ldap_path / 'lib', '-lldap', ]
-    if enable_rpath
-        ldap_link_args += ['-Wl,-rpath,' + ldap_path / 'lib']
-    endif
     ldap = declare_dependency(
         link_args: ldap_link_args,
         include_directories: include_directories(ldap_path / 'include'),
@@ -1265,9 +1253,6 @@ libiconv_link_args = []
 
 if iconv_path != ''
     libiconv_link_args += ['-L' + iconv_path / 'lib', '-liconv']
-    if enable_rpath
-        libiconv_link_args += ['-Wl,-rpath,' + iconv_path / 'lib']
-    endif
     iconv = declare_dependency(
         link_args: libiconv_link_args,
         include_directories: include_directories(iconv_path / 'include'),


### PR DESCRIPTION
Remove superfluous rpath linker arguments