### PR TITLE
Protect against null pointer dereference; use correct return values; division by zero

### DIFF
--- a/bin/pap/papstatus.c
+++ b/bin/pap/papstatus.c
@@ -98,7 +98,7 @@ static char			*printer = NULL;
 static char			cbuf[ 8 ];
 static struct nbpnve		nn;
 
-static void * print_status(char status, char mask, char * message){
+static void print_status(char status, char mask, char * message){
         printf("%s", message);
     if( status & mask){
             printf("True\n");

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -1869,7 +1869,7 @@ setdirparam_done:
     }
 
 setprivdone:
-    if (change_parent_mdate && dir->d_did != DIRDID_ROOT
+    if (change_parent_mdate && dir && dir->d_did != DIRDID_ROOT
         && gettimeofday(&tv, NULL) == 0) {
         if (movecwd(vol, dirlookup(vol, dir->d_pdid)) == 0) {
             newdate = AD_DATE_FROM_UNIX(tv.tv_sec);

--- a/etc/afpd/enumerate.c
+++ b/etc/afpd/enumerate.c
@@ -317,6 +317,10 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
         sd.sd_last = sd.sd_buf;
     }
     while ( sd.sd_sindex < sindex ) {
+        if (sd.sd_last == NULL) {
+            sd.sd_did = 0;
+            return AFPERR_MISC;
+        }
         len = (unsigned char)*(sd.sd_last)++;
         if ( len == 0 ) {
             sd.sd_did = 0;	/* invalidate sd struct to force re-read */

--- a/etc/afpd/fce_api.c
+++ b/etc/afpd/fce_api.c
@@ -149,6 +149,7 @@ void fce_init_udp(void)
         if (p == NULL) {
             LOG(log_error, logtype_fce, "fce_init_udp: no socket for %s:%s",
                 udp_entry->addr, udp_entry->port);
+            continue;
         }
         udp_entry->addrinfo = *p;
         memcpy(&udp_entry->addrinfo, p, sizeof(struct addrinfo));

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -288,6 +288,10 @@ static void as_timer(int sig _U_)
 	    end = packet + sizeof( packet );
 
 	    sat = gate->g_sat;
+	    if (zap == NULL) {
+			LOG(log_error, logtype_atalkd, "as_timer: No ZIP port available for interface %s", iface->i_name);
+			continue;
+	    }
 	    sat.sat_port = zap->ap_port;
 
 	    /*
@@ -489,6 +493,10 @@ static void as_timer(int sig _U_)
 	    sat.sat_family = AF_APPLETALK;
 	    sat.sat_addr.s_net = ATADDR_ANYNET;
 	    sat.sat_addr.s_node = ATADDR_BCAST;
+		if (rap == NULL) {
+			LOG(log_error, logtype_atalkd, "as_timer: No RTMP port available for interface %s", iface->i_name);
+			continue;
+		}
 	    sat.sat_port = rap->ap_port;
 
 	    data = packet;

--- a/test/testsuite/adoublehelper.c
+++ b/test/testsuite/adoublehelper.c
@@ -115,7 +115,7 @@ int delete_unix_file(char *path, char *name, char *file)
 	return rc;
 }
 
-/* Rename a file and it's resource fork */
+/* Rename a file and its resource fork */
 int rename_unix_file(char *path, char *dir, char *src, char *dst)
 {
     sprintf(temp, "%s/%s/%s", Path, dir, src);
@@ -142,6 +142,7 @@ int rename_unix_file(char *path, char *dir, char *src, char *dst)
                 fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
             }
             test_failed();
+            return -1;
         }
     } else {
 #ifndef HAVE_EAFD
@@ -155,10 +156,13 @@ int rename_unix_file(char *path, char *dir, char *src, char *dst)
                 fprintf(stdout,"\tFAILED unable to rename %s to %s :%s\n", temp, temp1, strerror(errno));
             }
             test_failed();
+            return -1;
         }
 
 #endif
     }
+
+    return 0;
 }
 
 /* unlink file only, dont care about adouble file */

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -153,7 +153,10 @@ static void displayresults(void)
         for (i=0, sum=0; i < Iterations_save; i++)
             sum += (*results)[i][test];
         avg = sum / (Iterations_save - divsub);
-        fprintf(stderr, "%s%6llu ms", resultstrings[test], avg);
+        if (avg < 1) {
+            fprintf(stderr, "\tFATAL ERROR: invalid result\n");
+            exit(1);
+        }
         if ((test == TEST_WRITE100MB) || (test == TEST_READ100MB)) {
             thrput = (rwsize / 1000) / avg;
             fprintf(stderr, " for %lu MB (avg. %llu MB/s)", rwsize / (1024 * 1024), thrput);


### PR DESCRIPTION
This addresses all current high severity Sonarqube code bugs.