### PR TITLE
Consistently credit two authors with email address

### DIFF
--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Entry point script for netatalk docker container.
 # Copyright (C) 2023  Eric Harmon
-# Copyright (C) 2024-2025  Daniel Markstedt
+# Copyright (C) 2024-2025  Daniel Markstedt <daniel@mindani.net>
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License

--- a/contrib/webmin_module/delete_atalk.cgi
+++ b/contrib/webmin_module/delete_atalk.cgi
@@ -4,7 +4,7 @@
 #    Netatalk Webmin Module
 #    Copyright (C) 2000 Sven Mosimann/EcoLogic <sven.mosimann@ecologic.ch>
 #    Copyright (C) 2013 Ralph Boehme <sloowfranklin@gmail.com>
-#    Copyright (C) 2024 Daniel Markstedt <daniel@mindani>
+#    Copyright (C) 2024 Daniel Markstedt <daniel@mindani.net>
 #
 #    This program is free software; you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by

--- a/doc/po/AppleTalk.md.ja.po
+++ b/doc/po/AppleTalk.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/Compilation.md.ja.po
+++ b/doc/po/Compilation.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/Configuration.md.ja.po
+++ b/doc/po/Configuration.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/Installation.md.ja.po
+++ b/doc/po/Installation.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/Upgrading.md.ja.po
+++ b/doc/po/Upgrading.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/_Sidebar.md.ja.po
+++ b/doc/po/_Sidebar.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2025 Daniel Markstedt
+# Copyright (C) 2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/a2boot.8.md.ja.po
+++ b/doc/po/a2boot.8.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/ad.1.md.ja.po
+++ b/doc/po/ad.1.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/addump.1.md.ja.po
+++ b/doc/po/addump.1.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/aecho.1.md.ja.po
+++ b/doc/po/aecho.1.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/afp.conf.5.md.ja.po
+++ b/doc/po/afp.conf.5.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/afp_signature.conf.5.md.ja.po
+++ b/doc/po/afp_signature.conf.5.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/afp_voluuid.conf.5.md.ja.po
+++ b/doc/po/afp_voluuid.conf.5.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/afpd.8.md.ja.po
+++ b/doc/po/afpd.8.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/afpldaptest.1.md.ja.po
+++ b/doc/po/afpldaptest.1.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/afppasswd.1.md.ja.po
+++ b/doc/po/afppasswd.1.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/afpstats.1.md.ja.po
+++ b/doc/po/afpstats.1.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/afptest.1.md.ja.po
+++ b/doc/po/afptest.1.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/asip-status.1.md.ja.po
+++ b/doc/po/asip-status.1.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/atalk.4.md.ja.po
+++ b/doc/po/atalk.4.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/atalk_aton.3.md.ja.po
+++ b/doc/po/atalk_aton.3.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/atalkd.8.md.ja.po
+++ b/doc/po/atalkd.8.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/atalkd.conf.5.md.ja.po
+++ b/doc/po/atalkd.conf.5.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/cnid_dbd.8.md.ja.po
+++ b/doc/po/cnid_dbd.8.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/cnid_metad.8.md.ja.po
+++ b/doc/po/cnid_metad.8.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/dbd.1.md.ja.po
+++ b/doc/po/dbd.1.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/extmap.conf.5.md.ja.po
+++ b/doc/po/extmap.conf.5.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/getzones.1.md.ja.po
+++ b/doc/po/getzones.1.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/index.md.ja.po
+++ b/doc/po/index.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/macipgw.8.md.ja.po
+++ b/doc/po/macipgw.8.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/macusers.1.md.ja.po
+++ b/doc/po/macusers.1.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/nbp.1.md.ja.po
+++ b/doc/po/nbp.1.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/nbp_name.3.md.ja.po
+++ b/doc/po/nbp_name.3.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/netatalk.8.md.ja.po
+++ b/doc/po/netatalk.8.md.ja.po
@@ -1,8 +1,8 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
 # Copyright (C) 2015-2017 Eiichirou UDA
-# Copyright (C) 2015-2017 HAT
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2015-2017 HAT <hat@fa2.so-net.ne.jp>
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/pap.1.md.ja.po
+++ b/doc/po/pap.1.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/papd.8.md.ja.po
+++ b/doc/po/papd.8.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/papd.conf.5.md.ja.po
+++ b/doc/po/papd.conf.5.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/papstatus.8.md.ja.po
+++ b/doc/po/papstatus.8.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""

--- a/doc/po/timelord.8.md.ja.po
+++ b/doc/po/timelord.8.md.ja.po
@@ -1,6 +1,6 @@
 # Japanese translations for Netatalk documentation
 # Netatalk ドキュメントの日本語訳
-# Copyright (C) 2024-2025 Daniel Markstedt
+# Copyright (C) 2024-2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
 #
 msgid ""


### PR DESCRIPTION
When we have an email address on record, use it consistently when crediting in source file headers