### PR TITLE
docs: Clean up markdown indentation in manual and man pages

### DIFF
--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -141,56 +141,56 @@ specified in a volume specific section.
 You can use variables in volume names. The use of variables in paths is
 limited to $u.
 
-1.  if you specify an unknown variable, it will not get converted.
+1. if you specify an unknown variable, it will not get converted.
 
-2.  if you specify a known variable, but that variable doesn't have a
-    value, it will get ignored.
+2. if you specify a known variable, but that variable doesn't have a
+value, it will get ignored.
 
 The variables which can be used for substitutions are:
 
-$b
+> $b
 
-> basename
+> > basename
 
-$c
+> $c
 
-> client's ip address
+> > client's ip address
 
-$d
+> $d
 
-> volume pathname on server
+> > volume pathname on server
 
-$f
+> $f
 
-> full name (contents of the gecos field in the passwd file)
+> > full name (contents of the gecos field in the passwd file)
 
-$g
+> $g
 
-> group name
+> > group name
 
-$h
+> $h
 
-> hostname
+> > hostname
 
-$i
+> $i
 
-> client's ip, without port
+> > client's ip, without port
 
-$s
+> $s
 
-> server name (this can be the hostname)
+> > server name (this can be the hostname)
 
-$u
+> $u
 
-> user name (if guest, it is the user that guest is running as)
+> > user name (if guest, it is the user that guest is running as)
 
-$v
+> $v
 
-> volume name
+> > volume name
 
-$$
+> $$
 
-> prints dollar sign ($)
+> > prints dollar sign ($)
 
 # Explanation of Global Parameters
 
@@ -254,36 +254,36 @@ uams_dhx2.so").
 
 The most commonly used UAMs are:
 
-uams_guest.so
+> uams_guest.so
 
-> allows guest logins
+> > allows guest logins
 
-uams_clrtxt.so
+> uams_clrtxt.so
 
-> (uams_pam.so or uams_passwd.so) Allow logins with passwords transmitted
+> > (uams_pam.so or uams_passwd.so) Allow logins with passwords transmitted
 in the clear. Compatible with Mac OS 9 and earlier.
 
-uams_randnum.so
+> uams_randnum.so
 
-> allows Random Number and Two-Way Random Number Exchange for
+> > allows Random Number and Two-Way Random Number Exchange for
 authentication (requires a separate file containing the passwords,
 either the default *afppasswd* file or the one specified via
 "**passwd file**"). See **afppasswd**(1) for details.
 Compatible with Mac OS 9 and earlier.
 
-uams_dhx.so
+> uams_dhx.so
 
-> (uams_dhx_pam.so or uams_dhx_passwd.so) Allow Diffie-Hellman eXchange
+> > (uams_dhx_pam.so or uams_dhx_passwd.so) Allow Diffie-Hellman eXchange
 (DHX) for authentication.
 
-uams_dhx2.so
+> uams_dhx2.so
 
-> (uams_dhx2_pam.so or uams_dhx2_passwd.so) Allow Diffie-Hellman eXchange
-2 (DHX2) for authentication.
+> > (uams_dhx2_pam.so or uams_dhx2_passwd.so) Allow Diffie-Hellman eXchange 2
+(DHX2) for authentication.
 
-uam_gss.so
+> uam_gss.so
 
-> Allow Kerberos V for authentication (optional)
+> > Allow Kerberos V for authentication (optional)
 
 uam path = <path\> **(G)**
 
@@ -515,14 +515,14 @@ chmod request = <preserve (default) | ignore | simple\> **(G)**/**(V)**
 
 > Advanced permission control that deals with ACLs.
 
-- **ignore** - UNIX chmod() requests are completely ignored, use this
-  option to allow the parent directory's ACL inheritance full control
-  over new items.
+> - **ignore** - UNIX chmod() requests are completely ignored, use this
+option to allow the parent directory's ACL inheritance full control
+over new items.
 
-- **preserve** - preserve ZFS ACEs for named users and groups or POSIX ACL
-  group mask
+> - **preserve** - preserve ZFS ACEs for named users and groups or POSIX ACL
+group mask
 
-- **simple** - just to a chmod() as requested without any extra steps
+> - **simple** - just to a chmod() as requested without any extra steps
 
 close vol = <BOOLEAN\> (default: *no*) **(G)**
 
@@ -567,7 +567,7 @@ dircachesize = <number\> **(G)**
 directories and files. It is used to cache the full path to directories
 and CNIDs which considerably speeds up directory enumeration.
 
-Default size is 8192, maximum size is 131072. Given value is rounded up
+> Default size is 8192, maximum size is 131072. Given value is rounded up
 to nearest power of 2. Each entry takes about 100 bytes, which is not
 much, but remember that every afpd child process for every connected
 user has its cache.
@@ -583,7 +583,7 @@ force xattr with sticky bit = <BOOLEAN\> (default: *no*) `(G/V)`
 even though we may have write access to a directory, because if the
 sticky bit is set only the owner is allowed to write xattrs.
 
-By enabling this option Netatalk will write the metadata xattr as root.
+> By enabling this option Netatalk will write the metadata xattr as root.
 
 guest account = <name\> **(G)**
 
@@ -600,7 +600,7 @@ ignored attributes = <all | nowrite | nodelete | norename\> **(G)**/**(V)**
 > Specify a set of file and directory attributes that shall be ignored by
 the server, `all` includes all the other options.
 
-In OS X when the Finder sets a lock on a file/directory or you set the
+> In OS X when the Finder sets a lock on a file/directory or you set the
 BSD uchg flag in the Terminal, all three attributes are used. Thus in
 order to ignore the Finder lock/BSD uchg flag, add set *ignored
 attributes = all*.
@@ -611,11 +611,9 @@ legacy icon = <icon\> **(G)**
 Note that some versions of Classic Mac OS ignores this icon. Examples of
 valid icon styles:
 
-- **daemon**
-
-- **globe**
-
-- **sdcard**
+> - **daemon**
+> - **globe**
+> - **sdcard**
 
 login message = <message\> **(G)**/**(V)**
 
@@ -628,13 +626,11 @@ mimic model = <model\> **(G)**
 clients. Default is to let macOS choose. Requires netatalk to be built
 with Zeroconf. Examples:
 
-- **Laptop**
+> - **Laptop**
+> - **RackMount**
+> - **Tower**
 
-- **RackMount**
-
-- **Tower**
-
-A complete set of supported model codes by a macOS client can be found
+> A complete set of supported model codes by a macOS client can be found
 by inspecting system properties files, such as
 */System/Library/CoreServices/CoreTypes.bundle/Contents/Info.plist*
 on macOS 15 Sequoia.
@@ -708,7 +704,7 @@ especially sensitive to this.
     80: limit of Mac OS X 10.4/10.5 (default)
     255: limit of recent Mac OS X
 
