### PR TITLE
Add configuration option for AppleTalk Zone.

### DIFF
--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -662,6 +662,18 @@
         </varlistentry>
 
         <varlistentry>
+          <term>ddp zone = <replaceable>ddp zone</replaceable>
+          <type>(G)</type></term>
+
+          <listitem>
+            <para>Specifies the AppleTalk zone to register the server in. The
+            default is to register the server in the default zone of the last
+            interface configured by the system.
+            </para>
+          </listitem>
+        </varlistentry>
+
+        <varlistentry>
           <term>disconnect time = <replaceable>number</replaceable>
           <type>(G)</type></term>
 

--- a/etc/afpd/main.c
+++ b/etc/afpd/main.c
@@ -126,7 +126,7 @@ static void afp_goaway(int sig)
         if (server_children)
             server_child_kill(server_children, SIGTERM);
 #ifndef NO_DDP
-        if ((asp_obj.Obj))
+        if ((asp_obj.handle))
         {
             asp_cleanup(&asp_obj);
         }
@@ -406,11 +406,11 @@ int main(int ac, char **av)
             configfree(&dsi_obj, NULL);
             afp_config_free(&dsi_obj);
 #ifndef NO_DDP
-            if ((asp_obj.Obj))
+            afp_config_free(&asp_obj);
+            if ((asp_obj.handle))
             {
                 asp_cleanup(&asp_obj);
                 configfree(&asp_obj, NULL);
-                afp_config_free(&asp_obj);
             }
 #endif /* no afp/asp */
 

--- a/etc/afpd/status.c
+++ b/etc/afpd/status.c
@@ -88,7 +88,7 @@ static void status_flags(char *data,
 static int status_server(char *data, const char *server, const struct afp_options *options)
 {
     char                *start = data;
-    char                * Obj, * Type, * Zone;
+    char*       Obj;
     char		buf[32];
     uint16_t           status;
     size_t		len;
@@ -98,9 +98,7 @@ static int status_server(char *data, const char *server, const struct afp_option
 
     /* extract the obj part of the server */
     Obj = (char *) server;
-#ifndef NO_DDP
-    nbp_name(server, &Obj, &Type, &Zone);
-#endif
+
     if ((size_t)-1 == (len = convert_string(
                            options->unixcharset, options->maccharset,
                            Obj, -1, buf, sizeof(buf))) ) {
@@ -366,7 +364,6 @@ static size_t status_utf8servername(char *data, int *nameoffset,
 				 const DSI *dsi _U_,
 				 const struct afp_options *options)
 {
-    char* Obj, * Type, * Zone;
     uint16_t namelen;
     size_t len;
     char *begin = data;
@@ -377,10 +374,7 @@ static size_t status_utf8servername(char *data, int *nameoffset,
     data += offset;
 
     LOG(log_info, logtype_afpd, "servername: %s", options->hostname);
-    Obj = (char*)(options->server ? options->server : options->hostname);
-#ifndef NO_DDP
-    nbp_name(options->server ? options->server : options->hostname, &Obj, &Type, &Zone);
-#endif
+
     if ((len = convert_string(options->unixcharset,
                               CH_UTF8_MAC,
                               options->hostname,
@@ -445,7 +439,7 @@ void status_init(AFPObj *dsi_obj, AFPObj* asp_obj, DSI *dsi)
     maxstatuslen = sizeof(dsi->status);
 
 #ifndef NO_DDP
-    if (asp_obj->Obj) {
+    if (asp_obj->handle) {
         asp = asp_obj->handle;
     }
     else
@@ -518,7 +512,7 @@ void status_init(AFPObj *dsi_obj, AFPObj* asp_obj, DSI *dsi)
         statuslen = status_utf8servername(status, &c, dsi, options);
 
 #ifndef NO_DDP
-    if (asp_obj->Obj) {
+    if (asp_obj->handle) {
         asp_setstatus(asp, status, statuslen);
         asp_obj->signature = status + sigoff;
         //asp_obj->statuslen = statuslen;

--- a/include/atalk/globals.h
+++ b/include/atalk/globals.h
@@ -105,7 +105,7 @@ struct afp_options {
     unsigned char passwdbits, passwdminlen;
     uint32_t server_quantum;
     int dsireadbuf; /* scale factor for sizefof(dsi->buffer) = server_quantum * dsireadbuf */
-    char* hostname, *server;
+    char* hostname, *zone;
 #ifndef NO_DDP
     struct at_addr ddpaddr;
 #endif

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2167,6 +2167,13 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
         atalk_aton(q, &options->ddpaddr);
     if (q)
         free(q);
+
+    if ((p = atalk_iniparser_getstrdup(config, INISEC_GLOBAL, "ddp zone", NULL))) {
+        if (strlen(p) <= 32)
+        {
+            EC_NULL_LOG(options->zone = strdup(p));
+        }
+    }
 #endif
 
     if ((p = atalk_iniparser_getstring(config, INISEC_GLOBAL, "hostname", NULL))) {
@@ -2387,12 +2394,14 @@ void afp_config_free(AFPObj *obj)
         CONFIG_ARG_FREE(obj->options.maccodepage);
     if (obj->options.volcodepage)
         CONFIG_ARG_FREE(obj->options.volcodepage);
+#ifndef NO_DDP
+    if (obj->options.zone)
+        CONFIG_ARG_FREE(obj->options.zone);
+    atalk_aton("0.0", &obj->options.ddpaddr);
+#endif
 
     obj->options.flags = 0;
     obj->options.passwdbits = 0;
-#ifndef NO_DDP
-    atalk_aton("0.0", &obj->options.ddpaddr);
-#endif
 
     /* Free everything called from afp_config_parse() */
     free_extmap();


### PR DESCRIPTION
Adds new option called "ddp zone" to allow a user to register the server in an AppleTalk zone other then the default zone of an interface. Fixes #1462.