### PR TITLE
meson: Introduce with-bdb-include-path override option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -431,6 +431,7 @@ endif
 #
 
 bdb_path = get_option('with-bdb-path')
+bdb_include_path_override = get_option('with-bdb-include-path')
 bdb_req_version = get_option('with-bdb-version')
 
 have_bdb = false
@@ -495,7 +496,11 @@ endif
 
 foreach dir : bdb_dirs
     foreach subdir : bdb_subdirs
-        bdb_include_path = dir / 'include' / subdir
+        if bdb_include_path_override != ''
+            bdb_include_path = bdb_include_path_override
+        else
+            bdb_include_path = dir / 'include' / subdir
+        endif
         bdb_header = bdb_include_path / 'db.h'
         if fs.exists(bdb_header)
             bdb_includes = include_directories(bdb_include_path)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -214,6 +214,12 @@ option(
     description: 'Set path to Berkeley DB installation. Must contain lib and include dirs',
 )
 option(
+    'with-bdb-include-path',
+    type: 'string',
+    value: '',
+    description: 'Set path to Berkeley DB include dir. When defined, -Dwith-bdb-path is used only for lib dir',
+)
+option(
     'with-bdb-version',
     type: 'string',
     value: '',


### PR DESCRIPTION
In some environments, notable NixOS, lib and include for a library is in different dirs. Since we have a hackish berkeley db detection routine, this new `-Dwith-bdb-include-path` option allows you to define an include path separate from the lib path for bdb.