### PR TITLE
Remove redundant parentheses in function calls and if statements

### DIFF
--- a/bin/ad/ad_util.c
+++ b/bin/ad/ad_util.c
@@ -122,7 +122,7 @@ int openvol(AFPObj *obj, const char *path, afpvol_t *vol)
     if (vol->vol->v_vfs_ea != AFPVOL_EA_AD && vol->vol->v_vfs_ea != AFPVOL_EA_SYS)
         ERROR("Unsupported Extended Attributes option: %u", vol->vol->v_vfs_ea);
 
-    if ((vol->vol->v_flags & AFPVOL_NODEV))
+    if (vol->vol->v_flags & AFPVOL_NODEV)
         flags |= CNID_FLAG_NODEV;
 
     if ((vol->vol->v_cdb = cnid_open(vol->vol,
@@ -166,12 +166,12 @@ char *utompath(const struct vol *vol, const char *upath)
     u = upath;
     outlen = strlen(upath);
 
-    if ((vol->v_casefold & AFPVOL_UTOMUPPER))
+    if (vol->v_casefold & AFPVOL_UTOMUPPER)
         flags |= CONV_TOUPPER;
-    else if ((vol->v_casefold & AFPVOL_UTOMLOWER))
+    else if (vol->v_casefold & AFPVOL_UTOMLOWER)
         flags |= CONV_TOLOWER;
 
-    if ((vol->v_flags & AFPVOL_EILSEQ)) {
+    if (vol->v_flags & AFPVOL_EILSEQ) {
         flags |= CONV__EILSEQ;
     }
 

--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -279,7 +279,7 @@ static void alarm_handler(int sig _U_)
     setitimer(ITIMER_REAL, &dsi->timer, NULL);
 
     /* we got some traffic from the client since the previous timer tick. */
-    if ((dsi->flags & DSI_DATA)) {
+    if (dsi->flags & DSI_DATA) {
         dsi->flags &= ~DSI_DATA;
         return;
     }
@@ -589,7 +589,7 @@ void afp_over_dsi(AFPObj *obj)
             dsi->flags &= ~DSI_DATA; /* thats no data in the sense we use it in alarm_handler */
             LOG(log_debug, logtype_afpd, "DSI: client tickle");
             /* timer is not every 30 seconds anymore, so we don't get killed on the client side. */
-            if ((dsi->flags & DSI_DIE))
+            if (dsi->flags & DSI_DIE)
                 dsi_tickle(dsi);
             break;
 

--- a/etc/afpd/catsearch.c
+++ b/etc/afpd/catsearch.c
@@ -199,7 +199,7 @@ static struct adouble *adl_lkup(struct vol *vol, struct path *path, struct adoub
 		adp = &ad;
 	}
 
-    if ( ad_metadata( path->u_name, ((isdir) ? ADFLAGS_DIR : 0), adp) < 0 ) {
+    if ( ad_metadata( path->u_name, (isdir ? ADFLAGS_DIR : 0), adp) < 0 ) {
         adp = NULL; /* FIXME without resource fork adl_lkup will be call again */
     }
 
@@ -291,11 +291,11 @@ static int crit_check(struct vol *vol, struct path *path) {
 	 */
 
 	/* Check for filename */
-	if ((c1.rbitmap & (1U<<DIRPBIT_LNAME))) {
+	if (c1.rbitmap & (1U<<DIRPBIT_LNAME)) {
 		if ( (size_t)(-1) == (len = convert_string(vol->v_maccharset, CH_UCS2, path->m_name, -1, convbuf, 512)) )
 			goto crit_check_ret;
 
-		if ((c1.rbitmap & (1U<<CATPBIT_PARTIAL))) {
+		if (c1.rbitmap & (1U<<CATPBIT_PARTIAL)) {
 			if (strcasestr_w( (ucs2_t*) convbuf, (ucs2_t*) c1.lname) == NULL)
 				goto crit_check_ret;
 		} else
@@ -303,7 +303,7 @@ static int crit_check(struct vol *vol, struct path *path) {
 				goto crit_check_ret;
 	}
 
-	if ((c1.rbitmap & (1U<<FILPBIT_PDINFO))) {
+	if (c1.rbitmap & (1U<<FILPBIT_PDINFO)) {
 		if ( (size_t)(-1) == (len = convert_charset( CH_UTF8_MAC, CH_UCS2, CH_UTF8, path->m_name, strlen(path->m_name), convbuf, 512, &flags))) {
 			goto crit_check_ret;
 		}
@@ -326,13 +326,13 @@ static int crit_check(struct vol *vol, struct path *path) {
 		c2.bdate = 0x7fffffff;
 
 	/* Check for modification date */
-	if ((c1.rbitmap & (1U<<DIRPBIT_MDATE))) {
+	if (c1.rbitmap & (1U<<DIRPBIT_MDATE)) {
 		if (path->st.st_mtime < c1.mdate || path->st.st_mtime > c2.mdate)
 			goto crit_check_ret;
 	}
 
 	/* Check for creation date... */
-	if ((c1.rbitmap & (1U<<DIRPBIT_CDATE))) {
+	if (c1.rbitmap & (1U<<DIRPBIT_CDATE)) {
 		c_date = path->st.st_mtime;
 		adp = adl_lkup(vol, path, adp);
 		if (adp && ad_getdate(adp, AD_DATE_CREATE, &ac_date) >= 0)
@@ -343,7 +343,7 @@ static int crit_check(struct vol *vol, struct path *path) {
 	}
 
 	/* Check for backup date... */
-	if ((c1.rbitmap & (1U<<DIRPBIT_BDATE))) {
+	if (c1.rbitmap & (1U<<DIRPBIT_BDATE)) {
 		b_date = path->st.st_mtime;
 		adp = adl_lkup(vol, path, adp);
 		if (adp && ad_getdate(adp, AD_DATE_BACKUP, &ab_date) >= 0)
@@ -442,7 +442,7 @@ static int rslt_add (const AFPObj *obj, struct vol *vol, struct path *path, char
 		return 0;
 
 	/* Make sure entry length is even */
-	if ((tbuf & 1)) {
+	if (tbuf & 1) {
 	   *p++ = 0;
 	   tbuf++;
 	}
@@ -636,7 +636,7 @@ static int catsearch(const AFPObj *obj,
 			ccr = crit_check(vol, &path);
 
 			/* bit 0 means that criteria has been met */
-			if ((ccr & 1)) {
+			if (ccr & 1) {
 				r = rslt_add (obj, vol, &path, &rrbuf, ext);
 
 				if (r == 0) {
@@ -807,7 +807,7 @@ static int catsearch_db(const AFPObj *obj,
 
         /* At last we can check the search criteria */
         ccr = crit_check(vol, &path);
-        if ((ccr & 1)) {
+        if (ccr & 1) {
             LOG(log_debug, logtype_afpd,"catsearch_db: match: %s/%s",
                 getcwdpath(), path.u_name);
             /* bit 1 means that criteria has been met */

--- a/etc/afpd/desktop.c
+++ b/etc/afpd/desktop.c
@@ -779,7 +779,7 @@ char *mtoupath(const struct vol *vol, char *mpath, cnid_t did, int utf8)
     inplen = strlen(m);
     outlen = MAXPATHLEN;
 
-    if ((size_t)-1 == (outlen = convert_charset ( (utf8)?CH_UTF8_MAC:vol->v_maccharset, vol->v_volcharset, vol->v_maccharset, m, inplen, u, outlen, &flags)) ) {
+    if ((size_t)-1 == (outlen = convert_charset ( utf8?CH_UTF8_MAC:vol->v_maccharset, vol->v_volcharset, vol->v_maccharset, m, inplen, u, outlen, &flags)) ) {
         LOG(log_error, logtype_afpd, "conversion from %s to %s for %s failed.", (utf8)?"UTF8-MAC":vol->v_maccodepage, vol->v_volcodepage, mpath);
 	    return NULL;
     }
@@ -806,7 +806,7 @@ char *utompath(const struct vol *vol, char *upath, cnid_t id, int utf8)
     u = upath;
 
     /* convert charsets */
-    if ((size_t)-1 == ( outlen = convert_charset ( vol->v_volcharset, (utf8)?CH_UTF8_MAC:vol->v_maccharset, vol->v_maccharset, u, outlen, mpath, MAXPATHLEN, &flags)) ) {
+    if ((size_t)-1 == ( outlen = convert_charset ( vol->v_volcharset, utf8?CH_UTF8_MAC:vol->v_maccharset, vol->v_maccharset, u, outlen, mpath, MAXPATHLEN, &flags)) ) {
         LOG(log_error, logtype_afpd, "Conversion from %s to %s for %s (%u) failed.", vol->v_volcodepage, vol->v_maccodepage, u, ntohl(id));
 	goto utompath_error;
     }
@@ -823,7 +823,7 @@ char *utompath(const struct vol *vol, char *upath, cnid_t id, int utf8)
 
 utompath_error:
     u = "???";
-    m = mangle(vol, u, strlen(u), upath, id, (utf8)?3:1);
+    m = mangle(vol, u, strlen(u), upath, id, utf8?3:1);
     return m;
 }
 
@@ -852,13 +852,13 @@ static int ad_addcomment(const AFPObj *obj, struct vol *vol, struct path *path, 
         adp = of->of_ad;
 
     if (ad_open(adp, upath,
-                ADFLAGS_HF | ( (isadir) ? ADFLAGS_DIR : 0) | ADFLAGS_CREATE | ADFLAGS_RDWR,
+                ADFLAGS_HF | ( isadir ? ADFLAGS_DIR : 0) | ADFLAGS_CREATE | ADFLAGS_RDWR,
                 0666) < 0 ) {
         return AFPERR_ACCESS;
     }
 
     if (ad_getentryoff(adp, ADEID_COMMENT) && ad_entry(adp, ADEID_COMMENT)) {
-        if ( (ad_get_MD_flags( adp ) & O_CREAT) ) {
+        if ( ad_get_MD_flags( adp ) & O_CREAT ) {
             if ( *path->m_name == '\0' ) {
                 name = (char *)curdir->d_m_name->data;
             } else {
@@ -926,7 +926,7 @@ static int ad_getcomment(struct vol *vol, struct path *path, char *rbuf, size_t 
     } else
         adp = of->of_ad;
 
-    if ( ad_metadata( upath, ((isadir) ? ADFLAGS_DIR : 0), adp) < 0 ) {
+    if ( ad_metadata( upath, (isadir ? ADFLAGS_DIR : 0), adp) < 0 ) {
         return AFPERR_NOITEM;
     }
 
@@ -1003,7 +1003,7 @@ static int ad_rmvcomment(const AFPObj *obj, struct vol *vol, struct path *path)
     } else
         adp = of->of_ad;
 
-    if ( ad_open(adp, upath, ADFLAGS_HF | ADFLAGS_RDWR | ((isadir) ? ADFLAGS_DIR : 0)) < 0 ) {
+    if ( ad_open(adp, upath, ADFLAGS_HF | ADFLAGS_RDWR | (isadir ? ADFLAGS_DIR : 0)) < 0 ) {
         switch ( errno ) {
         case ENOENT :
             return AFPERR_NOITEM;

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -514,7 +514,7 @@ struct dir *dirlookup(const struct vol *vol, cnid_t did)
     }
 
     utf8 = utf8_encoding(vol->v_obj);
-    maxpath = (utf8) ? MAXPATHLEN - 7 : 255;
+    maxpath = utf8 ? MAXPATHLEN - 7 : 255;
 
     /* Get it from the database */
     cnid = did;
@@ -1257,11 +1257,11 @@ int getdirparams(const AFPObj *obj,
     struct stat *st = &s_path->st;
     char *upath = s_path->u_name;
 
-    if ((bitmap & ((1 << DIRPBIT_ATTR)  |
+    if (bitmap & ((1 << DIRPBIT_ATTR)  |
                    (1 << DIRPBIT_CDATE) |
                    (1 << DIRPBIT_MDATE) |
                    (1 << DIRPBIT_BDATE) |
-                   (1 << DIRPBIT_FINFO)))) {
+                   (1 << DIRPBIT_FINFO))) {
 
         ad_init(&ad, vol);
         if ( !ad_metadata( upath, ADFLAGS_DIR, &ad) ) {
@@ -1678,7 +1678,7 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap, char *bu
             LOG(log_debug, logtype_afpd, "setdirparams(\"%s\", bitmap: %02x): need adouble", path->u_name, d_bitmap);
             return AFPERR_ACCESS;
         }
-        if ((ad_get_MD_flags(&ad) & O_CREAT)) {
+        if (ad_get_MD_flags(&ad) & O_CREAT) {
             ad_setname(&ad, cfrombstr(curdir->d_m_name));
         }
         isad = 1;

--- a/etc/afpd/enumerate.c
+++ b/etc/afpd/enumerate.c
@@ -252,7 +252,7 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
         ibuf += sizeof( temp16 );
     }
 
-    header = (ext)?4:2;
+    header = ext?4:2;
     header *=sizeof( uint8_t );
 
     maxsz = min(maxsz, *rbuflen - REPLY_PARAM_MAXLEN);

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -303,7 +303,7 @@ int getmetadata(const AFPObj *obj,
     data = buf;
 
     if ( ((bitmap & ( (1 << FILPBIT_FINFO)|(1 << FILPBIT_LNAME)|(1 <<FILPBIT_PDINFO) ) ) && !path->m_name)
-         || (bitmap & ( (1 << FILPBIT_LNAME) ) && utf8_encoding(obj)) /* FIXME should be m_name utf8 filename */
+         || (bitmap & (1 << FILPBIT_LNAME) && utf8_encoding(obj)) /* FIXME should be m_name utf8 filename */
          || (bitmap & (1 << FILPBIT_FNUM))) {
         if (!path->id) {
             bstring fullpath;
@@ -405,7 +405,7 @@ int getmetadata(const AFPObj *obj,
 
         case FILPBIT_MDATE :
             if ( adp && (ad_getdate(adp, AD_DATE_MODIFY, &aint) == 0)) {
-                if ((st->st_mtime > AD_DATE_TO_UNIX(aint))) {
+                if (st->st_mtime > AD_DATE_TO_UNIX(aint)) {
                    aint = AD_DATE_FROM_UNIX(st->st_mtime);
                 }
             } else {
@@ -953,7 +953,7 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
             memcpy( &upriv, buf, sizeof( upriv ));
             buf += sizeof( upriv );
             upriv = ntohl (upriv);
-            if ((upriv & S_IWUSR)) {
+            if (upriv & S_IWUSR) {
             	setfilunixmode(vol, path, upriv);
             }
             else {
@@ -1005,7 +1005,7 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
         }
         LOG(log_debug, logtype_afpd, "setfilparams: no adouble perms, but only FILPBIT_MDATE and/or FILPBIT_UNIXPR");
         isad = 0;
-    } else if ((ad_get_MD_flags( adp ) & O_CREAT) ) {
+    } else if (ad_get_MD_flags( adp ) & O_CREAT ) {
         ad_setname(adp, path->m_name);
         cnid_t id;
         if ((id = get_id(vol, adp, &path->st, curdir->d_did, upath, strlen(upath))) == CNID_INVALID) {
@@ -1577,7 +1577,7 @@ uint16_t   bshort = 0;
 	if (!(vol->v_ignattr & ATTRBIT_NODELETE) && (bshort & htons(ATTRBIT_NODELETE))) {
 		return AFPERR_OLOCK;
 	}
-     if ((bshort & htons(ATTRBIT_DOPEN | ATTRBIT_ROPEN))) {
+     if (bshort & htons(ATTRBIT_DOPEN | ATTRBIT_ROPEN)) {
     	return AFPERR_BUSY;
 	}
 	return 0;
@@ -2092,7 +2092,7 @@ int afp_exchangefiles(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U
         return AFPERR_PARAM;
     }
 
-    if ((vol->v_flags & AFPVOL_RO))
+    if (vol->v_flags & AFPVOL_RO)
         return AFPERR_VLOCK;
 
     /* source and destination dids */

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -154,7 +154,7 @@ static int fork_setmode(const AFPObj *obj _U_, struct adouble *adp, int eid, int
         return ad_lock(adp, eid, ADLOCK_RD | ADLOCK_FILELOCK, AD_FILELOCK_OPEN_NONE, 1, ofrefnum);
     }
 
-    if ((access & (OPENACC_RD | OPENACC_DRD))) {
+    if (access & (OPENACC_RD | OPENACC_DRD)) {
         if ((readset = ad_testlock(adp, eid, AD_FILELOCK_OPEN_RD)) <0)
             return readset;
         if ((denyreadset = ad_testlock(adp, eid, AD_FILELOCK_DENY_RD)) <0)
@@ -171,19 +171,19 @@ static int fork_setmode(const AFPObj *obj _U_, struct adouble *adp, int eid, int
         /* boolean logic is not enough, because getforkmode is not always telling the
          * true
          */
-        if ((access & OPENACC_RD)) {
+        if (access & OPENACC_RD) {
             ret = ad_lock(adp, eid, ADLOCK_RD | ADLOCK_FILELOCK, AD_FILELOCK_OPEN_RD, 1, ofrefnum);
             if (ret)
                 return ret;
         }
-        if ((access & OPENACC_DRD)) {
+        if (access & OPENACC_DRD) {
             ret = ad_lock(adp, eid, ADLOCK_RD | ADLOCK_FILELOCK, AD_FILELOCK_DENY_RD, 1, ofrefnum);
             if (ret)
                 return ret;
         }
     }
     /* ------------same for writing -------------- */
-    if ((access & (OPENACC_WR | OPENACC_DWR))) {
+    if (access & (OPENACC_WR | OPENACC_DWR)) {
         if ((writeset = ad_testlock(adp, eid, AD_FILELOCK_OPEN_WR)) <0)
             return writeset;
         if ((denywriteset = ad_testlock(adp, eid, AD_FILELOCK_DENY_WR)) <0)
@@ -197,12 +197,12 @@ static int fork_setmode(const AFPObj *obj _U_, struct adouble *adp, int eid, int
             errno = EACCES;
             return -1;
         }
-        if ((access & OPENACC_WR)) {
+        if (access & OPENACC_WR) {
             ret = ad_lock(adp, eid, ADLOCK_RD | ADLOCK_FILELOCK, AD_FILELOCK_OPEN_WR, 1, ofrefnum);
             if (ret)
                 return ret;
         }
-        if ((access & OPENACC_DWR)) {
+        if (access & OPENACC_DWR) {
             ret = ad_lock(adp, eid, ADLOCK_RD | ADLOCK_FILELOCK, AD_FILELOCK_DENY_WR, 1, ofrefnum);
             if (ret)
                 return ret;
@@ -482,11 +482,11 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf, si
                 return AFPERR_PARAM;
             }
         }
-        if ((access & OPENACC_WR))
+        if (access & OPENACC_WR)
             ofork->of_flags |= AFPFORK_ACCWR;
     }
     /* the file may be open read only without resource fork */
-    if ((access & OPENACC_RD))
+    if (access & OPENACC_RD)
         ofork->of_flags |= AFPFORK_ACCRD;
 
     LOG(log_debug, logtype_afpd, "afp_openfork(\"%s\"): fork: %" PRIu16,
@@ -561,7 +561,7 @@ int afp_setforkparams(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf _U_, s
     }
 
     is64 = 0;
-    if ((bitmap & ( (1<<FILPBIT_EXTDFLEN) | (1<<FILPBIT_EXTRFLEN) ))) {
+    if (bitmap & ( (1<<FILPBIT_EXTDFLEN) | (1<<FILPBIT_EXTRFLEN) )) {
         if (obj->afp_version >= 30) {
             is64 = 4;
         }

--- a/etc/afpd/main.c
+++ b/etc/afpd/main.c
@@ -126,7 +126,7 @@ static void afp_goaway(int sig)
         if (server_children)
             server_child_kill(server_children, SIGTERM);
 #ifndef NO_DDP
-        if ((asp_obj.handle))
+        if (asp_obj.handle)
         {
             asp_cleanup(&asp_obj);
         }
@@ -407,7 +407,7 @@ int main(int ac, char **av)
             afp_config_free(&dsi_obj);
 #ifndef NO_DDP
             afp_config_free(&asp_obj);
-            if ((asp_obj.handle))
+            if (asp_obj.handle)
             {
                 asp_cleanup(&asp_obj);
                 configfree(&asp_obj, NULL);

--- a/etc/afpd/mangle.c
+++ b/etc/afpd/mangle.c
@@ -90,7 +90,7 @@ static char *demangle_checks(const struct vol *vol, char* uname, char * mfilenam
     /* if we only checked if "prefix" number of characters match */
     /* we get a false postive in above case			     */
 
-    if ( (flags & CONV_REQMANGLE) ) {
+    if ( flags & CONV_REQMANGLE ) {
         if (len) {
             /* convert the buffer to UTF8_MAC ... */
             if ((size_t) -1 == (len = convert_charset(vol->v_maccharset, CH_UTF8_MAC, 0,

--- a/etc/afpd/messages.c
+++ b/etc/afpd/messages.c
@@ -164,12 +164,12 @@ int afp_getsrvrmesg(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, siz
         if ( (size_t)-1 == (outlen = convert_string(obj->options.unixcharset, utf8?CH_UTF8_MAC:obj->options.maccharset,
                                                     message, msglen, localized_message, msgsize)) )
         {
-    	    memcpy(rbuf+((utf8)?2:1), message, msglen); /*FIXME*/
+    	    memcpy(rbuf+(utf8?2:1), message, msglen); /*FIXME*/
 	    outlen = msglen;
         }
         else
         {
-	    memcpy(rbuf+((utf8)?2:1), localized_message, outlen);
+	    memcpy(rbuf+(utf8?2:1), localized_message, outlen);
         }
     }
 

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -426,7 +426,7 @@ int of_closefork(const AFPObj *obj, struct ofork *ofork)
     }
 
     /* Somone has used write_fork, we assume file was changed, register it to file change event api */
-    if ((ofork->of_flags & AFPFORK_MODIFIED) && (forkpath)) {
+    if ((ofork->of_flags & AFPFORK_MODIFIED) && forkpath) {
         fce_register(obj, FCE_FILE_MODIFY, bdata(forkpath), NULL);
     }
 

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -658,7 +658,7 @@ static int volume_openDB(const AFPObj *obj _U_, struct vol *volume)
 {
     int flags = 0;
 
-    if ((volume->v_flags & AFPVOL_NODEV)) {
+    if (volume->v_flags & AFPVOL_NODEV) {
         flags |= CNID_FLAG_NODEV;
     }
 
@@ -762,7 +762,7 @@ int afp_openvol(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
         return AFPERR_ACCESS;
     }
 
-    if (( volume->v_flags & AFPVOL_OPEN  ) ) {
+    if ( volume->v_flags & AFPVOL_OPEN ) {
         /* the volume is already open */
         return stat_vol(obj, bitmap, volume, rbuf, rbuflen);
     }
@@ -848,7 +848,7 @@ int afp_openvol(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf, size_t 
          * fixing the trash at DID 17.
          * FIXME (RL): should it be done inside a CNID backend ? (always returning Trash DID when asked) ?
          */
-        if ((volume->v_cdb->cnid_db_flags & CNID_FLAG_PERSISTENT)) {
+        if (volume->v_cdb->cnid_db_flags & CNID_FLAG_PERSISTENT) {
 
             /* FIXME find db time stamp */
             if (cnid_getstamp(volume->v_cdb, volume->v_stamp, sizeof(volume->v_stamp)) < 0) {
@@ -914,7 +914,7 @@ void close_all_vol(const AFPObj *obj)
     struct vol  *ovol;
     curdir = NULL;
     for ( ovol = getvolumes(); ovol; ovol = ovol->v_next ) {
-        if ( (ovol->v_flags & AFPVOL_OPEN) ) {
+        if ( ovol->v_flags & AFPVOL_OPEN ) {
             ovol->v_flags &= ~AFPVOL_OPEN;
             closevol(obj, ovol);
         }
@@ -1056,7 +1056,7 @@ int afp_setvolparams(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf
         return AFPERR_PARAM;
     }
 
-    if ((vol->v_flags & AFPVOL_RO))
+    if (vol->v_flags & AFPVOL_RO)
         return AFPERR_VLOCK;
 
     /* we can only set the backup date. */

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -200,7 +200,7 @@ static void as_timer(int sig _U_)
 		iface->i_time++;
 	    } else {
 		iface->i_flags |= IFACE_NOROUTER;
-		if ((iface->i_flags & IFACE_ISROUTER)) {
+		if (iface->i_flags & IFACE_ISROUTER) {
 		    if (( iface->i_flags & IFACE_SEED ) == 0 ) {
 			/*
 			 * No seed info, and we've got multiple interfaces.
@@ -486,7 +486,7 @@ static void as_timer(int sig _U_)
 	 * Send RTMP broadcasts if we have multiple interfaces or our
 	 * interface is configured as a router.
 	 */
-	if ((iface->i_flags & IFACE_ISROUTER)) {
+	if (iface->i_flags & IFACE_ISROUTER) {
 #ifdef BSD4_4
 	    sat.sat_len = sizeof( struct sockaddr_at );
 #endif /* BSD4_4 */

--- a/etc/cnid_dbd/cmd_dbd_scanvol.c
+++ b/etc/cnid_dbd/cmd_dbd_scanvol.c
@@ -82,12 +82,12 @@ static char *utompath(char *upath)
     u = upath;
     outlen = strlen(upath);
 
-    if ((vol->v_casefold & AFPVOL_UTOMUPPER))
+    if (vol->v_casefold & AFPVOL_UTOMUPPER)
         flags |= CONV_TOUPPER;
-    else if ((vol->v_casefold & AFPVOL_UTOMLOWER))
+    else if (vol->v_casefold & AFPVOL_UTOMLOWER)
         flags |= CONV_TOLOWER;
 
-    if ((vol->v_flags & AFPVOL_EILSEQ)) {
+    if (vol->v_flags & AFPVOL_EILSEQ) {
         flags |= CONV__EILSEQ;
     }
 

--- a/etc/cnid_dbd/dbif.c
+++ b/etc/cnid_dbd/dbif.c
@@ -614,7 +614,7 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
                                               dbd->db_txn,
                                               dbd->db_table[DBIF_IDX_DIDNAME].db,
                                               didname,
-                                              (reindex) ? DB_CREATE : 0))
+                                              reindex ? DB_CREATE : 0))
          != 0) {
         LOG(log_error, logtype_cnid, "Failed to associate didname database: %s",db_strerror(ret));
         return -1;
@@ -628,7 +628,7 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
                                               dbd->db_txn,
                                               dbd->db_table[DBIF_IDX_DEVINO].db,
                                               devino,
-                                              (reindex) ? DB_CREATE : 0))
+                                              reindex ? DB_CREATE : 0))
         != 0) {
         LOG(log_error, logtype_cnid, "Failed to associate devino database: %s",db_strerror(ret));
         return -1;

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -281,7 +281,7 @@ cups_get_printer_ppd ( char * name)
 	cupsFilePuts(fp, "*FileSystem: False\n");
 	cupsFilePuts(fp, "*PCFileName: \"ippeve.ppd\"\n");
 
-	if ((dests != NULL))
+	if (dests != NULL)
 		strcpy(make, make_model);
 	else
 		strcpy(make, "Unknown Printer");

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -56,7 +56,7 @@ static  int home_passwd(const struct passwd *pwd,
   struct stat st;
   int fd, i;
 
-  if ( (fd = open(path, (set) ? O_WRONLY : O_RDONLY)) < 0 ) {
+  if ( (fd = open(path, set ? O_WRONLY : O_RDONLY)) < 0 ) {
     LOG(log_error, logtype_uams, "Failed to open %s", path);
     return AFPERR_ACCESS;
   }
@@ -141,7 +141,7 @@ static int afppasswd(const struct passwd *pwd,
       return AFPERR_MISC;
   }
 
-  if ((fp = fopen(path, (set) ? "r+" : "r")) == NULL) {
+  if ((fp = fopen(path, set ? "r+" : "r")) == NULL) {
     LOG(log_error, logtype_uams, "Failed to open %s", path);
     return AFPERR_ACCESS;
   }

--- a/libatalk/adouble/ad_attr.c
+++ b/libatalk/adouble/ad_attr.c
@@ -128,7 +128,7 @@ int ad_setid (struct adouble *adp, const dev_t dev, const ino_t ino , const uint
         EC_FAIL;
     }
 
-    if ((adp->ad_options & ADVOL_NODEV)) {
+    if (adp->ad_options & ADVOL_NODEV) {
         memset(ade, 0, sizeof(dev_t));
     } else {
         memcpy(ade, &dev, sizeof(dev_t));

--- a/libatalk/adouble/ad_flush.c
+++ b/libatalk/adouble/ad_flush.c
@@ -399,7 +399,7 @@ static int ad_flush_rf(struct adouble *ad)
 
     LOG(log_debug, logtype_ad, "ad_flush_rf(%s)", adflags2logstr(ad->ad_adflags));
 
-    if ((ad->ad_rfp->adf_flags & O_RDWR)) {
+    if (ad->ad_rfp->adf_flags & O_RDWR) {
         if (ad_getentryoff(ad, ADEID_RFORK)) {
             if (ad->ad_rlen > 0xffffffff)
                 ad_setentrylen(ad, ADEID_RFORK, 0xffffffff);

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -892,7 +892,7 @@ static int ad_chown(const char *path, struct stat *stbuf)
 
     if (default_uid != (uid_t)-1) {
         /* we are root (admin) */
-        id = (default_uid)?default_uid:stbuf->st_uid;
+        id = default_uid?default_uid:stbuf->st_uid;
         ret = lchown( path, id, stbuf->st_gid );
     }
 #endif
@@ -1046,9 +1046,9 @@ static int ad_open_df(const char *path, int adflags, mode_t mode, struct adouble
     oflags = ad2openflags(ad, ADFLAGS_DF, adflags);
 
     admode = mode;
-    if ((adflags & ADFLAGS_CREATE)) {
+    if (adflags & ADFLAGS_CREATE) {
         st_invalid = ad_mode_st(path, &admode, &st_dir);
-        if ((ad->ad_options & ADVOL_UNIXPRIV))
+        if (ad->ad_options & ADVOL_UNIXPRIV)
             admode = mode;
     }
 
@@ -1165,14 +1165,14 @@ static int ad_open_hf_v2(const char *path, int adflags, mode_t mode, struct adou
             admode = mode;
             errno = 0;
             st_invalid = ad_mode_st(ad_p, &admode, &st_dir);
-            if ((ad->ad_options & ADVOL_UNIXPRIV))
+            if (ad->ad_options & ADVOL_UNIXPRIV)
                 admode = mode;
             admode = ad_hf_mode(admode);
             if (errno == ENOENT) {
                 EC_NEG1_LOG( ad->ad_ops->ad_mkrf(ad_p) );
                 admode = mode;
                 st_invalid = ad_mode_st(ad_p, &admode, &st_dir);
-                if ((ad->ad_options & ADVOL_UNIXPRIV))
+                if (ad->ad_options & ADVOL_UNIXPRIV)
                     admode = mode;
                 admode = ad_hf_mode(admode);
             }
@@ -1206,7 +1206,7 @@ static int ad_open_hf_v2(const char *path, int adflags, mode_t mode, struct adou
     adf_lock_init(ad->ad_mdp);
     ad->ad_mdp->adf_refcount = 1;
 
-    if ((ad->ad_mdp->adf_flags & ( O_TRUNC | O_CREAT ))) {
+    if (ad->ad_mdp->adf_flags & ( O_TRUNC | O_CREAT )) {
         /* This is a new adouble header file, create it */
         EC_NEG1_LOG( new_ad_header(ad, path, pst, adflags) );
         ad_flush(ad);
@@ -2268,19 +2268,19 @@ mode_t ad_hf_mode(mode_t mode)
 {
     mode &= ~(S_IXUSR | S_IXGRP | S_IXOTH);
     /* fnctl lock need write access */
-    if ((mode & S_IRUSR))
+    if (mode & S_IRUSR)
         mode |= S_IWUSR;
-    if ((mode & S_IRGRP))
+    if (mode & S_IRGRP)
         mode |= S_IWGRP;
-    if ((mode & S_IROTH))
+    if (mode & S_IROTH)
         mode |= S_IWOTH;
 
     /* if write mode set add read mode */
-    if ((mode & S_IWUSR))
+    if (mode & S_IWUSR)
         mode |= S_IRUSR;
-    if ((mode & S_IWGRP))
+    if (mode & S_IWGRP)
         mode |= S_IRGRP;
-    if ((mode & S_IWOTH))
+    if (mode & S_IWOTH)
         mode |= S_IROTH;
 
     return mode;

--- a/libatalk/cnid/cnid.c
+++ b/libatalk/cnid/cnid.c
@@ -179,7 +179,7 @@ struct _cnid_db *cnid_open(struct vol *vol, char *type, int flags)
 /* ------------------- */
 static void block_signal(uint32_t flags)
 {
-    if ((flags & CNID_FLAG_BLOCK)) {
+    if (flags & CNID_FLAG_BLOCK) {
         pthread_sigmask(SIG_BLOCK, &sigblockset, NULL);
     }
 }
@@ -187,7 +187,7 @@ static void block_signal(uint32_t flags)
 /* ------------------- */
 static void unblock_signal(uint32_t flags)
 {
-    if ((flags & CNID_FLAG_BLOCK)) {
+    if (flags & CNID_FLAG_BLOCK) {
         pthread_sigmask(SIG_UNBLOCK, &sigblockset, NULL);
     }
 }

--- a/libatalk/cnid/dbd/cnid_dbd.c
+++ b/libatalk/cnid/dbd/cnid_dbd.c
@@ -197,7 +197,7 @@ static int write_vec(int fd, struct iovec *iov, ssize_t towrite, int vecs)
     int sleepsecs;
 
     while (1) {
-        if (((len = writev(fd, iov, vecs)) == -1 && errno == EINTR))
+        if ((len = writev(fd, iov, vecs)) == -1 && errno == EINTR)
             continue;
 
         if ((! slept) && len == -1 && errno == EAGAIN) {

--- a/libatalk/unicode/charcnv.c
+++ b/libatalk/unicode/charcnv.c
@@ -756,11 +756,11 @@ static size_t pull_charset_flags (charset_t from_set, charset_t to_set, charset_
             atalk_iconv(descriptor, &inbuf, &i_len, &outbuf, &o_len) == (size_t)-1) {
             if (errno == EILSEQ || errno == EINVAL) {
                 errno = EILSEQ;
-                if ((option & CONV_IGNORE)) {
+                if (option & CONV_IGNORE) {
                     *flags |= CONV_REQMANGLE;
                     return destlen - o_len;
                 }
-                if ((option & CONV__EILSEQ)) {
+                if (option & CONV__EILSEQ) {
                     if (o_len < 2) {
                         errno = E2BIG;
                         goto end;
@@ -782,7 +782,7 @@ static size_t pull_charset_flags (charset_t from_set, charset_t to_set, charset_
             i_len = j, j = 0;
 
             if (escch == ':') {
-                if ((option & CONV_UNESCAPEHEX)) {
+                if (option & CONV_UNESCAPEHEX) {
                     /* treat it as a CAP hex encoded char */
                     char h[MAXPATHLEN];
                     size_t hlen = 0;
@@ -807,7 +807,7 @@ static size_t pull_charset_flags (charset_t from_set, charset_t to_set, charset_
                     } else {
                         /* We have an invalid :xx sequence */
                         errno = EILSEQ;
-                        if ((option & CONV_IGNORE)) {
+                        if (option & CONV_IGNORE) {
                             *flags |= CONV_REQMANGLE;
                             return destlen - o_len;
                         }
@@ -928,11 +928,11 @@ static size_t push_charset_flags (charset_t to_set, charset_t cap_set, char* src
         while (i_len > 0 &&
                atalk_iconv(descriptor, &inbuf, &i_len, &outbuf, &o_len) == (size_t)-1) {
             if (errno == EILSEQ) {
-                if ((option & CONV_IGNORE)) {
+                if (option & CONV_IGNORE) {
                     *flags |= CONV_REQMANGLE;
                     return destlen - o_len;
                 }
-                if ((option & CONV_ESCAPEHEX)) {
+                if (option & CONV_ESCAPEHEX) {
                     const size_t bufsiz = o_len / 3 + 1;
                     char *buf = malloc(bufsiz);
                     size_t buflen;

--- a/libatalk/util/bprint.c
+++ b/libatalk/util/bprint.c
@@ -36,7 +36,7 @@ void bprint( char *data, int len )
 	    aout[ i ] = '.';
 	}
 
-	xout[ (i*3) ] = hexdig[ ( *data & 0xf0 ) >> 4 ];
+	xout[ i*3 ] = hexdig[ ( *data & 0xf0 ) >> 4 ];
 	xout[ (i*3) + 1 ] = hexdig[ *data & 0x0f ];
 	xout[ (i*3) + 2 ] = ' ';
     }

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -1106,35 +1106,35 @@ static struct vol *creatvol(AFPObj *obj,
         volume->v_flags |= AFPVOL_RO;
 #endif
 
-    if ((volume->v_flags & AFPVOL_NODEV))
+    if (volume->v_flags & AFPVOL_NODEV)
         volume->v_ad_options |= ADVOL_NODEV;
-    if ((volume->v_flags & AFPVOL_UNIX_PRIV))
+    if (volume->v_flags & AFPVOL_UNIX_PRIV)
         volume->v_ad_options |= ADVOL_UNIXPRIV;
-    if ((volume->v_flags & AFPVOL_INV_DOTS))
+    if (volume->v_flags & AFPVOL_INV_DOTS)
         volume->v_ad_options |= ADVOL_INVDOTS;
-    if ((volume->v_flags & AFPVOL_FOLLOWSYM))
+    if (volume->v_flags & AFPVOL_FOLLOWSYM)
         volume->v_ad_options |= ADVOL_FOLLO_SYML;
-    if ((volume->v_flags & AFPVOL_RO))
+    if (volume->v_flags & AFPVOL_RO)
         volume->v_ad_options |= ADVOL_RO;
-    if ((volume->v_flags & AFPVOL_FORCE_STICKY_XATTR))
+    if (volume->v_flags & AFPVOL_FORCE_STICKY_XATTR)
         volume->v_ad_options |= ADVOL_FORCE_STICKY_XATTR;
 
     /* Mac to Unix conversion flags*/
-    if ((volume->v_flags & AFPVOL_EILSEQ))
+    if (volume->v_flags & AFPVOL_EILSEQ)
         volume->v_mtou_flags |= CONV__EILSEQ;
 
-    if ((volume->v_casefold & AFPVOL_MTOUUPPER))
+    if (volume->v_casefold & AFPVOL_MTOUUPPER)
         volume->v_mtou_flags |= CONV_TOUPPER;
-    else if ((volume->v_casefold & AFPVOL_MTOULOWER))
+    else if (volume->v_casefold & AFPVOL_MTOULOWER)
         volume->v_mtou_flags |= CONV_TOLOWER;
 
     /* Unix to Mac conversion flags*/
     volume->v_utom_flags = CONV_IGNORE;
-    if ((volume->v_casefold & AFPVOL_UTOMUPPER))
+    if (volume->v_casefold & AFPVOL_UTOMUPPER)
         volume->v_utom_flags |= CONV_TOUPPER;
-    else if ((volume->v_casefold & AFPVOL_UTOMLOWER))
+    else if (volume->v_casefold & AFPVOL_UTOMLOWER)
         volume->v_utom_flags |= CONV_TOLOWER;
-    if ((volume->v_flags & AFPVOL_EILSEQ))
+    if (volume->v_flags & AFPVOL_EILSEQ)
         volume->v_utom_flags |= CONV__EILSEQ;
 
     /* suffix for mangling use (lastvid + 1)   */

--- a/libatalk/vfs/ea_sys.c
+++ b/libatalk/vfs/ea_sys.c
@@ -73,7 +73,7 @@ int sys_get_easize(VFS_FUNC_ARGS_EA_GETSIZE)
 	LOG(log_debug, logtype_afpd, "sys_get_easize(%s): file is already opened", uname);
 	ret = sys_fgetxattr(fd, attruname, rbuf +4, 0);
     } else {
-	if ((oflag & O_NOFOLLOW) ) {
+	if (oflag & O_NOFOLLOW ) {
     	    ret = sys_lgetxattr(uname, attruname, rbuf +4, 0);
 	}
 	else {
@@ -201,7 +201,7 @@ int sys_get_eacontent(VFS_FUNC_ARGS_EA_GETCONTENT)
 	LOG(log_debug, logtype_afpd, "sys_get_eacontent(%s): file is already opened", uname);
 	ret = sys_fgetxattr(fd, attruname, rbuf +4, maxreply + extra);
     } else {
-	if ((oflag & O_NOFOLLOW) ) {
+	if (oflag & O_NOFOLLOW ) {
     	    ret = sys_lgetxattr(uname, attruname, rbuf +4, maxreply + extra);
 	}
 	else {
@@ -295,7 +295,7 @@ int sys_list_eas(VFS_FUNC_ARGS_EA_LIST)
 	LOG(log_debug, logtype_afpd, "sys_list_eas(%s): file is already opened", uname);
 	ret = sys_flistxattr(fd, uname, buf, ATTRNAMEBUFSIZ);
     } else {
-	if ((oflag & O_NOFOLLOW)) {
+	if (oflag & O_NOFOLLOW) {
     	    ret = sys_llistxattr(uname, buf, ATTRNAMEBUFSIZ);
 	}
 	else {
@@ -401,9 +401,9 @@ int sys_set_ea(VFS_FUNC_ARGS_EA_SET)
     eabuf[attrsize] = 0;
 
     attr_flag = 0;
-    if ((oflag & O_CREAT) )
+    if (oflag & O_CREAT)
         attr_flag |= XATTR_CREATE;
-    else if ((oflag & O_TRUNC) )
+    else if (oflag & O_TRUNC)
         attr_flag |= XATTR_REPLACE;
 
     if (vol->v_flags & AFPVOL_EA_SAMBA) {
@@ -415,7 +415,7 @@ int sys_set_ea(VFS_FUNC_ARGS_EA_SET)
 	LOG(log_debug, logtype_afpd, "sys_set_ea(%s): file is already opened", uname);
 	ret = sys_fsetxattr(fd, attruname, eabuf, attrsize, attr_flag);
     } else {
-	if ((oflag & O_NOFOLLOW) ) {
+	if (oflag & O_NOFOLLOW) {
    	    ret = sys_lsetxattr(uname, attruname, eabuf, attrsize,attr_flag);
 	}
 	else {
@@ -494,7 +494,7 @@ int sys_remove_ea(VFS_FUNC_ARGS_EA_REMOVE)
 	LOG(log_debug, logtype_afpd, "sys_remove_ea(%s): file is already opened", uname);
 	ret = sys_fremovexattr(fd, uname, attruname);
     } else {
-	if ((oflag & O_NOFOLLOW) ) {
+	if (oflag & O_NOFOLLOW) {
     	    ret = sys_lremovexattr(uname, attruname);
 	}
 	else {

--- a/test/testsuite/Error.c
+++ b/test/testsuite/Error.c
@@ -506,7 +506,7 @@ int dt;
 	}
 
 	/* FIXME afp_errno in file.c */
-	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
+	if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
 		ret = FPCreateID(Conn,vol, DIRDID_ROOT, name1);
 		if (ret != ntohl(AFPERR_NOOBJ)) {
 			test_failed();
@@ -594,7 +594,7 @@ int  dt;
 
 	FAIL (ntohl(AFPERR_ACCESS) != FPCopyFile(Conn, vol, DIRDID_ROOT, vol, DIRDID_ROOT, name1, "", name))
 
-	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
+	if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
 		ret = FPCreateID(Conn,vol, DIRDID_ROOT, name1);
 		if (ret != ntohl(AFPERR_ACCESS)) {
 			test_failed();
@@ -703,7 +703,7 @@ int  dt;
 	}
 
 	FAIL (ntohl(AFPERR_BADTYPE) != FPCopyFile(Conn, vol, DIRDID_ROOT, vol, DIRDID_ROOT, name1, "", name))
-	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
+	if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
 		FAIL (ntohl(AFPERR_BADTYPE) != FPCreateID(Conn,vol, DIRDID_ROOT, name1))
 	}
 
@@ -799,7 +799,7 @@ int  dt;
 		test_failed();
 	}
 
-	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
+	if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
 		FAIL (ntohl(AFPERR_BADTYPE) != FPCreateID(Conn,vol, dir, ""))
 	}
 
@@ -901,7 +901,7 @@ int  dt;
 	FAIL (err != FPCopyFile(Conn, vol, dir, vol, DIRDID_ROOT, name1, "", name))
 
 	/* FIXME afp_errno in file.c */
-	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
+	if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
 		if (err != FPCreateID(Conn,vol, dir, name1)) {
 			test_failed();
 		}
@@ -975,7 +975,7 @@ int  dt;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 
 	/* -------------------- */
-	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
+	if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
 		ret = FPCreateID(Conn,vol, DIRDID_ROOT_PARENT, "");
 		FAIL (htonl(AFPERR_NOOBJ) != ret && htonl(AFPERR_PARAM) != ret )
 	}
@@ -1130,7 +1130,7 @@ int  dt;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 
 	/* -------------------- */
-	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
+	if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
 		ret = FPCreateID(Conn,vol, tdir, tname);
 		if (htonl(AFPERR_NOOBJ) != ret && htonl(AFPERR_PARAM) != ret ) {
 			test_failed();
@@ -1268,7 +1268,7 @@ int  dt;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 
 	/* -------------------- */
-	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
+	if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
 		ret = FPCreateID(Conn,vol, tdir, tname);
 		FAIL (htonl(AFPERR_PARAM) != ret)
 	}
@@ -1439,7 +1439,7 @@ int  dt;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 
 	/* -------------------- */
-	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
+	if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
 		ret = FPCreateID(Conn,vol, tdir, tname);
 		if (htonl(AFPERR_NOOBJ) != ret && htonl(AFPERR_PARAM) != ret ) {
 			test_failed();

--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -594,7 +594,7 @@ static int create_trash(CONN *conn, uint16_t vol)
 {
 char *trash = "Network Trash Folder";
 int  ofs =  3 * sizeof( uint16_t );
-uint16_t bitmap = (DIRPBIT_ATTR)| (1<<DIRPBIT_FINFO)| (1<<DIRPBIT_CDATE) |
+uint16_t bitmap = DIRPBIT_ATTR | (1<<DIRPBIT_FINFO)| (1<<DIRPBIT_CDATE) |
 					(1<<DIRPBIT_BDATE) | (1<<DIRPBIT_MDATE)| (1<<DIRPBIT_UID) |
 	    			(1 << DIRPBIT_GID) |(1 << DIRPBIT_ACCESS);
 DSI *dsi;
@@ -664,7 +664,7 @@ int fork;
 static int set_perm(CONN *conn, uint16_t vol, int dir)
 {
 int  ofs =  3 * sizeof( uint16_t );
-uint16_t bitmap = (DIRPBIT_ATTR)| (1<<DIRPBIT_FINFO)| (1<<DIRPBIT_CDATE) |
+uint16_t bitmap = DIRPBIT_ATTR | (1<<DIRPBIT_FINFO)| (1<<DIRPBIT_CDATE) |
 					(1<<DIRPBIT_BDATE) | (1<<DIRPBIT_MDATE)| (1<<DIRPBIT_UID) |
 	    			(1 << DIRPBIT_GID) |(1 << DIRPBIT_ACCESS);
 DSI *dsi;
@@ -697,7 +697,7 @@ struct afp_filedir_parms filedir;
 static int write_access(CONN *conn, uint16_t  vol, int dir)
 {
 int  ofs =  3 * sizeof( uint16_t );
-uint16_t bitmap = (DIRPBIT_ATTR)| (1<<DIRPBIT_FINFO)| (1<<DIRPBIT_CDATE) |
+uint16_t bitmap = DIRPBIT_ATTR | (1<<DIRPBIT_FINFO)| (1<<DIRPBIT_CDATE) |
 					(1<<DIRPBIT_BDATE) | (1<<DIRPBIT_MDATE)| (1<<DIRPBIT_UID) |
 	    			(1 << DIRPBIT_GID) |(1 << DIRPBIT_ACCESS);
 DSI *dsi;

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -207,7 +207,7 @@ int dt;
 	FAIL (FPDelete(Conn, vol,  DIRDID_ROOT , name))
 
 	/* -------------------- */
-	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) ) {
+	if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
 		ret = FPCreateID(Conn,vol, tdir, tname);
 		if (htonl(AFPERR_NOOBJ) != ret && htonl(AFPERR_PARAM) != ret ) {
 			test_failed();

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -420,7 +420,7 @@ struct afp_filedir_parms filedir;
     action.sa_handler = pipe_handler;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
-    if ((sigaction(SIGPIPE, &action, NULL) < 0)) {
+    if (sigaction(SIGPIPE, &action, NULL) < 0) {
 		test_nottested();
 		goto fin;
     }
@@ -438,7 +438,7 @@ struct afp_filedir_parms filedir;
     action.sa_handler = SIG_DFL;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
-    if ((sigaction(SIGPIPE, &action, NULL) < 0)) {
+    if (sigaction(SIGPIPE, &action, NULL) < 0) {
 		test_nottested();
     }
 fin:
@@ -589,7 +589,7 @@ struct afp_filedir_parms filedir;
     action.sa_handler = pipe_handler;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
-    if ((sigaction(SIGPIPE, &action, NULL) < 0)) {
+    if (sigaction(SIGPIPE, &action, NULL) < 0) {
 		test_nottested();
 		goto fin;
     }
@@ -599,7 +599,7 @@ struct afp_filedir_parms filedir;
     action.sa_handler = SIG_DFL;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
-    if ((sigaction(SIGPIPE, &action, NULL) < 0)) {
+    if (sigaction(SIGPIPE, &action, NULL) < 0) {
 		test_nottested();
     }
 

--- a/test/testsuite/FPOpenFork.c
+++ b/test/testsuite/FPOpenFork.c
@@ -818,7 +818,7 @@ int nowhat = (type == OPENFORK_DATA)?ATTRBIT_ROPEN:ATTRBIT_DOPEN;
 		if (!(filedir.attr & what)) {
 			test_failed();
 		}
-		if ((filedir.attr & nowhat)) {
+		if (filedir.attr & nowhat) {
 			test_failed();
 		}
 	}
@@ -836,7 +836,7 @@ int nowhat = (type == OPENFORK_DATA)?ATTRBIT_ROPEN:ATTRBIT_DOPEN;
 		if (!(filedir.attr & what)) {
 			test_failed();
 		}
-		if ((filedir.attr & nowhat)) {
+		if (filedir.attr & nowhat) {
 			test_failed();
 		}
 	}
@@ -851,7 +851,7 @@ int nowhat = (type == OPENFORK_DATA)?ATTRBIT_ROPEN:ATTRBIT_DOPEN;
 		if (!(filedir.attr & what)) {
 			test_failed();
 		}
-		if ((filedir.attr & nowhat)) {
+		if (filedir.attr & nowhat) {
 			test_failed();
 		}
 	}
@@ -863,10 +863,10 @@ int nowhat = (type == OPENFORK_DATA)?ATTRBIT_ROPEN:ATTRBIT_DOPEN;
 	else {
 		filedir.isdir = 0;
 		afp_filedir_unpack(&filedir, dsi2->data +ofs, bitmap, 0);
-		if ((filedir.attr & what)) {
+		if (filedir.attr & what) {
 			test_failed();
 		}
-		if ((filedir.attr & nowhat)) {
+		if (filedir.attr & nowhat) {
 			test_failed();
 		}
 	}

--- a/test/testsuite/FPRead.c
+++ b/test/testsuite/FPRead.c
@@ -525,7 +525,7 @@ fin:
     action.sa_handler = SIG_DFL;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
-    if ((sigaction(SIGALRM, &action, NULL) < 0)) {
+    if (sigaction(SIGALRM, &action, NULL) < 0) {
 		test_nottested();
     }
 	sleep(1);

--- a/test/testsuite/FPSetDirParms.c
+++ b/test/testsuite/FPSetDirParms.c
@@ -106,7 +106,7 @@ int  ofs =  3 * sizeof( uint16_t );
 int pdir = 0;
 int rdir = 0;
 struct afp_filedir_parms filedir;
-uint16_t bitmap = (DIRPBIT_ATTR)| (1<<DIRPBIT_FINFO)| (1<<DIRPBIT_CDATE) |
+uint16_t bitmap = DIRPBIT_ATTR | (1<<DIRPBIT_FINFO)| (1<<DIRPBIT_CDATE) |
 					(1<<DIRPBIT_BDATE) | (1<<DIRPBIT_MDATE)| (1<<DIRPBIT_UID) |
 	    			(1 << DIRPBIT_GID) |(1 << DIRPBIT_ACCESS);
 uint16_t vol = VolID;
@@ -515,7 +515,7 @@ DSI *dsi;
 
 	ENTER_TEST
 
-	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
+	if (get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV) {
         test_skipped(T_NO_UNIX_PREV);
 		goto test_exit;
 	}

--- a/test/testsuite/FPSetFileDirParms.c
+++ b/test/testsuite/FPSetFileDirParms.c
@@ -593,7 +593,7 @@ DSI *dsi;
 
 	ENTER_TEST
 
-	if ((get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
+	if (get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV) {
 		test_skipped(T_NO_UNIX_PREV);
 		goto test_exit;
 	}

--- a/test/testsuite/FPzzz.c
+++ b/test/testsuite/FPzzz.c
@@ -44,7 +44,7 @@ uint32_t time= 12345;
     action.sa_handler = pipe_handler;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
-    if ((sigaction(SIGPIPE, &action, NULL) < 0)) {
+    if (sigaction(SIGPIPE, &action, NULL) < 0) {
 		test_nottested();
 		goto test_exit;
     }
@@ -97,7 +97,7 @@ fin:
     action.sa_handler = SIG_DFL;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
-    if ((sigaction(SIGPIPE, &action, NULL) < 0)) {
+    if (sigaction(SIGPIPE, &action, NULL) < 0) {
 		test_nottested();
     }
 test_exit:
@@ -133,7 +133,7 @@ uint32_t time= 12345;
     action.sa_handler = pipe_handler;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
-    if ((sigaction(SIGPIPE, &action, NULL) < 0)) {
+    if (sigaction(SIGPIPE, &action, NULL) < 0) {
 		test_nottested();
 		goto test_exit;
     }
@@ -183,7 +183,7 @@ fin:
     action.sa_handler = SIG_DFL;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
-    if ((sigaction(SIGPIPE, &action, NULL) < 0)) {
+    if (sigaction(SIGPIPE, &action, NULL) < 0) {
 		test_nottested();
     }
 test_exit:
@@ -219,7 +219,7 @@ int sock;
     action.sa_handler = pipe_handler;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
-    if ((sigaction(SIGPIPE, &action, NULL) < 0)) {
+    if (sigaction(SIGPIPE, &action, NULL) < 0) {
 		test_nottested();
 		goto test_exit;
     }
@@ -234,7 +234,7 @@ fin:
     action.sa_handler = SIG_DFL;
     sigemptyset(&action.sa_mask);
     action.sa_flags = SA_RESTART;
-    if ((sigaction(SIGPIPE, &action, NULL) < 0)) {
+    if (sigaction(SIGPIPE, &action, NULL) < 0) {
 		test_nottested();
     }
 test_exit:

--- a/test/testsuite/Utf8.c
+++ b/test/testsuite/Utf8.c
@@ -877,7 +877,7 @@ uint16_t vol = VolID;
 		goto test_exit;
 	}
 
-	if ( (get_vol_attrib(vol) & VOLPBIT_ATTR_UTF8)) {
+	if (get_vol_attrib(vol) & VOLPBIT_ATTR_UTF8) {
 		test_failed();
 	}
 

--- a/test/testsuite/afparg_FPfuncs.c
+++ b/test/testsuite/afparg_FPfuncs.c
@@ -82,7 +82,7 @@ void FPLockrw_arg(char **argv)
 
     action.sa_handler = handler;
     sigemptyset(&action.sa_mask);
-    if ((sigaction(SIGINT, &action, NULL) < 0)) {
+    if (sigaction(SIGINT, &action, NULL) < 0) {
 		test_nottested();
 		goto test_exit;
     }
@@ -124,7 +124,7 @@ void FPLockw_arg(char **argv)
 
     action.sa_handler = handler;
     sigemptyset(&action.sa_mask);
-    if ((sigaction(SIGINT, &action, NULL) < 0)) {
+    if (sigaction(SIGINT, &action, NULL) < 0) {
 		test_nottested();
 		goto test_exit;
     }

--- a/test/testsuite/afpcli.c
+++ b/test/testsuite/afpcli.c
@@ -958,7 +958,7 @@ DSI *dsi;
 		ofs += sizeof(result);
 		result = ntohs(result);
 		/* XXXX need to fully parse this stuff */
-		if ((result & (1<<VOLPBIT_ATTR))) {
+		if (result & (1<<VOLPBIT_ATTR)) {
 		    /* volume attribute  */
 		    memcpy(&result, dsi->commands, sizeof(result));
 		    ofs += sizeof(result);
@@ -1160,7 +1160,7 @@ void afp_filedir_unpack(struct afp_filedir_parms *filedir, unsigned char *b, uin
 	unsigned char *beg = b;
 
     isdir = filedir->isdir;
-	bitmap = (isdir)?rdbitmap:rfbitmap;
+	bitmap = isdir?rdbitmap:rfbitmap;
 	while (bitmap != 0) {
 		while (( bitmap & 1 ) == 0 ) {
 			bitmap = bitmap>>1;
@@ -1289,7 +1289,7 @@ int afp_filedir_pack(unsigned char *b, struct afp_filedir_parms *filedir, uint16
 	unsigned char *u_ofs = NULL;
 
     isdir = filedir->isdir;
-	bitmap = (isdir)?rdbitmap:rfbitmap;
+	bitmap = isdir?rdbitmap:rfbitmap;
 	while (bitmap != 0) {
 		while (( bitmap & 1 ) == 0 ) {
 			bitmap = bitmap>>1;
@@ -1790,7 +1790,7 @@ DSI *dsi;
 	ofs += sizeof(did);
 
     ofs = FPset_name(conn, ofs, name);
-	if ((ofs & 1))
+	if (ofs & 1)
 	    ofs++;
 	len = strlen(cmt);
 	dsi->commands[ofs++] = len;

--- a/test/testsuite/afpcmd.c
+++ b/test/testsuite/afpcmd.c
@@ -1559,7 +1559,7 @@ DSI *dsi;
 	dsi = &conn->dsi;
 
 	if (!Quiet) {
-		fprintf(stdout,"[%s] Create File %s Vol %d did : 0x%x <%s>\n", __func__, (type )?"HARD":"SOFT", vol, ntohl(did), name);
+		fprintf(stdout,"[%s] Create File %s Vol %d did : 0x%x <%s>\n", __func__, type?"HARD":"SOFT", vol, ntohl(did), name);
 	}
 	ret = AFPCreateFile(conn,vol, type, did , name);
 	dump_header(dsi);
@@ -1679,7 +1679,7 @@ DSI *dsi;
 	ofs += sizeof(bitmap);
 
 	ofs = FPset_name(conn, ofs, name);
-	if ((ofs & 1)) {
+	if (ofs & 1) {
 		ofs++;
 	}
 	ofs +=afp_filedir_pack(dsi->commands +ofs, dir, 0, bitmap);
@@ -1728,7 +1728,7 @@ DSI *dsi;
 	ofs += sizeof(bitmap);
 
 	ofs = FPset_name(conn, ofs, name);
-	if ((ofs & 1)) {
+	if (ofs & 1) {
 		ofs++;
 	}
 	ofs +=afp_filedir_pack(dsi->commands +ofs, fil, bitmap,0);
@@ -1849,7 +1849,7 @@ DSI *dsi;
 	ofs += sizeof(bitmap);
 
 	ofs = FPset_name(conn, ofs, name);
-	if ((ofs & 1)) {
+	if (ofs & 1) {
 		ofs++;
 	}
 	ofs +=afp_filedir_pack(dsi->commands +ofs, fil, bitmap,bitmap);

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -730,52 +730,52 @@ static char temp[4096];
 static char temp1[4096];
 
 	temp[0] = 0;
-	if ((BITERR_NOOBJ & bitmap)) {
+	if (BITERR_NOOBJ & bitmap) {
 	    sprintf(temp, "%d %s ", AFPERR_NOOBJ, afp_error(htonl(AFPERR_NOOBJ)));
 	}
-	if ((BITERR_NODIR & bitmap)) {
+	if (BITERR_NODIR & bitmap) {
 	    sprintf(temp1, "%d %s ", AFPERR_NODIR, afp_error(htonl(AFPERR_NODIR)));
 		strcat(temp, temp1);
 	}
 
-	if ((BITERR_PARAM & bitmap)) {
+	if (BITERR_PARAM & bitmap) {
 	    sprintf(temp1, "%d %s ", AFPERR_PARAM, afp_error(htonl(AFPERR_PARAM)));
 		strcat(temp, temp1);
 	}
 
-	if ((BITERR_BUSY & bitmap)) {
+	if (BITERR_BUSY & bitmap) {
 	    sprintf(temp1, "%d %s ", AFPERR_BUSY, afp_error(htonl(AFPERR_BUSY)));
 		strcat(temp, temp1);
 	}
-	if ((BITERR_BADTYPE & bitmap)) {
+	if (BITERR_BADTYPE & bitmap) {
 	    sprintf(temp1, "%d %s ", AFPERR_BADTYPE, afp_error(htonl(AFPERR_BADTYPE)));
 		strcat(temp, temp1);
 	}
-	if ((BITERR_NOITEM & bitmap)) {
+	if (BITERR_NOITEM & bitmap) {
 	    sprintf(temp1, "%d %s ", AFPERR_NOITEM, afp_error(htonl(AFPERR_NOITEM)));
 		strcat(temp, temp1);
 	}
-	if ((BITERR_DENYCONF & bitmap)) {
+	if (BITERR_DENYCONF & bitmap) {
 	    sprintf(temp1, "%d %s ", AFPERR_DENYCONF, afp_error(htonl(AFPERR_DENYCONF)));
 		strcat(temp, temp1);
 	}
-	if ((BITERR_NFILE & bitmap)) {
+	if (BITERR_NFILE & bitmap) {
 	    sprintf(temp1, "%d %s ", AFPERR_NFILE, afp_error(htonl(AFPERR_NFILE)));
 		strcat(temp, temp1);
 	}
-	if ((BITERR_ACCESS & bitmap)) {
+	if (BITERR_ACCESS & bitmap) {
 	    sprintf(temp1, "%d %s ", AFPERR_ACCESS, afp_error(htonl(AFPERR_ACCESS)));
 		strcat(temp, temp1);
 	}
-	if ((BITERR_NOID & bitmap)) {
+	if (BITERR_NOID & bitmap) {
 	    sprintf(temp1, "%d %s ", AFPERR_NOID, afp_error(htonl(AFPERR_NOID)));
 		strcat(temp, temp1);
 	}
-	if ((BITERR_BITMAP & bitmap)) {
+	if (BITERR_BITMAP & bitmap) {
 	    sprintf(temp1, "%d %s ", AFPERR_BITMAP, afp_error(htonl(AFPERR_BITMAP)));
 		strcat(temp, temp1);
 	}
-	if ((BITERR_MISC & bitmap)) {
+	if (BITERR_MISC & bitmap) {
 	    sprintf(temp1, "%d %s ", AFPERR_MISC, afp_error(htonl(AFPERR_MISC)));
 		strcat(temp, temp1);
 	}

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -259,7 +259,7 @@ int fd;
 
 	if (!Quiet) {
 		fprintf(stdout,"---------------------\n");
-		fprintf(stdout,"Create File %s Vol %d did : 0x%x <%s>\n\n", (type )?"HARD":"SOFT", vol, ntohl(did), name);
+		fprintf(stdout,"Create File %s Vol %d did : 0x%x <%s>\n\n", type?"HARD":"SOFT", vol, ntohl(did), name);
 	}
 	did = ntohl(did);
 	if (local_chdir(vol, did) < 0) {


### PR DESCRIPTION
No need for parentheses around statements when it doesn't make a difference to the logic.