### PR TITLE
docs: Use correct Markdown hyperlinks in manual

### DIFF
--- a/doc/manual/AppleTalk.md
+++ b/doc/manual/AppleTalk.md
@@ -11,7 +11,7 @@ Netatalk implements the AppleTalk protocols to serve files over AFP and
 provide other services to old Mac and Apple II clients.
 
 A complete overview can be found inside the [developer
-documentation](https://netatalk.io/appletalk).
+documentation](/appletalk.html).
 
 ### To use AppleTalk or not
 

--- a/doc/manual/Configuration.md
+++ b/doc/manual/Configuration.md
@@ -11,8 +11,7 @@ Netatalk's `afpd` daemon offers AFP fileservices to Apple clients. The
 configuration is managed through the `afp.conf` file which uses an ini
 style configuration syntax.
 
-Support for [Spotlight](#spotlight) was
-added in Netatalk 3.1.
+Support for [Spotlight](#spotlight) was added in Netatalk 3.1.
 
 Mac OS X 10.5 (Leopard) introduced support for Time Machine backups over
 AFP. Two new functions ensure that backups are written to disk, not just
@@ -597,7 +596,7 @@ By default, the effective permission of the authenticated user are only
 mapped to the mentioned
 UARightspermission structure, not the
 UNIX mode. You can adjust this behaviour with the configuration option
-[map acls](#map_acls).
+[map acls](afp.conf#options-for-acl-handling).
 
 However, neither in Finder "Get Info" windows nor in the Terminal will
 you be able to see the ACLs, because of how ACLs in macOS are designed.
@@ -645,7 +644,7 @@ In detail:
       and PAM
 
     - configure Netatalk via the special [LDAP options for
-      ACLs](#acl_options) in [afp.conf](#afp.conf.5) so that Netatalk is
+      ACLs](afp.conf#options-for-acl-handling) in `afp.conf` so that Netatalk is
       able to retrieve the UUID for users and groups via LDAP search
       queries
 
@@ -865,8 +864,8 @@ Solaris with Tracker from OpenCSW:
 
   We therefore recommend to disable live filesystem monitoring and let
   Tracker periodically scan filesystems for changes instead, see the
-  Tracker configuration options [enable-monitors](#enable-monitors) and
-  [crawling-interval](#crawling-interval) below.
+  [Tracker configuration options](#advanced-tracker-command-line-configuration)
+  enable-monitors and crawling-interval below.
 
 - Indexing home directories
 

--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -3,7 +3,7 @@
 > **WARNING**
 
 > Before upgrading to Netatalk 4 from an earlier version, please read the
-[[Upgrade]] chapter in this manual.
+[Upgrade](Upgrading.html) chapter in this manual.
 
 ## How to obtain Netatalk
 
@@ -217,11 +217,10 @@ functionality.
 
 Instructions on how to use the build system to configure and build
 netatalk source code are documented in the
-[INSTALL.md](https://github.com/Netatalk/netatalk/blob/main/INSTALL.md)
-file in the Netatalk source tree.
+[Install Quick Start](/install.html) guide.
 
 For examples of concrete steps to compile on specific operating systems,
-refer to the [Compile Netatalk from Source](#compile) appendix in this
+refer to the [Compile Netatalk from Source](Compilation.html) appendix in this
 manual, which is automatically generated from the CI build scripts.
 
 ## Starting and stopping Netatalk
@@ -264,5 +263,5 @@ be by running the `netatalk -V` command.
 
 If you want to run AppleTalk services, you also need to start the
 `atalkd` daemon, plus the optional `papd`, `timelord`, and `a2boot`
-daemons. See the [AppleTalk](#appletalk) chapter in this manual for more
+daemons. See the [AppleTalk](AppleTalk.html) chapter in this manual for more
 information.

--- a/doc/manual/Upgrading.md
+++ b/doc/manual/Upgrading.md
@@ -41,7 +41,7 @@ There are three major changes between Netatalk 2 and Netatalk 4:
 > **WARNING**
 
 > most option names have changed, read the full manpage
-[afp.conf](#afp.conf.5) for details
+[afp.conf](afp.conf.html) for details
 
 `extmap.conf`
 
@@ -98,7 +98,7 @@ Implementation details:
 
 ### Other major changes
 
-- New service controller daemon [netatalk](#netatalk.8) which is
+- New service controller daemon [netatalk](netatalk.html) which is
   responsible for starting and restarting the AFP and CNID daemons. All
   bundled start scripts have been updated, make sure to update yours!
 

--- a/doc/manual/_Sidebar.md
+++ b/doc/manual/_Sidebar.md
@@ -1,57 +1,57 @@
-[[en]] | [[ja]]
+[en](/manual/en) | [ja](/manual/ja)
 
 Manual
 
-* [[Installation]]
-* [[Configuration]]
-* [[AppleTalk]]
-* [[Upgrading]]
+* [Installation](Installation.html)
+* [Configuration](Configuration.html)
+* [AppleTalk](AppleTalk.html)
+* [Upgrading](Upgrading.html)
 
 User Tools
 
-* [[ad]]
-* [[addump]]
-* [[aecho]]
-* [[afpldaptest]]
-* [[afppasswd]]
-* [[afpstats]]
-* [[afptest]]
-* [[asip-status]]
-* [[dbd]]
-* [[getzones]]
-* [[macusers]]
-* [[nbp]]
-* [[pap]]
+* [ad](ad.html)
+* [addump](addump.html)
+* [aecho](aecho.html)
+* [afpldaptest](afpldaptest.html)
+* [afppasswd](afppasswd.html)
+* [afpstats](afpstats.html)
+* [afptest](afptest.html)
+* [asip-status](asip-status.html)
+* [dbd](dbd.html)
+* [getzones](getzones.html)
+* [macusers](macusers.html)
+* [nbp](nbp.html)
+* [pap](pap.html)
 
 Configuration Files
 
-* [[afp_signature.conf]]
-* [[afp_voluuid.conf]]
-* [[afp.conf]]
-* [[atalkd.conf]]
-* [[extmap.conf]]
-* [[papd.conf]]
+* [afp_signature.conf](afp_signature.conf.html)
+* [afp_voluuid.conf](afp_voluuid.conf.html)
+* [afp.conf](afp.conf.html)
+* [atalkd.conf](atalkd.conf.html)
+* [extmap.conf](extmap.conf.html)
+* [papd.conf](papd.conf.html)
 
 Daemons and Admin Tools
 
-* [[a2boot]]
-* [[afpd]]
-* [[atalkd]]
-* [[cnid_dbd]]
-* [[cnid_metad]]
-* [[macipgw]]
-* [[netatalk]]
-* [[papd]]
-* [[papstatus]]
-* [[timelord]]
+* [a2boot](a2boot.html)
+* [afpd](afpd.html)
+* [atalkd](atalkd.html)
+* [cnid_dbd](cnid_dbd.html)
+* [cnid_metad](cnid_metad.html)
+* [macipgw](macipgw.html)
+* [netatalk](netatalk.html)
+* [papd](papd.html)
+* [papstatus](papstatus.html)
+* [timelord](timelord.html)
 
 Developer References
 
-* [[atalk]]
-* [[atalk_aton]]
-* [[nbp_name]]
+* [atalk](atalk.html)
+* [atalk_aton](atalk_aton.html)
+* [nbp_name](nbp_name.html)
 
 Appendices
 
-* [[Compilation]]
-* [[License]]
+* [Compilation](Compilation.html)
+* [License](License.html)

--- a/doc/po/AppleTalk.md.ja.po
+++ b/doc/po/AppleTalk.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-25 21:35+0100\n"
+"POT-Creation-Date: 2025-01-26 21:23+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -17,7 +17,7 @@ msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:1053 manpages/man5/afp.conf.5.md:1088
-#: manual/AppleTalk.md:154 manual/Configuration.md:838 manual/Installation.md:4
+#: manual/AppleTalk.md:154 manual/Configuration.md:837 manual/Installation.md:4
 #: manual/Upgrading.md:42
 #, no-wrap
 msgid "> **WARNING**\n"
@@ -72,11 +72,9 @@ msgstr ""
 #. type: Plain text
 #: manual/AppleTalk.md:15
 msgid ""
-"A complete overview can be found inside the [developer documentation]"
-"(https://netatalk.io/appletalk)."
-msgstr ""
-"完全な概要は、[開発者向けドキュメント](https://netatalk.io/appletalk) にあ"
-"る。"
+"A complete overview can be found inside the [developer documentation](/"
+"appletalk.html)."
+msgstr "完全な概要は、[開発者向けドキュメント](/appletalk.html) にある。"
 
 #. type: Title ###
 #: manual/AppleTalk.md:16

--- a/doc/po/Configuration.md.ja.po
+++ b/doc/po/Configuration.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-25 21:15+0100\n"
+"POT-Creation-Date: 2025-01-26 22:32+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -22,28 +22,28 @@ msgstr ""
 #: manpages/man5/afp.conf.5.md:370 manpages/man5/afp.conf.5.md:722
 #: manpages/man5/afp.conf.5.md:1048 manpages/man5/afp.conf.5.md:1173
 #: manpages/man5/afp.conf.5.md:1211 manpages/man8/papd.8.md:97
-#: manual/Configuration.md:114
+#: manual/Configuration.md:113
 #, no-wrap
 msgid "> **NOTE**\n"
 msgstr "> **注記**\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:1053 manpages/man5/afp.conf.5.md:1088
-#: manual/AppleTalk.md:154 manual/Configuration.md:838 manual/Installation.md:4
+#: manual/AppleTalk.md:154 manual/Configuration.md:837 manual/Installation.md:4
 #: manual/Upgrading.md:42
 #, no-wrap
 msgid "> **WARNING**\n"
 msgstr "> **警告**\n"
 
 #. type: Title ###
-#: manpages/man8/cnid_dbd.8.md:63 manual/Configuration.md:584
-#: manual/Configuration.md:832
+#: manpages/man8/cnid_dbd.8.md:63 manual/Configuration.md:583
+#: manual/Configuration.md:831
 #, no-wrap
 msgid "Configuration"
 msgstr "設定"
 
 #. type: Title ##
-#: manpages/man8/papd.8.md:61 manual/Configuration.md:343
+#: manpages/man8/papd.8.md:61 manual/Configuration.md:342
 #, no-wrap
 msgid "Authentication"
 msgstr "認証"
@@ -83,12 +83,12 @@ msgstr ""
 "する。"
 
 #. type: Plain text
-#: manual/Configuration.md:16
+#: manual/Configuration.md:15
 msgid "Support for [Spotlight](#spotlight) was added in Netatalk 3.1."
 msgstr "[Spotlight](#spotlight) サポートは Netatalk 3.1 より加えられた。"
 
 #. type: Plain text
-#: manual/Configuration.md:22
+#: manual/Configuration.md:21
 msgid ""
 "Mac OS X 10.5 (Leopard) introduced support for Time Machine backups over "
 "AFP. Two new functions ensure that backups are written to disk, not just in "
@@ -104,7 +104,7 @@ msgstr ""
 "ボリュームオプション \"`time machine = yes`\" を使用する。"
 
 #. type: Plain text
-#: manual/Configuration.md:28
+#: manual/Configuration.md:27
 msgid ""
 "Starting with Netatalk 2.1 UNIX symlinks can be used on the server. "
 "Semantics are the same as for e.g. NFS, i.e.  they are not resolved on the "
@@ -118,13 +118,13 @@ msgstr ""
 "内でしかるべき場所を示すリンクとなる。"
 
 #. type: Title ###
-#: manual/Configuration.md:29
+#: manual/Configuration.md:28
 #, no-wrap
 msgid "afp.conf"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:34
+#: manual/Configuration.md:33
 msgid ""
 "`afp.conf` is the configuration file used by afpd to determine the behaviour "
 "and configuration of the AFP file server and the AFP volume that it provides."
@@ -133,34 +133,34 @@ msgstr ""
 "決定するために afpd が使用する設定ファイルである。"
 
 #. type: Plain text
-#: manual/Configuration.md:36
+#: manual/Configuration.md:35
 msgid "The `afp.conf` is divided into several sections:"
 msgstr "`afp.conf` は複数のサーバーセクションに分割できる。すなわち："
 
 #. type: Plain text
-#: manual/Configuration.md:38
+#: manual/Configuration.md:37
 msgid "\\[Global\\]"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:40
+#: manual/Configuration.md:39
 #, no-wrap
 msgid "> The global section defines general server options\n"
 msgstr "> グローバルセクションで基本的なサーバーオプションを定義する\n"
 
 #. type: Plain text
-#: manual/Configuration.md:42
+#: manual/Configuration.md:41
 msgid "\\[Homes\\]"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:44
+#: manual/Configuration.md:43
 #, no-wrap
 msgid "> The homes section defines user home volumes\n"
 msgstr "> ホームセクションでユーザーのホームボリュームを定義する\n"
 
 #. type: Plain text
-#: manual/Configuration.md:47
+#: manual/Configuration.md:46
 msgid ""
 "Any section not called `Global` or `Homes` is interpreted as an AFP volume."
 msgstr ""
@@ -168,7 +168,7 @@ msgstr ""
 "であると解釈される"
 
 #. type: Plain text
-#: manual/Configuration.md:51
+#: manual/Configuration.md:50
 msgid ""
 "For sharing user homes by defining a `Homes` section you must specify the "
 "option `basedir regex` which can be a simple string with the path to the "
@@ -179,12 +179,12 @@ msgstr ""
 "ディレクトリのパスあるいは正規表現からなる単純な文字列でよい。"
 
 #. type: Plain text
-#: manual/Configuration.md:53
+#: manual/Configuration.md:52
 msgid "Example:"
 msgstr "例："
 
 #. type: Plain text
-#: manual/Configuration.md:56
+#: manual/Configuration.md:55
 #, no-wrap
 msgid ""
 "    [Homes]\n"
@@ -192,7 +192,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:59
+#: manual/Configuration.md:58
 msgid ""
 "Now any user logging into the AFP server will have a user volume available "
 "whose path is `/home/NAME`."
@@ -201,7 +201,7 @@ msgstr ""
 "名）` というパス名でのユーザーボリュームを使用できる。"
 
 #. type: Plain text
-#: manual/Configuration.md:62
+#: manual/Configuration.md:61
 msgid ""
 "A more complex setup would be a server with a large amount of user homes "
 "which are split across e.g. two different filesystems:"
@@ -210,22 +210,22 @@ msgstr ""
 "された、 大量のユーザーホームディレクトリーのあるサーバーなら："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:64
+#: manual/Configuration.md:63
 msgid "/RAID1/homes"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:66
+#: manual/Configuration.md:65
 msgid "/RAID2/morehomes"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:68
+#: manual/Configuration.md:67
 msgid "The following configuration is required:"
 msgstr "以下の設定が必要である："
 
 #. type: Plain text
-#: manual/Configuration.md:71
+#: manual/Configuration.md:70
 #, no-wrap
 msgid ""
 "    [Homes]\n"
@@ -233,7 +233,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:74
+#: manual/Configuration.md:73
 msgid ""
 "If `basedir regex` contains a symlink, set the canonicalized absolute path. "
 "When `/home` links to `/usr/home`:"
@@ -243,7 +243,7 @@ msgstr ""
 "ンクがはられていた場合："
 
 #. type: Plain text
-#: manual/Configuration.md:77
+#: manual/Configuration.md:76
 #, no-wrap
 msgid ""
 "    [Homes]\n"
@@ -251,7 +251,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:80
+#: manual/Configuration.md:79
 msgid ""
 "For a more detailed explanation of the available options, please refer to "
 "the `afp.conf(5)` man page."
@@ -260,13 +260,13 @@ msgstr ""
 "照いただきたい。"
 
 #. type: Title ##
-#: manual/Configuration.md:81
+#: manual/Configuration.md:80
 #, no-wrap
 msgid "CNID backends"
 msgstr "CNID バックエンド"
 
 #. type: Plain text
-#: manual/Configuration.md:91
+#: manual/Configuration.md:90
 msgid ""
 "Unlike other protocols like SMB or NFS, the AFP protocol mostly refers to "
 "files and directories by ID and not by a path (the IDs are also called CNID, "
@@ -286,7 +286,7 @@ msgstr ""
 "は Finder のみで当てはまることであり、アプリケーションでは当てはまらない）。"
 
 #. type: Plain text
-#: manual/Configuration.md:98
+#: manual/Configuration.md:97
 msgid ""
 "Every file in an AFP volume has to have a unique file ID, IDs must, "
 "according to the specs, never be reused, and IDs are 32 bit numbers "
@@ -302,7 +302,7 @@ msgstr ""
 "願いしたい :-)"
 
 #. type: Plain text
-#: manual/Configuration.md:105
+#: manual/Configuration.md:104
 #, no-wrap
 msgid ""
 "Netatalk needs to map IDs to files and folders in the host filesystem.\n"
@@ -323,7 +323,7 @@ msgstr ""
 "名前を一対一対応させるデータベースである。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:109
+#: manual/Configuration.md:108
 msgid ""
 "The CNID databases are by default located in `$prefix/var/netatalk/CNID`. "
 "You can change the location by configuring `-Dwith-statedir-path=PATH` at "
@@ -333,7 +333,7 @@ msgstr ""
 "パイル時に `-Dwith-statedir-path=PATH` オプションで場所を変えられる。"
 
 #. type: Plain text
-#: manual/Configuration.md:112
+#: manual/Configuration.md:111
 msgid ""
 "There is a command line utility called `dbd` available which can be used to "
 "verify, repair and rebuild the CNID database."
@@ -342,7 +342,7 @@ msgstr ""
 "名のコマンドが用意されていている。"
 
 #. type: Plain text
-#: manual/Configuration.md:117
+#: manual/Configuration.md:116
 #, no-wrap
 msgid ""
 "> There are some CNID related things you should keep in mind when\n"
@@ -352,7 +352,7 @@ msgstr ""
 "に関する点を留意しておかなければならない。すなわち：\n"
 
 #. type: Plain text
-#: manual/Configuration.md:119
+#: manual/Configuration.md:118
 #, no-wrap
 msgid "> - Don't nest volumes unless \"`vol dbnest = yes`\" is set.\n"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 "が指定してある時以外はボリュームをネスト（入れ子）にしてはならない。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:122
+#: manual/Configuration.md:121
 #, no-wrap
 msgid ""
 "> - CNID backends are databases, so they turn afpd into a file\n"
@@ -370,7 +370,7 @@ msgstr ""
 "はファイルサーバーとデータベースの混成物とならしめている。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:126
+#: manual/Configuration.md:125
 #, no-wrap
 msgid ""
 "> - If there's no more space on the filesystem left, the database will\n"
@@ -385,7 +385,7 @@ msgstr ""
 "データベースフォルダーがクオータなしでユーザー／グループのオーナーとなっているか確認する。のいずれかである。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:132
+#: manual/Configuration.md:131
 #, no-wrap
 msgid ""
 "> - Be careful with CNID databases for volumes that are mounted via NFS.\n"
@@ -403,13 +403,13 @@ msgstr ""
 "`vol dbpath` ディレクティブを使用するべきである。\n"
 
 #. type: Title ###
-#: manual/Configuration.md:133
+#: manual/Configuration.md:132
 #, no-wrap
 msgid "dbd"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:139
+#: manual/Configuration.md:138
 msgid ""
 "The \"Database Daemon\" backend is built on Berkeley DB. Access to the CNID "
 "database is restricted to the cnid_dbd daemon process. afpd processes "
@@ -421,19 +421,19 @@ msgstr ""
 "やりとりをする。 データベースが破損する可能性は経験的にはほぼゼロである。"
 
 #. type: Plain text
-#: manual/Configuration.md:141
+#: manual/Configuration.md:140
 msgid "This is the default backend since Netatalk 2.1."
 msgstr ""
 "本バックエンドは Netatalk 2.1 以来、デフォルトのバックエンドとなっている。"
 
 #. type: Title ###
-#: manual/Configuration.md:142
+#: manual/Configuration.md:141
 #, no-wrap
 msgid "last"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:148
+#: manual/Configuration.md:147
 msgid ""
 "The last backend is an in-memory tdb database. It is not persistent, with "
 "IDs valid only for the current session. Starting with netatalk 3.0, it "
@@ -446,7 +446,7 @@ msgstr ""
 "化テスト などに有用である。"
 
 #. type: Plain text
-#: manual/Configuration.md:151
+#: manual/Configuration.md:150
 msgid ""
 "This is basically equivalent to how `afpd` stored CNID data in netatalk 1.5 "
 "and earlier."
@@ -455,13 +455,13 @@ msgstr ""
 "法に一致している。"
 
 #. type: Title ###
-#: manual/Configuration.md:152
+#: manual/Configuration.md:151
 #, no-wrap
 msgid "mysql"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:156
+#: manual/Configuration.md:155
 msgid ""
 "CNID backend using a MySQL server. The MySQL server has to be provisioned by "
 "the system administrator."
@@ -470,19 +470,19 @@ msgstr ""
 "がプロビジョニングする必要がある。"
 
 #. type: Title ##
-#: manual/Configuration.md:157
+#: manual/Configuration.md:156
 #, no-wrap
 msgid "Charsets/Unicode"
 msgstr ""
 
 #. type: Title ###
-#: manual/Configuration.md:159
+#: manual/Configuration.md:158
 #, no-wrap
 msgid "Why Unicode?"
 msgstr "なぜ Unicode？"
 
 #. type: Plain text
-#: manual/Configuration.md:166
+#: manual/Configuration.md:165
 msgid ""
 "Internally, computers don't know anything about characters and texts, they "
 "only know numbers. Therefore, each letter is assigned a number. A character "
@@ -495,7 +495,7 @@ msgstr ""
 "*codepage* とも呼ばれるが、これは“数”と“字”の一対一対応を規定している。"
 
 #. type: Plain text
-#: manual/Configuration.md:175
+#: manual/Configuration.md:174
 msgid ""
 "If two or more computer systems need to communicate with each other, the "
 "have to use the same character set. In the 1960s the ASCII (American "
@@ -513,7 +513,7 @@ msgstr ""
 "ターで使われるキャラクタースキームの標準的なものである。"
 
 #. type: Plain text
-#: manual/Configuration.md:181
+#: manual/Configuration.md:180
 msgid ""
 "Later versions defined 256 characters to produce a more international "
 "fluency and to include some slightly esoteric graphical characters.  Using "
@@ -528,7 +528,7 @@ msgstr ""
 "ではなかった。"
 
 #. type: Plain text
-#: manual/Configuration.md:190
+#: manual/Configuration.md:189
 msgid ""
 "As a result localized character sets were defined later, e.g the ISO-8859 "
 "character sets. Most operating system vendors introduced their own "
@@ -548,7 +548,7 @@ msgstr ""
 "す。"
 
 #. type: Plain text
-#: manual/Configuration.md:195
+#: manual/Configuration.md:194
 msgid ""
 "Almost all of those characters sets defined 256 characters, where the first "
 "128 (0-127) character mappings are identical to ASCII. As a result, "
@@ -561,7 +561,7 @@ msgstr ""
 "実上 ASCII キャラクターセット限定となった。"
 
 #. type: Plain text
-#: manual/Configuration.md:200
+#: manual/Configuration.md:199
 msgid ""
 "To solve this problem new, larger character sets were defined. To make room "
 "for more character mappings, these character sets use at least 2 bytes to "
@@ -574,7 +574,7 @@ msgstr ""
 "めそういったキャラクターセットは*マルチバイト* キャラクターセットと呼ばれる。"
 
 #. type: Plain text
-#: manual/Configuration.md:205
+#: manual/Configuration.md:204
 msgid ""
 "One standardized multibyte charset encoding scheme is known as [Unicode]"
 "(http://www.unicode.org/). A big advantage of using a multibyte charset is "
@@ -588,13 +588,13 @@ msgstr ""
 "がない。"
 
 #. type: Title ###
-#: manual/Configuration.md:206
+#: manual/Configuration.md:205
 #, no-wrap
 msgid "Character sets used by Apple"
 msgstr "Apple で使われている（使われていた）キャラクターセット"
 
 #. type: Plain text
-#: manual/Configuration.md:211
+#: manual/Configuration.md:210
 msgid ""
 "In the past, Apple clients used single-byte charsets to communicate over the "
 "network. Over the years Apple defined a number of codepages, western users "
@@ -606,92 +606,92 @@ msgstr ""
 "であろう。"
 
 #. type: Plain text
-#: manual/Configuration.md:213
+#: manual/Configuration.md:212
 msgid "Codepages defined by Apple include:"
 msgstr "Apple の定義したコードページに含まれるもの："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:215
+#: manual/Configuration.md:214
 msgid "MacArabic, MacFarsi"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:217
+#: manual/Configuration.md:216
 msgid "MacCentralEurope"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:219
+#: manual/Configuration.md:218
 msgid "MacChineseSimple"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:221
+#: manual/Configuration.md:220
 msgid "MacChineseTraditional"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:223
+#: manual/Configuration.md:222
 msgid "MacCroatian"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:225
+#: manual/Configuration.md:224
 msgid "MacCyrillic"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:227
+#: manual/Configuration.md:226
 msgid "MacDevanagari"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:229
+#: manual/Configuration.md:228
 msgid "MacGreek"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:231
+#: manual/Configuration.md:230
 msgid "MacHebrew"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:233
+#: manual/Configuration.md:232
 msgid "MacIcelandic"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:235
+#: manual/Configuration.md:234
 msgid "MacJapanese"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:237
+#: manual/Configuration.md:236
 msgid "MacKorean"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:239
+#: manual/Configuration.md:238
 msgid "MacRoman"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:241
+#: manual/Configuration.md:240
 msgid "MacRomanian"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:243
+#: manual/Configuration.md:242
 msgid "MacThai"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:245
+#: manual/Configuration.md:244
 msgid "MacTurkish"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:251
+#: manual/Configuration.md:250
 msgid ""
 "Starting with Mac OS X and AFP3, [UTF-8](http://www.utf-8.com/) is used.  "
 "UTF-8 encodes Unicode characters in an ASCII compatible way, each Unicode "
@@ -705,7 +705,7 @@ msgstr ""
 "クターセットのエンコーディングなのである。"
 
 #. type: Plain text
-#: manual/Configuration.md:258
+#: manual/Configuration.md:257
 msgid ""
 "To complicate things, Unicode defines several *[normalization](http://"
 "www.unicode.org/reports/tr15/index.html)* forms.  While [samba](http://"
@@ -718,7 +718,7 @@ msgstr ""
 "を使用する。一方 Apple は *decomposed* normalization を使うことに決めた。"
 
 #. type: Plain text
-#: manual/Configuration.md:264
+#: manual/Configuration.md:263
 msgid ""
 "For example lets take the German character 'ä'. Using the precomposed "
 "normalization, Unicode maps this character to 0xE4. In decomposed "
@@ -732,7 +732,7 @@ msgstr ""
 "は *COMBINING DIAERESIS*（訳注：いわゆるウムラウト）に対応付けられている。"
 
 #. type: Plain text
-#: manual/Configuration.md:268
+#: manual/Configuration.md:267
 msgid ""
 "Netatalk refers to precomposed UTF-8 as *UTF8* and to decomposed UTF-8 as "
 "*UTF8-MAC*."
@@ -741,13 +741,13 @@ msgstr ""
 "と呼ぶ。"
 
 #. type: Title ###
-#: manual/Configuration.md:269
+#: manual/Configuration.md:268
 #, no-wrap
 msgid "afpd and character sets"
 msgstr "afpd とキャラクターセット"
 
 #. type: Plain text
-#: manual/Configuration.md:275
+#: manual/Configuration.md:274
 msgid ""
 "To support new AFP 3.x and older AFP 2.x clients at the same time, afpd "
 "needs to be able to convert between the various charsets used. AFP 3.x "
@@ -760,7 +760,7 @@ msgstr ""
 "Apple コードページのうちの一つを使う。"
 
 #. type: Plain text
-#: manual/Configuration.md:277
+#: manual/Configuration.md:276
 msgid ""
 "At the time of writing, netatalk supports the following Apple codepages:"
 msgstr ""
@@ -768,67 +768,67 @@ msgstr ""
 "トしている："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:279
+#: manual/Configuration.md:278
 msgid "MAC_CENTRALEUROPE"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:281
+#: manual/Configuration.md:280
 msgid "MAC_CHINESE_SIMP"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:283
+#: manual/Configuration.md:282
 msgid "MAC_CHINESE_TRAD"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:285
+#: manual/Configuration.md:284
 msgid "MAC_CYRILLIC"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:287
+#: manual/Configuration.md:286
 msgid "MAC_GREEK"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:289
+#: manual/Configuration.md:288
 msgid "MAC_HEBREW"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:291
+#: manual/Configuration.md:290
 msgid "MAC_JAPANESE"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:293
+#: manual/Configuration.md:292
 msgid "MAC_KOREAN"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:295
+#: manual/Configuration.md:294
 msgid "MAC_ROMAN"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:297
+#: manual/Configuration.md:296
 msgid "MAC_TURKISH"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:299
+#: manual/Configuration.md:298
 msgid "afpd handles three different character set options:"
 msgstr "afpd は三つの異なるキャラクターセットオプションを扱う："
 
 #. type: Plain text
-#: manual/Configuration.md:301
+#: manual/Configuration.md:300
 msgid "unix charset"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:308
+#: manual/Configuration.md:307
 #, no-wrap
 msgid ""
 "> This is the codepage used internally by your operating system. If not\n"
@@ -845,12 +845,12 @@ msgstr ""
 "`afp.conf(5)` を参照のこと。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:310
+#: manual/Configuration.md:309
 msgid "mac charset"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:317
+#: manual/Configuration.md:316
 #, no-wrap
 msgid ""
 "> As already mentioned, older Mac OS clients (up to AFP 2.2) use codepages\n"
@@ -869,12 +869,12 @@ msgstr ""
 "を参照のこと。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:319
+#: manual/Configuration.md:318
 msgid "vol charset"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:324
+#: manual/Configuration.md:323
 #, no-wrap
 msgid ""
 "> This defines the charset afpd should use for filenames on disk. By\n"
@@ -889,7 +889,7 @@ msgstr ""
 "が提供するキャラクターセットも使用することができる。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:333
+#: manual/Configuration.md:332
 #, no-wrap
 msgid ""
 "afpd needs a way to preserve extended Macintosh characters, or\n"
@@ -915,7 +915,7 @@ msgstr ""
 "にエンコードされる。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:337
+#: manual/Configuration.md:336
 msgid ""
 "Even though this version now uses `UTF8` as the default encoding for "
 "filenames, '/' will be converted to ':'. For western users another useful "
@@ -926,7 +926,7 @@ msgstr ""
 "とって別の有用な設定として `vol charset = ISO-8859-15` もあり得る。"
 
 #. type: Plain text
-#: manual/Configuration.md:342
+#: manual/Configuration.md:341
 msgid ""
 "If a character cannot be converted from the `mac charset` to the selected "
 "`vol charset`, you'll receive a -50 error on the mac. *Note*: Whenever you "
@@ -938,13 +938,13 @@ msgstr ""
 "参照のこと。"
 
 #. type: Title ###
-#: manual/Configuration.md:345
+#: manual/Configuration.md:344
 #, no-wrap
 msgid "AFP authentication basics"
 msgstr "AFP 認証の基本"
 
 #. type: Plain text
-#: manual/Configuration.md:353
+#: manual/Configuration.md:352
 msgid ""
 "Apple chose a flexible model called \"User Authentication Modules\" (UAMs) "
 "for authentication purposes between AFP client and server. An AFP client "
@@ -958,7 +958,7 @@ msgstr ""
 "せる。そして、クライアントがサポートしている最も強い暗号化の UAM を選ぶ。"
 
 #. type: Plain text
-#: manual/Configuration.md:356
+#: manual/Configuration.md:355
 msgid ""
 "Several UAMs have been developed by Apple over the time, some by 3rd-party "
 "developers."
@@ -967,28 +967,28 @@ msgstr ""
 "によるものもある。"
 
 #. type: Title ###
-#: manual/Configuration.md:357
+#: manual/Configuration.md:356
 #, no-wrap
 msgid "UAMs supported by Netatalk"
 msgstr "Netatalk でサポートされている UAM"
 
 #. type: Plain text
-#: manual/Configuration.md:360
+#: manual/Configuration.md:359
 msgid "Netatalk supports the following ones by default:"
 msgstr "Netatalk はデフォルトで以下のものをサポートしている："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:363
+#: manual/Configuration.md:362
 msgid "\"No User Authent\" UAM (guest access without authentication)"
 msgstr "\"No User Authent\" UAM（ユーザー認証なしのゲスト接続）"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:366
+#: manual/Configuration.md:365
 msgid "\"Cleartxt Passwrd\" UAM (no password encryption)"
 msgstr "\"Cleartxt Passwrd\" UAM（クリアテキスト(平文)パスワード、暗号化なし）"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:370
+#: manual/Configuration.md:369
 msgid ""
 "\"Randnum exchange\"/\"2-Way Randnum exchange\" UAMs (weak password "
 "encryption, separate password storage)"
@@ -997,22 +997,22 @@ msgstr ""
 "換、弱いパスワード暗号化、パスワードを別途保存する）"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:373
+#: manual/Configuration.md:372
 msgid "\"DHCAST128\" UAM (a.k.a. DHX; stronger password encryption)"
 msgstr "\"DHCAST128\" UAM（より強いパスワード暗号化）"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:375
+#: manual/Configuration.md:374
 msgid "\"DHX2\" UAM (successor of DHCAST128)"
 msgstr "\"DHX2\" UAM（DHCAST128 の後継版）"
 
 #. type: Plain text
-#: manual/Configuration.md:377
+#: manual/Configuration.md:376
 msgid "There exist other optional UAMs as well:"
 msgstr "他にもオプションとして以下のような UAM がある："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:381
+#: manual/Configuration.md:380
 msgid ""
 "\"Client Krb v2\" UAM (Kerberos V, suitable for \"Single Sign On\" Scenarios "
 "with macOS clients – see below)"
@@ -1021,7 +1021,7 @@ msgstr ""
 "適当である――下記参照）"
 
 #. type: Plain text
-#: manual/Configuration.md:387
+#: manual/Configuration.md:386
 msgid ""
 "You can configure which UAMs should be activated by defining \"`uam list`\" "
 "in `Global` section. `afpd` will log which UAMs it's using and if problems "
@@ -1036,7 +1036,7 @@ msgstr ""
 "するのに使うことができる。"
 
 #. type: Plain text
-#: manual/Configuration.md:392
+#: manual/Configuration.md:391
 msgid ""
 "Having a specific UAM available at the server does not automatically mean "
 "that a client can use it. Client-side support is also necessary.  For older "
@@ -1049,7 +1049,7 @@ msgstr ""
 "DHCAST128 のサポートは AppleShare クライアント 3.8.x 以降には存在している。"
 
 #. type: Plain text
-#: manual/Configuration.md:397
+#: manual/Configuration.md:396
 msgid ""
 "On macOS, there exist some client-side techniques to make the AFP-client "
 "more verbose, so one can have a look at what's happening while negotiating "
@@ -1062,13 +1062,13 @@ msgstr ""
 "article.gmane.org/gmane.network.netatalk.devel/7383/)  と比較してみるとよい。"
 
 #. type: Title ###
-#: manual/Configuration.md:398
+#: manual/Configuration.md:397
 #, no-wrap
 msgid "Which UAMs to activate?"
 msgstr "どの UAM を有効にすべきか？"
 
 #. type: Plain text
-#: manual/Configuration.md:403
+#: manual/Configuration.md:402
 msgid ""
 "It depends primarily on your needs and on the kind of macOS clients you have "
 "to support. If your network consists of exclusively macOS (Mac OS X) "
@@ -1079,7 +1079,7 @@ msgstr ""
 "DHX2 で十分であり、最も強力な暗号化を提供する。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:409
+#: manual/Configuration.md:408
 msgid ""
 "Unless you really have to supply guest access to your server's volumes "
 "ensure that you disable \"No User Authent\" since it might lead accidentally "
@@ -1093,7 +1093,7 @@ msgstr ""
 "トアクセスを有効化することを強制するように気を配るべきである。"
 
 #. type: Plain text
-#: manual/Configuration.md:412
+#: manual/Configuration.md:411
 #, no-wrap
 msgid ""
 "  Note: \"No User Authent\" is required to use Apple II NetBoot services\n"
@@ -1103,7 +1103,7 @@ msgstr ""
 "  Apple //e を起動するには、「ユーザー認証なし」が必要である。\n"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:416
+#: manual/Configuration.md:415
 msgid ""
 "The \"ClearTxt Passwrd\" UAM is as bad as it sounds since passwords go "
 "unencrypted over the wire. Try to avoid it at both the server's side as well "
@@ -1114,7 +1114,7 @@ msgstr ""
 "無効にするよう務めるべきである。"
 
 #. type: Plain text
-#: manual/Configuration.md:421
+#: manual/Configuration.md:420
 #, no-wrap
 msgid ""
 "  Note: If you want to provide Mac OS 8/9 clients with NetBoot-services\n"
@@ -1128,7 +1128,7 @@ msgstr ""
 "  クライアントがこうした基本的な形の認証しか扱わないためである。\n"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:429
+#: manual/Configuration.md:428
 msgid ""
 "Since \"Randnum exchange\"/\"2-Way Randnum exchange\" uses only 56 bit DES "
 "for encryption it should be avoided as well. Another disadvantage is the "
@@ -1145,7 +1145,7 @@ msgstr ""
 "途パスワードを管理しなければならない）という点である。"
 
 #. type: Plain text
-#: manual/Configuration.md:432
+#: manual/Configuration.md:431
 #, no-wrap
 msgid ""
 "  However, this is the strongest form of authentication that can be used\n"
@@ -1153,7 +1153,7 @@ msgid ""
 msgstr "  ただし、これは 漢字Talk 7.1 以前で使用できる最も強力な認証形式である。\n"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:435
+#: manual/Configuration.md:434
 msgid ""
 "\"DHCAST128\" (\"DHX\") or \"DHX2\" should be the sweet spot for most people "
 "since it combines stronger encryption with PAM integration."
@@ -1162,7 +1162,7 @@ msgstr ""
 "み合わせられているので、 ほとんどの人々にとって良い妥協案であろう。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:446
+#: manual/Configuration.md:445
 msgid ""
 "Using the Kerberos V (\"Client Krb v2\")  UAM, it's possible to implement "
 "real single sign on scenarios using Kerberos tickets. The password is not "
@@ -1184,7 +1184,7 @@ msgstr ""
 "知の実装の仕方のために、この認証方法は中間者攻撃に対して脆弱である。"
 
 #. type: Plain text
-#: manual/Configuration.md:451
+#: manual/Configuration.md:450
 msgid ""
 "For a more detailed overview over the technical implications of the "
 "different UAMs, please have a look at Apple's [File Server Security](http://"
@@ -1198,13 +1198,13 @@ msgstr ""
 "TP40000854-CH232-SW1)  ページを見ていただきたい。"
 
 #. type: Title ###
-#: manual/Configuration.md:452
+#: manual/Configuration.md:451
 #, no-wrap
 msgid "Using different authentication sources with specific UAMs"
 msgstr "特定の UAM で別の認証ソースを使う"
 
 #. type: Plain text
-#: manual/Configuration.md:462
+#: manual/Configuration.md:461
 msgid ""
 "Some UAMs provide the ability to use different authentication \"backends\", "
 "namely `uams_cleartext.so`, `uams_dhx.so` and `uams_dhx2.so`. They can use "
@@ -1224,7 +1224,7 @@ msgstr ""
 "は `uams_dhx2_pam.so`へのシンボリックリンクとすることができる。"
 
 #. type: Plain text
-#: manual/Configuration.md:465
+#: manual/Configuration.md:464
 msgid ""
 "So, if it looks like this in Netatalk's UAMs folder (per default `/etc/"
 "netatalk/uams/`):"
@@ -1233,7 +1233,7 @@ msgstr ""
 "が以下のようであれば："
 
 #. type: Plain text
-#: manual/Configuration.md:469
+#: manual/Configuration.md:468
 #, no-wrap
 msgid ""
 "    uams_clrtxt.so -> uams_pam.so\n"
@@ -1242,7 +1242,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:477
+#: manual/Configuration.md:476
 msgid ""
 "then you're using PAM, otherwise classic UNIX passwords. The main advantage "
 "of using PAM is that one can integrate Netatalk in centralized "
@@ -1261,18 +1261,18 @@ msgstr ""
 "に除去することを考えるべきである。"
 
 #. type: Title ###
-#: manual/Configuration.md:478
+#: manual/Configuration.md:477
 #, no-wrap
 msgid "Netatalk UAM overview table"
 msgstr "Netatalk UAM を概要表"
 
 #. type: Plain text
-#: manual/Configuration.md:481
+#: manual/Configuration.md:480
 msgid "A small overview of the most commonly used UAMs."
 msgstr "最も一般的に用いられる UAM の概観。"
 
 #. type: Plain text
-#: manual/Configuration.md:489
+#: manual/Configuration.md:488
 #, no-wrap
 msgid ""
 "| UAM | No User Authent | Cleartxt Passwrd | (2-Way) Randnum exchange | DHCAST128 | DHX2 | Client Krb v2 |\n"
@@ -1293,7 +1293,7 @@ msgstr ""
 "| パスワードの保管方法 | なし | /etc/passwd (/etc/shadow) ないしは PAM | パスワードは別のテキストファイルに平文として保存される | /etc/passwd (/etc/shadow) ないしは PAM | /etc/passwd (/etc/shadow) ないしは PAM | Kerberos キー配布センター\\* |\n"
 
 #. type: Plain text
-#: manual/Configuration.md:492
+#: manual/Configuration.md:491
 msgid ""
 "\\* Have a look at this [Kerberos overview](https://web.archive.org/web/"
 "20070705043002/http://cryptnet.net/fdp/admin/kerby-infra/en/kerby-infra.html)"
@@ -1302,13 +1302,13 @@ msgstr ""
 "cryptnet.net/fdp/admin/kerby-infra/en/kerby-infra.html)  も一読のこと"
 
 #. type: Title ###
-#: manual/Configuration.md:493
+#: manual/Configuration.md:492
 #, no-wrap
 msgid "SSH tunneling"
 msgstr "SSH トンネリング"
 
 #. type: Plain text
-#: manual/Configuration.md:499
+#: manual/Configuration.md:498
 msgid ""
 "Tunneling and VPNs usually have nothing to do with AFP authentication and "
 "UAMs. But since Apple introduced an option called \"Allow Secure Connections "
@@ -1320,13 +1320,13 @@ msgstr ""
 "下ではその点についても述べる。"
 
 #. type: Title ####
-#: manual/Configuration.md:500
+#: manual/Configuration.md:499
 #, no-wrap
 msgid "Manually tunneling an AFP session"
 msgstr "手動で AFP セッションをトンネリング"
 
 #. type: Plain text
-#: manual/Configuration.md:506
+#: manual/Configuration.md:505
 msgid ""
 "This works since the first AFP servers that spoke \"AFP over TCP\" appeared "
 "in networks. One simply tunnels the remote server's AFP port to a local port "
@@ -1339,13 +1339,13 @@ msgstr ""
 "だけである。macOS では以下のようにすればよい。"
 
 #. type: Plain text
-#: manual/Configuration.md:508
+#: manual/Configuration.md:507
 #, no-wrap
 msgid "    ssh -l $USER $SERVER -L 10548:127.0.0.1:548 sleep 3000\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:515
+#: manual/Configuration.md:514
 msgid ""
 "After establishing the tunnel one will use `\"afp://127.0.0.1:10548\"` in "
 "the \"Connect to server\" dialog. All AFP traffic including the initial "
@@ -1360,7 +1360,7 @@ msgstr ""
 "も含めて全ての AFP トラフィックがネットワークを暗号化されて送られる。"
 
 #. type: Plain text
-#: manual/Configuration.md:521
+#: manual/Configuration.md:520
 msgid ""
 "This sort of tunnel is an ideal solution if you must access an AFP server "
 "through the Internet without having the ability or desire to use a \"real\" "
@@ -1376,13 +1376,13 @@ msgstr ""
 "る。"
 
 #. type: Title ####
-#: manual/Configuration.md:522
+#: manual/Configuration.md:521
 #, no-wrap
 msgid "Automatically establishing a tunneled AFP connection"
 msgstr "自動的にトンネル AFP 接続を確立する"
 
 #. type: Plain text
-#: manual/Configuration.md:529
+#: manual/Configuration.md:528
 msgid ""
 "From Mac OS X 10.2 to 10.4, Apple added an \"Allow Secure Connections Using "
 "SSH\" checkbox to the \"Connect to Server\" dialog. The idea behind this "
@@ -1397,7 +1397,7 @@ msgstr ""
 "を通して送る。ということなのである。"
 
 #. type: Plain text
-#: manual/Configuration.md:534
+#: manual/Configuration.md:533
 msgid ""
 "But it took until the release of Mac OS X 10.3 that this feature worked the "
 "first time... partly. In case, the SSH tunnel could not be established and "
@@ -1409,7 +1409,7 @@ msgstr ""
 "暗号化していない AFP 接続試行にフォールバックした。"
 
 #. type: Plain text
-#: manual/Configuration.md:540
+#: manual/Configuration.md:539
 msgid ""
 "Netatalk's afpd will report that it is capable of handling SSH tunneled AFP "
 "requests, when both \"`advertise ssh`\" and \"`fqdn`\" options are set in "
@@ -1424,7 +1424,7 @@ msgstr ""
 "なる２、３の理由がある："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:545
+#: manual/Configuration.md:544
 msgid ""
 "Most users who need such a feature are probably already familiar with using "
 "a VPN; it might be easier for the user to employ the same VPN software in "
@@ -1436,7 +1436,7 @@ msgstr ""
 "ワークに接続し、 AFP サーバーにアクセスする方が簡単だろう。"
 
 #. type: Plain text
-#: manual/Configuration.md:551
+#: manual/Configuration.md:550
 #, no-wrap
 msgid ""
 "  That being said, for the simple case of connecting to one specific AFP\n"
@@ -1453,7 +1453,7 @@ msgstr ""
 "  TCP データをカプセル化していないためである。\n"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:557
+#: manual/Configuration.md:556
 msgid ""
 "Since this SSH kludge isn't a normal UAM that integrates directly into the "
 "AFP authentication mechanisms but instead uses a single flag signalling "
@@ -1466,7 +1466,7 @@ msgstr ""
 "がおかしい時に何が起こっているのかを見ようとする気を失ってしまう。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:561
+#: manual/Configuration.md:560
 msgid ""
 "You cannot control which machines are logged on by Netatalk tools like a "
 "`macusers` since all connection attempts seem to be made from localhost."
@@ -1476,7 +1476,7 @@ msgstr ""
 "い。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:566
+#: manual/Configuration.md:565
 msgid ""
 "Indeed, to ensure that all AFP sessions are encrypted via SSH, you need to "
 "limit afpd to connections that originate only from localhost (e.g., by using "
@@ -1489,7 +1489,7 @@ msgstr ""
 "トフィルタリング機能を使用するなど。"
 
 #. type: Plain text
-#: manual/Configuration.md:572
+#: manual/Configuration.md:571
 #, no-wrap
 msgid ""
 "  Otherwise, when you're using Mac OS X 10.2 through 10.3.3, you get the\n"
@@ -1505,7 +1505,7 @@ msgstr ""
 "  Mac OS X 10.3.4 になってそれをはじめて修正した。\n"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:578
+#: manual/Configuration.md:577
 msgid ""
 "Encrypting all AFP sessions via SSH can lead to a significantly higher load "
 "on the computer that is running the AFP server, because that computer must "
@@ -1517,13 +1517,13 @@ msgstr ""
 "ている場合、そのような暗号化は無駄かもしれない。"
 
 #. type: Title ##
-#: manual/Configuration.md:579
+#: manual/Configuration.md:578
 #, no-wrap
 msgid "ACL Support"
 msgstr "ACL のサーポート"
 
 #. type: Plain text
-#: manual/Configuration.md:583
+#: manual/Configuration.md:582
 msgid ""
 "ACL support for AFP is implemented for ZFS ACLs on Solaris and derived "
 "platforms and for POSIX 1e ACLs on Linux."
@@ -1532,7 +1532,7 @@ msgstr ""
 "Linux の POSIX 1e ACL で実装されている。"
 
 #. type: Plain text
-#: manual/Configuration.md:595
+#: manual/Configuration.md:594
 msgid ""
 "For a basic mode of operation there's nothing to configure. Netatalk reads "
 "ACLs on the fly and calculates effective permissions which are then send to "
@@ -1553,19 +1553,19 @@ msgstr ""
 "できないであろう。"
 
 #. type: Plain text
-#: manual/Configuration.md:601
+#: manual/Configuration.md:600
 msgid ""
 "By default, the effective permission of the authenticated user are only "
 "mapped to the mentioned UARightspermission structure, not the UNIX mode. You "
 "can adjust this behaviour with the configuration option [map acls]"
-"(#map_acls)."
+"(afp.conf#options-for-acl-handling)."
 msgstr ""
 "デフォルトでは、認証ユーザーに有効なパーミションは UNIX のモードではなく、前"
 "記 UARights の機構のみに対応付けられる。この挙動は設定オプション [map acls]"
-"(#map_acls) で修正することができる。"
+"(afp.conf#options-for-acl-handling) で修正することができる。"
 
 #. type: Plain text
-#: manual/Configuration.md:611
+#: manual/Configuration.md:610
 msgid ""
 "However, neither in Finder \"Get Info\" windows nor in the Terminal will you "
 "be able to see the ACLs, because of how ACLs in macOS are designed.  If you "
@@ -1588,7 +1588,7 @@ msgstr ""
 "付けた UNIX uid と gid も含めたサーバー側の ACL を返すことができる。"
 
 #. type: Plain text
-#: manual/Configuration.md:616
+#: manual/Configuration.md:615
 msgid ""
 "Netatalk can query a directory server using LDAP queries. Either the "
 "directory server already provides an UUID attribute for user and groups "
@@ -1602,17 +1602,17 @@ msgstr ""
 "れかである。"
 
 #. type: Plain text
-#: manual/Configuration.md:618
+#: manual/Configuration.md:617
 msgid "In detail:"
 msgstr "より踏み込むと："
 
 #. type: Bullet: '1.  '
-#: manual/Configuration.md:620
+#: manual/Configuration.md:619
 msgid "For Solaris/ZFS: ZFS Volumes"
 msgstr "ZFS を使っている Solarisの ZFS ボリュームごとに対して、"
 
 #. type: Plain text
-#: manual/Configuration.md:623
+#: manual/Configuration.md:622
 #, no-wrap
 msgid ""
 "    You should configure a ZFS ACL know for any volume you want to use\n"
@@ -1622,7 +1622,7 @@ msgstr ""
 "    がわかるように構成すべきである：\n"
 
 #. type: Plain text
-#: manual/Configuration.md:626
+#: manual/Configuration.md:625
 #, no-wrap
 msgid ""
 "        aclinherit = passthrough\n"
@@ -1630,7 +1630,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:629
+#: manual/Configuration.md:628
 #, no-wrap
 msgid ""
 "    For an explanation of what this knob does and how to apply it, check\n"
@@ -1640,12 +1640,12 @@ msgstr ""
 "    ZFS ドキュメンテーション（例えば man zfs）を確認のこと。\n"
 
 #. type: Bullet: '2.  '
-#: manual/Configuration.md:631
+#: manual/Configuration.md:630
 msgid "Authentication Domain"
 msgstr "認証ドメイン"
 
 #. type: Plain text
-#: manual/Configuration.md:638
+#: manual/Configuration.md:637
 #, no-wrap
 msgid ""
 "    Your server and the clients must be part of a security association\n"
@@ -1663,7 +1663,7 @@ msgstr ""
 "    UUID は ASCII テキストとして保管されている。言い換えれば：\n"
 
 #. type: Bullet: '    - '
-#: manual/Configuration.md:641
+#: manual/Configuration.md:640
 msgid ""
 "you need an Open Directory Server or an LDAP server where you store UUIDs in "
 "some attribute"
@@ -1672,37 +1672,37 @@ msgstr ""
 "サーバーが必要である。"
 
 #. type: Bullet: '    - '
-#: manual/Configuration.md:643
+#: manual/Configuration.md:642
 msgid "your clients must be configured to use this server"
 msgstr ""
 "クライアントはこのサーバーを使用するように構成されていなければならない。"
 
 #. type: Bullet: '    - '
-#: manual/Configuration.md:646
+#: manual/Configuration.md:645
 msgid ""
 "your server should be configured to use this server via nsswitch and PAM"
 msgstr ""
 "サーバーは nsswitch と PAM 経由で使用されるよう構成しなければならない。"
 
 #. type: Bullet: '    - '
-#: manual/Configuration.md:651
+#: manual/Configuration.md:650
 msgid ""
-"configure Netatalk via the special [LDAP options for ACLs](#acl_options) in "
-"[afp.conf](#afp.conf.5) so that Netatalk is able to retrieve the UUID for "
-"users and groups via LDAP search queries"
+"configure Netatalk via the special [LDAP options for ACLs](afp.conf#options-"
+"for-acl-handling) in `afp.conf` so that Netatalk is able to retrieve the "
+"UUID for users and groups via LDAP search queries"
 msgstr ""
 "Netatalk が LDAP 検索クエリでユーザーとグループの UUID を引き出せるように、"
-"[afp.conf](#afp.conf.5) 内で [ACL 専用のオプションを](#acl_options)使って "
-"Netatalk を設定しなければならない。"
+"`afp.conf` 内で [ACL 専用のオプション](afp.conf#options-for-acl-handling)を"
+"使って Netatalk を設定しなければならない。"
 
 #. type: Title ###
-#: manual/Configuration.md:652
+#: manual/Configuration.md:651
 #, no-wrap
 msgid "macOS ACLs"
 msgstr "macOS の ACL"
 
 #. type: Plain text
-#: manual/Configuration.md:658
+#: manual/Configuration.md:657
 msgid ""
 "With Access Control Lists (ACLs), macOS offers a powerful extension of the "
 "traditional UNIX permissions model. An ACL is an ordered list of Access "
@@ -1715,7 +1715,7 @@ msgstr ""
 "リストである。"
 
 #. type: Plain text
-#: manual/Configuration.md:663
+#: manual/Configuration.md:662
 msgid ""
 "Unlike UNIX permissions, which are bound to user or group IDs, ACLs are tied "
 "to UUIDs. For this reason accessing an object's ACL requires server and "
@@ -1728,7 +1728,7 @@ msgstr ""
 "てくれる、共通のディレクトリサービスを使うことを要求される。"
 
 #. type: Plain text
-#: manual/Configuration.md:675
+#: manual/Configuration.md:674
 msgid ""
 "ACLs and UNIX permissions interact in a rather simple way. As ACLs are "
 "optional UNIX permissions act as a default mechanism for access control.  "
@@ -1753,13 +1753,13 @@ msgstr ""
 "つまり、ACL は常に UNIX のパーミションより優先順位が上位ということである。"
 
 #. type: Title ###
-#: manual/Configuration.md:676
+#: manual/Configuration.md:675
 #, no-wrap
 msgid "ZFS ACLs"
 msgstr "ZFS の ACL"
 
 #. type: Plain text
-#: manual/Configuration.md:680
+#: manual/Configuration.md:679
 msgid ""
 "ZFS ACLs closely match macOS ACLs. Both offer mostly identical fine grained "
 "permissions and inheritance settings."
@@ -1768,19 +1768,19 @@ msgstr ""
 "粒度のパーミションと設定の継承が提供されている。"
 
 #. type: Title ###
-#: manual/Configuration.md:681
+#: manual/Configuration.md:680
 #, no-wrap
 msgid "POSIX ACLs"
 msgstr "POSIX の ACL"
 
 #. type: Title ####
-#: manual/Configuration.md:683
+#: manual/Configuration.md:682
 #, no-wrap
 msgid "Overview"
 msgstr "概要"
 
 #. type: Plain text
-#: manual/Configuration.md:689
+#: manual/Configuration.md:688
 msgid ""
 "Compared to macOS or NFSv4 ACLs, POSIX ACLs represent a different, less "
 "versatile approach to overcome the limitations of the traditional UNIX "
@@ -1792,7 +1792,7 @@ msgstr ""
 "Posix 標準を取り込んだものを基礎としている。"
 
 #. type: Plain text
-#: manual/Configuration.md:697
+#: manual/Configuration.md:696
 msgid ""
 "The standard defines two types of ACLs. Files and directories can have "
 "access ACLs which are consulted for access checks. Directories can also have "
@@ -1810,14 +1810,14 @@ msgstr ""
 "を継承する。 継承制御にそれ以上のメカニズムは何もない。"
 
 #. type: Plain text
-#: manual/Configuration.md:700
+#: manual/Configuration.md:699
 msgid ""
 "Architectural differences between POSIX ACLs and macOS ACLs especially "
 "involve:"
 msgstr "設計上、Posix ACL と macOS 間の違いに含まれている特筆すべき点は："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:703
+#: manual/Configuration.md:702
 msgid ""
 "No fine-granular permissions model. Like UNIX permissions POSIX ACLs only "
 "differentiate between read, write and execute permissions."
@@ -1826,12 +1826,12 @@ msgstr ""
 "ACL は読み込み、書き込み、そして実行権限を区別している。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:705
+#: manual/Configuration.md:704
 msgid "Entries within an ACL are unordered."
 msgstr "ACL 内のエントリーに順序はない。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:708
+#: manual/Configuration.md:707
 msgid ""
 "POSIX ACLs can only grant rights. There is no way to explicitly deny rights "
 "by an entry."
@@ -1840,12 +1840,12 @@ msgstr ""
 "する手立てはない。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:710
+#: manual/Configuration.md:709
 msgid "UNIX permissions are integrated into an ACL as special entries."
 msgstr "UNIX パーミションは特別なエントリーとして ACL に統合されている。"
 
 #. type: Plain text
-#: manual/Configuration.md:715
+#: manual/Configuration.md:714
 msgid ""
 "POSIX 1003.1e defines 6 different types of ACL entries. The first three "
 "types are used to integrate standard UNIX permissions. They form a minimal "
@@ -1858,37 +1858,37 @@ msgstr ""
 "つのエントリーだけが ACL 内に許される。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:717
+#: manual/Configuration.md:716
 msgid "ACL_USER_OBJ: the owner's access rights."
 msgstr "ACL_USER_OBJ：所有ユーザー（オーナー）のアクセス権限。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:719
+#: manual/Configuration.md:718
 msgid "ACL_GROUP_OBJ: the owning group's access rights."
 msgstr "ACL_GROUP_OBJ：所有グループ（オーナーグループ）のアクセス権限。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:721
+#: manual/Configuration.md:720
 msgid "ACL_OTHER: everybody's access rights."
 msgstr "ACL_OTHER：あらゆるユーザー・グループに対するアクセス権限。"
 
 #. type: Plain text
-#: manual/Configuration.md:723
+#: manual/Configuration.md:722
 msgid "The remaining entry types expand the traditional permissions model:"
 msgstr "残りのエントリーのタイプは伝統的パーミションモデルの拡張である："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:725
+#: manual/Configuration.md:724
 msgid "ACL_USER: grants access rights to a certain user."
 msgstr "ACL_USER：あるユーザーに対するアクセス権を許可する。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:727
+#: manual/Configuration.md:726
 msgid "ACL_GROUP: grants access rights to a certain group."
 msgstr "ACL_GROUP：あるグループに対するアクセス権を許可する。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:733
+#: manual/Configuration.md:732
 msgid ""
 "ACL_MASK: limits the maximum access rights which can be granted by entries "
 "of type ACL_GROUP_OBJ, ACL_USER and ACL_GROUP. As the name suggests, this "
@@ -1904,7 +1904,7 @@ msgstr ""
 "ンである。"
 
 #. type: Plain text
-#: manual/Configuration.md:739
+#: manual/Configuration.md:738
 msgid ""
 "In order to maintain compatibility with applications not aware of ACLs, "
 "POSIX 1003.1e changes the semantics of system calls and utilities which "
@@ -1919,7 +1919,7 @@ msgstr ""
 "エントリーの値に対応する。"
 
 #. type: Plain text
-#: manual/Configuration.md:746
+#: manual/Configuration.md:745
 msgid ""
 "However, if the ACL also contains an ACL_MASK entry, the behavior of those "
 "system calls and utilities is different. The group permissions bits of the "
@@ -1936,13 +1936,13 @@ msgstr ""
 "のエンティティ全てを無効にするのである。"
 
 #. type: Title ####
-#: manual/Configuration.md:747
+#: manual/Configuration.md:746
 #, no-wrap
 msgid "Mapping POSIX ACLs to macOS ACLs"
 msgstr "POSIX ACL から macOS の ACL へのマッピング"
 
 #. type: Plain text
-#: manual/Configuration.md:755
+#: manual/Configuration.md:754
 msgid ""
 "When a client wants to read an object's ACL, afpd maps its POSIX ACL onto an "
 "equivalent macOS ACL. Writing an object's ACL requires afpd to map an macOS "
@@ -1957,7 +1957,7 @@ msgstr ""
 "ね同じになるような正確なマッピングを見出すことは通常不可能である。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:758
+#: manual/Configuration.md:757
 msgid ""
 "afpd silently discard entries which deny a set of permissions because they "
 "they can't be represented within the POSIX architecture."
@@ -1966,7 +1966,7 @@ msgstr ""
 "Posix の設計では表現する手立てがないためである。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:761
+#: manual/Configuration.md:760
 msgid ""
 "As entries within POSIX ACLs are unordered, it is impossible to preserve "
 "order."
@@ -1975,12 +1975,12 @@ msgstr ""
 "る。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:763
+#: manual/Configuration.md:762
 msgid "Inheritance control is subject to severe limitations as well:"
 msgstr "継承制御もまた厳しい制限を受けやすい："
 
 #. type: Bullet: '  - '
-#: manual/Configuration.md:766
+#: manual/Configuration.md:765
 msgid ""
 "Entries with the only_inherit flag set will only become part of the "
 "directory's default ACL."
@@ -1989,7 +1989,7 @@ msgstr ""
 "部にしかならない。"
 
 #. type: Bullet: '  - '
-#: manual/Configuration.md:771
+#: manual/Configuration.md:770
 msgid ""
 "Entries with at least one of the flags file_inherit, directory_inherit or "
 "limit_inherit set, will become part of the directory's access and default "
@@ -2000,7 +2000,7 @@ msgstr ""
 "しかし継承に課せられた制約は無視される。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:774
+#: manual/Configuration.md:773
 msgid ""
 "The lack of a fine-granular permission model on the POSIX side will normally "
 "result in an increase of granted permissions."
@@ -2009,7 +2009,7 @@ msgstr ""
 "許可されるパーミションが増えるという結果になる。"
 
 #. type: Plain text
-#: manual/Configuration.md:788
+#: manual/Configuration.md:787
 msgid ""
 "As macOS clients aren't aware of the POSIX 1003.1e specific relationship "
 "between UNIX permissions and ACL_MASK, afpd does not expose this feature to "
@@ -2038,13 +2038,13 @@ msgstr ""
 "ACL_MASK の値の再計算を afpd が行う。"
 
 #. type: Title ##
-#: manual/Configuration.md:789
+#: manual/Configuration.md:788
 #, no-wrap
 msgid "Filesystem Change Events"
 msgstr "ファイルシステム変更イベント"
 
 #. type: Plain text
-#: manual/Configuration.md:794
+#: manual/Configuration.md:793
 msgid ""
 "Netatalk includes a nifty filesystem change event (FCE) mechanism where afpd "
 "processes notify interested listeners about certain filesystem event by UDP "
@@ -2056,7 +2056,7 @@ msgstr ""
 "経由で通知する。"
 
 #. type: Plain text
-#: manual/Configuration.md:798
+#: manual/Configuration.md:797
 msgid ""
 "For the format of the UDP packets and for an example C application that "
 "demonstrates how to use these in a listener, take a look at the Netatalk "
@@ -2067,62 +2067,62 @@ msgstr ""
 "ソースファイル `bin/misc/fce.c` に目を通していただきたい。"
 
 #. type: Plain text
-#: manual/Configuration.md:800
+#: manual/Configuration.md:799
 msgid "The currently supported FCE v1 events are:"
 msgstr "現在サポートされているファイルシステム変更イベントは以下である："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:802
+#: manual/Configuration.md:801
 msgid "file modification (fmod)"
 msgstr "ファイル変更：file modification (fmod)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:804
+#: manual/Configuration.md:803
 msgid "file deletion (fdel)"
 msgstr "ファイル削除：file deletion (fdel)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:806
+#: manual/Configuration.md:805
 msgid "directory deletion (ddel)"
 msgstr "ディレクトリ削除：directory deletion (ddel)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:808
+#: manual/Configuration.md:807
 msgid "file creation (fcre)"
 msgstr "ファイル作成：file creation (fcre)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:810
+#: manual/Configuration.md:809
 msgid "directory creation (dcre)"
 msgstr "ディレクトリ削除：directory deletion (ddel)"
 
 #. type: Plain text
-#: manual/Configuration.md:812
+#: manual/Configuration.md:811
 msgid "When using FCE v2 you also get:"
 msgstr "FCE v2 の場合はする際には下記イベントも使用可能："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:814
+#: manual/Configuration.md:813
 msgid "file moving (fmov)"
 msgstr "ファイル移動 (fmov)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:816
+#: manual/Configuration.md:815
 msgid "directory moving (dmov)"
 msgstr "ディレクトリー移動 (dmov)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:818
+#: manual/Configuration.md:817
 msgid "user login (login)"
 msgstr "ユーザーログイン (login)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:820
+#: manual/Configuration.md:819
 msgid "user logout (logout)"
 msgstr "ユーザーログアウト (logout)"
 
 #. type: Plain text
-#: manual/Configuration.md:823
+#: manual/Configuration.md:822
 msgid ""
 "For details on the available simple configuration options, take a look at "
 "`afp.conf`."
@@ -2131,13 +2131,13 @@ msgstr ""
 "だきたい。"
 
 #. type: Title ##
-#: manual/Configuration.md:824
+#: manual/Configuration.md:823
 #, no-wrap
 msgid "Spotlight"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:831
+#: manual/Configuration.md:830
 msgid ""
 "Starting with version 3.1 Netatalk supports Spotlight searching.  Netatalk "
 "uses GNOME [Tracker](https://projects.gnome.org/tracker/) or its later "
@@ -2151,7 +2151,7 @@ msgstr ""
 "を用いる。"
 
 #. type: Plain text
-#: manual/Configuration.md:836
+#: manual/Configuration.md:835
 msgid ""
 "You can enable Spotlight and indexing either globally or on a per volume "
 "basis with the `spotlight` option."
@@ -2160,7 +2160,7 @@ msgstr ""
 "Spotlight とインデックス化を有効にできる。"
 
 #. type: Plain text
-#: manual/Configuration.md:841
+#: manual/Configuration.md:840
 #, no-wrap
 msgid ""
 "> Once Spotlight is enabled for a single volume, all other volumes for\n"
@@ -2170,7 +2170,7 @@ msgstr ""
 "が無効にされたことになるその他全てのボリュームでは全く検索できないようになる。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:845
+#: manual/Configuration.md:844
 msgid ""
 "The `dbus-daemon` binary has to be installed for Spotlight feature. The path "
 "to dbus-daemon is determined at compile time the dbus-daemon build system "
@@ -2181,7 +2181,7 @@ msgstr ""
 "定する。"
 
 #. type: Plain text
-#: manual/Configuration.md:849
+#: manual/Configuration.md:848
 msgid ""
 "In case the `dbus-daemon` binary is installed at the other path, you must "
 "use the global option `dbus daemon` to point to the path, e.g. for Solaris "
@@ -2192,24 +2192,24 @@ msgstr ""
 "Solaris 上で OpenCSW 由来の Tracker を用いている場合は以下のようにする："
 
 #. type: Plain text
-#: manual/Configuration.md:851
+#: manual/Configuration.md:850
 #, no-wrap
 msgid "    dbus daemon = /opt/csw/bin/dbus-daemon\n"
 msgstr ""
 
 #. type: Title ####
-#: manual/Configuration.md:852
+#: manual/Configuration.md:851
 #, no-wrap
 msgid "Limitations and notes"
 msgstr "制限と注意"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:855
+#: manual/Configuration.md:854
 msgid "Large filesystems"
 msgstr "大きいファイルシステム"
 
 #. type: Plain text
-#: manual/Configuration.md:861
+#: manual/Configuration.md:860
 #, no-wrap
 msgid ""
 "  Tracker on Linux uses the inotify Kernel filesystem change event API\n"
@@ -2225,7 +2225,7 @@ msgstr ""
 "  代わりにあらゆるサブディレクトリの監視が各々で追加されなければならないということを要求してくるからである。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:865
+#: manual/Configuration.md:864
 #, no-wrap
 msgid ""
 "  On Solaris the FEN file event notification system is used. It is\n"
@@ -2237,26 +2237,26 @@ msgstr ""
 "  のサブシステムではどんな制限とリソース消費があるのか不明である。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:870
+#: manual/Configuration.md:869
 #, no-wrap
 msgid ""
 "  We therefore recommend to disable live filesystem monitoring and let\n"
 "  Tracker periodically scan filesystems for changes instead, see the\n"
-"  Tracker configuration options [enable-monitors](#enable-monitors) and\n"
-"  [crawling-interval](#crawling-interval) below.\n"
+"  [Tracker configuration options](#advanced-tracker-command-line-configuration)\n"
+"  enable-monitors and crawling-interval below.\n"
 msgstr ""
 "  それ故、ライブでのファイルシステム監視は無効にして、その代わりに定期的に\n"
 "  Tracker にファイルシステム変更のスキャンを行わせることを推奨する。下記\n"
-"  Tracker オプション、[enable-monitors](#enable-monitors) および\n"
-"  [crawling-interval](#crawling-interval) を参照のこと。\n"
+"  [Tracker オプション](#advanced-tracker-command-line-configuration)、enable-monitors および\n"
+"  crawling-interval を参照のこと。\n"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:872
+#: manual/Configuration.md:871
 msgid "Indexing home directories"
 msgstr "home ディレクトリのインデックスは作成されない"
 
 #. type: Plain text
-#: manual/Configuration.md:875
+#: manual/Configuration.md:874
 #, no-wrap
 msgid ""
 "  A known limitation with the current implementation means that shared\n"
@@ -2267,7 +2267,7 @@ msgstr ""
 "  によってインデックス付けされない。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:878
+#: manual/Configuration.md:877
 #, no-wrap
 msgid ""
 "  As a workaround, keep the shared volumes you want to have indexed\n"
@@ -2275,13 +2275,13 @@ msgid ""
 msgstr "  回避策として、ファイルシステム別場所に共有ボリュームを設定する。\n"
 
 #. type: Title ###
-#: manual/Configuration.md:879
+#: manual/Configuration.md:878
 #, no-wrap
 msgid "Using Tracker commandline tools on the server"
 msgstr "サーバー上での Tracker コマンドラインツールの使用"
 
 #. type: Plain text
-#: manual/Configuration.md:883
+#: manual/Configuration.md:882
 msgid ""
 "Netatalk must be running, commands must be executed as root and some "
 "environment variables must be set up."
@@ -2290,7 +2290,7 @@ msgstr ""
 "らない。"
 
 #. type: Plain text
-#: manual/Configuration.md:889
+#: manual/Configuration.md:888
 msgid ""
 "If the .tracker_profile file does not exist, create it first. If you need to "
 "make the environment variables persistent, source .tracker_profile from /"
@@ -2303,7 +2303,7 @@ msgstr ""
 "Netatalk をインストールしたベースディレクトリにあわせて読み替える。"
 
 #. type: Plain text
-#: manual/Configuration.md:898
+#: manual/Configuration.md:897
 #, no-wrap
 msgid ""
 "    $ su\n"
@@ -2317,96 +2317,96 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:900
+#: manual/Configuration.md:899
 msgid "When using Tracker from OpenCSW you must also update your PATH:"
 msgstr "OpenCSW の Tracker を使用していたら PATH も以下のように更新する："
 
 #. type: Plain text
-#: manual/Configuration.md:902
+#: manual/Configuration.md:901
 #, no-wrap
 msgid "    # export PATH=/opt/csw/bin:$PATH\n"
 msgstr ""
 
 #. type: Title ####
-#: manual/Configuration.md:903
+#: manual/Configuration.md:902
 #, no-wrap
 msgid "Common Tracker commands"
 msgstr "Tracker コマンド"
 
 #. type: Plain text
-#: manual/Configuration.md:906
+#: manual/Configuration.md:905
 msgid "Querying Tracker status:"
 msgstr "Tracker の状態の問い合わせ:"
 
 #. type: Plain text
-#: manual/Configuration.md:908
+#: manual/Configuration.md:907
 #, no-wrap
 msgid ">     # tracker daemon\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:910
+#: manual/Configuration.md:909
 msgid "Stop Tracker:"
 msgstr "Tracker の停止:"
 
 #. type: Plain text
-#: manual/Configuration.md:912
+#: manual/Configuration.md:911
 #, no-wrap
 msgid ">     # tracker daemon -t\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:914
+#: manual/Configuration.md:913
 msgid "Start Tracker:"
 msgstr "Tracker の開始:"
 
 #. type: Plain text
-#: manual/Configuration.md:916
+#: manual/Configuration.md:915
 #, no-wrap
 msgid ">     # tracker daemon -s\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:918
+#: manual/Configuration.md:917
 msgid "Reindex directory:"
 msgstr "ディレクトリの再インデックス:"
 
 #. type: Plain text
-#: manual/Configuration.md:920
+#: manual/Configuration.md:919
 #, no-wrap
 msgid ">     # tracker index -f PATH\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:922
+#: manual/Configuration.md:921
 msgid "Query Tracker for information about a file or directory:"
 msgstr "Tracker にファイルやディレクトリの情報を問い合わせる:"
 
 #. type: Plain text
-#: manual/Configuration.md:924
+#: manual/Configuration.md:923
 #, no-wrap
 msgid ">     # tracker info PATH\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:926
+#: manual/Configuration.md:925
 msgid "Search Tracker:"
 msgstr "Tracker で検索:"
 
 #. type: Plain text
-#: manual/Configuration.md:928
+#: manual/Configuration.md:927
 #, no-wrap
 msgid ">     # tracker search QUERY\n"
 msgstr ""
 
 #. type: Title ####
-#: manual/Configuration.md:929
+#: manual/Configuration.md:928
 #, no-wrap
 msgid "Advanced Tracker command line configuration"
 msgstr "Tracker コマンドラインのより進んだ設定"
 
 #. type: Plain text
-#: manual/Configuration.md:933
+#: manual/Configuration.md:932
 msgid ""
 "Tracker stores its configuration via Gnome dconf backend which can be "
 "modified with the command `gsettings`."
@@ -2415,7 +2415,7 @@ msgstr ""
 "コマンドで変更できる。"
 
 #. type: Plain text
-#: manual/Configuration.md:939
+#: manual/Configuration.md:938
 msgid ""
 "Gnome dconf settings are per-user settings, so, as Netatalk runs the Tracker "
 "processes as root, the settings are stored in the root user context and "
@@ -2429,7 +2429,7 @@ msgstr ""
 "ければならない）"
 
 #. type: Plain text
-#: manual/Configuration.md:943
+#: manual/Configuration.md:942
 #, no-wrap
 msgid ""
 "    # gsettings list-recursively | grep Tracker\n"
@@ -2438,7 +2438,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:946
+#: manual/Configuration.md:945
 msgid ""
 "The following list describes some important Tracker options and their "
 "default settings."
@@ -2447,12 +2447,12 @@ msgstr ""
 "示す。"
 
 #. type: Plain text
-#: manual/Configuration.md:948
+#: manual/Configuration.md:947
 msgid "org.freedesktop.Tracker.Miner.Files index-recursive-directories"
 msgstr "org.freedesktop.Tracker.Miner.Files index-recursive-directories"
 
 #. type: Plain text
-#: manual/Configuration.md:952
+#: manual/Configuration.md:951
 #, no-wrap
 msgid ""
 "> This option controls which directories Tracker will index. Don't change\n"
@@ -2466,12 +2466,12 @@ msgstr ""
 "によってセットされるので、手動で変更してはならない。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:954
+#: manual/Configuration.md:953
 msgid "org.freedesktop.Tracker.Miner.Files enable-monitors `true`"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:961
+#: manual/Configuration.md:960
 #, no-wrap
 msgid ""
 "> The value controls whether Tracker watches all configured paths for\n"
@@ -2489,12 +2489,12 @@ msgstr ""
 "`crawling-interval` も参照のこと。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:963
+#: manual/Configuration.md:962
 msgid "org.freedesktop.Tracker.Miner.Files crawling-interval `-1`"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:968
+#: manual/Configuration.md:967
 #, no-wrap
 msgid ""
 "> Interval in days to check the filesystem is up to date in the database,\n"
@@ -2508,18 +2508,18 @@ msgstr ""
 "= 強制的にクローリングされる\n"
 
 #. type: Title ###
-#: manual/Configuration.md:969
+#: manual/Configuration.md:968
 #, no-wrap
 msgid "Supported metadata attributes"
 msgstr "サポートされているメタデータ属性"
 
 #. type: Plain text
-#: manual/Configuration.md:972
+#: manual/Configuration.md:971
 msgid "The following table lists the supported Spotlight metadata attributes"
 msgstr "下記表にサポートされている Spotlight メタデータ属性を挙げる。"
 
 #. type: Plain text
-#: manual/Configuration.md:997
+#: manual/Configuration.md:996
 #, no-wrap
 msgid ""
 "| Description | Spotlight Key |\n"
@@ -2573,18 +2573,18 @@ msgstr ""
 "| 歌あるいは楽曲の音楽ジャンル | kMDItemMusicalGenre |\n"
 
 #. type: Title ####
-#: manual/Configuration.md:998
+#: manual/Configuration.md:997
 #, no-wrap
 msgid "References"
 msgstr "参考"
 
 #. type: Bullet: '1.  '
-#: manual/Configuration.md:1001
+#: manual/Configuration.md:1000
 msgid ""
 "[MDItem](https://developer.apple.com/documentation/coreservices/mditemref/)"
 msgstr ""
 
 #. type: Bullet: '2.  '
-#: manual/Configuration.md:1002
+#: manual/Configuration.md:1001
 msgid "[Tracker](https://gnome.pages.gitlab.gnome.org/tracker/docs/developer/)"
 msgstr ""

--- a/doc/po/Installation.md.ja.po
+++ b/doc/po/Installation.md.ja.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-25 23:40+0100\n"
+"POT-Creation-Date: 2025-01-26 23:23+0100\n"
 "PO-Revision-Date: 2025-01-25 15:05+0100\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -19,7 +19,7 @@ msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:1053 manpages/man5/afp.conf.5.md:1088
-#: manual/AppleTalk.md:154 manual/Configuration.md:838 manual/Installation.md:4
+#: manual/AppleTalk.md:154 manual/Configuration.md:837 manual/Installation.md:4
 #: manual/Upgrading.md:42
 #, no-wrap
 msgid "> **WARNING**\n"
@@ -36,10 +36,10 @@ msgstr "インストール"
 #, no-wrap
 msgid ""
 "> Before upgrading to Netatalk 4 from an earlier version, please read the\n"
-"[[Upgrade]] chapter in this manual.\n"
+"[Upgrade](Upgrading.html) chapter in this manual.\n"
 msgstr ""
 "> Netatalk 2 または 3 から Netatalk 4\n"
-"にアップグレードする前に、このマニュアルの [[アップグレード]]\n"
+"にアップグレードする前に、このマニュアルの[アップグレード](Upgrading.html)\n"
 "の章を必ずお読みください。\n"
 
 #. type: Title ##
@@ -619,34 +619,32 @@ msgid "Configure and build Netatalk"
 msgstr "Netatalk のコンパイル"
 
 #. type: Plain text
-#: manual/Installation.md:222
+#: manual/Installation.md:221
 msgid ""
 "Instructions on how to use the build system to configure and build netatalk "
-"source code are documented in the [INSTALL.md](https://github.com/Netatalk/"
-"netatalk/blob/main/INSTALL.md)  file in the Netatalk source tree."
+"source code are documented in the [Install Quick Start](/install.html) guide."
 msgstr ""
-"ビルドシステムの使い方、コードのコンフィグ又はビルドの手順書は [INSTALL]"
-"(https://github.com/Netatalk/netatalk/blob/main/INSTALL)  ファイルを参考して"
-"ください。"
+"ビルドシステムの使い方、コードのコンフィグ又はビルドの手順書は [Install "
+"Quick Start](/install.html) というのがあるので、ご参考まで。"
 
 #. type: Plain text
-#: manual/Installation.md:226
+#: manual/Installation.md:225
 msgid ""
 "For examples of concrete steps to compile on specific operating systems, "
-"refer to the [Compile Netatalk from Source](#compile) appendix in this "
-"manual, which is automatically generated from the CI build scripts."
+"refer to the [Compile Netatalk from Source](Compilation.html) appendix in "
+"this manual, which is automatically generated from the CI build scripts."
 msgstr ""
-"特定の OS に対しての具体的なビルド事例は [ Netatalk をソースコードからコンパ"
-"イルする](#compile) 付録を参考してください。"
+"特定の OS に対しての具体的なビルド事例は [Netatalk をソースコードからコンパイ"
+"ルする](Compilation.html) 付録を参考してください。"
 
 #. type: Title ##
-#: manual/Installation.md:227
+#: manual/Installation.md:226
 #, no-wrap
 msgid "Starting and stopping Netatalk"
 msgstr "Netatalk の起動と停止"
 
 #. type: Plain text
-#: manual/Installation.md:235
+#: manual/Installation.md:234
 msgid ""
 "The Netatalk distribution comes with several operating system specific "
 "startup script templates that are tailored according to the options given to "
@@ -661,7 +659,7 @@ msgstr ""
 "トフォーム固有のスクリプトに加えて、systemd、openrc 用に提供されている。"
 
 #. type: Plain text
-#: manual/Installation.md:242
+#: manual/Installation.md:241
 msgid ""
 "When building from source, the Netatalk build system will attempt to detect "
 "which init style is appropriate for your platform. You can also configure "
@@ -676,7 +674,7 @@ msgstr ""
 "テキストを参照してください。"
 
 #. type: Plain text
-#: manual/Installation.md:247
+#: manual/Installation.md:246
 msgid ""
 "Since new Linux, \\*BSD, and Solaris-like distributions appear at regular "
 "intervals, and the startup procedure for the other systems mentioned above "
@@ -689,7 +687,7 @@ msgstr ""
 "ることをお勧めする。"
 
 #. type: Plain text
-#: manual/Installation.md:252
+#: manual/Installation.md:251
 msgid ""
 "If you use Netatalk as part of a fixed setup, like a Linux distribution, an "
 "RPM or a BSD package, things will probably have been arranged properly for "
@@ -702,7 +700,7 @@ msgstr ""
 "まる。"
 
 #. type: Plain text
-#: manual/Installation.md:255
+#: manual/Installation.md:254
 msgid ""
 "The following daemon need to be started by whatever startup script mechanism "
 "is used:"
@@ -711,12 +709,12 @@ msgstr ""
 "必要がある:"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:257
+#: manual/Installation.md:256
 msgid "netatalk"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:260
+#: manual/Installation.md:259
 msgid ""
 "In the absence of a startup script, you can also launch this daemon directly "
 "(as root), and kill it with SIGTERM when you are done with it."
@@ -725,7 +723,7 @@ msgstr ""
 "し、使い終わったら SIGTERM で終了することもできる。"
 
 #. type: Plain text
-#: manual/Installation.md:264
+#: manual/Installation.md:263
 msgid ""
 "Additionally, make sure that the configuration file `afp.conf` is in the "
 "right place. You can inquire netatalk where it is expecting the file to be "
@@ -736,12 +734,12 @@ msgstr ""
 "どうかを問い合わせることができる。"
 
 #. type: Plain text
-#: manual/Installation.md:268
+#: manual/Installation.md:267
 msgid ""
 "If you want to run AppleTalk services, you also need to start the `atalkd` "
 "daemon, plus the optional `papd`, `timelord`, and `a2boot` daemons. See the "
-"[AppleTalk](#appletalk) chapter in this manual for more information."
+"[AppleTalk](AppleTalk.html) chapter in this manual for more information."
 msgstr ""
 "AppleTalk サービスを実行する場合は、`atalkd` デーモンに加えて、オプションの "
 "`papd`、`timelord`、`a2boot` デーモンも起動する必要がある。詳細については、こ"
-"のマニュアルの [AppleTalk](#appletalk) の章を参照してください。"
+"のマニュアルの [AppleTalk](AppleTalk.html) の章を参照してください。"

--- a/doc/po/Upgrading.md.ja.po
+++ b/doc/po/Upgrading.md.ja.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-25 20:36+0100\n"
+"POT-Creation-Date: 2025-01-26 21:23+0100\n"
 "PO-Revision-Date: 2025-01-23 08:10+0100\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -18,7 +18,7 @@ msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:1053 manpages/man5/afp.conf.5.md:1088
-#: manual/AppleTalk.md:154 manual/Configuration.md:838 manual/Installation.md:4
+#: manual/AppleTalk.md:154 manual/Configuration.md:837 manual/Installation.md:4
 #: manual/Upgrading.md:42
 #, no-wrap
 msgid "> **WARNING**\n"
@@ -144,10 +144,10 @@ msgstr ""
 #, no-wrap
 msgid ""
 "> most option names have changed, read the full manpage\n"
-"[afp.conf](#afp.conf.5) for details\n"
+"[afp.conf](afp.conf.html) for details\n"
 msgstr ""
 "> ほとんどのオプション名は変更されたので、 詳細については\n"
-"[afp.conf](#afp.conf.5) の manpage 全体を読むこと\n"
+"[afp.conf](afp.conf.html) の manpage 全体を読むこと\n"
 
 #. type: Bullet: '- '
 #: manual/Upgrading.md:49
@@ -285,13 +285,14 @@ msgstr "そのほかの主要な変更点"
 #. type: Bullet: '- '
 #: manual/Upgrading.md:104
 msgid ""
-"New service controller daemon [netatalk](#netatalk.8) which is responsible "
+"New service controller daemon [netatalk](netatalk.html) which is responsible "
 "for starting and restarting the AFP and CNID daemons. All bundled start "
 "scripts have been updated, make sure to update yours!"
 msgstr ""
 "AFP 及び CNID デーモンの起動・再起動を担う新しいサービスコントローラデーモン "
-"[netatalk](#netatalk.8) の導入。バンドルされているスタートスクリプトが すべて"
-"更新されているため、自分の環境でもアップデートされているか確認する必要あり！"
+"[netatalk](netatalk.html) の導入。バンドルされているスタートスクリプトが すべ"
+"て更新されているため、自分の環境でもアップデートされているか確認する必要あ"
+"り！"
 
 #. type: Bullet: '- '
 #: manual/Upgrading.md:107

--- a/doc/po/_Sidebar.md.ja.po
+++ b/doc/po/_Sidebar.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-25 21:15+0100\n"
+"POT-Creation-Date: 2025-01-26 22:12+0100\n"
 "PO-Revision-Date: 2025-01-24 23:25+0100\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -18,7 +18,7 @@ msgstr ""
 
 #. type: Plain text
 #: manual/_Sidebar.md:2
-msgid "[[en]] | [[ja]]"
+msgid "[en](/manual/en) | [ja](/manual/ja)"
 msgstr ""
 
 #. type: Plain text
@@ -28,23 +28,23 @@ msgstr "マニュアル"
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:9
-msgid "[[Installation]]"
-msgstr "[[インストール]]"
+msgid "[Installation](Installation.html)"
+msgstr "[インストール](Installation.html)"
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:9
-msgid "[[Configuration]]"
-msgstr "[[セットアップ]]"
+msgid "[Configuration](Configuration.html)"
+msgstr "[Netatalk のセットアップ](Configuration.html)"
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:9
-msgid "[[AppleTalk]]"
+msgid "[AppleTalk](AppleTalk.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:9
-msgid "[[Upgrading]]"
-msgstr "[[アップグレード]]"
+msgid "[Upgrading](Upgrading.html)"
+msgstr "[以前の Netatalk バージョンからのアップグレード](Upgrading.html)"
 
 #. type: Plain text
 #: manual/_Sidebar.md:11
@@ -53,67 +53,67 @@ msgstr "ユーザーツール"
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:25
-msgid "[[ad]]"
+msgid "[ad](ad.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:25
-msgid "[[addump]]"
+msgid "[addump](addump.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:25
-msgid "[[aecho]]"
+msgid "[aecho](aecho.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:25
-msgid "[[afpldaptest]]"
+msgid "[afpldaptest](afpldaptest.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:25
-msgid "[[afppasswd]]"
+msgid "[afppasswd](afppasswd.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:25
-msgid "[[afpstats]]"
+msgid "[afpstats](afpstats.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:25
-msgid "[[afptest]]"
+msgid "[afptest](afptest.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:25
-msgid "[[asip-status]]"
+msgid "[asip-status](asip-status.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:25
-msgid "[[dbd]]"
+msgid "[dbd](dbd.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:25
-msgid "[[getzones]]"
+msgid "[getzones](getzones.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:25
-msgid "[[macusers]]"
+msgid "[macusers](macusers.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:25
-msgid "[[nbp]]"
+msgid "[nbp](nbp.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:25
-msgid "[[pap]]"
+msgid "[pap](pap.html)"
 msgstr ""
 
 #. type: Plain text
@@ -123,32 +123,32 @@ msgstr "コンフィグファイル"
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:34
-msgid "[[afp_signature.conf]]"
+msgid "[afp_signature.conf](afp_signature.conf.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:34
-msgid "[[afp_voluuid.conf]]"
+msgid "[afp_voluuid.conf](afp_voluuid.conf.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:34
-msgid "[[afp.conf]]"
+msgid "[afp.conf](afp.conf.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:34
-msgid "[[atalkd.conf]]"
+msgid "[atalkd.conf](atalkd.conf.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:34
-msgid "[[extmap.conf]]"
+msgid "[extmap.conf](extmap.conf.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:34
-msgid "[[papd.conf]]"
+msgid "[papd.conf](papd.conf.html)"
 msgstr ""
 
 #. type: Plain text
@@ -158,52 +158,52 @@ msgstr "デーモン及び管理ツール"
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:47
-msgid "[[a2boot]]"
+msgid "[a2boot](a2boot.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:47
-msgid "[[afpd]]"
+msgid "[afpd](afpd.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:47
-msgid "[[atalkd]]"
+msgid "[atalkd](atalkd.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:47
-msgid "[[cnid_dbd]]"
+msgid "[cnid_dbd](cnid_dbd.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:47
-msgid "[[cnid_metad]]"
+msgid "[cnid_metad](cnid_metad.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:47
-msgid "[[macipgw]]"
+msgid "[macipgw](macipgw.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:47
-msgid "[[netatalk]]"
+msgid "[netatalk](netatalk.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:47
-msgid "[[papd]]"
+msgid "[papd](papd.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:47
-msgid "[[papstatus]]"
+msgid "[papstatus](papstatus.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:47
-msgid "[[timelord]]"
+msgid "[timelord](timelord.html)"
 msgstr ""
 
 #. type: Plain text
@@ -213,17 +213,17 @@ msgstr "開発者参考資料"
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:53
-msgid "[[atalk]]"
+msgid "[atalk](atalk.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:53
-msgid "[[atalk_aton]]"
+msgid "[atalk_aton](atalk_aton.html)"
 msgstr ""
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:53
-msgid "[[nbp_name]]"
+msgid "[nbp_name](nbp_name.html)"
 msgstr ""
 
 #. type: Plain text
@@ -233,10 +233,10 @@ msgstr "付録"
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:57
-msgid "[[Compilation]]"
-msgstr "[[コンパイル]]"
+msgid "[Compilation](Compilation.html)"
+msgstr "[ソースコードから Netatalk をコンパイルする](Compilation.html)"
 
 #. type: Bullet: '* '
 #: manual/_Sidebar.md:57
-msgid "[[License]]"
-msgstr "[[ライセンス]]"
+msgid "[License](License.html)"
+msgstr "[ライセンス](License.html)"

--- a/doc/po4a.cfg
+++ b/doc/po4a.cfg
@@ -38,9 +38,9 @@
 
 [type: text] manual/_Sidebar.md $lang:translated/$lang/_Sidebar.md
 [type: text] manual/AppleTalk.md $lang:translated/$lang/AppleTalk.md
-[type: text] manual/Compilation.md $lang:translated/$lang/コンパイル.md
-[type: text] manual/Configuration.md $lang:translated/$lang/セットアップ.md
+[type: text] manual/Compilation.md $lang:translated/$lang/Compilation.md
+[type: text] manual/Configuration.md $lang:translated/$lang/Configuration.md
 [type: text] manual/index.md $lang:translated/$lang/index.md
-[type: text] manual/Installation.md $lang:translated/$lang/インストール.md
-[type: text] manual/License.md $lang:translated/$lang/ライセンス.md
-[type: text] manual/Upgrading.md $lang:translated/$lang/アップグレード.md
+[type: text] manual/Installation.md $lang:translated/$lang/Installation.md
+[type: text] manual/License.md $lang:translated/$lang/License.md
+[type: text] manual/Upgrading.md $lang:translated/$lang/Upgrading.md

--- a/doc/translated/ja/meson.build
+++ b/doc/translated/ja/meson.build
@@ -1,7 +1,7 @@
 manual_pages = [
-    'セットアップ',
-    'インストール',
-    'アップグレード',
+    'Configuration',
+    'Installation',
+    'Upgrading',
 ]
 
 if get_option('with-website')
@@ -20,13 +20,13 @@ if get_option('with-website')
         'asip-status',
         'cnid_dbd',
         'cnid_metad',
+        'Compilation',
         'dbd',
         'extmap.conf',
         'index',
+        'License',
         'macusers',
         'netatalk',
-        'コンパイル',
-        'ライセンス',
     ]
 endif
 


### PR DESCRIPTION
Fixing a grab bag of incorrect hyperlinks in the manual Markdown sources.

Also moving away from localizing file names. In practice, this caused extra overhead when doing translations to little benefit.