### PR TITLE
meson: Generate Unicode lookup table sources before using them

### DIFF
--- a/libatalk/unicode/meson.build
+++ b/libatalk/unicode/meson.build
@@ -1,21 +1,5 @@
 subdir('charsets')
 
-unicode_sources = [
-    'charcnv.c',
-    'iconv.c',
-    'utf8.c',
-    'utf16_case.c',
-    'util_unistr.c',
-]
-
-libunicode = static_library(
-    'unicode',
-    unicode_sources,
-    include_directories: root_includes,
-    link_with: libcharsets,
-    install: false,
-)
-
 if get_option('with-unicode-data')
     unicode_dirs = [
         meson.current_source_dir(),
@@ -58,3 +42,19 @@ if get_option('with-unicode-data')
         error('Perl and Unicode data file required to generate case tables')
     endif
 endif
+
+unicode_sources = [
+    'charcnv.c',
+    'iconv.c',
+    'utf8.c',
+    'utf16_case.c',
+    'util_unistr.c',
+]
+
+libunicode = static_library(
+    'unicode',
+    unicode_sources,
+    include_directories: root_includes,
+    link_with: libcharsets,
+    install: false,
+)


### PR DESCRIPTION
The build system will attempt to build the unicode static library before generating some of the source code files used for the target. This is normally not a problem since we bundle pre-built sources. But in some packaging environments (notably Debian) we strip out the pre-built sources and rely on the source generation logic.

This fix reverses the sequence of those two actions.