-Mac OS 9 and earlier are not influenced by this, because Maccharset
+> Mac OS 9 and earlier are not influenced by this, because Maccharset
 volume name is always limited to 27 bytes.
 
 vol preset = <name\> **(G)**/**(V)**
@@ -729,12 +725,12 @@ log level = <type:level \[type:level ...\]\> **(G)**; log level = <type:level,\[
 > Specify that any message of a loglevel up to the given **log level**
 should be logged.
 
-By default afpd logs to syslog with a default logging setup equivalent
+> By default afpd logs to syslog with a default logging setup equivalent
 to **default:note**
 
-logtypes: default, afpdaemon, logger, uamsdaemon
+> logtypes: default, afpdaemon, logger, uamsdaemon
 
-loglevels: severe, error, warn, note, info, debug, debug6, debug7,
+> loglevels: severe, error, warn, note, info, debug, debug6, debug7,
 debug8, debug9, maxdebug
 
 > **NOTE**
@@ -849,7 +845,7 @@ seconds to detect changes in opened server windows. *Note*: Depending on
 the number of simultaneously connected clients and the network's speed,
 this can lead to a significant higher load on your network!
 
-Do not use this option any longer as present Netatalk correctly supports
+> Do not use this option any longer as present Netatalk correctly supports
 server notifications, allowing connected clients to update folder
 listings in case another client changed the contents.
 
@@ -864,16 +860,16 @@ map acls = <none|rights|mode\> **(G)**
 
 > none
 
-> no mapping of ACLs
+> > no mapping of ACLs
 
-rights
+> rights
 
-> effective permissions are mapped to UARights structure. This is the
+> > effective permissions are mapped to UARights structure. This is the
 default.
 
-mode
+> mode
 
-> ACLs are additionally mapped to the UNIX mode of the filesystem object.
+> > ACLs are additionally mapped to the UNIX mode of the filesystem object.
 
 If you want to be able to display ACLs on the client, you must setup
 both client and server as part on a authentication domain (directory
@@ -892,15 +888,13 @@ The following LDAP options must be configured for Netatalk:
 
 ldap auth method = <none|simple\> **(G)**
 
-> Authentication method: **none** | **simple**
+> none
 
-none
+> > anonymous LDAP bind
 
-> anonymous LDAP bind
+> simple
 
-simple
-
-> simple LDAP bind
+> > simple LDAP bind
 
 ldap auth dn = <dn\> **(G)**
 
@@ -917,7 +911,7 @@ be ldap, ldapi or ldaps, specifying LDAP over TCP, ICP or TLS
 respectively (if supported by the LDAP library). This is only needed for
 explicit ACL support in order to be able to query LDAP for UUIDs.
 
-You can use **afpldaptest**(1) to syntactically check your config.
+> You can use **afpldaptest**(1) to syntactically check your config.
 
 ldap userbase = <base dn\> **(G)**
 
@@ -939,7 +933,7 @@ ldap uuid attr = <dn\> **(G)**
 
 > Name of the LDAP attribute with the UUIDs.
 
-Note: this is used both for users and groups.
+> Note: this is used both for users and groups.
 
 ldap name attr = <dn\> **(G)**
 
@@ -954,7 +948,7 @@ ldap uuid string = <STRING\> **(G)**
 > Format of the uuid string in the directory. A series of x and -, where
 every x denotes a value 0-9a-f and every - is a separator.
 
-Default: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+> Default: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
 ldap uuid encoding = <string | ms-guid (default: string)\> **(G)**
 
@@ -965,15 +959,15 @@ LDAP stores. If set to ms-guid, the internal UUID representation is
 converted to and from the binary format used in the objectGUID attribute
 found on objects in Active Directory when interacting with the server.
 
-See also the options **ldap user filter** and **ldap group filter**.
+> See also the options **ldap user filter** and **ldap group filter**.
 
-string
+> string
 
-> UUID is a string, use with e.g. OpenDirectory.
+> > UUID is a string, use with e.g. OpenDirectory.
 
-ms-guid
+> ms-guid
 
-> Binary objectGUID from Active Directory
+> > Binary objectGUID from Active Directory
 
 ldap user filter = <STRING (default: unused)\> **(G)**
 
@@ -981,7 +975,7 @@ ldap user filter = <STRING (default: unused)\> **(G)**
 Active Directory environments where users and groups are stored in the
 same directory subtree.
 
-Recommended setting for Active Directory: **objectClass=user**.
+> Recommended setting for Active Directory: **objectClass=user**.
 
 ldap group filter = <STRING (default: unused)\> **(G)**
 
@@ -989,7 +983,7 @@ ldap group filter = <STRING (default: unused)\> **(G)**
 Active Directory environments where users and groups are stored in the
 same directory subtree.
 
-Recommended setting for Active Directory: **objectClass=group**.
+> Recommended setting for Active Directory: **objectClass=group**.
 
 # Explanation of Volume Parameters
 
@@ -1041,13 +1035,13 @@ hosts allow = <IP host address/IP netmask bits \[ ... \]\> **(V)**
 network address may be specified either in dotted-decimal format for
 IPv4 or in hexadecimal format for IPv6.
 
-Example: hosts allow = 10.1.0.0/16 10.2.1.100 2001:0db8:1234::/48
+> Example: hosts allow = 10.1.0.0/16 10.2.1.100 2001:0db8:1234::/48
 
 hosts deny = <IP host address/IP netmask bits \[ ... \]\> **(V)**
 
 > Listed hosts and nets are rejected, all others are allowed.
 
-Example: hosts deny = 192.168.100/24 10.1.1.1 2001:db8::1428:57ab
+> Example: hosts deny = 192.168.100/24 10.1.1.1 2001:db8::1428:57ab
 
 cnid scheme = <backend\> **(V)**
 
@@ -1070,30 +1064,30 @@ ea = <sys|samba|ad|none\> (default: auto detect) **(V)**
 > Specify how Extended Attributes and Classic Mac OS resource forks are
 stored.
 
-By default, we attempt to enable **sys** with a fallback to **ad**.
+> By default, we attempt to enable **sys** with a fallback to **ad**.
 For the auto detection to work, the volume needs to be writable
 because we attempt to set an EA on the shared directory itself.
 If **read only = yes** is set, we fallback to **sys**.
 Use explicit "**ea = ad|none**" for read-only volumes where appropriate.
 
-sys
+> sys
 
-> Use filesystem Extended Attributes.
+> > Use filesystem Extended Attributes.
 
-samba
+> samba
 
-> Use filesystem Extended Attributes, but append a 0 byte to each xattr in
+> > Use filesystem Extended Attributes, but append a 0 byte to each xattr in
 order to be compatible with Samba's vfs_streams_xattr.
 
-ad
+> ad
 
-> Use AppleDouble v2 metadata stored as files in *.AppleDouble* directories.
+> > Use AppleDouble v2 metadata stored as files in *.AppleDouble* directories.
 This should only be used when the host's filesystem does not support
 Extended Attributes.
 
-none
+> none
 
-> No Extended Attributes support.
+> > No Extended Attributes support.
 
 > **WARNING**
 
@@ -1112,13 +1106,13 @@ casefold = <option\> **(V)**
 > The casefold option handles, if the case of filenames should be changed.
 The available options are:
 
-**tolower** - Lowercases names in both directions.
+> **tolower** - Lowercases names in both directions.
 
-**toupper** - Uppercases names in both directions.
+> **toupper** - Uppercases names in both directions.
 
-**xlatelower** - Client sees lowercase, server sees uppercase.
+> **xlatelower** - Client sees lowercase, server sees uppercase.
 
-**xlateupper** - Client sees uppercase, server sees lowercase.
+> **xlateupper** - Client sees uppercase, server sees lowercase.
 
 password = <password\> **(V)**
 
@@ -1132,7 +1126,7 @@ file perm = <mode\> **(V)**; directory perm = <mode\> **(V)**
 only, **directory perm** is for directories only. Don't use with
 "**unix priv = no**".
 
-## Example: Volume for a collaborative workgroup
+> **Example**: Volume for a collaborative workgroup
 
     file perm = 0660
     directory perm = 0770
@@ -1207,7 +1201,7 @@ files option). If this option is set to no (the default) then if a
 directory contains any non-vetoed files or directories then the
 directory delete will fail. This is usually what you want.
 
-If this option is set to yes, then Netatalk will attempt to recursively
+> If this option is set to yes, then Netatalk will attempt to recursively
 delete any files and directories within the vetoed directory.
 
 follow symlinks = <BOOLEAN\> (default: *no*) **(V)**

--- a/doc/manpages/man5/atalkd.conf.5.md
+++ b/doc/manpages/man5/atalkd.conf.5.md
@@ -81,19 +81,19 @@ special characters should be enclosed in quotation marks.
 
 Single interface on Solaris with auto-detected parameters.
 
-       le0
+      le0
 
 The same on Linux.
 
-       eth0
+      eth0
 
 Below is an example configuration file from a Sun 4/40. The machine has
 two interfaces, "le0" and "le1". The "le0" interface is
 configured automatically from other routers on the network. The machine
 is the only router for the "le1" interface.
 
-       le0
-       le1 -seed -net 9461-9471 -zone netatalk -zone Argus
+      le0
+      le1 -seed -net 9461-9471 -zone netatalk -zone Argus
 
 # See Also
 

--- a/doc/manpages/man8/cnid_dbd.8.md
+++ b/doc/manpages/man8/cnid_dbd.8.md
@@ -132,13 +132,13 @@ Berkeley DB library versions, follow this steps:
 - Stop the to be upgraded old version of Netatalk
 
 - Using the old Berkeley DB utilities run
-  `db_recover -h <path to .AppleDB>`
+`db_recover -h <path to .AppleDB>`
 
 - Using the new Berkeley DB utilities run
-  `db_upgrade -v -h <path to .AppleDB> -f cnid2.db`
+`db_upgrade -v -h <path to .AppleDB> -f cnid2.db`
 
 - Again using the new Berkeley DB utilities run
-  `db_checkpoint -1 -h <path to .AppleDB>`
+`db_checkpoint -1 -h <path to .AppleDB>`
 
 - Start the the new version of Netatalk
 

--- a/doc/manual/AppleTalk.md
+++ b/doc/manual/AppleTalk.md
@@ -116,16 +116,16 @@ Several types of AppleTalk routers exist: seed, non-seed and so called
 soft-seed routers.
 
 - A seed router has its own configuration and publishes this into the
-  network segments it is configured for.
+    network segments it is configured for.
 
 - A non-seed router needs a seed router on the interface to which it is
-  connected to learn the network configuration. So this type of
-  AppleTalk router can work completely without manual configuration.
+    connected to learn the network configuration. So this type of
+    AppleTalk router can work completely without manual configuration.
 
 - A so called soft-seed router is exactly the same as a non-seed router
-  except the fact, that it can also remember the configuration of a seed
-  router and act as a replacement in case, the real seed router
-  disappears from the net.
+    except the fact, that it can also remember the configuration of a seed
+    router and act as a replacement in case, the real seed router
+    disappears from the net.
 
 Netatalk's atalkd can act as both a seed and a soft-seed router, even in
 a mixed mode, where it acts on one interface in this way and on the
@@ -197,14 +197,14 @@ You'll have to set the following options in atalkd.conf:
 
 - **-net** (use reasonable values between 1-65279 for each interface)
 
-  In case, this value is suppressed but -addr is present, the netrange
-  from this specific address will be used
+    In case, this value is suppressed but -addr is present, the netrange
+    from this specific address will be used
 
 - **-addr** (the net part must match the -net settings if present, the node
-  address should be between 142 and 255)
+    address should be between 142 and 255)
 
 - **-zone** (can be used multiple times in one single line, the first entry
-  is the default zone)
+    is the default zone)
 
 Note that you are able to set up "zone mapping", that means publishing
 exactly the same zone name on all AppleTalk segments, as well as

--- a/doc/manual/Configuration.md
+++ b/doc/manual/Configuration.md
@@ -355,26 +355,21 @@ Several UAMs have been developed by Apple over the time, some by
 
 Netatalk supports the following ones by default:
 
-- "No User Authent" UAM (guest access
-  without authentication)
+- "No User Authent" UAM (guest access without authentication)
 
-- "Cleartxt Passwrd" UAM (no password
-  encryption)
+- "Cleartxt Passwrd" UAM (no password encryption)
 
-- "Randnum exchange"/"2-Way Randnum
-  exchange" UAMs (weak password
-  encryption, separate password storage)
+- "Randnum exchange"/"2-Way Randnum exchange" UAMs (weak password
+encryption, separate password storage)
 
-- "DHCAST128" UAM (a.k.a. DHX; stronger
-  password encryption)
+- "DHCAST128" UAM (a.k.a. DHX; stronger password encryption)
 
 - "DHX2" UAM (successor of DHCAST128)
 
 There exist other optional UAMs as well:
 
-- "Client Krb v2" UAM (Kerberos V,
-  suitable for "Single Sign On" Scenarios with macOS clients – see
-  below)
+- "Client Krb v2" UAM (Kerberos V, suitable for "Single Sign On" Scenarios
+with macOS clients – see below)
 
 You can configure which UAMs should be activated by defining
 "**uam list**" in **Global** section. **afpd** will log which UAMs it's using
@@ -399,47 +394,47 @@ have to support. If your network consists of exclusively macOS (Mac OS
 X) clients, DHX2 is sufficient, and provides the strongest encryption.
 
 - Unless you really have to supply guest access to your server's volumes
-  ensure that you disable "No User Authent" since it might lead
-  accidentally to unauthorized access. In case you must enable guest
-  access take care that you enforce this on a per volume base using the
-  access controls.
+ensure that you disable "No User Authent" since it might lead
+accidentally to unauthorized access. In case you must enable guest
+access take care that you enforce this on a per volume base using the
+access controls.
 
-  Note: "No User Authent" is required to use Apple II NetBoot services
-  (**a2boot**) to boot an Apple //e over AFP.
+    Note: "No User Authent" is required to use Apple II NetBoot services
+    (**a2boot**) to boot an Apple //e over AFP.
 
 - The "ClearTxt Passwrd" UAM is as bad as it sounds since passwords go
-  unencrypted over the wire. Try to avoid it at both the server's side
-  as well as on the client's.
+unencrypted over the wire. Try to avoid it at both the server's side
+as well as on the client's.
 
-  Note: If you want to provide Mac OS 8/9 clients with NetBoot-services
-  then you need uams_cleartxt.so since the AFP-client integrated into
-  the Mac's firmware can only deal with this basic form of
-  authentication.
+    Note: If you want to provide Mac OS 8/9 clients with NetBoot-services
+    then you need uams_cleartxt.so since the AFP-client integrated into
+    the Mac's firmware can only deal with this basic form of
+    authentication.
 
 - Since "Randnum exchange"/"2-Way Randnum exchange" uses only 56 bit DES
-  for encryption it should be avoided as well. Another disadvantage is
-  the fact that the passwords have to be stored in cleartext on the
-  server and that it doesn't integrate into both PAM scenarios or
-  classic /etc/shadow (you have to administrate passwords separately by
-  using the **afppasswd** utility, in order for clients to use these
-  UAMs)
+for encryption it should be avoided as well. Another disadvantage is
+the fact that the passwords have to be stored in cleartext on the
+server and that it doesn't integrate into both PAM scenarios or
+classic /etc/shadow (you have to administrate passwords separately by
+using the **afppasswd** utility, in order for clients to use these
+UAMs)
 
-  However, this is the strongest form of authentication that can be used
-  with Macintosh System Software 7.1 or earlier.
+    However, this is the strongest form of authentication that can be used
+    with Macintosh System Software 7.1 or earlier.
 
 - "DHCAST128" ("DHX") or "DHX2" should be the sweet spot for most people
-  since it combines stronger encryption with PAM integration.
+since it combines stronger encryption with PAM integration.
 
 - Using the Kerberos V ("Client Krb v2")
-  UAM, it's possible to implement real single sign on scenarios using
-  Kerberos tickets. The password is not sent over the network. Instead,
-  the user password is used to decrypt a service ticket for the
-  AppleShare server. The service ticket contains an encryption key for
-  the client and some encrypted data (which only the AppleShare server
-  can decrypt). The encrypted portion of the service ticket is sent to
-  the server and used to authenticate the user. Because of the way that
-  the afpd service principal detection is implemented, this
-  authentication method is vulnerable to man-in-the-middle attacks.
+UAM, it's possible to implement real single sign on scenarios using
+Kerberos tickets. The password is not sent over the network. Instead,
+the user password is used to decrypt a service ticket for the
+AppleShare server. The service ticket contains an encryption key for
+the client and some encrypted data (which only the AppleShare server
+can decrypt). The encrypted portion of the service ticket is sent to
+the server and used to authenticate the user. Because of the way that
+the afpd service principal detection is implemented, this
+authentication method is vulnerable to man-in-the-middle attacks.
 
 For a more detailed overview over the technical implications of the
 different UAMs, please have a look at Apple's [File Server
@@ -536,42 +531,42 @@ restarted afpd when you made changes to the settings). But there are a
 couple of reasons why you don't want to use this option at all:
 
 - Most users who need such a feature are probably already familiar with
-  using a VPN; it might be easier for the user to employ the same VPN
-  software in order to connect to the network on which the AFP server is
-  running, and then to access the AFP server as normal.
+using a VPN; it might be easier for the user to employ the same VPN
+software in order to connect to the network on which the AFP server is
+running, and then to access the AFP server as normal.
 
-  That being said, for the simple case of connecting to one specific AFP
-  server, a direct SSH connection is likely to perform better than a
-  general-purpose VPN; contrary to popular belief, tunneling via SSH
-  does **not** result in what's called "TCP-over-TCP meltdown", because
-  the AFP data that are being tunneled do not encapsulate TCP data.
+    That being said, for the simple case of connecting to one specific AFP
+    server, a direct SSH connection is likely to perform better than a
+    general-purpose VPN; contrary to popular belief, tunneling via SSH
+    does **not** result in what's called "TCP-over-TCP meltdown", because
+    the AFP data that are being tunneled do not encapsulate TCP data.
 
 - Since this SSH kludge isn't a normal UAM that integrates directly into
-  the AFP authentication mechanisms but instead uses a single flag
-  signalling clients whether they can **try** to establish a tunnel or
-  not, it makes life harder to see what's happening when things go
-  wrong.
+the AFP authentication mechanisms but instead uses a single flag
+signalling clients whether they can **try** to establish a tunnel or
+not, it makes life harder to see what's happening when things go
+wrong.
 
 - You cannot control which machines are logged on by Netatalk tools like
-  a **macusers** since all connection attempts seem to be made from
-  localhost.
+a **macusers** since all connection attempts seem to be made from
+localhost.
 
 - Indeed, to ensure that all AFP sessions are encrypted via SSH, you
-  need to limit afpd to connections that originate only from localhost
-  (e.g., by using Wietse Venema's TCP Wrappers, or by using suitable
-  firewall or packet-filtering facilities, etc.).
+need to limit afpd to connections that originate only from localhost
+(e.g., by using Wietse Venema's TCP Wrappers, or by using suitable
+firewall or packet-filtering facilities, etc.).
 
-  Otherwise, when you're using Mac OS X 10.2 through 10.3.3, you get the
-  opposite of what you'd expect: potentially unencrypted AFP
-  communications (including login credentials) being sent across the
-  network without a single notification that establishing the tunnel
-  failed. Apple fixed that with Mac OS X 10.3.4.
+    Otherwise, when you're using Mac OS X 10.2 through 10.3.3, you get the
+    opposite of what you'd expect: potentially unencrypted AFP
+    communications (including login credentials) being sent across the
+    network without a single notification that establishing the tunnel
+    failed. Apple fixed that with Mac OS X 10.3.4.
 
 - Encrypting all AFP sessions via SSH can lead to a significantly higher
-  load on the computer that is running the AFP server, because that
-  computer must also handle encryption; if the user is connecting
-  through a trusted network, then such encryption might be an
-  unnecessary overhead.
+load on the computer that is running the AFP server, because that
+computer must also handle encryption; if the user is connecting
+through a trusted network, then such encryption might be an
+unnecessary overhead.
 
 ## ACL Support
 
@@ -696,12 +691,12 @@ Architectural differences between POSIX ACLs and macOS ACLs especially
 involve:
 
 - No fine-granular permissions model. Like UNIX permissions POSIX ACLs
-  only differentiate between read, write and execute permissions.
+only differentiate between read, write and execute permissions.
 
 - Entries within an ACL are unordered.
 
 - POSIX ACLs can only grant rights. There is no way to explicitly deny
-  rights by an entry.
+rights by an entry.
 
 - UNIX permissions are integrated into an ACL as special entries.
 
@@ -723,10 +718,10 @@ The remaining entry types expand the traditional permissions model:
 - ACL_GROUP: grants access rights to a certain group.
 
 - ACL_MASK: limits the maximum access rights which can be granted by
-  entries of type ACL_GROUP_OBJ, ACL_USER and ACL_GROUP. As the name
-  suggests, this entry acts as a mask. Only one ACL_MASK entry is
-  allowed per ACL. If an ACL contains ACL_USER or ACL_GROUP entries, an
-  ACL_MASK entry must be present too, otherwise it is optional.
+entries of type ACL_GROUP_OBJ, ACL_USER and ACL_GROUP. As the name
+suggests, this entry acts as a mask. Only one ACL_MASK entry is
+allowed per ACL. If an ACL contains ACL_USER or ACL_GROUP entries, an
+ACL_MASK entry must be present too, otherwise it is optional.
 
 In order to maintain compatibility with applications not aware of ACLs,
 POSIX 1003.1e changes the semantics of system calls and utilities which
@@ -751,10 +746,10 @@ the result of the mapping process will be an approximation of the
 original ACL's semantic.
 
 - afpd silently discard entries which deny a set of permissions because
-  they they can't be represented within the POSIX architecture.
+they they can't be represented within the POSIX architecture.
 
 - As entries within POSIX ACLs are unordered, it is impossible to
-  preserve order.
+preserve order.
 
 - Inheritance control is subject to severe limitations as well:
 
@@ -767,7 +762,7 @@ original ACL's semantic.
     on inheritance will be ignored.
 
 - The lack of a fine-granular permission model on the POSIX side will
-  normally result in an increase of granted permissions.
+normally result in an increase of granted permissions.
 
 As macOS clients aren't aware of the POSIX 1003.1e specific relationship
 between UNIX permissions and ACL_MASK, afpd does not expose this feature
@@ -847,28 +842,28 @@ Solaris with Tracker from OpenCSW:
 
 - Large filesystems
 
-  Tracker on Linux uses the inotify Kernel filesystem change event API
-  for tracking filesystem changes. On large filesystems this may be
-  problematic since the inotify API doesn't offer recursive directory
-  watches but instead requires that for every subdirectory watches must
-  be added individually.
+    Tracker on Linux uses the inotify Kernel filesystem change event API
+    for tracking filesystem changes. On large filesystems this may be
+    problematic since the inotify API doesn't offer recursive directory
+    watches but instead requires that for every subdirectory watches must
+    be added individually.
 
-  On Solaris the FEN file event notification system is used. It is
-  unknown which limitations and resource consumption this Solaris
-  subsystem may have.
+    On Solaris the FEN file event notification system is used. It is
+    unknown which limitations and resource consumption this Solaris
+    subsystem may have.
 
-  We therefore recommend to disable live filesystem monitoring and let
-  Tracker periodically scan filesystems for changes instead, see the
-  [Tracker configuration options](#advanced-tracker-command-line-configuration)
-  enable-monitors and crawling-interval below.
+    We therefore recommend to disable live filesystem monitoring and let
+    Tracker periodically scan filesystems for changes instead, see the
+    [Tracker configuration options](#advanced-tracker-command-line-configuration)
+    enable-monitors and crawling-interval below.
 
 - Indexing home directories
 
-  A known limitation with the current implementation means that shared
-  volumes in a user's home directory does not get indexed by Spotlight.
+    A known limitation with the current implementation means that shared
+    volumes in a user's home directory does not get indexed by Spotlight.
 
-  As a workaround, keep the shared volumes you want to have indexed
-  elsewhere on the host filesystem.
+    As a workaround, keep the shared volumes you want to have indexed
+    elsewhere on the host filesystem.
 
 ### Using Tracker commandline tools on the server
 

--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -73,28 +73,28 @@ Downloading the Git repository can be done quickly and easily:
 
 - Berkeley DB
 
-  The default dbd CNID backend for netatalk uses Berkeley DB to store
-  unique file identifiers. At the time of writing you need at least
-  version 4.6.
+    The default dbd CNID backend for netatalk uses Berkeley DB to store
+    unique file identifiers. At the time of writing you need at least
+    version 4.6.
 
-  The recommended version is 5.3, the final release under the permissive
-  Sleepycat license, and therefore the most widely distributed version.
+    The recommended version is 5.3, the final release under the permissive
+    Sleepycat license, and therefore the most widely distributed version.
 
 - iniparser
 
-  The iniparser library is used to parse the configuration files.
-  At least version 3.1 is required, while 4.0 or later is recommended.
+    The iniparser library is used to parse the configuration files.
+    At least version 3.1 is required, while 4.0 or later is recommended.
 
 - libevent
 
-  Internal event callbacks in the netatalk service controller daemon are
-  built on libevent version 2.
+    Internal event callbacks in the netatalk service controller daemon are
+    built on libevent version 2.
 
 - Libgcrypt
 
-  The [Libgcrypt](https://gnupg.org/software/libgcrypt/) library
-  supplies the encryption for the standard User Authentication Modules
-  (UAMs). They are: DHX2, DHCAST128 (a.k.a. DHX) and RandNum.
+    The [Libgcrypt](https://gnupg.org/software/libgcrypt/) library
+    supplies the encryption for the standard User Authentication Modules
+    (UAMs). They are: DHX2, DHCAST128 (a.k.a. DHX) and RandNum.
 
 #### Optional third-party software
 
@@ -103,120 +103,120 @@ functionality.
 
 - ACL and LDAP
 
-  LDAP is an open and industry-standard user directory protocol that
-  works in tandem with the advanced permissions scheme of ACL. On some
-  operating systems ACL and LDAP libraries are built in to the system,
-  while on others you have to install supporting packages to enable this
-  functionality.
+    LDAP is an open and industry-standard user directory protocol that
+    works in tandem with the advanced permissions scheme of ACL. On some
+    operating systems ACL and LDAP libraries are built in to the system,
+    while on others you have to install supporting packages to enable this
+    functionality.
 
 - Avahi or mDNSresponder for Bonjour
 
-  Mac OS X 10.2 and later uses Bonjour (a.k.a. Zeroconf) for automatic
-  service discovery. Netatalk can advertise AFP file sharing and Time
-  Machine volumes by using Avahi or mDNSResponder.
+    Mac OS X 10.2 and later uses Bonjour (a.k.a. Zeroconf) for automatic
+    service discovery. Netatalk can advertise AFP file sharing and Time
+    Machine volumes by using Avahi or mDNSResponder.
 
-  When using Avahi, D-Bus is also required, and the Avahi library must
-  have been built with D-Bus support.
+    When using Avahi, D-Bus is also required, and the Avahi library must
+    have been built with D-Bus support.
 
 - cmark or cmark-gfm
 
-  Netatalk's documentation is authored in Markdown format.
-  The man page sources consist of standards-compliant CommonMark,
-  while the rest of the documentation is authored in GitHub-Flavored
-  Markdown.
+    Netatalk's documentation is authored in Markdown format.
+    The man page sources consist of standards-compliant CommonMark,
+    while the rest of the documentation is authored in GitHub-Flavored
+    Markdown.
 
-  You can use cmark to generate roff man pages from the Markdown sources,
-  and cmark-gfm to generate all documentation, including HTML pages.
-  If you have access to the latter, you don't need the former.
+    You can use cmark to generate roff man pages from the Markdown sources,
+    and cmark-gfm to generate all documentation, including HTML pages.
+    If you have access to the latter, you don't need the former.
 
 - CrackLib
 
-  When using the Random Number UAMs and netatalk's own **afppasswd**
-  password manager, CrackLib can help protect against setting weak
-  passwords for authentication with netatalk.
+    When using the Random Number UAMs and netatalk's own **afppasswd**
+    password manager, CrackLib can help protect against setting weak
+    passwords for authentication with netatalk.
 
-  The CrackLib dictionary, which is sometimes distributed separately in
-  a runtime package, is also a requirement.
+    The CrackLib dictionary, which is sometimes distributed separately in
+    a runtime package, is also a requirement.
 
 - D-Bus
 
-  D-Bus provides a mechanism for sending messages between processes,
-  used by multiple Netatalk features: Spotlight, Zeroconf with Avahi,
-  and the **afpstats** tool.
+    D-Bus provides a mechanism for sending messages between processes,
+    used by multiple Netatalk features: Spotlight, Zeroconf with Avahi,
+    and the **afpstats** tool.
 
 - GLib and GIO
 
-  Used by the **afpstats** tool to interface with D-Bus.
+    Used by the **afpstats** tool to interface with D-Bus.
 
 - iconv
 
-  iconv provides conversion routines for many character encodings.
-  Netatalk uses it to provide charsets it does not have built in
-  conversions for, like ISO-8859-1. On glibc systems, Netatalk can use
-  the glibc provided iconv implementation. Otherwise you can use the GNU
-  libiconv implementation.
+    iconv provides conversion routines for many character encodings.
+    Netatalk uses it to provide charsets it does not have built in
+    conversions for, like ISO-8859-1. On glibc systems, Netatalk can use
+    the glibc provided iconv implementation. Otherwise you can use the GNU
+    libiconv implementation.
 
 - Kerberos V
 
-  Kerberos v5 is a client-server based authentication protocol invented
-  at the Massachusetts Institute of Technology. With the Kerberos
-  library, netatalk can produce the GSS UAM library for authentication
-  with existing Kerberos infrastructure.
+    Kerberos v5 is a client-server based authentication protocol invented
+    at the Massachusetts Institute of Technology. With the Kerberos
+    library, netatalk can produce the GSS UAM library for authentication
+    with existing Kerberos infrastructure.
 
 - MySQL or MariaDB
 
-  By leveraging a MySQL-compatible client library, netatalk can be built
-  with a MySQL CNID backend that is highly scalable and reliable. The
-  administrator has to provide a separate database instance for use with
-  this backend.
+    By leveraging a MySQL-compatible client library, netatalk can be built
+    with a MySQL CNID backend that is highly scalable and reliable. The
+    administrator has to provide a separate database instance for use with
+    this backend.
 
 - PAM
 
-  PAM provides a flexible mechanism for authenticating users. PAM was
-  invented by SUN Microsystems. Linux-PAM
-  is a suite of shared libraries that enable the local system
-  administrator to choose how applications authenticate users.
+    PAM provides a flexible mechanism for authenticating users. PAM was
+    invented by SUN Microsystems. Linux-PAM
+    is a suite of shared libraries that enable the local system
+    administrator to choose how applications authenticate users.
 
 - Perl
 
-  Netatalk's administrative utility scripts rely on the Perl runtime,
-  version 5.8 or later. The required Perl modules include
-  *IO::Socket::IP* (asip-status) and *Net::DBus* (afpstats).
+    Netatalk's administrative utility scripts rely on the Perl runtime,
+    version 5.8 or later. The required Perl modules include
+    *IO::Socket::IP* (asip-status) and *Net::DBus* (afpstats).
 
 - po4a
 
-  With the help of po4a, Netatalk's documentation can be translated
-  into other languages. It uses gettext to extract translatable
-  strings from source files and merge them with the translations
-  stored in PO files.
+    With the help of po4a, Netatalk's documentation can be translated
+    into other languages. It uses gettext to extract translatable
+    strings from source files and merge them with the translations
+    stored in PO files.
 
 - TCP wrappers
 
-  Wietse Venema's network logger, also known as TCPD or LOG_TCP.
+    Wietse Venema's network logger, also known as TCPD or LOG_TCP.
 
-  Security options are: access control per host, domain and/or service;
-  detection of host name spoofing or host address spoofing; booby traps
-  to implement an early-warning system.
+    Security options are: access control per host, domain and/or service;
+    detection of host name spoofing or host address spoofing; booby traps
+    to implement an early-warning system.
 
 - Tracker, or TinySPARQL / LocalSearch
 
-  Netatalk uses [Tracker](https://tracker.gnome.org) or its later
-  incarnation
-  TinySPARQL/[LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/)
-  as the metadata backend for Spotlight
-  search indexing. The minimum required version is 0.7 as this was the
-  first version to support
-  [SPARQL](https://gnome.pages.gitlab.gnome.org/tracker/).
+    Netatalk uses [Tracker](https://tracker.gnome.org) or its later
+    incarnation
+    TinySPARQL/[LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/)
+    as the metadata backend for Spotlight
+    search indexing. The minimum required version is 0.7 as this was the
+    first version to support
+    [SPARQL](https://gnome.pages.gitlab.gnome.org/tracker/).
 
 - talloc / bison / flex
 
-  Samba's talloc library, a Yacc parser such as bison, and a lexer like
-  flex are also required for Spotlight.
+    Samba's talloc library, a Yacc parser such as bison, and a lexer like
+    flex are also required for Spotlight.
 
 - UnicodeData.txt
 
-  The build system uses Perl and the Unicode Character Database to
-  generate Netatalk's Unicode character conversion sources.
+    The build system uses Perl and the Unicode Character Database to
+    generate Netatalk's Unicode character conversion sources.
 
 ### Configure and build Netatalk
 
@@ -240,9 +240,8 @@ macOS.
 When building from source, the Netatalk build system will attempt to
 detect which init style is appropriate for your platform. You can also
 configure the build system to install the specific type of startup
-script(s)  you want by specifying the
-**with-init-style** option. For the syntax, please refer to the build
-system's help text.
+script(s) you want by specifying the **with-init-style** option.
+For the syntax, please refer to the build system's help text.
 
 Since new Linux, \*BSD, and Solaris-like distributions appear at regular
 intervals, and the startup procedure for the other systems mentioned

--- a/doc/manual/License.md
+++ b/doc/manual/License.md
@@ -96,17 +96,14 @@ portion of it, thus forming a work based on the Program, and copy and
 distribute such modifications or work under the terms of Section 1
 above, provided that you also meet all of these conditions:
 
-  
 **a)** You must cause the modified files to carry prominent notices
 stating that you changed the files and the date of any change.
 
-  
 **b)** You must cause any work that you distribute or publish, that in
 whole or in part contains or is derived from the Program or any part
 thereof, to be licensed as a whole at no charge to all third parties
 under the terms of this License.
 
-  
 **c)** If the modified program normally reads commands interactively
 when run, you must cause it, when started running for such interactive
 use in the most ordinary way, to print or display an announcement
@@ -143,12 +140,10 @@ the scope of this License.
 under Section 2) in object code or executable form under the terms of
 Sections 1 and 2 above provided that you also do one of the following:
 
-  
 **a)** Accompany it with the complete corresponding machine-readable
 source code, which must be distributed under the terms of Sections 1
 and 2 above on a medium customarily used for software interchange; or,
 
-  
 **b)** Accompany it with a written offer, valid for at least three
 years, to give any third party, for a charge no more than your cost of
 physically performing source distribution, a complete machine-readable
@@ -156,7 +151,6 @@ copy of the corresponding source code, to be distributed under the
 terms of Sections 1 and 2 above on a medium customarily used for
 software interchange; or,
 
-  
 **c)** Accompany it with the information you received as to the offer
 to distribute corresponding source code. (This alternative is allowed
 only for noncommercial distribution and only if you received the

--- a/doc/manual/Upgrading.md
+++ b/doc/manual/Upgrading.md
@@ -36,7 +36,7 @@ There are three major changes between Netatalk 2 and Netatalk 4:
 - one to rule them all: configure AFP settings and volumes in one file
 
 - obsoletes *afpd.conf*, *netatalk.conf*, *AppleVolumes.default* and
-  *afp_ldap.conf*
+*afp_ldap.conf*
 
 > **WARNING**
 
@@ -48,7 +48,7 @@ There are three major changes between Netatalk 2 and Netatalk 4:
 - maps file extensions to Classic Mac OS type/creator
 
 - unlike 2.x, the mappings are disabled by default; uncomment the lines
-  in the file to enable them
+in the file to enable them
 
 - obsoletes *AppleVolumes.system*
 
@@ -60,53 +60,53 @@ and Classic Mac OS resource forks in extended attributes of the filesystem.
 - default backend (!)
 
 - requires a filesystem with Extended Attributes, fallback is AppleDouble v2
-  which is enabled with **ea = ad**
+which is enabled with **ea = ad**
 
 - converts filesystems from AppleDouble v2 to Extended Attributes on
-  the fly when accessed by clients (can be disabled with **convert appledouble**)
+the fly when accessed by clients (can be disabled with **convert appledouble**)
 
 - **dbd** can be used to do conversion in one shot
 
 Implementation details:
 
 - stores Mac Metadata (e.g. FinderInfo, AFP Flags, Comment, CNID) in an
-  Extended Attributed named “*org.netatalk.Metadata*”
+Extended Attributed named “*org.netatalk.Metadata*”
 
-  - Additionally, on macOS hosts running Netatalk 4.1.0 or later,
+    - Additionally, on macOS hosts running Netatalk 4.1.0 or later,
     FinderInfo is natively stored in the file system and appears as an
     Extended Attribute named “*com.apple.FinderInfo*”
 
 - stores Mac ResourceFork either in
 
-  - an Extended Attribute named “*org.netatalk.ResourceFork*” on
+    - an Extended Attribute named “*org.netatalk.ResourceFork*” on
     Solaris w. ZFS, or in
 
-  - an extra AppleDouble file named “*._file*” for a file named “*file*”
+    - an extra AppleDouble file named “*._file*” for a file named “*file*”,
     or
 
-  - natively stored in the resource fork on macOS hosts as of Netatalk
+    - natively stored in the resource fork on macOS hosts as of Netatalk
     4.1.0.
 
 - the format of the .\_ file is exactly as the Mac’s CIFS client expects
-  it when accessing the same filesystem via a CIFS server (Samba), thus
-  you can have parallel access from Macs to the same dataset via AFP and
-  CIFS without the risk of loosing data (resources or metadata).
-  Accessing the same dataset with CIFS from Windows clients will still
-  break the coupling of “*file*” and “*._file*” on non ZFS filesystems
-  (see above), so for this we still need an enhanced Samba VFS module
-  (in the works).
+it when accessing the same filesystem via a CIFS server (Samba), thus
+you can have parallel access from Macs to the same dataset via AFP and
+CIFS without the risk of loosing data (resources or metadata).
+Accessing the same dataset with CIFS from Windows clients will still
+break the coupling of “*file*” and “*._file*” on non ZFS filesystems
+(see above), so for this we still need an enhanced Samba VFS module
+(in the works).
 
 ### Other major changes
 
 - New service controller daemon [netatalk](netatalk.html) which is
-  responsible for starting and restarting the AFP and CNID daemons. All
-  bundled start scripts have been updated, make sure to update yours!
+responsible for starting and restarting the AFP and CNID daemons. All
+bundled start scripts have been updated, make sure to update yours!
 
 - All CNID databases are now stored under *$prefix/var/netatalk/CNID/*
-  by default, rather than in the individual shared volume directories
+by default, rather than in the individual shared volume directories
 
 - Netatalk 2.x volume options “**usedots**” and “**upriv**” now enabled by
-  default
+default
 
 - Removed SLP and AFP proxy support
 

--- a/doc/po/AppleTalk.md.ja.po
+++ b/doc/po/AppleTalk.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-02-01 19:55+0100\n"
+"POT-Creation-Date: 2025-03-13 21:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -16,8 +16,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1050 manpages/man5/afp.conf.5.md:1085
-#: manual/AppleTalk.md:154 manual/Configuration.md:832 manual/Installation.md:4
+#: manpages/man5/afp.conf.5.md:1061 manpages/man5/afp.conf.5.md:1097
+#: manual/AppleTalk.md:154 manual/Configuration.md:827 manual/Installation.md:4
 #: manual/Upgrading.md:42
 #, no-wrap
 msgid "> **WARNING**\n"
@@ -346,36 +346,32 @@ msgstr ""
 "AppleTalk ルータには、シード ルータ、非シード ルータ、いわゆるソフト シード "
 "ルータなど、いくつかの種類がある。"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manual/AppleTalk.md:120
+#, no-wrap
 msgid ""
-"A seed router has its own configuration and publishes this into the network "
-"segments it is configured for."
-msgstr ""
-"シード ルータには独自の構成があり、その構成を、そのルータが構成されているネッ"
-"トワーク セグメントに公開する。"
+"- A seed router has its own configuration and publishes this into the\n"
+"    network segments it is configured for.\n"
+msgstr "- シード ルータには独自の構成があり、その構成を、そのルータが構成されているネットワーク セグメントに公開する。\n"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manual/AppleTalk.md:124
+#, no-wrap
 msgid ""
-"A non-seed router needs a seed router on the interface to which it is "
-"connected to learn the network configuration. So this type of AppleTalk "
-"router can work completely without manual configuration."
-msgstr ""
-"非シード ルータは、ネットワーク構成を学習するために、接続先のインターフェイス"
-"にシード ルータが必要。したがって、このタイプの AppleTalk ルータは、手動設定"
-"なしで完全に動作する。"
+"- A non-seed router needs a seed router on the interface to which it is\n"
+"    connected to learn the network configuration. So this type of\n"
+"    AppleTalk router can work completely without manual configuration.\n"
+msgstr "- 非シード ルータは、ネットワーク構成を学習するために、接続先のインターフェイスにシード ルータが必要。したがって、このタイプの AppleTalk ルータは、手動設定なしで完全に動作する。\n"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manual/AppleTalk.md:129
+#, no-wrap
 msgid ""
-"A so called soft-seed router is exactly the same as a non-seed router except "
-"the fact, that it can also remember the configuration of a seed router and "
-"act as a replacement in case, the real seed router disappears from the net."
-msgstr ""
-"いわゆるソフトシード ルータは、シード ルータの設定を記憶し、実際のシード ルー"
-"タがネットから消えた場合に代わりとして動作できることを除けば、非シード ルータ"
-"とまったく同じ。"
+"- A so called soft-seed router is exactly the same as a non-seed router\n"
+"    except the fact, that it can also remember the configuration of a seed\n"
+"    router and act as a replacement in case, the real seed router\n"
+"    disappears from the net.\n"
+msgstr "- いわゆるソフトシード ルータは、シード ルータの設定を記憶し、実際のシード ルータがネットから消えた場合に代わりとして動作できることを除けば、非シード ルータとまったく同じ。\n"
 
 #. type: Plain text
 #: manual/AppleTalk.md:133
@@ -546,28 +542,25 @@ msgstr "**-net** (各インターフェースに 1 ～ 65279 の適切な値を�
 #: manual/AppleTalk.md:202
 #, no-wrap
 msgid ""
-"  In case, this value is suppressed but -addr is present, the netrange\n"
-"  from this specific address will be used\n"
-msgstr ""
-"  この値が抑制されていても -addr が存在する場合は、この特定のアドレスの\n"
-"  netrange が使用される\n"
+"    In case, this value is suppressed but -addr is present, the netrange\n"
+"    from this specific address will be used\n"
+msgstr "    この値が抑制されていても -addr が存在する場合は、この特定のアドレスのnetrangeが使用される\n"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manual/AppleTalk.md:205
+#, no-wrap
 msgid ""
-"**-addr** (the net part must match the -net settings if present, the node "
-"address should be between 142 and 255)"
-msgstr ""
-"**-addr** (net 部分は -net 設定 (存在する場合)  と一致する必要がある。ノード "
-"アドレスは 142 ～ 255 の範囲である必要がある)"
+"- **-addr** (the net part must match the -net settings if present, the node\n"
+"    address should be between 142 and 255)\n"
+msgstr "- **-addr** (net 部分は -net 設定 (存在する場合) と一致する必要がある。ノード アドレスは 142 ～ 255 の範囲である必要がある)\n"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manual/AppleTalk.md:208
+#, no-wrap
 msgid ""
-"**-zone** (can be used multiple times in one single line, the first entry is "
-"the default zone)"
-msgstr ""
-"**-zone** (1行に複数回使用できる。最初のエントリはデフォルトのゾーンになる。)"
+"- **-zone** (can be used multiple times in one single line, the first entry\n"
+"    is the default zone)\n"
+msgstr "- **-zone** (1行に複数回使用できる。最初のエントリはデフォルトのゾーンになる。)\n"
 
 #. type: Plain text
 #: manual/AppleTalk.md:216

--- a/doc/po/Configuration.md.ja.po
+++ b/doc/po/Configuration.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-03-02 09:47+0100\n"
+"POT-Creation-Date: 2025-03-13 21:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -20,24 +20,24 @@ msgstr ""
 #: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:334
 #: manpages/man5/afp.conf.5.md:358 manpages/man5/afp.conf.5.md:371
 #: manpages/man5/afp.conf.5.md:386 manpages/man5/afp.conf.5.md:741
-#: manpages/man5/afp.conf.5.md:1057 manpages/man5/afp.conf.5.md:1183
-#: manpages/man5/afp.conf.5.md:1221 manpages/man8/papd.8.md:96
+#: manpages/man5/afp.conf.5.md:1056 manpages/man5/afp.conf.5.md:1182
+#: manpages/man5/afp.conf.5.md:1220 manpages/man8/papd.8.md:96
 #: manual/Configuration.md:113
 #, no-wrap
 msgid "> **NOTE**\n"
 msgstr "> **注記**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1062 manpages/man5/afp.conf.5.md:1098
-#: manual/AppleTalk.md:154 manual/Configuration.md:832 manual/Installation.md:4
+#: manpages/man5/afp.conf.5.md:1061 manpages/man5/afp.conf.5.md:1097
+#: manual/AppleTalk.md:154 manual/Configuration.md:827 manual/Installation.md:4
 #: manual/Upgrading.md:42
 #, no-wrap
 msgid "> **WARNING**\n"
 msgstr "> **警告**\n"
 
 #. type: Title ###
-#: manpages/man8/cnid_dbd.8.md:63 manual/Configuration.md:581
-#: manual/Configuration.md:826
+#: manpages/man8/cnid_dbd.8.md:63 manual/Configuration.md:576
+#: manual/Configuration.md:821
 #, no-wrap
 msgid "Configuration"
 msgstr "設定"
@@ -975,50 +975,50 @@ msgid "Netatalk supports the following ones by default:"
 msgstr "Netatalk はデフォルトで以下のものをサポートしている："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:360
+#: manual/Configuration.md:359
 msgid "\"No User Authent\" UAM (guest access without authentication)"
 msgstr "\"No User Authent\" UAM（ユーザー認証なしのゲスト接続）"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:363
+#: manual/Configuration.md:361
 msgid "\"Cleartxt Passwrd\" UAM (no password encryption)"
 msgstr "\"Cleartxt Passwrd\" UAM（クリアテキスト(平文)パスワード、暗号化なし）"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:367
+#. type: Plain text
+#: manual/Configuration.md:364
 msgid ""
-"\"Randnum exchange\"/\"2-Way Randnum exchange\" UAMs (weak password "
+"- \"Randnum exchange\"/\"2-Way Randnum exchange\" UAMs (weak password "
 "encryption, separate password storage)"
 msgstr ""
-"\"Randnum exchange\"、\"2-Way Randnum exchange\" UAM （乱数交換・双方向乱数交"
-"換、弱いパスワード暗号化、パスワードを別途保存する）"
+"- \"Randnum exchange\"、\"2-Way Randnum exchange\" UAM （乱数交換・双方向乱数"
+"交換、弱いパスワード暗号化、パスワードを別途保存する）"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:370
+#: manual/Configuration.md:366
 msgid "\"DHCAST128\" UAM (a.k.a. DHX; stronger password encryption)"
 msgstr "\"DHCAST128\" UAM（より強いパスワード暗号化）"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:372
+#: manual/Configuration.md:368
 msgid "\"DHX2\" UAM (successor of DHCAST128)"
 msgstr "\"DHX2\" UAM（DHCAST128 の後継版）"
 
 #. type: Plain text
-#: manual/Configuration.md:374
+#: manual/Configuration.md:370
 msgid "There exist other optional UAMs as well:"
 msgstr "他にもオプションとして以下のような UAM がある："
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:378
+#. type: Plain text
+#: manual/Configuration.md:373
 msgid ""
-"\"Client Krb v2\" UAM (Kerberos V, suitable for \"Single Sign On\" Scenarios "
-"with macOS clients – see below)"
+"- \"Client Krb v2\" UAM (Kerberos V, suitable for \"Single Sign On\" "
+"Scenarios with macOS clients – see below)"
 msgstr ""
-"\"Client Krb v2\" UAM （Kerberos V、macOS で“シングルサインオン”環境には最も"
-"適当である――下記参照）"
+"- \"Client Krb v2\" UAM （Kerberos V、macOS で“シングルサインオン”環境には最"
+"も適当である――下記参照）"
 
 #. type: Plain text
-#: manual/Configuration.md:384
+#: manual/Configuration.md:379
 msgid ""
 "You can configure which UAMs should be activated by defining \"**uam "
 "list**\" in **Global** section. **afpd** will log which UAMs it's using and "
@@ -1033,7 +1033,7 @@ msgstr ""
 "い合わせをするのに使うことができる。"
 
 #. type: Plain text
-#: manual/Configuration.md:389
+#: manual/Configuration.md:384
 msgid ""
 "Having a specific UAM available at the server does not automatically mean "
 "that a client can use it. Client-side support is also necessary.  For older "
@@ -1046,7 +1046,7 @@ msgstr ""
 "DHCAST128 のサポートは AppleShare クライアント 3.8.x 以降には存在している。"
 
 #. type: Plain text
-#: manual/Configuration.md:394
+#: manual/Configuration.md:389
 msgid ""
 "On macOS, there exist some client-side techniques to make the AFP-client "
 "more verbose, so one can have a look at what's happening while negotiating "
@@ -1059,13 +1059,13 @@ msgstr ""
 "article.gmane.org/gmane.network.netatalk.devel/7383/)  と比較してみるとよい。"
 
 #. type: Title ###
-#: manual/Configuration.md:395
+#: manual/Configuration.md:390
 #, no-wrap
 msgid "Which UAMs to activate?"
 msgstr "どの UAM を有効にすべきか？"
 
 #. type: Plain text
-#: manual/Configuration.md:400
+#: manual/Configuration.md:395
 msgid ""
 "It depends primarily on your needs and on the kind of macOS clients you have "
 "to support. If your network consists of exclusively macOS (Mac OS X) "
@@ -1075,93 +1075,93 @@ msgstr ""
 "る。ネットワークが macOS (Mac OS X)  クライアントのみで構成されている場合は、"
 "DHX2 で十分であり、最も強力な暗号化を提供する。"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:406
+#. type: Plain text
+#: manual/Configuration.md:401
 msgid ""
-"Unless you really have to supply guest access to your server's volumes "
+"- Unless you really have to supply guest access to your server's volumes "
 "ensure that you disable \"No User Authent\" since it might lead accidentally "
 "to unauthorized access. In case you must enable guest access take care that "
 "you enforce this on a per volume base using the access controls."
 msgstr ""
-"サーバーのボリュームに本当にゲストアクセスを供することが必要な場合以外は、"
+"- サーバーのボリュームに本当にゲストアクセスを供することが必要な場合以外は、"
 "\"No User Authent\" が無効化されているか確認すべきである。さもないと、意図し"
 "ない権限のないアクセスを引き起こすことにもなる。 ゲストアクセスを有効にしなけ"
 "ればならない場合は、アクセスコントロールを使って、 ボリューム各々についてゲス"
 "トアクセスを有効化することを強制するように気を配るべきである。"
 
 #. type: Plain text
-#: manual/Configuration.md:409
+#: manual/Configuration.md:404
 #, no-wrap
 msgid ""
-"  Note: \"No User Authent\" is required to use Apple II NetBoot services\n"
-"  (**a2boot**) to boot an Apple //e over AFP.\n"
+"    Note: \"No User Authent\" is required to use Apple II NetBoot services\n"
+"    (**a2boot**) to boot an Apple //e over AFP.\n"
 msgstr ""
-"  注意：Apple II NetBoot サービス (**a2boot**) を使用して AFP 経由で\n"
-"  Apple //e を起動するには、「ユーザー認証なし」が必要である。\n"
+"    注意：Apple II NetBoot サービス (**a2boot**) を使用して AFP 経由で\n"
+"    Apple //e を起動するには、「ユーザー認証なし」が必要である。\n"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:413
+#. type: Plain text
+#: manual/Configuration.md:408
 msgid ""
-"The \"ClearTxt Passwrd\" UAM is as bad as it sounds since passwords go "
+"- The \"ClearTxt Passwrd\" UAM is as bad as it sounds since passwords go "
 "unencrypted over the wire. Try to avoid it at both the server's side as well "
 "as on the client's."
 msgstr ""
-"\"ClearTxt Passwrd\" UAM ではパスワードがネットワーク上を暗号化されずに伝わっ"
-"ていくので、 字句そのまんまに良くない。クライアント側のみならずサーバー側でも"
-"無効にするよう務めるべきである。"
+"- \"ClearTxt Passwrd\" UAM ではパスワードがネットワーク上を暗号化されずに伝"
+"わっていくので、 字句そのまんまに良くない。クライアント側のみならずサーバー側"
+"でも無効にするよう務めるべきである。"
 
 #. type: Plain text
-#: manual/Configuration.md:418
+#: manual/Configuration.md:413
 #, no-wrap
 msgid ""
-"  Note: If you want to provide Mac OS 8/9 clients with NetBoot-services\n"
-"  then you need uams_cleartxt.so since the AFP-client integrated into\n"
-"  the Mac's firmware can only deal with this basic form of\n"
-"  authentication.\n"
+"    Note: If you want to provide Mac OS 8/9 clients with NetBoot-services\n"
+"    then you need uams_cleartxt.so since the AFP-client integrated into\n"
+"    the Mac's firmware can only deal with this basic form of\n"
+"    authentication.\n"
 msgstr ""
-"  注意：もし NetBoot サービスを使用している Mac OS 8/9\n"
-"  にサービスを提供したい場合、uams_cleartxt.so の UAM が必要となる。\n"
-"  これはそういった Mac のファームウエアに組み込まれた AFP\n"
-"  クライアントがこうした基本的な形の認証しか扱わないためである。\n"
+"    注意：もし NetBoot サービスを使用している Mac OS 8/9\n"
+"    にサービスを提供したい場合、uams_cleartxt.so の UAM が必要となる。\n"
+"    これはそういった Mac のファームウエアに組み込まれた AFP\n"
+"    クライアントがこうした基本的な形の認証しか扱わないためである。\n"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:426
+#. type: Plain text
+#: manual/Configuration.md:421
 msgid ""
-"Since \"Randnum exchange\"/\"2-Way Randnum exchange\" uses only 56 bit DES "
+"- Since \"Randnum exchange\"/\"2-Way Randnum exchange\" uses only 56 bit DES "
 "for encryption it should be avoided as well. Another disadvantage is the "
 "fact that the passwords have to be stored in cleartext on the server and "
 "that it doesn't integrate into both PAM scenarios or classic /etc/shadow "
 "(you have to administrate passwords separately by using the **afppasswd** "
 "utility, in order for clients to use these UAMs)"
 msgstr ""
-"\"Randnum exchange\" と \"2-Way Randnum exchange\" は 56 ビット DES 暗号化し"
-"か使わないので、これらもやはり回避すべきである。 そしてなおかつ不利なのは、パ"
-"スワードがサーバーに平文テキストとして保存されなければならないこと、および "
+"- \"Randnum exchange\" と \"2-Way Randnum exchange\" は 56 ビット DES 暗号化"
+"しか使わないので、これらもやはり回避すべきである。 そしてなおかつ不利なのは、"
+"パスワードがサーバーに平文テキストとして保存されなければならないこと、および "
 "PAM 環境とも古典的な /etc/shadow とも統合がとれない （もしクライアントがこれ"
 "らの UAM を使わなければならない場合、**afppasswd** ユーティリティを使って別途"
 "パスワードを管理しなければならない）という点である。"
 
 #. type: Plain text
-#: manual/Configuration.md:429
+#: manual/Configuration.md:424
 #, no-wrap
 msgid ""
-"  However, this is the strongest form of authentication that can be used\n"
-"  with Macintosh System Software 7.1 or earlier.\n"
-msgstr "  ただし、これは 漢字Talk 7.1 以前で使用できる最も強力な認証形式である。\n"
+"    However, this is the strongest form of authentication that can be used\n"
+"    with Macintosh System Software 7.1 or earlier.\n"
+msgstr "    ただし、これは 漢字Talk 7.1 以前で使用できる最も強力な認証形式である。\n"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:432
+#. type: Plain text
+#: manual/Configuration.md:427
 msgid ""
-"\"DHCAST128\" (\"DHX\") or \"DHX2\" should be the sweet spot for most people "
-"since it combines stronger encryption with PAM integration."
+"- \"DHCAST128\" (\"DHX\") or \"DHX2\" should be the sweet spot for most "
+"people since it combines stronger encryption with PAM integration."
 msgstr ""
-"\"DHCAST128\" (\"DHX\") あるいは \"DHX2\" は PAM との統合と強力な暗号化とが組"
-"み合わせられているので、 ほとんどの人々にとって良い妥協案であろう。"
+"- \"DHCAST128\" (\"DHX\") あるいは \"DHX2\" は PAM との統合と強力な暗号化とが"
+"組み合わせられているので、 ほとんどの人々にとって良い妥協案であろう。"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:443
+#. type: Plain text
+#: manual/Configuration.md:438
 msgid ""
-"Using the Kerberos V (\"Client Krb v2\")  UAM, it's possible to implement "
+"- Using the Kerberos V (\"Client Krb v2\")  UAM, it's possible to implement "
 "real single sign on scenarios using Kerberos tickets. The password is not "
 "sent over the network. Instead, the user password is used to decrypt a "
 "service ticket for the AppleShare server. The service ticket contains an "
@@ -1171,17 +1171,17 @@ msgid ""
 "that the afpd service principal detection is implemented, this "
 "authentication method is vulnerable to man-in-the-middle attacks."
 msgstr ""
-"Kerberos V (\"Client Krb v2\") UAM を用いれば、Kerberos チケットを用いて真の"
-"シングルサインオン環境を実装することが可能である。パスワードがネットワークを"
-"通して送られることもない。 その代わり、ユーザーのパスワードは AppleShare サー"
-"バーへのサービスチケットを暗号から復号するのに用いられる。 サービスチケットに"
-"はクライアントの暗号鍵と幾らかの暗号化されたデータが含まれる （それは "
+"- Kerberos V (\"Client Krb v2\") UAM を用いれば、Kerberos チケットを用いて真"
+"のシングルサインオン環境を実装することが可能である。パスワードがネットワーク"
+"を通して送られることもない。 その代わり、ユーザーのパスワードは AppleShare "
+"サーバーへのサービスチケットを暗号から復号するのに用いられる。 サービスチケッ"
+"トにはクライアントの暗号鍵と幾らかの暗号化されたデータが含まれる （それは "
 "AppleShare サーバーだけが復号できる）。サービスチケットの暗号化された部分が"
 "サーバーに送られ、ユーザーを認証するのに使われる。afpd サービスプリンシパル検"
 "知の実装の仕方のために、この認証方法は中間者攻撃に対して脆弱である。"
 
 #. type: Plain text
-#: manual/Configuration.md:448
+#: manual/Configuration.md:443
 msgid ""
 "For a more detailed overview over the technical implications of the "
 "different UAMs, please have a look at Apple's [File Server Security](http://"
@@ -1195,13 +1195,13 @@ msgstr ""
 "TP40000854-CH232-SW1)  ページを見ていただきたい。"
 
 #. type: Title ###
-#: manual/Configuration.md:449
+#: manual/Configuration.md:444
 #, no-wrap
 msgid "Using different authentication sources with specific UAMs"
 msgstr "特定の UAM で別の認証ソースを使う"
 
 #. type: Plain text
-#: manual/Configuration.md:459
+#: manual/Configuration.md:454
 msgid ""
 "Some UAMs provide the ability to use different authentication \"backends\", "
 "namely **uams_clrtxt.so**, **uams_dhx.so** and **uams_dhx2.so**. They can "
@@ -1221,7 +1221,7 @@ msgstr ""
 "ないしは **uams_dhx2_pam.so**へのシンボリックリンクとすることができる。"
 
 #. type: Plain text
-#: manual/Configuration.md:463
+#: manual/Configuration.md:458
 msgid ""
 "So, if it looks like this in Netatalk's UAMs folder (per default */etc/"
 "netatalk/uams/*) then you're using PAM, otherwise classic UNIX passwords."
