### PR TITLE
Restore the author’s email address in pap shell script

### DIFF
--- a/config/pap.in
+++ b/config/pap.in
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2003-2017 Thomas Kaiser
+# Copyright 2003-2017 Thomas Kaiser <Thomas.Kaiser@phg-online.de>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Thomas Kaiser’s email address fell off when the header was reformatted for inclusion with netatalk