### PR TITLE
testsuite: Print a summary of skipped tests at end of spectest run

### DIFF
--- a/test/testsuite/afparg.c
+++ b/test/testsuite/afparg.c
@@ -60,6 +60,7 @@ int SkipCount = 0;
 int NotTestedCount = 0;
 char FailedTests[1024][256] = {{0}};
 char NotTestedTests[1024][256] = {{0}};
+char SkippedTests[1024][256] = {{0}};
 
 /* =============================== */
 static void list_tests(void)

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -973,6 +973,8 @@ void exit_test(char *name)
 		}
 		break;
 	case 3:
+		strlcpy(SkippedTests[SkipCount], name, 255);
+		SkippedTests[SkipCount][255] = '\0';
 		SkipCount++;
 		s = skipped_msg_buf;
 		break;

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -46,6 +46,7 @@ int SkipCount = 0;
 int NotTestedCount = 0;
 char FailedTests[1024][256] = {{0}};
 char NotTestedTests[1024][256] = {{0}};
+char SkippedTests[1024][256] = {{0}};
 
 /* Configure the tests */
 #define DIRNUM 10                                 /* 10^3 nested dirs */

--- a/test/testsuite/logintest.c
+++ b/test/testsuite/logintest.c
@@ -14,6 +14,7 @@ int SkipCount = 0;
 int NotTestedCount = 0;
 char FailedTests[1024][256] = {{0}};
 char NotTestedTests[1024][256] = {{0}};
+char SkippedTests[1024][256] = {{0}};
 
 DSI *Dsi;
 

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -18,6 +18,7 @@ int NotTestedCount = 0;
 
 char FailedTests[1024][256] = {{0}};
 char NotTestedTests[1024][256] = {{0}};
+char SkippedTests[1024][256] = {{0}};
 
 #define FN(a) a ## _test
 #define EXT_FN(a) extern void FN(a) (void)
@@ -580,10 +581,16 @@ int ret;
     fprintf(stdout, " TEST RESULT SUMMARY\n");
     fprintf(stdout, "---------------------\n");
 	fprintf(stdout, "  Passed:     %d\n", PassCount);
-	fprintf(stdout, "  Failed:     %d\n", FailCount);
 	fprintf(stdout, "  Skipped:    %d\n", SkipCount);
+	fprintf(stdout, "  Failed:     %d\n", FailCount);
 	fprintf(stdout, "  Not tested: %d\n", NotTestedCount);
 
+	if (SkipCount) {
+		fprintf(stdout, "\n  Skipped tests (precondition not met):\n");
+		for (int i = 0; i < SkipCount; i++) {
+			fprintf(stdout, "    %s\n", SkippedTests[i]);
+		}
+	}
 	if (FailCount) {
 		fprintf(stdout, "\n  Failed tests:\n");
 		for (int i = 0; i < FailCount; i++) {
@@ -591,7 +598,7 @@ int ret;
 		}
 	}
 	if (NotTestedCount) {
-		fprintf(stdout, "\n  Not tested tests:\n");
+		fprintf(stdout, "\n  Not tested tests (setup step failed):\n");
 		for (int i = 0; i < NotTestedCount; i++) {
 			fprintf(stdout, "    %s\n", NotTestedTests[i]);
 		}

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -65,6 +65,7 @@ int SkipCount = 0;
 int NotTestedCount = 0;
 char FailedTests[1024][256] = {{0}};
 char NotTestedTests[1024][256] = {{0}};
+char SkippedTests[1024][256] = {{0}};
 
 struct vfs {
 	unsigned int (*getfiledirparams)(CONN *, uint16_t , int , char *, uint16_t, uint16_t);

--- a/test/testsuite/test.h
+++ b/test/testsuite/test.h
@@ -126,6 +126,7 @@ extern CONN *Conn, *Conn2;
 extern char Data[];
 extern char FailedTests[1024][256];
 extern char NotTestedTests[1024][256];
+extern char SkippedTests[1024][256];
 
 extern char *Vol;
 extern char *Vol2;


### PR DESCRIPTION
In addition to failed and untested tests, print a list of skipped tests

At the same time, tweak test report labels to clarify the meaning of each test status