### PR TITLE
Include config.h by relative path consistently

### DIFF
--- a/etc/netatalk/afp_avahi.c
+++ b/etc/netatalk/afp_avahi.c
@@ -6,7 +6,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #ifdef HAVE_AVAHI

--- a/etc/netatalk/afp_mdns.c
+++ b/etc/netatalk/afp_mdns.c
@@ -6,7 +6,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #ifdef HAVE_MDNS

--- a/etc/netatalk/afp_zeroconf.c
+++ b/etc/netatalk/afp_zeroconf.c
@@ -8,7 +8,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #include "afp_zeroconf.h"

--- a/etc/uams/uams_passwd.c
+++ b/etc/uams/uams_passwd.c
@@ -5,7 +5,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif /* HAVE_CONFIG_H */
 
 #include <arpa/inet.h>

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -30,7 +30,7 @@
 #define _ATALK_ADOUBLE_H
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #include <fcntl.h>

--- a/include/atalk/bstradd.h
+++ b/include/atalk/bstradd.h
@@ -21,7 +21,7 @@
 #define ATALK_BSTRADD_H
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #include <atalk/bstrlib.h>

--- a/include/atalk/ea.h
+++ b/include/atalk/ea.h
@@ -16,7 +16,7 @@
 #define ATALK_EA_H
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #if HAVE_ATTR_XATTR_H

--- a/include/atalk/rpc.h
+++ b/include/atalk/rpc.h
@@ -7,7 +7,7 @@
 #define ATALK_RPC_H
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #include <sys/types.h>

--- a/include/atalk/unix.h
+++ b/include/atalk/unix.h
@@ -16,7 +16,7 @@
 #define ATALK_UNIX_H
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #include <dirent.h>

--- a/libatalk/adouble/ad_flush.c
+++ b/libatalk/adouble/ad_flush.c
@@ -23,7 +23,7 @@
  */
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif /* HAVE_CONFIG_H */
 
 #include <arpa/inet.h>

--- a/test/testsuite/compat.h
+++ b/test/testsuite/compat.h
@@ -16,7 +16,7 @@
 #define ATALK_COMPAT_H
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #ifndef HAVE_STRLCPY

--- a/test/testsuite/ea.h
+++ b/test/testsuite/ea.h
@@ -16,7 +16,7 @@
 #define ATALK_EA_H
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #if HAVE_ATTR_XATTR_H

--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -5,7 +5,7 @@
 #define SPECS_H
 
 #ifdef HAVE_CONFIG_H
-#include <config.h>
+#include "config.h"
 #endif
 
 #include <signal.h>


### PR DESCRIPTION
Including C headers by greater than / less than implies an include path relative to standard library location on the system. Our config.h is a local file in our build dir hence the use of quotation marks is appropriate.