### PR TITLE
errno.h should always be available

### DIFF
--- a/contrib/macipgw/macip.c
+++ b/contrib/macipgw/macip.c
@@ -23,7 +23,6 @@
 #include <sys/param.h>
 #include <sys/socket.h>
 #include <sys/time.h>
-#include <sys/errno.h>
 #include <sys/uio.h>
 
 #include <netatalk/at.h>

--- a/contrib/macipgw/main.c
+++ b/contrib/macipgw/main.c
@@ -22,7 +22,6 @@
 #include <sys/param.h>
 #include <sys/socket.h>
 #include <sys/time.h>
-#include <sys/errno.h>
 #include <sys/uio.h>
 
 #include <netatalk/at.h>
@@ -30,6 +29,7 @@
 #include <atalk/ddp.h>
 #include <atalk/atp.h>
 
+#include <errno.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/contrib/macipgw/nbp_lkup_async.c
+++ b/contrib/macipgw/nbp_lkup_async.c
@@ -35,8 +35,8 @@
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/socket.h>
-#include <sys/signal.h>
 #include <sys/time.h>
+#include <signal.h>
 #include <stdio.h>
 #include <string.h>
 #include <netatalk/at.h>

--- a/contrib/macipgw/tunnel_bsd.c
+++ b/contrib/macipgw/tunnel_bsd.c
@@ -24,13 +24,13 @@
 #include <sys/socket.h>
 #include <sys/select.h>
 #include <sys/ioctl.h>
-#include <sys/errno.h>
 #include <netinet/in_systm.h>
 #include <netinet/in.h>
 
 #include <net/if.h>
 #include <net/if_tun.h>
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/contrib/macipgw/tunnel_linux.c
+++ b/contrib/macipgw/tunnel_linux.c
@@ -23,7 +23,6 @@
 #include <sys/socket.h>
 #include <sys/select.h>
 #include <sys/ioctl.h>
-#include <sys/errno.h>
 #include <netinet/in_systm.h>
 #include <netinet/in.h>
 
@@ -31,6 +30,7 @@
 #include <linux/if_tun.h>
 #include <linux/route.h>
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/etc/papd/session.c
+++ b/etc/papd/session.c
@@ -7,13 +7,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#ifdef HAVE_SYS_ERRNO_H
-#include <sys/errno.h>
-#endif /* HAVE_SYS_ERRNO_H */
-#ifdef HAVE_ERRNO_H
 #include <errno.h>
-#endif /* HAVE_ERRNO_H */
-
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>

--- a/meson_config.h
+++ b/meson_config.h
@@ -151,12 +151,6 @@
 /* Define if you have the _dyld_func_lookup function. */
 #mesondefine HAVE_DYLD
 
-/* Define if errno declaration exists */
-#mesondefine HAVE_ERRNO
-
-/* Define to 1 if you have the <errno.h> header file. */
-#mesondefine HAVE_ERRNO_H
-
 /* extattr API has full fledged fds for EAs */
 #mesondefine HAVE_EAFD
 


### PR DESCRIPTION
<sys/errno.h> is an alias for <errno.h> on all supported OSes

Also, removes obsoleted capability flags in config.h