### PR TITLE
testsuite: Merge encoding test into spectest

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -265,23 +265,6 @@ jobs:
           - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
-    afp-logintest-afp34:
-      name: AFP login test - AFP 3.4
-      needs: build-container-testsuite
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_PASS: afpafp
-          AFP_GROUP: afpusers
-          INSECURE_AUTH: 1
-          VERBOSE: 1
-          TESTSUITE: login
-          AFP_VERSION: 7
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
-
-
     afp-rotest-afp21:
       name: AFP spec test (Readonly) - AFP 2.1
       needs: build-container-testsuite
@@ -301,6 +284,23 @@ jobs:
           - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
+    afp-logintest-afp34:
+      name: AFP login test - AFP 3.4
+      needs: build-container-testsuite
+      runs-on: ubuntu-latest
+      timeout-minutes: 5
+      env:
+          AFP_USER: atalk1
+          AFP_PASS: afpafp
+          AFP_GROUP: afpusers
+          INSECURE_AUTH: 1
+          VERBOSE: 1
+          TESTSUITE: login
+          AFP_VERSION: 7
+      steps:
+          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+
+
     afp-logintest-afp21:
       name: AFP login test - AFP 2.1
       needs: build-container-testsuite
@@ -313,24 +313,6 @@ jobs:
           INSECURE_AUTH: 1
           VERBOSE: 1
           TESTSUITE: login
-          AFP_VERSION: 1
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
-
-
-    afp-encodingtest-afp21:
-      name: AFP encoding test - AFP 2.1
-      needs: build-container-testsuite
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_PASS: afpafp
-          AFP_GROUP: afpusers
-          SHARE_NAME: test1
-          INSECURE_AUTH: 1
-          VERBOSE: 1
-          TESTSUITE: encoding
           AFP_VERSION: 1
       steps:
           - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest

--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -212,8 +212,6 @@ EXT
         afp_spectest "${TEST_FLAGS}" -"${AFP_VERSION}" -f Readonly_test -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}" -s "${SHARE_NAME}"
     elif [ "$TESTSUITE" == "login" ]; then
         afp_logintest "${TEST_FLAGS}" -"${AFP_VERSION}" -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}"
-    elif [ "$TESTSUITE" == "encoding" ]; then
-        afp_encodingtest "${TEST_FLAGS}" -"${AFP_VERSION}" -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}"  -s "${SHARE_NAME}" -c /mnt/afpshare
     else
         echo "Unknown testsuite: ${TESTSUITE}"
         exit 1

--- a/doc/ja/manpages/man1/afptest.1.xml
+++ b/doc/ja/manpages/man1/afptest.1.xml
@@ -17,8 +17,6 @@
   <refnamediv>
     <refname>afptest</refname>
 
-    <refname>afp_encodingtest</refname>
-
     <refname>afp_lantest</refname>
 
     <refname>afp_logintest</refname>
@@ -33,28 +31,6 @@
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis>
-      <command>afp_encodingtest<indexterm>
-          <primary>afptest</primary>
-        </indexterm></command>
-
-      <arg>-1234567CdVv</arg>
-
-      <arg>-h <replaceable>ホスト</replaceable></arg>
-
-      <arg>-p <replaceable>ポート</replaceable></arg>
-
-      <arg>-s <replaceable>ボリューム</replaceable></arg>
-
-      <arg>-c <replaceable>ボリュームへのパス</replaceable></arg>
-
-      <arg>-u <replaceable>ユーザー</replaceable></arg>
-
-      <arg>-w <replaceable>パスワード</replaceable></arg>
-
-      <arg>-e <replaceable>エンコーディング</replaceable></arg>
-    </cmdsynopsis>
-
     <cmdsynopsis>
       <command>afp_lantest<indexterm>
           <primary>afptest</primary>
@@ -192,9 +168,8 @@
     たとえば、Tier 2 (T2) テストは、共有ボリュームへのパスを示す <option>-c</option> オプションを使用してホスト上で
     実行する必要があります。また、読み取り専用テストとスリープ テストも別々に実行する必要があります。</para>
 
