### PR TITLE
Set resource max limit to 10240 on macOS

### DIFF
--- a/etc/afpd/main.c
+++ b/etc/afpd/main.c
@@ -201,10 +201,10 @@ static int setlimits(void)
         LOG(log_warning, logtype_afpd, "setlimits: reading current limits failed: %s", strerror(errno));
         return -1;
     }
-    if (rlim.rlim_cur != RLIM_INFINITY && rlim.rlim_cur < 65535) {
-        rlim.rlim_cur = 65535;
-        if (rlim.rlim_max != RLIM_INFINITY && rlim.rlim_max < 65535)
-            rlim.rlim_max = 65535;
+    if (rlim.rlim_cur != RLIM_INFINITY && rlim.rlim_cur < RLIM_MAX) {
+        rlim.rlim_cur = RLIM_MAX;
+        if (rlim.rlim_max != RLIM_INFINITY && rlim.rlim_max < RLIM_MAX)
+            rlim.rlim_max = RLIM_MAX;
         if (setrlimit(RLIMIT_NOFILE, &rlim) != 0) {
             LOG(log_warning, logtype_afpd, "setlimits: increasing limits failed: %s", strerror(errno));
             return -1;

--- a/etc/cnid_dbd/cnid_metad.c
+++ b/etc/cnid_dbd/cnid_metad.c
@@ -422,10 +422,10 @@ static int setlimits(void)
         LOG(log_error, logtype_afpd, "setlimits: %s", strerror(errno));
         exit(1);
     }
-    if (rlim.rlim_cur != RLIM_INFINITY && rlim.rlim_cur < 65535) {
-        rlim.rlim_cur = 65535;
-        if (rlim.rlim_max != RLIM_INFINITY && rlim.rlim_max < 65535)
-            rlim.rlim_max = 65535;
+    if (rlim.rlim_cur != RLIM_INFINITY && rlim.rlim_cur < RLIM_MAX) {
+        rlim.rlim_cur = RLIM_MAX;
+        if (rlim.rlim_max != RLIM_INFINITY && rlim.rlim_max < RLIM_MAX)
+            rlim.rlim_max = RLIM_MAX;
         if (setrlimit(RLIMIT_NOFILE, &rlim) != 0) {
             LOG(log_error, logtype_afpd, "setlimits: %s", strerror(errno));
             exit(1);

--- a/include/atalk/util.h
+++ b/include/atalk/util.h
@@ -24,6 +24,14 @@
 #include <atalk/cnid.h>
 #include <atalk/unicode.h>
 
+#ifndef RLIM_MAX
+#ifdef __APPLE__
+#define RLIM_MAX 10240
+#else
+#define RLIM_MAX 65535
+#endif
+#endif
+
 /* exit error codes */
 #define EXITERR_CLNT 1  /* client related error */
 #define EXITERR_CONF 2  /* error in config files/cmd line parameters */


### PR DESCRIPTION
Earlier versions of macOS such as 10.15 Catalina will throw an error when ulimit is set to too high a number. This PR uses a compliant value when calling `setrlimit()` on macOS specifically.