### PR TITLE
Flag rtmpqry man page for localization in po4a.cfg

### DIFF
--- a/doc/po4a.cfg
+++ b/doc/po4a.cfg
@@ -16,6 +16,7 @@
 [type: text] manpages/man1/macusers.1.md $lang:translated/$lang/macusers.1.md
 [type: text] manpages/man1/nbp.1.md $lang:translated/$lang/nbp.1.md
 [type: text] manpages/man1/pap.1.md $lang:translated/$lang/pap.1.md
+[type: text] manpages/man1/rtmpqry.1.md $lang:translated/$lang/rtmpqry.1.md
 [type: text] manpages/man3/atalk_aton.3.md $lang:translated/$lang/atalk_aton.3.md
 [type: text] manpages/man3/nbp_name.3.md $lang:translated/$lang/nbp_name.3.md
 [type: text] manpages/man4/atalk.4.md $lang:translated/$lang/atalk.4.md


### PR DESCRIPTION
The newly added rtmpqry.1.md documentation file needs to be added to po4a.cfg to be picked up for translation