### PR TITLE
Fix ad cp loss of FinderInfo

### DIFF
--- a/libatalk/vfs/ea_sys.c
+++ b/libatalk/vfs/ea_sys.c
@@ -599,9 +599,6 @@ int sys_ea_copyfile(VFS_FUNC_ARGS_COPYFILE)
 		if (!*name)
 			continue;
 
-        if (STRCMP(name, ==, AD_EA_META))
-            continue;
-
 #if defined(SOLARIS) && defined(HAVE_SYS_ATTR_H)
         /* Skip special attributes set by NFS server */
         if (!strcmp(name, VIEW_READONLY) || !strcmp(name, VIEW_READWRITE))


### PR DESCRIPTION
Do copy the Netatalk private EA during FPCopyFile calls. This was preventing the `ad cp` tool from copying vital information like FinderInfo. There is code elsewhere to update the CNID information in the newly created file. Fixes #2025.