### PR TITLE
docs: Format man page code blocks without backticks

### DIFF
--- a/doc/manpages/man1/ad.1.md
+++ b/doc/manpages/man1/ad.1.md
@@ -4,9 +4,9 @@ ad - AppleDouble file utility suite
 
 # Synopsis
 
-`ad [ ls | cp | mv | rm | set ] [...]`
+**ad** [ ls | cp | mv | rm | set ] [...]
 
-`ad [ -v | --version ]`
+**ad** [ -v | --version ]
 
 # Description
 
@@ -20,31 +20,31 @@ volume are modified.
 
 List files and directories.
 
-> `ad ls [-dRl[u]] {file|dir [...]}`
+> ad ls [-dRl[u]] {file|dir [...]}
 
 Copy files and directories.
 
-> `ad cp [-aipvf] {src_file} {dst_file}`
+> ad cp [-aipvf] {src_file} {dst_file}
 
-> `ad cp -R [-aipvf] {src_file|src_directory ...} {dst_directory}`
+> ad cp -R [-aipvf] {src_file|src_directory ...} {dst_directory}
 
 Move files and directories.
 
-> `ad mv [-finv] {src_file} {dst_file}`
+> ad mv [-finv] {src_file} {dst_file}
 
-> `ad mv [-finv] {src_file|src_directory ...} {dst_directory}`
+> ad mv [-finv] {src_file|src_directory ...} {dst_directory}
 
 Remove files and directories.
 
-> `ad rm [-Rv] {file|directory}`
+> ad rm [-Rv] {file|directory}
 
 Set metadata on files.
 
-> `ad set [-t type] [-c creator] [-l label] [-f flags] [-a attributes] {file}`
+> ad set [-t type] [-c creator] [-l label] [-f flags] [-a attributes] {file}
 
 Show version.
 
-> `ad -v | --version`
+> ad -v | --version
 
 # ad ls
 

--- a/doc/manpages/man1/addump.1.md
+++ b/doc/manpages/man1/addump.1.md
@@ -4,17 +4,17 @@ addump - Dump AppleSingle/AppleDouble format data
 
 # Synopsis
 
-`addump [-a] [ FILE | DIR ]`
+**addump** [-a] [ FILE | DIR ]
 
-`addump [-e] [ FILE | DIR ]`
+**addump** [-e] [ FILE | DIR ]
 
-`addump [-f] [FILE]`
+**addump** [-f] [FILE]
 
-`addump [-d] [FILE]`
+**addump** [-d] [FILE]
 
-`addump [ -h | -help | --help ]`
+**addump** [ -h | -help | --help ]
 
-`addump [ -v | -version | --version ]`
+**addump** [ -v | -version | --version ]
 
 # Description
 

--- a/doc/manpages/man1/aecho.1.md
+++ b/doc/manpages/man1/aecho.1.md
@@ -4,7 +4,7 @@ aecho - send AppleTalk Echo Protocol packets to network hosts
 
 # Synopsis
 
-`aecho [-c count] [ address | nbpname ]`
+**aecho** [-c count] [ address | nbpname ]
 
 # Description
 

--- a/doc/manpages/man1/afpldaptest.1.md
+++ b/doc/manpages/man1/afpldaptest.1.md
@@ -4,9 +4,9 @@ afpldaptest — Syntactically check LDAP parameters in afp.conf
 
 # Synopsis
 
-`afpldaptest [ -u USER | -g GROUP | -i UUID ]`
+**afpldaptest** [ -u USER | -g GROUP | -i UUID ]
 
-`afpldaptest [ -h | -? | -: ]`
+**afpldaptest** [ -h | -? | -: ]
 
 # Description
 

--- a/doc/manpages/man1/afppasswd.1.md
+++ b/doc/manpages/man1/afppasswd.1.md
@@ -4,7 +4,7 @@ afppasswd — AFP password maintenance utility
 
 # Synopsis
 
-`afppasswd [-acfn] [-p afppasswd file] [-u minimum uid] [-w password string]`
+**afppasswd** [-acfn] [-p afppasswd file] [-u minimum uid] [-w password string]
 
 # Description
 

--- a/doc/manpages/man1/afptest.1.md
+++ b/doc/manpages/man1/afptest.1.md
@@ -4,17 +4,17 @@ afp_lantest, afp_logintest, afp_spectest, afp_speedtest, afparg, fce_listen — 
 
 # Synopsis
 
-`afp_lantest [-34567GgVv] [-h host] [-p port] [-s volume] [-u user] [-w password] [-n iterations] [-t tests] [-F bigfile]`
+**afp_lantest** [-34567GgVv] [-h host] [-p port] [-s volume] [-u user] [-w password] [-n iterations] [-t tests] [-F bigfile]
 
-`afp_logintest [-1234567CmVv] [-h host] [-p port] [-s volume] [-u user] [-w password]`
+**afp_logintest** [-1234567CmVv] [-h host] [-p port] [-s volume] [-u user] [-w password]
 
-`afp_spectest [-1234567aCiLlmVvXx] [-h host] [-H host2] [-p port] [-s volume] [-c path to volume] [-S volume2] [-u user] [-d user2] [-w password] [-f test]`
+**afp_spectest** [-1234567aCiLlmVvXx] [-h host] [-H host2] [-p port] [-s volume] [-c path to volume] [-S volume2] [-u user] [-d user2] [-w password] [-f test]
 
-`afp_speedtest [-1234567aeiLnVvy] [-h host] [-p port] [-s volume] [-S volume2] [-u user] [-w password] [-n iterations] [-d size] [-q quantum] [-F file] [-f test]`
+**afp_speedtest** [-1234567aeiLnVvy] [-h host] [-p port] [-s volume] [-S volume2] [-u user] [-w password] [-n iterations] [-d size] [-q quantum] [-F file] [-f test]
 
-`afparg [-1234567lVv] [-h host] [-p port] [-s volume] [-u user] [-w password] [-f command]`
+**afparg** [-1234567lVv] [-h host] [-p port] [-s volume] [-u user] [-w password] [-f command]
 
-`fce_listen [-h host] [-p port]`
+**fce_listen** [-h host] [-p port]
 
 # Description
 
@@ -73,7 +73,7 @@ in order to test netatalk speeds against other file transfer protocols.
 
 **afparg** is an interactive AFP client that takes an AFP command with
 optional arguments. This can be used for troubleshooting or system
-administration. Run `afparg -l` to list available commands.
+administration. Run *afparg -l* to list available commands.
 
 **fce_listen** is a simple listener for Netatalk's Filesystem Change Event
 (FCE) protocol. It will print out any UDP datagrams received from the AFP
@@ -85,7 +85,7 @@ This suite of tools were designed primarily to test Netatalk AFP servers,
 however they can also be used to test a native Mac OS AFP server hosted
 by an older Mac OS X or Classic Mac OS system.
 
-Launch the test runner with the `-m` option when testing a Mac AFP server.
+Launch the test runner with the **-m** option when testing a Mac AFP server.
 When running in Mac mode, the test runner will report tests with known current
 or historical differences between Mac and Netatalk.
 
@@ -106,19 +106,16 @@ but now behave the same way:
 
 Below is a sample configuration for running the APF spec tests.
 
-- 2 users: `user1`, `user2` with the same password
-- 1 group: `afpusers`
-- `user1`, `user2` assigned to `afpusers` group
+- 2 users: user1, user2 with the same password
+- 1 group: afpusers
+- user1, user2 assigned to afpusers group
 - clear text UAM + guest UAM
-- two empty volumes:
 
-```
-drwxrwsr-x    5 user1   afpusers       176 avr 27 23:56 /tmp/afptest1
-drwxrwsr-x    5 user1   afpusers       176 avr 27 23:56 /tmp/afptest2
-```
+Arrange two *empty* directories. Some tests will fail if there are
+residual files in the test directories.
 
-*Note:* Some tests will fail if there are residual files
-in the test volumes.
+    drwxrwsr-x    5 user1   afpusers       176 avr 27 23:56 /tmp/afptest1
+    drwxrwsr-x    5 user1   afpusers       176 avr 27 23:56 /tmp/afptest2
 
 Set afp.conf as follows:
 

--- a/doc/manpages/man1/asip-status.1.md
+++ b/doc/manpages/man1/asip-status.1.md
@@ -4,11 +4,11 @@ asip-status — Queries an AFP server for its capabilities
 
 # Synopsis
 
-`asip-status [ -4 | -6 ] [-d] [-i] [-x] [HOSTNAME] [PORT]`
+**asip-status** [ -4 | -6 ] [-d] [-i] [-x] [HOSTNAME] [PORT]
 
-`asip-status [ -4 | -6 ] [-d] [-i] [-x] [ HOSTNAME:PORT ]`
+**asip-status** [ -4 | -6 ] [-d] [-i] [-x] [ HOSTNAME:PORT ]
 
-`asip-status [ -v | -version | --version ]`
+**asip-status** [ -v | -version | --version ]
 
 # Description
 

--- a/doc/manpages/man1/dbd.1.md
+++ b/doc/manpages/man1/dbd.1.md
@@ -4,9 +4,9 @@ dbd — CNID database maintenance
 
 # Synopsis
 
-`dbd [-cfFstuv] [volumepath]`
+**dbd** [-cfFstuv] [volumepath]
 
-`dbd [-V]`
+**dbd** [-V]
 
 # Description
 

--- a/doc/manpages/man1/getzones.1.md
+++ b/doc/manpages/man1/getzones.1.md
@@ -4,7 +4,7 @@ getzones — list AppleTalk zone names
 
 # Synopsis
 
-`getzones [ -m | -l ] [address]`
+**getzones** [ -m | -l ] [address]
 
 # Description
 

--- a/doc/manpages/man1/macusers.1.md
+++ b/doc/manpages/man1/macusers.1.md
@@ -6,7 +6,7 @@ macusers — List the users connecting via AFP
 
 **macusers**
 
-`macusers [ -v | -version | --version | -h | -help | --help ]`
+**macusers** [ -v | -version | --version | -h | -help | --help ]
 
 # Description
 

--- a/doc/manpages/man1/nbp.1.md
+++ b/doc/manpages/man1/nbp.1.md
@@ -2,6 +2,14 @@
 
 nbplkup, nbprgstr, nbpunrgstr — tools for accessing the NBP database
 
+# Synopsis
+
+**nbplkup**
+
+**nbprgstr** [ -A address ] [ -m Mac charset ] [ -p port ] obj:type@zone
+
+**nbpunrgstr** [ -A address ] [ -m Mac charset ] obj:type@zone
+
 # Description
 
 **nbprgstr** registers <nbpname\> with **atalkd**(8), at the given

--- a/doc/manpages/man1/pap.1.md
+++ b/doc/manpages/man1/pap.1.md
@@ -4,7 +4,7 @@ pap — client interface to remote printers using Printer Access Protocol
 
 # Synopsis
 
-`pap [-A address] [-c] [-d] [-e] [-E] [-p nbpname] [-s statusfile] [-w] [-W] [FILES]`
+**pap** [-A address] [-c] [-d] [-e] [-E] [-p nbpname] [-s statusfile] [-w] [-W] [FILES]
 
 # Description
 

--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -558,7 +558,7 @@ extmap file = <path\> **(G)**
 > Sets the path to the file which defines file extension type/creator
 mappings.
 
