### PR TITLE
Introduce yaml code style guide and automatic formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
     container:
       image: alpine:latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install dependencies
         run: |
           apk add \
@@ -108,7 +108,7 @@ jobs:
     container:
       image: archlinux:latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install dependencies
         run: |
           pacman -Sy --noconfirm \
@@ -166,7 +166,7 @@ jobs:
     container:
       image: debian:latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install dependencies
         run: |
           apt-get update
@@ -240,7 +240,7 @@ jobs:
     container:
       image: fedora:latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install dependencies
         run: |
           dnf --setopt=install_weak_deps=False --assumeyes install \
@@ -305,7 +305,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -383,7 +383,7 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install dependencies
         run: |
           brew update
@@ -428,9 +428,9 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build on VM
-        uses: vmactions/dragonflybsd-vm@e3c420e8a2362c2496fca6e76a291abd46f5d8e7
+        uses: vmactions/dragonflybsd-vm@e3c420e8a2362c2496fca6e76a291abd46f5d8e7 # v1.1.0
         with:
           copyback: false
           usesh: true
@@ -473,9 +473,9 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build on VM
-        uses: vmactions/freebsd-vm@966989c456d41351f095a421f60e71342d3bce41
+        uses: vmactions/freebsd-vm@966989c456d41351f095a421f60e71342d3bce41 # v1.2.1
         with:
           copyback: false
           prepare: |
@@ -522,9 +522,9 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build on VM
-        uses: vmactions/netbsd-vm@46a58bbf03682b4cb24142b97fa315ae52bed573
+        uses: vmactions/netbsd-vm@46a58bbf03682b4cb24142b97fa315ae52bed573 # v1.1.8
         with:
           copyback: false
           prepare: |
@@ -579,9 +579,9 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build on VM
-        uses: vmactions/openbsd-vm@0d65352eee1508bab7cb12d130536d3a556be487
+        uses: vmactions/openbsd-vm@0d65352eee1508bab7cb12d130536d3a556be487 # v1.1.8
         with:
           copyback: false
           prepare: |
@@ -632,9 +632,9 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build on VM
-        uses: vmactions/omnios-vm@8eba2a9217262f275d4566751a92d6ef2f433d00
+        uses: vmactions/omnios-vm@8eba2a9217262f275d4566751a92d6ef2f433d00 # v1.1.0
         with:
           copyback: false
           prepare: |
@@ -684,9 +684,9 @@ jobs:
     timeout-minutes: 12
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Build on VM
-        uses: vmactions/solaris-vm@170f1f96f376cf7467cc41627e0c7590932fccaa
+        uses: vmactions/solaris-vm@170f1f96f376cf7467cc41627e0c7590932fccaa # v1.1.4
         with:
           copyback: false
           prepare: |

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -26,11 +26,11 @@ jobs:
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Install Build Wrapper
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@8c71dc039c2dd71d3821e89a2b58ecc7fee6ced9
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@8c71dc039c2dd71d3821e89a2b58ecc7fee6ced9 # v5.3.0
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -72,7 +72,7 @@ jobs:
               -Dwith-testsuite=true
           build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} meson compile -C build
       - name: Run SonarQube scan
-        uses: sonarsource/sonarqube-scan-action@8c71dc039c2dd71d3821e89a2b58ecc7fee6ced9
+        uses: sonarsource/sonarqube-scan-action@8c71dc039c2dd71d3821e89a2b58ecc7fee6ced9 # v5.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -16,65 +16,65 @@ on:
 permissions: read-all
 
 jobs:
-    static_analysis:
-        name: SonarQube Static Analysis
-        runs-on: ubuntu-latest
-        if: >
-          (github.event_name == 'push' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot') ||
-          (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && github.actor != 'dependabot')
+  static_analysis:
+    name: SonarQube Static Analysis
+    runs-on: ubuntu-latest
+    if: >
+      (github.event_name == 'push' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot') || (github.event_name
+      == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && github.actor
+      != 'dependabot')
+    env:
+      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+      - name: Install Build Wrapper
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@8c71dc039c2dd71d3821e89a2b58ecc7fee6ced9
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --assume-yes --no-install-recommends \
+              bison \
+              cracklib-runtime \
+              flex \
+              libacl1-dev \
+              libavahi-client-dev \
+              libcrack2-dev \
+              libcups2-dev \
+              libdb-dev \
+              libdbus-1-dev \
+              libevent-dev \
+              libgcrypt20-dev \
+              libglib2.0-dev \
+              libiniparser-dev \
+              libkrb5-dev \
+              libldap2-dev \
+              libmariadb-dev \
+              libpam0g-dev \
+              libtalloc-dev \
+              libtirpc-dev \
+              libtracker-sparql-3.0-dev \
+              libwrap0-dev \
+              meson \
+              ninja-build \
+              systemtap-sdt-dev \
+              tracker-miner-fs
+      - name: Run build wrapper
+        run: |
+          mkdir -p ${{ env.BUILD_WRAPPER_OUT_DIR }}
+          meson setup build \
+              -Dbuildtype=debug \
+              -Dwith-appletalk=true \
+              -Dwith-docs= \
+              -Dwith-init-style=none \
+              -Dwith-tests=true \
+              -Dwith-testsuite=true
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} meson compile -C build
+      - name: Run SonarQube scan
+        uses: sonarsource/sonarqube-scan-action@8c71dc039c2dd71d3821e89a2b58ecc7fee6ced9
         env:
