### PR TITLE
GitHub CI: Directly trigger SonarQube workflow again

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -1,9 +1,17 @@
 name: Code Analysis
 on:
-  workflow_run:
-    workflows: [Tests]
-    types: 
-      - completed
+  push:
+    branches:
+      - main
+      - branch-*
+  pull_request:
+    branches:
+      - main
+      - branch-*
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 permissions: read-all
 
@@ -11,6 +19,7 @@ jobs:
     static_analysis:
         name: SonarQube Static Analysis
         runs-on: ubuntu-latest
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         env:
           BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
         steps:


### PR DESCRIPTION
When using the indirect workflow trigger, the SonarQube static analysis wrapper doesn't seem to work properly, not picking up the latest code and therefore not doing any static analysis since the cache is used 100%

So this brings back the previous behavior of triggering this workflow directly, but only for PRs originating from the project and not forks