### PR TITLE
Use markdown headings in the GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,28 +7,28 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+# Describe the bug
 
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+## Reproduction steps
 
 Steps to reproduce the behavior.
 
-**Expected behavior**
+## Expected behavior
 
 A clear and concise description of what you expected to happen.
 
-**Environment**
+## Environment
 
 - Server OS: [e.g. Debian Linux 12.0]
 - Client OS: [e.g. macOS Sonoma]
 - Netatalk Version: [e.g. 3.1.18]
 
-**Logs**
+## Logs
 
 Attach syslogs from the malfunctioning process, `maxdebug` log level
 
-**Additional context**
+## Additional context
 
 If it is a crash, please attach a [stacktrace](https://github.com/Netatalk/netatalk/wiki/Using-GDB-to-Analyze-a-Crash).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,18 +7,20 @@ assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+# Feature request overview
+
+Is your feature request related to a problem? Please describe.
 
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+## Describe the solution you'd like
 
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+## Describe alternatives you've considered
 
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+## Additional context
 
 Add any other context or screenshots about the feature request here.

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,6 +2,5 @@
   "default": true,
   "MD013": { "code_blocks": false, "line_length": 120, "tables": false },
   "first-line-h1": false,
-  "no-emphasis-as-heading": false,
   "single-h1": false
 }


### PR DESCRIPTION
Disable the emphasis as heading rule override for markdownlint, and convert the issue template markdown to use proper headings instead