### PR TITLE
Safer memory handling and afpd and the ftw library

### DIFF
--- a/libatalk/util/ftw.c
+++ b/libatalk/util/ftw.c
@@ -34,6 +34,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <search.h>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -297,7 +298,24 @@ open_dir_stream (int *dfdp, struct ftw_data *data, struct dir_data *dirp)
                 {
                     char *newp;
                     bufsize += MAX (1024, 2 * this_len);
-                    newp = (char *) realloc (buf, bufsize);
+                    size_t new_size;
+
+                    if (this_len > SIZE_MAX/2 - 1024) {
+                        /* this_len is too large to safely allocate memory */
+                        int save_err = ENOMEM;
+                        free (buf);
+                        __set_errno (save_err);
+                        return -1;
+                    }
+                    new_size = bufsize + MAX (1024, 2 * this_len);
+                    if (new_size <= bufsize) {
+                        int save_err = ENOMEM;
+                        free (buf);
+                        __set_errno (save_err);
+                        return -1;
+                    }
+
+                    newp = (char *) realloc (buf, new_size);
                     if (newp == NULL)
                     {
                         /* No more memory.  */
@@ -307,6 +325,7 @@ open_dir_stream (int *dfdp, struct ftw_data *data, struct dir_data *dirp)
                         return -1;
                     }
                     buf = newp;
+                    bufsize = new_size;
                 }
 
                 if (actsize + this_len < bufsize) {
@@ -323,7 +342,7 @@ open_dir_stream (int *dfdp, struct ftw_data *data, struct dir_data *dirp)
             if (data->dirstreams[data->actdir]->content == NULL)
             {
                 int save_err = errno;
-                if (buf) {
+                if (actsize > 0) {
                     free (buf);
                 }
                 __set_errno (save_err);


### PR DESCRIPTION
In afpd, this shores up protections in the appl, enumerate and the fce API modules. This reverts previous attempts at plugging the same holes that didn't quite address all potential entry points.

It also has adds protections in our fork of the glibc ftw library.