### PR TITLE
meson: Clean up obsolete header and function checks

### DIFF
--- a/bin/aecho/aecho.c
+++ b/bin/aecho/aecho.c
@@ -33,15 +33,13 @@
 #include <sys/param.h>
 #include <sys/socket.h>
 #include <sys/time.h>
-#include <errno.h>
 
+#include <errno.h>
+#include <netdb.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef HAVE_NETDB_H
-#include <netdb.h>
-#endif /* HAVE_NETDB_H */
 
 #include <netatalk/endian.h>
 #include <netatalk/at.h>

--- a/bin/getzones/getzones.c
+++ b/bin/getzones/getzones.c
@@ -8,9 +8,7 @@
 #include <sys/uio.h>
 #include <sys/time.h>
 #include <unistd.h>
-#ifdef HAVE_NETDB_H
 #include <netdb.h>
-#endif /* HAVE_NETDB_H */
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/bin/nbp/nbplkup.c
+++ b/bin/nbp/nbplkup.c
@@ -32,9 +32,7 @@
 #include <atalk/util.h>
 #include <string.h>
 #include <stdio.h>
-#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
-#endif
 
 
 #include <atalk/unicode.h>

--- a/contrib/a2boot/a2boot.c
+++ b/contrib/a2boot/a2boot.c
@@ -45,19 +45,10 @@
 #include <atalk/logger.h>
 #include <stdio.h>
 #include <string.h>
-
-#ifdef HAVE_NETDB_H
 #include <netdb.h>
-#endif /* HAVE_NETDB_H */
 
 #include <fcntl.h>
-
-#ifdef HAVE_TERMIOS_H
 #include <termios.h>
-#endif /* HAVE_TERMIOS_H */
-#ifdef HAVE_SYS_TERMIOS_H
-#include <termios.h>
-#endif /* HAVE_SYS_TERMIOS_H */
 
 #define	TL_OK		'\0'
 #define TL_EOF		'\1'

--- a/contrib/timelord/timelord.c
+++ b/contrib/timelord/timelord.c
@@ -41,9 +41,7 @@
 #include <atalk/logger.h>
 #include <stdio.h>
 #include <string.h>
-#ifdef HAVE_NETDB_H
 #include <netdb.h>
-#endif /* HAVE_NETDB_H */
 
 #include <fcntl.h>
 

--- a/etc/afpd/afp_asp.c
+++ b/etc/afpd/afp_asp.c
@@ -16,19 +16,15 @@
 #include <stdlib.h>
 #include <string.h>
 #include <signal.h>
-#include <atalk/logger.h>
 #include <errno.h>
-#ifdef HAVE_SYS_TIME_H
 #include <sys/time.h>
-#endif /* HAVE_SYS_TIME_H */
-#ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
-#endif /* HAVE_SYS_STAT_H */
 
 #include <netatalk/endian.h>
 #include <atalk/atp.h>
 #include <atalk/asp.h>
 #include <atalk/compat.h>
+#include <atalk/logger.h>
 #include <atalk/util.h>
 #include <atalk/globals.h>
 #include <atalk/netatalk_conf.h>

--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -21,10 +21,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
-
-#ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
-#endif /* HAVE_SYS_STAT_H */
 
 #include <sys/time.h>
 #include <sys/types.h>

--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -14,11 +14,7 @@
 #include <arpa/inet.h>
 #include <ctype.h>
 #include <grp.h>
-
-#ifdef HAVE_NETDB_H
 #include <netdb.h>
-#endif /* HAVE_NETDB_H */
-
 #include <netinet/in.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/etc/afpd/nfsquota.c
+++ b/etc/afpd/nfsquota.c
@@ -44,9 +44,7 @@
 #include <sys/socket.h>
 #include <sys/param.h> /* for DEV_BSIZE */
 #include <sys/time.h>
-#ifdef HAVE_NETDB_H
 #include <netdb.h>
-#endif /* HAVE_NETDB_H */
 #include <netinet/in.h>
 #ifndef PORTMAP
 #define PORTMAP 1

