### PR TITLE
Remove redundant parentheses from return statements

### DIFF
--- a/bin/ad/ad_cp.c
+++ b/bin/ad/ad_cp.c
@@ -640,7 +640,7 @@ static int ftw_copy_file(const struct FTW *entp _U_,
 
     if ((from_fd = open(spath, O_RDONLY, 0)) == -1) {
         SLOG("%s: %s", spath, strerror(errno));
-        return (1);
+        return 1;
     }
 
     /*
@@ -657,7 +657,7 @@ static int ftw_copy_file(const struct FTW *entp _U_,
             if (vflag)
                 printf("%s not overwritten\n", to.p_path);
             (void)close(from_fd);
-            return (0);
+            return 0;
         } else if (iflag) {
             (void)fprintf(stderr, "overwrite %s? %s",
                           to.p_path, YESNO);
@@ -667,7 +667,7 @@ static int ftw_copy_file(const struct FTW *entp _U_,
             if (checkch != 'y' && checkch != 'Y') {
                 (void)close(from_fd);
                 (void)fprintf(stderr, "not overwritten\n");
-                return (1);
+                return 1;
             }
         }
 
@@ -690,7 +690,7 @@ static int ftw_copy_file(const struct FTW *entp _U_,
     if (to_fd == -1) {
         SLOG("%s: %s", to.p_path, strerror(errno));
         (void)close(from_fd);
-        return (1);
+        return 1;
     }
 
     rval = 0;
@@ -784,7 +784,7 @@ static int ftw_copy_file(const struct FTW *entp _U_,
 
     (void)close(from_fd);
 
-    return (rval);
+    return rval;
 }
 
 static int ftw_copy_link(const struct FTW *p _U_,
@@ -881,7 +881,7 @@ static int setfile(const struct stat *fs, int fd)
         }
 #endif
 
-    return (rval);
+    return rval;
 }
 
 static int preserve_fd_acls(int source_fd _U_, int dest_fd _U_)
@@ -897,7 +897,7 @@ static int preserve_fd_acls(int source_fd _U_, int dest_fd _U_)
         acl_type = ACL_TYPE_NFS4;
     } else if (ret < 0 && errno != EINVAL) {
         warn("fpathconf(..., _PC_ACL_NFS4) failed for %s", to.p_path);
-        return (1);
+        return 1;
     }
     if (acl_supported == 0) {
         ret = fpathconf(source_fd, _PC_ACL_EXTENDED);
@@ -907,34 +907,34 @@ static int preserve_fd_acls(int source_fd _U_, int dest_fd _U_)
         } else if (ret < 0 && errno != EINVAL) {
             warn("fpathconf(..., _PC_ACL_EXTENDED) failed for %s",
                  to.p_path);
-            return (1);
+            return 1;
         }
     }
     if (acl_supported == 0)
-        return (0);
+        return 0;
 
     acl = acl_get_fd_np(source_fd, acl_type);
     if (acl == NULL) {
         warn("failed to get acl entries while setting %s", to.p_path);
-        return (1);
+        return 1;
     }
     if (acl_is_trivial_np(acl, &trivial)) {
         warn("acl_is_trivial() failed for %s", to.p_path);
         acl_free(acl);
-        return (1);
+        return 1;
     }
     if (trivial) {
         acl_free(acl);
-        return (0);
+        return 0;
     }
     if (acl_set_fd_np(dest_fd, acl, acl_type) < 0) {
         warn("failed to set acl entries for %s", to.p_path);
         acl_free(acl);
-        return (1);
+        return 1;
     }
     acl_free(acl);
 #endif
-    return (0);
+    return 0;
 }
 
 #if 0
@@ -953,7 +953,7 @@ static int preserve_dir_acls(const struct stat *fs, char *source_dir, char *dest
         acl_type = ACL_TYPE_NFS4;
     } else if (ret < 0 && errno != EINVAL) {
         warn("fpathconf(..., _PC_ACL_NFS4) failed for %s", source_dir);
-        return (1);
+        return 1;
     }
     if (acl_supported == 0) {
         ret = pathconf(source_dir, _PC_ACL_EXTENDED);
@@ -963,11 +963,11 @@ static int preserve_dir_acls(const struct stat *fs, char *source_dir, char *dest
         } else if (ret < 0 && errno != EINVAL) {
             warn("fpathconf(..., _PC_ACL_EXTENDED) failed for %s",
                  source_dir);
-            return (1);
+            return 1;
         }
     }
     if (acl_supported == 0)
-        return (0);
+        return 0;
 
     /*
      * If the file is a link we will not follow it
@@ -989,7 +989,7 @@ static int preserve_dir_acls(const struct stat *fs, char *source_dir, char *dest
         if (acl == NULL) {
             warn("failed to get default acl entries on %s",
                  source_dir);
-            return (1);
+            return 1;
         }
         aclp = &acl->ats_acl;
         if (aclp->acl_cnt != 0 && aclsetf(dest_dir,
@@ -997,30 +997,30 @@ static int preserve_dir_acls(const struct stat *fs, char *source_dir, char *dest
             warn("failed to set default acl entries on %s",
                  dest_dir);
             acl_free(acl);
-            return (1);
+            return 1;
         }
         acl_free(acl);
     }
     acl = aclgetf(source_dir, acl_type);
     if (acl == NULL) {
         warn("failed to get acl entries on %s", source_dir);
-        return (1);
+        return 1;
     }
     if (acl_is_trivial_np(acl, &trivial)) {
         warn("acl_is_trivial() failed on %s", source_dir);
         acl_free(acl);
-        return (1);
+        return 1;
     }
     if (trivial) {
         acl_free(acl);
-        return (0);
+        return 0;
     }
     if (aclsetf(dest_dir, acl_type, acl) < 0) {
         warn("failed to set acl entries on %s", dest_dir);
         acl_free(acl);
-        return (1);
+        return 1;
     }
     acl_free(acl);
-    return (0);
+    return 0;
 }
 #endif

--- a/bin/ad/ad_mv.c
+++ b/bin/ad/ad_mv.c
@@ -261,14 +261,14 @@ static int do_move(const char *from, const char *to)
         /* prompt only if source exist */
         if (lstat(from, &sb) == -1) {
             SLOG("%s: %s", from, strerror(errno));
-            return (1);
+            return 1;
         }
 
         ask = 0;
         if (nflg) {
             if (vflg)
                 printf("%s not overwritten\n", to);
-            return (0);
+            return 0;
         } else if (iflg) {
             (void)fprintf(stderr, "overwrite %s? (y/n [n]) ", to);
             ask = 1;
@@ -282,7 +282,7 @@ static int do_move(const char *from, const char *to)
                 ch = getchar();
             if (first != 'y' && first != 'Y') {
                 (void)fprintf(stderr, "not overwritten\n");
-                return (0);
+                return 0;
             }
         }
     }
@@ -328,18 +328,18 @@ static int do_move(const char *from, const char *to)
                  */
                 if (lstat(from, &sb) == -1) {
                     SLOG("%s: %s", from, strerror(errno));
-                    return (-1);
+                    return -1;
                 }
                 if (!S_ISLNK(sb.st_mode)) {
                     /* Can't mv(1) a mount point. */
                     if (realpath(from, path) == NULL) {
                         SLOG("cannot resolve %s: %s: %s", from, path, strerror(errno));
-                        return (1);
+                        return 1;
                     }
                 }
             } else { /* != EXDEV */
                 SLOG("rename %s to %s: %s", from, to, strerror(errno));
-                return (1);
+                return 1;
             }
         } /* rename != 0*/
 
@@ -391,7 +391,7 @@ static int do_move(const char *from, const char *to)
 
         if (vflg)
             printf("%s -> %s\n", from, to);
-        return (0);
+        return 0;
     }
 
     if (mustcopy)
@@ -411,17 +411,17 @@ static int copy(const char *from, const char *to)
         if (S_ISDIR(sb.st_mode)) {
             if (rmdir(to) != 0) {
                 SLOG("rmdir %s: %s", to, strerror(errno));
-                return (1);
+                return 1;
             }
         } else {
             if (unlink(to) != 0) {
                 SLOG("unlink %s: %s", to, strerror(errno));
-                return (1);
+                return 1;
             }
         }
     } else if (errno != ENOENT) {
         SLOG("%s: %s", to, strerror(errno));
-        return (1);
+        return 1;
     }
 
     /* Copy source to destination. */
@@ -433,11 +433,11 @@ static int copy(const char *from, const char *to)
         if (errno == EINTR)
             continue;
         SLOG("%s cp -R %s %s: waitpid: %s", _PATH_AD, from, to, strerror(errno));
-        return (1);
+        return 1;
     }
     if (!WIFEXITED(status)) {
         SLOG("%s cp -R %s %s: did not terminate normally", _PATH_AD, from, to);
-        return (1);
+        return 1;
     }
     switch (WEXITSTATUS(status)) {
     case 0:
@@ -445,7 +445,7 @@ static int copy(const char *from, const char *to)
     default:
         SLOG("%s cp -R %s %s: terminated with %d (non-zero) status",
              _PATH_AD, from, to, WEXITSTATUS(status));
-        return (1);
+        return 1;
     }
 
     /* Delete the source. */
@@ -457,11 +457,11 @@ static int copy(const char *from, const char *to)
         if (errno == EINTR)
             continue;
         SLOG("%s rm -R %s: waitpid: %s", _PATH_AD, from, strerror(errno));
-        return (1);
+        return 1;
     }
     if (!WIFEXITED(status)) {
         SLOG("%s rm -R %s: did not terminate normally", _PATH_AD, from);
-        return (1);
+        return 1;
     }
     switch (WEXITSTATUS(status)) {
     case 0:
@@ -469,7 +469,7 @@ static int copy(const char *from, const char *to)
     default:
         SLOG("%s rm -R %s: terminated with %d (non-zero) status",
               _PATH_AD, from, WEXITSTATUS(status));
-        return (1);
+        return 1;
     }
     return 0;
 }

--- a/bin/ad/ad_util.c
+++ b/bin/ad/ad_util.c
@@ -185,7 +185,7 @@ char *utompath(const struct vol *vol, const char *upath)
         return NULL;
     }
 
-    return(m);
+    return m;
 }
 
 

--- a/bin/nbp/nbprgstr.c
+++ b/bin/nbp/nbprgstr.c
@@ -96,7 +96,7 @@ int main(int ac, char **av)
     memset(&addr, 0, sizeof(addr));
     memcpy(&addr.sat_addr, &ataddr, sizeof(addr.sat_addr));
     if ((s = netddp_open(&addr, NULL)) < 0)
-	return( -1 );
+	return -1;
 
     if ( port ) {
 	addr.sat_port = port;

--- a/bin/pap/pap.c
+++ b/bin/pap/pap.c
@@ -69,7 +69,7 @@ paprc(void)
 
     if (( f = fopen( _PATH_PAPRC, "r" )) == NULL ) {
 	if ( errno == ENOENT ) {
-	    return( NULL );
+	    return NULL;
 	} else {
 	    perror( _PATH_PAPRC );
 	    exit( 2 );
@@ -84,7 +84,7 @@ paprc(void)
 	break;
     }
     fclose( f );
-    return( name );
+    return name;
 }
 
 static char			*printer = NULL;
@@ -696,7 +696,7 @@ static int send_file( int fd, ATP atp, int lastfile, int is_imagewriter)
 
 	if(debug){ printf( "< DATA (eof)\n" ), fflush( stdout );}
 
-		    return( 0 );
+		    return 0;
 		}
 
 	if(debug){ printf( "< DATA\n" ), fflush( stdout );}
@@ -774,7 +774,7 @@ static int send_file( int fd, ATP atp, int lastfile, int is_imagewriter)
 	     * EOF before closing.
 	     */
 	    if ( eof && noeof && lastfile ) {
-		return( 0 );
+		return 0;
 	    }
 	} else {
 	    /*

--- a/bin/pap/papstatus.c
+++ b/bin/pap/papstatus.c
@@ -79,7 +79,7 @@ paprc(void)
     FILE	*f;
 
     if (( f = fopen( _PATH_PAPRC, "r" )) == NULL ) {
-	return( NULL );
+	return NULL;
     }
     while ( fgets( s, sizeof( s ), f ) != NULL ) {
 	s[ strlen( s ) - 1 ] = '\0';	/* remove trailing newline */
@@ -90,7 +90,7 @@ paprc(void)
 	break;
     }
     fclose( f );
-    return( name );
+    return name;
 }
 
 static char			*printer = NULL;

--- a/contrib/macipgw/macip.c
+++ b/contrib/macipgw/macip.c
@@ -143,7 +143,7 @@ static uint16_t cksum(char *buffer, int len)
 	}
 	sum = (sum & 0xffff) + ((sum >> 16) & 0xffff);
 	sum = sum > 65535 ? sum - 65535 : sum;
-	return (~sum & 0xffff);
+	return ~sum & 0xffff;
 }
 
 

--- a/contrib/macipgw/nbp_lkup_async.c
+++ b/contrib/macipgw/nbp_lkup_async.c
@@ -92,7 +92,7 @@ int nbp_lookup_req(int s, char *name, char *type, char *zone)
 
 	i = sizeof(struct sockaddr_at);
 	if (getsockname(s, (struct sockaddr *) &addr, &i) < 0) {
-		return (-1);
+		return -1;
 	}
 
 	*p++ = DDPTYPE_NBP;
@@ -124,7 +124,7 @@ int nbp_lookup_req(int s, char *name, char *type, char *zone)
 
 	if (sendto(s, buffer, p - buffer, 0, (struct sockaddr *) &addr,
 		   sizeof(struct sockaddr_at)) < 0) {
-		return (-1);
+		return -1;
 	}
 	return 0;
 }

--- a/etc/afpd/appl.c
+++ b/etc/afpd/appl.c
@@ -43,7 +43,7 @@ static int applopen(struct vol *vol, uint8_t creator[ 4 ], int flags, int mode)
         if ( !(flags & ( O_RDWR | O_WRONLY )) &&
                 memcmp( sa.sdt_creator, creator, sizeof( CreatorType )) == 0 &&
                 sa.sdt_vid == vol->v_vid ) {
-            return( AFP_OK );
+            return AFP_OK;
         }
         close( sa.sdt_fd );
         sa.sdt_fd = -1;
@@ -76,7 +76,7 @@ static int applopen(struct vol *vol, uint8_t creator[ 4 ], int flags, int mode)
     memcpy( sa.sdt_creator, creator, sizeof( CreatorType ));
     sa.sdt_vid = vol->v_vid;
     sa.sdt_index = 0;
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /*
@@ -153,7 +153,7 @@ static int copyapplfile(int sfd, int dfd, char *mpath, u_short mplen)
         }
     }
 
-    return( cc );
+    return cc;
 }
 
 /*
@@ -195,7 +195,7 @@ makemacpath(const struct vol *vol, char *mpath, int mpathlen, struct dir *dir, c
         if ((dir = dirlookup(vol, dir->d_pdid)) == NULL)
             return NULL;
     }
-    return( p );
+    return p;
 
 }
 
@@ -247,7 +247,7 @@ int afp_addappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, siz
         return get_afp_errno(AFPERR_PARAM);
     }
     if ( path_isadir(path) ) {
-        return( AFPERR_BADTYPE );
+        return AFPERR_BADTYPE;
     }
 
     if ( applopen( vol, creator, O_RDWR|O_CREAT, 0666 ) != AFP_OK ) {
@@ -320,7 +320,7 @@ int afp_addappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, siz
     if ( rename( tempfile, dtfile( vol, creator, ".appl" )) < 0 ) {
         return AFPERR_PARAM;
     }
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 int afp_rmvappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, size_t *rbuflen)
@@ -361,11 +361,11 @@ int afp_rmvappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, siz
         return get_afp_errno(AFPERR_PARAM);
     }
     if ( path_isadir(path) ) {
-        return( AFPERR_BADTYPE );
+        return AFPERR_BADTYPE;
     }
 
     if ( applopen( vol, creator, O_RDWR, 0666 ) != AFP_OK ) {
-        return( AFPERR_NOOBJ );
+        return AFPERR_NOOBJ;
     }
     if ( lseek( sa.sdt_fd, 0L, SEEK_SET ) < 0 ) {
         return AFPERR_PARAM;
@@ -416,7 +416,7 @@ int afp_rmvappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, siz
         return AFPERR_PARAM;
     }
 
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 int afp_getappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t *rbuflen)
@@ -461,7 +461,7 @@ int afp_getappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
 
     if ( applopen( vol, creator, O_RDONLY, 0666 ) != AFP_OK ) {
         *rbuflen = 0;
-        return( AFPERR_NOITEM );
+        return AFPERR_NOITEM;
     }
     if ( aindex < sa.sdt_index ) {
         if ( lseek( sa.sdt_fd, 0L, SEEK_SET ) < 0 ) {
@@ -481,7 +481,7 @@ int afp_getappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
         p += sizeof( u_short );
         if ( len > sizeof(obj->oldtmp) - (p - buf) ) {
             *rbuflen = 0;
-            return( AFPERR_NOITEM );
+            return AFPERR_NOITEM;
         }
         if (( cc = read( sa.sdt_fd, p, len )) < len ) {
             break;
@@ -493,7 +493,7 @@ int afp_getappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
     }
     if ( cc <= 0 || sa.sdt_index != aindex ) {
         *rbuflen = 0;
-        return( AFPERR_NOITEM );
+        return AFPERR_NOITEM;
     }
     sa.sdt_index++;
 
@@ -541,18 +541,18 @@ int afp_getappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
 
     if (( path = cname( vol, vol->v_root, &q )) == NULL ) {
         *rbuflen = 0;
-        return( AFPERR_NOITEM );
+        return AFPERR_NOITEM;
     }
 
     if ( path_isadir(path) || path->st_errno ) {
         *rbuflen = 0;
-        return( AFPERR_NOITEM );
+        return AFPERR_NOITEM;
     }
     buflen = *rbuflen - sizeof( bitmap ) - sizeof( appltag );
     if ( getfilparams(obj, vol, bitmap, path, curdir, rbuf + sizeof( bitmap ) +
                       sizeof( appltag ), &buflen, 0) != AFP_OK ) {
         *rbuflen = 0;
-        return( AFPERR_BITMAP );
+        return AFPERR_BITMAP;
     }
 
     *rbuflen = buflen + sizeof( bitmap ) + sizeof( appltag );
@@ -561,5 +561,5 @@ int afp_getappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
     rbuf += sizeof( bitmap );
     memcpy( rbuf, appltag, sizeof( appltag ));
     rbuf += sizeof( appltag );
-    return( AFP_OK );
+    return AFP_OK;
 }

--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -157,7 +157,7 @@ static int afp_null_nolog(AFPObj *obj _U_, char *ibuf _U_, size_t ibuflen _U_,
                           char *rbuf _U_, size_t *rbuflen)
 {
     *rbuflen = 0;
-    return( AFPERR_NOOP );
+    return AFPERR_NOOP;
 }
 
 static int set_auth_switch(const AFPObj *obj, int expired)
@@ -303,7 +303,7 @@ static int login(AFPObj *obj, struct passwd *pwd, void (*logout)(void), int expi
     /* Send FCE login event */
     fce_register(obj, FCE_LOGIN, "", NULL);
 
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* ---------------------- */

--- a/etc/afpd/desktop.c
+++ b/etc/afpd/desktop.c
@@ -59,7 +59,7 @@ int setdeskmode(const struct vol *vol, const mode_t mode)
         return -1 ;
     }
     if ( getcwd( wd , MAXPATHLEN) == NULL ) {
-        return( -1 );
+        return -1;
     }
 
     bstring dtpath = bfromcstr(vol->v_dbpath);
@@ -152,7 +152,7 @@ int setdeskowner(const struct vol *vol, uid_t uid, gid_t gid)
     DIR			*desk, *sub;
 
     if ( getcwd( wd, MAXPATHLEN ) == NULL ) {
-        return( -1 );
+        return -1;
     }
 
     bstring dtpath = bfromcstr(vol->v_dbpath);
