### PR TITLE
testsuite: Prevent potential buffer overflow in test336

### DIFF
--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -781,7 +781,14 @@ struct afp_filedir_parms filedir;
 	if (Path) {
 	    struct stat st;
 
-		sprintf(temp1, "%s/%s/%s", Path, ndir, temp);
+		strlcpy(temp1, Path, sizeof(temp1));
+		strlcat(temp1, "/", sizeof(temp1));
+		strlcat(temp1, ndir, sizeof(temp1));
+		strlcat(temp1, "/", sizeof(temp1));
+		strlcat(temp1, temp, sizeof(temp1));
+		if (strlcat(temp1, temp, sizeof(temp1)) >= sizeof(temp1) && !Quiet) {
+			fprintf(stdout, "\tWARNING: Path too long, truncated to: %s\n", temp1);
+		}
 		if (stat(temp1, &st)) {
 			if (!Quiet) {
 				fprintf(stdout,"\tFAILED stat( %s ) %s\n", temp1, strerror(errno));


### PR DESCRIPTION
gcc 11.4.0 on Ubuntu 22.04 warns about a potential buffer overflow in an sprintf concatenation, which is fixed with more deliberate concatenation and error check