### PR TITLE
meson: Restore prioritized Berkeley DB detection

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -489,83 +489,78 @@ if bdb_req_version != ''
 endif
 
 foreach dir : bdb_dirs
-    libdb = cc.find_library('db', dirs: dir, required: false)
-    if libdb.found()
-        have_bdb = true
-    else
-        foreach subdir : bdb_subdirs
-            bdb_include_path = dir / 'include' / subdir
-            bdb_header = bdb_include_path / 'db.h'
-            if fs.exists(bdb_header)
-                bdb_includes = include_directories(bdb_include_path)
+    foreach subdir : bdb_subdirs
+        bdb_include_path = dir / 'include' / subdir
+        bdb_header = bdb_include_path / 'db.h'
+        if fs.exists(bdb_header)
+            bdb_includes = include_directories(bdb_include_path)
 
-                grep_result = run_command(
-                    'grep',
-                    'DB_VERSION_MAJOR',
-                    bdb_header,
-                    check: false,
-                )
-                if grep_result.returncode() != 0
-                    warning('Unable to determine Berkeley DB major version from header', bdb_header)
-                    continue
-                endif
-                bdb_major_version = grep_result.stdout().strip().substring(25)
+            grep_result = run_command(
+                'grep',
+                'DB_VERSION_MAJOR',
+                bdb_header,
+                check: false,
+            )
+            if grep_result.returncode() != 0
+                warning('Unable to determine Berkeley DB major version from header', bdb_header)
+                continue
+            endif
+            bdb_major_version = grep_result.stdout().strip().substring(25)
 
-                grep_result = run_command(
-                    'grep',
-                    'DB_VERSION_MINOR',
-                    bdb_header,
-                    check: false,
-                )
-                if grep_result.returncode() != 0
-                    warning('Unable to determine Berkeley DB minor version from header', bdb_header)
-                    continue
-                endif
-                bdb_minor_version = grep_result.stdout().strip().substring(25)
+            grep_result = run_command(
+                'grep',
+                'DB_VERSION_MINOR',
+                bdb_header,
+                check: false,
+            )
+            if grep_result.returncode() != 0
+                warning('Unable to determine Berkeley DB minor version from header', bdb_header)
+                continue
+            endif
+            bdb_minor_version = grep_result.stdout().strip().substring(25)
 
-                bdb_version = bdb_major_version + '.' + bdb_minor_version
+            bdb_version = bdb_major_version + '.' + bdb_minor_version
 
-                if not bdb_version.version_compare('>=4.6')
-                    continue
-                endif
+            if not bdb_version.version_compare('>=4.6')
+                continue
+            endif
 
-                if bdb_req_version != '' and not bdb_version.version_compare('~' + bdb_req_version)
-                    continue
-                endif
+            if bdb_req_version != '' and not bdb_version.version_compare('~' + bdb_req_version)
+                continue
+            endif
 
-                message('Berkeley DB header found at', bdb_header)
+            message('Berkeley DB header found at', bdb_header)
 
-                # Now find lib file matching header
-                if target_os == 'sunos' and compiler_64_bit_mode and fs.exists(dir / 'lib/64')
-                    bdb_libdir = dir / 'lib/64'
-                else
-                    bdb_libdir = dir / 'lib'
-                endif
+            # Now find lib file matching header
+            if target_os == 'sunos' and compiler_64_bit_mode and fs.exists(dir / 'lib/64')
+                bdb_libdir = dir / 'lib/64'
+            else
+                bdb_libdir = dir / 'lib'
+            endif
 
-                # Guess lib name starting from more specific ones
-                bdb_libnames = [
-                    'db-' + bdb_major_version + '.' + bdb_minor_version,
-                    'db'  + bdb_major_version + '.' + bdb_minor_version,
-                    'db'  + bdb_major_version + bdb_minor_version,
-                    'db-' + bdb_major_version,
-                    'db'  + bdb_major_version,
-                    'db',
-                ]
+            # Guess lib name starting from more specific ones
+            bdb_libnames = [
+                'db-' + bdb_major_version + '.' + bdb_minor_version,
+                'db'  + bdb_major_version + '.' + bdb_minor_version,
+                'db'  + bdb_major_version + bdb_minor_version,
+                'db-' + bdb_major_version,
+                'db'  + bdb_major_version,
+                'db',
+            ]
 
-                foreach name : bdb_libnames
-                    libdb = cc.find_library(name, dirs: bdb_libdir, required: false)
-                    if libdb.found()
-                        have_bdb = true
-                        break
-                    endif
-                endforeach
-
-                if have_bdb
+            foreach name : bdb_libnames
+                libdb = cc.find_library(name, dirs: bdb_libdir, required: false)
+                if libdb.found()
+                    have_bdb = true
                     break
                 endif
+            endforeach
+
+            if have_bdb
+                break
             endif
-        endforeach
-    endif
+        endif
+    endforeach
 
     if have_bdb
         break


### PR DESCRIPTION
While making the builds Homebrew compatible I went overboard with bypassing the granular bdb version prioritization.

This brings back the previous logic, by simply removing an early find_library() call that was added.