### PR TITLE
docs: Document afppasswd -w option in the man page synopsis

### DIFF
--- a/doc/ja/manpages/man1/afpldaptest.1.xml
+++ b/doc/ja/manpages/man1/afpldaptest.1.xml
@@ -24,24 +24,24 @@
     <cmdsynopsis>
       <command>afpldaptest</command>
 
-      <group choice="req">
-        <arg choice="plain">-u <replaceable>USER</replaceable></arg>
+      <group>
+        <arg>-u <replaceable>USER</replaceable></arg>
 
-        <arg choice="plain">-g <replaceable>GROUP</replaceable></arg>
+        <arg>-g <replaceable>GROUP</replaceable></arg>
 
-        <arg choice="plain">-i <replaceable>UUID</replaceable></arg>
+        <arg>-i <replaceable>UUID</replaceable></arg>
       </group>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>afpldaptest</command>
 
-      <group choice="req">
-        <arg choice="plain">-h</arg>
+      <group>
+        <arg>-h</arg>
 
-        <arg choice="plain">-?</arg>
+        <arg>-?</arg>
 
-        <arg choice="plain">-:</arg>
+        <arg>-:</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man1/afppasswd.1.xml
+++ b/doc/ja/manpages/man1/afppasswd.1.xml
@@ -24,17 +24,13 @@
     <cmdsynopsis>
       <command>afppasswd</command>
 
-      <arg choice="opt">-acfn</arg>
+      <arg>-acfn</arg>
 
-      <arg choice="opt"><arg choice="plain">-p
-      <replaceable>afppasswdファイル</replaceable></arg></arg>
+      <arg>-p <replaceable>afppasswdファイル</replaceable></arg>
 
-      <arg choice="opt"><arg choice="plain">-u
-      <replaceable>minimum</replaceable></arg><arg
-      choice="plain"><replaceable>uid</replaceable></arg></arg>
+      <arg>-u <replaceable>最低限 uid</replaceable></arg>
 
-      <arg choice="opt"><arg choice="plain">-w
-      <replaceable>パスワード文字列</replaceable></arg></arg>
+      <arg>-w <replaceable>パスワード文字列</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/ja/manpages/man1/afppasswd.1.xml
+++ b/doc/ja/manpages/man1/afppasswd.1.xml
@@ -27,12 +27,14 @@
       <arg choice="opt">-acfn</arg>
 
       <arg choice="opt"><arg choice="plain">-p
-      <replaceable>passwd</replaceable></arg><arg
-      choice="plain"><replaceable>file</replaceable></arg></arg>
+      <replaceable>afppasswdファイル</replaceable></arg></arg>
 
       <arg choice="opt"><arg choice="plain">-u
       <replaceable>minimum</replaceable></arg><arg
       choice="plain"><replaceable>uid</replaceable></arg></arg>
+
+      <arg choice="opt"><arg choice="plain">-w
+      <replaceable>パスワード文字列</replaceable></arg></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -119,7 +121,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>-w</option><replaceable> 文字列</replaceable></term>
+        <term><option>-w</option><replaceable> パスワード文字列</replaceable></term>
 
         <listitem>
           <para>パスワードを対話形式で入力するのではなく、文字列をパスワードとして使用する。

--- a/doc/ja/manpages/man1/apple_dump.1.xml
+++ b/doc/ja/manpages/man1/apple_dump.1.xml
@@ -24,64 +24,64 @@
     <cmdsynopsis>
       <command>apple_dump</command>
 
-      <arg choice="opt"><arg choice="plain">-a</arg></arg>
+      <arg><arg>-a</arg></arg>
 
-      <group choice="opt">
-        <arg choice="plain"><replaceable>FILE</replaceable></arg>
+      <group>
+        <arg><replaceable>FILE</replaceable></arg>
 
-        <arg choice="plain"><replaceable>DIR</replaceable></arg>
+        <arg><replaceable>DIR</replaceable></arg>
       </group>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>apple_dump</command>
 
-      <arg choice="plain">-e</arg>
+      <arg>-e</arg>
 
