### PR TITLE
GitHub CI: Use curl on UnicodeData.txt and fix directory traversal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Run tests
-        run: cd build && meson test
+        run: cd build && meson test && cd ..
       - name: Install
         run: meson install -C build
       - name: Start netatalk
@@ -166,7 +166,7 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Run tests
-        run: cd build && meson test
+        run: cd build && meson test && cd ..
       - name: Install
         run: meson install -C build
       - name: Start netatalk
@@ -199,7 +199,7 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Run tests
-        run: cd build && meson test
+        run: cd build && meson test && cd ..
       - name: Install
         run: meson install -C build
       - name: Start netatalk
@@ -257,7 +257,7 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Run tests
-        run: cd build && meson test
+        run: cd build && meson test && cd ..
       - name: Install
         run: sudo meson install -C build
       - name: Start netatalk
@@ -317,7 +317,7 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Run tests
-        run: cd build && meson test
+        run: cd build && meson test && cd ..
       - name: Install
         run: meson install -C build
       - name: Start netatalk
@@ -347,7 +347,7 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Run distribution tests
-        run: cd build && meson dist
+        run: cd build && meson dist && cd ..
       - name: Install
         run: sudo meson install -C build
       - name: Start netatalk
@@ -374,7 +374,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew install berkeley-db cmark-gfm docbook-xsl libxslt meson mysql talloc
-          wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
+          curl https://www.unicode.org/Public/UNIDATA/UnicodeData.txt --output UnicodeData.txt
       - name: Configure
         run: |
           meson setup build \
@@ -383,7 +383,7 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Run tests
-        run: cd build && meson test
+        run: cd build && meson test && cd ..
       - name: Install
         run: sudo meson install -C build
       - name: Start netatalk
@@ -430,11 +430,10 @@ jobs:
               py39-sqlite3 \
               py39-tkinter \
               talloc \
-              tracker3 \
-              wget
+              tracker3
           run: |
             set -e
-            wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
+            curl https://www.unicode.org/Public/UNIDATA/UnicodeData.txt --output UnicodeData.txt
             meson setup build \
               -Dwith-appletalk=true
             meson compile -C build
@@ -472,11 +471,10 @@ jobs:
               perl5 \
               pkgconf \
               talloc \
-              tracker3 \
-              wget
+              tracker3
           run: |
             set -e
-            wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
+            curl https://www.unicode.org/Public/UNIDATA/UnicodeData.txt --output UnicodeData.txt
             meson setup build \
               -Dpkg_config_path=/usr/local/libdata/pkgconfig \
               -Dwith-appletalk=true
@@ -532,7 +530,8 @@ jobs:
               -Dwith-dtrace=false \
               -Dwith-tests=true
             meson compile -C build
-            cd build && meson test
+            cd build
+            meson test
             cd ..
             meson install -C build
             /usr/local/sbin/netatalk -V
@@ -573,11 +572,10 @@ jobs:
               openpam \
               p5-Net-DBus \
               pkgconf \
-              tracker3 \
-              wget
+              tracker3
           run: |
             set -e
-            wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
+            curl https://www.unicode.org/Public/UNIDATA/UnicodeData.txt --output UnicodeData.txt
             meson setup build \
               -Dpkg_config_path=/usr/local/lib/pkgconfig \
               -Dwith-appletalk=true
@@ -624,7 +622,7 @@ jobs:
           run: |
             set -e
             export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
-            wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
+            curl https://www.unicode.org/Public/UNIDATA/UnicodeData.txt --output UnicodeData.txt
             meson setup build \
               -Dpkg_config_path=/opt/local/lib/pkgconfig \
               -Dwith-appletalk=true \
@@ -662,12 +660,11 @@ jobs:
               libgcrypt \
               ninja \
               pkg-config \
-              python/pip \
-              wget
+              python/pip
             pip install meson
           run: |
             set -e
-            wget https://www.unicode.org/Public/UNIDATA/UnicodeData.txt
+            curl https://www.unicode.org/Public/UNIDATA/UnicodeData.txt --output UnicodeData.txt
             meson setup build \
               -Dpkg_config_path=/usr/lib/amd64/pkgconfig \
               -Dwith-appletalk=true \