@@ -1231,7 +1231,7 @@ msgstr ""
 "けである。"
 
 #. type: Plain text
-#: manual/Configuration.md:467
+#: manual/Configuration.md:462
 #, no-wrap
 msgid ""
 "    uams_clrtxt.so -> uams_pam.so\n"
@@ -1240,7 +1240,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:474
+#: manual/Configuration.md:469
 msgid ""
 "The main advantage of using PAM is that one can integrate Netatalk in "
 "centralized authentication scenarios, e.g. via LDAP, NIS and the like.  "
@@ -1257,18 +1257,18 @@ msgstr ""
 "ワーク上から 完全に除去することを考えるべきである。"
 
 #. type: Title ###
-#: manual/Configuration.md:475
+#: manual/Configuration.md:470
 #, no-wrap
 msgid "Netatalk UAM overview table"
 msgstr "Netatalk UAM を概要表"
 
 #. type: Plain text
-#: manual/Configuration.md:478
+#: manual/Configuration.md:473
 msgid "A small overview of the most commonly used UAMs."
 msgstr "最も一般的に用いられる UAM の概観。"
 
 #. type: Plain text
-#: manual/Configuration.md:486
+#: manual/Configuration.md:481
 #, no-wrap
 msgid ""
 "| UAM | No User Authent | Cleartxt Passwrd | (2-Way) Randnum exchange | DHCAST128 | DHX2 | Client Krb v2 |\n"
@@ -1289,7 +1289,7 @@ msgstr ""
 "| パスワードの保管方法 | なし | /etc/passwd (/etc/shadow) ないしは PAM | パスワードは別のテキストファイルに平文として保存される | /etc/passwd (/etc/shadow) ないしは PAM | /etc/passwd (/etc/shadow) ないしは PAM | Kerberos キー配布センター\\* |\n"
 
 #. type: Plain text
-#: manual/Configuration.md:489
+#: manual/Configuration.md:484
 msgid ""
 "\\* Have a look at this [Kerberos overview](https://web.archive.org/web/"
 "20070705043002/http://cryptnet.net/fdp/admin/kerby-infra/en/kerby-infra.html)"
@@ -1298,13 +1298,13 @@ msgstr ""
 "cryptnet.net/fdp/admin/kerby-infra/en/kerby-infra.html)  も一読のこと"
 
 #. type: Title ###
-#: manual/Configuration.md:490
+#: manual/Configuration.md:485
 #, no-wrap
 msgid "SSH tunneling"
 msgstr "SSH トンネリング"
 
 #. type: Plain text
-#: manual/Configuration.md:496
+#: manual/Configuration.md:491
 msgid ""
 "Tunneling and VPNs usually have nothing to do with AFP authentication and "
 "UAMs. But since Apple introduced an option called \"Allow Secure Connections "
@@ -1316,13 +1316,13 @@ msgstr ""
 "下ではその点についても述べる。"
 
 #. type: Title ####
-#: manual/Configuration.md:497
+#: manual/Configuration.md:492
 #, no-wrap
 msgid "Manually tunneling an AFP session"
 msgstr "手動で AFP セッションをトンネリング"
 
 #. type: Plain text
-#: manual/Configuration.md:503
+#: manual/Configuration.md:498
 msgid ""
 "This works since the first AFP servers that spoke \"AFP over TCP\" appeared "
 "in networks. One simply tunnels the remote server's AFP port to a local port "
@@ -1335,13 +1335,13 @@ msgstr ""
 "だけである。macOS では以下のようにすればよい。"
 
 #. type: Plain text
-#: manual/Configuration.md:505
+#: manual/Configuration.md:500
 #, no-wrap
 msgid "    ssh -l $USER $SERVER -L 10548:127.0.0.1:548 sleep 3000\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:512
+#: manual/Configuration.md:507
 msgid ""
 "After establishing the tunnel one will use `\"afp://127.0.0.1:10548\"` in "
 "the \"Connect to server\" dialog. All AFP traffic including the initial "
@@ -1356,7 +1356,7 @@ msgstr ""
 "も含めて全ての AFP トラフィックがネットワークを暗号化されて送られる。"
 
 #. type: Plain text
-#: manual/Configuration.md:518
+#: manual/Configuration.md:513
 msgid ""
 "This sort of tunnel is an ideal solution if you must access an AFP server "
 "through the Internet without having the ability or desire to use a \"real\" "
@@ -1372,13 +1372,13 @@ msgstr ""
 "る。"
 
 #. type: Title ####
-#: manual/Configuration.md:519
+#: manual/Configuration.md:514
 #, no-wrap
 msgid "Automatically establishing a tunneled AFP connection"
 msgstr "自動的にトンネル AFP 接続を確立する"
 
 #. type: Plain text
-#: manual/Configuration.md:526
+#: manual/Configuration.md:521
 msgid ""
 "From Mac OS X 10.2 to 10.4, Apple added an \"Allow Secure Connections Using "
 "SSH\" checkbox to the \"Connect to Server\" dialog. The idea behind this "
@@ -1393,7 +1393,7 @@ msgstr ""
 "を通して送る。ということなのである。"
 
 #. type: Plain text
-#: manual/Configuration.md:531
+#: manual/Configuration.md:526
 msgid ""
 "But it took until the release of Mac OS X 10.3 that this feature worked the "
 "first time... partly. In case, the SSH tunnel could not be established and "
@@ -1405,7 +1405,7 @@ msgstr ""
 "暗号化していない AFP 接続試行にフォールバックした。"
 
 #. type: Plain text
-#: manual/Configuration.md:537
+#: manual/Configuration.md:532
 msgid ""
 "Netatalk's afpd will report that it is capable of handling SSH tunneled AFP "
 "requests, when both \"**advertise ssh**\" and \"**fqdn**\" options are set "
@@ -1419,107 +1419,104 @@ msgstr ""
 "ことを Netatalk の afpd はレポートする。しかし、このオプションを決して使用し"
 "たくなくなる２、３の理由がある："
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:542
+#. type: Plain text
+#: manual/Configuration.md:537
 msgid ""
-"Most users who need such a feature are probably already familiar with using "
-"a VPN; it might be easier for the user to employ the same VPN software in "
-"order to connect to the network on which the AFP server is running, and then "
-"to access the AFP server as normal."
+"- Most users who need such a feature are probably already familiar with "
+"using a VPN; it might be easier for the user to employ the same VPN software "
+"in order to connect to the network on which the AFP server is running, and "
+"then to access the AFP server as normal."
 msgstr ""
-"こう言うような機能を必要とする大部分のユーザーは、 おそらく使い慣れている "
+"- こう言うような機能を必要とする大部分のユーザーは、 おそらく使い慣れている "
 "VPN はあるとしたら、 通常のVPNを使用して AFP サーバーが実行されているネット"
 "ワークに接続し、 AFP サーバーにアクセスする方が簡単だろう。"
 
 #. type: Plain text
-#: manual/Configuration.md:548
+#: manual/Configuration.md:543
 #, no-wrap
 msgid ""
-"  That being said, for the simple case of connecting to one specific AFP\n"
-"  server, a direct SSH connection is likely to perform better than a\n"
-"  general-purpose VPN; contrary to popular belief, tunneling via SSH\n"
-"  does **not** result in what's called \"TCP-over-TCP meltdown\", because\n"
-"  the AFP data that are being tunneled do not encapsulate TCP data.\n"
+"    That being said, for the simple case of connecting to one specific AFP\n"
+"    server, a direct SSH connection is likely to perform better than a\n"
+"    general-purpose VPN; contrary to popular belief, tunneling via SSH\n"
+"    does **not** result in what's called \"TCP-over-TCP meltdown\", because\n"
+"    the AFP data that are being tunneled do not encapsulate TCP data.\n"
 msgstr ""
-"  とはいっても、１台の AFP サーバーに接続するという単純なケースでは、\n"
-"  VPN より直接 SSH\n"
-"  接続の方がパフォーマンス的に良いだろう。噂と違って、SSH\n"
-"  経由のトンネリングでは、 いわゆる「TCP-over-TCP\n"
-"  メルトダウン」は発生しない。何故なら、トンネリングされるAFPデータが\n"
-"  TCP データをカプセル化していないためである。\n"
+"    とはいっても、１台のAFPサーバーに接続するという単純なケースでは、\n"
+"    VPNより直接SSH接続の方がパフォーマンス的に良いだろう。噂と違って、SSH\n"
+"    経由のトンネリングでは、いわゆる「TCP-over-TCP\n"
+"    メルトダウン」は発生しない。何故なら、トンネリングされるAFPデータが\n"
+"    TCPデータをカプセル化していないためである。\n"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:554
+#. type: Plain text
+#: manual/Configuration.md:549
 msgid ""
-"Since this SSH kludge isn't a normal UAM that integrates directly into the "
+"- Since this SSH kludge isn't a normal UAM that integrates directly into the "
 "AFP authentication mechanisms but instead uses a single flag signalling "
 "clients whether they can **try** to establish a tunnel or not, it makes life "
 "harder to see what's happening when things go wrong."
 msgstr ""
-"このように SSH でその場をしのぐことは AFP 認証機構に直接統合された通常の UAM "
-"ではないし、 代わりにこの方法では、トンネルの確立を**試行** できるのかどうな"
-"のかのサインをクライアントに送るために、単一のフラグを用いる。 このため、何か"
-"がおかしい時に何が起こっているのかを見ようとする気を失ってしまう。"
+"- このようにSSHでその場をしのぐことはAFP認証機構に直接統合された通常のUAMでは"
+"ないし、代わりにこの方法では、トンネルの確立を**試行**できるのかどうなのかの"
+"サインをクライアントに送るために、単一のフラグを用いる。このため、何かがおか"
+"しい時に何が起こっているのかを見ようとする気を失ってしまう。"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:558
+#. type: Plain text
+#: manual/Configuration.md:553
 msgid ""
-"You cannot control which machines are logged on by Netatalk tools like a "
+"- You cannot control which machines are logged on by Netatalk tools like a "
 "**macusers** since all connection attempts seem to be made from localhost."
 msgstr ""
-"全ての接続試行は localhost から行われているように見えるので、 **macusers** の"
-"ような Netatalk ツールによって、 どのマシンがログオンしているのか制御ができな"
-"い。"
+"- 全ての接続試行はlocalhostから行われているように見えるので、**macusers**のよ"
+"うなNetatalkツールによって、どのマシンがログオンしているのか制御ができない。"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:563
+#. type: Plain text
+#: manual/Configuration.md:558
 msgid ""
-"Indeed, to ensure that all AFP sessions are encrypted via SSH, you need to "
+"- Indeed, to ensure that all AFP sessions are encrypted via SSH, you need to "
 "limit afpd to connections that originate only from localhost (e.g., by using "
 "Wietse Venema's TCP Wrappers, or by using suitable firewall or packet-"
 "filtering facilities, etc.)."
 msgstr ""
-"実際、AFP セッションが全てが SSH で暗号化されていることを確実にしたい場合は、"
-"afpd へのアクセスを localhost のみ発信される接続に制限する必要がある。たとえ"
-"ば、Wietse Venema の TCP ラッパーを使用するか、適切なファイアウォールやパケッ"
-"トフィルタリング機能を使用するなど。"
+"- 実際、AFPセッションが全てがSSHで暗号化されていることを確実にしたい場合は、"
+"afpdへのアクセスをlocalhostのみ発信される接続に制限する必要がある。たとえば、"
+"Wietse VenemaのTCPラッパーを使用するか、適切なファイアウォールやパケットフィ"
+"ルタリング機能を使用するなど。"
 
 #. type: Plain text
-#: manual/Configuration.md:569
+#: manual/Configuration.md:564
 #, no-wrap
 msgid ""
-"  Otherwise, when you're using Mac OS X 10.2 through 10.3.3, you get the\n"
-"  opposite of what you'd expect: potentially unencrypted AFP\n"
-"  communications (including login credentials) being sent across the\n"
-"  network without a single notification that establishing the tunnel\n"
-"  failed. Apple fixed that with Mac OS X 10.3.4.\n"
+"    Otherwise, when you're using Mac OS X 10.2 through 10.3.3, you get the\n"
+"    opposite of what you'd expect: potentially unencrypted AFP\n"
+"    communications (including login credentials) being sent across the\n"
+"    network without a single notification that establishing the tunnel\n"
+"    failed. Apple fixed that with Mac OS X 10.3.4.\n"
 msgstr ""
-"  そうしなければ、10.2 から 10.3.3 を使っている場合は、予想とは逆に：\n"
-"  トンネルの確立に失敗したという通知一つもなく、ネットワーク上で暗号化されていない\n"
-"  AFP\n"
-"  の通信（ログイン資格情報を含む）が起こりえるということである。Apple は\n"
-"  Mac OS X 10.3.4 になってそれをはじめて修正した。\n"
+"    そうしなければ、10.2 から 10.3.3 を使っている場合は、予想とは逆に：\n"
+"    トンネルの確立に失敗したという通知一つもなく、ネットワーク上で暗号化されていない\n"
+"    AFPの通信（ログイン資格情報を含む）が起こりえるということである。Appleは\n"
+"    Mac OS X 10.3.4 になってそれをはじめて修正した。\n"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:575
+#. type: Plain text
+#: manual/Configuration.md:570
 msgid ""
-"Encrypting all AFP sessions via SSH can lead to a significantly higher load "
-"on the computer that is running the AFP server, because that computer must "
-"also handle encryption; if the user is connecting through a trusted network, "
-"then such encryption might be an unnecessary overhead."
+"- Encrypting all AFP sessions via SSH can lead to a significantly higher "
+"load on the computer that is running the AFP server, because that computer "
+"must also handle encryption; if the user is connecting through a trusted "
+"network, then such encryption might be an unnecessary overhead."
 msgstr ""
-"SSH 経由で全ての AFP セッションを暗号化するることは、Netatalk サーバーの負荷"
-"の著しい上昇を招く可能性がある。 ユーザーが信頼できるネットワーク経由で接続し"
-"ている場合、そのような暗号化は無駄かもしれない。"
+"- SSH経由で全てのAFPセッションを暗号化するることは、Netatalkサーバーの負荷の"
+"著しい上昇を招く可能性がある。ユーザーが信頼できるネットワーク経由で接続して"
+"いる場合、そのような暗号化は無駄かもしれない。"
 
 #. type: Title ##
-#: manual/Configuration.md:576
+#: manual/Configuration.md:571
 #, no-wrap
 msgid "ACL Support"
 msgstr "ACL のサーポート"
 
 #. type: Plain text
-#: manual/Configuration.md:580
+#: manual/Configuration.md:575
 msgid ""
 "ACL support for AFP is implemented for ZFS ACLs on Solaris and derived "
 "platforms and for POSIX 1e ACLs on Linux."
@@ -1528,7 +1525,7 @@ msgstr ""
 "Linux の POSIX 1e ACL で実装されている。"
 
 #. type: Plain text
-#: manual/Configuration.md:592
+#: manual/Configuration.md:587
 msgid ""
 "For a basic mode of operation there's nothing to configure. Netatalk reads "
 "ACLs on the fly and calculates effective permissions which are then send to "
@@ -1549,7 +1546,7 @@ msgstr ""
 "できないであろう。"
 
 #. type: Plain text
-#: manual/Configuration.md:598
+#: manual/Configuration.md:593
 msgid ""
 "By default, the effective permission of the authenticated user are only "
 "mapped to the mentioned UARightspermission structure, not the UNIX mode. You "
@@ -1561,7 +1558,7 @@ msgstr ""
 "(afp.conf#options-for-acl-handling) で修正することができる。"
 
 #. type: Plain text
-#: manual/Configuration.md:608
+#: manual/Configuration.md:603
 msgid ""
 "However, neither in Finder \"Get Info\" windows nor in the Terminal will you "
 "be able to see the ACLs, because of how ACLs in macOS are designed.  If you "
@@ -1584,7 +1581,7 @@ msgstr ""
 "付けた UNIX uid と gid も含めたサーバー側の ACL を返すことができる。"
 
 #. type: Plain text
-#: manual/Configuration.md:613
+#: manual/Configuration.md:608
 msgid ""
 "Netatalk can query a directory server using LDAP queries. Either the "
 "directory server already provides an UUID attribute for user and groups "
@@ -1598,17 +1595,17 @@ msgstr ""
 "れかである。"
 
 #. type: Plain text
-#: manual/Configuration.md:615
+#: manual/Configuration.md:610
 msgid "In detail:"
 msgstr "より踏み込むと："
 
 #. type: Bullet: '1.  '
-#: manual/Configuration.md:617
+#: manual/Configuration.md:612
 msgid "For Solaris/ZFS: ZFS Volumes"
 msgstr "ZFS を使っている Solarisの ZFS ボリュームごとに対して、"
 
 #. type: Plain text
-#: manual/Configuration.md:620
+#: manual/Configuration.md:615
 #, no-wrap
 msgid ""
 "    You should configure a ZFS ACL know for any volume you want to use\n"
@@ -1618,7 +1615,7 @@ msgstr ""
 "    がわかるように構成すべきである：\n"
 
 #. type: Plain text
-#: manual/Configuration.md:623
+#: manual/Configuration.md:618
 #, no-wrap
 msgid ""
 "        aclinherit = passthrough\n"
@@ -1626,7 +1623,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:626
+#: manual/Configuration.md:621
 #, no-wrap
 msgid ""
 "    For an explanation of what this knob does and how to apply it, check\n"
@@ -1636,12 +1633,12 @@ msgstr ""
 "    ZFS ドキュメンテーション（例えば man zfs）を確認のこと。\n"
 
 #. type: Bullet: '2.  '
-#: manual/Configuration.md:628
+#: manual/Configuration.md:623
 msgid "Authentication Domain"
 msgstr "認証ドメイン"
 
 #. type: Plain text
-#: manual/Configuration.md:635
+#: manual/Configuration.md:630
 #, no-wrap
 msgid ""
 "    Your server and the clients must be part of a security association\n"
@@ -1659,7 +1656,7 @@ msgstr ""
 "    UUID は ASCII テキストとして保管されている。言い換えれば：\n"
 
 #. type: Bullet: '    - '
-#: manual/Configuration.md:638
+#: manual/Configuration.md:633
 msgid ""
 "you need an Open Directory Server or an LDAP server where you store UUIDs in "
 "some attribute"
@@ -1668,20 +1665,20 @@ msgstr ""
 "サーバーが必要である。"
 
 #. type: Bullet: '    - '
-#: manual/Configuration.md:640
+#: manual/Configuration.md:635
 msgid "your clients must be configured to use this server"
 msgstr ""
 "クライアントはこのサーバーを使用するように構成されていなければならない。"
 
 #. type: Bullet: '    - '
-#: manual/Configuration.md:643
+#: manual/Configuration.md:638
 msgid ""
 "your server should be configured to use this server via nsswitch and PAM"
 msgstr ""
 "サーバーは nsswitch と PAM 経由で使用されるよう構成しなければならない。"
 
 #. type: Bullet: '    - '
-#: manual/Configuration.md:648
+#: manual/Configuration.md:643
 msgid ""
 "configure Netatalk via the special [LDAP options for ACLs]"
 "(afp.conf.html#options-for-acl-handling) in *afp.conf* so that Netatalk is "
@@ -1692,13 +1689,13 @@ msgstr ""
 "handling)を使って Netatalk を設定しなければならない。"
 
 #. type: Title ###
-#: manual/Configuration.md:649
+#: manual/Configuration.md:644
 #, no-wrap
 msgid "macOS ACLs"
 msgstr "macOS の ACL"
 
 #. type: Plain text
-#: manual/Configuration.md:655
+#: manual/Configuration.md:650
 msgid ""
 "With Access Control Lists (ACLs), macOS offers a powerful extension of the "
 "traditional UNIX permissions model. An ACL is an ordered list of Access "
@@ -1711,7 +1708,7 @@ msgstr ""
 "リストである。"
 
 #. type: Plain text
-#: manual/Configuration.md:660
+#: manual/Configuration.md:655
 msgid ""
 "Unlike UNIX permissions, which are bound to user or group IDs, ACLs are tied "
 "to UUIDs. For this reason accessing an object's ACL requires server and "
@@ -1724,7 +1721,7 @@ msgstr ""
 "てくれる、共通のディレクトリサービスを使うことを要求される。"
 
 #. type: Plain text
-#: manual/Configuration.md:672
+#: manual/Configuration.md:667
 msgid ""
 "ACLs and UNIX permissions interact in a rather simple way. As ACLs are "
 "optional UNIX permissions act as a default mechanism for access control.  "
@@ -1749,13 +1746,13 @@ msgstr ""
 "つまり、ACL は常に UNIX のパーミションより優先順位が上位ということである。"
 
 #. type: Title ###
-#: manual/Configuration.md:673
+#: manual/Configuration.md:668
 #, no-wrap
 msgid "ZFS ACLs"
 msgstr "ZFS の ACL"
 
 #. type: Plain text
-#: manual/Configuration.md:677
+#: manual/Configuration.md:672
 msgid ""
 "ZFS ACLs closely match macOS ACLs. Both offer mostly identical fine grained "
 "permissions and inheritance settings."
@@ -1764,19 +1761,19 @@ msgstr ""
 "粒度のパーミションと設定の継承が提供されている。"
 
 #. type: Title ###
-#: manual/Configuration.md:678
+#: manual/Configuration.md:673
 #, no-wrap
 msgid "POSIX ACLs"
 msgstr "POSIX の ACL"
 
 #. type: Title ####
-#: manual/Configuration.md:680
+#: manual/Configuration.md:675
 #, no-wrap
 msgid "Overview"
 msgstr "概要"
 
 #. type: Plain text
-#: manual/Configuration.md:686
+#: manual/Configuration.md:681
 msgid ""
 "Compared to macOS or NFSv4 ACLs, POSIX ACLs represent a different, less "
 "versatile approach to overcome the limitations of the traditional UNIX "
@@ -1788,7 +1785,7 @@ msgstr ""
 "Posix 標準を取り込んだものを基礎としている。"
 
 #. type: Plain text
-#: manual/Configuration.md:694
+#: manual/Configuration.md:689
 msgid ""
 "The standard defines two types of ACLs. Files and directories can have "
 "access ACLs which are consulted for access checks. Directories can also have "
@@ -1806,42 +1803,42 @@ msgstr ""
 "を継承する。 継承制御にそれ以上のメカニズムは何もない。"
 
 #. type: Plain text
-#: manual/Configuration.md:697
+#: manual/Configuration.md:692
 msgid ""
 "Architectural differences between POSIX ACLs and macOS ACLs especially "
 "involve:"
 msgstr "設計上、Posix ACL と macOS 間の違いに含まれている特筆すべき点は："
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:700
+#. type: Plain text
+#: manual/Configuration.md:695
 msgid ""
-"No fine-granular permissions model. Like UNIX permissions POSIX ACLs only "
+"- No fine-granular permissions model. Like UNIX permissions POSIX ACLs only "
 "differentiate between read, write and execute permissions."
 msgstr ""
-"パーミションモデルは何も細分化されていない。UNIX のパーミション同様、Posix "
-"ACL は読み込み、書き込み、そして実行権限を区別している。"
+"- パーミションモデルは何も細分化されていない。UNIX のパーミション同様、Posix "
+"ACLは読み込み、書き込み、そして実行権限を区別している。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:702
+#: manual/Configuration.md:697
 msgid "Entries within an ACL are unordered."
 msgstr "ACL 内のエントリーに順序はない。"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:705
+#. type: Plain text
+#: manual/Configuration.md:700
 msgid ""
-"POSIX ACLs can only grant rights. There is no way to explicitly deny rights "
-"by an entry."
+"- POSIX ACLs can only grant rights. There is no way to explicitly deny "
+"rights by an entry."
 msgstr ""
-"Posix ACL は権限を許可することしかできない。 エントリーから権限を明示的に拒否"
+"- Posix ACLは権限を許可することしかできない。エントリーから権限を明示的に拒否"
 "する手立てはない。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:707
+#: manual/Configuration.md:702
 msgid "UNIX permissions are integrated into an ACL as special entries."
 msgstr "UNIX パーミションは特別なエントリーとして ACL に統合されている。"
 
 #. type: Plain text
-#: manual/Configuration.md:712
+#: manual/Configuration.md:707
 msgid ""
 "POSIX 1003.1e defines 6 different types of ACL entries. The first three "
 "types are used to integrate standard UNIX permissions. They form a minimal "
@@ -1854,53 +1851,53 @@ msgstr ""
 "つのエントリーだけが ACL 内に許される。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:714
+#: manual/Configuration.md:709
 msgid "ACL_USER_OBJ: the owner's access rights."
 msgstr "ACL_USER_OBJ：所有ユーザー（オーナー）のアクセス権限。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:716
+#: manual/Configuration.md:711
 msgid "ACL_GROUP_OBJ: the owning group's access rights."
 msgstr "ACL_GROUP_OBJ：所有グループ（オーナーグループ）のアクセス権限。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:718