-      <group choice="plain">
-        <arg choice="plain"><replaceable>FILE</replaceable></arg>
+      <group>
+        <arg><replaceable>FILE</replaceable></arg>
 
-        <arg choice="plain"><replaceable>DIR</replaceable></arg>
+        <arg><replaceable>DIR</replaceable></arg>
       </group>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>apple_dump</command>
 
-      <arg choice="plain">-f</arg>
+      <arg>-f</arg>
 
-      <arg choice="opt"><replaceable>FILE</replaceable></arg>
+      <arg><replaceable>FILE</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>apple_dump</command>
 
-      <arg choice="plain">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt"><replaceable>FILE</replaceable></arg>
+      <arg><replaceable>FILE</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>apple_dump</command>
 
-      <group choice="plain">
-        <arg choice="plain">-h</arg>
+      <group>
+        <arg>-h</arg>
 
-        <arg choice="plain">-help</arg>
+        <arg>-help</arg>
 
-        <arg choice="plain">--help</arg>
+        <arg>--help</arg>
       </group>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>apple_dump</command>
 
-      <group choice="plain">
-        <arg choice="plain">-v</arg>
+      <group>
+        <arg>-v</arg>
 
-        <arg choice="plain">-version</arg>
+        <arg>-version</arg>
 
-        <arg choice="plain">--version</arg>
+        <arg>--version</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man1/asip-status.1.xml
+++ b/doc/ja/manpages/man1/asip-status.1.xml
@@ -24,51 +24,52 @@
     <cmdsynopsis>
       <command>asip-status</command>
 
-      <group choice="opt">
-        <arg choice="plain">-4</arg>
+      <group>
+        <arg>-4</arg>
 
-        <arg choice="plain">-6</arg>
+        <arg>-6</arg>
       </group>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt">-i</arg>
+      <arg>-i</arg>
 
-      <arg choice="opt">-x</arg>
+      <arg>-x</arg>
 
-      <arg choice="plain"><replaceable>HOSTNAME</replaceable></arg>
+      <arg><replaceable>HOSTNAME</replaceable></arg>
 
-      <arg choice="opt"><replaceable>PORT</replaceable></arg>
+      <arg><replaceable>PORT</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>asip-status</command>
 
-      <group choice="opt">
-        <arg choice="plain">-4</arg>
+      <group>
+        <arg>-4</arg>
 
-        <arg choice="plain">-6</arg>
+        <arg>-6</arg>
       </group>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt">-i</arg>
+      <arg>-i</arg>
 
-      <arg choice="opt">-x</arg>
+      <arg>-x</arg>
 
-      <arg
-      choice="plain"><replaceable>HOSTNAME</replaceable>:<replaceable>PORT</replaceable></arg>
+      <arg>
+        <replaceable>HOSTNAME</replaceable>:<replaceable>PORT</replaceable>
+      </arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>asip-status</command>
 
-      <group choice="plain">
-        <arg choice="plain">-v</arg>
+      <group>
+        <arg>-v</arg>
 
-        <arg choice="plain">-version</arg>
+        <arg>-version</arg>
 
-        <arg choice="plain">--version</arg>
+        <arg>--version</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man1/dbd.1.xml
+++ b/doc/ja/manpages/man1/dbd.1.xml
@@ -24,9 +24,9 @@
     <cmdsynopsis>
       <command>dbd</command>
 
-      <arg choice="opt">-cfFstuvV</arg>
+      <arg>-cfFstuvV</arg>
 
-      <arg choice="plain"><replaceable>volumepath</replaceable></arg>
+      <arg><replaceable>volumepath</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/ja/manpages/man1/getzones.1.xml
+++ b/doc/ja/manpages/man1/getzones.1.xml
@@ -26,13 +26,13 @@
           <primary>getzones</primary>
         </indexterm></command>
 
-      <group choice="opt">
-        <arg choice="plain">-m</arg>
+      <group>
+        <arg>-m</arg>
 
-        <arg choice="plain">-l</arg>
+        <arg>-l</arg>
       </group>
 
-      <arg choice="opt"><replaceable>address</replaceable></arg>
+      <arg><replaceable>address</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/ja/manpages/man1/macusers.1.xml
+++ b/doc/ja/manpages/man1/macusers.1.xml
@@ -28,18 +28,18 @@
     <cmdsynopsis>
       <command>macusers</command>
 
