### PR TITLE
[3.2] docs: Remove straggler path substitution in afp.conf

### DIFF
--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -462,8 +462,7 @@
           <type>(G)</type></term>
 
           <listitem>
-            <para>Sets the default path for UAMs for this server (default is
-            @libdir@/netatalk).</para>
+            <para>Sets the default path for UAMs for this server.</para>
           </listitem>
         </varlistentry>
       </variablelist>


### PR DESCRIPTION
These substitutions don't result in consistent results cross platform. The others were removed some time ago.