### PR TITLE
GitHub CI: Use specific pkgsrc mirror for NetBSD package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -560,6 +560,7 @@ jobs:
         with:
           copyback: false
           prepare: |
+            export PKG_PATH=http://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/
             pkg_add \
               bison \
               db5 \


### PR DESCRIPTION
Letting pkg_add choose pkgsrc mirror leads to flaky results. This will force it to use the main netbsd.org mirror.