### PR TITLE
GitHub CI: Enable Arch Linux job again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,6 @@ jobs:
         run: ninja -C build uninstall
 
   build-archlinux:
-    if: false
     name: Arch Linux
     runs-on: ubuntu-latest
     timeout-minutes: 12


### PR DESCRIPTION
This is to turn on the Arch build job again once they've recovered their dependency tree