### PR TITLE
Remove C source file overrides since astyle fixed their bug

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -10,8 +10,6 @@
 --delete-empty-lines
 --exclude=build
 --exclude=builddir
---exclude=etc/afpd/directory.c
---exclude=etc/afpd/file.c
 --exclude=libatalk/unicode/precompose.h
 --exclude=libatalk/unicode/utf16_case.c
 --exclude=libatalk/unicode/utf16_casetable.h


### PR DESCRIPTION
A bug in astyle previously caused a breakdown in indentation under very specific circumstances