### PR TITLE
GitHub CI: Build on Ubuntu without Unicode data to avoid dirty repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -381,7 +381,6 @@ jobs:
             tcpd \
             tracker \
             tracker-miner-fs \
-            unicode-data \
             xsltproc
       - name: Configure
         run: |


### PR DESCRIPTION
The dirty repo state will fail the distcheck later