### PR TITLE
docs: Elaborate on the relationship between cnid server and cnid listen

### DIFF
--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -399,8 +399,9 @@ operating system supports the AppleTalk networking protocol.
 
 cnid listen = <ip address\[:port\] \[ip address\[:port\] ...\]\> **(G)**
 
-> Specifies the IP address that the CNID server should listen on. The
-default is **localhost:4700**.
+> Specifies the IP address and port that the CNID server should listen on.
+This should match the address and port of the **cnid server** option
+for most deployments. The default is **localhost:4700**.
 
 ddp address = <ddp address\> **(G)**
 
@@ -547,10 +548,12 @@ privileges.
 
 cnid server = <ipaddress\[:port\]\> **(G)**/**(V)**
 
-> Specifies the IP address and port of a cnid_metad server, required for
-CNID dbd backend. Defaults to localhost:4700. The network address may be
-specified either in dotted-decimal format for IPv4 or in hexadecimal
-format for IPv6.-
+> Specifies the IP address and port of a cnid_metad server, required
+for the CNID dbd backend. This should match the address and port of the
+**cnid listen** option for most deployments. Defaults to localhost:4700.
+
+> The network address may be specified either in dotted-decimal format
+for IPv4 or in hexadecimal format for IPv6.
 
 dbus daemon = <path\> **(G)**
 

--- a/doc/po/afp.conf.5.md.ja.po
+++ b/doc/po/afp.conf.5.md.ja.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-02-23 14:13+0100\n"
+"POT-Creation-Date: 2025-02-23 15:03+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -66,7 +66,7 @@ msgstr "概要"
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
 #: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1351
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1354
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
@@ -88,7 +88,7 @@ msgstr "著者"
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
 #: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1353
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1356
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
@@ -105,7 +105,7 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1346 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1349 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
 #: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
@@ -120,7 +120,7 @@ msgstr "関連項目"
 #: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:50
 #: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
 #: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1296
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1299
 #: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
 #: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
@@ -131,9 +131,9 @@ msgstr "例"
 #: manpages/man1/afppasswd.1.md:20 manpages/man5/afp_signature.conf.5.md:21
 #: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:334
 #: manpages/man5/afp.conf.5.md:358 manpages/man5/afp.conf.5.md:371
-#: manpages/man5/afp.conf.5.md:386 manpages/man5/afp.conf.5.md:738
-#: manpages/man5/afp.conf.5.md:1065 manpages/man5/afp.conf.5.md:1190
-#: manpages/man5/afp.conf.5.md:1228 manpages/man8/papd.8.md:96
+#: manpages/man5/afp.conf.5.md:386 manpages/man5/afp.conf.5.md:741
+#: manpages/man5/afp.conf.5.md:1068 manpages/man5/afp.conf.5.md:1193
+#: manpages/man5/afp.conf.5.md:1231 manpages/man8/papd.8.md:96
 #: manual/Configuration.md:113
 #, no-wrap
 msgid "> **NOTE**\n"
@@ -465,7 +465,7 @@ msgid ""
 msgstr "(H)の印がついているパラメータはこのボリュームセクション用である。"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:129 manpages/man5/afp.conf.5.md:992
+#: manpages/man5/afp.conf.5.md:129 manpages/man5/afp.conf.5.md:995
 #, no-wrap
 msgid "Parameters"
 msgstr "パラメータ"
@@ -1168,21 +1168,22 @@ msgid "cnid listen = <ip address\\[:port\\] \\[ip address\\[:port\\] ...\\]\\> *
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:404
+#: manpages/man5/afp.conf.5.md:405
 #, no-wrap
 msgid ""
-"> Specifies the IP address that the CNID server should listen on. The\n"
-"default is **localhost:4700**.\n"
-msgstr "> CNIDサーバがリッスンするIPアドレスを指定する。デフォルトは**localhost:4700**である。\n"
+"> Specifies the IP address and port that the CNID server should listen on.\n"
+"This should match the address and port of the **cnid server** option\n"
+"for most deployments. The default is **localhost:4700**.\n"
+msgstr "> CNIDサーバがリッスンするIPアドレスとポートを指定する。これはほとんどのデプロイメントで**cnid server**オプションと一致するべきである。デフォルトは**localhost:4700**である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:406
+#: manpages/man5/afp.conf.5.md:407
 #, no-wrap
 msgid "ddp address = <ddp address\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:410
+#: manpages/man5/afp.conf.5.md:411
 #, no-wrap
 msgid ""
 "> Specifies the DDP address of the server. The default is to auto-assign\n"
@@ -1194,13 +1195,13 @@ msgstr ""
 "を実行している場合にのみ役立つ。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:412
+#: manpages/man5/afp.conf.5.md:413
 #, no-wrap
 msgid "ddp zone = <ddp zone\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:416
+#: manpages/man5/afp.conf.5.md:417
 #, no-wrap
 msgid ""
 "> Specifies the AppleTalk zone to register the server in. The default is\n"
@@ -1212,13 +1213,13 @@ msgstr ""
 "ゾーンにサーバーが登録される。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:418
+#: manpages/man5/afp.conf.5.md:419
 #, no-wrap
 msgid "disconnect time = <number\\> **(G)**\n"
 msgstr "splice size = <number\\> (デフォルト: *64k*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:421
+#: manpages/man5/afp.conf.5.md:422
 #, no-wrap
 msgid ""
 "> Keep disconnected AFP sessions for <number\\> hours before dropping them.\n"
@@ -1226,13 +1227,13 @@ msgid ""
 msgstr "> ドロップする前に、切断されたAFPセッションを<number\\>時間維持する。デフォルトは24時間である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:423
+#: manpages/man5/afp.conf.5.md:424
 #, no-wrap
 msgid "dsireadbuf = <number\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:431
+#: manpages/man5/afp.conf.5.md:432
 #, no-wrap
 msgid ""
 "> Scale factor that determines the size of the DSI/TCP readahead buffer,\n"
@@ -1251,13 +1252,13 @@ msgstr ""
 "(バッファサイズ \\* クライアント数)。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:433
+#: manpages/man5/afp.conf.5.md:434
 #, no-wrap
 msgid "fqdn = <name\\[:port\\]\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:440
+#: manpages/man5/afp.conf.5.md:441
 #, no-wrap
 msgid ""
 "> Specifies a fully-qualified domain name, with an optional port. This is\n"
@@ -1272,13 +1273,13 @@ msgstr ""
 "3.8.3以前はこのオプションを評価しない。このオプションはデフォルトで無効である。これによりクライアント側は名前解決を二段階踏むことになるので注意して使ってください。afpdはこのname:portの組み合わせを宣伝するが自動的にはリッスンしないことにも注意してください。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:442
+#: manpages/man5/afp.conf.5.md:443
 #, no-wrap
 msgid "hostname = <name\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:447
+#: manpages/man5/afp.conf.5.md:448
 #, no-wrap
 msgid ""
 "> Use this instead of the result from calling hostname for determining\n"
@@ -1288,13 +1289,13 @@ msgid ""
 msgstr "> 宣伝用のIPアドレスを決定するため、ホスト名の呼出結果の代わりにこれを用いる。従って、このホスト名から宣伝用IPアドレスが解決されるようになる。これはリスニングには使われないし、**afp listen**によって上書きされてしまう。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:449
+#: manpages/man5/afp.conf.5.md:450
 #, no-wrap
 msgid "max connections = <number\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:452
+#: manpages/man5/afp.conf.5.md:453
 #, no-wrap
 msgid ""
 "> Sets the maximum number of clients that can simultaneously connect to\n"
@@ -1302,13 +1303,13 @@ msgid ""
 msgstr "> 同時にサーバに接続できるクライアントの最大数を設定する(デフォルトは200)。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:454
+#: manpages/man5/afp.conf.5.md:455
 #, no-wrap
 msgid "server quantum = <number\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:459
+#: manpages/man5/afp.conf.5.md:460
 #, no-wrap
 msgid ""
 "> This specifies the DSI server quantum. The default value is 0x100000 (1\n"
@@ -1320,13 +1321,13 @@ msgstr ""
 "(1MiB)である。最大値は0xFFFFFFFFFであり最小値は32000である。範囲外の値を指定した場合、デフォルト値が設定される。自分が何をしようとしているか確信がない限り、この値を変更しないでください。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:461
+#: manpages/man5/afp.conf.5.md:462
 #, no-wrap
 msgid "sleep time = <number\\> **(G)**\n"
 msgstr "splice size = <number\\> (デフォルト: *64k*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:464
+#: manpages/man5/afp.conf.5.md:465
 #, no-wrap
 msgid ""
 "> Keep sleeping AFP sessions for <number\\> hours before disconnecting\n"
@@ -1334,13 +1335,13 @@ msgid ""
 msgstr "> スリープモードにおいてクライアントを切断する前に、スリープ中のAFPセッションを<number\\>時間維持する。デフォルトは10時間である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:466
+#: manpages/man5/afp.conf.5.md:467
 #, no-wrap
 msgid "tcprcvbuf = <number\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:469
+#: manpages/man5/afp.conf.5.md:470
 #, no-wrap
 msgid ""
 "> Try to set TCP receive buffer using setsockopt(). Often OSes impose\n"
@@ -1348,13 +1349,13 @@ msgid ""
 msgstr "> setsockopt()を使ってTCP受信バッファの設定を試みる。しばしばOSはこの値を設定しようとするアプリケーションの資格を制限する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:471
+#: manpages/man5/afp.conf.5.md:472
 #, no-wrap
 msgid "tcpsndbuf = <number\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:474
+#: manpages/man5/afp.conf.5.md:475
 #, no-wrap
 msgid ""
 "> Try to set TCP send buffer using setsockopt(). Often OSes impose\n"
@@ -1362,37 +1363,37 @@ msgid ""
 msgstr "> setsockopt()を使ってTCP送信バッファの設定を試みる。しばしばOSはこの値を設定しようとするアプリケーションの資格を制限する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:476
+#: manpages/man5/afp.conf.5.md:477
 #, no-wrap
 msgid "recvfile = <BOOLEAN\\> (default: *no*) **(G)**\n"
 msgstr "recvfile = <BOOLEAN\\> (デフォルト: *no*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:478
+#: manpages/man5/afp.conf.5.md:479
 #, no-wrap
 msgid "> Whether to use splice() on Linux for receiving data.\n"
 msgstr "> データ受信のためにLinuxのsplice()を使うかどうか。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:480
+#: manpages/man5/afp.conf.5.md:481
 #, no-wrap
 msgid "splice size = <number\\> (default: *64k*) **(G)**\n"
 msgstr "splice size = <number\\> (デフォルト: *64k*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:482
+#: manpages/man5/afp.conf.5.md:483
 #, no-wrap
 msgid "> Maximum number of bytes spliced.\n"
 msgstr "> spliceする最大バイト数。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:484
+#: manpages/man5/afp.conf.5.md:485
 #, no-wrap
 msgid "use sendfile = <BOOLEAN\\> (default: *yes*) **(G)**\n"
 msgstr "use sendfile = <BOOLEAN\\> (デフォルト: *yes*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:487
+#: manpages/man5/afp.conf.5.md:488
 #, no-wrap
 msgid ""
 "> Whether to use sendfile syscall for\n"
@@ -1400,13 +1401,13 @@ msgid ""
 msgstr "> クライアントにファイルデータを送るためにsendfileシステムコールを使うかどうか。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:489
+#: manpages/man5/afp.conf.5.md:490
 #, no-wrap
 msgid "zeroconf = <BOOLEAN\\> (default: *yes*) **(G)**\n"
 msgstr "zeroconf = <BOOLEAN\\> (デフォルト: *yes*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:492
+#: manpages/man5/afp.conf.5.md:493
 #, no-wrap
 msgid ""
 "> Whether to use automatic Zeroconf service\n"
@@ -1414,19 +1415,19 @@ msgid ""
 msgstr "> AvahiまたはmDNSResponder込みでコンパイル済の場合、自動的なZeroconfサービス登録を使うかどうか。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:493
+#: manpages/man5/afp.conf.5.md:494
 #, no-wrap
 msgid "Miscellaneous Options"
 msgstr "雑多なオプション"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:496
+#: manpages/man5/afp.conf.5.md:497
 #, no-wrap
 msgid "afp read locks = <BOOLEAN\\> (default: *no*) **(G)**\n"
 msgstr "afp read locks = <BOOLEAN\\> (デフォルト: *no*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:500
+#: manpages/man5/afp.conf.5.md:501
 #, no-wrap
 msgid ""
 "> Whether to apply locks to the byte region read in FPRead calls. The AFP\n"
@@ -1435,13 +1436,13 @@ msgid ""
 msgstr "> FPReadコールにおいてバイト領域リードロックを適用するかどうか。AFPの仕様はこれを義務付けるが、実際のところこれはUNIXの動作に合致しないし、パフォーマンスを抑え込む。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:502
+#: manpages/man5/afp.conf.5.md:503
 #, no-wrap
 msgid "afpstats = <BOOLEAN\\> (default: *no*) **(G)**\n"
 msgstr "afpstats = <BOOLEAN\\> (デフォルト: *no*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:505
+#: manpages/man5/afp.conf.5.md:506
 #, no-wrap
 msgid ""
 "> Whether to provide AFP runtime statistics (connected users, open\n"
@@ -1451,13 +1452,13 @@ msgstr ""
 "を提供するかどうか。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:507
+#: manpages/man5/afp.conf.5.md:508
 #, no-wrap
 msgid "basedir regex = <regex\\> **(H)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:512
+#: manpages/man5/afp.conf.5.md:513
 #, no-wrap
 msgid ""
 "> Regular expression which matches the parent directory of the user homes.\n"
@@ -1467,19 +1468,19 @@ msgid ""
 msgstr "> ユーザホームの親ディレクトリにマッチする正規表現。**basedir regex**がシンボリックリンクを含む場合、正規化した絶対パスを設定しなければならない。簡単なケースだとこれは単に一つのパスである。つまり**basedir regex = /home**である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:514
+#: manpages/man5/afp.conf.5.md:515
 #, no-wrap
 msgid "chmod request = <preserve (default) | ignore | simple\\> **(G)**/**(V)**\n"
 msgstr "chmod request = <preserve (デフォルト) \\| ignore \\| simple\\> **(G)**/**(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:516
