### PR TITLE
testsuite: Fix the iterations option for afp_speedtest

### DIFF
--- a/contrib/scripts/netatalk_container_entrypoint.sh
+++ b/contrib/scripts/netatalk_container_entrypoint.sh
@@ -268,26 +268,26 @@ else
     echo "*** Running testsuite: $TESTSUITE"
     case "$TESTSUITE" in
         spectest)
-            echo "afp_spectest $TEST_FLAGS -$AFP_VERSION -h $AFP_HOST -p $AFP_PORT -u $AFP_USER -d $AFP_USER2 -w $AFP_PASS -s $SHARE_NAME -S $SHARE_NAME2"
+            set -x
             afp_spectest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -d "$AFP_USER2" -w "$AFP_PASS" -s "$SHARE_NAME" -S "$SHARE_NAME2"
             ;;
         readonly)
             echo "testfile uno" > /mnt/afpshare/first.txt
             echo "testfile dos" > /mnt/afpshare/second.txt
             mkdir /mnt/afpshare/third
-            echo "afp_spectest $TEST_FLAGS -$AFP_VERSION -h $AFP_HOST -p $AFP_PORT -u $AFP_USER -w $AFP_PASS -s $SHARE_NAME -f Readonly_test"
+            set -x
             afp_spectest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" -f Readonly_test
             ;;
         login)
-            echo "afp_logintest $TEST_FLAGS -$AFP_VERSION -h $AFP_HOST -p $AFP_PORT -u $AFP_USER -w $AFP_PASS"
+            set -x
             afp_logintest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS"
             ;;
         lan)
-            echo "afp_lantest $TEST_FLAGS -$AFP_VERSION -h $AFP_HOST -p $AFP_PORT -u $AFP_USER -w $AFP_PASS -s $SHARE_NAME"
+            set -x
             afp_lantest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME"
             ;;
         speed)
-            echo "afp_speedtest $TEST_FLAGS -$AFP_VERSION -h $AFP_HOST -p $AFP_PORT -u $AFP_USER -w $AFP_PASS -s $SHARE_NAME"
+            set -x
             afp_speedtest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" -n 2
             ;;
         *)

--- a/contrib/scripts/netatalk_container_entrypoint.sh
+++ b/contrib/scripts/netatalk_container_entrypoint.sh
@@ -288,7 +288,7 @@ else
             ;;
         speed)
             echo "afp_speedtest $TEST_FLAGS -$AFP_VERSION -h $AFP_HOST -p $AFP_PORT -u $AFP_USER -w $AFP_PASS -s $SHARE_NAME"
-            afp_speedtest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME"
+            afp_speedtest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" -n 2
             ;;
         *)
             echo "Unknown testsuite: $TESTSUITE"

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -1570,7 +1570,7 @@ int main(int ac, char **av)
     }
 
     while ((cc = getopt(ac, av,
-                        "1234567aeDiLnVvyc:d:F:f:h:o:p:q:R:r:S:s:u:w:")) != EOF) {
+                        "1234567aeDiLVvyc:d:F:f:h:n:o:p:q:R:r:S:s:u:w:")) != EOF) {
         switch (cc) {
         case '1':
             vers = "AFPVersion 2.1";


### PR DESCRIPTION
The -n option that defines how many times the speedtest shall run hasn't been functioning because of a typo in the optarg string