### PR TITLE
Properly support LocalSearch and remove Tracker < v3 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -260,6 +260,7 @@ jobs:
             libdb-devel \
             libgcrypt-devel \
             libtalloc-devel \
+            localsearch \
             mariadb-connector-c-devel \
             meson \
             ninja-build \
@@ -272,8 +273,7 @@ jobs:
             sqlite-devel \
             systemd \
             systemtap-sdt-devel \
-            tracker \
-            tracker-devel
+            tinysparql-devel
       - name: Configure
         run: |
           meson setup build \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -73,8 +73,8 @@ required at the bare minimum.
 | Package    | Details |
 |------------|---------|
 | D-Bus      | Also used by avahi and afpstats |
+| localsearch **OR** tracker | v3.0 or later |
 | talloc     |  |
-| tracker **OR** localsearch | v0.12 or later|
 | bison      |  |
 | flex       |  |
 

--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -189,15 +189,11 @@ functionality.
     detection of host name spoofing or host address spoofing; booby traps
     to implement an early-warning system.
 
-- Tracker, or TinySPARQL / LocalSearch
+- LocalSearch or Tracker
 
-    Netatalk uses [Tracker](https://tracker.gnome.org) or its later
-    incarnation
-    TinySPARQL/[LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/)
-    as the metadata backend for Spotlight
-    search indexing. The minimum required version is 0.12 as this was the
-    first version to support
-    [SPARQL](https://gnome.pages.gitlab.gnome.org/tracker/).
+    Netatalk uses [GNOME LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/index.html),
+    or Tracker as it was previously known, version 3 or later as the metadata backend for Spotlight
+    compatible search indexing.
 
 - talloc / bison / flex
 

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -86,7 +86,8 @@ static bool service_running(pid_t pid)
     return false;
 }
 
-/* Set Tracker Miners to index all our volumes */
+#ifdef WITH_SPOTLIGHT
+/* Set indexers to index all our volumes */
 static int set_sl_volumes(void)
 {
     EC_INIT;
@@ -104,12 +105,13 @@ static int set_sl_volumes(void)
     }
 
     volnamelist = bjoin(vollist, sep);
-    cmd = bformat("gsettings set org.freedesktop.Tracker.Miner.Files index-recursive-directories \"[%s]\"",
+    cmd = bformat("gsettings set " INDEXER_DBUS_NAME
+                  " index-recursive-directories \"[%s]\"",
                   bdata(volnamelist) ? bdata(volnamelist) : "");
     LOG(log_debug, logtype_sl, "set_sl_volumes: %s", bdata(cmd));
     system(bdata(cmd));
     /* Disable default root user home indexing */
-    system("gsettings set org.freedesktop.Tracker.Miner.Files index-single-directories \"[]\"");
+    system("gsettings set " INDEXER_DBUS_NAME " index-single-directories \"[]\"");
 EC_CLEANUP:
 
     if (cmd) {
@@ -130,6 +132,7 @@ EC_CLEANUP:
 
     EC_EXIT;
 }
+#endif /* WITH_SPOTLIGHT */
 
 /******************************************************************
  * libevent helper functions

--- a/include/atalk/spotlight.h
+++ b/include/atalk/spotlight.h
@@ -22,14 +22,13 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-
 #include <gio/gio.h>
 
-#ifndef HAVE_TRACKER3
-#include <libtracker-miner/tracker-miner.h>
-#endif
-
+#ifdef HAVE_TRACKER3
 #include <tracker-sparql.h>
+#else
+#include <tinysparql.h>
+#endif
 
 #include <atalk/globals.h>
 #include <atalk/volume.h>

--- a/meson.build
+++ b/meson.build
@@ -943,8 +943,6 @@ endif
 # Check for Spotlight support
 #
 
-tracker_prefix = get_option('with-tracker-prefix')
-
 have_spotlight = false
 
 if get_option('with-spotlight')
@@ -963,95 +961,50 @@ if get_option('with-spotlight')
 
     # Check for SPARQL
 
-    sparql_versions = ['tracker-sparql-3.0', 'tracker-sparql-2.0', 'tracker-sparql-1.0']
+    sparql_found = false
+    tinysparql = dependency('tinysparql-3.0', required: false)
+    tracker_sparql = dependency('tracker-sparql-3.0', required: false)
 
-    foreach sparql_version : sparql_versions
-        sparql = dependency(sparql_version, required: false)
-        if sparql.found()
-            break
-        endif
-    endforeach
+    if tinysparql.found()
+        sparql_found = true
+        sparql = tinysparql
+    elif tracker_sparql.found()
+        sparql_found = true
+        sparql = tracker_sparql
+        cdata.set('HAVE_TRACKER3', 1)
+    endif
 
-    if not sparql.found()
-        warning(
-            'Tracker SPARQL or TinySPARQL not found (required for Spotlight support)',
-        )
-    else
-        sparql_prefix = sparql.get_variable(pkgconfig: 'prefix')
+    # Check for indexer
 
-        # Check for indexer
+    indexer_found = false
+    localsearch = find_program('localsearch', required: false)
+    tracker3 = find_program('tracker3', required: false)
 
-        if tracker_prefix != ''
-            indexer_dirs = [tracker_prefix + '/bin']
-        else
-            indexer_dirs = []
-        endif
-
-        tracker = find_program(
-            'tracker',
-            dirs: indexer_dirs,
-            required: false,
-        )
-        tracker3 = find_program(
-            'tracker3',
-            dirs: indexer_dirs,
-            required: false,
-        )
-        tracker_control = find_program(
-            'tracker-control',
-            dirs: indexer_dirs,
-            required: false,
-        )
-        localsearch = find_program(
-            'localsearch',
-            dirs: indexer_dirs,
-            required: false,
-        )
-
-        indexer_command = ''
-
-        if localsearch.found()
-            cdata.set('HAVE_TRACKER3', 1)
-            indexer_command = localsearch.full_path() + ' daemon'
-        elif tracker3.found()
-            cdata.set('HAVE_TRACKER3', 1)
-            indexer_command = tracker3.full_path() + ' daemon'
-        elif tracker.found()
-            indexer_command = tracker.full_path() + ' daemon'
-        elif tracker_control.found()
-            indexer_command = tracker_control.full_path()
-        endif
-        indexer_found = (
-            tracker.found()
-            or tracker3.found()
-            or tracker_control.found()
-            or localsearch.found()
-        )
-        if indexer_found
-            cdata.set('INDEXER_COMMAND', '"' + indexer_command + '"')
-        else
-            warning(
-                'Tracker or LocalSearch not found (required for Spotlight support)',
-            )
-        endif
-        if not talloc.found()
-            warning(
-                'talloc library not found (required for Spotlight support)',
-            )
-        endif
+    if localsearch.found()
+        indexer_found = true
+        cdata.set('INDEXER_DBUS_NAME', '"org.freedesktop.LocalSearch3"')
+        cdata.set('INDEXER_COMMAND', '"' + localsearch.full_path() + ' daemon"')
+    elif tracker3.found()
+        indexer_found = true
+        cdata.set('INDEXER_DBUS_NAME', '"org.freedesktop.Tracker3.Miner.Files"')
+        cdata.set('INDEXER_COMMAND', '"' + tracker3.full_path() + ' daemon"')
     endif
 
     have_spotlight = (
-        sparql.found()
+        sparql_found
         and indexer_found
         and talloc.found()
         and flex.found()
         and bison.found()
     )
-endif
 
-if have_spotlight
-    cdata.set('WITH_SPOTLIGHT', 1)
+    if have_spotlight
+        cdata.set('WITH_SPOTLIGHT', 1)
+    else
+        warning(
+            'Spotlight support requested but required libraries not found',
+        )
+    endif
 endif
 
 #
@@ -2500,11 +2453,6 @@ summary_info = {
     '  Print spool directory': spooldir,
     '  User home basedir': homedir,
 }
-if have_spotlight
-    summary_info += {
-        '  Indexer command': indexer_command,
-    }
-endif
 summary(summary_info, bool_yn: true, section: '  Paths:')
 
 summary_info = {

--- a/meson_config.h
+++ b/meson_config.h
@@ -394,6 +394,9 @@
 /* Indexer managing command */
 #mesondefine INDEXER_COMMAND
 
+/* Indexer D-Bus name */
+#mesondefine INDEXER_DBUS_NAME
+
 /* Define if cracklib should be used */
 #mesondefine USE_CRACKLIB
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -352,18 +352,6 @@ option(
     description: 'Set path for statedir used for CNID databases etc.',
 )
 option(
-    'with-tracker-install-prefix',
-    type: 'string',
-    value: '',
-    description: 'Set Tracker installation prefix',
-)
-option(
-    'with-tracker-prefix',
-    type: 'string',
-    value: '',
-    description: 'Set Tracker prefix',
-)
-option(
     'with-uams-path',
     type: 'string',
     value: 'libdir / netatalk',

--- a/testsuite_deb.Dockerfile
+++ b/testsuite_deb.Dockerfile
@@ -86,7 +86,6 @@ RUN meson setup build \
     -Dwith-spooldir=/var/spool/netatalk \
     -Dwith-tcp-wrappers=false \
     -Dwith-testsuite=true \
-    -Dwith-tracker-prefix=/usr \
 &&  meson compile -C build
 
 RUN meson install --destdir=/staging/ -C build


### PR DESCRIPTION
Tighten up dependency checks for LocalSearch and TinySPARQL in meson

When detected, use TinySPARQL header and LocalSearch API, rather than the deprecated Tracker backward compatibility fallbacks

This fixes a bug where LocalSearch failed to register a D-Bus service using a too old D-Bus name (pre-Tracker3)

At the same time, remove compatibility checks and code for Tracker older than v3, which have been deprecated since 2020

The obsoleted meson options -Dwith-tracker-install-prefix and -Dwith-tracker-prefix have been removed as well