### PR TITLE
libatalk: Use unspecified network stack by default on OpenBSD

### DIFF
--- a/libatalk/dsi/dsi_tcp.c
+++ b/libatalk/dsi/dsi_tcp.c
@@ -445,9 +445,8 @@ int dsi_tcp_init(DSI *dsi, const char *hostname, const char *inaddress, const ch
 
     if (!address) {
         hints.ai_flags |= AI_PASSIVE;
-#if defined(__OpenBSD__)
-        /* IPv6 sockets only accept IPv6 connections on OpenBSD */
-        hints.ai_family = AF_INET;
+#if defined(__OpenBSD__) /* no IPv4/v6 dual stack on OpenBSD */
+        hints.ai_family = AF_UNSPEC;
 #else
         hints.ai_family = AF_INET6;
 #endif


### PR DESCRIPTION
OpenBSD lacks dual IPv4/IPv6 stack. The following makes for a better default.

Patch by Antoine Jacoutot from the OpenBSD project