### PR TITLE
testsuite: Consolidate the spectest into a single test suite

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -92,8 +92,8 @@ jobs:
                 tags: ${{ steps.metadata.outputs.tags }}
 
 
-    afp-spectest-t1-afp34:
-        name: AFP spec test tier 1 - AFP 3.4
+    afp-spectest-afp34:
+        name: AFP spec test - AFP 3.4
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
@@ -108,14 +108,14 @@ jobs:
             INSECURE_AUTH: 1
             DISABLE_TIMEMACHINE: 1
             VERBOSE: 1
-            TESTSUITE: tier1
+            TESTSUITE: spectest
             AFP_VERSION: 7
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
-    afp-spectest-t2-afp34:
-        name: AFP spec test tier 2 - AFP 3.4
+    afp-spectest-afp33:
+        name: AFP spec test - AFP 3.3
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
@@ -130,14 +130,124 @@ jobs:
             INSECURE_AUTH: 1
             DISABLE_TIMEMACHINE: 1
             VERBOSE: 1
-            TESTSUITE: tier2
-            AFP_VERSION: 7
+            TESTSUITE: spectest
+            AFP_VERSION: 6
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+
+
+    afp-spectest-afp32:
+        name: AFP spec test - AFP 3.2
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_USER2: atalk2
+            AFP_PASS: afpafp
+            AFP_PASS2: afpafp
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            SHARE_NAME2: test2
+            INSECURE_AUTH: 1
+            DISABLE_TIMEMACHINE: 1
+            VERBOSE: 1
+            TESTSUITE: spectest
+            AFP_VERSION: 5
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+
+
+    afp-spectest-afp31:
+        name: AFP spec test - AFP 3.1
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_USER2: atalk2
+            AFP_PASS: afpafp
+            AFP_PASS2: afpafp
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            SHARE_NAME2: test2
+            INSECURE_AUTH: 1
+            DISABLE_TIMEMACHINE: 1
+            VERBOSE: 1
+            TESTSUITE: spectest
+            AFP_VERSION: 4
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+
+
+    afp-spectest-afp30:
+        name: AFP spec test - AFP 3.0
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_USER2: atalk2
+            AFP_PASS: afpafp
+            AFP_PASS2: afpafp
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            SHARE_NAME2: test2
+            INSECURE_AUTH: 1
+            DISABLE_TIMEMACHINE: 1
+            VERBOSE: 1
+            TESTSUITE: spectest
+            AFP_VERSION: 3
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+
+
+    afp-spectest-afp22:
+        name: AFP spec test - AFP 2.2
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_USER2: atalk2
+            AFP_PASS: afpafp
+            AFP_PASS2: afpafp
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            SHARE_NAME2: test2
+            INSECURE_AUTH: 1
+            DISABLE_TIMEMACHINE: 1
+            VERBOSE: 1
+            TESTSUITE: spectest
+            AFP_VERSION: 2
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+  
+
+    afp-spectest-afp21:
+        name: AFP spec test - AFP 2.1
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_USER2: atalk2
+            AFP_PASS: afpafp
+            AFP_PASS2: afpafp
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            SHARE_NAME2: test2
+            INSECURE_AUTH: 1
+            DISABLE_TIMEMACHINE: 1
+            VERBOSE: 1
+            TESTSUITE: spectest
+            AFP_VERSION: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
     afp-rotest-afp34:
-      name: AFP readonly test - AFP 3.4
+      name: AFP spec test (Readonly) - AFP 3.4
       needs: build-container-testsuite
       runs-on: ubuntu-latest
       timeout-minutes: 5
@@ -172,71 +282,8 @@ jobs:
           - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
-    afp-encodingtest-afp22:
-      name: AFP encoding test - AFP 2.2
-      needs: build-container-testsuite
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_PASS: afpafp
-          AFP_GROUP: afpusers
-          SHARE_NAME: test1
-          INSECURE_AUTH: 1
-          VERBOSE: 1
-          TESTSUITE: encoding
-          AFP_VERSION: 2
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
-
-
-
-    afp-spectest-afp21:
-      name: AFP spec test tier 1 - AFP 2.1
-      needs: build-container-testsuite
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_USER2: atalk2
-          AFP_PASS: afpafp
-          AFP_PASS2: afpafp
-          AFP_GROUP: afpusers
-          SHARE_NAME: test1
-          SHARE_NAME2: test2
-          INSECURE_AUTH: 1
-          DISABLE_TIMEMACHINE: 1
-          VERBOSE: 1
-          TESTSUITE: tier1
-          AFP_VERSION: 1
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
-  
-
-    afp-spectest-t2-afp21:
-        name: AFP spec test tier 2 - AFP 2.1
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        env:
-            AFP_USER: atalk1
-            AFP_USER2: atalk2
-            AFP_PASS: afpafp
-            AFP_PASS2: afpafp
-            AFP_GROUP: afpusers
-            SHARE_NAME: test1
-            SHARE_NAME2: test2
-            INSECURE_AUTH: 1
-            DISABLE_TIMEMACHINE: 1
-            VERBOSE: 1
-            TESTSUITE: tier2
-            AFP_VERSION: 1
-        steps:
-            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
-
-
     afp-rotest-afp21:
-      name: AFP readonly test - AFP 2.1
+      name: AFP spec test (Readonly) - AFP 2.1
       needs: build-container-testsuite
       runs-on: ubuntu-latest
       timeout-minutes: 5

--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -194,17 +194,22 @@ if [ -z "$TESTSUITE" ]; then
     # Prevent afpd from forking with '-d' parameter, to maintain container lifecycle
     netatalk -d
 else
+    if [ "$TESTSUITE" == "spectest" ]; then
+        cat <<EXT > /usr/local/etc/extmap.conf
+.         "????"  "????"      Unix Binary                    Unix                      application/octet-stream
+.doc      "WDBN"  "MSWD"      Word Document                  Microsoft Word            application/msword
+.pdf      "PDF "  "CARO"      Portable Document Format       Acrobat Reader            application/pdf
+EXT
+    fi
     netatalk
     sleep 2
