### PR TITLE
GitHub CI: Use proper syntax for multiple container tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm64
           push: true
           tags: |
-            netatalk/netatalk:latest,\
-            netatalk/netatalk:${{ steps.get_version.outputs.major_version }},\
-            netatalk/netatalk:${{ steps.get_version.outputs.minor_version }},\
+            netatalk/netatalk:latest
+            netatalk/netatalk:${{ steps.get_version.outputs.major_version }}
+            netatalk/netatalk:${{ steps.get_version.outputs.minor_version }}
             netatalk/netatalk:${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
Container tags are listed one per line in the yaml block rather than in a long line with backslash continuation