### PR TITLE
Initialize the last few variables that were once flagged as: uninitialized ok

### DIFF
--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -619,8 +619,8 @@ int getfilparams(const AFPObj *obj, struct vol *vol, uint16_t bitmap, struct pat
 {
     struct adouble	ad, *adp;
     int                 opened = 0;
-    int rc;
-    int flags; /* uninitialized ok */
+    int rc = AFP_OK;
+    int flags = 0;
 
     LOG(log_debug, logtype_afpd, "getfilparams(\"%s\")", path->u_name);
 

--- a/libatalk/unicode/charcnv.c
+++ b/libatalk/unicode/charcnv.c
@@ -709,7 +709,7 @@ static size_t pull_charset_flags (charset_t from_set, charset_t to_set, charset_
     char* outbuf = dest;
     atalk_iconv_t descriptor;
     atalk_iconv_t descriptor_cap;
-    char escch;                 /* 150210: uninitialized OK, depends on j */
+    char escch = 0;
 
     if (srclen == (size_t)-1)
         srclen = strlen(src) + 1;


### PR DESCRIPTION
Historically, this project has used a minor optimization technique, leaving certain key variables uninitialized at the top of the function. This has led to undefined behavior when code paths subsequently changed.