+#: manual/Configuration.md:713
 msgid "ACL_OTHER: everybody's access rights."
 msgstr "ACL_OTHER：あらゆるユーザー・グループに対するアクセス権限。"
 
 #. type: Plain text
-#: manual/Configuration.md:720
+#: manual/Configuration.md:715
 msgid "The remaining entry types expand the traditional permissions model:"
 msgstr "残りのエントリーのタイプは伝統的パーミションモデルの拡張である："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:722
+#: manual/Configuration.md:717
 msgid "ACL_USER: grants access rights to a certain user."
 msgstr "ACL_USER：あるユーザーに対するアクセス権を許可する。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:724
+#: manual/Configuration.md:719
 msgid "ACL_GROUP: grants access rights to a certain group."
 msgstr "ACL_GROUP：あるグループに対するアクセス権を許可する。"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:730
+#. type: Plain text
+#: manual/Configuration.md:725
 msgid ""
-"ACL_MASK: limits the maximum access rights which can be granted by entries "
+"- ACL_MASK: limits the maximum access rights which can be granted by entries "
 "of type ACL_GROUP_OBJ, ACL_USER and ACL_GROUP. As the name suggests, this "
 "entry acts as a mask. Only one ACL_MASK entry is allowed per ACL. If an ACL "
 "contains ACL_USER or ACL_GROUP entries, an ACL_MASK entry must be present "
 "too, otherwise it is optional."
 msgstr ""
-"ACL_MASK：ACL_GROUP_OBJ、ACL_USER および ACL_GROUP タイプのエントリーで許可さ"
-"れうるアクセス権の最大値を制限する。名前の示すように、このエントリーはマスク"
-"として働く。一つの ACL あたり一個だけの ACL_MASK エントリーが許される。もし "
-"ACL に、ACL_USER ないしは ACL_GROUP エントリーが含まれているのであれば、"
+"- ACL_MASK：ACL_GROUP_OBJ、ACL_USER および ACL_GROUP タイプのエントリーで許可"
+"されうるアクセス権の最大値を制限する。名前の示すように、このエントリーはマス"
+"クとして働く。一つの ACL あたり一個だけの ACL_MASK エントリーが許される。も"
+"し ACL に、ACL_USER ないしは ACL_GROUP エントリーが含まれているのであれば、"
 "ACL_MASK エントリーも存在しなければならない。さもなくば、ACL_MASK はオプショ"
 "ンである。"
 
 #. type: Plain text
-#: manual/Configuration.md:736
+#: manual/Configuration.md:731
 msgid ""
 "In order to maintain compatibility with applications not aware of ACLs, "
 "POSIX 1003.1e changes the semantics of system calls and utilities which "
@@ -1915,7 +1912,7 @@ msgstr ""
 "エントリーの値に対応する。"
 
 #. type: Plain text
-#: manual/Configuration.md:743
+#: manual/Configuration.md:738
 msgid ""
 "However, if the ACL also contains an ACL_MASK entry, the behavior of those "
 "system calls and utilities is different. The group permissions bits of the "
@@ -1932,13 +1929,13 @@ msgstr ""
 "のエンティティ全てを無効にするのである。"
 
 #. type: Title ####
-#: manual/Configuration.md:744
+#: manual/Configuration.md:739
 #, no-wrap
 msgid "Mapping POSIX ACLs to macOS ACLs"
 msgstr "POSIX ACL から macOS の ACL へのマッピング"
 
 #. type: Plain text
-#: manual/Configuration.md:752
+#: manual/Configuration.md:747
 msgid ""
 "When a client wants to read an object's ACL, afpd maps its POSIX ACL onto an "
 "equivalent macOS ACL. Writing an object's ACL requires afpd to map an macOS "
@@ -1952,31 +1949,31 @@ msgstr ""
 "設計上の制約から、マッピングを経た結果がオリジナルの ACL のセマンティクスと概"
 "ね同じになるような正確なマッピングを見出すことは通常不可能である。"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:755
+#. type: Plain text
+#: manual/Configuration.md:750
 msgid ""
-"afpd silently discard entries which deny a set of permissions because they "
+"- afpd silently discard entries which deny a set of permissions because they "
 "they can't be represented within the POSIX architecture."
 msgstr ""
-"afpd はパーミション一式を拒否したエントリーを通告なしに破棄する。これは "
+"- afpd はパーミション一式を拒否したエントリーを通告なしに破棄する。これは "
 "Posix の設計では表現する手立てがないためである。"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:758
+#. type: Plain text
+#: manual/Configuration.md:753
 msgid ""
-"As entries within POSIX ACLs are unordered, it is impossible to preserve "
+"- As entries within POSIX ACLs are unordered, it is impossible to preserve "
 "order."
 msgstr ""
-"Posix ACL ではエントリーが順序付きではないので、順序を保管するのは不可能であ"
-"る。"
+"- Posix ACL ではエントリーが順序付きではないので、順序を保管するのは不可能で"
+"ある。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:760
+#: manual/Configuration.md:755
 msgid "Inheritance control is subject to severe limitations as well:"
 msgstr "継承制御もまた厳しい制限を受けやすい："
 
 #. type: Bullet: '  - '
-#: manual/Configuration.md:763
+#: manual/Configuration.md:758
 msgid ""
 "Entries with the only_inherit flag set will only become part of the "
 "directory's default ACL."
@@ -1985,7 +1982,7 @@ msgstr ""
 "部にしかならない。"
 
 #. type: Bullet: '  - '
-#: manual/Configuration.md:768
+#: manual/Configuration.md:763
 msgid ""
 "Entries with at least one of the flags file_inherit, directory_inherit or "
 "limit_inherit set, will become part of the directory's access and default "
@@ -1995,17 +1992,17 @@ msgstr ""
 "が設定されたエントリーはディレクトリアクセスとデフォルト ACL の一部分となる。"
 "しかし継承に課せられた制約は無視される。"
 
-#. type: Bullet: '- '
-#: manual/Configuration.md:771
+#. type: Plain text
+#: manual/Configuration.md:766
 msgid ""
-"The lack of a fine-granular permission model on the POSIX side will normally "
-"result in an increase of granted permissions."
+"- The lack of a fine-granular permission model on the POSIX side will "
+"normally result in an increase of granted permissions."
 msgstr ""
-"Posix 側により細分化されたパーミションモデルがないことで、 結果としては通常は"
-"許可されるパーミションが増えるという結果になる。"
+"- Posix 側により細分化されたパーミションモデルがないことで、 結果としては通常"
+"は許可されるパーミションが増えるという結果になる。"
 
 #. type: Plain text
-#: manual/Configuration.md:785
+#: manual/Configuration.md:780
 msgid ""
 "As macOS clients aren't aware of the POSIX 1003.1e specific relationship "
 "between UNIX permissions and ACL_MASK, afpd does not expose this feature to "
@@ -2034,13 +2031,13 @@ msgstr ""
 "ACL_MASK の値の再計算を afpd が行う。"
 
 #. type: Title ##
-#: manual/Configuration.md:786
+#: manual/Configuration.md:781
 #, no-wrap
 msgid "Filesystem Change Events"
 msgstr "ファイルシステム変更イベント"
 
 #. type: Plain text
-#: manual/Configuration.md:791
+#: manual/Configuration.md:786
 msgid ""
 "Netatalk includes a nifty filesystem change event (FCE) mechanism where afpd "
 "processes notify interested listeners about certain filesystem event by UDP "
@@ -2052,7 +2049,7 @@ msgstr ""
 "経由で通知する。"
 
 #. type: Plain text
-#: manual/Configuration.md:795
+#: manual/Configuration.md:790
 msgid ""
 "For the format of the UDP packets and for an example C application that "
 "demonstrates how to use these in a listener, take a look at the Netatalk "
@@ -2063,68 +2060,68 @@ msgstr ""
 "ソースファイル `bin/misc/fce.c` に目を通していただきたい。"
 
 #. type: Plain text
-#: manual/Configuration.md:797
+#: manual/Configuration.md:792
 msgid "The currently supported FCE v1 events are:"
 msgstr "現在サポートされているファイルシステム変更イベントは以下である："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:799
+#: manual/Configuration.md:794
 msgid "file modification (fmod)"
 msgstr "ファイル変更：file modification (fmod)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:801
+#: manual/Configuration.md:796
 msgid "file deletion (fdel)"
 msgstr "ファイル削除：file deletion (fdel)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:803
+#: manual/Configuration.md:798
 msgid "directory deletion (ddel)"
 msgstr "ディレクトリ削除：directory deletion (ddel)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:805
+#: manual/Configuration.md:800
 msgid "file creation (fcre)"
 msgstr "ファイル作成：file creation (fcre)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:807
+#: manual/Configuration.md:802
 msgid "directory creation (dcre)"
 msgstr "ディレクトリ削除：directory deletion (ddel)"
 
 #. type: Plain text
-#: manual/Configuration.md:809
+#: manual/Configuration.md:804
 msgid "When using FCE v2 you also get:"
 msgstr "FCE v2 の場合はする際には下記イベントも使用可能："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:811
+#: manual/Configuration.md:806
 msgid "file moving (fmov)"
 msgstr "ファイル移動 (fmov)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:813
+#: manual/Configuration.md:808
 msgid "directory moving (dmov)"
 msgstr "ディレクトリー移動 (dmov)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:815
+#: manual/Configuration.md:810
 msgid "user login (login)"
 msgstr "ユーザーログイン (login)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:817
+#: manual/Configuration.md:812
 msgid "user logout (logout)"
 msgstr "ユーザーログアウト (logout)"
 
 #. type: Title ##
-#: manual/Configuration.md:818
+#: manual/Configuration.md:813
 #, no-wrap
 msgid "Spotlight"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:825
+#: manual/Configuration.md:820
 msgid ""
 "Starting with version 3.1 Netatalk supports Spotlight searching.  Netatalk "
 "uses GNOME [Tracker](https://projects.gnome.org/tracker/) or its later "
@@ -2138,7 +2135,7 @@ msgstr ""
 "を用いる。"
 
 #. type: Plain text
-#: manual/Configuration.md:830
+#: manual/Configuration.md:825
 msgid ""
 "You can enable Spotlight and indexing either globally or on a per volume "
 "basis with the **spotlight** option."
@@ -2147,7 +2144,7 @@ msgstr ""
 "に Spotlight とインデックス化を有効にできる。"
 
 #. type: Plain text
-#: manual/Configuration.md:835
+#: manual/Configuration.md:830
 #, no-wrap
 msgid ""
 "> Once Spotlight is enabled for a single volume, all other volumes for\n"
@@ -2157,7 +2154,7 @@ msgstr ""
 "が無効にされたことになるその他全てのボリュームでは全く検索できないようになる。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:839
+#: manual/Configuration.md:834
 msgid ""
 "The **dbus-daemon** binary has to be installed for Spotlight feature. The "
 "path to dbus-daemon is determined at compile time the dbus-daemon build "
@@ -2168,7 +2165,7 @@ msgstr ""
 "決定する。"
 
 #. type: Plain text
-#: manual/Configuration.md:843
+#: manual/Configuration.md:838
 msgid ""
 "In case the **dbus-daemon** binary is installed at the other path, you must "
 "use the global option **dbus daemon** to point to the path, e.g. for Solaris "
@@ -2179,96 +2176,94 @@ msgstr ""
 "ば Solaris 上で OpenCSW 由来の Tracker を用いている場合は以下のようにする："
 
 #. type: Plain text
-#: manual/Configuration.md:845
+#: manual/Configuration.md:840
 #, no-wrap
 msgid "    dbus daemon = /opt/csw/bin/dbus-daemon\n"
 msgstr ""
 
 #. type: Title ####
-#: manual/Configuration.md:846
+#: manual/Configuration.md:841
 #, no-wrap
 msgid "Limitations and notes"
 msgstr "制限と注意"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:849
+#: manual/Configuration.md:844
 msgid "Large filesystems"
 msgstr "大きいファイルシステム"
 
 #. type: Plain text
-#: manual/Configuration.md:855
+#: manual/Configuration.md:850
 #, no-wrap
 msgid ""
-"  Tracker on Linux uses the inotify Kernel filesystem change event API\n"
-"  for tracking filesystem changes. On large filesystems this may be\n"
-"  problematic since the inotify API doesn't offer recursive directory\n"
-"  watches but instead requires that for every subdirectory watches must\n"
-"  be added individually.\n"
+"    Tracker on Linux uses the inotify Kernel filesystem change event API\n"
+"    for tracking filesystem changes. On large filesystems this may be\n"
+"    problematic since the inotify API doesn't offer recursive directory\n"
+"    watches but instead requires that for every subdirectory watches must\n"
+"    be added individually.\n"
 msgstr ""
-"  Linux 上の Tracker はファイルシステム変更の追跡に inotify\n"
-"  カーネルファイルシステム変更イベント API\n"
-"  を使用する。大きなファイルシステムではこれが問題になりやすい。なぜなら、この\n"
-"  inotofy API は再帰的ディレクトリ監視を提供してはおらず、\n"
-"  代わりにあらゆるサブディレクトリの監視が各々で追加されなければならないということを要求してくるからである。\n"
+"    Linux 上の Tracker はファイルシステム変更の追跡に inotify\n"
+"    カーネルファイルシステム変更イベント API\n"
+"    を使用する。大きなファイルシステムではこれが問題になりやすい。なぜなら、この\n"
+"    inotofy API は再帰的ディレクトリ監視を提供してはおらず、\n"
+"    代わりにあらゆるサブディレクトリの監視が各々で追加されなければならないということを要求してくるからである。\n"
+
+#. type: Plain text
+#: manual/Configuration.md:854
+#, no-wrap
+msgid ""
+"    On Solaris the FEN file event notification system is used. It is\n"
+"    unknown which limitations and resource consumption this Solaris\n"
+"    subsystem may have.\n"
+msgstr ""
+"    Solarisではファイルイベント通知（FEN: File Event Notification)\n"
+"    が用いられる。このSolarisのサブシステムではどんな制限とリソース消費があるのか不明である。\n"
 
 #. type: Plain text
 #: manual/Configuration.md:859
 #, no-wrap
 msgid ""
-"  On Solaris the FEN file event notification system is used. It is\n"
-"  unknown which limitations and resource consumption this Solaris\n"
-"  subsystem may have.\n"
+"    We therefore recommend to disable live filesystem monitoring and let\n"
+"    Tracker periodically scan filesystems for changes instead, see the\n"
+"    [Tracker configuration options](#advanced-tracker-command-line-configuration)\n"
+"    enable-monitors and crawling-interval below.\n"
 msgstr ""
-"  Solaris ではファイルイベント通知（FEN: File Event Notification)\n"
-"  が用いられる。この Solaris\n"
-"  のサブシステムではどんな制限とリソース消費があるのか不明である。\n"
+"    それ故、ライブでのファイルシステム監視は無効にして、その代わりに定期的に\n"
+"    Tracker にファイルシステム変更のスキャンを行わせることを推奨する。下記\n"
+"    [Tracker オプション](#advanced-tracker-command-line-configuration)、enable-monitors および\n"
+"    crawling-interval を参照のこと。\n"
+
+#. type: Bullet: '- '
+#: manual/Configuration.md:861
+msgid "Indexing home directories"
+msgstr "home ディレクトリのインデックスは作成されない"
 
 #. type: Plain text
 #: manual/Configuration.md:864
 #, no-wrap
 msgid ""
-"  We therefore recommend to disable live filesystem monitoring and let\n"
-"  Tracker periodically scan filesystems for changes instead, see the\n"
-"  [Tracker configuration options](#advanced-tracker-command-line-configuration)\n"
-"  enable-monitors and crawling-interval below.\n"
+"    A known limitation with the current implementation means that shared\n"
+"    volumes in a user's home directory does not get indexed by Spotlight.\n"
 msgstr ""
-"  それ故、ライブでのファイルシステム監視は無効にして、その代わりに定期的に\n"
-"  Tracker にファイルシステム変更のスキャンを行わせることを推奨する。下記\n"
-"  [Tracker オプション](#advanced-tracker-command-line-configuration)、enable-monitors および\n"
-"  crawling-interval を参照のこと。\n"
-
-#. type: Bullet: '- '
-#: manual/Configuration.md:866
-msgid "Indexing home directories"
-msgstr "home ディレクトリのインデックスは作成されない"
+"    現在の実装の既知の制限により、ユーザーのhomeディレクトリ内の共有ボリュームは Spotlight\n"
+"    によってインデックス付けされない。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:869
+#: manual/Configuration.md:867
 #, no-wrap
 msgid ""
-"  A known limitation with the current implementation means that shared\n"
-"  volumes in a user's home directory does not get indexed by Spotlight.\n"
-msgstr ""
-"  現在の実装の既知の制限により、ユーザーのhome\n"
-"  ディレクトリ内の共有ボリュームは Spotlight\n"
-"  によってインデックス付けされない。\n"
-
-#. type: Plain text
-#: manual/Configuration.md:872
-#, no-wrap
-msgid ""
-"  As a workaround, keep the shared volumes you want to have indexed\n"
-"  elsewhere on the host filesystem.\n"
-msgstr "  回避策として、ファイルシステム別場所に共有ボリュームを設定する。\n"
+"    As a workaround, keep the shared volumes you want to have indexed\n"
+"    elsewhere on the host filesystem.\n"
+msgstr "    回避策として、ファイルシステム別場所に共有ボリュームを設定する。\n"
 
 #. type: Title ###
-#: manual/Configuration.md:873
+#: manual/Configuration.md:868
 #, no-wrap
 msgid "Using Tracker commandline tools on the server"
 msgstr "サーバー上での Tracker コマンドラインツールの使用"
 
 #. type: Plain text
-#: manual/Configuration.md:877
+#: manual/Configuration.md:872
 msgid ""
 "Netatalk must be running, commands must be executed as root and some "
 "environment variables must be set up."
@@ -2277,7 +2272,7 @@ msgstr ""
 "らない。"
 
 #. type: Plain text
-#: manual/Configuration.md:883
+#: manual/Configuration.md:878
 msgid ""
 "If the .tracker_profile file does not exist, create it first. If you need to "
 "make the environment variables persistent, source .tracker_profile from /"
@@ -2290,7 +2285,7 @@ msgstr ""
 "Netatalk をインストールしたベースディレクトリにあわせて読み替える。"
 
 #. type: Plain text
-#: manual/Configuration.md:892
+#: manual/Configuration.md:887
 #, no-wrap
 msgid ""
 "    $ su\n"
@@ -2304,96 +2299,96 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:894
+#: manual/Configuration.md:889
 msgid "When using Tracker from OpenCSW you must also update your PATH:"
 msgstr "OpenCSW の Tracker を使用していたら PATH も以下のように更新する："
 
 #. type: Plain text
-#: manual/Configuration.md:896
+#: manual/Configuration.md:891
 #, no-wrap
 msgid "    # export PATH=/opt/csw/bin:$PATH\n"
 msgstr ""
 
 #. type: Title ####
-#: manual/Configuration.md:897
+#: manual/Configuration.md:892
 #, no-wrap
 msgid "Common Tracker commands"
 msgstr "Tracker コマンド"
 
 #. type: Plain text
-#: manual/Configuration.md:900
+#: manual/Configuration.md:895
 msgid "Querying Tracker status:"
 msgstr "Tracker の状態の問い合わせ:"
 
 #. type: Plain text
-#: manual/Configuration.md:902
+#: manual/Configuration.md:897
 #, no-wrap
 msgid ">     # tracker daemon\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:904
+#: manual/Configuration.md:899
 msgid "Stop Tracker:"
 msgstr "Tracker の停止:"
 
 #. type: Plain text
-#: manual/Configuration.md:906
+#: manual/Configuration.md:901
 #, no-wrap
 msgid ">     # tracker daemon -t\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:908
+#: manual/Configuration.md:903
 msgid "Start Tracker:"
 msgstr "Tracker の開始:"
 
 #. type: Plain text
-#: manual/Configuration.md:910
+#: manual/Configuration.md:905
 #, no-wrap
 msgid ">     # tracker daemon -s\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:912
+#: manual/Configuration.md:907
 msgid "Reindex directory:"
 msgstr "ディレクトリの再インデックス:"
 
 #. type: Plain text
-#: manual/Configuration.md:914
+#: manual/Configuration.md:909
 #, no-wrap
 msgid ">     # tracker index -f PATH\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:916
+#: manual/Configuration.md:911
 msgid "Query Tracker for information about a file or directory:"
 msgstr "Tracker にファイルやディレクトリの情報を問い合わせる:"
 
 #. type: Plain text
-#: manual/Configuration.md:918
+#: manual/Configuration.md:913
 #, no-wrap
 msgid ">     # tracker info PATH\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:920
+#: manual/Configuration.md:915
 msgid "Search Tracker:"
 msgstr "Tracker で検索:"
 
 #. type: Plain text
-#: manual/Configuration.md:922
+#: manual/Configuration.md:917
 #, no-wrap
 msgid ">     # tracker search QUERY\n"
 msgstr ""
 
 #. type: Title ####
-#: manual/Configuration.md:923
+#: manual/Configuration.md:918
 #, no-wrap
 msgid "Advanced Tracker command line configuration"
 msgstr "Tracker コマンドラインのより進んだ設定"
 
 #. type: Plain text
-#: manual/Configuration.md:927
+#: manual/Configuration.md:922
 msgid ""
 "Tracker stores its configuration via Gnome dconf backend which can be "
 "modified with the command **gsettings**."
@@ -2402,7 +2397,7 @@ msgstr ""
 "**gsettings** コマンドで変更できる。"
 
 #. type: Plain text
-#: manual/Configuration.md:933
+#: manual/Configuration.md:928
 msgid ""
 "Gnome dconf settings are per-user settings, so, as Netatalk runs the Tracker "
 "processes as root, the settings are stored in the root user context and "
@@ -2416,7 +2411,7 @@ msgstr ""
 "ければならない）"
 
 #. type: Plain text
-#: manual/Configuration.md:937
+#: manual/Configuration.md:932
 #, no-wrap
 msgid ""
 "    # gsettings list-recursively | grep Tracker\n"
@@ -2425,7 +2420,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:940
+#: manual/Configuration.md:935
 msgid ""
 "The following list describes some important Tracker options and their "
 "default settings."
@@ -2434,12 +2429,12 @@ msgstr ""
 "示す。"
 
 #. type: Plain text
-#: manual/Configuration.md:942
+#: manual/Configuration.md:937
 msgid "org.freedesktop.Tracker.Miner.Files index-recursive-directories"
 msgstr "org.freedesktop.Tracker.Miner.Files index-recursive-directories"
 
 #. type: Plain text
-#: manual/Configuration.md:946
+#: manual/Configuration.md:941
 #, no-wrap
 msgid ""
 "> This option controls which directories Tracker will index. Don't change\n"
@@ -2453,12 +2448,12 @@ msgstr ""
 "によってセットされるので、手動で変更してはならない。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:948
+#: manual/Configuration.md:943
 msgid "org.freedesktop.Tracker.Miner.Files enable-monitors true"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:955
+#: manual/Configuration.md:950
 #, no-wrap
 msgid ""
 "> The value controls whether Tracker watches all configured paths for\n"
@@ -2476,12 +2471,12 @@ msgstr ""
 "**crawling-interval** も参照のこと。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:957
+#: manual/Configuration.md:952
 msgid "org.freedesktop.Tracker.Miner.Files crawling-interval -1"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:962
+#: manual/Configuration.md:957
 #, no-wrap
 msgid ""
 "> Interval in days to check the filesystem is up to date in the database,\n"
@@ -2495,18 +2490,18 @@ msgstr ""
 "= 強制的にクローリングされる\n"
 
 #. type: Title ###
-#: manual/Configuration.md:963
+#: manual/Configuration.md:958
 #, no-wrap
 msgid "Supported metadata attributes"
 msgstr "サポートされているメタデータ属性"
 
 #. type: Plain text
-#: manual/Configuration.md:966
+#: manual/Configuration.md:961
 msgid "The following table lists the supported Spotlight metadata attributes"
 msgstr "下記表にサポートされている Spotlight メタデータ属性を挙げる。"
 
 #. type: Plain text
-#: manual/Configuration.md:991
+#: manual/Configuration.md:986
 #, no-wrap
 msgid ""
 "| Description | Spotlight Key |\n"
@@ -2560,18 +2555,18 @@ msgstr ""
 "| 歌あるいは楽曲の音楽ジャンル | kMDItemMusicalGenre |\n"
 
 #. type: Title ####
-#: manual/Configuration.md:992
+#: manual/Configuration.md:987
 #, no-wrap
 msgid "References"
 msgstr "参考"
 
 #. type: Bullet: '1.  '
-#: manual/Configuration.md:995
+#: manual/Configuration.md:990
 msgid ""
 "[MDItem](https://developer.apple.com/documentation/coreservices/mditemref/)"
 msgstr ""
 
 #. type: Bullet: '2.  '
-#: manual/Configuration.md:996
+#: manual/Configuration.md:991
 msgid "[Tracker](https://gnome.pages.gitlab.gnome.org/tracker/docs/developer/)"
 msgstr ""

--- a/doc/po/Installation.md.ja.po
+++ b/doc/po/Installation.md.ja.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-02-21 07:01+0100\n"
+"POT-Creation-Date: 2025-03-13 21:12+0100\n"
 "PO-Revision-Date: 2025-01-25 15:05+0100\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -18,9 +18,9 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1011 manpages/man5/afp.conf.5.md:1070
-#: manpages/man5/afp.conf.5.md:1105 manual/AppleTalk.md:154
-#: manual/Configuration.md:832 manual/Installation.md:4 manual/Upgrading.md:42
+#: manpages/man5/afp.conf.5.md:1061 manpages/man5/afp.conf.5.md:1097
+#: manual/AppleTalk.md:154 manual/Configuration.md:827 manual/Installation.md:4
+#: manual/Upgrading.md:42
 #, no-wrap
 msgid "> **WARNING**\n"
 msgstr "> **警告**\n"
@@ -221,20 +221,20 @@ msgstr ""
 #: manual/Installation.md:79
 #, no-wrap
 msgid ""
-"  The default dbd CNID backend for netatalk uses Berkeley DB to store\n"
-"  unique file identifiers. At the time of writing you need at least\n"
-"  version 4.6.\n"
-msgstr "  書き込みの時に最低でもバージョン 4.6 が必要となる。\n"
+"    The default dbd CNID backend for netatalk uses Berkeley DB to store\n"
+"    unique file identifiers. At the time of writing you need at least\n"
+"    version 4.6.\n"
+msgstr "    デフォルトのdbd CNIDバックエンドは、Berkeley DBを使用して一意のファイル識別子を保存します。書き込みの時に最低でもバージョン 4.6 が必要となる。\n"
 
 #. type: Plain text
 #: manual/Installation.md:82
 #, no-wrap
 msgid ""
-"  The recommended version is 5.3, the final release under the permissive\n"
-"  Sleepycat license, and therefore the most widely distributed version.\n"
+"    The recommended version is 5.3, the final release under the permissive\n"
+"    Sleepycat license, and therefore the most widely distributed version.\n"
 msgstr ""
-"  推奨バージョンは 5.3 である Sleepycat\n"
-"  ライセンスで提供された最終リリースである。\n"
+"    推奨バージョンは 5.3 である Sleepycat\n"
+"    ライセンスで提供された最終リリースである。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:84
@@ -245,11 +245,11 @@ msgstr ""
 #: manual/Installation.md:87
 #, no-wrap
 msgid ""
-"  The iniparser library is used to parse the configuration files.\n"
-"  At least version 3.1 is required, while 4.0 or later is recommended.\n"
+"    The iniparser library is used to parse the configuration files.\n"
+"    At least version 3.1 is required, while 4.0 or later is recommended.\n"
 msgstr ""
-"  iniparser ライブラリは設定ファイルを解析するために使用される。\n"
-"  最低でもバージョン 3.1 が必要であり、4.0 以降が推奨される。\n"
+"    iniparser ライブラリは設定ファイルを解析するために使用される。\n"
+"    最低でもバージョン 3.1 が必要であり、4.0 以降が推奨される。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:89
@@ -260,11 +260,11 @@ msgstr ""
 #: manual/Installation.md:92
 #, no-wrap
 msgid ""
-"  Internal event callbacks in the netatalk service controller daemon are\n"
-"  built on libevent version 2.\n"
+"    Internal event callbacks in the netatalk service controller daemon are\n"
+"    built on libevent version 2.\n"
 msgstr ""
-"  netatalk サービス コントローラー デーモンの内部イベント\n"
-"  コールバックは、 libevent バージョン 2 に基づいて構築されている。\n"
+"    netatalk サービス コントローラー デーモンの内部イベント\n"
+"    コールバックは、 libevent バージョン 2 に基づいて構築されている。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:94
@@ -275,14 +275,14 @@ msgstr ""
 #: manual/Installation.md:98
 #, no-wrap
 msgid ""
-"  The [Libgcrypt](https://gnupg.org/software/libgcrypt/) library\n"
-"  supplies the encryption for the standard User Authentication Modules\n"
-"  (UAMs). They are: DHX2, DHCAST128 (a.k.a. DHX) and RandNum.\n"
+"    The [Libgcrypt](https://gnupg.org/software/libgcrypt/) library\n"
+"    supplies the encryption for the standard User Authentication Modules\n"
+"    (UAMs). They are: DHX2, DHCAST128 (a.k.a. DHX) and RandNum.\n"
 msgstr ""
-"  [Libgcrypt](https://gnupg.org/software/libgcrypt/)\n"
-"  ライブラリは、標準のユーザー認証モジュール (UAM)\n"
-"  の暗号化を提供する。これらは、DHX2、DHCAST128 (別名 DHX)、および\n"
-"  RandNum である。\n"
+"    [Libgcrypt](https://gnupg.org/software/libgcrypt/)\n"
+"    ライブラリは、標準のユーザー認証モジュール (UAM)\n"
+"    の暗号化を提供する。これらは、DHX2、DHCAST128 (別名 DHX)、および\n"
+"    RandNum である。\n"
 
 #. type: Title ####
 #: manual/Installation.md:99
@@ -308,18 +308,17 @@ msgstr "ACL と LDAP"
 #: manual/Installation.md:111
 #, no-wrap
 msgid ""
-"  LDAP is an open and industry-standard user directory protocol that\n"
-"  works in tandem with the advanced permissions scheme of ACL. On some\n"
-"  operating systems ACL and LDAP libraries are built in to the system,\n"
-"  while on others you have to install supporting packages to enable this\n"
-"  functionality.\n"
+"    LDAP is an open and industry-standard user directory protocol that\n"
+"    works in tandem with the advanced permissions scheme of ACL. On some\n"
+"    operating systems ACL and LDAP libraries are built in to the system,\n"
+"    while on others you have to install supporting packages to enable this\n"
+"    functionality.\n"
 msgstr ""
