### PR TITLE
docker: Expose Classic Mac OS login message option

### DIFF
--- a/contrib/scripts/netatalk_container_entrypoint.sh
+++ b/contrib/scripts/netatalk_container_entrypoint.sh
@@ -219,6 +219,7 @@ cnid mysql db = $AFP_CNID_SQL_DB
 legacy icon = $AFP_LEGACY_ICON
 log file = /var/log/afpd.log
 log level = default:${AFP_LOGLEVEL:-info}
+login message = $AFP_LOGIN_MESSAGE
 mimic model = $AFP_MIMIC_MODEL
 server name = ${SERVER_NAME:-Netatalk File Server}
 uam list = $UAMS


### PR DESCRIPTION
A new $AFP_LOGIN_MESSAGE environment variable sets the login message read by Classic Mac OS, as a global option