### PR TITLE
Revive commented out code, or put them in #if 0 blocks

### DIFF
--- a/contrib/a2boot/a2boot.c
+++ b/contrib/a2boot/a2boot.c
@@ -79,8 +79,7 @@ void usage(char *p)
 /*
  * Unregister ourself on signal.
  */
-void
-goaway(int signal)
+void goaway(int signal _U_)
 {
     int regerr;
     regerr = nbp_unrgstr(server, "Apple //gs", "*", NULL);
@@ -292,8 +291,7 @@ int main(int ac, char **av)
 
 
 /* below MJ 2002 (initially borrowed from aep_packet */
-long a2bootreq(fname)
-char	*fname;
+long a2bootreq(char *fname)
 {
     int f;
     int32_t readlen;
@@ -327,4 +325,3 @@ char	*fname;
     close(f);
     return  TL_OK;
 }
-

--- a/contrib/a2boot/a2boot.c
+++ b/contrib/a2boot/a2boot.c
@@ -234,22 +234,21 @@ int main(int ac, char **av)
         req = ntohl(req);
         p += sizeof(int32_t);
 #ifdef EBUG
-        LOG(log_info, logtype_default, "req = %08lx",(long)req );
+        LOG(log_info, logtype_default, "req = %08lx", (long)req);
 #endif
         /* Byte-swap and multiply by 0x200. Converts block number to
            file offset. */
         fileoff = ((req & 0x00ff0000) >> 7) | ((req & 0x0000ff00) << 9);
         req &= 0xff000000;
-
 #ifdef EBUG
-        LOG(log_info, logtype_default, "       req now = %08lx",(long)req );
+        LOG(log_info, logtype_default, "       req now = %08lx", (long)req);
 #endif
 
         switch (req) {
         /* Apple IIgs both ROM 1 and ROM 3 */
         case 0x01000000 :
 #ifdef EBUG
-            LOG(log_info, logtype_default, "          Req ProDOS16 Boot Blocks" );
+            LOG(log_info, logtype_default, "          Req ProDOS16 Boot Blocks");
 #endif
             resp = a2bootreq(_PATH_A_GS_BLOCKS);
             break;
@@ -257,7 +256,7 @@ int main(int ac, char **av)
         /* Apple 2 Workstation card  */
         case 0x02000000 :
 #ifdef EBUG
-            LOG(log_info, logtype_default, "          Req Apple //e Boot" );
+            LOG(log_info, logtype_default, "          Req Apple //e Boot");
 #endif
             resp = a2bootreq(_PATH_A_2E_BLOCKS);
             break;
@@ -265,7 +264,7 @@ int main(int ac, char **av)
         /* Apple IIgs both ROM 1 and ROM 3 */
         case 0x03000000 :
 #ifdef EBUG
-            LOG(log_info, logtype_default, "          Req ProDOS16 Image" );
+            LOG(log_info, logtype_default, "          Req ProDOS16 Image");
 #endif
             resp = a2bootreq(_PATH_P16_IMAGE);
             break;
@@ -299,7 +298,7 @@ char	*fname;
     int f;
     int32_t readlen;
 #if EBUG
-    LOG(log_info, logtype_default, "          a2bootreq( %s )",fname );
+    LOG(log_info, logtype_default, "          a2bootreq( %s )", fname);
 #endif
     f = open(fname, O_RDONLY);
 
@@ -309,18 +308,17 @@ char	*fname;
     }
 
 #if EBUG
-    LOG(log_info, logtype_default, "would lseek to %08lx",fileoff);
+    LOG(log_info, logtype_default, "would lseek to %08lx", fileoff);
 #endif
     lseek(f, fileoff, 0);
     readlen = read(f, buf + sizeof(int32_t), 512);
-
 #if EBUG
     LOG(log_info, logtype_default, "length is %08lx", readlen);
 #endif
 
     if (readlen < 0x200) {
 #if EBUG
-    LOG(log_info, logtype_default, "Read to EOF");
+        LOG(log_info, logtype_default, "Read to EOF");
 #endif
         close(f);
         return TL_EOF;

--- a/contrib/a2boot/a2boot.c
+++ b/contrib/a2boot/a2boot.c
@@ -233,36 +233,40 @@ int main(int ac, char **av)
         bcopy(p, &req, sizeof(int32_t));
         req = ntohl(req);
         p += sizeof(int32_t);
-        /*
-            LOG(log_info, logtype_default, "req = %08lx",(long)req );
-        */
+#ifdef EBUG
+        LOG(log_info, logtype_default, "req = %08lx",(long)req );
+#endif
         /* Byte-swap and multiply by 0x200. Converts block number to
            file offset. */
         fileoff = ((req & 0x00ff0000) >> 7) | ((req & 0x0000ff00) << 9);
         req &= 0xff000000;
 
-        /*
-            LOG(log_info, logtype_default, "       reqblklo = %02x",(int)reqblklo );
-            LOG(log_info, logtype_default, "       reqblkhi = %02x",(int)reqblkhi );
-            LOG(log_info, logtype_default, "       req now = %08lx",(long)req );
-        */
+#ifdef EBUG
+        LOG(log_info, logtype_default, "       req now = %08lx",(long)req );
+#endif
 
         switch (req) {
         /* Apple IIgs both ROM 1 and ROM 3 */
         case 0x01000000 :
-            /*    LOG(log_info, logtype_default, "          Req ProDOS16 Boot Blocks" ); */
+#ifdef EBUG
+            LOG(log_info, logtype_default, "          Req ProDOS16 Boot Blocks" );
+#endif
             resp = a2bootreq(_PATH_A_GS_BLOCKS);
             break;
 
         /* Apple 2 Workstation card  */
         case 0x02000000 :
-            /*    LOG(log_info, logtype_default, "          Req Apple //e Boot" );  */
+#ifdef EBUG
+            LOG(log_info, logtype_default, "          Req Apple //e Boot" );
+#endif
             resp = a2bootreq(_PATH_A_2E_BLOCKS);
             break;
 
         /* Apple IIgs both ROM 1 and ROM 3 */
         case 0x03000000 :
-            /*    LOG(log_info, logtype_default, "          Req ProDOS16 Image" );    */
+#ifdef EBUG
+            LOG(log_info, logtype_default, "          Req ProDOS16 Image" );
+#endif
             resp = a2bootreq(_PATH_P16_IMAGE);
             break;
 
@@ -294,9 +298,9 @@ char	*fname;
 {
     int f;
     int32_t readlen;
-    /*
-        LOG(log_info, logtype_default, "          a2bootreq( %s )",fname );
-    */
+#if EBUG
+    LOG(log_info, logtype_default, "          a2bootreq( %s )",fname );
+#endif
     f = open(fname, O_RDONLY);
 
     if (f == EOF) {
@@ -304,18 +308,20 @@ char	*fname;
         return close(f);
     }
 
-    /*
-        LOG(log_info, logtype_default, "would lseek to %08lx",fileoff);
-    */
+#if EBUG
+    LOG(log_info, logtype_default, "would lseek to %08lx",fileoff);
+#endif
     lseek(f, fileoff, 0);
     readlen = read(f, buf + sizeof(int32_t), 512);
 
-    /*
-        LOG(log_info, logtype_default, "length is %08lx", readlen);
-    */
+#if EBUG
+    LOG(log_info, logtype_default, "length is %08lx", readlen);
+#endif
 
     if (readlen < 0x200) {
-        /*    LOG(log_info, logtype_default, "Read to EOF");  */
+#if EBUG
+    LOG(log_info, logtype_default, "Read to EOF");
+#endif
         close(f);
         return TL_EOF;
     }

--- a/contrib/timelord/timelord.c
+++ b/contrib/timelord/timelord.c
@@ -77,8 +77,7 @@ void usage(char *p)
 /*
  * Unregister ourself on signal.
  */
-void
-goaway(int signal)
+void goaway(int signal _U_)
 {
     if (nbp_unrgstr(server, "TimeLord", "*", NULL) < 0) {
         LOG(log_error, logtype_default, "Can't unregister %s", server);

--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -504,7 +504,9 @@ int afp_getsession(
                 return AFPERR_PARAM;
             }
 
-            /* memcpy (id, ibuf, idlen) */
+#if 0
+            memcpy (id, ibuf, idlen)
+#endif
             tklen = obj->sinfo.sessiontoken_len;
             token = obj->sinfo.sessiontoken;
         }
@@ -1197,9 +1199,6 @@ int auth_load(AFPObj *obj, const char *path, const char *list)
         strlcpy(name + len, p, sizeof(name) - len);
         LOG(log_debug, logtype_afpd, "uam: loading (%s)", name);
 
-        /*
-          if ((stat(name, &st) == 0) && (mod = uam_load(name, p))) {
-        */
         if (stat(name, &st) == 0) {
             if ((mod = uam_load(obj, name, p))) {
                 uam_attach(&uam_modules, mod);

--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -505,7 +505,7 @@ int afp_getsession(
             }
 
 #if 0
-            memcpy (id, ibuf, idlen)
+            memcpy(id, ibuf, idlen)
 #endif
             tklen = obj->sinfo.sessiontoken_len;
             token = obj->sinfo.sessiontoken;

--- a/etc/afpd/catsearch.c
+++ b/etc/afpd/catsearch.c
@@ -196,7 +196,9 @@ static int reducestack(void)
     while (dsidx > 0) {
         if (dstack[dsidx - 1].ds_checked) {
             dsidx--;
-//			free(dstack[dsidx].path);
+#if 0
+			free(dstack[dsidx].path);
+#endif
         } else {
             return dsidx - 1;
         }

--- a/etc/afpd/catsearch.c
+++ b/etc/afpd/catsearch.c
@@ -197,7 +197,7 @@ static int reducestack(void)
         if (dstack[dsidx - 1].ds_checked) {
             dsidx--;
 #if 0
-			free(dstack[dsidx].path);
+            free(dstack[dsidx].path);
 #endif
         } else {
             return dsidx - 1;

--- a/etc/afpd/desktop.c
+++ b/etc/afpd/desktop.c
@@ -550,8 +550,10 @@ addicon_err:
 }
 
 static const uint8_t	utag[] = { 0, 0, 0, 0 };
-static const uint8_t	ucreator[] = { 0, 0, 0, 0 };/* { 'U', 'N', 'I', 'X' };*/
-static const uint8_t	utype[] = { 0, 0, 0, 0 };/* { 'T', 'E', 'X', 'T' };*/
+/* example values: U, N, I, X */
+static const uint8_t	ucreator[] = { 0, 0, 0, 0 };
+/* example values: T, E, X, T */
+static const uint8_t	utype[] = { 0, 0, 0, 0 };
 static const short	usize = 256;
 
 

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -59,21 +59,32 @@
 int         afp_errno;
 /* As long as directory.c hasn't got its own init call, this get initialized in dircache_init */
 struct dir rootParent  = {
-    NULL, NULL, NULL, NULL,          /* d_fullpath, d_m_name, d_u_name, d_m_name_ucs2 */
-    NULL, 0, 0, 0,                   /* qidx_node, d_ctime, d_flags d_pdid */
-    0, 0, 0, 0,                      /* d_did, d_offcnt, d_vid, d_rights_cache */
-    0, 0                             /* d_cache_ctime, d_cache_ino */
+    /* d_fullpath, d_m_name, d_u_name, d_m_name_ucs2 */
+    NULL, NULL, NULL, NULL,
+    /* qidx_node, d_ctime, d_flags d_pdid */
+    NULL, 0, 0, 0,
+    /* d_did, d_offcnt, d_vid, d_rights_cache */
+    0, 0, 0, 0,
+    /* d_cache_ctime, d_cache_ino */
+    0, 0
 };
 struct dir  *curdir = &rootParent;
 struct path Cur_Path = {
     0,
-    "",  /* mac name */
-    ".", /* unix name */
-    0,   /* id */
-    NULL,/* struct dir * */
-    0,   /* stat is not set */
-    0,   /* errno */
-    {0} /* struct stat */
+    /* mac name */
+    "",
+    /* unix name */
+    ".",
+    /* id */
+    0,
+    /* struct dir * */
+    NULL,
+    /* stat is not set */
+    0,
+    /* errno */
+    0,
+    /* struct stat */
+    {0}
 };
 
 /*

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -77,7 +77,7 @@ struct path Cur_Path = {
     ".",
     /* id */
     0,
-    /* struct dir * */
+    /* pointer to struct dir */
     NULL,
     /* stat is not set */
     0,

--- a/etc/afpd/enumerate.c
+++ b/etc/afpd/enumerate.c
@@ -222,9 +222,11 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
 
     /* check for proper bitmaps -- the stuff in comments is for
      * variable directory ids. */
-    if (!(fbitmap || dbitmap)
-            /*|| (fbitmap & (1 << FILPBIT_PDID)) ||
-              (dbitmap & (1 << DIRPBIT_PDID))*/) {
+    if (!(fbitmap || dbitmap)) {
+#if 0
+            || (fbitmap & (1 << FILPBIT_PDID)) ||
+              (dbitmap & (1 << DIRPBIT_PDID))
+#endif
         *rbuflen = 0;
         return AFPERR_BITMAP;
     }

--- a/etc/afpd/enumerate.c
+++ b/etc/afpd/enumerate.c
@@ -224,8 +224,8 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
      * variable directory ids. */
     if (!(fbitmap || dbitmap)) {
 #if 0
-            || (fbitmap & (1 << FILPBIT_PDID)) ||
-              (dbitmap & (1 << DIRPBIT_PDID))
+        || (fbitmap & (1 << FILPBIT_PDID)) ||
+        (dbitmap & (1 << DIRPBIT_PDID))
 #endif
         *rbuflen = 0;
         return AFPERR_BITMAP;

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -2552,7 +2552,9 @@ int afp_exchangefiles(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
     /*
      * we need to exchange ACL entries as well
      */
-    /* exchange_acls(vol, p, upath); */
+#if 0
+    exchange_acls(vol, p, upath);
+#endif
     path->st = srcst;
     path->st_valid = 1;
     path->st_errno = 0;

--- a/etc/papd/lp.c
+++ b/etc/papd/lp.c
@@ -665,8 +665,12 @@ int lp_open(struct papfile *out, struct sockaddr_at *sat)
     }
 
     if (lp.lp_flags & LP_OPEN) {
-        /* LOG(log_error, logtype_papd, "lp_open already open" ); */
-        /* abort(); */
+#ifdef EBUG
+        LOG(log_error, logtype_papd, "lp_open already open" );
+#endif
+#if 0
+        abort();
+#endif
         return -1;
     }
 
@@ -1005,7 +1009,9 @@ int lp_print(void)
                            printer->p_operator, printer->p_cupsoptions);
         }
 
-        /*LOG(log_info, logtype_papd, "lp_print unlink %s", lp.lp_spoolfile );*/
+#ifdef EBUG
+        LOG(log_info, logtype_papd, "lp_print unlink %s", lp.lp_spoolfile);
+#endif
         unlink(lp.lp_spoolfile);
         return 0;
 #endif /* HAVE_CUPS*/

--- a/etc/papd/lp.c
+++ b/etc/papd/lp.c
@@ -666,7 +666,7 @@ int lp_open(struct papfile *out, struct sockaddr_at *sat)
 
     if (lp.lp_flags & LP_OPEN) {
 #ifdef EBUG
-        LOG(log_error, logtype_papd, "lp_open already open" );
+        LOG(log_error, logtype_papd, "lp_open already open");
 #endif
 #if 0
         abort();

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -814,8 +814,9 @@ static int uam_setup(void *obj _U_, const char *path)
         return -1;
     }
 
-    /*uam_register(UAM_SERVER_PRINTAUTH, path, "DHCAST128",
-      pam_printer);*/
+#if 0
+    uam_register(UAM_SERVER_PRINTAUTH, path, "DHCAST128", pam_printer);
+#endif
     return 0;
 }
 
@@ -823,7 +824,9 @@ static void uam_cleanup(void)
 {
     uam_unregister(UAM_SERVER_LOGIN, "DHCAST128");
     uam_unregister(UAM_SERVER_CHANGEPW, "DHCAST128");
-    /*uam_unregister(UAM_SERVER_PRINTAUTH, "DHCAST128"); */
+#if 0
+    uam_unregister(UAM_SERVER_PRINTAUTH, "DHCAST128");
+#endif
 }
 
 UAM_MODULE_EXPORT struct uam_export uams_dhx = {

--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -415,15 +415,18 @@ static int uam_setup(void *obj, const char *path)
         return -1;
     }
 
-    /*uam_register(UAM_SERVER_PRINTAUTH, path, "DHCAST128",
-      passwd_printer);*/
+#if 0
+    uam_register(UAM_SERVER_PRINTAUTH, path, "DHCAST128", passwd_printer);
+#endif
     return 0;
 }
 
 static void uam_cleanup(void)
 {
     uam_unregister(UAM_SERVER_LOGIN, "DHCAST128");
-    /*uam_unregister(UAM_SERVER_PRINTAUTH, "DHCAST128"); */
+#if 0
+    uam_unregister(UAM_SERVER_PRINTAUTH, "DHCAST128");
+#endif
 }
 
 UAM_MODULE_EXPORT struct uam_export uams_dhx = {

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -635,8 +635,9 @@ static int uam_setup(void *obj, const char *path)
         return -1;
     }
 
-    /*uam_register(UAM_SERVER_PRINTAUTH, path, "Randnum Exchange",
-      pam_printer);*/
+#if 0
+    uam_register(UAM_SERVER_PRINTAUTH, path, "Randnum Exchange", pam_printer);
+#endif
     return 0;
 }
 
@@ -645,7 +646,9 @@ static void uam_cleanup(void)
     uam_unregister(UAM_SERVER_LOGIN, "Randnum exchange");
     uam_unregister(UAM_SERVER_LOGIN, "2-Way Randnum exchange");
     uam_unregister(UAM_SERVER_CHANGEPW, "Randnum Exchange");
-    /*uam_unregister(UAM_SERVER_PRINTAUTH, "Randnum Exchange");*/
+#if 0
+    uam_unregister(UAM_SERVER_PRINTAUTH, "Randnum Exchange");
+#endif
 }
 
 UAM_MODULE_EXPORT struct uam_export uams_randnum = {

--- a/include/atalk/directory.h
+++ b/include/atalk/directory.h
@@ -40,16 +40,21 @@
 #endif /* DIRBITS */
 
 /* reserved directory id's */
-#define DIRDID_ROOT_PARENT    htonl(1)  /* parent directory of root */
-#define DIRDID_ROOT           htonl(2)  /* root directory */
+/* parent directory of root */
+#define DIRDID_ROOT_PARENT    htonl(1)
+/* root directory */
+#define DIRDID_ROOT           htonl(2)
 
 /* struct dir.d_flags */
 #define DIRF_FSMASK	   (3<<0)
 #define DIRF_NOFS	   (0<<0)
 #define DIRF_UFS	   (1<<1)
-#define DIRF_ISFILE    (1<<3) /* it's cached file, not a directory */
-#define DIRF_OFFCNT    (1<<4) /* offsprings count is valid */
-#define DIRF_CNID	   (1<<5) /* renumerate id */
+/* it's cached file, not a directory */
+#define DIRF_ISFILE    (1<<3)
+/* offsprings count is valid */
+#define DIRF_OFFCNT    (1<<4)
+/* renumerate id */
+#define DIRF_CNID	   (1<<5)
 
 struct dir {
     /* complete unix path to dir (or file) */
@@ -87,12 +92,17 @@ struct dir {
 };
 
 struct path {
-    int         m_type;             /* mac name type (long name, unicode */
-    char        *m_name;            /* mac name */
-    char        *u_name;            /* unix name */
-    cnid_t      id;                 /* file id (only for getmetadata) */
-    struct dir  *d_dir;             /* */
-    int         st_valid;           /* does st_errno and st set */
+    /* mac name type (long name, unicode */
+    int         m_type;
+    /* mac name */
+    char        *m_name;
+    /* unix name */
+    char        *u_name;
+    /* file id (only for getmetadata) */
+    cnid_t      id;
+    struct dir  *d_dir;
+    /* does st_errno and st set */
+    int         st_valid;
     int         st_errno;
     struct stat st;
 };

--- a/include/atalk/ea.h
+++ b/include/atalk/ea.h
@@ -100,11 +100,15 @@ ssize_t sys_lgetxattr(const char *path, const char *name, void *value,
 ssize_t sys_fgetxattr(int filedes, const char *name, void *value, size_t size);
 ssize_t sys_listxattr(const char *path, char *list, size_t size);
 ssize_t sys_llistxattr(const char *path, char *list, size_t size);
-/* ssize_t sys_flistxattr (int filedes, char *list, size_t size); */
+#if 0
+ssize_t sys_flistxattr (int filedes, char *list, size_t size);
+#endif
 ssize_t sys_flistxattr(int filedes, const char *path, char *list, size_t size);
 int sys_removexattr(const char *path, const char *name);
 int sys_lremovexattr(const char *path, const char *name);
-/* int sys_fremovexattr (int filedes, const char *name); */
+#if 0
+int sys_fremovexattr (int filedes, const char *name);
+#endif
 int sys_fremovexattr(int filedes, const char *path, const char *name);
 int sys_setxattr(const char *path, const char *name, const void *value,
                  size_t size, int flags);

--- a/include/atalk/ea.h
+++ b/include/atalk/ea.h
@@ -101,13 +101,13 @@ ssize_t sys_fgetxattr(int filedes, const char *name, void *value, size_t size);
 ssize_t sys_listxattr(const char *path, char *list, size_t size);
 ssize_t sys_llistxattr(const char *path, char *list, size_t size);
 #if 0
-ssize_t sys_flistxattr (int filedes, char *list, size_t size);
+ssize_t sys_flistxattr(int filedes, char *list, size_t size);
 #endif
 ssize_t sys_flistxattr(int filedes, const char *path, char *list, size_t size);
 int sys_removexattr(const char *path, const char *name);
 int sys_lremovexattr(const char *path, const char *name);
 #if 0
-int sys_fremovexattr (int filedes, const char *name);
+int sys_fremovexattr(int filedes, const char *name);
 #endif
 int sys_fremovexattr(int filedes, const char *path, const char *name);
 int sys_setxattr(const char *path, const char *name, const void *value,

--- a/include/atalk/spotlight.h
+++ b/include/atalk/spotlight.h
@@ -50,20 +50,27 @@
 #define SL_ENC_BIG_ENDIAN    2
 #define SL_ENC_UTF_16        4
 
-typedef DALLOC_CTX     sl_array_t;    /* an array of elements                 */
-typedef DALLOC_CTX     sl_dict_t;     /* an array of key/value elements       */
-typedef DALLOC_CTX     sl_filemeta_t; /* contains one sl_array_t              */
-typedef int            sl_nil_t;      /* a nil element                        */
-typedef bool           sl_bool_t;     /* a boolean, we avoid bool_t           */
+/* an array of elements */
+typedef DALLOC_CTX     sl_array_t;
+/* an array of key/value elements */
+typedef DALLOC_CTX     sl_dict_t;
+/* contains one sl_array_t */
+typedef DALLOC_CTX     sl_filemeta_t;
+/* a nil element */
+typedef int            sl_nil_t;
+/* a boolean, we avoid bool_t */
+typedef bool           sl_bool_t;
 typedef struct timeval sl_time_t;
 typedef struct {
+    /* a UUID */
     char sl_uuid[16];
-}  sl_uuid_t;                         /* a UUID                               */
+}  sl_uuid_t;
 typedef struct {
+    /* an array of CNIDs */
     uint16_t   ca_unkn1;
     uint32_t   ca_context;
     DALLOC_CTX *ca_cnids;
-}  sl_cnids_t;                        /* an array of CNIDs                    */
+}  sl_cnids_t;
 
 /******************************************************************************
  * Some helper stuff dealing with queries
@@ -71,14 +78,22 @@ typedef struct {
 
 /* query state */
 typedef enum {
-    SLQ_STATE_NEW,            /* Query received from client           */
-    SLQ_STATE_RUNNING,        /* Query dispatched to Tracker          */
-    SLQ_STATE_RESULTS,        /* Async Tracker query read             */
-    SLQ_STATE_FULL,           /* result queue is full                 */
-    SLQ_STATE_DONE,           /* Got all results from Tracker         */
-    SLQ_STATE_CANCEL_PENDING, /* a cancel op for the query is pending */
-    SLQ_STATE_CANCELLED,      /* the query has been cancelled         */
-    SLQ_STATE_ERROR	          /* an error happended somewhere         */
+    /* Query received from client */
+    SLQ_STATE_NEW,
+    /* Query dispatched to Tracker */
+    SLQ_STATE_RUNNING,
+    /* Async Tracker query read */
+    SLQ_STATE_RESULTS,
+    /* result queue is full */
+    SLQ_STATE_FULL,
+    /* Got all results from Tracker */
+    SLQ_STATE_DONE,
+    /* a cancel op for the query is pending */
+    SLQ_STATE_CANCEL_PENDING,
+    /* the query has been cancelled */
+    SLQ_STATE_CANCELLED,
+    /* an error happended somewhere */
+    SLQ_STATE_ERROR
 } slq_state_t;
 
 /* Handle for query results */
@@ -90,29 +105,46 @@ struct sl_rslts {
 
 /* Internal query data structure */
 typedef struct _slq_t {
-    struct list_head  slq_list;           /* queries are stored in a list     */
-    slq_state_t       slq_state;          /* State                            */
-    AFPObj           *slq_obj;            /* global AFPObj handle             */
-    const struct vol *slq_vol;            /* volume handle                    */
-    char             *slq_scope;          /* search scope                     */
-    time_t            slq_time;           /* timestamp received query         */
-    uint64_t          slq_ctx1;           /* client context 1                 */
-    uint64_t          slq_ctx2;           /* client context 2                 */
-    sl_array_t       *slq_reqinfo;        /* array with requested metadata    */
-    const char       *slq_qstring;        /* the Spotlight query string       */
-    uint64_t         *slq_cnids;          /* Pointer to array with CNIDs      */
-    size_t            slq_cnids_num;      /* Size of slq_cnids array          */
-    void             *tracker_cursor;     /* Tracker SPARQL cursor            */
-    bool              slq_allow_expr;     /* Whether to allow expressions     */
-    uint64_t          slq_result_limit;   /* Whether to LIMIT SPARQL results  */
-    struct sl_rslts  *query_results;      /* query results                    */
+    /* queries are stored in a list */
+    struct list_head  slq_list;
+    /* State */
+    slq_state_t       slq_state;
+    /* global AFPObj handle */
+    AFPObj           *slq_obj;
+    /* volume handle */
+    const struct vol *slq_vol;
+    /* search scope */
+    char             *slq_scope;
+    /* timestamp received query */
+    time_t            slq_time;
+    /* client context 1 */
+    uint64_t          slq_ctx1;
+    /* client context 2 */
+    uint64_t          slq_ctx2;
+    /* array with requested metadata */
+    sl_array_t       *slq_reqinfo;
+    /* the Spotlight query string */
+    const char       *slq_qstring;
+    /* Pointer to array with CNIDs */
+    uint64_t         *slq_cnids;
+    /* Size of slq_cnids array */
+    size_t            slq_cnids_num;
+    /* Tracker SPARQL cursor */
+    void             *tracker_cursor;
+    /* Whether to allow expressions */
+    bool              slq_allow_expr;
+    /* Whether to LIMIT SPARQL results */
+    uint64_t          slq_result_limit;
+    /* query results */
+    struct sl_rslts  *query_results;
 } slq_t;
 
 struct sl_ctx {
     TrackerSparqlConnection *tracker_con;
     GCancellable *cancellable;
     GMainLoop *mainloop;
-    slq_t *query_list; /* list of active queries */
+    /* list of active queries */
+    slq_t *query_list;
 };
 
 /******************************************************************************

--- a/libatalk/cnid/last/cnid_last.c
+++ b/libatalk/cnid/last/cnid_last.c
@@ -124,7 +124,8 @@ static struct _cnid_db *cnid_last_new(struct vol *vol _U_)
     cdb->cnid_delete = cnid_last_delete;
     cdb->cnid_get = cnid_last_get;
     cdb->cnid_lookup = cnid_last_lookup;
-    cdb->cnid_nextid = NULL;    /* cnid_last_nextid; */
+    /* cnid_last_nextid; */
+    cdb->cnid_nextid = NULL;
     cdb->cnid_resolve = cnid_last_resolve;
     cdb->cnid_update = cnid_last_update;
     cdb->cnid_close = cnid_last_close;

--- a/libatalk/dsi/dsi_getstat.c
+++ b/libatalk/dsi/dsi_getstat.c
@@ -19,7 +19,9 @@
 void dsi_getstatus(DSI *dsi)
 {
     dsi->header.dsi_flags = DSIFL_REPLY;
-    /*dsi->header.dsi_command = DSIFUNC_STAT;*/
+#if 0
+    dsi->header.dsi_command = DSIFUNC_STAT;
+#endif
     dsi->header.dsi_data.dsi_code = dsi->header.dsi_reserved = 0;
     memcpy(dsi->commands, dsi->status, dsi->statuslen);
     dsi->cmdlen = dsi->statuslen;

--- a/libatalk/dsi/dsi_opensess.c
+++ b/libatalk/dsi/dsi_opensess.c
@@ -55,6 +55,7 @@ void dsi_opensession(DSI *dsi)
             dsi->attn_quantum = ntohl(dsi->attn_quantum);
 
         case DSIOPT_SERVQUANT:
+
         /* just ignore these */
         default:
             break;

--- a/libatalk/dsi/dsi_opensess.c
+++ b/libatalk/dsi/dsi_opensess.c
@@ -67,7 +67,9 @@ void dsi_opensession(DSI *dsi)
      * max server quantum due to a bug in appleshare client 3.8.6. */
     dsi->header.dsi_flags = DSIFL_REPLY;
     dsi->header.dsi_data.dsi_code = 0;
-    /* dsi->header.dsi_command = DSIFUNC_OPEN;*/
+#if 0
+    dsi->header.dsi_command = DSIFUNC_OPEN;
+#endif
     /* length of data. dsi_send uses it. */
     dsi->cmdlen = 2 * (2 + sizeof(uint32_t));
     /* DSI Option Server Request Quantum */

--- a/libatalk/dsi/dsi_opensess.c
+++ b/libatalk/dsi/dsi_opensess.c
@@ -54,7 +54,8 @@ void dsi_opensession(DSI *dsi)
             memcpy(&dsi->attn_quantum, &dsi->commands[i], option_len);
             dsi->attn_quantum = ntohl(dsi->attn_quantum);
 
-        case DSIOPT_SERVQUANT: /* just ignore these */
+        case DSIOPT_SERVQUANT:
+        /* just ignore these */
         default:
             break;
         }

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2343,9 +2343,11 @@ struct vol *getvolbypath(AFPObj *obj, const char *path)
     if ((subpathconfig = getoption_str(obj->iniconfig, INISEC_HOMES, "path", NULL,
                                        NULL))) {
 #if 0
+
         if (!subpath || strncmp(subpathconfig, subpath, strlen(subpathconfig)) != 0) {
             EC_FAIL;
         }
+
 #endif
         strlcat(tmpbuf, subpathconfig, MAXPATHLEN);
         strlcat(tmpbuf, "/", MAXPATHLEN);

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2342,11 +2342,11 @@ struct vol *getvolbypath(AFPObj *obj, const char *path)
     /* (6) */
     if ((subpathconfig = getoption_str(obj->iniconfig, INISEC_HOMES, "path", NULL,
                                        NULL))) {
-        /*
+#if 0
         if (!subpath || strncmp(subpathconfig, subpath, strlen(subpathconfig)) != 0) {
             EC_FAIL;
         }
-        */
+#endif
         strlcat(tmpbuf, subpathconfig, MAXPATHLEN);
         strlcat(tmpbuf, "/", MAXPATHLEN);
     }

--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -531,8 +531,8 @@ STATIC void test329()
         test_failed();
     }
 
-    fork2 = FPOpenFork(Conn2, vol2, type, bitmap, DIRDID_ROOT,
-                       name,/* OPENACC_WR | */OPENACC_RD);
+    fork2 = FPOpenFork(Conn2, vol2, type, bitmap, DIRDID_ROOT, name,
+                       OPENACC_RD);
 
     if (!fork2) {
         test_failed();
@@ -1043,8 +1043,8 @@ STATIC void test366()
         test_failed();
     }
 
-    fork2 = FPOpenFork(Conn2, vol2, type, bitmap, DIRDID_ROOT,
-                       name,/* OPENACC_WR | */OPENACC_RD);
+    fork2 = FPOpenFork(Conn2, vol2, type, bitmap, DIRDID_ROOT, name,
+                       OPENACC_RD);
 
     if (!fork2) {
         test_failed();

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -80,8 +80,7 @@ STATIC void test222()
         goto fin;
     }
 
-    fork = FPOpenFork(conn2, vol2, OPENFORK_RSCS, 0, DIRDID_ROOT,
-                      name,  /* OPENACC_WR |OPENACC_RD |*/
+    fork = FPOpenFork(conn2, vol2, OPENFORK_RSCS, 0, DIRDID_ROOT, name,
                       OPENACC_DWR | OPENACC_DRD);
 
     if (!fork) {

--- a/test/testsuite/FPGetACL.c
+++ b/test/testsuite/FPGetACL.c
@@ -28,14 +28,14 @@ STATIC void test398()
     }
 
     FAIL(FPGetACL(Conn, vol, DIRDID_ROOT, 7, file))
-    /*
-    	FPGetACL(Conn,vol, DIRDID_ROOT , 7, "testdir");
-    	FPGetACL(Conn,vol, DIRDID_ROOT , 8, "test");
-    	FPGetACL(Conn,vol, DIRDID_ROOT , 23, "test");
-    	FPGetACL(Conn,vol, DIRDID_ROOT , 23, "test2");
-    	FPGetACL(Conn,vol, DIRDID_ROOT , 23, "test3");
-    	FPGetACL(Conn,vol, DIRDID_ROOT , 23, "testdir");
-    */
+#if 0
+    FPGetACL(Conn,vol, DIRDID_ROOT , 7, "testdir");
+    FPGetACL(Conn,vol, DIRDID_ROOT , 8, "test");
+    FPGetACL(Conn,vol, DIRDID_ROOT , 23, "test");
+    FPGetACL(Conn,vol, DIRDID_ROOT , 23, "test2");
+    FPGetACL(Conn,vol, DIRDID_ROOT , 23, "test3");
+    FPGetACL(Conn,vol, DIRDID_ROOT , 23, "testdir");
+#endif
     FPDelete(Conn, vol, DIRDID_ROOT, file);
 test_exit:
     exit_test("FPGetACL:test398: check ACL support");

--- a/test/testsuite/FPGetACL.c
+++ b/test/testsuite/FPGetACL.c
@@ -29,12 +29,12 @@ STATIC void test398()
 
     FAIL(FPGetACL(Conn, vol, DIRDID_ROOT, 7, file))
 #if 0
-    FPGetACL(Conn,vol, DIRDID_ROOT , 7, "testdir");
-    FPGetACL(Conn,vol, DIRDID_ROOT , 8, "test");
-    FPGetACL(Conn,vol, DIRDID_ROOT , 23, "test");
-    FPGetACL(Conn,vol, DIRDID_ROOT , 23, "test2");
-    FPGetACL(Conn,vol, DIRDID_ROOT , 23, "test3");
-    FPGetACL(Conn,vol, DIRDID_ROOT , 23, "testdir");
+    FPGetACL(Conn, vol, DIRDID_ROOT, 7, "testdir");
+    FPGetACL(Conn, vol, DIRDID_ROOT, 8, "test");
+    FPGetACL(Conn, vol, DIRDID_ROOT, 23, "test");
+    FPGetACL(Conn, vol, DIRDID_ROOT, 23, "test2");
+    FPGetACL(Conn, vol, DIRDID_ROOT, 23, "test3");
+    FPGetACL(Conn, vol, DIRDID_ROOT, 23, "testdir");
 #endif
     FPDelete(Conn, vol, DIRDID_ROOT, file);
 test_exit:

--- a/test/testsuite/FPResolveID.c
+++ b/test/testsuite/FPResolveID.c
@@ -91,7 +91,9 @@ STATIC void test91()
         test_failed();
     }
 
-//	FAIL (FPCreateID(Conn,vol, dir, name))
+#if 0
+	FAIL (FPCreateID(Conn,vol, dir, name))
+#endif
 
     if (FPGetFileDirParams(Conn, vol, dir, name, bitmap, 0)) {
         test_failed();

--- a/test/testsuite/FPResolveID.c
+++ b/test/testsuite/FPResolveID.c
@@ -92,7 +92,7 @@ STATIC void test91()
     }
 
 #if 0
-	FAIL (FPCreateID(Conn,vol, dir, name))
+    FAIL(FPCreateID(Conn, vol, dir, name))
 #endif
 
     if (FPGetFileDirParams(Conn, vol, dir, name, bitmap, 0)) {

--- a/test/testsuite/T2_FPByteRangeLock.c
+++ b/test/testsuite/T2_FPByteRangeLock.c
@@ -155,7 +155,9 @@ void test117()
         goto test_exit;
     }
 
-//	test_bytelock(vol2, name, OPENFORK_DATA);
+#if 0
+	test_bytelock(vol2, name, OPENFORK_DATA);
+#endif
     name = "t117 exclusive open RF";
     test_bytelock(vol2, name, OPENFORK_RSCS);
     FPCloseVol(Conn2, vol2);

--- a/test/testsuite/T2_FPByteRangeLock.c
+++ b/test/testsuite/T2_FPByteRangeLock.c
@@ -156,7 +156,7 @@ void test117()
     }
 
 #if 0
-	test_bytelock(vol2, name, OPENFORK_DATA);
+    test_bytelock(vol2, name, OPENFORK_DATA);
 #endif
     name = "t117 exclusive open RF";
     test_bytelock(vol2, name, OPENFORK_RSCS);

--- a/test/testsuite/afpcli.c
+++ b/test/testsuite/afpcli.c
@@ -1,3 +1,5 @@
+#include <atalk/afp.h>
+
 #include "afpclient.h"
 #include "test.h"
 
@@ -1906,7 +1908,7 @@ unsigned int AFPGetUserInfo(CONN *conn, char flag, int id, uint16_t bitmap)
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
-    dsi->commands[ofs++] = 37; /* AFP_GETUSERINFO;*/
+    dsi->commands[ofs++] = AFP_GETUSERINFO;
     memcpy(dsi->commands + ofs, &flag, sizeof(flag));
     ofs++;
     id = htonl(id);


### PR DESCRIPTION
Rather than keeping disabled code in comments, put them inside `#if 0` preprocessor blocks so that they can be easily found and eliminated at a later time

In the case of debug logging, put this code behind the EBUG compiler flag instead

This also includes some other minor fixes, such as clean up of trailing code comments, and modernization of syntax