-"  LDAP は、ACL\n"
-"  の高度な権限スキームと連携して動作するオープンで業界標準のユーザー\n"
-"  ディレクトリ プロトコルである。一部のオペレーティング システムでは ACL\n"
-"  と LDAP ライブラリがシステムに組み込まれているが、他のオペレーティング\n"
-"  システムではこの機能を有効にするためにサポート\n"
-"  パッケージをインストールする必要がある。\n"
+"    LDAPは、ACLの高度な権限スキームと連携して動作するオープンで業界標準のユーザー\n"
+"    ディレクトリ プロトコルである。一部のオペレーティング システムではACL\n"
+"    とLDAPライブラリがシステムに組み込まれているが、他のオペレーティング\n"
+"    システムではこの機能を有効にするためにサポート\n"
+"    パッケージをインストールする必要がある。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:113
@@ -330,23 +329,23 @@ msgstr "Bonjour 用の Avahi または mDNSresponder"
 #: manual/Installation.md:117
 #, no-wrap
 msgid ""
-"  Mac OS X 10.2 and later uses Bonjour (a.k.a. Zeroconf) for automatic\n"
-"  service discovery. Netatalk can advertise AFP file sharing and Time\n"
-"  Machine volumes by using Avahi or mDNSResponder.\n"
+"    Mac OS X 10.2 and later uses Bonjour (a.k.a. Zeroconf) for automatic\n"
+"    service discovery. Netatalk can advertise AFP file sharing and Time\n"
+"    Machine volumes by using Avahi or mDNSResponder.\n"
 msgstr ""
-"  Mac OS X 10.2 以降では、自動サービス検出に Bonjour (別名 Zeroconf)\n"
-"  を使用する。 Netatalk は、Avahi または mDNSResponder を使用して AFP\n"
-"  ファイル共有と Time Machine ボリュームをアドバタイズできる。\n"
+"    Mac OS X 10.2 以降では、自動サービス検出に Bonjour (別名 Zeroconf)\n"
+"    を使用する。 Netatalk は、Avahi または mDNSResponder を使用して AFP\n"
+"    ファイル共有と Time Machine ボリュームをアドバタイズできる。\n"
 
 #. type: Plain text
 #: manual/Installation.md:120
 #, no-wrap
 msgid ""
-"  When using Avahi, D-Bus is also required, and the Avahi library must\n"
-"  have been built with D-Bus support.\n"
+"    When using Avahi, D-Bus is also required, and the Avahi library must\n"
+"    have been built with D-Bus support.\n"
 msgstr ""
-"  Avahi を使用する場合は、D-Bus または D-Bus サポートを有効になっている\n"
-"  Avahi ライブラリは必要になる。\n"
+"    Avahi を使用する場合は、D-Bus または D-Bus サポートを有効になっている\n"
+"    Avahi ライブラリは必要になる。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:122
@@ -357,25 +356,25 @@ msgstr "cmark もしくは cmark-gfm"
 #: manual/Installation.md:127
 #, no-wrap
 msgid ""
-"  Netatalk's documentation is authored in Markdown format.\n"
-"  The man page sources consist of standards-compliant CommonMark,\n"
-"  while the rest of the documentation is authored in GitHub-Flavored\n"
-"  Markdown.\n"
+"    Netatalk's documentation is authored in Markdown format.\n"
+"    The man page sources consist of standards-compliant CommonMark,\n"
+"    while the rest of the documentation is authored in GitHub-Flavored\n"
+"    Markdown.\n"
 msgstr ""
-"  Netatalk のドキュメントは Markdown 形式で作成されている。\n"
-"  マニュアル ページのソースは標準に準拠した CommonMark で構成され、\n"
-"  ドキュメントの残りの部分は GitHub 風の Markdown (gfm) で作成されている。\n"
+"    Netatalk のドキュメントは Markdown 形式で作成されている。\n"
+"    マニュアル ページのソースは標準に準拠した CommonMark で構成され、\n"
+"    ドキュメントの残りの部分は GitHub 風の Markdown (gfm) で作成されている。\n"
 
 #. type: Plain text
 #: manual/Installation.md:131
 #, no-wrap
 msgid ""
-"  You can use cmark to generate roff man pages from the Markdown sources,\n"
-"  and cmark-gfm to generate all documentation, including HTML pages.\n"
-"  If you have access to the latter, you don't need the former.\n"
+"    You can use cmark to generate roff man pages from the Markdown sources,\n"
+"    and cmark-gfm to generate all documentation, including HTML pages.\n"
+"    If you have access to the latter, you don't need the former.\n"
 msgstr ""
-"cmark を使用して Markdown ソースから roff マニュアル ページを生成し、cmark-gfm を使用して HTML ページを含むすべてのドキュメントを生成できる。\n"
-"後者は利用可能な場合は、前者は必要ない。\n"
+"    cmark を使用して Markdown ソースから roff マニュアル ページを生成し、cmark-gfm を使用して HTML ページを含むすべてのドキュメントを生成できる。\n"
+"    後者は利用可能な場合は、前者は必要ない。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:133
@@ -386,23 +385,23 @@ msgstr ""
 #: manual/Installation.md:137
 #, no-wrap
 msgid ""
-"  When using the Random Number UAMs and netatalk's own **afppasswd**\n"
-"  password manager, CrackLib can help protect against setting weak\n"
-"  passwords for authentication with netatalk.\n"
+"    When using the Random Number UAMs and netatalk's own **afppasswd**\n"
+"    password manager, CrackLib can help protect against setting weak\n"
+"    passwords for authentication with netatalk.\n"
 msgstr ""
-"  Random Number UAM と netatalk 独自の **afppasswd** パスワード\n"
-"  マネージャを使用する場合、CrackLib は netatalk\n"
-"  での認証に弱いパスワードを設定するのを防ぐのに役立つ。\n"
+"    Random Number UAM と netatalk 独自の **afppasswd** パスワード\n"
+"    マネージャを使用する場合、CrackLib は netatalk\n"
+"    での認証に弱いパスワードを設定するのを防ぐのに役立つ。\n"
 
 #. type: Plain text
 #: manual/Installation.md:140
 #, no-wrap
 msgid ""
-"  The CrackLib dictionary, which is sometimes distributed separately in\n"
-"  a runtime package, is also a requirement.\n"
+"    The CrackLib dictionary, which is sometimes distributed separately in\n"
+"    a runtime package, is also a requirement.\n"
 msgstr ""
-"  ランタイム パッケージで別途配布されることもある CrackLib\n"
-"  辞書も必須である。\n"
+"    ランタイム パッケージで別途配布されることもある CrackLib\n"
+"    辞書も必須である。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:142
@@ -413,13 +412,13 @@ msgstr ""
 #: manual/Installation.md:146
 #, no-wrap
 msgid ""
-"  D-Bus provides a mechanism for sending messages between processes,\n"
-"  used by multiple Netatalk features: Spotlight, Zeroconf with Avahi,\n"
-"  and the **afpstats** tool.\n"
+"    D-Bus provides a mechanism for sending messages between processes,\n"
+"    used by multiple Netatalk features: Spotlight, Zeroconf with Avahi,\n"
+"    and the **afpstats** tool.\n"
 msgstr ""
-"  D-Bus はプロセス間にメッセージを通信するメカニズムを提供し、下記\n"
-"  Netatalk 機能に使われる： Spotlight、Avahi を使用した Zeroconf、および\n"
-"  **afpstats** ツール。\n"
+"    D-Bus はプロセス間にメッセージを通信するメカニズムを提供し、下記\n"
+"    Netatalk 機能に使われる： Spotlight、Avahi を使用した Zeroconf、および\n"
+"    **afpstats** ツール。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:148
@@ -429,8 +428,8 @@ msgstr "GLib および GIO"
 #. type: Plain text
 #: manual/Installation.md:150
 #, no-wrap
-msgid "  Used by the **afpstats** tool to interface with D-Bus.\n"
-msgstr "  D-Bus とのインターフェースとして、**afpstats** ツールに使われる。\n"
+msgid "    Used by the **afpstats** tool to interface with D-Bus.\n"
+msgstr "    D-Bus とのインターフェースとして、**afpstats** ツールに使われる。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:152
@@ -441,17 +440,17 @@ msgstr ""
 #: manual/Installation.md:158
 #, no-wrap
 msgid ""
-"  iconv provides conversion routines for many character encodings.\n"
-"  Netatalk uses it to provide charsets it does not have built in\n"
-"  conversions for, like ISO-8859-1. On glibc systems, Netatalk can use\n"
-"  the glibc provided iconv implementation. Otherwise you can use the GNU\n"
-"  libiconv implementation.\n"
+"    iconv provides conversion routines for many character encodings.\n"
+"    Netatalk uses it to provide charsets it does not have built in\n"
+"    conversions for, like ISO-8859-1. On glibc systems, Netatalk can use\n"
+"    the glibc provided iconv implementation. Otherwise you can use the GNU\n"
+"    libiconv implementation.\n"
 msgstr ""
-"  iconv は、多くの文字エンコードの変換ルーチンを提供する。Netatalk\n"
-"  は、ISO-8859-1\n"
-"  など、組み込みの変換がない文字セットを提供するためにこれを使用する。glibc\n"
-"  システムでは、Netatalk は glibc が提供する iconv\n"
-"  実装を使用できる。それ以外の場合は、GNU libiconv 実装を使用できる。\n"
+"    iconv は、多くの文字エンコードの変換ルーチンを提供する。Netatalk\n"
+"    は、ISO-8859-1\n"
+"    など、組み込みの変換がない文字セットを提供するためにこれを使用する。glibc\n"
+"    システムでは、Netatalk は glibc が提供する iconv\n"
+"    実装を使用できる。それ以外の場合は、GNU libiconv 実装を使用できる。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:160
@@ -462,15 +461,15 @@ msgstr ""
 #: manual/Installation.md:165
 #, no-wrap
 msgid ""
-"  Kerberos v5 is a client-server based authentication protocol invented\n"
-"  at the Massachusetts Institute of Technology. With the Kerberos\n"
-"  library, netatalk can produce the GSS UAM library for authentication\n"
-"  with existing Kerberos infrastructure.\n"
+"    Kerberos v5 is a client-server based authentication protocol invented\n"
+"    at the Massachusetts Institute of Technology. With the Kerberos\n"
+"    library, netatalk can produce the GSS UAM library for authentication\n"
+"    with existing Kerberos infrastructure.\n"
 msgstr ""
-"  Kerberos v5 は、マサチューセッツ工科大学で発明されたクライアント\n"
-"  サーバー ベースの認証プロトコルである。Kerberos\n"
-"  ライブラリを使用すると、netatalk は既存の Kerberos\n"
-"  インフラストラクチャでの認証用に GSS UAM ライブラリを作成できる。\n"
+"    Kerberos v5 は、マサチューセッツ工科大学で発明されたクライアント\n"
+"    サーバー ベースの認証プロトコルである。Kerberos\n"
+"    ライブラリを使用すると、netatalk は既存の Kerberos\n"
+"    インフラストラクチャでの認証用に GSS UAM ライブラリを作成できる。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:167
@@ -481,15 +480,15 @@ msgstr "MySQL または MariaDB"
 #: manual/Installation.md:172
 #, no-wrap
 msgid ""
-"  By leveraging a MySQL-compatible client library, netatalk can be built\n"
-"  with a MySQL CNID backend that is highly scalable and reliable. The\n"
-"  administrator has to provide a separate database instance for use with\n"
-"  this backend.\n"
+"    By leveraging a MySQL-compatible client library, netatalk can be built\n"
+"    with a MySQL CNID backend that is highly scalable and reliable. The\n"
+"    administrator has to provide a separate database instance for use with\n"
+"    this backend.\n"
 msgstr ""
-"  MySQL 互換のクライアント ライブラリを活用することで、netatalk\n"
-"  は、スケーラビリティと信頼性に優れた MySQL CNID\n"
-"  バックエンドを使用して構築できる。管理者は、このバックエンドで使用するために別のデータベース\n"
-"  インスタンスを用意する必要がある。\n"
+"    MySQL 互換のクライアント ライブラリを活用することで、netatalk\n"
+"    は、スケーラビリティと信頼性に優れた MySQL CNID\n"
+"    バックエンドを使用して構築できる。管理者は、このバックエンドで使用するために別のデータベース\n"
+"    インスタンスを用意する必要がある。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:174
@@ -500,16 +499,16 @@ msgstr ""
 #: manual/Installation.md:179
 #, no-wrap
 msgid ""
-"  PAM provides a flexible mechanism for authenticating users. PAM was\n"
-"  invented by SUN Microsystems. Linux-PAM\n"
-"  is a suite of shared libraries that enable the local system\n"
-"  administrator to choose how applications authenticate users.\n"
+"    PAM provides a flexible mechanism for authenticating users. PAM was\n"
+"    invented by SUN Microsystems. Linux-PAM\n"
+"    is a suite of shared libraries that enable the local system\n"
+"    administrator to choose how applications authenticate users.\n"
 msgstr ""
-"  PAM は、ユーザーを認証するための柔軟なメカニズムを提供する。 PAM は\n"
-"  SUN Microsystems\n"
-"  によって発明された。Linux-PAM は、ローカル\n"
-"  システム管理者がアプリケーションによるユーザー認証方法を選択できるようにする共有ライブラリ\n"
-"  スイートである。\n"
+"    PAM は、ユーザーを認証するための柔軟なメカニズムを提供する。 PAM は\n"
+"    SUN Microsystems\n"
+"    によって発明された。Linux-PAM は、ローカル\n"
+"    システム管理者がアプリケーションによるユーザー認証方法を選択できるようにする共有ライブラリ\n"
+"    スイートである。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:181
@@ -520,13 +519,13 @@ msgstr ""
 #: manual/Installation.md:185
 #, no-wrap
 msgid ""
-"  Netatalk's administrative utility scripts rely on the Perl runtime,\n"
-"  version 5.8 or later. The required Perl modules include\n"
-"  *IO::Socket::IP* (asip-status) and *Net::DBus* (afpstats).\n"
+"    Netatalk's administrative utility scripts rely on the Perl runtime,\n"
+"    version 5.8 or later. The required Perl modules include\n"
+"    *IO::Socket::IP* (asip-status) and *Net::DBus* (afpstats).\n"
 msgstr ""
-"  Netatalk の管理ユーティリティ スクリプトは、Perl ランタイム バージョン\n"
-"  5.8 以降に依存する。必須 Perl モジュールは以下： *IO::Socket::IP*\n"
-"  (asip-status) 又は *Net::DBus* (afpstats)。\n"
+"    Netatalk の管理ユーティリティ スクリプトは、Perl ランタイム バージョン\n"
+"    5.8 以降に依存する。必須 Perl モジュールは以下： *IO::Socket::IP*\n"
+"    (asip-status) 又は *Net::DBus* (afpstats)。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:187
@@ -537,14 +536,14 @@ msgstr ""
 #: manual/Installation.md:192
 #, no-wrap
 msgid ""
-"  With the help of po4a, Netatalk's documentation can be translated\n"
-"  into other languages. It uses gettext to extract translatable\n"
-"  strings from source files and merge them with the translations\n"
-"  stored in PO files.\n"
+"    With the help of po4a, Netatalk's documentation can be translated\n"
+"    into other languages. It uses gettext to extract translatable\n"
+"    strings from source files and merge them with the translations\n"
+"    stored in PO files.\n"
 msgstr ""
-"  po4a の助けを借りて、Netatalk のドキュメントは他の言語に翻訳できる。gettext\n"
-"  を使用して、ソース ファイルから翻訳可能な文字列を抽出し、PO\n"
-"  ファイルに保存されている翻訳と結合する。\n"
+"    po4a の助けを借りて、Netatalk のドキュメントは他の言語に翻訳できる。gettext\n"
+"    を使用して、ソース ファイルから翻訳可能な文字列を抽出し、PO\n"
+"    ファイルに保存されている翻訳と結合する。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:194
@@ -554,22 +553,19 @@ msgstr "TCP ラッパー"
 #. type: Plain text
 #: manual/Installation.md:196
 #, no-wrap
-msgid "  Wietse Venema's network logger, also known as TCPD or LOG_TCP.\n"
-msgstr ""
-"  Wietse Venema のネットワーク ロガー。TCPD または LOG_TCP\n"
-"  とも呼ばれる。\n"
+msgid "    Wietse Venema's network logger, also known as TCPD or LOG_TCP.\n"
+msgstr "    Wietse Venema のネットワーク ロガー。TCPD または LOG_TCP とも呼ばれる。\n"
 
 #. type: Plain text
 #: manual/Installation.md:200
 #, no-wrap
 msgid ""
-"  Security options are: access control per host, domain and/or service;\n"
-"  detection of host name spoofing or host address spoofing; booby traps\n"
-"  to implement an early-warning system.\n"
+"    Security options are: access control per host, domain and/or service;\n"
+"    detection of host name spoofing or host address spoofing; booby traps\n"
+"    to implement an early-warning system.\n"
 msgstr ""
-"  セキュリティ\n"
-"  オプションは次のとおり。ホスト、ドメイン、および/またはサービスごとのアクセス制御、ホスト名のスプーフィングまたはホスト\n"
-"  アドレスのスプーフィングの検出。ブービートラップを使用して早期警告システムを実装する。\n"
+"    セキュリティオプションは次のとおり。ホスト、ドメイン、および/またはサービスごとのアクセス制御、ホスト名のスプーフィングまたはホスト\n"
+"    アドレスのスプーフィングの検出。ブービートラップを使用して早期警告システムを実装する。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:202
@@ -580,21 +576,20 @@ msgstr "Tracker もしくは TinySPARQL / LocalSearch"
 #: manual/Installation.md:210
 #, no-wrap
 msgid ""
-"  Netatalk uses [Tracker](https://tracker.gnome.org) or its later\n"
-"  incarnation\n"
-"  TinySPARQL/[LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/)\n"
-"  as the metadata backend for Spotlight\n"
-"  search indexing. The minimum required version is 0.7 as this was the\n"
-"  first version to support\n"
-"  [SPARQL](https://gnome.pages.gitlab.gnome.org/tracker/).\n"
+"    Netatalk uses [Tracker](https://tracker.gnome.org) or its later\n"
+"    incarnation\n"
+"    TinySPARQL/[LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/)\n"
+"    as the metadata backend for Spotlight\n"
+"    search indexing. The minimum required version is 0.7 as this was the\n"
+"    first version to support\n"
+"    [SPARQL](https://gnome.pages.gitlab.gnome.org/tracker/).\n"
 msgstr ""
-"  Netatalk は、Spotlight\n"
-"  検索インデックスのメタデータ バックエンドとして\n"
-"  [Tracker](https://tracker.gnome.org) またはそれ以降のバージョンである\n"
-"  TinySPARQL/[LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/)\n"
-"  を使用する。必要な最小限のバージョンは 0.7 である。これは\n"
-"  [SPARQL](https://gnome.pages.gitlab.gnome.org/tracker/)\n"
-"  をサポートする最初のバージョンだからである。\n"
+"    Netatalkは、Spotlight検索インデックスのメタデータ バックエンドとして\n"
+"    [Tracker](https://tracker.gnome.org) またはそれ以降のバージョンである\n"
+"    TinySPARQL/[LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/)\n"
+"    を使用する。必要な最小限のバージョンは 0.7 である。これは\n"
+"    [SPARQL](https://gnome.pages.gitlab.gnome.org/tracker/)\n"
+"    をサポートする最初のバージョンだからである。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:212
@@ -605,11 +600,11 @@ msgstr ""
 #: manual/Installation.md:215
 #, no-wrap
 msgid ""
-"  Samba's talloc library, a Yacc parser such as bison, and a lexer like\n"
-"  flex are also required for Spotlight.\n"
+"    Samba's talloc library, a Yacc parser such as bison, and a lexer like\n"
+"    flex are also required for Spotlight.\n"
 msgstr ""
-"  Spotlight には、Samba の talloc ライブラリ、bison などの Yacc\n"
-"  パーサー、flex などのレキサーも必要。\n"
+"    Spotlight には、Samba の talloc ライブラリ、bison などの Yacc\n"
+"    パーサー、flex などのレキサーも必要。\n"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:217
@@ -620,12 +615,11 @@ msgstr ""
 #: manual/Installation.md:220
 #, no-wrap
 msgid ""
-"  The build system uses Perl and the Unicode Character Database to\n"
-"  generate Netatalk's Unicode character conversion sources.\n"
+"    The build system uses Perl and the Unicode Character Database to\n"
+"    generate Netatalk's Unicode character conversion sources.\n"
 msgstr ""
-"  ビルド システムは、Perl と Unicode\n"
-"  文字データベースを使用して、Netatalk の Unicode\n"
-"  文字変換ソースを生成する。\n"
+"    ビルド システムは、Perl と Unicode 文字データベースを使用して、NetatalkのUnicode\n"
+"    文字変換ソースを生成する。\n"
 
 #. type: Title ###
 #: manual/Installation.md:221
@@ -674,12 +668,12 @@ msgstr ""
 "トフォーム固有のスクリプトに加えて、systemd、openrc 用に提供されている。"
 
 #. type: Plain text
-#: manual/Installation.md:246
+#: manual/Installation.md:245
 msgid ""
 "When building from source, the Netatalk build system will attempt to detect "
 "which init style is appropriate for your platform. You can also configure "
-"the build system to install the specific type of startup script(s)  you want "
-"by specifying the **with-init-style** option. For the syntax, please refer "
+"the build system to install the specific type of startup script(s) you want "
+"by specifying the **with-init-style** option.  For the syntax, please refer "
 "to the build system's help text."
 msgstr ""
 "ソースからビルドする場合、Netatalk ビルド システムは、どの initスタイルがプ"
@@ -689,7 +683,7 @@ msgstr ""
 "テキストを参照してください。"
 
 #. type: Plain text
-#: manual/Installation.md:251
+#: manual/Installation.md:250
 msgid ""
 "Since new Linux, \\*BSD, and Solaris-like distributions appear at regular "
 "intervals, and the startup procedure for the other systems mentioned above "
@@ -702,7 +696,7 @@ msgstr ""
 "ることをお勧めする。"
 
 #. type: Plain text
-#: manual/Installation.md:256
+#: manual/Installation.md:255
 msgid ""
 "If you use Netatalk as part of a fixed setup, like a Linux distribution, an "
 "RPM or a BSD package, things will probably have been arranged properly for "
@@ -715,7 +709,7 @@ msgstr ""
 "まる。"
 
 #. type: Plain text
-#: manual/Installation.md:259
+#: manual/Installation.md:258
 msgid ""
 "The following daemon need to be started by whatever startup script mechanism "
 "is used:"
@@ -724,12 +718,12 @@ msgstr ""
 "必要がある:"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:261
+#: manual/Installation.md:260
 msgid "netatalk"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:264
+#: manual/Installation.md:263
 msgid ""
 "In the absence of a startup script, you can also launch this daemon directly "
 "(as root), and kill it with SIGTERM when you are done with it."
@@ -738,7 +732,7 @@ msgstr ""
 "し、使い終わったら SIGTERM で終了することもできる。"
 
 #. type: Plain text
-#: manual/Installation.md:268
+#: manual/Installation.md:267
 msgid ""
 "Additionally, make sure that the configuration file *afp.conf* is in the "
 "right place. You can inquire netatalk where it is expecting the file to be "
@@ -749,7 +743,7 @@ msgstr ""
 "かどうかを問い合わせることができる。"
 
 #. type: Plain text
-#: manual/Installation.md:272
+#: manual/Installation.md:271
 msgid ""
 "If you want to run AppleTalk services, you also need to start the **atalkd** "
 "daemon, plus the optional **papd**, **timelord**, and **a2boot** daemons. "

--- a/doc/po/Upgrading.md.ja.po
+++ b/doc/po/Upgrading.md.ja.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-03-01 10:52+0100\n"
+"POT-Creation-Date: 2025-03-13 21:32+0100\n"
 "PO-Revision-Date: 2025-01-23 08:10+0100\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -17,8 +17,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1062 manpages/man5/afp.conf.5.md:1098
-#: manual/AppleTalk.md:154 manual/Configuration.md:832 manual/Installation.md:4
+#: manpages/man5/afp.conf.5.md:1055 manpages/man5/afp.conf.5.md:1091
+#: manual/AppleTalk.md:154 manual/Configuration.md:827 manual/Installation.md:4
 #: manual/Upgrading.md:42
 #, no-wrap
 msgid "> **WARNING**\n"
@@ -124,13 +124,13 @@ msgstr ""
 "一つで設定すべてを指示するという点： AFP 及びボリュームの構成を共に一つのファ"
 "イルで設定することになるという点"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manual/Upgrading.md:40
 msgid ""
-"obsoletes *afpd.conf*, *netatalk.conf*, *AppleVolumes.default* and "
+"- obsoletes *afpd.conf*, *netatalk.conf*, *AppleVolumes.default* and "
 "*afp_ldap.conf*"
 msgstr ""
-"*afpd.conf*、 *netatalk.conf*、 *AppleVolumes.default* 及び、 "
+"- *afpd.conf*、 *netatalk.conf*、 *AppleVolumes.default* 及び、 "
 "*afp_ldap.conf* の廃止"
 
 #. type: Plain text
@@ -154,13 +154,13 @@ msgstr ""
 msgid "maps file extensions to Classic Mac OS type/creator"
 msgstr "Classic Mac OS type/creator と拡張子の関連付け"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manual/Upgrading.md:52
 msgid ""
-"unlike 2.x, the mappings are disabled by default; uncomment the lines in the "
-"file to enable them"
+"- unlike 2.x, the mappings are disabled by default; uncomment the lines in "
+"the file to enable them"
 msgstr ""
-"2.x とは異なり、マッピングはデフォルトで無効になっている。有効にするには、"
+"- 2.x とは異なり、マッピングはデフォルトで無効になっている。有効にするには、"
 "ファイル内の行のコメントを解除する"
 
 #. type: Bullet: '- '
@@ -189,23 +189,23 @@ msgstr ""
 msgid "default backend (!)"
 msgstr "デフォルトのバックエンドである（！）"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manual/Upgrading.md:64
 msgid ""
-"requires a filesystem with Extended Attributes, fallback is AppleDouble v2 "
+"- requires a filesystem with Extended Attributes, fallback is AppleDouble v2 "
 "which is enabled with **ea = ad**"
 msgstr ""
-"拡張属性のあるファイルシステムが必須。 さもなくば **ea = ad** オプションの使"
-"用が代替となる"
+"- 拡張属性のあるファイルシステムが必須。 さもなくば **ea = ad** オプションの"
+"使用が代替となる"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manual/Upgrading.md:67
 msgid ""
-"converts filesystems from AppleDouble v2 to Extended Attributes on the fly "
+"- converts filesystems from AppleDouble v2 to Extended Attributes on the fly "
 "when accessed by clients (can be disabled with **convert appledouble**)"
 msgstr ""
-"ファイルシステムを AppleDouble v2 から拡張属性への変換はアクセス時、その都度"
-"行われる（**convert appledouble** オプションを無効にすることも可能）"
+"- ファイルシステムを AppleDouble v2 から拡張属性への変換はアクセス時、その都"
+"度行われる（**convert appledouble** オプションを無効にすることも可能）"
 
 #. type: Bullet: '- '
 #: manual/Upgrading.md:69
@@ -217,59 +217,57 @@ msgstr "一括で変換する場合 **dbd** を用いることができる"
 msgid "Implementation details:"
 msgstr "実装の詳細："
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manual/Upgrading.md:74
 msgid ""
-"stores Mac Metadata (e.g. FinderInfo, AFP Flags, Comment, CNID) in an "
+"- stores Mac Metadata (e.g. FinderInfo, AFP Flags, Comment, CNID) in an "
 "Extended Attributed named “*org.netatalk.Metadata*”"
 msgstr ""
-"Mac のメタデータ（すなわち FinderInfo、AFP フラグ、コメント、CNID）は "
+"- Mac のメタデータ（すなわち FinderInfo、AFP フラグ、コメント、CNID）は "
 "“*org.netatalk.Metadata*” という名前の拡張属性に保存される。"
 
-#. type: Bullet: '  - '
+#. type: Plain text
 #: manual/Upgrading.md:78
+#, no-wrap
 msgid ""
-"Additionally, on macOS hosts running Netatalk 4.1.0 or later, FinderInfo is "
-"natively stored in the file system and appears as an Extended Attribute "
-"named “*com.apple.FinderInfo*”"
-msgstr ""
-"さらに、Netatalk 4.1.0以降を実行しているmacOSホストでは、FinderInfo はファイ"
-"ルシステムにネイティブに保存され、\"com.apple.FinderInfo\" という名前の拡張属"
-"性として表示される。"
+"    - Additionally, on macOS hosts running Netatalk 4.1.0 or later,\n"
+"    FinderInfo is natively stored in the file system and appears as an\n"
+"    Extended Attribute named “*com.apple.FinderInfo*”\n"
+msgstr "- さらに、Netatalk 4.1.0以降を実行しているmacOSホストでは、FinderInfo はファイルシステムにネイティブに保存され、\"com.apple.FinderInfo\" という名前の拡張属性として表示される。\n"
 
 #. type: Bullet: '- '
 #: manual/Upgrading.md:80
 msgid "stores Mac ResourceFork either in"
 msgstr "マックのリソースフォークは："
 
-#. type: Bullet: '  - '
+#. type: Plain text
 #: manual/Upgrading.md:83
+#, no-wrap
 msgid ""
-"an Extended Attribute named “*org.netatalk.ResourceFork*” on Solaris w. ZFS, "
-"or in"
-msgstr ""
-"ZFS を用いた Solaris では “*org.netatalk.ResourceFork*” という拡張属性に保存"
-"される。"
+"    - an Extended Attribute named “*org.netatalk.ResourceFork*” on\n"
+"    Solaris w. ZFS, or in\n"
+msgstr "- ZFS を用いた Solaris では “*org.netatalk.ResourceFork*” という拡張属性に保存される。\n"
 
-#. type: Bullet: '  - '
+#. type: Plain text
 #: manual/Upgrading.md:86
-msgid "an extra AppleDouble file named “*._file*” for a file named “*file*” or"
-msgstr ""
-"ないしは、ファイル名が “*file*” であるものに対して各々、“*._file*” という名の"
-"別の AppleDouble ファイルに保存される。"
-
-#. type: Bullet: '  - '
-#: manual/Upgrading.md:89
+#, no-wrap
 msgid ""
-"natively stored in the resource fork on macOS hosts as of Netatalk 4.1.0."
-msgstr ""
-"Netatalk 4.1.0 以降、macOS ホスト上のリソース フォークにネイティブに保存され"
-"ている。"
+"    - an extra AppleDouble file named “*._file*” for a file named “*file*”,\n"
+"    or\n"
+msgstr "- ないしは、ファイル名が “*file*” であるものに対して各々、“*._file*” という名の別の AppleDouble ファイルに保存される。\n"
 
