### PR TITLE
GitHub CI: Trigger the Container Test Runs workflow off the correct workflow

### DIFF
--- a/.github/workflows/container_runs.yml
+++ b/.github/workflows/container_runs.yml
@@ -1,7 +1,7 @@
 name: Container Test Runs
 on:
   workflow_run:
-    workflows: [Containers]
+    workflows: [Build Containers]
     types: 
       - completed
 


### PR DESCRIPTION
This was a missing update after rearranging the workflow triggers earlier (cumbersome that you cannot test workflow triggers in a PR)