### PR TITLE
testsuite: Print help text for missing mandatory options

### DIFF
--- a/test/testsuite/afparg.c
+++ b/test/testsuite/afparg.c
@@ -45,7 +45,7 @@ char    *Vol = "";
 char    *User;
 int     Version = 21;
 int     List = 0;
-char    *Test;
+char    *Test = "";
 
 /* Unused but required in afphelper.c. Argh. */
 CONN       *Conn2;
@@ -102,10 +102,9 @@ void usage( char * av0 )
     fprintf( stdout, "usage:\t%s [-1234567lVv] [-h host] [-p port] [-s vol] [-u user] [-w password] [-f command args]\n", av0 );
     fprintf( stdout,"\t-h\tserver host name (default localhost)\n");
     fprintf( stdout,"\t-p\tserver port (default 548)\n");
-    fprintf( stdout,"\t-s\tvolume to mount (default home)\n");
+    fprintf( stdout,"\t-s\tvolume to mount\n");
     fprintf( stdout,"\t-u\tuser name (default uid)\n");
-
-    fprintf( stdout,"\t-w\tpassword (default none)\n");
+    fprintf( stdout,"\t-w\tpassword\n");
     fprintf( stdout,"\t-1\tAFP 2.1 version (default)\n");
     fprintf( stdout,"\t-2\tAFP 2.2 version\n");
     fprintf( stdout,"\t-3\tAFP 3.0 version\n");
@@ -200,6 +199,25 @@ int ret;
 		exit (2);
 	}
 
+    if (!Quiet) {
+        fprintf(stdout, "Connecting to host %s:%d\n", Server, Port);
+    }
+	if (User != NULL && User[0] == '\0') {
+        fprintf(stdout, "Error: Define a user with -u\n");
+	}
+	if (Password != NULL && Password[0] == '\0') {
+        fprintf(stdout, "Error: Define a password with -w\n");
+	}
+	if (Vol != NULL && Vol[0] == '\0') {
+        fprintf(stdout, "Error: Define a volume with -s\n");
+	}
+	if (Test != NULL && Test[0] == '\0') {
+        fprintf(stdout, "Error: Define an AFP command with -f\n");
+        fprintf(stdout, "Available commands:\n");
+        list_tests();
+        exit(1);
+	}
+
     if ((Conn = (CONN *)calloc(1, sizeof(CONN))) == NULL) {
     	return 1;
     }
@@ -225,24 +243,16 @@ int ret;
 		ret = FPopenLoginExt(Conn, vers, uam, User, Password);
 	}
 	else {
+#endif
 		ret = FPopenLogin(Conn, vers, uam, User, Password);
+#if 0
 	}
-#else
-	ret = FPopenLogin(Conn, vers, uam, User, Password);
 #endif
 	if (ret) {
 		printf("Login failed\n");
 		exit(1);
 	}
 	Conn->afp_version = Version;
-
-	/*********************************
-	*/
-	if (Test == NULL) {
-        fprintf( stdout, "no test specified; choose one from:\n");
-        list_tests();
-        exit(1);
-    }
 
     run_one(Test, &av[optind]);
 

--- a/test/testsuite/encoding_test.c
+++ b/test/testsuite/encoding_test.c
@@ -7,8 +7,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
-char    *Path;
-
 uint16_t VolID;
 static DSI *dsi;
 CONN *Conn;
@@ -214,21 +212,22 @@ int     Port = 548;
 char    *Password = "";
 char    *Vol = "";
 char    *User;
+char    *Path = "";
 int     Version = 21;
 int     Mac = 0;
 
 /* =============================== */
 void usage( char * av0 )
 {
-    fprintf( stdout, "usage:\t%s [-1234567CdmVv] [-e encoding] [-h host] [-p port] [-s vol] [-c vol path] [-u user] [-w password]\n", av0 );
-    fprintf( stdout,"\t-m\tserver is a Mac\n");
+    fprintf( stdout, "usage:\t%s [-1234567CdVv] [-h host] [-p port] [-s vol] [-c vol path] "
+	"[-u user] [-w password] [-e encoding]\n", av0 );
     fprintf( stdout,"\t-e\tclient encoding (default western)\n");
     fprintf( stdout,"\t-h\tserver host name (default localhost)\n");
     fprintf( stdout,"\t-p\tserver port (default 548)\n");
-    fprintf( stdout,"\t-s\tvolume to mount (default home)\n");
+    fprintf( stdout,"\t-s\tvolume to mount\n");
     fprintf( stdout,"\t-c\tvolume path on the server\n");
     fprintf( stdout,"\t-u\tuser name (default uid)\n");
-    fprintf( stdout,"\t-w\tpassword (default none)\n");
+    fprintf( stdout,"\t-w\tpassword\n");
     fprintf( stdout,"\t-1\tAFP 2.1 version (default)\n");
     fprintf( stdout,"\t-2\tAFP 2.2 version\n");
     fprintf( stdout,"\t-3\tAFP 3.0 version\n");
@@ -292,9 +291,6 @@ static char *uam = "Cleartxt Passwrd";
         case 'h':
             Server = strdup(optarg);
             break;
-		case 'm':
-			Mac = 1;
-			break;
         case 'p' :
             Port = atoi( optarg );
             if (Port <= 0) {
@@ -323,6 +319,22 @@ static char *uam = "Cleartxt Passwrd";
         }
     }
 
