### PR TITLE
libatalk: Bail out early when actsize is 0 in ftw library

### DIFF
--- a/libatalk/util/ftw.c
+++ b/libatalk/util/ftw.c
@@ -315,26 +315,32 @@ open_dir_stream (int *dfdp, struct ftw_data *data, struct dir_data *dirp)
                 }
             }
 
-            /* Terminate the list with an additional NUL byte.  */
-            buf[actsize++] = '\0';
-
-            /* Shrink the buffer to what we actually need.  */
-            data->dirstreams[data->actdir]->content = realloc (buf, actsize);
-            if (data->dirstreams[data->actdir]->content == NULL)
-            {
+            if (actsize == 0) {
                 int save_err = errno;
-                if (buf && actsize > 0) {
-                    free (buf);
-                }
+                free (buf);
                 __set_errno (save_err);
                 result = -1;
             }
-            else
-            {
-                __closedir (st);
-                data->dirstreams[data->actdir]->stream = NULL;
-                data->dirstreams[data->actdir]->streamfd = -1;
-                data->dirstreams[data->actdir] = NULL;
+            else {
+                /* Terminate the list with an additional NUL byte.  */
+                buf[actsize++] = '\0';
+
+                /* Shrink the buffer to what we actually need.  */
+                data->dirstreams[data->actdir]->content = realloc (buf, actsize);
+                if (data->dirstreams[data->actdir]->content == NULL)
+                {
+                    int save_err = errno;
+                    free (buf);
+                    __set_errno (save_err);
+                    result = -1;
+                }
+                else
+                {
+                    __closedir (st);
+                    data->dirstreams[data->actdir]->stream = NULL;
+                    data->dirstreams[data->actdir]->streamfd = -1;
+                    data->dirstreams[data->actdir] = NULL;
+                }
             }
         }
     }


### PR DESCRIPTION
Doing an early check on actsize and bail out if 0, to avoid memory management failure later.