### PR TITLE
testsuite: Clean up test executable options and helptext

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -172,6 +172,24 @@ jobs:
           - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
+    afp-encodingtest-afp34:
+      name: AFP encoding test - AFP 3.4
+      needs: build-container-testsuite
+      runs-on: ubuntu-latest
+      timeout-minutes: 5
+      env:
+          AFP_USER: atalk1
+          AFP_PASS: afpafp
+          AFP_GROUP: afpusers
+          SHARE_NAME: test1
+          INSECURE_AUTH: 1
+          VERBOSE: 1
+          TESTSUITE: encoding
+          AFP_VERSION: 7
+      steps:
+          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+
+
 
     afp-spectest-afp21:
       name: AFP spec test tier 1 - AFP 2.1
@@ -248,6 +266,24 @@ jobs:
           INSECURE_AUTH: 1
           VERBOSE: 1
           TESTSUITE: login
+          AFP_VERSION: 1
+      steps:
+          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+
+
+    afp-encodingtest-afp21:
+      name: AFP encoding test - AFP 2.1
+      needs: build-container-testsuite
+      runs-on: ubuntu-latest
+      timeout-minutes: 5
+      env:
+          AFP_USER: atalk1
+          AFP_PASS: afpafp
+          AFP_GROUP: afpusers
+          SHARE_NAME: test1
+          INSECURE_AUTH: 1
+          VERBOSE: 1
+          TESTSUITE: encoding
           AFP_VERSION: 1
       steps:
           - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest

--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -203,9 +203,11 @@ else
         echo "testfile uno" > /mnt/afpshare/first.txt
         echo "testfile dos" > /mnt/afpshare/second.txt
         mkdir /mnt/afpshare/third
-        afp_spectest "${TEST_FLAGS}" -"${AFP_VERSION}" -F "$TESTSUITE" -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}" -s "${SHARE_NAME}"
+        afp_spectest "${TEST_FLAGS}" -"${AFP_VERSION}" -C -F "$TESTSUITE" -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}" -s "${SHARE_NAME}"
     elif [ "$TESTSUITE" == "login" ]; then
-        afp_logintest "${TEST_FLAGS}" -"${AFP_VERSION}" -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}"
+        afp_logintest "${TEST_FLAGS}" -"${AFP_VERSION}" -C -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}"
+    elif [ "$TESTSUITE" == "encoding" ]; then
+        afp_encodingtest "${TEST_FLAGS}" -"${AFP_VERSION}" -C -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}"  -s "${SHARE_NAME}" -c /mnt/afpshare
     else
         echo "Unknown testsuite: ${TESTSUITE}"
         exit 1

