### PR TITLE
AFP over ASP: Cleanup unused code

### DIFF
--- a/include/atalk/globals.h
+++ b/include/atalk/globals.h
@@ -117,7 +117,6 @@ struct afp_options {
     char *uuidconf;
     char *guest, *loginmesg, *keyfile, *passwdfile, *extmapfile;
     char *uamlist;
-    char authprintdir;
     char *signatureopt;
     unsigned char signature[16];
     char *k5service, *k5realm, *k5keytab;


### PR DESCRIPTION
* Completely remove `afp_options.authprintdir` in `include/atalk/globals.h`
* Remove `afp_authprint_remove` from `etc/afpd/afp_asp.c`