### PR TITLE
testsuite: Skip tests not compatible with the mysql backend

### DIFF
--- a/test/testsuite/FPAddAPPL.c
+++ b/test/testsuite/FPAddAPPL.c
@@ -17,6 +17,11 @@ int dir;
 
 	ENTER_TEST
 
+	// Not supported with the mysql backend
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;

--- a/test/testsuite/FPAddIcon.c
+++ b/test/testsuite/FPAddIcon.c
@@ -58,6 +58,12 @@ DSI *dsi = &Conn->dsi;
 
 	ENTER_TEST
 
+	// Not supported with the mysql backend
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
+
 	dt = FPOpenDT(Conn,vol);
 	FAIL (FPAddIcon(Conn,  dt, "ttxt", "3DMF", 1, 0, 256, icon0_256 ))
 	// FIXME: afpd crash in afp_addicon() that hangs the execution

--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -946,6 +946,13 @@ char *name1= "new t407 file.pdf";
 uint16_t vol2;
 
 	ENTER_TEST
+
+	// Not supported with the mysql backend
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
+
 	if (!*Vol2) {
 		test_skipped(T_VOL2);
 		goto test_exit;
@@ -970,6 +977,13 @@ char *name1 = "t408 new file name";
 uint16_t vol2;
 
 	ENTER_TEST
+
+	// Not supported with the mysql backend
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
+
 	if (!*Vol2) {
 		test_skipped(T_VOL2);
 		goto test_exit;

--- a/test/testsuite/FPGetAPPL.c
+++ b/test/testsuite/FPGetAPPL.c
@@ -12,6 +12,12 @@ int dir;
 
 	ENTER_TEST
 
+	// Not supported with the mysql backend
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
+
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , file)) {
 		test_nottested();
 		goto test_exit;

--- a/test/testsuite/FPGetIcon.c
+++ b/test/testsuite/FPGetIcon.c
@@ -14,6 +14,12 @@ char   u_null[] = { 0, 0, 0, 0 };
 
 	ENTER_TEST
 
+	// Not supported with the mysql backend
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
+
 	dt = FPOpenDT(Conn,vol);
 
 	ret = FPGetIcon(Conn,  dt, "ttxt", "3DMF", 1, 256);
@@ -38,6 +44,8 @@ char   u_null[] = { 0, 0, 0, 0 };
 	}
 
 	FPCloseDT(Conn,dt);
+
+test_exit:
 	exit_test("FPGetIcon:test115: get Icon call");
 }
 

--- a/test/testsuite/FPGetIconInfo.c
+++ b/test/testsuite/FPGetIconInfo.c
@@ -14,12 +14,18 @@ u_char   u_null[] = { 0, 0, 0, 0 };
 
 	ENTER_TEST
 
+	// Not supported with the mysql backend
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
+
 	dt = FPOpenDT(Conn,vol);
 
 	ret = FPGetIconInfo(Conn,  dt, (unsigned char *) "ttxt", 1);
 	if (ret == htonl(AFPERR_NOITEM)) {
 		FAIL (FPAddIcon(Conn,  dt, "ttxt", "3DMF", 1, 0, 256, icon0_256 ))
-		goto test_exit;
+		goto fin;
 	}
 
 	FAIL (FPGetIconInfo(Conn,  dt, (unsigned char *) "ttxt", 1))
@@ -31,19 +37,20 @@ u_char   u_null[] = { 0, 0, 0, 0 };
 		if (ret == htonl(AFPERR_NOITEM)) {
 			FAIL (FPGetIconInfo(Conn,  dt, u_null, 1 ))
 			FAIL (htonl(AFPERR_NOITEM) != FPGetIconInfo(Conn,  dt, u_null, 2 ))
-			goto test_exit;
+			goto fin;
 		}
 		else if (ret) {
 			test_failed();
-			goto test_exit;
+			goto fin;
 		}
 		else {
 			FAIL (htonl(AFPERR_NOITEM) != FPGetIconInfo(Conn,  dt, (unsigned char *) "UNIX", 2 ))
 		}
 	}
 
-test_exit:
+fin:
 	FPCloseDT(Conn,dt);
+test_exit:
 	exit_test("FPGetIconInfo:test213: get Icon Info call");
 }
 

--- a/test/testsuite/FPRemoveAPPL.c
+++ b/test/testsuite/FPRemoveAPPL.c
@@ -13,6 +13,12 @@ unsigned int ret;
 
 	ENTER_TEST
 
+	// Not supported with the mysql backend
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
+
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , file)) {
 		test_nottested();
 		goto test_exit;

--- a/test/testsuite/FPSetDirParms.c
+++ b/test/testsuite/FPSetDirParms.c
@@ -205,6 +205,11 @@ DSI *dsi2;
 
 	ENTER_TEST
 
+	// Not supported with the mysql backend
+	if (Exclude) {
+		test_skipped(T_EXCLUDE);
+		goto test_exit;
+	}
 	if (!Conn2) {
 		test_skipped(T_CONN2);
 		goto test_exit;


### PR DESCRIPTION
This adds tests failing with the mysql CNID backend to the Exclude bucket

The reasons for failure has not yet been indentified, so this is just an acitivity for unblocking running these tests with mysql in CI

The Exclude bucket is activated when tests are run with the `-x` parameter