### PR TITLE
Use BSD extension strlcpy/strlcat/snprintf to manage buffer size

### DIFF
--- a/bin/ad/ad_ls.c
+++ b/bin/ad/ad_ls.c
@@ -483,9 +483,9 @@ static int ad_ls_r(char *path, afpvol_t *vol)
     if ( first)
         cwdpath[0] = 0;
     else
-        strcat(cwdpath, "/");
+        strlcat(cwdpath, "/", sizeof(cwdpath));
 
-    strcat(cwdpath, path);
+    strlcat(cwdpath, path, sizeof(cwdpath));
     first = 0;
 
     if (lstat(path, &st) < 0) {

--- a/bin/ad/ad_mv.c
+++ b/bin/ad/ad_mv.c
@@ -185,10 +185,17 @@ int ad_mv(int argc, char *argv[], AFPObj *obj)
     }
 
     /* It's a directory, move each file into it. */
-    if (strlen(argv[argc - 1]) > sizeof(path) - 1)
-        ERROR("%s: destination pathname too long", *argv);
+    if (strlen(argv[argc - 1]) >= sizeof(path)) {
+        SLOG("%s: destination pathname too long", argv[argc - 1]);
+        return 1;
+    }
 
-    (void)strcpy(path, argv[argc - 1]);
+    size_t copied = strlcpy(path, argv[argc - 1], sizeof(path));
+    if (copied >= sizeof(path)) {
+        SLOG("%s: destination pathname too long", argv[argc - 1]);
+        return 1;
+    }
+
     baselen = strlen(path);
     endp = &path[baselen];
     if (!baselen || *(endp - 1) != '/') {

--- a/bin/afppasswd/afppasswd.c
+++ b/bin/afppasswd/afppasswd.c
@@ -37,6 +37,8 @@
 
 #include <gcrypt.h>
 
+#include <atalk/compat.h>
+
 #ifndef DES_KEY_SZ
 #define DES_KEY_SZ 8
 #endif
@@ -127,9 +129,9 @@ static int update_passwd(const char *path, const char *name, int flags, const ch
   }
 
   /* open the key file if it exists */
-  strcpy(buf, path);
+  strlcpy(buf, path, sizeof(buf));
   if (strlen(path) < sizeof(buf) - 5) {
-    strcat(buf, ".key");
+    strlcat(buf, ".key", sizeof(buf));
     keyfd = open(buf, O_RDONLY);
   }
 
@@ -153,8 +155,8 @@ static int update_passwd(const char *path, const char *name, int flags, const ch
   }
 
   if (flags & OPT_ADDUSER) {
-    strcpy(buf, name);
-    strcat(buf, FORMAT);
+    strlcpy(buf, name, sizeof(buf));
+    strlcat(buf, FORMAT, sizeof(buf));
     p = strchr(buf, ':') + 1;
     fwrite(buf, strlen(buf), 1, fp);
   } else {
@@ -264,8 +266,8 @@ static int create_file(const char *path, uid_t minuid)
     /* a little paranoia */
     if (strlen(pwd->pw_name) + FORMAT_LEN > sizeof(buf) - 1)
       continue;
-    strcpy(buf, pwd->pw_name);
-    strcat(buf, FORMAT);
+    strlcpy(buf, pwd->pw_name, sizeof(buf));
+    strlcat(buf, FORMAT, sizeof(buf));
     len = strlen(buf);
     if (write(fd, buf, len) != len) {
       fprintf(stderr, "afppasswd: problem writing to %s: %s\n", path,

--- a/bin/afppasswd/meson.build
+++ b/bin/afppasswd/meson.build
@@ -3,7 +3,7 @@ afppasswd_sources = [
 ]
 
 afppasswd_deps = []
-afppasswd_libs = []
+afppasswd_libs = [libatalk]
 
 if have_cracklib
     afppasswd_deps += crack

--- a/bin/nbp/nbplkup.c
+++ b/bin/nbp/nbplkup.c
@@ -128,21 +128,21 @@ int main(int ac, char **av)
 	    perror( "malloc" );
 	    exit( 1 );
 	}
-	strcpy( name, Obj );
+	strlcpy( name, Obj, sizeof(name));
 	Obj = name;
 
 	if (( name = (char *)malloc( strlen( Type ) + 1 )) == NULL ) {
 	    perror( "malloc" );
 	    exit( 1 );
 	}
-	strcpy( name, Type );
+	strlcpy( name, Type, sizeof(name));
 	Type = name;
 
 	if (( name = (char *)malloc( strlen( Zone ) + 1 )) == NULL ) {
 	    perror( "malloc" );
 	    exit( 1 );
 	}
-	strcpy( name, Zone );
+	strlcpy( name, Zone, sizeof(name));
 	Zone = name;
 
     }

--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -1041,9 +1041,9 @@ int auth_load(AFPObj *obj, const char *path, const char *list)
     if ((p = strtok_r(buf, ", ", &last)) == NULL)
         return -1;
 
-    strcpy(name, path);
+    strlcpy(name, path, sizeof(name));
     if (name[len - 1] != '/') {
-        strcat(name, "/");
+        strlcat(name, "/", sizeof(name));
         len++;
     }
 

--- a/etc/atalkd/config.c
+++ b/etc/atalkd/config.c
@@ -192,7 +192,7 @@ int writeconf(char *cf)
     if (( p = strrchr( path, '/' )) == NULL ) {
 	strcpy( newpath, _PATH_ATALKDTMP );
     } else {
-	sprintf( newpath, "%.*s/%s", (int)(p - path), path, _PATH_ATALKDTMP );
+	snprintf( newpath, sizeof(newpath), "%.*s/%s", (int)(p - path), path, _PATH_ATALKDTMP );
     }
     if (( fd = open( newpath, O_WRONLY|O_CREAT|O_TRUNC, mode )) < 0 ) {
 	LOG(log_error, logtype_atalkd, "%s: %s", newpath, strerror(errno) );

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -1361,7 +1361,7 @@ int ifconfig( const char *iname, unsigned long cmd, struct sockaddr_at *sa)
     int			s;
 
     memset(&ifr, 0, sizeof(ifr));
-    strcpy( ifr.ifr_name, iname );
+    strlcpy(ifr.ifr_name, iname, sizeof(ifr.ifr_name));
     ifr.ifr_addr = *(struct sockaddr *)sa;
 
     if (( s = socket( AF_APPLETALK, SOCK_DGRAM, 0 )) < 0 ) {

--- a/etc/cnid_dbd/cmd_dbd_scanvol.c
+++ b/etc/cnid_dbd/cmd_dbd_scanvol.c
@@ -564,7 +564,7 @@ static int read_addir(void)
             continue;
 
         /* Check for data file */
-        strcpy(pname + 3, ep->d_name);
+        strlcpy(pname + 3, ep->d_name, sizeof(pname) - 3);
         if ((access( pname, F_OK)) != 0) {
             if (errno != ENOENT) {
                 dbd_log(LOGSTD, "Access error for file '%s/%s': %s",
@@ -825,8 +825,8 @@ static int dbd_readdir(int volroot, cnid_t did)
           Recursion
         **************************************************************************/
         if (S_ISDIR(st.st_mode) && cnid) { /* If we have no cnid for it we can't enter recursion */
-            strcat(cwdbuf, "/");
-            strcat(cwdbuf, name);
+            strlcat(cwdbuf, "/", sizeof(cwdbuf));
+            strlcat(cwdbuf, name, sizeof(cwdbuf));
             dbd_log( LOGDEBUG, "Entering directory: %s", cwdbuf);
             if (-1 == (cwd = open(".", O_RDONLY))) {
                 dbd_log( LOGSTD, "Can't open directory '%s': %s", cwdbuf, strerror(errno));
@@ -898,7 +898,7 @@ int cmd_dbd_scanvol(struct vol *vol_in, dbd_flags_t flags)
         EC_EXIT_STATUS(0); /* Got signal, jump from dbd_readdir */
     }
 
-    strcpy(cwdbuf, vol->v_path);
+    strlcpy(cwdbuf, vol->v_path, sizeof(cwdbuf));
     chdir(vol->v_path);
 
     if ((vol->v_adouble == AD_VERSION_EA) && (dbd_flags & DBD_FLAGS_V2TOEA)) {

--- a/etc/cnid_dbd/cnid_metad.c
+++ b/etc/cnid_dbd/cnid_metad.c
@@ -258,8 +258,8 @@ static struct server *test_usockfn(const char *path)
             }
         }
 
-        sprintf(buf1, "%i", sv[1]);
-        sprintf(buf2, "%i", rqstfd);
+        snprintf(buf1, sizeof(buf1), "%i", sv[1]);
+        snprintf(buf2, sizeof(buf2), "%i", rqstfd);
 
         if (up->count == MAXSPAWN) {
             /* there's a pb with the db inform child, it will delete the db */

--- a/etc/cnid_dbd/db_param.c
+++ b/etc/cnid_dbd/db_param.c
@@ -42,14 +42,14 @@ static int make_pathname(char *path, char *dir, char *fn, size_t maxlen)
         len = strlen(dir);
         if (len + 1 + strlen(fn) > maxlen)
             return -1;
-        strcpy(path, dir);
+        strlcpy(path, dir, maxlen);
         if (path[len - 1] != '/')
-            strcat(path, "/");
-        strcat(path, fn);
+            strlcat(path, "/", maxlen);
+        strlcat(path, fn, maxlen);
     } else {
         if (strlen(fn) > maxlen)
             return -1;
-        strcpy(path, fn);
+        strlcpy(path, fn, maxlen);
     }
     return 0;
 }


### PR DESCRIPTION
This addresses a number of OpenBSD compiler warnings

This continues a process of adopting these BSD extension that started at least 16 years ago with commits like https://github.com/Netatalk/netatalk/commit/4a671e56e9e8448e8f11b1dd4654780cdad0ad4f