### PR TITLE
Update CONTRIBUTORS for versions 2.0~4.0

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -56,16 +56,32 @@ Developers: Version 1.4.99 - 2.0
 
 Webmin Module:
 	Matthew Keller <kellermg@potsdam.edu>
+	Sven Mosimann/EcoLogic <sven.mosimann@ecologic.ch>
+	Steffan Cline <steffan@hldns.com>
+	Ralph Boehme <slow@samba.org> (3.x version)
+	Daniel Markstedt <daniel@mindani.net> (2.x and 4.x versions)
 
 Test Suite:
 	Didier Gautheron <dgautheron@magic.fr>
 	Rafal Lewczuk <rlewczuk@pronet.pl>
+	Frank Lahm <franklahm@gmail.com>
+	Ralph Boehme <slow@samba.org>
+	CHANG-NING TSAI <spiderpower02@gmail.com>
+	Daniel Markstedt <daniel@mindani.net>
 
 Package Maintainers and Contributors:
 	Sebastian Rittau <srittau@debian.org> (Debian GNU/Linux)
 	Jonas Smedegaard <dr@jones.dk> (Debian GNU/Linux)
+	Daniel Markstedt <daniel@mindani.net> (Debian GNU/Linux)
+	Andrew Bauer <zonexpertconsulting@outlook.com> (Fedora)
 	Joe Clarke <marcus@FreeBSD.org> (FreeBSD)
 	David Rankin <drankin@bohemians.lexington.ky.us> (NetBSD)
+	Hauke Fath <hf@spg.tu-darmstadt.de> (NetBSD)
+	Arvid Norlander (Arch Linux)
+
+NOTE: This list of package maintainers is nowhere near complete.
+      This cohort represent folks who have engaged directly with the
+      Netatalk developers.
 
 Sourceforge Website Maintainers:
 	Andrew Morgan <morgan@orst.edu>
@@ -91,7 +107,7 @@ Bug Reports: Version 1.4.99 - 2.0
 	Ryan Dooley <dooleyr@missouri.edu>
 	Don Jessup <DJessup@tricord.com>
 	Kevin M. Myer <kevin_myer@iu13.k12.pa.us>
-	Lawrence Farr" <netatalk@epcdirect.co.uk>
+	Lawrence Farr <netatalk@epcdirect.co.uk>
 	Ralph Hackl <ralph.hackl@cancom.at>
 	Adrian Moir <adrianm@siliconsystems.co.uk>
 	Akop Pogosian <akopps@CSUA.Berkeley.EDU>
@@ -116,9 +132,114 @@ Bug Reports: Version 1.4.99 - 2.0
 	<mikko@fs.sorl.net>
 	Roger <roger.day@globalgraphics.com>
 
