### PR TITLE
GitHub CI: Always run the Tests workflow on all file changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,6 @@ on:
     branches:
       - main
       - branch-*
-    paths-ignore:
-      - "**/COPYING"
-      - "**/COPYRIGHT"
-      - "**/README"
   pull_request:
     branches:
       - main
@@ -16,10 +12,6 @@ on:
       - opened
       - synchronize
       - reopened
-    paths-ignore:
-        - "**/COPYING"
-        - "**/COPYRIGHT"
-        - "**/README"
 
 permissions: read-all
 


### PR DESCRIPTION
Running the Tests jobs is fairly cheap, and may reveal issues with any kind of file