### PR TITLE
docs: Standardize formatting of all synopsis sections

### DIFF
--- a/doc/ja/manpages/man1/ad.1.xml
+++ b/doc/ja/manpages/man1/ad.1.xml
@@ -24,15 +24,24 @@
     <cmdsynopsis>
       <command>ad</command>
 
-      <arg choice="req">ls | cp | mv | rm | set</arg>
+      <group>
+        <arg choice="plain">ls</arg>
+        <arg choice="plain">cp</arg>
+        <arg choice="plain">mv</arg>
+        <arg choice="plain">rm</arg>
+        <arg choice="plain">set</arg>
+      </group>
 
-      <arg>...</arg>
+      <arg><replaceable>...</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>ad</command>
 
-      <arg choice="req">-v | --version</arg>
+      <group>
+        <arg choice="plain">-v</arg>
+        <arg choice="plain">--version</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/ja/manpages/man1/aecho.1.xml
+++ b/doc/ja/manpages/man1/aecho.1.xml
@@ -21,15 +21,23 @@
   </refnamediv>
 
   <refsynopsisdiv>
-    <para><command>aecho<indexterm>
+    <cmdsynopsis>
+      <command>aecho<indexterm>
         <primary>aecho</primary>
       </indexterm><indexterm>
         <primary>AEP</primary>
 
         <secondary>Apple Echo Protocol</secondary>
-      </indexterm></command> [ <option>-c</option><replaceable>
-    count</replaceable> ] ( <command>address</command> |
-    <command>nbpname</command> )</para>
+      </indexterm></command>
+
+      <arg>-c <replaceable>count</replaceable></arg>
+
+      <group>
+        <arg choice="plain"><replaceable>address</replaceable></arg>
+
+        <arg choice="plain"><replaceable>nbpname</replaceable></arg>
+      </group>
+    </cmdsynopsis>
   </refsynopsisdiv>
 
   <refsect1>

--- a/doc/ja/manpages/man1/afpldaptest.1.xml
+++ b/doc/ja/manpages/man1/afpldaptest.1.xml
@@ -25,11 +25,11 @@
       <command>afpldaptest</command>
 
       <group>
-        <arg>-u <replaceable>USER</replaceable></arg>
+        <arg choice="plain">-u <replaceable>USER</replaceable></arg>
 
-        <arg>-g <replaceable>GROUP</replaceable></arg>
+        <arg choice="plain">-g <replaceable>GROUP</replaceable></arg>
 
-        <arg>-i <replaceable>UUID</replaceable></arg>
+        <arg choice="plain">-i <replaceable>UUID</replaceable></arg>
       </group>
     </cmdsynopsis>
 
@@ -37,11 +37,11 @@
       <command>afpldaptest</command>
 
       <group>
-        <arg>-h</arg>
+        <arg choice="plain">-h</arg>
 
-        <arg>-?</arg>
+        <arg choice="plain">-?</arg>
 
-        <arg>-:</arg>
+        <arg choice="plain">-:</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man1/apple_dump.1.xml
+++ b/doc/ja/manpages/man1/apple_dump.1.xml
@@ -24,12 +24,12 @@
     <cmdsynopsis>
       <command>apple_dump</command>
 
-      <arg><arg>-a</arg></arg>
+      <arg>-a</arg>
 
       <group>
-        <arg><replaceable>FILE</replaceable></arg>
+        <arg choice="plain"><replaceable>FILE</replaceable></arg>
 
-        <arg><replaceable>DIR</replaceable></arg>
+        <arg choice="plain"><replaceable>DIR</replaceable></arg>
       </group>
     </cmdsynopsis>
 
@@ -39,9 +39,9 @@
       <arg>-e</arg>
 
       <group>
-        <arg><replaceable>FILE</replaceable></arg>
+        <arg choice="plain"><replaceable>FILE</replaceable></arg>
 
-        <arg><replaceable>DIR</replaceable></arg>
+        <arg choice="plain"><replaceable>DIR</replaceable></arg>
       </group>
     </cmdsynopsis>
 
