### PR TITLE
meson: Refactor spotlight dependencies

### DIFF
--- a/etc/spotlight/meson.build
+++ b/etc/spotlight/meson.build
@@ -14,10 +14,20 @@ run_command(
 
 srp_sources = ['sparql_map.c', 'sparql_parser.c', 'spotlight_rawquery_lexer.c']
 
-spotlight_deps = [bstring, iniparser]
+spotlight_deps = [
+    bstring,
+    glib,
+    iniparser,
+    talloc,
+    sparql,
+]
 
 if have_iconv
     spotlight_deps += iconv
+endif
+
+if use_mysql_backend
+    spotlight_deps += mysqlclient
 endif
 
 executable(
@@ -25,13 +35,7 @@ executable(
     srp_sources,
     include_directories: root_includes,
     link_with: libatalk,
-    dependencies: [
-        glib,
-        mysqlclient,
-        talloc,
-        sparql,
-        spotlight_deps,
-    ],
+    dependencies: spotlight_deps,
     c_args: ['-DMAIN'],
     install: false,
 )


### PR DESCRIPTION
Consolidating a single list of spotlight dependencies, while making the mysqlclient library conditional on building with mysql CNID backend support