### PR TITLE
uams: Correct shadow password length check for ClearTxt

### DIFF
--- a/etc/uams/uams_passwd.c
+++ b/etc/uams/uams_passwd.c
@@ -55,7 +55,7 @@ static int pwd_login(void *obj, char *username, int ulen, struct passwd **uam_pw
     struct spwd *sp;
 #endif /* SHADOWPW */
 
-    if (ibuflen <= PASSWDLEN) {
+    if (ibuflen < PASSWDLEN) {
         return( AFPERR_PARAM );
     }
     ibuf[ PASSWDLEN ] = '\0';


### PR DESCRIPTION
ibuflen should be '8' after stripping the username (and optional one byte pad) and match PASSWDLEN