### PR TITLE
initscripts: add atalkd dependencies and remove NBP unregister steps

### DIFF
--- a/distrib/initscripts/debian.a2boot.in
+++ b/distrib/initscripts/debian.a2boot.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          a2boot
-# Required-Start:    $remote_fs $syslog
+# Required-Start:    $remote_fs $syslog atalkd
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6

--- a/distrib/initscripts/debian.atalkd.in
+++ b/distrib/initscripts/debian.atalkd.in
@@ -49,8 +49,6 @@ case "$1" in
 
     stop)
         echo -n "Stopping $NAME"
-        @bindir@/nbpunrgstr "$ATALK_NAME:Workstation"
-        @bindir@/nbpunrgstr "$ATALK_NAME:netatalk"
         start-stop-daemon --stop --quiet --oknodo --pidfile $PIDFILE
         echo "."
         ;;

--- a/distrib/initscripts/debian.netatalk.in
+++ b/distrib/initscripts/debian.netatalk.in
@@ -2,7 +2,7 @@
 ### BEGIN INIT INFO
 # Provides:          netatalk
 # Required-Start:    $remote_fs $syslog
-# Should-Start:      avahi-daemon
+# Should-Start:      avahi-daemon atalkd
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6

--- a/distrib/initscripts/debian.papd.in
+++ b/distrib/initscripts/debian.papd.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          papd
-# Required-Start:    $remote_fs $syslog
+# Required-Start:    $remote_fs $syslog atalkd
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6

--- a/distrib/initscripts/debian.timelord.in
+++ b/distrib/initscripts/debian.timelord.in
@@ -1,7 +1,7 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          timelord
-# Required-Start:    $remote_fs $syslog
+# Required-Start:    $remote_fs $syslog atalkd
 # Required-Stop:     $remote_fs $syslog
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6

--- a/distrib/initscripts/openrc.atalkd.in
+++ b/distrib/initscripts/openrc.atalkd.in
@@ -30,12 +30,4 @@ stop() {
     ebegin "Stopping $name"
     start-stop-daemon --stop --quiet --exec @sbindir@/$name
     eend $?
-    for reg in \
-        "${ATALK_NAME}:Workstation" \
-        "${ATALK_NAME}:netatalk"
-    do
-        ebegin "Unregistering $reg"
-        @bindir@/nbpunrgstr "$reg"
-        eend $?
-    done
 }

--- a/distrib/initscripts/openrc.netatalk.in
+++ b/distrib/initscripts/openrc.netatalk.in
@@ -11,4 +11,5 @@ depend() {
 		need net
 		use logger dns
 		use avahi-daemon
+		use atalkd
 }


### PR DESCRIPTION
Touching up the Debian sysv and OpenRC init script handling of atalkd startup and shutdown.