### PR TITLE
docs: Trim indentation spaces from generated man pages

### DIFF
--- a/doc/man.xsl.in
+++ b/doc/man.xsl.in
@@ -2,6 +2,8 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
 <xsl:import href="@DOCBOOK_ROOT@/manpages/docbook.xsl"/>
 
+<xsl:strip-space elements="*"/>
+
 <!-- * Collect date from <refmiscinfo class="date"> -->
 <xsl:param name="refentry.date.profile.enabled">1</xsl:param>
 <xsl:param name="refentry.date.profile">


### PR DESCRIPTION
Indentation spaces from XML were transferred to man pages which lead to incorrect rendering (#1800)