### PR TITLE
libatalk: Plug another two potential memory leaks

### DIFF
--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2193,14 +2193,14 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     if ((p = INIPARSER_GETSTRDUP(config, "Global:ddp zone", NULL))) {
         if (strlen(p) <= 32)
         {
-            EC_NULL_LOG(options->zone = strdup(p));
+            options->zone = strdup(p);
         }
         free(p);
     }
 #endif
 
     if ((p = INIPARSER_GETSTRDUP(config, "Global:hostname", NULL))) {
-        EC_NULL_LOG( options->hostname = strdup(p) );
+        options->hostname = strdup(p);
         free(p);
     } else {
         if (gethostname(val, sizeof(val)) < 0 ) {


### PR DESCRIPTION
I don't think we need this extra error handling for strdup() operations on variables that were strduped just before. The error handling macros breaks out of the function without freeing the memory.