### PR TITLE
GitHub CI: Bump to the latest BSD vmactions runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -521,7 +521,7 @@ jobs:
               libxslt \
               meson \
               mysql84-client \
-              openldap26-client-2.6.8 \
+              openldap26-client \
               p5-Net-DBus \
               perl5 \
               pkgconf \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -506,7 +506,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/freebsd-vm@v1.1.6
+        uses: vmactions/freebsd-vm@v1.1.8
         with:
           copyback: false
           prepare: |
@@ -557,7 +557,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/netbsd-vm@v1.1.6
+        uses: vmactions/netbsd-vm@v1.1.7
         with:
           copyback: false
           prepare: |
@@ -611,7 +611,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/openbsd-vm@v1.1.4
+        uses: vmactions/openbsd-vm@v1.1.6
         with:
           copyback: false
           prepare: |


### PR DESCRIPTION
Use the latest upstream vmactions runner images, as well as the unversioned openldap26 package in FreeBSD (they finally seem to have removed that ambiguity from Ports)