### PR TITLE
afpd: Simplify getpwnam_shadow() compatibility code

### DIFF
--- a/etc/afpd/uam.c
+++ b/etc/afpd/uam.c
@@ -214,14 +214,12 @@ struct passwd *uam_getname(void *private, char *name, const int len)
 
 #ifdef HAVE_GETPWNAM_SHADOW
     if (pwent = getpwnam_shadow(name)) {
-        return pwent;
-    }
 #else
     if (getpwnam_r(name, &pwent_buf, buffer, sizeof(buffer), &pwent) == 0 && pwent != NULL) {
         free(buffer);
+#endif
         return pwent;
     }
-#endif
 
     /* if we have a NT domain name try with it */
     if (obj->options.addomain || (obj->options.ntdomain && obj->options.ntseparator)) {
@@ -233,11 +231,7 @@ struct passwd *uam_getname(void *private, char *name, const int len)
 
         if (bdata(princ) != NULL) {
             const char *bdatum = bdata(princ);
-#ifdef HAVE_GETPWNAM_SHADOW
-            getpwnam_shadow(bdatum);
-#else
             getpwnam_r(bdatum, &pwent_buf, buffer, sizeof(buffer), &pwent);
-#endif
         }
         bdestroy(princ);
 


### PR DESCRIPTION
This removes the unnecessary application of getpwnam_shadow on the AD domain, while reusing more code behind macros.