### PR TITLE
Refactor retreival of native FinderInfo EA on macOS hosts.

### DIFF
--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -109,7 +109,7 @@ void *get_finderinfo(const struct vol *vol, const char *upath, struct adouble *a
     /* If no adouble finder information was found, check for native macOS info */
     if (chk_ext && (vol->v_adouble == AD_VERSION_EA))
     {
-        char NativeFinderInfo[32] ={'\0'};
+        char NativeFinderInfo[ADEDLEN_FINDERI] ={'\0'};
         if (ad_open_native_finderinfo(upath, NativeFinderInfo))
         {
             memcpy(data, NativeFinderInfo, ADEDLEN_FINDERI);

--- a/libatalk/adouble/ad_conv.c
+++ b/libatalk/adouble/ad_conv.c
@@ -116,9 +116,9 @@ copy:
 #ifdef __APPLE__
     /* Create macOS native FinderInfo EA */
     char * FinderInfo;
-    char NativeFinderInfo[32]={'\0'};
+    char NativeFinderInfo[ADEDLEN_FINDERI]={'\0'};
     FinderInfo = ad_entry(&adv2, ADEID_FINDERI);
-    memcpy(NativeFinderInfo, FinderInfo,ADEDLEN_FINDERI);
+    memcpy(NativeFinderInfo, FinderInfo, ADEDLEN_FINDERI);
     EC_ZERO_LOG( sys_setxattr(path, EA_FINFO, NativeFinderInfo, ADEDLEN_FINDERI, 0) );
 #endif
     EC_ZERO_LOGSTR( ad_open(&adea, path, adflags | ADFLAGS_HF | ADFLAGS_RDWR | ADFLAGS_CREATE),

--- a/libatalk/adouble/ad_flush.c
+++ b/libatalk/adouble/ad_flush.c
@@ -315,7 +315,7 @@ static int ad_flush_hf(struct adouble *ad)
             if (AD_META_OPEN(ad)) {
 #ifdef __APPLE__
                 char * FinderInfo;
-                char NativeFinderInfo[32]={'\0'};
+                char NativeFinderInfo[ADEDLEN_FINDERI]={'\0'};
                 FinderInfo = ad_entry(ad, ADEID_FINDERI);
                 memcpy(NativeFinderInfo, FinderInfo,ADEDLEN_FINDERI);
 #endif


### PR DESCRIPTION
Check size of `com.apple.FinderInfo` EA to verify it exists before returning.