-    if [ "$TESTSUITE" == "tier1" ]; then
-        afp_spectest "${TEST_FLAGS}" -"${AFP_VERSION}" -x -F "$TESTSUITE" -h 127.0.0.1 -p 548 -u "${AFP_USER}" -d "${AFP_USER2}" -w "${AFP_PASS}" -s "${SHARE_NAME}" -S "${SHARE2_NAME}"
-    elif [ "$TESTSUITE" == "tier2" ]; then
-        afp_spectest "${TEST_FLAGS}" -"${AFP_VERSION}" -x -F "$TESTSUITE" -h 127.0.0.1 -p 548 -u "${AFP_USER}" -d "${AFP_USER2}" -w "${AFP_PASS}" -s "${SHARE_NAME}" -S "${SHARE2_NAME}" -c /mnt/afpshare
+    if [ "$TESTSUITE" == "spectest" ]; then
+        afp_spectest "${TEST_FLAGS}" -"${AFP_VERSION}" -x -h 127.0.0.1 -p 548 -u "${AFP_USER}" -d "${AFP_USER2}" -w "${AFP_PASS}" -s "${SHARE_NAME}" -S "${SHARE2_NAME}" -c /mnt/afpshare
     elif [ "$TESTSUITE" == "readonly" ]; then
         echo "testfile uno" > /mnt/afpshare/first.txt
         echo "testfile dos" > /mnt/afpshare/second.txt
         mkdir /mnt/afpshare/third
-        afp_spectest "${TEST_FLAGS}" -"${AFP_VERSION}" -F "$TESTSUITE" -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}" -s "${SHARE_NAME}"
+        afp_spectest "${TEST_FLAGS}" -"${AFP_VERSION}" -f Readonly_test -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}" -s "${SHARE_NAME}"
     elif [ "$TESTSUITE" == "login" ]; then
         afp_logintest "${TEST_FLAGS}" -"${AFP_VERSION}" -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}"
     elif [ "$TESTSUITE" == "encoding" ]; then

--- a/doc/ja/manpages/man1/afptest.1.xml
+++ b/doc/ja/manpages/man1/afptest.1.xml
@@ -122,8 +122,6 @@
 
       <arg>-w <replaceable>パスワード</replaceable></arg>
 
-      <arg>-F <replaceable>テストスイート</replaceable></arg>
-
       <arg>-f <replaceable>テスト</replaceable></arg>
     </cmdsynopsis>
 
@@ -189,12 +187,10 @@
     セクションは、<option>-f</option> オプションで実行できます。使用可能なテストは、<option>-l</option>
     オプションで一覧表示できます。</para>
 
-    <para><command>afp_spectest</command> は、300 を超えるテスト ケースを含む AFP 仕様テスト
-    スイートの中核を構成します。テストケースは、実行の前提条件によって分割され、内部的に複数のテストスイートに編成されています。現在使用可能なスイートは、<emphasis
-    remap="I">tier1</emphasis>、<emphasis remap="I">tier2</emphasis>
-    (<option>-c</option> オプションを使用してローカルで実行する必要があります)、<emphasis
-    remap="I">readonly</emphasis> (ファイルが読み込まれた読み取り専用ボリュームが必要です)、および <emphasis
-    remap="I">sleep</emphasis> です。</para>
+    <para><command>afp_spectest</command> は、300 を超えるテスト ケースを含む AFP 仕様テスト スイートの中核を
+    構成します。これは、テストする AFP コマンド別、またはテストの前提条件別に分けられたテストセットに編成されています。
+    たとえば、Tier 2 (T2) テストは、共有ボリュームへのパスを示す <option>-c</option> オプションを使用してホスト上で
+    実行する必要があります。また、読み取り専用テストとスリープ テストも別々に実行する必要があります。</para>
 
     <para><command>afp_encodingtest</command> および
     <command>afp_logintest</command> は、独自のランナーを持つ特定の AFP

--- a/doc/manpages/man1/afptest.1.xml
+++ b/doc/manpages/man1/afptest.1.xml
@@ -122,8 +122,6 @@
 
       <arg>-w <replaceable>password</replaceable></arg>
 
-      <arg>-F <replaceable>testsuite</replaceable></arg>
-
       <arg>-f <replaceable>test</replaceable></arg>
     </cmdsynopsis>
 
@@ -192,13 +190,12 @@
     tests can be listed with the <option>-l</option> option.</para>
 
     <para><command>afp_spectest</command> makes up the core of the AFP
-    specification test suite, with just over 300 test cases. The test cases
-    are organized into multiple test suites internally, split by preconditions
-    for execution. The available suites are currently: <emphasis
-    remap="I">tier1</emphasis>, <emphasis remap="I">tier2</emphasis> (needs to
-    run locally with the <option>-c</option> option), <emphasis
-    remap="I">readonly</emphasis> (needs a read only volume populated with
-    files), and <emphasis remap="I">sleep</emphasis>.</para>
+    specification test suite, with just over 300 test cases. It is organized
+    into testsets, divided by AFP commands tested, or by preconditions for
+    testing. For instance, the tier 2 (T2) tests need to be run on the host
+    with the <option>-c</option> option indicating the path to the shared
+    volume. There are also read-only and sleep tests that need to be run
+    separately.</para>
 
     <para><command>afp_encodingtest</command> and
     <command>afp_logintest</command> are specific AFP specification test

--- a/test/testsuite/Error.c
+++ b/test/testsuite/Error.c
@@ -1528,9 +1528,7 @@ test_exit:
 /* ----------- */
 void Error_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test35();
 	test36();
 	test37();

--- a/test/testsuite/Error.c
+++ b/test/testsuite/Error.c
@@ -334,6 +334,7 @@ DSI *dsi;
 }
 
 /* ------------------------- */
+// FIXME: afpd crash in dircache_search_by_did()
 STATIC void test95()
 {
 int dir;
@@ -346,11 +347,7 @@ int ret;
 uint16_t vol = VolID;
 
 	ENTER_TEST
-	// FIXME: afpd crash in dircache_search_by_did()
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
+
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -918,6 +915,7 @@ int  dt;
 }
 
 /* -------------------------- */
