### PR TITLE
Update systemd.netatalk.service.in to support atalkd

### DIFF
--- a/distrib/initscripts/systemd.netatalk.service.in
+++ b/distrib/initscripts/systemd.netatalk.service.in
@@ -4,7 +4,7 @@
 Description=Netatalk AFP fileserver for Macintosh clients
 Documentation=man:afp.conf(5) man:netatalk(8) man:afpd(8) man:cnid_metad(8) man:cnid_dbd(8)
 Documentation=https://netatalk.io/
-After=network.target avahi-daemon.service
+After=network.target avahi-daemon.service atalkd.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
Allow for loading atalkd before starting the AFP server, like 2.x did.