### PR TITLE
docs: Improve grammar and layout in signature and UUID man pages

### DIFF
--- a/doc/manpages/man5/afp_signature.conf.5.md
+++ b/doc/manpages/man5/afp_signature.conf.5.md
@@ -4,34 +4,36 @@ afp_signature.conf — Configuration file used by afpd to specify server signatu
 
 # Description
 
-**afp_signature.conf** is the configuration file used by **afpd** to specify
-server signature automagically. The configuration lines are composed
+**afp_signature.conf** is the configuration file used by **afpd** to store
+a server signature automagically. The configuration lines are composed
 like:
 
-<"server-name"\> <hexa-string\>
+    "server-name" hexa-string
 
-The first field is server name. Server names must be quoted if they
+The first field is the server name. Server names must be quoted if they
 contain spaces. The second field is the hexadecimal string of 32
-characters for 16-bytes server signature.
+characters for a 16-byte server signature.
 
-The leading spaces and tabs are ignored. Blank lines are ignored. The
-lines prefixed with \# are ignored. The illegal lines are ignored.
+All leading spaces and tabs are ignored. Blank lines are ignored. The
+lines prefixed with \# are ignored. Any illegal lines are ignored.
 
 > **NOTE**
 
-> Server Signature is unique 16-bytes identifier used to prevent logging
-on to the same server twice.
+> The server signature is a unique 16-byte identifier used to prevent
+users from logging on to the same server twice.
 
-> Netatalk 2.0 and earlier generated server signature by using
-gethostid(). There was a problem that another servers have the same
-signature because the hostid is not unique enough.
+> Netatalk 2.0 and earlier generated a server signature by using
+`gethostid()`. This led to a problem where multiple servers could end up with
+the same signature because the hostid is not unique enough.
 
 > Current netatalk generates the signature from random numbers and saves
-it into afp_signature.conf. When starting next time, it is read from
-this file.
+it into afp_signature.conf upon initial startup. For subsequent starts, it is
+read from this file.
 
-> This file should not be thoughtlessly edited and be copied onto another
-server. If it wants to set the signature intentionally, use the option
+> This file should not be thoughtlessly edited or copied onto another
+server.
+
+> If you want to set the signature intentionally, use the option
 "signature =" in afp.conf. In this case, afp_signature.conf is not used.
 
 # Examples

--- a/doc/manpages/man5/afp_voluuid.conf.5.md
+++ b/doc/manpages/man5/afp_voluuid.conf.5.md
@@ -4,17 +4,17 @@ afp_voluuid.conf — Configuration file used by afpd to specify UUID for AFP vol
 
 # Description
 
-**afp_voluuid.conf** is the configuration file used by **afpd** to specify
+**afp_voluuid.conf** is the configuration file used by **afpd** to store
 UUID of all AFP volumes. The configuration lines are composed like:
 
-<"volume-name"\> <uuid-string\>
+    "volume-name" "uuid-string"
 
-The first field is volume name. Volume names must be quoted if they
+The first field is the volume name. Volume names must be quoted if they
 contain spaces. The second field is the 36 character hexadecimal ASCII
 string representation of a UUID.
 
-The leading spaces and tabs are ignored. Blank lines are ignored. The
-lines prefixed with \# are ignored. The illegal lines are ignored.
+All leading spaces and tabs are ignored. Blank lines are ignored. The
+lines prefixed with \# are ignored. Any illegal lines are ignored.
 
 > **NOTE**
 
@@ -23,7 +23,7 @@ disambiguation of Time Machine volumes.
 
 > It is also used by the MySQL CNID backend.
 
-> This file should not be thoughtlessly edited and be copied onto another
+> This file should not be thoughtlessly edited or copied onto another
 server.
 
 # Examples

