### PR TITLE
Flag a few C source files to not be formatted by astyle

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -10,6 +10,11 @@
 --delete-empty-lines
 --exclude=build
 --exclude=builddir
+--exclude=etc/afpd/directory.c
+--exclude=etc/afpd/file.c
+--exclude=libatalk/unicode/precompose.h
+--exclude=libatalk/unicode/utf16_case.c
+--exclude=libatalk/unicode/utf16_casetable.h
 --ignore-exclude-errors-x
 --indent=spaces=4
 --max-code-length=80

--- a/bin/getzones/getzones.c
+++ b/bin/getzones/getzones.c
@@ -329,7 +329,7 @@ void do_getnetinfo(struct sockaddr_at *dest, const char *zone_to_confirm,
         exit(1);
     }
 
-    ret = netddp_sendto(sockfd, buf, cursor - buf, 0, (struct sockaddr*)dest,
+    ret = netddp_sendto(sockfd, buf, cursor - buf, 0, (struct sockaddr *)dest,
                         sizeof(struct sockaddr_at));
 
     if (ret < 0) {
@@ -378,9 +378,9 @@ static void print_gnireply(ssize_t len, uint8_t *buf, charset_t charset)
     /* skip over DDP type and ZIP operation, which we checked above */
     cursor += 2;
     uint8_t flags = *cursor++;
-    uint16_t net_start = ntohs(*((uint16_t*)cursor));
+    uint16_t net_start = ntohs(*((uint16_t *)cursor));
     cursor += 2;
-    uint16_t net_end = ntohs(*((uint16_t*)cursor));
+    uint16_t net_end = ntohs(*((uint16_t *)cursor));
     cursor += 2;
     printf("Network range: %"PRIu16"-%"PRIu16"\n", net_start, net_end);
     /* Decode the flags */
@@ -492,7 +492,7 @@ void do_query(struct sockaddr_at *dest, uint16_t network, charset_t charset)
     *cursor++ = ZIPOP_QUERY;
     /* Network count = 1; we only support querying one network at a time */
     *cursor++ = 1;
-    *((uint16_t*)cursor) = htons(network);
+    *((uint16_t *)cursor) = htons(network);
     cursor += 2;
     /* Send the thing */
     int sockfd = netddp_open(&laddr, NULL);
@@ -502,7 +502,7 @@ void do_query(struct sockaddr_at *dest, uint16_t network, charset_t charset)
         exit(1);
     }
 
-    length = netddp_sendto(sockfd, buf, cursor - buf, 0, (struct sockaddr*)dest,
+    length = netddp_sendto(sockfd, buf, cursor - buf, 0, (struct sockaddr *)dest,
                            sizeof(struct sockaddr_at));
 
     if (length < 0) {
@@ -573,7 +573,7 @@ static int print_and_count_zones_in_reply(uint8_t *buf, size_t len,
 
         /* Can we read a network number without falling off the end of the packet? */
         if ((cursor + 2) - buf <= len) {
-            network_number = ntohs(*(uint16_t*)cursor);
+            network_number = ntohs(*(uint16_t *)cursor);
             cursor += 2;
         } else {
             break;

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -1012,8 +1012,8 @@ struct path *cname(struct vol *vol, struct dir *dir, char **cpath)
 
     /* 1 */
     switch (ret.m_type) {
-case 2:
-            data++;
+    case 2:
+        data++;
         len = (unsigned char) * data++;
         size = 2;
 
@@ -1024,22 +1024,22 @@ case 2:
 
         break;
 
-case 3:
-            if (vol->v_obj->afp_version >= 30) {
-                data++;
-                memcpy(&hint, data, sizeof(hint));
-                hint = ntohl(hint);
-                data += sizeof(hint);
-                memcpy(&len16, data, sizeof(len16));
-                len = ntohs(len16);
-                data += 2;
-                size = 7;
-                break;
-            }
+    case 3:
+        if (vol->v_obj->afp_version >= 30) {
+            data++;
+            memcpy(&hint, data, sizeof(hint));
+            hint = ntohl(hint);
+            data += sizeof(hint);
+            memcpy(&len16, data, sizeof(len16));
+            len = ntohs(len16);
+            data += 2;
+            size = 7;
+            break;
+        }
 
     /* else it's an error */
-default:
-            afp_errno = AFPERR_PARAM;
+    default:
+        afp_errno = AFPERR_PARAM;
         return NULL;
     }
 

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -2235,17 +2235,17 @@ static struct adouble *find_adouble(const AFPObj *obj, struct vol *vol,
 
     if (path->st_errno) {
         switch (path->st_errno) {
-    case ENOENT:
-                afp_errno = AFPERR_NOID;
+        case ENOENT:
+            afp_errno = AFPERR_NOID;
             break;
 
-    case EPERM:
+        case EPERM:
         case EACCES:
-                    afp_errno = AFPERR_ACCESS;
+            afp_errno = AFPERR_ACCESS;
             break;
 
-    default:
-                afp_errno = AFPERR_PARAM;
+        default:
+            afp_errno = AFPERR_PARAM;
             break;
         }
 


### PR DESCRIPTION
We now skip two groups of files from being formatted by astyle:

Three files under libatalk/unicode/ – generated by Perl scripts

Two files under etc/afpd/ – trigger a bug in astyle 3.6: https://gitlab.com/saalen/astyle/-/issues/26