-      <group choice="plain">
-        <arg choice="plain">-v</arg>
+      <group>
+        <arg>-v</arg>
 
-        <arg choice="plain">-version</arg>
+        <arg>-version</arg>
 
-        <arg choice="plain">--version</arg>
+        <arg>--version</arg>
 
-        <arg choice="plain">-h</arg>
+        <arg>-h</arg>
 
-        <arg choice="plain">-help</arg>
+        <arg>-help</arg>
 
-        <arg choice="plain">--help</arg>
+        <arg>--help</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man1/nbp.1.xml
+++ b/doc/ja/manpages/man1/nbp.1.xml
@@ -40,7 +40,7 @@
 
       <arg>-m <replaceable>maccodepage</replaceable></arg>
 
-      <arg choice="plain"><replaceable>nbpname</replaceable></arg>
+      <arg><replaceable>nbpname</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
@@ -54,7 +54,7 @@
 
       <arg>-m <replaceable>maccodepage</replaceable></arg>
 
-      <arg choice="plain"><replaceable>nbpname</replaceable></arg>
+      <arg><replaceable>nbpname</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
@@ -66,7 +66,7 @@
 
       <arg>-m <replaceable>maccodepage</replaceable></arg>
 
-      <arg choice="plain"><replaceable>nbpname</replaceable></arg>
+      <arg><replaceable>nbpname</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/ja/manpages/man1/pap.1.xml
+++ b/doc/ja/manpages/man1/pap.1.xml
@@ -26,28 +26,25 @@
           <primary>pap</primary>
         </indexterm></command>
 
-      <arg choice="opt"><arg choice="plain">-A </arg><arg
-      choice="plain"><replaceable>address</replaceable></arg></arg>
+      <arg>-A <replaceable>address</replaceable></arg>
 
-      <arg choice="opt">-c</arg>
+      <arg>-c</arg>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt">-e</arg>
+      <arg>-e</arg>
 
-      <arg choice="opt">-E</arg>
+      <arg>-E</arg>
 
-      <arg choice="opt"><arg choice="plain">-p </arg><arg
-      choice="plain"><replaceable>nbpname</replaceable></arg></arg>
+      <arg>-p <replaceable>nbpname</replaceable></arg>
 
-      <arg choice="opt"><arg choice="plain">-s </arg><arg
-      choice="plain"><replaceable>statusfile</replaceable></arg></arg>
+      <arg>-s <replaceable>statusfile</replaceable></arg>
 
-      <arg choice="opt">-w</arg>
+      <arg>-w</arg>
 
-      <arg choice="opt">-W</arg>
+      <arg>-W</arg>
 
-      <arg choice="opt"><replaceable>FILES</replaceable></arg>
+      <arg><replaceable>FILES</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/ja/manpages/man8/a2boot.8.xml
+++ b/doc/ja/manpages/man8/a2boot.8.xml
@@ -24,11 +24,11 @@
     <cmdsynopsis>
       <command>a2boot</command>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt">-n <replaceable>nbpname</replaceable></arg>
+      <arg>-n <replaceable>nbpname</replaceable></arg>
 
-      <arg choice="opt">-v</arg>
+      <arg>-v</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/ja/manpages/man8/afpd.8.xml
+++ b/doc/ja/manpages/man8/afpd.8.xml
@@ -24,20 +24,20 @@
     <cmdsynopsis>
       <command>afpd</command>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt">-F <replaceable>configfile</replaceable></arg>
+      <arg>-F <replaceable>configfile</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>afpd</command>
 
-      <group choice="plain">
-        <arg choice="plain">-v</arg>
+      <group>
+        <arg>-v</arg>
 
-        <arg choice="plain">-V</arg>
+        <arg>-V</arg>
 
-        <arg choice="plain">-h</arg>
+        <arg>-h</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man8/cnid_dbd.8.xml
+++ b/doc/ja/manpages/man8/cnid_dbd.8.xml
@@ -28,10 +28,10 @@
     <cmdsynopsis>
       <command>cnid_dbd</command>
 
