### PR TITLE
testsuite: Refactor and add verbose error output to EXPECT_FAIL macro

### DIFF
--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -27,7 +27,15 @@
         test_failed(); \
     }
 
-#define EXPECT_FAIL(a, b) do { int _experr;  _experr = (a); if (htonl(_experr) != (b)) { test_failed(); } } while(0);
+#define EXPECT_FAIL(a, b) do { \
+    int _experr = (a); \
+    if (htonl(_experr) != (b)) { \
+        if (!Quiet) \
+            fprintf(stderr, "EXPECT_FAIL: got %d, expected %d\n", htonl(_experr), (b)); \
+        test_failed(); \
+    } \
+} while(0);
+
 #define FAILEXIT(a, label) if ((a)) { test_failed(); goto label;}
 #define STATIC
 


### PR DESCRIPTION
Refactor and add error logging to EXPECT_FAIL macro to make debugging failures easier