### PR TITLE
testsuite: Remove workarounds for broken fcntl locking in spectest

### DIFF
--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -196,11 +196,6 @@ STATIC void test65()
         goto test_exit;
     }
 
-    if (Locking) {
-        test_skipped(T_LOCKING);
-        goto test_exit;
-    }
-
     test_bytelock3(name, OPENFORK_DATA);
     name = "t65 RF FPByteLock 2 users";
 
@@ -264,12 +259,6 @@ static void test_bytelock2(char *name, int type)
 
     if (Conn2) {
         uint16_t vol2;
-
-        if (Locking) {
-            test_skipped(T_LOCKING);
-            goto fin;
-        }
-
         dsi2 = &Conn2->dsi;
         vol2  = FPOpenVol(Conn2, Vol);
 
@@ -320,11 +309,6 @@ void test78()
                 "FPByteRangeLock:test78: test Byte Lock size -1 with no large file support\n");
     }
 
-    if (Locking) {
-        test_skipped(T_LOCKING);
-        goto test_exit;
-    }
-
     test_bytelock2(name, OPENFORK_RSCS);
 
     if (!Quiet) {
@@ -334,7 +318,6 @@ void test78()
 
     name = "t78 FPByteLock DF size -1";
     test_bytelock2(name, OPENFORK_DATA);
-test_exit:
     exit_test("FPByteRangeLock:test78: test Byte Lock size -1");
 }
 
@@ -465,11 +448,6 @@ STATIC void test329()
         goto test_exit;
     }
 
-    if (Locking) {
-        test_skipped(T_LOCKING);
-        goto test_exit;
-    }
-
     if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
         test_nottested();
         goto test_exit;
@@ -571,11 +549,6 @@ STATIC void test410()
 
     if (!Conn2) {
         test_skipped(T_CONN2);
-        goto test_exit;
-    }
-
-    if (Locking) {
-        test_skipped(T_LOCKING);
         goto test_exit;
     }
 
@@ -965,11 +938,6 @@ STATIC void test366()
 
     if (!Conn2) {
         test_skipped(T_CONN2);
-        goto test_exit;
-    }
-
-    if (Locking) {
-        test_skipped(T_LOCKING);
         goto test_exit;
     }
 

--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -362,11 +362,6 @@ STATIC void test374()
         goto test_exit;
     }
 
-    if (Locking) {
-        test_skipped(T_LOCKING);
-        goto test_exit;
-    }
-
     vol2  = FPOpenVol(Conn2, Vol);
 
     if (vol2 == 0xffff) {

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -83,11 +83,6 @@ STATIC  void test74()
         goto test_exit;
     }
 
-    if (Locking) {
-        test_skipped(T_LOCKING);
-        goto test_exit;
-    }
-
     if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
         test_nottested();
         goto test_exit;
@@ -415,11 +410,6 @@ STATIC void test368()
         goto test_exit;
     }
 
-    if (Locking) {
-        test_skipped(T_LOCKING);
-        goto test_exit;
-    }
-
     dir  = FPCreateDir(Conn, vol, DIRDID_ROOT, name2);
 
     if (!dir) {
@@ -471,11 +461,6 @@ STATIC void test369()
 
     if (!Conn2) {
         test_skipped(T_CONN2);
-        goto test_exit;
-    }
-
-    if (Locking) {
-        test_skipped(T_LOCKING);
         goto test_exit;
     }
 

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -37,11 +37,6 @@ STATIC void test222()
         goto test_exit;
     }
 
-    if (Locking) {
-        test_skipped(T_LOCKING);
-        goto test_exit;
-    }
-
     ret = FPGetSessionToken(Conn, 0, 0, 0, NULL);
 
     if (ret) {
@@ -206,11 +201,6 @@ STATIC void test338()
         goto test_exit;
     }
 
-    if (Locking) {
-        test_skipped(T_LOCKING);
-        goto test_exit;
-    }
-
     /* setup 2 new connections for testing */
 
     /* connection 1 */
@@ -358,11 +348,6 @@ STATIC void test339()
 
     if (Conn->afp_version < 30) {
         test_skipped(T_AFP3);
-        goto test_exit;
-    }
-
-    if (Locking) {
-        test_skipped(T_LOCKING);
         goto test_exit;
     }
 
@@ -550,11 +535,6 @@ STATIC void test370()
 
     if (Conn->afp_version < 30) {
         test_skipped(T_AFP3);
-        goto test_exit;
-    }
-
-    if (Locking) {
-        test_skipped(T_LOCKING);
         goto test_exit;
     }
 

