### PR TITLE
docker: Support for the mysql CNID backend in container

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -149,7 +149,6 @@ jobs:
         name: Production container dry run
         needs: build-container
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -165,11 +164,86 @@ jobs:
                 args: -V
 
 
-    afp-spectest-afp34:
-        name: AFP spec test (ea) AFP 3.4 - Alpine
+    afp-spectest-mysql-afp34:
+        name: AFP spec test (cnid:mysql) AFP 3.4 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
+        timeout-minutes: 10
+        steps:
+            - name: Create Docker network
+              run: |
+                docker network create afp_network
+            - name: Start MariaDB container
+              run: |
+                docker run -d --name mariadb --network afp_network \
+                    -e MARIADB_ROOT_PASSWORD=${{ secrets.MARIADB_ROOT_PASSWORD }} \
+                    mariadb:latest
+            - name: Wait for MariaDB to initialize
+              run: |
+                sleep 4
+            - name: Run Netatalk testsuite
+              run: |
+                docker run --rm --network afp_network \
+                    -e AFP_USER=atalk1 \
+                    -e AFP_USER2=atalk2 \
+                    -e AFP_PASS=${{ secrets.AFP_PASSWD }} \
+                    -e AFP_PASS2=${{ secrets.AFP_PASSWD }} \
+                    -e AFP_GROUP=afpusers \
+                    -e AFP_CNID_BACKEND=mysql \
+                    -e SHARE_NAME=test1 \
+                    -e SHARE_NAME2=test2 \
+                    -e INSECURE_AUTH=1 \
+                    -e DISABLE_TIMEMACHINE=1 \
+                    -e VERBOSE=1 \
+                    -e TESTSUITE=spectest \
+                    -e AFP_VERSION=7 \
+                    -e AFP_CNID_SQL_HOST=mariadb \
+                    -e AFP_CNID_SQL_PASS=${{ secrets.MARIADB_ROOT_PASSWORD }} \
+                    ghcr.io/netatalk/netatalk-testsuite:latest
+
+
+    afp-spectest-mysql-afp34-debian:
+        name: AFP spec test (cnid:mysql) AFP 3.4 - Debian
+        needs: build-container-testsuite-debian
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - name: Create Docker network
+              run: |
+                docker network create afp_network
+            - name: Start MariaDB container
+              run: |
+                docker run -d --name mariadb --network afp_network \
+                    -e MARIADB_ROOT_PASSWORD=${{ secrets.MARIADB_ROOT_PASSWORD }} \
+                    mariadb:latest
+            - name: Wait for MariaDB to initialize
+              run: |
+                sleep 4
+            - name: Run Netatalk testsuite
+              run: |
+                docker run --rm --network afp_network \
+                    -e AFP_USER=atalk1 \
+                    -e AFP_USER2=atalk2 \
+                    -e AFP_PASS=${{ secrets.AFP_PASSWD }} \
+                    -e AFP_PASS2=${{ secrets.AFP_PASSWD }} \
+                    -e AFP_GROUP=afpusers \
+                    -e AFP_CNID_BACKEND=mysql \
+                    -e SHARE_NAME=test1 \
+                    -e SHARE_NAME2=test2 \
+                    -e INSECURE_AUTH=1 \
+                    -e DISABLE_TIMEMACHINE=1 \
+                    -e VERBOSE=1 \
+                    -e TESTSUITE=spectest \
+                    -e AFP_VERSION=7 \
+                    -e AFP_CNID_SQL_HOST=mariadb \
+                    -e AFP_CNID_SQL_PASS=${{ secrets.MARIADB_ROOT_PASSWORD }} \
+                    ghcr.io/netatalk/netatalk-testsuite-debian:latest
+
+
+    afp-spectest-afp34:
+        name: AFP spec test (ea:sys) AFP 3.4 - Alpine
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -189,10 +263,9 @@ jobs:
 
 
     afp-spectest-afp34-debian:
-        name: AFP spec test (ea) AFP 3.4 - Debian
+        name: AFP spec test (ea:sys) AFP 3.4 - Debian
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -212,10 +285,9 @@ jobs:
 
 
     afp-adtest-afp34:
-        name: AFP spec test (adouble v2) AFP 3.4 - Alpine
+        name: AFP spec test (ea:ad) AFP 3.4 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -236,10 +308,9 @@ jobs:
 
 
     afp-adtest-afp34-debian:
-        name: AFP spec test (adouble v2) AFP 3.4 - Debian
+        name: AFP spec test (ea:ad) AFP 3.4 - Debian
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -260,10 +331,9 @@ jobs:
 
 
     afp-spectest-afp33:
-        name: AFP spec test (ea) AFP 3.3 - Alpine
+        name: AFP spec test (ea:sys) AFP 3.3 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -283,10 +353,9 @@ jobs:
 
 
     afp-spectest-afp32:
-        name: AFP spec test (ea) AFP 3.2 - Alpine
+        name: AFP spec test (ea:sys) AFP 3.2 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -306,10 +375,9 @@ jobs:
 
 
     afp-spectest-afp31:
-        name: AFP spec test (ea) AFP 3.1 - Alpine
+        name: AFP spec test (ea:sys) AFP 3.1 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -329,10 +397,9 @@ jobs:
 
 
     afp-spectest-afp30:
-        name: AFP spec test (ea) AFP 3.0 - Alpine
+        name: AFP spec test (ea:sys) AFP 3.0 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -352,10 +419,9 @@ jobs:
 
 
     afp-spectest-afp30-debian:
-        name: AFP spec test (ea) AFP 3.0 - Debian
+        name: AFP spec test (ea:sys) AFP 3.0 - Debian
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -375,10 +441,9 @@ jobs:
 
 
     afp-spectest-afp22:
-        name: AFP spec test (ea) AFP 2.2 - Alpine
+        name: AFP spec test (ea:sys) AFP 2.2 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -398,10 +463,9 @@ jobs:
   
 
     afp-spectest-afp21:
-        name: AFP spec test (ea) AFP 2.1 - Alpine
+        name: AFP spec test (ea:sys) AFP 2.1 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -421,10 +485,9 @@ jobs:
 
   
     afp-spectest-afp21-debian:
-        name: AFP spec test (ea) AFP 2.1 - Debian
+        name: AFP spec test (ea:sys) AFP 2.1 - Debian
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -444,10 +507,9 @@ jobs:
 
 
     afp-adtest-afp21:
-        name: AFP spec test (adouble v2) AFP 2.1 - Alpine
+        name: AFP spec test (ea:ad) AFP 2.1 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -468,10 +530,9 @@ jobs:
 
 
     afp-adtest-afp21-debian:
-        name: AFP spec test (adouble v2) AFP 2.1 - Debian
+        name: AFP spec test (ea:ad) AFP 2.1 - Debian
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -494,7 +555,6 @@ jobs:
         name: AFP spec test (readonly) AFP 3.4 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -514,7 +574,6 @@ jobs:
         name: AFP spec test (readonly) AFP 2.1 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -534,7 +593,6 @@ jobs:
         name: AFP login test AFP 3.4 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -552,7 +610,6 @@ jobs:
         name: AFP login test AFP 2.1 - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -570,7 +627,6 @@ jobs:
         name: AFP lantest - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1
@@ -589,7 +645,6 @@ jobs:
         name: AFP speedtest - Alpine
         needs: build-container-testsuite
         runs-on: ubuntu-latest
-        environment: devtest
         timeout-minutes: 5
         env:
             AFP_USER: atalk1

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -2,9 +2,11 @@
 
 Netatalk comes with a Dockerfile and entry point script for running a containerized AFP server and AppleTalk services.
 
-Out of the box, exactly two users, and two shared volumes are supported in this container. One of the shared volumes is a Time Machine backup volume by default. If you need a different setup, please use the manual configuration option.
+Out of the box, exactly two users, and two shared volumes are supported in this container.
+One of the shared volumes is a backup volume by default.
+If you need a different setup, please use the manual configuration option.
 
-Make sure you have Docker Engine installed, then build the netatalk container:
+Make sure you have a container runtime installed, then build the netatalk container:
 
 ```
 docker build -t netatalk:latest .
@@ -14,11 +16,12 @@ Alternatively, pull a pre-built Docker image from [Docker Hub](https://hub.docke
 
 ## How to Run
 
-Once you have the netatalk image on your machine with Docker Engine, run it with `docker run` or `docker compose`.
+Once you have the netatalk image on your machine run it with `docker`, `podman` or equivalent container runtime.
 
-To enable full functionality including Zeroconf service discovery and AppleTalk, use the `host` network driver.
+The easiest way to enable full functionality including Zeroconf service discovery and AppleTalk, is to use the `host` network driver.
 
-For a hardened deployment, use the `bridge` network driver and expose port 548 for AFP. However, this means that you will have to manually specify the IP address in the client when connecting to the file server.
+For a hardened deployment, use the `bridge` network driver and expose port 548 for AFP.
+However, Zeroconf service discovery may not work and you will have to manually specify the IP address in the client when connecting to the file server.
 
 It is recommended to set up either a bind mount, or a Docker managed volume for persistent storage.
 Without this, the shared volume be stored in volatile storage that is lost upon container shutdown.
@@ -39,16 +42,16 @@ docker run --rm \
   --env AFP_USER= \
   --env AFP_PASS= \
   --env AFP_GROUP=afpusers \
-  --env ATALKD_INTERFACE= \
-  --env TZ= \
+  --env ATALKD_INTERFACE=eth0 \
+  --env TZ=Europe/Stockholm \
   --name netatalk netatalk:latest
 ```
 
 ## Constraints
 
-In order to use Zeroconf service discovery as well as the AppleTalk transport layer, the `host` network driver and `NET_ADMIN` capabilities are mandatory.
+The most straight forward way to enable Zeroconf service discovery as well as the AppleTalk transport layer, is to use the `host` network driver and `NET_ADMIN` capabilities.
 