+// FIXME: afpd crash in dircache_search_by_did()
 STATIC void test170()
 {
 uint16_t bitmap = 0;
@@ -935,11 +933,6 @@ int  dt;
 	dsi = &Conn->dsi;
 
 	ENTER_TEST
-	// FIXME: afpd crash in dircache_search_by_did()
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 
     /* ---- fork.c ---- */
 	fork = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap ,DIRDID_ROOT_PARENT, "",OPENACC_WR | OPENACC_RD);
@@ -1077,6 +1070,7 @@ test_exit:
 }
 
 /* -------------------------- */
+// FIXME: afpd crash in dircache_search_by_did()
 STATIC void test171()
 {
 uint16_t bitmap = 0;
@@ -1096,11 +1090,6 @@ int  dt;
 	dsi = &Conn->dsi;
 
 	ENTER_TEST
-	// FIXME: afpd crash in dircache_search_by_did()
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 
     /* ---- fork.c ---- */
 	fork = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap , tdir, tname,OPENACC_WR | OPENACC_RD);
@@ -1219,6 +1208,7 @@ test_exit:
 }
 
 /* -------------------------- */
+// FIXME: afpd crash in dircache_search_by_did()
 STATIC void test173()
 {
 uint16_t bitmap = 0;
@@ -1238,11 +1228,6 @@ int  dt;
 	dsi = &Conn->dsi;
 
 	ENTER_TEST
-	// FIXME: afpd crash in dircache_search_by_did()
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 
     /* ---- fork.c ---- */
 	fork = FPOpenFork(Conn, vol, OPENFORK_DATA , bitmap , tdir, tname,OPENACC_WR | OPENACC_RD);
@@ -1544,19 +1529,25 @@ test_exit:
 void Error_test()
 {
     fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s: Various errors\n", __func__);
+    fprintf(stdout,"%s\n", __func__);
     fprintf(stdout,"-------------------\n");
 	test35();
 	test36();
 	test37();
+#if 0
+	test95();
+#endif
 	test99();
 	test100();
 	test101();
 	test102();
 	test103();
 	test105();
+// FIXME: Because of an afpd crash, test data cleanup fails
+#if 0
 	test170();
 	test171();
 	test173();
+#endif
 	test174();
 }

--- a/test/testsuite/FPAddAPPL.c
+++ b/test/testsuite/FPAddAPPL.c
@@ -149,9 +149,7 @@ fin:
 /* ----------- */
 void FPAddAPPL_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test214();
 	test301();
 }

--- a/test/testsuite/FPAddComment.c
+++ b/test/testsuite/FPAddComment.c
@@ -106,8 +106,6 @@ test_exit:
 /* ----------- */
 void FPAddComment_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test55();
 }

--- a/test/testsuite/FPAddIcon.c
+++ b/test/testsuite/FPAddIcon.c
@@ -123,8 +123,6 @@ test_exit:
 /* ----------- */
 void FPAddIcon_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test212();
 }

--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -848,7 +848,10 @@ int dir, dir2;
 fin:
 	if (fork) {
 		FAIL (FPCloseFork(Conn, fork))
-	        FAIL (FPDelete(Conn, vol, dir, ""))
+		FAIL (FPDelete(Conn, vol, dir, ""))
+		dir = get_did(Conn, vol, DIRDID_ROOT , "Network Trash Folder");
+		FAIL (FPDelete(Conn, vol, dir, "Trash Can Usage Map"))
+		FAIL (FPDelete(Conn, vol, DIRDID_ROOT, "Network Trash Folder"))
 	}
 test_exit:
 	exit_test("FPByteRangeLock:test330: pre OSX trash folder");

--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -959,9 +959,7 @@ test_exit:
 /* ----------- */
 void FPByteRangeLock_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test60();
 #if 0
 	test63();

--- a/test/testsuite/FPByteRangeLockExt.c
+++ b/test/testsuite/FPByteRangeLockExt.c
@@ -132,9 +132,7 @@ test_exit:
 /* ----------- */
 void FPByteRangeLockExt_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 #if 0
     test66();
     test67();

--- a/test/testsuite/FPCatSearch.c
+++ b/test/testsuite/FPCatSearch.c
@@ -105,8 +105,6 @@ test_exit:
 /* ----------- */
 void FPCatSearch_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test225();
 }

--- a/test/testsuite/FPCatSearchExt.c
+++ b/test/testsuite/FPCatSearchExt.c
@@ -141,8 +141,6 @@ test_exit:
 /* ----------- */
 void FPCatSearchExt_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test227();
 }

--- a/test/testsuite/FPCloseDT.c
+++ b/test/testsuite/FPCloseDT.c
@@ -27,8 +27,6 @@ test_exit:
 /* ----------- */
 void FPCloseDT_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test201();
 }

--- a/test/testsuite/FPCloseDir.c
+++ b/test/testsuite/FPCloseDir.c
@@ -47,8 +47,6 @@ test_exit:
 /* ----------- */
 void FPCloseDir_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test199();
 }

--- a/test/testsuite/FPCloseFork.c
+++ b/test/testsuite/FPCloseFork.c
@@ -54,9 +54,7 @@ DSI *dsi;
 /* ----------- */
 void FPCloseFork_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test186();
 	test187();
 }

--- a/test/testsuite/FPCloseVol.c
+++ b/test/testsuite/FPCloseVol.c
@@ -29,8 +29,6 @@ int ret;
 /* ----------- */
 void FPCloseVol_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test204();
 }

--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -1141,9 +1141,7 @@ test_exit:
 /* ----------- */
 void FPCopyFile_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test71();
 	test158();
 	test315();

--- a/test/testsuite/FPCreateDir.c
+++ b/test/testsuite/FPCreateDir.c
@@ -360,9 +360,7 @@ test_exit:
 /* ----------- */
 void FPCreateDir_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test6();
 	test26();
 	test45();

