### PR TITLE
Fix loss of FinderInfo on resource fork creation with AppleDouble EA.

### DIFF
--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -1495,7 +1495,6 @@ static int ad_open_rf_ea(const char *path, int adflags, int mode, struct adouble
         /* This is a new adouble header file, create it */
         LOG(log_debug, logtype_ad, "ad_open_rf(\"%s\"): created adouble rfork, initializing: \"%s\"",
             path, rfpath);
-        EC_NEG1_LOG( new_ad_header(ad, path, NULL, adflags) );
         LOG(log_debug, logtype_ad, "ad_open_rf(\"%s\"): created adouble rfork, flushing: \"%s\"",
             path, rfpath);
         ad_flush(ad);


### PR DESCRIPTION
Fixes a regression introduced in this commit: https://github.com/Netatalk/netatalk/commit/8e8430ea012c57e2285b04e3b2567b75d7d1a38f

Fixes these two bug reports over on SourceForge:
https://sourceforge.net/p/netatalk/bugs/580/
https://sourceforge.net/p/netatalk/bugs/600/

This bug only affects the `ea` AppleDouble backend when using separate files for resource fork storage. Platforms like Solaris that store resource forks in EAs are not affected and the `v2` backend uses a different code path.

When creating new files to a Netatalk volume, the FinderInfo data for that file was being reinitialized to the default after a resource fork was added. In most cases this did not cause an issue as the client usually (re)writes the FinderInfo data in a FPSetFileParams call after the fork copy is complete.

In the case of the built-in macOS unzip tool and rsync, the client does not do this. FinderInfo data is written to the file before the resource fork is written. Subsequent FPSetFileParams calls only set timestamps.

The fix is to remove this unnecessary re-initialization of the AppleDouble EA when creating a resource fork.