### PR TITLE
docs: Create manual page for afptest tools

### DIFF
--- a/doc/ja/manpages/man1/afptest.1.xml
+++ b/doc/ja/manpages/man1/afptest.1.xml
@@ -1,0 +1,271 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<refentry id="afptest.1">
+  <refmeta>
+    <refentrytitle>afptest</refentrytitle>
+
+    <manvolnum>1</manvolnum>
+
+    <refmiscinfo class="date">27 October 2024</refmiscinfo>
+
+    <refmiscinfo class="source">Netatalk</refmiscinfo>
+
+    <refmiscinfo class="manual">Netatalk AFP ファイルサーバーのマニュアル</refmiscinfo>
+
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
+  </refmeta>
+
+  <refnamediv>
+    <refname>afptest</refname>
+
+    <refname>afp_encodingtest</refname>
+
+    <refname>afp_lantest</refname>
+
+    <refname>afp_logintest</refname>
+
+    <refname>afp_spectest</refname>
+
+    <refname>afp_speedtest</refname>
+
+    <refname>afparg</refname>
+
+    <refpurpose>AFP プロトコルテスト</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+    <cmdsynopsis>
+      <command>afp_encodingtest<indexterm>
+          <primary>afptest</primary>
+        </indexterm></command>
+
+      <arg>-1234567CdVv</arg>
+
+      <arg>-h <replaceable>ホスト</replaceable></arg>
+
+      <arg>-p <replaceable>ポート</replaceable></arg>
+
+      <arg>-s <replaceable>ボリューム</replaceable></arg>
+
+      <arg>-c <replaceable>ボリュームへのパス</replaceable></arg>
+
+      <arg>-u <replaceable>ユーザー</replaceable></arg>
+
+      <arg>-w <replaceable>パスワード</replaceable></arg>
+
+      <arg>-e <replaceable>エンコーディング</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>afp_lantest<indexterm>
+          <primary>afptest</primary>
+        </indexterm></command>
+
+      <arg>-34567GgVv</arg>
+
+      <arg>-h <replaceable>ホスト</replaceable></arg>
+
+      <arg>-p <replaceable>ポート</replaceable></arg>
+
+      <arg>-s <replaceable>ボリューム</replaceable></arg>
+
+      <arg>-u <replaceable>ユーザー</replaceable></arg>
+
+      <arg>-w <replaceable>パスワード</replaceable></arg>
+
+      <arg>-n <replaceable>反復</replaceable></arg>
+
+      <arg>-t <replaceable>実行するテスト</replaceable></arg>
+
+      <arg>-F <replaceable>bigfile</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>afp_logintest<indexterm>
+          <primary>afptest</primary>
+        </indexterm></command>
+
+      <arg>-1234567CmVv</arg>
+
+      <arg>-h <replaceable>ホスト</replaceable></arg>
+
+      <arg>-p <replaceable>ポート</replaceable></arg>
+
+      <arg>-s <replaceable>ボリューム</replaceable></arg>
+
+      <arg>-u <replaceable>ユーザー</replaceable></arg>
+
+      <arg>-w <replaceable>パスワード</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>afp_spectest<indexterm>
+          <primary>afptest</primary>
+        </indexterm></command>
+
+      <arg>-1234567aCiLlmnVvx</arg>
+
+      <arg>-h <replaceable>ホスト</replaceable></arg>
+
+      <arg>-H <replaceable>ホスト2</replaceable></arg>
+
+      <arg>-p <replaceable>port</replaceable></arg>
+
+      <arg>-s <replaceable>ボリューム</replaceable></arg>
+
+      <arg>-c <replaceable>ボリュームへのパス</replaceable></arg>
+
+      <arg>-S <replaceable>ボリューム2</replaceable></arg>
+
+      <arg>-u <replaceable>ユーザー</replaceable></arg>
+
+      <arg>-d <replaceable>user2</replaceable></arg>
+
+      <arg>-w <replaceable>パスワード</replaceable></arg>
+
+      <arg>-F <replaceable>テストスイート</replaceable></arg>
+
+      <arg>-f <replaceable>テスト</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>afp_speedtest<indexterm>
+          <primary>afptest</primary>
+        </indexterm></command>
+
+      <arg>-1234567aeiLnVvy</arg>
+
+      <arg>-h <replaceable>ホスト</replaceable></arg>
+
+      <arg>-p <replaceable>ポート</replaceable></arg>
+
+      <arg>-s <replaceable>ボリューム</replaceable></arg>
+
+      <arg>-S <replaceable>ボリューム2</replaceable></arg>
+
+      <arg>-u <replaceable>ユーザー</replaceable></arg>
+
+      <arg>-w <replaceable>パスワード</replaceable></arg>
+
+      <arg>-n <replaceable>反復</replaceable></arg>
+
+      <arg>-d <replaceable>サイズ</replaceable></arg>
+
+      <arg>-q <replaceable>quantum</replaceable></arg>
+
+      <arg>-F <replaceable>ファイル</replaceable></arg>
+
+      <arg>-f <replaceable>テスト</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>afparg<indexterm>
+          <primary>afptest</primary>
+        </indexterm></command>
+
+      <arg>-1234567lVv</arg>
+
+      <arg>-h <replaceable>ホスト</replaceable></arg>
+
+      <arg>-p <replaceable>ポート</replaceable></arg>
+
+      <arg>-s <replaceable>ボリューム</replaceable></arg>
+
+      <arg>-u <replaceable>ユーザー</replaceable></arg>
+
+      <arg>-w <replaceable>パスワード</replaceable></arg>
+
+      <arg>-f <replaceable>コマンド</replaceable></arg>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+
+  <refsect1>
+    <title>説明</title>
+
+    <para><emphasis remap="I">afptest</emphasis>
+    ファミリーのすべてのツールは、同じ一般的な使用パターンとパラメータに従います。 AFP プロトコル リビジョン
+    (<option>-1</option> から <option>-7</option>) を設定し、次にテストするホストのアドレスと資格情報
+    (localhost も可) を設定します。一部のテストでは、2 番目のユーザーと 2 番目のボリュームを定義する必要があります。さらに別のテスト
+    セットを localhost から実行し、テスト対象のボリュームへのローカル パスを指定する必要があります。 単一のテストまたはテスト
+    セクションは、<option>-f</option> オプションで実行できます。使用可能なテストは、<option>-l</option>
+    オプションで一覧表示できます。</para>
+
+    <para><command>afp_spectest</command> は、300 を超えるテスト ケースを含む AFP 仕様テスト
+    スイートの中核を構成します。テストケースは、実行の前提条件によって分割され、内部的に複数のテストスイートに編成されています。現在使用可能なスイートは、<emphasis
+    remap="I">tier1</emphasis>、<emphasis remap="I">tier2</emphasis>
+    (<option>-c</option> オプションを使用してローカルで実行する必要があります)、<emphasis
+    remap="I">readonly</emphasis> (ファイルが読み込まれた読み取り専用ボリュームが必要です)、および <emphasis
+    remap="I">sleep</emphasis> です。</para>
+
+    <para><command>afp_encodingtest</command> および
+    <command>afp_logintest</command> は、独自のランナーを持つ特定の AFP
+    仕様テストスイートです。前者は、<option>-c</option> オプションを使用してローカルで実行する必要があります。</para>
+
+    <para><command>afp_lantest</command> と <command>afp_speedtest</command>
+    は、AFP サーバーのファイル転送ベンチマークです。前者は、さまざまなファイル転送パターンのバッチを実行する <emphasis
+    remap="I">HELIOS LanTest</emphasis> にヒントを得たものです。後者は、いくつかのテスト
+    ケースが用意された、よりシンプルなツールです。</para>
+
+    <para><command>afparg</command> は、オプションの引数を持つ特定のコマンドを受け取り、AFP
+    サーバーに単一のアクションを送信する AFP CLI クライアントです。これは、1
+    回限りのトラブルシューティングやシステム管理に使用できます。</para>
+
+    <para>各オプションの正確な使用方法については、各ツールのヘルプテキストを参照してください。</para>
+  </refsect1>
+
+  <refsect1>
+    <title>例</title>
+
+    <para>afp_spectest の FPSetForkParms_test テストセットを AFP 3.4 で実行します。</para>
+
+    <screen><prompt>%</prompt> <userinput>afp_spectest -h 127.0.0.1 -p 548 -u user1 -d user2 -w passwd -s testvol1 -S testvol2 -c /srv/afptest1 -7 -f FPSetForkParms_test</userinput>
+<computeroutput>===================
+FPSetForkParms_test
+-------------------
+FPSetForkParms:test62: SetForkParams errors - PASSED
+FPSetForkParms:test141: Setforkmode error - PASSED
+FPSetForkParms:test217: Setfork size 64 bits - PASSED
+FPSetForkParms:test306: set fork size, new size &gt; old size - PASSED</computeroutput>
+</screen>
+
+    <para>AFP 3.0 を使用して afp_lantest ベンチマークを実行します。</para>
+
+    <screen><prompt>%</prompt> <userinput>afp_lantest -h 192.168.0.2 -s testvol1 -u user1 -w passwd -3</userinput>
+<computeroutput>Run 0 =&gt; Opening, stating and reading 512 bytes from 1000 files   1799 ms
+Run 0 =&gt; Writing one large file                                     30 ms for 100 MB (avg. 3495 MB/s)
+Run 0 =&gt; Reading one large file                                      8 ms for 100 MB (avg. 13107 MB/s)
+Run 0 =&gt; Locking/Unlocking 10000 times each                       1959 ms
+Run 0 =&gt; Creating dir with 2000 files                             1339 ms
+Run 0 =&gt; Enumerate dir with 2000 files                             217 ms
+Run 0 =&gt; Create directory tree with 10^3 dirs                      496 ms
+
+Netatalk Lantest Results (averages)
+===================================
+
+Opening, stating and reading 512 bytes from 1000 files   1799 ms
+Writing one large file                                     30 ms for 100 MB (avg. 3495 MB/s)
+Reading one large file                                      8 ms for 100 MB (avg. 13107 MB/s)
+Locking/Unlocking 10000 times each                       1959 ms
+Creating dir with 2000 files                             1339 ms
+Enumerate dir with 2000 files                             217 ms
+Create directory tree with 10^3 dirs                      496 ms</computeroutput>
+</screen>
+  </refsect1>
+
+  <refsect1>
+    <title>参照</title>
+
+    <para><citerefentry>
+        <refentrytitle>afpd</refentrytitle>
+
+        <manvolnum>8</manvolnum>
+      </citerefentry>.</para>
+  </refsect1>
+
+  <refsect1>
+    <title>著者</title>
+
+    <para><ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
+    を参照</para>
+  </refsect1>
+</refentry>

