### PR TITLE
Avoid compiler complaints re: getpwnam() argument being NULL

### DIFF
--- a/etc/afpd/uam.c
+++ b/etc/afpd/uam.c
@@ -210,7 +210,11 @@ struct passwd *uam_getname(void *private, char *name, const int len)
             princ = bformat("%s@%s", name, obj->options.addomain);
         else
             princ = bformat("%s%s%s", obj->options.ntdomain, obj->options.ntseparator, name);
-        pwent = getpwnam(bdata(princ));
+        if (bdata(princ) != NULL) {
+            /* squelch compiler complaints re: getpwnam() receiving a NULL argument */
+            char *bdatum = bdata(princ);
+            pwent = getpwnam(bdatum);
+        }
         bdestroy(princ);
 
         if (pwent) {


### PR DESCRIPTION
I didn't immediately find a smaller way to prevent compiler warnings with gcc 11.4.0.  Originally, gcc complained thus.

[131/205] Compiling C object etc/afpd/libafpd.a.p/uam.c.o
../etc/afpd/uam.c: In function ‘uam_getname’:
../etc/afpd/uam.c:214:25: warning: argument 1 null where non-null expected [-Wnonnull]
  214 |                 pwent = getpwnam(bdata(princ));
      |                         ^~~~~~~~
In file included from ../include/atalk/uam.h:8,
                 from ../include/atalk/globals.h:23,
                 from ../include/atalk/dsi.h:17,
                 from ../etc/afpd/uam.c:30:
/usr/include/pwd.h:116:23: note: in a call to function ‘getpwnam’ declared ‘nonnull’
  116 | extern struct passwd *getpwnam (const char *__name) __nonnull ((1));
      |                       ^~~~~~~~
