### PR TITLE
uams: Disable incorrect libgcrypt library version validation

### DIFF
--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -72,8 +72,10 @@ static int dh_params_generate (unsigned int bits) {
 
     /* Version check should be the very first call because it
        makes sure that important subsystems are initialized. */
-    if (!gcry_check_version (GCRYPT_VERSION)) {
-        LOG(log_error, logtype_uams, "PAM DHX2: libgcrypt versions mismatch. Need: %s", GCRYPT_VERSION);
+    if (!gcry_check_version (UAM_NEED_LIBGCRYPT_VERSION)) {
+        LOG(log_error, logtype_uams,
+            "PAM DHX2: libgcrypt versions mismatch. Needs: %s Has: %s",
+            UAM_NEED_LIBGCRYPT_VERSION, gcry_check_version (NULL));
         result = AFPERR_MISC;
         goto error;
     }

--- a/etc/uams/uams_dhx2_passwd.c
+++ b/etc/uams/uams_dhx2_passwd.c
@@ -78,8 +78,10 @@ dh_params_generate (gcry_mpi_t *ret_p, gcry_mpi_t *ret_g, unsigned int bits) {
 
     /* Version check should be the very first call because it
        makes sure that important subsystems are initialized. */
-    if (!gcry_check_version (GCRYPT_VERSION)) {
-        LOG(log_info, logtype_uams, "PAM DHX2: libgcrypt versions mismatch. Need: %s", GCRYPT_VERSION);
+    if (!gcry_check_version (UAM_NEED_LIBGCRYPT_VERSION)) {
+        LOG(log_error, logtype_uams,
+            "DHX2: libgcrypt versions mismatch. Needs: %s Has: %s",
+            UAM_NEED_LIBGCRYPT_VERSION, gcry_check_version (NULL));
         result = AFPERR_MISC;
         goto error;
     }

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -181,8 +181,12 @@ static int dhx_setup(void *obj, const unsigned char *ibuf, size_t ibuflen _U_,
     size_t i;
     size_t nwritten;
 
-    if (!gcry_check_version(GCRYPT_VERSION))
-        LOG(log_info, logtype_uams, "uams_dhx_pam.c : libgcrypt versions mismatch. Need: %s", GCRYPT_VERSION);
+    if (!gcry_check_version(UAM_NEED_LIBGCRYPT_VERSION)) {
+        LOG(log_error, logtype_uams,
+            "uams_dhx_pam.c: libgcrypt versions mismatch. Needs: %s Has: %s",
+            UAM_NEED_LIBGCRYPT_VERSION, gcry_check_version(NULL));
+        return AFPERR_MISC;
+    }
 
     gcry_mpi_t p, g, Rb, Ma, Mb;
     p = gcry_mpi_new(0);

--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -63,8 +63,12 @@ static int pwd_login(void *obj, char *username, int ulen, struct passwd **uam_pw
     size_t nwritten;
     size_t i;
 
-    if (!gcry_check_version(GCRYPT_VERSION))
-        LOG(log_info, logtype_uams, "uams_dhx_passwd.c : libgcrypt versions mismatch. Need: %s", GCRYPT_VERSION);
+    if (!gcry_check_version(UAM_NEED_LIBGCRYPT_VERSION)) {
+        LOG(log_error, logtype_uams,
+            "uams_dhx_passwd.c: libgcrypt versions mismatch. Needs: %s Has: %s",
+            UAM_NEED_LIBGCRYPT_VERSION, gcry_check_version(NULL));
+        return AFPERR_MISC;
+    }
 
     gcry_mpi_t p, g, Rb, Ma, Mb;
     p = gcry_mpi_new(0);

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -134,8 +134,12 @@ static int afppasswd(const struct passwd *pwd,
   gcry_cipher_hd_t ctx;
   gcry_error_t ctxerror;
 
-  if (!gcry_check_version(GCRYPT_VERSION))
-      LOG(log_info, logtype_uams, "RandNum: libgcrypt versions mismatch. Need: %s", GCRYPT_VERSION);
+  if (!gcry_check_version(UAM_NEED_LIBGCRYPT_VERSION)) {
+      LOG(log_error, logtype_uams,
+          "UAM RandNum: libgcrypt versions mismatch. Needs: %s Has: %s",
+          UAM_NEED_LIBGCRYPT_VERSION, gcry_check_version(NULL));
+      return AFPERR_MISC;
+  }
 
   if ((fp = fopen(path, (set) ? "r+" : "r")) == NULL) {
     LOG(log_error, logtype_uams, "Failed to open %s", path);

--- a/include/atalk/uam.h
+++ b/include/atalk/uam.h
@@ -20,6 +20,9 @@
 /* in case something drastic has to change */
 #define UAM_MODULE_VERSION       1
 
+/* define if minimum version of libgcrypt is required */
+#define UAM_NEED_LIBGCRYPT_VERSION  NULL
+
 /* things for which we can have uams */
 #define UAM_SERVER_LOGIN         (1 << 0)
 #define UAM_SERVER_CHANGEPW      (1 << 1)


### PR DESCRIPTION
This removes the overzealous check for the exact libgcrypt version that netatalk was linked with.
At the same time, add scaffolding for future libgcrypt minimum version validation.