### PR TITLE
meson: In summary, list Webmin module under a new Add-ons section

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2364,7 +2364,6 @@ endif
 summary_info += {
     '  Spotlight': have_spotlight,
     '  TCP wrapper': have_tcpwrap,
-    '  Webmin module': have_webmin,
     '  Zeroconf': have_zeroconf,
 }
 if enable_zeroconf
@@ -2400,3 +2399,8 @@ summary_info = {
     '  Manual style': get_option('with-manual'),
 }
 summary(summary_info, bool_yn: true, section: '  Documentation:')
+
+summary_info = {
+    '  Webmin module': have_webmin,
+}
+summary(summary_info, bool_yn: true, section: '  Add-ons:')


### PR DESCRIPTION
The Webmin module is arguably not a feature of Netatalk proper, but an external add-on component. Displaying it as such in the setup summary to avoid misunderstandings.