### PR TITLE
spotlight: Use idiomatic NULL check to avoid compiler warning on Solaris

### DIFF
--- a/etc/spotlight/sparql_parser.y
+++ b/etc/spotlight/sparql_parser.y
@@ -153,7 +153,7 @@ static time_t isodate2unix(const char *s)
 {
     struct tm tm;
 
-    if (strptime(s, "%Y-%m-%dT%H:%M:%SZ", &tm) == NULL)
+    if (!strptime(s, "%Y-%m-%dT%H:%M:%SZ", &tm))
         return (time_t)-1;
     return mktime(&tm);
 }


### PR DESCRIPTION
Rather than casting NULL as a pointer, use the idiomatic implicit comparison in the control structure

Before, compiling on Solaris with gcc 14.2.0 led to:

```
# meson compile -C build
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /usr/bin/ninja -C /root/netatalk/build
ninja: Entering directory `/root/netatalk/build'
[93/366] Compiling C object etc/spotlight/liblibspotlight.a.p/sparql_parser.c.o
sparql_parser.y: In function ‘isodate2unix’:
sparql_parser.y:156:48: warning: comparison between pointer and integer
[134/366] Compiling C object etc/spotlight/srp.p/sparql_parser.c.o
sparql_parser.y: In function ‘isodate2unix’:
sparql_parser.y:156:48: warning: comparison between pointer and integer
[366/366] Linking target test/afpd/afpdtest
```