### PR TITLE
libatalk: Use file descriptors and exclusive access to avoid TOCTOU conditions

### DIFF
--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -1019,6 +1019,10 @@ char *attr_name="test416_attribute";
         test_skipped(T_AFP32);
         goto test_exit;
     }
+	if (adouble == AD_V2) {
+		test_skipped(T_ADEA);
+		goto test_exit;
+	}
 
     if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_EXTATTRS)) {
         test_skipped(T_UTF8);

--- a/test/testsuite/FPGetACL.c
+++ b/test/testsuite/FPGetACL.c
@@ -61,6 +61,10 @@ char *attr_name="test399_attribute";
         test_skipped(T_AFP3);
         goto test_exit;
     }
+	if (adouble == AD_V2) {
+		test_skipped(T_ADEA);
+		goto test_exit;
+	}
 
     if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_EXTATTRS)) {
         test_skipped(T_UTF8);


### PR DESCRIPTION
Refactoring write_ea operation in the libatalk vfs module to be more concurrency safe.