### PR TITLE
GitHub CI: Lock Alpine runner to 3.21 due to dependency tree failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     container:
-      image: alpine:latest
+      image: alpine:3.21
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies


### PR DESCRIPTION
Dependencies for packages not directly related to netatalk is failing in Alpine 3.22. Let's use the older image version in the meantime.