### PR TITLE
GitHub CI: Enable multi-arch container builds for ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,10 @@ jobs:
             type=raw,value=${{ steps.get_version.outputs.major_version }}
             type=raw,value=${{ steps.get_version.outputs.minor_version }}
             type=raw,value=${{ steps.get_version.outputs.version }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Build and push container image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
@@ -211,6 +215,10 @@ jobs:
             type=raw,value=${{ steps.get_version.outputs.major_version }}
             type=raw,value=${{ steps.get_version.outputs.minor_version }}
             type=raw,value=${{ steps.get_version.outputs.version }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Build and push container image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
@@ -316,7 +324,7 @@ jobs:
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm64
           push: true
           tags: |
-            netatalk/netatalk:latest
-            netatalk/netatalk:${{ steps.get_version.outputs.major_version }}
-            netatalk/netatalk:${{ steps.get_version.outputs.minor_version }}
-            netatalk/netatalk:${{ steps.get_version.outputs.version }}
+            netatalk/webmin:latest
+            netatalk/webmin:${{ steps.get_version.outputs.major_version }}
+            netatalk/webmin:${{ steps.get_version.outputs.minor_version }}
+            netatalk/webmin:${{ steps.get_version.outputs.version }}


### PR DESCRIPTION
The buildx environment needs to get set up in order to build multi-arch containers