### PR TITLE
docker: Tweak startup messages for DDP services

### DIFF
--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -203,10 +203,10 @@ fi
 
 # Configuring AppleTalk if enabled
 if [ -n "$ATALKD_INTERFACE" ]; then
-    echo "*** Configuring DDP"
+    echo "*** Configuring DDP services"
     echo "$ATALKD_INTERFACE $ATALKD_OPTIONS" > /usr/local/etc/atalkd.conf
     echo "cupsautoadd:op=root:" > /usr/local/etc/papd.conf
-    echo "*** Starting DDP services"
+    echo "*** Starting DDP services (this will take a minute)"
     cupsd
     atalkd
     papd


### PR DESCRIPTION
Brings back the notice that atalkd takes a good while to start up that fell off when rewriting the script to sh