### PR TITLE
Fix regression in get_vol_uuid()

### DIFF
--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -147,7 +147,7 @@ static char *get_vol_uuid(const AFPObj *obj, const char *volname)
     lock.l_len = 0;
     lock.l_whence = SEEK_SET;
 
-    fp = fopen(obj->options.uuidconf, "r+");
+    fp = fopen(obj->options.uuidconf, "r");
     if (fp != NULL) {
         /* Lock the file */
         lock.l_type = F_RDLCK;


### PR DESCRIPTION
This fixes a regression introduced in commit: https://github.com/Netatalk/netatalk/commit/f4ae924843e376e96ea46de5e23c176dbe959682

The file containing the volume UUID should be opened read-only because in some contexts, the user does not have read-write privileges (ex: running the `ad` tool suite).