### PR TITLE
meson: Introduce option for controlling state dir creation

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -89,7 +89,9 @@ if (
     )
 endif
 
-install_data('README', install_dir: localstatedir / 'netatalk/CNID')
+if get_option('with-statedir-creation')
+    install_data('README', install_dir: localstatedir / 'netatalk/CNID')
+endif
 
 if have_pam
     subdir('pam')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -166,6 +166,12 @@ option(
     description: 'Enable Spotlight support',
 )
 option(
+    'with-statedir-creation',
+    type: 'boolean',
+    value: true,
+    description: 'Create the Netatalk state directories if they do not exist',
+)
+option(
     'with-tcp-wrappers',
     type: 'boolean',
     value: true,


### PR DESCRIPTION
New option -Dwith-statedir-creation which is true by default. Set this to false if you don't want the built system to create the @localstatedir@/netatalk/CNID dir structure. This obviously also skips the installation of the
CNID README file.

This important for f.e. NixOS packaging where the package script itself will prepare the file system, including the localstatedir for CNID databases and server signature files.