### PR TITLE
testsuite: Install the stabilized test binaries

### DIFF
--- a/test/testsuite/README
+++ b/test/testsuite/README
@@ -3,10 +3,10 @@
                  =======================
 
 This suite contains several small utilities aimed at testing
-a) AFP Server conformance to the AFP Specs, eg. `spectest`
-b) benchmarking AFP Servers, eg. `lantest`
+a) AFP Server conformance to the AFP Specs, eg. `afp_spectest`
+b) benchmarking AFP Servers, eg. `afp_lantest`
 
-For end users the most useful utility is probably `lantest` which
+For end users the most useful utility is probably `afp_lantest` which
 is a CLI counterpart for the famous HELIOS Lan Test.
 
 Tests prg in test directory:
@@ -15,33 +15,33 @@ Tests prg in test directory:
 Spec conformance tests:
 -----------------------
 
-./spectest:
+./afp_spectest:
 AFP spec test. Assume exported volumes are only modified with netatalk.
 
-./sleeptest:
+./afp_sleeptest:
 AFP spec tests for sleeping (FPZzz). Not included in spectest.
 
-./logintest:
+./afp_logintest:
 AFP spec tests for DSI and login. Not included in spectest.
 
-./rotest:
+./afp_rotest:
 AFP spec tests on a read only volume. Not included in spectest.
 
-./failed_spectest:
+./afp_spectest_fail:
 AFP spec tests which fail with current netatalk but pass on a Mac.
 
-./T2_spectest
-AFP spec tests when .AppleDouble is missing or bogus.
+./afp_spectest_t2
+AFP tier 2 spec tests when .AppleDouble is missing or bogus.
 Requires local access to volume (-c option).
 
 
 Benchmarking
 ------------
 
-./lantest
+./afp_lantest
 Netatalk implementation of HELIOS Lan Test.
 
-./speedtest
+./afp_speedtest
 Bench Read, Write and file copy (either Read/Write or FPCopyFile),
 it can also run the same tests using Posix syscalls and can
 be use for testing afpd speed against local or others protocols.
@@ -118,16 +118,16 @@ on a Mac server or afpd.
 Example:
 --------
 Run all tests on server 192.168.2.123
-spectest -h 192.168.2.123 -u user1 -d usr2 -s test -w toto
+afp_spectest -h 192.168.2.123 -u user1 -d usr2 -s test -w toto
 Same but on a Mac
-spectest -m -h 192.168.2.64 -u user1 -d usr2 -s test -w toto
+afp_spectest -m -h 192.168.2.64 -u user1 -d usr2 -s test -w toto
 
 Run FPByteRangeLock tests with AFP 3.0, two different servers are exporting the same volume.
-T2_spectest -f FPByteRangeLock -3 -h 192.168.2.123 -H 192.168.2.124 -u user1 -d usr2 -s test -c /tmp/afptest1 -w toto
+afp_spectest_t2 -f FPByteRangeLock -3 -h 192.168.2.123 -H 192.168.2.124 -u user1 -d usr2 -s test -c /tmp/afptest1 -w toto
 
 At least on linux, it's possible to compile them with LDFLAGS=-rdynamic
 and the program can run individual test:
-./T2_spectest -4 -u <user> -d <seconduser> -w <passwd> -s <vol> -c <path> -f test235
+afp_spectest_t2 -4 -u <user> -d <seconduser> -w <passwd> -s <vol> -c <path> -f test235
 
 Tests output
 ------------
@@ -136,11 +136,11 @@ Test name
 if the test is not executed, reason, ex: SKIPPED (need AFP 3.x)
 list of AFP calls executed with error code if any
 
-if Mac result and Netatalk differ or if Mac result differ between versions, Mac result
+- if Mac result and Netatalk differ or if Mac result differ between versions, Mac result
 Ex:
 header.dsi_code       -5000     AFPERR_ACCESS
 MAC RESULT: -5019 AFPERR_PARAM    -5010 AFPERR_BUSY
 Netatalk returns AFPERR_ACCESS when a Mac return AFPERR_PARAM or AFPERR_BUSY
 
-if Mac and Netatalk now return the same result:
+- if Mac and Netatalk now return the same result:
 Warning MAC and Netatalk now same RESULT!

--- a/test/testsuite/meson.build
+++ b/test/testsuite/meson.build
@@ -36,11 +36,12 @@ lantest_sources = [
 ]
 
 executable(
-    'lantest',
+    'afp_lantest',
     lantest_sources,
     include_directories: root_includes,
     dependencies: afptest_external_deps,
     link_with: libafptest,
+    install: true,
 )
 
 afp_ls_sources = [
@@ -59,7 +60,7 @@ encoding_test_sources = [
 ]
 
 executable(
-    'encoding_test',
+    'afp_encoding_test',
     encoding_test_sources,
     include_directories: root_includes,
     link_with: libafptest,
@@ -70,7 +71,7 @@ login_test_sources = [
 ]
 
 executable(
-    'logintest',
+    'afp_logintest',
     login_test_sources,
     include_directories: root_includes,
     link_with: libafptest,
@@ -81,7 +82,7 @@ rotest_sources = [
 ]
 
 executable(
-    'rotest',
+    'afp_rotest',
     rotest_sources,
     include_directories: root_includes,
     link_with: libafptest,
@@ -92,10 +93,11 @@ speedtest_sources = [
 ]
 
 executable(
-    'speedtest',
+    'afp_speedtest',
     speedtest_sources,
     include_directories: root_includes,
     link_with: libafptest,
+    install: true,
 )
 
 spectest_sources = [
@@ -162,10 +164,11 @@ spectest_sources = [
 ]
 
 executable(
-    'spectest',
+    'afp_spectest',
     spectest_sources,
     include_directories: root_includes,
     link_with: libafptest,
+    install: true,
 )
 
 sleeptest_sources = [
@@ -174,7 +177,7 @@ sleeptest_sources = [
 ]
 
 executable(
-    'sleeptest',
+    'afp_sleeptest',
     sleeptest_sources,
     include_directories: root_includes,
     link_with: libafptest,
@@ -182,14 +185,15 @@ executable(
 
 fail_spectest_sources = [
     'fail_spectest.c',
+    'failed_Error.c',
     'failed_FPEnumerate.c',
     'failed_FPExchangeFiles.c',
 	'failed_FPMoveAndRename.c',
-    'failed_Error.c',
+    'failed_T2_FPResolveID.c',
 ]
 
 executable(
-    'fail_spectest',
+    'afp_spectest_fail',
     fail_spectest_sources,
     include_directories: root_includes,
     link_with: libafptest,
@@ -215,10 +219,11 @@ t2_spectest_sources = [
 ]
 
 executable(
-    'T2_spectest',
+    'afp_spectest_t2',
     t2_spectest_sources,
     include_directories: root_includes,
     link_with: libafptest,
+    install: true,
 )
 
 spectest_sh = find_program('spectest.sh')


### PR DESCRIPTION
This installs the spectest, tier 2 spectest, speedtest, and lantest binaries. The binaries have been renamed with an `afp_` prefix to distinguish them from other similarly named binaries on a system.

The other test binaries are still buggy, so keeping them off the install manifest for now.

Note that the binaries are only built when `with-testsuite=true` is enabled, so this won't affect normal builds.