--- a/test/testsuite/FPCreateFile.c
+++ b/test/testsuite/FPCreateFile.c
@@ -150,8 +150,6 @@ test_exit:
 /* ----------- */
 void FPCreateFile_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test51();
 }

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -600,9 +600,7 @@ test_exit:
 /* ----------- */
 void FPDelete_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test13();
 	test27();
 	test74();

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -611,9 +611,7 @@ test_exit:
 /* ----------- */
 void FPDisconnectOldSession_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 #if 0
     test222();
 #endif

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -279,6 +279,7 @@ test_exit:
 }
 
 /* ------------------------- */
+// Failing with 4.0.x as well as 3.1.12. May have to do with broken FPopenLoginExt().
 STATIC void test339()
 {
 char *name = "t339 file";
@@ -307,11 +308,6 @@ struct afp_filedir_parms filedir;
 
 	ENTER_TEST
 
-    // Failing with 4.0.x as well as 3.1.12. May have to do with broken FPopenLoginExt().
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 	if (Conn->afp_version < 30) {
     	test_skipped(T_AFP3);
 		goto test_exit;
@@ -622,6 +618,8 @@ void FPDisconnectOldSession_test()
     test222();
 #endif
     test338();
+#if 0
     test339();
+#endif
     test370();
 }

--- a/test/testsuite/FPEnumerate.c
+++ b/test/testsuite/FPEnumerate.c
@@ -591,9 +591,7 @@ test_exit:
 /* ----------- */
 void FPEnumerate_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 
     test28();
 #if 0

--- a/test/testsuite/FPEnumerate.c
+++ b/test/testsuite/FPEnumerate.c
@@ -482,7 +482,7 @@ test_exit:
 }
 
 /* ------------------------- */
-static void test300(void)
+STATIC void test300(void)
 {
 uint8_t buffer[DSI_DATASIZ];
 uint16_t vol = VolID;

--- a/test/testsuite/FPEnumerateExt.c
+++ b/test/testsuite/FPEnumerateExt.c
@@ -70,8 +70,6 @@ test_exit:
 /* ----------- */
 void FPEnumerateExt_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test23();
 }

--- a/test/testsuite/FPEnumerateExt2.c
+++ b/test/testsuite/FPEnumerateExt2.c
@@ -120,9 +120,7 @@ test_exit:
 /* ----------- */
 void FPEnumerateExt2_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test25();
     test211();
 }

--- a/test/testsuite/FPExchangeFiles.c
+++ b/test/testsuite/FPExchangeFiles.c
@@ -562,9 +562,7 @@ test_exit:
 /* ----------- */
 void FPExchangeFiles_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test108();
 	test111();
 	test197();

--- a/test/testsuite/FPFlush.c
+++ b/test/testsuite/FPFlush.c
@@ -18,8 +18,6 @@ uint16_t vol = VolID;
 /* ----------- */
 void FPFlush_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test202();
 }

--- a/test/testsuite/FPFlushFork.c
+++ b/test/testsuite/FPFlushFork.c
@@ -78,8 +78,6 @@ test_exit:
 /* ----------- */
 void FPFlushFork_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test203();
 }

--- a/test/testsuite/FPGetACL.c
+++ b/test/testsuite/FPGetACL.c
@@ -164,9 +164,7 @@ test_exit:
 /* ----------- */
 void FPGetACL_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 
     test398();
 #if 0

--- a/test/testsuite/FPGetAPPL.c
+++ b/test/testsuite/FPGetAPPL.c
@@ -43,8 +43,6 @@ test_exit:
 /* ----------- */
 void FPGetAPPL_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test169();
 }

--- a/test/testsuite/FPGetComment.c
+++ b/test/testsuite/FPGetComment.c
@@ -106,9 +106,7 @@ test_exit:
 /* ----------- */
 void FPGetComment_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test53();
 	test394();
 }

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -718,6 +718,7 @@ int id;
 
 	if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, bitmap, 0)) {
 		test_nottested();
+		goto test_exit;
 	}
 #if 0
 	else {
@@ -739,8 +740,8 @@ int id;
 	    || ( Conn->afp_version < 30 && ret)) {
 		test_failed();
 	}
-	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:
+	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 	exit_test("FPGetFileDirParms:test326: long file name >31 bytes");
 }
 
@@ -970,10 +971,6 @@ uint16_t bitmap;
 
 	ENTER_TEST
 
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		test_nottested();
 		goto fin;
@@ -984,6 +981,7 @@ uint16_t bitmap;
 
 	if (FPGetFileDirParams(Conn, vol,  DIRDID_ROOT , name, bitmap,0)) {
 		test_failed();
+		goto fin;
 	}
 	else {
 		filedir.isdir = 0;
@@ -993,11 +991,13 @@ uint16_t bitmap;
 				fprintf(stdout,"FAILED not default type\n");
 			}
 			test_failed();
+			goto fin;
 		}
 	}
 	FAIL (FPRename(Conn, vol, DIRDID_ROOT, name, name1))
 	if (FPGetFileDirParams(Conn, vol,  DIRDID_ROOT , name1, bitmap,0)) {
 		test_failed();
+		goto fin;
 	}
 	else {
 		filedir.isdir = 0;
@@ -1012,7 +1012,6 @@ uint16_t bitmap;
 fin:
 	FPDelete(Conn, vol,  DIRDID_ROOT , name);
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name1))
-test_exit:
 	exit_test("FPGetFileDirParms:test371: check default type");
 }
 
@@ -1034,10 +1033,6 @@ uint16_t bitmap1 =  (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)| (1<<FILPBIT_CDATE) |
 
 	ENTER_TEST
 
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		test_nottested();
 		goto fin;
@@ -1048,6 +1043,7 @@ uint16_t bitmap1 =  (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)| (1<<FILPBIT_CDATE) |
 
 	if (FPGetFileDirParams(Conn, vol,  DIRDID_ROOT , name, bitmap,0)) {
 		test_failed();
+		goto fin;
 	}
 	else {
 		filedir.isdir = 0;
@@ -1057,11 +1053,13 @@ uint16_t bitmap1 =  (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)| (1<<FILPBIT_CDATE) |
 				fprintf(stdout,"FAILED not default type\n");
 			}
 			test_failed();
