### PR TITLE
Remove the ability to run AFP commands with root privileges

### DIFF
--- a/contrib/webmin_module/netatalk-lib.pl
+++ b/contrib/webmin_module/netatalk-lib.pl
@@ -68,7 +68,6 @@ our %netatalkParameterDefaults = (
 	'prodos'				=> 'no',
 	'recvfile'					=> 'no',
 	'read only'					=> 'no',
-	'root preexec close'		=> 'no',
 	'save password'				=> 'yes',
 	'search db'					=> 'no',
 	'server quantum'			=> '1048576',

--- a/doc/ja/manpages/man5/afp.conf.5.xml
+++ b/doc/ja/manpages/man5/afp.conf.5.xml
@@ -1851,24 +1851,6 @@ directory perm = 0770</programlisting></para>
         </varlistentry>
 
         <varlistentry>
-          <term>root preexec = <replaceable>command</replaceable>
-          <type>(V)</type></term>
-
-          <listitem>
-            <para>ボリュームがマウントされる時にルート権限で実行されるコマンド</para>
-          </listitem>
-        </varlistentry>
-
-        <varlistentry>
-          <term>root postexec = <replaceable>command</replaceable>
-          <type>(V)</type></term>
-
-          <listitem>
-            <para>ボリュームが閉じられる時にルート権限で実行されるコマンド</para>
-          </listitem>
-        </varlistentry>
-
-        <varlistentry>
           <term>rolist = <option>users/groups</option> <type>(V)</type></term>
 
           <listitem>
@@ -2047,16 +2029,6 @@ directory perm = 0770</programlisting></para>
           <listitem>
             <para>その共有を全てのユーザーに対して読み込み専用と指定する。<option>ea = auto</option> は
             <option>ea = none</option> で上書きされる。</para>
-          </listitem>
-        </varlistentry>
-
-        <varlistentry>
-          <term>root preexec close= <replaceable>BOOLEAN</replaceable> (デフォルト:
-          <emphasis>no</emphasis>) <type>(V)</type></term>
-
-          <listitem>
-            <para>root_preexec からの 0
-            以外のリターンコードで、クライアントがボリュームをマウントする／見ることを防ぐために当該ボリュームを即座に閉じる。</para>
           </listitem>
         </varlistentry>
 

--- a/doc/ja/manual/upgrade.xml
+++ b/doc/ja/manual/upgrade.xml
@@ -2023,15 +2023,15 @@
               <row>
                 <entry>root_preexec:</entry>
 
-                <entry>root preexec</entry>
-
                 <entry>-</entry>
 
                 <entry>-</entry>
 
-                <entry>(V)</entry>
-
                 <entry>-</entry>
+
+                <entry></entry>
+
+                <entry>4.1.0で廃止</entry>
               </row>
 
               <row>
@@ -2051,15 +2051,15 @@
               <row>
                 <entry>root_postexec:</entry>
 
-                <entry>root postexec</entry>
+                <entry>-</entry>
+
+                <entry>-</entry>
 
                 <entry>-</entry>
 
                 <entry>-</entry>
 
-                <entry>(V)</entry>
-
-                <entry>-</entry>
+                <entry>4.1.0で廃止</entry>
               </row>
 
               <row>
@@ -2233,15 +2233,15 @@
               <row>
                 <entry>options:root_preexec_close</entry>
 
-                <entry>root preexec close</entry>
+                <entry>-</entry>
 
                 <entry>-</entry>
 
-                <entry>no</entry>
-
-                <entry>(V)</entry>
+                <entry>-</entry>
 
                 <entry>-</entry>
+
+                <entry>4.1.0で廃止</entry>
               </row>
 
               <row>

--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -2087,24 +2087,6 @@
         </varlistentry>
 
         <varlistentry>
-          <term>root preexec = <replaceable>command</replaceable>
-          <type>(V)</type></term>
-
-          <listitem>
-            <para>command to be run as root when the volume is mounted</para>
-          </listitem>
-        </varlistentry>
-
-        <varlistentry>
-          <term>root postexec = <replaceable>command</replaceable>
-          <type>(V)</type></term>
-
-          <listitem>
-            <para>command to be run as root when the volume is closed</para>
-          </listitem>
-        </varlistentry>
-
-        <varlistentry>
           <term>rolist = <option>users/groups</option> <type>(V)</type></term>
 
           <listitem>
@@ -2301,17 +2283,6 @@
             <para>Specifies the share as being read only for all users.
             Overwrites <option>ea = auto</option> with <option>ea =
             none</option></para>
-          </listitem>
-        </varlistentry>
-
-        <varlistentry>
-          <term>root preexec close= <replaceable>BOOLEAN</replaceable>
-          (default: <emphasis>no</emphasis>) <type>(V)</type></term>
-
-          <listitem>
-            <para>A non-zero return code from root_preexec closes the volume
-            immediately, preventing clients to mount/see the volume in
-            question.</para>
           </listitem>
         </varlistentry>
 

--- a/doc/manual/upgrade.xml
+++ b/doc/manual/upgrade.xml
@@ -608,7 +608,7 @@
 
                 <entry>(G)</entry>
 
-                <entry>Reinstated in 4.0.0</entry>
+                <entry>introduced in 4.0.0</entry>
               </row>
             </tbody>
           </tgroup>
@@ -1301,7 +1301,7 @@
 
                 <entry>(G)</entry>
 
-                <entry>Reinstated in 4.0.0</entry>
+                <entry>introduced in 4.0.0</entry>
               </row>
 
               <row>
@@ -1469,7 +1469,7 @@
 
                 <entry>(G)</entry>
 
-                <entry>Reinstated in 4.0.0</entry>
+                <entry>introduced in 4.0.0</entry>
               </row>
 
               <row>
@@ -1483,7 +1483,7 @@
 
                 <entry>(G)</entry>
 
-                <entry>Reinstated in 4.0.2</entry>
+                <entry>introduced in 4.0.2</entry>
               </row>
 
               <row>
@@ -2036,15 +2036,15 @@
               <row>
                 <entry>root_preexec:</entry>
 
-                <entry>root preexec</entry>
+                <entry>-</entry>
+
+                <entry>-</entry>
 
                 <entry>-</entry>
 
                 <entry>-</entry>
 
-                <entry>(V)</entry>
-
-                <entry>-</entry>
+                <entry>obsoleted in 4.1.0</entry>
               </row>
 
               <row>
@@ -2246,15 +2246,15 @@
               <row>
                 <entry>options:root_preexec_close</entry>
 
-                <entry>root preexec close</entry>
+                <entry>-</entry>
 
                 <entry>-</entry>
 
-                <entry>no</entry>
-
-                <entry>(V)</entry>
+                <entry>-</entry>
 
                 <entry>-</entry>
+
+                <entry>obsoleted in 4.1.0</entry>
               </row>
 
               <row>
@@ -2422,7 +2422,7 @@
 
                 <entry>(V)</entry>
 
-                <entry>Reinstated in 4.0.0</entry>
+                <entry>introduced in 4.0.0</entry>
               </row>
 
               <row>
@@ -2478,7 +2478,7 @@
 
                 <entry>(V)</entry>
 
-                <entry>Reinstated in 4.0.0</entry>
+                <entry>introduced in 4.0.0</entry>
               </row>
 
               <row>

--- a/etc/afpd/fce_api.c
+++ b/etc/afpd/fce_api.c
@@ -66,7 +66,7 @@
 // ONLY USED IN THIS FILE
 #include "fce_api_internal.h"
 
-extern int afprun_bg(int root, char *cmd);
+extern int afprun_bg(char *cmd);
 
 /* We store our connection data here */
 static struct udp_entry udp_socket_list[FCE_MAX_UDP_SOCKS];
@@ -368,7 +368,7 @@ static void send_fce_event(const AFPObj *obj, int event, const char *path, const
             bformata(cmd, " -S '%s'", bdata(boldpath));
             bdestroy(boldpath);
         }
-        (void)afprun_bg(1, bdata(cmd));
+        (void)afprun_bg(bdata(cmd));
         bdestroy(cmd);
     }
 

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -63,7 +63,7 @@
 
 #define VOLPASSLEN  8
 
