### PR TITLE
Improve and harden the FCE listener app

### DIFF
--- a/bin/misc/meson.build
+++ b/bin/misc/meson.build
@@ -1,45 +1,32 @@
-netacnv_sources = ['netacnv.c']
-
-loggertest_sources = ['logger_test.c']
-
-fce_sources = ['fce.c']
-
-afpldaptest_sources = ['uuidtest.c']
-
-misc_deps = []
-
 if have_iconv
-    misc_deps += iconv
+    executable(
+        'netacnv',
+        ['netacnv.c'],
+        include_directories: root_includes,
+        link_with: libatalk,
+        dependencies: [iconv],
+        install: false,
+    )
 endif
 
 executable(
-    'netacnv',
-    netacnv_sources,
-    include_directories: root_includes,
-    link_with: libatalk,
-    dependencies: [mysqlclient, misc_deps],
-    install: false,
-)
-
-executable(
     'logger_test',
-    loggertest_sources,
+    ['logger_test.c'],
     include_directories: root_includes,
     link_with: libatalk,
-    dependencies: [mysqlclient, misc_deps],
     install: false,
 )
 
 executable(
     'fce_listen',
-    fce_sources,
+    ['fce.c'],
     include_directories: root_includes,
     link_with: libatalk,
-    dependencies: [iniparser, mysqlclient, misc_deps],
+    dependencies: [iniparser],
     install: true,
 )
 
-afpldaptest_deps = [iniparser]
+afpldaptest_deps = [iniparser, ldap]
 
 if use_mysql_backend
     afpldaptest_deps += mysqlclient
@@ -48,10 +35,10 @@ endif
 if have_ldap
     executable(
         'afpldaptest',
-        afpldaptest_sources,
+        ['uuidtest.c'],
         include_directories: root_includes,
         link_with: libatalk,
-        dependencies: [afpldaptest_deps, ldap, misc_deps],
+        dependencies: [afpldaptest_deps],
         c_args: confdir,
         install: true,
         build_rpath: rpath_libdir,

--- a/bin/misc/meson.build
+++ b/bin/misc/meson.build
@@ -31,12 +31,12 @@ executable(
 )
 
 executable(
-    'fce',
+    'fce_listen',
     fce_sources,
     include_directories: root_includes,
     link_with: libatalk,
     dependencies: [iniparser, mysqlclient, misc_deps],
-    install: false,
+    install: true,
 )
 
 afpldaptest_deps = [iniparser]

--- a/doc/manpages/man1/afptest.1.md
+++ b/doc/manpages/man1/afptest.1.md
@@ -1,6 +1,6 @@
 # Name
 
-afp_lantest, afp_logintest, afp_spectest, afp_speedtest, afparg — AFP protocol tests
+afp_lantest, afp_logintest, afp_spectest, afp_speedtest, afparg, fce_listen — AFP protocol tests
 
 # Synopsis
 
@@ -13,6 +13,8 @@ afp_lantest, afp_logintest, afp_spectest, afp_speedtest, afparg — AFP protocol
 `afp_speedtest [-1234567aeiLnVvy] [-h host] [-p port] [-s volume] [-S volume2] [-u user] [-w password] [-n iterations] [-d size] [-q quantum] [-F file] [-f test]`
 
 `afparg [-1234567lVv] [-h host] [-p port] [-s volume] [-u user] [-w password] [-f command]`
+
+`fce_listen [-h host] [-p port]`
 
 # Description
 
@@ -43,6 +45,10 @@ handful of available test cases.
 **afparg**` is an AFP CLI client that takes a specific command with
 optional arguments, and sends a single action to the AFP server. This
 can be used for one-off troubleshooting or system administration.
+
+**fce_listen** is a simple listener for Netatalk's Filesystem Change Event
+(FCE) protocol. It will print out any UDP datagrams received from the AFP
+server.
 
 Please refer to the helptext of each tool for the precise use of each
 option.

--- a/doc/manpages/man1/meson.build
+++ b/doc/manpages/man1/meson.build
@@ -45,6 +45,7 @@ afptest_staticmans = [
     'afp_spectest.1',
     'afp_speedtest.1',
     'afparg.1',
+    'fce_listen.1',
 ]
 
 foreach man : afptest_staticmans


### PR DESCRIPTION
Among other things, this addresses the buffer overflow reported and demonstrated by hzshang in [SourceForge bug 671](https://sourceforge.net/p/netatalk/bugs/671/)

- Add -p option for setting custom port
- Strengthen validation of input data to avoid buffer overflows when recieved malformed datagrams
- Rename binary to fce_listen and install it
- Cover documentation in the afptest man page
- Consolidate misc binary dependencies