### PR TITLE
docker: Explicitly launch the cupsd daemon on startup

### DIFF
--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -179,6 +179,7 @@ else
     echo "cupsautoadd:op=root:" > /usr/local/etc/papd.conf
 
 	echo "*** Starting AppleTalk services (this will take a minute)"
+ 	cupsd
 	atalkd
 	nbprgstr -p 4 "${ATALK_NAME}:Workstation"
 	nbprgstr -p 4 "${ATALK_NAME}:netatalk"


### PR DESCRIPTION
The CUPS daemon is no longer starting up by itself, so adding a step to the Docker entrypoint script.