### PR TITLE
Fix reported AFP versions when AppleTalk support is disabled.

### DIFF
--- a/etc/afpd/auth.h
+++ b/etc/afpd/auth.h
@@ -16,9 +16,11 @@ struct afp_versions {
 };
 
 static const struct afp_versions  afp_versions[] = {
+#ifndef NO_DDP
     { "AFPVersion 1.1", 11 },
     { "AFPVersion 2.0", 20 },
     { "AFPVersion 2.1", 21 },
+#endif /* ! NO_DDP */
     { "AFP2.2", 22 },
     { "AFPX03", 30 },
     { "AFP3.1", 31 },


### PR DESCRIPTION
Only report AFP2.2 or newer in FPGetSrvrInfo calls when compiling with AppleTalk disabled. This restores back Netatalk 2.x behavior.