--- a/doc/po/afp_signature.conf.5.md.ja.po
+++ b/doc/po/afp_signature.conf.5.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 00:07+0100\n"
+"POT-Creation-Date: 2025-04-06 19:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -43,7 +43,7 @@ msgstr "名前"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
 #: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
@@ -61,10 +61,10 @@ msgid "Description"
 msgstr "説明"
 
 #. type: Title #
-#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:85
+#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:91
 #: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:46
-#: manpages/man5/afp_signature.conf.5.md:44
-#: manpages/man5/afp_voluuid.conf.5.md:38 manpages/man8/papd.8.md:133
+#: manpages/man5/afp_signature.conf.5.md:46
+#: manpages/man5/afp_voluuid.conf.5.md:38 manpages/man8/papd.8.md:132
 #, no-wrap
 msgid "See also"
 msgstr "参照"
@@ -73,19 +73,19 @@ msgstr "参照"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:95 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
 #: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
-#: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:32
+#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1362
+#: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
 #: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
-#: manpages/man8/papd.8.md:137 manpages/man8/papstatus.8.md:53
+#: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
 msgid "Author"
@@ -95,18 +95,18 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:97 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
 #: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:46 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
-#: manpages/man5/atalkd.conf.5.md:106 manpages/man5/extmap.conf.5.md:34
+#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1364
+#: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
 #: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:139
+#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"
@@ -114,23 +114,23 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 
 #. type: Title #
 #: manpages/man1/aecho.1.md:24 manpages/man1/afppasswd.1.md:26
-#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:50
+#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:56
 #: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
-#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/atalkd.conf.5.md:82
-#: manpages/man5/extmap.conf.5.md:18 manpages/man5/papd.conf.5.md:91
-#: manpages/man8/macipgw.8.md:79
+#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:39
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1307
+#: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
+#: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
 msgid "Examples"
 msgstr "例"
 
 #. type: Plain text
 #: manpages/man1/afppasswd.1.md:20 manpages/man5/afp_signature.conf.5.md:21
-#: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:318
-#: manpages/man5/afp.conf.5.md:342 manpages/man5/afp.conf.5.md:355
-#: manpages/man5/afp.conf.5.md:370 manpages/man5/afp.conf.5.md:722
-#: manpages/man5/afp.conf.5.md:1048 manpages/man5/afp.conf.5.md:1173
-#: manpages/man5/afp.conf.5.md:1211 manpages/man8/papd.8.md:97
+#: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:339
+#: manpages/man5/afp.conf.5.md:363 manpages/man5/afp.conf.5.md:376
+#: manpages/man5/afp.conf.5.md:391 manpages/man5/afp.conf.5.md:694
+#: manpages/man5/afp.conf.5.md:1093 manpages/man5/afp.conf.5.md:1219
+#: manpages/man5/afp.conf.5.md:1257 manpages/man8/papd.8.md:96
 #: manual/Configuration.md:113
 #, no-wrap
 msgid "> **NOTE**\n"
@@ -149,23 +149,23 @@ msgstr ""
 #: manpages/man5/afp_signature.conf.5.md:10
 #, no-wrap
 msgid ""
-"**afp_signature.conf** is the configuration file used by **afpd** to specify\n"
-"server signature automagically. The configuration lines are composed\n"
+"**afp_signature.conf** is the configuration file used by **afpd** to store\n"
+"a server signature automagically. The configuration lines are composed\n"
 "like:\n"
 msgstr "**afp_signature.conf** はサーバシグネチャを魔法のように自動的に指定するために **afpd** が利用する設定ファイルである。設定行は以下のように構成される。\n"
 
 #. type: Plain text
 #: manpages/man5/afp_signature.conf.5.md:12
 #, no-wrap
-msgid "<\"server-name\"\\> <hexa-string\\>\n"
+msgid "    \"server-name\" hexa-string\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp_signature.conf.5.md:16
 msgid ""