-force xattr with sticky bit = <BOOLEAN\> (default: *no*) `(G/V)`
+force xattr with sticky bit = <BOOLEAN\> (default: *no*) **(G)**/**(V)**
 
 > Writing metadata xattr on directories with the sticky bit set may fail
 even though we may have write access to a directory, because if the
@@ -569,7 +569,7 @@ sticky bit is set only the owner is allowed to write xattrs.
 ignored attributes = <all | nowrite | nodelete | norename\> **(G)**/**(V)**
 
 > Specify a set of file and directory attributes that shall be ignored by
-the server, `all` includes all the other options.
+the server, *all* includes all the other options.
 
 > In OS X when the Finder sets a lock on a file/directory or you set the
 BSD uchg flag in the Terminal, all three attributes are used. Thus in
@@ -767,7 +767,7 @@ Default: 0 milliseconds.
 fce ignore names = <NAME\[,NAME2,...\]\> **(G)**
 
 > Comma-delimited list of filenames for which FCE events shall not be
-generated. Default: `.DS_Store`
+generated. Default: *.DS_Store*
 
 fce ignore directories = <PATH\[,PATH2,...\]\> **(G)**
 
@@ -1301,7 +1301,7 @@ time machine = <BOOLEAN\> (default: *no*) **(V)**
 unix priv = <BOOLEAN\> (default: *yes*) **(V)**
 
 > Whether to use AFP3 UNIX privileges. This should be set for OS X
-clients. See also: **file perm**, **directory perm** and `umask`.
+clients. See also: **file perm**, **directory perm**, and **umask**.
 
 # Examples
 
@@ -1313,16 +1313,14 @@ used to make the server look like an Xserve.
 
 The home directory is mounted on */home/{user}/afp-data*.
 
-```
-[Global]
-afpstats = yes
-spotlight = yes
-mimic model = RackMac
+    [Global]
+    afpstats = yes
+    spotlight = yes
+    mimic model = RackMac
 
-[Home]
-basedir regex = /home
-path = afp-data
-```
+    [Home]
+    basedir regex = /home
+    path = afp-data
 
 ## Example: Classic Mac clients
 
@@ -1336,22 +1334,20 @@ for very old Macs, while **prodos** is used to enable ProDOS
 boot flags on the volume while limiting the volume free space
 to 32 MB.
 
-```
-[Global]
-appletalk = yes
-uam list = uams_dhx.so uams_dhx2.so uams_randnum.so uams_clrtxt.so
-legacy icon = daemon
+    [Global]
+    appletalk = yes
+    uam list = uams_dhx.so uams_dhx2.so uams_randnum.so uams_clrtxt.so
+    legacy icon = daemon
 
-[mac]
-volume name = Mac Files
-path = /srv/mac
-legacy volume size = yes
+    [mac]
+    volume name = Mac Files
+    path = /srv/mac
+    legacy volume size = yes
 
-[apple2]
-volume name = Apple II Files
-path = /srv/apple2
-prodos = yes
-```
+    [apple2]
+    volume name = Apple II Files
+    path = /srv/apple2
+    prodos = yes
 
 # See Also
 

--- a/doc/manpages/man5/afp_signature.conf.5.md
+++ b/doc/manpages/man5/afp_signature.conf.5.md
@@ -23,7 +23,7 @@ lines prefixed with \# are ignored. Any illegal lines are ignored.
 users from logging on to the same server twice.
 
 > Netatalk 2.0 and earlier generated a server signature by using
-`gethostid()`. This led to a problem where multiple servers could end up with
+*gethostid()*. This led to a problem where multiple servers could end up with
 the same signature because the hostid is not unique enough.
 
 > Current netatalk generates the signature from random numbers and saves

--- a/doc/manpages/man5/atalkd.conf.5.md
+++ b/doc/manpages/man5/atalkd.conf.5.md
@@ -11,7 +11,7 @@ Any line not prefixed with *\#* is interpreted. Each interface has be
 configured on an uninterrupted line, with no support for split lines.
 The configuration line format is:
 
-`interface [ -seed ] [ -phase <number> ] [ -net <net-range> ] [ -addr <address> ] [ -zone <zonename> ] ...`
+    interface [ -seed ] [ -phase <number> ] [ -net <net-range> ] [ -addr <address> ] [ -zone <zonename> ] ...
 
 The simplest case is to have either no atalkd.conf, or to have one that
 has no active lines. In this case, atalkd will auto-discover the local

--- a/doc/manpages/man5/extmap.conf.5.md
+++ b/doc/manpages/man5/extmap.conf.5.md
@@ -9,7 +9,7 @@ name extension mappings.
 
 The configuration lines are composed like:
 
