### PR TITLE
GitHub CI: NetBSD version agnostic PKG_PATH definition

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -507,7 +507,7 @@ jobs:
         with:
           copyback: false
           prepare: |
-            export PKG_PATH=http://ftp.netbsd.org/pub/pkgsrc/packages/NetBSD/x86_64/10.1/All/
+            export PKG_PATH="https://cdn.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f '1 2' -d.)/All/"
             pkg_add \
               bison \
               db5 \


### PR DESCRIPTION
This is the portable way to set the PKG_PATH env variable, to accommodate future NetBSD version bumps.