### PR TITLE
meson: Add glib runtime dependency for ACLs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
             dbus-dev \
             flex \
             gcc \
+            glib \
             iniparser-dev \
             krb5-dev \
             libevent-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ARG RUN_DEPS="\
     cups \
     db \
     dbus \
+    glib \
     iniparser \
     krb5 \
     libevent \

--- a/meson.build
+++ b/meson.build
@@ -1359,6 +1359,9 @@ else
         if cc.has_function('getxattr', dependencies: attr)
             acl_deps += attr
         endif
+        if glib.found()
+            acl_deps += glib
+        endif
     endif
 
     acl_get_entry_code = '''

--- a/testsuite_alp.Dockerfile
+++ b/testsuite_alp.Dockerfile
@@ -4,6 +4,7 @@ ARG RUN_DEPS="\
     cups \
     db \
     dbus \
+    glib \
     iniparser \
     krb5 \
     libevent \


### PR DESCRIPTION
Notably on Alpine Linux, for ACLs to function you need the GNOME glib runtime dependency

This hasn't triggered before because the glib dependency has been linked with implicitly through other features such as Spotlight, but when disabling Spotlight it came to light