### PR TITLE
Consistently return exit code 0 after showing version info

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,13 +87,18 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Run integration tests
-        run: cd build && meson test && cd ..
+        run: meson test -C build
       - name: Install
         run: meson install -C build
       - name: Check netatalk capabilities
         run: |
           netatalk -V
           afpd -V
+          atalkd -V
+          a2boot -V
+          macipgw -V
+          papd -V
+          timelord -V
       - name: Uninstall
         run: ninja -C build uninstall
 
@@ -134,13 +139,18 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Run integration tests
-        run: cd build && meson test && cd ..
+        run: meson test -C build
       - name: Install
         run: meson install -C build
       - name: Check netatalk capabilities
         run: |
           netatalk -V
           afpd -V
+          atalkd -V
+          a2boot -V
+          macipgw -V
+          papd -V
+          timelord -V
       - name: Uninstall
         run: ninja -C build uninstall
 
@@ -201,13 +211,18 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Run integration tests
-        run: cd build && meson test && cd ..
+        run: meson test -C build
       - name: Install
         run: meson install -C build
       - name: Check netatalk capabilities
         run: |
           netatalk -V
           afpd -V
+          atalkd -V
+          a2boot -V
+          macipgw -V
+          papd -V
+          timelord -V
       - name: Uninstall
         run: ninja -C build uninstall
 
@@ -262,13 +277,18 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Run integration tests
-        run: cd build && meson test && cd ..
+        run: meson test -C build
       - name: Install
         run: sudo meson install -C build
       - name: Check netatalk capabilities
         run: |
           netatalk -V
           afpd -V
+          atalkd -V
+          a2boot -V
+          macipgw -V
+          papd -V
+          timelord -V
       - name: Uninstall
         run: sudo ninja -C build uninstall
 
@@ -325,13 +345,18 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Run distribution tests
-        run: cd build && meson dist && cd ..
+        run: meson dist -C build
       - name: Install
         run: sudo meson install -C build
       - name: Check netatalk capabilities
         run: |
           netatalk -V
           afpd -V
+          atalkd -V
+          a2boot -V
+          macipgw -V
+          papd -V
+          timelord -V
       - name: Start netatalk
         run: |
           sudo systemctl start netatalk
@@ -370,7 +395,7 @@ jobs:
       - name: Build
         run: meson compile -C build
       - name: Run integration tests
-        run: cd build && meson test && cd ..
+        run: meson test -C build
       - name: Install
         run: sudo meson install -C build
       - name: Check netatalk capabilities
@@ -472,9 +497,7 @@ jobs:
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build
-            cd build
-            meson test
-            cd ..
+            meson test -C build
             meson install -C build
             netatalk -V
             afpd -V
@@ -528,12 +551,15 @@ jobs:
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build
-            cd build
-            meson test
-            cd ..
+            meson test -C build
             meson install -C build
             netatalk -V
             afpd -V
+            atalkd -V
+            a2boot -V
+            macipgw -V
+            papd -V
+            timelord -V
             service netatalk onestart
             sleep 1
             asip-status localhost
@@ -636,9 +662,7 @@ jobs:
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build
-            cd build
-            meson test
-            cd ..
+            meson test -C build
             meson install -C build
             netatalk -V
             afpd -V
@@ -706,9 +730,7 @@ jobs:
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build
-            cd build
-            meson test
-            cd ..
+            meson test -C build
             meson install -C build
             netatalk -V
             afpd -V

--- a/contrib/a2boot/a2boot.c
+++ b/contrib/a2boot/a2boot.c
@@ -131,7 +131,7 @@ int main( int ac, char **av )
                "Copyright (c) 1990,1992 Regents of The University of Michigan.\n"
                "\tAll Rights Reserved.\n"
                "Copyright (c) 1990, The University of Melbourne.\n", version );
-        exit ( 1 );
+        exit(0);
         break;
 	default :
 	    fprintf( stderr, "Unknown option -- '%c'\n", c );

--- a/contrib/macipgw/main.c
+++ b/contrib/macipgw/main.c
@@ -231,7 +231,7 @@ int main(int argc, char *argv[])
                "Copyright (c) 1990, 1996 Regents of The University of Michigan.\n"
                "\tAll Rights Reserved.\n"
                "See the file COPYRIGHT for further information.\n", version);
-            exit(1);
+            exit(0);
 			break;
 		case 'u':
 			pwd = get_user(optarg);

--- a/contrib/timelord/timelord.c
+++ b/contrib/timelord/timelord.c
@@ -129,7 +129,7 @@ int main( int ac, char **av )
                "Copyright (c) 1990,1992 Regents of The University of Michigan.\n"
                "\tAll Rights Reserved.\n"
                "Copyright (c) 1990, The University of Melbourne.\n", version );
-        exit ( 1 );
+        exit(0);
         break;
 	default :
 	    fprintf( stderr, "Unknown option -- '%c'\n", c );

--- a/etc/atalkd/main.c
+++ b/etc/atalkd/main.c
@@ -858,7 +858,7 @@ int main( int ac, char **av)
 	case 'V' :
 	case 'v' :	/* version */
 	    printf( "atalkd %s - AppleTalk Network Manager Daemon\n", version );
-	    exit ( 1 );
+	    exit(0);
 	    break;
 
 	default :

--- a/etc/cnid_dbd/cnid_metad.c
+++ b/etc/cnid_dbd/cnid_metad.c
@@ -482,7 +482,7 @@ int main(int argc, char *argv[])
             if (obj.cmdlineconfigfile != NULL) {
                 free((void *)obj.cmdlineconfigfile);
             }
-            return -1;
+            return 0;
         default:
             printf("cnid_metad [-dvV] [-F alternate configfile ]\n");
             if (obj.cmdlineconfigfile != NULL) {

--- a/etc/papd/main.c
+++ b/etc/papd/main.c
@@ -226,7 +226,7 @@ int main(int ac, char **av)
 	case 'V' :
 	case 'v' :		/* version */
 	    printf( "papd %s - Printer Access Protocol Daemon\n", version );
-	    exit ( 1 );
+	    exit(0);
 	    break;
 
 	default :


### PR DESCRIPTION
The various netatalk daemons inconsistently returned 0 (success) and non-0 exit codes; this standardizes on running the daemon with -V as a non-failure