### PR TITLE
webmin: Properly install netatalk-lib.pl that had fallen off recently

### DIFF
--- a/contrib/webmin_module/meson.build
+++ b/contrib/webmin_module/meson.build
@@ -9,6 +9,7 @@ webmin_files = [
     'edit_print.cgi',
     'edit_vol_section.cgi',
     'index.cgi',
+    'netatalk-lib.pl',
     'README.md',
     'save_atalk.cgi',
     'save_global_section.cgi',


### PR DESCRIPTION
The netatalk-lib.pl file had fallen off the install manifest. If you were overwriting an existing module it worked, but when installing from scratch the module was (obviously) broken.