### PR TITLE
uams: Fix DHCAST128 key alignment problem.

### DIFF
--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -10,6 +10,7 @@
 
 #include <arpa/inet.h>
 #include <pwd.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -73,6 +74,7 @@ static int pwd_login(void *obj, char *username, int ulen, struct passwd **uam_pw
     BIGNUM *bn, *gbn, *pbn;
     const BIGNUM *pub_key;
     uint16_t sessid;
+    int nwritten;
     size_t i;
     DH *dh;
     *rbuflen = 0;
@@ -138,9 +140,13 @@ static int pwd_login(void *obj, char *username, int ulen, struct passwd **uam_pw
 
     /* figure out the key. use rbuf as a temporary buffer. */
     i = DH_compute_key((unsigned char *)rbuf, bn, dh);
+    if (i < KEYSIZE) {
+        memmove( rbuf + KEYSIZE - i, rbuf, i );
+        memset( rbuf, 0, KEYSIZE - i );
+    }
 
     /* set the key */
-    cast5_set_key((struct cast128_ctx *)&castkey, i, (unsigned char *)rbuf);
+    cast5_set_key((struct cast128_ctx *)&castkey, KEYSIZE, (unsigned char *)rbuf);
 
     /* session id. it's just a hashed version of the object pointer. */
     sessid = dhxhash(obj);
@@ -149,7 +155,11 @@ static int pwd_login(void *obj, char *username, int ulen, struct passwd **uam_pw
     *rbuflen += sizeof(sessid);
 
     /* send our public key */
-    BN_bn2bin(pub_key, (unsigned char *)rbuf);
+    nwritten = BN_bn2bin(pub_key, (unsigned char *)rbuf);
+    if (nwritten < KEYSIZE) {
+        memmove( rbuf + KEYSIZE - nwritten, rbuf, nwritten );
+        memset( rbuf, 0, KEYSIZE - nwritten );
+    }
     rbuf += KEYSIZE;
     *rbuflen += KEYSIZE;
 
@@ -274,8 +284,13 @@ static int passwd_logincont(void *obj, struct passwd **uam_pwd,
 
     /* check for session id */
     memcpy(&sessid, ibuf, sizeof(sessid));
-    if (sessid != dhxhash(obj))
+    if (sessid != dhxhash(obj)) {
+    /* Log Entry */
+           LOG(log_info, logtype_uams, "uams_dhx_passwd.c :passwd Session ID - DHXHash Mismatch -- %s",
+		  strerror(errno));
+    /* Log Entry */
       return AFPERR_PARAM;
+    }
     ibuf += sizeof(sessid);
 
     /* use rbuf as scratch space */


### PR DESCRIPTION
Fixes: when Mb (the server's "public" key part in the Diffie-Hellman exchange) or K (the "private" key) are shorter than KEYSIZE, the UAM code does not verify that they are aligned correctly to the memory regions they're being placed in.