### PR TITLE
GitHub CI: Refactor the sqlite workflow jobs to the run format

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -335,47 +335,50 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        env:
-            AFP_USER: atalk1
-            AFP_USER2: atalk2
-            AFP_PASS: ${{ secrets.AFP_PASSWD }}
-            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
-            AFP_GROUP: afpusers
-            AFP_CNID_BACKEND: sqlite
-            SHARE_NAME: test1
-            SHARE_NAME2: test2
-            INSECURE_AUTH: 1
-            DISABLE_TIMEMACHINE: 1
-            VERBOSE: 1
-            TESTSUITE: spectest
-            AFP_VERSION: 7
-            AFP_EXTMAP: 1
         steps:
-            - uses: docker://ghcr.io/netatalk/netatalk-testsuite:latest
+            - name: Run Netatalk testsuite
+              run: |
+                docker run --rm \
+                  -e AFP_USER="atalk1" \
+                  -e AFP_USER2="atalk2" \
+                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+                  -e AFP_GROUP="afpusers" \
+                  -e AFP_CNID_BACKEND="sqlite" \
+                  -e SHARE_NAME="test1" \
+                  -e SHARE_NAME2="test2" \
+                  -e INSECURE_AUTH="1" \
+                  -e DISABLE_TIMEMACHINE="1" \
+                  -e VERBOSE="1" \
+                  -e TESTSUITE="spectest" \
+                  -e AFP_VERSION="7" \
+                  -e AFP_EXTMAP="1" \
+                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
 
     afp-spectest-sqlite-afp34-debian:
         name: AFP spec test (cnid:sqlite) AFP 3.4 - Debian
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        env:
-            AFP_USER: atalk1
-            AFP_USER2: atalk2
-            AFP_PASS: ${{ secrets.AFP_PASSWD }}
-            AFP_PASS2: ${{ secrets.AFP_PASSWD }}
-            AFP_GROUP: afpusers
-            AFP_CNID_BACKEND: sqlite
-            SHARE_NAME: test1
-            SHARE_NAME2: test2
-            INSECURE_AUTH: 1
-            DISABLE_TIMEMACHINE: 1
-            VERBOSE: 1
-            TESTSUITE: spectest
-            AFP_VERSION: 7
-            AFP_EXTMAP: 1
         steps:
-            - uses: docker://ghcr.io/netatalk/netatalk-testsuite-debian:latest
-
+            - name: Run Netatalk testsuite
+              run: |
+                docker run --rm \
+                  -e AFP_USER="atalk1" \
+                  -e AFP_USER2="atalk2" \
+                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+                  -e AFP_GROUP="afpusers" \
+                  -e AFP_CNID_BACKEND="sqlite" \
+                  -e SHARE_NAME="test1" \
+                  -e SHARE_NAME2="test2" \
+                  -e INSECURE_AUTH="1" \
+                  -e DISABLE_TIMEMACHINE="1" \
+                  -e VERBOSE="1" \
+                  -e TESTSUITE="spectest" \
+                  -e AFP_VERSION="7" \
+                  -e AFP_EXTMAP="1" \
+                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
 
     afp-spectest-afp34:
         name: AFP spec test (ea:sys) AFP 3.4 - Alpine


### PR DESCRIPTION
These jobs originate from a branch that existed before the refactoring of the container workflow jobs