### PR TITLE
Handle DSIWrite() bug in ASC 3.7.x

### DIFF
--- a/libatalk/dsi/dsi_stream.c
+++ b/libatalk/dsi/dsi_stream.c
@@ -626,6 +626,10 @@ int dsi_stream_receive(DSI *dsi)
   dsi->cmdlen = MIN(ntohl(dsi->header.dsi_len), dsi->server_quantum);
   dsi->header.dsi_data.dsi_doff = MIN(dsi->header.dsi_data.dsi_doff, dsi->server_quantum);
 
+  /* Work around bug in ASC 3.7.x when client sends a zero byte AFPWrite() */
+  if (dsi->header.dsi_command == DSIFUNC_WRITE && !(dsi->header.dsi_data.dsi_doff))
+    dsi->header.dsi_data.dsi_doff = 12;
+
   /* Receiving DSIWrite data is done in AFP function, not here */
   if (dsi->header.dsi_data.dsi_doff) {
       LOG(log_maxdebug, logtype_dsi, "dsi_stream_receive: write request");


### PR DESCRIPTION
When sending a FPWrite() packet with data length/reqcount of zero (programs like Stuff-It Expander 5.1.4 do this for some reason), some revisions of AppleShare Client (confirmed 3.7.2 to 3.7.4) also set the write offset in the DSI header to zero. This is blatantly wrong and must always be set to 12 to accommodate the packet header. Fixes #2078