### PR TITLE
GitHub CI: Build the testsuite on all OSes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,8 @@ jobs:
             -Dwith-appletalk=true \
             -Dwith-cups-pap-backend=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
-            -Dwith-tests=true
+            -Dwith-tests=true \
+            -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
       - name: Run integration tests
@@ -132,7 +133,8 @@ jobs:
             -Dwith-cups-pap-backend=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-init-hooks=false \
-            -Dwith-tests=true
+            -Dwith-tests=true \
+            -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
       - name: Run integration tests
@@ -200,7 +202,8 @@ jobs:
             -Dwith-init-hooks=false \
             -Dwith-init-style=debian-sysv,systemd \
             -Dwith-pkgconfdir-path=/etc/netatalk \
-            -Dwith-tests=true
+            -Dwith-tests=true \
+            -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
       - name: Run integration tests
@@ -260,7 +263,8 @@ jobs:
             -Dwith-cups-pap-backend=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-init-hooks=false \
-            -Dwith-tests=true
+            -Dwith-tests=true \
+            -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
       - name: Run integration tests
@@ -322,7 +326,8 @@ jobs:
             -Dwith-cups-pap-backend=true \
             -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
             -Dwith-init-hooks=false \
-            -Dwith-tests=true
+            -Dwith-tests=true \
+            -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
       - name: Run distribution tests
@@ -366,7 +371,8 @@ jobs:
         run: |
           meson setup build \
             -Dbuildtype=release \
-            -Dwith-tests=true
+            -Dwith-tests=true \
+            -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
       - name: Run integration tests
@@ -425,7 +431,8 @@ jobs:
             meson setup build \
               -Dbuildtype=release \
               -Dwith-appletalk=true \
-              -Dwith-tests=true
+              -Dwith-tests=true \
+              -Dwith-testsuite=true
             meson compile -C build
             meson install -C build
             netatalk -V
@@ -468,7 +475,8 @@ jobs:
             meson setup build \
               -Dbuildtype=release \
               -Dpkg_config_path=/usr/local/libdata/pkgconfig \
-              -Dwith-tests=true
+              -Dwith-tests=true \
+              -Dwith-testsuite=true
             meson compile -C build
             cd build
             meson test
@@ -523,7 +531,8 @@ jobs:
               -Dwith-appletalk=true \
               -Dwith-cups-pap-backend=true \
               -Dwith-dtrace=false \
-              -Dwith-tests=true
+              -Dwith-tests=true \
+              -Dwith-testsuite=true
             meson compile -C build
             cd build
             meson test
@@ -577,7 +586,8 @@ jobs:
               -Dwith-gssapi-path=/usr/local/heimdal \
               -Dwith-kerberos-path=/usr/local/heimdal \
               -Dwith-pam=false \
-              -Dwith-tests=true
+              -Dwith-tests=true \
+              -Dwith-testsuite=true
             meson compile -C build
             meson install -C build
             netatalk -V
@@ -628,7 +638,8 @@ jobs:
               -Dpkg_config_path=/opt/local/lib/pkgconfig \
               -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
               -Dwith-ldap-path=/opt/local \
-              -Dwith-tests=true
+              -Dwith-tests=true \
+              -Dwith-testsuite=true
             meson compile -C build
             cd build
             meson test
@@ -685,7 +696,8 @@ jobs:
               -Dpkg_config_path=/usr/lib/amd64/pkgconfig \
               -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
               -Dwith-iniparser-path=/usr/local \
-              -Dwith-tests=true
+              -Dwith-tests=true \
+              -Dwith-testsuite=true
             meson compile -C build
             cd build
             meson test


### PR DESCRIPTION
The testsuite has seen improved functionality and portability recently so it makes more sense now to build it everywhere