### PR TITLE
GitHub CI: Define hard timeouts for workflow actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,7 @@ jobs:
   build-alpine:
     name: Alpine Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 9
     container:
       image: alpine:latest
     steps:
@@ -99,6 +100,7 @@ jobs:
   build-archlinux:
     name: Arch Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 9
     container:
       image: archlinux:latest
     steps:
@@ -151,6 +153,7 @@ jobs:
   build-debian:
     name: Debian Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 9
     container:
       image: debian:latest
     steps:
@@ -217,6 +220,7 @@ jobs:
   build-fedora:
     name: Fedora Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 9
     container:
       image: fedora:latest
     steps:
@@ -276,6 +280,7 @@ jobs:
   build-opensuse:
     name: openSUSE Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 9
     container:
       image: opensuse/tumbleweed:latest
     steps:
@@ -337,6 +342,7 @@ jobs:
   build-ubuntu:
     name: Ubuntu Linux
     runs-on: ubuntu-latest
+    timeout-minutes: 9
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -407,6 +413,7 @@ jobs:
   build-macos:
     name: macOS
     runs-on: macos-latest
+    timeout-minutes: 9
     env:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
@@ -446,6 +453,7 @@ jobs:
   build-dflybsd:
     name: DragonflyBSD
     runs-on: ubuntu-latest
+    timeout-minutes: 9
     permissions:
       contents: read
     steps:
@@ -492,6 +500,7 @@ jobs:
   build-freebsd:
     name: FreeBSD
     runs-on: ubuntu-latest
+    timeout-minutes: 9
     permissions:
       contents: read
     steps:
@@ -544,6 +553,7 @@ jobs:
   build-netbsd:
     name: NetBSD
     runs-on: ubuntu-latest
+    timeout-minutes: 9
     permissions:
       contents: read
     steps:
@@ -600,6 +610,7 @@ jobs:
   build-openbsd:
     name: OpenBSD
     runs-on: ubuntu-latest
+    timeout-minutes: 9
     permissions:
       contents: read
     steps:
@@ -650,6 +661,7 @@ jobs:
   build-omnios:
     name: OmniOS
     runs-on: ubuntu-latest
+    timeout-minutes: 9
     permissions:
       contents: read
     steps:
@@ -704,6 +716,7 @@ jobs:
   build-solaris:
     name: Solaris
     runs-on: ubuntu-latest
+    timeout-minutes: 9
     permissions:
       contents: read
     steps:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -15,6 +15,7 @@ jobs:
     build-container:
         name: Netatalk container
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         if: ${{ !github.event.pull_request.head.repo.fork }}
         permissions:
             contents: read
@@ -54,6 +55,7 @@ jobs:
     build-container-testsuite:
         name: Netatalk testsuite container
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         if: ${{ !github.event.pull_request.head.repo.fork }}
         permissions:
             contents: read
@@ -94,6 +96,7 @@ jobs:
         name: AFP spectest
         needs: build-container-testsuite
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
@@ -114,6 +117,7 @@ jobs:
         name: AFP spectest tier 2
         needs: build-container-testsuite
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2


### PR DESCRIPTION
Sometimes the vmactions jobs in particular can stall badly and run for an hour or longer before failing by themselves. Setting a hard timeout prevents this.