### PR TITLE
Protect against memory leaks and out of bounds array access

### DIFF
--- a/bin/ad/ad_find.c
+++ b/bin/ad/ad_find.c
@@ -92,12 +92,14 @@ int ad_find(int argc, char **argv, AFPObj *obj)
     while ((c = getopt(argc-1, &argv[1], ":v:")) != -1) {
         switch(c) {
         case 'v':
+            free((void *)srchvol);
             srchvol = strdup(optarg);
             break;
         case ':':
         case '?':
             usage_find();
-            return -1;
+            free((void *)srchvol);
+            exit(1);
             break;
         }
 
@@ -106,6 +108,7 @@ int ad_find(int argc, char **argv, AFPObj *obj)
 
     if ((argc - optind) != 1) {
         usage_find();
+        free((void *)srchvol);
         exit(1);
     }
 

--- a/bin/misc/fce.c
+++ b/bin/misc/fce.c
@@ -117,8 +117,14 @@ int main(int argc, char **argv)
     while ((c = getopt(argc, argv, "h:")) != -1) {
         switch(c) {
         case 'h':
+            free((void *)host);
             host = strdup(optarg);
             break;
+        case '?':
+        default:
+            fprintf(stderr, "Usage: %s [-h hostname]\n", argv[0]);
+            free((void *)host);
+            return 1;
         }
     }
 
@@ -151,6 +157,7 @@ int main(int argc, char **argv)
 
     if (p == NULL) {
         fprintf(stderr, "listener: failed to bind socket\n");
+        free((void *)host);
         return 2;
     }
 

--- a/bin/misc/netacnv.c
+++ b/bin/misc/netacnv.c
@@ -34,14 +34,24 @@ struct flag_map flag_map[] = {
 
 char buffer[MAXPATHLEN +2];
 
+static void usage(void)
+{
+    printf("Usage: netacnv [-o <conversion option> [...]] [-f <from charset>] [-t <to charset>] [-m legacy Mac charset] <string>\n");
+    printf("Defaults: -f: UTF8-MAC, -t: UTF8, -m MAC_ROMAN\n");
+    printf("Available conversion options:\n");
+    for (int i = 0; i < (sizeof(flag_map)/sizeof(struct flag_map) - 1); i++) {
+        printf("%s\n", flag_map[i].flagname);
+    }
+}
+
 int main(int argc, char **argv)
 {
     int opt;
     uint16_t flags = 0;
     char *string;
     char *macName = strdup(MACCHARSET);
-    const char *f = NULL;
-    const char *t = NULL;
+    char *f = NULL;
+    char *t = NULL;
     charset_t from;
     charset_t to;
     charset_t mac;
@@ -62,16 +72,21 @@ int main(int argc, char **argv)
         case 't':
             t = strdup(optarg);
             break;
+        case '?':
+        default:
+            usage();
+            free((void *)macName);
+            if (f) free((void *)f);
+            if (t) free((void *)t);
+            return 1;
         }
     }
 
     if ((optind + 1) != argc) {
-        printf("Usage: test [-o <conversion option> [...]] [-f <from charset>] [-t <to charset>] [-m legacy Mac charset] <string>\n");
-        printf("Defaults: -f: UTF8-MAC, -t: UTF8, -m MAC_ROMAN\n");
-        printf("Available conversion options:\n");
-        for (int i = 0; i < (sizeof(flag_map)/sizeof(struct flag_map) - 1); i++) {
-            printf("%s\n", flag_map[i].flagname);
-        }
+        usage();
+        free((void *)macName);
+        if (f) free((void *)f);
+        if (t) free((void *)t);
         return 1;
     }
     string = argv[optind];

--- a/etc/afpd/appl.c
+++ b/etc/afpd/appl.c
@@ -215,14 +215,17 @@ int afp_addappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, siz
     /* write the new appl entry at start of temporary file */
     p = mp - sizeof( u_short );
     mplen = htons( mplen );
-    if (p >= mpath && (p + sizeof(mplen)) <= (mpath + AFPOBJ_TMPSIZ)) {
-        memcpy(p, &mplen, sizeof(mplen));
-    } else {
+    if (p < mpath || (p + sizeof(mplen)) > (mpath + AFPOBJ_TMPSIZ)) {
         close(tfd);
         return AFPERR_PARAM;
     }
+    memcpy( p, &mplen, sizeof( mplen ));
     mplen = ntohs( mplen );
     p -= sizeof( appltag );
+    if (p < mpath || (p + sizeof(appltag)) > (mpath + AFPOBJ_TMPSIZ)) {
+        close(tfd);
+        return AFPERR_PARAM;
+    }
     memcpy(p, appltag, sizeof( appltag ));
     cc = mpath + AFPOBJ_TMPSIZ - p;
     if ( write( tfd, p, cc ) != cc ) {

--- a/etc/cnid_dbd/cnid_metad.c
+++ b/etc/cnid_dbd/cnid_metad.c
@@ -471,20 +471,33 @@ int main(int argc, char *argv[])
             debug = 1;
             break;
         case 'F':
+            if (obj.cmdlineconfigfile != NULL) {
+                free((void *)obj.cmdlineconfigfile);
+            }
             obj.cmdlineconfigfile = strdup(optarg);
             break;
         case 'v':
         case 'V':
             printf("cnid_metad (Netatalk %s)\n", VERSION);
+            if (obj.cmdlineconfigfile != NULL) {
+                free((void *)obj.cmdlineconfigfile);
+            }
             return -1;
         default:
             printf("cnid_metad [-dvV] [-F alternate configfile ]\n");
+            if (obj.cmdlineconfigfile != NULL) {
+                free((void *)obj.cmdlineconfigfile);
+            }
             return -1;
         }
     }
 
-    if (!debug && daemonize(0, 0) != 0)
+    if (!debug && daemonize(0, 0) != 0) {
+        if (obj.cmdlineconfigfile != NULL) {
+            free((void *)obj.cmdlineconfigfile);
+        }
         exit(EXITERR_SYS);
+    }
 
     if (afp_config_parse(&obj, "cnid_metad") != 0) {
         if (obj.cmdlineconfigfile != NULL) {

--- a/etc/cnid_dbd/main.c
+++ b/etc/cnid_dbd/main.c
@@ -504,11 +504,20 @@ int main(int argc, char *argv[])
         case 'v':
         case 'V':
             printf("cnid_dbd (Netatalk %s)\n", VERSION);
+            if (username) {
+                free((void *)username);
+            }
+            if (volpath) {
+                free((void *)volpath);
+            }
             return -1;
         case 'F':
             obj.cmdlineconfigfile = strdup(optarg);
             break;
         case 'p':
+            if (volpath) {
+                free((void *)volpath);
+            }
             volpath = strdup(optarg);
             break;
         case 'l':
@@ -518,6 +527,9 @@ int main(int argc, char *argv[])
             ctrlfd = atoi(optarg);
             break;
         case 'u':
+            if (username) {
+                free((void *)username);
+            }
             username = strdup(optarg);
             break;
         case ':':
@@ -527,6 +539,15 @@ int main(int argc, char *argv[])
 
     if (ctrlfd == -1 || clntfd == -1 || !volpath) {
         LOG(log_error, logtype_cnid, "main: bad IPC fds");
+        if (obj.cmdlineconfigfile) {
+            free((void *)obj.cmdlineconfigfile);
+        }
+        if (volpath) {
+            free((void *)volpath);
+        }
+        if (username) {
+            free((void *)username);
+        }
         exit(EXIT_FAILURE);
     }
 

--- a/libatalk/bstring/bstrlib.c
+++ b/libatalk/bstring/bstrlib.c
@@ -1076,11 +1076,12 @@ int bdelete (bstring b, int pos, int len) {
  *  been bdestroyed is undefined.
  */
 int bdestroy (bstring b) {
-	if (b == NULL || b->slen < 0 || b->mlen <= 0 || b->mlen < b->slen ||
-	    b->data == NULL)
+	if (b == NULL) {
 		return BSTR_ERR;
-
-	bstr__free (b->data);
+	}
+	if (b->data != NULL) {
+		bstr__free (b->data);
+	}
 
 	/* In case there is any stale usage, there is one more chance to
 	   notice this error. */

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -895,10 +895,11 @@ static struct vol *creatvol(AFPObj *obj,
     /* vol charset is in [G] and [V] */
     if ((val = getoption_str(obj->iniconfig, section, "vol charset", preset, NULL))) {
         if (strcasecmp(val, "UTF-8") == 0) {
-            val = strdup("UTF8");
+            EC_NULL( volume->v_volcodepage = strdup("UTF8") );
         }
-        volume->v_volcodepage = strdup(val);
-        EC_NULL( volume->v_volcodepage );
+        else {
+            EC_NULL( volume->v_volcodepage = strdup(val) );
+        }
     }
     else
         EC_NULL( volume->v_volcodepage = strdup(obj->options.volcodepage) );

--- a/libatalk/vfs/ea_sys.c
+++ b/libatalk/vfs/ea_sys.c
@@ -395,7 +395,6 @@ int sys_set_ea(VFS_FUNC_ARGS_EA_SET)
      */
     eabuf = malloc(attrsize + 1);
     if (eabuf == NULL) {
-        free(eabuf);
         return AFPERR_MISC;
     }
     memcpy(eabuf, ibuf, attrsize);
@@ -424,6 +423,8 @@ int sys_set_ea(VFS_FUNC_ARGS_EA_SET)
 	}
     }
     /* PBaranski fix */
+
+    free(eabuf);
 
     if (ret == -1) {
         switch(errno) {

--- a/libatalk/vfs/vfs.c
+++ b/libatalk/vfs/vfs.c
@@ -329,7 +329,7 @@ static int RF_copyfile_adouble(VFS_FUNC_ARGS_COPYFILE)
 
         /* build src path to AppleDouble file*/
         EC_NULL(dup1 = strdup(src));
-        EC_NULL(name = basename(strdup(dup1)));
+        EC_NULL(name = basename(dup1));
 
         EC_NULL(dup2 = strdup(src));
         EC_NULL(dir = dirname(dup2));


### PR DESCRIPTION
Addresses critical level reliability bugs flagged by SonarQube.

One notable change is in our vendored bstrlib, where the `bdestroy()` function has been rewritten a bit to be more aggressive about freeing memory even when individual members of the bstring object are malformed. This addresses potential memory leak issues.

In afpd, this changeset partially reverts earlier refactoring that attempted to address the same memory leaks, with simpler and less intrusive solutions.

While refactoring, I noticed that the loop for skipped dirs was nested in the loop for skipped files in the FCE API module, so I split them apart. I think this was a bug.