### PR TITLE
GitHub CI: Build on Alpine Linux with localsearch/tinysparql

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
             libtracker \
             libxslt \
             linux-pam-dev \
+            localsearch \
             mariadb-dev \
             meson \
             ninja \
@@ -75,9 +76,7 @@ jobs:
             pkgconfig \
             rpcsvc-proto-dev \
             talloc-dev \
-            tracker \
-            tracker-dev \
-            tracker-miners \
+            tinysparql-dev \
             unicode-character-database
       - name: Configure
         run: |


### PR DESCRIPTION
Alpine Linux 3.21 has now moved to localsearch and tinysparql, the new names for tracker libraries.