### PR TITLE
docs: Correct description of hostname option in afp.conf

### DIFF
--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -440,10 +440,9 @@ combination but not automatically listen to it.
 
 hostname = <name\> **(G)**
 
-> Use this instead of the result from calling hostname for determining
-which IP address to advertise, therefore the hostname is resolved to an
-IP which is the advertised. This is NOT used for listening and it is
-also overwritten by **afp listen**.
+> Sets a custom AFP server name to be displayed in the client.
+When absent, the fallback server name is the host system's hostname
+up until the first period.
 
 max connections = <number\> **(G)**
 


### PR DESCRIPTION
The afp.conf man page was still using the description of the old `-hostname` option in netatalk 2.x verbatim, despite the behavior having changed completely as of 3.x.

Thanks to thecloud on 68kmla for reporting this.