### PR TITLE
testsuite: Don't require username and password for afp_logintest

### DIFF
--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -1039,6 +1039,10 @@ void test_skipped(int why)
     case T_BIGENDIAN:
         s = "not big-endian compatible";
         break;
+
+    case T_CRED:
+        s = "username/password for the AFP server";
+        break;
     }
 
     if (Color) {

--- a/test/testsuite/logintest.c
+++ b/test/testsuite/logintest.c
@@ -214,6 +214,11 @@ STATIC void test5(void)
     connect_server(Conn);
     Dsi = &Conn->dsi;
 
+    if (!User || Password[0] == '\0') {
+        test_skipped(T_CRED);
+        goto test_exit;
+    }
+
     if (Version >= 30) {
         ret = FPopenLoginExt(Conn, vers, uam, User, Password);
     } else {
@@ -257,6 +262,11 @@ STATIC void test6(void)
     memcpy(dsi->commands + 2, &i, sizeof(i));
     my_dsi_send(dsi);
     my_dsi_cmd_receive(dsi);
+
+    if (!User || Password[0] == '\0') {
+        test_skipped(T_CRED);
+        goto test_exit;
+    }
 
     if (dsi->header.dsi_code) {
         test_failed();
@@ -393,14 +403,6 @@ int main(int ac, char **av)
 
     if (!Quiet) {
         fprintf(stdout, "Connecting to host %s:%d\n", Server, Port);
-    }
-
-    if (User != NULL && User[0] == '\0') {
-        fprintf(stdout, "Error: Define a user with -u\n");
-    }
-
-    if (Password != NULL && Password[0] == '\0') {
-        fprintf(stdout, "Error: Define a password with -w\n");
     }
 
     if ((Conn = (CONN *)calloc(1, sizeof(CONN))) == NULL) {

--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -118,6 +118,7 @@ extern int not_valid_bitmap(unsigned int ret, unsigned int bitmap,
 #define T_AFP32      27
 #define T_NONDETERM  28
 #define T_BIGENDIAN  29
+#define T_CRED       30
 
 /* ---------------------------------
 */


### PR DESCRIPTION
The afp_logintest has DSI session and Guest auth tests that are perfectly valid to test without username and password

Adds checks to the tests that require credentials that makes the runner skip them if none are available