-          BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
-        steps:
-        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-          with:
-            fetch-depth: 0
-        - name: Install Build Wrapper
-          uses: SonarSource/sonarqube-scan-action/install-build-wrapper@8c71dc039c2dd71d3821e89a2b58ecc7fee6ced9
-        - name: Install dependencies
-          run: |
-            sudo apt-get update
-            sudo apt-get install --assume-yes --no-install-recommends \
-                bison \
-                cracklib-runtime \
-                flex \
-                libacl1-dev \
-                libavahi-client-dev \
-                libcrack2-dev \
-                libcups2-dev \
-                libdb-dev \
-                libdbus-1-dev \
-                libevent-dev \
-                libgcrypt20-dev \
-                libglib2.0-dev \
-                libiniparser-dev \
-                libkrb5-dev \
-                libldap2-dev \
-                libmariadb-dev \
-                libpam0g-dev \
-                libtalloc-dev \
-                libtirpc-dev \
-                libtracker-sparql-3.0-dev \
-                libwrap0-dev \
-                meson \
-                ninja-build \
-                systemtap-sdt-dev \
-                tracker-miner-fs
-        - name: Run build wrapper
-          run: |
-            mkdir -p ${{ env.BUILD_WRAPPER_OUT_DIR }}
-            meson setup build \
-                -Dbuildtype=debug \
-                -Dwith-appletalk=true \
-                -Dwith-docs= \
-                -Dwith-init-style=none \
-                -Dwith-tests=true \
-                -Dwith-testsuite=true
-            build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} meson compile -C build
-        - name: Run SonarQube scan
-          uses: sonarsource/sonarqube-scan-action@8c71dc039c2dd71d3821e89a2b58ecc7fee6ced9
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          with:
-            args: >
-              --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json" 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: "--define sonar.cfamily.compile-commands=\"${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json\" \n"

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -35,24 +35,24 @@ jobs:
       packages: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Create image name
         run: |
           echo "IMAGE_NAME=${REPO,,}" >> ${GITHUB_ENV}
       - name: Login to container registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata
         id: metadata
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: type=raw,value=${{ github.sha }}
       - name: Build and push container image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: Dockerfile
@@ -70,24 +70,24 @@ jobs:
       packages: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Create image name
         run: |
           echo "IMAGE_NAME=${REPO,,}-testsuite" >> ${GITHUB_ENV}
       - name: Login to container registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata
         id: metadata
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: type=raw,value=${{ github.sha }}
       - name: Build and push container image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: testsuite_alp.Dockerfile
@@ -105,24 +105,24 @@ jobs:
       packages: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Create image name
         run: |
           echo "IMAGE_NAME=${REPO,,}-webmin" >> ${GITHUB_ENV}
       - name: Login to container registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata
         id: metadata
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: type=raw,value=${{ github.sha }}
       - name: Build and push container image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: webmin_module.Dockerfile
@@ -140,24 +140,24 @@ jobs:
       packages: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Create image name
         run: |
           echo "IMAGE_NAME=${REPO,,}-testsuite-debian" >> ${GITHUB_ENV}
       - name: Login to container registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata
         id: metadata
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: type=raw,value=${{ github.sha }}
       - name: Build and push container image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: testsuite_deb.Dockerfile

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,843 +1,838 @@
 name: Containers
 on:
-    push:
-        branches: [ "main" ]
-        paths-ignore:
-          - "**.md"
-          - "**/COPYING"
-          - "**/README*"
-          - ".github/workflows/build.yml"
-          - "contrib/webmin_module/**"
-          - "COPYRIGHT"
-    pull_request:
-        branches: [ "main" ]
-        paths-ignore:
-          - "**.md"
-          - "**/COPYING"
-          - "**/README*"
-          - ".github/workflows/build.yml"
-          - "contrib/webmin_module/**"
-          - "COPYRIGHT"
+  push:
+    branches: ["main"]
+    paths-ignore:
+      - "**.md"
+      - "**/COPYING"
+      - "**/README*"
+      - ".github/workflows/build.yml"
+      - "contrib/webmin_module/**"
+      - "COPYRIGHT"
+  pull_request:
+    branches: ["main"]
+    paths-ignore:
+      - "**.md"
+      - "**/COPYING"
+      - "**/README*"
+      - ".github/workflows/build.yml"
+      - "contrib/webmin_module/**"
+      - "COPYRIGHT"
 
 permissions: read-all
 env:
-    REGISTRY: ghcr.io
-    REPO: ${{ github.repository }}
+  REGISTRY: ghcr.io
+  REPO: ${{ github.repository }}
 
 jobs:
-    build-container:
-        name: Build production container
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        permissions:
-            contents: read
-            packages: write
-        steps:
-            - name: Checkout repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-            - name: Create image name
-              run: |
-                echo "IMAGE_NAME=${REPO,,}" >> ${GITHUB_ENV}
-            - name: Login to container registry
-              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
-              with:
-                registry: ${{ env.REGISTRY }}
-                username: ${{ github.actor }}
-                password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Extract metadata
-              id: metadata
-              uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
-              with:
-                images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-                tags: type=raw,value=${{ github.sha }}
-            - name: Build and push container image
-              uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
-              with:
-                context: .
-                file: Dockerfile
-                push: true
-                labels: ${{ steps.metadata.outputs.labels }}
-                tags: ${{ steps.metadata.outputs.tags }}
+  build-container:
+    name: Build production container
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Create image name
+        run: |
+          echo "IMAGE_NAME=${REPO,,}" >> ${GITHUB_ENV}
+      - name: Login to container registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: metadata
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: type=raw,value=${{ github.sha }}
+      - name: Build and push container image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}
 
