### PR TITLE
meson: Don't always build AppleTalk utils with RPATH

### DIFF
--- a/bin/aecho/meson.build
+++ b/bin/aecho/meson.build
@@ -4,6 +4,6 @@ executable(
     include_directories: root_includes,
     link_with: libatalk,
     install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
 )

--- a/bin/getzones/meson.build
+++ b/bin/getzones/meson.build
@@ -4,6 +4,6 @@ executable(
     include_directories: root_includes,
     link_with: libatalk,
     install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
 )

--- a/bin/nbp/meson.build
+++ b/bin/nbp/meson.build
@@ -4,8 +4,8 @@ executable(
     include_directories: root_includes,
     link_with: libatalk,
     install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
 )
 executable(
     'nbprgstr',
@@ -13,8 +13,8 @@ executable(
     include_directories: root_includes,
     link_with: libatalk,
     install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
 )
 executable(
     'nbpunrgstr',
@@ -22,6 +22,6 @@ executable(
     include_directories: root_includes,
     link_with: libatalk,
     install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
 )

--- a/bin/pap/meson.build
+++ b/bin/pap/meson.build
@@ -4,8 +4,8 @@ executable(
     include_directories: root_includes,
     link_with: libatalk,
     install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
 )
 executable(
     'papstatus',
@@ -13,6 +13,6 @@ executable(
     include_directories: root_includes,
     link_with: libatalk,
     install: true,
-    build_rpath: libdir,
-    install_rpath: libdir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
 )

--- a/contrib/a2boot/meson.build
+++ b/contrib/a2boot/meson.build
@@ -16,6 +16,6 @@ executable(
     c_args: a2boot_c_args,
     install: true,
     install_dir: sbindir,
-    build_rpath: libdir,
-    install_rpath: libdir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
 )

--- a/contrib/timelord/meson.build
+++ b/contrib/timelord/meson.build
@@ -5,6 +5,6 @@ executable(
     link_with: libatalk,
     install: true,
     install_dir: sbindir,
-    build_rpath: libdir,
-    install_rpath: libdir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
 )


### PR DESCRIPTION
Copy paste mistake while porting the build scripts from 2.4 to 4.0.