### PR TITLE
test: Bump tested protocol version to AFP 3.4

### DIFF
--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -180,13 +180,13 @@ afpdtest = executable(
 test_sh = find_program('test.sh')
 
 test(
-    'test prep',
+    'afpd integration tests - setup',
     test_sh,
     is_parallel: false,
     priority: 1,
 )
 test(
-    'test suite',
+    'afpd integration tests - run',
     afpdtest,
     is_parallel: false,
     priority: 0,

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -68,7 +68,7 @@ int main()
     TEST( cnid_init() );
     TEST( load_volumes(&obj, LV_ALL) );
     TEST_int( dircache_init(8192), 0);
-    obj.afp_version = 32;
+    obj.afp_version = 34;
 
     printf("\n");
 


### PR DESCRIPTION
AFP version shouldn't make a difference at this test level, but bumping to the latest version for good measure.