### PR TITLE
Remove chevrons from placeholder tokens in macro

### DIFF
--- a/test/testsuite/afparg.c
+++ b/test/testsuite/afparg.c
@@ -19,11 +19,11 @@ struct test_fn {
 #define FN_N(a,b) { # a, FN(a) , # a " " # b},
 
 static struct test_fn Test_list[] = {
-    FN_N(FPResolveID, <file CNID>)
-    FN_N(FPEnumerate, <dir>)
-    FN_N(FPCopyFile, <source> <dest>)
-    FN_N(FPLockrw, d | r <file>)
-    FN_N(FPLockw, d | r <file>)
+    FN_N(FPResolveID, CNID)
+    FN_N(FPEnumerate, dir)
+    FN_N(FPCopyFile, source dest)
+    FN_N(FPLockrw, d | r file)
+    FN_N(FPLockw, d | r file)
 
     {NULL, NULL},
 };


### PR DESCRIPTION
The chevrons aren't standard C syntax, and their inclusion outside of quotation marks confuse astyle in certain circumstances