### PR TITLE
meson: spooldir FHS compliance; add statedir override option

### DIFF
--- a/doc/ja/manual/configuration.xml
+++ b/doc/ja/manual/configuration.xml
@@ -159,8 +159,8 @@ basedir regex = /usr/home</programlisting></para>
       </indexterm> オプションで選択が可能である。CNID バックエンドは基本的には、ストアされた ID &lt;-&gt;
     名前を一対一対応させるデータベースである。</para>
 
-    <para>The CNID データベースはデフォルトで <filename>/var/netatalk/CNID</filename>
-    に置かれる。コンパイル時に <command>localstatedir=PATH</command> オプションで場所を変えられる。</para>
+    <para>CNID データベースはデフォルトで <filename>$prefix/var/netatalk/CNID</filename>
+    に置かれる。コンパイル時に <command>-Dwith-statedir-path=PATH</command> オプションで場所を変えられる。</para>
 
     <para>CNID データベースの検証・修復・再構築のために用いることができる <command>dbd</command>
     という名のコマンドが用意されていている。</para>

--- a/doc/ja/manual/upgrade.xml
+++ b/doc/ja/manual/upgrade.xml
@@ -169,7 +169,7 @@
           </listitem>
 
           <listitem>
-            <para>CNID データベースはデフォルトで <filename>/var/netatalk/CNID/</filename>
+            <para>CNID データベースはデフォルトで <filename>$prefix/var/netatalk/CNID/</filename>
             以下に保存される。以前は各共有ボリュームにて保存されていた。</para>
           </listitem>
 
@@ -211,7 +211,7 @@
           <listitem>
             <para><filename>afp_voluuid.conf</filename> 及び
             <filename>afp_signature.conf</filename> を localstate ディレクトリ
-            （デフォルトでは <filename>/var/netatalk/</filename>）、に移動。 正しいパスを見つけるために
+            （デフォルトでは <filename>$prefix/var/netatalk/</filename>）、に移動。 正しいパスを見つけるために
             <command>afpd -v</command> コマンドが有用</para>
           </listitem>
 
@@ -1948,7 +1948,7 @@
                 <entry><emphasis role="bold">（ボリュームディレクトリ）</emphasis></entry>
 
                 <entry><emphasis
-                role="bold">var/netatalk/CNID/</emphasis></entry>
+                role="bold">$prefix/var/netatalk/CNID/</emphasis></entry>
 
                 <entry>(G)</entry>
 

--- a/doc/manual/configuration.xml
+++ b/doc/manual/configuration.xml
@@ -165,8 +165,8 @@ basedir regex = /usr/home</programlisting></para>
     database storing ID &lt;-&gt; name mappings.</para>
 
     <para>The CNID databases are by default located in
-    <filename>/var/netatalk/CNID</filename>. You can change the location by
-    configuring <command>localstatedir</command> at compile time.</para>
+    <filename>$prefix/var/netatalk/CNID</filename>. You can change the location by
+    configuring <command>-Dwith-statedir-path=PATH</command> at compile time.</para>
 
     <para>There is a command line utility called <command>dbd</command>
     available which can be used to verify, repair and rebuild the CNID

--- a/doc/manual/upgrade.xml
+++ b/doc/manual/upgrade.xml
@@ -175,7 +175,7 @@
 
           <listitem>
             <para>All CNID databases are now stored under
-            <filename>/var/netatalk/CNID/</filename> by default, rather than
+            <filename>$prefix/var/netatalk/CNID/</filename> by default, rather than
             in the individual shared volume directories</para>
           </listitem>
 
@@ -218,7 +218,7 @@
           <listitem>
             <para>Move <filename>afp_voluuid.conf</filename> and
             <filename>afp_signature.conf</filename> to the localstate
-            directory (default <filename>/var/netatalk/</filename>), you can
+            directory (default <filename>$prefix/var/netatalk/</filename>), you can
             use <command>afpd -v</command> in order to find the correct
             path</para>
           </listitem>

