### PR TITLE
testsuite: Treat not tested as non failure and reduce verbosity

### DIFF
--- a/test/testsuite/Error.c
+++ b/test/testsuite/Error.c
@@ -36,7 +36,8 @@ unsigned int ret;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
+
 	memset(dsi->commands, 0, sizeof(dsi->commands));
 	did  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!did) {
@@ -181,7 +182,7 @@ int pdir;
 int ret;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -266,7 +267,7 @@ int  dir = 0;
 char *name = "t99 dir no access";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -300,7 +301,7 @@ int dt;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	dt = FPOpenDT(Conn,vol);
 	FAIL (ntohl(AFPERR_NOOBJ) != FPAddComment(Conn, vol,  DIRDID_ROOT , name1,"essai"))
@@ -378,7 +379,7 @@ int  dt;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -485,7 +486,7 @@ int  dt;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -587,7 +588,7 @@ int  dt;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -691,7 +692,7 @@ int  dt;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
     dir = 0;
     err = ntohl(AFPERR_PARAM);
@@ -765,7 +766,7 @@ int  dt;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
     /* ---- fork.c ---- */
 	fork = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap ,DIRDID_ROOT_PARENT, "",OPENACC_WR | OPENACC_RD);
@@ -905,7 +906,7 @@ int  dt;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
     /* ---- fork.c ---- */
 	fork = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap , tdir, tname,OPENACC_WR | OPENACC_RD);
@@ -1033,7 +1034,7 @@ int  dt;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
     /* ---- fork.c ---- */
 	fork = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap , tdir, tname,OPENACC_WR | OPENACC_RD);
@@ -1165,7 +1166,7 @@ DSI *dsi = &Conn->dsi;
 DSI *dsi2;
 int  dt;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;

--- a/test/testsuite/Error.c
+++ b/test/testsuite/Error.c
@@ -37,8 +37,6 @@ unsigned int ret;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Error:test36: no folder error (ERR_NOOBJ)\n");
 	memset(dsi->commands, 0, sizeof(dsi->commands));
 	did  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!did) {
@@ -75,12 +73,14 @@ unsigned int ret;
 		my_dsi_cmd_receive(dsi);
 		ret = dsi->header.dsi_code;
     	if (ntohl(AFPERR_NOOBJ) != ret) {
+		if (!Quiet) {
 			fprintf(stdout,"\tFAILED command %3i %s\t result %d %s\n", cmd, AfpNum2name(cmd),ntohl(ret), afp_error(ret));
+		}
 			failed_nomsg();
     	}
     }
 test_exit:
-	exit_test("test36");
+	exit_test("Error:test36: no folder error (ERR_NOOBJ)");
 }
 
 /* ----------------------
@@ -120,11 +120,15 @@ DSI *dsi;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 
 	if (filedir.pdid != 2) {
-		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.pdid, 2 );
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n",filedir.pdid, 2 );
+		}
 		failed_nomsg();
 	}
 	if (strcmp(filedir.lname, name)) {
-		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name );
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name );
+		}
 		failed_nomsg();
 	}
 	FAIL (FPEnumerate(Conn, vol,  DIRDID_ROOT , "", 0, bitmap))
@@ -136,11 +140,15 @@ DSI *dsi;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 
 	if (filedir.pdid != 2) {
-		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.pdid, 2 );
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n",filedir.pdid, 2 );
+		}
 		failed_nomsg();
 	}
 	if (strcmp(filedir.lname, name)) {
-		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name );
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name );
+		}
 		failed_nomsg();
 	}
 
@@ -174,8 +182,6 @@ int ret;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"test95: exchange files\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -250,7 +256,7 @@ uint16_t vol = VolID;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name1))
 test_exit:
-	exit_test("test95");
+	exit_test("Error:test95: exchange files");
 }
 
 /* ----------------- */
@@ -261,8 +267,6 @@ char *name = "t99 dir no access";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Error:t99: test folder without access right\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -278,7 +282,7 @@ uint16_t vol = VolID;
 #endif
 	delete_folder(vol, DIRDID_ROOT, name);
 test_exit:
-	exit_test("test99");
+	exit_test("Error:test99: test folder without access right");
 }
 
 /* --------------------- */
@@ -297,8 +301,6 @@ int dt;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Error:t100: no obj cname error (AFPERR_NOOBJ)\n");
 
 	dt = FPOpenDT(Conn,vol);
 	FAIL (ntohl(AFPERR_NOOBJ) != FPAddComment(Conn, vol,  DIRDID_ROOT , name1,"essai"))
@@ -357,7 +359,7 @@ int dt;
 	FAIL (ntohl(AFPERR_NOOBJ) != FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 
 	FAIL (ntohl(AFPERR_NOOBJ) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, DIRDID_ROOT, name1, name))
-	exit_test("test100");
+	exit_test("Error:test100: no obj cname error (AFPERR_NOOBJ)");
 }
 
 /* --------------------- */
@@ -377,8 +379,6 @@ int  dt;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Error:t101: access error cname \n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -447,7 +447,7 @@ int  dt;
 	FAIL (ntohl(AFPERR_ACCESS) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, DIRDID_ROOT, name1, name))
 	delete_folder(vol, DIRDID_ROOT, ndir);
 test_exit:
-	exit_test("test101");
+	exit_test("Error:test101: access error cname");
 }
 
 /* --------------------- */
@@ -486,8 +486,6 @@ int  dt;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Error:t102: access error but not cname \n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -570,7 +568,7 @@ int  dt;
 	if (ret)
 		delete_folder(vol, DIRDID_ROOT, name1);
 test_exit:
-	exit_test("test102");
+	exit_test("Error:test102: access error but not cname");
 }
 
 /* --------------------- */
@@ -590,8 +588,6 @@ int  dt;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"t103: did access error \n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -676,7 +672,7 @@ int  dt;
 	if (ret)
 		delete_folder(vol, DIRDID_ROOT, name1);
 test_exit:
-	exit_test("test103");
+	exit_test("Error:test103: did access error");
 }
 
 /* --------------------- */
@@ -696,8 +692,6 @@ int  dt;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Error:t105: bad DID in call \n");
 
     dir = 0;
     err = ntohl(AFPERR_PARAM);
@@ -751,7 +745,7 @@ int  dt;
 	FAIL (err != FPRename(Conn, vol, dir, name1, name))
 	FAIL (err != FPDelete(Conn, vol,  dir , name1))
 	FAIL (err != FPMoveAndRename(Conn, vol, dir, DIRDID_ROOT, name1, name))
-	exit_test("test105");
+	exit_test("Error:test105: bad DID in call");
 }
 
 /* -------------------------- */
@@ -772,8 +766,6 @@ int  dt;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Error:test170: cname error did=1 name=\"\"\n");
 
     /* ---- fork.c ---- */
 	fork = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap ,DIRDID_ROOT_PARENT, "",OPENACC_WR | OPENACC_RD);
@@ -891,7 +883,7 @@ int  dt;
 	FAIL (ntohl(AFPERR_NOOBJ) != FPGetComment(Conn, vol,  DIRDID_ROOT_PARENT , ""))
 	FAIL (ntohl(AFPERR_NOOBJ) != FPRemoveComment(Conn, vol,  DIRDID_ROOT_PARENT , ""))
 	FAIL (FPCloseDT(Conn, dt))
-	exit_test("test170");
+	exit_test("Error:test170: cname error did=1 name=\"\"");
 }
 
 /* -------------------------- */
@@ -914,8 +906,6 @@ int  dt;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Error:test171: cname error did=1 name=bad name\n");
 
     /* ---- fork.c ---- */
 	fork = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap , tdir, tname,OPENACC_WR | OPENACC_RD);
@@ -1021,7 +1011,7 @@ int  dt;
 	FAIL (ntohl(AFPERR_NOOBJ) != FPGetComment(Conn, vol, tdir, tname))
 	FAIL (ntohl(AFPERR_NOOBJ) != FPRemoveComment(Conn, vol, tdir, tname))
 	FAIL (FPCloseDT(Conn, dt))
-	exit_test("test171");
+	exit_test("Error:test171: cname error did=1 name=bad name");
 }
 
 /* -------------------------- */
@@ -1044,8 +1034,6 @@ int  dt;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Error:test173: did error did=0 name=test173 name\n");
 
     /* ---- fork.c ---- */
 	fork = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap , tdir, tname,OPENACC_WR | OPENACC_RD);
@@ -1155,7 +1143,7 @@ int  dt;
 	FAIL (FPCloseDT(Conn, dt))
 
 	/* ---- appl.c ---- */
-	exit_test("test173");
+	exit_test("Error:test173: did error did=0 name=test173 name");
 }
 
 /* -------------------------- */
@@ -1178,8 +1166,6 @@ DSI *dsi2;
 int  dt;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Error:test174: did error two users from parent folder did=<deleted> name=test174 name\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -1256,7 +1242,7 @@ int  dt;
 	FAIL (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name1))
 
 	ret = FPExchangeFile(Conn, vol, tdir,dir, tname, name1);
-	if (ntohl(AFPERR_NOOBJ) != ret) {
+	if (ntohl(AFPERR_NOOBJ) != ret && !Quiet) {
 		if (Quirk && ret == htonl(AFPERR_PARAM))
 			fprintf(stdout,"\tFAILED (IGNORED) not always the same error code!\n");
 		else
@@ -1325,7 +1311,7 @@ int  dt;
 	FAIL (ntohl(AFPERR_NOOBJ) != FPRemoveComment(Conn, vol, tdir, tname))
 	FAIL (FPCloseDT(Conn, dt))
 test_exit:
-	exit_test("test174");
+	exit_test("Error:test174: did error two users from parent folder did=<deleted> name=test174 name");
 }
 
 /* ----------- */
@@ -1333,25 +1319,23 @@ void Error_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"Various errors\n");
+    fprintf(stdout,"-------------------\n");
 	test36();
+// FIXME: afpd crash in dircache_search_by_did()
+#if 0
+	test95();
+#endif
 	test99();
 	test100();
 	test101();
 	test102();
 	test103();
 	test105();
-// FIXME: these tests are crashing the test suite
+// FIXME: afpd crash in dircache_search_by_did()
 #if 0
-	test95();
 	test170();
 	test171();
 	test173();
-	test174();
-#else
-    fprintf(stdout,"test95 - SKIPPED - crashing test suite\n");
-    fprintf(stdout,"test170 - SKIPPED - crashing test suite\n");
-    fprintf(stdout,"test171 - SKIPPED - crashing test suite\n");
-    fprintf(stdout,"test173 - SKIPPED - crashing test suite\n");
-    fprintf(stdout,"test174 - SKIPPED - crashing test suite\n");
 #endif
+	test174();
 }

--- a/test/testsuite/Error.c
+++ b/test/testsuite/Error.c
@@ -183,6 +183,11 @@ int ret;
 uint16_t vol = VolID;
 
 	ENTER_TEST
+	// FIXME: afpd crash in dircache_search_by_did()
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -767,6 +772,11 @@ int  dt;
 	dsi = &Conn->dsi;
 
 	ENTER_TEST
+	// FIXME: afpd crash in dircache_search_by_did()
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 
     /* ---- fork.c ---- */
 	fork = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap ,DIRDID_ROOT_PARENT, "",OPENACC_WR | OPENACC_RD);
@@ -884,6 +894,8 @@ int  dt;
 	FAIL (ntohl(AFPERR_NOOBJ) != FPGetComment(Conn, vol,  DIRDID_ROOT_PARENT , ""))
 	FAIL (ntohl(AFPERR_NOOBJ) != FPRemoveComment(Conn, vol,  DIRDID_ROOT_PARENT , ""))
 	FAIL (FPCloseDT(Conn, dt))
+
+test_exit:
 	exit_test("Error:test170: cname error did=1 name=\"\"");
 }
 
@@ -907,6 +919,11 @@ int  dt;
 	dsi = &Conn->dsi;
 
 	ENTER_TEST
+	// FIXME: afpd crash in dircache_search_by_did()
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 
     /* ---- fork.c ---- */
 	fork = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap , tdir, tname,OPENACC_WR | OPENACC_RD);
@@ -1012,6 +1029,8 @@ int  dt;
 	FAIL (ntohl(AFPERR_NOOBJ) != FPGetComment(Conn, vol, tdir, tname))
 	FAIL (ntohl(AFPERR_NOOBJ) != FPRemoveComment(Conn, vol, tdir, tname))
 	FAIL (FPCloseDT(Conn, dt))
+
+test_exit:
 	exit_test("Error:test171: cname error did=1 name=bad name");
 }
 
@@ -1035,6 +1054,11 @@ int  dt;
 	dsi = &Conn->dsi;
 
 	ENTER_TEST
+	// FIXME: afpd crash in dircache_search_by_did()
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 
     /* ---- fork.c ---- */
 	fork = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap , tdir, tname,OPENACC_WR | OPENACC_RD);
@@ -1144,6 +1168,7 @@ int  dt;
 	FAIL (FPCloseDT(Conn, dt))
 
 	/* ---- appl.c ---- */
+test_exit:
 	exit_test("Error:test173: did error did=0 name=test173 name");
 }
 
@@ -1322,21 +1347,14 @@ void Error_test()
     fprintf(stdout,"Various errors\n");
     fprintf(stdout,"-------------------\n");
 	test36();
-// FIXME: afpd crash in dircache_search_by_did()
-#if 0
-	test95();
-#endif
 	test99();
 	test100();
 	test101();
 	test102();
 	test103();
 	test105();
-// FIXME: afpd crash in dircache_search_by_did()
-#if 0
 	test170();
 	test171();
 	test173();
-#endif
 	test174();
 }

--- a/test/testsuite/FPAddAPPL.c
+++ b/test/testsuite/FPAddAPPL.c
@@ -16,8 +16,6 @@ unsigned int pdir;
 int dir;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPAddAPPL:test214: test appl\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -65,7 +63,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , file))
 	FAIL (FPCloseDT(Conn,dt))
 test_exit:
-	exit_test("test214");
+	exit_test("FPAddAPPL:test214: test appl");
 }
 
 /* ------------------------- */
@@ -85,8 +83,6 @@ struct afp_filedir_parms filedir;
 int dir;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPAddAPPL:test301: test appl\n");
     if (!Conn2) {
 	 	dir = get_did(Conn, vol, did, name);
 	 	if (!dir) {
@@ -102,12 +98,16 @@ int dir;
 		     (1<< DIRPBIT_ATTR) |  (1<< DIRPBIT_LNAME) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID)|(1<< DIRPBIT_ACCESS)
 		     | (1<<DIRPBIT_UID) | (1 << DIRPBIT_GID));
 		if (ret) {
-			fprintf(stdout, "OK can't create a file\n");
+			if (!Quiet) {
+				fprintf(stdout, "OK can't create a file\n");
+			}
 			goto fin;
 		}
 		fork = FPOpenFork(Conn, vol, OPENFORK_DATA  , 0 ,dir, file,OPENACC_RD| OPENACC_WR );
 		if (fork) {
-			fprintf(stdout, "Ouch now we have a fork open then read/write in a folder we no access\n");
+			if (!Quiet) {
+				fprintf(stdout, "Ouch now we have a fork open then read/write in a folder we no access\n");
+			}
 			FPCloseFork(Conn,fork);
 		}
 	}
@@ -142,7 +142,7 @@ int dir;
 		FPCloseVol(Conn2,vol2);
 	}
 fin:
- 	exit_test("test301");
+ 	exit_test("FPAddAPPL:test301: test appl");
 }
 
 /* ----------- */
@@ -150,6 +150,7 @@ void FPAddAPPL_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPAddAPPL page 94\n");
+    fprintf(stdout,"-------------------\n");
 	test214();
 /*
 	test301();

--- a/test/testsuite/FPAddAPPL.c
+++ b/test/testsuite/FPAddAPPL.c
@@ -15,7 +15,7 @@ unsigned int pdir;
 
 int dir;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -82,7 +82,7 @@ uint16_t fork;
 struct afp_filedir_parms filedir;
 int dir;
 
-	enter_test();
+	ENTER_TEST
     if (!Conn2) {
 	 	dir = get_did(Conn, vol, did, name);
 	 	if (!dir) {

--- a/test/testsuite/FPAddComment.c
+++ b/test/testsuite/FPAddComment.c
@@ -21,17 +21,16 @@ char *cmt;
 int  dt;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPAddComment:test55: add comment\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
 	}
 
 	if (!(rdir = read_only_folder(vol, DIRDID_ROOT, name2) ) ) {
+		nottested();
 		goto test_exit;
 	}
-	if (!(pdir = no_access_folder(vol, DIRDID_ROOT, name))) {
+	if (!(pdir = no_access_folder(vol, DIRDID_ROOT, name)) && !Quiet) {
 		fprintf(stdout,"\tWARNING folder without access failed\n");
 	}
 	dsi2 = &Conn2->dsi;
@@ -101,7 +100,7 @@ fin:
 	}
 	FAIL (FPCloseDT(Conn, dt))
 test_exit:
-	exit_test("test55");
+	exit_test("FPAddComment:test55: add comment");
 }
 
 /* ----------- */
@@ -109,5 +108,6 @@ void FPAddComment_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPAddComment page 96\n");
+    fprintf(stdout,"-------------------\n");
 	test55();
 }

--- a/test/testsuite/FPAddComment.c
+++ b/test/testsuite/FPAddComment.c
@@ -20,7 +20,7 @@ DSI *dsi = &Conn->dsi;
 char *cmt;
 int  dt;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;

--- a/test/testsuite/FPAddIcon.c
+++ b/test/testsuite/FPAddIcon.c
@@ -56,7 +56,7 @@ uint16_t dt;
 int ret;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	dt = FPOpenDT(Conn,vol);
 	FAIL (FPAddIcon(Conn,  dt, "ttxt", "3DMF", 1, 0, 256, icon0_256 ))

--- a/test/testsuite/FPAddIcon.c
+++ b/test/testsuite/FPAddIcon.c
@@ -57,8 +57,6 @@ int ret;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPAddIcon:test212: Add Icon call\n");
 
 	dt = FPOpenDT(Conn,vol);
 	FAIL (FPAddIcon(Conn,  dt, "ttxt", "3DMF", 1, 0, 256, icon0_256 ))
@@ -69,7 +67,9 @@ DSI *dsi = &Conn->dsi;
 		failed();
 	}
 	else if (memcmp(dsi->commands, icon0_256, 256)) {
-		fprintf(stdout,"\tFAILED AddIcon and GetIcon data differ\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED AddIcon and GetIcon data differ\n");
+		}
 		failed_nomsg();
 	}
 
@@ -80,7 +80,9 @@ DSI *dsi = &Conn->dsi;
 		failed();
 	}
 	else if (memcmp(dsi->commands, icon0_256, 256)) {
-		fprintf(stdout,"\tFAILED AddIcon and GetIcon data differ\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED AddIcon and GetIcon data differ\n");
+		}
 		failed_nomsg();
 	}
 
@@ -92,25 +94,26 @@ DSI *dsi = &Conn->dsi;
 		failed();
 	}
 	else if (memcmp(dsi->commands, icon0_64, 64)) {
-		fprintf(stdout,"\tFAILED AddIcon and GetIcon data differ\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED AddIcon and GetIcon data differ\n");
+		}
 		failed_nomsg();
 	}
 
 	FAIL (htonl(AFPERR_ITYPE) != FPAddIcon(Conn,  dt, "ttxt", "3DMF", 4, 0, 256, icon0_256))
 
 	FPCloseDT(Conn,dt);
-	exit_test("test212");
+	exit_test("FPAddIcon:test212: Add Icon call");
 }
 
 /* ----------- */
 void FPAddIcon_test()
 {
+// FIXME: afpd crash in afp_addicon()
+#if 0
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPAddIcon page 99\n");
-// FIXME: these tests are crashing the test suite
-#if 0
+    fprintf(stdout,"-------------------\n");
 	test212();
-#else
-    fprintf(stdout,"test212 - SKIPPED - crashing test suite\n");
 #endif
 }

--- a/test/testsuite/FPAddIcon.c
+++ b/test/testsuite/FPAddIcon.c
@@ -58,6 +58,12 @@ DSI *dsi = &Conn->dsi;
 
 	ENTER_TEST
 
+	// FIXME: afpd crash in afp_addicon()
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
+
 	dt = FPOpenDT(Conn,vol);
 	FAIL (FPAddIcon(Conn,  dt, "ttxt", "3DMF", 1, 0, 256, icon0_256 ))
 	FAIL (htonl(AFPERR_PARAM) != FPAddIcon(Conn,  dt+1, "ttxt", "3DMF", 1, 0, 256, icon0_256 ))
@@ -103,17 +109,16 @@ DSI *dsi = &Conn->dsi;
 	FAIL (htonl(AFPERR_ITYPE) != FPAddIcon(Conn,  dt, "ttxt", "3DMF", 4, 0, 256, icon0_256))
 
 	FPCloseDT(Conn,dt);
+
+test_exit:
 	exit_test("FPAddIcon:test212: Add Icon call");
 }
 
 /* ----------- */
 void FPAddIcon_test()
 {
-// FIXME: afpd crash in afp_addicon()
-#if 0
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPAddIcon page 99\n");
     fprintf(stdout,"-------------------\n");
 	test212();
-#endif
 }

--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -979,7 +979,10 @@ void FPByteRangeLock_test()
 	test63();
 	test64();
 	test65();
-//	test78(); /* badly broken, didn't bother fixing for appledouble = ea */
+/* badly broken, didn't bother fixing for appledouble = ea */
+#if 0
+	test78();
+#endif
 	test79();
 	test80();
 	test329();

--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -110,7 +110,14 @@ STATIC void test63()
 char *name = "test63 FPByteLock DF";
 
 	ENTER_TEST
+	// FIXME: broken with Netatalk 4.0 - could not locate fork
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	test_bytelock(VolID, name, OPENFORK_DATA);
+
+test_exit:
 	exit_test("FPByteRangeLock:test63: FPByteLock Data Fork");
 }
 
@@ -120,7 +127,14 @@ STATIC void test64()
 char *name = "test64 FPByteLock RF";
 
 	ENTER_TEST
+	// FIXME: broken with Netatalk 4.0 - could not locate fork
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	test_bytelock(VolID, name, OPENFORK_RSCS);
+
+test_exit:
 	exit_test("FPByteRangeLock:test64: FPByteLock Resource Fork");
 }
 
@@ -187,6 +201,12 @@ STATIC void test65()
 char *name = "t65 DF FPByteLock 2 users";
 
 	ENTER_TEST
+
+	// FIXME: broken with Netatalk 4.0 - could not locate fork
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (!Quiet) {
 		fprintf(stdout,"FPByteRangeLock:test65: FPByteLock 2users DATA FORK\n");
 	}
@@ -316,6 +336,12 @@ char *name = "t79 FPByteLock Read";
 int len = (type == OPENFORK_RSCS)?(1<<FILPBIT_RFLEN):(1<<FILPBIT_DFLEN);
 
 	ENTER_TEST
+
+	// FIXME: broken with Netatalk 4.0 - could not locate fork
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
 		goto test_exit;
@@ -950,14 +976,11 @@ void FPByteRangeLock_test()
     fprintf(stdout,"FPByteRangeLock page 101\n");
     fprintf(stdout,"-------------------\n");
     test60();
-// FIXME: broken with Netatalk 4.0 - could not locate fork
-#if 0
 	test63();
 	test64();
 	test65();
 //	test78(); /* badly broken, didn't bother fixing for appledouble = ea */
 	test79();
-#endif
 	test80();
 	test329();
 	test330();

--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -955,7 +955,7 @@ void FPByteRangeLock_test()
 	test63();
 	test64();
 	test65();
-//	test78(); /* badly broken, didn't bother fixing for adouble:ea */
+//	test78(); /* badly broken, didn't bother fixing for appledouble = ea */
 	test79();
 #endif
 	test80();

--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -13,11 +13,9 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test60: illegal fork\n");
 
 	illegal_fork(dsi, AFP_BYTELOCK, name);
-	exit_test("test60");
+	exit_test("FPByteRangeLock:test60: illegal fork");
 }
 
 /* ------------------------- */
@@ -112,10 +110,8 @@ STATIC void test63()
 char *name = "test63 FPByteLock DF";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test63: FPByteLock Data Fork\n");
 	test_bytelock(VolID, name, OPENFORK_DATA);
-	exit_test("test63");
+	exit_test("FPByteRangeLock:test63: FPByteLock Data Fork");
 }
 
 /* ----------- */
@@ -124,10 +120,8 @@ STATIC void test64()
 char *name = "test64 FPByteLock RF";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test64: FPByteLock Resource Fork\n");
 	test_bytelock(VolID, name, OPENFORK_RSCS);
-	exit_test("test64");
+	exit_test("FPByteRangeLock:test64: FPByteLock Resource Fork");
 }
 
 /* -------------------------- */
@@ -193,9 +187,9 @@ STATIC void test65()
 char *name = "t65 DF FPByteLock 2 users";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test65: FPByteLock 2users DATA FORK\n");
-
+	if (!Quiet) {
+		fprintf(stdout,"FPByteRangeLock:test65: FPByteLock 2users DATA FORK\n");
+	}
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -207,11 +201,12 @@ char *name = "t65 DF FPByteLock 2 users";
     test_bytelock3(name, OPENFORK_DATA);
 
 	name = "t65 RF FPByteLock 2 users";
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test65: FPByteLock 2users Resource FORK\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPByteRangeLock:test65: FPByteLock 2users Resource FORK\n");
+	}
     test_bytelock3(name, OPENFORK_RSCS);
 test_exit:
-	exit_test("test65");
+	exit_test("FPByteRangeLock:test65: FPByteLock 2users");
 }
 
 /* ---------------------------- */
@@ -291,20 +286,22 @@ void test78()
 char *name = "t78 FPByteLock RF size -1";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test78: test Byte Lock size -1 with no large file support\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPByteRangeLock:test78: test Byte Lock size -1 with no large file support\n");
+	}
 	if (Locking) {
 		test_skipped(T_LOCKING);
 		goto test_exit;
 	}
 	test_bytelock2(name, OPENFORK_RSCS);
 
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test78: test Byte Lock size -1 with no large file support, DATA fork\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPByteRangeLock:test78: test Byte Lock size -1 with no large file support, DATA fork\n");
+	}
 	name = "t78 FPByteLock DF size -1";
 	test_bytelock2(name, OPENFORK_DATA);
 test_exit:
-	exit_test("test78");
+	exit_test("FPByteRangeLock:test78: test Byte Lock size -1");
 }
 
 /* ----------- */
@@ -319,8 +316,6 @@ char *name = "t79 FPByteLock Read";
 int len = (type == OPENFORK_RSCS)?(1<<FILPBIT_RFLEN):(1<<FILPBIT_DFLEN);
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test79: test Byte Lock and read conflict\n");
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
 		goto test_exit;
@@ -352,7 +347,7 @@ int len = (type == OPENFORK_RSCS)?(1<<FILPBIT_RFLEN):(1<<FILPBIT_DFLEN);
 		nottested();
 	}
 test_exit:
-	exit_test("test79");
+	exit_test("FPByteRangeLock:test79: test Byte Lock and read conflict");
 }
 
 /* -------------------------- */
@@ -392,16 +387,18 @@ STATIC void test80()
 char *name = "t80 RF FPByteLock Read write";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test80: Resource Fork test Byte Lock and read write same user(file)\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPByteRangeLock:test80: Resource Fork test Byte Lock and read write same user(file)\n");
+	}
 	test_bytelock5(VolID, name, OPENFORK_RSCS);
 
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test80: Data Fork test Byte Lock and read write same user(file)\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPByteRangeLock:test80: Data Fork test Byte Lock and read write same user(file)\n");
+	}
 	name = "t80 DF FPByteLock Read write";
 	test_bytelock5(VolID, name, OPENFORK_DATA);
 
-	exit_test("test80");
+	exit_test("FPByteRangeLock:test80: Resource Fork FPByteLock Read write");
 }
 
 /* --------------- */
@@ -418,8 +415,6 @@ DSI *dsi2;
 int type = OPENFORK_DATA;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test329: FPByteLock 2users DATA FORK\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -493,7 +488,7 @@ int type = OPENFORK_DATA;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test329");
+	exit_test("FPByteRangeLock:test329: FPByteLock 2users DATA FORK");
 }
 
 /* --------------- */
@@ -510,8 +505,6 @@ STATIC void test410()
     int type = OPENFORK_DATA;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test410: FPByteLock 2users DATA FORK\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -584,7 +577,7 @@ fin2:
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test410");
+	exit_test("FPByteRangeLock:test410: FPByteLock 2users DATA FORK");
 }
 
 /* ------------------- */
@@ -812,8 +805,6 @@ DSI *dsi2;
 int dir, dir2;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test330: pre OSX trash folder\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -833,7 +824,9 @@ int dir, dir2;
 	if (!fork2)
 		goto fin;
 	if (dir2 == dir) {
-		fprintf(stdout,"\tFAILED both client are using the same folder for trash\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED both client are using the same folder for trash\n");
+		}
 		failed_nomsg();
 	}
 
@@ -849,7 +842,7 @@ fin:
 	        FAIL (FPDelete(Conn, vol, dir, ""))
 	}
 test_exit:
-	exit_test("test330");
+	exit_test("FPByteRangeLock:test330: pre OSX trash folder");
 }
 
 /* --------------- */
@@ -867,8 +860,6 @@ DSI *dsi2;
 int type = OPENFORK_DATA;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test366: Locks released on exit\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -880,7 +871,7 @@ int type = OPENFORK_DATA;
 	}
 	/* hack, it closes a connection */
 	if (!Test) {
-		fprintf(stdout,"\tSKIPPED (only with -f option)\n");
+		test_skipped(T_SINGLE);
 		goto test_exit;
 	}
 
@@ -949,7 +940,7 @@ int type = OPENFORK_DATA;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test366");
+	exit_test("FPByteRangeLock:test366: Locks released on exit");
 }
 
 /* ----------- */
@@ -957,8 +948,9 @@ void FPByteRangeLock_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPByteRangeLock page 101\n");
+    fprintf(stdout,"-------------------\n");
     test60();
-// FIXME: These tests are broken with Netatalk 4.0
+// FIXME: broken with Netatalk 4.0 - could not locate fork
 #if 0
 	test63();
 	test64();
@@ -968,10 +960,7 @@ void FPByteRangeLock_test()
 #endif
 	test80();
 	test329();
-// FIXME: broken with Netatalk 4.0
-#if 0
 	test330();
-#endif
     test410();
 	/* must be the last one */
 	test366();

--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -12,7 +12,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	illegal_fork(dsi, AFP_BYTELOCK, name);
 	exit_test("FPByteRangeLock:test60: illegal fork");
@@ -109,7 +109,7 @@ STATIC void test63()
 {
 char *name = "test63 FPByteLock DF";
 
-	enter_test();
+	ENTER_TEST
 	test_bytelock(VolID, name, OPENFORK_DATA);
 	exit_test("FPByteRangeLock:test63: FPByteLock Data Fork");
 }
@@ -119,7 +119,7 @@ STATIC void test64()
 {
 char *name = "test64 FPByteLock RF";
 
-	enter_test();
+	ENTER_TEST
 	test_bytelock(VolID, name, OPENFORK_RSCS);
 	exit_test("FPByteRangeLock:test64: FPByteLock Resource Fork");
 }
@@ -186,7 +186,7 @@ STATIC void test65()
 {
 char *name = "t65 DF FPByteLock 2 users";
 
-	enter_test();
+	ENTER_TEST
 	if (!Quiet) {
 		fprintf(stdout,"FPByteRangeLock:test65: FPByteLock 2users DATA FORK\n");
 	}
@@ -285,7 +285,7 @@ void test78()
 {
 char *name = "t78 FPByteLock RF size -1";
 
-	enter_test();
+	ENTER_TEST
 	if (!Quiet) {
 		fprintf(stdout,"FPByteRangeLock:test78: test Byte Lock size -1 with no large file support\n");
 	}
@@ -315,7 +315,7 @@ int type = OPENFORK_DATA;
 char *name = "t79 FPByteLock Read";
 int len = (type == OPENFORK_RSCS)?(1<<FILPBIT_RFLEN):(1<<FILPBIT_DFLEN);
 
-	enter_test();
+	ENTER_TEST
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
 		goto test_exit;
@@ -386,7 +386,7 @@ STATIC void test80()
 {
 char *name = "t80 RF FPByteLock Read write";
 
-	enter_test();
+	ENTER_TEST
 	if (!Quiet) {
 		fprintf(stdout,"FPByteRangeLock:test80: Resource Fork test Byte Lock and read write same user(file)\n");
 	}
@@ -414,7 +414,7 @@ uint16_t vol2;
 DSI *dsi2;
 int type = OPENFORK_DATA;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -504,7 +504,7 @@ STATIC void test410()
     DSI *dsi2;
     int type = OPENFORK_DATA;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -804,7 +804,7 @@ int fork2 = 0;
 DSI *dsi2;
 int dir, dir2;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -859,7 +859,7 @@ uint16_t vol2;
 DSI *dsi2;
 int type = OPENFORK_DATA;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);

--- a/test/testsuite/FPByteRangeLockExt.c
+++ b/test/testsuite/FPByteRangeLockExt.c
@@ -82,7 +82,7 @@ STATIC void test66()
 {
 char *name = "t66 FPByteLock_ext DF";
 
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -97,7 +97,7 @@ STATIC void test67()
 {
 char *name = "t67 FPByteLock_ext RF";
 
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -116,7 +116,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;

--- a/test/testsuite/FPByteRangeLockExt.c
+++ b/test/testsuite/FPByteRangeLockExt.c
@@ -83,6 +83,11 @@ STATIC void test66()
 char *name = "t66 FPByteLock_ext DF";
 
 	ENTER_TEST
+	// FIXME: tests fail with Netatalk 4.0
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -98,6 +103,11 @@ STATIC void test67()
 char *name = "t67 FPByteLock_ext RF";
 
 	ENTER_TEST
+	// FIXME: tests fail with Netatalk 4.0
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -133,10 +143,7 @@ void FPByteRangeLockExt_test()
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPByteRangeLockExt page 105\n");
     fprintf(stdout,"-------------------\n");
-    // FIXME: tests fail with Netatalk 4.0
-#if 0
     test66();
     test67();
-#endif
     test195();
 }

--- a/test/testsuite/FPByteRangeLockExt.c
+++ b/test/testsuite/FPByteRangeLockExt.c
@@ -83,15 +83,13 @@ STATIC void test66()
 char *name = "t66 FPByteLock_ext DF";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLockExt:test66: FPByteLock Data Fork\n");
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
 	}
 	test_bytelock_ext(VolID, name, OPENFORK_DATA);
 test_exit:
-	exit_test("test66");
+	exit_test("FPByteRangeLockExt:test66: FPByteLock Data Fork");
 }
 
 /* ----------- */
@@ -100,15 +98,13 @@ STATIC void test67()
 char *name = "t67 FPByteLock_ext RF";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLockExt:test67: FPByteLock Ressource Fork\n");
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
 	}
 	test_bytelock_ext(VolID, name, OPENFORK_RSCS);
 test_exit:
-	exit_test("test67");
+	exit_test("FPByteRangeLockExt:test67: FPByteLock Ressource Fork");
 }
 
 
@@ -121,8 +117,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLockExt:test195: illegal fork\n");
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -130,7 +124,7 @@ DSI *dsi;
 
 	illegal_fork(dsi, AFP_BYTELOCK_EXT, name);
 test_exit:
-	exit_test("test195");
+	exit_test("FPByteRangeLockExt:test195: illegal fork");
 }
 
 /* ----------- */
@@ -138,6 +132,7 @@ void FPByteRangeLockExt_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPByteRangeLockExt page 105\n");
+    fprintf(stdout,"-------------------\n");
     // FIXME: tests fail with Netatalk 4.0
 #if 0
     test66();

--- a/test/testsuite/FPCatSearch.c
+++ b/test/testsuite/FPCatSearch.c
@@ -17,7 +17,7 @@ struct afp_filedir_parms filedir;
 struct afp_filedir_parms filedir2;
 unsigned int ret;
 
-	enter_test();
+	ENTER_TEST
 	dsi = &Conn->dsi;
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {

--- a/test/testsuite/FPCatSearch.c
+++ b/test/testsuite/FPCatSearch.c
@@ -19,8 +19,6 @@ unsigned int ret;
 
 	enter_test();
 	dsi = &Conn->dsi;
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCatSearch:test225: Catalog search\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -41,7 +39,9 @@ unsigned int ret;
 	memcpy(&temp, dsi->data + 20, sizeof(temp));
 	temp = ntohl(temp);
 	if (temp) {
-		fprintf(stdout,"\tFAILED want 0 get %d\n", temp);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED want 0 get %d\n", temp);
+		}
 		failed_nomsg();
 	}
 
@@ -60,7 +60,9 @@ unsigned int ret;
 	memcpy(&temp, dsi->data + 20, sizeof(temp));
 	temp = ntohl(temp);
 	if (temp != 1) {
-		fprintf(stdout,"\tFAILED want 1 get %d\n", temp);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED want 1 get %d\n", temp);
+		}
 		failed_nomsg();
 	}
 
@@ -73,7 +75,9 @@ unsigned int ret;
 	memcpy(&temp, dsi->data + 20, sizeof(temp));
 	temp = ntohl(temp);
 	if (temp != 1) {
-		fprintf(stdout,"\tFAILED want 1 get %d\n", temp);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED want 1 get %d\n", temp);
+		}
 		failed_nomsg();
 	}
 	/* -------------------- */
@@ -95,7 +99,7 @@ unsigned int ret;
  	FAIL (FPSetFileParams(Conn, vol, DIRDID_ROOT , name, bitmap, &filedir))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test225");
+	exit_test("FPCatSearch:test225: Catalog search");
 }
 
 /* ----------- */
@@ -103,5 +107,6 @@ void FPCatSearch_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPCatSearch page 110\n");
+    fprintf(stdout,"-------------------\n");
 	test225();
 }

--- a/test/testsuite/FPCatSearchExt.c
+++ b/test/testsuite/FPCatSearchExt.c
@@ -20,8 +20,6 @@ unsigned int ret;
 
 	enter_test();
 	dsi = &Conn->dsi;
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCatSearchExt:test227: Catalog search\n");
 
 	memset(pos, 0, sizeof(pos));
 	memset(&filedir, 0, sizeof(filedir));
@@ -53,7 +51,9 @@ unsigned int ret;
 	memcpy(&temp, dsi->data + 20, sizeof(temp));
 	temp = ntohl(temp);
 	if (temp) {
-		fprintf(stdout,"\tFAILED want 0 get %d\n", temp);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED want 0 get %d\n", temp);
+		}
 		failed_nomsg();
 	}
 
@@ -72,7 +72,9 @@ unsigned int ret;
 	memcpy(&temp, dsi->data + 20, sizeof(temp));
 	temp = ntohl(temp);
 	if (temp != 1) {
-		fprintf(stdout,"\tFAILED want 1 get %d\n", temp);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED want 1 get %d\n", temp);
+		}
 		failed_nomsg();
 	}
 
@@ -85,7 +87,9 @@ unsigned int ret;
 	memcpy(&temp, dsi->data + 20, sizeof(temp));
 	temp = ntohl(temp);
 	if (temp != 1) {
-		fprintf(stdout,"\tFAILED want 1 get %d\n", temp);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED want 1 get %d\n", temp);
+		}
 		failed_nomsg();
 	}
 #if 1
@@ -131,7 +135,7 @@ unsigned int ret;
  	FAIL (FPSetFileParams(Conn, vol, DIRDID_ROOT , name, bitmap, &filedir))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test227");
+	exit_test("FPCatSearchExt:test227: Catalog search");
 }
 
 /* ----------- */
@@ -139,5 +143,6 @@ void FPCatSearchExt_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPCatSearchExt page 117\n");
+    fprintf(stdout,"-------------------\n");
 	test227();
 }

--- a/test/testsuite/FPCatSearchExt.c
+++ b/test/testsuite/FPCatSearchExt.c
@@ -18,7 +18,7 @@ struct afp_filedir_parms filedir;
 struct afp_filedir_parms filedir2;
 unsigned int ret;
 
-	enter_test();
+	ENTER_TEST
 	dsi = &Conn->dsi;
 
 	memset(pos, 0, sizeof(pos));

--- a/test/testsuite/FPCloseDT.c
+++ b/test/testsuite/FPCloseDT.c
@@ -9,7 +9,7 @@ uint16_t  dir;
 uint16_t vol = VolID;
 int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (0xffff == (dir = FPOpenDT(Conn,vol))) {
 		nottested();

--- a/test/testsuite/FPCloseDT.c
+++ b/test/testsuite/FPCloseDT.c
@@ -10,8 +10,6 @@ uint16_t vol = VolID;
 int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPCloseDT:test201: FPCloseDT call\n");
 
 	if (0xffff == (dir = FPOpenDT(Conn,vol))) {
 		nottested();
@@ -23,7 +21,7 @@ int ret;
 	}
 	FAIL (FPCloseDT(Conn, dir))
 test_exit:
-	exit_test("test201");
+	exit_test("FPCloseDT:test201: FPCloseDT call");
 }
 
 /* ----------- */
@@ -31,5 +29,6 @@ void FPCloseDT_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPCloseDT page 128\n");
+    fprintf(stdout,"-------------------\n");
 	test201();
 }

--- a/test/testsuite/FPCloseDir.c
+++ b/test/testsuite/FPCloseDir.c
@@ -13,8 +13,6 @@ DSI *dsi;
 
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPCloseDir:test199: FPCloseDir call\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -43,7 +41,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test199");
+	exit_test("FPCloseDir:test199: FPCloseDir call");
 }
 
 /* ----------- */
@@ -51,5 +49,6 @@ void FPCloseDir_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPCloseDir page 127\n");
+    fprintf(stdout,"-------------------\n");
 	test199();
 }

--- a/test/testsuite/FPCloseDir.c
+++ b/test/testsuite/FPCloseDir.c
@@ -12,7 +12,7 @@ int ret;
 DSI *dsi;
 
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;

--- a/test/testsuite/FPCloseFork.c
+++ b/test/testsuite/FPCloseFork.c
@@ -11,7 +11,7 @@ uint16_t vol = VolID;
 int type = OPENFORK_DATA;
 char *name = "t186 FPCloseFork";
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -45,7 +45,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	illegal_fork(dsi, AFP_CLOSEFORK, name);
 	exit_test("FPCloseFork:test187: illegal fork");

--- a/test/testsuite/FPCloseFork.c
+++ b/test/testsuite/FPCloseFork.c
@@ -12,8 +12,6 @@ int type = OPENFORK_DATA;
 char *name = "t186 FPCloseFork";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCloseFork:test186: FPCloseFork\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -36,7 +34,7 @@ char *name = "t186 FPCloseFork";
 		nottested();
 	}
 test_exit:
-	exit_test("test186");
+	exit_test("FPCloseFork:test186: FPCloseFork");
 }
 
 /* -------------------------- */
@@ -48,11 +46,9 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCloseFork:test187: illegal fork\n");
 
 	illegal_fork(dsi, AFP_CLOSEFORK, name);
-	exit_test("test187");
+	exit_test("FPCloseFork:test187: illegal fork");
 }
 
 /* ----------- */
@@ -60,6 +56,7 @@ void FPCloseFork_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPCloseFork page 129\n");
+    fprintf(stdout,"-------------------\n");
 	test186();
 	test187();
 }

--- a/test/testsuite/FPCloseVol.c
+++ b/test/testsuite/FPCloseVol.c
@@ -9,8 +9,6 @@ uint16_t vol = VolID;
 int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCloseVol:test204: Close Volume call\n");
 
 	FAIL (FPCloseVol(Conn,vol))
 	/* double close */
@@ -24,7 +22,7 @@ int ret;
 	if (vol == 0xffff) {
 		failed();
 	}
-	exit_test("test204");
+	exit_test("FPCloseVol:test204: Close Volume call");
 
 }
 
@@ -33,5 +31,6 @@ void FPCloseVol_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPCloseVol page 130\n");
+    fprintf(stdout,"-------------------\n");
 	test204();
 }

--- a/test/testsuite/FPCloseVol.c
+++ b/test/testsuite/FPCloseVol.c
@@ -8,7 +8,7 @@ STATIC void test204()
 uint16_t vol = VolID;
 int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	FAIL (FPCloseVol(Conn,vol))
 	/* double close */

--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -21,8 +21,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:test71: Copy file\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -94,7 +92,7 @@ fin:
 	delete_folder(vol, DIRDID_ROOT, ndir);
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name2))
 test_exit:
-	exit_test("test71");
+	exit_test("FPCopyFile:test71: Copy file");
 }
 
 /* ------------------------- */
@@ -105,8 +103,6 @@ char *name1 = "t158 new file name";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:test158: copyFile dest exist\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -120,7 +116,7 @@ uint16_t vol = VolID;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 
-	exit_test("test158");
+	exit_test("FPCopyFile:test158: copyFile dest exist");
 }
 
 /* ------------------------- */
@@ -133,8 +129,6 @@ uint16_t vol = VolID;
 int fork;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:test315: copyFile\n");
 
 	if (get_vol_free(vol) < 130*1024*1024) {
 	    /* assume sparse file for setforkparam, not for copyfile */
@@ -184,7 +178,7 @@ int fork;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test315");
+	exit_test("FPCopyFile:test315: copyFile");
 }
 
 /* ------------------------- */
@@ -230,9 +224,11 @@ char finder_info[32];
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 		if (memcmp(finder_info, filedir.finder_info, 32)) {
-	        fprintf(stdout,"\tFAILED finder info differ\n");
-	        failed_nomsg();
-	        goto fin;
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED finder info differ\n");
+			}
+			failed_nomsg();
+			goto fin;
 		}
 	}
 
@@ -242,7 +238,9 @@ char finder_info[32];
 		goto fin;
 	}
 	if (tp == tp1) {
-	    fprintf(stdout,"\tFAILED both files have same ID\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED both files have same ID\n");
+		}
 	    failed_nomsg();
 	}
 
@@ -259,11 +257,9 @@ char *name  = "t317 old file name";
 char *name1 = "t317 new file name";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:test317: copyFile check meta data\n");
     test_meta(name, name1, VolID);
 
-	exit_test("test317");
+	exit_test("FPCopyFile:test317: copyFile check meta data");
 }
 
 /* ------------------------- */
@@ -280,14 +276,14 @@ uint16_t bitmap;
 uint32_t mdate = 0;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:test332: copyFile check meta data\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
 		goto fin;
 	}
-	fprintf(stdout,"sleep(2)\n");
+	if (!Quiet) {
+		fprintf(stdout,"sleep(2)\n");
+	}
 	sleep(2);
 	tp = get_fid(Conn, vol, DIRDID_ROOT, name);
 	if (!tp) {
@@ -313,9 +309,11 @@ uint32_t mdate = 0;
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 		if (mdate != filedir.mdate)  {
-	        fprintf(stdout,"\tFAILED modification date differ\n");
-	        failed_nomsg();
-	        goto fin;
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED modification date differ\n");
+			}
+			failed_nomsg();
+			goto fin;
 		}
 	}
 
@@ -325,7 +323,9 @@ uint32_t mdate = 0;
 		goto fin;
 	}
 	if (tp == tp1) {
-	    fprintf(stdout,"\tFAILED both files have same ID\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED both files have same ID\n");
+		}
 	    failed_nomsg();
 	}
 
@@ -333,7 +333,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 
-	exit_test("test332");
+	exit_test("FPCopyFile:test332: copyFile check meta data");
 }
 
 /* ----------- */
@@ -350,8 +350,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:test374: Copy open file (deny read), two clients\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -388,7 +386,7 @@ fin:
 	FPCloseVol(Conn2,vol2);
 
 test_exit:
-	exit_test("test374");
+	exit_test("FPCopyFile:test374: Copy open file (deny read), two clients");
 }
 
 /* ------------------------- */
@@ -402,8 +400,6 @@ char *name1 = "t375 new file name";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:test158: copyFile dest exist and is open\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -437,7 +433,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 
-	exit_test("test375");
+	exit_test("FPCopyFile:test158: copyFile dest exist and is open");
 }
 
 /* ------------------------- */
@@ -458,8 +454,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:t401: unix access privilege, read only file\n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -539,7 +533,7 @@ fin1:
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test401");
+	exit_test("FPCopyFile:test401: unix access privilege, read only file");
 }
 
 /* ------------------------- */
@@ -560,8 +554,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:t401: unix access privilege, read only file\n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -631,7 +623,7 @@ fin1:
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test402");
+	exit_test("FPCopyFile:test402: unix access privilege");
 }
 
 /* ------------------------- */
@@ -651,8 +643,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:t403: unix access privilege, same priv\n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -712,7 +702,9 @@ DSI *dsi;
 	filedir.isdir = 0;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 	if ((filedir.unix_priv & 0444) != 0444) {
-		fprintf(stdout,"\tFAILED unix priv differ\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unix priv differ\n");
+		}
 	    failed_nomsg();
 	}
 
@@ -723,7 +715,7 @@ fin1:
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test403");
+	exit_test("FPCopyFile:test403: unix access privilege, same priv");
 }
 
 
@@ -743,8 +735,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:t406: unix access privilege, read only file\n");
 
 	bitmap = (1 <<  FILPBIT_PDINFO) | (1<< FILPBIT_PDID) | (1<< FILPBIT_FNUM) | (1<<FILPBIT_ATTR);
 
@@ -755,7 +745,7 @@ DSI *dsi;
 	FPCopyFile(Conn, vol, dir, vol, dir, name, "", name1);
 
 test_exit:
-	exit_test("test406");
+	exit_test("FPCopyFile:test406: unix access privilege, read only file");
 }
 
 /* ------------------------- */
@@ -827,8 +817,10 @@ char data[20];
 	filedir.isdir = 0;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 	if (filedir.dflen != 400 || filedir.rflen != 300 ) {
-		fprintf(stdout, "\tFAILED after copy wrong size (data %d, resource %d) \n",
-			filedir.dflen, filedir.rflen);
+		if (!Quiet) {
+			fprintf(stdout, "\tFAILED after copy wrong size (data %d, resource %d) \n",
+				filedir.dflen, filedir.rflen);
+		}
 		failed_nomsg();
 		goto fin2;
 	}
@@ -848,7 +840,9 @@ char data[20];
 	FPCloseFork(Conn,fork);
 
 	if (memcmp(data, "Data fork", 9)) {
-		fprintf(stdout, "\tFAILED not \"Data fork\" read\n");
+		if (!Quiet) {
+			fprintf(stdout, "\tFAILED not \"Data fork\" read\n");
+		}
 		failed_nomsg();
 		goto fin2;
 	}
@@ -867,7 +861,9 @@ char data[20];
 	FPCloseFork(Conn,fork);
 
 	if (memcmp(data, "Resource fork", 13)) {
-		fprintf(stdout, "\tFAILED not \"Resource fork\" read\n");
+		if (!Quiet) {
+			fprintf(stdout, "\tFAILED not \"Resource fork\" read\n");
+		}
 		failed_nomsg();
 		goto fin2;
 	}
@@ -883,7 +879,9 @@ char data[20];
 	filedir.isdir = 0;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 	if (filedir.dflen != 400 || filedir.rflen != 300 ) {
-		fprintf(stdout, "\tFAILED after copy wrong size\n");
+		if (!Quiet) {
+			fprintf(stdout, "\tFAILED after copy wrong size\n");
+		}
 		failed_nomsg();
 		goto fin2;
 	}
@@ -904,7 +902,9 @@ char data[20];
 	FPCloseFork(Conn,fork);
 
 	if (memcmp(data, "Data fork", 9)) {
-		fprintf(stdout, "\tFAILED not \"Data fork\" read\n");
+		if (!Quiet) {
+			fprintf(stdout, "\tFAILED not \"Data fork\" read\n");
+		}
 		failed_nomsg();
 		goto fin2;
 	}
@@ -923,7 +923,9 @@ char data[20];
 	FPCloseFork(Conn,fork);
 
 	if (memcmp(data, "Resource fork", 13)) {
-		fprintf(stdout, "\tFAILED not \"Resource fork\" read\n");
+		if (!Quiet) {
+			fprintf(stdout, "\tFAILED not \"Resource fork\" read\n");
+		}
 		failed_nomsg();
 		goto fin2;
 	}
@@ -944,8 +946,6 @@ char *name1= "new t407 file.pdf";
 uint16_t vol2;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:t407: copy file between two volumes\n");
 	if (!*Vol2) {
 		test_skipped(T_VOL2);
 		goto test_exit;
@@ -959,7 +959,7 @@ uint16_t vol2;
 	FAIL (FPCloseVol(Conn, vol2))
 
 test_exit:
-	exit_test("test407");
+	exit_test("FPCopyFile:test407: copy file between two volumes");
 }
 
 /* ------------------------- */
@@ -970,8 +970,6 @@ char *name1 = "t408 new file name";
 uint16_t vol2;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:test408: copyFile check meta data, two volumes\n");
 	if (!*Vol2) {
 		test_skipped(T_VOL2);
 		goto test_exit;
@@ -986,7 +984,7 @@ uint16_t vol2;
 
 	FAIL (FPCloseVol(Conn, vol2))
 test_exit:
-	exit_test("test408");
+	exit_test("FPCopyFile:test408: copyFile check meta data, two volumes");
 }
 
 
@@ -997,12 +995,10 @@ char *name  = "t409 old file name";
 char *name1 = "t409 new file name";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:test409: copyFile check meta data, one volume\n");
 
     test_data(name, name1, VolID);
 
-	exit_test("test409");
+	exit_test("FPCopyFile:test409: copyFile check meta data, one volume");
 }
 
 /* ------------------------- */
@@ -1018,8 +1014,6 @@ char *attr_name="test416_attribute";
     dsi = &Conn->dsi;
 
 	enter_test();
-	fprintf(stdout,"===================\n");
-	fprintf(stdout,"FPCopyFile:test416: copy xattr\n");
 
     if (Conn->afp_version < 32) {
         test_skipped(T_AFP3);
@@ -1054,7 +1048,7 @@ char *attr_name="test416_attribute";
     FAIL(FPDelete(Conn, vol,  DIRDID_ROOT , file1))
 
 test_exit:
-	exit_test("test416");
+	exit_test("FPCopyFile:test416: copy xattr");
 }
 
 /* ------------------------- */
@@ -1067,8 +1061,6 @@ char *name2 = "t414 dir";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:test414: copyFile with bad dest directory\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -1092,7 +1084,7 @@ test_exit:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name2))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 
-	exit_test("test414");
+	exit_test("FPCopyFile:test414: copyFile with bad dest directory");
 }
 
 /* ------------------------- */
@@ -1111,8 +1103,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:test424: Copy file with dest directory\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -1144,7 +1134,7 @@ fin:
 	delete_folder(vol, DIRDID_ROOT, ndir);
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name2))
 test_exit:
-	exit_test("test424");
+	exit_test("FPCopyFile:test424: Copy file with dest directory");
 }
 
 
@@ -1153,12 +1143,10 @@ void FPCopyFile_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPCopyFile page 131\n");
+    fprintf(stdout,"-------------------\n");
     test71();
 	test158();
-// FIXME: why is this test "not run" when the server under test is remote?
-#if 0
 	test315();
-#endif
 	test317();
 	test332();
 	test374();

--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -1016,7 +1016,7 @@ char *attr_name="test416_attribute";
 	ENTER_TEST
 
     if (Conn->afp_version < 32) {
-        test_skipped(T_AFP3);
+        test_skipped(T_AFP32);
         goto test_exit;
     }
 

--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -20,7 +20,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -102,7 +102,7 @@ char *name  = "t158 old file name";
 char *name1 = "t158 new file name";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -128,7 +128,7 @@ char *name1 = "t315 new file name";
 uint16_t vol = VolID;
 int fork;
 
-	enter_test();
+	ENTER_TEST
 
 	if (get_vol_free(vol) < 130*1024*1024) {
 	    /* assume sparse file for setforkparam, not for copyfile */
@@ -256,7 +256,7 @@ STATIC void test317()
 char *name  = "t317 old file name";
 char *name1 = "t317 new file name";
 
-	enter_test();
+	ENTER_TEST
     test_meta(name, name1, VolID);
 
 	exit_test("FPCopyFile:test317: copyFile check meta data");
@@ -275,7 +275,7 @@ DSI *dsi = &Conn->dsi;
 uint16_t bitmap;
 uint32_t mdate = 0;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -349,7 +349,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -399,7 +399,7 @@ char *name  = "t375 old file name";
 char *name1 = "t375 new file name";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -453,7 +453,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -553,7 +553,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -642,7 +642,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -734,7 +734,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	bitmap = (1 <<  FILPBIT_PDINFO) | (1<< FILPBIT_PDID) | (1<< FILPBIT_FNUM) | (1<<FILPBIT_ATTR);
 
@@ -945,7 +945,7 @@ char *name = "t407 file.pdf";
 char *name1= "new t407 file.pdf";
 uint16_t vol2;
 
-	enter_test();
+	ENTER_TEST
 	if (!*Vol2) {
 		test_skipped(T_VOL2);
 		goto test_exit;
@@ -969,7 +969,7 @@ char *name  = "t408 old file name";
 char *name1 = "t408 new file name";
 uint16_t vol2;
 
-	enter_test();
+	ENTER_TEST
 	if (!*Vol2) {
 		test_skipped(T_VOL2);
 		goto test_exit;
@@ -994,7 +994,7 @@ STATIC void test409()
 char *name  = "t409 old file name";
 char *name1 = "t409 new file name";
 
-	enter_test();
+	ENTER_TEST
 
     test_data(name, name1, VolID);
 
@@ -1013,7 +1013,7 @@ char *attr_name="test416_attribute";
 
     dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
     if (Conn->afp_version < 32) {
         test_skipped(T_AFP3);
@@ -1060,7 +1060,7 @@ char *name1 = "t414 new file name";
 char *name2 = "t414 dir";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -1102,7 +1102,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;

--- a/test/testsuite/FPCreateDir.c
+++ b/test/testsuite/FPCreateDir.c
@@ -10,8 +10,6 @@ char *name = "test6 dir";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCreateDir:test6: create dir\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		failed();
@@ -27,7 +25,7 @@ uint16_t vol = VolID;
 
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test6");
+	exit_test("FPCreateDir:test6: create dir");
 }
 
 /* ------------------------- */
@@ -38,8 +36,6 @@ int pdir;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCreateDir:test26: folder without right access\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -71,7 +67,7 @@ uint16_t vol = VolID;
 fin:
 	delete_folder(vol, DIRDID_ROOT, name);
 test_exit:
-	exit_test("test26");
+	exit_test("FPCreateDir:test26: folder without right access");
 }
 
 /* ------------------------- */
@@ -89,8 +85,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCreateDir:test45: Folder Creation\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -133,7 +127,7 @@ fin:
 		delete_folder(vol, DIRDID_ROOT, rodir);
 	}
 test_exit:
-	exit_test("test45");
+	exit_test("FPCreateDir:test45: Folder Creation");
 }
 
 /* -------------------------- */
@@ -178,8 +172,6 @@ unsigned int ret;
 
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCreateDir:test175: did error two users in  folder did=<deleted> name=test175\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -234,7 +226,7 @@ unsigned int ret;
 	    FPDelete(Conn, vol, dir , "");
 	}
 test_exit:
-	exit_test("test175");
+	exit_test("FPCreateDir:test175: did error two users in  folder did=<deleted> name=test175");
 }
 
 /* ----------- */
@@ -252,8 +244,6 @@ DSI *dsi2;
 unsigned int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCreateDir:test198: second user delete folder\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -297,7 +287,7 @@ fin:
 	FAIL (tdir && FPDelete(Conn, vol, tdir , ""))
 	FAIL (tdir1 && FPDelete(Conn, vol, tdir1 , ""))
 test_exit:
-	exit_test("test198");
+	exit_test("FPCreateDir:test198: second user delete folder");
 }
 
 /* ----------- */
@@ -318,8 +308,6 @@ DSI *dsi2;
 unsigned int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCreateDir:test357: admin user \n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -366,7 +354,7 @@ unsigned int ret;
 		FAIL (FPDelete(Conn, vol, tdir , ""))
 	}
 test_exit:
-	exit_test("test357");
+	exit_test("FPCreateDir:test357: admin user");
 }
 
 /* ----------- */
@@ -374,6 +362,7 @@ void FPCreateDir_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPCreateDir page 136\n");
+    fprintf(stdout,"-------------------\n");
 	test6();
 	test26();
 	test45();

--- a/test/testsuite/FPCreateDir.c
+++ b/test/testsuite/FPCreateDir.c
@@ -9,7 +9,7 @@ int  dir;
 char *name = "test6 dir";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		failed();
@@ -35,7 +35,7 @@ char *name = "test26 dir";
 int pdir;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -84,7 +84,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -171,7 +171,7 @@ DSI *dsi;
 unsigned int ret;
 
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -243,7 +243,7 @@ uint16_t vol2;
 DSI *dsi2;
 unsigned int ret;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -307,7 +307,7 @@ DSI *dsi;
 DSI *dsi2;
 unsigned int ret;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;

--- a/test/testsuite/FPCreateFile.c
+++ b/test/testsuite/FPCreateFile.c
@@ -20,7 +20,7 @@ int ret;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -119,7 +119,7 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 getchar();
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version >= 30) {
 		test_skipped(T_AFP2);
 		goto test_exit;

--- a/test/testsuite/FPCreateFile.c
+++ b/test/testsuite/FPCreateFile.c
@@ -21,8 +21,6 @@ int ret;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPCreateFile:test51:  Create file with errors\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -91,7 +89,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name3))
 
 test_exit:
-	exit_test("test51");
+	exit_test("FPCreateFile:test51:  Create file with errors");
 }
 
 /* --------------------------
@@ -122,8 +120,6 @@ DSI *dsi;
 
 getchar();
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPCreateFile:test393:  Create file with Japanese name, illegal char\n");
 	if (Conn->afp_version >= 30) {
 		test_skipped(T_AFP2);
 		goto test_exit;
@@ -148,7 +144,7 @@ getchar();
 	FAIL( FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 
 test_exit:
-	exit_test("test393");
+	exit_test("FPCreateFile:test393:  Create file with Japanese name, illegal char");
 }
 
 /* ----------- */
@@ -156,5 +152,6 @@ void FPCreateFile_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPCreateFile page 138\n");
+    fprintf(stdout,"-------------------\n");
     test51();
 }

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -326,7 +326,7 @@ uint16_t bitmap = (1 <<  DIRPBIT_LNAME) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID)
 		if (!Quiet) {
 			fprintf(stdout, "\tFAILED (not run kill 1.6.x servers)\n");
 		}
-		failed_nomsg();
+		test_skipped(T_EXCLUDE);
 		goto test_exit;
 	}
 

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -301,6 +301,7 @@ test_exit:
 }
 
 /* -------------------------- */
+// Known to kill afpd 1.6.x servers
 STATIC void test196()
 {
 char *name = "test196";
@@ -319,14 +320,6 @@ uint16_t bitmap = (1 <<  DIRPBIT_LNAME) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID)
 	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
-		goto test_exit;
-	}
-
-	if (Exclude) {
-		if (!Quiet) {
-			fprintf(stdout, "\tFAILED (not run kill 1.6.x servers)\n");
-		}
-		test_skipped(T_EXCLUDE);
 		goto test_exit;
 	}
 

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -12,8 +12,6 @@ int ret = 0;
 int fork;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"test13: delete open file same connection\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -37,7 +35,7 @@ int fork;
 fin:
 	FAIL (ret && FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test13");
+	exit_test("FPDelete:test13: delete open file same connection");
 }
 
 /* ------------------------- */
@@ -49,8 +47,6 @@ uint16_t vol = VolID;
 int  dir;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDelete:test27: delete not empty dir\n");
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name2);
 	if (!dir) {
@@ -67,7 +63,7 @@ int  dir;
 	FAIL (FPDelete(Conn, vol,  dir , name));
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name2))
 test_exit:
-	exit_test("test27");
+	exit_test("FPDelete:test27: delete not empty dir");
 }
 
 /* -------------------------- */
@@ -83,8 +79,6 @@ uint16_t vol = VolID;
 DSI *dsi2;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDelete:test74: Delete File 2 users\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -118,7 +112,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	FAIL (FPCloseVol(Conn2,vol2))
 test_exit:
-	exit_test("test74");
+	exit_test("FPDelete:test74: Delete File 2 users");
 }
 
 /* ------------------------- */
@@ -132,8 +126,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDelete:test90: delete a dir without access\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -145,7 +137,7 @@ DSI *dsi;
 	FAIL (ntohl(AFPERR_ACCESS) != FPDelete(Conn, vol,  DIRDID_ROOT , name))
 	delete_folder(vol, DIRDID_ROOT, name);
 test_exit:
-	exit_test("test90");
+	exit_test("FPDelete:test90: delete a dir without access");
 }
 
 /* -------------------------- */
@@ -168,8 +160,6 @@ int dt;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDelete:test172: did error did=<deleted> name=test172 name\n");
 
 	memset(&filedir, 0, sizeof(filedir));
 	tdir  = FPCreateDir(Conn,vol, DIRDID_ROOT, tname);
@@ -230,8 +220,12 @@ int dt;
 
 	ret = FPExchangeFile(Conn, vol, tdir,dir, tname, name1);
 	if (ntohl(AFPERR_NOOBJ) != ret) {
-		if (Quirk && ret == htonl(AFPERR_PARAM))
-			fprintf(stdout,"\tFAILED (IGNORED) not always the same error code!\n");
+		if (Quirk && ret == htonl(AFPERR_PARAM)) {
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED (IGNORED) not always the same error code!\n");
+			}
+			skipped_nomsg();
+		}
 		else {
 			failed();
 		}
@@ -303,7 +297,7 @@ int dt;
 	FAIL (FPCloseDT(Conn, dt))
 
 test_exit:
-	exit_test("test172");
+	exit_test("FPDelete:test172: did error did=<deleted> name=test172 name");
 }
 
 /* -------------------------- */
@@ -323,15 +317,15 @@ uint16_t bitmap = (1 <<  DIRPBIT_LNAME) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID)
 	    	(1 << DIRPBIT_GID) |(1 << DIRPBIT_ACCESS);
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDelete:test196: delete a folder in a deleted folder\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
 	}
 
 	if (Exclude) {
-		fprintf(stdout, "\tFAILED (not run kill 1.6.x servers)\n");
+		if (!Quiet) {
+			fprintf(stdout, "\tFAILED (not run kill 1.6.x servers)\n");
+		}
 		failed_nomsg();
 		goto test_exit;
 	}
@@ -386,7 +380,7 @@ fin:
 	FAIL (tdir1 && FPDelete(Conn, vol, tdir1 , ""))
 	FAIL (tdir && FPDelete(Conn, vol, tdir , ""))
 test_exit:
-	exit_test("test196");
+	exit_test("FPDelete:test196: delete a folder in a deleted folder");
 }
 
 /* -------------------------- */
@@ -405,8 +399,6 @@ DSI *dsi2;
 int  dir;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDelete:test368: Delete File 2 users after it has been moved\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -448,7 +440,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir, ""))
 	FAIL (FPCloseVol(Conn2,vol2))
 test_exit:
-	exit_test("test368");
+	exit_test("FPDelete:test368: Delete File 2 users after it has been moved");
 }
 
 /* -------------------------- */
@@ -466,8 +458,6 @@ DSI *dsi2;
 int  dir;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDelete:test369: Delete File 2 users after it has been moved\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -508,7 +498,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir, ""))
 	FAIL (FPCloseVol(Conn2,vol2))
 test_exit:
-	exit_test("test369");
+	exit_test("FPDelete:test369: Delete File 2 users after it has been moved");
 }
 
 /* -------------------------- */
@@ -525,8 +515,6 @@ uint16_t bitmap = (1 <<  DIRPBIT_LNAME) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID)
 	    	(1 << DIRPBIT_GID) |(1 << DIRPBIT_ACCESS);
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDelete:test421: delete an already deleted curdir folder\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -567,7 +555,7 @@ uint16_t bitmap = (1 <<  DIRPBIT_LNAME) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID)
 fin:
 	FAIL (tdir && FPDelete(Conn, vol, tdir , ""))
 test_exit:
-	exit_test("test421");
+	exit_test("FPDelete:test421: delete an already deleted curdir folder");
 }
 
 /* ------------------------- */
@@ -580,8 +568,6 @@ char *name = "t422 file";
 int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"test422: Server notification on volume date change if AFP < 3.2\n");
 
 	if (Mac) {
 		test_skipped(T_MAC);
@@ -602,7 +588,9 @@ int ret;
 	}
     if (Conn->afp_version < 32) {
     	if (!Attention_received) {
+		if (!Quiet) {
 			fprintf(stdout, "\tFAILED no attention received\n");
+		}
 			failed_nomsg();
 		}
     }
@@ -612,7 +600,7 @@ int ret;
     }
 
 test_exit:
-	exit_test("test422");
+	exit_test("FPDelete:test422: Server notification on volume date change if AFP < 3.2");
 }
 
 
@@ -621,6 +609,7 @@ void FPDelete_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPDelete page 143\n");
+    fprintf(stdout,"-------------------\n");
     test13();
 	test27();
 	test74();

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -11,7 +11,7 @@ char *name = "t13 file";
 int ret = 0;
 int fork;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -46,7 +46,7 @@ char *name2 = "t27 dir";
 uint16_t vol = VolID;
 int  dir;
 
-	enter_test();
+	ENTER_TEST
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name2);
 	if (!dir) {
@@ -78,7 +78,7 @@ int len = (type == OPENFORK_RSCS)?(1<<FILPBIT_RFLEN):(1<<FILPBIT_DFLEN);
 uint16_t vol = VolID;
 DSI *dsi2;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -125,7 +125,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -159,7 +159,7 @@ int dt;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	memset(&filedir, 0, sizeof(filedir));
 	tdir  = FPCreateDir(Conn,vol, DIRDID_ROOT, tname);
@@ -316,7 +316,7 @@ DSI *dsi = &Conn->dsi;
 uint16_t bitmap = (1 <<  DIRPBIT_LNAME) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID) | (1<<DIRPBIT_UID) |
 	    	(1 << DIRPBIT_GID) |(1 << DIRPBIT_ACCESS);
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -398,7 +398,7 @@ uint16_t vol = VolID;
 DSI *dsi2;
 int  dir;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -457,7 +457,7 @@ uint16_t vol = VolID;
 DSI *dsi2;
 int  dir;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -514,7 +514,7 @@ DSI *dsi = &Conn->dsi;
 uint16_t bitmap = (1 <<  DIRPBIT_LNAME) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID) | (1<<DIRPBIT_UID) |
 	    	(1 << DIRPBIT_GID) |(1 << DIRPBIT_ACCESS);
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -567,7 +567,7 @@ uint16_t vol = VolID;
 char *name = "t422 file";
 int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Mac) {
 		test_skipped(T_MAC);

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -30,7 +30,7 @@ int sock;
 int fork = 0, fork1;
 struct sigaction action;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -176,7 +176,7 @@ char *id1="testsuite-test338-1";
 uint32_t time= 12345;
 
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
     	test_skipped(T_AFP3);
@@ -310,7 +310,7 @@ int  ofs =  3 * sizeof( uint16_t );
 uint16_t bitmap =  (1 << DIRPBIT_ACCESS);
 struct afp_filedir_parms filedir;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
     	test_skipped(T_AFP3);
@@ -471,7 +471,7 @@ int  ofs =  3 * sizeof( uint16_t );
 uint16_t bitmap =  (1 << DIRPBIT_ACCESS);
 struct afp_filedir_parms filedir;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
     	test_skipped(T_AFP3);

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -31,8 +31,6 @@ int fork = 0, fork1;
 struct sigaction action;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDisconnectOldSession :test222: AFP 3.x disconnect old session\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -43,7 +41,9 @@ struct sigaction action;
 		goto test_exit;
 	}
 
-	fprintf(stdout,"\tSKIPPED, FIXME need to recheck GetSessionToken 0\n");
+    if (!Quiet) {
+    	fprintf(stdout,"\tSKIPPED, FIXME need to recheck GetSessionToken 0\n");
+    }
 	skipped_nomsg();
 	goto test_exit;
 
@@ -105,7 +105,9 @@ struct sigaction action;
 		goto fin;
 	}
 	if (!(token = malloc(len +4))) {
-		fprintf(stdout, "\tFAILED malloc(%x) %s\n", len, strerror(errno));
+        if (!Quiet) {
+            fprintf(stdout, "\tFAILED malloc(%x) %s\n", len, strerror(errno));
+        }
 		failed_nomsg();
 		goto fin;
 	}
@@ -151,7 +153,7 @@ fin:
     }
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test222");
+	exit_test("FPDisconnectOldSession :test222: AFP 3.x disconnect old session");
 
 }
 
@@ -175,8 +177,6 @@ uint32_t time= 12345;
 
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDisconnectOldSession :test338: AFP 3.x disconnect old session\n");
 
 	if (Conn->afp_version < 30) {
     	test_skipped(T_AFP3);
@@ -224,7 +224,9 @@ uint32_t time= 12345;
         goto fin;
     }
     if (!(token = malloc(len + 4))) {
-        fprintf(stdout, "\tFAILED malloc(%x) %s\n", len, strerror(errno));
+        if (!Quiet) {
+            fprintf(stdout, "\tFAILED malloc(%x) %s\n", len, strerror(errno));
+        }
         failed_nomsg();
         goto fin;
     }
@@ -277,7 +279,7 @@ uint32_t time= 12345;
 fin:
     FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test338");
+	exit_test("FPDisconnectOldSession :test338: AFP 3.x disconnect old session");
 
 }
 
@@ -308,10 +310,7 @@ int  ofs =  3 * sizeof( uint16_t );
 uint16_t bitmap =  (1 << DIRPBIT_ACCESS);
 struct afp_filedir_parms filedir;
 
-
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDisconnectOldSession :test339: AFP 3.x No auth disconnect old session\n");
 
 	if (Conn->afp_version < 30) {
     	test_skipped(T_AFP3);
@@ -359,7 +358,9 @@ struct afp_filedir_parms filedir;
 		goto test_exit;
     }
     if (!(token = malloc(len +4))) {
-        fprintf(stdout, "\tNOT TESTED malloc(%x) %s\n", len, strerror(errno));
+        if (!Quiet) {
+            fprintf(stdout, "\tNOT TESTED malloc(%x) %s\n", len, strerror(errno));
+        }
         nottested();
 		goto test_exit;
     }
@@ -441,7 +442,7 @@ fin:
     FAIL (FPDelete(Conn, vol,  dir, name))
     FAIL (FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test339");
+	exit_test("FPDisconnectOldSession :test339: AFP 3.x No auth disconnect old session");
 }
 
 /* ------------------------- */
@@ -470,10 +471,7 @@ int  ofs =  3 * sizeof( uint16_t );
 uint16_t bitmap =  (1 << DIRPBIT_ACCESS);
 struct afp_filedir_parms filedir;
 
-
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDisconnectOldSession :test370: AFP 3.x disconnect different user\n");
 
 	if (Conn->afp_version < 30) {
     	test_skipped(T_AFP3);
@@ -483,12 +481,6 @@ struct afp_filedir_parms filedir;
     	test_skipped(T_LOCKING);
 		goto test_exit;
 	}
-
-#if 0
-	fprintf(stdout,"\tSKIPPED, FIXME need to recheck GetSessionToken 0\n");
-	skipped_nomsg();
-	goto test_exit;
-#endif
 
     /* setup 2 new connections for testing */
 
@@ -528,7 +520,9 @@ struct afp_filedir_parms filedir;
 		goto test_exit;
     }
     if (!(token = malloc(len +4))) {
-        fprintf(stdout, "\tNOT TESTED malloc(%x) %s\n", len, strerror(errno));
+        if (!Quiet) {
+            fprintf(stdout, "\tNOT TESTED malloc(%x) %s\n", len, strerror(errno));
+        }
         nottested();
 		goto test_exit;
     }
@@ -614,7 +608,7 @@ fin:
     FAIL (FPDelete(Conn, vol,  dir, name))
     FAIL (FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test370");
+	exit_test("FPDisconnectOldSession :test370: AFP 3.x disconnect different user");
 
 }
 
@@ -623,14 +617,9 @@ void FPDisconnectOldSession_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPDisconnectOldSession page 148\n");
-//    test222();
-// FIXME: test flaky with Netatalk 4.0
-#if 0
+    fprintf(stdout,"-------------------\n");
+    test222();
     test338();
-#endif
     test339();
-// FIXME: test flaky with Netatalk 4.0
-#if 0
     test370();
-#endif
 }

--- a/test/testsuite/FPEnumerate.c
+++ b/test/testsuite/FPEnumerate.c
@@ -14,7 +14,7 @@ char *nfile = "t38 read write file";
 DSI *dsi;
 
 	dsi = &Conn->dsi;
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -83,7 +83,7 @@ STATIC void test34()
 {
 char *name = "essai permission";
 
-	enter_test();
+	ENTER_TEST
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPEnumerate:test34: folder with --rwx-- perm\n");
 
@@ -122,7 +122,7 @@ uint16_t vol = VolID;
 unsigned int ret;
 int  dir;
 
-	enter_test();
+	ENTER_TEST
 
 	dir   = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {
@@ -180,7 +180,7 @@ char *name2 = "t41 dir/sub dir/foo";
 char *name3 = "t41 dir/sub dir";
 unsigned int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	dir   = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {
@@ -260,7 +260,7 @@ int dir1 = 0;
 int ret;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -324,7 +324,7 @@ int isdir;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;

--- a/test/testsuite/FPEnumerate.c
+++ b/test/testsuite/FPEnumerate.c
@@ -15,8 +15,6 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPEnumerate:test38: enumerate folder with no write access\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -76,7 +74,7 @@ DSI *dsi;
 fin:
 	delete_folder_with_file(vol, DIRDID_ROOT, name, nfile);
 test_exit:
-	exit_test("test38");
+	exit_test("FPEnumerate:test38: enumerate folder with no write access");
 }
 
 /* ------------------------- */
@@ -125,8 +123,6 @@ unsigned int ret;
 int  dir;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPEnumerate:test40: enumerate deleted folder\n");
 
 	dir   = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {
@@ -169,7 +165,7 @@ int  dir;
 		failed();
 	}
 test_exit:
-	exit_test("test40");
+	exit_test("FPEnumerate:test40: enumerate deleted folder");
 
 }
 
@@ -185,8 +181,6 @@ char *name3 = "t41 dir/sub dir";
 unsigned int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPEnumerate:test41: enumerate folder not there\n");
 
 	dir   = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {
@@ -252,7 +246,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name1))
 	FAIL (FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test41");
+	exit_test("FPEnumerate:test41: enumerate folder not there");
 
 }
 
@@ -267,8 +261,6 @@ int ret;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPEnumerate:test93: enumerate error\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -309,7 +301,7 @@ fin:
 	FAIL (dir1 && FPDelete(Conn, vol,  dir , name1))
 	FAIL (dir && FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 test_exit:
-	exit_test("test93");
+	exit_test("FPEnumerate:test93: enumerate error");
 }
 
 /* ------------------------- */
@@ -333,8 +325,6 @@ int isdir;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPEnumerate:test218: enumerate arguments\n");
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -405,7 +395,7 @@ fin:
 	FAIL (htonl(AFPERR_NOOBJ) != FPEnumerateFull(Conn, vol, 1, 1, 800,  bdir, "", bitmap, bitmap))
 	FPDelete(Conn, vol,  DIRDID_ROOT, base);
 test_exit:
-	exit_test("test218");
+	exit_test("FPEnumerate:test218: enumerate arguments");
 }
 
 /* ----------- */
@@ -413,6 +403,7 @@ void FPEnumerate_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPEnumerate page 150\n");
+    fprintf(stdout,"-------------------\n");
 
     test38();
     test40();

--- a/test/testsuite/FPEnumerateExt.c
+++ b/test/testsuite/FPEnumerateExt.c
@@ -12,7 +12,7 @@ int  dir,dir1;
 uint16_t vol = VolID;
 
 
-	enter_test();
+	ENTER_TEST
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {

--- a/test/testsuite/FPEnumerateExt.c
+++ b/test/testsuite/FPEnumerateExt.c
@@ -13,8 +13,6 @@ uint16_t vol = VolID;
 
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPEnumerateExt:test23: AFP 3.0 FPEnumerate ext\n");
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {
@@ -66,7 +64,7 @@ uint16_t vol = VolID;
 		FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	}
 test_exit:
-	exit_test("test23");
+	exit_test("FPEnumerateExt:test23: AFP 3.0 FPEnumerate ext");
 }
 
 /* ----------- */
@@ -74,5 +72,6 @@ void FPEnumerateExt_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPEnumerateExt page 155\n");
+    fprintf(stdout,"-------------------\n");
     test23();
 }

--- a/test/testsuite/FPEnumerateExt2.c
+++ b/test/testsuite/FPEnumerateExt2.c
@@ -13,7 +13,7 @@ uint16_t vol = VolID;
 
 	ENTER_TEST
 	if (Conn->afp_version < 31) {
-		test_skipped(T_AFP3);
+		test_skipped(T_AFP31);
 		goto test_exit;
 	}
 

--- a/test/testsuite/FPEnumerateExt2.c
+++ b/test/testsuite/FPEnumerateExt2.c
@@ -11,7 +11,7 @@ char *name2 = "t25 file";
 int  dir,dir1;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version < 31) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -67,7 +67,7 @@ int  dir,dir1;
 uint16_t vol = VolID;
 
 
-	enter_test();
+	ENTER_TEST
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {

--- a/test/testsuite/FPEnumerateExt2.c
+++ b/test/testsuite/FPEnumerateExt2.c
@@ -12,8 +12,6 @@ int  dir,dir1;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPEnumerateExt2:test25: FPEnumerate ext2\n");
 	if (Conn->afp_version < 31) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -56,7 +54,7 @@ uint16_t vol = VolID;
 fin:
 	FPDelete(Conn, vol,  DIRDID_ROOT, name);
 test_exit:
-	exit_test("test25");
+	exit_test("FPEnumerateExt2:test25: FPEnumerate ext2");
 }
 
 /* ------------------------- */
@@ -70,8 +68,6 @@ uint16_t vol = VolID;
 
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPEnumerateExt2:test211: AFP 3.1 FPEnumerate ext2\n");
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {
@@ -118,7 +114,7 @@ uint16_t vol = VolID;
 		FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	}
 test_exit:
-	exit_test("test211");
+	exit_test("FPEnumerateExt2:test211: AFP 3.1 FPEnumerate ext2");
 }
 
 /* ----------- */
@@ -126,6 +122,7 @@ void FPEnumerateExt2_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPEnumerateExt2 page 155\n");
+    fprintf(stdout,"-------------------\n");
     test25();
     test211();
 }

--- a/test/testsuite/FPExchangeFiles.c
+++ b/test/testsuite/FPExchangeFiles.c
@@ -14,7 +14,7 @@ int fid_name1;
 int temp;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -87,7 +87,7 @@ int fid_name1;
 uint16_t vol = VolID;
 int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)){
 		nottested();
@@ -182,7 +182,7 @@ char *name1 = "t197 new file name";
 char *ndir  = "t197 dir";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -236,7 +236,7 @@ uint16_t bitmap;
 DSI *dsi = &Conn->dsi;
 int  ofs =  3 * sizeof( uint16_t );
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -324,7 +324,7 @@ int temp;
 int fork;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -398,7 +398,7 @@ int temp;
 int fork;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -473,7 +473,7 @@ int temp;
 int fork;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();

--- a/test/testsuite/FPExchangeFiles.c
+++ b/test/testsuite/FPExchangeFiles.c
@@ -15,8 +15,6 @@ int temp;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPExchangeFiles:test108: exchange files\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -37,22 +35,33 @@ uint16_t vol = VolID;
 
 	/* test remove of no cnid db */
 	if ((temp = get_fid(Conn, vol, DIRDID_ROOT , name)) != fid_name) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name);
+		}
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name);
+		}
 		failed_nomsg();
 	}
 	if ((temp = get_fid(Conn, vol, dir , name1)) != fid_name1) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name1);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name1);
+		}
 		failed_nomsg();
 	}
 
 	read_fork(Conn, vol,  DIRDID_ROOT , name, 3);
 	if (strcmp(Data,"red")) {
-		fprintf(stdout,"\tFAILED should be red\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be red\n");
+		}
 		failed_nomsg();
 	}
 	read_fork(Conn,  vol, dir , name1, 4);
 	if (strcmp(Data,"blue")) {
-		fprintf(stdout,"\tFAILED should be blue\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be blue\n");
+		}
 		failed_nomsg();
 	}
 	FAIL (FPDelete(Conn, vol,  dir , name1))
@@ -60,7 +69,7 @@ uint16_t vol = VolID;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, ndir))
 test_exit:
-	exit_test("test108");
+	exit_test("FPExchangeFiles:test108: exchange files");
 }
 
 /* ------------------------- */
@@ -79,8 +88,6 @@ uint16_t vol = VolID;
 int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPExchangeFiles:test111: exchange open files\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)){
 		nottested();
@@ -110,12 +117,16 @@ int ret;
 
 	read_fork(Conn, vol, DIRDID_ROOT , name, 3);
 	if (strcmp(Data,"red")) {
-		fprintf(stdout,"\tFAILED should be red\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be red\n");
+		}
 		failed_nomsg();
 	}
 	read_fork(Conn, vol, dir , name1, 4);
 	if (strcmp(Data,"blue")) {
-		fprintf(stdout,"\tFAILED should be blue\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be blue\n");
+		}
 		failed_nomsg();
 	}
 
@@ -123,7 +134,9 @@ int ret;
 
 	read_fork(Conn, vol, dir , name1, 3);
 	if (strcmp(Data,"new")) {
-		fprintf(stdout,"\tFAILED should be new\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be new\n");
+		}
 		failed_nomsg();
 	}
 
@@ -139,12 +152,16 @@ int ret;
 
 	if (fork) FPCloseFork(Conn,fork);
 	if ((ret = get_fid(Conn, vol, DIRDID_ROOT , name)) != fid_name) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name);
+		}
 		failed_nomsg();
 	}
 
 	if ((ret = get_fid(Conn, vol, dir , name1)) != fid_name1) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name1);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name);
+		}
 		failed_nomsg();
 	}
 
@@ -153,7 +170,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, ndir))
 test_exit:
-	exit_test("test111");
+	exit_test("FPExchangeFiles:test111: exchange open files");
 }
 
 /* ------------------------- */
@@ -166,8 +183,6 @@ char *ndir  = "t197 dir";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPExchangeFiles:test197: exchange files (doesn't check files' ID)\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -185,12 +200,16 @@ uint16_t vol = VolID;
 
 	read_fork(Conn, vol,  DIRDID_ROOT , name, 3);
 	if (strcmp(Data,"red")) {
-		fprintf(stdout,"\tFAILED should be red\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be red\n");
+		}
 		failed_nomsg();
 	}
 	read_fork(Conn,  vol, dir , name1, 4);
 	if (strcmp(Data,"blue")) {
-		fprintf(stdout,"\tFAILED should be blue\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be blue\n");
+		}
 		failed_nomsg();
 	}
 	FAIL (FPDelete(Conn, vol,  dir , name1))
@@ -198,7 +217,7 @@ uint16_t vol = VolID;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, ndir))
 test_exit:
-	exit_test("test197");
+	exit_test("FPExchangeFiles:test197: exchange files (doesn't check files' ID)");
 }
 
 /* ------------------------- */
@@ -218,8 +237,6 @@ DSI *dsi = &Conn->dsi;
 int  ofs =  3 * sizeof( uint16_t );
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPExchangeFiles:test342: exchange files\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -254,34 +271,44 @@ int  ofs =  3 * sizeof( uint16_t );
     filedir.isdir = 0;
     afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
     if (memcmp(finder_info, filedir.finder_info, 32) != 0) {
-		fprintf(stdout,"\tFAILED: metadata wasn't preserved\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED: metadata wasn't preserved\n");
+		}
 		failed_nomsg();
     }
 
 	/* test remove of no cnid db */
 	if ((temp = get_fid(Conn, vol, DIRDID_ROOT , name)) != fid_name) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name);
+		}
 		failed_nomsg();
 	}
 	if ((temp = get_fid(Conn, vol, dir , name1)) != fid_name1) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name1);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name1);
+		}
 		failed_nomsg();
 	}
 
 	read_fork(Conn, vol,  DIRDID_ROOT , name, 3);
 	if (strcmp(Data,"red")) {
-		fprintf(stdout,"\tFAILED should be red\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be red\n");
+		}
 		failed_nomsg();
 	}
 	read_fork(Conn,  vol, dir , name1, 4);
 	if (strcmp(Data,"blue")) {
-		fprintf(stdout,"\tFAILED should be blue\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be blue\n");
+		}
 		failed_nomsg();
 	}
 	FAIL (FPDelete(Conn, vol,  dir , name1))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test342");
+	exit_test("FPExchangeFiles:test342: exchange files");
 }
 
 /* ------------------------- */
@@ -298,8 +325,6 @@ int fork;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPExchangeFiles:test389: exchange files, source with resource fork open\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -326,22 +351,30 @@ uint16_t vol = VolID;
 
 	/* test remove of no cnid db */
 	if ((temp = get_fid(Conn, vol, DIRDID_ROOT , name)) != fid_name) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name);
+		}
 		failed_nomsg();
 	}
 	if ((temp = get_fid(Conn, vol, dir , name1)) != fid_name1) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name1);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name1);
+		}
 		failed_nomsg();
 	}
 
 	read_fork(Conn, vol,  DIRDID_ROOT , name, 3);
 	if (strcmp(Data,"red")) {
-		fprintf(stdout,"\tFAILED should be red\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be red\n");
+		}
 		failed_nomsg();
 	}
 	read_fork(Conn,  vol, dir , name1, 4);
 	if (strcmp(Data,"blue")) {
-		fprintf(stdout,"\tFAILED should be blue\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be blue\n");
+		}
 		failed_nomsg();
 	}
 
@@ -349,7 +382,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir , name1))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test389");
+	exit_test("FPExchangeFiles:test389: exchange files, source with resource fork open");
 }
 
 /* ------------------------- */
@@ -366,8 +399,6 @@ int fork;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPExchangeFiles:test390: exchange files, source with resource fork open\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -395,22 +426,30 @@ uint16_t vol = VolID;
 
 	/* test remove of no cnid db */
 	if ((temp = get_fid(Conn, vol, DIRDID_ROOT , name)) != fid_name) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name);
+		}
 		failed_nomsg();
 	}
 	if ((temp = get_fid(Conn, vol, dir , name1)) != fid_name1) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name1);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name1);
+		}
 		failed_nomsg();
 	}
 
 	read_fork(Conn, vol,  DIRDID_ROOT , name, 3);
 	if (strcmp(Data,"red")) {
-		fprintf(stdout,"\tFAILED should be red\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be red\n");
+		}
 		failed_nomsg();
 	}
 	read_fork(Conn,  vol, dir , name1, 4);
 	if (strcmp(Data,"blue")) {
-		fprintf(stdout,"\tFAILED should be blue\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be blue\n");
+		}
 		failed_nomsg();
 	}
 
@@ -418,7 +457,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir , name1))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test390");
+	exit_test("FPExchangeFiles:test390: exchange files, source with resource fork open");
 }
 
 /* ------------------------- */
@@ -435,8 +474,6 @@ int fork;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPExchangeFiles:test391: exchange files, dest with resource fork open\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -463,22 +500,30 @@ uint16_t vol = VolID;
 
 	/* test remove of no cnid db */
 	if ((temp = get_fid(Conn, vol, DIRDID_ROOT , name)) != fid_name) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name);
+		}
 		failed_nomsg();
 	}
 	if ((temp = get_fid(Conn, vol, dir , name1)) != fid_name1) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name1);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name1);
+		}
 		failed_nomsg();
 	}
 
 	read_fork(Conn, vol,  DIRDID_ROOT , name, 3);
 	if (strcmp(Data,"red")) {
-		fprintf(stdout,"\tFAILED should be red\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be red\n");
+		}
 		failed_nomsg();
 	}
 	read_fork(Conn,  vol, dir , name1, 4);
 	if (strcmp(Data,"blue")) {
-		fprintf(stdout,"\tFAILED should be blue\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be blue\n");
+		}
 		failed_nomsg();
 	}
 
@@ -486,7 +531,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir , name1))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test391");
+	exit_test("FPExchangeFiles:test391: exchange files, dest with resource fork open");
 }
 
 /* ----------- */
@@ -494,6 +539,7 @@ void FPExchangeFiles_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPExchangeFiles page 166\n");
+    fprintf(stdout,"-------------------\n");
 	test108();
 	test111();
 	test197();

--- a/test/testsuite/FPFlush.c
+++ b/test/testsuite/FPFlush.c
@@ -8,13 +8,11 @@ STATIC void test202()
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPFlush:test202: flush volume call\n");
 
 	FAIL (FPFlush(Conn, vol))
 
 	FAIL (htonl(AFPERR_PARAM) != FPFlush(Conn, vol +1))
-	exit_test("test202");
+	exit_test("FPFlush:test202: flush volume call");
 }
 
 /* ----------- */
@@ -22,5 +20,6 @@ void FPFlush_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPFlush page 169\n");
+    fprintf(stdout,"-------------------\n");
 	test202();
 }

--- a/test/testsuite/FPFlush.c
+++ b/test/testsuite/FPFlush.c
@@ -7,7 +7,7 @@ STATIC void test202()
 {
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	FAIL (FPFlush(Conn, vol))
 

--- a/test/testsuite/FPFlushFork.c
+++ b/test/testsuite/FPFlushFork.c
@@ -13,7 +13,7 @@ char *name = "t203 file";
 uint32_t mdate;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();

--- a/test/testsuite/FPFlushFork.c
+++ b/test/testsuite/FPFlushFork.c
@@ -14,8 +14,6 @@ uint32_t mdate;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPFlushFork:test203: flush fork call\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -43,7 +41,9 @@ DSI *dsi = &Conn->dsi;
 	afp_filedir_unpack(&filedir, dsi->data +sizeof(uint16_t), bitmap, 0);
 	/* is that always true? ie over nfs */
 	if (mdate != filedir.mdate) {
-		fprintf(stdout,"\tFAILED dates differ\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED dates differ\n");
+		}
 		failed_nomsg();
 	}
 
@@ -60,7 +60,9 @@ DSI *dsi = &Conn->dsi;
 	afp_filedir_unpack(&filedir, dsi->data +sizeof(uint16_t), bitmap, 0);
 	/* is that always true? ie over nfs */
 	if (mdate == filedir.mdate) {
-		fprintf(stdout,"\tFAILED dates equal\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED dates equal\n");
+		}
 		failed_nomsg();
 	}
 
@@ -70,7 +72,7 @@ fin:
 	FAIL (fork && FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test203");
+	exit_test("FPFlushFork:test203: flush fork call");
 }
 
 /* ----------- */
@@ -78,5 +80,6 @@ void FPFlushFork_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPFlushFork page 171\n");
+    fprintf(stdout,"-------------------\n");
 	test203();
 }

--- a/test/testsuite/FPGetACL.c
+++ b/test/testsuite/FPGetACL.c
@@ -12,7 +12,7 @@ char *file="test398_file";
 
     dsi = &Conn->dsi;
 
-    enter_test();
+    ENTER_TEST
     if (Conn->afp_version < 30) {
     	test_skipped(T_AFP3);
         goto test_exit;
@@ -54,7 +54,7 @@ char *attr_name="test399_attribute";
 
     dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
     if (Conn->afp_version < 30) {
         test_skipped(T_AFP3);
         goto test_exit;
@@ -109,7 +109,7 @@ STATIC void test432()
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;

--- a/test/testsuite/FPGetACL.c
+++ b/test/testsuite/FPGetACL.c
@@ -13,8 +13,6 @@ char *file="test398_file";
     dsi = &Conn->dsi;
 
     enter_test();
-	fprintf(stdout,"===================\n");
-	fprintf(stdout,"FPGetACL:test398: check ACL support\n");
     if (Conn->afp_version < 30) {
     	test_skipped(T_AFP3);
         goto test_exit;
@@ -41,7 +39,7 @@ char *file="test398_file";
 */
     FPDelete(Conn, vol,  DIRDID_ROOT , file);
 test_exit:
-	exit_test("test398");
+	exit_test("FPGetACL:test398: check ACL support");
 }
 
 
@@ -57,8 +55,6 @@ char *attr_name="test399_attribute";
     dsi = &Conn->dsi;
 
 	enter_test();
-	fprintf(stdout,"===================\n");
-	fprintf(stdout,"FPGetExtAttr:test399: check Extended Attributes Support\n");
     if (Conn->afp_version < 30) {
         test_skipped(T_AFP3);
         goto test_exit;
@@ -97,7 +93,7 @@ char *attr_name="test399_attribute";
     FPDelete(Conn, vol,  DIRDID_ROOT , file);
 
 test_exit:
-	exit_test("test399");
+	exit_test("FPGetExtAttr:test399: check Extended Attributes Support");
 }
 
 STATIC void test432()
@@ -114,8 +110,6 @@ STATIC void test432()
 	dsi = &Conn->dsi;
 
 	enter_test();
-	fprintf(stdout,"===================\n");
-	fprintf(stdout,"FPGetExtAttr:test399: check Extended Attributes Support\n");
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -162,7 +156,7 @@ STATIC void test432()
 	FPDelete(Conn, vol,  DIRDID_ROOT , file);
 
 test_exit:
-	exit_test("test432");
+	exit_test("FPGetExtAttr:test432: set and get Extended Attributes");
 }
 
 /* ----------- */
@@ -170,6 +164,7 @@ void FPGetACL_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetACL\n");
+    fprintf(stdout,"-------------------\n");
 
     test398();
 // FIXME: broken in Netatalk 4.0

--- a/test/testsuite/FPGetACL.c
+++ b/test/testsuite/FPGetACL.c
@@ -55,6 +55,12 @@ char *attr_name="test399_attribute";
     dsi = &Conn->dsi;
 
 	ENTER_TEST
+	// FIXME: tests fail with Netatalk 4.0
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
+
     if (Conn->afp_version < 30) {
         test_skipped(T_AFP3);
         goto test_exit;
@@ -167,9 +173,6 @@ void FPGetACL_test()
     fprintf(stdout,"-------------------\n");
 
     test398();
-// FIXME: broken in Netatalk 4.0
-#if 0
     test399();
-#endif
     test432();
 }

--- a/test/testsuite/FPGetAPPL.c
+++ b/test/testsuite/FPGetAPPL.c
@@ -10,7 +10,7 @@ uint16_t dt;
 char *file = "t169 file";
 int dir;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , file)) {
 		nottested();

--- a/test/testsuite/FPGetAPPL.c
+++ b/test/testsuite/FPGetAPPL.c
@@ -11,8 +11,6 @@ char *file = "t169 file";
 int dir;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetAPPL:t169: test appl\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , file)) {
 		nottested();
@@ -39,7 +37,7 @@ int dir;
 	FAIL ( FPRemoveAPPL(Conn , dt, DIRDID_ROOT, "ttxt", file))
 	FAIL (FPCloseDT(Conn,dt))
 test_exit:
-	exit_test("test169");
+	exit_test("FPGetAPPL:test169: test appl");
 }
 
 /* ----------- */
@@ -47,5 +45,6 @@ void FPGetAPPL_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetAPPL page 172\n");
+    fprintf(stdout,"-------------------\n");
 	test169();
 }

--- a/test/testsuite/FPGetComment.c
+++ b/test/testsuite/FPGetComment.c
@@ -18,8 +18,6 @@ uint16_t vol2;
 DSI *dsi2;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPGetComment:test53: get comment\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -73,7 +71,7 @@ fin:
 	delete_folder(vol, DIRDID_ROOT, name);
 	FAIL (FPCloseDT(Conn, dt))
 test_exit:
-	exit_test("test53");
+	exit_test("FPGetComment:test53: get comment");
 }
 
 
@@ -87,8 +85,6 @@ int ret;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPGetComment:test394: no comment\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -104,7 +100,7 @@ uint16_t vol = VolID;
 	FAIL (FPCloseDT(Conn, dt))
 
 test_exit:
-	exit_test("test394");
+	exit_test("FPGetComment:test394: no comment");
 }
 
 /* ----------- */
@@ -112,6 +108,7 @@ void FPGetComment_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetComment page 176\n");
+    fprintf(stdout,"-------------------\n");
 	test53();
 	test394();
 }

--- a/test/testsuite/FPGetComment.c
+++ b/test/testsuite/FPGetComment.c
@@ -17,7 +17,7 @@ uint16_t vol = VolID;
 uint16_t vol2;
 DSI *dsi2;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -84,7 +84,7 @@ int dir;
 int ret;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -16,8 +16,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test44: access .. folder\n");
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {
@@ -31,7 +29,9 @@ DSI *dsi;
 	memcpy(&did, dsi->data +3 * sizeof( uint16_t ), sizeof(did));
 
 	if (dir != did) {
-		fprintf(stdout,"\tFAILED DIDs differ\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED DIDs differ\n");
+		}
 		failed_nomsg();
 		goto fin;
 	}
@@ -43,7 +43,9 @@ DSI *dsi;
 	memcpy(&did, dsi->data +3 * sizeof( uint16_t ), sizeof(did));
 
 	if (DIRDID_ROOT != did) {
-		fprintf(stdout,"\tFAILED DID not DIRDID_ROOT\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED DID not DIRDID_ROOT\n");
+		}
 		failed_nomsg();
 		goto fin;
 	}
@@ -51,7 +53,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test44");
+	exit_test("FPGetFileDirParms:test44: access .. folder");
 }
 
 /* -------------------------- */
@@ -60,8 +62,6 @@ STATIC void test58()
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test58: folder 1 (DIRDID_ROOT_PARENT)\n");
 
 	if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, DIRDID_ROOT_PARENT, "", 0,
 	        (1 <<  DIRPBIT_LNAME) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID) | (1<<DIRPBIT_UID) |
@@ -83,7 +83,7 @@ uint16_t vol = VolID;
 	) {
 		failed();
 	}
-	exit_test("test58");
+	exit_test("FPGetFileDirParms:test58: folder 1 (DIRDID_ROOT_PARENT)");
 }
 
 /* ----------- */
@@ -100,15 +100,15 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test70: bogus cname (unknow type)\n");
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
 	}
 
-	fprintf(stdout,"---------------------\n");
-	fprintf(stdout,"GetFileDirParams Vol %d \n\n", vol);
+	if (!Quiet) {
+		fprintf(stdout,"---------------------\n");
+		fprintf(stdout,"GetFileDirParams Vol %d \n\n", vol);
+	}
 	memset(dsi->commands, 0, DSI_CMDSIZ);
 	dsi->header.dsi_flags = DSIFL_REQUEST;
 	dsi->header.dsi_command = DSIFUNC_CMD;
@@ -150,7 +150,7 @@ DSI *dsi;
 		failed();
 	}
 test_exit:
-	exit_test("test70");
+	exit_test("FPGetFileDirParms:test70: bogus cname (unknown type)");
 }
 
 /* ------------------------- */
@@ -168,8 +168,6 @@ int offcnt;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test94: test invisible bit attribute\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -182,7 +180,9 @@ int offcnt;
 	filedir.isdir = 1;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 	offcnt = filedir.offcnt;
-	fprintf(stdout,"Modif date parent %x offcnt %d\n", filedir.mdate, offcnt);
+	if (!Quiet) {
+		fprintf(stdout,"Modif date parent %x offcnt %d\n", filedir.mdate, offcnt);
+	}
 	sleep(4);
 
 	if (FPGetFileDirParams(Conn, vol,  DIRDID_ROOT , name, 0,bitmap )) {
@@ -192,7 +192,9 @@ int offcnt;
 	filedir.isdir = 1;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 
-	fprintf(stdout,"Modif date dir %x \n", filedir.mdate);
+	if (!Quiet) {
+		fprintf(stdout,"Modif date dir %x \n", filedir.mdate);
+	}
 	sleep(5);
 
 	filedir.attr = ATTRBIT_INVISIBLE | ATTRBIT_SETCLR ;
@@ -209,7 +211,9 @@ int offcnt;
 	}
 	filedir.isdir = 1;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
-	fprintf(stdout,"Modif date dir %x\n", filedir.mdate);
+	if (!Quiet) {
+		fprintf(stdout,"Modif date dir %x\n", filedir.mdate);
+	}
 
 	if (FPGetFileDirParams(Conn, vol,  DIRDID_ROOT , "", 0,bitmap )) {
 		failed();
@@ -218,15 +222,19 @@ int offcnt;
 	filedir.isdir = 1;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 	if (offcnt != filedir.offcnt) {
-		fprintf(stdout,"\tFAILED got %d want %d\n",filedir.offcnt, offcnt);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED got %d want %d\n",filedir.offcnt, offcnt);
+		}
 		failed_nomsg();
 	}
 
-	fprintf(stdout,"Modif date parent %x\n", filedir.mdate);
+	if (!Quiet) {
+		fprintf(stdout,"Modif date parent %x\n", filedir.mdate);
+	}
 end:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test94");
+	exit_test("FPGetFileDirParms:test94: test invisible bit attribute");
 }
 
 /* --------------------- */
@@ -250,8 +258,6 @@ DSI *dsi;
 
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:t104: cname with trailing 0 \n");
 
 	if (!(dir1 = FPCreateDir(Conn,vol, DIRDID_ROOT , name1))) {
 		nottested();
@@ -285,12 +291,16 @@ DSI *dsi;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 
 	if (filedir.did != dir3) {
-		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, dir3 );
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, dir3 );
+		}
 		failed_nomsg();
 		goto fin;
 	}
 	if (strcmp(filedir.lname, name3)) {
-		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name3);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name3);
+		}
 		failed_nomsg();
 		goto fin;
 	}
@@ -302,17 +312,23 @@ DSI *dsi;
 	}
 	afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 	if (filedir.did != dir2) {
-		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, dir2 );
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, dir2 );
+		}
 		failed_nomsg();
 		goto fin;
 	}
 	if (strcmp(filedir.lname, name2)) {
-		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name2);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name2);
+		}
 		failed_nomsg();
 		goto fin;
 	}
 	if (filedir.offcnt != 2) {
-		fprintf(stdout,"\tFAILED %d\n",filedir.offcnt);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %d\n",filedir.offcnt);
+		}
 		failed_nomsg();
 		goto fin;
 	}
@@ -323,12 +339,16 @@ DSI *dsi;
 	}
 	afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 	if (filedir.did != dir4) {
-		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, dir4 );
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, dir4 );
+		}
 		failed_nomsg();
 		goto fin;
 	}
 	if (strcmp(filedir.lname, name4)) {
-		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name4);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name4);
+		}
 		failed_nomsg();
 	}
 fin:
@@ -337,7 +357,7 @@ fin:
 	FAIL (dir2 && FPDelete(Conn, vol,  dir2 , name5))
 	FAIL (dir1 && FPDelete(Conn, vol,  dir1 , name2))
 	FAIL (dir1 && FPDelete(Conn, vol,  dir1 , ""))
-	exit_test("test104");
+	exit_test("FPGetFileDirParms:test104: cname with trailing 0");
 }
 
 /* -------------------------- */
@@ -353,8 +373,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test132: GetFilDirParams errors\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name1))) {
 		nottested();
@@ -374,7 +392,9 @@ DSI *dsi;
 		     (1<< DIRPBIT_LNAME) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID)|(1<< DIRPBIT_ACCESS);
 
 	if (!strcmp("disk1", Vol)) {
-		fprintf(stdout, "Volume is disk1 choose other name!\n");
+		if (!Quiet) {
+			fprintf(stdout, "Volume is disk1 choose other name!\n");
+		}
 		nottested();
 		goto fin;
 	}
@@ -391,7 +411,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test132");
+	exit_test("FPGetFileDirParms:test132: GetFilDirParams errors");
 }
 
 /* ------------------------- */
@@ -405,8 +425,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test194: dir without access\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -423,7 +441,7 @@ DSI *dsi;
 	}
 	delete_folder(vol, DIRDID_ROOT, name);
 test_exit:
-	exit_test("test194");
+	exit_test("FPGetFileDirParms:test194: dir without access");
 }
 
 /* ------------------------- */
@@ -438,8 +456,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test229: unix access privilege\n");
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -477,7 +493,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test229");
+	exit_test("FPGetFileDirParms:test229: unix access privilege");
 }
 
 /* ------------------------- */
@@ -495,8 +511,6 @@ char *result;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms::test307: mangled dirname\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		failed();
@@ -527,7 +541,7 @@ char *result;
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test307");
+	exit_test("FPGetFileDirParms:test307: mangled dirname");
 }
 
 /* ------------------------- */
@@ -545,8 +559,6 @@ char *result;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms::test308: mangled dirname\n");
 
 	if (Conn->afp_version >= 30) {
 		bitmap = (1<<FILPBIT_PDINFO);
@@ -584,7 +596,7 @@ char *result;
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test308");
+	exit_test("FPGetFileDirParms:test308: mangled dirname");
 }
 
 /* ------------------------- */
@@ -593,13 +605,11 @@ STATIC void test319()
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test319: get volume access right\n");
 
 	if (FPGetFileDirParams(Conn, vol,  DIRDID_ROOT, "", 0,(1 << DIRPBIT_ACCESS) )) {
 		failed();
 	}
-	exit_test("test319");
+	exit_test("FPGetFileDirParms:test319: get volume access right");
 }
 
 /* ------------------------- */
@@ -619,8 +629,6 @@ int id;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms::test324: long file name >31 bytes\n");
 
 	if (Conn->afp_version >= 30) {
 		bitmap = (1<<FILPBIT_PDINFO);
@@ -676,30 +684,20 @@ int id;
 
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test324");
+	exit_test("FPGetFileDirParms:test324: long file name >31 bytes");
 }
 
 
 /* ------------------------- */
 STATIC void test326()
 {
-#if 0
 char *name = "t326 long filename and extension .longtxt";
 uint16_t vol = VolID;
-DSI *dsi;
-int  ofs =  3 * sizeof( uint16_t );
-struct afp_filedir_parms filedir;
 uint16_t bitmap = 0;
-unsigned int dir;
-char *result;
 int ret;
 int id;
 
-	dsi = &Conn->dsi;
-
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms::test326: long file name >31 bytes\n");
 
 	ret = FPCreateFile(Conn, vol,  0, DIRDID_ROOT, name);
 	if (ret) {
@@ -739,8 +737,8 @@ int id;
 		failed();
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
-#endif
-	exit_test("test326");
+test_exit:
+	exit_test("FPGetFileDirParms:test326: long file name >31 bytes");
 }
 
 /* ------------------------- */
@@ -756,8 +754,6 @@ int id;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms::test333: long file name >31 bytes\n");
 
 	if (Conn->afp_version >= 30) {
 		bitmap = (1<<FILPBIT_PDINFO);
@@ -808,7 +804,7 @@ int id;
 
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test333");
+	exit_test("FPGetFileDirParms:test333: long file name >31 bytes");
 }
 
 /* ------------------------- */
@@ -824,8 +820,6 @@ int id;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms::test334: long file name >31 bytes (no ext)\n");
 
 	if (Conn->afp_version >= 30) {
 		bitmap = (1<<FILPBIT_PDINFO);
@@ -877,7 +871,7 @@ int id;
 
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test334");
+	exit_test("FPGetFileDirParms:test334: long file name >31 bytes (no ext)");
 }
 
 /* ------------------------- */
@@ -895,8 +889,6 @@ int id;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms::test335: long file name >31 bytes\n");
 
 	if (Conn->afp_version >= 30) {
 		bitmap = (1<<FILPBIT_PDINFO);
@@ -954,7 +946,7 @@ int id;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test335");
+	exit_test("FPGetFileDirParms:test335: long file name >31 bytes");
 }
 
 /* -------------------------
@@ -974,8 +966,6 @@ DSI *dsi = &Conn->dsi;
 uint16_t bitmap;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test371: check default type\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -992,7 +982,9 @@ uint16_t bitmap;
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 		if (memcmp(filedir.finder_info, "????????", 8)) {
-			fprintf(stdout,"FAILED not default type\n");
+			if (!Quiet) {
+				fprintf(stdout,"FAILED not default type\n");
+			}
 			failed_nomsg();
 		}
 	}
@@ -1004,7 +996,9 @@ uint16_t bitmap;
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 		if (memcmp(filedir.finder_info, "PDF CARO", 8)) {
-			fprintf(stdout,"FAILED not PDF\n");
+			if (!Quiet) {
+				fprintf(stdout,"FAILED not PDF\n");
+			}
 			failed_nomsg();
 		}
 	}
@@ -1012,7 +1006,7 @@ fin:
 	FPDelete(Conn, vol,  DIRDID_ROOT , name);
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 
-	exit_test("test371");
+	exit_test("FPGetFileDirParms:test371: check default type");
 }
 
 /* -------------------------
@@ -1032,8 +1026,6 @@ uint16_t bitmap1 =  (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)| (1<<FILPBIT_CDATE) |
 					(1<<FILPBIT_BDATE) | (1<<FILPBIT_MDATE);
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test380: check type mapping\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -1050,7 +1042,9 @@ uint16_t bitmap1 =  (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)| (1<<FILPBIT_CDATE) |
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 		if (memcmp(filedir.finder_info, "WDBNMSWD", 8)) {
-			fprintf(stdout,"FAILED not default type\n");
+			if (!Quiet) {
+				fprintf(stdout,"FAILED not default type\n");
+			}
 			failed_nomsg();
 		}
 	}
@@ -1062,14 +1056,16 @@ uint16_t bitmap1 =  (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)| (1<<FILPBIT_CDATE) |
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 		if (memcmp(filedir.finder_info, "WDBNMSWD", 8)) {
-			fprintf(stdout,"FAILED not WDBNMSWD\n");
+			if (!Quiet) {
+				fprintf(stdout,"FAILED not WDBNMSWD\n");
+			}
 			failed_nomsg();
 		}
 	}
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 
-	exit_test("test380");
+	exit_test("FPGetFileDirParms:test380: check type mapping");
 }
 
 /* ------------------------- */
@@ -1087,8 +1083,6 @@ unsigned int dir;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms::test396: dir root attribute\n");
 
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
@@ -1116,7 +1110,7 @@ unsigned int dir;
 
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test396");
+	exit_test("FPGetFileDirParms:test396: dir root attribute");
 }
 
 /* ----------- */
@@ -1124,6 +1118,7 @@ void FPGetFileDirParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetFileDirParms page 179\n");
+    fprintf(stdout,"-------------------\n");
 	test44();
 	test58();
 	test70();
@@ -1136,6 +1131,10 @@ void FPGetFileDirParms_test()
 	test308();
 	test319();
 	test324();
+// FIXME: Broken for AFP 2.x
+#if 0
+	test326();
+#endif
 	test333();
 	test334();
 	test335();

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -970,6 +970,11 @@ uint16_t bitmap;
 
 	ENTER_TEST
 
+	// FIXME: may or may not be testable with the right extmap.conf settings
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
 		goto fin;
@@ -1008,7 +1013,7 @@ uint16_t bitmap;
 fin:
 	FPDelete(Conn, vol,  DIRDID_ROOT , name);
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
-
+test_exit:
 	exit_test("FPGetFileDirParms:test371: check default type");
 }
 
@@ -1030,6 +1035,11 @@ uint16_t bitmap1 =  (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)| (1<<FILPBIT_CDATE) |
 
 	ENTER_TEST
 
+	// FIXME: may or may not be testable with the right extmap.conf settings
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
 		goto fin;
@@ -1067,7 +1077,7 @@ uint16_t bitmap1 =  (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)| (1<<FILPBIT_CDATE) |
 	}
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
-
+test_exit:
 	exit_test("FPGetFileDirParms:test380: check type mapping");
 }
 
@@ -1138,9 +1148,7 @@ void FPGetFileDirParms_test()
 	test333();
 	test334();
 	test335();
-// FIXME: These tests require extmap.conf settings which are disabled by default
-#if 0
     test371();
     test380();
-#endif
+	test396();
 }

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -15,7 +15,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {
@@ -61,7 +61,7 @@ STATIC void test58()
 {
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, DIRDID_ROOT_PARENT, "", 0,
 	        (1 <<  DIRPBIT_LNAME) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID) | (1<<DIRPBIT_UID) |
@@ -99,7 +99,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -167,7 +167,7 @@ int offcnt;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -257,7 +257,7 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir1 = FPCreateDir(Conn,vol, DIRDID_ROOT , name1))) {
 		nottested();
@@ -372,7 +372,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name1))) {
 		nottested();
@@ -424,7 +424,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -455,7 +455,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -510,7 +510,7 @@ char *result;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		failed();
@@ -558,7 +558,7 @@ char *result;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version >= 30) {
 		bitmap = (1<<FILPBIT_PDINFO);
@@ -604,7 +604,7 @@ STATIC void test319()
 {
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPGetFileDirParams(Conn, vol,  DIRDID_ROOT, "", 0,(1 << DIRPBIT_ACCESS) )) {
 		failed();
@@ -628,7 +628,7 @@ int id;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version >= 30) {
 		bitmap = (1<<FILPBIT_PDINFO);
@@ -697,7 +697,7 @@ uint16_t bitmap = 0;
 int ret;
 int id;
 
-	enter_test();
+	ENTER_TEST
 
 	ret = FPCreateFile(Conn, vol,  0, DIRDID_ROOT, name);
 	if (ret) {
@@ -756,7 +756,7 @@ int id;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version >= 30) {
 		bitmap = (1<<FILPBIT_PDINFO);
@@ -822,7 +822,7 @@ int id;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version >= 30) {
 		bitmap = (1<<FILPBIT_PDINFO);
@@ -891,7 +891,7 @@ int id;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version >= 30) {
 		bitmap = (1<<FILPBIT_PDINFO);
@@ -968,7 +968,7 @@ struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 uint16_t bitmap;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -1028,7 +1028,7 @@ uint16_t bitmap;
 uint16_t bitmap1 =  (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)| (1<<FILPBIT_CDATE) |
 					(1<<FILPBIT_BDATE) | (1<<FILPBIT_MDATE);
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -1085,7 +1085,7 @@ unsigned int dir;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -708,7 +708,10 @@ int id;
 		bitmap = (1<<FILPBIT_PDINFO);
 	}
 	else {
+		// FIXME: fails with afp 2.x despite the comment below
 		bitmap = (1<<DIRPBIT_LNAME);
+		test_skipped(T_AFP3);
+		goto test_exit;
 	}
 	/* hack if filename < 255 it works with afp 2.x too */
 	id = get_fid(Conn, vol, DIRDID_ROOT , name);
@@ -1131,10 +1134,7 @@ void FPGetFileDirParms_test()
 	test308();
 	test319();
 	test324();
-// FIXME: Broken for AFP 2.x
-#if 0
 	test326();
-#endif
 	test333();
 	test334();
 	test335();

--- a/test/testsuite/FPGetForkParms.c
+++ b/test/testsuite/FPGetForkParms.c
@@ -11,7 +11,9 @@ static void check_forklen(DSI *dsi, int type, uint32_t  len)
 uint32_t flen;
 	flen = get_forklen(dsi, type);
 	if (flen != len) {
-		fprintf(stdout,"\tFAILED got %d but %d expected\n", flen, len);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED got %d but %d expected\n", flen, len);
+		}
 		failed_nomsg();
 	}
 }
@@ -84,9 +86,6 @@ uint16_t vol = VolID;
 char *name = "t21 file";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetForkParms:test21: setting/reading fork len\n");
-
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -98,7 +97,7 @@ char *name = "t21 file";
 
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test21");
+	exit_test("FPGetForkParms:test21: setting/reading fork len");
 }
 
 /* --------------------------
@@ -117,8 +116,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPGetForkParms:test50: deny mode & move file\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -181,7 +178,7 @@ fin:
 	FAIL (fork && FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 test_exit:
-	exit_test("test50");
+	exit_test("FPGetForkParms:test50: deny mode & move file");
 }
 
 /* -------------------------- */
@@ -193,11 +190,9 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetForkParms:test188: illegal fork\n");
 
 	illegal_fork(dsi, AFP_GETFORKPARAM, name);
-	exit_test("test188");
+	exit_test("FPGetForkParms:test188: illegal fork");
 }
 
 /* -------------------------- */
@@ -210,8 +205,6 @@ int ret;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPGetForkParms:test192: open write only\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -243,7 +236,7 @@ fin:
 	FAIL (fork && FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test192");
+	exit_test("FPGetForkParms:test192: open write only");
 }
 
 /* ------------------------- */
@@ -258,8 +251,6 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetForkParms:test305: fork len after a 0 byte write\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -286,7 +277,7 @@ fin:
 	FAIL (fork && FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test305");
+	exit_test("FPGetForkParms:test305: fork len after a 0 byte write");
 }
 
 /* ----------- */
@@ -294,6 +285,7 @@ void FPGetForkParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetForkParms page 184\n");
+    fprintf(stdout,"-------------------\n");
     test21();
     test50();
 	test188();

--- a/test/testsuite/FPGetForkParms.c
+++ b/test/testsuite/FPGetForkParms.c
@@ -85,7 +85,7 @@ STATIC void test21()
 uint16_t vol = VolID;
 char *name = "t21 file";
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -115,7 +115,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -189,7 +189,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	illegal_fork(dsi, AFP_GETFORKPARAM, name);
 	exit_test("FPGetForkParms:test188: illegal fork");
@@ -204,7 +204,7 @@ char *name = "t192 file";
 int ret;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -250,7 +250,7 @@ int len = (1<<FILPBIT_DFLEN);
 DSI *dsi;
 
 	dsi = &Conn->dsi;
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();

--- a/test/testsuite/FPGetIcon.c
+++ b/test/testsuite/FPGetIcon.c
@@ -12,7 +12,7 @@ uint16_t dt;
 unsigned int ret;
 char   u_null[] = { 0, 0, 0, 0 };
 
-	enter_test();
+	ENTER_TEST
 
 	dt = FPOpenDT(Conn,vol);
 

--- a/test/testsuite/FPGetIcon.c
+++ b/test/testsuite/FPGetIcon.c
@@ -13,8 +13,6 @@ unsigned int ret;
 char   u_null[] = { 0, 0, 0, 0 };
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPGetIcon:test115: get Icon call\n");
 
 	dt = FPOpenDT(Conn,vol);
 
@@ -40,7 +38,7 @@ char   u_null[] = { 0, 0, 0, 0 };
 	}
 
 	FPCloseDT(Conn,dt);
-	exit_test("test115");
+	exit_test("FPGetIcon:test115: get Icon call");
 }
 
 /* ----------- */
@@ -48,5 +46,6 @@ void FPGetIcon_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetIcon page 186\n");
+    fprintf(stdout,"-------------------\n");
 	test115();
 }

--- a/test/testsuite/FPGetIconInfo.c
+++ b/test/testsuite/FPGetIconInfo.c
@@ -13,8 +13,6 @@ unsigned int ret;
 u_char   u_null[] = { 0, 0, 0, 0 };
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPGetIconInfo:test213: get Icon Info call\n");
 
 	dt = FPOpenDT(Conn,vol);
 
@@ -42,7 +40,7 @@ u_char   u_null[] = { 0, 0, 0, 0 };
 	}
 
 	FPCloseDT(Conn,dt);
-	exit_test("test213");
+	exit_test("FPGetIconInfo:test213: get Icon Info call");
 }
 
 /* ----------- */
@@ -52,6 +50,7 @@ void FPGetIconInfo_test()
 #if 0
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetIconInfo page 188\n");
+    fprintf(stdout,"-------------------\n");
 	test213();
 #endif
 }

--- a/test/testsuite/FPGetIconInfo.c
+++ b/test/testsuite/FPGetIconInfo.c
@@ -14,6 +14,12 @@ u_char   u_null[] = { 0, 0, 0, 0 };
 
 	ENTER_TEST
 
+	// FIXME: icon tests are broken in Netatalk 4.0
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
+
 	dt = FPOpenDT(Conn,vol);
 
 	ret = FPGetIconInfo(Conn,  dt, (unsigned char *) "ttxt", 1);
@@ -40,17 +46,16 @@ u_char   u_null[] = { 0, 0, 0, 0 };
 	}
 
 	FPCloseDT(Conn,dt);
+
+test_exit:
 	exit_test("FPGetIconInfo:test213: get Icon Info call");
 }
 
 /* ----------- */
 void FPGetIconInfo_test()
 {
-// FIXME: icon tests are broken in Netatalk 4.0
-#if 0
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetIconInfo page 188\n");
     fprintf(stdout,"-------------------\n");
 	test213();
-#endif
 }

--- a/test/testsuite/FPGetIconInfo.c
+++ b/test/testsuite/FPGetIconInfo.c
@@ -12,7 +12,7 @@ uint16_t dt;
 unsigned int ret;
 u_char   u_null[] = { 0, 0, 0, 0 };
 
-	enter_test();
+	ENTER_TEST
 
 	dt = FPOpenDT(Conn,vol);
 

--- a/test/testsuite/FPGetSessionToken.c
+++ b/test/testsuite/FPGetSessionToken.c
@@ -84,7 +84,7 @@ STATIC void test221()
 {
 	ENTER_TEST
 	if (Conn->afp_version <= 31) {
-		test_skipped(T_AFP3);
+		test_skipped(T_AFP32);
 		goto test_exit;
 	}
 

--- a/test/testsuite/FPGetSessionToken.c
+++ b/test/testsuite/FPGetSessionToken.c
@@ -25,8 +25,6 @@ int  dir,dir1;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetSessionToken:test220: AFP 3.0 get session token\n");
 	if (Conn->afp_version != 30) {
 		test_skipped(T_AFP30);
 		goto test_exit;
@@ -78,15 +76,13 @@ uint16_t vol = VolID;
 		FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	}
 test_exit:
-	exit_test("test220");
+	exit_test("FPGetSessionToken:test220: AFP 3.0 get session token");
 }
 
 /* ------------------------- */
 STATIC void test221()
 {
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetSessionToken:test221: AFP 3.1 get session token\n");
 	if (Conn->afp_version <= 31) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -95,7 +91,7 @@ STATIC void test221()
 	FAIL (FPGetSessionToken(Conn, 3, 0, 5, "token"))
         FAIL (FPzzz(Conn, 0))
 test_exit:
-	exit_test("test221");
+	exit_test("FPGetSessionToken:test221: AFP 3.1 get session token");
 }
 
 /* ----------- */
@@ -103,6 +99,7 @@ void FPGetSessionToken_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetSessionToken page 191\n");
+    fprintf(stdout,"-------------------\n");
     test220();
     test221();
 }

--- a/test/testsuite/FPGetSessionToken.c
+++ b/test/testsuite/FPGetSessionToken.c
@@ -24,7 +24,7 @@ char *name2 = "t23 file";
 int  dir,dir1;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version != 30) {
 		test_skipped(T_AFP30);
 		goto test_exit;
@@ -82,7 +82,7 @@ test_exit:
 /* ------------------------- */
 STATIC void test221()
 {
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version <= 31) {
 		test_skipped(T_AFP3);
 		goto test_exit;

--- a/test/testsuite/FPGetSrvrInfo.c
+++ b/test/testsuite/FPGetSrvrInfo.c
@@ -6,7 +6,7 @@
 STATIC void test1(void)
 {
 int ret;
-	enter_test();
+	ENTER_TEST
 
 	ret = FPGetSrvrInfo(Conn);
 	if (ret) {

--- a/test/testsuite/FPGetSrvrInfo.c
+++ b/test/testsuite/FPGetSrvrInfo.c
@@ -7,15 +7,13 @@ STATIC void test1(void)
 {
 int ret;
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetSrvrInfo:test1: GetSrvInfo\n");
 
 	ret = FPGetSrvrInfo(Conn);
 	if (ret) {
 		failed();
 	}
 
-	exit_test("test1");
+	exit_test("FPGetSrvrInfo:test1: GetSrvInfo");
 }
 
 /* ----------- */
@@ -23,5 +21,6 @@ void FPGetSrvrInfo_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetSrvInfo page 194\n");
+    fprintf(stdout,"-------------------\n");
 	test1();
 }

--- a/test/testsuite/FPGetSrvrMsg.c
+++ b/test/testsuite/FPGetSrvrMsg.c
@@ -5,7 +5,7 @@
 /* ----------------------- */
 STATIC void test210(void)
 {
-	enter_test();
+	ENTER_TEST
 
 	FAIL (FPGetSrvrMsg(Conn, 0, 0))
 	FAIL (FPGetSrvrMsg(Conn, 1, 0))

--- a/test/testsuite/FPGetSrvrMsg.c
+++ b/test/testsuite/FPGetSrvrMsg.c
@@ -6,12 +6,10 @@
 STATIC void test210(void)
 {
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetSrvrMsg:test210: GetSrvrParms call\n");
 
 	FAIL (FPGetSrvrMsg(Conn, 0, 0))
 	FAIL (FPGetSrvrMsg(Conn, 1, 0))
-	exit_test("test210");
+	exit_test("FPGetSrvrMsg:test210: GetSrvrParms call");
 }
 
 /* ----------- */
@@ -19,5 +17,6 @@ void FPGetSrvrMsg_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetSrvrMsg page 200\n");
+    fprintf(stdout,"-------------------\n");
 	test210();
 }

--- a/test/testsuite/FPGetSrvrParms.c
+++ b/test/testsuite/FPGetSrvrParms.c
@@ -6,7 +6,7 @@
 STATIC void test209(void)
 {
 int ret;
-	enter_test();
+	ENTER_TEST
 
 	ret = FPGetSrvrParms(Conn);
 	if (ret) {
@@ -26,7 +26,7 @@ int found = 0;
 unsigned char len;
 unsigned char *b;
 
-	enter_test();
+	ENTER_TEST
 
 	FPCloseVol(Conn,VolID);
 

--- a/test/testsuite/FPGetSrvrParms.c
+++ b/test/testsuite/FPGetSrvrParms.c
@@ -7,14 +7,12 @@ STATIC void test209(void)
 {
 int ret;
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetSrvrParms:test209: GetSrvrParms call\n");
 
 	ret = FPGetSrvrParms(Conn);
 	if (ret) {
 		failed();
 	}
-	exit_test("test209");
+	exit_test("FPGetSrvrParms:test209: GetSrvrParms call");
 
 }
 
@@ -29,8 +27,6 @@ unsigned char len;
 unsigned char *b;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetSrvrParms:test316: GetSrvrParms for a volume with option nostat set\n");
 
 	FPCloseVol(Conn,VolID);
 
@@ -56,7 +52,7 @@ unsigned char *b;
 	if (VolID == 0xffff) {
 		nottested();
 	}
-	exit_test("test316");
+	exit_test("FPGetSrvrParms:test316: GetSrvrParms for a volume with option nostat set");
 }
 
 /* ----------- */
@@ -64,6 +60,7 @@ void FPGetSrvrParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetSrvrParms page 203\n");
+    fprintf(stdout,"-------------------\n");
 	test209();
 	test316();
 }

--- a/test/testsuite/FPGetUserInfo.c
+++ b/test/testsuite/FPGetUserInfo.c
@@ -15,7 +15,7 @@ uint16_t bitmap =  (1<<DIRPBIT_UID) | (1 << DIRPBIT_GID);
 uint16_t vol = VolID;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();

--- a/test/testsuite/FPGetUserInfo.c
+++ b/test/testsuite/FPGetUserInfo.c
@@ -16,8 +16,6 @@ uint16_t vol = VolID;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetUserInfo:test75: Get User Info\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -43,7 +41,9 @@ DSI *dsi = &Conn->dsi;
 		FAIL (FPMapID(Conn, 1, uid))
 		FAIL (FPMapID(Conn, 2, gid))
 		if (uid != filedir.uid ) {
-			fprintf(stdout, "\tFAILED uids differ\n");
+			if (!Quiet) {
+				fprintf(stdout, "\tFAILED uids differ\n");
+			}
 			failed_nomsg();
 		}
 	}
@@ -68,13 +68,15 @@ DSI *dsi = &Conn->dsi;
 	FAIL (FPMapID(Conn, 1, uid))
 	FAIL (FPMapID(Conn, 2, gid))
 	if (uid != filedir.uid) {
-		fprintf(stdout, "\tFAILED uid differ\n");
+		if (!Quiet) {
+			fprintf(stdout, "\tFAILED uid differ\n");
+		}
 		failed_nomsg();
 	}
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test75");
+	exit_test("FPGetUserInfo:test75: Get User Info");
 }
 
 /* ----------- */
@@ -82,5 +84,6 @@ void FPGetUserInfo_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPFPGetUserInfo page 204\n");
+    fprintf(stdout,"-------------------\n");
 	test75();
 }

--- a/test/testsuite/FPGetVolParms.c
+++ b/test/testsuite/FPGetVolParms.c
@@ -9,8 +9,6 @@ uint16_t bitmap;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPGetVolParms:test56: Volume parameters\n");
     bitmap = (1 << VOLPBIT_ATTR  )
 	    |(1 << VOLPBIT_SIG   )
     	|(1 << VOLPBIT_CDATE )
@@ -29,7 +27,7 @@ uint16_t vol = VolID;
  	FAIL (htonl(AFPERR_PARAM) != FPGetVolParam(Conn, vol +1, bitmap))
  	FAIL (htonl(AFPERR_BITMAP) != FPGetVolParam(Conn, vol , 0xffff))
 
-	exit_test("test56");
+	exit_test("FPGetVolParms:test56: Volume parameters");
 } 
 
 /* ----------- */
@@ -37,5 +35,6 @@ void FPGetVolParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetVolParms page 207\n");
+    fprintf(stdout,"-------------------\n");
 	test56();
 }

--- a/test/testsuite/FPGetVolParms.c
+++ b/test/testsuite/FPGetVolParms.c
@@ -8,7 +8,7 @@ STATIC void test56()
 uint16_t bitmap;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
     bitmap = (1 << VOLPBIT_ATTR  )
 	    |(1 << VOLPBIT_SIG   )
     	|(1 << VOLPBIT_CDATE )

--- a/test/testsuite/FPMapID.c
+++ b/test/testsuite/FPMapID.c
@@ -14,7 +14,7 @@ unsigned int ret;
 uint16_t vol = VolID;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();

--- a/test/testsuite/FPMapID.c
+++ b/test/testsuite/FPMapID.c
@@ -15,8 +15,6 @@ uint16_t vol = VolID;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPMapID:test208: test Map ID call\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -62,7 +60,7 @@ DSI *dsi = &Conn->dsi;
 	/* --------------------- */
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test208");
+	exit_test("FPMapID:test208: test Map ID call");
 }
 
 /* ----------- */
@@ -72,6 +70,7 @@ void FPMapID_test()
 #if 0
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPMapID page 220\n");
+    fprintf(stdout,"-------------------\n");
 	test208();
 #endif
 }

--- a/test/testsuite/FPMapID.c
+++ b/test/testsuite/FPMapID.c
@@ -16,6 +16,12 @@ DSI *dsi = &Conn->dsi;
 
 	ENTER_TEST
 
+	// FIXME: encoding tests are broken in Netatalk 4.0
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
+
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
 		goto test_exit;
@@ -66,11 +72,8 @@ test_exit:
 /* ----------- */
 void FPMapID_test()
 {
-// FIXME: encoding tests are broken in Netatalk 4.0
-#if 0
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPMapID page 220\n");
     fprintf(stdout,"-------------------\n");
 	test208();
-#endif
 }

--- a/test/testsuite/FPMapName.c
+++ b/test/testsuite/FPMapName.c
@@ -76,13 +76,13 @@ char *usr = NULL;
 
 	FAIL (htonl(AFPERR_NOITEM) != FPMapName(Conn, 5, "toto"))
 
-	if (!Exclude) {
-		/* fail with OSX and new netatalk */
-		ret = FPMapName(Conn, 3, "");
-		if (ret && not_valid_bitmap(ret, BITERR_NOOBJ, AFPERR_PARAM)) {
-			failed();
-		}
+#if 0
+	/* fail with OSX and new netatalk */
+	ret = FPMapName(Conn, 3, "");
+	if (ret && not_valid_bitmap(ret, BITERR_NOOBJ, AFPERR_PARAM)) {
+		failed();
 	}
+#endif
 
 	ret = FPMapName(Conn, 3, "toto");
 	if (not_valid_bitmap(ret, BITERR_NOOBJ | BITERR_NOITEM, AFPERR_NOITEM)) {

--- a/test/testsuite/FPMapName.c
+++ b/test/testsuite/FPMapName.c
@@ -18,6 +18,11 @@ char *usr = NULL;
 
 	ENTER_TEST
 
+	// FIXME: encoding tests are broken in Netatalk 4.0
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
 		goto test_exit;
@@ -138,11 +143,8 @@ test_exit:
 /* ----------- */
 void FPMapName_test()
 {
-// FIXME: encoding tests are broken in Netatalk 4.0
-#if 0
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPMapName page 222\n");
     fprintf(stdout,"-------------------\n");
 	test180();
-#endif
 }

--- a/test/testsuite/FPMapName.c
+++ b/test/testsuite/FPMapName.c
@@ -17,8 +17,6 @@ char *grp = NULL;
 char *usr = NULL;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPMapName:test180: test Map Name\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -134,7 +132,7 @@ char *usr = NULL;
 
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test180");
+	exit_test("FPMapName:test180: test Map Name");
 }
 
 /* ----------- */
@@ -144,6 +142,7 @@ void FPMapName_test()
 #if 0
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPMapName page 222\n");
+    fprintf(stdout,"-------------------\n");
 	test180();
 #endif
 }

--- a/test/testsuite/FPMapName.c
+++ b/test/testsuite/FPMapName.c
@@ -16,7 +16,7 @@ DSI *dsi = &Conn->dsi;
 char *grp = NULL;
 char *usr = NULL;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();

--- a/test/testsuite/FPMoveAndRename.c
+++ b/test/testsuite/FPMoveAndRename.c
@@ -10,7 +10,7 @@ char *name1= "t43 subdir";
 uint16_t vol = VolID;
 int  dir = 0,dir1 = 0,dir2 = 0;
 
-	enter_test();
+	ENTER_TEST
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {
@@ -73,7 +73,7 @@ char *name = "t77 Move open fork other dir";
 char *name1 = "t77 dir";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name1))) {
 		nottested();
@@ -116,7 +116,7 @@ char *dest  = "t123 dest";
 char *dest1  = "t123 dest_1";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -172,7 +172,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name1))) {
 		nottested();
@@ -221,7 +221,7 @@ char *name1 = "t378 Name";
 uint16_t vol = VolID;
 int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		failed();

--- a/test/testsuite/FPMoveAndRename.c
+++ b/test/testsuite/FPMoveAndRename.c
@@ -11,8 +11,6 @@ uint16_t vol = VolID;
 int  dir = 0,dir1 = 0,dir2 = 0;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPMoveAndRename:test43: move and rename folders\n");
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {
@@ -63,7 +61,7 @@ fin:
 	FAIL (dir1 && FPDelete(Conn, vol,  dir1, ""))
 	FAIL (dir && FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test43");
+	exit_test("FPMoveAndRename:test43: move and rename folders");
 }
 
 /* -------------------------- */
@@ -76,8 +74,6 @@ char *name1 = "t77 dir";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPMoveAndRename:t77: Move an open fork in a different folder\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name1))) {
 		nottested();
@@ -104,7 +100,7 @@ uint16_t vol = VolID;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 test_exit:
-	exit_test("test77");
+	exit_test("FPMoveAndRename:test77: Move an open fork in a different folder");
 }
 
 /* ------------------------------ */
@@ -121,8 +117,6 @@ char *dest1  = "t123 dest_1";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPMoveAndRename:test123: Move And Rename dir with sibling\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -160,7 +154,7 @@ fin:
 	FAIL (dir1 && FPDelete(Conn, vol,  dir1 , ""))
 	FAIL (dir4 && FPDelete(Conn, vol,  dir4 , ""))
 	FAIL (dir && FPDelete(Conn, vol,  dir , ""))
-	exit_test("test123");
+	exit_test("FPMoveAndRename:test123: Move And Rename dir with sibling");
 
 }
 
@@ -179,8 +173,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPMoveAndRename:test138: Move And Rename \n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name1))) {
 		nottested();
@@ -217,7 +209,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test138");
+	exit_test("FPMoveAndRename:test138: Move And Rename");
 }
 
 /* -------------------------
@@ -230,8 +222,6 @@ uint16_t vol = VolID;
 int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPMoveAndRename:test378: dest file exist but diff only by case, is this one OK \n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		failed();
@@ -255,7 +245,7 @@ fin:
 	FPDelete(Conn, vol,  DIRDID_ROOT , name);
 
 test_exit:
-	exit_test("test378");
+	exit_test("FPMoveAndRename:test378: dest file exist but diff only by case, is this one OK");
 }
 
 /* ----------- */
@@ -263,6 +253,7 @@ void FPMoveAndRename_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPMoveAndRename page 223\n");
+    fprintf(stdout,"-------------------\n");
     test43();
     test77();
     test138();

--- a/test/testsuite/FPOpenDT.c
+++ b/test/testsuite/FPOpenDT.c
@@ -9,7 +9,7 @@ uint16_t  dir;
 uint16_t vol = VolID;
 DSI *dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	dsi = &Conn->dsi;
 

--- a/test/testsuite/FPOpenDT.c
+++ b/test/testsuite/FPOpenDT.c
@@ -10,8 +10,6 @@ uint16_t vol = VolID;
 DSI *dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPOpenDT:test200: OpenDT call\n");
 
 	dsi = &Conn->dsi;
 
@@ -24,7 +22,7 @@ DSI *dsi;
     if (dir != 0xffff || ntohl(AFPERR_PARAM) != dsi->header.dsi_code) {
 		failed();
 	}
-	exit_test("test200");
+	exit_test("FPOpenDT:test200: OpenDT call");
 }
 
 /* ----------- */
@@ -32,5 +30,6 @@ void FPOpenDT_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPOpenDT page 229\n");
+    fprintf(stdout,"-------------------\n");
 	test200();
 }

--- a/test/testsuite/FPOpenDir.c
+++ b/test/testsuite/FPOpenDir.c
@@ -18,8 +18,6 @@ DSI *dsi;
 
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPOpenDir:test57: OpenDir call\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -81,7 +79,7 @@ fin:
 		delete_folder(vol, DIRDID_ROOT, name2);
 	}
 test_exit:
-	exit_test("test57");
+	exit_test("FPOpenDir:test57: OpenDir call");
 }
 
 /* ----------- */
@@ -89,5 +87,6 @@ void FPOpenDir_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPOpenDir page 227\n");
+    fprintf(stdout,"-------------------\n");
 	test57();
 }

--- a/test/testsuite/FPOpenDir.c
+++ b/test/testsuite/FPOpenDir.c
@@ -17,7 +17,7 @@ int ret;
 DSI *dsi;
 
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;

--- a/test/testsuite/FPOpenFork.c
+++ b/test/testsuite/FPOpenFork.c
@@ -12,7 +12,7 @@ int fork;
 uint16_t vol = VolID;
 char *name = "t14 file";
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -54,7 +54,7 @@ uint16_t vol = VolID;
 int fork;
 char *name = "t15 file";
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -89,7 +89,7 @@ int fork = 0;
 int fork2 = 0;
 char *name = "t16 file";
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -134,7 +134,7 @@ int fork2 = 0;
 int fork3 = 0;
 char *name = "t17 file";
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -201,7 +201,7 @@ int fork2 = 0;
 int fork3 = 0;
 char *name = "t18 file";
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -249,7 +249,7 @@ int fork2 = 0;
 int fork3 = 0;
 char *name = "t19 file";
 
-	enter_test();
+	ENTER_TEST
 
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
@@ -317,7 +317,7 @@ int fork = 0;
 int fork2 = 0;
 char *name = "t20 file";
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -361,7 +361,7 @@ char *name1 = "t39 dir//t39 file.txt";
 char *name2 = "t39 dir///t39 file.txt";
 int  fork;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , ndir))) {
 		nottested();
@@ -418,7 +418,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , ndir))) {
 		nottested();
@@ -531,7 +531,7 @@ STATIC void test81()
 {
 char *name = "t81 Denymode RF 2users";
 
-	enter_test();
+	ENTER_TEST
 	if (!Quiet) {
 		fprintf(stdout,"FPOpenFork:test81: Deny mode 2 users RF\n");
 	}
@@ -570,7 +570,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -629,7 +629,7 @@ int fork;
 char *name = "t145 file.txt";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)){
 		nottested();
@@ -662,7 +662,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name1)){
 		nottested();
@@ -722,7 +722,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -872,7 +872,7 @@ STATIC void test341()
 {
 char *name = "t341 Attrib open mode RF";
 
-	enter_test();
+	ENTER_TEST
 	if (!Quiet) {
 		fprintf(stdout,"FPOpenFork:test341: Attrib open mode 2 users RF\n");
 	}
@@ -952,7 +952,7 @@ STATIC void test367()
 {
 char *name = "t367 Denymode RF 2users";
 
-	enter_test();
+	ENTER_TEST
 	if (!Quiet) {
 		fprintf(stdout,"FPOpenFork:test367: Deny mode 2 users RF\n");
 	}

--- a/test/testsuite/FPOpenFork.c
+++ b/test/testsuite/FPOpenFork.c
@@ -13,8 +13,6 @@ uint16_t vol = VolID;
 char *name = "t14 file";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test14: get data fork open attribute same connection\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -41,7 +39,7 @@ char *name = "t14 file";
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test14");
+	exit_test("FPOpenFork:test14: get data fork open attribute same connection");
 
 }
 
@@ -57,8 +55,6 @@ int fork;
 char *name = "t15 file";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test15: get resource fork open attribute\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -80,7 +76,7 @@ char *name = "t15 file";
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test15");
+	exit_test("FPOpenFork:test15: get resource fork open attribute");
 
 }
 
@@ -94,8 +90,6 @@ int fork2 = 0;
 char *name = "t16 file";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPOpenFork:test16: open deny mode/ fork attrib\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -126,7 +120,7 @@ fin:
 	FAIL (fork2 && FPCloseFork(Conn,fork2))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test16");
+	exit_test("FPOpenFork:test16: open deny mode/ fork attrib");
 
 }
 
@@ -141,8 +135,6 @@ int fork3 = 0;
 char *name = "t17 file";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPOpenFork:test17: open deny mode/ fork attrib\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -196,7 +188,7 @@ fin:
 	FAIL (fork3 && FPCloseFork(Conn,fork3))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test17");
+	exit_test("FPOpenFork:test17: open deny mode/ fork attrib");
 }
 
 /* -------------------------- */
@@ -210,8 +202,6 @@ int fork3 = 0;
 char *name = "t18 file";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPOpenFork:test18: open deny mode/ fork attrib\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -246,7 +236,7 @@ fin:
 	FAIL (fork3 && FPCloseFork(Conn,fork3))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test18");
+	exit_test("FPOpenFork:test18: open deny mode/ fork attrib");
 }
 
 /* -------------------------- */
@@ -260,8 +250,6 @@ int fork3 = 0;
 char *name = "t19 file";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPOpenFork:test19: open deny mode/ fork attrib\n");
 
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
@@ -317,7 +305,7 @@ fin:
 	FAIL (fork3 && FPCloseFork(Conn,fork3))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test19");
+	exit_test("FPOpenFork:test19: open deny mode/ fork attrib");
 }
 
 /* ------------------------- */
@@ -330,8 +318,6 @@ int fork2 = 0;
 char *name = "t20 file";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test20: open file read only and read write\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -358,7 +344,7 @@ fin:
 	FAIL (fork && FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test20");
+	exit_test("FPOpenFork:test20: open file read only and read write");
 }
 
 /* ----------------------- */
@@ -376,8 +362,6 @@ char *name2 = "t39 dir///t39 file.txt";
 int  fork;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test39: cname path folder + filename\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , ndir))) {
 		nottested();
@@ -419,7 +403,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , nf1))
 test_exit:
-	exit_test("test39");
+	exit_test("FPOpenFork:test39: cname path folder + filename");
 }
 
 /* ------------------------- */
@@ -435,8 +419,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test48: open fork a folder\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , ndir))) {
 		nottested();
@@ -454,7 +436,7 @@ DSI *dsi;
 
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test48");
+	exit_test("FPOpenFork:test48: open fork a folder");
 }
 
 /* ---------------------------- */
@@ -550,8 +532,9 @@ STATIC void test81()
 char *name = "t81 Denymode RF 2users";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test81: Deny mode 2 users RF\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test81: Deny mode 2 users RF\n");
+	}
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -564,13 +547,14 @@ char *name = "t81 Denymode RF 2users";
 
 	test_denymode(name, OPENFORK_RSCS);
 
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test81: Deny mode 2 users DF\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test81: Deny mode 2 users DF\n");
+	}
 	name = "t81 Denymode DF 2users";
 	test_denymode(name, OPENFORK_DATA);
 
 test_exit:
-	exit_test("test81");
+	exit_test("FPOpenFork:test81: Deny mode 2 users");
 }
 
 /* ------------------------- */
@@ -586,10 +570,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:t116: test file's no-write attribute\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -637,7 +618,7 @@ DSI *dsi;
 end:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test116");
+	exit_test("FPOpenFork:test116: test file's no-write attribute");
 }
 
 /* -------------------------- */
@@ -649,8 +630,6 @@ char *name = "t145 file.txt";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPOpenFork:test145: open RF mode 0\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)){
 		nottested();
@@ -665,7 +644,7 @@ uint16_t vol = VolID;
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test145");
+	exit_test("FPOpenFork:test145: open RF mode 0");
 }
 
 /* ------------------------- */
@@ -684,8 +663,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test151: too many open files\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name1)){
 		nottested();
@@ -730,7 +707,7 @@ DSI *dsi;
 end:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name1))
 test_exit:
-	exit_test("test151");
+	exit_test("FPOpenFork:test151: too many open files");
 }
 
 /* -------------------------- */
@@ -746,8 +723,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPOpenFork::test190: deny mode after file moved\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -788,7 +763,7 @@ fin:
 	FAIL (fork && FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 test_exit:
-	exit_test("test190");
+	exit_test("FPOpenFork::test190: deny mode after file moved");
 }
 
 
@@ -898,14 +873,13 @@ STATIC void test341()
 char *name = "t341 Attrib open mode RF";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test341: Attrib open mode 2 users RF\n");
-
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test341: Attrib open mode 2 users RF\n");
+	}
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
 	}
-
 	if (Locking) {
 		test_skipped(T_LOCKING);
 		goto test_exit;
@@ -913,12 +887,14 @@ char *name = "t341 Attrib open mode RF";
 
 	test_openmode(name, OPENFORK_RSCS);
 
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test341: Attrib open mode 2 users DF\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test341: Attrib open mode 2 users DF\n");
+	}
+
     name = "t341 Attrib open mode RF";
 	test_openmode(name, OPENFORK_DATA);
 test_exit:
-	exit_test("test341");
+	exit_test("FPOpenFork:test341: Attrib open mode 2 users");
 }
 
 /* ---------------------------- */
@@ -977,8 +953,9 @@ STATIC void test367()
 char *name = "t367 Denymode RF 2users";
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test367: Deny mode 2 users RF\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test367: Deny mode 2 users RF\n");
+	}
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -991,12 +968,13 @@ char *name = "t367 Denymode RF 2users";
 
 	test_denymode1(name, OPENFORK_RSCS);
 
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test367: Deny mode 2 users DF\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test367: Deny mode 2 users DF\n");
+	}
 	name = "t367 Denymode DF 2users";
 	test_denymode1(name, OPENFORK_DATA);
 test_exit:
-	exit_test("test367");
+	exit_test("FPOpenFork:test367: Deny mode 2 users");
 }
 
 /* ----------- */
@@ -1004,6 +982,7 @@ void FPOpenFork_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPOpenFork page 230\n");
+    fprintf(stdout,"-------------------\n");
 
     test14();
     test15();

--- a/test/testsuite/FPOpenFork.c
+++ b/test/testsuite/FPOpenFork.c
@@ -996,6 +996,7 @@ void FPOpenFork_test()
     test81();
     test116();
     test145();
+// Disable test for too many open forks, it was skipped anyway
 //    test151();
     test190();
     test341();

--- a/test/testsuite/FPOpenVol.c
+++ b/test/testsuite/FPOpenVol.c
@@ -10,7 +10,7 @@ DSI *dsi = &Conn->dsi;
 uint16_t ret;
 char *tp;
 
-	enter_test();
+	ENTER_TEST
 
     FAIL (FPCloseVol(Conn, vol));
 	/* --------- */
@@ -73,7 +73,7 @@ uint16_t vol = VolID;
 DSI *dsi = &Conn->dsi;
 uint16_t ret;
 
-	enter_test();
+	ENTER_TEST
 
     FAIL (FPCloseVol(Conn, vol));
 

--- a/test/testsuite/FPOpenVol.c
+++ b/test/testsuite/FPOpenVol.c
@@ -11,8 +11,6 @@ uint16_t ret;
 char *tp;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenVol:t205: Open Volume call\n");
 
     FAIL (FPCloseVol(Conn, vol));
 	/* --------- */
@@ -53,7 +51,9 @@ char *tp;
 	}
 	vol = FPOpenVol(Conn, Vol);
 	if (vol != ret) {
-		fprintf(stdout,"\tFAILED double open != volume id\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED double open != volume id\n");
+		}
 		failed_nomsg();
 	}
     FAIL (FPCloseVol(Conn, ret));
@@ -63,7 +63,7 @@ fin:
 	if (ret == 0xffff) {
 		failed();
 	}
-	exit_test("test205");
+	exit_test("FPOpenVol:test205: Open Volume call");
 }
 
 /* -------------------------------- */
@@ -74,8 +74,6 @@ DSI *dsi = &Conn->dsi;
 uint16_t ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenVol:t404: lazy init of dbd cnid\n");
 
     FAIL (FPCloseVol(Conn, vol));
 
@@ -100,7 +98,7 @@ fin:
 	if (ret == 0xffff) {
 		failed();
 	}
-	exit_test("test404");
+	exit_test("FPOpenVol:test404: lazy init of dbd cnid");
 }
 
 /* ----------- */
@@ -108,6 +106,8 @@ void FPOpenVol_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPOpenVol page 235\n");
+    fprintf(stdout,"-------------------\n");
 
     test205();
+    test404();
 }

--- a/test/testsuite/FPRead.c
+++ b/test/testsuite/FPRead.c
@@ -31,7 +31,7 @@ int size;
 DSI *dsi;
 
 	dsi = &Conn->dsi;
-	enter_test();
+	ENTER_TEST
 	size = min(10000, dsi->server_quantum);
 	if (size < 2000) {
 		if (!Quiet) {
@@ -145,7 +145,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	size = min(10000, dsi->server_quantum);
 	if (size < 2000) {
 		if (!Quiet) {
@@ -250,7 +250,7 @@ char *name = "test59 FPRead,FPWrite 2GB lim";
 uint16_t vol = VolID;
 int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -290,7 +290,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	size = min(10000, dsi->server_quantum);
 	if (size < 2000) {
 		if (!Quiet) {
@@ -538,7 +538,7 @@ fin:
 /* -------------------------- */
 STATIC void test309()
 {
-	enter_test();
+	ENTER_TEST
     write_test(1024);
 	exit_test("FPRread:test309: FPRead, FPWrite deadlock");
 }
@@ -546,7 +546,7 @@ STATIC void test309()
 /* -------------------------- */
 STATIC void test327()
 {
-	enter_test();
+	ENTER_TEST
     write_test(	128*1024);
 	exit_test("FPRread:test327: FPRead, FPWrite deadlock");
 }
@@ -568,7 +568,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	sprintf(temp,"test328 dir");
 
 	if (get_vol_free(vol) < 17*1024*1024) {
@@ -726,7 +726,7 @@ int size;
 DSI *dsi;
 
 	dsi = &Conn->dsi;
-	enter_test();
+	ENTER_TEST
 	size = min(4096, dsi->server_quantum);
 	if (size < 2000) {
 		if (!Quiet) {
@@ -782,7 +782,7 @@ int ret;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	size = 100;
 	offset = 128;
 
@@ -850,7 +850,7 @@ STATIC void test8()
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Locking) {
 		test_skipped(T_LOCKING);

--- a/test/testsuite/FPRead.c
+++ b/test/testsuite/FPRead.c
@@ -32,11 +32,11 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRead:test5: read/write data fork\n");
 	size = min(10000, dsi->server_quantum);
 	if (size < 2000) {
-		fprintf(stdout,"\t server quantum (%d) too small\n", size);
+		if (!Quiet) {
+			fprintf(stdout,"\t server quantum (%d) too small\n", size);
+		}
 		nottested();
 		goto test_exit;
 	}
@@ -130,7 +130,7 @@ fin1:
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test5");
+	exit_test("FPRead:test5: read/write data fork");
 }
 
 /* ------------------------- */
@@ -146,11 +146,11 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPread:test46: read/write resource fork\n");
 	size = min(10000, dsi->server_quantum);
 	if (size < 2000) {
-		fprintf(stdout,"\t server quantum (%d) too small\n", size);
+		if (!Quiet) {
+			fprintf(stdout,"\t server quantum (%d) too small\n", size);
+		}
 		nottested();
 		goto test_exit;
 	}
@@ -238,7 +238,7 @@ fin:
 
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test46");
+	exit_test("FPread:test46: read/write resource fork");
 }
 
 /* -------------------------- */
@@ -251,8 +251,6 @@ uint16_t vol = VolID;
 int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRead:test59: 2 GBytes for offset limit FPRead, FPWrite\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -277,7 +275,7 @@ int ret;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test59");
+	exit_test("FPRead:test59: 2 GBytes for offset limit FPRead, FPWrite");
 }
 
 /* -------------------------- */
@@ -293,12 +291,12 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRread:test61: FPRead, FPWrite errors\n");
 	size = min(10000, dsi->server_quantum);
 	if (size < 2000) {
+		if (!Quiet) {
+			fprintf(stdout,"\t server quantum (%d) too small\n", size);
+		}
 		nottested();
-		fprintf(stdout,"\t server quantum (%d) too small\n", size);
 		goto test_exit;
 	}
 
@@ -339,7 +337,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test61");
+	exit_test("FPRread:test61: FPRead, FPWrite errors");
 }
 
 extern char *Server;
@@ -383,7 +381,9 @@ CONN *myconn;
 
 	quantum = min(size, dsi->server_quantum);
 	if (quantum < size) {
-		fprintf(stdout,"\t server quantum (%d) too small\n", quantum);
+		if (!Quiet) {
+			fprintf(stdout,"\t server quantum (%d) too small\n", quantum);
+		}
 		nottested();
 		return;
 	}
@@ -507,7 +507,9 @@ CONN *myconn;
 
 fin:
 	if (sigp ) {
-		fprintf(stdout,"\tFAILED deadlock\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED deadlock\n");
+		}
 		failed_nomsg();
 		sleep(5);
 	}
@@ -537,20 +539,16 @@ fin:
 STATIC void test309()
 {
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRread:test309: FPRead, FPWrite deadlock\n");
     write_test(1024);
-	exit_test("test309");
+	exit_test("FPRread:test309: FPRead, FPWrite deadlock");
 }
 
 /* -------------------------- */
 STATIC void test327()
 {
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRread:test327: FPRead, FPWrite deadlock\n");
     write_test(	128*1024);
-	exit_test("test327");
+	exit_test("FPRread:test327: FPRead, FPWrite deadlock");
 }
 
 /* ------------------------- */
@@ -571,8 +569,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"test328: read speed\n");
 	sprintf(temp,"test328 dir");
 
 	if (get_vol_free(vol) < 17*1024*1024) {
@@ -716,7 +712,7 @@ fin:
 	free(ndir);
 	free(data);
 test_exit:
-	exit_test("test328");
+	exit_test("FPRread:test328: read speed");
 }
 
 /* ------------------------- */
@@ -731,12 +727,12 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRead:test343: read/write data fork (small size)\n");
 	size = min(4096, dsi->server_quantum);
 	if (size < 2000) {
+		if (!Quiet) {
+			fprintf(stdout,"\t server quantum (%d) too small\n", size);
+		}
 		nottested();
-		fprintf(stdout,"\t server quantum (%d) too small\n", size);
 		goto test_exit;
 	}
 
@@ -768,7 +764,7 @@ fin1:
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test343");
+	exit_test("FPRead:test343: read/write data fork (small size)");
 }
 
 /* ------------------------- */
@@ -787,8 +783,6 @@ int ret;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPread:test344: read after EOF\n");
 	size = 100;
 	offset = 128;
 
@@ -839,7 +833,7 @@ fin:
 
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test344");
+	exit_test("FPread:test344: read after EOF");
 }
 
 /* ------------------------- */
@@ -857,8 +851,6 @@ STATIC void test8()
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRead:test8: open data and rfork, datafork size is 0, rfork is 65k, read from datafork after EOF\n");
 
 	if (Locking) {
 		test_skipped(T_LOCKING);
@@ -937,7 +929,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name1))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name2))
 test_exit:
-	exit_test("test8");
+	exit_test("FPRead:test8: open data and rfork, datafork size is 0, rfork is 65k, read from datafork after EOF");
 }
 
 
@@ -946,6 +938,7 @@ void FPRead_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPRead page 238\n");
+    fprintf(stdout,"-------------------\n");
 	test5();
 	test8();
 	test46();

--- a/test/testsuite/FPReadExt.c
+++ b/test/testsuite/FPReadExt.c
@@ -18,7 +18,7 @@ uint16_t vol = VolID;
 char utf8name[20];
 int i;
 
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;

--- a/test/testsuite/FPReadExt.c
+++ b/test/testsuite/FPReadExt.c
@@ -19,8 +19,6 @@ char utf8name[20];
 int i;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPReadExt:test22: AFP 3.0 read/Write\n");
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -123,7 +121,9 @@ fin2g:
 	}
 	else for (i = 0; i < 10000; i++) {
 		if (Data[i] != 0) {
-			fprintf(stdout,"\tFAILED Data != 0\n");
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED Data != 0\n");
+			}
 			failed_nomsg();
 			break;
 		}
@@ -168,7 +168,7 @@ fin2g:
 	FAIL (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , utf8name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, utf8name))
 test_exit:
-	exit_test("test22");
+	exit_test("FPReadExt:test22: AFP 3.0 read/Write");
 }
 
 /* ----------- */
@@ -176,5 +176,6 @@ void FPReadExt_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPReadExt page 241\n");
+    fprintf(stdout,"-------------------\n");
 	test22();
 }

--- a/test/testsuite/FPRemoveAPPL.c
+++ b/test/testsuite/FPRemoveAPPL.c
@@ -12,8 +12,6 @@ char *file1 = "t215 file1";
 unsigned int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRemoveAPPL:t215: remove appl\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , file)) {
 		nottested();
@@ -45,7 +43,7 @@ unsigned int ret;
 	FAIL ( FPRemoveAPPL(Conn , dt, DIRDID_ROOT, "ttxt", file))
 	FAIL (FPCloseDT(Conn,dt))
 test_exit:
-	exit_test("test215");
+	exit_test("FPRemoveAPPL:test215: remove appl");
 }
 
 /* ----------- */
@@ -53,5 +51,6 @@ void FPRemoveAPPL_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPRemoveAPPL page 245\n");
+    fprintf(stdout,"-------------------\n");
 	test215();
 }

--- a/test/testsuite/FPRemoveAPPL.c
+++ b/test/testsuite/FPRemoveAPPL.c
@@ -11,7 +11,7 @@ char *file = "t215 file";
 char *file1 = "t215 file1";
 unsigned int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , file)) {
 		nottested();

--- a/test/testsuite/FPRemoveComment.c
+++ b/test/testsuite/FPRemoveComment.c
@@ -18,7 +18,7 @@ uint16_t vol2;
 DSI *dsi2;
 int dt;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -104,7 +104,7 @@ char *name1 = "t379 file.txt";
 uint16_t vol = VolID;
 int  dt;
 
-	enter_test();
+	ENTER_TEST
 
 	FAIL (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name1))
 

--- a/test/testsuite/FPRemoveComment.c
+++ b/test/testsuite/FPRemoveComment.c
@@ -19,8 +19,6 @@ DSI *dsi2;
 int dt;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPRemoveComment:test54: remove comment\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -94,7 +92,7 @@ fin:
 	}
 	FAIL (FPCloseDT(Conn, dt))
 test_exit:
-	exit_test("test54");
+	exit_test("FPRemoveComment:test54: remove comment");
 }
 
 
@@ -106,10 +104,7 @@ char *name1 = "t379 file.txt";
 uint16_t vol = VolID;
 int  dt;
 
-
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPRemoveComment:test379: remove comment\n");
 
 	FAIL (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name1))
 
@@ -125,7 +120,7 @@ int  dt;
 	FAIL (FPCloseDT(Conn, dt))
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
-	exit_test("test379");
+	exit_test("FPRemoveComment:test379: remove comment");
 }
 
 
@@ -134,6 +129,7 @@ void FPRemoveComment_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPRemoveComment page 247\n");
+    fprintf(stdout,"-------------------\n");
 	test54();
 	test379();
 }

--- a/test/testsuite/FPRename.c
+++ b/test/testsuite/FPRename.c
@@ -11,8 +11,6 @@ char *name2 = "t69 new name";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRename:test69: rename a folder with Unix name != Mac name\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -37,7 +35,7 @@ uint16_t vol = VolID;
 	FAIL (FPRename(Conn, vol, DIRDID_ROOT, name2, name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test69");
+	exit_test("FPRename:test69: rename a folder with Unix name != Mac name");
 }
 
 /* ------------------------- */
@@ -59,8 +57,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRename:test72: check input parameter\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name2))) {
 		nottested();
@@ -110,7 +106,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name1))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name2))
 test_exit:
-	exit_test("test72");
+	exit_test("FPRename:test72: check input parameter");
 }
 
 /* -------------------------- */
@@ -175,7 +171,7 @@ int tp,tp1;
 		nottested();
 		goto fin;
 	}
-	if (tp != tdir) {
+	if (tp != tdir && !Quiet) {
 		fprintf(stdout,"Warning DID connection1 0x%x ==> connection2 0x%x\n", tdir, tp);
 	}
 	tp1 = get_did(Conn2, vol2, tp, name);
@@ -183,7 +179,7 @@ int tp,tp1;
 		nottested();
 		goto fin;
 	}
-	if (tp1 != tdir1) {
+	if (tp1 != tdir1 && !Quiet) {
 		fprintf(stdout,"Warning DID connection1 0x%x ==> connection2 0x%x\n", tdir1, tp1);
 	}
 	if (FPDelete(Conn2, vol2,  tp1 , "")) {
@@ -214,8 +210,6 @@ uint16_t vol = VolID;
 
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRename:test183: did error two users in  folder did=<deleted> name=test183\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -234,7 +228,7 @@ uint16_t vol = VolID;
 	}
 	FAIL (ntohl(AFPERR_NOOBJ) != FPRename(Conn, vol, tdir, "", name1))
 test_exit:
-	exit_test("test183");
+	exit_test("FPRename:test183: did error two users in  folder did=<deleted> name=test183");
 }
 
 /* ------------------------- */
@@ -245,8 +239,6 @@ char *name1 = "t184new.txt";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRename:test184: rename\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -258,7 +250,7 @@ uint16_t vol = VolID;
 	FAIL (!FPDelete(Conn, vol, DIRDID_ROOT , name))
 	FPFlush(Conn, vol);
 test_exit:
-	exit_test("test184");
+	exit_test("FPRename:test184: rename");
 }
 
 /* ------------------------- */
@@ -271,8 +263,6 @@ uint16_t vol = VolID;
 int  dir = 0,dir1 = 0,dir2 = 0;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRename:test191: rename folders\n");
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {
@@ -300,7 +290,7 @@ fin:
 	FAIL (dir1 && FPDelete(Conn, vol,  dir1, ""))
 	FAIL (dir && FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test191");
+	exit_test("FPRename:test191: rename folders");
 }
 
 /* ------------------------- */
@@ -314,8 +304,6 @@ int  dir = 0;
 DSI	*dsi2 = &Conn2->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRename:test219: rename folders two users\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -345,7 +333,7 @@ DSI	*dsi2 = &Conn2->dsi;
 fin:
 	FAIL (dir && FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test219");
+	exit_test("FPRename:test219: rename folders two users");
 }
 
 /* ------------------------- */
@@ -356,8 +344,6 @@ char *name1 = "t376 new name";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRename:test376: dest file exist\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		failed();
@@ -376,7 +362,7 @@ fin:
 	FPDelete(Conn, vol,  DIRDID_ROOT , name);
 
 test_exit:
-	exit_test("test376");
+	exit_test("FPRename:test376: dest file exist");
 }
 
 
@@ -390,8 +376,6 @@ uint16_t vol = VolID;
 int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRename:test377: dest file exist but diff only by case, is this one OK \n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		failed();
@@ -414,7 +398,7 @@ fin:
 	FPDelete(Conn, vol,  DIRDID_ROOT , name);
 
 test_exit:
-	exit_test("test377");
+	exit_test("FPRename:test377: dest file exist but diff only by case, is this one OK");
 }
 
 
@@ -423,6 +407,7 @@ void FPRename_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPRename page 250\n");
+    fprintf(stdout,"-------------------\n");
 	test69();
 	test72();
 	test183();

--- a/test/testsuite/FPRename.c
+++ b/test/testsuite/FPRename.c
@@ -10,7 +10,7 @@ char *name = "t69 rename file!name";
 char *name2 = "t69 new name";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -56,7 +56,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name2))) {
 		nottested();
@@ -209,7 +209,7 @@ int tdir;
 uint16_t vol = VolID;
 
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -238,7 +238,7 @@ char *name  = "t184.txt";
 char *name1 = "t184new.txt";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -262,7 +262,7 @@ char *dest = "t191 newname";
 uint16_t vol = VolID;
 int  dir = 0,dir1 = 0,dir2 = 0;
 
-	enter_test();
+	ENTER_TEST
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {
@@ -303,7 +303,7 @@ uint16_t vol2, bitmap;
 int  dir = 0;
 DSI	*dsi2 = &Conn2->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -343,7 +343,7 @@ char *name = "t376 name";
 char *name1 = "t376 new name";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		failed();
@@ -375,7 +375,7 @@ char *name1 = "t377 Name";
 uint16_t vol = VolID;
 int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		failed();

--- a/test/testsuite/FPResolveID.c
+++ b/test/testsuite/FPResolveID.c
@@ -17,8 +17,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test76: Resolve ID\n");
 
 	if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
 		test_skipped(T_ID);
@@ -47,7 +45,7 @@ DSI *dsi;
 	FAIL (FPDelete(Conn, vol,  dir , name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 test_exit:
-	exit_test("test76");
+	exit_test("FPResolveID:test76: Resolve ID");
 }
 
 /* -------------------------
@@ -68,8 +66,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test91: Resolve ID errors\n");
 
 	if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
 		test_skipped(T_ID);
@@ -121,7 +117,7 @@ DSI *dsi;
 	FAIL (FPDelete(Conn, vol,  dir , name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 test_exit:
-	exit_test("test91");
+	exit_test("FPResolveID:test91: Resolve ID errors");
 }
 
 /* -------------------------
@@ -140,8 +136,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test310: Resolve ID after rename\n");
 
 	if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
 		test_skipped(T_ID);
@@ -165,7 +159,7 @@ DSI *dsi;
 
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 test_exit:
-	exit_test("test310");
+	exit_test("FPResolveID:test310: Resolve ID after rename");
 }
 
 /* -------------------------
@@ -184,8 +178,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test311: Resolve ID after rename\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -214,7 +206,7 @@ DSI *dsi;
 
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 test_exit:
-	exit_test("test311");
+	exit_test("FPResolveID:test311: Resolve ID after rename");
 }
 
 /* -------------------------- */
@@ -232,8 +224,6 @@ uint16_t vol2;
 DSI *dsi2;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test362: Resolve ID two users interactions\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -275,7 +265,7 @@ DSI *dsi2;
 	vol  = FPOpenVol(Conn, Vol);
 	FAIL (ntohl(AFPERR_NOID ) != FPResolveID(Conn, vol, filedir.did, bitmap))
 test_exit:
-	exit_test("test362");
+	exit_test("FPResolveID:test362: Resolve ID two users interactions");
 }
 
 
@@ -284,6 +274,7 @@ void FPResolveID_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPResolveID page 252\n");
+    fprintf(stdout,"-------------------\n");
 	test76();
 	test91();
 	test310();

--- a/test/testsuite/FPResolveID.c
+++ b/test/testsuite/FPResolveID.c
@@ -16,7 +16,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
 		test_skipped(T_ID);
@@ -65,7 +65,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
 		test_skipped(T_ID);
@@ -135,7 +135,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
 		test_skipped(T_ID);
@@ -177,7 +177,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -223,7 +223,7 @@ DSI *dsi = &Conn->dsi;
 uint16_t vol2;
 DSI *dsi2;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);

--- a/test/testsuite/FPSetDirParms.c
+++ b/test/testsuite/FPSetDirParms.c
@@ -16,7 +16,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -67,7 +67,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -115,7 +115,7 @@ unsigned int ret;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -203,7 +203,7 @@ DSI *dsi2;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -302,7 +302,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -344,7 +344,7 @@ int ret;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -385,7 +385,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , ndir))) {
 		nottested();
@@ -451,7 +451,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , ndir))) {
 		nottested();
 		goto test_exit;
@@ -513,7 +513,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_NO_UNIX_PREV);
@@ -596,7 +596,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -666,7 +666,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -741,7 +741,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -859,7 +859,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);

--- a/test/testsuite/FPSetDirParms.c
+++ b/test/testsuite/FPSetDirParms.c
@@ -17,8 +17,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:test82: test set dir parameters\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -51,7 +49,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test82");
+	exit_test("FPSetDirParms:test82: test set dir parameters");
 }
 
 /* ------------------------- */
@@ -70,8 +68,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:test84: test dir set no delete attribute\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -94,7 +90,7 @@ DSI *dsi;
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test84");
+	exit_test("FPSetDirParms:test84: test dir set no delete attribute");
 }
 
 /* ------------------------- */
@@ -120,8 +116,6 @@ unsigned int ret;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:test88: test error setdirparam\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -184,7 +178,7 @@ fin:
 
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test88");
+	exit_test("FPSetDirParms:test88: test error setdirparam");
 }
 
 /* ------------------------- */
@@ -210,8 +204,6 @@ DSI *dsi2;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:t107: test dir\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -290,7 +282,7 @@ DSI *dsi2;
 fin:
 	delete_folder(vol, DIRDID_ROOT, ndir);
 test_exit:
-	exit_test("test107");
+	exit_test("FPSetDirParms:test107: test dir");
 }
 
 
@@ -311,8 +303,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:test189: test error setdirparam\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -337,7 +327,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test189");
+	exit_test("FPSetDirParms:test189: test error setdirparam");
 }
 
 /* ------------------------- */
@@ -355,8 +345,6 @@ int ret;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:test193: user permission set\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
@@ -378,7 +366,7 @@ int ret;
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test193");
+	exit_test("FPSetDirParms:test193: user permission set");
 }
 
 /* ------------------------- */
@@ -398,8 +386,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:t351: change root folder unix perm\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , ndir))) {
 		nottested();
@@ -446,7 +432,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test351");
+	exit_test("FPSetDirParms:test351: change root folder unix perm");
 }
 
 /* ------------------------- */
@@ -466,8 +452,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:t352: Change Mac perm to no perm in root folder\n");
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , ndir))) {
 		nottested();
 		goto test_exit;
@@ -512,7 +496,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test352");
+	exit_test("FPSetDirParms:test352: Change Mac perm to no perm in root folder");
 }
 
 /* ------------------------- */
@@ -530,8 +514,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:t353: no unix access privilege \n");
 
 	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_NO_UNIX_PREV);
@@ -550,18 +532,10 @@ DSI *dsi;
 	bitmap = (1<< DIRPBIT_PDINFO) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID) |
 	         (1<< DIRPBIT_UNIXPR);
 
-#if 0
-	if (htonl(AFPERR_BITMAP) != FPGetFileDirParams(Conn, vol, dir, "", 0, bitmap)) {
-		known_failure(" current version doesn't return an error if for unixpriv");
-		//failed();
-		goto fin1;
-	}
-#else
 	if (FPGetFileDirParams(Conn, vol, dir, "", 0, bitmap)) {
 		failed();
 		goto fin1;
 	}
-#endif
 
 	bitmap = (1<< DIRPBIT_UNIXPR);
 	filedir.isdir = 1;
@@ -604,7 +578,7 @@ fin1:
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test353");
+	exit_test("FPSetDirParms:test353: no unix access privilege");
 }
 
 /* ------------------------- */
@@ -623,8 +597,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:t354: change a folder perm in root folder\n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -674,7 +646,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test354");
+	exit_test("FPSetDirParms:test354: change a folder perm in root folder");
 }
 
 /* ------------------------- */
@@ -695,8 +667,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:t355: change a folder perm in a folder\n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -752,7 +722,7 @@ fin:
 	FAIL (dir1 && FPDelete(Conn, vol,  dir1 , ""))
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test355");
+	exit_test("FPSetDirParms:test355: change a folder perm in a folder");
 }
 
 /* ------------------------- */
@@ -772,8 +742,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:t356: change root folder unix perm\n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -826,7 +794,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test356");
+	exit_test("FPSetDirParms:test356: change root folder unix perm");
 }
 
 /* ---------------------- */
@@ -892,8 +860,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:t405: change a folder group owner in the root folder\n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -933,7 +899,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test405");
+	exit_test("FPSetDirParms:test405: change a folder group owner in the root folder");
 }
 
 /* ----------- */
@@ -941,26 +907,18 @@ void FPSetDirParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPSetDirParms page 255\n");
-// FIXME: broken in Netatalk 4.0
-#if 0
+    fprintf(stdout,"-------------------\n");
     test82();
-#endif
     test84();
     test88();
     test107();
     test189();
     test193();
-// FIXME: broken in Netatalk 4.0
-#if 0
     test351();
-#endif
     test352();
     test353();
     test354();
     test355();
-// FIXME: broken in Netatalk 4.0
-#if 0
     test356();
-#endif
     test405();
 }

--- a/test/testsuite/FPSetFileDirParms.c
+++ b/test/testsuite/FPSetFileDirParms.c
@@ -24,8 +24,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t98: test error setfildirparam\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -85,7 +83,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir , name1))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test98");
+	exit_test("FPSetFileDirParms:test98: test error setfildirparam");
 }
 
 /* ------------------------- */
@@ -105,8 +103,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t230: set unix access privilege\n");
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -136,7 +132,9 @@ DSI *dsi;
 		filedir.isdir = 1;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 		if (!(S_ISDIR(filedir.unix_priv))) {
-			fprintf(stdout, "\tFAILED %o not a dir\n", filedir.unix_priv);
+			if (!Quiet) {
+				fprintf(stdout, "\tFAILED %o not a dir\n", filedir.unix_priv);
+			}
 			failed_nomsg();
 		}
 		bitmap = (1<< DIRPBIT_UNIXPR);
@@ -223,7 +221,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test230");
+	exit_test("FPSetFileDirParms:test230: set unix access privilege");
 }
 
 /* ------------------------- */
@@ -245,8 +243,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t231: set unix access privilege two users\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -352,7 +348,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test231");
+	exit_test("FPSetFileDirParms:test231: set unix access privilege two users");
 }
 
 /* ------------------------- */
@@ -371,8 +367,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t232: unix access privilege delete ro file in a rw folder\n");
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -425,7 +419,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test232");
+	exit_test("FPSetFileDirParms:test232: unix access privilege delete ro file in a rw folder");
 }
 
 /* ------------------------- */
@@ -445,8 +439,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t345: no unix access privilege \n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -518,7 +510,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test345");
+	exit_test("FPSetFileDirParms:test345: no unix access privilege");
 }
 
 /* ------------------------- */
@@ -537,8 +529,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t346: delete a file with no unix access privilege \n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -584,7 +574,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test346");
+	exit_test("FPSetFileDirParms:test346: delete a file with no unix access privilege");
 }
 
 /* ------------------------- */
@@ -602,8 +592,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t347: no unix access privilege \n");
 
 	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_NO_UNIX_PREV);
@@ -622,19 +610,10 @@ DSI *dsi;
 	bitmap = (1<< DIRPBIT_PDINFO) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID) |
 	         (1<< DIRPBIT_UNIXPR);
 
-#if 0
-	if (htonl(AFPERR_BITMAP) != FPGetFileDirParams(Conn, vol, dir, "", 0, bitmap)) {
-		known_failure(" current version doesn't return an error if unixpriv set");
-		// failed();
-		goto fin1;
-	}
-#else
 	if ( FPGetFileDirParams(Conn, vol, dir, "", 0, bitmap)) {
 		failed();
 		goto fin1;
 	}
-
-#endif
 
 	bitmap = (1<< DIRPBIT_UNIXPR);
 	filedir.isdir = 1;
@@ -677,7 +656,7 @@ fin1:
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test347");
+	exit_test("FPSetFileDirParms:test347: no unix access privilege");
 }
 
 /* ------------------------- */
@@ -696,8 +675,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t348: change a folder perm in root folder\n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -747,7 +724,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test348");
+	exit_test("FPSetFileDirParms:test348: change a folder perm in root folder");
 }
 
 /* ------------------------- */
@@ -768,8 +745,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t349: change a folder perm in a folder\n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -825,7 +800,7 @@ fin:
 	FAIL (dir1 && FPDelete(Conn, vol,  dir1 , ""))
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test349");
+	exit_test("FPSetFileDirParms:test349: change a folder perm in a folder");
 }
 
 /* ------------------------- */
@@ -845,8 +820,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t350: change root folder perm\n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -899,7 +872,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test350");
+	exit_test("FPSetFileDirParms:test350: change root folder perm");
 }
 
 /* ------------------------- */
@@ -922,8 +895,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t358: set unix access privilege two users\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -978,7 +949,7 @@ fin:
 	sleep(1);
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test358");
+	exit_test("FPSetFileDirParms:test358: set unix access privilege two users");
 }
 
 /* ------------------------- */
@@ -997,8 +968,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t359: no unix access privilege with finder info \n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -1044,7 +1013,9 @@ DSI *dsi;
 	}
 	afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap,0);
 	if ((filedir.attr & ATTRBIT_NODELETE) != ATTRBIT_NODELETE) {
-		fprintf(stdout,"\tFAILED attribute not set\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED attribute not set\n");
+		}
 		failed_nomsg();
 	}
 	ret = FPDelete(Conn, vol,  dir , name);
@@ -1067,7 +1038,7 @@ fin1:
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test359");
+	exit_test("FPSetFileDirParms:test359: no unix access privilege with finder info");
 }
 
 /* ------------------------- */
@@ -1088,8 +1059,6 @@ uint16_t vol2;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t361: no unix access privilege two users with finder info \n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -1146,7 +1115,9 @@ uint16_t vol2;
 	}
 	afp_filedir_unpack(&filedir, dsi2->data +ofs, bitmap,0);
 	if ((filedir.attr & ATTRBIT_NODELETE) != ATTRBIT_NODELETE) {
-		fprintf(stdout,"\tFAILED attribute not set\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED attribute not set\n");
+		}
 		failed_nomsg();
 	}
 	ret = FPDelete(Conn2, vol2,  dir , name);
@@ -1169,7 +1140,7 @@ fin1:
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test361");
+	exit_test("FPSetFileDirParms:test361: no unix access privilege two users with finder info");
 }
 
 /* ------------------------- */
@@ -1187,8 +1158,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileDirParms:t400: set file owner\n");
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -1228,7 +1197,7 @@ fin1:
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test400");
+	exit_test("FPSetFileDirParms:test400: set file owner");
 }
 
 /* ----------- */
@@ -1236,6 +1205,7 @@ void FPSetFileDirParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPSetFileDirParms page 258\n");
+    fprintf(stdout,"-------------------\n");
     test98();
     test230();
     test231();
@@ -1245,10 +1215,7 @@ void FPSetFileDirParms_test()
     test347();
     test348();
     test349();
-// FIXME: broken in Netatalk 4.0
-#if 0
     test350();
-#endif
     test358();
     test359();
     test361();

--- a/test/testsuite/FPSetFileDirParms.c
+++ b/test/testsuite/FPSetFileDirParms.c
@@ -23,7 +23,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -102,7 +102,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -242,7 +242,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -366,7 +366,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -438,7 +438,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -528,7 +528,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -591,7 +591,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_NO_UNIX_PREV);
@@ -674,7 +674,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -744,7 +744,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -819,7 +819,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -894,7 +894,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -967,7 +967,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);
@@ -1058,7 +1058,7 @@ uint16_t vol2;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -1157,7 +1157,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
 		test_skipped(T_UNIX_PREV);

--- a/test/testsuite/FPSetFileParms.c
+++ b/test/testsuite/FPSetFileParms.c
@@ -18,8 +18,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"t83: test set file setfilparam\n");
 
 	if (!(dir =FPCreateDir(Conn,vol, DIRDID_ROOT , ndir))) {
 		nottested();
@@ -46,7 +44,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test83");
+	exit_test("FPSetFileParms:test83: test set file setfilparam");
 }
 
 /* ------------------------- */
@@ -62,8 +60,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileParms:t96: test file's invisible bit\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -76,7 +72,9 @@ DSI *dsi;
 	}
 	filedir.isdir = 1;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
-	fprintf(stdout,"Modif date parent %x\n", filedir.mdate);
+	if (!Quiet) {
+		fprintf(stdout,"Modif date parent %x\n", filedir.mdate);
+	}
 	sleep(4);
 
 	if (FPGetFileDirParams(Conn, vol,  DIRDID_ROOT , name,bitmap, 0 )) {
@@ -85,7 +83,9 @@ DSI *dsi;
 	}
 	filedir.isdir = 0;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
-	fprintf(stdout,"Modif date file %x\n", filedir.mdate);
+	if (!Quiet) {
+		fprintf(stdout,"Modif date file %x\n", filedir.mdate);
+	}
 	sleep(5);
 
 	filedir.attr = ATTRBIT_INVISIBLE | ATTRBIT_SETCLR ;
@@ -99,7 +99,9 @@ DSI *dsi;
 	}
 	filedir.isdir = 0;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
-	fprintf(stdout,"Modif date file %x\n", filedir.mdate);
+	if (!Quiet) {
+		fprintf(stdout,"Modif date file %x\n", filedir.mdate);
+	}
 
 	if (FPGetFileDirParams(Conn, vol,  DIRDID_ROOT , "", 0,bitmap )) {
 		failed();
@@ -107,11 +109,13 @@ DSI *dsi;
 	}
 	filedir.isdir = 1;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
-	fprintf(stdout,"Modif date parent %x\n", filedir.mdate);
+	if (!Quiet) {
+		fprintf(stdout,"Modif date parent %x\n", filedir.mdate);
+	}
 end:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test96");
+	exit_test("FPSetFileParms:test96: test file's invisible bit");
 }
 
 /* ------------------------- */
@@ -127,8 +131,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileParms:t118: test file no delete attribute\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -148,7 +150,7 @@ DSI *dsi;
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test118");
+	exit_test("FPSetFileParms:test118: test file no delete attribute");
 }
 
 /* ------------------------- */
@@ -170,8 +172,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"t122: test setfilparam open fork\n");
 
 	memset(&filedir, 0, sizeof(filedir));
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
@@ -210,7 +210,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test122");
+	exit_test("FPSetFileParms:test122: test setfilparam open fork");
 }
 
 /* ------------------------- */
@@ -226,8 +226,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileParms:t318: set UTF8 name(error)\n");
 
  	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -248,7 +246,7 @@ DSI *dsi;
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test318");
+	exit_test("FPSetFileParms:test318: set UTF8 name(error)");
 }
 
 /* ------------------------ */
@@ -314,8 +312,6 @@ int fork = 0;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileParms:t427: Create a symlink\n");
 
     if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , dest)) {
 		nottested();
@@ -339,7 +335,7 @@ test_exit:
     }
     FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , dest))
     FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
-	exit_test("test427");
+	exit_test("FPSetFileParms:test427: Create a symlink");
 }
 
 /* ------------------------- */
@@ -352,8 +348,6 @@ uint16_t vol = VolID;
 uint16_t vol2 = 0xffff;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileParms:t428: Delete symlinks, two users\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -390,7 +384,7 @@ test_error:
     FPDelete(Conn, vol,  DIRDID_ROOT , name2);
 
 test_exit:
-	exit_test("test428");
+	exit_test("FPSetFileParms:test428: Delete symlinks, two users");
 }
 
 /* ------------------------- */
@@ -409,8 +403,6 @@ int id;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileParms:t429: symlink File ID\n");
 
     if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , dest)) {
 		nottested();
@@ -439,7 +431,9 @@ int id;
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 		if (!filedir.did || filedir.did != id) {
-		    fprintf(stdout,"\tFAILED cnids are not the same %x %x\n", filedir.did, id);
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED cnids are not the same %x %x\n", filedir.did, id);
+			}
 			failed_nomsg();
 		}
 	}
@@ -450,7 +444,7 @@ test_exit:
     }
     FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , dest))
     FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
-	exit_test("test429");
+	exit_test("FPSetFileParms:test429: symlink File ID");
 }
 
 /* ------------------------- */
@@ -469,8 +463,6 @@ STATIC void test430()
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileParms:t430: set creation date on symlink\n");
 
     if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , dest)) {
 		nottested();
@@ -487,7 +479,7 @@ STATIC void test430()
 test_exit:
     FAIL (FPDelete(Conn, vol, DIRDID_ROOT, dest))
     FAIL (FPDelete(Conn, vol, DIRDID_ROOT, name))
-	exit_test("test430");
+	exit_test("FPSetFileParms:test430: set creation date on symlink");
 }
 
 
@@ -496,6 +488,7 @@ void FPSetFileParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPSetFileParms page 262\n");
+    fprintf(stdout,"-------------------\n");
     test83();
     test96();
     test118();

--- a/test/testsuite/FPSetFileParms.c
+++ b/test/testsuite/FPSetFileParms.c
@@ -17,7 +17,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir =FPCreateDir(Conn,vol, DIRDID_ROOT , ndir))) {
 		nottested();
@@ -59,7 +59,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -130,7 +130,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -171,7 +171,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	memset(&filedir, 0, sizeof(filedir));
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
@@ -225,7 +225,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
  	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -311,7 +311,7 @@ int fork = 0;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
     if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , dest)) {
 		nottested();
@@ -347,7 +347,7 @@ char *dest = "t428 dest";
 uint16_t vol = VolID;
 uint16_t vol2 = 0xffff;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -402,7 +402,7 @@ int id;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
     if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , dest)) {
 		nottested();
@@ -462,7 +462,7 @@ STATIC void test430()
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
     if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , dest)) {
 		nottested();

--- a/test/testsuite/FPSetForkParms.c
+++ b/test/testsuite/FPSetForkParms.c
@@ -15,7 +15,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -93,7 +93,7 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)){
 		nottested();
@@ -146,7 +146,7 @@ unsigned int ret;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -191,7 +191,7 @@ uint32_t data = (unsigned)-1;
 DSI *dsi;
 
 	dsi = &Conn->dsi;
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();

--- a/test/testsuite/FPSetForkParms.c
+++ b/test/testsuite/FPSetForkParms.c
@@ -16,8 +16,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetForkParms:test62: SetForkParams errors\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -81,7 +79,7 @@ fin:
 	FAIL (fork1 && FPCloseFork(Conn,fork1))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test62");
+	exit_test("FPSetForkParms:test62: SetForkParams errors");
 }
 
 /* ------------------------- */
@@ -96,8 +94,6 @@ DSI *dsi;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetForkParms:test141: Setforkmode error\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)){
 		nottested();
@@ -134,7 +130,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test141");
+	exit_test("FPSetForkParms:test141: Setforkmode error");
 }
 
 
@@ -151,8 +147,6 @@ unsigned int ret;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetForkParms:test217: Setfork size 64 bits\n");
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -183,7 +177,7 @@ fin:
 	FAIL (fork && FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test217");
+	exit_test("FPSetForkParms:test217: Setfork size 64 bits");
 }
 
 /* ------------------------- */
@@ -198,8 +192,6 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetForkParms:test306: set fork size, new size > old size\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -218,11 +210,13 @@ DSI *dsi;
 		goto fin;
 	}
 	if (data != 0) {
-		if (Mac) {
+		if (Mac && !Quiet) {
 			fprintf(stdout,"\tMac result 0x%x but 0 expected\n", data);
 		}
 		else {
-			fprintf(stdout,"\tFAILED got 0x%x but 0 expected\n", data);
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED got 0x%x but 0 expected\n", data);
+			}
 			failed_nomsg();
 			goto fin;
 		}
@@ -233,7 +227,7 @@ fin:
 	FAIL (fork && FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test306");
+	exit_test("FPSetForkParms:test306: set fork size, new size > old size");
 }
 
 /* ----------- */
@@ -241,6 +235,7 @@ void FPSetForkParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPSetForkParms page 266\n");
+    fprintf(stdout,"-------------------\n");
     test62();
     test141();
     test217();

--- a/test/testsuite/FPSetVolParms.c
+++ b/test/testsuite/FPSetVolParms.c
@@ -10,7 +10,7 @@ uint16_t vol = VolID;
 struct afp_volume_parms parms;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
     bitmap = (1 << VOLPBIT_ATTR  )
 	    |(1 << VOLPBIT_SIG   )
     	|(1 << VOLPBIT_CDATE )

--- a/test/testsuite/FPSetVolParms.c
+++ b/test/testsuite/FPSetVolParms.c
@@ -11,8 +11,6 @@ struct afp_volume_parms parms;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPSetVolParms:test206: Set Volume parameters\n");
     bitmap = (1 << VOLPBIT_ATTR  )
 	    |(1 << VOLPBIT_SIG   )
     	|(1 << VOLPBIT_CDATE )
@@ -25,7 +23,9 @@ DSI *dsi = &Conn->dsi;
 
  	FAIL (FPGetVolParam(Conn, vol, bitmap))
  	if (parms.bdate == parms.mdate) {
- 		fprintf(stdout,"Backup and modification date are the same!\n");
+		if (!Quiet) {
+	 		fprintf(stdout,"Backup and modification date are the same!\n");
+		}
  		nottested();
 		goto test_exit;
  	}
@@ -40,12 +40,14 @@ DSI *dsi = &Conn->dsi;
  	FAIL (FPGetVolParam(Conn, vol, bitmap))
 	afp_volume_unpack(&parms, dsi->commands +sizeof( uint16_t ), bitmap);
  	if (parms.bdate != parms.mdate) {
- 		fprintf(stdout,"\tFAILED Backup %x and modification %x date are not the same!\n",parms.bdate, parms.mdate );
+		if (!Quiet) {
+	 		fprintf(stdout,"\tFAILED Backup %x and modification %x date are not the same!\n",parms.bdate, parms.mdate );
+		}
  		failed_nomsg();
  	}
  
 test_exit:
-	exit_test("test206");
+	exit_test("FPSetVolParms:test206: Set Volume parameters");
 } 
 
 /* ----------- */
@@ -53,5 +55,6 @@ void FPSetVolParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPSetVolParms page 268\n");
+    fprintf(stdout,"-------------------\n");
 	test206();
 }

--- a/test/testsuite/FPSync.c
+++ b/test/testsuite/FPSync.c
@@ -12,7 +12,7 @@ STATIC void test2()
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
  	if (FPSyncDir(Conn, vol, DIRDID_ROOT)) {
 		failed();

--- a/test/testsuite/FPSync.c
+++ b/test/testsuite/FPSync.c
@@ -4,7 +4,6 @@
 /* ------------------------- */
 STATIC void test2()
 {
-    int  dir;
     uint16_t vol = VolID;
     DSI *dsi;
     char *name = "t2 sync dir";
@@ -14,13 +13,12 @@ STATIC void test2()
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSyncDir(test2): sync dir\n");
 
- 	if (FPSyncDir(Conn, vol, DIRDID_ROOT))
+ 	if (FPSyncDir(Conn, vol, DIRDID_ROOT)) {
 		failed();
+	}
 
-	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
+	if (!(FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		nottested();
 		goto test_exit;
 	}
@@ -31,11 +29,23 @@ STATIC void test2()
 
     filedir.isdir = 1;
     afp_filedir_unpack(&filedir, dsi->data +ofs, 0, (1 << DIRPBIT_DID));
- 	if (FPSyncDir(Conn, vol, filedir.did))
+ 	if (FPSyncDir(Conn, vol, filedir.did)) {
 		failed();
+	}
 
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test2");
+	exit_test("FPSyncDir:test2: sync dir");
+}
+
+/* ----------- */
+void FPSync_test()
+{
+#if 0
+    fprintf(stdout,"===================\n");
+    fprintf(stdout,"FPSync\n");
+    fprintf(stdout,"-------------------\n");
+	test2();
+#endif
 }

--- a/test/testsuite/FPWrite.c
+++ b/test/testsuite/FPWrite.c
@@ -14,7 +14,7 @@ int size;
 DSI *dsi;
 
 	dsi = &Conn->dsi;
-	enter_test();
+	ENTER_TEST
 	size = min(0x20000, dsi->server_quantum);
 	if (size < 0x20000) {
 		if (!Quiet) {
@@ -72,7 +72,7 @@ DSI *dsi;
 int i,j;
 
 	dsi = &Conn->dsi;
-	enter_test();
+	ENTER_TEST
 	size = min(0x20000, dsi->server_quantum); /* 128 k */
 	if (size < 0x20000) {
 		if (!Quiet) {
@@ -153,7 +153,7 @@ uint16_t vol = VolID;
 DSI *dsi;
 
 	dsi = &Conn->dsi;
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();

--- a/test/testsuite/FPWrite.c
+++ b/test/testsuite/FPWrite.c
@@ -15,11 +15,11 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPWrite:test216: read/write data fork\n");
 	size = min(0x20000, dsi->server_quantum);
 	if (size < 0x20000) {
-		fprintf(stdout,"\t server quantum (%d) too small\n", size);
+		if (!Quiet) {
+			fprintf(stdout,"\t server quantum (%d) too small\n", size);
+		}
 		nottested();
 		goto test_exit;
 	}
@@ -56,7 +56,7 @@ fin:
 	FAIL (fork && FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test216");
+	exit_test("FPWrite:test216: read/write data fork");
 }
 
 /* ------------------------- */
@@ -73,11 +73,11 @@ int i,j;
 
 	dsi = &Conn->dsi;
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPWrite:test226: disk full error\n");
 	size = min(0x20000, dsi->server_quantum); /* 128 k */
 	if (size < 0x20000) {
-		fprintf(stdout,"\t server quantum (%d) too small\n", size);
+		if (!Quiet) {
+			fprintf(stdout,"\t server quantum (%d) too small\n", size);
+		}
 		nottested();
 		goto test_exit;
 	}
@@ -89,7 +89,7 @@ int i,j;
 	afp_volume_unpack(&parms, dsi->commands +sizeof( uint16_t ), (1 << VOLPBIT_BFREE));
 
 	if (parms.bfree > 2*1024*1024) {
-		fprintf(stdout,"\t Volume too big, skipped\n");
+		test_skipped(T_VOL_BIG);
 		/* FIXME */
 		goto test_exit;
 	}
@@ -140,7 +140,7 @@ fin:
 	FAIL (fork && FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test226");
+	exit_test("FPWrite:test226: disk full error");
 }
 
 /* ------------------------- */
@@ -154,8 +154,6 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPWrite:test303: Write 0 byte to data fork \n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -177,7 +175,7 @@ fin:
 	FAIL (fork && FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test303");
+	exit_test("FPWrite:test303: Write 0 byte to data fork");
 }
 
 /* ----------- */
@@ -185,6 +183,7 @@ void FPWrite_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPWrite page 270\n");
+    fprintf(stdout,"-------------------\n");
 	test216();
 	test226();
 	test303();

--- a/test/testsuite/FPWriteExt.c
+++ b/test/testsuite/FPWriteExt.c
@@ -18,7 +18,7 @@ uint16_t vol = VolID;
 int tdir;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
  	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -127,7 +127,7 @@ char *name = "t207 file";
 uint16_t vol = VolID;
 int i;
 
-	enter_test();
+	ENTER_TEST
  	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -276,7 +276,7 @@ uint16_t vol = VolID;
 DSI *dsi;
 
 	dsi = &Conn->dsi;
-	enter_test();
+	ENTER_TEST
  	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;

--- a/test/testsuite/FPWriteExt.c
+++ b/test/testsuite/FPWriteExt.c
@@ -19,8 +19,6 @@ int tdir;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPWriteExt:test148: AFP 3.0 FPWriteExt\n");
  	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -64,12 +62,16 @@ DSI *dsi = &Conn->dsi;
 	else {
 		memcpy(&rep, dsi->commands, sizeof(rep));
 		if (rep) {
-			fprintf(stdout,"\tFAILED size %d\n", rep);
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED size %d\n", rep);
+			}
 			failed_nomsg();
 		}
 		memcpy(&rep, dsi->commands +sizeof(rep), sizeof(rep));
 		if (ntohl(rep) != 1714) {
-			fprintf(stdout,"\tFAILED size %d\n", ntohl(rep));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED size %d\n", ntohl(rep));
+			}
 			failed_nomsg();
 		}
 	}
@@ -80,12 +82,16 @@ DSI *dsi = &Conn->dsi;
 	else {
 		memcpy(&rep, dsi->commands, sizeof(rep));
 		if (rep) {
-			fprintf(stdout,"\tFAILED size %d\n", rep);
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED size %d\n", rep);
+			}
 			failed_nomsg();
 		}
 		memcpy(&rep, dsi->commands +sizeof(rep), sizeof(rep));
 		if (ntohl(rep) != 1714) {
-			fprintf(stdout,"\tFAILED size %d\n", ntohl(rep));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED size %d\n", ntohl(rep));
+			}
 			failed_nomsg();
 		}
 	}
@@ -108,7 +114,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, dir))
 test_exit:
-	exit_test("test148");
+	exit_test("FPWriteExt:test148: AFP 3.0 FPWriteExt");
 }
 
 /* --------------------- */
@@ -122,8 +128,6 @@ uint16_t vol = VolID;
 int i;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPWriteExt:test207: AFP 3.0 read/Write\n");
  	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -231,7 +235,9 @@ int i;
 	}
 	else for (i = 0; i < 10000; i++) {
 		if (Data[i] != 0) {
-			fprintf(stdout,"\tFAILED Data != 0\n");
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED Data != 0\n");
+			}
 			failed_nomsg();
 			break;
 		}
@@ -257,7 +263,7 @@ fin:
 	FAIL (FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, "very big"))
 test_exit:
-	exit_test("test207");
+	exit_test("FPWriteExt:test207: AFP 3.0 read/Write");
 }
 
 /* ------------------------- */
@@ -271,8 +277,6 @@ DSI *dsi;
 
 	dsi = &Conn->dsi;
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPWriteExt:test304: Write 0 byte to data fork\n");
  	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
 		goto test_exit;
@@ -299,7 +303,7 @@ fin:
 	FAIL (fork && FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test304");
+	exit_test("FPWriteExt:test304: Write 0 byte to data fork");
 }
 
 
@@ -308,6 +312,7 @@ void FPWriteExt_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPWriteExt page 273\n");
+    fprintf(stdout,"-------------------\n");
     test148();
 	test207();
 	test304();

--- a/test/testsuite/FPzzz.c
+++ b/test/testsuite/FPzzz.c
@@ -27,8 +27,6 @@ int sock;
 uint32_t time= 12345;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPzzz:test223: AFP 3.x enter sleep mode\n");
 	if (Conn->afp_version < 30 || Conn2) {
 		test_skipped(T_AFP3_CONN2);
 		goto test_exit;
@@ -95,7 +93,7 @@ fin:
 		nottested();
     }
 test_exit:
-	exit_test("test223");
+	exit_test("FPzzz:test223: AFP 3.x enter sleep mode");
 }
 
 /* ------------------------- */
@@ -109,8 +107,6 @@ int sock;
 uint32_t time= 12345;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPzzz:test224: disconnected after 2 mn\n");
 
 	if (Conn->afp_version < 30 || Conn2) {
 		test_skipped(T_AFP3_CONN2);
@@ -176,7 +172,7 @@ fin:
 		nottested();
     }
 test_exit:
-	exit_test("test224");
+	exit_test("FPzzz:test224: disconnected after 2 mn");
 
 }
 
@@ -191,8 +187,6 @@ DSI *dsi;
 int sock;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPzzz:test239: AFP 3.x enter extended sleep\n");
 
 	if (Conn->afp_version < 30 || Conn2) {
 		test_skipped(T_AFP3_CONN2);
@@ -221,7 +215,7 @@ fin:
 		nottested();
     }
 test_exit:
-	exit_test("test239");
+	exit_test("FPzzz:test239: AFP 3.x enter extended sleep");
 }
 
 /* ----------- */
@@ -229,6 +223,7 @@ void FPzzz_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPzzz\n");
+    fprintf(stdout,"-------------------\n");
     test223();
     test224();
     test239();

--- a/test/testsuite/FPzzz.c
+++ b/test/testsuite/FPzzz.c
@@ -26,7 +26,7 @@ DSI *dsi;
 int sock;
 uint32_t time= 12345;
 
-	enter_test();
+	ENTER_TEST
 	if (Conn->afp_version < 30 || Conn2) {
 		test_skipped(T_AFP3_CONN2);
 		goto test_exit;
@@ -106,7 +106,7 @@ struct sigaction action;
 int sock;
 uint32_t time= 12345;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30 || Conn2) {
 		test_skipped(T_AFP3_CONN2);
@@ -186,7 +186,7 @@ struct sigaction action;
 DSI *dsi;
 int sock;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30 || Conn2) {
 		test_skipped(T_AFP3_CONN2);

--- a/test/testsuite/README
+++ b/test/testsuite/README
@@ -105,11 +105,14 @@ You can also run the complete spectest (one user, two users, local access) with
 - edit "build/test/testsuite/spectest.conf" to suit your needs
 - run `meson test` again
 
-Return Code
------------
+Return Codes
+------------
 0 PASSED
 1 FAILED
-2 NOT TESTED the test failed too early
+2 NOT TESTED - a test setup step or precondition check failed
+3 SKIPPED - test environment requirements not satisfied
+
+Note that 2 and 3 are treated as an overall return code 0 for the purpose of test reporting.
 
 spectest, logintext and rotest shall return the same results whether they are run
 on a Mac server or afpd.

--- a/test/testsuite/README
+++ b/test/testsuite/README
@@ -84,14 +84,12 @@ afp.conf:
 [Global]
 uam list = uams_clrtxt.so uams_guest.so
 
-# volume mount read only
 # not empty at least 2 files and one folder (empty).
-[cdrom]
-path = /mnt/cdrom
-vol dbpath = /opt/var/afpd/cdrom
+[test1]
+path = /tmp/afptest1
 
-[test]
-path = /u/test
+[test2]
+path = /tmp/afptest2
 #<<<<<<<<
 
 For testing with a Mac, same config (user1 or user2 are not owner)
@@ -120,12 +118,12 @@ on a Mac server or afpd.
 Example:
 --------
 Run all tests on server 192.168.2.123
-spectest  -h 192.168.2.123 -u user1 -d usr2 -s test -w  toto
+spectest -h 192.168.2.123 -u user1 -d usr2 -s test -w toto
 Same but on a Mac
-spectest -m -h 192.168.2.64 -u user1 -d usr2 -s test -w  toto
+spectest -m -h 192.168.2.64 -u user1 -d usr2 -s test -w toto
 
 Run FPByteRangeLock tests with AFP 3.0, two different servers are exporting the same volume.
-T2_spectest -f FPByteRangeLock -3  -h 192.168.2.123 -H 192.168.2.124 -u user1 -d usr2 -s test -c /u/test -w toto
+T2_spectest -f FPByteRangeLock -3 -h 192.168.2.123 -H 192.168.2.124 -u user1 -d usr2 -s test -c /tmp/afptest1 -w toto
 
 At least on linux, it's possible to compile them with LDFLAGS=-rdynamic
 and the program can run individual test:

--- a/test/testsuite/T2_Dircache_attack.c
+++ b/test/testsuite/T2_Dircache_attack.c
@@ -136,8 +136,6 @@ STATIC void test500()
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
 	enter_test();
-    fprintf(stdout, "===================\n");
-    fprintf(stdout, "Dircache:test500: move and rename dir, enumerate new parent, stat renamed dir\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -169,11 +167,15 @@ STATIC void test500()
 	afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
 
 	if (filedir.did != subdir1_id) {
-		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir1_id);
+        if (!Quiet) {
+    		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir1_id);
+        }
         failed();
 	}
 	if (strcmp(filedir.lname, renamedsubdir1)) {
-		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, renamedsubdir1);
+        if (!Quiet) {
+    		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, renamedsubdir1);
+        }
         failed();
 	}
 
@@ -185,7 +187,7 @@ fin:
     FAIL( FPDelete(Conn, vol1, dir_id, "") );
 
 test_exit:
-	exit_test("test500");
+	exit_test("Dircache:test500: move and rename dir, enumerate new parent, stat renamed dir");
 }
 
 /* move and rename dir, then stat it */
@@ -204,8 +206,6 @@ STATIC void test501()
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
 	enter_test();
-    fprintf(stdout, "===================\n");
-    fprintf(stdout, "Dircache:test501: move and rename dir, then stat it\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -234,11 +234,15 @@ STATIC void test501()
 	afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
 
 	if (filedir.did != subdir1_id) {
-		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir1_id);
+        if (!Quiet) {
+    		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir1_id);
+        }
         failed();
 	}
 	if (strcmp(filedir.lname, renamedsubdir1)) {
-		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, renamedsubdir1);
+        if (!Quiet) {
+    		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, renamedsubdir1);
+        }
         failed();
 	}
 
@@ -250,7 +254,7 @@ fin:
     FAIL( FPDelete(Conn, vol1, dir_id, "") );
 
 test_exit:
-	exit_test("test501");
+	exit_test("Dircache:test501: move and rename dir, then stat it");
 }
 
 /* move and rename dir, enumerate renamed dir */
@@ -269,8 +273,6 @@ STATIC void test502()
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
 	enter_test();
-    fprintf(stdout, "===================\n");
-    fprintf(stdout, "Dircache:test502: move and rename dir, enumerate renamed dir\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -303,11 +305,15 @@ STATIC void test502()
 	afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
 
 	if (filedir.did != subdir1_id) {
-		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir1_id);
+        if (!Quiet) {
+    		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir1_id);
+        }
         failed();
 	}
 	if (strcmp(filedir.lname, renamedsubdir1)) {
-		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, renamedsubdir1);
+        if (!Quiet) {
+    		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, renamedsubdir1);
+        }
         failed();
 	}
 
@@ -320,7 +326,7 @@ fin:
     FAIL( FPDelete(Conn, vol1, dir_id, "") );
 
 test_exit:
-	exit_test("test502");
+	exit_test("Dircache:test502: move and rename dir, enumerate renamed dir");
 }
 
 /* move and rename dir, stat renamed dir */
@@ -339,8 +345,6 @@ STATIC void test503()
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
 	enter_test();
-    fprintf(stdout, "===================\n");
-    fprintf(stdout, "Dircache:test503: move and rename dir, enumerate renamed dir\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -369,11 +373,15 @@ STATIC void test503()
 	afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
 
 	if (filedir.did != subdir1_id) {
-		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir1_id);
+        if (!Quiet) {
+    		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir1_id);
+        }
         failed();
 	}
 	if (strcmp(filedir.lname, renamedsubdir1)) {
-		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, renamedsubdir1);
+        if (!Quiet) {
+    		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, renamedsubdir1);
+        }
         failed();
 	}
 
@@ -385,7 +393,7 @@ fin:
     FAIL( FPDelete(Conn, vol1, dir_id, "") );
 
 test_exit:
-	exit_test("test503");
+	exit_test("Dircache:test503: move and rename dir, enumerate renamed dir");
 }
 
 /* rename topdir, stat file in subdir of renamed topdir */
@@ -404,8 +412,6 @@ STATIC void test504()
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
 	enter_test();
-    fprintf(stdout, "===================\n");
-    fprintf(stdout, "Dircache:test504: rename topdir, stat file in subdir of renamed topdir\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -440,7 +446,9 @@ STATIC void test504()
 	afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
 
 	if (filedir.did != file_id) {
-		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir1_id);
+        if (!Quiet) {
+    		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir1_id);
+        }
         failed();
 	}
 
@@ -452,7 +460,7 @@ fin:
     FAIL( FPDelete(Conn, vol1, dir_id, "") );
 
 test_exit:
-	exit_test("test504");
+	exit_test("Dircache:test504: rename topdir, stat file in subdir of renamed topdir");
 }
 
 /* rename dir, stat subdir in renamed dir */
@@ -471,8 +479,6 @@ STATIC void test505()
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
 	enter_test();
-    fprintf(stdout, "===================\n");
-    fprintf(stdout, "Dircache:test505: rename dir, stat subdir in renamed dir\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -501,12 +507,16 @@ STATIC void test505()
 	afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
 
 	if (filedir.did != subdir2_id) {
-		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir2_id);
+        if (!Quiet) {
+    		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir2_id);
+        }
         failed();
 	}
 	if (strcmp(filedir.lname, subdir2
 )) {
-		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, subdir2);
+        if (!Quiet) {
+    		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, subdir2);
+        }
         failed();
 	}
 
@@ -518,7 +528,7 @@ fin:
     FAIL( FPDelete(Conn, vol1, dir_id, "") );
 
 test_exit:
-	exit_test("test505");
+	exit_test("Dircache:test505: rename dir, stat subdir in renamed dir");
 }
 
 /* stat subdir in poisened path */
@@ -537,8 +547,6 @@ STATIC void test506()
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
 	enter_test();
-    fprintf(stdout, "===================\n");
-    fprintf(stdout, "Dircache:test506: stat subdir in poisened path\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -570,12 +578,16 @@ STATIC void test506()
 	afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
 
 	if (filedir.did != subdir2_id) {
-		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir2_id);
+        if (!Quiet) {
+    		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, subdir2_id);
+        }
         failed();
 	}
 	if (strcmp(filedir.lname, subdir2
 )) {
-		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, subdir2);
+        if (!Quiet) {
+    		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, subdir2);
+        }
         failed();
 	}
 
@@ -588,13 +600,14 @@ fin:
     FAIL( FPDelete(Conn, vol1, dir_id, "") );
 
 test_exit:
-	exit_test("test506");
+	exit_test("Dircache:test506: stat subdir in poisoned path");
 }
 
 void Dircache_attack_test()
 {
     fprintf(stdout, "===================\n");
     fprintf(stdout, "Dircache attack\n");
+    fprintf(stdout, "===================\n");
     test500();
     test501();
     test502();

--- a/test/testsuite/T2_Dircache_attack.c
+++ b/test/testsuite/T2_Dircache_attack.c
@@ -607,7 +607,7 @@ void Dircache_attack_test()
 {
     fprintf(stdout, "===================\n");
     fprintf(stdout, "Dircache attack\n");
-    fprintf(stdout, "===================\n");
+    fprintf(stdout, "-------------------\n");
     test500();
     test501();
     test502();

--- a/test/testsuite/T2_Dircache_attack.c
+++ b/test/testsuite/T2_Dircache_attack.c
@@ -135,7 +135,7 @@ STATIC void test500()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -205,7 +205,7 @@ STATIC void test501()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -272,7 +272,7 @@ STATIC void test502()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -344,7 +344,7 @@ STATIC void test503()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -411,7 +411,7 @@ STATIC void test504()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -478,7 +478,7 @@ STATIC void test505()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -546,7 +546,7 @@ STATIC void test506()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);

--- a/test/testsuite/T2_FPByteRangeLock.c
+++ b/test/testsuite/T2_FPByteRangeLock.c
@@ -106,7 +106,7 @@ void test117()
 char *name = "t117 exclusive open DF";
 uint16_t vol2;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);

--- a/test/testsuite/T2_FPByteRangeLock.c
+++ b/test/testsuite/T2_FPByteRangeLock.c
@@ -33,10 +33,10 @@ uint16_t vol = VolID;
 		return;
 	}
 
-	if (FPSetForkParam(Conn, fork, len , 50)) {fprintf(stdout,"\tFAILED\n");}
-	if (FPByteLock(Conn, fork, 0, 0 , 0 , 100)) {fprintf(stdout,"\tFAILED\n");}
-	if (FPRead(Conn, fork, 0, 40, Data)) {fprintf(stdout,"\tFAILED\n");}
-	if (FPWrite(Conn, fork, 10, 40, Data, 0)) {fprintf(stdout,"\tFAILED\n");}
+	if (!Quiet && FPSetForkParam(Conn, fork, len , 50)) {fprintf(stdout,"\tFAILED\n");}
+	if (!Quiet && FPByteLock(Conn, fork, 0, 0 , 0 , 100)) {fprintf(stdout,"\tFAILED\n");}
+	if (!Quiet && FPRead(Conn, fork, 0, 40, Data)) {fprintf(stdout,"\tFAILED\n");}
+	if (!Quiet && FPWrite(Conn, fork, 10, 40, Data, 0)) {fprintf(stdout,"\tFAILED\n");}
 	fork1 = FPOpenFork(Conn, vol, type , bitmap ,DIRDID_ROOT, name,OPENACC_WR |OPENACC_RD);
 	if (fork1) {
 		failed();
@@ -47,8 +47,10 @@ uint16_t vol = VolID;
     strcat(temp,(type == OPENFORK_RSCS && adouble == AD_V2) ? "/.AppleDouble/" : "/");
     strcat(temp, name);
 
-	fprintf(stdout," \n---------------------\n");
-	fprintf(stdout, "open(\"%s\", O_RDWR)\n", temp);
+	if (!Quiet) {
+		fprintf(stdout," \n---------------------\n");
+		fprintf(stdout, "open(\"%s\", O_RDWR)\n", temp);
+	}
 	fd = open(temp, O_RDWR, 0);
 	if (fd >= 0) {
         if (adouble == AD_V2) {
@@ -64,19 +66,23 @@ uint16_t vol = VolID;
     	if ((ret = fcntl(fd, F_SETLK, &lock)) >= 0 || (errno != EACCES && errno != EAGAIN)) {
     	    if (!ret >= 0)
     	    	errno = 0;
-    		perror("fcntl ");
+		if (!Quiet) {
+			perror("fcntl ");
 			fprintf(stdout,"\tFAILED\n");
+		}
     	}
     	fcntl(fd, F_UNLCK, &lock);
     	close(fd);
 	}
-	else {
-    	perror("open ");
+	else if (!Quiet) {
+		perror("open ");
 		fprintf(stdout,"\tFAILED \n");
 	}
 	fork1 = FPOpenFork(Conn2, vol2, type , bitmap ,DIRDID_ROOT, name,OPENACC_WR |OPENACC_RD);
 	if (fork1) {
-		fprintf(stdout,"\tFAILED\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED\n");
+		}
 		FPCloseFork(Conn2,fork1);
 	}
 
@@ -84,7 +90,9 @@ uint16_t vol = VolID;
 	fork1 = FPOpenFork(Conn2, vol2, type , bitmap ,DIRDID_ROOT, name,OPENACC_WR |OPENACC_RD);
 	if (!fork1) {
 		failed();
-		fprintf(stdout,"\tFAILED\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED\n");
+		}
 	}
 	else {
 		FAIL (FPCloseFork(Conn2,fork1))
@@ -99,8 +107,6 @@ char *name = "t117 exclusive open DF";
 uint16_t vol2;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPByteRangeLock:test117: test open excl mode\n");
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);
@@ -123,7 +129,7 @@ uint16_t vol2;
 
 	FPCloseVol(Conn2,vol2);
 test_exit:
-	exit_test("test117");
+	exit_test("FPByteRangeLock:test117: test open excl mode");
 }
 
 /* ----------- */
@@ -131,5 +137,6 @@ void FPByteRangeLock_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPByteRangeLock page 101\n");
+    fprintf(stdout,"-------------------\n");
     test117();
 }

--- a/test/testsuite/T2_FPCopyFile.c
+++ b/test/testsuite/T2_FPCopyFile.c
@@ -17,8 +17,6 @@ uint16_t bitmap;
 uint32_t mdate = 0;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPCopyFile:test373: copyFile check meta data, file without resource fork\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -35,7 +33,9 @@ uint32_t mdate = 0;
 		goto fin;
 	}
 
-	fprintf(stdout,"sleep(2)\n");
+	if (!Quiet) {
+		fprintf(stdout,"sleep(2)\n");
+	}
 	sleep(2);
 	tp = get_fid(Conn, vol, DIRDID_ROOT, name);
 	if (!tp) {
@@ -61,7 +61,9 @@ uint32_t mdate = 0;
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 		if (mdate != filedir.mdate)  {
-	        fprintf(stdout,"\tFAILED modification date differ\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED modification date differ\n");
+		}
 	        failed_nomsg();
 	        goto fin;
 		}
@@ -73,7 +75,9 @@ uint32_t mdate = 0;
 		goto fin;
 	}
 	if (tp == tp1) {
-	    fprintf(stdout,"\tFAILED both files have same ID\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED both files have same ID\n");
+		}
 	    failed_nomsg();
 	}
 
@@ -82,7 +86,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
 
 test_exit:
-	exit_test("test373");
+	exit_test("FPCopyFile:test373: copyFile check meta data, file without resource fork");
 }
 
 /* ----------- */
@@ -90,5 +94,6 @@ void FPCopyFile_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPCopyFile page 131\n");
+    fprintf(stdout,"-------------------\n");
 	test373();
 }

--- a/test/testsuite/T2_FPCopyFile.c
+++ b/test/testsuite/T2_FPCopyFile.c
@@ -16,7 +16,7 @@ DSI *dsi = &Conn->dsi;
 uint16_t bitmap;
 uint32_t mdate = 0;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);

--- a/test/testsuite/T2_FPCreateFile.c
+++ b/test/testsuite/T2_FPCreateFile.c
@@ -14,7 +14,7 @@ int ret;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if ((!Path && !Mac)) {
         test_skipped(T_MAC_PATH);

--- a/test/testsuite/T2_FPCreateFile.c
+++ b/test/testsuite/T2_FPCreateFile.c
@@ -15,8 +15,6 @@ int ret;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPCreateFile:test325:  recreate a file with dangling symlink and no right\n");
 
 	if ((!Path && !Mac)) {
         test_skipped(T_MAC_PATH);
@@ -34,17 +32,25 @@ int ret;
 	}
 	if (!Mac) {
 		sprintf(temp,"%s/%s", Path, name);
-		fprintf(stdout,"unlink data fork\n");
+		if (!Quiet) {
+			fprintf(stdout,"unlink data fork\n");
+		}
 		if (unlink(temp) <0) {
-			fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 			goto fin;
 		}
 
 		sprintf(temp,"%s/.AppleDouble/%s", Path, name);
-		fprintf(stdout,"chmod 444 resource fork\n");
+		if (!Quiet) {
+			fprintf(stdout,"chmod 444 resource fork\n");
+		}
 		if (chmod(temp, 0444) <0) {
-			fprintf(stdout,"\tFAILED chmod(%s) %s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED chmod(%s) %s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 			goto fin;
 		}
@@ -69,7 +75,7 @@ fin:
 		unlink(temp);
 	}
 test_exit:
-	exit_test("test325");
+	exit_test("FPCreateFile:test325: recreate a file with dangling symlink and no right");
 }
 
 /* ----------- */
@@ -77,5 +83,6 @@ void FPCreateFile_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPCreateFile page 138\n");
+    fprintf(stdout,"-------------------\n");
     test325();
 }

--- a/test/testsuite/T2_FPDelete.c
+++ b/test/testsuite/T2_FPDelete.c
@@ -24,6 +24,11 @@ int ret;
 
 	ENTER_TEST
 
+	// FIXME: broken in Netatalk 4.0
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -138,6 +143,11 @@ DSI *dsi = &Conn->dsi;
 
 	ENTER_TEST
 
+	// FIXME: broken in Netatalk 4.0
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;
@@ -256,6 +266,11 @@ DSI *dsi = &Conn->dsi;
 
 	ENTER_TEST
 
+	// FIXME: broken in Netatalk 4.0
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;
@@ -294,8 +309,6 @@ test_exit:
 /* ----------- */
 void FPDelete_test()
 {
-// FIXME: all flaky with Netatalk 4.0; mix of fails and false passes
-#if 0
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPDelete page 143\n");
     fprintf(stdout,"-------------------\n");
@@ -305,5 +318,4 @@ void FPDelete_test()
     test363();
 #endif
     test364();
-#endif
 }

--- a/test/testsuite/T2_FPDelete.c
+++ b/test/testsuite/T2_FPDelete.c
@@ -23,8 +23,6 @@ DSI *dsi2;
 int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPDelete:test146: delete read only open file\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -81,12 +79,16 @@ int ret;
 	if (!Mac && adouble == AD_V2) {
 		sprintf(temp,"%s/%s/.AppleDouble/%s", Path, name1, name);
 		if (chmod(temp, 0644) <0) {
-			fprintf(stdout,"\tFAILED chmod(%s) %s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED chmod(%s) %s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 		}
 	}
 	if (ntohl(AFPERR_BUSY) != FPDelete(Conn2, vol2,  dir , name)) {
-		fprintf(stdout,"\tFIXME FAILED open but deleted\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFIXME FAILED open but deleted\n");
+		}
 #if 0
 		failed_nomsg();
 #endif
@@ -99,7 +101,9 @@ int ret;
 	} else {
         if (!Mac && adouble == AD_V2) {
             if (chmod(temp, 0666) <0) {
-                fprintf(stdout,"\tFAILED chmod(%s) %s\n", temp, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED chmod(%s) %s\n", temp, strerror(errno));
+		}
                 failed_nomsg();
             }
         }
@@ -117,7 +121,7 @@ int ret;
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 	FAIL (FPCloseVol(Conn2,vol2))
 test_exit:
-	exit_test("test146");
+	exit_test("FPDelete:test146: delete read only open file");
 }
 
 /* -------------------------- */
@@ -133,8 +137,6 @@ struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDelete:test507: Resolve ID in a deleted folder\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -165,7 +167,7 @@ DSI *dsi = &Conn->dsi;
 	vol  = FPOpenVol(Conn, Vol);
 	FAIL (ntohl(AFPERR_NOID ) != FPResolveID(Conn, vol, filedir.did, bitmap))
 test_exit:
-	exit_test("test507");
+	exit_test("FPDelete:test507: Resolve ID in a deleted folder");
 }
 
 /* -------------------------- */
@@ -182,8 +184,6 @@ DSI *dsi = &Conn->dsi;
 int fork;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDelete:test363: Get fork param in a deleted folder\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -214,12 +214,16 @@ int fork;
 		sprintf(temp1, "%s/%s/.AppleDouble/%s", Path, name1, name);
 
 		if (unlink(temp1) <0) {
-			fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 		}
 		sprintf(temp1, "%s/%s/%s", Path, name1, name);
 		if (unlink(temp1) <0) {
-			fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 		}
 		if (delete_unix_dir(Path, name1)) {
@@ -234,7 +238,7 @@ fin:
 	FPDelete(Conn, vol,  dir , name);
 	FPDelete(Conn, vol,  dir , "");
 test_exit:
-	exit_test("test363");
+	exit_test("FPDelete:test363: Get fork param in a deleted folder");
 
 }
 
@@ -251,8 +255,6 @@ struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPDelete:test364: Delete ID in a deleted folder\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -285,7 +287,7 @@ fin:
 	FPDelete(Conn, vol,  dir , name);
 	FPDelete(Conn, vol,  dir , "");
 test_exit:
-	exit_test("test364");
+	exit_test("FPDelete:test364: Delete ID in a deleted folder");
 
 }
 
@@ -296,6 +298,7 @@ void FPDelete_test()
 #if 0
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPDelete page 143\n");
+    fprintf(stdout,"-------------------\n");
     test146();
     test507();
 #if 0

--- a/test/testsuite/T2_FPDelete.c
+++ b/test/testsuite/T2_FPDelete.c
@@ -22,7 +22,7 @@ DSI *dsi = &Conn->dsi;
 DSI *dsi2;
 int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -136,7 +136,7 @@ uint16_t bitmap = (1<<FILPBIT_FNUM );
 struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -183,7 +183,7 @@ struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 int fork;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -254,7 +254,7 @@ uint16_t bitmap = (1<<FILPBIT_FNUM );
 struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);

--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -20,8 +20,6 @@ int  ret;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test32: dir deleted by someone else, access with ID\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -119,7 +117,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name1))
 test_exit:
-	exit_test("test32");
+	exit_test("FPGetFileDirParms:test32: dir deleted by someone else, access with ID");
 }
 
 /* ------------------------- */
@@ -132,8 +130,6 @@ uint16_t vol = VolID;
 int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test33: dir deleted by someone else, access with name\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -226,7 +222,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name1))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test33");
+	exit_test("FPGetFileDirParms:test33: dir deleted by someone else, access with name");
 }
 
 /* ------------------------- */
@@ -238,8 +234,6 @@ int  dir,dir1;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test42: dir deleted by someone else, access with ID from another dir\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -305,19 +299,16 @@ fin:
 	FAIL (dir && FPDelete(Conn, vol,  dir, ""))
 	FAIL (dir1 && FPDelete(Conn, vol,  dir1, ""))
 test_exit:
-	exit_test("test42");
+	exit_test("FPGetFileDirParms:test42: dir deleted by someone else, access with ID from another dir");
 }
 
 /* -------------------------- */
-#if 0
-FIXME
+// FIXME
 STATIC void test52()
 {
-char name ".t52 invisible";
+uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-	fprintf(stdout, "FPGetFileDirParms:test52: test .file without AppleDouble\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -333,9 +324,8 @@ char name ".t52 invisible";
 		failed();
 	}
 test_exit:
-	exit_test("test52");
+	exit_test("FPGetFileDirParms:test52: test .file without AppleDouble");
 }
-#endif
 
 /* --------------------- */
 STATIC void test106()
@@ -354,8 +344,6 @@ struct afp_filedir_parms filedir;
 uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:t106: cname with trailing 0 and chdir\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -395,20 +383,28 @@ uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 	afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 
 	if (filedir.did != dir3) {
-		fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, dir3 );
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, dir3 );
+		}
 		failed_nomsg();
 	}
 	if (strcmp(filedir.lname, name3)) {
-		fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name3);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name3);
+		}
 		failed_nomsg();
 	}
 
     sleep(1);
     if (!Mac) {
 		sprintf(temp, "%s/t104 dir1/t104 dir2/t104 dir2_1", Path);
-		fprintf(stdout, "mkdir(%s)\n", temp);
+		if (!Quiet) {
+			fprintf(stdout, "mkdir(%s)\n", temp);
+		}
 		if (mkdir(temp, 0777)) {
-		    fprintf(stdout,"\tFAILED mkdir %s %s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED mkdir %s %s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 		}
 	}
@@ -423,15 +419,21 @@ uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 	else {
 		afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 		if (filedir.did != dir2) {
-			fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, dir2 );
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, dir2 );
+			}
 			failed_nomsg();
 		}
 		if (strcmp(filedir.lname, name2)) {
-			fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name2);
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name2);
+			}
 			failed_nomsg();
 		}
 		if (filedir.offcnt != 3) {
-			fprintf(stdout,"\tFAILED %d\n",filedir.offcnt);
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED %d\n",filedir.offcnt);
+			}
 			failed_nomsg();
 		}
 	}
@@ -442,11 +444,15 @@ uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 	else {
 		afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 		if (filedir.did != dir4) {
-			fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, dir4 );
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED %x should be %x\n",filedir.did, dir4 );
+			}
 			failed_nomsg();
 		}
 		if (strcmp(filedir.lname, name4)) {
-			fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name4);
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED %s should be %s\n",filedir.lname, name4);
+			}
 			failed_nomsg();
 		}
 	}
@@ -459,7 +465,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir1 , name2))
 	FAIL (FPDelete(Conn, vol,  dir1 , ""))
 test_exit:
-	exit_test("test106");
+	exit_test("FPGetFileDirParms:test106: cname with trailing 0 and chdir");
 }
 
 /* ------------------------- */
@@ -473,8 +479,6 @@ uint16_t bitmap = (1<<FILPBIT_FNUM );
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test127: dir removed with cnid not updated\n");
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
@@ -512,7 +516,7 @@ uint16_t vol = VolID;
 
 	FAIL (htonl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, dir1, "", 0, bitmap))
 test_exit:
-	exit_test("test127");
+	exit_test("FPGetFileDirParms:test127: dir removed with cnid not updated");
 }
 
 /* ------------------------- */
@@ -526,8 +530,6 @@ uint16_t bitmap = (1<<FILPBIT_FNUM );
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test128: dir removed with cnid not updated\n");
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
@@ -562,7 +564,7 @@ uint16_t vol = VolID;
 	FAIL (htonl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, dir1, "", 0, bitmap))
 	FAIL (!FPDelete(Conn,vol, dir,""))
 test_exit:
-	exit_test("test128");
+	exit_test("FPGetFileDirParms:test128: dir removed with cnid not updated");
 }
 
 /* ------------------------- */
@@ -575,8 +577,6 @@ int  dir2;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test182: dir deleted by someone else, access with ID (dirlookup)\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -657,7 +657,7 @@ uint16_t vol = VolID;
     /* dir and dir1 should be != but if inode reused they are the same */
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test182");
+	exit_test("FPGetFileDirParms:test182: dir deleted by someone else, access with ID (dirlookup)");
 }
 
 /* ------------------------- */
@@ -672,8 +672,6 @@ uint32_t id,id1;
 int fd;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test235: file deleted and recreated by someone else, cnid not updated\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -696,7 +694,9 @@ int fd;
 		sprintf(temp,"%s/%s/%s", Path, name, name2);
 		fd = open(temp, O_RDWR | O_CREAT, 0666);
 		if (fd < 0) {
-			fprintf(stdout,"\tFAILED unable to create %s :%s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to create %s :%s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 			goto fin;
 		}
@@ -705,7 +705,9 @@ int fd;
 
 		sprintf(temp1,"%s/%s/%s", Path, name, name1);
 		if (rename(temp, temp1) < 0) {
-			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			}
 			failed_nomsg();
 		}
 	}
@@ -715,14 +717,16 @@ int fd;
 	}
 	id1 = get_fid(Conn, vol, dir , name1);
 	if (id == id1) {
-		fprintf(stdout,"\tFAILED ids are the same: %u/%u\n", ntohl(id), ntohl(id1));
-        failed_nomsg();
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED ids are the same: %u/%u\n", ntohl(id), ntohl(id1));
+		}
+		failed_nomsg();
 	}
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , name1))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test235");
+	exit_test("FPGetFileDirParms:test235: file deleted and recreated by someone else, cnid not updated");
 }
 
 /* ------------------------- */
@@ -744,8 +748,6 @@ struct afp_filedir_parms filedir;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms::test336: long dirname >31 bytes\n");
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -810,7 +812,9 @@ struct afp_filedir_parms filedir;
 
 		sprintf(temp1, "%s/%s/%s", Path, ndir, temp);
 		if (stat(temp1, &st)) {
-			fprintf(stdout,"\tFAILED stat( %s ) %s\n", temp1, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED stat( %s ) %s\n", temp1, strerror(errno));
+			}
 			failed_nomsg();
 		}
 	}
@@ -826,7 +830,9 @@ struct afp_filedir_parms filedir;
 		filedir.isdir = 1;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 		if (filedir.pdid != ntohl(dir)) {
-		    fprintf(stdout,"\tFAILED %x should be %x\n", filedir.pdid, ntohl(dir) );
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED %x should be %x\n", filedir.pdid, ntohl(dir) );
+			}
 			failed_nomsg();
 		}
 	}
@@ -836,7 +842,7 @@ struct afp_filedir_parms filedir;
 fin:
 	FAIL (FPDelete(Conn, vol,  id, ""))
 test_exit:
-	exit_test("test336");
+	exit_test("FPGetFileDirParms:test336: long dirname >31 bytes");
 }
 
 /* ----------------------- */
@@ -849,8 +855,6 @@ int  ret;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test340: dir deleted by someone else, access with ID\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -958,7 +962,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name1))
 test_exit:
-	exit_test("test340");
+	exit_test("FPGetFileDirParms:test340: dir deleted by someone else, access with ID");
 }
 
 /* -------------------------- */
@@ -977,8 +981,6 @@ int fork = 0;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test420: FPGetFileDirParms an open file is renamed with local fs\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -1014,7 +1016,9 @@ DSI *dsi = &Conn->dsi;
 	}
 	if (!Mac) {
 		if (rename_unix_file(Path, name1, name, name2) < 0) {
-			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", name, name2, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", name, name2, strerror(errno));
+			}
 			failed_nomsg();
 		}
 	}
@@ -1028,7 +1032,9 @@ DSI *dsi = &Conn->dsi;
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 		if (fid != filedir.did) {
-			fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
+			}
 			failed_nomsg();
 
 		}
@@ -1043,8 +1049,7 @@ fin:
 	FPDelete(Conn, vol,  dir, name);
 	FAIL (FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test420");
-
+	exit_test("FPGetFileDirParms:test420: FPGetFileDirParms an open file is renamed with local fs");
 }
 
 
@@ -1053,9 +1058,13 @@ void FPGetFileDirParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetFileDirParms page 179\n");
+    fprintf(stdout,"-------------------\n");
 	test32();
 	test33();
 	test42();
+#if 0
+	test52();
+#endif
 	test106();
 	test127();
 	test128();

--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -19,7 +19,7 @@ int  dir,dir1;
 int  ret;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -129,7 +129,7 @@ int  dir,dir1;
 uint16_t vol = VolID;
 int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -233,7 +233,7 @@ char *name1 = "t42 dir1";
 int  dir,dir1;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -308,7 +308,7 @@ STATIC void test52()
 {
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -343,7 +343,7 @@ int  ofs =  3 * sizeof( uint16_t );
 struct afp_filedir_parms filedir;
 uint16_t bitmap = (1<< DIRPBIT_DID)|(1<< DIRPBIT_LNAME);
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -478,7 +478,7 @@ int  dir1,dir;
 uint16_t bitmap = (1<<FILPBIT_FNUM );
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
@@ -529,7 +529,7 @@ int  dir1,dir;
 uint16_t bitmap = (1<<FILPBIT_FNUM );
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
@@ -576,7 +576,7 @@ int  dir,dir1;
 int  dir2;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -671,7 +671,7 @@ uint16_t vol = VolID;
 uint32_t id,id1;
 int fd;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -747,7 +747,7 @@ struct afp_filedir_parms filedir;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Conn2) {
 		test_skipped(T_CONN2);
@@ -854,7 +854,7 @@ int  dir,dir1;
 int  ret;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -980,7 +980,7 @@ int fid = 0;
 int fork = 0;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);

--- a/test/testsuite/T2_FPGetSrvrParms.c
+++ b/test/testsuite/T2_FPGetSrvrParms.c
@@ -17,7 +17,7 @@ unsigned char len;
 uint16_t vol2;
 unsigned char *b;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);

--- a/test/testsuite/T2_FPGetSrvrParms.c
+++ b/test/testsuite/T2_FPGetSrvrParms.c
@@ -19,8 +19,6 @@ uint16_t vol2;
 unsigned char *b;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetSrvrParms:test320: GetSrvrParms after volume config file has been modified\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -67,7 +65,7 @@ unsigned char *b;
 	}
 	FAIL (FPCloseVol(Conn,vol2))
 test_exit:
-	exit_test("test320");
+	exit_test("FPGetSrvrParms:test320: GetSrvrParms after volume config file has been modified");
 }
 
 /* ----------- */
@@ -75,5 +73,6 @@ void FPGetSrvrParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPGetSrvrParms page 203\n");
+    fprintf(stdout,"-------------------\n");
 	test320();
 }

--- a/test/testsuite/T2_FPGetSrvrParms.c
+++ b/test/testsuite/T2_FPGetSrvrParms.c
@@ -5,7 +5,6 @@
 #include <fcntl.h>
 #include "specs.h"
 extern char *Vol2;
-extern int Manuel;
 
 /* ----------------------- */
 STATIC void test320(void)
@@ -24,8 +23,12 @@ unsigned char *b;
 		test_skipped(T_MAC_PATH);
 		goto test_exit;
 	}
-	if (!Manuel || *Vol2 == 0) {
+	if (*Vol2 == 0) {
 		test_skipped(T_VOL2);
+		goto test_exit;
+	}
+	if (!Interactive) {
+		test_skipped(T_MANUAL);
 		goto test_exit;
 	}
 
@@ -34,7 +37,7 @@ unsigned char *b;
 		nottested();
 		goto test_exit;
 	}
-	printf("Modify AppleVolumes.default and press enter\n");
+	printf("Modify afp.conf and press enter\n");
 	getchar();
 
 

--- a/test/testsuite/T2_FPMoveAndRename.c
+++ b/test/testsuite/T2_FPMoveAndRename.c
@@ -17,8 +17,6 @@ uint16_t vol = VolID;
 unsigned int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPMoveAndRename:test136: move and rename in a dir without .AppleDouble\n");
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
@@ -28,9 +26,13 @@ unsigned int ret;
 	FAIL (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name))
 	if (!Mac) {
 		sprintf(temp, "%s/%s", Path, ndir);
-		fprintf(stdout, "mkdir(%s)\n", temp);
+		if (!Quiet) {
+			fprintf(stdout, "mkdir(%s)\n", temp);
+		}
 		if (mkdir(temp, 0777)) {
-			fprintf(stdout,"\tFAILED mkdir %s %s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED mkdir %s %s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 		}
 	}
@@ -54,7 +56,7 @@ unsigned int ret;
 	FAIL (!FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	FAIL (FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test136");
+	exit_test("FPMoveAndRename:test136: move and rename in a dir without .AppleDouble");
 }
 
 /* ----------------------- */
@@ -71,8 +73,6 @@ uint16_t vol = VolID;
 unsigned int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPMoveAndRename:test137: move and rename open file in dir without .AppleDouble\n");
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
@@ -82,9 +82,13 @@ unsigned int ret;
 	FAIL (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name))
 	if (!Mac) {
 		sprintf(temp, "%s/%s", Path, ndir);
-		fprintf(stdout, "mkdir(%s)\n", temp);
+		if (!Quiet) {
+			fprintf(stdout, "mkdir(%s)\n", temp);
+		}
 		if (mkdir(temp, 0777)) {
-			fprintf(stdout,"\tFAILED mkdir %s %s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED mkdir %s %s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 		}
 	}
@@ -114,7 +118,7 @@ unsigned int ret;
 	FAIL (!FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	FAIL (FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test137");
+	exit_test("FPMoveAndRename:test137: move and rename open file in dir without .AppleDouble");
 }
 
 /* -------------------------- */
@@ -126,8 +130,6 @@ char *name1 = "t139 dir";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPMoveAndRename:test139: Move And Rename \n");
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
@@ -150,7 +152,7 @@ uint16_t vol = VolID;
 	FAIL (!FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test139");
+	exit_test("FPMoveAndRename:test139: Move And Rename");
 }
 
 /* ------------------------- */
@@ -165,8 +167,6 @@ uint16_t bitmap = (1<<FILPBIT_FNUM );
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test323: file moved with cnid not updated\n");
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
@@ -190,9 +190,13 @@ uint16_t vol = VolID;
 	if (!Mac) {
 		sprintf(temp,"%s/%s/%s", Path, name, file);
 		sprintf(temp1,"%s/%s/%s", Path, name1, file);
-		fprintf (stdout, "rename %s --> %s\n", temp, temp1);
+		if (!Quiet) {
+			fprintf (stdout, "rename %s --> %s\n", temp, temp1);
+		}
 		if (rename(temp, temp1) < 0) {
-			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			}
 			failed_nomsg();
 		}
 
@@ -211,7 +215,7 @@ fin:
 	FAIL (FPDelete(Conn,vol, dir,""))
 	FAIL (FPDelete(Conn,vol, dir1,""))
 test_exit:
-	exit_test("test323");
+	exit_test("FPGetFileDirParms:test323: file moved with cnid not updated");
 }
 
 /* ------------------------- */
@@ -226,8 +230,6 @@ uint16_t bitmap = (1<<FILPBIT_FNUM );
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPGetFileDirParms:test365: file moved with cnid not updated\n");
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
@@ -249,19 +251,27 @@ uint16_t vol = VolID;
 	if (!Mac) {
 		sprintf(temp,"%s/%s/%s", Path, name, file);
 		sprintf(temp1,"%s/%s/%s", Path, name1, file);
-		fprintf (stdout, "rename %s --> %s\n", temp, temp1);
+		if (!Quiet) {
+			fprintf (stdout, "rename %s --> %s\n", temp, temp1);
+		}
 		if (rename(temp, temp1) < 0) {
-			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			}
 			failed_nomsg();
 		}
 
         if (adouble == AD_V2) {
             sprintf(temp,"%s/%s/.AppleDouble/%s", Path, name, file);
             sprintf(temp1,"%s/%s/.AppleDouble/%s", Path, name1, file);
-            fprintf (stdout, "rename %s --> %s\n", temp, temp1);
+	    if (!Quiet) {
+		fprintf (stdout, "rename %s --> %s\n", temp, temp1);
+	    }
             if (rename(temp, temp1) < 0) {
-                fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
-                failed_nomsg();
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		}
+		failed_nomsg();
             }
         }
 	}
@@ -279,7 +289,7 @@ fin:
 	FAIL (FPDelete(Conn,vol, dir,""))
 	FAIL (FPDelete(Conn,vol, dir1,""))
 test_exit:
-	exit_test("test365");
+	exit_test("FPGetFileDirParms:test365: file moved with cnid not updated");
 }
 
 /* ----------- */
@@ -287,6 +297,7 @@ void FPMoveAndRename_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPMoveAndRename page 223\n");
+    fprintf(stdout,"-------------------\n");
     test136();
     test137();
     test139();

--- a/test/testsuite/T2_FPMoveAndRename.c
+++ b/test/testsuite/T2_FPMoveAndRename.c
@@ -16,7 +16,7 @@ char *ndir  = "t136 dir";
 uint16_t vol = VolID;
 unsigned int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
@@ -72,7 +72,7 @@ char *ndir  = "t137 dir";
 uint16_t vol = VolID;
 unsigned int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
@@ -129,7 +129,7 @@ char *name = "t139 file";
 char *name1 = "t139 dir";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
@@ -166,7 +166,7 @@ int  dir1,dir;
 uint16_t bitmap = (1<<FILPBIT_FNUM );
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
@@ -229,7 +229,7 @@ int  dir1,dir;
 uint16_t bitmap = (1<<FILPBIT_FNUM );
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);

--- a/test/testsuite/T2_FPOpenFork.c
+++ b/test/testsuite/T2_FPOpenFork.c
@@ -20,10 +20,10 @@ STATIC void test3()
     uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test3: open data fork without metadata twice, close once, then read\n");
-    fprintf(stdout,"                  Checks data fork / adouble metadata refcounting\n");
 
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test3: Checks data fork / adouble metadata refcounting\n");
+	}
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;
@@ -65,7 +65,7 @@ STATIC void test3()
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test3");
+	exit_test("FPOpenFork:test3: open data fork without metadata twice, close once, then read");
 }
 
 /* ------------------------- */
@@ -77,10 +77,10 @@ STATIC void test4()
     uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test4: open reso fork without metadata twice, close once, then read\n");
-    fprintf(stdout,"                  Checks reso fork / adouble metadata refcounting\n");
 
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test4: Checks reso fork / adouble metadata refcounting\n");
+	}
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;
@@ -124,7 +124,7 @@ STATIC void test4()
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test4");
+	exit_test("FPOpenFork:test4: open reso fork without metadata twice, close once, then read");
 }
 
 /* ------------------------- */
@@ -136,10 +136,10 @@ STATIC void test7()
     uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test7: open data fork without metadata, then open and close resource fork\n");
-    fprintf(stdout,"                  Checks fork / adouble metadata refcounting\n");
 
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test7: Checks fork / adouble metadata refcounting\n");
+	}
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;
@@ -181,7 +181,7 @@ STATIC void test7()
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test7");
+	exit_test("FPOpenFork:test7: open data fork without metadata, then open and close resource fork");
 }
 
 /* ------------------------- */
@@ -195,9 +195,6 @@ int fork = 0, fork1 = 0;
 int dir;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test47: open read only file read only then read write\n");
-    fprintf(stdout,"FPOpenFork:test47: in a read only folder\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -367,7 +364,7 @@ fin1:
 fin:
 	delete_ro_adouble(vol, dir, file);
 test_exit:
-	exit_test("test47");
+	exit_test("FPOpenFork:test47: open read only file read only then read write in a read only folder");
 }
 
 /* ------------------------- */
@@ -381,9 +378,6 @@ uint16_t vol = VolID;
 int dir;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test49: open read-write file without ressource fork\n");
-    fprintf(stdout,"FPOpenFork:test49: in a read-write folder\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -417,8 +411,8 @@ int dir;
 	FAIL (FPCloseFork(Conn,fork))
 	FAIL (FPCloseFork(Conn,fork1))
 
-	if (!unlink(temp)) {
-		fprintf(stdout,"\tRessource fork there!\n");
+	if (!unlink(temp) && !Quiet) {
+		fprintf(stdout,"\tResource fork there!\n");
 	}
 
 	fork1 = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap ,dir, file,OPENACC_WR | OPENACC_RD);
@@ -428,15 +422,14 @@ int dir;
 	}
 	FAIL (FPCloseFork(Conn,fork1))
 
-	if (!unlink(temp)) {
-		fprintf(stdout,"\tRessource fork there!\n");
+	if (!unlink(temp) && !Quiet) {
+		fprintf(stdout,"\tResource fork there!\n");
 	}
 fin:
 	FAIL (FPDelete(Conn, vol,  dir , file))
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test49");
-
+	exit_test("FPOpenFork:test49: open read-write file without resource fork in a read-write folder");
 }
 
 /* ------------------------- */
@@ -452,8 +445,6 @@ DSI *dsi = &Conn->dsi;
 unsigned int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test152: Error when no write access to .AppleDouble\n");
 
 	if ((!Mac && !Path)) {
 		test_skipped(T_MAC_PATH);
@@ -485,7 +476,7 @@ unsigned int ret;
 	}
 	delete_ro_adouble(vol, dir, file);
 test_exit:
-	exit_test("test152");
+	exit_test("FPOpenFork:test152: Error when no write access to .AppleDouble");
 }
 
 /* ------------------------- */
@@ -497,8 +488,6 @@ int fork;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test153: open data fork without ressource fork\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -527,7 +516,7 @@ uint16_t vol = VolID;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test153");
+	exit_test("FPOpenFork:test153: open data fork without ressource fork");
 }
 
 /* ------------------------- */
@@ -539,8 +528,6 @@ STATIC void test157()
     uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test157: open not existing ressource fork read-only\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -570,7 +557,7 @@ STATIC void test157()
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test157");
+	exit_test("FPOpenFork:test157: open not existing ressource fork read-only");
 }
 
 /* ------------------------- */
@@ -584,8 +571,6 @@ char *file  = "t156 test.pdf";
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test156: Open data fork with no write access to .AppleDouble\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -616,7 +601,7 @@ uint16_t vol = VolID;
 fin:
 	delete_ro_adouble(vol, dir, file);
 test_exit:
-	exit_test("test156");
+	exit_test("FPOpenFork:test156: Open data fork with no write access to .AppleDouble");
 }
 
 /* ------------------------- */
@@ -629,8 +614,6 @@ uint16_t vol = VolID;
 int fd;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test321: Bogus (empty) resource fork\n");
 
 	if ((!Mac && !Path)) {
 		test_skipped(T_MAC_PATH);
@@ -650,22 +633,30 @@ int fd;
 	if (!Mac) {
 		sprintf(temp,"%s/%s", Path, file);
 		if (chmod(temp, 0444) < 0) {
-			fprintf(stdout,"\tFAILED unable to chmod %s :%s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to chmod %s :%s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 			goto fin;
 		}
 		sprintf(temp,"%s/.AppleDouble/%s", Path, file);
-		fprintf(stdout,"unlink %s \n", temp);
+		if (!Quiet) {
+			fprintf(stdout,"unlink %s \n", temp);
+		}
 		unlink(temp);
 		fd = open(temp, O_RDWR | O_CREAT, 0666);
 		if (fd < 0) {
-			fprintf(stdout,"\tFAILED unable to create %s :%s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to create %s :%s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 			goto fin;
 		}
 		close(fd);
 		if (chmod(temp, 0444) < 0) {
-			fprintf(stdout,"\tFAILED unable to chmod %s :%s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to chmod %s :%s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 			goto fin;
 		}
@@ -691,7 +682,7 @@ int fd;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, file))
 test_exit:
-	exit_test("test321");
+	exit_test("FPOpenFork:test321: Bogus (empty) resource fork");
 }
 
 /* --------------------- */
@@ -708,8 +699,6 @@ uint16_t bitmap;
 int fd;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRead:test372: no crlf convertion for TEXT file\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -751,24 +740,32 @@ int fd;
 		goto fin1;
 	}
 	if (memcmp(data, "test\r", 5)) {
-		fprintf(stdout, "\tFAILED wrote \"test\\r\" get \"%s\"\n", data);
+		if (!Quiet) {
+			fprintf(stdout, "\tFAILED wrote \"test\\r\" get \"%s\"\n", data);
+		}
 	    failed_nomsg();
 	}
 	if (!Mac) {
 		sprintf(temp,"%s/%s", Path, name);
 		fd = open(temp, O_RDWR , 0666);
 		if (fd < 0) {
-			fprintf(stdout,"\tFAILED unable to open %s :%s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to open %s :%s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 			goto fin1;
 		}
 		if (read(fd, data, 5) != 5) {
-			fprintf(stdout,"\tFAILED unable to read data:%s\n", strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to read data:%s\n", strerror(errno));
+			}
 			failed_nomsg();
 		}
 		if (memcmp(data, "test\r", 5)) {
-		    fprintf(stdout, "\tFAILED not \"test\\r\" get 0x%x 0x%x 0x%x 0x%x 0x%x\n",
-		    data[0],data[1],data[2],data[3],data[4]);
+			if (!Quiet) {
+				fprintf(stdout, "\tFAILED not \"test\\r\" get 0x%x 0x%x 0x%x 0x%x 0x%x\n",
+				data[0],data[1],data[2],data[3],data[4]);
+			}
 		    failed_nomsg();
 		}
 		close(fd);
@@ -779,7 +776,7 @@ fin1:
 fin:
 	FPDelete(Conn, vol,  DIRDID_ROOT , name);
 test_exit:
-	exit_test("test372");
+	exit_test("FPRead:test372: no crlf convertion for TEXT file");
 }
 
 /* -------------------------
@@ -803,8 +800,6 @@ uint16_t bitmap;
 int fd;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRead:test387: crlf convertion for TEXT file\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -846,24 +841,32 @@ int fd;
 		goto fin1;
 	}
 	if (memcmp(data, "test\r", 5)) {
-		fprintf(stdout, "\tFAILED wrote \"test\\r\" get \"%s\"\n", data);
+		if (!Quiet) {
+			fprintf(stdout, "\tFAILED wrote \"test\\r\" get \"%s\"\n", data);
+		}
 	    failed_nomsg();
 	}
 	if (!Mac) {
 		sprintf(temp,"%s/%s", Path, name);
 		fd = open(temp, O_RDWR , 0666);
 		if (fd < 0) {
-			fprintf(stdout,"\tFAILED unable to open %s :%s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to open %s :%s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 			goto fin1;
 		}
 		if (read(fd, data, 5) != 5) {
-			fprintf(stdout,"\tFAILED unable to read data:%s\n", strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to read data:%s\n", strerror(errno));
+			}
 			failed_nomsg();
 		}
 		if (memcmp(data, "test\n", 5)) {
-		    fprintf(stdout, "\tFAILED not \"test\\n\" get 0x%x 0x%x 0x%x 0x%x 0x%x\n",
-		    data[0],data[1],data[2],data[3],data[4]);
+			if (!Quiet) {
+				fprintf(stdout, "\tFAILED not \"test\\n\" get 0x%x 0x%x 0x%x 0x%x 0x%x\n",
+				data[0],data[1],data[2],data[3],data[4]);
+			}
 		    failed_nomsg();
 		}
 		close(fd);
@@ -874,7 +877,7 @@ fin1:
 fin:
 	FPDelete(Conn, vol,  DIRDID_ROOT , name);
 test_exit:
-	exit_test("test387");
+	exit_test("FPRead:test387: crlf convertion for TEXT file");
 }
 
 /* --------------------- */
@@ -891,8 +894,6 @@ uint16_t bitmap;
 int fd;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRead:test388: crlf convertion for TEXT file (not default type)\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -934,24 +935,32 @@ int fd;
 		goto fin1;
 	}
 	if (memcmp(data, "test\r", 5)) {
-		fprintf(stdout, "\tFAILED wrote \"test\\r\" get \"%s\"\n", data);
+		if (!Quiet) {
+			fprintf(stdout, "\tFAILED wrote \"test\\r\" get \"%s\"\n", data);
+		}
 	    failed_nomsg();
 	}
 	if (!Mac) {
 		sprintf(temp,"%s/%s", Path, name);
 		fd = open(temp, O_RDWR , 0666);
 		if (fd < 0) {
-			fprintf(stdout,"\tFAILED unable to open %s :%s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to open %s :%s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 			goto fin1;
 		}
 		if (read(fd, data, 5) != 5) {
-			fprintf(stdout,"\tFAILED unable to read data:%s\n", strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to read data:%s\n", strerror(errno));
+			}
 			failed_nomsg();
 		}
 		if (memcmp(data, "test\n", 5)) {
-		    fprintf(stdout, "\tFAILED not \"test\\n\" get 0x%x 0x%x 0x%x 0x%x 0x%x\n",
-		    data[0],data[1],data[2],data[3],data[4]);
+			if (!Quiet) {
+				fprintf(stdout, "\tFAILED not \"test\\n\" get 0x%x 0x%x 0x%x 0x%x 0x%x\n",
+				data[0],data[1],data[2],data[3],data[4]);
+			}
 		    failed_nomsg();
 		}
 		close(fd);
@@ -962,7 +971,7 @@ fin1:
 fin:
 	FPDelete(Conn, vol,  DIRDID_ROOT , name);
 test_exit:
-	exit_test("test388");
+	exit_test("FPRead:test388: crlf convertion for TEXT file (not default type)");
 }
 
 /* --------------------- */
@@ -979,8 +988,6 @@ uint16_t bitmap;
 int fd;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPRead:test392: no crlf convertion for no TEXT file\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -1022,24 +1029,32 @@ int fd;
 		goto fin1;
 	}
 	if (memcmp(data, "test\r", 5)) {
-		fprintf(stdout, "\tFAILED wrote \"test\\r\" get \"%s\"\n", data);
+		if (!Quiet) {
+			fprintf(stdout, "\tFAILED wrote \"test\\r\" get \"%s\"\n", data);
+		}
 	    failed_nomsg();
 	}
 	if (!Mac) {
 		sprintf(temp,"%s/%s", Path, name);
 		fd = open(temp, O_RDWR , 0666);
 		if (fd < 0) {
-			fprintf(stdout,"\tFAILED unable to open %s :%s\n", temp, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to open %s :%s\n", temp, strerror(errno));
+			}
 			failed_nomsg();
 			goto fin1;
 		}
 		if (read(fd, data, 5) != 5) {
-			fprintf(stdout,"\tFAILED unable to read data:%s\n", strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to read data:%s\n", strerror(errno));
+			}
 			failed_nomsg();
 		}
 		if (memcmp(data, "test\r", 5)) {
-		    fprintf(stdout, "\tFAILED not \"test\\r\" get 0x%x 0x%x 0x%x 0x%x 0x%x\n",
-		    data[0],data[1],data[2],data[3],data[4]);
+			if (!Quiet) {
+				fprintf(stdout, "\tFAILED not \"test\\r\" get 0x%x 0x%x 0x%x 0x%x 0x%x\n",
+				data[0],data[1],data[2],data[3],data[4]);
+			}
 		    failed_nomsg();
 		}
 		close(fd);
@@ -1050,7 +1065,7 @@ fin1:
 fin:
 	FPDelete(Conn, vol,  DIRDID_ROOT , name);
 test_exit:
-	exit_test("test392");
+	exit_test("FPRead:test392: no crlf convertion for no TEXT file");
 }
 
 /* ------------------------- */
@@ -1064,8 +1079,6 @@ uint16_t vol = VolID;
 int dir;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test411: open read-only a file without ressource fork\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -1095,7 +1108,9 @@ int dir;
 	FAIL (FPCloseFork(Conn,fork))
 
     if (!Mac && (delete_unix_md(Path, name, file) == 0)) {
-		fprintf(stdout,"\tFAILED Ressource fork there!\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED Ressource fork there!\n");
+		}
 		failed_nomsg();
 	}
 
@@ -1103,7 +1118,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir , file))
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test411");
+	exit_test("FPOpenFork:test411: open read-only a file without ressource fork");
 
 }
 
@@ -1121,8 +1136,6 @@ uint16_t vol = VolID;
 int dir;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test415: don't set the name again in the resource fork if file open twice\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -1169,7 +1182,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir , file))
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("test415");
+	exit_test("FPOpenFork:test415: don't set the name again in the resource fork if file open twice");
 }
 
 /* ------------------------- */
@@ -1187,8 +1200,6 @@ STATIC void test236()
     int  ofs =  3 * sizeof( uint16_t );
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test236: symlink attack: try reading /etc/passwd\n");
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);
@@ -1257,7 +1268,7 @@ fin:
     FAIL (unlink_unix_file(Path, name1, name2))
 	FAIL (testdir && FPDelete(Conn, vol,  testdir, ""))
 test_exit:
-	exit_test("test236");
+	exit_test("FPOpenFork:test236: symlink attack: try reading /etc/passwd");
 }
 
 /* ------------------------- */
@@ -1275,8 +1286,6 @@ STATIC void test237()
     int  ofs =  3 * sizeof( uint16_t );
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test237: symlink reading and attack: try reading /etc/passwd\n");
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);
@@ -1323,7 +1332,9 @@ STATIC void test237()
 	}
 
     Data[11] = 0;
-    fprintf(stdout, "readlink: %s\n", Data);
+	if (!Quiet) {
+		fprintf(stdout, "readlink: %s\n", Data);
+	}
 
     if (strcmp(Data, name4) != 0) {
 		failed();
@@ -1335,7 +1346,7 @@ fin:
     FAIL (unlink_unix_file(Path, name1, name2))
 	FAIL (testdir && FPDelete(Conn, vol,  testdir, ""))
 test_exit:
-	exit_test("test237");
+	exit_test("FPOpenFork:test237: symlink reading and attack: try reading /etc/passwd");
 }
 
 /* ------------------------- */
@@ -1353,8 +1364,6 @@ STATIC void test238()
     int  ofs =  3 * sizeof( uint16_t );
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test238: symlink reading with short reqcount\n");
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);
@@ -1409,7 +1418,9 @@ STATIC void test238()
 	}
 
     Data[strlen(verylonglinkname)] = 0;
-    fprintf(stdout, "readlink: %s\n", Data);
+	if (!Quiet) {
+		fprintf(stdout, "readlink: %s\n", Data);
+	}
 
     if (strcmp(Data, verylonglinkname) != 0) {
 		failed();
@@ -1422,7 +1433,7 @@ fin:
 	FAIL (testdir && FPDelete(Conn, vol,  testdir, verylonglinkname))
 	FAIL (testdir && FPDelete(Conn, vol,  testdir, ""))
 test_exit:
-	exit_test("test238");
+	exit_test("FPOpenFork:test238: symlink reading with short reqcount");
 }
 
 /* ------------------------- */
@@ -1438,8 +1449,6 @@ STATIC void test431()
     DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPOpenFork:test431: check AppleDouble conversion from v2 to ea\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -1448,7 +1457,9 @@ STATIC void test431()
 
     /* touch resource_fork_conversion_test base file */
     if (snprintf(cmd, sizeof(cmd), "touch %s/resource_fork_conversion_test", Path) > sizeof(cmd)) {
-        fprintf(stdout,"FPOpenFork:test431: path too long\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test431: path too long\n");
+	}
 		failed();
 		goto fin;
     }
@@ -1459,7 +1470,9 @@ STATIC void test431()
 
     /* Create .AppleDouble directory */
     if (snprintf(cmd, sizeof(cmd), "%s/.AppleDouble", Path) > sizeof(cmd)) {
-        fprintf(stdout,"FPOpenFork:test431: path too long\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test431: path too long\n");
+	}
 		failed();
 		goto fin;
     }
@@ -1470,7 +1483,9 @@ STATIC void test431()
 
     /* Copy resource fork */
     if (snprintf(cmd, sizeof(cmd), "cp data/resource_fork_conversion_test %s/.AppleDouble/", Path) > sizeof(cmd)) {
-        fprintf(stdout,"FPOpenFork:test431: path too long\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test431: path too long\n");
+	}
 		failed();
 		goto fin;
     }
@@ -1495,7 +1510,9 @@ STATIC void test431()
 	FAIL (FPRead(Conn, fork1, 0, strlen(teststring), Data))
 
     if (memcmp(Data, teststring, strlen(teststring)) != 0) {
-        fprintf(stdout,"FPOpenFork:test431: conversion failed\n");
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test431: conversion failed\n");
+	}
 		failed();
 		goto fin;
     }
@@ -1506,7 +1523,9 @@ STATIC void test431()
 
     afp_filedir_unpack(&filedir, dsi->data + 6, (1<<FILPBIT_FINFO), 0);
     if (memcmp(filedir.finder_info, "TEXTTEST", 8)) {
-        fprintf(stdout,"FAILED - bad type/creator\n");
+	if (!Quiet) {
+		fprintf(stdout,"FAILED - bad type/creator\n");
+	}
         failed_nomsg();
     }
 
@@ -1515,7 +1534,7 @@ fin:
         FPCloseFork(Conn, fork1);
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test431");
+	exit_test("FPOpenFork:test431: check AppleDouble conversion from v2 to ea");
 }
 
 
@@ -1524,6 +1543,7 @@ void FPOpenFork_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPOpenFork page 230\n");
+    fprintf(stdout,"-------------------\n");
     test3();
     test4();
     test7();

--- a/test/testsuite/T2_FPOpenFork.c
+++ b/test/testsuite/T2_FPOpenFork.c
@@ -1450,6 +1450,12 @@ STATIC void test431()
 
 	ENTER_TEST
 
+	// FIXME: failing; might require manually moving data file to
+	// data/resource_fork_conversion_test
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;
@@ -1562,10 +1568,5 @@ void FPOpenFork_test()
     test236();
     test237();
     test238();
-// FIXME: test seems to require manually moving data file to
-// data/resource_fork_conversion_test
-// Disabling for now.
-#if 0
     test431();
-#endif
 }

--- a/test/testsuite/T2_FPOpenFork.c
+++ b/test/testsuite/T2_FPOpenFork.c
@@ -19,7 +19,7 @@ STATIC void test3()
     int fork1, fork2;
     uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Quiet) {
 		fprintf(stdout,"FPOpenFork:test3: Checks data fork / adouble metadata refcounting\n");
@@ -76,7 +76,7 @@ STATIC void test4()
     int fork1, fork2;
     uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Quiet) {
 		fprintf(stdout,"FPOpenFork:test4: Checks reso fork / adouble metadata refcounting\n");
@@ -135,7 +135,7 @@ STATIC void test7()
     int fork1, fork2;
     uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Quiet) {
 		fprintf(stdout,"FPOpenFork:test7: Checks fork / adouble metadata refcounting\n");
@@ -194,7 +194,7 @@ uint16_t bitmap = 0;
 int fork = 0, fork1 = 0;
 int dir;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -377,7 +377,7 @@ int fork, fork1;
 uint16_t vol = VolID;
 int dir;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -444,7 +444,7 @@ uint16_t vol = VolID;
 DSI *dsi = &Conn->dsi;
 unsigned int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if ((!Mac && !Path)) {
 		test_skipped(T_MAC_PATH);
@@ -487,7 +487,7 @@ uint16_t bitmap = 0;
 int fork;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -527,7 +527,7 @@ STATIC void test157()
     int fork;
     uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -570,7 +570,7 @@ char *name  = "t156 ro AppleDouble";
 char *file  = "t156 test.pdf";
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -613,7 +613,7 @@ char *file  = "t321 test.txt";
 uint16_t vol = VolID;
 int fd;
 
-	enter_test();
+	ENTER_TEST
 
 	if ((!Mac && !Path)) {
 		test_skipped(T_MAC_PATH);
@@ -698,7 +698,7 @@ DSI *dsi = &Conn->dsi;
 uint16_t bitmap;
 int fd;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -799,7 +799,7 @@ DSI *dsi = &Conn->dsi;
 uint16_t bitmap;
 int fd;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -893,7 +893,7 @@ DSI *dsi = &Conn->dsi;
 uint16_t bitmap;
 int fd;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -987,7 +987,7 @@ DSI *dsi = &Conn->dsi;
 uint16_t bitmap;
 int fd;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -1078,7 +1078,7 @@ int fork;
 uint16_t vol = VolID;
 int dir;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -1135,7 +1135,7 @@ int fork1;
 uint16_t vol = VolID;
 int dir;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -1199,7 +1199,7 @@ STATIC void test236()
     DSI *dsi = &Conn->dsi;
     int  ofs =  3 * sizeof( uint16_t );
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);
@@ -1285,7 +1285,7 @@ STATIC void test237()
     DSI *dsi = &Conn->dsi;
     int  ofs =  3 * sizeof( uint16_t );
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);
@@ -1363,7 +1363,7 @@ STATIC void test238()
     DSI *dsi = &Conn->dsi;
     int  ofs =  3 * sizeof( uint16_t );
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);
@@ -1448,7 +1448,7 @@ STATIC void test431()
     struct afp_filedir_parms filedir = { 0 };
     DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);

--- a/test/testsuite/T2_FPRead.c
+++ b/test/testsuite/T2_FPRead.c
@@ -16,8 +16,6 @@ STATIC void test109()
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPread:test109: read resource fork that is ro (0400), inaccessible (0000) or without metadata EA\n");
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);
@@ -113,7 +111,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 
 test_exit:
-	exit_test("test109");
+	exit_test("FPread:test109: read resource fork that is ro (0400), inaccessible (0000) or without metadata EA");
 }
 
 /* ----------- */
@@ -121,5 +119,6 @@ void FPRead_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPRead\n");
+    fprintf(stdout,"-------------------\n");
 	test109();
 }

--- a/test/testsuite/T2_FPRead.c
+++ b/test/testsuite/T2_FPRead.c
@@ -22,6 +22,11 @@ STATIC void test109()
 		goto test_exit;
 	}
 
+	if (adouble == AD_EA) {
+		test_skipped(T_ADV2);
+		goto test_exit;
+	}
+
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
 		goto test_exit;
@@ -45,7 +50,6 @@ STATIC void test109()
     /* ----------------- */
     if (chmod_unix_rfork(Path, "", name, 0400) != 0) {
         failed();
-        exit(1);
         goto fin;
     }
 	fork = FPOpenFork(Conn, vol, OPENFORK_RSCS , bitmap ,DIRDID_ROOT, name, OPENACC_RD);

--- a/test/testsuite/T2_FPRead.c
+++ b/test/testsuite/T2_FPRead.c
@@ -15,7 +15,7 @@ STATIC void test109()
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);

--- a/test/testsuite/T2_FPResolveID.c
+++ b/test/testsuite/T2_FPResolveID.c
@@ -21,7 +21,7 @@ uint16_t bitmap = (1<<FILPBIT_FNUM );
 struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -86,7 +86,7 @@ struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -156,7 +156,7 @@ uint16_t bitmap = (1<<FILPBIT_FNUM );
 struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -222,7 +222,7 @@ struct afp_filedir_parms filedir;
 int fid = 0;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -372,7 +372,7 @@ int fid = 0;
 int fork = 0;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -493,7 +493,7 @@ uint16_t bitmap = (1<<FILPBIT_FNUM );
 struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);
@@ -548,7 +548,7 @@ struct afp_filedir_parms filedir;
 int fid = 0;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -649,7 +649,7 @@ struct afp_filedir_parms filedir;
 int fid = 0;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -757,7 +757,7 @@ int fid1 = 0, fid2 = 0;
 int nfid1 = 0, nfid2 = 0;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -961,7 +961,7 @@ struct afp_filedir_parms filedir;
 int fid1 = 0, fid2;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -1059,7 +1059,7 @@ int fid1 = 0, fid2;
 int nfid1 = 0, nfid2 = 0;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);

--- a/test/testsuite/T2_FPResolveID.c
+++ b/test/testsuite/T2_FPResolveID.c
@@ -22,8 +22,6 @@ struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test129: Resolve ID \n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -49,13 +47,17 @@ DSI *dsi = &Conn->dsi;
     if (adouble == AD_V2) {
         sprintf(temp1, "%s/%s/.AppleDouble/%s", Path, name1, name);
         if (unlink(temp1) <0) {
-            fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		}
             failed_nomsg();
         }
     }
 	sprintf(temp1, "%s/%s/%s", Path, name1, name);
 	if (unlink(temp1) <0) {
-		fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		}
 		failed_nomsg();
 	}
 
@@ -68,7 +70,7 @@ DSI *dsi = &Conn->dsi;
 	vol  = FPOpenVol(Conn, Vol);
 	FAIL (ntohl(AFPERR_NOID ) != FPResolveID(Conn, vol, filedir.did, bitmap))
 test_exit:
-	exit_test("test129");
+	exit_test("FPResolveID:test129: Resolve ID");
 }
 
 /* -------------------------- */
@@ -85,8 +87,6 @@ DSI *dsi = &Conn->dsi;
 int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test130: Delete ID \n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -114,13 +114,17 @@ int ret;
     if (adouble == AD_V2) {
         sprintf(temp1, "%s/%s/.AppleDouble/%s", Path, name1, name);
         if (unlink(temp1) <0) {
-            fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		}
             failed_nomsg();
         }
     }
 	sprintf(temp1, "%s/%s/%s", Path, name1, name);
 	if (unlink(temp1) <0) {
-		fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		}
 		failed_nomsg();
 	}
 
@@ -137,7 +141,7 @@ int ret;
 	}
 
 test_exit:
-	exit_test("test130");
+	exit_test("FPResolveID:test130: Delete ID");
 }
 
 /* -------------------------- */
@@ -153,8 +157,6 @@ struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test131: Resolve ID \n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -179,13 +181,17 @@ DSI *dsi = &Conn->dsi;
     if (adouble == AD_V2) {
         sprintf(temp1, "%s/%s/.AppleDouble/%s", Path, name1, name);
         if (unlink(temp1) <0) {
-            fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		}
             failed_nomsg();
         }
     }
 	sprintf(temp1, "%s/%s/%s", Path, name1, name);
 	if (unlink(temp1) <0) {
-		fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		}
 		failed_nomsg();
 	}
 
@@ -198,7 +204,7 @@ DSI *dsi = &Conn->dsi;
 	vol  = FPOpenVol(Conn, Vol);
 	FAIL (ntohl(AFPERR_NOID ) != FPDeleteID(Conn, vol, filedir.did))
 test_exit:
-	exit_test("test131");
+	exit_test("FPResolveID:test131: Resolve ID");
 }
 
 
@@ -217,8 +223,6 @@ int fid = 0;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test331: Resolve ID file modified with local fs\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -249,18 +253,26 @@ DSI *dsi = &Conn->dsi;
 	if (!Mac) {
 		sprintf(temp, "%s/%s/%s", Path, name1, name);
 		sprintf(temp1,"%s/%s/%s", Path, name1, name2);
-		fprintf(stdout,"rename %s %s\n", temp, temp1);
+		if (!Quiet) {
+			fprintf(stdout,"rename %s %s\n", temp, temp1);
+		}
 		if (rename(temp, temp1) < 0) {
-			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			}
 			failed_nomsg();
 		}
 
         if (adouble == AD_V2) {
             sprintf(temp, "%s/%s/.AppleDouble/%s", Path, name1, name);
             sprintf(temp1,"%s/%s/.AppleDouble/%s", Path, name1, name2);
-            fprintf(stdout,"rename %s %s\n", temp, temp1);
+		if (!Quiet) {
+			fprintf(stdout,"rename %s %s\n", temp, temp1);
+		}
             if (rename(temp, temp1) < 0) {
-                fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		}
                 failed_nomsg();
             }
         }
@@ -275,7 +287,9 @@ DSI *dsi = &Conn->dsi;
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 		if (fid != filedir.did) {
-			fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
+			}
 			failed_nomsg();
 
 		}
@@ -289,7 +303,7 @@ fin:
 	FPDelete(Conn, vol,  dir, name);
 	FAIL (FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test331");
+	exit_test("FPResolveID:test331: Resolve ID file modified with local fs");
 
 }
 
@@ -305,8 +319,10 @@ static int get_fs_lock(char *folder, char *file)
     else
         sprintf(temp, "%s/%s/%s", Path, folder, file);
 
-	fprintf(stdout," \n---------------------\n");
-	fprintf(stdout, "open(\"%s\", O_RDWR)\n", temp);
+	if (!Quiet) {
+		fprintf(stdout," \n---------------------\n");
+		fprintf(stdout, "open(\"%s\", O_RDWR)\n", temp);
+	}
 	fd = open(temp, O_RDWR, 0);
 	if (fd >= 0) {
 		lock.l_start = 0;		/* after meta data */
@@ -314,12 +330,16 @@ static int get_fs_lock(char *folder, char *file)
 	    lock.l_whence = SEEK_SET;
     	lock.l_len = 0;
 
-		fprintf(stdout, "fcntl(1024)\n");
+		if (!Quiet) {
+			fprintf(stdout, "fcntl(1024)\n");
+		}
     	if ((ret = fcntl(fd, F_SETLK, &lock)) >= 0 || (errno != EACCES && errno != EAGAIN)) {
     		if (!ret >= 0)
     	    	errno = 0;
-    		perror("fcntl ");
+		if (!Quiet) {
+			perror("fcntl ");
 			fprintf(stdout,"\tFAILED\n");
+		}
 			failed_nomsg();
     	}
     	fcntl(fd, F_UNLCK, &lock);
@@ -327,8 +347,10 @@ static int get_fs_lock(char *folder, char *file)
     	return 0;
     }
     else {
-    	perror("open ");
+	if (!Quiet) {
+		perror("open ");
 		fprintf(stdout,"\tFAILED\n");
+	}
 		failed_nomsg();
     }
     return -1;
@@ -351,8 +373,6 @@ int fork = 0;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test360: Resolve ID file modified with local fs and a file is opened\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -399,18 +419,26 @@ DSI *dsi = &Conn->dsi;
 	if (!Mac) {
 		sprintf(temp, "%s/%s/%s", Path, name1, name);
 		sprintf(temp1,"%s/%s/%s", Path, name1, name2);
-		fprintf(stdout,"rename %s %s\n", temp, temp1);
+		if (!Quiet) {
+			fprintf(stdout,"rename %s %s\n", temp, temp1);
+		}
 		if (rename(temp, temp1) < 0) {
-			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			}
 			failed_nomsg();
 		}
 
         if (adouble == AD_V2) {
             sprintf(temp, "%s/%s/.AppleDouble/%s", Path, name1, name);
             sprintf(temp1,"%s/%s/.AppleDouble/%s", Path, name1, name2);
-            fprintf(stdout,"rename %s %s\n", temp, temp1);
+		if (!Quiet) {
+			fprintf(stdout,"rename %s %s\n", temp, temp1);
+		}
             if (rename(temp, temp1) < 0) {
-                fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		}
                 failed_nomsg();
             }
             if (get_fs_lock(name1, name3) < 0) {
@@ -428,7 +456,9 @@ DSI *dsi = &Conn->dsi;
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 		if (fid != filedir.did) {
-			fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
+			}
 			failed_nomsg();
 
 		}
@@ -449,7 +479,7 @@ fin:
 	FPDelete(Conn, vol,  dir, name);
 	FAIL (FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test360");
+	exit_test("FPResolveID:test360: Resolve ID file modified with local fs and a file is opened");
 
 }
 
@@ -464,8 +494,6 @@ struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test397: Resolve ID file deleted local fs \n");
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);
@@ -486,20 +514,24 @@ DSI *dsi = &Conn->dsi;
     if (adouble == AD_V2) {
         sprintf(temp1, "%s/.AppleDouble/%s", Path, name);
         if (unlink(temp1) <0) {
-            fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		}
             failed_nomsg();
         }
     }
 	sprintf(temp1, "%s/%s", Path, name);
 	if (unlink(temp1) <0) {
-		fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unlink %s %s\n", temp, strerror(errno));
+		}
 		failed_nomsg();
 	}
 	FAIL (ntohl(AFPERR_NOID ) != FPResolveID(Conn, vol, filedir.did, bitmap))
 	FAIL (ntohl(AFPERR_NOID ) != FPResolveID(Conn, vol, filedir.did, bitmap))
 
 test_exit:
-	exit_test("test397");
+	exit_test("FPResolveID:test397: Resolve ID file deleted local fs");
 }
 
 /* -------------------------- */
@@ -517,8 +549,6 @@ int fid = 0;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test412: Resolve ID file modified with local fs\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -550,9 +580,13 @@ DSI *dsi = &Conn->dsi;
 	if (!Mac) {
 		sprintf(temp, "%s/%s", Path, ndir1);
 		sprintf(temp1,"%s/%s/%s", Path, ndir2, ndir1);
-		fprintf(stdout,"rename %s %s\n", temp, temp1);
+		if (!Quiet) {
+			fprintf(stdout,"rename %s %s\n", temp, temp1);
+		}
 		if (rename(temp, temp1) < 0) {
-			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			}
 			failed_nomsg();
 		}
 	}
@@ -581,7 +615,9 @@ DSI *dsi = &Conn->dsi;
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 		if (fid != filedir.did) {
-			fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
+			}
 			failed_nomsg();
 
 		}
@@ -595,7 +631,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir1, ""))
 	FAIL (FPDelete(Conn, vol,  dir2, ""))
 test_exit:
-	exit_test("test412");
+	exit_test("FPResolveID:test412: Resolve ID file modified with local fs");
 
 }
 
@@ -614,8 +650,6 @@ int fid = 0;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test413: Resolve ID file modified with local fs\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -651,18 +685,26 @@ DSI *dsi = &Conn->dsi;
 	if (!Mac) {
 		sprintf(temp, "%s/%s/%s", Path, name1, name);
 		sprintf(temp1,"%s/%s/%s", Path, name2, name);
-		fprintf(stdout,"rename %s %s\n", temp, temp1);
+		if (!Quiet) {
+			fprintf(stdout,"rename %s %s\n", temp, temp1);
+		}
 		if (rename(temp, temp1) < 0) {
-			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			}
 			failed_nomsg();
 		}
 
         if (adouble == AD_V2) {
             sprintf(temp, "%s/%s/.AppleDouble/%s", Path, name1, name);
             sprintf(temp1,"%s/%s/.AppleDouble/%s", Path, name2, name);
-            fprintf(stdout,"rename %s %s\n", temp, temp1);
+		if (!Quiet) {
+			fprintf(stdout,"rename %s %s\n", temp, temp1);
+		}
             if (rename(temp, temp1) < 0) {
-                fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		}
                 failed_nomsg();
             }
         }
@@ -678,9 +720,10 @@ DSI *dsi = &Conn->dsi;
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 		if (fid != filedir.did) {
-			fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
+			}
 			failed_nomsg();
-
 		}
 		else {
 			FAIL (FPResolveID(Conn, vol, filedir.did, bitmap))
@@ -693,7 +736,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir, ""))
 	FAIL (FPDelete(Conn, vol,  dir2, ""))
 test_exit:
-	exit_test("test413");
+	exit_test("FPResolveID:test413: Resolve ID file modified with local fs");
 
 }
 
@@ -715,8 +758,6 @@ int nfid1 = 0, nfid2 = 0;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test417: Resolve ID files swapped by local fs\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -742,7 +783,9 @@ DSI *dsi = &Conn->dsi;
 	FAIL (FPResolveID(Conn, vol, fid1, bitmap))
 	afp_filedir_unpack(&filedir, dsi->data +ofs_res, bitmap, 0);
 	if (fid1 != filedir.did) {
-		fprintf(stdout,"\tFAILED FPGetFileDirParams, FPResolveID id differ %x %x\n", fid1, filedir.did);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED FPGetFileDirParams, FPResolveID id differ %x %x\n", fid1, filedir.did);
+		}
 		failed_nomsg();
 	}
 
@@ -760,58 +803,84 @@ DSI *dsi = &Conn->dsi;
 	FAIL (FPResolveID(Conn, vol, fid2, bitmap))
 	afp_filedir_unpack(&filedir, dsi->data +ofs_res, bitmap, 0);
 	if (fid2 != filedir.did) {
-		fprintf(stdout,"\tFAILED FPGetFileDirParams, FPResolveID id differ %x %x\n", fid2, filedir.did);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED FPGetFileDirParams, FPResolveID id differ %x %x\n", fid2, filedir.did);
+		}
 		failed_nomsg();
 	}
 
 	/* rename name1 --> tmp */
 	sprintf(temp, "%s/%s/%s", Path, dir1, name1);
 	sprintf(temp1,"%s/%s/tmp", Path, dir1);
-	fprintf(stdout,"rename %s %s\n", temp, temp1);
+	if (!Quiet) {
+		fprintf(stdout,"rename %s %s\n", temp, temp1);
+	}
 	if (rename(temp, temp1) < 0) {
-		fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		}
 		failed_nomsg();
 	}
 
 	sprintf(temp, "%s/%s/.AppleDouble/%s", Path, dir1, name1);
 	sprintf(temp1,"%s/%s/.AppleDouble/tmp", Path, dir1);
-	fprintf(stdout,"rename %s %s\n", temp, temp1);
+	if (!Quiet) {
+		fprintf(stdout,"rename %s %s\n", temp, temp1);
+	}
 	if (rename(temp, temp1) < 0) {
-		fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		}
 		failed_nomsg();
 	}
 
 	/* rename file2 to file1 */
 	sprintf(temp, "%s/%s/%s", Path, dir1, name2);
 	sprintf(temp1,"%s/%s/%s", Path, dir1, name1);
-	fprintf(stdout,"rename %s %s\n", temp, temp1);
+	if (!Quiet) {
+		fprintf(stdout,"rename %s %s\n", temp, temp1);
+	}
 	if (rename(temp, temp1) < 0) {
-		fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		}
 		failed_nomsg();
 	}
 
 	sprintf(temp, "%s/%s/.AppleDouble/%s", Path, dir1, name2);
 	sprintf(temp1,"%s/%s/.AppleDouble/%s", Path, dir1, name1);
-	fprintf(stdout,"rename %s %s\n", temp, temp1);
+	if (!Quiet) {
+		fprintf(stdout,"rename %s %s\n", temp, temp1);
+	}
 	if (rename(temp, temp1) < 0) {
-		fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		}
 		failed_nomsg();
 	}
 
 	/* rename tmp to file2 */
 	sprintf(temp, "%s/%s/%s", Path, dir1, name2);
 	sprintf(temp1,"%s/%s/tmp", Path, dir1);
-	fprintf(stdout,"rename %s %s\n", temp1, temp);
+	if (!Quiet) {
+		fprintf(stdout,"rename %s %s\n", temp1, temp);
+	}
 	if (rename(temp1, temp) < 0) {
-		fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp1, temp, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp1, temp, strerror(errno));
+		}
 		failed_nomsg();
 	}
 
 	sprintf(temp, "%s/%s/.AppleDouble/%s", Path, dir1, name2);
 	sprintf(temp1,"%s/%s/.AppleDouble/tmp", Path, dir1);
-	fprintf(stdout,"rename %s %s\n", temp1, temp);
+	if (!Quiet) {
+		fprintf(stdout,"rename %s %s\n", temp1, temp);
+	}
 	if (rename(temp1, temp) < 0) {
-		fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp1, temp, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp1, temp, strerror(errno));
+		}
 		failed_nomsg();
 	}
 
@@ -824,14 +893,18 @@ DSI *dsi = &Conn->dsi;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 	nfid1 = filedir.did;
 	if (fid2 != filedir.did) {
-		fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid2, filedir.did);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid2, filedir.did);
+		}
 		failed_nomsg();
 	}
 
 	FAIL (FPResolveID(Conn, vol, filedir.did, bitmap))
 	afp_filedir_unpack(&filedir, dsi->data +ofs_res, bitmap, 0);
 	if (nfid1 != filedir.did) {
-		fprintf(stdout,"\tFAILED FPGetFileDirParams, FPResolveID id differ %x %x\n", nfid1, filedir.did);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED FPGetFileDirParams, FPResolveID id differ %x %x\n", nfid1, filedir.did);
+		}
 		failed_nomsg();
 	}
 
@@ -844,26 +917,32 @@ DSI *dsi = &Conn->dsi;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 	nfid2 = filedir.did;
 	if (fid1 != filedir.did) {
-		fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid1, filedir.did);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid1, filedir.did);
+		}
 		failed_nomsg();
 	}
 
 	FAIL (FPResolveID(Conn, vol, filedir.did, bitmap))
 	afp_filedir_unpack(&filedir, dsi->data +ofs_res, bitmap, 0);
 	if (nfid2 != filedir.did) {
-		fprintf(stdout,"\tFAILED FPGetFileDirParams, FPResolveID id differ %x %x\n", nfid2, filedir.did);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED FPGetFileDirParams, FPResolveID id differ %x %x\n", nfid2, filedir.did);
+		}
 		failed_nomsg();
 	}
 
-	fprintf(stdout,"file %s old %x  new %x\n", name1, fid1, nfid1);
-	fprintf(stdout,"file %s old %x  new %x\n", name2, fid2, nfid2);
+	if (!Quiet) {
+		fprintf(stdout,"file %s old %x  new %x\n", name1, fid1, nfid1);
+		fprintf(stdout,"file %s old %x  new %x\n", name2, fid2, nfid2);
+	}
 
 fin:
 	FAIL (FPDelete(Conn, vol,  dir, name1))
 	FAIL (FPDelete(Conn, vol,  dir, name2))
 	FAIL (FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test417");
+	exit_test("FPResolveID:test417: Resolve ID files swapped by local fs");
 
 }
 
@@ -883,8 +962,6 @@ int fid1 = 0, fid2;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test418: Resolve ID files name swapped with AFP rename\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -937,7 +1014,9 @@ DSI *dsi = &Conn->dsi;
 	filedir.isdir = 0;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 	if (fid2 != filedir.did) {
-		fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid2, filedir.did);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid2, filedir.did);
+		}
 		failed_nomsg();
 	}
 	FAIL (FPResolveID(Conn, vol, filedir.did, bitmap))
@@ -950,7 +1029,9 @@ DSI *dsi = &Conn->dsi;
 	filedir.isdir = 0;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 	if (fid1 != filedir.did) {
-		fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid1, filedir.did);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid1, filedir.did);
+		}
 		failed_nomsg();
 	}
 	FAIL (FPResolveID(Conn, vol, filedir.did, bitmap))
@@ -960,7 +1041,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir, name2))
 	FAIL (FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test418");
+	exit_test("FPResolveID:test418: Resolve ID files name swapped with AFP rename");
 }
 
 /* -------------------------- */
@@ -979,8 +1060,6 @@ int nfid1 = 0, nfid2 = 0;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPResolveID:test419: Resolve ID files swapped by local fs but not their resource forks\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -1019,27 +1098,39 @@ DSI *dsi = &Conn->dsi;
 	/* rename name1 --> tmp */
 	sprintf(temp, "%s/%s/%s", Path, dir1, name1);
 	sprintf(temp1,"%s/%s/tmp", Path, dir1);
-	fprintf(stdout,"rename %s %s\n", temp, temp1);
+	if (!Quiet) {
+		fprintf(stdout,"rename %s %s\n", temp, temp1);
+	}
 	if (rename(temp, temp1) < 0) {
-		fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		}
 		failed_nomsg();
 	}
 
 	/* rename file2 to file1 */
 	sprintf(temp, "%s/%s/%s", Path, dir1, name2);
 	sprintf(temp1,"%s/%s/%s", Path, dir1, name1);
-	fprintf(stdout,"rename %s %s\n", temp, temp1);
+	if (!Quiet) {
+		fprintf(stdout,"rename %s %s\n", temp, temp1);
+	}
 	if (rename(temp, temp1) < 0) {
-		fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+		}
 		failed_nomsg();
 	}
 
 	/* rename tmp to file2 */
 	sprintf(temp, "%s/%s/%s", Path, dir1, name2);
 	sprintf(temp1,"%s/%s/tmp", Path, dir1);
-	fprintf(stdout,"rename %s %s\n", temp1, temp);
+	if (!Quiet) {
+		fprintf(stdout,"rename %s %s\n", temp1, temp);
+	}
 	if (rename(temp1, temp) < 0) {
-		fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp1, temp, strerror(errno));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp1, temp, strerror(errno));
+		}
 		failed_nomsg();
 	}
 
@@ -1052,7 +1143,9 @@ DSI *dsi = &Conn->dsi;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 	nfid1 = filedir.did;
 	if (fid2 != filedir.did) {
-		fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid2, filedir.did);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid2, filedir.did);
+		}
 		failed_nomsg();
 	}
 	FAIL (FPResolveID(Conn, vol, filedir.did, bitmap))
@@ -1066,20 +1159,24 @@ DSI *dsi = &Conn->dsi;
 	afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap, 0);
 	nfid2 = filedir.did;
 	if (fid1 != filedir.did) {
-		fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid1, filedir.did);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED FPGetFileDirParams id differ %x %x\n", fid1, filedir.did);
+		}
 		failed_nomsg();
 	}
 	FAIL (FPResolveID(Conn, vol, filedir.did, bitmap))
 
-	fprintf(stdout,"file %s old %x  new %x\n", name1, fid1, nfid1);
-	fprintf(stdout,"file %s old %x  new %x\n", name2, fid2, nfid2);
+	if (!Quiet) {
+		fprintf(stdout,"file %s old %x  new %x\n", name1, fid1, nfid1);
+		fprintf(stdout,"file %s old %x  new %x\n", name2, fid2, nfid2);
+	}
 
 fin:
 	FAIL (FPDelete(Conn, vol,  dir, name1))
 	FAIL (FPDelete(Conn, vol,  dir, name2))
 	FAIL (FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test419");
+	exit_test("FPResolveID:test419: Resolve ID files swapped by local fs but not their resource forks");
 }
 
 
@@ -1089,6 +1186,7 @@ void FPResolveID_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPResolveID page 252\n");
+    fprintf(stdout,"-------------------\n");
 	test129();
 	test130();
 	test131();

--- a/test/testsuite/T2_FPResolveID.c
+++ b/test/testsuite/T2_FPResolveID.c
@@ -1195,6 +1195,7 @@ void FPResolveID_test()
 	test397();
 	test412();
 	test413();
+// remove test417 and 419, should be moved in fail_spectest
 //	test417();
 	test418();
 //	test419();

--- a/test/testsuite/T2_FPSetDirParms.c
+++ b/test/testsuite/T2_FPSetDirParms.c
@@ -14,7 +14,7 @@ uint16_t bitmap = (1<<DIRPBIT_FINFO)| (1<<DIRPBIT_CDATE) | (1<<DIRPBIT_BDATE) | 
 uint16_t vol = VolID;
 DSI *dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);

--- a/test/testsuite/T2_FPSetDirParms.c
+++ b/test/testsuite/T2_FPSetDirParms.c
@@ -15,8 +15,6 @@ uint16_t vol = VolID;
 DSI *dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetDirParms:t121: test set dir setfilparam (create .AppleDouble)\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -46,7 +44,7 @@ DSI *dsi;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test121");
+	exit_test("FPSetDirParms:test121: test set dir setfilparam (create .AppleDouble)");
 }
 
 /* ----------- */
@@ -54,5 +52,6 @@ void FPSetDirParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPSetDirParms page 255\n");
+    fprintf(stdout,"-------------------\n");
     test121();
 }

--- a/test/testsuite/T2_FPSetFileParms.c
+++ b/test/testsuite/T2_FPSetFileParms.c
@@ -66,8 +66,6 @@ DSI *dsi = &Conn->dsi;
 unsigned ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileParms:test89: test set file setfilparam\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -100,7 +98,7 @@ unsigned ret;
 	}
 	delete_ro_adouble(vol, dir, file);
 test_exit:
-	exit_test("test89");
+	exit_test("FPSetFileParms:test89: test set file setfilparam");
 }
 
 /* ------------------------- */
@@ -115,8 +113,6 @@ uint16_t vol = VolID;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileParms:t120: test set file setfilparam (create .AppleDouble)\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -142,7 +138,7 @@ DSI *dsi = &Conn->dsi;
 
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("test120");
+	exit_test("FPSetFileParms:test120: test set file setfilparam (create .AppleDouble)");
 }
 
 /* ------------------------- */
@@ -162,8 +158,6 @@ STATIC void test426()
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetFileParms:t426: Create a dangling symlink\n");
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);
@@ -178,7 +172,9 @@ STATIC void test426()
     /* Check if volume uses option 'followsymlinks' */
     sprintf(temp, "%s/%s", Path, name);
     if (lstat(temp, &st)) {
-        fprintf(stdout,"\tFAILED stat( %s ) %s\n", temp, strerror(errno));
+	if (!Quiet) {
+		fprintf(stdout,"\tFAILED stat( %s ) %s\n", temp, strerror(errno));
+	}
         failed_nomsg();
     }
     if (!S_ISLNK(st.st_mode)) {
@@ -210,7 +206,7 @@ test_exit:
 	    FPCloseFork(Conn,fork);
     }
     FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
-	exit_test("test426");
+	exit_test("FPSetFileParms:test426: Create a dangling symlink");
 }
 
 /* ----------- */
@@ -218,6 +214,7 @@ void FPSetFileParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPSetFileParms page 262\n");
+    fprintf(stdout,"-------------------\n");
     test89();
     test120();
 // FIXME: test stalls indefinitely

--- a/test/testsuite/T2_FPSetFileParms.c
+++ b/test/testsuite/T2_FPSetFileParms.c
@@ -159,6 +159,11 @@ STATIC void test426()
 
 	ENTER_TEST
 
+	// FIXME: test stalls indefinitely with Netatalk 4.0
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (!Path) {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;
@@ -217,8 +222,5 @@ void FPSetFileParms_test()
     fprintf(stdout,"-------------------\n");
     test89();
     test120();
-// FIXME: test stalls indefinitely
-#if 0
     test426();
-#endif
 }

--- a/test/testsuite/T2_FPSetFileParms.c
+++ b/test/testsuite/T2_FPSetFileParms.c
@@ -159,7 +159,7 @@ STATIC void test426()
 
 	ENTER_TEST
 
-	// FIXME: test stalls indefinitely with Netatalk 4.0
+	// FIXME: unexpected failure with Netatalk 4.0
 	if (Exclude) {
 		test_skipped(T_EXCLUDE);
 		goto test_exit;
@@ -206,11 +206,12 @@ STATIC void test426()
 		failed();
 	}
 
-test_exit:
     if (fork) {
 	    FPCloseFork(Conn,fork);
     }
     FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
+
+test_exit:
 	exit_test("FPSetFileParms:test426: Create a dangling symlink");
 }
 

--- a/test/testsuite/T2_FPSetFileParms.c
+++ b/test/testsuite/T2_FPSetFileParms.c
@@ -65,7 +65,7 @@ uint16_t vol = VolID;
 DSI *dsi = &Conn->dsi;
 unsigned ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -112,7 +112,7 @@ uint16_t bitmap = (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)| (1<<FILPBIT_CDATE) |
 uint16_t vol = VolID;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -157,7 +157,7 @@ STATIC void test426()
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Path) {
 		test_skipped(T_MAC_PATH);

--- a/test/testsuite/T2_FPSetForkParms.c
+++ b/test/testsuite/T2_FPSetForkParms.c
@@ -15,8 +15,6 @@ STATIC void test9()
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPSetForkParms:test9: name encoding\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -41,7 +39,7 @@ fin:
 	FAIL (fork && FPCloseFork(Conn,fork))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test9");
+	exit_test("FPSetForkParms:test9: name encoding");
 }
 
 /* ----------- */
@@ -49,5 +47,6 @@ void FPSetForkParms_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPSetForkParms\n");
+    fprintf(stdout,"-------------------\n");
 	test9();
 }

--- a/test/testsuite/T2_FPSetForkParms.c
+++ b/test/testsuite/T2_FPSetForkParms.c
@@ -14,7 +14,7 @@ STATIC void test9()
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();

--- a/test/testsuite/T2_spectest.c
+++ b/test/testsuite/T2_spectest.c
@@ -264,7 +264,7 @@ enum adouble adouble = AD_EA;
 void usage( char * av0 )
 {
     fprintf( stdout, "usage:\t%s [-aLmn] [-h host] [-p port] [-s vol] [-u user] [-w password] -f [call]\n", av0 );
-    fprintf( stdout,"\t-a\t\volume is appledouble = v2 instead of default appledouble = ea\n");
+    fprintf( stdout,"\t-a\tvolume is appledouble = v2 instead of default appledouble = ea\n");
     fprintf( stdout,"\t-L\tserver without working fcntl locking, skip tests using it\n");
     fprintf( stdout,"\t-m\tserver is a Mac\n");
     fprintf( stdout,"\t-h\tserver host name (default localhost)\n");
@@ -287,6 +287,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-v\tverbose\n");
     fprintf( stdout,"\t-V\tvery verbose\n");
 
+    fprintf( stdout,"\t-x\tdon't run tests with known bugs\n");
     fprintf( stdout,"\t-f\ttest to run\n");
     fprintf( stdout,"\t-l\tlist tests\n");
     fprintf( stdout,"\t-i\tinteractive mode, prompts before every test (debug purposes)\n");
@@ -302,7 +303,7 @@ int ret;
 static char *vers = "AFPVersion 2.1";
 static char *uam = "Cleartxt Passwrd";
 
-    while (( cc = getopt( ac, av, "ivV1234567ah:H:p:s:u:d:w:c:f:lmMS:LC" )) != EOF ) {
+    while (( cc = getopt( ac, av, "ivV1234567ah:H:p:s:u:d:w:c:f:lmMS:LCx" )) != EOF ) {
         switch ( cc ) {
         case '1':
 			vers = "AFPVersion 2.1";
@@ -391,6 +392,9 @@ static char *uam = "Cleartxt Passwrd";
 	case 'C':
 		Color = 1;
 		break;
+        case 'x':
+        	Exclude = 1;
+        	break;
         default :
             usage( av[ 0 ] );
         }

--- a/test/testsuite/T2_spectest.c
+++ b/test/testsuite/T2_spectest.c
@@ -286,6 +286,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
     fprintf( stdout,"\t-v\tverbose\n");
+    fprintf( stdout,"\t-Q\tnon-quiet\n");
 
     fprintf( stdout,"\t-f\ttest to run\n");
     fprintf( stdout,"\t-l\tlist tests\n");
@@ -302,7 +303,7 @@ int ret;
 static char *vers = "AFPVersion 2.1";
 static char *uam = "Cleartxt Passwrd";
 
-    while (( cc = getopt( ac, av, "iv1234567ah:H:p:s:u:d:w:c:f:lmMS:LC" )) != EOF ) {
+    while (( cc = getopt( ac, av, "iv1234567ah:H:p:s:u:d:w:c:f:lmMS:LCQ" )) != EOF ) {
         switch ( cc ) {
         case '1':
 			vers = "AFPVersion 2.1";
@@ -384,6 +385,9 @@ static char *uam = "Cleartxt Passwrd";
 		case 'v':
 			Verbose = 1;
 			break;
+	case 'Q':
+		Quiet = 0;
+		break;
 		case 'M':
 			Manuel = 1;
 			break;

--- a/test/testsuite/T2_spectest.c
+++ b/test/testsuite/T2_spectest.c
@@ -258,7 +258,6 @@ int     Version = 21;
 int     List = 0;
 int     Mac = 0;
 char    *Test;
-int     Manuel = 0;
 enum adouble adouble = AD_EA;
 
 /* =============================== */
@@ -286,7 +285,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
     fprintf( stdout,"\t-v\tverbose\n");
-    fprintf( stdout,"\t-Q\tnon-quiet\n");
+    fprintf( stdout,"\t-V\tvery verbose\n");
 
     fprintf( stdout,"\t-f\ttest to run\n");
     fprintf( stdout,"\t-l\tlist tests\n");
@@ -303,7 +302,7 @@ int ret;
 static char *vers = "AFPVersion 2.1";
 static char *uam = "Cleartxt Passwrd";
 
-    while (( cc = getopt( ac, av, "iv1234567ah:H:p:s:u:d:w:c:f:lmMS:LCQ" )) != EOF ) {
+    while (( cc = getopt( ac, av, "ivV1234567ah:H:p:s:u:d:w:c:f:lmMS:LC" )) != EOF ) {
         switch ( cc ) {
         case '1':
 			vers = "AFPVersion 2.1";
@@ -382,15 +381,13 @@ static char *uam = "Cleartxt Passwrd";
                 exit(1);
             }
             break;
-		case 'v':
-			Verbose = 1;
-			break;
-	case 'Q':
+	case 'v':
 		Quiet = 0;
 		break;
-		case 'M':
-			Manuel = 1;
-			break;
+	case 'V':
+		Quiet = 0;
+		Verbose = 1;
+		break;
 	case 'C':
 		Color = 1;
 		break;

--- a/test/testsuite/T2_spectest.c
+++ b/test/testsuite/T2_spectest.c
@@ -265,7 +265,7 @@ enum adouble adouble = AD_EA;
 void usage( char * av0 )
 {
     fprintf( stdout, "usage:\t%s [-aLmn] [-h host] [-p port] [-s vol] [-u user] [-w password] -f [call]\n", av0 );
-    fprintf( stdout,"\t-a\t\volume is adouble:v2 instead of default adouble:ea\n");
+    fprintf( stdout,"\t-a\t\volume is appledouble = v2 instead of default appledouble = ea\n");
     fprintf( stdout,"\t-L\tserver without working fcntl locking, skip tests using it\n");
     fprintf( stdout,"\t-m\tserver is a Mac\n");
     fprintf( stdout,"\t-h\tserver host name (default localhost)\n");

--- a/test/testsuite/Utf8.c
+++ b/test/testsuite/Utf8.c
@@ -14,8 +14,6 @@ uint16_t vol = VolID;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test162: illegal UTF8 name\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -38,7 +36,7 @@ DSI *dsi = &Conn->dsi;
 		failed();
 	}
 test_exit:
-	exit_test("test162");
+	exit_test("Utf8:test162: illegal UTF8 name");
 }
 
 /* ------------------------- */
@@ -52,8 +50,6 @@ struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test166: utf8 precompose decompose\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -83,7 +79,9 @@ DSI *dsi = &Conn->dsi;
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap,0);
 	    if (strcmp(filedir.lname, "\216.rtf")) {
-		    fprintf(stdout,"\tFAILED %s should be \\216.rtf\n",filedir.lname);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %s should be \\216.rtf\n",filedir.lname);
+		}
 		    failed_nomsg();
 	    }
 	}
@@ -96,7 +94,7 @@ DSI *dsi = &Conn->dsi;
 	nfile[2] = 0x81;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , nfile))
 test_exit:
-	exit_test("test166");
+	exit_test("Utf8:test166: utf8 precompose decompose");
 }
 
 /* ------------------------- */
@@ -110,8 +108,6 @@ struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test167: utf8 precompose decompose\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -141,7 +137,9 @@ DSI *dsi = &Conn->dsi;
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap,0);
 	    if (strcmp(filedir.lname, "l\210")) {
-		    fprintf(stdout,"\tFAILED %s should be l\\210\n",filedir.lname);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %s should be l\\210\n",filedir.lname);
+		}
 		    failed_nomsg();
 	    }
 	}
@@ -154,7 +152,7 @@ DSI *dsi = &Conn->dsi;
 	nfile[3] = 0x80;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , nfile))
 test_exit:
-	exit_test("test167");
+	exit_test("Utf8:test167: utf8 precompose decompose");
 }
 
 /* ------------------------- */
@@ -168,8 +166,6 @@ int  dir;
 int  dir1;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test181: test search by ID UTF8\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -230,7 +226,7 @@ int  dir1;
 	FAIL (FPDelete(Conn, vol,  dir , name1))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test181");
+	exit_test("Utf8:test181: test search by ID UTF8");
 }
 
 /* -------------------------
@@ -242,8 +238,6 @@ char *name1 = "t185 donne\314"; /* decomposed donn�es */
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test185: rename utf8 name\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -268,7 +262,7 @@ uint16_t vol = VolID;
 
 	FPFlush(Conn, vol);
 test_exit:
-	exit_test("test185");
+	exit_test("Utf8:test185: rename utf8 name");
 }
 
 /* ------------------------- */
@@ -283,8 +277,6 @@ uint16_t bitmap = 0;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test233: false mangled UTF8 dirname\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -318,7 +310,7 @@ uint16_t bitmap = 0;
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test233");
+	exit_test("Utf8:test233: false mangled UTF8 dirname");
 }
 
 /* ------------------------- */
@@ -334,8 +326,6 @@ uint16_t bitmap = 0;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test234: false mangled UTF8 filename\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -368,7 +358,7 @@ uint16_t bitmap = 0;
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test234");
+	exit_test("Utf8:test234: false mangled UTF8 filename");
 }
 
 /* ------------------------- */
@@ -384,8 +374,6 @@ uint16_t bitmap = 0;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test312: mangled UTF8 filename\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -420,8 +408,8 @@ uint16_t bitmap = 0;
 		else {
 		    filedir.isdir = 0;
 		    afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap,0);
-		    if (strcmp(filedir.utf8_name, name)) {
-				fprintf(stdout,"\tFAILED %s should be %s\n",filedir.utf8_name, name); 
+		    if (strcmp(filedir.utf8_name, name) && !Quiet) {
+			fprintf(stdout,"\tFAILED %s should be %s\n",filedir.utf8_name, name);
 		    }
 		}
         sprintf(temp,"t3-#%X.mp3", ntohl(filedir.did));
@@ -431,7 +419,7 @@ uint16_t bitmap = 0;
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test312");
+	exit_test("Utf8:test312: mangled UTF8 filename");
 }
 
 /* ------------------------- */
@@ -446,8 +434,6 @@ uint16_t bitmap = 0;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test313: mangled UTF8 dirname\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -474,7 +460,7 @@ uint16_t bitmap = 0;
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test313");
+	exit_test("Utf8:test313: mangled UTF8 dirname");
 }
 
 /* ------------------------- */
@@ -488,8 +474,6 @@ uint16_t bitmap = 0;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test314: invalid mangled UTF8 name\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -510,7 +494,7 @@ uint16_t bitmap = 0;
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test314");
+	exit_test("Utf8:test314: invalid mangled UTF8 name");
 }
 
 /* -------------------------
@@ -528,8 +512,6 @@ uint16_t bitmap = 0;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test337: mangled UTF8 filename\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -565,8 +547,8 @@ uint16_t bitmap = 0;
 		else {
 		    filedir.isdir = 0;
 		    afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap,0);
-		    if (strcmp(filedir.utf8_name, name)) {
-				fprintf(stdout,"\tFAILED %s should be %s\n",filedir.utf8_name, name); 
+		    if (strcmp(filedir.utf8_name, name) && !Quiet) {
+			fprintf(stdout,"\tFAILED %s should be %s\n",filedir.utf8_name, name);
 		    }
 		}
         sprintf(temp,"t#%X.mp3", ntohl(filedir.did));
@@ -577,7 +559,7 @@ uint16_t bitmap = 0;
 	}
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test337");
+	exit_test("Utf8:test337: mangled UTF8 filename");
 }
 
 /* ------------------------- */
@@ -593,8 +575,6 @@ struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test381: utf8 use type 2 name with AFP3 connection\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -624,7 +604,9 @@ DSI *dsi = &Conn->dsi;
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, bitmap,0);
 	    if (strcmp(filedir.lname, "l\210")) {
-		    fprintf(stdout,"\tFAILED %s should be l\\210\n",filedir.lname);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %s should be l\\210\n",filedir.lname);
+		}
 		    failed_nomsg();
 	    }
 	}
@@ -634,7 +616,7 @@ DSI *dsi = &Conn->dsi;
 
 	FAIL (ntohl(AFPERR_NOOBJ) !=  FPDelete(Conn, vol,  DIRDID_ROOT , nfile))
 test_exit:
-	exit_test("test381");
+	exit_test("Utf8:test381: utf8 use type 2 name with AFP3 connection");
 }
 
 /* ------------------------- */
@@ -648,8 +630,6 @@ struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test382: utf8 use type 2 name with AFP3 connection\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -679,7 +659,9 @@ DSI *dsi = &Conn->dsi;
 		filedir.isdir = 1;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, 0, bitmap);
 	    if (strcmp(filedir.lname, "l\210")) {
-		    fprintf(stdout,"\tFAILED %s should be l\\210\n",filedir.lname);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %s should be l\\210\n",filedir.lname);
+		}
 		    failed_nomsg();
 	    }
 	}
@@ -689,7 +671,7 @@ DSI *dsi = &Conn->dsi;
 
 	FAIL (ntohl(AFPERR_NOOBJ) != FPDelete(Conn, vol,  DIRDID_ROOT , nfile))
 test_exit:
-	exit_test("test382");
+	exit_test("Utf8:test382: utf8 use type 2 name with AFP3 connection");
 }
 
 /* ------------------------- */
@@ -703,8 +685,6 @@ uint16_t bitmap;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test383: utf8 rename type 2 name, AFP3 connection\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -729,7 +709,7 @@ uint16_t vol = VolID;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , nfile))
 	FPDelete(Conn, vol,  DIRDID_ROOT , file);
 test_exit:
-	exit_test("test383");
+	exit_test("Utf8:test383: utf8 rename type 2 name, AFP3 connection");
 }
 
 /* ------------------------- */
@@ -743,8 +723,6 @@ uint16_t bitmap;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test384: utf8 rename type 2 name, AFP3 connection wrong parameter\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -769,7 +747,7 @@ uint16_t vol = VolID;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , file))
 	FPDelete(Conn, vol,  DIRDID_ROOT , nfile);
 test_exit:
-	exit_test("test384");
+	exit_test("Utf8:test384: utf8 rename type 2 name, AFP3 connection wrong parameter");
 }
 
 /* ------------------------- */
@@ -783,8 +761,6 @@ uint16_t bitmap;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test385: utf8 copyfile type 2 name, AFP3 connection\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -809,7 +785,7 @@ uint16_t vol = VolID;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , nfile))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , file));
 test_exit:
-	exit_test("test385");
+	exit_test("Utf8:test385: utf8 copyfile type 2 name, AFP3 connection");
 }
 
 /* ------------------------- */
@@ -823,8 +799,6 @@ uint16_t bitmap;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test386: utf8 moveandrename type 2 name, AFP3 connection\n");
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -849,7 +823,7 @@ uint16_t vol = VolID;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , nfile))
 	FPDelete(Conn, vol,  DIRDID_ROOT , file);
 test_exit:
-	exit_test("test386");
+	exit_test("Utf8:test386: utf8 moveandrename type 2 name, AFP3 connection");
 }
 
 /* ------------------------- */
@@ -858,8 +832,6 @@ STATIC void test395()
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Utf8:test395: utf8 bit set if AFP < 3.0\n");
 
 	if (Conn->afp_version >= 30) {
 		test_skipped(T_AFP2);
@@ -871,7 +843,7 @@ uint16_t vol = VolID;
 	}
 
 test_exit:
-	exit_test("test395");
+	exit_test("Utf8:test395: utf8 bit set if AFP < 3.0");
 }
 
 
@@ -880,6 +852,7 @@ void Utf8_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"UTF8 tests\n");
+    fprintf(stdout,"-------------------\n");
     test162();
     test166();
     test167();

--- a/test/testsuite/Utf8.c
+++ b/test/testsuite/Utf8.c
@@ -13,7 +13,7 @@ int dir;
 uint16_t vol = VolID;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -49,7 +49,7 @@ int  ofs =  3 * sizeof( uint16_t );
 struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -107,7 +107,7 @@ int  ofs =  3 * sizeof( uint16_t );
 struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -165,7 +165,7 @@ uint16_t vol = VolID;
 int  dir;
 int  dir1;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -237,7 +237,7 @@ char *name = "t185.txt";
 char *name1 = "t185 donne\314"; /* decomposed donn�es */
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -276,7 +276,7 @@ uint16_t bitmap = 0;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -325,7 +325,7 @@ uint16_t bitmap = 0;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -373,7 +373,7 @@ uint16_t bitmap = 0;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -433,7 +433,7 @@ uint16_t bitmap = 0;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -473,7 +473,7 @@ uint16_t bitmap = 0;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -511,7 +511,7 @@ uint16_t bitmap = 0;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -574,7 +574,7 @@ int  ofs =  3 * sizeof( uint16_t );
 struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -629,7 +629,7 @@ int  ofs =  3 * sizeof( uint16_t );
 struct afp_filedir_parms filedir;
 DSI *dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -684,7 +684,7 @@ char *nfile = "test 383 new name la\xcc\x80";/* l� */
 uint16_t bitmap;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -722,7 +722,7 @@ char *nfile = "test 384 new name la\xcc\x80";/* l� */
 uint16_t bitmap;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -760,7 +760,7 @@ char *nfile = "test 385 new name la\xcc\x80";/* l� */
 uint16_t bitmap;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -798,7 +798,7 @@ char *nfile = "test 386 new name la\xcc\x80";/* l� */
 uint16_t bitmap;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version < 30) {
 		test_skipped(T_AFP3);
@@ -831,7 +831,7 @@ STATIC void test395()
 {
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (Conn->afp_version >= 30) {
 		test_skipped(T_AFP2);

--- a/test/testsuite/adoublehelper.c
+++ b/test/testsuite/adoublehelper.c
@@ -248,7 +248,7 @@ static int chmod_unix_adouble(char *path,char *name, int mode)
 
 /* --------------------
 */
-int chmod_unix_meta(char *path, char *name, char *file, int mode)
+int chmod_unix_meta(char *path, char *name, char *file, mode_t mode)
 {
     if (adouble == AD_EA) {
 #ifdef HAVE_EAFD
@@ -270,7 +270,7 @@ int chmod_unix_meta(char *path, char *name, char *file, int mode)
     } else {
         sprintf(temp, "%s/%s/.AppleDouble/%s", path, name, file);
         if (!Quiet) {
-            fprintf(stdout, "chmod (%s, %o)\n", temp, mode);
+            fprintf(stdout, "chmod (%s, 0%o)\n", temp, mode);
         }
         if (chmod(temp, mode)) {
             if (!Quiet) {
@@ -285,7 +285,7 @@ int chmod_unix_meta(char *path, char *name, char *file, int mode)
 
 /* --------------------
 */
-int chmod_unix_rfork(char *path, char *name, char *file, int mode)
+int chmod_unix_rfork(char *path, char *name, char *file, mode_t mode)
 {
     if (adouble == AD_EA) {
 #ifdef HAVE_EAFD
@@ -304,7 +304,7 @@ int chmod_unix_rfork(char *path, char *name, char *file, int mode)
 #else
         sprintf(temp, "%s/%s/._%s", path, name, file);
         if (!Quiet) {
-            fprintf(stdout, "chmod(%s, %d)\n", temp, mode);
+            fprintf(stdout, "chmod(%s, 0%o)\n", temp, mode);
         }
         if (chmod(temp, mode)) {
             if (!Quiet) {
@@ -318,7 +318,7 @@ int chmod_unix_rfork(char *path, char *name, char *file, int mode)
     } else {
         sprintf(temp, "%s/%s/.AppleDouble/%s", path, name, file);
         if (!Quiet) {
-            fprintf(stdout, "chmod (%s, %o)\n", temp, mode);
+            fprintf(stdout, "chmod (%s, 0%o)\n", temp, mode);
         }
         if (chmod(temp, mode)) {
             if (!Quiet) {

--- a/test/testsuite/adoublehelper.c
+++ b/test/testsuite/adoublehelper.c
@@ -19,15 +19,21 @@ int delete_unix_md(char *path, char *name, char *file)
         else {
             sprintf(temp, "%s/%s/.AppleDouble/%s", path, name, file);
         }
-        fprintf(stdout,"unlink(%s)\n", temp);
+        if (!Quiet) {
+            fprintf(stdout,"unlink(%s)\n", temp);
+        }
         if (unlink(temp) <0) {
-            fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+			if (!Quiet) {
+                fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+            }
             return -1;
         }
     } else {
         sprintf(temp, "%s/%s/%s", path, name, file);
         if (sys_lremovexattr(temp, AD_EA_META) != 0) {
-            fprintf(stdout,"\tFAILED sys_lremovexattr(%s, %s) %s\n", temp, AD_EA_META, strerror(errno));
+			if (!Quiet) {
+                fprintf(stdout,"\tFAILED sys_lremovexattr(%s, %s) %s\n", temp, AD_EA_META, strerror(errno));
+            }
             return -1;
         }
     }
@@ -47,9 +53,13 @@ int delete_unix_rf(char *path, char *name, char *file)
         else {
             sprintf(temp, "%s/%s/.AppleDouble/%s", path, name, file);
         }
-        fprintf(stdout,"unlink(%s)\n", temp);
+        if (!Quiet) {
+            fprintf(stdout,"unlink(%s)\n", temp);
+        }
         if (unlink(temp) <0) {
-            fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+			if (!Quiet) {
+                fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+            }
             return -1;
         }
     } else {
@@ -57,16 +67,22 @@ int delete_unix_rf(char *path, char *name, char *file)
         if (file) {
             sprintf(temp, "%s/%s/%s", path, name, file);
             if (sys_lremovexattr(temp, AD_EA_RESO) != 0) {
-                fprintf(stdout,"\tFAILED sys_lremovexattr(%s, %s) %s\n", temp, AD_EA_RESO, strerror(errno));
+                if (!Quiet) {
+                    fprintf(stdout,"\tFAILED sys_lremovexattr(%s, %s) %s\n", temp, AD_EA_RESO, strerror(errno));
+                }
                 return -1;
             }
         }
 #else
         if (file) {
             sprintf(temp, "%s/%s/._%s", path, name, file);
-            fprintf(stdout,"unlink(%s)\n", temp);
+			if (!Quiet) {
+                fprintf(stdout,"unlink(%s)\n", temp);
+            }
             if (unlink(temp) <0) {
-                fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+                if (!Quiet) {
+                    fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+                }
                 return -1;
             }
         }
@@ -86,10 +102,14 @@ int delete_unix_file(char *path, char *name, char *file)
     if (delete_unix_rf(path, name, file))
 		rc = -1;
 
-	sprintf(temp, "%s/%s/%s", path, name, file);
-	fprintf(stdout,"unlink(%s)\n", temp);
+    sprintf(temp, "%s/%s/%s", path, name, file);
+    if (!Quiet) {
+        fprintf(stdout,"unlink(%s)\n", temp);
+    }
 	if (unlink(temp) <0) {
-		fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+        if (!Quiet) {
+            fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+        }
         rc = -1;
 	}
 	return rc;
@@ -100,9 +120,13 @@ int rename_unix_file(char *path, char *dir, char *src, char *dst)
 {
     sprintf(temp, "%s/%s/%s", Path, dir, src);
     sprintf(temp1, "%s/%s/%s", Path, dir, dst);
-    fprintf(stdout,"rename %s %s\n", temp, temp1);
+    if (!Quiet) {
+        fprintf(stdout,"rename %s %s\n", temp, temp1);
+    }
     if (rename(temp, temp1) < 0) {
-        fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+        if (!Quiet) {
+            fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+        }
         failed_nomsg();
         return -1;
     }
@@ -110,18 +134,26 @@ int rename_unix_file(char *path, char *dir, char *src, char *dst)
     if (adouble == AD_V2) {
         sprintf(temp, "%s/%s/.AppleDouble/%s", Path, dir, src);
         sprintf(temp1,"%s/%s/.AppleDouble/%s", Path, dir, dst);
-        fprintf(stdout,"rename %s %s\n", temp, temp1);
+        if (!Quiet) {
+            fprintf(stdout,"rename %s %s\n", temp, temp1);
+        }
         if (rename(temp, temp1) < 0) {
-            fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+            if (!Quiet) {
+                fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+            }
             failed_nomsg();
         }
     } else {
 #ifndef HAVE_EAFD
         sprintf(temp, "%s/%s/._%s", Path, dir, src);
         sprintf(temp1,"%s/%s/._%s", Path, dir, dst);
-        fprintf(stdout,"rename %s %s\n", temp, temp1);
+        if (!Quiet) {
+            fprintf(stdout,"rename %s %s\n", temp, temp1);
+        }
         if (rename(temp, temp1) < 0) {
-            fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+            if (!Quiet) {
+                fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+            }
             failed_nomsg();
         }
 
@@ -133,9 +165,13 @@ int rename_unix_file(char *path, char *dir, char *src, char *dst)
 int unlink_unix_file(char *path, char *name, char *file)
 {
 	sprintf(temp, "%s/%s/%s", path, name, file);
-	fprintf(stdout,"unlink(%s)\n", temp);
+    if (!Quiet) {
+        fprintf(stdout,"unlink(%s)\n", temp);
+    }
 	if (unlink(temp) <0) {
-		fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+        if (!Quiet) {
+            fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+        }
 		failed_nomsg();
 		return -1;
 	}
@@ -146,9 +182,13 @@ int unlink_unix_file(char *path, char *name, char *file)
 int symlink_unix_file(char *target, char *path, char *source)
 {
 	sprintf(temp, "%s/%s", path, source);
-	fprintf(stdout,"symlink(%s -> %s)\n", temp, target);
+    if (!Quiet) {
+        fprintf(stdout,"symlink(%s -> %s)\n", temp, target);
+    }
 	if (symlink(target, temp) <0) {
-		fprintf(stdout,"\tFAILED symlink(%s -> %s) %s\n", temp, target, strerror(errno));
+        if (!Quiet) {
+            fprintf(stdout,"\tFAILED symlink(%s -> %s) %s\n", temp, target, strerror(errno));
+        }
 		failed_nomsg();
 		return -1;
 	}
@@ -163,16 +203,22 @@ int delete_unix_adouble(char *path, char *name)
         sys_lremovexattr(temp, AD_EA_META);
         sys_lremovexattr(temp, AD_EA_RESO);
     } else {
-        fprintf(stdout,"rmdir(%s/.AppleDouble) \n", name);
+        if (!Quiet) {
+            fprintf(stdout,"rmdir(%s/.AppleDouble) \n", name);
+        }
         sprintf(temp, "%s/%s/.AppleDouble/.Parent", path, name);
         if (unlink(temp) <0) {
-            fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+            if (!Quiet) {
+                fprintf(stdout,"\tFAILED unlink(%s) %s\n", temp, strerror(errno));
+            }
             failed_nomsg();
             return -1;
         }
         sprintf(temp, "%s/%s/.AppleDouble", path, name);
         if (rmdir(temp) <0) {
-            fprintf(stdout,"\tFAILED rmdir(%s) %s\n", temp, strerror(errno));
+            if (!Quiet) {
+                fprintf(stdout,"\tFAILED rmdir(%s) %s\n", temp, strerror(errno));
+            }
             failed_nomsg();
             return -1;
         }
@@ -187,9 +233,13 @@ static int chmod_unix_adouble(char *path,char *name, int mode)
         return 0;
 
 	sprintf(temp, "%s/%s/.AppleDouble", path, name);
-	fprintf(stdout, "chmod (%s, %o)\n", temp, mode);
+    if (!Quiet) {
+        fprintf(stdout, "chmod (%s, %o)\n", temp, mode);
+    }
 	if (chmod(temp, mode)) {
-		fprintf(stdout,"\tFAILED %s\n", strerror(errno));
+        if (!Quiet) {
+            fprintf(stdout,"\tFAILED %s\n", strerror(errno));
+        }
 		failed_nomsg();
 		return -1;
 	}
@@ -203,9 +253,13 @@ int chmod_unix_meta(char *path, char *name, char *file, int mode)
     if (adouble == AD_EA) {
 #ifdef HAVE_EAFD
         sprintf(temp, "runat '%s/%s/%s' chmod 0%o %s", path, name, file, mode, AD_EA_META);
-        fprintf(stdout, "%s\n", temp);
+        if (!Quiet) {
+            fprintf(stdout, "%s\n", temp);
+        }
         if (system(temp) != 0) {
-            fprintf(stdout,"\tFAILED %s\n", strerror(errno));
+            if (!Quiet) {
+                fprintf(stdout,"\tFAILED %s\n", strerror(errno));
+            }
             failed_nomsg();
             return -1;
         }
@@ -215,9 +269,13 @@ int chmod_unix_meta(char *path, char *name, char *file, int mode)
 #endif
     } else {
         sprintf(temp, "%s/%s/.AppleDouble/%s", path, name, file);
-        fprintf(stdout, "chmod (%s, %o)\n", temp, mode);
+        if (!Quiet) {
+            fprintf(stdout, "chmod (%s, %o)\n", temp, mode);
+        }
         if (chmod(temp, mode)) {
-            fprintf(stdout,"\tFAILED %s\n", strerror(errno));
+            if (!Quiet) {
+                fprintf(stdout,"\tFAILED %s\n", strerror(errno));
+            }
             failed_nomsg();
             return -1;
         }
@@ -232,18 +290,26 @@ int chmod_unix_rfork(char *path, char *name, char *file, int mode)
     if (adouble == AD_EA) {
 #ifdef HAVE_EAFD
         sprintf(temp, "runat '%s/%s/%s' chmod 0%o %s", path, name, file, mode, AD_EA_RESO);
-        fprintf(stdout, "%s\n", temp);
+        if (!Quiet) {
+            fprintf(stdout, "%s\n", temp);
+        }
         if (system(temp) != 0) {
-            fprintf(stdout,"\tFAILED %s\n", strerror(errno));
+            if (!Quiet) {
+                fprintf(stdout,"\tFAILED %s\n", strerror(errno));
+            }
             failed_nomsg();
             return -1;
         }
         return 0;
 #else
         sprintf(temp, "%s/%s/._%s", path, name, file);
-        fprintf(stdout, "chmod(%s, %d)\n", temp, mode);
+        if (!Quiet) {
+            fprintf(stdout, "chmod(%s, %d)\n", temp, mode);
+        }
         if (chmod(temp, mode)) {
-            fprintf(stdout,"\tFAILED %s\n", strerror(errno));
+            if (!Quiet) {
+                fprintf(stdout,"\tFAILED %s\n", strerror(errno));
+            }
             failed_nomsg();
             return -1;
         }
@@ -251,9 +317,13 @@ int chmod_unix_rfork(char *path, char *name, char *file, int mode)
 #endif
     } else {
         sprintf(temp, "%s/%s/.AppleDouble/%s", path, name, file);
-        fprintf(stdout, "chmod (%s, %o)\n", temp, mode);
+        if (!Quiet) {
+            fprintf(stdout, "chmod (%s, %o)\n", temp, mode);
+        }
         if (chmod(temp, mode)) {
-            fprintf(stdout,"\tFAILED %s\n", strerror(errno));
+            if (!Quiet) {
+                fprintf(stdout,"\tFAILED %s\n", strerror(errno));
+            }
             failed_nomsg();
             return -1;
         }
@@ -266,14 +336,18 @@ int chmod_unix_rfork(char *path, char *name, char *file, int mode)
 */
 int delete_unix_dir(char *path, char *name)
 {
-	fprintf(stdout,"rmdir(%s)\n", name);
+    if (!Quiet) {
+        fprintf(stdout,"rmdir(%s)\n", name);
+    }
 
     if (adouble == AD_V2)
         if (delete_unix_adouble(path, name))
             return -1;
 	sprintf(temp, "%s/%s", path, name);
 	if (rmdir(temp) <0) {
-		fprintf(stdout,"\tFAILED rmdir %s %s\n", temp, strerror(errno));
+        if (!Quiet) {
+            fprintf(stdout,"\tFAILED rmdir %s %s\n", temp, strerror(errno));
+        }
 		return -1;
 	}
 	return 0;
@@ -288,7 +362,9 @@ int ret = 0;
 int dir = 0;
 uint16_t bitmap =  (1 << DIRPBIT_ACCESS);
 
-	fprintf(stdout,"\t>>>>>>>> Create folder with ro adouble <<<<<<<<<< \n");
+    if (!Quiet) {
+        fprintf(stdout,"\t>>>>>>>> Create folder with ro adouble <<<<<<<<<< \n");
+    }
 
 	if (!(dir = FPCreateDir(Conn,vol, did , name))) {
 		nottested();
@@ -326,15 +402,18 @@ fin:
 			nottested();
 		}
 	}
-	fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+    if (!Quiet) {
+        fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+    }
 	return ret;
 }
 
 /* -------------------------------- */
 int delete_ro_adouble(uint16_t vol, int did, char *file)
 {
-
-	fprintf(stdout,"\t>>>>>>>> delete folder with ro adouble <<<<<<<<<< \n");
+    if (!Quiet) {
+        fprintf(stdout,"\t>>>>>>>> delete folder with ro adouble <<<<<<<<<< \n");
+    }
 	FAIL (FPDelete(Conn, vol, did, file))
 	FAIL (FPDelete(Conn, vol, did, ""))
 	return 0;

--- a/test/testsuite/adoublehelper.h
+++ b/test/testsuite/adoublehelper.h
@@ -13,7 +13,7 @@ extern int rename_unix_file(char *path, char *dir, char *src, char *dst);
 extern int unlink_unix_file(char *path, char *name, char *file);
 extern int symlink_unix_file(char *target, char *path, char *source);
 
-extern int chmod_unix_meta(char *path, char *name, char *file, int mode);
-extern int chmod_unix_rfork(char *path, char *name, char *file, int mode);
+extern int chmod_unix_meta(char *path, char *name, char *file, mode_t mode);
+extern int chmod_unix_rfork(char *path, char *name, char *file, mode_t mode);
 /* -------------------
 */

--- a/test/testsuite/afp_ls.c
+++ b/test/testsuite/afp_ls.c
@@ -103,7 +103,7 @@ int size = 1000;
 	    		    	filedir.isdir = 0;
 	        		    afp_filedir_unpack(&filedir, b + 2, f_bitmap, 0);
 			        }
-			        if (Quiet) {
+			        if (!Quiet) {
 			        	fprintf(stdout, "0x%08x %s%s\n", ntohl(filedir.did),
 			        	      (Conn->afp_version >= 30)?filedir.utf8_name:filedir.lname,
 			        	      filedir.isdir?"/":"");

--- a/test/testsuite/afp_ls.c
+++ b/test/testsuite/afp_ls.c
@@ -185,6 +185,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
     fprintf( stdout,"\t-v\tverbose\n");
+    fprintf( stdout,"\t-V\tvery verbose\n");
     fprintf( stdout,"\t-t\trun it twice (ie one with the cache warm)\n");
 
     exit (1);
@@ -198,7 +199,7 @@ int cc;
 static char *vers = "AFPVersion 2.1";
 static char *uam = "Cleartxt Passwrd";
 
-    while (( cc = getopt( ac, av, "Rimlv34567th:p:s:u:w:d:" )) != EOF ) {
+    while (( cc = getopt( ac, av, "RimlvV34567th:p:s:u:w:d:" )) != EOF ) {
         switch ( cc ) {
         case 'i':
             Quiet = 1;
@@ -254,12 +255,16 @@ static char *uam = "Cleartxt Passwrd";
                 exit(1);
             }
             break;
-		case 'v':
-			Verbose = 1;
-			break;
-		case 't':
-			Twice = 1;
-			break;
+	case 'v':
+		Quiet = 0;
+		break;
+	case 'V':
+		Quiet = 0;
+		Verbose = 1;
+		break;
+	case 't':
+		Twice = 1;
+		break;
         default :
             usage( av[ 0 ] );
         }

--- a/test/testsuite/afparg.c
+++ b/test/testsuite/afparg.c
@@ -232,6 +232,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
     fprintf( stdout,"\t-v\tverbose\n");
+    fprintf( stdout,"\t-V\tvery verbose\n");
 
     fprintf( stdout,"\t-f\ttest to run\n");
     fprintf( stdout,"\t-l\tlist tests\n");
@@ -246,7 +247,7 @@ int main( int ac, char **av )
 int cc;
 int ret;
 
-    while (( cc = getopt( ac, av, "v1234567h:p:s:u:w:f:l" )) != EOF ) {
+    while (( cc = getopt( ac, av, "vV1234567h:p:s:u:w:f:l" )) != EOF ) {
         switch ( cc ) {
         case '1':
 			vers = "AFPVersion 2.1";
@@ -301,9 +302,13 @@ int ret;
                 exit(1);
             }
             break;
-        case 'v':
-            Verbose = 1;
-            break;
+	case 'v':
+		Quiet = 0;
+		break;
+	case 'V':
+		Quiet = 0;
+		Verbose = 1;
+		break;
         default :
             usage( av[ 0 ] );
         }

--- a/test/testsuite/afpcli.c
+++ b/test/testsuite/afpcli.c
@@ -80,7 +80,9 @@ size_t my_dsi_stream_read(DSI *dsi, void *data, const size_t length)
     if (len > 0)
       stored += len;
     else {/* eof or error */
-      fprintf(stdout, "dsi_stream_read(%ld): %s\n", len, (len < 0)?strerror(errno):"EOF");
+      if (!Quiet) {
+        fprintf(stdout, "dsi_stream_read(%ld): %s\n", len, (len < 0)?strerror(errno):"EOF");
+      }
       if (!len)
           dsi->header.dsi_code = 0xffffffff;
       break;
@@ -144,7 +146,9 @@ ssize_t len;
       continue;
 
     if (len < 0) {
-      fprintf(stdout, "dsi_stream_write: %s\n", strerror(errno));
+      if (!Quiet) {
+        fprintf(stdout, "dsi_stream_write: %s\n", strerror(errno));
+      }
       break;
     }
 
@@ -196,7 +200,9 @@ int my_dsi_stream_send(DSI *dsi, void *buf, size_t length)
 	    	if (len == towrite) /* wrote everything out */
       			break;
 	    	else if (len < 0) { /* error */
-      			fprintf(stdout, "my_dsi_stream_send: %s", strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout, "my_dsi_stream_send: %s", strerror(errno));
+			}
       			return 0;
 	    	}
 

--- a/test/testsuite/afpcli.c
+++ b/test/testsuite/afpcli.c
@@ -11,6 +11,7 @@ int	Verbose = 0;
 int	Recurse = 0;
 int	Twice = 0;
 int	Color = 0;
+int	Exclude = 0;
 
 #define UNICODE(a) (a->afp_version >= 30)
 

--- a/test/testsuite/afpcmd.c
+++ b/test/testsuite/afpcmd.c
@@ -2079,7 +2079,7 @@ DSI *dsi;
 	dsi = &conn->dsi;
 
 	if (!Quiet) {
-		fprintf(stdout,"[%s] read fork %d  offset %ll size %d\n", __func__, fork , offset, size);
+		fprintf(stdout,"[%s] read fork %d  offset %lld size %d\n", __func__, fork , offset, size);
 	}
 
 	ret = AFPRead(conn,fork, offset, size, data);

--- a/test/testsuite/afpcmd.c
+++ b/test/testsuite/afpcmd.c
@@ -246,7 +246,9 @@ DSI *dsi;
 			return -1;
 		usr = p->pw_name;
 	}
-	fprintf(stdout,"[%s] Login Version: \"%s\" uam: \"%s\" user: \"%s\"\n", __func__, vers, uam, usr);
+	if (!Quiet) {
+		fprintf(stdout,"[%s] Login Version: \"%s\" uam: \"%s\" user: \"%s\"\n", __func__, vers, uam, usr);
+	}
 	ret = AFPopenLogin(conn, vers, uam, usr, pwd);
 	dump_header(dsi);
 	return ret;
@@ -268,7 +270,9 @@ DSI *dsi;
 			return -1;
 		usr = p->pw_name;
 	}
-	fprintf(stdout,"[%s] LoginExt Version: \"%s\" uam: \"%s\" user: \"%s\"\n", __func__, vers, uam, usr);
+	if (!Quiet) {
+		fprintf(stdout,"[%s] LoginExt Version: \"%s\" uam: \"%s\" user: \"%s\"\n", __func__, vers, uam, usr);
+	}
 	ret = AFPopenLoginExt(conn,vers, uam, usr, pwd);
 	dump_header(dsi);
 	return ret;
@@ -281,7 +285,9 @@ int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
-	fprintf(stdout,"[%s] Logout\n", __func__);
+	if (!Quiet) {
+		fprintf(stdout,"[%s] Logout\n", __func__);
+	}
 	ret = AFPLogOut(conn);
 	dump_header(dsi);
 	return ret;

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -825,6 +825,12 @@ void test_skipped(int why)
 	case T_AFP3_CONN2:
 		s = "AFP 3.x and no second user";
 		break;
+	case T_AFP31:
+		s = "AFP 3.1 or higher";
+		break;
+	case T_AFP32:
+		s = "AFP 3.2 or higher";
+		break;
 	case T_MAC_PATH:
 		s = "-m (Mac server) or the volume path";
 		break;

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -824,10 +824,10 @@ void test_skipped(int why)
 		s = "volume with extendend attribute support";
 		break;
 	case T_ADEA:
-		s = "Netatalk 3 and volume with adouble:ea";
+		s = "Netatalk 3 and volume with appledouble = ea";
 		break;
 	case T_ADV2:
-		s = "adouble:v2 volume";
+		s = "appledouble = v2 volume";
 		break;
 	case T_NOSYML:
 		s = "volume without option 'followsymlinks'";
@@ -847,15 +847,19 @@ void failed_nomsg(void)
 /* ------------------------- */
 void skipped_nomsg(void)
 {
+#if 0
 	if (!ExitCode)
 		ExitCode = 3;
+#endif
 	CurTestResult = 3;
 }
 /* ------------------------- */
 void nottested_nomsg(void)
 {
+#if 0
 	if (!ExitCode)
 		ExitCode = 2;
+#endif
 	CurTestResult = 2;
 }
 
@@ -909,11 +913,6 @@ void exit_test(char *name)
 		} else {
 			s = "FAILED";
 		}
-#if 0
-        fprintf(stderr, "%s - summary - ", name);
-        fprintf(stderr, "%s%s (%d)\n", s, Why, CurTestResult);
-        fflush(stderr);
-#endif
         fprintf(stdout, "%s - summary - ", name);
         fprintf(stdout, "%s%s (%d)\n", s, Why, CurTestResult);
         fflush(stdout);
@@ -929,6 +928,11 @@ void exit_test(char *name)
 		s = skipped_msg_buf;
 		break;
 	}
+#if 0
+        fprintf(stderr, "%s - summary - ", name);
+        fprintf(stderr, "%s%s (%d)\n", s, Why, CurTestResult);
+        fflush(stderr);
+#endif
 	fprintf(stdout, "%s - summary - ", name);
 	fprintf(stdout, "%s%s (%d)\n", s, Why, CurTestResult);
     fflush(stdout);

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -814,16 +814,16 @@ void test_skipped(int why)
 		s = "volume path";
 		break;
 	case T_AFP2:
-		s = "< AFP 3.0";
-		break;
-	case T_AFP30:
-		s = "AFP 3.0";
+		s = "AFP 2.x";
 		break;
 	case T_AFP3:
 		s = "AFP 3.x";
 		break;
 	case T_AFP3_CONN2:
 		s = "AFP 3.x and no second user";
+		break;
+	case T_AFP30:
+		s = "AFP 3.0 only";
 		break;
 	case T_AFP31:
 		s = "AFP 3.1 or higher";
@@ -835,7 +835,7 @@ void test_skipped(int why)
 		s = "-m (Mac server) or the volume path";
 		break;
 	case T_UNIX_PREV:
-		s ="volume with UNIX privilege";
+		s ="volume with UNIX privileges";
 		break;
 	case T_NO_UNIX_PREV:
 		s ="volume without UNIX privileges";
@@ -850,7 +850,7 @@ void test_skipped(int why)
 		s = "a second volume";
 		break;
 	case T_LOCKING:
-		s = "a working fcntl locking";
+		s = "working fcntl locking";
 		break;
 	case T_VOL_SMALL:
 		s = "a bigger volume";
@@ -859,7 +859,7 @@ void test_skipped(int why)
 		s = "AFP FileID calls";
 		break;
 	case T_MAC:
-		s = "a server which is not a Mac";
+		s = "server which is not a Mac";
 		break;
 	case T_ACL:
 		s = "volume with ACL support";
@@ -877,22 +877,22 @@ void test_skipped(int why)
 		s = "volume without option 'follow symlinks'";
 		break;
 	case T_SINGLE:
-		s = "to run individually with -f";
+		s = "run individually with -f";
 		break;
 	case T_VOL_BIG:
 		s = "a smaller volume";
 		break;
 	case T_EXCLUDE:
-		s = "a newer Netatalk";
+		s = "in the Exclude bucket";
 		break;
 	case T_MANUAL:
 		s = "Interactive mode";
 		break;
 	}
 	if (Color) {
-		snprintf(skipped_msg_buf, sizeof(skipped_msg_buf), ANSI_BBLUE "SKIPPED (need %s)" ANSI_NORMAL, s);
+		snprintf(skipped_msg_buf, sizeof(skipped_msg_buf), ANSI_BBLUE "SKIPPED (%s)" ANSI_NORMAL, s);
 	} else {
-		snprintf(skipped_msg_buf, sizeof(skipped_msg_buf), "SKIPPED (need %s)", s);
+		snprintf(skipped_msg_buf, sizeof(skipped_msg_buf), "SKIPPED (%s)", s);
 	}
 	CurTestResult = 3;
 }

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -876,6 +876,9 @@ void test_skipped(int why)
 	case T_VOL_BIG:
 		s = "a smaller volume";
 		break;
+	case T_EXCLUDE:
+		s = "a newer Netatalk";
+		break;
 	}
 	if (Color) {
 		snprintf(skipped_msg_buf, sizeof(skipped_msg_buf), ANSI_BBLUE "SKIPPED (need %s)" ANSI_NORMAL, s);

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -88,14 +88,18 @@ uint16_t bitmap = 0;
 	dsi->header.dsi_len = htonl(dsi->datalen);
 	dsi->header.dsi_code = 0;
 
-	fprintf(stdout,"---------------------\n");
-	fprintf(stdout,"AFP call  %d\n\n", cmd);
+	if (!Quiet) {
+		fprintf(stdout,"---------------------\n");
+		fprintf(stdout,"AFP call  %d\n\n", cmd);
+	}
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 	my_dsi_cmd_receive(dsi);
 	dump_header(dsi);
 
     if (ntohl(AFPERR_PARAM) != dsi->header.dsi_code) {
+	if (!Quiet) {
 		fprintf(stdout,"\tFAILED command %i\n", cmd);
+	}
 		failed();
     }
 }
@@ -214,7 +218,11 @@ uint32_t uid;
     if (!Conn2) {
     	return 0;
     }
-	fprintf(stdout,"\t>>>>>>>> Create no access folder <<<<<<<<<< \n");
+
+	if (!Quiet) {
+		fprintf(stdout,"\t>>>>>>>> Create no access folder <<<<<<<<<< \n");
+	}
+
 	dsi2 = &Conn2->dsi;
 	dsi = &Conn->dsi;
 	vol2  = FPOpenVol(Conn2, Vol);
@@ -300,7 +308,9 @@ fin:
 		}
 	}
 	FPCloseVol(Conn2,vol2);
-	fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+	if (!Quiet) {
+		fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+	}
 	return ret;
 }
 
@@ -318,7 +328,9 @@ DSI *dsi, *dsi2;
     if (!Conn2) {
     	return 0;
     }
-	fprintf(stdout,"\t>>>>>>>> Create ---rwx--- folder <<<<<<<<<< \n");
+	if (!Quiet) {
+		fprintf(stdout,"\t>>>>>>>> Create ---rwx--- folder <<<<<<<<<< \n");
+	}
 	dsi2 = &Conn2->dsi;
 	dsi = &Conn->dsi;
 	vol2  = FPOpenVol(Conn2, Vol);
@@ -367,7 +379,9 @@ fin:
 		}
 	}
 	FPCloseVol(Conn2,vol2);
-	fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+	if (!Quiet) {
+		fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+	}
 	return ret;
 }
 
@@ -388,7 +402,9 @@ DSI *dsi2;
     if (!Conn2) {
     	return 0;
     }
-	fprintf(stdout,"\t>>>>>>>> Create read only folder <<<<<<<<<< \n");
+	if (!Quiet) {
+		fprintf(stdout,"\t>>>>>>>> Create read only folder <<<<<<<<<< \n");
+	}
 	dsi2 = &Conn2->dsi;
 	vol2  = FPOpenVol(Conn2, Vol);
 	if (vol2 == 0xffff) {
@@ -429,7 +445,9 @@ fin:
 		}
 	}
 	FPCloseVol(Conn2,vol2);
-	fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+	if (!Quiet) {
+		fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+	}
 	return ret;
 }
 
@@ -450,7 +468,9 @@ DSI *dsi2;
     if (!Conn2) {
     	return 0;
     }
-	fprintf(stdout,"\t>>>>>>>> Create folder <<<<<<<<<< \n");
+	if (!Quiet) {
+		fprintf(stdout,"\t>>>>>>>> Create folder <<<<<<<<<< \n");
+	}
 	dsi2 = &Conn2->dsi;
 	vol2  = FPOpenVol(Conn2, Vol);
 	if (vol2 == 0xffff) {
@@ -497,7 +517,9 @@ fin:
 		}
 	}
 	FPCloseVol(Conn2,vol2);
-	fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+	if (!Quiet) {
+		fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+	}
 	return ret;
 }
 
@@ -515,7 +537,11 @@ DSI *dsi2;
     if (!Conn2) {
     	return 0;
     }
-	fprintf(stdout,"\t>>>>>>>> Delete folder <<<<<<<<<< \n");
+
+	if (!Quiet) {
+		fprintf(stdout,"\t>>>>>>>> Delete folder <<<<<<<<<< \n");
+	}
+
 	dsi2 = &Conn2->dsi;
 	vol2  = FPOpenVol(Conn2, Vol);
 	if (vol2 == 0xffff) {
@@ -544,7 +570,11 @@ DSI *dsi2;
 		return 0;
 	}
 	FPCloseVol(Conn2,vol2);
-	fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+
+	if (!Quiet) {
+		fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+	}
+
 	return 1;
 }
 
@@ -562,7 +592,9 @@ DSI *dsi2;
     if (!Conn2) {
     	return 0;
     }
-	fprintf(stdout,"\t>>>>>>>> Delete folder <<<<<<<<<< \n");
+	if (!Quiet) {
+		fprintf(stdout,"\t>>>>>>>> Delete folder <<<<<<<<<< \n");
+	}
 	dsi2 = &Conn2->dsi;
 	vol2  = FPOpenVol(Conn2, Vol);
 	if (vol2 == 0xffff) {
@@ -595,7 +627,9 @@ DSI *dsi2;
 		return 0;
 	}
 	FPCloseVol(Conn2,vol2);
-	fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+	if (!Quiet) {
+		fprintf(stdout,"\t>>>>>>>> done <<<<<<<<<< \n");
+	}
 	return 1;
 }
 
@@ -636,20 +670,24 @@ int not_valid(unsigned int ret, int mac_error, int netatalk_error)
 {
 	if (htonl(mac_error) != ret) {
 		if (!Mac) {
-    		fprintf(stdout,"MAC RESULT: %d %s\n", mac_error, afp_error(htonl(mac_error)));
+			if (!Quiet) {
+				fprintf(stdout,"MAC RESULT: %d %s\n", mac_error, afp_error(htonl(mac_error)));
+			}
 			if (htonl(netatalk_error) != ret) {
 				return 1;
 			}
     	}
     	else if (htonl(netatalk_error) == ret) {
-    	    fprintf(stdout,"Warning MAC and Netatalk now same RESULT!\n");
+		if (!Quiet) {
+			fprintf(stdout,"Warning MAC and Netatalk now same RESULT!\n");
+		}
     		return 0;
     	}
     	else
     		return 1;
 	}
-	else if (!Mac) {
-    	fprintf(stdout,"Warning MAC and Netatalk now same RESULT!\n");
+	else if (!Mac && !Quiet) {
+		fprintf(stdout,"Warning MAC and Netatalk now same RESULT!\n");
 	}
 	return 0;
 }
@@ -747,9 +785,9 @@ static char temp1[4096];
 /* ---------------------- */
 int not_valid_bitmap(unsigned int ret, unsigned int bitmap, int netatalk_error)
 {
-	if (!Mac) {
-    	fprintf(stdout,"MAC RESULT: %s\n", bitmap2text(bitmap));
-    }
+	if (!Mac && !Quiet) {
+		fprintf(stdout,"MAC RESULT: %s\n", bitmap2text(bitmap));
+	}
 	if (!error_in_list(bitmap,ret)) {
 		if (htonl(netatalk_error) == ret) {
 		    return 0;
@@ -791,7 +829,7 @@ void test_skipped(int why)
 		s = "-m (Mac server) or the volume path";
 		break;
 	case T_UNIX_PREV:
-		s ="volume with unix privilege";
+		s ="volume with UNIX privilege";
 		break;
 	case T_NO_UNIX_PREV:
 		s ="volume without UNIX privileges";
@@ -824,13 +862,19 @@ void test_skipped(int why)
 		s = "volume with extendend attribute support";
 		break;
 	case T_ADEA:
-		s = "Netatalk 3 and volume with appledouble = ea";
+		s = "Netatalk 3+ and volume with 'appledouble = ea'";
 		break;
 	case T_ADV2:
-		s = "appledouble = v2 volume";
+		s = "volume with 'appledouble = v2'";
 		break;
 	case T_NOSYML:
-		s = "volume without option 'followsymlinks'";
+		s = "volume without option 'follow symlinks'";
+		break;
+	case T_SINGLE:
+		s = "to run individually with -f";
+		break;
+	case T_VOL_BIG:
+		s = "a smaller volume";
 		break;
 	}
 	if (Color) {
@@ -870,25 +914,20 @@ void nottested_nomsg(void)
 /* ------------------------- */
 void failed(void)
 {
-	fprintf(stdout,"\tFAILED\n");
+	if (!Quiet) {
+		fprintf(stdout,"\tFAILED\n");
+	}
 	failed_nomsg();
 }
 
 /* ------------------------- */
 void nottested(void)
 {
-	fprintf(stdout,"\tNOT TESTED\n");
+	if (!Quiet) {
+		fprintf(stdout,"\tNOT TESTED\n");
+	}
 	nottested_nomsg();
 }
-
-/* ------------------------- */
-void known_failure(char *why)
-{
-	fprintf(stdout,"\tFAILED (known)\n");
-	CurTestResult = 4;
-	Why = why;
-}
-
 
 /* ------------------------- */
 void enter_test(void)
@@ -910,15 +949,14 @@ void exit_test(char *name)
 			s = "PASSED";
 		}
 		break;
-	case 4:
 	case 1:
 		if (Color) {
 			s = ANSI_BRED "FAILED" ANSI_NORMAL;
 		} else {
 			s = "FAILED";
 		}
-        fprintf(stdout, "%s - summary - ", name);
-        fprintf(stdout, "%s%s (%d)\n", s, Why, CurTestResult);
+        fprintf(stdout, "%s - ", name);
+        fprintf(stdout, "%s%s\n", s, Why);
         fflush(stdout);
 		return;
 	case 2:
@@ -932,13 +970,8 @@ void exit_test(char *name)
 		s = skipped_msg_buf;
 		break;
 	}
-#if 0
-        fprintf(stderr, "%s - summary - ", name);
-        fprintf(stderr, "%s%s (%d)\n", s, Why, CurTestResult);
-        fflush(stderr);
-#endif
-	fprintf(stdout, "%s - summary - ", name);
-	fprintf(stdout, "%s%s (%d)\n", s, Why, CurTestResult);
+	fprintf(stdout, "%s - ", name);
+	fprintf(stdout, "%s%s\n", s, Why);
     fflush(stdout);
 }
 

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -879,6 +879,9 @@ void test_skipped(int why)
 	case T_EXCLUDE:
 		s = "a newer Netatalk";
 		break;
+	case T_MANUAL:
+		s = "Interactive mode";
+		break;
 	}
 	if (Color) {
 		snprintf(skipped_msg_buf, sizeof(skipped_msg_buf), ANSI_BBLUE "SKIPPED (need %s)" ANSI_NORMAL, s);

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -833,7 +833,11 @@ void test_skipped(int why)
 		s = "volume without option 'followsymlinks'";
 		break;
 	}
-	snprintf(skipped_msg_buf, sizeof(skipped_msg_buf), "SKIPPED (need %s)", s);
+	if (Color) {
+		snprintf(skipped_msg_buf, sizeof(skipped_msg_buf), ANSI_BBLUE "SKIPPED (need %s)" ANSI_NORMAL, s);
+	} else {
+		snprintf(skipped_msg_buf, sizeof(skipped_msg_buf), "SKIPPED (need %s)", s);
+	}
 	CurTestResult = 3;
 }
 

--- a/test/testsuite/encoding_test.c
+++ b/test/testsuite/encoding_test.c
@@ -220,6 +220,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
     fprintf( stdout,"\t-v\tverbose\n");
+    fprintf( stdout,"\t-V\tvery verbose\n");
 
     exit (1);
 }
@@ -232,7 +233,7 @@ int cc;
 static char *vers = "AFPVersion 2.1";
 static char *uam = "Cleartxt Passwrd";
 
-    while (( cc = getopt( ac, av, "Rmlv34567h:p:s:u:w:d:c:" )) != EOF ) {
+    while (( cc = getopt( ac, av, "RmlvV34567h:p:s:u:w:d:c:" )) != EOF ) {
         switch ( cc ) {
         case '3':
 			vers = "AFPX03";
@@ -288,9 +289,13 @@ static char *uam = "Cleartxt Passwrd";
                 exit(1);
             }
             break;
-		case 'v':
-			Verbose = 1;
-			break;
+	case 'v':
+		Quiet = 0;
+		break;
+	case 'V':
+		Quiet = 0;
+		Verbose = 1;
+		break;
         default :
             usage( av[ 0 ] );
         }

--- a/test/testsuite/fail_spectest.c
+++ b/test/testsuite/fail_spectest.c
@@ -277,6 +277,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
     fprintf( stdout,"\t-v\tverbose\n");
+    fprintf( stdout,"\t-V\tvery verbose\n");
 
     fprintf( stdout,"\t-x\tdon't run tests known to kill very old afpd versions\n");
     fprintf( stdout,"\t-f\ttest to run\n");
@@ -292,7 +293,7 @@ int main( int ac, char **av )
 int cc;
 int ret;
 
-    while (( cc = getopt( ac, av, "v1234567h:H:p:s:u:d:w:c:f:lmx" )) != EOF ) {
+    while (( cc = getopt( ac, av, "vV1234567h:H:p:s:u:d:w:c:f:lmx" )) != EOF ) {
         switch ( cc ) {
         case '1':
 			vers = "AFPVersion 2.1";
@@ -365,9 +366,13 @@ int ret;
                 exit(1);
             }
             break;
-		case 'v':
-			Verbose = 1;
-			break;
+	case 'v':
+		Quiet = 0;
+		break;
+	case 'V':
+		Quiet = 0;
+		Verbose = 1;
+		break;
         default :
             usage( av[ 0 ] );
         }

--- a/test/testsuite/fail_spectest.c
+++ b/test/testsuite/fail_spectest.c
@@ -278,7 +278,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
     fprintf( stdout,"\t-v\tverbose\n");
 
-    fprintf( stdout,"\t-x\tdon't run tests known to kill some afpd versions\n");
+    fprintf( stdout,"\t-x\tdon't run tests known to kill very old afpd versions\n");
     fprintf( stdout,"\t-f\ttest to run\n");
     fprintf( stdout,"\t-l\tlist tests\n");
     exit (1);

--- a/test/testsuite/fail_spectest.c
+++ b/test/testsuite/fail_spectest.c
@@ -253,7 +253,6 @@ int     Version = 21;
 int     List = 0;
 int     Mac = 0;
 char    *Test;
-int     Exclude = 0;
 
 /* =============================== */
 void usage( char * av0 )
@@ -279,7 +278,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-v\tverbose\n");
     fprintf( stdout,"\t-V\tvery verbose\n");
 
-    fprintf( stdout,"\t-x\tdon't run tests known to kill very old afpd versions\n");
+    fprintf( stdout,"\t-x\tdon't run tests with known bugs\n");
     fprintf( stdout,"\t-f\ttest to run\n");
     fprintf( stdout,"\t-l\tlist tests\n");
     exit (1);

--- a/test/testsuite/failed_Error.c
+++ b/test/testsuite/failed_Error.c
@@ -53,7 +53,7 @@ unsigned char cmd;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	for (i = 0 ;i < sizeof(afp_cmd_with_vol);i++) {
 		memset(dsi->commands, 0, DSI_CMDSIZ);
@@ -109,7 +109,7 @@ unsigned char cmd;
 
 	dsi = &Conn->dsi;
 
-	enter_test();
+	ENTER_TEST
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {

--- a/test/testsuite/failed_Error.c
+++ b/test/testsuite/failed_Error.c
@@ -54,8 +54,6 @@ unsigned char cmd;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Error:test35: illegal volume (-5019 AFP_ERRPARAM)\n");
 
 	for (i = 0 ;i < sizeof(afp_cmd_with_vol);i++) {
 		memset(dsi->commands, 0, DSI_CMDSIZ);
@@ -80,11 +78,13 @@ unsigned char cmd;
 		ret = dsi->header.dsi_code;
 
     	if (ntohl(AFPERR_PARAM) != ret) {
+		if (!Quiet) {
 			fprintf(stdout,"\tFAILED command %3i %s\t result %d %s\n", cmd, AfpNum2name(cmd),ntohl(ret), afp_error(ret));
+		}
 			failed_nomsg();
     	}
     }
-	exit_test("test35");
+	exit_test("Error:test35: illegal volume (-5019 AFP_ERRPARAM)");
 }
 
 /* -------------------------------------------- */
@@ -110,8 +110,6 @@ unsigned char cmd;
 	dsi = &Conn->dsi;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"Errror:test37: no folder error ==> ERR_NOOBJ\n");
 
 	dir  = FPCreateDir(Conn,vol, DIRDID_ROOT , name);
 	if (!dir) {
@@ -145,13 +143,15 @@ unsigned char cmd;
 		my_dsi_cmd_receive(dsi);
 		ret = dsi->header.dsi_code;
     	if (ntohl(AFPERR_NOOBJ) != ret) {
+		if (!Quiet) {
 			fprintf(stdout,"\tFAILED command %3i %s\t result %d %s\n", cmd, AfpNum2name(cmd),ntohl(ret), afp_error(ret));
+		}
 			failed_nomsg();
     	}
     }
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
-	exit_test("test37");
+	exit_test("Errror:test37: no folder error ==> ERR_NOOBJ");
 }
 
 
@@ -160,6 +160,7 @@ void Error_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"Various errors\n");
+    fprintf(stdout,"-------------------\n");
 	test35();
 	test37();
 }

--- a/test/testsuite/failed_FPEnumerate.c
+++ b/test/testsuite/failed_FPEnumerate.c
@@ -15,7 +15,7 @@ char *name2 = "t28 file";
 int  dir;
 int  dir1;
 
-	enter_test();
+	ENTER_TEST
 
 	/* we need to empty the server cashe */
 	FPCloseVol(Conn, vol);

--- a/test/testsuite/failed_FPEnumerate.c
+++ b/test/testsuite/failed_FPEnumerate.c
@@ -16,8 +16,6 @@ int  dir;
 int  dir1;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPEnumerate:test28: test search by ID\n");
 
 	/* we need to empty the server cashe */
 	FPCloseVol(Conn, vol);
@@ -86,7 +84,7 @@ fin:
 	FAIL (dir1 && FPDelete(Conn, vol,  dir1 , ""))
 	FAIL (dir && FPDelete(Conn, vol,  dir, ""))
 test_exit:
-	exit_test("test28");
+	exit_test("FPEnumerate:test28: test search by ID");
 }
 
 /* ----------- */
@@ -94,5 +92,6 @@ void FPEnumerate_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPEnumerate page 150\n");
+    fprintf(stdout,"-------------------\n");
     test28();
 }

--- a/test/testsuite/failed_FPExchangeFiles.c
+++ b/test/testsuite/failed_FPExchangeFiles.c
@@ -18,8 +18,6 @@ int temp;
 uint16_t vol = VolID;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPExchangeFiles:test108: exchange files\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -43,7 +41,9 @@ uint16_t vol = VolID;
 #ifdef QUIRK
 		fprintf(stdout,"\tFAILED (IGNORED) %x should be %x\n", temp, fid_name);
 #else
-		fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name);
+		}
 		failed_nomsg();
 #endif
 	}
@@ -51,19 +51,25 @@ uint16_t vol = VolID;
 #ifdef QUIRK
 		fprintf(stdout,"\tFAILED (IGNORED) %x should be %x\n", temp, fid_name1);
 #else
-		fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name1);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", temp, fid_name1);
+		}
 		failed_nomsg();
 #endif
 	}
 
 	read_fork(Conn, vol,  DIRDID_ROOT , name, 3);
 	if (strcmp(Data,"red")) {
-		fprintf(stdout,"\tFAILED should be red\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be red\n");
+		}
 		failed_nomsg();
 	}
 	read_fork(Conn,  vol, dir , name1, 4);
 	if (strcmp(Data,"blue")) {
-		fprintf(stdout,"\tFAILED should be blue\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be blue\n");
+		}
 		failed_nomsg();
 	}
 	FAIL (FPDelete(Conn, vol,  dir , name1))
@@ -71,7 +77,7 @@ uint16_t vol = VolID;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, ndir))
 test_exit:
-	exit_test("test108");
+	exit_test("FPExchangeFiles:test108: exchange files");
 }
 
 /* ------------------------- */
@@ -90,8 +96,6 @@ uint16_t vol = VolID;
 int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPExchangeFiles:test111: exchange open files\n");
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)){
 		nottested();
@@ -121,12 +125,16 @@ int ret;
 
 	read_fork(Conn, vol, DIRDID_ROOT , name, 3);
 	if (strcmp(Data,"red")) {
-		fprintf(stdout,"\tFAILED should be red\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be red\n");
+		}
 		failed_nomsg();
 	}
 	read_fork(Conn, vol, dir , name1, 4);
 	if (strcmp(Data,"blue")) {
-		fprintf(stdout,"\tFAILED should be blue\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be blue\n");
+		}
 		failed_nomsg();
 	}
 
@@ -153,7 +161,9 @@ int ret;
 #ifdef QUIRK
 		fprintf(stdout,"\tFAILED (IGNORED) %x should be %x\n", ret, fid_name);
 #else
-		fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name);
+		}
 		failed_nomsg();
 #endif
 	}
@@ -162,7 +172,9 @@ int ret;
 #ifdef QUIRK
 		fprintf(stdout,"\tFAILED (IGNORED) %x should be %x\n", ret, fid_name1);
 #else
-		fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name1);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name);
+		}
 		failed_nomsg();
 #endif
 	}
@@ -172,7 +184,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, ndir))
 test_exit:
-	exit_test("test111");
+	exit_test("FPExchangeFiles:test111: exchange open files");
 }
 
 
@@ -181,6 +193,7 @@ void FPExchangeFiles_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPExchangeFiles page 166\n");
+    fprintf(stdout,"-------------------\n");
 	test108();
 	test111();
 }

--- a/test/testsuite/failed_FPExchangeFiles.c
+++ b/test/testsuite/failed_FPExchangeFiles.c
@@ -17,7 +17,7 @@ int fid_name1;
 int temp;
 uint16_t vol = VolID;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
@@ -95,7 +95,7 @@ int fid_name1;
 uint16_t vol = VolID;
 int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)){
 		nottested();

--- a/test/testsuite/failed_FPMoveAndRename.c
+++ b/test/testsuite/failed_FPMoveAndRename.c
@@ -16,8 +16,6 @@ uint16_t vol = VolID;
 int ret;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPMoveAndRename:test73: Move and rename\n");
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name2))) {
 		nottested();
@@ -83,7 +81,7 @@ int ret;
 	FAIL (FPDelete(Conn, vol,  dir1, name))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name2))
 test_exit:
-	exit_test("test73");
+	exit_test("FPMoveAndRename:test73: Move and rename");
 }
 
 static char temp[MAXPATHLEN];
@@ -100,8 +98,6 @@ uint16_t vol = VolID;
 int id,id1;
 
 	enter_test();
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"FPMoveAndRename:test302: file renamed by someone else, cnid not updated\n");
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);
@@ -122,7 +118,9 @@ int id,id1;
 		sprintf(temp,"%s/%s/%s", Path, name, name1);
 		sprintf(temp1,"%s/%s/%s", Path, name, name2);
 		if (rename(temp, temp1) < 0) {
-			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+			}
 			failed_nomsg();
 		}
 	}
@@ -131,13 +129,15 @@ int id,id1;
 	}
 	id1 = get_fid(Conn, vol, dir , name2);
 	if (id != id1) {
-		fprintf(stdout,"\tFAILED id are not the same %d %d\n", ntohl(id), ntohl(id1));
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED id are not the same %d %d\n", ntohl(id), ntohl(id1));
+		}
 		failed_nomsg();
 	}
 	FAIL (FPDelete(Conn, vol,  dir , name2))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("test302");
+	exit_test("FPMoveAndRename:test302: file renamed by someone else, cnid not updated");
 }
 
 
@@ -146,6 +146,7 @@ void FPMoveAndRename_test()
 {
     fprintf(stdout,"===================\n");
     fprintf(stdout,"FPMoveAndRename page 223\n");
+    fprintf(stdout,"-------------------\n");
     test73();
     test302();
 }

--- a/test/testsuite/failed_FPMoveAndRename.c
+++ b/test/testsuite/failed_FPMoveAndRename.c
@@ -15,7 +15,7 @@ char *name2 = "t73 dir";
 uint16_t vol = VolID;
 int ret;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name2))) {
 		nottested();
@@ -97,7 +97,7 @@ int  dir;
 uint16_t vol = VolID;
 int id,id1;
 
-	enter_test();
+	ENTER_TEST
 
 	if (!Mac && !Path) {
 		test_skipped(T_MAC_PATH);

--- a/test/testsuite/logintest.c
+++ b/test/testsuite/logintest.c
@@ -135,6 +135,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
     fprintf( stdout,"\t-v\tverbose\n");
+    fprintf( stdout,"\t-V\tvery verbose\n");
 
     exit (1);
 }
@@ -146,7 +147,7 @@ int cc;
 static char *uam = "Cleartxt Passwrd";
 unsigned int ret;
 
-    while (( cc = getopt( ac, av, "v1234567h:p:u:w:m" )) != EOF ) {
+    while (( cc = getopt( ac, av, "vV1234567h:p:u:w:m" )) != EOF ) {
         switch ( cc ) {
         case '1':
 			vers = "AFPVersion 2.1";
@@ -195,9 +196,13 @@ unsigned int ret;
                 exit(1);
             }
             break;
-		case 'v':
-			Verbose = 1;
-			break;
+	case 'v':
+		Quiet = 0;
+		break;
+	case 'V':
+		Quiet = 0;
+		Verbose = 1;
+		break;
         default :
             usage( av[ 0 ] );
         }

--- a/test/testsuite/meson.build
+++ b/test/testsuite/meson.build
@@ -24,7 +24,7 @@ afparg_sources = [
     'afparg_FPfuncs.c',
 ]
 
-afparg = executable(
+executable(
     'afparg',
     afparg_sources,
     include_directories: root_includes,
@@ -35,7 +35,7 @@ lantest_sources = [
     'lantest.c',
 ]
 
-lantest = executable(
+executable(
     'lantest',
     lantest_sources,
     include_directories: root_includes,
@@ -47,7 +47,7 @@ afp_ls_sources = [
     'afp_ls.c',
 ]
 
-afp_ls = executable(
+executable(
     'afp_ls',
     afp_ls_sources,
     include_directories: root_includes,
@@ -58,7 +58,7 @@ encoding_test_sources = [
     'encoding_test.c',
 ]
 
-encoding_test = executable(
+executable(
     'encoding_test',
     encoding_test_sources,
     include_directories: root_includes,
@@ -69,7 +69,7 @@ login_test_sources = [
     'logintest.c',
 ]
 
-login_test = executable(
+executable(
     'logintest',
     login_test_sources,
     include_directories: root_includes,
@@ -80,7 +80,7 @@ rotest_sources = [
     'rotest.c',
 ]
 
-rotest = executable(
+executable(
     'rotest',
     rotest_sources,
     include_directories: root_includes,
@@ -91,7 +91,7 @@ speedtest_sources = [
     'speedtest.c',
 ]
 
-speedtest = executable(
+executable(
     'speedtest',
     speedtest_sources,
     include_directories: root_includes,
@@ -158,9 +158,10 @@ spectest_sources = [
     'Error.c',
     'Utf8.c',
     'FPGetACL.c',
+    'FPSync.c',
 ]
 
-spectest = executable(
+executable(
     'spectest',
     spectest_sources,
     include_directories: root_includes,
@@ -172,7 +173,7 @@ sleeptest_sources = [
     'FPzzz.c',
 ]
 
-sleeptest = executable(
+executable(
     'sleeptest',
     sleeptest_sources,
     include_directories: root_includes,
@@ -187,7 +188,7 @@ fail_spectest_sources = [
     'failed_Error.c',
 ]
 
-fail_spectest = executable(
+executable(
     'fail_spectest',
     fail_spectest_sources,
     include_directories: root_includes,
@@ -195,7 +196,7 @@ fail_spectest = executable(
     c_args: ['-DQUIRK'],
 )
 
-T2_spectest_sources = [
+t2_spectest_sources = [
     'T2_spectest.c',
     'T2_FPByteRangeLock.c',
     'T2_FPDelete.c',
@@ -213,9 +214,9 @@ T2_spectest_sources = [
     'T2_FPSetForkParms.c',
 ]
 
-T2_spectest = executable(
+executable(
     'T2_spectest',
-    T2_spectest_sources,
+    t2_spectest_sources,
     include_directories: root_includes,
     link_with: libafptest,
 )

--- a/test/testsuite/rotest.c
+++ b/test/testsuite/rotest.c
@@ -359,6 +359,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
     fprintf( stdout,"\t-v\tverbose\n");
+    fprintf( stdout,"\t-V\tvery verbose\n");
 
     exit (1);
 }
@@ -370,7 +371,7 @@ int cc;
 int ret;
 static char *uam = "Cleartxt Passwrd";
 
-    while (( cc = getopt( ac, av, "v1234567h:p:u:w:ms:" )) != EOF ) {
+    while (( cc = getopt( ac, av, "vV1234567h:p:u:w:ms:" )) != EOF ) {
         switch ( cc ) {
         case 's':
             Vol = strdup(optarg);
@@ -421,10 +422,13 @@ static char *uam = "Cleartxt Passwrd";
                 fprintf(stdout, "Bad port.\n");
                 exit(1);
             }
-            break;
-		case 'v':
-			Verbose = 1;
-			break;
+	case 'v':
+		Quiet = 0;
+		break;
+	case 'V':
+		Quiet = 0;
+		Verbose = 1;
+		break;
         default :
             usage( av[ 0 ] );
         }

--- a/test/testsuite/rotest.c
+++ b/test/testsuite/rotest.c
@@ -90,7 +90,7 @@ DSI *dsi = &Conn->dsi;
 uint32_t flen;
 unsigned int ret;
 
-	enter_test();
+	ENTER_TEST
     fprintf(stdout,"===================\n");
     fprintf(stdout,"Read only volume\n");
 	VolID = FPOpenVol(Conn, Vol);

--- a/test/testsuite/sleeptest.c
+++ b/test/testsuite/sleeptest.c
@@ -181,6 +181,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
     fprintf( stdout,"\t-v\tverbose\n");
+    fprintf( stdout,"\t-V\tvery verbose\n");
 
     fprintf( stdout,"\t-x\tdon't run tests known to kill very old afpd versions\n");
     fprintf( stdout,"\t-f\ttest to run\n");
@@ -197,7 +198,7 @@ int main( int ac, char **av )
 int cc;
 int ret;
 
-    while (( cc = getopt( ac, av, "v1234567ah:H:p:s:S:u:d:w:c:f:Llmxi" )) != EOF ) {
+    while (( cc = getopt( ac, av, "vV1234567ah:H:p:s:S:u:d:w:c:f:Llmxi" )) != EOF ) {
         switch ( cc ) {
         case '1':
 			vers = "AFPVersion 2.1";
@@ -280,6 +281,10 @@ int ret;
             }
             break;
 	case 'v':
+		Quiet = 0;
+		break;
+	case 'V':
+		Quiet = 0;
 		Verbose = 1;
 		break;
 	case 'i':

--- a/test/testsuite/sleeptest.c
+++ b/test/testsuite/sleeptest.c
@@ -160,7 +160,7 @@ enum adouble adouble = AD_EA;
 void usage( char * av0 )
 {
     fprintf( stdout, "usage:\t%s [-aLmn] [-h host] [-p port] [-s vol] [-u user] [-w password] -f [call]\n", av0 );
-    fprintf( stdout,"\t-a\tvolume is adouble:v2 instead of default adouble:ea\n");
+    fprintf( stdout,"\t-a\tvolume is appledouble = v2 instead of default appledouble = ea\n");
     fprintf( stdout,"\t-L\tserver without working fcntl locking, skip tests using it\n");
     fprintf( stdout,"\t-m\tserver is a Mac\n");
     fprintf( stdout,"\t-h\tserver host name (default localhost)\n");
@@ -182,7 +182,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
     fprintf( stdout,"\t-v\tverbose\n");
 
-    fprintf( stdout,"\t-x\tdon't run tests known to kill some afpd versions\n");
+    fprintf( stdout,"\t-x\tdon't run tests known to kill very old afpd versions\n");
     fprintf( stdout,"\t-f\ttest to run\n");
     fprintf( stdout,"\t-l\tlist tests\n");
     fprintf( stdout,"\t-i\tinteractive mode, prompts before every test (debug purposes)\n");

--- a/test/testsuite/sleeptest.c
+++ b/test/testsuite/sleeptest.c
@@ -152,7 +152,6 @@ int     Version = 21;
 int     List = 0;
 int     Mac = 0;
 char    *Test;
-int     Exclude = 0;
 int		Locking;
 enum adouble adouble = AD_EA;
 
@@ -183,7 +182,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-v\tverbose\n");
     fprintf( stdout,"\t-V\tvery verbose\n");
 
-    fprintf( stdout,"\t-x\tdon't run tests known to kill very old afpd versions\n");
+    fprintf( stdout,"\t-x\tdon't run tests with known bugs\n");
     fprintf( stdout,"\t-f\ttest to run\n");
     fprintf( stdout,"\t-l\tlist tests\n");
     fprintf( stdout,"\t-i\tinteractive mode, prompts before every test (debug purposes)\n");

--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -100,6 +100,7 @@ extern void test_skipped(int why);
 #define T_SINGLE     22
 #define T_VOL_BIG    23
 #define T_EXCLUDE    24
+#define T_MANUAL     25
 
 /* ---------------------------------
 */

--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -107,6 +107,8 @@ extern void test_skipped(int why);
 #define T_VOL_BIG    23
 #define T_EXCLUDE    24
 #define T_MANUAL     25
+#define T_AFP31      26
+#define T_AFP32      27
 
 /* ---------------------------------
 */

--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -99,6 +99,7 @@ extern void test_skipped(int why);
 #define T_NO_UNIX_PREV 21
 #define T_SINGLE     22
 #define T_VOL_BIG    23
+#define T_EXCLUDE    24
 
 /* ---------------------------------
 */

--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -15,20 +15,18 @@
 #include "test.h"
 
 /* Defines */
-#if 0
-#define FAIL(a) if ((a)) { failed();}
-#else
 #define FAIL(a) \
     if ((a)) { \
-        if (Color) { \
-            fprintf(stdout, ANSI_BRED"[%s:%d] " #a "\n" ANSI_NORMAL, __FILE__, __LINE__);\
-        } else {\
-            fprintf(stdout, "[%s:%d] " #a "\n", __FILE__, __LINE__); \
+        if (!Quiet) { \
+            if (Color) { \
+                fprintf(stdout, ANSI_BRED"[%s:%d] " #a "\n" ANSI_NORMAL, __FILE__, __LINE__);\
+            } else {\
+                fprintf(stdout, "[%s:%d] " #a "\n", __FILE__, __LINE__); \
+            } \
         } \
         failed_nomsg(); \
     }
 
-#endif
 #define EXPECT_FAIL(a, b) do { int _experr;  _experr = (a); if (htonl(_experr) != (b)) { failed(); } } while(0);
 #define FAILEXIT(a, label) if ((a)) { failed(); goto label;}
 #define STATIC
@@ -70,7 +68,6 @@ extern void failed_nomsg(void);
 extern void skipped_nomsg(void);
 extern void nottested_nomsg(void);
 extern void failed(void);
-extern void known_failure(char *why);
 extern void enter_test(void);
 extern void exit_test(char *name);
 
@@ -100,6 +97,8 @@ extern void test_skipped(int why);
 #define T_ADV2       19
 #define T_AFP30      20
 #define T_NO_UNIX_PREV 21
+#define T_SINGLE     22
+#define T_VOL_BIG    23
 
 /* ---------------------------------
 */

--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -31,6 +31,12 @@
 #define FAILEXIT(a, label) if ((a)) { failed(); goto label;}
 #define STATIC
 
+#define ENTER_TEST \
+    if (!Quiet) { \
+            fprintf(stdout, "############## entering %s ##############\n", __func__); \
+        } \
+    enter_test(); \
+
 /* Types */
 enum adouble {
     AD_EA = 1,

--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -47,7 +47,6 @@ enum adouble {
 extern uint16_t VolID;
 extern int Mac;
 extern int ExitCode;
-extern int Exclude;
 extern enum adouble adouble;
 
 /* Functions */

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -277,7 +277,6 @@ int     Version = 21;
 int     List = 0;
 int     Mac = 0;
 char    *Test;
-int     Exclude = 0;
 int		Locking;
 enum adouble adouble = AD_EA;
 
@@ -308,7 +307,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-v\tverbose\n");
     fprintf( stdout,"\t-V\tvery verbose\n");
 
-    fprintf( stdout,"\t-x\tdon't run tests known to kill very old afpd versions\n");
+    fprintf( stdout,"\t-x\tdon't run tests with known bugs\n");
     fprintf( stdout,"\t-f\ttest to run\n");
     fprintf( stdout,"\t-l\tlist tests\n");
     fprintf( stdout,"\t-i\tinteractive mode, prompts before every test (debug purposes)\n");

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -71,6 +71,7 @@ EXT_FN(FPWriteExt);
 EXT_FN(Error);
 EXT_FN(Utf8);
 EXT_FN(FPGetACL);
+EXT_FN(FPSync);
 
 
 struct test_fn {
@@ -145,6 +146,7 @@ FN_N(FPWriteExt)
 FN_N(Error)
 FN_N(Utf8)
 FN_N(FPGetACL)
+FN_N(FPSync)
 #endif
 
 {NULL, NULL},

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -306,7 +306,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
     fprintf( stdout,"\t-v\tverbose\n");
-    fprintf( stdout,"\t-Q\tnon-quiet\n");
+    fprintf( stdout,"\t-V\tvery verbose\n");
 
     fprintf( stdout,"\t-x\tdon't run tests known to kill very old afpd versions\n");
     fprintf( stdout,"\t-f\ttest to run\n");
@@ -324,7 +324,7 @@ int main( int ac, char **av )
 int cc;
 int ret;
 
-    while (( cc = getopt( ac, av, "v1234567ah:H:p:s:S:u:d:w:c:f:LlmxiCQ" )) != EOF ) {
+    while (( cc = getopt( ac, av, "vV1234567ah:H:p:s:S:u:d:w:c:f:LlmxiC" )) != EOF ) {
         switch ( cc ) {
         case '1':
 			vers = "AFPVersion 2.1";
@@ -407,10 +407,11 @@ int ret;
             }
             break;
 	case 'v':
-		Verbose = 1;
-		break;
-	case 'Q':
 		Quiet = 0;
+		break;
+	case 'V':
+		Quiet = 0;
+		Verbose = 1;
 		break;
 	case 'i':
 		Interactive = 1;

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -285,7 +285,7 @@ enum adouble adouble = AD_EA;
 void usage( char * av0 )
 {
     fprintf( stdout, "usage:\t%s [-aLmn] [-h host] [-p port] [-s vol] [-u user] [-w password] -f [call]\n", av0 );
-    fprintf( stdout,"\t-a\tvolume is adouble:v2 instead of default adouble:ea\n");
+    fprintf( stdout,"\t-a\tvolume is appledouble = v2 instead of default appledouble = ea\n");
     fprintf( stdout,"\t-L\tserver without working fcntl locking, skip tests using it\n");
     fprintf( stdout,"\t-m\tserver is a Mac\n");
     fprintf( stdout,"\t-h\tserver host name (default localhost)\n");
@@ -308,7 +308,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-v\tverbose\n");
     fprintf( stdout,"\t-Q\tnon-quiet\n");
 
-    fprintf( stdout,"\t-x\tdon't run tests known to kill some afpd versions\n");
+    fprintf( stdout,"\t-x\tdon't run tests known to kill very old afpd versions\n");
     fprintf( stdout,"\t-f\ttest to run\n");
     fprintf( stdout,"\t-l\tlist tests\n");
     fprintf( stdout,"\t-i\tinteractive mode, prompts before every test (debug purposes)\n");

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -304,6 +304,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
     fprintf( stdout,"\t-v\tverbose\n");
+    fprintf( stdout,"\t-Q\tnon-quiet\n");
 
     fprintf( stdout,"\t-x\tdon't run tests known to kill some afpd versions\n");
     fprintf( stdout,"\t-f\ttest to run\n");
@@ -321,7 +322,7 @@ int main( int ac, char **av )
 int cc;
 int ret;
 
-    while (( cc = getopt( ac, av, "v1234567ah:H:p:s:S:u:d:w:c:f:LlmxiC" )) != EOF ) {
+    while (( cc = getopt( ac, av, "v1234567ah:H:p:s:S:u:d:w:c:f:LlmxiCQ" )) != EOF ) {
         switch ( cc ) {
         case '1':
 			vers = "AFPVersion 2.1";
@@ -405,6 +406,8 @@ int ret;
             break;
 	case 'v':
 		Verbose = 1;
+		break;
+	case 'Q':
 		Quiet = 0;
 		break;
 	case 'i':

--- a/test/testsuite/spectest.sh
+++ b/test/testsuite/spectest.sh
@@ -77,26 +77,26 @@ echo "====================================="
 echo "Test summary"
 echo "------------"
 echo "Passed tests:"
-grep "summary.*PASS" ./test/testsuite/spectest.log | wc -l
+grep "PASS" ./test/testsuite/spectest.log | wc -l
 echo "Failed tests:"
-grep "summary.*FAIL" ./test/testsuite/spectest.log | wc -l
+grep "FAIL" ./test/testsuite/spectest.log | wc -l
 echo "Skipped tests:"
-egrep "summary.*NOT TESTED|summary.*SKIPPED" ./test/testsuite/spectest.log | wc -l
+egrep "NOT TESTED|SKIPPED" ./test/testsuite/spectest.log | wc -l
 echo "====================================="
 
 echo "Failed tests"
 echo "------------"
-grep "summary.*FAIL" ./test/testsuite/spectest.log | sed s/test//g | sed s/summary\ -\ //g | sort -n | uniq
+grep "FAIL" ./test/testsuite/spectest.log | sort -n | uniq
 echo "====================================="
 
 echo "Skipped tests"
 echo "------------"
-egrep "summary.*NOT TESTED|summary.*SKIPPED" ./test/testsuite/spectest.log | sed s/test//g | sed s/summary\ -\ //g | sort -n | uniq
+egrep "NOT TESTED|SKIPPED" ./test/testsuite/spectest.log | sort -n | uniq
 echo "====================================="
 
 echo "Successful tests"
 echo "------------"
-grep "summary.*PASSED" ./test/testsuite/spectest.log | sed s/test//g | sed s/summary\ -\ //g | sort -n | uniq
+grep "PASSED" ./test/testsuite/spectest.log | sort -n | uniq
 echo "====================================="
 
 # cleanup

--- a/test/testsuite/spectest.sh
+++ b/test/testsuite/spectest.sh
@@ -61,13 +61,13 @@ rm -f ./test/testsuite/spectest.log
 
 ##
 echo "Running spectest with two users..."
-./test/testsuite/spectest -"$AFPVERSION" -h "$AFPSERVER" -p "$AFPPORT" -u "$USER1" -d "$USER2" -w "$PASSWD" -s "$VOLUME1" -S "$VOLUME2" >> ./test/testsuite/spectest.log 2>&1
+./test/testsuite/spectest -"$AFPVERSION" -x -h "$AFPSERVER" -p "$AFPPORT" -u "$USER1" -d "$USER2" -w "$PASSWD" -s "$VOLUME1" -S "$VOLUME2" >> ./test/testsuite/spectest.log 2>&1
 check_return
 
 ##
 if test ! -z "$LOCALVOL1PATH" ; then
     echo "Running spectest with local filesystem modifications..."
-    ./test/testsuite/T2_spectest -"$AFPVERSION" -h "$AFPSERVER" -p "$AFPPORT" -u "$USER1" -d "$USER2" -w "$PASSWD" -s "$VOLUME1" -S "$VOLUME2" -c "$LOCALVOL1PATH" >> ./test/testsuite/spectest.log 2>&1
+    ./test/testsuite/T2_spectest -"$AFPVERSION" -x -h "$AFPSERVER" -p "$AFPPORT" -u "$USER1" -d "$USER2" -w "$PASSWD" -s "$VOLUME1" -S "$VOLUME2" -c "$LOCALVOL1PATH" >> ./test/testsuite/spectest.log 2>&1
     check_return
 else
     echo "Skipping spectest with local filesystem modifications..."

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -1413,6 +1413,7 @@ int cc;
 		Quiet = 0;
 		break;
 	case 'V':
+		Quiet = 0;
 		Verbose = 1;
 		break;
 	case 'i':

--- a/test/testsuite/temp.c
+++ b/test/testsuite/temp.c
@@ -942,19 +942,27 @@ struct stat st;
 	}
 	read_fork( DIRDID_ROOT , name, 3);
 	if (strcmp(Data,"red")) {
-		fprintf(stdout,"\tFAILED should be red\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be red\n");
+		}
 
 	}
 	read_fork( dir , name1, 4);
 	if (strcmp(Data,"blue")) {
-		fprintf(stdout,"\tFAILED should be blue\n");
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED should be blue\n");
+		}
 	}
 	if ((ret = get_fid(DIRDID_ROOT , name)) != fid_name) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name);
+		}
 	}
 
 	if ((ret = get_fid(dir , name1)) != fid_name1) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name1);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name);
+		}
 	}
 
 	if (FPDelete(Conn, vol,  dir , name1)) { fprintf(stdout,"\tFAILED\n");}
@@ -1066,7 +1074,9 @@ struct stat st;
 	}
 
 	if ((ret = get_fid(dir , name1)) != fid_name) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name);
+		}
 	}
 
 	if (FPDelete(Conn, vol,  dir , name1)) { fprintf(stdout,"\tFAILED\n");}
@@ -1115,7 +1125,9 @@ struct stat st;
 	}
 
 	if ((ret = get_fid(dir , name)) != fid_name) {
-		fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name);
+		if (!Quiet) {
+			fprintf(stdout,"\tFAILED %x should be %x\n", ret, fid_name);
+		}
 	}
 
 	if (FPDelete(Conn, vol,  dir , name)) { fprintf(stdout,"\tFAILED\n");}

--- a/test/testsuite/test.h
+++ b/test/testsuite/test.h
@@ -143,3 +143,4 @@ extern int Interactive;
 extern int Throttle;
 extern int Recurse;
 extern int Twice;
+extern int Exclude;


### PR DESCRIPTION
Overhaul of testsuite to reduce default verbosity for more readable test logs, and treat NOT TESTED and SKIPPED as non-failure for more consistent results in a CI environment.

Restore a handful of tests that were made functional by recent code improvements.

Standardize on `-v` for medium verbosity and `-V` for high level of verbosity logging.

Refashion the `-x` (Exclude) option for flagging tests that are failing with Netatalk 4.0 for unknown reasons. Investigation required.

Colorize also the SKIPPED test results.

All of this results in a cleaner test log and test report generated by spectest.sh that is much more readable. Sample:

```
===================
FPAddAPPL page 94
-------------------
FPAddAPPL:test214: test appl - NOT TESTED
===================
FPAddComment page 96
-------------------
FPAddComment:test55: add comment - NOT TESTED
===================
FPByteRangeLock page 101
-------------------
FPByteRangeLock:test60: illegal fork - FAILED
FPByteRangeLock:test80: Resource Fork FPByteLock Read write - NOT TESTED
FPByteRangeLock:test329: FPByteLock 2users DATA FORK - NOT TESTED
FPByteRangeLock:test330: pre OSX trash folder - NOT TESTED
FPByteRangeLock:test410: FPByteLock 2users DATA FORK - NOT TESTED
FPByteRangeLock:test366: Locks released on exit - SKIPPED (need to run individually with -f)
===================
FPByteRangeLockExt page 105
-------------------
FPByteRangeLockExt:test195: illegal fork - FAILED
===================
FPCatSearch page 110
-------------------
FPCatSearch:test225: Catalog search - NOT TESTED
```