### PR TITLE
GitHub CI: Skip container builds when code originates from a fork

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -15,6 +15,7 @@ jobs:
     build-container:
         name: Netatalk container
         runs-on: ubuntu-latest
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         permissions:
             contents: read
             packages: write
@@ -53,6 +54,7 @@ jobs:
     build-container-testsuite:
         name: Netatalk testsuite container
         runs-on: ubuntu-latest
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         permissions:
             contents: read
             packages: write


### PR DESCRIPTION
Only the mother repo can generate tokens with the privileges to push to the container registry.