### PR TITLE
docker: Containerized testsuite and build containers in CI workflow

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,128 @@
+name: Containers
+
+on:
+    push:
+        branches: [ "main" ]
+    pull_request:
+        branches: [ "main" ]
+    workflow_dispatch:
+
+env:
+    REGISTRY: ghcr.io
+    REPO: ${{ github.repository }}
+
+jobs:
+    build-container:
+        name: Netatalk container
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v4
+            - name: Create image name
+              run: |
+                echo "IMAGE_NAME=${REPO,,}" >> ${GITHUB_ENV}
+            - name: Login to container registry
+              uses: docker/login-action@v3
+              with:
+                registry: ${{ env.REGISTRY }}
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Extract metadata
+              id: metadata
+              uses: docker/metadata-action@v5
+              with:
+                images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                tags: |
+                  type=ref,event=branch
+                  type=ref,event=tag
+                  type=raw,value=latest
+                  type=sha
+            - name: Build and push container image
+              uses: docker/build-push-action@v5
+              with:
+                context: .
+                file: Dockerfile
+                push: true
+                labels: ${{ steps.metadata.outputs.labels }}
+                tags: ${{ steps.metadata.outputs.tags }}
+
+
+    build-container-testsuite:
+        name: Netatalk testsuite container
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v4
+            - name: Create image name
+              run: |
+                echo "IMAGE_NAME=${REPO,,}-testsuite" >> ${GITHUB_ENV}
+            - name: Login to container registry
+              uses: docker/login-action@v3
+              with:
+                registry: ${{ env.REGISTRY }}
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Extract metadata
+              id: metadata
+              uses: docker/metadata-action@v5
+              with:
+                images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                tags: |
+                  type=ref,event=branch
+                  type=ref,event=tag
+                  type=raw,value=latest
+                  type=sha
+            - name: Build and push container image
+              uses: docker/build-push-action@v5
+              with:
+                context: .
+                file: Dockerfile.testsuite
+                push: true
+                labels: ${{ steps.metadata.outputs.labels }}
+                tags: ${{ steps.metadata.outputs.tags }}
+
+
+    afp-spectest:
+        name: AFP spectest
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        env:
+            AFP_USER: atalk1
+            AFP_USER2: atalk2
+            AFP_PASS: afpafp
+            AFP_PASS2: afpafp
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            SHARE_NAME2: test2
+            INSECURE_AUTH: 1
+            DISABLE_TIMEMACHINE: 1
+            VERBOSE: 1
+            TESTSUITE: spectest
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+
+
+    afp-spectest_t2:
+        name: AFP spectest tier 2
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        env:
+            AFP_USER: atalk1
+            AFP_USER2: atalk2
+            AFP_PASS: afpafp
+            AFP_PASS2: afpafp
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            SHARE_NAME2: test2
+            INSECURE_AUTH: 1
+            DISABLE_TIMEMACHINE: 1
+            VERBOSE: 1
+            TESTSUITE: spectest_t2
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest

--- a/Dockerfile.testsuite
+++ b/Dockerfile.testsuite
@@ -1,0 +1,91 @@
+ARG RUN_DEPS="\
+    acl \
+    avahi \
+    avahi-compat-libdns_sd \
+    bash \
+    cups \
+    db \
+    dbus \
+    krb5 \
+    libevent \
+    libgcrypt \
+    libtracker \
+    linux-pam \
+    openldap \
+    talloc \
+    tracker \
+    tracker-miners \
+    tzdata \
+    bash"
+ARG BUILD_DEPS="\
+    acl-dev \
+    avahi-dev \
+    bison \
+    cups-dev \
+    curl \
+    db-dev \
+    dbus-dev \
+    build-base \
+    flex \
+    gcc \
+    krb5-dev \
+    libevent-dev \
+    libgcrypt-dev \
+    linux-pam-dev \
+    meson \
+    ninja \
+    openldap-dev \
+    perl \
+    pkgconfig \
+    talloc-dev \
+    tracker-dev \
+    unicode-character-database"
+
+FROM alpine:3.20 AS build
+
+ARG RUN_DEPS
+ARG BUILD_DEPS
+ENV RUN_DEPS=$RUN_DEPS
+ENV BUILD_DEPS=$BUILD_DEPS
+
+RUN apk update \
+&&  apk add --no-cache \
+    $RUN_DEPS \
+    $BUILD_DEPS
+
+WORKDIR /netatalk-code
+COPY . .
+RUN rm -rf build
+
+RUN meson setup build \
+    -Dbuildtype=debug \
+    -Dwith-afpstats=false \
+    -Dwith-appletalk=true \
+    -Dwith-dbus-daemon-path=/usr/bin/dbus-daemon \
+    -Dwith-dbus-sysconf-path=/etc \
+    -Dwith-dtrace=false \
+    -Dwith-init-style=none \
+    -Dwith-manual=none \
+    -Dwith-quota=false \
+    -Dwith-tcp-wrappers=false \
+    -Dwith-testsuite=true \
+&&  meson compile -C build
+
+RUN meson install --destdir=/staging/ -C build
+
+FROM alpine:3.20 AS deploy
+
+ARG RUN_DEPS
+ENV RUN_DEPS=$RUN_DEPS
+
+COPY --from=build /staging/ /
+
+RUN apk update \
+&&  apk add --no-cache $RUN_DEPS
+
+COPY /contrib/shell_utils/docker-entrypoint.sh /entrypoint.sh
+
+WORKDIR /mnt
+EXPOSE 548
+VOLUME ["/mnt/afpshare", "/mnt/afpbackup"]
+CMD ["/entrypoint.sh"]

--- a/Dockerfile.testsuite
+++ b/Dockerfile.testsuite
@@ -58,7 +58,7 @@ COPY . .
 RUN rm -rf build
 
 RUN meson setup build \
-    -Dbuildtype=debug \
+    -Dbuildtype=release \
     -Dwith-afpstats=false \
     -Dwith-appletalk=true \
     -Dwith-dbus-daemon-path=/usr/bin/dbus-daemon \

--- a/test/testsuite/T2_FPMoveAndRename.c
+++ b/test/testsuite/T2_FPMoveAndRename.c
@@ -18,6 +18,11 @@ unsigned int ret;
 
 	ENTER_TEST
 
+	// FIXME: https://github.com/Netatalk/netatalk/issues/1682
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;
@@ -74,6 +79,11 @@ unsigned int ret;
 
 	ENTER_TEST
 
+	// FIXME: https://github.com/Netatalk/netatalk/issues/1682
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (!Path && !Mac) {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;


### PR DESCRIPTION
Create a Docker container that builds both netatalk and the testsuite. While the baseline spectest test suite can be run remotely, the tier 2 spectest requires access to the local filesystem, so I opted to have the netatalk instance under test in the same container as the testsuite. AFP requests still done over port 548 but on a local socket.

Additionally, create a new GitHub actions workflow that builds the Docker containers, publishes them to the GitHub container store, and then runs the two containerized spectest suites.