### PR TITLE
launchd item: Start netatalk in non-forking mode

### DIFF
--- a/distrib/initscripts/macos.netatalk.plist.in
+++ b/distrib/initscripts/macos.netatalk.plist.in
@@ -11,8 +11,8 @@
 	<string>io.netatalk.daemon</string>
 	<key>ProgramArguments</key>
 	<array>
-		<string>@bindir@/netatalkd</string>
-		<string>start</string>
+		<string>@sbindir@/netatalk</string>
+		<string>-d</string>
 	</array>
 	<key>RunAtLoad</key>
 	<true/>


### PR DESCRIPTION
An issue with the current implementation of the launchd item is that unloading or stopping the it (e.g by running `sudo brew services stop netatalk`) doesn't actually stop the `netatalk` process. This is because the launchd is running the equivalent of `sudo netatalkd start` (which starts `netatalk` (which itself starts `afpd` and `cnid_metad`)) and immediately exits. 

Since Apple's [docs for processes managed by launchd](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html) specify that they be non-forking, a workaround is to invoke the `netatalk` process directly with its `-d` flag. When the launchd item is stopped, `netatalk` is ended along with `afpd` and `cnid_metad`.