### PR TITLE
docker: Introduce an AFP_EXTMAP option to enable extension mapping

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -168,6 +168,7 @@ jobs:
                     -e SHARE_NAME2=test2 \
                     -e INSECURE_AUTH=1 \
                     -e DISABLE_TIMEMACHINE=1 \
+                    -e AFP_EXTMAP=1 \
                     ghcr.io/netatalk/netatalk:latest
             - name: Run Netatalk testsuite
               run: |
@@ -219,6 +220,7 @@ jobs:
                     -e SHARE_NAME2=test2 \
                     -e INSECURE_AUTH=1 \
                     -e DISABLE_TIMEMACHINE=1 \
+                    -e AFP_EXTMAP=1 \
                     -e AFP_CNID_SQL_HOST=mariadb \
                     -e AFP_CNID_SQL_PASS=${{ secrets.MARIADB_ROOT_PASSWORD }} \
                     ghcr.io/netatalk/netatalk:latest
@@ -276,6 +278,7 @@ jobs:
                     -e TESTSUITE=spectest \
                     -e AFP_VERSION=7 \
                     -e AFP_REMOTE=1 \
+                    -e AFP_EXTMAP=1 \
                     -e AFP_CNID_SQL_HOST=mariadb \
                     -e AFP_CNID_SQL_PASS=${{ secrets.MARIADB_ROOT_PASSWORD }} \
                     ghcr.io/netatalk/netatalk-testsuite-debian:latest
@@ -299,6 +302,7 @@ jobs:
             VERBOSE: 1
             TESTSUITE: spectest
             AFP_VERSION: 7
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
@@ -321,6 +325,7 @@ jobs:
             VERBOSE: 1
             TESTSUITE: spectest
             AFP_VERSION: 7
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite-debian:latest
 
@@ -344,6 +349,7 @@ jobs:
             AFP_ADOUBLE: 1
             TESTSUITE: spectest
             AFP_VERSION: 7
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
@@ -367,6 +373,7 @@ jobs:
             AFP_ADOUBLE: 1
             TESTSUITE: spectest
             AFP_VERSION: 7
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite-debian:latest
 
@@ -389,6 +396,7 @@ jobs:
             VERBOSE: 1
             TESTSUITE: spectest
             AFP_VERSION: 6
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
@@ -411,6 +419,7 @@ jobs:
             VERBOSE: 1
             TESTSUITE: spectest
             AFP_VERSION: 5
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
@@ -433,6 +442,7 @@ jobs:
             VERBOSE: 1
             TESTSUITE: spectest
             AFP_VERSION: 4
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
@@ -455,6 +465,7 @@ jobs:
             VERBOSE: 1
             TESTSUITE: spectest
             AFP_VERSION: 3
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
@@ -477,6 +488,7 @@ jobs:
             VERBOSE: 1
             TESTSUITE: spectest
             AFP_VERSION: 3
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite-debian:latest
 
@@ -499,6 +511,7 @@ jobs:
             VERBOSE: 1
             TESTSUITE: spectest
             AFP_VERSION: 2
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
   
@@ -521,6 +534,7 @@ jobs:
             VERBOSE: 1
             TESTSUITE: spectest
             AFP_VERSION: 1
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
@@ -543,6 +557,7 @@ jobs:
             VERBOSE: 1
             TESTSUITE: spectest
             AFP_VERSION: 1
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite-debian:latest
 
@@ -566,6 +581,7 @@ jobs:
             AFP_ADOUBLE: 1
             TESTSUITE: spectest
             AFP_VERSION: 1
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
 
@@ -589,6 +605,7 @@ jobs:
             AFP_ADOUBLE: 1
             TESTSUITE: spectest
             AFP_VERSION: 1