-      <group choice="plain">
-        <arg choice="plain">-v</arg>
+      <group>
+        <arg>-v</arg>
 
-        <arg choice="plain">-V</arg>
+        <arg>-V</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man8/cnid_metad.8.xml
+++ b/doc/ja/manpages/man8/cnid_metad.8.xml
@@ -25,19 +25,18 @@
     <cmdsynopsis>
       <command>cnid_metad</command>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt"><arg choice="plain">-F </arg><arg
-      choice="plain"><replaceable>configuration file</replaceable></arg></arg>
+      <arg>-F <replaceable>configuration file</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>cnid_metad</command>
 
-      <group choice="plain">
-        <arg choice="plain">-v</arg>
+      <group>
+        <arg>-v</arg>
 
-        <arg choice="plain">-V</arg>
+        <arg>-V</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man8/macipgw.8.xml
+++ b/doc/ja/manpages/man8/macipgw.8.xml
@@ -34,9 +34,9 @@
 
       <arg>-v</arg>
 
-      <arg choice="plain"><replaceable>network</replaceable></arg>
+      <arg><replaceable>network</replaceable></arg>
 
-      <arg choice="plain"><replaceable>netmask</replaceable></arg>
+      <arg><replaceable>netmask</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/ja/manpages/man8/netatalk.8.xml
+++ b/doc/ja/manpages/man8/netatalk.8.xml
@@ -24,16 +24,16 @@
     <cmdsynopsis>
       <command>netatalk</command>
 
-      <arg choice="opt">-F <replaceable>configfile</replaceable></arg>
+      <arg>-F <replaceable>configfile</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>netatalk</command>
 
-      <group choice="plain">
-        <arg choice="plain">-v</arg>
+      <group>
+        <arg>-v</arg>
 
-        <arg choice="plain">-V</arg>
+        <arg>-V</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man8/papd.8.xml
+++ b/doc/ja/manpages/man8/papd.8.xml
@@ -32,11 +32,11 @@
 
       <arg>-d</arg>
 
-      <arg>-f configfile</arg>
+      <arg>-f <replaceable>configfile</replaceable></arg>
 
-      <arg>-p printcap</arg>
+      <arg>-p <replaceable>printcap</replaceable></arg>
 
-      <arg>-P pidfile</arg>
+      <arg>-P <replaceable>pidfile</replaceable></arg>
 
       <arg>-v</arg>
     </cmdsynopsis>

--- a/doc/ja/manpages/man8/papstatus.8.xml
+++ b/doc/ja/manpages/man8/papstatus.8.xml
@@ -26,12 +26,11 @@
           <primary>papstatus</primary>
         </indexterm></command>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt"><arg choice="plain">-p </arg><arg
-      choice="plain"><replaceable>printer</replaceable></arg></arg>
+      <arg>-p <replaceable>printer</replaceable></arg>
 
-      <arg choice="opt"><replaceable>retrytime</replaceable></arg>
+      <arg><replaceable>retrytime</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/ja/manpages/man8/timelord.8.xml
+++ b/doc/ja/manpages/man8/timelord.8.xml
@@ -24,13 +24,13 @@
     <cmdsynopsis>
       <command>timelord</command>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt">-l</arg>
+      <arg>-l</arg>
 
-      <arg choice="opt">-n <replaceable>nbpname</replaceable></arg>
+      <arg>-n <replaceable>nbpname</replaceable></arg>
 
-      <arg choice="opt">-v</arg>
+      <arg>-v</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/manpages/man1/afpldaptest.1.xml
+++ b/doc/manpages/man1/afpldaptest.1.xml
@@ -22,20 +22,20 @@
     <cmdsynopsis>
       <command>afpldaptest</command>
 
-      <group choice="req">
-        <arg choice="plain">-u <replaceable>USER</replaceable></arg>
-        <arg choice="plain">-g <replaceable>GROUP</replaceable></arg>
-        <arg choice="plain">-i <replaceable>UUID</replaceable></arg>
+      <group>
+        <arg>-u <replaceable>USER</replaceable></arg>
+        <arg>-g <replaceable>GROUP</replaceable></arg>
+        <arg>-i <replaceable>UUID</replaceable></arg>
       </group>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>afpldaptest</command>
 
