### PR TITLE
afpd: Use servername for ASP connections with hostname fallback

### DIFF
--- a/etc/afpd/afp_config.c
+++ b/etc/afpd/afp_config.c
@@ -149,7 +149,14 @@ int configinit(AFPObj *dsi_obj, AFPObj *asp_obj)
         }
 
         /* register asp server */
-        Obj = (char*)asp_obj->options.hostname;
+        Obj = asp_obj->options.servername ? asp_obj->options.servername : asp_obj->options.hostname;
+        char tmpnam[32];
+        convert_string(asp_obj->options.unixcharset,
+                        asp_obj->options.maccharset,
+                        Obj, strnlen(Obj, PATH_MAX),
+                        tmpnam, sizeof(tmpnam)-1);
+        tmpnam[31] = '\0';
+        Obj = tmpnam;
 
         /* set a custom zone if user requested one */
         if (asp_obj->options.zone) {


### PR DESCRIPTION
Missing part of https://github.com/Netatalk/netatalk/pull/1974 where the new servername option was introduced.