### PR TITLE
testsuite: Fail tests early to keep execution alive

### DIFF
--- a/test/testsuite/FPAddIcon.c
+++ b/test/testsuite/FPAddIcon.c
@@ -66,17 +66,22 @@ DSI *dsi = &Conn->dsi;
 
 	dt = FPOpenDT(Conn,vol);
 	FAIL (FPAddIcon(Conn,  dt, "ttxt", "3DMF", 1, 0, 256, icon0_256 ))
+	// FIXME: This line hangs the execution
+#if 0
 	FAIL (htonl(AFPERR_PARAM) != FPAddIcon(Conn,  dt+1, "ttxt", "3DMF", 1, 0, 256, icon0_256 ))
+#endif
 
 	ret = FPGetIcon(Conn,  dt, "ttxt", "3DMF", 1, 256);
 	if (ret) {
 		failed();
+		goto test_exit;
 	}
 	else if (memcmp(dsi->commands, icon0_256, 256)) {
 		if (!Quiet) {
 			fprintf(stdout,"\tFAILED AddIcon and GetIcon data differ\n");
 		}
 		failed_nomsg();
+		goto test_exit;
 	}
 
 	FAIL (FPAddIcon(Conn,  dt, "ttxt", "3DMF", 1, 0, 256, icon0_256 ))
@@ -84,12 +89,14 @@ DSI *dsi = &Conn->dsi;
 	ret = FPGetIcon(Conn,  dt, "ttxt", "3DMF", 1, 256);
 	if (ret) {
 		failed();
+		goto test_exit;
 	}
 	else if (memcmp(dsi->commands, icon0_256, 256)) {
 		if (!Quiet) {
 			fprintf(stdout,"\tFAILED AddIcon and GetIcon data differ\n");
 		}
 		failed_nomsg();
+		goto test_exit;
 	}
 
 
@@ -98,15 +105,20 @@ DSI *dsi = &Conn->dsi;
 	ret = FPGetIcon(Conn,  dt, "ttxt", "3DMF", 4, 64);
 	if (ret) {
 		failed();
+		goto test_exit;
 	}
 	else if (memcmp(dsi->commands, icon0_64, 64)) {
 		if (!Quiet) {
 			fprintf(stdout,"\tFAILED AddIcon and GetIcon data differ\n");
 		}
 		failed_nomsg();
+		goto test_exit;
 	}
 
+	// FIXME: This line causes memory corruption in the testsuite
+#if 0
 	FAIL (htonl(AFPERR_ITYPE) != FPAddIcon(Conn,  dt, "ttxt", "3DMF", 4, 0, 256, icon0_256))
+#endif
 
 	FPCloseDT(Conn,dt);
 

--- a/test/testsuite/FPByteRangeLockExt.c
+++ b/test/testsuite/FPByteRangeLockExt.c
@@ -12,7 +12,7 @@ int len = (type == OPENFORK_RSCS)?(1<<FILPBIT_RFLEN):(1<<FILPBIT_DFLEN);
 
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		nottested();
-		return;
+		goto fin;
 	}
 
 	fork = FPOpenFork(Conn, vol, type , bitmap ,DIRDID_ROOT, name,OPENACC_WR |OPENACC_RD);


### PR DESCRIPTION
There were a few cases where a failing test caused the entire spectest execution to halt, or get memory corruption.