@@ -254,20 +254,20 @@ int afp_opendt(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, size
     memcpy( &vid, ibuf, sizeof(vid));
     if (NULL == ( vol = getvolbyvid( vid )) ) {
         *rbuflen = 0;
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     create_appledesktop_folder(vol);
 
     memcpy( rbuf, &vid, sizeof(vid));
     *rbuflen = sizeof(vid);
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 int afp_closedt(AFPObj *obj _U_, char *ibuf _U_, size_t ibuflen _U_, char *rbuf _U_, size_t *rbuflen)
 {
     *rbuflen = 0;
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 static struct savedt	si = { { 0, 0, 0, 0 }, -1, 0, 0 };
@@ -437,7 +437,7 @@ addicon_err:
     case AFPPROTO_ASP:
         buflen = bsize;
         if ((asp_wrtcont(obj->handle, rbuf, &buflen) < 0) || buflen != bsize)
-            return(AFPERR_PARAM);
+            return AFPERR_PARAM;
 
         /*
          * We're at the end of the file, add the headers, etc.  */
@@ -460,7 +460,7 @@ addicon_err:
 
         if (writev(si.sdt_fd, iov, iovcnt) < 0) {
             LOG(log_error, logtype_afpd, "afp_addicon(%s): writev: %s", icon_dtfile(vol, fcreator), strerror(errno));
-            return(AFPERR_PARAM);
+            return AFPERR_PARAM;
         }
         break;
 #endif /* no afp/asp */
@@ -496,7 +496,7 @@ addicon_err:
 
     close( si.sdt_fd );
     si.sdt_fd = -1;
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 static const uint8_t	utag[] = { 0, 0, 0, 0 };
@@ -517,7 +517,7 @@ int afp_geticoninfo(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
     memcpy( &vid, ibuf, sizeof( vid ));
     ibuf += sizeof( vid );
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     memcpy( fcreator, ibuf, sizeof( fcreator ));
@@ -527,7 +527,7 @@ int afp_geticoninfo(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
 
     if ( memcmp( fcreator, ucreator, sizeof( ucreator )) == 0 ) {
         if ( iindex > 1 ) {
-            return( AFPERR_NOITEM );
+            return AFPERR_NOITEM;
         }
         memcpy( ih, utag, sizeof( utag ));
         memcpy( ih + sizeof( utag ), utype, sizeof( utype ));
@@ -537,16 +537,16 @@ int afp_geticoninfo(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
                 sizeof( usize ));
         memcpy( rbuf, ih, sizeof( ih ));
         *rbuflen = sizeof( ih );
-        return( AFP_OK );
+        return AFP_OK;
     }
 
     if ( iconopen( vol, fcreator, O_RDONLY, 0 ) < 0) {
-        return( AFPERR_NOITEM );
+        return AFPERR_NOITEM;
     }
 
     if ( iindex < si.sdt_index ) {
         if ( lseek( si.sdt_fd, (off_t) 0L, SEEK_SET ) < 0 ) {
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
         si.sdt_index = 1;
     }
@@ -558,18 +558,18 @@ int afp_geticoninfo(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
         if ( read( si.sdt_fd, ih, sizeof( ih )) != sizeof( ih )) {
             close( si.sdt_fd );
             si.sdt_fd = -1;
-            return( AFPERR_NOITEM );
+            return AFPERR_NOITEM;
         }
         memcpy( &bsize, ih + 10, sizeof( bsize ));
         bsize = ntohs(bsize);
         if ( lseek( si.sdt_fd, (off_t) bsize, SEEK_CUR ) < 0 ) {
             LOG(log_error, logtype_afpd, "afp_iconinfo(%s): lseek: %s", icon_dtfile(vol, fcreator), strerror(errno) );
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
         if ( si.sdt_index == iindex ) {
             memcpy( rbuf, ih, sizeof( ih ));
             *rbuflen = sizeof( ih );
-            return( AFP_OK );
+            return AFP_OK;
         }
         si.sdt_index++;
     }
@@ -591,7 +591,7 @@ int afp_geticon(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
     memcpy( &vid, ibuf, sizeof( vid ));
     ibuf += sizeof( vid );
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     memcpy( fcreator, ibuf, sizeof( fcreator ));
@@ -605,14 +605,14 @@ int afp_geticon(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
 
 
     if ( iconopen( vol, fcreator, O_RDONLY, 0 ) < 0) {
-        return( AFPERR_NOITEM );
+        return AFPERR_NOITEM;
     }
 
     if ( lseek( si.sdt_fd, (off_t) 0L, SEEK_SET ) < 0 ) {
         close(si.sdt_fd);
         si.sdt_fd = -1;
         LOG(log_error, logtype_afpd, "afp_geticon(%s): lseek: %s", icon_dtfile(vol, fcreator), strerror(errno));
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     si.sdt_index = 1;
@@ -628,18 +628,18 @@ int afp_geticon(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
         rsize = ntohs( rsize );
         if ( lseek( si.sdt_fd, (off_t) rsize, SEEK_CUR ) < 0 ) {
             LOG(log_error, logtype_afpd, "afp_geticon(%s): lseek: %s", icon_dtfile(vol, fcreator), strerror(errno) );
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
         offset += rsize;
     }
 
     if ( rc < 0 ) {
         LOG(log_error, logtype_afpd, "afp_geticon(%s): read: %s", icon_dtfile(vol, fcreator), strerror(errno));
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if ( rc == 0 ) {
-        return( AFPERR_NOITEM );
+        return AFPERR_NOITEM;
     }
 
     memcpy( &rsize, ih + 10, sizeof( rsize ));
@@ -704,7 +704,7 @@ geticon_exit:
 
     } else {
         if ( read( si.sdt_fd, rbuf, rc ) < rc ) {
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
         *rbuflen = rc;
     }
@@ -744,7 +744,7 @@ char *dtfile(const struct vol *vol, uint8_t creator[], char *ext )
     *p = '\0';
     strcat( path, ext );
 
-    return( path );
+    return path;
 }
 
 /* ---------------------------
@@ -785,7 +785,7 @@ char *mtoupath(const struct vol *vol, char *mpath, cnid_t did, int utf8)
     }
 
     LOG(log_debug9, logtype_afpd, "mtoupath: '%s':'%s'", mpath, upath);
-    return( upath );
+    return upath;
 }
 
 /* ---------------
@@ -819,12 +819,12 @@ char *utompath(const struct vol *vol, char *upath, cnid_t id, int utf8)
     m = mangle(vol, mpath, outlen, upath, id, flags);
 
     LOG(log_debug9, logtype_afpd, "utompath: '%s':'%s':'%2.2X'", upath, m, ntohl(id));
-    return(m);
+    return m;
 
 utompath_error:
     u = "???";
     m = mangle(vol, u, strlen(u), upath, id, (utf8)?3:1);
-    return(m);
+    return m;
 }
 
 /* ------------------------- */
@@ -854,7 +854,7 @@ static int ad_addcomment(const AFPObj *obj, struct vol *vol, struct path *path, 
     if (ad_open(adp, upath,
                 ADFLAGS_HF | ( (isadir) ? ADFLAGS_DIR : 0) | ADFLAGS_CREATE | ADFLAGS_RDWR,
                 0666) < 0 ) {
-        return( AFPERR_ACCESS );
+        return AFPERR_ACCESS;
     }
 
     if (ad_getentryoff(adp, ADEID_COMMENT) && ad_entry(adp, ADEID_COMMENT)) {
@@ -871,7 +871,7 @@ static int ad_addcomment(const AFPObj *obj, struct vol *vol, struct path *path, 
         ad_flush( adp );
     }
     ad_close(adp, ADFLAGS_HF);
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* ----------------------------- */
@@ -889,7 +889,7 @@ int afp_addcomment(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, 
     memcpy( &vid, ibuf, sizeof( vid ));
     ibuf += sizeof( vid );
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     memcpy( &did, ibuf, sizeof( did ));
@@ -927,7 +927,7 @@ static int ad_getcomment(struct vol *vol, struct path *path, char *rbuf, size_t 
         adp = of->of_ad;
 
     if ( ad_metadata( upath, ((isadir) ? ADFLAGS_DIR : 0), adp) < 0 ) {
-        return( AFPERR_NOITEM );
+        return AFPERR_NOITEM;
     }
 
     if (!ad_getentryoff(adp, ADEID_COMMENT) || !ad_entry(adp, ADEID_COMMENT)) {
@@ -940,7 +940,7 @@ static int ad_getcomment(struct vol *vol, struct path *path, char *rbuf, size_t 
     if ( ad_getentrylen( adp, ADEID_COMMENT ) <= 0 ||
             ad_getentrylen( adp, ADEID_COMMENT ) > 199 ) {
         ad_close(adp, ADFLAGS_HF);
-        return( AFPERR_NOITEM );
+        return AFPERR_NOITEM;
     }
 
     clen = min( ad_getentrylen( adp, ADEID_COMMENT ), 128 ); /* OSX only use 128, greater kill Adobe CS2 */
@@ -949,7 +949,7 @@ static int ad_getcomment(struct vol *vol, struct path *path, char *rbuf, size_t 
     *rbuflen = clen + 1;
     ad_close(adp, ADFLAGS_HF);
 
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* -------------------- */
@@ -967,7 +967,7 @@ int afp_getcomment(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, 
     memcpy( &vid, ibuf, sizeof( vid ));
     ibuf += sizeof( vid );
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     memcpy( &did, ibuf, sizeof( did ));
@@ -1006,11 +1006,11 @@ static int ad_rmvcomment(const AFPObj *obj, struct vol *vol, struct path *path)
     if ( ad_open(adp, upath, ADFLAGS_HF | ADFLAGS_RDWR | ((isadir) ? ADFLAGS_DIR : 0)) < 0 ) {
         switch ( errno ) {
         case ENOENT :
-            return( AFPERR_NOITEM );
+            return AFPERR_NOITEM;
         case EACCES :
-            return( AFPERR_ACCESS );
+            return AFPERR_ACCESS;
         default :
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
     }
 
@@ -1019,7 +1019,7 @@ static int ad_rmvcomment(const AFPObj *obj, struct vol *vol, struct path *path)
         ad_flush( adp );
     }
     ad_close(adp, ADFLAGS_HF);
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* ----------------------- */
@@ -1037,7 +1037,7 @@ int afp_rmvcomment(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _
     memcpy( &vid, ibuf, sizeof( vid ));
     ibuf += sizeof( vid );
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     memcpy( &did, ibuf, sizeof( did ));

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -116,19 +116,19 @@ static int netatalk_mkdir(const struct vol *vol, const char *name)
     if (ret < 0) {
         switch ( errno ) {
         case ENOENT :
-            return( AFPERR_NOOBJ );
+            return AFPERR_NOOBJ;
         case EROFS :
-            return( AFPERR_VLOCK );
+            return AFPERR_VLOCK;
         case EPERM:
         case EACCES :
-            return( AFPERR_ACCESS );
+            return AFPERR_ACCESS;
         case EEXIST :
-            return( AFPERR_EXIST );
+            return AFPERR_EXIST;
         case ENOSPC :
         case EDQUOT :
-            return( AFPERR_DFULL );
+            return AFPERR_DFULL;
         default :
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
     }
     return AFP_OK;
@@ -816,7 +816,7 @@ exit:
             ntohl(cdir->d_did), cfrombstr(cdir->d_fullpath));
     }
 
-    return(cdir);
+    return cdir;
 }
 
 /*!
@@ -936,7 +936,7 @@ struct path *cname(struct vol *vol, struct dir *dir, char **cpath)
         /* else it's an error */
     default:
         afp_errno = AFPERR_PARAM;
-        return( NULL );
+        return NULL;
     }
     *cpath += len + size;
 
@@ -1164,11 +1164,11 @@ int movecwd(const struct vol *vol, struct dir *dir)
         default:
             afp_errno = AFPERR_NOOBJ;
         }
-        return( -1 );
+        return -1;
     }
 
     curdir = dir;
-    return( 0 );
+    return 0;
 }
 
 /*
@@ -1462,7 +1462,7 @@ int getdirparams(const AFPObj *obj,
             if ( isad ) {
                 ad_close(&ad, ADFLAGS_HF);
             }
-            return( AFPERR_BITMAP );
+            return AFPERR_BITMAP;
         }
         bitmap = bitmap>>1;
         bit++;
@@ -1481,7 +1481,7 @@ int getdirparams(const AFPObj *obj,
         ad_close(&ad, ADFLAGS_HF);
     }
     *buflen = data - buf;
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* ----------------------------- */
@@ -1514,7 +1514,7 @@ int afp_setdirparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_
     ibuf += sizeof( vid );
 
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if (vol->v_flags & AFPVOL_RO)
@@ -1552,7 +1552,7 @@ int afp_setdirparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_
     if (AFP_OK == ( rc = setdirparams(vol, path, bitmap, ibuf )) ) {
         setvoltime(obj, vol );
     }
-    return( rc );
+    return rc;
 }
 
 /*
@@ -1897,7 +1897,7 @@ int afp_syncdir(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
     memcpy( &vid, ibuf, sizeof( vid ));
     ibuf += sizeof( vid );
     if (NULL == (vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     memcpy( &did, ibuf, sizeof( did ));
@@ -1919,7 +1919,7 @@ int afp_syncdir(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
         }
 
         if (movecwd( vol, dir ) < 0 )
-            return ( AFPERR_NOOBJ );
+            return AFPERR_NOOBJ;
 
         /*
          * Assuming only OSens that have dirfd also may require fsyncing directories
@@ -1930,11 +1930,11 @@ int afp_syncdir(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
         if (NULL == ( dp = opendir( "." )) ) {
             switch( errno ) {
             case ENOENT :
-                return( AFPERR_NOOBJ );
+                return AFPERR_NOOBJ;
             case EACCES :
-                return( AFPERR_ACCESS );
+                return AFPERR_ACCESS;
             default :
-                return( AFPERR_PARAM );
+                return AFPERR_PARAM;
             }
         }
 
@@ -1950,11 +1950,11 @@ int afp_syncdir(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
         if ( -1 == (dfd = open(vol->ad_path(".", ADFLAGS_DIR), O_RDWR))) {
             switch( errno ) {
             case ENOENT:
-                return( AFPERR_NOOBJ );
+                return AFPERR_NOOBJ;
             case EACCES:
-                return( AFPERR_ACCESS );
+                return AFPERR_ACCESS;
             default:
-                return( AFPERR_PARAM );
+                return AFPERR_PARAM;
             }
         }
 
@@ -1967,7 +1967,7 @@ int afp_syncdir(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
         close(dfd);
     }
 
-    return ( AFP_OK );
+    return AFP_OK;
 }
 
 int afp_createdir(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t *rbuflen)
@@ -1987,7 +1987,7 @@ int afp_createdir(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_
     memcpy( &vid, ibuf, sizeof( vid ));
     ibuf += sizeof( vid );
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if (vol->v_flags & AFPVOL_RO)
@@ -2027,12 +2027,12 @@ int afp_createdir(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_
     }
 
     if ( movecwd( vol, dir ) < 0 ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     ad_init(&ad, vol);
     if (ad_open(&ad, ".", ADFLAGS_HF | ADFLAGS_DIR | ADFLAGS_CREATE | ADFLAGS_RDWR, 0777) < 0)  {
-        return( AFPERR_ACCESS );
+        return AFPERR_ACCESS;
     }
     ad_setname(&ad, s_path->m_name);
     ad_setid( &ad, s_path->st.st_dev, s_path->st.st_ino, dir->d_did, did, vol->v_stamp);
@@ -2045,7 +2045,7 @@ int afp_createdir(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_
     memcpy( rbuf, &dir->d_did, sizeof( uint32_t ));
     *rbuflen = sizeof( uint32_t );
     setvoltime(obj, vol );
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /*
@@ -2068,9 +2068,9 @@ int renamedir(struct vol *vol,
     if ( unix_rename(dirfd, src, -1, dst ) < 0 ) {
         switch ( errno ) {
         case ENOENT :
-            return( AFPERR_NOOBJ );
+            return AFPERR_NOOBJ;
         case EACCES :
-            return( AFPERR_ACCESS );
+            return AFPERR_ACCESS;
         case EROFS:
             return AFPERR_VLOCK;
         case EINVAL:
@@ -2087,7 +2087,7 @@ int renamedir(struct vol *vol,
                 return err;
             break;
         default :
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
     }
 
@@ -2101,7 +2101,7 @@ int renamedir(struct vol *vol,
         ad_close(&ad, ADFLAGS_HF);
     }
 
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* delete an empty directory */
@@ -2113,7 +2113,7 @@ int deletecurdir(struct vol *vol)
     int err;
 
     if ((pdir = dirlookup(vol, curdir->d_pdid)) == NULL) {
-        return( AFPERR_ACCESS );
+        return AFPERR_ACCESS;
     }
 
     fdir = curdir;
@@ -2185,7 +2185,7 @@ int afp_mapid(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t *r
 
     if (sfunc >= 3 && sfunc <= 6) {
         if (obj->afp_version < 30) {
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
         utf8 = 1;
     }
@@ -2197,7 +2197,7 @@ int afp_mapid(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t *r
         id = ntohl(id);
         if ( id != 0 ) {
             if (( pw = getpwuid( id )) == NULL ) {
-                return( AFPERR_NOITEM );
+                return AFPERR_NOITEM;
             }
             len = convert_string_allocate( obj->options.unixcharset, ((!utf8)?obj->options.maccharset:CH_UTF8_MAC),
                                            pw->pw_name, -1, &name);
@@ -2212,7 +2212,7 @@ int afp_mapid(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t *r
         id = ntohl(id);
         if ( id != 0 ) {
             if (NULL == ( gr = (struct group *)getgrgid( id ))) {
-                return( AFPERR_NOITEM );
+                return AFPERR_NOITEM;
             }
             len = convert_string_allocate( obj->options.unixcharset, (!utf8)?obj->options.maccharset:CH_UTF8_MAC,
                                            gr->gr_name, -1, &name);
@@ -2234,7 +2234,7 @@ int afp_mapid(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t *r
         switch (type) {
         case UUID_USER:
             if (( pw = getpwnam( name )) == NULL )
-                return( AFPERR_NOITEM );
+                return AFPERR_NOITEM;
             LOG(log_debug, logtype_afpd, "afp_mapid: name:%s -> uid:%d", name, pw->pw_uid);
             id = htonl(UUID_USER);
             memcpy( rbuf, &id, sizeof( id ));
@@ -2246,7 +2246,7 @@ int afp_mapid(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t *r
             break;
         case UUID_GROUP:
             if (( gr = getgrnam( name )) == NULL )
-                return( AFPERR_NOITEM );
+                return AFPERR_NOITEM;
             LOG(log_debug, logtype_afpd, "afp_mapid: group:%s -> gid:%d", name, gr->gr_gid);
             id = htonl(UUID_GROUP);
             memcpy( rbuf, &id, sizeof( id ));
@@ -2262,7 +2262,7 @@ int afp_mapid(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t *r
         break;
 
     default :
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if (name)
@@ -2284,7 +2284,7 @@ int afp_mapid(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t *r
     *rbuflen += len;
     if (name)
         free(name);
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 int afp_mapname(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t *rbuflen)
@@ -2303,7 +2303,7 @@ int afp_mapname(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
     case 1 :
     case 2 : /* unicode */
         if (obj->afp_version < 30) {
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
         memcpy(&ulen, ibuf, sizeof(ulen));
         len = ntohs(ulen);
@@ -2323,7 +2323,7 @@ int afp_mapname(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
         ibuf += 2;
         break;
     default :
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if (len >= ibuflen - 1)
@@ -2338,7 +2338,7 @@ int afp_mapname(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
         case 1 : /* unicode */
         case 3 :
             if (NULL == ( pw = (struct passwd *)getpwnam( ibuf )) ) {
-                return( AFPERR_NOITEM );
+                return AFPERR_NOITEM;
             }
             id = pw->pw_uid;
             id = htonl(id);
@@ -2350,7 +2350,7 @@ int afp_mapname(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
         case 4 :
             LOG(log_debug, logtype_afpd, "afp_mapname: getgrnam for name: %s",ibuf);
             if (NULL == ( gr = (struct group *)getgrnam( ibuf ))) {
-                return( AFPERR_NOITEM );
+                return AFPERR_NOITEM;
             }
             id = gr->gr_gid;
             LOG(log_debug, logtype_afpd, "afp_mapname: getgrnam for name: %s -> id: %d",ibuf, id);
@@ -2372,7 +2372,7 @@ int afp_mapname(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
             break;
         }
     }
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* ------------------------------------
@@ -2404,7 +2404,7 @@ int afp_opendir(AFPObj *obj _U_, char *ibuf, size_t ibuflen  _U_, char *rbuf, si
     ibuf += sizeof( vid );
 
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     memcpy(&did, ibuf, sizeof(did));
@@ -2423,10 +2423,10 @@ int afp_opendir(AFPObj *obj _U_, char *ibuf, size_t ibuflen  _U_, char *rbuf, si
     }
 
     if ( !path->st_valid && of_stat(vol, path) < 0 ) {
-        return( AFPERR_NOOBJ );
+        return AFPERR_NOOBJ;
     }
     if ( path->st_errno ) {
-        return( AFPERR_NOOBJ );
+        return AFPERR_NOOBJ;
     }
 
     memcpy(rbuf, &curdir->d_did, sizeof(curdir->d_did));

--- a/etc/afpd/enumerate.c
+++ b/etc/afpd/enumerate.c
@@ -193,7 +193,7 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
 
     if (NULL == ( vol = getvolbyvid( vid )) ) {
         *rbuflen = 0;
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     memcpy( &did, ibuf, sizeof( did ));
@@ -324,7 +324,7 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
         len = (unsigned char)*(sd.sd_last)++;
         if ( len == 0 ) {
             sd.sd_did = 0;	/* invalidate sd struct to force re-read */
-            return( AFPERR_NOOBJ );
+            return AFPERR_NOOBJ;
         }
         sd.sd_last += len + 1;
         sd.sd_sindex++;
@@ -403,7 +403,7 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
                 }
             }
             if ((ret = getdirparams(obj, vol, dbitmap, &s_path, dir, data + header , &esz)) != AFP_OK)
-                return( ret );
+                return ret;
 
         } else {
             if ( fbitmap == 0 ) {
@@ -412,7 +412,7 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
             /* files are added to the dircache in getfilparams() -> getmetadata() */
             if (AFP_OK != ( ret = getfilparams(obj, vol, fbitmap, &s_path, curdir,
                                                data + header, &esz, 1)) ) {
-                return( ret );
+                return ret;
             }
         }
 
@@ -469,7 +469,7 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
         if (vol->v_adouble == AD_VERSION_EA && ! (vol->v_flags & AFPVOL_NOV2TOEACONV))
             (void)rmdir(".AppleDouble");
 
-        return( AFPERR_NOOBJ );
+        return AFPERR_NOOBJ;
     }
     sd.sd_sindex = sindex + actcnt;
 
@@ -486,7 +486,7 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
     memcpy( rbuf, &actcnt, sizeof( actcnt ));
     rbuf += sizeof( actcnt );
     *rbuflen = sz;
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* ----------------------------- */

--- a/etc/afpd/extattrs.c
+++ b/etc/afpd/extattrs.c
@@ -113,7 +113,7 @@ int afp_listextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
         of_statdir(vol, s_path);
     }
     if (s_path->st_errno != 0) {
-        return(AFPERR_NOOBJ);
+        return AFPERR_NOOBJ;
     }
 
     uname = s_path->u_name;

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -594,7 +594,7 @@ int getmetadata(const AFPObj *obj,
             break;
 
         default :
-            return( AFPERR_BITMAP );
+            return AFPERR_BITMAP;
         }
         bitmap = bitmap>>1;
         bit++;
@@ -610,7 +610,7 @@ int getmetadata(const AFPObj *obj,
         data = set_name(vol, data, dir->d_did, path->m_name, id, utf8);
     }
     *buflen = data - buf;
-    return (AFP_OK);
+    return AFP_OK;
 }
 
 /* ----------------------- */
@@ -660,7 +660,7 @@ int getfilparams(const AFPObj *obj, struct vol *vol, uint16_t bitmap, struct pat
     if (opened)
         ad_close(adp, ADFLAGS_HF | flags);
 
-    return( rc );
+    return rc;
 }
 
 /* ----------------------------- */
@@ -683,7 +683,7 @@ int afp_createfile(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, 
     ibuf += sizeof( vid );
 
     if (NULL == ( vol = getvolbyvid( vid )) )
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
 
     if (vol->v_flags & AFPVOL_RO)
         return AFPERR_VLOCK;
@@ -697,7 +697,7 @@ int afp_createfile(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, 
     if (NULL == ( s_path = cname( vol, dir, &ibuf )) )
         return get_afp_errno(AFPERR_PARAM);
     if ( *s_path->m_name == '\0' )
-        return( AFPERR_BADTYPE );
+        return AFPERR_BADTYPE;
 
     upath = s_path->u_name;
     ad_init(&ad, vol);
@@ -722,17 +722,17 @@ int afp_createfile(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, 
         case EROFS:
             return AFPERR_VLOCK;
         case ENOENT : /* we were already in 'did folder' so chdir() didn't fail */
-            return ( AFPERR_NOOBJ );
+            return AFPERR_NOOBJ;
         case EEXIST :
-            return( AFPERR_EXIST );
+            return AFPERR_EXIST;
         case EACCES :
-            return( AFPERR_ACCESS );
+            return AFPERR_ACCESS;
         case EDQUOT:
         case ENOSPC :
 	    LOG(log_info, logtype_afpd, "afp_createfile: DISK FULL");
-            return( AFPERR_DFULL );
+            return AFPERR_DFULL;
         default :
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
     }
     if ( ad_meta_fileno( &ad ) == -1 ) { /* Hard META / HF */
@@ -770,7 +770,7 @@ createfile_iderr:
     curdir->d_offcnt++;
     setvoltime(obj, vol );
 
-    return (retvalue);
+    return retvalue;
 }
 
 int afp_setfilparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, size_t *rbuflen)
@@ -787,7 +787,7 @@ int afp_setfilparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_
     memcpy(&vid, ibuf, sizeof( vid ));
     ibuf += sizeof( vid );
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if (vol->v_flags & AFPVOL_RO)
@@ -808,11 +808,11 @@ int afp_setfilparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_
     }
 
     if (path_isadir(s_path)) {
-        return( AFPERR_BADTYPE ); /* it's a directory */
+        return AFPERR_BADTYPE; /* it's a directory */
     }
 
     if ( s_path->st_errno != 0 ) {
-        return( AFPERR_NOOBJ );
+        return AFPERR_NOOBJ;
     }
 
     if ((intptr_t)ibuf & 1 ) {
@@ -823,7 +823,7 @@ int afp_setfilparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_
         setvoltime(obj, vol );
     }
 
-    return( rc );
+    return rc;
 }
 
 /*
@@ -1149,10 +1149,10 @@ int renamefile(struct vol *vol, struct dir *ddir, int sdir_fd, char *src, char *
     if ( unix_rename( sdir_fd, src, -1, dst ) < 0 ) {
         switch ( errno ) {
         case ENOENT :
-            return( AFPERR_NOOBJ );
+            return AFPERR_NOOBJ;
         case EPERM:
         case EACCES :
-            return( AFPERR_ACCESS );
+            return AFPERR_ACCESS;
         case EROFS:
             return AFPERR_VLOCK;
         case EXDEV :			/* Cross device move -- try copy */
@@ -1166,11 +1166,11 @@ int renamefile(struct vol *vol, struct dir *ddir, int sdir_fd, char *src, char *
     	    }
             if (AFP_OK != ( rc = copyfile(vol, vol, ddir, sdir_fd, src, dst, newname, NULL )) ) {
                 /* on error copyfile delete dest */
-                return( rc );
+                return rc;
             }
             return deletefile(vol, sdir_fd, src, 0);
         default :
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
     }
 
@@ -1205,7 +1205,7 @@ int renamefile(struct vol *vol, struct dir *ddir, int sdir_fd, char *src, char *
         ad_close( adp, ADFLAGS_HF );
     }
 
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* ----------------
@@ -1301,7 +1301,7 @@ int afp_copyfile(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, si
     memcpy(&svid, ibuf, sizeof( svid ));
     ibuf += sizeof( svid );
     if (NULL == ( s_vol = getvolbyvid( svid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     memcpy(&sdid, ibuf, sizeof( sdid ));
@@ -1319,7 +1319,7 @@ int afp_copyfile(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, si
         return get_afp_errno(AFPERR_PARAM);
     }
     if ( path_isadir(s_path) ) {
-        return( AFPERR_BADTYPE );
+        return AFPERR_BADTYPE;
     }
 
     /* don't allow copies when the file is open.
@@ -1414,7 +1414,7 @@ copy_exit:
         fce_register(obj, FCE_FILE_CREATE, fullpathname(upath), NULL);
     }
     ad_close( adp, ADFLAGS_DF |ADFLAGS_HF | ADFLAGS_SETSHRMD);
-    return( retvalue );
+    return retvalue;
 }
 
 /* ----------------------------------
@@ -1696,7 +1696,7 @@ int afp_createid(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, si
     ibuf += sizeof(vid);
 
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM);
+        return AFPERR_PARAM;
     }
 
     if (vol->v_cdb == NULL || !(vol->v_cdb->cnid_db_flags & CNID_FLAG_PERSISTENT)) {
@@ -1718,7 +1718,7 @@ int afp_createid(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, si
     }
 
     if ( path_isadir(s_path) ) {
-        return( AFPERR_BADTYPE );
+        return AFPERR_BADTYPE;
     }
 
     upath = s_path->u_name;
@@ -1835,7 +1835,7 @@ int afp_resolveid(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_
     ibuf += sizeof(vid);
 
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM);
+        return AFPERR_PARAM;
     }
 
     if (vol->v_cdb == NULL || !(vol->v_cdb->cnid_db_flags & CNID_FLAG_PERSISTENT)) {
@@ -1943,7 +1943,7 @@ int afp_deleteid(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _U_
     ibuf += sizeof(vid);
 
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM);
+        return AFPERR_PARAM;
     }
 
     if (vol->v_cdb == NULL || !(vol->v_cdb->cnid_db_flags & CNID_FLAG_PERSISTENT)) {
@@ -1969,7 +1969,7 @@ int afp_deleteid(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _U_
             err = AFPERR_NOOBJ;
             goto delete;
         }
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     err = AFP_OK;
@@ -2089,7 +2089,7 @@ int afp_exchangefiles(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U
     ibuf += sizeof(vid);
 
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM);
+        return AFPERR_PARAM;
     }
 
     if ((vol->v_flags & AFPVOL_RO))

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -57,7 +57,7 @@ int afp_getfildirparams(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *r
         /* was AFPERR_PARAM but it helps OS 10.3 when a volume has been removed
          * from the list.
          */
-        return( AFPERR_ACCESS );
+        return AFPERR_ACCESS;
     }
 
     memcpy( &did, ibuf, sizeof( did ));
@@ -93,7 +93,7 @@ int afp_getfildirparams(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *r
     }
     if ( s_path->st_errno != 0 ) {
         if (afp_errno != AFPERR_ACCESS) {
-            return( AFPERR_NOOBJ );
+            return AFPERR_NOOBJ;
         }
     }
 
@@ -108,14 +108,14 @@ int afp_getfildirparams(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *r
             ret = getdirparams(obj, vol, dbitmap, s_path, dir,
                                rbuf + 3 * sizeof( uint16_t ), &buflen );
             if (ret != AFP_OK )
-                return( ret );
+                return ret;
         }
         /* this is a directory */
         *(rbuf + 2 * sizeof( uint16_t )) = (char) FILDIRBIT_ISDIR;
     } else {
         if (fbitmap && AFP_OK != (ret = getfilparams(obj, vol, fbitmap, s_path, curdir,
                                                      rbuf + 3 * sizeof( uint16_t ), &buflen, 0)) ) {
-            return( ret );
+            return ret;
         }
         /* this is a file */
         *(rbuf + 2 * sizeof( uint16_t )) = FILDIRBIT_ISFILE;
@@ -129,7 +129,7 @@ int afp_getfildirparams(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *r
     rbuf += sizeof( dbitmap ) + sizeof( uint8_t );
     *rbuf = 0;
 
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 int afp_setfildirparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, size_t *rbuflen)
@@ -147,7 +147,7 @@ int afp_setfildirparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf 
     ibuf += sizeof( vid );
 
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if (vol->v_flags & AFPVOL_RO)
@@ -178,7 +178,7 @@ int afp_setfildirparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf 
 
     if ( path->st_errno != 0 ) {
         if (afp_errno != AFPERR_ACCESS)
-            return( AFPERR_NOOBJ );
+            return AFPERR_NOOBJ;
     }
     /*
      * If ibuf is odd, make it even.
@@ -196,7 +196,7 @@ int afp_setfildirparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf 
         setvoltime(obj, vol );
     }
 
-    return( rc );
+    return rc;
 }
 
 /* --------------------------------------------
@@ -420,7 +420,7 @@ int afp_rename(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, size
     memcpy( &vid, ibuf, sizeof( vid ));
     ibuf += sizeof( vid );
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if (vol->v_flags & AFPVOL_RO)
@@ -450,7 +450,7 @@ int afp_rename(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, size
     }
     else {
         if ( sdir->d_did == DIRDID_ROOT ) { /* root directory */
-            return( AFPERR_NORENAME );
+            return AFPERR_NORENAME;
         }
         /* move to destination dir */
         if ( movecwd( vol, dirlookup(vol, sdir->d_pdid) ) < 0 ) {
@@ -461,7 +461,7 @@ int afp_rename(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, size
 
     /* another place where we know about the path type */
     if ((plen = copy_path_name(vol, newname, ibuf)) < 0) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if (!plen) {
@@ -473,7 +473,7 @@ int afp_rename(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, size
         setvoltime(obj, vol );
     }
 
-    return( rc );
+    return rc;
 }
 
 /*
@@ -570,7 +570,7 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, size
     memcpy( &vid, ibuf, sizeof( vid ));
     ibuf += sizeof( vid );
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if (vol->v_flags & AFPVOL_RO)
@@ -662,7 +662,7 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, size
         setvoltime(obj, vol );
     }
 
-    return( rc );
+    return rc;
 }
 /* ------------------------ */
 char *absupath(const struct vol *vol, struct dir *dir, char *u)
@@ -689,7 +689,7 @@ char *absupath(const struct vol *vol, struct dir *dir, char *u)
     strncpy(pathbuf, cfrombstr(path), blength(path) + 1);
     bdestroy(path);
 
-    return(pathbuf);
+    return pathbuf;
 }
 
 char *ctoupath(const struct vol *vol, struct dir *dir, char *name)
@@ -721,7 +721,7 @@ int afp_moveandrename(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U
     memcpy( &vid, ibuf, sizeof( vid ));
     ibuf += sizeof( vid );
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if (vol->v_flags & AFPVOL_RO)
@@ -810,7 +810,7 @@ exit:
     if (sdir_fd != -1)
         close(sdir_fd);
 
-    return( rc );
+    return rc;
 }
 
 int veto_file(const char*veto_str, const char*path)

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -51,7 +51,7 @@ static int getforkparams(const AFPObj *obj, struct ofork *ofork, uint16_t bitmap
          ||
          ( (bitmap & ((1<<FILPBIT_RFLEN) | (1<<FILPBIT_EXTRFLEN)))
            && (ofork->of_flags & AFPFORK_DATA))) {
-        return( AFPERR_BITMAP );
+        return AFPERR_BITMAP;
     }
 
     if (! AD_META_OPEN(ofork->of_ad)) {
@@ -64,7 +64,7 @@ static int getforkparams(const AFPObj *obj, struct ofork *ofork, uint16_t bitmap
     dir = dirlookup(vol, ofork->of_did);
 
     if (NULL == (path.u_name = mtoupath(vol, of_name(ofork), dir->d_did, utf8_encoding(obj)))) {
-        return( AFPERR_MISC );
+        return AFPERR_MISC;
     }
     path.m_name = of_name(ofork);
     path.id = 0;
@@ -75,12 +75,12 @@ static int getforkparams(const AFPObj *obj, struct ofork *ofork, uint16_t bitmap
         if ( ad_data_fileno( ofork->of_ad ) <= 0 ) {
             /* 0 is for symlink */
             if (movecwd(vol, dir) < 0)
-                return( AFPERR_NOOBJ );
+                return AFPERR_NOOBJ;
             if ( lstat( path.u_name, st ) < 0 )
-                return( AFPERR_NOOBJ );
+                return AFPERR_NOOBJ;
         } else {
             if ( fstat( ad_data_fileno( ofork->of_ad ), st ) < 0 ) {
-                return( AFPERR_BITMAP );
+                return AFPERR_BITMAP;
             }
         }
     }
@@ -264,7 +264,7 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, si
 
     *rbuflen = 0;
     if (NULL == ( vol = getvolbyvid( vid ))) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     memcpy(&did, ibuf, sizeof( did ));
@@ -449,7 +449,7 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, si
             of_dealloc(ofork);
             ofrefnum = 0;
             memcpy(rbuf, &ofrefnum, sizeof(ofrefnum));
-            return(AFPERR_OLOCK);
+            return AFPERR_OLOCK;
         }
     }
 
@@ -474,12 +474,12 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, si
             case EINVAL:
                 ofrefnum = 0;
                 memcpy(rbuf, &ofrefnum, sizeof(ofrefnum));
-                return( AFPERR_DENYCONF );
+                return AFPERR_DENYCONF;
                 break;
             default:
                 *rbuflen = 0;
                 LOG(log_error, logtype_afpd, "afp_openfork(%s): ad_lock: %s", s_path->m_name, strerror(ret) );
-                return( AFPERR_PARAM );
+                return AFPERR_PARAM;
             }
         }
         if ((access & OPENACC_WR))
@@ -493,7 +493,7 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, si
         fullpathname(s_path->m_name), ofork->of_refnum);
 
     memcpy(rbuf, &ofrefnum, sizeof(ofrefnum));
-    return( AFP_OK );
+    return AFP_OK;
 
 openfork_err:
     of_dealloc(ofork);
@@ -526,7 +526,7 @@ int afp_setforkparams(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf _U_, s
     *rbuflen = 0;
     if (NULL == ( ofork = of_find( ofrefnum )) ) {
         LOG(log_error, logtype_afpd, "afp_setforkparams: of_find(%d) could not locate fork", ofrefnum );
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     vol = ofork->of_vol;
@@ -613,7 +613,7 @@ int afp_setforkparams(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf _U_, s
     } else
         return AFPERR_BITMAP;
 
-    return( AFP_OK );
+    return AFP_OK;
 
 afp_setfork_err:
     if (err == -2)
@@ -667,7 +667,7 @@ static int byte_lock(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf
 
     if (NULL == ( ofork = of_find( ofrefnum )) ) {
         LOG(log_error, logtype_afpd, "byte_lock: of_find(%d) could not locate fork", ofrefnum );
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if ( ofork->of_flags & AFPFORK_DATA) {
@@ -721,7 +721,7 @@ static int byte_lock(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf
         }
     }
     *rbuflen = set_off_t (offset, rbuf, is64);
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* --------------------------- */
@@ -758,7 +758,7 @@ static int read_file(const struct ofork *ofork, int eid, off_t offset, char *rbu
     if ( cc < 0 ) {
         LOG(log_error, logtype_afpd, "afp_read(%s): ad_read: %s", of_name(ofork), strerror(errno) );
         *rbuflen = 0;
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if ((size_t)cc < *rbuflen)
@@ -767,7 +767,7 @@ static int read_file(const struct ofork *ofork, int eid, off_t offset, char *rbu
     *rbuflen = cc;
 
     if ( eof ) {
-        return( AFPERR_EOF );
+        return AFPERR_EOF;
     }
     return AFP_OK;
 }
@@ -982,11 +982,11 @@ int afp_flush(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, s
 
     memcpy(&vid, ibuf, sizeof(vid));
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     of_flush(vol);
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 int afp_flushfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, size_t *rbuflen)
@@ -1000,7 +1000,7 @@ int afp_flushfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _U
 
     if (NULL == ( ofork = of_find( ofrefnum )) ) {
         LOG(log_error, logtype_afpd, "afp_flushfork: of_find(%d) could not locate fork", ofrefnum );
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     LOG(log_debug, logtype_afpd, "afp_flushfork(fork: %s)",
@@ -1010,7 +1010,7 @@ int afp_flushfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _U
         LOG(log_error, logtype_afpd, "afp_flushfork(%s): %s", of_name(ofork), strerror(errno) );
     }
 
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /*
@@ -1032,7 +1032,7 @@ int afp_syncfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _U_
 
     if (NULL == ( ofork = of_find( ofrefnum )) ) {
         LOG(log_error, logtype_afpd, "afpd_syncfork: of_find(%d) could not locate fork", ofrefnum );
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     LOG(log_debug, logtype_afpd, "afp_syncfork(fork: %s)",
@@ -1043,7 +1043,7 @@ int afp_syncfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf _U_
         return AFPERR_MISC;
     }
 
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* this is very similar to closefork */
@@ -1085,7 +1085,7 @@ int flushfork(struct ofork *ofork)
                 of_name(ofork), ad_reso_fileno(ofork->of_ad), strerror(errno) );
     }
 
-    return( err );
+    return err;
 }
 
 int afp_closefork(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, size_t *rbuflen)
@@ -1099,7 +1099,7 @@ int afp_closefork(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, s
 
     if (NULL == ( ofork = of_find( ofrefnum )) ) {
         LOG(log_error, logtype_afpd, "afp_closefork: of_find(%d) could not locate fork", ofrefnum );
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     LOG(log_debug, logtype_afpd, "afp_closefork(fork: %" PRIu16 " [%s])",
@@ -1107,10 +1107,10 @@ int afp_closefork(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, s
 
     if (of_closefork(obj, ofork) < 0 ) {
         LOG(log_error, logtype_afpd, "afp_closefork: of_closefork: %s", strerror(errno) );
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 
@@ -1130,12 +1130,12 @@ static ssize_t write_file(struct ofork *ofork, int eid,
         case EFBIG :
         case ENOSPC :
             LOG(log_error, logtype_afpd, "write_file: DISK FULL");
-            return( AFPERR_DFULL );
+            return AFPERR_DFULL;
         case EACCES:
             return AFPERR_ACCESS;
         default :
             LOG(log_error, logtype_afpd, "afp_write(%s): ad_write: %s", of_name(ofork), strerror(errno) );
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
     }
 
@@ -1246,7 +1246,7 @@ static int write_fork(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, s
         if (asp_wrtcont(obj->handle, rbuf, rbuflen) < 0) {
             *rbuflen = 0;
             LOG(log_error, logtype_afpd, "afp_write: asp_wrtcont: %s", strerror(errno));
-            return(AFPERR_PARAM);
+            return AFPERR_PARAM;
         }
 
         if (obj->options.flags & OPTION_DEBUG) {
@@ -1353,7 +1353,7 @@ afp_write_done:
 
     *rbuflen = set_off_t (offset, rbuf, is64);
     AFP_WRITE_DONE();
-    return( AFP_OK );
+    return AFP_OK;
 
 afp_write_err:
     if (obj->proto == AFPPROTO_DSI) {
@@ -1398,22 +1398,22 @@ int afp_getforkparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, s
     *rbuflen = 0;
     if (NULL == ( ofork = of_find( ofrefnum )) ) {
         LOG(log_error, logtype_afpd, "afp_getforkparams: of_find(%d) could not locate fork", ofrefnum );
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if (AD_META_OPEN(ofork->of_ad)) {
         if ( ad_refresh(NULL, ofork->of_ad ) < 0 ) {
             LOG(log_error, logtype_afpd, "getforkparams(%s): ad_refresh: %s", of_name(ofork), strerror(errno) );
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
     }
 
     if (AFP_OK != (ret = getforkparams(obj, ofork, bitmap, rbuf + sizeof( u_short ), &buflen ))) {
-        return( ret );
+        return ret;
     }
 
     *rbuflen = buflen + sizeof( u_short );
     bitmap = htons( bitmap );
     memcpy(rbuf, &bitmap, sizeof( bitmap ));
-    return( AFP_OK );
+    return AFP_OK;
 }

--- a/etc/afpd/hash.c
+++ b/etc/afpd/hash.c
@@ -96,7 +96,7 @@ static int is_power_of_two(hash_val_t arg)
         return 0;
     while ((arg & 1) == 0)
         arg >>= 1;
-    return (arg == 1);
+    return arg == 1;
 }
 
 /*

--- a/etc/afpd/nfsquota.c
+++ b/etc/afpd/nfsquota.c
@@ -76,7 +76,7 @@ callaurpc(struct vol *vol,
         int socket = RPC_ANYSOCK;
 
         if ((hp = gethostbyname(vol->v_gvs)) == NULL)
-            return ((int) RPC_UNKNOWNHOST);
+            return (int) RPC_UNKNOWNHOST;
         timeout.tv_usec = 0;
         timeout.tv_sec = 6;
         memcpy(&server_addr.sin_addr, hp->h_addr, hp->h_length);
@@ -86,7 +86,7 @@ callaurpc(struct vol *vol,
         if ((vol->v_nfsclient = (void *)
                                 clntudp_create(&server_addr, prognum, versnum,
                                                timeout, &socket)) == NULL)
-            return ((int) rpc_createerr.cf_stat);
+            return (int) rpc_createerr.cf_stat;
 
         ((CLIENT *) vol->v_nfsclient)->cl_auth = authunix_create_default();
     }
@@ -95,7 +95,7 @@ callaurpc(struct vol *vol,
     tottimeout.tv_usec = 0;
     clnt_stat = clnt_call((CLIENT *) vol->v_nfsclient, procnum,
                           inproc, in, outproc, out, tottimeout);
-    return ((int) clnt_stat);
+    return (int) clnt_stat;
 }
 
 

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -89,7 +89,7 @@ int of_flush(const struct vol *vol)
             LOG(log_error, logtype_afpd, "of_flush: %s", strerror(errno) );
         }
     }
-    return( 0 );
+    return 0;
 }
 
 int of_rename(const struct vol *vol,
@@ -179,7 +179,7 @@ of_alloc(struct vol *vol,
     lastrefnum = refnum;
     if ( i == nforks ) {
         LOG(log_error, logtype_afpd, "of_alloc: maximum number of forks exceeded.");
-        return( NULL );
+        return NULL;
     }
 
     of_refnum = refnum % nforks;
@@ -230,7 +230,7 @@ of_alloc(struct vol *vol,
         of->of_flags = AFPFORK_RSRC;
 
     of_hash(of);
-    return( of );
+    return of;
 }
 
 struct ofork *of_find(const uint16_t ofrefnum )
@@ -238,7 +238,7 @@ struct ofork *of_find(const uint16_t ofrefnum )
     if (!oforks || !nforks)
         return NULL;
 
-    return( oforks[ ofrefnum % nforks ] );
+    return oforks[ ofrefnum % nforks ];
 }
 
 /* -------------------------- */

--- a/etc/afpd/quota.c
+++ b/etc/afpd/quota.c
@@ -408,12 +408,12 @@ mountp( char *file, int *nfs)
     static struct mnttab	mnt;
 
     if (stat(file, &sb) < 0) {
-        return( NULL );
+        return NULL;
     }
     devno = sb.st_dev;
 
     if (( mtab = fopen( "/etc/mnttab", "r" )) == NULL ) {
-        return( NULL );
+        return NULL;
     }
 
     while ( getmntent( mtab, &mnt ) == 0 ) {
@@ -432,7 +432,7 @@ mountp( char *file, int *nfs)
     }
 
     fclose( mtab );
-    return( NULL );
+    return NULL;
 }
 
 #else /* __svr4__ */
@@ -444,13 +444,13 @@ special(char *file, int *nfs)
     static struct statfs	sfs;
 
     if ( statfs( file, &sfs ) < 0 ) {
-        return( NULL );
+        return NULL;
     }
 
     /* XXX: make sure this really detects an nfs mounted fs */
     if (strchr(sfs.f_mntfromname, ':'))
         *nfs = 1;
-    return( sfs.f_mntfromname );
+    return sfs.f_mntfromname;
 }
 
 #else /* BSD4_4 */
@@ -465,12 +465,12 @@ special(char *file, int *nfs)
     int 		found=0;
 
     if (stat(file, &sb) < 0 ) {
-        return( NULL );
+        return NULL;
     }
     devno = sb.st_dev;
 
     if (( mtab = setmntent( "/etc/mtab", "r" )) == NULL ) {
-        return( NULL );
+        return NULL;
     }
 
     while (( mnt = getmntent( mtab )) != NULL ) {
@@ -493,13 +493,13 @@ special(char *file, int *nfs)
     endmntent( mtab );
 
     if (!found)
-	return (NULL);
+	return NULL;
 #ifdef __linux__
     if (strcmp(mnt->mnt_type, "xfs") == 0)
 	is_xfs = 1;
 #endif
 
-    return( mnt->mnt_fsname );
+    return mnt->mnt_fsname;
 }
 
 #endif /* BSD4_4 */
@@ -525,7 +525,7 @@ static int getfsquota(const AFPObj *obj, struct vol *vol, const int uid, struct 
     qc.uid = uid;
     qc.addr = (caddr_t)dq;
     if ( ioctl( vol->v_qfd, Q_QUOTACTL, &qc ) < 0 ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
 #else /* __svr4__ */
@@ -549,7 +549,7 @@ static int getfsquota(const AFPObj *obj, struct vol *vol, const int uid, struct 
             if ( quotactl(vol->v_path, QCMD(Q_GETQUOTA, GRPQUOTA),
                             obj->groups[0], (char *) &dqg) != 0 ) {
                 unbecome_root();
-                return( AFPERR_PARAM );
+                return AFPERR_PARAM;
             }
         }
     }
@@ -616,7 +616,7 @@ static int getquota(const AFPObj *obj, struct vol *vol, struct dqblk *dq, const 
     if ( vol->v_qfd == -1 && vol->v_gvs == NULL) {
         if (( p = mountp( vol->v_path, &vol->v_nfs)) == NULL ) {
             LOG(log_info, logtype_afpd, "getquota: mountp %s fails", vol->v_path );
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
 
         if (vol->v_nfs) {
@@ -630,7 +630,7 @@ static int getquota(const AFPObj *obj, struct vol *vol, struct dqblk *dq, const 
             sprintf( buf, "%s/quotas", p );
             if (( vol->v_qfd = open( buf, O_RDONLY, 0 )) < 0 ) {
                 LOG(log_info, logtype_afpd, "open %s: %s", buf, strerror(errno) );
-                return( AFPERR_PARAM );
+                return AFPERR_PARAM;
             }
         }
 
@@ -639,7 +639,7 @@ static int getquota(const AFPObj *obj, struct vol *vol, struct dqblk *dq, const 
     if ( vol->v_gvs == NULL ) {
         if (( p = special( vol->v_path, &vol->v_nfs )) == NULL ) {
             LOG(log_info, logtype_afpd, "getquota: special %s fails", vol->v_path );
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
 
         if (( vol->v_gvs = (char *)malloc( strlen( p ) + 1 )) == NULL ) {
@@ -660,21 +660,21 @@ static int overquota( struct dqblk *dqblk)
 
     if ( dqblk->dqb_curblocks > dqblk->dqb_bhardlimit &&
          dqblk->dqb_bhardlimit != 0 ) {
-        return( 1 );
+        return 1;
     }
 
     if ( dqblk->dqb_curblocks < dqblk->dqb_bsoftlimit ||
          dqblk->dqb_bsoftlimit == 0 ) {
-        return( 0 );
+        return 0;
     }
     if ( gettimeofday( &tv, NULL ) < 0 ) {
         LOG(log_error, logtype_afpd, "overquota: gettimeofday: %s", strerror(errno) );
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
     if ( dqblk->dqb_btimelimit && dqblk->dqb_btimelimit > tv.tv_sec ) {
-        return( 0 );
+        return 0;
     }
-    return( 1 );
+    return 1;
 }
 
 /*
@@ -711,7 +711,7 @@ int uquota_getvolspace(const AFPObj *obj, struct vol *vol, VolSpace *bfree, VolS
 	this_bsize = bsize;
 
 	if (getquota(obj, vol, &dqblk, bsize) != 0 ) {
-		return( AFPERR_PARAM );
+		return AFPERR_PARAM;
 	}
 
 #ifdef __linux__
@@ -737,7 +737,7 @@ int uquota_getvolspace(const AFPObj *obj, struct vol *vol, VolSpace *bfree, VolS
                  	  tobytes( dqblk.dqb_curblocks, this_bsize );
     	}
 
-	return( AFP_OK );
+	return AFP_OK;
 }
 #endif /* HAVE_LIBQUOTA */
 #endif

--- a/etc/afpd/status.c
+++ b/etc/afpd/status.c
@@ -321,7 +321,7 @@ static size_t status_netaddress(char *data, int *servoffset,
     memcpy(begin + *servoffset, &offset, sizeof(offset));
 
     /* return length of buffer */
-    return (data - begin);
+    return data - begin;
 }
 
 
@@ -357,7 +357,7 @@ static size_t status_directorynames(char *data,
     memcpy(begin + *diroffset, &offset, sizeof(uint16_t));
 
     /* return length of buffer */
-    return (data - begin);
+    return data - begin;
 }
 
 static size_t status_utf8servername(char *data, int *nameoffset,
@@ -406,7 +406,7 @@ static size_t status_utf8servername(char *data, int *nameoffset,
     }
 
     /* return length of buffer */
-    return (data - begin);
+    return data - begin;
 }
 
 /* returns actual offset to signature */

--- a/etc/afpd/switch.c
+++ b/etc/afpd/switch.c
@@ -52,7 +52,7 @@ static int afp_null(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf 
 {
     LOG(log_info, logtype_afpd, "afp_null handle %d", *ibuf );
     *rbuflen = 0;
-    return( AFPERR_NOOP );
+    return AFPERR_NOOP;
 }
 
 /*

--- a/etc/afpd/unix.c
+++ b/etc/afpd/unix.c
@@ -44,7 +44,7 @@ int ustatfs_getvolspace(const struct vol *vol, VolSpace *bfree, VolSpace *btotal
 
     if ( statfs( vol->v_path, &sfs ) < 0 ) {
         LOG(log_error, logtype_afpd, "ustatfs_getvolspace unable to stat %s", vol->v_path);
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     *bfree = (VolSpace) sfs.f_bavail;
@@ -65,7 +65,7 @@ int ustatfs_getvolspace(const struct vol *vol, VolSpace *bfree, VolSpace *btotal
         *btotal *= *bsize;
     }
 
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 static int utombits(mode_t bits)
@@ -79,7 +79,7 @@ static int utombits(mode_t bits)
     /* Do we really need this? */
     mbits |= ( bits & ( S_IEXEC >> 6) ) ? AR_USEARCH : 0;
 
-    return( mbits );
+    return mbits;
 }
 
 /* --------------------------------
@@ -162,7 +162,7 @@ static mode_t mtoubits(uint8_t bits)
     /* I don't think there's a way to set the SEARCH bit by itself on a Mac
         mode |= ( bits & AR_USEARCH ) ? ( S_IEXEC >> 6 ) : 0; */
 
-    return( mode );
+    return mode;
 }
 
 /* ----------------------------------
@@ -183,7 +183,7 @@ mode_t mtoumode(struct maccess *ma)
 
     mode |= mtoubits( ma->ma_world );
 
-    return( mode );
+    return mode;
 }
 
 /* --------------------- */
@@ -267,5 +267,5 @@ int setdirowner(const struct vol *vol, const char *name, const uid_t uid, const 
     if (vol->vfs->vfs_setdirowner(vol, name, uid, gid) < 0)
         return -1;
 
-    return( 0 );
+    return 0;
 }

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -244,7 +244,7 @@ static int getvolspace(const AFPObj *obj, struct vol *vol,
          ? 0x7fffffffL : 0xffffffffL);
 
     if (( rc = ustatfs_getvolspace( vol, xbfree, xbtotal, bsize)) != AFP_OK ) {
-        return( rc );
+        return rc;
     }
 
 #ifndef NO_QUOTA_SUPPORT
@@ -274,7 +274,7 @@ getvolspace_done:
 
     *bfree = MIN(*xbfree, maxsize);
     *btotal = MIN(*xbtotal, maxsize);
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* -----------------------
@@ -355,7 +355,7 @@ static int getvolparams(const AFPObj *obj, uint16_t bitmap, struct vol *vol, str
             if ( isad ) {
                 ad_close( &ad, ADFLAGS_HF );
             }
-            return( AFPERR_PARAM );
+            return AFPERR_PARAM;
         }
     }
 
@@ -484,7 +484,7 @@ static int getvolparams(const AFPObj *obj, uint16_t bitmap, struct vol *vol, str
             if ( isad ) {
                 ad_close( &ad, ADFLAGS_HF );
             }
-            return( AFPERR_BITMAP );
+            return AFPERR_BITMAP;
         }
         bitmap = bitmap>>1;
         bit++;
@@ -506,7 +506,7 @@ static int getvolparams(const AFPObj *obj, uint16_t bitmap, struct vol *vol, str
         ad_close(&ad, ADFLAGS_HF);
     }
     *buflen = data - buf;
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* ------------------------- */
@@ -518,7 +518,7 @@ static int stat_vol(const AFPObj *obj, uint16_t bitmap, struct vol *vol, char *r
 
     if ( stat( vol->v_path, &st ) < 0 ) {
         *rbuflen = 0;
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
     /* save the volume device number */
     vol->v_dev = st.st_dev;
@@ -527,12 +527,12 @@ static int stat_vol(const AFPObj *obj, uint16_t bitmap, struct vol *vol, char *r
     if (( ret = getvolparams(obj, bitmap, vol, &st,
                               rbuf + sizeof( bitmap ), &buflen )) != AFP_OK ) {
         *rbuflen = 0;
-        return( ret );
+        return ret;
     }
     *rbuflen = buflen + sizeof( bitmap );
     bitmap = htons( bitmap );
     memcpy(rbuf, &bitmap, sizeof( bitmap ));
-    return( AFP_OK );
+    return AFP_OK;
 
 }
 
@@ -616,7 +616,7 @@ int afp_getsrvrparms(AFPObj *obj, char *ibuf _U_, size_t ibuflen _U_, char *rbuf
     memcpy(data, &aint, sizeof( uint32_t));
     data += sizeof( uint32_t);
     *data = vcnt;
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* ------------------------- */
@@ -868,7 +868,7 @@ int afp_openvol(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
 
         free(vol_mname);
         server_ipc_volumes(obj);
-        return( AFP_OK );
+        return AFP_OK;
     }
 
 openvol_err:
@@ -931,7 +931,7 @@ int afp_closevol(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, si
     ibuf += 2;
     memcpy(&vid, ibuf, sizeof( vid ));
     if (NULL == ( vol = getvolbyvid( vid )) ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     (void)chdir("/");
@@ -939,7 +939,7 @@ int afp_closevol(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_, si
     closevol(obj, vol);
     server_ipc_volumes(obj);
 
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 /* --------------------------
@@ -1029,7 +1029,7 @@ int afp_getvolparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_,char *rbuf, siz
 
     if (NULL == ( vol = getvolbyvid( vid )) ) {
         *rbuflen = 0;
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     return stat_vol(obj, bitmap, vol, rbuf, rbuflen);
@@ -1053,7 +1053,7 @@ int afp_setvolparams(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf
     ibuf += sizeof(bitmap);
 
     if (( vol = getvolbyvid( vid )) == NULL ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     if ((vol->v_flags & AFPVOL_RO))
@@ -1075,5 +1075,5 @@ int afp_setvolparams(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf
     ad_setdate(&ad, AD_DATE_BACKUP, aint);
     ad_flush(&ad);
     ad_close(&ad, ADFLAGS_HF);
-    return( AFP_OK );
+    return AFP_OK;
 }

--- a/etc/atalkd/config.c
+++ b/etc/atalkd/config.c
@@ -276,7 +276,7 @@ int writeconf(char *cf)
 	LOG(log_error, logtype_atalkd, "rename %s to %s: %s", newpath, path, strerror(errno) );
 	return -1;
     }
-    return( 0 );
+    return 0;
 }
 
 /*
@@ -431,7 +431,7 @@ int readconf(char *cf)
     for ( iface = interfaces, cc = 0; iface; iface = iface->i_next, cc++ )
 	;
     if ( cc >= IFBASE ) {
-	return( 0 );
+	return 0;
     } else {
 	return -1;
     }
@@ -463,7 +463,7 @@ int router(struct interface *iface, char **av _U_)
 
     /* -router also implies -seed */
     iface->i_flags |= IFACE_RSEED | IFACE_SEED | IFACE_ISROUTER;
-    return( 1 );
+    return 1;
 }
 
 /*ARGSUSED*/
@@ -476,7 +476,7 @@ int dontroute(struct interface *iface, char **av _U_)
     }
 
     iface->i_flags |= IFACE_DONTROUTE;
-    return( 1 );
+    return 1;
 }
 
 /*ARGSUSED*/
@@ -493,7 +493,7 @@ int seed( struct interface *iface, char **av _U_)
     }
 
     iface->i_flags |= IFACE_SEED;
-    return( 1 );
+    return 1;
 }
 
 int phase(struct interface *iface, char **av)
@@ -519,7 +519,7 @@ int phase(struct interface *iface, char **av)
 	fprintf( stderr, "No phase %d.\n", n );
 	return -1;
     }
-    return( 2 );
+    return 2;
 }
 
 int net(struct interface *iface, char **av)
@@ -587,7 +587,7 @@ int net(struct interface *iface, char **av)
 	fprintf( stderr, "Must specify phase before networks.\n" );
 	return -1;
     }
-    return( 2 );
+    return 2;
 }
 
 int addr(struct interface *iface, char **av)
@@ -621,7 +621,7 @@ int addr(struct interface *iface, char **av)
 		iface->i_caddr.sat_addr.s_net;
     }
 
-    return( 2 );
+    return 2;
 }
 
 int zone(struct interface *iface, char **av)
@@ -665,7 +665,7 @@ int zone(struct interface *iface, char **av)
     }
     free(zname);
 
-    return( 2 );
+    return 2;
 }
 
 /*
@@ -744,7 +744,7 @@ int getifconf(void)
     }
     freeifacelist(start);
     (void)close( s );
-    return( 0 );
+    return 0;
 }
 
 /*
@@ -758,7 +758,7 @@ struct interface *newiface( const char *name)
 
     if (( niface = (struct interface *)calloc(1, sizeof( struct interface )))
 	    == NULL ) {
-	return( NULL );
+	return NULL;
     }
     strlcpy( niface->i_name, name, sizeof(niface->i_name));
 #ifdef BSD4_4
@@ -767,7 +767,7 @@ struct interface *newiface( const char *name)
 #endif /* BSD4_4 */
     niface->i_addr.sat_family = AF_APPLETALK;
     niface->i_caddr.sat_family = AF_APPLETALK;
-    return( niface );
+    return niface;
 }
 
 #ifdef __svr4__
@@ -829,6 +829,6 @@ int plumb(void)
     close(fd);
     }
 
-    return( 0 );
+    return 0;
 }
 #endif /* __svr4__ */

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -1365,17 +1365,17 @@ int ifconfig( const char *iname, unsigned long cmd, struct sockaddr_at *sa)
     ifr.ifr_addr = *(struct sockaddr *)sa;
 
     if (( s = socket( AF_APPLETALK, SOCK_DGRAM, 0 )) < 0 ) {
-	return( 1 );
+	return 1;
     }
     if ( ioctl( s, cmd, &ifr ) < 0 ) {
 	close(s);
-	return( 1 );
+	return 1;
     }
     close( s );
     if ( cmd == SIOCGIFADDR ) {
 	*(struct sockaddr *)sa = ifr.ifr_addr;
     }
-    return( 0 );
+    return 0;
 }
 
 void dumpconfig( struct interface *iface)

--- a/etc/atalkd/multicast.c
+++ b/etc/atalkd/multicast.c
@@ -321,7 +321,7 @@ atalk_cksum( unsigned char *data, int len)
 	cksum = 0x0000ffff;
     }
 
-    return( (uint16_t) cksum );
+    return (uint16_t) cksum;
 }
 
 /*

--- a/etc/atalkd/route.c
+++ b/etc/atalkd/route.c
@@ -28,7 +28,7 @@ int route( int message, struct sockaddr *dst, struct sockaddr *gate, int flags)
     rtent.rt_dst = *dst;
     rtent.rt_gateway = *gate;
     rtent.rt_flags = flags;
-    return( ioctl( rtfd, message, &rtent ));
+    return ioctl( rtfd, message, &rtent );
 }
 
 #else /* BSD4_4 */
@@ -72,8 +72,8 @@ int route( int message, struct sockaddr_at	*dst, struct sockaddr_at *gate, int f
     rtma.rtma_gate = *gate;
     if (( rc = write( rtfd, &rtma, rtma.rtma_rtm.rtm_msglen )) !=
 	    rtma.rtma_rtm.rtm_msglen ) {
-	return( -1 );
+	return -1;
     }
-    return( 0 );
+    return 0;
 }
 #endif /* BSD4_4 */

--- a/etc/atalkd/rtmp.c
+++ b/etc/atalkd/rtmp.c
@@ -392,12 +392,12 @@ int rtmp_replace(struct rtmptab *replace)
 	if ( replace->rt_state == RTMPTAB_BAD ) {
 	    rtmp_free( replace );
 	}
-	return( 0 );
+	return 0;
     } else {
 	if ( replace->rt_hops == RTMPHOPS_POISON ) {
 	    gateroute( RTMP_DEL, replace );
 	}
-	return( 1 );
+	return 1;
     }
 }
 
@@ -964,14 +964,14 @@ int looproute(struct interface *iface, unsigned int cmd)
 		(struct sockaddr *) &dst,
 		(struct sockaddr *) &loop,
 		RTF_UP | RTF_HOST ) ) {
-	return( 1 );
+	return 1;
     }
 #else /* ! BSD4_4 */
     if ( route( cmd,
 	    	(struct sockaddr_at *) &dst,
 		(struct sockaddr_at *) &loop,
 		RTF_UP | RTF_HOST ) ) {
-	return ( 1);
+		return 1;
     }
 #endif /* BSD4_4 */
     if ( cmd == RTMP_ADD ) {
@@ -980,7 +980,7 @@ int looproute(struct interface *iface, unsigned int cmd)
     if ( cmd == RTMP_DEL ) {
 	iface->i_flags &= ~IFACE_LOOP;
     }
-    return( 0 );
+    return 0;
 }
 
 int gateroute(unsigned int command, struct rtmptab *rtmp)
@@ -994,10 +994,10 @@ int gateroute(unsigned int command, struct rtmptab *rtmp)
     }
 
     if ( command == RTMP_DEL && ( rtmp->rt_flags & RTMPTAB_ROUTE ) == 0 ) {
-	return( -1 );
+	return -1;
     }
     if ( command == RTMP_ADD && ( rtmp->rt_flags & RTMPTAB_ROUTE )) {
-	return( -1 );
+	return -1;
     }
 
     if (rtmp->rt_gate == NULL) {
@@ -1061,7 +1061,7 @@ int gateroute(unsigned int command, struct rtmptab *rtmp)
 	rtmp->rt_flags &= ~RTMPTAB_ROUTE;
     }
 
-    return( 0 );
+    return 0;
 }
 
     struct rtmptab *
@@ -1070,9 +1070,9 @@ newrt(const struct interface *iface)
     struct rtmptab	*rtmp;
 
     if (( rtmp = (struct rtmptab *)calloc(1, sizeof(struct rtmptab))) == NULL ) {
-	return( NULL );
+	return NULL;
     }
 
     rtmp->rt_iface = iface;
-    return( rtmp );
+    return rtmp;
 }

--- a/etc/atalkd/zip.c
+++ b/etc/atalkd/zip.c
@@ -48,7 +48,7 @@ static int zonecheck(struct rtmptab *rtmp, struct interface *iface)
     int			cztcnt, ztcnt;
 
     if (( iface->i_flags & IFACE_SEED ) == 0 ) {
-	return( 0 );
+	return 0;
     }
 
     for ( cztcnt = 0, czt = iface->i_czt; czt; czt = czt->zt_next, cztcnt++ ) {
@@ -62,7 +62,7 @@ static int zonecheck(struct rtmptab *rtmp, struct interface *iface)
 	if ( l == NULL ) {
 	    LOG(log_error, logtype_atalkd, "zonecheck: %.*s not in zone list", czt->zt_len,
 		    czt->zt_name );
-	    return( -1 );	/* configured zone not found in net zones */
+	    return -1;	/* configured zone not found in net zones */
 	}
     }
 
@@ -72,10 +72,10 @@ static int zonecheck(struct rtmptab *rtmp, struct interface *iface)
     if ( cztcnt != ztcnt ) {
 	LOG(log_error, logtype_atalkd, "zonecheck: %d configured zones, %d zones found",
 		cztcnt, ztcnt );
-	return( -1 );		/* more net zones than configured zones */
+	return -1;		/* more net zones than configured zones */
     }
 
-    return( 0 );
+    return 0;
 }
 
 
@@ -945,17 +945,17 @@ struct ziptab *newzt(const int len, const char *name)
     struct ziptab	*zt;
 
     if (( zt = (struct ziptab *)calloc(1, sizeof( struct ziptab ))) == NULL ) {
-	return( NULL );
+	return NULL;
     }
 
     zt->zt_len = len;
     if (( zt->zt_name = (char *)malloc( len )) == NULL ) {
 	free(zt);
-	return( NULL );
+	return NULL;
     }
 
     memcpy( zt->zt_name, name, len );
-    return( zt );
+    return zt;
 }
 
 
@@ -969,7 +969,7 @@ static int add_list(struct list **head, void *data)
 
     for ( l = *head; l; l = l->l_next ) {
 	if ( l->l_data == data ) {
-	    return( 1 );
+	    return 1;
 	}
     }
     if (( l = (struct list *)malloc( sizeof( struct list ))) == NULL ) {
@@ -989,7 +989,7 @@ static int add_list(struct list **head, void *data)
 	l->l_prev = l2;
 	l2->l_next = l;
     }
-    return( 0 );
+    return 0;
 }
 
 int addzone(struct rtmptab *rt, int len, char *zone)

--- a/etc/cnid_dbd/cmd_dbd_scanvol.c
+++ b/etc/cnid_dbd/cmd_dbd_scanvol.c
@@ -101,7 +101,7 @@ static char *utompath(char *upath)
         return NULL;
     }
 
-    return(m);
+    return m;
 }
 
 /*

--- a/etc/cnid_dbd/pack.c
+++ b/etc/cnid_dbd/pack.c
@@ -62,7 +62,7 @@ int len;
        out already. */
     len = strlen((char *)skey->data + CNID_DID_LEN);
     skey->size = CNID_DID_LEN + len + 1;
-    return (0);
+    return 0;
 }
 
 /* --------------- */
@@ -71,7 +71,7 @@ int devino(DB *dbp _U_, const DBT *pkey _U_,  const DBT *pdata, DBT *skey)
     memset(skey, 0, sizeof(DBT));
     skey->data = (char *)pdata->data + CNID_DEVINO_OFS;
     skey->size = CNID_DEVINO_LEN;
-    return (0);
+    return 0;
 }
 
 /* --------------- */
@@ -94,7 +94,7 @@ int idxname(DB *dbp _U_, const DBT *pkey _U_,  const DBT *pdata, DBT *skey)
 
     skey->data = buffer;
     skey->size = strlen(skey->data);
-    return (0);
+    return 0;
 }
 
 void pack_setvol(const struct vol *vol)

--- a/etc/netatalk/afp_mdns.c
+++ b/etc/netatalk/afp_mdns.c
@@ -113,7 +113,7 @@ static void *polling_thread(void *arg _U_) {
             }
         }
     }
-    return(NULL);
+    return NULL;
 }
 
 /*

--- a/etc/papd/auth.c
+++ b/etc/papd/auth.c
@@ -43,7 +43,7 @@ int getuamnames(const int type, char *uamnames)
     struct uam_obj *prev, *start;
 
     if (!(start = UAM_LIST(type)))
-        return(-1);
+        return -1;
 
     prev = start;
 
@@ -53,7 +53,7 @@ int getuamnames(const int type, char *uamnames)
     }
 
     strcat(uamnames, "*\n");
-    return(0);
+    return 0;
 }
 
 

--- a/etc/papd/comment.c
+++ b/etc/papd/comment.c
@@ -56,11 +56,11 @@ int comswitch(struct papd_comment *comments, int (*handler)())
     }
     if ( comment == NULL || comment->c_handler != handler ) {
 	LOG(log_error, logtype_papd, "comswitch: can't find handler!" );
-	return( -1 );
+	return -1;
     }
     compop();
     compush( comment );
-    return( 0 );
+    return 0;
 }
 
 int comcmp( char *start, char *stop, char *str,int how)
@@ -71,15 +71,15 @@ int comcmp( char *start, char *stop, char *str,int how)
     cc = strlen( str );
     if ( how & C_FULL ) {
 	if ( (cc == len) && (strncmp( str, start, cc ) == 0) ) {
-	    return( 0 );
+	    return 0;
 	}
     } else {
 	if ( (cc <= len) && (strncmp( str, start, cc ) == 0) ) {
-	    return( 0 );
+	    return 0;
 	}
     }
 
-    return( 1 );
+    return 1;
 }
 
 struct papd_comment *commatch( char *start, char *stop, struct papd_comment comments[])
@@ -92,8 +92,8 @@ struct papd_comment *commatch( char *start, char *stop, struct papd_comment comm
 	}
     }
     if ( comment->c_begin ) {
-	return( comment );
+	return comment;
     } else {
-	return( NULL );
+	return NULL;
     }
 }

--- a/etc/papd/file.c
+++ b/etc/papd/file.c
@@ -20,7 +20,7 @@ int markline( struct papfile *pf, char **start, int *linelength, int *crlflength
     char		*p;
 
     if ( pf->pf_datalen == 0 && ( pf->pf_state & PF_EOF )) {
-	return( 0 );
+	return 0;
     }
 
     *start = pf->pf_data;
@@ -37,7 +37,7 @@ int markline( struct papfile *pf, char **start, int *linelength, int *crlflength
 	if ( pf->pf_state & PF_EOF ) {
 	    append( pf, "\n", 1 );
 	} else {
-	    return( -1 );
+	    return -1;
 	}
     }
 
@@ -53,12 +53,12 @@ int markline( struct papfile *pf, char **start, int *linelength, int *crlflength
     if (!*crlflength) {
         // line is way too long, something fishy is going on, give up
         LOG(log_error, logtype_papd, "markline: no crlf in comment, give up" );
-        return( -2 );
+        return -2;
     }
     */
 
     /* success, return 1 */
-    return( 1 );
+    return 1;
 }
 
 void morespace(struct papfile *pf, const char *data, int len)

--- a/etc/papd/headers.c
+++ b/etc/papd/headers.c
@@ -85,13 +85,13 @@ int ch_for( struct papfile *in, struct papfile *out _U_)
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :
-        return( 0 );
+        return 0;
 
     case -1 :
-        return( CH_MORE );
+        return CH_MORE;
 
     case -2 :
-        return( CH_ERROR );
+        return CH_ERROR;
     }
 
     cmt = get_text(start, linelength);
@@ -106,7 +106,7 @@ int ch_for( struct papfile *in, struct papfile *out _U_)
     in->pf_state &= ~PF_TRANSLATE;
     compop();
     CONSUME( in, linelength + crlflength );
-    return( CH_DONE );
+    return CH_DONE;
 }
 
 int ch_title( struct papfile *in, struct papfile *out _U_)
@@ -116,13 +116,13 @@ int ch_title( struct papfile *in, struct papfile *out _U_)
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :
-	return( 0 );
+	return 0;
 
     case -1 :
-	return( CH_MORE );
+	return CH_MORE;
 
     case -2 :
-        return( CH_ERROR );
+        return CH_ERROR;
     }
 
     LOG(log_debug9, logtype_papd, "Parsing %%Title");
@@ -139,7 +139,7 @@ int ch_title( struct papfile *in, struct papfile *out _U_)
     in->pf_state &= ~PF_TRANSLATE;
     compop();
     CONSUME( in, linelength + crlflength );
-    return( CH_DONE );
+    return CH_DONE;
 }
 
 static int guess_creator ( char *creator )
@@ -160,13 +160,13 @@ int ch_creator( struct papfile *in, struct papfile *out _U_)
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :
-	return( 0 );
+	return 0;
 
     case -1 :
-	return( CH_MORE );
+	return CH_MORE;
 
     case -2 :
-        return( CH_ERROR );
+        return CH_ERROR;
     }
 
     cmt = get_text(start, linelength);
@@ -182,7 +182,7 @@ int ch_creator( struct papfile *in, struct papfile *out _U_)
     in->pf_state &= ~PF_TRANSLATE;
     compop();
     CONSUME( in, linelength + crlflength );
-    return( CH_DONE );
+    return CH_DONE;
 }
 
 int ch_endcomm( struct papfile *in, struct papfile *out _U_)
@@ -196,13 +196,13 @@ int ch_endcomm( struct papfile *in, struct papfile *out _U_)
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :
-	return( 0 );
+	return 0;
 
     case -1 :
-	return( CH_MORE );
+	return CH_MORE;
 
     case -2 :
-        return( CH_ERROR );
+        return CH_ERROR;
     }
 
     in->pf_state |= PF_TRANSLATE;
@@ -210,7 +210,7 @@ int ch_endcomm( struct papfile *in, struct papfile *out _U_)
     in->pf_state &= ~PF_TRANSLATE;
     compop();
     CONSUME( in, linelength + crlflength );
-    return ( CH_DONE);
+    return CH_DONE;
 }
 
 int ch_starttranslate( struct papfile *in, struct papfile *out _U_)
