### PR TITLE
Spotlight: Support TinySPARQL/LocalSearch

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -86,7 +86,7 @@ Required:
 Required for Spotlight support:
 
   - talloc
-  - tracker version 0.12 or later
+  - tracker version 0.12 or later, or tinysparql and localsearch version 3.8.0 or later
   - bison
   - flex
 

--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -1128,7 +1128,7 @@
 
           <listitem>
             <para>Impose a limit on the number of results queried from Tracker
-            via SPARQL queries.</para>
+            or LocalSearch via SPARQL queries.</para>
           </listitem>
         </varlistentry>
 
@@ -1172,8 +1172,8 @@
           <emphasis>yes</emphasis>) <type>(G)</type></term>
 
           <listitem>
-            <para>Whether to start a dbus instance for use with
-            Tracker.</para>
+            <para>Whether to start a dbus instance for use with Tracker or
+            LocalSearch.</para>
           </listitem>
         </varlistentry>
 
@@ -1182,9 +1182,10 @@
           <emphasis>yes</emphasis>) <type>(G)</type></term>
 
           <listitem>
-            <para>Whether to start Tracker with "<command>tracker daemon
-            -s</command>". In case of old Tracker, "<command>tracker-control
-            -s</command>" is used instead.</para>
+            <para>Whether to start Tracker or LocalSearch with "<command>tracker
+            daemon -s</command>" or "<command>localsearch daemon -s</command>".
+            In case of old Tracker, "<command>tracker-control -s</command>" is
+            used instead.</para>
           </listitem>
         </varlistentry>
 

--- a/doc/manual/configuration.xml
+++ b/doc/manual/configuration.xml
@@ -1465,9 +1465,11 @@ aclmode = passthrough</screen>
       </indexterm></title>
 
     <para>Starting with version 3.1 Netatalk supports Spotlight searching.
-    Netatalk uses GNOME <ulink
-    url="https://projects.gnome.org/tracker/">Tracker</ulink> as metadata
-    store, indexer and search engine.</para>
+      Netatalk uses GNOME <ulink
+      url="https://projects.gnome.org/tracker/">Tracker</ulink> or its later
+      incarnation TinySPARQL/<ulink
+      url="https://gnome.pages.gitlab.gnome.org/localsearch/">LocalSearch
+      </ulink> as metadata store, indexer and search engine.</para>
 
     <sect2>
       <title>Configuration</title>

--- a/doc/manual/install.xml
+++ b/doc/manual/install.xml
@@ -266,15 +266,16 @@ Resolving deltas: 100% (32227/32227), done.
           </listitem>
 
           <listitem>
-            <para>Tracker / talloc / bison / flex</para>
+            <para>Tracker / TinySPARQL / LocalSearch / talloc / bison / flex</para>
 
-            <para>Netatalk uses <ulink
-            url="https://tracker.gnome.org">Tracker</ulink> as the metadata
-            backend for Spotlight<indexterm>
-                <primary>Spotlight</primary>
-              </indexterm> search indexing. The minimum required version is
-            0.7 as this was the first version to support <ulink
-            url="https://gnome.pages.gitlab.gnome.org/tracker/">SPARQL</ulink>.</para>
+            <para>Netatalk uses <ulink url="https://tracker.gnome.org">Tracker</ulink>
+              or its later incarnation TinySPARQL/<ulink
+              url="https://gnome.pages.gitlab.gnome.org/localsearch/">LocalSearch
+              </ulink> as the metadata backend for Spotlight<indexterm>
+              <primary>Spotlight</primary></indexterm> search indexing. The minimum
+              required version is 0.7 as this was the first version to support <ulink
+              url="https://gnome.pages.gitlab.gnome.org/tracker/">SPARQL</ulink>.
+              </para>
 
             <para>Samba's talloc library, a Yacc parser such as bison, and a
             lexer like flex are also required for Spotlight.</para>

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -49,7 +49,7 @@ if have_spotlight
     afpd_external_deps += [
         glib,
         talloc,
-        tracker_sparql,
+        sparql,
     ]
 endif
 

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -177,7 +177,7 @@ static void sigterm_cb(evutil_socket_t fd _U_, short what _U_, void *arg _U_)
     event_del(timer_ev);
 
 #ifdef WITH_SPOTLIGHT
