### PR TITLE
Build and run netatalk without Berkeley DB

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -39,14 +39,28 @@ documentation for more details.
 
 ### Required
 
+These are the libraries that are hard requirements for netatalk.
+
 | Package      | Details |
 |--------------|---------|
-| Berkeley DB  | v4.6.0 or later (often packaged as `bdb` or sometimes `db`) |
 | iniparser    | v3.1 or later |
 | libevent     | v2.0 or later |
 | libgcrypt    | v1.2.3 or later |
 
-### Required to Build
+### CNID Backend Requirements
+
+One or more of the below is required to build the respective CNID backend.
+
+| Package      | Backend | Details |
+|--------------|---------|---------|
+| Berkeley DB  | dbd     | v4.6.0 or later (often packaged as `bdb` or sometimes `db`) |
+| mysql-client **OR** mariadb-client | mysql |  |
+| sqlite3      | sqlite  |  |
+
+### Required for Build Environment
+
+In order to build netatalk from source code, the following components are
+required at the bare minimum.
 
 | Package    | Details |
 |------------|---------|
@@ -54,7 +68,7 @@ documentation for more details.
 | meson      | v0.61.2 or later |
 | ninja      | Often packaged as `ninja-build` |
 
-### Required for Spotlight Support
+### Optional Spotlight Support
 
 | Package    | Details |
 |------------|---------|
@@ -64,7 +78,7 @@ documentation for more details.
 | bison      |  |
 | flex       |  |
 
-### Optional
+### Optional Features
 
 | Package      | Details |
 |--------------|---------|
@@ -77,10 +91,8 @@ documentation for more details.
 | libldap                    | For LDAP support |
 | libpam                     | For PAM support |
 | libtirpc **OR** libquota   | For Quota support |
-| mysql-client **OR** mariadb-client | For *mysql* CNID backend support |
 | Perl                       | For admin scripts |
 | po4a                       | For localization of documentation |
