### PR TITLE
meson: Build and link with Homebrew libraries is now opt-in

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -395,6 +395,7 @@ jobs:
         run: |
           meson setup build \
             -Dbuildtype=release \
+            -Dwith-homebrew=true \
             -Dwith-tests=true \
             -Dwith-testsuite=true
       - name: Build

--- a/meson.build
+++ b/meson.build
@@ -165,19 +165,21 @@ endif
 # note: the brew app is not visible from within the brew build wrapper iteslf,
 # so rather than checking for brew we apply a blanket prefix
 brew_prefix = ''
-if host_os == 'darwin'
-    if cpu == 'aarch64' and fs.is_dir('/opt/homebrew')
-        brew_prefix = '/opt/homebrew'
+if get_option('with-homebrew') == true
+    if host_os == 'darwin'
+        if cpu == 'aarch64' and fs.is_dir('/opt/homebrew')
+            brew_prefix = '/opt/homebrew'
+            if fs.is_dir(brew_prefix + '/include')
+                include_dirs += brew_prefix + '/include'
+            endif
+        elif cpu == 'x86_64'
+            brew_prefix = '/usr/local'
+        endif
+    elif host_os == 'linux' and fs.is_dir('/opt/linuxbrew/.linuxbrew')
+        brew_prefix = '/home/linuxbrew/.linuxbrew'
         if fs.is_dir(brew_prefix + '/include')
             include_dirs += brew_prefix + '/include'
         endif
-    elif cpu == 'x86_64'
-        brew_prefix = '/usr/local'
-    endif
-elif host_os == 'linux' and fs.is_dir('/opt/linuxbrew/.linuxbrew')
-    brew_prefix = '/home/linuxbrew/.linuxbrew'
-    if fs.is_dir(brew_prefix + '/include')
-        include_dirs += brew_prefix + '/include'
     endif
 endif
 
@@ -834,8 +836,12 @@ endif
 # Check for Spotlight support
 #
 
+bison = ''
+
 if host_os == 'darwin'
-    bison = find_program(brew_prefix / 'opt/bison/bin/bison', required: false)
+    if brew_prefix != ''
+        bison = find_program(brew_prefix / 'opt/bison/bin/bison', required: false)
+    endif
     if not bison.found()
         bison = find_program('/opt/local/bin/bison', required: false)
     endif
@@ -1903,7 +1909,7 @@ else
         cdata.set('USE_CRACKLIB', 1)
         if cracklib_path != ''
             cdata.set('_PATH_CRACKLIB', '"' + cracklib_path + '"')
-        elif host_os == 'darwin'
+        elif host_os == 'darwin' and brew_prefix != ''
             cdata.set(
                 '_PATH_CRACKLIB',
                 '"' + brew_prefix / 'var/cracklib/cracklib-words' + '"',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -88,6 +88,12 @@ option(
     description: 'Enable GSSAPI support',
 )
 option(
+    'with-homebrew',
+    type: 'boolean',
+    value: false,
+    description: 'Build and link with headers and libraries supplied by Homebrew',
+)
+option(
     'with-init-hooks',
     type: 'boolean',
     value: true,


### PR DESCRIPTION
Before, the build system would always attempt to detect an appropriate brew_prefix and then add Homebrew include and lib search paths

This causes issues when using Homebrew on Linux and attempt to build Netatalk on the side, or when building MacPorts packages on macOS

Therefore, Homebrew builds are now opt-in with the new -Dwith-homebrew boolean meson option