@@ -222,20 +222,20 @@ int ch_starttranslate( struct papfile *in, struct papfile *out _U_)
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :
-        return( 0 );
+        return 0;
 
     case -1 :
-        return( CH_MORE );
+        return CH_MORE;
 
     case -2 :
-        return( CH_ERROR );
+        return CH_ERROR;
     }
 
     in->pf_state |= PF_TRANSLATE;
     lp_write( in, start, linelength + crlflength );
     compop();
     CONSUME( in, linelength + crlflength );
-    return ( CH_DONE);
+    return CH_DONE;
 }
 
 int ch_endtranslate(struct papfile *in, struct papfile *out _U_)
@@ -247,20 +247,20 @@ int ch_endtranslate(struct papfile *in, struct papfile *out _U_)
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :
-        return( 0 );
+        return 0;
 
     case -1 :
-        return( CH_MORE );
+        return CH_MORE;
 
     case -2 :
-        return( CH_ERROR );
+        return CH_ERROR;
     }
 
     lp_write( in, start, linelength + crlflength );
     in->pf_state &= ~PF_TRANSLATE;
     compop();
     CONSUME( in, linelength + crlflength );
-    return ( CH_DONE);
+    return CH_DONE;
 }
 
 int ch_translateone( struct papfile *in, struct papfile *out _U_)
