### PR TITLE
testsuite: afp_speedtest takes comma separated list of tests

### DIFF
--- a/contrib/scripts/netatalk_container_entrypoint.sh
+++ b/contrib/scripts/netatalk_container_entrypoint.sh
@@ -288,7 +288,7 @@ else
             ;;
         speed)
             set -x
-            afp_speedtest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" -n 2
+            afp_speedtest $TEST_FLAGS -"$AFP_VERSION" -h "$AFP_HOST" -p "$AFP_PORT" -u "$AFP_USER" -w "$AFP_PASS" -s "$SHARE_NAME" -n 5 -f Read,Write,Copy,ServerCopy
             ;;
         *)
             echo "Unknown testsuite: $TESTSUITE"


### PR DESCRIPTION
This refactors the speedtest runner routine to use a table of function pointers to iterate over named tests

The -f parameter takes a comma separated list of tests

Numerous minor bugs and dead code are addressed as well

The test container will now run all speedtest tests 5 times