+#: manpages/man5/afp.conf.5.md:517
 #, no-wrap
 msgid "> Advanced permission control that deals with ACLs.\n"
 msgstr "> ACLに対応する高度なパーミッション制御。\n"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:520
+#: manpages/man5/afp.conf.5.md:521
 msgid ""
 "**ignore** - UNIX chmod() requests are completely ignored, use this option "
 "to allow the parent directory's ACL inheritance full control over new items."
@@ -1488,7 +1489,7 @@ msgstr ""
 "クトリのACL継承に完全コントロールさせるためにこのオプションを使う。"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:523
+#: manpages/man5/afp.conf.5.md:524
 msgid ""
 "**preserve** - preserve ZFS ACEs for named users and groups or POSIX ACL "
 "group mask"
@@ -1497,18 +1498,18 @@ msgstr ""
 "クを維持する"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:525
+#: manpages/man5/afp.conf.5.md:526
 msgid "**simple** - just to a chmod() as requested without any extra steps"
 msgstr "**simple** - いかなる追加の手順も踏まず、単に要求通りにchmod()する"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:527
+#: manpages/man5/afp.conf.5.md:528
 #, no-wrap
 msgid "close vol = <BOOLEAN\\> (default: *no*) **(G)**\n"
 msgstr "close vol = <BOOLEAN\\> (デフォルト: *no*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:530
+#: manpages/man5/afp.conf.5.md:531
 #, no-wrap
 msgid ""
 "> Whether to close volumes possibly opened by clients when they're removed\n"
@@ -1516,49 +1517,49 @@ msgid ""
 msgstr "> ボリュームが設定から削除され、その設定が再読み込みされたとき、クライアントが既に開いているボリュームを可能な限り閉じるかどうか。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:532
+#: manpages/man5/afp.conf.5.md:533
 #, no-wrap
 msgid "cnid mysql host = <MySQL server address\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:534
+#: manpages/man5/afp.conf.5.md:535
 #, no-wrap
 msgid "> name or address of a MySQL server for use with the mysql CNID backend.\n"
 msgstr "> mysql CNIDバックエンド利用時のMySQLサーバの名前またはアドレス。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:536
+#: manpages/man5/afp.conf.5.md:537
 #, no-wrap
 msgid "cnid mysql user = <MySQL user\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:538
+#: manpages/man5/afp.conf.5.md:539
 #, no-wrap
 msgid "> MySQL user for authentication with the server.\n"
 msgstr "> MySQLサーバ認証のためのユーザ名。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:540
+#: manpages/man5/afp.conf.5.md:541
 #, no-wrap
 msgid "cnid mysql pw = <password\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:542
+#: manpages/man5/afp.conf.5.md:543
 #, no-wrap
 msgid "> Password for MySQL server.\n"
 msgstr "> MySQLサーバのためのパスワード。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:544
+#: manpages/man5/afp.conf.5.md:545
 #, no-wrap
 msgid "cnid mysql db = <database name\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:547
+#: manpages/man5/afp.conf.5.md:548
 #, no-wrap
 msgid ""
 "> Name of an existing database for which the specified user has full\n"
@@ -1566,7 +1567,7 @@ msgid ""
 msgstr "> 指定ユーザが完全アクセス権を持つための存続しているデータベースの名前。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:549
+#: manpages/man5/afp.conf.5.md:550
 #, no-wrap
 msgid "cnid server = <ipaddress\\[:port\\]\\> **(G)**/**(V)**\n"
 msgstr ""
@@ -1575,22 +1576,27 @@ msgstr ""
 #: manpages/man5/afp.conf.5.md:554
 #, no-wrap
 msgid ""
-"> Specifies the IP address and port of a cnid_metad server, required for\n"
-"CNID dbd backend. Defaults to localhost:4700. The network address may be\n"
-"specified either in dotted-decimal format for IPv4 or in hexadecimal\n"
-"format for IPv6.-\n"
-msgstr ""
-"> cnid_metadサーバのIPアドレスとポート番号を指定する。CNID\n"
-"dbdバックエンドのために必要。デフォルトはlocalhost:4700。ネットワークアドレスはIPv4のドット分割10進数フォーマットでもよいし、IPv6の16進数フォーマットでもよい。\n"
+"> Specifies the IP address and port of a cnid_metad server, required\n"
+"for the CNID dbd backend. This should match the address and port of the\n"
+"**cnid listen** option for most deployments. Defaults to localhost:4700.\n"
+msgstr "> cnid_metadサーバのIPアドレスとポート番号を指定する。CNID dbdバックエンドのために必要。これはほとんどのデプロイメントで**cnid listen**オプションと一致するべきである。デフォルトはlocalhost:4700。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:556
+#: manpages/man5/afp.conf.5.md:557
+#, no-wrap
+msgid ""
+"> The network address may be specified either in dotted-decimal format\n"
+"for IPv4 or in hexadecimal format for IPv6.\n"
+msgstr "> ネットワークアドレスはIPv4のドット分割10進数フォーマットでもよいし、IPv6の16進数フォーマットでもよい。\n"
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:559
 #, no-wrap
 msgid "dbus daemon = <path\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:560
+#: manpages/man5/afp.conf.5.md:563
 #, no-wrap
 msgid ""
 "> Sets the path to dbus-daemon binary used by the Spotlight feature. Can\n"
@@ -1601,13 +1607,13 @@ msgstr ""
 "コンパイル時のデフォルト値が実行環境と一致しない場合に使用する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:562
+#: manpages/man5/afp.conf.5.md:565
 #, no-wrap
 msgid "dircachesize = <number\\> **(G)**\n"
 msgstr "splice size = <number\\> (デフォルト: *64k*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:566
+#: manpages/man5/afp.conf.5.md:569
 #, no-wrap
 msgid ""
 "> Maximum possible entries in the directory cache. The cache stores\n"
@@ -1616,7 +1622,7 @@ msgid ""
 msgstr "> ディレクトリキャッシュにおける最大エントリ数。キャッシュはディレクトリとファイルを格納する。これはディレクトリのフルパスと、ディレクトリ一覧を大幅にスピードアップするCNIDをキャッシュするために使われる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:571
