### PR TITLE
Update uams_guest.c with accurate copyright header

### DIFF
--- a/etc/uams/uams_guest.c
+++ b/etc/uams/uams_guest.c
@@ -1,6 +1,6 @@
 /*
- *
- * (c) 2001 (see COPYING)
+ * Copyright (c) 1990,1993 Regents of The University of Michigan.
+ * All Rights Reserved.  See COPYRIGHT.
  */
 
 #ifdef HAVE_CONFIG_H


### PR DESCRIPTION
Grounds for this change:

The 2001 copyright date, without an author name, was added in commit 5268a18 in February 2001 by rufustfirefly, which contained no other change to this source file that would justify claiming copyright. The same author had no previous contributions to this source file according to the commit log.

In the commit just before that from July 2000, Andrew Morgan added substantial new code, but he claimed no explicit copyright at that time.

The commit before that was the original revision when the project was first brought under revision control.

The code of uams_guest.c at the time of this original revision is a nearly exact match with the noauth_login() function in etc/afpd/auth.c of the 1.4b2 release version source code. This source code had the standard Regents of The University of Michigan copyright blurb of the project at the time.

Hence, my conclusion is that the accurate author and copyright of the uams_guest.c code is the same as the rest of the original netatalk codebase.