### PR TITLE
meson: Make it possible to generate the html manual with plain cmark

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,9 +27,15 @@ git clone https://github.com/netatalk/netatalk.git      # clone the repository
 cd netatalk                                             # change to the repo directory
 ```
 
-## External software dependencies
+## Install software dependencies
 
-Install software dependencies using your operating system's package manager.
+At this point, you need to install the software dependencies for building
+and running Netatalk.
+
+This list is not exhaustive, and you may need to install additional software
+depending on your platform and configuration. See the
+[Compilation](https://netatalk.io/compilation)
+documentation for more details.
 
 ### Required
 
@@ -62,7 +68,7 @@ Install software dependencies using your operating system's package manager.
 | Package      | Details |
 |--------------|---------|
 | avahi **OR** mDNSresponder | For Zeroconf support |
-| cmark **OR** cmark-gfm     | For generating documentation |
+| cmark **OR** cmark-gfm **OR** pandoc | For generating documentation |
 | cracklib and cracklib dictionary | For password strength check in afppasswd |
 | GLib 2 and GIO             | For afpstats support |
 | Kerberos V                 | For krbV UAM support |

--- a/doc/manpages/meson.build
+++ b/doc/manpages/meson.build
@@ -1,3 +1,13 @@
+if pandoc.found()
+    transcoder = pandoc
+elif cmarkgfm.found()
+    transcoder = cmarkgfm
+elif cmark.found()
+    transcoder = cmark
+else
+    warning('No supported Markdown parser found')
+endif
+
 make_man = find_program('make_man.sh')
 
 subdir('man1')

--- a/doc/manual/Configuration.md
+++ b/doc/manual/Configuration.md
@@ -469,15 +469,15 @@ that the UAM in question supplies. So think about eliminating weak UAMs like
 
 ### Netatalk UAM overview table
 
-A small overview of the most commonly used UAMs.
+A small overview of the officially supported UAMs.
 
-| UAM | No User Authent | Cleartxt Passwrd | (2-Way) Randnum exchange | DHCAST128 | DHX2 | Client Krb v2 |
-|----|----|----|----|----|----|----|
+| UAM | No User Auth | Cleartxt Passwrd | RandNum Exchange | DHCAST128 | DHX2 | Kerberos V |
+|-----|--------------|------------------|------------------|-----------|------|------------|
 | Password length | guest access | max. 8 characters | max. 8 characters | max. 64 characters | max. 256 characters | Kerberos tickets |
 | Client support | built-in into all Mac OS versions | built-in in all Mac OS versions except 10.0. Has to be activated explicitly in later Mac OS X versions | built-in into almost all Mac OS versions | built-in since AppleShare client 3.8.4, available as a plug-in for 3.8.3, integrated in macOS's AFP client | built-in since Mac OS X 10.2 | built-in since Mac OS X 10.2 |
 | Encryption | Enables guest access without authentication between client and server. | Password will be sent in cleartext over the wire. Just as bad as it sounds, therefore avoid at all if possible (note: providing NetBoot services requires the ClearTxt UAM) | 8-byte random numbers are sent over the wire, comparable with DES, 56 bits. Vulnerable to offline dictionary attack. Requires passwords in clear on the server. | Password will be encrypted with 128 bit SSL, user will be authenticated against the server but not vice versa. Therefore weak against man-in-the-middle attacks. | Password will be encrypted using libgcrypt with CAST 128 in CBC mode. User will be authenticated against the server but not vice versa. Therefore weak against man-in-the-middle attacks. | Password is not sent over the network. Due to the service principal detection method, this authentication method is vulnerable to man-in-the-middle attacks. |
 | Server support | uams_guest.so | uams_cleartxt.so | uams_randnum.so | uams_dhx.so | uams_dhx2.so | uams_gss.so |
-| Password storage method | None | Either /etc/passwd (/etc/shadow) or PAM | Passwords stored in clear text in a separate text file | Either /etc/passwd (/etc/shadow) or PAM | Either /etc/passwd (/etc/shadow) or PAM | At the Kerberos Key Distribution Center\* |
+| Password storage method | None | Either system auth or PAM | Passwords stored in clear text in a separate text file | Either system auth or PAM | Either system auth or PAM | At the Kerberos Key Distribution Center\* |
 
 \* Have a look at this [Kerberos
 overview](https://web.archive.org/web/20070705043002/http://cryptnet.net/fdp/admin/kerby-infra/en/kerby-infra.html)
@@ -969,7 +969,7 @@ crawling is forced
 The following table lists the supported Spotlight metadata attributes
 
 | Description | Spotlight Key |
-|----|----|
+|-------------|---------------|
 | Name | kMDItemDisplayName, kMDItemFSName |
 | Document content (full text search) | kMDItemTextContent |
 | File type | \_kMDItemGroupId, kMDItemContentTypeTree |

--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -95,16 +95,17 @@ functionality.
     When using Avahi, D-Bus is also required, and the Avahi library must
     have been built with D-Bus support.
 
-- cmark or cmark-gfm
+- cmark, cmark-gfm, or pandoc
 
     Netatalk's documentation is authored in Markdown format.
     The man page sources consist of standards-compliant CommonMark,
     while the rest of the documentation is authored in GitHub-Flavored
-    Markdown.
+    Markdown (gfm).
 
-    You can use cmark to generate roff man pages from the Markdown sources,
-    and cmark-gfm to generate all documentation, including HTML pages.
-    If you have access to the latter, you don't need the former.
+    The pandoc library generates the nicest output, but is
+    significantly more resource intensive than the other two options.
+    The cmark reference implementation is the most widely distributed,
+    but cmark-gfm handles GitHub extensions like tables better.
 
 - CrackLib
 

--- a/doc/manual/Upgrading.md
+++ b/doc/manual/Upgrading.md
@@ -131,7 +131,7 @@ default
 ### Old and new configuration file names
 
 | Old File Name | New File Name | Description |
-|----|----|----|
+|---------------|---------------|-------------|
 | \- | `etc/afp.conf` | new ini-style format |
 | \- | `etc/extmap.conf` | starting with netatalk 3.0.2 |
 | `etc/netatalk/afp_signature.conf` | `var/netatalk/afp_signature.conf` | moved to $localstatedir |
@@ -148,7 +148,7 @@ default
 **From netatalk.conf (`/etc/default/netatalk`) to afp.conf**
 
 | Old netatalk.conf | New afp.conf | Old Default Value | New Default Value | Section | Description |
-|----|----|----|----|----|----|
+|-------------------|--------------|-------------------|-------------------|---------|-------------|
 | ATALK_NAME | hostname | \- | \- | \(G\) | use gethostname() by default |
 | ATALK_UNIX_CHARSET | unix charset | LOCALE | UTF8 | \(G\) | \- |
 | ATALK_MAC_CHARSET | mac charset | MAC_ROMAN | MAC_ROMAN | (G)/(V) | \- |
@@ -169,8 +169,8 @@ default
 **From afpd.conf to afp.conf**
 
 | Old afpd.conf | New afp.conf | Old Default Value | New Default Value | Section | Description |
-|----|----|----|----|----|----|
-| 1st field ("-" or "server name") | server name | \- | \- | \(G\) | new in 4.2.0; use value of hostname by default |
+|---------------|--------------|-------------------|-------------------|---------|-------------|
+| 1st field ("-" or "server name") | server name | \- | \- | \(G\) | new in 4.2.0; default is the value of hostname |
 | -uamlist | uam list | uams_dhx.so,uams_dhx2.so | uams_dhx.so uams_dhx2.so | \(G\) | \- |
 | -nozeroconf | zeroconf | \- | yes (if supported) | \(G\) | \- |
 | -advertise_ssh | advertise ssh | \- | no | \(G\) | \- |
@@ -234,8 +234,8 @@ default
 
 **From afp_ldap.conf to afp.conf**
 
-| Old afp_ldap.conf | New afp.conf | Old Default Value | New Defalut Value | Section | Description |
-|----|----|----|----|----|----|
+| Old afp_ldap.conf | New afp.conf | Old Default Value | New Default Value | Section | Description |
+|-------------------|--------------|-------------------|-------------------|---------|-------------|
 | ldap_server | ldap server | \- | \- | \(G\) | \- |
 | ldap_auth_method | ldap auth method | \- | \- | \(G\) | \- |
 | ldap_auth_dn | ldap auth dn | \- | \- | \(G\) | \- |
@@ -252,7 +252,7 @@ default
 **From AppleVolumes.\* to afp.conf**
 
 | Old AppleVolumes.\* | New afp.conf | Old Default Value | New Defalut Value | Section | Description |
-|----|----|----|----|----|----|
+|--------------------|--------------|-------------------|-------------------|---------|-------------|
 | (leading-dot lines) | \- | \- | \- | \- | moved to extmap.conf |
 | :DEFAULT: | \- | options:upriv,usedots | \- | \- | use "vol preset" |
 | 1st field ("~") | \- | \- | \- | \- | use \[Homes\] section |

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -29,7 +29,7 @@ foreach page : manual_pages
             input: ['_Navlinks.md', page + '.md'],
             output: page + '.html',
             command: [
-                transcoder,
+                pandoc,
                 '--from', 'gfm',
                 '--to', 'html',
                 '@INPUT@',
@@ -38,17 +38,31 @@ foreach page : manual_pages
             install: true,
             install_dir: manual_install_path,
         )
-    else
+    elif cmarkgfm.found()
         custom_target(
             'manual_' + page,
             input: ['_Navlinks.md', page + '.md'],
             output: page + '.html',
             command: [
-                transcoder,
+                cmarkgfm,
                 '--smart',
                 '--extension', 'table',
                 '--to', 'html',
                 '@INPUT@',
+            ],
+            capture: true,
+            install: true,
+            install_dir: manual_install_path,
+        )
+    elif cmark.found()
+        custom_target(
+            'manual_' + page,
+            input: ['_Navlinks.md', page + '.md'],
+            output: page + '.html',
+            command: [
+                'sh', '-c',
+                cmark.full_path() + ' --to html "$1" "$2" | sed -e "s#<p>|#<pre>|#g" -e "s#|</p>#|</pre>#g"',
+                'sh', '@INPUT@'
             ],
             capture: true,
             install: true,

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,13 +1,3 @@
-if pandoc.found()
-    transcoder = pandoc
-elif cmarkgfm.found()
-    transcoder = cmarkgfm
-elif cmark.found()
-    transcoder = cmark
-else
-    warning('No supported Markdown parser found')
-endif
-
 if build_man_docs
     subdir('manpages')
 endif

--- a/doc/po/Configuration.md.ja.po
+++ b/doc/po/Configuration.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-03-30 22:49+0200\n"
+"POT-Creation-Date: 2025-04-21 19:03+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -22,17 +22,15 @@ msgstr ""
 #: manpages/man5/afp_voluuid.conf.5.md:20 manpages/man5/afp.conf.5.md:339
 #: manpages/man5/afp.conf.5.md:363 manpages/man5/afp.conf.5.md:376
 #: manpages/man5/afp.conf.5.md:391 manpages/man5/afp.conf.5.md:694
-#: manpages/man5/afp.conf.5.md:1093 manpages/man5/afp.conf.5.md:1219
-#: manpages/man5/afp.conf.5.md:1257 manpages/man8/papd.8.md:96
-#: manual/Configuration.md:113
+#: manpages/man5/afp.conf.5.md:1214 manpages/man5/afp.conf.5.md:1252
+#: manpages/man8/papd.8.md:96 manual/Configuration.md:113
 #, no-wrap
 msgid "> **NOTE**\n"
 msgstr "> **注記**\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1098 manpages/man5/afp.conf.5.md:1134
-#: manual/AppleTalk.md:154 manual/Configuration.md:836 manual/Installation.md:4
-#: manual/Upgrading.md:42
+#: manpages/man5/afp.conf.5.md:1129 manual/AppleTalk.md:154
+#: manual/Configuration.md:836 manual/Installation.md:4 manual/Upgrading.md:42
 #, no-wrap
 msgid "> **WARNING**\n"
 msgstr "> **警告**\n"
@@ -1266,29 +1264,28 @@ msgstr "Netatalk UAM を概要表"
 
 #. type: Plain text
 #: manual/Configuration.md:473
-msgid "A small overview of the most commonly used UAMs."
-msgstr "最も一般的に用いられる UAM の概観。"
+msgid "A small overview of the officially supported UAMs."
+msgstr "公式にサポートされているUAMの概観。"
 
 #. type: Plain text
 #: manual/Configuration.md:481
 #, no-wrap
 msgid ""
-"| UAM | No User Authent | Cleartxt Passwrd | (2-Way) Randnum exchange | DHCAST128 | DHX2 | Client Krb v2 |\n"
-"|----|----|----|----|----|----|----|\n"
+"| UAM | No User Auth | Cleartxt Passwrd | RandNum Exchange | DHCAST128 | DHX2 | Kerberos V |\n"
+"|-----|--------------|------------------|------------------|-----------|------|------------|\n"
 "| Password length | guest access | max. 8 characters | max. 8 characters | max. 64 characters | max. 256 characters | Kerberos tickets |\n"
 "| Client support | built-in into all Mac OS versions | built-in in all Mac OS versions except 10.0. Has to be activated explicitly in later Mac OS X versions | built-in into almost all Mac OS versions | built-in since AppleShare client 3.8.4, available as a plug-in for 3.8.3, integrated in macOS's AFP client | built-in since Mac OS X 10.2 | built-in since Mac OS X 10.2 |\n"
 "| Encryption | Enables guest access without authentication between client and server. | Password will be sent in cleartext over the wire. Just as bad as it sounds, therefore avoid at all if possible (note: providing NetBoot services requires the ClearTxt UAM) | 8-byte random numbers are sent over the wire, comparable with DES, 56 bits. Vulnerable to offline dictionary attack. Requires passwords in clear on the server. | Password will be encrypted with 128 bit SSL, user will be authenticated against the server but not vice versa. Therefore weak against man-in-the-middle attacks. | Password will be encrypted using libgcrypt with CAST 128 in CBC mode. User will be authenticated against the server but not vice versa. Therefore weak against man-in-the-middle attacks. | Password is not sent over the network. Due to the service principal detection method, this authentication method is vulnerable to man-in-the-middle attacks. |\n"
 "| Server support | uams_guest.so | uams_cleartxt.so | uams_randnum.so | uams_dhx.so | uams_dhx2.so | uams_gss.so |\n"
-"| Password storage method | None | Either /etc/passwd (/etc/shadow) or PAM | Passwords stored in clear text in a separate text file | Either /etc/passwd (/etc/shadow) or PAM | Either /etc/passwd (/etc/shadow) or PAM | At the Kerberos Key Distribution Center\\* |\n"
+"| Password storage method | None | Either system auth or PAM | Passwords stored in clear text in a separate text file | Either system auth or PAM | Either system auth or PAM | At the Kerberos Key Distribution Center\\* |\n"
 msgstr ""
-"|  |  |  |  |  |  |  |\n"
-"|----|----|----|----|----|----|----|\n"
-"| UAM | No User Authent | Cleartxt Passwrd | (2-Way) Randnum exchange | DHCAST128 | DHX2 | Client Krb v2 |\n"
+"| UAM | No User Auth | Cleartxt Passwrd | RandNum Exchange | DHCAST128 | DHX2 | Kerberos V |\n"
+"|-----|--------------|------------------|------------------|-----------|------|------------|\n"
 "| パスワード長 | ゲストアクセス | 最大 8 文字 | 最大 8 文字 | 最大 64 文字 | 最大 256 文字 | Kerberos チケット |\n"
 "| サポートするクライアント | 全ての Mac OS のバージョンで組み込み済 | 10.0 を除く全ての Mac OS のバージョンで組み込み済。 最近のバージョンでは明示的にアクティブ化する必要がある。 | ほとんど全ての Mac OS のバージョンで組み込み済 | AppleShare クライアント 3.8.4 より組み込み済で、3.8.3 では macOS の AFP クライアントに統合したプラグインとしての用意あり。 | Mac OS X 10.2 より組み込み済 | Mac OS X 10.2 より組み込み済 |\n"
 "| 暗号化 | クライアント・サーバー間で認証なくゲストアクセス可能。 | パスワードがネットワーク上を暗号化されずに伝わっていく。 字句そのままに悪いので、可能ならば全面的に使用を回避すべき （注意：NetBoot サービスの提供には ClearTxt UAM が必要） | DES, 56 ビットに相当する 8 バイトの乱数がネットワーク上に送出。オフラインの辞書攻撃に対して脆弱。 パスワードがサーバー上で平文であることが求められる。 | パスワードは 128 ビット SSL で暗号化され、ユーザーはサーバーに認証されるが、“逆もまた真”ではない。 このため中間者攻撃に対して弱い。 | パスワードは libgcrypt の CAST 128、CBC モードを用いて暗号化される。 ユーザーはサーバーに認証されるが、“逆もまた真”ではない。このため中間者攻撃に対して弱い。 | パスワードがネットワークを通して送られることがない。サービスプリンシパル検知の方法が原因で、 この認証方法は中間者攻撃に対して脆弱である。 |\n"
 "| サーバーがサポートする共有オブジェクト | uams_guest.so | uams_cleartxt.so | uams_randnum.so | uams_dhx.so | uams_dhx2.so | uams_gss.so |\n"
-"| パスワードの保管方法 | なし | /etc/passwd (/etc/shadow) ないしは PAM | パスワードは別のテキストファイルに平文として保存される | /etc/passwd (/etc/shadow) ないしは PAM | /etc/passwd (/etc/shadow) ないしは PAM | Kerberos キー配布センター\\* |\n"
+"| パスワードの保管方法 | なし | システム認証ないしはPAM | パスワードは別のテキストファイルに平文として保存される | システム認証ないしはPAM | システム認証ないしはPAM | Kerberosキー配布センター\\* |\n"
 
 #. type: Plain text
 #: manual/Configuration.md:484
@@ -2536,7 +2533,7 @@ msgstr "下記表にサポートされている Spotlight メタデータ属性�
 #, no-wrap
 msgid ""
 "| Description | Spotlight Key |\n"
-"|----|----|\n"
+"|-------------|---------------|\n"
 "| Name | kMDItemDisplayName, kMDItemFSName |\n"
 "| Document content (full text search) | kMDItemTextContent |\n"
 "| File type | \\_kMDItemGroupId, kMDItemContentTypeTree |\n"
@@ -2561,7 +2558,7 @@ msgid ""
 "| The musical genre of the song or composition | kMDItemMusicalGenre |\n"
 msgstr ""
 "| 内容 | Spotlight キー |\n"
-"|----|----|\n"
+"|----|--------------|\n"
 "| 名前 | kMDItemDisplayName, kMDItemFSName |\n"
 "| ドキュメントの内容（全文検索） | kMDItemTextContent |\n"
 "| ファイルタイプ | \\_kMDItemGroupId, kMDItemContentTypeTree |\n"

--- a/doc/po/Installation.md.ja.po
+++ b/doc/po/Installation.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-04-13 17:06+0200\n"
+"POT-Creation-Date: 2025-04-21 21:07+0200\n"
 "PO-Revision-Date: 2025-01-25 15:05+0100\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -19,9 +19,8 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1098 manpages/man5/afp.conf.5.md:1133
-#: manual/AppleTalk.md:154 manual/Configuration.md:836 manual/Installation.md:4
-#: manual/Upgrading.md:42
+#: manpages/man5/afp.conf.5.md:1129 manual/AppleTalk.md:154
+#: manual/Configuration.md:836 manual/Installation.md:4 manual/Upgrading.md:42
 #, no-wrap
 msgid "> **WARNING**\n"
 msgstr "> **警告**\n"
@@ -295,8 +294,8 @@ msgstr ""
 
 #. type: Bullet: '- '
 #: manual/Installation.md:99
-msgid "cmark or cmark-gfm"
-msgstr "cmark もしくは cmark-gfm"
+msgid "cmark, cmark-gfm, or pandoc"
+msgstr "cmark、cmark-gfm、またはpandoc"
 
 #. type: Plain text
 #: manual/Installation.md:104
@@ -305,30 +304,32 @@ msgid ""
 "    Netatalk's documentation is authored in Markdown format.\n"
 "    The man page sources consist of standards-compliant CommonMark,\n"
 "    while the rest of the documentation is authored in GitHub-Flavored\n"
-"    Markdown.\n"
+"    Markdown (gfm).\n"
 msgstr ""
-"    Netatalk のドキュメントは Markdown 形式で作成されている。\n"
-"    マニュアル ページのソースは標準に準拠した CommonMark で構成され、\n"
-"    ドキュメントの残りの部分は GitHub 風の Markdown (gfm) で作成されている。\n"
+"    Netatalk のドキュメントはMarkdown形式で作成されている。\n"
+"    マニュアルページのソースは標準に準拠したCommonMarkで構成され、\n"
+"    ドキュメントの残りの部分はGitHub風の Markdown (gfm)で作成されている。\n"
 
 #. type: Plain text
-#: manual/Installation.md:108
+#: manual/Installation.md:109
 #, no-wrap
 msgid ""
-"    You can use cmark to generate roff man pages from the Markdown sources,\n"
-"    and cmark-gfm to generate all documentation, including HTML pages.\n"
-"    If you have access to the latter, you don't need the former.\n"
+"    The pandoc library generates the nicest output, but is\n"
+"    significantly more resource intensive than the other two options.\n"
+"    The cmark reference implementation is the most widely distributed,\n"
+"    but cmark-gfm handles GitHub extensions like tables better.\n"
 msgstr ""
-"    cmark を使用して Markdown ソースから roff マニュアル ページを生成し、cmark-gfm を使用して HTML ページを含むすべてのドキュメントを生成できる。\n"
-"    後者は利用可能な場合は、前者は必要ない。\n"
+"    pandocライブラリは最もきれいな出力を生成するが、他の2つのオプション\n"
+"    よりもはるかにリソースを消費する。cmarkのリファレンス実装が最も広く配布\n"
+"    されているが、cmark-gfm はテーブルのようなGitHub拡張機能をよりよく扱う。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:110
+#: manual/Installation.md:111
 msgid "CrackLib"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:114
+#: manual/Installation.md:115
 #, no-wrap
 msgid ""
 "    When using the Random Number UAMs and netatalk's own **afppasswd**\n"
@@ -340,7 +341,7 @@ msgstr ""
 "    での認証に弱いパスワードを設定するのを防ぐのに役立つ。\n"
 
 #. type: Plain text
-#: manual/Installation.md:117
+#: manual/Installation.md:118
 #, no-wrap
 msgid ""
 "    The CrackLib dictionary, which is sometimes distributed separately in\n"
@@ -350,12 +351,12 @@ msgstr ""
 "    もコンパイル時にも実行時にも必須である。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:119
+#: manual/Installation.md:120
 msgid "D-Bus"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:123
+#: manual/Installation.md:124
 #, no-wrap
 msgid ""
 "    D-Bus provides a mechanism for sending messages between processes,\n"
@@ -367,23 +368,23 @@ msgstr ""
 "    **afpstats** ツール。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:125
+#: manual/Installation.md:126
 msgid "GLib and GIO"
 msgstr "GLib および GIO"
 
 #. type: Plain text
-#: manual/Installation.md:127
+#: manual/Installation.md:128
 #, no-wrap
 msgid "    Used by the **afpstats** tool to interface with D-Bus.\n"
 msgstr "    D-Bus とのインターフェースとして、**afpstats** ツールに使われる。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:129
+#: manual/Installation.md:130
 msgid "iconv"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:135
+#: manual/Installation.md:136
 #, no-wrap
 msgid ""
 "    iconv provides conversion routines for many character encodings.\n"
@@ -399,12 +400,12 @@ msgstr ""
 "    実装を使用できる。それ以外の場合は、GNU libiconv 実装を使用できる。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:137
+#: manual/Installation.md:138
 msgid "Kerberos V"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:142
+#: manual/Installation.md:143
 #, no-wrap
 msgid ""
 "    Kerberos v5 is a client-server based authentication protocol invented\n"
@@ -418,12 +419,12 @@ msgstr ""
 "    インフラストラクチャでの認証用に GSS UAM ライブラリを作成できる。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:144
+#: manual/Installation.md:145
 msgid "MySQL or MariaDB"
 msgstr "MySQL または MariaDB"
 
 #. type: Plain text
-#: manual/Installation.md:149
+#: manual/Installation.md:150
 #, no-wrap
 msgid ""
 "    By leveraging a MySQL-compatible client library, netatalk can be built\n"
@@ -437,12 +438,12 @@ msgstr ""
 "    インスタンスを用意する必要がある。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:151
+#: manual/Installation.md:152
 msgid "PAM"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:156
+#: manual/Installation.md:157
 #, no-wrap
 msgid ""
 "    PAM provides a flexible mechanism for authenticating users. PAM was\n"
@@ -457,12 +458,12 @@ msgstr ""
 "    スイートである。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:158
+#: manual/Installation.md:159
 msgid "Perl"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:162
+#: manual/Installation.md:163
 #, no-wrap
 msgid ""
 "    Netatalk's administrative utility scripts rely on the Perl runtime,\n"
@@ -474,12 +475,12 @@ msgstr ""
 "    (asip-status) 又は *Net::DBus* (afpstats)。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:164
+#: manual/Installation.md:165
 msgid "po4a"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:169
+#: manual/Installation.md:170
 #, no-wrap
 msgid ""
 "    With the help of po4a, Netatalk's documentation can be translated\n"
@@ -492,18 +493,18 @@ msgstr ""
 "    ファイルに保存されている翻訳と結合する。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:171
+#: manual/Installation.md:172
 msgid "TCP wrappers"
 msgstr "TCP ラッパー"
 
 #. type: Plain text
-#: manual/Installation.md:173
+#: manual/Installation.md:174
 #, no-wrap
 msgid "    Wietse Venema's network logger, also known as TCPD or LOG_TCP.\n"
 msgstr "    Wietse Venema のネットワーク ロガー。TCPD または LOG_TCP とも呼ばれる。\n"
 
 #. type: Plain text
-#: manual/Installation.md:177
+#: manual/Installation.md:178
 #, no-wrap
 msgid ""
 "    Security options are: access control per host, domain and/or service;\n"
@@ -514,12 +515,12 @@ msgstr ""
 "    アドレスのスプーフィングの検出。ブービートラップを使用して早期警告システムを実装する。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:179
+#: manual/Installation.md:180
 msgid "Tracker, or TinySPARQL / LocalSearch"
 msgstr "Tracker もしくは TinySPARQL / LocalSearch"
 
 #. type: Plain text
-#: manual/Installation.md:187
+#: manual/Installation.md:188
 #, no-wrap
 msgid ""
 "    Netatalk uses [Tracker](https://tracker.gnome.org) or its later\n"
@@ -538,12 +539,12 @@ msgstr ""
 "    をサポートする最初のバージョンだからである。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:189
+#: manual/Installation.md:190
 msgid "talloc / bison / flex"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:192
+#: manual/Installation.md:193
 #, no-wrap
 msgid ""
 "    Samba's talloc library, a Yacc parser such as bison, and a lexer like\n"
@@ -553,12 +554,12 @@ msgstr ""
 "    パーサー、flex などのレキサーも必要。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:194
+#: manual/Installation.md:195
 msgid "UnicodeData.txt"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:197
+#: manual/Installation.md:198
 #, no-wrap
 msgid ""
 "    The [Unicode Character Database](https://www.unicode.org/Public/UNIDATA/UnicodeData.txt)\n"
@@ -568,7 +569,7 @@ msgstr ""
 "    が必要である。\n"
 
 #. type: Plain text
-#: manual/Installation.md:200
+#: manual/Installation.md:201
 #, no-wrap
 msgid ""
 "    This is mostly relevant for developers or package managers who want to regenerate\n"
@@ -576,13 +577,13 @@ msgid ""
 msgstr "    これは、開発者やパッケージ マネージャーが Netatalk の Unicode 文字変換テーブルを再生成したい場合に関連する。\n"
 
 #. type: Title ##
-#: manual/Installation.md:201
+#: manual/Installation.md:202
 #, no-wrap
 msgid "Starting and stopping Netatalk"
 msgstr "Netatalk の起動と停止"
 
 #. type: Plain text
-#: manual/Installation.md:209
+#: manual/Installation.md:210
 msgid ""
 "The Netatalk distribution comes with several operating system specific "
 "startup script templates that are tailored according to the options given to "
@@ -597,7 +598,7 @@ msgstr ""
 "トフォーム固有のスクリプトに加えて、systemd、openrc 用に提供されている。"
 
 #. type: Plain text
-#: manual/Installation.md:215
+#: manual/Installation.md:216
 msgid ""
 "When building from source, the Netatalk build system will attempt to detect "
 "which init style is appropriate for your platform. You can also configure "
@@ -612,7 +613,7 @@ msgstr ""
 "テキストを参照してください。"
 
 #. type: Plain text
-#: manual/Installation.md:220
+#: manual/Installation.md:221
 msgid ""
 "Since new Linux, \\*BSD, and Solaris-like distributions appear at regular "
 "intervals, and the startup procedure for the other systems mentioned above "
@@ -625,7 +626,7 @@ msgstr ""
 "ることをお勧めする。"
 
 #. type: Plain text
-#: manual/Installation.md:225
+#: manual/Installation.md:226
 msgid ""
 "If you use Netatalk as part of a fixed setup, like a Linux distribution, an "
 "RPM or a BSD package, things will probably have been arranged properly for "
@@ -638,7 +639,7 @@ msgstr ""
 "まる。"
 
 #. type: Plain text
-#: manual/Installation.md:228
+#: manual/Installation.md:229
 msgid ""
 "The following daemon need to be started by whatever startup script mechanism "
 "is used:"
@@ -647,12 +648,12 @@ msgstr ""
 "必要がある:"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:230
+#: manual/Installation.md:231
 msgid "netatalk"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:233
+#: manual/Installation.md:234
 msgid ""
 "In the absence of a startup script, you can also launch this daemon directly "
 "(as root), and kill it with SIGTERM when you are done with it."
@@ -661,7 +662,7 @@ msgstr ""
 "し、使い終わったら SIGTERM で終了することもできる。"
 
 #. type: Plain text
-#: manual/Installation.md:237
+#: manual/Installation.md:238
 msgid ""
 "Additionally, make sure that the configuration file *afp.conf* is in the "
 "right place. You can inquire netatalk where it is expecting the file to be "
@@ -672,7 +673,7 @@ msgstr ""
 "かどうかを問い合わせることができる。"
 
 #. type: Plain text
-#: manual/Installation.md:241
+#: manual/Installation.md:242
 msgid ""
 "If you want to run AppleTalk services, you also need to start the **atalkd** "
 "daemon, plus the optional **papd**, **timelord**, and **a2boot** daemons. "

--- a/doc/po/Upgrading.md.ja.po
+++ b/doc/po/Upgrading.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-03-13 21:32+0100\n"
+"POT-Creation-Date: 2025-04-21 19:03+0200\n"
 "PO-Revision-Date: 2025-01-23 08:10+0100\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -18,9 +18,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1055 manpages/man5/afp.conf.5.md:1091
-#: manual/AppleTalk.md:154 manual/Configuration.md:827 manual/Installation.md:4
-#: manual/Upgrading.md:42
+#: manpages/man5/afp.conf.5.md:1129 manual/AppleTalk.md:154
+#: manual/Configuration.md:836 manual/Installation.md:4 manual/Upgrading.md:42
 #, no-wrap
 msgid "> **WARNING**\n"
 msgstr "> **警告**\n"
@@ -384,7 +383,7 @@ msgstr "新旧設定ファイル名"
 #, no-wrap
 msgid ""
 "| Old File Name | New File Name | Description |\n"
-"|----|----|----|\n"
+"|---------------|---------------|-------------|\n"
 "| \\- | `etc/afp.conf` | new ini-style format |\n"
 "| \\- | `etc/extmap.conf` | starting with netatalk 3.0.2 |\n"
 "| `etc/netatalk/afp_signature.conf` | `var/netatalk/afp_signature.conf` | moved to $localstatedir |\n"
@@ -426,7 +425,7 @@ msgstr "**netatalk.conf (/etc/default/netatalk) から afp.conf**\n"
 #, no-wrap
 msgid ""
 "| Old netatalk.conf | New afp.conf | Old Default Value | New Default Value | Section | Description |\n"
-"|----|----|----|----|----|----|\n"
+"|-------------------|--------------|-------------------|-------------------|---------|-------------|\n"
 "| ATALK_NAME | hostname | \\- | \\- | \\(G\\) | use gethostname() by default |\n"
 "| ATALK_UNIX_CHARSET | unix charset | LOCALE | UTF8 | \\(G\\) | \\- |\n"
 "| ATALK_MAC_CHARSET | mac charset | MAC_ROMAN | MAC_ROMAN | (G)/(V) | \\- |\n"
@@ -474,8 +473,8 @@ msgstr "**afpd.conf から afp.conf**\n"
 #, no-wrap
 msgid ""
 "| Old afpd.conf | New afp.conf | Old Default Value | New Default Value | Section | Description |\n"
-"|----|----|----|----|----|----|\n"
-"| 1st field (\"-\" or \"server name\") | server name | \\- | \\- | \\(G\\) | new in 4.2.0; use value of hostname by default |\n"
+"|---------------|--------------|-------------------|-------------------|---------|-------------|\n"
+"| 1st field (\"-\" or \"server name\") | server name | \\- | \\- | \\(G\\) | new in 4.2.0; default is the value of hostname |\n"
 "| -uamlist | uam list | uams_dhx.so,uams_dhx2.so | uams_dhx.so uams_dhx2.so | \\(G\\) | \\- |\n"
 "| -nozeroconf | zeroconf | \\- | yes (if supported) | \\(G\\) | \\- |\n"
 "| -advertise_ssh | advertise ssh | \\- | no | \\(G\\) | \\- |\n"
@@ -611,8 +610,8 @@ msgstr "**from afp_ldap.conf から afp.conf**\n"
 #: manual/Upgrading.md:251
 #, no-wrap
 msgid ""
-"| Old afp_ldap.conf | New afp.conf | Old Default Value | New Defalut Value | Section | Description |\n"
-"|----|----|----|----|----|----|\n"
+"| Old afp_ldap.conf | New afp.conf | Old Default Value | New Default Value | Section | Description |\n"
+"|-------------------|--------------|-------------------|-------------------|---------|-------------|\n"
 "| ldap_server | ldap server | \\- | \\- | \\(G\\) | \\- |\n"
 "| ldap_auth_method | ldap auth method | \\- | \\- | \\(G\\) | \\- |\n"
 "| ldap_auth_dn | ldap auth dn | \\- | \\- | \\(G\\) | \\- |\n"
@@ -652,7 +651,7 @@ msgstr "**AppleVolumes.\\* から afp.conf**\n"
 #, no-wrap
 msgid ""
 "| Old AppleVolumes.\\* | New afp.conf | Old Default Value | New Defalut Value | Section | Description |\n"
-"|----|----|----|----|----|----|\n"
+"|--------------------|--------------|-------------------|-------------------|---------|-------------|\n"
 "| (leading-dot lines) | \\- | \\- | \\- | \\- | moved to extmap.conf |\n"
 "| :DEFAULT: | \\- | options:upriv,usedots | \\- | \\- | use \"vol preset\" |\n"
 "| 1st field (\"~\") | \\- | \\- | \\- | \\- | use \\[Homes\\] section |\n"

--- a/meson.build
+++ b/meson.build
@@ -2281,7 +2281,6 @@ if 'readmes' in get_option('with-docs')
                     install_dir: datadir / 'doc/netatalk',
                 )
             else
-                warning('cmark-gfm or pandoc is required for markdown to plain text conversion of READMEs')
                 install_data(file + '.md', install_dir: datadir / 'doc/netatalk')
             endif
         endif
@@ -2297,10 +2296,10 @@ if 'man' in get_option('with-docs')
 endif
 
 if 'html_manual' in get_option('with-docs')
-    if cmarkgfm.found() or pandoc.found()
+    if cmark.found() or cmarkgfm.found() or pandoc.found()
         build_html_docs = true
     else
-        warning('cmark-gfm or pandoc is required to build the html manual')
+        warning('cmark, cmark-gfm or pandoc is required to build the html manual')
     endif
 endif
 


### PR DESCRIPTION
When using cmark, filter the output to enclose table markdown in pre tags to get an acceptable html layout

The resulting tables aren't ideal for readability, but I would argue that they are perfectly serviceable 