### PR TITLE
libatalk: Introduce standardized interface for iniparser

### DIFF
--- a/contrib/macipgw/main.c
+++ b/contrib/macipgw/main.c
@@ -177,11 +177,11 @@ macip_options * read_options(const char *conf)
 
     if ((config = iniparser_load(conf)) == NULL)
         return NULL;
-    options->network = INIPARSER_GETSTRDUP(config, "Global:network", "");
-    options->netmask = INIPARSER_GETSTRDUP(config, "Global:netmask", "");
-    options->nameserver = INIPARSER_GETSTRDUP(config, "Global:nameserver", "");
-    options->zone = INIPARSER_GETSTRDUP(config, "Global:zone", "");
-    options->unprivileged_user = INIPARSER_GETSTRDUP(config, "Global:unprivileged user", "");
+    options->network = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL, "network", "");
+    options->netmask = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL, "netmask", "");
+    options->nameserver = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL, "nameserver", "");
+    options->zone = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL, "zone", "");
+    options->unprivileged_user = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL, "unprivileged user", "");
 
 	iniparser_freedict(config);
 

--- a/etc/afpd/afp_config.c
+++ b/etc/afpd/afp_config.c
@@ -330,33 +330,32 @@ int configinit(AFPObj *dsi_obj, AFPObj *asp_obj)
     acl_ldap_readconfig(dsi_obj->iniconfig);
 #endif /* HAVE_LDAP */
 
