### PR TITLE
GitHub CI: Use read-only workflow permissions to the greatest degree

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,4 @@
+name: Builds
 on:
   push:
     branches:
@@ -26,7 +27,7 @@ on:
       - "COPYRIGHT"
       - "*Dockerfile"
 
-name: Builds
+permissions: read-all
 
 jobs:
   build-alpine:
@@ -422,8 +423,6 @@ jobs:
     name: DragonflyBSD
     runs-on: ubuntu-latest
     timeout-minutes: 12
-    permissions:
-      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -468,8 +467,6 @@ jobs:
     name: FreeBSD
     runs-on: ubuntu-latest
     timeout-minutes: 12
-    permissions:
-      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -518,8 +515,6 @@ jobs:
     name: NetBSD
     runs-on: ubuntu-latest
     timeout-minutes: 12
-    permissions:
-      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -576,8 +571,6 @@ jobs:
     name: OpenBSD
     runs-on: ubuntu-latest
     timeout-minutes: 12
-    permissions:
-      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -630,8 +623,6 @@ jobs:
     name: OmniOS
     runs-on: ubuntu-latest
     timeout-minutes: 12
-    permissions:
-      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -683,8 +674,6 @@ jobs:
     name: Solaris
     runs-on: ubuntu-latest
     timeout-minutes: 12
-    permissions:
-      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,3 +1,4 @@
+name: Containers
 on:
     push:
         branches: [ "main" ]
@@ -18,11 +19,10 @@ on:
           - "contrib/webmin_module/**"
           - "COPYRIGHT"
 
+permissions: read-all
 env:
     REGISTRY: ghcr.io
     REPO: ${{ github.repository }}
-
-name: Containers
 
 jobs:
     build-container:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [ "main" ]
 
-# Declare default permissions as read only.
 permissions: read-all
 
 jobs:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,3 +1,4 @@
+name: Deploy static content to Pages
 on:
   push:
     branches: ["main"]
@@ -6,22 +7,16 @@ on:
       - 'doc/**'
       - 'meson.build'
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
-
-name: Deploy static content to Pages
 
 jobs:
   deploy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+name: Tests
 on:
   push:
     branches:
@@ -20,7 +21,7 @@ on:
         - "**/COPYRIGHT"
         - "**/README"
 
-name: Tests
+permissions: read-all
 
 jobs:
     formatting:


### PR DESCRIPTION
By default, we should only allow read-only access to the jobs

This also cleans up the yaml structure a bit and removes redundant comments