### PR TITLE
Ensure that `optind` is reset on each call to afp_options_parse_cmdline()

### DIFF
--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -195,6 +195,7 @@ static void show_usage(void)
 void afp_options_parse_cmdline(AFPObj *obj, int ac, char **av)
 {
     int c, err = 0;
+    optind = 1;
 
     while (EOF != ( c = getopt( ac, av, "dF:vVh" )) ) {
         switch ( c ) {


### PR DESCRIPTION
The `optind` variable is global and needs to be reset to `1` with each call to `getopt()`. Fixes #2150.