### PR TITLE
Control metadata settings with 'ea' solely, removing 'appledouble' option

### DIFF
--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -123,11 +123,9 @@ fi
 
 if [ -n "$AFP_ADOUBLE" ]; then
     AFP_EA="ad"
-    AFP_AD="v2"
     TEST_FLAGS="$TEST_FLAGS -a"
 else
     AFP_EA="sys"
-    AFP_AD="ea"
 fi
 
 if [ -n "$AFP_DROPBOX" ]; then
@@ -150,14 +148,12 @@ server name = ${SERVER_NAME:-Netatalk File Server}
 spotlight = yes
 uam list = $UAMS
 [${SHARE_NAME:-File Sharing}]
-appledouble = $AFP_AD
 ea = $AFP_EA
 path = /mnt/afpshare
 valid users = $AFP_VALIDUSERS1
 volume name = ${SHARE_NAME:-File Sharing}
 $AFP_RWRO = $AFP_VALIDUSERS1
 [${SHARE2_NAME:-Time Machine}]
-appledouble = $AFP_AD
 ea = $AFP_EA
 path = /mnt/afpbackup
 time machine = $TIMEMACHINE

--- a/doc/manpages/man1/dbd.1.md
+++ b/doc/manpages/man1/dbd.1.md
@@ -12,13 +12,13 @@ dbd — CNID database maintenance
 
 **dbd** scans all file and directories of AFP volumes, updating the CNID
 database of the volume. It must be run with appropriate permissions i.e.
-as root..
+as root.
 
 # Options
 
 **-c**
 
-> convert from "**appledouble = v2**" to "**appledouble = ea**"
+> convert from *AppleDouble v2* to *EA* filesystem metadata
 
 **-f**
 

--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -1004,17 +1004,6 @@ path = <PATH\> **(V)**
 
 > The path name must be a fully qualified path name.
 
-appledouble = <ea|v2\> **(V)**
-
-> Specify the format of the metadata files, which are used for saving Mac
-resource forks and extended attributes.
-Earlier versions used AppleDouble **v2**, the new default format is **ea**.
-
-> **WARNING**
-
-> The **v2** option is obsolete and should not be used unless
-absoluteley necessary. It may go away in the future.
-
 vol size limit = <size in MiB\> **(V)**
 
 > Useful for Time Machine: limits the reported volume size, thus
@@ -1075,17 +1064,16 @@ MySQL database instance for use with netatalk.
 heavily on a persistent ID database. Aliases will likely not work and
 filename mangling is not supported.
 
-ea = <none|auto|sys|ad|samba\> **(V)**
+ea = <sys|samba|ad|none\> (default: auto detect) **(V)**
 
-> Specify how Extended Attributes are
-stored. **auto** is the default.
+> Specify how Extended Attributes and Classic Mac OS resource forks are
+stored.
 
-auto
-
-> Try **sys** (by setting an EA on the shared directory itself), fallback to
-**ad**. Requires writable volume for performing test. "**read only = yes**"
-overwrites **auto** with **none**. Use explicit "**ea = sys|ad**" for
-read-only volumes where appropriate.
+By default, we attempt to enable **sys** with a fallback to **ad**.
+For the auto detection to work, the volume needs to be writable
+because we attempt to set an EA on the shared directory itself.
+If **read only = yes** is set, we fallback to **sys**.
+Use explicit "**ea = ad|none**" for read-only volumes where appropriate.
 
 sys
 
@@ -1098,7 +1086,9 @@ order to be compatible with Samba's vfs_streams_xattr.
 
 ad
 
-> Use files in *.AppleDouble* directories.
+> Use AppleDouble v2 metadata stored as files in *.AppleDouble* directories.
+This should only be used when the host's filesystem does not support
+Extended Attributes.
 
 none
 
@@ -1202,11 +1192,11 @@ device number is not constant across a reboot, e.g. cluster, ...
 
 convert appledouble = <BOOLEAN\> (default: *yes*) **(V)**
 
-> Whether automatic conversion from **appledouble = v2** to
-**appledouble = ea** is performed when accessing filesystems from clients.
+> Whether automatic conversion from AppleDouble v2 to Extended Attributes
+is performed when accessing filesystems from clients.
 This is generally useful, but costs some performance. It's recommendable
 to run **dbd** on volumes and do the conversion with that. Then this
-option can be set to no.
+option can be set to *no*.
 
 delete veto files = <BOOLEAN\> (default: *no*) **(V)**
 

--- a/doc/manual/Upgrading.md
+++ b/doc/manual/Upgrading.md
@@ -18,8 +18,8 @@ There are three major changes between Netatalk 2 and Netatalk 4:
 1.  New configuration files that replaces most of the previous ones:
     *afp.conf* and *extmap.conf*
 
-2.  New AppleDouble backend **appledouble = ea** which stores Mac metadata
-    and resource forks in extended attributes of the filesystem.
+2.  New backend for file metadata which stores metadata in extended attributes
+    of the filesystem.
 
 3.  The AppleTalk transport layer is disabled by default. If you want to
     use Netatalk with very old Macs, turn it on with the
@@ -52,18 +52,18 @@ There are three major changes between Netatalk 2 and Netatalk 4:
 
 - obsoletes *AppleVolumes.system*
 
-### New AppleDouble backend
+### New metadata backend
 
-New AppleDouble backend **appledouble = ea** which stores Mac metadata and
-resource forks in extended attributes of the filesystem.
+New file metadata backend **ea = sys** which stores macOS extended attributes
+and Classic Mac OS resource forks in extended attributes of the filesystem.
 
 - default backend (!)
 
