### PR TITLE
docs: Fixes for spelling and grammar

### DIFF
--- a/doc/DEVELOPER
+++ b/doc/DEVELOPER
@@ -171,7 +171,7 @@ Disadvantages:
   is very portable and the cnid_dbd IPC mechanisms can be extended to
   use faster IPC (like mmap) on architectures where it is
   supported. As a ballpark figure, 20000 requests/replies to the cnid_dbd
-  daemon take about 0.6 seconds on a Pentium III 733 Mhz running Linux
+  daemon take about 0.6 seconds on a Pentium III 733 MHz running Linux
   Kernel 2.4.18 using unix domain sockets. The requests are "empty"
   (no database lookups/changes), so this is just the IPC
   overhead.

--- a/doc/README.AppleTalk
+++ b/doc/README.AppleTalk
@@ -1,4 +1,4 @@
-This is a README for using netatalk with AppleTalk networking.
+This is a README for using Netatalk with AppleTalk networking.
 
 Platforms Covered:
 A.   Linux
@@ -12,7 +12,7 @@ A. Linux
 
 Some Linux distributions ship with AppleTalk support out of the box
 (e.g. Debian) others have the kernel module but with a blacklisting
-in effect that has to be deactived before you can use it (e.g. Fedora.)
+in effect that has to be deactivated before you can use it (e.g. Fedora.)
 
 Netatalk supplies two different types of AFP servers and both
 can run at the same time. Classic AFP requires afpd and
@@ -60,7 +60,7 @@ The source code for the kernel module is located in
 sys/netatalk of the NetBSD source tree.
 
 As of NetBSD 9.3, the netatalk kernel module is loaded by default,
-and made available to the atalkd deamon when it starts up.
+and made available to the atalkd daemon when it starts up.
 
 B.II Other BSDs
 
@@ -69,8 +69,8 @@ dated after 12 September 1996, as well as OpenBSD 2.2,
 or openbsd-current dated after Aug 1, 1997.
 
 However, both distributions deprecated AppleTalk in the 2010s.
-You can still run netatalk as an AFP over TCP server on any
-BSD derived operating system.
+You can still run Netatalk as an AFP over TCP server on any
+BSD-derived operating system.
 
 ----------------------------------------------------------------
 

--- a/doc/manpages/man5/afp.conf.5.xml
+++ b/doc/manpages/man5/afp.conf.5.xml
@@ -2220,7 +2220,7 @@
 
           <listitem>
             <para>make dot files invisible. WARNING: enabling this option will
-            lead to unwanted sideeffects were OS X applications when saving
+            lead to unwanted side effects where OS X applications, when saving
             files to a temporary file starting with a dot first, then renaming
             the temp file to its final name, result in the saved file being
             invisible. The only thing this option is useful for is making
@@ -2363,7 +2363,7 @@
           <para>This backend is an exception, in terms of ID persistency. ID's
           are only valid for the current session. This is basically what
           <command>afpd</command> did in the 1.5 (and 1.6) versions. This
-          backend is still available, as it is useful for e.g. sharing cdroms.
+          backend is still available, as it is useful for e.g. sharing CD-ROMs.
           Starting with Netatalk 3.0, it becomes the <emphasis>read only
           mode</emphasis> automatically.</para>
 

--- a/doc/manpages/man8/atalkd.8.xml
+++ b/doc/manpages/man8/atalkd.8.xml
@@ -25,7 +25,7 @@
         </indexterm><indexterm>
           <primary>RTMP</primary>
 
-          <secondary>Routing Table Maintainance Protocol</secondary>
+          <secondary>Routing Table Maintenance Protocol</secondary>
         </indexterm><indexterm>
           <primary>NBP</primary>
 

--- a/doc/manpages/man8/cnid_dbd.8.xml
+++ b/doc/manpages/man8/cnid_dbd.8.xml
@@ -164,7 +164,7 @@
           remap="I">flush_frequency</emphasis> requests have been received or
           ii) more than <emphasis remap="I">flush_interval</emphasis> seconds
           have elapsed since the last save/checkpoint. Be careful to check
-          your harddisk configuration for on disk cache settings. Many IDE
+          your hard disk configuration for on disk cache settings. Many IDE
           disks just cache writes as the default behaviour, so even flushing
           database files to disk will not have the desired effect.</para>
         </listitem>

