### PR TITLE
docker: Introduce AFP_EXCLUDE_TESTS flag for triggering test exclusion

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -238,6 +238,7 @@ jobs:
                     -e TESTSUITE=spectest \
                     -e AFP_VERSION=7 \
                     -e AFP_REMOTE=1 \
+                    -e AFP_EXCLUDE_TESTS=1 \
                     -e AFP_HOST=afp_server \
                     -e AFP_CNID_SQL_HOST=mariadb \
                     -e AFP_CNID_SQL_PASS=${{ secrets.MARIADB_ROOT_PASSWORD }} \
@@ -279,6 +280,7 @@ jobs:
                     -e AFP_VERSION=7 \
                     -e AFP_REMOTE=1 \
                     -e AFP_EXTMAP=1 \
+                    -e AFP_EXCLUDE_TESTS=1 \
                     -e AFP_CNID_SQL_HOST=mariadb \
                     -e AFP_CNID_SQL_PASS=${{ secrets.MARIADB_ROOT_PASSWORD }} \
                     ghcr.io/netatalk/netatalk-testsuite-debian:latest

--- a/contrib/shell_utils/docker-entrypoint.sh
+++ b/contrib/shell_utils/docker-entrypoint.sh
@@ -194,12 +194,12 @@ if [ $AFP_CNID_BACKEND = "mysql" ]; then
     fi
 fi
 
-if [ "$TESTSUITE" = "spectest" ]; then
-    if [ -z "$AFP_REMOTE" ]; then
-        TEST_FLAGS="$TEST_FLAGS -c /mnt/afpshare"
-    else
-        TEST_FLAGS="$TEST_FLAGS -x"
-    fi
+if [ "$TESTSUITE" = "spectest" ] && [ -z "$AFP_REMOTE" ]; then
+    TEST_FLAGS="$TEST_FLAGS -c /mnt/afpshare"
+fi
+
+if [ -n "$AFP_EXCLUDE_TESTS" ]; then
+    TEST_FLAGS="$TEST_FLAGS -x"
 fi
 
 if [ -z "$MANUAL_CONFIG" ]; then


### PR DESCRIPTION
What was previously hard coded, this allows you to more dynamically specify when to skip the Exclude bucket in the testsuite through the CI job definitions