@@ -272,13 +272,13 @@ int ch_translateone( struct papfile *in, struct papfile *out _U_)
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :
-        return( 0 );
+        return 0;
 
     case -1 :
-        return( CH_MORE );
+        return CH_MORE;
 
     case -2 :
-        return( CH_ERROR );
+        return CH_ERROR;
     }
 
     in->pf_state |= PF_TRANSLATE;
@@ -286,7 +286,7 @@ int ch_translateone( struct papfile *in, struct papfile *out _U_)
     in->pf_state &= ~PF_TRANSLATE;
     compop();
     CONSUME( in, linelength + crlflength );
-    return ( CH_DONE);
+    return CH_DONE;
 }
 
 

--- a/etc/papd/lp.c
+++ b/etc/papd/lp.c
@@ -384,13 +384,13 @@ int lp_pagecost(void)
     int		err;
 
     if ( lp.lp_person == NULL ) {
-	return( -1 );
+	return -1;
     }
     err = ABS_canprint( lp.lp_person, printer->p_role, printer->p_srvid,
 	    cost, balance );
     printer->p_pagecost = floor( atof( cost ) * 10000.0 );
     printer->p_balance = atof( balance ) + atof( cost );
-    return( err < 0 ? -1 : 0 );
+    return err < 0 ? -1 : 0;
 }
 #endif /* ABS_PRINT */
 
@@ -504,7 +504,7 @@ static int lp_init(struct papfile *out, struct sockaddr_at *sat)
 	if ( authenticated == 0 ) {
 	    LOG(log_error, logtype_papd, "lp_init: must authenticate" );
 	    spoolerror( out, "Authentication required." );
-	    return( -1 );
+	    return -1;
 	}
 
 #ifdef ABS_PRINT
@@ -513,7 +513,7 @@ static int lp_init(struct papfile *out, struct sockaddr_at *sat)
 		printer->p_srvid, cost, balance )) {
 	    LOG(log_error, logtype_papd, "lp_init: no ABS funds" );
 	    spoolerror( out, "No ABS funds available." );
-	    return( -1 );
+	    return -1;
 	}
 #endif /* ABS_PRINT */
     }
@@ -539,32 +539,32 @@ static int lp_init(struct papfile *out, struct sockaddr_at *sat)
 	if ( stat( printer->p_lock, &st ) < 0 ) {
 	    LOG(log_error, logtype_papd, "lp_init: %s: %s", printer->p_lock, strerror(errno) );
 	    spoolerror( out, NULL );
-	    return( -1 );
+	    return -1;
 	}
 	if ( st.st_mode & 010 ) {
 	    LOG(log_info, logtype_papd, "lp_init: queuing is disabled" );
 	    spoolerror( out, "Queuing is disabled." );
-	    return( -1 );
+	    return -1;
 	}
 
 	if (( fd = open( ".seq", O_RDWR|O_CREAT, 0661 )) < 0 ) {
 	    LOG(log_error, logtype_papd, "lp_init: can't create .seq" );
 	    spoolerror( out, NULL );
-	    return( -1 );
+	    return -1;
 	}
 
 	lock.l_type = F_WRLCK;
 	if (( fcntl(fd, F_SETLK, &lock)) < 0 ) {
 	    LOG(log_error, logtype_papd, "lp_init: can't lock .seq" );
 	    spoolerror( out, NULL );
-	    return( -1 );
+	    return -1;
 	}
 
 	n = 0;
 	if (( len = read( fd, buf, sizeof( buf ))) < 0 ) {
 	    LOG(log_error, logtype_papd, "lp_init read: %s", strerror(errno) );
 	    spoolerror( out, NULL );
-	    return( -1 );
+	    return -1;
 	}
 	if ( len > 0 ) {
 	    for ( cp = buf; len; len--, cp++ ) {
@@ -587,7 +587,7 @@ static int lp_init(struct papfile *out, struct sockaddr_at *sat)
 	if (cups_get_printer_status ( printer ) == 0)
 	{
 	    spoolerror( out, "Queuing is disabled." );
-	    return( -1 );
+	    return -1;
 	}
 
 	lp.lp_seq = getpid();
@@ -598,7 +598,7 @@ static int lp_init(struct papfile *out, struct sockaddr_at *sat)
     }
 
     lp.lp_flags |= LP_INIT;
-    return( 0 );
+    return 0;
 }
 
 int lp_open(struct papfile *out, struct sockaddr_at *sat)
@@ -614,12 +614,12 @@ int lp_open(struct papfile *out, struct sockaddr_at *sat)
     }
 
     if (( lp.lp_flags & LP_INIT ) == 0 && lp_init( out, sat ) != 0 ) {
-	return( -1 );
+	return -1;
     }
     if ( lp.lp_flags & LP_OPEN ) {
 	/* LOG(log_error, logtype_papd, "lp_open already open" ); */
 	/* abort(); */
-	return (-1);
+	return -1;
     }
 
     if ( lp.lp_flags & LP_PIPE ) {
@@ -643,12 +643,12 @@ int lp_open(struct papfile *out, struct sockaddr_at *sat)
 	if (!pipe_cmd) {
 	    LOG(log_error, logtype_papd, "lp_open: no pipe cmd" );
 	    spoolerror( out, NULL );
-	    return( -1 );
+	    return -1;
 	}
 	if (( lp.lp_stream = popen(pipe_cmd, "w" )) == NULL ) {
 	    LOG(log_error, logtype_papd, "lp_open popen %s: %s", printer->p_printer, strerror(errno) );
 	    spoolerror( out, NULL );
-	    return( -1 );
+	    return -1;
 	}
         LOG(log_debug, logtype_papd, "lp_open: opened %s",  pipe_cmd );
     } else {
@@ -657,7 +657,7 @@ int lp_open(struct papfile *out, struct sockaddr_at *sat)
 	if (( fd = open( name, O_WRONLY|O_CREAT|O_EXCL, 0660 )) < 0 ) {
 	    LOG(log_error, logtype_papd, "lp_open %s: %s", name, strerror(errno) );
 	    spoolerror( out, NULL );
-	    return( -1 );
+	    return -1;
 	}
 
 	if ( NULL == (lp.lp_spoolfile = (char *) malloc (strlen (name) +1)) ) {
@@ -670,31 +670,31 @@ int lp_open(struct papfile *out, struct sockaddr_at *sat)
 	    if ((pwent = getpwnam(lp.lp_person)) == NULL) {
 		LOG(log_error, logtype_papd, "getpwnam %s: no such user", lp.lp_person);
 		spoolerror( out, NULL );
-		return( -1 );
+		return -1;
 	    }
 	} else {
 	    if ((pwent = getpwnam(printer->p_operator)) == NULL) {
 		LOG(log_error, logtype_papd, "getpwnam %s: no such user", printer->p_operator);
 		spoolerror( out, NULL );
-		return( -1 );
+		return -1;
 	    }
 	}
 
 	if (fchown(fd, pwent->pw_uid, -1) < 0) {
 	    LOG(log_error, logtype_papd, "chown %s %s: %s", pwent->pw_name, name, strerror(errno));
 	    spoolerror( out, NULL );
-	    return( -1 );
+	    return -1;
 	}
 
 	if (( lp.lp_stream = fdopen( fd, "w" )) == NULL ) {
 	    LOG(log_error, logtype_papd, "lp_open fdopen: %s", strerror(errno) );
 	    spoolerror( out, NULL );
-	    return( -1 );
+	    return -1;
 	}
 	LOG(log_debug9, logtype_papd, "lp_open: opened %s", name );
     }
     lp.lp_flags |= LP_OPEN;
-    return( 0 );
+    return 0;
 }
 
 int lp_close(void)
@@ -772,7 +772,7 @@ int lp_write(struct papfile *in, char *buf, size_t len)
             bufpos += len;
             if (bufpos > BUFSIZE/2)
                 in->pf_state |= PF_STW; /* we used half of the buffer, start writing */
-            return(0);
+            return 0;
 	}
     }
     else if ( bufpos) {
@@ -787,7 +787,7 @@ int lp_write(struct papfile *in, char *buf, size_t len)
 	LOG(log_error, logtype_papd, "lp_write: %s", strerror(errno) );
 	abort();
     }
-    return( 0 );
+    return 0;
 }
 
 int lp_cancel(void)
@@ -940,7 +940,7 @@ int lp_print(void)
 #ifndef HAVE_CUPS
 int lp_disconn_unix( int fd )
 {
-    return( close( fd ));
+    return close( fd );
 }
 
 int lp_conn_unix(void)
@@ -950,7 +950,7 @@ int lp_conn_unix(void)
 
     if (( s = socket( AF_UNIX, SOCK_STREAM, 0 )) < 0 ) {
 	LOG(log_error, logtype_papd, "lp_conn_unix socket: %s", strerror(errno) );
-	return( -1 );
+	return -1;
     }
     memset( &saun, 0, sizeof( struct sockaddr_un ));
     saun.sun_family = AF_UNIX;
@@ -959,15 +959,15 @@ int lp_conn_unix(void)
 	    strlen( saun.sun_path ) + 2 ) < 0 ) {
 	LOG(log_error, logtype_papd, "lp_conn_unix connect %s: %s", saun.sun_path, strerror(errno) );
 	close( s );
-	return( -1 );
+	return -1;
     }
 
-    return( s );
+    return s;
 }
 
 int lp_disconn_inet( int fd )
 {
-    return( close( fd ));
+    return close( fd );
 }
 
 int lp_conn_inet(void)
@@ -979,7 +979,7 @@ int lp_conn_inet(void)
 
     if (( sp = getservbyname( "printer", "tcp" )) == NULL ) {
 	LOG(log_error, logtype_papd, "printer/tcp: unknown service" );
-	return( -1 );
+	return -1;
     }
 
     if ( gethostname( hostname, sizeof( hostname )) < 0 ) {
@@ -989,13 +989,13 @@ int lp_conn_inet(void)
 
     if (( hp = gethostbyname( hostname )) == NULL ) {
 	LOG(log_error, logtype_papd, "%s: unknown host", hostname );
-	return( -1 );
+	return -1;
     }
 
     if (( privfd = rresvport( &port )) < 0 ) {
 	LOG(log_error, logtype_papd, "lp_connect: socket: %s", strerror(errno) );
 	close( privfd );
-	return( -1 );
+	return -1;
     }
 
     memset( &sin, 0, sizeof( struct sockaddr_in ));
@@ -1008,10 +1008,10 @@ int lp_conn_inet(void)
 	    sizeof( struct sockaddr_in )) < 0 ) {
 	LOG(log_error, logtype_papd, "lp_connect: %s", strerror(errno) );
 	close( privfd );
-	return( -1 );
+	return -1;
     }
 
-    return( privfd );
+    return privfd;
 }
 
 int lp_rmjob( int job)
@@ -1021,11 +1021,11 @@ int lp_rmjob( int job)
 
     if (( s = lp_conn_inet()) < 0 ) {
 	LOG(log_error, logtype_papd, "lp_rmjob: %s", strerror(errno) );
-	return( -1 );
+	return -1;
     }
 
     if ( lp.lp_person == NULL ) {
-	return( -1 );
+	return -1;
     }
 
     sprintf( buf, "\5%s %s %d\n", printer->p_printer, lp.lp_person, job );
@@ -1033,14 +1033,14 @@ int lp_rmjob( int job)
     if ( write( s, buf, n ) != n ) {
 	LOG(log_error, logtype_papd, "lp_rmjob write: %s", strerror(errno) );
 	lp_disconn_inet( s );
-	return( -1 );
+	return -1;
     }
     while (( n = read( s, buf, sizeof( buf ))) > 0 ) {
 	LOG(log_debug, logtype_papd, "read %.*s", n, buf );
     }
 
     lp_disconn_inet( s );
-    return( 0 );
+    return 0;
 }
 
 char	*kw_rank = "Rank";
@@ -1064,7 +1064,7 @@ int lp_queue( struct papfile *out)
 
     if (( s = lp_conn_unix()) < 0 ) {
 	LOG(log_error, logtype_papd, "lp_queue: %s", strerror(errno) );
-	return( -1 );
+	return -1;
     }
 
     sprintf( buf, "\3%s\n", printer->p_printer );
@@ -1072,7 +1072,7 @@ int lp_queue( struct papfile *out)
     if ( write( s, buf, n ) != n ) {
 	LOG(log_error, logtype_papd, "lp_queue write: %s", strerror(errno) );
 	lp_disconn_unix( s );
-	return( -1 );
+	return -1;
     }
     pf.pf_state = PF_BOT;
 
@@ -1200,7 +1200,7 @@ int lp_queue( struct papfile *out)
 	} else {
 	    append( out, "*\n", 2 );
 	    lp_disconn_unix( s );
-	    return( 0 );
+	    return 0;
 	}
     }
 }

--- a/etc/papd/magics.c
+++ b/etc/papd/magics.c
@@ -54,14 +54,14 @@ int ps( struct papfile *infile, struct papfile *outfile, struct sockaddr_at *sat
 		continue;
 
 	    case CH_MORE :
-		return( CH_MORE );
+		return CH_MORE;
 
 	    case CH_ERROR :
 	        parser_error(outfile);
-		return( 0 );
+		return 0;
 
 	    default :
-		return( CH_ERROR );
+		return CH_ERROR;
 	    }
 	} else {
 	    switch ( markline( infile, &start, &linelength, &crlflength )) {
@@ -69,15 +69,15 @@ int ps( struct papfile *infile, struct papfile *outfile, struct sockaddr_at *sat
 		/* eof on infile */
 		outfile->pf_state |= PF_EOF;
 		lp_close();
-		return( 0 );
+		return 0;
 
 	    case -2:
 	        parser_error(outfile);
-		return( 0 );
+		return 0;
 
 	    case -1 :
 		spoolreply( outfile, "Processing..." );
-		return( 0 );
+		return 0;
 	    }
 
 	    if ( infile->pf_state & PF_BOT ) {
@@ -119,21 +119,21 @@ int cm_psquery( struct papfile *in, struct papfile *out, struct sockaddr_at *sat
 	{
 	    /* handle eof at end of query job */
 	    compop();
-	    return (CH_DONE);
+	    return CH_DONE;
 	}
 	switch ( markline( in, &start, &linelength, &crlflength )) {
 	case 0 :
 	    /* eof on infile */
 	    out->pf_state |= PF_EOF;
 	    compop();
-	    return( CH_DONE );
+	    return CH_DONE;
 
 	case -1 :
 	    spoolreply( out, "Processing..." );
-	    return( CH_MORE );
+	    return CH_MORE;
 
         case -2 :
-            return( CH_ERROR );
+            return CH_ERROR;
 	}
 
 	if ( in->pf_state & PF_BOT ) {
@@ -141,7 +141,7 @@ int cm_psquery( struct papfile *in, struct papfile *out, struct sockaddr_at *sat
 	} else {
 	    if (( comment = commatch( start, start+linelength, queries )) != NULL ) {
 		compush( comment );
-		return( CH_DONE );
+		return CH_DONE;
 	    }
 	}
 
@@ -161,13 +161,13 @@ int cm_psadobe( struct papfile *in, struct papfile *out, struct sockaddr_at *sat
 	    /* eof on infile */
 	    out->pf_state |= PF_EOF;
 	    compop();
-	    return( CH_DONE );
+	    return CH_DONE;
 
 	case -1 :
-	    return( CH_MORE );
+	    return CH_MORE;
 
         case -2 :
-            return( CH_ERROR );
+            return CH_ERROR;
 	}
 	if ( in->pf_state & PF_BOT ) {
 	    in->pf_state &= ~PF_BOT;
@@ -180,7 +180,7 @@ int cm_psadobe( struct papfile *in, struct papfile *out, struct sockaddr_at *sat
 	} else {
 	    if (( comment = commatch( start, start + linelength, headers )) != NULL ) {
 		compush( comment );
-		return( CH_DONE );
+		return CH_DONE;
 	    }
 	}
 
@@ -206,13 +206,13 @@ int cm_psswitch(struct papfile *in, struct papfile *out, struct sockaddr_at *sat
 	/* eof on infile */
 	out->pf_state |= PF_EOF;
 	compop();
-	return( 0 );
+	return 0;
 
     case -1 :
-	return( CH_MORE );
+	return CH_MORE;
 
     case -2 :
-        return( CH_ERROR );
+        return CH_ERROR;
     }
 
     stop = start + linelength;
@@ -239,7 +239,7 @@ int cm_psswitch(struct papfile *in, struct papfile *out, struct sockaddr_at *sat
 	    exit( 1 );
 	}
     }
-    return( CH_DONE );
+    return CH_DONE;
 }
 
 

--- a/etc/papd/main.c
+++ b/etc/papd/main.c
@@ -563,12 +563,12 @@ int getstatus(struct printer *pr, rbuf_t *buf)
     if ( pr->p_flags & P_PIPED ) {
 	buf->buf_len = strlen(cannedstatus);
 	snprintf(buf->buf, 255, "%s", cannedstatus);
-	return (buf->buf_len + 1);
+	return buf->buf_len + 1;
     } else {
 	cups_get_printer_status( pr );
 	buf->buf_len = strlen(pr->p_status);
 	snprintf(buf->buf, 255, "%s", pr->p_status);
-	return (buf->buf_len + 1);
+	return buf->buf_len + 1;
     }
 #else
     char path[MAXPATHLEN];
@@ -585,7 +585,7 @@ int getstatus(struct printer *pr, rbuf_t *buf)
     if ((pr->p_flags & P_PIPED) || (fd == NULL)) {
 	buf->buf_len = strlen(cannedstatus);
 	snprintf(buf->buf, 255, "%s", cannedstatus);
-	return (buf->buf_len + 1);
+	return buf->buf_len + 1;
     } else {
 	rc = fread(getstatus_buffer, 255, sizeof(unsigned char), fd);
 	fclose(fd);
@@ -601,7 +601,7 @@ int getstatus(struct printer *pr, rbuf_t *buf)
 		buf->buf_len = 0;
 	}
 
-	return (buf->buf_len + 1);
+	return buf->buf_len + 1;
     }
 #endif /* HAVE_CUPS */
 }
@@ -807,7 +807,7 @@ int rprintcap( struct printer *pr)
     if ( pr->p_flags & P_SPOOLED && !(pr->p_flags & P_CUPS_AUTOADDED) ) { /* Skip check if autoadded */
 	if ( cups_printername_ok ( pr->p_printer ) != 1) {
 	    LOG(log_error, logtype_papd, "No such CUPS printer: '%s'", pr->p_printer );
-	    return( -1 );
+	    return -1;
 	}
     }
 
@@ -839,7 +839,7 @@ int rprintcap( struct printer *pr)
     if ( pr->p_flags & P_SPOOLED ) {
 	if ( pgetent( printcap, buf, pr->p_printer ) != 1 ) {
 	    LOG(log_error, logtype_papd, "No such printer: %s", pr->p_printer );
-	    return( -1 );
+	    return -1;
 	}
 
 	/*
@@ -938,5 +938,5 @@ int rprintcap( struct printer *pr)
     }
 #endif /* HAVE_CUPS */
 
-    return( 0 );
+    return 0;
 }

--- a/etc/papd/ppd.c
+++ b/etc/papd/ppd.c
@@ -119,7 +119,7 @@ static struct ppdent *getppdent( FILE *stream)
 	if ( *p == '\n' ) {
 	    *p = '\0';
 	    ppdent.pe_option = ppdent.pe_translation = ppdent.pe_value = NULL;
-	    return( &ppdent );
+	    return &ppdent;
 	}
 
 	if ( *p != ':' ) {	/* option key word */
@@ -168,10 +168,10 @@ static struct ppdent *getppdent( FILE *stream)
 	*p = '\0';
 	ppdent.pe_value = q;
 
-	return( &ppdent );
+	return &ppdent;
     }
 
-    return( NULL );
+    return NULL;
 }
 
 int read_ppd(char *file, int fcnt)
@@ -183,12 +183,12 @@ int read_ppd(char *file, int fcnt)
 
     if ( fcnt > 20 ) {
 	LOG(log_error, logtype_papd, "read_ppd: %s: Too many files!", file );
-	return( -1 );
+	return -1;
     }
 
     if (( ppdfile = fopen( file, "r" )) == NULL ) {
 	LOG(log_error, logtype_papd, "read_ppd %s: %s", file, strerror(errno) );
-	return( -1 );
+	return -1;
     }
 
     while (( pe = getppdent( ppdfile )) != NULL ) {
@@ -245,7 +245,7 @@ int read_ppd(char *file, int fcnt)
     }
 
     fclose( ppdfile );
-    return( 0 );
+    return 0;
 }
 
 struct ppd_font *ppd_font( char *font)
@@ -260,10 +260,10 @@ struct ppd_font *ppd_font( char *font)
 
     for ( pfo = ppd_fonts; pfo; pfo = pfo->pd_next ) {
 	if ( strcmp( pfo->pd_font, font ) == 0 ) {
-	    return( pfo );
+	    return pfo;
 	}
     }
-    return( NULL );
+    return NULL;
 }
 
 struct ppd_feature *ppd_feature( const char *feature, int len)
@@ -280,22 +280,22 @@ struct ppd_feature *ppd_feature( const char *feature, int len)
 #endif /* SHOWPPD */
 
     if (len > sizeof(ppd_feature_main) -1)