@@ -65,11 +65,11 @@
       <command>apple_dump</command>
 
       <group>
-        <arg>-h</arg>
+        <arg choice="plain">-h</arg>
 
-        <arg>-help</arg>
+        <arg choice="plain">-help</arg>
 
-        <arg>--help</arg>
+        <arg choice="plain">--help</arg>
       </group>
     </cmdsynopsis>
 
@@ -77,11 +77,11 @@
       <command>apple_dump</command>
 
       <group>
-        <arg>-v</arg>
+        <arg choice="plain">-v</arg>
 
-        <arg>-version</arg>
+        <arg choice="plain">-version</arg>
 
-        <arg>--version</arg>
+        <arg choice="plain">--version</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man1/asip-status.1.xml
+++ b/doc/ja/manpages/man1/asip-status.1.xml
@@ -25,9 +25,9 @@
       <command>asip-status</command>
 
       <group>
-        <arg>-4</arg>
+        <arg choice="plain">-4</arg>
 
-        <arg>-6</arg>
+        <arg choice="plain">-6</arg>
       </group>
 
       <arg>-d</arg>
@@ -45,9 +45,9 @@
       <command>asip-status</command>
 
       <group>
-        <arg>-4</arg>
+        <arg choice="plain">-4</arg>
 
-        <arg>-6</arg>
+        <arg choice="plain">-6</arg>
       </group>
 
       <arg>-d</arg>
@@ -65,11 +65,11 @@
       <command>asip-status</command>
 
       <group>
-        <arg>-v</arg>
+        <arg choice="plain">-v</arg>
 
-        <arg>-version</arg>
+        <arg choice="plain">-version</arg>
 
-        <arg>--version</arg>
+        <arg choice="plain">--version</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man1/getzones.1.xml
+++ b/doc/ja/manpages/man1/getzones.1.xml
@@ -27,9 +27,9 @@
         </indexterm></command>
 
       <group>
-        <arg>-m</arg>
+        <arg choice="plain">-m</arg>
 
-        <arg>-l</arg>
+        <arg choice="plain">-l</arg>
       </group>
 
       <arg><replaceable>address</replaceable></arg>

--- a/doc/ja/manpages/man1/macusers.1.xml
+++ b/doc/ja/manpages/man1/macusers.1.xml
@@ -29,17 +29,17 @@
       <command>macusers</command>
 
       <group>
-        <arg>-v</arg>
+        <arg choice="plain">-v</arg>
 
-        <arg>-version</arg>
+        <arg choice="plain">-version</arg>
 
-        <arg>--version</arg>
+        <arg choice="plain">--version</arg>
 
-        <arg>-h</arg>
+        <arg choice="plain">-h</arg>
 
-        <arg>-help</arg>
+        <arg choice="plain">-help</arg>
 
-        <arg>--help</arg>
+        <arg choice="plain">--help</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man8/a2boot.8.xml
+++ b/doc/ja/manpages/man8/a2boot.8.xml
@@ -27,8 +27,15 @@
       <arg>-d</arg>
 
       <arg>-n <replaceable>nbpname</replaceable></arg>
+    </cmdsynopsis>
 
-      <arg>-v</arg>
+    <cmdsynopsis>
+      <command>a2boot</command>
+      <group>
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -83,7 +90,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term>-v</term>
+        <term>-v | -V</term>
 
         <listitem>
           <para>バージョン情報を出力して終了します。</para>

--- a/doc/ja/manpages/man8/afpd.8.xml
+++ b/doc/ja/manpages/man8/afpd.8.xml
@@ -33,11 +33,11 @@
       <command>afpd</command>
 
       <group>
-        <arg>-v</arg>
+        <arg choice="plain">-v</arg>
 
-        <arg>-V</arg>
+        <arg choice="plain">-V</arg>
 
-        <arg>-h</arg>
+        <arg choice="plain">-h</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man8/atalkd.8.xml
+++ b/doc/ja/manpages/man8/atalkd.8.xml
@@ -57,8 +57,16 @@
       <arg>-d</arg>
 
       <arg>-t</arg>
