### PR TITLE
libatalk: Undefine _FORTIFY_SOURCE macro only when defined

### DIFF
--- a/libatalk/cnid/mysql/cnid_mysql.c
+++ b/libatalk/cnid/mysql/cnid_mysql.c
@@ -8,11 +8,13 @@
  * (at your option) any later version.
  */
 
+#ifdef _FORTIFY_SOURCE
+#undef _FORTIFY_SOURCE
+#endif
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
-
-#undef _FORTIFY_SOURCE
 
 #include <arpa/inet.h>
 #include <errno.h>


### PR DESCRIPTION
Additionally, move the macro to before the first header include, as per GNU docs.