-        return( NULL );
+        return NULL;
 
     for ( end = feature + len, p = feature, q = ppd_feature_main;
 	    (p <= end) && (*p != '\n') && (*p != '\r'); p++, q++ ) {
 	*q = *p;
     }
     if ( p > end ) {
-	return( NULL );
+	return NULL;
     }
     *q = '\0';
 
     for ( pfe = ppd_features; pfe->pd_name; pfe++ ) {
 	if ( (strcmp( pfe->pd_name, ppd_feature_main ) == 0) && pfe->pd_value ) {
-	    return( pfe );
+	    return pfe;
 	}
     }
 
-    return( NULL );
+    return NULL;
 }

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -82,7 +82,7 @@ cups_passwd_cb(const char *prompt _U_, http_t *http, const char *method, const c
  /*
   * Always return NULL to indicate that no password is available...
   */
-  return (NULL);
+  return NULL;
 }
 
 
@@ -114,16 +114,16 @@ cups_printername_ok(char *name)         /* I - Name of printer */
 	{
 		LOG(log_error, logtype_papd,
 		    "Unable to get destination \"%s\": %s", name, cupsLastErrorString());
-		return (0);
+		return 0;
 	}
 	if ((http = cupsConnectDest(dest, CUPS_DEST_FLAGS_NONE, 30000, NULL, NULL, 0, NULL, NULL)) == NULL)
 	{
 		LOG(log_error, logtype_papd,
 		    "Unable to connect to destination \"%s\": %s", dest->name, cupsLastErrorString());
-		return (0);
+		return 0;
 	}
 
-	return (1);
+	return 1;
 }
 
 const char *
@@ -156,7 +156,7 @@ cups_get_printer_ppd ( char * name)
 	{
 		LOG(log_error, logtype_papd, "Unable to get destination \"%s\": %s\n", name, cupsLastErrorString());
 		cupsFreeDests(num_dests,dests);
-		return (0);
+		return 0;
 	}
 
 	const char* make_model = cupsGetOption("printer-make-and-model", dest->num_options, dest->options);
@@ -174,7 +174,7 @@ cups_get_printer_ppd ( char * name)
 	{
 		LOG(log_error, logtype_papd, "Unable to connect to destination \"%s\": %s\n", dest->name, cupsLastErrorString());
 		cupsFreeDests(num_dests,dests);
-		return (0);
+		return 0;
 	}
 
 	const char* uri = cupsGetOption("device-uri", dest->num_options, dest->options);
@@ -215,7 +215,7 @@ cups_get_printer_ppd ( char * name)
 				ippErrorString(cupsLastError()));
 		httpClose(http);
 		cupsFreeDests(num_dests,dests);
-		return (0);
+		return 0;
 	}
 
 	if (ippGetStatusCode(response) >= IPP_STATUS_OK_CONFLICTING)
@@ -225,7 +225,7 @@ cups_get_printer_ppd ( char * name)
 		ippDelete(response);
 		httpClose(http);
 		cupsFreeDests(num_dests,dests);
-		return (0);
+		return 0;
 	}
 
 	/*
@@ -242,7 +242,7 @@ cups_get_printer_ppd ( char * name)
 		ippDelete(response);
 		httpClose(http);
 		cupsFreeDests(num_dests,dests);
-		return (0);
+		return 0;
 	}
 
 	if (!response)
@@ -251,7 +251,7 @@ cups_get_printer_ppd ( char * name)
 		ippDelete(response);
 		httpClose(http);
 		cupsFreeDests(num_dests,dests);
-		return (0);
+		return 0;
 	}
 
 	/*
@@ -264,7 +264,7 @@ cups_get_printer_ppd ( char * name)
 		ippDelete(response);
 		httpClose(http);
 		cupsFreeDests(num_dests,dests);
-		return (0);
+		return 0;
 	}
 
 	/*
@@ -319,7 +319,7 @@ cups_get_printer_ppd ( char * name)
 	ippDelete(response);
 	cupsFileClose(fp);
 	cupsFreeDests(num_dests,dests);
-	return (buffer);
+	return buffer;
 }
 
 int
@@ -351,7 +351,7 @@ cups_get_printer_status (struct printer *pr)
 		LOG(log_error, logtype_papd,
 			"Unable to get destination \"%s\": %s", pr->p_printer, cupsLastErrorString());
 		snprintf(pr->p_status, 255, "status: busy; info: \"%s\" appears to be offline.", pr->p_printer);
-		return (0);
+		return 0;
 	}
 
 	/*
@@ -372,7 +372,7 @@ cups_get_printer_status (struct printer *pr)
 			"Unable to connect to destination \"%s\": %s", dest->name, cupsLastErrorString());
 		snprintf(pr->p_status, 255, "status: busy; info: \"%s\" appears to be offline.", pr->p_printer);
 		cupsFreeDests(1, dest);
-		return (0);
+		return 0;
 	}
 	ipp_t	* request,       /* IPP Request */
 		* response;      /* IPP Response */
@@ -419,7 +419,7 @@ cups_get_printer_status (struct printer *pr)
 		snprintf(pr->p_status, 255, "status: busy; info: \"%s\" not responding to queries.", pr->p_printer);
 		httpClose(http);
 		cupsFreeDests(1, dest);
-		return (1);
+		return 1;
 	}
 	if ((attr = ippFindAttribute(response, "printer-state",
 		IPP_TAG_ENUM)) != NULL)
@@ -471,7 +471,7 @@ cups_get_printer_status (struct printer *pr)
 	 */
 
 	cupsFreeDests(1, dest);
-	return (status);
+	return status;
 }
 
 
@@ -510,7 +510,7 @@ int cups_print_job ( char * name, const char *filename, char *job, char *usernam
 		LOG(log_error, logtype_papd,
 		    "Unable to get destination \"%s\": %s", name, cupsLastErrorString());
 		cupsFreeDests(1,dest);
-		return (0);
+		return 0;
 	}
 
 	info = cupsCopyDestInfo(CUPS_HTTP_DEFAULT, dest);
@@ -570,7 +570,7 @@ int cups_print_job ( char * name, const char *filename, char *job, char *usernam
 
 	cupsFreeOptions(num_options, options);
 	cupsFreeDests(1, dest);
-	return (jobid);
+	return jobid;
 }
 
 
@@ -682,9 +682,9 @@ static int cups_mangle_printer_name ( struct printer *pr, struct printer *printe
 	}
 
 	if ( count > 99)
-		return (2);
+		return 2;
 
-	return (0);
+	return 0;
 }
 
 /*------------------------------------------------------------------------*/
@@ -714,7 +714,7 @@ to_ascii ( char  *inptr, char **outptr)
 	}
 	*out = '\0';
 	*outptr = osav;
-	return ( strlen (osav) );
+	return strlen (osav);
 }
 
 
@@ -759,7 +759,7 @@ static int convert_to_mac_name ( const char * encoding, char * inptr, char * out
 	}
 	*soptr = '\0';
 	free (outbuf);
-	return (i);
+	return i;
 }
 
 
@@ -784,9 +784,9 @@ int cups_check_printer ( struct printer *pr, struct printer *printers, int repla
 		if ( strcasecmp (pr->p_name, listptr->p_name) == 0) {
 			if ( pr->p_flags & P_CUPS_AUTOADDED ) {  /* Check if printer has been autoadded */
 				if ( listptr->p_flags & P_CUPS_AUTOADDED )
-					return (-1);		 /* Conflicting Cups Auto Printer (mangling issue?) */
+					return -1;		 /* Conflicting Cups Auto Printer (mangling issue?) */
 				else
-					return (1);		 /* Never replace a hand edited printer with auto one */
+					return 1;		 /* Never replace a hand edited printer with auto one */
 			}
 
 			if ( replace ) {
@@ -802,12 +802,12 @@ int cups_check_printer ( struct printer *pr, struct printer *printers, int repla
 					cups_free_printer (listptr);
 				}
 			}
-			return (1);  /* Conflicting Printers */
+			return 1;  /* Conflicting Printers */
 		}
 		listprev = listptr;
 		listptr = listptr->p_next;
 	}
-	return (0);	/* No conflict */
+	return 0;	/* No conflict */
 }
 
 

--- a/etc/papd/printcap.c
+++ b/etc/papd/printcap.c
@@ -98,7 +98,7 @@ int getprent( char *cap, char *bp, int bufsize)
 	int i;
 
 	if (pfp == NULL && (pfp = fopen( cap, "r")) == NULL)
-		return(-1);
+		return -1;
 	tbuf = bp;
 	i = 0;
 	for (;;) {
@@ -182,7 +182,7 @@ int tgetent(char *cap, char *bp, const char *name)
 			cp2 = getenv("TERM");
 			if (cp2==(char *) 0 || strcmp(name,cp2)==0) {
 				strcpy(bp,cp);
-				return(tnchktc(cap));
+				return tnchktc(cap);
 			} else {
 				tf = open(cap, 0);
 			}
@@ -195,7 +195,7 @@ int tgetent(char *cap, char *bp, const char *name)
 	tf = open(cap, 0);
 #endif /* V6 */
 	if (tf < 0)
-		return (-1);
+		return -1;
 	for (;;) {
 		cp = bp;
 		skip = 0;
@@ -237,7 +237,7 @@ int tgetent(char *cap, char *bp, const char *name)
 		 */
 		if (tnamatch(name)) {
 			close(tf);
-			return(tnchktc(cap));
+			return tnchktc(cap);
 		}
 	}
 }
@@ -343,7 +343,7 @@ static char *tskip(char *bp)
 		bp++;
 	while (*bp && *bp == ':')
 		bp++;
-	return (bp);
+	return bp;
 }
 
 /*
@@ -363,11 +363,11 @@ int tgetnum(char *id)
 	for (;;) {
 		bp = tskip(bp);
 		if (*bp == 0)
-			return (-1);
+			return -1;
 		if (*bp++ != id[0] || *bp == 0 || *bp++ != id[1])
 			continue;
 		if (*bp == '@')
-			return(-1);
+			return -1;
 		if (*bp != '#')
 			continue;
 		bp++;
@@ -377,7 +377,7 @@ int tgetnum(char *id)
 		i = 0;
 		while (isdigit(*bp))
 			i *= base, i += *bp++ - '0';
-		return (i);
+		return i;
 	}
 }
 
@@ -448,7 +448,7 @@ nextc:
 	*cp++ = 0;
 	str = *area;
 	*area = cp;
-	return (str);
+	return str;
 }
 
 /*
@@ -467,15 +467,15 @@ tgetstr(char *id, char **area)
 	for (;;) {
 		bp = tskip(bp);
 		if (!*bp)
-			return (NULL);
+			return NULL;
 		if (*bp++ != id[0] || *bp == 0 || *bp++ != id[1])
 			continue;
 		if (*bp == '@')
-			return(NULL);
+			return NULL;
 		if (*bp != '=')
 			continue;
 		bp++;
-		return (tdecode(bp, area));
+		return tdecode(bp, area);
 	}
 }
 
@@ -519,11 +519,11 @@ nextc:
 	*cp++ = 0;
 	str = *area;
 	*area = cp;
-	return (str);
+	return str;
 }
 
 char *
 getpname(char **area, int bufsize)
 {
-	return( decodename( tbuf, area, bufsize));
+	return decodename( tbuf, area, bufsize);
 }

--- a/etc/papd/queries.c
+++ b/etc/papd/queries.c
@@ -58,13 +58,13 @@ int cq_default( struct papfile *in, struct papfile *out)
     for (;;) {
 	switch ( markline( in, &start, &linelength, &crlflength )) {
 	case 0 :
-	    return( 0 );
+	    return 0;
 
 	case -1 :
-	    return( CH_MORE );
+	    return CH_MORE;
 
         case -2 :
-            return( CH_ERROR );
+            return CH_ERROR;
 	}
 
 	stop = start+linelength;
@@ -75,7 +75,7 @@ int cq_default( struct papfile *in, struct papfile *out)
 	    } else {
 		compop();
 		CONSUME( in, linelength + crlflength );
-		return( CH_DONE );
+		return CH_DONE;
 	    }
 	} else {
 	    /* return default */
@@ -95,7 +95,7 @@ int cq_default( struct papfile *in, struct papfile *out)
 		append( out, p, stop - p + crlflength );
 		compop();
 		CONSUME( in, linelength + crlflength );
-		return( CH_DONE );
+		return CH_DONE;
 	    }
 	}
 
@@ -107,9 +107,9 @@ int gq_true( struct papfile *out)
 {
     if ( printer->p_flags & P_SPOOLED ) {
 	append( out, "true\n", 5 );
-	return( 0 );
+	return 0;
     } else {
-	return( -1 );
+	return -1;
     }
 }
 
@@ -128,10 +128,10 @@ int gq_pagecost( struct papfile *out)
 	sprintf( cost, "%d", printer->p_pagecost );
 	append( out, cost, strlen( cost ));
     } else {
-	return( -1 );
+	return -1;
     }
     append( out, "\n", 1 );
-    return( 0 );
+    return 0;
 }
 
 #ifdef ABS_PRINT
@@ -140,11 +140,11 @@ int gq_balance( struct papfile *out)
     char		balance[ 60 ];
 
     if ( lp_pagecost() != 0 ) {
-	return( -1 );
+	return -1;
     }
     sprintf( balance, "$%1.2f\n", printer->p_balance );
     append( out, balance, strlen( balance ));
-    return( 0 );
+    return 0;
 }
 #endif /* ABS_PRINT */
 
@@ -158,7 +158,7 @@ static const char *spoolerid = "(PAPD Spooler) 1.0 (" VERSION ")\n";
 int gq_rbispoolerid( struct papfile *out)
 {
     append( out, spoolerid, strlen( spoolerid ));
-    return(0);
+    return 0;
 }
 
 
@@ -176,14 +176,14 @@ int gq_rbiuamlist( struct papfile *out)
     if (printer->p_flags & P_AUTH_PSSP) {
 	if (getuamnames(UAM_SERVER_PRINTAUTH, uamnames) < 0) {
 	    append(out, nouams, strlen(nouams));
-	    return(0);
+	    return 0;
 	} else {
 	    append(out, uamnames, strlen(uamnames));
-	    return(0);
+	    return 0;
 	}
     } else {
 	append(out, nouams, strlen(nouams));
-	return(0);
+	return 0;
     }
 }
 
@@ -193,7 +193,7 @@ int gq_product( struct papfile *out)
     pdprod = ppd_feature( "*Product\n", strlen( "*Product\n" ));
     append( out, pdprod->pd_value, strlen( pdprod->pd_value ));
     append( out, "\r", 1 );
-    return(0);
+    return 0;
 }
 
 
@@ -225,13 +225,13 @@ int cq_query( struct papfile *in, struct papfile *out)
     for (;;) {
 	switch ( markline( in, &start, &linelength, &crlflength )) {
 	case 0 :
-	    return( 0 );
+	    return 0;
 
 	case -1 :
-	    return( CH_MORE );
+	    return CH_MORE;
 
         case -2 :
-            return( CH_ERROR );
+            return CH_ERROR;
 	}
 
 	stop = start+linelength;
@@ -269,13 +269,13 @@ int cq_query( struct papfile *in, struct papfile *out)
 		    LOG(log_error, logtype_papd, "cq_feature: can't find default!" );
 		    exit( 1 );
 		}
-		return( CH_DONE );
+		return CH_DONE;
 	    }
 	} else {
 	    if ( comcmp( start, stop, comment->c_end, 0 ) == 0 ) {
 		compop();
 		CONSUME( in, linelength + crlflength );
-		return( CH_DONE );
+		return CH_DONE;
 	    }
 	}
 
@@ -328,13 +328,13 @@ int cq_fontlist(struct papfile *in, struct papfile *out)
     for (;;){
         switch ( markline( in, &start, &linelength, &crlflength )) {
         case 0 :
-	return( 0 );
+	return 0;
 
         case -1 :
-	return( CH_MORE );
+	return CH_MORE;
 
         case -2 :
-        return( CH_ERROR );
+        return CH_ERROR;
         }
 	if ( comgetflags() == 0 ) {
 	    comsetflags( 1 );
@@ -381,7 +381,7 @@ int cq_fontlist(struct papfile *in, struct papfile *out)
 	    if ( comcmp( start, start+linelength, comment->c_end, 0 ) == 0 ) {
 		compop();
 		CONSUME( in, linelength + crlflength );
-		return( CH_DONE );
+		return CH_DONE;
 	    }
 
         }
@@ -399,13 +399,13 @@ int cq_font(struct papfile *in, struct papfile *out)
     for (;;) {
 	switch ( markline( in, &start, &linelength, &crlflength )) {
 	case 0 :
-	    return( 0 );
+	    return 0;
 
 	case -1 :
-	    return( CH_MORE );
+	    return CH_MORE;
 
         case -2 :
-            return( CH_ERROR );
+            return CH_ERROR;
 	}
 
 	stop = start + linelength;
@@ -442,7 +442,7 @@ int cq_font(struct papfile *in, struct papfile *out)
 		    append( out, "*\n", 2 );
 		    compop();
 		    CONSUME( in, linelength + crlflength );
-		    return( CH_DONE );
+		    return CH_DONE;
 		}
 	    }
 	}
@@ -461,13 +461,13 @@ int cq_feature( struct papfile *in, struct papfile *out)
     for (;;) {
 	switch ( markline( in, &start, &linelength, &crlflength )) {
 	case 0 :
-	    return( 0 );
+	    return 0;
 
 	case -1 :
-	    return( CH_MORE );
+	    return CH_MORE;
 
         case -2 :
-            return( CH_ERROR );
+            return CH_ERROR;
 	}
 
 	stop = start + linelength;
@@ -499,7 +499,7 @@ int cq_feature( struct papfile *in, struct papfile *out)
 		    LOG(log_error, logtype_papd, "cq_feature: can't find default!" );
 		    exit( 1 );
 		}
-		return( CH_DONE );
+		return CH_DONE;
 	    }
 
 	    append( out, pfe->pd_value, strlen( pfe->pd_value ));
@@ -508,7 +508,7 @@ int cq_feature( struct papfile *in, struct papfile *out)
 	    if ( comcmp( start, stop, comment->c_end, 0 ) == 0 ) {
 		compop();
 		CONSUME( in, linelength + crlflength );
-		return( CH_DONE );
+		return CH_DONE;
 	    }
 	}
 
@@ -529,13 +529,13 @@ int cq_printer(struct papfile *in, struct papfile *out)
     for (;;) {
 	switch ( markline( in, &start, &linelength, &crlflength )) {
 	case 0 :
-	    return( 0 );
+	    return 0;
 
 	case -1 :
-	    return( CH_MORE );
+	    return CH_MORE;
 
         case -2 :
-            return( CH_ERROR );
+            return CH_ERROR;
 	}
 
 	if ( comgetflags() == 0 ) {
@@ -546,7 +546,7 @@ int cq_printer(struct papfile *in, struct papfile *out)
 		    LOG(log_error, logtype_papd, "cq_printer: can't find default!" );
 		    exit( 1 );
 		}
-		return( CH_DONE );
+		return CH_DONE;
 	    }
 
 	    for ( p = pdpsver->pd_value; *p != '\0'; p++ ) {
@@ -560,7 +560,7 @@ int cq_printer(struct papfile *in, struct papfile *out)
 		    LOG(log_error, logtype_papd, "cq_printer: can't find default!" );
 		    exit( 1 );
 		}
-		return( CH_DONE );
+		return CH_DONE;
 	    }
 
 	    if (( pdprod = ppd_feature( prod, strlen( prod ))) == NULL ) {
@@ -568,7 +568,7 @@ int cq_printer(struct papfile *in, struct papfile *out)
 		    LOG(log_error, logtype_papd, "cq_printer: can't find default!" );
 		    exit( 1 );
 		}
-		return( CH_DONE );
+		return CH_DONE;
 	    }
 
 	    /* revision */
@@ -586,7 +586,7 @@ int cq_printer(struct papfile *in, struct papfile *out)
 	    if ( comcmp( start, start+linelength, comment->c_end, 0 ) == 0 ) {
 		compop();
 		CONSUME( in, linelength + crlflength );
-		return( CH_DONE );
+		return CH_DONE;
 	    }
 	}
 
@@ -607,13 +607,13 @@ int cq_rmjob( struct papfile *in, struct papfile *out)
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :
-	return( 0 );
+	return 0;
 
     case -1 :
-	return( CH_MORE );
+	return CH_MORE;
 
     case -2 :
-        return( CH_ERROR );
+        return CH_ERROR;
     }
 
     stop = start + linelength;
@@ -639,7 +639,7 @@ int cq_rmjob( struct papfile *in, struct papfile *out)
 
     compop();
     CONSUME( in, linelength + crlflength );
-    return( CH_DONE );
+    return CH_DONE;
 }
 
 int cq_listq( struct papfile *in, struct papfile *out)
@@ -649,13 +649,13 @@ int cq_listq( struct papfile *in, struct papfile *out)
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :
-	return( 0 );
+	return 0;
 
     case -1 :
-	return( CH_MORE );
+	return CH_MORE;
 
     case -2 :
-        return( CH_ERROR );
+        return CH_ERROR;
     }
 
     if ( lp_queue( out )) {
@@ -664,7 +664,7 @@ int cq_listq( struct papfile *in, struct papfile *out)
 
     compop();
     CONSUME( in, linelength + crlflength );
-    return( CH_DONE );
+    return CH_DONE;
 }
 #endif /* HAVE_CUPS */
 
@@ -692,13 +692,13 @@ int cq_rbilogin( struct papfile *in, struct papfile *out)
     for (;;) {
         switch ( markline( in, &start, &linelength, &crlflength )) {
         case 0 :
-            return( 0 );
+            return 0;
 
         case -1 :
-            return( CH_MORE );
+            return CH_MORE;
 
         case -2 :
-            return( CH_ERROR );
+            return CH_ERROR;
         }
 
 	stop = start + linelength;
@@ -735,7 +735,7 @@ int cq_rbilogin( struct papfile *in, struct papfile *out)
         } else {
             if ( comcmp( start, stop, comment->c_end, 0 ) == 0 ) {
                 compop();
-                return( CH_DONE );
+                return CH_DONE;
             }
         }
 
@@ -750,18 +750,18 @@ int cq_end( struct papfile *in, struct papfile *out)
 
     switch ( markline( in, &start, &linelength, &crlflength )) {
     case 0 :
-        return( 0 );
+        return 0;
 
     case -1 :
-        return( CH_MORE );
+        return CH_MORE;
 
     case -2 :
-        return( CH_ERROR );
+        return CH_ERROR;
     }
     in->pf_state |= PF_QUERY;
     compop();
     CONSUME( in, linelength + crlflength );
-    return ( CH_DONE );
+    return CH_DONE ;
 }
 
 /*

--- a/etc/papd/session.c
+++ b/etc/papd/session.c
@@ -85,7 +85,7 @@ int session(ATP atp, struct sockaddr_at *sat)
     atpb.atp_sreqtries = -1;		/* infinite retries */
     if ( atp_sreq( atp, &atpb, oquantum, ATP_XO )) {
 	LOG(log_error, logtype_papd, "atp_sreq: %s", strerror(errno) );
-	return( -1 );
+	return -1;
     }
 
     for (;;) {
@@ -108,13 +108,13 @@ int session(ATP atp, struct sockaddr_at *sat)
 
 	if ( cc < 0 ) {
 	  LOG(log_error, logtype_papd, "select: Error is unrecoverable" );
-	  return( -1 );
+	  return -1;
 	}
 	if ( cc == 0 ) {
 	    if ( timeout++ > 2 ) {
 		LOG(log_error, logtype_papd, "connection timed out" );
 		lp_cancel();
-		return( -1 );
+		return -1;
 	    }
 
 	    /*
@@ -130,7 +130,7 @@ int session(ATP atp, struct sockaddr_at *sat)
 	    atpb.atp_sreqtries = 1;		/* try once */
 	    if ( atp_sreq( atp, &atpb, 0, 0 )) {
 		LOG(log_error, logtype_papd, "atp_sreq: %s", strerror(errno) );
-		return( -1 );
+		return -1;
 	    }
 	    continue;
 	} else {
@@ -145,7 +145,7 @@ int session(ATP atp, struct sockaddr_at *sat)
 	    atpb.atp_rreqdlen = sizeof( cbuf );
 	    if ( atp_rreq( atp, &atpb ) < 0 ) {
 		LOG(log_error, logtype_papd, "atp_rreq: %s", strerror(errno) );
-		return( -1 );
+		return -1;
 	    }
 	    /* sanity */
 	    if ( (unsigned char)cbuf[ 0 ] != connid ) {
@@ -193,7 +193,7 @@ int session(ATP atp, struct sockaddr_at *sat)
 		    LOG(log_error, logtype_papd, "atp_sresp: %s", strerror(errno) );
 		    exit( 1 );
 		}
-		return( 0 );
+		return 0;
 		break;
 
 	    case PAP_TICKLE :
@@ -213,7 +213,7 @@ int session(ATP atp, struct sockaddr_at *sat)
 	    atpb.atp_rresiovcnt = oquantum;
 	    if ( atp_rresp( atp, &atpb ) < 0 ) {
 		LOG(log_error, logtype_papd, "atp_rresp: %s", strerror(errno) );
-		return( -1 );
+		return -1;
 	    }
 
 	    /* sanity */
@@ -235,7 +235,7 @@ int session(ATP atp, struct sockaddr_at *sat)
 	    /* move data */
 	    if ( ps( &infile, &outfile, sat ) < 0 ) {
 		LOG(log_error, logtype_papd, "parse: bad return" );
-		return( -1 );	/* really?  close? */
+		return -1;	/* really?  close? */
 	    }
 
 	    /*
@@ -253,7 +253,7 @@ int session(ATP atp, struct sockaddr_at *sat)
 	    atpb.atp_sreqtries = -1;		/* infinite retries */
 	    if ( atp_sreq( atp, &atpb, oquantum, ATP_XO )) {
 		LOG(log_error, logtype_papd, "atp_sreq: %s", strerror(errno) );
-		return( -1 );
+		return -1;
 	    }
 	    break;
 
@@ -262,7 +262,7 @@ int session(ATP atp, struct sockaddr_at *sat)
 
 	default :
 	    LOG(log_error, logtype_papd, "atp_rsel: %s", strerror(errno) );
-	    return( -1 );
+	    return -1;
 	}
 
 	/* send any data that we have */
@@ -303,7 +303,7 @@ int session(ATP atp, struct sockaddr_at *sat)
 	    atpb.atp_sresiovcnt = i;	/* reported by stevebn@pc1.eos.co.uk */
 	    if ( atp_sresp( atp, &atpb ) < 0 ) {
 		LOG(log_error, logtype_papd, "atp_sresp: %s", strerror(errno) );
-		return( -1 );
+		return -1;
 	    }
 	    readpending = 0;
 	    }
@@ -339,7 +339,7 @@ int session(ATP atp, struct sockaddr_at *sat)
 	    atpb.atp_sresiovcnt = i;	/* reported by stevebn@pc1.eos.co.uk */
 	    if ( atp_sresp( atp, &atpb ) < 0 ) {
 		LOG(log_error, logtype_papd, "atp_sresp: %s", strerror(errno) );
-		return( -1 );
+		return -1;
 	    }
 	    readpending = 0;
 	}

--- a/etc/papd/uam.c
+++ b/etc/papd/uam.c
@@ -169,7 +169,7 @@ void uam_unregister(const int type, const char *name)
 int uam_afpserver_option(void *private _U_, const int what _U_, void *option _U_,
                          size_t *len _U_)
 {
-	return(0);
+	return 0;
 }
 
 /* --- helper functions for plugin uams --- */

