### PR TITLE
afpd: Use getpwnam_shadow() for basic auth on OpenBSD

### DIFF
--- a/etc/afpd/uam.c
+++ b/etc/afpd/uam.c
@@ -212,10 +212,16 @@ struct passwd *uam_getname(void *private, char *name, const int len)
         return NULL;
     }
 
+#ifdef HAVE_GETPWNAM_SHADOW
+    if (pwent = getpwnam_shadow(name)) {
+        return pwent;
+    }
+#else
     if (getpwnam_r(name, &pwent_buf, buffer, sizeof(buffer), &pwent) == 0 && pwent != NULL) {
         free(buffer);
         return pwent;
     }
+#endif
 
     /* if we have a NT domain name try with it */
     if (obj->options.addomain || (obj->options.ntdomain && obj->options.ntseparator)) {
@@ -227,7 +233,11 @@ struct passwd *uam_getname(void *private, char *name, const int len)
 
         if (bdata(princ) != NULL) {
             const char *bdatum = bdata(princ);
+#ifdef HAVE_GETPWNAM_SHADOW
+            getpwnam_shadow(bdatum);
+#else
             getpwnam_r(bdatum, &pwent_buf, buffer, sizeof(buffer), &pwent);
+#endif
         }
         bdestroy(princ);
 

--- a/meson.build
+++ b/meson.build
@@ -271,6 +271,7 @@ check_functions = [
     'asprintf',
     'backtrace_symbols',
     'dirfd',
+    'getpwnam_shadow',
     'pread',
     'pselect',
     'pwrite',

--- a/meson_config.h
+++ b/meson_config.h
@@ -163,6 +163,9 @@
 /* Define to 1 if you have the `getifaddrs' function. */
 #mesondefine HAVE_GETIFADDRS
 
+/* Define to 1 if you have the `getpwnam_shadow' function. */
+#mesondefine HAVE_GETPWNAM_SHADOW
+
 /* Define to 1 if you have the `getxattr' function. */
 #mesondefine HAVE_GETXATTR
 


### PR DESCRIPTION
This unblocks basic authentication on OpenBSD
Inspired by patches by Nils Frohberg, Stuart Henderson, and Antoine Jacoutot
From the OpenBSD project