### PR TITLE
testsuite: Add dircache-focused performance tests to afp_lantest

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+# Build artifacts
+build/
+clean/
+*.o
+*.a

--- a/contrib/scripts/netatalk_container_entrypoint.sh
+++ b/contrib/scripts/netatalk_container_entrypoint.sh
@@ -265,23 +265,29 @@ if [ -z "$TESTSUITE" ]; then
 else
     netatalk
     sleep 2
+    echo "*** Running testsuite: $TESTSUITE"
     case "$TESTSUITE" in
         spectest)
+            echo "afp_spectest $TEST_FLAGS -$AFP_VERSION -h $AFP_HOST -p $AFP_PORT -u $AFP_USER -d $AFP_USER2 -w $AFP_PASS -s $SHARE_NAME -S $SHARE_NAME2"
             afp_spectest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -d "$AFP_USER2" -w "$AFP_PASS" -s "$SHARE_NAME" -S "$SHARE_NAME2"
             ;;
         readonly)
             echo "testfile uno" > /mnt/afpshare/first.txt
             echo "testfile dos" > /mnt/afpshare/second.txt
             mkdir /mnt/afpshare/third
+            echo "afp_spectest $TEST_FLAGS -$AFP_VERSION -h $AFP_HOST -p $AFP_PORT -u $AFP_USER -w $AFP_PASS -s $SHARE_NAME -f Readonly_test"
             afp_spectest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" -f Readonly_test
             ;;
         login)
+            echo "afp_logintest $TEST_FLAGS -$AFP_VERSION -h $AFP_HOST -p $AFP_PORT -u $AFP_USER -w $AFP_PASS"
             afp_logintest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS"
             ;;
         lan)
+            echo "afp_lantest $TEST_FLAGS -$AFP_VERSION -h $AFP_HOST -p $AFP_PORT -u $AFP_USER -w $AFP_PASS -s $SHARE_NAME"
             afp_lantest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME"
             ;;
         speed)
+            echo "afp_speedtest $TEST_FLAGS -$AFP_VERSION -h $AFP_HOST -p $AFP_PORT -u $AFP_USER -w $AFP_PASS -s $SHARE_NAME"
             afp_speedtest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME"
             ;;
         *)

--- a/doc/manpages/man1/afp_lantest.1.md
+++ b/doc/manpages/man1/afp_lantest.1.md
@@ -1,0 +1,174 @@
+# Name
+
+afp_lantest — AFP LAN performance and directory cache testing tool
+
+# Synopsis
+
+**afp_lantest** [-34567GgVvbC] [-h *host*] [-p *port*] [-s *volume*] [-u *user*] [-w *password*]
+[-n *iterations*] [-f *tests*] [-F *bigfile*]
+
+# Description
+
+**afp_lantest** is a comprehensive AFP (Apple Filing Protocol) performance testing tool designed to
+benchmark various aspects of AFP servers, with special focus on directory cache performance
+improvements in netatalk.
+
+The tool runs a series of tests that measure file operations, directory traversal, and caching
+efficiency. It includes both traditional file system benchmarks and specialized cache-focused tests
+that highlight the benefits of optimized directory cache validation and probabilistic validation
+features.
+
+# Options
+
+**-3**
+: Use AFP 3.0 protocol version
+
+**-4**
+: Use AFP 3.1 protocol version
+
+**-5**
+: Use AFP 3.2 protocol version
+
+**-6**
+: Use AFP 3.3 protocol version
+
+**-7**
+: Use AFP 3.4 protocol version (default)
+
+**-h** *host*
+: Server hostname or IP address (default: localhost)
+
+**-p** *port*
+: Server port number (default: 548)
+
+**-s** *volume*
+: Volume name to mount for testing
+
+**-u** *user*
+: Username for authentication (default: current uid)
+
+**-w** *password*
+: Password for authentication
+
+**-n** *iterations*
+: Number of test iterations to run (default: 1)
+
+**-f** *tests*
+: Specific tests to run, specified as digits (e.g., "134" runs tests 1, 3, and 4)
+
+**-F** *bigfile*
+: Use existing file in volume root for read test (file size must match -g/-G options)
+
+**-g**
+: Optimize for gigabit networks (increases file test size to 1 GB)
+
+**-G**
+: Optimize for 10-gigabit networks (increases file test size to 10 GB)
+
+**-C**
+: Run cache-focused tests only (tests 8-11)
+
+**-v**
+: Verbose output
+
+**-V**
+: Very verbose output
+
+**-b**
+: Debug mode
+
+# Available Tests
+
+The following tests are available:
+
+**(1) Opening, stating and reading 512 bytes from 1000 files**
+: Tests basic file access patterns with many small operations
+
+**(2) Writing one large file**
+: Measures sustained write performance
+
+**(3) Reading one large file**
+: Measures sustained read performance
+
+**(4) Locking/Unlocking 10000 times each**
+: Tests file locking performance
+
+**(5) Creating dir with 2000 files**
+: Tests directory creation and file creation performance
+
+**(6) Enumerate dir with 2000 files**
+: Tests directory enumeration with many files
+
+**(7) Create directory tree with 10^3 dirs**
+: Tests nested directory creation
+
+**(8) Directory cache hits [CACHE]**
+: Tests directory and file lookup performance (1000 dirs + 10000 files)
+
+**(9) Mixed cache operations [CACHE]**
+: Tests mixed create/stat/enum/delete operations
+
+**(10) Deep path traversal [CACHE]**
+: Tests performance with deep directory structures
+
+**(11) Cache validation [CACHE]**
+: Tests directory cache validation mechanisms
+
+## Cache-Focused Tests
+
+Tests 8-11 are specifically designed to highlight directory cache performance improvements in
+netatalk. These tests benefit significantly from optimized cache validation and probabilistic
+validation features. Use the **-C** option to run only these cache-focused tests.
+
+# Examples
+
+Run all tests with default settings:
+
+```bash
+afp_lantest -h server.example.com -u testuser -w password -s TestVolume
+```
+
+Run only cache-focused tests:
+
+```bash
+afp_lantest -C -h server.example.com -u testuser -w password -s TestVolume
+```
+
+Run specific tests (file operations):
+
+```bash
+afp_lantest -f 123 -h server.example.com -u testuser -w password -s TestVolume
+```
+
+Run tests optimized for gigabit network:
+
+```bash
+afp_lantest -g -h server.example.com -u testuser -w password -s TestVolume
+```
+
+Run multiple iterations for statistical analysis:
+
+```bash
+afp_lantest -n 5 -h server.example.com -u testuser -w password -s TestVolume
+```
+
+# Return Codes
+
+**0**
+: All tests passed successfully
+
+**1**
+: One or more tests failed
+
+# Notes
+
+- Tests that involve large file operations (tests 2 and 3) will create temporary files in the
+  test volume
+- The **-g** and **-G** options significantly increase test file sizes and test duration
+- Cache-focused tests (8-11) provide the most insight into netatalk's directory cache performance
+- Multiple iterations (**-n**) are recommended for consistent performance measurements
+- The tool requires write access to the specified AFP volume
+
+# See Also
+
+**afptest**(1), **afpd**(8), **netatalk**(8)