-    system(TRACKER_MANAGING_COMMAND " -t");
+    system(INDEXER_COMMAND " -t");
 #endif
     kill_childs(SIGTERM, &afpd_pid, &cnid_metad_pid, &dbus_pid, NULL);
 }
@@ -187,7 +187,7 @@ static void sigquit_cb(evutil_socket_t fd _U_, short what _U_, void *arg _U_)
 {
     LOG(log_note, logtype_afpd, "Exiting on SIGQUIT");
 #ifdef WITH_SPOTLIGHT
-    system(TRACKER_MANAGING_COMMAND " -t");
+    system(INDEXER_COMMAND " -t");
 #endif
     kill_childs(SIGQUIT, &afpd_pid, &cnid_metad_pid, &dbus_pid, NULL);
 }
@@ -377,7 +377,7 @@ static void show_netatalk_paths( void )
 #ifdef WITH_SPOTLIGHT
   printf( "           dbus-daemon:\t%s\n", DBUS_DAEMON_PATH);
   printf( "     dbus-session.conf:\t%s\n", _PATH_CONFDIR "dbus-session.conf");
-  printf( "       tracker manager:\t%s\n", TRACKER_PREFIX "/bin/" TRACKER_MANAGING_COMMAND);
+  printf( "       indexer manager:\t%s\n", INDEXER_COMMAND);
 #endif
 
 #ifndef SOLARIS
@@ -503,8 +503,8 @@ int main(int argc, char **argv)
         set_sl_volumes();
 
         if (atalk_iniparser_getboolean(obj.iniconfig, INISEC_GLOBAL, "start tracker", 1)) {
-            LOG(log_note, logtype_default, "Starting Tracker: " TRACKER_PREFIX "/bin/" TRACKER_MANAGING_COMMAND " -s");
-            system(TRACKER_PREFIX "/bin/" TRACKER_MANAGING_COMMAND " -s");
+            LOG(log_note, logtype_default, "Starting indexer: " INDEXER_COMMAND " -s");
+            system(INDEXER_COMMAND " -s");
         }
     }
 #endif

--- a/etc/spotlight/meson.build
+++ b/etc/spotlight/meson.build
@@ -23,7 +23,7 @@ executable(
         glib,
         mysqlclient,
         talloc,
-        tracker_sparql,
+        sparql,
     ],
     c_args: ['-DMAIN'],
     install: false,
