### PR TITLE
GitHub CI: Build without cracklib and glibc on openSUSE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,15 +289,12 @@ jobs:
         run: |
           zypper in -y \
             bison \
-            dbus-1-devel \
             docbook-xsl-stylesheets \
             file \
             flex \
             gawk \
             gcc \
             krb5-devel \
-            libacl-devel \
-            libavahi-devel \
             libdb-4_8-devel \
             libevent-devel \
             libgcrypt-devel \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,7 +289,6 @@ jobs:
         run: |
           zypper in -y \
             bison \
-            cracklib-devel \
             dbus-1-devel \
             docbook-xsl-stylesheets \
             file \


### PR DESCRIPTION
openSUSE Tumbleweed has broken the dependency tree for cracklib, glibc, and dbus. Let's just build without them.