### PR TITLE
Loosen AppleDouble checks for macOS

### DIFF
--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -1588,7 +1588,11 @@ static bool ad_entry_check_size(uint32_t eid,
 		[ADEID_SHORTNAME] = {ADEDLEN_SHORTNAME, false, false},
 		[ADEID_AFPFILEI] = {ADEDLEN_AFPFILEI, true, false},
 		[ADEID_DID] = {ADEDLEN_DID, true, false},
+#ifdef __APPLE__
+		[ADEID_PRIVDEV] = {ADEDLEN_PRIVDEV, false, false},
+#else
 		[ADEID_PRIVDEV] = {ADEDLEN_PRIVDEV, true, false},
+#endif
 		[ADEID_PRIVINO] = {ADEDLEN_PRIVINO, true, false},
 		[ADEID_PRIVSYN] = {ADEDLEN_PRIVSYN, true, false},
 		[ADEID_PRIVID] = {ADEDLEN_PRIVID, true, false},


### PR DESCRIPTION
The length of `dev_t` on macOS is 4 as opposed to 8 on other platforms. The current code that checks the validity of AppleDouble headers expects the length of a `PRIVDEV` AppleDouble entry to always be fixed at 8. Once this fix is applied, the function `ad_getid()` appear to be working and filesystem information (dev, ino, etc) is now being written to AppleDouble files. Scans with the `dbd` tool should also work now. Previously they were failing with not being able to retrieve data from AppleDouble files.

Right now, Darwin/macOS is the only platform this appears to be an issue on, so we only loosen the check on that platform. If other platforms have this issue, we can later remove the #ifdef macro. May fix #1826