### PR TITLE
initscripts: Remove the redundant systemd Also directive

### DIFF
--- a/distrib/initscripts/systemd.a2boot.service.in
+++ b/distrib/initscripts/systemd.a2boot.service.in
@@ -16,4 +16,3 @@ RestartSec=1
 
 [Install]
 WantedBy=multi-user.target
-Also=atalkd.service

--- a/distrib/initscripts/systemd.macipgw.service.in
+++ b/distrib/initscripts/systemd.macipgw.service.in
@@ -16,4 +16,3 @@ RestartSec=1
 
 [Install]
 WantedBy=multi-user.target
-Also=atalkd.service

--- a/distrib/initscripts/systemd.papd.service.in
+++ b/distrib/initscripts/systemd.papd.service.in
@@ -16,4 +16,3 @@ RestartSec=1
 
 [Install]
 WantedBy=multi-user.target
-Also=atalkd.service

--- a/distrib/initscripts/systemd.timelord.service.in
+++ b/distrib/initscripts/systemd.timelord.service.in
@@ -16,4 +16,3 @@ RestartSec=1
 
 [Install]
 WantedBy=multi-user.target
-Also=atalkd.service


### PR DESCRIPTION
Also is redundant to After and Requires in regular systemd use. Enabling/disabling services is normally handled by wrappers. Also has been shown to cause side effects in a particular wrapper (debhelper).