### PR TITLE
Print unified version information for all AppleTalk daemons

### DIFF
--- a/contrib/a2boot/a2boot.c
+++ b/contrib/a2boot/a2boot.c
@@ -67,6 +67,7 @@ char	*bad = "Bad request!";
 char	buf[ 4624 ];
 char	*server;
 int32_t fileoff;
+static char	*version = VERSION;
 
 long a2bootreq(char *fname);
 
@@ -125,7 +126,7 @@ int main( int ac, char **av )
     }
     server = hostname;
 
-    while (( c = getopt( ac, av, "dn:" )) != EOF ) {
+    while (( c = getopt( ac, av, "dVvn:" )) != EOF ) {
 	switch ( c ) {
 	case 'd' :
 	    debug++;
@@ -133,6 +134,14 @@ int main( int ac, char **av )
 	case 'n' :
 	    server = optarg;
 	    break;
+    case 'V' :
+    case 'v' :
+        fprintf(stdout, "a2boot %s - Apple2 Netboot Daemon\n"
+               "Copyright (c) 1990,1992 Regents of The University of Michigan.\n"
+               "\tAll Rights Reserved.\n"
+               "Copyright (c) 1990, The University of Melbourne.\n", version );
+        exit ( 1 );
+        break;
 	default :
 	    fprintf( stderr, "Unknown option -- '%c'\n", c );
 	    usage( *av );

--- a/contrib/a2boot/meson.build
+++ b/contrib/a2boot/meson.build
@@ -6,6 +6,7 @@ a2boot_c_args = [
     + pkgconfdir
     + '/a2boot/Apple :2f:2fe Boot Blocks"',
     '-D_PATH_P16_IMAGE="' + pkgconfdir + '/a2boot/ProDOS16 Image"',
+    dversion,
 ]
 
 executable(

--- a/contrib/macipgw/main.c
+++ b/contrib/macipgw/main.c
@@ -18,6 +18,10 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/socket.h>
@@ -46,17 +50,10 @@
 #include "tunnel.h"
 #include "util.h"
 
-static char *version = "macipgw 1.1\n"
-    "Copyright (c) 1997 Stefan Bethke. All rights reserved.\n"
-    "Copyright (c) 1988, 1992, 1993\n"
-    "\tThe Regents of the University of California.  All rights reserved.\n"
-    "Copyright (c) 1990,1996 Regents of The University of Michigan.\n"
-    "\tAll Rights Reserved.\n"
-    "See the file COPYRIGHT for further information.\n";
-
 int atsocket;
 int tundev;
 int debug = 0;
+static char	*version = VERSION;
 
 static void die(int n)
 {
@@ -179,21 +176,27 @@ int main(int argc, char *argv[])
 
 	gDebug = 0;
 
-    while ((opt = getopt(argc, argv, "Vd:n:u:z:")) != -1) {
+    while ((opt = getopt(argc, argv, "Vvd:n:u:z:")) != -1) {
         switch (opt) {
 		case 'd':
 			gDebug = strtol(optarg, 0, 0);
 			break;
-
 		case 'n':
 			ns = atoip(optarg);
 			break;
-
 		case 'z':
 			zone = optarg;
-			break;
-		case 'V':
-			usage(version);
+            break;
+        case 'V':
+        case 'v':
+            fprintf(stdout, "macipgw %s - Mac IP Gateway Daemon\n"
+               "Copyright (c) 1997, 2013 Stefan Bethke. All rights reserved.\n"
+               "Copyright (c) 1988, 1992, 1993\n"
+               "\tThe Regents of the University of California.  All rights reserved.\n"
+               "Copyright (c) 1990, 1996 Regents of The University of Michigan.\n"
+               "\tAll Rights Reserved.\n"
+               "See the file COPYRIGHT for further information.\n", version);
+            exit(1);
 			break;
 		case 'u':
 			pwd = get_user(optarg);

--- a/contrib/macipgw/meson.build
+++ b/contrib/macipgw/meson.build
@@ -10,7 +10,7 @@ macipgw_sources = [
 
 macipgw_includes = include_directories('../../libatalk/atp')
 
-macipgw_c_args = ['-DSERVERTEXT="' + pkgconfdir + '/msg"']
+macipgw_c_args = ['-DSERVERTEXT="' + pkgconfdir + '/msg"', dversion]
 
 executable(
     'macipgw',

--- a/contrib/timelord/meson.build
+++ b/contrib/timelord/meson.build
@@ -3,6 +3,7 @@ executable(
     'timelord.c',
     include_directories: root_includes,
     link_with: libatalk,
+    c_args: dversion,
     install: true,
     install_dir: sbindir,
     build_rpath: rpath_libdir,

--- a/contrib/timelord/timelord.c
+++ b/contrib/timelord/timelord.c
@@ -60,6 +60,7 @@ int	debug = 0;
 char	*bad = "Bad request!";
 char	buf[ 4624 ];
 char	*server;
+static char	*version = VERSION;
 
 void usage( char *p )
 {
@@ -113,7 +114,7 @@ int main( int ac, char **av )
     }
     server = hostname;
 
-    while (( c = getopt( ac, av, "dln:" )) != EOF ) {
+    while (( c = getopt( ac, av, "dlVvn:" )) != EOF ) {
 	switch ( c ) {
 	case 'd' :
 	    debug++;
@@ -124,6 +125,14 @@ int main( int ac, char **av )
 	case 'n' :
 	    server = optarg;
 	    break;
+    case 'V' :
+    case 'v' :
+        fprintf(stdout, "timelord %s - Timelord Time Server Daemon\n"
+               "Copyright (c) 1990,1992 Regents of The University of Michigan.\n"
+               "\tAll Rights Reserved.\n"
+               "Copyright (c) 1990, The University of Melbourne.\n", version );
+        exit ( 1 );
+        break;
 	default :
 	    fprintf( stderr, "Unknown option -- '%c'\n", c );
 	    usage( *av );

--- a/doc/ja/manpages/man8/a2boot.8.xml
+++ b/doc/ja/manpages/man8/a2boot.8.xml
@@ -27,6 +27,8 @@
       <arg choice="opt">-d</arg>
 
       <arg choice="opt">-n <replaceable>nbpname</replaceable></arg>
+
+      <arg choice="opt">-v</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -77,6 +79,14 @@
         <listitem>
           <para>このサーバーを <emphasis remap="I">nbpname</emphasis>
           として登録します。デフォルトではホスト名になります。</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>-v</term>
+
+        <listitem>
+          <para>バージョン情報を出力して終了します。</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/doc/ja/manpages/man8/macipgw.8.xml
+++ b/doc/ja/manpages/man8/macipgw.8.xml
@@ -32,7 +32,7 @@
 
       <arg>-z <replaceable>zone</replaceable></arg>
 
-      <arg>-V</arg>
+      <arg>-v</arg>
 
       <arg choice="plain"><replaceable>network</replaceable></arg>
 
@@ -112,7 +112,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term>-V</term>
+        <term>-v</term>
 
         <listitem>
           <para>バージョン情報を表示して終了します。</para>

--- a/doc/ja/manpages/man8/papd.8.xml
+++ b/doc/ja/manpages/man8/papd.8.xml
@@ -37,6 +37,8 @@
       <arg>-p printcap</arg>
 
       <arg>-P pidfile</arg>
+
+      <arg>-v</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -108,6 +110,14 @@
 
         <listitem>
           <para><command>papd</command> がプロセス ID を保存するファイルを指定します。</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>-v</term>
+
+        <listitem>
+          <para>バージョン情報を出力して終了します。</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/doc/ja/manpages/man8/timelord.8.xml
+++ b/doc/ja/manpages/man8/timelord.8.xml
@@ -29,6 +29,8 @@
       <arg choice="opt">-l</arg>
 
       <arg choice="opt">-n <replaceable>nbpname</replaceable></arg>
+
+      <arg choice="opt">-v</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -73,6 +75,14 @@
         <listitem>
           <para>このサーバーを <emphasis remap="I">nbpname</emphasis>
           として登録します。デフォルトではホスト名になります。</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>-v</term>
+
+        <listitem>
+          <para>バージョン情報を出力して終了します。</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/doc/manpages/man8/a2boot.8.xml
+++ b/doc/manpages/man8/a2boot.8.xml
@@ -25,6 +25,8 @@
       <arg choice="opt">-d</arg>
 
       <arg choice="opt">-n <replaceable>nbpname</replaceable></arg>
+
+      <arg choice="opt">-v</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -78,6 +80,14 @@
         <listitem>
           <para>Register this server as <emphasis
           remap="I">nbpname</emphasis>. This defaults to the hostname.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>-v</term>
+
+        <listitem>
+          <para>Print version information and exit.</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/doc/manpages/man8/macipgw.8.xml
+++ b/doc/manpages/man8/macipgw.8.xml
@@ -32,7 +32,7 @@
 
       <arg>-z <replaceable>zone</replaceable></arg>
 
-      <arg>-V</arg>
+      <arg>-v</arg>
 
       <arg choice="plain"><replaceable>network</replaceable></arg>
 
@@ -118,7 +118,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term>-V</term>
+        <term>-v</term>
 
         <listitem>
           <para>Show version information and exit.</para>

--- a/doc/manpages/man8/papd.8.xml
+++ b/doc/manpages/man8/papd.8.xml
@@ -35,6 +35,8 @@
       <arg>-p printcap</arg>
 
       <arg>-P pidfile</arg>
+
+      <arg>-v</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -114,6 +116,14 @@
         <listitem>
           <para>Specifies the file in which <command>papd</command> stores its
           process id.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>-v</term>
+
+        <listitem>
+          <para>Print version information and exit.</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/doc/manpages/man8/timelord.8.xml
+++ b/doc/manpages/man8/timelord.8.xml
@@ -27,6 +27,8 @@
       <arg choice="opt">-l</arg>
 
       <arg choice="opt">-n <replaceable>nbpname</replaceable></arg>
+
+      <arg choice="opt">-v</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -74,6 +76,14 @@
         <listitem>
           <para>Register this server as <emphasis
           remap="I">nbpname</emphasis>. This defaults to the hostname.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>-v</term>
+
+        <listitem>
+          <para>Print version information and exit.</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -818,7 +818,7 @@ int main( int ac, char **av)
     socklen_t 		fromlen;
     char		*prog;
 
-    while (( c = getopt( ac, av, "12df:P:tv" )) != EOF ) {
+    while (( c = getopt( ac, av, "12dtVvf:P:" )) != EOF ) {
 	switch ( c ) {
 	case '1' :
 	    defphase = IFACE_PHASE1;
@@ -844,8 +844,9 @@ int main( int ac, char **av)
 	    transition++;
 	    break;
 
+	case 'V' :
 	case 'v' :	/* version */
-	    printf( "atalkd (version %s)\n", version );
+	    printf( "atalkd %s - AppleTalk Network Manager Daemon\n", version );
 	    exit ( 1 );
 	    break;
 

--- a/etc/papd/main.c
+++ b/etc/papd/main.c
@@ -4,7 +4,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif /* HAVE_CONFIG_H */
 
 #include <string.h>
@@ -203,7 +203,7 @@ int main(int ac, char **av)
     defprinter.p_pagecost_msg = NULL;
     defprinter.p_lock = "lock";
 
-    while (( c = getopt( ac, av, "adf:p:P:v" )) != EOF ) {
+    while (( c = getopt( ac, av, "adVvf:p:P:" )) != EOF ) {
 	switch ( c ) {
 	case 'a' :		/* for compatibility with old papd */
 	    break;
@@ -224,8 +224,9 @@ int main(int ac, char **av)
 	    pidfile = optarg;
 	    break;
 
+	case 'V' :
 	case 'v' :		/* version */
-	    printf( "papd (version %s)\n", VERSION );
+	    printf( "papd %s - Printer Access Protocol Daemon\n", version );
 	    exit ( 1 );
 	    break;
 


### PR DESCRIPTION
For atalkd, papd, a2boot, macipgw, timelord: Add a -v/-V flag that prints version number and short description of the daemon. And for the daemons under contrib/ with code that originate outside of Netatalk, print also the COPYRIGHT information.

Note that -v and -V have the same effect for these daemons, with no extra verbose mode implemented. macipgw was using the latter for normal version output, while the former is common for all other daemons in Netatalk. I'm enabling both for backwards compatibility, but only documenting the former.