### PR TITLE
meson: Missing xsltproc and docbook-xsl treated as non-fatal error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -702,7 +702,32 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install --assume-yes --no-install-recommends ${{ env.APT_PACKAGES }}
+          sudo apt-get install --assume-yes --no-install-recommends \
+            bison \
+            cracklib-runtime \
+            flex \
+            libacl1-dev \
+            libavahi-client-dev \
+            libcrack2-dev \
+            libcups2-dev \
+            libdb-dev \
+            libdbus-1-dev \
+            libevent-dev \
+            libgcrypt-dev \
+            libglib2.0-dev \
+            libkrb5-dev \
+            libldap2-dev \
+            libmariadb-dev \
+            libpam0g-dev \
+            libtalloc-dev \
+            libtirpc-dev \
+            libtracker-sparql-3.0-dev \
+            libwrap0-dev \
+            meson \
+            ninja-build \
+            systemtap-sdt-dev \
+            tracker-miner-fs \
+            unicode-data
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v3
       - name: Run build-wrapper
@@ -711,6 +736,7 @@ jobs:
           meson setup build \
             -Dwith-appletalk=true \
             -Dwith-init-style=none \
+            -Dwith-readmes=false \
             -Dwith-tests=true
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} meson compile -C build
       - name: Run sonar-scanner

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,20 +1,29 @@
-if get_option('with-manual') == 'www'
-    input_file = 'html-www.xsl.in'
-else
-    input_file = 'html.xsl.in'
+if build_xml_docs
+    if get_option('with-manual') == 'www'
+        input_file = 'html-www.xsl.in'
+    else
+        input_file = 'html.xsl.in'
+    endif
+
+    manpages_stylesheet = configure_file(
+        input: 'man.xsl.in',
+        output: 'man.xsl',
+        configuration: cdata,
+    )
+
+    manual_stylesheet = configure_file(
+        input: input_file,
+        output: 'html.xsl',
+        configuration: cdata,
+    )
+
+    subdir('manpages')
+    subdir('manual')
+
+    if 'ja' in get_option('with-manual-l10n')
+        subdir('ja')
+    endif
 endif
-
-manpages_stylesheet = configure_file(
-    input: 'man.xsl.in',
-    output: 'man.xsl',
-    configuration: cdata,
-)
-
-manual_stylesheet = configure_file(
-    input: input_file,
-    output: 'html.xsl',
-    configuration: cdata,
-)
 
 if get_option('with-readmes')
     readmes = [
@@ -28,11 +37,4 @@ if get_option('with-readmes')
             install_dir: datadir / 'doc/netatalk',
         )
     endforeach
-endif
-
-subdir('manpages')
-subdir('manual')
-
-if 'ja' in get_option('with-manual-l10n')
-    subdir('ja')
 endif

--- a/meson.build
+++ b/meson.build
@@ -1504,6 +1504,7 @@ endif
 
 docbook_path = get_option('with-docbook-path')
 compile_manual = get_option('with-manual') != 'none'
+build_xml_docs = false
 
 xsltproc = find_program('xsltproc', required: false)
 xsl = []
@@ -1522,9 +1523,7 @@ if host_os == 'darwin'
     docbook_xsl_dirs += macos_prefix / 'opt/docbook-xsl/docbook-xsl'
 endif
 
-if not compile_manual
-    build_xml_docs = false
-else
+if compile_manual
     foreach dir : docbook_xsl_dirs
         foreach format : ['html', 'manpages']
             if fs.exists(dir / format / 'docbook.xsl')
@@ -1552,7 +1551,7 @@ endif
 docbook_ok = xsltproc.found() and docbook_root != ''
 
 if compile_manual and not docbook_ok
-    error(
+    warning(
         'xsltproc and docbook-xsl stylesheets are required to compile manpages and html documentation',
     )
 endif


### PR DESCRIPTION
The build system should still continue when XSL dependencies are missing.

In this case, the troff man pages and html pages aren't generated, but the rest of the netatalk build will succeed.