### PR TITLE
GitHub CI: Build on FreeBSD with the latest mysql91-client

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -464,7 +464,7 @@ jobs:
               libgcrypt \
               localsearch \
               meson \
-              mysql84-client \
+              mysql91-client \
               openldap26-client \
               p5-Net-DBus \
               perl5 \


### PR DESCRIPTION
The MySQL client library has gotten a version bump from 8.4 to 9.1 in the FreeBSD ports repo