### PR TITLE
nbplkup: allow specification of NBP operation and of destination address

### DIFF
--- a/bin/nbp/nbplkup.c
+++ b/bin/nbp/nbplkup.c
@@ -100,6 +100,9 @@ int main(int ac, char **av)
                 exit(1);
             }
             break;
+        case 's':
+            script_friendly_output = true;
+            break;
         case 'A':
             if (!atalk_aton(optarg, &addr)) {
                 fprintf(stderr, "Bad address.\n");
@@ -113,9 +116,6 @@ int main(int ac, char **av)
                 exit(1);
             }
             break;
-        case 'r' :
-            nresp = atoi(optarg);
-            break;
         case 'm':
             chMac = add_charset(optarg);
             if ((charset_t)-1 == chMac) {
@@ -123,8 +123,8 @@ int main(int ac, char **av)
                 exit(1);
             }
             break;
-        case 's':
-            script_friendly_output = true;
+        case 'r' :
+            nresp = atoi(optarg);
             break;
 
         default:

--- a/bin/nbp/nbplkup.c
+++ b/bin/nbp/nbplkup.c
@@ -32,6 +32,7 @@
 #include <atalk/util.h>
 #include <string.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -54,16 +55,18 @@ static void Usage(char *av0)
         p++;
     }
 