+#: manpages/man5/afp.conf.5.md:574
 msgid ""
 "Default size is 8192, maximum size is 131072. Given value is rounded up to "
 "nearest power of 2. Each entry takes about 100 bytes, which is not much, but "
@@ -1629,13 +1635,13 @@ msgstr ""
 "てください。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:573
+#: manpages/man5/afp.conf.5.md:576
 #, no-wrap
 msgid "extmap file = <path\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:576
+#: manpages/man5/afp.conf.5.md:579
 #, no-wrap
 msgid ""
 "> Sets the path to the file which defines file extension type/creator\n"
@@ -1643,13 +1649,13 @@ msgid ""
 msgstr "> ファイル拡張子とタイプ/クリエータのマッピングを定義するファイルのパスを設定する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:578
+#: manpages/man5/afp.conf.5.md:581
 #, no-wrap
 msgid "force xattr with sticky bit = <BOOLEAN\\> (default: *no*) `(G/V)`\n"
 msgstr "force xattr with sticky bit = <BOOLEAN\\> (デフォルト: *no*) `(G/V)`\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:582
+#: manpages/man5/afp.conf.5.md:585
 #, no-wrap
 msgid ""
 "> Writing metadata xattr on directories with the sticky bit set may fail\n"
@@ -1658,20 +1664,20 @@ msgid ""
 msgstr "> ディレクトリへの書き込み権限があったとしても、スティッキービット設定を使ってメタデータ(拡張属性)を書き込むことに失敗するかもしれない。なぜなら、スティッキービットが設定されている場合、所有者だけが拡張属性への書き込みを許されるからである。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:584
+#: manpages/man5/afp.conf.5.md:587
 msgid "By enabling this option Netatalk will write the metadata xattr as root."
 msgstr ""
 "このオプションを有効にするとNetatalkはroot権限でメタデータ(拡張属性)を書き込"
 "む。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:586
+#: manpages/man5/afp.conf.5.md:589
 #, no-wrap
 msgid "guest account = <name\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:589
+#: manpages/man5/afp.conf.5.md:592
 #, no-wrap
 msgid ""
 "> Specifies the user that guests should use (default is nobody). The name\n"
@@ -1681,13 +1687,13 @@ msgstr ""
 "本ユーザ名はシステム上の有効なユーザーである必要がある。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:591
+#: manpages/man5/afp.conf.5.md:594
 #, no-wrap
 msgid "home name = <name\\> **(H)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:594
+#: manpages/man5/afp.conf.5.md:597
 #, no-wrap
 msgid ""
 "> AFP user home volume name. The default is *$u's home*. The name must\n"
@@ -1697,13 +1703,13 @@ msgstr ""
 "ボリューム名の文字列に\"*$u*\"は必須である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:596
+#: manpages/man5/afp.conf.5.md:599
 #, no-wrap
 msgid "ignored attributes = <all | nowrite | nodelete | norename\\> **(G)**/**(V)**\n"
 msgstr "ignored attributes = <all \\| nowrite \\| nodelete \\| norename\\> **(G)**/**(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:599
+#: manpages/man5/afp.conf.5.md:602
 #, no-wrap
 msgid ""
 "> Specify a set of file and directory attributes that shall be ignored by\n"
@@ -1711,7 +1717,7 @@ msgid ""
 msgstr "> サーバが無視すべきファイルとディレクトリの属性を設定する。`all`はオプション全部という意味である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:604
+#: manpages/man5/afp.conf.5.md:607
 msgid ""
 "In OS X when the Finder sets a lock on a file/directory or you set the BSD "
 "uchg flag in the Terminal, all three attributes are used. Thus in order to "
@@ -1723,13 +1729,13 @@ msgstr ""
 "てください。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:606
+#: manpages/man5/afp.conf.5.md:609
 #, no-wrap
 msgid "legacy icon = <icon\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:610
+#: manpages/man5/afp.conf.5.md:613
 #, no-wrap
 msgid ""
 "> Sets the shared volume icon displayed in the Finder in Classic Mac OS.\n"
@@ -1742,28 +1748,28 @@ msgstr ""
 "有効なアイコン名の例は以下になる。\n"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:612
+#: manpages/man5/afp.conf.5.md:615
 msgid "**daemon**"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:614
+#: manpages/man5/afp.conf.5.md:617
 msgid "**globe**"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:616
+#: manpages/man5/afp.conf.5.md:619
 msgid "**sdcard**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:618
+#: manpages/man5/afp.conf.5.md:621
 #, no-wrap
 msgid "login message = <message\\> **(G)**/**(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:621
+#: manpages/man5/afp.conf.5.md:624
 #, no-wrap
 msgid ""
 "> Sets a message to be displayed when clients logon to the server. The\n"
@@ -1771,13 +1777,13 @@ msgid ""
 msgstr "> クライアントがサーバにログオンしたときに表示されるメッセージを設定する。メッセージは**unix charset**で書く。拡張文字が使える。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:623
+#: manpages/man5/afp.conf.5.md:626
 #, no-wrap
 msgid "mimic model = <model\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:627
+#: manpages/man5/afp.conf.5.md:630
 #, no-wrap
 msgid ""
 "> Specifies a custom icon for the mounted AFP volume on macOS / Mac OS X\n"
@@ -1789,22 +1795,22 @@ msgstr ""
 "に任せること。netatalkがZeroconfをサポートしなければならないことに注意してください。例:\n"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:629
+#: manpages/man5/afp.conf.5.md:632
 msgid "**Laptop**"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:631
+#: manpages/man5/afp.conf.5.md:634
 msgid "**RackMount**"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:633
+#: manpages/man5/afp.conf.5.md:636
 msgid "**Tower**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:638
+#: manpages/man5/afp.conf.5.md:641
 msgid ""
 "A complete set of supported model codes by a macOS client can be found by "
 "inspecting system properties files, such as */System/Library/CoreServices/"
@@ -1815,13 +1821,13 @@ msgstr ""
 "Sequoia の場合。)"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:640
+#: manpages/man5/afp.conf.5.md:643
 #, no-wrap
 msgid "server name = <name\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:645
+#: manpages/man5/afp.conf.5.md:648
 #, no-wrap
 msgid ""
 "> Specifies a human-readable name that uniquely describes the AFP server.\n"
@@ -1831,13 +1837,13 @@ msgid ""
 msgstr "> 一意に AFP サーバを記述する人間が読める名前を指定する。デフォルトでは、最初のピリオドまでの**hostname**の値を使用する。netatalkがZeroconfサポートでビルドされている場合、これはサービス名としても登録され、UTF-8で最大63オクテット(バイト)の長さまで宣伝される。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:647
+#: manpages/man5/afp.conf.5.md:650
 #, no-wrap
 msgid "signature = <STRING\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:653
+#: manpages/man5/afp.conf.5.md:656
 #, no-wrap
 msgid ""
 "> Specify a server signature. The maximum length is 16 characters. This\n"
@@ -1848,13 +1854,13 @@ msgid ""
 msgstr "> サーバシグネチャを指定する。最大長は16文字である。このオプションは障害隔離などを提供するクラスタ環境において有用である。デフォルトでは、afpdは自動的にシグネチャを(乱数を元に)生成し、それを**afp_signature.conf**に保存する。asip-status(1)も見よ。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:655
+#: manpages/man5/afp.conf.5.md:658
 #, no-wrap
 msgid "solaris share reservations = <BOOLEAN\\> (default: *yes*) **(G)**\n"
 msgstr "solaris share reservations = <BOOLEAN\\> (デフォルト: *yes*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:658
+#: manpages/man5/afp.conf.5.md:661
 #, no-wrap
 msgid ""
 "> Use share reservations on Solaris. Solaris CIFS server uses this too, so\n"
@@ -1864,13 +1870,13 @@ msgstr ""
 "CIFSサーバもこれを利用するので、ロックを統一したマルチプロトコルサーバを形成する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:660
+#: manpages/man5/afp.conf.5.md:663
 #, no-wrap
 msgid "sparql results limit = <NUMBER\\> (default: *UNLIMITED*) **(G)**\n"
 msgstr "sparql results limit = <NUMBER\\> (デフォルト: *無制限*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:663
+#: manpages/man5/afp.conf.5.md:666
 #, no-wrap
 msgid ""
 "> Impose a limit on the number of results queried from Tracker or\n"
@@ -1880,13 +1886,13 @@ msgstr ""
 "からのクエリ結果の数に制限を課す。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:665
+#: manpages/man5/afp.conf.5.md:668
 #, no-wrap
 msgid "spotlight = <BOOLEAN\\> (default: *no*) **(G)**/**(V)**\n"
 msgstr "spotlight = <BOOLEAN\\> (デフォルト: *no*) **(G)**/**(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:669
+#: manpages/man5/afp.conf.5.md:672
 #, no-wrap
 msgid ""
 "> Whether to enable Spotlight searches. Note: once the global option is\n"
@@ -1898,13 +1904,13 @@ msgstr ""
 "daemon*オプションも見よ。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:671
+#: manpages/man5/afp.conf.5.md:674
 #, no-wrap
 msgid "spotlight attributes = <COMMA SEPARATED STRING\\> (default: *EMPTY*) **(G)**\n"
 msgstr "spotlight attributes = <カンマで分割した文字列\\> (デフォルト: *空*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:675
+#: manpages/man5/afp.conf.5.md:678
 #, no-wrap
 msgid ""
 "> A list of attributes that are allowed to be used in Spotlight searches.\n"
@@ -1915,31 +1921,31 @@ msgstr ""
 "例:\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:677
+#: manpages/man5/afp.conf.5.md:680
 #, no-wrap
 msgid "    spotlight attributes = *,kMDItemTextContent\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:679
+#: manpages/man5/afp.conf.5.md:682
 #, no-wrap
 msgid "spotlight expr = <BOOLEAN\\> (default: *yes*) **(G)**\n"
 msgstr "spotlight expr = <BOOLEAN\\> (デフォルト: *yes*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:681
+#: manpages/man5/afp.conf.5.md:684
 #, no-wrap
 msgid "> Whether to allow the use of logic expression in searches.\n"
 msgstr "> 検索において論理式の使用を認めるかどうか。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:683
