### PR TITLE
Add GPL v2 license grant to mysql CNID backend code

### DIFF
--- a/libatalk/cnid/mysql/cnid_mysql.c
+++ b/libatalk/cnid/mysql/cnid_mysql.c
@@ -1,6 +1,11 @@
 /*
  * Copyright (C) Ralph Boehme 2013
  * All Rights Reserved.  See COPYING.
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
  */
 
 #ifdef HAVE_CONFIG_H


### PR DESCRIPTION
This adds the standard GNU GPL v2 license grant blurb to this one source file. It currently defers to [COPYING](https://github.com/Netatalk/netatalk/blob/main/COPYING) for the license, which is ambiguous.

Approved by original author in a comment below.