--- a/test/testsuite/afparg.c
+++ b/test/testsuite/afparg.c
@@ -217,7 +217,7 @@ static void run_one(char *name, char **args)
 /* =============================== */
 void usage( char * av0 )
 {
-    fprintf( stdout, "usage:\t%s [-v] [-h host] [-p port] [-s vol] [-u user] [-w password] -f [call] [optional args for requested AFP call]\n", av0 );
+    fprintf( stdout, "usage:\t%s [-1234567lVv] [-h host] [-p port] [-s vol] [-u user] [-w password] -f [call] [optional args for requested AFP call]\n", av0 );
     fprintf( stdout,"\t-h\tserver host name (default localhost)\n");
     fprintf( stdout,"\t-p\tserver port (default 548)\n");
     fprintf( stdout,"\t-s\tvolume to mount (default home)\n");
@@ -247,7 +247,7 @@ int main( int ac, char **av )
 int cc;
 int ret;
 
-    while (( cc = getopt( ac, av, "vV1234567h:p:s:u:w:f:l" )) != EOF ) {
+    while (( cc = getopt( ac, av, "1234567lVvf:h:p:s:u:w:" )) != EOF ) {
         switch ( cc ) {
         case '1':
 			vers = "AFPVersion 2.1";
@@ -277,23 +277,14 @@ int ret;
 			vers = "AFP3.4";
 			Version = 34;
 			break;
+        case 'f' :
+            Test = strdup(optarg);
+            break;
         case 'h':
             Server = strdup(optarg);
             break;
-        case 's':
-            Vol = strdup(optarg);
-            break;
-        case 'u':
-            User = strdup(optarg);
-            break;
-        case 'w':
-            Password = strdup(optarg);
-            break;
         case 'l' :
             List = 1;
-            break;
-        case 'f' :
-            Test = strdup(optarg);
             break;
         case 'p' :
             Port = atoi( optarg );
@@ -302,13 +293,22 @@ int ret;
                 exit(1);
             }
             break;
-	case 'v':
-		Quiet = 0;
-		break;
-	case 'V':
-		Quiet = 0;
-		Verbose = 1;
-		break;
+        case 's':
+            Vol = strdup(optarg);
+            break;
+        case 'u':
+            User = strdup(optarg);
+            break;
+        case 'V':
+            Quiet = 0;
+            Verbose = 1;
+            break;
+        case 'v':
+            Quiet = 0;
+            break;
+        case 'w':
+            Password = strdup(optarg);
+            break;
         default :
             usage( av[ 0 ] );
         }

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -333,7 +333,7 @@ enum adouble adouble = AD_EA;
 /* =============================== */
 void usage( char * av0 )
 {
-    fprintf( stdout, "usage:\t%s [-aCiLlmnvVx1234567] [-h host] [-p port] [-s vol] [-u user] [-w password] [-F testsuite] [-f test]\n", av0 );
+    fprintf( stdout, "usage:\t%s [-1234567aCiLlmnVvx] [-h host] [-H host2] [-p port] [-s vol] [-c vol path] [-S vol2] [-u user] [-d user2] [-w password] [-F testsuite] [-f test]\n", av0 );
     fprintf( stdout,"\t-a\tvolume is appledouble = v2 instead of default appledouble = ea\n");
     fprintf( stdout,"\t-L\tserver without working fcntl locking, skip tests using it\n");
     fprintf( stdout,"\t-m\tserver is a Mac\n");
@@ -407,51 +407,39 @@ int ret;
 		case 'a':
             adouble = AD_V2;
 			break;
+		case 'C':
+			Color = 1;
+			break;
 		case 'c':
 			Path = strdup(optarg);
 			break;
-		case 'L':
-			Locking = 1;
+        case 'd':
+            User2 = strdup(optarg);
+            break;
+        case 'F' :
+            Suite = strdup(optarg);
+            break;
+        case 'f' :
+            Test = strdup(optarg);
+            break;
+        case 'H':
+            Server2 = strdup(optarg);
+            break;
+        case 'h':
+            Server = strdup(optarg);
+            break;
+		case 'i':
+			Interactive = 1;
 			break;
+        case 'l' :
+            List = 1;
+            break;
 		case 'm':
 			Mac = 1;
 			break;
         case 'n':
             Proto = 1;
             break;
-        case 'h':
-            Server = strdup(optarg);
-            break;
-        case 'H':
-            Server2 = strdup(optarg);
-            break;
-        case 's':
-            Vol = strdup(optarg);
-            break;
-        case 'S':
-            Vol2 = strdup(optarg);
-            break;
-        case 'u':
-            User = strdup(optarg);
-            break;
-        case 'd':
-            User2 = strdup(optarg);
-            break;
-        case 'w':
-            Password = strdup(optarg);
-            break;
-        case 'l' :
-            List = 1;
-            break;
-        case 'f' :
-            Test = strdup(optarg);
-            break;
-        case 'F' :
-            Suite = strdup(optarg);
-            break;
-        case 'x':
-        	Exclude = 1;
-        	break;
         case 'p' :
             Port = atoi( optarg );
             if (Port <= 0) {
@@ -459,19 +447,28 @@ int ret;
                 exit(1);
             }
             break;
-		case 'v':
-			Quiet = 0;
-			break;
+        case 'S':
+            Vol2 = strdup(optarg);
+            break;
+        case 's':
+            Vol = strdup(optarg);
+            break;
+        case 'u':
+            User = strdup(optarg);
+            break;
 		case 'V':
 			Quiet = 0;
 			Verbose = 1;
 			break;
-		case 'i':
-			Interactive = 1;
+		case 'v':
+			Quiet = 0;
 			break;
-		case 'C':
-			Color = 1;
-			break;
+        case 'w':
+            Password = strdup(optarg);
+            break;
+        case 'x':
+        	Exclude = 1;
+        	break;
 
         default :
             usage( av[ 0 ] );

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -1271,8 +1271,8 @@ void (*fn)(void) = NULL;
 /* =============================== */
 void usage( char * av0 )
 {
-    fprintf( stdout, "usage:\t%s [-h host] [-p port] [-s vol] [-S Vol2] [-u user] [-w password] [-f test] [-c count] "
-    "[-d size] [-q quantum] [-F file] [-1234567LvViyea] \n", av0 );
+    fprintf( stdout, "usage:\t%s [-1234567aeiLnVvy] [-h host] [-p port] [-s vol] [-S vol2] [-u user] [-w password] [-f test] [-c count] "
+    "[-d size] [-q quantum] [-F file] \n", av0 );
     fprintf( stdout,"\t-h\tserver host name (default localhost)\n");
     fprintf( stdout,"\t-p\tserver port (default 548)\n");
     fprintf( stdout,"\t-s\tvolume to mount (default home)\n");
@@ -1317,42 +1317,8 @@ int main( int ac, char **av )
 int cc;
 
 	Quiet = 1;
-    while (( cc = getopt( ac, av, "Vv1234567h:p:s:S:u:d:w:f:ic:""o:q:r:yeLDaF:R:" )) != EOF ) {
+    while (( cc = getopt( ac, av, "1234567aeDiLnVvyc:d:F:f:h:o:p:q:R:r:S:s:u:w:" )) != EOF ) {
         switch ( cc ) {
-		case 'd':
-			Size = atoi(optarg) * MEGABYTE;
-			break;
-		case 'q':
-			Quantum = atoi(optarg) *KILOBYTE;
-			break;
-		case 'r':
-			Request = atoi(optarg);
-			break;
-		case 'R':
-			Req = atoi(optarg);
-			break;
-		case 'y':
-			Delete = 1;
-			break;
-		case 'e':
-			Sparse = 1;
-			break;
-		case 'L':
-			Local = 1;
-			break;
-		case 'D':
-			Direct = 1;
-			break;
-		case 'a':
-			Flush = 0;
-			break;
-		case 'c':
-			Count = atoi(optarg);
-			break;
-		case 'F':
-            Filename = strdup(optarg);
-            break;
-
         case '1':
 			vers = "AFPVersion 2.1";
 			Version = 21;
@@ -1381,26 +1347,38 @@ int cc;
 			vers = "AFP3.4";
 			Version = 34;
 			break;
-        case 'n':
-            Proto = 1;
+		case 'a':
+			Flush = 0;
+			break;
+		case 'c':
+			Count = atoi(optarg);
+			break;
+		case 'D':
+			Direct = 1;
+			break;
+		case 'd':
+			Size = atoi(optarg) * MEGABYTE;
+			break;
+		case 'e':
+			Sparse = 1;
+			break;
+		case 'F':
+            Filename = strdup(optarg);
+            break;
+        case 'f' :
+            Test = strdup(optarg);
             break;
         case 'h':
             Server = strdup(optarg);
             break;
-        case 's':
-            Vol = strdup(optarg);
-            break;
-        case 'S':
-            Vol2 = strdup(optarg);
-            break;
-        case 'u':
-            User = strdup(optarg);
-            break;
-        case 'w':
-            Password = strdup(optarg);
-            break;
-        case 'f' :
-            Test = strdup(optarg);
+		case 'i':
+			Interactive = 1;
+			break;
+		case 'L':
+			Local = 1;
+			break;
+        case 'n':
+            Proto = 1;
             break;
         case 'p' :
             Port = atoi( optarg );
@@ -1409,17 +1387,37 @@ int cc;
                 exit(1);
             }
             break;
-	case 'v':
-		Quiet = 0;
-		break;
-	case 'V':
-		Quiet = 0;
-		Verbose = 1;
-		break;
-	case 'i':
-		Interactive = 1;
-		break;
-
+		case 'q':
+			Quantum = atoi(optarg) *KILOBYTE;
+			break;
+		case 'R':
+			Req = atoi(optarg);
+			break;
+		case 'r':
+			Request = atoi(optarg);
+			break;
+        case 'S':
+            Vol2 = strdup(optarg);
+            break;
+        case 's':
+            Vol = strdup(optarg);
+            break;
+        case 'u':
+            User = strdup(optarg);
+            break;
+		case 'V':
+			Quiet = 0;
+			Verbose = 1;
+			break;
+		case 'v':
+			Quiet = 0;
+			break;
+        case 'w':
+            Password = strdup(optarg);
+            break;
+		case 'y':
+			Delete = 1;
+			break;
         default :
             usage( av[ 0 ] );
         }
@@ -1454,12 +1452,17 @@ int cc;
 		}
 
 	    /* login */
+		// FIXME: workaround for FPopenLoginExt() being broken
+#if 0
     	if (Version >= 30) {
 			FPopenLoginExt(Conn, vers, uam, User, Password);
 		}
 		else {
+#endif
 			FPopenLogin(Conn, vers, uam, User, Password);
+#if 0
 		}
+#endif
 	}
 	Conn->afp_version = Version;
 


### PR DESCRIPTION
- Standardize test app options as much as possible
- Order options alphabetically for easier maintenance
- Fix a bunch of bugs in some of the tests
- Add afp_encodingtest CI job