### PR TITLE
[3.2] uams: Disable incorrect libgcrypt library version validation

### DIFF
--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -77,8 +77,10 @@ static int dh_params_generate (unsigned int bits) {
 
     /* Version check should be the very first call because it
        makes sure that important subsystems are initialized. */
-    if (!gcry_check_version (GCRYPT_VERSION)) {
-        LOG(log_error, logtype_uams, "PAM DHX2: libgcrypt versions mismatch. Need: %s", GCRYPT_VERSION);
+    if (!gcry_check_version (UAM_NEED_LIBGCRYPT_VERSION)) {
+        LOG(log_error, logtype_uams,
+            "PAM DHX2: libgcrypt versions mismatch. Needs: %s Has: %s",
+            UAM_NEED_LIBGCRYPT_VERSION, gcry_check_version (NULL));
         result = AFPERR_MISC;
         goto error;
     }

--- a/etc/uams/uams_dhx2_passwd.c
+++ b/etc/uams/uams_dhx2_passwd.c
@@ -83,8 +83,10 @@ dh_params_generate (gcry_mpi_t *ret_p, gcry_mpi_t *ret_g, unsigned int bits) {
 
     /* Version check should be the very first call because it
        makes sure that important subsystems are initialized. */
-    if (!gcry_check_version (GCRYPT_VERSION)) {
-        LOG(log_info, logtype_uams, "PAM DHX2: libgcrypt versions mismatch. Need: %s", GCRYPT_VERSION);
+    if (!gcry_check_version (UAM_NEED_LIBGCRYPT_VERSION)) {
+        LOG(log_error, logtype_uams,
+            "DHX2: libgcrypt versions mismatch. Needs: %s Has: %s",
+            UAM_NEED_LIBGCRYPT_VERSION, gcry_check_version (NULL));
         result = AFPERR_MISC;
         goto error;
     }

--- a/include/atalk/uam.h
+++ b/include/atalk/uam.h
@@ -20,6 +20,9 @@
 /* in case something drastic has to change */
 #define UAM_MODULE_VERSION       1
 
+/* define if minimum version of libgcrypt is required */
+#define UAM_NEED_LIBGCRYPT_VERSION  NULL
+
 /* things for which we can have uams */
 #define UAM_SERVER_LOGIN         (1 << 0)
 #define UAM_SERVER_CHANGEPW      (1 << 1)


### PR DESCRIPTION
This removes the overzealous check for the exact libgcrypt version that netatalk was linked with.
At the same time, add scaffolding for future libgcrypt minimum version validation.