### PR TITLE
Update Japanese localization for netatalk 4.3 release

### DIFF
--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -12,7 +12,7 @@ and may not always be optimized for standalone execution.
 Install dependencies
 
 ```shell
-apk add acl-dev avahi-compat-libdns_sd avahi-dev bison build-base cracklib cracklib-dev cracklib-words cups cups-dev curl db-dev dbus-dev flex gcc iniparser-dev krb5-dev libevent-dev libgcrypt-dev libtirpc-dev libtracker linux-pam-dev localsearch mariadb-dev meson ninja openldap-dev openrc pandoc perl pkgconfig rpcsvc-proto-dev talloc-dev tinysparql-dev
+apk add acl-dev avahi-compat-libdns_sd avahi-dev bison build-base cracklib cracklib-dev cracklib-words cups cups-dev curl db-dev dbus-dev flex gcc glib iniparser-dev krb5-dev libevent-dev libgcrypt-dev libtirpc-dev libtracker linux-pam-dev localsearch mariadb-dev meson ninja openldap-dev openrc pandoc perl pkgconfig rpcsvc-proto-dev sqlite-dev talloc-dev tinysparql-dev
 ```
 
 Configure
@@ -62,7 +62,7 @@ ninja -C build uninstall
 Install dependencies
 
 ```shell
-pacman -Sy --noconfirm avahi bison cmark-gfm cracklib cups db flex gcc iniparser localsearch mariadb-clients meson ninja perl pkgconfig rpcsvc-proto talloc tinysparql
+pacman -Sy --noconfirm avahi bison cmark-gfm cracklib cups db flex gcc iniparser localsearch mariadb-clients meson ninja perl pkgconfig rpcsvc-proto sqlite talloc tinysparql
 ```
 
 Configure
@@ -113,7 +113,7 @@ Install dependencies
 
 ```shell
 apt-get update
-apt-get install --assume-yes --no-install-recommends bison cmark-gfm cracklib-runtime file flex libacl1-dev libavahi-client-dev libcrack2-dev libcups2-dev libdb-dev libdbus-1-dev libevent-dev libgcrypt20-dev libglib2.0-dev libiniparser-dev libkrb5-dev libldap2-dev libmariadb-dev libpam0g-dev libtalloc-dev libtirpc-dev libtracker-sparql-3.0-dev libwrap0-dev meson ninja-build quota systemtap-sdt-dev tcpd tracker tracker-miner-fs
+apt-get install --assume-yes --no-install-recommends bison ca-certificates cmark-gfm cracklib-runtime file flex libacl1-dev libavahi-client-dev libcrack2-dev libcups2-dev libdb-dev libdbus-1-dev libevent-dev libgcrypt20-dev libglib2.0-dev libiniparser-dev libkrb5-dev libldap2-dev libmariadb-dev libpam0g-dev libsqlite3-dev libtalloc-dev libtirpc-dev libtracker-sparql-3.0-dev libwrap0-dev meson ninja-build quota systemtap-sdt-dev tcpd tracker tracker-miner-fs
 ```
 
 Configure
@@ -163,7 +163,7 @@ ninja -C build uninstall
 Install dependencies
 
 ```shell
-dnf --setopt=install_weak_deps=False --assumeyes install avahi-devel bison chkconfig cracklib-devel cups-devel dbus-devel flex glib2-devel iniparser-devel krb5-devel libacl-devel libdb-devel libgcrypt-devel libtalloc-devel mariadb-connector-c-devel meson ninja-build openldap-devel pam-devel pandoc perl perl-Net-DBus quota-devel systemd systemtap-sdt-devel tracker tracker-devel
+dnf --setopt=install_weak_deps=False --assumeyes install avahi-devel bison chkconfig cracklib-devel cups-devel dbus-devel flex glib2-devel iniparser-devel krb5-devel libacl-devel libdb-devel libgcrypt-devel libtalloc-devel localsearch mariadb-connector-c-devel meson ninja-build openldap-devel pam-devel pandoc perl perl-Net-DBus quota-devel sqlite-devel systemd systemtap-sdt-devel tinysparql-devel
 ```
 
 Configure
@@ -279,13 +279,13 @@ Install dependencies
 
 ```shell
 brew update
-brew install cmark-gfm cracklib iniparser mariadb meson openldap
+brew install cmark-gfm cracklib iniparser mariadb meson openldap sqlite
 ```
 
 Configure
 
 ```shell
-meson setup build -Dbuildtype=release -Dwith-tests=true -Dwith-testsuite=true
+meson setup build -Dbuildtype=release -Dwith-homebrew=true -Dwith-tests=true -Dwith-testsuite=true
 ```
 
 Build
@@ -338,7 +338,7 @@ sudo ninja -C build uninstall
 Install required packages
 
 ```shell
-pkg install -y avahi bison cmark db5 iniparser libevent libgcrypt meson mysql80-client openldap26-client perl5 pkgconf py39-gdbm py39-sqlite3 py39-tkinter talloc tracker3
+pkg install -y avahi bison cmark db5 iniparser libevent libgcrypt meson mysql80-client openldap26-client perl5 pkgconf py39-gdbm py39-sqlite3 py39-tkinter sqlite talloc tracker3
 ```
 
 Configure, compile, install, run, and uninstall
@@ -358,7 +358,7 @@ ninja -C build uninstall
 Install required packages
 
 ```shell
-pkg install -y avahi bison cmark db5 flex iniparser libevent libgcrypt localsearch meson mysql91-client openldap26-client p5-Net-DBus perl5 pkgconf talloc
+pkg install -y avahi bison cmark db5 flex iniparser libevent libgcrypt localsearch meson mysql91-client openldap26-client p5-Net-DBus perl5 pkgconf sqlite3 talloc
 ```
 
 Configure, compile, install, run, and uninstall
@@ -385,7 +385,7 @@ Install required packages
 
 ```shell
 export PKG_PATH="http://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f '1 2' -d.)/All/"
-pkg_add bison cmark db5 flex gcc13 gnome-tracker heimdal iniparser libcups libevent libgcrypt meson mysql-client p5-Net-DBus perl pkg-config talloc
+pkg_add bison cmark db5 flex gcc13 gnome-tracker heimdal iniparser libcups libevent libgcrypt meson mysql-client p5-Net-DBus perl pkg-config sqlite3 talloc
 ```
 
 Configure, compile, install, run, and uninstall
@@ -415,7 +415,7 @@ ninja -C build uninstall
 Install required packages
 
 ```shell
-pkg_add -I avahi bison cmark db-4.6.21p7v0 dbus gcc-11.2.0p15 heimdal iniparser libevent libgcrypt libtalloc localsearch-3.8.2p0 mariadb-client meson openldap-client-2.6.9p0v0 p5-Net-DBus pkgconf tinysparql-3.8.2
+pkg_add -I avahi bison cmark db-4.6.21p7v0 dbus gcc-11.2.0p15 heimdal iniparser libevent libgcrypt libtalloc localsearch-3.8.2p0 mariadb-client meson openldap-client-2.6.9p0v0 p5-Net-DBus pkgconf sqlite tinysparql-3.8.2
 ```
 
 Configure, compile, install, run, and uninstall
@@ -441,10 +441,10 @@ Install required packages
 
 ```shell
 pkg install build-essential pkg-config
-curl -O https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-trunk-x86_64-20240116.tar.gz
-tar -zxpf bootstrap-trunk-x86_64-20240116.tar.gz -C /
+curl -o bootstrap.tar.gz https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-2024Q4-x86_64.tar.gz
+tar -zxpf bootstrap.tar.gz -C /
 export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
-pkgin -y install avahi cmark gnome-tracker iniparser libevent libgcrypt meson mysql-client talloc
+pkgin -y install avahi cmark gnome-tracker iniparser libevent libgcrypt meson mysql-client sqlite3 talloc
 ```
 
 Configure, compile, install, run, and uninstall
@@ -472,7 +472,7 @@ Install required packages
 
 ```shell
 set -e
-pkg install bison cmake flex gcc libevent libgcrypt meson ninja pkg-config
+pkg install bison cmake flex gcc libevent libgcrypt meson ninja pkg-config sqlite-3
 curl --location -o cmark.tar.gz https://github.com/commonmark/cmark/archive/refs/tags/0.31.1.tar.gz
 curl --location -o iniparser.tar.gz https://gitlab.com/iniparser/iniparser/-/archive/v4.2.5/iniparser-v4.2.5.tar.gz
 set +e # tar on Solaris is too old to handle git tarballs cleanly
@@ -497,7 +497,7 @@ Configure, compile, install, run, and uninstall
 ```shell
 set -e
 export PATH=/usr/local/sbin:/usr/local/bin:$PATH
-meson setup build --prefix=/usr/local -Dbuildtype=release -Dpkg_config_path=/usr/lib/amd64/pkgconfig -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d -Dwith-iniparser-path=/usr/local -Dwith-pam=false -Dwith-tests=true -Dwith-testsuite=true
+meson setup build --prefix=/usr/local -Dbuildtype=release -Dpkg_config_path=/usr/lib/amd64/pkgconfig -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d -Dwith-iniparser-path=/usr/local -Dwith-tests=true -Dwith-testsuite=true
 meson compile -C build
 meson test -C build
 meson install -C build

--- a/doc/po/AppleTalk.md.ja.po
+++ b/doc/po/AppleTalk.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-05-25 10:43+0200\n"
+"POT-Creation-Date: 2025-07-31 07:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: manpages/man5/papd.conf.5.md:137 manual/AppleTalk.md:349
+#: manpages/man5/papd.conf.5.md:137 manual/AppleTalk.md:364
 msgid ""
 "Starting with Netatalk 2.0, direct CUPS integration is available. In this "
 "case, defining only a queue name as **pr** parameter won't invoke the SysV "
@@ -65,18 +65,63 @@ msgstr ""
 #. type: Plain text
 #: manual/AppleTalk.md:15
 msgid ""
-"A complete overview can be found inside the [developer documentation](/"
-"appletalk.html)."
-msgstr "完全な概要は、[開発者向けドキュメント](/appletalk.html) にある。"
+"It supports EtherTalk Phase I and II, RTMP, NBP, ZIP, AEP, ATP, PAP, and "
+"ASP, while expecting the host OS kernel to supply DDP."
+msgstr ""
+"EtherTalk Phase I および II、RTMP、NBP、ZIP、AEP、ATP、PAP、ASP をサポートし"
+"ますが、ホスト OS カーネルが DDP を提供することが必須。"
+
+#. type: Bullet: '- '
+#: manual/AppleTalk.md:18
+msgid ""
+"DDP is a socket to socket protocol that all other AppleTalk protocols are "
+"built on top of."
+msgstr ""
+"DDP はソケット間プロトコルであり、他のすべての AppleTalk プロトコルはこのプロ"
+"トコルの上に構築されている。"
+
+#. type: Bullet: '- '
+#: manual/AppleTalk.md:21
+msgid ""
+"ATP, ASP, and NBP are implemented as statically linked libraries in "
+"Netatalk's *libatalk* shared library."
+msgstr ""
+"ATP、ASP、NBP は、Netatalk の *libatalk* 共有ライブラリに静的リンクライブラリ"
+"として実装されている。"
+
+#. type: Bullet: '- '
+#: manual/AppleTalk.md:23
+msgid "The **atalkd** daemon implements RTMP, ZIP, and AEP."
+msgstr "**atalkd** デーモンは RTMP、ZIP、AEP を実装している。"
+
+#. type: Bullet: '- '
+#: manual/AppleTalk.md:26
+msgid ""
+"The **papd** daemon implements PAP, allowing Mac clients to spool to a Unix "
+"print spooler on the netatalk host computer."
+msgstr ""
+"**papd** デーモンは PAP を実装しており、Mac クライアントが netatalk ホストコ"
+"ンピュータ上の Unix 印刷スプーラにスプールできるようにする。"
+
+#. type: Plain text
+#: manual/AppleTalk.md:30
+msgid ""
+"A diagram of the network stack can be found inside the [developer readme](/"
+"developer.html), while the latest information about DDP support in the "
+"kernel can be found in the [AppleTalk readme](/appletalk.html)."
+msgstr ""
+"ネットワークスタックの図は [開発者向け readme](/developer.html) に記載されて"
+"いる。カーネルにおける DDP サポートに関する最新情報は [AppleTalk readme](/"
+"appletalk.html) に記載されている。"
 
 #. type: Title ###
-#: manual/AppleTalk.md:16
+#: manual/AppleTalk.md:31
 #, no-wrap
 msgid "To use AppleTalk or not"
 msgstr "AppleTalk を使用するかどうか"
 
 #. type: Plain text
-#: manual/AppleTalk.md:23
+#: manual/AppleTalk.md:38
 msgid ""
 "You'll need the AppleTalk support built into Netatalk to provide file "
 "services to older AFP clients not capable of using AFP over TCP. It also "
@@ -90,7 +135,7 @@ msgstr ""
 "有効になる。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:30
+#: manual/AppleTalk.md:45
 msgid ""
 "In addition, if you are serving Classic Mac OS clients, you might consider "
 "using AppleTalk for service propagation/location, having the ease of use for "
@@ -107,7 +152,7 @@ msgstr ""
 "参照してください)。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:34
+#: manual/AppleTalk.md:49
 msgid ""
 "To use the different base AppleTalk protocols with Netatalk, one has to use "
 "**atalkd**. It can also be used as an AppleTalk router to connect different "
@@ -118,7 +163,7 @@ msgstr ""
 "トワーク セグメントを相互に接続することもできる。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:39
+#: manual/AppleTalk.md:54
 msgid ""
 "To use AppleTalk/atalkd, your system has to have kernel support for "
 "AppleTalk. If missing, you will be restricted to AFP over TCP, and won't be "
@@ -129,13 +174,13 @@ msgstr ""
 "されている AppleTalk サービスのいずれも使用できなくなる。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:41
+#: manual/AppleTalk.md:56
 #, no-wrap
 msgid "    appletalk = yes\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/AppleTalk.md:45
+#: manual/AppleTalk.md:60
 msgid ""
 "If Netatalk has been built with AppleTalk support (pass *-Dwith-"
 "appletalk=true* to the build system), this activates AFP over AppleTalk."
@@ -144,13 +189,13 @@ msgstr ""
 "*-Dwith-appletalk=true* を渡す)、AppleTalk 経由の AFP がアクティブになる。"
 
 #. type: Title ###
-#: manual/AppleTalk.md:46
+#: manual/AppleTalk.md:61
 #, no-wrap
 msgid "No AppleTalk routing"
 msgstr "AppleTalk ルーティングなし"
 
 #. type: Plain text
-#: manual/AppleTalk.md:53
+#: manual/AppleTalk.md:68
 msgid ""
 "This is the most simple form, you can use AppleTalk with netatalk. In case, "
 "you have only one network interface up and running, you haven't to deal with "
@@ -164,7 +209,7 @@ msgstr ""
 "得し、自動的にネットワークに登録する。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:56
+#: manual/AppleTalk.md:71
 msgid ""
 "In case, you have more than one active network interface, you have to make a "
 "decision:"
@@ -173,13 +218,13 @@ msgstr ""
 "する必要がある。"
 
 #. type: Title ####
-#: manual/AppleTalk.md:57
+#: manual/AppleTalk.md:72
 #, no-wrap
 msgid "Using only one interface"
 msgstr "1 つのインターフェイスのみを使用する"
 
 #. type: Plain text
-#: manual/AppleTalk.md:61
+#: manual/AppleTalk.md:76
 msgid ""
 "Just add the interface name (en1, le0, eth2, ... for example) to atalkd.conf "
 "on a single line. Do only list *one* interface here."
@@ -188,13 +233,13 @@ msgstr ""
 "け。ここでは、*1 つの*インターフェースのみをリストしてください。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:63
+#: manual/AppleTalk.md:78
 #, no-wrap
 msgid "    eth0\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/AppleTalk.md:66
+#: manual/AppleTalk.md:81
 msgid ""
 "AppleTalk networking should be enabled on eth0 interface. All the necessary "
 "configuration will be fetched from the network"
@@ -203,7 +248,7 @@ msgstr ""
 "ある。必要なすべての構成はネットワークから取得される"
 
 #. type: Plain text
-#: manual/AppleTalk.md:69
+#: manual/AppleTalk.md:84
 msgid ""
 "At startup time, atalkd will add the real settings (address and network and "
 "eventually a zone) to atalkd.conf on its own"
@@ -212,13 +257,13 @@ msgstr ""
 "atalkd.conf に自動的に追加する"
 
 #. type: Plain text
-#: manual/AppleTalk.md:71
+#: manual/AppleTalk.md:86
 #, no-wrap
 msgid "    eth0 -phase 2 -net 0-65534 -addr 65280.166\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/AppleTalk.md:77
+#: manual/AppleTalk.md:92
 msgid ""
 "atalkd filled in the AppleTalk settings that apply to this network segment. "
 "A netrange of 0-65534 indicates that there is no AppleTalk router present, "
@@ -233,13 +278,13 @@ msgstr ""
 "～ 255 である。"
 
 #. type: Title ####
-#: manual/AppleTalk.md:78
+#: manual/AppleTalk.md:93
 #, no-wrap
 msgid "Using several interfaces"
 msgstr "複数のインターフェイスの使用"
 
 #. type: Plain text
-#: manual/AppleTalk.md:82
+#: manual/AppleTalk.md:97
 msgid ""
 "When using several interfaces you have to add them line by line following "
 "the **-dontroute** switch in *atalkd.conf*."
@@ -248,13 +293,13 @@ msgstr ""
 "イッチの後に、1行ずつ追加する必要がある。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:84
+#: manual/AppleTalk.md:99
 #, no-wrap
 msgid "    eth0 -dontroute eth1 -dontroute eth2 -dontroute\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/AppleTalk.md:88
+#: manual/AppleTalk.md:103
 msgid ""
 "AppleTalk networking should be enabled on all three interfaces, but no "
 "routing should be done between the different segments. Again, all the "
@@ -265,7 +310,7 @@ msgstr ""
 "べての設定は接続されたネットワークから取得される。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:92
+#: manual/AppleTalk.md:107
 #, no-wrap
 msgid ""
 "    eth0 -dontroute -phase 2 -net 0-65534 -addr 65280.152\n"
@@ -274,7 +319,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/AppleTalk.md:98
+#: manual/AppleTalk.md:113
 msgid ""
 "On eth0 and eth1, there are no other routers present, so atalkd chooses an "
 "address from within the startup range. But on eth2 there lives an already "
@@ -288,7 +333,7 @@ msgstr ""
 "でのネット範囲のアドレスを自身に割り当てるように強制している。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:103
+#: manual/AppleTalk.md:118
 msgid ""
 "In this case, atalkd will handle each interface as it would be the only "
 "active one. This can have some side effects when it comes to the point where "
@@ -301,7 +346,7 @@ msgstr ""
 "さい。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:109
+#: manual/AppleTalk.md:124
 msgid ""
 "In case, you have more than one active network interface and do not take "
 "special precautions as outlined above, then autoconfiguration of the "
@@ -315,7 +360,7 @@ msgstr ""
 "接続されている状況で、インターフェイスの自動構成が失敗する可能性がある。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:112
+#: manual/AppleTalk.md:127
 msgid ""
 "For further information see [atalkd.conf](atalkd.conf.5.html)  and the "
 "developer documentation."
@@ -324,13 +369,13 @@ msgstr ""
 "トを参照してください。"
 
 #. type: Title ###
-#: manual/AppleTalk.md:113
+#: manual/AppleTalk.md:128
 #, no-wrap
 msgid "atalkd acting as an AppleTalk router"
 msgstr "AppleTalk ルーターとして機能する atalkd"
 
 #. type: Plain text
-#: manual/AppleTalk.md:117
+#: manual/AppleTalk.md:132
 msgid ""
 "Several types of AppleTalk routers exist: seed, non-seed and so called soft-"
 "seed routers."
@@ -339,34 +384,40 @@ msgstr ""
 "ルータなど、いくつかの種類がある。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:120
+#: manual/AppleTalk.md:135
 #, no-wrap
 msgid ""
 "- A seed router has its own configuration and publishes this into the\n"
 "    network segments it is configured for.\n"
-msgstr "- シード ルータには独自の構成があり、その構成を、そのルータが構成されているネットワーク セグメントに公開する。\n"
+msgstr ""
+"- シード ルータには独自の構成があり、その構成を、\n"
+"そのルータが構成されているネットワーク セグメントに公開する。\n"
 
 #. type: Plain text
-#: manual/AppleTalk.md:124
+#: manual/AppleTalk.md:139
 #, no-wrap
 msgid ""
 "- A non-seed router needs a seed router on the interface to which it is\n"
 "    connected to learn the network configuration. So this type of\n"
 "    AppleTalk router can work completely without manual configuration.\n"
-msgstr "- 非シード ルータは、ネットワーク構成を学習するために、接続先のインターフェイスにシード ルータが必要。したがって、このタイプの AppleTalk ルータは、手動設定なしで完全に動作する。\n"
+msgstr ""
+"- 非シード ルータは、ネットワーク構成を学習するために、接続先のインターフェイスにシード ルータが必要。\n"
+"したがって、このタイプの AppleTalk ルータは、手動設定なしで完全に動作する。\n"
 
 #. type: Plain text
-#: manual/AppleTalk.md:129
+#: manual/AppleTalk.md:144
 #, no-wrap
 msgid ""
 "- A so called soft-seed router is exactly the same as a non-seed router\n"
 "    except the fact, that it can also remember the configuration of a seed\n"
 "    router and act as a replacement in case, the real seed router\n"
 "    disappears from the net.\n"
-msgstr "- いわゆるソフトシード ルータは、シード ルータの設定を記憶し、実際のシード ルータがネットから消えた場合に代わりとして動作できることを除けば、非シード ルータとまったく同じ。\n"
+msgstr ""
+"- いわゆるソフトシード ルータは、シード ルータの設定を記憶し、\n"
+"実際のシード ルータがネットから消えた場合に代わりとして動作できることを除けば、非シード ルータとまったく同じ。\n"
 
 #. type: Plain text
-#: manual/AppleTalk.md:133
+#: manual/AppleTalk.md:148
 msgid ""
 "Netatalk's atalkd can act as both a seed and a soft-seed router, even in a "
 "mixed mode, where it acts on one interface in this way and on the other in "
@@ -377,7 +428,7 @@ msgstr ""
 "ンターフェイスでは別の方法で動作する。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:139
+#: manual/AppleTalk.md:154
 msgid ""
 "If you leave your atalkd.conf completely empty or simply add all active "
 "interfaces line by line without using seed settings (atalkd will act "
@@ -392,12 +443,12 @@ msgstr ""
 "スでは失敗する。ルーティング情報を取得する。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:141
+#: manual/AppleTalk.md:156
 msgid "In this case, other services, that depend on atalkd, might also fail."
 msgstr "この場合、atalkd に依存する他のサービスも失敗する可能性がある。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:144
+#: manual/AppleTalk.md:159
 msgid ""
 "So you should have atalkd act as a seed router on one or all active "
 "interfaces. A seed router has to supply information about:"
@@ -407,27 +458,27 @@ msgstr ""
 "ある:"
 
 #. type: Bullet: '- '
-#: manual/AppleTalk.md:146
+#: manual/AppleTalk.md:161
 msgid "The specific netrange on this segment"
 msgstr "このセグメントの特定のネット範囲"
 
 #. type: Bullet: '- '
-#: manual/AppleTalk.md:148
+#: manual/AppleTalk.md:163
 msgid "Its own AppleTalk address"
 msgstr "独自の AppleTalk アドレス"
 
 #. type: Bullet: '- '
-#: manual/AppleTalk.md:150
+#: manual/AppleTalk.md:165
 msgid "The zones (one to many) available in this segment"
 msgstr "このセグメントで使用可能なゾーン (1 対多)"
 
 #. type: Bullet: '- '
-#: manual/AppleTalk.md:152
+#: manual/AppleTalk.md:167
 msgid "The so called \"default zone\" for this segment"
 msgstr "このセグメントのいわゆる「デフォルト ゾーン」"
 
 #. type: Plain text
-#: manual/AppleTalk.md:157
+#: manual/AppleTalk.md:172
 #, no-wrap
 msgid ""
 "> ***WARNING:*** Unless you are the network admin yourself, consider asking them before\n"
@@ -440,7 +491,7 @@ msgstr ""
 "AppleTalkネットワーククライアントに副作用が生じる可能性がある。\n"
 
 #. type: Plain text
-#: manual/AppleTalk.md:164
+#: manual/AppleTalk.md:179
 msgid ""
 "In an AppleTalk network netranges have to be unique and must not overlap "
 "each other. Fortunately netatalk's atalkd is polite enough to check whether "
@@ -455,7 +506,7 @@ msgstr ""
 "さい)。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:170
+#: manual/AppleTalk.md:185
 msgid ""
 "Netranges, you can use, include pretty small ones, e.g. 42-42, to very large "
 "ones, e.g. 1-65279 - the latter one representing the maximum. In routed "
@@ -468,7 +519,7 @@ msgstr ""
 "数値を使用できる。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:178
+#: manual/AppleTalk.md:193
 msgid ""
 "The own AppleTalk address consists of a net part and a node part (the former "
 "16 bit, the latter 8 bit, for example 12057.143). Apple recommends using "
@@ -485,7 +536,7 @@ msgstr ""
 "たくないため、142 以上のノード アドレスを使用することをお勧めする。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:184
+#: manual/AppleTalk.md:199
 msgid ""
 "AppleTalk zones have *nothing* to do with physical networks. They're just a "
 "hint for your client's convenience, letting them locate network resources in "
@@ -500,7 +551,7 @@ msgstr ""
 "まざまな組み合わせも使用できる)。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:190
+#: manual/AppleTalk.md:205
 msgid ""
 "So all you have to do is to *draw a network chart* containing the physical "
 "segments, the netranges you want to assign to each one, the zone names you "
@@ -514,24 +565,24 @@ msgstr ""
 "む *ネットワーク チャートを描く* ことだけ。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:193
+#: manual/AppleTalk.md:208
 msgid ""
 "If you finished the steps outlined above, you might want to edit atalkd.conf "
 "to fit your needs."
 msgstr "上記の手順を完了したら、必要に応じて atalkd.conf を編集してください。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:195
+#: manual/AppleTalk.md:210
 msgid "You'll have to set the following options in atalkd.conf:"
 msgstr "atalkd.conf で次のオプションを設定する必要がある:"
 
 #. type: Bullet: '- '
-#: manual/AppleTalk.md:197
+#: manual/AppleTalk.md:212
 msgid "**-net** (use reasonable values between 1-65279 for each interface)"
 msgstr "**-net** (各インターフェースに 1 ～ 65279 の適切な値を使用する)"
 
 #. type: Plain text
-#: manual/AppleTalk.md:200
+#: manual/AppleTalk.md:215
 #, no-wrap
 msgid ""
 "    In case, this value is suppressed but -addr is present, the netrange\n"
@@ -539,15 +590,17 @@ msgid ""
 msgstr "    この値が抑制されていても -addr が存在する場合は、この特定のアドレスのnetrangeが使用される\n"
 
 #. type: Plain text
-#: manual/AppleTalk.md:203
+#: manual/AppleTalk.md:218
 #, no-wrap
 msgid ""
 "- **-addr** (the net part must match the -net settings if present, the node\n"
 "    address should be between 142 and 255)\n"
-msgstr "- **-addr** (net 部分は -net 設定 (存在する場合) と一致する必要がある。ノード アドレスは 142 ～ 255 の範囲である必要がある)\n"
+msgstr ""
+"- **-addr** (net 部分は -net 設定 (存在する場合) と一致する必要がある。\n"
+"ノード アドレスは 142 ～ 255 の範囲である必要がある)\n"
 
 #. type: Plain text
-#: manual/AppleTalk.md:206
+#: manual/AppleTalk.md:221
 #, no-wrap
 msgid ""
 "- **-zone** (can be used multiple times in one single line, the first entry\n"
@@ -555,7 +608,7 @@ msgid ""
 msgstr "- **-zone** (1行に複数回使用できる。最初のエントリはデフォルトのゾーンになる。)\n"
 
 #. type: Plain text
-#: manual/AppleTalk.md:214
+#: manual/AppleTalk.md:229
 msgid ""
 "Note that you are able to set up \"zone mapping\", that means publishing "
 "exactly the same zone name on all AppleTalk segments, as well as providing "
@@ -573,7 +626,7 @@ msgstr ""
 "を選択できる。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:217
+#: manual/AppleTalk.md:232
 #, no-wrap
 msgid ""
 "    eth0 -seed -phase 2 -net 1-1000 -addr 1000.142 -zone \"Printers\" -zone \"Spoolers\"\n"
@@ -581,7 +634,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/AppleTalk.md:227
+#: manual/AppleTalk.md:242
 msgid ""
 "The settings for eth0 force AppleTalk devices within the connected network "
 "to assign themselves an address in the netrange 1-1000. Two zone names are "
@@ -603,7 +656,7 @@ msgstr ""
 "ンを「Macs」に設定して、4 番目のゾーン名「Servers」を発行する。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:230
+#: manual/AppleTalk.md:245
 #, no-wrap
 msgid ""
 "    eth0 -seed -phase 2 -net 1-1000 -addr 1000.142 -zone \"foo\"\n"
@@ -611,7 +664,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/AppleTalk.md:237
+#: manual/AppleTalk.md:252
 msgid ""
 "We use the same network settings as in the example above but let atalkd "
 "publish the same zone name on both segments. As the same zone name will be "
@@ -624,17 +677,17 @@ msgstr ""
 "ゾーン名を公開するようにする。AppleTalk ネットワークのすべてのセグメントで同"
 "じゾーン名が使用されるため、ゾーン名はまったく表示されないが、AppleTalk ルー"
 "ティングは引き続きアクティブになる。この場合、いわゆる「非拡張」LocalTalk "
-"ネットワーク (フェーズ 1) を EtherTalk「拡張」ネットワーク (フェーズ 2)  に透"
-"過的に接続する。"
+"ネットワーク（フェーズ1）を EtherTalk「拡張」ネットワーク（フェーズ2）に透過"
+"的に接続する。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:239
+#: manual/AppleTalk.md:254
 #, no-wrap
 msgid "    eth0 eth1 eth2\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/AppleTalk.md:245
+#: manual/AppleTalk.md:260
 msgid ""
 "As we have more than one interface, atalkd will try to act as an AppleTalk "
 "router between both segments. As we don't supply any network configuration "
@@ -648,7 +701,7 @@ msgstr ""
 "つのセグメントにのみ利用可能なシード ルータがない場合、全体が失敗する。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:249
+#: manual/AppleTalk.md:264
 #, no-wrap
 msgid ""
 "    eth0 -phase 2 -net 10-10 -addr 10.166 -zone \"Parking\"\n"
@@ -657,7 +710,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/AppleTalk.md:258
+#: manual/AppleTalk.md:273
 msgid ""
 "In this case, active seed routers are present in all three connected "
 "networks, so atalkd was able to fetch the network configuration from them "
@@ -677,7 +730,7 @@ msgstr ""
 "め)。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:261
+#: manual/AppleTalk.md:276
 #, no-wrap
 msgid ""
 "    eth0\n"
@@ -685,7 +738,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/AppleTalk.md:267
+#: manual/AppleTalk.md:282
 msgid ""
 "In case in the network connected to eth0 lives no active seed router or one "
 "with a mismatching configuration (e.g. an overlapping netrange of 1-200) "
@@ -700,7 +753,7 @@ msgstr ""
 "る。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:273
+#: manual/AppleTalk.md:288
 msgid ""
 "By the way: It is perfectly legal to have more than one seed router "
 "connected to a network segment. But in this case, you should take care that "
@@ -713,13 +766,13 @@ msgstr ""
 "まったく同じになるように注意する必要がある。"
 
 #. type: Title ##
-#: manual/AppleTalk.md:274
+#: manual/AppleTalk.md:289
 #, no-wrap
 msgid "Printing"
 msgstr "印刷"
 
 #. type: Plain text
-#: manual/AppleTalk.md:279
+#: manual/AppleTalk.md:294
 msgid ""
 "Netatalk can act both as a PAP client to access AppleTalk-capable printers, "
 "and as a PAP server. The former by using the **pap** utility and the latter "
@@ -730,7 +783,7 @@ msgstr ""
 "は **papd** サービスを起動することで行う。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:290
+#: manual/AppleTalk.md:305
 msgid ""
 "The \"Printer Access Protocol\" as part of the AppleTalk protocol suite is a "
 "fully 8 bit aware and bidirectional printing protocol, developed by Apple in "
@@ -753,7 +806,7 @@ msgstr ""
 "LPR などと比べて大きな利点である。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:301
+#: manual/AppleTalk.md:316
 #, no-wrap
 msgid ""
 "*Bidirectional* means that printing source (usually a Macintosh\n"
@@ -779,13 +832,13 @@ msgstr ""
 "に関する通知を生成することができる。\n"
 
 #. type: Title ###
-#: manual/AppleTalk.md:302
+#: manual/AppleTalk.md:317
 #, no-wrap
 msgid "Setting up the PAP print server"
 msgstr "PAP 印刷サーバーの設定"
 
 #. type: Plain text
-#: manual/AppleTalk.md:311
+#: manual/AppleTalk.md:326
 msgid ""
 "Netatalk's [papd](papd.8.html) is able to provide AppleTalk printing "
 "services for Macintoshes or, to be more precise, PAP clients in general. "
@@ -801,7 +854,7 @@ msgstr ""
 "(例:クラシック SysV lpd、BSD lpr、LPRng、CUPS など。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:318
+#: manual/AppleTalk.md:333
 msgid ""
 "Since it is so important to answer the client's feature queries correctly, "
 "how does papd achieve this? By parsing the relevant keywords of the assigned "
@@ -816,7 +869,7 @@ msgstr ""
 "ることが印刷を可能にするために重要。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:328
+#: manual/AppleTalk.md:343
 msgid ""
 "Netatalk formerly had built-in support for System V lpd printing in a way "
 "that papd saved the printed job directly into the spooldir and calls **lpd** "
@@ -838,13 +891,13 @@ msgstr ""
 "アル ページにある。"
 
 #. type: Title ####
-#: manual/AppleTalk.md:329
+#: manual/AppleTalk.md:344
 #, no-wrap
 msgid "Integrating papd with SysV lpd"
 msgstr "papd と SysV lpd の統合"
 
 #. type: Plain text
-#: manual/AppleTalk.md:335
+#: manual/AppleTalk.md:350
 msgid ""
 "Unless CUPS support has been compiled in (which is default from Netatalk 2.0 "
 "on) one simply defines the lpd queue in question by setting the **pr** "
@@ -857,13 +910,13 @@ msgstr ""
 "される。"
 
 #. type: Title ####
-#: manual/AppleTalk.md:336
+#: manual/AppleTalk.md:351
 #, no-wrap
 msgid "Using pipes with papd"
 msgstr "papd でパイプを使用する"
 
 #. type: Plain text
-#: manual/AppleTalk.md:341
+#: manual/AppleTalk.md:356
 msgid ""
 "An alternative to the technique outlined above is to direct papd's output "
 "via a pipe into another program. Using this mechanism almost all printing "
@@ -874,13 +927,13 @@ msgstr ""
 "る。"
 
 #. type: Title ####
-#: manual/AppleTalk.md:342
+#: manual/AppleTalk.md:357
 #, no-wrap
 msgid "Using direct CUPS support"
 msgstr "直接 CUPS サポートを使用する"
 
 #. type: Plain text
-#: manual/AppleTalk.md:355
+#: manual/AppleTalk.md:370
 msgid ""
 "There exists one special share named *cupsautoadd*. If this is present in "
 "*papd.conf*, then all available CUPS queues will be served automagically "
@@ -894,19 +947,19 @@ msgstr ""
 "個々のスプーラのこれらのグローバル設定を上書きできる。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:357
+#: manual/AppleTalk.md:372
 #, no-wrap
 msgid "    cupsautoadd:op=root:\n"
 msgstr ""
 
 #. type: Title ###
-#: manual/AppleTalk.md:358
+#: manual/AppleTalk.md:373
 #, no-wrap
 msgid "Using AppleTalk printers"
 msgstr "AppleTalk プリンタの使用"
 
 #. type: Plain text
-#: manual/AppleTalk.md:362
+#: manual/AppleTalk.md:377
 msgid ""
 "Netatalk's [papstatus](papstatus.8.html) can be used to query AppleTalk "
 "printers, [pap](pap.1.html) to print to them."
@@ -915,22 +968,24 @@ msgstr ""
 "でき、 [pap](pap.1.html) はプリンタに印刷するのに使用できる。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:366
+#: manual/AppleTalk.md:381
 #, no-wrap
 msgid ""
 "**pap** can be used stand-alone or as part of an output filter or a CUPS\n"
 "backend (which is the preferred method\n"
 "since one does not have to deal with all the options).\n"
-msgstr "**pap** はスタンドアロンで使用することも、出力フィルタまたは CUPS バックエンドの一部として使用することもできる (すべてのプリンタを処理する必要がないため、この方法の方が推奨される)オプション)。\n"
+msgstr ""
+"**pap** はスタンドアロンで使用することも、出力フィルタまたは CUPS バックエンドの一部として\n"
+"使用することもできる (すべてのプリンタを処理する必要がないため、この方法の方が推奨される)オプション)。\n"
 
 #. type: Title ####
-#: manual/AppleTalk.md:367
+#: manual/AppleTalk.md:382
 #, no-wrap
 msgid "Using pap stand-alone"
 msgstr "pap を単独で使用する"
 
 #. type: Plain text
-#: manual/AppleTalk.md:372
+#: manual/AppleTalk.md:387
 msgid ""
 "In this example, the file */usr/share/doc/gs/examples/tiger.ps* is sent to a "
 "printer called \"ColorLaserWriter 16/600\" in the standard zone \"\\*\".  "
@@ -941,13 +996,13 @@ msgstr ""
 "ス タイプは \"LaserWriter\" (デフォルトなので省略できる)。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:374
+#: manual/AppleTalk.md:389
 #, no-wrap
 msgid "    pap -p\"ColorLaserWriter 16/600@*\" /usr/share/doc/gs/examples/tiger.ps\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/AppleTalk.md:381
+#: manual/AppleTalk.md:396
 msgid ""
 "Next, GhostScript is used to convert a PostScript job to PCL3 output "
 "suitable for a Color DeskWriter. Since no file has been supplied on the "
@@ -965,19 +1020,19 @@ msgstr ""
 "り、**pap**はプリンタからのEOFを待たなくなる。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:383
+#: manual/AppleTalk.md:398
 #, no-wrap
 msgid "    gs -q -dNOPAUSE -sDEVICE=cdjcolor -sOutputFile=test.ps | pap -E\n"
 msgstr ""
 
 #. type: Title ####
-#: manual/AppleTalk.md:384
+#: manual/AppleTalk.md:399
 #, no-wrap
 msgid "Using pap as a CUPS backend"
 msgstr "pap を CUPS バックエンドとして使用する"
 
 #. type: Plain text
-#: manual/AppleTalk.md:390
+#: manual/AppleTalk.md:405
 msgid ""
 "Netatalk bundles a CUPS backend that can be used to print to AppleTalk "
 "printers. The backend is called **pap** and is installed in */usr/lib/cups/"
@@ -988,7 +1043,7 @@ msgstr ""
 "cups/backend* または */usr/pkg/libexec/cups/backend* に配置される。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:393
+#: manual/AppleTalk.md:408
 msgid ""
 "The backend can be configured by editing the file with printer model and a "
 "few other options."
@@ -997,7 +1052,7 @@ msgstr ""
 "ことで設定できる。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:402
+#: manual/AppleTalk.md:417
 msgid ""
 "In CUPS 1.x, you can configure your AppleTalk printers through the \"Find "
 "New Printers\" wizard.  In CUPS 2.x, however, the backend needs to be "
@@ -1014,28 +1069,30 @@ msgstr ""
 "エンドを使用できない。"
 
 #. type: Title ##
-#: manual/AppleTalk.md:403
+#: manual/AppleTalk.md:418
 #, no-wrap
 msgid "Time Services"
 msgstr "タイム サービス"
 
 #. type: Title ###
-#: manual/AppleTalk.md:405
+#: manual/AppleTalk.md:420
 #, no-wrap
 msgid "Timelord"
 msgstr ""
 
 #. type: Plain text
-#: manual/AppleTalk.md:410
+#: manual/AppleTalk.md:425
 #, no-wrap
 msgid ""
 "**timelord**, an AppleTalk based time server,\n"
 "is useful for automatically synchronizing the system time on\n"
 "older Macintosh or Apple II clients that do not support NTP.\n"
-msgstr "**timelord** は AppleTalk ベースのタイム サーバーで、NTP をサポートしていない古い Macintosh または Apple II クライアントのシステム時間を自動的に同期するのに役立つ。\n"
+msgstr ""
+"**timelord** は AppleTalk ベースのタイム サーバーで、NTP をサポートしていない\n"
+"古い Macintosh または Apple II クライアントのシステム時間を自動的に同期するのに役立つ。\n"
 
 #. type: Plain text
-#: manual/AppleTalk.md:414
+#: manual/AppleTalk.md:429
 msgid ""
 "Netatalk's **timelord** is compatible with the tardis client for Macintosh "
 "developed at the [University of Melbourne.](https://web.archive.org/web/"
@@ -1046,7 +1103,7 @@ msgstr ""
 "発された Macintosh 用の tardis クライアントと互換性がある。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:416
+#: manual/AppleTalk.md:431
 msgid ""
 "For further information please have a look at the [timelord]"
 "(timelord.8.html) manual page."
@@ -1054,28 +1111,30 @@ msgstr ""
 "詳細については、[timelord](timelord.8.html) マニュアル ページをご覧ください。"
 
 #. type: Title ##
-#: manual/AppleTalk.md:417
+#: manual/AppleTalk.md:432
 #, no-wrap
 msgid "NetBoot Services"
 msgstr "ネットブート サービス"
 
 #. type: Title ###
-#: manual/AppleTalk.md:419
+#: manual/AppleTalk.md:434
 #, no-wrap
 msgid "Apple 2 NetBooting"
 msgstr "Apple 2 ネットブート"
 
 #. type: Plain text
-#: manual/AppleTalk.md:424
+#: manual/AppleTalk.md:439
 #, no-wrap
 msgid ""
 "**a2boot** is a service that allows you to\n"
 "boot an Apple //e or Apple IIGS into ProDOS or GS/OS through an AFP\n"
 "volume served by Netatalk.\n"
-msgstr "**a2boot** は、 Apple //e または Apple IIGS を、Netatalk が提供する AFP ボリュームを介して ProDOS または GS/OS にブートする。\n"
+msgstr ""
+"**a2boot** は、 Apple //e または Apple IIGS を、Netatalk が提供する \n"
+"AFP ボリュームを介して ProDOS または GS/OS にブートする。\n"
 
 #. type: Plain text
-#: manual/AppleTalk.md:427
+#: manual/AppleTalk.md:442
 msgid ""
 "You need to supply the appropriate boot blocks and system files provided by "
 "Apple yourself."
@@ -1084,7 +1143,7 @@ msgstr ""
 "がある。"
 
 #. type: Plain text
-#: manual/AppleTalk.md:429
+#: manual/AppleTalk.md:444
 msgid ""
 "For further information please have a look at the [a2boot](a2boot.8.html) "
 "manual page."

--- a/doc/po/Configuration.md.ja.po
+++ b/doc/po/Configuration.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-05-28 20:17+0200\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -18,13 +18,13 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Title ###
-#: manpages/man8/cnid_dbd.8.md:63 manual/Configuration.md:568
+#: manpages/man8/cnid_dbd.8.md:64 manual/Configuration.md:587
 #, no-wrap
 msgid "Configuration"
 msgstr "設定"
 
 #. type: Title ##
-#: manpages/man8/papd.8.md:61 manual/Configuration.md:335
+#: manpages/man8/papd.8.md:61 manual/Configuration.md:354
 #, no-wrap
 msgid "Authentication"
 msgstr "認証"
@@ -117,7 +117,9 @@ msgid ""
 "*afp.conf* is the configuration file used by afpd to determine the\n"
 "behaviour and configuration of the AFP file server and the AFP volume\n"
 "that it provides.\n"
-msgstr "*afp.conf* は、AFP ファイルサーバー及び提供する AFP ボリュームの挙動と設定を決定するために afpd が使用する設定ファイルである。\n"
+msgstr ""
+"*afp.conf* は、AFP ファイルサーバー及び提供する AFP ボリュームの挙動と設定を\n"
+"決定するために afpd が使用する設定ファイルである。\n"
 
 #. type: Plain text
 #: manual/Configuration.md:36
@@ -257,16 +259,16 @@ msgstr "CNID バックエンド"
 #: manual/Configuration.md:91
 msgid ""
 "Unlike other protocols like SMB or NFS, the AFP protocol mostly refers to "
-"files and directories by ID and not by a path (the IDs are also called CNID, "
-"which stand for Catalog Node ID). A typical AFP request uses a directory ID "
+"files and directories by ID and not by a path. These IDs are called CNID, "
+"which stand for Catalog Node ID.  A typical AFP request uses a directory ID "
 "and a filename, something like \"server, please open the file named 'Test' "
 "in the directory with id 167\". For example \"Aliases\" on the Mac basically "
 "work by ID (with a fallback to the absolute path in more recent AFP "
 "clients.  But this applies only to Finder, not to applications)."
 msgstr ""
 "SMB や NFS のようなほかのプロトコルとは異なり、ほとんどの場合、AFP プロトコル"
-"はファイルやディレクトリをパスではなく ID を通して参照している。（その ID は "
-"CNID とも言われ、カタログ・ノード ID (Catalog Node ID) の略である） 典型的に"
+"はファイルやディレクトリをパスではなく ID を通して参照している。その ID は "
+"CNID とも言われ、カタログ・ノード ID (Catalog Node ID) の略である。典型的に"
 "は、まず AFP リクエストで、例えば、“サーバーさん id 167 のディレクトリにあ"
 "る、ファイル名 'Test' というのを開いてください。”といった調子でディレクトリ "
 "IDとファイル名を用いる。例えば、Mac での \"Aliases\" は基本的には ID として作"
@@ -274,31 +276,34 @@ msgstr ""
 "は Finder のみで当てはまることであり、アプリケーションでは当てはまらない）。"
 
 #. type: Plain text
-#: manual/Configuration.md:98
+#: manual/Configuration.md:100
 msgid ""
-"Every file in an AFP volume has to have a unique file ID, IDs must, "
-"according to the specs, never be reused, and IDs are 32 bit numbers "
-"(Directory IDs use the same ID pool). So, after ~4 billion files/folders "
-"have been written to an AFP volume, the ID pool is depleted and no new file "
-"can be written to the volume. No whining please :-)"
+"Every file in an AFP volume has to have a unique file ID.  CNIDs must, "
+"according to the AFP specification, never be reused.  The IDs are "
+"represented as 32 bit numbers, and directory IDs use the same ID pool. So, "
+"after ~4 billion files/folders have been written to an AFP volume, the ID "
+"pool is depleted and no new file can be written to the volume. Some of "
+"Netatalk's CNID backends may attempt to reuse available IDs after depletion, "
+"which is technically in violation of the spec, but may enable continuous use "
+"on long-lived volumes."
 msgstr ""
 "AFP ボリュームにある各々のファイルに一意のファイル ID が割り当てられる。仕様"
-"により ID は絶対に再利用禁止であり、ID は 32 bit の数字である。（ディレクト"
-"リ ID も同じ ID プールを使用する）このため、ある AFP ボリュームにおよそ 40 億"
-"個以上のファイル・フォルダーを書き込むと、その時点で ID プールが枯渇され、当"
-"該ボリュームへの新ファイルの書き込みができなくなる。愚痴はなしということでお"
-"願いしたい :-)"
+"により CNID は絶対に再利用禁止であり、32 bit の数字である。ディレクトリ ID も"
+"同じ ID プールを使用する。このため、ある AFP ボリュームにおよそ 40 億個以上の"
+"ファイル・フォルダーを書き込むと、その時点で ID プールが枯渇され、当該ボ"
+"リュームへの新ファイルの書き込みができなくなる。Netatalk の CNID バックエンド"
+"の一部は、利用可能な ID を使い果たした後に再利用しようとする場合がある。これ"
+"は厳密的には仕様違反にはなるが、長期間有効なボリュームでは継続的な使用可能に"
+"する。"
 
 #. type: Plain text
 #: manual/Configuration.md:105
 #, no-wrap
 msgid ""
 "Netatalk needs to map IDs to files and folders in the host filesystem.\n"
-"To achieve this, several different CNID\n"
-"backends are available and can be\n"
-"selected with the **cnid scheme** option in\n"
-"the *afp.conf* configuration file. A CNID backend is basically a\n"
-"database storing ID <-\\> name mappings.\n"
+"To achieve this, several different CNID backends are available and can be\n"
+"selected with the **cnid scheme** option in the *afp.conf* configuration file.\n"
+"A CNID backend is basically a database storing ID <-\\> name mappings.\n"
 msgstr ""
 "Netatalk はホストのファイルシステム内で ID\n"
 "とファイルあるいはフォルダーのマップ（ID\n"
@@ -311,18 +316,20 @@ msgstr ""
 "名前を一対一対応させるデータベースである。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:110
+#: manual/Configuration.md:111
 msgid ""
-"The CNID databases are by default located in a *netatalk/CNID* subdirectory "
-"of your system's state directory path, e.g. */var/lib*.  You can change the "
-"state directory path with *-Dwith-statedir-path=PATH* at compile time."
+"For the CNID backends which use a zero-configuration database, the database "
+"files are by default located in a *netatalk/CNID* subdirectory of your "
+"system's state directory path, e.g. */var/lib*.  You can change the state "
+"directory path with *-Dwith-statedir-path=PATH* at compile time."
 msgstr ""
-"CNID データベースはデフォルトではシステムの状態ディレクトリパス（例：*/var/"
-"lib*）の下にある *netatalk/CNID* サブディレクトリに置かれる。コンパイル時に "
-"*-Dwith-statedir-path=PATH* オプションで場所を変えられる。"
+"設定の必要ないCNIDバックエンドの場合、CNIDデータベースはデフォルトではシステ"
+"ムの状態ディレクトリパス（例：*/var/lib*）の下にある *netatalk/CNID* サブディ"
+"レクトリに置かれる。コンパイル時に *-Dwith-statedir-path=PATH* オプションで場"
+"所を変えられる。"
 
 #. type: Plain text
-#: manual/Configuration.md:113
+#: manual/Configuration.md:114
 msgid ""
 "There is a command line utility called **dbd** available which can be used "
 "to verify, repair and rebuild the CNID database."
@@ -331,7 +338,7 @@ msgstr ""
 "う名のコマンドが用意されていている。"
 
 #. type: Plain text
-#: manual/Configuration.md:116
+#: manual/Configuration.md:117
 #, no-wrap
 msgid ""
 "***NOTE:*** There are some CNID related things you should keep in mind when\n"
@@ -339,14 +346,14 @@ msgid ""
 msgstr "> 【注記】 netatalkで作業する上で、いくつかのCNIDに関する点を留意しておかなければならない。すなわち：\n"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:128
+#: manual/Configuration.md:129
 msgid "Don't nest volumes unless \"**vol dbnest = yes**\" is set."
 msgstr ""
 "\"**vol dbnest = yes** が指定してある時以外はボリュームをネスト（入れ子）にし"
 "てはならない。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:128
+#: manual/Configuration.md:129
 msgid ""
 "CNID backends are databases, so they turn afpd into a file server/database "
 "mix."
@@ -355,7 +362,7 @@ msgstr ""
 "ベースの混成物とならしめている。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:128
+#: manual/Configuration.md:129
 msgid ""
 "If there's no more space on the filesystem left, the database will get "
 "corrupted. You can work around this by using the **vol dbpath** option and "
@@ -368,7 +375,7 @@ msgstr ""
 "なっているか確認する。のいずれかである。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:128
+#: manual/Configuration.md:129
 msgid ""
 "Be careful with CNID databases for volumes that are mounted via NFS.  That "
 "is a pretty audacious decision to make anyway, but putting a database there "
@@ -383,51 +390,68 @@ msgstr ""
 "場合はデータベースをローカルディスクに置くために**vol dbpath** ディレクティブ"
 "を使用するべきである。"
 
+#. type: Plain text
+#: manual/Configuration.md:135
+msgid ""
+"Below follows descriptions of the various CNID backends that are included "
+"with netatalk.  You can choose to build one or several of them at compile "
+"time.  Run the command *afpd -v* to see which backends are available to you, "
+"as well as which one is the default."
+msgstr ""
+"以下は、netatalk に含まれる様々な CNID バックエンドの説明がある。コンパイル時"
+"に、これらのバックエンドを1つまたは複数選択してビルドできる。使用可能なバック"
+"エンドとデフォルトのバックエンドを確認するには、コマンド *afpd -v* を実行する"
+"こと。"
+
 #. type: Title ###
-#: manual/Configuration.md:129
+#: manual/Configuration.md:136
 #, no-wrap
 msgid "dbd"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:135
+#: manual/Configuration.md:143
 msgid ""
 "The \"Database Daemon\" backend is built on Berkeley DB. Access to the CNID "
-"database is restricted to the cnid_dbd daemon process. afpd processes "
-"communicate with the daemon for database reads and updates.  The probability "
-"for database corruption is practically zero."
+"database is restricted to the **cnid_dbd** daemon process.  **afpd** "
+"processes communicate with the **cnid_dbd** daemon for database reads and "
+"updates, which is in turn launched and controlled by the **cnid_metad** "
+"daemon."
 msgstr ""
-"CNID データベースへのアクセスは cnid_dbd デーモンプロセスのみに制限されてい"
-"る。afpd プロセスはデータベースの読み込みと更新のために cnid_dbd デーモン と"
-"やりとりをする。 データベースが破損する可能性は経験的にはほぼゼロである。"
+"「データベースデーモン」（dbd）バックエンドはBerkeley DB上に構築されている。"
+"CNID データベースへのアクセスは **cnid_dbd** デーモンプロセスのみに制限されて"
+"いる。**afpd** プロセスは **cnid_dbd** データベースの読み込みと更新のために "
+"**cnid_dbd** デーモン とやりとりをする。全ては **cnid_metad** デーモンによっ"
+"て制御されている。"
 
 #. type: Plain text
-#: manual/Configuration.md:137
-msgid "This is the default backend since Netatalk 2.1."
+#: manual/Configuration.md:145
+msgid "This is the most reliable and proven backend for daily use."
 msgstr ""
-"本バックエンドは Netatalk 2.1 以来、デフォルトのバックエンドとなっている。"
+"本バックエンドは日常使用において最も信頼性が高く、実績のあるバックエンドであ"
+"る。"
 
 #. type: Title ###
-#: manual/Configuration.md:138
+#: manual/Configuration.md:146
 #, no-wrap
 msgid "last"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:144
+#: manual/Configuration.md:152
 msgid ""
-"The last backend is an in-memory tdb database. It is not persistent, with "
-"IDs valid only for the current session. Starting with netatalk 3.0, it "
-"operates in *read only mode*. This backend is useful e.g. for mounting CD-"
-"ROMs, or for automated testing."
+"The last backend is an in-memory Trivial Database (tdb). It is not "
+"persistent, with IDs valid only for the current session. Starting with "
+"netatalk 3.0, it operates in *read only mode*. This backend is useful e.g. "
+"for mounting CD-ROMs, or for automated testing."
 msgstr ""
-"last バックエンドはメモリーにデータを保持する tdb データベースである。故永続"
-"性がなく、ID はカレントセッションでしか有効ではない。netatalk 3.0 からは、そ"
-"れは*読み込み専用モード*になっている。このバックエンドは例えば CD-ROM や自動"
-"化テスト などに有用である。"
+"last バックエンドはメモリーにデータを保持する「Trivial Database」 (tdb) デー"
+"タベースである。故永続性がなく、ID はカレントセッションでしか有効ではない。"
+"netatalk 3.0 からは、それは*読み込み専用モード*になっている。このバックエンド"
+"は例えば CD-ROM や自動化テスト などに有用である。"
 
 #. type: Plain text
-#: manual/Configuration.md:147
+#: manual/Configuration.md:155
 msgid ""
 "This is basically equivalent to how **afpd** stored CNID data in netatalk "
 "1.5 and earlier."
@@ -436,34 +460,63 @@ msgstr ""
 "方法に一致している。"
 
 #. type: Title ###
-#: manual/Configuration.md:148
+#: manual/Configuration.md:156
 #, no-wrap
 msgid "mysql"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:152
+#: manual/Configuration.md:161
 msgid ""
 "CNID backend using a MySQL server. The MySQL server has to be provisioned by "
-"the system administrator."
+"the system administrator, and Netatalk configured to connect to it over the "
+"network."
 msgstr ""
 "CNID バックエンドは MySQL サーバーを使用する。MySQL サーバーはシステム管理者"
-"がプロビジョニングする必要がある。"
+"がプロビジョニングする必要があり、Netatalkをデータベースに接続する設定する必"
+"要もある。"
 
-#. type: Title ##
-#: manual/Configuration.md:153
-#, no-wrap
-msgid "Charsets/Unicode"
-msgstr ""
+#. type: Plain text
+#: manual/Configuration.md:163
+msgid "See **afp.conf**(5) for documentation of the configuration options."
+msgstr "設定オプションの詳細については**afp.conf**(5)を参照。"
 
 #. type: Title ###
-#: manual/Configuration.md:155
+#: manual/Configuration.md:164
+#, no-wrap
+msgid "sqlite"
+msgstr ""
+
+#. type: Plain text
+#: manual/Configuration.md:168
+msgid ""
+"A zero-configuration database backend that uses the SQLite v3 embedded "
+"database engine."
+msgstr ""
+"SQLite v3 組み込みデータベースエンジンを使用する、設定不要のデータベースバッ"
+"クエンド。"
+
+#. type: Plain text
+#: manual/Configuration.md:171
+msgid ""
+"This backend is considered experimental and should only be used for testing."
+msgstr ""
+"本バックエンドは実験的なものとみなされており、テスト目的でのみ使用すること。"
+
+#. type: Title ##
+#: manual/Configuration.md:172
+#, no-wrap
+msgid "Charsets/Unicode"
+msgstr "本バックエンドは実験的なものとみなされており、テスト目的でのみ使用すること。"
+
+#. type: Title ###
+#: manual/Configuration.md:174
 #, no-wrap
 msgid "Why Unicode?"
 msgstr "なぜ Unicode？"
 
 #. type: Plain text
-#: manual/Configuration.md:162
+#: manual/Configuration.md:181
 msgid ""
 "Internally, computers don't know anything about characters and texts, they "
 "only know numbers. Therefore, each letter is assigned a number. A character "
@@ -476,7 +529,7 @@ msgstr ""
 "*codepage* とも呼ばれるが、これは“数”と“字”の一対一対応を規定している。"
 
 #. type: Plain text
-#: manual/Configuration.md:171
+#: manual/Configuration.md:190
 msgid ""
 "If two or more computer systems need to communicate with each other, the "
 "have to use the same character set. In the 1960s the ASCII (American "
@@ -494,7 +547,7 @@ msgstr ""
 "ターで使われるキャラクタースキームの標準的なものである。"
 
 #. type: Plain text
-#: manual/Configuration.md:177
+#: manual/Configuration.md:196
 msgid ""
 "Later versions defined 256 characters to produce a more international "
 "fluency and to include some slightly esoteric graphical characters.  Using "
@@ -509,7 +562,7 @@ msgstr ""
 "ではなかった。"
 
 #. type: Plain text
-#: manual/Configuration.md:186
+#: manual/Configuration.md:205
 msgid ""
 "As a result localized character sets were defined later, e.g the ISO-8859 "
 "character sets. Most operating system vendors introduced their own "
@@ -529,7 +582,7 @@ msgstr ""
 "す。"
 
 #. type: Plain text
-#: manual/Configuration.md:191
+#: manual/Configuration.md:210
 msgid ""
 "Almost all of those characters sets defined 256 characters, where the first "
 "128 (0-127) character mappings are identical to ASCII. As a result, "
@@ -542,7 +595,7 @@ msgstr ""
 "実上 ASCII キャラクターセット限定となった。"
 
 #. type: Plain text
-#: manual/Configuration.md:196
+#: manual/Configuration.md:215
 msgid ""
 "To solve this problem new, larger character sets were defined. To make room "
 "for more character mappings, these character sets use at least 2 bytes to "
@@ -555,7 +608,7 @@ msgstr ""
 "めそういったキャラクターセットは*マルチバイト* キャラクターセットと呼ばれる。"
 
 #. type: Plain text
-#: manual/Configuration.md:201
+#: manual/Configuration.md:220
 msgid ""
 "One standardized multibyte charset encoding scheme is known as [Unicode]"
 "(http://www.unicode.org/). A big advantage of using a multibyte charset is "
@@ -569,13 +622,13 @@ msgstr ""
 "がない。"
 
 #. type: Title ###
-#: manual/Configuration.md:202
+#: manual/Configuration.md:221
 #, no-wrap
 msgid "Character sets used by Apple"
 msgstr "Apple で使われている（使われていた）キャラクターセット"
 
 #. type: Plain text
-#: manual/Configuration.md:207
+#: manual/Configuration.md:226
 msgid ""
 "In the past, Apple clients used single-byte charsets to communicate over the "
 "network. Over the years Apple defined a number of codepages, western users "
@@ -587,92 +640,92 @@ msgstr ""
 "であろう。"
 
 #. type: Plain text
-#: manual/Configuration.md:209
+#: manual/Configuration.md:228
 msgid "Codepages defined by Apple include:"
 msgstr "Apple の定義したコードページに含まれるもの："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:211
+#: manual/Configuration.md:230
 msgid "MacArabic, MacFarsi"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:213
+#: manual/Configuration.md:232
 msgid "MacCentralEurope"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:215
+#: manual/Configuration.md:234
 msgid "MacChineseSimple"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:217
+#: manual/Configuration.md:236
 msgid "MacChineseTraditional"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:219
+#: manual/Configuration.md:238
 msgid "MacCroatian"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:221
+#: manual/Configuration.md:240
 msgid "MacCyrillic"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:223
+#: manual/Configuration.md:242
 msgid "MacDevanagari"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:225
+#: manual/Configuration.md:244
 msgid "MacGreek"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:227
+#: manual/Configuration.md:246
 msgid "MacHebrew"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:229
+#: manual/Configuration.md:248
 msgid "MacIcelandic"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:231
+#: manual/Configuration.md:250
 msgid "MacJapanese"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:233
+#: manual/Configuration.md:252
 msgid "MacKorean"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:235
+#: manual/Configuration.md:254
 msgid "MacRoman"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:237
+#: manual/Configuration.md:256
 msgid "MacRomanian"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:239
+#: manual/Configuration.md:258
 msgid "MacThai"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:241
+#: manual/Configuration.md:260
 msgid "MacTurkish"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:247
+#: manual/Configuration.md:266
 msgid ""
 "Starting with Mac OS X and AFP3, [UTF-8](http://www.utf-8.com/) is used.  "
 "UTF-8 encodes Unicode characters in an ASCII compatible way, each Unicode "
@@ -686,7 +739,7 @@ msgstr ""
 "クターセットのエンコーディングなのである。"
 
 #. type: Plain text
-#: manual/Configuration.md:253
+#: manual/Configuration.md:272
 msgid ""
 "To complicate things, Unicode defines several *[normalization](http://"
 "www.unicode.org/reports/tr15/index.html)* forms.  While [samba](http://"
@@ -699,7 +752,7 @@ msgstr ""
 "を使用する。一方 Apple は *decomposed* normalization を使うことに決めた。"
 
 #. type: Plain text
-#: manual/Configuration.md:259
+#: manual/Configuration.md:278
 msgid ""
 "For example lets take the character 'ä' (lowercase a with diaeresis).  Using "
 "the precomposed normalization, Unicode maps this character to 0xE4.  In "
@@ -712,7 +765,7 @@ msgstr ""
 "付ける。0x61 は 'a' に、0x308 は *COMBINING DIAERESIS*に対応付けられている。"
 
 #. type: Plain text
-#: manual/Configuration.md:262
+#: manual/Configuration.md:281
 msgid ""
 "Netatalk refers to precomposed UTF-8 as *UTF8* and to decomposed UTF-8 as "
 "*UTF8-MAC*."
@@ -721,13 +774,13 @@ msgstr ""
 "と呼ぶ。"
 
 #. type: Title ###
-#: manual/Configuration.md:263
+#: manual/Configuration.md:282
 #, no-wrap
 msgid "afpd and character sets"
 msgstr "afpd とキャラクターセット"
 
 #. type: Plain text
-#: manual/Configuration.md:269
+#: manual/Configuration.md:288
 msgid ""
 "To support new AFP 3.x and older AFP 2.x clients at the same time, afpd "
 "needs to be able to convert between the various charsets used. AFP 3.x "
@@ -740,7 +793,7 @@ msgstr ""
 "Apple コードページのうちの一つを使う。"
 
 #. type: Plain text
-#: manual/Configuration.md:271
+#: manual/Configuration.md:290
 msgid ""
 "At the time of writing, netatalk supports the following Apple codepages:"
 msgstr ""
@@ -748,67 +801,67 @@ msgstr ""
 "トしている："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:273
+#: manual/Configuration.md:292
 msgid "MAC_CENTRALEUROPE"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:275
+#: manual/Configuration.md:294
 msgid "MAC_CHINESE_SIMP"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:277
+#: manual/Configuration.md:296
 msgid "MAC_CHINESE_TRAD"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:279
+#: manual/Configuration.md:298
 msgid "MAC_CYRILLIC"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:281
+#: manual/Configuration.md:300
 msgid "MAC_GREEK"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:283
+#: manual/Configuration.md:302
 msgid "MAC_HEBREW"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:285
+#: manual/Configuration.md:304
 msgid "MAC_JAPANESE"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:287
+#: manual/Configuration.md:306
 msgid "MAC_KOREAN"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:289
+#: manual/Configuration.md:308
 msgid "MAC_ROMAN"
 msgstr ""
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:291
+#: manual/Configuration.md:310
 msgid "MAC_TURKISH"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:293
+#: manual/Configuration.md:312
 msgid "afpd handles three different character set options:"
 msgstr "afpd は三つの異なるキャラクターセットオプションを扱う："
 
 #. type: Plain text
-#: manual/Configuration.md:295
+#: manual/Configuration.md:314
 msgid "unix charset"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:301
+#: manual/Configuration.md:320
 #, no-wrap
 msgid ""
 "> This is the codepage used internally by your operating system. If not\n"
@@ -817,18 +870,20 @@ msgid ""
 "uses this codepage to read its configuration files, so you can use\n"
 "extended characters for volume names, login messages, etc.\n"
 msgstr ""
-"> これはオペレーティングシステムの内側で使われているコードページである。もし指定されていなければ、デフォルトで\n"
+"> これはオペレーティングシステムの内側で使われているコードページである。\n"
+"もし指定されていなければ、デフォルトで\n"
 "**UTF8** になる。もし **LOCALE** が指定されていて、 システムが UNIX locales\n"
 "をサポートしていれば、afpd はコードページを検出しようとし、afpd\n"
-"は検出したコードページを使って設定ファイルを読む。なので、ボリューム名やログインメッセージなどに拡張文字を使うことができる。\n"
+"は検出したコードページを使って設定ファイルを読む。\n"
+"なので、ボリューム名やログインメッセージなどに拡張文字を使うことができる。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:303
+#: manual/Configuration.md:322
 msgid "mac charset"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:310
+#: manual/Configuration.md:329
 #, no-wrap
 msgid ""
 "> As already mentioned, older Mac OS clients (up to AFP 2.2) use codepages\n"
@@ -840,18 +895,19 @@ msgid ""
 msgstr ""
 "> 既に述べたように、旧式の Mac OS クライアント（AFP 2.2 までのもの）は\n"
 "afpd と通信するのにコードページを用いる。しかしながら、AFP\n"
-"プロトコルにはクライアントが使用しているコードページの折り合いをつけるというサポートはない。もしほかのどこかで指定されていないと、\n"
+"プロトコルにはクライアントが使用しているコードページの折り合いをつけるというサポートはない。\n"
+"もしほかのどこかで指定されていないと、\n"
 "afpd は *MacRoman* コードページが使われていると仮定する。\n"
 "クライアントが別のコードページ、例えば *MacCyrillic* を使っていたならば,\n"
 "それを明示的に設定**しなければならない**だろう。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:312
+#: manual/Configuration.md:331
 msgid "vol charset"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:317
+#: manual/Configuration.md:336
 #, no-wrap
 msgid ""
 "> This defines the charset afpd should use for filenames on disk. By\n"
@@ -866,7 +922,7 @@ msgstr ""
 "が提供するキャラクターセットも使用することができる。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:326
+#: manual/Configuration.md:345
 #, no-wrap
 msgid ""
 "afpd needs a way to preserve extended Macintosh characters, or\n"
@@ -888,7 +944,7 @@ msgstr ""
 "にエンコードされる。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:330
+#: manual/Configuration.md:349
 msgid ""
 "Even though this version now uses **UTF8** as the default encoding for "
 "filenames, '/' will be converted to ':'. For western users another useful "
@@ -899,7 +955,7 @@ msgstr ""
 "にとって別の有用な設定として **vol charset = ISO-8859-15** もあり得る。"
 
 #. type: Plain text
-#: manual/Configuration.md:334
+#: manual/Configuration.md:353
 msgid ""
 "If a character cannot be converted from the **mac charset** to the selected "
 "**vol charset**, you'll receive a -50 error on the Mac. *Note*: Whenever you "
@@ -910,13 +966,13 @@ msgstr ""
 "常に、デフォルトの UTF8 ボリュームフォーマットにしてください。"
 
 #. type: Title ###
-#: manual/Configuration.md:337
+#: manual/Configuration.md:356
 #, no-wrap
 msgid "AFP authentication basics"
 msgstr "AFP 認証の基本"
 
 #. type: Plain text
-#: manual/Configuration.md:345
+#: manual/Configuration.md:364
 msgid ""
 "Apple chose a flexible model called \"User Authentication Modules\" (UAMs) "
 "for authentication purposes between AFP client and server. An AFP client "
@@ -930,7 +986,7 @@ msgstr ""
 "せる。そして、クライアントがサポートしている最も強い暗号化の UAM を選ぶ。"
 
 #. type: Plain text
-#: manual/Configuration.md:348
+#: manual/Configuration.md:367
 msgid ""
 "Several UAMs have been developed by Apple over the time, some by 3rd-party "
 "developers."
@@ -939,28 +995,28 @@ msgstr ""
 "によるものもある。"
 
 #. type: Title ###
-#: manual/Configuration.md:349
+#: manual/Configuration.md:368
 #, no-wrap
 msgid "UAMs supported by Netatalk"
 msgstr "Netatalk でサポートされている UAM"
 
 #. type: Plain text
-#: manual/Configuration.md:352
+#: manual/Configuration.md:371
 msgid "Netatalk supports the following ones by default:"
 msgstr "Netatalk はデフォルトで以下のものをサポートしている："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:354
+#: manual/Configuration.md:373
 msgid "\"No User Authent\" UAM (guest access without authentication)"
 msgstr "\"No User Authent\" UAM（ユーザー認証なしのゲスト接続）"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:356
+#: manual/Configuration.md:375
 msgid "\"Cleartxt Passwrd\" UAM (no password encryption)"
 msgstr "\"Cleartxt Passwrd\" UAM（クリアテキスト(平文)パスワード、暗号化なし）"
 
 #. type: Plain text
-#: manual/Configuration.md:359
+#: manual/Configuration.md:378
 msgid ""
 "- \"Randnum exchange\"/\"2-Way Randnum exchange\" UAMs (weak password "
 "encryption, separate password storage)"
@@ -969,22 +1025,22 @@ msgstr ""
 "交換、弱いパスワード暗号化、パスワードを別途保存する）"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:361
+#: manual/Configuration.md:380
 msgid "\"DHCAST128\" UAM (a.k.a. DHX; stronger password encryption)"
 msgstr "\"DHCAST128\" UAM（より強いパスワード暗号化）"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:363
+#: manual/Configuration.md:382
 msgid "\"DHX2\" UAM (successor of DHCAST128)"
 msgstr "\"DHX2\" UAM（DHCAST128 の後継版）"
 
 #. type: Plain text
-#: manual/Configuration.md:365
+#: manual/Configuration.md:384
 msgid "There exist other optional UAMs as well:"
 msgstr "他にもオプションとして以下のような UAM がある："
 
 #. type: Plain text
-#: manual/Configuration.md:368
+#: manual/Configuration.md:387
 msgid ""
 "- \"Client Krb v2\" UAM (Kerberos V, suitable for \"Single Sign On\" "
 "Scenarios with macOS clients – see below)"
@@ -993,7 +1049,7 @@ msgstr ""
 "も適当である――下記参照）"
 
 #. type: Plain text
-#: manual/Configuration.md:374
+#: manual/Configuration.md:393
 msgid ""
 "You can configure which UAMs should be activated by defining \"**uam "
 "list**\" in **Global** section. **afpd** will log which UAMs it's using and "
@@ -1008,7 +1064,7 @@ msgstr ""
 "い合わせをするのに使うことができる。"
 
 #. type: Plain text
-#: manual/Configuration.md:379
+#: manual/Configuration.md:398
 msgid ""
 "Having a specific UAM available at the server does not automatically mean "
 "that a client can use it. Client-side support is also necessary.  For older "
@@ -1021,7 +1077,7 @@ msgstr ""
 "DHCAST128 のサポートは AppleShare クライアント 3.8.x 以降には存在している。"
 
 #. type: Plain text
-#: manual/Configuration.md:384
+#: manual/Configuration.md:403
 msgid ""
 "On macOS, there exist some client-side techniques to make the AFP-client "
 "more verbose, so one can have a look at what's happening while negotiating "
@@ -1034,13 +1090,13 @@ msgstr ""
 "article.gmane.org/gmane.network.netatalk.devel/7383/)  と比較してみるとよい。"
 
 #. type: Title ###
-#: manual/Configuration.md:385
+#: manual/Configuration.md:404
 #, no-wrap
 msgid "Which UAMs to activate?"
 msgstr "どの UAM を有効にすべきか？"
 
 #. type: Plain text
-#: manual/Configuration.md:390
+#: manual/Configuration.md:409
 msgid ""
 "It depends primarily on your needs and on the kind of macOS clients you have "
 "to support. If your network consists of exclusively macOS (Mac OS X) "
@@ -1051,7 +1107,7 @@ msgstr ""
 "DHX2 で十分であり、最も強力な暗号化を提供する。"
 
 #. type: Plain text
-#: manual/Configuration.md:396
+#: manual/Configuration.md:415
 msgid ""
 "- Unless you really have to supply guest access to your server's volumes "
 "ensure that you disable \"No User Authent\" since it might lead accidentally "
@@ -1065,7 +1121,7 @@ msgstr ""
 "トアクセスを有効化することを強制するように気を配るべきである。"
 
 #. type: Plain text
-#: manual/Configuration.md:399
+#: manual/Configuration.md:418
 #, no-wrap
 msgid ""
 "    Note: \"No User Authent\" is required to use Apple II NetBoot services\n"
@@ -1075,7 +1131,7 @@ msgstr ""
 "    Apple //e を起動するには、「ユーザー認証なし」が必要である。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:403
+#: manual/Configuration.md:422
 msgid ""
 "- The \"ClearTxt Passwrd\" UAM is as bad as it sounds since passwords go "
 "unencrypted over the wire. Try to avoid it at both the server's side as well "
@@ -1086,7 +1142,7 @@ msgstr ""
 "でも無効にするよう務めるべきである。"
 
 #. type: Plain text
-#: manual/Configuration.md:408
+#: manual/Configuration.md:427
 #, no-wrap
 msgid ""
 "    Note: If you want to provide Mac OS 8/9 clients with NetBoot-services\n"
@@ -1100,7 +1156,7 @@ msgstr ""
 "    クライアントがこうした基本的な形の認証しか扱わないためである。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:416
+#: manual/Configuration.md:435
 msgid ""
 "- Since \"Randnum exchange\"/\"2-Way Randnum exchange\" uses only 56 bit DES "
 "for encryption it should be avoided as well. Another disadvantage is the "
@@ -1117,7 +1173,7 @@ msgstr ""
 "パスワードを管理しなければならない）という点である。"
 
 #. type: Plain text
-#: manual/Configuration.md:419
+#: manual/Configuration.md:438
 #, no-wrap
 msgid ""
 "    However, this is the strongest form of authentication that can be used\n"
@@ -1125,7 +1181,7 @@ msgid ""
 msgstr "    ただし、これは 漢字Talk 7.1 以前で使用できる最も強力な認証形式である。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:422
+#: manual/Configuration.md:441
 msgid ""
 "- \"DHCAST128\" (\"DHX\") or \"DHX2\" should be the sweet spot for most "
 "people since it combines stronger encryption with PAM integration."
@@ -1134,7 +1190,7 @@ msgstr ""
 "組み合わせられているので、 ほとんどの人々にとって良い妥協案であろう。"
 
 #. type: Plain text
-#: manual/Configuration.md:433
+#: manual/Configuration.md:452
 msgid ""
 "- Using the Kerberos V (\"Client Krb v2\")  UAM, it's possible to implement "
 "real single sign on scenarios using Kerberos tickets. The password is not "
@@ -1156,7 +1212,7 @@ msgstr ""
 "知の実装の仕方のために、この認証方法は中間者攻撃に対して脆弱である。"
 
 #. type: Plain text
-#: manual/Configuration.md:438
+#: manual/Configuration.md:457
 msgid ""
 "For a more detailed overview over the technical implications of the "
 "different UAMs, please have a look at Apple's [File Server Security](http://"
@@ -1170,13 +1226,13 @@ msgstr ""
 "TP40000854-CH232-SW1)  ページを見ていただきたい。"
 
 #. type: Title ###
-#: manual/Configuration.md:439
+#: manual/Configuration.md:458
 #, no-wrap
 msgid "Using different authentication sources with specific UAMs"
 msgstr "特定の UAM で別の認証ソースを使う"
 
 #. type: Plain text
-#: manual/Configuration.md:449
+#: manual/Configuration.md:468
 msgid ""
 "Some UAMs provide the ability to use different authentication \"backends\", "
 "namely **uams_clrtxt.so**, **uams_dhx.so** and **uams_dhx2.so**. They can "
@@ -1196,7 +1252,7 @@ msgstr ""
 "ないしは **uams_dhx2_pam.so**へのシンボリックリンクとすることができる。"
 
 #. type: Plain text
-#: manual/Configuration.md:453
+#: manual/Configuration.md:472
 msgid ""
 "So, if it looks like this in Netatalk's UAMs folder (per default */etc/"
 "netatalk/uams/*) then you're using PAM, otherwise classic UNIX passwords."
@@ -1206,7 +1262,7 @@ msgstr ""
 "けである。"
 
 #. type: Plain text
-#: manual/Configuration.md:457
+#: manual/Configuration.md:476
 #, no-wrap
 msgid ""
 "    uams_clrtxt.so -> uams_pam.so\n"
@@ -1215,7 +1271,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:464
+#: manual/Configuration.md:483
 msgid ""
 "The main advantage of using PAM is that one can integrate Netatalk in "
 "centralized authentication scenarios, e.g. via LDAP, NIS and the like.  "
@@ -1232,18 +1288,18 @@ msgstr ""
 "ワーク上から 完全に除去することを考えるべきである。"
 
 #. type: Title ###
-#: manual/Configuration.md:465
+#: manual/Configuration.md:484
 #, no-wrap
 msgid "Netatalk UAM overview table"
 msgstr "Netatalk UAM を概要表"
 
 #. type: Plain text
-#: manual/Configuration.md:468
+#: manual/Configuration.md:487
 msgid "A small overview of the officially supported UAMs."
 msgstr "公式にサポートされているUAMの概観。"
 
 #. type: Plain text
-#: manual/Configuration.md:476
+#: manual/Configuration.md:495
 #, no-wrap
 msgid ""
 "| UAM              | No User Auth  | Cleartxt Passwrd | RandNum Exchange | DHCAST128    | DHX2          | Kerberos V       |\n"
@@ -1263,13 +1319,13 @@ msgstr ""
 "| パスワードの保管方法 | なし | システム認証ないしはPAM | パスワードは別のテキストファイルに平文として保存される | システム認証ないしはPAM | システム認証ないしはPAM | Kerberosキー配布センター |\n"
 
 #. type: Title ###
-#: manual/Configuration.md:477
+#: manual/Configuration.md:496
 #, no-wrap
 msgid "SSH tunneling"
 msgstr "SSH トンネリング"
 
 #. type: Plain text
-#: manual/Configuration.md:483
+#: manual/Configuration.md:502
 msgid ""
 "Tunneling and VPNs usually have nothing to do with AFP authentication and "
 "UAMs. But since Apple introduced an option called \"Allow Secure Connections "
@@ -1281,13 +1337,13 @@ msgstr ""
 "下ではその点についても述べる。"
 
 #. type: Title ####
-#: manual/Configuration.md:484
+#: manual/Configuration.md:503
 #, no-wrap
 msgid "Manually tunneling an AFP session"
 msgstr "手動で AFP セッションをトンネリング"
 
 #. type: Plain text
-#: manual/Configuration.md:490
+#: manual/Configuration.md:509
 msgid ""
 "This works since the first AFP servers that spoke \"AFP over TCP\" appeared "
 "in networks. One simply tunnels the remote server's AFP port to a local port "
@@ -1300,13 +1356,13 @@ msgstr ""
 "だけである。macOS では以下のようにすればよい。"
 
 #. type: Plain text
-#: manual/Configuration.md:492
+#: manual/Configuration.md:511
 #, no-wrap
 msgid "    ssh -l $USER $SERVER -L 10548:127.0.0.1:548 sleep 3000\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:499
+#: manual/Configuration.md:518
 msgid ""
 "After establishing the tunnel one will use `\"afp://127.0.0.1:10548\"` in "
 "the \"Connect to server\" dialog. All AFP traffic including the initial "
@@ -1321,7 +1377,7 @@ msgstr ""
 "も含めて全ての AFP トラフィックがネットワークを暗号化されて送られる。"
 
 #. type: Plain text
-#: manual/Configuration.md:505
+#: manual/Configuration.md:524
 msgid ""
 "This sort of tunnel is an ideal solution if you must access an AFP server "
 "through the Internet without having the ability or desire to use a \"real\" "
@@ -1337,13 +1393,13 @@ msgstr ""
 "る。"
 
 #. type: Title ####
-#: manual/Configuration.md:506
+#: manual/Configuration.md:525
 #, no-wrap
 msgid "Automatically establishing a tunneled AFP connection"
 msgstr "自動的にトンネル AFP 接続を確立する"
 
 #. type: Plain text
-#: manual/Configuration.md:513
+#: manual/Configuration.md:532
 msgid ""
 "From Mac OS X 10.2 to 10.4, Apple added an \"Allow Secure Connections Using "
 "SSH\" checkbox to the \"Connect to Server\" dialog. The idea behind this "
@@ -1358,7 +1414,7 @@ msgstr ""
 "を通して送る。ということなのである。"
 
 #. type: Plain text
-#: manual/Configuration.md:518
+#: manual/Configuration.md:537
 msgid ""
 "But it took until the release of Mac OS X 10.3 that this feature worked the "
 "first time... partly. In case, the SSH tunnel could not be established and "
@@ -1370,7 +1426,7 @@ msgstr ""
 "暗号化していない AFP 接続試行にフォールバックした。"
 
 #. type: Plain text
-#: manual/Configuration.md:524
+#: manual/Configuration.md:543
 msgid ""
 "Netatalk's afpd will report that it is capable of handling SSH tunneled AFP "
 "requests, when both \"**advertise ssh**\" and \"**fqdn**\" options are set "
@@ -1385,7 +1441,7 @@ msgstr ""
 "たくなくなる２、３の理由がある："
 
 #. type: Plain text
-#: manual/Configuration.md:529
+#: manual/Configuration.md:548
 msgid ""
 "- Most users who need such a feature are probably already familiar with "
 "using a VPN; it might be easier for the user to employ the same VPN software "
@@ -1397,7 +1453,7 @@ msgstr ""
 "ワークに接続し、 AFP サーバーにアクセスする方が簡単だろう。"
 
 #. type: Plain text
-#: manual/Configuration.md:535
+#: manual/Configuration.md:554
 #, no-wrap
 msgid ""
 "    That being said, for the simple case of connecting to one specific AFP\n"
@@ -1413,7 +1469,7 @@ msgstr ""
 "    TCPデータをカプセル化していないためである。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:541
+#: manual/Configuration.md:560
 msgid ""
 "- Since this SSH kludge isn't a normal UAM that integrates directly into the "
 "AFP authentication mechanisms but instead uses a single flag signalling "
@@ -1426,7 +1482,7 @@ msgstr ""
 "しい時に何が起こっているのかを見ようとする気を失ってしまう。"
 
 #. type: Plain text
-#: manual/Configuration.md:545
+#: manual/Configuration.md:564
 msgid ""
 "- You cannot control which machines are logged on by Netatalk tools like a "
 "**macusers** since all connection attempts seem to be made from localhost."
@@ -1435,7 +1491,7 @@ msgstr ""
 "うなNetatalkツールによって、どのマシンがログオンしているのか制御ができない。"
 
 #. type: Plain text
-#: manual/Configuration.md:550
+#: manual/Configuration.md:569
 msgid ""
 "- Indeed, to ensure that all AFP sessions are encrypted via SSH, you need to "
 "limit afpd to connections that originate only from localhost (e.g., by using "
@@ -1448,7 +1504,7 @@ msgstr ""
 "ルタリング機能を使用するなど。"
 
 #. type: Plain text
-#: manual/Configuration.md:556
+#: manual/Configuration.md:575
 #, no-wrap
 msgid ""
 "    Otherwise, when you're using Mac OS X 10.2 through 10.3.3, you get the\n"
@@ -1463,7 +1519,7 @@ msgstr ""
 "    Mac OS X 10.3.4 になってそれをはじめて修正した。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:562
+#: manual/Configuration.md:581
 msgid ""
 "- Encrypting all AFP sessions via SSH can lead to a significantly higher "
 "load on the computer that is running the AFP server, because that computer "
@@ -1475,13 +1531,13 @@ msgstr ""
 "いる場合、そのような暗号化は無駄かもしれない。"
 
 #. type: Title ##
-#: manual/Configuration.md:563
+#: manual/Configuration.md:582
 #, no-wrap
 msgid "ACL Support"
 msgstr "ACL のサーポート"
 
 #. type: Plain text
-#: manual/Configuration.md:567
+#: manual/Configuration.md:586
 msgid ""
 "ACL support for AFP is implemented for ZFS ACLs on Solaris and derived "
 "platforms and for POSIX 1e ACLs on Linux."
@@ -1490,7 +1546,7 @@ msgstr ""
 "Linux の POSIX 1e ACL で実装されている。"
 
 #. type: Plain text
-#: manual/Configuration.md:579
+#: manual/Configuration.md:598
 msgid ""
 "For a basic mode of operation there's nothing to configure. Netatalk reads "
 "ACLs on the fly and calculates effective permissions which are then send to "
@@ -1511,7 +1567,7 @@ msgstr ""
 "できないであろう。"
 
 #. type: Plain text
-#: manual/Configuration.md:584
+#: manual/Configuration.md:603
 msgid ""
 "By default, the effective permission of the authenticated user are only "
 "mapped to the mentioned UARightspermission structure, not the UNIX mode.  "
@@ -1523,7 +1579,7 @@ msgstr ""
 "(afp.conf#options-for-acl-handling) で修正することができる。"
 
 #. type: Plain text
-#: manual/Configuration.md:594
+#: manual/Configuration.md:613
 msgid ""
 "However, neither in Finder \"Get Info\" windows nor in the Terminal will you "
 "be able to see the ACLs, because of how ACLs in macOS are designed.  If you "
@@ -1546,7 +1602,7 @@ msgstr ""
 "付けた UNIX uid と gid も含めたサーバー側の ACL を返すことができる。"
 
 #. type: Plain text
-#: manual/Configuration.md:599
+#: manual/Configuration.md:618
 msgid ""
 "Netatalk can query a directory server using LDAP queries. Either the "
 "directory server already provides an UUID attribute for user and groups "
@@ -1560,17 +1616,17 @@ msgstr ""
 "れかである。"
 
 #. type: Plain text
-#: manual/Configuration.md:601
+#: manual/Configuration.md:620
 msgid "In detail:"
 msgstr "より踏み込むと："
 
 #. type: Bullet: '1. '
-#: manual/Configuration.md:603
+#: manual/Configuration.md:622
 msgid "For Solaris/ZFS: ZFS Volumes"
 msgstr "ZFS を使っている Solarisの ZFS ボリュームごとに対して、"
 
 #. type: Plain text
-#: manual/Configuration.md:606
+#: manual/Configuration.md:625
 #, no-wrap
 msgid ""
 "    You should configure a ZFS ACL know for any volume you want to use\n"
@@ -1580,7 +1636,7 @@ msgstr ""
 "    がわかるように構成すべきである：\n"
 
 #. type: Plain text
-#: manual/Configuration.md:609
+#: manual/Configuration.md:628
 #, no-wrap
 msgid ""
 "        aclinherit = passthrough\n"
@@ -1588,7 +1644,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:612
+#: manual/Configuration.md:631
 #, no-wrap
 msgid ""
 "    For an explanation of what this knob does and how to apply it, check\n"
@@ -1598,12 +1654,12 @@ msgstr ""
 "    ZFS ドキュメンテーション（例えば man zfs）を確認のこと。\n"
 
 #. type: Bullet: '2. '
-#: manual/Configuration.md:614
+#: manual/Configuration.md:633
 msgid "Authentication Domain"
 msgstr "認証ドメイン"
 
 #. type: Plain text
-#: manual/Configuration.md:621
+#: manual/Configuration.md:640
 #, no-wrap
 msgid ""
 "    Your server and the clients must be part of a security association\n"
@@ -1621,7 +1677,7 @@ msgstr ""
 "    UUID は ASCII テキストとして保管されている。言い換えれば：\n"
 
 #. type: Bullet: '    - '
-#: manual/Configuration.md:624
+#: manual/Configuration.md:643
 msgid ""
 "you need an Open Directory Server or an LDAP server where you store UUIDs in "
 "some attribute"
@@ -1630,20 +1686,20 @@ msgstr ""
 "サーバーが必要である。"
 
 #. type: Bullet: '    - '
-#: manual/Configuration.md:626
+#: manual/Configuration.md:645
 msgid "your clients must be configured to use this server"
 msgstr ""
 "クライアントはこのサーバーを使用するように構成されていなければならない。"
 
 #. type: Bullet: '    - '
-#: manual/Configuration.md:629
+#: manual/Configuration.md:648
 msgid ""
 "your server should be configured to use this server via nsswitch and PAM"
 msgstr ""
 "サーバーは nsswitch と PAM 経由で使用されるよう構成しなければならない。"
 
 #. type: Bullet: '    - '
-#: manual/Configuration.md:634
+#: manual/Configuration.md:653
 msgid ""
 "configure Netatalk via the special [LDAP options for ACLs]"
 "(afp.conf.html#options-for-acl-handling) in *afp.conf* so that Netatalk is "
@@ -1654,13 +1710,13 @@ msgstr ""
 "handling)を使って Netatalk を設定しなければならない。"
 
 #. type: Title ###
-#: manual/Configuration.md:635
+#: manual/Configuration.md:654
 #, no-wrap
 msgid "macOS ACLs"
 msgstr "macOS の ACL"
 
 #. type: Plain text
-#: manual/Configuration.md:641
+#: manual/Configuration.md:660
 msgid ""
 "With Access Control Lists (ACLs), macOS offers a powerful extension of the "
 "traditional UNIX permissions model. An ACL is an ordered list of Access "
@@ -1673,7 +1729,7 @@ msgstr ""
 "リストである。"
 
 #. type: Plain text
-#: manual/Configuration.md:646
+#: manual/Configuration.md:665
 msgid ""
 "Unlike UNIX permissions, which are bound to user or group IDs, ACLs are tied "
 "to UUIDs. For this reason accessing an object's ACL requires server and "
@@ -1686,7 +1742,7 @@ msgstr ""
 "てくれる、共通のディレクトリサービスを使うことを要求される。"
 
 #. type: Plain text
-#: manual/Configuration.md:658
+#: manual/Configuration.md:677
 msgid ""
 "ACLs and UNIX permissions interact in a rather simple way. As ACLs are "
 "optional UNIX permissions act as a default mechanism for access control.  "
@@ -1711,13 +1767,13 @@ msgstr ""
 "つまり、ACL は常に UNIX のパーミションより優先順位が上位ということである。"
 
 #. type: Title ###
-#: manual/Configuration.md:659
+#: manual/Configuration.md:678
 #, no-wrap
 msgid "ZFS ACLs"
 msgstr "ZFS の ACL"
 
 #. type: Plain text
-#: manual/Configuration.md:663
+#: manual/Configuration.md:682
 msgid ""
 "ZFS ACLs closely match macOS ACLs. Both offer mostly identical fine grained "
 "permissions and inheritance settings."
@@ -1726,19 +1782,19 @@ msgstr ""
 "粒度のパーミションと設定の継承が提供されている。"
 
 #. type: Title ###
-#: manual/Configuration.md:664
+#: manual/Configuration.md:683
 #, no-wrap
 msgid "POSIX ACLs"
 msgstr "POSIX の ACL"
 
 #. type: Title ####
-#: manual/Configuration.md:666
+#: manual/Configuration.md:685
 #, no-wrap
 msgid "Overview"
 msgstr "概要"
 
 #. type: Plain text
-#: manual/Configuration.md:672
+#: manual/Configuration.md:691
 msgid ""
 "Compared to macOS or NFSv4 ACLs, POSIX ACLs represent a different, less "
 "versatile approach to overcome the limitations of the traditional UNIX "
@@ -1750,7 +1806,7 @@ msgstr ""
 "Posix 標準を取り込んだものを基礎としている。"
 
 #. type: Plain text
-#: manual/Configuration.md:680
+#: manual/Configuration.md:699
 msgid ""
 "The standard defines two types of ACLs. Files and directories can have "
 "access ACLs which are consulted for access checks. Directories can also have "
@@ -1768,14 +1824,14 @@ msgstr ""
 "を継承する。 継承制御にそれ以上のメカニズムは何もない。"
 
 #. type: Plain text
-#: manual/Configuration.md:683
+#: manual/Configuration.md:702
 msgid ""
 "Architectural differences between POSIX ACLs and macOS ACLs especially "
 "involve:"
 msgstr "設計上、Posix ACL と macOS 間の違いに含まれている特筆すべき点は："
 
 #. type: Plain text
-#: manual/Configuration.md:686
+#: manual/Configuration.md:705
 msgid ""
 "- No fine-granular permissions model. Like UNIX permissions POSIX ACLs only "
 "differentiate between read, write and execute permissions."
@@ -1784,12 +1840,12 @@ msgstr ""
 "ACLは読み込み、書き込み、そして実行権限を区別している。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:688
+#: manual/Configuration.md:707
 msgid "Entries within an ACL are unordered."
 msgstr "ACL 内のエントリーに順序はない。"
 
 #. type: Plain text
-#: manual/Configuration.md:691
+#: manual/Configuration.md:710
 msgid ""
 "- POSIX ACLs can only grant rights. There is no way to explicitly deny "
 "rights by an entry."
@@ -1798,12 +1854,12 @@ msgstr ""
 "する手立てはない。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:693
+#: manual/Configuration.md:712
 msgid "UNIX permissions are integrated into an ACL as special entries."
 msgstr "UNIX パーミションは特別なエントリーとして ACL に統合されている。"
 
 #. type: Plain text
-#: manual/Configuration.md:698
+#: manual/Configuration.md:717
 msgid ""
 "POSIX 1003.1e defines 6 different types of ACL entries. The first three "
 "types are used to integrate standard UNIX permissions. They form a minimal "
@@ -1816,37 +1872,37 @@ msgstr ""
 "つのエントリーだけが ACL 内に許される。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:700
+#: manual/Configuration.md:719
 msgid "ACL_USER_OBJ: the owner's access rights."
 msgstr "ACL_USER_OBJ：所有ユーザー（オーナー）のアクセス権限。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:702
+#: manual/Configuration.md:721
 msgid "ACL_GROUP_OBJ: the owning group's access rights."
 msgstr "ACL_GROUP_OBJ：所有グループ（オーナーグループ）のアクセス権限。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:704
+#: manual/Configuration.md:723
 msgid "ACL_OTHER: everybody's access rights."
 msgstr "ACL_OTHER：あらゆるユーザー・グループに対するアクセス権限。"
 
 #. type: Plain text
-#: manual/Configuration.md:706
+#: manual/Configuration.md:725
 msgid "The remaining entry types expand the traditional permissions model:"
 msgstr "残りのエントリーのタイプは伝統的パーミションモデルの拡張である："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:708
+#: manual/Configuration.md:727
 msgid "ACL_USER: grants access rights to a certain user."
 msgstr "ACL_USER：あるユーザーに対するアクセス権を許可する。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:710
+#: manual/Configuration.md:729
 msgid "ACL_GROUP: grants access rights to a certain group."
 msgstr "ACL_GROUP：あるグループに対するアクセス権を許可する。"
 
 #. type: Plain text
-#: manual/Configuration.md:716
+#: manual/Configuration.md:735
 msgid ""
 "- ACL_MASK: limits the maximum access rights which can be granted by entries "
 "of type ACL_GROUP_OBJ, ACL_USER and ACL_GROUP. As the name suggests, this "
@@ -1862,7 +1918,7 @@ msgstr ""
 "ンである。"
 
 #. type: Plain text
-#: manual/Configuration.md:722
+#: manual/Configuration.md:741
 msgid ""
 "In order to maintain compatibility with applications not aware of ACLs, "
 "POSIX 1003.1e changes the semantics of system calls and utilities which "
@@ -1877,7 +1933,7 @@ msgstr ""
 "エントリーの値に対応する。"
 
 #. type: Plain text
-#: manual/Configuration.md:729
+#: manual/Configuration.md:748
 msgid ""
 "However, if the ACL also contains an ACL_MASK entry, the behavior of those "
 "system calls and utilities is different. The group permissions bits of the "
@@ -1894,13 +1950,13 @@ msgstr ""
 "のエンティティ全てを無効にするのである。"
 
 #. type: Title ####
-#: manual/Configuration.md:730
+#: manual/Configuration.md:749
 #, no-wrap
 msgid "Mapping POSIX ACLs to macOS ACLs"
 msgstr "POSIX ACL から macOS の ACL へのマッピング"
 
 #. type: Plain text
-#: manual/Configuration.md:738
+#: manual/Configuration.md:757
 msgid ""
 "When a client wants to read an object's ACL, afpd maps its POSIX ACL onto an "
 "equivalent macOS ACL. Writing an object's ACL requires afpd to map an macOS "
@@ -1915,7 +1971,7 @@ msgstr ""
 "ね同じになるような正確なマッピングを見出すことは通常不可能である。"
 
 #. type: Plain text
-#: manual/Configuration.md:741
+#: manual/Configuration.md:760
 msgid ""
 "- afpd silently discard entries which deny a set of permissions because they "
 "they can't be represented within the POSIX architecture."
@@ -1924,7 +1980,7 @@ msgstr ""
 "Posix の設計では表現する手立てがないためである。"
 
 #. type: Plain text
-#: manual/Configuration.md:744
+#: manual/Configuration.md:763
 msgid ""
 "- As entries within POSIX ACLs are unordered, it is impossible to preserve "
 "order."
@@ -1933,12 +1989,12 @@ msgstr ""
 "ある。"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:746
+#: manual/Configuration.md:765
 msgid "Inheritance control is subject to severe limitations as well:"
 msgstr "継承制御もまた厳しい制限を受けやすい："
 
 #. type: Bullet: '  - '
-#: manual/Configuration.md:749
+#: manual/Configuration.md:768
 msgid ""
 "Entries with the only_inherit flag set will only become part of the "
 "directory's default ACL."
@@ -1947,7 +2003,7 @@ msgstr ""
 "部にしかならない。"
 
 #. type: Bullet: '  - '
-#: manual/Configuration.md:754
+#: manual/Configuration.md:773
 msgid ""
 "Entries with at least one of the flags file_inherit, directory_inherit or "
 "limit_inherit set, will become part of the directory's access and default "
@@ -1958,7 +2014,7 @@ msgstr ""
 "しかし継承に課せられた制約は無視される。"
 
 #. type: Plain text
-#: manual/Configuration.md:757
+#: manual/Configuration.md:776
 msgid ""
 "- The lack of a fine-granular permission model on the POSIX side will "
 "normally result in an increase of granted permissions."
@@ -1967,7 +2023,7 @@ msgstr ""
 "は許可されるパーミションが増えるという結果になる。"
 
 #. type: Plain text
-#: manual/Configuration.md:771
+#: manual/Configuration.md:790
 msgid ""
 "As macOS clients aren't aware of the POSIX 1003.1e specific relationship "
 "between UNIX permissions and ACL_MASK, afpd does not expose this feature to "
@@ -1996,13 +2052,13 @@ msgstr ""
 "ACL_MASK の値の再計算を afpd が行う。"
 
 #. type: Title ##
-#: manual/Configuration.md:772
+#: manual/Configuration.md:791
 #, no-wrap
 msgid "Filesystem Change Events"
 msgstr "ファイルシステム変更イベント"
 
 #. type: Plain text
-#: manual/Configuration.md:777
+#: manual/Configuration.md:796
 msgid ""
 "Netatalk includes a nifty filesystem change event (FCE) mechanism where afpd "
 "processes notify interested listeners about certain filesystem events by UDP "
@@ -2014,7 +2070,7 @@ msgstr ""
 "経由で通知する。"
 
 #. type: Plain text
-#: manual/Configuration.md:781
+#: manual/Configuration.md:800
 msgid ""
 "This feature is disabled by default. To enable it, set the **fce listener** "
 "option in afp.conf to the hostname or IP address of the host that should "
@@ -2025,7 +2081,7 @@ msgstr ""
 "アドレスに設定する。"
 
 #. type: Plain text
-#: manual/Configuration.md:785
+#: manual/Configuration.md:804
 msgid ""
 "Netatalk distributes a simple FCE listener application called "
 "**fce_listen**.  It will print out any UDP datagrams received from the AFP "
@@ -2038,49 +2094,49 @@ msgstr ""
 "トとしても役立つ。"
 
 #. type: Title ###
-#: manual/Configuration.md:786
+#: manual/Configuration.md:805
 #, no-wrap
 msgid "FCE v1"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:789
+#: manual/Configuration.md:808
 msgid "The currently supported FCE v1 events are:"
 msgstr "現在サポートされているファイルシステム変更イベントは以下である："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:791
+#: manual/Configuration.md:810
 msgid "file modification (fmod)"
 msgstr "ファイル変更：file modification (fmod)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:793
+#: manual/Configuration.md:812
 msgid "file deletion (fdel)"
 msgstr "ファイル削除：file deletion (fdel)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:795
+#: manual/Configuration.md:814
 msgid "directory deletion (ddel)"
 msgstr "ディレクトリ削除：directory deletion (ddel)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:797
+#: manual/Configuration.md:816
 msgid "file creation (fcre)"
 msgstr "ファイル作成：file creation (fcre)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:799
+#: manual/Configuration.md:818
 msgid "directory creation (dcre)"
 msgstr "ディレクトリ削除：directory deletion (ddel)"
 
 #. type: Title ###
-#: manual/Configuration.md:800
+#: manual/Configuration.md:819
 #, no-wrap
 msgid "FCE v2"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:804
+#: manual/Configuration.md:823
 msgid ""
 "FCE v2 events provide additional context such as the user who performed the "
 "action. When using FCE v2 you also get the following events:"
@@ -2089,33 +2145,33 @@ msgstr ""
 "する。FCE v2 を使用する場合は、以下のイベントも取得できる："
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:806
+#: manual/Configuration.md:825
 msgid "file moving (fmov)"
 msgstr "ファイル移動 (fmov)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:808
+#: manual/Configuration.md:827
 msgid "directory moving (dmov)"
 msgstr "ディレクトリー移動 (dmov)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:810
+#: manual/Configuration.md:829
 msgid "user login (login)"
 msgstr "ユーザーログイン (login)"
 
 #. type: Bullet: '- '
-#: manual/Configuration.md:812
+#: manual/Configuration.md:831
 msgid "user logout (logout)"
 msgstr "ユーザーログアウト (logout)"
 
 #. type: Title ##
-#: manual/Configuration.md:813
+#: manual/Configuration.md:832
 #, no-wrap
 msgid "Spotlight Compatible Search"
 msgstr ""
 
 #. type: Plain text
-#: manual/Configuration.md:817
+#: manual/Configuration.md:836
 msgid ""
 "You can enable Netatalk's Spotlight compatible search and indexing either "
 "globally or on a per volume basis with the **spotlight** option."
@@ -2124,7 +2180,7 @@ msgstr ""
 "に Netatalk の Spotlight 互換検索とインデックス化を有効にできる。"
 
 #. type: Plain text
-#: manual/Configuration.md:820
+#: manual/Configuration.md:839
 #, no-wrap
 msgid ""
 "> ***WARNING:*** Once Spotlight is enabled for a single volume,\n"
@@ -2134,7 +2190,7 @@ msgstr ""
 "が無効にされたことになるその他全てのボリュームでは全く検索できないようになる。\n"
 
 #. type: Plain text
-#: manual/Configuration.md:824
+#: manual/Configuration.md:843
 msgid ""
 "The **dbus-daemon** binary has to be installed for Spotlight feature. The "
 "path to dbus-daemon is determined at compile time the dbus-daemon build "
@@ -2145,7 +2201,7 @@ msgstr ""
 "決定する。"
 
 #. type: Plain text
-#: manual/Configuration.md:828
+#: manual/Configuration.md:847
 msgid ""
 "In case the **dbus-daemon** binary is installed at the other path, you must "
 "use the global option **dbus daemon** to point to the path, e.g. for Solaris "
@@ -2156,7 +2212,7 @@ msgstr ""
 "ば Solaris 上で OpenCSW 由来の Tracker を用いている場合は以下のようにする："
 
 #. type: Plain text
-#: manual/Configuration.md:829
+#: manual/Configuration.md:848
 #, no-wrap
 msgid "    dbus daemon = /opt/csw/bin/dbus-daemon\n"
 msgstr ""

--- a/doc/po/Installation.md.ja.po
+++ b/doc/po/Installation.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-05-25 10:43+0200\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
 "PO-Revision-Date: 2025-01-25 15:05+0100\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -151,35 +151,11 @@ msgstr "必要なサードパーティソフトウェア"
 
 #. type: Bullet: '- '
 #: manual/Installation.md:50
-msgid "Berkeley DB"
-msgstr ""
-
-#. type: Plain text
-#: manual/Installation.md:54
-#, no-wrap
-msgid ""
-"    The default dbd CNID backend for netatalk uses Berkeley DB to store\n"
-"    unique file identifiers. At the time of writing you need at least\n"
-"    version 4.6.\n"
-msgstr "    デフォルトのdbd CNIDバックエンドは、Berkeley DBを使用して一意のファイル識別子を保存します。書き込みの時に最低でもバージョン 4.6 が必要となる。\n"
-
-#. type: Plain text
-#: manual/Installation.md:57
-#, no-wrap
-msgid ""
-"    The recommended version is 5.3, the final release under the permissive\n"
-"    Sleepycat license, and therefore the most widely distributed version.\n"
-msgstr ""
-"    推奨バージョンは 5.3 である Sleepycat\n"
-"    ライセンスで提供された最終リリースである。\n"
-
-#. type: Bullet: '- '
-#: manual/Installation.md:59
 msgid "iniparser"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:62
+#: manual/Installation.md:53
 #, no-wrap
 msgid ""
 "    The iniparser library is used to parse the configuration files.\n"
@@ -189,12 +165,12 @@ msgstr ""
 "    最低でもバージョン 3.1 が必要であり、4.0 以降が推奨される。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:64
+#: manual/Installation.md:55
 msgid "libevent"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:67
+#: manual/Installation.md:58
 #, no-wrap
 msgid ""
 "    Internal event callbacks in the netatalk service controller daemon are\n"
@@ -204,12 +180,12 @@ msgstr ""
 "    コールバックは、 libevent バージョン 2 に基づいて構築されている。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:69
+#: manual/Installation.md:60
 msgid "Libgcrypt"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:73
+#: manual/Installation.md:64
 #, no-wrap
 msgid ""
 "    The [Libgcrypt](https://gnupg.org/software/libgcrypt/) library\n"
@@ -221,14 +197,95 @@ msgstr ""
 "    の暗号化を提供する。これらは、DHX2、DHCAST128 (別名 DHX)、および\n"
 "    RandNum である。\n"
 
-#. type: Title ###
+#. type: Title ####
+#: manual/Installation.md:65
+#, no-wrap
+msgid "CNID database backends"
+msgstr "CNID データベースバックエンド一覧"
+
+#. type: Plain text
+#: manual/Installation.md:72
+msgid ""
+"At least one of the below database libraries is required to power the CNID "
+"scheme of your choice.  Without one of these, only the *last* backend will "
+"be available which operates in read-only mode and therefore not recommended "
+"for daily use."
+msgstr ""
+"CNIDスキームを有効するには、以下のデータベースライブラリの少なくとも1つが必要"
+"になる。いずれか1つがない場合は、*last* バックエンドのみ利用可能となりるが、"
+"これは読み取り専用モードで動作するため、日常的な使用には推奨しない。"
+
+#. type: Bullet: '- '
 #: manual/Installation.md:74
+msgid "Berkeley DB"
+msgstr ""
+
+#. type: Plain text
+#: manual/Installation.md:78
+#, no-wrap
+msgid ""
+"    The default dbd CNID backend for netatalk uses Berkeley DB to store\n"
+"    unique file identifiers. At the time of writing you need at least\n"
+"    version 4.6.\n"
+msgstr ""
+"    デフォルトのdbd CNIDバックエンドは、Berkeley DBを使用して一意のファイル識別子を保存します。\n"
+"    書き込みの時に最低でもバージョン 4.6 が必要となる。\n"
+
+#. type: Plain text
+#: manual/Installation.md:81
+#, no-wrap
+msgid ""
+"    The recommended version is 5.3, the final release under the permissive\n"
+"    Sleepycat license, and therefore the most widely distributed version.\n"
+msgstr ""
+"    推奨バージョンは 5.3 である Sleepycat\n"
+"    ライセンスで提供された最終リリースである。\n"
+
+#. type: Bullet: '- '
+#: manual/Installation.md:83
+msgid "MySQL or MariaDB"
+msgstr "MySQL または MariaDB"
+
+#. type: Plain text
+#: manual/Installation.md:88
+#, no-wrap
+msgid ""
+"    By leveraging a MySQL-compatible client library, netatalk can be built\n"
+"    with a MySQL CNID backend that is highly scalable and reliable.\n"
+"    The administrator has to provide a separate database instance for use with\n"
+"    this backend.\n"
+msgstr ""
+"    MySQL 互換のクライアント ライブラリを活用することで、netatalk\n"
+"    は、スケーラビリティと信頼性に優れた MySQL CNID\n"
+"    バックエンドを使用して構築できる。管理者は、このバックエンドで使用するために別のデータベース\n"
+"    インスタンスを用意する必要がある。\n"
+
+#. type: Bullet: '- '
+#: manual/Installation.md:90
+msgid "SQLite v3"
+msgstr ""
+
+#. type: Plain text
+#: manual/Installation.md:95
+#, no-wrap
+msgid ""
+"    The SQLite library version 3 enables the SQLite CNID backend\n"
+"    which is an alternative zero-configuration backend.\n"
+"    This backend is **experimental** and should be used only for\n"
+"    testing purposes.\n"
+msgstr ""
+"    SQLite ライブラリ バージョン3は、SQLite CNID バックエンドが有効にする。\n"
+"    設定不要の代替バックエンドである。\n"
+"    本バックエンドは**実験的**であり、テスト目的でのみ使用すること。\n"
+
+#. type: Title ###
+#: manual/Installation.md:96
 #, no-wrap
 msgid "Optional third-party software"
 msgstr "任意のサードパーティソフトウェア"
 
 #. type: Plain text
-#: manual/Installation.md:78
+#: manual/Installation.md:100
 msgid ""
 "Netatalk can use the following third-party software to enhance its "
 "functionality."
@@ -237,12 +294,12 @@ msgstr ""
 "ることができる。"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:80
+#: manual/Installation.md:102
 msgid "ACL and LDAP"
 msgstr "ACL と LDAP"
 
 #. type: Plain text
-#: manual/Installation.md:86
+#: manual/Installation.md:108
 #, no-wrap
 msgid ""
 "    LDAP is an open and industry-standard user directory protocol that\n"
@@ -258,12 +315,12 @@ msgstr ""
 "    パッケージをインストールする必要がある。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:88
+#: manual/Installation.md:110
 msgid "Avahi or mDNSresponder for Bonjour"
 msgstr "Bonjour 用の Avahi または mDNSresponder"
 
 #. type: Plain text
-#: manual/Installation.md:92
+#: manual/Installation.md:114
 #, no-wrap
 msgid ""
 "    Mac OS X 10.2 and later uses Bonjour (a.k.a. Zeroconf) for automatic\n"
@@ -275,7 +332,7 @@ msgstr ""
 "    ファイル共有と Time Machine ボリュームをアドバタイズできる。\n"
 
 #. type: Plain text
-#: manual/Installation.md:95
+#: manual/Installation.md:117
 #, no-wrap
 msgid ""
 "    When using Avahi, D-Bus is also required, and the Avahi library must\n"
@@ -285,12 +342,12 @@ msgstr ""
 "    Avahi ライブラリは必要になる。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:97
+#: manual/Installation.md:119
 msgid "cmark, cmark-gfm, or pandoc"
 msgstr "cmark、cmark-gfm、またはpandoc"
 
 #. type: Plain text
-#: manual/Installation.md:102
+#: manual/Installation.md:124
 #, no-wrap
 msgid ""
 "    Netatalk's documentation is authored in Markdown format.\n"
@@ -303,7 +360,7 @@ msgstr ""
 "    ドキュメントの残りの部分はGitHub風の Markdown (gfm)で作成されている。\n"
 
 #. type: Plain text
-#: manual/Installation.md:107
+#: manual/Installation.md:129
 #, no-wrap
 msgid ""
 "    The pandoc library generates the nicest output, but is\n"
@@ -316,12 +373,12 @@ msgstr ""
 "    されているが、cmark-gfm はテーブルのようなGitHub拡張機能をよりよく扱う。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:109
+#: manual/Installation.md:131
 msgid "CrackLib"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:113
+#: manual/Installation.md:135
 #, no-wrap
 msgid ""
 "    When using the Random Number UAMs and netatalk's own **afppasswd**\n"
@@ -333,7 +390,7 @@ msgstr ""
 "    での認証に弱いパスワードを設定するのを防ぐのに役立つ。\n"
 
 #. type: Plain text
-#: manual/Installation.md:116
+#: manual/Installation.md:138
 #, no-wrap
 msgid ""
 "    The CrackLib dictionary, which is sometimes distributed separately in\n"
@@ -343,12 +400,12 @@ msgstr ""
 "    もコンパイル時にも実行時にも必須である。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:118
+#: manual/Installation.md:140
 msgid "D-Bus"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:122
+#: manual/Installation.md:144
 #, no-wrap
 msgid ""
 "    D-Bus provides a mechanism for sending messages between processes,\n"
@@ -360,23 +417,23 @@ msgstr ""
 "    **afpstats** ツール。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:124
+#: manual/Installation.md:146
 msgid "GLib and GIO"
 msgstr "GLib および GIO"
 
 #. type: Plain text
-#: manual/Installation.md:126
+#: manual/Installation.md:148
 #, no-wrap
 msgid "    Used by the **afpstats** tool to interface with D-Bus.\n"
 msgstr "    D-Bus とのインターフェースとして、**afpstats** ツールに使われる。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:128
+#: manual/Installation.md:150
 msgid "iconv"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:134
+#: manual/Installation.md:156
 #, no-wrap
 msgid ""
 "    iconv provides conversion routines for many character encodings.\n"
@@ -392,12 +449,12 @@ msgstr ""
 "    実装を使用できる。それ以外の場合は、GNU libiconv 実装を使用できる。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:136
+#: manual/Installation.md:158
 msgid "Kerberos V"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:141
+#: manual/Installation.md:163
 #, no-wrap
 msgid ""
 "    Kerberos v5 is a client-server based authentication protocol invented\n"
@@ -411,31 +468,12 @@ msgstr ""
 "    インフラストラクチャでの認証用に GSS UAM ライブラリを作成できる。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:143
-msgid "MySQL or MariaDB"
-msgstr "MySQL または MariaDB"
-
-#. type: Plain text
-#: manual/Installation.md:148
-#, no-wrap
-msgid ""
-"    By leveraging a MySQL-compatible client library, netatalk can be built\n"
-"    with a MySQL CNID backend that is highly scalable and reliable. The\n"
-"    administrator has to provide a separate database instance for use with\n"
-"    this backend.\n"
-msgstr ""
-"    MySQL 互換のクライアント ライブラリを活用することで、netatalk\n"
-"    は、スケーラビリティと信頼性に優れた MySQL CNID\n"
-"    バックエンドを使用して構築できる。管理者は、このバックエンドで使用するために別のデータベース\n"
-"    インスタンスを用意する必要がある。\n"
-
-#. type: Bullet: '- '
-#: manual/Installation.md:150
+#: manual/Installation.md:165
 msgid "PAM"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:155
+#: manual/Installation.md:170
 #, no-wrap
 msgid ""
 "    PAM provides a flexible mechanism for authenticating users. PAM was\n"
@@ -450,12 +488,12 @@ msgstr ""
 "    スイートである。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:157
+#: manual/Installation.md:172
 msgid "Perl"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:161
+#: manual/Installation.md:176
 #, no-wrap
 msgid ""
 "    Netatalk's administrative utility scripts rely on the Perl runtime,\n"
@@ -467,12 +505,12 @@ msgstr ""
 "    (asip-status) 又は *Net::DBus* (afpstats)。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:163
+#: manual/Installation.md:178
 msgid "po4a"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:168
+#: manual/Installation.md:183
 #, no-wrap
 msgid ""
 "    With the help of po4a, Netatalk's documentation can be translated\n"
@@ -485,58 +523,52 @@ msgstr ""
 "    ファイルに保存されている翻訳と結合する。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:170
+#: manual/Installation.md:185
 msgid "TCP wrappers"
 msgstr "TCP ラッパー"
 
 #. type: Plain text
-#: manual/Installation.md:172
+#: manual/Installation.md:187
 #, no-wrap
 msgid "    Wietse Venema's network logger, also known as TCPD or LOG_TCP.\n"
 msgstr "    Wietse Venema のネットワーク ロガー。TCPD または LOG_TCP とも呼ばれる。\n"
 
 #. type: Plain text
-#: manual/Installation.md:176
+#: manual/Installation.md:191
 #, no-wrap
 msgid ""
 "    Security options are: access control per host, domain and/or service;\n"
 "    detection of host name spoofing or host address spoofing; booby traps\n"
 "    to implement an early-warning system.\n"
 msgstr ""
-"    セキュリティオプションは次のとおり。ホスト、ドメイン、および/またはサービスごとのアクセス制御、ホスト名のスプーフィングまたはホスト\n"
+"    セキュリティオプションは次のとおり。\n"
+"    ホスト、ドメイン、および/またはサービスごとのアクセス制御、ホスト名のスプーフィングまたはホスト\n"
 "    アドレスのスプーフィングの検出。ブービートラップを使用して早期警告システムを実装する。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:178
-msgid "Tracker, or TinySPARQL / LocalSearch"
-msgstr "Tracker もしくは TinySPARQL / LocalSearch"
+#: manual/Installation.md:193
+msgid "LocalSearch or Tracker"
+msgstr "LocalSearch または Tracker"
 
 #. type: Plain text
-#: manual/Installation.md:186
+#: manual/Installation.md:197
 #, no-wrap
 msgid ""
-"    Netatalk uses [Tracker](https://tracker.gnome.org) or its later\n"
-"    incarnation\n"
-"    TinySPARQL/[LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/)\n"
-"    as the metadata backend for Spotlight\n"
-"    search indexing. The minimum required version is 0.12 as this was the\n"
-"    first version to support\n"
-"    [SPARQL](https://gnome.pages.gitlab.gnome.org/tracker/).\n"
+"    Netatalk uses [GNOME LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/index.html),\n"
+"    or Tracker as it was previously known, version 3 or later as the metadata backend for Spotlight\n"
+"    compatible search indexing.\n"
 msgstr ""
-"    Netatalkは、Spotlight検索インデックスのメタデータ バックエンドとして\n"
-"    [Tracker](https://tracker.gnome.org) またはそれ以降のバージョンである\n"
-"    TinySPARQL/[LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/)\n"
-"    を使用する。必要な最小限のバージョンは 0.12 である。これは\n"
-"    [SPARQL](https://gnome.pages.gitlab.gnome.org/tracker/)\n"
-"    をサポートする最初のバージョンだからである。\n"
+"    Netatalk は、Spotlight 互換の検索インデックスのメタデータバックエンドとして、\n"
+"    [GNOME LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/index.html)\n"
+"    （以前は Tracker）バージョン3以降を使用する。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:188
+#: manual/Installation.md:199
 msgid "talloc / bison / flex"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:191
+#: manual/Installation.md:202
 #, no-wrap
 msgid ""
 "    Samba's talloc library, a Yacc parser such as bison, and a lexer like\n"
@@ -546,36 +578,39 @@ msgstr ""
 "    パーサー、flex などのレキサーも必要。\n"
 
 #. type: Bullet: '- '
-#: manual/Installation.md:193
+#: manual/Installation.md:204
 msgid "UnicodeData.txt"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:196
+#: manual/Installation.md:207
 #, no-wrap
 msgid ""
 "    The [Unicode Character Database](https://www.unicode.org/Public/UNIDATA/UnicodeData.txt)\n"
 "    is required to regenerate Netatalk's Unicode character conversion tables.\n"
 msgstr ""
-"    Netatalk の Unicode 文字変換テーブルを再生成するには、[Unicode 文字データベース](https://www.unicode.org/Public/UNIDATA/UnicodeData.txt)\n"
+"    Netatalk の Unicode 文字変換テーブルを再生成するには、\n"
+"    [Unicode 文字データベース](https://www.unicode.org/Public/UNIDATA/UnicodeData.txt)\n"
 "    が必要である。\n"
 
 #. type: Plain text
-#: manual/Installation.md:199
+#: manual/Installation.md:210
 #, no-wrap
 msgid ""
 "    This is mostly relevant for developers or package managers who want to regenerate\n"
 "    the Unicode source files.\n"
-msgstr "    これは、開発者やパッケージ マネージャーが Netatalk の Unicode 文字変換テーブルを再生成したい場合に関連する。\n"
+msgstr ""
+"    これは、開発者やパッケージ マネージャーが Netatalk の Unicode \n"
+"    文字変換テーブルを再生成したい場合に関連する。\n"
 
 #. type: Title ##
-#: manual/Installation.md:200
+#: manual/Installation.md:211
 #, no-wrap
 msgid "Starting and stopping Netatalk"
 msgstr "Netatalk の起動と停止"
 
 #. type: Plain text
-#: manual/Installation.md:208
+#: manual/Installation.md:219
 msgid ""
 "The Netatalk distribution comes with several operating system specific "
 "startup script templates that are tailored according to the options given to "
@@ -590,7 +625,7 @@ msgstr ""
 "トフォーム固有のスクリプトに加えて、systemd、openrc 用に提供されている。"
 
 #. type: Plain text
-#: manual/Installation.md:214
+#: manual/Installation.md:225
 msgid ""
 "When building from source, the Netatalk build system will attempt to detect "
 "which init style is appropriate for your platform. You can also configure "
@@ -605,7 +640,7 @@ msgstr ""
 "テキストを参照してください。"
 
 #. type: Plain text
-#: manual/Installation.md:219
+#: manual/Installation.md:230
 msgid ""
 "Since new Linux, \\*BSD, and Solaris-like distributions appear at regular "
 "intervals, and the startup procedure for the other systems mentioned above "
@@ -618,7 +653,7 @@ msgstr ""
 "ることをお勧めする。"
 
 #. type: Plain text
-#: manual/Installation.md:224
+#: manual/Installation.md:235
 msgid ""
 "If you use Netatalk as part of a fixed setup, like a Linux distribution, an "
 "RPM or a BSD package, things will probably have been arranged properly for "
@@ -631,7 +666,7 @@ msgstr ""
 "まる。"
 
 #. type: Plain text
-#: manual/Installation.md:227
+#: manual/Installation.md:238
 msgid ""
 "The following daemon need to be started by whatever startup script mechanism "
 "is used:"
@@ -639,13 +674,14 @@ msgstr ""
 "次のデーモンは、使用するスタートアップ スクリプト メカニズムによって起動する"
 "必要がある:"
 
-#. type: Bullet: '- '
-#: manual/Installation.md:229
+#. type: Title ##
+#: manual/Installation.md:240 manual/Legal.md:10
+#, no-wrap
 msgid "netatalk"
 msgstr ""
 
 #. type: Plain text
-#: manual/Installation.md:232
+#: manual/Installation.md:243
 msgid ""
 "In the absence of a startup script, you can also launch this daemon directly "
 "(as root), and kill it with SIGTERM when you are done with it."
@@ -654,7 +690,7 @@ msgstr ""
 "し、使い終わったら SIGTERM で終了することもできる。"
 
 #. type: Plain text
-#: manual/Installation.md:236
+#: manual/Installation.md:247
 msgid ""
 "Additionally, make sure that the configuration file *afp.conf* is in the "
 "right place. You can inquire netatalk where it is expecting the file to be "
@@ -665,7 +701,7 @@ msgstr ""
 "かどうかを問い合わせることができる。"
 
 #. type: Plain text
-#: manual/Installation.md:240
+#: manual/Installation.md:251
 msgid ""
 "If you want to run AppleTalk services, you also need to start the **atalkd** "
 "daemon, plus the optional **papd**, **timelord**, and **a2boot** daemons. "

--- a/doc/po/Legal.md.ja.po
+++ b/doc/po/Legal.md.ja.po
@@ -1,0 +1,417 @@
+# Japanese translations for Netatalk documentation
+# Netatalk ドキュメントの日本語訳
+# Copyright (C) 2025 Daniel Markstedt <daniel@mindani.net>
+# This file is distributed under the same license as the Netatalk package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Netatalk 4.3.0dev\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
+"PO-Revision-Date: 2025-07-29 20:18+0200\n"
+"Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Title ##
+#: manual/Installation.md:240 manual/Legal.md:10
+#, no-wrap
+msgid "netatalk"
+msgstr ""
+
+#. type: Title #
+#: manual/Legal.md:1
+#, no-wrap
+msgid "Legal Notices"
+msgstr "法的条項"
+
+#. type: Plain text
+#: manual/Legal.md:7
+msgid ""
+"The Netatalk software package as well as this documentation are distributed "
+"under the [GNU General Public License version 2](License.html).  A copy of "
+"the license is included with this documentation, as well as within the "
+"Netatalk source distribution."
+msgstr ""
+"Netatalk のソフトウェアのパッケージまたは本ドキュメントは [GNU 一般公衆利用許"
+"諾書 (GPL) バージョン 2](License.html) のもとで配布されている。 Netatalk ソー"
+"ス一式にも本ドキュメントと同様に許諾書のコピーが同梱されている。"
+
+#. type: Plain text
+#: manual/Legal.md:9
+msgid ""
+"Legal notices for individual modules bundled with the Netatalk distribution "
+"follow below."
+msgstr ""
+"Netatalk ディストリビューションにバンドルされている個々のモジュールに関する法"
+"的通知は下記のとおり。"
+
+#. type: Plain text
+#: manual/Legal.md:14
+#, no-wrap
+msgid ""
+"    Copyright (c) 1990,1996 Regents of The University of Michigan.\n"
+"    All Rights Reserved.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:24 manual/Legal.md:69 manual/Legal.md:167
+#: manual/Legal.md:229
+#, no-wrap
+msgid ""
+"    Permission to use, copy, modify, and distribute this software and\n"
+"    its documentation for any purpose and without fee is hereby granted,\n"
+"    provided that the above copyright notice appears in all copies and\n"
+"    that both that copyright notice and this permission notice appear\n"
+"    in supporting documentation, and that the name of The University\n"
+"    of Michigan not be used in advertising or publicity pertaining to\n"
+"    distribution of the software without specific, written prior\n"
+"    permission. This software is supplied as is without expressed or\n"
+"    implied warranties of any kind.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:27
+#, no-wrap
+msgid ""
+"    This product includes software developed by the University of\n"
+"    California, Berkeley and its contributors.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:35
+#, no-wrap
+msgid ""
+"    Research Systems Unix Group\n"
+"    The University of Michigan\n"
+"    c/o Wesley Craig\n"
+"    535 W. William Street\n"
+"    Ann Arbor, Michigan\n"
+"    +1-313-764-2278\n"
+"    netatalk@umich.edu\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:38
+#, no-wrap
+msgid ""
+"    Modifications for Appleshare IP and other files copyrighted by Adrian\n"
+"    Sun are under the following copyright:\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:41
+#, no-wrap
+msgid ""
+"    Copyright (c) 1997,1998,1999,2000 Adrian Sun (asun@cobalt.com)\n"
+"    All Rights Reserved.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:48
+#, no-wrap
+msgid ""
+"    Permission to use, copy, modify, and distribute this software and\n"
+"    its documentation for any purpose and without fee is hereby granted,\n"
+"    provided that the above copyright notice appears in all copies and\n"
+"    that both that copyright notice and this permission notice appear\n"
+"    in supporting documentation. This software is supplied as is\n"
+"    without expressed or implied warranties of any kind.\n"
+msgstr ""
+
+#. type: Title ##
+#: manual/Legal.md:49
+#, no-wrap
+msgid "a2boot"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:56
+#, no-wrap
+msgid ""
+"    Recoding circa Dec 2002-early 2003          by Marsha Jackson\n"
+"    support booting of Apple 2 computers,   with aid of Steven N. Hirsch\n"
+"    Code is copyrighted as listed below...\n"
+"    M. Jackson is establishing no personal copyright\n"
+"    or personal restrictions on this software.  Only the below rights exist\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:57 manual/Legal.md:217
+#, no-wrap
+msgid "    Copyright (c) 1990,1994 Regents of The University of Michigan.  \n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:59 manual/Legal.md:157 manual/Legal.md:219
+#, no-wrap
+msgid "    All Rights Reserved.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:77 manual/Legal.md:237
+#, no-wrap
+msgid ""
+"    Research Systems Unix Group\n"
+"    The University of Michigan\n"
+"    c/o Wesley Craig\n"
+"    535 W. William Street\n"
+"    Ann Arbor, Michigan\n"
+"    +1 313 764 2278\n"
+"    netatalk@umich.edu\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:82 manual/Legal.md:242
+#, no-wrap
+msgid ""
+"    The \"timelord protocol\" was reverse engineered from Timelord,\n"
+"    distributed with CAP, Copyright (c) 1990, The University of\n"
+"    Melbourne.  The following copyright, supplied by The University\n"
+"    of Melbourne, may apply to this code:\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:85 manual/Legal.md:245
+#, no-wrap
+msgid ""
+"    This version of timelord.c is based on code distributed\n"
+"    by the University of Melbourne as part of the CAP package.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:88 manual/Legal.md:247
+#, no-wrap
+msgid ""
+"    The tardis/Timelord package for Macintosh/CAP is\n"
+"    Copyright (c) 1990, The University of Melbourne.\n"
+msgstr ""
+
+#. type: Title ##
+#: manual/Legal.md:89
+#, no-wrap
+msgid "authentic-theme"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:92
+#, no-wrap
+msgid "    MIT License\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:94
+#, no-wrap
+msgid "    Copyright (c) Ilia Rostovtsev\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:101
+#, no-wrap
+msgid ""
+"    Permission is hereby granted, free of charge, to any person obtaining a copy\n"
+"    of this software and associated documentation files (the \"Software\"), to deal\n"
+"    in the Software without restriction, including without limitation the rights\n"
+"    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n"
+"    copies of the Software, and to permit persons to whom the Software is\n"
+"    furnished to do so, subject to the following conditions:\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:104
+#, no-wrap
+msgid ""
+"    The above copyright notice and this permission notice shall be included in all\n"
+"    copies or substantial portions of the Software.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:112
+#, no-wrap
+msgid ""
+"    THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n"
+"    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n"
+"    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n"
+"    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n"
+"    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n"
+"    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE\n"
+"    SOFTWARE.\n"
+msgstr ""
+
+#. type: Title ##
+#: manual/Legal.md:113
+#, no-wrap
+msgid "glibc"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:119
+#, no-wrap
+msgid ""
+"    File tree walker functions.\n"
+"    Copyright (C) 1996-2004, 2006-2008, 2010 Free Software Foundation, Inc.\n"
+"    This file is part of the GNU C Library.\n"
+"    Contributed by Ulrich Drepper <drepper@cygnus.com>, 1996.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:124
+#, no-wrap
+msgid ""
+"    The GNU C Library is free software; you can redistribute it and/or\n"
+"    modify it under the terms of the GNU Lesser General Public\n"
+"    License as published by the Free Software Foundation; either\n"
+"    version 2.1 of the License, or (at your option) any later version.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:129
+#, no-wrap
+msgid ""
+"    The GNU C Library is distributed in the hope that it will be useful,\n"
+"    but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+"    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU\n"
+"    Lesser General Public License for more details.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:134
+#, no-wrap
+msgid ""
+"    You should have received a copy of the GNU Lesser General Public\n"
+"    License along with the GNU C Library; if not, write to the Free\n"
+"    Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA\n"
+"    02110-1301 USA.\n"
+msgstr ""
+
+#. type: Title ##
+#: manual/Legal.md:135
+#, no-wrap
+msgid "macipgw"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:138
+#, no-wrap
+msgid "    AppleTalk MacIP Gateway\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:140
+#, no-wrap
+msgid "    (c) 2013, 1997 Stefan Bethke. All rights reserved.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:145 manual/Legal.md:205
+#, no-wrap
+msgid ""
+"    This program is free software; you can redistribute it and/or modify\n"
+"    it under the terms of the GNU General Public License as published by\n"
+"    the Free Software Foundation; either version 2 of the License, or\n"
+"    (at your option) any later version.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:150 manual/Legal.md:210 manual/License.md:314
+#, no-wrap
+msgid ""
+"    This program is distributed in the hope that it will be useful,\n"
+"    but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+"    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
+"    GNU General Public License for more details.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:154 manual/Legal.md:214
+#, no-wrap
+msgid ""
+"    You should have received a copy of the GNU General Public License along\n"
+"    with this program; if not, write to the Free Software Foundation, Inc.,\n"
+"    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:155
+#, no-wrap
+msgid "    Copyright (c) 1990,1996 Regents of The University of Michigan.  \n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:168
+#, no-wrap
+msgid "    Copyright (c) 1988, 1992, 1993  \n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:170
+#, no-wrap
+msgid "    The Regents of the University of California.  All rights reserved.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:182
+#, no-wrap
+msgid ""
+"    Redistribution and use in source and binary forms, with or without\n"
+"    modification, are permitted provided that the following conditions\n"
+"    are met:\n"
+"    1. Redistributions of source code must retain the above copyright\n"
+"    notice, this list of conditions and the following disclaimer.\n"
+"    2. Redistributions in binary form must reproduce the above copyright\n"
+"    notice, this list of conditions and the following disclaimer in the\n"
+"    documentation and/or other materials provided with the distribution.\n"
+"    4. Neither the name of the University nor the names of its contributors\n"
+"    may be used to endorse or promote products derived from this software\n"
+"    without specific prior written permission.\n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:194
+#, no-wrap
+msgid ""
+"    THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND\n"
+"    ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE\n"
+"    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE\n"
+"    ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE\n"
+"    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL\n"
+"    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS\n"
+"    OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)\n"
+"    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT\n"
+"    LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY\n"
+"    OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF\n"
+"    SUCH DAMAGE.\n"
+msgstr ""
+
+#. type: Title ##
+#: manual/Legal.md:195
+#, no-wrap
+msgid "testsuite"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:197
+#, no-wrap
+msgid "    The Netatalk Test-Suite  \n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:198
+#, no-wrap
+msgid "    Copyright (C) 2003 Rafal Lewczuk <rlewczuk@pronet.pl>  \n"
+msgstr ""
+
+#. type: Plain text
+#: manual/Legal.md:200
+#, no-wrap
+msgid "    Copyright (C) 2003-2010 Didier Gautheron <dgautheron@magic.fr>\n"
+msgstr ""
+
+#. type: Title ##
+#: manual/Legal.md:215
+#, no-wrap
+msgid "timelord"
+msgstr ""

--- a/doc/po/License.md.ja.po
+++ b/doc/po/License.md.ja.po
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-01-25 09:26+0100\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
 "PO-Revision-Date: 2025-01-25 09:26+0100\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,6 +16,16 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+#: manual/Legal.md:150 manual/Legal.md:210 manual/License.md:314
+#, no-wrap
+msgid ""
+"    This program is distributed in the hope that it will be useful,\n"
+"    but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
+"    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
+"    GNU General Public License for more details.\n"
+msgstr ""
 
 #. type: Title #
 #: manual/License.md:1
@@ -196,7 +206,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:102
+#: manual/License.md:101
 #, no-wrap
 msgid ""
 "**a)** You must cause the modified files to carry prominent notices\n"
@@ -204,7 +214,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:108
+#: manual/License.md:106
 #, no-wrap
 msgid ""
 "**b)** You must cause any work that you distribute or publish, that in\n"
@@ -214,7 +224,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:120
+#: manual/License.md:117
 #, no-wrap
 msgid ""
 "**c)** If the modified program normally reads commands interactively\n"
@@ -230,7 +240,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:131
+#: manual/License.md:128
 msgid ""
 "These requirements apply to the modified work as a whole. If identifiable "
 "sections of that work are not derived from the Program, and can be "
@@ -244,7 +254,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:136
+#: manual/License.md:133
 msgid ""
 "Thus, it is not the intent of this section to claim rights or contest your "
 "rights to work written entirely by you; rather, the intent is to exercise "
@@ -253,7 +263,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:141
+#: manual/License.md:138
 msgid ""
 "In addition, mere aggregation of another work not based on the Program with "
 "the Program (or with a work based on the Program) on a volume of a storage "
@@ -262,7 +272,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:145
+#: manual/License.md:142
 #, no-wrap
 msgid ""
 "**3.** You may copy and distribute the Program (or a work based on it,\n"
@@ -271,7 +281,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:150
+#: manual/License.md:146
 #, no-wrap
 msgid ""
 "**a)** Accompany it with the complete corresponding machine-readable\n"
@@ -280,7 +290,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:158
+#: manual/License.md:153
 #, no-wrap
 msgid ""
 "**b)** Accompany it with a written offer, valid for at least three\n"
@@ -292,7 +302,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:165
+#: manual/License.md:159
 #, no-wrap
 msgid ""
 "**c)** Accompany it with the information you received as to the offer\n"
@@ -303,7 +313,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:176
+#: manual/License.md:170
 msgid ""
 "The source code for a work means the preferred form of the work for making "
 "modifications to it. For an executable work, complete source code means all "
@@ -317,7 +327,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:182
+#: manual/License.md:176
 msgid ""
 "If distribution of executable or object code is made by offering access to "
 "copy from a designated place, then offering equivalent access to copy the "
@@ -327,7 +337,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:190
+#: manual/License.md:184
 #, no-wrap
 msgid ""
 "**4.** You may not copy, modify, sublicense, or distribute the Program\n"
@@ -340,7 +350,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:199
+#: manual/License.md:193
 #, no-wrap
 msgid ""
 "**5.** You are not required to accept this License, since you have not\n"
@@ -354,7 +364,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:207
+#: manual/License.md:201
 #, no-wrap
 msgid ""
 "**6.** Each time you redistribute the Program (or any work based on\n"
@@ -367,7 +377,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:221
+#: manual/License.md:215
 #, no-wrap
 msgid ""
 "**7.** If, as a consequence of a court judgment or allegation of\n"
@@ -386,7 +396,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:226
+#: manual/License.md:220
 msgid ""
 "If any portion of this section is held invalid or unenforceable under any "
 "particular circumstance, the balance of the section is intended to apply and "
@@ -394,7 +404,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:237
+#: manual/License.md:231
 msgid ""
 "It is not the purpose of this section to induce you to infringe any patents "
 "or other property right claims or to contest validity of any such claims; "
@@ -408,14 +418,14 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:240
+#: manual/License.md:234
 msgid ""
 "This section is intended to make thoroughly clear what is believed to be a "
 "consequence of the rest of this License."
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:248
+#: manual/License.md:242
 #, no-wrap
 msgid ""
 "**8.** If the distribution and/or use of the Program is restricted in\n"
@@ -428,7 +438,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:253
+#: manual/License.md:247
 #, no-wrap
 msgid ""
 "**9.** The Free Software Foundation may publish revised and/or new\n"
@@ -438,7 +448,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:261
+#: manual/License.md:255
 msgid ""
 "Each version is given a distinguishing version number. If the Program "
 "specifies a version number of this License which applies to it and \"any "
@@ -450,7 +460,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:270
+#: manual/License.md:264
 #, no-wrap
 msgid ""
 "**10.** If you wish to incorporate parts of the Program into other\n"
@@ -464,13 +474,13 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:272
+#: manual/License.md:266
 #, no-wrap
 msgid "**NO WARRANTY**\n"
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:282
+#: manual/License.md:276
 #, no-wrap
 msgid ""
 "**11.** BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO\n"
@@ -485,7 +495,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:293
+#: manual/License.md:287
 #, no-wrap
 msgid ""
 "**12.** IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN\n"
@@ -501,18 +511,18 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:295
+#: manual/License.md:289
 msgid "END OF TERMS AND CONDITIONS"
 msgstr ""
 
 #. type: Title ##
-#: manual/License.md:296
+#: manual/License.md:290
 #, no-wrap
 msgid "How to Apply These Terms to Your New Programs"
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:302
+#: manual/License.md:296
 msgid ""
 "If you develop a new program, and you want it to be of the greatest possible "
 "use to the public, the best way to achieve this is to make it free software "
@@ -520,7 +530,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:307
+#: manual/License.md:301
 msgid ""
 "To do so, attach the following notices to the program. It is safest to "
 "attach them to the start of each source file to most effectively convey the "
@@ -529,7 +539,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:310
+#: manual/License.md:304
 #, no-wrap
 msgid ""
 "    one line to give the program's name and an idea of what it does.\n"
@@ -537,7 +547,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:315
+#: manual/License.md:309
 #, no-wrap
 msgid ""
 "    This program is free software; you can redistribute it and/or\n"
@@ -547,17 +557,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:320
-#, no-wrap
-msgid ""
-"    This program is distributed in the hope that it will be useful,\n"
-"    but WITHOUT ANY WARRANTY; without even the implied warranty of\n"
-"    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the\n"
-"    GNU General Public License for more details.\n"
-msgstr ""
-
-#. type: Plain text
-#: manual/License.md:323
+#: manual/License.md:317
 #, no-wrap
 msgid ""
 "    You should have received a copy of the GNU General Public License\n"
@@ -565,20 +565,20 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:326
+#: manual/License.md:320
 msgid ""
 "Also add information on how to contact you by electronic and paper mail."
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:329
+#: manual/License.md:323
 msgid ""
 "If the program is interactive, make it output a short notice like this when "
 "it starts in an interactive mode:"
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:335
+#: manual/License.md:329
 #, no-wrap
 msgid ""
 "    Gnomovision version 69, Copyright (C) year name of author\n"
@@ -589,7 +589,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:341
+#: manual/License.md:335
 msgid ""
 "The hypothetical commands \\`show w' and \\`show c' should show the "
 "appropriate parts of the General Public License. Of course, the commands you "
@@ -598,7 +598,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:345
+#: manual/License.md:339
 msgid ""
 "You should also get your employer (if you work as a programmer) or your "
 "school, if any, to sign a \"copyright disclaimer\" for the program, if "
@@ -606,7 +606,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:350
+#: manual/License.md:344
 #, no-wrap
 msgid ""
 "    Yoyodyne, Inc., hereby disclaims all copyright\n"
@@ -616,7 +616,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:353
+#: manual/License.md:347
 #, no-wrap
 msgid ""
 "    signature of Moe Ghoul, 1 April 1989\n"
@@ -624,7 +624,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manual/License.md:360
+#: manual/License.md:354
 msgid ""
 "This General Public License does not permit incorporating your program into "
 "proprietary programs. If your program is a subroutine library, you may "

--- a/doc/po/_Navlinks.md.ja.po
+++ b/doc/po/_Navlinks.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-04-22 22:06+0200\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
 "PO-Revision-Date: 2025-04-22 21:52+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -20,29 +20,34 @@ msgstr ""
 #: manual/_Navlinks.md:1 manual/_Navlinks_atalk.md:1
 #, no-wrap
 msgid "Netatalk Manual"
-msgstr ""
+msgstr "Netatalk マニュアル"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[Introduction](index.html)"
 msgstr "[序説](index.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[Installation](Installation.html)"
 msgstr "[インストール](Installation.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[Configuration](Configuration.html)"
 msgstr "[セットアップ](Configuration.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[Upgrading](Upgrading.html)"
 msgstr "[アップグレード](Upgrading.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[License](License.html)"
 msgstr "[ライセンス](License.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
+msgid "[Legal Notices](Legal.html)"
+msgstr "[法的条項](Legal.html)"

--- a/doc/po/_Navlinks_atalk.md.ja.po
+++ b/doc/po/_Navlinks_atalk.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-04-22 22:06+0200\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
 "PO-Revision-Date: 2025-04-22 22:06+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -20,34 +20,39 @@ msgstr ""
 #: manual/_Navlinks.md:1 manual/_Navlinks_atalk.md:1
 #, no-wrap
 msgid "Netatalk Manual"
-msgstr ""
+msgstr "Netatalk マニュアル"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[Introduction](index.html)"
 msgstr "[序説](index.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[Installation](Installation.html)"
 msgstr "[インストール](Installation.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[Configuration](Configuration.html)"
 msgstr "[セットアップ](Configuration.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[Upgrading](Upgrading.html)"
 msgstr "[アップグレード](Upgrading.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[License](License.html)"
 msgstr "[ライセンス](License.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
+msgid "[Legal Notices](Legal.html)"
+msgstr "[法的条項](Legal.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[AppleTalk](AppleTalk.html)"
 msgstr ""

--- a/doc/po/_Sidebar.md.ja.po
+++ b/doc/po/_Sidebar.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-05-28 20:02+0200\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
 "PO-Revision-Date: 2025-01-24 23:25+0100\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -17,32 +17,37 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[Introduction](index.html)"
 msgstr "[序説](index.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[Installation](Installation.html)"
 msgstr "[インストール](Installation.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[Configuration](Configuration.html)"
 msgstr "[セットアップ](Configuration.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[Upgrading](Upgrading.html)"
 msgstr "[アップグレード](Upgrading.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks.md:7 manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[License](License.html)"
 msgstr "[ライセンス](License.html)"
 
 #. type: Bullet: '* '
-#: manual/_Navlinks_atalk.md:8 manual/_Sidebar.md:11
+#: manual/_Navlinks.md:8 manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
+msgid "[Legal Notices](Legal.html)"
+msgstr "[法的条項](Legal.html)"
+
+#. type: Bullet: '* '
+#: manual/_Navlinks_atalk.md:9 manual/_Sidebar.md:12
 msgid "[AppleTalk](AppleTalk.html)"
 msgstr ""
 
@@ -57,186 +62,186 @@ msgid "Manual"
 msgstr "マニュアル"
 
 #. type: Plain text
-#: manual/_Sidebar.md:13
+#: manual/_Sidebar.md:14
 msgid "User Tools"
 msgstr "ユーザーツール"
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[ad](ad.1.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[addump](addump.1.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[aecho](aecho.1.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[afpldaptest](afpldaptest.1.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[afppasswd](afppasswd.1.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[afpstats](afpstats.1.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[afptest](afptest.1.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[asip-status](asip-status.1.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[dbd](dbd.1.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[getzones](getzones.1.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[macusers](macusers.1.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[nbp](nbp.1.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[pap](pap.1.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:28
+#: manual/_Sidebar.md:29
 msgid "[rtmpqry](rtmpqry.1.html)"
 msgstr ""
 
 #. type: Plain text
-#: manual/_Sidebar.md:30
+#: manual/_Sidebar.md:31
 msgid "Configuration Files"
 msgstr "コンフィグファイル"
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:37
+#: manual/_Sidebar.md:38
 msgid "[afp_signature.conf](afp_signature.conf.5.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:37
+#: manual/_Sidebar.md:38
 msgid "[afp_voluuid.conf](afp_voluuid.conf.5.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:37
+#: manual/_Sidebar.md:38
 msgid "[afp.conf](afp.conf.5.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:37
+#: manual/_Sidebar.md:38
 msgid "[atalkd.conf](atalkd.conf.5.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:37
+#: manual/_Sidebar.md:38
 msgid "[extmap.conf](extmap.conf.5.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:37
+#: manual/_Sidebar.md:38
 msgid "[papd.conf](papd.conf.5.html)"
 msgstr ""
 
 #. type: Plain text
-#: manual/_Sidebar.md:39
+#: manual/_Sidebar.md:40
 msgid "Daemons and Admin Tools"
 msgstr "デーモン及び管理ツール"
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:50
+#: manual/_Sidebar.md:51
 msgid "[a2boot](a2boot.8.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:50
+#: manual/_Sidebar.md:51
 msgid "[afpd](afpd.8.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:50
+#: manual/_Sidebar.md:51
 msgid "[atalkd](atalkd.8.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:50
+#: manual/_Sidebar.md:51
 msgid "[cnid_dbd](cnid_dbd.8.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:50
+#: manual/_Sidebar.md:51
 msgid "[cnid_metad](cnid_metad.8.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:50
+#: manual/_Sidebar.md:51
 msgid "[macipgw](macipgw.8.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:50
+#: manual/_Sidebar.md:51
 msgid "[netatalk](netatalk.8.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:50
+#: manual/_Sidebar.md:51
 msgid "[papd](papd.8.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:50
+#: manual/_Sidebar.md:51
 msgid "[papstatus](papstatus.8.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:50
+#: manual/_Sidebar.md:51
 msgid "[timelord](timelord.8.html)"
 msgstr ""
 
 #. type: Plain text
-#: manual/_Sidebar.md:52
+#: manual/_Sidebar.md:53
 msgid "Developer References"
 msgstr "開発者参考資料"
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:55
+#: manual/_Sidebar.md:56
 msgid "[atalk](atalk.4.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:55
+#: manual/_Sidebar.md:56
 msgid "[atalk_aton](atalk_aton.3.html)"
 msgstr ""
 
 #. type: Bullet: '* '
-#: manual/_Sidebar.md:55
+#: manual/_Sidebar.md:56
 msgid "[nbp_name](nbp_name.3.html)"
 msgstr ""

--- a/doc/po/ad.1.md.ja.po
+++ b/doc/po/ad.1.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-05-25 10:43+0200\n"
+"POT-Creation-Date: 2025-07-31 07:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -66,7 +66,7 @@ msgstr "概要"
 #. type: Plain text
 #: manpages/man1/ad.1.md:8
 #, no-wrap
-msgid "**ad** [ls | cp | mv | rm | set] [...]\n"
+msgid "**ad** [ls | cp | mv | rm | set | find] [...]\n"
 msgstr ""
 
 #. type: Plain text
@@ -107,30 +107,41 @@ msgid ""
 "volume are modified.\n"
 msgstr "**ad**は、Netatalk 互換の AppleDouble ファイルユーティリティ一式である。Netatalk 共有ボリューム内の AppleDouble データ (ファイルの拡張属性や、同じディレクトリ内の.\\_fileや、**.AppleDouble**ディレクトリ内のファイル) とCNIDデータベースを適切に更新する。\n"
 
+#. type: Plain text
+#: manpages/man1/ad.1.md:22
+msgid ""
+"This is preferable over using the equivalent system file operation commands "
+"on files in a Netatalk shared volume to preserve the integrity of Mac OS "
+"metadata and CNIDs."
+msgstr ""
+"Mac OS メタデータと CNID の整合性を維持するために、Netatalk 共有ボリューム内"
+"のファイルに対して同等のシステムファイル操作コマンドを使用するよりも推奨す"
+"る。"
+
 #. type: Title #
-#: manpages/man1/ad.1.md:19
+#: manpages/man1/ad.1.md:23
 #, no-wrap
 msgid "Available Commands"
 msgstr "有効なコマンド"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:22
+#: manpages/man1/ad.1.md:26
 msgid "List files and directories."
-msgstr "List files and directories."
+msgstr "ファイルやディレクトリをリストする。"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:24
+#: manpages/man1/ad.1.md:28
 #, no-wrap
-msgid "> ad ls [-dRl[u]] {file|dir [...]}\n"
+msgid "> ad ls [-dRl[u]] {file|directory [...]}\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:26 manpages/man1/ad.1.md:101
+#: manpages/man1/ad.1.md:30 manpages/man1/ad.1.md:109
 msgid "Copy files and directories."
 msgstr "ファイルやディレクトリをコピーする。"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:30
+#: manpages/man1/ad.1.md:34
 #, no-wrap
 msgid ""
 "> ad cp [-aipvf] {src_file} {dst_file}\n"
@@ -139,12 +150,12 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:32 manpages/man1/ad.1.md:162
+#: manpages/man1/ad.1.md:36 manpages/man1/ad.1.md:170
 msgid "Move files and directories."
 msgstr "ファイルやディレクトリを移動する。"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:36
+#: manpages/man1/ad.1.md:40
 #, no-wrap
 msgid ""
 "> ad mv [-finv] {src_file} {dst_file}\n"
@@ -153,54 +164,65 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:38 manpages/man1/ad.1.md:196
+#: manpages/man1/ad.1.md:42 manpages/man1/ad.1.md:204
 msgid "Remove files and directories."
 msgstr "ファイルやディレクトリを削除する。"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:40
+#: manpages/man1/ad.1.md:44
 #, no-wrap
 msgid "> ad rm [-Rv] {file|directory}\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:42 manpages/man1/ad.1.md:214
+#: manpages/man1/ad.1.md:46 manpages/man1/ad.1.md:222
 msgid "Set metadata on files."
 msgstr "ファイルにメタデータを設定する。"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:44
+#: manpages/man1/ad.1.md:48
 #, no-wrap
 msgid "> ad set [-t type] [-c creator] [-l label] [-f flags] [-a attributes] {file}\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:46
+#: manpages/man1/ad.1.md:50
+msgid "Find files and directories"
+msgstr "ファイルやディレクトリを検索する。"
+
+#. type: Plain text
+#: manpages/man1/ad.1.md:52
+#, no-wrap
+msgid "> ad find [-v volume path] {file|directory}\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/ad.1.md:54
 msgid "Show version."
 msgstr "バージョンを表示する。"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:48
+#: manpages/man1/ad.1.md:56
 #, no-wrap
 msgid "> ad -v | --version\n"
-msgstr "> バージョンを表示する。\n"
+msgstr ""
 
 #. type: Title #
-#: manpages/man1/ad.1.md:49
+#: manpages/man1/ad.1.md:57
 #, no-wrap
 msgid "ad ls"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:52
+#: manpages/man1/ad.1.md:60
 msgid "List files and directories. Options:"
 msgstr "ファイルやディレクトリをリストする。 オプション:"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:54 manpages/man1/asip-status.1.md:39
+#: manpages/man1/ad.1.md:62 manpages/man1/asip-status.1.md:39
 #: manpages/man1/pap.1.md:45 manpages/man8/a2boot.8.md:35
 #: manpages/man8/afpd.8.md:22 manpages/man8/atalkd.8.md:37
-#: manpages/man8/cnid_metad.8.md:21 manpages/man8/netatalk.8.md:20
+#: manpages/man8/cnid_metad.8.md:24 manpages/man8/netatalk.8.md:29
 #: manpages/man8/papd.8.md:40 manpages/man8/papstatus.8.md:27
 #: manpages/man8/timelord.8.md:26
 #, no-wrap
@@ -208,68 +230,68 @@ msgid "**-d**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:56
+#: manpages/man1/ad.1.md:64
 #, no-wrap
 msgid "> Directories are listed as plain files\n"
 msgstr "> ディレクトリを単純なファイルとしてリストする\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:58 manpages/man1/ad.1.md:146 manpages/man1/ad.1.md:204
+#: manpages/man1/ad.1.md:66 manpages/man1/ad.1.md:154 manpages/man1/ad.1.md:212
 #, no-wrap
 msgid "**-R**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:60
+#: manpages/man1/ad.1.md:68
 #, no-wrap
 msgid "> list subdirectories recursively\n"
 msgstr "> サブディレクトリを再帰的にリストする\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:62 manpages/man1/getzones.1.md:25
+#: manpages/man1/ad.1.md:70 manpages/man1/getzones.1.md:25
 #: manpages/man8/timelord.8.md:30
 #, no-wrap
 msgid "**-l**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:64
+#: manpages/man1/ad.1.md:72
 #, no-wrap
 msgid "> Long output, list AFP info\n"
 msgstr "> 長い出力。AFP infoをリストする\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:66 manpages/man1/dbd.1.md:41
+#: manpages/man1/ad.1.md:74 manpages/man1/dbd.1.md:45
 #, no-wrap
 msgid "**-u**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:68
+#: manpages/man1/ad.1.md:76
 #, no-wrap
 msgid "> List UNIX info\n"
 msgstr "> UNIX infoをリストする\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:70
+#: manpages/man1/ad.1.md:78
 #, no-wrap
 msgid "*Long output description*\n"
 msgstr "*長い出力の説明*\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:72
+#: manpages/man1/ad.1.md:80
 #, no-wrap
 msgid "    <unixinfo> <FinderFlags> <AFP Attributes> <Color> <Type> <Creator> <CNID from AppleDouble> <name>\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:74
+#: manpages/man1/ad.1.md:82
 #, no-wrap
 msgid "    FinderFlags (valid for (f)iles and/or (d)irectories):\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:86 manpages/man1/ad.1.md:260
+#: manpages/man1/ad.1.md:94 manpages/man1/ad.1.md:268
 #, no-wrap
 msgid ""
 "      d = On Desktop                      (f/d)\n"
@@ -286,13 +308,13 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:88 manpages/man1/ad.1.md:262
+#: manpages/man1/ad.1.md:96 manpages/man1/ad.1.md:270
 #, no-wrap
 msgid "    AFP Attributes:\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:95 manpages/man1/ad.1.md:269
+#: manpages/man1/ad.1.md:103 manpages/man1/ad.1.md:277
 #, no-wrap
 msgid ""
 "      y = System                          (f/d)\n"
@@ -304,19 +326,19 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:97
+#: manpages/man1/ad.1.md:105
 #, no-wrap
 msgid "    Note: any letter appearing in uppercase means the flag is set but it's a directory for which the flag is not allowed.\n"
 msgstr ""
 
 #. type: Title #
-#: manpages/man1/ad.1.md:98
+#: manpages/man1/ad.1.md:106
 #, no-wrap
 msgid "ad cp"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:107
+#: manpages/man1/ad.1.md:115
 msgid ""
 "In the first synopsis form, the cp utility copies the contents of the "
 "src_file to the dst_file. In the second synopsis form, the contents of each "
@@ -330,7 +352,7 @@ msgstr ""
 "自身へコピーしようとしているのをcpが検出したら、コピーは失敗する。"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:112
+#: manpages/man1/ad.1.md:120
 msgid ""
 "When a copy targeting an AFP volume is detected, its CNID database daemon is "
 "connected and all copies will also go through the CNID database. AppleDouble "
@@ -341,65 +363,71 @@ msgstr ""
 "場合はAppleDoubleデータもまたコピーされ、必要なら作成される。"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:114 manpages/man1/ad.1.md:171
+#: manpages/man1/ad.1.md:122 manpages/man1/ad.1.md:179
 msgid "Options:"
 msgstr "オプション:"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:116 manpages/man1/afppasswd.1.md:36
+#: manpages/man1/ad.1.md:124 manpages/man1/afppasswd.1.md:36
 #: manpages/man1/rtmpqry.1.md:18
 #, no-wrap
 msgid "**-a**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:118
+#: manpages/man1/ad.1.md:126
 #, no-wrap
 msgid "> Archive mode. Same as **-Rp**.\n"
 msgstr "> アーカイブモード。**-Rp** と同じ。\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:120 manpages/man1/ad.1.md:173
-#: manpages/man1/afppasswd.1.md:44 manpages/man1/dbd.1.md:24
+#: manpages/man1/ad.1.md:128 manpages/man1/ad.1.md:181
+#: manpages/man1/afppasswd.1.md:44 manpages/man1/dbd.1.md:28
 #, no-wrap
 msgid "**-f**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:124
+#: manpages/man1/ad.1.md:132
 #, no-wrap
 msgid ""
 "> For each existing destination pathname, remove it and create a new file,\n"
 "without prompting for confirmation regardless of its permissions. (The\n"
 "**-f** option overrides any previous **-i** or **-n** options.)\n"
-msgstr "> それぞれの配布先パス名が既に存在している場合、それを削除してから新しいファイルを作成する。パーミッションに関わらず確認プロンプトを出さない。(**-f** オプションは手前の **-i** オプションと **-n** オプションを無効にする。)\n"
+msgstr ""
+"> それぞれの配布先パス名が既に存在している場合、それを削除してから新しいファイルを作成する。\n"
+"パーミッションに関わらず確認プロンプトを出さない。\n"
+"(**-f** オプションは手前の **-i** オプションと **-n** オプションを無効にする。)\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:126 manpages/man1/ad.1.md:178
+#: manpages/man1/ad.1.md:134 manpages/man1/ad.1.md:186
 #: manpages/man1/asip-status.1.md:43
 #, no-wrap
 msgid "**-i**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:131
+#: manpages/man1/ad.1.md:139
 #, no-wrap
 msgid ""
 "> Cause cp to write a prompt to the standard error output before copying a\n"
 "file that would overwrite an existing file. If the response from the\n"
 "standard input begins with the character 'y' or 'Y', the file copy is\n"
 "attempted. (The **-i** option overrides any previous **-f** or **-n** options.)\n"
-msgstr "> 存在するファイルに上書きする前に、標準エラー出力にプロンプトを出す。もし標準入力からの返答が'y'または'Y'で始まるならばファイルコピーを試みる。(**-i** オプションは手前の **-f** オプションと **-n** オプションを無効にする。)\n"
+msgstr ""
+"> 存在するファイルに上書きする前に、標準エラー出力にプロンプトを出す。\n"
+"もし標準入力からの返答が'y'または'Y'で始まるならばファイルコピーを試みる。\n"
+"(**-i** オプションは手前の **-f** オプションと **-n** オプションを無効にする。)\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:133 manpages/man1/ad.1.md:185
+#: manpages/man1/ad.1.md:141 manpages/man1/ad.1.md:193
 #: manpages/man1/afppasswd.1.md:52
 #, no-wrap
 msgid "**-n**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:136 manpages/man1/ad.1.md:188
+#: manpages/man1/ad.1.md:144 manpages/man1/ad.1.md:196
 #, no-wrap
 msgid ""
 "> Do not overwrite an existing file. (The **-n** option overrides any previous\n"
@@ -409,13 +437,13 @@ msgstr ""
 "(**-n** オプションは手前の **-f** オプションと-iオプションを無効にする。)\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:138
+#: manpages/man1/ad.1.md:146
 #, no-wrap
 msgid "**-p**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:144
+#: manpages/man1/ad.1.md:152
 #, no-wrap
 msgid ""
 "> Cause cp to preserve the following attributes of each source file in the\n"
@@ -425,51 +453,54 @@ msgid ""
 "not altered.\n"
 msgstr ""
 "> 以下に示すそれぞれのコピー元ファイルの属性を、パーミッションが許す限り維持する:\n"
-"変更時刻、アクセス時刻、ファイルフラグ、ファイルモード、ユーザIDグループID。ユーザIDとグループIDが維持されない場合、エラーメッセージは表示されず、終了コードは変更されない。\n"
+"変更時刻、アクセス時刻、ファイルフラグ、ファイルモード、ユーザIDグループID。\n"
+"ユーザIDとグループIDが維持されない場合、エラーメッセージは表示されず、終了コードは変更されない。\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:150
+#: manpages/man1/ad.1.md:158
 #, no-wrap
 msgid ""
 "> If src_file designates a directory, cp copies the directory and the\n"
 "entire subtree connected at that point. If the src_file ends in a /, the\n"
 "contents of the directory are copied rather than the directory itself.\n"
-msgstr "> もしsrc_fileでディレクトリを指定した場合、cpはそのディレクトリと全体のサブツリーをコピーする。もしsrc_fileが「/」で終わっている場合、ディレクトリ自身ではなく中身をコピーする。\n"
+msgstr ""
+"> もしsrc_fileでディレクトリを指定した場合、cpはそのディレクトリと全体のサブツリーをコピーする。\n"
+"もしsrc_fileが「/」で終わっている場合、ディレクトリ自身ではなく中身をコピーする。\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:152 manpages/man1/ad.1.md:190
-#: manpages/man1/ad.1.md:208 manpages/man1/dbd.1.md:45
+#: manpages/man1/ad.1.md:160 manpages/man1/ad.1.md:198
+#: manpages/man1/ad.1.md:216 manpages/man1/dbd.1.md:49
 #: manpages/man8/afpd.8.md:26
 #, no-wrap
 msgid "**-v**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:154
+#: manpages/man1/ad.1.md:162
 #, no-wrap
 msgid "> Cause cp to be verbose, showing files as they are copied.\n"
 msgstr "> コピーしたファイルを詳細に表示する。\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:156 manpages/man1/asip-status.1.md:47
+#: manpages/man1/ad.1.md:164 manpages/man1/asip-status.1.md:47
 #, no-wrap
 msgid "**-x**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:158
+#: manpages/man1/ad.1.md:166
 #, no-wrap
 msgid "> File system mount points are not traversed.\n"
 msgstr "> ファイルシステムのマウントポイントを横断しない。\n"
 
 #. type: Title #
-#: manpages/man1/ad.1.md:159
+#: manpages/man1/ad.1.md:167
 #, no-wrap
 msgid "ad mv"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:165
+#: manpages/man1/ad.1.md:173
 msgid ""
 "Move files around within an AFP volume, updating the CNID database as "
 "needed. If either condition below is true, the files are copied and removed "
@@ -479,17 +510,17 @@ msgstr ""
 "下のどちらかの場合はファイルをコピーしてからコピー元を削除する。"
 
 #. type: Bullet: '- '
-#: manpages/man1/ad.1.md:167
+#: manpages/man1/ad.1.md:175
 msgid "source or destination is not an AFP volume"
 msgstr "移動元または移動先がAFPボリュームでない"
 
 #. type: Bullet: '- '
-#: manpages/man1/ad.1.md:169
+#: manpages/man1/ad.1.md:177
 msgid "source AFP volume != destination AFP volume"
 msgstr "移動元AFPボリュームと移動先AFPボリュームが異なる"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:176
+#: manpages/man1/ad.1.md:184
 #, no-wrap
 msgid ""
 "> Do not prompt for confirmation before overwriting the destination path.\n"
@@ -497,29 +528,32 @@ msgid ""
 msgstr "> 配布先パスに上書きする前に確認プロンプトを出さない。(**-f** オプションは手前の **-i** オプションと **-n** オプションを無効にする。)\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:183
+#: manpages/man1/ad.1.md:191
 #, no-wrap
 msgid ""
 "> Cause mv to write a prompt to standard error before moving a file that\n"
 "would overwrite an existing file. If the response from the standard\n"
 "input begins with the character \\`y' or \\`Y', the move is attempted.\n"
 "(The **-i** option overrides any previous **-f** or **-n** options.)\n"
-msgstr "> 存在するファイルに上書きする前に、標準エラー出力にプロンプトを出す。もし標準入力からの返答が'y'または'Y'で始まるならば移動を試みる。(**-i** オプションは手前の **-f** オプションと **-n** オプションを無効にする。)\n"
+msgstr ""
+"> 存在するファイルに上書きする前に、標準エラー出力にプロンプトを出す。\n"
+"もし標準入力からの返答が'y'または'Y'で始まるならば移動を試みる。\n"
+"(**-i** オプションは手前の **-f** オプションと **-n** オプションを無効にする。)\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:192
+#: manpages/man1/ad.1.md:200
 #, no-wrap
 msgid "> Cause mv to be verbose, showing files after they are moved.\n"
 msgstr "> 移動したファイルを詳細に表示する。\n"
 
 #. type: Title #
-#: manpages/man1/ad.1.md:193
+#: manpages/man1/ad.1.md:201
 #, no-wrap
 msgid "ad rm"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:200
+#: manpages/man1/ad.1.md:208
 msgid ""
 "The rm utility attempts to remove the non-directory type files specified on "
 "the command line. If the files and directories reside on an AFP volume, the "
@@ -530,78 +564,78 @@ msgstr ""
 "CNIDをボリュームデータベースから削除する。"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:202 manpages/man1/ad.1.md:218
+#: manpages/man1/ad.1.md:210 manpages/man1/ad.1.md:226
 msgid "The options are as follows:"
 msgstr "オプションは次の通り。"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:206
+#: manpages/man1/ad.1.md:214
 #, no-wrap
 msgid "> Attempt to remove the file hierarchy rooted in each file argument.\n"
 msgstr "> それぞれのファイル引数の下のファイル階層を削除しようと試みる。\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:210
+#: manpages/man1/ad.1.md:218
 #, no-wrap
 msgid "> Be verbose when deleting files, showing them as they are removed.\n"
 msgstr "> ファイルを削除するときに詳細を表示する。\n"
 
 #. type: Title #
-#: manpages/man1/ad.1.md:211
+#: manpages/man1/ad.1.md:219
 #, no-wrap
 msgid "ad set"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:216
+#: manpages/man1/ad.1.md:224
 msgid "The set utility alters metadata on files within an AFP volume."
 msgstr ""
 "set ユーティリティは、AFP ボリューム内のファイルのメタデータを変更する。"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:220
+#: manpages/man1/ad.1.md:228
 #, no-wrap
 msgid "**-t** *type*\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:222
+#: manpages/man1/ad.1.md:230
 #, no-wrap
 msgid "> Change a file's four character file type.\n"
 msgstr "> ファイルの 4 文字のファイル タイプを変更する。\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:224
+#: manpages/man1/ad.1.md:232
 #, no-wrap
 msgid "**-c** *creator*\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:226
+#: manpages/man1/ad.1.md:234
 #, no-wrap
 msgid "> Change a file's four character creator type.\n"
 msgstr "> ファイルの 4 文字の作成者タイプを変更する。\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:228
+#: manpages/man1/ad.1.md:236
 #, no-wrap
 msgid "**-l** *label*\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:230
+#: manpages/man1/ad.1.md:238
 #, no-wrap
 msgid "> Change a file's color label. See list below for available colors.\n"
 msgstr "> ファイルの色ラベルを変更する。使用可能な色については、以下のリストを参照。\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:232
+#: manpages/man1/ad.1.md:240
 #, no-wrap
 msgid "**-f** *flags*\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:235
+#: manpages/man1/ad.1.md:243
 #, no-wrap
 msgid ""
 "> Change a file's Finder flags. See list below for available flags.\n"
@@ -611,13 +645,13 @@ msgstr ""
 "フラグを変更する。使用可能なフラグについては、以下のリストを参照。大文字はフラグを設定し、小文字はフラグを削除する。\n"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:237
+#: manpages/man1/ad.1.md:245
 #, no-wrap
 msgid "**-a** *attributes*\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:240
+#: manpages/man1/ad.1.md:248
 #, no-wrap
 msgid ""
 "> Change a file's attributes. See list below for available attributes.\n"
@@ -625,32 +659,68 @@ msgid ""
 msgstr "> ファイルの属性を変更する。使用可能な属性については、以下のリストを参照。大文字はフラグを設定し、小文字はフラグを削除する。\n"
 
 #. type: Title ##
-#: manpages/man1/ad.1.md:241
+#: manpages/man1/ad.1.md:249
 #, no-wrap
 msgid "Flag descriptions"
 msgstr "旗の説明"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:244
+#: manpages/man1/ad.1.md:252
 #, no-wrap
 msgid "    Color Labels:\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:246
+#: manpages/man1/ad.1.md:254
 #, no-wrap
 msgid "      none | grey | green | violet | blue | yellow | red | orange\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:248
+#: manpages/man1/ad.1.md:256
 #, no-wrap
 msgid "    Finder Flags (valid for (f)iles and/or (d)irectories):\n"
 msgstr ""
 
 #. type: Title #
-#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:175
-#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:86
+#: manpages/man1/ad.1.md:278
+#, no-wrap
+msgid "ad find"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/ad.1.md:281
+msgid "Find files and directories in an AFP volume."
+msgstr "AFPボリューム内のファイルやディレクトリを検索する。"
+
+#. type: Plain text
+#: manpages/man1/ad.1.md:283
+msgid ""
+"This returns a list of paths that wholly or partially match the given name."
+msgstr "指定されたファイル名と完全にまたは部分的に一致するパスのリストを返す。"
+
+#. type: Plain text
+#: manpages/man1/ad.1.md:285
+msgid "It takes one option:"
+msgstr "オプション："
+
+#. type: Plain text
+#: manpages/man1/ad.1.md:287
+#, no-wrap
+msgid "**-v** *path*\n"
+msgstr "**-v** *パス*\n"
+
+#. type: Plain text
+#: manpages/man1/ad.1.md:290
+#, no-wrap
+msgid ""
+"> Use path to the shared volume to search rather than the current working\n"
+"directory.\n"
+msgstr "現在の作業ディレクトリの代わりに、共有ボリュームへのパスを使用して検索する。\n"
+
+#. type: Title #
+#: manpages/man1/ad.1.md:291 manpages/man1/afptest.1.md:175
+#: manpages/man1/dbd.1.md:68 manpages/man1/nbp.1.md:86
 #: manpages/man5/afp_signature.conf.5.md:44
 #: manpages/man5/afp_voluuid.conf.5.md:36 manpages/man8/papd.8.md:130
 #, no-wrap
@@ -658,26 +728,26 @@ msgid "See also"
 msgstr "参照"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:273
+#: manpages/man1/ad.1.md:294
 msgid "dbd(1), addump(1)"
 msgstr ""
 
 #. type: Title #
-#: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
+#: manpages/man1/ad.1.md:295 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:72 manpages/man1/afpstats.1.md:31
 #: manpages/man1/afptest.1.md:179 manpages/man1/asip-status.1.md:106
-#: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:88
+#: manpages/man1/dbd.1.md:72 manpages/man1/getzones.1.md:88
 #: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:90
 #: manpages/man1/pap.1.md:97 manpages/man1/rtmpqry.1.md:56
 #: manpages/man3/atalk_aton.3.md:28 manpages/man3/nbp_name.3.md:42
 #: manpages/man4/atalk.4.md:49 manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:40 manpages/man5/afp.conf.5.md:1339
+#: manpages/man5/afp_voluuid.conf.5.md:40 manpages/man5/afp.conf.5.md:1353
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
-#: manpages/man8/macipgw.8.md:107 manpages/man8/netatalk.8.md:52
+#: manpages/man8/cnid_dbd.8.md:146 manpages/man8/cnid_metad.8.md:51
+#: manpages/man8/macipgw.8.md:107 manpages/man8/netatalk.8.md:61
 #: manpages/man8/papd.8.md:134 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
@@ -685,21 +755,21 @@ msgid "Author"
 msgstr "著者"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
+#: manpages/man1/ad.1.md:297 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:33
 #: manpages/man1/afptest.1.md:181 manpages/man1/asip-status.1.md:108
-#: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:90
+#: manpages/man1/dbd.1.md:74 manpages/man1/getzones.1.md:90
 #: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:92
 #: manpages/man1/pap.1.md:99 manpages/man1/rtmpqry.1.md:58
 #: manpages/man3/atalk_aton.3.md:30 manpages/man3/nbp_name.3.md:44
 #: manpages/man4/atalk.4.md:51 manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1341
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1355
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:120 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:136
+#: manpages/man8/cnid_dbd.8.md:148 manpages/man8/cnid_metad.8.md:53
+#: manpages/man8/netatalk.8.md:63 manpages/man8/papd.8.md:136
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"

--- a/doc/po/addump.1.md.ja.po
+++ b/doc/po/addump.1.md.ja.po
@@ -216,7 +216,10 @@ msgid ""
 "look for extended attributes, *.AppleDouble/FILE* and *.\\_FILE*. If\n"
 "*DIR*, look for extended attributes, *DIR/.AppleDouble/.Parent* and\n"
 "*.\\_DIR*.\n"
-msgstr "> これがデフォルトである。*FILE*または*DIR*のためのAppleSingle/AppleDoubleデータを自動的にダンプする。もし*FILE*がAppleSingle/AppleDoubleフォーマットでないなら、拡張属性と*.AppleDouble/FILE*と*.\\_FILE*を探す。もし*DIR*なら、拡張属性と*DIR/.AppleDouble/.Parent*と*.\\_DIR*を探す。\n"
+msgstr ""
+"> これがデフォルトである。*FILE*または*DIR*のためのAppleSingle/AppleDoubleデータを自動的にダンプする。\n"
+"もし*FILE*がAppleSingle/AppleDoubleフォーマットでないなら、拡張属性と*.AppleDouble/FILE*と*.\\_FILE*を探す。\n"
+"もし*DIR*なら、拡張属性と*DIR/.AppleDouble/.Parent*と*.\\_DIR*を探す。\n"
 
 #. type: Plain text
 #: manpages/man1/addump.1.md:40

--- a/doc/po/afp.conf.5.md.ja.po
+++ b/doc/po/afp.conf.5.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-05-29 08:09+0200\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -59,21 +59,21 @@ msgid "Synopsis"
 msgstr "概要"
 
 #. type: Title #
-#: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
+#: manpages/man1/ad.1.md:295 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:72 manpages/man1/afpstats.1.md:31
 #: manpages/man1/afptest.1.md:179 manpages/man1/asip-status.1.md:106
-#: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:88
+#: manpages/man1/dbd.1.md:72 manpages/man1/getzones.1.md:88
 #: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:90
 #: manpages/man1/pap.1.md:97 manpages/man1/rtmpqry.1.md:56
 #: manpages/man3/atalk_aton.3.md:28 manpages/man3/nbp_name.3.md:42
 #: manpages/man4/atalk.4.md:49 manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:40 manpages/man5/afp.conf.5.md:1339
+#: manpages/man5/afp_voluuid.conf.5.md:40 manpages/man5/afp.conf.5.md:1353
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
-#: manpages/man8/macipgw.8.md:107 manpages/man8/netatalk.8.md:52
+#: manpages/man8/cnid_dbd.8.md:146 manpages/man8/cnid_metad.8.md:51
+#: manpages/man8/macipgw.8.md:107 manpages/man8/netatalk.8.md:61
 #: manpages/man8/papd.8.md:134 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
@@ -81,21 +81,21 @@ msgid "Author"
 msgstr "著者"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
+#: manpages/man1/ad.1.md:297 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:33
 #: manpages/man1/afptest.1.md:181 manpages/man1/asip-status.1.md:108
-#: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:90
+#: manpages/man1/dbd.1.md:74 manpages/man1/getzones.1.md:90
 #: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:92
 #: manpages/man1/pap.1.md:99 manpages/man1/rtmpqry.1.md:58
 #: manpages/man3/atalk_aton.3.md:30 manpages/man3/nbp_name.3.md:44
 #: manpages/man4/atalk.4.md:51 manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1341
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1355
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:120 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:136
+#: manpages/man8/cnid_dbd.8.md:148 manpages/man8/cnid_metad.8.md:53
+#: manpages/man8/netatalk.8.md:63 manpages/man8/papd.8.md:136
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"
@@ -107,12 +107,12 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:84
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man1/rtmpqry.1.md:52 manpages/man3/atalk_aton.3.md:24
-#: manpages/man4/atalk.4.md:45 manpages/man5/afp.conf.5.md:1334
+#: manpages/man4/atalk.4.md:45 manpages/man5/afp.conf.5.md:1348
 #: manpages/man5/atalkd.conf.5.md:98 manpages/man5/extmap.conf.5.md:28
 #: manpages/man5/papd.conf.5.md:164 manpages/man8/afpd.8.md:112
-#: manpages/man8/atalkd.8.md:79 manpages/man8/cnid_dbd.8.md:141
-#: manpages/man8/cnid_metad.8.md:44 manpages/man8/macipgw.8.md:98
-#: manpages/man8/netatalk.8.md:48 manpages/man8/papstatus.8.md:49
+#: manpages/man8/atalkd.8.md:79 manpages/man8/cnid_dbd.8.md:142
+#: manpages/man8/cnid_metad.8.md:47 manpages/man8/macipgw.8.md:98
+#: manpages/man8/netatalk.8.md:57 manpages/man8/papstatus.8.md:49
 #, no-wrap
 msgid "See Also"
 msgstr "関連項目"
@@ -123,7 +123,7 @@ msgstr "関連項目"
 #: manpages/man1/asip-status.1.md:54 manpages/man1/getzones.1.md:57
 #: manpages/man1/nbp.1.md:62 manpages/man1/rtmpqry.1.md:34
 #: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:27 manpages/man5/afp.conf.5.md:1288
+#: manpages/man5/afp_voluuid.conf.5.md:27 manpages/man5/afp.conf.5.md:1302
 #: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
 #: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:78
 #, no-wrap
@@ -645,7 +645,11 @@ msgid ""
 "If this succeeds, a normal session is created for the original\n"
 "connecting user. Said differently: if you know the password of\n"
 "**admin auth user**, you can authenticate as any other user.\n"
-msgstr "> 例えば\"**admin auth user = root**\"を指定すると、通常ユーザのログインが失敗したときにafpdは必ず指定した**admin auth user**として認証を試みる。これが成功した場合、元の接続ユーザとして通常のセッションが確立される。言い換えると、あなたが**admin auth user**のパスワードを知っている場合、如何なる他のユーザとしてでも認証できる。\n"
+msgstr ""
+"> 例えば\"**admin auth user = root**\"を指定すると、\n"
+"通常ユーザのログインが失敗したときにafpdは必ず指定した**admin auth user**として認証を試みる。\n"
+"これが成功した場合、元の接続ユーザとして通常のセッションが確立される。\n"
+"言い換えると、あなたが**admin auth user**のパスワードを知っている場合、如何なる他のユーザとしてでも認証できる。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:214
@@ -658,7 +662,9 @@ msgstr ""
 msgid ""
 "> Allows users of a certain group to be seen as the superuser when they\n"
 "log in. This option is disabled by default.\n"
-msgstr "> 信頼できるグループのユーザがログインしたときスーパユーザとして見えるようにする。このオプションはデフォルトで無効である。\n"
+msgstr ""
+"> 信頼できるグループのユーザがログインしたときスーパユーザとして見えるようにする。\n"
+"このオプションはデフォルトで無効である。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:219
@@ -673,7 +679,10 @@ msgid ""
 "user for all users connecting to this server. This is useful for sharing\n"
 "files. You should also use it carefully as using it incorrectly can\n"
 "cause security problems.\n"
-msgstr "> このサーバに接続する全ユーザへ、デフォルトユーザとして割り当てるUNIXユーザ名を指定する。これは共有ファイルに役立つ。間違ってセキュリティ問題を引き起こすような使い方が可能なので、それにも注意して利用すべきである。\n"
+msgstr ""
+"> このサーバに接続する全ユーザへ、デフォルトユーザとして割り当てるUNIXユーザ名を指定する。\n"
+"これは共有ファイルに役立つ。間違ってセキュリティ問題を引き起こすような使い方が可能なので、\n"
+"それにも注意して利用すべきである。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:226
@@ -730,7 +739,9 @@ msgid ""
 "> Use for e.g. winbind authentication, prepends both strings before the\n"
 "username from login and then tries to authenticate with the result\n"
 "through the available and active UAM authentication modules.\n"
-msgstr "> 例えばwinbind認証で利用し、有効かつ動作中のUAM認証を通して、ログイン時のユーザ名の前に両方の文字列を付けたもので認証を試みる。\n"
+msgstr ""
+"> 例えばwinbind認証で利用し、有効かつ動作中のUAM認証を通して、\n"
+"ログイン時のユーザ名の前に両方の文字列を付けたもので認証を試みる。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:247
@@ -914,8 +925,10 @@ msgid ""
 "This will also be the default for the volumes **mac charset**. Defaults to\n"
 "*MAC_ROMAN*.\n"
 msgstr ""
-"> Macクライアントの文字セット、例えば*MAC_ROMAN*を指定する。これは文字列やファイル名をOS9やClassic環境のクライアントコードページに変換するために用いられる。すなわち認証やAFPメッセージ(SIGUSR2\n"
-"messaging)である。これはボリュームの**mac charset**のデフォルトにもなる。デフォルトは*MAC_ROMAN*。\n"
+"> Macクライアントの文字セット、例えば*MAC_ROMAN*を指定する。\n"
+"これは文字列やファイル名をOS9やClassic環境のクライアントコードページに変換するために用いられる。\n"
+"すなわち認証やAFPメッセージ(SIGUSR2 messaging)である。\n"
+"これはボリュームの**mac charset**のデフォルトにもなる。デフォルトは*MAC_ROMAN*。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:327
@@ -930,7 +943,11 @@ msgid ""
 "is used to convert strings to/from the systems locale, e.g. for\n"
 "authentication, server messages and volume names. If *LOCALE* is set,\n"
 "the systems locale is used. Defaults to *UTF8*.\n"
-msgstr "> サーバのunix文字セット、例えば*ISO-8859-15*や*EUC-JP*を指定する。これは文字列をシステムロケールとの間で変換するのに使われる。すなわち認証やサーバメッセージやボリューム名である。LOCALEが設定された場合、システムロケールが使われる。デフォルトはUTF8。\n"
+msgstr ""
+"> サーバのunix文字セット、例えば*ISO-8859-15*や*EUC-JP*を指定する。\n"
+"これは文字列をシステムロケールとの間で変換するのに使われる。\n"
+"すなわち認証やサーバメッセージやボリューム名である。\n"
+"LOCALEが設定された場合、システムロケールが使われる。デフォルトはUTF8。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:334
@@ -1071,7 +1088,9 @@ msgid ""
 "> Allows a different TCP port to be used for AFP. The default is 548. Also\n"
 "sets the default port applied when none specified in an **afp listen**\n"
 "option.\n"
-msgstr "> 異なるTCPポートをAFPに使わせる。デフォルトは548である。**afp listen**オプションで何も指定しなかった場合も適用されたデフォルトポートを設定する。\n"
+msgstr ""
+"> 異なるTCPポートをAFPに使わせる。デフォルトは548である。\n"
+"**afp listen**オプションで何も指定しなかった場合も適用されたデフォルトポートを設定する。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:393
@@ -1085,7 +1104,9 @@ msgid ""
 "> Whether to apply locks to the byte region read in FPRead calls. The AFP\n"
 "spec mandates this, but it's not really in line with UNIX semantics and\n"
 "is a performance hog.\n"
-msgstr "> FPReadコールにおいてバイト領域リードロックを適用するかどうか。AFPの仕様はこれを義務付けるが、実際のところこれはUNIXの動作に合致しないし、パフォーマンスを抑え込む。\n"
+msgstr ""
+"> FPReadコールにおいてバイト領域リードロックを適用するかどうか。\n"
+"AFPの仕様はこれを義務付けるが、実際のところこれはUNIXの動作に合致しないし、パフォーマンスを抑え込む。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:399
@@ -1099,7 +1120,10 @@ msgid ""
 "> Specifies the IP address and port that the CNID server should listen on.\n"
 "This should match the address and port of the **cnid server** option\n"
 "for most deployments. The default is **localhost:4700**.\n"
-msgstr "> CNIDサーバがリッスンするIPアドレスとポートを指定する。これはほとんどのデプロイメントで**cnid server**オプションと一致するべきである。デフォルトは**localhost:4700**である。\n"
+msgstr ""
+"> CNIDサーバがリッスンするIPアドレスとポートを指定する。\n"
+"これはほとんどのデプロイメントで**cnid server**オプションと一致するべきである。\n"
+"デフォルトは**localhost:4700**である。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:405
@@ -1173,7 +1197,10 @@ msgid ""
 "which IP address to advertise, therefore the hostname is resolved to an\n"
 "IP which is the advertised. This is NOT used for listening and can be\n"
 "overridden by **afp listen**.\n"
-msgstr "> 宣伝用のIPアドレスを決定するため、ホスト名の呼出結果の代わりにこれを用いる。従って、このホスト名から宣伝用IPアドレスが解決されるようになる。これはリスニングには使われないし、**afp listen**によって上書きされてしまう。\n"
+msgstr ""
+"> 宣伝用のIPアドレスを決定するため、ホスト名の呼出結果の代わりにこれを用いる。\n"
+"従って、このホスト名から宣伝用IPアドレスが解決されるようになる。\n"
+"これはリスニングには使われないし、**afp listen**によって上書きされてしまう。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:437
@@ -1203,7 +1230,9 @@ msgid ""
 "not change this value unless you're absolutely sure, what you're doing\n"
 msgstr ""
 "> これはDSI server quantumを指定する。デフォルト値は0x100000\n"
-"(1MiB)である。最大値は0xFFFFFFFFFであり最小値は32000である。範囲外の値を指定した場合、デフォルト値が設定される。自分が何をしようとしているか確信がない限り、この値を変更しないでください。\n"
+"(1MiB)である。最大値は0xFFFFFFFFFであり最小値は32000である。\n"
+"範囲外の値を指定した場合、デフォルト値が設定される。\n"
+"自分が何をしようとしているか確信がない限り、この値を変更しないでください。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:449
@@ -1216,7 +1245,9 @@ msgstr ""
 msgid ""
 "> Keep sleeping AFP sessions for *number* hours before disconnecting\n"
 "clients in sleep mode. Default is 10 hours.\n"
-msgstr "> スリープモードにおいてクライアントを切断する前に、スリープ中のAFPセッションを*number*時間維持する。デフォルトは10時間である。\n"
+msgstr ""
+"> スリープモードにおいてクライアントを切断する前に、スリープ中のAFPセッションを*number*時間維持する。\n"
+"デフォルトは10時間である。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:454
@@ -1229,7 +1260,9 @@ msgstr ""
 msgid ""
 "> Try to set TCP receive buffer using setsockopt(). Often OSes impose\n"
 "restrictions on the applications ability to set this value.\n"
-msgstr "> setsockopt()を使ってTCP受信バッファの設定を試みる。しばしばOSはこの値を設定しようとするアプリケーションの資格を制限する。\n"
+msgstr ""
+"> setsockopt()を使ってTCP受信バッファの設定を試みる。\n"
+"しばしばOSはこの値を設定しようとするアプリケーションの資格を制限する。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:459
@@ -1242,7 +1275,9 @@ msgstr ""
 msgid ""
 "> Try to set TCP send buffer using setsockopt(). Often OSes impose\n"
 "restrictions on the applications ability to set this value.\n"
-msgstr "> setsockopt()を使ってTCP送信バッファの設定を試みる。しばしばOSはこの値を設定しようとするアプリケーションの資格を制限する。\n"
+msgstr ""
+"> setsockopt()を使ってTCP送信バッファの設定を試みる。\n"
+"しばしばOSはこの値を設定しようとするアプリケーションの資格を制限する。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:464
@@ -1290,7 +1325,9 @@ msgstr "zeroconf = *BOOLEAN* (デフォルト: *yes*) **(G)**"
 msgid ""
 "> Whether to use automatic Zeroconf service\n"
 "registration if Avahi or mDNSResponder were compiled in.\n"
-msgstr "> AvahiまたはmDNSResponder込みでコンパイル済の場合、自動的なZeroconfサービス登録を使うかどうか。\n"
+msgstr ""
+"> AvahiまたはmDNSResponder込みでコンパイル済の場合、\n"
+"自動的なZeroconfサービス登録を使うかどうか。\n"
 
 #. type: Title ##
 #: manpages/man5/afp.conf.5.md:481
@@ -1393,7 +1430,9 @@ msgstr ""
 msgid ""
 "> Sets the path where the database information will be stored. You have to\n"
 "specify a writable location, even if the volume is read only.\n"
-msgstr "> データベース情報をpathに格納するように設定する。ボリュームが読み込み専用だったとしても、書き込み可能な場所を設定しなければならない。\n"
+msgstr ""
+"> データベース情報をpathに格納するように設定する。\n"
+"ボリュームが読み込み専用だったとしても、書き込み可能な場所を設定しなければならない。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:521
@@ -1409,7 +1448,8 @@ msgid ""
 "each share.\n"
 msgstr ""
 "> このオプションをtrueに設定するとNetatalk\n"
-"2の動作に立ち返る。つまり、それぞれの共有のボリュームルートの下にある.AppleDBというフォルダにCNIDデータベースを格納する。\n"
+"2の動作に立ち返る。つまり、それぞれの共有のボリュームルートの下にある\n"
+"「.AppleDB」というフォルダにCNIDデータベースを格納する。\n"
 
 #. type: Title ##
 #: manpages/man5/afp.conf.5.md:526
@@ -1443,7 +1483,9 @@ msgstr "close vol = *BOOLEAN* (デフォルト: *no*) **(G)**"
 msgid ""
 "> Whether to close volumes possibly opened by clients when they're removed\n"
 "from the configuration and the configuration is reloaded.\n"
-msgstr "> ボリュームが設定から削除され、その設定が再読み込みされたとき、クライアントが既に開いているボリュームを可能な限り閉じるかどうか。\n"
+msgstr ""
+"> ボリュームが設定から削除され、その設定が再読み込みされたとき、\n"
+"クライアントが既に開いているボリュームを可能な限り閉じるかどうか。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:539
@@ -1577,7 +1619,11 @@ msgid ""
 "Defaults to the value of **hostname** up until the first period.\n"
 "When netatalk is built with Zeroconf support, this is also registered as\n"
 "the service name and advertised as UTF-8, up to 63 octets (bytes) in length.\n"
-msgstr "> 一意に AFP サーバを記述する人間が読める名前を指定する。デフォルトでは、最初のピリオドまでの**hostname**の値を使用する。netatalkがZeroconfサポートでビルドされている場合、これはサービス名としても登録され、UTF-8で最大63オクテット(バイト)の長さまで宣伝される。\n"
+msgstr ""
+"> 一意に AFP サーバを記述する人間が読める名前を指定する。\n"
+"デフォルトでは、最初のピリオドまでの**hostname**の値を使用する。\n"
+"netatalkがZeroconfサポートでビルドされている場合、これはサービス名としても登録され、\n"
+"UTF-8で最大63オクテット(バイト)の長さまで宣伝される。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:595
@@ -1593,7 +1639,11 @@ msgid ""
 "etc. By default, afpd generates a signature and saves it to a file\n"
 "called **afp_signature.conf** automatically (based on random numbers). See\n"
 "also asip-status(1).\n"
-msgstr "> サーバシグネチャを指定する。最大長は16文字である。このオプションは障害隔離などを提供するクラスタ環境において有用である。デフォルトでは、afpdは自動的にシグネチャを(乱数を元に)生成し、それを**afp_signature.conf**に保存する。asip-status(1)も見よ。\n"
+msgstr ""
+"> サーバシグネチャを指定する。最大長は16文字である。\n"
+"このオプションは障害隔離などを提供するクラスタ環境において有用である。\n"
+"デフォルトでは、afpdは自動的にシグネチャを(乱数を元に)生成し、\n"
+"それを**afp_signature.conf**に保存する。asip-status(1)も見よ。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:603
@@ -1622,7 +1672,10 @@ msgid ""
 "> Send optional AFP messages for vetoed files. Then whenever a client\n"
 "tries to access any file or directory with a vetoed name, it will be\n"
 "sent an AFP message indicating the name and the directory.\n"
-msgstr "> 禁止ファイルに関するオプションのAFPメッセージを送る。クライアントが禁止名を持つファイルやディレクトリにアクセスを試みたとき、名前とディレクトリを示したAFPメッセージを送る。\n"
+msgstr ""
+"> 禁止ファイルに関するオプションのAFPメッセージを送る。\n"
+"クライアントが禁止名を持つファイルやディレクトリにアクセスを試みたとき、\n"
+"名前とディレクトリを示したAFPメッセージを送る。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:614
@@ -1749,7 +1802,8 @@ msgid ""
 "By default all attributes can be searched, passing a string limits\n"
 "attributes to elements of the string. Example:\n"
 msgstr ""
-"> Spotlight検索で使うことを許された属性のリスト。デフォルトでは全ての属性を検索できるが、文字列を渡せば属性をその文字列の要素に制限できる。\n"
+"> Spotlight検索で使うことを許された属性のリスト。\n"
+"デフォルトでは全ての属性を検索できるが、文字列を渡せば属性をその文字列の要素に制限できる。\n"
 "例:\n"
 
 #. type: Plain text
@@ -1842,7 +1896,8 @@ msgid ""
 "timestamps record only whole seconds. Only takes effect when used in\n"
 "tandem with the **log file** option.\n"
 msgstr ""
-"> タイムスタンプをマイクロ秒単位の精度でログに記録する。無効にすると、タイムスタンプは秒単位のみを記録する。**log file**\n"
+"> タイムスタンプをマイクロ秒単位の精度でログに記録する。\n"
+"無効にすると、タイムスタンプは秒単位のみを記録する。**log file**\n"
 "オプションと組み合わせて使用​​した場合にのみ有効になる。\n"
 
 #. type: Title ##
@@ -1989,8 +2044,10 @@ msgid ""
 "every \"save\". Default: 60 seconds.\n"
 msgstr ""
 "> これは、もしクライアントによって FCE ファイル変更イベント (fmod)\n"
-"を送信する前に同じファイルに対する別の変更が同時に行われる場合、常に待機する遅延時間を秒単位で決定する。例えば、フォトショップでファイルを保存することでそのファイル自体の複数のイベントを引き起こす。なぜなら、アプリケーションはその“保存する”たびにファイルを複数回、開き、変更しそして閉じるからである。デフォルトでは\n"
-"60 秒である。\n"
+"を送信する前に同じファイルに対する別の変更が同時に行われる場合、常に待機する遅延時間を秒単位で決定する。\n"
+"例えば、フォトショップでファイルを保存することでそのファイル自体の複数のイベントを引き起こす。\n"
+"なぜなら、アプリケーションはその“保存する”たびにファイルを複数回、開き、変更しそして閉じるからである。デフォルトでは\n"
+"60秒である。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:750
@@ -2559,7 +2616,9 @@ msgid ""
 "log on to the server.\n"
 "The message should be in **unix charset**.\n"
 "Extended characters are allowed.\n"
-msgstr "> Classic Mac OSクライアントがサーバにログオンしたときに表示されるメッセージを設定する。メッセージは**unix charset**で書く。拡張文字が使える。\n"
+msgstr ""
+"> Classic Mac OSクライアントがサーバにログオンしたときに表示されるメッセージを設定する。\n"
+"メッセージは**unix charset**で書く。拡張文字が使える。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:971
@@ -2616,7 +2675,9 @@ msgstr ""
 msgid ""
 "> Specify the number of tickles to send before timing out a connection.\n"
 "The default is 4, therefore a connection will timeout after 2 minutes.\n"
-msgstr "> 接続がタイムアウトする前に送るtickleの数を指定する。デフォルトは4なので、2分後に接続がタイムアウトする。\n"
+msgstr ""
+"> 接続がタイムアウトする前に送るtickleの数を指定する。\n"
+"デフォルトは4なので、2分後に接続がタイムアウトする。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:992
@@ -2632,7 +2693,9 @@ msgid ""
 "seconds to detect changes in opened server windows.\n"
 msgstr ""
 "> このオプションを有効にすると、afpdはserver\n"
-"notificationの機能があることを宣伝しない。これは、接続中のクライアントが開いているサーバのウインドウの変更を検出するために10秒毎にポーリングするのを目的としている。\n"
+"notificationの機能があることを宣伝しない。これは、\n"
+"接続中のクライアントが開いているサーバのウインドウの変更を検出するために\n"
+"10秒毎にポーリングするのを目的としている。\n"
 
 #. type: Title #
 #: manpages/man5/afp.conf.5.md:997
@@ -2664,7 +2727,10 @@ msgid ""
 "If **basedir regex** contains symlink, you must set the canonicalized\n"
 "absolute path. In the simple case this is just a path i.e.\n"
 "**basedir regex = /home**\n"
-msgstr "> ユーザホームの親ディレクトリにマッチする正規表現。**basedir regex**がシンボリックリンクを含む場合、正規化した絶対パスを設定しなければならない。簡単なケースだとこれは単に一つのパスである。つまり**basedir regex = /home**である。\n"
+msgstr ""
+"> ユーザホームの親ディレクトリにマッチする正規表現。\n"
+"**basedir regex**がシンボリックリンクを含む場合、正規化した絶対パスを設定しなければならない。\n"
+"簡単なケースだとこれは単に一つのパスである。つまり**basedir regex = /home**である。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:1011
@@ -2723,11 +2789,14 @@ msgid ""
 "Mac charset volume name is limited to 27 characters.\n"
 "UTF8-MAC volume name is limited to volnamelen parameter.\n"
 msgstr ""
-"> AFP共有ボリュームの名前を指定する。デフォルトでは、ボリュームが定義されている ini ファイルの小文字に変換されたセクション名となる。\n"
+"> AFP共有ボリュームの名前を指定する。デフォルトでは、ボリュームが定義されている ini ファイルの\n"
+"小文字に変換されたセクション名となる。\n"
 ">\n"
 "> 同じ名前の二つのボリュームというのは無いであろう。\n"
-"ボリューム名が文字 ':' を含むことはできない。ボリューム名がとても長ければマングルされる。\n"
-"Macキャラクターセットのボリューム名は27文字までに制限される。UTF8-MAC ボリューム名は volnamelen パラメータで制限される。\n"
+"ボリューム名が文字 ':' を含むことはできない。\n"
+"ボリューム名がとても長ければマングルされる。\n"
+"Macキャラクターセットのボリューム名は27文字までに制限される。\n"
+"UTF8-MAC ボリューム名は volnamelen パラメータで制限される。\n"
 
 #. type: Plain text
 #: manpages/man5/afp.conf.5.md:1036
@@ -2757,7 +2826,8 @@ msgstr ""
 ">\n"
 "> 【重要】 これは Time Machine sparsebundle イメージの中身を考慮した概算である。\n"
 "それ故このオプションを使用した時、このボリュームを他のコンテンツを保管するのに使用“してはならない”。\n"
-"なぜなら勘定に入っていないからである。計算は sparsebundle の Info.plist XML ファイルからバンドサイズを読む、\n"
+"なぜなら勘定に入っていないからである。\n"
+"計算は sparsebundle の Info.plist XML ファイルからバンドサイズを読む、\n"
 "バンドファイルの数を数えてバンド／ディレクトリを読む、そしてお互いの乗算をする。ことによって行われる。\n"
 
 #. type: Plain text
@@ -2773,7 +2843,8 @@ msgid ""
 "specified. Users and groups are specified, delimited by spaces or\n"
 "commas. Groups are designated by a @ prefix. Example:\n"
 msgstr ""
-"> この許可オプションは指定された共有にそのユーザーとグループのアクセスを許可する。ユーザーとグループはスペースかコンマで区切って指定する。グループは\n"
+"> この許可オプションは指定された共有にそのユーザーとグループのアクセスを許可する。\n"
+"ユーザーとグループはスペースかコンマで区切って指定する。グループは\n"
 "@ プレフィックスで明示する。例:\n"
 
 #. type: Plain text
@@ -2840,35 +2911,59 @@ msgid "cnid scheme = *backend* **(V)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1088
+#: manpages/man5/afp.conf.5.md:1102
 #, no-wrap
 msgid ""
 "> set the CNID backend to be used for the volume.\n"
-"The \"dbd\" and \"last\" backends are always available. Default is **dbd**.\n"
-"Run *afpd -v* to see a list of available backends.\n"
+"Run **afpd -v** to see a list of available backends,\n"
+"as well as which one is the default.\n"
 ">\n"
-"> The \"last\" backend is read only, used to mount CD-ROMs and similar media.\n"
+"> *dbd* is a zero-configuration, full-featured, and reliable backend\n"
+"using Berkeley DB, where database access is managed through\n"
+"the **cnid_dbd** daemon.\n"
 ">\n"
-"> The optional \"mysql\" backend requires the system administrator to provision\n"
-"a MySQL database instance for use with Netatalk, as well as setting the\n"
-"*cnid mysql \\** configuration options.\n"
+"> The *last* backend uses a read-only, in-memory Trivial Database.\n"
+"It can be used to mount CD-ROMs and similar read-only media, for instance.\n"
+">\n"
+"> The *mysql* backend requires that a MySQL (or MariaDB) database instance\n"
+"has been provisioned for use with Netatalk.\n"
+"The upside is that you get full control over how the CNID data is stored,\n"
+"which makes for a robust and scalable solution.\n"
+">\n"
+"> The EXPERIMENTAL *sqlite* backend is a zero-configuration backend\n"
+"that uses the SQLite library. It is performant and lean, requiring\n"
+"no external database or daemon.\n"
+">\n"
+"> ***WARNING:*** The *sqlite* backend should only be used for testing purposes\n"
+"and not in a production setting.\n"
+"Please take a backup of your data before enabling this backend.\n"
 msgstr ""
-"> そのボリュームに使う CNID バックエンドをセットする。\"dbd\" と \"last\" バックエンドは常に利用可能である。\n"
-"デフォルトのバックエンドは **dbd** である。\n"
-"*afpd -v* を実行して有効なバックエンドの一覧を表示すること。\n"
+"> そのボリュームに使う CNID バックエンドをセットする。\n"
+"*afpd -v* を実行して有効なバックエンドの一覧またはデフォルトバックエンドを表示すること。\n"
 ">\n"
-"> \"last\" バックエンドは読み取り専用で、CD-ROMや同様のメディアをマウントするために使用される。\n"
+"*dbd* は、Berkeley DB を使用した、構成不要でフル機能を備えた信頼性の高いバックエンドであり、\n"
+"データベースアクセスは **cnid_dbd** デーモンによって管理される。\n"
 ">\n"
-"> 「mysql」バックエンドでは、システム管理者が netatalk で使用するために\n"
-"MySQLデータベースインスタンスを設定する必要がある。また、*cnid mysql \\** 設定オプションを設定する必要がある。\n"
+"> *last* バックエンドは読み取り専用インメモリトリビアルデータベースを使用し、\n"
+"CD-ROMや同様のメディアをマウントするために使用される。\n"
+">\n"
+"> *mysql* バックエンドでは、システム管理者が netatalk で使用するために\n"
+"MySQL（もしくはMariaDB）データベースインスタンスを設定する必要がある。\n"
+"利点は、CNID データの保存方法を完全に制御できるため、堅牢でスケーラブルなソリューションが実現できることである。\n"
+">\n"
+"> 実験的な *sqlite* バックエンドは、SQLiteライブラリを使用する設定不要のバックエンドである。\n"
+"パフォーマンスが高く、軽量で、外部データベースやデーモンは必要ない。\n"
+">\n"
+"> 【警告】 SQLiteバックエンドはテスト目的でのみ使用し、本番環境では使用しないこと。\n"
+"このバックエンドを有効にする前に、データのバックアップを作成すること。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1090
+#: manpages/man5/afp.conf.5.md:1104
 msgid "ea = *sys* | *samba* | *ad* | *none* (default: auto detect) **(V)**"
 msgstr "ea = *sys* | *samba* | *ad* | *none* (デフォルト: 自動検出) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1120
+#: manpages/man5/afp.conf.5.md:1134
 #, no-wrap
 msgid ""
 "> Specify how Extended Attributes and Classic Mac OS resource forks are\n"
@@ -2903,7 +2998,8 @@ msgid ""
 msgstr ""
 "> 拡張属性およびリソースフォークをどのように保存するか指定する。\n"
 ">\n"
-"> 共有ディレクトリ自体に拡張属性を設定することにより **sys** を試行して、フォールバックすると **none** になる。\n"
+"> 共有ディレクトリ自体に拡張属性を設定することにより **sys** を試行して、\n"
+"フォールバックすると **none** になる。\n"
 "試行を実行するためにはボリュームが書き込み可能であることが必要である。\n"
 "読み込み専用ボリュームの場合は、このオプションを明示的に設定すること。\n"
 ">\n"
@@ -2913,7 +3009,8 @@ msgstr ""
 ">\n"
 "> samba\n"
 ">\n"
-"> > ファイルシステムの拡張属性を使うが、Sambaのvfs_streams_xattrとの互換性の目的で、それぞれの拡張属性に値がゼロの1バイトを追加する。\n"
+"> > ファイルシステムの拡張属性を使うが、Sambaのvfs_streams_xattrとの互換性の目的で、\n"
+"それぞれの拡張属性に値がゼロの1バイトを追加する。\n"
 ">\n"
 "> ad\n"
 ">\n"
@@ -2928,12 +3025,12 @@ msgstr ""
 "これにより、データが失われる可能性がある。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1122
+#: manpages/man5/afp.conf.5.md:1136
 msgid "mac charset = *charset* **(V)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1127
+#: manpages/man5/afp.conf.5.md:1141
 #, no-wrap
 msgid ""
 "> specifies the Mac client charset for this Volume, e.g. *MAC_ROMAN*,\n"
@@ -2947,12 +3044,12 @@ msgstr ""
 "セクションで全体的にセットしたキャラクターセットと異なるというボリュームを必要とする時のみ必須である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1129
+#: manpages/man5/afp.conf.5.md:1143
 msgid "casefold = *option* **(V)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1140
+#: manpages/man5/afp.conf.5.md:1154
 #, no-wrap
 msgid ""
 "> The casefold option handles, if the case of filenames should be changed.\n"
@@ -2977,12 +3074,12 @@ msgstr ""
 "> **xlateupper** - クライアントでは大文字に見えて、サーバでは小文字にみえる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1142
+#: manpages/man5/afp.conf.5.md:1156
 msgid "password = *password* **(V)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1146
+#: manpages/man5/afp.conf.5.md:1160
 #, no-wrap
 msgid ""
 "> This option allows you to set a volume password, which can be a maximum\n"
@@ -2993,12 +3090,12 @@ msgstr ""
 "8 文字の長さ（これを記入するときには ASCII を強く推奨）\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1148
+#: manpages/man5/afp.conf.5.md:1162
 msgid "file perm = *mode* **(V)**; directory perm = *mode* **(V)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1154
+#: manpages/man5/afp.conf.5.md:1168
 #, no-wrap
 msgid ""
 "> Add(or) with the client requested permissions: **file perm** is for files\n"
@@ -3014,7 +3111,7 @@ msgstr ""
 "> **例**：共同作業グループ向けのボリューム\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1157
+#: manpages/man5/afp.conf.5.md:1171
 #, no-wrap
 msgid ""
 "    file perm = 0660\n"
@@ -3022,45 +3119,45 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1159
+#: manpages/man5/afp.conf.5.md:1173
 msgid "umask = *mode* **(V)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1161
+#: manpages/man5/afp.conf.5.md:1175
 #, no-wrap
 msgid "> set perm mask. Don't use with \"**unix priv = no**\".\n"
 msgstr "> 権限のマスクを設定する。\"**unix priv = no**\" と共に用いてはならない。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1163
+#: manpages/man5/afp.conf.5.md:1177
 msgid "preexec = *command* **(V)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1165
+#: manpages/man5/afp.conf.5.md:1179
 #, no-wrap
 msgid "> command to be run when the volume is mounted\n"
 msgstr "> ボリュームがマウントされる時に実行されるコマンド\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1167
+#: manpages/man5/afp.conf.5.md:1181
 msgid "postexec = *command* **(V)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1169
+#: manpages/man5/afp.conf.5.md:1183
 #, no-wrap
 msgid "> command to be run when the volume is closed\n"
 msgstr "> ボリュームが閉じられる時に実行されるコマンド\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1171
+#: manpages/man5/afp.conf.5.md:1185
 msgid "rolist = *users/groups* **(V)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1174
+#: manpages/man5/afp.conf.5.md:1188
 #, no-wrap
 msgid ""
 "> Allows certain users and groups to have read-only access to a share.\n"
@@ -3070,12 +3167,12 @@ msgstr ""
 "allow オプションに準ずる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1176
+#: manpages/man5/afp.conf.5.md:1190
 msgid "rwlist = *users/groups* **(V)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1179
+#: manpages/man5/afp.conf.5.md:1193
 #, no-wrap
 msgid ""
 "> Allows certain users and groups to have read/write access to a share.\n"
@@ -3085,12 +3182,12 @@ msgstr ""
 "allow オプションに準ずる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1181
+#: manpages/man5/afp.conf.5.md:1195
 msgid "veto files = *vetoed names* **(V)**"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1185
+#: manpages/man5/afp.conf.5.md:1199
 #, no-wrap
 msgid ""
 "> hide files and directories,where the path matches one of the '/'\n"
@@ -3103,23 +3200,23 @@ msgstr ""
 "= veto1/veto2/\"。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:1186
+#: manpages/man5/afp.conf.5.md:1200
 #, no-wrap
 msgid "Volume options"
 msgstr "ボリュームオプション"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1189
+#: manpages/man5/afp.conf.5.md:1203
 msgid "Boolean volume options."
 msgstr "ブーリアン型のボリュームオプション。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1191
+#: manpages/man5/afp.conf.5.md:1205
 msgid "acls = *BOOLEAN* (default: *yes*) **(V)**"
 msgstr "acls = *BOOLEAN* (デフォルト: *yes*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1194
+#: manpages/man5/afp.conf.5.md:1208
 #, no-wrap
 msgid ""
 "> Whether to flag volumes as supporting ACLs. If ACL support is compiled\n"
@@ -3129,12 +3226,12 @@ msgstr ""
 "サポートでコンパイルしていれば、これはデフォルトで yes。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1196
+#: manpages/man5/afp.conf.5.md:1210
 msgid "case sensitive = *BOOLEAN* (default: *yes*) **(V)**"
 msgstr "case sensitive = *BOOLEAN* (デフォルト: *yes*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1204
+#: manpages/man5/afp.conf.5.md:1218
 #, no-wrap
 msgid ""
 "> Whether to flag volumes as supporting case-sensitive filenames. If the\n"
@@ -3153,12 +3250,12 @@ msgstr ""
 "kCaseSensitiveフラグを通知しなかった。バージョン3.1.4からはデフォルトで正しく通知される。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1206
+#: manpages/man5/afp.conf.5.md:1220
 msgid "cnid dev = *BOOLEAN* (default: *yes*) **(V)**"
 msgstr "cnid dev = *BOOLEAN* (デフォルト: *yes*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1209
+#: manpages/man5/afp.conf.5.md:1223
 #, no-wrap
 msgid ""
 "> Whether to use the device number in the CNID backends. Helps when the\n"
@@ -3168,12 +3265,12 @@ msgstr ""
 "例えばクラスターなどでリブートを経るとデバイス番号が固定ではない時有用。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1211
+#: manpages/man5/afp.conf.5.md:1225
 msgid "convert appledouble = *BOOLEAN* (default: *yes*) **(V)**"
 msgstr "convert appledouble = *BOOLEAN* (デフォルト: *yes*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1217
+#: manpages/man5/afp.conf.5.md:1231
 #, no-wrap
 msgid ""
 "> Whether automatic conversion from AppleDouble v2 to Extended Attributes\n"
@@ -3183,17 +3280,18 @@ msgid ""
 "option can be set to *no*.\n"
 msgstr ""
 "> クライアントからのファイルシステムへのアクセス時、AppleTalk v2\n"
-"から拡張属性への自動的な変換を行うかどうか。これは概して有用であるがいくらかパフォーマンスが犠牲となる。ボリューム上で\n"
+"から拡張属性への自動的な変換を行うかどうか。\n"
+"これは概して有用であるがいくらかパフォーマンスが犠牲となる。ボリューム上で\n"
 "**dbd** を実行しそれで変換をするのが推奨される。その後このオプションを no\n"
 "に設定することもできる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1219
+#: manpages/man5/afp.conf.5.md:1233
 msgid "delete veto files = *BOOLEAN* (default: *no*) **(V)**"
 msgstr "delete veto files = *BOOLEAN* (デフォルト: *no*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1228
+#: manpages/man5/afp.conf.5.md:1242
 #, no-wrap
 msgid ""
 "> This option is used when Netatalk is attempting to delete a directory\n"
@@ -3215,12 +3313,12 @@ msgstr ""
 "含めあらゆるファイル、ディレクトリを再帰的に削除しようとするであろう。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1230
+#: manpages/man5/afp.conf.5.md:1244
 msgid "follow symlinks = *BOOLEAN* (default: *no*) **(V)**"
 msgstr "follow symlinks = *BOOLEAN* (デフォルト: *no*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1239
+#: manpages/man5/afp.conf.5.md:1253
 #, no-wrap
 msgid ""
 "> The default setting is false thus symlinks are not followed on the\n"
@@ -3241,12 +3339,12 @@ msgstr ""
 "> 【注記】 シンボリックリンクがファイルシステムの境界をまたいで張られている時、このオプションは巧妙に断ち切る。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1241
+#: manpages/man5/afp.conf.5.md:1255
 msgid "invisible dots = *BOOLEAN* (default: *no*) **(V)**"
 msgstr "invisible dots = *BOOLEAN* (デフォルト: *no*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1251
+#: manpages/man5/afp.conf.5.md:1265
 #, no-wrap
 msgid ""
 "> make dot files invisible.\n"
@@ -3262,18 +3360,20 @@ msgstr ""
 "ドットファイルを不可視にする。\n"
 ">\n"
 "> 【警告】 このオプションを有効にすると、望まない副作用をOS Xアプリケーションに引き起こす。\n"
-"つまり、先頭がドットではじまる一時ファイルにファイルをセーブし、それから一時ファイルを最終的なファイル名にリネームした時、\n"
+"つまり、先頭がドットではじまる一時ファイルにファイルをセーブし、\n"
+"それから一時ファイルを最終的なファイル名にリネームした時、\n"
 "結果としてセーブしたファイルが見えなくなる。唯一このオプションが有用なのは、\n"
 "Mac OS 9でドットからはじまるファイルを見えなくさせるためである。\n"
-"Mac OS Xでは、Finderでもターミナルでもドットではじまるファイルはいずれにしても隠しファイルなので、完全に無駄である。\n"
+"Mac OS Xでは、Finderでもターミナルでもドットではじまるファイルはいずれにしても\n"
+"隠しファイルなので、完全に無駄である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1253
+#: manpages/man5/afp.conf.5.md:1267
 msgid "network ids = *BOOLEAN* (default: *yes*) **(V)**"
 msgstr "network ids = *BOOLEAN* (デフォルト: *yes*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1256
+#: manpages/man5/afp.conf.5.md:1270
 #, no-wrap
 msgid ""
 "> Whether the server support network ids. Setting this to *no* will result\n"
@@ -3283,12 +3383,12 @@ msgstr ""
 "に設定すると結果としてクライアントは ACL AFP 機能を使わなくなる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1258
+#: manpages/man5/afp.conf.5.md:1272
 msgid "preexec close = *BOOLEAN* (default: *no*) **(V)**"
 msgstr "preexec close = *BOOLEAN* (デフォルト: *no*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1261
+#: manpages/man5/afp.conf.5.md:1275
 #, no-wrap
 msgid ""
 "> A non-zero return code from preexec close the volume being immediately,\n"
@@ -3298,12 +3398,12 @@ msgstr ""
 "クライアントがボリュームをマウントする／見ることを防ぐために当該ボリュームを即座に閉じる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1263
+#: manpages/man5/afp.conf.5.md:1277
 msgid "read only = *BOOLEAN* (default: *no*) **(V)**"
 msgstr "read only = *BOOLEAN* (デフォルト: *no*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1266
+#: manpages/man5/afp.conf.5.md:1280
 #, no-wrap
 msgid ""
 "> Specifies the share as being read only for all users.\n"
@@ -3311,12 +3411,12 @@ msgid ""
 msgstr "> その共有を全てのユーザーに対して読み込み専用と指定する。強制的に **ea = sys** となる。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1268
+#: manpages/man5/afp.conf.5.md:1282
 msgid "search db = *BOOLEAN* (default: *no*) **(V)**"
 msgstr "search db = *BOOLEAN* (デフォルト: *no*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1273
+#: manpages/man5/afp.conf.5.md:1287
 #, no-wrap
 msgid ""
 "> Use fast CNID database namesearch instead of slow recursive filesystem\n"
@@ -3331,12 +3431,12 @@ msgstr ""
 "CNID db のボリュームのみで動作する。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1275
+#: manpages/man5/afp.conf.5.md:1289
 msgid "stat vol = *BOOLEAN* (default: *yes*) **(V)**"
 msgstr "stat vol = *BOOLEAN* (デフォルト: *yes*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1278
+#: manpages/man5/afp.conf.5.md:1292
 #, no-wrap
 msgid ""
 "> Whether to stat volume path when enumerating volumes list, useful for\n"
@@ -3347,23 +3447,23 @@ msgstr ""
 "スクリプトで作成されたボリュームに有用である。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1280
+#: manpages/man5/afp.conf.5.md:1294
 msgid "time machine = *BOOLEAN* (default: *no*) **(V)**"
 msgstr "time machine = *BOOLEAN* (デフォルト: *no*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1282
+#: manpages/man5/afp.conf.5.md:1296
 #, no-wrap
 msgid "> Whether to enable Time Machine support for this volume.\n"
 msgstr "> このボリュームの Time Machine サポートを有効にするかどうか。\n"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1284
+#: manpages/man5/afp.conf.5.md:1298
 msgid "unix priv = *BOOLEAN* (default: *yes*) **(V)**"
 msgstr "unix priv = *BOOLEAN* (デフォルト: *yes*) **(V)**"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1287
+#: manpages/man5/afp.conf.5.md:1301
 #, no-wrap
 msgid ""
 "> Whether to use AFP3 UNIX privileges. This should be set for OS X\n"
@@ -3374,13 +3474,13 @@ msgstr ""
 "及び **umask** も参照。\n"
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:1290
+#: manpages/man5/afp.conf.5.md:1304
 #, no-wrap
 msgid "Example: Modern Mac clients"
 msgstr "例：現代の Mac クライアント"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1295
+#: manpages/man5/afp.conf.5.md:1309
 msgid ""
 "This enables Spotlight and AFP stats if Netatalk was built with Spotlight "
 "and AFP stats support. The **mimic model** option is used to make the server "
@@ -3391,12 +3491,12 @@ msgstr ""
 "る。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1297
+#: manpages/man5/afp.conf.5.md:1311
 msgid "The home directory is mounted on */home/{user}/afp-data*."
 msgstr "ホームディレクトリは */home/{user}/afp-data* にマウントされる。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1302
+#: manpages/man5/afp.conf.5.md:1316
 #, no-wrap
 msgid ""
 "    [Global]\n"
@@ -3406,7 +3506,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1306
+#: manpages/man5/afp.conf.5.md:1320
 #, no-wrap
 msgid ""
 "    [Home]\n"
@@ -3415,13 +3515,13 @@ msgid ""
 msgstr ""
 
 #. type: Title ##
-#: manpages/man5/afp.conf.5.md:1307
+#: manpages/man5/afp.conf.5.md:1321
 #, no-wrap
 msgid "Example: Classic Mac clients"
 msgstr "例：レトロ Mac クライアント"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1313
+#: manpages/man5/afp.conf.5.md:1327
 msgid ""
 "This enables AppleTalk if Netatalk was built with AppleTalk support.  The "
 "Random Number and ClearTxt authentication modules are used.  The **legacy "
@@ -3432,7 +3532,7 @@ msgstr ""
 "ションはサーバーを BSD デーモンのように見せるために使われる。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1318
+#: manpages/man5/afp.conf.5.md:1332
 msgid ""
 "With **legacy volume size** the volume size is limited to 2 GB for very old "
 "Macs, while **prodos** is used to enable ProDOS boot flags on the volume "
@@ -3443,7 +3543,7 @@ msgstr ""
 "制限される。"
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1323
+#: manpages/man5/afp.conf.5.md:1337
 #, no-wrap
 msgid ""
 "    [Global]\n"
@@ -3453,7 +3553,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1328
+#: manpages/man5/afp.conf.5.md:1342
 #, no-wrap
 msgid ""
 "    [mac]\n"
@@ -3463,7 +3563,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1333
+#: manpages/man5/afp.conf.5.md:1347
 #, no-wrap
 msgid ""
 "    [apple2]\n"
@@ -3473,7 +3573,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: manpages/man5/afp.conf.5.md:1338
+#: manpages/man5/afp.conf.5.md:1352
 msgid ""
 "afpd(8), afppasswd(5), afp_signature.conf(5), extmap.conf(5), cnid_metad(8)"
 msgstr ""

--- a/doc/po/afp_signature.conf.5.md.ja.po
+++ b/doc/po/afp_signature.conf.5.md.ja.po
@@ -141,7 +141,10 @@ msgid ""
 "**afp_signature.conf** is the configuration file used by **afpd** to store\n"
 "a server signature automagically. The configuration lines are composed\n"
 "like:\n"
-msgstr "**afp_signature.conf** はサーバシグネチャを魔法のように自動的に指定するために **afpd** が利用する設定ファイルである。設定行は以下のように構成される。\n"
+msgstr ""
+"**afp_signature.conf** はサーバシグネチャを魔法のように\n"
+"自動的に指定するために **afpd** が利用する設定ファイルである。\n"
+"設定行は以下のように構成される。\n"
 
 #. type: Plain text
 #: manpages/man5/afp_signature.conf.5.md:12

--- a/doc/po/afp_voluuid.conf.5.md.ja.po
+++ b/doc/po/afp_voluuid.conf.5.md.ja.po
@@ -150,7 +150,10 @@ msgstr ""
 msgid ""
 "**afp_voluuid.conf** is the configuration file used by **afpd** to store\n"
 "UUID of all AFP volumes. The configuration lines are composed like:\n"
-msgstr "**afp_voluuid.conf** は全てのAFPボリュームのUUIDを魔法のように自動的に指定するために **afpd** が利用する設定ファイルである。設定行は以下のように構成される。\n"
+msgstr ""
+"**afp_voluuid.conf** は全てのAFPボリュームのUUIDを魔法のように\n"
+"自動的に指定するために **afpd** が利用する設定ファイルである。\n"
+"設定行は以下のように構成される。\n"
 
 #. type: Plain text
 #: manpages/man5/afp_voluuid.conf.5.md:11

--- a/doc/po/afpd.8.md.ja.po
+++ b/doc/po/afpd.8.md.ja.po
@@ -217,7 +217,9 @@ msgstr ""
 msgid ""
 "**afpd** provides an Apple Filing Protocol (AFP) interface to the Unix\n"
 "file system. It is normally started at boot time by **netatalk**(8).\n"
-msgstr "**afpd**はUnixファイルシステムにApple Filing Protocol (AFP)インターフェースを提供する。これは通常、**netatalk**(8)によってブート時に起動される。\n"
+msgstr ""
+"**afpd**はUnixファイルシステムにApple Filing Protocol (AFP)インターフェースを提供する。\n"
+"これは通常、**netatalk**(8)によってブート時に起動される。\n"
 
 #. type: Plain text
 #: manpages/man8/afpd.8.md:18
@@ -314,7 +316,9 @@ msgid ""
 "> Sending this to the parent **afpd** will cause it to exit,\n"
 "but leaving all children running!\n"
 "This can be used to implement an AFP service without downtime.\n"
-msgstr "> 親**afpd**にこれを送ると全ての子プロセスを終了する。休止時間なしでAFPサービスを実施するのに使われる。\n"
+msgstr ""
+"> 親**afpd**にこれを送ると全ての子プロセスを終了する。\n"
+"休止時間なしでAFPサービスを実施するのに使われる。\n"
 
 #. type: Plain text
 #: manpages/man8/afpd.8.md:64 manpages/man8/netatalk.8.md:38
@@ -362,7 +366,9 @@ msgid ""
 "disabling all new connections.\n"
 msgstr ""
 "> **afpd**プロセスはクライアントに「The server is going down for\n"
-"maintenance.」というメッセージを送り、5分後に自身を終了する。新規接続を許さない。子プロセスのafpdにこれを送った場合、他の子プロセスには影響しない。それでもメインプロセスは終了するだろうし、全ての新規接続は無効になる。\n"
+"maintenance.」というメッセージを送り、5分後に自身を終了する。新規接続を許さない。\n"
+"子プロセスのafpdにこれを送った場合、他の子プロセスには影響しない。\n"
+"それでもメインプロセスは終了するだろうし、全ての新規接続は無効になる。\n"
 
 #. type: Plain text
 #: manpages/man8/afpd.8.md:84
@@ -378,7 +384,11 @@ msgid ""
 "contents will be sent as a message to the associated AFP client. The\n"
 "file is removed after the message is sent. This should only be sent to a\n"
 "child **afpd**.\n"
-msgstr "> **afpd**プロセスはビルド時に設定したメッセージディレクトリの下のmessage.pidという名前のファイルを探する。発見したプロセスについて、その内容をメッセージとして対応するAFPクライアントに送る。メッセージを送った後にファイルは削除される。このシグナルは子プロセスの**afpd**にのみ送るべき。\n"
+msgstr ""
+"> **afpd**プロセスはビルド時に設定したメッセージディレクトリの下の\n"
+"message.pidという名前のファイルを探する。\n"
+"発見したプロセスについて、その内容をメッセージとして対応するAFPクライアントに送る。\n"
+"メッセージを送った後にファイルは削除される。このシグナルは子プロセスの**afpd**にのみ送るべき。\n"
 
 #. type: Plain text
 #: manpages/man8/afpd.8.md:94 manpages/man8/netatalk.8.md:45

--- a/doc/po/afppasswd.1.md.ja.po
+++ b/doc/po/afppasswd.1.md.ja.po
@@ -205,7 +205,9 @@ msgid ""
 "**afppasswd** creates and maintains an *afppasswd* file, which supplies the\n"
 "user credentials for the \"Randnum exchange\" and \"2-Way Randnum exchange\"\n"
 "User Authentication Modules.\n"
-msgstr "**afppasswd** は、「Randnum exchange」および「2-Way Randnum exchange」ユーザー認証モジュールのユーザー資格情報を提供する afppasswd ファイルを作成および管理する。\n"
+msgstr ""
+"**afppasswd** は、「Randnum exchange」および「2-Way Randnum exchange」\n"
+"ユーザー認証モジュールのユーザー資格情報を提供する afppasswd ファイルを作成および管理する。\n"
 
 #. type: Plain text
 #: manpages/man1/afppasswd.1.md:18
@@ -214,7 +216,9 @@ msgid ""
 "**afppasswd** can either be called by root with parameters to manage all\n"
 "user credentials, or by local system users with no parameters to change\n"
 "their own AFP passwords.\n"
-msgstr "**afppasswd**は、rootがパラメータ付きで呼び出すことも、一般のユーザが自分のAFPパスワードを変更するためにパラメータなしで呼び出すこともできる。\n"
+msgstr ""
+"**afppasswd**は、rootがパラメータ付きで呼び出すことも、\n"
+"一般のユーザが自分のAFPパスワードを変更するためにパラメータなしで呼び出すこともできる。\n"
 
 #. type: Plain text
 #: manpages/man1/afppasswd.1.md:23
@@ -292,7 +296,10 @@ msgid ""
 "> If cracklib support is built into *netatalk* this option will cause\n"
 "cracklib checking to be disabled, if the superuser does not want to have\n"
 "the password run against the cracklib dictionary.\n"
-msgstr "> もしcracklibサポートが*netatalk*に組み込まれており、cracklib辞書に対して実行されたパスワードを持つことをスーパユーザが望まないなら、このオプションはcracklibチェックを無効にできるだろう。\n"
+msgstr ""
+"> もしcracklibサポートが*netatalk*に組み込まれており、\n"
+"cracklib辞書に対して実行されたパスワードを持つことをスーパユーザが望まないなら、\n"
+"このオプションはcracklibチェックを無効にできるだろう。\n"
 
 #. type: Plain text
 #: manpages/man1/afppasswd.1.md:58

--- a/doc/po/afptest.1.md.ja.po
+++ b/doc/po/afptest.1.md.ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-05-25 10:43+0200\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -78,8 +78,8 @@ msgid "Description"
 msgstr "説明"
 
 #. type: Title #
-#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:175
-#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:86
+#: manpages/man1/ad.1.md:291 manpages/man1/afptest.1.md:175
+#: manpages/man1/dbd.1.md:68 manpages/man1/nbp.1.md:86
 #: manpages/man5/afp_signature.conf.5.md:44
 #: manpages/man5/afp_voluuid.conf.5.md:36 manpages/man8/papd.8.md:130
 #, no-wrap
@@ -87,21 +87,21 @@ msgid "See also"
 msgstr "参照"
 
 #. type: Title #
-#: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
+#: manpages/man1/ad.1.md:295 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:72 manpages/man1/afpstats.1.md:31
 #: manpages/man1/afptest.1.md:179 manpages/man1/asip-status.1.md:106
-#: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:88
+#: manpages/man1/dbd.1.md:72 manpages/man1/getzones.1.md:88
 #: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:90
 #: manpages/man1/pap.1.md:97 manpages/man1/rtmpqry.1.md:56
 #: manpages/man3/atalk_aton.3.md:28 manpages/man3/nbp_name.3.md:42
 #: manpages/man4/atalk.4.md:49 manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:40 manpages/man5/afp.conf.5.md:1339
+#: manpages/man5/afp_voluuid.conf.5.md:40 manpages/man5/afp.conf.5.md:1353
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
-#: manpages/man8/macipgw.8.md:107 manpages/man8/netatalk.8.md:52
+#: manpages/man8/cnid_dbd.8.md:146 manpages/man8/cnid_metad.8.md:51
+#: manpages/man8/macipgw.8.md:107 manpages/man8/netatalk.8.md:61
 #: manpages/man8/papd.8.md:134 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
@@ -109,21 +109,21 @@ msgid "Author"
 msgstr "著者"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
+#: manpages/man1/ad.1.md:297 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:33
 #: manpages/man1/afptest.1.md:181 manpages/man1/asip-status.1.md:108
-#: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:90
+#: manpages/man1/dbd.1.md:74 manpages/man1/getzones.1.md:90
 #: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:92
 #: manpages/man1/pap.1.md:99 manpages/man1/rtmpqry.1.md:58
 #: manpages/man3/atalk_aton.3.md:30 manpages/man3/nbp_name.3.md:44
 #: manpages/man4/atalk.4.md:51 manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1341
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1355
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:120 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:136
+#: manpages/man8/cnid_dbd.8.md:148 manpages/man8/cnid_metad.8.md:53
+#: manpages/man8/netatalk.8.md:63 manpages/man8/papd.8.md:136
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"
@@ -135,7 +135,7 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 #: manpages/man1/asip-status.1.md:54 manpages/man1/getzones.1.md:57
 #: manpages/man1/nbp.1.md:62 manpages/man1/rtmpqry.1.md:34
 #: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:27 manpages/man5/afp.conf.5.md:1288
+#: manpages/man5/afp_voluuid.conf.5.md:27 manpages/man5/afp.conf.5.md:1302
 #: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
 #: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:78
 #, no-wrap
@@ -169,7 +169,7 @@ msgstr ""
 #: manpages/man1/afptest.1.md:14
 #, no-wrap
 msgid ""
-"**afp_spectest** [-1234567aCiLlmVvXx] [-h *host*] [-H *host2*] [-p *port*] [-s *volume*] [-c *path to volume*]\n"
+"**afp_spectest** [-1234567aCiLlmVvX] [-h *host*] [-H *host2*] [-p *port*] [-s *volume*] [-c *path to volume*]\n"
 "[-S *volume2*] [-u *user*] [-d *user2*] [-w *password*] [-f *test*]\n"
 msgstr ""
 

--- a/doc/po/asip-status.1.md.ja.po
+++ b/doc/po/asip-status.1.md.ja.po
@@ -213,8 +213,10 @@ msgid ""
 "signature\" and the network addresses that the server provides AFP\n"
 "services on.\n"
 msgstr ""
-"**asip-status**は、*HOSTNAME*:*PORT*で示したAFPサーバにFPGetSrvrInfoリクエストを送信し、その結果を表示する。すなわち、そのサーバがAFPサービスで提供する\"Machine\n"
-"type\"、サーバ名、サポートするAFPバージョン、ユーザ認証モジュール(UAM)、AFPフラグ、サーバシグネチャ、ネットワークアドレスである。\n"
+"**asip-status**は、*HOSTNAME*:*PORT*で示したAFPサーバにFPGetSrvrInfoリクエストを送信し、\n"
+"その結果を表示する。すなわち、そのサーバがAFPサービスで提供する\"Machine\n"
+"type\"、サーバ名、サポートするAFPバージョン、ユーザ認証モジュール(UAM)、\n"
+"AFPフラグ、サーバシグネチャ、ネットワークアドレスである。\n"
 
 #. type: Plain text
 #: manpages/man1/asip-status.1.md:23

--- a/doc/po/atalkd.8.md.ja.po
+++ b/doc/po/atalkd.8.md.ja.po
@@ -219,7 +219,11 @@ msgid ""
 "the AppleTalk Echo Protocol (similar to **ping**(8)). Specifically, this\n"
 "corresponds to the RTMP, NBP, ZIP, and AEP protocols in the AppleTalk\n"
 "protocol family.\n"
-msgstr "**atalkd** は、すべてのユーザー レベルの AppleTalk ネットワーク管理を担当する。これには、ルーティング、名前の登録と検索、ゾーン検索、および AppleTalk Echo プロトコル (**ping**(8) に類似)  が含まれる。具体的には、AppleTalk プロトコル ファミリの RTMP、NBP、ZIP、および AEP プロトコルに対応する。\n"
+msgstr ""
+"**atalkd** は、すべてのユーザー レベルの AppleTalk ネットワーク管理を担当する。\n"
+"これには、ルーティング、名前の登録と検索、ゾーン検索、および AppleTalk Echo プロトコル \n"
+"(**ping**(8) に類似)  が含まれる。\n"
+"具体的には、AppleTalk プロトコル ファミリの RTMP、NBP、ZIP、および AEP プロトコルに対応する。\n"
 
 #. type: Plain text
 #: manpages/man8/atalkd.8.md:25
@@ -334,7 +338,13 @@ msgid ""
 "for startup). It is best to choose the smallest useful net-range, i.e.\n"
 "if you have three machines on a LAN, choose a net-range below 1000. Each\n"
 "net-range may have an arbitrary list of zones associated with it.\n"
-msgstr "**atalkd**は、複数のインターフェイスを構成することでインターフェイス間のルーティングを提供できる。各インターフェースには、1から 65279 までの一意のネット範囲 を割り当てる必要がある (0 から 65535 は無効で、65280 から 65534までのアドレスは起動用に予約されている)。最も小さい有効なネット範囲を選択するのが最善。つまり、LAN上に 3 台のマシンがある場合は、1000未満のネット範囲を選択する。各ネット範囲には任意のリストを設定できる。\n"
+msgstr ""
+"**atalkd**は、複数のインターフェイスを構成することでインターフェイス間のルーティングを提供できる。\n"
+"各インターフェースには、1から 65279 までの一意のネット範囲 を割り当てる必要がある \n"
+"(0 から 65535 は無効で、65280 から 65534までのアドレスは起動用に予約されている)。\n"
+"最も小さい有効なネット範囲を選択するのが最善。\n"
+"つまり、LAN上に 3 台のマシンがある場合は、1000未満のネット範囲を選択する。\n"
+"各ネット範囲には任意のリストを設定できる。\n"
 
 #. type: Plain text
 #: manpages/man8/atalkd.8.md:74

--- a/doc/po/atalkd.conf.5.md.ja.po
+++ b/doc/po/atalkd.conf.5.md.ja.po
@@ -242,7 +242,9 @@ msgstr ""
 msgid ""
 "> Allows specification of the net and node numbers for this interface,\n"
 "specified in AppleTalk numbering format (example: **-addr 66.6**).\n"
-msgstr "このインターフェイスのネット番号とノード番号を指定できる。AppleTalk 番号形式 (例: **-addr 66.6**) で指定する。\n"
+msgstr ""
+"このインターフェイスのネット番号とノード番号を指定できる。\n"
+"AppleTalk 番号形式 (例: **-addr 66.6**) で指定する。\n"
 
 #. type: Plain text
 #: manpages/man5/atalkd.conf.5.md:50
@@ -294,7 +296,9 @@ msgstr ""
 msgid ""
 "> Seed an AppleTalk router on a single interface. The inverse option is\n"
 "**-dontroute**. Akin to **-seed**, but allows single interface routing.\n"
-msgstr "> 単一のインターフェイスで AppleTalk ルーターをシードする。逆の オプションは**-dontroute**。 **-seed**に似ているが、単一インターフェイス ルーティング。\n"
+msgstr ""
+"> 単一のインターフェイスで AppleTalk ルーターをシードする。\n"
+"逆の オプションは**-dontroute**。 **-seed**に似ているが、単一インターフェイス ルーティング。\n"
 
 #. type: Plain text
 #: manpages/man5/atalkd.conf.5.md:68
@@ -310,7 +314,10 @@ msgid ""
 "configured. If you have a single network interface, use **-router**\n"
 "instead. It also causes all missing arguments to be automagically\n"
 "configured from the network.\n"
-msgstr "> AppleTalk ルーターをシードする。これには、2 つ以上のインターフェイスを構成する必要がある。単一のネットワーク インターフェイスがある場合は、代わりに **-router** を使用する。これにより、不足しているすべての引数がネットワークから自動的に構成される。\n"
+msgstr ""
+"> AppleTalk ルーターをシードする。これには、2 つ以上のインターフェイスを構成する必要がある。\n"
+"単一のネットワーク インターフェイスがある場合は、代わりに **-router** を使用する。\n"
+"これにより、不足しているすべての引数がネットワークから自動的に構成される。\n"
 
 #. type: Plain text
 #: manpages/man5/atalkd.conf.5.md:75
@@ -325,7 +332,9 @@ msgid ""
 "> Specifies a specific zone that this interface should appear on (example:\n"
 "**-zone \"Parking Lot\"**). Please note that zones with spaces and other\n"
 "special characters should be enclosed in quotation marks.\n"
-msgstr "> このインターフェイスが表示される特定のゾーンを指定する (例: **-zone** \"Parking Lot\")。スペースやその他の特殊文字を含むゾーンは、ダブルクォーテーションで囲む必要があることに注意してください。\n"
+msgstr ""
+"> このインターフェイスが表示される特定のゾーンを指定する (例: **-zone** \"Parking Lot\")。\n"
+"スペースやその他の特殊文字を含むゾーンは、ダブルクォーテーションで囲む必要があることに注意してください。\n"
 
 #. type: Plain text
 #: manpages/man5/atalkd.conf.5.md:83

--- a/doc/po/cnid_dbd.8.md.ja.po
+++ b/doc/po/cnid_dbd.8.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-04-26 22:52+0200\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -24,9 +24,9 @@ msgstr ""
 #: manpages/man1/afptest.1.md:1 manpages/man1/asip-status.1.md:1
 #: manpages/man1/dbd.1.md:1 manpages/man1/getzones.1.md:1
 #: manpages/man1/macusers.1.md:1 manpages/man1/nbp.1.md:1
-#: manpages/man1/pap.1.md:1 manpages/man3/atalk_aton.3.md:1
-#: manpages/man3/nbp_name.3.md:1 manpages/man4/atalk.4.md:1
-#: manpages/man5/afp_signature.conf.5.md:1
+#: manpages/man1/pap.1.md:1 manpages/man1/rtmpqry.1.md:1
+#: manpages/man3/atalk_aton.3.md:1 manpages/man3/nbp_name.3.md:1
+#: manpages/man4/atalk.4.md:1 manpages/man5/afp_signature.conf.5.md:1
 #: manpages/man5/afp_voluuid.conf.5.md:1 manpages/man5/afp.conf.5.md:1
 #: manpages/man5/atalkd.conf.5.md:1 manpages/man5/extmap.conf.5.md:1
 #: manpages/man5/papd.conf.5.md:1 manpages/man8/a2boot.8.md:1
@@ -46,14 +46,14 @@ msgstr "名前"
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
 #: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
-#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
-#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
-#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
-#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
-#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
-#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
-#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
-#: manpages/man8/timelord.8.md:5
+#: manpages/man1/pap.1.md:5 manpages/man1/rtmpqry.1.md:5
+#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
+#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
+#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
+#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
+#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
+#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
+#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -62,12 +62,12 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:22 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
 #: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
-#: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
-#: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
-#: manpages/man5/afp_signature.conf.5.md:5
+#: manpages/man1/pap.1.md:9 manpages/man1/rtmpqry.1.md:9
+#: manpages/man3/atalk_aton.3.md:14 manpages/man3/nbp_name.3.md:16
+#: manpages/man4/atalk.4.md:10 manpages/man5/afp_signature.conf.5.md:5
 #: manpages/man5/afp_voluuid.conf.5.md:5 manpages/man5/atalkd.conf.5.md:5
 #: manpages/man5/extmap.conf.5.md:5 manpages/man5/papd.conf.5.md:5
 #: manpages/man8/a2boot.8.md:11 manpages/man8/afpd.8.md:11
@@ -80,43 +80,43 @@ msgid "Description"
 msgstr "説明"
 
 #. type: Title #
-#: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
+#: manpages/man1/ad.1.md:295 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
-#: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
-#: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
-#: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1353
+#: manpages/man1/afppasswd.1.md:72 manpages/man1/afpstats.1.md:31
+#: manpages/man1/afptest.1.md:179 manpages/man1/asip-status.1.md:106
+#: manpages/man1/dbd.1.md:72 manpages/man1/getzones.1.md:88
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:90
+#: manpages/man1/pap.1.md:97 manpages/man1/rtmpqry.1.md:56
+#: manpages/man3/atalk_aton.3.md:28 manpages/man3/nbp_name.3.md:42
+#: manpages/man4/atalk.4.md:49 manpages/man5/afp_signature.conf.5.md:48
+#: manpages/man5/afp_voluuid.conf.5.md:40 manpages/man5/afp.conf.5.md:1353
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
-#: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:82
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
-#: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
-#: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
+#: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:83
+#: manpages/man8/cnid_dbd.8.md:146 manpages/man8/cnid_metad.8.md:51
+#: manpages/man8/macipgw.8.md:107 manpages/man8/netatalk.8.md:61
+#: manpages/man8/papd.8.md:134 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
 msgid "Author"
 msgstr "著者"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
+#: manpages/man1/ad.1.md:297 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
-#: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
-#: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
-#: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:52
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1355
+#: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:33
+#: manpages/man1/afptest.1.md:181 manpages/man1/asip-status.1.md:108
+#: manpages/man1/dbd.1.md:74 manpages/man1/getzones.1.md:90
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:92
+#: manpages/man1/pap.1.md:99 manpages/man1/rtmpqry.1.md:58
+#: manpages/man3/atalk_aton.3.md:30 manpages/man3/nbp_name.3.md:44
+#: manpages/man4/atalk.4.md:51 manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1355
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
-#: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:84
-#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
+#: manpages/man8/afpd.8.md:120 manpages/man8/atalkd.8.md:85
+#: manpages/man8/cnid_dbd.8.md:148 manpages/man8/cnid_metad.8.md:53
+#: manpages/man8/netatalk.8.md:63 manpages/man8/papd.8.md:136
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"
@@ -124,39 +124,39 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 
 #. type: Title #
 #: manpages/man1/addump.1.md:29 manpages/man1/aecho.1.md:40
-#: manpages/man1/afpldaptest.1.md:16 manpages/man1/afppasswd.1.md:35
-#: manpages/man1/asip-status.1.md:28 manpages/man1/dbd.1.md:17
+#: manpages/man1/afpldaptest.1.md:16 manpages/man1/afppasswd.1.md:33
+#: manpages/man1/asip-status.1.md:28 manpages/man1/dbd.1.md:21
 #: manpages/man1/getzones.1.md:16 manpages/man1/macusers.1.md:15
-#: manpages/man1/pap.1.md:29 manpages/man8/a2boot.8.md:32
-#: manpages/man8/afpd.8.md:19 manpages/man8/atalkd.8.md:26
-#: manpages/man8/cnid_dbd.8.md:57 manpages/man8/cnid_metad.8.md:18
-#: manpages/man8/macipgw.8.md:39 manpages/man8/netatalk.8.md:17
-#: manpages/man8/papd.8.md:37 manpages/man8/papstatus.8.md:24
-#: manpages/man8/timelord.8.md:23
+#: manpages/man1/pap.1.md:29 manpages/man1/rtmpqry.1.md:15
+#: manpages/man8/a2boot.8.md:32 manpages/man8/afpd.8.md:19
+#: manpages/man8/atalkd.8.md:26 manpages/man8/cnid_dbd.8.md:58
+#: manpages/man8/cnid_metad.8.md:21 manpages/man8/macipgw.8.md:38
+#: manpages/man8/netatalk.8.md:26 manpages/man8/papd.8.md:37
+#: manpages/man8/papstatus.8.md:24 manpages/man8/timelord.8.md:23
 #, no-wrap
 msgid "Options"
 msgstr "オプション"
 
 #. type: Title #
 #: manpages/man1/addump.1.md:68 manpages/man1/aecho.1.md:46
-#: manpages/man1/afpldaptest.1.md:34 manpages/man1/afppasswd.1.md:70
-#: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
+#: manpages/man1/afpldaptest.1.md:34 manpages/man1/afppasswd.1.md:68
+#: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:84
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
-#: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1348 manpages/man5/atalkd.conf.5.md:98
-#: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
-#: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:78
-#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
-#: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
-#: manpages/man8/papstatus.8.md:49
+#: manpages/man1/rtmpqry.1.md:52 manpages/man3/atalk_aton.3.md:24
+#: manpages/man4/atalk.4.md:45 manpages/man5/afp.conf.5.md:1348
+#: manpages/man5/atalkd.conf.5.md:98 manpages/man5/extmap.conf.5.md:28
+#: manpages/man5/papd.conf.5.md:164 manpages/man8/afpd.8.md:112
+#: manpages/man8/atalkd.8.md:79 manpages/man8/cnid_dbd.8.md:142
+#: manpages/man8/cnid_metad.8.md:47 manpages/man8/macipgw.8.md:98
+#: manpages/man8/netatalk.8.md:57 manpages/man8/papstatus.8.md:49
 #, no-wrap
 msgid "See Also"
 msgstr "関連項目"
 
 #. type: Plain text
-#: manpages/man8/a2boot.8.md:43 manpages/man8/atalkd.8.md:54
-#: manpages/man8/cnid_dbd.8.md:60 manpages/man8/macipgw.8.md:68
-#: manpages/man8/netatalk.8.md:28 manpages/man8/papd.8.md:58
+#: manpages/man8/a2boot.8.md:43 manpages/man8/atalkd.8.md:55
+#: manpages/man8/cnid_dbd.8.md:61 manpages/man8/macipgw.8.md:67
+#: manpages/man8/netatalk.8.md:37 manpages/man8/papd.8.md:58
 #: manpages/man8/timelord.8.md:39
 #, no-wrap
 msgid "**-v** | **-V**\n"
@@ -180,38 +180,56 @@ msgid "**cnid_dbd** [-v | -V]\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:19
+#: manpages/man8/cnid_dbd.8.md:16
 #, no-wrap
 msgid ""
 "**cnid_dbd** provides an interface for storage and retrieval of catalog\n"
-"node IDs (CNIDs) and related information to the *afpd* daemon. CNIDs are\n"
-"a component of Macintosh based file systems with semantics that map not\n"
-"easily onto Unix file systems. This makes separate storage in a database\n"
-"necessary. **cnid_dbd** is part of the *CNID backend* framework of *afpd*\n"
-"and implements the *dbd* backend.\n"
-msgstr "**cnid_dbd**はストレージとカタログノードID (CNID)と関連情報の検索のためのインターフェースを*afpd*デーモンに提供する。CNIDはMacintoshベースのファイルシステムの構成要素であるが、これの動作は単純にはUnixファイルシステム上にマッピングできない。従って、一つのデータベース内に分離した記憶域が必要となる。**cnid_dbd**は*afpd*の*CNIDバックエンド*の一つであり、*dbd*バックエンドを実装する。\n"
+"node IDs (CNIDs) and related information to the *afpd* daemon\n"
+"when using the *dbd* (Database Daemon) CNID backend.\n"
+msgstr ""
+"**cnid_dbd**はストレージとカタログノードID (CNID)と関連情報の検索のための\n"
+"インターフェースを*afpd*デーモンに提供する。\n"
+"*dbd* (Database Daemon) CNIDバックエンドを使う際に実行される。\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:23
+#: manpages/man8/cnid_dbd.8.md:20
+msgid ""
+"CNIDs are a component of Classic Mac OS based file systems with semantics "
+"that does not map easily onto Unix file systems.  This makes separate "
+"storage in a database necessary."
+msgstr ""
+"CNIDはClassic Mac OSのファイルシステムの構成要素であるが、これの動作は単純に"
+"はUnixファイルシステム上にマッピングできない。従って、一つのデータベース内に"
+"分離した記憶域が必要となる。"
+
+#. type: Plain text
+#: manpages/man8/cnid_dbd.8.md:24
 #, no-wrap
 msgid ""
 "**cnid_dbd** is never started via the command line or system startup\n"
 "scripts but only by the *cnid_metad* daemon. There is one instance of\n"
 "**cnid_dbd** per netatalk volume.\n"
-msgstr "**cnid_dbd**はコマンドラインやシステム起動スクリプトではなく、*cnid_metad*デーモンによって起動する。netatalkボリューム一つにつき、**cnid_dbd**のインスタンスが一つである。\n"
+msgstr ""
+"**cnid_dbd**はコマンドラインやシステム起動スクリプトではなく、\n"
+"*cnid_metad*デーモンによって起動する。netatalkボリューム一つにつき、\n"
+"**cnid_dbd**のインスタンスが一つである。\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:28
+#: manpages/man8/cnid_dbd.8.md:29
 #, no-wrap
 msgid ""
 "**cnid_dbd** uses the *Berkeley DB* database library and uses\n"
 "transactionally protected updates. The *dbd* backend with transactions\n"
 "will avoid corruption of the CNID database even if the system crashes\n"
 "unexpectedly.\n"
-msgstr "**cnid_dbd**は*Berkeley DB*データベースライブラリを用いて、トランザクションで保護したアップデートを行う。トランザクションによる*dbd*バックエンドは、たとえシステムが不意にクラッシュしても、CNIDデータベースの破損を防ぐだろう。\n"
+msgstr ""
+"**cnid_dbd**は*Berkeley DB*データベースライブラリを用いて、\n"
+"トランザクションで保護したアップデートを行う。\n"
+"トランザクションによる*dbd*バックエンドは、たとえシステムが不意にクラッシュしても、\n"
+"CNIDデータベースの破損を防ぐだろう。\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:40
+#: manpages/man8/cnid_dbd.8.md:41
 #, no-wrap
 msgid ""
 "**cnid_dbd** inherits the effective userid and groupid from *cnid_metad*\n"
@@ -225,10 +243,20 @@ msgid ""
 "*clntfd*. Subsequent instances of *afpd* that want to access the same\n"
 "volume are redirected to the running **cnid_dbd** process by *cnid_metad*\n"
 "via the filedescriptor *ctrlfd*.\n"
-msgstr "**cnid_dbd**は起動時に*cnid_metad*からの有効なユーザIDとグループIDを継承する。普通、この動作はnetatalkボリュームをクライアントへ提供する*afpd*によって生じる。それはボリュームに関連付けられた*Berkeley DB*データベースのホームディレクトリ*dbdir*を変更する。もし*cnid_metad*から継承したユーザIDが0 (root)ならば、**cnid_dbd**はユーザIDとグループIDをデータベースホームディレクトリの所有者とグループに変更する。そうでない場合は、継承した値を使い続ける。このとき、**cnid_dbd**はデータベースを開き、ファイル記述子*clntfd*を使って要求されたものを提供開始する。同じボリュームへアクセスしようとする次の*afpd*のインスタンスは、ファイル記述子*ctrlfd*を用いる*cnid_metad*によって、既に動いている**cnid_dbd**へリダイレクトされる。\n"
+msgstr ""
+"**cnid_dbd**は起動時に*cnid_metad*からの有効なユーザIDとグループIDを継承する。\n"
+"普通、この動作はnetatalkボリュームをクライアントへ提供する*afpd*によって生じる。\n"
+"それはボリュームに関連付けられた*Berkeley DB*データベースのホームディレクトリ*dbdir*を変更する。\n"
+"もし*cnid_metad*から継承したユーザIDが0 (root)ならば、\n"
+"**cnid_dbd**はユーザIDとグループIDをデータベースホームディレクトリの所有者とグループに変更する。\n"
+"そうでない場合は、継承した値を使い続ける。このとき、**cnid_dbd**はデータベースを開き、\n"
+"ファイル記述子*clntfd*を使って要求されたものを提供開始する。\n"
+"同じボリュームへアクセスしようとする次の*afpd*のインスタンスは、\n"
+"ファイル記述子*ctrlfd*を用いる*cnid_metad*によって、\n"
+"既に動いている**cnid_dbd**へリダイレクトされる。\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:49
+#: manpages/man8/cnid_dbd.8.md:50
 #, no-wrap
 msgid ""
 "**cnid_dbd** can be configured to run forever or to exit after a period of\n"
@@ -239,10 +267,17 @@ msgid ""
 "handled and will cause an immediate exit, possibly leaving the CNID\n"
 "database in an inconsistent state (no transactions) or losing recent\n"
 "updates during recovery (transactions).\n"
-msgstr "**cnid_dbd**は、永久に動作するか、または不活性期間の後に終了するかを設定できる。もし**cnid_dbd**がTERMやINTシグナルを受け取った場合、汚れたデータベースバッファをディスクにフラッシュし、*Berkeley DB*データベース環境を閉じてから、綺麗に終了する。この方法で**cnid_dbd**を終了するのは安全な事であり、もし必要なら再起動する。他のシグナルは処理されず、即座に終了するか、もしかすると(トランザクションなしのとき)CNIDデータベースを矛盾した状態のままにしておくか、(トランザクションありのとき)リカバリ中の直近の更新を失うかするだろう。\n"
+msgstr ""
+"**cnid_dbd**は、永久に動作するか、または不活性期間の後に終了するかを設定できる。\n"
+"もし**cnid_dbd**がTERMやINTシグナルを受け取った場合、\n"
+"汚れたデータベースバッファをディスクにフラッシュし、*Berkeley DB*データベース環境を閉じてから、\n"
+"綺麗に終了する。この方法で**cnid_dbd**を終了するのは安全な事であり、もし必要なら再起動する。\n"
+"他のシグナルは処理されず、即座に終了するか、もしかすると(トランザクションなしのとき)\n"
+"CNIDデータベースを矛盾した状態のままにしておくか、\n"
+"(トランザクションありのとき)リカバリ中の直近の更新を失うかするだろう。\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:56
+#: manpages/man8/cnid_dbd.8.md:57
 msgid ""
 "The *Berkeley DB* database subsystem will create files named log.xxxxxxxxxx "
 "in the database home directory *dbdir*, where xxxxxxxxxx is a monotonically "
@@ -260,19 +295,19 @@ msgstr ""
 "期的に削除される。"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:62 manpages/man8/cnid_metad.8.md:33
+#: manpages/man8/cnid_dbd.8.md:63 manpages/man8/cnid_metad.8.md:36
 #, no-wrap
 msgid "> Show version and exit.\n"
 msgstr "> バージョンを表示してから終了する。\n"
 
 #. type: Title ###
-#: manpages/man8/cnid_dbd.8.md:63 manual/Configuration.md:572
+#: manpages/man8/cnid_dbd.8.md:64 manual/Configuration.md:587
 #, no-wrap
 msgid "Configuration"
 msgstr "設定"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:71
+#: manpages/man8/cnid_dbd.8.md:72
 #, no-wrap
 msgid ""
 "**cnid_dbd** reads configuration information from the file *db_param* in\n"
@@ -281,16 +316,20 @@ msgid ""
 "for a single parameter is the parameter name, followed by one or more\n"
 "spaces, followed by the parameter value, followed by a newline. The\n"
 "following parameters are currently recognized:\n"
-msgstr "**cnid_dbd**は起動時、データベースディレクトリ*dbdir* の中のファイル*db_param*から設定情報を読む。ファイルがない場合やパラメータが載っていない場合、適切なデフォルト値が使われる。ひとつのパラメータのフォーマットは、まずパラメータ名、それに続く一つ以上のスペース、それに続くパラメータ値、それに続く改行で構成される。現在以下のパラメータが認識される:\n"
+msgstr ""
+"**cnid_dbd**は起動時、データベースディレクトリ*dbdir* の中のファイル*db_param*から設定情報を読む。\n"
+"ファイルがない場合やパラメータが載っていない場合、適切なデフォルト値が使われる。\n"
+"ひとつのパラメータのフォーマットは、まずパラメータ名、それに続く一つ以上のスペース、\n"
+"それに続くパラメータ値、それに続く改行で構成される。現在以下のパラメータが認識される:\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:73
+#: manpages/man8/cnid_dbd.8.md:74
 #, no-wrap
 msgid "**logfile_autoremove**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:77
+#: manpages/man8/cnid_dbd.8.md:78
 #, no-wrap
 msgid ""
 "> If set to 0, unused Berkeley DB transactional logfiles (log.xxxxxxxxxx\n"
@@ -298,16 +337,17 @@ msgid ""
 "and on a regular basis. Default: 1.\n"
 msgstr ""
 "> もし0を設定した場合、**cnid_dbd**の起動時に未使用のBerkeley\n"
-"DBトランザクションのログファイル(データベースホームディレクトリの中のlog.xxxxxxxxxx)の定期的な削除が行われない。デフォルトは1。\n"
+"DBトランザクションのログファイル(データベースホームディレクトリの中のlog.xxxxxxxxxx)の定期的な\n"
+"削除が行われない。デフォルトは1。\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:79
+#: manpages/man8/cnid_dbd.8.md:80
 #, no-wrap
 msgid "**cachesize**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:90
+#: manpages/man8/cnid_dbd.8.md:91
 #, no-wrap
 msgid ""
 "> Determines the size of the Berkeley DB cache in kilobytes.\n"
@@ -321,20 +361,24 @@ msgid ""
 "*Berkeley DB Tutorial and Reference Guide* has a section *Selecting a\n"
 "cache size* that gives more detailed information.\n"
 msgstr ""
-"> Berkeley\n"
-"DBのキャッシュサイズをキロバイト単位で決定する。デフォルトは8192。それぞれの**cnid_dbd**プロセスは通常のメモリ占有量に加えて大量のメモリを獲得する。これはデータベースのパフォーマンスを調整するのに使われる。Berkeley\n"
-"DBに附属する*db_stat*ユーティリティに**-m**オプションを付けると、この値を変更すべきかどうかを決定するのに役立つ。デフォルトではキャッシュが要求の大半を丁度良く満たすように極めて保守的な値になっている。メモリがシステムのボトルネックにならないなら、あなたはその値を放置してよい。*Berkeley\n"
-"DB Tutorial and Reference Guide*には、より詳しい情報を記した*Selecting a\n"
-"cache size*という章がある。\n"
+"> Berkeley DBのキャッシュサイズをキロバイト単位で決定する。\n"
+"デフォルトは8192。それぞれの**cnid_dbd**プロセスは通常のメモリ占有量に加えて大量のメモリを獲得する。\n"
+"これはデータベースのパフォーマンスを調整するのに使われる。\n"
+"Berkeley DBに附属する*db_stat*ユーティリティに**-m**オプションを付けると、\n"
+"この値を変更すべきかどうかを決定するのに役立つ。\n"
+"デフォルトではキャッシュが要求の大半を丁度良く満たすように極めて保守的な値になっている。\n"
+"メモリがシステムのボトルネックにならないなら、あなたはその値を放置してよい。\n"
+"*Berkeley DB Tutorial and Reference Guide*には、より詳しい情報を記した\n"
+"*Selecting a cache size*という章がある。\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:92
+#: manpages/man8/cnid_dbd.8.md:93
 #, no-wrap
 msgid "**flush_frequency**; **flush_interval**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:101
+#: manpages/man8/cnid_dbd.8.md:102
 #, no-wrap
 msgid ""
 "> **flush_frequency** (Default: 1000) and **flush_interval** (Default: 1800)\n"
@@ -349,16 +393,19 @@ msgstr ""
 "> **flush_frequency** (デフォルト: 1000)と**flush_interval** (デフォルト:\n"
 "1800)はデータベースへの変更を書き戻す頻度を制御する。これらの両方動作は、i)\n"
 "**flush_frequency**を越える要求を受け取った場合、ii)\n"
-"最後の保存/書き戻しから**flush_interval**秒よりも経過した場合のどちらかで実行される。ディスクキャッシュ設定のため、あなたのハードディスク設定の確認に慎重を期してください。多くのIDEディスクはデフォルト動作では書き込みを単にキャッシュするだけ。従って、たとえデータベースファイルをフラッシュしても期待した効果は得られないでしょう。\n"
+"最後の保存/書き戻しから**flush_interval**秒よりも経過した場合のどちらかで実行される。\n"
+"ディスクキャッシュ設定のため、あなたのハードディスク設定の確認に慎重を期してください。\n"
+"多くのIDEディスクはデフォルト動作では書き込みを単にキャッシュするだけ。\n"
+"従って、たとえデータベースファイルをフラッシュしても期待した効果は得られないでしょう。\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:103
+#: manpages/man8/cnid_dbd.8.md:104
 #, no-wrap
 msgid "**fd_table_size**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:114
+#: manpages/man8/cnid_dbd.8.md:115
 #, no-wrap
 msgid ""
 "> is the maximum number of connections (filedescriptors) that can be open\n"
@@ -371,30 +418,41 @@ msgid ""
 "process limit of open file descriptors on your system. It is safe to set\n"
 "the value to 1 on volumes where only one *afpd* client process is\n"
 "expected to run, e.g. home directories.\n"
-msgstr "> *afpd*クライアントが*cnid_dbd*で処理するために開く最大の接続数(ファイル記述子数)。デフォルトは512。この値を超えた場合、存在する接続のうち一つを閉じて再利用する。影響を受けた*afpd*プロセスは後に透過的に再接続される。これは僅かなオーバヘッドを生じる。一方、全ての記述子を*select()*システムコールでチェックしなければならないので、このパラメータを極めて高い値に設定すると**cnid_dbd**のパフォーマンスに影響するかもしれないし、更に悪いことにプロセスあたりに開くファイル記述子のシステム上の上限を超えるかもしれない。たった一つの*afpd*クライアントプロセスが動作すると予想されるボリュームでは、この値を1に設定すると安全である。例えばホームディレクトリである。\n"
+msgstr ""
+"> *afpd*クライアントが*cnid_dbd*で処理するために開く最大の接続数(ファイル記述子数)。\n"
+"デフォルトは512。この値を超えた場合、存在する接続のうち一つを閉じて再利用する。\n"
+"影響を受けた*afpd*プロセスは後に透過的に再接続される。\n"
+"これは僅かなオーバヘッドを生じる。\n"
+"一方、全ての記述子を*select()*システムコールでチェックしなければならないので、\n"
+"このパラメータを極めて高い値に設定すると**cnid_dbd**のパフォーマンスに影響するかもしれないし、\n"
+"更に悪いことにプロセスあたりに開くファイル記述子のシステム上の上限を超えるかもしれない。\n"
+"たった一つの*afpd*クライアントプロセスが動作すると予想されるボリュームでは、\n"
+"この値を1に設定すると安全である。例えばホームディレクトリである。\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:116
+#: manpages/man8/cnid_dbd.8.md:117
 #, no-wrap
 msgid "**idle_timeout**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:119
+#: manpages/man8/cnid_dbd.8.md:120
 #, no-wrap
 msgid ""
 "> is the number of seconds of inactivity before an idle **cnid_dbd** exits.\n"
 "Default: 600. Set this to 0 to disable the timeout.\n"
-msgstr "> アイドリング中の**cnid_dbd**が終了するまでの静止状態の秒数。デフォルトは600。これを0に設定するとタイムアウトが無効になる。\n"
+msgstr ""
+"> アイドリング中の**cnid_dbd**が終了するまでの静止状態の秒数。\n"
+"デフォルトは600。これを0に設定するとタイムアウトが無効になる。\n"
 
 #. type: Title #
-#: manpages/man8/cnid_dbd.8.md:120
+#: manpages/man8/cnid_dbd.8.md:121
 #, no-wrap
 msgid "Updating"
 msgstr "アップデート"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:124
+#: manpages/man8/cnid_dbd.8.md:125
 msgid ""
 "Starting with Netatalk 2.1.1, automatic Berkeley DB updates are supported, "
 "as long as Netatalk 2.1.0 or later was used to create the database."
@@ -403,7 +461,7 @@ msgstr ""
 "アップデートがサポートされる。"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:127
+#: manpages/man8/cnid_dbd.8.md:128
 msgid ""
 "In order to update between older Netatalk releases using different Berkeley "
 "DB library versions, follow these steps:"
@@ -412,12 +470,12 @@ msgstr ""
 "するためには、以下の手順をとる:"
 
 #. type: Bullet: '- '
-#: manpages/man8/cnid_dbd.8.md:129
+#: manpages/man8/cnid_dbd.8.md:130
 msgid "Stop the to be upgraded old version of Netatalk"
 msgstr "これからアップグレードする古いバージョンのNetatalkを停止する"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:132
+#: manpages/man8/cnid_dbd.8.md:133
 msgid ""
 "- Using the old Berkeley DB utilities run *db_recover -h path/to/.AppleDB*"
 msgstr ""
@@ -425,7 +483,7 @@ msgstr ""
 "行する"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:135
+#: manpages/man8/cnid_dbd.8.md:136
 msgid ""
 "- Using the new Berkeley DB utilities run *db_upgrade -v -h path/to/.AppleDB "
 "-f cnid2.db*"
@@ -434,7 +492,7 @@ msgstr ""
 "-f cnid2.db* を実行する"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:138
+#: manpages/man8/cnid_dbd.8.md:139
 msgid ""
 "- Again using the new Berkeley DB utilities run *db_checkpoint -1 -h path/"
 "to/.AppleDB*"
@@ -443,11 +501,11 @@ msgstr ""
 "のパス* を実行する"
 
 #. type: Bullet: '- '
-#: manpages/man8/cnid_dbd.8.md:140
+#: manpages/man8/cnid_dbd.8.md:141
 msgid "Start the the new version of Netatalk"
 msgstr "新しいバージョンのNetatalkを起動する"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:144
+#: manpages/man8/cnid_dbd.8.md:145
 msgid "cnid_metad(8), afpd(8), dbd(1)"
 msgstr ""

--- a/doc/po/cnid_metad.8.md.ja.po
+++ b/doc/po/cnid_metad.8.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-04-26 22:52+0200\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -24,9 +24,9 @@ msgstr ""
 #: manpages/man1/afptest.1.md:1 manpages/man1/asip-status.1.md:1
 #: manpages/man1/dbd.1.md:1 manpages/man1/getzones.1.md:1
 #: manpages/man1/macusers.1.md:1 manpages/man1/nbp.1.md:1
-#: manpages/man1/pap.1.md:1 manpages/man3/atalk_aton.3.md:1
-#: manpages/man3/nbp_name.3.md:1 manpages/man4/atalk.4.md:1
-#: manpages/man5/afp_signature.conf.5.md:1
+#: manpages/man1/pap.1.md:1 manpages/man1/rtmpqry.1.md:1
+#: manpages/man3/atalk_aton.3.md:1 manpages/man3/nbp_name.3.md:1
+#: manpages/man4/atalk.4.md:1 manpages/man5/afp_signature.conf.5.md:1
 #: manpages/man5/afp_voluuid.conf.5.md:1 manpages/man5/afp.conf.5.md:1
 #: manpages/man5/atalkd.conf.5.md:1 manpages/man5/extmap.conf.5.md:1
 #: manpages/man5/papd.conf.5.md:1 manpages/man8/a2boot.8.md:1
@@ -46,14 +46,14 @@ msgstr "名前"
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
 #: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
-#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
-#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
-#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
-#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
-#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
-#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
-#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
-#: manpages/man8/timelord.8.md:5
+#: manpages/man1/pap.1.md:5 manpages/man1/rtmpqry.1.md:5
+#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
+#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
+#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
+#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
+#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
+#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
+#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -62,12 +62,12 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:22 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
 #: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
-#: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
-#: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
-#: manpages/man5/afp_signature.conf.5.md:5
+#: manpages/man1/pap.1.md:9 manpages/man1/rtmpqry.1.md:9
+#: manpages/man3/atalk_aton.3.md:14 manpages/man3/nbp_name.3.md:16
+#: manpages/man4/atalk.4.md:10 manpages/man5/afp_signature.conf.5.md:5
 #: manpages/man5/afp_voluuid.conf.5.md:5 manpages/man5/atalkd.conf.5.md:5
 #: manpages/man5/extmap.conf.5.md:5 manpages/man5/papd.conf.5.md:5
 #: manpages/man8/a2boot.8.md:11 manpages/man8/afpd.8.md:11
@@ -80,10 +80,10 @@ msgid "Description"
 msgstr "説明"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:54 manpages/man1/asip-status.1.md:39
+#: manpages/man1/ad.1.md:62 manpages/man1/asip-status.1.md:39
 #: manpages/man1/pap.1.md:45 manpages/man8/a2boot.8.md:35
 #: manpages/man8/afpd.8.md:22 manpages/man8/atalkd.8.md:37
-#: manpages/man8/cnid_metad.8.md:21 manpages/man8/netatalk.8.md:20
+#: manpages/man8/cnid_metad.8.md:24 manpages/man8/netatalk.8.md:29
 #: manpages/man8/papd.8.md:40 manpages/man8/papstatus.8.md:27
 #: manpages/man8/timelord.8.md:26
 #, no-wrap
@@ -91,43 +91,43 @@ msgid "**-d**\n"
 msgstr ""
 
 #. type: Title #
-#: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
+#: manpages/man1/ad.1.md:295 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
-#: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
-#: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
-#: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1353
+#: manpages/man1/afppasswd.1.md:72 manpages/man1/afpstats.1.md:31
+#: manpages/man1/afptest.1.md:179 manpages/man1/asip-status.1.md:106
+#: manpages/man1/dbd.1.md:72 manpages/man1/getzones.1.md:88
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:90
+#: manpages/man1/pap.1.md:97 manpages/man1/rtmpqry.1.md:56
+#: manpages/man3/atalk_aton.3.md:28 manpages/man3/nbp_name.3.md:42
+#: manpages/man4/atalk.4.md:49 manpages/man5/afp_signature.conf.5.md:48
+#: manpages/man5/afp_voluuid.conf.5.md:40 manpages/man5/afp.conf.5.md:1353
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
-#: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:82
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
-#: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
-#: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
+#: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:83
+#: manpages/man8/cnid_dbd.8.md:146 manpages/man8/cnid_metad.8.md:51
+#: manpages/man8/macipgw.8.md:107 manpages/man8/netatalk.8.md:61
+#: manpages/man8/papd.8.md:134 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
 msgid "Author"
 msgstr "著者"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
+#: manpages/man1/ad.1.md:297 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
-#: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
-#: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
-#: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:52
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1355
+#: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:33
+#: manpages/man1/afptest.1.md:181 manpages/man1/asip-status.1.md:108
+#: manpages/man1/dbd.1.md:74 manpages/man1/getzones.1.md:90
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:92
+#: manpages/man1/pap.1.md:99 manpages/man1/rtmpqry.1.md:58
+#: manpages/man3/atalk_aton.3.md:30 manpages/man3/nbp_name.3.md:44
+#: manpages/man4/atalk.4.md:51 manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1355
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
-#: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:84
-#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
+#: manpages/man8/afpd.8.md:120 manpages/man8/atalkd.8.md:85
+#: manpages/man8/cnid_dbd.8.md:148 manpages/man8/cnid_metad.8.md:53
+#: manpages/man8/netatalk.8.md:63 manpages/man8/papd.8.md:136
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"
@@ -135,44 +135,44 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 
 #. type: Title #
 #: manpages/man1/addump.1.md:29 manpages/man1/aecho.1.md:40
-#: manpages/man1/afpldaptest.1.md:16 manpages/man1/afppasswd.1.md:35
-#: manpages/man1/asip-status.1.md:28 manpages/man1/dbd.1.md:17
+#: manpages/man1/afpldaptest.1.md:16 manpages/man1/afppasswd.1.md:33
+#: manpages/man1/asip-status.1.md:28 manpages/man1/dbd.1.md:21
 #: manpages/man1/getzones.1.md:16 manpages/man1/macusers.1.md:15
-#: manpages/man1/pap.1.md:29 manpages/man8/a2boot.8.md:32
-#: manpages/man8/afpd.8.md:19 manpages/man8/atalkd.8.md:26
-#: manpages/man8/cnid_dbd.8.md:57 manpages/man8/cnid_metad.8.md:18
-#: manpages/man8/macipgw.8.md:39 manpages/man8/netatalk.8.md:17
-#: manpages/man8/papd.8.md:37 manpages/man8/papstatus.8.md:24
-#: manpages/man8/timelord.8.md:23
+#: manpages/man1/pap.1.md:29 manpages/man1/rtmpqry.1.md:15
+#: manpages/man8/a2boot.8.md:32 manpages/man8/afpd.8.md:19
+#: manpages/man8/atalkd.8.md:26 manpages/man8/cnid_dbd.8.md:58
+#: manpages/man8/cnid_metad.8.md:21 manpages/man8/macipgw.8.md:38
+#: manpages/man8/netatalk.8.md:26 manpages/man8/papd.8.md:37
+#: manpages/man8/papstatus.8.md:24 manpages/man8/timelord.8.md:23
 #, no-wrap
 msgid "Options"
 msgstr "オプション"
 
 #. type: Title #
 #: manpages/man1/addump.1.md:68 manpages/man1/aecho.1.md:46
-#: manpages/man1/afpldaptest.1.md:34 manpages/man1/afppasswd.1.md:70
-#: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
+#: manpages/man1/afpldaptest.1.md:34 manpages/man1/afppasswd.1.md:68
+#: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:84
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
-#: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1348 manpages/man5/atalkd.conf.5.md:98
-#: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
-#: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:78
-#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
-#: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
-#: manpages/man8/papstatus.8.md:49
+#: manpages/man1/rtmpqry.1.md:52 manpages/man3/atalk_aton.3.md:24
+#: manpages/man4/atalk.4.md:45 manpages/man5/afp.conf.5.md:1348
+#: manpages/man5/atalkd.conf.5.md:98 manpages/man5/extmap.conf.5.md:28
+#: manpages/man5/papd.conf.5.md:164 manpages/man8/afpd.8.md:112
+#: manpages/man8/atalkd.8.md:79 manpages/man8/cnid_dbd.8.md:142
+#: manpages/man8/cnid_metad.8.md:47 manpages/man8/macipgw.8.md:98
+#: manpages/man8/netatalk.8.md:57 manpages/man8/papstatus.8.md:49
 #, no-wrap
 msgid "See Also"
 msgstr "関連項目"
 
 #. type: Title #
-#: manpages/man5/papd.conf.5.md:158 manpages/man8/cnid_metad.8.md:34
-#: manpages/man8/papd.8.md:117
+#: manpages/man5/papd.conf.5.md:158 manpages/man8/cnid_metad.8.md:37
+#: manpages/man8/papd.8.md:115
 #, no-wrap
 msgid "Caveats"
 msgstr "注意事項"
 
 #. type: Plain text
-#: manpages/man8/cnid_dbd.8.md:62 manpages/man8/cnid_metad.8.md:33
+#: manpages/man8/cnid_dbd.8.md:63 manpages/man8/cnid_metad.8.md:36
 #, no-wrap
 msgid "> Show version and exit.\n"
 msgstr "> バージョンを表示してから終了する。\n"
@@ -195,32 +195,47 @@ msgid "**cnid_metad** [-v | -V]\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man8/cnid_metad.8.md:17
+#: manpages/man8/cnid_metad.8.md:16
 #, no-wrap
 msgid ""
 "**cnid_metad** waits for requests from *afpd* to start up instances of the\n"
 "*cnid_dbd* daemon. It keeps track of the status of a *cnid_dbd* instance\n"
-"once started and will restart it if necessary. **cnid_metad** is normally\n"
-"started at boot time by **netatalk**(8) and runs until shutdown.\n"
-msgstr "**cnid_metad**は*afpd*からの要求を待ち、*cnid_dbd*デーモンのインスタンスを起動する。一度起動した*cnid_dbd*インスタンスの状態を絶えず把握し、もし必要なら再起動する。 **cnid_metad**は通常、**netatalk**(8)によってブート時に起動され、シャットダウンまでずっと動作する。\n"
+"once started and will restart it if necessary.\n"
+msgstr ""
+"**cnid_metad**は*afpd*からの要求を待ち、*cnid_dbd*デーモンのインスタンスを起動する。\n"
+"一度起動した*cnid_dbd*インスタンスの状態を絶えず把握し、もし必要なら再起動する。\n"
+"**cnid_metad** は通常、ブート時に **netatalk**(8) によって起動され、シャットダウンまで実行される。\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_metad.8.md:25
+#: manpages/man8/cnid_metad.8.md:20
+msgid ""
+"When built with support for the *dbd* (Database Daemon) CNID backend, "
+"**netatalk**(8) will start and stop **cnid_metad** as needed.  The user will "
+"normally not interact with it directly."
+msgstr ""
+"*dbd* (データベースデーモン) CNIDバックエンドのサポート付きでビルドされた場"
+"合、**netatalk**(8) は必要に応じて **cnid_metad** を起動および停止をさせる。"
+"通常、ユーザーは直接操作することはない。"
+
+#. type: Plain text
+#: manpages/man8/cnid_metad.8.md:28
 #, no-wrap
 msgid ""
 "> **cnid_metad** will remain in the foreground and will also leave the\n"
 "standard input, standard output and standard error file descriptors\n"
 "open. Useful for debugging.\n"
-msgstr "> **cnid_metad** はフォアグラウンドに留まり、更に標準入力、標準出力、標準エラー出力のファイル記述子を開いたままにする。デバッグに有用。\n"
+msgstr ""
+"> **cnid_metad** はフォアグラウンドに留まり、更に標準入力、標準出力、\n"
+"標準エラー出力のファイル記述子を開いたままにする。デバッグに有用。\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_metad.8.md:27
+#: manpages/man8/cnid_metad.8.md:30
 #, no-wrap
 msgid "**-F** *configuration file*\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man8/cnid_metad.8.md:29
+#: manpages/man8/cnid_metad.8.md:32
 #, no-wrap
 msgid "> Use *configuration file* as the configuration file.\n"
 msgstr ""
@@ -228,13 +243,13 @@ msgstr ""
 "file*を使う。デフォルトは*afp.conf*である。\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_metad.8.md:31
+#: manpages/man8/cnid_metad.8.md:34
 #, no-wrap
 msgid "**-v**, **-V**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man8/cnid_metad.8.md:43
+#: manpages/man8/cnid_metad.8.md:46
 #, no-wrap
 msgid ""
 "**cnid_metad** does not block or catch any signals apart from SIGPIPE. It\n"
@@ -244,9 +259,16 @@ msgid ""
 "maintained in memory by **cnid_metad** this is desired behaviour. As soon\n"
 "as **cnid_metad** is restarted **afpd** processes will transparently\n"
 "reconnect.\n"
-msgstr "**cnid_metad**はSIGPIPEを除くいかなるシグナルもブロックしないし補足もしない。従って、受け取ったほとんどのシグナルにより終了する。これは、**cnid_metad**により起動した全ての*cnid_dbd*のインスタンスを優雅に終了させる。このような状況により、サブプロセスにアクセスするIPCは**cnid_metad**によりメモリ上で維持されるだけなので、これは望ましい動作だといえる。**cnid_metad**が再起動したあとすぐ、**afpd**プロセスは透過的に再接続する。\n"
+msgstr ""
+"**cnid_metad**はSIGPIPEを除くいかなるシグナルもブロックしないし補足もしない。\n"
+"従って、受け取ったほとんどのシグナルにより終了する。\n"
+"これは、**cnid_metad**により起動した全ての*cnid_dbd*のインスタンスを優雅に終了させる。\n"
+"このような状況により、\n"
+"サブプロセスにアクセスするIPCは**cnid_metad**によりメモリ上で維持されるだけなので、\n"
+"これは望ましい動作だといえる。**cnid_metad**が再起動したあとすぐ、\n"
+"**afpd**プロセスは透過的に再接続する。\n"
 
 #. type: Plain text
-#: manpages/man8/cnid_metad.8.md:47
+#: manpages/man8/cnid_metad.8.md:50
 msgid "netatalk(8), cnid_dbd(8), afpd(8), dbd(1), afp.conf(5)"
 msgstr ""

--- a/doc/po/dbd.1.md.ja.po
+++ b/doc/po/dbd.1.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-04-26 22:52+0200\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -24,9 +24,9 @@ msgstr ""
 #: manpages/man1/afptest.1.md:1 manpages/man1/asip-status.1.md:1
 #: manpages/man1/dbd.1.md:1 manpages/man1/getzones.1.md:1
 #: manpages/man1/macusers.1.md:1 manpages/man1/nbp.1.md:1
-#: manpages/man1/pap.1.md:1 manpages/man3/atalk_aton.3.md:1
-#: manpages/man3/nbp_name.3.md:1 manpages/man4/atalk.4.md:1
-#: manpages/man5/afp_signature.conf.5.md:1
+#: manpages/man1/pap.1.md:1 manpages/man1/rtmpqry.1.md:1
+#: manpages/man3/atalk_aton.3.md:1 manpages/man3/nbp_name.3.md:1
+#: manpages/man4/atalk.4.md:1 manpages/man5/afp_signature.conf.5.md:1
 #: manpages/man5/afp_voluuid.conf.5.md:1 manpages/man5/afp.conf.5.md:1
 #: manpages/man5/atalkd.conf.5.md:1 manpages/man5/extmap.conf.5.md:1
 #: manpages/man5/papd.conf.5.md:1 manpages/man8/a2boot.8.md:1
@@ -46,14 +46,14 @@ msgstr "名前"
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
 #: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
-#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
-#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
-#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
-#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
-#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
-#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
-#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
-#: manpages/man8/timelord.8.md:5
+#: manpages/man1/pap.1.md:5 manpages/man1/rtmpqry.1.md:5
+#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
+#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
+#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
+#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
+#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
+#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
+#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -62,12 +62,12 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:22 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
 #: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
-#: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
-#: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
-#: manpages/man5/afp_signature.conf.5.md:5
+#: manpages/man1/pap.1.md:9 manpages/man1/rtmpqry.1.md:9
+#: manpages/man3/atalk_aton.3.md:14 manpages/man3/nbp_name.3.md:16
+#: manpages/man4/atalk.4.md:10 manpages/man5/afp_signature.conf.5.md:5
 #: manpages/man5/afp_voluuid.conf.5.md:5 manpages/man5/atalkd.conf.5.md:5
 #: manpages/man5/extmap.conf.5.md:5 manpages/man5/papd.conf.5.md:5
 #: manpages/man8/a2boot.8.md:11 manpages/man8/afpd.8.md:11
@@ -80,73 +80,73 @@ msgid "Description"
 msgstr "説明"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:66 manpages/man1/dbd.1.md:41
+#: manpages/man1/ad.1.md:74 manpages/man1/dbd.1.md:45
 #, no-wrap
 msgid "**-u**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:120 manpages/man1/ad.1.md:173
-#: manpages/man1/afppasswd.1.md:46 manpages/man1/dbd.1.md:24
+#: manpages/man1/ad.1.md:128 manpages/man1/ad.1.md:181
+#: manpages/man1/afppasswd.1.md:44 manpages/man1/dbd.1.md:28
 #, no-wrap
 msgid "**-f**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:152 manpages/man1/ad.1.md:190
-#: manpages/man1/ad.1.md:208 manpages/man1/dbd.1.md:45
+#: manpages/man1/ad.1.md:160 manpages/man1/ad.1.md:198
+#: manpages/man1/ad.1.md:216 manpages/man1/dbd.1.md:49
 #: manpages/man8/afpd.8.md:26
 #, no-wrap
 msgid "**-v**\n"
 msgstr ""
 
 #. type: Title #
-#: manpages/man1/ad.1.md:270 manpages/man1/afptest.1.md:172
-#: manpages/man1/dbd.1.md:59 manpages/man1/nbp.1.md:54
-#: manpages/man5/afp_signature.conf.5.md:46
-#: manpages/man5/afp_voluuid.conf.5.md:38 manpages/man8/papd.8.md:132
+#: manpages/man1/ad.1.md:291 manpages/man1/afptest.1.md:175
+#: manpages/man1/dbd.1.md:68 manpages/man1/nbp.1.md:86
+#: manpages/man5/afp_signature.conf.5.md:44
+#: manpages/man5/afp_voluuid.conf.5.md:36 manpages/man8/papd.8.md:130
 #, no-wrap
 msgid "See also"
 msgstr "参照"
 
 #. type: Title #
-#: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
+#: manpages/man1/ad.1.md:295 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
-#: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
-#: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
-#: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1353
+#: manpages/man1/afppasswd.1.md:72 manpages/man1/afpstats.1.md:31
+#: manpages/man1/afptest.1.md:179 manpages/man1/asip-status.1.md:106
+#: manpages/man1/dbd.1.md:72 manpages/man1/getzones.1.md:88
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:90
+#: manpages/man1/pap.1.md:97 manpages/man1/rtmpqry.1.md:56
+#: manpages/man3/atalk_aton.3.md:28 manpages/man3/nbp_name.3.md:42
+#: manpages/man4/atalk.4.md:49 manpages/man5/afp_signature.conf.5.md:48
+#: manpages/man5/afp_voluuid.conf.5.md:40 manpages/man5/afp.conf.5.md:1353
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
-#: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:82
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
-#: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
-#: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
+#: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:83
+#: manpages/man8/cnid_dbd.8.md:146 manpages/man8/cnid_metad.8.md:51
+#: manpages/man8/macipgw.8.md:107 manpages/man8/netatalk.8.md:61
+#: manpages/man8/papd.8.md:134 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
 msgid "Author"
 msgstr "著者"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
+#: manpages/man1/ad.1.md:297 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
-#: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
-#: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
-#: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:52
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1355
+#: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:33
+#: manpages/man1/afptest.1.md:181 manpages/man1/asip-status.1.md:108
+#: manpages/man1/dbd.1.md:74 manpages/man1/getzones.1.md:90
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:92
+#: manpages/man1/pap.1.md:99 manpages/man1/rtmpqry.1.md:58
+#: manpages/man3/atalk_aton.3.md:30 manpages/man3/nbp_name.3.md:44
+#: manpages/man4/atalk.4.md:51 manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1355
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
-#: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:84
-#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
+#: manpages/man8/afpd.8.md:120 manpages/man8/atalkd.8.md:85
+#: manpages/man8/cnid_dbd.8.md:148 manpages/man8/cnid_metad.8.md:53
+#: manpages/man8/netatalk.8.md:63 manpages/man8/papd.8.md:136
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"
@@ -154,30 +154,30 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 
 #. type: Title #
 #: manpages/man1/addump.1.md:29 manpages/man1/aecho.1.md:40
-#: manpages/man1/afpldaptest.1.md:16 manpages/man1/afppasswd.1.md:35
-#: manpages/man1/asip-status.1.md:28 manpages/man1/dbd.1.md:17
+#: manpages/man1/afpldaptest.1.md:16 manpages/man1/afppasswd.1.md:33
+#: manpages/man1/asip-status.1.md:28 manpages/man1/dbd.1.md:21
 #: manpages/man1/getzones.1.md:16 manpages/man1/macusers.1.md:15
-#: manpages/man1/pap.1.md:29 manpages/man8/a2boot.8.md:32
-#: manpages/man8/afpd.8.md:19 manpages/man8/atalkd.8.md:26
-#: manpages/man8/cnid_dbd.8.md:57 manpages/man8/cnid_metad.8.md:18
-#: manpages/man8/macipgw.8.md:39 manpages/man8/netatalk.8.md:17
-#: manpages/man8/papd.8.md:37 manpages/man8/papstatus.8.md:24
-#: manpages/man8/timelord.8.md:23
+#: manpages/man1/pap.1.md:29 manpages/man1/rtmpqry.1.md:15
+#: manpages/man8/a2boot.8.md:32 manpages/man8/afpd.8.md:19
+#: manpages/man8/atalkd.8.md:26 manpages/man8/cnid_dbd.8.md:58
+#: manpages/man8/cnid_metad.8.md:21 manpages/man8/macipgw.8.md:38
+#: manpages/man8/netatalk.8.md:26 manpages/man8/papd.8.md:37
+#: manpages/man8/papstatus.8.md:24 manpages/man8/timelord.8.md:23
 #, no-wrap
 msgid "Options"
 msgstr "オプション"
 
 #. type: Plain text
-#: manpages/man1/afppasswd.1.md:42 manpages/man1/dbd.1.md:20
-#: manpages/man1/pap.1.md:38
+#: manpages/man1/afppasswd.1.md:40 manpages/man1/dbd.1.md:24
+#: manpages/man1/getzones.1.md:48 manpages/man1/pap.1.md:38
 #, no-wrap
 msgid "**-c**\n"
 msgstr ""
 
 #. type: Plain text
 #: manpages/man1/dbd.1.md:4
-msgid "dbd — CNID database maintenance"
-msgstr "dbd — CNID データベースの保守"
+msgid "dbd — CNID database maintenance utility"
+msgstr "dbd — CNID データベース保守ユーティリティ"
 
 #. type: Plain text
 #: manpages/man1/dbd.1.md:8
@@ -198,101 +198,128 @@ msgid ""
 "**dbd** scans all file and directories of AFP volumes, updating the CNID\n"
 "database of the volume. It must be run with appropriate permissions i.e.\n"
 "as root.\n"
-msgstr "**dbd**は、AFPボリューム上の全てのファイルとディレクトリをスキャンし、そのボリュームのCNIDデータベースをアップデートする。適切なパーミッションすなわちrootとして実行しなければならない。\n"
+msgstr ""
+"**dbd**は、AFPボリューム上の全てのファイルとディレクトリをスキャンし、\n"
+"そのボリュームのCNIDデータベースをアップデートする。\n"
+"適切なパーミッションすなわちrootとして実行しなければならない。\n"
 
 #. type: Plain text
-#: manpages/man1/dbd.1.md:22
-#, no-wrap
-msgid "> convert from *AppleDouble v2* to *EA* filesystem metadata\n"
-msgstr "> *AppleDouble v2*から*拡張属性*へ変換する\n"
+#: manpages/man1/dbd.1.md:20
+msgid ""
+"When run with the **-f** parameter, it will completely wipe the existing "
+"volume table in the database and create a new one from scratch.  This can be "
+"used to for example convert from one CNID scheme to another."
+msgstr ""
+"**-f** パラメータを指定して実行すると、データベース内の既存のボリュームテーブ"
+"ルが完全に消去され、新しいボリュームテーブルが最初から作成される。これは、例"
+"えば、あるCNIDスキームから別のCNIDスキームに変換する場合に使用できる。"
 
 #. type: Plain text
 #: manpages/man1/dbd.1.md:26
+#, no-wrap
+msgid "> convert from *AppleDouble v2* to *Extended Attributes* filesystem metadata\n"
+msgstr "> *AppleDouble v2*から*拡張属性*へ変換する\n"
+
+#. type: Plain text
+#: manpages/man1/dbd.1.md:30
 #, no-wrap
 msgid "> delete and recreate CNID database\n"
 msgstr "> CNIDデータベースを削除してから再作成する\n"
 
 #. type: Plain text
-#: manpages/man1/dbd.1.md:28
+#: manpages/man1/dbd.1.md:32
 #, no-wrap
 msgid "**-F**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/dbd.1.md:30
+#: manpages/man1/dbd.1.md:34
 #, no-wrap
 msgid "> location of the *afp.conf* config file\n"
 msgstr "> 設定ファイルafp.confの場所\n"
 
 #. type: Plain text
-#: manpages/man1/dbd.1.md:32
+#: manpages/man1/dbd.1.md:36
 #, no-wrap
 msgid "**-s**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/dbd.1.md:35
+#: manpages/man1/dbd.1.md:39
 #, no-wrap
 msgid ""
 "> scan volume: treat the volume as read only and don't perform any\n"
 "filesystem modifications\n"
-msgstr "> ボリュームをスキャンする。すなわち、ボリュームをリードオンリーとして扱い、いかなるファイルシステムの変更も行わない。\n"
+msgstr ""
+"> ボリュームをスキャンする。すなわち、ボリュームをリードオンリーとして扱い、\n"
+"いかなるファイルシステムの変更も行わない。\n"
 
 #. type: Plain text
-#: manpages/man1/dbd.1.md:37 manpages/man8/atalkd.8.md:50
+#: manpages/man1/dbd.1.md:41 manpages/man8/atalkd.8.md:51
 #, no-wrap
 msgid "**-t**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/dbd.1.md:39
+#: manpages/man1/dbd.1.md:43
 #, no-wrap
 msgid "> show statistics while running\n"
 msgstr "> 実行中の統計を表示する\n"
 
 #. type: Plain text
-#: manpages/man1/dbd.1.md:43
+#: manpages/man1/dbd.1.md:47
 #, no-wrap
 msgid "> username for use with AFP volumes using user variable $u\n"
 msgstr "> ユーザ変数$uを使うAFPボリュームのユーザ名\n"
 
 #. type: Plain text
-#: manpages/man1/dbd.1.md:47
+#: manpages/man1/dbd.1.md:51
 #, no-wrap
 msgid "> verbose\n"
 msgstr "> 詳細\n"
 
 #. type: Plain text
-#: manpages/man1/dbd.1.md:49 manpages/man8/afpd.8.md:30
+#: manpages/man1/dbd.1.md:53 manpages/man8/afpd.8.md:30
 #, no-wrap
 msgid "**-V**\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man1/dbd.1.md:51
+#: manpages/man1/dbd.1.md:55
 #, no-wrap
 msgid "> display version info\n"
 msgstr "> バージョン情報の表示\n"
 
 #. type: Title #
-#: manpages/man1/dbd.1.md:52
+#: manpages/man1/dbd.1.md:56
 #, no-wrap
-msgid "CNID background"
-msgstr "CNID の背景"
+msgid "CNID usage"
+msgstr "CNID 使用上の注意"
 
 #. type: Plain text
-#: manpages/man1/dbd.1.md:58
+#: manpages/man1/dbd.1.md:62
 msgid ""
-"The CNID backends maintains name to ID mappings. If you change a filename "
-"outside **afpd**(8) (shell, samba), the CNID database will not reflect that "
-"change. Netatalk tries to recover from such inconsistencies as gracefully as "
-"possible."
+"The CNID backends maintains filename to ID mappings. If you change a "
+"filename outside **afpd**(8) (shell, samba), the CNID database will not "
+"reflect that change. Netatalk tries to recover from such inconsistencies as "
+"gracefully as possible."
 msgstr ""
 "CNIDバックエンドは名前からIDへのマッピングを保持する。もしあなたがafpd(8)の"
 "外、すなわちシェルやsambaでファイル名を変更した場合、CNIDデータベースはその変"
 "更を反映しない。Netatalkは可能な限り優美にそのような矛盾の修復を試む。"
 
 #. type: Plain text
-#: manpages/man1/dbd.1.md:62
-msgid "cnid_metad(8), cnid_dbd(8)"
+#: manpages/man1/dbd.1.md:67
+msgid ""
+"For when you want to operate on a Netatalk volume outside of an AFP client "
+"without sacrificing the integrity of the CNID database, you can use the "
+"**ad**(1) tool which updates the CNID records while modifying files."
+msgstr ""
+"CNIDデータベースの整合性を損なうことなく、AFPクライアントの外部にあるNetatalk"
+"ボリュームを操作したい場合は、ファイルを変更しながらCNIDレコードを更新する"
+"**ad**(1)ツールの使用を推奨する。"
+
+#. type: Plain text
+#: manpages/man1/dbd.1.md:71
+msgid "ad(1), cnid_metad(8), cnid_dbd(8)"
 msgstr ""

--- a/doc/po/extmap.conf.5.md.ja.po
+++ b/doc/po/extmap.conf.5.md.ja.po
@@ -146,7 +146,9 @@ msgstr ""
 msgid ""
 "**extmap.conf** is the configuration file used by **afpd** to specify file\n"
 "name extension mappings.\n"
-msgstr "**extmap.conf**はファイル名拡張子マッピングを指定するために**afpd**が利用する設定ファイルである。\n"
+msgstr ""
+"**extmap.conf**はファイル名拡張子マッピングを指定するために\n"
+"**afpd**が利用する設定ファイルである。\n"
 
 #. type: Plain text
 #: manpages/man5/extmap.conf.5.md:11

--- a/doc/po/getzones.1.md.ja.po
+++ b/doc/po/getzones.1.md.ja.po
@@ -290,7 +290,9 @@ msgstr ""
 msgid ""
 "> Sets the Macintosh character set to use when interpreting zone names.  If not specified,\n"
 "defaults to MacRoman.\n"
-msgstr "> ゾーン名を解釈する際に使用するMacintosh文字セットを設定する。指定しない場合は、デフォルトでMacRomanが使用される。\n"
+msgstr ""
+"> ゾーン名を解釈する際に使用するMacintosh文字セットを設定する。\n"
+"指定しない場合は、デフォルトでMacRomanが使用される。\n"
 
 #. type: Plain text
 #: manpages/man1/getzones.1.md:53

--- a/doc/po/index.md.ja.po
+++ b/doc/po/index.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-01-25 20:17+0100\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -20,44 +20,11 @@ msgstr ""
 #. type: Title #
 #: manual/index.md:1
 #, no-wrap
-msgid "Introduction"
+msgid "Introduction to Netatalk"
 msgstr "序説"
 
-#. type: Title ##
-#: manual/index.md:3
-#, no-wrap
-msgid "Legal Notice"
-msgstr "法的条項"
-
 #. type: Plain text
-#: manual/index.md:9
-msgid ""
-"The Netatalk software package as well as this documentation are distributed "
-"under the GNU General Public License (GPL) version 2. A copy of the license "
-"is included in this documentation, as well as within the Netatalk source "
-"distribution."
-msgstr ""
-"Netatalk のソフトウェアのパッケージまたは本ドキュメントは GNU 一般公衆利用許"
-"諾書 (GPL) バージョン 2 のもとで配布されている。 Netatalk ソース一式にも本ド"
-"キュメントと同様に許諾書のコピーが同梱されている。"
-
-#. type: Plain text
-#: manual/index.md:12
-msgid ""
-"The Free Software Foundation distributes an [online copy of the license]"
-"(http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt)."
-msgstr ""
-"[許諾書のコピーのオンライン版](http://www.gnu.org/licenses/old-licenses/"
-"gpl-2.0.txt) はフリーソフトウェア財団によって配布されている。"
-
-#. type: Title ##
-#: manual/index.md:13
-#, no-wrap
-msgid "Overview of Netatalk"
-msgstr "Netatalk 概要"
-
-#. type: Plain text
-#: manual/index.md:19
+#: manual/index.md:7
 msgid ""
 "Netatalk is an Open Source software package that can be used to turn a "
 "\\*NIX machine into a performant and light-weight file server for Macintosh "
@@ -69,7 +36,7 @@ msgstr ""
 "す。TCP/IP と従来の AppleTalk トランスポート層を提供する。"
 
 #. type: Plain text
-#: manual/index.md:26
+#: manual/index.md:14
 msgid ""
 "Using Netatalk's AFP 3.4 compliant file-server leads to noticeably higher "
 "transmission speeds for macOS clients compared to Samba/NFS, while providing "
@@ -84,7 +51,7 @@ msgstr ""
 "の Mac が混在する環境を容易にする。"
 
 #. type: Plain text
-#: manual/index.md:31
+#: manual/index.md:19
 msgid ""
 "Netatalk ships with range of capabilities to accommodate most deployment "
 "environments, including Kerberos, ACLs and LDAP. Modern macOS features such "
@@ -96,7 +63,7 @@ msgstr ""
 "Spotlight インデックス検索などの最新の macOS 機能が提供される。"
 
 #. type: Plain text
-#: manual/index.md:36
+#: manual/index.md:24
 msgid ""
 "For AppleTalk networks with legacy Macs and Apple IIs, Netatalk provides a "
 "print server, time server, and Apple II NetBoot server. The print server is "
@@ -110,7 +77,7 @@ msgstr ""
 "る。"
 
 #. type: Plain text
-#: manual/index.md:39
+#: manual/index.md:27
 msgid ""
 "Additionally, Netatalk can be configured as an AppleTalk router through its "
 "AppleTalk Network Management daemon, providing both segmentation and zone "

--- a/doc/po/macipgw.8.md.ja.po
+++ b/doc/po/macipgw.8.md.ja.po
@@ -189,7 +189,10 @@ msgid ""
 "**macipgw** provides IP connectivity for devices connected through an\n"
 "AppleTalk-only network, i.e. LocalTalk or Apple Remote Access (ARA).\n"
 "**macipgw** is normally started out of */etc/rc*.\n"
-msgstr "**macipgw** は、AppleTalk のみのネットワークを介して接続されたデバイスに IP 接続を提供する。つまり、LocalTalk または Apple Remote Access (ARA)。**macipgw** は通常、*/etc/rc* から起動される。\n"
+msgstr ""
+"**macipgw** は、AppleTalk のみのネットワークを介して接続されたデバイスに IP 接続を提供する。\n"
+"つまり、LocalTalk または Apple Remote Access (ARA)。\n"
+"**macipgw** は通常、*/etc/rc* から起動される。\n"
 
 #. type: Plain text
 #: manpages/man8/macipgw.8.md:25
@@ -240,7 +243,9 @@ msgstr ""
 msgid ""
 "**macipgw** will log operational messages through **syslog**(3) under the\n"
 "facility *LOG_DAEMON*.\n"
-msgstr "**macipgw** は、*LOG_DAEMON* 機能の下で、**syslog**(3) を介して操作メッセージをログに記録する。\n"
+msgstr ""
+"**macipgw** は、*LOG_DAEMON* 機能の下で、**syslog**(3) を介して\n"
+"操作メッセージをログに記録する。\n"
 
 #. type: Plain text
 #: manpages/man8/macipgw.8.md:41

--- a/doc/po/nbp_name.3.md.ja.po
+++ b/doc/po/nbp_name.3.md.ja.po
@@ -161,7 +161,15 @@ msgid ""
 "*object:type@zone*, where each of *object*, *:type*, and *@zone*\n"
 "replace *obj*, *type*, and *zone*, respectively. *type* must be\n"
 "proceeded by \\`*:*', and *zone* must be preceded by \\`*@*'.\n"
-msgstr "**nbp_name()** は、ユーザーが指定した名前を、そのコンポーネント オブジェクト、タイプ、およびゾーンに解析する。 *obj*、*type*、*zone* は参照渡しされ、呼び出し元のデフォルト値を指す必要がある。**nbp_name()** は、解析された値へのポインタを変更する。 *name* は、*object:type@**zone* の形式である。ここで、*object*、 *:type、*、および *@**zone* はそれぞれ、*obj*、 *type*、*zone,* です。*type* の前には \\`*:*' が、*zone* の前には \\`*@*' がなければならない。\n"
+msgstr ""
+"**nbp_name()** は、ユーザーが指定した名前を、そのコンポーネント オブジェクト、\n"
+"タイプ、およびゾーンに解析する。\n"
+"*obj*、*type*、*zone* は参照渡しされ、呼び出し元のデフォルト値を指す必要がある。\n"
+"**nbp_name()** は、解析された値へのポインタを変更する。\n"
+"*name* は、*object:type@**zone* の形式である。\n"
+"ここで、*object*、 *:type、*、および *@**zone* はそれぞれ、\n"
+"*obj*、 *type*、*zone,* です。\n"
+"*type* の前には \\`*:*' が、*zone* の前には \\`*@*' がなければならない。\n"
 
 #. type: Plain text
 #: manpages/man3/nbp_name.3.md:34

--- a/doc/po/netatalk.8.md.ja.po
+++ b/doc/po/netatalk.8.md.ja.po
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-04-26 22:52+0200\n"
+"POT-Creation-Date: 2025-07-31 07:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
@@ -24,9 +24,9 @@ msgstr ""
 #: manpages/man1/afptest.1.md:1 manpages/man1/asip-status.1.md:1
 #: manpages/man1/dbd.1.md:1 manpages/man1/getzones.1.md:1
 #: manpages/man1/macusers.1.md:1 manpages/man1/nbp.1.md:1
-#: manpages/man1/pap.1.md:1 manpages/man3/atalk_aton.3.md:1
-#: manpages/man3/nbp_name.3.md:1 manpages/man4/atalk.4.md:1
-#: manpages/man5/afp_signature.conf.5.md:1
+#: manpages/man1/pap.1.md:1 manpages/man1/rtmpqry.1.md:1
+#: manpages/man3/atalk_aton.3.md:1 manpages/man3/nbp_name.3.md:1
+#: manpages/man4/atalk.4.md:1 manpages/man5/afp_signature.conf.5.md:1
 #: manpages/man5/afp_voluuid.conf.5.md:1 manpages/man5/afp.conf.5.md:1
 #: manpages/man5/atalkd.conf.5.md:1 manpages/man5/extmap.conf.5.md:1
 #: manpages/man5/papd.conf.5.md:1 manpages/man8/a2boot.8.md:1
@@ -46,14 +46,14 @@ msgstr "名前"
 #: manpages/man1/afptest.1.md:5 manpages/man1/asip-status.1.md:5
 #: manpages/man1/dbd.1.md:5 manpages/man1/getzones.1.md:5
 #: manpages/man1/macusers.1.md:5 manpages/man1/nbp.1.md:5
-#: manpages/man1/pap.1.md:5 manpages/man3/atalk_aton.3.md:5
-#: manpages/man3/nbp_name.3.md:5 manpages/man4/atalk.4.md:5
-#: manpages/man5/afp.conf.5.md:5 manpages/man8/a2boot.8.md:5
-#: manpages/man8/afpd.8.md:5 manpages/man8/atalkd.8.md:5
-#: manpages/man8/cnid_dbd.8.md:5 manpages/man8/cnid_metad.8.md:5
-#: manpages/man8/macipgw.8.md:5 manpages/man8/netatalk.8.md:5
-#: manpages/man8/papd.8.md:5 manpages/man8/papstatus.8.md:5
-#: manpages/man8/timelord.8.md:5
+#: manpages/man1/pap.1.md:5 manpages/man1/rtmpqry.1.md:5
+#: manpages/man3/atalk_aton.3.md:5 manpages/man3/nbp_name.3.md:5
+#: manpages/man4/atalk.4.md:5 manpages/man5/afp.conf.5.md:5
+#: manpages/man8/a2boot.8.md:5 manpages/man8/afpd.8.md:5
+#: manpages/man8/atalkd.8.md:5 manpages/man8/cnid_dbd.8.md:5
+#: manpages/man8/cnid_metad.8.md:5 manpages/man8/macipgw.8.md:5
+#: manpages/man8/netatalk.8.md:5 manpages/man8/papd.8.md:5
+#: manpages/man8/papstatus.8.md:5 manpages/man8/timelord.8.md:5
 #, no-wrap
 msgid "Synopsis"
 msgstr "概要"
@@ -62,12 +62,12 @@ msgstr "概要"
 #: manpages/man1/ad.1.md:11 manpages/man1/addump.1.md:19
 #: manpages/man1/aecho.1.md:9 manpages/man1/afpldaptest.1.md:11
 #: manpages/man1/afppasswd.1.md:9 manpages/man1/afpstats.1.md:9
-#: manpages/man1/afptest.1.md:19 manpages/man1/asip-status.1.md:13
+#: manpages/man1/afptest.1.md:22 manpages/man1/asip-status.1.md:13
 #: manpages/man1/dbd.1.md:11 manpages/man1/getzones.1.md:9
 #: manpages/man1/macusers.1.md:11 manpages/man1/nbp.1.md:13
-#: manpages/man1/pap.1.md:9 manpages/man3/atalk_aton.3.md:15
-#: manpages/man3/nbp_name.3.md:16 manpages/man4/atalk.4.md:10
-#: manpages/man5/afp_signature.conf.5.md:5
+#: manpages/man1/pap.1.md:9 manpages/man1/rtmpqry.1.md:9
+#: manpages/man3/atalk_aton.3.md:14 manpages/man3/nbp_name.3.md:16
+#: manpages/man4/atalk.4.md:10 manpages/man5/afp_signature.conf.5.md:5
 #: manpages/man5/afp_voluuid.conf.5.md:5 manpages/man5/atalkd.conf.5.md:5
 #: manpages/man5/extmap.conf.5.md:5 manpages/man5/papd.conf.5.md:5
 #: manpages/man8/a2boot.8.md:11 manpages/man8/afpd.8.md:11
@@ -80,10 +80,10 @@ msgid "Description"
 msgstr "説明"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:54 manpages/man1/asip-status.1.md:39
+#: manpages/man1/ad.1.md:62 manpages/man1/asip-status.1.md:39
 #: manpages/man1/pap.1.md:45 manpages/man8/a2boot.8.md:35
 #: manpages/man8/afpd.8.md:22 manpages/man8/atalkd.8.md:37
-#: manpages/man8/cnid_metad.8.md:21 manpages/man8/netatalk.8.md:20
+#: manpages/man8/cnid_metad.8.md:24 manpages/man8/netatalk.8.md:29
 #: manpages/man8/papd.8.md:40 manpages/man8/papstatus.8.md:27
 #: manpages/man8/timelord.8.md:26
 #, no-wrap
@@ -91,43 +91,43 @@ msgid "**-d**\n"
 msgstr ""
 
 #. type: Title #
-#: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
+#: manpages/man1/ad.1.md:295 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
-#: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:31
-#: manpages/man1/afptest.1.md:176 manpages/man1/asip-status.1.md:106
-#: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:37
-#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:58
-#: manpages/man1/pap.1.md:97 manpages/man3/atalk_aton.3.md:29
-#: manpages/man3/nbp_name.3.md:42 manpages/man4/atalk.4.md:49
-#: manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1353
+#: manpages/man1/afppasswd.1.md:72 manpages/man1/afpstats.1.md:31
+#: manpages/man1/afptest.1.md:179 manpages/man1/asip-status.1.md:106
+#: manpages/man1/dbd.1.md:72 manpages/man1/getzones.1.md:88
+#: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:90
+#: manpages/man1/pap.1.md:97 manpages/man1/rtmpqry.1.md:56
+#: manpages/man3/atalk_aton.3.md:28 manpages/man3/nbp_name.3.md:42
+#: manpages/man4/atalk.4.md:49 manpages/man5/afp_signature.conf.5.md:48
+#: manpages/man5/afp_voluuid.conf.5.md:40 manpages/man5/afp.conf.5.md:1353
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
-#: manpages/man8/afpd.8.md:116 manpages/man8/atalkd.8.md:82
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
-#: manpages/man8/macipgw.8.md:108 manpages/man8/netatalk.8.md:52
-#: manpages/man8/papd.8.md:136 manpages/man8/papstatus.8.md:53
+#: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:83
+#: manpages/man8/cnid_dbd.8.md:146 manpages/man8/cnid_metad.8.md:51
+#: manpages/man8/macipgw.8.md:107 manpages/man8/netatalk.8.md:61
+#: manpages/man8/papd.8.md:134 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
 msgid "Author"
 msgstr "著者"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
+#: manpages/man1/ad.1.md:297 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
-#: manpages/man1/afppasswd.1.md:76 manpages/man1/afpstats.1.md:33
-#: manpages/man1/afptest.1.md:178 manpages/man1/asip-status.1.md:108
-#: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:39
-#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:60
-#: manpages/man1/pap.1.md:99 manpages/man3/atalk_aton.3.md:31
-#: manpages/man3/nbp_name.3.md:44 manpages/man4/atalk.4.md:51
-#: manpages/man5/afp_signature.conf.5.md:52
-#: manpages/man5/afp_voluuid.conf.5.md:44 manpages/man5/afp.conf.5.md:1355
+#: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:33
+#: manpages/man1/afptest.1.md:181 manpages/man1/asip-status.1.md:108
+#: manpages/man1/dbd.1.md:74 manpages/man1/getzones.1.md:90
+#: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:92
+#: manpages/man1/pap.1.md:99 manpages/man1/rtmpqry.1.md:58
+#: manpages/man3/atalk_aton.3.md:30 manpages/man3/nbp_name.3.md:44
+#: manpages/man4/atalk.4.md:51 manpages/man5/afp_signature.conf.5.md:50
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1355
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
-#: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:84
-#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:138
+#: manpages/man8/afpd.8.md:120 manpages/man8/atalkd.8.md:85
+#: manpages/man8/cnid_dbd.8.md:148 manpages/man8/cnid_metad.8.md:53
+#: manpages/man8/netatalk.8.md:63 manpages/man8/papd.8.md:136
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"
@@ -135,47 +135,47 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 
 #. type: Title #
 #: manpages/man1/addump.1.md:29 manpages/man1/aecho.1.md:40
-#: manpages/man1/afpldaptest.1.md:16 manpages/man1/afppasswd.1.md:35
-#: manpages/man1/asip-status.1.md:28 manpages/man1/dbd.1.md:17
+#: manpages/man1/afpldaptest.1.md:16 manpages/man1/afppasswd.1.md:33
+#: manpages/man1/asip-status.1.md:28 manpages/man1/dbd.1.md:21
 #: manpages/man1/getzones.1.md:16 manpages/man1/macusers.1.md:15
-#: manpages/man1/pap.1.md:29 manpages/man8/a2boot.8.md:32
-#: manpages/man8/afpd.8.md:19 manpages/man8/atalkd.8.md:26
-#: manpages/man8/cnid_dbd.8.md:57 manpages/man8/cnid_metad.8.md:18
-#: manpages/man8/macipgw.8.md:39 manpages/man8/netatalk.8.md:17
-#: manpages/man8/papd.8.md:37 manpages/man8/papstatus.8.md:24
-#: manpages/man8/timelord.8.md:23
+#: manpages/man1/pap.1.md:29 manpages/man1/rtmpqry.1.md:15
+#: manpages/man8/a2boot.8.md:32 manpages/man8/afpd.8.md:19
+#: manpages/man8/atalkd.8.md:26 manpages/man8/cnid_dbd.8.md:58
+#: manpages/man8/cnid_metad.8.md:21 manpages/man8/macipgw.8.md:38
+#: manpages/man8/netatalk.8.md:26 manpages/man8/papd.8.md:37
+#: manpages/man8/papstatus.8.md:24 manpages/man8/timelord.8.md:23
 #, no-wrap
 msgid "Options"
 msgstr "オプション"
 
 #. type: Title #
 #: manpages/man1/addump.1.md:68 manpages/man1/aecho.1.md:46
-#: manpages/man1/afpldaptest.1.md:34 manpages/man1/afppasswd.1.md:70
-#: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:33
+#: manpages/man1/afpldaptest.1.md:34 manpages/man1/afppasswd.1.md:68
+#: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:84
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
-#: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:45
-#: manpages/man5/afp.conf.5.md:1348 manpages/man5/atalkd.conf.5.md:98
-#: manpages/man5/extmap.conf.5.md:28 manpages/man5/papd.conf.5.md:164
-#: manpages/man8/afpd.8.md:110 manpages/man8/atalkd.8.md:78
-#: manpages/man8/cnid_dbd.8.md:141 manpages/man8/cnid_metad.8.md:44
-#: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:48
-#: manpages/man8/papstatus.8.md:49
+#: manpages/man1/rtmpqry.1.md:52 manpages/man3/atalk_aton.3.md:24
+#: manpages/man4/atalk.4.md:45 manpages/man5/afp.conf.5.md:1348
+#: manpages/man5/atalkd.conf.5.md:98 manpages/man5/extmap.conf.5.md:28
+#: manpages/man5/papd.conf.5.md:164 manpages/man8/afpd.8.md:112
+#: manpages/man8/atalkd.8.md:79 manpages/man8/cnid_dbd.8.md:142
+#: manpages/man8/cnid_metad.8.md:47 manpages/man8/macipgw.8.md:98
+#: manpages/man8/netatalk.8.md:57 manpages/man8/papstatus.8.md:49
 #, no-wrap
 msgid "See Also"
 msgstr "関連項目"
 
 #. type: Title #
-#: manpages/man1/pap.1.md:87 manpages/man8/afpd.8.md:88
-#: manpages/man8/atalkd.8.md:74 manpages/man8/netatalk.8.md:42
-#: manpages/man8/papd.8.md:99 manpages/man8/papstatus.8.md:43
+#: manpages/man1/pap.1.md:87 manpages/man8/afpd.8.md:90
+#: manpages/man8/atalkd.8.md:75 manpages/man8/netatalk.8.md:51
+#: manpages/man8/papd.8.md:97 manpages/man8/papstatus.8.md:43
 #, no-wrap
 msgid "Files"
 msgstr "ファイル"
 
 #. type: Plain text
-#: manpages/man8/a2boot.8.md:43 manpages/man8/atalkd.8.md:54
-#: manpages/man8/cnid_dbd.8.md:60 manpages/man8/macipgw.8.md:68
-#: manpages/man8/netatalk.8.md:28 manpages/man8/papd.8.md:58
+#: manpages/man8/a2boot.8.md:43 manpages/man8/atalkd.8.md:55
+#: manpages/man8/cnid_dbd.8.md:61 manpages/man8/macipgw.8.md:67
+#: manpages/man8/netatalk.8.md:37 manpages/man8/papd.8.md:58
 #: manpages/man8/timelord.8.md:39
 #, no-wrap
 msgid "**-v** | **-V**\n"
@@ -183,48 +183,48 @@ msgstr ""
 
 #. type: Plain text
 #: manpages/man8/a2boot.8.md:45 manpages/man8/afpd.8.md:28
-#: manpages/man8/atalkd.8.md:56 manpages/man8/netatalk.8.md:30
+#: manpages/man8/atalkd.8.md:57 manpages/man8/netatalk.8.md:39
 #: manpages/man8/papd.8.md:60 manpages/man8/timelord.8.md:41
 #, no-wrap
 msgid "> Print version information and exit.\n"
 msgstr "> バージョン情報を出力して終了する。\n"
 
 #. type: Plain text
-#: manpages/man8/afpd.8.md:24 manpages/man8/netatalk.8.md:22
+#: manpages/man8/afpd.8.md:24 manpages/man8/netatalk.8.md:31
 #, no-wrap
 msgid "> Do not disassociate daemon from terminal.\n"
 msgstr "> デーモンをターミナルから切り離さない。\n"
 
 #. type: Plain text
-#: manpages/man8/afpd.8.md:38 manpages/man8/netatalk.8.md:24
+#: manpages/man8/afpd.8.md:38 manpages/man8/netatalk.8.md:33
 #, no-wrap
 msgid "**-F** *configfile*\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man8/afpd.8.md:40 manpages/man8/netatalk.8.md:26
+#: manpages/man8/afpd.8.md:40 manpages/man8/netatalk.8.md:35
 #, no-wrap
 msgid "> Specifies the configuration file to use.\n"
 msgstr "> 利用する設定ファイルを指定する。\n"
 
 #. type: Title #
-#: manpages/man8/afpd.8.md:41 manpages/man8/netatalk.8.md:31
+#: manpages/man8/afpd.8.md:41 manpages/man8/netatalk.8.md:40
 #, no-wrap
 msgid "Signals"
 msgstr "シグナル"
 
 #. type: Plain text
-#: manpages/man8/afpd.8.md:53 manpages/man8/netatalk.8.md:34
+#: manpages/man8/afpd.8.md:53 manpages/man8/netatalk.8.md:43
 msgid "SIGTERM"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man8/afpd.8.md:62 manpages/man8/netatalk.8.md:38
+#: manpages/man8/afpd.8.md:63 manpages/man8/netatalk.8.md:47
 msgid "SIGHUP"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man8/afpd.8.md:91 manpages/man8/netatalk.8.md:45
+#: manpages/man8/afpd.8.md:93 manpages/man8/netatalk.8.md:54
 #, no-wrap
 msgid "*afp.conf*\n"
 msgstr ""
@@ -247,35 +247,61 @@ msgid "**netatalk** [-v | -V]\n"
 msgstr ""
 
 #. type: Plain text
-#: manpages/man8/netatalk.8.md:16
+#: manpages/man8/netatalk.8.md:18
 #, no-wrap
 msgid ""
-"**netatalk** is the service controller daemon responsible for starting and\n"
-"restarting the AFP daemon **afpd** and the CNID daemon **cnid_metad**. It is\n"
-"normally started at boot time by an init system.\n"
-msgstr "**netatalk**は、AFPデーモン**afpd**とCNIDデーモン**cnid_metad**の起動と再起動を請け負うサービスコントローラデーモンである。\n"
+"**netatalk** is the daemon used to control the Netatalk AFP file server,\n"
+"which is made up of multiple forking daemons.\n"
+"For most deployments you would use **netatalk** for centralized control\n"
+"rather than launching and stopping each daemon individually.\n"
+"The **netatalk** daemon is normally started at boot time by an init system.\n"
+msgstr ""
+"**netatalk** は、複数のフォーク型デーモンで構成される Netatalk AFP ファイルサーバーを\n"
+"制御するためのデーモンである。\n"
+"ほとんどの導入では、各デーモンを個別に起動・停止するのではなく、\n"
+"netatalk を集中管理に使用する。\n"
+"netatalk デーモンは通常、ブート時に init システムによって起動される。\n"
 
 #. type: Plain text
-#: manpages/man8/netatalk.8.md:36
+#: manpages/man8/netatalk.8.md:22
+msgid ""
+"The controller daemon will launch the AFP daemon **afpd** and the CNID meta "
+"daemon **cnid_metad**. The latter will in turn launch the CNID database "
+"daemon **cnid_dbd**."
+msgstr ""
+"コントローラーデーモンは、AFP デーモン **afpd** と CNID メタデーモン "
+"**cnid_metad** を起動する。後者は、CNID データベースデーモン **cnid_dbd** を"
+"起動する。"
+
+#. type: Plain text
+#: manpages/man8/netatalk.8.md:25
+msgid ""
+"The configurations of all four daemons are managed in a single configuration "
+"file called *afp.conf*."
+msgstr ""
+"4つのデーモンの設定はすべて、afp.conf という単一の設定ファイルで管理される。"
+
+#. type: Plain text
+#: manpages/man8/netatalk.8.md:45
 #, no-wrap
-msgid "> Stop Netatalk service, AFP and CNID daemons\n"
-msgstr "> Netatalkサービス、AFPデーモンとCNIDデーモンを停止する\n"
+msgid "> Stop the Netatalk AFP and CNID daemons.\n"
+msgstr "> NetatalkのAFPデーモンとCNIDデーモンを停止する\n"
 
 #. type: Plain text
-#: manpages/man8/netatalk.8.md:41
+#: manpages/man8/netatalk.8.md:50
 #, no-wrap
 msgid ""
-"> Sending a *SIGHUP* will cause the AFP daemon reload its configuration\n"
-"file.\n"
-msgstr "> *SIGHUP*を送るとAFPデーモンが設定ファイルを再読み込みする。\n"
+"> Sending a *SIGHUP* will cause the Netatalk AFP and CNID daemons to reload\n"
+"their configurations from *afp.conf*.\n"
+msgstr "> *SIGHUP*を送るとNetatalkのAFPデーモンとCNIDデーモンが設定ファイルを再読み込みする。\n"
 
 #. type: Plain text
-#: manpages/man8/netatalk.8.md:47
+#: manpages/man8/netatalk.8.md:56
 #, no-wrap
 msgid "> configuration file used by **netatalk**(8), **afpd**(8) and **cnid_metad**(8)\n"
 msgstr "> **netatalk**(8)と**afpd**(8)と**cnid_metad**(8)が使う設定ファイル\n"
 
 #. type: Plain text
-#: manpages/man8/netatalk.8.md:51
+#: manpages/man8/netatalk.8.md:60
 msgid "afpd(8), cnid_metad(8), afp.conf(5)"
 msgstr ""

--- a/doc/po/pap.1.md.ja.po
+++ b/doc/po/pap.1.md.ja.po
@@ -300,10 +300,9 @@ msgid ""
 "connection. Some clients don't wait, and hence some printers have\n"
 "related bugs in their implementation.\n"
 msgstr ""
-"> プリンタからの EOF を待機しない。このオプションは、PAP\n"
-"を正しく実装していないプリンタで役立つ。正しい実装では、クライアント側は接続を閉じる前にプリンタが\n"
-"EOF\n"
-"を返すのを待機する必要がある。一部のクライアントは待機しないため、一部のプリンタでは実装に関連するバグがある。\n"
+"> プリンタからの EOF を待機しない。このオプションは、PAPを正しく実装していないプリンタで役立つ。\n"
+"正しい実装では、クライアント側は接続を閉じる前にプリンタがEOFを返すのを待機する必要がある。\n"
+"一部のクライアントは待機しないため、一部のプリンタでは実装に関連するバグがある。\n"
 
 #. type: Plain text
 #: manpages/man1/pap.1.md:62
@@ -340,7 +339,7 @@ msgid ""
 "**pap** is invoked by **psf**(8) within *lpd*'s spool directory.\n"
 msgstr ""
 "> *statusfile* というファイルを更新して、プリンタからの最新のステータス\n"
-"メッセージを含める。 **pap**\n"
+"メッセージを含める。**pap**\n"
 "は、プリンタが入力を処理するのを待っているときに、プリンタからステータスを取得する。*statusfile*\n"
 "には、改行で終了する 1 行が含まれる。これは、*lpd* のスプール\n"
 "ディレクトリ内の **psf**(8) によって **pap** が呼び出される場合に便利。\n"
@@ -359,10 +358,8 @@ msgid ""
 "the job. This is to defeat printer-side spool available on HP IV and V\n"
 "printers.\n"
 msgstr ""
-"> ジョブを送信する前に、プリンタ\n"
-"ステータスに「waiting」という単語が含まれるまで待機する。これは、HP IV\n"
-"および V\n"
-"プリンターで使用可能なプリンター側スプールを無効にするためのものである。\n"
+"> ジョブを送信する前に、プリンタステータスに「waiting」という単語が含まれるまで待機する。\n"
+"これは、HP IV および V プリンターで使用可能なプリンター側スプールを無効にするためのものである。\n"
 
 #. type: Plain text
 #: manpages/man1/pap.1.md:82
@@ -378,9 +375,8 @@ msgid ""
 "the job. This is to defeat printer-side spool available on HP IV and V\n"
 "printers.\n"
 msgstr ""
-"> ジョブを送信する前に、プリンターのステータスに「アイドル」という単語が含まれるまで待機する。これは、HP\n"
-"IV および V\n"
-"プリンタで利用可能なプリンタ側スプールを無効にするためのものである。\n"
+"> ジョブを送信する前に、プリンターのステータスに「アイドル」という単語が含まれるまで待機する。\n"
+"これは、HP IV および V プリンタで利用可能なプリンタ側スプールを無効にするためのものである。\n"
 
 #. type: Title #
 #: manpages/man1/pap.1.md:87 manpages/man8/afpd.8.md:88

--- a/doc/po/papd.8.md.ja.po
+++ b/doc/po/papd.8.md.ja.po
@@ -228,7 +228,13 @@ msgid ""
 "after accepting a job from the network to have it re-examine the\n"
 "appropriate spool directory. The actual printing and spooling is handled\n"
 "entirely by **lpd**.\n"
-msgstr "**papd** は AppleTalk プリンタ デーモンである。このデーモンは、プリンタ アクセス プロトコル (PAP) を使用して、AppleTalk クライアント (通常は Macintosh コンピュータ) からの印刷ジョブを受け入れる。 System V 印刷システムで使用する場合、**papd** はジョブを **lpd**(8) スプール ディレクトリに直接スプールし、ネットワークからジョブを受け入れた後に **lpd** を起動して適切なスプール ディレクトリを再検査させる。実際の印刷とスプールは、すべて **lpd** によって処理される。\n"
+msgstr ""
+"**papd** は AppleTalk プリンタ デーモンである。\n"
+"このデーモンは、プリンタ アクセス プロトコル (PAP) を使用して、\n"
+"AppleTalk クライアント (通常は Macintosh コンピュータ) からの印刷ジョブを受け入れる。\n"
+"System V 印刷システムで使用する場合、**papd** はジョブを **lpd**(8) スプールディレクトリに\n"
+"直接スプールし、ネットワークからジョブを受け入れた後に **lpd** を起動して適切な\n"
+"スプールディレクトリを再検査させる。実際の印刷とスプールは、すべて **lpd** によって処理される。\n"
 
 #. type: Plain text
 #: manpages/man8/papd.8.md:24
@@ -237,7 +243,10 @@ msgid ""
 "**papd** can also pipe the print job to an external program for\n"
 "processing, and this is the preferred method on systems not using CUPS\n"
 "to avoid compatibility problems with all the flavours of **lpd** in use.\n"
-msgstr "**papd** は、印刷ジョブを外部プログラムにパイプして処理することもできる。これは、CUPS を使用していないシステムで推奨される方法である。これは、使用されているすべての種類の **lpd** との互換性の問題を回避するためである。\n"
+msgstr ""
+"**papd** は、印刷ジョブを外部プログラムにパイプして処理することもできる。\n"
+"これは、CUPS を使用していないシステムで推奨される方法である。\n"
+"これは、使用されているすべての種類の **lpd** との互換性の問題を回避するためである。\n"
 
 #. type: Plain text
 #: manpages/man8/papd.8.md:30
@@ -259,7 +268,9 @@ msgstr ""
 msgid ""
 "**papd** is typically started at boot time from system init scripts or\n"
 "services. It first reads from its configuration file, **papd.conf**.\n"
-msgstr "**papd** は通常、システムの init スクリプトまたはサービスからブート時に起動される。まず、設定ファイル **papd.conf** から読み取る。\n"
+msgstr ""
+"**papd** は通常、システムの init スクリプトまたはサービスからブート時に起動される。\n"
+"まず、設定ファイル **papd.conf** から読み取る。\n"
 
 #. type: Plain text
 #: manpages/man8/papd.8.md:36
@@ -426,11 +437,12 @@ msgid ""
 "manufacturer. If no PPD file is configured, papd will return the default\n"
 "answer, possibly causing the client to send excessively large jobs.\n"
 msgstr ""
-"> PostScript プリンタ記述ファイル。 papd は、設定された PPD\n"
-"ファイルを参照して、印刷クライアントからの設定およびフォントのクエリに応答する。このようなファイルは、Adobe,\n"
-"Inc. またはプリンタの製造元から入手できる。PPD\n"
-"ファイルが設定されていない場合、papd\n"
-"はデフォルトの応答を返すため、クライアントが過度に大きなジョブを送信する可能性がある。\n"
+"> PostScript プリンタ記述ファイル。\n"
+"papd は、設定された PPD ファイルを参照して、\n"
+"印刷クライアントからの設定およびフォントのクエリに応答する。\n"
+"このようなファイルは、Adobe, Inc. またはプリンタの製造元から入手できる。\n"
+"PPD ファイルが設定されていない場合、papd はデフォルトの応答を返すため、\n"
+"クライアントが過度に大きなジョブを送信する可能性がある。\n"
 
 #. type: Plain text
 #: manpages/man8/papd.8.md:125
@@ -444,7 +456,15 @@ msgid ""
 "printer to accept a full 8 bits or take special precautions and convert\n"
 "the printjob's encoding (e.g. by using *co=\"protocol=BCP\"* when using\n"
 "CUPS 1.1.19 or above).\n"
-msgstr "**papd** は、クライアントから上位ビットが設定された文字 (完全な 8 ビット)  を受け入れるが、一部の PostScript プリンタ (Apple の LaserWriter ファミリを含む) は、デフォルトでシリアル インターフェイスで 7 ビット文字のみを受け入れる。TCP/IP メソッド (リモート LPR またはソケット)  経由でアクセスされる一部のプリンタにも同じことが当てはまる。プリンタを 8 ビット全体を受け入れるように設定するか、特別な予防措置を講じて印刷ジョブのエンコードを変換する必要がある (たとえば、CUPS 1.1.19 以降を使用している場合は、*co=\"protocol=BCP\"* を使用する)。\n"
+msgstr ""
+"**papd** は、クライアントから上位ビットが設定された文字 (完全な8ビット) を受け入れるが、\n"
+"一部の PostScript プリンタ (Apple の LaserWriter ファミリを含む) は、\n"
+"デフォルトでシリアルインターフェイスで7ビット文字のみを受け入れる。\n"
+"TCP/IP メソッド (リモート LPR またはソケット) 経由でアクセスされる\n"
+"一部のプリンタにも同じことが当てはまる。\n"
+"プリンタを8ビット全体を受け入れるように設定するか、\n"
+"特別な予防措置を講じて印刷ジョブのエンコードを変換する必要がある \n"
+"(たとえば、CUPS 1.1.19 以降を使用している場合は、*co=\"protocol=BCP\"* を使用する)。\n"
 
 #. type: Plain text
 #: manpages/man8/papd.8.md:129

--- a/doc/po/papd.conf.5.md.ja.po
+++ b/doc/po/papd.conf.5.md.ja.po
@@ -291,7 +291,13 @@ msgid ""
 "Unless the *pd* option is set, the CUPS PPDs will be used. To overwrite\n"
 "these global settings for individual printers simply add them\n"
 "subsequently to papd.conf and assign different settings.\n"
-msgstr "> papd.conf の最初のエントリとして使用すると、papd を介してすべての CUPS プリンタが共有される。この特別な共有プリンタに割り当てられたタイプ/ゾーン設定とその他のパラメータは、すべての CUPS プリンタに適用される。*pd* オプションが設定されていない場合は、CUPS PPD が使用される。個々のプリンタのこれらのグローバル設定を上書きするには、後でそれらを papd.conf に追加し、異なる設定を割り当てるだけである。\n"
+msgstr ""
+"> papd.conf の最初のエントリとして使用すると、papd を介してすべての CUPS プリンタが共有される。\n"
+"この特別な共有プリンタに割り当てられたタイプ/ゾーン設定とその他のパラメータは、\n"
+"すべての CUPS プリンタに適用される。\n"
+"*pd* オプションが設定されていない場合は、CUPS PPD が使用される。\n"
+"個々のプリンタのこれらのグローバル設定を上書きするには、\n"
+"後でそれらを papd.conf に追加し、異なる設定を割り当てるだけである。\n"
 
 #. type: Plain text
 #: manpages/man5/papd.conf.5.md:66
@@ -307,7 +313,11 @@ msgid ""
 "originating from pre-Mac OS X LaserWriter drivers to let *foomatic-rip*\n"
 "recognize foomatic PPD options set in the printer dialog. Attention: Use\n"
 "with caution since this might corrupt binary print jobs!\n"
-msgstr "> このフラグが存在する場合、Mac OS X 以前の LaserWriter ドライバから生成された行末を変換するハックが有効になり、*foomatic-rip* がプリンタ ダイアログで設定された foomatic PPD オプションを認識できるようになる。注意: バイナリ印刷ジョブが破損する可能性があるため、注意して使用してください。\n"
+msgstr ""
+"> このフラグが存在する場合、Mac OS X 以前の LaserWriter ドライバから\n"
+"生成された行末を変換するハックが有効になり、*foomatic-rip* がプリンタダイアログで\n"
+"設定された foomatic PPD オプションを認識できるようになる。\n"
+"注意: バイナリ印刷ジョブが破損する可能性があるため、注意して使用してください。\n"
 
 #. type: Plain text
 #: manpages/man5/papd.conf.5.md:73

--- a/doc/po/rtmpqry.1.md.ja.po
+++ b/doc/po/rtmpqry.1.md.ja.po
@@ -1,14 +1,14 @@
-# Japanese translations for Netatalk package
-# Copyright (C) 2025 Contributors to the Netatalk Project
+# Japanese translations for Netatalk documentation
+# Netatalk ドキュメントの日本語訳
+# Copyright (C) 2025 Daniel Markstedt <daniel@mindani.net>
 # This file is distributed under the same license as the Netatalk package.
-# Automatically generated, 2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Netatalk 4.3.0dev\n"
-"POT-Creation-Date: 2025-05-25 09:45+0200\n"
+"POT-Creation-Date: 2025-07-29 20:18+0200\n"
 "PO-Revision-Date: 2025-05-25 09:45+0200\n"
-"Last-Translator: Automatically generated\n"
+"Last-Translator: Daniel Markstedt <daniel@mindani.net>\n"
 "Language-Team: none\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
@@ -79,28 +79,28 @@ msgid "Description"
 msgstr "説明"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:116 manpages/man1/afppasswd.1.md:36
+#: manpages/man1/ad.1.md:124 manpages/man1/afppasswd.1.md:36
 #: manpages/man1/rtmpqry.1.md:18
 #, no-wrap
 msgid "**-a**\n"
 msgstr ""
 
 #. type: Title #
-#: manpages/man1/ad.1.md:274 manpages/man1/addump.1.md:73
+#: manpages/man1/ad.1.md:295 manpages/man1/addump.1.md:73
 #: manpages/man1/aecho.1.md:50 manpages/man1/afpldaptest.1.md:38
 #: manpages/man1/afppasswd.1.md:72 manpages/man1/afpstats.1.md:31
 #: manpages/man1/afptest.1.md:179 manpages/man1/asip-status.1.md:106
-#: manpages/man1/dbd.1.md:63 manpages/man1/getzones.1.md:88
+#: manpages/man1/dbd.1.md:72 manpages/man1/getzones.1.md:88
 #: manpages/man1/macusers.1.md:29 manpages/man1/nbp.1.md:90
 #: manpages/man1/pap.1.md:97 manpages/man1/rtmpqry.1.md:56
 #: manpages/man3/atalk_aton.3.md:28 manpages/man3/nbp_name.3.md:42
 #: manpages/man4/atalk.4.md:49 manpages/man5/afp_signature.conf.5.md:48
-#: manpages/man5/afp_voluuid.conf.5.md:40 manpages/man5/afp.conf.5.md:1339
+#: manpages/man5/afp_voluuid.conf.5.md:40 manpages/man5/afp.conf.5.md:1353
 #: manpages/man5/atalkd.conf.5.md:102 manpages/man5/extmap.conf.5.md:32
 #: manpages/man5/papd.conf.5.md:168 manpages/man8/a2boot.8.md:46
 #: manpages/man8/afpd.8.md:118 manpages/man8/atalkd.8.md:83
-#: manpages/man8/cnid_dbd.8.md:145 manpages/man8/cnid_metad.8.md:48
-#: manpages/man8/macipgw.8.md:107 manpages/man8/netatalk.8.md:52
+#: manpages/man8/cnid_dbd.8.md:146 manpages/man8/cnid_metad.8.md:51
+#: manpages/man8/macipgw.8.md:107 manpages/man8/netatalk.8.md:61
 #: manpages/man8/papd.8.md:134 manpages/man8/papstatus.8.md:53
 #: manpages/man8/timelord.8.md:42
 #, no-wrap
@@ -108,21 +108,21 @@ msgid "Author"
 msgstr "著者"
 
 #. type: Plain text
-#: manpages/man1/ad.1.md:276 manpages/man1/addump.1.md:75
+#: manpages/man1/ad.1.md:297 manpages/man1/addump.1.md:75
 #: manpages/man1/aecho.1.md:52 manpages/man1/afpldaptest.1.md:40
 #: manpages/man1/afppasswd.1.md:74 manpages/man1/afpstats.1.md:33
 #: manpages/man1/afptest.1.md:181 manpages/man1/asip-status.1.md:108
-#: manpages/man1/dbd.1.md:65 manpages/man1/getzones.1.md:90
+#: manpages/man1/dbd.1.md:74 manpages/man1/getzones.1.md:90
 #: manpages/man1/macusers.1.md:31 manpages/man1/nbp.1.md:92
 #: manpages/man1/pap.1.md:99 manpages/man1/rtmpqry.1.md:58
 #: manpages/man3/atalk_aton.3.md:30 manpages/man3/nbp_name.3.md:44
 #: manpages/man4/atalk.4.md:51 manpages/man5/afp_signature.conf.5.md:50
-#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1341
+#: manpages/man5/afp_voluuid.conf.5.md:42 manpages/man5/afp.conf.5.md:1355
 #: manpages/man5/atalkd.conf.5.md:104 manpages/man5/extmap.conf.5.md:34
 #: manpages/man5/papd.conf.5.md:170 manpages/man8/a2boot.8.md:48
 #: manpages/man8/afpd.8.md:120 manpages/man8/atalkd.8.md:85
-#: manpages/man8/cnid_dbd.8.md:147 manpages/man8/cnid_metad.8.md:50
-#: manpages/man8/netatalk.8.md:54 manpages/man8/papd.8.md:136
+#: manpages/man8/cnid_dbd.8.md:148 manpages/man8/cnid_metad.8.md:53
+#: manpages/man8/netatalk.8.md:63 manpages/man8/papd.8.md:136
 #: manpages/man8/papstatus.8.md:55 manpages/man8/timelord.8.md:44
 msgid ""
 "[Contributors to the Netatalk Project](https://netatalk.io/contributors)"
@@ -131,13 +131,13 @@ msgstr "[CONTRIBUTORS](https://netatalk.io/contributors) を参照"
 #. type: Title #
 #: manpages/man1/addump.1.md:29 manpages/man1/aecho.1.md:40
 #: manpages/man1/afpldaptest.1.md:16 manpages/man1/afppasswd.1.md:33
-#: manpages/man1/asip-status.1.md:28 manpages/man1/dbd.1.md:17
+#: manpages/man1/asip-status.1.md:28 manpages/man1/dbd.1.md:21
 #: manpages/man1/getzones.1.md:16 manpages/man1/macusers.1.md:15
 #: manpages/man1/pap.1.md:29 manpages/man1/rtmpqry.1.md:15
 #: manpages/man8/a2boot.8.md:32 manpages/man8/afpd.8.md:19
-#: manpages/man8/atalkd.8.md:26 manpages/man8/cnid_dbd.8.md:57
-#: manpages/man8/cnid_metad.8.md:18 manpages/man8/macipgw.8.md:38
-#: manpages/man8/netatalk.8.md:17 manpages/man8/papd.8.md:37
+#: manpages/man8/atalkd.8.md:26 manpages/man8/cnid_dbd.8.md:58
+#: manpages/man8/cnid_metad.8.md:21 manpages/man8/macipgw.8.md:38
+#: manpages/man8/netatalk.8.md:26 manpages/man8/papd.8.md:37
 #: manpages/man8/papstatus.8.md:24 manpages/man8/timelord.8.md:23
 #, no-wrap
 msgid "Options"
@@ -149,12 +149,12 @@ msgstr "オプション"
 #: manpages/man1/afpstats.1.md:27 manpages/man1/getzones.1.md:84
 #: manpages/man1/macusers.1.md:25 manpages/man1/pap.1.md:93
 #: manpages/man1/rtmpqry.1.md:52 manpages/man3/atalk_aton.3.md:24
-#: manpages/man4/atalk.4.md:45 manpages/man5/afp.conf.5.md:1334
+#: manpages/man4/atalk.4.md:45 manpages/man5/afp.conf.5.md:1348
 #: manpages/man5/atalkd.conf.5.md:98 manpages/man5/extmap.conf.5.md:28
 #: manpages/man5/papd.conf.5.md:164 manpages/man8/afpd.8.md:112
-#: manpages/man8/atalkd.8.md:79 manpages/man8/cnid_dbd.8.md:141
-#: manpages/man8/cnid_metad.8.md:44 manpages/man8/macipgw.8.md:98
-#: manpages/man8/netatalk.8.md:48 manpages/man8/papstatus.8.md:49
+#: manpages/man8/atalkd.8.md:79 manpages/man8/cnid_dbd.8.md:142
+#: manpages/man8/cnid_metad.8.md:47 manpages/man8/macipgw.8.md:98
+#: manpages/man8/netatalk.8.md:57 manpages/man8/papstatus.8.md:49
 #, no-wrap
 msgid "See Also"
 msgstr "関連項目"
@@ -165,7 +165,7 @@ msgstr "関連項目"
 #: manpages/man1/asip-status.1.md:54 manpages/man1/getzones.1.md:57
 #: manpages/man1/nbp.1.md:62 manpages/man1/rtmpqry.1.md:34
 #: manpages/man3/nbp_name.3.md:26 manpages/man5/afp_signature.conf.5.md:37
-#: manpages/man5/afp_voluuid.conf.5.md:27 manpages/man5/afp.conf.5.md:1288
+#: manpages/man5/afp_voluuid.conf.5.md:27 manpages/man5/afp.conf.5.md:1302
 #: manpages/man5/atalkd.conf.5.md:80 manpages/man5/extmap.conf.5.md:18
 #: manpages/man5/papd.conf.5.md:91 manpages/man8/macipgw.8.md:78
 #, no-wrap
@@ -258,7 +258,7 @@ msgstr "12.1 のルータからすべてのルートを取得する："
 #: manpages/man1/rtmpqry.1.md:49
 #, no-wrap
 msgid ""
-"    example$ build/bin/rtmpqry/rtmpqry -a 12.1\n"
+"    example$ rtmpqry -a 12.1\n"
 "    3 - 10 distance 0 via 12.1\n"
 "    11 distance 0 via 12.1\n"
 "    12 distance 0 via 12.1\n"


### PR DESCRIPTION
This should take care of all translatable strings, while refreshing gettext references and touching up line endings

Also includes a refresh of the compilation readme