### PR TITLE
GitHub CI: Bump vmactions runner to FreeBSD 13.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -437,7 +437,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/freebsd-vm@v1.1.8
+        uses: vmactions/freebsd-vm@v1.1.9
         with:
           copyback: false
           prepare: |


### PR DESCRIPTION
The vmactions project has a 1.1.9 release available now