### PR TITLE
testsuite: Remove obsolete protocol option stubs

### DIFF
--- a/test/testsuite/FPRead.c
+++ b/test/testsuite/FPRead.c
@@ -367,7 +367,6 @@ extern int  Port;
 extern char *Password;
 extern char *vers;
 extern char *uam;
-extern int  Proto;
 
 static volatile int sigp = 0;
 static int sock = -1;
@@ -440,7 +439,6 @@ static void write_test(int size)
         goto fin;
     }
 
-    myconn->type = Proto;
     dsi2 = &myconn->dsi;
     sock = OpenClientSocket(Server, Port);
 

--- a/test/testsuite/afparg.c
+++ b/test/testsuite/afparg.c
@@ -37,7 +37,6 @@ DSI        *Dsi;
 
 /* Default values for options */
 char    *Server = "localhost";
-int     Proto = 0;
 int     Port = DSI_AFPOVERTCP_PORT;
 char    *Password = "";
 char    *Vol = "";
@@ -259,21 +258,16 @@ int main(int ac, char **av)
         return 1;
     }
 
-    Conn->type = Proto;
+    int sock;
+    Dsi = &Conn->dsi;
+    dsi = Dsi;
+    sock = OpenClientSocket(Server, Port);
 
-    if (!Proto) {
-        int sock;
-        Dsi = &Conn->dsi;
-        dsi = Dsi;
-        sock = OpenClientSocket(Server, Port);
-
-        if (sock < 0) {
-            return 2;
-        }
-
-        Dsi->socket = sock;
-    } else {
+    if (sock < 0) {
+        return 2;
     }
+
+    Dsi->socket = sock;
 
     /* login */
     if (Version >= 30) {

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -58,7 +58,6 @@ static int create_enum_files = 2000;              /* 2000 files */
 static uint16_t vol;
 static DSI *dsi;
 static char    *Server = "localhost";
-static int     Proto = 0;
 static int     Port = DSI_AFPOVERTCP_PORT;
 static char    *Password = "";
 static int     Iterations = 1;
@@ -990,20 +989,15 @@ int main(int ac, char **av)
         return 1;
     }
 
-    Conn->type = Proto;
+    int sock;
+    dsi = &Conn->dsi;
+    sock = OpenClientSocket(Server, Port);
 
-    if (!Proto) {
-        int sock;
-        dsi = &Conn->dsi;
-        sock = OpenClientSocket(Server, Port);
-
-        if (sock < 0) {
-            return 2;
-        }
-
-        dsi->socket = sock;
+    if (sock < 0) {
+        return 2;
     }
 
+    dsi->socket = sock;
     Conn->afp_version = Version;
 
     /* login */

--- a/test/testsuite/logintest.c
+++ b/test/testsuite/logintest.c
@@ -22,7 +22,6 @@ char Data[300000] = "";
 /* ------------------------------- */
 char    *Server = "localhost";
 char    *Server2;
-int     Proto = 0;
 int     Port = DSI_AFPOVERTCP_PORT;
 char    *Password = "";
 char    *Vol = "";
@@ -38,20 +37,16 @@ static char  *vers = "AFP3.4";
 STATIC void connect_server(CONN *conn)
 {
     DSI *dsi;
-    conn->type = Proto;
+    int sock;
+    dsi = &conn->dsi;
+    sock = OpenClientSocket(Server, Port);
 
-    if (!Proto) {
-        int sock;
-        dsi = &conn->dsi;
-        sock = OpenClientSocket(Server, Port);
-
-        if (sock < 0) {
-            test_nottested();
-            exit(ExitCode);
-        }
-
-        dsi->socket = sock;
+    if (sock < 0) {
+        test_nottested();
+        exit(ExitCode);
     }
+
+    dsi->socket = sock;
 }
 
 /* ------------------------- */

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -320,7 +320,6 @@ char Data[300000] = "";
 /* ------------------------------- */
 char    *Server = "localhost";
 char    *Server2;
-int     Proto = 0;
 int     Port = DSI_AFPOVERTCP_PORT;
 char    *Password = "";
 char    *Vol = "";
@@ -462,12 +461,6 @@ int main(int ac, char **av)
         case 'm':
             Mac = 1;
             break;
-#if 0
-
-        case 'n':
-            Proto = 1;
-            break;
-#endif
 
         case 'p' :
             Port = atoi(optarg);
@@ -550,23 +543,17 @@ int main(int ac, char **av)
         return 1;
     }
 
-    Conn->type = Proto;
+    int sock;
+    Dsi = &Conn->dsi;
+    dsi = Dsi;
+    sock = OpenClientSocket(Server, Port);
 
-    if (!Proto) {
-        int sock;
-        Dsi = &Conn->dsi;
-        dsi = Dsi;
-        sock = OpenClientSocket(Server, Port);
-
-        if (sock < 0) {
-            return 2;
-        }
-
-        Dsi->socket = sock;
-    } else {
+    if (sock < 0) {
+        return 2;
     }
 
-    /* login */
+    Dsi->socket = sock;
+
     if (Version >= 30) {
         ret = FPopenLoginExt(Conn, vers, uam, User, Password);
     } else {
@@ -585,28 +572,22 @@ int main(int ac, char **av)
      * User 2                              *
      *                                     *
      ***************************************/
-    /* user 2 */
+
     if (User2) {
         if ((Conn2 = (CONN *)calloc(1, sizeof(CONN))) == NULL) {
             return 1;
         }
 
-        Conn2->type = Proto;
+        int sock2;
+        Dsi2 = &Conn2->dsi;
+        sock2 = OpenClientSocket(Server2 ? Server2 : Server, Port);
 
-        if (!Proto) {
-            int sock;
-            Dsi2 = &Conn2->dsi;
-            sock = OpenClientSocket(Server2 ? Server2 : Server, Port);
-
-            if (sock < 0) {
-                return 1;
-            }
-
-            Dsi2->socket = sock;
-        } else {
+        if (sock2 < 0) {
+            return 1;
         }
 
-        /* login */
+        Dsi2->socket = sock2;
+
         if (Version >= 30) {
             ret = FPopenLoginExt(Conn2, vers, uam, User2, Password);
         } else {

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -32,7 +32,6 @@ struct timeval Timer_end;
 
 /* ------------------------------- */
 static char    *Server = "localhost";
-static int     Proto = 0;
 static int     Port = DSI_AFPOVERTCP_PORT;
 static char    *Password = "";
 char    *Vol = "";
@@ -1647,12 +1646,6 @@ int main(int ac, char **av)
         case 'n':
             Count = atoi(optarg);
             break;
-#if 0
-
-        case 'n':
-            Proto = 1;
-            break;
-#endif
 
         case 'p' :
             Port = atoi(optarg);
@@ -1733,26 +1726,22 @@ int main(int ac, char **av)
         return 1;
     }
 
-    Conn->type = Proto;
-
     if (Local) {
         Dsi = &Conn->dsi;
         dsi = Dsi;
         dsi->server_quantum = 512 * KILOBYTE;
         VFS = local_VFS;
     } else {
-        if (!Proto) {
-            int sock;
-            Dsi = &Conn->dsi;
-            dsi = Dsi;
-            sock = OpenClientSocket(Server, Port);
+        int sock;
+        Dsi = &Conn->dsi;
+        dsi = Dsi;
+        sock = OpenClientSocket(Server, Port);
 
-            if (sock < 0) {
-                return 2;
-            }
-
-            Dsi->socket = sock;
+        if (sock < 0) {
+            return 2;
         }
+
+        Dsi->socket = sock;
 
         /* login */
         if (Version >= 30) {


### PR DESCRIPTION
The testsuite supports only DSI protocol, so remove the global variables and empty conditionals for the global Proto variable

This code was likely meant as a stub for DDP protocol support in the testsuite