### PR TITLE
GitHub CI: Run lantest and speedtest jobs

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -350,3 +350,39 @@ jobs:
           AFP_VERSION: 1
       steps:
           - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+
+
+    afp-lantest:
+      name: AFP lantest
+      needs: build-container-testsuite
+      runs-on: ubuntu-latest
+      timeout-minutes: 5
+      env:
+          AFP_USER: atalk1
+          AFP_PASS: afpafp
+          AFP_GROUP: afpusers
+          SHARE_NAME: test1
+          INSECURE_AUTH: 1
+          VERBOSE: 1
+          TESTSUITE: lan
+          AFP_VERSION: 7
+      steps:
+          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+
+
+    afp-speedtest:
+      name: AFP speedtest
+      needs: build-container-testsuite
+      runs-on: ubuntu-latest
+      timeout-minutes: 5
+      env:
+          AFP_USER: atalk1
+          AFP_PASS: afpafp
+          AFP_GROUP: afpusers
+          SHARE_NAME: test1
+          INSECURE_AUTH: 1
+          VERBOSE: 1
+          TESTSUITE: speed
+          AFP_VERSION: 7
+      steps:
+          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest

--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -222,6 +222,10 @@ EXT
         afp_spectest "${TEST_FLAGS}" -"${AFP_VERSION}" -f Readonly_test -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}" -s "${SHARE_NAME}"
     elif [ "$TESTSUITE" == "login" ]; then
         afp_logintest "${TEST_FLAGS}" -"${AFP_VERSION}" -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}"
+    elif [ "$TESTSUITE" == "lan" ]; then
+        afp_lantest "${TEST_FLAGS}" -"${AFP_VERSION}" -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}" -s "${SHARE_NAME}"
+    elif [ "$TESTSUITE" == "speed" ]; then
+        afp_speedtest "${TEST_FLAGS}" -"${AFP_VERSION}" -h 127.0.0.1 -p 548 -u "${AFP_USER}" -w "${AFP_PASS}" -s "${SHARE_NAME}"
     else
         echo "Unknown testsuite: ${TESTSUITE}"
         exit 1


### PR DESCRIPTION
This will run afp_lantest and afp_speedtest with default parameters. For now, this is mainly to validate that these two don't break. Not really to track performance (yet).