### PR TITLE
meson: Throw missing cracklib dictionary warning separately

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ env:
   APT_PACKAGES: |
     bison \
     cmark-gfm \
+    cracklib-runtime \
     docbook-xsl \
     file \
     flex \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -93,7 +93,7 @@ Required for Spotlight support:
 Optional:
 
   - avahi or mDNSresponder           (for Zeroconf support)
-  - cracklib                         (for cracklib support)
+  - cracklib and cracklib dictionary (for password strength check in afppasswd)
   - Docbook XSL and xsltproc         (for manpages & manual documentation)
   - GLib 2 and dbus-glib             (for afpstats support)
   - Kerberos V                       (for krbV UAM support)

--- a/doc/ja/manual/install.xml
+++ b/doc/ja/manual/install.xml
@@ -173,6 +173,8 @@ Resolving deltas: 100% (32227/32227), done.
             <para>Random Number UAM と netatalk 独自の
             <userinput>afppasswd</userinput> パスワード マネージャを使用する場合、CrackLib は
             netatalk での認証に弱いパスワードを設定するのを防ぐのに役立ちます。</para>
+
+            <para>ランタイム パッケージで別途配布されることもある CrackLib 辞書も必須である。</para>
           </listitem>
 
           <listitem>

--- a/doc/manual/install.xml
+++ b/doc/manual/install.xml
@@ -188,6 +188,9 @@ Resolving deltas: 100% (32227/32227), done.
             <userinput>afppasswd</userinput> password manager, CrackLib can
             help protect against setting weak passwords for authentication
             with netatalk.</para>
+
+            <para>The CrackLib dictionary, which is sometimes distributed
+            separately in a runtime package, is also a requirement.</para>
           </listitem>
 
           <listitem>

--- a/meson.build
+++ b/meson.build
@@ -1989,7 +1989,12 @@ else
         endif
     else
         have_cracklib = false
-        warning('Cracklib support requested but cracklib library not found')
+        if not crack.found()
+            warning('Cracklib support requested but cracklib library not found')
+        endif
+        if not (cracklib_path != '' or cracklib_dict != '')
+            warning('Cracklib support requested but cracklib dictionary not found')
+        endif
     endif
 endif
 


### PR DESCRIPTION
Some distributions package the cracklib library and the cracklib dictionary separately. Both are required to build netatalk with cracklib support. This change is to indicate which one is missing in the setup log.