### PR TITLE
Handle return codes from function calls consistently

### DIFF
--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -1045,7 +1045,11 @@ int afp_closevol(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
         return AFPERR_PARAM;
     }
 
-    (void)chdir("/");
+    if (chdir("/") < 0) {
+        LOG(log_error, logtype_afpd, "afp_closevol: chdir: %s", strerror(errno));
+        return AFPERR_PARAM;
+    }
+
     curdir = NULL;
     closevol(obj, vol);
     server_ipc_volumes(obj);

--- a/libatalk/adouble/ad_conv.c
+++ b/libatalk/adouble/ad_conv.c
@@ -194,8 +194,8 @@ static int ad_conv_v22ea_rf(const char *path, const struct stat *sp,
                               copybuf_len));
         adea.ad_rlen = adv2.ad_rlen;
         ad_flush(&adea);
-        fchmod(ad_reso_fileno(&adea), sp->st_mode & 0666);
-        fchown(ad_reso_fileno(&adea), sp->st_uid, sp->st_gid);
+        EC_NEG1_LOG(fchmod(ad_reso_fileno(&adea), sp->st_mode & 0666));
+        EC_NEG1_LOG(fchown(ad_reso_fileno(&adea), sp->st_uid, sp->st_gid));
     }
 
 EC_CLEANUP:

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -1984,8 +1984,17 @@ const char *ad_path_osx(const char *path, int adflags _U_)
     char    c, *slash, buf[MAXPATHLEN + 1];
 
     if (!strcmp(path, ".")) {
-        /* fixme */
-        getcwd(buf, MAXPATHLEN);
+        if (getcwd(buf, MAXPATHLEN) == NULL) {
+            LOG(log_error, logtype_default,
+                "ad_path_osx(\"%s\"): getcwd() failed in ad_path_osx: %s", path,
+                strerror(errno));
+            buf[0] = '\0';
+        } else if (strnlen(buf, MAXPATHLEN + 1) >= MAXPATHLEN) {
+            LOG(log_error, logtype_default,
+                "ad_path_osx(\"%s\"): Current working directory path too long, truncating to MAXPATHLEN",
+                path);
+            buf[MAXPATHLEN - 1] = '\0';
+        }
     } else {
         strlcpy(buf, path, MAXPATHLEN + 1);
     }

--- a/libatalk/cnid/sqlite/cnid_sqlite.c
+++ b/libatalk/cnid/sqlite/cnid_sqlite.c
@@ -368,18 +368,20 @@ int cnid_sqlite_update(struct _cnid_db *cdb,
 
     do {
         EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "BEGIN"));
-        asprintf(&sql, "DELETE FROM \"%s\" WHERE Id=%" PRIu32,
-                 db->cnid_sqlite_voluuid_str, ntohl(id));
+        EC_NEG1(asprintf(&sql, "DELETE FROM \"%s\" WHERE Id=%" PRIu32,
+                         db->cnid_sqlite_voluuid_str, ntohl(id)));
         EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, sql));
         free(sql);
         sql = NULL;
-        asprintf(&sql, "DELETE FROM \"%s\" WHERE Did = %" PRIu32 " AND Name = \"%s\"",
-                 db->cnid_sqlite_voluuid_str, ntohl(did), name);
+        EC_NEG1(asprintf(&sql, "DELETE FROM \"%s\" WHERE Did = %" PRIu32
+                         " AND Name = \"%s\"",
+                         db->cnid_sqlite_voluuid_str, ntohl(did), name));
         EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, sql));
         free(sql);
         sql = NULL;
-        asprintf(&sql, "DELETE FROM \"%s\" WHERE DevNo = %" PRIu64 " AND InodeNo = %"
-                 PRIu64, db->cnid_sqlite_voluuid_str, dev, ino);
+        EC_NEG1(asprintf(&sql, "DELETE FROM \"%s\" WHERE DevNo = %" PRIu64
+                         " AND InodeNo = %"
+                         PRIu64, db->cnid_sqlite_voluuid_str, dev, ino));
         EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, sql));
         free(sql);
         sql = NULL;
@@ -798,8 +800,8 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
                 LOG(log_info, logtype_cnid,
                     "cnid_sqlite_add: CNID set is depleted, resetting ID sequence");
                 EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "BEGIN"));
-                asprintf(&sql, "UPDATE volumes SET Depleted = 1 WHERE VolUUID = \"%s\"",
-                         db->cnid_sqlite_voluuid_str);
+                EC_NEG1(asprintf(&sql, "UPDATE volumes SET Depleted = 1 WHERE VolUUID = \"%s\"",
+                                 db->cnid_sqlite_voluuid_str));
 
                 if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
                     EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
@@ -808,7 +810,7 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
 
                 free(sql);
                 sql = NULL;