+  build-container-testsuite:
+    name: Build Alpine testsuite container
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Create image name
+        run: |
+          echo "IMAGE_NAME=${REPO,,}-testsuite" >> ${GITHUB_ENV}
+      - name: Login to container registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: metadata
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: type=raw,value=${{ github.sha }}
+      - name: Build and push container image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: .
+          file: testsuite_alp.Dockerfile
+          push: true
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}
 
-    build-container-testsuite:
-        name: Build Alpine testsuite container
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        permissions:
-            contents: read
-            packages: write
-        steps:
-            - name: Checkout repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-            - name: Create image name
-              run: |
-                echo "IMAGE_NAME=${REPO,,}-testsuite" >> ${GITHUB_ENV}
-            - name: Login to container registry
-              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
-              with:
-                registry: ${{ env.REGISTRY }}
-                username: ${{ github.actor }}
-                password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Extract metadata
-              id: metadata
-              uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
-              with:
-                images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-                tags: type=raw,value=${{ github.sha }}
-            - name: Build and push container image
-              uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
-              with:
-                context: .
-                file: testsuite_alp.Dockerfile
-                push: true
-                labels: ${{ steps.metadata.outputs.labels }}
-                tags: ${{ steps.metadata.outputs.tags }}
+  build-container-webmin:
+    name: Build Netatalk Webmin Module container
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Create image name
+        run: |
+          echo "IMAGE_NAME=${REPO,,}-webmin" >> ${GITHUB_ENV}
+      - name: Login to container registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: metadata
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: type=raw,value=${{ github.sha }}
+      - name: Build and push container image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: .
+          file: webmin_module.Dockerfile
+          push: true
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}
 
+  build-container-testsuite-debian:
+    name: Build Debian testsuite container
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Create image name
+        run: |
+          echo "IMAGE_NAME=${REPO,,}-testsuite-debian" >> ${GITHUB_ENV}
+      - name: Login to container registry
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: metadata
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: type=raw,value=${{ github.sha }}
+      - name: Build and push container image
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: .
+          file: testsuite_deb.Dockerfile
+          push: true
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}
 
