### PR TITLE
testsuite: Use common pattern for validating error code in test432

### DIFF
--- a/test/testsuite/FPGetACL.c
+++ b/test/testsuite/FPGetACL.c
@@ -153,10 +153,10 @@ STATIC void test432()
 	 * be possible to get just the first byte of an xattr by
 	 * specifying an req_count of 7.
 	 */
-	EXPECT_FAIL( FPGetExtAttr(Conn,vol, DIRDID_ROOT , 0, 1, file, attr_name), AFPERR_PARAM );
-	EXPECT_FAIL( FPGetExtAttr(Conn,vol, DIRDID_ROOT , 0, 6, file, attr_name), AFPERR_PARAM );
-	EXPECT_FAIL( FPGetExtAttr(Conn,vol, DIRDID_ROOT , 0, 7, file, attr_name), AFPERR_PARAM );
-	EXPECT_FAIL( FPGetExtAttr(Conn,vol, DIRDID_ROOT , 0, 15, file, attr_name), AFPERR_PARAM );
+	FAIL ( htonl(AFPERR_PARAM) != FPGetExtAttr(Conn,vol, DIRDID_ROOT , 0, 1, file, attr_name));
+	FAIL ( htonl(AFPERR_PARAM) != FPGetExtAttr(Conn,vol, DIRDID_ROOT , 0, 6, file, attr_name));
+	FAIL ( htonl(AFPERR_PARAM) != FPGetExtAttr(Conn,vol, DIRDID_ROOT , 0, 7, file, attr_name));
+	FAIL ( htonl(AFPERR_PARAM) != FPGetExtAttr(Conn,vol, DIRDID_ROOT , 0, 15, file, attr_name));
 
 	FAIL( FPGetExtAttr(Conn,vol, DIRDID_ROOT , 0, 16, file, attr_name) );
 

--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -27,15 +27,6 @@
         test_failed(); \
     }
 
-#define EXPECT_FAIL(a, b) do { \
-    int _experr = (a); \
-    if (htonl(_experr) != (b)) { \
-        if (!Quiet) \
-            fprintf(stderr, "EXPECT_FAIL: got %d, expected %d\n", htonl(_experr), (b)); \
-        test_failed(); \
-    } \
-} while(0);
-
 #define FAILEXIT(a, label) if ((a)) { test_failed(); goto label;}
 #define STATIC
 


### PR DESCRIPTION
This removes the EXPECT_FAIL macro only used in this single test and harmonizes the way all tests in the suite checks AFP return code