### PR TITLE
GitHub CI: Use proper logic for choosing when to run SonarQube job

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -20,7 +20,7 @@ jobs:
         name: SonarQube Static Analysis
         runs-on: ubuntu-latest
         if: |
-          ${{ !github.event.pull_request.head.repo.fork }} ||
+          ${{ !github.event.pull_request.head.repo.fork }} &&
           ${{ github.actor != 'dependabot[bot]' }}
         env:
           BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory


### PR DESCRIPTION
The two criteria for running the code analysis job must both be true, not just one of them