@@ -41,7 +41,7 @@ libspotlight = static_library(
     dependencies: [
         glib,
         talloc,
-        tracker_sparql,
+        sparql,
     ],
     include_directories: root_includes,
     c_args: ['-DDBUS_API_SUBJECT_TO_CHANGE', statedir],

--- a/meson.build
+++ b/meson.build
@@ -781,27 +781,32 @@ endif
 
 talloc = dependency('talloc', required: false)
 
-tracker_manager = ''
 tracker_prefix = get_option('with-tracker-prefix')
 
 if not get_option('with-spotlight')
     have_spotlight = false
 else
-    # Check for tracker SPARQL
+    # Check for SPARQL
 
-    tracker_sparql_version = ['3.0', '2.0', '1.0']
+    sparql_versions = [
+        'tracker-sparql-3.0',
+        'tracker-sparql-2.0',
+        'tracker-sparql-1.0'
+    ]
 
-    foreach version : tracker_sparql_version
-        tracker_sparql = dependency('tracker-sparql-' + version, required: false)
-        if tracker_sparql.found()
+    foreach sparql_version : sparql_versions
+        sparql = dependency(sparql_version, required: false)
+        if sparql.found()
             break
         endif
     endforeach
 
-    if not tracker_sparql.found()
-        warning('tracker SPARQL not found (required for Spotlight support)')
+    if not sparql.found()
+        warning('Tracker SPARQL or TinySPARQL not found (required for Spotlight support)')
     else
-        # Check for tracker
+        sparql_prefix = sparql.get_variable(pkgconfig: 'prefix')
+
+        # Check for indexer
 
         tracker = find_program(
             'tracker',
@@ -818,49 +823,36 @@ else
             dirs: tracker_prefix + '/bin',
             required: false,
         )
+        localsearch = find_program(
+            'localsearch',
+            dirs: tracker_prefix + '/bin',
+            required: false,
+        )
 
-        if tracker.found()
-            cdata.set(
-                'TRACKER_MANAGING_COMMAND',
-                '"tracker daemon"',
-            )
-            cdata.set(
-                'TRACKER_PREFIX',
-                '"'
-                + tracker_sparql.get_variable(pkgconfig: 'prefix')
-                + '"',
-            )
-            tracker_manager += 'tracker'
+        indexer_command = ''
+
+        if localsearch.found()
+            cdata.set('HAVE_TRACKER3', 1)
+            indexer_command = '"' + localsearch.full_path() + ' daemon"'
         elif tracker3.found()
             cdata.set('HAVE_TRACKER3', 1)
-            cdata.set(
-                'TRACKER_MANAGING_COMMAND',
-                '"tracker3 daemon"',
-            )
-            cdata.set(
-                'TRACKER_PREFIX',
-                '"'
-                + tracker_sparql.get_variable(pkgconfig: 'prefix')
-                + '"',
-            )
-            tracker_manager += 'tracker3'
+            indexer_command = '"' + tracker3.full_path() + ' daemon"'
+        elif tracker.found()
+            indexer_command = '"' + tracker.full_path() + ' daemon"'
         elif tracker_control.found()
-            cdata.set(
-                'TRACKER_MANAGING_COMMAND',
-                '"tracker-control"',
-            )
-            cdata.set(
-                'TRACKER_PREFIX',
-                '"'
-                + tracker_sparql.get_variable(pkgconfig: 'prefix')
-                + '"',
-            )
-            tracker_manager += 'tracker_control'
+            indexer_command = '"' + tracker_control.full_path() + '"'
         endif
-        tracker_found = (tracker.found() or tracker3.found() or tracker_control.found())
-        if not tracker_found
-            warning('tracker not found (required for Spotlight support)')
+        indexer_found = (
+            tracker.found()
+            or tracker3.found()
+            or tracker_control.found()
+            or localsearch.found()
+        )
+        if not indexer_found
+            warning('Tracker or LocalSearch not found (required for Spotlight support)')
         else
+            cdata.set('INDEXER_COMMAND', indexer_command)
+
             # Check for talloc
 
             if talloc.found()
@@ -875,8 +867,8 @@ else
 endif
 
 have_spotlight = (
-    tracker_sparql.found()
-    and tracker_found
+    sparql.found()
+    and indexer_found
     and talloc.found()
     and flex.found()
     and bison.found()
@@ -2400,12 +2392,7 @@ summary_info = {
 }
 if have_spotlight
     summary_info += {
-        '  tracker prefix': tracker_sparql.get_variable(pkgconfig: 'prefix'),
-        '  tracker install prefix': tracker_sparql.get_variable(
-            pkgconfig: 'prefix',
-        ),
-        '  tracker manager': tracker_sparql.get_variable(pkgconfig: 'prefix') / 'bin' / tracker_manager
-        + ' daemon',
+        '  Indexer command': indexer_command,
     }
 endif
 summary(summary_info, bool_yn: true, section: '  Paths:')

--- a/meson_config.h
+++ b/meson_config.h
@@ -625,11 +625,8 @@
 /* Define if TCP wrappers should be used */
 #mesondefine TCPWRAP
 
-/* tracker managing command */
-#mesondefine TRACKER_MANAGING_COMMAND
-
-/* Path to Tracker */
-#mesondefine TRACKER_PREFIX
+/* Indexer managing command */
+#mesondefine INDEXER_COMMAND
 
 /* Define if cracklib should be used */
 #mesondefine USE_CRACKLIB

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -45,7 +45,7 @@ if have_spotlight
     test_external_deps += [
         glib,
         talloc,
-        tracker_sparql,
+        sparql,
     ]
 endif
 


### PR DESCRIPTION
As of version 3.8 Tracker has [split into TinySPARQL and LocalSearch](https://blogs.gnome.org/carlosg/2024/07/14/goodbye-tracker-hello-tinysparql-and-localsearch/) with command line tool renamed to `localsearch`.