### PR TITLE
rtmpqry: Apple clang requires an int return type for main()

### DIFF
--- a/bin/rtmpqry/rtmpqry.c
+++ b/bin/rtmpqry/rtmpqry.c
@@ -43,7 +43,7 @@ static void usage(char *s)
     exit(1);
 }
 
-void main(int argc, char** argv)
+int main(int argc, char** argv)
 {
     int c;
     int error_flag = 0;


### PR DESCRIPTION
The void return type for main() causes a hard compilation failure on Apple clang 17.0.0