### PR TITLE
Fix for CNID error with ad mv utility

### DIFF
--- a/bin/ad/ad_mv.c
+++ b/bin/ad/ad_mv.c
@@ -100,7 +100,7 @@ static void usage_mv(void)
         "Move files around within an AFP volume, updating the CNID\n"
         "database as needed. If either:\n"
         " - source or destination is not an AFP volume\n"
-        " - source volume != destinatio volume\n"
+        " - source volume != destination volume\n"
         "the files are copied and removed from the source.\n\n"
         "The following options are available:\n\n"
         "   -f   Do not prompt for confirmation before overwriting the destination\n"

--- a/bin/ad/ad_util.c
+++ b/bin/ad/ad_util.c
@@ -269,6 +269,7 @@ cnid_t cnid_for_paths_parent(const afpvol_t *vol,
 
     EC_NULL(rpath = rel_path_in_vol(path, vol->vol->v_path));
     EC_NULL(statpath = bfromcstr(vol->vol->v_path));
+    EC_ZERO(bconchar(statpath, '/'));
 
     l = bsplit(rpath, '/');
     if (l->qty == 1)


### PR DESCRIPTION
Adds back the missing slash in the path so lstat check doesn't fail and throw error. Fixes #2049