### PR TITLE
testsuite: Print usage helptext when running test binaries without params

### DIFF
--- a/test/testsuite/afparg.c
+++ b/test/testsuite/afparg.c
@@ -136,6 +136,10 @@ int main( int ac, char **av )
 int cc;
 int ret;
 
+    if (ac == 1) {
+        usage(av[0]);
+    }
+
     while (( cc = getopt( ac, av, "1234567lVvf:h:p:s:u:w:" )) != EOF ) {
         switch ( cc ) {
         case '1':

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -670,6 +670,10 @@ int main(int ac, char **av)
     static char *vers = "AFP3.4";
     static char *uam = "Cleartxt Passwrd";
 
+    if (ac == 1) {
+        usage(av[0]);
+    }
+
     while (( cc = getopt( ac, av, "1234567bGgVvF:f:h:n:p:s:u:w:" )) != EOF ) {
         switch ( cc ) {
         case '3':

--- a/test/testsuite/logintest.c
+++ b/test/testsuite/logintest.c
@@ -300,6 +300,10 @@ int main( int ac, char **av )
 {
 int cc;
 
+    if (ac == 1) {
+        usage(av[0]);
+    }
+
     while (( cc = getopt( ac, av, "1234567CmVvh:p:u:w:" )) != EOF ) {
         switch ( cc ) {
         case '1':

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -369,6 +369,10 @@ int main( int ac, char **av )
 int cc;
 int ret;
 
+    if (ac == 1) {
+        usage(av[0]);
+    }
+
     while (( cc = getopt( ac, av, "1234567aCiLlmVvXxc:d:f:H:h:p:S:s:u:w:" )) != EOF ) {
         switch ( cc ) {
         case '1':

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -1323,6 +1323,10 @@ int main( int ac, char **av )
 {
 int cc;
 
+    if (ac == 1) {
+        usage(av[0]);
+    }
+
     while (( cc = getopt( ac, av, "1234567aeDiLnVvyc:d:F:f:h:o:p:q:R:r:S:s:u:w:" )) != EOF ) {
         switch ( cc ) {
         case '1':


### PR DESCRIPTION
Rather than outputting obscure errors, print the helpful summary of available parameters