### PR TITLE
meson: Define library rpath for testsuite executables

### DIFF
--- a/test/testsuite/meson.build
+++ b/test/testsuite/meson.build
@@ -32,6 +32,8 @@ executable(
     link_args: ['-rdynamic'],
     link_with: libafptest,
     install: true,
+    install_rpath: rpath_libdir,
+    build_rpath: rpath_libdir,
 )
 
 lantest_sources = [
@@ -45,6 +47,8 @@ executable(
     dependencies: afptest_external_deps,
     link_with: libafptest,
     install: true,
+    install_rpath: rpath_libdir,
+    build_rpath: rpath_libdir,
 )
 
 login_test_sources = [
@@ -58,6 +62,8 @@ executable(
     link_args: ['-rdynamic'],
     link_with: libafptest,
     install: true,
+    install_rpath: rpath_libdir,
+    build_rpath: rpath_libdir,
 )
 
 speedtest_sources = [
@@ -71,6 +77,8 @@ executable(
     link_args: ['-rdynamic'],
     link_with: libafptest,
     install: true,
+    install_rpath: rpath_libdir,
+    build_rpath: rpath_libdir,
 )
 
 spectest_sources = [
@@ -161,4 +169,6 @@ executable(
     link_args: ['-rdynamic'],
     link_with: libafptest,
     install: true,
+    install_rpath: rpath_libdir,
+    build_rpath: rpath_libdir,
 )


### PR DESCRIPTION
The dynamic linker on macOS couldn't find libatalk under certain circumstances when rpaths weren't explicitly set