### PR TITLE
Eliminate obsoleted NO_REAL_USER_NAME capability flag macro

### DIFF
--- a/etc/afpd/uam.c
+++ b/etc/afpd/uam.c
@@ -245,8 +245,6 @@ struct passwd *uam_getname(void *private, char *name, const int len)
 
     free(buffer);
 
-#if !defined(NO_REAL_USER_NAME)
-
     namelen = convert_string((utf8_encoding(obj))?CH_UTF8_MAC:obj->options.maccharset,
                             CH_UCS2, name, -1, username, sizeof(username));
     if (namelen == -1)
@@ -275,7 +273,6 @@ struct passwd *uam_getname(void *private, char *name, const int len)
         }
     }
     endpwent();
-#endif /* ! NO_REAL_USER_NAME */
 
     /* os x server doesn't keep anything useful if we do getpwent */
     return pwent ? getpwnam(name) : NULL;

--- a/etc/papd/uam.c
+++ b/etc/papd/uam.c
@@ -183,7 +183,6 @@ struct passwd *uam_getname(void *dummy _U_, char *name, const int len)
   if ((pwent = getpwnam(name)))
     return pwent;
 
-#ifndef NO_REAL_USER_NAME
   for (i = 0; i < len; i++)
     name[i] = tolower(name[i]);
 
@@ -201,7 +200,6 @@ struct passwd *uam_getname(void *dummy _U_, char *name, const int len)
     }
   }
   endpwent();
-#endif /* NO_REAL_USER_NAME */
 
   /* os x server doesn't keep anything useful if we do getpwent */
   return pwent ? getpwnam(name) : NULL;


### PR DESCRIPTION
This is a long since removed flag, and not a common C convention to my best knowledge.