### PR TITLE
docs: Build the macipgw html manual page

### DIFF
--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -59,6 +59,7 @@ custom_target(
         'index.html',
         'installation.html',
         'intro.html',
+        'macipgw.8.html',
         'macusers.1.html',
         'man-pages.html',
         'manual-index.html',


### PR DESCRIPTION
A missing build directive left the macipgw html page out of the generated manual.