### PR TITLE
Add back "ddp address" option.

### DIFF
--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -651,6 +651,16 @@
         </varlistentry>
 
         <varlistentry>
+          <term>ddp address = <replaceable>ddp address</replaceable> <type>(G)</type></term>
+
+          <listitem>
+            <para>Specifies the DDP address of the server. The default is to
+            auto-assign an address (0.0). This is only useful if you are
+            running AppleTalk on more than one interface.</para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
           <term>disconnect time = <replaceable>number</replaceable>
           <type>(G)</type></term>
 

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2162,6 +2162,13 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
         }
     }
 
+#ifndef NO_DDP
+    if ((q = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "ddp address", NULL)))
+        atalk_aton(q, &options->ddpaddr);
+    if (q)
+        free(q);
+#endif
+
     if ((p = atalk_iniparser_getstring(config, INISEC_GLOBAL, "hostname", NULL))) {
         EC_NULL_LOG( options->hostname = strdup(p) );
     } else {
@@ -2383,6 +2390,9 @@ void afp_config_free(AFPObj *obj)
 
     obj->options.flags = 0;
     obj->options.passwdbits = 0;
+#ifndef NO_DDP
+    atalk_aton("0.0", &obj->options.ddpaddr);
+#endif
 
     /* Free everything called from afp_config_parse() */
     free_extmap();


### PR DESCRIPTION
Allow user to configure DDP address the server listens on by default if they have multiple interfaces running AppleTalk. Addresses part of #1442. Tested in multi-interface configuration and confirmed working.