### PR TITLE
testsuite: Use AFP 3.4 protocol by default in all tools

### DIFF
--- a/doc/ja/manpages/man1/afptest.1.xml
+++ b/doc/ja/manpages/man1/afptest.1.xml
@@ -78,7 +78,7 @@
           <primary>afptest</primary>
         </indexterm></command>
 
-      <arg>-1234567aCiLlmnVvx</arg>
+      <arg>-1234567aCiLlmVv</arg>
 
       <arg>-h <replaceable>ホスト</replaceable></arg>
 

--- a/doc/manpages/man1/afptest.1.xml
+++ b/doc/manpages/man1/afptest.1.xml
@@ -78,7 +78,7 @@
           <primary>afptest</primary>
         </indexterm></command>
 
-      <arg>-1234567aCiLlmnVvx</arg>
+      <arg>-1234567aCiLlmVv</arg>
 
       <arg>-h <replaceable>host</replaceable></arg>
 

--- a/test/testsuite/afparg.c
+++ b/test/testsuite/afparg.c
@@ -43,9 +43,12 @@ int     Port = 548;
 char    *Password = "";
 char    *Vol = "";
 char    *User;
-int     Version = 21;
+int     Version = 34;
 int     List = 0;
 char    *Test = "";
+
+char *vers = "AFP3.4";
+char *uam = "Cleartxt Passwrd";
 
 /* Unused but required in afphelper.c. Argh. */
 CONN       *Conn2;
@@ -109,13 +112,13 @@ void usage( char * av0 )
     fprintf( stdout,"\t-s\tvolume to mount\n");
     fprintf( stdout,"\t-u\tuser name (default uid)\n");
     fprintf( stdout,"\t-w\tpassword\n");
-    fprintf( stdout,"\t-1\tAFP 2.1 version (default)\n");
+    fprintf( stdout,"\t-1\tAFP 2.1 version\n");
     fprintf( stdout,"\t-2\tAFP 2.2 version\n");
     fprintf( stdout,"\t-3\tAFP 3.0 version\n");
     fprintf( stdout,"\t-4\tAFP 3.1 version\n");
     fprintf( stdout,"\t-5\tAFP 3.2 version\n");
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
-    fprintf( stdout,"\t-7\tAFP 3.4 version\n");
+    fprintf( stdout,"\t-7\tAFP 3.4 version (default)\n");
     fprintf( stdout,"\t-v\tverbose\n");
     fprintf( stdout,"\t-V\tvery verbose\n");
 
@@ -124,8 +127,6 @@ void usage( char * av0 )
     exit (1);
 }
 
