### PR TITLE
cnid: Make the mysql CNID backend a bit more resilient

### DIFF
--- a/libatalk/cnid/mysql/cnid_mysql.c
+++ b/libatalk/cnid/mysql/cnid_mysql.c
@@ -41,6 +41,7 @@
 #include <atalk/errchk.h>
 #include <atalk/globals.h>
 #include <atalk/logger.h>
+#include <atalk/unix.h>
 #include <atalk/util.h>
 #include <atalk/volume.h>
 

--- a/libatalk/cnid/mysql/cnid_mysql.c
+++ b/libatalk/cnid/mysql/cnid_mysql.c
@@ -336,7 +336,7 @@ int cnid_mysql_update(struct _cnid_db *cdb,
             }
         }
 
-        update_id = mysql_stmt_insert_id(db->cnid_put_stmt);
+        update_id = (cnid_t)mysql_stmt_insert_id(db->cnid_put_stmt);
     } while (update_id != ntohl(id));
 
 EC_CLEANUP:
@@ -437,8 +437,8 @@ exec_stmt:
         EC_FAIL;
     }
 
-    retid = htonl(lookup_result_id);
-    retdid = htonl(lookup_result_did);
+    retid = htonl((uint32_t)lookup_result_id);
+    retdid = htonl((uint32_t)lookup_result_did);
     retname = lookup_result_name;
     retdev = lookup_result_dev;
     retino = lookup_result_ino;


### PR DESCRIPTION
Addresses a range of code quality and convention issues, in part aligning with improvements in the sqlite backend

- Use preformatted SQL strings in execute function rather than dynamic formatting
- The mysql CNID module uses functions declared in unix.h, notable become_root() so let's include it explicitly
- Use standard while loop instead of goto statement
- Explicit type casting, remove unused variable, merge if statements, etc.