-    build-container-webmin:
-        name: Build Netatalk Webmin Module container
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        permissions:
-            contents: read
-            packages: write
-        steps:
-            - name: Checkout repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-            - name: Create image name
-              run: |
-                echo "IMAGE_NAME=${REPO,,}-webmin" >> ${GITHUB_ENV}
-            - name: Login to container registry
-              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
-              with:
-                registry: ${{ env.REGISTRY }}
-                username: ${{ github.actor }}
-                password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Extract metadata
-              id: metadata
-              uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
-              with:
-                images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-                tags: type=raw,value=${{ github.sha }}
-            - name: Build and push container image
-              uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
-              with:
-                context: .
-                file: webmin_module.Dockerfile
-                push: true
-                labels: ${{ steps.metadata.outputs.labels }}
-                tags: ${{ steps.metadata.outputs.tags }}
+  afp-spectest-afp34-prod:
+    name: AFP spec test (cnid:dbd) AFP 3.4 - Alpine (Prod)
+    needs:
+      - build-container
+      - build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Create Docker network
+        run: |
+          docker network create afp_network
+      - name: Run Netatalk
+        run: |
+          docker run --detach \
+              --name afp_server \
+              --network afp_network \
+              -e AFP_USER=atalk1 \
+              -e AFP_USER2=atalk2 \
+              -e AFP_PASS=${{ secrets.AFP_PASSWD }} \
+              -e AFP_PASS2=${{ secrets.AFP_PASSWD }} \
+              -e AFP_GROUP=afpusers \
+              -e SHARE_NAME=test1 \
+              -e SHARE_NAME2=test2 \
+              -e INSECURE_AUTH=1 \
+              -e DISABLE_TIMEMACHINE=1 \
+              -e AFP_EXTMAP=1 \
+              ${{ env.REGISTRY }}/netatalk/netatalk:${{ github.sha }}
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+              --network afp_network \
+              -e AFP_USER=atalk1 \
+              -e AFP_USER2=atalk2 \
+              -e AFP_PASS=${{ secrets.AFP_PASSWD }} \
+              -e AFP_PASS2=${{ secrets.AFP_PASSWD }} \
+              -e AFP_GROUP=afpusers \
+              -e SHARE_NAME=test1 \
+              -e SHARE_NAME2=test2 \
+              -e VERBOSE=1 \
+              -e TESTSUITE=spectest \
+              -e AFP_VERSION=7 \
+              -e AFP_REMOTE=1 \
+              -e AFP_HOST=afp_server \
+              ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
+  afp-spectest-mysql-afp34-prod:
+    name: AFP spec test (cnid:mysql) AFP 3.4 - Alpine (Prod)
+    needs:
+      - build-container
+      - build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Create container network
+        run: |
+          docker network create afp_network
+      - name: Start MariaDB
+        run: |
+          docker run --detach --name mariadb --network afp_network \
+              -e MARIADB_ROOT_PASSWORD=${{ secrets.MARIADB_ROOT_PASSWORD }} \
+              mariadb:latest
+      - name: Wait for MariaDB to initialize
+        run: |
+          sleep 4
+      - name: Start Netatalk
+        run: |
+          docker run --detach \
+              --name afp_server \
+              --network afp_network \
+              -e AFP_USER=atalk1 \
+              -e AFP_USER2=atalk2 \
+              -e AFP_PASS=${{ secrets.AFP_PASSWD }} \
+              -e AFP_PASS2=${{ secrets.AFP_PASSWD }} \
+              -e AFP_GROUP=afpusers \
+              -e AFP_CNID_BACKEND=mysql \
+              -e SHARE_NAME=test1 \
+              -e SHARE_NAME2=test2 \
+              -e INSECURE_AUTH=1 \
+              -e DISABLE_TIMEMACHINE=1 \
+              -e AFP_EXTMAP=1 \
+              -e AFP_CNID_SQL_HOST=mariadb \
+              -e AFP_CNID_SQL_PASS=${{ secrets.MARIADB_ROOT_PASSWORD }} \
+              ${{ env.REGISTRY }}/netatalk/netatalk:${{ github.sha }}
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+              --network afp_network \
+              -e AFP_USER=atalk1 \
+              -e AFP_USER2=atalk2 \
+              -e AFP_PASS=${{ secrets.AFP_PASSWD }} \
+              -e AFP_PASS2=${{ secrets.AFP_PASSWD }} \
+              -e AFP_GROUP=afpusers \
+              -e SHARE_NAME=test1 \
+              -e SHARE_NAME2=test2 \
+              -e VERBOSE=1 \
+              -e TESTSUITE=spectest \
+              -e AFP_VERSION=7 \
+              -e AFP_REMOTE=1 \
+              -e AFP_HOST=afp_server \
+              -e AFP_CNID_SQL_HOST=mariadb \
+              -e AFP_CNID_SQL_PASS=${{ secrets.MARIADB_ROOT_PASSWORD }} \
+              ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    build-container-testsuite-debian:
-        name: Build Debian testsuite container
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ !github.event.pull_request.head.repo.fork }}
-        permissions:
-            contents: read
-            packages: write
-        steps:
-            - name: Checkout repo
-              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-            - name: Create image name
-              run: |
-                echo "IMAGE_NAME=${REPO,,}-testsuite-debian" >> ${GITHUB_ENV}
-            - name: Login to container registry
-              uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
-              with:
-                registry: ${{ env.REGISTRY }}
-                username: ${{ github.actor }}
-                password: ${{ secrets.GITHUB_TOKEN }}
-            - name: Extract metadata
-              id: metadata
-              uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
-              with:
-                images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-                tags: type=raw,value=${{ github.sha }}
-            - name: Build and push container image
-              uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
-              with:
-                context: .
-                file: testsuite_deb.Dockerfile
-                push: true
-                labels: ${{ steps.metadata.outputs.labels }}
-                tags: ${{ steps.metadata.outputs.tags }}
+  afp-spectest-mysql-afp34-debian:
+    name: AFP spec test (cnid:mysql) AFP 3.4 - Debian
+    needs: build-container-testsuite-debian
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Create container network
+        run: |
+          docker network create afp_network
+      - name: Start MariaDB container
+        run: |
+          docker run --detach --name mariadb --network afp_network \
+              -e MARIADB_ROOT_PASSWORD=${{ secrets.MARIADB_ROOT_PASSWORD }} \
+              mariadb:latest
+      - name: Wait for MariaDB to initialize
+        run: |
+          sleep 4
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+              --network afp_network \
+              -e AFP_USER=atalk1 \
+              -e AFP_USER2=atalk2 \
+              -e AFP_PASS=${{ secrets.AFP_PASSWD }} \
+              -e AFP_PASS2=${{ secrets.AFP_PASSWD }} \
+              -e AFP_GROUP=afpusers \
+              -e AFP_CNID_BACKEND=mysql \
+              -e SHARE_NAME=test1 \
+              -e SHARE_NAME2=test2 \
+              -e INSECURE_AUTH=1 \
+              -e DISABLE_TIMEMACHINE=1 \
+              -e VERBOSE=1 \
+              -e TESTSUITE=spectest \
+              -e AFP_VERSION=7 \
+              -e AFP_REMOTE=1 \
+              -e AFP_EXTMAP=1 \
+              -e AFP_CNID_SQL_HOST=mariadb \
+              -e AFP_CNID_SQL_PASS=${{ secrets.MARIADB_ROOT_PASSWORD }} \
+              ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
 
+  afp-spectest-sqlite-afp34-debian:
+    name: AFP spec test (cnid:sqlite) AFP 3.4 - Debian
+    needs: build-container-testsuite-debian
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e AFP_CNID_BACKEND="sqlite" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="7" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
 
