### PR TITLE
getzones: allow all ZIP query types to be generated (and sundry other enhancements)

### DIFF
--- a/bin/getzones/getzones.c
+++ b/bin/getzones/getzones.c
@@ -257,12 +257,17 @@ static void print_zones(short n, char *buf, charset_t charset)
     for (; n--; buf += (*buf) + 1) {
         if ((size_t)(-1) == (zone_len = convert_string_allocate(charset,
                                         CH_UNIX, buf + 1, *buf, &zone))) {
+            
+            /* If the string conversion fails, just copy the MacRoman string
+               and hope it makes sense as whatever our UNIX charset is */
             zone_len = *buf;
-
-            if ((zone = strdup(buf + 1)) == NULL) {
-                perror("strdup");
+            zone = malloc(zone_len+1);
+            if (zone == NULL) {
+                perror("malloc");
                 exit(1);
             }
+            memcpy(zone, buf+1, zone_len);
+            zone[zone_len] = 0;
         }
 
         printf("%.*s\n", (int)zone_len, zone);

--- a/bin/getzones/getzones.c
+++ b/bin/getzones/getzones.c
@@ -25,15 +25,20 @@
 #define ZIPOP_DEFAULT ZIPOP_GETZONELIST
 
 static void print_zones(short n, char *buf, charset_t charset);
-void do_atp_lookup(struct sockaddr_at *saddr, uint8_t lookup_type, charset_t charset);
+void do_atp_lookup(struct sockaddr_at *saddr, uint8_t lookup_type,
+                   charset_t charset);
 static void print_gnireply(size_t len, uint8_t *buf, charset_t charset);
-void do_getnetinfo(struct sockaddr_at *dest, char *zone_to_confirm, charset_t charset);
-static int print_and_count_zones_in_reply(char *buf, size_t len, charset_t charset);
+void do_getnetinfo(struct sockaddr_at *dest, char *zone_to_confirm,
+                   charset_t charset);
+static int print_and_count_zones_in_reply(char *buf, size_t len,
+        charset_t charset);
 void do_query(struct sockaddr_at *dest, uint16_t network, charset_t charset);
 
 static void usage(char *s)
 {
-    fprintf(stderr, "usage:\t%s [-g | -l | -m | -q network | -z zone ] [-c Mac charset] [address]\n", s);
+    fprintf(stderr,
+            "usage:\t%s [-g | -l | -m | -q network | -z zone ] [-c Mac charset] [address]\n",
+            s);
     exit(1);
 }
 
@@ -45,10 +50,9 @@ int main(int argc, char *argv[])
     extern int optind;
     charset_t chMac = CH_MAC;
     uint8_t lookup_type = ZIPOP_DEFAULT;
-    char* requested_zone = NULL;
+    char *requested_zone = NULL;
     long requested_network = 0;
     char *end_of_digits;
-
     set_charset_name(CH_UNIX, "UTF8");
     set_charset_name(CH_MAC, MACCHARSET);
 
@@ -58,6 +62,7 @@ int main(int argc, char *argv[])
             if (lookup_type != ZIPOP_DEFAULT) {
                 ++errflg;
             }
+
             lookup_type = ZIPOP_GNI;
             break;
 
@@ -65,44 +70,53 @@ int main(int argc, char *argv[])
             if (lookup_type != ZIPOP_DEFAULT) {
                 ++errflg;
             }
+
             lookup_type = ZIPOP_GETLOCALZONES;
             break;
-            
+
         case 'm':
             if (lookup_type != ZIPOP_DEFAULT) {
                 ++errflg;
             }
+
             lookup_type = ZIPOP_GETMYZONE;
             break;
 
         case 'c':
             chMac = add_charset(optarg);
+
             if ((charset_t) -1 == chMac) {
                 fprintf(stderr, "Invalid Mac charset.\n");
                 exit(1);
             }
+
             break;
-            
+
         case 'q':
             if (lookup_type != ZIPOP_DEFAULT) {
                 ++errflg;
             }
+
             requested_network = strtol(optarg, &end_of_digits, 10);
+
             if (*end_of_digits != '\0') {
                 fprintf(stderr, "Network must be a number between 0 and 65535.\n");
                 exit(1);
             }
+
             if (requested_network < 0 || requested_network > 65535) {
                 fprintf(stderr, "Network must be a number between 0 and 65535.\n");
                 exit(1);
             }
+
             lookup_type = ZIPOP_QUERY;
             break;
-            
+
         case 'z':
             if (lookup_type != ZIPOP_DEFAULT) {
                 ++errflg;
             }
+
             requested_zone = strdup(optarg);
             lookup_type = ZIPOP_GNI;
             break;
@@ -111,7 +125,6 @@ int main(int argc, char *argv[])
             ++errflg;
         }
     }
