### PR TITLE
Update afp.conf examples with new volume name scheme

### DIFF
--- a/config/afp.conf.in
+++ b/config/afp.conf.in
@@ -8,9 +8,11 @@
 [Homes]
 basedir regex = @homedir@
 
-; [My AFP Volume]
+; [my volume]
 ; path = /path/to/volume
+; volume name = My AFP Volume
 
-; [My Time Machine Volume]
+; [my backup]
 ; path = /path/to/backup
 ; time machine = yes
+; volume name = My Backup Volume


### PR DESCRIPTION
The commented-out volume section examples now use the volume name option for case-sensitive names, while simplifying the section names for illustration.