### PR TITLE
Remove obsoleted Mac OS X Server compatibility code in module.c

### DIFF
--- a/libatalk/util/module.c
+++ b/libatalk/util/module.c
@@ -10,42 +10,7 @@
 
 #include <atalk/util.h>
 
-#ifndef HAVE_DLFCN_H
-#ifdef MACOSX_SERVER
-#include <mach-o/dyld.h>
-
-void *mod_open(const char *path)
-{
-  NSObjectFileImage file;
-
-  if (NSCreateObjectFileImageFromFile(path, &file) !=
-      NSObjectFileImageSuccess)
-    return NULL;
-  return NSLinkModule(file, path, TRUE);
-}
-
-void *mod_symbol(void *module, const char *name)
-{
-   NSSymbol symbol;
-   char *underscore;
-
-   if ((underscore = (char *) malloc(strlen(name) + 2)) == NULL)
-     return NULL;
-   strcpy(underscore, "_");
-   strcat(underscore, name);
-   symbol = NSLookupAndBindSymbol(underscore);
-   free(underscore);
-
-   return NSAddressOfSymbol(symbol);
-}
-
-void mod_close(void *module)
-{
-  NSUnLinkModule(module, FALSE);
-}
-#endif /* MACOSX_SERVER */
-
-#else /* HAVE_DLFCN_H */
+#ifdef HAVE_DLFCN_H
 
 #include <dlfcn.h>
 


### PR DESCRIPTION
Straggler compatibility code for running on the long-obsoleted OSX Server