### PR TITLE
testsuite: Restore file ID checks following fix for macOS AD validation

### DIFF
--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -990,8 +990,7 @@ DSI *dsi = &Conn->dsi;
 			if (!Quiet) {
 				fprintf(stdout,"\tNOTE FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
 			}
-			// FIXME; file ID gets changed on f.e. macOS
-			// test_failed();
+			test_failed();
 
 		}
 		else {

--- a/test/testsuite/T2_FPMoveAndRename.c
+++ b/test/testsuite/T2_FPMoveAndRename.c
@@ -188,8 +188,7 @@ int id1;
 		if (!Quiet) {
 			fprintf(stdout,"\tNOTE id are not the same %d %d\n", ntohl(id), ntohl(id1));
 		}
-		// FIXME; file ID gets changed on f.e. macOS
-		// test_failed();
+		test_failed();
 	}
 	FAIL (FPDelete(Conn, vol,  dir , name2))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))

--- a/test/testsuite/T2_FPResolveID.c
+++ b/test/testsuite/T2_FPResolveID.c
@@ -286,8 +286,7 @@ DSI *dsi = &Conn->dsi;
 			if (!Quiet) {
 				fprintf(stdout,"\tNOTE FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
 			}
-			// FIXME; file ID gets changed on f.e. macOS
-			// test_failed();
+			test_failed();
 
 		}
 		else {
@@ -453,8 +452,7 @@ DSI *dsi = &Conn->dsi;
 			if (!Quiet) {
 				fprintf(stdout,"\tNOTE FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
 			}
-			// FIXME; file ID gets changed on f.e. macOS
-			// test_failed();
+			test_failed();
 
 		}
 		else {
@@ -597,7 +595,6 @@ DSI *dsi = &Conn->dsi;
 	}
 
 	if (FPGetFileDirParams(Conn, vol,  dir1 , name, bitmap,0)) {
-		// FIXME: Why does this assertion fail on macOS?
 		test_failed();
 		goto fin;
 	}
@@ -608,8 +605,7 @@ DSI *dsi = &Conn->dsi;
 		if (!Quiet) {
 			fprintf(stdout,"\tNOTE FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
 		}
-		// FIXME; file ID gets changed on f.e. macOS
-		// test_failed();
+		test_failed();
 
 	}
 	else {
@@ -705,8 +701,7 @@ DSI *dsi = &Conn->dsi;
 		if (!Quiet) {
 			fprintf(stdout,"\tNOTE FPGetFileDirParams id differ %x %x\n", fid, filedir.did);
 		}
-		// FIXME; file ID gets changed on f.e. macOS
-		// test_failed();
+		test_failed();
 	}
 	else {
 		FAIL (FPResolveID(Conn, vol, filedir.did, bitmap))


### PR DESCRIPTION
With https://github.com/Netatalk/netatalk/pull/1829 the checks for unchanged IDs for files and dirs after file system operations are passing on macOS. This restores these assertions.