+#: manpages/man5/afp.conf.5.md:686
 #, no-wrap
 msgid "veto message = <BOOLEAN\\> (default: *no*) **(G)**\n"
 msgstr "veto message = <BOOLEAN\\> (デフォルト: *no*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:687
+#: manpages/man5/afp.conf.5.md:690
 #, no-wrap
 msgid ""
 "> Send optional AFP messages for vetoed files. Then whenever a client\n"
@@ -1948,13 +1954,13 @@ msgid ""
 msgstr "> 禁止ファイルに関するオプションのAFPメッセージを送る。クライアントが禁止名を持つファイルやディレクトリにアクセスを試みたとき、名前とディレクトリを示したAFPメッセージを送る。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:689
+#: manpages/man5/afp.conf.5.md:692
 #, no-wrap
 msgid "vol dbpath = <path\\> **(G)**/**(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:692
+#: manpages/man5/afp.conf.5.md:695
 #, no-wrap
 msgid ""
 "> Sets the path where the database information will be stored. You have to\n"
@@ -1962,13 +1968,13 @@ msgid ""
 msgstr "> データベース情報をpathに格納するように設定する。ボリュームが読み込み専用だったとしても、書き込み可能な場所を設定しなければならない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:694
+#: manpages/man5/afp.conf.5.md:697
 #, no-wrap
 msgid "vol dbnest = <BOOLEAN\\> (default: *no*) **(G)**\n"
 msgstr "vol dbnest = <BOOLEAN\\> (デフォルト: *no*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:698
+#: manpages/man5/afp.conf.5.md:701
 #, no-wrap
 msgid ""
 "> Setting this option to true brings back Netatalk 2 behaviour of storing\n"
@@ -1979,13 +1985,13 @@ msgstr ""
 "2の動作に立ち返る。つまり、それぞれの共有のボリュームルートの下にある.AppleDBというフォルダにCNIDデータベースを格納する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:700
+#: manpages/man5/afp.conf.5.md:703
 #, no-wrap
 msgid "volnamelen = <number\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:703
+#: manpages/man5/afp.conf.5.md:706
 #, no-wrap
 msgid ""
 "> Max length of UTF8-MAC volume name for Mac OS X. Note that Hangul is\n"
@@ -1995,7 +2001,7 @@ msgstr ""
 "XのためのUTF8-MACボリューム名の最大長。ハングルはこれに特に敏感なので注意してください。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:707
+#: manpages/man5/afp.conf.5.md:710
 #, no-wrap
 msgid ""
 "    73: limit of Mac OS X 10.1\n"
@@ -2007,7 +2013,7 @@ msgstr ""
 "    255: 最近のMac OS Xの制限\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:710
+#: manpages/man5/afp.conf.5.md:713
 msgid ""
 "Mac OS 9 and earlier are not influenced by this, because Maccharset volume "
 "name is always limited to 27 bytes."
@@ -2016,13 +2022,13 @@ msgstr ""
 "バイト制限がある。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:712
+#: manpages/man5/afp.conf.5.md:715
 #, no-wrap
 msgid "vol preset = <name\\> **(G)**/**(V)**\n"
 msgstr "vol size limit = <MiB 単位でのサイズ\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:716
+#: manpages/man5/afp.conf.5.md:719
 #, no-wrap
 msgid ""
 "> Use section <name\\> as option preset for all volumes (when set in the\n"
@@ -2033,19 +2039,19 @@ msgstr ""
 "全ボリューム、(ボリュームセクションで設定したときは)そのボリュームのオプション初期設定となるセクションの<name\\>を使う。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:717
+#: manpages/man5/afp.conf.5.md:720
 #, no-wrap
 msgid "Logging Options"
 msgstr "ログのオプション"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:720
+#: manpages/man5/afp.conf.5.md:723
 #, no-wrap
 msgid "log file = <logfile\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:723
+#: manpages/man5/afp.conf.5.md:726
 #, no-wrap
 msgid ""
 "> Write logs to **logfile** on the file system. If not specified, Netatalk\n"
@@ -2053,7 +2059,7 @@ msgid ""
 msgstr "> ログを**logfile**に出力する。指定しない場合、Netatalkはsyslogデーモン機能にログを出力する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:725
+#: manpages/man5/afp.conf.5.md:728
 msgid ""
 "log level = <type:level \\[type:level ...\\]\\> **(G)**; log level = "
 "<type:level,\\[type:level, ...\\]\\> **(G)**"
@@ -2062,7 +2068,7 @@ msgstr ""
 "<type:level,\\[type:level, ...\\]\\> **(G)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:728
+#: manpages/man5/afp.conf.5.md:731
 #, no-wrap
 msgid ""
 "> Specify that any message of a loglevel up to the given **log level**\n"
@@ -2070,19 +2076,19 @@ msgid ""
 msgstr "> 与えられた**log level**までのログレベルのメッセージを出力するように設定する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:731
+#: manpages/man5/afp.conf.5.md:734
 msgid ""
 "By default afpd logs to syslog with a default logging setup equivalent to "
 "**default:note**"
 msgstr "デフォルトではafpdは**default:note**に相当する設定でsyslogに出力する。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:733
+#: manpages/man5/afp.conf.5.md:736
 msgid "logtypes: default, afpdaemon, logger, uamsdaemon"
 msgstr "ログタイプ: default, afpdaemon, logger, uamsdaemon"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:736
+#: manpages/man5/afp.conf.5.md:739
 msgid ""
 "loglevels: severe, error, warn, note, info, debug, debug6, debug7, debug8, "
 "debug9, maxdebug"
@@ -2091,19 +2097,19 @@ msgstr ""
 "debug9, maxdebug"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:740
+#: manpages/man5/afp.conf.5.md:743
 #, no-wrap
 msgid "> Both logtype and loglevels are case insensitive.\n"
 msgstr "> ログタイプとログレベルはどちらも大文字小文字を区別しない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:742
+#: manpages/man5/afp.conf.5.md:745
 #, no-wrap
 msgid "log microseconds = <BOOLEAN\\> (default: *yes*) **(G)**\n"
 msgstr "log microseconds = <BOOLEAN\\> (デフォルト: *yes*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:746
+#: manpages/man5/afp.conf.5.md:749
 #, no-wrap
 msgid ""
 "> Log timestamps with accuracy down to microseconds. If disabled, the\n"
@@ -2114,13 +2120,13 @@ msgstr ""
 "オプションと組み合わせて使用​​した場合にのみ有効になる。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:747
+#: manpages/man5/afp.conf.5.md:750
 #, no-wrap
 msgid "Filesystem Change Events (FCE)"
 msgstr "ファイルシステム変更イベント (FCE)"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:752
+#: manpages/man5/afp.conf.5.md:755
 msgid ""
 "Netatalk includes a nifty filesystem change event mechanism where afpd "
 "processes notify interested listeners about certain filesystem event by UDP "
@@ -2131,63 +2137,63 @@ msgstr ""
 "るリスナーに、UDP ネットワークデータグラムで通知する。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:754
+#: manpages/man5/afp.conf.5.md:757
 msgid "The following FCE events are defined:"
 msgstr "以下の FCE イベントが定義されている:"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:756
+#: manpages/man5/afp.conf.5.md:759
 msgid "file modification (**fmod**)"
 msgstr "ファイル変更 (**fmod**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:758
+#: manpages/man5/afp.conf.5.md:761
 msgid "file deletion (**fdel**)"
 msgstr "ファイル削除 (**fdel**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:760
+#: manpages/man5/afp.conf.5.md:763
 msgid "directory deletion (**ddel**)"
 msgstr "ディレクトリ削除 (**ddel**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:762
+#: manpages/man5/afp.conf.5.md:765
 msgid "file creation (**fcre**)"
 msgstr "ファイル作成 (**fcre**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:764
+#: manpages/man5/afp.conf.5.md:767
 msgid "directory creation (**dcre**)"
 msgstr "ディレクトリ作成 (**dcre**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:766
+#: manpages/man5/afp.conf.5.md:769
 msgid "file move or rename (**fmov**)"
 msgstr "ファイル移動または名前変更 (**fmov**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:768
+#: manpages/man5/afp.conf.5.md:771
 msgid "directory move or rename (**dmov**)"
 msgstr "ディレクトリ移動または名前変更 (**dmov**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:770
+#: manpages/man5/afp.conf.5.md:773
 msgid "login (**login**)"
 msgstr "ログイン (**login**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:772
+#: manpages/man5/afp.conf.5.md:775
 msgid "logout (**logout**)"
 msgstr "ログアウト (**logout**)"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:774
+#: manpages/man5/afp.conf.5.md:777
 #, no-wrap
 msgid "fce listener = <host\\[:port\\]\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:778
+#: manpages/man5/afp.conf.5.md:781
 #, no-wrap
 msgid ""
 "> Enables sending FCE events to the specified **host**, default **port** is\n"
@@ -2200,13 +2206,13 @@ msgstr ""
 "である。複数のリスナーを指定するにはそれぞれのリスナーに対するオプションを一度に指定することである。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:780
+#: manpages/man5/afp.conf.5.md:783
 #, no-wrap
 msgid "fce version = <1|2\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:783
+#: manpages/man5/afp.conf.5.md:786
 #, no-wrap
 msgid ""
 "> FCE protocol version, default is 1. You need version 2 for the fmov,\n"
@@ -2217,13 +2223,13 @@ msgstr ""
 "が必要である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:785
+#: manpages/man5/afp.conf.5.md:788
 #, no-wrap
 msgid "fce events = <fmod,fdel,ddel,fcre,dcre,fmov,dmov,login,logout\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:788
+#: manpages/man5/afp.conf.5.md:791
 #, no-wrap
 msgid ""
 "> Specifies which FCE events are active, default is\n"
@@ -2233,25 +2239,25 @@ msgstr ""
 "**fmod,fdel,ddel,fcre,dcre** である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:790
+#: manpages/man5/afp.conf.5.md:793
 #, no-wrap
 msgid "fce coalesce = <all|delete|create\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:792
+#: manpages/man5/afp.conf.5.md:795
 #, no-wrap
 msgid "> Coalesce FCE events.\n"
 msgstr "> FCE イベントを結合する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:794
+#: manpages/man5/afp.conf.5.md:797
 #, no-wrap
 msgid "fce holdfmod = <seconds\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:801
