### PR TITLE
GitHub CI: Use libgcrypt20 packages for Debian/Ubuntu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,7 +177,7 @@ jobs:
             libdb-dev \
             libdbus-1-dev \
             libevent-dev \
-            libgcrypt-dev \
+            libgcrypt20-dev \
             libglib2.0-dev \
             libkrb5-dev \
             libldap2-dev \
@@ -364,7 +364,7 @@ jobs:
             libdb-dev \
             libdbus-1-dev \
             libevent-dev \
-            libgcrypt-dev \
+            libgcrypt20-dev \
             libglib2.0-dev \
             libkrb5-dev \
             libldap2-dev \
@@ -778,7 +778,7 @@ jobs:
             libdb-dev \
             libdbus-1-dev \
             libevent-dev \
-            libgcrypt-dev \
+            libgcrypt20-dev \
             libglib2.0-dev \
             libkrb5-dev \
             libldap2-dev \


### PR DESCRIPTION
libgcrypt is an alias for libgcrypt20. Better use the actual name.