### PR TITLE
GitHub CI: Build without Spotlight support on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,17 +358,13 @@ jobs:
           brew update
           brew upgrade
           brew install \
-            bison \
             cmark-gfm \
             cracklib \
-            dbus \
             iniparser \
             mariadb \
             meson \
             openldap \
-            po4a \
-            talloc \
-            tracker
+            po4a
       - name: Configure
         run: |
           meson setup build \


### PR DESCRIPTION
…because tracker is going away

Homebrew has flagged the tracker formula for deletion in early 2026. At the same time, Homebrew does not support tinysparql on macOS (only Linux.)

Without either of those, Spotlight cannot be built, so removing the entire stack.