+    </cmdsynopsis>
 
-      <arg>-v</arg>
+    <cmdsynopsis>
+      <command>atalkd</command>
+
+      <group>
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -138,7 +146,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term>-v</term>
+        <term>-v | -V</term>
 
         <listitem>
           <para>バージョン情報を出力して終了します。</para>

--- a/doc/ja/manpages/man8/cnid_dbd.8.xml
+++ b/doc/ja/manpages/man8/cnid_dbd.8.xml
@@ -29,9 +29,9 @@
       <command>cnid_dbd</command>
 
       <group>
-        <arg>-v</arg>
+        <arg choice="plain">-v</arg>
 
-        <arg>-V</arg>
+        <arg choice="plain">-V</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>
@@ -82,7 +82,7 @@
 
     <variablelist remap="TP">
       <varlistentry>
-        <term><option>-v, -V</option></term>
+        <term><option>-v | -V</option></term>
 
         <listitem>
           <para>バージョンを表示してから終了する。</para>

--- a/doc/ja/manpages/man8/cnid_metad.8.xml
+++ b/doc/ja/manpages/man8/cnid_metad.8.xml
@@ -34,9 +34,9 @@
       <command>cnid_metad</command>
 
       <group>
-        <arg>-v</arg>
+        <arg choice="plain">-v</arg>
 
-        <arg>-V</arg>
+        <arg choice="plain">-V</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>
@@ -47,7 +47,8 @@
     <para><command>cnid_metad</command>は<emphasis
     remap="B">afpd</emphasis>からの要求を待ち、<emphasis
     remap="B">cnid_dbd</emphasis>デーモンのインスタンスを起動する。一度起動した<emphasis
-    remap="B">cnid_dbd</emphasis>インスタンスの状態を絶えず把握し、もし必要なら再起動する。<command>cnid_metad</command>は通常、<command>netatalk</command>(8)によってブート時に起動され、シャットダウンまでずっと動作する。</para>
+    remap="B">cnid_dbd</emphasis>インスタンスの状態を絶えず把握し、もし必要なら再起動する。
+    <command>cnid_metad</command>は通常、<command>netatalk</command>(8)によってブート時に起動され、シャットダウンまでずっと動作する。</para>
   </refsect1>
 
   <refsect1>
@@ -75,7 +76,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>-v, -V</option></term>
+        <term><option>-v | -V</option></term>
 
         <listitem>
           <para>バージョンを表示してから終了する。</para>

--- a/doc/ja/manpages/man8/macipgw.8.xml
+++ b/doc/ja/manpages/man8/macipgw.8.xml
@@ -32,11 +32,19 @@
 
       <arg>-z <replaceable>zone</replaceable></arg>
 
-      <arg>-v</arg>
-
       <arg><replaceable>network</replaceable></arg>
 
       <arg><replaceable>netmask</replaceable></arg>
+    </cmdsynopsis>
+
+    <cmdsynopsis>
+      <command>macipgw</command>
+
+      <group>
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -112,7 +120,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term>-v</term>
+        <term>-v | -V</term>
 
         <listitem>
           <para>バージョン情報を表示して終了します。</para>

--- a/doc/ja/manpages/man8/netatalk.8.xml
+++ b/doc/ja/manpages/man8/netatalk.8.xml
@@ -31,9 +31,9 @@
       <command>netatalk</command>
 
       <group>
-        <arg>-v</arg>
+        <arg choice="plain">-v</arg>
 
-        <arg>-V</arg>
+        <arg choice="plain">-V</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/ja/manpages/man8/papd.8.xml
+++ b/doc/ja/manpages/man8/papd.8.xml
@@ -37,8 +37,16 @@
       <arg>-p <replaceable>printcap</replaceable></arg>
 
       <arg>-P <replaceable>pidfile</replaceable></arg>
+    </cmdsynopsis>
 