-- requires a filesystem with Extended Attributes, fallback is
-  **appledouble = v2**
+- requires a filesystem with Extended Attributes, fallback is AppleDouble v2
+  which is enabled with **ea = ad**
 
-- converts filesystems from **appledouble = v2** to **appledouble = ea** on
-  the fly when accessed (can be disabled)
+- converts filesystems from AppleDouble v2 to Extended Attributes on
+  the fly when accessed by clients (can be disabled with **convert appledouble**)
 
 - **dbd** can be used to do conversion in one shot
 
@@ -267,16 +267,16 @@ Implementation details:
 | veto: | veto files | \- | \- | \(V\) | \- |
 | cnidscheme: | cnid scheme | dbd | dbd | \(V\) | \- |
 | casefold: | casefold | \- | \- | \(V\) | \- |
-| adouble: | appledouble | v2 | ea | \(V\) | v1, osx and sfm are obsoleted |
+| adouble: | \- | v2 | \- | \- | removed in 4.2.0 |
 | cnidserver: | cnid server | localhost:4700 | localhost:4700 | (G)/(V) | \- |
 | dbpath: | vol dbpath | (volume directory) | var/netatalk/CNID/ | \(G\) | moved to $localstatedir |
 | umask: | umask | 0000 | 0000 | \(V\) | \- |
 | dperm: | directory perm | 0000 | 0000 | \(V\) | \- |
 | fperm: | file perm | 0000 | 0000 | \(V\) | \- |
 | password: | password | \- | \- | \(V\) | \- |
-| root_preexec: | \- | \- | \- | \- | obsoleted in 4.1.0 |
+| root_preexec: | \- | \- | \- | \- | removed in 4.1.0 |
 | preexec: | preexec | \- | \- | \(V\) | \- |
-| root_postexec: | \- | \- | \- | \- | obsoleted in 4.1.0 |
+| root_postexec: | \- | \- | \- | \- | removed in 4.1.0 |
 | postexec: | postexec | \- | \- | \(V\) | \- |
 | allowed_hosts: | hosts allow | \- | \- | \(V\) | \- |
 | denied_hosts: | hosts deny | \- | \- | \(V\) | \- |
@@ -289,7 +289,7 @@ Implementation details:
 | options:invisibledots | invisible dots | \- | no | \(V\) | \- |
 | options:nostat | stat vol | \- | yes | \(V\) | \- |
 | options:preexec_close | preexec close | \- | no | \(V\) | \- |
-| options:root_preexec_close | \- | \- | \- | \- | obsoleted in 4.1.0 |
+| options:root_preexec_close | \- | \- | \- | \- | removed in 4.1.0 |
 | options:upriv | unix priv | \- | yes | \(V\) | \- |
 | options:nodev | cnid dev | \- | yes | \(V\) | \- |
 | options:illegalseq | illegal seq | \- | no | \(V\) | \- |

--- a/test/afpd/test.sh
+++ b/test/afpd/test.sh
@@ -16,6 +16,7 @@ afp port = 10548
 [test]
 path = /tmp/AFPtestvolume
 cnid scheme = last
+ea = none
 EOF
     echo [ok]
 fi

--- a/test/testsuite/README
+++ b/test/testsuite/README
@@ -69,12 +69,12 @@ afp.conf:
 uam list = uams_clrtxt.so uams_guest.so
 
 [volume1]
-appledouble = ea
+ea = sys
 path = /tmp/afptest1
 valid users = @afpusers
 
 [volume2]
-appledouble = ea
+ea = sys
 path = /tmp/afptest2
 valid users = @afpusers
 #<<<<<<<<

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -870,10 +870,10 @@ void test_skipped(int why)
 		s = "volume with extendend attribute support";
 		break;
 	case T_ADEA:
-		s = "Netatalk 3+ and volume with 'appledouble = ea'";
+		s = "Netatalk 3+ and volume with EA metadata";
 		break;
 	case T_ADV2:
-		s = "volume with 'appledouble = v2'";
+		s = "volume with AppleDouble metadata";
 		break;
 	case T_NOSYML:
 		s = "volume without option 'follow symlinks'";

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -327,7 +327,7 @@ void usage( char * av0 )
 {
     fprintf( stdout, "usage:\t%s [-1234567aCiLlmnVvXx] [-h host] [-H host2] [-p port] [-s vol] [-c vol path] [-S vol2] "
 	"[-u user] [-d user2] [-w password] [-F testsuite] [-f test]\n", av0 );
-    fprintf( stdout,"\t-a\tvolume is appledouble = v2 instead of default appledouble = ea\n");
+    fprintf( stdout,"\t-a\tvolume is using AppleDouble metadata and not EA\n");
     fprintf( stdout,"\t-L\tserver without working fcntl locking, skip tests using it\n");
     fprintf( stdout,"\t-m\tserver is a Mac\n");
     fprintf( stdout,"\t-h\tserver host name (default localhost)\n");

--- a/test/testsuite/spectest.sh
+++ b/test/testsuite/spectest.sh
@@ -22,7 +22,7 @@ USER1=
 USER2=
 PASSWD=
 
-# *** volumes configured with appledouble = ea
+# *** volumes configured with ea = sys
 VOLUME1=
 VOLUME2=
 


### PR DESCRIPTION
- Always use ad v2 metadata with ad, and ea metadata with sys
- Remove the distinct 'appledouble' option
- Remove references to the 'ea = auto' option since it is undefined
- Use ad v2 fallback for ea metadata rather than none