### PR TITLE
[2.4] initscripts: Don't define nonexistent pid file for NetBSD scripts

### DIFF
--- a/distrib/initscripts/rc.a2boot.netbsd.tmpl
+++ b/distrib/initscripts/rc.a2boot.netbsd.tmpl
@@ -14,7 +14,6 @@
 name="a2boot"
 rcvar=$name
 command=":SBINDIR:/a2boot"
-pidfile="/var/run/${name}.pid"
 
 load_rc_config $name
 run_rc_command "$1"

--- a/distrib/initscripts/rc.timelord.netbsd.tmpl
+++ b/distrib/initscripts/rc.timelord.netbsd.tmpl
@@ -14,7 +14,6 @@
 name="timelord"
 rcvar=$name
 command=":SBINDIR:/timelord"
-pidfile="/var/run/${name}.pid"
 
 load_rc_config $name
 run_rc_command "$1"


### PR DESCRIPTION
The superfluous pid definition prevents you from stopping the daemon with the NetBSD init system.