### PR TITLE
addump.pl: enable 'use strict'

### DIFF
--- a/contrib/shell_utils/addump.pl
+++ b/contrib/shell_utils/addump.pl
@@ -436,10 +436,7 @@ exit 0;
 
 sub filedatesdump {
     my ($ofst, $len) = @_;
-    my ($datedata);
-    my ($i);
-    my ($datestr);
-    my $buf;
+    my ($datedata, $datestr, $buf);
 
     my @datetype = ('create    ', 'modify    ', 'backup    ', 'access    ');
 
@@ -448,7 +445,7 @@ sub filedatesdump {
     print "\n";
     printf("-DATE------:          : (GMT)                    : (Local)\n");
 
-    for ($i = 0 ; $i < 4 ; $i++) {
+    for (my $i = 0 ; $i < 4 ; $i++) {
         read(INFILE, $buf, 4);
         $datedata = unpack("N", $buf);
         if ($datedata < 0x80000000) {
@@ -782,10 +779,7 @@ sub eadump {
 
 sub bedump {
     my ($ofst, $len) = @_;
-    my ($i);
-    my ($value);
-    my @bytedata;
-    my $buf;
+    my ($i, $value, $buf, @bytedata);
 
     seek(INFILE, $ofst, 0);
 
@@ -808,10 +802,7 @@ sub bedump {
 
 sub ledump {
     my ($ofst, $len) = @_;
-    my ($i);
-    my ($value);
-    my @bytedata;
-    my $buf;
+    my ($i, $value, $buf, @bytedata);
 
     seek(INFILE, $ofst, 0);
 
@@ -852,7 +843,7 @@ sub rawdump {
 
 sub hexdump {
     my ($buf, $len, $col, $delimit) = @_;
-    my ($i);
+    my $i;
 
     my $hexstr = "";
     my $ascstr = "";


### PR DESCRIPTION
This PR achieves three main goals:

- Enables the strict pragma for this script, which will make it considerably easier to work in, and fixes implicit global variable scopes that 'strict vars' didn't like (and which we shouldn't like, either).
- Fixes an old bug where the extended attributes file handle wouldn't actually be closed (I think).  Perl's close only takes one file handle; the second parameter would have been ignored, which is good, because it also I think would have got flattened into a string constant (thanks, the 1990s).
- Makes the trauma-ridden part of me that twitches every time it sees a perl script without 'use strict' at the top rest a little calmer ;-)