### PR TITLE
GitHub CI: Use different strategy to skip jobs for dependabot

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -19,9 +19,7 @@ jobs:
     static_analysis:
         name: SonarQube Static Analysis
         runs-on: ubuntu-latest
-        if: |
-          ${{ !github.event.pull_request.head.repo.fork }} ||
-          ${{ !github.actor == 'dependabot[bot]' }}
+        if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]'
         env:
           BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
         steps:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -29,9 +29,7 @@ jobs:
         name: Build production container
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: |
-          ${{ !github.event.pull_request.head.repo.fork }} ||
-          ${{ !github.actor == 'dependabot[bot]' }}
+        if: github.event.pull_request.head.repo.full_name == github.repository
         permissions:
             contents: read
             packages: write
@@ -71,9 +69,7 @@ jobs:
         name: Build Alpine testsuite container
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: |
-          ${{ !github.event.pull_request.head.repo.fork }} ||
-          ${{ !github.actor == 'dependabot[bot]' }}
+        if: github.event.pull_request.head.repo.full_name == github.repository
         permissions:
             contents: read
             packages: write
@@ -113,9 +109,7 @@ jobs:
         name: Build Netatalk Webmin Module container
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: |
-          ${{ !github.event.pull_request.head.repo.fork }} ||
-          ${{ !github.actor == 'dependabot[bot]' }}
+        if: github.event.pull_request.head.repo.full_name == github.repository
         permissions:
             contents: read
             packages: write
@@ -155,9 +149,7 @@ jobs:
         name: Build Debian testsuite container
         runs-on: ubuntu-latest
         timeout-minutes: 5
-        if: |
-          ${{ !github.event.pull_request.head.repo.fork }} ||
-          ${{ !github.actor == 'dependabot[bot]' }}
+        if: github.event.pull_request.head.repo.full_name == github.repository
         permissions:
             contents: read
             packages: write
@@ -200,6 +192,7 @@ jobs:
             - build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Create Docker network
               run: |
@@ -245,6 +238,7 @@ jobs:
             - build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 10
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Create container network
               run: |
@@ -303,6 +297,7 @@ jobs:
             - build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Create Docker network
               run: |
@@ -347,6 +342,7 @@ jobs:
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
         timeout-minutes: 10
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Create container network
               run: |
@@ -387,6 +383,7 @@ jobs:
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -412,6 +409,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -436,6 +434,7 @@ jobs:
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -460,6 +459,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -485,6 +485,7 @@ jobs:
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -510,6 +511,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -534,6 +536,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -558,6 +561,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -582,6 +586,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -606,6 +611,7 @@ jobs:
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -630,6 +636,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -654,6 +661,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -678,6 +686,7 @@ jobs:
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -702,6 +711,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -727,6 +737,7 @@ jobs:
         needs: build-container-testsuite-debian
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -752,6 +763,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -772,6 +784,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -792,6 +805,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -810,6 +824,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -828,6 +843,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |
@@ -847,6 +863,7 @@ jobs:
         needs: build-container-testsuite
         runs-on: ubuntu-latest
         timeout-minutes: 5
+        if: github.actor != 'dependabot[bot]'
         steps:
             - name: Run Netatalk testsuite
               run: |


### PR DESCRIPTION
The previous attempt did not work in real life, so using a plain logic comparison this time