### PR TITLE
Restore order of original copyright paragraphs, and remove Sun blurb

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -11,18 +11,16 @@ All Rights Reserved.
     permission. This software is supplied as is without expressed or
     implied warranties of any kind.
 
-This product includes software developed by the University of
-California, Berkeley and its contributors.
+    This product includes software developed by the University of
+    California, Berkeley and its contributors.
 
-Solaris code is encumbered by the following:
-    Copyright (C) 1996 by Sun Microsystems Computer Co.
-
-    Permission to use, copy, modify, and distribute this software and
-    its documentation for any purpose and without fee is hereby
-    granted, provided that the above copyright notice appear in all
-    copies and that both that copyright notice and this permission
-    notice appear in supporting documentation.  This software is
-    provided "as is" without express or implied warranty.
+    Research Systems Unix Group
+    The University of Michigan
+    c/o Wesley Craig
+    535 W. William Street
+    Ann Arbor, Michigan
+    +1-313-764-2278
+    netatalk@umich.edu
 
 Modifications for Appleshare IP and other files copyrighted by Adrian
 Sun are under the following copyright:
@@ -36,11 +34,3 @@ Sun are under the following copyright:
     that both that copyright notice and this permission notice appear
     in supporting documentation. This software is supplied as is
     without expressed or implied warranties of any kind.
-
-Research Systems Unix Group
-The University of Michigan
-c/o Wesley Craig
-535 W. William Street
-Ann Arbor, Michigan
-+1-313-764-2278
-netatalk@umich.edu


### PR DESCRIPTION
In the netatalk v1.3.3 distribution, the COPYRIGHT header had the University of Michigan address immediately following the original copyright blurb

In subsequent releases, it got pushed further and further down by other copyright holders, which arguably breaks the context of the address

Also, all code copyrighted by Sun Microsystems was removed with netatalk v3.0 (everything under sys/solaris) so the Sun copyright blurb is no longer relevant