### PR TITLE
docker: Use named volumes in docker compose examples

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -67,7 +67,7 @@ enable the `unconfined` security option.
 
 Example for the docker compose yaml configuration file:
 
-```docker
+```yaml
     security_opt:
       - apparmor=unconfined
 ```
@@ -131,8 +131,11 @@ services:
 
 volumes:
   afpshare:
+    name: afpshare
   afpbackup:
+    name: afpbackup
   cnid_db_data:
+    name: cnid_db_data
 
 networks:
   afp_network:
@@ -189,8 +192,11 @@ services:
 
 volumes:
   afpshare:
+    name: afpshare
   afpbackup:
+    name: afpbackup
   afpconf:
+    name: afpconf
 
 networks:
   afp_network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   netatalk:
-    image: netatalk:latest
+    image: netatalk/netatalk:latest
     network_mode: "host"
     cap_add:
       - NET_ADMIN
@@ -16,4 +16,6 @@ services:
       - TZ=
 volumes:
   afpshare:
+    name: afpshare
   afpbackup:
+    name: afpbackup


### PR DESCRIPTION
Named volumes is arguably more consistent than anonymous volumes for a file sharing application

Credits to phlagios for the report / suggestion

Also changing to using a remote registry by default in the docker compose example