### PR TITLE
Beautify shell scripts with shfmt

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*.sh]
+indent_style       = space
+indent_size        = 4
+shell_variant      = posix
+binary_next_line   = true
+space_redirects    = true
+switch_case_indent = true
+
+[build/**]
+ignore             = true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,12 +52,14 @@ jobs:
               brew install \
                 astyle \
                 muon \
-                perltidy
+                perltidy \
+                shfmt
         - name: Check formatting
           run: |
               ./contrib/scripts/codefmt.sh -v -s c
               ./contrib/scripts/codefmt.sh -v -s meson
               ./contrib/scripts/codefmt.sh -v -s perl
+              ./contrib/scripts/codefmt.sh -v -s shell
 
     markdown-linting:
         name: Markdown Linting

--- a/contrib/scripts/codefmt.sh
+++ b/contrib/scripts/codefmt.sh
@@ -25,26 +25,26 @@ usage() {
 }
 
 while getopts "vs:" opt; do
-  case $opt in
-    v)
-      VERBOSE=1
-      ;;
-    s)
-      SOURCE_TYPE="$OPTARG"
-      if [ "$SOURCE_TYPE" != "c" ] && [ "$SOURCE_TYPE" != "meson" ] && [ "$SOURCE_TYPE" != "perl" ] && [ "$SOURCE_TYPE" != "shell" ]; then
-        echo "Error: Source type must be either 'c', 'meson', 'perl', or 'shell'"
-        usage
-        exit 2
-      fi
-      ;;
-    *)
-      usage
-      exit 2
-      ;;
-  esac
+    case $opt in
+        v)
+            VERBOSE=1
+            ;;
+        s)
+            SOURCE_TYPE="$OPTARG"
+            if [ "$SOURCE_TYPE" != "c" ] && [ "$SOURCE_TYPE" != "meson" ] && [ "$SOURCE_TYPE" != "perl" ] && [ "$SOURCE_TYPE" != "shell" ]; then
+                echo "Error: Source type must be either 'c', 'meson', 'perl', or 'shell'"
+                usage
+                exit 2
+            fi
+            ;;
+        *)
+            usage
+            exit 2
+            ;;
+    esac
 done
 
-if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
     echo "Warning: Not inside a git repository; no diff will be produced"
 else
     IS_GIT=1
@@ -53,7 +53,7 @@ else
 fi
 
 if [ "$SOURCE_TYPE" = "c" ] || [ "$SOURCE_TYPE" = "" ]; then
-    if command -v astyle >/dev/null 2>&1; then
+    if command -v astyle > /dev/null 2>&1; then
         FORMATTER_CMD="astyle --options=.astylerc --recursive --suffix=none"
         if [ $VERBOSE -eq 1 ]; then
             echo "Formatting C sources..."
@@ -68,9 +68,9 @@ if [ "$SOURCE_TYPE" = "c" ] || [ "$SOURCE_TYPE" = "" ]; then
 fi
 
 if [ "$SOURCE_TYPE" = "meson" ] || [ "$SOURCE_TYPE" = "" ]; then
-    if command -v muon >/dev/null 2>&1; then
+    if command -v muon > /dev/null 2>&1; then
         FORMATTER_CMD="muon"
-    elif command -v muon-meson >/dev/null 2>&1; then
+    elif command -v muon-meson > /dev/null 2>&1; then
         FORMATTER_CMD="muon-meson"
     else
         echo "Error: No variant of muon found in PATH"
@@ -85,7 +85,7 @@ if [ "$SOURCE_TYPE" = "meson" ] || [ "$SOURCE_TYPE" = "" ]; then
 fi
 
 if [ "$SOURCE_TYPE" = "perl" ] || [ "$SOURCE_TYPE" = "" ]; then
-    if command -v perltidy >/dev/null 2>&1; then
+    if command -v perltidy > /dev/null 2>&1; then
         if [ "$VERBOSE" -eq 1 ]; then
             echo "Formatting Perl sources..."
             find . -type f \( -name "*.pl" -o -name "*.cgi" \) -exec sh -c '
@@ -104,7 +104,7 @@ if [ "$SOURCE_TYPE" = "perl" ] || [ "$SOURCE_TYPE" = "" ]; then
 fi
 
 if [ "$SOURCE_TYPE" = "shell" ] || [ "$SOURCE_TYPE" = "" ]; then
-    if command -v shfmt >/dev/null 2>&1; then
+    if command -v shfmt > /dev/null 2>&1; then
         if [ $VERBOSE -eq 1 ]; then
             echo "Formatting shell scripts..."
             find . -name "*.sh" -exec sh -c '

--- a/contrib/scripts/codefmt.sh
+++ b/contrib/scripts/codefmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Recursively format source files in the current repo directory
 #
@@ -60,7 +60,7 @@ if [ "$SOURCE_TYPE" = "c" ] || [ "$SOURCE_TYPE" = "" ]; then
         else
             FORMATTER_CMD="$FORMATTER_CMD --quiet"
         fi
-        $FORMATTER_CMD '*.h' '*.c'
+        eval "$FORMATTER_CMD '*.h' '*.c'"
     else
         echo "Error: astyle not found in PATH"
         exit 2
@@ -89,7 +89,7 @@ if [ "$SOURCE_TYPE" = "perl" ] || [ "$SOURCE_TYPE" = "" ]; then
         if [ "$VERBOSE" -eq 1 ]; then
             echo "Formatting Perl sources..."
             find . -type f \( -name "*.pl" -o -name "*.cgi" \) -exec sh -c '
-                for file do
+                for file in "$@"; do
                     echo "Processing: $file"
                     perltidy --backup-file-extension="/" "$file"
                 done
@@ -108,7 +108,7 @@ if [ "$SOURCE_TYPE" = "shell" ] || [ "$SOURCE_TYPE" = "" ]; then
         if [ $VERBOSE -eq 1 ]; then
             echo "Formatting shell scripts..."
             find . -name "*.sh" -exec sh -c '
-                for file do
+                for file in "$@"; do
                     echo "Processing: $file"
                     shfmt -w "$file"
                 done

--- a/contrib/scripts/fce_ev_script.sh
+++ b/contrib/scripts/fce_ev_script.sh
@@ -14,49 +14,58 @@ where:
 "
 
 while getopts ':hs:v:e:P:S:u:p:i:' option; do
-  case "$option" in
-    h) echo "$usage"
-       exit
-       ;;
-    v) version=$OPTARG
-       ;;
-    e) event=$OPTARG
-       ;;
-    P) path=$OPTARG
-       ;;
-    S) srcpath=$OPTARG
-       ;;
-    u) user=$OPTARG
-       ;;
-    p) pid=$OPTARG
-       ;;
-    i) evid=$OPTARG
-       ;;
-    ?) printf "illegal option: '%s'\n" "$OPTARG" >&2
-       echo "$usage" >&2
-       exit 1
-       ;;
-  esac
+    case "$option" in
+        h)
+            echo "$usage"
+            exit
+            ;;
+        v)
+            version=$OPTARG
+            ;;
+        e)
+            event=$OPTARG
+            ;;
+        P)
+            path=$OPTARG
+            ;;
+        S)
+            srcpath=$OPTARG
+            ;;
+        u)
+            user=$OPTARG
+            ;;
+        p)
+            pid=$OPTARG
+            ;;
+        i)
+            evid=$OPTARG
+            ;;
+        ?)
+            printf "illegal option: '%s'\n" "$OPTARG" >&2
+            echo "$usage" >&2
+            exit 1
+            ;;
+    esac
 done
 shift $((OPTIND - 1))
 
 printf "FCE Event: $event" >> /tmp/fce.log
-if [ -n "$version" ] ; then
+if [ -n "$version" ]; then
     printf ", protocol: $version" >> /tmp/fce.log
 fi
-if [ -n "$evid" ] ; then
+if [ -n "$evid" ]; then
     printf ", ID: $evid" >> /tmp/fce.log
 fi
-if [ -n "$pid" ] ; then
+if [ -n "$pid" ]; then
     printf ", pid: $pid" >> /tmp/fce.log
 fi
-if [ -n "$user" ] ; then
+if [ -n "$user" ]; then
     echo -n ", user: $user" >> /tmp/fce.log
 fi
-if [ -n "$srcpath" ] ; then
+if [ -n "$srcpath" ]; then
     echo -n ", source: $srcpath" >> /tmp/fce.log
 fi
-if [ -n "$path" ] ; then
+if [ -n "$path" ]; then
     echo -n ", path: $path" >> /tmp/fce.log
 fi
 printf "\n" >> /tmp/fce.log

--- a/contrib/scripts/netatalk_container_entrypoint.sh
+++ b/contrib/scripts/netatalk_container_entrypoint.sh
@@ -26,7 +26,7 @@ set -e
 
 DISTRO="unknown"
 if [ -f /etc/os-release ]; then
-    DISTRO=`grep -E '^ID=' /etc/os-release | cut -d= -f2 | tr -d '"'`
+    DISTRO=$(grep -E '^ID=' /etc/os-release | cut -d= -f2 | tr -d '"')
     echo "Detected Linux distribution: $DISTRO"
 else
     echo "WARNING: /etc/os-release not found; are we running on Linux?"
@@ -47,7 +47,6 @@ if [ -z "$AFP_GROUP" ]; then
     exit 1
 fi
 
-
 if [ "$DISTRO" = "alpine" ]; then
     uidcmd=""
     gidcmd=""
@@ -57,8 +56,8 @@ if [ "$DISTRO" = "alpine" ]; then
     if [ -n "$AFP_GID" ]; then
         gidcmd="-g $AFP_GID"
     fi
-    adduser $uidcmd --no-create-home --disabled-password "$AFP_USER" 2>/dev/null || true
-    addgroup $gidcmd "$AFP_GROUP" 2>/dev/null || true
+    adduser $uidcmd --no-create-home --disabled-password "$AFP_USER" 2> /dev/null || true
+    addgroup $gidcmd "$AFP_GROUP" 2> /dev/null || true
     addgroup "$AFP_USER" "$AFP_GROUP"
 else
     cmd=""
@@ -94,7 +93,7 @@ if [ -n "$AFP_DROPBOX" ]; then
     fi
 elif [ -n "$AFP_USER2" ]; then
     if [ "$DISTRO" = "alpine" ]; then
-        adduser --no-create-home --disabled-password "$AFP_USER2" 2>/dev/null || true
+        adduser --no-create-home --disabled-password "$AFP_USER2" 2> /dev/null || true
         addgroup "$AFP_USER2" "$AFP_GROUP"
     else
         adduser --no-create-home --disabled-password --gecos '' "$AFP_USER2" 2> /dev/null || true
@@ -220,7 +219,7 @@ if [ -n "$AFP_CONFIG_POLLING" ]; then
 fi
 
 if [ -z "$MANUAL_CONFIG" ]; then
-    cat <<EOF > /etc/netatalk/afp.conf
+    cat << EOF > /etc/netatalk/afp.conf
 [Global]
 appletalk = $AFP_DDP
 cnid mysql host = $AFP_CNID_SQL_HOST

--- a/contrib/scripts/webmin_container_entrypoint.sh
+++ b/contrib/scripts/webmin_container_entrypoint.sh
@@ -23,7 +23,7 @@ set -e
 
 handle_sigterm() {
     echo "*** Received SIGTERM, shutting down Webmin..."
-    if [ -n "$MINISERV_PID" ] && kill -0 "$MINISERV_PID" 2>/dev/null; then
+    if [ -n "$MINISERV_PID" ] && kill -0 "$MINISERV_PID" 2> /dev/null; then
         kill "$MINISERV_PID"
         wait "$MINISERV_PID"
     fi

--- a/doc/manpages/make_man.sh
+++ b/doc/manpages/make_man.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 if [ "$#" -ne 5 ]; then
-  echo "Usage: $0 <transcoder> <file> <manpage> <section> <version>"
-  exit 1
+    echo "Usage: $0 <transcoder> <file> <manpage> <section> <version>"
+    exit 1
 fi
 
 transcoder="$1"
@@ -16,10 +16,10 @@ transcoder_name=$(basename "${transcoder}")
 echo ".TH \"${man}\" \"${sec}\" \"\" \"Netatalk ${ver}\" \"Netatalk AFP Fileserver Manual\""
 
 if [ "${transcoder_name}" = "pandoc" ]; then
-  ${transcoder} --from commonmark --to man ${input}
+    ${transcoder} --from commonmark --to man ${input}
 elif [ "${transcoder_name}" = "cmark" ] || [ "${transcoder_name}" = "cmark-gfm" ]; then
-  ${transcoder} --smart --to man ${input}
+    ${transcoder} --smart --to man ${input}
 else
-  echo "Unknown transcoder: ${transcoder_name}"
-  exit 1
+    echo "Unknown transcoder: ${transcoder_name}"
+    exit 1
 fi

--- a/test/afpd/test.sh
+++ b/test/afpd/test.sh
@@ -1,15 +1,15 @@
 #!/bin/sh
-if [ ! -d /tmp/AFPtestvolume ] ; then
+if [ ! -d /tmp/AFPtestvolume ]; then
     mkdir -p /tmp/AFPtestvolume
-    if [ $? -ne 0 ] ; then
+    if [ $? -ne 0 ]; then
         echo Error creating AFP test volume /tmp/AFPtestvolume
         exit 1
     fi
 fi
 
-if [ ! -f test.conf ] ; then
+if [ ! -f test.conf ]; then
     echo -n "Creating configuration template ... "
-    cat > test.conf <<EOF
+    cat > test.conf << EOF
 [Global]
 afp port = 10548
 


### PR DESCRIPTION
Create an .editorconfig code styling config file with shfmt compatible directives, while adding support for shell formatting in the codefmt.sh shell script

The codefmt.sh script has been refactored to be POSIX compatible, which enables us to enforce POSIX standards on all shell scripts in this repo

Finally, run shfmt with the new rules against all shell scripts in the repo to beautify them

These formatting rules are now enforced in the Tests CI workflow