-                asprintf(&sql, "DELETE FROM \"%s\"", db->cnid_sqlite_voluuid_str);
+                EC_NEG1(asprintf(&sql, "DELETE FROM \"%s\"", db->cnid_sqlite_voluuid_str));
 
                 if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
                     EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
@@ -817,8 +819,9 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
 
                 free(sql);
                 sql = NULL;
-                asprintf(&sql, "UPDATE sqlite_sequence SET seq = 16 WHERE name = \"%s\";",
-                         db->cnid_sqlite_voluuid_str);
+                EC_NEG1(asprintf(&sql,
+                                 "UPDATE sqlite_sequence SET seq = 16 WHERE name = \"%s\";",
+                                 db->cnid_sqlite_voluuid_str));
 
                 if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
                     EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
@@ -827,11 +830,11 @@ cnid_t cnid_sqlite_add(struct _cnid_db *cdb,
 
                 free(sql);
                 sql = NULL;
-                asprintf(&sql, "INSERT INTO sqlite_sequence (name,seq) SELECT \"%s\", "
-                               "16 WHERE NOT EXISTS "
-                               "(SELECT changes() AS change "
-                               "FROM sqlite_sequence WHERE change <> 0);",
-                         db->cnid_sqlite_voluuid_str);
+                EC_NEG1(asprintf(&sql, "INSERT INTO sqlite_sequence (name,seq) SELECT \"%s\", "
+                                       "16 WHERE NOT EXISTS "
+                                       "(SELECT changes() AS change "
+                                       "FROM sqlite_sequence WHERE change <> 0);",
+                                 db->cnid_sqlite_voluuid_str));
 
                 if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
                     EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
@@ -1064,8 +1067,9 @@ int cnid_sqlite_wipe(struct _cnid_db *cdb)
     }
 
     EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "BEGIN"));
-    asprintf(&sql, "UPDATE volumes SET Depleted = 0 WHERE VolUUID = \"%s\";",
-             db->cnid_sqlite_voluuid_str);
+    EC_NEG1(asprintf(&sql,
+                     "UPDATE volumes SET Depleted = 0 WHERE VolUUID = \"%s\";",
+                     db->cnid_sqlite_voluuid_str));
 
     if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
         EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
@@ -1074,7 +1078,7 @@ int cnid_sqlite_wipe(struct _cnid_db *cdb)
 
     free(sql);
     sql = NULL;
-    asprintf(&sql, "DELETE FROM \"%s\";", db->cnid_sqlite_voluuid_str);
+    EC_NEG1(asprintf(&sql, "DELETE FROM \"%s\";", db->cnid_sqlite_voluuid_str));
 
     if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
         EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
@@ -1083,8 +1087,9 @@ int cnid_sqlite_wipe(struct _cnid_db *cdb)
 
     free(sql);
     sql = NULL;
-    asprintf(&sql, "UPDATE sqlite_sequence SET seq = 16 WHERE name = \"%s\";",
-             db->cnid_sqlite_voluuid_str);
+    EC_NEG1(asprintf(&sql,
+                     "UPDATE sqlite_sequence SET seq = 16 WHERE name = \"%s\";",
+                     db->cnid_sqlite_voluuid_str));
 
     if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
         EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
@@ -1093,9 +1098,9 @@ int cnid_sqlite_wipe(struct _cnid_db *cdb)
 
     free(sql);
     sql = NULL;
-    asprintf(&sql,
-             "INSERT INTO sqlite_sequence (name,seq) SELECT \"%s\", 16 WHERE NOT EXISTS (SELECT changes() AS change FROM sqlite_sequence WHERE change <> 0);",
-             db->cnid_sqlite_voluuid_str);
+    EC_NEG1(asprintf(&sql,
+                     "INSERT INTO sqlite_sequence (name,seq) SELECT \"%s\", 16 WHERE NOT EXISTS (SELECT changes() AS change FROM sqlite_sequence WHERE change <> 0);",
+                     db->cnid_sqlite_voluuid_str));
 
     if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
         EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
@@ -1316,16 +1321,16 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
     sqlite3_reset(transient_stmt);
     sqlite3_clear_bindings(transient_stmt);
     /* Create volume table */
