### PR TITLE
netatalk: fix iconv dependency build issue

### DIFF
--- a/bin/misc/meson.build
+++ b/bin/misc/meson.build
@@ -1,10 +1,13 @@
+misc_deps = []
+
 if have_iconv
+    misc_deps += iconv
     executable(
         'netacnv',
         ['netacnv.c'],
         include_directories: root_includes,
         link_with: libatalk,
-        dependencies: [iconv],
+        dependencies: [misc_deps],
         install: false,
     )
 endif
@@ -14,6 +17,7 @@ executable(
     ['logger_test.c'],
     include_directories: root_includes,
     link_with: libatalk,
+    dependencies: [misc_deps],
     install: false,
 )
 
@@ -22,7 +26,7 @@ executable(
     ['fce.c'],
     include_directories: root_includes,
     link_with: libatalk,
-    dependencies: [iniparser],
+    dependencies: [iniparser, misc_deps],
     install: true,
 )
 
@@ -38,7 +42,7 @@ if have_ldap
         ['uuidtest.c'],
         include_directories: root_includes,
         link_with: libatalk,
-        dependencies: [afpldaptest_deps],
+        dependencies: [afpldaptest_deps, misc_deps],
         c_args: confdir,
         install: true,
         build_rpath: rpath_libdir,

--- a/meson.build
+++ b/meson.build
@@ -1417,7 +1417,7 @@ else
             cdata.set('ICONV_CONST', 'const')
         endif
 
-        if not meson.is_cross_build()
+        if meson.can_run_host_binaries()
                 if cc.run(
                     '''
                 #include <iconv.h>


### PR DESCRIPTION
OpenWrt build for 4.2.2 (and 4.2.1) fails if iconv is enabled as the dependency is not present for some of the bin/misc artefacts.

Also picked up change suggested here: https://github.com/Netatalk/netatalk/issues/1921