### PR TITLE
Use native doubly linked list when available

### DIFF
--- a/etc/afpd/spotlight.c
+++ b/etc/afpd/spotlight.c
@@ -35,7 +35,11 @@
 #include <atalk/compat.h>
 #include <atalk/dalloc.h>
 #include <atalk/errchk.h>
+#if HAVE_LIST_H
+#include <list.h>
+#else
 #include <atalk/list.h>
+#endif
 #include <atalk/logger.h>
 #include <atalk/netatalk_conf.h>
 #include <atalk/spotlight.h>

--- a/include/atalk/cnid.h
+++ b/include/atalk/cnid.h
@@ -27,7 +27,11 @@
 #define _ATALK_CNID__H 1
 
 #include <atalk/adouble.h>
+#if HAVE_LIST_H
+#include <list.h>
+#else
 #include <atalk/list.h>
+#endif
 #include <atalk/uuid.h>
 
 /* CNID object flags */

--- a/include/atalk/util.h
+++ b/include/atalk/util.h
@@ -138,6 +138,14 @@ extern void mod_close    (void *);
 #define strequal(a,b) (strcmp((a),(b)) == 0)
 #endif
 
+#ifndef ATALK_LIST_HEAD
+#define ATALK_LIST_HEAD LIST_HEAD
+#endif
+
+#ifndef ATALK_LIST_HEAD_INIT
+#define ATALK_LIST_HEAD_INIT LIST_HEAD_INIT
+#endif
+
 /******************************************************************
  * locking.c
  ******************************************************************/

--- a/libatalk/cnid/cnid.c
+++ b/libatalk/cnid/cnid.c
@@ -31,7 +31,11 @@
 
 #include <atalk/cnid.h>
 #include <atalk/compat.h>
+#if HAVE_LIST_H
+#include <list.h>
+#else
 #include <atalk/list.h>
+#endif
 #include <atalk/logger.h>
 #include <atalk/util.h>
 #include <atalk/volume.h>

--- a/libatalk/cnid/cnid_init.c
+++ b/libatalk/cnid/cnid_init.c
@@ -29,7 +29,6 @@
 #include <stdlib.h>
 
 #include <atalk/cnid.h>
-#include <atalk/list.h>
 #include <atalk/logger.h>
 
 #ifdef CNID_BACKEND_LAST

--- a/meson.build
+++ b/meson.build
@@ -240,6 +240,7 @@ check_headers = [
     'langinfo.h',
     'linux/dqblk/xfs.h',
     'linux/xqm.h',
+    'list.h',
     'locale.h',
     'mntent.h',
     'pam/pam_appl.h',

--- a/meson_config.h
+++ b/meson_config.h
@@ -199,6 +199,9 @@
 /* define if you have libquota */
 #mesondefine HAVE_LIBQUOTA
 
+/* Define to 1 if you have the <list.h> header file. */
+#mesondefine HAVE_LIST_H
+
 /* Define to 1 if you have the `listea' function. */
 #mesondefine HAVE_LISTEA
 


### PR DESCRIPTION
Netatalk's list.h is borrowed from the Linux kernel, so use the native header when available