-    asprintf(&sql, "CREATE TABLE IF NOT EXISTS \"%s\" ("
-                   "Id INTEGER PRIMARY KEY AUTOINCREMENT,"
-                   "Name VARCHAR(255) NOT NULL,"
-                   "Did INTEGER NOT NULL,"
-                   "DevNo INTEGER NOT NULL,"
-                   "InodeNo INTEGER NOT NULL,"
-                   "UNIQUE (Did, Name),"
-                   "UNIQUE (DevNo, InodeNo)"
-                   ");",
-             db->cnid_sqlite_voluuid_str);
+    EC_NEG1(asprintf(&sql, "CREATE TABLE IF NOT EXISTS \"%s\" ("
+                           "Id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                           "Name VARCHAR(255) NOT NULL,"
+                           "Did INTEGER NOT NULL,"
+                           "DevNo INTEGER NOT NULL,"
+                           "InodeNo INTEGER NOT NULL,"
+                           "UNIQUE (Did, Name),"
+                           "UNIQUE (DevNo, InodeNo)"
+                           ");",
+                     db->cnid_sqlite_voluuid_str));
 
     if (cnid_sqlite_execute(db->cnid_sqlite_con, sql)) {
         EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
@@ -1367,8 +1372,9 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
         LOG(log_debug, logtype_cnid,
             "Creating new CNID table for volume '%s' with ID sequence starting at 16",
             vol->v_path);
-        asprintf(&sql, "UPDATE sqlite_sequence SET seq = 16 WHERE name = \"%s\";",
-                 db->cnid_sqlite_voluuid_str);
+        EC_NEG1(asprintf(&sql,
+                         "UPDATE sqlite_sequence SET seq = 16 WHERE name = \"%s\";",
+                         db->cnid_sqlite_voluuid_str));
 
         if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
             EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));
@@ -1377,11 +1383,11 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
 
         free(sql);
         sql = NULL;
-        asprintf(&sql, "INSERT INTO sqlite_sequence (name,seq) SELECT \"%s\","
-                       "16 WHERE NOT EXISTS "
-                       "(SELECT changes() AS change "
-                       "FROM sqlite_sequence WHERE change <> 0);",
-                 db->cnid_sqlite_voluuid_str);
+        EC_NEG1(asprintf(&sql, "INSERT INTO sqlite_sequence (name,seq) SELECT \"%s\","
+                               "16 WHERE NOT EXISTS "
+                               "(SELECT changes() AS change "
+                               "FROM sqlite_sequence WHERE change <> 0);",
+                         db->cnid_sqlite_voluuid_str));
 
         if (cnid_sqlite_execute(db->cnid_sqlite_con, sql) < 0) {
             EC_NEG1(cnid_sqlite_execute(db->cnid_sqlite_con, "ROLLBACK"));

--- a/libatalk/util/ftw.c
+++ b/libatalk/util/ftw.c
@@ -833,12 +833,20 @@ static int ftw_startup(const char *dir,
     /* Return to the start directory (if necessary).  */
     if (cwdfd != -1) {
         int save_err = errno;
-        __fchdir(cwdfd);
+
+        if (__fchdir(cwdfd) < 0) {
+            result = -1;
+        }
+
         close(cwdfd);
         __set_errno(save_err);
     } else if (cwd != NULL) {
         int save_err = errno;
-        __chdir(cwd);
+
+        if (__chdir(cwd) < 0) {
+            result = -1;
+        }
+
         free(cwd);
         __set_errno(save_err);
     }

--- a/libatalk/util/logger.c
+++ b/libatalk/util/logger.c
@@ -529,7 +529,15 @@ void make_log_entry(enum loglevels loglevel, enum logtypes logtype,
         goto exit;
     }
 
-    write(fd, log_message, len);
+    if (write(fd, log_message, len) < 0) {
+        LOG(log_error, logtype_logger,
+            "make_log_entry: write to log file %s failed: %s",
+            log_src_filename, strerror(errno));
+        close(fd);
+        type_configs[logtype].fd = -1;
+        goto exit;
+    }
+
     free(log_message);
     free(user_message);
 exit:

--- a/libatalk/util/unix.c
+++ b/libatalk/util/unix.c
@@ -153,8 +153,19 @@ int daemonize(void)
 
     closeall(0);
     open("/dev/null", O_RDWR);
-    dup(0);
-    dup(0);
+
+    if (dup(0) < 0) {
+        LOG(log_error, logtype_default, "Can't dup /dev/null first time: %s",
+            strerror(errno));
+        return -1;
+    }
+
+    if (dup(0) < 0) {
+        LOG(log_error, logtype_default, "Can't dup /dev/null second time: %s",
+            strerror(errno));
+        return -1;
+    }
+
     return 0;
 }
 

--- a/meson.build
+++ b/meson.build
@@ -1359,9 +1359,10 @@ else
         if cc.has_function('getxattr', dependencies: attr)
             acl_deps += attr
         endif
-        if glib.found()
-            acl_deps += glib
-        endif
+    endif
+
+    if glib.found()
+        acl_deps += glib
     endif
 
     acl_get_entry_code = '''

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -947,7 +947,10 @@ int main(int ac, char **av)
     }
 
     if (! Debug) {
-        freopen("/dev/null", "w", stdout);
+        if (freopen("/dev/null", "w", stdout) == NULL) {
+            fprintf(stderr, "Error: Could not redirect stdout to /dev/null\n");
+            exit(1);
+        }
     }
 
 #if 0


### PR DESCRIPTION
Consistently handle return values from non-void functions, and exit the function/program early with logging on failure

This appeases the -Wunused-result compiler flag

Also includes a small meson change to always link with glib when building POSIX ACLs, not just on Linux.