--- a/doc/manpages/man1/afptest.1.md
+++ b/doc/manpages/man1/afptest.1.md
@@ -4,7 +4,7 @@ afp_lantest, afp_logintest, afp_spectest, afp_speedtest, afparg, fce_listen — 
 
 # Synopsis
 
-**afp_lantest** [-34567GgVv] [-h *host*] [-p *port*] [-s *volume*] [-u *user*] [-w *password*] [-n *iterations*]
+**afp_lantest** [-34567CGgVv] [-h *host*] [-p *port*] [-s *volume*] [-u *user*] [-w *password*] [-n *iterations*]
 [-t *tests*] [-F *bigfile*]
 
 **afp_logintest** [-1234567CmVv] [-h *host*] [-p *port*] [-s *volume*] [-u *user*] [-w *password*]
@@ -150,27 +150,69 @@ Run the afp_spectest for the "FPSetForkParms_test" testset with AFP 3.4.
     FPSetForkParms:test217: Setfork size 64 bits - PASSED
     FPSetForkParms:test306: set fork size, new size > old size - PASSED
 
-Run the afp_lantest benchmark using AFP 3.0.
+Run the afp_lantest benchmark using AFP 3.4.
 
-    % afp_lantest -h 192.168.0.2 -s testvol1 -u user1 -w passwd -3
-    Run 0 => Opening, stating and reading 512 bytes from 1000 files   1799 ms
-    Run 0 => Writing one large file                                     30 ms for 100 MB (avg. 3495 MB/s)
-    Run 0 => Reading one large file                                      8 ms for 100 MB (avg. 13107 MB/s)
-    Run 0 => Locking/Unlocking 10000 times each                       1959 ms
-    Run 0 => Creating dir with 2000 files                             1339 ms
-    Run 0 => Enumerate dir with 2000 files                             217 ms
-    Run 0 => Create directory tree with 10^3 dirs                      496 ms
+    % afp_lantest -7 -h localhost -p 548 -u test -w test -s "File Sharing" -n 2
+    Run 0 => Opening, stating and reading 512 bytes from 1000 files   3237 ms
+    Run 0 => Writing one large file                                    146 ms for 100 MB (avg. 718 MB/s)
+    Run 0 => Reading one large file                                     36 ms for 100 MB (avg. 2912 MB/s)
+    Run 0 => Locking/Unlocking 10000 times each                        772 ms
+    Run 0 => Creating dir with 2000 files                             3615 ms
+    Run 0 => Enumerate dir with 2000 files                             755 ms
+    Run 0 => Create directory tree with 10^3 dirs                     1724 ms
+    Run 0 => Directory cache hits (1000 dir + 10000 file lookups)     3056 ms
+    Run 0 => Mixed cache operations (create/stat/enum/delete)          484 ms
+    Run 0 => Deep path traversal (nested directory navigation)         377 ms
+    Run 0 => Cache validation efficiency (metadata changes)           8822 ms
+    Run 1 => Opening, stating and reading 512 bytes from 1000 files   3448 ms
+    Run 1 => Writing one large file                                     79 ms for 100 MB (avg. 1327 MB/s)
+    Run 1 => Reading one large file                                     37 ms for 100 MB (avg. 2833 MB/s)
+    Run 1 => Locking/Unlocking 10000 times each                        779 ms
+    Run 1 => Creating dir with 2000 files                             3731 ms
+    Run 1 => Enumerate dir with 2000 files                             587 ms
+    Run 1 => Create directory tree with 10^3 dirs                     1802 ms
+    Run 1 => Directory cache hits (1000 dir + 10000 file lookups)     3006 ms
+    Run 1 => Mixed cache operations (create/stat/enum/delete)          463 ms
+    Run 1 => Deep path traversal (nested directory navigation)         247 ms
+    Run 1 => Cache validation efficiency (metadata changes)           8565 ms
 
-    Netatalk Lantest Results (averages)
+    Netatalk Lantest Results (average times across 2 iterations)
     ===================================
 
