### PR TITLE
[3.2] docker: We disable afpstats so dbus-glib is superfluous

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV LIB_DEPS \
     bash \
     db \
     dbus \
-    dbus-glib \
     krb5 \
     libevent \
     libgcrypt \
@@ -25,7 +24,6 @@ ENV BUILD_DEPS \
     curl \
     db-dev \
     dbus-dev \
-    dbus-glib-dev \
     build-base \
     flex \
     gcc \


### PR DESCRIPTION
Removing an unused dependent library.