-"The first field is server name. Server names must be quoted if they contain "
-"spaces. The second field is the hexadecimal string of 32 characters for 16-"
-"bytes server signature."
+"The first field is the server name. Server names must be quoted if they "
+"contain spaces. The second field is the hexadecimal string of 32 characters "
+"for a 16-byte server signature."
 msgstr ""
 "最初のフィールドはサーバ名である。 サーバ名がスペースを含む場合、それを引用符"
 "で囲まなければならない。第二のフィールドは16バイトのサーバシグネチャのための"
@@ -175,8 +175,8 @@ msgstr ""
 #: manpages/man5/afp_signature.conf.5.md:19
 #: manpages/man5/afp_voluuid.conf.5.md:18
 msgid ""
-"The leading spaces and tabs are ignored. Blank lines are ignored. The lines "
-"prefixed with \\# are ignored. The illegal lines are ignored."
+"All leading spaces and tabs are ignored. Blank lines are ignored. The lines "
+"prefixed with \\# are ignored. Any illegal lines are ignored."
 msgstr ""
 "先頭のスペースとタブは無視される。空行は無視される。頭に#が付いた行は無視され"
 "る。不正な行は無視される。"
@@ -185,47 +185,55 @@ msgstr ""
 #: manpages/man5/afp_signature.conf.5.md:24
 #, no-wrap
 msgid ""
-"> Server Signature is unique 16-bytes identifier used to prevent logging\n"
-"on to the same server twice.\n"
+"> The server signature is a unique 16-byte identifier used to prevent\n"
+"users from logging on to the same server twice.\n"
 msgstr "> サーバシグネチャは同じサーバに二重にログオンするのを防ぐために使われる固有の16バイトの識別子である。\n"
 
 #. type: Plain text
 #: manpages/man5/afp_signature.conf.5.md:28
 #, no-wrap
 msgid ""
-"> Netatalk 2.0 and earlier generated server signature by using\n"
-"gethostid(). There was a problem that another servers have the same\n"
-"signature because the hostid is not unique enough.\n"
+"> Netatalk 2.0 and earlier generated a server signature by using\n"
+"`gethostid()`. This led to a problem where multiple servers could end up with\n"
+"the same signature because the hostid is not unique enough.\n"
 msgstr ""
 "> Netatalk\n"
-"2.0以前はgethostid()を使ってサーバシグネチャを生成した。他のサーバが同じシグネチャをもつ問題があった。なぜなら、hostidは十分に固有でないからである。\n"
+"2.0以前は`gethostid()`を使ってサーバシグネチャを生成した。他のサーバが同じシグネチャをもつ問題があった。なぜなら、hostidは十分に固有でないからである。\n"
 
 #. type: Plain text
 #: manpages/man5/afp_signature.conf.5.md:32
 #, no-wrap
 msgid ""
 "> Current netatalk generates the signature from random numbers and saves\n"
-"it into afp_signature.conf. When starting next time, it is read from\n"
-"this file.\n"
+"it into afp_signature.conf upon initial startup. For subsequent starts, it is\n"
+"read from this file.\n"
 msgstr "> 現在のnetatalkは乱数からシグネチャを生成し、それをafp_signature.confに保存する。次回起動したとき、それはこのファイルから読み込まれる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp_signature.conf.5.md:36
+#: manpages/man5/afp_signature.conf.5.md:35
+#: manpages/man5/afp_voluuid.conf.5.md:28
 #, no-wrap
 msgid ""
-"> This file should not be thoughtlessly edited and be copied onto another\n"
-"server. If it wants to set the signature intentionally, use the option\n"
+"> This file should not be thoughtlessly edited or copied onto another\n"
+"server.\n"
+msgstr "> このファイルを軽率に編集すべきでないし、他のサーバにコピーすべきでもない。\n"
+
+#. type: Plain text
+#: manpages/man5/afp_signature.conf.5.md:38
+#, no-wrap
+msgid ""
+"> If you want to set the signature intentionally, use the option\n"
 "\"signature =\" in afp.conf. In this case, afp_signature.conf is not used.\n"
