### PR TITLE
GitHub CI: Build with mariadb on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -424,7 +424,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install dependencies
         run: |
-          brew install berkeley-db@5 bison cmark-gfm dbus docbook-xsl libxslt meson mysql openldap talloc tracker
+          brew install berkeley-db@5 bison cmark-gfm dbus docbook-xsl libxslt mariadb meson openldap talloc tracker
       - name: Configure
         run: |
           meson setup build \


### PR DESCRIPTION
Rather than mysql, use the more light-weight mariadb on macOS to build the mysql CNID backend