### PR TITLE
testsuite: Workarounds for MUSL system calls default permissions

### DIFF
--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -204,7 +204,7 @@ EXT
     netatalk
     sleep 2
     if [ "$TESTSUITE" == "spectest" ]; then
-        afp_spectest "${TEST_FLAGS}" -"${AFP_VERSION}" -x -h 127.0.0.1 -p 548 -u "${AFP_USER}" -d "${AFP_USER2}" -w "${AFP_PASS}" -s "${SHARE_NAME}" -S "${SHARE2_NAME}" -c /mnt/afpshare
+        afp_spectest "${TEST_FLAGS}" -"${AFP_VERSION}" -h 127.0.0.1 -p 548 -u "${AFP_USER}" -d "${AFP_USER2}" -w "${AFP_PASS}" -s "${SHARE_NAME}" -S "${SHARE2_NAME}" -c /mnt/afpshare
     elif [ "$TESTSUITE" == "readonly" ]; then
         echo "testfile uno" > /mnt/afpshare/first.txt
         echo "testfile dos" > /mnt/afpshare/second.txt

--- a/test/testsuite/FPMapID.c
+++ b/test/testsuite/FPMapID.c
@@ -16,12 +16,6 @@ DSI *dsi = &Conn->dsi;
 
 	ENTER_TEST
 
-	// FIXME: encoding tests are broken in Netatalk 4.0
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
-
 	if (!(dir = FPCreateDir(Conn,vol, DIRDID_ROOT , name))) {
 		test_nottested();
 		goto test_exit;
@@ -62,7 +56,10 @@ DSI *dsi = &Conn->dsi;
 		test_failed();
 	}
 
-	FAIL ((htonl(AFPERR_NOITEM) != FPMapID(Conn, 5, filedir.gid)))
+	// Older AFP versions only have 4 subfunctions
+	if (Conn->afp_version > 31) {
+		FAIL ((htonl(AFPERR_NOITEM) != FPMapID(Conn, 5, filedir.gid)))
+	}
 	/* --------------------- */
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 test_exit:

--- a/test/testsuite/T2_FPMoveAndRename.c
+++ b/test/testsuite/T2_FPMoveAndRename.c
@@ -18,11 +18,6 @@ unsigned int ret;
 
 	ENTER_TEST
 
-	// FIXME: https://github.com/Netatalk/netatalk/issues/1682
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 	if (!Mac && Path[0] == '\0') {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;
@@ -38,6 +33,10 @@ unsigned int ret;
 			if (!Quiet) {
 				fprintf(stdout,"\tFAILED mkdir %s %s\n", temp, strerror(errno));
 			}
+			test_failed();
+		}
+		// Workaround for musl mkdir() not setting the right permissions
+		if (chmod(temp, 0777)) {
 			test_failed();
 		}
 	}
@@ -79,11 +78,6 @@ unsigned int ret;
 
 	ENTER_TEST
 
-	// FIXME: https://github.com/Netatalk/netatalk/issues/1682
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 	if (!Mac && Path[0] == '\0') {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;
@@ -99,6 +93,10 @@ unsigned int ret;
 			if (!Quiet) {
 				fprintf(stdout,"\tFAILED mkdir %s %s\n", temp, strerror(errno));
 			}
+			test_failed();
+		}
+		// Workaround for musl mkdir() not setting the right permissions
+		if (chmod(temp, 0777)) {
 			test_failed();
 		}
 	}

--- a/test/testsuite/T2_FPOpenFork.c.in
+++ b/test/testsuite/T2_FPOpenFork.c.in
@@ -1348,11 +1348,6 @@ STATIC void test431()
 
 	ENTER_TEST
 
-	// FIXME: Fails specifically on Alpine Linux
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 	if (!Mac && Path[0] == '\0') {
 		test_skipped(T_MAC_PATH);
 		goto test_exit;
@@ -1371,6 +1366,17 @@ STATIC void test431()
 		goto fin;
     }
     if (system(cmd) != 0) {
+		test_failed();
+		goto fin;
+    }
+    if (snprintf(cmd, sizeof(cmd), "%s/%s", Path, name) > sizeof(cmd)) {
+	if (!Quiet) {
+		fprintf(stdout,"FPOpenFork:test431: path too long\n");
+	}
+		test_failed();
+		goto fin;
+    }
+    if (chmod(cmd, 0666) != 0) {
 		test_failed();
 		goto fin;
     }


### PR DESCRIPTION
MUSL system calls (Alpine) result in files/dirs with no write permissions for the group, unlike glibc (Debian).