-`.extension [ type [ creator ] ]`
+    .extension [ type [ creator ] ]
 
 Any line beginning with a hash (“#”) character is ignored. The
 leading-dot lines specify file name extension mappings. The extension

--- a/doc/manpages/man8/a2boot.8.md
+++ b/doc/manpages/man8/a2boot.8.md
@@ -4,9 +4,9 @@ a2boot — Apple II netboot server daemon
 
 # Synopsis
 
-`a2boot [-d] [-n nbpname]`
+**a2boot** [-d] [-n nbpname]
 
-`a2boot [ -v | -V ]`
+**a2boot** [ -v | -V ]
 
 # Description
 

--- a/doc/manpages/man8/afpd.8.md
+++ b/doc/manpages/man8/afpd.8.md
@@ -4,9 +4,9 @@ afpd — Apple Filing Protocol daemon
 
 # Synopsis
 
-`afpd [-d] [-F configfile]`
+**afpd** [-d] [-F configfile]
 
-`afpd [ -v | -V | -h ]`
+**afpd** [ -v | -V | -h ]
 
 # Description
 

--- a/doc/manpages/man8/atalkd.8.md
+++ b/doc/manpages/man8/atalkd.8.md
@@ -4,9 +4,9 @@ atalkd — userland AppleTalk network manager daemon
 
 # Synopsis
 
-`atalkd [-f configfile] [-P pidfile] [-1] [-2] [-d] [-t]`
+**atalkd** [-f configfile] [-P pidfile] [-1] [-2] [-d] [-t]
 
-`atalkd [ -v | -V ]`
+**atalkd** [ -v | -V ]
 
 # Description
 

--- a/doc/manpages/man8/cnid_dbd.8.md
+++ b/doc/manpages/man8/cnid_dbd.8.md
@@ -4,9 +4,9 @@ cnid_dbd — CNID database access daemon
 
 # Synopsis
 
-`cnid_dbd`
+**cnid_dbd**
 
-`cnid_dbd [ -v | -V ]`
+**cnid_dbd** [ -v | -V ]
 
 # Description
 
@@ -107,7 +107,7 @@ is exceeded, one of the existing connections is closed and reused. The
 affected *afpd* process will transparently reconnect later, which causes
 slight overhead. On the other hand, setting this parameter too high
 could affect performance in **cnid_dbd** since all descriptors have to be
-checked in a `select()` system call, or worse, you might exceed the per
+checked in a *select()* system call, or worse, you might exceed the per
 process limit of open file descriptors on your system. It is safe to set
 the value to 1 on volumes where only one *afpd* client process is
 expected to run, e.g. home directories.
@@ -119,26 +119,22 @@ Default: 600. Set this to 0 to disable the timeout.
 
 # Updating
 
-Note that the first version to appear *after* Netatalk 2.1 i.e. Netatalk
-2.1.1, will support Berkeley DB updates on the fly without manual
-intervention. In other words Netatalk 2.1 does contain code to prepare
-the Berkeley DB database for upgrades and to upgrade it in case it has
-been prepared before. That means it can't upgrade a 2.0.x version
-because that one didn't prepare the database.
+Starting with Netatalk 2.1.1, automatic Berkeley DB updates are supported,
+as long as Netatalk 2.1.0 or later was used to create the database.
 
 In order to update between older Netatalk releases using different
-Berkeley DB library versions, follow this steps:
+Berkeley DB library versions, follow these steps:
 
 - Stop the to be upgraded old version of Netatalk
 
 - Using the old Berkeley DB utilities run
-`db_recover -h <path to .AppleDB>`
+*db_recover -h <path to .AppleDB>*
 
 - Using the new Berkeley DB utilities run
-`db_upgrade -v -h <path to .AppleDB> -f cnid2.db`
+*db_upgrade -v -h <path to .AppleDB> -f cnid2.db*
 
 - Again using the new Berkeley DB utilities run
-`db_checkpoint -1 -h <path to .AppleDB>`
+*db_checkpoint -1 -h <path to .AppleDB>*
 
 - Start the the new version of Netatalk
 

--- a/doc/manpages/man8/cnid_metad.8.md
+++ b/doc/manpages/man8/cnid_metad.8.md
@@ -4,9 +4,9 @@ cnid_metad — daemon for starting cnid_dbd daemons on demand
 
 # Synopsis
 
-`cnid_metad [-d] [-F configuration file]`
+**cnid_metad** [-d] [-F configuration file]
 
-`cnid_metad [ -v | -V ]`
+**cnid_metad** [ -v | -V ]
 
 # Description
 

--- a/doc/manpages/man8/macipgw.8.md
+++ b/doc/manpages/man8/macipgw.8.md
@@ -4,9 +4,9 @@ macipgw — MacIP Gateway Daemon
 
 # Synopsis
 
-`macipgw [-d debugclass] [-f configfile] [-n nameserver] [-u unprivileged-user] [-z zone] [network] [netmask]`
+**macipgw** [-d debugclass] [-f configfile] [-n nameserver] [-u unprivileged-user] [-z zone] [network] [netmask]
 
-`macipgw [ -v | -V ]`
+**macipgw** [ -v | -V ]
 
 # Description
 

--- a/doc/manpages/man8/netatalk.8.md
+++ b/doc/manpages/man8/netatalk.8.md
@@ -4,9 +4,9 @@ netatalk — Netatalk AFP server service controller daemon
 
 # Synopsis
 
-`netatalk [-F configfile]`
+**netatalk** [-F configfile]
 
-`netatalk [ -v | -V ]`
+**netatalk** [ -v | -V ]
 
 # Description
 

--- a/doc/manpages/man8/papd.8.md
+++ b/doc/manpages/man8/papd.8.md
@@ -4,9 +4,9 @@ papd — AppleTalk print server daemon
 
 # Synopsis
 
-`papd [-d] [-f configfile] [-p printcap] [-P pidfile]`
+**papd** [-d] [-f configfile] [-p printcap] [-P pidfile]
 
-`papd [ -v | -V ]`
+**papd** [ -v | -V ]
 
 # Description
 

--- a/doc/manpages/man8/papstatus.8.md
+++ b/doc/manpages/man8/papstatus.8.md
@@ -4,7 +4,7 @@ papstatus — get the status of an AppleTalk-connected printer
 
 # Synopsis
 
-`papstatus [-d] [-p printer] [retrytime]`
+**papstatus** [-d] [-p printer] [retrytime]
 
 # Description
 

--- a/doc/manpages/man8/timelord.8.md
+++ b/doc/manpages/man8/timelord.8.md
@@ -4,9 +4,9 @@ timelord — Macintosh time server daemon
 
 # Synopsis
 
-`timelord [-d] [-l] [-n nbpname]`
+**timelord** [-d] [-l] [-n nbpname]
 
-`timelord [ -v | -V ]`
+**timelord** [ -v | -V ]
 
 # Description
 

--- a/doc/po/a2boot.8.md.ja.po
+++ b/doc/po/a2boot.8.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 01:30+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -43,14 +43,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -59,9 +60,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -91,17 +92,17 @@ msgstr ""
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
+#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -113,17 +114,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:46 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
+#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -152,12 +153,14 @@ msgstr "a2boot — Apple II ネットブート サーバー デーモン"
 
 #. type: Plain text
 #: manpages/man8/a2boot.8.md:8
-msgid "`a2boot [-d] [-n nbpname]`"
+#, no-wrap
+msgid "**a2boot** [-d] [-n nbpname]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man8/a2boot.8.md:10
-msgid "`a2boot [ -v | -V ]`"
+#, no-wrap
+msgid "**a2boot** [ -v | -V ]\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/ad.1.md.ja.po
+++ b/doc/po/ad.1.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 12:47+0100\n"
+"POT-Creation-Date: 2025-04-16 08:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -50,35 +50,38 @@ msgstr "ad - AppleDouble ファイルユーティリティ 一式"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
 
 #. type: Plain text
 #: manpages/man1/ad.1.md:8
-msgid "`ad [ ls | cp | mv | rm | set ] [...]`"
+#, no-wrap
+msgid "**ad** [ ls | cp | mv | rm | set ] [...]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/ad.1.md:10
-msgid "`ad [ -v | --version ]`"
+#, no-wrap
+msgid "**ad** [ -v | --version ]\n"
 msgstr ""
 
 #. type: Title #
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -118,7 +121,7 @@ msgstr "List files and directories."
 #. type: Plain text
 #: manpages/man1/ad.1.md:24
 #, no-wrap
-msgid "> `ad ls [-dRl[u]] {file|dir [...]}`\n"
+msgid "> ad ls [-dRl[u]] {file|dir [...]}\n"
 msgstr ""
 
 #. type: Plain text
@@ -129,13 +132,13 @@ msgstr "ファイルやディレクトリをコピーする。"
 #. type: Plain text
 #: manpages/man1/ad.1.md:28
 #, no-wrap
-msgid "> `ad cp [-aipvf] {src_file} {dst_file}`\n"
+msgid "> ad cp [-aipvf] {src_file} {dst_file}\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/ad.1.md:30
 #, no-wrap
-msgid "> `ad cp -R [-aipvf] {src_file|src_directory ...} {dst_directory}`\n"
+msgid "> ad cp -R [-aipvf] {src_file|src_directory ...} {dst_directory}\n"
 msgstr ""
 
 #. type: Plain text
@@ -146,13 +149,13 @@ msgstr "ファイルやディレクトリを移動する。"
 #. type: Plain text
 #: manpages/man1/ad.1.md:34
 #, no-wrap
-msgid "> `ad mv [-finv] {src_file} {dst_file}`\n"
+msgid "> ad mv [-finv] {src_file} {dst_file}\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/ad.1.md:36
 #, no-wrap
-msgid "> `ad mv [-finv] {src_file|src_directory ...} {dst_directory}`\n"
+msgid "> ad mv [-finv] {src_file|src_directory ...} {dst_directory}\n"
 msgstr ""
 
 #. type: Plain text
@@ -163,7 +166,7 @@ msgstr "ファイルやディレクトリを削除する。"
 #. type: Plain text
 #: manpages/man1/ad.1.md:40
 #, no-wrap
-msgid "> `ad rm [-Rv] {file|directory}`\n"
+msgid "> ad rm [-Rv] {file|directory}\n"
 msgstr ""
 
 #. type: Plain text
@@ -174,7 +177,7 @@ msgstr "ファイルにメタデータを設定する。"
 #. type: Plain text
 #: manpages/man1/ad.1.md:44
 #, no-wrap
-msgid "> `ad set [-t type] [-c creator] [-l label] [-f flags] [-a attributes] {file}`\n"
+msgid "> ad set [-t type] [-c creator] [-l label] [-f flags] [-a attributes] {file}\n"
 msgstr ""
 
 #. type: Plain text
@@ -185,8 +188,8 @@ msgstr "バージョンを表示する。"
 #. type: Plain text
 #: manpages/man1/ad.1.md:48
 #, no-wrap
-msgid "> `ad -v | --version`\n"
-msgstr ""
+msgid "> ad -v | --version\n"
+msgstr "> バージョンを表示する。\n"
 
 #. type: Title #
 #: manpages/man1/ad.1.md:49
@@ -651,9 +654,9 @@ msgid "    Finder Flags (valid for (f)iles and/or (d)irectories):\n"
 msgstr ""
 
 #. type: Title #
-#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:85
-#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:46
-#: manpages/man5/afp_signature.conf.5.md:44
+#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:172
+#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:54
+#: manpages/man5/afp_signature.conf.5.md:46
 #: manpages/man5/afp_voluuid.conf.5.md:38 manpages/man8/papd.8.md:132
 #, no-wrap
 msgid "See also"
@@ -668,17 +671,17 @@ msgstr ""
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1279
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -690,17 +693,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1281
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""

--- a/doc/po/addump.1.md.ja.po
+++ b/doc/po/addump.1.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 18:48+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -45,14 +45,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -61,9 +62,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -82,17 +83,17 @@ msgstr "説明"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1279
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -104,17 +105,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1281
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -128,32 +129,38 @@ msgstr "addump - AppleSingle/AppleDouble フォーマットのデータをダン
 
 #. type: Plain text
 #: manpages/man1/addump.1.md:8
-msgid "`addump [-a] [ FILE | DIR ]`"
+#, no-wrap
+msgid "**addump** [-a] [ FILE | DIR ]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/addump.1.md:10
-msgid "`addump [-e] [ FILE | DIR ]`"
+#, no-wrap
+msgid "**addump** [-e] [ FILE | DIR ]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/addump.1.md:12
-msgid "`addump [-f] [FILE]`"
+#, no-wrap
+msgid "**addump** [-f] [FILE]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/addump.1.md:14
-msgid "`addump [-d] [FILE]`"
+#, no-wrap
+msgid "**addump** [-d] [FILE]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/addump.1.md:16
-msgid "`addump [ -h | -help | --help ]`"
+#, no-wrap
+msgid "**addump** [ -h | -help | --help ]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/addump.1.md:18
-msgid "`addump [ -v | -version | --version ]`"
+#, no-wrap
+msgid "**addump** [ -v | -version | --version ]\n"
 msgstr ""
 
 #. type: Plain text
@@ -304,10 +311,10 @@ msgstr ""
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1274 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap

--- a/doc/po/aecho.1.md.ja.po
+++ b/doc/po/aecho.1.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 00:36+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -43,14 +43,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -59,9 +60,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -80,19 +81,19 @@ msgstr "説明"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
-#: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:32
+#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
+#: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
-#: manpages/man8/papd.8.md:137 manpages/man8/papstatus.8.md:53
+#: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
 msgid "Author"
@@ -102,18 +103,18 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:46 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
-#: manpages/man5/atalkd.conf.5.md:106 manpages/man5/extmap.conf.5.md:34
+#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
+#: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:139
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"
@@ -140,10 +141,10 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1273 manpages/man5/atalkd.conf.5.md:100
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -159,7 +160,8 @@ msgstr ""
 
 #. type: Plain text
 #: manpages/man1/aecho.1.md:8
-msgid "`aecho [-c count] [ address | nbpname ]`"
+#, no-wrap
+msgid "**aecho** [-c count] [ address | nbpname ]\n"
 msgstr ""
 
 #. type: Plain text
@@ -195,12 +197,12 @@ msgstr ""
 
 #. type: Title #
 #: manpages/man1/aecho.1.md:24 manpages/man1/afppasswd.1.md:26
-#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:50
-#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
-#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/atalkd.conf.5.md:82
-#: manpages/man5/extmap.conf.5.md:18 manpages/man5/papd.conf.5.md:91
-#: manpages/man8/macipgw.8.md:79
+#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:103
+#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:39
+#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:39
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1306
+#: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
+#: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
 msgid "Examples"
 msgstr "例"

--- a/doc/po/afp.conf.5.md.ja.po
+++ b/doc/po/afp.conf.5.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-04-12 20:52+0200\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -45,14 +45,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -61,17 +62,17 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:179 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
 #: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1361
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -83,17 +84,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:181 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
 #: manpages/man5/afp_signature.conf.5.md:52
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1363
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -106,10 +107,10 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1356 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -119,7 +120,7 @@ msgstr "関連項目"
 #. type: Title #
 #: manpages/man1/aecho.1.md:24 manpages/man1/afppasswd.1.md:26
 #: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:103
-#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
+#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:39
 #: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:39
 #: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1306
 #: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
@@ -1614,8 +1615,8 @@ msgstr "> ファイル拡張子とタイプ/クリエータのマッピングを
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:562
 #, no-wrap
-msgid "force xattr with sticky bit = <BOOLEAN\\> (default: *no*) `(G/V)`\n"
-msgstr "force xattr with sticky bit = <BOOLEAN\\> (デフォルト: *no*) `(G/V)`\n"
+msgid "force xattr with sticky bit = <BOOLEAN\\> (default: *no*) **(G)**/**(V)**\n"
+msgstr "force xattr with sticky bit = <BOOLEAN\\> (デフォルト: *no*) **(G)**/**(V)**\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:566
@@ -1643,8 +1644,8 @@ msgstr ""
 #, no-wrap
 msgid ""
 "> Specify a set of file and directory attributes that shall be ignored by\n"
-"the server, `all` includes all the other options.\n"
-msgstr "> サーバが無視すべきファイルとディレクトリの属性を設定する。`all`はオプション全部という意味である。\n"
+"the server, *all* includes all the other options.\n"
+msgstr "> サーバが無視すべきファイルとディレクトリの属性を設定する。*all*はオプション全部という意味である。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:578
@@ -2181,10 +2182,10 @@ msgstr ""
 #, no-wrap
 msgid ""
 "> Comma-delimited list of filenames for which FCE events shall not be\n"
-"generated. Default: `.DS_Store`\n"
+"generated. Default: *.DS_Store*\n"
 msgstr ""
 "> FCEイベントを生成すべきでないファイル名をカンマ区切りのリスト。デフォルトでは\n"
-"`.DS_Store`\n"
+"*.DS_Store*\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:773
@@ -3693,11 +3694,11 @@ msgstr "unix priv = <BOOLEAN\\> (デフォルト: *yes*) **(V)**\n"
 #, no-wrap
 msgid ""
 "> Whether to use AFP3 UNIX privileges. This should be set for OS X\n"
-"clients. See also: **file perm**, **directory perm** and `umask`.\n"
+"clients. See also: **file perm**, **directory perm**, and **umask**.\n"
 msgstr ""
 "> AFP3 UNIX 権限を使うかどうか。これは OS X\n"
 "クライアントに対しては設定すべきである。**file perm**、**directory perm**\n"
-"及び `umask` も参照。\n"
+"及び **umask** も参照。\n"
 
 #. type: Title ##
 #: manpages/man5/afp.conf.5.md:1308
@@ -3721,28 +3722,33 @@ msgstr ""
 msgid "The home directory is mounted on */home/{user}/afp-data*."
 msgstr "ホームディレクトリは */home/{user}/afp-data* にマウントされる。"
 
-#. type: Fenced code block
-#: manpages/man5/afp.conf.5.md:1316
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:1320
 #, no-wrap
 msgid ""
-"[Global]\n"
-"afpstats = yes\n"
-"spotlight = yes\n"
-"mimic model = RackMac\n"
-"\n"
-"[Home]\n"
-"basedir regex = /home\n"
-"path = afp-data\n"
+"    [Global]\n"
+"    afpstats = yes\n"
+"    spotlight = yes\n"
+"    mimic model = RackMac\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:1324
+#, no-wrap
+msgid ""
+"    [Home]\n"
+"    basedir regex = /home\n"
+"    path = afp-data\n"
 msgstr ""
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:1327
+#: manpages/man5/afp.conf.5.md:1325
 #, no-wrap
 msgid "Example: Classic Mac clients"
 msgstr "例：レトロ Mac クライアント"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1333
+#: manpages/man5/afp.conf.5.md:1331
 msgid ""
 "This enables AppleTalk if Netatalk was built with AppleTalk support.  The "
 "Random Number and ClearTxt authentication modules are used.  The **legacy "
@@ -3753,7 +3759,7 @@ msgstr ""
 "ションはサーバーを BSD デーモンのように見せるために使われる。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1338
+#: manpages/man5/afp.conf.5.md:1336
 msgid ""
 "With **legacy volume size** the volume size is limited to 2 GB for very old "
 "Macs, while **prodos** is used to enable ProDOS boot flags on the volume "
@@ -3763,28 +3769,38 @@ msgstr ""
 "ボリュームに ProDOS ブートフラグを設定する上、ボリュームの空き領域は 32 MB に"
 "制限される。"
 
-#. type: Fenced code block
-#: manpages/man5/afp.conf.5.md:1339
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:1341
 #, no-wrap
 msgid ""
-"[Global]\n"
-"appletalk = yes\n"
-"uam list = uams_dhx.so uams_dhx2.so uams_randnum.so uams_clrtxt.so\n"
-"legacy icon = daemon\n"
-"\n"
-"[mac]\n"
-"volume name = Mac Files\n"
-"path = /srv/mac\n"
-"legacy volume size = yes\n"
-"\n"
-"[apple2]\n"
-"volume name = Apple II Files\n"
-"path = /srv/apple2\n"
-"prodos = yes\n"
+"    [Global]\n"
+"    appletalk = yes\n"
+"    uam list = uams_dhx.so uams_dhx2.so uams_randnum.so uams_clrtxt.so\n"
+"    legacy icon = daemon\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1360
+#: manpages/man5/afp.conf.5.md:1346
+#, no-wrap
+msgid ""
+"    [mac]\n"
+"    volume name = Mac Files\n"
+"    path = /srv/mac\n"
+"    legacy volume size = yes\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:1351
+#, no-wrap
+msgid ""
+"    [apple2]\n"
+"    volume name = Apple II Files\n"
+"    path = /srv/apple2\n"
+"    prodos = yes\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man5/afp.conf.5.md:1356
 msgid ""
 "afpd(8), afppasswd(5), afp_signature.conf(5), extmap.conf(5), cnid_metad(8)"
 msgstr ""

--- a/doc/po/afp_signature.conf.5.md.ja.po
+++ b/doc/po/afp_signature.conf.5.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-04-06 19:17+0200\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -45,7 +45,7 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
 #: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -61,8 +61,8 @@ msgid "Description"
 msgstr "説明"
 
 #. type: Title #
-#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:91
-#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:46
+#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:172
+#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:54
 #: manpages/man5/afp_signature.conf.5.md:46
 #: manpages/man5/afp_voluuid.conf.5.md:38 manpages/man8/papd.8.md:132
 #, no-wrap
@@ -73,17 +73,17 @@ msgstr "参照"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:95 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
 #: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1362
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -95,17 +95,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:97 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
 #: manpages/man5/afp_signature.conf.5.md:52
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1364
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -114,10 +114,10 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 
 #. type: Title #
 #: manpages/man1/aecho.1.md:24 manpages/man1/afppasswd.1.md:26
-#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:56
-#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
+#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:103
+#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:39
 #: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:39
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1307
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1306
 #: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
 #: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
@@ -129,8 +129,8 @@ msgstr "例"
 #: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:339
 #: manpages/man5/afp.conf.5.md:363 manpages/man5/afp.conf.5.md:376
 #: manpages/man5/afp.conf.5.md:391 manpages/man5/afp.conf.5.md:694
-#: manpages/man5/afp.conf.5.md:1093 manpages/man5/afp.conf.5.md:1219
-#: manpages/man5/afp.conf.5.md:1257 manpages/man8/papd.8.md:96
+#: manpages/man5/afp.conf.5.md:1093 manpages/man5/afp.conf.5.md:1218
+#: manpages/man5/afp.conf.5.md:1256 manpages/man8/papd.8.md:96
 #: manual/Configuration.md:113
 #, no-wrap
 msgid "> **NOTE**\n"
@@ -194,11 +194,11 @@ msgstr "> サーバシグネチャは同じサーバに二重にログオンす�
 #, no-wrap
 msgid ""
 "> Netatalk 2.0 and earlier generated a server signature by using\n"
-"`gethostid()`. This led to a problem where multiple servers could end up with\n"
+"*gethostid()*. This led to a problem where multiple servers could end up with\n"
 "the same signature because the hostid is not unique enough.\n"
 msgstr ""
 "> Netatalk\n"
-"2.0以前は`gethostid()`を使ってサーバシグネチャを生成した。他のサーバが同じシグネチャをもつ問題があった。なぜなら、hostidは十分に固有でないからである。\n"
+"2.0以前は*gethostid()*を使ってサーバシグネチャを生成した。他のサーバが同じシグネチャをもつ問題があった。なぜなら、hostidは十分に固有でないからである。\n"
 
 #. type: Plain text
 #: manpages/man5/afp_signature.conf.5.md:32

--- a/doc/po/afpd.8.md.ja.po
+++ b/doc/po/afpd.8.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 12:33+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -45,14 +45,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -61,9 +62,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -101,17 +102,17 @@ msgstr ""
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -123,17 +124,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -161,10 +162,10 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1273 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -200,12 +201,14 @@ msgstr "afpd — Apple Filing Protocol デーモン"
 
 #. type: Plain text
 #: manpages/man8/afpd.8.md:8
-msgid "`afpd [-d] [-F configfile]`"
+#, no-wrap
+msgid "**afpd** [-d] [-F configfile]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man8/afpd.8.md:10
-msgid "`afpd [ -v | -V | -h ]`"
+#, no-wrap
+msgid "**afpd** [ -v | -V | -h ]\n"
 msgstr ""
 
 #. type: Plain text
@@ -375,7 +378,6 @@ msgstr "> **afpd**プロセスはビルド時に設定したメッセージデ�
 
 #. type: Plain text
 #: manpages/man8/afpd.8.md:91 manpages/man8/netatalk.8.md:45
-#: manual/Upgrading.md:33
 #, no-wrap
 msgid "*afp.conf*\n"
 msgstr ""

--- a/doc/po/afpldaptest.1.md.ja.po
+++ b/doc/po/afpldaptest.1.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 12:57+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -45,14 +45,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -61,9 +62,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -82,17 +83,17 @@ msgstr "説明"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1279
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -104,17 +105,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1281
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -142,10 +143,10 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1274 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -159,12 +160,14 @@ msgstr "afpldaptest — afp.conf の LDAP パラメータを構文チェック�
 
 #. type: Plain text
 #: manpages/man1/afpldaptest.1.md:8
-msgid "`afpldaptest [ -u USER | -g GROUP | -i UUID ]`"
+#, no-wrap
+msgid "**afpldaptest** [ -u USER | -g GROUP | -i UUID ]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/afpldaptest.1.md:10
-msgid "`afpldaptest [ -h | -? | -: ]`"
+#, no-wrap
+msgid "**afpldaptest** [ -h | -? | -: ]\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/afppasswd.1.md.ja.po
+++ b/doc/po/afppasswd.1.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 12:47+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -45,14 +45,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -61,9 +62,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -102,17 +103,17 @@ msgstr ""
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1279
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -124,17 +125,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1281
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -162,10 +163,10 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1274 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -174,12 +175,12 @@ msgstr "関連項目"
 
 #. type: Title #
 #: manpages/man1/aecho.1.md:24 manpages/man1/afppasswd.1.md:26
-#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:50
-#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
-#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/atalkd.conf.5.md:80
-#: manpages/man5/extmap.conf.5.md:18 manpages/man5/papd.conf.5.md:91
-#: manpages/man8/macipgw.8.md:79
+#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:103
+#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:39
+#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:39
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1306
+#: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
+#: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
 msgid "Examples"
 msgstr "例"
@@ -191,8 +192,8 @@ msgstr "afppasswd — AFP パスワード保守ユーティリティ"
 
 #. type: Plain text
 #: manpages/man1/afppasswd.1.md:8
-msgid ""
-"`afppasswd [-acfn] [-p afppasswd file] [-u minimum uid] [-w password string]`"
+#, no-wrap
+msgid "**afppasswd** [-acfn] [-p afppasswd file] [-u minimum uid] [-w password string]\n"
 msgstr ""
 
 #. type: Plain text
@@ -215,11 +216,11 @@ msgstr "**afppasswd**は、rootがパラメータ付きで呼び出すことも�
 
 #. type: Plain text
 #: manpages/man1/afppasswd.1.md:20 manpages/man5/afp_signature.conf.5.md:21
-#: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:319
-#: manpages/man5/afp.conf.5.md:343 manpages/man5/afp.conf.5.md:356
-#: manpages/man5/afp.conf.5.md:371 manpages/man5/afp.conf.5.md:723
-#: manpages/man5/afp.conf.5.md:1049 manpages/man5/afp.conf.5.md:1174
-#: manpages/man5/afp.conf.5.md:1212 manpages/man8/papd.8.md:96
+#: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:339
+#: manpages/man5/afp.conf.5.md:363 manpages/man5/afp.conf.5.md:376
+#: manpages/man5/afp.conf.5.md:391 manpages/man5/afp.conf.5.md:694
+#: manpages/man5/afp.conf.5.md:1093 manpages/man5/afp.conf.5.md:1218
+#: manpages/man5/afp.conf.5.md:1256 manpages/man8/papd.8.md:96
 #: manual/Configuration.md:113
 #, no-wrap
 msgid "> **NOTE**\n"

--- a/doc/po/afptest.1.md.ja.po
+++ b/doc/po/afptest.1.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-04-12 14:08+0200\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -43,14 +43,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -61,7 +62,7 @@ msgstr "概要"
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
 #: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -77,8 +78,8 @@ msgid "Description"
 msgstr "説明"
 
 #. type: Title #
-#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:175
-#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:46
+#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:172
+#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:54
 #: manpages/man5/afp_signature.conf.5.md:46
 #: manpages/man5/afp_voluuid.conf.5.md:38 manpages/man8/papd.8.md:132
 #, no-wrap
@@ -89,17 +90,17 @@ msgstr "参照"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:179 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
 #: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1362
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -111,17 +112,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:181 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
 #: manpages/man5/afp_signature.conf.5.md:52
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1364
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -131,9 +132,9 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 #. type: Title #
 #: manpages/man1/aecho.1.md:24 manpages/man1/afppasswd.1.md:26
 #: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:103
-#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
+#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:39
 #: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:39
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1307
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1306
 #: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
 #: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
@@ -151,44 +152,38 @@ msgstr ""
 
 #. type: Plain text
 #: manpages/man1/afptest.1.md:8
-msgid ""
-"`afp_lantest [-34567GgVv] [-h host] [-p port] [-s volume] [-u user] [-w "
-"password] [-n iterations] [-t tests] [-F bigfile]`"
+#, no-wrap
+msgid "**afp_lantest** [-34567GgVv] [-h host] [-p port] [-s volume] [-u user] [-w password] [-n iterations] [-t tests] [-F bigfile]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/afptest.1.md:10
-msgid ""
-"`afp_logintest [-1234567CmVv] [-h host] [-p port] [-s volume] [-u user] [-w "
-"password]`"
+#, no-wrap
+msgid "**afp_logintest** [-1234567CmVv] [-h host] [-p port] [-s volume] [-u user] [-w password]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/afptest.1.md:12
-msgid ""
-"`afp_spectest [-1234567aCiLlmVvXx] [-h host] [-H host2] [-p port] [-s "
-"volume] [-c path to volume] [-S volume2] [-u user] [-d user2] [-w password] "
-"[-f test]`"
+#, no-wrap
+msgid "**afp_spectest** [-1234567aCiLlmVvXx] [-h host] [-H host2] [-p port] [-s volume] [-c path to volume] [-S volume2] [-u user] [-d user2] [-w password] [-f test]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/afptest.1.md:14
-msgid ""
-"`afp_speedtest [-1234567aeiLnVvy] [-h host] [-p port] [-s volume] [-S "
-"volume2] [-u user] [-w password] [-n iterations] [-d size] [-q quantum] [-F "
-"file] [-f test]`"
+#, no-wrap
+msgid "**afp_speedtest** [-1234567aeiLnVvy] [-h host] [-p port] [-s volume] [-S volume2] [-u user] [-w password] [-n iterations] [-d size] [-q quantum] [-F file] [-f test]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/afptest.1.md:16
-msgid ""
-"`afparg [-1234567lVv] [-h host] [-p port] [-s volume] [-u user] [-w "
-"password] [-f command]`"
+#, no-wrap
+msgid "**afparg** [-1234567lVv] [-h host] [-p port] [-s volume] [-u user] [-w password] [-f command]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/afptest.1.md:18
-msgid "`fce_listen [-h host] [-p port]`"
+#, no-wrap
+msgid "**fce_listen** [-h host] [-p port]\n"
 msgstr ""
 
 #. type: Plain text
@@ -340,8 +335,8 @@ msgstr "ヘルパー"
 msgid ""
 "**afparg** is an interactive AFP client that takes an AFP command with\n"
 "optional arguments. This can be used for troubleshooting or system\n"
-"administration. Run `afparg -l` to list available commands.\n"
-msgstr "**afparg** は、オプションの引数を持つ特定のコマンドを受け取り、AFP サーバーにアクションを送信する対話型 AFP クライアントである。サーバの問題検討やシステム管理などに活用できる。`afparg -l` を実行して利用可能なコマンドを一覧表示する。\n"
+"administration. Run *afparg -l* to list available commands.\n"
+msgstr "**afparg** は、オプションの引数を持つ特定のコマンドを受け取り、AFP サーバーにアクションを送信する対話型 AFP クライアントである。サーバの問題検討やシステム管理などに活用できる。*afparg -l* を実行して利用可能なコマンドを一覧表示する。\n"
 
 #. type: Plain text
 #: manpages/man1/afptest.1.md:81
@@ -372,13 +367,13 @@ msgstr ""
 #. type: Plain text
 #: manpages/man1/afptest.1.md:91
 msgid ""
-"Launch the test runner with the `-m` option when testing a Mac AFP server.  "
-"When running in Mac mode, the test runner will report tests with known "
-"current or historical differences between Mac and Netatalk."
+"Launch the test runner with the **-m** option when testing a Mac AFP "
+"server.  When running in Mac mode, the test runner will report tests with "
+"known current or historical differences between Mac and Netatalk."
 msgstr ""
-"Mac AFP サーバーをテストする場合は、`-m` オプションを使用してテストランナーを"
-"起動する。Mac モードで実行すると、テストランナーは、Mac と Netatalk の間の既"
-"知の現在または過去の相違点を持つテストを報告する。"
+"Mac AFP サーバーをテストする場合は、**-m** オプションを使用してテストランナー"
+"を起動する。Mac モードで実行すると、テストランナーは、Mac と Netatalk の間の"
+"既知の現在または過去の相違点を持つテストを報告する。"
 
 #. type: Plain text
 #: manpages/man1/afptest.1.md:93
@@ -422,53 +417,49 @@ msgid "Below is a sample configuration for running the APF spec tests."
 msgstr "以下は、APF 仕様テストを実行するためのサンプル設定です。"
 
 #. type: Bullet: '- '
-#: manpages/man1/afptest.1.md:114
-msgid "2 users: `user1`, `user2` with the same password"
-msgstr "2人のユーザー: `user1`, `user2` は同じパスワードを持つ。"
+#: manpages/man1/afptest.1.md:113
+msgid "2 users: user1, user2 with the same password"
+msgstr "2人のユーザー: user1, user2 は同じパスワードを持つ。"
 
 #. type: Bullet: '- '
-#: manpages/man1/afptest.1.md:114
-msgid "1 group: `afpusers`"
-msgstr "1つのグループ: `afpusers`"
+#: manpages/man1/afptest.1.md:113
+msgid "1 group: afpusers"
+msgstr "1つのグループ: afpusers"
 
 #. type: Bullet: '- '
-#: manpages/man1/afptest.1.md:114
-msgid "`user1`, `user2` assigned to `afpusers` group"
-msgstr "`user1`, `user2` は `afpusers` グループに割り当てられる。"
+#: manpages/man1/afptest.1.md:113
+msgid "user1, user2 assigned to afpusers group"
+msgstr "user1, user2 は afpusers グループに割り当てられる。"
 
 #. type: Bullet: '- '
-#: manpages/man1/afptest.1.md:114
+#: manpages/man1/afptest.1.md:113
 msgid "clear text UAM + guest UAM"
 msgstr ""
 
-#. type: Bullet: '- '
-#: manpages/man1/afptest.1.md:114
-msgid "two empty volumes:"
-msgstr "2つの空のボリューム:"
+#. type: Plain text
+#: manpages/man1/afptest.1.md:116
+msgid ""
+"Arrange two *empty* directories. Some tests will fail if there are residual "
+"files in the test directories."
+msgstr ""
+"2つの空のディレクトリを用意する。テストディレクトリに残ったファイルがあると、"
+"いくつかのテストが失敗する。"
 
-#. type: Fenced code block
-#: manpages/man1/afptest.1.md:115
+#. type: Plain text
+#: manpages/man1/afptest.1.md:119
 #, no-wrap
 msgid ""
-"drwxrwsr-x    5 user1   afpusers       176 avr 27 23:56 /tmp/afptest1\n"
-"drwxrwsr-x    5 user1   afpusers       176 avr 27 23:56 /tmp/afptest2\n"
+"    drwxrwsr-x    5 user1   afpusers       176 avr 27 23:56 /tmp/afptest1\n"
+"    drwxrwsr-x    5 user1   afpusers       176 avr 27 23:56 /tmp/afptest2\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/afptest.1.md:122
-#, no-wrap
-msgid ""
-"*Note:* Some tests will fail if there are residual files\n"
-"in the test volumes.\n"
-msgstr "*注意:* テストボリュームに残ったファイルがあると、いくつかのテストが失敗する。\n"
-
-#. type: Plain text
-#: manpages/man1/afptest.1.md:124
+#: manpages/man1/afptest.1.md:121
 msgid "Set afp.conf as follows:"
 msgstr "afp.confオプションは次の通り。"
 
 #. type: Plain text
-#: manpages/man1/afptest.1.md:127
+#: manpages/man1/afptest.1.md:124
 #, no-wrap
 msgid ""
 "    [Global]\n"
@@ -476,7 +467,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/afptest.1.md:133
+#: manpages/man1/afptest.1.md:130
 #, no-wrap
 msgid ""
 "    [testvol1]\n"
@@ -487,7 +478,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/afptest.1.md:139
+#: manpages/man1/afptest.1.md:136
 #, no-wrap
 msgid ""
 "    [testvol2]\n"
@@ -498,20 +489,20 @@ msgid ""
 msgstr ""
 
 #. type: Title ##
-#: manpages/man1/afptest.1.md:140
+#: manpages/man1/afptest.1.md:137
 #, no-wrap
 msgid "Running tests"
 msgstr "テストを実行する"
 
 #. type: Plain text
-#: manpages/man1/afptest.1.md:143
+#: manpages/man1/afptest.1.md:140
 msgid ""
 "Run the afp_spectest for the \"FPSetForkParms_test\" testset with AFP 3.4."
 msgstr ""
 "afp_spectest の FPSetForkParms_test テストセットを AFP 3.4 で実行する。"
 
 #. type: Plain text
-#: manpages/man1/afptest.1.md:152
+#: manpages/man1/afptest.1.md:149
 #, no-wrap
 msgid ""
 "    % afp_spectest -h 127.0.0.1 -p 548 -u user1 -d user2 -w passwd -s testvol1 -S testvol2 -c /srv/afptest1 -7 -f FPSetForkParms_test\n"
@@ -525,12 +516,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/afptest.1.md:154
+#: manpages/man1/afptest.1.md:151
 msgid "Run the afp_lantest benchmark using AFP 3.0."
 msgstr "AFP 3.0 を使用して afp_lantest ベンチマークを実行する。"
 
 #. type: Plain text
-#: manpages/man1/afptest.1.md:163
+#: manpages/man1/afptest.1.md:160
 #, no-wrap
 msgid ""
 "    % afp_lantest -h 192.168.0.2 -s testvol1 -u user1 -w passwd -3\n"
@@ -544,7 +535,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/afptest.1.md:166
+#: manpages/man1/afptest.1.md:163
 #, no-wrap
 msgid ""
 "    Netatalk Lantest Results (averages)\n"
@@ -552,7 +543,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/afptest.1.md:174
+#: manpages/man1/afptest.1.md:171
 #, no-wrap
 msgid ""
 "    Opening, stating and reading 512 bytes from 1000 files   1799 ms\n"
@@ -565,6 +556,6 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/afptest.1.md:178 manpages/man1/macusers.1.md:28
+#: manpages/man1/afptest.1.md:175 manpages/man1/macusers.1.md:28
 msgid "afpd(8)"
 msgstr ""

--- a/doc/po/asip-status.1.md.ja.po
+++ b/doc/po/asip-status.1.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 18:48+0100\n"
+"POT-Creation-Date: 2025-04-16 19:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -45,14 +45,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -61,9 +62,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -106,17 +107,17 @@ msgstr ""
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1279
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -128,17 +129,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1281
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -169,12 +170,12 @@ msgstr ""
 
 #. type: Title #
 #: manpages/man1/aecho.1.md:24 manpages/man1/afppasswd.1.md:26
-#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:50
-#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
-#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/atalkd.conf.5.md:80
-#: manpages/man5/extmap.conf.5.md:18 manpages/man5/papd.conf.5.md:91
-#: manpages/man8/macipgw.8.md:79
+#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:103
+#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:39
+#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:39
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1306
+#: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
+#: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
 msgid "Examples"
 msgstr "例"
@@ -186,17 +187,20 @@ msgstr "asip-status — AFP サーバに機能を問い合わせる"
 
 #. type: Plain text
 #: manpages/man1/asip-status.1.md:8
-msgid "`asip-status [ -4 | -6 ] [-d] [-i] [-x] [HOSTNAME] [PORT]`"
+#, no-wrap
+msgid "**asip-status** [ -4 | -6 ] [-d] [-i] [-x] [HOSTNAME] [PORT]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/asip-status.1.md:10
-msgid "`asip-status [ -4 | -6 ] [-d] [-i] [-x] [ HOSTNAME:PORT ]`"
+#, no-wrap
+msgid "**asip-status** [ -4 | -6 ] [-d] [-i] [-x] [ HOSTNAME:PORT ]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/asip-status.1.md:12
-msgid "`asip-status [ -v | -version | --version ]`"
+#, no-wrap
+msgid "**asip-status** [ -v | -version | --version ]\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/atalkd.8.md.ja.po
+++ b/doc/po/atalkd.8.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 12:33+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -43,14 +43,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -59,9 +60,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -91,17 +92,17 @@ msgstr ""
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -113,17 +114,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -151,10 +152,10 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1273 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -199,12 +200,14 @@ msgstr "atalkd — ユーザーランド AppleTalk ネットワーク マネー�
 
 #. type: Plain text
 #: manpages/man8/atalkd.8.md:8
-msgid "`atalkd [-f configfile] [-P pidfile] [-1] [-2] [-d] [-t]`"
+#, no-wrap
+msgid "**atalkd** [-f configfile] [-P pidfile] [-1] [-2] [-d] [-t]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man8/atalkd.8.md:10
-msgid "`atalkd [ -v | -V ]`"
+#, no-wrap
+msgid "**atalkd** [ -v | -V ]\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/atalkd.conf.5.md.ja.po
+++ b/doc/po/atalkd.conf.5.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-03-13 21:12+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -41,9 +41,9 @@ msgstr "名前"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -62,17 +62,17 @@ msgstr "説明"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1343
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -84,17 +84,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1345
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -107,10 +107,10 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1338 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -119,10 +119,10 @@ msgstr "関連項目"
 
 #. type: Title #
 #: manpages/man1/aecho.1.md:24 manpages/man1/afppasswd.1.md:26
-#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:50
-#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
-#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1288
+#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:103
+#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:39
+#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:39
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1306
 #: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
 #: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
@@ -161,7 +161,7 @@ msgstr ""
 #. type: Plain text
 #: manpages/man5/atalkd.conf.5.md:15
 #, no-wrap
-msgid "`interface [ -seed ] [ -phase <number> ] [ -net <net-range> ] [ -addr <address> ] [ -zone <zonename> ] ...`\n"
+msgid "    interface [ -seed ] [ -phase <number> ] [ -net <net-range> ] [ -addr <address> ] [ -zone <zonename> ] ...\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/cnid_dbd.8.md.ja.po
+++ b/doc/po/cnid_dbd.8.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-03-13 21:12+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -45,14 +45,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -61,9 +62,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -82,17 +83,17 @@ msgstr "説明"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1343
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -104,17 +105,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1345
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -142,10 +143,10 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1338 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -168,12 +169,14 @@ msgstr "cnid_dbd — CNID データベースへのアクセスデーモン"
 
 #. type: Plain text
 #: manpages/man8/cnid_dbd.8.md:8
-msgid "`cnid_dbd`"
+#, no-wrap
+msgid "**cnid_dbd**\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man8/cnid_dbd.8.md:10
-msgid "`cnid_dbd [ -v | -V ]`"
+#, no-wrap
+msgid "**cnid_dbd** [ -v | -V ]\n"
 msgstr ""
 
 #. type: Plain text
@@ -264,7 +267,7 @@ msgstr "> バージョンを表示してから終了する。\n"
 
 #. type: Title ###
 #: manpages/man8/cnid_dbd.8.md:63 manual/Configuration.md:576
-#: manual/Configuration.md:821
+#: manual/Configuration.md:830
 #, no-wrap
 msgid "Configuration"
 msgstr "設定"
@@ -365,11 +368,11 @@ msgid ""
 "affected *afpd* process will transparently reconnect later, which causes\n"
 "slight overhead. On the other hand, setting this parameter too high\n"
 "could affect performance in **cnid_dbd** since all descriptors have to be\n"
-"checked in a `select()` system call, or worse, you might exceed the per\n"
+"checked in a *select()* system call, or worse, you might exceed the per\n"
 "process limit of open file descriptors on your system. It is safe to set\n"
 "the value to 1 on volumes where only one *afpd* client process is\n"
 "expected to run, e.g. home directories.\n"
-msgstr "> *afpd*クライアントが*cnid_dbd*で処理するために開く最大の接続数(ファイル記述子数)。デフォルトは512。この値を超えた場合、存在する接続のうち一つを閉じて再利用する。影響を受けた*afpd*プロセスは後に透過的に再接続される。これは僅かなオーバヘッドを生じる。一方、全ての記述子を`select()`システムコールでチェックしなければならないので、このパラメータを極めて高い値に設定すると**cnid_dbd**のパフォーマンスに影響するかもしれないし、更に悪いことにプロセスあたりに開くファイル記述子のシステム上の上限を超えるかもしれない。たった一つの*afpd*クライアントプロセスが動作すると予想されるボリュームでは、この値を1に設定すると安全である。例えばホームディレクトリである。\n"
+msgstr "> *afpd*クライアントが*cnid_dbd*で処理するために開く最大の接続数(ファイル記述子数)。デフォルトは512。この値を超えた場合、存在する接続のうち一つを閉じて再利用する。影響を受けた*afpd*プロセスは後に透過的に再接続される。これは僅かなオーバヘッドを生じる。一方、全ての記述子を*select()*システムコールでチェックしなければならないので、このパラメータを極めて高い値に設定すると**cnid_dbd**のパフォーマンスに影響するかもしれないし、更に悪いことにプロセスあたりに開くファイル記述子のシステム上の上限を超えるかもしれない。たった一つの*afpd*クライアントプロセスが動作すると予想されるボリュームでは、この値を1に設定すると安全である。例えばホームディレクトリである。\n"
 
 #. type: Plain text
 #: manpages/man8/cnid_dbd.8.md:116
@@ -392,66 +395,58 @@ msgid "Updating"
 msgstr "アップデート"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:128
+#: manpages/man8/cnid_dbd.8.md:124
 msgid ""
-"Note that the first version to appear *after* Netatalk 2.1 i.e. Netatalk "
-"2.1.1, will support Berkeley DB updates on the fly without manual "
-"intervention. In other words Netatalk 2.1 does contain code to prepare the "
-"Berkeley DB database for upgrades and to upgrade it in case it has been "
-"prepared before. That means it can't upgrade a 2.0.x version because that "
-"one didn't prepare the database."
+"Starting with Netatalk 2.1.1, automatic Berkeley DB updates are supported, "
+"as long as Netatalk 2.1.0 or later was used to create the database."
 msgstr ""
-"Netatalk 2.1の*後*に出た最初のバージョン、すなわちNetatalk 2.1.1は、手動操作"
-"なしに自動的にBerkeley DBアップデートをサポートすることに注意せよ。言い換える"
-"と、Netatalk 2.1はBerkeley DBデータベースのアップグレードを準備するコードと、"
-"既に準備されている場合にそれをアップグレードするコードを含んでいる。これは"
-"バージョン2.0.xからはアップグレードできないことを意味する。なぜならデータベー"
-"スの準備をしていないからである。"
+"Netatalk 2.1.0 以降を使ってデータベースを作成した場合、自動的なBerkeley DBの"
+"アップデートがサポートされる。"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:131
+#: manpages/man8/cnid_dbd.8.md:127
 msgid ""
 "In order to update between older Netatalk releases using different Berkeley "
-"DB library versions, follow this steps:"
+"DB library versions, follow these steps:"
 msgstr ""
 "異なるバージョンのBerkeley DBライブラリを使っている古いNetatalkをアップデート"
 "するためには、以下の手順をとる:"
 
 #. type: Bullet: '- '
-#: manpages/man8/cnid_dbd.8.md:133
+#: manpages/man8/cnid_dbd.8.md:129
 msgid "Stop the to be upgraded old version of Netatalk"
 msgstr "これからアップグレードする古いバージョンのNetatalkを停止する"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:136
+#: manpages/man8/cnid_dbd.8.md:132
 #, no-wrap
 msgid ""
 "- Using the old Berkeley DB utilities run\n"
-"`db_recover -h <path to .AppleDB>`\n"
-msgstr "- 古いBerkeley DBユーティリティを使って、`db_checkpoint -1 -h <.AppleDBのパス>` を実行する\n"
+"*db_recover -h <path to .AppleDB>*\n"
+msgstr "- 古いBerkeley DBユーティリティを使って、*db_checkpoint -1 -h <.AppleDBのパス>* を実行する\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:139
+#: manpages/man8/cnid_dbd.8.md:135
 #, no-wrap
 msgid ""
 "- Using the new Berkeley DB utilities run\n"
-"`db_upgrade -v -h <path to .AppleDB> -f cnid2.db`\n"
-msgstr "- 新しいBerkeley DBユーティリティを使って、`db_upgrade -v -h <.AppleDBのパス> -f cnid2.db` を実行する\n"
+"*db_upgrade -v -h <path to .AppleDB> -f cnid2.db*\n"
+msgstr "- 新しいBerkeley DBユーティリティを使って、*db_upgrade -v -h <.AppleDBのパス> -f cnid2.db* を実行する\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:142
+#: manpages/man8/cnid_dbd.8.md:138
 #, no-wrap
 msgid ""
 "- Again using the new Berkeley DB utilities run\n"
-"`db_checkpoint -1 -h <path to .AppleDB>`\n"
-msgstr "- 再び新しいBerkeley DBユーティリティを使って、`db_checkpoint -1 -h <.AppleDBのパス>` を実行する\n"
+"*db_checkpoint -1 -h <path to .AppleDB>*\n"
+msgstr "- 再び新しいBerkeley DBユーティリティを使って、*db_checkpoint -1 -h <.AppleDBのパス>* を実行する\n"
 
 #. type: Bullet: '- '
-#: manpages/man8/cnid_dbd.8.md:144
+#: manpages/man8/cnid_dbd.8.md:140
 msgid "Start the the new version of Netatalk"
 msgstr "新しいバージョンのNetatalkを起動する"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:148
+#: manpages/man8/cnid_dbd.8.md:144
 msgid "cnid_metad(8), afpd(8), dbd(1)"
 msgstr ""

--- a/doc/po/cnid_metad.8.md.ja.po
+++ b/doc/po/cnid_metad.8.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 01:30+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -45,14 +45,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -61,9 +62,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -93,17 +94,17 @@ msgstr ""
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
+#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -115,17 +116,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:46 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
+#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -153,10 +154,10 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1273 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -183,12 +184,14 @@ msgstr "cnid_metad — 要求に応じて cnid_dbd デーモンを起動する�
 
 #. type: Plain text
 #: manpages/man8/cnid_metad.8.md:8
-msgid "`cnid_metad [-d] [-F configuration file]`"
+#, no-wrap
+msgid "**cnid_metad** [-d] [-F configuration file]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man8/cnid_metad.8.md:10
-msgid "`cnid_metad [ -v | -V ]`"
+#, no-wrap
+msgid "**cnid_metad** [ -v | -V ]\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/dbd.1.md.ja.po
+++ b/doc/po/dbd.1.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-03-01 10:52+0100\n"
+"POT-Creation-Date: 2025-04-16 19:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -45,14 +45,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -61,9 +62,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -100,9 +101,9 @@ msgid "**-v**\n"
 msgstr ""
 
 #. type: Title #
-#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:85
-#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:46
-#: manpages/man5/afp_signature.conf.5.md:44
+#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:172
+#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:54
+#: manpages/man5/afp_signature.conf.5.md:46
 #: manpages/man5/afp_voluuid.conf.5.md:38 manpages/man8/papd.8.md:132
 #, no-wrap
 msgid "See also"
@@ -112,17 +113,17 @@ msgstr "参照"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1344
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -134,17 +135,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1346
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -180,12 +181,14 @@ msgstr "dbd — CNID データベースの保守"
 
 #. type: Plain text
 #: manpages/man1/dbd.1.md:8
-msgid "`dbd [-cfFstuv] [volumepath]`"
+#, no-wrap
+msgid "**dbd** [-cfFstuv] [volumepath]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/dbd.1.md:10
-msgid "`dbd [-V]`"
+#, no-wrap
+msgid "**dbd** [-V]\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/extmap.conf.5.md.ja.po
+++ b/doc/po/extmap.conf.5.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 01:30+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -43,9 +43,9 @@ msgstr "名前"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -64,17 +64,17 @@ msgstr "説明"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
+#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -86,17 +86,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:46 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
+#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -109,10 +109,10 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1273 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -121,12 +121,12 @@ msgstr "関連項目"
 
 #. type: Title #
 #: manpages/man1/aecho.1.md:24 manpages/man1/afppasswd.1.md:26
-#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:50
-#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
-#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/atalkd.conf.5.md:80
-#: manpages/man5/extmap.conf.5.md:18 manpages/man5/papd.conf.5.md:91
-#: manpages/man8/macipgw.8.md:79
+#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:103
+#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:39
+#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:39
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1306
+#: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
+#: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
 msgid "Examples"
 msgstr "例"
@@ -155,7 +155,8 @@ msgstr "設定行は以下のように構成される。"
 
 #. type: Plain text
 #: manpages/man5/extmap.conf.5.md:13
-msgid "`.extension [ type [ creator ] ]`"
+#, no-wrap
+msgid "    .extension [ type [ creator ] ]\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/getzones.1.md.ja.po
+++ b/doc/po/getzones.1.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 00:07+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -43,14 +43,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -59,9 +60,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -87,19 +88,19 @@ msgstr ""
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
-#: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:32
+#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
+#: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
-#: manpages/man8/papd.8.md:137 manpages/man8/papstatus.8.md:53
+#: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
 msgid "Author"
@@ -109,18 +110,18 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:46 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
-#: manpages/man5/atalkd.conf.5.md:106 manpages/man5/extmap.conf.5.md:34
+#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
+#: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:139
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"
@@ -147,10 +148,10 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1273 manpages/man5/atalkd.conf.5.md:100
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -164,7 +165,8 @@ msgstr "getzones — AppleTalk ゾーン名を一覧表示する"
 
 #. type: Plain text
 #: manpages/man1/getzones.1.md:8
-msgid "`getzones [ -m | -l ] [address]`"
+#, no-wrap
+msgid "**getzones** [ -m | -l ] [address]\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/macipgw.8.md.ja.po
+++ b/doc/po/macipgw.8.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 13:17+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -43,14 +43,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -59,9 +60,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -80,17 +81,17 @@ msgstr "説明"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1279
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -119,10 +120,10 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1274 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -131,12 +132,12 @@ msgstr "関連項目"
 
 #. type: Title #
 #: manpages/man1/aecho.1.md:24 manpages/man1/afppasswd.1.md:26
-#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:50
-#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
-#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/atalkd.conf.5.md:80
-#: manpages/man5/extmap.conf.5.md:18 manpages/man5/papd.conf.5.md:91
-#: manpages/man8/macipgw.8.md:79
+#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:103
+#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:39
+#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:39
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1306
+#: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
+#: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
 msgid "Examples"
 msgstr "例"
@@ -170,16 +171,14 @@ msgstr "macipgw — MacIP ゲートウェイ デーモン"
 
 #. type: Plain text
 #: manpages/man8/macipgw.8.md:8
-msgid ""
-"`macipgw [-d debugclass] [-f configfile] [-n nameserver] [-u unprivileged-"
-"user] [-z zone] [network] [netmask]`"
+#, no-wrap
+msgid "**macipgw** [-d debugclass] [-f configfile] [-n nameserver] [-u unprivileged-user] [-z zone] [network] [netmask]\n"
 msgstr ""
-"`macipgw [-d debugclass] [-f configfile] [-n nameserver] [-u unprivileged-"
-"user] [-z zone] [network] [netmask]`"
 
 #. type: Plain text
 #: manpages/man8/macipgw.8.md:10
-msgid "`macipgw [ -v | -V ]`"
+#, no-wrap
+msgid "**macipgw** [ -v | -V ]\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/macusers.1.md.ja.po
+++ b/doc/po/macusers.1.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 18:48+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -45,14 +45,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -61,9 +62,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -82,17 +83,17 @@ msgstr "説明"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1279
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -104,17 +105,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1281
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -167,10 +168,10 @@ msgstr "> バージョンを表示して終了する\n"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1274 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -178,7 +179,7 @@ msgid "See Also"
 msgstr "関連項目"
 
 #. type: Plain text
-#: manpages/man1/afptest.1.md:88 manpages/man1/macusers.1.md:28
+#: manpages/man1/afptest.1.md:175 manpages/man1/macusers.1.md:28
 msgid "afpd(8)"
 msgstr ""
 
@@ -195,7 +196,8 @@ msgstr ""
 
 #. type: Plain text
 #: manpages/man1/macusers.1.md:10
-msgid "`macusers [ -v | -version | --version | -h | -help | --help ]`"
+#, no-wrap
+msgid "**macusers** [ -v | -version | --version | -h | -help | --help ]\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/nbp.1.md.ja.po
+++ b/doc/po/nbp.1.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 00:07+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -38,12 +38,31 @@ msgid "Name"
 msgstr "名前"
 
 #. type: Title #
+#: manpages/man1/ad.1.md:5 manpages/man1/addump.1.md:5
+#: manpages/man1/aecho.1.md:5 manpages/man1/afpldaptest.1.md:5
+#: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
+#: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
+#: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
+#, no-wrap
+msgid "Synopsis"
+msgstr "概要"
+
+#. type: Title #
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -59,10 +78,10 @@ msgid "Description"
 msgstr "説明"
 
 #. type: Title #
-#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:85
-#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:46
-#: manpages/man5/afp_signature.conf.5.md:44
-#: manpages/man5/afp_voluuid.conf.5.md:38 manpages/man8/papd.8.md:133
+#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:172
+#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:54
+#: manpages/man5/afp_signature.conf.5.md:46
+#: manpages/man5/afp_voluuid.conf.5.md:38 manpages/man8/papd.8.md:132
 #, no-wrap
 msgid "See also"
 msgstr "参照"
@@ -71,19 +90,19 @@ msgstr "参照"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
-#: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:32
+#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
+#: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
-#: manpages/man8/papd.8.md:137 manpages/man8/papstatus.8.md:53
+#: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
 msgid "Author"
@@ -93,18 +112,18 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:46 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
-#: manpages/man5/atalkd.conf.5.md:106 manpages/man5/extmap.conf.5.md:34
+#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
+#: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:139
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"
@@ -112,12 +131,12 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 
 #. type: Title #
 #: manpages/man1/aecho.1.md:24 manpages/man1/afppasswd.1.md:26
-#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:50
-#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:31
-#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/atalkd.conf.5.md:82
-#: manpages/man5/extmap.conf.5.md:18 manpages/man5/papd.conf.5.md:91
-#: manpages/man8/macipgw.8.md:79
+#: manpages/man1/afpstats.1.md:20 manpages/man1/afptest.1.md:103
+#: manpages/man1/asip-status.1.md:54 manpages/man1/nbp.1.md:39
+#: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:39
+#: manpages/man5/afp_voluuid.conf.5.md:29 manpages/man5/afp.conf.5.md:1306
+#: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
+#: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:79
 #, no-wrap
 msgid "Examples"
 msgstr "例"
@@ -128,7 +147,25 @@ msgid "nbplkup, nbprgstr, nbpunrgstr — tools for accessing the NBP database"
 msgstr "nbplkup, nbprgstr, nbpunrgstr — NBP データベースにアクセスするツール群"
 
 #. type: Plain text
+#: manpages/man1/nbp.1.md:8
+#, no-wrap
+msgid "**nbplkup**\n"
+msgstr ""
+
+#. type: Plain text
 #: manpages/man1/nbp.1.md:10
+#, no-wrap
+msgid "**nbprgstr** [ -A address ] [ -m Mac charset ] [ -p port ] obj:type@zone\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/nbp.1.md:12
+#, no-wrap
+msgid "**nbpunrgstr** [ -A address ] [ -m Mac charset ] obj:type@zone\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/nbp.1.md:18
 #, no-wrap
 msgid ""
 "**nbprgstr** registers <nbpname\\> with **atalkd**(8), at the given\n"
@@ -140,7 +177,7 @@ msgstr ""
 "がアドバタイズされなくなったことを通知する。\n"
 
 #. type: Plain text
-#: manpages/man1/nbp.1.md:16
+#: manpages/man1/nbp.1.md:24
 #, no-wrap
 msgid ""
 "**nbplkup** displays up to <maxresponses\\> (default 1000) entities\n"
@@ -156,51 +193,51 @@ msgstr ""
 "環境変数から取得され、<nbpname\\> として解析される。\n"
 
 #. type: Title #
-#: manpages/man1/nbp.1.md:17
+#: manpages/man1/nbp.1.md:25
 #, no-wrap
 msgid "Environment Variables"
 msgstr "環境変数"
 
 #. type: Plain text
-#: manpages/man1/nbp.1.md:20
-msgid "NBPLKUP"
-msgstr ""
-
-#. type: Plain text
-#: manpages/man1/nbp.1.md:22
-#, no-wrap
-msgid "> default nbpname for nbplkup\n"
-msgstr "> nbplkup のデフォルトの nbpname\n"
-
-#. type: Plain text
-#: manpages/man1/nbp.1.md:24
-msgid "ATALK_MAC_CHARSET"
-msgstr ""
-
-#. type: Plain text
-#: manpages/man1/nbp.1.md:26
-#, no-wrap
-msgid "> the codepage used by the clients on the Appletalk network\n"
-msgstr "> Appletalk ネットワーク上のクライアントが使用するコードページ\n"
-
-#. type: Plain text
 #: manpages/man1/nbp.1.md:28
-msgid "ATALK_UNIX_CHARSET"
+msgid "NBPLKUP"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/nbp.1.md:30
 #, no-wrap
+msgid "> default nbpname for nbplkup\n"
+msgstr "> nbplkup のデフォルトの nbpname\n"
+
+#. type: Plain text
+#: manpages/man1/nbp.1.md:32
+msgid "ATALK_MAC_CHARSET"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/nbp.1.md:34
+#, no-wrap
+msgid "> the codepage used by the clients on the Appletalk network\n"
+msgstr "> Appletalk ネットワーク上のクライアントが使用するコードページ\n"
+
+#. type: Plain text
+#: manpages/man1/nbp.1.md:36
+msgid "ATALK_UNIX_CHARSET"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/nbp.1.md:38
+#, no-wrap
 msgid "> the codepage used to display extended characters on this shell.\n"
 msgstr "> このシェルで拡張文字を表示するために使用するコードページ。\n"
 
 #. type: Plain text
-#: manpages/man1/nbp.1.md:34
+#: manpages/man1/nbp.1.md:42
 msgid "Find all devices of type *LaserWriter* in the local zone."
 msgstr "ローカル ゾーンでタイプ *LaserWriter* のすべてのデバイスを検索する。"
 
 #. type: Plain text
-#: manpages/man1/nbp.1.md:45
+#: manpages/man1/nbp.1.md:53
 #, no-wrap
 msgid ""
 "    example% nbplkup :LaserWriter\n"
@@ -216,6 +253,6 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/nbp.1.md:49
+#: manpages/man1/nbp.1.md:57
 msgid "nbp_name(3), atalkd(8)"
 msgstr ""

--- a/doc/po/netatalk.8.md.ja.po
+++ b/doc/po/netatalk.8.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 01:30+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -45,14 +45,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -61,9 +62,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -93,17 +94,17 @@ msgstr ""
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
+#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -115,17 +116,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:46 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
+#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -153,10 +154,10 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1273 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -224,7 +225,6 @@ msgstr ""
 
 #. type: Plain text
 #: manpages/man8/afpd.8.md:91 manpages/man8/netatalk.8.md:45
-#: manual/Upgrading.md:33
 #, no-wrap
 msgid "*afp.conf*\n"
 msgstr ""
@@ -236,12 +236,14 @@ msgstr "netatalk — Netatalk AFP サーバのサービス コントローラ �
 
 #. type: Plain text
 #: manpages/man8/netatalk.8.md:8
-msgid "`netatalk [-F configfile]`"
+#, no-wrap
+msgid "**netatalk** [-F configfile]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man8/netatalk.8.md:10
-msgid "`netatalk [ -v | -V ]`"
+#, no-wrap
+msgid "**netatalk** [ -v | -V ]\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/pap.1.md.ja.po
+++ b/doc/po/pap.1.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 00:36+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -43,14 +43,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -59,9 +60,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -79,7 +80,9 @@ msgstr "説明"
 #. type: Plain text
 #: manpages/man1/ad.1.md:54 manpages/man1/asip-status.1.md:39
 #: manpages/man1/pap.1.md:45 manpages/man8/a2boot.8.md:35
-#: manpages/man8/cnid_metad.8.md:21 manpages/man8/papstatus.8.md:27
+#: manpages/man8/afpd.8.md:22 manpages/man8/atalkd.8.md:37
+#: manpages/man8/cnid_metad.8.md:21 manpages/man8/netatalk.8.md:20
+#: manpages/man8/papd.8.md:40 manpages/man8/papstatus.8.md:27
 #: manpages/man8/timelord.8.md:26
 #, no-wrap
 msgid "**-d**\n"
@@ -89,19 +92,19 @@ msgstr ""
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
-#: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:32
+#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
+#: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
-#: manpages/man8/papd.8.md:137 manpages/man8/papstatus.8.md:53
+#: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
 msgid "Author"
@@ -111,18 +114,18 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:46 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
-#: manpages/man5/atalkd.conf.5.md:106 manpages/man5/extmap.conf.5.md:34
+#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
+#: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:139
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"
@@ -149,10 +152,10 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1273 manpages/man5/atalkd.conf.5.md:100
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -181,9 +184,8 @@ msgstr ""
 
 #. type: Plain text
 #: manpages/man1/pap.1.md:8
-msgid ""
-"`pap [-A address] [-c] [-d] [-e] [-E] [-p nbpname] [-s statusfile] [-w] [-W] "
-"[FILES]`"
+#, no-wrap
+msgid "**pap** [-A address] [-c] [-d] [-e] [-E] [-p nbpname] [-s statusfile] [-w] [-W] [FILES]\n"
 msgstr ""
 
 #. type: Plain text
@@ -379,7 +381,7 @@ msgstr ""
 #. type: Title #
 #: manpages/man1/pap.1.md:87 manpages/man8/afpd.8.md:88
 #: manpages/man8/atalkd.8.md:75 manpages/man8/netatalk.8.md:42
-#: manpages/man8/papd.8.md:100 manpages/man8/papstatus.8.md:43
+#: manpages/man8/papd.8.md:99 manpages/man8/papstatus.8.md:43
 #, no-wrap
 msgid "Files"
 msgstr "ファイル"

--- a/doc/po/papd.8.md.ja.po
+++ b/doc/po/papd.8.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 13:17+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -43,14 +43,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -59,9 +60,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -88,9 +89,9 @@ msgid "**-d**\n"
 msgstr ""
 
 #. type: Title #
-#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:85
-#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:46
-#: manpages/man5/afp_signature.conf.5.md:44
+#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:172
+#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:54
+#: manpages/man5/afp_signature.conf.5.md:46
 #: manpages/man5/afp_voluuid.conf.5.md:38 manpages/man8/papd.8.md:132
 #, no-wrap
 msgid "See also"
@@ -100,17 +101,17 @@ msgstr "参照"
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
 #: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1279
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -122,17 +123,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
 #: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1281
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -156,11 +157,11 @@ msgstr "オプション"
 
 #. type: Plain text
 #: manpages/man1/afppasswd.1.md:20 manpages/man5/afp_signature.conf.5.md:21
-#: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:319
-#: manpages/man5/afp.conf.5.md:343 manpages/man5/afp.conf.5.md:356
-#: manpages/man5/afp.conf.5.md:371 manpages/man5/afp.conf.5.md:723
-#: manpages/man5/afp.conf.5.md:1049 manpages/man5/afp.conf.5.md:1174
-#: manpages/man5/afp.conf.5.md:1212 manpages/man8/papd.8.md:96
+#: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:339
+#: manpages/man5/afp.conf.5.md:363 manpages/man5/afp.conf.5.md:376
+#: manpages/man5/afp.conf.5.md:391 manpages/man5/afp.conf.5.md:694
+#: manpages/man5/afp.conf.5.md:1093 manpages/man5/afp.conf.5.md:1218
+#: manpages/man5/afp.conf.5.md:1256 manpages/man8/papd.8.md:96
 #: manual/Configuration.md:113
 #, no-wrap
 msgid "> **NOTE**\n"
@@ -218,12 +219,14 @@ msgstr "papd — AppleTalk プリント サーバー デーモン"
 
 #. type: Plain text
 #: manpages/man8/papd.8.md:8
-msgid "`papd [-d] [-f configfile] [-p printcap] [-P pidfile]`"
+#, no-wrap
+msgid "**papd** [-d] [-f configfile] [-p printcap] [-P pidfile]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man8/papd.8.md:10
-msgid "`papd [ -v | -V ]`"
+#, no-wrap
+msgid "**papd** [ -v | -V ]\n"
 msgstr ""
 
 #. type: Plain text

--- a/doc/po/papstatus.8.md.ja.po
+++ b/doc/po/papstatus.8.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 01:30+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -43,14 +43,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -59,9 +60,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -91,17 +92,17 @@ msgstr ""
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
+#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -113,17 +114,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:46 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
+#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -151,10 +152,10 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1273 manpages/man5/atalkd.conf.5.md:98
+#: manpages/man5/afp.conf.5.md:1352 manpages/man5/atalkd.conf.5.md:98
 #: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
 #: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:79
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:44
+#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
 #: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
 #: manpages/man8/papstatus.8.md:49
 #, no-wrap
@@ -182,8 +183,9 @@ msgstr "papstatus — AppleTalk 接続プリンタのステータスを取得す
 
 #. type: Plain text
 #: manpages/man8/papstatus.8.md:8
-msgid "`papstatus [-d] [-p printer] [retrytime]`"
-msgstr "`papstatus [-d] [-p printer] [retrytime]`"
+#, no-wrap
+msgid "**papstatus** [-d] [-p printer] [retrytime]\n"
+msgstr ""
 
 #. type: Plain text
 #: manpages/man8/papstatus.8.md:14

--- a/doc/po/timelord.8.md.ja.po
+++ b/doc/po/timelord.8.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-01-29 01:41+0100\n"
+"POT-Creation-Date: 2025-04-16 08:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -43,14 +43,15 @@ msgstr "名前"
 #: manpages/man1/afppasswd.1.md:5 manpages/man1/afpstats.1.md:5
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
-#: manpages/man1/macusers.1.md:5 manpages/man1/pap.1.md:5
-#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
-#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
-#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
-#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
-#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
-#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
-#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
+#: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
+#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
+#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
+#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
+#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
+#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
+#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
+#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
+#: manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -59,9 +60,9 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:17 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
-#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:5
+#: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
 #: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
 #: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
 #: manpages/man5/afp_signature.conf.5.md:5
@@ -98,17 +99,17 @@ msgstr ""
 #: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:89 manpages/man1/asip-status.1.md:106
+#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
 #: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:50
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
 #: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1278
+#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
+#: manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1357
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:149 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
 #: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
 #: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
@@ -120,17 +121,17 @@ msgstr "著者"
 #: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:91 manpages/man1/asip-status.1.md:108
+#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
 #: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:52
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
 #: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:46 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1280
+#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
+#: manpages/man5/afp_signature.conf.5.md:52
+#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1359
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:151 manpages/man8/cnid_metad.8.md:50
+#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
 #: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
@@ -196,12 +197,14 @@ msgstr "timelord — Macintosh タイム サーバー デーモン"
 
 #. type: Plain text
 #: manpages/man8/timelord.8.md:8
-msgid "`timelord [-d] [-l] [-n nbpname]`"
+#, no-wrap
+msgid "**timelord** [-d] [-l] [-n nbpname]\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man8/timelord.8.md:10
-msgid "`timelord [ -v | -V ]`"
+#, no-wrap
+msgid "**timelord** [ -v | -V ]\n"
 msgstr ""
 
 #. type: Plain text


### PR DESCRIPTION
Backticks in Markdown tends to transcode to roff code that certain roff parsers don't like, notably groff on Debian Trixie

Specifically, the backticks transcode to the font style `C` that groff chokes on