-    <para><command>afp_encodingtest</command> および
-    <command>afp_logintest</command> は、独自のランナーを持つ特定の AFP
-    仕様テストスイートです。前者は、<option>-c</option> オプションを使用してローカルで実行する必要があります。</para>
+    <para><command>afp_logintest</command> は、独自のランナーを持つ特定の AFP ログイン認証
+    テストスイートです。</para>
 
     <para><command>afp_lantest</command> と <command>afp_speedtest</command>
     は、AFP サーバーのファイル転送ベンチマークです。前者は、さまざまなファイル転送パターンのバッチを実行する <emphasis

--- a/doc/manpages/man1/afptest.1.xml
+++ b/doc/manpages/man1/afptest.1.xml
@@ -17,8 +17,6 @@
   <refnamediv>
     <refname>afptest</refname>
 
-    <refname>afp_encodingtest</refname>
-
     <refname>afp_lantest</refname>
 
     <refname>afp_logintest</refname>
@@ -33,28 +31,6 @@
   </refnamediv>
 
   <refsynopsisdiv>
-    <cmdsynopsis>
-      <command>afp_encodingtest<indexterm>
-          <primary>afptest</primary>
-        </indexterm></command>
-
-      <arg>-1234567CdVv</arg>
-
-      <arg>-h <replaceable>host</replaceable></arg>
-
-      <arg>-p <replaceable>port</replaceable></arg>
-
-      <arg>-s <replaceable>volume</replaceable></arg>
-
-      <arg>-c <replaceable>path to volume</replaceable></arg>
-
-      <arg>-u <replaceable>user</replaceable></arg>
-
-      <arg>-w <replaceable>password</replaceable></arg>
-
-      <arg>-e <replaceable>encoding</replaceable></arg>
-    </cmdsynopsis>
-
     <cmdsynopsis>
       <command>afp_lantest<indexterm>
           <primary>afptest</primary>
@@ -197,10 +173,8 @@
     volume. There are also read-only and sleep tests that need to be run
     separately.</para>
 
-    <para><command>afp_encodingtest</command> and
-    <command>afp_logintest</command> are specific AFP specification test
-    suites that have their own runners. The former must run locally with the
-    <option>-c</option> option.</para>
+    <para><command>afp_logintest</command> is an AFP login authentication test
+    suite that has its own runners.</para>
 
     <para><command>afp_lantest</command> and <command>afp_speedtest</command>
     are file transfer benchmarks for AFP servers. The former is inspired by

--- a/test/testsuite/README
+++ b/test/testsuite/README
@@ -22,9 +22,6 @@ Tier 2 testsets can only be run locally, activated with the -c option.
 ./afp_logintest:
 AFP spec tests for DSI and login. Not included in spectest.
 
-./afp_encodingtest:
-AFP spec tests for encoding. Not included in spectest.
-
 
 Benchmarking
 ------------

--- a/test/testsuite/encoding_test.c
+++ b/test/testsuite/encoding_test.c
@@ -1,114 +1,40 @@
-#include "afpclient.h"
-#include "test.h"
 #include "specs.h"
-#include <time.h>
-#include <getopt.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
 
-uint16_t VolID;
-static DSI *dsi;
-CONN *Conn;
-CONN *Conn2;
-
-int ExitCode = 0;
-char *Encoding = "western";
-extern int Convert;
 static char temp[MAXPATHLEN];
