### PR TITLE
GitHub CI: Bump to SmartOS bootstrap 2024Q4 for OmniOS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -640,8 +640,8 @@ jobs:
             pkg install \
               build-essential \
               pkg-config
-            curl -O https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-trunk-x86_64-20240116.tar.gz
-            tar -zxpf bootstrap-trunk-x86_64-20240116.tar.gz -C /
+            curl -o bootstrap.tar.gz https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-2024Q4-x86_64.tar.gz
+            tar -zxpf bootstrap.tar.gz -C /
             export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
             pkgin -y install \
               avahi \


### PR DESCRIPTION
The previous bootstrap release 20240116 introduced conflicting libiconv headers into OmniOS leading to compilation errors in netatalk