### PR TITLE
On macOS, enable binary section workaround for ObjC fork policy

### DIFF
--- a/distrib/initscripts/macos.netatalk.in
+++ b/distrib/initscripts/macos.netatalk.in
@@ -3,7 +3,6 @@
 # # Startup daemon for netatalk on macOS
 
 # Prepare the environment
-export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 . /etc/rc.common
 
 # root check

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -34,6 +34,10 @@ afpd_external_deps = [libgcrypt]
 afpd_internal_deps = []
 afpd_link_args = []
 
+if host_os == 'darwin'
+    afpd_link_args += '-Wl,-sectcreate,__DATA,__objc_fork_ok'
+endif
+
 if have_appletalk
     afpd_sources += [
         'afp_asp.c',
@@ -195,7 +199,7 @@ executable(
         statedir,
         uamdir,
     ],
-    link_args: netatalk_common_link_args,
+    link_args: [netatalk_common_link_args, afpd_link_args],
     export_dynamic: true,
     install: true,
     install_dir: sbindir,

--- a/etc/cnid_dbd/meson.build
+++ b/etc/cnid_dbd/meson.build
@@ -1,79 +1,82 @@
-if use_dbd_backend
-    cnid_dbd_sources = [
-        'comm.c',
-        'db_param.c',
-        'dbd_add.c',
-        'dbd_dbcheck.c',
-        'dbd_delete.c',
-        'dbd_get.c',
-        'dbd_getstamp.c',
-        'dbd_lookup.c',
-        'dbd_rebuild_add.c',
-        'dbd_resolve.c',
-        'dbd_search.c',
-        'dbd_update.c',
-        'dbif.c',
-        'main.c',
-        'pack.c',
-    ]
+cnid_dbd_sources = [
+    'comm.c',
+    'db_param.c',
+    'dbd_add.c',
+    'dbd_dbcheck.c',
+    'dbd_delete.c',
+    'dbd_get.c',
+    'dbd_getstamp.c',
+    'dbd_lookup.c',
+    'dbd_rebuild_add.c',
+    'dbd_resolve.c',
+    'dbd_search.c',
+    'dbd_update.c',
+    'dbif.c',
+    'main.c',
+    'pack.c',
+]
 
-    cnid_dbd_deps = []
+cnid_dbd_deps = []
+cnid_dbd_link_args = []
 
-    if use_mysql_backend
-        cnid_dbd_deps += mysqlclient
-    endif
-
-    cnid_metad_sources = ['cnid_metad.c', 'usockfd.c', 'db_param.c']
-
-    dbd_sources = [
-        'cmd_dbd.c',
-        'cmd_dbd_scanvol.c',
-        'dbd_add.c',
-        'dbd_delete.c',
-        'dbd_getstamp.c',
-        'dbd_lookup.c',
-        'dbd_rebuild_add.c',
-        'dbd_resolve.c',
-        'dbd_update.c',
-        'dbif.c',
-        'pack.c',
-    ]
-
-    executable(
-        'cnid_dbd',
-        cnid_dbd_sources,
-        include_directories: [bdb_includes, root_includes],
-        link_with: libatalk,
-        dependencies: [cnid_dbd_deps, db],
-        c_args: [cnid_dbd, dversion],
-        link_args: bdb_link_args,
-        install: true,
-        install_dir: sbindir,
-        build_rpath: rpath_libdir,
-        install_rpath: rpath_libdir,
-    )
-    executable(
-        'cnid_metad',
-        cnid_metad_sources,
-        include_directories: root_includes,
-        link_with: libatalk,
-        dependencies: cnid_dbd_deps,
-        c_args: [cnid_dbd, dversion],
-        install: true,
-        install_dir: sbindir,
-        build_rpath: rpath_libdir,
-        install_rpath: rpath_libdir,
-    )
-    executable(
-        'dbd',
-        dbd_sources,
-        include_directories: [bdb_includes, root_includes],
-        link_with: libatalk,
-        dependencies: [cnid_dbd_deps, db],
-        c_args: dversion,
-        link_args: bdb_link_args,
-        install: true,
-        build_rpath: rpath_libdir,
-        install_rpath: rpath_libdir,
-    )
+if host_os == 'darwin'
+    cnid_dbd_link_args += '-Wl,-sectcreate,__DATA,__objc_fork_ok'
 endif
+
+if use_mysql_backend
+    cnid_dbd_deps += mysqlclient
+endif
+
+cnid_metad_sources = ['cnid_metad.c', 'usockfd.c', 'db_param.c']
+
+dbd_sources = [
+    'cmd_dbd.c',
+    'cmd_dbd_scanvol.c',
+    'dbd_add.c',
+    'dbd_delete.c',
+    'dbd_getstamp.c',
+    'dbd_lookup.c',
+    'dbd_rebuild_add.c',
+    'dbd_resolve.c',
+    'dbd_update.c',
+    'dbif.c',
+    'pack.c',
+]
+
+executable(
+    'cnid_dbd',
+    cnid_dbd_sources,
+    include_directories: [bdb_includes, root_includes],
+    link_with: libatalk,
+    dependencies: [cnid_dbd_deps, db],
+    c_args: [cnid_dbd, dversion],
+    link_args: [bdb_link_args, cnid_dbd_link_args],
+    install: true,
+    install_dir: sbindir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)
+executable(
+    'cnid_metad',
+    cnid_metad_sources,
+    include_directories: root_includes,
+    link_with: libatalk,
+    dependencies: cnid_dbd_deps,
+    c_args: [cnid_dbd, dversion, cnid_dbd_link_args],
+    install: true,
+    install_dir: sbindir,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)
+executable(
+    'dbd',
+    dbd_sources,
+    include_directories: [bdb_includes, root_includes],
+    link_with: libatalk,
+    dependencies: [cnid_dbd_deps, db],
+    c_args: dversion,
+    link_args: bdb_link_args,
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/etc/meson.build
+++ b/etc/meson.build
@@ -1,8 +1,12 @@
 if have_spotlight
     subdir('spotlight')
 endif
+
+if use_dbd_backend
+    subdir('cnid_dbd')
+endif
+
 subdir('afpd')
-subdir('cnid_dbd')
 subdir('netatalk')
 subdir('uams')
 

--- a/etc/netatalk/meson.build
+++ b/etc/netatalk/meson.build
@@ -1,5 +1,10 @@
 netatalk_sources = ['afp_avahi.c', 'afp_mdns.c', 'afp_zeroconf.c', 'netatalk.c']
 netatalk_deps = [libevent]
+netatalk_link_args = []
+
+if host_os == 'darwin'
+    netatalk_link_args += '-Wl,-sectcreate,__DATA,__objc_fork_ok'
+endif
 
 if use_mysql_backend
     netatalk_deps += mysqlclient
@@ -17,7 +22,7 @@ executable(
     include_directories: root_includes,
     link_with: libatalk,
     dependencies: netatalk_deps,
-    c_args: [confdir, statedir, afpd, cnid_metad, dversion],
+    c_args: [confdir, statedir, afpd, cnid_metad, dversion, netatalk_link_args],
     install: true,
     install_dir: sbindir,
     build_rpath: rpath_libdir,


### PR DESCRIPTION
Rather than setting the `OBJC_DISABLE_INITIALIZE_FORK_SAFETY` env variable, use the linker to inject a section with `__DATA,__objc_fork_ok` into the resulting macOS binary. This allows for a more persistent way to bypass Apple's anti-forking policy.