### PR TITLE
initscripts: Improvements to the OpenRC netatalk init script

### DIFF
--- a/distrib/initscripts/openrc.netatalk.in
+++ b/distrib/initscripts/openrc.netatalk.in
@@ -3,6 +3,9 @@
 # Netatalk @netatalk_version@ init script.
 # AFP file server (netatalk)
 
+extra_started_commands="reload"
+description_reload="Reload configuration"
+
 name=$RC_SVCNAME
 command="@sbindir@/${RC_SVCNAME}"
 pidfile=@lockfile_path@
@@ -10,6 +13,13 @@ pidfile=@lockfile_path@
 depend() {
 		need net
 		use logger dns
-		use avahi-daemon
-		use atalkd
+		after atalkd
+		after avahi-daemon
+		after firewall
+}
+
+reload() {
+		ebegin "Reloading $name"
+		start-stop-daemon --signal SIGHUP --name $command
+		eend $?
 }


### PR DESCRIPTION
In addition to a netatalk reload command that sends a SIGHUP signal to netatalk, we now have a soft dependence on firewall

These improvements are borrowed from the Alpine Linux OpenRC script created by @jirutka

https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/netatalk/netatalk.initd

Additionally, we make atalkd and avahi-client soft dependencies to make it easier to run netatalk standalone when AppleTalk or Avahi are not required