-extern int afprun(int root, char *cmd, int *outfd);
+extern int afprun(char *cmd, int *outfd);
 
 /*!
  * Read band-size info from Info.plist XML file of an TM sparsebundle
@@ -763,15 +763,8 @@ int afp_openvol(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
         return stat_vol(obj, bitmap, volume, rbuf, rbuflen);
     }
 
-    if (volume->v_root_preexec) {
-        if ((ret = afprun(1, volume->v_root_preexec, NULL)) && volume->v_root_preexec_close) {
-            LOG(log_error, logtype_afpd, "afp_openvol(%s): root preexec : %d", volume->v_path, ret );
-            return AFPERR_MISC;
-        }
-    }
-
     if (volume->v_preexec) {
-        if ((ret = afprun(0, volume->v_preexec, NULL)) && volume->v_preexec_close) {
+        if ((ret = afprun(volume->v_preexec, NULL)) && volume->v_preexec_close) {
             LOG(log_error, logtype_afpd, "afp_openvol(%s): preexec : %d", volume->v_path, ret );
             return AFPERR_MISC;
         }
@@ -906,10 +899,7 @@ void closevol(const AFPObj *obj, struct vol *vol)
     }
 
     if (vol->v_postexec) {
-        afprun(0, vol->v_postexec, NULL);
-    }
-    if (vol->v_root_postexec) {
-        afprun(1, vol->v_root_postexec, NULL);
+        afprun(vol->v_postexec, NULL);
     }
 }
 

--- a/include/atalk/volume.h
+++ b/include/atalk/volume.h
@@ -90,11 +90,17 @@ struct vol {
     int             v_new;        /* volume deleted but there's a new one with the same name */
 #endif
     int             v_deleted;    /* volume open but deleted in new config file */
