### PR TITLE
Build test containers with Spotlight, and run sqlite tests with Alpine test container

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -528,7 +528,7 @@ jobs:
         with:
           copyback: false
           prepare: |
-            export PKG_PATH="http://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f '1 2' -d.)/All/"
+            export PKG_PATH="http://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f '1 2' -d.)/All"
             pkg_add \
               bison \
               cmark \

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -429,6 +429,32 @@ jobs:
                   -e AFP_EXTMAP="1" \
                   ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
+
+    afp-spectest-sqlite-afp34:
+        name: AFP spec test (cnid:sqlite) AFP 3.4 - Alpine
+        needs: build-container-testsuite
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+        steps:
+            - name: Run Netatalk testsuite
+              run: |
+                docker run --rm \
+                  -e AFP_USER="atalk1" \
+                  -e AFP_USER2="atalk2" \
+                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+                  -e AFP_GROUP="afpusers" \
+                  -e AFP_CNID_BACKEND="sqlite" \
+                  -e SHARE_NAME="test1" \
+                  -e SHARE_NAME2="test2" \
+                  -e INSECURE_AUTH="1" \
+                  -e DISABLE_TIMEMACHINE="1" \
+                  -e VERBOSE="1" \
+                  -e TESTSUITE="spectest" \
+                  -e AFP_VERSION="7" \
+                  -e AFP_EXTMAP="1" \
+                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
     afp-spectest-afp34-debian:
         name: AFP spec test (ea:sys) AFP 3.4 - Debian
         needs: build-container-testsuite-debian

--- a/meson.build
+++ b/meson.build
@@ -1361,10 +1361,6 @@ else
         endif
     endif
 
-    if glib.found()
-        acl_deps += glib
-    endif
-
     acl_get_entry_code = '''
         #include <sys/types.h>
         #include <sys/acl.h>

--- a/testsuite_alp.Dockerfile
+++ b/testsuite_alp.Dockerfile
@@ -10,19 +10,24 @@ ARG RUN_DEPS="\
     libevent \
     libgcrypt \
     linux-pam \
+    localsearch \
     mariadb-client \
     mariadb-connector-c \
     openldap \
     sqlite \
+    talloc \
+    tinysparql \
     tzdata \
     "
 ARG BUILD_DEPS="\
     acl-dev \
     avahi-dev \
+    bison \
     cups-dev \
     db-dev \
     dbus-dev \
     build-base \
+    flex \
     gcc \
     iniparser-dev \
     krb5-dev \
@@ -35,6 +40,8 @@ ARG BUILD_DEPS="\
     openldap-dev \
     pkgconfig \
     sqlite-dev \
+    talloc-dev \
+    tinysparql-dev \
     "
 
 FROM alpine:3.22@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1 AS build
@@ -64,7 +71,7 @@ RUN meson setup build \
     -Dwith-init-style=none \
     -Dwith-pkgconfdir-path=/etc/netatalk \
     -Dwith-quota=false \
-    -Dwith-spotlight=false \
+    -Dwith-spotlight=true \
     -Dwith-tcp-wrappers=false \
     -Dwith-testsuite=true \
 &&  meson compile -C build

--- a/testsuite_deb.Dockerfile
+++ b/testsuite_deb.Dockerfile
@@ -15,14 +15,19 @@ ARG RUN_DEPS="\
     libpam0g \
     libsqlite3-0 \
     libssl3 \
+    libtalloc2 \
+    libtinysparql-3.0-0 \
     libtirpc3t64 \
     libwrap0 \
+    localsearch \
     mariadb-client \
     systemtap \
     "
 ARG BUILD_DEPS="\
+    bison \
     build-essential \
     file \
+    flex \
     libacl1-dev \
     libattr1-dev \
     libavahi-client-dev \
@@ -39,6 +44,8 @@ ARG BUILD_DEPS="\
     libmariadb-dev \
     libpam0g-dev \
     libsqlite3-dev \
+    libtalloc-dev \
+    libtinysparql-dev \
     libtirpc-dev \
     libwrap0-dev \
     meson \
@@ -77,7 +84,7 @@ RUN meson setup build \
     -Dwith-pkgconfdir-path=/etc/netatalk \
     -Dwith-rpath=false \
     -Dwith-spooldir=/var/spool/netatalk \
-    -Dwith-spotlight=false \
+    -Dwith-spotlight=true \
     -Dwith-tcp-wrappers=false \
     -Dwith-testsuite=true \
 &&  meson compile -C build


### PR DESCRIPTION
This PR contains a handful of minor tweaks to the container test environment:

- Have both a production and a test container run for the cnid:sqlite pattern on Alpine
- Build both Alpine and Debian test containers with the Spotlight stack (but not the production container)
- Remove red herring glib linking workaround for ACLs
- Remove trailing forward slash in NetBSD pkgsrc path