### PR TITLE
iconv fixes for OpenWrt

### DIFF
--- a/bin/ad/meson.build
+++ b/bin/ad/meson.build
@@ -12,6 +12,10 @@ ad_sources = [
 
 ad_deps = []
 
+if have_iconv
+    ad_deps += iconv
+endif
+
 if use_mysql_backend
     ad_deps += mysqlclient
 endif

--- a/bin/aecho/meson.build
+++ b/bin/aecho/meson.build
@@ -1,8 +1,15 @@
+aecho_deps = []
+
+if have_iconv
+    aecho_deps += iconv
+endif
+
 executable(
     'aecho',
     'aecho.c',
     include_directories: root_includes,
     link_with: libatalk,
+    dependencies: aecho_deps,
     install: true,
     build_rpath: rpath_libdir,
     install_rpath: rpath_libdir,

--- a/bin/afppasswd/meson.build
+++ b/bin/afppasswd/meson.build
@@ -17,6 +17,10 @@ if have_libgcrypt
     afppasswd_deps += [libgcrypt]
 endif
 
+if have_iconv
+    afppasswd_deps += iconv
+endif
+
 executable(
     'afppasswd',
     afppasswd_sources,

--- a/bin/getzones/meson.build
+++ b/bin/getzones/meson.build
@@ -1,8 +1,15 @@
+getzones_deps = []
+
+if have_iconv
+    getzones_deps += iconv
+endif
+
 executable(
     'getzones',
     'getzones.c',
     include_directories: root_includes,
     link_with: libatalk,
+    dependencies: getzones_deps,
     install: true,
     build_rpath: rpath_libdir,
     install_rpath: rpath_libdir,

--- a/bin/misc/meson.build
+++ b/bin/misc/meson.build
@@ -6,12 +6,18 @@ fce_sources = ['fce.c']
 
 afpldaptest_sources = ['uuidtest.c']
 
+misc_deps = []
+
+if have_iconv
+    misc_deps += iconv
+endif
+
 executable(
     'netacnv',
     netacnv_sources,
     include_directories: root_includes,
     link_with: libatalk,
-    dependencies: mysqlclient,
+    dependencies: [mysqlclient, misc_deps],
     install: false,
 )
 
@@ -20,7 +26,7 @@ executable(
     loggertest_sources,
     include_directories: root_includes,
     link_with: libatalk,
-    dependencies: mysqlclient,
+    dependencies: [mysqlclient, misc_deps],
     install: false,
 )
 
@@ -29,7 +35,7 @@ executable(
     fce_sources,
     include_directories: root_includes,
     link_with: libatalk,
-    dependencies: mysqlclient,
+    dependencies: [mysqlclient, misc_deps],
     install: false,
 )
 
@@ -45,7 +51,7 @@ if have_ldap
         afpldaptest_sources,
         include_directories: root_includes,
         link_with: libatalk,
-        dependencies: [afpldaptest_deps, ldap],
+        dependencies: [afpldaptest_deps, ldap, misc_deps],
         c_args: confdir,
         install: true,
         build_rpath: rpath_libdir,

--- a/bin/nbp/meson.build
+++ b/bin/nbp/meson.build
@@ -1,8 +1,15 @@
+npb_deps = []
+
+if have_iconv
+    npb_deps += iconv
+endif
+
 executable(
     'nbplkup',
     'nbplkup.c',
     include_directories: root_includes,
     link_with: libatalk,
+    dependencies: npb_deps,
     install: true,
     build_rpath: rpath_libdir,
     install_rpath: rpath_libdir,
@@ -12,6 +19,7 @@ executable(
     'nbprgstr.c',
     include_directories: root_includes,
     link_with: libatalk,
+    dependencies: npb_deps,
     install: true,
     build_rpath: rpath_libdir,
     install_rpath: rpath_libdir,
@@ -21,6 +29,7 @@ executable(
     'nbpunrgstr.c',
     include_directories: root_includes,
     link_with: libatalk,
+    dependencies: npb_deps,
     install: true,
     build_rpath: rpath_libdir,
     install_rpath: rpath_libdir,

--- a/bin/pap/meson.build
+++ b/bin/pap/meson.build
@@ -1,8 +1,15 @@
+pap_deps = []
+
+if have_iconv
+    pap_deps += iconv
+endif
+
 executable(
     'pap',
     'pap.c',
     include_directories: root_includes,
     link_with: libatalk,
+    dependencies: pap_deps,
     install: true,
     build_rpath: rpath_libdir,
     install_rpath: rpath_libdir,
@@ -12,6 +19,7 @@ executable(
     'papstatus.c',
     include_directories: root_includes,
     link_with: libatalk,
+    dependencies: pap_deps,
     install: true,
     build_rpath: rpath_libdir,
     install_rpath: rpath_libdir,

--- a/contrib/a2boot/meson.build
+++ b/contrib/a2boot/meson.build
@@ -1,3 +1,9 @@
+a2boot_deps = []
+
+if have_iconv
+    a2boot_deps += iconv
+endif
+
 a2boot_c_args = [
     '-D_PATH_A_GS_BLOCKS="'
     + pkgconfdir
@@ -14,6 +20,7 @@ executable(
     'a2boot.c',
     include_directories: root_includes,
     link_with: libatalk,
+    dependencies: a2boot_deps,
     c_args: a2boot_c_args,
     install: true,
     install_dir: sbindir,

--- a/contrib/macipgw/meson.build
+++ b/contrib/macipgw/meson.build
@@ -1,3 +1,9 @@
+macipgw_deps = []
+
+if have_iconv
+    macipgw_deps += iconv
+endif
+
 macipgw_sources = [
 	'atp_input.c',
 	'macip.c',
@@ -17,6 +23,7 @@ executable(
     macipgw_sources,
     include_directories: [root_includes, macipgw_includes],
     link_with: libatalk,
+    dependencies: macipgw_deps,
     c_args: macipgw_c_args,
     export_dynamic: true,
     install: true,

--- a/contrib/timelord/meson.build
+++ b/contrib/timelord/meson.build
@@ -1,8 +1,15 @@
+timelord_deps = []
+
+if have_iconv
+    timelord_deps += iconv
+endif
+
 executable(
     'timelord',
     'timelord.c',
     include_directories: root_includes,
     link_with: libatalk,
+    dependencies: timelord_deps,
     c_args: dversion,
     install: true,
     install_dir: sbindir,

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -72,6 +72,10 @@ if have_acls
     afpd_external_deps += [acl_deps]
 endif
 
+if have_iconv
+    afpd_external_deps += iconv
+endif
+
 if have_quota
     afpd_sources += [
         'quota.c',

--- a/etc/atalkd/meson.build
+++ b/etc/atalkd/meson.build
@@ -11,11 +11,18 @@ atalkd_sources = [
 
 atalkd_c_args = ['-D_PATH_ATALKDCONF="' + pkgconfdir + '/atalkd.conf"', dversion]
 
+atalkd_deps = []
+
+if have_iconv
+    atalkd_deps += iconv
+endif
+
 executable(
     'atalkd',
     atalkd_sources,
     include_directories: root_includes,
     link_with: libatalk,
+    dependencies: atalkd_deps,
     c_args: atalkd_c_args,
     install: true,
     install_dir: sbindir,

--- a/etc/cnid_dbd/meson.build
+++ b/etc/cnid_dbd/meson.build
@@ -23,6 +23,10 @@ if use_dbd_backend
         cnid_dbd_deps += mysqlclient
     endif
 
+    if have_iconv
+        cnid_dbd_deps += iconv
+    endif
+
     cnid_metad_sources = ['cnid_metad.c', 'usockfd.c', 'db_param.c']
 
     dbd_sources = [

--- a/etc/netatalk/meson.build
+++ b/etc/netatalk/meson.build
@@ -11,6 +11,10 @@ elif have_dns
     netatalk_deps += dns_sd_libs
 endif
 
+if have_iconv
+    netatalk_deps += iconv
+endif
+
 executable(
     'netatalk',
     netatalk_sources,

--- a/etc/papd/meson.build
+++ b/etc/papd/meson.build
@@ -32,12 +32,18 @@ papd_c_args = [
     dversion,
 ]
 
+papd_deps = []
+
+if have_iconv
+    papd_deps += iconv
+endif
+
 executable(
     'papd',
     papd_sources,
     include_directories: root_includes,
     link_with: libatalk,
-    dependencies: cups,
+    dependencies: [cups, papd_deps],
     c_args: papd_c_args,
     export_dynamic: true,
     install: true,

--- a/etc/spotlight/meson.build
+++ b/etc/spotlight/meson.build
@@ -14,6 +14,12 @@ run_command(
 
 srp_sources = ['sparql_map.c', 'sparql_parser.c', 'spotlight_rawquery_lexer.c']
 
+spotlight_deps = []
+
+if have_iconv
+    spotlight_deps += iconv
+endif
+
 executable(
     'srp',
     srp_sources,
@@ -24,6 +30,7 @@ executable(
         mysqlclient,
         talloc,
         sparql,
+        spotlight_deps,
     ],
     c_args: ['-DMAIN'],
     install: false,

--- a/meson.build
+++ b/meson.build
@@ -1515,17 +1515,19 @@ else
             cdata.set('ICONV_CONST', 'const')
         endif
 
-        if cc.run(
-            '''
-        #include <iconv.h>
-        int main(void) {
-            iconv_t cd = iconv_open("ASCII", "UCS-2-INTERNAL");
-            if (cd == 0 || cd == (iconv_t)-1) return -1;
-            return 0;
-        }
-        ''',
-        ).returncode() == 0
-            cdata.set('HAVE_UCS2INTERNAL', 1)
+        if not meson.is_cross_build()
+                if cc.run(
+                    '''
+                #include <iconv.h>
+                int main(void) {
+                    iconv_t cd = iconv_open("ASCII", "UCS-2-INTERNAL");
+                    if (cd == 0 || cd == (iconv_t)-1) return -1;
+                    return 0;
+                }
+                ''',
+                ).returncode() == 0
+                    cdata.set('HAVE_UCS2INTERNAL', 1)
+                endif
         endif
     else
         have_iconv = false


### PR DESCRIPTION
Addresses a build issue with cross-compiling with iconv as meson cannot run code to determine if INTERNAL iconv support is available.
Addresses linking issues when iconv is supported by libiconv (detected or with path provided) instead of the more common libc6 implementation in Linux (maybe MacOS and others too).