### PR TITLE
docker: Introduce env variable flag for enabling debug mode in entry script

### DIFF
--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -20,6 +20,8 @@
 
 set -e
 
+[ -n "$DEBUG_ENTRY_SCRIPT" ] && set -x
+
 echo "*** Setting up users and groups"
 
 if [ -z "$AFP_USER" ]; then


### PR DESCRIPTION
Set `DEBUG_ENTRY_SCRIPT` to non-zero to echo back all shell commands to the terminal.