+			goto fin;
 		}
 	}
  	FAIL (FPSetFileParams(Conn, vol, DIRDID_ROOT , name, bitmap1, &filedir))
 	if (FPGetFileDirParams(Conn, vol,  DIRDID_ROOT , name, bitmap,0)) {
 		test_failed();
+		goto fin;
 	}
 	else {
 		filedir.isdir = 0;
@@ -1075,7 +1073,6 @@ uint16_t bitmap1 =  (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)| (1<<FILPBIT_CDATE) |
 	}
 fin:
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
-test_exit:
 	exit_test("FPGetFileDirParms:test380: check type mapping");
 }
 
@@ -1094,7 +1091,6 @@ unsigned int dir;
 	dsi = &Conn->dsi;
 
 	ENTER_TEST
-
 
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		test_failed();
@@ -1127,9 +1123,7 @@ test_exit:
 /* ----------- */
 void FPGetFileDirParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test44();
 	test58();
 	test70();

--- a/test/testsuite/FPGetForkParms.c
+++ b/test/testsuite/FPGetForkParms.c
@@ -283,9 +283,7 @@ test_exit:
 /* ----------- */
 void FPGetForkParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test21();
     test50();
 	test188();

--- a/test/testsuite/FPGetIcon.c
+++ b/test/testsuite/FPGetIcon.c
@@ -44,8 +44,6 @@ char   u_null[] = { 0, 0, 0, 0 };
 /* ----------- */
 void FPGetIcon_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test115();
 }

--- a/test/testsuite/FPGetIconInfo.c
+++ b/test/testsuite/FPGetIconInfo.c
@@ -50,8 +50,6 @@ test_exit:
 /* ----------- */
 void FPGetIconInfo_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test213();
 }

--- a/test/testsuite/FPGetIconInfo.c
+++ b/test/testsuite/FPGetIconInfo.c
@@ -14,17 +14,12 @@ u_char   u_null[] = { 0, 0, 0, 0 };
 
 	ENTER_TEST
 
-	// FIXME: icon tests are broken in Netatalk 4.0
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
-
 	dt = FPOpenDT(Conn,vol);
 
 	ret = FPGetIconInfo(Conn,  dt, (unsigned char *) "ttxt", 1);
 	if (ret == htonl(AFPERR_NOITEM)) {
 		FAIL (FPAddIcon(Conn,  dt, "ttxt", "3DMF", 1, 0, 256, icon0_256 ))
+		goto test_exit;
 	}
 
 	FAIL (FPGetIconInfo(Conn,  dt, (unsigned char *) "ttxt", 1))
@@ -36,18 +31,19 @@ u_char   u_null[] = { 0, 0, 0, 0 };
 		if (ret == htonl(AFPERR_NOITEM)) {
 			FAIL (FPGetIconInfo(Conn,  dt, u_null, 1 ))
 			FAIL (htonl(AFPERR_NOITEM) != FPGetIconInfo(Conn,  dt, u_null, 2 ))
+			goto test_exit;
 		}
 		else if (ret) {
 			test_failed();
+			goto test_exit;
 		}
 		else {
 			FAIL (htonl(AFPERR_NOITEM) != FPGetIconInfo(Conn,  dt, (unsigned char *) "UNIX", 2 ))
 		}
 	}
 
-	FPCloseDT(Conn,dt);
-
 test_exit:
+	FPCloseDT(Conn,dt);
 	exit_test("FPGetIconInfo:test213: get Icon Info call");
 }
 

--- a/test/testsuite/FPGetSessionToken.c
+++ b/test/testsuite/FPGetSessionToken.c
@@ -97,9 +97,7 @@ test_exit:
 /* ----------- */
 void FPGetSessionToken_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test220();
     test221();
 }

--- a/test/testsuite/FPGetSrvrInfo.c
+++ b/test/testsuite/FPGetSrvrInfo.c
@@ -19,8 +19,6 @@ int ret;
 /* ----------- */
 void FPGetSrvrInfo_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test1();
 }

--- a/test/testsuite/FPGetSrvrMsg.c
+++ b/test/testsuite/FPGetSrvrMsg.c
@@ -15,8 +15,6 @@ STATIC void test210(void)
 /* ----------- */
 void FPGetSrvrMsg_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test210();
 }

--- a/test/testsuite/FPGetSrvrParms.c
+++ b/test/testsuite/FPGetSrvrParms.c
@@ -58,9 +58,7 @@ unsigned char *b;
 /* ----------- */
 void FPGetSrvrParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test209();
 	test316();
 }

--- a/test/testsuite/FPGetUserInfo.c
+++ b/test/testsuite/FPGetUserInfo.c
@@ -82,8 +82,6 @@ test_exit:
 /* ----------- */
 void FPGetUserInfo_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test75();
 }

--- a/test/testsuite/FPGetVolParms.c
+++ b/test/testsuite/FPGetVolParms.c
@@ -33,8 +33,6 @@ uint16_t vol = VolID;
 /* ----------- */
 void FPGetVolParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test56();
 }

--- a/test/testsuite/FPMapID.c
+++ b/test/testsuite/FPMapID.c
@@ -72,8 +72,6 @@ test_exit:
 /* ----------- */
 void FPMapID_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test208();
 }

--- a/test/testsuite/FPMapName.c
+++ b/test/testsuite/FPMapName.c
@@ -138,9 +138,7 @@ test_exit:
 /* ----------- */
 void FPMapName_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 #if 0
 	test180();
 #endif

--- a/test/testsuite/FPMapName.c
+++ b/test/testsuite/FPMapName.c
@@ -18,11 +18,6 @@ char *usr = NULL;
 
 	ENTER_TEST
 
-	// FIXME: encoding tests are broken in Netatalk 4.0
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		test_nottested();
 		goto test_exit;
@@ -146,5 +141,7 @@ void FPMapName_test()
     fprintf(stdout,"===================\n");
     fprintf(stdout,"%s\n", __func__);
     fprintf(stdout,"-------------------\n");
+#if 0
 	test180();
+#endif
 }

--- a/test/testsuite/FPMoveAndRename.c
+++ b/test/testsuite/FPMoveAndRename.c
@@ -336,9 +336,7 @@ test_exit:
 /* ----------- */
 void FPMoveAndRename_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test43();
     test73();
     test77();