+#: manpages/man5/afp.conf.5.md:804
 #, no-wrap
 msgid ""
 "> This determines the time delay in seconds which is always waited if\n"
@@ -2266,13 +2272,13 @@ msgstr ""
 "60 秒である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:803
+#: manpages/man5/afp.conf.5.md:806
 #, no-wrap
 msgid "fce sendwait = <milliseconds\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:810
+#: manpages/man5/afp.conf.5.md:813
 #, no-wrap
 msgid ""
 "> Defines a delay in milliseconds between the emission of each FCE event.\n"
@@ -2290,13 +2296,13 @@ msgstr ""
 "から 999 までの値は設定可能。デフォルト: 0 ミリ秒。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:812
+#: manpages/man5/afp.conf.5.md:815
 #, no-wrap
 msgid "fce ignore names = <NAME\\[/NAME2/...\\]\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:815
+#: manpages/man5/afp.conf.5.md:818
 #, no-wrap
 msgid ""
 "> Slash delimited list of filenames for which FCE events shall not be\n"
@@ -2307,13 +2313,13 @@ msgstr ""
 ".DS_Store。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:817
+#: manpages/man5/afp.conf.5.md:820
 #, no-wrap
 msgid "fce ignore directories = <NAME\\[,NAME2,...\\]\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:820
+#: manpages/man5/afp.conf.5.md:823
 #, no-wrap
 msgid ""
 "> Comma delimited list of directories for which FCE events shall not be\n"
@@ -2323,13 +2329,13 @@ msgstr ""
 "イベントが生成されないディレクトリのカンマ区切りのリスト。デフォルトは無し。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:822
+#: manpages/man5/afp.conf.5.md:825
 #, no-wrap
 msgid "fce notify script = <PATH\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:826
+#: manpages/man5/afp.conf.5.md:829
 #, no-wrap
 msgid ""
 "> Script which will be executed for every FCE event, see\n"
@@ -2341,36 +2347,36 @@ msgstr ""
 "のソースの contrib/shell_utils/fce_ev_script.sh を参照のこと。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:827
+#: manpages/man5/afp.conf.5.md:830
 #, no-wrap
 msgid "Debug Parameters"
 msgstr "デバッグパラメータ"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:830
+#: manpages/man5/afp.conf.5.md:833
 msgid "These options are useful for debugging only."
 msgstr "これらのオプションはデバッグのみに有用である。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:832
+#: manpages/man5/afp.conf.5.md:835
 #, no-wrap
 msgid "tickleval = <number\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:834
+#: manpages/man5/afp.conf.5.md:837
 #, no-wrap
 msgid "> Sets the tickle timeout interval (in seconds). Defaults to 30.\n"
 msgstr "> tickleタイムアウトの間隔を(秒単位で)設定する。デフォルトは30。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:836
+#: manpages/man5/afp.conf.5.md:839
 #, no-wrap
 msgid "timeout = <number\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:839
+#: manpages/man5/afp.conf.5.md:842
 #, no-wrap
 msgid ""
 "> Specify the number of tickles to send before timing out a connection.\n"
@@ -2378,13 +2384,13 @@ msgid ""
 msgstr "> 接続がタイムアウトする前に送るtickleの数を指定する。デフォルトは4なので、2分後に接続がタイムアウトする。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:841
+#: manpages/man5/afp.conf.5.md:844
 #, no-wrap
 msgid "client polling = <BOOLEAN\\> (default: *no*) **(G)**\n"
 msgstr "client polling = <BOOLEAN\\> (デフォルト: *no*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:847
+#: manpages/man5/afp.conf.5.md:850
 #, no-wrap
 msgid ""
 "> With this option enabled, afpd won't advertise that it is capable of\n"
@@ -2398,7 +2404,7 @@ msgstr ""
 "同時接続クライアント数とネットワークスピード次第でネットワークの負荷が相当に高くなる!\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:851
+#: manpages/man5/afp.conf.5.md:854
 msgid ""
 "Do not use this option any longer as present Netatalk correctly supports "
 "server notifications, allowing connected clients to update folder listings "
@@ -2409,13 +2415,13 @@ msgstr ""
 "で、もはやこのオプションは使わないでください。"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:852
+#: manpages/man5/afp.conf.5.md:855
 #, no-wrap
 msgid "Options for ACL handling"
 msgstr "ACL処理のためのオプション"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:858
+#: manpages/man5/afp.conf.5.md:861
 msgid ""
 "By default, the effective permission of the authenticated user are only "
 "mapped to the mentioned UARights permission structure, not the UNIX mode. "
@@ -2425,30 +2431,30 @@ msgstr ""
 "される。UNIXモードではない。この挙動は設定オプション**map acls**で調整できる:"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:860
+#: manpages/man5/afp.conf.5.md:863
 #, no-wrap
 msgid "map acls = <none|rights|mode\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:862
+#: manpages/man5/afp.conf.5.md:865
 #, no-wrap
 msgid "> none\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:864
+#: manpages/man5/afp.conf.5.md:867
 #, no-wrap
 msgid "> no mapping of ACLs\n"
 msgstr "> ACLのマッピングをしない\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:866
+#: manpages/man5/afp.conf.5.md:869
 msgid "rights"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:869
+#: manpages/man5/afp.conf.5.md:872
 #, no-wrap
 msgid ""
 "> effective permissions are mapped to UARights structure. This is the\n"
@@ -2456,18 +2462,18 @@ msgid ""
 msgstr "> 有効な権限がUARights構造にマップされる。これがデフォルトである。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:871
+#: manpages/man5/afp.conf.5.md:874
 msgid "mode"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:873
+#: manpages/man5/afp.conf.5.md:876
 #, no-wrap
 msgid "> ACLs are additionally mapped to the UNIX mode of the filesystem object.\n"
 msgstr "> ACLはファイルシステムオブジェクトのUNIXモードにもマップされる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:881
+#: manpages/man5/afp.conf.5.md:884
 msgid ""
 "If you want to be able to display ACLs on the client, you must setup both "
 "client and server as part on a authentication domain (directory service, "
@@ -2485,7 +2491,7 @@ msgstr ""
 "を UUID と紐付けできるようにしなければならない。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:886
+#: manpages/man5/afp.conf.5.md:889
 msgid ""
 "Netatalk can query a directory server using LDAP queries. Either the "
 "directory server already provides an UUID attribute for user and groups "
@@ -2499,75 +2505,75 @@ msgstr ""
 "かである。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:888
+#: manpages/man5/afp.conf.5.md:891
 msgid "The following LDAP options must be configured for Netatalk:"
 msgstr "Netatalk では以下の LDAP オプションが設定されなければならない:"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:890
+#: manpages/man5/afp.conf.5.md:893
 #, no-wrap
 msgid "ldap auth method = <none|simple\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:892
+#: manpages/man5/afp.conf.5.md:895
 #, no-wrap
 msgid "> Authentication method: **none** | **simple**\n"
 msgstr "> 認証方式: **none** | **simple**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:894 manpages/man5/afp.conf.5.md:1101
+#: manpages/man5/afp.conf.5.md:897 manpages/man5/afp.conf.5.md:1104
 msgid "none"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:896
+#: manpages/man5/afp.conf.5.md:899
 #, no-wrap
 msgid "> anonymous LDAP bind\n"
 msgstr "> 匿名 LDAP 認証\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:898
+#: manpages/man5/afp.conf.5.md:901
 msgid "simple"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:900
+#: manpages/man5/afp.conf.5.md:903
 #, no-wrap
 msgid "> simple LDAP bind\n"
 msgstr "> 簡易 LDAP 認証\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:902
+#: manpages/man5/afp.conf.5.md:905
 #, no-wrap
 msgid "ldap auth dn = <dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:904
+#: manpages/man5/afp.conf.5.md:907
 #, no-wrap
 msgid "> Distinguished Name of the user for simple bind.\n"
 msgstr "> 簡易認証でのユーザーの識別名。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:906
+#: manpages/man5/afp.conf.5.md:909
 #, no-wrap
 msgid "ldap auth pw = <password\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:908
+#: manpages/man5/afp.conf.5.md:911
 #, no-wrap
 msgid "> Password for simple bind.\n"
 msgstr "> 簡易認証でのパスワード。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:910
+#: manpages/man5/afp.conf.5.md:913
 msgid "ldap uri = <ldap://somehost:1234/\\> **(G)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:915
+#: manpages/man5/afp.conf.5.md:918
 #, no-wrap
 msgid ""
 "> Specifies the LDAP URI of the server to connect to. The URI scheme may\n"
@@ -2582,107 +2588,107 @@ msgstr ""
 "サポートを必要とする時のみ必要。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:917
+#: manpages/man5/afp.conf.5.md:920
 msgid "You can use **afpldaptest**(1) to syntactically check your config."
 msgstr "設定の構文的なチェックのために **afpldaptest**(1) を使うこともできる。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:919
+#: manpages/man5/afp.conf.5.md:922
 #, no-wrap
 msgid "ldap userbase = <base dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:921
+#: manpages/man5/afp.conf.5.md:924
 #, no-wrap
 msgid "> DN of the user container in LDAP.\n"
 msgstr "> LDAP 内のユーザーコンテナの DN。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:923
+#: manpages/man5/afp.conf.5.md:926
 #, no-wrap
 msgid "ldap userscope = <scope\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:925
+#: manpages/man5/afp.conf.5.md:928
 #, no-wrap
 msgid "> Search scope for user search: **base** | **one** | **sub**\n"
 msgstr "> ユーザー検索での検索スコープ: **base** | **one** | **sub**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:927
+#: manpages/man5/afp.conf.5.md:930
 #, no-wrap
 msgid "ldap groupbase = <base dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:929
+#: manpages/man5/afp.conf.5.md:932
 #, no-wrap
 msgid "> DN of the group container in LDAP.\n"
 msgstr "> LDAP 内のグループコンテナの DN。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:931
+#: manpages/man5/afp.conf.5.md:934
 #, no-wrap
 msgid "ldap groupscope = <scope\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:933
+#: manpages/man5/afp.conf.5.md:936
 #, no-wrap
 msgid "> Search scope for group search: **base** | **one** | **sub**\n"
 msgstr "> グループ検索での検索スコープ: **base** | **one** | **sub**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:935
