### PR TITLE
docs: List the rtmpqry.1 man page in the html manual index

### DIFF
--- a/doc/manual/_Sidebar.md
+++ b/doc/manual/_Sidebar.md
@@ -24,6 +24,7 @@ User Tools
 * [macusers](macusers.1.html)
 * [nbp](nbp.1.html)
 * [pap](pap.1.html)
+* [rtmpqry](rtmpqry.1.html)
 
 Configuration Files
 


### PR DESCRIPTION
Newly added man pages needs to be put in the proper spot on this index sidebar