### PR TITLE
docs: Refer to CONTRIBUTORS hosted on netatalk.io in man pages

### DIFF
--- a/doc/ja/manpages/man1/ad.1.xml
+++ b/doc/ja/manpages/man1/ad.1.xml
@@ -473,7 +473,6 @@ AFP Attributes:
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/aecho.1.xml
+++ b/doc/ja/manpages/man1/aecho.1.xml
@@ -125,8 +125,6 @@ round-trip (ms)  min/avg/max = 9/9/10
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/afpldaptest.1.xml
+++ b/doc/ja/manpages/man1/afpldaptest.1.xml
@@ -103,7 +103,6 @@
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/afppasswd.1.xml
+++ b/doc/ja/manpages/man1/afppasswd.1.xml
@@ -144,7 +144,6 @@
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/afpstats.1.xml
+++ b/doc/ja/manpages/man1/afpstats.1.xml
@@ -74,7 +74,6 @@ charlie          451969   Apr 28 21:21:32   active         My AFP Volume
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/afptest.1.xml
+++ b/doc/ja/manpages/man1/afptest.1.xml
@@ -235,8 +235,6 @@ Create directory tree with 10^3 dirs                      496 ms</computeroutput
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/apple_dump.1.xml
+++ b/doc/ja/manpages/man1/apple_dump.1.xml
@@ -194,7 +194,6 @@
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/asip-status.1.xml
+++ b/doc/ja/manpages/man1/asip-status.1.xml
@@ -199,7 +199,6 @@ UTF8 Servername: myserver
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/dbd.1.xml
+++ b/doc/ja/manpages/man1/dbd.1.xml
@@ -130,7 +130,6 @@
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/getzones.1.xml
+++ b/doc/ja/manpages/man1/getzones.1.xml
@@ -101,8 +101,6 @@
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/macusers.1.xml
+++ b/doc/ja/manpages/man1/macusers.1.xml
@@ -85,7 +85,6 @@
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/nbp.1.xml
+++ b/doc/ja/manpages/man1/nbp.1.xml
@@ -164,8 +164,6 @@
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man1/pap.1.xml
+++ b/doc/ja/manpages/man1/pap.1.xml
@@ -226,8 +226,6 @@
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man3/atalk_aton.3.xml
+++ b/doc/ja/manpages/man3/atalk_aton.3.xml
@@ -60,8 +60,6 @@
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man3/nbp_name.3.xml
+++ b/doc/ja/manpages/man3/nbp_name.3.xml
@@ -96,8 +96,6 @@
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man4/atalk.4.xml
+++ b/doc/ja/manpages/man4/atalk.4.xml
@@ -103,8 +103,6 @@
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man5/afp.conf.5.xml
+++ b/doc/ja/manpages/man5/afp.conf.5.xml
@@ -2230,7 +2230,6 @@ directory perm = 0770</programlisting></para>
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man5/afp_signature.conf.5.xml
+++ b/doc/ja/manpages/man5/afp_signature.conf.5.xml
@@ -79,7 +79,6 @@
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man5/afp_voluuid.conf.5.xml
+++ b/doc/ja/manpages/man5/afp_voluuid.conf.5.xml
@@ -80,7 +80,6 @@ mary 6331E2D1-446C-B68C-3066-D685AADBE911</programlisting>
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man5/atalkd.conf.5.xml
+++ b/doc/ja/manpages/man5/atalkd.conf.5.xml
@@ -174,8 +174,6 @@ le1 -seed -net 9461-9471 -zone netatalk -zone Argus</programlisting></para>
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man5/extmap.conf.5.xml
+++ b/doc/ja/manpages/man5/extmap.conf.5.xml
@@ -74,7 +74,6 @@
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man5/papd.conf.5.xml
+++ b/doc/ja/manpages/man5/papd.conf.5.xml
@@ -247,8 +247,6 @@ Boss' LaserWriter@2nd floor:\
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man8/a2boot.8.xml
+++ b/doc/ja/manpages/man8/a2boot.8.xml
@@ -102,8 +102,6 @@
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man8/afpd.8.xml
+++ b/doc/ja/manpages/man8/afpd.8.xml
@@ -242,7 +242,6 @@
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man8/atalkd.8.xml
+++ b/doc/ja/manpages/man8/atalkd.8.xml
@@ -194,8 +194,6 @@
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man8/cnid_dbd.8.xml
+++ b/doc/ja/manpages/man8/cnid_dbd.8.xml
@@ -216,7 +216,6 @@
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man8/cnid_metad.8.xml
+++ b/doc/ja/manpages/man8/cnid_metad.8.xml
@@ -122,7 +122,6 @@
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man8/netatalk.8.xml
+++ b/doc/ja/manpages/man8/netatalk.8.xml
@@ -132,7 +132,6 @@
   <refsect1>
     <title>著作者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man8/papd.8.xml
+++ b/doc/ja/manpages/man8/papd.8.xml
@@ -259,8 +259,6 @@
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man8/papstatus.8.xml
+++ b/doc/ja/manpages/man8/papstatus.8.xml
@@ -126,8 +126,6 @@
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/ja/manpages/man8/timelord.8.xml
+++ b/doc/ja/manpages/man8/timelord.8.xml
@@ -99,8 +99,6 @@
   <refsect1>
     <title>著者</title>
 
