### PR TITLE
Remove duplicate header includes in MySQL CNID backend

### DIFF
--- a/libatalk/cnid/mysql/cnid_mysql.c
+++ b/libatalk/cnid/mysql/cnid_mysql.c
@@ -10,12 +10,9 @@
 #undef _FORTIFY_SOURCE
 
 #include <arpa/inet.h>
-#include <arpa/inet.h>
-#include <errno.h>
 #include <errno.h>
 #include <net/if.h>
 #include <netdb.h>
-#include <netinet/in.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <stdlib.h>


### PR DESCRIPTION
...revealed when sorting the headers alphabetically...