### PR TITLE
GitHub CI: Arrange for all privileged jobs to run as workflow triggers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,7 @@ on:
       - "**.md"
       - "**/COPYING"
       - "**/README*"
-      - "contrib/webmin_module/**"
       - "COPYRIGHT"
-      - "*Dockerfile"
   pull_request:
     branches:
       - main
@@ -23,9 +21,7 @@ on:
       - "**.md"
       - "**/COPYING"
       - "**/README*"
-      - "contrib/webmin_module/**"
       - "COPYRIGHT"
-      - "*Dockerfile"
 
 permissions: read-all
 

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -1,9 +1,9 @@
 name: Code Analysis
 on:
   workflow_run:
-    workflows: ["Builds"]
+    workflows: [Tests]
     types: 
-      - requested
+      - completed
 
 permissions: read-all
 

--- a/.github/workflows/container_runs.yml
+++ b/.github/workflows/container_runs.yml
@@ -14,6 +14,7 @@ jobs:
         name: AFP spec test (cnid:dbd) AFP 3.4 - Alpine (Prod)
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Create Docker network
               run: |
@@ -56,6 +57,7 @@ jobs:
         name: AFP spec test (cnid:mysql) AFP 3.4 - Alpine (Prod)
         runs-on: ubuntu-latest
         timeout-minutes: 10
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Create container network
               run: |
@@ -111,6 +113,7 @@ jobs:
         name: AFP spec test (cnid:mysql) AFP 3.4 - Debian
         runs-on: ubuntu-latest
         timeout-minutes: 10
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Create container network
               run: |
@@ -150,6 +153,7 @@ jobs:
         name: AFP spec test (cnid:sqlite) AFP 3.4 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -174,6 +178,7 @@ jobs:
         name: AFP spec test (cnid:sqlite) AFP 3.4 - Debian
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -198,6 +203,7 @@ jobs:
         name: AFP spec test (ea:sys) AFP 3.4 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -221,6 +227,7 @@ jobs:
         name: AFP spec test (ea:sys) AFP 3.4 - Debian
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -244,6 +251,7 @@ jobs:
         name: AFP spec test (ea:ad) AFP 3.4 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -268,6 +276,7 @@ jobs:
         name: AFP spec test (ea:ad) AFP 3.4 - Debian
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -292,6 +301,7 @@ jobs:
         name: AFP spec test (ea:sys) AFP 3.3 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -315,6 +325,7 @@ jobs:
         name: AFP spec test (ea:sys) AFP 3.2 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -338,6 +349,7 @@ jobs:
         name: AFP spec test (ea:sys) AFP 3.1 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -361,6 +373,7 @@ jobs:
         name: AFP spec test (ea:sys) AFP 3.0 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -384,6 +397,7 @@ jobs:
         name: AFP spec test (ea:sys) AFP 3.0 - Debian
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -407,6 +421,7 @@ jobs:
         name: AFP spec test (ea:sys) AFP 2.2 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -430,6 +445,7 @@ jobs:
         name: AFP spec test (ea:sys) AFP 2.1 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -453,6 +469,7 @@ jobs:
         name: AFP spec test (ea:sys) AFP 2.1 - Debian
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -476,6 +493,7 @@ jobs:
         name: AFP spec test (ea:ad) AFP 2.1 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -500,6 +518,7 @@ jobs:
         name: AFP spec test (ea:ad) AFP 2.1 - Debian
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -524,6 +543,7 @@ jobs:
         name: AFP spec test (readonly) AFP 3.4 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -543,6 +563,7 @@ jobs:
         name: AFP spec test (readonly) AFP 2.1 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -562,6 +583,7 @@ jobs:
         name: AFP login test AFP 3.4 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -579,6 +601,7 @@ jobs:
         name: AFP login test AFP 2.1 - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -596,6 +619,7 @@ jobs:
         name: AFP lantest - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -614,6 +638,7 @@ jobs:
         name: AFP speedtest - Alpine
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
         steps:
             - name: Run Netatalk testsuite
               run: |

--- a/.github/workflows/container_runs.yml
+++ b/.github/workflows/container_runs.yml
@@ -1,7 +1,7 @@
 name: Container Test Runs
 on:
   workflow_run:
-    workflows: ["Containers"]
+    workflows: [Containers]
     types: 
       - completed
 

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,23 +1,9 @@
-name: Containers
+name: Build Containers
 on:
-    push:
-        branches: [ "main" ]
-        paths-ignore:
-          - "**.md"
-          - "**/COPYING"
-          - "**/README*"
-          - ".github/workflows/build.yml"
-          - "contrib/webmin_module/**"
-          - "COPYRIGHT"
-    pull_request:
-        branches: [ "main" ]
-        paths-ignore:
-          - "**.md"
-          - "**/COPYING"
-          - "**/README*"
-          - ".github/workflows/build.yml"
-          - "contrib/webmin_module/**"
-          - "COPYRIGHT"
+  workflow_run:
+    workflows: [Tests]
+    types:
+      - completed
 
 permissions: read-all
 env:
@@ -29,7 +15,6 @@ jobs:
         name: Build production container
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         permissions:
             contents: read
             packages: write
@@ -69,7 +54,6 @@ jobs:
         name: Build Alpine testsuite container
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         permissions:
             contents: read
             packages: write
@@ -109,7 +93,6 @@ jobs:
         name: Build Netatalk Webmin Module container
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         permissions:
             contents: read
             packages: write
@@ -149,7 +132,6 @@ jobs:
         name: Build Debian testsuite container
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: ${{ !github.event.pull_request.head.repo.fork }}
         permissions:
             contents: read
             packages: write


### PR DESCRIPTION
A few tweaks to the workflows so that only non-privileged jobs are triggered directly by the PR, with the rest triggering indirectly to grant them access to secrets

Run the container test runs only on container build success: Only a successful container build workflow will result in usable containers

Containers workflow triggered off of the Tests workflow: Also loosens up the trigger criteria for other workflows