### PR TITLE
Move global temp dir handling to libatalk util module

### DIFF
--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -566,9 +566,9 @@ void afp_over_dsi(AFPObj *obj)
                     setuplog("default:note", NULL, true);
                 debugging = 0;
             } else {
-                char logstr[50];
+                char logstr[MAXPATHLEN + 1];
                 debugging = 1;
-                sprintf(logstr, "/tmp/afpd.%u.XXXXXX", getpid());
+                snprintf(logstr, sizeof(logstr)-1, "%s/afpd.%u.XXXXXX", tmpdir(), getpid());
                 setuplog("default:maxdebug", logstr, true);
             }
         }

--- a/etc/afpd/afprun.c
+++ b/etc/afpd/afprun.c
@@ -46,20 +46,7 @@
 #endif
 
 #include <atalk/logger.h>
-
-/****************************************************************************
- Find a suitable temporary directory. The result should be copied immediately
-  as it may be overwritten by a subsequent call.
-****************************************************************************/
-
-static const char *tmpdir(void)
-{
-    char *p;
-
-    if ((p = getenv("TMPDIR")))
-        return p;
-    return "/tmp";
-}
+#include <atalk/util.h>
 
 /****************************************************************************
 This is a utility function of afprun().

--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -624,7 +624,7 @@ void log_dircache_stat(void)
  */
 void dircache_dump(void)
 {
-    char tmpnam[64];
+    char tmpnam[MAXPATHLEN + 1];
     FILE *dump;
     qnode_t *n = index_queue->next;
     hnode_t *hn;
@@ -634,7 +634,7 @@ void dircache_dump(void)
 
     LOG(log_warning, logtype_afpd, "Dumping directory cache...");
 
-    sprintf(tmpnam, "/tmp/dircache.%u", getpid());
+    snprintf(tmpnam, sizeof(tmpnam)-1, "%s/dircache.%u", tmpdir(), getpid());
     if ((dump = fopen(tmpnam, "w+")) == NULL) {
         LOG(log_error, logtype_afpd, "dircache_dump: %s", strerror(errno));
         return;

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -683,12 +683,12 @@ as_debug(int sig _U_)
     struct gate		*gate;
     struct rtmptab	*rt;
     FILE		*rtmpdebug;
+    char path_atalkdebug[MAXPATHLEN + 1];
 
-    if (_PATH_ATALKDEBUG != NULL) {
-        rtmpdebug = fopen(_PATH_ATALKDEBUG, "w");
-        if (rtmpdebug == NULL) {
-            LOG(log_error, logtype_atalkd, "rtmp: %s", strerror(errno));
-        }
+    snprintf(path_atalkdebug, sizeof(path_atalkdebug)-1, "%s/atalkd.%u.debug", tmpdir(), getpid());
+    rtmpdebug = fopen(path_atalkdebug, "w");
+    if (rtmpdebug == NULL) {
+        LOG(log_error, logtype_atalkd, "rtmp: %s", strerror(errno));
     }
 
 	if (rtmpdebug) {

--- a/etc/atalkd/main.h
+++ b/etc/atalkd/main.h
@@ -1,7 +1,6 @@
 #ifndef ATALKD_MAIN_H
 #define ATALKD_MAIN_H
 
-#define _PATH_ATALKDEBUG	"/tmp/atalkd.debug"
 #define _PATH_ATALKDTMP		"atalkd.tmp"
 
 #include <sys/types.h>

--- a/include/atalk/util.h
+++ b/include/atalk/util.h
@@ -211,6 +211,7 @@ extern int run_cmd(const char *cmd, char **cmd_argv);
 extern char *realpath_safe(const char *path);
 extern const char *basename_safe(const char *path);
 extern char *strtok_quote (char *s, const char *delim);
+extern const char *tmpdir(void);
 
 extern int ochdir(const char *dir, int options);
 extern int ostat(const char *path, struct stat *buf, int options);


### PR DESCRIPTION
This takes the tmpdir() method previously used locally in the afprun module and turns it into a global member of libatalk. Then, apply it instead of local hard coding of /tmp across the codebase.