### PR TITLE
Add rtmpqry utility to allow querying of routing information from neighbour routers

### DIFF
--- a/bin/meson.build
+++ b/bin/meson.build
@@ -13,4 +13,5 @@ if have_appletalk
     subdir('getzones')
     subdir('nbp')
     subdir('pap')
+    subdir('rtmpqry')
 endif

--- a/bin/rtmpqry/meson.build
+++ b/bin/rtmpqry/meson.build
@@ -1,0 +1,16 @@
+getzones_deps = []
+
+if have_iconv
+    getzones_deps += iconv
+endif
+
+executable(
+    'rtmpqry',
+    'rtmpqry.c',
+    include_directories: root_includes,
+    link_with: libatalk,
+    dependencies: getzones_deps,
+    install: true,
+    build_rpath: rpath_libdir,
+    install_rpath: rpath_libdir,
+)

--- a/bin/rtmpqry/rtmpqry.c
+++ b/bin/rtmpqry/rtmpqry.c
@@ -34,10 +34,12 @@ int setup_ddp_socket(const struct at_addr *local_addr,
 void do_rtmp_rdr(int sockfd, const struct sockaddr_at *sa_remote, bool get_all,
                  int secs_timeout);
 void print_rtmp_data_packet(const uint8_t *buf, size_t len);
+void do_rtmp_request(int sockfd, struct sockaddr_at *sa_remote);
 
 static void usage(char *s)
 {
-    fprintf(stderr, "usage:\t%s [ -A local_address ] [remote_address]\n", s);
+    fprintf(stderr, "usage:\t%s [-a | -r] [ -A local_address ] [remote_address]\n",
+            s);
     exit(1);
 }
 
@@ -48,9 +50,29 @@ void main(int argc, char** argv)
     struct at_addr local_addr = { 0 };
     struct at_addr *remote_addr = NULL;
     int sockfd;
+    bool all_routes = false;
+    bool send_request = false;
 
-    while ((c = getopt(argc, argv, "A:")) != EOF) {
+    while ((c = getopt(argc, argv, "arA:")) != EOF) {
         switch (c) {
+        case 'a':
+            if (send_request) {
+                error_flag++;
+            } else {
+                all_routes = true;
+            }
+
+            break;
+
+        case 'r':
+            if (all_routes) {
+                error_flag++;
+            } else {
+                send_request = true;
+            }
+
+            break;
+
         case 'A':
             if (!atalk_aton(optarg, &local_addr)) {
                 fprintf(stderr, "Bad address.\n");
@@ -95,7 +117,12 @@ void main(int argc, char** argv)
     /* RIS socket is always 1 */
     sa_remote.sat_port = 1;
     memcpy(&sa_remote.sat_addr, remote_addr, sizeof(struct at_addr));
-    do_rtmp_rdr(sockfd, &sa_remote, true, 2);
+
+    if (send_request) {
+        do_rtmp_request(sockfd, &sa_remote);
+    } else {
+        do_rtmp_rdr(sockfd, &sa_remote, all_routes, 2);
+    }
 }
 
 /* Set up a DDP socket ready for sending RTMP packets.  The remote_addr is a pointer
@@ -122,6 +149,101 @@ int setup_ddp_socket(const struct at_addr *local_addr,
     }
 
     return sockfd;
+}
+
+/* Send an RTMP Request and wait for a reply.  An RTMP request just requests details
+   of the network this node is connected to; in general, these aren't used on extended
+   networks (instead, a ZIP GetNetInfo is used) but they should be supported anyway. */
+void do_rtmp_request(int sockfd, struct sockaddr_at *sa_remote)
+{
+    /* See Inside Appletalk 2nd ed p. 5-18 for packet layout for both request and
+       reply. */
+    uint8_t buf[600];
+    buf[0] = DDPTYPE_RTMPR;
+    buf[1] = RTMPROP_REQUEST;
+    int ret = netddp_sendto(sockfd, buf, 2, 0, (struct sockaddr*)sa_remote,
+                            (int)sizeof(struct sockaddr_at));
+
+    if (ret < 0) {
+        perror("netddp_sendto");
+        exit(1);
+    }
+
+    for (;;) {
+        int length = netddp_recvfrom(sockfd, buf, (int)sizeof(buf), 0, NULL, NULL);
+
+        if (length < 0) {
+            perror("netddp_recvfrom");
+            exit(1);
+        }
+
+        /* Is this a RTMP response?  If not, it's just some random
+           packet that's fallen into our socket; ignore it.  */
+        if (length < 5) {
+            /* 4 is DDP type + network number + id length + node.  No valid reply will be
+               shorter than this */
+            continue;
+        }
+
+        if (buf[0] != DDPTYPE_RTMPRD) {
+            continue;
+        }
+
+        /* Skip the DDP type which we checked above */
+        uint8_t *cursor = buf + 1;
+        uint16_t router_net = ntohs(*(uint16_t*)cursor);
+        cursor += 2;
+        uint8_t id_len = *cursor++;
+
+        if (id_len != 8) {
+            fprintf(stderr, "RTMP packet contained bad id length %"PRIu8" - are you "
+                            "living in an alternate timeline where DDP was extended?", id_len);
+            continue;
+        }
+
+        uint8_t router_node = *cursor++;
+        /* If this is a nonextended network, we'll now have run out of packet.  If
+           this is extended, we'll have six more bytes. */
+        uint16_t net_start = 0;
+        uint16_t net_end = 0;
+        bool extended_network = false;
+
+        if (((cursor + 6) - buf) <= length) {
+            extended_network = true;
+            net_start = ntohs(*(uint16_t*)cursor);
+            cursor += 2;
+
+            /* magic number.  Why 0x80?  Who knows! */
+            if ((*cursor++) != 0x80) {
+                fprintf(stderr, "Bad magic byte in RTMP response; giving up.");
+                exit(1);
+            }
+
+            net_end = ntohs(*(uint16_t*)cursor);
+            cursor += 2;
+            /* Another magic byte: I assume this is the RTMP version as it's the same
+               as bytes documented as RTMP version in other packets, but IA isn't
+               actually very forthcoming here. */
+            uint8_t rtmp_version = *cursor++;
+
+            if (rtmp_version != 0x82) {
+                fprintf(stderr, "Bad RTMP version 0x"PRIx8" in response; bailing out.");
+                exit(1);
+            }
+        }
+
+        /* At this point, we should have extracted all the data from the packet.
+           Now print it and quit. */
+        printf("Router: %"PRIu16".%"PRIu8"\n", router_net, router_node);
+
+        if (!extended_network) {
+            printf("Network(s): %"PRIu16"\n", router_net);
+        } else {
+            printf("Network(s): %"PRIu16" - %"PRIu16"\n", net_start, net_end);
+        }
+
+        break;
+    }
 }
 
 /* Send an RTMP Route Data Request (RDR) and wait for a reply. An RTMP RDR solicits

--- a/bin/rtmpqry/rtmpqry.c
+++ b/bin/rtmpqry/rtmpqry.c
@@ -1,5 +1,210 @@
-#include <stdio.h>
+/*
+ * Copyright (C) Rob Mitchelmore 2025
+ * All Rights Reserved.  See COPYING.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
 
-void main(int argc, char** argv) {
-	printf("honk\n");
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <sys/param.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <netatalk/at.h>
+
+#include <atalk/ddp.h>
+#include <atalk/netddp.h>
+#include <atalk/rtmp.h>
+#include <atalk/util.h>
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int setup_ddp_socket(const struct at_addr *local_addr,
+                     struct at_addr **remote_addr);
+void do_rtmp_rdr(int sockfd, const struct sockaddr_at *sa_remote, bool get_all,
+                 int secs_timeout);
+
+static void usage(char *s)
+{
+    fprintf(stderr, "usage:\t%s [ -A local_address ] [remote_address]\n", s);
+    exit(1);
+}
+
+void main(int argc, char** argv)
+{
+    int c;
+    int error_flag = 0;
+    struct at_addr local_addr = { 0 };
+    struct at_addr *remote_addr = NULL;
+    int sockfd;
+
+    while ((c = getopt(argc, argv, "A:")) != EOF) {
+        switch (c) {
+        case 'A':
+            if (!atalk_aton(optarg, &local_addr)) {
+                fprintf(stderr, "Bad address.\n");
+                exit(1);
+            }
+
+            break;
+
+        default:
+            error_flag++;
+        }
+    }
+
+    if (error_flag || argc - optind > 1) {
+        usage(argv[0]);
+    }
+
+    /* set remote address from command line if we have one */
+    if (argc > optind) {
+        remote_addr = calloc(1, sizeof(struct at_addr));
+
+        if (remote_addr == NULL) {
+            perror("calloc");
+            exit(1);
+        }
+
+        if (!atalk_aton(argv[optind], remote_addr)) {
+            fprintf(stderr, "Bad address.\n");
+            exit(1);
+        }
+    }
+
+    /* set up DDP socket - fills in the remote address if none was explicitly
+       provided */
+    sockfd = setup_ddp_socket(&local_addr, &remote_addr);
+    printf("honk %d.%d\n", (int)ntohs(remote_addr->s_net),
+           (int)remote_addr->s_node);
+    /* Construct remote sockaddr */
+    struct sockaddr_at sa_remote = { 0 };
+#ifdef BSD4_4
+    sa_remote.sat_len = sizeof(struct sockaddr_at);
+#endif /* BSD4_4 */
+    sa_remote.sat_family = AF_APPLETALK;
+    /* RIS socket is always 1 */
+    sa_remote.sat_port = 1;
+    memcpy(&sa_remote.sat_addr, remote_addr, sizeof(struct at_addr));
+    do_rtmp_rdr(sockfd, &sa_remote, true, 2);
+}
+
+/* Set up a DDP socket ready for sending RTMP packets.  The remote_addr is a pointer
+   to a pointer so that if it's null we can fill it in with the address the kernel
+   provides, as we do in libatalk/nbp/nbp_lkup.c for example. */
+int setup_ddp_socket(const struct at_addr *local_addr,
+                     struct at_addr **remote_addr)
+{
+    struct sockaddr_at local = { 0 };
+    int sockfd;
+    memcpy(&local.sat_addr, local_addr, sizeof(struct at_addr));
+    sockfd = netddp_open(&local, NULL);
+
+    if (sockfd < 0) {
+        perror("netddp_open");
+        exit(1);
+    }
+
+    /* Do we have a remote address? */
+    if (*remote_addr == NULL) {
+        /* Nope, fill it in with the address the kernel has bound us to. */
+        *remote_addr = malloc(sizeof(struct at_addr));
+        memcpy(*remote_addr, &local.sat_addr, sizeof(struct at_addr));
+    }
+
+    return sockfd;
+}
+
+/* Send an RTMP Route Data Request (RDR) and wait for a reply. An RTMP RDR solicits
+   RTMP data packets - generally, these are sent out broadcast on a timer, but one can
+   specifically ask for them to be sent to a non-standard socket by means of an RDR.
+   An RDR can also specify whether or not for the router to do split horizon
+   processing (or whether to return all routes). */
+void do_rtmp_rdr(int sockfd, const struct sockaddr_at *sa_remote, bool get_all,
+                 int secs_timeout)
+{
+    uint8_t buf[600];
+    /* First send the RDR */
+    buf[0] = DDPTYPE_RTMPR;
+
+    if (!get_all) {
+        buf[1] = RTMPROP_RDR;
+    } else {
+        buf[1] = RTMPROP_RDR_NOSH;
+    }
+
+    int ret = netddp_sendto(sockfd, buf, 2, 0, (struct sockaddr*)sa_remote,
+                            (int)sizeof(struct sockaddr_at));
+
+    if (ret < 0) {
+        perror("netddp_sendto");
+        exit(1);
+    }
+
+    /* Now, wait at least timeout_secs for replies.  We could do the whole dance that
+       the NBP code does to precisely wait for the right number of seconds - but we
+       really don't need that kind of precision, and nobody is going to really care
+       whether we wait for 2 or 2.9 seconds.  So instead we're just going to set the
+       timeout to secs_timeout + 1 so we always wait >= secs_timeout and
+       <= secs_timeout + select_timeout. */
+    /* Set up timeouts */
+    int secs_to_wait = secs_timeout + 1;
+    struct timeval select_timeout;
+    struct timeval end_time;
+    select_timeout.tv_sec = 0;
+    select_timeout.tv_usec = 250000;
+    ret = gettimeofday(&end_time, NULL);
+
+    if (ret < 0) {
+        perror("gettimeofday");
+        exit(1);
+    }
+
+    end_time.tv_sec += secs_to_wait;
+
+    /* Go around in small circles until we run out of time */
+    for (;;) {
+        fd_set fds;
+        FD_ZERO(&fds);
+        FD_SET(sockfd, &fds);
+        ret = select(sockfd + 1, &fds, NULL, NULL, &select_timeout);
+
+        if (ret < 0) {
+            perror("select");
+            exit(1);
+        }
+
+        if (ret > 0) {
+            ret = netddp_recvfrom(sockfd, buf, (int)sizeof(buf), 0, NULL, NULL);
+
+            if (ret < 0) {
+                perror("netddp_recvfrom");
+                exit(1);
+            }
+
+            printf("%d bytes\n", ret);
+        }
+
+        /* have we run out of time? */
+        struct timeval now;
+        ret = gettimeofday(&now, NULL);
+
+        if (ret < 0) {
+            perror("gettimeofday");
+            exit(1);
+        }
+
+        if (now.tv_sec >= end_time.tv_sec) {
+            break;
+        }
+    }
 }

--- a/bin/rtmpqry/rtmpqry.c
+++ b/bin/rtmpqry/rtmpqry.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+void main(int argc, char** argv) {
+	printf("honk\n");
+}

--- a/doc/manpages/man1/meson.build
+++ b/doc/manpages/man1/meson.build
@@ -16,6 +16,7 @@ if have_appletalk
         'getzones',
         'nbp',
         'pap',
+        'rtmpqry',
     ]
 endif
 

--- a/doc/manpages/man1/rtmpqry.1.md
+++ b/doc/manpages/man1/rtmpqry.1.md
@@ -1,0 +1,58 @@
+# Name
+
+rtmpqry — query AppleTalk routing information
+
+# Synopsis
+
+**rtmpqry** [-a | -r] [ -A local_address ] [remote_address]
+
+# Description
+
+**rtmpqry** is used to query and display the routing information that an
+AppleTalk router is advertising using the RTMP protocol.  By default,
+it queries the local atalkd instance.
+
+# Options
+
+**-a**
+
+> Query all routes, do not suppress those that would be dropped by split-
+horizon processing.  Generally (and if this option is omitted), routers
+do not advertise routes where, if you sent it a packet, it would send that
+packet straight back out the same interface to another router, as this would
+be pointless.  However, for visibility into the structure of the internetwork,
+it is sometimes useful to see all the routes.
+
+**-r**
+
+> Request just the RTMP network metadata, not any routes.
+
+**-A**
+
+> Bind to the local AppleTalk address given.
+
+# Examples
+
+Get network range and seed router for the current network:
+
+    example$ rtmpqry -r 0.255
+    Router: 9.239
+    Network(s): 3 - 10
+    example$
+
+Get all routes from the router at 12.1:
+
+    example$ build/bin/rtmpqry/rtmpqry -a 12.1
+    3 - 10 distance 0 via 12.1
+    11 distance 0 via 12.1
+    12 distance 0 via 12.1
+
+    example$
+
+# See Also
+
+atalk_aton(3), atalkd(8), getzones(1)
+
+# Author
+
+[Contributors to the Netatalk Project](https://netatalk.io/contributors)

--- a/include/atalk/rtmp.h
+++ b/include/atalk/rtmp.h
@@ -28,6 +28,8 @@
 #include <netatalk/endian.h>
 
 #define RTMPROP_REQUEST	1
+#define RTMPROP_RDR 2
+#define RTMPROP_RDR_NOSH 3
 
 struct rtmpent {
     u_int16_t   re_net;


### PR DESCRIPTION
This PR introduces rtmpqry, a utility to allow querying of what neighbouring routers are advertising using RTMP.  The man page and the commit messages should hopefully be enough to give you an idea of what's going on here; essentially, we can solicit an RTMP data dump using an RTMP Route Data Request, or we can ask for network metadata through an RTMP Query.  These are very confusingly named, and I've done my best to add clarity to the distinction where possible, but there's only so much can be done.