### PR TITLE
GitHub CI: Use an even more explicit conditional for SonarQube job

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -19,9 +19,9 @@ jobs:
     static_analysis:
         name: SonarQube Static Analysis
         runs-on: ubuntu-latest
-        if: |
-          ${{ !github.event.pull_request.head.repo.fork }} &&
-          ${{ github.actor != 'dependabot[bot]' }}
+        if: >
+            (github.event_name == 'push' && github.actor != 'dependabot[bot]') ||
+            (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]')
         env:
           BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
         steps:


### PR DESCRIPTION
Explicitly check for the type of event, plus both fork and dependabot checks twice

Hopefully it will work this time when merged to main