-      <group choice="req">
-        <arg choice="plain">-h</arg>
-        <arg choice="plain">-?</arg>
-        <arg choice="plain">-:</arg>
+      <group>
+        <arg>-h</arg>
+        <arg>-?</arg>
+        <arg>-:</arg>
       </group>
 
     </cmdsynopsis>

--- a/doc/manpages/man1/afppasswd.1.xml
+++ b/doc/manpages/man1/afppasswd.1.xml
@@ -26,12 +26,16 @@
       <arg choice="opt">-acfn</arg>
 
       <arg choice="opt"><arg choice="plain">-p
-      <replaceable>passwd</replaceable></arg><arg
+      <replaceable>afppasswd</replaceable></arg><arg
       choice="plain"><replaceable>file</replaceable></arg></arg>
 
       <arg choice="opt"><arg choice="plain">-u
       <replaceable>minimum</replaceable></arg><arg
       choice="plain"><replaceable>uid</replaceable></arg></arg>
+
+      <arg choice="opt"><arg choice="plain">-w
+      <replaceable>password</replaceable></arg><arg
+      choice="plain"><replaceable>string</replaceable></arg></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -127,12 +131,12 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>-w</option><replaceable> string</replaceable></term>
+        <term><option>-w</option><replaceable> password string</replaceable></term>
 
         <listitem>
           <para>Use string as password, instead of typing it interactively.
           Please use this option only if absolutely necessary, since the
-          password will remain in the terminal history in plain text.</para>
+          password may remain in the terminal history in plain text.</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/doc/manpages/man1/afppasswd.1.xml
+++ b/doc/manpages/man1/afppasswd.1.xml
@@ -23,19 +23,13 @@
     <cmdsynopsis>
       <command>afppasswd</command>
 
-      <arg choice="opt">-acfn</arg>
+      <arg>-acfn</arg>
 
-      <arg choice="opt"><arg choice="plain">-p
-      <replaceable>afppasswd</replaceable></arg><arg
-      choice="plain"><replaceable>file</replaceable></arg></arg>
+      <arg>-p <replaceable>afppasswd file</replaceable></arg>
 
-      <arg choice="opt"><arg choice="plain">-u
-      <replaceable>minimum</replaceable></arg><arg
-      choice="plain"><replaceable>uid</replaceable></arg></arg>
+      <arg>-u <replaceable>minimum uid</replaceable></arg>
 
-      <arg choice="opt"><arg choice="plain">-w
-      <replaceable>password</replaceable></arg><arg
-      choice="plain"><replaceable>string</replaceable></arg></arg>
+      <arg>-w <replaceable>password string</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/manpages/man1/apple_dump.1.xml
+++ b/doc/manpages/man1/apple_dump.1.xml
@@ -21,58 +21,58 @@
     <cmdsynopsis>
       <command>apple_dump</command>
 
-      <arg choice="opt"><arg choice="plain">-a</arg></arg>
+      <arg>-a</arg>
 
-      <group choice="opt">
-        <arg choice="plain"><replaceable>FILE</replaceable></arg>
-        <arg choice="plain"><replaceable>DIR</replaceable></arg>
+      <group>
+        <arg><replaceable>FILE</replaceable></arg>
+        <arg><replaceable>DIR</replaceable></arg>
       </group>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>apple_dump</command>
 
-      <arg choice="plain">-e</arg>
+      <arg>-e</arg>
 
-      <group choice="plain">
-        <arg choice="plain"><replaceable>FILE</replaceable></arg>
-        <arg choice="plain"><replaceable>DIR</replaceable></arg>
+      <group>
+        <arg><replaceable>FILE</replaceable></arg>
+        <arg><replaceable>DIR</replaceable></arg>
       </group>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>apple_dump</command>
 
-      <arg choice="plain">-f</arg>
+      <arg>-f</arg>
 
-      <arg choice="opt"><replaceable>FILE</replaceable></arg>
+      <arg><replaceable>FILE</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>apple_dump</command>
 
