### PR TITLE
docs: Clarify the behavior of the -d option for daemons

### DIFF
--- a/doc/ja/manpages/man8/afpd.8.xml
+++ b/doc/ja/manpages/man8/afpd.8.xml
@@ -59,7 +59,7 @@
         <term>-d</term>
 
         <listitem>
-          <para>デーモンがフォークしないことを指定する。</para>
+          <para>デーモンをターミナルから切り離さない。</para>
         </listitem>
       </varlistentry>
 

--- a/doc/ja/manpages/man8/atalkd.8.xml
+++ b/doc/ja/manpages/man8/atalkd.8.xml
@@ -116,7 +116,7 @@
         <term>-d</term>
 
         <listitem>
-          <para>追加のデバッグ情報を stdout に書き込みます。</para>
+          <para>デーモンをターミナルから切り離さないで、追加のデバッグ情報を stdout に書き込みます。</para>
         </listitem>
       </varlistentry>
 

--- a/doc/ja/manpages/man8/netatalk.8.xml
+++ b/doc/ja/manpages/man8/netatalk.8.xml
@@ -41,8 +41,7 @@
   <refsect1>
     <title>説明</title>
 
-    <para><command>netatalk</command>は、AFPデーモン<command>afpd</command>とCNIDデーモン<command>cnid_metad</command>の起動と再起動を請け負うサービスコントローラデーモンである。これは通常、ブート時にinitシステム
-    (BSDスタイルinit、SysVスタイルinit、systemd、Upstart、OpenRC、SMF等) によって起動される。</para>
+    <para><command>netatalk</command>は、AFPデーモン<command>afpd</command>とCNIDデーモン<command>cnid_metad</command>の起動と再起動を請け負うサービスコントローラデーモンである。</para>
   </refsect1>
 
   <refsect1>
@@ -53,7 +52,7 @@
         <term>-d</term>
 
         <listitem>
-          <para>デバッグ目的で、netatalk を非フォーク モードで開始する。</para>
+          <para>デーモンをターミナルから切り離さない。</para>
         </listitem>
       </varlistentry>
 

--- a/doc/manpages/man8/afpd.8.xml
+++ b/doc/manpages/man8/afpd.8.xml
@@ -60,7 +60,7 @@
         <term>-d</term>
 
         <listitem>
-          <para>Specifies that the daemon should not fork.</para>
+          <para>Do not disassociate daemon from terminal.</para>
         </listitem>
       </varlistentry>
 

--- a/doc/manpages/man8/atalkd.8.xml
+++ b/doc/manpages/man8/atalkd.8.xml
@@ -117,7 +117,8 @@
         <term>-d</term>
 
         <listitem>
-          <para>Write some additional debugging information to stdout.</para>
+          <para>Do not disassociate daemon from terminal. Writes some additional
+          debugging information to stdout.</para>
         </listitem>
       </varlistentry>
 

--- a/doc/manpages/man8/netatalk.8.xml
+++ b/doc/manpages/man8/netatalk.8.xml
@@ -41,8 +41,7 @@
     <para><command>netatalk</command> is the service controller daemon
     responsible for starting and restarting the AFP daemon
     <command>afpd</command> and the CNID daemon <command>cnid_metad</command>.
-    It is normally started at boot time by an init system (BSD-style init,
-    SysV-sytle init, systemd, Upstart, OpenRC, SMF and so on).</para>
+    It is normally started at boot time by an init system.</para>
   </refsect1>
 
   <refsect1>
@@ -53,7 +52,7 @@
         <term>-d</term>
 
         <listitem>
-          <para>Starts netatalk in non-forking mode, for debugging purposes.</para>
+          <para>Do not disassociate daemon from terminal.</para>
         </listitem>
       </varlistentry>
 


### PR DESCRIPTION
Create a unified theme for the usage of the -d option across the daemons.