### PR TITLE
docker: The ability to customize the secondary shared volume

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,8 +1,8 @@
 # Docker
 
-Netatalk comes with a Dockerfile and entry point script for running a containerized AFP server.
+Netatalk comes with a Dockerfile and entry point script for running a containerized AFP server and AppleTalk services.
 
-For simplicity, exactly one user, one shared volume, and one Time Machine volume is supported. It is hard coded to output afpd logs to the container's stdout, default info log level.
+Out of the box, exactly two users, and two shared volumes are supported in this container. One of the shared volumes is a Time Machine backup volume by default. If you need a different setup, please use the manual configuration option.
 
 Make sure you have Docker Engine installed, then build the netatalk container:
 
@@ -10,20 +10,20 @@ Make sure you have Docker Engine installed, then build the netatalk container:
 docker build -t netatalk:latest .
 ```
 
-Alternatively, pull a pre-built Docker container from [Docker Hub](https://hub.docker.com/u/netatalk).
+Alternatively, pull a pre-built Docker image from [Docker Hub](https://hub.docker.com/u/netatalk).
 
 ## How to Run
 
-Once the container is ready, run it with `docker run` or `docker compose`.
+Once you have the netatalk image on your machine with Docker Engine, run it with `docker run` or `docker compose`.
 When running, expose either port 548 for AFP, or use the `host` network driver.
-The former option is more secure, but you will have to manually specify the IP address when connecting to the file server.
+The former option is more secure, but you will have to manually specify the IP address in the client when connecting to the file server.
 
 It is recommended to set up either a bind mount, or a Docker managed volume for persistent storage.
 Without this, the shared volume be stored in volatile storage that is lost upon container shutdown.
 
-You can use the sample [docker-compose.yml](https://github.com/Netatalk/netatalk/blob/main/docker-compose.yml) that is distributed with this source code.
+For Docker Compose, you can use the sample [docker-compose.yml](https://github.com/Netatalk/netatalk/blob/main/docker-compose.yml) file that is distributed with this source code.
 
-Below follows a sample `docker run` command. Substitute `/path/to/share` with an actual path on your file system with appropriate permissions, and `AFP_USER` and `AFP_PASS` with the appropriate user and password, and `ATALKD_INTERFACE` with the network interface to use for AppleTalk.
+Below follows a sample `docker run` command. Substitute `/path/to/share` with an actual path on your file system with appropriate permissions, `AFP_USER` and `AFP_PASS` with the appropriate user and password, and `ATALKD_INTERFACE` with the network interface to use for AppleTalk.
 
 You also need to set the timezone with `TZ` to the [IANA time zone ID](https://nodatime.org/TimeZones) for your location, in order to get the correct time synchronized with the Timelord time server.
 
@@ -44,9 +44,11 @@ docker run --rm \
 
 ## Constraints
 
-In order to use Zeroconf service discovery and the AppleTalk transport layer, the container requires the "host" network driver and NET_ADMIN capabilities.
+In order to use Zeroconf service discovery as well as the AppleTalk transport layer, the `host` network driver and `NET_ADMIN` capabilities are mandatory.
 
-Additionally, we rely on the host's DBUS for Zeroconf, achieved with a bind mount for `/var/run/dbus:/var/run/dbus`.
+Additionally, we rely on the host's DBUS for Zeroconf, achieved with a bind mount such as `/var/run/dbus:/var/run/dbus`. The left hand side of the bind mount is the host machine, and the right hand side is the container. The host machine path may have to be changed to match the location of DBUS on the host machine.
+
+The container is hard coded to output `afpd` (the Netatalk file server daemon) logs to the container's stdout, with default log level `info`. Logs from the AppleTalk daemons are sent to the syslog.
 
 ## Printing
 
@@ -62,8 +64,8 @@ These are required to set the credentials used to authenticate with the file ser
 
 | Variable | Description |
 | --- | --- |
-| `AFP_USER` | Username to authenticate with the file server |
-| `AFP_PASS` | Password to authenticate with the file server |
+| `AFP_USER` | Primary user of the shared volumes |
+| `AFP_PASS` | Password to authenticate with the primary user |
 | `AFP_GROUP` | Group that owns the shared volume dirs |
 
 ### Mandatory for AppleTalk
@@ -79,9 +81,12 @@ These are required to set the credentials used to authenticate with the file ser
 |-----------------|----------------------------------------------------------------|
 | `AFP_UID`       | Specify user id of `AFP_USER`                                  |
 | `AFP_GID`       | Specify group id of `AFP_GROUP`                                |
+| `AFP_USER2`     | Username for the secondary user                                |
+| `AFP_PASS2`     | Password for the secondary user                                |
 | `SERVER_NAME`   | The name of the server reported to Zeroconf                    |
-| `SHARE_NAME`    | The name of the file sharing volume                            |
+| `SHARE_NAME`    | The name of the primary shared volume                          |
+| `SHARE2_NAME`   | The name of the secondary shared (Time Machine) volume         |
 | `AFP_LOGLEVEL`  | The verbosity of logs; default is "info"                       |
 | `INSECURE_AUTH` | When non-zero, enable the "ClearTxt" and "Guest" UAMs          |
+| `DISABLE_TIMEMACHINE` | When non-zero, the secondary shared volume is a regular volume |
 | `MANUAL_CONFIG` | When non-zero, enable manual management of config files        |
-

--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -60,7 +60,7 @@ if [ $? -ne 0 ]; then
 fi
 set -e
 
-# Crude way to create a second AFP user for testing purposes
+# Crude way to create a second AFP user
 if [ ! -z "${AFP_USER2}" ]; then
     adduser --no-create-home --disabled-password "${AFP_USER2}" || true 2> /dev/null
     addgroup ${AFP_USER2} ${AFP_GROUP}
@@ -122,6 +122,12 @@ if [ ! -z "${INSECURE_AUTH}" ]; then
     UAMS+=" uams_clrtxt.so uams_guest.so"
 fi
 
+if [ ! -z "${DISABLE_TIMEMACHINE}" ]; then
+    TIMEMACHINE="no"
+else
+    TIMEMACHINE="yes"
+fi
+
 if [ -z "${MANUAL_CONFIG}" ]; then
     echo "*** Configuring Netatalk"
     cat <<EOF > /usr/local/etc/afp.conf
@@ -138,10 +144,13 @@ valid users = ${AFP_USER} ${AFP_USER2}
 rwlist = ${AFP_USER} ${AFP_USER2}
 file perm = 0660
 directory perm = 0770
-[Time Machine]
+[${SHARE2_NAME:-Time Machine}]
 path = /mnt/afpbackup
-time machine = yes
+time machine = ${TIMEMACHINE}
 valid users = ${AFP_USER} ${AFP_USER2}
+rwlist = ${AFP_USER} ${AFP_USER2}
+file perm = 0660
+directory perm = 0770
 EOF
 fi
 


### PR DESCRIPTION
Rather than hard coding the secondary shared volume as Time Machine, allow the user to use it as a regular volume.

This is required for afptest.