### PR TITLE
[3.2] meson: Throw missing cracklib dictionary warning separately

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ env:
     autoconf \
     automake \
     bison \
+    cracklib-runtime \
     docbook-xsl \
     flex \
     libacl1-dev \

--- a/meson.build
+++ b/meson.build
@@ -1898,7 +1898,12 @@ else
         endif
     else
         have_cracklib = false
-        warning('Cracklib support requested but cracklib library not found')
+        if not crack.found()
+            warning('Cracklib support requested but cracklib library not found')
+        endif
+        if not (cracklib_path != '' or cracklib_dict != '')
+            warning('Cracklib support requested but cracklib dictionary not found')
+        endif
     endif
 endif
 


### PR DESCRIPTION
Some distributions package the cracklib library and the cracklib dictionary separately. Both are required to build netatalk with cracklib support. This change is to indicate which one is missing in the setup log.