### PR TITLE
Limit versions reported by FPGetSrvrInfo Over DSI

### DIFF
--- a/etc/afpd/status.c
+++ b/etc/afpd/status.c
@@ -499,7 +499,7 @@ void status_init(AFPObj *dsi_obj, AFPObj* asp_obj, DSI *dsi)
     status_machine(status);
     status_versions(status,
 #ifndef NO_DDP
-                    asp,
+                    NULL,
 #endif
                     dsi);
     status_uams(status, options->uamlist);


### PR DESCRIPTION
Refer to #1661. Turns out that AppleShare Client 3.7.4 suffers from the 512 byte packet limit bug, including when receiving responses over DSI. Being that this is the only officially supported version with AFP-over-TCP for System 7 clients, it is important that this is fixed.

This change limits Netatalk to replying with AFP versions 2.2 to 3.4 to DSI clients, which poses no compatibility issues as there are technically no TCP/IP clients supporting the older versions.

The only exception to this is the AFPBridge control panel for GS/OS, which identifies as AFPVersion2.0 by default. This TCP/IP client has been tested and still works fine even with this change.