### PR TITLE
Move ftw code from libatalk into the ad binary

### DIFF
--- a/bin/ad/ad.h
+++ b/bin/ad/ad.h
@@ -23,7 +23,6 @@
 #include <atalk/globals.h>
 #include <atalk/cnid.h>
 #include <atalk/compat.h>
-#include <atalk/ftw.h>
 #include <atalk/volume.h>
 
 #define DIR_DOT_OR_DOTDOT(a) \

--- a/bin/ad/ad_cp.c
+++ b/bin/ad/ad_cp.c
@@ -64,7 +64,6 @@
 #include <bstrlib.h>
 
 #include <atalk/adouble.h>
-#include <atalk/ftw.h>
 #include <atalk/queue.h>
 #include <atalk/unix.h>
 #include <atalk/util.h>
@@ -72,6 +71,7 @@
 #include <atalk/volume.h>
 
 #include "ad.h"
+#include "ftw.h"
 
 #define STRIP_TRAILING_SLASH(p) {                                   \
         while ((p).p_end > (p).p_path + 1 && (p).p_end[-1] == '/')  \

--- a/bin/ad/ad_mv.c
+++ b/bin/ad/ad_mv.c
@@ -31,7 +31,6 @@
 #include <bstrlib.h>
 
 #include <atalk/adouble.h>
-#include <atalk/ftw.h>
 #include <atalk/queue.h>
 #include <atalk/unix.h>
 #include <atalk/util.h>

--- a/bin/ad/ad_rm.c
+++ b/bin/ad/ad_rm.c
@@ -29,7 +29,6 @@
 #include <bstrlib.h>
 
 #include <atalk/adouble.h>
-#include <atalk/ftw.h>
 #include <atalk/queue.h>
 #include <atalk/unix.h>
 #include <atalk/util.h>
@@ -37,6 +36,7 @@
 #include <atalk/volume.h>
 
 #include "ad.h"
+#include "ftw.h"
 
 #define STRIP_TRAILING_SLASH(p) {                                   \
         while ((p).p_end > (p).p_path + 1 && (p).p_end[-1] == '/')  \

--- a/bin/ad/ftw.c
+++ b/bin/ad/ftw.c
@@ -113,7 +113,6 @@
 # define NFTW_NAME nftw
 # define NFTW_OLD_NAME __old_nftw
 # define NFTW_NEW_NAME __new_nftw
-# define INO_T ino_t
 # define STAT stat
 # define LXSTAT(V,f,sb) lstat (f,sb)
 # define XSTAT(V,f,sb) stat (f,sb)