+#: manpages/man5/afp.conf.5.md:938
 #, no-wrap
 msgid "ldap uuid attr = <dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:937
+#: manpages/man5/afp.conf.5.md:940
 #, no-wrap
 msgid "> Name of the LDAP attribute with the UUIDs.\n"
 msgstr "> UUID のある LDAP 属性の名前。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:939
+#: manpages/man5/afp.conf.5.md:942
 msgid "Note: this is used both for users and groups."
 msgstr "注記: これはユーザーでもグループでも双方で用いられる。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:941
+#: manpages/man5/afp.conf.5.md:944
 #, no-wrap
 msgid "ldap name attr = <dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:943
+#: manpages/man5/afp.conf.5.md:946
 #, no-wrap
 msgid "> Name of the LDAP attribute with the users short name.\n"
 msgstr "> ユーザーの短縮名のある LDAP 属性の名前。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:945
+#: manpages/man5/afp.conf.5.md:948
 #, no-wrap
 msgid "ldap group attr = <dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:947
+#: manpages/man5/afp.conf.5.md:950
 #, no-wrap
 msgid "> Name of the LDAP attribute with the groups short name.\n"
 msgstr "> グループの短縮名のある LDAP 属性の名前。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:949
+#: manpages/man5/afp.conf.5.md:952
 #, no-wrap
 msgid "ldap uuid string = <STRING\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:952
+#: manpages/man5/afp.conf.5.md:955
 #, no-wrap
 msgid ""
 "> Format of the uuid string in the directory. A series of x and -, where\n"
@@ -2693,18 +2699,18 @@ msgstr ""
 "はそれぞれ区切り文字である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:954
+#: manpages/man5/afp.conf.5.md:957
 msgid "Default: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 msgstr "デフォルト: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:956
+#: manpages/man5/afp.conf.5.md:959
 #, no-wrap
 msgid "ldap uuid encoding = <string | ms-guid (default: string)\\> **(G)**\n"
 msgstr "ldap uuid encoding = <string | ms-guid (デフォルト: string)\\> **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:963
+#: manpages/man5/afp.conf.5.md:966
 #, no-wrap
 msgid ""
 "> Format of the UUID of the LDAP attribute, allows usage of the binary\n"
@@ -2723,41 +2729,41 @@ msgstr ""
 "表記とバイナリー形式が相互に変換される。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:965
+#: manpages/man5/afp.conf.5.md:968
 msgid "See also the options **ldap user filter** and **ldap group filter**."
 msgstr ""
 "オプション **ldap user filter** 及び **ldap group filter** も参照のこと。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:967
+#: manpages/man5/afp.conf.5.md:970
 msgid "string"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:969
+#: manpages/man5/afp.conf.5.md:972
 #, no-wrap
 msgid "> UUID is a string, use with e.g. OpenDirectory.\n"
 msgstr "> UUID は文字列。例えば OpenDirectory とで使用する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:971
+#: manpages/man5/afp.conf.5.md:974
 msgid "ms-guid"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:973
+#: manpages/man5/afp.conf.5.md:976
 #, no-wrap
 msgid "> Binary objectGUID from Active Directory\n"
 msgstr "> Active Directory からの objectGUID バイナリー。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:975
+#: manpages/man5/afp.conf.5.md:978
 #, no-wrap
 msgid "ldap user filter = <STRING (default: unused)\\> **(G)**\n"
 msgstr "ldap user filter = <STRING (デフォルト: 未使用)\\> **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:979
+#: manpages/man5/afp.conf.5.md:982
 #, no-wrap
 msgid ""
 "> Optional LDAP filter that matches user objects. This is necessary for\n"
@@ -2769,18 +2775,18 @@ msgstr ""
 "Active Directory 環境で必要。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:981
+#: manpages/man5/afp.conf.5.md:984
 msgid "Recommended setting for Active Directory: **objectClass=user**."
 msgstr "Active Directory での推奨設定: **objectClass=user**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:983
+#: manpages/man5/afp.conf.5.md:986
 #, no-wrap
 msgid "ldap group filter = <STRING (default: unused)\\> **(G)**\n"
 msgstr "ldap group filter = <STRING (デフォルト: 未使用)\\> **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:987
+#: manpages/man5/afp.conf.5.md:990
 #, no-wrap
 msgid ""
 "> Optional LDAP filter that matches group objects. This is necessary for\n"
@@ -2792,18 +2798,18 @@ msgstr ""
 "Active Directory 環境で必要。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:989
+#: manpages/man5/afp.conf.5.md:992
 msgid "Recommended setting for Active Directory: **objectClass=group**."
 msgstr "Active Directory での推奨設定: **objectClass=group**"
 
 #. type: Title #
-#: manpages/man5/afp.conf.5.md:990
+#: manpages/man5/afp.conf.5.md:993
 #, no-wrap
 msgid "Explanation of Volume Parameters"
 msgstr "ボリュームパラメータの説明"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:999
+#: manpages/man5/afp.conf.5.md:1002
 msgid ""
 "The section name defines the volume name. No two volumes may have the same "
 "name. The volume name cannot contain the ':' character. The volume name is "
@@ -2816,25 +2822,25 @@ msgstr ""
 "される。UTF8-MAC ボリューム名は volnamelen パラメータで制限される。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1001
+#: manpages/man5/afp.conf.5.md:1004
 #, no-wrap
 msgid "path = <PATH\\> **(V)**\n"
 msgstr "mac charset = <CHARSET\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1003
+#: manpages/man5/afp.conf.5.md:1006
 #, no-wrap
 msgid "> The path name must be a fully qualified path name.\n"
 msgstr "> パス名は完全修飾パス名でなければならない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1005
+#: manpages/man5/afp.conf.5.md:1008
 #, no-wrap
 msgid "appledouble = <ea|v2\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1009
+#: manpages/man5/afp.conf.5.md:1012
 #, no-wrap
 msgid ""
 "> Specify the format of the metadata files, which are used for saving Mac\n"
@@ -2846,15 +2852,15 @@ msgstr ""
 "v2 が用いられ、新しいデフォルトのフォーマットは **ea** である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1011 manpages/man5/afp.conf.5.md:1070
-#: manpages/man5/afp.conf.5.md:1105 manual/AppleTalk.md:154
+#: manpages/man5/afp.conf.5.md:1014 manpages/man5/afp.conf.5.md:1073
+#: manpages/man5/afp.conf.5.md:1108 manual/AppleTalk.md:154
 #: manual/Configuration.md:832 manual/Installation.md:4 manual/Upgrading.md:42
 #, no-wrap
 msgid "> **WARNING**\n"
 msgstr "> **警告**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1014
+#: manpages/man5/afp.conf.5.md:1017
 #, no-wrap
 msgid ""
 "> The **v2** option is obsolete and should not be used unless\n"
@@ -2862,13 +2868,13 @@ msgid ""
 msgstr "> このオプションは廃止予定であり、絶対に必要な場合を除き使用しないでください。将来のリリースでは削除される可能性がある。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1016
+#: manpages/man5/afp.conf.5.md:1019
 #, no-wrap
 msgid "vol size limit = <size in MiB\\> **(V)**\n"
 msgstr "vol size limit = <MiB 単位でのサイズ\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1021
+#: manpages/man5/afp.conf.5.md:1024
 #, no-wrap
 msgid ""
 "> Useful for Time Machine: limits the reported volume size, thus\n"
@@ -2883,13 +2889,13 @@ msgstr ""
 "に制限する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1023
+#: manpages/man5/afp.conf.5.md:1026
 #, no-wrap
 msgid "> **IMPORTANT**\n"
 msgstr "> **重要**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1031
+#: manpages/man5/afp.conf.5.md:1034
 #, no-wrap
 msgid ""
 "> This is an approximated calculation taking into\n"
@@ -2909,13 +2915,13 @@ msgstr ""
 "を読む、そしてお互いの乗算をする。ことによって行われる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1033
+#: manpages/man5/afp.conf.5.md:1036
 #, no-wrap
 msgid "valid users = <user @group\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1037
+#: manpages/man5/afp.conf.5.md:1040
 #, no-wrap
 msgid ""
 "> The allow option allows the users and groups that access a share to be\n"
@@ -2926,19 +2932,19 @@ msgstr ""
 "@ プレフィックスで明示する。例:\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1039
+#: manpages/man5/afp.conf.5.md:1042
 #, no-wrap
 msgid "    valid users = user @group\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1041
+#: manpages/man5/afp.conf.5.md:1044
 #, no-wrap
 msgid "invalid users = <users/groups\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1044
+#: manpages/man5/afp.conf.5.md:1047
 #, no-wrap
 msgid ""
 "> The deny option specifies users and groups who are not allowed access to\n"
@@ -2948,13 +2954,13 @@ msgstr ""
 "\"valid users\" オプションと同じフォーマットである。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1046
+#: manpages/man5/afp.conf.5.md:1049
 #, no-wrap
 msgid "hosts allow = <IP host address/IP netmask bits \\[ ... \\]\\> **(V)**\n"
 msgstr "hosts allow = <IPホストアドレス/IPマスクビット \\[ ... \\]\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1050
+#: manpages/man5/afp.conf.5.md:1053
 #, no-wrap
 msgid ""
 "> Only listed hosts and networks are allowed, all others are rejected. The\n"
@@ -2966,35 +2972,35 @@ msgstr ""
 "のドット区切りフォーマット、IPv6の16進数フォーマットのどちらでもよい。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1052
+#: manpages/man5/afp.conf.5.md:1055
 msgid "Example: hosts allow = 10.1.0.0/16 10.2.1.100 2001:0db8:1234::/48"
 msgstr "例: hosts allow = 10.1.0.0/16 10.2.1.100 2001:0db8:1234::/48"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1054
+#: manpages/man5/afp.conf.5.md:1057
 #, no-wrap
 msgid "hosts deny = <IP host address/IP netmask bits \\[ ... \\]\\> **(V)**\n"
 msgstr "hosts deny = <IPホストアドレス/IPマスクビット \\[ ... \\]\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1056
+#: manpages/man5/afp.conf.5.md:1059
 #, no-wrap
 msgid "> Listed hosts and nets are rejected, all others are allowed.\n"
 msgstr "> 列挙されたホストとネットのみが拒否され、ほかの全ては許可される。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1058
