### PR TITLE
meson: Correct capability check for SunRPC on *BSD

### DIFF
--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -73,9 +73,13 @@ endif
 
 if have_quota
     afpd_sources += [
-        'nfsquota.c',
         'quota.c',
     ]
+    if not have_libquota
+        afpd_sources += [
+            'nfsquota.c',
+        ]
+    endif
     afpd_external_deps += quota_deps
 endif
 

--- a/etc/afpd/quota.c
+++ b/etc/afpd/quota.c
@@ -32,6 +32,7 @@
 #include <atalk/util.h>
 
 #include "auth.h"
+#include "directory.h"
 #include "volume.h"
 #include "unix.h"
 

--- a/meson.build
+++ b/meson.build
@@ -971,6 +971,7 @@ tirpc = dependency('libtirpc', required: false)
 
 quota_deps = []
 quota_provider = ''
+have_libquota = false
 
 rpc_headers = [
     'rpc/rpc.h',
@@ -1017,7 +1018,8 @@ else
         if have_quota
             quota_deps += rpcsvc
             quota_provider += 'SunRPC'
-            if quota.found() and cc.has_function('getfsquota', dependencies: [quota, prop, rpcsvc])
+            if quota.found() and cc.has_function('quota_open', dependencies: [quota, prop, rpcsvc])
+                have_libquota = true
                 quota_deps += [quota, prop]
                 cdata.set('HAVE_LIBQUOTA', 1)
             endif

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -56,9 +56,13 @@ endif
 
 if have_quota
     test_sources += [
-        meson.project_source_root() / 'etc/afpd/nfsquota.c',
         meson.project_source_root() / 'etc/afpd/quota.c',
     ]
+    if not have_libquota
+        test_sources += [
+            meson.project_source_root() / 'etc/afpd/nfsquota.c',
+        ]
+    endif
     test_external_deps += quota_deps
 endif
 


### PR DESCRIPTION
For the SunRPC / libquota check, look for `quota_open()` instead of the obsolete `getfsquota()`

Don't compile the bundled nfsquota module when using libquota.