### PR TITLE
GitHub CI: bump to SmartOS bootstrap 2024Q4 for OmniOS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -641,7 +641,7 @@ jobs:
               build-essential \
               pkg-config
             curl -O https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-2024Q4-x86_64.tar.gz
-            tar -zxpf bootstrap-trunk-x86_64-20240116.tar.gz -C /
+            tar -zxpf bootstrap-2024Q4-x86_64.tar.gz -C /
             export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
             pkgin -y install \
               avahi \


### PR DESCRIPTION
Use the latest stable version released by the SmartOS project for the CI job