### PR TITLE
Protect Netatalk metadata EA

### DIFF
--- a/include/atalk/ea.h
+++ b/include/atalk/ea.h
@@ -88,6 +88,7 @@ enum {
 
 /* Names for our Extended Attributes adouble data */
 #define AD_EA_META "org.netatalk.Metadata"
+#define AD_EA_META_LEN (sizeof (AD_EA_META) - 1)
 #ifdef __APPLE__
 #define AD_EA_RESO "com.apple.ResourceFork"
 #define EA_FINFO "com.apple.FinderInfo"

--- a/libatalk/vfs/ea_sys.c
+++ b/libatalk/vfs/ea_sys.c
@@ -170,6 +170,10 @@ int sys_get_eacontent(VFS_FUNC_ARGS_EA_GETCONTENT)
         return AFPERR_ACCESS;
 #endif
 
+    /* Protect special attributes set by Netatalk server */
+    if (!strncmp(attruname, AD_EA_META, AD_EA_META_LEN))
+        return AFPERR_ACCESS;
+
     /* Start building reply packet */
 
     if (maxreply <= MAX_REPLY_EXTRA_BYTES) {
@@ -380,6 +384,10 @@ int sys_set_ea(VFS_FUNC_ARGS_EA_SET)
     if (!strncmp(attruname, SMB_ATTR_PREFIX, SMB_ATTR_PREFIX_LEN))
         return AFPERR_ACCESS;
 #endif
+
+    /* Protect special attributes set by Netatalk server */
+    if (!strncmp(attruname, AD_EA_META, AD_EA_META_LEN))
+        return AFPERR_ACCESS;
 
     /*
      * Buffer for a copy of the xattr plus one byte in case


### PR DESCRIPTION
Currently, a client can create new files on the server with the same name as the Netatalk metadata extended attribute (`org.netatalk.Metadata`). If this EA has valid AppleDouble data (ex: from another Netatalk host), the server will treat the EA as read-only and not be able to update the data.

Additionally clients will not be able to update metadata on the file such as comments or FinderInfo. The only way to fix the problem is deleting the extended attribute on the server side, or deleting the file.