### PR TITLE
Reduce excessive code comment separators in logger module

### DIFF
--- a/include/atalk/logger.h
+++ b/include/atalk/logger.h
@@ -72,7 +72,7 @@ enum logtypes {
 
 /* =========================================================================
     Structure definitions
-   ========================================================================= */
+ */
 
 /* Main log config */
 typedef struct {
@@ -106,7 +106,7 @@ typedef struct {
 
 /* =========================================================================
     Global variables
-    ========================================================================= */
+ */
 
 /* Make config accessible for LOG macro */
 extern log_config_t log_config;
@@ -116,7 +116,7 @@ type_configs[logtype_end_of_list_marker];
 
 /* =========================================================================
     Global function decarations
-   ========================================================================= */
+ */
 
 void setuplog(const char *loglevel, const char *logfile,
               const bool log_us_timestamp);

--- a/libatalk/util/logger.c
+++ b/libatalk/util/logger.c
@@ -11,7 +11,7 @@ I believe libatalk is released under the L/GPL licence.
 Just incase, it is, thats the licence I'm applying to this file.
 Netatalk 2001 (c)
 
-========================================================================= */
+ */
 
 #include <ctype.h>
 #include <errno.h>
@@ -67,7 +67,7 @@ Netatalk 2001 (c)
 
 /* =========================================================================
    Config
-   ========================================================================= */
+ */
 
 /* Main log config container */
 log_config_t log_config = { 0 };
@@ -115,7 +115,7 @@ static const unsigned int num_loglevel_strings =
 
 /* =========================================================================
    Internal function definitions
-   ========================================================================= */
+ */
 
 static int generate_message(char **message_details_buffer,
                             char *user_message,
@@ -437,7 +437,7 @@ static void setuplog_internal(const char *loglevel, const char *logtype,
 
 /* =========================================================================
    Global function definitions
-   ========================================================================= */
+ */
 
 /* This function sets up the processname */
 void set_processname(const char *processname)


### PR DESCRIPTION
Use sequences of equals signs to separate code sections only at the top and reduce the bottom to closing the comment

This aligns the logger module code comment style with the rest of the codebase

But frankly, the triggering reason for this change is a bug in astyle 3.6.10 that triggers indentation style malfunction

https://gitlab.com/saalen/astyle/-/issues/92