### PR TITLE
meson: Generate appendix doc and allow custom manual install path

### DIFF
--- a/doc/ja/manual/meson.build
+++ b/doc/ja/manual/meson.build
@@ -98,5 +98,5 @@ custom_target(
         '@INPUT@',
     ],
     install: true,
-    install_dir: datadir / 'doc/netatalk/htmldocs/ja',
+    install_dir: manual_install_path / 'ja',
 )

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -98,10 +98,12 @@ custom_target(
         '@INPUT@',
     ],
     install: true,
-    install_dir: datadir / 'doc/netatalk/htmldocs',
+    install_dir: manual_install_path,
 )
 
-install_data(
-    'netatalk.css',
-    install_dir: datadir / 'doc/netatalk/htmldocs',
-)
+if get_option('with-manual') == 'local'
+    install_data(
+        'netatalk.css',
+        install_dir: manual_install_path,
+    )
+endif

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,6 +1,10 @@
 if build_xml_docs
     if get_option('with-manual') == 'www'
         input_file = 'html-www.xsl.in'
+        python = find_program('python3', required: false)
+        if python.found()
+            run_command(python, 'generate_compile_docs.py')
+        endif
     else
         input_file = 'html.xsl.in'
     endif

--- a/meson.build
+++ b/meson.build
@@ -101,6 +101,12 @@ else
     homedir = '/home'
 endif
 
+manual_install_path = get_option('with-manual-install-path')
+
+if manual_install_path == ''
+    manual_install_path = datadir / 'doc/netatalk/htmldocs'
+endif
+
 ##################
 # Compiler flags #
 ##################

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -280,6 +280,12 @@ option(
     description: 'Set path to Netatalk lockfile',
 )
 option(
+    'with-manual-install-path',
+    type: 'string',
+    value: '',
+    description: 'Set path where to install manual html pages',
+)
+option(
     'with-pam-path',
     type: 'string',
     value: '',


### PR DESCRIPTION
This adds build system functionality for project admins specifically.

First, when building with `-Dwith-manual=www` the python script for refreshing the compile manual XML sources is run
Secondly, with the new `-Dwith-manual-install-path` option you can set a custom install path, e.g. the path to a checked out copy of netatalk-homepage

These automates currently manual parts of the release process.

Note that the build system won't check for required python libraries. Only python3 itself. This is up to the user to prepare.