### PR TITLE
[3.2] meson: Capture only defined capability flags in wolfssl check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,7 +108,8 @@ jobs:
             talloc-dev \
             tracker \
             tracker-dev \
-            tracker-miners
+            tracker-miners \
+            wolfssl
       - name: Autotools - Bootstrap
         run: ./bootstrap
       - name: Autotools - Configure
@@ -171,7 +172,8 @@ jobs:
             meson \
             ninja \
             pkgconfig \
-            rpcsvc-proto
+            rpcsvc-proto \
+            wolfssl
       - name: Autotools - Bootstrap
         run: ./bootstrap
       - name: Autotools - Configure
@@ -554,7 +556,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
-        run: brew install automake berkeley-db libressl libtool meson mysql talloc
+        run: brew install automake berkeley-db libressl libtool meson mysql talloc wolfssl
       - name: Autotools - Bootstrap
         run: ./bootstrap
       - name: Autotools - Configure
@@ -635,7 +637,8 @@ jobs:
               py39-sqlite3 \
               py39-tkinter \
               talloc \
-              tracker3
+              tracker3 \
+              wolfssl
           run: |
             set -e
             echo "Building with Autotools"
@@ -688,7 +691,8 @@ jobs:
               openldap26-client-2.6.8 \
               pkgconf \
               talloc \
-              tracker3
+              tracker3 \
+              wolfssl
           run: |
             set -e
             echo "Building with Autotools"
@@ -760,7 +764,8 @@ jobs:
               p5-Net-DBus \
               perl \
               pkg-config \
-              talloc
+              talloc \
+              wolfssl
           run: |
             set -e
             echo "Building with Autotools"

--- a/meson.build
+++ b/meson.build
@@ -499,10 +499,10 @@ if wolfssl.found()
     ).stdout().strip()
 
     if (
-        wolfssl_check.contains('HAVE_DH_DEFAULT_PARAMS')
-        and wolfssl_check.contains('WOLFSSL_DES_ECB')
-        and wolfssl_check.contains('OPENSSL_EXTRA')
-        and wolfssl_check.contains('OPENSSL_ALL')
+        wolfssl_check.contains('#define HAVE_DH_DEFAULT_PARAMS')
+        and wolfssl_check.contains('#define WOLFSSL_DES_ECB')
+        and wolfssl_check.contains('#define OPENSSL_EXTRA')
+        and wolfssl_check.contains('#define OPENSSL_ALL')
     )
         have_wolfssl = true
         have_embedded_ssl = false


### PR DESCRIPTION
Use a more specific pattern to match the wolfssl capability definitions. This avoids a false positive with the wolfssl headers that Arch Linux distributes.