-
 
     if (errflg || argc - optind > 1) {
         usage(argv[0]);
@@ -139,28 +152,30 @@ int main(int argc, char *argv[])
         }
     }
 
-    switch(lookup_type) {
+    switch (lookup_type) {
     case ZIPOP_GETZONELIST:
     case ZIPOP_GETMYZONE:
     case ZIPOP_GETLOCALZONES:
         do_atp_lookup(&saddr, lookup_type, chMac);
         break;
-        
+
     case ZIPOP_GNI:
         do_getnetinfo(&saddr, requested_zone, chMac);
         break;
-        
+
     case ZIPOP_QUERY:
         do_query(&saddr, (uint16_t)requested_network, chMac);
         break;
     }
-    
+
     if (requested_zone != NULL) {
         free(requested_zone);
     }
 }
 
-void do_atp_lookup(struct sockaddr_at *saddr, uint8_t lookup_type, charset_t charset) {
+void do_atp_lookup(struct sockaddr_at *saddr, uint8_t lookup_type,
+                   charset_t charset)
+{
     struct atp_handle *ah;
     struct atp_block atpb;
     char reqdata[4], buf[ATP_MAXDATA];
@@ -174,7 +189,6 @@ void do_atp_lookup(struct sockaddr_at *saddr, uint8_t lookup_type, charset_t cha
 
     reqdata[0] = lookup_type;
     reqdata[1] = 0;
-
     /* We need to set the "starting index" in the query we're going to send out.
        This allows for a kind of pagination; you ask for zones starting at zone 1 and
        you get a reply's worth.  Say you get three zones back.  You then add three to
@@ -183,6 +197,7 @@ void do_atp_lookup(struct sockaddr_at *saddr, uint8_t lookup_type, charset_t cha
        Yes, this is racy, and will not give the correct results in a network where
        the zone state has not converged.  We can't do much about that now... */
     start_index = 1;
+
     if (lookup_type == ZIPOP_GETMYZONE) {
         /* However, for some reason best known to Apple circa 1992, GetMyZone requires
            the index set to 0 (see Inside Appletalk, p. 8-15). */
@@ -191,11 +206,9 @@ void do_atp_lookup(struct sockaddr_at *saddr, uint8_t lookup_type, charset_t cha
 
     do {
         atpb.atp_saddr = saddr;
-
         /* Put the start index into the packet */
         uint16_t start_idx_for_packet = htons(start_index);
         memcpy(reqdata + 2, &start_idx_for_packet, 2);
-
         atpb.atp_sreqdata = reqdata;
         atpb.atp_sreqdlen = 4;
         atpb.atp_sreqto = 2;
@@ -234,7 +247,7 @@ void do_atp_lookup(struct sockaddr_at *saddr, uint8_t lookup_type, charset_t cha
         /* Otherwise, we need to add the number of zones returned to the start index
            and loop.  The loop condition here is checking the LastFlag field of the
            reply, which is 0 if there are more zones to come, and 1 otherwise. */
-        start_index += zone_count_returned; 
+        start_index += zone_count_returned;
     } while (!((char *)iov.iov_base)[0]);
 
     if (atp_close(ah) != 0) {
@@ -258,16 +271,17 @@ static void print_zones(short n, char *buf, charset_t charset)
     for (; n--; buf += (*buf) + 1) {
         if ((size_t)(-1) == (zone_len = convert_string_allocate(charset,
                                         CH_UNIX, buf + 1, *buf, &zone))) {
-            
             /* If the string conversion fails, just copy the MacRoman string
                and hope it makes sense as whatever our UNIX charset is */
             zone_len = *buf;
-            zone = malloc(zone_len+1);
+            zone = malloc(zone_len + 1);
+
             if (zone == NULL) {
                 perror("malloc");
                 exit(1);
             }
-            memcpy(zone, buf+1, zone_len);
+
+            memcpy(zone, buf + 1, zone_len);
             zone[zone_len] = 0;
         }
 
@@ -276,21 +290,22 @@ static void print_zones(short n, char *buf, charset_t charset)
     }
 }
 
-void do_getnetinfo(struct sockaddr_at *dest, char *zone_to_confirm, charset_t charset) {
+void do_getnetinfo(struct sockaddr_at *dest, char *zone_to_confirm,
+                   charset_t charset)
+{
     uint8_t buf[600];
     uint8_t *cursor;
     int i;
     struct sockaddr_at laddr = { 0 };
-    
     cursor = buf;
-    
     /* Construct packet. Layout is in IA, 2nd ed. p. 8-17 */
     *cursor++ = DDPTYPE_ZIP;
     *cursor++ = ZIPOP_GNI;
+
     for (i = 0; i < 5; i++) {
         *cursor++ = 0;
     }
-    
+
     if (zone_to_confirm != NULL) {
         size_t zonelen = strnlen(zone_to_confirm, 32);
         *cursor++ = (uint8_t)zonelen;
@@ -300,48 +315,53 @@ void do_getnetinfo(struct sockaddr_at *dest, char *zone_to_confirm, charset_t ch
         /* If we aren't trying to find out about a specific zone, give an empty name */
         *cursor++ = 0;
     }
-    
+
     /* Send the thing */
     int sockfd = netddp_open(&laddr, NULL);
+
     if (sockfd < 0) {
         perror("netddp_open");
         exit(1);
     }
-    
+
     int ret = netddp_sendto(sockfd, buf, cursor - buf, 0, (struct sockaddr*)dest,
-        sizeof(struct sockaddr_at));
+                            sizeof(struct sockaddr_at));
+
     if (ret < 0) {
         perror("netddp_sendto");
         exit(1);
     }
-    
+
     /* Wait for a reply */
-    for(;;) {
+    for (;;) {
         ret = netddp_recvfrom(sockfd, buf, sizeof(buf), 0, NULL, NULL);
+
         if (ret < 0) {
             perror("netddp_recvfrom");
             exit(1);
         }
-        
+
         /* Is this actually a ZIP GNI reply or some random packet that's just wandered
            into our socket? */
         if (ret < 2) {
             continue;
         }
+
         if (buf[0] != DDPTYPE_ZIP || buf[1] != ZIPOP_GNIREPLY) {
             continue;
         }
-                
+
         break;
     }
-    
-    print_gnireply(ret, buf, charset);   
+
+    print_gnireply(ret, buf, charset);
 }
 
-static void print_gnireply(size_t len, uint8_t *buf, charset_t charset) {
+static void print_gnireply(size_t len, uint8_t *buf, charset_t charset)
+{
     int ret;
     uint8_t *cursor;
-    
+
     /* Is the packet long enough for our flags and stuff? */
     if (len < 9) {
         fprintf(stderr, "getnetinfo reply too short, bailing out\n");
@@ -351,88 +371,100 @@ static void print_gnireply(size_t len, uint8_t *buf, charset_t charset) {
     /* Fish out the fixed-length metadata. */
     cursor = buf;
     /* skip over DDP type and ZIP operation, which we checked above */
-    cursor += 2; 
-    
+    cursor += 2;
     uint8_t flags = *cursor++;
     uint16_t net_start = ntohs(*((uint16_t*)cursor));
     cursor += 2;
     uint16_t net_end = ntohs(*((uint16_t*)cursor));
     cursor += 2;
-    
     printf("Network range: %"PRIu16"-%"PRIu16"\n", net_start, net_end);
-        
     /* Decode the flags */
     printf("Flags (0x%"PRIx8"):", flags);
+
     if (flags & ZIPGNI_INVALID) {
         printf(" requested-zone-invalid");
     }
+
     if (flags & ZIPGNI_USEBROADCAST) {
         printf(" use-broadcast");
     }
+
     if (flags & ZIPGNI_ONEZONE) {
         printf(" only-one-zone");
     }
+
     printf("\n");
-    
     /* Print out the zone requested */
     uint8_t requested_zone_length = *cursor++;
+
     if ((cursor - buf) + requested_zone_length >= len) {
-        fprintf(stderr, "getnetinfo reply too short (missing requested zone), bailing out\n");
+        fprintf(stderr,
+                "getnetinfo reply too short (missing requested zone), bailing out\n");
         exit(1);
     }
-    char* requested_zone;
+
+    char *requested_zone;
     ret = convert_string_allocate(charset, CH_UNIX, cursor, requested_zone_length,
                                   &requested_zone);
+
     if (ret == -1) {
         fprintf(stderr, "malformed requested zone name, bailing out\n");
         exit(1);
     }
+
     printf("Requested zone: %s\n", requested_zone);
     cursor += ret;
     free(requested_zone);
-    
     /* Print out multicast address */
     uint8_t multicast_length = *cursor++;
+
     if ((cursor - buf) + multicast_length > len) {
-        fprintf(stderr, "getnetinfo reply too short (missing multicast address), bailing out\n");
+        fprintf(stderr,
+                "getnetinfo reply too short (missing multicast address), bailing out\n");
         exit(1);
     }
-    
+
     printf("Zone multicast address: ");
     bool first_octet = true;
+
     for (int i = 0; i < multicast_length; i++) {
         if (!first_octet) {
             printf(":");
         }
+
         printf("%02"PRIx8, *cursor++);
         first_octet = false;
     }
+
     printf("\n");
-    
     /* Do we have a default zone? */
     uint8_t default_zone_len = 0;
+
     if ((cursor - buf) <= len) {
         default_zone_len = *cursor++;
     }
-    
+
     if (default_zone_len > 0 && (cursor - buf) + default_zone_len > len) {
-        fprintf(stderr, "getnetinfo reply too short (insufficient room for default zone), bailing out\n");
+        fprintf(stderr,
+                "getnetinfo reply too short (insufficient room for default zone), bailing out\n");
         exit(1);
     }
-    
+
     if (default_zone_len > 0) {
         /* Yes! (We will never have a legit zone name with len = 0, it's not allowed). */
-        char* default_zone_name;
+        char *default_zone_name;
         ret = convert_string_allocate(charset, CH_UNIX, cursor, default_zone_len,
                                       &default_zone_name);
+
         if (ret == -1) {
             fprintf(stderr, "malformed default zone name, bailing out\n");
             exit(1);
         }
+
         printf("Default zone: %s\n", default_zone_name);
         free(default_zone_name);
     }
-    
+
     /* If we're trying to verify a specific zone, then bail out with exit status 2 if
        the zone is invalid. */
     if (requested_zone != NULL && (flags & ZIPGNI_INVALID)) {
@@ -440,7 +472,8 @@ static void print_gnireply(size_t len, uint8_t *buf, charset_t charset) {
     }
 }
 
-void do_query(struct sockaddr_at *dest, uint16_t network, charset_t charset) {
+void do_query(struct sockaddr_at *dest, uint16_t network, charset_t charset)
+{
     uint8_t buf[600];
     uint8_t *cursor;
     int i;
@@ -448,52 +481,55 @@ void do_query(struct sockaddr_at *dest, uint16_t network, charset_t charset) {
     uint8_t reply_type;
     int replied_zone_count = 0;
     int expected_zone_count = 0;
-    
     cursor = buf;
-    
     /* Construct packet. Layout is in IA, 2nd ed. p. 8-12 */
     *cursor++ = DDPTYPE_ZIP;
     *cursor++ = ZIPOP_QUERY;
     /* Network count = 1; we only support querying one network at a time */
-    *cursor++ = 1; 
+    *cursor++ = 1;
     *((uint16_t*)cursor) = htons(network);
     cursor += 2;
-    
     /* Send the thing */
     int sockfd = netddp_open(&laddr, NULL);
+
     if (sockfd < 0) {
         perror("netddp_open");
         exit(1);
     }
-    
+
     int length = netddp_sendto(sockfd, buf, cursor - buf, 0, (struct sockaddr*)dest,
-        sizeof(struct sockaddr_at));
+                               sizeof(struct sockaddr_at));
+
     if (length < 0) {
         perror("netddp_sendto");
         exit(1);
     }
-    
-    for(;;) {
+
+    for (;;) {
         length = netddp_recvfrom(sockfd, buf, sizeof(buf), 0, NULL, NULL);
+
         if (length < 0) {
             perror("netddp_recvfrom");
             exit(1);
         }
-        
+
         /* Is this a ZIP reply or extended reply?  If not, it's just some random
            packet that's fallen into our socket; ignore it.
            The 3 bytes here are: DDP type, ZIP Op, Num of networks */
         if (length < 3) {
             continue;
         }
+
         if (buf[0] != DDPTYPE_ZIP) {
             continue;
         }
+
         reply_type = buf[1];
+
         if (reply_type != ZIPOP_REPLY && reply_type != ZIPOP_EREPLY) {
             continue;
         }
-                
+
         if (reply_type == ZIPOP_REPLY) {
             /* A reply contains all the zones in one packet; we can bail out.
                Ignore the network count; we only asked for one network. */
@@ -503,11 +539,13 @@ void do_query(struct sockaddr_at *dest, uint16_t network, charset_t charset) {
             /* An extended reply may be spread over more than one packet; we
                need to keep track of how many we've seen and only exit once we've
                seen enough zones. */
-            
             if (expected_zone_count == 0) {
                 expected_zone_count = buf[2];
             }
-            replied_zone_count += print_and_count_zones_in_reply(buf + 3, length - 3, charset);
+
+            replied_zone_count += print_and_count_zones_in_reply(buf + 3, length - 3,
+                                  charset);
+
             if (replied_zone_count >= expected_zone_count) {
                 break;
             }
@@ -515,17 +553,19 @@ void do_query(struct sockaddr_at *dest, uint16_t network, charset_t charset) {
     }
 }
 
-static int print_and_count_zones_in_reply(char *buf, size_t len, charset_t charset) {
+static int print_and_count_zones_in_reply(char *buf, size_t len,
+        charset_t charset)
+{
     char *cursor = buf;
     int count = 0;
-    
+
     while (cursor - buf < len) {
         uint16_t network_number = 0;
         uint8_t zone_len = 0;
-        
+
         /* Proceed carefully; we don't know how many zones are in this packet, so we
            just have to iterate until we run out of packet to iterate over. */
-        
+
         /* Can we read a network number without falling off the end of the packet? */
         if ((cursor + 2) - buf <= len) {
             network_number = ntohs(*(uint16_t*)cursor);
@@ -533,34 +573,34 @@ static int print_and_count_zones_in_reply(char *buf, size_t len, charset_t chars
         } else {
             break;
         }
-        
+
         /* What about a string length? */
         if ((cursor + 1) - buf <= len) {
             zone_len = *cursor++;
         } else {
             break;
         }
-        
+
         /* How about the zone name? */
         if ((cursor + zone_len) - buf <= len) {
-            char* unix_zone_name;
+            char *unix_zone_name;
             int ret = convert_string_allocate(charset, CH_UNIX, cursor, zone_len,
                                               &unix_zone_name);
+
             if (ret == -1) {
                 fprintf(stderr, "malformed default zone name, bailing out\n");
                 exit(1);
             }
-            
+
             /* Hooray!  We got a whole tuple.  Print it, quick, before it gets away. */
             printf("%"PRIu16" %s\n", network_number, unix_zone_name);
             free(unix_zone_name);
-            
         } else {
             break;
         }
-        
+
         count++;
     }
-    
+
     return count;
 }

--- a/bin/getzones/getzones.c
+++ b/bin/getzones/getzones.c
@@ -33,7 +33,7 @@ void do_query(struct sockaddr_at *dest, uint16_t network, charset_t charset);
 
 static void usage(char *s)
 {
-    fprintf(stderr, "usage:\t%s [-m | -l | -g | -q network | -z zone ] [-c Mac charset] [address]\n", s);
+    fprintf(stderr, "usage:\t%s [-g | -l | -m | -q network | -z zone ] [-c Mac charset] [address]\n", s);
     exit(1);
 }
 
@@ -60,18 +60,19 @@ int main(int argc, char *argv[])
             }
             lookup_type = ZIPOP_GNI;
             break;
-        case 'm':
-            if (lookup_type != ZIPOP_DEFAULT) {
-                ++errflg;
-            }
-            lookup_type = ZIPOP_GETMYZONE;
-            break;
 
         case 'l':
             if (lookup_type != ZIPOP_DEFAULT) {
                 ++errflg;
             }
             lookup_type = ZIPOP_GETLOCALZONES;
+            break;
+            
+        case 'm':
+            if (lookup_type != ZIPOP_DEFAULT) {
+                ++errflg;
+            }
+            lookup_type = ZIPOP_GETMYZONE;
             break;
 
         case 'c':

--- a/doc/manpages/man1/getzones.1.md
+++ b/doc/manpages/man1/getzones.1.md
@@ -4,7 +4,7 @@ getzones — list AppleTalk zone names
 
 # Synopsis
 
-**getzones** [-m | -l] [*address*]
+**getzones** [-m | -l] [-c *Mac charset*] [*address*]
 
 # Description
 
@@ -24,6 +24,11 @@ ZIP GetMyZone request.
 
 > List the local zones; this is accomplished by sending a GetLocalZones
 request.
+
+**-c**
+
+> Sets the Macintosh character set to use when interpreting zone names.  If not specified,
+defaults to MacRoman.
 
 *address*
 

--- a/doc/manpages/man1/getzones.1.md
+++ b/doc/manpages/man1/getzones.1.md
@@ -4,7 +4,7 @@ getzones — list AppleTalk zone names
 
 # Synopsis
 
-**getzones** [-g | -m | -l] [-c *Mac charset*] [*address*]
+**getzones** [-g | -m | -l | -z *zone*] [-c *Mac charset*] [*address*]
 
 # Description
 
@@ -30,6 +30,13 @@ ZIP GetMyZone request.
 
 > List the local zones; this is accomplished by sending a GetLocalZones
 request.
+
+**-z**
+
+> Verifies whether *zone* is a valid zone for this network by sending a GetNetInfo.
+If *zone* is valid, exit with 0; if *zone* is not valid, exit with 2.  Also prints the
+network configuration including, if the zone is invalid, the default zone to use instead
+of the one requested.
 
 **-c**
 
@@ -60,6 +67,12 @@ is seeding this network;
 	Requested zone: 
 	Zone multicast address: 09:00:07:00:00:a8
 	Default zone: Ethernet
+	example$
+	
+Check whether OtherNet is a valid zone for the current network:
+
+	example$ getzones -z Othernet 0.255 >/dev/null || echo "bad zone"
+	bad zone
 	example$
 
 # See Also

--- a/doc/manpages/man1/getzones.1.md
+++ b/doc/manpages/man1/getzones.1.md
@@ -4,7 +4,7 @@ getzones — list AppleTalk zone names
 
 # Synopsis
 
-**getzones** [-g | -m | -l | -q network | -z *zone*] [-c *Mac charset*] [*address*]
+**getzones** [-g | -l | -m | -q network | -z *zone*] [-c *Mac charset*] [*address*]
 
 # Description
 
@@ -21,15 +21,15 @@ running **atalkd**(8).
 This is accomplished by sending a ZIP GetNetInfo request.  Note that only seed routers
 respond to GetNetInfo, so the usual idiom is to broadcast it.
 
-**-m**
-
-> List the name of the local zone only; this is accomplished by sending a
-ZIP GetMyZone request.
-
 **-l**
 
 > List the local zones; this is accomplished by sending a GetLocalZones
 request.
+
+**-m**
+
+> List the name of the local zone only; this is accomplished by sending a
+ZIP GetMyZone request.
 
 **-q**
 

--- a/doc/manpages/man1/getzones.1.md
+++ b/doc/manpages/man1/getzones.1.md
@@ -4,7 +4,7 @@ getzones — list AppleTalk zone names
 
 # Synopsis
 
-**getzones** [-g | -m | -l | -z *zone*] [-c *Mac charset*] [*address*]
+**getzones** [-g | -m | -l | -q network | -z *zone*] [-c *Mac charset*] [*address*]
 
 # Description
 
@@ -30,6 +30,12 @@ ZIP GetMyZone request.
 
 > List the local zones; this is accomplished by sending a GetLocalZones
 request.
+
+**-q**
+
+> List the zones available to a given network range.  This is accomplished by sending
+a ZIP Query.  Note that to query the zones available to an extended network, generally
+the first network number in the range must be used.
 
 **-z**
 

--- a/doc/manpages/man1/getzones.1.md
+++ b/doc/manpages/man1/getzones.1.md
@@ -4,7 +4,7 @@ getzones — list AppleTalk zone names
 
 # Synopsis
 
-**getzones** [-m | -l] [-c *Mac charset*] [*address*]
+**getzones** [-g | -m | -l] [-c *Mac charset*] [*address*]
 
 # Description
 
@@ -14,6 +14,12 @@ AppleTalk router. By default, it sends the request to the locally
 running **atalkd**(8).
 
 # Options
+
+**-g**
+
+> Get the current default zone and the valid network range for the current network.
+This is accomplished by sending a ZIP GetNetInfo request.  Note that only seed routers
+respond to GetNetInfo, so the usual idiom is to broadcast it.
 
 **-m**
 
@@ -34,6 +40,27 @@ defaults to MacRoman.
 
 > Contact the AppleTalk router at *address.* *address* is parsed by
 **atalk_aton**(3).
+
+# Examples
+
+Show all zones on the AppleTalk internetwork:
+
+	example$ getzones
+	Ethernet
+	LocalTalk
+	AirTalk
+	example$
+
+Get default zone and network configuration for current network from whichever router
+is seeding this network;
+
+	example$ getzones -g 0.255
+	Network range: 3-10
+	Flags (0xa0): requested-zone-invalid only-one-zone
+	Requested zone: 
+	Zone multicast address: 09:00:07:00:00:a8
+	Default zone: Ethernet
+	example$
 
 # See Also
 

--- a/doc/manpages/man1/nbp.1.md
+++ b/doc/manpages/man1/nbp.1.md
@@ -42,6 +42,9 @@ If -s is specified, output is printed in a script-friendly format: for each
 response, first the address is printed, followed by a single space, followed 
 by the name and type, followed by a linefeed.
 
+If -m is specified, strings will be interpreted in the given Macintosh character set.
+If -m is not specified, nbplkup defaults to using MacRoman.
+
 # Environment Variables
 
 NBPLKUP

--- a/include/atalk/zip.h
+++ b/include/atalk/zip.h
@@ -55,6 +55,7 @@ struct zipreplent {
 #define ZIPOP_GETLOCALZONES 9
 
 #define ZIPGNI_INVALID	0x80
+#define ZIPGNI_USEBROADCAST	0x40
 #define ZIPGNI_ONEZONE	0x20
 
 #define MAX_ZONE_LENGTH 32


### PR DESCRIPTION
The intent of this PR is to get getzones to the point it can meaningfully be used to probe ZIP with more query types than just the ATP ones.  I only ran astyle at the end, because my brain was addled, so apologies for any stylistic infelicities in earlier commits.

Most of the commit messages hopefully speak for themselves, but perhaps the strdup fix could do with a little discussion even though the code is tiny and trivial.  Essentially, the code as it is cannot work, because strdup will run off the end of the pascal string and just chunter off into memory for who knows how long.  Hooray.  However, this only ever is triggered when string conversion fails, and I'm not sure it realistically does fail except in circumstances where the fallback would also fail.  So in this PR I haven't bothered adding it to the further-down string converstions, but if you think it's worthwhile I'll do that (or if you think the whole thing is silly, I'll remove it from the place where it was).

Examples in the man page are for my own network; the AirTalk isn't there for product placement :p it's just that that's what the zone is called on my own network.  If you'd prefer to have a different zone name, though, I don't object to changing it, was just too lazy.