### PR TITLE
meson: Look for shared Berkeley DB library in versioned subdir too

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -560,6 +560,10 @@ foreach dir : bdb_dirs
 
             foreach name : bdb_libnames
                 libdb = cc.find_library(name, dirs: bdb_libdir, required: false)
+                if not libdb.found()
+                    libdb = cc.find_library(name, dirs: bdb_libdir / subdir, required: false)
+                endif
+
                 if libdb.found()
                     have_bdb = true
                     break


### PR DESCRIPTION
Some environments keep the Berkeley DB shared libraries in a versioned subdir, like what is common with the Berkeley DB include dir. This change makes it so that checking the subdir is a fallback when looking for libraries.