### PR TITLE
Mark the 3.1 release series as EOL

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ For instance, if 4.0 and 4.1 are supported, and we release 4.2, then support for
 | 4.1.x   | ✓         | Mar 31, 2026        |
 | 4.0.x   | X         | -                   |
 | 3.2.x   | ✓         | Sep 28, 2025        |
-| 3.1.x   | ✓         | May 31, 2025        |
+| 3.1.x   | X         | -                   |
 | 3.0.x   | X         | -                   |
 | 2.4.x   | ✓         | Sep 28, 2025        |
 | < 2.4   | X         | -                   |


### PR DESCRIPTION
Update the Security Policy to indicate that the netatalk 3.1 release series is now considered End of Life, with no guarantee of security patches or releases