### PR TITLE
tests: Use the sqlite CNID backend in the afpd integration tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,10 +88,10 @@ jobs:
             -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
-      - name: Run integration tests
-        run: meson test -C build
       - name: Install
         run: meson install -C build
+      - name: Run integration tests
+        run: meson test -C build
       - name: Check netatalk capabilities
         run: |
           netatalk -V
@@ -146,10 +146,10 @@ jobs:
             -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
-      - name: Run integration tests
-        run: meson test -C build
       - name: Install
         run: meson install -C build
+      - name: Run integration tests
+        run: meson test -C build
       - name: Check netatalk capabilities
         run: |
           netatalk -V
@@ -219,10 +219,10 @@ jobs:
             -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
-      - name: Run integration tests
-        run: meson test -C build
       - name: Install
         run: meson install -C build
+      - name: Run integration tests
+        run: meson test -C build
       - name: Check netatalk capabilities
         run: |
           netatalk -V
@@ -406,10 +406,10 @@ jobs:
             -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
-      - name: Run integration tests
-        run: meson test -C build
       - name: Install
         run: sudo meson install -C build
+      - name: Run integration tests
+        run: meson test -C build
       - name: Check netatalk capabilities
         run: |
           netatalk -V
@@ -465,6 +465,7 @@ jobs:
               -Dwith-testsuite=true
             meson compile -C build
             meson install -C build
+            meson test -C build
             netatalk -V
             afpd -V
             ninja -C build uninstall
@@ -507,8 +508,8 @@ jobs:
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build
-            meson test -C build
             meson install -C build
+            meson test -C build
             netatalk -V
             afpd -V
             /usr/local/etc/rc.d/netatalk start
@@ -560,8 +561,8 @@ jobs:
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build
-            meson test -C build
             meson install -C build
+            meson test -C build
             netatalk -V
             afpd -V
             atalkd -V
@@ -619,6 +620,7 @@ jobs:
               -Dwith-testsuite=true
             meson compile -C build
             meson install -C build
+            meson test -C build
             netatalk -V
             afpd -V
             rcctl -d start netatalk
@@ -669,8 +671,8 @@ jobs:
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build
-            meson test -C build
             meson install -C build
+            meson test -C build
             netatalk -V
             afpd -V
             sleep 1
@@ -735,8 +737,8 @@ jobs:
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build
-            meson test -C build
             meson install -C build
+            meson test -C build
             netatalk -V
             afpd -V
             sleep 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,10 +286,10 @@ jobs:
             -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
-      - name: Run integration tests
-        run: meson test -C build
       - name: Install
         run: sudo meson install -C build
+      - name: Run integration tests
+        run: meson test -C build
       - name: Check netatalk capabilities
         run: |
           netatalk -V
@@ -354,10 +354,10 @@ jobs:
             -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
-      - name: Run distribution tests
-        run: meson dist -C build
       - name: Install
         run: sudo meson install -C build
+      - name: Run integration tests
+        run: meson test -C build
       - name: Check netatalk capabilities
         run: |
           netatalk -V

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -1273,13 +1273,9 @@ static struct vol *creatvol(AFPObj *obj,
         volume->v_flags |= AFPVOL_RO;
     }
 
-#ifndef WITH_TESTS
-
     if (0 == strcmp(volume->v_cnidscheme, "last")) {
         volume->v_flags |= AFPVOL_RO;
     }
-
-#endif
 
     if (volume->v_flags & AFPVOL_NODEV) {
         volume->v_ad_options |= ADVOL_NODEV;

--- a/meson.build
+++ b/meson.build
@@ -2260,10 +2260,6 @@ if have_webmin
     cdata.set('init_a2boot_restart', init_a2boot_restart)
 endif
 
-if get_option('with-tests')
-    cdata.set('WITH_TESTS', 1)
-endif
-
 configure_file(
     input: 'meson_config.h',
     output: 'config.h',

--- a/meson_config.h
+++ b/meson_config.h
@@ -415,9 +415,6 @@
 /* Define whether to enable Spotlight support */
 #mesondefine WITH_SPOTLIGHT
 
-/* Define when the test suite should be executed */
-#mesondefine WITH_TESTS
-
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
 #if defined AC_APPLE_UNIVERSAL_BUILD

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -32,7 +32,7 @@ test_sources = [
 ]
 
 test_c_args = []
-test_external_deps = [iniparser, libgcrypt]
+test_external_deps = [iniparser, libgcrypt, sqlite_deps]
 test_internal_deps = []
 test_link_args = []
 test_includes = [root_includes]

--- a/test/afpd/test.sh
+++ b/test/afpd/test.sh
@@ -15,7 +15,7 @@ afp port = 10548
 
 [test]
 path = /tmp/AFPtestvolume
-cnid scheme = last
+cnid scheme = sqlite
 ea = none
 EOF
     echo [ok]

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,5 +1,9 @@
 if get_option('with-tests')
-    subdir('afpd')
+    if sqlite_deps.found()
+        subdir('afpd')
+    else
+        warning('Not building afpd tests: SQLite library required')
+    endif
 endif
 
 if get_option('with-testsuite')


### PR DESCRIPTION
The sqlite backend is zero-configuration and run embedded in afpd so it's ideal for running the afpd tests

The last CNID backend can now be made permanently read-only again