+    if (!Quiet) {
+        fprintf(stdout, "Connecting to host %s:%d\n", Server, Port);
+    }
+	if (User != NULL && User[0] == '\0') {
+        fprintf(stdout, "Error: Define a user with -u\n");
+	}
+	if (Password != NULL && Password[0] == '\0') {
+        fprintf(stdout, "Error: Define a password with -w\n");
+	}
+	if (Vol != NULL && Vol[0] == '\0') {
+        fprintf(stdout, "Error: Define a volume with -s\n");
+	}
+	if (Path != NULL && Path[0] == '\0') {
+        fprintf(stdout, "Error: Define the local path to the volume with -c\n");
+	}
+
 	/************************************
 	 *                                  *
 	 * Connection user 1                *
@@ -350,7 +362,6 @@ static char *uam = "Cleartxt Passwrd";
     /* login */
 	FPopenLogin(Conn, vers, uam, User, Password);
 	Conn->afp_version = Version;
-
 
 	run_one();
 

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -636,12 +636,13 @@ fin:
 void usage( char * av0 )
 {
     int i=0;
-    fprintf( stdout, "usage:\t%s [-34567VvGg] [-h host] [-p port] [-s vol] [-u user] [-w password] [-n iterations] [-t tests to run] [-F bigfile]\n", av0 );
+    fprintf( stdout, "usage:\t%s [-34567GgVv] [-h host] [-p port] [-s vol] [-u user] [-w password] "
+    "[-n iterations] [-f tests] [-F bigfile]\n", av0 );
     fprintf( stdout,"\t-h\tserver host name (default localhost)\n");
     fprintf( stdout,"\t-p\tserver port (default 548)\n");
-    fprintf( stdout,"\t-s\tvolume to mount (default home)\n");
+    fprintf( stdout,"\t-s\tvolume to mount\n");
     fprintf( stdout,"\t-u\tuser name (default uid)\n");
-    fprintf( stdout,"\t-w\tpassword (default none)\n");
+    fprintf( stdout,"\t-w\tpassword\n");
     fprintf( stdout,"\t-3\tAFP 3.0 version\n");
     fprintf( stdout,"\t-4\tAFP 3.1 version\n");
     fprintf( stdout,"\t-5\tAFP 3.2 version\n");
@@ -653,7 +654,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-b\tdebug mode\n");
     fprintf( stdout,"\t-g\tfast network (Gbit, file testsize 1 GB)\n");
     fprintf( stdout,"\t-G\tridiculously fast network (10 Gbit, file testsize 10 GB)\n");
-    fprintf( stdout,"\t-t\ttests to run, eg 134 for tests 1, 3 and 4\n");
+    fprintf( stdout,"\t-f\ttests to run, eg 134 for tests 1, 3 and 4\n");
     fprintf( stdout,"\t-F\tuse this file located in the volume root for the read test (size must match -g and -G options)\n");
     fprintf( stdout,"\tAvailable tests:\n");
     for (i = 0; i < NUMTESTS; i++)
@@ -674,7 +675,7 @@ int main(int ac, char **av)
     if (pw)
         User = strdup(pw->pw_name);
 
-    while (( cc = getopt( ac, av, "1234567bGgVvF:h:n:p:s:t:u:w:" )) != EOF ) {
+    while (( cc = getopt( ac, av, "1234567bGgVvF:f:h:n:p:s:u:w:" )) != EOF ) {
         switch ( cc ) {
         case '3':
             vers = "AFPX03";
@@ -702,6 +703,9 @@ int main(int ac, char **av)
         case 'F':
             bigfilename = strdup(optarg);
             break;
+        case 'f':
+            tests = strdup(optarg);
+            break;
         case 'G':
             rwsize *= 100;
             break;
@@ -724,9 +728,6 @@ int main(int ac, char **av)
         case 's':
             Vol = strdup(optarg);
             break;
-        case 't':
-            tests = strdup(optarg);
-            break;
         case 'u':
             if (User)
                 free(User);
@@ -747,12 +748,28 @@ int main(int ac, char **av)
         }
     }
 
+    if (!Quiet) {
+        fprintf(stdout, "Connecting to host %s:%d\n", Server, Port);
+    }
+	if (User != NULL && User[0] == '\0') {
+        fprintf(stdout, "Error: Define a user with -u\n");
+	}
+	if (Password != NULL && Password[0] == '\0') {
+        fprintf(stdout, "Error: Define a password with -w\n");
+	}
+	if (Vol != NULL && Vol[0] == '\0') {
+        fprintf(stdout, "Error: Define a volume with -s\n");
+	}
+
     if (! Debug) {
         freopen("/dev/null", "w", stdout);
     }
 
+// FIXME: guest auth leads to broken DSI request
+#if 0
     if ((User[0] == 0) || (Password[0] == 0))
         uam = "No User Authent";
+#endif
 
     Iterations_save = Iterations;
     results = calloc(Iterations * NUMTESTS, sizeof(unsigned long));

--- a/test/testsuite/logintest.c
+++ b/test/testsuite/logintest.c
@@ -133,13 +133,12 @@ test_exit:
 /* =============================== */
 void usage( char * av0 )
 {
-    fprintf( stdout, "usage:\t%s [-1234567mVv] [-h host] [-p port] [-s vol] [-u user] [-w password]\n", av0 );
+    fprintf( stdout, "usage:\t%s [-1234567CmVv] [-h host] [-p port] [-s vol] [-u user] [-w password]\n", av0 );
     fprintf( stdout,"\t-m\tserver is a Mac\n");
     fprintf( stdout,"\t-h\tserver host name (default localhost)\n");
     fprintf( stdout,"\t-p\tserver port (default 548)\n");
     fprintf( stdout,"\t-u\tuser name (default uid)\n");
-
-    fprintf( stdout,"\t-w\tpassword (default none)\n");
+    fprintf( stdout,"\t-w\tpassword\n");
     fprintf( stdout,"\t-1\tAFP 2.1 version (default)\n");
     fprintf( stdout,"\t-2\tAFP 2.2 version\n");
     fprintf( stdout,"\t-3\tAFP 3.0 version\n");
@@ -223,6 +222,17 @@ unsigned int ret;
             usage( av[ 0 ] );
         }
     }
+
+    if (!Quiet) {
+        fprintf(stdout, "Connecting to host %s:%d\n", Server, Port);
+    }
+	if (User != NULL && User[0] == '\0') {
+        fprintf(stdout, "Error: Define a user with -u\n");
+	}
+	if (Password != NULL && Password[0] == '\0') {
+        fprintf(stdout, "Error: Define a password with -w\n");
+	}
+
 	/************************************
 	 *                                  *
 	 * Connection user 1                *
@@ -335,10 +345,10 @@ uint32_t i = 0;
 		ret = FPopenLoginExt(Conn, vers, uam, User, Password);
 	}
 	else {
+#endif
 		ret = FPopenLogin(Conn, vers, uam, User, Password);
+#if 0
 	}
-#else
-	ret = FPopenLogin(Conn, vers, uam, User, Password);
 #endif
 	if (ret) {
 		failed();

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -220,7 +220,7 @@ static void list_tests(void)
 {
 int i = 0;
 	while (Test_list[i].name != NULL) {
-		fprintf(stdout, "%s\n", Test_list[i].name);
+		fprintf(stdout, "%s_test\n", Test_list[i].name);
 		i++;
 	}
 }
@@ -321,7 +321,7 @@ char    *Vol = "";
 char    *Vol2 = "";
 char    *User;
 char    *User2;
-char    *Path;
+char    *Path = "";
 int     Version = 21;
 int     List = 0;
 int     Mac = 0;
@@ -333,20 +333,21 @@ enum adouble adouble = AD_EA;
 /* =============================== */
 void usage( char * av0 )
 {
-    fprintf( stdout, "usage:\t%s [-1234567aCiLlmnVvx] [-h host] [-H host2] [-p port] [-s vol] [-c vol path] [-S vol2] [-u user] [-d user2] [-w password] [-F testsuite] [-f test]\n", av0 );
+    fprintf( stdout, "usage:\t%s [-1234567aCiLlmnVvx] [-h host] [-H host2] [-p port] [-s vol] [-c vol path] [-S vol2] "
+	"[-u user] [-d user2] [-w password] [-F testsuite] [-f test]\n", av0 );
     fprintf( stdout,"\t-a\tvolume is appledouble = v2 instead of default appledouble = ea\n");
     fprintf( stdout,"\t-L\tserver without working fcntl locking, skip tests using it\n");
     fprintf( stdout,"\t-m\tserver is a Mac\n");
     fprintf( stdout,"\t-h\tserver host name (default localhost)\n");
     fprintf( stdout,"\t-p\tserver port (default 548)\n");
-    fprintf( stdout,"\t-s\tvolume to mount (default home)\n");
-    fprintf( stdout,"\t-S\tsecond volume to mount (default none)\n");
+    fprintf( stdout,"\t-s\tvolume to mount\n");
+    fprintf( stdout,"\t-S\tsecond volume to mount\n");
     fprintf( stdout,"\t-c\tvolume path on the server\n");
     fprintf( stdout,"\t-u\tuser name (default uid)\n");
+    fprintf( stdout,"\t-w\tpassword\n");
     fprintf( stdout,"\t-d\tsecond user for two connections (same password!)\n");
-    fprintf( stdout,"\t-H\tsecond server for two connections (default use only one server)\n");
+    fprintf( stdout,"\t-H\tsecond server for two connections\n");
 
-    fprintf( stdout,"\t-w\tpassword (default none)\n");
     fprintf( stdout,"\t-1\tAFP 2.1 version (default)\n");
     fprintf( stdout,"\t-2\tAFP 2.2 version\n");
     fprintf( stdout,"\t-3\tAFP 3.0 version\n");
@@ -358,9 +359,9 @@ void usage( char * av0 )
     fprintf( stdout,"\t-V\tvery verbose\n");
 
     fprintf( stdout,"\t-x\tdon't run tests with known bugs\n");
-    fprintf( stdout,"\t-F\ttestsuite to run (default tier1)\n");
-    fprintf( stdout,"\t-f\ttest to run\n");
-    fprintf( stdout,"\t-l\tlist tests\n");
+    fprintf( stdout,"\t-F\ttestsuite to run (tier1 (default), tier2, readonly, sleep)\n");
+    fprintf( stdout,"\t-f\ttest or testset to run\n");
+    fprintf( stdout,"\t-l\tlist testsets\n");
     fprintf( stdout,"\t-i\tinteractive mode, prompts before every test (debug purposes)\n");
     fprintf( stdout,"\t-C\tturn on terminal color output\n");
     exit (1);
@@ -437,9 +438,11 @@ int ret;
 		case 'm':
 			Mac = 1;
 			break;
+#if 0
         case 'n':
             Proto = 1;
             break;
+#endif
         case 'p' :
             Port = atoi( optarg );
             if (Port <= 0) {
@@ -474,6 +477,7 @@ int ret;
             usage( av[ 0 ] );
         }
     }
+
 	Loglevel = AFP_LOG_INFO;
 
 	if (strcmp(Suite, "tier1") == 0) {
@@ -493,6 +497,23 @@ int ret;
 		list_tests();
 		exit (2);
 	}
+
+    if (!Quiet) {
+        fprintf(stdout, "Connecting to host %s:%d\n", Server, Port);
+    }
+	if (User != NULL && User[0] == '\0') {
+        fprintf(stdout, "Error: Define a user with -u\n");
+	}
+	if (Password != NULL && Password[0] == '\0') {
+        fprintf(stdout, "Error: Define a password with -w\n");
+	}
+	if (Vol != NULL && Vol[0] == '\0') {
+        fprintf(stdout, "Error: Define a volume with -s\n");
+	}
+	if (Path != NULL && Path[0] == '\0' && strcmp(Suite, "tier2") == 0) {
+        fprintf(stdout, "Error: Define the local path to the volume with -c\n");
+	}
+
 	/************************************
 	 *                                  *
 	 * Connection user 1                *
@@ -524,10 +545,10 @@ int ret;
 		ret = FPopenLoginExt(Conn, vers, uam, User, Password);
 	}
 	else {
+#endif
 		ret = FPopenLogin(Conn, vers, uam, User, Password);
+#if 0
 	}
-#else
-	ret = FPopenLogin(Conn, vers, uam, User, Password);
 #endif
 	if (ret) {
 		printf("Login failed\n");
@@ -566,10 +587,10 @@ int ret;
 			ret = FPopenLoginExt(Conn2, vers, uam, User2, Password);
 		}
     	else {
+#endif
 			ret = FPopenLogin(Conn2, vers, uam, User2, Password);
+#if 0
 		}
-#else
-	ret = FPopenLogin(Conn2, vers, uam, User2, Password);
 #endif
 	if (ret) {
 		printf("Login failed\n");

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -1271,18 +1271,18 @@ void (*fn)(void) = NULL;
 /* =============================== */
 void usage( char * av0 )
 {
-    fprintf( stdout, "usage:\t%s [-1234567aeiLnVvy] [-h host] [-p port] [-s vol] [-S vol2] [-u user] [-w password] [-f test] [-c count] "
-    "[-d size] [-q quantum] [-F file] \n", av0 );
+    fprintf( stdout, "usage:\t%s [-1234567aeLnVvy] [-h host] [-p port] [-s vol] [-S vol2] [-u user] [-w password] [-n iterations] "
+    "[-d size] [-q quantum] [-f test] [-F file] \n", av0 );
     fprintf( stdout,"\t-h\tserver host name (default localhost)\n");
     fprintf( stdout,"\t-p\tserver port (default 548)\n");
-    fprintf( stdout,"\t-s\tvolume to mount (default home)\n");
-    fprintf( stdout,"\t-S\tsecond volume to mount (default none)\n");
+    fprintf( stdout,"\t-s\tvolume to mount\n");
+    fprintf( stdout,"\t-S\tsecond volume to mount\n");
     fprintf( stdout,"\t-u\tuser name (default uid)\n");
+    fprintf( stdout,"\t-w\tpassword\n");
 
     fprintf( stdout,"\t-L\tuse posix calls (default AFP calls)\n");
     fprintf( stdout,"\t-D\twith -L use O_DIRECT in open flags (default no)\n");
 
-    fprintf( stdout,"\t-w\tpassword (default none)\n");
     fprintf( stdout,"\t-1\tAFP 2.1 version (default)\n");
     fprintf( stdout,"\t-2\tAFP 2.2 version\n");
     fprintf( stdout,"\t-3\tAFP 3.0 version\n");
@@ -1291,7 +1291,7 @@ void usage( char * av0 )
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
     fprintf( stdout,"\t-7\tAFP 3.4 version\n");
 
-    fprintf( stdout,"\t-c\trun test count times\n");
+    fprintf( stdout,"\t-n\thow many iterations to run (default: 1)\n");
     fprintf( stdout,"\t-d\tfile size (Mbytes, default 64)\n");
     fprintf( stdout,"\t-q\tpacket size (Kbytes, default server quantum)\n");
     fprintf( stdout,"\t-r\tnumber of outstanding requests (default 1)\n");
@@ -1316,7 +1316,6 @@ int main( int ac, char **av )
 {
 int cc;
 
-	Quiet = 1;
     while (( cc = getopt( ac, av, "1234567aeDiLnVvyc:d:F:f:h:o:p:q:R:r:S:s:u:w:" )) != EOF ) {
         switch ( cc ) {
         case '1':
@@ -1350,9 +1349,6 @@ int cc;
 		case 'a':
 			Flush = 0;
 			break;
-		case 'c':
-			Count = atoi(optarg);
-			break;
 		case 'D':
 			Direct = 1;
 			break;
@@ -1377,9 +1373,14 @@ int cc;
 		case 'L':
 			Local = 1;
 			break;
+		case 'n':
+			Count = atoi(optarg);
+			break;
+#if 0
         case 'n':
             Proto = 1;
             break;
+#endif
         case 'p' :
             Port = atoi( optarg );
             if (Port <= 0) {
@@ -1423,6 +1424,19 @@ int cc;
         }
     }
 
+    if (!Quiet) {
+        fprintf(stdout, "Connecting to host %s:%d\n", Server, Port);
+    }
+	if (User != NULL && User[0] == '\0') {
+        fprintf(stdout,"Error: Define a user with -u\n");
+	}
+	if (Password != NULL && Password[0] == '\0') {
+        fprintf(stdout,"Error: Define a password with -w\n");
+	}
+	if (Vol != NULL && Vol[0] == '\0') {
+        fprintf(stdout,"Error: Define a volume with -s\n");
+	}
+
 	/**************************
 	 Connection */
 
@@ -1448,8 +1462,6 @@ int cc;
     	 	Dsi->protocol = DSI_TCPIP;
 	    	Dsi->socket = sock;
 	    }
-    	else {
-		}
 
 	    /* login */
 		// FIXME: workaround for FPopenLoginExt() being broken
@@ -1468,8 +1480,6 @@ int cc;
 
 	/*********************************
 	*/
-	if (Verbose)
-		Quiet = 0;
 	run_one(Test);
 	if (!Local)
    		FPLogOut(Conn);


### PR DESCRIPTION
Gives a more helpful stdout response when mandatory options are missing.