-char *vers = "AFPVersion 2.1";
-char *uam = "Cleartxt Passwrd";
 /* ------------------------------- */
 int main( int ac, char **av )
 {

--- a/test/testsuite/afpcli.c
+++ b/test/testsuite/afpcli.c
@@ -2,13 +2,15 @@
 #include "test.h"
 
 // Define the global test settings
-int     Throttle = 0;
-int     Convert = 1;
+int Throttle = 0;
+int Convert = 1;
 int	Interactive = 0;
 int	Quiet = 1;
 int	Verbose = 0;
 int	Color = 1;
+#if 0
 int	Exclude = 0;
+#endif
 
 #define UNICODE(a) (a->afp_version >= 30)
 

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -882,9 +882,11 @@ void test_skipped(int why)
 	case T_VOL_BIG:
 		s = "a smaller volume";
 		break;
+#if 0
 	case T_EXCLUDE:
 		s = "in the Exclude bucket";
 		break;
+#endif
 	case T_MANUAL:
 		s = "Interactive mode";
 		break;

--- a/test/testsuite/logintest.c
+++ b/test/testsuite/logintest.c
@@ -26,11 +26,11 @@ char    *Vol = "";
 char    *User;
 char    *User2;
 char    *Path;
-int     Version = 21;
+int     Version = 34;
 int     List = 0;
 int     Mac = 0;
 char    *Test;
-static char  *vers = "AFPVersion 2.1";
+static char  *vers = "AFP3.4";
 
 static void connect_server(CONN *conn)
 {
@@ -279,13 +279,13 @@ void usage( char * av0 )
     fprintf( stdout,"\t-p\tserver port (default 548)\n");
     fprintf( stdout,"\t-u\tuser name (default uid)\n");
     fprintf( stdout,"\t-w\tpassword\n");
-    fprintf( stdout,"\t-1\tAFP 2.1 version (default)\n");
+    fprintf( stdout,"\t-1\tAFP 2.1 version\n");
     fprintf( stdout,"\t-2\tAFP 2.2 version\n");
     fprintf( stdout,"\t-3\tAFP 3.0 version\n");
     fprintf( stdout,"\t-4\tAFP 3.1 version\n");
     fprintf( stdout,"\t-5\tAFP 3.2 version\n");
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
-    fprintf( stdout,"\t-7\tAFP 3.4 version\n");
+    fprintf( stdout,"\t-7\tAFP 3.4 version (default)\n");
     fprintf( stdout,"\t-v\tverbose\n");
     fprintf( stdout,"\t-V\tvery verbose\n");
     fprintf( stdout,"\t-C\tturn off terminal color output\n");

--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -105,7 +105,9 @@ extern int not_valid_bitmap(unsigned int ret, unsigned int bitmap, int afpd_erro
 #define T_NO_UNIX_PREV 21
 #define T_SINGLE     22
 #define T_VOL_BIG    23
+#if 0
 #define T_EXCLUDE    24
+#endif
 #define T_MANUAL     25
 #define T_AFP31      26
 #define T_AFP32      27

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -319,6 +319,9 @@ char    *Test;
 int		Locking;
 enum adouble adouble = AD_EA;
 
+char *vers = "AFPVersion 3.4";
+char *uam = "Cleartxt Passwrd";
+
 /* =============================== */
 void usage( char * av0 )
 {
@@ -337,13 +340,13 @@ void usage( char * av0 )
     fprintf( stdout,"\t-d\tsecond user for two connections (same password!)\n");
     fprintf( stdout,"\t-H\tsecond server for two connections\n");
 
-    fprintf( stdout,"\t-1\tAFP 2.1 version (default)\n");
+    fprintf( stdout,"\t-1\tAFP 2.1 version\n");
     fprintf( stdout,"\t-2\tAFP 2.2 version\n");
     fprintf( stdout,"\t-3\tAFP 3.0 version\n");
     fprintf( stdout,"\t-4\tAFP 3.1 version\n");
     fprintf( stdout,"\t-5\tAFP 3.2 version\n");
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
-    fprintf( stdout,"\t-7\tAFP 3.4 version\n");
+    fprintf( stdout,"\t-7\tAFP 3.4 version (default)\n");
     fprintf( stdout,"\t-v\tverbose\n");
     fprintf( stdout,"\t-V\tvery verbose\n");
 
@@ -354,9 +357,6 @@ void usage( char * av0 )
     fprintf( stdout,"\t-C\tturn off terminal color output\n");
     exit (1);
 }
-
-char *vers = "AFPVersion 2.1";
-char *uam = "Cleartxt Passwrd";
 /* ------------------------------- */
 int main( int ac, char **av )
 {

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -349,8 +349,9 @@ void usage( char * av0 )
     fprintf( stdout,"\t-7\tAFP 3.4 version (default)\n");
     fprintf( stdout,"\t-v\tverbose\n");
     fprintf( stdout,"\t-V\tvery verbose\n");
-
+#if 0
     fprintf( stdout,"\t-x\tdon't run tests with known bugs\n");
+#endif
     fprintf( stdout,"\t-f\ttest or testset to run\n");
     fprintf( stdout,"\t-l\tlist testsets\n");
     fprintf( stdout,"\t-i\tinteractive mode, prompts before every test (debug purposes)\n");
@@ -363,7 +364,7 @@ int main( int ac, char **av )
 int cc;
 int ret;
 
-    while (( cc = getopt( ac, av, "vV1234567ah:H:p:s:S:u:d:w:c:f:LlmxiC" )) != EOF ) {
+    while (( cc = getopt( ac, av, "1234567aCiLlmVvc:d:f:H:h:p:S:s:u:w:" )) != EOF ) {
         switch ( cc ) {
         case '1':
 			vers = "AFPVersion 2.1";
@@ -454,9 +455,11 @@ int ret;
         case 'w':
             Password = strdup(optarg);
             break;
+#if 0
         case 'x':
         	Exclude = 1;
         	break;
+#endif
 
         default :
             usage( av[ 0 ] );

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -38,9 +38,12 @@ static char    *Password = "";
 char    *Vol = "";
 char    *Vol2 = "";
 char    *User;
-int     Version = 21;
+int     Version = 34;
 char    *Test = "Write";
 static char    *Filename;
+
+char *vers = "AFP3.4";
+char *uam = "Cleartxt Passwrd";
 
 static int Count = 1;
 static off_t Size = 64* MEGABYTE;
@@ -1265,13 +1268,13 @@ void usage( char * av0 )
     fprintf( stdout,"\t-L\tuse posix calls (default AFP calls)\n");
     fprintf( stdout,"\t-D\twith -L use O_DIRECT in open flags (default no)\n");
 
-    fprintf( stdout,"\t-1\tAFP 2.1 version (default)\n");
+    fprintf( stdout,"\t-1\tAFP 2.1 version\n");
     fprintf( stdout,"\t-2\tAFP 2.2 version\n");
     fprintf( stdout,"\t-3\tAFP 3.0 version\n");
     fprintf( stdout,"\t-4\tAFP 3.1 version\n");
     fprintf( stdout,"\t-5\tAFP 3.2 version\n");
     fprintf( stdout,"\t-6\tAFP 3.3 version\n");
-    fprintf( stdout,"\t-7\tAFP 3.4 version\n");
+    fprintf( stdout,"\t-7\tAFP 3.4 version (default)\n");
 
     fprintf( stdout,"\t-n\thow many iterations to run (default: 1)\n");
     fprintf( stdout,"\t-d\tfile size (Mbytes, default 64)\n");
@@ -1291,8 +1294,6 @@ void usage( char * av0 )
     exit (1);
 }
 
-char *vers = "AFPVersion 2.1";
-char *uam = "Cleartxt Passwrd";
 /* ------------------------------- */
 int main( int ac, char **av )
 {

--- a/test/testsuite/test.h
+++ b/test/testsuite/test.h
@@ -123,8 +123,6 @@ const char *AfpNum2name(int num);
 
 extern CONN *Conn, *Conn2;
 
-// extern DSI *dsi;
-// extern uint16_t vol;
 extern char Data[];
 
 extern char *Vol;
@@ -141,7 +139,9 @@ extern int Loglevel;
 extern int Color;
 extern int Interactive;
 extern int Throttle;
+#if 0
 extern int Exclude;
+#endif
 
 extern int PassCount;
 extern int FailCount;


### PR DESCRIPTION
Have every test tool default to AFP 3.4 instead of 2.1