+Version 2.1 - 3.1 (ca. 2005-2018)
+
+Developers: Version 2.1 - 3.1
+	Andrew Morgan <morgan@orst.edu> (-2008)
+	Didier Gautheron <dgautheron@magic.fr> (-2010)
+	Frank Lahm <franklahm@gmail.com> (2008-2014)
+	HAT <hat@fa2.so-net.ne.jp> (2008-2017)
+	Ralph Boehme <slow@samba.org> (2012-2023)
+	Andrew Stormont <andyjstormont@gmail.com> (2016)
+
+Patches: Version 2.1 - 3.1
+	Justin Mazzola Paluska
+	Panos Christeas
+	TSUBAKIMOTO Hiroya <zorac@4000do.co.jp>
+	Bolke de Bruin
+	Adam Goode
+	Martin Nagy
+	Tsiyon Sadiky exanet
+	Stephen J. Butler
+	Olaf Hering
+	Nico Golde
+	Tim Nowaczyk
+	Jiri Skala
+	Oliver Geisen
+	Timm Okke
+	Toshihiro Togo
+	Patrick Coulthard
+	Jonas Smedegaard <dr@jones.dk>
+	Laura Mueller <laura-mueller@uni-duesseldorf.de>
+	Akinori MUSHA
+	Brad Smith
+	Rob Braun
+	Mark Williams
+	Riccardo Magliocchetti
+	Denis Ahrens
+	Lee Essen
+	Anton Starikov
+	Jamie Gilbertson
+	Thomas Johnson <NTmatter@gmail.com>
+	Oichinokata
+	Don Lee
+	Justin Maggard <jmaggard10@gmail.com>
+	Ross Lagerwall
+	Shannon Wynter <s.wynter@bookmaker.com.au>
+	Doug Goldstein <cardoe@cardoe.com>
+	Eiichirou UDA
+	Kyle VanderBeek <kylev@gametime.co>
+	Phil Kauffman <kauffman@cs.uchicago.edu>
+	David Buckley <dbuckley@oreilly.com>
+	Justin Maggard <jmaggard@netgear.com>
+	Justin Lecher <jlec@gentoo.org>
+	Sam Zaydel <szaydel@gmail.com>
+	Scott Talbert <scott.talbert@wdc.com>
+	Denis Bychkov <manover@gmail.com>
+	Sergei Lomakov
+	Dave Horlick
+	Ruben Kerkhof
+	Michael Witten
+
+Documentation: Version 2.1 - 3.1
+	Frank Lahm <franklahm@gmail.com> (Upgrade chapter)
+	Eiichirou UDA (Japanese localization)
+	HAT <hat@fa2.so-net.ne.jp> (Japanese localization)
+
+
+Version 3.2 - 4.0 (2019 - present)
+
+Developers: Version 3.2 - 4.0
+	Ralph Boehme <slow@samba.org> (2012-2023)
+	Daniel Markstedt <daniel@mindani.net> (2022-)
+	dgsga (2023-2024)
+	NJRoadfan (2023-)
+
+Patches: Version 3.2 - 4.0
+	Andrew Bauer <zonexpertconsulting@outlook.com>
+	Jose Quinteiro <github@quinteiro.org>
+	Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>
+	Andrew Walker <awalker@ixsystems.com>
+	Simon Muras <s.muras@laudert.de>
+	Fabrice Fontaine
+	Etienne Helluy-Lafont <etienne.helluy-lafont@synacktiv.com>
+	Hauke Fath <hf@spg.tu-darmstadt.de>
+	Christopher Kobayashi
+	pgajdos
+	psykose
+	Mikhail Emelchenkov <m@emelchenkov.pro>
+	Florian Weimer
+	Richard van den Berg
+	Andy Chen <andychen@synology.com>
+	Petr Gajdos
+	도환김 (down) <dohwan09@cau.ac.kr>
+	Eric Harmon
+	Derrik Pates
+	Simon McVittie <smcv@collabora.com>
+	cy384
+	Denis Yantarev
+
+macipgw
+	Stefan Bethke <Stefan.Bethke@Hanse.DE> (1997-2013)
+	Jason King (2015-2017)
+	Christopher Kobayashi (2020)
+
 
 And thanks to everyone on the netatalk-devel and netatalk-docs
-lists. If you feel you should be listed here and aren't, please let
+lists. And in recent years, the TinkerDifferent, 68kmla, E-Maculation,
+and other online communities.
+
+If you feel you should be listed here and aren't, please let
 us know.
 
 Cheers!


### PR DESCRIPTION
Code contributors for the period between the v2.0 and v4.0 releases, roughly 2005-2024. The source of this information is the Netatalk git commit history.

I have tried to be mindful and selective about recording personal information here. While open source projects traditionally have been very, err, _open_ about sharing the names and email addresses of code contributors, today the culture has shifted and many individuals prefer to keep their email addresses private, and sometimes also strictly use pseudonyms online. I believe it is important to respect the will of such individuals.

Criteria for using someone's real name:
- The name is on their public GitHub/GitLab profile

Criteria for recording someone's email address is one of the below:
- The email address is in a copyright blurb in the Netatalk codebase
- The email address is spelled out on their public GitHub/GitLab profile
- The email address is spelled out on a personal homepage or blog
- The email address has a TLD belonging to a company or institution of higher education (important for the sake of open source to record a contributor's business or academic association)

This means that I have redacted many personal email addresses that were recorded in the git commit, but nowhere else.

If anyone of your who are listed in this document would like to be redacted, or anonymized in any way, please don't hesitate to respond here, or contact me in private (see my GitHub profile for the email address.) And the same goes if you want to be credited with full name and email, instead of anonymity, of course!