-    printf("Usage:\t%s [-A address] [-r responses] [-m Mac charset] [-s] [obj:type@zone]\n", p);
+    printf("Usage:\t%s [-A address] [-D address] [-r responses] [-m Mac charset] [-f | -l] [-s] [obj:type@zone]\n", p);
     exit(1);
 }
 
 int main(int ac, char **av)
 {
+    uint8_t nbp_op = NBPOP_BRRQ;
     struct nbpnve *nn;
     char *name;
     int i, c, nresp = 1000;
     struct at_addr addr;
+    struct at_addr *dst_addr = NULL;
     char *obj = NULL;
     char *type = NULL;
     size_t obj_len;
@@ -79,10 +82,33 @@ int main(int ac, char **av)
     set_charset_name(CH_MAC, MACCHARSET);
 
     memset(&addr, 0, sizeof(addr));
-    while ((c = getopt(ac, av, "sA:m:r:")) != EOF) {
+    while ((c = getopt(ac, av, "flsA:D:m:r:")) != EOF) {
         switch (c) {
+        case 'f':
+            if (nbp_op == NBPOP_BRRQ) {
+                nbp_op = NBPOP_FWD;
+            } else {
+                fprintf(stderr, "Cannot use both -f and -l in the same command.\n");
+                exit(1);
+            }
+            break;
+        case 'l':
+            if (nbp_op == NBPOP_BRRQ) {
+                nbp_op = NBPOP_LKUP;
+            } else {
+                fprintf(stderr, "Cannot use both -f and -l in the same command.\n");
+                exit(1);
+            }
+            break;
         case 'A':
             if (!atalk_aton(optarg, &addr)) {
+                fprintf(stderr, "Bad address.\n");
+                exit(1);
+            }
+            break;
+        case 'D':
+            dst_addr = malloc(sizeof(struct at_addr));
+            if (!atalk_aton(optarg, dst_addr)) {
                 fprintf(stderr, "Bad address.\n");
                 exit(1);
             }
@@ -163,7 +189,7 @@ int main(int ac, char **av)
         }
     }
 
-    c = nbp_lookup(Obj, Type, Zone, nn, nresp, &addr);
+    c = nbp_do_lookup_op(Obj, Type, Zone, nn, nresp, &addr, dst_addr, nbp_op);
     if (c < 0) {
         perror("nbp_lookup");
         exit(-1);

--- a/doc/manpages/man1/nbp.1.md
+++ b/doc/manpages/man1/nbp.1.md
@@ -8,7 +8,7 @@ nbplkup, nbprgstr, nbpunrgstr — tools for accessing the NBP database
 
 **nbprgstr** [-A *address*] [-m *Mac charset*] [-p *port*] *obj:type@zone*
 
-**nbpunrgstr** [-A *address*] [-m *Mac charset*] [-s] *obj:type@zone*
+**nbpunrgstr** [-A *address*] [-D *address*] [-m *Mac charset*] [-s] [-f | -l] *obj:type@zone*
 
 # Description
 
@@ -21,6 +21,22 @@ registered on the AppleTalk internet. *nbpname* is parsed by
 **nbp_name**(3). An \`*=*' for the *object* or *type* matches anything,
 and an \`*\**' for *zone* means the local zone. The default values are
 taken from the NBPLKUP environment variable, parsed as an *nbpname*.
+
+If -A is specified, this address is used as the local address to be used for the lookup.
+If -D is specified, this address is used as the destination address to send the lookup to.
+The -f and -l options allow FwdReq and LkUp operations to be used instead of the
+default BrRq.
+
+A BrRq asks a router (by default the local atalkd instance) to propagate a lookup request
+across the entire AppleTalk internetwork, and is the default option because it is 
+generally the most useful.  If in doubt, use a BrRq.
+
+A LkUp asks a node just about itself; it can be used either to query what names are bound 
+on a specific node, or by specifying a broadcast destination, simulate the kind of lookup 
+that is done on a routerless network.  A FwdReq asks a router to propagate the lookup to 
+its directly connected networks that are members of the zone specified, but not to 
+propagate it any further across the internetwork; this can be useful on large 
+internetworks, or to troubleshoot caches on refractory nodes.
 
 If -s is specified, output is printed in a script-friendly format: for each
 response, first the address is printed, followed by a single space, followed 

--- a/include/atalk/nbp.h
+++ b/include/atalk/nbp.h
@@ -94,6 +94,9 @@ struct nbpnve {
 #define NBPMATCH_NOZONE	(1<<2)
 
 extern int nbp_name (const char *, char **, char **, char **);
+extern int nbp_do_lookup_op(const char *, const char *, const char *,
+			   struct nbpnve *, const int,
+			   const struct at_addr *, uint8_t);
 extern int nbp_lookup (const char *, const char *, const char *,
 			   struct nbpnve *, const int,
 			   const struct at_addr *);

--- a/include/atalk/nbp.h
+++ b/include/atalk/nbp.h
@@ -96,7 +96,7 @@ struct nbpnve {
 extern int nbp_name (const char *, char **, char **, char **);
 extern int nbp_do_lookup_op(const char *, const char *, const char *,
 			   struct nbpnve *, const int,
-			   const struct at_addr *, uint8_t);
+			   const struct at_addr *, const struct at_addr *, uint8_t);
 extern int nbp_lookup (const char *, const char *, const char *,
 			   struct nbpnve *, const int,
 			   const struct at_addr *);

--- a/libatalk/nbp/nbp_lkup.c
+++ b/libatalk/nbp/nbp_lkup.c
@@ -33,7 +33,13 @@
 #endif /* ! SOCKLEN_T */
 
 int nbp_lookup(const char *obj, const char *type, const char *zone, struct nbpnve *nn,
-                int nncnt, const struct at_addr *ataddr) {
+               int nncnt, const struct at_addr *ataddr) {
+
+    return nbp_do_lookup_op(obj, type, zone, nn, nncnt, ataddr, NBPOP_BRRQ);
+}
+
+int nbp_do_lookup_op(const char *obj, const char *type, const char *zone, struct nbpnve *nn,
+                     int nncnt, const struct at_addr *ataddr, uint8_t op) {
     struct sockaddr_at addr, from;
     struct timeval tv, tv_begin, tv_end;
     fd_set fds;
@@ -55,7 +61,7 @@ int nbp_lookup(const char *obj, const char *type, const char *zone, struct nbpnv
     }
 
     *data++ = DDPTYPE_NBP;
-    nh.nh_op = NBPOP_BRRQ;
+    nh.nh_op = op;
 
     nh.nh_cnt = 1;
     nh.nh_id = ++nbp_id;

--- a/libatalk/nbp/nbp_lkup.c
+++ b/libatalk/nbp/nbp_lkup.c
@@ -32,27 +32,27 @@
 #define SOCKLEN_T unsigned int
 #endif /* ! SOCKLEN_T */
 
-int nbp_lookup( const char *obj, const char *type, const char *zone, struct nbpnve *nn,
-    int			nncnt,
-    const struct at_addr *ataddr)
-{
-    struct sockaddr_at	addr, from;
-    struct timeval	tv, tv_begin, tv_end;
-    fd_set		fds;
-    struct nbpnve	nve;
-    struct nbphdr	nh;
-    struct nbptuple	nt;
-    struct servent	*se;
-    char		*data = nbp_send;
-    SOCKLEN_T   	namelen;
-    int			s, cnt, tries, sc, cc, i, c;
+int nbp_lookup(const char *obj, const char *type, const char *zone, struct nbpnve *nn,
+                int nncnt, const struct at_addr *ataddr) {
+    struct sockaddr_at addr, from;
+    struct timeval tv, tv_begin, tv_end;
+    fd_set fds;
+    struct nbpnve nve;
+    struct nbphdr nh;
+    struct nbptuple nt;
+    struct servent *se;
+    char *data = nbp_send;
+    SOCKLEN_T namelen;
+    int s, cnt, tries, sc, cc, i, c;
 
     memset(&addr, 0, sizeof(addr));
     memset(&from, 0, sizeof(from));
-    if (ataddr)
-      memcpy(&addr.sat_addr, ataddr, sizeof(struct at_addr));
-    if ((s = netddp_open(&addr, &from)) < 0)
-      return -1;
+    if (ataddr) {
+        memcpy(&addr.sat_addr, ataddr, sizeof(struct at_addr));
+    }
+    if ((s = netddp_open(&addr, &from)) < 0) {
+        return -1;
+    }
 
     *data++ = DDPTYPE_NBP;
     nh.nh_op = NBPOP_BRRQ;
@@ -71,41 +71,47 @@ int nbp_lookup( const char *obj, const char *type, const char *zone, struct nbpn
     data += SZ_NBPTUPLE;
 
     if ( obj ) {
-	if (( cc = strlen( obj )) > NBPSTRLEN ) goto lookup_err;
-	*data++ = cc;
-	memcpy( data, obj, cc );
-	data += cc;
+        if (( cc = strlen( obj )) > NBPSTRLEN ) {
+            goto lookup_err;
+        }
+        *data++ = cc;
+        memcpy( data, obj, cc );
+        data += cc;
     } else {
-	*data++ = 1;
-	*data++ = '='; /* match anything */
+        *data++ = 1;
+        *data++ = '='; /* match anything */
     }
 
     if ( type ) {
-	if (( cc = strlen( type )) > NBPSTRLEN ) goto lookup_err;
-	*data++ = cc;
-	memcpy( data, type, cc );
-	data += cc;
+        if (( cc = strlen( type )) > NBPSTRLEN ) {
+            goto lookup_err;
+        }
+        *data++ = cc;
+        memcpy( data, type, cc );
+        data += cc;
     } else {
-	*data++ = 1;
-	*data++ = '='; /* match anything */
+        *data++ = 1;
+        *data++ = '='; /* match anything */
     }
 
     if ( zone ) {
-	if (( cc = strlen( zone )) > NBPSTRLEN ) goto lookup_err;
-	*data++ = cc;
-	memcpy( data, zone, cc );
-	data += cc;
+        if (( cc = strlen( zone )) > NBPSTRLEN ) {
+            goto lookup_err;
+        }
+        *data++ = cc;
+        memcpy( data, zone, cc );
+        data += cc;
     } else {
-	*data++ = 1;
-	*data++ = '*'; /* default zone */
+        *data++ = 1;
+        *data++ = '*'; /* default zone */
     }
 
     if ( nbp_port == 0 ) {
-      if (( se = getservbyname( "nbp", "ddp" )) == NULL ) {
-	            nbp_port = 2;
-      } else {
-	            nbp_port = ntohs( se->s_port );
-      }
+        if (( se = getservbyname( "nbp", "ddp" )) == NULL ) {
+            nbp_port = 2;
+        } else {
+            nbp_port = ntohs( se->s_port );
+        }
     }
 
     addr.sat_port = nbp_port;
@@ -114,87 +120,87 @@ int nbp_lookup( const char *obj, const char *type, const char *zone, struct nbpn
     tries = 3;
     sc = data - nbp_send;
     while ( tries > 0 ) {
-	if ( netddp_sendto( s, nbp_send, sc, 0, (struct sockaddr *)&addr,
-		sizeof( struct sockaddr_at )) < 0 ) {
-	    goto lookup_err;
-	}
+        if ( netddp_sendto( s, nbp_send, sc, 0, (struct sockaddr *)&addr,
+                            sizeof( struct sockaddr_at )) < 0 ) {
+            goto lookup_err;
+        }
 
-	tv.tv_sec = 2L;
-	tv.tv_usec = 0;
+        tv.tv_sec = 2L;
+        tv.tv_usec = 0;
 
-	for (;;) {
-	    FD_ZERO( &fds );
-	    FD_SET( s, &fds );
-	    if ( gettimeofday( &tv_begin, NULL ) < 0 ) {
-		goto lookup_err;
-	    }
-	    if (( c = select( s + 1, &fds, NULL, NULL, &tv )) < 0 ) {
-		goto lookup_err;
-	    }
-	    if ( c == 0 || FD_ISSET( s, &fds ) == 0 ) {
-		break;
-	    }
-	    if ( gettimeofday( &tv_end, NULL ) < 0 ) {
-		goto lookup_err;
-	    }
-	    if ( tv_begin.tv_usec > tv_end.tv_sec ) {
-		tv_end.tv_usec += 1000000;
-		tv_end.tv_sec -= 1;
-	    }
-	    if (( tv.tv_usec -= ( tv_end.tv_usec - tv_begin.tv_usec )) < 0 ) {
-		tv.tv_usec += 1000000;
-		tv.tv_sec -= 1;
-	    }
-	    if (( tv.tv_sec -= ( tv_end.tv_sec - tv_begin.tv_sec )) < 0 ) {
-		break;
-	    }
+        for (;;) {
+            FD_ZERO( &fds );
+            FD_SET( s, &fds );
+            if ( gettimeofday( &tv_begin, NULL ) < 0 ) {
+                goto lookup_err;
+            }
+            if (( c = select( s + 1, &fds, NULL, NULL, &tv )) < 0 ) {
+                goto lookup_err;
+            }
+            if ( c == 0 || FD_ISSET( s, &fds ) == 0 ) {
+                break;
+            }
+            if ( gettimeofday( &tv_end, NULL ) < 0 ) {
+                goto lookup_err;
+            }
+            if ( tv_begin.tv_usec > tv_end.tv_sec ) {
+                tv_end.tv_usec += 1000000;
+                tv_end.tv_sec -= 1;
+            }
+            if (( tv.tv_usec -= ( tv_end.tv_usec - tv_begin.tv_usec )) < 0 ) {
+                tv.tv_usec += 1000000;
+                tv.tv_sec -= 1;
+            }
+            if (( tv.tv_sec -= ( tv_end.tv_sec - tv_begin.tv_sec )) < 0 ) {
+                break;
+            }
 
-	    namelen = sizeof( struct sockaddr_at );
-	    if (( cc = netddp_recvfrom( s, nbp_recv, sizeof( nbp_recv ), 0,
-		    (struct sockaddr *)&from, &namelen )) < 0 ) {
-		goto lookup_err;
-	    }
+            namelen = sizeof( struct sockaddr_at );
+            if (( cc = netddp_recvfrom( s, nbp_recv, sizeof( nbp_recv ), 0,
+                                        (struct sockaddr *)&from, &namelen )) < 0 ) {
+                goto lookup_err;
+            }
 
-	    data = nbp_recv;
-	    if ( *data++ != DDPTYPE_NBP ) {
-		continue;
-	    }
-	    cc--;
+            data = nbp_recv;
+            if ( *data++ != DDPTYPE_NBP ) {
+                continue;
+            }
+            cc--;
 
-	    memcpy( &nh, data, SZ_NBPHDR );
-	    data += SZ_NBPHDR;
-	    if ( nh.nh_op != NBPOP_LKUPREPLY ) {
-		continue;
-	    }
-	    cc -= SZ_NBPHDR;
+            memcpy( &nh, data, SZ_NBPHDR );
+            data += SZ_NBPHDR;
+            if ( nh.nh_op != NBPOP_LKUPREPLY ) {
+                continue;
+            }
+            cc -= SZ_NBPHDR;
 
-	    while (( i = nbp_parse( data, &nve, cc )) >= 0 ) {
-		data += cc - i;
-		cc = i;
-		/*
-		 * Check to see if nve is already in nn. If not,
-		 * put it in, and increment cnt.
-		 */
-		for ( i = 0; i < cnt; i++ ) {
-		    if ( nbp_match( &nve, &nn[ i ],
-			    NBPMATCH_NOZONE|NBPMATCH_NOGLOB )) {
-			break;
-		    }
-		}
-		if ( i == cnt ) {
-		    nn[ cnt++ ] = nve;
-		}
-		if ( cnt == nncnt ) {
-		    tries = 0;
-		    break;
-		}
-	    }
-	    if ( cnt == nncnt ) {
-		tries = 0;
-		break;
-	    }
-	}
-	tries--;
+            while (( i = nbp_parse( data, &nve, cc )) >= 0 ) {
+                data += cc - i;
+                cc = i;
+                /*
+                 * Check to see if nve is already in nn. If not,
+                 * put it in, and increment cnt.
+                 */
+                for ( i = 0; i < cnt; i++ ) {
+                    if ( nbp_match( &nve, &nn[ i ],
+                                    NBPMATCH_NOZONE|NBPMATCH_NOGLOB )) {
+                        break;
+                    }
+                }
+                if ( i == cnt ) {
+                    nn[ cnt++ ] = nve;
+                }
+                if ( cnt == nncnt ) {
+                    tries = 0;
+                    break;
+                }
+            }
+            if ( cnt == nncnt ) {
+                tries = 0;
+                break;
+            }
+        }
+        tries--;
     }
 
     netddp_close(s);


### PR DESCRIPTION
The intent of this PR is to allow nbplkup to probe NBP speakers that are not the local host.

To do this, it adds two features:

- A -D option, which specifies the address of the remote NBP speaker to direct queries to
- -f and -l options, which override the default BrRq request type and enable either LkUp or FwdReqs to be generated.

While I was passing I also ran astyle on libatalk/nbp/nbp_lkup.c - hope this doesn't interfere with your coding style work.

Tested only on NetBSD, but again, I can't see any reason this wouldn't be portable.

