### PR TITLE
testsuite: Use matching return value types for DSI status codes

### DIFF
--- a/test/testsuite/afpcli.c
+++ b/test/testsuite/afpcli.c
@@ -360,7 +360,7 @@ int ofs;
 }
 
 /* ------------------------- */
-static int SendCmdVolDidCname(CONN *conn, int cmd, uint16_t vol, int did , char *name)
+static unsigned int SendCmdVolDidCname(CONN *conn, int cmd, uint16_t vol, int did , char *name)
 {
 int ofs;
 DSI *dsi;
@@ -392,7 +392,7 @@ DSI *dsi;
 /* -----------------------------------------------
    Open a new session
 */
-int DSIOpenSession(CONN *conn)
+unsigned int DSIOpenSession(CONN *conn)
 {
 DSI *dsi;
 uint32_t i = 0;
@@ -433,7 +433,7 @@ uint32_t i = 0;
 /* -----------------------------------------------
    GetStatus
 */
-int DSIGetStatus(CONN *conn)
+unsigned int DSIGetStatus(CONN *conn)
 {
 DSI *dsi;
 
@@ -455,7 +455,7 @@ DSI *dsi;
    Close Session
    no reply
 */
-int DSICloseSession(CONN *conn)
+unsigned int DSICloseSession(CONN *conn)
 {
 DSI *dsi;
 
@@ -475,7 +475,7 @@ DSI *dsi;
 	spec violation in netatalk
 	FPlogout ==> dsiclose
 */
-int AFPopenLogin(CONN *conn, char *vers, char *uam, char *usr, char *pwd)
+unsigned int AFPopenLogin(CONN *conn, char *vers, char *uam, char *usr, char *pwd)
 {
 uint8_t len;
 int ofs;
@@ -522,7 +522,7 @@ DSI *dsi = &conn->dsi;
 }
 
 /* ---------------------------- */
-int AFPopenLoginExt(CONN *conn, char *vers, char *uam, char *usr, char *pwd)
+unsigned int AFPopenLoginExt(CONN *conn, char *vers, char *uam, char *usr, char *pwd)
 {
 uint8_t len;
 uint16_t len16;
@@ -597,7 +597,7 @@ DSI *dsi;
 }
 
 /* --------------------------- */
-int AFPChangePW(CONN *conn, char *uam, char *usr, char *opwd, char *pwd)
+unsigned int AFPChangePW(CONN *conn, char *uam, char *usr, char *opwd, char *pwd)
 {
 uint8_t len;
 int ofs;
@@ -645,7 +645,7 @@ DSI *dsi;
 	return dsi->header.dsi_code;
 }
 /* ------------------------------- */
-int AFPLogOut(CONN *conn)
+unsigned int AFPLogOut(CONN *conn)
 {
     DSI *dsi;
     int ret;
@@ -659,7 +659,7 @@ int AFPLogOut(CONN *conn)
 }
 
 /* ------------------------------- */
-int AFPzzz(CONN *conn, int flag)
+unsigned int AFPzzz(CONN *conn, int flag)
 {
     int 		ofs = 0;
     DSI			*dsi = &conn->dsi;
@@ -684,7 +684,7 @@ int AFPzzz(CONN *conn, int flag)
 }
 
 /* ------------------------------- */
-int AFPGetSrvrInfo(CONN *conn)
+unsigned int AFPGetSrvrInfo(CONN *conn)
 {
 DSI *dsi;
 
@@ -695,7 +695,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPGetSrvrParms(CONN *conn)
+unsigned int AFPGetSrvrParms(CONN *conn)
 {
 DSI *dsi;
 
@@ -706,7 +706,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPGetSrvrMsg(CONN *conn, uint16_t type, uint16_t bitmap)
+unsigned int AFPGetSrvrMsg(CONN *conn, uint16_t type, uint16_t bitmap)
 {
 int ofs;
 DSI *dsi;
@@ -734,7 +734,7 @@ DSI *dsi;
 }
 
 /* -------------------------------  */
-int AFPCloseVol(CONN *conn, uint16_t vol)
+unsigned int AFPCloseVol(CONN *conn, uint16_t vol)
 {
 DSI *dsi;
 
@@ -745,7 +745,7 @@ DSI *dsi;
 }
 
 /* -------------------------------  */
-int AFPCloseDT(CONN *conn, uint16_t vol)
+unsigned int AFPCloseDT(CONN *conn, uint16_t vol)
 {
 DSI *dsi;
 
@@ -756,7 +756,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPCloseFork(CONN *conn, uint16_t fork)
+unsigned int AFPCloseFork(CONN *conn, uint16_t fork)
 {
 DSI *dsi;
 
@@ -767,7 +767,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPByteLock(CONN *conn, uint16_t fork, int end, int mode, int offset, int size )
+unsigned int AFPByteLock(CONN *conn, uint16_t fork, int end, int mode, int offset, int size )
 {
 int ofs;
 DSI *dsi;
@@ -841,7 +841,7 @@ static int set_off_t(off_t offset, uint8_t *rbuf, int is64)
 }
 
 /* ------------------------------- */
-int AFPByteLock_ext(CONN *conn, uint16_t fork, int end, int mode, off_t offset, off_t size )
+unsigned int AFPByteLock_ext(CONN *conn, uint16_t fork, int end, int mode, off_t offset, off_t size )
 {
 int ofs;
 DSI *dsi;
@@ -899,7 +899,7 @@ int is64 = bitmap & ((1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN));
 }
 
 /* ------------------------------- */
-int AFPFlush(CONN *conn, uint16_t vol)
+unsigned int AFPFlush(CONN *conn, uint16_t vol)
 {
 DSI *dsi;
 
@@ -910,7 +910,7 @@ DSI *dsi;
 }
 
 /* -------------------------------  */
-int AFPFlushFork(CONN *conn, uint16_t vol)
+unsigned int AFPFlushFork(CONN *conn, uint16_t vol)
 {
 DSI *dsi;
 
@@ -1414,7 +1414,7 @@ int afp_filedir_pack(unsigned char *b, struct afp_filedir_parms *filedir, uint16
 }
 
 /* -------------------------------  */
-int AFPGetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap)
+unsigned int AFPGetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap)
 {
 int ofs;
 DSI *dsi;
@@ -1442,7 +1442,7 @@ DSI *dsi;
 }
 
 /* -------------------------------  */
-int AFPSetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap, struct afp_volume_parms *parms)
+unsigned int AFPSetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap, struct afp_volume_parms *parms)
 {
 int ofs;
 DSI *dsi;
@@ -1557,7 +1557,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPWriteHeader(DSI *dsi, uint16_t fork, int offset, int size, char *data, char whence)
+unsigned int AFPWriteHeader(DSI *dsi, uint16_t fork, int offset, int size, char *data, char whence)
 {
 int ofs;
 int rsize;
@@ -1594,7 +1594,7 @@ uint32_t temp;
 }
 
 /* ------------------------------- */
-int AFPWriteFooter(DSI *dsi, uint16_t fork, int offset, int size, char *data, char whence)
+unsigned int AFPWriteFooter(DSI *dsi, uint16_t fork, int offset, int size, char *data, char whence)
 {
 uint32_t last;
 
@@ -1615,7 +1615,7 @@ uint32_t last;
 }
 
 /* ------------------------------- */
-int AFPWrite(CONN *conn, uint16_t fork, int offset, int size, char *data, char whence)
+unsigned int AFPWrite(CONN *conn, uint16_t fork, int offset, int size, char *data, char whence)
 {
 DSI *dsi;
 
@@ -1625,7 +1625,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPWrite_ext(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data, char whence)
+unsigned int AFPWrite_ext(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data, char whence)
 {
 int ofs;
 DSI *dsi;
@@ -1672,7 +1672,7 @@ unsigned char *ptr;
 }
 
 /* ------------------------------- */
-int AFPWrite_ext_async(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data, char whence)
+unsigned int AFPWrite_ext_async(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data, char whence)
 {
     int ofs;
     DSI *dsi = &conn->dsi;
@@ -1758,19 +1758,19 @@ unsigned int AFPDelete(CONN *conn, uint16_t vol, int did , char *name)
 }
 
 /* ------------------------------- */
-int AFPGetComment(CONN *conn, uint16_t vol, int did , char *name)
+unsigned int AFPGetComment(CONN *conn, uint16_t vol, int did , char *name)
 {
 	return  SendCmdVolDidCname(conn,AFP_GETCMT , vol, did , name);
 }
 
 /* ------------------------------- */
-int AFPRemoveComment(CONN *conn, uint16_t vol, int did , char *name)
+unsigned int AFPRemoveComment(CONN *conn, uint16_t vol, int did , char *name)
 {
 	return  SendCmdVolDidCname(conn,AFP_RMVCMT , vol, did , name);
 }
 
 /* ------------------------------- */
-int AFPAddComment(CONN *conn, uint16_t vol, int did , char *name, char *cmt)
+unsigned int AFPAddComment(CONN *conn, uint16_t vol, int did , char *name, char *cmt)
 {
 int ofs;
 int len;
@@ -1808,7 +1808,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPGetSessionToken(CONN *conn, int type, uint32_t time, int len, char *token)
+unsigned int AFPGetSessionToken(CONN *conn, int type, uint32_t time, int len, char *token)
 {
 int ofs;
 uint16_t tp = htons(type);
@@ -1846,7 +1846,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPDisconnectOldSession(CONN *conn, uint16_t type, int len, char *token)
+unsigned int AFPDisconnectOldSession(CONN *conn, uint16_t type, int len, char *token)
 {
 int ofs;
 uint16_t tp = htons(type);
@@ -1878,7 +1878,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPGetUserInfo(CONN *conn, char flag, int id, uint16_t bitmap)
+unsigned int AFPGetUserInfo(CONN *conn, char flag, int id, uint16_t bitmap)
 {
 int ofs;
 uint16_t type = htons(bitmap);
@@ -1909,7 +1909,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPMapID(CONN *conn, char fn, int id)
+unsigned int AFPMapID(CONN *conn, char fn, int id)
 {
 int ofs;
 DSI *dsi;
@@ -1936,7 +1936,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPMapName(CONN *conn, char fn, char *name )
+unsigned int AFPMapName(CONN *conn, char fn, char *name )
 {
 int ofs;
 uint16_t len,l;
@@ -1976,7 +1976,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPBadPacket(CONN *conn, char fn, char *name )
+unsigned int AFPBadPacket(CONN *conn, char fn, char *name )
 {
 int ofs;
 uint16_t l;
@@ -2004,7 +2004,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPReadHeader(DSI *dsi, uint16_t fork, int offset, int size, char *data)
+unsigned int AFPReadHeader(DSI *dsi, uint16_t fork, int offset, int size, char *data)
 {
 int ofs;
 uint32_t  temp;
@@ -2034,7 +2034,7 @@ uint32_t  temp;
 }
 
 /* ------------------------------- */
-int AFPReadFooter(DSI *dsi, uint16_t fork, int offset, int size, char *data)
+unsigned int AFPReadFooter(DSI *dsi, uint16_t fork, int offset, int size, char *data)
 {
 int rsize;
 
@@ -2047,7 +2047,7 @@ int rsize;
 }
 
 /* ------------------------------- */
-int AFPRead(CONN *conn, uint16_t fork, int offset, int size, char *data)
+unsigned int AFPRead(CONN *conn, uint16_t fork, int offset, int size, char *data)
 {
 DSI *dsi;
 
@@ -2060,7 +2060,7 @@ DSI *dsi;
 /* ----------------------
  * Assume size < 2GB
 */
-int AFPRead_ext(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data)
+unsigned int AFPRead_ext(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data)
 {
 int ofs;
 int rsize;
@@ -2105,7 +2105,7 @@ DSI *dsi;
 	return dsi->header.dsi_code?dsi->header.dsi_code:(rsize +dsi->cmdlen== size)?0:-1;
 }
 
-int AFPRead_ext_async(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data)
+unsigned int AFPRead_ext_async(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data)
 {
     int ofs;
     int rsize;
@@ -2131,10 +2131,10 @@ int AFPRead_ext_async(CONN *conn, uint16_t fork, off_t offset, off_t size, char 
 }
 
 /* -------------------------------- */
-int  AFPCreateDir(CONN *conn, uint16_t vol, int did , char *name)
+unsigned int  AFPCreateDir(CONN *conn, uint16_t vol, int did , char *name)
 {
 int ofs;
-int dir = 0;
+unsigned int dir = 0;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -2169,7 +2169,7 @@ DSI *dsi;
 }
 
 /* ------------------------------- */
-int AFPGetForkParam(CONN *conn, uint16_t fork, uint16_t bitmap)
+unsigned int AFPGetForkParam(CONN *conn, uint16_t fork, uint16_t bitmap)
 {
 int ofs;
 DSI *dsi;
@@ -2198,7 +2198,7 @@ DSI *dsi;
 
 /* -------------------------------
 */
-int AFPGetAPPL(CONN *conn, uint16_t dt, char *name, uint16_t index, uint16_t f_bitmap)
+unsigned int AFPGetAPPL(CONN *conn, uint16_t dt, char *name, uint16_t index, uint16_t f_bitmap)
 {
 int ofs;
 uint16_t bitmap;
@@ -2235,7 +2235,7 @@ DSI *dsi;
 
 /* -------------------------------
 */
-int AFPAddAPPL(CONN *conn, uint16_t dt, int did, char *creator, uint32_t tag, char *name)
+unsigned int AFPAddAPPL(CONN *conn, uint16_t dt, int did, char *creator, uint32_t tag, char *name)
 {
 int ofs;
 DSI *dsi;
@@ -2270,7 +2270,7 @@ DSI *dsi;
 
 /* -------------------------------
 */
-int AFPRemoveAPPL(CONN *conn, uint16_t dt, int did, char *creator, char *name)
+unsigned int AFPRemoveAPPL(CONN *conn, uint16_t dt, int did, char *creator, char *name)
 {
 int ofs;
 DSI *dsi;
@@ -2303,7 +2303,7 @@ DSI *dsi;
 
 /* -------------------------------
 */
-int AFPCatSearch(CONN *conn, uint16_t vol, uint32_t  nbe, char *pos, uint16_t f_bitmap,uint16_t d_bitmap,
+unsigned int AFPCatSearch(CONN *conn, uint16_t vol, uint32_t  nbe, char *pos, uint16_t f_bitmap,uint16_t d_bitmap,
 uint32_t rbitmap, struct afp_filedir_parms *filedir, struct afp_filedir_parms *filedir2)
 {
 int ofs;
@@ -2363,7 +2363,7 @@ uint16_t bitmap;
 
 /* -------------------------------
 */
-int AFPCatSearchExt(CONN *conn, uint16_t vol, uint32_t  nbe, char *pos, uint16_t f_bitmap,uint16_t d_bitmap,
+unsigned int AFPCatSearchExt(CONN *conn, uint16_t vol, uint32_t  nbe, char *pos, uint16_t f_bitmap,uint16_t d_bitmap,
 uint32_t rbitmap, struct afp_filedir_parms *filedir, struct afp_filedir_parms *filedir2)
 {
 int ofs;
@@ -2426,7 +2426,7 @@ uint16_t i;
 
 /* -------------------------------
 */
-int AFPGetACL(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char *name)
+unsigned int AFPGetACL(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char *name)
 {
 int ofs;
 DSI *dsi;
@@ -2463,7 +2463,7 @@ DSI *dsi;
 
 /* --------------------------------
 */
-int AFPGetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, int maxsize, char* pathname, char* attrname)
+unsigned int AFPGetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, int maxsize, char* pathname, char* attrname)
 {
 int ofs;
 DSI *dsi;
@@ -2526,7 +2526,7 @@ uint16_t len;
 
 /* --------------------------------
 */
-int AFPListExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, int maxsize, char* pathname)
+unsigned int AFPListExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, int maxsize, char* pathname)
 {
 int ofs;
 DSI *dsi;
@@ -2569,7 +2569,7 @@ DSI *dsi;
 
 /* --------------------------------
 */
-int AFPSetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char* pathname, char* attrname, char* data)
+unsigned int AFPSetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char* pathname, char* attrname, char* data)
 {
 int ofs;
 DSI *dsi;
@@ -2628,7 +2628,7 @@ uint32_t datalen;
         return dsi->header.dsi_code;
 }
 
-int AFPRemoveExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char* pathname, char* attrname)
+unsigned int AFPRemoveExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char* pathname, char* attrname)
 {
 int ofs;
 DSI *dsi;

--- a/test/testsuite/afpclient.h
+++ b/test/testsuite/afpclient.h
@@ -266,85 +266,84 @@ size_t my_dsi_stream_write(DSI *dsi, void *data, const size_t length);
 int my_dsi_stream_send(DSI *dsi, void *buf, size_t length);
 uint16_t my_dsi_cmd_nwriterply_async(CONN *conn, uint64_t n);
 
-int DSIOpenSession(CONN *conn);
-int DSIGetStatus(CONN *conn);
-int DSICloseSession(CONN *conn);
+unsigned int DSIOpenSession(CONN *conn);
+unsigned int DSIGetStatus(CONN *conn);
+unsigned int DSICloseSession(CONN *conn);
 
-int AFPopenLogin(CONN *conn, char *vers, char *uam, char *usr, char *pwd);
-int AFPopenLoginExt(CONN *conn, char *vers, char *uam, char *usr, char *pwd);
-int AFPLogOut(CONN *conn);
-int AFPChangePW(CONN *conn, char *uam, char *usr, char *opwd, char *pwd);
+unsigned int AFPopenLogin(CONN *conn, char *vers, char *uam, char *usr, char *pwd);
+unsigned int AFPopenLoginExt(CONN *conn, char *vers, char *uam, char *usr, char *pwd);
+unsigned int AFPLogOut(CONN *conn);
+unsigned int AFPChangePW(CONN *conn, char *uam, char *usr, char *opwd, char *pwd);
 
-int AFPzzz(CONN *conn, int);
+unsigned int AFPzzz(CONN *conn, int);
 
-int AFPGetSrvrInfo(CONN *conn);
-int AFPGetSrvrParms(CONN *conn);
-int AFPGetSrvrMsg(CONN *conn, uint16_t type, uint16_t bitmap);
+unsigned int AFPGetSrvrInfo(CONN *conn);
+unsigned int AFPGetSrvrParms(CONN *conn);
+unsigned int AFPGetSrvrMsg(CONN *conn, uint16_t type, uint16_t bitmap);
 
-int AFPCloseVol(CONN *conn, uint16_t vol);
-int AFPCloseDT(CONN *conn, uint16_t vol);
+unsigned int AFPCloseVol(CONN *conn, uint16_t vol);
+unsigned int AFPCloseDT(CONN *conn, uint16_t vol);
 
-int AFPByteLock(CONN *conn, uint16_t fork, int end, int mode, int offset, int size );
-int AFPByteLock_ext(CONN *conn, uint16_t fork, int end, int mode, off_t offset, off_t size );
-int AFPCloseFork(CONN *conn, uint16_t vol);
-int AFPFlush(CONN *conn, uint16_t vol);
-int AFPFlushFork(CONN *conn, uint16_t vol);
+unsigned int AFPByteLock(CONN *conn, uint16_t fork, int end, int mode, int offset, int size );
+unsigned int AFPByteLock_ext(CONN *conn, uint16_t fork, int end, int mode, off_t offset, off_t size );
+unsigned int AFPCloseFork(CONN *conn, uint16_t fork);
+unsigned int AFPFlush(CONN *conn, uint16_t vol);
+unsigned int AFPFlushFork(CONN *conn, uint16_t fork);
 unsigned int AFPDelete(CONN *conn, uint16_t vol, int did , char *name);
 
-int AFPGetComment(CONN *conn, uint16_t vol, int did , char *name);
-int AFPRemoveComment(CONN *conn, uint16_t vol, int did , char *name);
-int AFPAddComment(CONN *conn, uint16_t vol, int did , char *name, char *cmt);
+unsigned int AFPGetComment(CONN *conn, uint16_t vol, int did , char *name);
+unsigned int AFPRemoveComment(CONN *conn, uint16_t vol, int did , char *name);
+unsigned int AFPAddComment(CONN *conn, uint16_t vol, int did , char *name, char *cmt);
 
 uint16_t AFPOpenVol(CONN *conn, char *vol, uint16_t bitmap);
 uint16_t AFPOpenFork(CONN *conn, uint16_t vol, char type, uint16_t bitmap, int did , char *name,uint16_t access);
 
-int AFPGetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap);
-int AFPSetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap, struct afp_volume_parms *parms);
+unsigned int AFPGetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap);
+unsigned int AFPSetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap, struct afp_volume_parms *parms);
 
 unsigned int  AFPCreateFile(CONN *conn, uint16_t vol, char type, int did , char *name);
-int  AFPCreateDir(CONN *conn, uint16_t vol, int did , char *name);
+unsigned int  AFPCreateDir(CONN *conn, uint16_t vol, int did , char *name);
 
-int AFPWriteHeader(DSI *dsi, uint16_t fork, int offset, int size, char *data, char whence);
-int AFPWriteFooter(DSI *dsi, uint16_t fork, int offset, int size, char *data, char whence);
-int AFPWrite(CONN *conn, uint16_t fork, int offset, int size, char *data, char whence);
-int AFPWrite_ext(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data, char whence);
-int AFPWrite_ext_async(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data, char whence);
+unsigned int AFPWriteHeader(DSI *dsi, uint16_t fork, int offset, int size, char *data, char whence);
+unsigned int AFPWriteFooter(DSI *dsi, uint16_t fork, int offset, int size, char *data, char whence);
+unsigned int AFPWrite(CONN *conn, uint16_t fork, int offset, int size, char *data, char whence);
+unsigned int AFPWrite_ext(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data, char whence);
+unsigned int AFPWrite_ext_async(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data, char whence);
 
-int AFPReadHeader(DSI *dsi, uint16_t fork, int offset, int size, char *data);
-int AFPReadFooter(DSI *dsi, uint16_t fork, int offset, int size, char *data);
-int AFPRead(CONN *conn, uint16_t fork, int offset, int size, char *data);
-int AFPRead_ext(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data);
-int AFPRead_ext_async(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data);
+unsigned int AFPReadHeader(DSI *dsi, uint16_t fork, int offset, int size, char *data);
+unsigned int AFPReadFooter(DSI *dsi, uint16_t fork, int offset, int size, char *data);
+unsigned int AFPRead(CONN *conn, uint16_t fork, int offset, int size, char *data);
+unsigned int AFPRead_ext(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data);
+unsigned int AFPRead_ext_async(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data);
 
-int AFPGetForkParam(CONN *conn, uint16_t fork, uint16_t bitmap);
+unsigned int AFPGetForkParam(CONN *conn, uint16_t fork, uint16_t bitmap);
 
-int AFPGetSessionToken(CONN *conn, int type, uint32_t time, int len, char *token);
-int AFPDisconnectOldSession(CONN *conn, uint16_t type, int len, char *token);
+unsigned int AFPGetSessionToken(CONN *conn, int type, uint32_t time, int len, char *token);
+unsigned int AFPDisconnectOldSession(CONN *conn, uint16_t type, int len, char *token);
 
-int AFPMapID(CONN *conn, char fn, int id);
-int AFPMapName(CONN *conn, char fn, char *name );
+unsigned int AFPMapID(CONN *conn, char fn, int id);
+unsigned int AFPMapName(CONN *conn, char fn, char *name );
 
-int AFPAddAPPL(CONN *conn, uint16_t dt, int did, char *creator, uint32_t tag, char *name);
-int AFPGetAPPL(CONN *conn, uint16_t dt, char *name, uint16_t index, uint16_t f_bitmap);
-int AFPRemoveAPPL(CONN *conn, uint16_t dt, int did, char *creator, char *name);
+unsigned int AFPAddAPPL(CONN *conn, uint16_t dt, int did, char *creator, uint32_t tag, char *name);
+unsigned int AFPGetAPPL(CONN *conn, uint16_t dt, char *name, uint16_t index, uint16_t f_bitmap);
+unsigned int AFPRemoveAPPL(CONN *conn, uint16_t dt, int did, char *creator, char *name);
 
-int AFPGetUserInfo(CONN *conn, char flag, int id, uint16_t bitmap);
-int AFPBadPacket(CONN *conn, char fn, char *name );
+unsigned int AFPGetUserInfo(CONN *conn, char flag, int id, uint16_t bitmap);
+unsigned int AFPBadPacket(CONN *conn, char fn, char *name );
 
-int AFPCatSearch(CONN *conn, uint16_t vol, uint32_t  nbe, char *pos, uint16_t f_bitmap,uint16_t d_bitmap,
-uint32_t rbitmap, struct afp_filedir_parms *filedir, struct afp_filedir_parms *filedir2);
+unsigned int AFPCatSearch(CONN *conn, uint16_t vol, uint32_t  nbe, char *pos, uint16_t f_bitmap,uint16_t d_bitmap,
+        uint32_t rbitmap, struct afp_filedir_parms *filedir, struct afp_filedir_parms *filedir2);
 
-int AFPCatSearchExt(CONN *conn, uint16_t vol, uint32_t  nbe, char *pos, uint16_t f_bitmap,uint16_t d_bitmap,
-uint32_t rbitmap, struct afp_filedir_parms *filedir, struct afp_filedir_parms *filedir2);
+unsigned int AFPCatSearchExt(CONN *conn, uint16_t vol, uint32_t  nbe, char *pos, uint16_t f_bitmap,uint16_t d_bitmap,
+        uint32_t rbitmap, struct afp_filedir_parms *filedir, struct afp_filedir_parms *filedir2);
 
-unsigned int AFPSetFileParams(CONN *, uint16_t vol, int did, char *name, uint16_t bitmap, struct afp_filedir_parms *);
 unsigned int AFPSetForkParam(CONN *conn, uint16_t fork,  uint16_t bitmap, off_t size);
 
-int AFPGetACL(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char *name);
-int AFPListExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, int maxsize, char* pathname);
-int AFPGetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, int maxsize, char* pathname, char* attrname);
-int AFPSetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char* pathname, char* attrname, char* data);
-int AFPRemoveExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char* pathname, char* attrname);
+unsigned int AFPGetACL(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char *name);
+unsigned int AFPListExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, int maxsize, char* pathname);
+unsigned int AFPGetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, int maxsize, char* pathname, char* attrname);
+unsigned int AFPSetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char* pathname, char* attrname, char* data);
+unsigned int AFPRemoveExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char* pathname, char* attrname);
 
 int FPset_name(CONN *conn, int ofs, char *name);
 void u2mac(uint8_t *dst, char *name, int len);

--- a/test/testsuite/afpcmd.c
+++ b/test/testsuite/afpcmd.c
@@ -234,7 +234,7 @@ uint32_t i = 0;
 */
 unsigned int FPopenLogin(CONN *conn, char *vers, char *uam, char *usr, char *pwd)
 {
-int ret;
+unsigned int ret;
 struct passwd *p = NULL;
 DSI *dsi;
 
@@ -258,7 +258,7 @@ DSI *dsi;
 */
 unsigned int FPopenLoginExt(CONN *conn, char *vers, char *uam, char *usr, char *pwd)
 {
-int ret;
+unsigned int ret;
 struct passwd *p = NULL;
 DSI *dsi;
 
@@ -286,7 +286,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPLogOut(CONN *conn)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -301,7 +301,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPzzz(CONN *conn, int flag)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -316,7 +316,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPGetSessionToken(CONN *conn, int type, uint32_t time, int len, char *token)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -331,7 +331,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPDisconnectOldSession(CONN *conn, uint16_t type, int len, char *token)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -346,7 +346,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPMapID(CONN *conn, char fn, int id)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -361,7 +361,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPMapName(CONN *conn, char fn, char *name )
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -376,7 +376,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPBadPacket(CONN *conn, char fn, char *name )
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -391,7 +391,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPGetUserInfo(CONN *conn, char flag, int id, uint16_t bitmap)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -407,7 +407,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPGetSrvrInfo(CONN *conn)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -422,7 +422,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPGetSrvrParms(CONN *conn)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -437,7 +437,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPGetSrvrMsg(CONN *conn, uint16_t type, uint16_t bitmap)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -477,7 +477,6 @@ uint16_t FPOpenVol(CONN *conn, char *vol)
 /* ------------------------------- */
 unsigned int FPCloseVol(CONN *conn, uint16_t vol)
 {
-int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -485,7 +484,7 @@ DSI *dsi;
 		fprintf(stdout,"[%s] Close Vol %d\n", __func__, vol);
 	}
 
-	ret  = AFPCloseVol(conn,vol);
+	AFPCloseVol(conn,vol);
 	dump_header(dsi);
 	return dsi->header.dsi_code;
 }
@@ -677,7 +676,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPGetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -693,7 +692,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPSetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap, struct afp_volume_parms *parms)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -709,7 +708,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPCloseDT(CONN *conn, uint16_t vol)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -724,7 +723,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPCloseFork(CONN *conn, uint16_t vol)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -739,7 +738,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPFlush(CONN *conn, uint16_t vol)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -754,7 +753,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPByteLock(CONN *conn, uint16_t fork, int end, int mode, int offset, int size )
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -771,7 +770,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPByteLock_ext(CONN *conn, uint16_t fork, int end, int mode, off_t offset, off_t size )
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -788,7 +787,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPFlushFork(CONN *conn, uint16_t vol)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -1390,7 +1389,7 @@ unsigned int FPEnumerateExt2Full(CONN *conn,
 */
 unsigned int FPDelete(CONN *conn, uint16_t vol, int did , char *name)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -1408,7 +1407,7 @@ DSI *dsi;
 */
 unsigned int FPGetComment(CONN *conn, uint16_t vol, int did , char *name)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -1426,7 +1425,7 @@ DSI *dsi;
 */
 unsigned int FPRemoveComment(CONN *conn, uint16_t vol, int did , char *name)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -1444,7 +1443,7 @@ DSI *dsi;
 */
 unsigned int FPAddComment(CONN *conn, uint16_t vol, int did , char *name, char *cmt)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -1553,7 +1552,7 @@ DSI *dsi;
 /* ------------------------- */
 unsigned int FPCreateFile(CONN *conn, uint16_t vol, char type, int did , char *name)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -1569,7 +1568,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPGetForkParam(CONN *conn, uint16_t fork, uint16_t bitmap)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -1585,7 +1584,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPGetAppl(CONN *conn, uint16_t dt, char *name, uint16_t index, uint16_t bitmap)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -1601,7 +1600,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPAddAPPL(CONN *conn, uint16_t dt, int did, char *creator, uint32_t tag, char *name)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -1617,7 +1616,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPRemoveAPPL(CONN *conn, uint16_t dt, int did, char *creator, char *name)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -1633,7 +1632,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPSetForkParam(CONN *conn, uint16_t fork,  uint16_t bitmap, off_t size)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -1786,7 +1785,7 @@ unsigned int FPSyncDir(CONN *conn, uint16_t vol, int did)
 unsigned int FPCatSearch(CONN *conn, uint16_t vol, uint32_t  nbe, char *pos, uint16_t f_bitmap, uint16_t d_bitmap,
                                 uint32_t rbitmap, struct afp_filedir_parms *filedir, struct afp_filedir_parms *filedir2)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -1803,7 +1802,7 @@ DSI *dsi;
 unsigned int FPCatSearchExt(CONN *conn, uint16_t vol, uint32_t  nbe, char *pos, uint16_t f_bitmap, uint16_t d_bitmap,
                                 uint32_t rbitmap, struct afp_filedir_parms *filedir, struct afp_filedir_parms *filedir2)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -2049,7 +2048,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPReadHeader(DSI *dsi, uint16_t fork, int offset, int size, char *data)
 {
-int ret;
+unsigned int ret;
 
 	if (!Quiet) {
 		fprintf(stdout,"[%s] send read header fork %d  offset %d size %d\n", __func__, fork , offset, size);
@@ -2063,7 +2062,7 @@ int ret;
 /* ------------------------------- */
 unsigned int FPReadFooter(DSI *dsi, uint16_t fork, int offset, int size, char *data)
 {
-int ret;
+unsigned int ret;
 
 	if (!Quiet) {
 		fprintf(stdout,"[%s] get read reply fork %d  offset %d size %d\n", __func__, fork , offset, size);
@@ -2078,7 +2077,7 @@ int ret;
 /* ------------------------------- */
 unsigned int FPRead(CONN *conn, uint16_t fork, long long offset, int size, char *data)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -2096,7 +2095,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPRead_ext (CONN *conn, uint16_t fork, off_t offset, off_t size, char *data)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -2114,7 +2113,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPRead_ext_async(CONN *conn, uint16_t fork, off_t offset, off_t size, char *data)
 {
-    int ret;
+    unsigned int ret;
     DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -2132,7 +2131,7 @@ unsigned int FPRead_ext_async(CONN *conn, uint16_t fork, off_t offset, off_t siz
 /* ------------------------------- */
 unsigned int FPWriteHeader(DSI *dsi, uint16_t fork, int offset, int size, char *data, char whence)
 {
-int ret;
+unsigned int ret;
 
 	if (!Quiet) {
 		fprintf(stdout,"[%s] send write header fork %d  offset %d size %d from 0x%x\n", __func__, fork , offset, size, (unsigned)whence);
@@ -2146,7 +2145,7 @@ int ret;
 /* ------------------------------- */
 unsigned int FPWriteFooter(DSI *dsi, uint16_t fork, int offset, int size, char *data, char whence)
 {
-int ret;
+unsigned int ret;
 
 	if (!Quiet) {
 		fprintf(stdout,"[%s] get write footer fork %d  offset %d size %d from 0x%x\n", __func__, fork , offset, size, (unsigned)whence);
@@ -2160,7 +2159,7 @@ int ret;
 /* ------------------------------- */
 unsigned int FPWrite(CONN *conn, uint16_t fork, long long offset, int size, char *data, char whence)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -2177,8 +2176,8 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPWrite_ext(CONN *conn, uint16_t fork, off_t  offset, off_t size, char *data, char whence)
 {
-int ret;
-DSI *dsi;
+    unsigned int ret;
+    DSI *dsi;
 
 	dsi = &conn->dsi;
 
@@ -2194,7 +2193,7 @@ DSI *dsi;
 /* ------------------------------- */
 unsigned int FPWrite_ext_async(CONN *conn, uint16_t fork, off_t  offset, off_t size, char *data, char whence)
 {
-    int ret;
+    unsigned int ret;
     DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -2209,7 +2208,7 @@ unsigned int FPWrite_ext_async(CONN *conn, uint16_t fork, off_t  offset, off_t s
 
 unsigned int FPGetACL(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char *name)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -2225,7 +2224,7 @@ DSI *dsi;
 
 unsigned int FPGetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, uint16_t maxsize, char *name, char *attr)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -2241,7 +2240,7 @@ DSI *dsi;
 
 unsigned int FPListExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, int maxsize, char* name)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -2257,7 +2256,7 @@ DSI *dsi;
 
 unsigned int FPSetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char* name, char* attr, char* data)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;
@@ -2274,7 +2273,7 @@ DSI *dsi;
 
 unsigned int FPRemoveExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap, char* name, char* attr)
 {
-int ret;
+unsigned int ret;
 DSI *dsi;
 
 	dsi = &conn->dsi;

--- a/test/testsuite/test.h
+++ b/test/testsuite/test.h
@@ -5,7 +5,6 @@ extern unsigned int FPzzz(CONN *conn, int);
 extern unsigned int FPLogOut(CONN *conn);
 extern unsigned int FPMapID(CONN *conn, char fn, int id);
 extern unsigned int FPMapName(CONN *conn, char fn, char *name );
-extern unsigned int FPCreateDir(CONN *conn, uint16_t vol, int did , char *name);
 extern unsigned int FPGetSessionToken(CONN *conn, int type, uint32_t time, int len, char *token);
 extern unsigned int FPDisconnectOldSession(CONN *conn, uint16_t type, int len, char *token);
 


### PR DESCRIPTION
Use consistent data type for DSI status codes, namely unsigned int

Also removes a handful of unused function declarations