-    afp-spectest-afp34-prod:
-        name: AFP spec test (cnid:dbd) AFP 3.4 - Alpine (Prod)
-        needs:
-            - build-container
-            - build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Create Docker network
-              run: |
-                docker network create afp_network
-            - name: Run Netatalk
-              run: |
-                docker run --detach \
-                    --name afp_server \
-                    --network afp_network \
-                    -e AFP_USER=atalk1 \
-                    -e AFP_USER2=atalk2 \
-                    -e AFP_PASS=${{ secrets.AFP_PASSWD }} \
-                    -e AFP_PASS2=${{ secrets.AFP_PASSWD }} \
-                    -e AFP_GROUP=afpusers \
-                    -e SHARE_NAME=test1 \
-                    -e SHARE_NAME2=test2 \
-                    -e INSECURE_AUTH=1 \
-                    -e DISABLE_TIMEMACHINE=1 \
-                    -e AFP_EXTMAP=1 \
-                    ${{ env.REGISTRY }}/netatalk/netatalk:${{ github.sha }}
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                    --network afp_network \
-                    -e AFP_USER=atalk1 \
-                    -e AFP_USER2=atalk2 \
-                    -e AFP_PASS=${{ secrets.AFP_PASSWD }} \
-                    -e AFP_PASS2=${{ secrets.AFP_PASSWD }} \
-                    -e AFP_GROUP=afpusers \
-                    -e SHARE_NAME=test1 \
-                    -e SHARE_NAME2=test2 \
-                    -e VERBOSE=1 \
-                    -e TESTSUITE=spectest \
-                    -e AFP_VERSION=7 \
-                    -e AFP_REMOTE=1 \
-                    -e AFP_HOST=afp_server \
-                    ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+  afp-spectest-afp34:
+    name: AFP spec test (ea:sys) AFP 3.4 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="7" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-spectest-mysql-afp34-prod:
-        name: AFP spec test (cnid:mysql) AFP 3.4 - Alpine (Prod)
-        needs:
-            - build-container
-            - build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 10
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Create container network
-              run: |
-                docker network create afp_network
-            - name: Start MariaDB
-              run: |
-                docker run --detach --name mariadb --network afp_network \
-                    -e MARIADB_ROOT_PASSWORD=${{ secrets.MARIADB_ROOT_PASSWORD }} \
-                    mariadb:latest
-            - name: Wait for MariaDB to initialize
-              run: |
-                sleep 4
-            - name: Start Netatalk
-              run: |
-                docker run --detach \
-                    --name afp_server \
-                    --network afp_network \
-                    -e AFP_USER=atalk1 \
-                    -e AFP_USER2=atalk2 \
-                    -e AFP_PASS=${{ secrets.AFP_PASSWD }} \
-                    -e AFP_PASS2=${{ secrets.AFP_PASSWD }} \
-                    -e AFP_GROUP=afpusers \
-                    -e AFP_CNID_BACKEND=mysql \
-                    -e SHARE_NAME=test1 \
-                    -e SHARE_NAME2=test2 \
-                    -e INSECURE_AUTH=1 \
-                    -e DISABLE_TIMEMACHINE=1 \
-                    -e AFP_EXTMAP=1 \
-                    -e AFP_CNID_SQL_HOST=mariadb \
-                    -e AFP_CNID_SQL_PASS=${{ secrets.MARIADB_ROOT_PASSWORD }} \
-                    ${{ env.REGISTRY }}/netatalk/netatalk:${{ github.sha }}
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                    --network afp_network \
-                    -e AFP_USER=atalk1 \
-                    -e AFP_USER2=atalk2 \
-                    -e AFP_PASS=${{ secrets.AFP_PASSWD }} \
-                    -e AFP_PASS2=${{ secrets.AFP_PASSWD }} \
-                    -e AFP_GROUP=afpusers \
-                    -e SHARE_NAME=test1 \
-                    -e SHARE_NAME2=test2 \
-                    -e VERBOSE=1 \
-                    -e TESTSUITE=spectest \
-                    -e AFP_VERSION=7 \
-                    -e AFP_REMOTE=1 \
-                    -e AFP_HOST=afp_server \
-                    -e AFP_CNID_SQL_HOST=mariadb \
-                    -e AFP_CNID_SQL_PASS=${{ secrets.MARIADB_ROOT_PASSWORD }} \
-                    ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+  afp-spectest-sqlite-afp34:
+    name: AFP spec test (cnid:sqlite) AFP 3.4 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e AFP_CNID_BACKEND="sqlite" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="7" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-spectest-mysql-afp34-debian:
-        name: AFP spec test (cnid:mysql) AFP 3.4 - Debian
-        needs: build-container-testsuite-debian
-        runs-on: ubuntu-latest
-        timeout-minutes: 10
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Create container network
-              run: |
-                docker network create afp_network
-            - name: Start MariaDB container
-              run: |
-                docker run --detach --name mariadb --network afp_network \
-                    -e MARIADB_ROOT_PASSWORD=${{ secrets.MARIADB_ROOT_PASSWORD }} \
-                    mariadb:latest
-            - name: Wait for MariaDB to initialize
-              run: |
-                sleep 4
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                    --network afp_network \
-                    -e AFP_USER=atalk1 \
-                    -e AFP_USER2=atalk2 \
-                    -e AFP_PASS=${{ secrets.AFP_PASSWD }} \
-                    -e AFP_PASS2=${{ secrets.AFP_PASSWD }} \
-                    -e AFP_GROUP=afpusers \
-                    -e AFP_CNID_BACKEND=mysql \
-                    -e SHARE_NAME=test1 \
-                    -e SHARE_NAME2=test2 \
-                    -e INSECURE_AUTH=1 \
-                    -e DISABLE_TIMEMACHINE=1 \
-                    -e VERBOSE=1 \
-                    -e TESTSUITE=spectest \
-                    -e AFP_VERSION=7 \
-                    -e AFP_REMOTE=1 \
-                    -e AFP_EXTMAP=1 \
-                    -e AFP_CNID_SQL_HOST=mariadb \
-                    -e AFP_CNID_SQL_PASS=${{ secrets.MARIADB_ROOT_PASSWORD }} \
-                    ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+  afp-spectest-afp34-debian:
+    name: AFP spec test (ea:sys) AFP 3.4 - Debian
+    needs: build-container-testsuite-debian
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="7" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
 