-    Opening, stating and reading 512 bytes from 1000 files   1799 ms
-    Writing one large file                                     30 ms for 100 MB (avg. 3495 MB/s)
-    Reading one large file                                      8 ms for 100 MB (avg. 13107 MB/s)
-    Locking/Unlocking 10000 times each                       1959 ms
-    Creating dir with 2000 files                             1339 ms
-    Enumerate dir with 2000 files                             217 ms
-    Create directory tree with 10^3 dirs                      496 ms
+    Test 1: Opening, stating and reading 512 bytes from 1000 files
+     Average:   3342 ms ± 149.2 ms (std dev)
+
+    Test 2: Writing one large file
+     Average:    112 ms ± 47.4 ms (std dev)
+     Throughput: 936 MB/s (Write, 100 MB file)
+
+    Test 3: Reading one large file
+     Average:     36 ms ± 1.0 ms (std dev)
+     Throughput: 2912 MB/s (Read, 100 MB file)
+
+    Test 4: Locking/Unlocking 10000 times each
+     Average:    775 ms ± 5.0 ms (std dev)
+
+    Test 5: Creating dir with 2000 files
+     Average:   3673 ms ± 82.0 ms (std dev)
+
+    Test 6: Enumerate dir with 2000 files
+     Average:    671 ms ± 118.8 ms (std dev)
+
+    Test 7: Create directory tree with 10^3 dirs
+     Average:   1763 ms ± 55.2 ms (std dev)
+
+    Test 8: Directory cache hits (1000 dir + 10000 file lookups)
+     Average:   3031 ms ± 35.4 ms (std dev)
+
+    Test 9: Mixed cache operations (create/stat/enum/delete)
+     Average:    473 ms ± 14.9 ms (std dev)
+
+    Test 10: Deep path traversal (nested directory navigation)
+     Average:    312 ms ± 91.9 ms (std dev)
+
+    Test 11: Cache validation efficiency (metadata changes)
+     Average:   8693 ms ± 181.7 ms (std dev)
 
 # See also
 

