### PR TITLE
testsuite: Consistently use STATIC macro on test funcions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -564,18 +564,19 @@ jobs:
               cmark \
               db-4.6.21p7v0 \
               dbus \
-              gcc-11.2.0p14 \
+              gcc-11.2.0p15 \
               heimdal \
               iniparser \
               libevent \
               libgcrypt \
               libtalloc \
+              localsearch-3.8.2p0 \
               mariadb-client \
               meson \
-              openldap-client-2.6.8v0 \
+              openldap-client-2.6.9p0v0 \
               p5-Net-DBus \
               pkgconf \
-              tracker3
+              tinysparql-3.8.2
           run: |
             set -e
             meson setup build \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,23 +108,18 @@ jobs:
         run: |
           pacman -Sy --noconfirm \
             avahi \
-            bison \
             cmark-gfm \
             cracklib \
             cups \
             db \
-            flex \
             gcc \
             iniparser \
-            localsearch \
             mariadb-clients \
             meson \
             ninja \
             perl \
             pkgconfig \
-            rpcsvc-proto \
-            talloc \
-            tinysparql
+            rpcsvc-proto
       - name: Configure
         run: |
           meson setup build \

--- a/test/testsuite/FPGetForkParms.c
+++ b/test/testsuite/FPGetForkParms.c
@@ -19,7 +19,7 @@ uint32_t flen;
 }
 
 /* ------------- */
-static void test_21(uint16_t vol, char *name, int type)
+STATIC void test_21(uint16_t vol, char *name, int type)
 {
 
 int fork = 0;

--- a/test/testsuite/encoding_test.c
+++ b/test/testsuite/encoding_test.c
@@ -36,7 +36,7 @@ static char *extascii[24] = {
  * On today's systems this encoding doesn't exist in practice.
  * So, this test tests the equivalent Unicode character instead.
 */
-static void test_western()
+STATIC void test_western()
 {
 uint16_t vol = VolID;
 uint16_t f_bitmap;

--- a/test/testsuite/logintest.c
+++ b/test/testsuite/logintest.c
@@ -35,7 +35,7 @@ int     Mac = 0;
 char    *Test;
 static char  *vers = "AFP3.4";
 
-static void connect_server(CONN *conn)
+STATIC void connect_server(CONN *conn)
 {
 DSI *dsi;
 
@@ -53,7 +53,7 @@ DSI *dsi;
 }
 
 /* ------------------------- */
-static void test1(void)
+STATIC void test1(void)
 {
 	ENTER_TEST
 
@@ -72,7 +72,7 @@ static void test1(void)
 }
 
 /* ------------------------- */
-static void test2(void)
+STATIC void test2(void)
 {
 	ENTER_TEST
 
@@ -109,7 +109,7 @@ test_exit:
 }
 
 /* ------------------------- */
-static void test3(void)
+STATIC void test3(void)
 {
 static char *uam = "No User Authent";
 int ret;
@@ -149,7 +149,7 @@ test_exit:
 /* ------------------------- */
 // FIXME: when max connections is exceeded the server still returns
 // code DSIERR_OK and not DSIERR_TOOMANY (Netatalk 4.0.3, 3.1.12)
-static void test4(void)
+STATIC void test4(void)
 {
 CONN conn[50];
 int  i;
@@ -198,7 +198,7 @@ test_exit:
 }
 
 /* ------------------------- */
-static void test5(void)
+STATIC void test5(void)
 {
 static char *uam = "Cleartxt Passwrd";
 int ret;
@@ -229,7 +229,7 @@ test_exit:
 }
 
 /* ------------------------- */
-static void test6(void)
+STATIC void test6(void)
 {
 DSI *dsi;
 uint32_t i = 0;


### PR DESCRIPTION
The STATIC macro can be used as a global compile time flag to compile all test functions as static if needed; this is disabled by default, because dynamic functions allow us to cherry pick functions for execution

Also updates the GitHub build jobs to unblock the pipeline