### PR TITLE
meson: Option for controlling CUPS libdir path prefix and pap backend

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -49,13 +49,15 @@ endif
 
 cups_libdir = ''
 
-if host_os in ['netbsd']
+if get_option('with-cups-libdir-path') != ''
+    cups_libdir = get_option('with-cups-libdir-path')
+elif host_os in ['netbsd']
     cups_libdir = '/usr/pkg/libexec'
-elif host_os in ['linux']
+else
     cups_libdir = '/usr/lib'
 endif
 
-if have_appletalk and have_cups and cups_libdir != ''
+if have_appletalk and have_cups and get_option('with-cups-pap-backend')
     configure_file(
         input: 'pap.in',
         output: 'pap',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -46,6 +46,12 @@ option(
     description: 'Enable CUPS support',
 )
 option(
+    'with-cups-pap-backend',
+    type: 'boolean',
+    value: true,
+    description: 'Install the pap backend for CUPS',
+)
+option(
     'with-appletalk',
     type: 'boolean',
     value: false,
@@ -236,6 +242,12 @@ option(
     type: 'string',
     value: '',
     description: 'Set location of cracklib dictionary',
+)
+option(
+    'with-cups-libdir-path',
+    type: 'string',
+    value: '',
+    description: 'Set path to the prefix of the CUPS library directory',
 )
 option(
     'with-dbus-daemon-path',


### PR DESCRIPTION
The new -Dwith-cups-pap-backend boolean option, default true, controls whether to install the pap backend for CUPS or not. This is handy when you can't or won't install configuration files for other libraries on the system.

In addition, the new -Dwith-cups-libdir-path which takes a path defines the root path where CUPS library files are kept, used to install the pap backend into a cups/backend subdir.