### PR TITLE
meson: Introduce with-kerberos-path option for Heimdal compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -296,6 +296,7 @@ jobs:
             flex \
             gawk \
             gcc \
+            krb5-devel \
             libacl-devel \
             libavahi-devel \
             libdb-4_8-devel \
@@ -584,7 +585,6 @@ jobs:
               -Dbuildtype=release \
               -Dwith-appletalk=true \
               -Dwith-dtrace=false \
-              -Dwith-krbV-uam=false \
               -Dwith-tests=true
             meson compile -C build
             cd build
@@ -620,6 +620,7 @@ jobs:
               dbus \
               docbook-xsl \
               gcc-11.2.0p14 \
+              heimdal \
               libevent \
               libgcrypt \
               libtalloc \
@@ -636,6 +637,8 @@ jobs:
             meson setup build \
               -Dbuildtype=release \
               -Dpkg_config_path=/usr/local/lib/pkgconfig \
+              -Dwith-gssapi-path=/usr/local/heimdal \
+              -Dwith-kerberos-path=/usr/local/heimdal \
               -Dwith-tests=true
             meson compile -C build
             meson install -C build

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -33,6 +33,7 @@ afpd_c_args = []
 afpd_external_deps = [libgcrypt]
 afpd_internal_deps = []
 afpd_link_args = []
+afpd_includes = [root_includes]
 
 if have_appletalk
     afpd_sources += [
@@ -90,6 +91,7 @@ endif
 if have_kerberos
     afpd_external_deps += kerberos
     afpd_c_args += kerberos_c_args
+    afpd_includes += kerberos_includes
 endif
 
 if have_tcpwrap
@@ -114,7 +116,7 @@ endif
 libafpd = static_library(
     'afpd',
     afpd_sources,
-    include_directories: root_includes,
+    include_directories: afpd_includes,
     link_with: [afpd_internal_deps, libatalk],
     dependencies: afpd_external_deps,
     c_args: [
@@ -184,7 +186,7 @@ executable(
     'afpd',
     afpd_dtrace_input,
     objects: afpd_objs,
-    include_directories: root_includes,
+    include_directories: afpd_includes,
     link_with: [afpd_internal_deps, libatalk],
     dependencies: afpd_external_deps,
     c_args: [

--- a/meson.build
+++ b/meson.build
@@ -660,7 +660,7 @@ else
 
     if not enable_gssapi
         have_gssapi = false
-    elif get_option('with-gssapi-path') != ''
+    elif gssapi_path != ''
         have_gssapi = true
         gss = cc.find_library(
             'gssapi',
@@ -702,10 +702,9 @@ else
     #
 
     enable_kerberos = get_option('with-kerberos')
+    kerberos_path = get_option('with-kerberos-path')
 
-    kerberos = cc.find_library('krb5', dirs: libsearch_dirs, required: false)
-    krb5_config = find_program('krb5-config', required: false)
-
+    kerberos_includes = []
     kerberos_c_args = []
     kerberos_headers = [
         'kerberosv5/krb5.h',
@@ -713,12 +712,33 @@ else
         'krb5/krb5.h',
     ]
 
+    if kerberos_path != ''
+        kerberos = cc.find_library(
+            'krb5',
+            dirs: kerberos_path / 'lib',
+            required: false,
+        )
+        kerberos_includes += include_directories(kerberos_path / 'include')
+
+        krb5_config = find_program(
+            'krb5-config',
+            dirs: kerberos_path / 'bin',
+            required: false,
+        )
+    else
+        kerberos = cc.find_library('krb5', dirs: libsearch_dirs, required: false)
+        krb5_config = find_program('krb5-config', required: false)
+    endif
+
     foreach header : kerberos_headers
         if cc.has_header(
             header,
-            include_directories: include_directories(header_dir),
+            include_directories: include_directories(
+                [kerberos_path / 'include', header_dir],
+            )
         )
             cdata.set('HAVE_' + header.underscorify().to_upper(), 1)
+            break
         endif
     endforeach
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -256,6 +256,12 @@ option(
     description: 'Set path to OS specific init directory',
 )
 option(
+    'with-kerberos-path',
+    type: 'string',
+    value: '',
+    description: 'Set path to Kerberos V library. Must contain lib and include dirs',
+)
+option(
     'with-ldap-path',
     type: 'string',
     value: '',

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -35,6 +35,7 @@ test_c_args = []
 test_external_deps = [libgcrypt]
 test_internal_deps = []
 test_link_args = []
+test_includes = [root_includes]
 
 if have_spotlight
     test_sources += [
@@ -73,6 +74,7 @@ endif
 if have_kerberos
     test_external_deps += kerberos
     test_c_args += kerberos_c_args
+    test_includes += kerberos_includes
 endif
 
 if have_tcpwrap
@@ -97,7 +99,7 @@ endif
 afpdtestlib = static_library(
     'afpdtestlib',
     test_sources,
-    include_directories: root_includes,
+    include_directories: test_includes,
     link_with: [test_internal_deps, libatalk],
     dependencies: [
         test_external_deps,
@@ -169,7 +171,7 @@ afpdtest = executable(
     'afpdtest',
     afpdtest_dtrace_input,
     objects: test_objs,
-    include_directories: root_includes,
+    include_directories: test_includes,
     link_with: [test_internal_deps, libatalk],
     dependencies: [
         test_external_deps,


### PR DESCRIPTION
Heimdal's krb5 compatibility headers, shared libraries and binaries lives in `/usr/local/heimdal` on (at least) OpenBSD. This introduces a `-Dwith-kerberos-path` that can be used to get Meson to look for dependencies in this location.

Additionally, introduced a break when finding first krb.h header which avoids including broken `krb5/krb5.h` header on NetBSD.

With these changes, the krbV UAM can now be built on NetBSD, OpenBSD, and openSUSE