### PR TITLE
GitHub CI: Build and distribute webmin module tarball in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,16 @@ jobs:
         run: meson setup build
       - name: Create distribution tarball
         run: meson dist -C build --no-tests
+      - name: Create webmin module tarball
+        run: |
+          meson setup build -Dwith-webmin=true -Dwith-init-hooks=false -Dwith-init-style=systemd -Dwith-install-hooks=false --sbindir=/usr/sbin --sysconfdir=/usr/etc --reconfigure
+          meson compile -C build
+          sudo meson install -C build --tags webmin
       - name: Generate checksums
         run: |
-          sha256sum build/meson-dist/${{ steps.get_version.outputs.tarball_name }}.tar.xz > SHA256SUMS
-          sha512sum build/meson-dist/${{ steps.get_version.outputs.tarball_name }}.tar.xz > SHA512SUMS
+          cd build/meson-dist
+          sha256sum "${{ steps.get_version.outputs.tarball_name }}.tar.xz" > "${{ steps.get_version.outputs.tarball_name }}.tar.xz.sha256"
+          sha512sum "${{ steps.get_version.outputs.tarball_name }}.tar.xz" > "${{ steps.get_version.outputs.tarball_name }}.tar.xz.sha512"
       - name: Create release
         uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8
         with:
@@ -83,7 +89,8 @@ jobs:
             ```
           files: |
             build/meson-dist/${{ steps.get_version.outputs.tarball_name }}.tar.xz
-            SHA256SUMS
-            SHA512SUMS
+            build/meson-dist/${{ steps.get_version.outputs.tarball_name }}.tar.xz.sha256
+            build/meson-dist/${{ steps.get_version.outputs.tarball_name }}.tar.xz.sha512
+            build/contrib/webmin_module/${{ steps.get_version.outputs.tarball_name }}.wbm.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The webmin module has to be built separately, so creating a new step for this