--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -355,7 +355,7 @@ static int pam_login(void *obj, struct passwd **uam_pwd,
     if ((unsigned long) ibuf & 1) /* pad to even boundary */
         ++ibuf;
 
-    return (login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 /* ----------------------------- */
@@ -390,7 +390,7 @@ static int pam_login_ext(void *obj, char *uname, struct passwd **uam_pwd,
     memcpy(username, uname +2, len );
     username[ len ] = '\0';
 
-    return (login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 /* -------------------------------- */
@@ -760,13 +760,13 @@ static int changepw_1(void *obj, char *uname,
 
     /* Remember it now, use it in changepw_3 */
     PAM_username = uname;
-    return( dhx2_setup(obj, ibuf, ibuflen, rbuf, rbuflen) );
+    return dhx2_setup(obj, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 static int changepw_2(void *obj,
                       char *ibuf, size_t ibuflen, char *rbuf, size_t *rbuflen)
 {
-    return( logincont1(obj, ibuf, ibuflen, rbuf, rbuflen) );
+    return logincont1(obj, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 static int changepw_3(void *obj _U_,

--- a/etc/uams/uams_dhx2_passwd.c
+++ b/etc/uams/uams_dhx2_passwd.c
@@ -295,7 +295,7 @@ static int passwd_login(void *obj, struct passwd **uam_pwd,
     if ((unsigned long) ibuf & 1) /* pad to even boundary */
         ++ibuf;
 
-    return (login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 /* ----------------------------- */
@@ -330,7 +330,7 @@ static int passwd_login_ext(void *obj, char *uname, struct passwd **uam_pwd,
     memcpy(username, uname +2, len );
     username[ len ] = '\0';
 
-    return (login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 /* -------------------------------- */

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -352,7 +352,7 @@ static int pam_login(void *obj, struct passwd **uam_pwd,
     if ((unsigned long) ibuf & 1) /* pad to even boundary */
       ++ibuf;
 
-    return (login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 /* ----------------------------- */
@@ -388,7 +388,7 @@ static int pam_login_ext(void *obj, char *uname, struct passwd **uam_pwd,
     memcpy(username, uname +2, len );
     username[ len ] = '\0';
 
-    return (login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 /* -------------------------------- */

--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -212,13 +212,13 @@ static int passwd_login(void *obj, struct passwd **uam_pwd,
 	return AFPERR_MISC;
 
     if (ibuflen < 2) {
-	return( AFPERR_PARAM );
+	return AFPERR_PARAM;
     }
 
     len = (unsigned char) *ibuf++;
     ibuflen--;
     if (!len || len > ibuflen || len > ulen ) {
-	return( AFPERR_PARAM );
+	return AFPERR_PARAM;
     }
     memcpy(username, ibuf, len );
     ibuf += len;
@@ -229,7 +229,7 @@ static int passwd_login(void *obj, struct passwd **uam_pwd,
 	++ibuf;
 	ibuflen--;
     }
-    return (pwd_login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return pwd_login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 
 }
 
@@ -259,11 +259,11 @@ static int passwd_login_ext(void *obj, char *uname, struct passwd **uam_pwd,
     memcpy(&temp16, uname, sizeof(temp16));
     len = ntohs(temp16);
     if (!len || len > ulen ) {
-	return( AFPERR_PARAM );
+	return AFPERR_PARAM;
     }
     memcpy(username, uname +2, len );
     username[ len ] = '\0';
-    return (pwd_login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return pwd_login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 static int passwd_logincont(void *obj, struct passwd **uam_pwd,
@@ -358,7 +358,7 @@ static int passwd_logincont(void *obj, struct passwd **uam_pwd,
 #ifdef SHADOWPW
     if (( sp = getspnam( dhxpwd->pw_name )) == NULL ) {
 	LOG(log_info, logtype_uams, "no shadow passwd entry for %s", dhxpwd->pw_name);
-	return (AFPERR_NOTAUTH);
+	return AFPERR_NOTAUTH;
     }
 
     /* check for expired password */

--- a/etc/uams/uams_guest.c
+++ b/etc/uams/uams_guest.c
@@ -47,18 +47,18 @@ static int noauth_login(void *obj, struct passwd **uam_pwd,
     if ((pwent = getpwnam(guest)) == NULL) {
 	LOG(log_error, logtype_uams, "noauth_login: getpwnam( %s ): %s",
 		guest, strerror(errno) );
-	return( AFPERR_BADUAM );
+	return AFPERR_BADUAM;
     }
 
     *uam_pwd = pwent;
-    return( AFP_OK );
+    return AFP_OK;
 }
 
 static int noauth_login_ext(void *obj, char *uname _U_, struct passwd **uam_pwd,
                      char *ibuf, size_t ibuflen,
                      char *rbuf, size_t *rbuflen)
 {
-        return ( noauth_login (obj, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+        return noauth_login (obj, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 
@@ -71,7 +71,7 @@ static int noauth_printer(char *start, char *stop, char *username, struct papfil
     data = (char *)malloc(stop - start + 1);
     if (!data) {
 	LOG(log_info, logtype_uams,"Bad Login NoAuthUAM: malloc");
-	return(-1);
+	return -1;
     }
 
     strlcpy(data, start, stop - start + 1);
@@ -85,13 +85,13 @@ static int noauth_printer(char *start, char *stop, char *username, struct papfil
     if ((p = strchr(data, '(' )) == NULL) {
 	LOG(log_info, logtype_uams,"Bad Login NoAuthUAM: username not found in string");
 	free(data);
-	return(-1);
+	return -1;
     }
     p++;
     if ((q = strchr(p, ')' )) == NULL) {
 	LOG(log_info, logtype_uams,"Bad Login NoAuthUAM: username not found in string");
 	free(data);
-	return(-1);
+	return -1;
     }
     memcpy(username, p,  MIN( UAM_USERNAMELEN, q - p ));
 
@@ -101,13 +101,13 @@ static int noauth_printer(char *start, char *stop, char *username, struct papfil
     if (getpwnam(username) == NULL) {
 	LOG(log_info, logtype_uams, "Bad Login NoAuthUAM: %s: %s",
 	       username, strerror(errno) );
-	return(-1);
+	return -1;
     }
 
     /* Login successful */
     append(out, loginok, strlen(loginok));
     LOG(log_info, logtype_uams, "Login NoAuthUAM: %s", username);
-    return(0);
+    return 0;
 }
 
 

--- a/etc/uams/uams_pam.c
+++ b/etc/uams/uams_pam.c
@@ -214,7 +214,7 @@ static int pam_login(void *obj, struct passwd **uam_pwd,
 
     len = (unsigned char) *ibuf++;
     if ( len > ulen ) {
-	return( AFPERR_PARAM );
+	return AFPERR_PARAM;
     }
 
     memcpy(username, ibuf, len );
@@ -224,7 +224,7 @@ static int pam_login(void *obj, struct passwd **uam_pwd,
 
     if ((unsigned long) ibuf & 1)  /* pad character */
       ++ibuf;
-    return (login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 /* ----------------------------- */
@@ -248,12 +248,12 @@ static int pam_login_ext(void *obj, char *uname, struct passwd **uam_pwd,
     len = ntohs(temp16);
 
     if (!len || len > ulen ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
     memcpy(username, uname +2, len );
     username[ len ] = '\0';
 
-    return (login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 /* logout */
@@ -351,7 +351,7 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
     data = (char *)malloc(stop - start + 1);
     if (!data) {
 	LOG(log_info, logtype_uams,"Bad Login ClearTxtUAM: malloc");
-	return(-1);
+	return -1;
     }
 
     strlcpy(data, start, stop - start + 1);
@@ -366,13 +366,13 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
     if ((p = strchr(data, '(' )) == NULL) {
 	LOG(log_info, logtype_uams,"Bad Login ClearTxtUAM: username not found in string");
 	free(data);
-	return(-1);
+	return -1;
     }
     p++;
     if ((q = strstr(p, ") (" )) == NULL) {
 	LOG(log_info, logtype_uams,"Bad Login ClearTxtUAM: username not found in string");
 	free(data);
-	return(-1);
+	return -1;
     }
     memcpy(username, p, MIN(UAM_USERNAMELEN, q - p) );
 
@@ -381,7 +381,7 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
     if ((q = strrchr(p, ')' )) == NULL) {
 	LOG(log_info, logtype_uams,"Bad Login ClearTxtUAM: password not found in string");
 	free(data);
-	return(-1);
+	return -1;
     }
 
     /* Allocate memory for the global PAM_password */
@@ -402,14 +402,14 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
             username);
         free(PAM_password);
         PAM_password = NULL;
-        return(-1);
+        return -1;
     }
 
     if (uam_checkuser(pwd) < 0) {
         /* syslog of error happens in uam_checkuser */
         free(PAM_password);
         PAM_password = NULL;
-        return(-1);
+        return -1;
     }
 
     PAM_username = username;
@@ -423,7 +423,7 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
         pamh = NULL;
         free(PAM_password);
         PAM_password = NULL;
-        return(-1);
+        return -1;
     }
 
     pam_set_item(pamh, PAM_TTY, "papd");
@@ -436,7 +436,7 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
         pamh = NULL;
         free(PAM_password);
         PAM_password = NULL;
-        return(-1);
+        return -1;
     }
 
     PAM_error = pam_acct_mgmt(pamh, 0);
@@ -447,7 +447,7 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
         pamh = NULL;
         free(PAM_password);
         PAM_password = NULL;
-        return(-1);
+        return -1;
     }
 
     PAM_error = pam_open_session(pamh, 0);
@@ -458,7 +458,7 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
         pamh = NULL;
         free(PAM_password);
         PAM_password = NULL;
-        return(-1);
+        return -1;
     }
 
     /* Login successful, but no need to hang onto it,
@@ -473,7 +473,7 @@ static int pam_printer(char *start, char *stop, char *username, struct papfile *
     free(PAM_password);
     PAM_password = NULL;
 
-    return(0);
+    return 0;
 }
 
 

--- a/etc/uams/uams_passwd.c
+++ b/etc/uams/uams_passwd.c
@@ -49,7 +49,7 @@ static int pwd_login(void *obj, char *username, int ulen, struct passwd **uam_pw
 #endif /* SHADOWPW */
 
     if (ibuflen < PASSWDLEN) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
     ibuf[ PASSWDLEN ] = '\0';
 
@@ -115,13 +115,13 @@ static int passwd_login(void *obj, struct passwd **uam_pwd,
         return AFPERR_MISC;
 
     if (ibuflen < 2) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     len = (unsigned char) *ibuf++;
     ibuflen--;
     if (!len || len > ibuflen || len > ulen ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
     memcpy(username, ibuf, len );
     ibuf += len;
@@ -132,7 +132,7 @@ static int passwd_login(void *obj, struct passwd **uam_pwd,
         ++ibuf;
         ibuflen--;
     }
-    return (pwd_login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return pwd_login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 
 }
 
@@ -162,11 +162,11 @@ static int passwd_login_ext(void *obj, char *uname, struct passwd **uam_pwd,
     memcpy(&temp16, uname, sizeof(temp16));
     len = ntohs(temp16);
     if (!len || len > ulen ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
     memcpy(username, uname +2, len );
     username[ len ] = '\0';
-    return (pwd_login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return pwd_login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 /* Printer ClearTxtUAM login */
@@ -184,7 +184,7 @@ static int passwd_printer(char	*start, char *stop, char *username, struct papfil
     data = (char *)malloc(stop - start + 1);
     if (!data) {
 	LOG(log_info, logtype_uams,"Bad Login ClearTxtUAM: malloc");
-	return(-1);
+	return -1;
     }
     strlcpy(data, start, stop - start + 1);
 
@@ -198,13 +198,13 @@ static int passwd_printer(char	*start, char *stop, char *username, struct papfil
     if ((p = strchr(data, '(' )) == NULL) {
         LOG(log_info, logtype_uams,"Bad Login ClearTxtUAM: username not found in string");
         free(data);
-        return(-1);
+        return -1;
     }
     p++;
     if ((q = strstr(p, ") (" )) == NULL) {
         LOG(log_info, logtype_uams,"Bad Login ClearTxtUAM: username not found in string");
         free(data);
-        return(-1);
+        return -1;
     }
     memcpy(username, p,  MIN( UAM_USERNAMELEN, q - p ));
 
@@ -213,7 +213,7 @@ static int passwd_printer(char	*start, char *stop, char *username, struct papfil
     if ((q = strrchr(p , ')' )) == NULL) {
         LOG(log_info, logtype_uams,"Bad Login ClearTxtUAM: password not found in string");
         free(data);
-        return(-1);
+        return -1;
     }
     memcpy(password, p, MIN(PASSWDLEN, q - p) );
 
@@ -225,19 +225,19 @@ static int passwd_printer(char	*start, char *stop, char *username, struct papfil
     if (( pwd = uam_getname(NULL, username, ulen)) == NULL ) {
         LOG(log_info, logtype_uams, "Bad Login ClearTxtUAM: ( %s ) not found ",
             username);
-        return(-1);
+        return -1;
     }
 
     if (uam_checkuser(pwd) < 0) {
         /* syslog of error happens in uam_checkuser */
-        return(-1);
+        return -1;
     }
 
 #ifdef SHADOWPW
     if (( sp = getspnam( pwd->pw_name )) == NULL ) {
         LOG(log_info, logtype_uams, "Bad Login ClearTxtUAM: no shadow passwd entry for %s",
             username);
-        return(-1);
+        return -1;
     }
     pwd->pw_passwd = sp->sp_pwdp;
 
@@ -246,7 +246,7 @@ static int passwd_printer(char	*start, char *stop, char *username, struct papfil
         int32_t expire_days = sp->sp_lstchg - now + sp->sp_max;
         if ( expire_days < 0 ) {
                 LOG(log_info, logtype_uams, "Password for user %s expired", username);
-		return (-1);
+		return -1;
         }
     }
 
@@ -255,7 +255,7 @@ static int passwd_printer(char	*start, char *stop, char *username, struct papfil
     if (!pwd->pw_passwd) {
         LOG(log_info, logtype_uams, "Bad Login ClearTxtUAM: no password for %s",
             username);
-        return(-1);
+        return -1;
     }
 
 #ifdef HAVE_CRYPT_CHECKPASS
@@ -272,7 +272,7 @@ static int passwd_printer(char	*start, char *stop, char *username, struct papfil
     /* Login successful */
     append(out, loginok, strlen(loginok));
     LOG(log_info, logtype_uams, "Login ClearTxtUAM: %s", username);
-    return(0);
+    return 0;
 }
 
 static int uam_setup(void *obj, const char *path)

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -485,7 +485,7 @@ static int randnum_changepw(void *obj, const char *username _U_,
     if (err)
       return err;
 
-  return( AFP_OK );
+  return AFP_OK;
 }
 
 /* randnum login */
@@ -503,13 +503,13 @@ static int randnum_login(void *obj, struct passwd **uam_pwd,
         return AFPERR_MISC;
 
     if (ibuflen < 2) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
 
     len = (unsigned char) *ibuf++;
     ibuflen--;
     if (!len || len > ibuflen || len > ulen ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
     memcpy(username, ibuf, len );
     ibuf += len;
@@ -520,7 +520,7 @@ static int randnum_login(void *obj, struct passwd **uam_pwd,
         ++ibuf;
         ibuflen--;
     }
-    return (rand_login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return rand_login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 /* randnum login ext */
@@ -544,11 +544,11 @@ static int randnum_login_ext(void *obj, char *uname, struct passwd **uam_pwd,
     memcpy(&temp16, uname, sizeof(temp16));
     len = ntohs(temp16);
     if (!len || len > ulen ) {
-        return( AFPERR_PARAM );
+        return AFPERR_PARAM;
     }
     memcpy(username, uname +2, len );
     username[ len ] = '\0';
-    return (rand_login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen));
+    return rand_login(obj, username, ulen, uam_pwd, ibuf, ibuflen, rbuf, rbuflen);
 }
 
 static int uam_setup(void *obj, const char *path)

--- a/libatalk/adouble/ad_flush.c
+++ b/libatalk/adouble/ad_flush.c
@@ -308,7 +308,7 @@ static int ad_flush_hf(struct adouble *ad)
             if (adf_pwrite(ad->ad_mdp, ad->ad_data, len, 0) != len) {
                 if (errno == 0)
                     errno = EIO;
-                return( -1 );
+                return -1;
             }
             break;
         case AD_VERSION_EA:

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -1831,7 +1831,7 @@ const char *ad_path( const char *path, int adflags)
         }
     }
 
-    return( pathbuf );
+    return pathbuf;
 }
 
 /* -------------------------

--- a/libatalk/adouble/ad_read.c
+++ b/libatalk/adouble/ad_read.c
@@ -93,8 +93,8 @@ ssize_t ad_read( struct adouble *ad, const uint32_t eid, off_t off, char *buf, c
         }
 
         if (( cc = adf_pread( &ad->ad_resource_fork, buf, buflen, r_off )) < 0 )
-            return( -1 );
+            return -1;
     }
 
-    return( cc );
+    return cc;
 }

--- a/libatalk/adouble/ad_write.c
+++ b/libatalk/adouble/ad_write.c
@@ -65,7 +65,7 @@ ssize_t ad_write(struct adouble *ad, uint32_t eid, off_t off, int end, const cha
     if ( eid == ADEID_DFORK ) {
         if ( end ) {
             if ( fstat( ad_data_fileno(ad), &st ) < 0 ) {
-                return( -1 );
+                return -1;
             }
             off = st.st_size - off;
         }
@@ -73,7 +73,7 @@ ssize_t ad_write(struct adouble *ad, uint32_t eid, off_t off, int end, const cha
     } else if ( eid == ADEID_RFORK ) {
         if (end) {
             if (fstat( ad_reso_fileno(ad), &st ) < 0)
-                return(-1);
+                return -1;
             off = st.st_size - off - ad_getentryoff(ad, eid);
         }
         if (ad->ad_vers == AD_VERSION_EA) {
@@ -95,7 +95,7 @@ ssize_t ad_write(struct adouble *ad, uint32_t eid, off_t off, int end, const cha
 
     if (ret != 0)
         return ret;
-    return( cc );
+    return cc;
 }
 
 /*

--- a/libatalk/asp/asp_cmdreply.c
+++ b/libatalk/asp/asp_cmdreply.c
@@ -73,9 +73,9 @@ int asp_cmdreply(ASP asp, int result)
     atpb.atp_sresiov = iov;
     atpb.atp_sresiovcnt = iovcnt;
     if ( atp_sresp( asp->asp_atp, &atpb ) < 0 ) {
-	return( -1 );
+	return -1;
     }
     asp->asp_seq++;
 
-    return( 0 );
+    return 0;
 }

--- a/libatalk/asp/asp_getreq.c
+++ b/libatalk/asp/asp_getreq.c
@@ -46,7 +46,7 @@ int asp_getrequest(ASP asp)
     atpb.atp_rreqdlen = sizeof(asp->cmdbuf);
 
     if ( atp_rreq( asp->asp_atp, &atpb ) < 0 ) {
-	return( -1 );
+	return -1;
     }
 
     asp->cmdlen = atpb.atp_rreqdlen - 4;
@@ -55,11 +55,11 @@ int asp_getrequest(ASP asp)
     seq = ntohs( seq );
 
     if ((asp->cmdbuf[0] != ASPFUNC_CLOSE) && (seq != asp->asp_seq)) {
-	return( -2 );
+	return -2;
     }
     if ( asp->cmdbuf[1] != asp->asp_sid ) {
-	return( -3 );
+	return -3;
     }
 
-    return( asp->cmdbuf[0] ); /* the command */
+    return asp->cmdbuf[0]; /* the command */
 }

--- a/libatalk/asp/asp_getsess.c
+++ b/libatalk/asp/asp_getsess.c
@@ -165,7 +165,7 @@ ASP asp_getsession(ASP asp, server_child_t *server_children,
       if ( errno == EINTR || errno == EAGAIN ) {
 	continue;
       }
-      return( NULL );
+      return NULL;
     }
 
     switch ( asp->cmdbuf[ 0 ] ) {

--- a/libatalk/asp/asp_init.c
+++ b/libatalk/asp/asp_init.c
@@ -41,7 +41,7 @@ ASP asp_init(ATP atp)
     ASP		asp;
 
     if (( asp = (struct ASP *)calloc(1, sizeof( struct ASP ))) == NULL ) {
-	return( NULL );
+	return NULL;
     }
 
     asp->asp_atp = atp;
@@ -60,7 +60,7 @@ ASP asp_init(ATP atp)
     asp->read_count = asp->write_count = 0;
     asp->commands = asp->cmdbuf + 4;
 
-    return( asp );
+    return asp;
 }
 
 void asp_setstatus(ASP asp, char *status, const int slen)

--- a/libatalk/asp/asp_shutdown.c
+++ b/libatalk/asp/asp_shutdown.c
@@ -42,7 +42,7 @@ int asp_shutdown(ASP asp)
 
     if ( atp_sreq( asp->asp_atp, &atpb, 1, ATP_XO ) < 0 ) {
 	asp->asp_sat.sat_port = oport;
-	return( -1 );
+	return -1;
     }
 
     iov.iov_base = asp->commands;
@@ -52,9 +52,9 @@ int asp_shutdown(ASP asp)
 
     if ( atp_rresp( asp->asp_atp, &atpb ) < 0 ) {
 	asp->asp_sat.sat_port = oport;
-	return( -1 );
+	return -1;
     }
     asp->asp_sat.sat_port = oport;
 
-    return( 0 );
+    return 0;
 }

--- a/libatalk/asp/asp_write.c
+++ b/libatalk/asp/asp_write.c
@@ -67,7 +67,7 @@ int asp_wrtcont(ASP asp, char *buf, size_t *buflen)
 
     if ( atp_sreq( asp->asp_atp, &atpb, iovcnt, ATP_XO ) < 0 ) {
 	asp->asp_sat.sat_port = oport;
-	return( -1 );
+	return -1;
     }
     asp->write_count += atpb.atp_sreqdlen;
 
@@ -75,7 +75,7 @@ int asp_wrtcont(ASP asp, char *buf, size_t *buflen)
     atpb.atp_rresiovcnt = iovcnt;
     if ( atp_rresp( asp->asp_atp, &atpb ) < 0 ) {
 	asp->asp_sat.sat_port = oport;
-	return( -1 );
+	return -1;
     }
 
     asp->asp_sat.sat_port = oport;

--- a/libatalk/atp/atp_packet.c
+++ b/libatalk/atp/atp_packet.c
@@ -211,7 +211,7 @@ atp_recv_atp( ATP ah,
 	    pq->atpbuf_next = cq->atpbuf_next;
 	}
 	atp_free_buf( cq );
-	return( dlen );
+	return dlen;
     }
 
     /* we need to get it the net -- call on ddp to receive a packet
@@ -299,12 +299,12 @@ atp_recv_atp( ATP ah,
 	    }
 	}
 	if ( !wait && dlen < 0 ) {
-	    return( 0 );
+	    return 0;
 	}
 
     } while ( dlen < 0 );
 
-    return( dlen );
+    return dlen;
 }
 
 

--- a/libatalk/atp/atp_rreq.c
+++ b/libatalk/atp/atp_rreq.c
@@ -70,7 +70,7 @@ int atp_rreq(
 #ifdef EBUG
 	printf( "<%d> atp_rreq: atp_rsel returns err %d\n", getpid(), rc );
 #endif /* EBUG */
-	return( rc );
+	return rc;
     }
 
     /* allocate a buffer for receiving request
@@ -111,5 +111,5 @@ int atp_rreq(
 	    recvlen - ATP_HDRSIZE );
     atpb->atp_bitmap = req_hdr.atphd_bitmap;
     atp_free_buf( req_buf );
-    return( 0 );
+    return 0;
 }

--- a/libatalk/atp/atp_rresp.c
+++ b/libatalk/atp/atp_rresp.c
@@ -58,7 +58,7 @@ atp_rresp(
     */
     if ( atpb->atp_rresiovcnt <= 0 || atpb->atp_rresiovcnt > 8 ) {
 	errno = EINVAL;
-	return( -1 );
+	return -1;
     }
 
     while (( rc = atp_rsel( ah, atpb->atp_saddr, ATP_TRESP )) == 0 ) {
@@ -66,7 +66,7 @@ atp_rresp(
     }
 
     if ( rc != ATP_TRESP ) {
-	return( rc );
+	return rc;
     }
 
     for ( i = 0; i < 8; ++i ) {
@@ -77,7 +77,7 @@ atp_rresp(
 	if ( i > atpb->atp_rresiovcnt - 1 ||
 		len > atpb->atp_rresiov[ i ].iov_len ) {
 	    errno = EMSGSIZE;
-	    return( -1 );
+	    return -1;
 	}
 #ifdef EBUG
 	fprintf( stderr, "atp_rresp copying %ld bytes packet %d\n",
@@ -94,5 +94,5 @@ atp_rresp(
     }
     atpb->atp_rresiovcnt = i;
 
-    return( 0 );
+    return 0;
 }

--- a/libatalk/atp/atp_rsel.c
+++ b/libatalk/atp/atp_rsel.c
@@ -62,14 +62,14 @@ resend_request(ATP ah)
 	    ah->atph_reqpkt->atpbuf_dlen, 0,
 	    (struct sockaddr *) &ah->atph_reqpkt->atpbuf_addr,
 	    sizeof( struct sockaddr_at )) != ah->atph_reqpkt->atpbuf_dlen ) {
-	return( -1 );
+	return -1;
     }
 
     if ( ah->atph_reqtries > 0 ) {
 	--(ah->atph_reqtries);
     }
 
-    return( 0 );
+    return 0;
 }
 
 int
@@ -102,11 +102,11 @@ atp_rsel(
 	/*
 	 * we already have a complete atp response; just return
 	 */
-	return( ATP_TRESP );
+	return ATP_TRESP;
     }
 
     if (( abuf = atp_alloc_buf()) == NULL ) {
-	return( -1 );
+	return -1;
     }
 
     if ( requesting ) {
@@ -117,7 +117,7 @@ atp_rsel(
 	if ( tv.tv_sec - ah->atph_reqtv.tv_sec > ah->atph_reqto ) {
 	    if ( resend_request( ah ) < 0 ) {
 		atp_free_buf( abuf );
-		return( -1 );
+		return -1;
 	    }
 	}
     }
@@ -132,7 +132,7 @@ atp_rsel(
 	    if (( c = select( ah->atph_socket + 1, &fds, NULL, NULL,
 		    &tv )) < 0 ) {
 		atp_free_buf( abuf );
-		return( -1 );
+		return -1;
 	    }
 	    if ( c == 0 || FD_ISSET( ah->atph_socket, &fds ) == 0 ) {
 		recvlen = -1;
@@ -169,7 +169,7 @@ timeout :
 
     if ( recvlen <= 0 ) {	/* error */
 	atp_free_buf( abuf );
-	return( recvlen );
+	return recvlen;
     }
 
 #ifdef EBUG
@@ -256,10 +256,10 @@ timeout :
 	    memcpy( faddr, &saddr, sizeof( struct sockaddr_at ));
 	    abuf->atpbuf_next = ah->atph_queue;
 	    ah->atph_queue = abuf;
-	    return( ATP_TREQ );
+	    return ATP_TREQ;
 	} else {
 	    atp_free_buf( abuf );
-	    return( 0 );
+	    return 0;
 	}
     }
 
@@ -304,7 +304,7 @@ timeout :
 		    sizeof( struct sockaddr_at )) !=
 		    ah->atph_reqpkt->atpbuf_dlen ) {
 		atp_free_buf( abuf );
-		return( -1 );
+		return -1;
 	    }
 	}
     } else {
@@ -350,13 +350,13 @@ timeout :
     if ( ah->atph_rbitmap != 0 ) {
 	if ( ah->atph_reqtries > 0
 		|| ah->atph_reqtries == ATP_TRIES_INFINITE ) {
-	    return( 0 );
+	    return 0;
 	} else {
 	    errno = ETIMEDOUT;
-	    return( -1 );
+	    return -1;
 	}
     }
 
     memcpy( faddr, &saddr, sizeof( struct sockaddr_at ));
-    return( ATP_TRESP );
+    return ATP_TRESP;
 }

--- a/libatalk/atp/atp_sreq.c
+++ b/libatalk/atp/atp_sreq.c
@@ -88,7 +88,7 @@ atp_sreq( ATP ah, struct atp_block *atpb, int respcount, uint8_t flags )
     /* allocate a new buffer and build request packet
     */
     if (( req_buf = atp_alloc_buf()) == NULL ) {
-	return( -1 );
+	return -1;
     }
     atp_build_req_packet( req_buf, ah->atph_tid++, flags | ATP_TREQ, atpb );
     memcpy( &req_buf->atpbuf_addr, atpb->atp_saddr,
@@ -112,7 +112,7 @@ if (( random() % 3 ) != 2 ) {
 	    req_buf->atpbuf_dlen, 0, (struct sockaddr *) atpb->atp_saddr,
 	    sizeof( struct sockaddr_at )) != req_buf->atpbuf_dlen ) {
 	atp_free_buf( req_buf );
-	return( -1 );
+	return -1;
     }
 #ifdef DROPPACKETS
 } else printf( "<%d> atp_sreq: dropped request\n", getpid() );
@@ -137,5 +137,5 @@ if (( random() % 3 ) != 2 ) {
 	ah->atph_rrespcount = 0;
     }
 
-    return( 0 );
+    return 0;
 }

--- a/libatalk/cnid/dbd/cnid_dbd.c
+++ b/libatalk/cnid/dbd/cnid_dbd.c
@@ -175,7 +175,7 @@ static int tsock_getfd(const char *host, const char *port)
         return -1;
     }
 
-    return(sock);
+    return sock;
 }
 
 /*!

--- a/libatalk/compat/rquota_xdr.c
+++ b/libatalk/compat/rquota_xdr.c
@@ -31,48 +31,48 @@
 bool_t xdr_getquota_args(XDR *xdrs, getquota_args *objp)
 {
 	if (!xdr_string(xdrs, &objp->gqa_pathp, RQ_PATHLEN)) {
-		return (FALSE);
+		return FALSE;
 	}
 	if (!xdr_int(xdrs, &objp->gqa_uid)) {
-		return (FALSE);
+		return FALSE;
 	}
-	return (TRUE);
+	return TRUE;
 }
 
 
 bool_t xdr_rquota(XDR *xdrs, rquota *objp)
 {
 	if (!xdr_int(xdrs, &objp->rq_bsize)) {
-		return (FALSE);
+		return FALSE;
 	}
 	if (!xdr_bool(xdrs, &objp->rq_active)) {
-		return (FALSE);
+		return FALSE;
 	}
 	if (!xdr_u_int(xdrs, &objp->rq_bhardlimit)) {
-		return (FALSE);
+		return FALSE;
 	}
 	if (!xdr_u_int(xdrs, &objp->rq_bsoftlimit)) {
-		return (FALSE);
+		return FALSE;
 	}
 	if (!xdr_u_int(xdrs, &objp->rq_curblocks)) {
-		return (FALSE);
+		return FALSE;
 	}
 	if (!xdr_u_int(xdrs, &objp->rq_fhardlimit)) {
-		return (FALSE);
+		return FALSE;
 	}
 	if (!xdr_u_int(xdrs, &objp->rq_fsoftlimit)) {
-		return (FALSE);
+		return FALSE;
 	}
 	if (!xdr_u_int(xdrs, &objp->rq_curfiles)) {
-		return (FALSE);
+		return FALSE;
 	}
 	if (!xdr_u_int(xdrs, &objp->rq_btimeleft)) {
-		return (FALSE);
+		return FALSE;
 	}
 	if (!xdr_u_int(xdrs, &objp->rq_ftimeleft)) {
-		return (FALSE);
+		return FALSE;
 	}
-	return (TRUE);
+	return TRUE;
 }
 
 
@@ -84,21 +84,21 @@ bool_t xdr_gqr_status(XDR *xdrs, gqr_status *objp)
 #endif
 {
 	if (!xdr_enum(xdrs, (enum_t *)objp)) {
-		return (FALSE);
+		return FALSE;
 	}
-	return (TRUE);
+	return TRUE;
 }
 
 
 bool_t xdr_getquota_rslt(XDR *xdrs, getquota_rslt *objp)
 {
 	if (!xdr_gqr_status(xdrs, &objp->status)) {
-		return (FALSE);
+		return FALSE;
 	}
 	switch (objp->status) {
 	case Q_OK:
 		if (!xdr_rquota(xdrs, &objp->getquota_rslt_u.gqr_rquota)) {
-			return (FALSE);
+			return FALSE;
 		}
 		break;
 	case Q_NOQUOTA:
@@ -106,8 +106,8 @@ bool_t xdr_getquota_rslt(XDR *xdrs, getquota_rslt *objp)
 	case Q_EPERM:
 		break;
 	default:
-		return (FALSE);
+		return FALSE;
 	}
-	return (TRUE);
+	return TRUE;
 }
 #endif

--- a/libatalk/nbp/nbp_lkup.c
+++ b/libatalk/nbp/nbp_lkup.c
@@ -199,7 +199,7 @@ int nbp_lookup( const char *obj, const char *type, const char *zone, struct nbpn
 
     netddp_close(s);
     errno = 0;
-    return( cnt );
+    return cnt;
 
 lookup_err:
     netddp_close(s);

--- a/libatalk/nbp/nbp_rgstr.c
+++ b/libatalk/nbp/nbp_rgstr.c
@@ -45,7 +45,7 @@ int nbp_rgstr( struct sockaddr_at *sat, const char *obj, const char *type, const
 
     if ( nbp_lookup( obj, type, zone, &nn, 1, &sat->sat_addr ) > 0 ) {
         errno = EADDRINUSE;
-	return( -1 );
+	return -1;
     }
 
     memset(&to, 0, sizeof(to));
@@ -68,7 +68,7 @@ int nbp_rgstr( struct sockaddr_at *sat, const char *obj, const char *type, const
     data += SZ_NBPTUPLE;
 
     if ( obj ) {
-	if (( cc = strlen( obj )) > NBPSTRLEN ) return( -1 );
+	if (( cc = strlen( obj )) > NBPSTRLEN ) return -1;
 	*data++ = cc;
 	memcpy( data, obj, cc );
 	data += cc;
@@ -77,7 +77,7 @@ int nbp_rgstr( struct sockaddr_at *sat, const char *obj, const char *type, const
     }
 
     if ( type ) {
-	if (( cc = strlen( type )) > NBPSTRLEN ) return( -1 );
+	if (( cc = strlen( type )) > NBPSTRLEN ) return -1;
 	*data++ = cc;
 	memcpy( data, type, cc );
 	data += cc;
@@ -86,7 +86,7 @@ int nbp_rgstr( struct sockaddr_at *sat, const char *obj, const char *type, const
     }
 
     if ( zone ) {
-	if (( cc = strlen( zone )) > NBPSTRLEN ) return( -1 );
+	if (( cc = strlen( zone )) > NBPSTRLEN ) return -1;
 	*data++ = cc;
 	memcpy( data, zone, cc );
 	data += cc;
@@ -133,13 +133,13 @@ int nbp_rgstr( struct sockaddr_at *sat, const char *obj, const char *type, const
 
     data = nbp_recv;
     if ( *data++ != DDPTYPE_NBP ) {
-	return( -1 );
+	return -1;
     }
     memcpy( &nh, data, SZ_NBPHDR );
     if ( nh.nh_op != NBPOP_OK ) {
         return -1;
     }
-    return( 0 );
+    return 0;
 
 register_err:
     netddp_close(s);

--- a/libatalk/nbp/nbp_unrgstr.c
+++ b/libatalk/nbp/nbp_unrgstr.c
@@ -58,7 +58,7 @@ int nbp_unrgstr(const char *obj,const char *type,const char  *zone, const struct
     data += SZ_NBPTUPLE;
 
     if ( obj ) {
-	if (( cc = strlen( obj )) > NBPSTRLEN ) return( -1 );
+	if (( cc = strlen( obj )) > NBPSTRLEN ) return -1;
 	*data++ = cc;
 	memcpy( data, obj, cc );
 	data += cc;
@@ -67,7 +67,7 @@ int nbp_unrgstr(const char *obj,const char *type,const char  *zone, const struct
     }
 
     if ( type ) {
-	if (( cc = strlen( type )) > NBPSTRLEN ) return( -1 );
+	if (( cc = strlen( type )) > NBPSTRLEN ) return -1;
 	*data++ = cc;
 	memcpy( data, type, cc );
 	data += cc;
@@ -76,7 +76,7 @@ int nbp_unrgstr(const char *obj,const char *type,const char  *zone, const struct
     }
 
     if ( zone ) {
-	if (( cc = strlen( zone )) > NBPSTRLEN ) return( -1 );
+	if (( cc = strlen( zone )) > NBPSTRLEN ) return -1;
 	*data++ = cc;
 	memcpy( data, zone, cc );
 	data += cc;
@@ -128,13 +128,13 @@ int nbp_unrgstr(const char *obj,const char *type,const char  *zone, const struct
 
     data = nbp_recv;
     if ( *data++ != DDPTYPE_NBP ) {
-	return( -1 );
+	return -1;
     }
     memcpy( &nh, data, SZ_NBPHDR );
     if ( nh.nh_op != NBPOP_OK ) {
-	return( -1 );
+	return -1;
     }
-    return( 0 );
+    return 0;
 
 unregister_err:
     netddp_close(s);

--- a/libatalk/nbp/nbp_util.c
+++ b/libatalk/nbp/nbp_util.c
@@ -38,7 +38,7 @@ int nbp_parse(char *data, struct nbpnve *nn, int len)
     data += SZ_NBPTUPLE;
     len -= SZ_NBPTUPLE;
     if ( len < 0 ) {
-	return( -1 );
+	return -1;
     }
 
 #ifdef BSD4_4
@@ -52,10 +52,10 @@ int nbp_parse(char *data, struct nbpnve *nn, int len)
     nn->nn_objlen = *data++;
     len -= nn->nn_objlen + 1;
     if ( len < 0 ) {
-	return( -1 );
+	return -1;
     }
     if ( nn->nn_objlen > NBPSTRLEN ) {
-	return( -1 );
+	return -1;
     }
     memcpy( nn->nn_obj, data, nn->nn_objlen );
     data += nn->nn_objlen;
@@ -63,10 +63,10 @@ int nbp_parse(char *data, struct nbpnve *nn, int len)
     nn->nn_typelen = *data++;
     len -= nn->nn_typelen + 1;
     if ( len < 0 ) {
-	return( -1 );
+	return -1;
     }
     if ( nn->nn_typelen > NBPSTRLEN ) {
-	return( 1 );
+	return 1;
     }
     memcpy( nn->nn_type, data, nn->nn_typelen );
 
@@ -74,14 +74,14 @@ int nbp_parse(char *data, struct nbpnve *nn, int len)
     nn->nn_zonelen = *data++;
     len -= nn->nn_zonelen + 1;
     if ( len < 0 ) {
-	return( -1 );
+	return -1;
     }
     if ( nn->nn_zonelen > NBPSTRLEN ) {
-	return( 1 );
+	return 1;
     }
     memcpy( nn->nn_zone, data, nn->nn_zonelen );
 
-    return( len );
+    return len;
 }
 
 #define NBPM_OBJ	(1<<1)
@@ -108,23 +108,23 @@ int nbp_match(struct nbpnve *n1, struct nbpnve *n2, int flags)
     if ( !( match & NBPM_OBJ )) {
 	if ( n1->nn_objlen != n2->nn_objlen ||
 		strndiacasecmp( n1->nn_obj, n2->nn_obj, n1->nn_objlen )) {
-	    return( 0 );
+	    return 0;
 	}
     }
     if ( !( match & NBPM_TYPE )) {
 	if ( n1->nn_typelen != n2->nn_typelen ||
 		strndiacasecmp( n1->nn_type, n2->nn_type, n1->nn_typelen )) {
-	    return( 0 );
+	    return 0;
 	}
     }
     if ( !( match & NBPM_ZONE )) {
 	if ( n1->nn_zonelen != n2->nn_zonelen ||
 		strndiacasecmp( n1->nn_zone, n2->nn_zone, n1->nn_zonelen )) {
-	    return( 0 );
+	    return 0;
 	}
     }
 
-    return( 1 );
+    return 1;
 }
 
 int nbp_name(const char  *name, char **objp,char **typep,char **zonep)
@@ -134,7 +134,7 @@ int nbp_name(const char  *name, char **objp,char **typep,char **zonep)
 
     if ( name ) {
 	if ( strlen( name ) + 1 > sizeof( buf )) {
-	    return( -1 );
+	    return -1;
 	}
 	strcpy( buf, name );
 
@@ -151,5 +151,5 @@ int nbp_name(const char  *name, char **objp,char **typep,char **zonep)
 	}
     }
 
-    return( 0 );
+    return 0;
 }

--- a/libatalk/unicode/charcnv.c
+++ b/libatalk/unicode/charcnv.c
@@ -135,7 +135,7 @@ charset_t add_charset(const char* name)
 
     for (c1=0; c1<=max_charset_t;c1++) {
         if ( strcasecmp(name, charset_name(c1)) == 0)
-            return (c1);
+            return c1;
     }
 
     if ( cur_charset_t >= MAX_CHARSETS )  {
@@ -169,7 +169,7 @@ charset_t add_charset(const char* name)
     max_charset_t++;
 
     LOG(log_debug9, logtype_default, "Added charset %s with handle %u", name, cur_charset_t);
-    return (cur_charset_t);
+    return cur_charset_t;
 }
 
 /**
@@ -221,7 +221,7 @@ static size_t add_null(charset_t to, char *buf, size_t bytesleft, size_t len)
         buf[len]   = 0;
     else {
         errno = E2BIG;
-        return (size_t)(-1);
+        return (size_t) -1;
     }
 
     return len;
@@ -283,7 +283,7 @@ static size_t convert_string_internal(charset_t from, charset_t to,
             break;
         }
         LOG(log_debug, logtype_default,"Conversion error: %s",reason);
-        return (size_t)-1;
+        return (size_t) -1;
     }
 
     /* Terminate the string */
@@ -312,11 +312,11 @@ size_t convert_string(charset_t from, charset_t to,
     u = buffer2;
     if (charsets[to] && (charsets[to]->flags & CHARSET_DECOMPOSED) ) {
         if ( (size_t)-1 == (i_len = decompose_w(buffer, o_len, u, &i_len)) )
-            return (size_t)-1;
+            return (size_t) -1;
     }
     else if (!charsets[from] || (charsets[from]->flags & CHARSET_DECOMPOSED)) {
         if ( (size_t)-1 == (i_len = precompose_w(buffer, o_len, u, &i_len)) )
-            return (size_t)-1;
+            return (size_t) -1;
     }
     else {
         u = buffer;
@@ -355,7 +355,7 @@ static size_t convert_string_allocate_internal(charset_t from, charset_t to,
     *dest = NULL;
 
     if (src == NULL || srclen == (size_t)-1)
-        return (size_t)-1;
+        return (size_t) -1;
 
     lazy_initialize_conv();
 
@@ -374,7 +374,7 @@ convert:
     if (!outbuf) {
         LOG(log_debug, logtype_default,"convert_string_allocate: realloc failed!");
         SAFE_FREE(ob);
-        return (size_t)-1;
+        return (size_t) -1;
     } else {
         ob = outbuf;
     }
@@ -398,7 +398,7 @@ convert:
         }
         LOG(log_debug, logtype_default,"Conversion error: %s(%s)",reason,inbuf);
         SAFE_FREE(ob);
-        return (size_t)-1;
+        return (size_t) -1;
     }
 
 
@@ -421,7 +421,7 @@ convert:
     if (destlen && !*dest) {
         LOG(log_debug, logtype_default, "convert_string_allocate: out of memory!");
         SAFE_FREE(ob);
-        return (size_t)-1;
+        return (size_t) -1;
     }
 
     return destlen;
@@ -451,11 +451,11 @@ size_t convert_string_allocate(charset_t from, charset_t to,
     u = buffer2;
     if (charsets[to] && (charsets[to]->flags & CHARSET_DECOMPOSED) ) {
         if ( (size_t)-1 == (i_len = decompose_w(buffer, o_len, u, &i_len)) )
-            return (size_t)-1;
+            return (size_t) -1;
     }
     else if ( !charsets[from] || (charsets[from]->flags & CHARSET_DECOMPOSED) ) {
         if ( (size_t)-1 == (i_len = precompose_w(buffer, o_len, u, &i_len)) )
-            return (size_t)-1;
+            return (size_t) -1;
     }
     else {
         u = buffer;
@@ -617,16 +617,16 @@ size_t charset_precompose ( charset_t ch, char * src, size_t inlen, char * dst, 
 
     if ( (size_t)-1 == (ilen = precompose_w((ucs2_t *)buffer, len, u, &ilen)) ) {
         free (buffer);
-        return (size_t)(-1);
+        return (size_t) -1;
     }
 
     if ((size_t)(-1) == (len = convert_string_internal( CH_UCS2, ch, (char*)u, ilen, dst, outlen)) ) {
         free (buffer);
-        return (size_t)(-1);
+        return (size_t) -1;
     }
 
     free(buffer);
-    return (len);
+    return len;
 }
 
 size_t charset_decompose ( charset_t ch, char * src, size_t inlen, char * dst, size_t outlen)
@@ -643,16 +643,16 @@ size_t charset_decompose ( charset_t ch, char * src, size_t inlen, char * dst, s
 
     if ( (size_t)-1 == (ilen = decompose_w((ucs2_t *)buffer, len, u, &ilen)) ) {
         free (buffer);
-        return (size_t)(-1);
+        return (size_t) -1;
     }
 
     if ((size_t)(-1) == (len = convert_string_internal( CH_UCS2, ch, (char*)u, ilen, dst, outlen)) ) {
         free (buffer);
-        return (size_t)(-1);
+        return (size_t) -1;
     }
 
     free(buffer);
-    return (len);
+    return len;
 }
 
 size_t utf8_precompose ( char * src, size_t inlen, char * dst, size_t outlen)
@@ -719,7 +719,7 @@ static size_t pull_charset_flags (charset_t from_set, charset_t to_set, charset_
 
     if (descriptor == (atalk_iconv_t)-1 || descriptor == (atalk_iconv_t)0) {
         errno = EINVAL;
-        return (size_t)-1;
+        return (size_t) -1;
     }
 
     i_len=srclen;
@@ -1009,11 +1009,11 @@ size_t convert_charset ( charset_t from_set, charset_t to_set, charset_t cap_cha
     u = buffer2;
     if (CHECK_FLAGS(flags, CONV_DECOMPOSE) || (charsets[to_set] && (charsets[to_set]->flags & CHARSET_DECOMPOSED)) ) {
         if ( (size_t)-1 == (i_len = decompose_w(buffer, o_len, u, &i_len)) )
-            return (size_t)(-1);
+            return (size_t) -1;
     }
     else if (CHECK_FLAGS(flags, CONV_PRECOMPOSE) || !charsets[from_set] || (charsets[from_set]->flags & CHARSET_DECOMPOSED)) {
         if ( (size_t)-1 == (i_len = precompose_w(buffer, o_len, u, &i_len)) )
-            return (size_t)(-1);
+            return (size_t) -1;
     }
     else {
         u = buffer;

--- a/libatalk/unicode/charsets/generic_cjk.c
+++ b/libatalk/unicode/charsets/generic_cjk.c
@@ -125,7 +125,7 @@ size_t cjk_char_push(uint16_t c, uint8_t *out)
   if (!c) return 0;
   if (c == (uint16_t)-1) {
     errno = EILSEQ;
-    return (size_t)-1;
+    return (size_t) -1;
   }
   if (c <= 0xff) {
     out[0] = (uint8_t)c;

--- a/libatalk/unicode/charsets/mac_chinese_simp.c
+++ b/libatalk/unicode/charsets/mac_chinese_simp.c
@@ -94,11 +94,11 @@ static size_t mac_chinese_simp_char_pull(ucs2_t* out, const uint8_t* in, size_t*
 	c = (c << 8) + c2;
       } else {
 	errno = EILSEQ;
-	return (size_t)-1;
+	return (size_t) -1;
       }
     } else {
       errno = EINVAL;
-      return (size_t)-1;
+      return (size_t) -1;
     }
   } else {
     *size = 1;

--- a/libatalk/unicode/charsets/mac_chinese_trad.c
+++ b/libatalk/unicode/charsets/mac_chinese_trad.c
@@ -99,11 +99,11 @@ static size_t mac_chinese_trad_char_pull(ucs2_t* out, const uint8_t* in, size_t*
 	c = (c << 8) + c2;
       } else {
 	errno = EILSEQ;
-	return (size_t)-1;
+	return (size_t) -1;
       }
     } else {
       errno = EINVAL;
-      return (size_t)-1;
+      return (size_t) -1;
     }
   } else {
     *size = 1;

--- a/libatalk/unicode/charsets/mac_japanese.c
+++ b/libatalk/unicode/charsets/mac_japanese.c
@@ -62,7 +62,7 @@ static size_t mac_japanese_char_push(uint8_t* out, const ucs2_t* in, size_t* siz
   } else if ((wc & ~7) == 0xf860) {
     wc = cjk_compose_seq(in, size, mac_japanese_compose,
 			 sizeof(mac_japanese_compose) / sizeof(uint32_t));
-    if (!wc) return (size_t)-1;
+    if (!wc) return (size_t) -1;
   } else if (*size >= 2 && ((in[1] & ~15) == 0xf870 || in[1] == 0x20dd)) {
     ucs2_t comp = cjk_compose(wc, in[1], mac_japanese_compose,
 			      sizeof(mac_japanese_compose) / sizeof(uint32_t));
@@ -107,11 +107,11 @@ static size_t mac_japanese_char_pull(ucs2_t* out, const uint8_t* in, size_t* siz
 	c = (c << 8) + c2;
       } else {
 	errno = EILSEQ;
-	return (size_t)-1;
+	return (size_t) -1;
       }
     } else {
       errno = EINVAL;
-      return (size_t)-1;
+      return (size_t) -1;
     }
   } else {
     *size = 1;

--- a/libatalk/unicode/charsets/mac_korean.c
+++ b/libatalk/unicode/charsets/mac_korean.c
@@ -50,7 +50,7 @@ static size_t mac_korean_char_push(uint8_t* out, const ucs2_t* in, size_t* size)
   if ((wc & ~7) == 0xf860) {
     wc = cjk_compose_seq(in, size, mac_korean_compose,
 			 sizeof(mac_korean_compose) / sizeof(uint32_t));
-    if (!wc) return (size_t)-1;
+    if (!wc) return (size_t) -1;
   } else if ((wc & 0xf000) == 0xe000) {
     *size = 1;
     return 0;
@@ -103,11 +103,11 @@ static size_t mac_korean_char_pull(ucs2_t* out, const uint8_t* in, size_t* size)
 	c = (c << 8) + c2;
       } else {
 	errno = EILSEQ;
-	return (size_t)-1;
+	return (size_t) -1;
       }
     } else {
       errno = EINVAL;
-      return (size_t)-1;
+      return (size_t) -1;
     }
   } else {
     *size = 1;

--- a/libatalk/unicode/util_unistr.c
+++ b/libatalk/unicode/util_unistr.c
@@ -102,12 +102,12 @@ determine if a character is lowercase
 
 int islower_w(ucs2_t c)
 {
-	return ( c == tolower_w(c));
+	return c == tolower_w(c);
 }
 
 int islower_sp(uint32_t c_sp)
 {
-	return ( c_sp == tolower_sp(c_sp));
+	return c_sp == tolower_sp(c_sp);
 }
 
 /*******************************************************************
@@ -118,12 +118,12 @@ determine if a character is uppercase
 
 int isupper_w(ucs2_t c)
 {
-	return ( c == toupper_w(c));
+	return c == toupper_w(c);
 }
 
 int isupper_sp(uint32_t c_sp)
 {
-	return ( c_sp == toupper_sp(c_sp));
+	return c_sp == toupper_sp(c_sp);
 }
 
 /*******************************************************************
@@ -207,7 +207,7 @@ wide strcmp()
 int strcmp_w(const ucs2_t *a, const ucs2_t *b)
 {
 	while (*b && *a == *b) { a++; b++; }
-	return (*a - *b);
+	return *a - *b;
 	/* warning: if *a != *b and both are not 0 we retrun a random
 	   greater or lesser than 0 number not realted to which
 	   string is longer */
@@ -558,7 +558,7 @@ size_t precompose_w (ucs2_t *name, size_t inplen, ucs2_t *comp, size_t *outlen)
 	size_t o_len = *outlen;
 
 	if (!inplen || (inplen & 1) || inplen > o_len)
-		return (size_t)-1;
+		return (size_t) -1;
 
 	i = 0;
 	in  = name;
@@ -619,7 +619,7 @@ size_t precompose_w (ucs2_t *name, size_t inplen, ucs2_t *comp, size_t *outlen)
 
 				if (*outlen <= 2) {
 					errno = E2BIG;
-					return (size_t)-1;
+					return (size_t) -1;
 				}
 
 				*out = base_sp & 0xFFFF;
@@ -653,7 +653,7 @@ size_t precompose_w (ucs2_t *name, size_t inplen, ucs2_t *comp, size_t *outlen)
 	}
 
 	errno = E2BIG;
-	return (size_t)-1;
+	return (size_t) -1;
 }
 
 /* --------------- */
@@ -670,7 +670,7 @@ size_t decompose_w (ucs2_t *name, size_t inplen, ucs2_t *comp, size_t *outlen)
 	size_t o_len = *outlen;
 
 	if (!inplen || (inplen & 1))
-		return (size_t)-1;
+		return (size_t) -1;
 	i = 0;
 	in  = name;
 	out = comp;
@@ -715,7 +715,7 @@ size_t decompose_w (ucs2_t *name, size_t inplen, ucs2_t *comp, size_t *outlen)
 
 				if (*outlen < (comblen + 1) << 1) {
 					errno = E2BIG;
-					return (size_t)-1;
+					return (size_t) -1;
 				}
 
 				*out = base_sp >> 16;   /* hi */
@@ -741,7 +741,7 @@ size_t decompose_w (ucs2_t *name, size_t inplen, ucs2_t *comp, size_t *outlen)
 
 		if (*outlen < (comblen + 1) << 1) {
 			errno = E2BIG;
-			return (size_t)-1;
+			return (size_t) -1;
 		}
 
 		*out = base;
@@ -774,21 +774,21 @@ size_t utf8_charlen ( char* utf8 )
 	p = (unsigned char*) utf8;
 
 	if ( *p < 0x80 )
-		return (1);
+		return 1;
 	else if ( *p > 0xC1 && *p < 0xe0 && *(p+1) > 0x7f && *(p+1) < 0xC0)
-		return (2);
+		return 2;
 	else if ( *p == 0xe0 && *(p+1) > 0x9f && *(p+1) < 0xc0 && *(p+2) > 0x7f && *(p+2) < 0xc0)
-		return (3);
+		return 3;
 	else if ( *p > 0xe0  && *p < 0xf0 && *(p+1) > 0x7f && *(p+1) < 0xc0 && *(p+2) > 0x7f && *(p+2) < 0xc0)
-		return (3);
+		return 3;
 	else if ( *p == 0xf0 && *(p+1) > 0x8f && *(p+1) < 0xc0 && *(p+2) > 0x7f && *(p+2) < 0xc0 && *(p+3) > 0x7f && *(p+3) < 0xc0 )
-		return (4);
+		return 4;
 	else if ( *p > 0xf0 && *p < 0xf4 && *(p+1) > 0x7f && *(p+1) < 0xc0 && *(p+2) > 0x7f && *(p+2) < 0xc0 && *(p+3) > 0x7f && *(p+3) < 0xc0 )
-		return (4);
+		return 4;
 	else if ( *p == 0xf4 && *(p+1) > 0x7f && *(p+1) < 0x90 && *(p+2) > 0x7f && *(p+2) < 0xc0 && *(p+3) > 0x7f && *(p+3) < 0xc0 )
-		return (4);
+		return 4;
 	else
-		return ((size_t) -1);
+		return (size_t) -1;
 }
 
 
@@ -826,10 +826,10 @@ size_t utf8_strlen_validate ( char * utf8 )
 			p += 4;
 
 		else
-			return ((size_t) -1);
+			return (size_t) -1;
 
 		len++;
 	}
 
-	return (len);
+	return len;
 }

--- a/libatalk/util/atalk_addr.c
+++ b/libatalk/util/atalk_addr.c
@@ -62,14 +62,14 @@ int atalk_aton(char* cp, struct at_addr* addr)
 		}
 
 		if (c != '.' && c != '\0') {
-			return (0);
+			return 0;
 		}
 
 		switch (n) {
 		case 0:
 			if (addr) {
 				if (val > 65535) {
-					return (0);
+					return 0;
 				}
 				addr->s_net = val;
 			}
@@ -84,7 +84,7 @@ int atalk_aton(char* cp, struct at_addr* addr)
 		case 2:
 			if (addr) {
 				if (addr->s_net > 255) {
-					return (0);
+					return 0;
 				}
 				addr->s_net <<= 8;
 				addr->s_net += addr->s_node;
@@ -92,7 +92,7 @@ int atalk_aton(char* cp, struct at_addr* addr)
 		/*FALLTHROUGH*/ case 1:
 			if (addr) {
 				if (val > 255) {
-					return (0);
+					return 0;
 				}
 				addr->s_node = val;
 			}
@@ -105,18 +105,18 @@ int atalk_aton(char* cp, struct at_addr* addr)
 			continue;
 
 		default:
-			return (0);
+			return 0;
 		}
 		break;
 	}
 
 	if (n < 1) {
-		return (0);
+		return 0;
 	}
 	if (addr) {
 		addr->s_net = htons(addr->s_net);
 	}
-	return (1);
+	return 1;
 }
 
 #endif  /* NO_DDP */

--- a/libatalk/util/ftw.c
+++ b/libatalk/util/ftw.c
@@ -202,7 +202,7 @@ static void mytdestroy (void *vroot, __free_fn_t freefct)
 static char *mystpcpy(char *a, const char *b)
 {
     strcpy(a, b);
-    return (a + strlen(a));
+    return a + strlen(a);
 }
 
 static char *xgetcwd(void)

--- a/libatalk/util/gettok.c
+++ b/libatalk/util/gettok.c
@@ -41,7 +41,7 @@ parseline(int len, char *token)
     for (;;) {
         if ( l_curr > l_end ) {			/* end of line */
             *token = '\0';
-            return( -1 );
+            return -1;
         }
 
         switch ( *l_curr ) {
@@ -59,7 +59,7 @@ parseline(int len, char *token)
         case ' ' :
             if ( state == ST_WORD ) {
                 *p = '\0';
-                return( p - token );
+                return p - token;
             }
             if ( state != ST_QUOTE ) {
                 break;
@@ -72,7 +72,7 @@ parseline(int len, char *token)
             }
             if ( p > e ) {			/* end of token */
                 *token = '\0';
-                return( -1 );
+                return -1;
             }
             *p++ = *l_curr;
             break;

--- a/libatalk/util/locking.c
+++ b/libatalk/util/locking.c
@@ -92,5 +92,5 @@ int lock_reg(int fd, int cmd, int type, off_t offset, int whence, off_t len)
     lock.l_whence = whence;
     lock.l_len = len;
 
-    return (fcntl(fd, cmd, &lock));
+    return fcntl(fd, cmd, &lock);
 }

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -1529,23 +1529,23 @@ struct extmap *getextmap(const char *path)
     struct extmap *em;
 
     if (!Extmap_cnt || NULL == ( p = strrchr( path, '.' )) ) {
-        return( Defextmap );
+        return Defextmap;
     }
     p++;
     if (!*p) {
-        return( Defextmap );
+        return Defextmap;
     }
     em = bsearch(p, Extmap, Extmap_cnt, sizeof(struct extmap), ext_cmp_key);
     if (em) {
-        return( em );
+        return em;
     } else {
-        return( Defextmap );
+        return Defextmap;
     }
 }
 
 struct extmap *getdefextmap(void)
 {
-    return( Defextmap );
+    return Defextmap;
 }
 
 static int readextmap(const char *file)
@@ -1828,10 +1828,10 @@ struct vol *getvolbyvid(const uint16_t vid )
         }
     }
     if ( vol == NULL || ( vol->v_flags & AFPVOL_OPEN ) == 0 ) {
-        return( NULL );
+        return NULL;
     }
 
-    return( vol );
+    return vol;
 }
 
 /*

--- a/libatalk/util/socket.c
+++ b/libatalk/util/socket.c
@@ -307,7 +307,7 @@ const char *getip_string(const struct sockaddr *sa)
 
         /* Deal with IPv6 mapped IPv4 addresses*/
         if ((memcmp(sai6->sin6_addr.s6_addr, ipv4mapprefix, sizeof(ipv4mapprefix))) == 0)
-            return (strrchr(ip6, ':') + 1);
+            return strrchr(ip6, ':') + 1;
         return ip6;
     }
     default:

--- a/libatalk/util/strdicasecmp.c
+++ b/libatalk/util/strdicasecmp.c
@@ -529,11 +529,11 @@ int strdiacasecmp( const char *s1, const char *s2 )
     while ( _diacasemap[ (unsigned char) *s1 ] ==
 	    _diacasemap[ (unsigned char) *s2++ ] ) {
 	if ( *s1++ == '\0' ) {
-	    return( 0 );
+	    return 0;
 	}
     }
-    return( _diacasemap[ (unsigned char) *s1 ] -
-	    _diacasemap[ (unsigned char) *--s2 ] );
+    return _diacasemap[ (unsigned char) *s1 ] -
+	    _diacasemap[ (unsigned char) *--s2 ];
 }
 
 int strndiacasecmp( const char *s1, const char *s2, size_t n )
@@ -542,7 +542,7 @@ int strndiacasecmp( const char *s1, const char *s2, size_t n )
 	    _diacasemap[ (unsigned char) *s1 ] ==
 	    _diacasemap[ (unsigned char) *s2++ ] ) {
 	if ( *s1++ == '\0' ) {
-	    return( 0 );
+	    return 0;
 	}
 	n--;
     }

--- a/libatalk/util/unix.c
+++ b/libatalk/util/unix.c
@@ -226,7 +226,7 @@ char *stripped_slashes_basename(char *p)
     int i = strlen(p) - 1;
     while (i > 0 && p[i] == '/')
         p[i--] = 0;
-    return (strrchr(p, '/') ? strrchr(p, '/') + 1 : p);
+    return strrchr(p, '/') ? strrchr(p, '/') + 1 : p;
 }
 
 /****************************************************************************
@@ -520,10 +520,10 @@ int gmem(gid_t gid, int ngroups, gid_t *groups)
 
     for ( i = 0; i < ngroups; i++ ) {
         if ( groups[ i ] == gid ) {
-            return( 1 );
+            return 1;
         }
     }
-    return( 0 );
+    return 0;
 }
 
 /*

--- a/libatalk/vfs/ea_ad.c
+++ b/libatalk/vfs/ea_ad.c
@@ -85,7 +85,7 @@ static char *mtoupath(const struct vol *vol, const char *mpath)
         return NULL;
 
     if ( *mpath == '\0' ) {
-        return( "." );
+        return ".";
     }
 
     m = mpath;
@@ -101,7 +101,7 @@ static char *mtoupath(const struct vol *vol, const char *mpath)
         return NULL;
     }
 
-    return( upath );
+    return upath;
 }
 
 

--- a/libatalk/vfs/unix.c
+++ b/libatalk/vfs/unix.c
@@ -299,7 +299,7 @@ int statat(int dirfd _U_, const char *path, struct stat *st)
 {
     if (dirfd == -1)
         dirfd = AT_FDCWD;
-    return (fstatat(dirfd, path, st, 0));
+    return fstatat(dirfd, path, st, 0);
 }
 
 /*

--- a/sys/netatalk/aarp.c
+++ b/sys/netatalk/aarp.c
@@ -113,7 +113,7 @@ struct ifaddr *at_ifawithnet(struct sockaddr_at *sat, struct ifaddr *ifa)
 	}
 #endif /* BSD4_4 */
     }
-    return( ifa );
+    return ifa;
 }
 
 void aarpwhohas(struct arpcom *ac, struct sockaddr_at *sat)
@@ -216,7 +216,7 @@ int aarpresolve(struct arpcom *ac, struct mbuf *m, struct sockaddr_at *destsat, 
 	if (( aa = (struct at_ifaddr *)at_ifawithnet( destsat,
 		((struct ifnet *)ac)->if_addrlist )) == NULL ) {
 	    m_freem( m );
-	    return( 0 );
+	    return 0;
 	}
 	if ( aa->aa_flags & AFA_PHASE2 ) {
 	    bcopy( (caddr_t)atmulticastaddr, (caddr_t)desten,
@@ -225,7 +225,7 @@ int aarpresolve(struct arpcom *ac, struct mbuf *m, struct sockaddr_at *destsat, 
 	    bcopy( (caddr_t)etherbroadcastaddr, (caddr_t)desten,
 		    sizeof( etherbroadcastaddr ));
 	}
-	return( 1 );
+	return 1;
     }
 
     s = splimp();
@@ -238,7 +238,7 @@ int aarpresolve(struct arpcom *ac, struct mbuf *m, struct sockaddr_at *destsat, 
 	aat->aat_hold = m;
 	aarpwhohas( ac, destsat );
 	splx( s );
-	return( 0 );
+	return 0;
     }
     /* found an entry */
     aat->aat_timer = 0;
@@ -246,7 +246,7 @@ int aarpresolve(struct arpcom *ac, struct mbuf *m, struct sockaddr_at *destsat, 
 	bcopy( (caddr_t)aat->aat_enaddr, (caddr_t)desten,
 		sizeof( aat->aat_enaddr ));
 	splx( s );
-	return( 1 );
+	return 1;
     }
     /* entry has not completed */
     if ( aat->aat_hold ) {
@@ -255,7 +255,7 @@ int aarpresolve(struct arpcom *ac, struct mbuf *m, struct sockaddr_at *destsat, 
     aat->aat_hold = m;
     aarpwhohas( ac, destsat );
     splx( s );
-    return( 0 );
+    return 0;
 }
 
 void aarpinput(struct arpcom *ac, struct mbuf *m)
@@ -528,13 +528,13 @@ struct aarptab *aarptnew(struct at_addr *addr)
 	}
     }
     if ( aato == NULL )
-	return( NULL );
+	return NULL;
     aat = aato;
     aarptfree( aat );
 out:
     aat->aat_ataddr = *addr;
     aat->aat_flags = ATF_INUSE;
-    return( aat );
+    return aat;
 }
 
 void aarpprobe(struct arpcom *ac)

--- a/sys/netatalk/at_control.c
+++ b/sys/netatalk/at_control.c
@@ -56,10 +56,10 @@ int atalk_netmatch(struct sockaddr_at *sat1, struct sockaddr_at *sat2)
 	}
     }
     if ( aa ) {
-	return( ntohs( aa->aa_firstnet ) <= ntohs( sat2->sat_addr.s_net ) &&
-		ntohs( aa->aa_lastnet ) >= ntohs( sat2->sat_addr.s_net ));
+	return ntohs( aa->aa_firstnet ) <= ntohs( sat2->sat_addr.s_net ) &&
+		ntohs( aa->aa_lastnet ) >= ntohs( sat2->sat_addr.s_net );
     }
-    return( sat1->sat_addr.s_net == sat2->sat_addr.s_net );
+    return sat1->sat_addr.s_net == sat2->sat_addr.s_net;
 }
 #endif /* BSD4_4 */
 
@@ -98,7 +98,7 @@ at_control( cmd, data, ifp )
 	    }
 	}
 	if ( cmd == SIOCDIFADDR && aa == 0 ) {
-	    return( EADDRNOTAVAIL );
+	    return EADDRNOTAVAIL;
 	}
 	/*FALLTHROUGH*/
 #endif /* BSD4_4 */
@@ -110,11 +110,11 @@ at_control( cmd, data, ifp )
 	 * the return...
 	 */
 	if ( suser( u.u_cred, &u.u_acflag )) {
-	    return( EPERM );
+	    return EPERM;
 	}
 #else /* BSD4_4 */
 	if ( !suser()) {
-	    return( EPERM );
+	    return EPERM;
 	}
 #endif /* BSD4_4 */
 
@@ -141,7 +141,7 @@ at_control( cmd, data, ifp )
 	if ( aa == (struct at_ifaddr *) 0 ) {
 	    m = m_getclr( M_WAIT, MT_IFADDR );
 	    if ( m == (struct mbuf *)NULL ) {
-		return( ENOBUFS );
+		return ENOBUFS;
 	    }
 
 	    if (( aa = at_ifaddr ) != NULL ) {
@@ -212,7 +212,7 @@ at_control( cmd, data, ifp )
 	}
 
 	if ( aa == (struct at_ifaddr *) 0 )
-	    return( EADDRNOTAVAIL );
+	    return EADDRNOTAVAIL;
 	break;
     }
 
@@ -226,14 +226,14 @@ at_control( cmd, data, ifp )
 	break;
 
     case SIOCSIFADDR:
-	return( at_ifinit( ifp, aa, (struct sockaddr_at *)&ifr->ifr_addr ));
+	return at_ifinit( ifp, aa, (struct sockaddr_at *)&ifr->ifr_addr );
 
 #ifdef BSD4_4
     case SIOCAIFADDR:
 	if ( sateqaddr( &ifra->ifra_addr, &aa->aa_addr )) {
-	    return( 0 );
+	    return 0;
 	}
-	return( at_ifinit( ifp, aa, (struct sockaddr_at *)&ifr->ifr_addr ));
+	return at_ifinit( ifp, aa, (struct sockaddr_at *)&ifr->ifr_addr );
 
     case SIOCDIFADDR:
 	at_scrub( ifp, aa );
@@ -269,10 +269,10 @@ at_control( cmd, data, ifp )
 
     default:
 	if ( ifp == 0 || ifp->if_ioctl == 0 )
-	    return( EOPNOTSUPP );
-	return( (*ifp->if_ioctl)( ifp, cmd, data ));
+	    return EOPNOTSUPP;
+	return (*ifp->if_ioctl)( ifp, cmd, data );
     }
-    return( 0 );
+    return 0;
 }
 
 at_scrub( ifp, aa )
@@ -289,7 +289,7 @@ at_scrub( ifp, aa )
 #ifdef BSD4_4
 	if (( error = rtinit( &(aa->aa_ifa), RTM_DELETE,
 		( ifp->if_flags & IFF_LOOPBACK ) ? RTF_HOST : 0 )) != 0 ) {
-	    return( error );
+	    return error;
 	}
 	aa->aa_ifa.ifa_flags &= ~IFA_ROUTE;
 #else /* BSD4_4 */
@@ -321,7 +321,7 @@ at_scrub( ifp, aa )
 #endif /* BSD4_4 */
 	aa->aa_flags &= ~AFA_ROUTE;
     }
-    return( 0 );
+    return 0;
 }
 
 extern struct timeval	time;
@@ -380,7 +380,7 @@ at_ifinit( ifp, aa, sat )
 		    aa->aa_addr = oldaddr;
 		    aa->aa_firstnet = onr.nr_firstnet;
 		    aa->aa_lastnet = onr.nr_lastnet;
-		    return( EINVAL );
+		    return EINVAL;
 		}
 		net = ntohs( sat->sat_addr.s_net );
 	    }
@@ -412,7 +412,7 @@ at_ifinit( ifp, aa, sat )
 		    aa->aa_addr = oldaddr;
 		    aa->aa_firstnet = onr.nr_firstnet;
 		    aa->aa_lastnet = onr.nr_lastnet;
-		    return( EINTR );
+		    return EINTR;
 		}
 		s = splimp();
 		if (( aa->aa_flags & AFA_PROBING ) == 0 ) {
@@ -431,7 +431,7 @@ at_ifinit( ifp, aa, sat )
 	    aa->aa_firstnet = onr.nr_firstnet;
 	    aa->aa_lastnet = onr.nr_lastnet;
 	    splx( s );
-	    return( EADDRINUSE );
+	    return EADDRINUSE;
 	}
     }
 
@@ -441,7 +441,7 @@ at_ifinit( ifp, aa, sat )
 	aa->aa_addr = oldaddr;
 	aa->aa_firstnet = onr.nr_firstnet;
 	aa->aa_lastnet = onr.nr_lastnet;
-	return( error );
+	return error;
     }
 
 #ifdef BSD4_4
