### PR TITLE
wolfssl: Disable AES crypto to avoid symbol conflict with Nettle

### DIFF
--- a/include/wolfssl/openssl/evp.h
+++ b/include/wolfssl/openssl/evp.h
@@ -514,7 +514,10 @@ struct WOLFSSL_EVP_CIPHER_CTX {
     defined(WOLFSSL_SM4_GCM) || defined(WOLFSSL_SM4_CCM) || \
     (defined(HAVE_CHACHA) && defined(HAVE_POLY1305))
 #if defined(HAVE_AESGCM) || defined(HAVE_AESCCM) || defined(HAVE_ARIA)
+// TODO: Workaround for https://github.com/wolfSSL/wolfssl/issues/7984
+#ifndef NO_AES
     ALIGN16 unsigned char authTag[AES_BLOCK_SIZE];
+#endif
 #elif defined(WOLFSSL_SM4_GCM) || defined(WOLFSSL_SM4_CCM)
     ALIGN16 unsigned char authTag[SM4_BLOCK_SIZE];
 #else

--- a/include/wolfssl/wolfcrypt/cryptocb.h
+++ b/include/wolfssl/wolfcrypt/cryptocb.h
@@ -284,6 +284,8 @@ typedef struct wc_CryptoInfo {
 #if HAVE_ANONYMOUS_INLINE_AGGREGATES
         union {
 #endif
+// TODO: Workaround for https://github.com/wolfSSL/wolfssl/issues/7984
+	#ifndef NO_AES
         #ifdef HAVE_AESGCM
             struct {
                 Aes*        aes;
@@ -360,6 +362,7 @@ typedef struct wc_CryptoInfo {
                 word32      sz;
             } aesecb;
         #endif /* HAVE_AES_ECB */
+	#endif
         #ifndef NO_DES3
             struct {
                 Des3*       des;
@@ -429,6 +432,8 @@ typedef struct wc_CryptoInfo {
         word32 sz;
     } seed;
 #endif
+// TODO: Workaround for https://github.com/wolfSSL/wolfssl/issues/7984
+#ifndef NO_AES
 #ifdef WOLFSSL_CMAC
     struct {
         Cmac* cmac;
@@ -441,6 +446,7 @@ typedef struct wc_CryptoInfo {
         word32  inSz;
         int type;
     } cmac;
+#endif
 #endif
 #ifdef WOLF_CRYPTO_CB_CMD
     struct {      /* uses wc_AlgoType=ALGO_NONE */
@@ -640,10 +646,13 @@ WOLFSSL_LOCAL int wc_CryptoCb_RandomBlock(WC_RNG* rng, byte* out, word32 sz);
 WOLFSSL_LOCAL int wc_CryptoCb_RandomSeed(OS_Seed* os, byte* seed, word32 sz);
 #endif
 
+// TODO: Workaround for https://github.com/wolfSSL/wolfssl/issues/7984
+#ifndef NO_AES
 #ifdef WOLFSSL_CMAC
 WOLFSSL_LOCAL int wc_CryptoCb_Cmac(Cmac* cmac, const byte* key, word32 keySz,
         const byte* in, word32 inSz, byte* out, word32* outSz, int type,
         void* ctx);
+#endif
 #endif
 
 #endif /* WOLF_CRYPTO_CB */

--- a/meson_config.h
+++ b/meson_config.h
@@ -709,9 +709,11 @@
 
 /* WolfSSL configuration */
 
-#define HAVE_AESGCM
 #define HAVE_DH_DEFAULT_PARAMS
 #define HAVE_TLS_EXTENSIONS
+#define NO_AES
+#define NO_AES_CBC
+#define NO_AESGCM_AEAD
 #define NO_CPUID
 #define NO_DO178
 #define NO_DSA
@@ -734,6 +736,7 @@
 #define WC_RSA_PSS
 #define WOLFSSL_DES_ECB
 #define WOLFSSL_ENCRYPTED_KEYS
+#define WOLFSSL_NO_DEF_TICKET_ENC_CB
 
 /* Define to `__inline__' or `__inline' if that's what the C compiler
    calls it, or to nothing if 'inline' is not supported under any name.  */


### PR DESCRIPTION
We don't use AES crypto in the first place. It was just a matter of finding the right combination of configuration flags.