-    afp-spectest-sqlite-afp34-debian:
-        name: AFP spec test (cnid:sqlite) AFP 3.4 - Debian
-        needs: build-container-testsuite-debian
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e AFP_CNID_BACKEND="sqlite" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="7" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+  afp-adtest-afp34:
+    name: AFP spec test (ea:ad) AFP 3.4 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e AFP_ADOUBLE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="7" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-spectest-afp34:
-        name: AFP spec test (ea:sys) AFP 3.4 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="7" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+  afp-adtest-afp34-debian:
+    name: AFP spec test (ea:ad) AFP 3.4 - Debian
+    needs: build-container-testsuite-debian
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e AFP_ADOUBLE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="7" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
 
+  afp-spectest-afp33:
+    name: AFP spec test (ea:sys) AFP 3.3 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="6" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-spectest-sqlite-afp34:
-        name: AFP spec test (cnid:sqlite) AFP 3.4 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e AFP_CNID_BACKEND="sqlite" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="7" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+  afp-spectest-afp32:
+    name: AFP spec test (ea:sys) AFP 3.2 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="5" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-spectest-afp34-debian:
-        name: AFP spec test (ea:sys) AFP 3.4 - Debian
-        needs: build-container-testsuite-debian
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="7" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+  afp-spectest-afp31:
+    name: AFP spec test (ea:sys) AFP 3.1 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="4" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-adtest-afp34:
-        name: AFP spec test (ea:ad) AFP 3.4 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e AFP_ADOUBLE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="7" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+  afp-spectest-afp30:
+    name: AFP spec test (ea:sys) AFP 3.0 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="3" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-adtest-afp34-debian:
-        name: AFP spec test (ea:ad) AFP 3.4 - Debian
-        needs: build-container-testsuite-debian
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e AFP_ADOUBLE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="7" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+  afp-spectest-afp30-debian:
+    name: AFP spec test (ea:sys) AFP 3.0 - Debian
+    needs: build-container-testsuite-debian
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="3" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
 
-    afp-spectest-afp33:
-        name: AFP spec test (ea:sys) AFP 3.3 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="6" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+  afp-spectest-afp22:
+    name: AFP spec test (ea:sys) AFP 2.2 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="2" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-spectest-afp32:
-        name: AFP spec test (ea:sys) AFP 3.2 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="5" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+  afp-spectest-afp21:
+    name: AFP spec test (ea:sys) AFP 2.1 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="1" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-spectest-afp31:
-        name: AFP spec test (ea:sys) AFP 3.1 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="4" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+  afp-spectest-afp21-debian:
+    name: AFP spec test (ea:sys) AFP 2.1 - Debian
+    needs: build-container-testsuite-debian
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="1" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
 
-    afp-spectest-afp30:
-        name: AFP spec test (ea:sys) AFP 3.0 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="3" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+  afp-adtest-afp21:
+    name: AFP spec test (ea:ad) AFP 2.1 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e AFP_ADOUBLE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="1" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-spectest-afp30-debian:
-        name: AFP spec test (ea:sys) AFP 3.0 - Debian
-        needs: build-container-testsuite-debian
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="3" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+  afp-adtest-afp21-debian:
+    name: AFP spec test (ea:ad) AFP 2.1 - Debian
+    needs: build-container-testsuite-debian
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_USER2="atalk2" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e SHARE_NAME2="test2" \
+            -e INSECURE_AUTH="1" \
+            -e DISABLE_TIMEMACHINE="1" \
+            -e VERBOSE="1" \
+            -e AFP_ADOUBLE="1" \
+            -e TESTSUITE="spectest" \
+            -e AFP_VERSION="1" \
+            -e AFP_EXTMAP="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
 
