### PR TITLE
GitHub CI: GitHub Pages workflow needs CA certs

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,6 +34,7 @@ jobs:
           apt-get update
           apt-get install --assume-yes --no-install-recommends \
             build-essential \
+            ca-certificates \
             cmark-gfm \
             libdb-dev \
             libevent-dev \


### PR DESCRIPTION
To pull tarballs over secure connections (bstring subproject) we need the ca-certificates package on Debian