-      <arg choice="plain">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt"><replaceable>FILE</replaceable></arg>
+      <arg><replaceable>FILE</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>apple_dump</command>
 
-      <group choice="plain">
-        <arg choice="plain">-h</arg>
-        <arg choice="plain">-help</arg>
-        <arg choice="plain">--help</arg>
+      <group>
+        <arg>-h</arg>
+        <arg>-help</arg>
+        <arg>--help</arg>
       </group>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>apple_dump</command>
 
-      <group choice="plain">
-        <arg choice="plain">-v</arg>
-        <arg choice="plain">-version</arg>
-        <arg choice="plain">--version</arg>
+      <group>
+        <arg>-v</arg>
+        <arg>-version</arg>
+        <arg>--version</arg>
       </group>
 
     </cmdsynopsis>

--- a/doc/manpages/man1/asip-status.1.xml
+++ b/doc/manpages/man1/asip-status.1.xml
@@ -24,51 +24,52 @@
     <cmdsynopsis>
       <command>asip-status</command>
 
-      <group choice="opt">
-        <arg choice="plain">-4</arg>
+      <group>
+        <arg>-4</arg>
 
-        <arg choice="plain">-6</arg>
+        <arg>-6</arg>
       </group>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt">-i</arg>
+      <arg>-i</arg>
 
-      <arg choice="opt">-x</arg>
+      <arg>-x</arg>
 
-      <arg choice="plain"><replaceable>HOSTNAME</replaceable></arg>
+      <arg><replaceable>HOSTNAME</replaceable></arg>
 
-      <arg choice="opt"><replaceable>PORT</replaceable></arg>
+      <arg><replaceable>PORT</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>asip-status</command>
 
-      <group choice="opt">
-        <arg choice="plain">-4</arg>
+      <group>
+        <arg>-4</arg>
 
-        <arg choice="plain">-6</arg>
+        <arg>-6</arg>
       </group>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt">-i</arg>
+      <arg>-i</arg>
 
-      <arg choice="opt">-x</arg>
+      <arg>-x</arg>
 
-      <arg
-      choice="plain"><replaceable>HOSTNAME</replaceable>:<replaceable>PORT</replaceable></arg>
+      <arg>
+        <replaceable>HOSTNAME</replaceable>:<replaceable>PORT</replaceable>
+      </arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>asip-status</command>
 
-      <group choice="plain">
-        <arg choice="plain">-v</arg>
+      <group>
+        <arg>-v</arg>
 
-        <arg choice="plain">-version</arg>
+        <arg>-version</arg>
 
-        <arg choice="plain">--version</arg>
+        <arg>--version</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/manpages/man1/dbd.1.xml
+++ b/doc/manpages/man1/dbd.1.xml
@@ -22,9 +22,15 @@
     <cmdsynopsis>
       <command>dbd</command>
 
-      <arg choice="opt">-cfFstuvV</arg>
+      <arg>-cfFstuvV</arg>
 
-      <arg choice="plain"><replaceable>volumepath</replaceable></arg>
+      <arg><replaceable>volumepath</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>dbd</command>
+
+      <arg>-V</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/manpages/man1/getzones.1.xml
+++ b/doc/manpages/man1/getzones.1.xml
@@ -22,13 +22,13 @@
     <cmdsynopsis>
       <command>getzones<indexterm><primary>getzones</primary></indexterm></command>
 
-      <group choice="opt">
-        <arg choice="plain">-m</arg>
+      <group>
+        <arg>-m</arg>
 
-        <arg choice="plain">-l</arg>
+        <arg>-l</arg>
       </group>
 
-      <arg choice="opt"><replaceable>address</replaceable></arg>
+      <arg><replaceable>address</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/manpages/man1/macusers.1.xml
+++ b/doc/manpages/man1/macusers.1.xml
@@ -26,13 +26,13 @@
     <cmdsynopsis>
       <command>macusers</command>
 
