### PR TITLE
docs: Add config examples to afp.conf man page

### DIFF
--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -1275,7 +1275,7 @@ This enables Spotlight and AFP stats if Netatalk was built with
 Spotlight and AFP stats support. The **mimic model** option is
 used to make the server look like a Xserve.
 
-The home directory is mounted on **/home/afp-data**.
+The home directory is mounted on */home/{user}/afp-data*.
 
 ```
 [Global]

--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -1267,6 +1267,54 @@ unix priv = <BOOLEAN\> (default: *yes*) **(V)**
 > Whether to use AFP3 UNIX privileges. This should be set for OS X
 clients. See also: **file perm**, **directory perm** and `umask`.
 
+# Examples
+
+## Example: Modern Mac clients
+
+This enables Spotlight and AFP stats if Netatalk was built with
+Spotlight and AFP stats support. The **mimic model** option is
+used to make the server look like a Xserve.
+
+The home directory is mounted on **/home/afp-data**.
+
+```
+[Global]
+afpstats = yes
+spotlight = yes
+mimic model = RackMac
+
+[Home]
+basedir regex = /home
+path = afp-data
+```
+
+## Example: Classic Mac clients
+
+This enables AppleTalk if Netatalk was built with AppleTalk support.
+The Random Number and ClearTxt authentication modules are used.
+The **legacy icon** option is used to make the server look like a
+BSD Daemon.
+
+With **legacy volume size** the volume size is limited to 2 GB
+for very old Macs, while **prodos** is used to enable ProDOS
+boot flags on the volume while limiting the volume free space
+to 32 MB.
+
+```
+[Global]
+appletalk = yes
+uam list = uams_dhx.so uams_dhx2.so uams_randnum.so uams_clrtxt.so
+legacy icon = daemon
+
+[Mac Volume]
+path = /srv/mac
+legacy volume size = yes
+
+[Apple II Volume]
+path = /srv/apple2
+prodos = yes
+```
+
 # See Also
 
 afpd(8), afppasswd(5), afp_signature.conf(5), extmap.conf(5),

--- a/doc/po/afp.conf.5.md.ja.po
+++ b/doc/po/afp.conf.5.md.ja.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 18:48+0100\n"
+"POT-Creation-Date: 2025-01-30 22:19+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -66,7 +66,7 @@ msgstr "概要"
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
 #: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1279
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1323
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
@@ -88,7 +88,7 @@ msgstr "著者"
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
 #: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1281
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1325
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
@@ -105,7 +105,7 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1274 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1318 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
 #: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
@@ -115,13 +115,25 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 msgid "See Also"
 msgstr "関連項目"
 
+#. type: Title #
+#: manpages/man1/aecho.1.md:24 manpages/man1/afppasswd.1.md:26
+#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:50
+#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
+#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1270
+#: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
+#: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
+#, no-wrap
+msgid "Examples"
+msgstr "例"
+
 #. type: Plain text
 #: manpages/man1/afppasswd.1.md:20 manpages/man5/afp_signature.conf.5.md:21
 #: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:319
 #: manpages/man5/afp.conf.5.md:343 manpages/man5/afp.conf.5.md:356
 #: manpages/man5/afp.conf.5.md:371 manpages/man5/afp.conf.5.md:723
-#: manpages/man5/afp.conf.5.md:1049 manpages/man5/afp.conf.5.md:1174
-#: manpages/man5/afp.conf.5.md:1212 manpages/man8/papd.8.md:96
+#: manpages/man5/afp.conf.5.md:1045 manpages/man5/afp.conf.5.md:1170
+#: manpages/man5/afp.conf.5.md:1208 manpages/man8/papd.8.md:96
 #: manual/Configuration.md:113
 #, no-wrap
 msgid "> **NOTE**\n"
@@ -415,7 +427,7 @@ msgid ""
 msgstr ""
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:114 manpages/man5/afp.conf.5.md:981
+#: manpages/man5/afp.conf.5.md:114 manpages/man5/afp.conf.5.md:977
 #, no-wrap
 msgid "Parameters"
 msgstr "パラメータ"
@@ -2468,7 +2480,7 @@ msgid "> Authentication method: **none** | **simple**\n"
 msgstr "> 認証方式: **none** | **simple**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:879 manpages/man5/afp.conf.5.md:1085
+#: manpages/man5/afp.conf.5.md:879 manpages/man5/afp.conf.5.md:1081
 msgid "none"
 msgstr ""
 
@@ -2490,36 +2502,36 @@ msgid "> simple LDAP bind\n"
 msgstr "> 簡易 LDAP 認証\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:891
+#: manpages/man5/afp.conf.5.md:887
 #, no-wrap
 msgid "ldap auth dn = <dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:893
+#: manpages/man5/afp.conf.5.md:889
 #, no-wrap
 msgid "> Distinguished Name of the user for simple bind.\n"
 msgstr "> 簡易認証でのユーザーの識別名。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:895
+#: manpages/man5/afp.conf.5.md:891
 #, no-wrap
 msgid "ldap auth pw = <password\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:897
+#: manpages/man5/afp.conf.5.md:893
 #, no-wrap
 msgid "> Password for simple bind.\n"
 msgstr "> 簡易認証でのパスワード。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:899
+#: manpages/man5/afp.conf.5.md:895
 msgid "ldap uri = <ldap://somehost:1234/\\> **(G)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:904
+#: manpages/man5/afp.conf.5.md:900
 #, no-wrap
 msgid ""
 "> Specifies the LDAP URI of the server to connect to. The URI scheme may\n"
@@ -2534,107 +2546,107 @@ msgstr ""
 "サポートを必要とする時のみ必要。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:906
+#: manpages/man5/afp.conf.5.md:902
 msgid "You can use **afpldaptest**(1) to syntactically check your config."
 msgstr "設定の構文的なチェックのために **afpldaptest**(1) を使うこともできる。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:908
+#: manpages/man5/afp.conf.5.md:904
 #, no-wrap
 msgid "ldap userbase = <base dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:910
+#: manpages/man5/afp.conf.5.md:906
 #, no-wrap
 msgid "> DN of the user container in LDAP.\n"
 msgstr "> LDAP 内のユーザーコンテナの DN。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:912
+#: manpages/man5/afp.conf.5.md:908
 #, no-wrap
 msgid "ldap userscope = <scope\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:914
+#: manpages/man5/afp.conf.5.md:910
 #, no-wrap
 msgid "> Search scope for user search: **base** | **one** | **sub**\n"
 msgstr "> ユーザー検索での検索スコープ: **base** | **one** | **sub**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:916
+#: manpages/man5/afp.conf.5.md:912
 #, no-wrap
 msgid "ldap groupbase = <base dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:918
+#: manpages/man5/afp.conf.5.md:914
 #, no-wrap
 msgid "> DN of the group container in LDAP.\n"
 msgstr "> LDAP 内のグループコンテナの DN。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:920
+#: manpages/man5/afp.conf.5.md:916
 #, no-wrap
 msgid "ldap groupscope = <scope\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:922
+#: manpages/man5/afp.conf.5.md:918
 #, no-wrap
 msgid "> Search scope for group search: **base** | **one** | **sub**\n"
 msgstr "> グループ検索での検索スコープ: **base** | **one** | **sub**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:924
+#: manpages/man5/afp.conf.5.md:920
 #, no-wrap
 msgid "ldap uuid attr = <dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:926
+#: manpages/man5/afp.conf.5.md:922
 #, no-wrap
 msgid "> Name of the LDAP attribute with the UUIDs.\n"
 msgstr "> UUID のある LDAP 属性の名前。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:928
+#: manpages/man5/afp.conf.5.md:924
 msgid "Note: this is used both for users and groups."
 msgstr "注記: これはユーザーでもグループでも双方で用いられる。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:930
+#: manpages/man5/afp.conf.5.md:926
 #, no-wrap
 msgid "ldap name attr = <dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:932
+#: manpages/man5/afp.conf.5.md:928
 #, no-wrap
 msgid "> Name of the LDAP attribute with the users short name.\n"
 msgstr "> ユーザーの短縮名のある LDAP 属性の名前。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:934
+#: manpages/man5/afp.conf.5.md:930
 #, no-wrap
 msgid "ldap group attr = <dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:936
+#: manpages/man5/afp.conf.5.md:932
 #, no-wrap
 msgid "> Name of the LDAP attribute with the groups short name.\n"
 msgstr "> グループの短縮名のある LDAP 属性の名前。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:938
+#: manpages/man5/afp.conf.5.md:934
 #, no-wrap
 msgid "ldap uuid string = <STRING\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:941
+#: manpages/man5/afp.conf.5.md:937
 #, no-wrap
 msgid ""
 "> Format of the uuid string in the directory. A series of x and -, where\n"
@@ -2645,18 +2657,18 @@ msgstr ""
 "はそれぞれ区切り文字である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:943
+#: manpages/man5/afp.conf.5.md:939
 msgid "Default: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 msgstr "デフォルト: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:945
+#: manpages/man5/afp.conf.5.md:941
 #, no-wrap
 msgid "ldap uuid encoding = <string | ms-guid (default: string)\\> **(G)**\n"
 msgstr "ldap uuid encoding = <string | ms-guid (デフォルト: string)\\> **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:952
+#: manpages/man5/afp.conf.5.md:948
 #, no-wrap
 msgid ""
 "> Format of the UUID of the LDAP attribute, allows usage of the binary\n"
@@ -2675,41 +2687,41 @@ msgstr ""
 "表記とバイナリー形式が相互に変換される。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:954
+#: manpages/man5/afp.conf.5.md:950
 msgid "See also the options **ldap user filter** and **ldap group filter**."
 msgstr ""
 "オプション **ldap user filter** 及び **ldap group filter** も参照のこと。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:956
+#: manpages/man5/afp.conf.5.md:952
 msgid "string"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:958
+#: manpages/man5/afp.conf.5.md:954
 #, no-wrap
 msgid "> UUID is a string, use with e.g. OpenDirectory.\n"
 msgstr "> UUID は文字列。例えば OpenDirectory とで使用する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:960
+#: manpages/man5/afp.conf.5.md:956
 msgid "ms-guid"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:962
+#: manpages/man5/afp.conf.5.md:958
 #, no-wrap
 msgid "> Binary objectGUID from Active Directory\n"
 msgstr "> Active Directory からの objectGUID バイナリー。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:964
+#: manpages/man5/afp.conf.5.md:960
 #, no-wrap
 msgid "ldap user filter = <STRING (default: unused)\\> **(G)**\n"
 msgstr "ldap user filter = <STRING (デフォルト: 未使用)\\> **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:968
+#: manpages/man5/afp.conf.5.md:964
 #, no-wrap
 msgid ""
 "> Optional LDAP filter that matches user objects. This is necessary for\n"
@@ -2721,18 +2733,18 @@ msgstr ""
 "Active Directory 環境で必要。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:970
+#: manpages/man5/afp.conf.5.md:966
 msgid "Recommended setting for Active Directory: **objectClass=user**."
 msgstr "Active Directory での推奨設定: **objectClass=user**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:972
+#: manpages/man5/afp.conf.5.md:968
 #, no-wrap
 msgid "ldap group filter = <STRING (default: unused)\\> **(G)**\n"
 msgstr "ldap group filter = <STRING (デフォルト: 未使用)\\> **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:976
+#: manpages/man5/afp.conf.5.md:972
 #, no-wrap
 msgid ""
 "> Optional LDAP filter that matches group objects. This is necessary for\n"
@@ -2744,18 +2756,18 @@ msgstr ""
 "Active Directory 環境で必要。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:978
+#: manpages/man5/afp.conf.5.md:974
 msgid "Recommended setting for Active Directory: **objectClass=group**."
 msgstr "Active Directory での推奨設定: **objectClass=group**"
 
 #. type: Title #
-#: manpages/man5/afp.conf.5.md:979
+#: manpages/man5/afp.conf.5.md:975
 #, no-wrap
 msgid "Explanation of Volume Parameters"
 msgstr "ボリュームパラメータの説明"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:988
+#: manpages/man5/afp.conf.5.md:984
 msgid ""
 "The section name defines the volume name. No two volumes may have the same "
 "name. The volume name cannot contain the ':' character. The volume name is "
@@ -2768,25 +2780,25 @@ msgstr ""
 "される。UTF8-MAC ボリューム名は volnamelen パラメータで制限される。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:990
+#: manpages/man5/afp.conf.5.md:986
 #, no-wrap
 msgid "path = <PATH\\> **(V)**\n"
 msgstr "mac charset = <CHARSET\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:992
+#: manpages/man5/afp.conf.5.md:988
 #, no-wrap
 msgid "> The path name must be a fully qualified path name.\n"
 msgstr "> パス名は完全修飾パス名でなければならない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:994
+#: manpages/man5/afp.conf.5.md:990
 #, no-wrap
 msgid "appledouble = <ea|v2\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:998
+#: manpages/man5/afp.conf.5.md:994
 #, no-wrap
 msgid ""
 "> Specify the format of the metadata files, which are used for saving Mac\n"
@@ -2798,13 +2810,13 @@ msgstr ""
 "v2 が用いられ、新しいデフォルトのフォーマットは **ea** である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1000
+#: manpages/man5/afp.conf.5.md:996
 #, no-wrap
 msgid "vol size limit = <size in MiB\\> **(V)**\n"
 msgstr "vol size limit = <MiB 単位でのサイズ\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1005
+#: manpages/man5/afp.conf.5.md:1001
 #, no-wrap
 msgid ""
 "> Useful for Time Machine: limits the reported volume size, thus\n"
@@ -2819,13 +2831,13 @@ msgstr ""
 "に制限する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1007
+#: manpages/man5/afp.conf.5.md:1003
 #, no-wrap
 msgid "> **IMPORTANT**\n"
 msgstr "> **重要**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1015
+#: manpages/man5/afp.conf.5.md:1011
 #, no-wrap
 msgid ""
 "> This is an approximated calculation taking into\n"
@@ -2845,13 +2857,13 @@ msgstr ""
 "を読む、そしてお互いの乗算をする。ことによって行われる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1017
+#: manpages/man5/afp.conf.5.md:1013
 #, no-wrap
 msgid "valid users = <user @group\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1021
+#: manpages/man5/afp.conf.5.md:1017
 #, no-wrap
 msgid ""
 "> The allow option allows the users and groups that access a share to be\n"
@@ -2862,19 +2874,19 @@ msgstr ""
 "@ プレフィックスで明示する。例:\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1023
+#: manpages/man5/afp.conf.5.md:1019
 #, no-wrap
 msgid "    valid users = user @group\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1025
+#: manpages/man5/afp.conf.5.md:1021
 #, no-wrap
 msgid "invalid users = <users/groups\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1028
+#: manpages/man5/afp.conf.5.md:1024
 #, no-wrap
 msgid ""
 "> The deny option specifies users and groups who are not allowed access to\n"
@@ -2884,13 +2896,13 @@ msgstr ""
 "\"valid users\" オプションと同じフォーマットである。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1030
+#: manpages/man5/afp.conf.5.md:1026
 #, no-wrap
 msgid "hosts allow = <IP host address/IP netmask bits \\[ ... \\]\\> **(V)**\n"
 msgstr "hosts allow = <IPホストアドレス/IPマスクビット \\[ ... \\]\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1034
+#: manpages/man5/afp.conf.5.md:1030
 #, no-wrap
 msgid ""
 "> Only listed hosts and networks are allowed, all others are rejected. The\n"
@@ -2902,35 +2914,35 @@ msgstr ""
 "のドット区切りフォーマット、IPv6の16進数フォーマットのどちらでもよい。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1036
+#: manpages/man5/afp.conf.5.md:1032
 msgid "Example: hosts allow = 10.1.0.0/16 10.2.1.100 2001:0db8:1234::/48"
 msgstr "例: hosts allow = 10.1.0.0/16 10.2.1.100 2001:0db8:1234::/48"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1038
+#: manpages/man5/afp.conf.5.md:1034
 #, no-wrap
 msgid "hosts deny = <IP host address/IP netmask bits \\[ ... \\]\\> **(V)**\n"
 msgstr "hosts deny = <IPホストアドレス/IPマスクビット \\[ ... \\]\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1040
+#: manpages/man5/afp.conf.5.md:1036
 #, no-wrap
 msgid "> Listed hosts and nets are rejected, all others are allowed.\n"
 msgstr "> 列挙されたホストとネットのみが拒否され、ほかの全ては許可される。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1042
+#: manpages/man5/afp.conf.5.md:1038
 msgid "Example: hosts deny = 192.168.100/24 10.1.1.1 2001:db8::1428:57ab"
 msgstr "例: hosts deny = 192.168.100/24 10.1.1.1 2001:db8::1428:57ab"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1044
+#: manpages/man5/afp.conf.5.md:1040
 #, no-wrap
 msgid "cnid scheme = <backend\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1047
+#: manpages/man5/afp.conf.5.md:1043
 #, no-wrap
 msgid ""
 "> set the CNID backend to be used for the volume, default is\n"
@@ -2942,7 +2954,7 @@ msgstr ""
 "\\[@compiled_backends@\\] である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1052
+#: manpages/man5/afp.conf.5.md:1048
 #, no-wrap
 msgid ""
 "> The \"mysql\" backend requires the system administrator to configure a\n"
@@ -2952,7 +2964,7 @@ msgstr ""
 "MySQL データベース インスタンスを構成する必要がある。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1054 manpages/man5/afp.conf.5.md:1089
+#: manpages/man5/afp.conf.5.md:1050 manpages/man5/afp.conf.5.md:1085
 #: manual/AppleTalk.md:154 manual/Configuration.md:832 manual/Installation.md:4
 #: manual/Upgrading.md:42
 #, no-wrap
@@ -2960,7 +2972,7 @@ msgid "> **WARNING**\n"
 msgstr "> **警告**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1058
+#: manpages/man5/afp.conf.5.md:1054
 #, no-wrap
 msgid ""
 "> Do *NOT* use the \"last\" backend for volumes, because **afpd** relies\n"
@@ -2971,13 +2983,13 @@ msgstr ""
 "データベースに重く依存しているので、このバックエンドをボリュームに使用するのは推奨*されていない*。エイリアスはおそらく機能しないだろうし、ファイル名のマングリングもサポートされていない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1060
+#: manpages/man5/afp.conf.5.md:1056
 #, no-wrap
 msgid "ea = <none|auto|sys|ad|samba\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1063
+#: manpages/man5/afp.conf.5.md:1059
 #, no-wrap
 msgid ""
 "> Specify how Extended Attributes are\n"
@@ -2987,12 +2999,12 @@ msgstr ""
 "がデフォルトである。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1065
+#: manpages/man5/afp.conf.5.md:1061
 msgid "auto"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1070
+#: manpages/man5/afp.conf.5.md:1066
 #, no-wrap
 msgid ""
 "> Try **sys** (by setting an EA on the shared directory itself), fallback to\n"
@@ -3008,23 +3020,23 @@ msgstr ""
 "\"**ea = sys|ad**\" を使ってください。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1072
+#: manpages/man5/afp.conf.5.md:1068
 msgid "sys"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1074
+#: manpages/man5/afp.conf.5.md:1070
 #, no-wrap
 msgid "> Use filesystem Extended Attributes.\n"
 msgstr "> ファイルシステムの拡張属性を使う。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1076
+#: manpages/man5/afp.conf.5.md:1072
 msgid "samba"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1079
+#: manpages/man5/afp.conf.5.md:1075
 #, no-wrap
 msgid ""
 "> Use filesystem Extended Attributes, but append a 0 byte to each xattr in\n"
@@ -3032,24 +3044,24 @@ msgid ""
 msgstr "> ファイルシステムの拡張属性を使うが、Sambaのvfs_streams_xattrとの互換性の目的で、それぞれの拡張属性に値がゼロの1バイトを追加する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1081
+#: manpages/man5/afp.conf.5.md:1077
 msgid "ad"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1083
+#: manpages/man5/afp.conf.5.md:1079
 #, no-wrap
 msgid "> Use files in *.AppleDouble* directories.\n"
 msgstr "> *.AppleDouble* ディレクトリ内のファイルを使う。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1087
+#: manpages/man5/afp.conf.5.md:1083
 #, no-wrap
 msgid "> No Extended Attributes support.\n"
 msgstr "> 拡張属性をサポートしない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1092
+#: manpages/man5/afp.conf.5.md:1088
 #, no-wrap
 msgid ""
 "> The **samba** option should not be used on a volume that was previously\n"
@@ -3059,13 +3071,13 @@ msgstr ""
 "に設定されたボリュームでは使用しないでください。これにより、データが失われる可能性がある。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1094
+#: manpages/man5/afp.conf.5.md:1090
 #, no-wrap
 msgid "mac charset = <charset\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1099
+#: manpages/man5/afp.conf.5.md:1095
 #, no-wrap
 msgid ""
 "> specifies the Mac client charset for this Volume, e.g. *MAC_ROMAN*,\n"
@@ -3079,13 +3091,13 @@ msgstr ""
 "セクションで全体的にセットしたキャラクターセットと異なるというボリュームを必要とする時のみ必須である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1101
+#: manpages/man5/afp.conf.5.md:1097
 #, no-wrap
 msgid "casefold = <option\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1104
+#: manpages/man5/afp.conf.5.md:1100
 #, no-wrap
 msgid ""
 "> The casefold option handles, if the case of filenames should be changed.\n"
@@ -3095,37 +3107,37 @@ msgstr ""
 "オプションが処理する。有効なオプションは:\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1106
+#: manpages/man5/afp.conf.5.md:1102
 #, no-wrap
 msgid "**tolower** - Lowercases names in both directions.\n"
 msgstr "**tolower** - 双方向で名前を小文字に変換する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1108
+#: manpages/man5/afp.conf.5.md:1104
 #, no-wrap
 msgid "**toupper** - Uppercases names in both directions.\n"
 msgstr "**toupper** - 双方向で名前を大文字に変換する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1110
+#: manpages/man5/afp.conf.5.md:1106
 #, no-wrap
 msgid "**xlatelower** - Client sees lowercase, server sees uppercase.\n"
 msgstr "**xlatelower** - クライアントでは小文字に見えて、サーバでは大文字に見える。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1112
+#: manpages/man5/afp.conf.5.md:1108
 #, no-wrap
 msgid "**xlateupper** - Client sees uppercase, server sees lowercase.\n"
 msgstr "**xlateupper** - クライアントでは大文字に見えて、サーバでは小文字にみえる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1114
+#: manpages/man5/afp.conf.5.md:1110
 #, no-wrap
 msgid "password = <password\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1118
+#: manpages/man5/afp.conf.5.md:1114
 #, no-wrap
 msgid ""
 "> This option allows you to set a volume password, which can be a maximum\n"
@@ -3136,13 +3148,13 @@ msgstr ""
 "8 文字の長さ（これを記入するときには ASCII を強く推奨）\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1120
+#: manpages/man5/afp.conf.5.md:1116
 #, no-wrap
 msgid "file perm = <mode\\> **(V)**; directory perm = <mode\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1124
+#: manpages/man5/afp.conf.5.md:1120
 #, no-wrap
 msgid ""
 "> Add(or) with the client requested permissions: **file perm** is for files\n"
@@ -3154,13 +3166,13 @@ msgstr ""
 "\"**unix priv = no**\" と共に用いてはならない。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:1125
+#: manpages/man5/afp.conf.5.md:1121
 #, no-wrap
 msgid "Example: Volume for a collaborative workgroup"
 msgstr "例：共同作業グループ向けのボリューム"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1129
+#: manpages/man5/afp.conf.5.md:1125
 #, no-wrap
 msgid ""
 "    file perm = 0660\n"
@@ -3168,49 +3180,49 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1131
+#: manpages/man5/afp.conf.5.md:1127
 #, no-wrap
 msgid "umask = <mode\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1133
+#: manpages/man5/afp.conf.5.md:1129
 #, no-wrap
 msgid "> set perm mask. Don't use with \"**unix priv = no**\".\n"
 msgstr "> 権限のマスクを設定する。\"**unix priv = no**\" と共に用いてはならない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1135
+#: manpages/man5/afp.conf.5.md:1131
 #, no-wrap
 msgid "preexec = <command\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1137
+#: manpages/man5/afp.conf.5.md:1133
 #, no-wrap
 msgid "> command to be run when the volume is mounted\n"
 msgstr "> ボリュームがマウントされる時に実行されるコマンド\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1139
+#: manpages/man5/afp.conf.5.md:1135
 #, no-wrap
 msgid "postexec = <command\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1141
+#: manpages/man5/afp.conf.5.md:1137
 #, no-wrap
 msgid "> command to be run when the volume is closed\n"
 msgstr "> ボリュームが閉じられる時に実行されるコマンド\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1143
+#: manpages/man5/afp.conf.5.md:1139
 #, no-wrap
 msgid "rolist = <users/groups\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1146
+#: manpages/man5/afp.conf.5.md:1142
 #, no-wrap
 msgid ""
 "> Allows certain users and groups to have read-only access to a share.\n"
@@ -3220,13 +3232,13 @@ msgstr ""
 "allow オプションに準ずる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1148
+#: manpages/man5/afp.conf.5.md:1144
 #, no-wrap
 msgid "rwlist = <users/groups\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1151
+#: manpages/man5/afp.conf.5.md:1147
 #, no-wrap
 msgid ""
 "> Allows certain users and groups to have read/write access to a share.\n"
@@ -3236,13 +3248,13 @@ msgstr ""
 "allow オプションに準ずる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1153
+#: manpages/man5/afp.conf.5.md:1149
 #, no-wrap
 msgid "veto files = <vetoed names\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1157
+#: manpages/man5/afp.conf.5.md:1153
 #, no-wrap
 msgid ""
 "> hide files and directories,where the path matches one of the '/'\n"
@@ -3255,24 +3267,24 @@ msgstr ""
 "= veto1/veto2/\"。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:1158
+#: manpages/man5/afp.conf.5.md:1154
 #, no-wrap
 msgid "Volume options"
 msgstr "ボリュームオプション"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1161
+#: manpages/man5/afp.conf.5.md:1157
 msgid "Boolean volume options."
 msgstr "ブーリアン型のボリュームオプション。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1163
+#: manpages/man5/afp.conf.5.md:1159
 #, no-wrap
 msgid "acls = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "acls = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1166
+#: manpages/man5/afp.conf.5.md:1162
 #, no-wrap
 msgid ""
 "> Whether to flag volumes as supporting ACLs. If ACL support is compiled\n"
@@ -3282,13 +3294,13 @@ msgstr ""
 "サポートでコンパイルしていれば、これはデフォルトで yes。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1168
+#: manpages/man5/afp.conf.5.md:1164
 #, no-wrap
 msgid "case sensitive = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "case sensitive = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1172
+#: manpages/man5/afp.conf.5.md:1168
 #, no-wrap
 msgid ""
 "> Whether to flag volumes as supporting case-sensitive filenames. If the\n"
@@ -3300,7 +3312,7 @@ msgstr ""
 "を設定せよ。しかしながらこれは完全には確かめられていない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1178
+#: manpages/man5/afp.conf.5.md:1174
 #, no-wrap
 msgid ""
 "> In spite of being case sensitive as a matter of fact, netatalk 3.1.3 and\n"
@@ -3313,13 +3325,13 @@ msgstr ""
 "からはデフォルトで正しく通知される。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1180
+#: manpages/man5/afp.conf.5.md:1176
 #, no-wrap
 msgid "cnid dev = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "cnid dev = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1183
+#: manpages/man5/afp.conf.5.md:1179
 #, no-wrap
 msgid ""
 "> Whether to use the device number in the CNID backends. Helps when the\n"
@@ -3329,13 +3341,13 @@ msgstr ""
 "例えばクラスターなどでリブートを経るとデバイス番号が固定ではない時有用。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1185
+#: manpages/man5/afp.conf.5.md:1181
 #, no-wrap
 msgid "convert appledouble = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "convert appledouble = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1191
+#: manpages/man5/afp.conf.5.md:1187
 #, no-wrap
 msgid ""
 "> Whether automatic conversion from **appledouble = v2** to\n"
@@ -3351,13 +3363,13 @@ msgstr ""
 "に設定することもできる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1193
+#: manpages/man5/afp.conf.5.md:1189
 #, no-wrap
 msgid "delete veto files = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "delete veto files = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1199
+#: manpages/man5/afp.conf.5.md:1195
 #, no-wrap
 msgid ""
 "> This option is used when Netatalk is attempting to delete a directory\n"
@@ -3373,7 +3385,7 @@ msgstr ""
 "ファイルないしはディレクトリを含んでいたら、ディレクトリの削除は失敗するであろう。これは通常あなたの望むところの動作である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1202
+#: manpages/man5/afp.conf.5.md:1198
 msgid ""
 "If this option is set to yes, then Netatalk will attempt to recursively "
 "delete any files and directories within the vetoed directory."
@@ -3383,13 +3395,13 @@ msgstr ""
 "するであろう。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1204
+#: manpages/man5/afp.conf.5.md:1200
 #, no-wrap
 msgid "follow symlinks = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "follow symlinks = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1210
+#: manpages/man5/afp.conf.5.md:1206
 #, no-wrap
 msgid ""
 "> The default setting is false thus symlinks are not followed on the\n"
@@ -3405,7 +3417,7 @@ msgstr ""
 "ボリューム以外を指しているかもしれない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1215
+#: manpages/man5/afp.conf.5.md:1211
 #, no-wrap
 msgid ""
 "> This option will subtly break when the symlinks point across filesystem\n"
@@ -3413,13 +3425,13 @@ msgid ""
 msgstr "> シンボリックリンクがファイルシステムの境界をまたいで張られている時、このオプションは巧妙に断ち切る。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1217
+#: manpages/man5/afp.conf.5.md:1213
 #, no-wrap
 msgid "invisible dots = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "invisible dots = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1225
+#: manpages/man5/afp.conf.5.md:1221
 #, no-wrap
 msgid ""
 "> make dot files invisible. WARNING: enabling this option will lead to\n"
@@ -3439,13 +3451,13 @@ msgstr ""
 "でもターミナルでもドットではじまるファイルはいずれにしても隠しファイルなので、完全に無駄である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1227
+#: manpages/man5/afp.conf.5.md:1223
 #, no-wrap
 msgid "legacy volume size = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "legacy volume size = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1231
+#: manpages/man5/afp.conf.5.md:1227
 #, no-wrap
 msgid ""
 "> Limit disk size reporting to 2GB for legacy clients. This can be used\n"
@@ -3457,13 +3469,13 @@ msgstr ""
 "クライアントを使用している古い Macintosh で使用できる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1233
+#: manpages/man5/afp.conf.5.md:1229
 #, no-wrap
 msgid "network ids = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "network ids = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1236
+#: manpages/man5/afp.conf.5.md:1232
 #, no-wrap
 msgid ""
 "> Whether the server support network ids. Setting this to *no* will result\n"
@@ -3473,13 +3485,13 @@ msgstr ""
 "に設定すると結果としてクライアントは ACL AFP 機能を使わなくなる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1238
+#: manpages/man5/afp.conf.5.md:1234
 #, no-wrap
 msgid "preexec close = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "preexec close = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1241
+#: manpages/man5/afp.conf.5.md:1237
 #, no-wrap
 msgid ""
 "> A non-zero return code from preexec close the volume being immediately,\n"
@@ -3489,13 +3501,13 @@ msgstr ""
 "以外のリターンコードで、クライアントがボリュームをマウントする／見ることを防ぐために当該ボリュームを即座に閉じる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1243
+#: manpages/man5/afp.conf.5.md:1239
 #, no-wrap
 msgid "prodos = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "prodos = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1247
+#: manpages/man5/afp.conf.5.md:1243
 #, no-wrap
 msgid ""
 "> Enable ProDOS support. This option should only be enabled for volumes\n"
@@ -3508,13 +3520,13 @@ msgstr ""
 "に制限する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1249
+#: manpages/man5/afp.conf.5.md:1245
 #, no-wrap
 msgid "read only = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "read only = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1252
+#: manpages/man5/afp.conf.5.md:1248
 #, no-wrap
 msgid ""
 "> Specifies the share as being read only for all users. Overwrites\n"
@@ -3524,13 +3536,13 @@ msgstr ""
 "**ea = none** で上書きされる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1254
+#: manpages/man5/afp.conf.5.md:1250
 #, no-wrap
 msgid "search db = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "search db = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1259
+#: manpages/man5/afp.conf.5.md:1255
 #, no-wrap
 msgid ""
 "> Use fast CNID database namesearch instead of slow recursive filesystem\n"
@@ -3545,13 +3557,13 @@ msgstr ""
 "CNID db のボリュームのみで動作する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1261
+#: manpages/man5/afp.conf.5.md:1257
 #, no-wrap
 msgid "stat vol = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "stat vol = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1264
+#: manpages/man5/afp.conf.5.md:1260
 #, no-wrap
 msgid ""
 "> Whether to stat volume path when enumerating volumes list, useful for\n"
@@ -3562,25 +3574,25 @@ msgstr ""
 "スクリプトで作成されたボリュームに有用である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1266
+#: manpages/man5/afp.conf.5.md:1262
 #, no-wrap
 msgid "time machine = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "time machine = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1268
+#: manpages/man5/afp.conf.5.md:1264
 #, no-wrap
 msgid "> Whether to enable Time Machine support for this volume.\n"
 msgstr "> このボリュームの Time Machine サポートを有効にするかどうか。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1270
+#: manpages/man5/afp.conf.5.md:1266
 #, no-wrap
 msgid "unix priv = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "unix priv = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1273
+#: manpages/man5/afp.conf.5.md:1269
 #, no-wrap
 msgid ""
 "> Whether to use AFP3 UNIX privileges. This should be set for OS X\n"
@@ -3590,8 +3602,90 @@ msgstr ""
 "クライアントに対しては設定すべきである。**file perm**、**directory perm**\n"
 "及び `umask` も参照。\n"
 
+#. type: Title ##
+#: manpages/man5/afp.conf.5.md:1272
+#, no-wrap
+msgid "Example: Modern Mac clients"
+msgstr "例：現代の Mac クライアント"
+
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1278
+#: manpages/man5/afp.conf.5.md:1277
+msgid ""
+"This enables Spotlight and AFP stats if Netatalk was built with Spotlight "
+"and AFP stats support. The **mimic model** option is used to make the server "
+"look like a Xserve."
+msgstr ""
+"Netatalk が Spotlight および AFP stats サポート付きでビルドされた場合に有効に"
+"する。**mimic model** オプションはサーバーを Xserveのように見せるために使われ"
+"る。"
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:1279
+msgid "The home directory is mounted on */home/{user}/afp-data*."
+msgstr "ホームディレクトリは */home/{user}/afp-data* にマウントされる。"
+
+#. type: Fenced code block
+#: manpages/man5/afp.conf.5.md:1280
+#, no-wrap
+msgid ""
+"[Global]\n"
+"afpstats = yes\n"
+"spotlight = yes\n"
+"mimic model = RackMac\n"
+"\n"
+"[Home]\n"
+"basedir regex = /home\n"
+"path = afp-data\n"
+msgstr ""
+
+#. type: Title ##
+#: manpages/man5/afp.conf.5.md:1291
+#, no-wrap
+msgid "Example: Classic Mac clients"
+msgstr "例：レトロ Mac クライアント"
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:1297
+msgid ""
+"This enables AppleTalk if Netatalk was built with AppleTalk support.  The "
+"Random Number and ClearTxt authentication modules are used.  The **legacy "
+"icon** option is used to make the server look like a BSD Daemon."
+msgstr ""
+"Netatalk が AppleTalk サポートを付きでビルドされた場合に AppleTalk を有効にす"
+"る。Random Number と ClearTxt 認証モジュールが使われる。**legacy icon** オプ"
+"ションはサーバーを BSD デーモンのように見せるために使われる。"
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:1302
+msgid ""
+"With **legacy volume size** the volume size is limited to 2 GB for very old "
+"Macs, while **prodos** is used to enable ProDOS boot flags on the volume "
+"while limiting the volume free space to 32 MB."
+msgstr ""
+"**legacy volume size** でボリュームサイズは 2 GB に制限される。**prodos** は"
+"ボリュームに ProDOS ブートフラグを設定する上、ボリュームの空き領域は 32 MB に"
+"制限される。"
+
+#. type: Fenced code block
+#: manpages/man5/afp.conf.5.md:1303
+#, no-wrap
+msgid ""
+"[Global]\n"
+"appletalk = yes\n"
+"uam list = uams_dhx.so uams_dhx2.so uams_randnum.so uams_clrtxt.so\n"
+"legacy icon = daemon\n"
+"\n"
+"[Mac Volume]\n"
+"path = /srv/mac\n"
+"legacy volume size = yes\n"
+"\n"
+"[Apple II Volume]\n"
+"path = /srv/apple2\n"
+"prodos = yes\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:1322
 msgid ""
 "afpd(8), afppasswd(5), afp_signature.conf(5), extmap.conf(5), cnid_metad(8)"
 msgstr ""


### PR DESCRIPTION
Making the afp.conf man page a tad bit more helpful.