### PR TITLE
GitHub CI: Use FreeBSD 14.2 vmactions runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -504,7 +504,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/freebsd-vm@v1.1.3
+        uses: vmactions/freebsd-vm@v1.1.6
         with:
           copyback: false
           prepare: |


### PR DESCRIPTION
The vmactions project has released v1.1.6 of the FreeBSD image with support for v14.2 of the OS.