### PR TITLE
Remove MIN/MAX macros that are already defined centrally

### DIFF
--- a/etc/uams/uams_guest.c
+++ b/etc/uams/uams_guest.c
@@ -19,10 +19,6 @@
 #include <atalk/uam.h>
 #include <atalk/util.h>
 
-#ifndef MIN
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
-#endif /* MIN */
-
 /*XXX in etc/papd/file.h */
 struct papfile;
 extern UAM_MODULE_EXPORT void append(struct papfile *, const char *, int);

--- a/etc/uams/uams_pam.c
+++ b/etc/uams/uams_pam.c
@@ -30,11 +30,6 @@
 
 #define PASSWDLEN 8
 
-#ifndef MIN
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
-#endif /* MIN */
-
-
 /* Static variables used to communicate between the conversation function
  * and the server_login function
  */

--- a/etc/uams/uams_passwd.c
+++ b/etc/uams/uams_passwd.c
@@ -34,11 +34,6 @@
 
 #define PASSWDLEN 8
 
-#ifndef MIN
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
-#endif /* MIN */
-
-
 /*XXX in etc/papd/file.h */
 struct papfile;
 extern UAM_MODULE_EXPORT void append(struct papfile *, const char *, int);

--- a/include/atalk/unicode.h
+++ b/include/atalk/unicode.h
@@ -7,14 +7,6 @@
 
 #define ucs2_t uint16_t
 
-#ifndef MIN
-#define MIN(a,b)     ((a)<(b)?(a):(b))
-#endif /* ! MIN */
-
-#ifndef MAX
-#define MAX(a,b)     ((a)>(b)?(a):(b))
-#endif /* ! MIN */
-
 #define SAFE_FREE(x) do { if ((x) != NULL) {free(x); x=NULL;} } while(0)
 
 #ifndef EILSEQ

--- a/include/atalk/util.h
+++ b/include/atalk/util.h
@@ -68,12 +68,6 @@
 #define STRCMP(a,b,c) (strcmp(a,c) b 0)
 #define ZERO_STRUCT(a) memset(&(a), 0, sizeof(a))
 #define ZERO_STRUCTP(a) memset((a), 0, sizeof(a))
-#ifndef MAX
-#define MAX(a,b) ((a) > (b) ? a : b)
-#endif
-#ifndef MIN
-#define MIN(a,b) ((a) < (b) ? a : b)
-#endif
 
 #ifdef WORDS_BIGENDIAN
 #define hton64(x)       (x)

--- a/libatalk/asp/asp_getsess.c
+++ b/libatalk/asp/asp_getsess.c
@@ -28,6 +28,7 @@
 #include <atalk/atp.h>
 #include <atalk/asp.h>
 #include <atalk/server_child.h>
+#include <atalk/util.h>
 
 #include "asp_child.h"
 
@@ -37,10 +38,6 @@
 #ifndef WIFEXITED
 #define WIFEXITED(stat_val) (((stat_val) & 255) == 0)
 #endif /* ! WIFEXITED */
-
-#ifndef MIN
-#define MIN(a,b)     ((a)<(b)?(a):(b))
-#endif /* ! MIN */
 
 static ASP server_asp;
 static server_child_t *children = NULL;

--- a/libatalk/dsi/dsi_attn.c
+++ b/libatalk/dsi/dsi_attn.c
@@ -16,10 +16,7 @@
 
 #include <atalk/afp.h>
 #include <atalk/dsi.h>
-
-#ifndef MIN
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
-#endif /* MIN */
+#include <atalk/util.h>
 
 /* send an attention. this may get called at any time, so we can't use
  * DSI buffers to send one.

--- a/libatalk/netddp/netddp_recvfrom.c
+++ b/libatalk/netddp/netddp_recvfrom.c
@@ -21,8 +21,4 @@
 #include <netatalk/endian.h>
 #include <netatalk/ddp.h>
 #include <atalk/netddp.h>
-
-#ifndef MAX
-#define MAX(a, b)  ((a) < (b) ? (b) : (a))
-#endif /* ! MAX */
 #endif /* no ddp */

--- a/libatalk/unicode/iconv.c
+++ b/libatalk/unicode/iconv.c
@@ -45,6 +45,7 @@
 #include <atalk/byteorder.h>
 #include <atalk/logger.h>
 #include <atalk/unicode.h>
+#include <atalk/util.h>
 
 /**
  * @file

--- a/libatalk/util/ftw.c
+++ b/libatalk/util/ftw.c
@@ -76,8 +76,6 @@
 # define internal_function /* empty */
 # undef dirent64
 # define dirent64 dirent
-# undef MAX
-# define MAX(a, b) ((a) > (b) ? (a) : (b))
 #endif
 
 #ifndef __set_errno


### PR DESCRIPTION
Clean up local definitions of the MIN and MAX macros since they're defined properly in include/atalk/util.h

Bizarrely, util.h actually contained duplicate definitions of the same two macros. Probably an artifact of disparate feature branches being merged.