### PR TITLE
Shore up Unicode char table script error handling and detection

### DIFF
--- a/libatalk/unicode/make-casetable.pl
+++ b/libatalk/unicode/make-casetable.pl
@@ -81,8 +81,8 @@ our $block_end;
 our $char_start;
 our $char_end;
 
-open(CHEADER, ">$ARGV[1]");
-open(CSOURCE, ">$ARGV[2]");
+open(CHEADER, ">$ARGV[1]") or die "$0: open $ARGV[1]: $!";
+open(CSOURCE, ">$ARGV[2]") or die "$0: open $ARGV[2]: $!";
 
 print (CHEADER "\/\*\n");
 print (CHEADER "  DO NOT EDIT BY HAND\!\!\!\n");
@@ -155,7 +155,7 @@ sub make_array{
 
     # write data to table --------------------------------------------
 
-    open(UNICODEDATA, "<$ARGV[0]");
+    open(UNICODEDATA, "<$ARGV[0]") or die "$0: open $ARGV[0]: $!";
 
     while (<UNICODEDATA>) {
         chop;

--- a/libatalk/unicode/make-precompose.h.pl
+++ b/libatalk/unicode/make-precompose.h.pl
@@ -25,11 +25,11 @@
 
 # temp files for binary search (compose.TEMP, compose_sp.TEMP) -------------
 
-open(UNICODEDATA, "<$ARGV[0]");
-open(CHEADER, ">$ARGV[1]");
+open(UNICODEDATA, "<$ARGV[0]") or die "$0: open $ARGV[0]: $!";
+open(CHEADER, ">$ARGV[1]") or die "$0: open $ARGV[1]: $!";
 
-open(COMPOSE_TEMP, ">compose.TEMP");
-open(COMPOSE_SP_TEMP, ">compose_sp.TEMP");
+open(COMPOSE_TEMP, ">compose.TEMP") or die "$0: open compose.TEMP: $!";
+open(COMPOSE_SP_TEMP, ">compose_sp.TEMP") or die "$0: open compose_sp.TEMP: $!";
 
 while (<UNICODEDATA>) {
     chop;
@@ -95,7 +95,7 @@ close(COMPOSE_SP_TEMP);
 
 # macros for BMP (PRECOMP_COUNT, DECOMP_COUNT, MAXCOMBLEN) ----------------
 
-open(COMPOSE_TEMP, "<compose.TEMP");
+open(COMPOSE_TEMP, "<compose.TEMP") or die "$0: open compose.TEMP: $!";
 
 @comp_table = ();
 $comp_count = 0;
@@ -132,7 +132,7 @@ close(COMPOSE_TEMP);
 
 # macros for SP (PRECOMP_SP_COUNT,DECOMP_SP_COUNT, MAXCOMBSPLEN) -----------
 
-open(COMPOSE_SP_TEMP, "<compose_sp.TEMP");
+open(COMPOSE_SP_TEMP, "<compose_sp.TEMP") or die "$0: open compose_sp.TEMP: $!";
 
 @comp_sp_table = ();
 $comp_sp_count = 0;

--- a/meson.build
+++ b/meson.build
@@ -565,6 +565,7 @@ endif
 #
 
 unicode_dirs = [
+    meson.current_source_dir(),
     '/usr/share/unicode',
     '/usr/share/unicode/ucd',
     '/usr/pkg/share/texmf-dist/tex/generic/unicode-data',
@@ -574,19 +575,20 @@ unicode_dirs = [
 unicode_data_path = get_option('with-unicode-data-path')
 
 if unicode_data_path == ''
-    unicode_data_file = 'UnicodeData.txt'
     foreach dir : unicode_dirs
         if fs.exists(dir / 'UnicodeData.txt')
-            unicode_data_file = dir / 'UnicodeData.txt'
+            unicode_data_path = dir
             break
         endif
     endforeach
-else
-    unicode_data_file = unicode_data_path / 'UnicodeData.txt'
+elif not fs.is_absolute(unicode_data_path)
+    unicode_data_path = meson.current_source_dir() / unicode_data_path
 endif
 
+unicode_data_file = unicode_data_path / 'UnicodeData.txt'
+
 if fs.exists(unicode_data_file)
-    message('Using Unicode Character Database: ' + unicode_data_file)
+    message('Unicode Character Database found at ' + unicode_data_path)
 else
     error('UnicodeData.txt not found. Specify path with -Dwith-unicode-data-path')
 endif


### PR DESCRIPTION
The problem that's being solved here, is that an incorrect search path could lead to silently failing Perl scripts and therefore broken Unicode sources.

Two major changes here:
- Add error handling when `open()` fails in the Perl scripts
- Normalize UnicodeData.txt search paths to absolute paths in the Meson detection routine