-    <para><ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink>
-    を参照</para>
+    <para><ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink> を参照</para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man1/ad.1.xml
+++ b/doc/manpages/man1/ad.1.xml
@@ -514,6 +514,6 @@ AFP Attributes:
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man1/aecho.1.xml
+++ b/doc/manpages/man1/aecho.1.xml
@@ -105,6 +105,6 @@ round-trip (ms)  min/avg/max = 9/9/10
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man1/afpldaptest.1.xml
+++ b/doc/manpages/man1/afpldaptest.1.xml
@@ -100,6 +100,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man1/afppasswd.1.xml
+++ b/doc/manpages/man1/afppasswd.1.xml
@@ -153,6 +153,6 @@
   <refsect1>
     <title>Author</title>
 
-    <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+    <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man1/afpstats.1.xml
+++ b/doc/manpages/man1/afpstats.1.xml
@@ -74,7 +74,6 @@ charlie          451969   Apr 28 21:21:32   active         My AFP Volume
   <refsect1>
     <title>Author</title>
 
-    <para>See <ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink></para>
+    <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man1/afptest.1.xml
+++ b/doc/manpages/man1/afptest.1.xml
@@ -244,7 +244,6 @@ Create directory tree with 10^3 dirs                      496 ms</computeroutput
   <refsect1>
     <title>Author</title>
 
-    <para>See <ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink></para>
+    <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man1/apple_dump.1.xml
+++ b/doc/manpages/man1/apple_dump.1.xml
@@ -184,6 +184,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man1/asip-status.1.xml
+++ b/doc/manpages/man1/asip-status.1.xml
@@ -206,7 +206,6 @@ UTF8 Servername: myserver
   <refsect1>
     <title>Author</title>
 
-    <para>See <ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink></para>
+    <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man1/dbd.1.xml
+++ b/doc/manpages/man1/dbd.1.xml
@@ -140,6 +140,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man1/getzones.1.xml
+++ b/doc/manpages/man1/getzones.1.xml
@@ -85,6 +85,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man1/macusers.1.xml
+++ b/doc/manpages/man1/macusers.1.xml
@@ -78,6 +78,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man1/nbp.1.xml
+++ b/doc/manpages/man1/nbp.1.xml
@@ -140,6 +140,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man1/pap.1.xml
+++ b/doc/manpages/man1/pap.1.xml
@@ -205,6 +205,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man3/atalk_aton.3.xml
+++ b/doc/manpages/man3/atalk_aton.3.xml
@@ -55,6 +55,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man3/nbp_name.3.xml
+++ b/doc/manpages/man3/nbp_name.3.xml
@@ -88,6 +88,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man4/atalk.4.xml
+++ b/doc/manpages/man4/atalk.4.xml
@@ -85,6 +85,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -2496,7 +2496,6 @@
   <refsect1>
     <title>Author</title>
 
-    <para>See <ulink
-    url="https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS">CONTRIBUTORS</ulink></para>
+    <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man5/afp_signature.conf.5.xml
+++ b/doc/manpages/man5/afp_signature.conf.5.xml
@@ -88,6 +88,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man5/afp_voluuid.conf.5.xml
+++ b/doc/manpages/man5/afp_voluuid.conf.5.xml
@@ -87,6 +87,6 @@ mary 6331E2D1-446C-B68C-3066-D685AADBE911</programlisting>
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man5/atalkd.conf.5.xml
+++ b/doc/manpages/man5/atalkd.conf.5.xml
@@ -185,6 +185,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man5/extmap.conf.5.xml
+++ b/doc/manpages/man5/extmap.conf.5.xml
@@ -79,6 +79,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man5/papd.conf.5.xml
+++ b/doc/manpages/man5/papd.conf.5.xml
@@ -274,6 +274,6 @@ Boss' LaserWriter@2nd floor:\
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man8/a2boot.8.xml
+++ b/doc/manpages/man8/a2boot.8.xml
@@ -104,6 +104,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man8/afpd.8.xml
+++ b/doc/manpages/man8/afpd.8.xml
@@ -257,6 +257,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man8/atalkd.8.xml
+++ b/doc/manpages/man8/atalkd.8.xml
@@ -201,6 +201,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man8/cnid_dbd.8.xml
+++ b/doc/manpages/man8/cnid_dbd.8.xml
@@ -263,6 +263,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man8/cnid_metad.8.xml
+++ b/doc/manpages/man8/cnid_metad.8.xml
@@ -128,6 +128,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man8/netatalk.8.xml
+++ b/doc/manpages/man8/netatalk.8.xml
@@ -136,6 +136,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man8/papd.8.xml
+++ b/doc/manpages/man8/papd.8.xml
@@ -279,6 +279,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man8/papstatus.8.xml
+++ b/doc/manpages/man8/papstatus.8.xml
@@ -117,6 +117,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>

--- a/doc/manpages/man8/timelord.8.xml
+++ b/doc/manpages/man8/timelord.8.xml
@@ -100,6 +100,6 @@
   <refsect1>
       <title>Author</title>
 
-      <para>See <ulink url='https://github.com/Netatalk/netatalk/blob/main/CONTRIBUTORS'>CONTRIBUTORS</ulink></para>
+      <para>See <ulink url='https://netatalk.io/contributors'>CONTRIBUTORS</ulink></para>
   </refsect1>
 </refentry>


### PR DESCRIPTION
We are now self-hosting a version of CONTRIBUTORS: https://netatalk.io/contributors