### PR TITLE
docker: Build with optimizations and without debug symbols

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN chown -R builder:builder . \
 USER builder
 
 RUN meson setup build \
+    -Dbuildtype=release \
     -Dwith-afpstats=false \
     -Dwith-appletalk=true \
     -Dwith-dbus-daemon-path=/usr/bin/dbus-daemon \


### PR DESCRIPTION
Previously, the netatalk build was with 0 optimization and debug symbols enabled.