@@ -513,7 +513,7 @@ at_ifinit( ifp, aa, sat )
 	aa->aa_firstnet = onr.nr_firstnet;
 	aa->aa_lastnet = onr.nr_lastnet;
 	splx( s );
-	return( error );
+	return error;
     }
 
 #ifdef BSD4_4
@@ -521,7 +521,7 @@ at_ifinit( ifp, aa, sat )
 #endif /* BSD4_4 */
     aa->aa_flags |= AFA_ROUTE;
     splx( s );
-    return( 0 );
+    return 0;
 }
 
 at_broadcast( sat )
@@ -530,20 +530,20 @@ at_broadcast( sat )
     struct at_ifaddr	*aa;
 
     if ( sat->sat_addr.s_node != ATADDR_BCAST ) {
-	return( 0 );
+	return 0;
     }
     if ( sat->sat_addr.s_net == 0 ) {
-	return( 1 );
+	return 1;
     } else {
 	for ( aa = at_ifaddr; aa; aa = aa->aa_next ) {
 	    if (( aa->aa_ifp->if_flags & IFF_BROADCAST ) &&
 		 ( ntohs( sat->sat_addr.s_net ) >= ntohs( aa->aa_firstnet ) &&
 		 ntohs( sat->sat_addr.s_net ) <= ntohs( aa->aa_lastnet ))) {
-		return( 1 );
+		return 1;
 	    }
 	}
     }
