### PR TITLE
Clean up debug flags and code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -808,6 +808,7 @@ jobs:
         run: |
           mkdir -p ${{ env.BUILD_WRAPPER_OUT_DIR }}
           meson setup build \
+            -Dbuildtype=debug \
             -Dwith-appletalk=true \
             -Dwith-init-style=none \
             -Dwith-readmes=false \

--- a/etc/afpd/desktop.c
+++ b/etc/afpd/desktop.c
@@ -776,9 +776,7 @@ char *mtoupath(const struct vol *vol, char *mpath, cnid_t did, int utf8)
 	    return NULL;
     }
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_afpd, "mtoupath: '%s':'%s'", mpath, upath);
-#endif /* DEBUG */
     return( upath );
 }
 
@@ -812,9 +810,7 @@ char *utompath(const struct vol *vol, char *upath, cnid_t id, int utf8)
 
     m = mangle(vol, mpath, outlen, upath, id, flags);
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_afpd, "utompath: '%s':'%s':'%2.2X'", upath, m, ntohl(id));
-#endif /* DEBUG */
     return(m);
 
 utompath_error:

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -851,9 +851,7 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
     ssize_t len;
     char symbuf[MAXPATHLEN+1];
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_afpd, "begin setfilparams:");
-#endif /* DEBUG */
 
     adp = of_ad(vol, path, &ad);
     upath = path->u_name;
@@ -1113,9 +1111,7 @@ setfilparam_done:
         setdirparams(vol, &Cur_Path, bitmap, (char *)&newdate);
     }
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_afpd, "end setfilparams:");
-#endif /* DEBUG */
     return err;
 }
 

--- a/etc/afpd/messages.c
+++ b/etc/afpd/messages.c
@@ -64,9 +64,7 @@ void readmessage(AFPObj *obj)
 
     sprintf(filename, "%s/message.%d", SERVERTEXT, getpid());
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_afpd, "Reading file %s ", filename);
-#endif
 
     message=fopen(filename, "r");
     if (message==NULL) {
@@ -98,13 +96,11 @@ void readmessage(AFPObj *obj)
         if (rc < 0) {
             LOG(log_error, logtype_afpd, "Error deleting %s: %s", filename, strerror(rc));
         }
-#ifdef DEBUG
         else {
             LOG(log_debug9, logtype_afpd, "Deleted %s", filename);
         }
 
         LOG(log_debug9, logtype_afpd, "Set server message to \"%s\"", servermesg);
-#endif
     }
     free(filename);
 #endif /* SERVERTEXT */

--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -641,10 +641,6 @@ static int logincont2(void *obj_in, struct passwd **uam_pwd,
     }
     PAM_password = utfpass;
 
-#ifdef DEBUG
-    LOG(log_maxdebug, logtype_default, "DHX2: password: %s", PAM_password);
-#endif
-
     /* Set these things up for the conv function */
 
     ret = AFPERR_NOTAUTH;

--- a/libatalk/atp/atp_bufs.c
+++ b/libatalk/atp/atp_bufs.c
@@ -32,6 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include <sys/types.h>
 #include <sys/time.h>