-| sqlite3                    | for *sqlite* CNID backend support |
 | tcpwrap                    | For TCP wrapper support |
 | [UnicodeData.txt](https://www.unicode.org/Public/UNIDATA/UnicodeData.txt) | For regenerating Unicode lookup tables |
 

--- a/bin/afppasswd/meson.build
+++ b/bin/afppasswd/meson.build
@@ -1,8 +1,4 @@
-afppasswd_sources = [
-    'afppasswd.c',
-]
-
-afppasswd_deps = []
+afppasswd_deps = [libgcrypt]
 afppasswd_libs = [libatalk]
 
 if have_cracklib
@@ -13,17 +9,13 @@ if use_mysql_backend
     afppasswd_deps += mysqlclient
 endif
 
-if have_libgcrypt
-    afppasswd_deps += [libgcrypt]
-endif
-
 if have_iconv
     afppasswd_deps += iconv
 endif
 
 executable(
     'afppasswd',
-    afppasswd_sources,
+    ['afppasswd.c'],
     include_directories: root_includes,
     dependencies: afppasswd_deps,
     link_with: afppasswd_libs,

--- a/bin/meson.build
+++ b/bin/meson.build
@@ -1,11 +1,5 @@
-if have_bdb
-    subdir('ad')
-endif
-
-if have_libgcrypt
-    subdir('afppasswd')
-endif
-
+subdir('ad')
+subdir('afppasswd')
 subdir('misc')
 
 if have_appletalk

--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -1077,22 +1077,24 @@ hosts deny = *IP host address/IP netmask bits* [ ... ] **(V)**
 cnid scheme = *backend* **(V)**
 
 > set the CNID backend to be used for the volume.
-The *dbd* and *last* backends are always available. Default is *dbd*.
-Run **afpd -v** to see a list of available backends.
+Run **afpd -v** to see a list of available backends,
+as well as which one is the default.
 >
 > *dbd* is a zero-configuration, full-featured, and reliable backend
 using Berkeley DB, where database access is managed through
 the **cnid_dbd** daemon.
 >
-> The *last* backend uses a read only Trivial Database,
-commonly used to mount CD-ROMs and similar media.
+> The *last* backend uses a read-only, in-memory Trivial Database.
+It can be used to mount CD-ROMs and similar read-only media, for instance.
 >
-> The optional *mysql* backend requires the system administrator to provision
-a MySQL database instance for use with Netatalk, while setting the appropriate
-*cnid mysql \** configuration options.
+> The *mysql* backend requires that a MySQL (or MariaDB) database instance
+has been provisioned for use with Netatalk.
+The upside is that you get full control over how the CNID data is stored,
+which makes for a robust and scalable solution.
 >
-> The EXPERIMENTAL "sqlite" backend is a zero-configuration backend
-that uses the SQLite library.
+> The EXPERIMENTAL *sqlite* backend is a zero-configuration backend
+that uses the SQLite library. It is performant and lean, requiring
+no external database or daemon.
 >
 > ***WARNING:*** The *sqlite* backend should only be used for testing purposes
 and not in a production setting.

--- a/doc/manpages/man8/cnid_dbd.8.md
+++ b/doc/manpages/man8/cnid_dbd.8.md
@@ -11,11 +11,12 @@ cnid_dbd — CNID database access daemon
 # Description
 
 **cnid_dbd** provides an interface for storage and retrieval of catalog
-node IDs (CNIDs) and related information to the *afpd* daemon. CNIDs are
-a component of Macintosh based file systems with semantics that map not
-easily onto Unix file systems. This makes separate storage in a database
-necessary. **cnid_dbd** is part of the *CNID backend* framework of *afpd*
-and implements the *dbd* backend.
+node IDs (CNIDs) and related information to the *afpd* daemon
+when using the *dbd* (Database Daemon) CNID backend.
+
+CNIDs are a component of Classic Mac OS based file systems
+with semantics that does not map easily onto Unix file systems.
+This makes separate storage in a database necessary.
 
 **cnid_dbd** is never started via the command line or system startup
 scripts but only by the *cnid_metad* daemon. There is one instance of

--- a/doc/manpages/man8/cnid_metad.8.md
+++ b/doc/manpages/man8/cnid_metad.8.md
@@ -12,8 +12,11 @@ cnid_metad — daemon for starting cnid_dbd daemons on demand
 
 **cnid_metad** waits for requests from *afpd* to start up instances of the
 *cnid_dbd* daemon. It keeps track of the status of a *cnid_dbd* instance
-once started and will restart it if necessary. **cnid_metad** is normally
-started at boot time by **netatalk**(8) and runs until shutdown.
+once started and will restart it if necessary.
+
+When built with support for the *dbd* (Database Daemon) CNID backend,
+**netatalk**(8) will start and stop **cnid_metad** as needed.
+The user will normally not interact with it directly.
 
 # Options
 

--- a/doc/manpages/man8/meson.build
+++ b/doc/manpages/man8/meson.build
@@ -1,9 +1,14 @@
 manfiles = [
     'afpd',
-    'cnid_dbd',
-    'cnid_metad',
     'netatalk',
 ]
+
+if use_dbd_backend
+    manfiles += [
+        'cnid_dbd',
+        'cnid_metad',
+    ]
+endif
 
 if have_appletalk
     manfiles += [

--- a/doc/manual/Configuration.md
+++ b/doc/manual/Configuration.md
@@ -127,14 +127,21 @@ working with netatalk:
   corruption. Use the **vol dbpath** directive to put the databases onto
   a local disk if you must use NFS mounted volumes.
 
+Below follows descriptions of the various CNID backends that are
+included with netatalk.
+You can choose to build one or several of them at compile time.
+Run the command *afpd -v* to see which backends are available to you,
+as well as which one is the default.
+
 ### dbd
 
 The "Database Daemon" backend is built on Berkeley DB. Access to the
-CNID database is restricted to the cnid_dbd daemon process.
+CNID database is restricted to the **cnid_dbd** daemon process.
 **afpd** processes communicate with the **cnid_dbd** daemon
-for database reads and updates.
+for database reads and updates, which is in turn launched and
+controlled by the **cnid_metad** daemon.
 
-This is the default backend since Netatalk 2.1.
+This is the most reliable and proven backend for daily use.
 
 ### last
 

--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -46,15 +46,6 @@ packages that can be installed to enhance Netatalk's functionality.
 
 ### Required third-party software
 
-- Berkeley DB
-
-    The default dbd CNID backend for netatalk uses Berkeley DB to store
-    unique file identifiers. At the time of writing you need at least
-    version 4.6.
-
-    The recommended version is 5.3, the final release under the permissive
-    Sleepycat license, and therefore the most widely distributed version.
-
 - iniparser
 
     The iniparser library is used to parse the configuration files.
@@ -70,6 +61,37 @@ packages that can be installed to enhance Netatalk's functionality.
     The [Libgcrypt](https://gnupg.org/software/libgcrypt/) library
     supplies the encryption for the standard User Authentication Modules
     (UAMs). They are: DHX2, DHCAST128 (a.k.a. DHX) and RandNum.
+
+#### CNID database backends
+
+At least one of the below database libraries is required
+to power the CNID scheme of your choice.
+Without one of these, only the *last* backend will be available
+which operates in read-only mode and therefore not recommended
+for daily use.
+
+- Berkeley DB
+
+    The default dbd CNID backend for netatalk uses Berkeley DB to store
+    unique file identifiers. At the time of writing you need at least
+    version 4.6.
+
+    The recommended version is 5.3, the final release under the permissive
+    Sleepycat license, and therefore the most widely distributed version.
+
+- MySQL or MariaDB
+
+    By leveraging a MySQL-compatible client library, netatalk can be built
+    with a MySQL CNID backend that is highly scalable and reliable.
+    The administrator has to provide a separate database instance for use with
+    this backend.
+
+- SQLite v3
+
+    The SQLite library version 3 enables the SQLite CNID backend
+    which is an alternative zero-configuration backend.
+    This backend is **experimental** and should be used only for
+    testing purposes.
 
 ### Optional third-party software
 
@@ -139,13 +161,6 @@ functionality.
     library, netatalk can produce the GSS UAM library for authentication
     with existing Kerberos infrastructure.
 
-- MySQL or MariaDB
-
-    By leveraging a MySQL-compatible client library, netatalk can be built
-    with a MySQL CNID backend that is highly scalable and reliable. The
-    administrator has to provide a separate database instance for use with
-    this backend.
-
 - PAM
 
     PAM provides a flexible mechanism for authenticating users. PAM was
@@ -165,11 +180,6 @@ functionality.
     into other languages. It uses gettext to extract translatable
     strings from source files and merge them with the translations
     stored in PO files.
-
-- SQLite v3
-
-    The SQLite library version 3 enables the SQLite CNID backend
-    which is an alternative zero-configuration backend.
 
 - TCP wrappers
 

--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -81,6 +81,8 @@ static void show_version(void)
     printf("sqlite ");
 #endif
     puts("");
+    printf("  Default CNID backend:\t");
+    puts(DEFAULT_CNID_SCHEME);
 }
 
 /*

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -61,7 +61,11 @@ static void kill_childs(int sig, ...);
 /* static variables */
 static AFPObj obj;
 static pid_t afpd_pid = NETATALK_SRV_NEEDED;
+#ifdef CNID_BACKEND_DBD
 static pid_t cnid_metad_pid = NETATALK_SRV_NEEDED;
+#else
+static pid_t cnid_metad_pid = NETATALK_SRV_OPTIONAL;
+#endif
 static pid_t dbus_pid = NETATALK_SRV_OPTIONAL;
 static uint afpd_restarts, cnid_metad_restarts, dbus_restarts _U_;
 static struct event_base *base;
@@ -476,11 +480,15 @@ int main(int argc, char **argv)
         netatalk_exit(EXITERR_CONF);
     }
 
+#ifdef CNID_BACKEND_DBD
+
     if ((cnid_metad_pid = run_process(_PATH_CNID_METAD, "-d", "-F",
                                       obj.options.configfile, NULL)) == NETATALK_SRV_ERROR) {
         LOG(log_error, logtype_afpd, "Error starting 'cnid_metad'");
         netatalk_exit(EXITERR_CONF);
     }
+
+#endif
 
     if ((base = event_base_new()) == NULL) {
         LOG(log_error, logtype_afpd, "Error starting event loop");

--- a/etc/uams/meson.build
+++ b/etc/uams/meson.build
@@ -15,11 +15,9 @@ if crypt.found()
     passwd_deps += crypt
 endif
 
-uams_guest_sources = ['uams_guest.c']
-
 library(
     'uams_guest',
-    uams_guest_sources,
+    ['uams_guest.c'],
     include_directories: root_includes,
     name_prefix: '',
     name_suffix: lib_suffix,
@@ -28,11 +26,9 @@ library(
     install_dir: libdir / 'netatalk',
 )
 
-uams_passwd_sources = ['uams_passwd.c']
-
 library(
     'uams_passwd',
-    uams_passwd_sources,
+    ['uams_passwd.c'],
     include_directories: root_includes,
     dependencies: passwd_deps,
     name_prefix: '',
@@ -42,113 +38,70 @@ library(
     install_dir: libdir / 'netatalk',
 )
 
-if have_libgcrypt
-    uams_randnum_sources = ['uams_randnum.c']
-    uams_dhx2_passwd_sources = ['uams_dhx2_passwd.c']
-    uams_dhx_passwd_sources = ['uams_dhx_passwd.c']
+library(
+    'uams_randnum',
+    ['uams_randnum.c'],
+    include_directories: root_includes,
+    dependencies: [crack, libgcrypt],
+    name_prefix: '',
+    name_suffix: lib_suffix,
+    override_options: 'b_lundef=false',
+    install: true,
+    install_dir: libdir / 'netatalk',
+)
 
-    library(
-        'uams_randnum',
-        uams_randnum_sources,
-        include_directories: root_includes,
-        dependencies: [crack, libgcrypt],
-        name_prefix: '',
-        name_suffix: lib_suffix,
-        override_options: 'b_lundef=false',
-        install: true,
-        install_dir: libdir / 'netatalk',
-    )
+library(
+    'uams_dhx_passwd',
+    ['uams_dhx_passwd.c'],
+    include_directories: root_includes,
+    dependencies: [passwd_deps, libgcrypt],
+    name_prefix: '',
+    name_suffix: lib_suffix,
+    override_options: 'b_lundef=false',
+    install: true,
+    install_dir: libdir / 'netatalk',
+)
 
-    library(
-        'uams_dhx_passwd',
-        uams_dhx_passwd_sources,
-        include_directories: root_includes,
-        dependencies: [passwd_deps, libgcrypt],
-        name_prefix: '',
-        name_suffix: lib_suffix,
-        override_options: 'b_lundef=false',
-        install: true,
-        install_dir: libdir / 'netatalk',
-    )
-
-    library(
-        'uams_dhx2_passwd',
-        uams_dhx2_passwd_sources,
-        include_directories: root_includes,
-        dependencies: [passwd_deps, libgcrypt],
-        name_prefix: '',
-        name_suffix: lib_suffix,
-        override_options: 'b_lundef=false',
-        install: true,
-        install_dir: libdir / 'netatalk',
-    )
-    if have_pam
-        uams_dhx2_pam_sources = ['uams_dhx2_pam.c']
-
-        library(
-            'uams_dhx2_pam',
-            uams_dhx2_pam_sources,
-            include_directories: [pam_includes, root_includes],
-            dependencies: [iniparser, pam, libgcrypt],
-            name_prefix: '',
-            name_suffix: lib_suffix,
-            override_options: 'b_lundef=false',
-            install: true,
-            install_dir: libdir / 'netatalk',
-        )
-
-        if build_shared_lib
-            install_symlink(
-                'uams_dhx2.so',
-                install_dir: libdir / 'netatalk',
-                pointing_to: 'uams_dhx2_pam.so',
-            )
-        endif
-    elif build_shared_lib
-        install_symlink(
-            'uams_dhx2.so',
-            install_dir: libdir / 'netatalk',
-            pointing_to: 'uams_dhx2_passwd.so',
-        )
-    endif
-    if have_pam
-        uams_dhx_pam_sources = ['uams_dhx_pam.c']
-
-        library(
-            'uams_dhx_pam',
-            uams_dhx_pam_sources,
-            include_directories: [pam_includes, root_includes],
-            dependencies: [pam, libgcrypt],
-            name_prefix: '',
-            name_suffix: lib_suffix,
-            override_options: 'b_lundef=false',
-            install: true,
-            install_dir: libdir / 'netatalk',
-        )
-
-        if build_shared_lib
-            install_symlink(
-                'uams_dhx.so',
-                install_dir: libdir / 'netatalk',
-                pointing_to: 'uams_dhx_pam.so',
-            )
-        endif
-    elif build_shared_lib
-        install_symlink(
-            'uams_dhx.so',
-            install_dir: libdir / 'netatalk',
-            pointing_to: 'uams_dhx_passwd.so',
-        )
-    endif
-
-endif
+library(
+    'uams_dhx2_passwd',
+    ['uams_dhx2_passwd.c'],
+    include_directories: root_includes,
+    dependencies: [passwd_deps, libgcrypt],
+    name_prefix: '',
+    name_suffix: lib_suffix,
+    override_options: 'b_lundef=false',
+    install: true,
+    install_dir: libdir / 'netatalk',
+)
 
 if have_pam
-    uams_pam_sources = ['uams_pam.c']
+    library(
+        'uams_dhx_pam',
+        ['uams_dhx_pam.c'],
+        include_directories: [pam_includes, root_includes],
+        dependencies: [pam, libgcrypt],
+        name_prefix: '',
+        name_suffix: lib_suffix,
+        override_options: 'b_lundef=false',
+        install: true,
+        install_dir: libdir / 'netatalk',
+    )
+
+    library(
+        'uams_dhx2_pam',
+        ['uams_dhx2_pam.c'],
+        include_directories: [pam_includes, root_includes],
+        dependencies: [iniparser, pam, libgcrypt],
+        name_prefix: '',
+        name_suffix: lib_suffix,
+        override_options: 'b_lundef=false',
+        install: true,
+        install_dir: libdir / 'netatalk',
+    )
 
     library(
         'uams_pam',
-        uams_pam_sources,
+        ['uams_pam.c'],
         include_directories: [pam_includes, root_includes],
         dependencies: pam,
         name_prefix: '',
@@ -164,6 +117,16 @@ if have_pam
             install_dir: libdir / 'netatalk',
             pointing_to: 'uams_pam.so',
         )
+        install_symlink(
+            'uams_dhx.so',
+            install_dir: libdir / 'netatalk',
+            pointing_to: 'uams_dhx_pam.so',
+        )
+        install_symlink(
+            'uams_dhx2.so',
+            install_dir: libdir / 'netatalk',
+            pointing_to: 'uams_dhx2_pam.so',
+        )
     endif
 elif build_shared_lib
     install_symlink(
@@ -171,14 +134,22 @@ elif build_shared_lib
         install_dir: libdir / 'netatalk',
         pointing_to: 'uams_passwd.so',
     )
+    install_symlink(
+        'uams_dhx.so',
+        install_dir: libdir / 'netatalk',
+        pointing_to: 'uams_dhx_passwd.so',
+    )
+    install_symlink(
+        'uams_dhx2.so',
+        install_dir: libdir / 'netatalk',
+        pointing_to: 'uams_dhx2_passwd.so',
+    )
 endif
 
 if have_krb5_uam
-    uams_gss_sources = ['uams_gss.c']
-
     library(
         'uams_gss',
-        uams_gss_sources,
+        ['uams_gss.c'],
         include_directories: [gssapi_includes, root_includes],
         dependencies: [iniparser, gss_libs],
         c_args: kerberos_c_args,

--- a/libatalk/cnid/meson.build
+++ b/libatalk/cnid/meson.build
@@ -1,10 +1,13 @@
-subdir('dbd')
-subdir('last')
-
 libcnid_deps = [iniparser]
-libcnid_libs = [libcnid_dbd]
+libcnid_libs = []
+
+if use_dbd_backend
+    subdir('dbd')
+    libcnid_libs += libcnid_dbd
+endif
 
 if use_last_backend
+    subdir('last')
     libcnid_libs += libcnid_last
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -362,176 +362,276 @@ if host_os == 'sunos' or host_os == 'netbsd' or get_option('with-rpath')
 endif
 
 #
-# Check for the Berkeley DB library
+# Check which CNID backends to compile
 #
 
-grep = find_program('grep', required: false)
-bdb_path = get_option('with-bdb-path')
-bdb_include_path_override = get_option('with-bdb-include-path')
-bdb_req_version = get_option('with-bdb-version')
+cnid_backends = ''
 
+#
+# Check for the Berkeley DB library for the Database Daemon CNID backend
+#
+
+use_dbd_backend = false
 have_bdb = false
+grep = find_program('grep', required: false)
 
-bdb_header = ''
-bdb_includes = []
-bdb_libdir = ''
-bdb_major_version = ''
-bdb_minor_version = ''
-bdb_version = ''
-bdb_dirs = []
+if 'dbd' in get_option('with-cnid-backends')
+    bdb_path = get_option('with-bdb-path')
+    bdb_include_path_override = get_option('with-bdb-include-path')
+    bdb_req_version = get_option('with-bdb-version')
 
-if bdb_path != ''
-    bdb_dirs += [bdb_path]
-else
-    if brew_prefix != ''
+    bdb_header = ''
+    bdb_includes = []
+    bdb_libdir = ''
+    bdb_major_version = ''
+    bdb_minor_version = ''
+    bdb_version = ''
+    bdb_dirs = []
+
+    if bdb_path != ''
+        bdb_dirs += [bdb_path]
+    else
+        if brew_prefix != ''
+            bdb_dirs += [
+                brew_prefix / 'opt/berkeley-db@5',
+                brew_prefix / 'opt/berkeley-db@4',
+                brew_prefix / 'opt/berkeley-db',
+            ]
+        endif
+
         bdb_dirs += [
-            brew_prefix / 'opt/berkeley-db@5',
-            brew_prefix / 'opt/berkeley-db@4',
-            brew_prefix / 'opt/berkeley-db',
+            '/usr/local',
+            '/usr/pkg',
+            '/opt/local',
+            '/usr',
         ]
     endif
 
-    bdb_dirs += [
-        '/usr/local',
-        '/usr/pkg',
-        '/opt/local',
-        '/usr',
+    bdb_subdirs = [
+        'db62',
+        'db6.2',
+        'db61',
+        'db6.1',
+        'db5',
+        'db53',
+        'db5.3',
+        'db52',
+        'db5.2',
+        'db51',
+        'db5.1',
+        'db50',
+        'db5.0',
+        'db4',
+        'db48',
+        'db4.8',
+        'db47',
+        'db4.7',
+        'db46',
+        'db4.6',
+        '',
     ]
-endif
 
-bdb_subdirs = [
-    'db62',
-    'db6.2',
-    'db61',
-    'db6.1',
-    'db5',
-    'db53',
-    'db5.3',
-    'db52',
-    'db5.2',
-    'db51',
-    'db5.1',
-    'db50',
-    'db5.0',
-    'db4',
-    'db48',
-    'db4.8',
-    'db47',
-    'db4.7',
-    'db46',
-    'db4.6',
-    '',
-]
-
-if bdb_req_version != ''
-    if not bdb_req_version.version_compare('>=4.6')
-        error('Berkeley DB library version is below supported 4.6')
-    endif
-    message('Searching for Berkeley DB library version', bdb_req_version)
-endif
-
-foreach dir : bdb_dirs
-    foreach subdir : bdb_subdirs
-        if bdb_include_path_override != ''
-            bdb_include_path = bdb_include_path_override
-        else
-            bdb_include_path = dir / 'include' / subdir
+    if bdb_req_version != ''
+        if not bdb_req_version.version_compare('>=4.6')
+            error('Berkeley DB library version is below supported 4.6')
         endif
-        bdb_header = bdb_include_path / 'db.h'
-        if fs.exists(bdb_header)
-            bdb_includes = include_directories(bdb_include_path)
+        message('Searching for Berkeley DB library version', bdb_req_version)
+    endif
 
-            grep_result = run_command(
-                'grep',
-                'DB_VERSION_MAJOR',
-                bdb_header,
-                check: false,
-            )
-            if grep_result.returncode() != 0
-                warning(
-                    'Unable to determine Berkeley DB major version from header',
-                    bdb_header,
-                )
-                continue
-            endif
-            bdb_major_version = grep_result.stdout().strip().substring(25)
-
-            grep_result = run_command(
-                'grep',
-                'DB_VERSION_MINOR',
-                bdb_header,
-                check: false,
-            )
-            if grep_result.returncode() != 0
-                warning(
-                    'Unable to determine Berkeley DB minor version from header',
-                    bdb_header,
-                )
-                continue
-            endif
-            bdb_minor_version = grep_result.stdout().strip().substring(25)
-
-            bdb_version = bdb_major_version + '.' + bdb_minor_version
-
-            if not bdb_version.version_compare('>=4.6')
-                continue
-            endif
-
-            if bdb_req_version != '' and not bdb_version.version_compare('~' + bdb_req_version)
-                continue
-            endif
-
-            message('Berkeley DB header found at', bdb_header)
-
-            # Now find lib file matching header
-            if target_os == 'sunos' and compiler_64_bit_mode and fs.exists(dir / 'lib/64')
-                bdb_libdir = dir / 'lib/64'
+    foreach dir : bdb_dirs
+        foreach subdir : bdb_subdirs
+            if bdb_include_path_override != ''
+                bdb_include_path = bdb_include_path_override
             else
-                bdb_libdir = dir / 'lib'
+                bdb_include_path = dir / 'include' / subdir
             endif
+            bdb_header = bdb_include_path / 'db.h'
+            if fs.exists(bdb_header)
+                bdb_includes = include_directories(bdb_include_path)
 
-            # Guess lib name starting from more specific ones
-            bdb_libnames = [
-                'db-' + bdb_major_version + '.' + bdb_minor_version,
-                'db' + bdb_major_version + '.' + bdb_minor_version,
-                'db' + bdb_major_version + bdb_minor_version,
-                'db-' + bdb_major_version,
-                'db' + bdb_major_version,
-                'db',
-            ]
+                grep_result = run_command(
+                    'grep',
+                    'DB_VERSION_MAJOR',
+                    bdb_header,
+                    check: false,
+                )
+                if grep_result.returncode() != 0
+                    warning(
+                        'Unable to determine Berkeley DB major version from header',
+                        bdb_header,
+                    )
+                    continue
+                endif
+                bdb_major_version = grep_result.stdout().strip().substring(25)
 
-            foreach name : bdb_libnames
-                libdb = cc.find_library(name, dirs: bdb_libdir, required: false)
-                if not libdb.found()
-                    libdb = cc.find_library(name, dirs: bdb_libdir / subdir, required: false)
+                grep_result = run_command(
+                    'grep',
+                    'DB_VERSION_MINOR',
+                    bdb_header,
+                    check: false,
+                )
+                if grep_result.returncode() != 0
+                    warning(
+                        'Unable to determine Berkeley DB minor version from header',
+                        bdb_header,
+                    )
+                    continue
+                endif
+                bdb_minor_version = grep_result.stdout().strip().substring(25)
+
+                bdb_version = bdb_major_version + '.' + bdb_minor_version
+
+                if not bdb_version.version_compare('>=4.6')
+                    continue
                 endif
 
-                if libdb.found()
-                    have_bdb = true
+                if bdb_req_version != '' and not bdb_version.version_compare('~' + bdb_req_version)
+                    continue
+                endif
+
+                message('Berkeley DB header found at', bdb_header)
+
+                # Now find lib file matching header
+                if target_os == 'sunos' and compiler_64_bit_mode and fs.exists(dir / 'lib/64')
+                    bdb_libdir = dir / 'lib/64'
+                else
+                    bdb_libdir = dir / 'lib'
+                endif
+
+                # Guess lib name starting from more specific ones
+                bdb_libnames = [
+                    'db-' + bdb_major_version + '.' + bdb_minor_version,
+                    'db' + bdb_major_version + '.' + bdb_minor_version,
+                    'db' + bdb_major_version + bdb_minor_version,
+                    'db-' + bdb_major_version,
+                    'db' + bdb_major_version,
+                    'db',
+                ]
+
+                foreach name : bdb_libnames
+                    libdb = cc.find_library(name, dirs: bdb_libdir, required: false)
+                    if not libdb.found()
+                        libdb = cc.find_library(name, dirs: bdb_libdir / subdir, required: false)
+                    endif
+
+                    if libdb.found()
+                        have_bdb = true
+                        break
+                    endif
+                endforeach
+
+                if have_bdb
                     break
                 endif
-            endforeach
-
-            if have_bdb
-                break
             endif
+        endforeach
+
+        if have_bdb
+            break
         endif
     endforeach
 
     if have_bdb
-        break
-    endif
-endforeach
-
-if not have_bdb
-    if bdb_req_version != ''
-        msg = 'Berkeley DB library version ' + bdb_req_version + ' requested via -Dwith-bdb-version= not found!'
+        use_dbd_backend = true
+        cnid_backends += 'dbd'
+        cdata.set('CNID_BACKEND_DBD', 1)
     else
-        msg = 'Berkeley DB library required but not found!'
+        if bdb_req_version != ''
+            msg = 'Berkeley DB library version ' + bdb_req_version + ' requested via -Dwith-bdb-version= not found!'
+        else
+            msg = 'Berkeley DB library not found, bdb CNID backend will not be built!'
+        endif
+        message(
+            msg,
+            'If you want dbd CNID backend support, define the Berkeley DB path using the -Dwith-bdb-path= configure option (must include lib and include dirs)',
+        )
     endif
+endif
+
+# Determine whether or not to use LAST DID scheme
+
+use_last_backend = false
+
+if 'last' in get_option('with-cnid-backends')
+    use_last_backend = true
+    if cnid_backends != ''
+        cnid_backends += ' | '
+    endif
+    cnid_backends += 'last'
+    cdata.set('CNID_BACKEND_LAST', 1)
+endif
+
+# Check for mysql CNID backend
+
+mysqlclient = dependency('mysqlclient', required: false)
+mariadb = dependency('libmariadb', required: false)
+
+use_mysql_backend = false
+
+if 'mysql' in get_option('with-cnid-backends')
+    if mysqlclient.found()
+        mysql_deps = mysqlclient
+    else
+        mysql_deps = mariadb
+    endif
+    if mysql_deps.found()
+        use_mysql_backend = (
+            fs.exists(
+                mysql_deps.get_variable(pkgconfig: 'includedir') / 'mysql.h',
+            )
+        )
+    endif
+    if use_mysql_backend
+        if cnid_backends != ''
+            cnid_backends += ' | '
+        endif
+        cnid_backends += 'mysql'
+        cdata.set('CNID_BACKEND_MYSQL', 1)
+    endif
+endif
+
+# Check for sqlite CNID backend
+
+sqlite_deps = dependency('sqlite3', required: false)
+
+use_sqlite_backend = false
+
+if 'sqlite' in get_option('with-cnid-backends') and sqlite_deps.found()
+    use_sqlite_backend = true
+    if cnid_backends != ''
+        cnid_backends += ' | '
+    endif
+    cnid_backends += 'sqlite'
+    cdata.set('CNID_BACKEND_SQLITE', 1)
+endif
+
+if cnid_backends == ''
     error(
-        msg,
-        'Please specify an installation path using the -Dwith-bdb-path= configure option (must include lib and include dirs)',
+        'No CNID backends selected for compilation! Please select at least one backend using the -Dwith-cnid-backends= option',
+    )
+else
+    compiled_backends = '"' + cnid_backends + '"'
+    cdata.set('compiled_backends', compiled_backends)
+
+    summary_backends = cnid_backends
+endif
+
+# Determine default CNID backend
+
+default_backend = get_option('with-cnid-default-backend')
+cdata.set('DEFAULT_CNID_SCHEME', '"' + default_backend + '"')
+
+if default_backend == 'dbd' and not use_dbd_backend
+    error('Specified default CNID scheme dbd was not selected for compilation')
+elif default_backend == 'last' and not use_last_backend
+    error('Specified default CNID scheme last was not selected for compilation')
+elif default_backend == 'mysql' and not use_mysql_backend
+    error(
+        'Specified default CNID scheme mysql was not selected for compilation',
+    )
+elif default_backend == 'sqlite' and not use_sqlite_backend
+    error(
+        'Specified default CNID scheme sqlite was not selected for compilation',
     )
 endif
 
@@ -1456,99 +1556,6 @@ else
             'Please install libiconv',
         )
     endif
-endif
-
-#
-# Check whether BDB daemon needs to be compiled
-#
-
-cnid_backends = ''
-
-# Determine whether or not to use Database Daemon CNID backend
-
-use_dbd_backend = false
-
-if 'dbd' in get_option('with-cnid-backends')
-    use_dbd_backend = true
-    cnid_backends += 'dbd'
-    cdata.set('CNID_BACKEND_DBD', 1)
-endif
-
-# Determine whether or not to use LAST DID scheme
-
-use_last_backend = false
-
-if 'last' in get_option('with-cnid-backends')
-    use_last_backend = true
-    if cnid_backends != ''
-        cnid_backends += ' | '
-    endif
-    cnid_backends += 'last'
-    cdata.set('CNID_BACKEND_LAST', 1)
-endif
-
-# Check for mysql CNID backend
-
-mysqlclient = dependency('mysqlclient', required: false)
-mariadb = dependency('libmariadb', required: false)
-
-use_mysql_backend = false
-
-if 'mysql' in get_option('with-cnid-backends')
-    if mysqlclient.found()
-        mysql_deps = mysqlclient
-    else
-        mysql_deps = mariadb
-    endif
-    if mysql_deps.found()
-        use_mysql_backend = (
-            fs.exists(
-                mysql_deps.get_variable(pkgconfig: 'includedir') / 'mysql.h',
-            )
-        )
-    endif
-    if use_mysql_backend
-        if cnid_backends != ''
-            cnid_backends += ' | '
-        endif
-        cnid_backends += 'mysql'
-        cdata.set('CNID_BACKEND_MYSQL', 1)
-    endif
-endif
-
-# Check for sqlite CNID backend
-
-sqlite_deps = dependency('sqlite3', required: false)
-
-use_sqlite_backend = false
-
-if 'sqlite' in get_option('with-cnid-backends') and sqlite_deps.found()
-    use_sqlite_backend = true
-    if cnid_backends != ''
-        cnid_backends += ' | '
-    endif
-    cnid_backends += 'sqlite'
-    cdata.set('CNID_BACKEND_SQLITE', 1)
-endif
-
-compiled_backends = '"' + cnid_backends + '"'
-cdata.set('compiled_backends', compiled_backends)
-
-summary_backends = cnid_backends
-
-# Determine default CNID backend
-
-default_backend = get_option('with-cnid-default-backend')
-cdata.set('DEFAULT_CNID_SCHEME', '"' + default_backend + '"')
-
-if default_backend == 'dbd' and not use_dbd_backend
-    error('Specified default CNID scheme dbd was not selected for compilation')
-elif default_backend == 'last' and not use_last_backend
-    error('Specified default CNID scheme last was not selected for compilation')
-elif default_backend == 'mysql' and not use_mysql_backend
-    error(
-        'Specified default CNID scheme mysql was not selected for compilation',
-    )
 endif
 
 #

--- a/meson.build
+++ b/meson.build
@@ -605,23 +605,28 @@ if 'sqlite' in get_option('with-cnid-backends') and sqlite_deps.found()
     cdata.set('CNID_BACKEND_SQLITE', 1)
 endif
 
-if cnid_backends == ''
-    error(
-        'No CNID backends selected for compilation! Please select at least one backend using the -Dwith-cnid-backends= option',
-    )
-else
-    compiled_backends = '"' + cnid_backends + '"'
-    cdata.set('compiled_backends', compiled_backends)
+compiled_backends = '"' + cnid_backends + '"'
+cdata.set('compiled_backends', compiled_backends)
 
-    summary_backends = cnid_backends
-endif
+summary_backends = cnid_backends
 
 # Determine default CNID backend
 
 default_backend = get_option('with-cnid-default-backend')
-cdata.set('DEFAULT_CNID_SCHEME', '"' + default_backend + '"')
 
-if default_backend == 'dbd' and not use_dbd_backend
+if default_backend == ''
+    if use_dbd_backend
+        default_backend = 'dbd'
+    elif use_sqlite_backend
+        default_backend = 'sqlite'
+    elif use_mysql_backend
+        default_backend = 'mysql'
+    elif use_last_backend
+        default_backend = 'last'
+    else
+        error('No CNID backends selected for compilation')
+    endif
+elif default_backend == 'dbd' and not use_dbd_backend
     error('Specified default CNID scheme dbd was not selected for compilation')
 elif default_backend == 'last' and not use_last_backend
     error('Specified default CNID scheme last was not selected for compilation')
@@ -634,6 +639,8 @@ elif default_backend == 'sqlite' and not use_sqlite_backend
         'Specified default CNID scheme sqlite was not selected for compilation',
     )
 endif
+
+cdata.set('DEFAULT_CNID_SCHEME', '"' + default_backend + '"')
 
 #
 # Check for iniparser
@@ -2439,6 +2446,7 @@ summary({'Netatalk version': netatalk_version}, section: 'Configuration Summary:
 summary_info = {
     '  Access control': uams_options,
     '  CNID backends': summary_backends,
+    '  Default CNID backend': default_backend,
     '  Extended Attributes': netatalk_ea,
     '  Init script style': init_style,
 }

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -394,12 +394,13 @@ option(
     'with-cnid-default-backend',
     type: 'combo',
     choices: [
+        '',
         'dbd',
         'last',
         'mysql',
         'sqlite',
     ],
-    value: 'dbd',
+    value: '',
     description: 'Set default CNID scheme',
 )
 option(

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,5 +1,11 @@
 if get_option('with-tests')
-    subdir('afpd')
+    if use_last_backend
+        subdir('afpd')
+    else
+        warning(
+            'The afpd tests require the "last" backend to be built. Skipping afpd tests.',
+        )
+    endif
 endif
 
 if get_option('with-testsuite')


### PR DESCRIPTION
This changeset modifies both the build system and the netatalk executable to remove the hard dependency on Berkeley DB.

Regarding the build system piece: in the absence of a Berkeley DB library, it is now possible to build and use another CNID backend as the default. When the dbd backend is not built, we don't install the cnid_metad / cnid_dbd daemons or man pages.

In the netatalk controller daemon, when built without dbd support it will no longer attempt to launch the cnid_metad.

It introduces new logic for picking the default CNID backend which is more flexible, as well as printing the default backend in both the meson summary and in the output of afpd -V.

There is also surrounding refactoring of the build system for libgcrypt and the CNID backend libraries.