### PR TITLE
docs: Improve AppleTalk manual and developer readmes

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,15 +1,15 @@
 Information for Netatalk Developers
 ===================================
 
-For basic installation instructions, see the Installation chapter
-in the html manual published on the [Netatalk homepage](https://netatalk.io)
-and the [Installation Quick Start Guide](https://netatalk.io/install).
+To get started with a development environment, read the
+[https://netatalk.io/manual/en/Installation](Installation chapter)
+in the Netatalk manual, followed by the
+[Installation Quick Start Guide](https://netatalk.io/install).
 
 Netatalk is an implementation of Apple Filing Protocol (AFP) over TCP.
 The session layer used to carry AFP over TCP is called DSI.
-
 Netatalk also supports the AppleTalk Protocol Suite for legacy Macs,
-Lisas and Apple IIs via the "atalkd" daemon.
+Lisas and Apple IIs via the **atalkd** daemon.
 
 The complete stack looks like this on a BSD-derived system:
 
@@ -79,41 +79,46 @@ Examples
 stat() without EC macro:
 
 ```c
-  static int func(const char *name) {
+static int func(const char *name) {
     int ret = 0;
     ...
     if ((ret = stat(name, &some_struct_stat)) != 0) {
-      LOG(...);
-      ret = -1; /* often needed to explicitly set the error indicating return value */
-      goto cleanup;
+        LOG(...);
+        /* often needed to explicitly set the error indicating return value */
+        ret = -1;
+        goto cleanup;
     }
 
     return ret;
 
-  cleanup:
+    cleanup:
     ...
     return ret;
-  }
+}
 ```
 
 stat() with EC macro:
 
 ```c
-  static int func(const char *name) {
-    EC_INIT; /* expands to int ret = 0; */
+static int func(const char *name) {
+    /* expands to int ret = 0; */
+    EC_INIT;
 
-    char *uppername = NULL
+    char *uppername = NULL;
     EC_NULL(uppername = strdup(name));
     EC_ZERO(strtoupper(uppername));
 
-    EC_ZERO(stat(uppername, &some_struct_stat)); /* expands to complete if block from above */
+    /* expands to complete if block from above */
+    EC_ZERO(stat(uppername, &some_struct_stat));
 
     EC_STATUS(0);
 
 EC_CLEANUP:
-    if (uppername) free(uppername);
+    if (uppername) {
+        free(uppername);
+    }
     EC_EXIT;
-  }
+}
 ```
 
 A boilerplate function template is:

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -10,8 +10,6 @@ The session layer used to carry AFP over TCP is called DSI.
 
 Netatalk also supports the AppleTalk Protocol Suite for legacy Macs,
 Lisas and Apple IIs via the "atalkd" daemon.
-It supports EtherTalk Phase I and II, RTMP, NBP, ZIP, AEP, ATP,
-PAP, and ASP, while expecting the kernel to supply DDP.
 
 The complete stack looks like this on a BSD-derived system:
 
@@ -32,18 +30,6 @@ The complete stack looks like this on a BSD-derived system:
     |                Network-Interface                  |
     +---------------------------------------------------+
 ```
-
-* DDP is a socket to socket protocol that all other AppleTalk protocols
-  are built on top of.
-
-* "atalkd" implements RTMP, NBP, ZIP, and AEP.
-  It is the AppleTalk equivalent of Unix "routed".
-
-* There is also a client-stub library for NBP.
-  ATP and ASP are implemented as libraries.
-
-* "papd" allows Macs to spool to "lpd", and "pap" allows Unix
-  machines to print to AppleTalk connected printers.
 
 When built without AppleTalk support, the network stack looks something like this:
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,10 +48,11 @@ documentation for more details.
 
 ### Required to Build
 
-| Package | Details |
-|---------|---------|
-| meson   | v0.61.2 or later |
-| ninja   | Often packaged as `ninja-build` |
+| Package    | Details |
+|------------|---------|
+| C compiler | clang or gcc are recommended |
+| meson      | v0.61.2 or later |
+| ninja      | Often packaged as `ninja-build` |
 
 ### Required for Spotlight Support
 

--- a/doc/manual/AppleTalk.md
+++ b/doc/manual/AppleTalk.md
@@ -10,8 +10,25 @@ connections, and the like.
 Netatalk implements the AppleTalk protocols to serve files over AFP and
 provide other services to old Mac and Apple II clients.
 
-A complete overview can be found inside the [developer
-documentation](/appletalk.html).
+It supports EtherTalk Phase I and II, RTMP, NBP, ZIP, AEP, ATP,
+PAP, and ASP, while expecting the host OS kernel to supply DDP.
+
+- DDP is a socket to socket protocol that all other AppleTalk protocols
+  are built on top of.
+
+- ATP, ASP, and NBP are implemented as statically linked libraries
+  in Netatalk's *libatalk* shared library.
+
+- The **atalkd** daemon implements RTMP, ZIP, and AEP.
+  It is the AppleTalk equivalent of Unix **routed**.
+
+- The **papd** daemon allows Macs to spool to **lpd**,
+  while the **pap** application allows Unix machines to print to
+  AppleTalk connected printers.
+
+A diagram of the network stack can be found inside the [developer
+readme](/developer.html), while the latest information about DDP support
+in the kernel can be found in the [AppleTalk readme](/appletalk.html).
 
 ### To use AppleTalk or not
 


### PR DESCRIPTION
- Move info on AppleTalk protocols from the DEVELOPER readme to the html manual
- Opening paragraphs in the DEVELOPER readme get a clearer intention
- Sample C code in DEVELOPER readme should follow our own style guide
- Call out which C compilers are recommended in INSTALL readme