### PR TITLE
Limit FPGetSrvrInfo packet for AppleTalk clients

### DIFF
--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -75,7 +75,7 @@ void status_versions( char *data,
 #ifndef NO_DDP
         if (!asp && (afp_versions[i].av_number <= 21)) continue;
 #endif /* ! NO_DDP */
-        if ( !dsi && (afp_versions[ i ].av_number >= 22)) continue;
+        if ( !dsi && (afp_versions[ i ].av_number > 22)) continue;
         count++;
     }
     data += ntohs( status );
@@ -85,7 +85,7 @@ void status_versions( char *data,
 #ifndef NO_DDP
         if (!asp && (afp_versions[i].av_number <= 21)) continue;
 #endif /* ! NO_DDP */
-        if ( !dsi && (afp_versions[ i ].av_number >= 22)) continue;
+        if ( !dsi && (afp_versions[ i ].av_number > 22)) continue;
         len = strlen( afp_versions[ i ].av_name );
         *data++ = len;
         memcpy( data, afp_versions[ i ].av_name , len );

--- a/include/atalk/globals.h
+++ b/include/atalk/globals.h
@@ -161,6 +161,8 @@ typedef struct AFPObj {
     void* handle;
     #ifndef NO_DDP
     int fd;
+    int statuslen;
+    char aspstatus[1400];
     #endif /* NO_DDP */
     struct afp_options options;
     char *Obj, *Type, *Zone;


### PR DESCRIPTION
Early AppleTalk clients struggle with FPGetSrvrInfo packets that have a payload larger then 512 bytes. In many cases they claim that they received no response from the server. In some cases they may even crash.

To resolve this, craft a response just for AppleTalk clients without most of the AFP3.x only options (UTF8 server name, Directory Name, etc.). In addition, unless a custom icon is sent, the server will not send an icon image to AppleTalk clients by default.

Fixes: #1661