-Additionally, we rely on the host's DBUS for Zeroconf, achieved with a bind mount such as `/var/run/dbus:/var/run/dbus`. The left hand side of the bind mount is the host machine, and the right hand side is the container. The host machine path may have to be changed to match the location of DBUS on the host machine.
+Additionally, we rely on the host's D-Bus for Zeroconf, achieved with a bind mount such as `/var/run/dbus:/var/run/dbus`. The left hand side of the bind mount is the host machine, and the right hand side is the container. The host machine path may have to be changed to match the location of D-Bus on the host machine.
 
 On certain host OSes, notably Ubuntu: if the Apparmor security policy restricts D-Bus messages, enable the `unconfined` security option.
 
@@ -62,6 +65,67 @@ Example for the docker compose yaml configuration file:
 See the [Docker AppArmor security profiles documentation](https://docs.docker.com/engine/security/apparmor/) for further details.
 
 The container is hard coded to output `afpd` (the Netatalk file server daemon) logs to the container's stdout, with default log level `info`. Logs from the AppleTalk daemons are sent to the syslog.
+
+## MySQL CNID Backend
+
+The MySQL CNID backend is an alternative to the default Berkeley DB CNID backend which offers better scalability.
+
+Here follows a Docker Compose example to run a container network with MariaDB as the database for the MySQL CNID backend,
+plus a web interface to administer the database for good measure.
+
+Set `AFP_CNID_SQL_PASS` and `MARIADB_ROOT_PASSWORD` to the same password.
+
+```
+services:
+  netatalk:
+    image: netatalk:latest
+    networks:
+      - afp_network
+    ports:
+      - "548:548"
+    volumes:
+      - afpshare:/mnt/afpshare
+      - afpbackup:/mnt/afpbackup
+      - /var/run/dbus:/var/run/dbus
+    environment:
+      - AFP_USER=atalk1
+      - AFP_USER2=atalk2
+      - AFP_PASS=
+      - AFP_PASS2=
+      - AFP_GROUP=afpusers
+      - AFP_CNID_BACKEND=mysql
+      - AFP_CNID_SQL_HOST=cnid_db
+      - AFP_CNID_SQL_PASS=
+    depends_on:
+      - cnid_db
+
+  cnid_db:
+    image: mariadb:latest
+    restart: always
+    networks:
+      - afp_network
+    volumes:
+      - cnid_db_data:/var/lib/mysql
+    environment:
+      - MARIADB_ROOT_PASSWORD=
+
+  adminer:
+    image: adminer:latest
+    restart: always
+    networks:
+      - afp_network
+    ports:
+      - 8081:8080
+
+volumes:
+  afpshare:
+  afpbackup:
+  cnid_db_data:
+
+networks:
+  afp_network:
+    driver: bridge
+```
 
 ## Printing
 
@@ -107,3 +171,8 @@ These are required to set the credentials used to authenticate with the file ser
 | `MANUAL_CONFIG` | When non-zero, enable manual management of config files        |
 | `ATALKD_OPTIONS` | A string with options to append to atalkd.conf                |
 | `AFP_DROPBOX` |  Enable dropbox mode; turns secondary user into guest with read only access to the second shared volume |
+| `$AFP_CNID_BACKEND` | The backend to use for the CNID database; valid values are `bdb` and `mysql` |
+| `$AFP_CNID_SQL_HOST` | The hostname or IP address of the CNID SQL server         |
+| `$AFP_CNID_SQL_USER` | The username to use when connecting to the CNID SQL server |
+| `$AFP_CNID_SQL_PASS` | The password to use when connecting to the CNID SQL server |
+| `$AFP_CNID_SQL_DB` | The name of the designated database in the SQL server |

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ARG RUN_DEPS="\
     libgcrypt \
     linux-pam \
     localsearch \
+    mariadb-client \
+    mariadb-connector-c \
     openldap \
     talloc \
     tinysparql \
@@ -29,6 +31,7 @@ ARG BUILD_DEPS="\
     libevent-dev \
     libgcrypt-dev \
     linux-pam-dev \
+    mariadb-dev \
     meson \
     ninja \
     openldap-dev \

--- a/testsuite_alp.Dockerfile
+++ b/testsuite_alp.Dockerfile
@@ -10,6 +10,8 @@ ARG RUN_DEPS="\
     libgcrypt \
     linux-pam \
     localsearch \
+    mariadb-client \
+    mariadb-connector-c \
     openldap \
     talloc \
     tinysparql \
@@ -29,6 +31,7 @@ ARG BUILD_DEPS="\
     libevent-dev \
     libgcrypt-dev \
     linux-pam-dev \
+    mariadb-dev \
     meson \
     ninja \
     openldap-dev \


### PR DESCRIPTION
Added the ability to choose an arbitrary CNID backend in the
Docker entry script, with special case handling for the mysql backend

Updated the container CI workflow to run the tier 1 spectests
in with the mysql backend and a MariaDB database container

Usage instructions added to DOCKER.md