+            AFP_EXTMAP: 1
         steps:
             - uses: docker://ghcr.io/netatalk/netatalk-testsuite-debian:latest
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -171,6 +171,7 @@ These are required to set the credentials used to authenticate with the file ser
 | `MANUAL_CONFIG` | When non-zero, enable manual management of config files        |
 | `ATALKD_OPTIONS` | A string with options to append to atalkd.conf                |
 | `AFP_DROPBOX`   | Enable dropbox mode; turns secondary user into guest with read only access to the second shared volume |
+| `AFP_EXTMAP`    | Enable filename extension to Classic Mac OS type/creator mapping |
 | `AFP_CNID_BACKEND` | The backend to use for the CNID database; valid values are `bdb` and `mysql` |
 | `AFP_CNID_SQL_HOST` | The hostname or IP address of the CNID SQL server          |
 | `AFP_CNID_SQL_USER` | The username to use when connecting to the CNID SQL server |

--- a/config/extmap.conf
+++ b/config/extmap.conf
@@ -1,11 +1,13 @@
-# Netatalk file extension -> OS X type/creator mapping configuration file
+# Netatalk file extension -> Mac OS type/creator mapping configuration file
+# These are recognized by Classic Mac OS up until Mac OS X 10.4
+# Later Mac OS X versions look directly at the file extensions
 #
 # Delete a '#' character at the head of line to uncomment and enable a mapping
 #
-### Default translation:
+### Default translation; choose one of the following:
 #.         "????"  "????"      Unix Binary                    Unix                      application/octet-stream
-#.         "BINA"  "UNIX"      Unix Binary                    Unix                      application/octet-stream
-#.         "TEXT"  "ttxt"      ASCII Text                     SimpleText                text/plain
+##.         "BINA"  "UNIX"      Unix Binary                    Unix                      application/octet-stream
+##.         "TEXT"  "ttxt"      ASCII Text                     SimpleText                text/plain
 
 #.1st      "TEXT"  "ttxt"      Text Readme                    SimpleText                application/text
 #.669      "6669"  "SNPL"      669 MOD Music                  PlayerPro

--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -235,6 +235,10 @@ $AFP_RWRO = $AFP_VALIDUSERS2
 EOF
 fi
 
+if [ -n "$AFP_EXTMAP" ]; then
+    sed -i 's/^#\./\./' /usr/local/etc/extmap.conf
+fi
+
 # Configuring AppleTalk if enabled
 if [ -n "$ATALKD_INTERFACE" ]; then
     echo "*** Configuring DDP services"
@@ -252,19 +256,8 @@ fi
 
 echo "*** Starting AFP server"
 if [ -z "$TESTSUITE" ]; then
-    if [ -n "$AFP_DRYRUN" ]; then
-        netatalk -V
-    else
-        netatalk -d
-    fi
+    netatalk -d
 else
-    if [ "$TESTSUITE" = "spectest" ]; then
-    cat <<EXT > /usr/local/etc/extmap.conf
-.         "????"  "????"      Unix Binary                    Unix                      application/octet-stream
-.doc      "WDBN"  "MSWD"      Word Document                  Microsoft Word            application/msword
-.pdf      "PDF "  "CARO"      Portable Document Format       Acrobat Reader            application/pdf
-EXT
-    fi
     netatalk
     sleep 2
     case "$TESTSUITE" in

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -971,10 +971,6 @@ uint16_t bitmap;
 
 	ENTER_TEST
 
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		test_nottested();
 		goto fin;
@@ -1038,10 +1034,6 @@ uint16_t bitmap1 =  (1<<FILPBIT_ATTR) | (1<<FILPBIT_FINFO)| (1<<FILPBIT_CDATE) |
 
 	ENTER_TEST
 
-	if (Exclude) {
-		test_skipped(T_EXCLUDE);
-		goto test_exit;
-	}
 	if (FPCreateFile(Conn, vol,  0, DIRDID_ROOT , name)) {
 		test_nottested();
 		goto fin;


### PR DESCRIPTION
Use full extension mapping consistently for all CI jobs

Remove the extmap tests from the Exclude bucket

Flesh out the description of extmap.conf