### PR TITLE
webmin: Correct handling of volume and volume preset names

### DIFF
--- a/contrib/webmin_module/edit_vol_section.cgi
+++ b/contrib/webmin_module/edit_vol_section.cgi
@@ -146,10 +146,9 @@ if($subject eq 'homes') {
 	);
 }
 elsif($subject eq 'volume_preset') {
-	my $preset_name = (get_parameter_of_section($afpconfRef, $sectionRef, 'preset name', \%in))[0];
 	print &ui_table_row(
 		$text{'edit_vol_section_volume_preset_name'},
-		&ui_textbox('p_preset name', $preset_name ? $preset_name : $$sectionRef{'name'}, 40, undef, undef, "required")
+		&ui_textbox('name', exists $in{name} ? $in{name} : ($sectionRef ? $$sectionRef{name} : ''), 40, undef, undef, "required")
 	);
 }
 else {
@@ -160,11 +159,8 @@ else {
 	);
 }
 
-
-if($subject ne 'homes') {
-	print &ui_hidden('name', $$sectionRef{'name'});
-}
 if($subject eq 'volume') {
+	print &ui_hidden('name', $$sectionRef{'name'});
 	print &ui_table_row($text{'edit_vol_section_path'},
 		&ui_filebox('p_path', exists $in{p_path} ? $in{p_path} : (exists $$sectionRef{parameters}{'path'} ? $$sectionRef{parameters}{'path'}{value} : ''), 40, undef, undef, "required", 1) .
 		"<br /><a href=\"/filemin\" target=\"_blank\">$text{'edit_vol_section_path_note'}</a>"

--- a/contrib/webmin_module/index.cgi
+++ b/contrib/webmin_module/index.cgi
@@ -243,7 +243,6 @@ if(@{$$afpconf{volumeSections}}) {
 	print &ui_form_start('delete_sections.cgi?tab=fileserver', 'post', undef, "id='volumes'");
 	print &ui_columns_start( [
 			'',
-			$text{'index_col_title_vol_section'},
 			$text{'index_col_title_vol_name'},
 			$text{'index_col_title_path'},
 			$text{'index_col_title_uses_preset'}
@@ -252,8 +251,7 @@ if(@{$$afpconf{volumeSections}}) {
 	foreach $volumeSection (sort {lc($a->{name}) cmp lc($b->{name})} @{$$afpconf{volumeSections}}) {
 		print &ui_columns_row( [
 				&ui_checkbox('section_index', $$volumeSection{'index'}),
-				"<a href=\"edit_vol_section.cgi?action=edit_volume&tab=fileserver&index=$$volumeSection{'index'}\"><b>$$volumeSection{name}</b></a>",
-				$$volumeSection{parameters}{'volume name'}{value},
+				"<a href=\"edit_vol_section.cgi?action=edit_volume&tab=fileserver&index=$$volumeSection{'index'}\"><b>$$volumeSection{parameters}{'volume name'}{value}</b></a>",
 				$$volumeSection{parameters}{'path'}{value},
 				$$volumeSection{parameters}{'vol preset'}{value}
 		], [ "width='20'" ]);

--- a/contrib/webmin_module/lang/en
+++ b/contrib/webmin_module/lang/en
@@ -51,7 +51,6 @@ index_volumes=Volumes
 index_create_volume_link_name=Create new volume
 index_delete_volumes_button_title=Delete selected volumes
 index_no_volumes=No volumes defined
-index_col_title_vol_section=Volume ID
 index_col_title_vol_name=Volume name
 index_col_title_path=Path
 index_col_title_uses_preset=Uses preset

--- a/contrib/webmin_module/netatalk-lib.pl
+++ b/contrib/webmin_module/netatalk-lib.pl
@@ -308,8 +308,6 @@ sub modify_afpconf_ref_and_write {
 		$name = trim($$paramRef{'name'});
 	} elsif($$paramRef{'p_volume name'}) {
 		$name = $$paramRef{'p_volume name'};
-	} elsif($$paramRef{'p_preset name'}) {
-		$name = $$paramRef{'p_preset name'};
 	} else {
 		die "Volume/Volume preset name must not be empty.\n" unless($name);
 	}


### PR DESCRIPTION
Make it possible to actually edit volume preset names, rather than adding a useless preset name option to afp.conf (regression bug in 4.2.0)

When listing up volumes on the index page, only list volume names and not section names