### PR TITLE
[2.4] meson: Format afpd help text output to match autotools

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1059,7 +1059,7 @@ else
 endif
 
 if have_ea
-    netatalk_ea = ea + '|sys"'
+    netatalk_ea = ea + ' | sys"'
 else
     netatalk_ea = ea + '"'
 endif


### PR DESCRIPTION
Inject spaces between the two EA types, to synchronize the output of afpd -V build by Meson and Autotools.