### PR TITLE
Make testsuite AppleDouble v2 compatible, and run it in CI

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -280,6 +280,52 @@ jobs:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
+    afp-adtest-afp34:
+      name: AFP spec test (adouble v2) - AFP 3.4
+      needs: build-container-testsuite
+      runs-on: ubuntu-latest
+      timeout-minutes: 5
+      env:
+          AFP_USER: atalk1
+          AFP_USER2: atalk2
+          AFP_PASS: afpafp
+          AFP_PASS2: afpafp
+          AFP_GROUP: afpusers
+          SHARE_NAME: test1
+          SHARE_NAME2: test2
+          INSECURE_AUTH: 1
+          DISABLE_TIMEMACHINE: 1
+          VERBOSE: 1
+          AFP_ADOUBLE: 1
+          TESTSUITE: spectest
+          AFP_VERSION: 7
+      steps:
+          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+
+
+    afp-adtest-afp21:
+      name: AFP spec test (adouble v2) - AFP 2.1
+      needs: build-container-testsuite
+      runs-on: ubuntu-latest
+      timeout-minutes: 5
+      env:
+          AFP_USER: atalk1
+          AFP_USER2: atalk2
+          AFP_PASS: afpafp
+          AFP_PASS2: afpafp
+          AFP_GROUP: afpusers
+          SHARE_NAME: test1
+          SHARE_NAME2: test2
+          INSECURE_AUTH: 1
+          DISABLE_TIMEMACHINE: 1
+          VERBOSE: 1
+          AFP_ADOUBLE: 1
+          TESTSUITE: spectest
+          AFP_VERSION: 1
+      steps:
+          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+
+
     afp-rotest-afp34:
       name: AFP spec test (Readonly) - AFP 3.4
       needs: build-container-testsuite

--- a/test/testsuite/FPGetACL.c
+++ b/test/testsuite/FPGetACL.c
@@ -117,6 +117,10 @@ STATIC void test432()
 		goto test_exit;
 	}
 
+	if (adouble == AD_V2) {
+		test_skipped(T_ADEA);
+		goto test_exit;
+	}
 	if ( !(get_vol_attrib(vol) & VOLPBIT_ATTR_EXTATTRS)) {
 		test_skipped(T_UTF8);
 		goto test_exit;

--- a/test/testsuite/T2_FPMoveAndRename.c
+++ b/test/testsuite/T2_FPMoveAndRename.c
@@ -174,13 +174,25 @@ int id1;
 
 	id = get_fid(Conn, vol, dir , name1);
 
-	sprintf(temp,"%s/%s/%s", Path, name, name1);
-	sprintf(temp1,"%s/%s/%s", Path, name, name2);
-	if (rename(temp, temp1) < 0) {
-		if (!Quiet) {
-			fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
+	if (adouble == AD_V2) {
+		if (rename_unix_file(Path, name, name1, name2) < 0) {
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to rename \"%s/%s/%s\" to \"%s\" :%s\n", Path, name, name1, name2, strerror(errno));
+			}
+			test_failed();
+			goto fin;
 		}
-		test_failed();
+	}
+	else {
+		sprintf(temp,"%s/%s/%s", Path, name, name1);
+		sprintf(temp1,"%s/%s/%s", Path, name, name2);
+		if (rename(temp, temp1) < 0) {
+			if (!Quiet) {
+				fprintf(stdout,"\tFAILED unable to rename \"%s\" to \"%s\" :%s\n", temp, temp1, strerror(errno));
+			}
+			test_failed();
+			goto fin;
+		}
 	}
 
 	id1 = get_fid(Conn, vol, dir , name2);
@@ -190,6 +202,7 @@ int id1;
 		}
 		test_failed();
 	}
+fin:
 	FAIL (FPDelete(Conn, vol,  dir , name2))
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT, name))
 test_exit:

--- a/test/testsuite/T2_FPOpenFork.c.in
+++ b/test/testsuite/T2_FPOpenFork.c.in
@@ -1344,6 +1344,10 @@ STATIC void test431()
 		test_skipped(T_PATH);
 		goto test_exit;
 	}
+	if (adouble == AD_V2) {
+		test_skipped(T_ADEA);
+		goto test_exit;
+	}
 	if (Conn->afp_version < 31) {
 		test_skipped(T_AFP31);
 		goto test_exit;


### PR DESCRIPTION
The testsuite needed minor fixes to fully pass when using ad v2 metadata. First, test302 is updated with the correct rename function that also moves the appledouble metadata files, while test431 and test432 are skipped because they concern EA metadata.

Now let's run tests for AppleDouble v2 in the pipeline in addition to the standard filesystem EA. The metadata logic is entirely different and is known to be fragile.