### PR TITLE
Revert "GitHub CI: Temporarily build on Arch Linux without Spotlight"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,18 +114,23 @@ jobs:
         run: |
           pacman -Sy --noconfirm \
             avahi \
+            bison \
             cmark-gfm \
             cracklib \
             cups \
             db \
+            flex \
             gcc \
             iniparser \
+            localsearch \
             mariadb-clients \
             meson \
             ninja \
             perl \
             pkgconfig \
-            rpcsvc-proto
+            rpcsvc-proto \
+            talloc \
+            tinysparql
       - name: Configure
         run: |
           meson setup build \


### PR DESCRIPTION
This reverts commit a29fbb63d93d342a0d4014ec905bd359b99960a3.

We had this temporarily disabled because the official Arch container image had a broken dependency tree for a few weeks.