### PR TITLE
docker: Lock container images to specific index digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ARG BUILD_DEPS="\
     talloc-dev \
     tinysparql-dev"
 
-FROM alpine:3.22 AS build
+FROM alpine:3.22@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715 AS build
 
 ARG RUN_DEPS
 ARG BUILD_DEPS
@@ -70,7 +70,7 @@ RUN meson setup build \
 
 RUN meson install --destdir=/staging/ -C build
 
-FROM alpine:3.22 AS deploy
+FROM alpine:3.22@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715 AS deploy
 
 ARG RUN_DEPS
 ENV RUN_DEPS=$RUN_DEPS

--- a/testsuite_alp.Dockerfile
+++ b/testsuite_alp.Dockerfile
@@ -39,7 +39,7 @@ ARG BUILD_DEPS="\
     talloc-dev \
     tinysparql-dev"
 
-FROM alpine:3.22 AS build
+FROM alpine:3.22@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715 AS build
 
 ARG RUN_DEPS
 ARG BUILD_DEPS
@@ -72,7 +72,7 @@ RUN meson setup build \
 
 RUN meson install --destdir=/staging/ -C build
 
-FROM alpine:3.22 AS deploy
+FROM alpine:3.22@sha256:8a1f59ffb675680d47db6337b49d22281a139e9d709335b492be023728e11715 AS deploy
 
 ARG RUN_DEPS
 ENV RUN_DEPS=$RUN_DEPS

--- a/testsuite_deb.Dockerfile
+++ b/testsuite_deb.Dockerfile
@@ -52,7 +52,7 @@ ARG BUILD_DEPS="\
     systemtap-sdt-dev\
     "
 
-FROM debian:trixie-slim AS build
+FROM debian:trixie-slim@sha256:1fb8e914b9c7e1bb8576766b44c474b07f0e370fd12ce2083078af3cb72f4545 AS build
 
 ARG RUN_DEPS
 ARG BUILD_DEPS
@@ -89,7 +89,7 @@ RUN meson setup build \
 
 RUN meson install --destdir=/staging/ -C build
 
-FROM debian:trixie-slim AS deploy
+FROM debian:trixie-slim@sha256:1fb8e914b9c7e1bb8576766b44c474b07f0e370fd12ce2083078af3cb72f4545 AS deploy
 
 ARG RUN_DEPS
 ENV RUN_DEPS=$RUN_DEPS

--- a/webmin_module.Dockerfile
+++ b/webmin_module.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:e5865e6858dacc255bead044a7f2d0ad8c362433cfaa5acefb670c1edf54dfef
 
 ARG RUN_DEPS="\
     ca-certificates \


### PR DESCRIPTION
This applies the muli-arch index digest hashes to the images that we use in Dockerfiles, to prevent potential supply chain attacks