### PR TITLE
GitHub CI: Build with berkeley-db v5 on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -423,7 +423,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          brew install berkeley-db bison cmark-gfm dbus docbook-xsl libxslt meson mysql openldap talloc tracker
+          brew install berkeley-db@5 bison cmark-gfm dbus docbook-xsl libxslt meson mysql openldap talloc tracker
       - name: Configure
         run: |
           meson setup build \


### PR DESCRIPTION
Berkeley DB v5 is the last Sleepycat licensed version, and therefore the last GPLv2 compatible one. While I doubt the GitHub CI job can be considered redistribution, it's good to make it a habit to use v5 for all reference builds.