### PR TITLE
initscripts: Disable fork safety workaround for macOS

### DIFF
--- a/distrib/initscripts/macos.netatalk.in
+++ b/distrib/initscripts/macos.netatalk.in
@@ -3,7 +3,7 @@
 # # Startup daemon for netatalk on macOS
 
 # Prepare the environment
-export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+# export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 . /etc/rc.common
 
 # root check


### PR DESCRIPTION
The build system should no longer link with Apple Objective-C frameworks