### PR TITLE
docker: Introduce DISABLE_SPOTLIGHT flag for turning off indexing

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -226,6 +226,7 @@ These are required to set the credentials used to authenticate with the file ser
 | `AFP_LEGACY_ICON` | Use a custom legacy AFP icon, such as `daemon` or `sdcard`   |
 | `INSECURE_AUTH` | When non-zero, enable the "ClearTxt" and "Guest" UAMs          |
 | `DISABLE_TIMEMACHINE` | When non-zero, the secondary shared volume is a regular volume |
+| `DISABLE_SPOTLIGHT` | When non-zero, Spotlight compatible indexing is disabled   |
 | `MANUAL_CONFIG` | When non-zero, enable manual management of config files        |
 | `ATALKD_OPTIONS` | A string with options to append to atalkd.conf                |
 | `AFP_DROPBOX`   | Enable dropbox mode; turns secondary user into guest with read only access to the second shared volume |

--- a/contrib/shell_utils/netatalk_container_entrypoint.sh
+++ b/contrib/shell_utils/netatalk_container_entrypoint.sh
@@ -161,6 +161,12 @@ else
     TIMEMACHINE="yes"
 fi
 
+if [ -n "$DISABLE_SPOTLIGHT" ]; then
+    AFP_SPOTLIGHT="no"
+else
+    AFP_SPOTLIGHT="yes"
+fi
+
 if [ -n "$AFP_READONLY" ]; then
     AFP_RWRO="rolist"
 else
@@ -172,6 +178,12 @@ if [ -n "$AFP_ADOUBLE" ]; then
     TEST_FLAGS="$TEST_FLAGS -a"
 else
     AFP_EA="sys"
+fi
+
+if [ -n "$ATALKD_INTERFACE" ]; then
+    AFP_DDP="yes"
+else
+    AFP_DDP="no"
 fi
 
 if [ -n "$AFP_DROPBOX" ]; then
@@ -210,7 +222,7 @@ fi
 if [ -z "$MANUAL_CONFIG" ]; then
     cat <<EOF > /etc/netatalk/afp.conf
 [Global]
-appletalk = yes
+appletalk = $AFP_DDP
 cnid mysql host = $AFP_CNID_SQL_HOST
 cnid mysql user = $AFP_CNID_SQL_USER
 cnid mysql pw = $AFP_CNID_SQL_PASS
@@ -220,7 +232,7 @@ log file = /var/log/afpd.log
 log level = default:${AFP_LOGLEVEL:-info}
 mimic model = $AFP_MIMIC_MODEL
 server name = ${SERVER_NAME:-Netatalk File Server}
-spotlight = yes
+spotlight = $AFP_SPOTLIGHT
 uam list = $UAMS
 [${SHARE_NAME:-File Sharing}]
 cnid scheme = ${AFP_CNID_BACKEND:-dbd}


### PR DESCRIPTION
Setting the new DISABLE_SPOTLIGHT env variable to non-zero will set spotlight = no in afp.conf

Additionally, we explicitly set appletalk = no when no atalkd interface is defined