### PR TITLE
docs: Improve upgrade chapter and add usage note for afp listen/ifs

### DIFF
--- a/doc/ja/manpages/man5/afp.conf.5.xml
+++ b/doc/ja/manpages/man5/afp.conf.5.xml
@@ -504,6 +504,10 @@
 
           <listitem>
             <para>サーバがリッスンするネットワークインターフェースを指定する。デフォルトではシステムの最初のIPアドレスを宣伝するが、入ってくる如何なる要求もリッスンする。</para>
+
+            <note>
+              <para><option>afp listen</option> オプションと同時に使用しないでください。</para>
+            </note>
           </listitem>
         </varlistentry>
 
@@ -517,6 +521,10 @@
 
             <para>IPv6 address +
             portの組み合わせは角かっこを使ったフォーマット[IPv6]:portのURLを使わなければならない。</para>
+
+            <note>
+              <para><option>afp interfaces</option> オプションと同時に使用しないでください。</para>
+            </note>
           </listitem>
         </varlistentry>
 

--- a/doc/ja/manual/upgrade.xml
+++ b/doc/ja/manual/upgrade.xml
@@ -20,9 +20,14 @@
     <title>Netatalk 3 からのアップグレード</title>
 
     <para>Netatalk 3 から Netatalk 4
-    へのアップグレードは簡単。古いバージョンの上に新しいバージョンをインストールするだけ。主な違いは、Netatalk 4 では、Netatalk 2
-    と Netatalk 3 の間で削除された AppleTalk サービス、構成ファイル、およびマニュアル
-    ページがいくつか復活していることである。</para>
+    へのアップグレードは簡単。古いバージョンの上に新しいバージョンをインストールするだけ。Netatalk 4 での主要な変更点は、Netatalk 2
+    と Netatalk 3 の間で削除された AppleTalk サービス、構成ファイル、およびツールを一部復活させたことである。</para>
+
+    <para>主に、<command><link linkend="atalkd.8">atalkd</link></command> デーモンと
+    <filename><link linkend="atalkd.conf.5">atalkd.conf</link></filename>
+    設定ファイル、また <command><link linkend="papd.8">papd</link></command> デーモンと
+    <filename><link linkend="papd.conf.5">papd.conf</link></filename>
+    設定ファイルが追加された。</para>
   </sect1>
 
   <sect1>
@@ -30,24 +35,29 @@
 
     <para>Netatalk 4 の主要な変更は以下の3点：<orderedlist>
         <listitem>
-          <para>これまでの設定ファイルすべてが廃止され、ほぼ全オプション名を変更し、全く新しい設定ファイルとしての
-          <filename><link
-          linkend="afp.conf.5">afp.conf</link></filename>を追加した。</para>
+          <para>これまでの AFP 設定ファイルすべてが廃止され、AFP
+          に関してのほぼ全オプション名を変更し、新しい設定ファイルを追加した： <filename><link
+          linkend="afp.conf.5">afp.conf</link></filename> と <filename><link
+          linkend="extmap.conf.5">extmap.conf</link></filename></para>
         </listitem>
 
         <listitem>
-          <para>マックのメタデータとリソースフォークをファイルシステムの拡張属性に保存する "<option>appledouble =
-          ea</option>" という新しい AppleDouble のバックエンド。</para>
+          <para>マックのメタデータとリソースフォークをファイルシステムの拡張属性に保存する <option>appledouble =
+          ea</option> という新しい AppleDouble のバックエンド。</para>
         </listitem>
 
         <listitem>
           <para>AppleTalk トランスポート層はデフォルトで無効になっている。非常に古い Mac で Netatalk
-          を使用する場合は、"<option>appletalk = yes</option>" オプションで有効にしてください。</para>
+          を使用する場合は、<filename>afp.conf</filename> にて <option>appletalk =
+          yes</option> オプションで有効にしてください。 それから、<command>netatalk</command>
+          を起動する前に <command>atalkd</command> デーモンを立ち上げてください。</para>
         </listitem>
       </orderedlist></para>
 
     <sect2>
       <title>設定まわりの変更点</title>
+
+      <para><filename>afp.conf</filename></para>
 
       <para><itemizedlist>
           <listitem>
@@ -69,25 +79,42 @@
           <para>ほとんどのオプション名は変更されたので、 詳細については <link
           linkend="afp.conf.5">afp.conf</link> の manpage 全体を読むこと</para>
         </warning></para>