--- a/test/testsuite/FPOpenDT.c
+++ b/test/testsuite/FPOpenDT.c
@@ -28,8 +28,6 @@ DSI *dsi;
 /* ----------- */
 void FPOpenDT_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test200();
 }

--- a/test/testsuite/FPOpenDir.c
+++ b/test/testsuite/FPOpenDir.c
@@ -85,8 +85,6 @@ test_exit:
 /* ----------- */
 void FPOpenDir_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test57();
 }

--- a/test/testsuite/FPOpenFork.c
+++ b/test/testsuite/FPOpenFork.c
@@ -987,9 +987,7 @@ test_exit:
 /* ----------- */
 void FPOpenFork_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 
     test14();
     test15();

--- a/test/testsuite/FPOpenVol.c
+++ b/test/testsuite/FPOpenVol.c
@@ -104,9 +104,7 @@ fin:
 /* ----------- */
 void FPOpenVol_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 
     test205();
     test404();

--- a/test/testsuite/FPRead.c
+++ b/test/testsuite/FPRead.c
@@ -930,9 +930,7 @@ test_exit:
 /* ----------- */
 void FPRead_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test5();
 	test8();
 	test46();

--- a/test/testsuite/FPRead.c
+++ b/test/testsuite/FPRead.c
@@ -232,7 +232,7 @@ fin:
 
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:
-	exit_test("FPread:test46: read/write resource fork");
+	exit_test("FPRead:test46: read/write resource fork");
 }
 
 /* -------------------------- */

--- a/test/testsuite/FPReadExt.c
+++ b/test/testsuite/FPReadExt.c
@@ -174,8 +174,6 @@ test_exit:
 /* ----------- */
 void FPReadExt_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test22();
 }

--- a/test/testsuite/FPRemoveAPPL.c
+++ b/test/testsuite/FPRemoveAPPL.c
@@ -49,8 +49,6 @@ test_exit:
 /* ----------- */
 void FPRemoveAPPL_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test215();
 }

--- a/test/testsuite/FPRemoveComment.c
+++ b/test/testsuite/FPRemoveComment.c
@@ -127,9 +127,7 @@ fin:
 /* ----------- */
 void FPRemoveComment_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test54();
 	test379();
 }

--- a/test/testsuite/FPRename.c
+++ b/test/testsuite/FPRename.c
@@ -405,9 +405,7 @@ test_exit:
 /* ----------- */
 void FPRename_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test69();
 	test72();
 	test183();

--- a/test/testsuite/FPResolveID.c
+++ b/test/testsuite/FPResolveID.c
@@ -272,9 +272,7 @@ test_exit:
 /* ----------- */
 void FPResolveID_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test76();
 	test91();
 	test310();

--- a/test/testsuite/FPSetDirParms.c
+++ b/test/testsuite/FPSetDirParms.c
@@ -905,9 +905,7 @@ test_exit:
 /* ----------- */
 void FPSetDirParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test82();
     test84();
     test88();

--- a/test/testsuite/FPSetFileDirParms.c
+++ b/test/testsuite/FPSetFileDirParms.c
@@ -1203,9 +1203,7 @@ test_exit:
 /* ----------- */
 void FPSetFileDirParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test98();
     test230();
     test231();

--- a/test/testsuite/FPSetFileParms.c
+++ b/test/testsuite/FPSetFileParms.c
@@ -486,9 +486,7 @@ test_exit:
 /* ----------- */
 void FPSetFileParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test83();
     test96();
     test118();

--- a/test/testsuite/FPSetForkParms.c
+++ b/test/testsuite/FPSetForkParms.c
@@ -233,9 +233,7 @@ test_exit:
 /* ----------- */
 void FPSetForkParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test62();
     test141();
     test217();

--- a/test/testsuite/FPSetVolParms.c
+++ b/test/testsuite/FPSetVolParms.c
@@ -53,8 +53,6 @@ test_exit:
 /* ----------- */
 void FPSetVolParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test206();
 }

--- a/test/testsuite/FPSync.c
+++ b/test/testsuite/FPSync.c
@@ -43,9 +43,7 @@ test_exit:
 /* ----------- */
 void FPSync_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 #if 0
 	test2();
 #endif

--- a/test/testsuite/FPWrite.c
+++ b/test/testsuite/FPWrite.c
@@ -181,9 +181,7 @@ test_exit:
 /* ----------- */
 void FPWrite_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test216();
 	test226();
 	test303();

--- a/test/testsuite/FPWriteExt.c
+++ b/test/testsuite/FPWriteExt.c
@@ -310,9 +310,7 @@ test_exit:
 /* ----------- */
 void FPWriteExt_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test148();
 	test207();
 	test304();

--- a/test/testsuite/FPzzz.c
+++ b/test/testsuite/FPzzz.c
@@ -27,6 +27,15 @@ int sock;
 uint32_t time= 12345;
 
 	ENTER_TEST
