### PR TITLE
[2.4] meson: Use a valid code snippet for the TCP Wrappers check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -402,9 +402,13 @@ jobs:
         run: make distcheck
       - name: Autotools - Install
         run: sudo make install
-      - name: Start netatalk
-        run: sudo systemctl start afpd && sleep 2 && asip-status localhost
-      - name: Stop netatalk
+      - name: Autotools - Start netatalk
+        run: |
+          /usr/local/sbin/afpd -V
+          sudo systemctl start afpd
+          sleep 2
+          asip-status localhost
+      - name: Autotools - Stop netatalk
         run: sudo systemctl stop afpd
       - name: Autotools - Uninstall
         run: sudo make uninstall
@@ -416,7 +420,7 @@ jobs:
             -Dwith-init-style=systemd \
             -Dwith-quota=true \
             -Dwith-tests=true
-      - name: Meson - Build and generate man pages
+      - name: Meson - Build
         run: meson compile -C build
       - name: Meson - Tests
         run: cd build && meson test
@@ -424,9 +428,13 @@ jobs:
         run: cd build && meson dist
       - name: Meson - Install
         run: sudo meson install -C build
-      - name: Start netatalk
-        run: sudo systemctl start afpd && sleep 2 && asip-status localhost
-      - name: Stop netatalk
+      - name: Meson - Start netatalk
+        run: |
+          /usr/local/sbin/afpd -V
+          sudo systemctl start afpd
+          sleep 2
+          asip-status localhost
+      - name: Meson - Stop netatalk
         run: sudo systemctl stop afpd
       - name: Meson - Uninstall
         run: sudo ninja -C build uninstall
@@ -460,9 +468,13 @@ jobs:
         run: make check
       - name: Autotools - Install
         run: sudo make install
-      - name: Start netatalk
-        run: sudo netatalkd start && sleep 2 && asip-status localhost
-      - name: Stop netatalk
+      - name: Autotools - Start netatalk
+        run: |
+          /usr/local/sbin/afpd -V
+          sudo netatalkd start
+          sleep 2
+          asip-status localhost
+      - name: Autotools - Stop netatalk
         run: sudo netatalkd stop
       - name: Autotools - Uninstall
         run: sudo make uninstall
@@ -477,9 +489,13 @@ jobs:
         run: cd build && meson test
       - name: Meson - Install
         run: sudo meson install -C build
-      - name: Start netatalk
-        run: sudo netatalkd start && sleep 2 && asip-status localhost
-      - name: Stop netatalk
+      - name: Meson - Start netatalk
+        run: |
+          /opt/homebrew/sbin/afpd -V
+          sudo netatalkd start
+          sleep 2
+          asip-status localhost
+      - name: Meson - Stop netatalk
         run: sudo netatalkd stop
       - name: Meson - Uninstall
         run: sudo ninja -C build uninstall
@@ -568,12 +584,14 @@ jobs:
               PKG_CONFIG_PATH=/usr/local/libdata/pkgconfig
             gmake -j $(nproc)
             gmake install
+            /usr/local/sbin/afpd -V
             gmake uninstall
             echo "Building with Meson"
             meson setup build \
               -Dpkg_config_path=/usr/local/libdata/pkgconfig
             meson compile -C build
             meson install -C build
+            /usr/local/sbin/afpd -V
             ninja -C build uninstall
 
   build-netbsd:
@@ -615,6 +633,7 @@ jobs:
               --enable-pgp-uam
             gmake -j $(nproc)
             gmake install
+            /usr/local/sbin/afpd -V
             service afpd onestart
             sleep 2
             asip-status localhost
@@ -629,6 +648,7 @@ jobs:
             cd build && meson test
             cd ..
             meson install -C build
+            /usr/local/sbin/afpd -V
             service afpd onestart
             sleep 2
             asip-status localhost
@@ -675,6 +695,7 @@ jobs:
               PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
             gmake -j $(nproc)
             gmake install
+            /usr/local/sbin/afpd -V
             gmake uninstall
             echo "Building with Meson"
             meson setup build \
@@ -682,6 +703,7 @@ jobs:
               -Dwith-ddp=false
             meson compile -C build
             meson install -C build
+            /usr/local/sbin/afpd -V
             ninja -C build uninstall
 
   build-omnios:
@@ -722,6 +744,7 @@ jobs:
               --without-ldap
             make -j $(nproc)
             make install
+            /usr/local/sbin/afpd -V
             make uninstall
             echo "Building with Meson"
             meson setup build \
@@ -731,6 +754,7 @@ jobs:
               -Dwith-pgp-uam=true
             meson compile -C build
             meson install -C build
+            /usr/local/sbin/afpd -V
             chmod 744 /etc/rc2.d/S90netatalk
             chmod 744 /etc/rc0.d/K04netatalk
             /etc/rc2.d/S90netatalk start
@@ -785,6 +809,7 @@ jobs:
               --enable-cups=no
             gmake -j $(nproc) all
             gmake install
+            /usr/local/sbin/afpd -V
             gmake uninstall
             echo "Building with Meson"
             meson setup build \
@@ -796,6 +821,7 @@ jobs:
             cd build && meson test
             cd ..
             meson install -C build
+            /usr/local/sbin/afpd -V
             chmod 744 /etc/rc2.d/S90netatalk
             chmod 744 /etc/rc0.d/K04netatalk
             /etc/rc2.d/S90netatalk start

--- a/meson.build
+++ b/meson.build
@@ -1701,13 +1701,10 @@ if not enable_tcpwrap
     have_tcpwrap = false
 else
     tcpwrap_code = '''
-int allow_severity = 0;
-int deny_severity = 0;
-
+#include <tcpd.h>
 int main(void) {
-
-    hosts_access();
-
+    int allow_severity = 0;
+    int deny_severity = 0;
     ;
     return 0;
 }


### PR DESCRIPTION
The code snippet used to detect a working libwrap was incorrect.