--- a/doc/manpages/man1/meson.build
+++ b/doc/manpages/man1/meson.build
@@ -1,5 +1,6 @@
 manfiles = [
     'ad',
+    'afp_lantest',
     'afpldaptest',
     'afppasswd',
     'afpstats',

--- a/doc/manual/_Sidebar.md
+++ b/doc/manual/_Sidebar.md
@@ -15,6 +15,7 @@ User Tools
 * [ad](ad.1.html)
 * [addump](addump.1.html)
 * [aecho](aecho.1.html)
+* [afp_lantest](afp_lantest.1.html)
 * [afpldaptest](afpldaptest.1.html)
 * [afppasswd](afppasswd.1.html)
 * [afpstats](afpstats.1.html)

--- a/doc/po/afp_lantest.1.md.ja.po
+++ b/doc/po/afp_lantest.1.md.ja.po
@@ -1,0 +1,540 @@
+# Japanese translations for Netatalk package
+# Copyright (C) 2025 Contributors to the Netatalk Project
+# This file is distributed under the same license as the Netatalk package.
+# Automatically generated, 2025.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Netatalk 4.3.0\n"
+"POT-Creation-Date: 2025-08-04 14:23+1000\n"
+"PO-Revision-Date: 2025-08-04 14:22+1000\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#. type: Plain text
+#: manpages/man1/ad.1.md:2 manpages/man1/addump.1.md:2
+#: manpages/man1/aecho.1.md:2 manpages/man1/afp_lantest.1.md:2
+#: manpages/man1/afpldaptest.1.md:2 manpages/man1/afppasswd.1.md:2
+#: manpages/man1/afpstats.1.md:2 manpages/man1/afptest.1.md:2
+#: manpages/man1/asip-status.1.md:2 manpages/man1/dbd.1.md:2
+#: manpages/man1/getzones.1.md:2 manpages/man1/macusers.1.md:2
+#: manpages/man1/nbp.1.md:2 manpages/man1/pap.1.md:2
+#: manpages/man1/rtmpqry.1.md:2 manpages/man3/atalk_aton.3.md:2
+#: manpages/man3/nbp_name.3.md:2 manpages/man4/atalk.4.md:2
+#: manpages/man5/afp_signature.conf.5.md:2
+#: manpages/man5/afp_voluuid.conf.5.md:2 manpages/man5/afp.conf.5.md:2
+#: manpages/man5/atalkd.conf.5.md:2 manpages/man5/extmap.conf.5.md:2
+#: manpages/man5/papd.conf.5.md:2 manpages/man8/a2boot.8.md:2
+#: manpages/man8/afpd.8.md:2 manpages/man8/atalkd.8.md:2
+#: manpages/man8/cnid_dbd.8.md:2 manpages/man8/cnid_metad.8.md:2
+#: manpages/man8/macipgw.8.md:2 manpages/man8/netatalk.8.md:2
+#: manpages/man8/papd.8.md:2 manpages/man8/papstatus.8.md:2
+#: manpages/man8/timelord.8.md:2
+#, fuzzy
+#| msgid "Name"
+msgid "# Name"
+msgstr "名前"
+
+#. type: Plain text
+#: manpages/man1/ad.1.md:6 manpages/man1/addump.1.md:6
+#: manpages/man1/aecho.1.md:6 manpages/man1/afp_lantest.1.md:6
+#: manpages/man1/afpldaptest.1.md:6 manpages/man1/afppasswd.1.md:6
+#: manpages/man1/afpstats.1.md:6 manpages/man1/afptest.1.md:6
+#: manpages/man1/asip-status.1.md:6 manpages/man1/dbd.1.md:6
+#: manpages/man1/getzones.1.md:6 manpages/man1/macusers.1.md:6
+#: manpages/man1/nbp.1.md:6 manpages/man1/pap.1.md:6
+#: manpages/man1/rtmpqry.1.md:6 manpages/man3/atalk_aton.3.md:6
+#: manpages/man3/nbp_name.3.md:6 manpages/man4/atalk.4.md:6
+#: manpages/man5/afp.conf.5.md:6 manpages/man8/a2boot.8.md:6
+#: manpages/man8/afpd.8.md:6 manpages/man8/atalkd.8.md:6
+#: manpages/man8/cnid_dbd.8.md:6 manpages/man8/cnid_metad.8.md:6
+#: manpages/man8/macipgw.8.md:6 manpages/man8/netatalk.8.md:6
+#: manpages/man8/papd.8.md:6 manpages/man8/papstatus.8.md:6
+#: manpages/man8/timelord.8.md:6
+#, fuzzy
+#| msgid "Synopsis"
+msgid "# Synopsis"
+msgstr "概要"
+
+#. type: Plain text
+#: manpages/man1/ad.1.md:12 manpages/man1/addump.1.md:20
+#: manpages/man1/aecho.1.md:10 manpages/man1/afp_lantest.1.md:11
+#: manpages/man1/afpldaptest.1.md:12 manpages/man1/afppasswd.1.md:10
+#: manpages/man1/afpstats.1.md:10 manpages/man1/afptest.1.md:23
+#: manpages/man1/asip-status.1.md:14 manpages/man1/dbd.1.md:12
+#: manpages/man1/getzones.1.md:10 manpages/man1/macusers.1.md:12
+#: manpages/man1/nbp.1.md:14 manpages/man1/pap.1.md:10
+#: manpages/man1/rtmpqry.1.md:10 manpages/man3/atalk_aton.3.md:15
+#: manpages/man3/nbp_name.3.md:17 manpages/man4/atalk.4.md:11
+#: manpages/man5/afp_signature.conf.5.md:6
+#: manpages/man5/afp_voluuid.conf.5.md:6 manpages/man5/atalkd.conf.5.md:6
+#: manpages/man5/extmap.conf.5.md:6 manpages/man5/papd.conf.5.md:6
+#: manpages/man8/a2boot.8.md:12 manpages/man8/afpd.8.md:12
+#: manpages/man8/atalkd.8.md:12 manpages/man8/cnid_dbd.8.md:12
+#: manpages/man8/cnid_metad.8.md:12 manpages/man8/macipgw.8.md:12
+#: manpages/man8/netatalk.8.md:12 manpages/man8/papd.8.md:12
+#: manpages/man8/papstatus.8.md:10 manpages/man8/timelord.8.md:12
+#, fuzzy
+#| msgid "Description"
+msgid "# Description"
+msgstr "説明"
+
+#. type: Plain text
+#: manpages/man1/addump.1.md:30 manpages/man1/aecho.1.md:41
+#: manpages/man1/afp_lantest.1.md:22 manpages/man1/afpldaptest.1.md:17
+#: manpages/man1/afppasswd.1.md:34 manpages/man1/asip-status.1.md:29
+#: manpages/man1/dbd.1.md:22 manpages/man1/getzones.1.md:17
+#: manpages/man1/macusers.1.md:16 manpages/man1/pap.1.md:30
+#: manpages/man1/rtmpqry.1.md:16 manpages/man8/a2boot.8.md:33
+#: manpages/man8/afpd.8.md:20 manpages/man8/atalkd.8.md:27
+#: manpages/man8/cnid_dbd.8.md:59 manpages/man8/cnid_metad.8.md:22
+#: manpages/man8/macipgw.8.md:39 manpages/man8/netatalk.8.md:27
+#: manpages/man8/papd.8.md:38 manpages/man8/papstatus.8.md:25
+#: manpages/man8/timelord.8.md:24
+#, fuzzy
+#| msgid "Options"
+msgid "# Options"
+msgstr "オプション"
+
+#. type: Plain text
+#: manpages/man1/addump.1.md:69 manpages/man1/aecho.1.md:47
+#: manpages/man1/afp_lantest.1.md:168 manpages/man1/afpldaptest.1.md:35
+#: manpages/man1/afppasswd.1.md:69 manpages/man1/afpstats.1.md:28
+#: manpages/man1/getzones.1.md:85 manpages/man1/macusers.1.md:26
+#: manpages/man1/pap.1.md:94 manpages/man1/rtmpqry.1.md:53
+#: manpages/man3/atalk_aton.3.md:25 manpages/man4/atalk.4.md:46
+#: manpages/man5/afp.conf.5.md:1349 manpages/man5/atalkd.conf.5.md:99
+#: manpages/man5/extmap.conf.5.md:29 manpages/man5/papd.conf.5.md:165
+#: manpages/man8/afpd.8.md:113 manpages/man8/atalkd.8.md:80
+#: manpages/man8/cnid_dbd.8.md:143 manpages/man8/cnid_metad.8.md:48
+#: manpages/man8/macipgw.8.md:99 manpages/man8/netatalk.8.md:58
+#: manpages/man8/papstatus.8.md:50
+#, fuzzy
+#| msgid "See Also"
+msgid "# See Also"
+msgstr "関連項目"
+
+#. type: Plain text
+#: manpages/man1/aecho.1.md:25 manpages/man1/afp_lantest.1.md:124
+#: manpages/man1/afppasswd.1.md:25 manpages/man1/afpstats.1.md:21
+#: manpages/man1/afptest.1.md:107 manpages/man1/asip-status.1.md:55
+#: manpages/man1/getzones.1.md:58 manpages/man1/nbp.1.md:63
+#: manpages/man1/rtmpqry.1.md:35 manpages/man3/nbp_name.3.md:27
+#: manpages/man5/afp_signature.conf.5.md:38
+#: manpages/man5/afp_voluuid.conf.5.md:28 manpages/man5/afp.conf.5.md:1303
+#: manpages/man5/atalkd.conf.5.md:81 manpages/man5/extmap.conf.5.md:19
+#: manpages/man5/papd.conf.5.md:92 manpages/man8/macipgw.8.md:79
+#, fuzzy
+#| msgid "Examples"
+msgid "# Examples"
+msgstr "例"
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:4
+msgid "afp_lantest — AFP LAN performance and directory cache testing tool"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:9
+#, no-wrap
+msgid ""
+"**afp_lantest** [-34567GgVvbC] [-h *host*] [-p *port*] [-s *volume*] [-u *user*] [-w *password*] \n"
+"[-n *iterations*] [-f *tests*] [-F *bigfile*]\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:15
+#, no-wrap
+msgid ""
+"**afp_lantest** is a comprehensive AFP (Apple Filing Protocol) performance testing tool designed to \n"
+"benchmark various aspects of AFP servers, with special focus on directory cache performance \n"
+"improvements in netatalk.\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:20
+msgid ""
+"The tool runs a series of tests that measure file operations, directory "
+"traversal, and caching efficiency. It includes both traditional file system "
+"benchmarks and specialized cache-focused tests that highlight the benefits "
+"of optimized directory cache validation and probabilistic validation "
+"features."
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:25
+#, no-wrap
+msgid ""
+"**-3**\n"
+": Use AFP 3.0 protocol version\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:28
+#, no-wrap
+msgid ""
+"**-4** \n"
+": Use AFP 3.1 protocol version\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:31
+#, no-wrap
+msgid ""
+"**-5**\n"
+": Use AFP 3.2 protocol version\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:34
+#, no-wrap
+msgid ""
+"**-6**\n"
+": Use AFP 3.3 protocol version\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:37
+#, no-wrap
+msgid ""
+"**-7**\n"
+": Use AFP 3.4 protocol version (default)\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:40
+#, no-wrap
+msgid ""
+"**-h** *host*\n"
+": Server hostname or IP address (default: localhost)\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:43
+#, no-wrap
+msgid ""
+"**-p** *port*\n"
+": Server port number (default: 548)\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:46
+#, no-wrap
+msgid ""
+"**-s** *volume*\n"
+": Volume name to mount for testing\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:49
+#, no-wrap
+msgid ""
+"**-u** *user*\n"
+": Username for authentication (default: current uid)\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:52
+#, fuzzy, no-wrap
+#| msgid "**-w** *password string*\n"
+msgid ""
+"**-w** *password*\n"
+": Password for authentication\n"
+msgstr "**-w** *パスワード文字列*\n"
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:55
+#, no-wrap
+msgid ""
+"**-n** *iterations*\n"
+": Number of test iterations to run (default: 1)\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:58
+#, no-wrap
+msgid ""
+"**-f** *tests*\n"
+": Specific tests to run, specified as digits (e.g., \"134\" runs tests 1, 3, and 4)\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:61
+#, no-wrap
+msgid ""
+"**-F** *bigfile*\n"
+": Use existing file in volume root for read test (file size must match -g/-G options)\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:64
+#, no-wrap
+msgid ""
+"**-g**\n"
+": Optimize for gigabit networks (increases file test size to 1 GB)\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:67
+#, no-wrap
+msgid ""
+"**-G**\n"
+": Optimize for 10-gigabit networks (increases file test size to 10 GB)\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:70
+#, no-wrap
+msgid ""
+"**-C**\n"
+": Run cache-focused tests only (tests 8-11)\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:73
+#, no-wrap
+msgid ""
+"**-v**\n"
+": Verbose output\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:76
+#, no-wrap
+msgid ""
+"**-V**\n"
+": Very verbose output\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:79
+#, no-wrap
+msgid ""
+"**-b**\n"
+": Debug mode\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:81
+#, fuzzy
+#| msgid "Available Commands"
+msgid "# Available Tests"
+msgstr "有効なコマンド"
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:83
+#, fuzzy
+#| msgid "The following FCE events are defined:"
+msgid "The following tests are available:"
+msgstr "以下の FCE イベントが定義されている:"
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:86
+#, no-wrap
+msgid ""
+"**(1) Opening, stating and reading 512 bytes from 1000 files**\n"
+": Tests basic file access patterns with many small operations\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:89
+#, no-wrap
+msgid ""
+"**(2) Writing one large file**\n"
+": Measures sustained write performance\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:92
+#, no-wrap
+msgid ""
+"**(3) Reading one large file**  \n"
+": Measures sustained read performance\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:95
+#, no-wrap
+msgid ""
+"**(4) Locking/Unlocking 10000 times each**\n"
+": Tests file locking performance\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:98
+#, no-wrap
+msgid ""
+"**(5) Creating dir with 2000 files**\n"
+": Tests directory creation and file creation performance\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:101
+#, no-wrap
+msgid ""
+"**(6) Enumerate dir with 2000 files**\n"
+": Tests directory enumeration with many files\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:104
+#, no-wrap
+msgid ""
+"**(7) Create directory tree with 10^3 dirs**\n"
+": Tests nested directory creation\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:107
+#, no-wrap
+msgid ""
+"**(8) Directory cache hits [CACHE]**\n"
+": Tests directory and file lookup performance (1000 dirs + 10000 files)\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:110
+#, no-wrap
+msgid ""
+"**(9) Mixed cache operations [CACHE]**\n"
+": Tests mixed create/stat/enum/delete operations\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:113
+#, no-wrap
+msgid ""
+"**(10) Deep path traversal [CACHE]**\n"
+": Tests performance with deep directory structures  \n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:116
+#, no-wrap
+msgid ""
+"**(11) Cache validation [CACHE]**\n"
+": Tests directory cache validation mechanisms\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:118
+msgid "## Cache-Focused Tests"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:122
+msgid ""
+"Tests 8-11 are specifically designed to highlight directory cache "
+"performance improvements in netatalk. These tests benefit significantly from "
+"optimized cache validation and probabilistic validation features. Use the **-"
+"C** option to run only these cache-focused tests."
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:129
+msgid ""
+"Run all tests with default settings: ``` afp_lantest -h server.example.com "
+"-u testuser -w password -s TestVolume ```"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:134
+msgid ""
+"Run only cache-focused tests: ``` afp_lantest -C -h server.example.com -u "
+"testuser -w password -s TestVolume ```"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:139
+msgid ""
+"Run specific tests (file operations): ``` afp_lantest -f 123 -h "
+"server.example.com -u testuser -w password -s TestVolume ```"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:144
+msgid ""
+"Run tests optimized for gigabit network: ``` afp_lantest -g -h "
+"server.example.com -u testuser -w password -s TestVolume ```"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:149
+msgid ""
+"Run multiple iterations for statistical analysis: ``` afp_lantest -n 5 -h "
+"server.example.com -u testuser -w password -s TestVolume ```"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:151
+#, fuzzy
+#| msgid "Return codes"
+msgid "# Return Codes"
+msgstr "復帰コード"
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:154
+#, no-wrap
+msgid ""
+"**0**\n"
+": All tests passed successfully\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:157
+#, no-wrap
+msgid ""
+"**1** \n"
+": One or more tests failed\n"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:159
+#, fuzzy
+#| msgid "Note"
+msgid "# Notes"
+msgstr "注記"
+
+#. type: Bullet: '- '
+#: manpages/man1/afp_lantest.1.md:166
+msgid ""
+"Tests that involve large file operations (tests 2 and 3) will create "
+"temporary files in the test volume"
+msgstr ""
+
+#. type: Bullet: '- '
+#: manpages/man1/afp_lantest.1.md:166
+msgid ""
+"The **-g** and **-G** options significantly increase test file sizes and "
+"test duration"
+msgstr ""
+
+#. type: Bullet: '- '
+#: manpages/man1/afp_lantest.1.md:166
+msgid ""
+"Cache-focused tests (8-11) provide the most insight into netatalk's "
+"directory cache performance"
+msgstr ""
+
+#. type: Bullet: '- '
+#: manpages/man1/afp_lantest.1.md:166
+msgid ""
+"Multiple iterations (**-n**) are recommended for consistent performance "
+"measurements"
+msgstr ""
+
+#. type: Bullet: '- '
+#: manpages/man1/afp_lantest.1.md:166
+msgid "The tool requires write access to the specified AFP volume"
+msgstr ""
+
+#. type: Plain text
+#: manpages/man1/afp_lantest.1.md:169
+#, no-wrap
+msgid "**afptest**(1), **afpd**(8), **netatalk**(8)\n"
+msgstr ""

--- a/doc/po4a.cfg
+++ b/doc/po4a.cfg
@@ -6,6 +6,7 @@
 [type: text] manpages/man1/ad.1.md $lang:translated/$lang/ad.1.md
 [type: text] manpages/man1/addump.1.md $lang:translated/$lang/addump.1.md
 [type: text] manpages/man1/aecho.1.md $lang:translated/$lang/aecho.1.md
+[type: text] manpages/man1/afp_lantest.1.md $lang:translated/$lang/afp_lantest.1.md
 [type: text] manpages/man1/afpldaptest.1.md $lang:translated/$lang/afpldaptest.1.md
 [type: text] manpages/man1/afppasswd.1.md $lang:translated/$lang/afppasswd.1.md
 [type: text] manpages/man1/afpstats.1.md $lang:translated/$lang/afpstats.1.md

--- a/doc/translated/ja/meson.build
+++ b/doc/translated/ja/meson.build
@@ -16,6 +16,7 @@ if get_option('with-website')
         'afp_signature.conf.5',
         'afp_voluuid.conf.5',
         'afpd.8',
+        'afp_lantest.1',
         'afpldaptest.1',
         'afppasswd.1',
         'afpstats.1',

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -39,7 +39,7 @@ ssize_t get_sessiontoken(const char *buf, char **token)
     }
 
     if (!(*token = malloc(len))) {
-        fprintf(stdout, "\tFAILED malloc(%ld) %s\n", len, strerror(errno));
+        fprintf(stderr, "\tFAILED malloc(%ld) %s\n", len, strerror(errno));
         return -1;
     }
 
