### PR TITLE
initscripts: Don't define nonexistent pid file for NetBSD scripts

### DIFF
--- a/distrib/initscripts/netbsd.a2boot.in
+++ b/distrib/initscripts/netbsd.a2boot.in
@@ -3,19 +3,13 @@
 # PROVIDE: a2boot
 # REQUIRE: atalkd
 #
-# AppleTalk Apple II netboot daemon. (netatalk @netatalk_version@)
-# Make sure not to start atalkd in the background:
-# its data structures must have time to stablize before running the
-# other processes.
-#
+# AppleTalk Apple II netboot daemon (netatalk @netatalk_version@)
 
 . /etc/rc.subr
 
 name="a2boot"
 rcvar=$name
 command="@sbindir@/a2boot"
-pidfile="/var/run/${name}.pid"
 
 load_rc_config $name
 run_rc_command "$1"
-

--- a/distrib/initscripts/netbsd.atalkd.in
+++ b/distrib/initscripts/netbsd.atalkd.in
@@ -3,11 +3,7 @@
 # PROVIDE: atalkd
 # REQUIRE: DAEMON
 #
-# AppleTalk daemon. (netatalk @netatalk_version@)
-# If you use AppleTalk, Make sure not to start atalkd in the background:
-# its data structures must have time to stablize before running the
-# other processes.
-#
+# AppleTalk daemon (netatalk @netatalk_version@)
 
 . /etc/rc.subr
 

--- a/distrib/initscripts/netbsd.netatalk.in
+++ b/distrib/initscripts/netbsd.netatalk.in
@@ -4,7 +4,6 @@
 # KEYWORD: shutdown
 #
 # AFP fileserver for Macintosh clients (netatalk @netatalk_version@)
-#
 
 . /etc/rc.subr
 

--- a/distrib/initscripts/netbsd.papd.in
+++ b/distrib/initscripts/netbsd.papd.in
@@ -3,11 +3,7 @@
 # PROVIDE: papd
 # REQUIRE: atalkd
 #
-# AppleTalk print server daemon.  (netatalk @netatalk_version@)
-# Make sure not to start atalkd in the background:
-# its data structures must have time to stablize before running the
-# other processes.
-#
+# AppleTalk print server daemon (netatalk @netatalk_version@)
 
 . /etc/rc.subr
 

--- a/distrib/initscripts/netbsd.timelord.in
+++ b/distrib/initscripts/netbsd.timelord.in
@@ -3,19 +3,13 @@
 # PROVIDE: timelord
 # REQUIRE: atalkd
 #
-# AppleTalk time server daemon. (netatalk @netatalk_version@)
-# Make sure not to start atalkd in the background:
-# its data structures must have time to stablize before running the
-# other processes.
-#
+# AppleTalk time server daemon (netatalk @netatalk_version@)
 
 . /etc/rc.subr
 
 name="timelord"
 rcvar=$name
 command="@sbindir@/timelord"
-pidfile="/var/run/${name}.pid"
 
 load_rc_config $name
 run_rc_command "$1"
-


### PR DESCRIPTION
The superfluous pid definition prevents you from stopping the daemon with the NetBSD init system.

Also cleans up some redundant comments.