### PR TITLE
Add native metadata storage for macOS hosts.

### DIFF
--- a/doc/ja/manual/upgrade.xml
+++ b/doc/ja/manual/upgrade.xml
@@ -127,7 +127,13 @@
           <listitem>
             <para>Mac のメタデータ（すなわち FinderInfo、AFP フラグ、コメント、CNID）は
             “<filename>org.netatalk.Metadata</filename>”
-            という名前の拡張属性に保存される。</para>
+            という名前の拡張属性に保存される。<itemizedlist>
+                <listitem>
+                  <para>さらに、Netatalk 4.1.0以降を実行しているmacOSホストでは、FinderInfo
+                  はファイルシステムにネイティブに保存され、"com.apple.FinderInfo"
+                  という名前の拡張属性として表示されます。</para>
+                </listitem>
+              </itemizedlist></para>
           </listitem>
 
           <listitem>
@@ -142,6 +148,9 @@
                   <para>ないしは、ファイル名が “<filename>file</filename>”
                   であるものに対して各々、“<filename>._file</filename>” という名の別の
                   AppleDouble ファイルに保存される。</para>
+                </listitem>
+                <listitem>
+                  <para>Netatalk 4.1.0 以降、macOS ホスト上のリソース フォークにネイティブに保存されています。</para>
                 </listitem>
               </itemizedlist></para>
           </listitem>

--- a/doc/manual/upgrade.xml
+++ b/doc/manual/upgrade.xml
@@ -129,7 +129,14 @@
           <listitem>
             <para>stores Mac Metadata (eg FinderInfo, AFP Flags, Comment,
             CNID) in an Extended Attributed named
-            “<filename>org.netatalk.Metadata</filename>”</para>
+            “<filename>org.netatalk.Metadata</filename>”<itemizedlist>
+                <listitem>
+                  <para>Additionally, on macOS hosts running Netatalk 4.1.0 or 
+                  later, FinderInfo is natively stored in the file system and
+                  appears as an Extended Attribute named
+                  “<filename>com.apple.FinderInfo</filename>”</para>
+                </listitem>
+              </itemizedlist></para>
           </listitem>
 
           <listitem>
@@ -143,7 +150,12 @@
                 <listitem>
                   <para>an extra AppleDouble file named
                   “<filename>._file</filename>” for a file named
-                  “<filename>file</filename>”</para>
+                  “<filename>file</filename>” or</para>
+                </listitem>
+
+                <listitem>
+                  <para>natively stored in the resource fork
+                  on macOS hosts as of Netatalk 4.1.0.</para>
                 </listitem>
               </itemizedlist></para>
           </listitem>

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -105,6 +105,18 @@ void *get_finderinfo(const struct vol *vol, const char *upath, struct adouble *a
             memcpy((char *)data + FINDERINFO_FRFLAGOFF, &ashort, sizeof(ashort));
         }
     }