-      <arg>-v</arg>
+    <cmdsynopsis>
+      <command>macipgw</command>
+
+      <group>
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -114,7 +122,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term>-v</term>
+        <term>-v | -V</term>
 
         <listitem>
           <para>バージョン情報を出力して終了します。</para>

--- a/doc/ja/manpages/man8/timelord.8.xml
+++ b/doc/ja/manpages/man8/timelord.8.xml
@@ -29,8 +29,16 @@
       <arg>-l</arg>
 
       <arg>-n <replaceable>nbpname</replaceable></arg>
+    </cmdsynopsis>
 
-      <arg>-v</arg>
+    <cmdsynopsis>
+      <command>timelord</command>
+
+      <group>
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -79,7 +87,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term>-v</term>
+        <term>-v | -V</term>
 
         <listitem>
           <para>バージョン情報を出力して終了します。</para>

--- a/doc/manpages/man1/ad.1.xml
+++ b/doc/manpages/man1/ad.1.xml
@@ -22,15 +22,24 @@
     <cmdsynopsis>
       <command>ad</command>
 
-      <arg choice="req">ls | cp | mv | rm | set</arg>
+      <group>
+        <arg choice="plain">ls</arg>
+        <arg choice="plain">cp</arg>
+        <arg choice="plain">mv</arg>
+        <arg choice="plain">rm</arg>
+        <arg choice="plain">set</arg>
+      </group>
 
-      <arg>...</arg>
+      <arg><replaceable>...</replaceable></arg>
     </cmdsynopsis>
 
     <cmdsynopsis>
       <command>ad</command>
 
-      <arg choice="req">-v | --version</arg>
+      <group>
+        <arg choice="plain">-v</arg>
+        <arg choice="plain">--version</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 

--- a/doc/manpages/man1/aecho.1.xml
+++ b/doc/manpages/man1/aecho.1.xml
@@ -19,12 +19,23 @@
   </refnamediv>
 
   <refsynopsisdiv>
-    <para><command>aecho<indexterm><primary>aecho</primary></indexterm><indexterm>
+    <cmdsynopsis>
+      <command>aecho<indexterm>
+        <primary>aecho</primary>
+      </indexterm><indexterm>
         <primary>AEP</primary>
 
         <secondary>Apple Echo Protocol</secondary>
-      </indexterm></command> [ <option>-c</option><replaceable> count</replaceable>
-    ] ( <command>address</command> | <command>nbpname</command> )</para>
+      </indexterm></command>
+
+      <arg>-c <replaceable>count</replaceable></arg>
+
+      <group>
+        <arg choice="plain"><replaceable>address</replaceable></arg>
+
+        <arg choice="plain"><replaceable>nbpname</replaceable></arg>
+      </group>
+    </cmdsynopsis>
   </refsynopsisdiv>
 
   <refsect1>

--- a/doc/manpages/man1/afpldaptest.1.xml
+++ b/doc/manpages/man1/afpldaptest.1.xml
@@ -23,9 +23,9 @@
       <command>afpldaptest</command>
 
       <group>
-        <arg>-u <replaceable>USER</replaceable></arg>
-        <arg>-g <replaceable>GROUP</replaceable></arg>
-        <arg>-i <replaceable>UUID</replaceable></arg>
+        <arg choice="plain">-u <replaceable>USER</replaceable></arg>
+        <arg choice="plain">-g <replaceable>GROUP</replaceable></arg>
+        <arg choice="plain">-i <replaceable>UUID</replaceable></arg>
       </group>
     </cmdsynopsis>
 
@@ -33,9 +33,9 @@
       <command>afpldaptest</command>
 
       <group>
-        <arg>-h</arg>
-        <arg>-?</arg>
-        <arg>-:</arg>
+        <arg choice="plain">-h</arg>
+        <arg choice="plain">-?</arg>
+        <arg choice="plain">-:</arg>
       </group>
 
     </cmdsynopsis>

--- a/doc/manpages/man1/apple_dump.1.xml
+++ b/doc/manpages/man1/apple_dump.1.xml
@@ -24,8 +24,8 @@
       <arg>-a</arg>
 
       <group>