-#. type: Bullet: '- '
+#. type: Plain text
+#: manual/Upgrading.md:89
+#, no-wrap
+msgid ""
+"    - natively stored in the resource fork on macOS hosts as of Netatalk\n"
+"    4.1.0.\n"
+msgstr "- Netatalk 4.1.0 以降、macOS ホスト上のリソース フォークにネイティブに保存されている。\n"
+
+#. type: Plain text
 #: manual/Upgrading.md:98
 msgid ""
-"the format of the .\\_ file is exactly as the Mac’s CIFS client expects it "
+"- the format of the .\\_ file is exactly as the Mac’s CIFS client expects it "
 "when accessing the same filesystem via a CIFS server (Samba), thus you can "
 "have parallel access from Macs to the same dataset via AFP and CIFS without "
 "the risk of loosing data (resources or metadata).  Accessing the same "
@@ -277,7 +275,7 @@ msgid ""
 "“*file*” and “*._file*” on non ZFS filesystems (see above), so for this we "
 "still need an enhanced Samba VFS module (in the works)."
 msgstr ""
-"\".\\_\" ファイルのフォーマットは、 たとえそのファイルシステムに CIFS サー"
+"- \".\\_\" ファイルのフォーマットは、 たとえそのファイルシステムに CIFS サー"
 "バー (Samba) 経由でアクセスした場合でも、 マックの CIFS クライアントが想定し"
 "ているフォーマットと全く同じである。 なので、データを失う危険性（リソースもメ"
 "タデータも）なく、 マックから同じデータセットに AFP 経由と CIFS 経由と並行し"
@@ -292,35 +290,35 @@ msgstr ""
 msgid "Other major changes"
 msgstr "そのほかの主要な変更点"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manual/Upgrading.md:104
 msgid ""
-"New service controller daemon [netatalk](netatalk.html) which is responsible "
-"for starting and restarting the AFP and CNID daemons. All bundled start "
-"scripts have been updated, make sure to update yours!"
+"- New service controller daemon [netatalk](netatalk.html) which is "
+"responsible for starting and restarting the AFP and CNID daemons. All "
+"bundled start scripts have been updated, make sure to update yours!"
 msgstr ""
-"AFP 及び CNID デーモンの起動・再起動を担う新しいサービスコントローラデーモン "
-"[netatalk](netatalk.html) の導入。バンドルされているスタートスクリプトが すべ"
-"て更新されているため、自分の環境でもアップデートされているか確認する必要あ"
-"り！"
+"- AFP 及び CNID デーモンの起動・再起動を担う新しいサービスコントローラデーモ"
+"ン [netatalk](netatalk.html) の導入。バンドルされているスタートスクリプトが "
+"すべて更新されているため、自分の環境でもアップデートされているか確認する必要"
+"あり！"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manual/Upgrading.md:107
 msgid ""
-"All CNID databases are now stored under *$prefix/var/netatalk/CNID/* by "
+"- All CNID databases are now stored under *$prefix/var/netatalk/CNID/* by "
 "default, rather than in the individual shared volume directories"
 msgstr ""
-"CNID データベースはデフォルトで *$prefix/var/netatalk/CNID/* 以下に保存され"
+"- CNID データベースはデフォルトで *$prefix/var/netatalk/CNID/* 以下に保存され"
 "る。以前は各共有ボリュームにて保存されていた。"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manual/Upgrading.md:110
 msgid ""
-"Netatalk 2.x volume options “**usedots**” and “**upriv**” now enabled by "
+"- Netatalk 2.x volume options “**usedots**” and “**upriv**” now enabled by "
 "default"
 msgstr ""
-"Netatalk 2.x のボリュームオプション “**usedots**” 及び “**upriv**” はデフォル"
-"トとなった。"
+"- Netatalk 2.x のボリュームオプション “**usedots**” 及び “**upriv**” はデフォ"
+"ルトとなった。"
 
 #. type: Bullet: '- '
 #: manual/Upgrading.md:112

--- a/doc/po/afp.conf.5.md.ja.po
+++ b/doc/po/afp.conf.5.md.ja.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-03-01 10:52+0100\n"
+"POT-Creation-Date: 2025-03-13 23:15+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -66,7 +66,7 @@ msgstr "概要"
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
 #: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1344
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1339
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
@@ -88,7 +88,7 @@ msgstr "著者"
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
 #: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1346
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1341
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
@@ -105,7 +105,7 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1339 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1334 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
 #: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
@@ -120,7 +120,7 @@ msgstr "関連項目"
 #: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:50
 #: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
 #: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1289
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1284
 #: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
 #: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
@@ -131,9 +131,9 @@ msgstr "例"
 #: manpages/man1/afppasswd.1.md:20 manpages/man5/afp_signature.conf.5.md:21
 #: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:334
 #: manpages/man5/afp.conf.5.md:358 manpages/man5/afp.conf.5.md:371
-#: manpages/man5/afp.conf.5.md:386 manpages/man5/afp.conf.5.md:741
-#: manpages/man5/afp.conf.5.md:1057 manpages/man5/afp.conf.5.md:1183
-#: manpages/man5/afp.conf.5.md:1221 manpages/man8/papd.8.md:96
+#: manpages/man5/afp.conf.5.md:386 manpages/man5/afp.conf.5.md:737
+#: manpages/man5/afp.conf.5.md:1052 manpages/man5/afp.conf.5.md:1178
+#: manpages/man5/afp.conf.5.md:1216 manpages/man8/papd.8.md:96
 #: manual/Configuration.md:113
 #, no-wrap
 msgid "> **NOTE**\n"
@@ -294,11 +294,11 @@ msgstr ""
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:66
 msgid ""
-"The name of the volume is defined via the **name** option.  When absent, the "
-"volume name is the name of the section, expressed in lowercase."
+"The name of the volume is defined via the **volume name** option.  When "
+"absent, the volume name is the name of the section, expressed in lowercase."
 msgstr ""
-"ボリューム名は**name**オプションで定義される。省略された場合、ボリューム名は"
-"小文字で表されるセクション名となる。"
+"ボリューム名は**volume name**オプションで定義される。省略された場合、ボリュー"
+"ム名は小文字で表されるセクション名となる。"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:72
@@ -330,18 +330,17 @@ msgstr ""
 #: manpages/man5/afp.conf.5.md:80
 msgid ""
 "The following sample section defines an AFP volume. The user has full access "
-"to the path */foo/bar*. The share is accessed via the share name *Baz "
-"Volume*:"
+"to the path */foo/bar*. The share is accessed via the share name *Baz*:"
 msgstr ""
 "以下のセクションの例は、一つのAFPボリュームを定義している。ユーザはパス`/foo/"
-"bar`への完全なアクセス権を持つ。 *Baz Volume*という共有名でアクセスできる:"
+"bar`への完全なアクセス権を持つ。 *Baz*という共有名でアクセスできる:"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:84
 #, no-wrap
 msgid ""
 "    [baz]\n"
-"        name = Baz Volume\n"
+"        volume name = Baz\n"
 "        path = /foo/bar\n"
 msgstr ""
 
@@ -465,7 +464,7 @@ msgid ""
 msgstr "(H)の印がついているパラメータはこのボリュームセクション用である。"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:129 manpages/man5/afp.conf.5.md:995
+#: manpages/man5/afp.conf.5.md:129 manpages/man5/afp.conf.5.md:990
 #, no-wrap
 msgid "Parameters"
 msgstr "パラメータ"
@@ -503,17 +502,18 @@ msgid ""
 msgstr ""
 "ボリューム名で変数を使うことができる。パスでの変数の利用は$uに限られる。"
 
-#. type: Bullet: '1.  '
+#. type: Bullet: '1. '
 #: manpages/man5/afp.conf.5.md:145
 msgid "if you specify an unknown variable, it will not get converted."
 msgstr "不明な変数を指定した場合、それは変換されない。"
 
-#. type: Bullet: '2.  '
+#. type: Plain text
 #: manpages/man5/afp.conf.5.md:148
+#, no-wrap
 msgid ""
-"if you specify a known variable, but that variable doesn't have a value, it "
-"will get ignored."
-msgstr "既知の変数を指定したが変数が値を持たない場合、それは無視される。"
+"2. if you specify a known variable, but that variable doesn't have a\n"
+"value, it will get ignored.\n"
+msgstr "2. 既知の変数を指定したが変数が値を持たない場合、それは無視される。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:150
@@ -522,124 +522,135 @@ msgstr "置換に使われる変数は以下のとおり:"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:152
-msgid "$b"
+#, no-wrap
+msgid "> $b\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:154
 #, no-wrap
-msgid "> basename\n"
-msgstr "> ベース名\n"
+msgid "> > basename\n"
+msgstr "> > ベース名\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:156
-msgid "$c"
+#, no-wrap
+msgid "> $c\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:158
 #, no-wrap
-msgid "> client's ip address\n"
-msgstr "> クライアントのIPアドレス\n"
+msgid "> > client's ip address\n"
+msgstr "> > クライアントのIPアドレス\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:160
-msgid "$d"
+#, no-wrap
+msgid "> $d\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:162
 #, no-wrap
-msgid "> volume pathname on server\n"
-msgstr "> サーバ上のボリュームパス名\n"
+msgid "> > volume pathname on server\n"
+msgstr "> > サーバ上のボリュームパス名\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:164
-msgid "$f"
+#, no-wrap
+msgid "> $f\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:166
 #, no-wrap
-msgid "> full name (contents of the gecos field in the passwd file)\n"
-msgstr "> フルネーム (passwdファイルのGECOSフィールドの内容)\n"
+msgid "> > full name (contents of the gecos field in the passwd file)\n"
+msgstr "> > フルネーム (passwdファイルのGECOSフィールドの内容)\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:168
-msgid "$g"
+#, no-wrap
+msgid "> $g\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:170
 #, no-wrap
-msgid "> group name\n"
-msgstr "> グループ名\n"
+msgid "> > group name\n"
+msgstr "> > グループ名\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:172
-msgid "$h"
+#, no-wrap
+msgid "> $h\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:174
 #, no-wrap
-msgid "> hostname\n"
-msgstr "> ホスト名\n"
+msgid "> > hostname\n"
+msgstr "> > ホスト名\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:176
-msgid "$i"
+#, no-wrap
+msgid "> $i\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:178
 #, no-wrap
-msgid "> client's ip, without port\n"
-msgstr "> クライアントのIPアドレス。ポート番号なし\n"
+msgid "> > client's ip, without port\n"
+msgstr "> > クライアントのIPアドレス。ポート番号なし\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:180
-msgid "$s"
+#, no-wrap
+msgid "> $s\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:182
 #, no-wrap
-msgid "> server name (this can be the hostname)\n"
-msgstr "> サーバ名 (ホスト名になることができる)\n"
+msgid "> > server name (this can be the hostname)\n"
+msgstr "> > サーバ名 (ホスト名になることができる)\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:184
-msgid "$u"
+#, no-wrap
+msgid "> $u\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:186
 #, no-wrap
-msgid "> user name (if guest, it is the user that guest is running as)\n"
-msgstr "> ユーザ名 (ゲストの場合、ゲストとして動作しているユーザ名)\n"
+msgid "> > user name (if guest, it is the user that guest is running as)\n"
+msgstr "> > ユーザ名 (ゲストの場合、ゲストとして動作しているユーザ名)\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:188
-msgid "$v"
+#, no-wrap
+msgid "> $v\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:190
 #, no-wrap
-msgid "> volume name\n"
-msgstr "> ボリューム名\n"
+msgid "> > volume name\n"
+msgstr "> > ボリューム名\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:192
-msgid "$$"
+#, no-wrap
+msgid "> $$\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:194
 #, no-wrap
-msgid "> prints dollar sign ($)\n"
-msgstr "> ドル記号($)を表示する\n"
+msgid "> > prints dollar sign ($)\n"
+msgstr "> > ドル記号($)を表示する\n"
 
 #. type: Title #
 #: manpages/man5/afp.conf.5.md:195
@@ -809,89 +820,95 @@ msgstr "最も一般的に使われるUAMは以下の通り:"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:258
-msgid "uams_guest.so"
+#, no-wrap
+msgid "> uams_guest.so\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:260
 #, no-wrap
-msgid "> allows guest logins\n"
-msgstr "> ゲストログインを許可する\n"
+msgid "> > allows guest logins\n"
+msgstr "> > ゲストログインを許可する\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:262
-msgid "uams_clrtxt.so"
+#, no-wrap
+msgid "> uams_clrtxt.so\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:265
 #, no-wrap
 msgid ""
-"> (uams_pam.so or uams_passwd.so) Allow logins with passwords transmitted\n"
+"> > (uams_pam.so or uams_passwd.so) Allow logins with passwords transmitted\n"
 "in the clear. Compatible with Mac OS 9 and earlier.\n"
 msgstr ""
-"> (uams_pam.soまたはuams_passwd.so)\n"
+"> > (uams_pam.soまたはuams_passwd.so)\n"
 "暗号化なしで転送されたパスワードによるログインを許可する。Mac OS 9 以前と互換性がある。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:267
-msgid "uams_randnum.so"
+#, no-wrap
+msgid "> uams_randnum.so\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:273
 #, no-wrap
 msgid ""
-"> allows Random Number and Two-Way Random Number Exchange for\n"
+"> > allows Random Number and Two-Way Random Number Exchange for\n"
 "authentication (requires a separate file containing the passwords,\n"
 "either the default *afppasswd* file or the one specified via\n"
 "\"**passwd file**\"). See **afppasswd**(1) for details.\n"
 "Compatible with Mac OS 9 and earlier.\n"
 msgstr ""
-"> 認証のための乱数および双方向乱数交換を許可する\n"
+"> > 認証のための乱数および双方向乱数交換を許可する\n"
 "(パスワードを含んだファイル、つまりafppasswdファイルか\"**passwd file**\"で指定したファイルのどちらかが必要)。詳細は\n"
 "**afppasswd**(1)を見よ。Mac OS 9 以前と互換性がある。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:275
-msgid "uams_dhx.so"
+#, no-wrap
+msgid "> uams_dhx.so\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:278
 #, no-wrap
 msgid ""
-"> (uams_dhx_pam.so or uams_dhx_passwd.so) Allow Diffie-Hellman eXchange\n"
+"> > (uams_dhx_pam.so or uams_dhx_passwd.so) Allow Diffie-Hellman eXchange\n"
 "(DHX) for authentication.\n"
 msgstr ""
-"> (uams_dhx_pam.soまたはuams_dhx_passwd.so)\n"
+"> > (uams_dhx_pam.soまたはuams_dhx_passwd.so)\n"
 "認証のためのDiffie-Hellman交換(DHX)を許可する。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:280
-msgid "uams_dhx2.so"
+#, no-wrap
+msgid "> uams_dhx2.so\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:283
 #, no-wrap
 msgid ""
-"> (uams_dhx2_pam.so or uams_dhx2_passwd.so) Allow Diffie-Hellman eXchange\n"
-"2 (DHX2) for authentication.\n"
+"> > (uams_dhx2_pam.so or uams_dhx2_passwd.so) Allow Diffie-Hellman eXchange 2\n"
+"(DHX2) for authentication.\n"
 msgstr ""
-"> (uams_dhx2_pam.soまたはuams_dhx2_passwd.so)\n"
+"> > (uams_dhx2_pam.soまたはuams_dhx2_passwd.so)\n"
 "認証のためのDiffie-Hellman交換2(DHX2)を許可する。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:285
-msgid "uam_gss.so"
+#, no-wrap
+msgid "> uam_gss.so\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:287
 #, no-wrap
-msgid "> Allow Kerberos V for authentication (optional)\n"
-msgstr "> 認証のためのKerberos Vを許可する。(オプション)\n"
+msgid "> > Allow Kerberos V for authentication (optional)\n"
+msgstr "> > 認証のためのKerberos Vを許可する。(オプション)\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:289
@@ -1479,28 +1496,28 @@ msgstr "chmod request = <preserve (デフォルト) \\| ignore \\| simple\\> **(
 msgid "> Advanced permission control that deals with ACLs.\n"
 msgstr "> ACLに対応する高度なパーミッション制御。\n"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manpages/man5/afp.conf.5.md:521
+#, no-wrap
 msgid ""
-"**ignore** - UNIX chmod() requests are completely ignored, use this option "
-"to allow the parent directory's ACL inheritance full control over new items."
-msgstr ""
-"**ignore** - UNIXのchmod()要求を完全に無視する。新規作成を上書きして親ディレ"
-"クトリのACL継承に完全コントロールさせるためにこのオプションを使う。"
+"> - **ignore** - UNIX chmod() requests are completely ignored, use this\n"
+"option to allow the parent directory's ACL inheritance full control\n"
+"over new items.\n"
+msgstr "> - **ignore** - UNIXのchmod()要求を完全に無視する。新規作成を上書きして親ディレクトリのACL継承に完全コントロールさせるためにこのオプションを使う。\n"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manpages/man5/afp.conf.5.md:524
+#, no-wrap
 msgid ""
-"**preserve** - preserve ZFS ACEs for named users and groups or POSIX ACL "
-"group mask"
-msgstr ""
-"**preserve** - 名前付きユーザとグループのためのZFS ACEやPOSIX ACLグループマス"
-"クを維持する"
+"> - **preserve** - preserve ZFS ACEs for named users and groups or POSIX ACL\n"
+"group mask\n"
+msgstr "> - **preserve** - 名前付きユーザとグループのためのZFS ACEやPOSIX ACLグループマスクを維持する\n"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manpages/man5/afp.conf.5.md:526
-msgid "**simple** - just to a chmod() as requested without any extra steps"
-msgstr "**simple** - いかなる追加の手順も踏まず、単に要求通りにchmod()する"
+#, no-wrap
+msgid "> - **simple** - just to a chmod() as requested without any extra steps\n"
+msgstr "> - **simple** - いかなる追加の手順も踏まず、単に要求通りにchmod()する\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:528
@@ -1623,16 +1640,13 @@ msgstr "> ディレクトリキャッシュにおける最大エントリ数。�
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:574
+#, no-wrap
 msgid ""
-"Default size is 8192, maximum size is 131072. Given value is rounded up to "
-"nearest power of 2. Each entry takes about 100 bytes, which is not much, but "
-"remember that every afpd child process for every connected user has its "
-"cache."
-msgstr ""
-"デフォルトサイズは8192、最大サイズは131072。与えられた値は最も近い2の累乗に丸"
-"められる。それぞれのエントリは約100バイトを消費し、これは大きな値とは言えない"
-"が、それぞれの接続ユーザ毎のafpd子プロセスがキャッシュを持つことを念頭に置い"
-"てください。"
+"> Default size is 8192, maximum size is 131072. Given value is rounded up\n"
+"to nearest power of 2. Each entry takes about 100 bytes, which is not\n"
+"much, but remember that every afpd child process for every connected\n"
+"user has its cache.\n"
+msgstr "> デフォルトサイズは8192、最大サイズは131072。与えられた値は最も近い2の累乗に丸められる。それぞれのエントリは約100バイトを消費し、これは大きな値とは言えないが、それぞれの接続ユーザ毎のafpd子プロセスがキャッシュを持つことを念頭に置いてください。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:576
@@ -1665,10 +1679,9 @@ msgstr "> ディレクトリへの書き込み権限があったとしても、�
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:587
-msgid "By enabling this option Netatalk will write the metadata xattr as root."
-msgstr ""
-"このオプションを有効にするとNetatalkはroot権限でメタデータ(拡張属性)を書き込"
-"む。"
+#, no-wrap
+msgid "> By enabling this option Netatalk will write the metadata xattr as root.\n"
+msgstr "> このオプションを有効にするとNetatalkはroot権限でメタデータ(拡張属性)を書き込む。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:589
@@ -1718,15 +1731,13 @@ msgstr "> サーバが無視すべきファイルとディレクトリの属性�
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:607
+#, no-wrap
 msgid ""
-"In OS X when the Finder sets a lock on a file/directory or you set the BSD "
-"uchg flag in the Terminal, all three attributes are used. Thus in order to "
-"ignore the Finder lock/BSD uchg flag, add set *ignored attributes = all*."
-msgstr ""
-"OS Xにおいて、Finderがファイル/ディレクトリのロックを設定する場合、またはター"
-"ミナルでBSD uchgフラグを設定する場合、3つの属性が全て使われる。従って、Finder"
-"ロック/BSD uchgフラグを無視する目的で*ignored attributes = all*の設定を追加し"
-"てください。"
+"> In OS X when the Finder sets a lock on a file/directory or you set the\n"
+"BSD uchg flag in the Terminal, all three attributes are used. Thus in\n"
+"order to ignore the Finder lock/BSD uchg flag, add set *ignored\n"
+"attributes = all*.\n"
+msgstr "> OS Xにおいて、Finderがファイル/ディレクトリのロックを設定する場合、またはターミナルでBSD uchgフラグを設定する場合、3つの属性が全て使われる。従って、Finderロック/BSD uchgフラグを無視する目的で*ignored attributes = all*の設定を追加してください。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:609
@@ -1747,29 +1758,23 @@ msgstr ""
 "バージョンでは、このアイコン設定が無視される。\n"
 "有効なアイコン名の例は以下になる。\n"
 
-#. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:615
-msgid "**daemon**"
-msgstr ""
-
-#. type: Bullet: '- '
+#. type: Plain text
 #: manpages/man5/afp.conf.5.md:617
-msgid "**globe**"
-msgstr ""
-
-#. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:619
-msgid "**sdcard**"
+#, no-wrap
+msgid ""
+"> - **daemon**\n"
+"> - **globe**\n"
+"> - **sdcard**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:621
+#: manpages/man5/afp.conf.5.md:619
 #, no-wrap
 msgid "login message = <message\\> **(G)**/**(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:624
+#: manpages/man5/afp.conf.5.md:622
 #, no-wrap
 msgid ""
 "> Sets a message to be displayed when clients logon to the server. The\n"
@@ -1777,13 +1782,13 @@ msgid ""
 msgstr "> クライアントがサーバにログオンしたときに表示されるメッセージを設定する。メッセージは**unix charset**で書く。拡張文字が使える。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:626
+#: manpages/man5/afp.conf.5.md:624
 #, no-wrap
 msgid "mimic model = <model\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:630
+#: manpages/man5/afp.conf.5.md:628
 #, no-wrap
 msgid ""
 "> Specifies a custom icon for the mounted AFP volume on macOS / Mac OS X\n"
@@ -1794,40 +1799,33 @@ msgstr ""
 "Mac\n"
 "に任せること。netatalkがZeroconfをサポートしなければならないことに注意してください。例:\n"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manpages/man5/afp.conf.5.md:632
-msgid "**Laptop**"
-msgstr ""
-
-#. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:634
-msgid "**RackMount**"
-msgstr ""
-
-#. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:636
-msgid "**Tower**"
-msgstr ""
-
-#. type: Plain text
-#: manpages/man5/afp.conf.5.md:641
+#, no-wrap
 msgid ""
-"A complete set of supported model codes by a macOS client can be found by "
-"inspecting system properties files, such as */System/Library/CoreServices/"
-"CoreTypes.bundle/Contents/Info.plist* on macOS 15 Sequoia."
+"> - **Laptop**\n"
+"> - **RackMount**\n"
+"> - **Tower**\n"
 msgstr ""
-"macOSは認識しているモデルコードは */System/Library/CoreServices/"
-"CoreTypes.bundle/Contents/Info.plist* を参照すれば確認できる。(macOS 15 "
-"Sequoia の場合。)"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:643
+#: manpages/man5/afp.conf.5.md:637
+#, no-wrap
+msgid ""
+"> A complete set of supported model codes by a macOS client can be found\n"
+"by inspecting system properties files, such as\n"
+"*/System/Library/CoreServices/CoreTypes.bundle/Contents/Info.plist*\n"
+"on macOS 15 Sequoia.\n"
+msgstr "> macOSは認識しているモデルコードは */System/Library/CoreServices/CoreTypes.bundle/Contents/Info.plist* を参照すれば確認できる。(macOS 15 Sequoia の場合。)\n"
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:639
 #, no-wrap
 msgid "server name = <name\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:648
+#: manpages/man5/afp.conf.5.md:644
 #, no-wrap
 msgid ""
 "> Specifies a human-readable name that uniquely describes the AFP server.\n"
@@ -1837,13 +1835,13 @@ msgid ""
 msgstr "> 一意に AFP サーバを記述する人間が読める名前を指定する。デフォルトでは、最初のピリオドまでの**hostname**の値を使用する。netatalkがZeroconfサポートでビルドされている場合、これはサービス名としても登録され、UTF-8で最大63オクテット(バイト)の長さまで宣伝される。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:650
+#: manpages/man5/afp.conf.5.md:646
 #, no-wrap
 msgid "signature = <STRING\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:656
+#: manpages/man5/afp.conf.5.md:652
 #, no-wrap
 msgid ""
 "> Specify a server signature. The maximum length is 16 characters. This\n"
@@ -1854,13 +1852,13 @@ msgid ""
 msgstr "> サーバシグネチャを指定する。最大長は16文字である。このオプションは障害隔離などを提供するクラスタ環境において有用である。デフォルトでは、afpdは自動的にシグネチャを(乱数を元に)生成し、それを**afp_signature.conf**に保存する。asip-status(1)も見よ。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:658
+#: manpages/man5/afp.conf.5.md:654
 #, no-wrap
 msgid "solaris share reservations = <BOOLEAN\\> (default: *yes*) **(G)**\n"
 msgstr "solaris share reservations = <BOOLEAN\\> (デフォルト: *yes*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:661
+#: manpages/man5/afp.conf.5.md:657
 #, no-wrap
 msgid ""
 "> Use share reservations on Solaris. Solaris CIFS server uses this too, so\n"
@@ -1870,13 +1868,13 @@ msgstr ""
 "CIFSサーバもこれを利用するので、ロックを統一したマルチプロトコルサーバを形成する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:663
+#: manpages/man5/afp.conf.5.md:659
 #, no-wrap
 msgid "sparql results limit = <NUMBER\\> (default: *UNLIMITED*) **(G)**\n"
 msgstr "sparql results limit = <NUMBER\\> (デフォルト: *無制限*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:666
+#: manpages/man5/afp.conf.5.md:662
 #, no-wrap
 msgid ""
 "> Impose a limit on the number of results queried from Tracker or\n"
@@ -1886,13 +1884,13 @@ msgstr ""
 "からのクエリ結果の数に制限を課す。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:668
+#: manpages/man5/afp.conf.5.md:664
 #, no-wrap
 msgid "spotlight = <BOOLEAN\\> (default: *no*) **(G)**/**(V)**\n"
 msgstr "spotlight = <BOOLEAN\\> (デフォルト: *no*) **(G)**/**(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:672
+#: manpages/man5/afp.conf.5.md:668
 #, no-wrap
 msgid ""
 "> Whether to enable Spotlight searches. Note: once the global option is\n"
@@ -1904,13 +1902,13 @@ msgstr ""
 "daemon*オプションも見よ。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:674
+#: manpages/man5/afp.conf.5.md:670
 #, no-wrap
 msgid "spotlight attributes = <COMMA SEPARATED STRING\\> (default: *EMPTY*) **(G)**\n"
 msgstr "spotlight attributes = <カンマで分割した文字列\\> (デフォルト: *空*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:678
+#: manpages/man5/afp.conf.5.md:674
 #, no-wrap
 msgid ""
 "> A list of attributes that are allowed to be used in Spotlight searches.\n"
@@ -1921,31 +1919,31 @@ msgstr ""
 "例:\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:680
+#: manpages/man5/afp.conf.5.md:676
 #, no-wrap
 msgid "    spotlight attributes = *,kMDItemTextContent\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:682
+#: manpages/man5/afp.conf.5.md:678
 #, no-wrap
 msgid "spotlight expr = <BOOLEAN\\> (default: *yes*) **(G)**\n"
 msgstr "spotlight expr = <BOOLEAN\\> (デフォルト: *yes*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:684
+#: manpages/man5/afp.conf.5.md:680
 #, no-wrap
 msgid "> Whether to allow the use of logic expression in searches.\n"
 msgstr "> 検索において論理式の使用を認めるかどうか。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:686
+#: manpages/man5/afp.conf.5.md:682
 #, no-wrap
 msgid "veto message = <BOOLEAN\\> (default: *no*) **(G)**\n"
 msgstr "veto message = <BOOLEAN\\> (デフォルト: *no*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:690
+#: manpages/man5/afp.conf.5.md:686
 #, no-wrap
 msgid ""
 "> Send optional AFP messages for vetoed files. Then whenever a client\n"
@@ -1954,13 +1952,13 @@ msgid ""
 msgstr "> 禁止ファイルに関するオプションのAFPメッセージを送る。クライアントが禁止名を持つファイルやディレクトリにアクセスを試みたとき、名前とディレクトリを示したAFPメッセージを送る。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:692
+#: manpages/man5/afp.conf.5.md:688
 #, no-wrap
 msgid "vol dbpath = <path\\> **(G)**/**(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:695
+#: manpages/man5/afp.conf.5.md:691
 #, no-wrap
 msgid ""
 "> Sets the path where the database information will be stored. You have to\n"
@@ -1968,13 +1966,13 @@ msgid ""
 msgstr "> データベース情報をpathに格納するように設定する。ボリュームが読み込み専用だったとしても、書き込み可能な場所を設定しなければならない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:697
+#: manpages/man5/afp.conf.5.md:693
 #, no-wrap
 msgid "vol dbnest = <BOOLEAN\\> (default: *no*) **(G)**\n"
 msgstr "vol dbnest = <BOOLEAN\\> (デフォルト: *no*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:701
+#: manpages/man5/afp.conf.5.md:697
 #, no-wrap
 msgid ""
 "> Setting this option to true brings back Netatalk 2 behaviour of storing\n"
@@ -1985,13 +1983,13 @@ msgstr ""
 "2の動作に立ち返る。つまり、それぞれの共有のボリュームルートの下にある.AppleDBというフォルダにCNIDデータベースを格納する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:703
+#: manpages/man5/afp.conf.5.md:699
 #, no-wrap
 msgid "volnamelen = <number\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:706
+#: manpages/man5/afp.conf.5.md:702
 #, no-wrap
 msgid ""
 "> Max length of UTF8-MAC volume name for Mac OS X. Note that Hangul is\n"
@@ -2001,7 +1999,7 @@ msgstr ""
 "XのためのUTF8-MACボリューム名の最大長。ハングルはこれに特に敏感なので注意してください。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:710
+#: manpages/man5/afp.conf.5.md:706
 #, no-wrap
 msgid ""
 "    73: limit of Mac OS X 10.1\n"
@@ -2013,22 +2011,21 @@ msgstr ""
 "    255: 最近のMac OS Xの制限\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:713
