### PR TITLE
docker: Make AFP_GROUP mandatory, refactor group assignments

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -36,6 +36,7 @@ docker run --rm \
   --volume "/var/run/dbus:/var/run/dbus" \
   --env AFP_USER= \
   --env AFP_PASS= \
+  --env AFP_GROUP=afpusers \
   --env ATALKD_INTERFACE= \
   --env TZ= \
   --name netatalk netatalk:latest
@@ -63,6 +64,7 @@ These are required to set the credentials used to authenticate with the file ser
 | --- | --- |
 | `AFP_USER` | Username to authenticate with the file server |
 | `AFP_PASS` | Password to authenticate with the file server |
+| `AFP_GROUP` | Group that owns the shared volume dirs |
 
 ### Mandatory for AppleTalk
 
@@ -75,7 +77,6 @@ These are required to set the credentials used to authenticate with the file ser
 
 | Variable        | Description                                                    |
 |-----------------|----------------------------------------------------------------|
-| `AFP_GROUP`     | `AFP_USER`'s group that owns the shared volume                 |
 | `AFP_UID`       | Specify user id of `AFP_USER`                                  |
 | `AFP_GID`       | Specify group id of `AFP_GROUP`                                |
 | `SERVER_NAME`   | The name of the server reported to Zeroconf                    |
@@ -83,3 +84,4 @@ These are required to set the credentials used to authenticate with the file ser
 | `AFP_LOGLEVEL`  | The verbosity of logs; default is "info"                       |
 | `INSECURE_AUTH` | When non-zero, enable the "ClearTxt" and "Guest" UAMs          |
 | `MANUAL_CONFIG` | When non-zero, enable manual management of config files        |
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - AFP_USER=
       - AFP_PASS=
+      - AFP_GROUP=afpusers
       - ATALKD_INTERFACE=
       - TZ=
 volumes:


### PR DESCRIPTION
The AFP users are now added to their own groups as well as AFP_GROUP, for consistency.

The shared dirs are owned by root:AFP_GROUP

Also adds a second AFP user controlled with AFP_USER2/AFP_PASS2

Clean up atalkd and papd lockfiles