### PR TITLE
meson: Introduce with-unicode-data option to build case tables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -726,8 +726,7 @@ jobs:
             meson \
             ninja-build \
             systemtap-sdt-dev \
-            tracker-miner-fs \
-            unicode-data
+            tracker-miner-fs
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v3
       - name: Run build-wrapper

--- a/libatalk/unicode/meson.build
+++ b/libatalk/unicode/meson.build
@@ -8,22 +8,6 @@ unicode_sources = [
     'util_unistr.c',
 ]
 
-if fs.exists(unicode_data_file) and perl.found()
-    run_command(
-        'make-casetable.pl',
-        unicode_data_file,
-        'utf16_casetable.h',
-        'utf16_case.c',
-        check: true,
-    )
-    run_command(
-        'make-precompose.h.pl',
-        unicode_data_file,
-        'precompose.h',
-        check: true,
-    )
-endif
-
 libunicode = static_library(
     'unicode',
     unicode_sources,
@@ -31,3 +15,46 @@ libunicode = static_library(
     link_with: libcharsets,
     install: false,
 )
+
+if get_option('with-unicode-data')
+    unicode_dirs = [
+        meson.current_source_dir(),
+        '/usr/share/unicode',
+        '/usr/share/unicode/ucd',
+        '/usr/pkg/share/texmf-dist/tex/generic/unicode-data',
+        '/usr/local/share/texmf-dist/tex/generic/unicode-data/',
+    ]
+
+    unicode_data_path = get_option('with-unicode-data-path')
+
+    if unicode_data_path == ''
+        foreach dir : unicode_dirs
+            if fs.exists(dir / 'UnicodeData.txt')
+                unicode_data_path = dir
+                break
+            endif
+        endforeach
+    elif not fs.is_absolute(unicode_data_path)
+        unicode_data_path = meson.current_source_dir() / unicode_data_path
+    endif
+
+    unicode_data_file = unicode_data_path / 'UnicodeData.txt'
+
+    if fs.exists(unicode_data_file) and perl.found()
+        run_command(
+            'make-casetable.pl',
+            unicode_data_file,
+            'utf16_casetable.h',
+            'utf16_case.c',
+            check: true,
+        )
+        run_command(
+            'make-precompose.h.pl',
+            unicode_data_file,
+            'precompose.h',
+            check: true,
+        )
+    else
+        error('Perl and Unicode data file required to generate case tables')
+    endif
+endif

--- a/meson.build
+++ b/meson.build
@@ -588,37 +588,6 @@ else
 endif
 
 #
-# Check for Unicode Character Database
-#
-
-unicode_dirs = [
-    meson.current_source_dir(),
-    '/usr/share/unicode',
-    '/usr/share/unicode/ucd',
-    '/usr/pkg/share/texmf-dist/tex/generic/unicode-data',
-    '/usr/local/share/texmf-dist/tex/generic/unicode-data/',
-]
-
-unicode_data_path = get_option('with-unicode-data-path')
-
-if unicode_data_path == ''
-    foreach dir : unicode_dirs
-        if fs.exists(dir / 'UnicodeData.txt')
-            unicode_data_path = dir
-            break
-        endif
-    endforeach
-elif not fs.is_absolute(unicode_data_path)
-    unicode_data_path = meson.current_source_dir() / unicode_data_path
-endif
-
-unicode_data_file = unicode_data_path / 'UnicodeData.txt'
-
-if fs.exists(unicode_data_file)
-    message('Unicode Character Database found at ' + unicode_data_path)
-endif
-
-#
 # Check for crypt (for DHX authentication)
 #
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -190,6 +190,12 @@ option(
     description: 'Compile the AFP test suite',
 )
 option(
+    'with-unicode-data',
+    type: 'boolean',
+    value: false,
+    description: 'Rebuild the Unicode source files from UnicodeData.txt',
+)
+option(
     'with-webmin',
     type: 'boolean',
     value: false,


### PR DESCRIPTION
The new `with-unicode-data` Meson build system option will control whether to attempt to rebuild the Unicode case table sources or not. This is disabled by default, which is a change from before.

This makes it so that there are no surprising changes to local source files unless you deliberately ask for it.