### PR TITLE
GitHub CI: Remove pkg-config override for NetBSD job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -585,7 +585,6 @@ jobs:
             set -e
             meson setup build \
               -Dbuildtype=release \
-              -Dpkg_config_path=/usr/pkg/lib/pkgconfig \
               -Dwith-appletalk=true \
               -Dwith-dtrace=false \
               -Dwith-krbV-uam=false \


### PR DESCRIPTION
This was required in an earlier configuration, but no longer.