@@ -137,7 +136,7 @@ struct dir_data {
 
 struct known_object {
     dev_t dev;
-    INO_T ino;
+    ino_t ino;
 };
 
 struct ftw_data {
@@ -163,7 +162,7 @@ struct ftw_data {
     const int *cvt_arr;
 
     /* Callback function.  We always use the `nftw' form.  */
-    NFTW_FUNC_T func;
+    nftw_func_t func;
 
     /* Device of starting point.  Needed for FTW_MOUNT.  */
     dev_t dev;
@@ -756,7 +755,7 @@ static int ftw_startup(const char *dir,
        every case the callback using the format of the `nftw' version
        and get the correct result since the stack layout for a function
        call in C allows this.  */
-    data.func = (NFTW_FUNC_T) func;
+    data.func = (nftw_func_t) func;
     /* Since we internally use the complete set of FTW_* values we need
        to reduce the value range before calling a `ftw' callback.  */
     data.cvt_arr = is_nftw ? nftw_arr : ftw_arr;
@@ -895,7 +894,7 @@ out_fail:
 
 /* Entry points.  */
 int NFTW_NAME(const char *path,
-              NFTW_FUNC_T func,
+              nftw_func_t func,
               dir_notification_func_t up,
               int descriptors,
               int flags)

--- a/bin/ad/ftw.c
+++ b/bin/ad/ftw.c
@@ -53,29 +53,53 @@
 #include <assert.h>
 
 #ifndef _LIBC
+# ifdef __chdir
 # undef __chdir
+# endif
 # define __chdir chdir
+# ifdef __closedir
 # undef __closedir
+# endif
 # define __closedir closedir
+# ifdef __fchdir
 # undef __fchdir
+# endif
 # define __fchdir fchdir
+# ifdef __getcwd
 # undef __getcwd
+# endif
 # define __getcwd(P, N) xgetcwd ()
+# ifdef __mempcpy
 # undef __mempcpy
+# endif
 # define __mempcpy mempcpy
+# ifdef __opendir
 # undef __opendir
+# endif
 # define __opendir opendir
+# ifdef __readdir64
 # undef __readdir64
+# endif
 # define __readdir64 readdir
+# ifdef __tdestroy
 # undef __tdestroy
+# endif
 # define __tdestroy tdestroy
+# ifdef __tfind
 # undef __tfind
+# endif
 # define __tfind tfind
+# ifdef __tsearch
 # undef __tsearch
+# endif
 # define __tsearch tsearch
+# ifdef internal_function
 # undef internal_function
+# endif
 # define internal_function /* empty */
+# ifdef dirent64
 # undef dirent64
+# endif
 # define dirent64 dirent
 #endif
 

--- a/bin/ad/ftw.c
+++ b/bin/ad/ftw.c
@@ -859,7 +859,7 @@ static int ftw_startup(const char *dir,
 
     /* Return to the start directory (if necessary).  */
     if (cwdfd != -1) {
-        int save_err = errno;
+        save_err = errno;
 
         if (__fchdir(cwdfd) < 0) {
             result = -1;
@@ -868,7 +868,7 @@ static int ftw_startup(const char *dir,
         close(cwdfd);
         __set_errno(save_err);
     } else if (cwd != NULL) {
-        int save_err = errno;
+        save_err = errno;
 
         if (__chdir(cwd) < 0) {
             result = -1;

--- a/bin/ad/ftw.c
+++ b/bin/ad/ftw.c
@@ -193,7 +193,7 @@ static int ftw_dir(struct ftw_data *data, struct STAT *st,
 
 typedef void (*__free_fn_t)(void *__nodep);
 typedef struct node_t {
-    const void *key;
+    void *key;
     struct node_t *left;
     struct node_t *right;
     unsigned int red: 1;
@@ -209,7 +209,7 @@ static void tdestroy_recurse(node root, __free_fn_t freefct)
         tdestroy_recurse(root->right, freefct);
     }
 
-    (*freefct)((void *) root->key);
+    (*freefct)(root->key);
     /* Free the node itself.  */
     free(root);
 }

--- a/bin/ad/ftw.c
+++ b/bin/ad/ftw.c
@@ -592,7 +592,7 @@ ftw_dir(struct ftw_data *data, struct STAT *st, struct dir_data *old_dir)
         *startp++ = '/';
     }
 
-    data->ftw.base = startp - data->dirbuf;
+    data->ftw.base = (int)(startp - data->dirbuf);
 
     while (dir.stream != NULL && (d = __readdir64(dir.stream)) != NULL) {
         result = process_entry(data, &dir, d->d_name, NAMLEN(d));
@@ -744,7 +744,7 @@ static int ftw_startup(const char *dir,
         --cp;
     }
 
-    data.ftw.base = cp - data.dirbuf;
+    data.ftw.base = (int)(cp - data.dirbuf);
     data.flags = flags;
     /* This assignment might seem to be strange but it is what we want.
        The trick is that the first three arguments to the `ftw' and

--- a/bin/ad/ftw.c
+++ b/bin/ad/ftw.c
@@ -231,7 +231,7 @@ static char *mystpcpy(char *a, const char *b)
 static char *xgetcwd(void)
 {
     char *cwd;
-    char *ret;
+    const char *ret;
     unsigned path_max;
     errno = 0;
     path_max = (unsigned) PATH_MAX;
@@ -314,7 +314,7 @@ open_dir_stream(int *dfdp, struct ftw_data *data, struct dir_data *dirp)
             result = -1;
         } else {
             DIR *st = data->dirstreams[data->actdir]->stream;
-            struct dirent64 *d;
+            const struct dirent64 *d;
             size_t actsize = 0;
             const size_t MAX_FILENAME_LEN = 255;
             const size_t MAX_BUFFER_SIZE = 1024 * 1024;
@@ -546,7 +546,7 @@ static int
 ftw_dir(struct ftw_data *data, struct STAT *st, struct dir_data *old_dir)
 {
     struct dir_data dir;
-    struct dirent64 *d;
+    const struct dirent64 *d;
     int previous_base = data->ftw.base;
     int result;
     char *startp;
@@ -620,10 +620,10 @@ ftw_dir(struct ftw_data *data, struct STAT *st, struct dir_data *old_dir)
         data->dirstreams[data->actdir] = NULL;
     } else {
         int save_err;
-        char *runp = dir.content;
+        const char *runp = dir.content;
 
         while (result == 0 && *runp != '\0') {
-            char *endp = strchr(runp, '\0');
+            const char *endp = strchr(runp, '\0');
             /* XXX Should store the d_type values as well?! */
             result = process_entry(data, &dir, runp, endp - runp);
             runp = endp + 1;

--- a/bin/ad/ftw.c
+++ b/bin/ad/ftw.c
@@ -576,12 +576,10 @@ ftw_dir(struct ftw_data *data, struct STAT *st, struct dir_data *old_dir)
     }
 
     /* If necessary, change to this directory.  */
-    if (data->flags & FTW_CHDIR) {
-        if (__fchdir(dirfd(dir.stream)) < 0) {
-            result = -1;
-            need_cleanup = 1;
-            goto cleanup;
-        }
+    if (data->flags & FTW_CHDIR && __fchdir(dirfd(dir.stream)) < 0) {
+        result = -1;
+        need_cleanup = 1;
+        goto cleanup;
     }
 
     /* Next, update the `struct FTW' information.  */
@@ -677,10 +675,9 @@ cleanup:
         /* Change back to the parent directory.  */
         int done = 0;
 
-        if (old_dir->stream != NULL)
-            if (__fchdir(dirfd(old_dir->stream)) == 0) {
-                done = 1;
-            }
+        if (old_dir->stream != NULL && __fchdir(dirfd(old_dir->stream)) == 0) {
+            done = 1;
+        }
 
         if (!done) {
             if (data->ftw.base == 1) {

--- a/bin/ad/ftw.c
+++ b/bin/ad/ftw.c
@@ -41,9 +41,9 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-#include <atalk/ftw.h>
-#include <atalk/globals.h>
 #include <atalk/util.h>
+
+#include "ftw.h"
 
 #ifndef HAVE_MEMPCPY
 #define mempcpy(D, S, N) ((void *) ((char *) memcpy (D, S, N) + (N)))
@@ -293,13 +293,14 @@ open_dir_stream(int *dfdp, struct ftw_data *data, struct dir_data *dirp)
             DIR *st = data->dirstreams[data->actdir]->stream;
             struct dirent64 *d;
             size_t actsize = 0;
-            const size_t MAX_BUFFER_SIZE = 1024 * 1024; /* 1MB buffer limit */
+            const size_t MAX_FILENAME_LEN = 255;
+            const size_t MAX_BUFFER_SIZE = 1024 * 1024;
 
             while ((d = __readdir64(st)) != NULL) {
                 size_t this_len = NAMLEN(d);
 
-                if (this_len > UTF8FILELEN_EARLY) {
-                    this_len = UTF8FILELEN_EARLY;
+                if (this_len > MAX_FILENAME_LEN) {
+                    this_len = MAX_FILENAME_LEN;
                 }
 
                 /* Check if we need more space with overflow protection */

--- a/bin/ad/ftw.h
+++ b/bin/ad/ftw.h
@@ -20,9 +20,6 @@
  *	X/Open Portability Guide 4.2: ftw.h
  */
 
-#ifndef _ATALK_FTW_H
-#define	_ATALK_FTW_H	1
-
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -101,5 +98,3 @@ extern int nftw(const char *dir,
                 dir_notification_func_t up,
                 int descriptors,
                 int flag);
-
-#endif	/* ATALK_FTW_H */

--- a/bin/ad/ftw.h
+++ b/bin/ad/ftw.h
@@ -89,7 +89,6 @@ typedef int (*nftw_func_t)(const char *filename,
                            const struct stat *status,
                            int flag,
                            struct FTW *info);
-#define NFTW_FUNC_T nftw_func_t
 
 typedef void (*dir_notification_func_t)(void);
 

--- a/bin/ad/meson.build
+++ b/bin/ad/meson.build
@@ -8,6 +8,8 @@ ad_sources = [
     'ad_util.c',
     'ad.c',
     'ad.h',
+    'ftw.c',
+    'ftw.h',
 ]
 
 ad_deps = [bstring, iniparser]

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -41,7 +41,6 @@
 #include <atalk/ea.h>
 #include <atalk/errchk.h>
 #include <atalk/fce_api.h>
-#include <atalk/ftw.h>
 #include <atalk/globals.h>
 
 #ifdef HAVE_LDAP

--- a/libatalk/util/meson.build
+++ b/libatalk/util/meson.build
@@ -3,7 +3,6 @@ util_sources = [
     'bprint.c',
     'cnid.c',
     'fault.c',
-    'ftw.c',
     'getiface.c',
     'gettok.c',
     'locking.c',


### PR DESCRIPTION
The file tree walker functions are only used narrowly in the ad binary, so let's move it out of the shared libatalk library to reduce bloat

Removes the ftw.h header file from a few source files where the symbols aren't used

At the same time, fix a handful of code smells and security hotspots reported by SonarQube