### PR TITLE
GitHub CI: Build on DragonflyBSD without krb5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -406,7 +406,6 @@ jobs:
               cmark \
               db5 \
               iniparser \
-              krb5-devel \
               libevent \
               libgcrypt \
               meson \


### PR DESCRIPTION
The krb5-devel package has gone missing from DragonflyBSD's ports repo. It is probably just a temporary glitch. But let's remove this dependency to unblock the pipeline.