--- a/test/testsuite/FPOpenFork.c
+++ b/test/testsuite/FPOpenFork.c
@@ -600,11 +600,6 @@ STATIC void test81()
         goto test_exit;
     }
 
-    if (Locking) {
-        test_skipped(T_LOCKING);
-        goto test_exit;
-    }
-
     test_denymode(name, OPENFORK_RSCS);
 
     if (!Quiet) {
@@ -980,11 +975,6 @@ STATIC void test341()
         goto test_exit;
     }
 
-    if (Locking) {
-        test_skipped(T_LOCKING);
-        goto test_exit;
-    }
-
     test_openmode(name, OPENFORK_RSCS);
 
     if (!Quiet) {
@@ -1070,11 +1060,6 @@ STATIC void test367()
 
     if (!Conn2) {
         test_skipped(T_CONN2);
-        goto test_exit;
-    }
-
-    if (Locking) {
-        test_skipped(T_LOCKING);
         goto test_exit;
     }
 

--- a/test/testsuite/FPRead.c
+++ b/test/testsuite/FPRead.c
@@ -849,11 +849,6 @@ STATIC void test344()
     size = 100;
     offset = 128;
 
-    if (Locking) {
-        test_skipped(T_LOCKING);
-        goto test_exit;
-    }
-
     if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
         test_nottested();
         goto test_exit;
@@ -921,11 +916,6 @@ STATIC void test8()
     int ret;
     dsi = &Conn->dsi;
     ENTER_TEST
-
-    if (Locking) {
-        test_skipped(T_LOCKING);
-        goto test_exit;
-    }
 
     if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name1)) {
         test_failed();
@@ -1014,7 +1004,6 @@ fin:
 
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name1))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name2))
-test_exit:
     exit_test("FPRead:test8: open data and rfork, datafork size is 0, rfork is 65k, read from datafork after EOF");
 }
 

--- a/test/testsuite/T2_FPResolveID.c
+++ b/test/testsuite/T2_FPResolveID.c
@@ -399,11 +399,6 @@ STATIC void test360()
         goto test_exit;
     }
 
-    if (Locking) {
-        test_skipped(T_LOCKING);
-        goto test_exit;
-    }
-
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name1))) {
         test_failed();
         goto test_exit;

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -984,10 +984,6 @@ void test_skipped(int why)
         s = "a second volume";
         break;
 
-    case T_LOCKING:
-        s = "working fcntl locking";
-        break;
-
     case T_VOL_SMALL:
         s = "a bigger volume";
         break;

--- a/test/testsuite/specs.h
+++ b/test/testsuite/specs.h
@@ -95,7 +95,9 @@ extern int not_valid_bitmap(unsigned int ret, unsigned int bitmap,
 #define T_UNIX_PREV  6
 #define T_UTF8       7
 #define T_VOL2       8
+#if 0
 #define T_LOCKING    9
+#endif
 #define T_VOL_SMALL  10
 #define T_ID         11
 #define T_AFP2       12

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -341,11 +341,9 @@ char *uam = "Cleartxt Passwrd";
 void usage(char *av0)
 {
     fprintf(stdout,
-            "usage:\t%s [-1234567aCiLlmnVvX] [-h host] [-H host2] [-p port] [-s vol] [-c vol path] [-S vol2] "
+            "usage:\t%s [-1234567aCilmnVvX] [-h host] [-H host2] [-p port] [-s vol] [-c vol path] [-S vol2] "
             "[-u user] [-d user2] [-w password] [-F testsuite] [-f test]\n", av0);
     fprintf(stdout, "\t-a\tvolume is using AppleDouble metadata and not EA\n");
-    fprintf(stdout,
-            "\t-L\tserver without working fcntl locking, skip tests using it\n");
     fprintf(stdout, "\t-m\tserver is a Mac\n");
     fprintf(stdout, "\t-h\tserver host name (default localhost)\n");
     fprintf(stdout, "\t-p\tserver port (default 548)\n");
@@ -384,7 +382,7 @@ int main(int ac, char **av)
         usage(av[0]);
     }
 
-    while ((cc = getopt(ac, av, "1234567aCiLlmVvXc:d:f:H:h:p:S:s:u:w:")) != EOF) {
+    while ((cc = getopt(ac, av, "1234567aCilmVvXc:d:f:H:h:p:S:s:u:w:")) != EOF) {
         switch (cc) {
         case '1':
             vers = "AFPVersion 2.1";


### PR DESCRIPTION
The -L option skipped tests that were flagged as requiring a working fcntl locking mechanism in the host operating system

This workaround was introduced back in 2003 when locking wasn't reliable in many contemporary Unix flavors, but is not relevant anymore