--- a/etc/afpd/unix.h
+++ b/etc/afpd/unix.h
@@ -10,12 +10,6 @@
 #include <sys/vfs.h>
 #endif /* HAVE_SYS_VFS_H */
 
-#if defined(HAVE_STATFS_H)
-#include <sys/statfs.h>
-/* this might not be right. */
-#define f_mntfromname f_fname
-#endif /* HAVE_STATFS_H */
-
 #if defined(__svr4__) || defined(__NetBSD__)
 #include <sys/statvfs.h>
 #define statfs statvfs

--- a/include/atalk/globals.h
+++ b/include/atalk/globals.h
@@ -7,11 +7,7 @@
 #define AFPD_GLOBALS_H 1
 
 #include <grp.h>
-
-#ifdef HAVE_NETDB_H
 #include <netdb.h>
-#endif /* HAVE_NETDB_H */
-
 #include <stdbool.h>
 #include <sys/param.h>
 #include <sys/types.h>

--- a/libatalk/asp/asp_tickle.c
+++ b/libatalk/asp/asp_tickle.c
@@ -4,9 +4,7 @@
 
 #include <string.h>
 #include <atalk/logger.h>
-#ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
-#endif /* HAVE_SYS_TYPES_H */
 #include <errno.h>
 
 #include <sys/socket.h>

--- a/libatalk/dsi/dsi_tcp.c
+++ b/libatalk/dsi/dsi_tcp.c
@@ -13,11 +13,7 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <net/if.h>
-
-#ifdef HAVE_NETDB_H
 #include <netdb.h>
-#endif /* HAVE_NETDB_H */
-
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <signal.h>
@@ -30,8 +26,6 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
-
-
 
 #include <atalk/logger.h>
 

--- a/libatalk/nbp/nbp_lkup.c
+++ b/libatalk/nbp/nbp_lkup.c
@@ -7,6 +7,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <netdb.h>
 #include <string.h>
 #include <errno.h>
 #include <signal.h>
@@ -23,10 +24,6 @@
 #include <atalk/nbp.h>
 #include <atalk/netddp.h>
 #include <atalk/ddp.h>
-
-#ifdef HAVE_NETDB_H
-#include <netdb.h>
-#endif /* HAVE_NETDB_H */
 
 #include  "nbp_conf.h"
 

--- a/libatalk/nbp/nbp_rgstr.c
+++ b/libatalk/nbp/nbp_rgstr.c
@@ -7,6 +7,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <netdb.h>
 #include <string.h>
 #include <errno.h>
 #include <signal.h>
@@ -22,9 +23,6 @@
 #include <atalk/ddp.h>
 #include <atalk/netddp.h>
 
-#ifdef HAVE_NETDB_H
-#include <netdb.h>
-#endif /* HAVE_NETDB_H */
 #include  "nbp_conf.h"
 
 /* FIXME/SOCKLEN_T: socklen_t is a unix98 feature. */

--- a/libatalk/nbp/nbp_unrgstr.c
+++ b/libatalk/nbp/nbp_unrgstr.c
@@ -7,6 +7,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <netdb.h>
 #include <string.h>
 #include <errno.h>
 #include <signal.h>
@@ -22,9 +23,6 @@
 #include <atalk/netddp.h>
 #include <atalk/ddp.h>
 
-#ifdef HAVE_NETDB_H
-#include <netdb.h>
-#endif /* HAVE_NETDB_H */
 #include  "nbp_conf.h"
 
 /* FIXME/SOCKLEN_T: socklen_t is a unix98 feature. */

--- a/libatalk/nbp/nbp_util.c
+++ b/libatalk/nbp/nbp_util.c
@@ -7,6 +7,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <netdb.h>
 #include <string.h>
 #include <signal.h>
 
@@ -21,10 +22,6 @@
 #include <atalk/nbp.h>
 #include <atalk/ddp.h>
 #include <atalk/util.h>
-
-#ifdef HAVE_NETDB_H
-#include <netdb.h>
-#endif /* HAVE_NETDB_H */
 
 #include  "nbp_conf.h"
 