+#: manpages/man5/afp.conf.5.md:1061
 msgid "Example: hosts deny = 192.168.100/24 10.1.1.1 2001:db8::1428:57ab"
 msgstr "例: hosts deny = 192.168.100/24 10.1.1.1 2001:db8::1428:57ab"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1060
+#: manpages/man5/afp.conf.5.md:1063
 #, no-wrap
 msgid "cnid scheme = <backend\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1063
+#: manpages/man5/afp.conf.5.md:1066
 #, no-wrap
 msgid ""
 "> set the CNID backend to be used for the volume, default is\n"
@@ -3006,7 +3012,7 @@ msgstr ""
 "\\[@compiled_backends@\\] である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1068
+#: manpages/man5/afp.conf.5.md:1071
 #, no-wrap
 msgid ""
 "> The \"mysql\" backend requires the system administrator to configure a\n"
@@ -3016,7 +3022,7 @@ msgstr ""
 "MySQL データベース インスタンスを構成する必要がある。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1074
+#: manpages/man5/afp.conf.5.md:1077
 #, no-wrap
 msgid ""
 "> Do *NOT* use the \"last\" backend for volumes, because **afpd** relies\n"
@@ -3027,13 +3033,13 @@ msgstr ""
 "データベースに重く依存しているので、このバックエンドをボリュームに使用するのは推奨*されていない*。エイリアスはおそらく機能しないだろうし、ファイル名のマングリングもサポートされていない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1076
+#: manpages/man5/afp.conf.5.md:1079
 #, no-wrap
 msgid "ea = <none|auto|sys|ad|samba\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1079
+#: manpages/man5/afp.conf.5.md:1082
 #, no-wrap
 msgid ""
 "> Specify how Extended Attributes are\n"
@@ -3043,12 +3049,12 @@ msgstr ""
 "がデフォルトである。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1081
+#: manpages/man5/afp.conf.5.md:1084
 msgid "auto"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1086
+#: manpages/man5/afp.conf.5.md:1089
 #, no-wrap
 msgid ""
 "> Try **sys** (by setting an EA on the shared directory itself), fallback to\n"
@@ -3064,23 +3070,23 @@ msgstr ""
 "\"**ea = sys|ad**\" を使ってください。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1088
+#: manpages/man5/afp.conf.5.md:1091
 msgid "sys"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1090
+#: manpages/man5/afp.conf.5.md:1093
 #, no-wrap
 msgid "> Use filesystem Extended Attributes.\n"
 msgstr "> ファイルシステムの拡張属性を使う。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1092
+#: manpages/man5/afp.conf.5.md:1095
 msgid "samba"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1095
+#: manpages/man5/afp.conf.5.md:1098
 #, no-wrap
 msgid ""
 "> Use filesystem Extended Attributes, but append a 0 byte to each xattr in\n"
@@ -3088,24 +3094,24 @@ msgid ""
 msgstr "> ファイルシステムの拡張属性を使うが、Sambaのvfs_streams_xattrとの互換性の目的で、それぞれの拡張属性に値がゼロの1バイトを追加する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1097
+#: manpages/man5/afp.conf.5.md:1100
 msgid "ad"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1099
+#: manpages/man5/afp.conf.5.md:1102
 #, no-wrap
 msgid "> Use files in *.AppleDouble* directories.\n"
 msgstr "> *.AppleDouble* ディレクトリ内のファイルを使う。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1103
+#: manpages/man5/afp.conf.5.md:1106
 #, no-wrap
 msgid "> No Extended Attributes support.\n"
 msgstr "> 拡張属性をサポートしない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1108
+#: manpages/man5/afp.conf.5.md:1111
 #, no-wrap
 msgid ""
 "> The **samba** option should not be used on a volume that was previously\n"
@@ -3115,13 +3121,13 @@ msgstr ""
 "に設定されたボリュームでは使用しないでください。これにより、データが失われる可能性がある。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1110
+#: manpages/man5/afp.conf.5.md:1113
 #, no-wrap
 msgid "mac charset = <charset\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1115
+#: manpages/man5/afp.conf.5.md:1118
 #, no-wrap
 msgid ""
 "> specifies the Mac client charset for this Volume, e.g. *MAC_ROMAN*,\n"
@@ -3135,13 +3141,13 @@ msgstr ""
 "セクションで全体的にセットしたキャラクターセットと異なるというボリュームを必要とする時のみ必須である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1117
+#: manpages/man5/afp.conf.5.md:1120
 #, no-wrap
 msgid "casefold = <option\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1120
+#: manpages/man5/afp.conf.5.md:1123
 #, no-wrap
 msgid ""
 "> The casefold option handles, if the case of filenames should be changed.\n"
@@ -3151,37 +3157,37 @@ msgstr ""
 "オプションが処理する。有効なオプションは:\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1122
+#: manpages/man5/afp.conf.5.md:1125
 #, no-wrap
 msgid "**tolower** - Lowercases names in both directions.\n"
 msgstr "**tolower** - 双方向で名前を小文字に変換する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1124
+#: manpages/man5/afp.conf.5.md:1127
 #, no-wrap
 msgid "**toupper** - Uppercases names in both directions.\n"
 msgstr "**toupper** - 双方向で名前を大文字に変換する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1126
+#: manpages/man5/afp.conf.5.md:1129
 #, no-wrap
 msgid "**xlatelower** - Client sees lowercase, server sees uppercase.\n"
 msgstr "**xlatelower** - クライアントでは小文字に見えて、サーバでは大文字に見える。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1128
+#: manpages/man5/afp.conf.5.md:1131
 #, no-wrap
 msgid "**xlateupper** - Client sees uppercase, server sees lowercase.\n"
 msgstr "**xlateupper** - クライアントでは大文字に見えて、サーバでは小文字にみえる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1130
+#: manpages/man5/afp.conf.5.md:1133
 #, no-wrap
 msgid "password = <password\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1134
+#: manpages/man5/afp.conf.5.md:1137
 #, no-wrap
 msgid ""
 "> This option allows you to set a volume password, which can be a maximum\n"
@@ -3192,13 +3198,13 @@ msgstr ""
 "8 文字の長さ（これを記入するときには ASCII を強く推奨）\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1136
+#: manpages/man5/afp.conf.5.md:1139
 #, no-wrap
 msgid "file perm = <mode\\> **(V)**; directory perm = <mode\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1140
+#: manpages/man5/afp.conf.5.md:1143
 #, no-wrap
 msgid ""
 "> Add(or) with the client requested permissions: **file perm** is for files\n"
@@ -3210,13 +3216,13 @@ msgstr ""
 "\"**unix priv = no**\" と共に用いてはならない。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:1141
+#: manpages/man5/afp.conf.5.md:1144
 #, no-wrap
 msgid "Example: Volume for a collaborative workgroup"
 msgstr "例：共同作業グループ向けのボリューム"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1145
+#: manpages/man5/afp.conf.5.md:1148
 #, no-wrap
 msgid ""
 "    file perm = 0660\n"
@@ -3224,49 +3230,49 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1147
+#: manpages/man5/afp.conf.5.md:1150
 #, no-wrap
 msgid "umask = <mode\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1149
+#: manpages/man5/afp.conf.5.md:1152
 #, no-wrap
 msgid "> set perm mask. Don't use with \"**unix priv = no**\".\n"
 msgstr "> 権限のマスクを設定する。\"**unix priv = no**\" と共に用いてはならない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1151
+#: manpages/man5/afp.conf.5.md:1154
 #, no-wrap
 msgid "preexec = <command\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1153
+#: manpages/man5/afp.conf.5.md:1156
 #, no-wrap
 msgid "> command to be run when the volume is mounted\n"
 msgstr "> ボリュームがマウントされる時に実行されるコマンド\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1155
+#: manpages/man5/afp.conf.5.md:1158
 #, no-wrap
 msgid "postexec = <command\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1157
+#: manpages/man5/afp.conf.5.md:1160
 #, no-wrap
 msgid "> command to be run when the volume is closed\n"
 msgstr "> ボリュームが閉じられる時に実行されるコマンド\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1159
+#: manpages/man5/afp.conf.5.md:1162
 #, no-wrap
 msgid "rolist = <users/groups\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1162
+#: manpages/man5/afp.conf.5.md:1165
 #, no-wrap
 msgid ""
 "> Allows certain users and groups to have read-only access to a share.\n"
@@ -3276,13 +3282,13 @@ msgstr ""
 "allow オプションに準ずる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1164
+#: manpages/man5/afp.conf.5.md:1167
 #, no-wrap
 msgid "rwlist = <users/groups\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1167
+#: manpages/man5/afp.conf.5.md:1170
 #, no-wrap
 msgid ""
 "> Allows certain users and groups to have read/write access to a share.\n"
@@ -3292,13 +3298,13 @@ msgstr ""
 "allow オプションに準ずる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1169
+#: manpages/man5/afp.conf.5.md:1172
 #, no-wrap
 msgid "veto files = <vetoed names\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1173
+#: manpages/man5/afp.conf.5.md:1176
 #, no-wrap
 msgid ""
 "> hide files and directories,where the path matches one of the '/'\n"
@@ -3311,24 +3317,24 @@ msgstr ""
 "= veto1/veto2/\"。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:1174
+#: manpages/man5/afp.conf.5.md:1177
 #, no-wrap
 msgid "Volume options"
 msgstr "ボリュームオプション"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1177
+#: manpages/man5/afp.conf.5.md:1180
 msgid "Boolean volume options."
 msgstr "ブーリアン型のボリュームオプション。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1179
+#: manpages/man5/afp.conf.5.md:1182
 #, no-wrap
 msgid "acls = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "acls = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1182
+#: manpages/man5/afp.conf.5.md:1185
 #, no-wrap
 msgid ""
 "> Whether to flag volumes as supporting ACLs. If ACL support is compiled\n"
@@ -3338,13 +3344,13 @@ msgstr ""
 "サポートでコンパイルしていれば、これはデフォルトで yes。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1184
+#: manpages/man5/afp.conf.5.md:1187
 #, no-wrap
 msgid "case sensitive = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "case sensitive = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1188
+#: manpages/man5/afp.conf.5.md:1191
 #, no-wrap
 msgid ""
 "> Whether to flag volumes as supporting case-sensitive filenames. If the\n"