-      <group choice="plain">
-        <arg choice="plain">-v</arg>
-        <arg choice="plain">-version</arg>
-        <arg choice="plain">--version</arg>
-        <arg choice="plain">-h</arg>
-        <arg choice="plain">-help</arg>
-        <arg choice="plain">--help</arg>
+      <group>
+        <arg>-v</arg>
+        <arg>-version</arg>
+        <arg>--version</arg>
+        <arg>-h</arg>
+        <arg>-help</arg>
+        <arg>--help</arg>
       </group>
 
     </cmdsynopsis>

--- a/doc/manpages/man1/nbp.1.xml
+++ b/doc/manpages/man1/nbp.1.xml
@@ -34,7 +34,7 @@
 
       <arg>-m <replaceable>maccodepage</replaceable></arg>
 
-      <arg choice="plain"><replaceable>nbpname</replaceable></arg>
+      <arg><replaceable>nbpname</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
@@ -46,7 +46,7 @@
 
       <arg>-m <replaceable>maccodepage</replaceable></arg>
 
-      <arg choice="plain"><replaceable>nbpname</replaceable></arg>
+      <arg><replaceable>nbpname</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
@@ -56,7 +56,7 @@
 
       <arg>-m <replaceable>maccodepage</replaceable></arg>
 
-      <arg choice="plain"><replaceable>nbpname</replaceable></arg>
+      <arg><replaceable>nbpname</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/manpages/man1/pap.1.xml
+++ b/doc/manpages/man1/pap.1.xml
@@ -23,25 +23,25 @@
     <cmdsynopsis>
       <command>pap<indexterm><primary>pap</primary></indexterm></command>
 
-      <arg choice="opt"><arg choice="plain">-A </arg><arg choice="plain"><replaceable>address</replaceable></arg></arg>
+      <arg>-A <replaceable>address</replaceable></arg>
 
-      <arg choice="opt">-c</arg>
+      <arg>-c</arg>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt">-e</arg>
+      <arg>-e</arg>
 
-      <arg choice="opt">-E</arg>
+      <arg>-E</arg>
 
-      <arg choice="opt"><arg choice="plain">-p </arg><arg choice="plain"><replaceable>nbpname</replaceable></arg></arg>
+      <arg>-p <replaceable>nbpname</replaceable></arg>
 
-      <arg choice="opt"><arg choice="plain">-s </arg><arg choice="plain"><replaceable>statusfile</replaceable></arg></arg>
+      <arg>-s <replaceable>statusfile</replaceable></arg>
 
-      <arg choice="opt">-w</arg>
+      <arg>-w</arg>
 
-      <arg choice="opt">-W</arg>
+      <arg>-W</arg>
 
-      <arg choice="opt"><replaceable>FILES</replaceable></arg>
+      <arg><replaceable>FILES</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/manpages/man8/a2boot.8.xml
+++ b/doc/manpages/man8/a2boot.8.xml
@@ -22,11 +22,15 @@
     <cmdsynopsis>
       <command>a2boot</command>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt">-n <replaceable>nbpname</replaceable></arg>
+      <arg>-n <replaceable>nbpname</replaceable></arg>
+    </cmdsynopsis>
 
-      <arg choice="opt">-v</arg>
+    <cmdsynopsis>
+      <command>a2boot</command>
+
+      <arg>-v</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/manpages/man8/afpd.8.xml
+++ b/doc/manpages/man8/afpd.8.xml
@@ -22,18 +22,18 @@
     <cmdsynopsis>
       <command>afpd</command>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt">-F <replaceable>configfile</replaceable></arg>
+      <arg>-F <replaceable>configfile</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>afpd</command>
 
-      <group choice="plain">
-        <arg choice="plain">-v</arg>
-        <arg choice="plain">-V</arg>
-        <arg choice="plain">-h</arg>
+      <group>
+        <arg>-v</arg>
+        <arg>-V</arg>
+        <arg>-h</arg>
       </group>
 
     </cmdsynopsis>

--- a/doc/manpages/man8/atalkd.8.xml
+++ b/doc/manpages/man8/atalkd.8.xml
@@ -55,6 +55,10 @@
       <arg>-d</arg>
 
       <arg>-t</arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>atalkd</command>
 
       <arg>-v</arg>
     </cmdsynopsis>

