### PR TITLE
meson: Favor openldap when building on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -424,7 +424,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          brew install berkeley-db cmark-gfm dbus docbook-xsl libxslt meson mysql talloc
+          brew install berkeley-db cmark-gfm dbus docbook-xsl libxslt meson mysql openldap talloc
       - name: Configure
         run: |
           meson setup build \

--- a/meson.build
+++ b/meson.build
@@ -1361,6 +1361,10 @@ ldap_path = get_option('with-ldap-path')
 
 ldap_link_args = []
 
+if ldap_path == '' and host_os == 'darwin' and fs.exists(macos_prefix / 'opt/openldap')
+    ldap_path = macos_prefix / 'opt/openldap'
+endif
+
 if ldap_path != ''
     ldap_link_args += ['-L' + ldap_path / 'lib', '-lldap']
     ldap = declare_dependency(


### PR DESCRIPTION
On macOS when doing `find_library('ldap')` Meson will find LDAP.Framework libraries which are deprecated by Apple.

Ref. https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/OSX_Technology_Overview/SystemFrameworks/SystemFrameworks.html

This adds extra logic to the Meson build script to look for openldap libraries as installed by Homebrew, which is the most common use case.

It is still possible to override the logic with the `with-ldap-path` Meson option, if someone has rolled their own openldap installation.