-        <arg><replaceable>FILE</replaceable></arg>
-        <arg><replaceable>DIR</replaceable></arg>
+        <arg choice="plain"><replaceable>FILE</replaceable></arg>
+        <arg choice="plain"><replaceable>DIR</replaceable></arg>
       </group>
     </cmdsynopsis>
 
@@ -35,8 +35,8 @@
       <arg>-e</arg>
 
       <group>
-        <arg><replaceable>FILE</replaceable></arg>
-        <arg><replaceable>DIR</replaceable></arg>
+        <arg choice="plain"><replaceable>FILE</replaceable></arg>
+        <arg choice="plain"><replaceable>DIR</replaceable></arg>
       </group>
     </cmdsynopsis>
 
@@ -60,9 +60,9 @@
       <command>apple_dump</command>
 
       <group>
-        <arg>-h</arg>
-        <arg>-help</arg>
-        <arg>--help</arg>
+        <arg choice="plain">-h</arg>
+        <arg choice="plain">-help</arg>
+        <arg choice="plain">--help</arg>
       </group>
     </cmdsynopsis>
 
@@ -70,9 +70,9 @@
       <command>apple_dump</command>
 
       <group>
-        <arg>-v</arg>
-        <arg>-version</arg>
-        <arg>--version</arg>
+        <arg choice="plain">-v</arg>
+        <arg choice="plain">-version</arg>
+        <arg choice="plain">--version</arg>
       </group>
 
     </cmdsynopsis>

--- a/doc/manpages/man1/asip-status.1.xml
+++ b/doc/manpages/man1/asip-status.1.xml
@@ -25,9 +25,9 @@
       <command>asip-status</command>
 
       <group>
-        <arg>-4</arg>
+        <arg choice="plain">-4</arg>
 
-        <arg>-6</arg>
+        <arg choice="plain">-6</arg>
       </group>
 
       <arg>-d</arg>
@@ -45,9 +45,9 @@
       <command>asip-status</command>
 
       <group>
-        <arg>-4</arg>
+        <arg choice="plain">-4</arg>
 
-        <arg>-6</arg>
+        <arg choice="plain">-6</arg>
       </group>
 
       <arg>-d</arg>
@@ -65,11 +65,11 @@
       <command>asip-status</command>
 
       <group>
-        <arg>-v</arg>
+        <arg choice="plain">-v</arg>
 
-        <arg>-version</arg>
+        <arg choice="plain">-version</arg>
 
-        <arg>--version</arg>
+        <arg choice="plain">--version</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/manpages/man1/getzones.1.xml
+++ b/doc/manpages/man1/getzones.1.xml
@@ -23,9 +23,9 @@
       <command>getzones<indexterm><primary>getzones</primary></indexterm></command>
 
       <group>
-        <arg>-m</arg>
+        <arg choice="plain">-m</arg>
 
-        <arg>-l</arg>
+        <arg choice="plain">-l</arg>
       </group>
 
       <arg><replaceable>address</replaceable></arg>

--- a/doc/manpages/man1/macusers.1.xml
+++ b/doc/manpages/man1/macusers.1.xml
@@ -27,12 +27,12 @@
       <command>macusers</command>
 
       <group>
-        <arg>-v</arg>
-        <arg>-version</arg>
-        <arg>--version</arg>
-        <arg>-h</arg>
-        <arg>-help</arg>
-        <arg>--help</arg>
+        <arg choice="plain">-v</arg>
+        <arg choice="plain">-version</arg>
+        <arg choice="plain">--version</arg>
+        <arg choice="plain">-h</arg>
+        <arg choice="plain">-help</arg>
+        <arg choice="plain">--help</arg>
       </group>
 
     </cmdsynopsis>

--- a/doc/manpages/man8/a2boot.8.xml
+++ b/doc/manpages/man8/a2boot.8.xml
@@ -30,7 +30,11 @@
     <cmdsynopsis>
       <command>a2boot</command>
 