+#: manpages/man5/afp.conf.5.md:709
+#, no-wrap
 msgid ""
-"Mac OS 9 and earlier are not influenced by this, because Maccharset volume "
-"name is always limited to 27 bytes."
-msgstr ""
-"Mac OS 9以前はこれに影響されない。なぜならMac文字セットのボリューム名は常に27"
-"バイト制限がある。"
+"> Mac OS 9 and earlier are not influenced by this, because Maccharset\n"
+"volume name is always limited to 27 bytes.\n"
+msgstr "> Mac OS 9以前はこれに影響されない。なぜならMac文字セットのボリューム名は常に27バイト制限がある。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:715
+#: manpages/man5/afp.conf.5.md:711
 #, no-wrap
 msgid "vol preset = <name\\> **(G)**/**(V)**\n"
 msgstr "vol size limit = <MiB 単位でのサイズ\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:719
+#: manpages/man5/afp.conf.5.md:715
 #, no-wrap
 msgid ""
 "> Use section <name\\> as option preset for all volumes (when set in the\n"
@@ -2039,19 +2036,19 @@ msgstr ""
 "全ボリューム、(ボリュームセクションで設定したときは)そのボリュームのオプション初期設定となるセクションの<name\\>を使う。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:720
+#: manpages/man5/afp.conf.5.md:716
 #, no-wrap
 msgid "Logging Options"
 msgstr "ログのオプション"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:723
+#: manpages/man5/afp.conf.5.md:719
 #, no-wrap
 msgid "log file = <logfile\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:726
+#: manpages/man5/afp.conf.5.md:722
 #, no-wrap
 msgid ""
 "> Write logs to **logfile** on the file system. If not specified, Netatalk\n"
@@ -2059,7 +2056,7 @@ msgid ""
 msgstr "> ログを**logfile**に出力する。指定しない場合、Netatalkはsyslogデーモン機能にログを出力する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:728
+#: manpages/man5/afp.conf.5.md:724
 msgid ""
 "log level = <type:level \\[type:level ...\\]\\> **(G)**; log level = "
 "<type:level,\\[type:level, ...\\]\\> **(G)**"
@@ -2068,7 +2065,7 @@ msgstr ""
 "<type:level,\\[type:level, ...\\]\\> **(G)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:731
+#: manpages/man5/afp.conf.5.md:727
 #, no-wrap
 msgid ""
 "> Specify that any message of a loglevel up to the given **log level**\n"
@@ -2076,40 +2073,41 @@ msgid ""
 msgstr "> 与えられた**log level**までのログレベルのメッセージを出力するように設定する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:734
+#: manpages/man5/afp.conf.5.md:730
+#, no-wrap
 msgid ""
-"By default afpd logs to syslog with a default logging setup equivalent to "
-"**default:note**"
-msgstr "デフォルトではafpdは**default:note**に相当する設定でsyslogに出力する。"
+"> By default afpd logs to syslog with a default logging setup equivalent\n"
+"to **default:note**\n"
+msgstr "> デフォルトではafpdは**default:note**に相当する設定でsyslogに出力する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:736
-msgid "logtypes: default, afpdaemon, logger, uamsdaemon"
-msgstr "ログタイプ: default, afpdaemon, logger, uamsdaemon"
+#: manpages/man5/afp.conf.5.md:732
+#, no-wrap
+msgid "> logtypes: default, afpdaemon, logger, uamsdaemon\n"
+msgstr "> ログタイプ: default, afpdaemon, logger, uamsdaemon\n"
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:735
+#, no-wrap
+msgid ""
+"> loglevels: severe, error, warn, note, info, debug, debug6, debug7,\n"
+"debug8, debug9, maxdebug\n"
+msgstr "> ログレベル: severe, error, warn, note, info, debug, debug6, debug7, debug8, debug9, maxdebug\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:739
-msgid ""
-"loglevels: severe, error, warn, note, info, debug, debug6, debug7, debug8, "
-"debug9, maxdebug"
-msgstr ""
-"ログレベル: severe, error, warn, note, info, debug, debug6, debug7, debug8, "
-"debug9, maxdebug"
-
-#. type: Plain text
-#: manpages/man5/afp.conf.5.md:743
 #, no-wrap
 msgid "> Both logtype and loglevels are case insensitive.\n"
 msgstr "> ログタイプとログレベルはどちらも大文字小文字を区別しない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:745
+#: manpages/man5/afp.conf.5.md:741
 #, no-wrap
 msgid "log microseconds = <BOOLEAN\\> (default: *yes*) **(G)**\n"
 msgstr "log microseconds = <BOOLEAN\\> (デフォルト: *yes*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:749
+#: manpages/man5/afp.conf.5.md:745
 #, no-wrap
 msgid ""
 "> Log timestamps with accuracy down to microseconds. If disabled, the\n"
@@ -2120,13 +2118,13 @@ msgstr ""
 "オプションと組み合わせて使用​​した場合にのみ有効になる。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:750
+#: manpages/man5/afp.conf.5.md:746
 #, no-wrap
 msgid "Filesystem Change Events (FCE)"
 msgstr "ファイルシステム変更イベント (FCE)"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:755
+#: manpages/man5/afp.conf.5.md:751
 msgid ""
 "Netatalk includes a nifty filesystem change event mechanism where afpd "
 "processes notify interested listeners about certain filesystem event by UDP "
@@ -2137,63 +2135,63 @@ msgstr ""
 "るリスナーに、UDP ネットワークデータグラムで通知する。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:757
+#: manpages/man5/afp.conf.5.md:753
 msgid "The following FCE events are defined:"
 msgstr "以下の FCE イベントが定義されている:"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:759
+#: manpages/man5/afp.conf.5.md:755
 msgid "file modification (**fmod**)"
 msgstr "ファイル変更 (**fmod**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:761
+#: manpages/man5/afp.conf.5.md:757
 msgid "file deletion (**fdel**)"
 msgstr "ファイル削除 (**fdel**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:763
+#: manpages/man5/afp.conf.5.md:759
 msgid "directory deletion (**ddel**)"
 msgstr "ディレクトリ削除 (**ddel**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:765
+#: manpages/man5/afp.conf.5.md:761
 msgid "file creation (**fcre**)"
 msgstr "ファイル作成 (**fcre**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:767
+#: manpages/man5/afp.conf.5.md:763
 msgid "directory creation (**dcre**)"
 msgstr "ディレクトリ作成 (**dcre**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:769
+#: manpages/man5/afp.conf.5.md:765
 msgid "file move or rename (**fmov**)"
 msgstr "ファイル移動または名前変更 (**fmov**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:771
+#: manpages/man5/afp.conf.5.md:767
 msgid "directory move or rename (**dmov**)"
 msgstr "ディレクトリ移動または名前変更 (**dmov**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:773
+#: manpages/man5/afp.conf.5.md:769
 msgid "login (**login**)"
 msgstr "ログイン (**login**)"
 
 #. type: Bullet: '- '
-#: manpages/man5/afp.conf.5.md:775
+#: manpages/man5/afp.conf.5.md:771
 msgid "logout (**logout**)"
 msgstr "ログアウト (**logout**)"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:777
+#: manpages/man5/afp.conf.5.md:773
 #, no-wrap
 msgid "fce listener = <host\\[:port\\]\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:781
+#: manpages/man5/afp.conf.5.md:777
 #, no-wrap
 msgid ""
 "> Enables sending FCE events to the specified **host**, default **port** is\n"
@@ -2206,13 +2204,13 @@ msgstr ""
 "である。複数のリスナーを指定するにはそれぞれのリスナーに対するオプションを一度に指定することである。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:783
+#: manpages/man5/afp.conf.5.md:779
 #, no-wrap
 msgid "fce version = <1|2\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:786
+#: manpages/man5/afp.conf.5.md:782
 #, no-wrap
 msgid ""
 "> FCE protocol version, default is 1. You need version 2 for the fmov,\n"
@@ -2223,13 +2221,13 @@ msgstr ""
 "が必要である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:788
+#: manpages/man5/afp.conf.5.md:784
 #, no-wrap
 msgid "fce events = <fmod,fdel,ddel,fcre,dcre,fmov,dmov,login,logout\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:791
+#: manpages/man5/afp.conf.5.md:787
 #, no-wrap
 msgid ""
 "> Specifies which FCE events are active, default is\n"
@@ -2239,25 +2237,25 @@ msgstr ""
 "**fmod,fdel,ddel,fcre,dcre** である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:793
+#: manpages/man5/afp.conf.5.md:789
 #, no-wrap
 msgid "fce coalesce = <all|delete|create\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:795
+#: manpages/man5/afp.conf.5.md:791
 #, no-wrap
 msgid "> Coalesce FCE events.\n"
 msgstr "> FCE イベントを結合する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:797
+#: manpages/man5/afp.conf.5.md:793
 #, no-wrap
 msgid "fce holdfmod = <seconds\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:804
+#: manpages/man5/afp.conf.5.md:800
 #, no-wrap
 msgid ""
 "> This determines the time delay in seconds which is always waited if\n"
@@ -2272,13 +2270,13 @@ msgstr ""
 "60 秒である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:806
+#: manpages/man5/afp.conf.5.md:802
 #, no-wrap
 msgid "fce sendwait = <milliseconds\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:813
+#: manpages/man5/afp.conf.5.md:809
 #, no-wrap
 msgid ""
 "> Defines a delay in milliseconds between the emission of each FCE event.\n"
@@ -2296,46 +2294,46 @@ msgstr ""
 "から 999 までの値は設定可能。デフォルト: 0 ミリ秒。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:815
+#: manpages/man5/afp.conf.5.md:811
 #, no-wrap
-msgid "fce ignore names = <NAME\\[/NAME2/...\\]\\> **(G)**\n"
+msgid "fce ignore names = <NAME\\[,NAME2,...\\]\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:818
+#: manpages/man5/afp.conf.5.md:814
 #, no-wrap
 msgid ""
-"> Slash delimited list of filenames for which FCE events shall not be\n"
-"generated. Default: .DS_Store.\n"
+"> Comma-delimited list of filenames for which FCE events shall not be\n"
+"generated. Default: `.DS_Store`\n"
 msgstr ""
-"> FCE\n"
-"イベントを生成すべきでないファイル名をスラッシュで区切ったリスト。デフォルトでは\n"
-".DS_Store。\n"
+"> FCEイベントを生成すべきでないファイル名をカンマ区切りのリスト。デフォルトでは\n"
+"`.DS_Store`\n"
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:816
+#, no-wrap
+msgid "fce ignore directories = <PATH\\[,PATH2,...\\]\\> **(G)**\n"
+msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:820
 #, no-wrap
-msgid "fce ignore directories = <NAME\\[,NAME2,...\\]\\> **(G)**\n"
-msgstr ""
-
-#. type: Plain text
-#: manpages/man5/afp.conf.5.md:823
-#, no-wrap
 msgid ""
-"> Comma delimited list of directories for which FCE events shall not be\n"
-"generated. Default: empty.\n"
+"> Comma-delimited list of paths to directories for which FCE events\n"
+"shall not be generated. Has to be an absolute path on the host file system.\n"
+"Must not end with a slash. Default: empty\n"
 msgstr ""
-"> FCE\n"
-"イベントが生成されないディレクトリのカンマ区切りのリスト。デフォルトは無し。\n"
+"> FCEイベントが生成されないディレクトリのカンマ区切りのリスト。ホストのファイルシステム上の絶対パスである必要がある。\n"
+"パスはスラッシュで終わってはならない。デフォルトは無し。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:825
+#: manpages/man5/afp.conf.5.md:822
 #, no-wrap
 msgid "fce notify script = <PATH\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:829
+#: manpages/man5/afp.conf.5.md:826
 #, no-wrap
 msgid ""
 "> Script which will be executed for every FCE event, see\n"
@@ -2347,36 +2345,36 @@ msgstr ""
 "のソースの contrib/shell_utils/fce_ev_script.sh を参照のこと。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:830
+#: manpages/man5/afp.conf.5.md:827
 #, no-wrap
 msgid "Debug Parameters"
 msgstr "デバッグパラメータ"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:833
+#: manpages/man5/afp.conf.5.md:830
 msgid "These options are useful for debugging only."
 msgstr "これらのオプションはデバッグのみに有用である。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:835
+#: manpages/man5/afp.conf.5.md:832
 #, no-wrap
 msgid "tickleval = <number\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:837
+#: manpages/man5/afp.conf.5.md:834
 #, no-wrap
 msgid "> Sets the tickle timeout interval (in seconds). Defaults to 30.\n"
 msgstr "> tickleタイムアウトの間隔を(秒単位で)設定する。デフォルトは30。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:839
+#: manpages/man5/afp.conf.5.md:836
 #, no-wrap
 msgid "timeout = <number\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:842
+#: manpages/man5/afp.conf.5.md:839
 #, no-wrap
 msgid ""
 "> Specify the number of tickles to send before timing out a connection.\n"
@@ -2384,13 +2382,13 @@ msgid ""
 msgstr "> 接続がタイムアウトする前に送るtickleの数を指定する。デフォルトは4なので、2分後に接続がタイムアウトする。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:844
+#: manpages/man5/afp.conf.5.md:841
 #, no-wrap
 msgid "client polling = <BOOLEAN\\> (default: *no*) **(G)**\n"
 msgstr "client polling = <BOOLEAN\\> (デフォルト: *no*) **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:850
+#: manpages/man5/afp.conf.5.md:847
 #, no-wrap
 msgid ""
 "> With this option enabled, afpd won't advertise that it is capable of\n"
@@ -2404,24 +2402,22 @@ msgstr ""
 "同時接続クライアント数とネットワークスピード次第でネットワークの負荷が相当に高くなる!\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:854
+#: manpages/man5/afp.conf.5.md:851
+#, no-wrap
 msgid ""
-"Do not use this option any longer as present Netatalk correctly supports "
-"server notifications, allowing connected clients to update folder listings "
-"in case another client changed the contents."
-msgstr ""
-"現在のNetatalkはserver notificationを正確にサポートしており、接続中のクライア"
-"ントは他のクライアントが内容を変更したときにフォルダ内の一覧を更新できるの"
-"で、もはやこのオプションは使わないでください。"
+"> Do not use this option any longer as present Netatalk correctly supports\n"
+"server notifications, allowing connected clients to update folder\n"
+"listings in case another client changed the contents.\n"
+msgstr "> 現在のNetatalkはserver notificationを正確にサポートしており、接続中のクライアントは他のクライアントが内容を変更したときにフォルダ内の一覧を更新できるので、もはやこのオプションは使わないでください。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:855
+#: manpages/man5/afp.conf.5.md:852
 #, no-wrap
 msgid "Options for ACL handling"
 msgstr "ACL処理のためのオプション"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:861
+#: manpages/man5/afp.conf.5.md:858
 msgid ""
 "By default, the effective permission of the authenticated user are only "
 "mapped to the mentioned UARights permission structure, not the UNIX mode. "
@@ -2431,49 +2427,52 @@ msgstr ""
 "される。UNIXモードではない。この挙動は設定オプション**map acls**で調整できる:"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:863
+#: manpages/man5/afp.conf.5.md:860
 #, no-wrap
 msgid "map acls = <none|rights|mode\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:865
+#: manpages/man5/afp.conf.5.md:862 manpages/man5/afp.conf.5.md:892
+#: manpages/man5/afp.conf.5.md:1089
 #, no-wrap
 msgid "> none\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:867
+#: manpages/man5/afp.conf.5.md:864
 #, no-wrap
-msgid "> no mapping of ACLs\n"
-msgstr "> ACLのマッピングをしない\n"
+msgid "> > no mapping of ACLs\n"
+msgstr "> > ACLのマッピングをしない\n"
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:866
+#, no-wrap
+msgid "> rights\n"
+msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:869
-msgid "rights"
-msgstr ""
-
-#. type: Plain text
-#: manpages/man5/afp.conf.5.md:872
 #, no-wrap
 msgid ""
-"> effective permissions are mapped to UARights structure. This is the\n"
+"> > effective permissions are mapped to UARights structure. This is the\n"
 "default.\n"
-msgstr "> 有効な権限がUARights構造にマップされる。これがデフォルトである。\n"
+msgstr "> > 有効な権限がUARights構造にマップされる。これがデフォルトである。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:874
-msgid "mode"
+#: manpages/man5/afp.conf.5.md:871
+#, no-wrap
+msgid "> mode\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:876
+#: manpages/man5/afp.conf.5.md:873
 #, no-wrap
-msgid "> ACLs are additionally mapped to the UNIX mode of the filesystem object.\n"
-msgstr "> ACLはファイルシステムオブジェクトのUNIXモードにもマップされる。\n"
+msgid "> > ACLs are additionally mapped to the UNIX mode of the filesystem object.\n"
+msgstr "> > ACLはファイルシステムオブジェクトのUNIXモードにもマップされる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:884
+#: manpages/man5/afp.conf.5.md:881
 msgid ""
 "If you want to be able to display ACLs on the client, you must setup both "
 "client and server as part on a authentication domain (directory service, "
@@ -2491,7 +2490,7 @@ msgstr ""
 "を UUID と紐付けできるようにしなければならない。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:889
+#: manpages/man5/afp.conf.5.md:886
 msgid ""
 "Netatalk can query a directory server using LDAP queries. Either the "
 "directory server already provides an UUID attribute for user and groups "
@@ -2505,75 +2504,65 @@ msgstr ""
 "かである。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:891
+#: manpages/man5/afp.conf.5.md:888
 msgid "The following LDAP options must be configured for Netatalk:"
 msgstr "Netatalk では以下の LDAP オプションが設定されなければならない:"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:893
+#: manpages/man5/afp.conf.5.md:890
 #, no-wrap
 msgid "ldap auth method = <none|simple\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:895
+#: manpages/man5/afp.conf.5.md:894
 #, no-wrap
-msgid "> Authentication method: **none** | **simple**\n"
-msgstr "> 認証方式: **none** | **simple**\n"
+msgid "> > anonymous LDAP bind\n"
+msgstr "> > 匿名 LDAP 認証\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:897 manpages/man5/afp.conf.5.md:1094
-msgid "none"
+#: manpages/man5/afp.conf.5.md:896
+#, no-wrap
+msgid "> simple\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:899
+#: manpages/man5/afp.conf.5.md:898
 #, no-wrap
-msgid "> anonymous LDAP bind\n"
-msgstr "> 匿名 LDAP 認証\n"
+msgid "> > simple LDAP bind\n"
+msgstr "> > 簡易 LDAP 認証\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:901
-msgid "simple"
-msgstr ""
-
-#. type: Plain text
-#: manpages/man5/afp.conf.5.md:903
-#, no-wrap
-msgid "> simple LDAP bind\n"
-msgstr "> 簡易 LDAP 認証\n"
-
-#. type: Plain text
-#: manpages/man5/afp.conf.5.md:905
+#: manpages/man5/afp.conf.5.md:900
 #, no-wrap
 msgid "ldap auth dn = <dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:907
+#: manpages/man5/afp.conf.5.md:902
 #, no-wrap
 msgid "> Distinguished Name of the user for simple bind.\n"
 msgstr "> 簡易認証でのユーザーの識別名。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:909
+#: manpages/man5/afp.conf.5.md:904
 #, no-wrap
 msgid "ldap auth pw = <password\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:911
+#: manpages/man5/afp.conf.5.md:906
 #, no-wrap
 msgid "> Password for simple bind.\n"
 msgstr "> 簡易認証でのパスワード。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:913
+#: manpages/man5/afp.conf.5.md:908
 msgid "ldap uri = <ldap://somehost:1234/\\> **(G)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:918
+#: manpages/man5/afp.conf.5.md:913
 #, no-wrap
 msgid ""
 "> Specifies the LDAP URI of the server to connect to. The URI scheme may\n"
@@ -2588,107 +2577,109 @@ msgstr ""
 "サポートを必要とする時のみ必要。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:920
-msgid "You can use **afpldaptest**(1) to syntactically check your config."
-msgstr "設定の構文的なチェックのために **afpldaptest**(1) を使うこともできる。"
+#: manpages/man5/afp.conf.5.md:915
+#, no-wrap
+msgid "> You can use **afpldaptest**(1) to syntactically check your config.\n"
+msgstr "> 設定の構文的なチェックのために **afpldaptest**(1) を使うこともできる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:922
+#: manpages/man5/afp.conf.5.md:917
 #, no-wrap
 msgid "ldap userbase = <base dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:924
+#: manpages/man5/afp.conf.5.md:919
 #, no-wrap
 msgid "> DN of the user container in LDAP.\n"
 msgstr "> LDAP 内のユーザーコンテナの DN。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:926
+#: manpages/man5/afp.conf.5.md:921
 #, no-wrap
 msgid "ldap userscope = <scope\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:928
+#: manpages/man5/afp.conf.5.md:923
 #, no-wrap
 msgid "> Search scope for user search: **base** | **one** | **sub**\n"
 msgstr "> ユーザー検索での検索スコープ: **base** | **one** | **sub**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:930
+#: manpages/man5/afp.conf.5.md:925
 #, no-wrap
 msgid "ldap groupbase = <base dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:932
+#: manpages/man5/afp.conf.5.md:927
 #, no-wrap
 msgid "> DN of the group container in LDAP.\n"
 msgstr "> LDAP 内のグループコンテナの DN。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:934
+#: manpages/man5/afp.conf.5.md:929
 #, no-wrap
 msgid "ldap groupscope = <scope\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:936
+#: manpages/man5/afp.conf.5.md:931
 #, no-wrap
 msgid "> Search scope for group search: **base** | **one** | **sub**\n"
 msgstr "> グループ検索での検索スコープ: **base** | **one** | **sub**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:938
+#: manpages/man5/afp.conf.5.md:933
 #, no-wrap
 msgid "ldap uuid attr = <dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:940
+#: manpages/man5/afp.conf.5.md:935
 #, no-wrap
 msgid "> Name of the LDAP attribute with the UUIDs.\n"
 msgstr "> UUID のある LDAP 属性の名前。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:942
-msgid "Note: this is used both for users and groups."
-msgstr "注記: これはユーザーでもグループでも双方で用いられる。"
+#: manpages/man5/afp.conf.5.md:937
+#, no-wrap
+msgid "> Note: this is used both for users and groups.\n"
+msgstr "> 注記: これはユーザーでもグループでも双方で用いられる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:944
+#: manpages/man5/afp.conf.5.md:939
 #, no-wrap
 msgid "ldap name attr = <dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:946
+#: manpages/man5/afp.conf.5.md:941
 #, no-wrap
 msgid "> Name of the LDAP attribute with the users short name.\n"
 msgstr "> ユーザーの短縮名のある LDAP 属性の名前。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:948
+#: manpages/man5/afp.conf.5.md:943
 #, no-wrap
 msgid "ldap group attr = <dn\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:950
+#: manpages/man5/afp.conf.5.md:945
 #, no-wrap
 msgid "> Name of the LDAP attribute with the groups short name.\n"
 msgstr "> グループの短縮名のある LDAP 属性の名前。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:952
+#: manpages/man5/afp.conf.5.md:947
 #, no-wrap
 msgid "ldap uuid string = <STRING\\> **(G)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:955
+#: manpages/man5/afp.conf.5.md:950
 #, no-wrap
 msgid ""
 "> Format of the uuid string in the directory. A series of x and -, where\n"
@@ -2699,18 +2690,19 @@ msgstr ""
 "はそれぞれ区切り文字である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:957
-msgid "Default: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-msgstr "デフォルト: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+#: manpages/man5/afp.conf.5.md:952
+#, no-wrap
+msgid "> Default: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\n"
+msgstr "> デフォルト: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:959
+#: manpages/man5/afp.conf.5.md:954
 #, no-wrap
 msgid "ldap uuid encoding = <string | ms-guid (default: string)\\> **(G)**\n"
 msgstr "ldap uuid encoding = <string | ms-guid (デフォルト: string)\\> **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:966
+#: manpages/man5/afp.conf.5.md:961
 #, no-wrap
 msgid ""
 "> Format of the UUID of the LDAP attribute, allows usage of the binary\n"
@@ -2729,41 +2721,43 @@ msgstr ""
 "表記とバイナリー形式が相互に変換される。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:968
-msgid "See also the options **ldap user filter** and **ldap group filter**."
-msgstr ""
-"オプション **ldap user filter** 及び **ldap group filter** も参照のこと。"
-
-#. type: Plain text
-#: manpages/man5/afp.conf.5.md:970
-msgid "string"
-msgstr ""
-
-#. type: Plain text
-#: manpages/man5/afp.conf.5.md:972
+#: manpages/man5/afp.conf.5.md:963
 #, no-wrap
-msgid "> UUID is a string, use with e.g. OpenDirectory.\n"
-msgstr "> UUID は文字列。例えば OpenDirectory とで使用する。\n"
+msgid "> See also the options **ldap user filter** and **ldap group filter**.\n"
+msgstr "> オプション **ldap user filter** 及び **ldap group filter** も参照のこと。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:974
-msgid "ms-guid"
+#: manpages/man5/afp.conf.5.md:965
+#, no-wrap
+msgid "> string\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:976
+#: manpages/man5/afp.conf.5.md:967
 #, no-wrap
-msgid "> Binary objectGUID from Active Directory\n"
-msgstr "> Active Directory からの objectGUID バイナリー。\n"
+msgid "> > UUID is a string, use with e.g. OpenDirectory.\n"
+msgstr "> > UUID は文字列。例えば OpenDirectory とで使用する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:978
+#: manpages/man5/afp.conf.5.md:969
+#, no-wrap
+msgid "> ms-guid\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:971
+#, no-wrap
+msgid "> > Binary objectGUID from Active Directory\n"
+msgstr "> > Active Directory からの objectGUID バイナリー。\n"
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:973
 #, no-wrap
 msgid "ldap user filter = <STRING (default: unused)\\> **(G)**\n"
 msgstr "ldap user filter = <STRING (デフォルト: 未使用)\\> **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:982
+#: manpages/man5/afp.conf.5.md:977
 #, no-wrap
 msgid ""
 "> Optional LDAP filter that matches user objects. This is necessary for\n"
@@ -2775,18 +2769,19 @@ msgstr ""
 "Active Directory 環境で必要。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:984
-msgid "Recommended setting for Active Directory: **objectClass=user**."
-msgstr "Active Directory での推奨設定: **objectClass=user**"
+#: manpages/man5/afp.conf.5.md:979
+#, no-wrap
+msgid "> Recommended setting for Active Directory: **objectClass=user**.\n"
+msgstr "> Active Directory での推奨設定: **objectClass=user**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:986
+#: manpages/man5/afp.conf.5.md:981
 #, no-wrap
 msgid "ldap group filter = <STRING (default: unused)\\> **(G)**\n"
 msgstr "ldap group filter = <STRING (デフォルト: 未使用)\\> **(G)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:990
+#: manpages/man5/afp.conf.5.md:985
 #, no-wrap
 msgid ""
 "> Optional LDAP filter that matches group objects. This is necessary for\n"
@@ -2798,18 +2793,19 @@ msgstr ""
 "Active Directory 環境で必要。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:992
-msgid "Recommended setting for Active Directory: **objectClass=group**."
-msgstr "Active Directory での推奨設定: **objectClass=group**"
+#: manpages/man5/afp.conf.5.md:987
+#, no-wrap
+msgid "> Recommended setting for Active Directory: **objectClass=group**.\n"
+msgstr "> Active Directory での推奨設定: **objectClass=group**\n"
 
 #. type: Title #
-#: manpages/man5/afp.conf.5.md:993
+#: manpages/man5/afp.conf.5.md:988
 #, no-wrap
 msgid "Explanation of Volume Parameters"
 msgstr "ボリュームパラメータの説明"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1002
+#: manpages/man5/afp.conf.5.md:997
 msgid ""
 "The section name defines the volume name. No two volumes may have the same "
 "name. The volume name cannot contain the ':' character. The volume name is "
@@ -2822,25 +2818,25 @@ msgstr ""
 "される。UTF8-MAC ボリューム名は volnamelen パラメータで制限される。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1004
+#: manpages/man5/afp.conf.5.md:999
 #, no-wrap
 msgid "path = <PATH\\> **(V)**\n"
 msgstr "mac charset = <CHARSET\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1006
+#: manpages/man5/afp.conf.5.md:1001
 #, no-wrap
 msgid "> The path name must be a fully qualified path name.\n"
 msgstr "> パス名は完全修飾パス名でなければならない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1008
+#: manpages/man5/afp.conf.5.md:1003
 #, no-wrap
 msgid "vol size limit = <size in MiB\\> **(V)**\n"
 msgstr "vol size limit = <MiB 単位でのサイズ\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1013
+#: manpages/man5/afp.conf.5.md:1008
 #, no-wrap
 msgid ""
 "> Useful for Time Machine: limits the reported volume size, thus\n"
@@ -2855,13 +2851,13 @@ msgstr ""
 "に制限する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1015
+#: manpages/man5/afp.conf.5.md:1010
 #, no-wrap
 msgid "> **IMPORTANT**\n"
 msgstr "> **重要**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1023
+#: manpages/man5/afp.conf.5.md:1018
 #, no-wrap
 msgid ""
 "> This is an approximated calculation taking into\n"
@@ -2881,13 +2877,13 @@ msgstr ""
 "を読む、そしてお互いの乗算をする。ことによって行われる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1025
+#: manpages/man5/afp.conf.5.md:1020
 #, no-wrap
 msgid "valid users = <user @group\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1029
+#: manpages/man5/afp.conf.5.md:1024
 #, no-wrap
 msgid ""
 "> The allow option allows the users and groups that access a share to be\n"
@@ -2898,19 +2894,19 @@ msgstr ""
 "@ プレフィックスで明示する。例:\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1031
+#: manpages/man5/afp.conf.5.md:1026
 #, no-wrap
 msgid "    valid users = user @group\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1033
+#: manpages/man5/afp.conf.5.md:1028
 #, no-wrap
 msgid "invalid users = <users/groups\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1036
+#: manpages/man5/afp.conf.5.md:1031
 #, no-wrap
 msgid ""
 "> The deny option specifies users and groups who are not allowed access to\n"
@@ -2920,13 +2916,13 @@ msgstr ""
 "\"valid users\" オプションと同じフォーマットである。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1038
+#: manpages/man5/afp.conf.5.md:1033
 #, no-wrap
 msgid "hosts allow = <IP host address/IP netmask bits \\[ ... \\]\\> **(V)**\n"
 msgstr "hosts allow = <IPホストアドレス/IPマスクビット \\[ ... \\]\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1042
+#: manpages/man5/afp.conf.5.md:1037
 #, no-wrap
 msgid ""
 "> Only listed hosts and networks are allowed, all others are rejected. The\n"
@@ -2938,35 +2934,37 @@ msgstr ""
 "のドット区切りフォーマット、IPv6の16進数フォーマットのどちらでもよい。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1044
