### PR TITLE
Handle errors in f|chdir() and remove unused daemonize() params

### DIFF
--- a/etc/afpd/main.c
+++ b/etc/afpd/main.c
@@ -221,7 +221,7 @@ int main(int ac, char **av)
     /* Parse argv args and initialize default options */
     afp_options_parse_cmdline(&dsi_obj, ac, av);
 
-    if (!(dsi_obj.cmdlineflags & OPTION_DEBUG) && (daemonize(0, 0) != 0))
+    if (!(dsi_obj.cmdlineflags & OPTION_DEBUG) && (daemonize() != 0))
         exit(EXITERR_SYS);
 
     /* Log SIGBUS/SIGSEGV SBT */

--- a/etc/cnid_dbd/cmd_dbd_scanvol.c
+++ b/etc/cnid_dbd/cmd_dbd_scanvol.c
@@ -899,7 +899,10 @@ int cmd_dbd_scanvol(struct vol *vol_in, dbd_flags_t flags)
     }
 
     strlcpy(cwdbuf, vol->v_path, sizeof(cwdbuf));
-    chdir(vol->v_path);
+    if (chdir(vol->v_path) < 0) {
+        dbd_log(LOGSTD, "Can't chdir to '%s': %s", vol->v_path, strerror(errno));
+        EC_FAIL;
+    }
 
     if ((vol->v_adouble == AD_VERSION_EA) && (dbd_flags & DBD_FLAGS_V2TOEA)) {
         if (lstat(".", &st) != 0)

--- a/etc/cnid_dbd/cnid_metad.c
+++ b/etc/cnid_dbd/cnid_metad.c
@@ -492,7 +492,7 @@ int main(int argc, char *argv[])
         }
     }
 
-    if (!debug && daemonize(0, 0) != 0) {
+    if (!debug && daemonize() != 0) {
         if (obj.cmdlineconfigfile != NULL) {
             free((void *)obj.cmdlineconfigfile);
         }

--- a/etc/cnid_dbd/main.c
+++ b/etc/cnid_dbd/main.c
@@ -235,7 +235,9 @@ static int delete_db(void)
 
 EC_CLEANUP:
     if (cwd != -1) {
-        fchdir(cwd);
+        if (fchdir(cwd) < 0) {
+            LOG(log_error, logtype_default, "Can't fchdir(%d): %s", cwd, strerror(errno));
+        }
         close(cwd);
     }
     EC_EXIT;

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -424,7 +424,7 @@ int main(int argc, char **argv)
     if (check_lockfile("netatalk", PATH_NETATALK_LOCK) != 0)
         exit(EXITERR_SYS);
 
-    if (!debug && daemonize(0, 0) != 0)
+    if (!debug && daemonize() != 0)
         exit(EXITERR_SYS);
 
     if (create_lockfile("netatalk", PATH_NETATALK_LOCK) != 0)

--- a/include/atalk/util.h
+++ b/include/atalk/util.h
@@ -202,7 +202,7 @@ extern const char *getcwdpath(void);
 extern const char *fullpathname(const char *);
 extern char *stripped_slashes_basename(char *p);
 extern void randombytes(void *buf, int n);
-extern int daemonize(int nochdir, int noclose);
+extern int daemonize(void);
 extern int run_cmd(const char *cmd, char **cmd_argv);
 extern char *realpath_safe(const char *path);
 extern const char *basename_safe(const char *path);

--- a/libatalk/util/cnid.c
+++ b/libatalk/util/cnid.c
@@ -126,7 +126,9 @@ bstring rel_path_in_vol(const char *path, const char *volpath)
 EC_CLEANUP:
     if (dname) free(dname);
     if (cwd != -1) {
-        fchdir(cwd);
+        if (fchdir(cwd) < 0) {
+            LOG(log_error, logtype_default, "Can't fchdir(%d): %s", cwd, strerror(errno));
+        }
         close(cwd);
     }
     if (ret != 0)

--- a/libatalk/util/unix.c
+++ b/libatalk/util/unix.c
@@ -107,12 +107,12 @@ EC_CLEANUP:
 /*!
  * Daemonize
  *
- * Fork, exit parent, setsid(), optionally chdir("/"), optionally close all fds
+ * Fork, exit parent, setsid(), chdir("/"), close all fds
  *
  * returns -1 on failure, but you can't do much except exit in that case
  * since we may already have forked
  */
-int daemonize(int nochdir, int noclose)
+int daemonize(void)
 {
     switch (fork()) {
     case 0:
@@ -135,17 +135,15 @@ int daemonize(int nochdir, int noclose)
         _exit(0);
     }
 
-    if (!nochdir && chdir("/") < 0) {
+    if (chdir("/") < 0) {
         LOG(log_error, logtype_default, "Can't chdir(/): %s", strerror(errno));
         return -1;
     }
 
-    if (!noclose) {
-        closeall(0);
-        open("/dev/null",O_RDWR);
-        dup(0);
-        dup(0);
-    }
+    closeall(0);
+    open("/dev/null",O_RDWR);
+    dup(0);
+    dup(0);
 
     return 0;
 }

--- a/libatalk/util/unix.c
+++ b/libatalk/util/unix.c
@@ -135,8 +135,10 @@ int daemonize(int nochdir, int noclose)
         _exit(0);
     }
 
-    if (!nochdir)
-        chdir("/");
+    if (!nochdir && chdir("/") < 0) {
+        LOG(log_error, logtype_default, "Can't chdir(/): %s", strerror(errno));
+        return -1;
+    }
 
     if (!noclose) {
         closeall(0);


### PR DESCRIPTION
Depending on context, either bail out or continue when the chdir call fails.

Also removing branches within daemonize() that bypass chdir and closing of file descriptors, which weren't used anywhere.