### PR TITLE
docs: Document that DocBook XSL has to be non-namespaced

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -83,6 +83,7 @@ Required:
 
 Required for Spotlight support:
 
+  - D-Bus (also used by avahi and afpstats)
   - talloc
   - tracker version 0.12 or later, or tinysparql and localsearch version 3.8.0 or later
   - bison
@@ -91,9 +92,10 @@ Required for Spotlight support:
 Optional:
 
   - avahi or mDNSresponder           (for Zeroconf support)
+  - cmark-gfm                        (for converting Markdown to plain text)
   - cracklib and cracklib dictionary (for password strength check in afppasswd)
-  - Docbook XSL and xsltproc         (for manpages & manual documentation)
-  - GLib 2 and D-Bus                 (for afpstats support)
+  - Docbook XSL, non-namespaced      (for manpages & manual documentation)
+  - GLib 2 and GIO                   (for afpstats support)
   - Kerberos V                       (for krbV UAM support)
   - libacl                           (for ACL support)
   - libldap                          (for LDAP support)
@@ -102,6 +104,7 @@ Optional:
   - Perl                             (for admin scripts)
   - tcpwrap                          (for TCP wrapper support)
   - [UnicodeData.txt](https://www.unicode.org/Public/UNIDATA/UnicodeData.txt)                  (for regenerating Unicode lookup tables)
+  - xsltproc or libxslt              (for manpages & manual documentation)
 
 More details about dependencies can be found in the documentation at
 https://netatalk.io/stable/htmldocs/installation

--- a/doc/ja/manual/install.xml
+++ b/doc/ja/manual/install.xml
@@ -29,11 +29,10 @@
       <para>Netatalk のバイナリーパッケージは、いくつかの Linux、BSD、Solaris
       ディストリビューションに含まれている。通常の配布元も見たいだろうと思う。</para>
 
-      <para>第三者が提供しているパッケージ リポジトリも参照する手もある。例えば、Red Hat 派生 Linux
-      ディストリビューションの為の <ulink url="https://rpmfind.net/">rpmfind</ulink>、
-      Solaris 系 OS の為の <ulink
-      url="https://www.opencsw.org/">OpenCSW</ulink>、そして macOS の為の <ulink
-      url="https://brew.sh/">Homebrew</ulink> か <ulink
+      <para>第三者が提供しているパッケージ リポジトリも参照する手もある。例えば、Red Hat 派生 Linux ディストリビューションの為の
+      <ulink url="https://rpmfind.net/">rpmfind</ulink>、 Solaris 系 OS の為の
+      <ulink url="https://www.opencsw.org/">OpenCSW</ulink>、そして macOS の為の
+      <ulink url="https://brew.sh/">Homebrew</ulink> か <ulink
       url="https://www.macports.org/">MacPorts</ulink>。</para>
     </sect2>
 
@@ -154,7 +153,15 @@ Resolving deltas: 100% (32227/32227), done.
             Netatalk は、Avahi または mDNSResponder を使用して AFP ファイル共有と Time Machine
             ボリュームをアドバタイズできる。</para>
 
-            <para>Avahi を使用する場合は、D-Bus または D-Bus サポートを有効になっている Avahi ライブラリは必要になる。</para>
+            <para>Avahi を使用する場合は、D-Bus または D-Bus サポートを有効になっている Avahi
+            ライブラリは必要になる。</para>
+          </listitem>
+
+          <listitem>
+            <para>cmark-gfm</para>
+
+            <para>CommonMark は、マークダウンをプレーンテキストに変換するために使用され、Netatalk の README
+            をインストールまたはパッケージ化するのに使われる。</para>
           </listitem>
 
           <listitem>
@@ -178,9 +185,10 @@ Resolving deltas: 100% (32227/32227), done.
           <listitem>
             <para>DocBook XSL および xsltproc</para>
 
-            <para>このマニュアルを含む Netatalk ドキュメントは、XML 形式で作成されている。次に、DocBook XSL
+            <para>このマニュアルを含む Netatalk ドキュメントは、XML 形式で作成されている。DocBook XSL
             スタイルシートと xsltproc を使用して、XML を troff (マニュアル ページ用)、html、pdf
-            などの人間が読める形式に変換する。</para>
+            などの人間が読める形式に変換する。DocBook XSL
+            スタイルシートは名前空間化されていない必要があることに注意してください。</para>
           </listitem>
 
           <listitem>
@@ -232,9 +240,9 @@ Resolving deltas: 100% (32227/32227), done.
           <listitem>
             <para>Perl</para>
 
-            <para>Netatalk の管理ユーティリティ スクリプトは、Perl ランタイム バージョン 5.8
-            以降に依存する。必須 Perl モジュールは以下： <emphasis>IO::Socket::IP</emphasis>
-            (asip-status) 又は <emphasis>Net::DBus</emphasis> (afpstats)。</para>
+            <para>Netatalk の管理ユーティリティ スクリプトは、Perl ランタイム バージョン 5.8 以降に依存する。必須
+            Perl モジュールは以下： <emphasis>IO::Socket::IP</emphasis> (asip-status)
+            又は <emphasis>Net::DBus</emphasis> (afpstats)。</para>
           </listitem>
 
           <listitem>

--- a/doc/manual/install.xml
+++ b/doc/manual/install.xml
@@ -169,6 +169,14 @@ Resolving deltas: 100% (32227/32227), done.
           </listitem>
 
           <listitem>
+            <para>cmark-gfm</para>
+
+            <para>CommonMark is used to translate markdown to plain text,
+            which is useful for installing or packaging Netatalk's
+            READMEs.</para>
+          </listitem>
+
+          <listitem>
             <para>CrackLib</para>
 
             <para>When using the Random Number UAMs and netatalk's own
@@ -192,16 +200,17 @@ Resolving deltas: 100% (32227/32227), done.
             <para>DocBook XSL and xsltproc</para>
 
             <para>The Netatalk documentation, including this manual, are
-            authored in XML format. Then DocBook XSL stylesheets and xsltproc
-            are used to transcode the XML to other human-readable formats
-            such as troff (for man pages), html, or pdf.</para>
+            authored in XML format. DocBook XSL stylesheets and xsltproc are
+            used to transcode the XML to other human-readable formats such as
+            troff (for man pages), html, or pdf. Note that the DocBook XSL
+            stylesheets have to be non-namespaced.</para>
           </listitem>
 
           <listitem>
             <para>GLib and GIO</para>
 
-            <para>Used by the <userinput>afpstats</userinput> tool to interface
-            with D-Bus.</para>
+            <para>Used by the <userinput>afpstats</userinput> tool to
+            interface with D-Bus.</para>
           </listitem>
 
           <listitem>
@@ -252,10 +261,10 @@ Resolving deltas: 100% (32227/32227), done.
           <listitem>
             <para>Perl</para>
 
-            <para>Netatalk's administrative utility scripts rely
-            on the Perl runtime, version 5.8 or later. The required Perl
-            modules include <emphasis>IO::Socket::IP</emphasis> (asip-status)
-            and <emphasis>Net::DBus</emphasis> (afpstats).</para>
+            <para>Netatalk's administrative utility scripts rely on the Perl
+            runtime, version 5.8 or later. The required Perl modules include
+            <emphasis>IO::Socket::IP</emphasis> (asip-status) and
+            <emphasis>Net::DBus</emphasis> (afpstats).</para>
           </listitem>
 
           <listitem>


### PR DESCRIPTION
Also, document CommonMark, a few other clarifications. Then run auto-format with XMLmind.

For more background, see https://github.com/Netatalk/netatalk/issues/318