### PR TITLE
[2.4] cnid_dbd: Set explicit max length of db_params to prevent buffer overflow

### DIFF
--- a/etc/cnid_dbd/db_param.c
+++ b/etc/cnid_dbd/db_param.c
@@ -85,11 +85,6 @@ static int parse_int(char *val)
     return result;
 }
 
-
-/* TODO: This configuration file reading routine is neither very robust (%s
-   buffer overflow) nor elegant, we need to add support for whitespace in
-   filenames as well. */
-
 struct db_param *db_param_read(char *dir)
 {
     FILE *fp;
@@ -121,7 +116,7 @@ struct db_param *db_param_read(char *dir)
     }
     parse_err = 0;
 
-    while ((items = fscanf(fp, " %s %s", key, val)) != EOF) {
+    while ((items = fscanf(fp, " %64s %1024s", key, val)) != EOF) {
         if (items != 2) {
             LOG(log_error, logtype_cnid, "error parsing config file");
             parse_err++;


### PR DESCRIPTION
Security vulnerability flagged by Sonarcloud and picked up by GitHub. 

https://github.com/Netatalk/netatalk/security/code-scanning/2