### PR TITLE
atalkd: Don't send NBP Reply packets from the loopback interface

### DIFF
--- a/etc/atalkd/nbp.c
+++ b/etc/atalkd/nbp.c
@@ -499,6 +499,11 @@ Can't find route's interface!" );
         /*FALL THROUGH*/
 
     case NBPOP_LKUP :
+        /* do not send replies from the loopback interface */
+        if (ap->ap_iface->i_flags & IFACE_LOOPBACK)
+        {
+            return 0;
+        }
         /* search our data */
         n = i = 0;
         data = packet + 1 + SZ_NBPHDR;


### PR DESCRIPTION
In Linux 6.9+, NBP Reply packets can appear to come from the loopback interface, which has an address of `0.0`. This address is invalid on Phase 2 AppleTalk networks and should never appear. One minor benefit is less traffic is generated when doing NBP Lookups. Fixes #1731 without breaking anything additional.