### PR TITLE
GitHub CI: Bump NetBSD vmactions runner, skip krbV UAM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -516,7 +516,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/netbsd-vm@v1.1.3
+        uses: vmactions/netbsd-vm@v1.1.4
         with:
           release: "9.4"
           copyback: false
@@ -529,6 +529,7 @@ jobs:
               flex \
               gcc13 \
               gnome-tracker \
+              heimdal \
               libcups \
               libevent \
               libgcrypt \
@@ -547,6 +548,7 @@ jobs:
               -Dpkg_config_path=/usr/pkg/lib/pkgconfig \
               -Dwith-appletalk=true \
               -Dwith-dtrace=false \
+              -Dwith-krbV-uam=false \
               -Dwith-tests=true
             meson compile -C build
             cd build


### PR DESCRIPTION
It seems heimdal is broken in NetBSD right now, so disabling the krbV UAM for the time being.