### PR TITLE
[3.x] Fix tickle handler

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -48,7 +48,7 @@ option(
 option(
     'with-debugging',
     type: 'boolean',
-    value: true,
+    value: false,
     description: 'Enable SIGALARM timers and DSI tickles (eg for debugging with gdb/dbx/...)',
 )
 option(


### PR DESCRIPTION
Debugging was enabled by default in `meson_options.txt` in 3.x branch causing tickles to not be sent out. Fixes #1514.