--- a/doc/manual/appletalk.xml
+++ b/doc/manual/appletalk.xml
@@ -211,7 +211,7 @@ eth2 -dontroute -phase 2 -net 1-1000 -addr 10.142 -zone "Printers"</programlisti
       fail.</para>
 
       <para>So you should have atalkd act as a seed router on one or all
-      active interfaces. A seed router has to supply informations
+      active interfaces. A seed router has to supply information
       about:</para>
 
       <itemizedlist>
@@ -246,8 +246,8 @@ eth2 -dontroute -phase 2 -net 1-1000 -addr 10.142 -zone "Printers"</programlisti
       adapt the already established ones on the net (if in doubt, always check
       syslog for details).</para>
 
-      <para>Netranges, you can use, include pretty small ones, eg. 42-42, to
-      very large ones, eg. 1-65279 - the latter one representing the maximum.
+      <para>Netranges, you can use, include pretty small ones, e.g. 42-42, to
+      very large ones, e.g. 1-65279 - the latter one representing the maximum.
       In routed environments you can use any numbers in the range between 1
       and 65279 unless they do not overlap with settings of other connected
       subnets.</para>
@@ -376,7 +376,7 @@ eth2 -phase 2 -net 65279-65279 -addr 65279.142 -zone "Parking" -zone "No Parking
         <para><programlisting>eth0
 eth1 -seed -phase 2 -net 99-100 -addr 99.200 -zone "Testing"</programlisting>
         In case in the network connected to eth0 lives no active seed router