+
+      <para><filename>extmap.conf</filename></para>
+
+      <para><itemizedlist>
+          <listitem>
+            <para>Classic Mac OS type/creator と拡張子の関連付け</para>
+          </listitem>
+
+          <listitem>
+            <para>2.x
+            とは異なり、マッピングはデフォルトで無効になっている。有効にするには、ファイル内の行のコメントを解除する</para>
+          </listitem>
+
+          <listitem>
+            <para><filename>AppleVolumes.system</filename> の廃止</para>
+          </listitem>
+        </itemizedlist></para>
     </sect2>
 
     <sect2>
       <title>新たな AppleDouble バックエンド</title>
 
-      <para>マックのメタデータとリソースフォークをファイルシステムの拡張属性に保存する "<option>appledouble =
-      ea</option>" という新しい AppleDouble のバックエンド。<itemizedlist>
+      <para>マックのメタデータとリソースフォークをファイルシステムの拡張属性に保存する <option>appledouble =
+      ea</option> という新しい AppleDouble のバックエンド。<itemizedlist>
           <listitem>
             <para>デフォルトのバックエンドである（！）</para>
           </listitem>
 
           <listitem>
-            <para>拡張属性のあるファイルシステムが必須。 さもなくば "<option>appledouble =
-            v2</option>" オプションの使用が代替となる</para>
+            <para>拡張属性のあるファイルシステムが必須。 さもなくば <option>appledouble = v2</option>
+            オプションの使用が代替となる</para>
           </listitem>
 
           <listitem>
-            <para>"<option>appledouble = v2</option>" から "<option>appledouble
-            = ea</option>" ファイルシステムへの変換はアクセス時、その都度行われる（無効にすることも可能）</para>
+            <para><option>appledouble = v2</option> から <option>appledouble =
+            ea</option> ファイルシステムへの変換はアクセス時、その都度行われる（無効にすることも可能）</para>
           </listitem>
 
           <listitem>
@@ -143,7 +170,7 @@
 
           <listitem>
             <para>CNID データベースはデフォルトで <filename>/var/netatalk/CNID/</filename>
-            以下に保存される。</para>
+            以下に保存される。以前は各共有ボリュームにて保存されていた。</para>
           </listitem>
 
           <listitem>
@@ -153,10 +180,6 @@
 
           <listitem>
             <para>SLP 及び AFP プロキシのサポート機能は削除。</para>
-          </listitem>
-
-          <listitem>
-            <para>type/creator と拡張子の関連付けサポート機能は削除</para>
           </listitem>
         </itemizedlist></para>
     </sect2>
@@ -180,7 +203,8 @@
 
           <listitem>
             <para><command>afpd</command> と <command>cnid_metad</command>
-            の代わりに <link linkend="netatalk.8">netatalk</link> 起動にのみ関連している、
+            の代わりに <command><link
+            linkend="netatalk.8">netatalk</link></command> 起動にのみ関連している、
             Netatalk 起動スクリプトを更新するか、標準の起動スクリプトに置き換える。</para>
           </listitem>
 

--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -596,6 +596,10 @@
             <para>Specifies the network interfaces that the server should
             listens on. The default is advertise the first IP address of the
             system, but to listen for any incoming request.</para>
+
+            <note>
+              <para>Do not use at the same time as the <option>afp listen</option> option.</para>
+            </note>
           </listitem>
         </varlistentry>
 
@@ -613,6 +617,10 @@
 
             <para>IPv6 address + port combination must use URL the format
             using square brackets [IPv6]:port</para>
+
+            <note>
+              <para>Do not use at the same time as the <option>afp interfaces</option> option.</para>
+            </note>
           </listitem>
         </varlistentry>
 

--- a/doc/manual/upgrade.xml
+++ b/doc/manual/upgrade.xml
@@ -15,8 +15,15 @@
 
     <para>Upgrading to Netatalk 4 from Netatalk 3 is trivial. Just install the
     new version on top of the old one. The primary difference is that Netatalk
-    4 brings back essential AppleTalk services, configuration files, and man
-    pages that were removed between Netatalk 2 and Netatalk 3.</para>
+    4 brings back essential AppleTalk services, configuration files, and tools
+    that were removed between Netatalk 2 and Netatalk 3.</para>
+
+    <para>Notably, the <command><link
+    linkend="atalkd.8">atalkd</link></command> daemon with its <filename><link
+    linkend="atalkd.conf.5">atalkd.conf</link></filename> configuration file,
+    and the <command><link linkend="papd.8">papd</link></command> daemon with
+    its <filename><link linkend="papd.conf.5">papd.conf</link></filename>
+    configuration file are once more available.</para>
   </sect1>
 
   <sect1>
