### PR TITLE
Fix missing 'free' of remote_addr in rtmpqry

### DIFF
--- a/bin/rtmpqry/rtmpqry.c
+++ b/bin/rtmpqry/rtmpqry.c
@@ -123,6 +123,8 @@ int main(int argc, char** argv)
     } else {
         do_rtmp_rdr(sockfd, &sa_remote, all_routes, 2);
     }
+    
+    free(remote_addr);
 }
 
 /* Set up a DDP socket ready for sending RTMP packets.  The remote_addr is a pointer


### PR DESCRIPTION
Should address your note on #2181.  Not sure it really *matters* here hugely, since it's a command line tool with a very finite runtime, but we should be neat and not put snares in future maintainers' paths.  (I think this same laxness is perpetrated in some of the other CLI tools; I'll check as I have the energy)