### PR TITLE
webmin: Option for hiding service controls

### DIFF
--- a/contrib/webmin_module/config.in
+++ b/contrib/webmin_module/config.in
@@ -22,3 +22,4 @@ restart_timelord=@init_timelord_restart@
 start_a2boot=@init_a2boot_start@
 stop_a2boot=@init_a2boot_stop@
 restart_a2boot=@init_a2boot_restart@
+hide_service_controls=0

--- a/contrib/webmin_module/config.info
+++ b/contrib/webmin_module/config.info
@@ -25,3 +25,5 @@ restart_timelord=Restart timelord,0
 start_a2boot=Start a2boot,0
 stop_a2boot=Stop a2boot,0
 restart_a2boot=Restart a2boot,0
+general_options=General options,11
+hide_service_controls=Hide service controls,1,1-Enabled,0-Disabled

--- a/contrib/webmin_module/index.cgi
+++ b/contrib/webmin_module/index.cgi
@@ -182,48 +182,51 @@ if (@atalk_ifs) {
 	print &ui_links_row(\@atalk_links);
 }
 
-my @daemons = (
-	{basename($config{atalkd_d}) => $text{index_process_atalkd}},
-	{basename($config{papd_d}) => $text{index_process_papd}},
-	{basename($config{timelord_d}) => $text{index_process_timelord}},
-	{basename($config{a2boot_d}) => $text{index_process_a2boot}}
-);
+if (!$config{hide_service_controls}) {
+	print &ui_hr();
+	my @daemons = (
+		{basename($config{atalkd_d}) => $text{index_process_atalkd}},
+		{basename($config{papd_d}) => $text{index_process_papd}},
+		{basename($config{timelord_d}) => $text{index_process_timelord}},
+		{basename($config{a2boot_d}) => $text{index_process_a2boot}}
+	);
 
-print "<h3>$text{'index_appletalk_services'}</h3>\n";
-print "<p>$text{'index_appletalk_services_notice'}</p>";
+	print "<h3>$text{'index_appletalk_services'}</h3>\n";
+	print "<p>$text{'index_appletalk_services_notice'}</p>";
 
-foreach my $daemon (@daemons) {
-	foreach my $d (keys %$daemon) {
-		if (-x $config{$d.'_d'}) {
-			if (&find_byname($config{$d.'_d'})) {
-				print "<h3>".&text('index_running_service', $daemon->{$d})."</h3>\n";
-				print &ui_buttons_start();
-				print &ui_buttons_row(
-					'control.cgi?action=restart&daemon='.$d,
-					&text('running_restart_daemon', $daemon->{$d}),
-					&text('index_process_control_restart_daemon', $d)
-				);
-				print &ui_buttons_row(
-					'control.cgi?action=stop&daemon='.$d,
-					&text('running_stop_daemon', $daemon->{$d}),
-					&text('index_process_control_stop_daemon', $d)
-				);
-				print &ui_buttons_end();
-				$current_formindex += 2;
-			} else {
-				print "<h3>".&text('index_not_running', $daemon->{$d})."</h3>\n";
-				print &ui_buttons_start();
-				print &ui_buttons_row(
-					'control.cgi?action=start&daemon='.$d,
-					&text('running_start_daemon', $daemon->{$d}),
-					&text('index_process_control_start_daemon', $d)
-				);
-				print &ui_buttons_end();
-				$current_formindex += 1;
+	foreach my $daemon (@daemons) {
+		foreach my $d (keys %$daemon) {
+			if (-x $config{$d.'_d'}) {
+				if (&find_byname($config{$d.'_d'})) {
+					print "<h3>".&text('index_running_service', $daemon->{$d})."</h3>\n";
+					print &ui_buttons_start();
+					print &ui_buttons_row(
+						'control.cgi?action=restart&daemon='.$d,
+						&text('running_restart_daemon', $daemon->{$d}),
+						&text('index_process_control_restart_daemon', $d)
+					);
+					print &ui_buttons_row(
+						'control.cgi?action=stop&daemon='.$d,
+						&text('running_stop_daemon', $daemon->{$d}),
+						&text('index_process_control_stop_daemon', $d)
+					);
+					print &ui_buttons_end();
+					$current_formindex += 2;
+				} else {
+					print "<h3>".&text('index_not_running', $daemon->{$d})."</h3>\n";
+					print &ui_buttons_start();
+					print &ui_buttons_row(
+						'control.cgi?action=start&daemon='.$d,
+						&text('running_start_daemon', $daemon->{$d}),
+						&text('index_process_control_start_daemon', $d)
+					);
+					print &ui_buttons_end();
+					$current_formindex += 1;
+				}
 			}
-		}
-		else {
-			print "<p>".&text('index_daemon_not_found', $d)."</p>";
+			else {
+				print "<p>".&text('index_daemon_not_found', $d)."</p>";
+			}
 		}
 	}
 }
@@ -265,53 +268,56 @@ if(@{$$afpconf{volumeSections}}) {
 	print "<p>\n";
 	print &ui_links_row(\@volume_links);
 }
-print &ui_hr();
 
-# since we are using a different number of forms, depending on the status of the service,
-# we are keeping a running index while outputting the forms
-my $current_formindex = 0;
+if (!$config{hide_service_controls}) {
+	print &ui_hr();
 
-print "<h3>$text{'index_filesharing_services'}</h3>\n";
+	# since we are using a different number of forms, depending on the status of the service,
+	# we are keeping a running index while outputting the forms
+	my $current_formindex = 0;
 
-# Process control Buttons
-if(&find_byname($config{'netatalk_d'})) {
-	print &ui_buttons_start();
-	print &ui_buttons_row(
-		'control.cgi?action=restart&daemon='.basename($config{netatalk_d}),
-		$text{'running_restart'},
-		&text('index_process_control_restart_daemon', basename($config{netatalk_d}))
+	print "<h3>$text{'index_filesharing_services'}</h3>\n";
+
+	# Process control Buttons
+	if(&find_byname($config{'netatalk_d'})) {
+		print &ui_buttons_start();
+		print &ui_buttons_row(
+			'control.cgi?action=restart&daemon='.basename($config{netatalk_d}),
+			$text{'running_restart'},
+			&text('index_process_control_restart_daemon', basename($config{netatalk_d}))
+		);
+		print &ui_buttons_row(
+			'control.cgi?action=stop&daemon='.basename($config{netatalk_d}),
+			$text{'running_stop'},
+			&text('index_process_control_stop_daemon', basename($config{netatalk_d}))
+		);
+		print &ui_buttons_end();
+		$current_formindex += 2;
+	} else {
+		print &ui_buttons_start();
+		print &ui_buttons_row(
+			'control.cgi?action=start&daemon='.basename($config{netatalk_d}),
+			$text{'running_start'},
+			&text('index_process_control_start_daemon', basename($config{netatalk_d}))
+		);
+		print &ui_buttons_end();
+		$current_formindex += 1;
+	}
+
+	my @links_f = (
+		"server_status.cgi",
+		"show_users.cgi"
 	);
-	print &ui_buttons_row(
-		'control.cgi?action=stop&daemon='.basename($config{netatalk_d}),
-		$text{'running_stop'},
-		&text('index_process_control_stop_daemon', basename($config{netatalk_d}))
+	my @titles_f = (
+		$text{'index_icon_text_capabilities'},
+		$text{'index_icon_text_users'}
 	);
-	print &ui_buttons_end();
-	$current_formindex += 2;
-} else {
-	print &ui_buttons_start();
-	print &ui_buttons_row(
-		'control.cgi?action=start&daemon='.basename($config{netatalk_d}),
-		$text{'running_start'},
-		&text('index_process_control_start_daemon', basename($config{netatalk_d}))
+	my @icons_f = (
+		"images/inspect.gif",
+		"images/users.gif"
 	);
-	print &ui_buttons_end();
-	$current_formindex += 1;
+	icons_table(\@links_f, \@titles_f, \@icons_f);
 }
-
-my @links_f = (
-	"server_status.cgi",
-	"show_users.cgi"
-);
-my @titles_f = (
-	$text{'index_icon_text_capabilities'},
-	$text{'index_icon_text_users'}
-);
-my @icons_f = (
-	"images/inspect.gif",
-	"images/users.gif"
-);
-icons_table(\@links_f, \@titles_f, \@icons_f);
 
 print &ui_tabs_end_tab('mode', 'fileserver');
 print &ui_tabs_end();

--- a/webmin_module.Dockerfile
+++ b/webmin_module.Dockerfile
@@ -46,7 +46,8 @@ RUN apt-get update \
 WORKDIR /netatalk-code
 COPY . .
 
-RUN meson setup build \
+RUN sed -i 's/hide_service_controls=0/hide_service_controls=1/' /netatalk-code/contrib/webmin_module/config.in \
+&&  meson setup build \
     -Dbuildtype=release \
     -Dwith-afpstats=false \
     -Dwith-appletalk=true \
@@ -59,14 +60,13 @@ RUN meson setup build \
     -Dwith-tcp-wrappers=false \
     -Dwith-testsuite=false \
     -Dwith-webmin=true \
-&&  meson compile -C build
-
-RUN meson install -C build \
+&&  meson compile -C build \
+&&  meson install -C build \
 &&  apt-get remove --yes --auto-remove --purge $BUILD_DEPS \
 &&  apt-get --quiet --yes autoclean \
 &&  apt-get --quiet --yes autoremove \
-&&  apt-get --quiet --yes clean
-RUN rm -rf \
+&&  apt-get --quiet --yes clean \
+&&  rm -rf \
     /netatalk-code \
     /usr/include/netatalk \
     /usr/share/man \


### PR DESCRIPTION
This is mainly for the purposes of removing the
start/stop/restart controls from view when webmin
is running inside of a container

We enable this option on the fly when building
the webmin container for netatalk