-    afp-spectest-afp22:
-        name: AFP spec test (ea:sys) AFP 2.2 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="2" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+  afp-rotest-afp34:
+    name: AFP spec test (readonly) AFP 3.4 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e INSECURE_AUTH="1" \
+            -e VERBOSE="1" \
+            -e AFP_READONLY="1" \
+            -e TESTSUITE="readonly" \
+            -e AFP_VERSION="7" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-spectest-afp21:
-        name: AFP spec test (ea:sys) AFP 2.1 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="1" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+  afp-rotest-afp21:
+    name: AFP spec test (readonly) AFP 2.1 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e INSECURE_AUTH="1" \
+            -e VERBOSE="1" \
+            -e AFP_READONLY="1" \
+            -e TESTSUITE="readonly" \
+            -e AFP_VERSION="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-spectest-afp21-debian:
-        name: AFP spec test (ea:sys) AFP 2.1 - Debian
-        needs: build-container-testsuite-debian
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="1" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+  afp-logintest-afp34:
+    name: AFP login test AFP 3.4 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e INSECURE_AUTH="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="login" \
+            -e AFP_VERSION="7" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-adtest-afp21:
-        name: AFP spec test (ea:ad) AFP 2.1 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e AFP_ADOUBLE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="1" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+  afp-logintest-afp21:
+    name: AFP login test AFP 2.1 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e INSECURE_AUTH="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="login" \
+            -e AFP_VERSION="1" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-adtest-afp21-debian:
-        name: AFP spec test (ea:ad) AFP 2.1 - Debian
-        needs: build-container-testsuite-debian
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_USER2="atalk2" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_PASS2="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e SHARE_NAME2="test2" \
-                  -e INSECURE_AUTH="1" \
-                  -e DISABLE_TIMEMACHINE="1" \
-                  -e VERBOSE="1" \
-                  -e AFP_ADOUBLE="1" \
-                  -e TESTSUITE="spectest" \
-                  -e AFP_VERSION="1" \
-                  -e AFP_EXTMAP="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
+  afp-lantest:
+    name: AFP lantest - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e INSECURE_AUTH="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="lan" \
+            -e AFP_VERSION="7" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-    afp-rotest-afp34:
-        name: AFP spec test (readonly) AFP 3.4 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e INSECURE_AUTH="1" \
-                  -e VERBOSE="1" \
-                  -e AFP_READONLY="1" \
-                  -e TESTSUITE="readonly" \
-                  -e AFP_VERSION="7" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
-
-    afp-rotest-afp21:
-        name: AFP spec test (readonly) AFP 2.1 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e INSECURE_AUTH="1" \
-                  -e VERBOSE="1" \
-                  -e AFP_READONLY="1" \
-                  -e TESTSUITE="readonly" \
-                  -e AFP_VERSION="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
-
-    afp-logintest-afp34:
-        name: AFP login test AFP 3.4 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e INSECURE_AUTH="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="login" \
-                  -e AFP_VERSION="7" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
-
-    afp-logintest-afp21:
-        name: AFP login test AFP 2.1 - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e INSECURE_AUTH="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="login" \
-                  -e AFP_VERSION="1" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
-
-    afp-lantest:
-        name: AFP lantest - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e INSECURE_AUTH="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="lan" \
-                  -e AFP_VERSION="7" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
-
-    afp-speedtest:
-        name: AFP speedtest - Alpine
-        needs: build-container-testsuite
-        runs-on: ubuntu-latest
-        timeout-minutes: 5
-        if: ${{ github.actor != 'dependabot[bot]' }}
-        steps:
-            - name: Run Netatalk testsuite
-              run: |
-                docker run --rm \
-                  -e AFP_USER="atalk1" \
-                  -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
-                  -e AFP_GROUP="afpusers" \
-                  -e SHARE_NAME="test1" \
-                  -e INSECURE_AUTH="1" \
-                  -e VERBOSE="1" \
-                  -e TESTSUITE="speed" \
-                  -e AFP_VERSION="7" \
-                  ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+  afp-speedtest:
+    name: AFP speedtest - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_PASS="${{ secrets.AFP_PASSWD }}" \
+            -e AFP_GROUP="afpusers" \
+            -e SHARE_NAME="test1" \
+            -e INSECURE_AUTH="1" \
+            -e VERBOSE="1" \
+            -e TESTSUITE="speed" \
+            -e AFP_VERSION="7" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,10 +209,6 @@ jobs:
             type=raw,value=${{ steps.get_version.outputs.major_version }}
             type=raw,value=${{ steps.get_version.outputs.minor_version }}
             type=raw,value=${{ steps.get_version.outputs.version }}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Build and push container image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
@@ -303,13 +299,6 @@ jobs:
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-
       - name: Build and push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get version
         id: get_version
         run: |
@@ -133,14 +133,14 @@ jobs:
         run: |
           echo "IMAGE_NAME=${REPO,,}" >> ${GITHUB_ENV}
       - name: Login to container registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata
         id: metadata
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -154,7 +154,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Build and push container image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: Dockerfile
@@ -170,7 +170,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Get version
         id: get_version
         run: |
