### PR TITLE
Resolve macOS 15 clang compiler warnings

### DIFF
--- a/etc/afpd/catsearch.c
+++ b/etc/afpd/catsearch.c
@@ -424,7 +424,7 @@ static int rslt_add (const AFPObj *obj, struct vol *vol, struct path *path, char
 	else {
 		p++;
 	}
-	*p++ = isdir ? FILDIRBIT_ISDIR : FILDIRBIT_ISFILE;    /* IsDir ? */
+	*p++ = isdir ? (char) FILDIRBIT_ISDIR : FILDIRBIT_ISFILE;    /* IsDir ? */
 
 	if (ext) {
 		*p++ = 0;                  /* Pad */

--- a/etc/afpd/enumerate.c
+++ b/etc/afpd/enumerate.c
@@ -440,7 +440,7 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
             *data++ = esz + header;
         }
 
-        *data++ = S_ISDIR(s_path.st.st_mode) ? FILDIRBIT_ISDIR : FILDIRBIT_ISFILE;
+        *data++ = S_ISDIR(s_path.st.st_mode) ? (char) FILDIRBIT_ISDIR : FILDIRBIT_ISFILE;
         if (ext) {
              *data++ = 0;
         }

--- a/etc/afpd/fce_api.c
+++ b/etc/afpd/fce_api.c
@@ -182,7 +182,7 @@ void fce_cleanup(void)
  * Construct a UDP packet for our listeners and return packet size
  * */
 static ssize_t build_fce_packet(const AFPObj *obj,
-                                char *iobuf,
+                                unsigned char *iobuf,
                                 fce_ev_t event,
                                 const char *path,
                                 const char *oldpath,
@@ -190,7 +190,7 @@ static ssize_t build_fce_packet(const AFPObj *obj,
                                 const char *user,
                                 uint32_t event_id)
 {
-    char *p = iobuf;
+    unsigned char *p = iobuf;
     size_t pathlen;
     ssize_t datalen = 0;
     uint16_t uint16;

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -1472,7 +1472,7 @@ int copyfile(struct vol *s_vol,
         return AFPERR_EXIST;
     }
     size_t copybuf_len = 0;
-    char* copybuf;
+    uint8_t* copybuf;
 
     if (s_vol->v_obj->proto == AFPPROTO_DSI)
     {

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -583,7 +583,7 @@ int afp_getsrvrparms(AFPObj *obj, char *ibuf _U_, size_t ibuflen _U_, char *rbuf
             break;
 
         /* set password bit if there's a volume password */
-        *data = (volume->v_password) ? AFPSRVR_PASSWD : 0;
+        *data = (volume->v_password) ? (char) AFPSRVR_PASSWD : 0;
 
         /* Apple 2 clients running ProDOS-8 expect one volume to have
            bit 0 of this byte set.  They will not recognize anything

--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -141,7 +141,7 @@ static int pwd_login(void *obj, char *username, int ulen, struct passwd **uam_pw
     rbuf += sizeof(sessid);
     *rbuflen += sizeof(sessid);
 
-    gcry_mpi_print(GCRYMPI_FMT_USG, rbuf, KEYSIZE, &nwritten, Mb);
+    gcry_mpi_print(GCRYMPI_FMT_USG, (unsigned char *) rbuf, KEYSIZE, &nwritten, Mb);
     if (nwritten < KEYSIZE) {
         memmove(rbuf + KEYSIZE - nwritten, rbuf, nwritten);
         memset(rbuf, 0, KEYSIZE - nwritten);

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -436,7 +436,7 @@ extern ssize_t adf_pread(struct ad_fd *, void *, size_t, off_t);
 extern ssize_t adf_pwrite(struct ad_fd *, const void *, size_t, off_t);
 extern int     ad_dtruncate(struct adouble *, off_t);
 extern int     ad_rtruncate(struct adouble *, const char *, off_t);
-extern int     copy_fork(int eid, struct adouble *add, struct adouble *ads, char *buf, size_t buflen);
+extern int     copy_fork(int eid, struct adouble *add, struct adouble *ads, uint8_t *buf, size_t buflen);
 
 /* ad_size.c */
 extern off_t ad_size (const struct adouble *, uint32_t );

--- a/libatalk/adouble/ad_conv.c
+++ b/libatalk/adouble/ad_conv.c
@@ -157,7 +157,7 @@ static int ad_conv_v22ea_rf(const char *path, const struct stat *sp, const struc
     ad_init_old(&adv2, AD_VERSION2, adea.ad_options);
 
     size_t copybuf_len = 0;
-    char* copybuf;
+    uint8_t* copybuf;
 
     if (vol->v_obj->proto == AFPPROTO_DSI)
     {

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -411,7 +411,7 @@ static int new_ad_header(struct adouble *ad, const char *path, struct stat *stp,
 static int parse_entries(struct adouble *ad, uint16_t nentries, size_t valid_data_len)
 {
     uint32_t   eid, len, off;
-    uint8_t *buf = ad->ad_data + AD_HEADER_LEN;
+    uint8_t *buf = (uint8_t *) ad->ad_data + AD_HEADER_LEN;
 
     /* now, read in the entry bits */
     for (; nentries > 0; nentries-- ) {

--- a/libatalk/adouble/ad_write.c
+++ b/libatalk/adouble/ad_write.c
@@ -217,12 +217,12 @@ static int copy_all(const int dfd, const void *buf,
 /* --------------------------
  * copy only the fork data stream
 */
-int copy_fork(int eid, struct adouble *add, struct adouble *ads, char *buf, size_t buflen)
+int copy_fork(int eid, struct adouble *add, struct adouble *ads, uint8_t *buf, size_t buflen)
 {
     ssize_t cc;
     int     err = 0;
-    char    fixedbuf[8192];
-    char    *filebuf;
+    uint8_t fixedbuf[8192];
+    uint8_t *filebuf;
     int     sfd, dfd;
 
     if (buf != NULL && buflen > sizeof(fixedbuf)) {

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -275,13 +275,14 @@ int flags = O_RDWR;
 	}
 	did = ntohl(did);
 	if (local_chdir(vol, did) < 0) {
-		return ntohl(AFPERR_PARAM);
+		return (uint16_t) ntohl(AFPERR_PARAM);
 	}
 	fd = open(name, flags, 0666);
 	if (fd == -1) {
-		return ntohl(AFPERR_NOOBJ);
+		return (uint16_t) ntohl(AFPERR_NOOBJ);
 	}
-	return fd;
+	close(fd);
+	return (uint16_t) ntohl(AFP_OK);
 }
 
 /* ------------------------------- */


### PR DESCRIPTION
Resolves all compiler warnings thrown by Apple clang version 16.0.0 (clang-1600.0.26.6)