### PR TITLE
GitHub CI: Bump to NetBSD 10.1 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -556,7 +556,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/netbsd-vm@v1.1.4
+        uses: vmactions/netbsd-vm@v1.1.6
         with:
           copyback: false
           prepare: |


### PR DESCRIPTION
vmactions image v1.1.6 ships NetBSD 10.1