@@ -193,14 +193,14 @@ jobs:
         run: |
           echo "IMAGE_NAME=${REPO,,}-webmin" >> ${GITHUB_ENV}
       - name: Login to container registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ${{ env.GHCR_REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata
         id: metadata
-        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
+        uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -210,7 +210,7 @@ jobs:
             type=raw,value=${{ steps.get_version.outputs.minor_version }}
             type=raw,value=${{ steps.get_version.outputs.version }}
       - name: Build and push container image
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
           file: webmin_module.Dockerfile

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '45 23 * * 0'
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions: read-all
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -28,7 +28,7 @@ jobs:
       image: debian:trixie
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install dependencies
         run: |
           apt-get update
@@ -55,11 +55,11 @@ jobs:
       - name: Install
         run: meson install -C build
       - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: '/usr/local/share/doc/netatalk/htmldocs'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,13 +34,15 @@ jobs:
                 astyle \
                 muon \
                 perltidy \
-                shfmt
+                shfmt \
+                yamlfmt
         - name: Check formatting
           run: |
               ./contrib/scripts/codefmt.sh -v -s c
               ./contrib/scripts/codefmt.sh -v -s meson
               ./contrib/scripts/codefmt.sh -v -s perl
               ./contrib/scripts/codefmt.sh -v -s shell
+              ./contrib/scripts/codefmt.sh -v -s yaml
 
     markdown-linting:
         name: Markdown Linting

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,41 +16,41 @@ on:
 permissions: read-all
 
 jobs:
-    formatting:
-        name: Code Formatting
-        runs-on: macos-latest
-        env:
-          HOMEBREW_NO_INSTALL_CLEANUP: 1
-          HOMEBREW_NO_AUTO_UPDATE: 1
-        steps:
-        - name: Checkout code
-          uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-          with:
-            fetch-depth: 0
-        - name: Install dependencies
-          run: |
-              brew update
-              brew install \
-                astyle \
-                muon \
-                perltidy \
-                shfmt \
-                yamlfmt
-        - name: Check formatting
-          run: |
-              ./contrib/scripts/codefmt.sh -v -s c
-              ./contrib/scripts/codefmt.sh -v -s meson
-              ./contrib/scripts/codefmt.sh -v -s perl
-              ./contrib/scripts/codefmt.sh -v -s shell
-              ./contrib/scripts/codefmt.sh -v -s yaml
+  formatting:
+    name: Code Formatting
+    runs-on: macos-latest
+    env:
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_NO_AUTO_UPDATE: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install \
+            astyle \
+            muon \
+            perltidy \
+            shfmt \
+            yamlfmt
+      - name: Check formatting
+        run: |
+          ./contrib/scripts/codefmt.sh -v -s c
+          ./contrib/scripts/codefmt.sh -v -s meson
+          ./contrib/scripts/codefmt.sh -v -s perl
+          ./contrib/scripts/codefmt.sh -v -s shell
+          ./contrib/scripts/codefmt.sh -v -s yaml
 
-    markdown-linting:
-        name: Markdown Linting
-        runs-on: ubuntu-latest
-        steps:
-        - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-          with:
-            fetch-depth: 0
-        - uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e
-          with:
-            globs: '**/*.md'
+  markdown-linting:
+    name: Markdown Linting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+      - uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e
+        with:
+          globs: '**/*.md'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       HOMEBREW_NO_AUTO_UPDATE: 1
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - name: Install dependencies
@@ -48,7 +48,7 @@ jobs:
     name: Markdown Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
       - uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e

--- a/.yamlfmt.yaml
+++ b/.yamlfmt.yaml
@@ -1,0 +1,11 @@
+formatter:
+  type: basic
+  eof_newline: true
+  include_document_start: false
+  include_document_end: false
+  indent: 2
+  indentless_arrays: false
+  line_ending: lf
+  max_line_length: 120
+  pad_line_comments: 1
+  retain_line_breaks_single: true

--- a/contrib/scripts/codefmt.sh
+++ b/contrib/scripts/codefmt.sh
@@ -20,7 +20,7 @@ IS_GIT=0
 VERBOSE=0
 
 usage() {
-    echo "Usage: $0 [-v] [-s c|meson|perl|shell]"
+    echo "Usage: $0 [-v] [-s c|meson|perl|shell|yaml]"
     exit 2
 }
 
@@ -31,8 +31,8 @@ while getopts "vs:" opt; do
             ;;
         s)
             SOURCE_TYPE="$OPTARG"
-            if [ "$SOURCE_TYPE" != "c" ] && [ "$SOURCE_TYPE" != "meson" ] && [ "$SOURCE_TYPE" != "perl" ] && [ "$SOURCE_TYPE" != "shell" ]; then
-                echo "Error: Source type must be either 'c', 'meson', 'perl', or 'shell'"
+            if [ "$SOURCE_TYPE" != "c" ] && [ "$SOURCE_TYPE" != "meson" ] && [ "$SOURCE_TYPE" != "perl" ] && [ "$SOURCE_TYPE" != "shell" ] && [ "$SOURCE_TYPE" != "yaml" ]; then
+                echo "Error: Source type must be either 'c', 'meson', 'perl', 'shell', or 'yaml'"
                 usage
                 exit 2
             fi
@@ -117,6 +117,20 @@ if [ "$SOURCE_TYPE" = "shell" ] || [ "$SOURCE_TYPE" = "" ]; then
         shfmt --write .
     else
         echo "Error: shfmt not found in PATH"
+        exit 2
+    fi
+fi
+
+if [ "$SOURCE_TYPE" = "yaml" ] || [ "$SOURCE_TYPE" = "" ]; then
+    if command -v yamlfmt > /dev/null 2>&1; then
+        if [ $VERBOSE -eq 1 ]; then
+            echo "Formatting yaml files..."
+            yamlfmt --verbose .
+        else
+            yamlfmt .
+        fi
+    else
+        echo "Error: yamlfmt not found in PATH"
         exit 2
     fi
 fi


### PR DESCRIPTION
Apply yaml formatting rules based on the [yamlfmt style guide](https://github.com/google/yamlfmt/blob/main/docs/config-file.md) with the following configuration:

```
formatter:
  type: basic
  eof_newline: true
  include_document_start: false
  include_document_end: false
  indent: 2
  indentless_arrays: false
  line_ending: lf
  max_line_length: 120
  pad_line_comments: 1
  retain_line_breaks_single: true
```

- Introduce a configuration file for yamlfmt
- Add support for formatting yaml files to codefmt.sh
- GitHub CI: Check for yaml coding style compliance in test workflow
- GitHub CI: Remove redundant steps when building release webmin container
- GitHub CI: Consistently leave records of version tags for each action