-        or one with a mismatching configuration (eg. an overlapping netrange
+        or one with a mismatching configuration (e.g. an overlapping netrange
         of 1-200) atalkd will fail. Otherwise it will fetch the configuration
         from this machine and will route between eth0 and eth1, on the latter
         acting as a seed router itself.</para>
@@ -444,7 +444,7 @@ eth1 -seed -phase 2 -net 99-100 -addr 99.200 -zone "Testing"</programlisting>
       general. Netatalk does not contain a full-blown spooler implementation
       itself, papd only handles the bidirectional communication and
       submittance of printjobs from PAP clients. So normally one needs to
-      integrate papd with a Unix printing system like eg. classic SysV
+      integrate papd with a Unix printing system like e.g. classic SysV
       lpd<indexterm>
           <primary>lpd</primary>
 

--- a/doc/manual/configuration.xml
+++ b/doc/manual/configuration.xml
@@ -313,7 +313,7 @@ basedir regex = /usr/home</programlisting></para>
       <emphasis>multibyte</emphasis> character sets.</para>
 
       <para>One standardized multibyte charset encoding scheme is known as
-      <ulink url="http://www.unicode.org/">unicode</ulink>. A big advantage of
+      <ulink url="http://www.unicode.org/">Unicode</ulink>. A big advantage of
       using a multibyte charset is that you only need one. There is no need to
       make sure two computers use the same charset when they are
       communicating.</para>
@@ -526,10 +526,10 @@ basedir regex = /usr/home</programlisting></para>
             use codepages to communicate with afpd. However, there is no
             support for negotiating the codepage used by the client in the AFP
             protocol. If not specified otherwise, afpd assumes the
-            <emphasis>MacRoman</emphasis> codepage is used. In case you're
+            <emphasis>MacRoman</emphasis> codepage is used. In case your
             clients use another codepage, e.g.
             <emphasis>MacCyrillic</emphasis>, you'll <emphasis
-            role="bold">have</emphasis> to explicitly configure this. see
+            role="bold">have</emphasis> to explicitly configure this. See
             <citerefentry>
                 <refentrytitle>afp.conf</refentrytitle>
 
@@ -696,7 +696,7 @@ basedir regex = /usr/home</programlisting></para>
       support exists since AppleShare client 3.8.x.</para>
 
       <para>On macOS, there exist some client-side techniques to make the
-      AFP-client more verbose, so one can have a look what's happening while
+      AFP-client more verbose, so one can have a look at what's happening while
       negotiating the UAMs to use. Compare with this <ulink
       url="https://web.archive.org/web/20080312054723/http://article.gmane.org/gmane.network.netatalk.devel/7383/">hint</ulink>.</para>
     </sect2>
@@ -1149,7 +1149,7 @@ uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting> then you're using PAM,
       <para>Netatalk can query a directory server using LDAP queries. Either
       the directory server already provides an UUID attribute for user and
       groups (Active Directory, Open Directory) or you reuse an unused
-      attribute (or add a new one) to you directory server (eg
+      attribute (or add a new one) to you directory server (e.g.
       OpenLDAP).</para>
 
       <para>In detail:</para>
@@ -1165,7 +1165,7 @@ uams_dhx2.so -&gt; uams_dhx2_pam.so</programlisting> then you're using PAM,
 aclmode = passthrough</screen>
 
           <para>For an explanation of what this knob does and how to apply it,
-          check your hosts ZFS documentation (eg man zfs).</para>
+          check your hosts ZFS documentation (e.g. man zfs).</para>
         </listitem>
 
         <listitem>
@@ -1220,7 +1220,7 @@ aclmode = passthrough</screen>
 
       <para>ACLs and UNIX permissions interact in a rather simple way. As ACLs
       are optional UNIX permissions act as a default mechanism for access
-      control. Changing an objects's UNIX permissions will leave it's ACL
+      control. Changing an objects's UNIX permissions will leave its ACL
       intact and modifying an ACL will never change the object's UNIX
       permissions. While doing access checks, macOS first examines an object's
       ACL evaluating ACEs in order until all requested rights have been
@@ -1253,7 +1253,7 @@ aclmode = passthrough</screen>
         can have access ACLs which are consulted for access checks.
         Directories can also have default ACLs irrelevant to access checks.
         When a new object is created inside a directory with a default ACL,
-        the default ACL is applied to the new object as it's access ACL.
+        the default ACL is applied to the new object as its access ACL.
         Subdirectories inherit default ACLs from their parent. There are no
         further mechanisms of inheritance control.</para>
 
@@ -1341,7 +1341,7 @@ aclmode = passthrough</screen>
       <sect3>
         <title>Mapping POSIX ACLs to macOS ACLs</title>
 
-        <para>When a client wants to read an object's ACL, afpd maps it's
+        <para>When a client wants to read an object's ACL, afpd maps its
         POSIX ACL onto an equivalent macOS ACL. Writing an object's ACL
         requires afpd to map an macOS ACL onto a POSIX ACL. Due to
         architectural restrictions of POSIX ACLs, it is usually impossible to
@@ -1396,7 +1396,7 @@ aclmode = passthrough</screen>
         structure (see Apple Filing Protocol Reference, page 181). Changing an
         object's permissions, afpd always updates ACL_USER_OBJ, ACL_GROUP_OBJ
         and ACL_OTHERS. If an ACL_MASK entry is present too, afpd recalculates
-        it's value so that the new group rights become effective and existing
+        its value so that the new group rights become effective and existing
         entries of type ACL_USER or ACL_GROUP stay intact.</para>
       </sect3>
     </sect2>
@@ -1408,7 +1408,7 @@ aclmode = passthrough</screen>
       </indexterm></title>
 
     <para>Netatalk includes a nifty filesystem change event (FCE) mechanism
-    where afpd processes notfiy interested listeners about certain filesystem
+    where afpd processes notify interested listeners about certain filesystem
     event by UDP network datagrams.</para>
 
     <para>For the format of the UDP packets and for an example C application
@@ -1503,7 +1503,7 @@ aclmode = passthrough</screen>
             event API for tracking filesystem changes. On large filesystems
             this may be problematic since the inotify API doesn't offer
             recursive directory watches but instead requires that for every
-            subdirectoy watches must be added individually.</para>
+            subdirectory watches must be added individually.</para>
 
             <para>On Solaris the FEN file event notification system is used.
             It is unknown which limitations and resource consumption this
@@ -1650,7 +1650,7 @@ org.freedesktop.Tracker.Writeback verbosity 'debug'
               backend (FAM on Linux, FEN on Solaris), this feature may not
               work as reliable as one might wish, so it may be safer to
               disable it and instead rely on periodic crawling of Tracker
-              itself. See aslo the option <option>crawling-interval
+              itself. See also the option <option>crawling-interval
               </option>.</para>
             </listitem>
           </varlistentry>

--- a/doc/manual/upgrade.xml
+++ b/doc/manual/upgrade.xml
@@ -127,7 +127,7 @@
 
       <para>Implementation details:<itemizedlist>
           <listitem>
-            <para>stores Mac Metadata (eg FinderInfo, AFP Flags, Comment,
+            <para>stores Mac Metadata (e.g. FinderInfo, AFP Flags, Comment,
             CNID) in an Extended Attributed named
             “<filename>org.netatalk.Metadata</filename>”<itemizedlist>
                 <listitem>


### PR DESCRIPTION
Found while reading the docs and running `hunspell` against the source files.