### PR TITLE
meson: Use single array option to control CNID backends to build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1466,9 +1466,9 @@ cnid_backends = ''
 
 # Determine whether or not to use Database Daemon CNID backend
 
-if not get_option('with-cnid-dbd-backend')
-    use_dbd_backend = false
-else
+use_dbd_backend = false
+
+if 'dbd' in get_option('with-cnid-backends')
     use_dbd_backend = true
     cnid_backends += 'dbd'
     cdata.set('CNID_BACKEND_DBD', 1)
@@ -1476,9 +1476,9 @@ endif
 
 # Determine whether or not to use LAST DID scheme
 
-if not get_option('with-cnid-last-backend')
-    use_last_backend = false
-else
+use_last_backend = false
+
+if 'last' in get_option('with-cnid-backends')
     use_last_backend = true
     if cnid_backends != ''
         cnid_backends += ' | '
@@ -1494,7 +1494,7 @@ mariadb = dependency('libmariadb', required: false)
 
 use_mysql_backend = false
 
-if get_option('with-cnid-mysql-backend')
+if 'mysql' in get_option('with-cnid-backends')
     if mysqlclient.found()
         mysql_deps = mysqlclient
     else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -16,24 +16,6 @@ option(
     description: 'Enable AFP statistics via D-Bus',
 )
 option(
-    'with-cnid-dbd-backend',
-    type: 'boolean',
-    value: true,
-    description: 'Compile CNID with Database Daemon Data Store',
-)
-option(
-    'with-cnid-last-backend',
-    type: 'boolean',
-    value: true,
-    description: 'Compile LAST CNID scheme',
-)
-option(
-    'with-cnid-mysql-backend',
-    type: 'boolean',
-    value: true,
-    description: 'Compile MySQL CNID scheme',
-)
-option(
     'with-cracklib',
     type: 'boolean',
     value: true,
@@ -396,6 +378,17 @@ option(
 
 # The following options offer a choice from pre-defined selections
 
+option(
+    'with-cnid-backends',
+    type: 'array',
+    choices: [
+        'dbd',
+        'last',
+        'mysql',
+    ],
+    value: ['dbd', 'last', 'mysql'],
+    description: 'Choose the CNID backends to build and install',
+)
 option(
     'with-cnid-default-backend',
     type: 'combo',


### PR DESCRIPTION
Rather than atomic boolean meson options, use a single option that takes a comma separated array to enable the backends

Usage examples:

-Dwith-cnid-backends=dbd,last,mysql

-Dwith-cnid-backends=dbd