### PR TITLE
GitHub CI: The dependabot actor's name varies so cover both variants

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -20,8 +20,8 @@ jobs:
         name: SonarQube Static Analysis
         runs-on: ubuntu-latest
         if: >
-            (github.event_name == 'push' && github.actor != 'dependabot[bot]') ||
-            (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]')
+          (github.event_name == 'push' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot') ||
+          (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && github.actor != 'dependabot')
         env:
           BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
         steps:


### PR DESCRIPTION
Inexplicably, GitHub's dependabot actor has two possible names so we need to account for both in the job conditional logic