### PR TITLE
GitHub CI: Use native meson to build on Solaris

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -700,10 +700,9 @@ jobs:
               gcc \
               libevent \
               libgcrypt \
+              meson \
               ninja \
-              pkg-config \
-              python/pip
-            pip install meson
+              pkg-config
             curl --location -o cmark.tar.gz \
               https://github.com/commonmark/cmark/archive/refs/tags/0.31.1.tar.gz
             curl --location -o iniparser.tar.gz \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -731,6 +731,7 @@ jobs:
               -Dpkg_config_path=/usr/lib/amd64/pkgconfig \
               -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
               -Dwith-iniparser-path=/usr/local \
+              -Dwith-pam=false \
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build


### PR DESCRIPTION
The Oracle Solaris 11.4.81 CBE release now ships a recent enough meson package to be able to build netatalk

release notes:

https://blogs.oracle.com/solaris/post/whats-new-in-the-oracle-solaris-11481-cbe-release

This changeset also disables PAM for Solaris for the time being since it won’t build on this CBE. Will be followed up in an issue ticket. 