### PR TITLE
macipgw: Introduce a configuration file

### DIFF
--- a/config/macipgw.conf
+++ b/config/macipgw.conf
@@ -1,0 +1,5 @@
+# MacIP Gateway daemon configuration (netatalk 4.x)
+[Global]
+network = 192.168.151.0
+netmask = 255.255.255.0
+nameserver = 8.8.8.8

--- a/config/meson.build
+++ b/config/meson.build
@@ -44,7 +44,7 @@ endif
 static_conf_files = ['extmap.conf']
 
 if have_appletalk
-    static_conf_files += ['atalkd.conf', 'papd.conf']
+    static_conf_files += ['atalkd.conf', 'macipgw.conf', 'papd.conf']
 endif
 
 foreach file : static_conf_files

--- a/contrib/macipgw/common.h
+++ b/contrib/macipgw/common.h
@@ -1,6 +1,7 @@
 /*
  *
  * (c) 1997 Stefan Bethke. All rights reserved.
+ * (c) 2025 Daniel Markstedt. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -18,3 +19,13 @@
  */
 
 typedef void (*outputfunc_t)(char *buffer, int len);
+
+typedef struct {
+    char *network;
+    char *netmask;
+    char *nameserver;
+    char *zone;
+    char *unprivileged_user;
+} macip_options;
+
+macip_options * read_options (const char *);

--- a/contrib/macipgw/macip.c
+++ b/contrib/macipgw/macip.c
@@ -33,6 +33,7 @@
 
 #include <signal.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>

