### PR TITLE
docker: Containerized netatalk webmin module

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -23,7 +23,7 @@ env:
     REPO: ${{ github.repository }}
 
 name: Containers
-    
+
 jobs:
     build-container:
         name: Build production container
@@ -100,6 +100,46 @@ jobs:
               with:
                 context: .
                 file: testsuite_alp.Dockerfile
+                push: true
+                labels: ${{ steps.metadata.outputs.labels }}
+                tags: ${{ steps.metadata.outputs.tags }}
+
+
+    build-container-webmin:
+        name: Build Netatalk Webmin Module container
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        permissions:
+            contents: read
+            packages: write
+        steps:
+            - name: Checkout repo
+              uses: actions/checkout@v4
+            - name: Create image name
+              run: |
+                echo "IMAGE_NAME=${REPO,,}-webmin" >> ${GITHUB_ENV}
+            - name: Login to container registry
+              uses: docker/login-action@v3
+              with:
+                registry: ${{ env.REGISTRY }}
+                username: ${{ github.actor }}
+                password: ${{ secrets.GITHUB_TOKEN }}
+            - name: Extract metadata
+              id: metadata
+              uses: docker/metadata-action@v5
+              with:
+                images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                tags: |
+                  type=ref,event=branch
+                  type=ref,event=tag
+                  type=raw,value=latest
+                  type=sha
+            - name: Build and push container image
+              uses: docker/build-push-action@v5
+              with:
+                context: .
+                file: webmin_module.Dockerfile
                 push: true
                 labels: ${{ steps.metadata.outputs.labels }}
                 tags: ${{ steps.metadata.outputs.tags }}

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -127,6 +127,64 @@ networks:
     driver: bridge
 ```
 
+## Webmin Module
+
+Netatalk's Webmin module is distributed as a separate container image.
+The module allows you to administer the Netatalk configuration via a web interface.
+Here follows an example Docker Compose configuration to run the module in a container.
+
+Note that since the netatalk daemons run in a separate container, we cannot control
+the services directly. Instead, activate polling of changes to the afp.conf
+configuration file. Set `AFP_CONFIG_POLLING` to the number of seconds to wait between
+polling attempts.
+
+```
+services:
+  netatalk:
+    image: netatalk:latest
+    networks:
+      - afp_network
+    ports:
+      - "548:548"
+    volumes:
+      - afpshare:/mnt/afpshare
+      - afpbackup:/mnt/afpbackup
+      - afpconf:/etc/netatalk
+      - /var/run/dbus:/var/run/dbus
+    environment:
+      - AFP_USER=atalk1
+      - AFP_USER2=atalk2
+      - AFP_PASS=
+      - AFP_PASS2=
+      - AFP_GROUP=afpusers
+      - AFP_CONFIG_POLLING=5
+      - MANUAL_CONFIG=1
+
+  webmin:
+    image: netatalk_webmin_module:latest
+    networks:
+      - afp_network
+    ports:
+      - "10000:10000"
+    volumes:
+      - afpconf:/etc/netatalk
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      - WEBMIN_USER=admin
+      - WEBMIN_PASS=
+    depends_on:
+      - netatalk
+
+volumes:
+  afpshare:
+  afpbackup:
+  afpconf:
+
+networks:
+  afp_network:
+    driver: bridge
+```
+
 ## Printing
 
 The CUPS administrative web app is running on port 631 in the container, which is exposed to the host machine by default when using the `host` network driver. This is used to configure CUPS compatible printers for printing from an old Mac or Apple IIGS.

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ RUN apk update \
 
 WORKDIR /netatalk-code
 COPY . .
-RUN rm -rf build
 
 RUN meson setup build \
     -Dbuildtype=release \
@@ -64,6 +63,7 @@ RUN meson setup build \
     -Dwith-docs= \
     -Dwith-dtrace=false \
     -Dwith-init-style=none \
+    -Dwith-pkgconfdir-path=/etc/netatalk \
     -Dwith-quota=false \
     -Dwith-tcp-wrappers=false \
 &&  meson compile -C build
@@ -76,13 +76,14 @@ ARG RUN_DEPS
 ENV RUN_DEPS=$RUN_DEPS
 
 COPY --from=build /staging/ /
+COPY --from=build /netatalk-code/contrib/shell_utils/config_watch.sh /config_watch.sh
 
 RUN apk update \
 &&  apk add --no-cache $RUN_DEPS
 
 RUN ln -sf /dev/stdout /var/log/afpd.log
 
-COPY /contrib/shell_utils/docker-entrypoint.sh /entrypoint.sh
+COPY /contrib/shell_utils/netatalk_container_entrypoint.sh /entrypoint.sh
 
 WORKDIR /mnt
 EXPOSE 548

--- a/contrib/shell_utils/config_watch.sh
+++ b/contrib/shell_utils/config_watch.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Simple script for polling for netatalk config file changes
+# Copyright (C) 2025  Daniel Markstedt <daniel@mindani.net>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+WATCH_FILE="$1"
+SLEEP_INTERVAL="$2"
+
+get_checksum() {
+    cksum "$WATCH_FILE" | awk '{ print $1 }'
+}
+
+LAST_CHECKSUM=$(get_checksum)
+
+while true; do
+    sleep "$SLEEP_INTERVAL"
+    CURRENT_CHECKSUM=$(get_checksum)
+
+    if [ "$CURRENT_CHECKSUM" != "$LAST_CHECKSUM" ]; then
+        echo "$(date): Detected change in $WATCH_FILE"
+        pkill -HUP netatalk
+        echo "$(date): Sent SIGHUP to netatalk"
+        LAST_CHECKSUM="$CURRENT_CHECKSUM"
+    fi
+done

--- a/contrib/shell_utils/webmin_container_entrypoint.sh
+++ b/contrib/shell_utils/webmin_container_entrypoint.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+
+# Entry point script for the netatalk webmin module container.
+# Copyright (C) 2025  Daniel Markstedt <daniel@mindani.net>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+set -e
+
+[ -n "$DEBUG_ENTRY_SCRIPT" ] && set -x
+
+handle_sigterm() {
+    echo "*** Received SIGTERM, shutting down Webmin..."
+    if [ -n "$MINISERV_PID" ] && kill -0 "$MINISERV_PID" 2>/dev/null; then
+        kill "$MINISERV_PID"
+        wait "$MINISERV_PID"
+    fi
+    exit 0
+}
+
+trap handle_sigterm TERM INT
+
+echo "*** Setting up user"
+
+if [ -z "$WEBMIN_USER" ]; then
+    echo "ERROR: WEBMIN_USER needs to be set to use this container."
+    exit 1
+fi
+if [ -z "$WEBMIN_PASS" ]; then
+    echo "ERROR: WEBMIN_PASS needs to be set to use this container."
+    exit 1
+fi
+
+adduser --disabled-password --gecos '' "$WEBMIN_USER" 2> /dev/null || true
+usermod -aG sudo "$WEBMIN_USER"
+echo "$WEBMIN_USER:$WEBMIN_PASS" | chpasswd
+
+echo "*** Starting Webmin"
+
+/usr/share/webmin/miniserv.pl --nofork /etc/webmin/miniserv.conf &
+MINISERV_PID=$!
+
+wait "$MINISERV_PID"

--- a/testsuite_alp.Dockerfile
+++ b/testsuite_alp.Dockerfile
@@ -64,6 +64,7 @@ RUN meson setup build \
     -Dwith-docs= \
     -Dwith-dtrace=false \
     -Dwith-init-style=none \
+    -Dwith-pkgconfdir-path=/etc/netatalk \
     -Dwith-quota=false \
     -Dwith-tcp-wrappers=false \
     -Dwith-testsuite=true \
@@ -81,7 +82,7 @@ COPY --from=build /staging/ /
 RUN apk update \
 &&  apk add --no-cache $RUN_DEPS
 
-COPY /contrib/shell_utils/docker-entrypoint.sh /entrypoint.sh
+COPY /contrib/shell_utils/netatalk_container_entrypoint.sh /entrypoint.sh
 
 WORKDIR /mnt
 EXPOSE 548

--- a/testsuite_deb.Dockerfile
+++ b/testsuite_deb.Dockerfile
@@ -79,6 +79,7 @@ RUN meson setup build \
     -Dwith-init-style=none \
     -Dwith-krbV-uam=true \
     -Dwith-pam-config-path=/etc/pam.d \
+    -Dwith-pkgconfdir-path=/etc/netatalk \
     -Dwith-rpath=false \
     -Dwith-spooldir=/var/spool/netatalk \
     -Dwith-tcp-wrappers=false \
@@ -99,7 +100,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
 &&  apt-get install --yes --no-install-recommends $RUN_DEPS
 
-COPY /contrib/shell_utils/docker-entrypoint.sh /entrypoint.sh
+COPY /contrib/shell_utils/netatalk_container_entrypoint.sh /entrypoint.sh
 
 WORKDIR /mnt
 EXPOSE 548

--- a/webmin_module.Dockerfile
+++ b/webmin_module.Dockerfile
@@ -1,0 +1,81 @@
+FROM debian:bookworm-slim
+
+ARG RUN_DEPS="\
+    ca-certificates \
+    iproute2 \
+    libdb5.3 \
+    libevent-2.1-7 \
+    libgcrypt20 \
+    libpam0g \
+    sudo \
+    systemtap \
+    "
+ARG BUILD_DEPS="\
+    build-essential \
+    curl \
+    file \
+    libdb-dev \
+    libevent-dev \
+    libgcrypt20-dev \
+    libiniparser-dev \
+    libpam0g-dev \
+    meson \
+    ninja-build \
+    pkg-config \
+    systemtap-sdt-dev\
+    "
+
+ARG RUN_DEPS
+ARG BUILD_DEPS
+ENV RUN_DEPS=$RUN_DEPS
+ENV BUILD_DEPS=$BUILD_DEPS
+ENV PERLLIB=/usr/share/webmin
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+&&  apt-get install --yes --no-install-recommends \
+    $RUN_DEPS \
+    $BUILD_DEPS \
+&&  curl -o webmin-setup-repo.sh \
+    https://raw.githubusercontent.com/webmin/webmin/master/webmin-setup-repo.sh \
+&&  sh webmin-setup-repo.sh --force \
+&&  apt-get install --yes --no-install-recommends webmin \
+&&  apt-get clean
+
+WORKDIR /netatalk-code
+COPY . .
+
+RUN meson setup build \
+    -Dbuildtype=release \
+    -Dwith-afpstats=false \
+    -Dwith-appletalk=true \
+    -Dwith-docs= \
+    -Dwith-dtrace=false \
+    -Dwith-init-style=none \
+    -Dwith-krbV-uam=false \
+    -Dwith-pkgconfdir-path=/etc/netatalk \
+    -Dwith-rpath=false \
+    -Dwith-tcp-wrappers=false \
+    -Dwith-testsuite=false \
+    -Dwith-webmin=true \
+&&  meson compile -C build
+
+RUN meson install -C build \
+&&  apt-get remove --yes --auto-remove --purge $BUILD_DEPS \
+&&  apt-get --quiet --yes autoclean \
+&&  apt-get --quiet --yes autoremove \
+&&  apt-get --quiet --yes clean
+RUN rm -rf \
+    /netatalk-code \
+    /usr/include/netatalk \
+    /usr/share/man \
+    /usr/share/mime \
+    /usr/share/doc \
+    /usr/share/poppler \
+    /var/lib/apt/lists
+
+COPY /contrib/shell_utils/webmin_container_entrypoint.sh /entrypoint.sh
+
+WORKDIR /
+EXPOSE 10000
+CMD ["/entrypoint.sh"]


### PR DESCRIPTION
Introduce a new netatalk_webmin_module container which runs an isolated instance of webmin with the netatalk module

In the main netatalk container, newly introduced config file polling will pick up on any changes, since we cannot control the daemons directly from the webmin container

This changes the config file dir in the container to /etc/netatalk (from /usr/local/etc )