### PR TITLE
testsuite: Restore test151 but only when run by itself

### DIFF
--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -872,7 +872,6 @@ test_exit:
 }
 
 /* --------------- */
-extern char *Test;
 STATIC void test366()
 {
 char *name = "t366 FPByteLock 2 users";

--- a/test/testsuite/FPOpenFork.c
+++ b/test/testsuite/FPOpenFork.c
@@ -664,6 +664,11 @@ DSI *dsi;
 
 	ENTER_TEST
 
+// Opens too many forks to be run with other tests
+	if (!Test) {
+		test_skipped(T_SINGLE);
+		goto test_exit;
+	}
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name1)){
 		nottested();
 		goto test_exit;
@@ -996,8 +1001,7 @@ void FPOpenFork_test()
     test81();
     test116();
     test145();
-// Disable test for too many open forks, it was skipped anyway
-//    test151();
+    test151();
     test190();
     test341();
     test367();

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -39,7 +39,7 @@ char    *Vol = "";
 char    *Vol2 = "";
 char    *User;
 int     Version = 21;
-static char    *Test = "Write";
+char    *Test = "Write";
 static char    *Filename;
 
 static int Count = 1;

--- a/test/testsuite/test.h
+++ b/test/testsuite/test.h
@@ -129,9 +129,10 @@ extern char Data[];
 
 extern char *Vol;
 extern char *Vol2;
-
 extern char *Path;
 extern char *User;
+extern char *Test;
+
 extern int Version;
 extern int Quirk;
 extern int Verbose;


### PR DESCRIPTION
test151 opens up thousands of forks which causes instability for other tests. Uncomment it but allow it only to be run by itself (i.e. `-f test151`)

Also, refactor the `Test` variable (which controls the -f option) to be global.