### PR TITLE
GitHub CI: Always use latest NetBSD release in runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -557,7 +557,6 @@ jobs:
       - name: Build on VM
         uses: vmactions/netbsd-vm@v1.1.4
         with:
-          release: "9.4"
           copyback: false
           prepare: |
             pkg_add \


### PR DESCRIPTION
Remove the hard-coded NetBSD 9.4 release target, and allow the runner to use the latest available version in the vmrunner.