+#ifdef __APPLE__
+    /* If no adouble finder information was found, check for native macOS info */
+    if (chk_ext && (vol->v_adouble == AD_VERSION_EA))
+    {
+        char NativeFinderInfo[32] ={'\0'};
+        if (ad_open_native_finderinfo(upath, NativeFinderInfo))
+        {
+            memcpy(data, NativeFinderInfo, ADEDLEN_FINDERI);
+            chk_ext = 0;
+        }
+    }
+#endif
 
     if (islink && !vol_syml_opt(vol)) {
         uint16_t linkflag;

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -412,6 +412,9 @@ extern void ad_init       (struct adouble *, const struct vol * restrict);
 extern void ad_init_old   (struct adouble *ad, int flags, int options);
 extern int ad_init_offsets(struct adouble *ad);
 extern int ad_open        (struct adouble *ad, const char *path, int adflags, ...);
+#ifdef __APPLE__
+extern int ad_open_native_finderinfo(const char *path, char *ret);
+#endif
 extern int ad_openat      (struct adouble *, int dirfd, const char *path, int adflags, ...);
 extern int ad_refresh     (const char *path, struct adouble *);
 extern int ad_stat        (const char *, struct stat *);

--- a/include/atalk/ea.h
+++ b/include/atalk/ea.h
@@ -88,8 +88,14 @@ enum {
 
 /* Names for our Extended Attributes adouble data */
 #define AD_EA_META "org.netatalk.Metadata"
+#ifdef __APPLE__
+#define AD_EA_RESO "com.apple.ResourceFork"
+#define EA_FINFO "com.apple.FinderInfo"
+#define NOT_NETATALK_EA(a) (strcmp((a), AD_EA_META) != 0) && (strcmp((a), AD_EA_RESO) != 0) && (strcmp((a), EA_FINFO) != 0)
+#else
 #define AD_EA_RESO "org.netatalk.ResourceFork"
 #define NOT_NETATALK_EA(a) (strcmp((a), AD_EA_META) != 0) && (strcmp((a), AD_EA_RESO) != 0)
+#endif
 
 /****************************************************************************************
  * Wrappers for native EA functions taken from Samba

--- a/libatalk/adouble/ad_conv.c
+++ b/libatalk/adouble/ad_conv.c
@@ -113,6 +113,14 @@ static int ad_conv_v22ea_hf(const char *path, const struct stat *sp, const struc
 copy:
     /* Create a adouble:ea meta EA */
     LOG(log_debug, logtype_ad,"ad_conv_v22ea_hf(\"%s\"): copying adouble", fullpathname(path), ret);
+#ifdef __APPLE__
+    /* Create macOS native FinderInfo EA */
+    char * FinderInfo;
+    char NativeFinderInfo[32]={'\0'};
+    FinderInfo = ad_entry(&adv2, ADEID_FINDERI);
+    memcpy(NativeFinderInfo, FinderInfo,ADEDLEN_FINDERI);
+    EC_ZERO_LOG( sys_setxattr(path, EA_FINFO, NativeFinderInfo, ADEDLEN_FINDERI, 0) );
+#endif
     EC_ZERO_LOGSTR( ad_open(&adea, path, adflags | ADFLAGS_HF | ADFLAGS_RDWR | ADFLAGS_CREATE),
                     "ad_conv_v22ea_hf(\"%s\"): error creating metadata EA: %s",
                     fullpathname(path), strerror(errno));

--- a/libatalk/vfs/extattr.c
+++ b/libatalk/vfs/extattr.c
@@ -82,7 +82,7 @@ static char attr_name[256 +5] = "user.";
 
 static const char *prefix(const char *uname)
 {
-#if defined(SOLARIS)
+#if defined(SOLARIS) || defined(__APPLE__)
 	return uname;
 #else
 	strlcpy(attr_name +5, uname, 256);
@@ -124,6 +124,11 @@ ssize_t sys_getxattr (const char *path, const char *uname, void *value, size_t s
 	return getxattr(path, name, value, size);
 #else
 	int options = 0;
+#ifdef __APPLE__
+        /* macOS only returns EA size if value is NULL */
+        if (size == 0)
+            value = NULL;
+#endif
 	return getxattr(path, name, value, size, 0, options);
 #endif
 #elif defined(HAVE_GETEA)
@@ -182,6 +187,11 @@ ssize_t sys_fgetxattr (int filedes, const char *uname, void *value, size_t size)
     return fgetxattr(filedes, name, value, size);
 #else
     int options = 0;
+#ifdef __APPLE__
+    /* macOS only returns EA size if value is NULL */
+    if (size == 0)
+        value = NULL;
+#endif
     return fgetxattr(filedes, name, value, size, 0, options);
 #endif
 #elif defined(HAVE_FGETEA)
@@ -240,6 +250,11 @@ ssize_t sys_lgetxattr (const char *path, const char *uname, void *value, size_t 
 	return lgetxattr(path, name, value, size);
 #elif defined(HAVE_GETXATTR) && defined(XATTR_ADD_OPT)
 	int options = XATTR_NOFOLLOW;
+#ifdef __APPLE__
+        /* macOS only returns EA size if value is NULL */
+        if (size == 0)
+            value = NULL;
+#endif
 	return getxattr(path, name, value, size, 0, options);
 #elif defined(HAVE_LGETEA)
 	return lgetea(path, name, value, size);
@@ -444,7 +459,10 @@ static ssize_t remove_user(ssize_t ret, char *list, size_t size)
 	char *ptr;
 	char *ptr1;
 	ssize_t ptrsize;
-
+#ifdef __APPLE__
+        /* macOS doesn't prefix EAs with "user." */
+        return ret;
+#else
 	if (ret <= 0 || size == 0)
 		return ret;
 	ptrsize = ret;
@@ -461,6 +479,7 @@ static ssize_t remove_user(ssize_t ret, char *list, size_t size)
 		ptr1 += len;
 	}
 	return ptr -list;
+#endif
 }
 #endif
 
@@ -680,8 +699,7 @@ int sys_setxattr (const char *path, const char *uname, const void *value, size_t
 #ifndef XATTR_ADD_OPT
 	return setxattr(path, name, value, size, flags);
 #else
-	int options = 0;
-	return setxattr(path, name, value, size, 0, options);
+	return setxattr(path, name, value, size, 0, flags);
 #endif
 #elif defined(HAVE_SETEA)
 	return setea(path, name, value, size, flags);
@@ -743,8 +761,7 @@ int sys_fsetxattr (int filedes, const char *uname, const void *value, size_t siz
 #ifndef XATTR_ADD_OPT
     return fsetxattr(filedes, name, value, size, flags);
 #else
-    int options = 0;
-    return fsetxattr(filedes, name, value, size, 0, options);
+    return fsetxattr(filedes, name, value, size, 0, flags);
 #endif
 #elif defined(HAVE_FSETEA)
     return fsetea(filedes, name, value, size, flags);
@@ -807,8 +824,8 @@ int sys_lsetxattr (const char *path, const char *uname, const void *value, size_
 #if defined(HAVE_LSETXATTR)
 	return lsetxattr(path, name, value, size, flags);
 #elif defined(HAVE_SETXATTR) && defined(XATTR_ADD_OPT)
-	int options = XATTR_NOFOLLOW;
-	return setxattr(path, name, value, size, 0, options);
+	flags |= XATTR_NOFOLLOW;
+	return setxattr(path, name, value, size, 0, flags);
 #elif defined(LSETEA)
 	return lsetea(path, name, value, size, flags);
 #elif defined(HAVE_EXTATTR_SET_LINK)

--- a/libatalk/vfs/vfs.c
+++ b/libatalk/vfs/vfs.c
@@ -552,7 +552,7 @@ static int RF_deletefile_ea(VFS_FUNC_ARGS_DELETEFILE)
 }
 static int RF_copyfile_ea(VFS_FUNC_ARGS_COPYFILE)
 {
-#ifdef HAVE_EAFD
+#if defined (HAVE_EAFD) && defined (SOLARIS)
     /* the EA VFS module does this all for us */
     return 0;
 #endif
@@ -575,8 +575,14 @@ static int RF_copyfile_ea(VFS_FUNC_ARGS_COPYFILE)
     EC_NULL(dup2 = strdup(src));
     EC_NULL(dir = dirname(dup2));
     EC_NULL(s = bfromcstr(dir));
+#ifdef __APPLE__
+    EC_ZERO(bcatcstr(s, "/"));
+    EC_ZERO(bcatcstr(s, name));
+    EC_ZERO(bcatcstr(s, "/..namedfork/rsrc"));
+#else
     EC_ZERO(bcatcstr(s, "/._"));
     EC_ZERO(bcatcstr(s, name));
+#endif
 
     /* build dst path to ._file*/
     EC_NULL(dup4 = strdup(dst));
@@ -585,8 +591,14 @@ static int RF_copyfile_ea(VFS_FUNC_ARGS_COPYFILE)
     EC_NULL(dup3 = strdup(dst));
     EC_NULL(dir = dirname(dup3));
     EC_NULL(d = bfromcstr(dir));
+#ifdef __APPLE__
+    EC_ZERO(bcatcstr(d, "/"));
+    EC_ZERO(bcatcstr(d, name));
+    EC_ZERO(bcatcstr(d, "/..namedfork/rsrc"));
+#else
     EC_ZERO(bcatcstr(d, "/._"));
     EC_ZERO(bcatcstr(d, name));
+#endif
 
     if (copy_file(sfd, cfrombstr(s), cfrombstr(d), 0666) != 0) {
         switch (errno) {
@@ -864,7 +876,7 @@ void initvol_vfs(struct vol *vol)
         vol->ad_path = ad_path;
     } else {
         vol->vfs_modules[0] = &netatalk_adouble_ea;
-#ifdef HAVE_EAFD
+#if defined(HAVE_EAFD) && defined(SOLARIS)
         vol->ad_path = ad_path_ea;
 #else
         vol->ad_path = ad_path_osx;

--- a/meson.build
+++ b/meson.build
@@ -1192,6 +1192,9 @@ elif cc.has_function('getxattr', dependencies: attr)
             cdata.set(define, 1)
         endif
     endforeach
+    if host_os == 'darwin'
+        cdata.set('HAVE_EAFD', 1)
+    endif
 else
     have_ea = false
 endif

--- a/test/testsuite/adoublehelper.c
+++ b/test/testsuite/adoublehelper.c
@@ -251,7 +251,7 @@ static int chmod_unix_adouble(char *path,char *name, int mode)
 int chmod_unix_meta(char *path, char *name, char *file, mode_t mode)
 {
     if (adouble == AD_EA) {
-#ifdef HAVE_EAFD
+#if defined (HAVE_EAFD) && defined (SOLARIS)
         sprintf(temp, "runat '%s/%s/%s' chmod 0%o %s", path, name, file, mode, AD_EA_META);
         if (!Quiet) {
             fprintf(stdout, "%s\n", temp);
@@ -288,7 +288,7 @@ int chmod_unix_meta(char *path, char *name, char *file, mode_t mode)
 int chmod_unix_rfork(char *path, char *name, char *file, mode_t mode)
 {
     if (adouble == AD_EA) {
-#ifdef HAVE_EAFD
+#if defined (HAVE_EAFD) && defined (SOLARIS)
         sprintf(temp, "runat '%s/%s/%s' chmod 0%o %s", path, name, file, mode, AD_EA_RESO);
         if (!Quiet) {
             fprintf(stdout, "%s\n", temp);
@@ -302,6 +302,7 @@ int chmod_unix_rfork(char *path, char *name, char *file, mode_t mode)
         }
         return 0;
 #else
+#ifndef __APPLE__
         sprintf(temp, "%s/%s/._%s", path, name, file);
         if (!Quiet) {
             fprintf(stdout, "chmod(%s, 0%o)\n", temp, mode);
@@ -313,6 +314,7 @@ int chmod_unix_rfork(char *path, char *name, char *file, mode_t mode)
             test_failed();
             return -1;
         }
+#endif
         return 0;
 #endif
     } else {

--- a/test/testsuite/ea.h
+++ b/test/testsuite/ea.h
@@ -67,8 +67,14 @@ enum {
 
 /* Names for our Extended Attributes adouble data */
 #define AD_EA_META "org.netatalk.Metadata"
+#ifdef __APPLE__
+#define AD_EA_RESO "com.apple.ResourceFork"
+#define EA_FINFO "com.apple.FinderInfo"
+#define NOT_NETATALK_EA(a) (strcmp((a), AD_EA_META) != 0) && (strcmp((a), AD_EA_RESO) != 0) && (strcmp((a), EA_FINFO) != 0)
+#else
 #define AD_EA_RESO "org.netatalk.ResourceFork"
 #define NOT_NETATALK_EA(a) (strcmp((a), AD_EA_META) != 0) && (strcmp((a), AD_EA_RESO) != 0)
+#endif
 
 /****************************************************************************************
  * Wrappers for native EA functions taken from Samba


### PR DESCRIPTION
-Store all extended attributes without the `user.` prefix on macOS. This will orphan Netatalk metadata created on past versions, but is needed for native extended attributes to work properly on shares. Unlike Linux, macOS doesn't prefix user created extended attributes with `user.`.

-Store resource forks natively by using the `/..namedfork/rsrc` path instead of creating AppleDouble files. No need for separate files since the file system supports it natively.

-Synchronize native FinderInfo (stored in `com.apple.FinderInfo`) with Netatalk. Any changes made to FinderInfo by Netatalk clients or by the host OS are now visible to each other. Note that the contents of `com.apple.FinderInfo` take priority of that over what is stored in Netatalk's extended attributes.