### PR TITLE
Switch Randnum UAM to use libgcrypt

### DIFF
--- a/bin/afppasswd/meson.build
+++ b/bin/afppasswd/meson.build
@@ -13,11 +13,8 @@ if use_mysql_backend
     afppasswd_deps += mysqlclient
 endif
 
-if have_wolfssl and not have_ssl_override
-    afppasswd_deps += [nettle, wolfssl]
-elif have_embedded_ssl
-    afppasswd_libs += libatalk
-    afppasswd_deps += nettle
+if have_libgcrypt
+    afppasswd_deps += [libgcrypt]
 endif
 
 executable(

--- a/etc/uams/meson.build
+++ b/etc/uams/meson.build
@@ -43,23 +43,7 @@ if have_embedded_ssl
 endif
 
 if have_ssl
-    uams_randnum_sources = ['uams_randnum.c']
     uams_dhx_passwd_sources = ['uams_dhx_passwd.c']
-
-    library(
-        'uams_randnum',
-        uams_randnum_sources,
-        include_directories: root_includes,
-        dependencies: [crack, pam, ssl_deps, nettle],
-        link_with: ssl_links,
-        name_prefix: '',
-        name_suffix: lib_suffix,
-        override_options: 'b_lundef=false',
-        install: true,
-        install_dir: libdir / 'netatalk',
-        build_rpath: rpath_libdir,
-        install_rpath: rpath_libdir,
-    )
 
     library(
         'uams_dhx_passwd',
@@ -111,7 +95,22 @@ if have_ssl
 endif
 
 if have_libgcrypt
+    uams_randnum_sources = ['uams_randnum.c']
     uams_dhx2_passwd_sources = ['uams_dhx2_passwd.c']
+
+    library(
+        'uams_randnum',
+        uams_randnum_sources,
+        include_directories: root_includes,
+        dependencies: [crack, pam, libgcrypt],
+        name_prefix: '',
+        name_suffix: lib_suffix,
+        override_options: 'b_lundef=false',
+        install: true,
+        install_dir: libdir / 'netatalk',
+        build_rpath: rpath_libdir,
+        install_rpath: rpath_libdir,
+    )
 
     library(
         'uams_dhx2_passwd',


### PR DESCRIPTION
Switches the RandNum UAM and afppasswd utility from using WolfSSL+Nettle to libgcrypt for DES encryption functions.

Adopted from : https://sourceforge.net/p/netatalk/feature-requests/60/