@@ -3356,7 +3362,7 @@ msgstr ""
 "を設定せよ。しかしながらこれは完全には確かめられていない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1194
+#: manpages/man5/afp.conf.5.md:1197
 #, no-wrap
 msgid ""
 "> In spite of being case sensitive as a matter of fact, netatalk 3.1.3 and\n"
@@ -3369,13 +3375,13 @@ msgstr ""
 "からはデフォルトで正しく通知される。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1196
+#: manpages/man5/afp.conf.5.md:1199
 #, no-wrap
 msgid "cnid dev = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "cnid dev = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1199
+#: manpages/man5/afp.conf.5.md:1202
 #, no-wrap
 msgid ""
 "> Whether to use the device number in the CNID backends. Helps when the\n"
@@ -3385,13 +3391,13 @@ msgstr ""
 "例えばクラスターなどでリブートを経るとデバイス番号が固定ではない時有用。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1201
+#: manpages/man5/afp.conf.5.md:1204
 #, no-wrap
 msgid "convert appledouble = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "convert appledouble = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1207
+#: manpages/man5/afp.conf.5.md:1210
 #, no-wrap
 msgid ""
 "> Whether automatic conversion from **appledouble = v2** to\n"
@@ -3407,13 +3413,13 @@ msgstr ""
 "に設定することもできる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1209
+#: manpages/man5/afp.conf.5.md:1212
 #, no-wrap
 msgid "delete veto files = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "delete veto files = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1215
+#: manpages/man5/afp.conf.5.md:1218
 #, no-wrap
 msgid ""
 "> This option is used when Netatalk is attempting to delete a directory\n"
@@ -3429,7 +3435,7 @@ msgstr ""
 "ファイルないしはディレクトリを含んでいたら、ディレクトリの削除は失敗するであろう。これは通常あなたの望むところの動作である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1218
+#: manpages/man5/afp.conf.5.md:1221
 msgid ""
 "If this option is set to yes, then Netatalk will attempt to recursively "
 "delete any files and directories within the vetoed directory."
@@ -3439,13 +3445,13 @@ msgstr ""
 "するであろう。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1220
+#: manpages/man5/afp.conf.5.md:1223
 #, no-wrap
 msgid "follow symlinks = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "follow symlinks = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1226
+#: manpages/man5/afp.conf.5.md:1229
 #, no-wrap
 msgid ""
 "> The default setting is false thus symlinks are not followed on the\n"
@@ -3461,7 +3467,7 @@ msgstr ""
 "ボリューム以外を指しているかもしれない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1231
+#: manpages/man5/afp.conf.5.md:1234
 #, no-wrap
 msgid ""
 "> This option will subtly break when the symlinks point across filesystem\n"
@@ -3469,13 +3475,13 @@ msgid ""
 msgstr "> シンボリックリンクがファイルシステムの境界をまたいで張られている時、このオプションは巧妙に断ち切る。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1233
+#: manpages/man5/afp.conf.5.md:1236
 #, no-wrap
 msgid "invisible dots = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "invisible dots = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1241
+#: manpages/man5/afp.conf.5.md:1244
 #, no-wrap
 msgid ""
 "> make dot files invisible. WARNING: enabling this option will lead to\n"
@@ -3495,13 +3501,13 @@ msgstr ""
 "でもターミナルでもドットではじまるファイルはいずれにしても隠しファイルなので、完全に無駄である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1243
+#: manpages/man5/afp.conf.5.md:1246
 #, no-wrap
 msgid "legacy volume size = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "legacy volume size = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1247
+#: manpages/man5/afp.conf.5.md:1250
 #, no-wrap
 msgid ""
 "> Limit disk size reporting to 2GB for legacy clients. This can be used\n"
@@ -3513,13 +3519,13 @@ msgstr ""
 "クライアントを使用している古い Macintosh で使用できる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1249
+#: manpages/man5/afp.conf.5.md:1252
 #, no-wrap
 msgid "name = <STRING\\> (default: section name in lowercase) **(V)**\n"
 msgstr "name = <STRING\\> (デフォルト: 小文字のセクション名) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1253
+#: manpages/man5/afp.conf.5.md:1256
 #, no-wrap
 msgid ""
 "> The name option specifies the name of the shared AFP volume.\n"
@@ -3528,13 +3534,13 @@ msgid ""
 msgstr "> ボリュームの名前を指定する。デフォルトでは、ボリュームが定義されている ini ファイルの小文字に変換されたセクション名となる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1255
+#: manpages/man5/afp.conf.5.md:1258
 #, no-wrap
 msgid "network ids = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "network ids = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1258
+#: manpages/man5/afp.conf.5.md:1261
 #, no-wrap
 msgid ""
 "> Whether the server support network ids. Setting this to *no* will result\n"
@@ -3544,13 +3550,13 @@ msgstr ""
 "に設定すると結果としてクライアントは ACL AFP 機能を使わなくなる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1260
+#: manpages/man5/afp.conf.5.md:1263
 #, no-wrap
 msgid "preexec close = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "preexec close = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1263
+#: manpages/man5/afp.conf.5.md:1266
 #, no-wrap
 msgid ""
 "> A non-zero return code from preexec close the volume being immediately,\n"
@@ -3560,13 +3566,13 @@ msgstr ""
 "以外のリターンコードで、クライアントがボリュームをマウントする／見ることを防ぐために当該ボリュームを即座に閉じる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1265
+#: manpages/man5/afp.conf.5.md:1268
 #, no-wrap
 msgid "prodos = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "prodos = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1269
+#: manpages/man5/afp.conf.5.md:1272
 #, no-wrap
 msgid ""
 "> Enable ProDOS support. This option should only be enabled for volumes\n"
@@ -3579,13 +3585,13 @@ msgstr ""
 "に制限する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1271
+#: manpages/man5/afp.conf.5.md:1274
 #, no-wrap
 msgid "read only = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "read only = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1274
+#: manpages/man5/afp.conf.5.md:1277
 #, no-wrap
 msgid ""
 "> Specifies the share as being read only for all users. Overwrites\n"
@@ -3595,13 +3601,13 @@ msgstr ""
 "**ea = none** で上書きされる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1276
+#: manpages/man5/afp.conf.5.md:1279
 #, no-wrap
 msgid "search db = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "search db = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1281
+#: manpages/man5/afp.conf.5.md:1284
 #, no-wrap
 msgid ""
 "> Use fast CNID database namesearch instead of slow recursive filesystem\n"
@@ -3616,13 +3622,13 @@ msgstr ""
 "CNID db のボリュームのみで動作する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1283
+#: manpages/man5/afp.conf.5.md:1286
 #, no-wrap
 msgid "stat vol = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "stat vol = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1286
+#: manpages/man5/afp.conf.5.md:1289
 #, no-wrap
 msgid ""
 "> Whether to stat volume path when enumerating volumes list, useful for\n"
@@ -3633,25 +3639,25 @@ msgstr ""
 "スクリプトで作成されたボリュームに有用である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1288
+#: manpages/man5/afp.conf.5.md:1291
 #, no-wrap
 msgid "time machine = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "time machine = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1290
+#: manpages/man5/afp.conf.5.md:1293
 #, no-wrap
 msgid "> Whether to enable Time Machine support for this volume.\n"
 msgstr "> このボリュームの Time Machine サポートを有効にするかどうか。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1292
+#: manpages/man5/afp.conf.5.md:1295
 #, no-wrap
 msgid "unix priv = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "unix priv = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1295
+#: manpages/man5/afp.conf.5.md:1298
 #, no-wrap
 msgid ""
 "> Whether to use AFP3 UNIX privileges. This should be set for OS X\n"
@@ -3662,13 +3668,13 @@ msgstr ""
 "及び `umask` も参照。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:1298
+#: manpages/man5/afp.conf.5.md:1301
 #, no-wrap
 msgid "Example: Modern Mac clients"
 msgstr "例：現代の Mac クライアント"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1303
+#: manpages/man5/afp.conf.5.md:1306
 msgid ""
 "This enables Spotlight and AFP stats if Netatalk was built with Spotlight "
 "and AFP stats support. The **mimic model** option is used to make the server "
@@ -3679,12 +3685,12 @@ msgstr ""
 "る。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1305
+#: manpages/man5/afp.conf.5.md:1308
 msgid "The home directory is mounted on */home/{user}/afp-data*."
 msgstr "ホームディレクトリは */home/{user}/afp-data* にマウントされる。"
 
 #. type: Fenced code block
-#: manpages/man5/afp.conf.5.md:1306
+#: manpages/man5/afp.conf.5.md:1309
 #, no-wrap
 msgid ""
 "[Global]\n"
@@ -3698,13 +3704,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:1317
+#: manpages/man5/afp.conf.5.md:1320
 #, no-wrap
 msgid "Example: Classic Mac clients"
 msgstr "例：レトロ Mac クライアント"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1323
+#: manpages/man5/afp.conf.5.md:1326
 msgid ""
 "This enables AppleTalk if Netatalk was built with AppleTalk support.  The "
 "Random Number and ClearTxt authentication modules are used.  The **legacy "
@@ -3715,7 +3721,7 @@ msgstr ""
 "ションはサーバーを BSD デーモンのように見せるために使われる。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1328
+#: manpages/man5/afp.conf.5.md:1331
 msgid ""
 "With **legacy volume size** the volume size is limited to 2 GB for very old "
 "Macs, while **prodos** is used to enable ProDOS boot flags on the volume "
@@ -3726,7 +3732,7 @@ msgstr ""
 "制限される。"
 
 #. type: Fenced code block
-#: manpages/man5/afp.conf.5.md:1329
+#: manpages/man5/afp.conf.5.md:1332
 #, no-wrap
 msgid ""
 "[Global]\n"
@@ -3746,7 +3752,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1350
+#: manpages/man5/afp.conf.5.md:1353
 msgid ""
 "afpd(8), afppasswd(5), afp_signature.conf(5), extmap.conf(5), cnid_metad(8)"
 msgstr ""


### PR DESCRIPTION
`cnid listen` is used by cnid_metad to listen to db connections from afpd, while `cnid server` is used by afpd to tell it which cnid_metad to attempt to make db connections to. This documentation tweak should hopefully make that more clear.