+
+	if (!Test) {
+		if (!Quiet) {
+			fprintf(stdout, "Run sleep tests with: -f FPzzz_test.\n");
+		}
+		test_skipped(T_SINGLE);
+		goto test_exit;
+	}
+
 	if (Conn->afp_version < 30 || Conn2) {
 		test_skipped(T_AFP3_CONN2);
 		goto test_exit;
@@ -108,6 +117,14 @@ uint32_t time= 12345;
 
 	ENTER_TEST
 
+	if (!Test) {
+		if (!Quiet) {
+			fprintf(stdout, "Run sleep tests with: -f FPzzz_test.\n");
+		}
+		test_skipped(T_SINGLE);
+		goto test_exit;
+	}
+
 	if (Conn->afp_version < 30 || Conn2) {
 		test_skipped(T_AFP3_CONN2);
 		goto test_exit;
@@ -187,6 +204,14 @@ DSI *dsi;
 int sock;
 
 	ENTER_TEST
+
+	if (!Test) {
+		if (!Quiet) {
+			fprintf(stdout, "Run sleep tests with: -f FPzzz_test.\n");
+		}
+		test_skipped(T_SINGLE);
+		goto test_exit;
+	}
 
 	if (Conn->afp_version < 30 || Conn2) {
 		test_skipped(T_AFP3_CONN2);

--- a/test/testsuite/FPzzz.c
+++ b/test/testsuite/FPzzz.c
@@ -246,9 +246,7 @@ test_exit:
 /* ----------- */
 void FPzzz_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test223();
     test224();
     test239();

--- a/test/testsuite/README
+++ b/test/testsuite/README
@@ -17,24 +17,7 @@ Spec conformance tests
 
 ./afp_spectest:
 AFP spec test. Assume exported volumes are only modified with netatalk.
-Contains multiple test suites, activated with the -F option.
-
-List of available spec test suites:
-
-- tier1
-Baseline AFP specification tests.
-This is the default without the -F option.
-
-- tier2
-AFP spec tests when .AppleDouble is missing or bogus.
-Requires local access to volume (-c option).
-
-- readonly
-AFP spec tests on a read only volume.
-Requires read only volume with at least 2 files and 1 folder (empty).
-
-- sleep
-AFP spec tests for sleeping (FPZzz).
+Tier 2 testsets can only be run locally, activated with the -c option.
 
 ./afp_logintest:
 AFP spec tests for DSI and login. Not included in spectest.
@@ -88,12 +71,12 @@ afp.conf:
 [Global]
 uam list = uams_clrtxt.so uams_guest.so
 
-[test1]
+[volume1]
 appledouble = ea
 path = /tmp/afptest1
 valid users = @afpusers
 
-[test2]
+[volume2]
 appledouble = ea
 path = /tmp/afptest2
 valid users = @afpusers
@@ -117,20 +100,20 @@ Return Codes
 2 NOT TESTED - a test setup step or precondition check failed
 3 SKIPPED - test environment requirements not satisfied
 
-Note that 3 is treated as an overall return code 0 for the purpose of test reporting.
+Note that SKIPPED is treated as an overall return code 0 for the purpose of test reporting.
 
-spectest tier 1, readonly, and logintest shall return the same results whether they are run
+Spectest and logintest shall return the same results whether they are run
 on a Mac server or afpd.
 
 Example:
 --------
-Run all tier 1 spec tests on server 192.168.2.123
-afp_spectest -F tier1 -h 192.168.2.123 -u user1 -d user2 -s test -w toto
+Run tier 1 spec tests on server 192.168.2.123
+afp_spectest -h 192.168.2.123 -u user1 -d user2 -s volume1 -S volume2 -w toto
 Same but on a Mac
-afp_spectest -F tier1 -m -h 192.168.2.64 -u user1 -d usr2 -s test -w toto
+afp_spectest -m -h 192.168.2.64 -u user1 -d user2 -s volume1 -w toto
 
-Run tier 2 FPByteRangeLock tests with AFP 3.0, two different servers are exporting the same volume.
-afp_spectest -f T2FPByteRangeLock_test -3 -h 192.168.2.123 -H 192.168.2.124 -u user1 -d user2 -s test -c /tmp/afptest1 -w toto
+Run tier 2 T2FPMoveAndRename tests with AFP 3.0, running locally on the host.
+afp_spectest -f T2FPMoveAndRename_test -3 -h 127.0.0.1 -u user1 -d user2 -w toto -s volume1 -S volume2 -c /tmp/afptest1
 
 At least on linux, it's possible to compile them with LDFLAGS=-rdynamic
 and the program can run individual test:

--- a/test/testsuite/T2_Dircache_attack.c
+++ b/test/testsuite/T2_Dircache_attack.c
@@ -605,9 +605,7 @@ test_exit:
 
 void Dircache_attack_test()
 {
-    fprintf(stdout, "===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout, "-------------------\n");
+    ENTER_TESTSET
     test500();
     test501();
     test502();

--- a/test/testsuite/T2_FPByteRangeLock.c
+++ b/test/testsuite/T2_FPByteRangeLock.c
@@ -112,7 +112,6 @@ uint16_t vol2;
 		test_skipped(T_PATH);
 		goto test_exit;
 	}
-
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;

--- a/test/testsuite/T2_FPByteRangeLock.c
+++ b/test/testsuite/T2_FPByteRangeLock.c
@@ -134,8 +134,6 @@ test_exit:
 /* ----------- */
 void T2FPByteRangeLock_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test117();
 }

--- a/test/testsuite/T2_FPCopyFile.c
+++ b/test/testsuite/T2_FPCopyFile.c
@@ -92,8 +92,6 @@ test_exit:
 /* ----------- */
 void T2FPCopyFile_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test373();
 }

--- a/test/testsuite/T2_FPCreateFile.c
+++ b/test/testsuite/T2_FPCreateFile.c
@@ -81,8 +81,6 @@ test_exit:
 /* ----------- */
 void T2FPCreateFile_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test325();
 }

--- a/test/testsuite/T2_FPDelete.c
+++ b/test/testsuite/T2_FPDelete.c
@@ -294,9 +294,7 @@ test_exit:
 /* ----------- */
 void T2FPDelete_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test146();
     test507();
 #if 0

--- a/test/testsuite/T2_FPDelete.c
+++ b/test/testsuite/T2_FPDelete.c
@@ -24,11 +24,6 @@ int ret;
 
 	ENTER_TEST
 
-	// FIXME: broken in Netatalk 4.0
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;
@@ -143,11 +138,6 @@ DSI *dsi = &Conn->dsi;
 
 	ENTER_TEST
 
-	// FIXME: broken in Netatalk 4.0
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 	if (!Mac && Path[0] == '\0') {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;
@@ -266,11 +256,6 @@ DSI *dsi = &Conn->dsi;
 
 	ENTER_TEST
 
-	// FIXME: broken in Netatalk 4.0
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 	if (!Mac && Path[0] == '\0') {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;

--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -1055,9 +1055,7 @@ test_exit:
 /* ----------- */
 void T2FPGetFileDirParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test32();
 	test33();
 	test42();

--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -303,17 +303,11 @@ test_exit:
 }
 
 /* -------------------------- */
-// FIXME - passes in 3.1.12 but not 4.0.3
 STATIC void test52()
 {
 uint16_t vol = VolID;
 
 	ENTER_TEST
-
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 
 	if (!Mac && Path[0] == '\0') {
 		test_skipped(T_MAC_PATH);

--- a/test/testsuite/T2_FPGetSrvrParms.c
+++ b/test/testsuite/T2_FPGetSrvrParms.c
@@ -74,8 +74,6 @@ test_exit:
 /* ----------- */
 void T2FPGetSrvrParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test320();
 }

--- a/test/testsuite/T2_FPMoveAndRename.c
+++ b/test/testsuite/T2_FPMoveAndRename.c
@@ -358,9 +358,7 @@ test_exit:
 /* ----------- */
 void T2FPMoveAndRename_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test136();
     test137();
     test139();

--- a/test/testsuite/T2_FPOpenFork.c.in
+++ b/test/testsuite/T2_FPOpenFork.c.in
@@ -265,7 +265,6 @@ int dir;
 	FAIL (FPCloseFork(Conn,fork))
 	fork = 0;
 #if 0
-    fprintf(stdout,"===================\n");
     fprintf(stdout,"test47: in a read/write folder\n");
 
 
@@ -1452,9 +1451,7 @@ test_exit:
 /* ----------- */
 void T2FPOpenFork_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test3();
     test4();
     test7();

--- a/test/testsuite/T2_FPRead.c
+++ b/test/testsuite/T2_FPRead.c
@@ -121,8 +121,6 @@ test_exit:
 /* ----------- */
 void T2FPRead_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test109();
 }

--- a/test/testsuite/T2_FPResolveID.c
+++ b/test/testsuite/T2_FPResolveID.c
@@ -842,9 +842,7 @@ test_exit:
 /* ----------- */
 void T2FPResolveID_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test129();
 	test130();
 	test131();

--- a/test/testsuite/T2_FPSetDirParms.c
+++ b/test/testsuite/T2_FPSetDirParms.c
@@ -50,8 +50,6 @@ test_exit:
 /* ----------- */
 void T2FPSetDirParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test121();
 }

--- a/test/testsuite/T2_FPSetFileParms.c
+++ b/test/testsuite/T2_FPSetFileParms.c
@@ -218,9 +218,7 @@ test_exit:
 /* ----------- */
 void T2FPSetFileParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test89();
     test120();
     test426();

--- a/test/testsuite/T2_FPSetFileParms.c
+++ b/test/testsuite/T2_FPSetFileParms.c
@@ -159,10 +159,10 @@ STATIC void test426()
 
 	ENTER_TEST
 
-	// FIXME: unexpected failure with Netatalk 4.0
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
+	// FIXME: This test hangs with AFP2.x (3.1.12 - 4.0.3)
+	if (Conn->afp_version < 30) {
+		test_skipped(T_AFP3);
+        return;
 	}
 	if (Path[0] == '\0') {
 		test_skipped(T_PATH);

--- a/test/testsuite/T2_FPSetForkParms.c
+++ b/test/testsuite/T2_FPSetForkParms.c
@@ -45,8 +45,6 @@ test_exit:
 /* ----------- */
 void T2FPSetForkParms_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
 	test9();
 }

--- a/test/testsuite/Utf8.c
+++ b/test/testsuite/Utf8.c
@@ -850,9 +850,7 @@ test_exit:
 /* ----------- */
 void Utf8_test()
 {
-    fprintf(stdout,"===================\n");
-    fprintf(stdout,"%s\n", __func__);
-    fprintf(stdout,"-------------------\n");
+    ENTER_TESTSET
     test162();
     test166();
     test167();

--- a/test/testsuite/rotest.c
+++ b/test/testsuite/rotest.c
@@ -304,8 +304,6 @@ test_exit:
 
 void Readonly_test()
 {
-    fprintf(stdout, "===================\n");
-    fprintf(stdout, "%s\n", __func__);
-    fprintf(stdout, "-------------------\n");
+    ENTER_TESTSET
     test510();
 }

--- a/test/testsuite/rotest.c
+++ b/test/testsuite/rotest.c
@@ -43,8 +43,12 @@ unsigned int ret;
 
 	ENTER_TEST
 
-	if (!Quiet) {
-		fprintf(stdout, "Has to be tested with a read only volume, two files and one dir\n");
+	if (!Test) {
+		if (!Quiet) {
+			fprintf(stdout, "Has to be tested with a read only volume, two files and one dir.\n");
+		}
+		test_skipped(T_SINGLE);
+		goto test_exit;
 	}
 
 	VolID = FPOpenVol(Conn, Vol);
@@ -295,13 +299,13 @@ unsigned int ret;
 fin:
 	FAIL (FPCloseVol(Conn,VolID))
 test_exit:
-	exit_test("Rotest:test510: Access files and directories on a read only volume");
+	exit_test("Readonly:test510: Access files and directories on a read only volume");
 }
 
 void Readonly_test()
 {
     fprintf(stdout, "===================\n");
-    fprintf(stdout, "%s: Read only volume\n", __func__);
+    fprintf(stdout, "%s\n", __func__);
     fprintf(stdout, "-------------------\n");
     test510();
 }

--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -31,6 +31,10 @@
 #define FAILEXIT(a, label) if ((a)) { test_failed(); goto label;}
 #define STATIC
 
+#define ENTER_TESTSET \
+    fprintf(stdout,"===================\n"); \
+    fprintf(stdout,"Executing testset: %s\n", __func__); \
+
 #define ENTER_TEST \
     if (!Quiet) { \
             fprintf(stdout, "############## entering %s ##############\n", __func__); \

--- a/test/testsuite/test.h
+++ b/test/testsuite/test.h
@@ -132,7 +132,6 @@ extern char *Vol2;
 extern char *Path;
 extern char *User;
 extern char *Test;
-extern char *Suite;
 
 extern int Version;
 extern int Verbose;


### PR DESCRIPTION
This removes the concept of testsuites within the spectest. Instead, the tier2 tests will be skipped if no `-c` option is passed to afp_spectest. Additionally, the sleep and readonly testsets can be run with the `-f` option.

Update exclusion criteria for tests that have started working with recent improvements. Fix test data cleanup..