### PR TITLE
[4.1] meson: Look for shared Berkeley DB library in versioned subdir too

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -560,6 +560,10 @@ foreach dir : bdb_dirs
 
             foreach name : bdb_libnames
                 libdb = cc.find_library(name, dirs: bdb_libdir, required: false)
+                if not libdb.found()
+                    libdb = cc.find_library(name, dirs: bdb_libdir / subdir, required: false)
+                endif
+
                 if libdb.found()
                     have_bdb = true
                     break


### PR DESCRIPTION
Enables the build system to find bdb libs in a MacPorts environment.