### PR TITLE
GitHub CI: Actually use Debian Dockerfile for Debian test container

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -152,7 +152,7 @@ jobs:
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
-            AFP_PASS: afpafp
+            AFP_PASS: qx9z4thi
             AFP_GROUP: afpusers
             ATALKD_INTERFACE: eth0
             TZ: Europe/Stockholm
@@ -172,8 +172,8 @@ jobs:
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: afpafp
-            AFP_PASS2: afpafp
+            AFP_PASS: qx9z4thi
+            AFP_PASS2: qx9z4thi
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -194,8 +194,8 @@ jobs:
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: afpafp
-            AFP_PASS2: afpafp
+            AFP_PASS: qx9z4thi
+            AFP_PASS2: qx9z4thi
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -216,8 +216,8 @@ jobs:
       env:
           AFP_USER: atalk1
           AFP_USER2: atalk2
-          AFP_PASS: afpafp
-          AFP_PASS2: afpafp
+          AFP_PASS: qx9z4thi
+          AFP_PASS2: qx9z4thi
           AFP_GROUP: afpusers
           SHARE_NAME: test1
           SHARE_NAME2: test2
@@ -239,8 +239,8 @@ jobs:
       env:
           AFP_USER: atalk1
           AFP_USER2: atalk2
-          AFP_PASS: afpafp
-          AFP_PASS2: afpafp
+          AFP_PASS: qx9z4thi
+          AFP_PASS2: qx9z4thi
           AFP_GROUP: afpusers
           SHARE_NAME: test1
           SHARE_NAME2: test2
@@ -262,8 +262,8 @@ jobs:
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: afpafp
-            AFP_PASS2: afpafp
+            AFP_PASS: qx9z4thi
+            AFP_PASS2: qx9z4thi
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -284,8 +284,8 @@ jobs:
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: afpafp
-            AFP_PASS2: afpafp
+            AFP_PASS: qx9z4thi
+            AFP_PASS2: qx9z4thi
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -306,8 +306,8 @@ jobs:
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: afpafp
-            AFP_PASS2: afpafp
+            AFP_PASS: qx9z4thi
+            AFP_PASS2: qx9z4thi
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -328,8 +328,8 @@ jobs:
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: afpafp
-            AFP_PASS2: afpafp
+            AFP_PASS: qx9z4thi
+            AFP_PASS2: qx9z4thi
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -350,8 +350,8 @@ jobs:
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: afpafp
-            AFP_PASS2: afpafp
+            AFP_PASS: qx9z4thi
+            AFP_PASS2: qx9z4thi
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -372,8 +372,8 @@ jobs:
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: afpafp
-            AFP_PASS2: afpafp
+            AFP_PASS: qx9z4thi
+            AFP_PASS2: qx9z4thi
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -394,8 +394,8 @@ jobs:
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: afpafp
-            AFP_PASS2: afpafp
+            AFP_PASS: qx9z4thi
+            AFP_PASS2: qx9z4thi
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -416,8 +416,8 @@ jobs:
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: afpafp
-            AFP_PASS2: afpafp
+            AFP_PASS: qx9z4thi
+            AFP_PASS2: qx9z4thi
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -438,8 +438,8 @@ jobs:
       env:
           AFP_USER: atalk1
           AFP_USER2: atalk2
-          AFP_PASS: afpafp
-          AFP_PASS2: afpafp
+          AFP_PASS: qx9z4thi
+          AFP_PASS2: qx9z4thi
           AFP_GROUP: afpusers
           SHARE_NAME: test1
           SHARE_NAME2: test2
@@ -461,8 +461,8 @@ jobs:
       env:
           AFP_USER: atalk1
           AFP_USER2: atalk2
-          AFP_PASS: afpafp
-          AFP_PASS2: afpafp
+          AFP_PASS: qx9z4thi
+          AFP_PASS2: qx9z4thi
           AFP_GROUP: afpusers
           SHARE_NAME: test1
           SHARE_NAME2: test2
@@ -483,7 +483,7 @@ jobs:
       timeout-minutes: 5
       env:
           AFP_USER: atalk1
-          AFP_PASS: afpafp
+          AFP_PASS: qx9z4thi
           AFP_GROUP: afpusers
           SHARE_NAME: test1
           INSECURE_AUTH: 1
@@ -502,7 +502,7 @@ jobs:
       timeout-minutes: 5
       env:
           AFP_USER: atalk1
-          AFP_PASS: afpafp
+          AFP_PASS: qx9z4thi
           AFP_GROUP: afpusers
           SHARE_NAME: test1
           INSECURE_AUTH: 1
@@ -521,7 +521,7 @@ jobs:
       timeout-minutes: 5
       env:
           AFP_USER: atalk1
-          AFP_PASS: afpafp
+          AFP_PASS: qx9z4thi
           AFP_GROUP: afpusers
           INSECURE_AUTH: 1
           VERBOSE: 1
@@ -538,7 +538,7 @@ jobs:
       timeout-minutes: 5
       env:
           AFP_USER: atalk1
-          AFP_PASS: afpafp
+          AFP_PASS: qx9z4thi
           AFP_GROUP: afpusers
           INSECURE_AUTH: 1
           VERBOSE: 1
@@ -555,7 +555,7 @@ jobs:
       timeout-minutes: 5
       env:
           AFP_USER: atalk1
-          AFP_PASS: afpafp
+          AFP_PASS: qx9z4thi
           AFP_GROUP: afpusers
           SHARE_NAME: test1
           INSECURE_AUTH: 1
@@ -573,7 +573,7 @@ jobs:
       timeout-minutes: 5
       env:
           AFP_USER: atalk1
-          AFP_PASS: afpafp
+          AFP_PASS: qx9z4thi
           AFP_GROUP: afpusers
           SHARE_NAME: test1
           INSECURE_AUTH: 1

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -139,7 +139,7 @@ jobs:
               uses: docker/build-push-action@v5
               with:
                 context: .
-                file: testsuite_alp.Dockerfile
+                file: testsuite_deb.Dockerfile
                 push: true
                 labels: ${{ steps.metadata.outputs.labels }}
                 tags: ${{ steps.metadata.outputs.tags }}

--- a/testsuite_deb.Dockerfile
+++ b/testsuite_deb.Dockerfile
@@ -75,7 +75,6 @@ RUN meson setup build \
     -Dwith-init-style=none \
     -Dwith-krbV-uam=true \
     -Dwith-pam-config-path=/etc/pam.d \
-    -Dwith-pkgconfdir-path=/etc/netatalk \
     -Dwith-rpath=false \
     -Dwith-spooldir=/var/spool/netatalk \
     -Dwith-tcp-wrappers=false \

--- a/testsuite_deb.Dockerfile
+++ b/testsuite_deb.Dockerfile
@@ -1,17 +1,21 @@
 ARG RUN_DEPS="\
     cracklib-runtime \
+    libacl1 \
     libavahi-client3 \
     libdb5.3t64 \
+    libcups2t64 \
     libevent-2.1-7 \
     libgcrypt20 \
     libglib2.0-0 \
     libiniparser4 \
+    libkrb5-3 \
     libldap2 \
     libmariadb3 \
     libpam0g \
     libssl3 \
     libtalloc2 \
     libtinysparql-3.0-0 \
+    libtirpc3t64 \
     libwrap0 \
     localsearch \
     mariadb-client \


### PR DESCRIPTION
The Debian testsuite container was still using the Alpine dockerfile. This was a copy paste mistake when originally configuring this workflow

This changeset also touches up the Debian testsuite container, and uses stronger and longer test user passwords.