### PR TITLE
docker: Build and start AppleTalk services

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -7,10 +7,10 @@ For simplicity, exactly one user, one shared volume, and one Time Machine volume
 Make sure you have Docker Engine installed, then build the netatalk container:
 
 ```
-docker build -t netatalk3 .
+docker build -t netatalk:latest .
 ```
 
-Alternatively, fetch a pre-built docker container from [Docker Hub](https://hub.docker.com/u/netatalk).
+Alternatively, pull a pre-built Docker container from [Docker Hub](https://hub.docker.com/u/netatalk).
 
 ## How to Run
 
@@ -23,7 +23,9 @@ Without this, the shared volume be stored in volatile storage that is lost upon 
 
 You can use the sample [docker-compose.yml](https://github.com/Netatalk/netatalk/blob/main/docker-compose.yml) that is distributed with this source code.
 
-Below follows a sample `docker run` command. Substitute `/path/to/share` with an actual path on your file system with appropriate permissions, and `AFP_USER` and `AFP_PASS` with the appropriate user and password.
+Below follows a sample `docker run` command. Substitute `/path/to/share` with an actual path on your file system with appropriate permissions, and `AFP_USER` and `AFP_PASS` with the appropriate user and password, and `ATALKD_INTERFACE` with the network interface to use for AppleTalk.
+
+You also need to set the timezone with `TZ` to the [IANA time zone ID](https://nodatime.org/TimeZones) for your location, in order to get the correct time synchronized with the Timelord time server.
 
 ```
 docker run --rm \
@@ -34,16 +36,22 @@ docker run --rm \
   --volume "/var/run/dbus:/var/run/dbus" \
   --env AFP_USER= \
   --env AFP_PASS= \
-  --name netatalk netatalk3:latest
+  --env ATALKD_INTERFACE= \
+  --env TZ= \
+  --name netatalk netatalk:latest
 ```
 
 ## Constraints
 
-In order to use Zeroconf service discovery, the container requires the "host" network driver and NET_ADMIN capabilities.
+In order to use Zeroconf service discovery and the AppleTalk transport layer, the container requires the "host" network driver and NET_ADMIN capabilities.
 
 Additionally, we rely on the host's DBUS for Zeroconf, achieved with a bind mount for `/var/run/dbus:/var/run/dbus`.
 
-Note that the Dockerfile currently only supports Avahi for Zeroconf; no mDNS support at present.
+## Printing
+
+The CUPS administrative web app is running on port 631 in the container, which is exposed to the host machine by default when using the `host` network driver. This is used to configure CUPS compatible printers for printing from an old Mac or Apple IIGS.
+
+You may have to restart papd (or the entire container) after adding a CUPS printer for it to be picked up as an AppleTalk printer.
 
 ## Environment Variables
 
@@ -51,16 +59,27 @@ Note that the Dockerfile currently only supports Avahi for Zeroconf; no mDNS sup
 
 These are required to set the credentials used to authenticate with the file server.
 
-- `AFP_USER`
-- `AFP_PASS`
+| Variable | Description |
+| --- | --- |
+| `AFP_USER` | Username to authenticate with the file server |
+| `AFP_PASS` | Password to authenticate with the file server |
+
+### Mandatory for AppleTalk
+
+| Variable | Description |
+| --- | --- |
+| `ATALKD_INTERFACE` | The network interface to use for AppleTalk |
+| `TZ` | The timezone to use for the container; must be a [IANA time zone ID](https://nodatime.org/TimeZones) |
 
 ### Optional
 
-- `AFP_GROUP` <- group that owns the shared volume, and that AFP_USER gets assigned to
-- `AFP_UID` <- specify user id of AFP_USER
-- `AFP_GID` <- specify group id of AFP_GROUP
-- `SERVER_NAME` <- the name of the server reported to Zeroconf
-- `SHARE_NAME` <- the name of the file sharing volume
-- `AFP_LOGLEVEL` <- the verbosity of logs; default is "info"
-- `INSECURE_AUTH` <- when non-zero, enable the "Clear Text" and "Guest" UAMs
-- `MANUAL_CONFIG` <- when non-zero, skip netatalk config file modification, allowing you to manually manage them
+| Variable        | Description                                                    |
+|-----------------|----------------------------------------------------------------|
+| `AFP_GROUP`     | `AFP_USER`'s group that owns the shared volume                 |
+| `AFP_UID`       | Specify user id of `AFP_USER`                                  |
+| `AFP_GID`       | Specify group id of `AFP_GROUP`                                |
+| `SERVER_NAME`   | The name of the server reported to Zeroconf                    |
+| `SHARE_NAME`    | The name of the file sharing volume                            |
+| `AFP_LOGLEVEL`  | The verbosity of logs; default is "info"                       |
+| `INSECURE_AUTH` | When non-zero, enable the "ClearTxt" and "Guest" UAMs          |
+| `MANUAL_CONFIG` | When non-zero, enable manual management of config files        |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV LIB_DEPS \
     avahi \
     avahi-compat-libdns_sd \
     bash \
+    cups \
     db \
     dbus \
     dbus-glib \
@@ -17,11 +18,13 @@ ENV LIB_DEPS \
     openldap \
     talloc \
     tracker \
-    tracker-miners
+    tracker-miners \
+    tzdata
 ENV BUILD_DEPS \
     acl-dev \
     avahi-dev \
     bison \
+    cups-dev \
     curl \
     db-dev \
     dbus-dev \
@@ -61,6 +64,7 @@ USER builder
 
 RUN meson setup build \
     -Dwith-afpstats=false \
+    -Dwith-appletalk=true \
     -Dwith-dbus-daemon-path=/usr/bin/dbus-daemon \
     -Dwith-dbus-sysconf-path=/etc \
     -Dwith-dtrace=false \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   netatalk:
-    image: netatalk/netatalk3:latest
+    image: netatalk:latest
     network_mode: "host"
     cap_add:
       - NET_ADMIN
@@ -9,8 +9,10 @@ services:
       - afpbackup:/mnt/afpbackup
       - /var/run/dbus:/var/run/dbus
     environment:
-      - "AFP_USER="
-      - "AFP_PASS="
+      - AFP_USER=
+      - AFP_PASS=
+      - ATALKD_INTERFACE=
+      - TZ=
 volumes:
   afpshare:
   afpbackup:


### PR DESCRIPTION
Adapt the Docker container to build and launch AppleTalk services.