### PR TITLE
meson: Option to specify path to perl runtime

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -194,7 +194,6 @@ endif
 
 flex = find_program('flex', required: false)
 grep = find_program('grep', required: false)
-perl = find_program('perl', required: false)
 uname = find_program('uname', required: false)
 cmarkgfm = find_program('cmark-gfm', required: false)
 
@@ -567,6 +566,18 @@ if not have_bdb
         msg = 'Berkeley DB library required but not found!'
     endif
     error(msg, 'Please specify an installation path using the -Dwith-bdb-path= configure option (must include lib and include dirs)')
+endif
+
+#
+# Check for Perl
+#
+
+perl_path = get_option('with-perl-path')
+
+if perl_path == ''
+    perl = find_program('perl', required: false)
+else
+    perl = find_program(perl_path / 'perl', required: false)
 endif
 
 #

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -292,6 +292,12 @@ option(
     description: 'Set path to PAM config directory',
 )
 option(
+    'with-perl-path',
+    type: 'string',
+    value: '',
+    description: 'Set path to directory that containts the perl runtime binary',
+)
+option(
     'with-pkgconfdir-path',
     type: 'string',
     value: '',


### PR DESCRIPTION
Introduces `-Dwith-perl-path` which takes the path to the containing dir of perl. Passes to absolute path to perl to the build system.