-    if ((r = iniparser_getstring(dsi_obj->iniconfig, "Global:fce listener", NULL))) {
+    if ((r = INIPARSER_GETSTR(dsi_obj->iniconfig, INISEC_GLOBAL, "fce listener", NULL))) {
 		LOG(log_note, logtype_afpd, "Adding FCE listener: %s", r);
 		fce_add_udp_socket(r);
     }
-    if ((r = iniparser_getstring(dsi_obj->iniconfig, "Global:fce coalesce", NULL))) {
+    if ((r = INIPARSER_GETSTR(dsi_obj->iniconfig, INISEC_GLOBAL, "fce coalesce", NULL))) {
 		LOG(log_note, logtype_afpd, "Fce coalesce: %s", r);
 		fce_set_coalesce(r);
     }
-    if ((r = iniparser_getstring(dsi_obj->iniconfig, "Global:fce events", NULL))) {
+    if ((r = INIPARSER_GETSTR(dsi_obj->iniconfig, INISEC_GLOBAL, "fce events", NULL))) {
 		LOG(log_note, logtype_afpd, "Fce events: %s", r);
 		fce_set_events(r);
     }
-    r = iniparser_getstring(dsi_obj->iniconfig, "Global:fce version", "1");
+    r = INIPARSER_GETSTR(dsi_obj->iniconfig, INISEC_GLOBAL, "fce version", "1");
     LOG(log_debug, logtype_afpd, "Fce version: %s", r);
     dsi_obj->fce_version = atoi(r);
 
-    if ((r = iniparser_getstring(dsi_obj->iniconfig, "Global:fce ignore names", ".DS_Store"))) {
+    if ((r = INIPARSER_GETSTR(dsi_obj->iniconfig, INISEC_GLOBAL, "fce ignore names", ".DS_Store"))) {
         dsi_obj->fce_ign_names = strdup(r);
     }
-    if ((r = iniparser_getstring(dsi_obj->iniconfig, "Global:fce ignore directories", NULL))) {
+    if ((r = INIPARSER_GETSTR(dsi_obj->iniconfig, INISEC_GLOBAL, "fce ignore directories", NULL))) {
             dsi_obj->fce_ign_directories = strdup(r);
     }
 
-    if ((r = iniparser_getstring(dsi_obj->iniconfig, "Global:fce notify script", NULL))) {
+    if ((r = INIPARSER_GETSTR(dsi_obj->iniconfig, INISEC_GLOBAL, "fce notify script", NULL))) {
         dsi_obj->fce_notify_script = strdup(r);
     }
-
 
 
 EC_CLEANUP:

--- a/etc/afpd/spotlight.c
+++ b/etc/afpd/spotlight.c
@@ -1330,7 +1330,7 @@ int spotlight_init(AFPObj *obj)
     sl_ctx = talloc_zero(NULL, struct sl_ctx);
     obj->sl_ctx = sl_ctx;
 
-    attributes = iniparser_getstring(obj->iniconfig, "Global:spotlight attributes", NULL);
+    attributes = INIPARSER_GETSTR(obj->iniconfig, INISEC_GLOBAL, "spotlight attributes", NULL);
     if (attributes) {
         configure_spotlight_attributes(attributes);
     }

--- a/etc/cnid_dbd/cnid_metad.c
+++ b/etc/cnid_dbd/cnid_metad.c
@@ -500,7 +500,7 @@ int main(int argc, char *argv[])
 
     (void)setlimits();
 
-    host = INIPARSER_GETSTRDUP(obj.iniconfig, "Global:cnid listen", "localhost:4700");
+    host = INIPARSER_GETSTRDUP(obj.iniconfig, INISEC_GLOBAL, "cnid listen", "localhost:4700");
     if ((port = strrchr(host, ':')))
         *port++ = 0;
     else

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -487,7 +487,7 @@ int main(int argc, char **argv)
         setenv("XDG_CACHE_HOME", _PATH_STATEDIR, 0);
         setenv("TRACKER_USE_LOG_FILES", "1", 0);
 
-        dbus_path = iniparser_getstring(obj.iniconfig, "Global:dbus daemon", DBUS_DAEMON_PATH);
+        dbus_path = INIPARSER_GETSTR(obj.iniconfig, INISEC_GLOBAL, "dbus daemon", DBUS_DAEMON_PATH);
         LOG(log_note, logtype_default, "Starting dbus: %s", dbus_path);
         if ((dbus_pid = run_process(dbus_path, "--config-file=" _PATH_CONFDIR "dbus-session.conf", NULL)) == NETATALK_SRV_ERROR) {
             LOG(log_error, logtype_default, "Error starting '%s'", dbus_path);

--- a/include/atalk/globals.h
+++ b/include/atalk/globals.h
@@ -82,8 +82,16 @@
 #define INISEC_GLOBAL "global"
 #define INISEC_HOMES  "homes"
 
-#define INIPARSER_GETSTRDUP(config, section, default) ({              \
-    const char *_tmp = iniparser_getstring(config, section, default); \
+#define INIPARSER_GETSTR(config, section, key, default) ({            \
+    char _option[MAXOPTLEN];                                          \
+    snprintf(_option, sizeof(_option), "%s:%s", section, key);        \
+    iniparser_getstring(config, _option, default);                    \
+})
+
+#define INIPARSER_GETSTRDUP(config, section, key, default) ({         \
+    char _option[MAXOPTLEN];                                          \
+    snprintf(_option, sizeof(_option), "%s:%s", section, key);        \
+    const char *_tmp = iniparser_getstring(config, _option, default); \
     _tmp ? strdup(_tmp) : NULL;                                       \
 })
 

--- a/libatalk/acl/ldap_config.c
+++ b/libatalk/acl/ldap_config.c
@@ -56,7 +56,7 @@ int acl_ldap_readconfig(dictionary *iniconfig)
     /* now see if its a correct pref */
     for (i = 0; ldap_prefs[i].name != NULL; i++) {
         char option[MAXOPTLEN];
-        snprintf(option, sizeof(option), "Global:%s", ldap_prefs[i].name);
+        snprintf(option, sizeof(option), "%s:%s", INISEC_GLOBAL, ldap_prefs[i].name);
         if ((val = iniparser_getstring(iniconfig, option, NULL))) {
             /* check if we have pre-defined values */
             if (ldap_prefs[i].intfromarray == 0) {


### PR DESCRIPTION
Three new local utility functions in netatalk_conf that wrap iniparser calls, as well as allow for the use of presets:

- getoption_str() which a renamed getoption()
- getoption_strdup() which returns a dynamically allocated string
- getoption_int() which returns an integer

All of these are now consistently applied throughout netatalk_conf.c

For the global usecase, where presets aren't relevant, we now use these two macros consistently:

- INIPARSER_GETSTR
- INIPARSER_GETSTRDUP

This also allows us to get back to using the INISEC_GLOBAL and INISEC_HOMES macros for section names, rather than hard coded strings.