### PR TITLE
getzones: do not attempt to bind to the address we're also going to send packets to

### DIFF
--- a/bin/getzones/getzones.c
+++ b/bin/getzones/getzones.c
@@ -91,7 +91,7 @@ int main( int argc, char *argv[])
 	}
     }
 
-    if (( ah = atp_open( ATADDR_ANYPORT, &saddr.sat_addr )) == NULL ) {
+    if (( ah = atp_open( ATADDR_ANYPORT, NULL )) == NULL ) {
 	perror( "atp_open" );
 	exit( 1 );
     }


### PR DESCRIPTION
Having said I didn't have time to investigate issue #2050, I decided to investigate it rather than sleep.  This PR appears to fix it.

From reading the definition of atp_open(), it looks like passing NULL to this is the intended idiomatic "bind to any address" syntax.