### PR TITLE
Update afp_util.c with named copyright holder

### DIFF
--- a/etc/afpd/afp_util.c
+++ b/etc/afpd/afp_util.c
@@ -1,12 +1,8 @@
 /*
- *
+ * Copyright (c) 2002 Joe Marcus Clarke (marcus@marcuscom.com)
  * Copyright (c) 1999 Adrian Sun (asun@zoology.washington.edu)
  * Copyright (c) 1990,1993 Regents of The University of Michigan.
  * All Rights Reserved.  See COPYRIGHT.
- *
- * Copyright (c) 2002 netatalk
- *
- *
  */
 
 #ifdef HAVE_CONFIG_H


### PR DESCRIPTION
This source file was committed by Joe Marcus Clarke in 2002, so adding him as a named copyright holder instead of the generic "netatalk".

The standard project copyright still applies.