### PR TITLE
docs: Create a more navigation friendly local html manual

### DIFF
--- a/doc/manual/_Navlinks.md
+++ b/doc/manual/_Navlinks.md
@@ -1,0 +1,9 @@
+# Table of Contents
+
+* [Introduction](index.html)
+* [Installation](Installation.html)
+* [Configuration](Configuration.html)
+* [AppleTalk](AppleTalk.html)
+* [Upgrading](Upgrading.html)
+* [Compilation](Compilation.html)
+* [License](License.html)

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -1,7 +1,10 @@
 manual_pages = [
+    'Compilation',
     'Configuration',
     'Installation',
+    'License',
     'Upgrading',
+    'index',
 ]
 
 if have_appletalk
@@ -13,9 +16,6 @@ endif
 if get_option('with-website')
     manual_pages += [
         '_Sidebar',
-        'Compilation',
-        'index',
-        'License',
     ]
 
     python = find_program('python3', required: false)
@@ -30,22 +30,22 @@ if get_option('with-website')
     foreach page : manual_pages
         install_data(page + '.md', install_dir: manual_install_path + '/en')
     endforeach
-else
-    foreach page : manual_pages
-        custom_target(
-            'manual_' + page,
-            input: page + '.md',
-            output: page + '.html',
-            command: [
-                cmarkgfm,
-                '--smart',
-                '--extension', 'table',
-                '--to', 'html',
-                '@INPUT@',
-            ],
-            capture: true,
-            install: true,
-            install_dir: manual_install_path,
-        )
-    endforeach
 endif
+
+foreach page : manual_pages
+    custom_target(
+        'manual_' + page,
+        input: ['_Navlinks.md', page + '.md'],
+        output: page + '.html',
+        command: [
+            cmarkgfm,
+            '--smart',
+            '--extension', 'table',
+            '--to', 'html',
+            '@INPUT@',
+        ],
+        capture: true,
+        install: true,
+        install_dir: manual_install_path,
+    )
+endforeach


### PR DESCRIPTION
This brings back rudimentary navigation links for the html manual generated for local consumption.