### PR TITLE
config: Disable default options in macipgw.conf

### DIFF
--- a/config/macipgw.conf
+++ b/config/macipgw.conf
@@ -1,5 +1,8 @@
-# MacIP Gateway daemon configuration (netatalk 4.x)
+; MacIP Gateway daemon configuration (netatalk 4.x)
+;
+; See the `macipgw.conf' manual page for all available options
+
 [Global]
-network = 192.168.151.0
-netmask = 255.255.255.0
-nameserver = 8.8.8.8
+; network = 192.168.151.0
+; netmask = 255.255.255.0
+; nameserver = 8.8.8.8


### PR DESCRIPTION
Having a public DNS server configured by default is considered a tracking antipattern, while no default IP address can work in all network configurations.