-msgid "Example: hosts allow = 10.1.0.0/16 10.2.1.100 2001:0db8:1234::/48"
-msgstr "例: hosts allow = 10.1.0.0/16 10.2.1.100 2001:0db8:1234::/48"
+#: manpages/man5/afp.conf.5.md:1039
+#, no-wrap
+msgid "> Example: hosts allow = 10.1.0.0/16 10.2.1.100 2001:0db8:1234::/48\n"
+msgstr "> 例: hosts allow = 10.1.0.0/16 10.2.1.100 2001:0db8:1234::/48\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1046
+#: manpages/man5/afp.conf.5.md:1041
 #, no-wrap
 msgid "hosts deny = <IP host address/IP netmask bits \\[ ... \\]\\> **(V)**\n"
 msgstr "hosts deny = <IPホストアドレス/IPマスクビット \\[ ... \\]\\> **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1048
+#: manpages/man5/afp.conf.5.md:1043
 #, no-wrap
 msgid "> Listed hosts and nets are rejected, all others are allowed.\n"
 msgstr "> 列挙されたホストとネットのみが拒否され、ほかの全ては許可される。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1050
-msgid "Example: hosts deny = 192.168.100/24 10.1.1.1 2001:db8::1428:57ab"
-msgstr "例: hosts deny = 192.168.100/24 10.1.1.1 2001:db8::1428:57ab"
+#: manpages/man5/afp.conf.5.md:1045
+#, no-wrap
+msgid "> Example: hosts deny = 192.168.100/24 10.1.1.1 2001:db8::1428:57ab\n"
+msgstr "> 例: hosts deny = 192.168.100/24 10.1.1.1 2001:db8::1428:57ab\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1052
+#: manpages/man5/afp.conf.5.md:1047
 #, no-wrap
 msgid "cnid scheme = <backend\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1055
+#: manpages/man5/afp.conf.5.md:1050
 #, no-wrap
 msgid ""
 "> set the CNID backend to be used for the volume, default is\n"
@@ -2978,7 +2976,7 @@ msgstr ""
 "\\[@compiled_backends@\\] である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1060
+#: manpages/man5/afp.conf.5.md:1055
 #, no-wrap
 msgid ""
 "> The \"mysql\" backend requires the system administrator to configure a\n"
@@ -2988,15 +2986,15 @@ msgstr ""
 "MySQL データベース インスタンスを構成する必要がある。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1062 manpages/man5/afp.conf.5.md:1098
-#: manual/AppleTalk.md:154 manual/Configuration.md:832 manual/Installation.md:4
+#: manpages/man5/afp.conf.5.md:1057 manpages/man5/afp.conf.5.md:1093
+#: manual/AppleTalk.md:154 manual/Configuration.md:827 manual/Installation.md:4
 #: manual/Upgrading.md:42
 #, no-wrap
 msgid "> **WARNING**\n"
 msgstr "> **警告**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1066
+#: manpages/man5/afp.conf.5.md:1061
 #, no-wrap
 msgid ""
 "> Do *NOT* use the \"last\" backend for volumes, because **afpd** relies\n"
@@ -3007,13 +3005,13 @@ msgstr ""
 "データベースに重く依存しているので、このバックエンドをボリュームに使用するのは推奨*されていない*。エイリアスはおそらく機能しないだろうし、ファイル名のマングリングもサポートされていない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1068
+#: manpages/man5/afp.conf.5.md:1063
 #, no-wrap
 msgid "ea = <sys|samba|ad|none\\> (default: auto detect) **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1071
+#: manpages/man5/afp.conf.5.md:1066
 #, no-wrap
 msgid ""
 "> Specify how Extended Attributes and Classic Mac OS resource forks are\n"
@@ -3021,63 +3019,67 @@ msgid ""
 msgstr "> 拡張属性およびリソースフォークをどのように保存するか指定する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1077
+#: manpages/man5/afp.conf.5.md:1072
+#, no-wrap
 msgid ""
-"By default, we attempt to enable **sys** with a fallback to **ad**.  For the "
-"auto detection to work, the volume needs to be writable because we attempt "
-"to set an EA on the shared directory itself.  If **read only = yes** is set, "
-"we fallback to **sys**.  Use explicit \"**ea = ad|none**\" for read-only "
-"volumes where appropriate."
+"> By default, we attempt to enable **sys** with a fallback to **ad**.\n"
+"For the auto detection to work, the volume needs to be writable\n"
+"because we attempt to set an EA on the shared directory itself.\n"
+"If **read only = yes** is set, we fallback to **sys**.\n"
+"Use explicit \"**ea = ad|none**\" for read-only volumes where appropriate.\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1079
-msgid "sys"
+#: manpages/man5/afp.conf.5.md:1074
+#, no-wrap
+msgid "> sys\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:1076
+#, no-wrap
+msgid "> > Use filesystem Extended Attributes.\n"
+msgstr "> > ファイルシステムの拡張属性を使う。\n"
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:1078
+#, no-wrap
+msgid "> samba\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:1081
 #, no-wrap
-msgid "> Use filesystem Extended Attributes.\n"
-msgstr "> ファイルシステムの拡張属性を使う。\n"
+msgid ""
+"> > Use filesystem Extended Attributes, but append a 0 byte to each xattr in\n"
+"order to be compatible with Samba's vfs_streams_xattr.\n"
+msgstr "> > ファイルシステムの拡張属性を使うが、Sambaのvfs_streams_xattrとの互換性の目的で、それぞれの拡張属性に値がゼロの1バイトを追加する。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:1083
-msgid "samba"
+#, no-wrap
+msgid "> ad\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1086
+#: manpages/man5/afp.conf.5.md:1087
 #, no-wrap
 msgid ""
-"> Use filesystem Extended Attributes, but append a 0 byte to each xattr in\n"
-"order to be compatible with Samba's vfs_streams_xattr.\n"
-msgstr "> ファイルシステムの拡張属性を使うが、Sambaのvfs_streams_xattrとの互換性の目的で、それぞれの拡張属性に値がゼロの1バイトを追加する。\n"
-
-#. type: Plain text
-#: manpages/man5/afp.conf.5.md:1088
-msgid "ad"
-msgstr ""
-
-#. type: Plain text
-#: manpages/man5/afp.conf.5.md:1092
-#, no-wrap
-msgid ""
-"> Use AppleDouble v2 metadata stored as files in *.AppleDouble* directories.\n"
+"> > Use AppleDouble v2 metadata stored as files in *.AppleDouble* directories.\n"
 "This should only be used when the host's filesystem does not support\n"
 "Extended Attributes.\n"
 msgstr ""
-"> *.AppleDouble* ディレクトリ内のファイルとして格納された AppleDouble v2 メタデータを使用する。\n"
+"> > *.AppleDouble* ディレクトリ内のファイルとして格納された AppleDouble v2 メタデータを使用する。\n"
 "ファイルシステムが拡張属性をサポートしていない場合にのみ使用するべき。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1096
+#: manpages/man5/afp.conf.5.md:1091
 #, no-wrap
-msgid "> No Extended Attributes support.\n"
-msgstr "> 拡張属性をサポートしない。\n"
+msgid "> > No Extended Attributes support.\n"
+msgstr "> > 拡張属性をサポートしない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1101
+#: manpages/man5/afp.conf.5.md:1096
 #, no-wrap
 msgid ""
 "> The **samba** option should not be used on a volume that was previously\n"
@@ -3087,13 +3089,13 @@ msgstr ""
 "に設定されたボリュームでは使用しないでください。これにより、データが失われる可能性がある。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1103
+#: manpages/man5/afp.conf.5.md:1098
 #, no-wrap
 msgid "mac charset = <charset\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1108
+#: manpages/man5/afp.conf.5.md:1103
 #, no-wrap
 msgid ""
 "> specifies the Mac client charset for this Volume, e.g. *MAC_ROMAN*,\n"
@@ -3107,13 +3109,13 @@ msgstr ""
 "セクションで全体的にセットしたキャラクターセットと異なるというボリュームを必要とする時のみ必須である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1110
+#: manpages/man5/afp.conf.5.md:1105
 #, no-wrap
 msgid "casefold = <option\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1113
+#: manpages/man5/afp.conf.5.md:1108
 #, no-wrap
 msgid ""
 "> The casefold option handles, if the case of filenames should be changed.\n"
@@ -3123,37 +3125,37 @@ msgstr ""
 "オプションが処理する。有効なオプションは:\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1115
+#: manpages/man5/afp.conf.5.md:1110
 #, no-wrap
-msgid "**tolower** - Lowercases names in both directions.\n"
-msgstr "**tolower** - 双方向で名前を小文字に変換する。\n"
+msgid "> **tolower** - Lowercases names in both directions.\n"
+msgstr "> **tolower** - 双方向で名前を小文字に変換する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1117
+#: manpages/man5/afp.conf.5.md:1112
 #, no-wrap
-msgid "**toupper** - Uppercases names in both directions.\n"
-msgstr "**toupper** - 双方向で名前を大文字に変換する。\n"
+msgid "> **toupper** - Uppercases names in both directions.\n"
+msgstr "> **toupper** - 双方向で名前を大文字に変換する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1119
+#: manpages/man5/afp.conf.5.md:1114
 #, no-wrap
-msgid "**xlatelower** - Client sees lowercase, server sees uppercase.\n"
-msgstr "**xlatelower** - クライアントでは小文字に見えて、サーバでは大文字に見える。\n"
+msgid "> **xlatelower** - Client sees lowercase, server sees uppercase.\n"
+msgstr "> **xlatelower** - クライアントでは小文字に見えて、サーバでは大文字に見える。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1121
+#: manpages/man5/afp.conf.5.md:1116
 #, no-wrap
-msgid "**xlateupper** - Client sees uppercase, server sees lowercase.\n"
-msgstr "**xlateupper** - クライアントでは大文字に見えて、サーバでは小文字にみえる。\n"
+msgid "> **xlateupper** - Client sees uppercase, server sees lowercase.\n"
+msgstr "> **xlateupper** - クライアントでは大文字に見えて、サーバでは小文字にみえる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1123
+#: manpages/man5/afp.conf.5.md:1118
 #, no-wrap
 msgid "password = <password\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1127
+#: manpages/man5/afp.conf.5.md:1122
 #, no-wrap
 msgid ""
 "> This option allows you to set a volume password, which can be a maximum\n"
@@ -3164,13 +3166,13 @@ msgstr ""
 "8 文字の長さ（これを記入するときには ASCII を強く推奨）\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1129
+#: manpages/man5/afp.conf.5.md:1124
 #, no-wrap
 msgid "file perm = <mode\\> **(V)**; directory perm = <mode\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1133
+#: manpages/man5/afp.conf.5.md:1128
 #, no-wrap
 msgid ""
 "> Add(or) with the client requested permissions: **file perm** is for files\n"
@@ -3181,14 +3183,14 @@ msgstr ""
 "はファイルにのみ、**directory perm** はディレクトリにのみ用いる。\n"
 "\"**unix priv = no**\" と共に用いてはならない。\n"
 
-#. type: Title ##
-#: manpages/man5/afp.conf.5.md:1134
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:1130
 #, no-wrap
-msgid "Example: Volume for a collaborative workgroup"
-msgstr "例：共同作業グループ向けのボリューム"
+msgid "> **Example**: Volume for a collaborative workgroup\n"
+msgstr "> **例**：共同作業グループ向けのボリューム\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1138
+#: manpages/man5/afp.conf.5.md:1133
 #, no-wrap
 msgid ""
 "    file perm = 0660\n"
@@ -3196,49 +3198,49 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1140
+#: manpages/man5/afp.conf.5.md:1135
 #, no-wrap
 msgid "umask = <mode\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1142
+#: manpages/man5/afp.conf.5.md:1137
 #, no-wrap
 msgid "> set perm mask. Don't use with \"**unix priv = no**\".\n"
 msgstr "> 権限のマスクを設定する。\"**unix priv = no**\" と共に用いてはならない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1144
+#: manpages/man5/afp.conf.5.md:1139
 #, no-wrap
 msgid "preexec = <command\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1146
+#: manpages/man5/afp.conf.5.md:1141
 #, no-wrap
 msgid "> command to be run when the volume is mounted\n"
 msgstr "> ボリュームがマウントされる時に実行されるコマンド\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1148
+#: manpages/man5/afp.conf.5.md:1143
 #, no-wrap
 msgid "postexec = <command\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1150
+#: manpages/man5/afp.conf.5.md:1145
 #, no-wrap
 msgid "> command to be run when the volume is closed\n"
 msgstr "> ボリュームが閉じられる時に実行されるコマンド\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1152
+#: manpages/man5/afp.conf.5.md:1147
 #, no-wrap
 msgid "rolist = <users/groups\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1155
+#: manpages/man5/afp.conf.5.md:1150
 #, no-wrap
 msgid ""
 "> Allows certain users and groups to have read-only access to a share.\n"
@@ -3248,13 +3250,13 @@ msgstr ""
 "allow オプションに準ずる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1157
+#: manpages/man5/afp.conf.5.md:1152
 #, no-wrap
 msgid "rwlist = <users/groups\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1160
+#: manpages/man5/afp.conf.5.md:1155
 #, no-wrap
 msgid ""
 "> Allows certain users and groups to have read/write access to a share.\n"
@@ -3264,13 +3266,13 @@ msgstr ""
 "allow オプションに準ずる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1162
+#: manpages/man5/afp.conf.5.md:1157
 #, no-wrap
 msgid "veto files = <vetoed names\\> **(V)**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1166
+#: manpages/man5/afp.conf.5.md:1161
 #, no-wrap
 msgid ""
 "> hide files and directories,where the path matches one of the '/'\n"
@@ -3283,24 +3285,24 @@ msgstr ""
 "= veto1/veto2/\"。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:1167
+#: manpages/man5/afp.conf.5.md:1162
 #, no-wrap
 msgid "Volume options"
 msgstr "ボリュームオプション"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1170
+#: manpages/man5/afp.conf.5.md:1165
 msgid "Boolean volume options."
 msgstr "ブーリアン型のボリュームオプション。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1172
+#: manpages/man5/afp.conf.5.md:1167
 #, no-wrap
 msgid "acls = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "acls = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1175
+#: manpages/man5/afp.conf.5.md:1170
 #, no-wrap
 msgid ""
 "> Whether to flag volumes as supporting ACLs. If ACL support is compiled\n"
@@ -3310,13 +3312,13 @@ msgstr ""
 "サポートでコンパイルしていれば、これはデフォルトで yes。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1177
+#: manpages/man5/afp.conf.5.md:1172
 #, no-wrap
 msgid "case sensitive = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "case sensitive = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1181
+#: manpages/man5/afp.conf.5.md:1176
 #, no-wrap
 msgid ""
 "> Whether to flag volumes as supporting case-sensitive filenames. If the\n"
@@ -3328,7 +3330,7 @@ msgstr ""
 "を設定せよ。しかしながらこれは完全には確かめられていない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1187
+#: manpages/man5/afp.conf.5.md:1182
 #, no-wrap
 msgid ""
 "> In spite of being case sensitive as a matter of fact, netatalk 3.1.3 and\n"
@@ -3341,13 +3343,13 @@ msgstr ""
 "からはデフォルトで正しく通知される。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1189
+#: manpages/man5/afp.conf.5.md:1184
 #, no-wrap
 msgid "cnid dev = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "cnid dev = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1192
+#: manpages/man5/afp.conf.5.md:1187
 #, no-wrap
 msgid ""
 "> Whether to use the device number in the CNID backends. Helps when the\n"
@@ -3357,13 +3359,13 @@ msgstr ""
 "例えばクラスターなどでリブートを経るとデバイス番号が固定ではない時有用。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1194
+#: manpages/man5/afp.conf.5.md:1189
 #, no-wrap
 msgid "convert appledouble = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "convert appledouble = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1200
+#: manpages/man5/afp.conf.5.md:1195
 #, no-wrap
 msgid ""
 "> Whether automatic conversion from AppleDouble v2 to Extended Attributes\n"
@@ -3378,13 +3380,13 @@ msgstr ""
 "に設定することもできる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1202
+#: manpages/man5/afp.conf.5.md:1197
 #, no-wrap
 msgid "delete veto files = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "delete veto files = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1208
+#: manpages/man5/afp.conf.5.md:1203
 #, no-wrap
 msgid ""
 "> This option is used when Netatalk is attempting to delete a directory\n"
@@ -3400,23 +3402,21 @@ msgstr ""
 "ファイルないしはディレクトリを含んでいたら、ディレクトリの削除は失敗するであろう。これは通常あなたの望むところの動作である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1211
+#: manpages/man5/afp.conf.5.md:1206
+#, no-wrap
 msgid ""
-"If this option is set to yes, then Netatalk will attempt to recursively "
-"delete any files and directories within the vetoed directory."
-msgstr ""
-"もしこのオプションが yes に設定されていたら、Netatalk は veto 化ディレクト"
-"リ・ディレクトリ内も含めあらゆるファイル、ディレクトリを再帰的に削除しようと"
-"するであろう。"
+"> If this option is set to yes, then Netatalk will attempt to recursively\n"
+"delete any files and directories within the vetoed directory.\n"
+msgstr "> もしこのオプションが yes に設定されていたら、Netatalk は veto 化ディレクトリ・ディレクトリ内も含めあらゆるファイル、ディレクトリを再帰的に削除しようとするであろう。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1213
+#: manpages/man5/afp.conf.5.md:1208
 #, no-wrap
 msgid "follow symlinks = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "follow symlinks = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1219
+#: manpages/man5/afp.conf.5.md:1214
 #, no-wrap
 msgid ""
 "> The default setting is false thus symlinks are not followed on the\n"
@@ -3432,7 +3432,7 @@ msgstr ""
 "ボリューム以外を指しているかもしれない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1224
+#: manpages/man5/afp.conf.5.md:1219
 #, no-wrap
 msgid ""
 "> This option will subtly break when the symlinks point across filesystem\n"
@@ -3440,13 +3440,13 @@ msgid ""
 msgstr "> シンボリックリンクがファイルシステムの境界をまたいで張られている時、このオプションは巧妙に断ち切る。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1226
+#: manpages/man5/afp.conf.5.md:1221
 #, no-wrap
 msgid "invisible dots = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "invisible dots = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1234
+#: manpages/man5/afp.conf.5.md:1229
 #, no-wrap
 msgid ""
 "> make dot files invisible. WARNING: enabling this option will lead to\n"
@@ -3466,13 +3466,13 @@ msgstr ""
 "でもターミナルでもドットではじまるファイルはいずれにしても隠しファイルなので、完全に無駄である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1236
+#: manpages/man5/afp.conf.5.md:1231
 #, no-wrap
 msgid "legacy volume size = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "legacy volume size = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1240
+#: manpages/man5/afp.conf.5.md:1235
 #, no-wrap
 msgid ""
 "> Limit disk size reporting to 2GB for legacy clients. This can be used\n"
@@ -3484,13 +3484,13 @@ msgstr ""
 "クライアントを使用している古い Macintosh で使用できる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1242
+#: manpages/man5/afp.conf.5.md:1237
 #, no-wrap
 msgid "volume name = <STRING\\> (default: section name in lowercase) **(V)**\n"
 msgstr "volume name = <STRING\\> (デフォルト: 小文字のセクション名) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1246
+#: manpages/man5/afp.conf.5.md:1241
 #, no-wrap
 msgid ""
 "> The volume name option specifies the name of the shared AFP volume.\n"
@@ -3499,13 +3499,13 @@ msgid ""
 msgstr "> ボリュームの名前を指定する。デフォルトでは、ボリュームが定義されている ini ファイルの小文字に変換されたセクション名となる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1248
+#: manpages/man5/afp.conf.5.md:1243
 #, no-wrap
 msgid "network ids = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "network ids = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1251
+#: manpages/man5/afp.conf.5.md:1246
 #, no-wrap
 msgid ""
 "> Whether the server support network ids. Setting this to *no* will result\n"
@@ -3515,13 +3515,13 @@ msgstr ""
 "に設定すると結果としてクライアントは ACL AFP 機能を使わなくなる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1253
+#: manpages/man5/afp.conf.5.md:1248
 #, no-wrap
 msgid "preexec close = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "preexec close = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1256
+#: manpages/man5/afp.conf.5.md:1251
 #, no-wrap
 msgid ""
 "> A non-zero return code from preexec close the volume being immediately,\n"
@@ -3531,13 +3531,13 @@ msgstr ""
 "以外のリターンコードで、クライアントがボリュームをマウントする／見ることを防ぐために当該ボリュームを即座に閉じる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1258
+#: manpages/man5/afp.conf.5.md:1253
 #, no-wrap
 msgid "prodos = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "prodos = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1262
+#: manpages/man5/afp.conf.5.md:1257
 #, no-wrap
 msgid ""
 "> Enable ProDOS support. This option should only be enabled for volumes\n"
@@ -3550,13 +3550,13 @@ msgstr ""
 "に制限する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1264
+#: manpages/man5/afp.conf.5.md:1259
 #, no-wrap
 msgid "read only = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "read only = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1267
+#: manpages/man5/afp.conf.5.md:1262
 #, no-wrap
 msgid ""
 "> Specifies the share as being read only for all users. Overwrites\n"
@@ -3566,13 +3566,13 @@ msgstr ""
 "**ea = none** で上書きされる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1269
+#: manpages/man5/afp.conf.5.md:1264
 #, no-wrap
 msgid "search db = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "search db = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1274
+#: manpages/man5/afp.conf.5.md:1269
 #, no-wrap
 msgid ""
 "> Use fast CNID database namesearch instead of slow recursive filesystem\n"
@@ -3587,13 +3587,13 @@ msgstr ""
 "CNID db のボリュームのみで動作する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1276
+#: manpages/man5/afp.conf.5.md:1271
 #, no-wrap
 msgid "stat vol = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "stat vol = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1279
+#: manpages/man5/afp.conf.5.md:1274
 #, no-wrap
 msgid ""
 "> Whether to stat volume path when enumerating volumes list, useful for\n"
@@ -3604,25 +3604,25 @@ msgstr ""
 "スクリプトで作成されたボリュームに有用である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1281
+#: manpages/man5/afp.conf.5.md:1276
 #, no-wrap
 msgid "time machine = <BOOLEAN\\> (default: *no*) **(V)**\n"
 msgstr "time machine = <BOOLEAN\\> (デフォルト: *no*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1283
+#: manpages/man5/afp.conf.5.md:1278
 #, no-wrap
 msgid "> Whether to enable Time Machine support for this volume.\n"
 msgstr "> このボリュームの Time Machine サポートを有効にするかどうか。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1285
+#: manpages/man5/afp.conf.5.md:1280
 #, no-wrap
 msgid "unix priv = <BOOLEAN\\> (default: *yes*) **(V)**\n"
 msgstr "unix priv = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1288
+#: manpages/man5/afp.conf.5.md:1283
 #, no-wrap
 msgid ""
 "> Whether to use AFP3 UNIX privileges. This should be set for OS X\n"
@@ -3633,13 +3633,13 @@ msgstr ""
 "及び `umask` も参照。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:1291
+#: manpages/man5/afp.conf.5.md:1286
 #, no-wrap
 msgid "Example: Modern Mac clients"
 msgstr "例：現代の Mac クライアント"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1296
+#: manpages/man5/afp.conf.5.md:1291
 msgid ""
 "This enables Spotlight and AFP stats if Netatalk was built with Spotlight "
 "and AFP stats support. The **mimic model** option is used to make the server "
@@ -3650,12 +3650,12 @@ msgstr ""
 "る。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1298
+#: manpages/man5/afp.conf.5.md:1293
 msgid "The home directory is mounted on */home/{user}/afp-data*."
 msgstr "ホームディレクトリは */home/{user}/afp-data* にマウントされる。"
 
 #. type: Fenced code block
-#: manpages/man5/afp.conf.5.md:1299
+#: manpages/man5/afp.conf.5.md:1294
 #, no-wrap
 msgid ""
 "[Global]\n"
@@ -3669,13 +3669,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:1310
+#: manpages/man5/afp.conf.5.md:1305
 #, no-wrap
 msgid "Example: Classic Mac clients"
 msgstr "例：レトロ Mac クライアント"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1316
+#: manpages/man5/afp.conf.5.md:1311
 msgid ""
 "This enables AppleTalk if Netatalk was built with AppleTalk support.  The "
 "Random Number and ClearTxt authentication modules are used.  The **legacy "
@@ -3686,7 +3686,7 @@ msgstr ""
 "ションはサーバーを BSD デーモンのように見せるために使われる。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1321
+#: manpages/man5/afp.conf.5.md:1316
 msgid ""
 "With **legacy volume size** the volume size is limited to 2 GB for very old "
 "Macs, while **prodos** is used to enable ProDOS boot flags on the volume "
@@ -3697,7 +3697,7 @@ msgstr ""
 "制限される。"
 
 #. type: Fenced code block
-#: manpages/man5/afp.conf.5.md:1322
+#: manpages/man5/afp.conf.5.md:1317
 #, no-wrap
 msgid ""
 "[Global]\n"
@@ -3706,18 +3706,18 @@ msgid ""
 "legacy icon = daemon\n"
 "\n"
 "[mac]\n"
-"name = Mac Volume\n"
+"volume name = Mac Files\n"
 "path = /srv/mac\n"
 "legacy volume size = yes\n"
 "\n"
 "[apple2]\n"
-"name = Apple II Volume\n"
+"volume name = Apple II Files\n"
 "path = /srv/apple2\n"
 "prodos = yes\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1343
+#: manpages/man5/afp.conf.5.md:1338
 msgid ""
 "afpd(8), afppasswd(5), afp_signature.conf(5), extmap.conf(5), cnid_metad(8)"
 msgstr ""

--- a/doc/po/atalkd.conf.5.md.ja.po
+++ b/doc/po/atalkd.conf.5.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 01:41+0100\n"
+"POT-Creation-Date: 2025-03-13 21:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -66,9 +66,9 @@ msgstr "説明"
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
 #: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:49
+#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
 #: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1343
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
@@ -88,9 +88,9 @@ msgstr "著者"
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
 #: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:46 manpages/man4/atalk.4.md:51
+#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
 #: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1345
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
@@ -107,7 +107,7 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1273 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1338 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
 #: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
@@ -122,9 +122,9 @@ msgstr "関連項目"
 #: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:50
 #: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
 #: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/atalkd.conf.5.md:80
-#: manpages/man5/extmap.conf.5.md:18 manpages/man5/papd.conf.5.md:91
-#: manpages/man8/macipgw.8.md:79
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1288
+#: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
+#: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
 msgid "Examples"
 msgstr "例"
@@ -335,7 +335,7 @@ msgstr "Solaris 上の単一インターフェイスと自動検出パラメー�
 #. type: Plain text
 #: manpages/man5/atalkd.conf.5.md:85
 #, no-wrap
-msgid "       le0\n"
+msgid "      le0\n"
 msgstr ""
 
 #. type: Plain text
@@ -346,7 +346,7 @@ msgstr "Linux でも同様。"
 #. type: Plain text
 #: manpages/man5/atalkd.conf.5.md:89
 #, no-wrap
-msgid "       eth0\n"
+msgid "      eth0\n"
 msgstr ""
 
 #. type: Plain text
@@ -366,8 +366,8 @@ msgstr ""
 #: manpages/man5/atalkd.conf.5.md:97
 #, no-wrap
 msgid ""
-"       le0\n"
-"       le1 -seed -net 9461-9471 -zone netatalk -zone Argus\n"
+"      le0\n"
+"      le1 -seed -net 9461-9471 -zone netatalk -zone Argus\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/cnid_dbd.8.md.ja.po
+++ b/doc/po/cnid_dbd.8.md.ja.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 12:40+0100\n"
+"POT-Creation-Date: 2025-03-13 21:12+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -87,7 +87,7 @@ msgstr "説明"
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
 #: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1343
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
@@ -109,7 +109,7 @@ msgstr "著者"
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
 #: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1345
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
@@ -141,7 +141,7 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1273 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1338 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
 #: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
@@ -262,8 +262,8 @@ msgid "> Show version and exit.\n"
 msgstr "> バージョンを表示してから終了する。\n"
 
 #. type: Title ###
-#: manpages/man8/cnid_dbd.8.md:63 manual/Configuration.md:581
-#: manual/Configuration.md:826
+#: manpages/man8/cnid_dbd.8.md:63 manual/Configuration.md:576
+#: manual/Configuration.md:821
 #, no-wrap
 msgid "Configuration"
 msgstr "設定"
@@ -421,31 +421,29 @@ msgstr ""
 msgid "Stop the to be upgraded old version of Netatalk"
 msgstr "これからアップグレードする古いバージョンのNetatalkを停止する"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manpages/man8/cnid_dbd.8.md:136
+#, no-wrap
 msgid ""
-"Using the old Berkeley DB utilities run `db_recover -h <path to .AppleDB>`"
-msgstr ""
-"古いBerkeley DBユーティリティを使って、`db_checkpoint -1 -h <.AppleDBのパス"
-">` を実行する"
+"- Using the old Berkeley DB utilities run\n"
+"`db_recover -h <path to .AppleDB>`\n"
+msgstr "- 古いBerkeley DBユーティリティを使って、`db_checkpoint -1 -h <.AppleDBのパス>` を実行する\n"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manpages/man8/cnid_dbd.8.md:139
+#, no-wrap
 msgid ""
-"Using the new Berkeley DB utilities run `db_upgrade -v -h <path to .AppleDB> "
-"-f cnid2.db`"
-msgstr ""
-"新しいBerkeley DBユーティリティを使って、`db_upgrade -v -h <.AppleDBのパス> "
-"-f cnid2.db` を実行する"
+"- Using the new Berkeley DB utilities run\n"
+"`db_upgrade -v -h <path to .AppleDB> -f cnid2.db`\n"
+msgstr "- 新しいBerkeley DBユーティリティを使って、`db_upgrade -v -h <.AppleDBのパス> -f cnid2.db` を実行する\n"
 
-#. type: Bullet: '- '
+#. type: Plain text
 #: manpages/man8/cnid_dbd.8.md:142
+#, no-wrap
 msgid ""
-"Again using the new Berkeley DB utilities run `db_checkpoint -1 -h <path "
-"to .AppleDB>`"
-msgstr ""
-"再び新しいBerkeley DBユーティリティを使って、`db_checkpoint -1 -h <.AppleDBの"
-"パス>` を実行する"
+"- Again using the new Berkeley DB utilities run\n"
+"`db_checkpoint -1 -h <path to .AppleDB>`\n"
+msgstr "- 再び新しいBerkeley DBユーティリティを使って、`db_checkpoint -1 -h <.AppleDBのパス>` を実行する\n"
 
 #. type: Bullet: '- '
 #: manpages/man8/cnid_dbd.8.md:144


### PR DESCRIPTION
This should give us the correct layout when using the Python markdown library to generate html