@@ -25,13 +32,14 @@
     <para>There are three major changes between Netatalk 2 and Netatalk
     4:<orderedlist>
         <listitem>
-          <para>New configuration file <filename><link
-          linkend="afp.conf.5">afp.conf</link></filename>, obsoleting all
-          previous configuration files and renaming most options.</para>
+          <para>New configuration files that replaces most of the previous
+          ones: <filename><link
+          linkend="afp.conf.5">afp.conf</link></filename> and <filename><link
+          linkend="extmap.conf.5">extmap.conf</link></filename></para>
         </listitem>
 
         <listitem>
-          <para>New AppleDouble backend "<option>appledouble = ea</option>"
+          <para>New AppleDouble backend <option>appledouble = ea</option>
           which stores Mac metadata and resource forks in extended attributes
           of the filesystem.</para>
         </listitem>
@@ -39,12 +47,17 @@
         <listitem>
           <para>The AppleTalk transport layer is disabled by default. If you
           want to use Netatalk with very old Macs, turn it on with the
-          "<option>appletalk = yes</option>" option.</para>
+          <option>appletalk = yes</option> option in
+          <filename>afp.conf</filename>. Then start the
+          <command>atalkd</command> daemon before <command>netatalk</command>
+          in order to activate the AppleTalk transport layer.</para>
         </listitem>
       </orderedlist></para>
 
     <sect2>
       <title>New configuration</title>
+
+      <para><filename>afp.conf</filename></para>
 
       <para><itemizedlist>
           <listitem>
@@ -66,12 +79,29 @@
           <para>most option names have changed, read the full manpage <link
           linkend="afp.conf.5">afp.conf</link> for details</para>
         </warning></para>
+
+      <para><filename>extmap.conf</filename></para>
+
+      <para><itemizedlist>
+          <listitem>
+            <para>maps file extensions to Classic Mac OS type/creator</para>
+          </listitem>
+
+          <listitem>
+            <para>unlike 2.x, the mappings are disabled by default; uncomment
+            the lines in the file to enable them</para>
+          </listitem>
+
+          <listitem>
+            <para>obsoletes <filename>AppleVolumes.system</filename></para>
+          </listitem>
+        </itemizedlist></para>
     </sect2>
 
     <sect2>
       <title>New AppleDouble backend</title>
 
-      <para>New AppleDouble backend "<option>appledouble = ea</option>" which
+      <para>New AppleDouble backend <option>appledouble = ea</option> which
       stores Mac metadata and resource forks in extended attributes of the
       filesystem.<itemizedlist>
           <listitem>
@@ -80,13 +110,13 @@
 
           <listitem>
             <para>requires a filesystem with Extended Attributes, fallback is
-            "<option>appledouble = v2</option>"</para>
+            <option>appledouble = v2</option></para>
           </listitem>
 
           <listitem>
-            <para>converts filesystems from "<option>appledouble =
-            v2</option>" to "<option>appledouble = ea</option>" on the fly
-            when accessed (can be disabled)</para>
+            <para>converts filesystems from <option>appledouble = v2</option>
+            to <option>appledouble = ea</option> on the fly when accessed (can
+            be disabled)</para>
           </listitem>
 
           <listitem>
@@ -144,8 +174,9 @@
           </listitem>
 
           <listitem>
-            <para>The CNID databases are now stored under
-            <filename>/var/netatalk/CNID/</filename> by default.</para>
+            <para>All CNID databases are now stored under
+            <filename>/var/netatalk/CNID/</filename> by default, rather than
+            in the individual shared volume directories</para>
           </listitem>
 
           <listitem>
@@ -155,10 +186,6 @@
 
           <listitem>
             <para>Removed SLP and AFP proxy support</para>
-          </listitem>
-
-          <listitem>
-            <para>Removed type/creator extension mapping support</para>
           </listitem>
         </itemizedlist></para>
     </sect2>
@@ -181,8 +208,8 @@
           </listitem>
 
           <listitem>
-            <para>Update your Netatalk init script to start <link
-            linkend="netatalk.8">netatalk</link> instead of
+            <para>Update your Netatalk init script to start <command><link
+            linkend="netatalk.8">netatalk</link></command> instead of
             <command>afpd</command> and <command>cnid_metad</command>, or
             replace it with the appropriate stock init script for your
             system.</para>
@@ -1708,7 +1735,7 @@
 
                 <entry>-</entry>
 
-                <entry>move to extmap.conf</entry>
+                <entry>moved to extmap.conf</entry>
               </row>
 
               <row>


### PR DESCRIPTION
The Upgrade chapter has some misleading information about extmap.conf and the AppleTalk config files.