### PR TITLE
[2.x] Fix volume check for "ad" tools.

### DIFF
--- a/bin/ad/ad_util.c
+++ b/bin/ad/ad_util.c
@@ -116,7 +116,7 @@ int openvol(const char *path, afpvol_t *vol)
     if (vol->volinfo.v_adouble != AD_VERSION2)
         ERROR("Unsupported adouble versions: %u", vol->volinfo.v_adouble);
 
-    if (vol->volinfo.v_vfs_ea != AFPVOL_EA_SYS)
+    if (vol->volinfo.v_vfs_ea != AFPVOL_EA_AD && vol->volinfo.v_vfs_ea != AFPVOL_EA_SYS)
         ERROR("Unsupported Extended Attributes option: %u", vol->volinfo.v_vfs_ea);
 
     /* initialize sufficient struct vol for VFS initialisation */


### PR DESCRIPTION
Check was failing if the `ea = ad` option was set.