### PR TITLE
testsuite: Prevent potential buffer overflow in FPGetFileDirParms test

### DIFF
--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -832,7 +832,15 @@ STATIC void test336()
 
     if (Path) {
         struct stat st;
-        sprintf(temp1, "%s/%s/%s", Path, ndir, temp);
+        int len = snprintf(temp1, sizeof(temp1), "%s/%s/%s", Path, ndir, temp);
+
+        if (len < 0 || len >= sizeof(temp1)) {
+            if (!Quiet) {
+                fprintf(stdout, "\tFAILED path too long for temp1 buffer\n");
+            }
+
+            test_failed();
+        }
 
         if (stat(temp1, &st)) {
             if (!Quiet) {


### PR DESCRIPTION
Use snprintf to write to buffer with enforced max length, and bail out if the operation isn't successful,
which should make gcc 13.3.0 on Ubuntu 24.04 happy