### PR TITLE
[2.4] meson: Throw missing cracklib dictionary warning separately

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ env:
   APT_PACKAGES: |
     autoconf \
     automake \
+    cracklib-runtime \
     docbook-xsl \
     libacl1-dev \
     libavahi-client-dev \

--- a/meson.build
+++ b/meson.build
@@ -1685,7 +1685,12 @@ else
         endif
     else
         have_cracklib = false
-        warning('Cracklib support requested but cracklib library not found')
+        if not crack.found()
+            warning('Cracklib support requested but cracklib library not found')
+        endif
+        if not (cracklib_path != '' or cracklib_dict != '')
+            warning('Cracklib support requested but cracklib dictionary not found')
+        endif
     endif
 endif
 


### PR DESCRIPTION
Some distributions package the cracklib library and the cracklib dictionary separately. Both are required to build netatalk with cracklib support. This change is to indicate which one is missing in the setup log.