### PR TITLE
meson: Add manual type man_only which generates only troff pages

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -18,10 +18,13 @@ if build_xml_docs
     )
 
     subdir('manpages')
-    subdir('manual')
 
-    if 'ja' in get_option('with-manual-l10n')
-        subdir('ja')
+    if get_option('with-manual') != 'man_only'
+        subdir('manual')
+
+        if 'ja' in get_option('with-manual-l10n')
+            subdir('ja')
+        endif
     endif
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -370,11 +370,12 @@ option(
     type: 'combo',
     choices: [
         'none',
-        'local',
-        'www',
+        'local',    # html and troff docs for installation and distribution
+        'man_only', # troff man pages only for installation and distribution
+        'www',      # html for web publishing (project admin use)
     ],
     value: 'local',
-    description: 'Build and install the html manual',
+    description: 'Format of manual to build and install',
 )
 option(
     'with-manual-l10n',


### PR DESCRIPTION
For when you don't want to have the html pages generated and installed.