--- a/doc/ja/manpages/man1/meson.build
+++ b/doc/ja/manpages/man1/meson.build
@@ -4,6 +4,7 @@ manfiles = [
     'afpldaptest.1',
     'afppasswd.1',
     'afpstats.1',
+    'afptest.1',
     'apple_dump.1',
     'asip-status.1',
     'dbd.1',

--- a/doc/ja/manual/manual.xml.in
+++ b/doc/ja/manual/manual.xml.in
@@ -20,6 +20,7 @@
 <!ENTITY afpldaptest.1 SYSTEM "../manpages/man1/afpldaptest.1.xml">
 <!ENTITY afppasswd.1 SYSTEM "../manpages/man1/afppasswd.1.xml">
 <!ENTITY afpstats.1 SYSTEM "../manpages/man1/afpstats.1.xml">
+<!ENTITY afptest.1 SYSTEM "../manpages/man1/afptest.1.xml">
 <!ENTITY apple_dump.1 SYSTEM "../manpages/man1/apple_dump.1.xml">
 <!ENTITY asip-status.1 SYSTEM "../manpages/man1/asip-status.1.xml">
 <!ENTITY atalk.4 SYSTEM "../manpages/man4/atalk.4.xml">
@@ -95,6 +96,8 @@
     &afppasswd.1;
 
     &afpstats.1;
+
+    &afptest.1;
 
     &apple_dump.1;
 

--- a/doc/ja/manual/meson.build
+++ b/doc/ja/manual/meson.build
@@ -40,6 +40,8 @@ custom_target(
         'afpd.8.html',
         'afpldaptest.1.html',
         'afppasswd.1.html',
+        'afpstats.1.html',
+        'afptest.1.html',
         'apple_dump.1.html',
         'appletalk.html',
         'asip-status.1.html',

--- a/doc/manpages/man1/afptest.1
+++ b/doc/manpages/man1/afptest.1
@@ -1,0 +1,1 @@
+.so man1/afptest.1

--- a/doc/manpages/man1/afptest.1.xml
+++ b/doc/manpages/man1/afptest.1.xml
@@ -1,0 +1,279 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<refentry id="afptest.1">
+  <refmeta>
+    <refentrytitle>afptest</refentrytitle>
+
+    <manvolnum>1</manvolnum>
+
+    <refmiscinfo class="date">27 October 2024</refmiscinfo>
+
+    <refmiscinfo class="source">Netatalk</refmiscinfo>
+
+    <refmiscinfo class="manual">Netatalk AFP Fileserver Manual</refmiscinfo>
+
+    <refmiscinfo class="version">@netatalk_version@</refmiscinfo>
+  </refmeta>
+
+  <refnamediv>
+    <refname>afptest</refname>
+
+    <refname>afp_encodingtest</refname>
+
+    <refname>afp_lantest</refname>
+
+    <refname>afp_logintest</refname>
+
+    <refname>afp_spectest</refname>
+
+    <refname>afp_speedtest</refname>
+
+    <refname>afparg</refname>
+
+    <refpurpose>AFP protocol tests</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+    <cmdsynopsis>
+      <command>afp_encodingtest<indexterm>
+          <primary>afptest</primary>
+        </indexterm></command>
+
+      <arg>-1234567CdVv</arg>
+
+      <arg>-h <replaceable>host</replaceable></arg>
+
+      <arg>-p <replaceable>port</replaceable></arg>
+
+      <arg>-s <replaceable>volume</replaceable></arg>
+
+      <arg>-c <replaceable>path to volume</replaceable></arg>
+
+      <arg>-u <replaceable>user</replaceable></arg>
+
+      <arg>-w <replaceable>password</replaceable></arg>
+
+      <arg>-e <replaceable>encoding</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>afp_lantest<indexterm>
+          <primary>afptest</primary>
+        </indexterm></command>
+
+      <arg>-34567GgVv</arg>
+
+      <arg>-h <replaceable>host</replaceable></arg>
+
+      <arg>-p <replaceable>port</replaceable></arg>
+
+      <arg>-s <replaceable>volume</replaceable></arg>
+
+      <arg>-u <replaceable>user</replaceable></arg>
+
+      <arg>-w <replaceable>password</replaceable></arg>
+
+      <arg>-n <replaceable>iterations</replaceable></arg>
+
+      <arg>-t <replaceable>tests</replaceable></arg>
+
+      <arg>-F <replaceable>bigfile</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>afp_logintest<indexterm>
+          <primary>afptest</primary>
+        </indexterm></command>
+
+      <arg>-1234567CmVv</arg>
+
+      <arg>-h <replaceable>host</replaceable></arg>
+
+      <arg>-p <replaceable>port</replaceable></arg>
+
+      <arg>-s <replaceable>volume</replaceable></arg>
+
+      <arg>-u <replaceable>user</replaceable></arg>
+
+      <arg>-w <replaceable>password</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>afp_spectest<indexterm>
+          <primary>afptest</primary>
+        </indexterm></command>
+
+      <arg>-1234567aCiLlmnVvx</arg>
+
+      <arg>-h <replaceable>host</replaceable></arg>
+
+      <arg>-H <replaceable>host2</replaceable></arg>
+
+      <arg>-p <replaceable>port</replaceable></arg>
+
+      <arg>-s <replaceable>volume</replaceable></arg>
+
+      <arg>-c <replaceable>path to volume</replaceable></arg>
+
+      <arg>-S <replaceable>volume2</replaceable></arg>
+
+      <arg>-u <replaceable>user</replaceable></arg>
+
+      <arg>-d <replaceable>user2</replaceable></arg>
+
+      <arg>-w <replaceable>password</replaceable></arg>
+
+      <arg>-F <replaceable>testsuite</replaceable></arg>
+
+      <arg>-f <replaceable>test</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>afp_speedtest<indexterm>
+          <primary>afptest</primary>
+        </indexterm></command>
+
+      <arg>-1234567aeiLnVvy</arg>
+
+      <arg>-h <replaceable>host</replaceable></arg>
+
+      <arg>-p <replaceable>port</replaceable></arg>
+
+      <arg>-s <replaceable>volume</replaceable></arg>
+
+      <arg>-S <replaceable>volume2</replaceable></arg>
+
+      <arg>-u <replaceable>user</replaceable></arg>
+
+      <arg>-w <replaceable>password</replaceable></arg>
+
+      <arg>-n <replaceable>iterations</replaceable></arg>
+
+      <arg>-d <replaceable>size</replaceable></arg>
+
+      <arg>-q <replaceable>quantum</replaceable></arg>
+
+      <arg>-F <replaceable>file</replaceable></arg>
+
+      <arg>-f <replaceable>test</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>afparg<indexterm>
+          <primary>afptest</primary>
+        </indexterm></command>
+
+      <arg>-1234567lVv</arg>
+
+      <arg>-h <replaceable>host</replaceable></arg>
+
+      <arg>-p <replaceable>port</replaceable></arg>
+
+      <arg>-s <replaceable>volume</replaceable></arg>
+
+      <arg>-u <replaceable>user</replaceable></arg>
+
+      <arg>-w <replaceable>password</replaceable></arg>
+
+      <arg>-f <replaceable>command</replaceable></arg>
+    </cmdsynopsis>
+  </refsynopsisdiv>
+
+  <refsect1>
+    <title>Description</title>
+
+    <para>All of the tools in the <emphasis remap="I">afptest</emphasis>
+    family follow the same general usage pattern and parameters. You set the
+    AFP protocol revision (<option>-1</option> through <option>-7</option>),
+    then the address and credentials of the host to test (which can be
+    localhost). Some tests require a second user and second volume to be
+    define. Yet another set of tests must be run from localhost, and the local
+    path to the volume under test to be provided. Single tests or test
+    sections can be executed with the <option>-f</option> option. Available
+    tests can be listed with the <option>-l</option> option.</para>
+
+    <para><command>afp_spectest</command> makes up the core of the AFP
+    specification test suite, with just over 300 test cases. The test cases
+    are organized into multiple test suites internally, split by preconditions
+    for execution. The available suites are currently: <emphasis
+    remap="I">tier1</emphasis>, <emphasis remap="I">tier2</emphasis> (needs to
+    run locally with the <option>-c</option> option), <emphasis
+    remap="I">readonly</emphasis> (needs a read only volume populated with
+    files), and <emphasis remap="I">sleep</emphasis>.</para>
+
+    <para><command>afp_encodingtest</command> and
+    <command>afp_logintest</command> are specific AFP specification test
+    suites that have their own runners. The former must run locally with the
+    <option>-c</option> option.</para>
+
+    <para><command>afp_lantest</command> and <command>afp_speedtest</command>
+    are file transfer benchmarks for AFP servers. The former is inspired by
+    <emphasis remap="I">HELIOS LanTest</emphasis>, which runs a batch of
+    varied file transfer patterns. The latter is a simpler tool with a handful
+    of available test cases.</para>
+
+    <para><command>afparg</command> is an AFP CLI client that takes a specific
+    command with optional arguments, and sends a single action to the AFP
+    server. This can be used for one-off troubleshooting or system
+    administration.</para>
+
+    <para>Please refer to the helptext of each tool for the precise use of
+    each option.</para>
+  </refsect1>
+
+  <refsect1>
+    <title>Example</title>
+
+    <para>Run the afp_spectest for the "FPSetForkParms_test" testset with
+    AFP 3.4.</para>
+
+    <screen><prompt>%</prompt> <userinput>afp_spectest -h 127.0.0.1 -p 548 -u user1 -d user2 -w passwd -s testvol1 -S testvol2 -c /srv/afptest1 -7 -f FPSetForkParms_test</userinput>
+<computeroutput>===================
+FPSetForkParms_test
+-------------------
+FPSetForkParms:test62: SetForkParams errors - PASSED
+FPSetForkParms:test141: Setforkmode error - PASSED
+FPSetForkParms:test217: Setfork size 64 bits - PASSED
+FPSetForkParms:test306: set fork size, new size &gt; old size - PASSED</computeroutput>
+</screen>
+
+    <para>Run the afp_lantest benchmark using AFP 3.0.</para>
+
+    <screen><prompt>%</prompt> <userinput>afp_lantest -h 192.168.0.2 -s testvol1 -u user1 -w passwd -3</userinput>
+<computeroutput>Run 0 =&gt; Opening, stating and reading 512 bytes from 1000 files   1799 ms
+Run 0 =&gt; Writing one large file                                     30 ms for 100 MB (avg. 3495 MB/s)
+Run 0 =&gt; Reading one large file                                      8 ms for 100 MB (avg. 13107 MB/s)
+Run 0 =&gt; Locking/Unlocking 10000 times each                       1959 ms
+Run 0 =&gt; Creating dir with 2000 files                             1339 ms
+Run 0 =&gt; Enumerate dir with 2000 files                             217 ms
+Run 0 =&gt; Create directory tree with 10^3 dirs                      496 ms
+
+Netatalk Lantest Results (averages)
+===================================
+
+Opening, stating and reading 512 bytes from 1000 files   1799 ms
+Writing one large file                                     30 ms for 100 MB (avg. 3495 MB/s)
+Reading one large file                                      8 ms for 100 MB (avg. 13107 MB/s)
+Locking/Unlocking 10000 times each                       1959 ms
+Creating dir with 2000 files                             1339 ms
+Enumerate dir with 2000 files                             217 ms
+Create directory tree with 10^3 dirs                      496 ms</computeroutput>
+</screen>
+  </refsect1>
+
+  <refsect1>
+    <title>See also</title>
+
+    <para><citerefentry>
+        <refentrytitle>afpd</refentrytitle>
+
+        <manvolnum>8</manvolnum>
+      </citerefentry>.</para>
+  </refsect1>
+
+  <refsect1>
+    <title>Author</title>
+
+    <para>See <ulink
+    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink></para>
+  </refsect1>
+</refentry>

--- a/doc/manpages/man1/meson.build
+++ b/doc/manpages/man1/meson.build
@@ -4,6 +4,7 @@ manfiles = [
     'afpldaptest.1',
     'afppasswd.1',
     'afpstats.1',
+    'afptest.1',
     'apple_dump.1',
     'asip-status.1',
     'dbd.1',
@@ -29,6 +30,19 @@ foreach man : manfiles
         install_dir: mandir / 'man1',
         build_by_default: true,
     )
+endforeach
+
+afptest_staticmans = [
+    'afp_encodingtest.1',
+    'afp_lantest.1',
+    'afp_logintest.1',
+    'afp_spectest.1',
+    'afp_speedtest.1',
+    'afparg.1',
+]
+
+foreach man : afptest_staticmans
+    install_data('afptest.1', rename: man, install_dir: mandir / 'man1')
 endforeach
 
 nbp_staticmans = [

--- a/doc/manual/manual.xml.in
+++ b/doc/manual/manual.xml.in
@@ -20,6 +20,7 @@
 <!ENTITY afpldaptest.1 SYSTEM "../manpages/man1/afpldaptest.1.xml">
 <!ENTITY afppasswd.1 SYSTEM "../manpages/man1/afppasswd.1.xml">
 <!ENTITY afpstats.1 SYSTEM "../manpages/man1/afpstats.1.xml">
+<!ENTITY afptest.1 SYSTEM "../manpages/man1/afptest.1.xml">
 <!ENTITY apple_dump.1 SYSTEM "../manpages/man1/apple_dump.1.xml">
 <!ENTITY asip-status.1 SYSTEM "../manpages/man1/asip-status.1.xml">
 <!ENTITY atalk.4 SYSTEM "../manpages/man4/atalk.4.xml">
@@ -95,6 +96,8 @@
     &afppasswd.1;
 
     &afpstats.1;
+
+    &afptest.1;
 
     &apple_dump.1;
 

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -40,6 +40,8 @@ custom_target(
         'afpd.8.html',
         'afpldaptest.1.html',
         'afppasswd.1.html',
+        'afpstats.1.html',
+        'afptest.1.html',
         'apple_dump.1.html',
         'appletalk.html',
         'asip-status.1.html',


### PR DESCRIPTION
A single `afptest.1` man page for all six test tools.