### PR TITLE
nbplkup: provide for script-friendly output (and some code cleanup)

### DIFF
--- a/bin/nbp/nbplkup.c
+++ b/bin/nbp/nbplkup.c
@@ -45,9 +45,9 @@ static char *Zone = "*";
 
 static void Usage(char *av0)
 {
-    char *p;
+    char *p = strrchr(av0, '/');
 
-    if ((p = strrchr(av0, '/')) == NULL) {
+    if (p == NULL) {
         p = av0;
     } else {
         p++;
@@ -87,7 +87,8 @@ int main(int ac, char **av)
             nresp = atoi(optarg);
             break;
         case 'm':
-            if ((charset_t)-1 == (chMac = add_charset(optarg))) {
+            chMac = add_charset(optarg);
+            if ((charset_t)-1 == chMac) {
                 fprintf(stderr, "Invalid Mac charset.\n");
                 exit(1);
             }
@@ -99,7 +100,8 @@ int main(int ac, char **av)
         }
     }
 
-    if ((nn = (struct nbpnve *)malloc(nresp * sizeof(struct nbpnve))) == NULL) {
+    nn = (struct nbpnve *)malloc(nresp * sizeof(struct nbpnve));
+    if (nn == NULL) {
         perror("malloc");
         exit(1);
     }
@@ -123,21 +125,24 @@ int main(int ac, char **av)
             exit(1);
         }
 
-        if ((name = (char *)malloc(strlen(Obj) + 1)) == NULL) {
+        name = (char *)malloc(strlen(Obj) + 1);
+        if (name == NULL) {
             perror("malloc");
             exit(1);
         }
         strlcpy(name, Obj, sizeof(name));
         Obj = name;
 
-        if ((name = (char *)malloc(strlen(Type) + 1)) == NULL) {
+        name = (char *)malloc(strlen(Type) + 1);
+        if (name == NULL) {
             perror("malloc");
             exit(1);
         }
         strlcpy(name, Type, sizeof(name));
         Type = name;
 
-        if ((name = (char *)malloc(strlen(Zone) + 1)) == NULL) {
+        name = (char *)malloc(strlen(Zone) + 1);
+        if (name == NULL) {
             perror("malloc");
             exit(1);
         }
@@ -157,16 +162,20 @@ int main(int ac, char **av)
         }
     }
 
-    if ((c = nbp_lookup(Obj, Type, Zone, nn, nresp, &addr)) < 0) {
+    c = nbp_lookup(Obj, Type, Zone, nn, nresp, &addr);
+    if (c < 0) {
         perror("nbp_lookup");
         exit(-1);
     }
     
     for (i = 0; i < c; i++) {
-        if ((size_t)(-1) == (obj_len = convert_string_allocate(chMac,
-            CH_UNIX, nn[i].nn_obj, nn[i].nn_objlen, &obj))) {
+        obj_len = convert_string_allocate(chMac, CH_UNIX, nn[i].nn_obj, 
+            nn[i].nn_objlen, &obj);
+        
+        if ((size_t)(-1) == obj_len) {
             obj_len = nn[i].nn_objlen;
-            if ((obj = strdup(nn[i].nn_obj)) == NULL) {
+            obj = strdup(nn[i].nn_obj);
+            if (obj == NULL) {
                 perror("strdup");
                 exit(1);
             }

--- a/bin/nbp/nbplkup.c
+++ b/bin/nbp/nbplkup.c
@@ -31,6 +31,7 @@
 #include <atalk/nbp.h>
 #include <atalk/util.h>
 #include <string.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -53,7 +54,7 @@ static void Usage(char *av0)
         p++;
     }
 
-    printf("Usage:\t%s [-A address] [-r responses] [-m Mac charset] [obj:type@zone]\n", p);
+    printf("Usage:\t%s [-A address] [-r responses] [-m Mac charset] [-s] [obj:type@zone]\n", p);
     exit(1);
 }
 
@@ -69,6 +70,7 @@ int main(int ac, char **av)
     size_t type_len;
     charset_t chMac = CH_MAC;
     char * convname;
+    bool script_friendly_output = false;
 
     extern char *optarg;
     extern int optind;
@@ -77,7 +79,7 @@ int main(int ac, char **av)
     set_charset_name(CH_MAC, MACCHARSET);
 
     memset(&addr, 0, sizeof(addr));
-    while ((c = getopt(ac, av, "r:A:m:")) != EOF) {
+    while ((c = getopt(ac, av, "sA:m:r:")) != EOF) {
         switch (c) {
         case 'A':
             if (!atalk_aton(optarg, &addr)) {
@@ -94,6 +96,9 @@ int main(int ac, char **av)
                 fprintf(stderr, "Invalid Mac charset.\n");
                 exit(1);
             }
+            break;
+        case 's':
+            script_friendly_output = true;
             break;
 
         default:
@@ -185,12 +190,20 @@ int main(int ac, char **av)
             }
         }
 
-        printf("%31.*s:%-34.*s %u.%u:%u\n",
-            (int)obj_len, obj,
-            (int)type_len, type,
-            ntohs(nn[i].nn_sat.sat_addr.s_net),
-            nn[i].nn_sat.sat_addr.s_node,
-            nn[i].nn_sat.sat_port);
+        if (script_friendly_output) {
+            printf("%u.%u:%u %s:%s\n",
+                ntohs(nn[i].nn_sat.sat_addr.s_net),
+                nn[i].nn_sat.sat_addr.s_node,
+                nn[i].nn_sat.sat_port,
+                obj, type);
+        } else {
+            printf("%31.*s:%-34.*s %u.%u:%u\n",
+                (int)obj_len, obj,
+                (int)type_len, type,
+                ntohs(nn[i].nn_sat.sat_addr.s_net),
+                nn[i].nn_sat.sat_addr.s_node,
+                nn[i].nn_sat.sat_port);
+        }
 
         free(obj);
         free(type);

--- a/bin/nbp/nbplkup.c
+++ b/bin/nbp/nbplkup.c
@@ -64,7 +64,9 @@ int main(int ac, char **av)
     int i, c, nresp = 1000;
     struct at_addr addr;
     char *obj = NULL;
+    char *type = NULL;
     size_t obj_len;
+    size_t type_len;
     charset_t chMac = CH_MAC;
     char * convname;
 
@@ -169,8 +171,10 @@ int main(int ac, char **av)
     }
     
     for (i = 0; i < c; i++) {
-        obj_len = convert_string_allocate(chMac, CH_UNIX, nn[i].nn_obj, 
+        obj_len = convert_string_allocate(chMac, CH_UNIX, nn[i].nn_obj,
             nn[i].nn_objlen, &obj);
+        type_len = convert_string_allocate(chMac, CH_UNIX, nn[i].nn_type,
+            nn[i].nn_typelen, &type);
         
         if ((size_t)(-1) == obj_len) {
             obj_len = nn[i].nn_objlen;
@@ -183,12 +187,13 @@ int main(int ac, char **av)
 
         printf("%31.*s:%-34.*s %u.%u:%u\n",
             (int)obj_len, obj,
-            nn[i].nn_typelen, nn[i].nn_type,
+            (int)type_len, type,
             ntohs(nn[i].nn_sat.sat_addr.s_net),
             nn[i].nn_sat.sat_addr.s_node,
             nn[i].nn_sat.sat_port);
 
         free(obj);
+        free(type);
     }
 
     free(nn);

--- a/doc/manpages/man1/nbp.1.md
+++ b/doc/manpages/man1/nbp.1.md
@@ -8,7 +8,7 @@ nbplkup, nbprgstr, nbpunrgstr — tools for accessing the NBP database
 
 **nbprgstr** [-A *address*] [-m *Mac charset*] [-p *port*] *obj:type@zone*
 
-**nbpunrgstr** [-A *address*] [-m *Mac charset*] *obj:type@zone*
+**nbpunrgstr** [-A *address*] [-m *Mac charset*] [-s] *obj:type@zone*
 
 # Description
 
@@ -21,6 +21,10 @@ registered on the AppleTalk internet. *nbpname* is parsed by
 **nbp_name**(3). An \`*=*' for the *object* or *type* matches anything,
 and an \`*\**' for *zone* means the local zone. The default values are
 taken from the NBPLKUP environment variable, parsed as an *nbpname*.
+
+If -s is specified, output is printed in a script-friendly format: for each
+response, first the address is printed, followed by a single space, followed 
+by the name and type, followed by a linefeed.
 
 # Environment Variables
 
@@ -49,6 +53,15 @@ Find all devices of type *LaserWriter* in the local zone.
          Evil DEC from Hell:LaserWriter        7942.2:130
                   Hamtramck:LaserWriter        7942.2:134
              Iron Mountain :LaserWriter        7942.128:250
+    example%
+    
+Find all devices of type *netatalk* in the local zone, providing script-friendly
+output.
+
+    example% nbplkup -s :netatalk
+    5.42:4 netatalk-build:netatalk
+    4.162:4 prometheus:netatalk
+    8.31:4 Tiryns:netatalk
     example%
 
 # See also


### PR DESCRIPTION
This PR modifies nbplkup to provide output in a format that's fixed enough for a script to easily parse.  On its way to doing this, it normalises whitespace and factors out some of the side-effect-y if() conditions - the latter of which is admittedly a purely personal preference.

Tested locally but only on NetBSD; not that anything in here should be OS-specific.

Side note: does netatalk target any specific revision of the C standard?  I've introduced a reference to stdbool.h here, in the interests of striking out for sanity.