### PR TITLE
GitHub CI: SonarQube static analysis in own workflow, using v4 action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,3 @@
-name: Builds
 on:
   push:
     branches:
@@ -9,10 +8,9 @@ on:
       - "**/COPYING"
       - "**/README*"
       - "contrib/webmin_module/**"
-      - "CONTRIBUTORS"
+      - "COPYING"
       - "COPYRIGHT"
       - "Dockerfile*"
-      - "NEWS"
   pull_request:
     branches:
       - main
@@ -26,10 +24,11 @@ on:
       - "**/COPYING"
       - "**/README*"
       - "contrib/webmin_module/**"
-      - "CONTRIBUTORS"
+      - "COPYING"
       - "COPYRIGHT"
       - "Dockerfile*"
-      - "NEWS"
+
+name: Builds
 
 jobs:
   build-alpine:
@@ -703,64 +702,3 @@ jobs:
             asip-status localhost
             svcadm -v disable svc:/network/netatalk:default
             ninja -C build uninstall
-
-  static_analysis:
-    name: Static Analysis
-    runs-on: ubuntu-latest
-    env:
-      # Directory where build-wrapper output will be placed
-      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
-    if: ${{ !github.event.pull_request.head.repo.fork }} # Run only if not originating from a fork
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          # Check out commit history for all branches and tags, for a better relevancy of analysis
-          fetch-depth: 0
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install --assume-yes --no-install-recommends \
-            bison \
-            cracklib-runtime \
-            flex \
-            libacl1-dev \
-            libavahi-client-dev \
-            libcrack2-dev \
-            libcups2-dev \
-            libdb-dev \
-            libdbus-1-dev \
-            libevent-dev \
-            libgcrypt20-dev \
-            libglib2.0-dev \
-            libiniparser-dev \
-            libkrb5-dev \
-            libldap2-dev \
-            libmariadb-dev \
-            libpam0g-dev \
-            libtalloc-dev \
-            libtirpc-dev \
-            libtracker-sparql-3.0-dev \
-            libwrap0-dev \
-            meson \
-            ninja-build \
-            systemtap-sdt-dev \
-            tracker-miner-fs
-      - name: Install sonar-scanner and build-wrapper
-        uses: SonarSource/sonarcloud-github-c-cpp@v3
-      - name: Run build-wrapper
-        run: |
-          mkdir -p ${{ env.BUILD_WRAPPER_OUT_DIR }}
-          meson setup build \
-            -Dbuildtype=debug \
-            -Dwith-appletalk=true \
-            -Dwith-docs= \
-            -Dwith-init-style=none \
-            -Dwith-tests=true \
-            -Dwith-testsuite=true
-          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} meson compile -C build
-      - name: Run sonar-scanner
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          sonar-scanner --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,5 +1,3 @@
-name: Containers
-
 on:
     push:
         branches: [ "main" ]
@@ -26,6 +24,8 @@ env:
     REGISTRY: ghcr.io
     REPO: ${{ github.repository }}
 
+name: Containers
+    
 jobs:
     build-container:
         name: Build Netatalk container

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,5 +1,3 @@
-name: Deploy static content to Pages
-
 on:
   push:
     branches: ["main"]
@@ -22,6 +20,8 @@ permissions:
 concurrency:
   group: "pages"
   cancel-in-progress: false
+
+name: Deploy static content to Pages
 
 jobs:
   deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,100 @@
+on:
+  push:
+    branches:
+      - main
+      - branch-*
+    paths-ignore:
+      - "**.md"
+      - "**/COPYING"
+      - "**/README*"
+      - "config/**"
+      - "contrib/**"
+      - "distrib/**"
+      - "doc/**"
+      - "COPYING"
+      - "COPYRIGHT"
+      - "Dockerfile*"
+  pull_request:
+    branches:
+      - main
+      - branch-*
+    types:
+      - opened
+      - synchronize
+      - reopened
+    paths-ignore:
+        - "**.md"
+        - "**/COPYING"
+        - "**/README*"
+        - "config/**"
+        - "contrib/**"
+        - "distrib/**"
+        - "doc/**"
+        - "COPYING"
+        - "COPYRIGHT"
+        - "Dockerfile*"
+
+name: Tests
+
+jobs:
+    static_analysis:
+        name: Static Analysis
+        runs-on: ubuntu-latest
+        # Run only if not originating from a fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        env:
+          BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
+        steps:
+        - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0
+        - name: Install Build Wrapper
+          uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v4
+        - name: Install dependencies
+          run: |
+            sudo apt-get update
+            sudo apt-get install --assume-yes --no-install-recommends \
+                bison \
+                cracklib-runtime \
+                flex \
+                libacl1-dev \
+                libavahi-client-dev \
+                libcrack2-dev \
+                libcups2-dev \
+                libdb-dev \
+                libdbus-1-dev \
+                libevent-dev \
+                libgcrypt20-dev \
+                libglib2.0-dev \
+                libiniparser-dev \
+                libkrb5-dev \
+                libldap2-dev \
+                libmariadb-dev \
+                libpam0g-dev \
+                libtalloc-dev \
+                libtirpc-dev \
+                libtracker-sparql-3.0-dev \
+                libwrap0-dev \
+                meson \
+                ninja-build \
+                systemtap-sdt-dev \
+                tracker-miner-fs
+        - name: Run build wrapper
+          run: |
+            mkdir -p ${{ env.BUILD_WRAPPER_OUT_DIR }}
+            meson setup build \
+                -Dbuildtype=debug \
+                -Dwith-appletalk=true \
+                -Dwith-docs= \
+                -Dwith-init-style=none \
+                -Dwith-tests=true \
+                -Dwith-testsuite=true
+            build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} meson compile -C build
+        - name: Run SonarQube scan
+          uses: sonarsource/sonarqube-scan-action@v4
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          with:
+            args: >
+              --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json" 


### PR DESCRIPTION
The Sonarqube github actions have been renamed and updated. Migration is mandatory.

https://github.com/SonarSource/sonarqube-scan-action