### PR TITLE
initscripts: Remove redundant nbpunrgstr cleanup in atalkd systemd config

### DIFF
--- a/distrib/initscripts/systemd.atalkd.service.in
+++ b/distrib/initscripts/systemd.atalkd.service.in
@@ -13,8 +13,6 @@ ExecStartPre=/bin/sh -c 'systemctl set-environment ATALK_NAME=$$(hostname|cut -d
 ExecStart=@sbindir@/atalkd
 ExecStartPost=-@bindir@/nbprgstr -p 4 "${ATALK_NAME}:Workstation"
 ExecStartPost=-@bindir@/nbprgstr -p 4 "${ATALK_NAME}:netatalk"
-ExecStop=-@bindir@/nbpunrgstr "${ATALK_NAME}:Workstation"
-ExecStop=-@bindir@/nbpunrgstr "${ATALK_NAME}:netatalk"
 Restart=always
 RestartSec=1
 


### PR DESCRIPTION
As concluded elsewhere, nbpunrgstr is redundant when atalkd is already shutting down. The NBP registrations are automatically released.