### PR TITLE
docker: Introduce dropbox mode option for guest access

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -98,9 +98,10 @@ These are required to set the credentials used to authenticate with the file ser
 | `SHARE_NAME`    | The name of the primary shared volume                          |
 | `SHARE2_NAME`   | The name of the secondary shared (Time Machine) volume         |
 | `AFP_LOGLEVEL`  | The verbosity of logs; default is "info"                       |
-| `AFP_MIMIC_MODEL` | Use a custom modern AFP icon, such as `Tower` or `Laptop`    |
+| `AFP_MIMIC_MODEL` | Use a custom modern AFP icon, such as `Tower` or `RackMount` |
 | `AFP_LEGACY_ICON` | Use a custom legacy AFP icon, such as `daemon` or `sdcard`   |
 | `INSECURE_AUTH` | When non-zero, enable the "ClearTxt" and "Guest" UAMs          |
 | `DISABLE_TIMEMACHINE` | When non-zero, the secondary shared volume is a regular volume |
 | `MANUAL_CONFIG` | When non-zero, enable manual management of config files        |
-| `ATALKD_OPTIONS` | A string with options to append to atalkd.conf        |
+| `ATALKD_OPTIONS` | A string with options to append to atalkd.conf                |
+| `AFP_DROPBOX` |  Enable dropbox mode; turns secondary user into guest with read only access to the second shared volume |


### PR DESCRIPTION
When enabled, the secondary user is set to `nobody` and the secondary shared volume to be r/w by the guest user (while the primary volume is read-only by the guest user).

When setting $AFP_DROPBOX to non-zero, this will enable dropbox permissions, turn on insecure auth, disable time machine, and set the name of the secondary volume to Dropbox.