--- a/contrib/macipgw/meson.build
+++ b/contrib/macipgw/meson.build
@@ -16,7 +16,11 @@ macipgw_sources = [
 
 macipgw_includes = include_directories('../../libatalk/atp')
 
-macipgw_c_args = ['-DSERVERTEXT="' + pkgconfdir + '/msg"', dversion]
+macipgw_c_args = [
+    '-DSERVERTEXT="' + pkgconfdir + '/msg"',
+    '-D_PATH_MACIPGWCONF="' + pkgconfdir + '/macipgw.conf"',
+    dversion,
+]
 
 executable(
     'macipgw',

--- a/contrib/macipgw/tunnel.h
+++ b/contrib/macipgw/tunnel.h
@@ -17,6 +17,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <stdint.h>
+
 extern int  tunnel_open (uint32_t net, uint32_t mask, outputfunc_t o);
 extern void tunnel_close (void);
 extern void tunnel_input (void);

--- a/contrib/macipgw/tunnel_bsd.c
+++ b/contrib/macipgw/tunnel_bsd.c
@@ -32,6 +32,7 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/contrib/macipgw/tunnel_linux.c
+++ b/contrib/macipgw/tunnel_linux.c
@@ -32,6 +32,7 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>

--- a/contrib/macipgw/util.c
+++ b/contrib/macipgw/util.c
@@ -21,36 +21,37 @@
 #include <sys/types.h>
 
 #include <stdio.h>
+#include <stdint.h>
 #include <stdlib.h>
 
 int gDebug;
 
 
-char *iptoa(u_long ip)
+char *iptoa(uint32_t ip)
 {
 	static char s[16];
 
-	sprintf(s, "%ld.%ld.%ld.%ld",
+	sprintf(s, "%u.%u.%u.%u",
 		(ip >> 24) & 0xff, (ip >> 16) & 0xff,
 		(ip >> 8) & 0xff, ip & 0xff);
 	return s;
 }
 
 
-u_long atoip(char *s)
+uint32_t atoip(char *s)
 {
-	u_long ip;
+	uint32_t ip;
 
-	ip = strtol(s, &s, 0);
+	ip = (uint32_t) strtol(s, &s, 0);
 	if (*s++ != '.')
 		return 0;
-	ip = (ip << 8) | strtol(s, &s, 0);
+	ip = (ip << 8) | (uint32_t) strtol(s, &s, 0);
 	if (*s++ != '.')
 		return 0;
-	ip = (ip << 8) | strtol(s, &s, 0);
+	ip = (ip << 8) | (uint32_t) strtol(s, &s, 0);
 	if (*s++ != '.')
 		return 0;
-	ip = (ip << 8) | strtol(s, &s, 0);
+	ip = (ip << 8) | (uint32_t) strtol(s, &s, 0);
 	if (*s != 0)
 		return 0;
 	return ip;

--- a/contrib/macipgw/util.h
+++ b/contrib/macipgw/util.h
@@ -17,6 +17,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
+#include <stdint.h>
+
 extern int gDebug;
 
 #if defined(DEBUG)
@@ -31,5 +33,5 @@ extern int gDebug;
 #define DEBUG_TUNDEV	(0)
 #endif
 
-extern char *iptoa (u_long ip);
-extern u_long atoip (char *s);
+extern char *iptoa (uint32_t ip);
+extern uint32_t atoip (char *s);

--- a/distrib/initscripts/netbsd.macipgw.in
+++ b/distrib/initscripts/netbsd.macipgw.in
@@ -11,7 +11,6 @@
 name="macipgw"
 rcvar=$name
 command="@sbindir@/macipgw"
-command_args="-n 8.8.8.8 192.168.151.0 255.255.255.0"
 
 load_rc_config $name
 run_rc_command "$1"

--- a/distrib/initscripts/openrc.macipgw.in
+++ b/distrib/initscripts/openrc.macipgw.in
@@ -14,6 +14,6 @@ depend() {
 
 start() {
     ebegin "Starting $name"
-    start-stop-daemon --start --quiet --exec @sbindir@/$name -n 8.8.8.8 192.168.151.0 255.255.255.0
+    start-stop-daemon --start --quiet --exec @sbindir@/$name
     eend $?
 }

--- a/distrib/initscripts/systemd.macipgw.service.in
+++ b/distrib/initscripts/systemd.macipgw.service.in
@@ -10,7 +10,7 @@ Requires=atalkd.service
 [Service]
 Type=forking
 GuessMainPID=no
-ExecStart=@sbindir@/macipgw -n 8.8.8.8 192.168.151.0 255.255.255.0
+ExecStart=@sbindir@/macipgw
 Restart=always
 RestartSec=1
 

--- a/doc/ja/manpages/man8/atalkd.8.xml
+++ b/doc/ja/manpages/man8/atalkd.8.xml
@@ -125,7 +125,7 @@
 
         <listitem>
           <para>設定情報については、<filename>atalkd.conf</filename>
-          ではなく、<replaceable>configfile</replaceable> を参照してください。</para>
+          ではなく、<replaceable>configfile</replaceable> を参照します。</para>
         </listitem>
       </varlistentry>
 

--- a/doc/ja/manpages/man8/macipgw.8.xml
+++ b/doc/ja/manpages/man8/macipgw.8.xml
@@ -26,6 +26,8 @@
 
       <arg>-d <replaceable>debugclass</replaceable></arg>
 
+      <arg>-f <replaceable>configfile</replaceable></arg>
+
       <arg>-n <replaceable>nameserver</replaceable></arg>
 
       <arg>-u <replaceable>unprivileged-user</replaceable></arg>
@@ -71,6 +73,11 @@
     を使用しません。ゲートウェイは、常にネットワークの最初のアドレスをローカル アドレスとして使用します。つまり、ネットワーク
     192.168.1.0/24 の場合は 192.168.1.1 です。</para>
 
+    <para>存在する場合、<command>macipgw</command> は
+    <filename>/usr/etc/macipgw.conf</filename> (または同等の pkgconf パス)
+    から構成オプションを読み取ります。コマンド ライン オプションは、構成ファイル
+    オプションよりも優先されます。例については以下を参照してください。</para>
+
     <para><command>macipgw</command> は、<emphasis
     remap="B">LOG_DAEMON</emphasis> 機能の下で、<citerefentry>
         <refentrytitle>syslog</refentrytitle>
@@ -90,6 +97,15 @@
           <para>デーモンがフォークせず、すべてのアクションのトレースが書き込まれるように指定します<emphasis
           remap="B">stdout</emphasis> に出力します。 debugclass の有用な値については、ソース
           コードを参照してください。</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>-f <replaceable>configfile</replaceable></term>
+
+        <listitem>
+          <para>設定情報については、<filename>macipgw.conf</filename>
+          ではなく、<replaceable>configfile</replaceable> を参照します。</para>
         </listitem>
       </varlistentry>
 
@@ -148,12 +164,27 @@
   <refsect1>
     <title>例</title>
 
-    <screen><userinput>/usr/local/libexec/macipgw -n 192.168.1.1 -z "Remote Users" 192.168.1.0 255.255.255.0</userinput>
+    <example>
+      <title><command>macipgw</command> 呼び出しの例。</title>
+
+      <screen><userinput>/usr/local/libexec/macipgw -n 192.168.1.1 -z "Remote Users" 192.168.1.0 255.255.255.0</userinput>
 </screen>
 
-    <para><command>macipgw</command> を起動し、ゲートウェイ経由で接続されたデバイスにクラス C ネットワーク
-    192.168.1.0 を割り当て、<command>macipgw</command> が動作しているシステムをネーム
-    サーバーとして使用でき、ゾーン Remote Users に登録する必要があることを指定します。</para>
+      <para><command>macipgw</command> を起動し、ゲートウェイ経由で接続されたデバイスにクラス C ネットワーク
+      192.168.1.0 を割り当て、<command>macipgw</command> が動作しているシステムをネーム
+      サーバーとして使用でき、ゾーン Remote Users に登録する必要があることを指定します。</para>
+    </example>
+
+    <example>
+      <title>例: <filename>macipgw.conf</filename> 構成ファイル。</title>
+
+      <programlisting>[Global]
+network = 192.168.151.0
+netmask = 255.255.255.0
+nameserver = 8.8.8.8
+zone = My Zone
+unprivileged user = foobar</programlisting>
+    </example>
   </refsect1>
 
   <refsect1>

--- a/doc/manpages/man5/macipgw.conf.5
+++ b/doc/manpages/man5/macipgw.conf.5
@@ -1,0 +1,1 @@
+.so man8/macipgw.8

--- a/doc/manpages/man5/meson.build
+++ b/doc/manpages/man5/meson.build
@@ -29,3 +29,5 @@ foreach man : manfiles
         build_by_default: true,
     )
 endforeach
+
+install_data('macipgw.conf.5', install_dir: mandir / 'man5')

--- a/doc/manpages/man8/macipgw.8.xml
+++ b/doc/manpages/man8/macipgw.8.xml
@@ -26,6 +26,8 @@
 
       <arg>-d <replaceable>debugclass</replaceable></arg>
 
+      <arg>-f <replaceable>configfile</replaceable></arg>
+
       <arg>-n <replaceable>nameserver</replaceable></arg>
 
       <arg>-u <replaceable>unprivileged-user</replaceable></arg>
@@ -75,6 +77,11 @@
     for the local address, i.e. 192.168.1.1 for the network
     192.168.1.0/24.</para>
 
+    <para>If present, <command>macipgw</command> reads configuration options
+    from <filename>/usr/etc/macipgw.conf</filename> (or equivalent pkgconf
+    path.) Command line options will take precedence over configuration file
+    options. See below for an example.</para>
+
     <para><command>macipgw</command> will log operational messages through
     <citerefentry>
         <refentrytitle>syslog</refentrytitle>
@@ -95,6 +102,16 @@
           <para>Specifies that the daemon should not fork, and that a trace of
           all actions be written to <emphasis remap="B">stdout</emphasis>. See
           the source code for useful values of debugclass.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term>-f <replaceable>configfile</replaceable></term>
+
+        <listitem>
+          <para>Consult <replaceable>configfile</replaceable> instead of
+          <filename>macipgw.conf</filename> for the configuration
+          information.</para>
         </listitem>
       </varlistentry>
 
@@ -154,13 +171,30 @@
   <refsect1>
     <title>Example</title>
 
-    <screen><userinput>/usr/local/libexec/macipgw -n 192.168.1.1 -z "Remote Users" 192.168.1.0 255.255.255.0</userinput>
+    <example>
+      <title>Example <command>macipgw</command> invocation.</title>
+
+      <screen><userinput>/usr/local/libexec/macipgw -n 192.168.1.1 -z "Remote Users" 192.168.1.0 255.255.255.0</userinput>
 </screen>
 
-    <para>Starts <command>macipgw</command>, assigning the Class C network
-    192.168.1.0 for devices connected through the gateway, specifying that the
-    system <command>macipgw</command> is running on can be used as a name
-    server, and that it should register in the zone Remote Users.</para>
+      <para>Starts <command>macipgw</command>, assigning the Class C network
+      192.168.1.0 for devices connected through the gateway, specifying that
+      the system <command>macipgw</command> is running on can be used as a
+      name server, and that it should register in the zone Remote
+      Users.</para>
+    </example>
+
+    <example>
+      <title>Example <filename>macipgw.conf</filename> configuration
+      file.</title>
+
+      <programlisting>[Global]
+network = 192.168.151.0
+netmask = 255.255.255.0
+nameserver = 8.8.8.8
+zone = My Zone
+unprivileged user = foobar</programlisting>
+    </example>
   </refsect1>
 
   <refsect1>


### PR DESCRIPTION
Makes the macipgw daemon look for a macipgw.conf file in the default netatalk pkgconf path.  Without the config file, macipgw should behave as before.

Point to conf file in custom location with the `-f` terminal option.

Sample macipgw.conf file:

```
[Global]
network = 192.168.151.0
netmask = 255.255.255.0
nameserver = 8.8.8.8
zone = My Zone
unprivileged user = dmark
```

This changeset also fixes a few type safety issues.