### PR TITLE
Make last CNID backend writable when running tests

### DIFF
--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -1022,8 +1022,10 @@ static struct vol *creatvol(AFPObj *obj,
             || accessvol(obj, getoption(obj->iniconfig, section, "rwlist", preset, NULL), pwd->pw_name) == 0)
             volume->v_flags |= AFPVOL_RO;
     }
+#ifndef WITH_TESTS
     if (0 == strcmp(volume->v_cnidscheme, "last"))
         volume->v_flags |= AFPVOL_RO;
+#endif
 
     if ((volume->v_flags & AFPVOL_NODEV))
         volume->v_ad_options |= ADVOL_NODEV;

--- a/meson.build
+++ b/meson.build
@@ -2243,6 +2243,10 @@ if have_webmin
     cdata.set('init_a2boot_restart', init_a2boot_restart)
 endif
 
+if get_option('with-tests')
+    cdata.set('WITH_TESTS', 1)
+endif
+
 configure_file(
     input: 'meson_config.h',
     output: 'config.h',

--- a/meson_config.h
+++ b/meson_config.h
@@ -652,6 +652,9 @@
 /* Define whether to enable Spotlight support */
 #mesondefine WITH_SPOTLIGHT
 
+/* Define when the test suite should be executed */
+#mesondefine WITH_TESTS
+
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
 #if defined AC_APPLE_UNIVERSAL_BUILD

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -180,13 +180,13 @@ afpdtest = executable(
 test_sh = find_program('test.sh')
 
 test(
-    'test1',
+    'test prep',
     test_sh,
     is_parallel: false,
     priority: 1,
 )
 test(
-    'test2',
+    'test suite',
     afpdtest,
     is_parallel: false,
     priority: 0,

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -87,20 +87,11 @@ int main()
     TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT_PARENT, "test"), 0);
     TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT, ""), 0);
 
-#if 0
-// this doesn't work anymore since cnid sheme = last (which we use in the test)
-// has been changed to force read-only mode for the volume
     TEST_expr(reti = createdir(&obj, vid, DIRDID_ROOT, "dir1"),
               reti == 0 || reti == AFPERR_EXIST);
 
     TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT, "dir1"), 0);
-#endif
-/*
-  FIXME: this doesn't work although it should. "//" get translated to \000 \000 at means ".."
-  i.e. this should getfiledirparms for DIRDID_ROOT_PARENT -- at least afair!
-    TEST_int(getfiledirparms(&configs->obj, vid, DIRDID_ROOT, "//"), 0);
-*/
-#if 0
+    TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT, "\000\000"), 0);
     TEST_int(createfile(&obj, vid, DIRDID_ROOT, "dir1/file1"), 0);
     TEST_int(delete(&obj, vid, DIRDID_ROOT, "dir1/file1"), 0);
     TEST_int(delete(&obj, vid, DIRDID_ROOT, "dir1"), 0);
@@ -108,7 +99,6 @@ int main()
     TEST_int(createfile(&obj, vid, DIRDID_ROOT, "file1"), 0);
     TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT, "file1"), 0);
     TEST_int(delete(&obj, vid, DIRDID_ROOT, "file1"), 0);
-#endif
 
     /* test enumerate.c stuff */
     TEST_int(enumerate(&obj, vid, DIRDID_ROOT), 0);


### PR DESCRIPTION
When enabling tests with `-Dwith-tests=true`, `last` volumes are made writable.

Enabling and touching up all write tests in the afpd test suite.