### PR TITLE
[3.2] Update the Solaris manifest import command per Oracle docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -842,6 +842,7 @@ jobs:
               --with-tracker-pkgconfig-version=3.0
             make -j $(nproc)
             make install
+            sleep 2
             svcadm enable svc:/network/netatalk:default
             sleep 2
             /usr/local/bin/asip-status localhost
@@ -855,6 +856,7 @@ jobs:
               -Dwith-pgp-uam=true
             meson compile -C build
             meson install -C build
+            sleep 2
             svcadm enable svc:/network/netatalk:default
             sleep 2
             /usr/local/bin/asip-status localhost
@@ -913,6 +915,7 @@ jobs:
               PKG_CONFIG_PATH=/usr/lib/amd64/pkgconfig
             gmake -j $(nproc)
             gmake install
+            sleep 2
             svcadm enable svc:/network/netatalk:default
             sleep 2
             /usr/local/bin/asip-status localhost
@@ -928,6 +931,7 @@ jobs:
             cd build && meson test
             cd ..
             meson install -C build
+            sleep 2
             svcadm enable svc:/network/netatalk:default
             sleep 2
             /usr/local/bin/asip-status localhost

--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -147,9 +147,9 @@ if get_option('with-init-style') == 'solaris'
     )
     if get_option('with-init-hooks')
         meson.add_install_script(
-            find_program('svccfg'),
-            'import',
-            '/lib/svc/manifest/network/netatalk.xml',
+            find_program('svcadm'),
+            'restart',
+            'manifest-import',
         )
     endif
 endif


### PR DESCRIPTION
The old way of doing this is triggering warning messages in an up to date Solaris 11 system.

Sleeps have been added to the CI workflow because it takes a moment for manifest-import to restart.