### PR TITLE
Cleanup libgcrypt initialization

### DIFF
--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -180,7 +180,9 @@ static int dhx_setup(void *obj, const unsigned char *ibuf, size_t ibuflen _U_,
     uint16_t sessid;
     size_t i;
     size_t nwritten;
-    gcry_check_version(GCRYPT_VERSION);
+
+    if (!gcry_check_version(GCRYPT_VERSION))
+        LOG(log_info, logtype_uams, "uams_dhx_pam.c : libgcrypt versions mismatch. Need: %s", GCRYPT_VERSION);
 
     gcry_mpi_t p, g, Rb, Ma, Mb;
     p = gcry_mpi_new(0);

--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -62,7 +62,9 @@ static int pwd_login(void *obj, char *username, int ulen, struct passwd **uam_pw
     uint16_t sessid;
     size_t nwritten;
     size_t i;
-    gcry_check_version(GCRYPT_VERSION);
+
+    if (!gcry_check_version(GCRYPT_VERSION))
+        LOG(log_info, logtype_uams, "uams_dhx_passwd.c : libgcrypt versions mismatch. Need: %s", GCRYPT_VERSION);
 
     gcry_mpi_t p, g, Rb, Ma, Mb;
     p = gcry_mpi_new(0);

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -134,6 +134,9 @@ static int afppasswd(const struct passwd *pwd,
   gcry_cipher_hd_t ctx;
   gcry_error_t ctxerror;
 
+  if (!gcry_check_version(GCRYPT_VERSION))
+      LOG(log_info, logtype_uams, "RandNum: libgcrypt versions mismatch. Need: %s", GCRYPT_VERSION);
+
   if ((fp = fopen(path, (set) ? "r+" : "r")) == NULL) {
     LOG(log_error, logtype_uams, "Failed to open %s", path);
     return AFPERR_ACCESS;
@@ -427,6 +430,9 @@ static int randnum_changepw(void *obj, const char *username _U_,
     gcry_cipher_hd_t ctx;
     gcry_error_t ctxerror;
 
+    if (!gcry_check_version(GCRYPT_VERSION))
+        LOG(log_info, logtype_uams, "RandNum: libgcrypt versions mismatch. Need: %s", GCRYPT_VERSION);
+
     if (uam_checkuser(pwd) < 0)
       return AFPERR_ACCESS;
 
@@ -487,9 +493,6 @@ static int randnum_login(void *obj, struct passwd **uam_pwd,
     size_t len, ulen;
 
     *rbuflen = 0;
-
-    if (!gcry_check_version(GCRYPT_VERSION))
-        LOG(log_info, logtype_uams, "RandNum: libgcrypt versions mismatch. Need: %s", GCRYPT_VERSION);
 
     if (uam_afpserver_option(obj, UAM_OPTION_USERNAME,
                              (void *) &username, &ulen) < 0)


### PR DESCRIPTION
Fix for libgcrypt libraries that weren't consistently being initialized depending on how a user logged in.