--- a/libatalk/util/ftw.c
+++ b/libatalk/util/ftw.c
@@ -37,10 +37,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if HAVE_SYS_PARAM_H
-# include <sys/param.h>
-#endif
-
+#include <sys/param.h>
 #include <sys/stat.h>
 #include <unistd.h>
 

--- a/meson.build
+++ b/meson.build
@@ -235,45 +235,23 @@ check_headers = [
     'acl/libacl.h',
     'attr/xattr.h',
     'dlfcn.h',
-    'dns_sd.h',
-    'errno.h',
-    'fcntl.h',
-    'inttypes.h',
     'langinfo.h',
     'linux/dqblk/xfs.h',
-    'linux/xfs/fs.h',
     'linux/xqm.h',
     'locale.h',
     'mntent.h',
-    'netdb.h',
     'pam/pam_appl.h',
-    'poll.h',
     'security/pam_appl.h',
     'sgtty.h',
-    'statfs.h',
-    'stdint.h',
-    'stdio.h',
-    'stdlib.h',
-    'string.h',
-    'strings.h',
     'sys/attr.h',
     'sys/attributes.h',
     'sys/ea.h',
     'sys/extattr.h',
     'sys/mnttab.h',
     'sys/mount.h',
-    'sys/param.h',
-    'sys/stat.h',
-    'sys/statvfs.h',
-    'sys/types.h',
-    'sys/uio.h',
     'sys/vfs.h',
     'sys/xattr.h',
-    'termios.h',
     'ufs/quota.h',
-    'unistd.h',
-    'xfs/libxfs.h',
-    'xfs/xfs/fs.h',
     'xfs/xqm.h',
 ]
 
@@ -291,24 +269,14 @@ check_functions = [
     'asprintf',
     'backtrace_symbols',
     'dirfd',
-    'dlclose',
-    'dlerror',
-    'dlopen',
-    'dlsym',
-    'errno',
-    'getpagesize',
-    'getusershell',
-    'mmap',
     'pread',
     'pselect',
     'pwrite',
-    'setlinebuf',
-    'shl_load',
+    'rresvport',
     'splice',
     'strlcat',
     'strlcpy',
     'strnlen',
-    'utime',
     'vasprintf',
 ]
 
@@ -343,10 +311,6 @@ foreach f : at_functions
         cdata.set('HAVE_ATFUNCS', 1)
     endif
 endforeach
-
-if cc.has_function('rresvport')
-    cdata.set('HAVE_RRESVPORT', 1)
-endif
 
 ##########################
 # Type and member checks #
@@ -1097,7 +1061,6 @@ if host_os == 'sunos'
 elif host_os == 'freebsd'
     have_ea = true
     ea_functions = [
-        'extattr_delete_fd',
         'extattr_delete_file',
         'extattr_delete_link',
         'extattr_get_fd',
@@ -1123,15 +1086,12 @@ elif host_os == 'aix'
     have_ea = true
     ea_functions = [
         'fgetea',
-        'flistea',
-        'fremoveea',
         'fsetea',
         'getea',
         'lgetea',
         'listea',
         'llistea',
         'lremoveea',
-        'lsetea',
         'removeea',
         'setea',
     ]
@@ -1147,7 +1107,6 @@ elif cc.has_function('getxattr', dependencies: attr)
     ea_functions = [
         'fgetxattr',
         'flistxattr',
-        'fremovexattr',
         'fsetxattr',
         'getxattr',
         'lgetxattr',

--- a/test/testsuite/afpclient.h
+++ b/test/testsuite/afpclient.h
@@ -10,17 +10,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef HAVE_UNISTD_H
 #include <unistd.h>
-#endif /* HAVE_UNISTD_H */
-#ifdef HAVE_FCNTL_H
 #include <fcntl.h>
-#endif /* HAVE_FCNTL_H */
 #include <signal.h>
-
-#ifdef HAVE_BYTESWAP_H
-#include <byteswap.h>
-#endif
 
 #include <sys/types.h>
 #include <sys/stat.h>


### PR DESCRIPTION
This eliminates redundant header and function checks inherited from Autotools. Speeds up the setup process notably: for instance on my MacBook Pro M1, 8s -> 7s. (Should be even more notable on slower systems.)