@@ -675,7 +672,8 @@ jobs:
               -Dwith-docbook-path=/usr/share/sgml/docbook/xsl-stylesheets \
               -Dwith-tests=true
             meson compile -C build
-            cd build && meson test
+            cd build
+            meson test
             cd ..
             meson install -C build
             /usr/local/sbin/netatalk -V

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,7 @@ jobs:
       - name: Configure
         run: |
           meson setup build \
+            -Dbuildtype=release \
             -Dwith-appletalk=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-tests=true
@@ -158,6 +159,7 @@ jobs:
       - name: Configure
         run: |
           meson setup build \
+            -Dbuildtype=release \
             -Dwith-appletalk=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-docbook-path=/usr/share/xml/docbook/xsl-stylesheets-1.79.2 \
@@ -190,6 +192,7 @@ jobs:
       - name: Configure
         run: |
           meson setup build \
+            -Dbuildtype=release \
             -Dwith-appletalk=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-init-hooks=false \
@@ -250,6 +253,7 @@ jobs:
       - name: Configure
         run: |
           meson setup build \
+            -Dbuildtype=release \
             -Dwith-appletalk=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-init-hooks=false \
@@ -309,6 +313,7 @@ jobs:
       - name: Configure
         run: |
           meson setup build \
+            -Dbuildtype=release \
             -Dwith-appletalk=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-docbook-path=/usr/share/xml/docbook/stylesheet/nwalsh/1.79.2 \
@@ -339,6 +344,7 @@ jobs:
       - name: Configure
         run: |
           meson setup build \
+            -Dbuildtype=release \
             -Dwith-appletalk=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-init-hooks=false \
@@ -378,6 +384,7 @@ jobs:
       - name: Configure
         run: |
           meson setup build \
+            -Dbuildtype=release \
             -Dwith-appletalk=true \
             -Dwith-tests=true
       - name: Build
@@ -435,6 +442,7 @@ jobs:
             set -e
             curl https://www.unicode.org/Public/UNIDATA/UnicodeData.txt --output UnicodeData.txt
             meson setup build \
+              -Dbuildtype=release \
               -Dwith-appletalk=true
             meson compile -C build
             meson install -C build
@@ -476,6 +484,7 @@ jobs:
             set -e
             curl https://www.unicode.org/Public/UNIDATA/UnicodeData.txt --output UnicodeData.txt
             meson setup build \
+              -Dbuildtype=release \
               -Dpkg_config_path=/usr/local/libdata/pkgconfig \
               -Dwith-appletalk=true
             meson compile -C build
@@ -525,6 +534,7 @@ jobs:
           run: |
             set -e
             meson setup build \
+              -Dbuildtype=release \
               -Dpkg_config_path=/usr/pkg/lib/pkgconfig \
               -Dwith-appletalk=true \
               -Dwith-dtrace=false \
@@ -577,6 +587,7 @@ jobs:
             set -e
             curl https://www.unicode.org/Public/UNIDATA/UnicodeData.txt --output UnicodeData.txt
             meson setup build \
+              -Dbuildtype=release \
               -Dpkg_config_path=/usr/local/lib/pkgconfig \
               -Dwith-appletalk=true
             meson compile -C build
@@ -624,6 +635,7 @@ jobs:
             export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
             curl https://www.unicode.org/Public/UNIDATA/UnicodeData.txt --output UnicodeData.txt
             meson setup build \
+              -Dbuildtype=release \
               -Dpkg_config_path=/opt/local/lib/pkgconfig \
               -Dwith-appletalk=true \
               -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
@@ -666,6 +678,7 @@ jobs:
             set -e
             curl https://www.unicode.org/Public/UNIDATA/UnicodeData.txt --output UnicodeData.txt
             meson setup build \
+              -Dbuildtype=release \
               -Dpkg_config_path=/usr/lib/amd64/pkgconfig \
               -Dwith-appletalk=true \
               -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \


### PR DESCRIPTION
curl is available everywhere. Removes the wget dependency.

Also, clarify directory traversal for human readers (in the CI runner the current dir gets reset every step.)

In addition to the GitHub CI workflow, these changes will be reflected in the compile appendix in the html manual.