### PR TITLE
GitHub CI: Run zypper update before new package on openSUSE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,7 +287,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          zypper in -y \
+          zypper update -y
+          zypper install -y \
             bison \
             cracklib-devel \
             dbus-1-devel \


### PR DESCRIPTION
I don't think it will make a difference, but just in case we get less flakiness out of openSUSE Tumbleweed by running zypper update first...