@@ -98,7 +98,7 @@ void illegal_fork(DSI *dsi, char cmd, char *name)
 
     if (ntohl(AFPERR_PARAM) != dsi->header.dsi_code) {
         if (!Quiet) {
-            fprintf(stdout, "\tFAILED command %i\n", cmd);
+            fprintf(stderr, "\tFAILED command %i\n", cmd);
         }
 
         test_failed();
@@ -1055,7 +1055,7 @@ void test_skipped(int why)
 void test_failed(void)
 {
     if (!Quiet) {
-        fprintf(stdout, "\tFAILED\n");
+        fprintf(stderr, "\tFAILED\n");
     }
 
     ExitCode = 1;
@@ -1066,7 +1066,7 @@ void test_failed(void)
 void test_nottested(void)
 {
     if (!Quiet) {
-        fprintf(stdout, "\tNOT TESTED\n");
+        fprintf(stderr, "\tNOT TESTED\n");
     }
 
     if (!ExitCode) {

--- a/testsuite_alp.Dockerfile
+++ b/testsuite_alp.Dockerfile
@@ -1,3 +1,19 @@
+#
+# To test using this Dockerfile
+# Build Container Image: docker build -t netatalk-test:latest .
+
+# Init Container and Netatalk: docker run -d --network host --cap-add=NET_ADMIN --volume "<path to local folder>:/mnt/afpshare" --volume "<path to local folder>:/mnt/afpbackup" --env AFP_USER=test --env AFP_PASS=test --env SHARE_NAME='File Sharing' --env AFP_VERSION=7 --env AFP_GROUP=afpusers --env TZ=Europe/London --env INSECURE_AUTH=true --name netatalk-test netatalk-test:latest
+# Read Container Logs: docker logs netatalk-test
+# Run Netatalk Test: docker exec -it netatalk-test /usr/local/bin/afp_lantest -7 -h localhost -p 548 -u test -w test -s "File Sharing" -n 3
+# Stop Container: docker stop netatalk-test
+# Start Container: docker start netatalk-test netatalk-test
+
+# Init Container, Run Test, Shutdown: docker run --rm -it --network host --cap-add=NET_ADMIN --volume "<path to local folder>:/mnt/afpshare" --volume "<path to local folder>:/mnt/afpbackup" --env TESTSUITE=lan --env TEST_FLAGS="-n 2" --env AFP_USER=test --env AFP_PASS=test --env SHARE_NAME='File Sharing' --env AFP_VERSION=7 --env AFP_GROUP=afpusers --env TZ=Europe/London --env INSECURE_AUTH=true --name netatalk-test netatalk-test:latest
+
+# List Containers: docker ps -a
+# Delete Container Instance: docker rm netatalk-test
+# Delete Container Image: docker image rm netatalk-test
+
 ARG RUN_DEPS="\
     acl \
     avahi \


### PR DESCRIPTION
Add dircache-focused performance tests and enhance statistical analysis with robustness improvements to afp_lantest

    - Added 4 new cache performance tests (Tests 8-11): - TEST_CACHE_HITS: Directory cache efficiency testing - TEST_MIXED_CACHE_OPS: Cache lifecycle operations testing - TEST_DEEP_TRAVERSAL: Deep directory structure navigation - TEST_CACHE_VALIDATION: Cache validation efficiency testing
    - New -C command-line flag: Run cache-focused tests only
    - Enhanced analysis: Added standard deviation calculations with ± display format
    - Robustness improvements: Enhanced memory allocation, pthread handling, buffer safety
    - Bug fixes: Fixed array indexing, improved iteration tracking (off by one), enhanced error reporting (without debug mode)
    - Code quality: Added math.h header, improved results formatting, enhanced help text
    - Docs: Added new afp_lantest manpage

    Impact: afp_lantest enhancement adding new cache performance benchmarking capabilities
    while improving code reliability, statistical analysis, and user experience.

```
➜  /Volumes/case-sensitive/github/netatalk git:(Lantest) ✗ docker build -t netatalk-test:latest .
[+] Building 16.1s (17/17) FINISHED                                                                                                                                                                                                                                                                                                                  docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                                                                                                                                                                 0.0s
 => => transferring dockerfile: 3.25kB                                                                                                                                                                                                                                                                                                                               0.0s
 => [internal] load metadata for docker.io/library/alpine:3.22@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1                                                                                                                                                                                                                               2.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                                                    0.0s
 => => transferring context: 80B                                                                                                                                                                                                                                                                                                                                     0.0s
 => [internal] load build context                                                                                                                                                                                                                                                                                                                                    0.3s
 => => transferring context: 19.43MB                                                                                                                                                                                                                                                                                                                                 0.3s
 => CACHED [build 1/6] FROM docker.io/library/alpine:3.22@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1                                                                                                                                                                                                                                    0.0s
 => CACHED [build 2/6] RUN apk update &&  apk add --no-cache         avahi     cups     db     dbus     glib     iniparser     krb5     libevent     libgcrypt     linux-pam     mariadb-client     mariadb-connector-c     openldap     sqlite     tzdata              avahi-dev     cups-dev     db-dev     dbus-dev     build-base     gcc     iniparser-dev      0.0s
 => CACHED [build 3/6] WORKDIR /netatalk-code                                                                                                                                                                                                                                                                                                                        0.0s
 => [build 4/6] COPY . .                                                                                                                                                                                                                                                                                                                                             0.3s
 => [build 5/6] RUN meson setup build     -Dbuildtype=release     -Dwith-acls=false     -Dwith-afpstats=false     -Dwith-appletalk=true     -Dwith-testsuite=true     -Dwith-dbus-daemon-path=/usr/bin/dbus-daemon     -Dwith-dbus-sysconf-path=/etc     -Dwith-docs=     -Dwith-dtrace=false     -Dwith-init-style=none     -Dwith-pkgconfdir-path=/etc/netatalk    7.4s
 => [build 6/6] RUN meson install --destdir=/staging/ -C build                                                                                                                                                                                                                                                                                                       0.3s
 => [deploy 2/7] COPY --from=build /staging/ /                                                                                                                                                                                                                                                                                                                       0.0s
 => [deploy 3/7] COPY --from=build /netatalk-code/contrib/scripts/config_watch.sh /config_watch.sh                                                                                                                                                                                                                                                                   0.0s
 => [deploy 4/7] RUN apk update &&  apk add --no-cache     avahi     cups     db     dbus     glib     iniparser     krb5     libevent     libgcrypt     linux-pam     mariadb-client     mariadb-connector-c     openldap     sqlite     tzdata                                                                                                                     5.1s
 => [deploy 5/7] RUN ln -sf /dev/stdout /var/log/afpd.log                                                                                                                                                                                                                                                                                                            0.1s
 => [deploy 6/7] COPY /contrib/scripts/netatalk_container_entrypoint.sh /entrypoint.sh                                                                                                                                                                                                                                                                               0.0s
 => [deploy 7/7] WORKDIR /mnt                                                                                                                                                                                                                                                                                                                                        0.1s
 => exporting to image                                                                                                                                                                                                                                                                                                                                               0.2s
 => => exporting layers                                                                                                                                                                                                                                                                                                                                              0.2s
 => => writing image sha256:d873d6484e3fdbf6c513b6bc4df0ceb33b26623e4b4cd8e3cdbed2027a279a17                                                                                                                                                                                                                                                                         0.0s
 => => naming to docker.io/library/netatalk-test:latest                                                                                                                                                                                                                                                                                                              0.0s

➜  /Volumes/case-sensitive/github/netatalk git:(Lantest) ✗ docker run -d --network host --cap-add=NET_ADMIN --volume "/Volumes/case-sensitive/test:/mnt/afpshare" --volume "/Volumes/case-sensitive/test:/mnt/afpbackup" --env AFP_USER=test --env AFP_PASS=test --env SHARE_NAME='File Sharing' --env AFP_VERSION=7 --env AFP_GROUP=afpusers --env TZ=Europe/London --env INSECURE_AUTH=true --name netatalk-test netatalk-test:latest
e42f82bfb344aee9c683490bc3aeef0c38815b0cdeb82a17027fcc0be5fcf6dd

➜  /Volumes/case-sensitive/github/netatalk git:(Lantest) ✗ docker exec -it netatalk-test /usr/local/bin/afp_lantest -7 -h localhost -p 548 -u test -w test -s "File Sharing" -n 3
Run 0 => Opening, stating and reading 512 bytes from 1000 files   3588 ms
Run 0 => Writing one large file                                    173 ms for 100 MB (avg. 606 MB/s)
Run 0 => Reading one large file                                     45 ms for 100 MB (avg. 2330 MB/s)
Run 0 => Locking/Unlocking 10000 times each                        815 ms
Run 0 => Creating dir with 2000 files                             4499 ms
Run 0 => Enumerate dir with 2000 files                             808 ms
Run 0 => Create directory tree with 10^3 dirs                     1854 ms
Run 0 => Directory cache hits (1000 dir + 10000 file lookups)     3181 ms
Run 0 => Mixed cache operations (create/stat/enum/delete)          822 ms
Run 0 => Deep path traversal (nested directory navigation)         225 ms
Run 0 => Cache validation efficiency (metadata changes)           9394 ms
Run 1 => Opening, stating and reading 512 bytes from 1000 files   4057 ms
Run 1 => Writing one large file                                    122 ms for 100 MB (avg. 859 MB/s)
Run 1 => Reading one large file                                     52 ms for 100 MB (avg. 2016 MB/s)
Run 1 => Locking/Unlocking 10000 times each                        763 ms
Run 1 => Creating dir with 2000 files                             4193 ms
Run 1 => Enumerate dir with 2000 files                            1232 ms
Run 1 => Create directory tree with 10^3 dirs                     1877 ms
Run 1 => Directory cache hits (1000 dir + 10000 file lookups)     3197 ms
Run 1 => Mixed cache operations (create/stat/enum/delete)          690 ms
Run 1 => Deep path traversal (nested directory navigation)         253 ms
Run 1 => Cache validation efficiency (metadata changes)           9134 ms
Run 2 => Opening, stating and reading 512 bytes from 1000 files   3550 ms
Run 2 => Writing one large file                                    210 ms for 100 MB (avg. 499 MB/s)
Run 2 => Reading one large file                                     41 ms for 100 MB (avg. 2557 MB/s)
Run 2 => Locking/Unlocking 10000 times each                        800 ms
Run 2 => Creating dir with 2000 files                             3781 ms
Run 2 => Enumerate dir with 2000 files                             719 ms
Run 2 => Create directory tree with 10^3 dirs                     1837 ms
Run 2 => Directory cache hits (1000 dir + 10000 file lookups)     3759 ms
Run 2 => Mixed cache operations (create/stat/enum/delete)          495 ms
Run 2 => Deep path traversal (nested directory navigation)         426 ms
Run 2 => Cache validation efficiency (metadata changes)           9419 ms

Netatalk Lantest Results (average times across 3 iterations)
===================================

Test 1: Opening, stating and reading 512 bytes from 1000 files
	  Average:   3731 ms ± 282.4 ms (std dev)

Test 2: Writing one large file
	  Average:    168 ms ± 44.2 ms (std dev)
	  Throughput: 624 MB/s (Write, 100 MB file)

Test 3: Reading one large file
	  Average:     46 ms ± 5.6 ms (std dev)
	  Throughput: 2279 MB/s (Read, 100 MB file)

Test 4: Locking/Unlocking 10000 times each
	  Average:    792 ms ± 26.8 ms (std dev)

Test 5: Creating dir with 2000 files
	  Average:   4157 ms ± 360.3 ms (std dev)

Test 6: Enumerate dir with 2000 files
	  Average:    919 ms ± 274.1 ms (std dev)

Test 7: Create directory tree with 10^3 dirs
	  Average:   1856 ms ± 20.1 ms (std dev)

Test 8: Directory cache hits (1000 dir + 10000 file lookups)
	  Average:   3379 ms ± 329.2 ms (std dev)

Test 9: Mixed cache operations (create/stat/enum/delete)
	  Average:    669 ms ± 164.5 ms (std dev)

Test 10: Deep path traversal (nested directory navigation)
	  Average:    301 ms ± 108.9 ms (std dev)

Test 11: Cache validation efficiency (metadata changes)
	  Average:   9315 ms ± 157.8 ms (std dev)
```