-msgstr "このファイルを軽率に編集すべきでないし、他のサーバにコピーすべきでもない。もし意図的にシグネチャを設定したいなら、afp.confで\"signature =\"オプションを使いなさい。この場合、afp_signature.confは利用されない。\n"
+msgstr "もし意図的にシグネチャを設定したいなら、afp.confで\"signature =\"オプションを使いなさい。この場合、afp_signature.confは利用されない。\n"
 
 #. type: Title ##
-#: manpages/man5/afp_signature.conf.5.md:39
+#: manpages/man5/afp_signature.conf.5.md:41
 #, no-wrap
 msgid "Example: afp_signature.conf"
 msgstr "例: afp_signature.conf"
 
 #. type: Plain text
-#: manpages/man5/afp_signature.conf.5.md:43
+#: manpages/man5/afp_signature.conf.5.md:45
 #, no-wrap
 msgid ""
 "    # This is a comment.\n"
@@ -233,6 +241,6 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp_signature.conf.5.md:47
+#: manpages/man5/afp_signature.conf.5.md:49
 msgid "afpd(8), afp.conf(5), asip-status(1)"
 msgstr ""

--- a/doc/po/afp_voluuid.conf.5.md.ja.po
+++ b/doc/po/afp_voluuid.conf.5.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 00:07+0100\n"
+"POT-Creation-Date: 2025-04-06 19:17+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -43,7 +43,7 @@ msgstr "名前"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
 #: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
@@ -61,10 +61,10 @@ msgid "Description"
 msgstr "説明"
 
 #. type: Title #
-#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:85
+#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:91
 #: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:46
-#: manpages/man5/afp_signature.conf.5.md:44
-#: manpages/man5/afp_voluuid.conf.5.md:38 manpages/man8/papd.8.md:133
+#: manpages/man5/afp_signature.conf.5.md:46
+#: manpages/man5/afp_voluuid.conf.5.md:38 manpages/man8/papd.8.md:132
 #, no-wrap
 msgid "See also"
 msgstr "参照"
@@ -73,19 +73,19 @@ msgstr "参照"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:95 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
 #: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
-#: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:32
+#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1362
+#: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
 #: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
-#: manpages/man8/papd.8.md:137 manpages/man8/papstatus.8.md:53
+#: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
 msgid "Author"
@@ -95,18 +95,18 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:97 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
 #: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:46 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
-#: manpages/man5/atalkd.conf.5.md:106 manpages/man5/extmap.conf.5.md:34
+#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1364
+#: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
 #: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:139
+#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"
@@ -114,23 +114,23 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 
 #. type: Title #
 #: manpages/man1/aecho.1.md:24 manpages/man1/afppasswd.1.md:26
-#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:50
+#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:56
 #: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
-#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/atalkd.conf.5.md:82
-#: manpages/man5/extmap.conf.5.md:18 manpages/man5/papd.conf.5.md:91
-#: manpages/man8/macipgw.8.md:79
+#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:39
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1307
+#: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
+#: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
 msgid "Examples"
 msgstr "例"
 
 #. type: Plain text
 #: manpages/man1/afppasswd.1.md:20 manpages/man5/afp_signature.conf.5.md:21
-#: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:318
-#: manpages/man5/afp.conf.5.md:342 manpages/man5/afp.conf.5.md:355
-#: manpages/man5/afp.conf.5.md:370 manpages/man5/afp.conf.5.md:722
-#: manpages/man5/afp.conf.5.md:1048 manpages/man5/afp.conf.5.md:1173
-#: manpages/man5/afp.conf.5.md:1211 manpages/man8/papd.8.md:97
+#: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:339
+#: manpages/man5/afp.conf.5.md:363 manpages/man5/afp.conf.5.md:376
+#: manpages/man5/afp.conf.5.md:391 manpages/man5/afp.conf.5.md:694
+#: manpages/man5/afp.conf.5.md:1093 manpages/man5/afp.conf.5.md:1219
+#: manpages/man5/afp.conf.5.md:1257 manpages/man8/papd.8.md:96
 #: manual/Configuration.md:113
 #, no-wrap
 msgid "> **NOTE**\n"
