### PR TITLE
testsuite: Run test221 with AFP 3.1 or later

### DIFF
--- a/test/testsuite/FPGetSessionToken.c
+++ b/test/testsuite/FPGetSessionToken.c
@@ -83,8 +83,8 @@ test_exit:
 STATIC void test221()
 {
 	ENTER_TEST
-	if (Conn->afp_version <= 31) {
-		test_skipped(T_AFP32);
+	if (Conn->afp_version < 31) {
+		test_skipped(T_AFP31);
 		goto test_exit;
 	}
 


### PR DESCRIPTION
Both the condition and skip reason were set incorrectly, which made it being skipped on AFP 3.1