### PR TITLE
Deploy html manual to Pages only when doc files change

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -3,6 +3,9 @@ name: Deploy static content to Pages
 on:
   push:
     branches: ["main"]
+    paths:
+      - 'doc/**'
+      - 'meson.build'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
No need to re-deploy the static html manual when no manual files have changed.