### PR TITLE
libatalk: IPv6 sockets only accept IPv6 connections on OpenBSD

### DIFF
--- a/libatalk/dsi/dsi_tcp.c
+++ b/libatalk/dsi/dsi_tcp.c
@@ -445,7 +445,12 @@ int dsi_tcp_init(DSI *dsi, const char *hostname, const char *inaddress, const ch
 
     if (!address) {
         hints.ai_flags |= AI_PASSIVE;
+#if defined(__OpenBSD__)
+        /* IPv6 sockets only accept IPv6 connections on OpenBSD */
+        hints.ai_family = AF_INET;
+#else
         hints.ai_family = AF_INET6;
+#endif
     } else {
         hints.ai_flags |= AI_NUMERICHOST;
         hints.ai_family = AF_UNSPEC;


### PR DESCRIPTION
The fix for SourceForge bug 602 - 0b7f7fe6e - made afpd listen on IPv6 wildcard sockets on all plaforms.
An IPv4 socket is a more apt default for OpenBSD.

Originally reported and tested by Johan Huldtgren
Patch by Stuart Henderson, modified by Antoine Jacoutot From the OpenBSD project