### PR TITLE
Remove traces of unsupported LDAP SASL auth

### DIFF
--- a/bin/misc/uuidtest.c
+++ b/bin/misc/uuidtest.c
@@ -59,7 +59,7 @@ static void parse_ldapconf(void)
                 printf("afp.conf is ok. Using simple bind.\n");
             else {
                 ldap_config_valid = 0;
-                printf("afp.conf wants SASL which is not yet supported.\n");
+                printf("afp.conf defines an unsupported LDAP authentication method.\n");
                 exit(EXIT_FAILURE);
             }
         } else {

--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -871,9 +871,9 @@ add a new one) to you directory server (eg OpenLDAP).
 
 The following LDAP options must be configured for Netatalk:
 
-ldap auth method = <none|simple|sasl\> **(G)**
+ldap auth method = <none|simple\> **(G)**
 
-> Authentication method: **none** | **simple | **sasl**
+> Authentication method: **none** | **simple**
 
 none
 
@@ -882,10 +882,6 @@ none
 simple
 
 > simple LDAP bind
-
-sasl
-
-> SASL. Not yet supported !
 
 ldap auth dn = <dn\> **(G)**
 

--- a/doc/po/afp.conf.5.md.ja.po
+++ b/doc/po/afp.conf.5.md.ja.po
@@ -2458,14 +2458,14 @@ msgstr "Netatalk では以下の LDAP オプションが設定されなければ
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:875
 #, no-wrap
-msgid "ldap auth method = <none|simple|sasl\\> **(G)**\n"
+msgid "ldap auth method = <none|simple\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:877
 #, no-wrap
-msgid "> Authentication method: **none** | **simple | **sasl**\n"
-msgstr "> 認証方式: **none** | **simple | **sasl**\n"
+msgid "> Authentication method: **none** | **simple**\n"
+msgstr "> 認証方式: **none** | **simple**\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:879 manpages/man5/afp.conf.5.md:1085
@@ -2488,17 +2488,6 @@ msgstr ""
 #, no-wrap
 msgid "> simple LDAP bind\n"
 msgstr "> 簡易 LDAP 認証\n"
-
-#. type: Plain text
-#: manpages/man5/afp.conf.5.md:887
-msgid "sasl"
-msgstr ""
-
-#. type: Plain text
-#: manpages/man5/afp.conf.5.md:889
-#, no-wrap
-msgid "> SASL. Not yet supported !\n"
-msgstr "> SASL. まだサポートされていない!\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:891

--- a/libatalk/acl/ldap.c
+++ b/libatalk/acl/ldap.c
@@ -84,7 +84,9 @@ struct ldap_pref ldap_prefs[] = {
 struct pref_array prefs_array[] = {
     {"ldap auth method", "none",   LDAP_AUTH_NONE},
     {"ldap auth method", "simple", LDAP_AUTH_SIMPLE},
+#if 0
     {"ldap auth method", "sasl",   LDAP_AUTH_SASL},
+#endif
     {"ldap userscope",   "base",   LDAP_SCOPE_BASE},
     {"ldap userscope",   "one",    LDAP_SCOPE_ONELEVEL},
     {"ldap userscope",   "sub",    LDAP_SCOPE_SUBTREE},

--- a/libatalk/acl/ldap_config.c
+++ b/libatalk/acl/ldap_config.c
@@ -63,8 +63,7 @@ int acl_ldap_readconfig(dictionary *iniconfig)
                     /* store string as string */
                     *((const char **)(ldap_prefs[i].pref)) = strdup(val);
             } else {
-                /* ok, we have string to int mapping for this pref
-                   e.g. "none", "simple", "sasl" map to 0, 128, 129 */
+                /* ok, we have string to int mapping for this pref */
                 for (j = 0; prefs_array[j].pref != NULL; j++) {
                     if ((strcmp(prefs_array[j].pref, ldap_prefs[i].name) == 0)
                         && (strcmp(prefs_array[j].valuestring, val) == 0)) {
@@ -97,7 +96,7 @@ int acl_ldap_readconfig(dictionary *iniconfig)
             LOG(log_debug, logtype_afpd,"LDAP: Using simple bind.");
         else {
             ldap_config_valid = 0;
-            LOG(log_error, logtype_afpd,"LDAP: SASL not yet supported.");
+            LOG(log_error, logtype_afpd,"LDAP: Unsupported authentication method.");
         }
     } else
         LOG(log_info, logtype_afpd,"LDAP: not used");


### PR DESCRIPTION
Stub code for LDAP SASL auth was put in place way back when ACL was first implemented. But it's never been implemented. So let's remove it.