### PR TITLE
testsuite: Don't treat initial spectest.sh run as a failure

### DIFF
--- a/test/testsuite/spectest.sh
+++ b/test/testsuite/spectest.sh
@@ -37,7 +37,7 @@ EOF
     echo "A template configuration file spectest.conf has been generated."
     echo "Adjust it to match the AFP server under test and run this script again."
     echo "====================================="
-    exit 1
+    exit 0
 fi
 
 . ./test/testsuite/spectest.conf


### PR DESCRIPTION
The initial run of the spectest.sh script generates a config file that needs to be edited before running the whole suite. Before we treated this as a failed test to call attention this this fact. However this blocked CI jobs when tests and testsuite were both enabled and tests were ran.