-
-int PassCount = 0;
-int FailCount = 0;
-int SkipCount = 0;
-int NotTestedCount = 0;
-
-/* ------------------------- */
-int empty_volume()
-{
-uint16_t vol = VolID;
-uint16_t d_bitmap;
-uint16_t f_bitmap;
-unsigned int ret;
-int  dir;
-uint16_t  tp;
-int  i, j;
-unsigned char *b;
-struct afp_filedir_parms filedir;
-int *stack;
-int cnt = 0;
-int size = 1000;
-DSI *dsi;
-
-	dsi = &Conn->dsi;
-
-    if (!Quiet) {
-		fprintf(stdout,"Delete all files\n");
-	}
-
-    f_bitmap = (1<<FILPBIT_FNUM ) | (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)|
-	         (1<<FILPBIT_CDATE) | (1<<FILPBIT_BDATE) | (1<<FILPBIT_MDATE);
-
-	d_bitmap = (1<< DIRPBIT_ATTR) | (1<<DIRPBIT_FINFO) |  (1 << DIRPBIT_OFFCNT) |
-	         (1<<DIRPBIT_CDATE) | (1<<DIRPBIT_BDATE) | (1<<DIRPBIT_MDATE) |
-		    (1<< DIRPBIT_LNAME) | (1<< DIRPBIT_PDID) | (1<< DIRPBIT_DID)|(1<< DIRPBIT_ACCESS);
-
-	if (Conn->afp_version >= 30) {
-		f_bitmap |= (1<<FILPBIT_PDINFO);
-		d_bitmap |= (1<<FILPBIT_PDINFO);
-	}
-	else {
-		f_bitmap |= (1<<FILPBIT_LNAME);
-		d_bitmap |= (1<<FILPBIT_LNAME);
-	}
-	dir = get_did(Conn, vol, DIRDID_ROOT, "");
-	if (!dir) {
-		test_nottested();
-	    return -1;
-	}
-	if (!(stack = calloc(size, sizeof(int)) )) {
-		test_nottested();
-	    return -1;
-	}
-	stack[cnt] = dir;
-	cnt++;
-
-	while (cnt) {
-	    cnt--;
-	    dir = stack[cnt];
-		i = 1;
-		if (FPGetFileDirParams(Conn, vol,  dir , "", 0, d_bitmap)) {
-			test_nottested();
-			return -1;
-		}
-		while (!(ret = FPEnumerateFull(Conn, vol, i, 150, 8000,  dir , "", f_bitmap, d_bitmap))) {
-			memcpy(&tp, dsi->data +4, sizeof(tp));
-			tp = ntohs(tp);
-		    i += tp;
-		    b = dsi->data +6;
-			for (j = 1; j <= tp; j++, b += b[0]) {
-			    if (b[1]) {
-	    		   filedir.isdir = 1;
-	    		}
-	    		else {
-	    		   filedir.isdir = 0;
-	    		}
-	    		afp_filedir_unpack(&filedir, b + 2, f_bitmap, d_bitmap);
-	    		if (FPDelete(Conn, vol,  DIRDID_ROOT , (Conn->afp_version >= 30)?filedir.utf8_name:filedir.lname)) {
-	    		    test_nottested();
-	    		    return -1;
-	    		}
-	    	}
-	    }
-	    if (ret != ntohl(AFPERR_NOOBJ)) {
-			test_nottested();
-			return -1;
-	    }
-	}
-	return 0;
-}
+static char *extascii[24] = {
+	" ?\"#$%&'", // substituted: !
+	"()*+,-.?", // substituted: /
+	"01234567",
+	"89?;<=>?", // substituted: :
+	"@ABCDEFG",
+	"HIJKLMNO",
+	"PQRSTUVW",
+	"XYZ[\\]^_",
+	"`abcdefg",
+	"hijklmno",
+	"pqrstuvw",
+	"xyz{|}~¡",
+	"¢£¤¥¦§¨©",
+	"ª«¬­®¯°±",
+	"²³´µ¶·¸¹",
+	"º»¼½¾¿ÀÁ",
+	"ÂÃÄÅÆÇÈÉ",
+	"ÊËÌÍÎÏÐÑ",
+	"ÒÓÔÕÖ×ØÙ",
+	"ÚÛÜÝÞßàá",
+	"âãäåæçèé",
+	"êëìíîïðñ",
+	"òóôõö÷øù",
+	"úûüýþÿ"
+};
 
 /* ------------------
  * client encoding western 1 byte [1..255]
+ * NOTE: This test was original conceived to test
+ * Extended ASCII encoding.
+ * On today's systems this encoding doesn't exist in practice.
+ * So, this test tests the equivalent Unicode character instead.
 */
 static void test_western()
 {
@@ -116,50 +42,41 @@ uint16_t vol = VolID;
 uint16_t f_bitmap;
 int  ofs =  3 * sizeof( uint16_t );
 struct afp_filedir_parms filedir;
-char name[30];
 char *result;
-int  i, j = 0;
 DSI *dsi;
 
 	dsi = &Conn->dsi;
 
 	ENTER_TEST
 
-    for (i = 1; i < 8; i++) {
-    	name[i -1] = i;
-    }
-    name[i -1] = 0;
 	if (Conn->afp_version >= 30) {
 		f_bitmap = (1<<FILPBIT_PDINFO);
 	}
 	else {
 		f_bitmap = (1<<FILPBIT_LNAME);
 	}
-    while (j < 32) {
-        j++;
-		if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
+    for (int i = 0; i < 24; i++) {
+		if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , extascii[i])) {
 			test_nottested();
 			goto test_exit;
 		}
-		if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, f_bitmap, 0)) {
+		if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, extascii[i], f_bitmap, 0)) {
 			test_nottested();
 			goto test_exit;
 		}
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi->data +ofs, f_bitmap, 0);
 		result = (Conn->afp_version >= 30)?filedir.utf8_name:filedir.lname;
