### PR TITLE
GitHub CI: Bump vmactions image versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -410,7 +410,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/dragonflybsd-vm@v1.0.7
+        uses: vmactions/dragonflybsd-vm@v1.0.8
         with:
           copyback: false
           usesh: true
@@ -457,7 +457,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/freebsd-vm@v1.1.1
+        uses: vmactions/freebsd-vm@v1.1.3
         with:
           copyback: false
           prepare: |
@@ -506,7 +506,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/netbsd-vm@v1.1.1
+        uses: vmactions/netbsd-vm@v1.1.3
         with:
           release: "9.4"
           copyback: false
@@ -560,7 +560,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/openbsd-vm@v1.1.1
+        uses: vmactions/openbsd-vm@v1.1.2
         with:
           copyback: false
           prepare: |


### PR DESCRIPTION
Bumping all images except Solaris which I keep at 1.0.7 because the runtime balloons by 3min in 1.0.9