### PR TITLE
Change u_char data types to the portable uint8_t

### DIFF
--- a/etc/afpd/acls.c
+++ b/etc/afpd/acls.c
@@ -531,9 +531,9 @@ EC_CLEANUP:
  *
  * @returns         access rights
  */
-static u_char acl_permset_to_uarights(acl_entry_t entry) {
+static uint8_t acl_permset_to_uarights(acl_entry_t entry) {
     acl_permset_t permset;
-    u_char rights = 0;
+    uint8_t rights = 0;
 
     if (acl_get_permset(entry, &permset) == -1)
         return rights;
@@ -589,9 +589,9 @@ static int posix_acls_to_uaperms(const AFPObj *obj, const char *path, struct sta
     gid_t *gid;
     uid_t whoami = geteuid();
 
-    u_char group_rights = 0x00;
-    u_char acl_rights = 0x00;
-    u_char mask = 0xff;
+    uint8_t group_rights = 0x00;
+    uint8_t acl_rights = 0x00;
+    uint8_t mask = 0xff;
 
     acl = acl_get_file(path, ACL_TYPE_ACCESS);
     if (acl == NULL) {

--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -599,7 +599,7 @@ void afp_over_dsi(AFPObj *obj)
 
         case DSIFUNC_CMD:
 
-            function = (u_char) dsi->commands[0];
+            function = (uint8_t) dsi->commands[0];
 
             /* AFP replay cache */
             rc_idx = dsi->clientID % REPLAYCACHE_SIZE;
@@ -656,7 +656,7 @@ void afp_over_dsi(AFPObj *obj)
             break;
 
         case DSIFUNC_WRITE: /* FPWrite and FPAddIcon */
-            function = (u_char) dsi->commands[0];
+            function = (uint8_t) dsi->commands[0];
             if ( afp_switch[ function ] != NULL ) {
                 dsi->datalen = DSI_DATASIZ;
                 dsi->flags |= DSI_RUNNING;

--- a/etc/afpd/appl.c
+++ b/etc/afpd/appl.c
@@ -35,7 +35,7 @@ static int pathcmp(char *p, int plen, char *q, int qlen)
     return (( plen == qlen && memcmp( p, q, plen ) == 0 ) ? 0 : 1 );
 }
 
-static int applopen(struct vol *vol, u_char creator[ 4 ], int flags, int mode)
+static int applopen(struct vol *vol, uint8_t creator[ 4 ], int flags, int mode)
 {
     char	*dtf, *adt, *adts;
 

--- a/etc/afpd/desktop.c
+++ b/etc/afpd/desktop.c
@@ -272,12 +272,12 @@ int afp_closedt(AFPObj *obj _U_, char *ibuf _U_, size_t ibuflen _U_, char *rbuf 
 
 static struct savedt	si = { { 0, 0, 0, 0 }, -1, 0, 0 };
 
-static char *icon_dtfile(struct vol *vol, u_char creator[ 4 ])
+static char *icon_dtfile(struct vol *vol, uint8_t creator[ 4 ])
 {
     return dtfile( vol, creator, ".icon" );
 }
 
-static int iconopen(struct vol *vol, u_char creator[ 4 ], int flags, int mode)
+static int iconopen(struct vol *vol, uint8_t creator[ 4 ], int flags, int mode)
 {
     char	*dtf, *adt, *adts;
 
@@ -328,7 +328,7 @@ int afp_addicon(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
 #ifndef NO_DDP
     struct iovec	iov[2];
 #endif
-    u_char		fcreator[4], imh[12], irh[12], * p;
+    uint8_t		fcreator[4], imh[12], irh[12], * p;
     int			itype, cc = AFP_OK, iovcnt = 0;
     size_t 		buflen;
     uint32_t           ftype, itag;
@@ -491,9 +491,9 @@ addicon_err:
     return( AFP_OK );
 }
 
-static const u_char	utag[] = { 0, 0, 0, 0 };
-static const u_char	ucreator[] = { 0, 0, 0, 0 };/* { 'U', 'N', 'I', 'X' };*/
-static const u_char	utype[] = { 0, 0, 0, 0 };/* { 'T', 'E', 'X', 'T' };*/
+static const uint8_t	utag[] = { 0, 0, 0, 0 };
+static const uint8_t	ucreator[] = { 0, 0, 0, 0 };/* { 'U', 'N', 'I', 'X' };*/
+static const uint8_t	utype[] = { 0, 0, 0, 0 };/* { 'T', 'E', 'X', 'T' };*/
 static const short	usize = 256;
 
 
@@ -573,7 +573,7 @@ int afp_geticon(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
     struct vol	*vol;
     off_t       offset;
     ssize_t	rc, buflen;
-    u_char	fcreator[ 4 ], ftype[ 4 ], itype, ih[ 12 ];
+    uint8_t	fcreator[ 4 ], ftype[ 4 ], itype, ih[ 12 ];
     uint16_t	vid, bsize, rsize;
 
     buflen = *rbuflen;
@@ -705,7 +705,7 @@ geticon_exit:
 
 /* ---------------------- */
 static const char		hexdig[] = "0123456789abcdef";
-char *dtfile(const struct vol *vol, u_char creator[], char *ext )
+char *dtfile(const struct vol *vol, uint8_t creator[], char *ext )
 {
     static char	path[ MAXPATHLEN + 1];
     char	*p;
@@ -832,7 +832,7 @@ static int ad_addcomment(const AFPObj *obj, struct vol *vol, struct path *path, 
     int			clen;
     struct adouble	ad, *adp;
 
-    clen = (u_char)*ibuf++;
+    clen = (uint8_t)*ibuf++;
     clen = min( clen, 199 );
 
     upath = path->u_name;

--- a/etc/afpd/desktop.h
+++ b/etc/afpd/desktop.h
@@ -31,7 +31,7 @@
 #define APPLEDESKTOP ".AppleDesktop"
 
 struct savedt {
-    u_char	sdt_creator[ 4 ];
+    uint8_t	sdt_creator[ 4 ];
     int		sdt_fd;
     int		sdt_index;
     short	sdt_vid;
@@ -39,7 +39,7 @@ struct savedt {
 
 typedef unsigned char CreatorType[4];
 
-extern char	*dtfile (const struct vol *, u_char [], char *);
+extern char	*dtfile (const struct vol *, uint8_t [], char *);
 extern char	*mtoupath (const struct vol *, char *, cnid_t, int utf8);
 extern char	*utompath (const struct vol *, char *, cnid_t, int utf8);
 

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -1579,7 +1579,7 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap, char *bu
     int                 change_parent_mdate = 0;
     int                 newdate = 0;
     uint16_t           bitmap = d_bitmap;
-    u_char              finder_buf[32];
+    uint8_t              finder_buf[32];
     uint32_t       upriv;
     mode_t              mpriv = 0;
     bool                set_upriv = false, set_maccess = false;

--- a/etc/afpd/directory.h
+++ b/etc/afpd/directory.h
@@ -66,10 +66,10 @@
 #define CNID(a,b)     ((a)->st_ino & 0xffffffff)
 
 struct maccess {
-    u_char	ma_user;
-    u_char	ma_world;
-    u_char	ma_group;
-    u_char	ma_owner;
+    uint8_t	ma_user;
+    uint8_t	ma_world;
+    uint8_t	ma_group;
+    uint8_t	ma_owner;
 };
 
 #define	AR_USEARCH	(1<<0)

--- a/etc/afpd/enumerate.c
+++ b/etc/afpd/enumerate.c
@@ -248,7 +248,7 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
     }
 
     header = (ext)?4:2;
-    header *=sizeof( u_char );
+    header *=sizeof( uint8_t );
 
     maxsz = min(maxsz, *rbuflen - REPLY_PARAM_MAXLEN);
     o_path = cname( vol, dir, &ibuf );

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -59,14 +59,14 @@
  *                           putawayID    4  home directory id
  */
 
-const u_char ufinderi[ADEDLEN_FINDERI] = {
+const uint8_t ufinderi[ADEDLEN_FINDERI] = {
                               0, 0, 0, 0, 0, 0, 0, 0,
                               1, 0, 0, 0, 0, 0, 0, 0,
                               0, 0, 0, 0, 0, 0, 0, 0,
                               0, 0, 0, 0, 0, 0, 0, 0
                           };
 
-static const u_char old_ufinderi[] = {
+static const uint8_t old_ufinderi[] = {
                               'T', 'E', 'X', 'T', 'U', 'N', 'I', 'X'
                           };
 
@@ -279,7 +279,7 @@ int getmetadata(const AFPObj *obj,
     uint32_t		aint;
     cnid_t              id = 0;
     uint16_t		ashort;
-    u_char              achar, fdType[4];
+    uint8_t              achar, fdType[4];
     uint32_t           utf8 = 0;
     struct stat         *st;
     struct maccess	ma;
@@ -828,8 +828,8 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
     int			bit, isad = 1, err = AFP_OK;
     char                *upath;
     char		*ade = NULL;
-    u_char              achar, xyy[4];
-    const u_char        *fdType = NULL;
+    uint8_t              achar, xyy[4];
+    const uint8_t        *fdType = NULL;
     uint16_t		ashort = 0;
     uint16_t		bshort;
     uint16_t		oshort;
@@ -845,7 +845,7 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
     gid_t		f_gid;
     uint16_t           bitmap = f_bitmap;
     uint32_t           cdate,bdate;
-    u_char              finder_buf[32];
+    uint8_t              finder_buf[32];
     int symlinked = S_ISLNK(path->st.st_mode);
     int fp;
     ssize_t len;
@@ -957,10 +957,10 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
                 buf += 2;
                 /* Keep special case to support crlf translations */
                 if ((unsigned int) achar == 0x04) {
-	       	    fdType = (u_char *)"TEXT";
+	       	    fdType = (uint8_t *)"TEXT";
 		    buf += 2;
                 } else {
-            	    xyy[0] = ( u_char ) 'p';
+            	    xyy[0] = ( uint8_t ) 'p';
             	    xyy[1] = achar;
             	    xyy[3] = *buf++;
             	    xyy[2] = *buf++;

--- a/etc/afpd/file.h
+++ b/etc/afpd/file.h
@@ -34,7 +34,7 @@
 #include "directory.h"
 #include "volume.h"
 
-extern const u_char	ufinderi[];
+extern const uint8_t	ufinderi[];
 
 #define FILPBIT_ATTR	 0
 #define FILPBIT_PDID	 1

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -126,7 +126,7 @@ int afp_getfildirparams(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *r
     rbuf += sizeof( fbitmap );
     dbitmap = htons( dbitmap );
     memcpy( rbuf, &dbitmap, sizeof( dbitmap ));
-    rbuf += sizeof( dbitmap ) + sizeof( u_char );
+    rbuf += sizeof( dbitmap ) + sizeof( uint8_t );
     *rbuf = 0;
 
     return( AFP_OK );

--- a/etc/afpd/unix.c
+++ b/etc/afpd/unix.c
@@ -151,7 +151,7 @@ void accessmode(const AFPObj *obj, const struct vol *vol, char *path, struct mac
 #endif
 }
 
-static mode_t mtoubits(u_char bits)
+static mode_t mtoubits(uint8_t bits)
 {
     mode_t	mode;
 

--- a/libatalk/acl/unix.c
+++ b/libatalk/acl/unix.c
@@ -300,7 +300,7 @@ int posix_chmod(const char *name, mode_t mode) {
     acl_entry_t group_entry;
     acl_tag_t tag;
     acl_t acl;
-    u_char not_found = (SEARCH_GROUP_OBJ|SEARCH_MASK); /* used as flags */
+    uint8_t not_found = (SEARCH_GROUP_OBJ|SEARCH_MASK); /* used as flags */
 
     LOG(log_maxdebug, logtype_afpd, "posix_chmod(\"%s\", mode: %04o) BEGIN",
         fullpathname(name), mode);
@@ -417,7 +417,7 @@ int posix_fchmod(int fd, mode_t mode) {
     acl_entry_t group_entry;
     acl_tag_t tag;
     acl_t acl;
-    u_char not_found = (SEARCH_GROUP_OBJ|SEARCH_MASK); /* used as flags */
+    uint8_t not_found = (SEARCH_GROUP_OBJ|SEARCH_MASK); /* used as flags */
 
     /* Call chmod() first because there might be some special bits to be set which
      * aren't related to access control.


### PR DESCRIPTION
uint8_t is a POSIX standard while u_char is a BSD-ism.