### PR TITLE
cnid: Turn on normal synchronous pragma for the sqlite backend

### DIFF
--- a/libatalk/cnid/sqlite/cnid_sqlite.c
+++ b/libatalk/cnid/sqlite/cnid_sqlite.c
@@ -1216,6 +1216,7 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
     }
 
     sqlite3_busy_timeout(db->cnid_sqlite_con, 5000);
+    EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "PRAGMA synchronous=NORMAL;"));
     EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "PRAGMA journal_mode=WAL;"));
 
     /* Add volume to volume table */

--- a/libatalk/cnid/sqlite/cnid_sqlite.c
+++ b/libatalk/cnid/sqlite/cnid_sqlite.c
@@ -1215,7 +1215,7 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
             strerror(errno));
     }
 
-    sqlite3_busy_timeout(db->cnid_sqlite_con, 5000);
+    sqlite3_busy_timeout(db->cnid_sqlite_con, 2000);
     EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "PRAGMA synchronous=NORMAL;"));
     EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "PRAGMA journal_mode=WAL;"));
 


### PR DESCRIPTION
As per the SQLite docs, NORMAL synchronous pragma is a recommended companion for WAL journaling mode

Also lowers the global SQLite busy timeout from 5s to 2s. It was set high while debugging a write locking issue and I forgot to adjust it again.