### PR TITLE
meson: Properly build the localized html manual

### DIFF
--- a/doc/manual/_Navlinks_atalk.md
+++ b/doc/manual/_Navlinks_atalk.md
@@ -3,5 +3,6 @@
 * [Introduction](index.html)
 * [Installation](Installation.html)
 * [Configuration](Configuration.html)
+* [AppleTalk](AppleTalk.html)
 * [Upgrading](Upgrading.html)
 * [License](License.html)

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -26,7 +26,7 @@ foreach page : manual_pages
     if pandoc.found()
         custom_target(
             'manual_' + page,
-            input: ['_Navlinks.md', page + '.md'],
+            input: [navlinks, page + '.md'],
             output: page + '.html',
             command: [
                 pandoc,
@@ -41,7 +41,7 @@ foreach page : manual_pages
     elif cmarkgfm.found()
         custom_target(
             'manual_' + page,
-            input: ['_Navlinks.md', page + '.md'],
+            input: [navlinks, page + '.md'],
             output: page + '.html',
             command: [
                 cmarkgfm,
@@ -57,7 +57,7 @@ foreach page : manual_pages
     elif cmark.found()
         custom_target(
             'manual_' + page,
-            input: ['_Navlinks.md', page + '.md'],
+            input: [navlinks, page + '.md'],
             output: page + '.html',
             command: [
                 'sh', '-c',

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -2,6 +2,12 @@ if build_man_docs
     subdir('manpages')
 endif
 
+if have_appletalk
+    navlinks = '_Navlinks_atalk.md'
+else
+    navlinks = '_Navlinks.md'
+endif
+
 if build_html_docs
     subdir('manual')
 

--- a/doc/po/_Navlinks.md.ja.po
+++ b/doc/po/_Navlinks.md.ja.po
@@ -1,0 +1,48 @@
+# Japanese translations for Netatalk documentation
+# Netatalk ドキュメントの日本語訳
+# Copyright (C) 2025 Daniel Markstedt <daniel@mindani.net>
+# This file is distributed under the same license as the Netatalk package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Netatalk 4.2.2dev\n"
+"POT-Creation-Date: 2025-04-22 22:06+0200\n"
+"PO-Revision-Date: 2025-04-22 21:52+0200\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title #
+#: manual/_Navlinks.md:1 manual/_Navlinks_atalk.md:1
+#, no-wrap
+msgid "Netatalk Manual"
+msgstr ""
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[Introduction](index.html)"
+msgstr "[序説](index.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[Installation](Installation.html)"
+msgstr "[インストール](Installation.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[Configuration](Configuration.html)"
+msgstr "[セットアップ](Configuration.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[Upgrading](Upgrading.html)"
+msgstr "[アップグレード](Upgrading.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[License](License.html)"
+msgstr "[ライセンス](License.html)"

--- a/doc/po/_Navlinks_atalk.md.ja.po
+++ b/doc/po/_Navlinks_atalk.md.ja.po
@@ -1,0 +1,53 @@
+# Japanese translations for Netatalk documentation
+# Netatalk ドキュメントの日本語訳
+# Copyright (C) 2025 Daniel Markstedt <daniel@mindani.net>
+# This file is distributed under the same license as the Netatalk package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Netatalk 4.2.2dev\n"
+"POT-Creation-Date: 2025-04-22 22:06+0200\n"
+"PO-Revision-Date: 2025-04-22 22:06+0200\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title #
+#: manual/_Navlinks.md:1 manual/_Navlinks_atalk.md:1
+#, no-wrap
+msgid "Netatalk Manual"
+msgstr ""
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[Introduction](index.html)"
+msgstr "[序説](index.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[Installation](Installation.html)"
+msgstr "[インストール](Installation.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[Configuration](Configuration.html)"
+msgstr "[セットアップ](Configuration.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[Upgrading](Upgrading.html)"
+msgstr "[アップグレード](Upgrading.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[License](License.html)"
+msgstr "[ライセンス](License.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[AppleTalk](AppleTalk.html)"
+msgstr ""

--- a/doc/po/_Sidebar.md.ja.po
+++ b/doc/po/_Sidebar.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.1.2dev\n"
-"POT-Creation-Date: 2025-04-13 14:34+0200\n"
+"POT-Creation-Date: 2025-04-22 22:06+0200\n"
 "PO-Revision-Date: 2025-01-24 23:25+0100\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -15,6 +15,36 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[Introduction](index.html)"
+msgstr "[序説](index.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[Installation](Installation.html)"
+msgstr "[インストール](Installation.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[Configuration](Configuration.html)"
+msgstr "[セットアップ](Configuration.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[Upgrading](Upgrading.html)"
+msgstr "[アップグレード](Upgrading.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[License](License.html)"
+msgstr "[ライセンス](License.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+msgid "[AppleTalk](AppleTalk.html)"
+msgstr ""
 
 #. type: Plain text
 #: manual/_Sidebar.md:2
@@ -25,36 +55,6 @@ msgstr ""
 #: manual/_Sidebar.md:4
 msgid "Manual"
 msgstr "マニュアル"
-
-#. type: Bullet: '* '
-#: manual/_Sidebar.md:11
-msgid "[Introduction](index.html)"
-msgstr "[序説](index.html)"
-
-#. type: Bullet: '* '
-#: manual/_Sidebar.md:11
-msgid "[Installation](Installation.html)"
-msgstr "[インストール](Installation.html)"
-
-#. type: Bullet: '* '
-#: manual/_Sidebar.md:11
-msgid "[Configuration](Configuration.html)"
-msgstr "[セットアップ](Configuration.html)"
-
-#. type: Bullet: '* '
-#: manual/_Sidebar.md:11
-msgid "[AppleTalk](AppleTalk.html)"
-msgstr ""
-
-#. type: Bullet: '* '
-#: manual/_Sidebar.md:11
-msgid "[Upgrading](Upgrading.html)"
-msgstr "[アップグレード](Upgrading.html)"
-
-#. type: Bullet: '* '
-#: manual/_Sidebar.md:11
-msgid "[License](License.html)"
-msgstr "[ライセンス](License.html)"
 
 #. type: Plain text
 #: manual/_Sidebar.md:13

--- a/doc/po4a.cfg
+++ b/doc/po4a.cfg
@@ -36,6 +36,8 @@
 [type: text] manpages/man8/papstatus.8.md $lang:translated/$lang/papstatus.8.md
 [type: text] manpages/man8/timelord.8.md $lang:translated/$lang/timelord.8.md
 
+[type: text] manual/_Navlinks.md $lang:translated/$lang/_Navlinks.md
+[type: text] manual/_Navlinks_atalk.md $lang:translated/$lang/_Navlinks_atalk.md
 [type: text] manual/_Sidebar.md $lang:translated/$lang/_Sidebar.md
 [type: text] manual/AppleTalk.md $lang:translated/$lang/AppleTalk.md
 [type: text] manual/Configuration.md $lang:translated/$lang/Configuration.md

--- a/doc/translated/ja/meson.build
+++ b/doc/translated/ja/meson.build
@@ -1,6 +1,8 @@
 manual_pages = [
     'Configuration',
+    'index',
     'Installation',
+    'License',
     'Upgrading',
 ]
 
@@ -22,8 +24,6 @@ if get_option('with-website')
         'cnid_metad.8',
         'dbd.1',
         'extmap.conf.5',
-        'index',
-        'License',
         'macusers.1',
         'netatalk.8',
     ]
@@ -61,20 +61,51 @@ if get_option('with-website')
     endforeach
 else
     foreach page : manual_pages
-        custom_target(
-            'manual_' + page,
-            input: page + '.md',
-            output: page + '.html',
-            command: [
-                cmarkgfm,
-                '--smart',
-                '--extension', 'table',
-                '--to', 'html',
-                '@INPUT@',
-            ],
-            capture: true,
-            install: true,
-            install_dir: manual_install_path + '/ja',
-        )
+        if pandoc.found()
+            custom_target(
+                'manual_' + page,
+                input: [navlinks, page + '.md'],
+                output: page + '.html',
+                command: [
+                    pandoc,
+                    '--from', 'gfm',
+                    '--to', 'html',
+                    '@INPUT@',
+                ],
+                capture: true,
+                install: true,
+                install_dir: manual_install_path + '/ja',
+            )
+        elif cmarkgfm.found()
+            custom_target(
+                'manual_' + page,
+                input: [navlinks, page + '.md'],
+                output: page + '.html',
+                command: [
+                    cmarkgfm,
+                    '--smart',
+                    '--extension', 'table',
+                    '--to', 'html',
+                    '@INPUT@',
+                ],
+                capture: true,
+                install: true,
+                install_dir: manual_install_path + '/ja',
+            )
+        elif cmark.found()
+            custom_target(
+                'manual_' + page,
+                input: [navlinks, page + '.md'],
+                output: page + '.html',
+                command: [
+                    'sh', '-c',
+                    cmark.full_path() + ' --to html "$1" "$2" | sed -e "s#<p>|#<pre>|#g" -e "s#|</p>#|</pre>#g"',
+                    'sh', '@INPUT@'
+                ],
+                capture: true,
+                install: true,
+                install_dir: manual_install_path + '/ja',
+            )
+        endif
     endforeach
 endif


### PR DESCRIPTION
The localized html manual was missing the embedded navlinks, as well at the index and license pages

Additionally, port over the support for building html pages with pandoc and cmark

For good measure, allow for hiding the AppleTalk link in the navlinks when netatalk is built without AppleTalk support