### PR TITLE
GitHub CI: Bump vmactions runner to OmniOS r151052

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -663,7 +663,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/omnios-vm@v1.0.8
+        uses: vmactions/omnios-vm@v1.0.9
         with:
           copyback: false
           prepare: |


### PR DESCRIPTION
The vmactions project has released a new upstream image for OmniOS.