### PR TITLE
meson: Do not install the pap CUPS backend by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
           meson setup build \
             -Dbuildtype=release \
             -Dwith-appletalk=true \
+            -Dwith-cups-pap-backend=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-tests=true
       - name: Build
@@ -128,6 +129,7 @@ jobs:
           meson setup build \
             -Dbuildtype=release \
             -Dwith-appletalk=true \
+            -Dwith-cups-pap-backend=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-init-hooks=false \
             -Dwith-tests=true
@@ -192,6 +194,7 @@ jobs:
           meson setup build \
             -Dbuildtype=release \
             -Dwith-appletalk=true \
+            -Dwith-cups-pap-backend=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-docs-l10n=true \
             -Dwith-init-hooks=false \
@@ -254,6 +257,7 @@ jobs:
           meson setup build \
             -Dbuildtype=release \
             -Dwith-appletalk=true \
+            -Dwith-cups-pap-backend=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-init-hooks=false \
             -Dwith-tests=true
@@ -315,6 +319,7 @@ jobs:
           meson setup build \
             -Dbuildtype=release \
             -Dwith-appletalk=true \
+            -Dwith-cups-pap-backend=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-init-hooks=false \
             -Dwith-tests=true
@@ -516,6 +521,7 @@ jobs:
             meson setup build \
               -Dbuildtype=release \
               -Dwith-appletalk=true \
+              -Dwith-cups-pap-backend=true \
               -Dwith-dtrace=false \
               -Dwith-tests=true
             meson compile -C build

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -48,7 +48,7 @@ option(
 option(
     'with-cups-pap-backend',
     type: 'boolean',
-    value: true,
+    value: false,
     description: 'Install the pap backend for CUPS',
 )
 option(


### PR DESCRIPTION
The pap backend for CUPS modifies a 3rd party library which is not netatalk or the core system.
Certain OSes and package managers have policies against one package modifying the configuration of another package.
Notably NixOS.

This change makes it so that the pap CUPS backend has to be enabled explicitly at compile time to be installed.