### PR TITLE
meson: *BSD compatible libwrap check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2010,7 +2010,11 @@ int main(void) {
 }
 '''
 
-    have_tcpwrap = wrap.found() and cc.links(tcpwrap_code, args: '-lwrap')
+    # *BSD have tcpwrappers support in libc
+    have_tcpwrap = wrap.found() and cc.links(tcpwrap_code)
+    if not have_tcpwrap
+	have_tcpwrap = wrap.found() and cc.links(tcpwrap_code, args: '-lwrap')
+    endif
     if not have_tcpwrap
         have_tcpwrap = cc.links(tcpwrap_code, args: ['-lwrap', '-lnsl'])
     endif


### PR DESCRIPTION
While NetBSD has libwrap, the meson code doesn't find it. The test cond still succeeds, so add a branch that does not require the library.