### PR TITLE
GitHub CI: Select the correct testsuite container for the job

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -353,7 +353,7 @@ jobs:
                   -e TESTSUITE="spectest" \
                   -e AFP_VERSION="7" \
                   -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
     afp-spectest-sqlite-afp34-debian:
         name: AFP spec test (cnid:sqlite) AFP 3.4 - Debian


### PR DESCRIPTION
We were mistakenly depending on the Debian testsuite container while we actually used the Alpine one