+#if 0
     char            *v_root_preexec;
+#endif
     char            *v_preexec;
+#if 0
     char            *v_root_postexec;
+#endif
     char            *v_postexec;
+#if 0
     int             v_root_preexec_close;
+#endif
     int             v_preexec_close;
     char            *v_uuid;    /* For TimeMachine zeroconf record */
     int             v_qfd;

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -885,12 +885,6 @@ static struct vol *creatvol(AFPObj *obj,
     if ((val = getoption(obj->iniconfig, section, "postexec", preset, NULL)))
         EC_NULL( volume->v_postexec = volxlate(obj, NULL, MAXPATHLEN, val, pwd, path, name) );
 
-    if ((val = getoption(obj->iniconfig, section, "root preexec", preset, NULL)))
-        EC_NULL( volume->v_root_preexec = volxlate(obj, NULL, MAXPATHLEN, val, pwd, path, name) );
-
-    if ((val = getoption(obj->iniconfig, section, "root postexec", preset, NULL)))
-        EC_NULL( volume->v_root_postexec = volxlate(obj, NULL, MAXPATHLEN, val, pwd, path, name) );
-
     if ((val = getoption(obj->iniconfig, section, "appledouble", preset, NULL))) {
         if (strcmp(val, "v2") == 0)
             volume->v_adouble = AD_VERSION2;
@@ -980,8 +974,6 @@ static struct vol *creatvol(AFPObj *obj,
 
     if (getoption_bool(obj->iniconfig, section, "preexec close", preset, 0))
         volume->v_preexec_close = 1;
-    if (getoption_bool(obj->iniconfig, section, "root preexec close", preset, 0))
-        volume->v_root_preexec_close = 1;
     if (vdgoption_bool(obj->iniconfig, section, "force xattr with sticky bit", preset, 0))
         volume->v_flags |= AFPVOL_FORCE_STICKY_XATTR;
 
@@ -1575,9 +1567,7 @@ void volume_free(struct vol *vol)
     free(vol->v_cnidserver);
     free(vol->v_cnidport);
     free(vol->v_preexec);
-    free(vol->v_root_preexec);
     free(vol->v_postexec);
-    free(vol->v_root_postexec);
 
     free(vol);
 }


### PR DESCRIPTION
This modifies the afprun() function to execute shell commands only as the current user, not as root.

Removing the following runtime options:

- root preexec
- root postexec
- root preexec close