### PR TITLE
meson: Format afpd help text output to match autotools

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1168,7 +1168,7 @@ else
 endif
 
 if have_ea
-    netatalk_ea += '|sys"'
+    netatalk_ea += ' | sys"'
     ea_summary += ', filesystem EA'
 else
     netatalk_ea += '"'


### PR DESCRIPTION
Inject spaces between the two EA types, to synchronize the output of afpd -V build by Meson and Autotools.