### PR TITLE
Fix the spelling of resource forks

### DIFF
--- a/etc/afpd/acls.c
+++ b/etc/afpd/acls.c
@@ -1106,7 +1106,7 @@ static int remove_acl(const struct vol *vol,const char *path, int dir)
     int ret = AFP_OK;
 
 #if (defined HAVE_NFSV4_ACLS || defined HAVE_POSIX_ACLS)
-    /* Ressource etc. first */
+    /* Resource etc. first */
     if ((ret = vol->vfs->vfs_remove_acl(vol, path, dir)) != AFP_OK)
         return ret;
     /* now the data fork or dir */
@@ -1195,7 +1195,7 @@ static int set_acl(const struct vol *vol,
     }
     LOG(log_debug7, logtype_afpd, "set_acl: copied %d trivial ACEs", trivial_ace_count);
 
-    /* Ressourcefork first */
+    /* Resourcefork first */
     if ((ret = (vol->vfs->vfs_acl(vol, name, ACE_SETACL, new_aces_count, new_aces))) != 0) {
         LOG(log_debug, logtype_afpd, "set_acl: error setting acl: %s", strerror(errno));
         switch (errno) {

--- a/etc/afpd/catsearch.c
+++ b/etc/afpd/catsearch.c
@@ -996,12 +996,12 @@ static int catsearch_afp(AFPObj *obj _U_, char *ibuf, size_t ibuflen,
 	    	c2.offcnt = ntohs(c2.offcnt);
 		}
 		else if (c1.dbitmap == 0) {
-			/* ressource fork length */
+			/* resource fork length */
 		}
 		else {
 	    	return AFPERR_BITMAP;  /* error */
 		}
-    } /* Offspring count/ressource fork length */
+    } /* Offspring count/resource fork length */
 
     /* Long name */
     if (c1.rbitmap & (1U << FILPBIT_LNAME)) {

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -251,7 +251,7 @@ uint32_t get_id(struct vol *vol,
             }
         }
         else if (adp && adcnid && (adcnid != dbcnid)) { /* (3) */
-            /* Update the ressource fork. For a folder adp is always null */
+            /* Update the resource fork. For a folder adp is always null */
             LOG(log_debug, logtype_afpd, "get_id(%s/%s): calling ad_setid(old: %u, new: %u)",
                 getcwdpath(), upath, htonl(adcnid), htonl(dbcnid));
             if (ad_setid(adp, st->st_dev, st->st_ino, dbcnid, did, vol->v_stamp)) {
@@ -1190,7 +1190,7 @@ int renamefile(struct vol *vol, struct dir *ddir, int sdir_fd, char *src, char *
         }
     }
 
-    /* don't care if we can't open the newly renamed ressource fork */
+    /* don't care if we can't open the newly renamed resource fork */
     if (ad_open(adp, dst, ADFLAGS_HF | ADFLAGS_RDWR) == 0) {
         ad_setname(adp, newname);
         ad_flush( adp );
@@ -1620,10 +1620,10 @@ int deletefile(const struct vol *vol, int dirfd, char *file, int checkAttrib)
     if ( adp && AD_RSRC_OPEN(adp) ) { /* there's a resource fork */
         adflags |= ADFLAGS_RF;
         /* FIXME we have a pb here because we want to know if a file is open
-         * there's a 'priority inversion' if you can't open the ressource fork RW
+         * there's a 'priority inversion' if you can't open the resource fork RW
          * you can delete it if it's open because you can't get a write lock.
          *
-         * ADLOCK_FILELOCK means the whole ressource fork, not only after the
+         * ADLOCK_FILELOCK means the whole resource fork, not only after the
          * metadatas
          *
          * FIXME it doesn't work for RFORK open read only and fork open without deny mode
@@ -2268,7 +2268,7 @@ int afp_exchangefiles(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U
             ad_close(addp, ADFLAGS_HF);
     }
 
-    /* FIXME: we should switch ressource fork too */
+    /* FIXME: we should switch resource fork too */
 
     /* here we need to reopen if crossdev */
     if (sid && ad_setid(addp, destst.st_dev, destst.st_ino,  sid, sdir->d_did, vol->v_stamp))

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -357,7 +357,7 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, si
 
     ret = AFPERR_NOOBJ;
 
-    /* First ad_open(), opens data or ressource fork */
+    /* First ad_open(), opens data or resource fork */
     if (ad_open(ofork->of_ad, upath, adflags, 0666) < 0) {
         switch (errno) {
         case EROFS:
@@ -439,7 +439,7 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, si
     memcpy(rbuf, &bitmap, sizeof( uint16_t ));
     rbuf += sizeof( uint16_t );
 
-    /* check  WriteInhibit bit if we have a ressource fork
+    /* check  WriteInhibit bit if we have a resource fork
      * the test is done here, after some Mac trafic capture
      */
     if (ad_meta_fileno(ofork->of_ad) != -1) {   /* META */
@@ -485,7 +485,7 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, si
         if ((access & OPENACC_WR))
             ofork->of_flags |= AFPFORK_ACCWR;
     }
-    /* the file may be open read only without ressource fork */
+    /* the file may be open read only without resource fork */
     if ((access & OPENACC_RD))
         ofork->of_flags |= AFPFORK_ACCRD;
 
@@ -742,7 +742,7 @@ int afp_bytelock_ext(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf, size_t
  * Read *rbuflen bytes from fork at offset
  *
  * @param ofork    (r)  fork handle
- * @param eid      (r)  data fork or ressource fork entry id
+ * @param eid      (r)  data fork or resource fork entry id
  * @param offset   (r)  offset
  * @param rbuf     (r)  data buffer
  * @param rbuflen  (rw) in: number of bytes to read, out: bytes read

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -216,7 +216,7 @@ struct adouble {
     int                 ad_data_refcount;
     int                 ad_meta_refcount;
     int                 ad_reso_refcount;
-    off_t               ad_rlen;           /* ressource fork len with AFP 3.0         *
+    off_t               ad_rlen;           /* resource fork len with AFP 3.0         *
                                             * the header parameter size is too small. */
     char                *ad_name;          /* mac name (maccharset or UTF8-MAC)       */
     struct adouble_fops *ad_ops;
@@ -230,7 +230,7 @@ struct adouble {
 #define ADFLAGS_HF        (1<<2)
 #define ADFLAGS_DIR       (1<<3)
 #define ADFLAGS_NOHF      (1<<4)  /* not an error if no metadata fork */
-#define ADFLAGS_NORF      (1<<5)  /* not an error if no ressource fork */
+#define ADFLAGS_NORF      (1<<5)  /* not an error if no resource fork */
 #define ADFLAGS_CHECK_OF  (1<<6)  /* check for open forks from us and other afpd's */
 #define ADFLAGS_SETSHRMD  (1<<7)  /* setting share mode must be done with excl fcnt lock,
                                      which implies that the file must be openend rw.

--- a/libatalk/adouble/ad_lock.c
+++ b/libatalk/adouble/ad_lock.c
@@ -586,7 +586,7 @@ void ad_unlock(struct adouble *ad, const int fork, int unlckbrl)
  * Test for a share mode lock
  *
  * @param ad      (rw) handle
- * @param eid     (r)  datafork or ressource fork
+ * @param eid     (r)  datafork or resource fork
  * @param off     (r)  sharemode lock to test
  *
  * @returns           1 if there's an existing lock, 0 if there's no lock,

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -938,7 +938,7 @@ static int ad_header_upgrade_ea(struct adouble *ad _U_, const char *name _U_)
  *
  * We're called because opening ADFLAGS_HF caused an error.
  * 1. In case ad_open is called with ADFLAGS_NOHF the error is suppressed.
- * 2. Open non-existent ressource fork, this will just result in first read return EOF
+ * 2. Open non-existent resource fork, this will just result in first read return EOF
  * 3. If ad_open was called with ADFLAGS_DF we may have opened the datafork and thus
  *    ought to close it before returning with an error condition.
  */
@@ -1533,7 +1533,7 @@ EC_CLEANUP:
 }
 
 /*!
- * Open ressource fork
+ * Open resource fork
  */
 static int ad_open_rf(const char *path, int adflags, int mode, struct adouble *ad)
 {
@@ -1922,7 +1922,7 @@ void ad_init(struct adouble *ad, const struct vol * restrict vol)
 }
 
 /*!
- * Open data-, metadata(header)- or ressource fork
+ * Open data-, metadata(header)- or resource fork
  *
  * ad_open(struct adouble *ad, const char *path, int adflags, int flags)
  * ad_open(struct adouble *ad, const char *path, int adflags, int flags, mode_t mode)
@@ -1933,13 +1933,13 @@ void ad_init(struct adouble *ad, const struct vol * restrict vol)
  *      ad_init(&ad, vol->v_adouble, vol->v_ad_options);
  * @endcode
  *
- * Open a files data fork, metadata fork or ressource fork.
+ * Open a files data fork, metadata fork or resource fork.
  *
  * @param ad        (rw) pointer to struct adouble
  * @param path      (r)  Path to file or directory
  * @param adflags   (r)  Flags specifying which fork to open, can be or'd:
  *                         ADFLAGS_DF:        open data fork
- *                         ADFLAGS_RF:        open ressource fork
+ *                         ADFLAGS_RF:        open resource fork
  *                         ADFLAGS_HF:        open header (metadata) file
  *                         ADFLAGS_NOHF:      it's not an error if header file couldn't be opened
  *                         ADFLAGS_NORF:      it's not an error if reso fork couldn't be opened

--- a/libatalk/adouble/ad_write.c
+++ b/libatalk/adouble/ad_write.c
@@ -90,7 +90,7 @@ ssize_t ad_write(struct adouble *ad, uint32_t eid, off_t off, int end, const cha
         if ( ad->ad_rlen < off + cc )
             ad->ad_rlen = off + cc;
     } else {
-        return -1; /* we don't know how to write if it's not a ressource or data fork */
+        return -1; /* we don't know how to write if it's not a resource or data fork */
     }
 
     if (ret != 0)

--- a/libatalk/dsi/dsi_tcp.c
+++ b/libatalk/dsi/dsi_tcp.c
@@ -103,7 +103,7 @@ static void dsi_init_buffer(DSI *dsi)
 }
 
 /*!
- * Free any allocated ressources of the master afpd DSI objects and close server socket
+ * Free any allocated resources of the master afpd DSI objects and close server socket
  */
 void dsi_free(DSI *dsi)
 {

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -1552,7 +1552,7 @@ void volume_unlink(struct vol *volume)
  * Free all resources allocated in a struct vol in load_volumes()
  *
  * Actually opening a volume (afp_openvol()) will allocate additional
- * ressources which are freed in closevol()
+ * resources which are freed in closevol()
  */
 void volume_free(struct vol *vol)
 {

--- a/libatalk/vfs/vfs.c
+++ b/libatalk/vfs/vfs.c
@@ -271,7 +271,7 @@ static int RF_renamefile_adouble(VFS_FUNC_ARGS_RENAMEFILE)
         if (errno == ENOENT) {
 	        struct adouble    ad;
 
-            if (ostatat(dirfd, adsrc, &st, vol_syml_opt(vol))) /* source has no ressource fork, */
+            if (ostatat(dirfd, adsrc, &st, vol_syml_opt(vol))) /* source has no resource fork, */
                 return 0;
 
             /* We are here  because :
@@ -377,7 +377,7 @@ static int RF_solaris_acl(VFS_FUNC_ARGS_ACL)
         return AFPERR_MISC;
     }
     if (!S_ISDIR(st.st_mode)) {
-        /* set ACL on ressource fork */
+        /* set ACL on resource fork */
         if ((acl(vol->ad_path(path, ADFLAGS_HF), cmd, count, aces)) != 0)
             return AFPERR_MISC;
     }
@@ -393,7 +393,7 @@ static int RF_solaris_remove_acl(VFS_FUNC_ARGS_REMOVE_ACL)
     if (dir)
         return AFP_OK;
 
-    /* remove ACL from ressource fork */
+    /* remove ACL from resource fork */
     if ((ret = remove_acl_vfs(vol->ad_path(path, ADFLAGS_HF))) != AFP_OK) {
         if (errno == ENOENT)
             return AFP_OK;
@@ -414,7 +414,7 @@ static int RF_posix_acl(VFS_FUNC_ARGS_ACL)
         EC_FAIL;
 
     if (!S_ISDIR(st.st_mode)) {
-        /* set ACL on ressource fork */
+        /* set ACL on resource fork */
         EC_ZERO_ERR( acl_set_file(vol->ad_path(path, ADFLAGS_HF), type, acl), AFPERR_MISC );
     }
 
@@ -431,7 +431,7 @@ static int RF_posix_remove_acl(VFS_FUNC_ARGS_REMOVE_ACL)
     if (dir)
         EC_EXIT_STATUS(AFP_OK);
 
-    /* remove ACL from ressource fork */
+    /* remove ACL from resource fork */
     EC_ZERO_ERR( remove_acl_vfs(vol->ad_path(path, ADFLAGS_HF)), AFPERR_MISC );
 
 EC_CLEANUP:
@@ -623,7 +623,7 @@ static int RF_renamefile_ea(VFS_FUNC_ARGS_RENAMEFILE)
         struct stat st;
 
         err = errno;
-        if (errno == ENOENT && ostatat(dirfd, adsrc, &st, vol_syml_opt(vol))) /* source has no ressource fork, */
+        if (errno == ENOENT && ostatat(dirfd, adsrc, &st, vol_syml_opt(vol))) /* source has no resource fork, */
             return 0;
         errno = err;
         return -1;

--- a/test/testsuite/FPByteRangeLockExt.c
+++ b/test/testsuite/FPByteRangeLockExt.c
@@ -114,7 +114,7 @@ char *name = "t67 FPByteLock_ext RF";
 	}
 	test_bytelock_ext(VolID, name, OPENFORK_RSCS);
 test_exit:
-	exit_test("FPByteRangeLockExt:test67: FPByteLock Ressource Fork");
+	exit_test("FPByteRangeLockExt:test67: FPByteLock Resource Fork");
 }
 
 

--- a/test/testsuite/FPGetForkParms.c
+++ b/test/testsuite/FPGetForkParms.c
@@ -101,7 +101,7 @@ test_exit:
 }
 
 /* --------------------------
-FIXME set ressource for size and check
+FIXME set resource for size and check
 */
 STATIC void test50()
 {

--- a/test/testsuite/T2_FPOpenFork.c
+++ b/test/testsuite/T2_FPOpenFork.c
@@ -289,7 +289,7 @@ int dir;
 	strcpy(temp, Path);
 	strcat(temp,"/test folder/.AppleDouble/toto.txt");
 	if (unlink(temp)) {
-		fprintf(stdout,"\tFAILED Ressource fork not there\n");
+		fprintf(stdout,"\tFAILED Resource fork not there\n");
 		failed_nomsg();
 	}
 
@@ -312,7 +312,7 @@ int dir;
 
 	strcpy(temp, Path);strcat(temp,"/test folder/.AppleDouble/toto.txt");
 	if (unlink(temp)) {
-		fprintf(stdout,"\tFAILED Ressource fork not there\n");
+		fprintf(stdout,"\tFAILED Resource fork not there\n");
 		failed_nomsg();
 		goto fin1;
 	}
@@ -329,7 +329,7 @@ int dir;
 	}
 
 	fork1 = FPOpenFork(Conn, vol, OPENFORK_RSCS , bitmap ,DIRDID_ROOT, "test folder/toto.txt",OPENACC_WR | OPENACC_RD);
-    /* bad, but we are able to open read-write the ressource for of a read-only file (data fork)
+    /* bad, but we are able to open read-write the resource for of a read-only file (data fork)
      * difficult to fix.
      */
 	if (!fork1) {
@@ -516,7 +516,7 @@ uint16_t vol = VolID;
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("FPOpenFork:test153: open data fork without ressource fork");
+	exit_test("FPOpenFork:test153: open data fork without resource fork");
 }
 
 /* ------------------------- */
@@ -557,7 +557,7 @@ STATIC void test157()
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
-	exit_test("FPOpenFork:test157: open not existing ressource fork read-only");
+	exit_test("FPOpenFork:test157: open not existing resource fork read-only");
 }
 
 /* ------------------------- */
@@ -1109,7 +1109,7 @@ int dir;
 
     if (!Mac && (delete_unix_md(Path, name, file) == 0)) {
 		if (!Quiet) {
-			fprintf(stdout,"\tFAILED Ressource fork there!\n");
+			fprintf(stdout,"\tFAILED Resource fork there!\n");
 		}
 		failed_nomsg();
 	}
@@ -1118,7 +1118,7 @@ fin:
 	FAIL (FPDelete(Conn, vol,  dir , file))
 	FAIL (FPDelete(Conn, vol,  dir , ""))
 test_exit:
-	exit_test("FPOpenFork:test411: open read-only a file without ressource fork");
+	exit_test("FPOpenFork:test411: open read-only a file without resource fork");
 
 }
 

--- a/test/testsuite/adoublehelper.c
+++ b/test/testsuite/adoublehelper.c
@@ -115,7 +115,7 @@ int delete_unix_file(char *path, char *name, char *file)
 	return rc;
 }
 
-/* Rename a file and it's ressource fork */
+/* Rename a file and it's resource fork */
 int rename_unix_file(char *path, char *dir, char *src, char *dst)
 {
     sprintf(temp, "%s/%s/%s", Path, dir, src);

--- a/test/testsuite/afpcli.c
+++ b/test/testsuite/afpcli.c
@@ -1702,7 +1702,7 @@ int AFPWrite_ext_async(CONN *conn, uint16_t fork, off_t offset, off_t size, char
 }
 
 /* -------------------------------
-	type : ressource or data
+	type : resource or data
 */
 uint16_t  AFPOpenFork(CONN *conn, uint16_t vol, char type, uint16_t bitmap, int did , char *name,uint16_t access)
 {

--- a/test/testsuite/afpcli_asp.c
+++ b/test/testsuite/afpcli_asp.c
@@ -542,7 +542,7 @@ int rsize;
 
 
 /* -------------------------------
-	type : ressource or data
+	type : resource or data
 */
 uint16_t  AFPOpenFork(ASP *asp, uint16_t vol, char type, uint16_t bitmap, int did , char *name,uint16_t access)
 {

--- a/test/testsuite/temp.c
+++ b/test/testsuite/temp.c
@@ -247,7 +247,7 @@ int fork, fork1;
 
 	strcpy(temp, Path);strcat(temp,"/test folder/.AppleDouble/toto.txt");
 	if (unlink(temp)) {
-		fprintf(stdout,"\tRessource fork not there\n");
+		fprintf(stdout,"\tResource fork not there\n");
 	}
 
 	fork = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap ,DIRDID_ROOT, "test folder/toto.txt", OPENACC_RD);
@@ -268,7 +268,7 @@ int fork, fork1;
 
 	strcpy(temp, Path);strcat(temp,"/test folder/.AppleDouble/toto.txt");
 	if (unlink(temp)) {
-		fprintf(stdout,"\tRessource fork not there\n");
+		fprintf(stdout,"\tResource fork not there\n");
 	}
 
 	fork = FPOpenFork(Conn, vol, OPENFORK_RSCS , bitmap ,DIRDID_ROOT, "test folder/toto.txt", OPENACC_RD);
@@ -284,7 +284,7 @@ int fork, fork1;
 	}
 
 	fork1 = FPOpenFork(Conn, vol, OPENFORK_RSCS , bitmap ,DIRDID_ROOT, "test folder/toto.txt",OPENACC_WR | OPENACC_RD);
-    /* bad, but we are able to open read-write the ressource for of a read-only file (data fork)
+    /* bad, but we are able to open read-write the resource for of a read-only file (data fork)
      * difficult to fix.
      */
 	if (!fork1) {
@@ -2183,7 +2183,7 @@ int fork2, fork3;
 void test157()
 {
     fprintf(stdout,"===================\n");
-    fprintf(stdout,"test157: bad .AppleDouble ressource fork\n");
+    fprintf(stdout,"test157: bad .AppleDouble resource fork\n");
 
 	if (FPEnumerate(Conn, vol,  DIRDID_ROOT , "",
 	     (1<<FILPBIT_LNAME) | (1<<FILPBIT_FNUM ) | (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)|


### PR DESCRIPTION
The "ressource fork" misspelling is proliferating in this code base. Let's fix it in one go.