### PR TITLE
atalkd: Bring back freeing of allocated memory into rtmp_delzonemap loop

### DIFF
--- a/etc/atalkd/rtmp.c
+++ b/etc/atalkd/rtmp.c
@@ -65,6 +65,10 @@ void rtmp_delzonemap(struct rtmptab *rtmp)
 			} else {
 			    zt->zt_next->zt_prev = zt->zt_prev;
 			}
+			free( zt->zt_bcast );
+			free( zt->zt_name );
+			free( zt );
+			break;
 		    } else {
 			zt->zt_rt = lr->l_next;
 		    }
@@ -81,9 +85,6 @@ void rtmp_delzonemap(struct rtmptab *rtmp)
 		lr = lr->l_next;
 	    }
 	}
-	free( zt->zt_bcast );
-	free( zt->zt_name );
-	free( zt );
 	flz = lz;
 	lz = lz->l_next;
 	free( flz );


### PR DESCRIPTION
The previous solution led to memory corruption over time, so bringing back a variation of the previous one.

Partially reverts https://github.com/Netatalk/netatalk/commit/80509342c1e39c9d460428a15bc96fd61913685b