### PR TITLE
Remove unnecessary ifdef macro in cnid_dbd.c

### DIFF
--- a/libatalk/cnid/dbd/cnid_dbd.c
+++ b/libatalk/cnid/dbd/cnid_dbd.c
@@ -8,8 +8,6 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
-#ifdef CNID_BACKEND_DBD
-
 #include <arpa/inet.h>
 #include <arpa/inet.h>
 #include <errno.h>
@@ -1038,6 +1036,3 @@ struct _cnid_module cnid_dbd_module = {
     cnid_dbd_open,
     0
 };
-
-#endif /* CNID_DBD */
-


### PR DESCRIPTION
This macro once served a purpose, but now the Meson build system controls whether this code is compiled or not.