@@ -84,8 +85,11 @@ static int more_bufs(void)
 #ifdef EBUG
 void atp_print_bufuse(ATP ah, char *s)
 {
-    struct atpbuf	*bp;
-    int			i, sentcount, incount, respcount;
+    struct atpbuf *bp;
+    int i;
+    int sentcount;
+    int incount;
+    int respcount;
 
     sentcount = 0;
     for ( bp = ah->atph_sent; bp != NULL; bp = bp->atpbuf_next ) {

--- a/libatalk/atp/atp_bufs.c
+++ b/libatalk/atp/atp_bufs.c
@@ -41,6 +41,10 @@
 #include <atalk/atp.h>
 #include "atp_internals.h"
 
+#ifdef EBUG
+#include <stdio.h>
+#endif /* EBUG */
+
 #define			N_MORE_BUFS		10
 
 static struct atpbuf 	*free_list = NULL;	/* free buffers */

--- a/libatalk/atp/atp_close.c
+++ b/libatalk/atp/atp_close.c
@@ -28,7 +28,7 @@ int atp_close(ATP ah)
     /* remove from list of open atp sockets & discard queued data
     */
 #ifdef EBUG
-    print_bufuse( ah, "atp_close");
+    atp_print_bufuse( ah, "atp_close");
 #endif /* EBUG */
 
     while ( ah->atph_queue != NULL ) {
@@ -61,7 +61,7 @@ int atp_close(ATP ah)
     }
 
 #ifdef EBUG
-    print_bufuse( ah, "atp_close end");
+    atp_print_bufuse( ah, "atp_close end");
 #endif /* EBUG */
 
     i = ah->atph_socket;

--- a/libatalk/atp/atp_rreq.c
+++ b/libatalk/atp/atp_rreq.c
@@ -30,6 +30,7 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <errno.h>
+#include <unistd.h>
 
 #include <netinet/in.h>
 #include <netatalk/at.h>

--- a/libatalk/atp/atp_rreq.c
+++ b/libatalk/atp/atp_rreq.c
@@ -38,6 +38,10 @@
 
 #include "atp_internals.h"
 
+#ifdef EBUG
+#include <stdio.h>
+#endif /* EBUG */
+
 
 /* wait for a tranasaction service request
 */

--- a/libatalk/atp/atp_rsel.c
+++ b/libatalk/atp/atp_rsel.c
@@ -47,7 +47,7 @@ resend_request(ATP ah)
     atp_print_addr( " to", &ah->atph_reqpkt->atpbuf_addr );
     putchar( '\n' );
     bprint( ah->atph_reqpkt->atpbuf_info.atpbuf_data,
-	    ah->atph_reqpkt->atpbuf_dlen );
+	    (int) ah->atph_reqpkt->atpbuf_dlen );
 #endif /* EBUG */
 
     memcpy( &req_hdr, ah->atph_reqpkt->atpbuf_info.atpbuf_data + 1,
@@ -332,7 +332,7 @@ timeout :
 #ifdef EBUG
 	printf( "<%d> sending TREL", getpid() );
 	bprint( ah->atph_reqpkt->atpbuf_info.atpbuf_data,
-		ah->atph_reqpkt->atpbuf_dlen );
+		(int) ah->atph_reqpkt->atpbuf_dlen );
 #endif /* EBUG */
 #ifdef DROP_ATPTREL
 	if (( ++release_count % 10 ) != 0 ) {

--- a/libatalk/atp/atp_rsel.c
+++ b/libatalk/atp/atp_rsel.c
@@ -24,6 +24,10 @@
 
 #include "atp_internals.h"
 
+#ifdef EBUG
+#include <stdio.h>
+#endif /* EBUG */
+
 #ifdef DROP_ATPTREL
 static int	release_count = 0;
 #endif /* DROP_ATPTREL */

--- a/libatalk/atp/atp_sreq.c
+++ b/libatalk/atp/atp_sreq.c
@@ -43,6 +43,10 @@
 
 #include "atp_internals.h"
 
+#ifdef EBUG
+#include <stdio.h>
+#endif /* EBUG */
+
 /*
  * ah:        open atp handle
  * atpb:      parameter block

--- a/libatalk/atp/atp_sreq.c
+++ b/libatalk/atp/atp_sreq.c
@@ -101,7 +101,7 @@ atp_sreq( ATP ah, struct atp_block *atpb, int respcount, uint8_t flags )
 	    req_buf->atpbuf_dlen );
     atp_print_addr( " to", atpb->atp_saddr );
     putchar( '\n' );
-    bprint( req_buf->atpbuf_info.atpbuf_data, req_buf->atpbuf_dlen );
+    bprint( req_buf->atpbuf_info.atpbuf_data, (int) req_buf->atpbuf_dlen );
 #endif /* EBUG */
 
     gettimeofday( &ah->atph_reqtv, (struct timezone *)0 );

--- a/libatalk/atp/atp_sresp.c
+++ b/libatalk/atp/atp_sresp.c
@@ -113,7 +113,7 @@ if (( random() % 3 ) != 2 ) {
 #ifdef EBUG
 printf( "<%d> sending packet tid=%hu serial no.=%d\n", getpid(),
   ah->atph_rtid, i );
-bprint( resp_buf->atpbuf_info.atpbuf_data, resp_buf->atpbuf_dlen );
+bprint( resp_buf->atpbuf_info.atpbuf_data, (int) resp_buf->atpbuf_dlen );
 #endif /* EBUG */
 	if ( netddp_sendto( ah->atph_socket, resp_buf->atpbuf_info.atpbuf_data,
 	  resp_buf->atpbuf_dlen, 0, (struct sockaddr *) atpb->atp_saddr,

--- a/libatalk/atp/atp_sresp.c
+++ b/libatalk/atp/atp_sresp.c
@@ -42,6 +42,10 @@
 
 #include "atp_internals.h"
 
+#ifdef EBUG
+#include <stdio.h>
+#endif /* EBUG */
+
 /* send a transaction response
 */
 int atp_sresp(

--- a/libatalk/unicode/charcnv.c
+++ b/libatalk/unicode/charcnv.c
@@ -168,9 +168,7 @@ charset_t add_charset(const char* name)
     charsets[cur_charset_t] = get_charset_functions (cur_charset_t);
     max_charset_t++;
 
-#ifdef DEBUG
     LOG(log_debug9, logtype_default, "Added charset %s with handle %u", name, cur_charset_t);
-#endif
     return (cur_charset_t);
 }
 

--- a/libatalk/util/bprint.c
+++ b/libatalk/util/bprint.c
@@ -2,8 +2,6 @@
 #include "config.h"
 #endif
 
-#ifdef DEBUG
-
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -50,4 +48,3 @@ void bprint( data, len )
 
     printf("(end)\n");
 }
-#endif

--- a/libatalk/util/bprint.c
+++ b/libatalk/util/bprint.c
@@ -14,9 +14,7 @@ static const char	hexdig[] = "0123456789ABCDEF";
 #define BPXLEN	50
 #define BPALEN	18
 
-void bprint( data, len )
-    char	*data;
-    int		len;
+void bprint( char *data, int len )
 {
     char	xout[ BPXLEN ], aout[ BPALEN ];
     int         i;

--- a/meson.build
+++ b/meson.build
@@ -119,6 +119,10 @@ if host_os == 'linux'
     netatalk_common_flags += '-D_GNU_SOURCE'
 endif
 
+if get_option('buildtype') == 'debug'
+    netatalk_common_flags += '-DEBUG'
+endif
+
 add_global_arguments(netatalk_common_flags, language: 'c')
 
 netatalk_common_link_args = []

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,7 @@ netatalk_version = meson.project_version()
 cpu = host_machine.cpu_family()
 host_os = host_machine.system()
 target_os = target_machine.system()
+build_type = get_option('buildtype')
 
 linux_distro = ''
 
@@ -119,7 +120,7 @@ if host_os == 'linux'
     netatalk_common_flags += '-D_GNU_SOURCE'
 endif
 
-if get_option('buildtype') == 'debug'
+if build_type == 'debug'
     netatalk_common_flags += '-DEBUG'
 endif
 
@@ -2362,6 +2363,7 @@ summary_info = {
     'host CPU': cpu,
     'host endianness': build_machine.endian(),
     'C compiler': cc.get_id(),
+    'build stype': build_type,
     'Shared or static libraries': get_option('default_library'),
 }
 summary(summary_info, bool_yn: true, section: 'Compilation:')


### PR DESCRIPTION
- Enable the `EBUG` flag when build type is debug
- Print the build type in Meson summary
- Remove remnants of the obsoleted `DEBUG` flag
- Fix static analysis bugs