-		if (strcmp(result, name)) {
+		if (strcmp(result, extascii[i])) {
 			test_failed();
 			goto test_exit;
 		}
-
-		/* don't use ':' char */
-    	for (i = 0; i < 8; i++) {
-    		name[i] = (j*8 +i != 0x3a)?j*8 +i:0x39;
-	    }
-    	name[i] = 0;
+		if (FPDelete(Conn, vol, DIRDID_ROOT, extascii[i])) {
+			test_nottested();
+			goto test_exit;
+		}
 	}
-	if (Path) {
+	if (Path[0] != '\0') {
 	int fd;
 
 		sprintf(temp,"%s/:test", Path);
@@ -179,197 +96,9 @@ test_exit:
 	exit_test("Encoding:western");
 }
 
-/* ------------------ */
-static void run_one()
+/* ----------- */
+void Encoding_test()
 {
-	Convert = 0;
-	dsi = &Conn->dsi;
-	VolID = FPOpenVol(Conn, Vol);
-	if (VolID == 0xffff) {
-		test_nottested();
-		return;
-	}
-	if (empty_volume() < 0) {
-		test_nottested();
-	    return;
-	}
-	if (strcmp(Encoding, "western") == 0) {
-		if (!Quiet) {
-			fprintf(stdout, "Testing encoding: %s\n", Encoding);
-		}
-	    test_western();
-	}
-	else {
-		fprintf(stdout, "Unknown encoding: %s\n", Encoding);
-		ExitCode = 1;
-	}
-}
-
-/* =============================== */
-
-DSI *Dsi;
-
-char Data[300000] = "";
-/* ------------------------------- */
-char    *Server = "localhost";
-int     Proto = 0;
-int     Port = 548;
-char    *Password = "";
-char    *Vol = "";
-char    *User;
-char    *Path = "";
-int     Version = 21;
-int     Mac = 0;
-
-/* =============================== */
-void usage( char * av0 )
-{
-    fprintf( stdout, "usage:\t%s [-1234567CdVv] [-h host] [-p port] [-s vol] [-c vol path] "
-	"[-u user] [-w password] [-e encoding]\n", av0 );
-    fprintf( stdout,"\t-e\tclient encoding (default western)\n");
-    fprintf( stdout,"\t-h\tserver host name (default localhost)\n");
-    fprintf( stdout,"\t-p\tserver port (default 548)\n");
-    fprintf( stdout,"\t-s\tvolume to mount\n");
-    fprintf( stdout,"\t-c\tvolume path on the server\n");
-    fprintf( stdout,"\t-u\tuser name (default uid)\n");
-    fprintf( stdout,"\t-w\tpassword\n");
-    fprintf( stdout,"\t-1\tAFP 2.1 version (default)\n");
-    fprintf( stdout,"\t-2\tAFP 2.2 version\n");
-    fprintf( stdout,"\t-3\tAFP 3.0 version\n");
-    fprintf( stdout,"\t-4\tAFP 3.1 version\n");
-    fprintf( stdout,"\t-5\tAFP 3.2 version\n");
-    fprintf( stdout,"\t-6\tAFP 3.3 version\n");
-    fprintf( stdout,"\t-7\tAFP 3.4 version\n");
-    fprintf( stdout,"\t-v\tverbose\n");
-    fprintf( stdout,"\t-V\tvery verbose\n");
-    fprintf( stdout,"\t-C\tturn off terminal color output\n");
-
-    exit (1);
-}
-
-/* ------------------------------- */
-int main( int ac, char **av )
-{
-int cc;
-static char *vers = "AFPVersion 2.1";
-static char *uam = "Cleartxt Passwrd";
-
-    while (( cc = getopt( ac, av, "1234567ClmRvVc:e:h:p:s:u:w:" )) != EOF ) {
-        switch ( cc ) {
-        case '1':
-			vers = "AFPVersion 2.1";
-			Version = 21;
-			break;
-        case '2':
-			vers = "AFP2.2";
-			Version = 22;
-			break;
-        case '3':
-			vers = "AFPX03";
-			Version = 30;
-			break;
-        case '4':
-			vers = "AFP3.1";
-			Version = 31;
-			break;
-        case '5':
-			vers = "AFP3.2";
-			Version = 32;
-			break;
-        case '6':
-			vers = "AFP3.3";
-			Version = 33;
-			break;
-        case '7':
-			vers = "AFP3.4";
-			Version = 34;
-			break;
-		case 'C':
-			Color = 0;
-			break;
-		case 'c':
-			Path = strdup(optarg);
-			break;
-		case 'e':
-			Encoding = strdup(optarg);
-			break;
-        case 'h':
-            Server = strdup(optarg);
-            break;
-        case 'p' :
-            Port = atoi( optarg );
-            if (Port <= 0) {
-                fprintf(stdout, "Bad port.\n");
-                exit(1);
-            }
-            break;
-        case 's':
-            Vol = strdup(optarg);
-            break;
-        case 'u':
-            User = strdup(optarg);
-            break;
-		case 'V':
-			Quiet = 0;
-			Verbose = 1;
-			break;
-		case 'v':
-			Quiet = 0;
-			break;
-        case 'w':
-            Password = strdup(optarg);
-            break;
-        default :
-            usage( av[ 0 ] );
-        }
-    }
-
-    if (!Quiet) {
-        fprintf(stdout, "Connecting to host %s:%d\n", Server, Port);
-    }
-	if (User != NULL && User[0] == '\0') {
-        fprintf(stdout, "Error: Define a user with -u\n");
-	}
-	if (Password != NULL && Password[0] == '\0') {
-        fprintf(stdout, "Error: Define a password with -w\n");
-	}
-	if (Vol != NULL && Vol[0] == '\0') {
-        fprintf(stdout, "Error: Define a volume with -s\n");
-	}
-	if (Path != NULL && Path[0] == '\0') {
-        fprintf(stdout, "Error: Define the local path to the volume with -c\n");
-	}
-
-	/************************************
-	 *                                  *
-	 * Connection user 1                *
-	 *                                  *
-	 ************************************/
-
-    if ((Conn = (CONN *)calloc(1, sizeof(CONN))) == NULL) {
-    	return 1;
-    }
-    Conn->type = Proto;
-    if (!Proto) {
-	int sock;
-    	Dsi = &Conn->dsi;
-		dsi = Dsi;
-	    sock = OpenClientSocket(Server, Port);
-        if ( sock < 0) {
-	    	return 2;
-        }
-     	Dsi->protocol = DSI_TCPIP;
-	    Dsi->socket = sock;
-    }
-    else {
-	}
-
-    /* login */
-	FPopenLogin(Conn, vers, uam, User, Password);
-	Conn->afp_version = Version;
-
-	run_one();
-
-   	FPLogOut(Conn);
-	return ExitCode;
+    ENTER_TESTSET
+	test_western();
 }

--- a/test/testsuite/meson.build
+++ b/test/testsuite/meson.build
@@ -54,18 +54,6 @@ executable(
     install: true,
 )
 
-encoding_test_sources = [
-    'encoding_test.c',
-]
-
-executable(
-    'afp_encodingtest',
-    encoding_test_sources,
-    include_directories: root_includes,
-    link_with: libafptest,
-    install: true,
-)
-
 login_test_sources = [
     'logintest.c',
 ]
@@ -169,6 +157,7 @@ spectest_sources = [
     'T2_Dircache_attack.c',
     'T2_FPRead.c',
     'T2_FPSetForkParms.c',
+    'encoding_test.c',
     t2_fpopenfork_c,
 ]
 

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -94,6 +94,7 @@ EXT_FN(T2FPRead);
 EXT_FN(T2FPSetForkParms);
 
 EXT_FN(Dircache_attack);
+EXT_FN(Encoding);
 EXT_FN(Error);
 EXT_FN(Readonly);
 EXT_FN(Utf8);
@@ -180,6 +181,7 @@ FN_N(T2FPRead)
 FN_N(T2FPSetForkParms)
 
 FN_N(Dircache_attack)
+FN_N(Encoding)
 FN_N(Error)
 FN_N(Readonly)
 FN_N(Utf8)


### PR DESCRIPTION
The "western" encoding test has been refactored to use Unicode characters instead of defunct Extended ASCII, and then merged into the spectest as an Encoding testset.