### PR TITLE
GitHub CI: Use secret context for secure AFP test password handling

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -149,10 +149,11 @@ jobs:
         name: Production container dry run
         needs: build-container
         runs-on: ubuntu-latest
+        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
-            AFP_PASS: qx9z4thi
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
             AFP_GROUP: afpusers
             ATALKD_INTERFACE: eth0
             TZ: Europe/Stockholm
@@ -168,12 +169,13 @@ jobs:
         name: AFP spec test (ea) AFP 3.4 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
+        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: qx9z4thi
-            AFP_PASS2: qx9z4thi
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -190,12 +192,13 @@ jobs:
         name: AFP spec test (ea) AFP 3.4 - Debian
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
+        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: qx9z4thi
-            AFP_PASS2: qx9z4thi
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -209,61 +212,64 @@ jobs:
 
 
     afp-adtest-afp34:
-      name: AFP spec test (adouble v2) AFP 3.4 - Alpine
-      needs: build-container-testsuite
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_USER2: atalk2
-          AFP_PASS: qx9z4thi
-          AFP_PASS2: qx9z4thi
-          AFP_GROUP: afpusers
-          SHARE_NAME: test1
-          SHARE_NAME2: test2
-          INSECURE_AUTH: 1
-          DISABLE_TIMEMACHINE: 1
-          VERBOSE: 1
-          AFP_ADOUBLE: 1
-          TESTSUITE: spectest
-          AFP_VERSION: 7
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+        name: AFP spec test (adouble v2) AFP 3.4 - Alpine
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        environment: devtest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_USER2: atalk2
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            SHARE_NAME2: test2
+            INSECURE_AUTH: 1
+            DISABLE_TIMEMACHINE: 1
+            VERBOSE: 1
+            AFP_ADOUBLE: 1
+            TESTSUITE: spectest
+            AFP_VERSION: 7
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
     afp-adtest-afp34-debian:
-      name: AFP spec test (adouble v2) AFP 3.4 - Debian
-      needs: build-container-testsuite-debian
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_USER2: atalk2
-          AFP_PASS: qx9z4thi
-          AFP_PASS2: qx9z4thi
-          AFP_GROUP: afpusers
-          SHARE_NAME: test1
-          SHARE_NAME2: test2
-          INSECURE_AUTH: 1
-          DISABLE_TIMEMACHINE: 1
-          VERBOSE: 1
-          AFP_ADOUBLE: 1
-          TESTSUITE: spectest
-          AFP_VERSION: 7
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite-debian:latest
+        name: AFP spec test (adouble v2) AFP 3.4 - Debian
+        needs: build-container-testsuite-debian
+        runs-on: ubuntu-latest
+        environment: devtest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_USER2: atalk2
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            SHARE_NAME2: test2
+            INSECURE_AUTH: 1
+            DISABLE_TIMEMACHINE: 1
+            VERBOSE: 1
+            AFP_ADOUBLE: 1
+            TESTSUITE: spectest
+            AFP_VERSION: 7
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite-debian:latest
 
 
     afp-spectest-afp33:
         name: AFP spec test (ea) AFP 3.3 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
+        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: qx9z4thi
-            AFP_PASS2: qx9z4thi
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -280,12 +286,13 @@ jobs:
         name: AFP spec test (ea) AFP 3.2 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
+        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: qx9z4thi
-            AFP_PASS2: qx9z4thi
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -302,12 +309,13 @@ jobs:
         name: AFP spec test (ea) AFP 3.1 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
+        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: qx9z4thi
-            AFP_PASS2: qx9z4thi
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -324,12 +332,13 @@ jobs:
         name: AFP spec test (ea) AFP 3.0 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
+        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: qx9z4thi
-            AFP_PASS2: qx9z4thi
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -346,12 +355,13 @@ jobs:
         name: AFP spec test (ea) AFP 3.0 - Debian
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
+        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: qx9z4thi
-            AFP_PASS2: qx9z4thi
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -368,12 +378,13 @@ jobs:
         name: AFP spec test (ea) AFP 2.2 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
+        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: qx9z4thi
-            AFP_PASS2: qx9z4thi
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -390,12 +401,13 @@ jobs:
         name: AFP spec test (ea) AFP 2.1 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
+        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: qx9z4thi
-            AFP_PASS2: qx9z4thi
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -412,12 +424,13 @@ jobs:
         name: AFP spec test (ea) AFP 2.1 - Debian
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
+        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
             AFP_USER2: atalk2
-            AFP_PASS: qx9z4thi
-            AFP_PASS2: qx9z4thi
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
             AFP_GROUP: afpusers
             SHARE_NAME: test1
             SHARE_NAME2: test2
@@ -431,154 +444,161 @@ jobs:
 
 
     afp-adtest-afp21:
-      name: AFP spec test (adouble v2) AFP 2.1 - Alpine
-      needs: build-container-testsuite
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_USER2: atalk2
-          AFP_PASS: qx9z4thi
-          AFP_PASS2: qx9z4thi
-          AFP_GROUP: afpusers
-          SHARE_NAME: test1
-          SHARE_NAME2: test2
-          INSECURE_AUTH: 1
-          DISABLE_TIMEMACHINE: 1
-          VERBOSE: 1
-          AFP_ADOUBLE: 1
-          TESTSUITE: spectest
-          AFP_VERSION: 1
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+        name: AFP spec test (adouble v2) AFP 2.1 - Alpine
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        environment: devtest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_USER2: atalk2
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            SHARE_NAME2: test2
+            INSECURE_AUTH: 1
+            DISABLE_TIMEMACHINE: 1
+            VERBOSE: 1
+            AFP_ADOUBLE: 1
+            TESTSUITE: spectest
+            AFP_VERSION: 1
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
     afp-adtest-afp21-debian:
-      name: AFP spec test (adouble v2) AFP 2.1 - Debian
-      needs: build-container-testsuite-debian
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_USER2: atalk2
-          AFP_PASS: qx9z4thi
-          AFP_PASS2: qx9z4thi
-          AFP_GROUP: afpusers
-          SHARE_NAME: test1
-          SHARE_NAME2: test2
-          INSECURE_AUTH: 1
-          DISABLE_TIMEMACHINE: 1
-          VERBOSE: 1
-          AFP_ADOUBLE: 1
-          TESTSUITE: spectest
-          AFP_VERSION: 1
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite-debian:latest
-
+        name: AFP spec test (adouble v2) AFP 2.1 - Debian
+        needs: build-container-testsuite-debian
+        runs-on: ubuntu-latest
+        environment: devtest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_USER2: atalk2
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            SHARE_NAME2: test2
+            INSECURE_AUTH: 1
+            DISABLE_TIMEMACHINE: 1
+            VERBOSE: 1
+            AFP_ADOUBLE: 1
+            TESTSUITE: spectest
+            AFP_VERSION: 1
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite-debian:latest
 
     afp-rotest-afp34:
-      name: AFP spec test (readonly) AFP 3.4 - Alpine
-      needs: build-container-testsuite
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_PASS: qx9z4thi
-          AFP_GROUP: afpusers
-          SHARE_NAME: test1
-          INSECURE_AUTH: 1
-          VERBOSE: 1
-          AFP_READONLY: 1
-          TESTSUITE: readonly
-          AFP_VERSION: 7
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+        name: AFP spec test (readonly) AFP 3.4 - Alpine
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        environment: devtest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            INSECURE_AUTH: 1
+            VERBOSE: 1
+            AFP_READONLY: 1
+            TESTSUITE: readonly
+            AFP_VERSION: 7
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
     afp-rotest-afp21:
-      name: AFP spec test (readonly) AFP 2.1 - Alpine
-      needs: build-container-testsuite
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_PASS: qx9z4thi
-          AFP_GROUP: afpusers
-          SHARE_NAME: test1
-          INSECURE_AUTH: 1
-          VERBOSE: 1
-          AFP_READONLY: 1
-          TESTSUITE: readonly
-          AFP_VERSION: 1
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+        name: AFP spec test (readonly) AFP 2.1 - Alpine
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        environment: devtest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            INSECURE_AUTH: 1
+            VERBOSE: 1
+            AFP_READONLY: 1
+            TESTSUITE: readonly
+            AFP_VERSION: 1
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
     afp-logintest-afp34:
-      name: AFP login test AFP 3.4 - Alpine
-      needs: build-container-testsuite
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_PASS: qx9z4thi
-          AFP_GROUP: afpusers
-          INSECURE_AUTH: 1
-          VERBOSE: 1
-          TESTSUITE: login
-          AFP_VERSION: 7
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+        name: AFP login test AFP 3.4 - Alpine
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        environment: devtest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_GROUP: afpusers
+            INSECURE_AUTH: 1
+            VERBOSE: 1
+            TESTSUITE: login
+            AFP_VERSION: 7
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
     afp-logintest-afp21:
-      name: AFP login test AFP 2.1 - Alpine
-      needs: build-container-testsuite
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_PASS: qx9z4thi
-          AFP_GROUP: afpusers
-          INSECURE_AUTH: 1
-          VERBOSE: 1
-          TESTSUITE: login
-          AFP_VERSION: 1
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+        name: AFP login test AFP 2.1 - Alpine
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        environment: devtest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_GROUP: afpusers
+            INSECURE_AUTH: 1
+            VERBOSE: 1
+            TESTSUITE: login
+            AFP_VERSION: 1
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
     afp-lantest:
-      name: AFP lantest - Alpine
-      needs: build-container-testsuite
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_PASS: qx9z4thi
-          AFP_GROUP: afpusers
-          SHARE_NAME: test1
-          INSECURE_AUTH: 1
-          VERBOSE: 1
-          TESTSUITE: lan
-          AFP_VERSION: 7
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+        name: AFP lantest - Alpine
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        environment: devtest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            INSECURE_AUTH: 1
+            VERBOSE: 1
+            TESTSUITE: lan
+            AFP_VERSION: 7
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
 
     afp-speedtest:
-      name: AFP speedtest - Alpine
-      needs: build-container-testsuite
-      runs-on: ubuntu-latest
-      timeout-minutes: 5
-      env:
-          AFP_USER: atalk1
-          AFP_PASS: qx9z4thi
-          AFP_GROUP: afpusers
-          SHARE_NAME: test1
-          INSECURE_AUTH: 1
-          VERBOSE: 1
-          TESTSUITE: speed
-          AFP_VERSION: 7
-      steps:
-          - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+        name: AFP speedtest - Alpine
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        environment: devtest
+        timeout-minutes: 5
+        env:
+            AFP_USER: atalk1
+            AFP_PASS: ${{ secrets.AFP_PASSWD }}
+            AFP_GROUP: afpusers
+            SHARE_NAME: test1
+            INSECURE_AUTH: 1
+            VERBOSE: 1
+            TESTSUITE: speed
+            AFP_VERSION: 7
+        steps:
+            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest


### PR DESCRIPTION
While the AFP test password is for a throwaway test container, using the GitHub secret context makes me sleep better at night