### PR TITLE
Create SELinux policy for netatalk daemons

### DIFF
--- a/distrib/selinux/README.md
+++ b/distrib/selinux/README.md
@@ -1,0 +1,43 @@
+# Netatalk SELinux Policy Module
+
+This directory contains a SELinux policy module for Netatalk that provides security contexts and rules for
+running Netatalk services on SELinux-enabled systems.
+
+## Quick Start
+
+To build and install the policy module:
+
+```shell
+./netatalk.sh
+```
+
+This will compile the policy, install it, and generate an RPM package for distribution.
+
+## Policy Overview
+
+The policy defines the following security contexts:
+
+- _netatalk_t_ - Domain for Netatalk processes
+- _netatalk_exec_t_ - Type for executable files
+- _netatalk_etc_t_ - Type for configuration files
+- _netatalk_var_lib_t_ - Type for variable data
+- _netatalk_lock_t_ - Type for lock files
+- _netatalk_log_t_ - Type for log files
+
+## Troubleshooting
+
+If you encounter AVC denials, you can update the policy by running:
+
+```shell
+./netatalk.sh --update
+```
+
+This will analyze the audit log for new required permissions and offer to update the policy accordingly.
+
+## Further Reading
+
+For detailed information about SELinux policies and security contexts:
+
+- [SELinux Project Wiki](https://github.com/SELinuxProject/selinux/wiki)
+- [Red Hat SELinux Guide](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/using_selinux/index)
+- [Fedora SELinux Guide](https://docs.fedoraproject.org/en-US/quick-docs/getting-started-with-selinux/)

--- a/distrib/selinux/netatalk.fc
+++ b/distrib/selinux/netatalk.fc
@@ -1,0 +1,21 @@
+# Netatalk executables - all run in the same domain due to forking structure
+/usr/sbin/netatalk               --      gen_context(system_u:object_r:netatalk_exec_t,s0)
+/usr/sbin/afpd                   --      gen_context(system_u:object_r:netatalk_exec_t,s0)
+/usr/sbin/cnid_metad             --      gen_context(system_u:object_r:netatalk_exec_t,s0)
+/usr/sbin/cnid_dbd               --      gen_context(system_u:object_r:netatalk_exec_t,s0)
+
+# Configuration files
+/etc/netatalk(/.*)?                      gen_context(system_u:object_r:netatalk_etc_t,s0)
+/etc/netatalk/afp\.conf          --      gen_context(system_u:object_r:netatalk_etc_t,s0)
+/etc/netatalk/dbus-session\.conf --      gen_context(system_u:object_r:netatalk_etc_t,s0)
+/etc/netatalk/extmap\.conf       --      gen_context(system_u:object_r:netatalk_etc_t,s0)
+
+# Variable data
+/var/lib/netatalk/CNID(/.*)?             gen_context(system_u:object_r:netatalk_var_lib_t,s0)
+/var/lib/netatalk/afp_signature\.conf -- gen_context(system_u:object_r:netatalk_var_lib_t,s0)
+/var/lib/netatalk/afp_voluuid\.conf   -- gen_context(system_u:object_r:netatalk_var_lib_t,s0)
+/var/lock/netatalk(/.*)?                 gen_context(system_u:object_r:netatalk_lock_t,s0)
+
+# Log files
+/var/log/netatalk\.log           --      gen_context(system_u:object_r:netatalk_log_t,s0)
+/var/log/netatalk(/.*)?                  gen_context(system_u:object_r:netatalk_log_t,s0)

--- a/distrib/selinux/netatalk.if
+++ b/distrib/selinux/netatalk.if
@@ -1,0 +1,93 @@
+
+## <summary>policy for netatalk</summary>
+
+########################################
+## <summary>
+##      Execute netatalk_exec_t in the netatalk domain.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed to transition.
+##      </summary>
+## </param>
+#
+interface(`netatalk_domtrans',`
+        gen_require(`
+                type netatalk_t, netatalk_exec_t;
+        ')
+
+        corecmd_search_bin($1)
+        domtrans_pattern($1, netatalk_exec_t, netatalk_t)
+')
+
+########################################
+## <summary>
+##      Execute netatalk in the caller domain.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`netatalk_exec',`
+        gen_require(`
+                type netatalk_exec_t;
+        ')
+
+        corecmd_search_bin($1)
+        can_exec($1, netatalk_exec_t)
+')
+
+########################################
+## <summary>
+##      Read netatalk configuration files.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`netatalk_read_config',`
+        gen_require(`
+                type netatalk_etc_t;
+        ')
+
+        files_search_etc($1)
+        allow $1 netatalk_etc_t:dir list_dir_perms;
+        allow $1 netatalk_etc_t:file read_file_perms;
+')
+
+########################################
+## <summary>
+##      Manage netatalk log files.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+interface(`netatalk_manage_log',`
+        gen_require(`
+                type netatalk_log_t;
+        ')
+
+        logging_search_logs($1)
+        allow $1 netatalk_log_t:dir rw_dir_perms;
+        allow $1 netatalk_log_t:file manage_file_perms;
+')
+
+# Additional rules for the new types
+allow netatalk_t netatalk_etc_t:dir list_dir_perms;
+allow netatalk_t netatalk_etc_t:file read_file_perms;
+
+allow netatalk_t netatalk_var_lib_t:dir manage_dir_perms;
+allow netatalk_t netatalk_var_lib_t:file manage_file_perms;
+
+allow netatalk_t netatalk_lock_t:dir manage_dir_perms;
+allow netatalk_t netatalk_lock_t:file manage_file_perms;
+
+allow netatalk_t netatalk_log_t:dir manage_dir_perms;
+allow netatalk_t netatalk_log_t:file manage_file_perms;

--- a/distrib/selinux/netatalk.sh
+++ b/distrib/selinux/netatalk.sh
@@ -1,0 +1,52 @@
+#!/bin/sh -e
+
+DIRNAME=$(dirname $0)
+cd $DIRNAME
+USAGE="$0 [ --update ]"
+if [ $(id -u) != 0 ]; then
+    echo 'You must be root to run this script'
+    exit 1
+fi
+
+if [ $# -eq 1 ]; then
+    if [ "$1" = "--update" ]; then
+        time=$(ls -l --time-style="+%x %X" netatalk.te | awk '{ printf "%s %s", $6, $7 }')
+        rules=$(ausearch --start $time -m avc --raw -se netatalk)
+        if [ x"$rules" != "x" ]; then
+            echo "Found avc's to update policy with"
+            echo -e "$rules" | audit2allow -R
+            echo "Do you want these changes added to policy [y/n]?"
+            read ANS
+            if [ "$ANS" = "y" -o "$ANS" = "Y" ]; then
+                echo "Updating policy"
+                echo -e "$rules" | audit2allow -R >> netatalk.te
+                # Fall though and rebuild policy
+            else
+                exit 0
+            fi
+        else
+            echo "No new avcs found"
+            exit 0
+        fi
+    else
+        echo -e $USAGE
+        exit 1
+    fi
+elif [ $# -ge 2 ]; then
+    echo -e $USAGE
+    exit 1
+fi
+
+echo "Building and Loading Policy"
+set -x
+make -f /usr/share/selinux/devel/Makefile netatalk.pp || exit
+/usr/sbin/semodule -i netatalk.pp
+
+# Generate a man page of the installed module
+sepolicy manpage -p . -d netatalk_t
+# Fixing the file context on /usr/local/sbin/netatalk
+/sbin/restorecon -F -R -v /usr/sbin/netatalk
+# Generate a rpm package for the newly generated policy
+
+pwd=$(pwd)
+rpmbuild --define "_sourcedir ${pwd}" --define "_specdir ${pwd}" --define "_builddir ${pwd}" --define "_srcrpmdir ${pwd}" --define "_rpmdir ${pwd}" --define "_buildrootdir ${pwd}/.build" -ba netatalk_selinux.spec

--- a/distrib/selinux/netatalk.te
+++ b/distrib/selinux/netatalk.te
@@ -1,0 +1,103 @@
+policy_module(netatalk, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type netatalk_t;
+type netatalk_exec_t;
+init_daemon_domain(netatalk_t, netatalk_exec_t)
+
+# Ensure proper entrypoint
+allow netatalk_t netatalk_exec_t:file entrypoint;
+
+# Allow netatalk to execute and transition to its child daemons
+# This handles the forking structure: netatalk -> afpd, cnid_metad -> cnid_dbd
+allow netatalk_t netatalk_exec_t:file execute;
+domtrans_pattern(netatalk_t, netatalk_exec_t, netatalk_t)
+
+# Configuration files
+type netatalk_etc_t;
+files_config_file(netatalk_etc_t)
+
+# Variable library files
+type netatalk_var_lib_t;
+files_type(netatalk_var_lib_t)
+
+# Lock files
+type netatalk_lock_t;
+files_lock_file(netatalk_lock_t)
+
+# Log files
+type netatalk_log_t;
+logging_log_file(netatalk_log_t)
+
+########################################
+#
+# netatalk local policy
+#
+
+# Basic process and IPC permissions
+allow netatalk_t self:process { fork signal_perms };
+allow netatalk_t self:fifo_file rw_fifo_file_perms;
+allow netatalk_t self:unix_stream_socket create_stream_socket_perms;
+
+# Process management for forking daemons
+allow netatalk_t self:process { setrlimit setpgid setsched };
+
+# Allow netatalk to bind to privileged ports
+allow netatalk_t self:capability net_bind_service;
+
+# Socket permissions
+allow netatalk_t self:netlink_route_socket { bind create getattr nlmsg_read };
+allow netatalk_t self:tcp_socket { bind create ioctl listen setopt };
+allow netatalk_t self:udp_socket { connect create getattr };
+allow netatalk_t self:unix_dgram_socket { connect create };
+
+# Core command execution and binary mapping
+corecmd_exec_bin(netatalk_t)
+corecmd_exec_shell(netatalk_t)
+corecmd_mmap_bin_files(netatalk_t)
+
+# Network binding permissions
+corenet_tcp_bind_dhcpd_port(netatalk_t)
+corenet_tcp_bind_generic_node(netatalk_t)
+corenet_tcp_bind_generic_port(netatalk_t)
+corenet_udp_bind_generic_node(netatalk_t)
+corenet_udp_bind_generic_port(netatalk_t)
+
+# D-Bus communication
+dbus_read_pid_sock_files(netatalk_t)
+dbus_stream_connect_system_dbusd(netatalk_t)
+dbus_write_pid_sock_files(netatalk_t)
+
+# File and lock management
+files_create_lock_dirs(netatalk_t)
+files_manage_generic_locks(netatalk_t)
+files_rw_var_files(netatalk_t)
+files_search_locks(netatalk_t)
+files_read_etc_files(netatalk_t)
+
+# Kernel communication
+kernel_dgram_send(netatalk_t)
+kernel_read_proc_files(netatalk_t)
+kernel_read_system_state(netatalk_t)
+
+# Logging
+logging_create_devlog_dev(netatalk_t)
+logging_read_syslog_pid(netatalk_t)
+logging_send_syslog_msg(netatalk_t)
+
+# System network configuration
+sysnet_read_config(netatalk_t)
+
+# Interactive and standard daemon permissions
+domain_use_interactive_fds(netatalk_t)
+
+# Allow systemd to transition to netatalk
+init_domtrans_script(netatalk_exec_t)
+
+# Additional permissions that might be needed
+auth_use_nsswitch(netatalk_t)
+miscfiles_read_localization(netatalk_t)

--- a/distrib/selinux/netatalk_selinux.spec
+++ b/distrib/selinux/netatalk_selinux.spec
@@ -1,0 +1,72 @@
+# vim: sw=4:ts=4:et
+
+
+%define relabel_files() \
+restorecon -R /usr/sbin/netatalk; \
+
+%define selinux_policyver 41.44-1
+
+Name:   netatalk_selinux
+Version:	1.0
+Release:	1%{?dist}
+Summary:	SELinux policy module for netatalk
+
+Group:	System Environment/Base
+License:	GPLv2+
+URL:		http://HOSTNAME
+Source0:	netatalk.pp
+Source1:	netatalk.if
+Source2:	netatalk_selinux.8
+
+
+Requires: policycoreutils-python-utils, libselinux-utils
+Requires(post): selinux-policy-base >= %{selinux_policyver}, policycoreutils-python-utils
+Requires(postun): policycoreutils-python-utils
+BuildArch: noarch
+
+%description
+This package installs and sets up the  SELinux policy security module for netatalk.
+
+%install
+install -d %{buildroot}%{_datadir}/selinux/packages
+install -m 644 %{SOURCE0} %{buildroot}%{_datadir}/selinux/packages
+install -d %{buildroot}%{_datadir}/selinux/devel/include/contrib
+install -m 644 %{SOURCE1} %{buildroot}%{_datadir}/selinux/devel/include/contrib/
+install -d %{buildroot}%{_mandir}/man8/
+install -m 644 %{SOURCE2} %{buildroot}%{_mandir}/man8/netatalk_selinux.8
+install -d %{buildroot}/etc/selinux/targeted/contexts/users/
+
+
+%post
+semodule -n -i %{_datadir}/selinux/packages/netatalk.pp
+
+if [ $1 -eq 1 ]; then
+
+fi
+if /usr/sbin/selinuxenabled ; then
+    /usr/sbin/load_policy
+    %relabel_files
+fi;
+exit 0
+
+%postun
+if [ $1 -eq 0 ]; then
+
+    semodule -n -r netatalk
+    if /usr/sbin/selinuxenabled ; then
+       /usr/sbin/load_policy
+       %relabel_files
+    fi;
+fi;
+exit 0
+
+%files
+%attr(0600,root,root) %{_datadir}/selinux/packages/netatalk.pp
+%{_datadir}/selinux/devel/include/contrib/netatalk.if
+%{_mandir}/man8/netatalk_selinux.8.*
+
+
+%changelog
+* Fri Jun 27 2025 Daniel Markstedt <daniel@mindani.net> 1.0-1
+- Initial version
+


### PR DESCRIPTION
This is an attempt at creating an SELinux policy for the netatalk -> afpd -> cnid_metad -> cnid_dbd daemon set using the Red Hat guide.

https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/using_selinux/writing-a-custom-selinux-policy_using-selinux