-    return( 0 );
+    return 0;
 }
 
 aa_clean()

--- a/sys/netatalk/ddp_output.c
+++ b/sys/netatalk/ddp_output.c
@@ -52,7 +52,7 @@ ddp_output( ddp, m )
     MGET( m, M_WAIT, MT_HEADER );
     if ( m == 0 ) {
 	m_freem( m0 );
-	return( ENOBUFS );
+	return ENOBUFS;
     }
     m->m_next = m0;
 #endif /* BSD4_4 */
@@ -91,7 +91,7 @@ ddp_output( ddp, m )
     }
     deh->deh_bytes = htonl( deh->deh_bytes );
 
-    return( ddp_route( m, &ddp->ddp_route ));
+    return ddp_route( m, &ddp->ddp_route );
 }
 
     unsigned short
@@ -120,7 +120,7 @@ at_cksum( m, skip )
     if ( cksum == 0 ) {
 	cksum = 0x0000ffff;
     }
-    return( (unsigned short)cksum );
+    return (unsigned short)cksum;
 }
 
 ddp_route( m, ro )
@@ -151,7 +151,7 @@ ddp_route( m, ro )
     }
     if ( aa == NULL ) {
 	m_freem( m );
-	return( EINVAL );
+	return EINVAL;
     }
 
     /*
@@ -165,14 +165,14 @@ ddp_route( m, ro )
 	    mlen += m0->m_len;
 	}
 	if (( m = m_pullup( m, MIN( MLEN, mlen ))) == 0 ) {
-	    return( ENOBUFS );
+	    return ENOBUFS;
 	}
     } else {
 # ifdef notdef
 #ifdef BSD4_4
 	M_PREPEND( m, SZ_ELAPHDR, M_DONTWAIT );
 	if ( m == NULL ) {
-	    return( ENOBUFS );
+	    return ENOBUFS;
 	}
 #else /* BSD4_4 */
 	m->m_off -= SZ_ELAPHDR;
@@ -183,7 +183,7 @@ ddp_route( m, ro )
 	MGET( m0, M_WAIT, MT_HEADER );
 	if ( m0 == 0 ) {
 	    m_freem( m );
-	    return( ENOBUFS );
+	    return ENOBUFS;
 	}
 	m0->m_next = m;
 	m0->m_off = MMINOFF + align( sizeof( struct ether_header ));
@@ -222,5 +222,5 @@ ddp_route( m, ro )
     ro->ro_rt->rt_use++;
 
 
-    return((*ifp->if_output)( ifp, m, &gate ));
+    return (*ifp->if_output)( ifp, m, &gate );
 }

--- a/sys/netatalk/ddp_usrreq.c
+++ b/sys/netatalk/ddp_usrreq.c
@@ -41,8 +41,8 @@ ddp_usrreq( so, req, m, addr, rights )
     ddp = sotoddpcb( so );
 
     if ( req == PRU_CONTROL ) {
-	return( at_control( (int) m, (caddr_t) addr,
-		(struct ifnet *) rights ));
+	return at_control( (int) m, (caddr_t) addr,
+		(struct ifnet *) rights );
     }
 
     if ( rights && rights->m_len ) {
@@ -155,14 +155,14 @@ ddp_usrreq( so, req, m, addr, rights )
 	/*
 	 * Don't mfree. Good architecture...
 	 */
-	return( EOPNOTSUPP );
+	return EOPNOTSUPP;
 
     case PRU_SENSE:
 	/*
 	 * 1. Don't return block size.
 	 * 2. Don't mfree.
 	 */
-	return( 0 );
+	return 0;
 
     default:
 	error = EOPNOTSUPP;
@@ -172,7 +172,7 @@ release:
     if ( m != NULL ) {
 	m_freem( m );
     }
-    return( error );
+    return error;
 }
 
 at_sockaddr( ddp, addr )
@@ -195,16 +195,16 @@ at_pcbsetaddr( ddp, addr )
     struct ddpcb	*ddpp;
 
     if ( ddp->ddp_lsat.sat_port != ATADDR_ANYPORT ) { /* shouldn't be bound */
-	return( EINVAL );
+	return EINVAL;
     }
 
     if ( addr != 0 ) {			/* validate passed address */
 	sat = mtod( addr, struct sockaddr_at *);
 	if ( addr->m_len != sizeof( *sat )) {
-	    return( EINVAL );
+	    return EINVAL;
 	}
 	if ( sat->sat_family != AF_APPLETALK ) {
-	    return( EAFNOSUPPORT );
+	    return EAFNOSUPPORT;
 	}
 
 	if ( sat->sat_addr.s_node != ATADDR_ANYNODE ||
@@ -216,23 +216,23 @@ at_pcbsetaddr( ddp, addr )
 		}
 	    }
 	    if ( !aa ) {
-		return( EADDRNOTAVAIL );
+		return EADDRNOTAVAIL;
 	    }
 	}
 
 	if ( sat->sat_port != ATADDR_ANYPORT ) {
 	    if ( sat->sat_port < ATPORT_FIRST ||
 		    sat->sat_port >= ATPORT_LAST ) {
-		return( EINVAL );
+		return EINVAL;
 	    }
 #ifdef BSD4_4
 	    if ( sat->sat_port < ATPORT_RESERVED &&
 		    suser( u.u_cred, &u.u_acflag )) {
-		return( EACCES );
+		return EACCES;
 	    }
 #else /* BSD4_4 */
 	    if ( sat->sat_port < ATPORT_RESERVED && ( !suser())) {
-		return( EACCES );
+		return EACCES;
 	    }
 #endif /* BSD4_4 */
 	}
@@ -245,7 +245,7 @@ at_pcbsetaddr( ddp, addr )
     if ( sat->sat_addr.s_node == ATADDR_ANYNODE &&
 	    sat->sat_addr.s_net == ATADDR_ANYNET ) {
 	if ( at_ifaddr == NULL ) {
-	    return( EADDRNOTAVAIL );
+	    return EADDRNOTAVAIL;
 	}
 	sat->sat_addr = AA_SAT( at_ifaddr )->sat_addr;
     }
@@ -262,7 +262,7 @@ at_pcbsetaddr( ddp, addr )
 	    }
 	}
 	if ( sat->sat_port == ATPORT_LAST ) {
-	    return( EADDRNOTAVAIL );
+	    return EADDRNOTAVAIL;
 	}
 	ddp->ddp_lsat.sat_port = sat->sat_port;
 	ddp_ports[ sat->sat_port - 1 ] = ddp;
@@ -275,7 +275,7 @@ at_pcbsetaddr( ddp, addr )
 	    }
 	}
 	if ( ddpp != NULL ) {
-	    return( EADDRINUSE );
+	    return EADDRINUSE;
 	}
 	ddp->ddp_pnext = ddp_ports[ sat->sat_port - 1 ];
 	ddp_ports[ sat->sat_port - 1 ] = ddp;
@@ -284,7 +284,7 @@ at_pcbsetaddr( ddp, addr )
 	}
     }
 
-    return( 0 );
+    return 0;
 }
 
 at_pcbconnect( ddp, addr )
@@ -298,9 +298,9 @@ at_pcbconnect( ddp, addr )
     unsigned short		hintnet = 0, net;
 
     if ( addr->m_len != sizeof( *sat ))
-	return( EINVAL );
+	return EINVAL;
     if ( sat->sat_family != AF_APPLETALK ) {
-	return( EAFNOSUPPORT );
+	return EAFNOSUPPORT;
     }
 
     /*
@@ -310,7 +310,7 @@ at_pcbconnect( ddp, addr )
      */
     if ( sat->sat_addr.s_net == 0 && sat->sat_addr.s_node != ATADDR_ANYNODE ) {
 	if ( ddp->ddp_lsat.sat_port == ATADDR_ANYPORT ) {
-	    return( EADDRNOTAVAIL );
+	    return EADDRNOTAVAIL;
 	}
 	hintnet = ddp->ddp_lsat.sat_addr.s_net;
     }
@@ -376,14 +376,14 @@ at_pcbconnect( ddp, addr )
 	}
     }
     if ( aa == 0 ) {
-	return( ENETUNREACH );
+	return ENETUNREACH;
     }
 
     ddp->ddp_fsat = *sat;
     if ( ddp->ddp_lsat.sat_port == ATADDR_ANYPORT ) {
-	return( at_pcbsetaddr( ddp, (struct mbuf *)0 ));
+	return at_pcbsetaddr( ddp, (struct mbuf *)0 );
     }
-    return( 0 );
+    return 0;
 }
 
 at_pcbdisconnect( ddp )
@@ -415,7 +415,7 @@ at_pcballoc( so )
 
     ddp->ddp_socket = so;
     so->so_pcb = (caddr_t)ddp;
-    return( 0 );
+    return 0;
 }
 
 at_pcbdetach( so, ddp )
@@ -472,7 +472,7 @@ ddp_search( from, to, aa )
      * Check for bad ports.
      */
     if ( to->sat_port < ATPORT_FIRST || to->sat_port >= ATPORT_LAST ) {
-	return( NULL );
+	return NULL;
     }
 
     /*
@@ -505,7 +505,7 @@ ddp_search( from, to, aa )
 	    break;
 	}
     }
-    return( ddp );
+    return ddp;
 }
 
 ddp_init()

--- a/test/testsuite/FPCreateDir.c
+++ b/test/testsuite/FPCreateDir.c
@@ -158,7 +158,7 @@ DSI *dsi2;
 	}
 	FAIL (FPCloseVol(Conn2,vol2))
 
-	return(tdir);
+	return tdir;
 }
 
 /* ----------- */

--- a/test/testsuite/afpcli.c
+++ b/test/testsuite/afpcli.c
@@ -386,7 +386,7 @@ DSI *dsi;
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
 
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -----------------------------------------------
@@ -518,7 +518,7 @@ DSI *dsi = &conn->dsi;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ---------------------------- */
@@ -593,7 +593,7 @@ DSI *dsi;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* --------------------------- */
@@ -642,7 +642,7 @@ DSI *dsi;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 /* ------------------------------- */
 int AFPLogOut(CONN *conn)
@@ -655,7 +655,7 @@ int AFPLogOut(CONN *conn)
 	ret = my_dsi_full_receive(dsi, dsi->commands, DSI_CMDSIZ);
     DSICloseSession(conn);
 
-    return (dsi->header.dsi_code);
+    return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -680,7 +680,7 @@ int AFPzzz(CONN *conn, int flag)
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -691,7 +691,7 @@ DSI *dsi;
 	dsi = &conn->dsi;
 	SendCmd(dsi,AFP_GETSRVINFO);
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -702,7 +702,7 @@ DSI *dsi;
 	dsi = &conn->dsi;
 	SendCmd(dsi,AFP_GETSRVPARAM);
 	my_dsi_data_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -730,7 +730,7 @@ DSI *dsi;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------  */
@@ -741,7 +741,7 @@ DSI *dsi;
 	dsi = &conn->dsi;
 	SendCmdWithU16(dsi, AFP_CLOSEVOL, vol);
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------  */
@@ -752,7 +752,7 @@ DSI *dsi;
 	dsi = &conn->dsi;
 	SendCmdWithU16(dsi, AFP_CLOSEDT, vol);
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -763,7 +763,7 @@ DSI *dsi;
 	dsi = &conn->dsi;
 	SendCmdWithU16(dsi, AFP_CLOSEFORK, fork);
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -795,7 +795,7 @@ DSI *dsi;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ---------------------------- */
@@ -865,7 +865,7 @@ DSI *dsi;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -906,7 +906,7 @@ DSI *dsi;
 	dsi = &conn->dsi;
 	SendCmdWithU16(dsi, AFP_FLUSH, vol);
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------  */
@@ -917,7 +917,7 @@ DSI *dsi;
 	dsi = &conn->dsi;
 	SendCmdWithU16(dsi, AFP_FLUSHFORK, vol);
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------  */
@@ -967,7 +967,7 @@ DSI *dsi;
 		memcpy(&result, dsi->commands +ofs, sizeof(result));
 		volID = result;
 	}
-	return(volID);
+	return volID;
 }
 
 /* -------------------------------  */
@@ -1143,7 +1143,7 @@ int afp_volume_pack(unsigned char *b, struct afp_volume_parms *parms, uint16_t b
         bitmap = bitmap>>1;
         bit++;
     }
-    return (b -beg);
+    return b -beg;
 }
 
 /* -------------------------------------- */
@@ -1410,7 +1410,7 @@ int afp_filedir_pack(unsigned char *b, struct afp_filedir_parms *filedir, uint16
         	b += sizeof(tp);
         }
     }
-    return (b -beg);
+    return b -beg;
 }
 
 /* -------------------------------  */
@@ -1438,7 +1438,7 @@ DSI *dsi;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------  */
@@ -1468,7 +1468,7 @@ uint16_t tp;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ---------------------
@@ -1553,7 +1553,7 @@ DSI *dsi;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -1803,7 +1803,7 @@ DSI *dsi;
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
 
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 
 }
 
@@ -1842,7 +1842,7 @@ DSI *dsi;
 	/* ------------------ */
 	my_dsi_data_receive(dsi);
 
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -1874,7 +1874,7 @@ DSI *dsi;
 	/* ------------------ */
 	my_dsi_data_receive(dsi);
 
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -1905,7 +1905,7 @@ DSI *dsi;
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
 
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -1932,7 +1932,7 @@ DSI *dsi;
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
 
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -1972,7 +1972,7 @@ DSI *dsi;
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
 
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -2000,7 +2000,7 @@ DSI *dsi;
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
 
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -2165,7 +2165,7 @@ DSI *dsi;
 			fprintf(stdout,"directory ID 0x%x\n", ntohl(dir));
 		}
 	}
-	return(dir);
+	return dir;
 }
 
 /* ------------------------------- */
@@ -2230,7 +2230,7 @@ DSI *dsi;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 	/* ------------------ */
 	my_dsi_data_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------
@@ -2265,7 +2265,7 @@ DSI *dsi;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 	/* ------------------ */
 	my_dsi_data_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------
@@ -2298,7 +2298,7 @@ DSI *dsi;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 	/* ------------------ */
 	my_dsi_data_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------
@@ -2358,7 +2358,7 @@ uint16_t bitmap;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 	/* ------------------ */
 	my_dsi_data_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------
@@ -2421,7 +2421,7 @@ uint16_t i;
    	my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 	/* ------------------ */
 	my_dsi_data_receive(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------
@@ -2458,7 +2458,7 @@ DSI *dsi;
         my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
         /* ------------------ */
         my_dsi_data_receive(dsi);
-        return(dsi->header.dsi_code);
+        return dsi->header.dsi_code;
 }
 
 /* --------------------------------
@@ -2520,7 +2520,7 @@ uint16_t len;
         my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
         /* ------------------ */
         my_dsi_data_receive(dsi);
-        return(dsi->header.dsi_code);
+        return dsi->header.dsi_code;
 }
 
 
@@ -2564,7 +2564,7 @@ DSI *dsi;
         my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
         /* ------------------ */
         my_dsi_data_receive(dsi);
-        return(dsi->header.dsi_code);
+        return dsi->header.dsi_code;
 }
 
 /* --------------------------------
@@ -2625,7 +2625,7 @@ uint32_t datalen;
         my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
         /* ------------------ */
         my_dsi_data_receive(dsi);
-        return(dsi->header.dsi_code);
+        return dsi->header.dsi_code;
 }
 
 int AFPRemoveExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char* pathname, char* attrname)
@@ -2670,5 +2670,5 @@ uint16_t len;
         my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
         /* ------------------ */
         my_dsi_data_receive(dsi);
-        return(dsi->header.dsi_code);
+        return dsi->header.dsi_code;
 }

--- a/test/testsuite/afpcmd.c
+++ b/test/testsuite/afpcmd.c
@@ -465,7 +465,7 @@ DSI *dsi = &conn->dsi;
 
 	volID = AFPOpenVol(conn,vol, bitmap);
 	dump_header(dsi);
-	return(!dsi->header.dsi_code?volID:0xffff);
+	return !dsi->header.dsi_code?volID:0xffff;
 }
 
 /* ------------------ */
@@ -487,7 +487,7 @@ DSI *dsi;
 
 	ret  = AFPCloseVol(conn,vol);
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -531,7 +531,7 @@ DSI *dsi;
 			fprintf(stdout,"Desktop ID %d\n", id);
 		}
 	}
-	return(id);
+	return id;
 }
 
 /* ------------------------------- */
@@ -833,7 +833,7 @@ DSI *dsi;
 	/* ------------------ */
 	my_dsi_cmd_receive(dsi);
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------
@@ -904,7 +904,7 @@ DSI *dsi;
 	my_dsi_data_receive(dsi);
 
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 
@@ -979,7 +979,7 @@ DSI *dsi;
 	my_dsi_data_receive(dsi);
 
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------
@@ -1028,7 +1028,7 @@ DSI *dsi;
 	my_dsi_data_receive(dsi);
 
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------
@@ -1068,7 +1068,7 @@ DSI *dsi;
 	my_dsi_data_receive(dsi);
 
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------
@@ -1106,7 +1106,7 @@ DSI *dsi;
 	my_dsi_data_receive(dsi);
 
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------
@@ -1148,7 +1148,7 @@ DSI *dsi;
 	my_dsi_data_receive(dsi);
 
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 /* -------------------------------
 */
@@ -1222,7 +1222,7 @@ DSI *dsi;
 	my_dsi_data_receive(dsi);
 
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* -------------------------------
@@ -1298,7 +1298,7 @@ DSI *dsi;
 	my_dsi_data_receive(dsi);
 
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -1382,7 +1382,7 @@ unsigned int FPEnumerateExt2Full(CONN *conn,
 	my_dsi_data_receive(dsi);
 
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 
@@ -1505,7 +1505,7 @@ DSI *dsi;
 			fprintf(stdout,"directory ID 0x%x\n", ntohl(dir));
 		}
 	}
-	return(dir);
+	return dir;
 }
 
 /* -------------------------------- */
@@ -1523,7 +1523,7 @@ DSI *dsi;
 	dir = AFPCreateDir(conn,vol, did , name);
 
 	dump_header(dsi);
-	return(dir);
+	return dir;
 }
 
 /* -------------------------------
@@ -1912,7 +1912,7 @@ DSI *dsi;
 	my_dsi_data_receive(dsi);
 
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -1957,7 +1957,7 @@ DSI *dsi;
 	my_dsi_data_receive(dsi);
 
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */
@@ -2003,7 +2003,7 @@ DSI *dsi;
 	my_dsi_data_receive(dsi);
 
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 /* ------------------------------- */
 unsigned int FPRename(CONN *conn, uint16_t svol, int sdid, char *src, char *dst)
@@ -2043,7 +2043,7 @@ DSI *dsi;
 	my_dsi_data_receive(dsi);
 
 	dump_header(dsi);
-	return(dsi->header.dsi_code);
+	return dsi->header.dsi_code;
 }
 
 /* ------------------------------- */


### PR DESCRIPTION
In C `return` isn't a function. Parentheses are just for decoration. Removing them standardizes coding style and removes a little bit of syntax clutter.