### PR TITLE
uams: Check for const pam_message member of pam_conv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -731,7 +731,6 @@ jobs:
               -Dpkg_config_path=/usr/lib/amd64/pkgconfig \
               -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
               -Dwith-iniparser-path=/usr/local \
-              -Dwith-pam=false \
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build

--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -136,7 +136,11 @@ error:
  * echo off means password.
  */
 static int PAM_conv(int num_msg,
+#ifdef HAVE_PAM_CONV_CONST_PAM_MESSAGE
                     const struct pam_message **msg,
+#else
+                    struct pam_message **msg,
+#endif
                     struct pam_response **resp,
                     void *appdata_ptr _U_)
 {

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -67,7 +67,11 @@ static unsigned char *PAM_password;
  * echo off means password.
  */
 static int PAM_conv(int num_msg,
+#ifdef HAVE_PAM_CONV_CONST_PAM_MESSAGE
                     const struct pam_message **msg,
+#else
+                    struct pam_message **msg,
+#endif
                     struct pam_response **resp,
                     void *appdata_ptr _U_)
 {

--- a/etc/uams/uams_pam.c
+++ b/etc/uams/uams_pam.c
@@ -47,7 +47,11 @@ extern UAM_MODULE_EXPORT void append(struct papfile *, const char *, int);
  * echo off means password.
  */
 static int PAM_conv(int num_msg,
+#ifdef HAVE_PAM_CONV_CONST_PAM_MESSAGE
                     const struct pam_message **msg,
+#else
+                    struct pam_message **msg,
+#endif
                     struct pam_response **resp,
                     void *appdata_ptr _U_)
 {

--- a/meson.build
+++ b/meson.build
@@ -1640,6 +1640,30 @@ else
             cdata.set('PAM_SESSION', 'pam_unix.so')
         endif
 
+        pam_conv_with_const_code = '''
+        #include <security/pam_appl.h>
+
+        int my_conv(int, const struct pam_message **, struct pam_response **, void *);
+
+        static struct pam_conv conv = {
+        .conv = my_conv,
+        .appdata_ptr = 0,
+        };
+
+        int main(void) {
+        return 0;
+        }
+        '''
+
+        have_pam_conv_with_const = cc.compiles(
+            pam_conv_with_const_code,
+            name: 'pam_conv with const pam_message',
+        )
+
+        if have_pam_conv_with_const
+            cdata.set('HAVE_PAM_CONV_CONST_PAM_MESSAGE', 1)
+        endif
+
         if pam_conf_path != ''
             pam_confdir += pam_conf_path
         else

--- a/meson_config.h
+++ b/meson_config.h
@@ -235,6 +235,9 @@
 /* Whether NFSv4 ACLs are available */
 #mesondefine HAVE_NFSV4_ACLS
 
+/* Whether the PAM header has a pam_conv struct with const pam_message member. */
+#mesondefine HAVE_PAM_CONV_CONST_PAM_MESSAGE
+
 /* Define to 1 if you have the <pam/pam_appl.h> header file. */
 #mesondefine HAVE_PAM_PAM_APPL_H
 


### PR DESCRIPTION
The PAM implementations of Solaris vs. other OSes differ slightly which we need to accommodate for

Namely, the `struct pam_message` member of pam_conv isn't declared with const on Solaris