### PR TITLE
Fix "ad find" utility regression.

### DIFF
--- a/bin/ad/ad_find.c
+++ b/bin/ad/ad_find.c
@@ -117,8 +117,8 @@ int ad_find(int argc, char **argv, AFPObj *obj)
 
     uint16_t flags = CONV_TOLOWER;
     char namebuf[MAXPATHLEN + 1];
-    if (convert_charset(vol.vol->v_volcharset,
-                        vol.vol->v_volcharset,
+    if (convert_charset(CH_UNIX,
+                        CH_UNIX,
                         vol.vol->v_maccharset,
                         argv[optind],
                         strlen(argv[optind]),


### PR DESCRIPTION
Sometime after the switch to the INI based configuration in Netatalk 3.0, the `ad find` utility broke. Currently it only works if one enters only lowercase letters and strings of two characters or more. Otherwise it either returns no results or errors out.