--- a/meson.build
+++ b/meson.build
@@ -65,7 +65,6 @@ bindir = prefix / get_option('bindir')
 datadir = prefix / get_option('datadir')
 includedir = prefix / get_option('includedir')
 libdir = prefix / get_option('libdir')
-localstatedir = prefix / get_option('localstatedir')
 mandir = prefix / get_option('mandir')
 sbindir = prefix / get_option('sbindir')
 sysconfdir = prefix / get_option('sysconfdir')
@@ -73,6 +72,24 @@ sysconfdir = prefix / get_option('sysconfdir')
 pkgconfdir = get_option('with-pkgconfdir-path')
 if pkgconfdir == ''
     pkgconfdir = sysconfdir
+endif
+
+# TODO: This breaks FHS. Should be /var/lib or the platform-specific equivalent.
+# Meson's built-in option is called sharedstatedir.
+# Will keep the non-standard location for now to avoid breaking existing setups.
+# Ref: https://refspecs.linuxfoundation.org/FHS_3.0/fhs/ch05s08.html
+localstatedir = prefix / get_option('localstatedir')
+
+statedir_override = get_option('with-statedir-path')
+if statedir_override != ''
+    localstatedir = statedir_override
+endif
+
+spooldir = prefix / 'var/spool/netatalk'
+
+spooldir_override = get_option('with-spooldir')
+if spooldir_override != ''
+    spooldir = spooldir_override
 endif
 
 if host_os == 'darwin'
@@ -900,7 +917,6 @@ libevent = dependency(
 #
 
 cups = dependency('cups', required: false)
-spooldir = ''
 cups_config = find_program('cups-config', required: false)
 
 if not (get_option('with-appletalk') or get_option('with-cups'))
@@ -918,11 +934,6 @@ else
             check: true,
         ).stdout().strip()
         cdata.set('CUPS_API_VERSION', '"' + cups_api_version + '"')
-        if get_option('with-spooldir') != ''
-            spooldir += get_option('with-spooldir')
-        else
-            spooldir += prefix / 'var/spool/netatalk'
-        endif
     else
         warning('CUPS not found, you might need to specify the path to cups-config')
     endif
@@ -2325,6 +2336,7 @@ summary_info = {
     'Manual page directory': mandir,
     'System executable directory': sbindir,
     'Package conf directory': pkgconfdir,
+    'Shared state directory': localstatedir,
 }
 summary(summary_info, bool_yn: true, section: 'Directories:')
 
@@ -2395,7 +2407,7 @@ summary_info = {
     '  init directory': init_dirs,
     '  Netatalk lockfile': lockfile,
     '  PAM config directory': pam_confdir,
-    '  CUPS print spool directory': spooldir,
+    '  Print spool directory': spooldir,
     '  User home basedir': homedir,
 }
 if have_spotlight

--- a/meson.build
+++ b/meson.build
@@ -85,7 +85,7 @@ if statedir_override != ''
     localstatedir = statedir_override
 endif
 
-spooldir = prefix / 'var/spool/netatalk'
+spooldir = get_option('localstatedir') / 'spool' / 'netatalk'
 
 spooldir_override = get_option('with-spooldir')
 if spooldir_override != ''

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -298,6 +298,12 @@ option(
     description: 'Set path for spooldir used for CUPS support',
 )
 option(
+    'with-statedir-path',
+    type: 'string',
+    value: '',
+    description: 'Set path for statedir used for CNID databases etc.',
+)
+option(
     'with-tracker-install-prefix',
     type: 'string',
     value: '',


### PR DESCRIPTION
Introduce override option for statedir `with-statedir-path`, while refactoring for future FHS compliance of the CNID dir.

At the same time, make the print spool dir FHS compliant.

Also updates the documentation with the current de-facto statedir defaults.