### PR TITLE
testsuite: Use Exclude option for special case tests

### DIFF
--- a/doc/ja/manpages/man1/afptest.1.xml
+++ b/doc/ja/manpages/man1/afptest.1.xml
@@ -78,7 +78,7 @@
           <primary>afptest</primary>
         </indexterm></command>
 
-      <arg>-1234567aCiLlmVv</arg>
+      <arg>-1234567aCiLlmVvx</arg>
 
       <arg>-h <replaceable>ホスト</replaceable></arg>
 

--- a/doc/manpages/man1/afptest.1.xml
+++ b/doc/manpages/man1/afptest.1.xml
@@ -78,7 +78,7 @@
           <primary>afptest</primary>
         </indexterm></command>
 
-      <arg>-1234567aCiLlmVv</arg>
+      <arg>-1234567aCiLlmVvx</arg>
 
       <arg>-h <replaceable>host</replaceable></arg>
 

--- a/test/testsuite/FPAddAPPL.c
+++ b/test/testsuite/FPAddAPPL.c
@@ -67,6 +67,7 @@ test_exit:
 }
 
 /* ------------------------- */
+// FIXME: The first branch needs to get refactored. Always fails with 1 user.
 STATIC void test301()
 {
 uint16_t vol = VolID;
@@ -151,5 +152,7 @@ void FPAddAPPL_test()
 {
     ENTER_TESTSET
 	test214();
+#if 0
 	test301();
+#endif
 }

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -971,6 +971,9 @@ uint16_t bitmap;
 
 	ENTER_TEST
 
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+	}
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		test_nottested();
 		goto fin;
@@ -1033,6 +1036,9 @@ uint16_t bitmap1 =  (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)| (1<<FILPBIT_CDATE) |
 
 	ENTER_TEST
 
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+	}
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		test_nottested();
 		goto fin;

--- a/test/testsuite/afpcli.c
+++ b/test/testsuite/afpcli.c
@@ -8,9 +8,7 @@ int	Interactive = 0;
 int	Quiet = 1;
 int	Verbose = 0;
 int	Color = 1;
-#if 0
 int	Exclude = 0;
-#endif
 
 #define UNICODE(a) (a->afp_version >= 30)
 

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -882,11 +882,9 @@ void test_skipped(int why)
 	case T_VOL_BIG:
 		s = "a smaller volume";
 		break;
-#if 0
 	case T_EXCLUDE:
 		s = "in the Exclude bucket";
 		break;
-#endif
 	case T_MANUAL:
 		s = "Interactive mode";
 		break;

--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -105,9 +105,7 @@ extern int not_valid_bitmap(unsigned int ret, unsigned int bitmap, int afpd_erro
 #define T_NO_UNIX_PREV 21
 #define T_SINGLE     22
 #define T_VOL_BIG    23
-#if 0
 #define T_EXCLUDE    24
-#endif
 #define T_MANUAL     25
 #define T_AFP31      26
 #define T_AFP32      27

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -312,14 +312,14 @@ char    *Vol2 = "";
 char    *User;
 char    *User2;
 char    *Path = "";
-int     Version = 21;
+int     Version = 34;
 int     List = 0;
 int     Mac = 0;
 char    *Test;
 int		Locking;
 enum adouble adouble = AD_EA;
 
-char *vers = "AFPVersion 3.4";
+char *vers = "AFP3.4";
 char *uam = "Cleartxt Passwrd";
 
 /* =============================== */

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -349,22 +349,21 @@ void usage( char * av0 )
     fprintf( stdout,"\t-7\tAFP 3.4 version (default)\n");
     fprintf( stdout,"\t-v\tverbose\n");
     fprintf( stdout,"\t-V\tvery verbose\n");
-#if 0
-    fprintf( stdout,"\t-x\tdon't run tests with known bugs\n");
-#endif
+    fprintf( stdout,"\t-x\tdon't run tests that require special setup\n");
     fprintf( stdout,"\t-f\ttest or testset to run\n");
     fprintf( stdout,"\t-l\tlist testsets\n");
     fprintf( stdout,"\t-i\tinteractive mode, prompts before every test (debug purposes)\n");
     fprintf( stdout,"\t-C\tturn off terminal color output\n");
     exit (1);
 }
+
 /* ------------------------------- */
 int main( int ac, char **av )
 {
 int cc;
 int ret;
 
-    while (( cc = getopt( ac, av, "1234567aCiLlmVvc:d:f:H:h:p:S:s:u:w:" )) != EOF ) {
+    while (( cc = getopt( ac, av, "1234567aCiLlmVvxc:d:f:H:h:p:S:s:u:w:" )) != EOF ) {
         switch ( cc ) {
         case '1':
 			vers = "AFPVersion 2.1";
@@ -455,11 +454,9 @@ int ret;
         case 'w':
             Password = strdup(optarg);
             break;
-#if 0
         case 'x':
         	Exclude = 1;
         	break;
-#endif
 
         default :
             usage( av[ 0 ] );

--- a/test/testsuite/test.h
+++ b/test/testsuite/test.h
@@ -139,9 +139,7 @@ extern int Loglevel;
 extern int Color;
 extern int Interactive;
 extern int Throttle;
-#if 0
 extern int Exclude;
-#endif
 
 extern int PassCount;
 extern int FailCount;


### PR DESCRIPTION
- Bring back the -x option to use for tests that fail without special environment setup.
- Fix a typo in spectest default AFP version
- Disable test301 again. It's broken when run with a single user.