### PR TITLE
uams: Support for OpenBSD flavor crypt_checkpass() for password validation

### DIFF
--- a/etc/uams/meson.build
+++ b/etc/uams/meson.build
@@ -10,6 +10,11 @@ else
     lib_suffix = []
 endif
 
+passwd_deps = []
+if crypt.found()
+    passwd_deps += crypt
+endif
+
 uams_guest_sources = ['uams_guest.c']
 
 library(
@@ -29,7 +34,7 @@ library(
     'uams_passwd',
     uams_passwd_sources,
     include_directories: root_includes,
-    dependencies: crypt,
+    dependencies: passwd_deps,
     name_prefix: '',
     name_suffix: lib_suffix,
     override_options: 'b_lundef=false',
@@ -58,7 +63,7 @@ if have_libgcrypt
         'uams_dhx_passwd',
         uams_dhx_passwd_sources,
         include_directories: root_includes,
-        dependencies: [libgcrypt, crypt],
+        dependencies: [passwd_deps, libgcrypt],
         name_prefix: '',
         name_suffix: lib_suffix,
         override_options: 'b_lundef=false',
@@ -70,7 +75,7 @@ if have_libgcrypt
         'uams_dhx2_passwd',
         uams_dhx2_passwd_sources,
         include_directories: root_includes,
-        dependencies: [libgcrypt, crypt],
+        dependencies: [passwd_deps, libgcrypt],
         name_prefix: '',
         name_suffix: lib_suffix,
         override_options: 'b_lundef=false',

--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -345,12 +345,16 @@ static int passwd_logincont(void *obj, struct passwd **uam_pwd,
     gcry_mpi_release(bn3);
 
     rbuf[PASSWDLEN] = '\0';
-    p = crypt( rbuf, dhxpwd->pw_passwd );
-    memset(rbuf, 0, PASSWDLEN);
-    if ( strcmp( p, dhxpwd->pw_passwd ) == 0 ) {
-      *uam_pwd = dhxpwd;
-      err = AFP_OK;
+#ifdef HAVE_CRYPT_CHECKPASS
+    if (crypt_checkpass(rbuf, dhxpwd->pw_passwd) == 0) {
+#else
+    p = crypt(rbuf, dhxpwd->pw_passwd);
+    if (strcmp(p, dhxpwd->pw_passwd) == 0) {
+#endif
+        *uam_pwd = dhxpwd;
+        err = AFP_OK;
     }
+    memset(rbuf, 0, PASSWDLEN);
 #ifdef SHADOWPW
     if (( sp = getspnam( dhxpwd->pw_name )) == NULL ) {
 	LOG(log_info, logtype_uams, "no shadow passwd entry for %s", dhxpwd->pw_name);

--- a/meson.build
+++ b/meson.build
@@ -1648,14 +1648,29 @@ endif
 #
 
 crypt = cc.find_library('crypt', required: false)
+if crypt.found()
+    have_crypt = cc.has_function('crypt', dependencies: crypt)
+    have_crypt_checkpass = cc.has_function('crypt_checkpass', dependencies: crypt)
+else
+    have_crypt = cc.has_function('crypt')
+    have_crypt_checkpass = cc.has_function('crypt_checkpass')
+endif
 
-if cc.has_header('shadow.h')
+if have_crypt_checkpass
+    cdata.set('HAVE_CRYPT_CHECKPASS', 1)
+endif
+
+if host_os == 'darwin'
+    warning('non-PAM authentication currently not supported on macOS')
+elif cc.has_header('shadow.h')
     cdata.set('SHADOWPW', 1)
     uams_options += 'shadow'
-elif crypt.found()
+elif have_crypt or have_crypt_checkpass
     uams_options += 'passwd'
-else
-    warning('Neither shadow nor crypt library found. Only PAM authentication is available')
+endif
+
+if not have_crypt and not have_crypt_checkpass
+    warning('crypt functions not found; only PAM authentication is possible')
 endif
 
 #

--- a/meson_config.h
+++ b/meson_config.h
@@ -88,6 +88,9 @@
 /* Define to 1 if dbtob implementation is broken. */
 #mesondefine HAVE_BROKEN_DBTOB
 
+/* Define to 1 if you have the `crypt_checkpass' function. */
+#mesondefine HAVE_CRYPT_CHECKPASS
+
 /* Define to 1 if you have the <crypt.h> header file. */
 #mesondefine HAVE_CRYPT_H
 


### PR DESCRIPTION
The crypt() function is flagged as deprecated for OpenBSD,
so using the slightly more elegant crypt_checkpass() when available.

Also refactors the crypt/shadow checks in Meson to give a
more accurate summary output.