--- a/doc/manpages/man8/cnid_dbd.8.xml
+++ b/doc/manpages/man8/cnid_dbd.8.xml
@@ -26,9 +26,9 @@
     <cmdsynopsis>
       <command>cnid_dbd</command>
 
-        <group choice="plain">
-          <arg choice="plain">-v</arg>
-          <arg choice="plain">-V</arg>
+        <group>
+          <arg>-v</arg>
+          <arg>-V</arg>
         </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/manpages/man8/cnid_metad.8.xml
+++ b/doc/manpages/man8/cnid_metad.8.xml
@@ -23,19 +23,18 @@
     <cmdsynopsis>
       <command>cnid_metad</command>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt"><arg choice="plain">-F </arg><arg
-      choice="plain"><replaceable>configuration file</replaceable></arg></arg>
+      <arg>-F <replaceable>configuration file</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>cnid_metad</command>
 
-	<group choice="plain">
-	  <arg choice="plain">-v</arg>
-	  <arg choice="plain">-V</arg>
-	</group>
+      <group>
+        <arg>-v</arg>
+        <arg>-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/manpages/man8/macipgw.8.xml
+++ b/doc/manpages/man8/macipgw.8.xml
@@ -32,11 +32,15 @@
 
       <arg>-z <replaceable>zone</replaceable></arg>
 
+      <arg><replaceable>network</replaceable></arg>
+
+      <arg><replaceable>netmask</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>macipgw</command>
+
       <arg>-v</arg>
-
-      <arg choice="plain"><replaceable>network</replaceable></arg>
-
-      <arg choice="plain"><replaceable>netmask</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/manpages/man8/netatalk.8.xml
+++ b/doc/manpages/man8/netatalk.8.xml
@@ -22,15 +22,15 @@
     <cmdsynopsis>
       <command>netatalk</command>
 
-      <arg choice="opt">-F <replaceable>configfile</replaceable></arg>
+      <arg>-F <replaceable>configfile</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>netatalk</command>
 
-      <group choice="plain">
-        <arg choice="plain">-v</arg>
-        <arg choice="plain">-V</arg>
+      <group>
+        <arg>-v</arg>
+        <arg>-V</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/manpages/man8/papd.8.xml
+++ b/doc/manpages/man8/papd.8.xml
@@ -30,11 +30,15 @@
 
       <arg>-d</arg>
 
-      <arg>-f configfile</arg>
+      <arg>-f <replaceable>configfile</replaceable></arg>
 
-      <arg>-p printcap</arg>
+      <arg>-p <replaceable>printcap</replaceable></arg>
 
-      <arg>-P pidfile</arg>
+      <arg>-P <replaceable>pidfile</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>papd</command>
 
       <arg>-v</arg>
     </cmdsynopsis>

--- a/doc/manpages/man8/papstatus.8.xml
+++ b/doc/manpages/man8/papstatus.8.xml
@@ -22,11 +22,11 @@
     <cmdsynopsis>
       <command>papstatus<indexterm><primary>papstatus</primary></indexterm></command>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt"><arg choice="plain">-p </arg><arg choice="plain"><replaceable>printer</replaceable></arg></arg>
+      <arg>-p <replaceable>printer</replaceable></arg>
 
-      <arg choice="opt"><replaceable>retrytime</replaceable></arg>
+      <arg><replaceable>retrytime</replaceable></arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/manpages/man8/timelord.8.xml
+++ b/doc/manpages/man8/timelord.8.xml
@@ -22,13 +22,17 @@
     <cmdsynopsis>
       <command>timelord</command>
 
-      <arg choice="opt">-d</arg>
+      <arg>-d</arg>
 
-      <arg choice="opt">-l</arg>
+      <arg>-l</arg>
 
-      <arg choice="opt">-n <replaceable>nbpname</replaceable></arg>
+      <arg>-n <replaceable>nbpname</replaceable></arg>
+    </cmdsynopsis>
 
-      <arg choice="opt">-v</arg>
+    <cmdsynopsis>
+      <command>timelord</command>
+      
+      <arg>-v</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 


### PR DESCRIPTION
Also contains an overhaul of the command argument markup in the synopsis, to reduce unnecessary nesting and superfluous styles.