@@ -140,11 +140,20 @@ msgstr "> **注記**\n"
 #: manpages/man5/afp_signature.conf.5.md:19
 #: manpages/man5/afp_voluuid.conf.5.md:18
 msgid ""
-"The leading spaces and tabs are ignored. Blank lines are ignored. The lines "
-"prefixed with \\# are ignored. The illegal lines are ignored."
+"All leading spaces and tabs are ignored. Blank lines are ignored. The lines "
+"prefixed with \\# are ignored. Any illegal lines are ignored."
 msgstr ""
 "先頭のスペースとタブは無視される。空行は無視される。頭に#が付いた行は無視され"
 "る。不正な行は無視される。"
+
+#. type: Plain text
+#: manpages/man5/afp_signature.conf.5.md:35
+#: manpages/man5/afp_voluuid.conf.5.md:28
+#, no-wrap
+msgid ""
+"> This file should not be thoughtlessly edited or copied onto another\n"
+"server.\n"
+msgstr "> このファイルを軽率に編集すべきでないし、他のサーバにコピーすべきでもない。\n"
 
 #. type: Plain text
 #: manpages/man5/afp_voluuid.conf.5.md:4
@@ -159,22 +168,22 @@ msgstr ""
 #: manpages/man5/afp_voluuid.conf.5.md:9
 #, no-wrap
 msgid ""
-"**afp_voluuid.conf** is the configuration file used by **afpd** to specify\n"
+"**afp_voluuid.conf** is the configuration file used by **afpd** to store\n"
 "UUID of all AFP volumes. The configuration lines are composed like:\n"
 msgstr "**afp_voluuid.conf** は全てのAFPボリュームのUUIDを魔法のように自動的に指定するために **afpd** が利用する設定ファイルである。設定行は以下のように構成される。\n"
 
 #. type: Plain text
 #: manpages/man5/afp_voluuid.conf.5.md:11
 #, no-wrap
-msgid "<\"volume-name\"\\> <uuid-string\\>\n"
+msgid "    \"volume-name\" \"uuid-string\"\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man5/afp_voluuid.conf.5.md:15
 msgid ""
-"The first field is volume name. Volume names must be quoted if they contain "
-"spaces. The second field is the 36 character hexadecimal ASCII string "
-"representation of a UUID."
+"The first field is the volume name. Volume names must be quoted if they "
+"contain spaces. The second field is the 36 character hexadecimal ASCII "
+"string representation of a UUID."
 msgstr ""
 "最初のフィールドはボリューム名である。ボリューム名がスペースを含む場合、それ"
 "を引用符で囲まなければならない。第二のフィールドは36文字からなるUUIDの16進数"
@@ -195,14 +204,6 @@ msgstr ""
 #, no-wrap
 msgid "> It is also used by the MySQL CNID backend.\n"
 msgstr "> MySQL CNIDバックエンドにも使用されている。\n"
-
-#. type: Plain text
-#: manpages/man5/afp_voluuid.conf.5.md:28
-#, no-wrap
-msgid ""
-"> This file should not be thoughtlessly edited and be copied onto another\n"
-"server.\n"
-msgstr "> このファイルを軽率に編集すべきでないし、他のサーバにコピーすべきでもない。\n"
 
 #. type: Title ##
 #: manpages/man5/afp_voluuid.conf.5.md:31


### PR DESCRIPTION
This makes both the afp_signature.conf and afp_voluuid.conf man pages read and look better

These particular man pages had consistently awkward grammar and syntax