### PR TITLE
[3.2] GitHub CI: Bump vmactions image versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -598,7 +598,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/dragonflybsd-vm@v1.0.7
+        uses: vmactions/dragonflybsd-vm@v1.0.8
         with:
           copyback: false
           usesh: true
@@ -655,7 +655,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/freebsd-vm@v1.1.1
+        uses: vmactions/freebsd-vm@v1.1.3
         with:
           copyback: false
           prepare: |
@@ -723,7 +723,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/netbsd-vm@v1.1.1
+        uses: vmactions/netbsd-vm@v1.1.3
         with:
           release: "9.4"
           copyback: false
@@ -795,7 +795,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/openbsd-vm@v1.1.1
+        uses: vmactions/openbsd-vm@v1.1.2
         with:
           copyback: false
           prepare: |


### PR DESCRIPTION
Bumping all images except Solaris and OmniOS which I keep at 1.0.7 and 1.0.6 respectively, because the runtime balloons by several minutes in the latest images.