### PR TITLE
Small code quality fixups

### DIFF
--- a/bin/getzones/getzones.c
+++ b/bin/getzones/getzones.c
@@ -31,15 +31,15 @@ static void usage(char *s)
 
 int main(int argc, char *argv[])
 {
-    struct atp_handle	*ah;
-    struct atp_block	atpb;
-    struct sockaddr_at	saddr;
-    struct servent	*se;
-    char		reqdata[4], buf[ATP_MAXDATA];
-    struct iovec	iov;
-    short		temp, index = 0;
-    int			c, myzoneflg = 0, localzonesflg = 0, errflg = 0;
-    extern int		optind;
+    struct atp_handle *ah;
+    struct atp_block atpb;
+    struct sockaddr_at saddr;
+    struct servent *se;
+    char reqdata[4], buf[ATP_MAXDATA];
+    struct iovec iov;
+    short temp, index = 0;
+    int c, myzoneflg = 0, localzonesflg = 0, errflg = 0;
+    extern int optind;
     reqdata[0] = ZIPOP_GETZONELIST;
 
     while ((c = getopt(argc, argv, "ml")) != EOF) {

--- a/bin/nbp/nbplkup.c
+++ b/bin/nbp/nbplkup.c
@@ -29,14 +29,12 @@
 #include <netatalk/endian.h>
 #include <netatalk/at.h>
 #include <atalk/nbp.h>
+#include <atalk/unicode.h>
 #include <atalk/util.h>
 #include <string.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-
-
-#include <atalk/unicode.h>
 
 #define MACCHARSET "MAC_ROMAN"
 

--- a/bin/pap/pap.c
+++ b/bin/pap/pap.c
@@ -23,8 +23,6 @@
 #include <string.h>
 #include <stdlib.h>
 
-#define FUCKED
-
 #define _PATH_PAPRC	".paprc"
 
 #define IMAGEWRITER "ImageWriter"
@@ -172,8 +170,6 @@ int main(int ac, char	**av)
 
     while ((c = getopt(ac, av, "dWwcep:s:EA:")) != EOF) {
         switch (c) {
-#ifdef FUCKED
-
         case 'w' :
             waitforprinter = 1;
             break;
@@ -181,7 +177,6 @@ int main(int ac, char	**av)
         case 'W' :
             waitforidle = 1;
             break;
-#endif /* FUCKED */
 
         /* enable debugging */
         case 'd' :
@@ -932,8 +927,6 @@ static int send_file(int fd, ATP atp, int lastfile, int is_imagewriter)
                 printf("< STATUS\n"), fflush(stdout);
             }
 
-#ifdef FUCKED
-
             if (waitforprinter) {
                 char	st_buf[1024];	/* XXX too big */
                 memcpy(st_buf, (char *) rniov[0].iov_base + 9,
@@ -945,7 +938,6 @@ static int send_file(int fd, ATP atp, int lastfile, int is_imagewriter)
                 }
             }
 
-#endif /* FUCKED */
             updatestatus((char *) rniov[0].iov_base + 9,
                          ((char *)rniov[0].iov_base)[8]);
         }


### PR DESCRIPTION
Just a couple of small fixups not really connected to anything else but which were trivial to fix while I was passing

1. A slight tidying of includes and formatting.
2. While `#define FUCKED` gave me a real surge of empathy for whoever wrote that code, it is in fact redundant, since it looks like it's been permanently defined for the last 25 years; I think we can get rid of the ifdefs now.