### PR TITLE
testsuite: Use C arg to define path to test data

### DIFF
--- a/test/testsuite/T2_FPOpenFork.c
+++ b/test/testsuite/T2_FPOpenFork.c
@@ -1395,7 +1395,7 @@ STATIC void test431()
     }
 
     /* Copy resource fork */
-    if (snprintf(cmd, sizeof(cmd), "cp @datadir@/netatalk/test-data/test431_data %s/.AppleDouble/%s", Path, name) > sizeof(cmd)) {
+    if (snprintf(cmd, sizeof(cmd), "cp %s/test431_data %s/.AppleDouble/%s", _PATH_TESTDATA_DIR, Path, name) > sizeof(cmd)) {
 	if (!Quiet) {
 		fprintf(stdout,"FPOpenFork:test431: path too long\n");
 	}

--- a/test/testsuite/meson.build
+++ b/test/testsuite/meson.build
@@ -1,11 +1,5 @@
 subdir('data')
 
-t2_fpopenfork_c = configure_file(
-    input: 'T2_FPOpenFork.c.in',
-    output: 'T2_FPOpenFork.c',
-    configuration: cdata,
-)
-
 afptest_external_deps = []
 
 if threads.found()
@@ -157,14 +151,15 @@ spectest_sources = [
     'T2_Dircache_attack.c',
     'T2_FPRead.c',
     'T2_FPSetForkParms.c',
+    'T2_FPOpenFork.c',
     'encoding_test.c',
-    t2_fpopenfork_c,
 ]
 
 executable(
     'afp_spectest',
     spectest_sources,
     include_directories: root_includes,
+    c_args: ['-D_PATH_TESTDATA_DIR="' + datadir + '/netatalk/test-data"'],
     link_args: ['-rdynamic'],
     link_with: libafptest,
     install: true,


### PR DESCRIPTION
Rather than a Meson dependent substitution of the datadir, use a more portable C argument to pass the test data dir path to the C code