### PR TITLE
Always use at functions of the standard C library

### DIFF
--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -250,21 +250,10 @@ static int moveandrename(const AFPObj *obj,
         id = cnid_get(vol->v_cdb, sdir->d_did, oldunixname, strlen(oldunixname));
         AFP_CNID_DONE();
 
-#ifndef HAVE_ATFUNCS
-        /* Need full path */
-        free(oldunixname);
-        if ((oldunixname = strdup(ctoupath(vol, sdir, oldname))) == NULL)
-            return AFPERR_PARAM; /* pathname too long */
-#endif /* HAVE_ATFUNCS */
-
         path.st_valid = 0;
         path.u_name = oldunixname;
 
-#ifdef HAVE_ATFUNCS
         opened = of_findnameat(sdir_fd, &path);
-#else
-        opened = of_findname(vol, &path);
-#endif /* HAVE_ATFUNCS */
 
         if (opened) {
             /* reuse struct adouble so it won't break locks */
@@ -282,9 +271,6 @@ static int moveandrename(const AFPObj *obj,
     }
 
     /*
-     * oldunixname now points to either
-     *   a) full pathname of the source fs object (if renameat is not available)
-     *   b) the oldname (renameat is available)
      * we are in the dest folder so we need to use
      *   a) oldunixname for ad_open
      *   b) fchdir sdir_fd before e.g. ad_open or use *at functions where appropriate
@@ -770,10 +756,8 @@ int afp_moveandrename(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U
         memcpy(oldname, cfrombstr(sdir->d_m_name), blength(sdir->d_m_name) + 1);
     }
 
-#ifdef HAVE_ATFUNCS
     if ((sdir_fd = open(".", O_RDONLY)) == -1)
         return AFPERR_MISC;
-#endif
 
     /* get the destination directory */
     if (NULL == ( ddir = dirlookup( vol, did )) ) {
@@ -823,10 +807,8 @@ int afp_moveandrename(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U
     }
 
 exit:
-#ifdef HAVE_ATFUNCS
     if (sdir_fd != -1)
         close(sdir_fd);
-#endif
 
     return( rc );
 }

--- a/etc/afpd/fork.h
+++ b/etc/afpd/fork.h
@@ -69,11 +69,8 @@ extern int          of_closefork (const AFPObj *obj, struct ofork *ofork);
 extern void         of_closevol  (const AFPObj *obj, const struct vol *vol);
 extern void         of_close_all_forks(const AFPObj *obj);
 extern struct adouble *of_ad     (const struct vol *, struct path *, struct adouble *);
-
-#ifdef HAVE_ATFUNCS
 extern struct ofork *of_findnameat(int dirfd, struct path *path);
 extern int of_fstatat(int dirfd, struct path *path);
-#endif  /* HAVE_ATFUNCS */
 
 
 /* in fork.c */

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -258,8 +258,6 @@ int of_stat(const struct vol *vol, struct path *path)
     return ret;
 }
 
-
-#ifdef HAVE_ATFUNCS
 int of_fstatat(int dirfd, struct path *path)
 {
     int ret;
@@ -272,7 +270,6 @@ int of_fstatat(int dirfd, struct path *path)
 
    return ret;
 }
-#endif /* HAVE_ATFUNCS */
 
 /* --------------------------
    stat the current directory.
@@ -352,7 +349,6 @@ struct ofork *of_findname(const struct vol *vol, struct path *path)
  * @param dirfd     (r) directory fd
  * @param path      (rw) pointer to struct path
  */
-#ifdef HAVE_ATFUNCS
 struct ofork *of_findnameat(int dirfd, struct path *path)
 {
     struct ofork *of;
@@ -376,7 +372,6 @@ struct ofork *of_findnameat(int dirfd, struct path *path)
 
     return NULL;
 }
-#endif
 
 void of_dealloc(struct ofork *of)
 {

--- a/libatalk/util/meson.build
+++ b/libatalk/util/meson.build
@@ -3,6 +3,7 @@ util_sources = [
     'bprint.c',
     'cnid.c',
     'fault.c',
+    'ftw.c',
     'getiface.c',
     'gettok.c',
     'locking.c',
@@ -16,10 +17,6 @@ util_sources = [
     'strdicasecmp.c',
     'unix.c',
 ]
-
-if have_atfuncs
-    util_sources += 'ftw.c'
-endif
 
 libutil = static_library(
     'util',

--- a/libatalk/util/unix.c
+++ b/libatalk/util/unix.c
@@ -393,24 +393,17 @@ int ochmod(char *path, mode_t mode, const struct stat *st, int options)
 /*
  * @brief ostat/fsstatat multiplexer
  *
- * ostatat mulitplexes ostat and fstatat. If we don't HAVE_ATFUNCS, dirfd is ignored.
+ * ostatat mulitplexes ostat and fstatat.
  *
- * @param dirfd   (r) Only used if HAVE_ATFUNCS, ignored else, -1 gives AT_FDCWD
+ * @param dirfd   (r) -1 gives AT_FDCWD
  * @param path    (r) pathname
  * @param st      (rw) pointer to struct stat
  */
 int ostatat(int dirfd _U_, const char *path, struct stat *st, int options)
 {
-#ifdef HAVE_ATFUNCS
     if (dirfd == -1)
         dirfd = AT_FDCWD;
     return fstatat(dirfd, path, st, (options & O_NOFOLLOW) ? AT_SYMLINK_NOFOLLOW : 0);
-#else
-    return ostat(path, st, options);
-#endif
-
-    /* DEADC0DE */
-    return -1;
 }
 
 /*!

--- a/meson.build
+++ b/meson.build
@@ -303,14 +303,9 @@ at_functions = [
     'unlinkat',
 ]
 
-have_atfuncs = false
-
 foreach f : at_functions
-    if cc.has_function(f)
-        have_atfuncs = true
-        cdata.set('HAVE_' + f.underscorify().to_upper(), 1)
-        cdata.set('_ATFILE_SOURCE', 1)
-        cdata.set('HAVE_ATFUNCS', 1)
+    if not cc.has_function(f)
+        error('Standard C library function @0@ is required'.format(f))
     endif
 endforeach
 

--- a/meson_config.h
+++ b/meson_config.h
@@ -76,9 +76,6 @@
 /* set if struct at_addr is called atalk_addr */
 #mesondefine HAVE_ATALK_ADDR
 
-/* whether at funcs are available */
-#mesondefine HAVE_ATFUNCS
-
 /* Define to 1 if you have the `attr_get' function. */
 #mesondefine HAVE_ATTR_GET
 
@@ -220,9 +217,6 @@
 /* Define to 1 if the system has the type `fshare_t'. */
 #mesondefine HAVE_FSHARE_T
 
-/* Define to 1 if you have the `fstatat' function. */
-#mesondefine HAVE_FSTATAT
-
 /* Define to 1 if you have the `getea' function. */
 #mesondefine HAVE_GETEA
 
@@ -358,9 +352,6 @@
 /* Whether NFSv4 ACLs are available */
 #mesondefine HAVE_NFSV4_ACLS
 
-/* Define to 1 if you have the `openat' function. */
-#mesondefine HAVE_OPENAT
-
 /* Define to 1 if you have the <pam/pam_appl.h> header file. */
 #mesondefine HAVE_PAM_PAM_APPL_H
 
@@ -387,9 +378,6 @@
 
 /* Define to 1 if you have the `removexattr' function. */
 #mesondefine HAVE_REMOVEXATTR
-
-/* Define to 1 if you have the `renameat' function. */
-#mesondefine HAVE_RENAMEAT
 
 /* Define to 1 if you have the <rpcsvc/rquota.h> header file. */
 #mesondefine HAVE_RPCSVC_RQUOTA_H
@@ -522,9 +510,6 @@
 
 /* Define to 1 if you have the <ufs/quota.h> header file. */
 #mesondefine HAVE_UFS_QUOTA_H
-
-/* Define to 1 if you have the `unlinkat' function. */
-#mesondefine HAVE_UNLINKAT
 
 /* Whether to use native iconv */
 #mesondefine HAVE_USABLE_ICONV
@@ -682,9 +667,6 @@
 /* Define to 1 if `lex' declares `yytext' as a `char *' by default, not a
    `char[]'. */
 #mesondefine YYTEXT_POINTER
-
-/* AT file source */
-#mesondefine _ATFILE_SOURCE
 
 /* _FILE_OFFSET_BITS (for LARGEFILE support) */
 #mesondefine _FILE_OFFSET_BITS


### PR DESCRIPTION
The so-called at functions were introduced in the standard C libraries everywhere in the mid 2000s. We shouldn't need these fallbacks anymore.