### PR TITLE
docker: Remove dependence on bash in entry script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ARG RUN_DEPS="\
     acl \
     avahi \
-    bash \
     cups \
     db \
     dbus \

--- a/Dockerfile.testsuite
+++ b/Dockerfile.testsuite
@@ -1,7 +1,6 @@
 ARG RUN_DEPS="\
     acl \
     avahi \
-    bash \
     cups \
     db \
     dbus \


### PR DESCRIPTION
Remove bash dependency in Dockerfile and refactor the entrypoint script to be POSIX compliant.