-      <arg>-v</arg>
+      <group>
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -88,7 +92,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term>-v</term>
+        <term>-v | -V</term>
 
         <listitem>
           <para>Print version information and exit.</para>

--- a/doc/manpages/man8/afpd.8.xml
+++ b/doc/manpages/man8/afpd.8.xml
@@ -31,9 +31,9 @@
       <command>afpd</command>
 
       <group>
-        <arg>-v</arg>
-        <arg>-V</arg>
-        <arg>-h</arg>
+        <arg choice="plain">-v</arg>
+        <arg choice="plain">-V</arg>
+        <arg choice="plain">-h</arg>
       </group>
 
     </cmdsynopsis>

--- a/doc/manpages/man8/atalkd.8.xml
+++ b/doc/manpages/man8/atalkd.8.xml
@@ -60,7 +60,11 @@
     <cmdsynopsis>
       <command>atalkd</command>
 
-      <arg>-v</arg>
+      <group>
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -145,7 +149,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term>-v</term>
+        <term>-v | -V</term>
 
         <listitem>
           <para>Print version information and exit.</para>

--- a/doc/manpages/man8/cnid_dbd.8.xml
+++ b/doc/manpages/man8/cnid_dbd.8.xml
@@ -26,10 +26,11 @@
     <cmdsynopsis>
       <command>cnid_dbd</command>
 
-        <group>
-          <arg>-v</arg>
-          <arg>-V</arg>
-        </group>
+      <group>
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -98,7 +99,7 @@
 
     <variablelist remap="TP">
       <varlistentry>
-        <term><option>-v, -V</option></term>
+        <term><option>-v | -V</option></term>
 
         <listitem>
           <para>Show version and exit.</para>

--- a/doc/manpages/man8/cnid_metad.8.xml
+++ b/doc/manpages/man8/cnid_metad.8.xml
@@ -32,8 +32,9 @@
       <command>cnid_metad</command>
 
       <group>
-        <arg>-v</arg>
-        <arg>-V</arg>
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/manpages/man8/macipgw.8.xml
+++ b/doc/manpages/man8/macipgw.8.xml
@@ -40,7 +40,11 @@
     <cmdsynopsis>
       <command>macipgw</command>
 
-      <arg>-v</arg>
+      <group>
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -122,7 +126,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term>-v</term>
+        <term>-v | -V</term>
 
         <listitem>
           <para>Show version information and exit.</para>

--- a/doc/manpages/man8/netatalk.8.xml
+++ b/doc/manpages/man8/netatalk.8.xml
@@ -29,8 +29,8 @@
       <command>netatalk</command>
 
       <group>
-        <arg>-v</arg>
-        <arg>-V</arg>
+        <arg choice="plain">-v</arg>
+        <arg choice="plain">-V</arg>
       </group>
     </cmdsynopsis>
   </refsynopsisdiv>

--- a/doc/manpages/man8/papd.8.xml
+++ b/doc/manpages/man8/papd.8.xml
@@ -40,7 +40,11 @@
     <cmdsynopsis>
       <command>papd</command>
 
-      <arg>-v</arg>
+      <group>
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -124,7 +128,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term>-v</term>
+        <term>-v | -V</term>
 
         <listitem>
           <para>Print version information and exit.</para>

--- a/doc/manpages/man8/timelord.8.xml
+++ b/doc/manpages/man8/timelord.8.xml
@@ -31,8 +31,12 @@
 
     <cmdsynopsis>
       <command>timelord</command>
-      
-      <arg>-v</arg>
+
+      <group>
+        <arg choice="plain">-v</arg>
+
+        <arg choice="plain">-V</arg>
+      </group>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -84,7 +88,7 @@
       </varlistentry>
 
       <varlistentry>
-        <term>-v</term>
+        <term>-v | -V</term>
 
         <listitem>
           <para>Print version information and exit.</para>


### PR DESCRIPTION
Apply the "plain" property to all members of arg groups, to avoid double bracket clutter.

Also, the ad and aecho man pages didn't use the `<cmdsynopsis>` format correctly.