### PR TITLE
docs: Remove afp_encodingtest.1 man page alias

### DIFF
--- a/doc/manpages/man1/meson.build
+++ b/doc/manpages/man1/meson.build
@@ -33,7 +33,6 @@ foreach man : manfiles
 endforeach
 
 afptest_staticmans = [
-    'afp_encodingtest.1',
     'afp_lantest.1',
     'afp_logintest.1',
     'afp_spectest.1',


### PR DESCRIPTION
The afp_encodingtest tool itself was removed previously.