### PR TITLE
testsuite: afp_lantest, Added Linux IO monitoring to afp_lantest and refactored results display

### DIFF
--- a/contrib/scripts/netatalk_container_entrypoint.sh
+++ b/contrib/scripts/netatalk_container_entrypoint.sh
@@ -256,6 +256,23 @@ else
     echo "NOTE: Set the \`ATALKD_INTERFACE' environment variable to start DDP services."
 fi
 
+if [ -z "$AFP_VERSION" ]; then
+    AFP_VERSION=7
+fi
+
+if [ "$TESTSUITE" = "lan" ]; then
+    if [ -n "$IO_MONITORING" ]; then
+        if mkdir -p /proc_io && mount -t proc -o hidepid=0,gid=0 proc /proc_io 2> /dev/null; then
+            echo "Successfully created /proc_io with hidepid=0,gid=0 for I/O monitoring (gid=0 as TESTSUITE tests run as root)"
+        else
+            echo "WARNING: IO_MONITORING enabled, however failed to create /proc_io mount"
+            echo "NOTE: Container must be run with '--privileged' argument to allow proc mounts for afp_lantest IO monitoring"
+        fi
+    else
+        echo "NOTE: TESTSUITE set to 'lan' for afp_lantest test, however IO_MONITORING=1 envvar not set (mounts /proc_io filesystem). IO monitoring disabled."
+    fi
+fi
+
 echo "*** Starting AFP server"
 if [ -z "$TESTSUITE" ]; then
     netatalk -d
@@ -263,6 +280,7 @@ else
     netatalk
     sleep 2
     echo "*** Running testsuite: $TESTSUITE"
+    echo ""
     case "$TESTSUITE" in
         spectest)
             set -x

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2025, Andy Lemin (andylemin)
+ * Credits; Based on work by Rafal Lewczuk, Didier Gautheron, Frank Lahm, and Netatalk contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
 #include "specs.h"
 
 #include <getopt.h>
@@ -7,18 +22,33 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <pwd.h>
 #include <pthread.h>
 #include <sys/socket.h>
 #include <math.h>
 #include <stdint.h>
+#include <limits.h>
+
+#ifdef __linux__
+#include "lantest_io_monitor.h"
+#endif
 
 #include "afpclient.h"
 #include "test.h"
 
+/* IO Monitoring measurement types */
+#define MEASURE_TIME_MS 0
+#define MEASURE_AFPD_READ_IO 1
+#define MEASURE_AFPD_WRITE_IO 2
+#define MEASURE_CNID_READ_IO 3
+#define MEASURE_CNID_WRITE_IO 4
+#define NUM_MEASUREMENTS 5
+
 #define FPWRITE_RPLY_SIZE 24
 #define FPWRITE_RQST_SIZE 36
 
+/* Test IDs */
 #define TEST_OPENSTATREAD 0
 #define TEST_WRITE100MB 1
 #define TEST_READ100MB 2
@@ -33,18 +63,37 @@
 #define TEST_CACHE_VALIDATION 11
 #define LASTTEST TEST_CACHE_VALIDATION
 #define NUMTESTS (LASTTEST+1)
+#define TOTAL_AFP_OPS 80686
 
 CONN *Conn;
 int ExitCode = 0;
+int Version = 34;
+int Mac = 0;
 char Data[300000] = "";
 char    *Vol = "";
 char    *User = "";
 char    *Path;
-int     Version = 34;
-int     Mac = 0;
 char    *Test = NULL;
+static uint16_t vol;
+static DSI *dsi;
+static char    *Server = "localhost";
+static int32_t Port = DSI_AFPOVERTCP_PORT;
+static char    *Password = "";
+static uint8_t Iterations = 2;
+static uint8_t Iterations_save;
+static uint8_t iteration_counter = 0;
+static struct timeval tv_start;
+static struct timeval tv_end;
+static struct timeval tv_dif;
+static pthread_t tid;
+static uint8_t active_thread = 0;  /* Track if we have an active thread */
 
-/* Unused */
+/* Global Debug flag */
+uint8_t Debug = 0;
+/* Global Quiet flag override for lantest (stdout output enabled) */
+uint8_t lantest_Quiet = 0;
+
+/* Remote linker names */
 CONN *Conn2;
 uint16_t VolID;
 int PassCount = 0;
@@ -55,55 +104,62 @@ char FailedTests[1024][256] = {{0}};
 char NotTestedTests[1024][256] = {{0}};
 char SkippedTests[1024][256] = {{0}};
 
-/* Configure the tests */
-#define DIRNUM 10                                 /* 1000 nested dirs */
-static int smallfiles = 1000;                     /* 1000 files */
-static off_t rwsize = 100 * 1024 * 1024;          /* 100 MB */
-static int locking = 10000 / 40;                  /* 10000 times */
-static int create_enum_files = 2000;              /* 2000 files */
+/* Tests configuration */
+#define DIRNUM 10  /* 1000 nested dirs */
+static int32_t smallfiles = 1000;  /* 1000 files */
+static off_t rwsize = 100 * 1024 * 1024;  /* 100 MB */
+static int32_t locking = 10000 / 40;  /* 10000 times */
+static int32_t create_enum_files = 2000;  /* 2000 files */
+static int32_t cache_dirs = 10;  /* dirs for cache tests */
+static int32_t cache_files_per_dir = 10;  /* files per dir */
+static int32_t cache_lookup_iterations = 100;  /* cache test iterations */
+static int32_t mixed_cache_files = 200;  /* mixed ops file count */
+static int32_t deep_dir_levels = 20;  /* deep traversal dir levels */
+static int32_t deep_test_files = 50;  /* files in deepest dir */
+static int32_t deep_traversals = 50;  /* path traversal iterations */
+static int32_t validation_files = 100;  /* validation file count */
+static int32_t validation_iterations = 100;  /* validation iterations */
 
-/* Cache test configuration */
-static int cache_dirs = 10;                /* dirs for cache tests */
-static int cache_files_per_dir = 10;       /* files per dir */
-static int cache_lookup_iterations = 100;  /* cache test iterations */
-static int mixed_cache_files = 200;        /* mixed ops file count */
-static int deep_dir_levels = 20;           /* deep traversal dir levels */
-static int deep_test_files = 50;           /* files in deepest dir */
-static int deep_traversals = 50;           /* path traversal iterations */
-static int validation_files = 100;         /* validation file count */
-static int validation_iterations = 100;    /* validation iterations */
-
-static uint16_t vol;
-static DSI *dsi;
-static char    *Server = "localhost";
-static int     Port = DSI_AFPOVERTCP_PORT;
-static char    *Password = "";
-static int     Iterations = 1;
-static int     Iterations_save;
-static int     iteration_counter = 0;
-static struct timeval tv_start;
-static struct timeval tv_end;
-static struct timeval tv_dif;
-static pthread_t tid;
-static unsigned long long numrw;
+/* Forward declarations */
+void clean_exit(int exit_code);
+static uint64_t numrw;
+/* Bool array of which tests to run */
 static char teststorun[NUMTESTS];
-static unsigned long (*results)[][NUMTESTS];
+/* [iteration][test][measurement_type] */
+static uint64_t (*results)[][NUMTESTS][NUM_MEASUREMENTS];
 static char *bigfilename;
 
-static char *resultstrings[] = {
-    "Opening, stating and reading 512 bytes from 1000 files ",
-    "Writing one large file                                 ",
-    "Reading one large file                                 ",
-    "Locking/Unlocking 10000 times each                     ",
-    "Creating dir with 2000 files                           ",
-    "Enumerate dir with 2000 files                          ",
-    "Deleting dir with 2000 files                           ",
-    "Create directory tree with 1000 dirs                   ",
-    "Directory cache hits (1000 dir + 10000 file lookups)   ",
-    "Mixed cache operations (create/stat/enum/delete)       ",
-    "Deep path traversal (nested directory navigation)      ",
-    "Cache validation efficiency (metadata changes)         "
+/* Results display control
+0 = tabular (default), 1 = CSV */
+static int32_t csv_output = 0;
+/* Display width for test names in progress output */
+#define TEST_NAME_DISPLAY_WIDTH 66
+
+/* Descriptive test names for output formatting with AFP operation counts */
+static const char *test_names[NUMTESTS] = {
+    "Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]",  /* TEST_OPENSTATREAD */
+    "Writing one large file [103 AFP ops]",  /* TEST_WRITE100MB */
+    "Reading one large file [102 AFP ops]",  /* TEST_READ100MB */
+    "Locking/Unlocking 10000 times each [20,000 AFP ops]",  /* TEST_LOCKUNLOCK */
+    "Creating dir with 2000 files [4,000 AFP ops]",  /* TEST_CREATE2000FILES */
+    "Enumerate dir with 2000 files [~51 AFP ops]",  /* TEST_ENUM2000FILES */
+    "Deleting dir with 2000 files [2,000 AFP ops]",  /* TEST_DELETE2000FILES */
+    "Create directory tree with 1000 dirs [1,110 AFP ops]",  /* TEST_CREATEDIR */
+    "Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]",  /* TEST_DIRCACHE_HITS */
+    "Mixed cache operations (create/stat/enum/delete) [820 AFP ops]",  /* TEST_DIRCACHE_MIXED */
+    "Deep path traversal (nested directory navigation) [3,500 AFP ops]",  /* TEST_DIRCACHE_TRAVERSE */
+    "Cache validation efficiency (metadata changes) [30,000 AFP ops]"  /* TEST_CACHE_VALIDATION */
 };
+
+/* Global error constants for clean_exit() */
+#define ERROR_MEMORY_ALLOCATION  2
+#define ERROR_FILE_DIRECTORY_OPS 3
+#define ERROR_FORK_OPERATIONS    4
+#define ERROR_NETWORK_PROTOCOL   5
+#define ERROR_THREAD_OPERATIONS  6
+#define ERROR_VALIDATION_TEST    7
+#define ERROR_CONFIGURATION      8
+#define ERROR_VOLUME_OPERATIONS  9
 
 static void starttimer(void)
 {
@@ -115,7 +171,7 @@ static void stoptimer(void)
     gettimeofday(&tv_end, NULL);
 }
 
-static unsigned long timediff(void)
+static uint64_t timediff(void)
 {
     if (tv_end.tv_usec < tv_start.tv_usec) {
         tv_end.tv_usec += 1000000;
@@ -127,162 +183,612 @@ static unsigned long timediff(void)
     return (tv_dif.tv_sec * 1000) + (tv_dif.tv_usec / 1000);
 }
 
-static void addresult(int test, int iteration)
+/* Helper function to format test name with fixed-width padding */
+static void format_padded_test_name(char *dest, const char *src, size_t width)
 {
-    unsigned long t;
-    unsigned long long avg;
+    int32_t len = snprintf(dest, width + 1, "%-*s", (int32_t)width, src);
+
+    if (len >= 0 && len < width) {
+        memset(dest + len, ' ', width - len);
+    }
+
+    dest[width] = '\0';
+}
+
+static void addresult(int32_t test, int32_t iteration)
+{
+    uint64_t t;
+    uint64_t avg;
     t = timediff();
-    fprintf(stderr, "Run %u => %s%6lu ms", iteration, resultstrings[test], t);
+    /* Store timing measurement */
+    (*results)[iteration][test][MEASURE_TIME_MS] = t;
+#ifdef __linux__
+    /* Stop IO monitoring and capture values */
+    capture_io_values(TEST_STOP);
+
+    /* Store IO measurements if enabled */
+    if (io_monitoring_enabled) {
+        (*results)[iteration][test][MEASURE_AFPD_READ_IO] = iodiff_io(afpd_pid, 0);
+        (*results)[iteration][test][MEASURE_AFPD_WRITE_IO] = iodiff_io(afpd_pid, 1);
+        (*results)[iteration][test][MEASURE_CNID_READ_IO] = iodiff_io(cnid_dbd_pid, 0);
+        (*results)[iteration][test][MEASURE_CNID_WRITE_IO] = iodiff_io(cnid_dbd_pid, 1);
+    } else {
+        (*results)[iteration][test][MEASURE_AFPD_READ_IO] = 0;
+        (*results)[iteration][test][MEASURE_AFPD_WRITE_IO] = 0;
+        (*results)[iteration][test][MEASURE_CNID_READ_IO] = 0;
+        (*results)[iteration][test][MEASURE_CNID_WRITE_IO] = 0;
+    }
+
+#else
+    /* Non-Linux platforms: set IO measurements to 0 */
+    (*results)[iteration][test][MEASURE_AFPD_READ_IO] = 0;
+    (*results)[iteration][test][MEASURE_AFPD_WRITE_IO] = 0;
+    (*results)[iteration][test][MEASURE_CNID_READ_IO] = 0;
+    (*results)[iteration][test][MEASURE_CNID_WRITE_IO] = 0;
+#endif
+    /* Display human-readable progress */
+    char padded_name[TEST_NAME_DISPLAY_WIDTH + 1];
+    format_padded_test_name(padded_name, test_names[test], TEST_NAME_DISPLAY_WIDTH);
+    fprintf(stdout, "Run %u => %s %6lu ms", iteration + 1, padded_name, t);
 
     if ((test == TEST_WRITE100MB) || (test == TEST_READ100MB)) {
         if (t > 0) {  /* Prevent division by zero */
             avg = (rwsize / 1000) / t;
-            fprintf(stderr, " for %lu MB (avg. %llu MB/s)",
+            fprintf(stdout, " for %lu MB (avg. %llu MB/s)",
                     rwsize / (1024 * 1024), avg);
         } else {
-            fprintf(stderr, " for %lu MB (time too small to measure)",
+            fprintf(stdout, " for %lu MB (time too small to measure)",
                     rwsize / (1024 * 1024));
         }
     }
 
-    fprintf(stderr, "\n");
-    (*results)[iteration][test] = t;
+#ifdef __linux__
+
+    /* Display IO measurements if enabled */
+    if (io_monitoring_enabled) {
+        fprintf(stdout,
+                "\n         IO Operations; afpd: %llu READs, %llu WRITEs | cnid_dbd: %llu READs, %llu WRITEs",
+                (*results)[iteration][test][MEASURE_AFPD_READ_IO],
+                (*results)[iteration][test][MEASURE_AFPD_WRITE_IO],
+                (*results)[iteration][test][MEASURE_CNID_READ_IO],
+                (*results)[iteration][test][MEASURE_CNID_WRITE_IO]);
+    }
+
+#endif
+    fprintf(stdout, "\n");
+}
+
+/* Helper function to check if measurement should be skipped */
+static inline int32_t should_skip_measurement(int32_t measure_type)
+{
+#ifdef __linux__
+    return (!io_monitoring_enabled && measure_type > MEASURE_TIME_MS);
+#else
+    return (measure_type > MEASURE_TIME_MS);
+#endif
+}
+
+/* Helper function to calculate statistics for all tests */
+static void results_calc_stats(uint64_t
+                               averages[NUMTESTS][NUM_MEASUREMENTS],
+                               double std_devs[NUMTESTS][NUM_MEASUREMENTS],
+                               char teststorun[NUMTESTS])
+{
+    int32_t i, test, measure_type;
+    uint64_t sum;
+    int32_t valid_counts[NUMTESTS][NUM_MEASUREMENTS] = {0};
+
+    for (test = 0; test < NUMTESTS; test++) {
+        if (!teststorun[test]) {
+            continue;
+        }
+
+        /* Calculate averages */
+        for (measure_type = 0; measure_type < NUM_MEASUREMENTS; measure_type++) {
+            if (should_skip_measurement(measure_type)) {
+                continue;
+            }
+
+            sum = 0;
+            valid_counts[test][measure_type] = 0;
+
+            for (i = 0; i < Iterations_save; i++) {
+                if ((*results)[i][test][measure_type] > 0) {
+                    sum += (*results)[i][test][measure_type];
+                    valid_counts[test][measure_type]++;
+                }
+            }
+
+            if (valid_counts[test][measure_type] > 0) {
+                averages[test][measure_type] = sum / valid_counts[test][measure_type];
+            }
+        }
+
+        /* Calculate standard deviations */
+        if (Iterations_save > 1) {
+            for (measure_type = 0; measure_type < NUM_MEASUREMENTS; measure_type++) {
+                if (should_skip_measurement(measure_type)) {
+                    continue;
+                }
+
+                if (valid_counts[test][measure_type] > 1) {
+                    double sum_sq_diff = 0.0;
+
+                    for (i = 0; i < Iterations_save; i++) {
+                        if ((*results)[i][test][measure_type] > 0) {
+                            double diff = (double)((*results)[i][test][measure_type]) -
+                                          (double)averages[test][measure_type];
+                            sum_sq_diff += diff * diff;
+                        }
+                    }
+
+                    std_devs[test][measure_type] = sqrt(sum_sq_diff /
+                                                        (valid_counts[test][measure_type] - 1));
+                }
+            }
+        }
+    }
+}
+
+/* Helper function to print headers */
+static void results_print_headers(int32_t is_csv)
+{
+#ifdef __linux__
+
+    if (io_monitoring_enabled) {
+        if (is_csv) {
+            fprintf(stdout,
+                    "Test,Time_ms,Time±,AFPD_R,AFPD_R±,AFPD_W,AFPD_W±,CNID_R,CNID_R±,CNID_W,CNID_W±,MB/s\n");
+        } else {
+            fprintf(stdout, "%-66s %8s %6s %6s %7s %6s %7s %6s %7s %6s %7s %6s\n",
+                    "Test", " Time_ms", " Time±", "AFPD_R", "AFPD_R±", "AFPD_W", "AFPD_W±",
+                    "CNID_R", "CNID_R±", "CNID_W", "CNID_W±", "MB/s");
+            fprintf(stdout, "%-66s %8s %6s %6s %7s %6s %7s %6s %7s %6s %7s %6s\n",
+                    "------------------------------------------------------------------",
+                    "--------", "------",
+                    "------", "-------", "------", "-------", "------", "-------", "------",
+                    "-------", "------");
+        }
+    } else {
+        if (is_csv) {
+            fprintf(stdout, "Test,Time_ms,Time±,MB/s\n");
+        } else {
+            fprintf(stdout, "%-66s %7s %6s %6s\n",
+                    "Test", "Time_ms", "Time±", "MB/s");
+            fprintf(stdout, "%-66s %7s %6s %6s\n",
+                    "------------------------------------------------------------------", "-------",
+                    "------",
+                    "------");
+        }
+    }
+
+#else
+
+    if (is_csv) {
+        fprintf(stdout, "Test,Time_ms,Time±,MB/s\n");
+    } else {
+        fprintf(stdout, "%-66s %7s %6s %6s\n",
+                "Test", "Time_ms", "Time±", "MB/s");
+        fprintf(stdout, "%-66s %7s %6s %6s\n",
+                "------------------------------------------------------------------",
+                "--------", "------",
+                "------");
+    }
+
+#endif
+}
+
+/* Helper function to print data row */
+static void results_print_row(int32_t test, int32_t is_csv,
+                              uint64_t averages[NUMTESTS][NUM_MEASUREMENTS],
+                              double std_devs[NUMTESTS][NUM_MEASUREMENTS])
+{
+    /* Calculate throughput for file I/O tests */
+    uint64_t thrput = 0;
+
+    if ((test == TEST_WRITE100MB || test == TEST_READ100MB)
+            && averages[test][MEASURE_TIME_MS] > 0) {
+        thrput = (100 * 1000) / averages[test][MEASURE_TIME_MS];
+    }
+
+    /* Print test identifier */
+    const char *test_id = is_csv ? "Test_%d" : test_names[test];
+#ifdef __linux__
+
+    if (io_monitoring_enabled) {
+        if (is_csv) {
+            fprintf(stdout,
+                    "%s,%llu,%.1f,%llu,%.1f,%llu,%.1f,%llu,%.1f,%llu,%.1f,%llu\n",
+                    test_names[test],
+                    averages[test][MEASURE_TIME_MS], std_devs[test][MEASURE_TIME_MS],
+                    averages[test][MEASURE_AFPD_READ_IO], std_devs[test][MEASURE_AFPD_READ_IO],
+                    averages[test][MEASURE_AFPD_WRITE_IO], std_devs[test][MEASURE_AFPD_WRITE_IO],
+                    averages[test][MEASURE_CNID_READ_IO], std_devs[test][MEASURE_CNID_READ_IO],
+                    averages[test][MEASURE_CNID_WRITE_IO], std_devs[test][MEASURE_CNID_WRITE_IO],
+                    thrput);
+        } else {
+            fprintf(stdout,
+                    "%-66s %8llu %6.1f %6llu %7.1f %6llu %7.1f %6llu %7.1f %6llu %7.1f %6llu\n",
+                    test_names[test],
+                    averages[test][MEASURE_TIME_MS], std_devs[test][MEASURE_TIME_MS],
+                    averages[test][MEASURE_AFPD_READ_IO], std_devs[test][MEASURE_AFPD_READ_IO],
+                    averages[test][MEASURE_AFPD_WRITE_IO], std_devs[test][MEASURE_AFPD_WRITE_IO],
+                    averages[test][MEASURE_CNID_READ_IO], std_devs[test][MEASURE_CNID_READ_IO],
+                    averages[test][MEASURE_CNID_WRITE_IO], std_devs[test][MEASURE_CNID_WRITE_IO],
+                    thrput);
+        }
+    } else {
+        if (is_csv) {
+            fprintf(stdout, "%s,%llu,%.1f,%llu\n",
+                    test_names[test],
+                    averages[test][MEASURE_TIME_MS], std_devs[test][MEASURE_TIME_MS],
+                    thrput);
+        } else {
+            fprintf(stdout, "%-66s %7llu %6.1f %6llu\n",
+                    test_names[test],
+                    averages[test][MEASURE_TIME_MS], std_devs[test][MEASURE_TIME_MS],
+                    thrput);
+        }
+    }
+
+#else
+
+    if (is_csv) {
+        fprintf(stdout, "%s,%llu,%.1f,%llu\n",
+                test_names[test],
+                averages[test][MEASURE_TIME_MS], std_devs[test][MEASURE_TIME_MS],
+                thrput);
+    } else {
+        fprintf(stdout, "%-66s %7llu %6.1f %6llu\n",
+                test_names[test],
+                averages[test][MEASURE_TIME_MS], std_devs[test][MEASURE_TIME_MS],
+                thrput);
+    }
+
+#endif
+}
+
+static void result_print_summary(uint64_t
+                                 averages[NUMTESTS][NUM_MEASUREMENTS],
+                                 int32_t csv_output,
+                                 char teststorun[NUMTESTS])
+{
+    int32_t test, measure_type;
+    double column_sums[NUM_MEASUREMENTS] = {0.0};
+
+    /* Calculate sums for each measurement type across all active tests */
+    for (test = 0; test < NUMTESTS; test++) {
+        if (!teststorun[test]) {
+            continue;
+        }
+
+        for (measure_type = 0; measure_type < NUM_MEASUREMENTS; measure_type++) {
+            if (should_skip_measurement(measure_type)) {
+                continue;
+            }
+
+            column_sums[measure_type] += averages[test][measure_type];
+        }
+    }
+
+    /* Print separator line */
+    if (!csv_output) {
+#ifdef __linux__
+
+        if (io_monitoring_enabled) {
+            fprintf(stdout, "%-66s %8s %6s %6s %7s %6s %7s %6s %7s %6s %7s %6s\n",
+                    "------------------------------------------------------------------",
+                    "--------", "------",
+                    "------", "-------", "------", "-------", "------", "-------", "------",
+                    "-------", "------");
+        } else {
+            fprintf(stdout, "%-66s %7s %6s %6s\n",
+                    "------------------------------------------------------------------", "-------",
+                    "------",
+                    "------");
+        }
+
+#else
+        fprintf(stdout, "%-66s %7s %6s %6s\n",
+                "------------------------------------------------------------------", "-------",
+                "------",
+                "------");
+#endif
+    }
+
+    /* Print summary row */
+#ifdef __linux__
+
+    if (io_monitoring_enabled) {
+        if (csv_output) {
+            fprintf(stdout,
+                    "Sum of all AFP OPs = %d,%.0f,,%.0f,,%.0f,,%.0f,,%.0f,,\n",
+                    TOTAL_AFP_OPS,
+                    column_sums[MEASURE_TIME_MS],
+                    column_sums[MEASURE_AFPD_READ_IO],
+                    column_sums[MEASURE_AFPD_WRITE_IO],
+                    column_sums[MEASURE_CNID_READ_IO],
+                    column_sums[MEASURE_CNID_WRITE_IO]);
+        } else {
+            char summary_str[100];
+            snprintf(summary_str, sizeof(summary_str), "Sum of all AFP OPs = %d",
+                     TOTAL_AFP_OPS);
+            fprintf(stdout,
+                    "%-66s %8.0f %6s %6.0f %7s %6.0f %7s %6.0f %7s %6.0f %7s %6s\n",
+                    summary_str,
+                    column_sums[MEASURE_TIME_MS], "",
+                    column_sums[MEASURE_AFPD_READ_IO], "",
+                    column_sums[MEASURE_AFPD_WRITE_IO], "",
+                    column_sums[MEASURE_CNID_READ_IO], "",
+                    column_sums[MEASURE_CNID_WRITE_IO], "",
+                    "");
+        }
+    } else {
+        if (csv_output) {
+            fprintf(stdout, "Sum of all AFP OPs = %d,%.0f,,\n",
+                    TOTAL_AFP_OPS,
+                    column_sums[MEASURE_TIME_MS]);
+        } else {
+            char summary_str[100];
+            snprintf(summary_str, sizeof(summary_str), "Sum of all AFP OPs = %d",
+                     TOTAL_AFP_OPS);
+            fprintf(stdout, "%-66s %7.0f %6s %6s\n",
+                    summary_str,
+                    column_sums[MEASURE_TIME_MS], "", "");
+        }
+    }
+
+#else
+
+    if (csv_output) {
+        fprintf(stdout, "Sum of all AFP OPs = %d,%.0f,,\n",
+                TOTAL_AFP_OPS,
+                column_sums[MEASURE_TIME_MS]);
+    } else {
+        char summary_str[100];
+        snprintf(summary_str, sizeof(summary_str), "Sum of all AFP OPs = %d",
+                 TOTAL_AFP_OPS);
+        fprintf(stdout, "%-66s %7.0f %6s %6s\n",
+                summary_str,
+                column_sums[MEASURE_TIME_MS], "", "");
+    }
+
+#endif
+
+    /* Print aggregates summary */
+    if (!csv_output) {
+        fprintf(stdout, "\nAggregates Summary:\n");
+        fprintf(stdout, "-------------------\n");
+        /* Calculate average time per AFP OP */
+        double avg_time_per_op = column_sums[MEASURE_TIME_MS] / (double)TOTAL_AFP_OPS;
+        fprintf(stdout, "Average Time per AFP OP: %.3f ms\n", avg_time_per_op);
+#ifdef __linux__
+
+        if (io_monitoring_enabled) {
+            /* Calculate ratio of AFPD Reads to all AFP OPs */
+            double read_ratio = column_sums[MEASURE_AFPD_READ_IO] / (double)TOTAL_AFP_OPS;
+            fprintf(stdout, "Average AFPD Reads per AFP OP: %.3f\n", read_ratio);
+            /* Calculate ratio of AFPD Writes to all AFP OPs */
+            double write_ratio = column_sums[MEASURE_AFPD_WRITE_IO] / (double)TOTAL_AFP_OPS;
+            fprintf(stdout, "Average AFPD Writes per AFP OP: %.3f\n", write_ratio);
+        }
+
+#endif
+        fprintf(stdout, "\n");
+    }
 }
 
 static void displayresults(void)
 {
-    int i, test, maxindex, minindex;
-    unsigned long long sum, max, min;
+    int32_t i, test, maxindex, minindex;
+    uint64_t sum;
+    uint64_t max, min;
+    int32_t measure_type;
 
-    /* Eleminate runaways */
+    /* Eliminate runaways for all measurement types */
     if (Iterations_save > 5) {
         for (test = 0; test != NUMTESTS; test++) {
-            if (! teststorun[test]) {
+            if (!teststorun[test]) {
                 continue;
             }
 
-            /* Reset min/max for each test */
-            max = 0;
-            min = UINT64_MAX;
-            maxindex = 0;
-            minindex = 0;
-
-            for (i = 0; i < Iterations_save; i++) {
-                if ((*results)[i][test] < min) {
-                    min = (*results)[i][test];
-                    minindex = i;
+            /* Eliminate outliers for each measurement type */
+            for (measure_type = 0; measure_type < NUM_MEASUREMENTS; measure_type++) {
+                if (should_skip_measurement(measure_type)) {
+                    continue;
                 }
 
-                if ((*results)[i][test] > max) {
-                    max = (*results)[i][test];
-                    maxindex = i;
+                max = 0;
+                min = ULONG_MAX;
+                maxindex = 0;
+                minindex = 0;
+
+                /* Find min/max for this measurement type */
+                for (i = 0; i < Iterations_save; i++) {
+                    if ((*results)[i][test][measure_type] < min) {
+                        min = (*results)[i][test][measure_type];
+                        minindex = i;
+                    }
+
+                    if ((*results)[i][test][measure_type] > max) {
+                        max = (*results)[i][test][measure_type];
+                        maxindex = i;
+                    }
                 }
+
+                /* Exclude outliers */
+                (*results)[minindex][test][measure_type] = 0;
+                (*results)[maxindex][test][measure_type] = 0;
             }
-
-            (*results)[minindex][test] = 0;
-            (*results)[maxindex][test] = 0;
         }
     }
 
-    fprintf(stderr, "\nNetatalk Lantest Results");
+    /* Calculate statistics (results and standard deviations) for each test */
+    uint64_t averages[NUMTESTS][NUM_MEASUREMENTS] = {0};
+    double std_devs[NUMTESTS][NUM_MEASUREMENTS] = {0.0};
+    results_calc_stats(averages, std_devs, teststorun);
+    /* Display results banner */
+    fprintf(stdout, "\nNetatalk Lantest Results");
 
     if (Iterations_save > 1) {
-        fprintf(stderr, " (average times across %d iterations)", Iterations_save);
+        fprintf(stdout,
+                " (Averages and standard deviations (±) for all tests, across %d iterations%s)",
+                Iterations_save,
+                Iterations_save == 2 ? " (default)" : "");
     } else {
-        fprintf(stderr, " (single iteration)");
+        fprintf(stdout, " (single iteration)");
     }
 
-    fprintf(stderr, "\n");
-    fprintf(stderr, "===================================\n\n");
-    unsigned long long avg, thrput;
-    double std_dev;
+    fprintf(stdout, "\n");
+    fprintf(stdout,
+            "============================================================================================================\n\n");
+    /* Print results headers based on output format */
+    results_print_headers(csv_output);
 
+    /* Output row data for each test */
     for (test = 0; test < NUMTESTS; test++) {
-        if (! teststorun[test]) {
+        if (!teststorun[test]) {
             continue;
         }
 
-        /* Calculate sum and count valid values */
-        int valid_count = 0;
-
-        for (i = 0, sum = 0; i < Iterations_save; i++) {
-            /* Skip outliers that were set to 0 during elimination */
-            if ((*results)[i][test] > 0) {
-                sum += (*results)[i][test];
-                valid_count++;
-            }
-        }
-
-        if (valid_count <= 0) {
-            fprintf(stderr, "\tFATAL ERROR: no valid iterations for averaging\n");
-            exit(1);
-        }
-
-        avg = sum / valid_count;
-
-        if (avg < 1) {
-            fprintf(stderr, "\tFATAL ERROR: invalid result\n");
-            exit(1);
-        }
-
-        /* Calculate standard deviation if we have multiple valid iterations */
-        std_dev = 0.0;
-
-        if (valid_count > 1) {
-            double sum_sq_diff = 0.0;
-
-            for (i = 0; i < Iterations_save; i++) {
-                if ((*results)[i][test] > 0) {
-                    double diff = (double)((*results)[i][test]) - (double)avg;
-                    sum_sq_diff += diff * diff;
-                }
-            }
-
-            std_dev = sqrt(sum_sq_diff / (valid_count - 1));
-        }
-
-        /* Display test result */
-        fprintf(stderr, "Test %d: %s", test + 1, resultstrings[test]);
-
-        if (Iterations_save > 1) {
-            fprintf(stderr, "\n\t  Average: %6llu ms", avg);
-
-            if (valid_count > 1) {
-                fprintf(stderr, " ± %.1f ms (std dev)", std_dev);
-            }
-        } else {
-            fprintf(stderr, ": %6llu ms", avg);
-        }
-
-        if (test == TEST_WRITE100MB) {
-            thrput = (rwsize / 1000) / avg;
-            fprintf(stderr, "\n\t  Throughput: %llu MB/s (Write, %lu MB file)", thrput,
-                    rwsize / (1024 * 1024));
-        }
-
-        if (test == TEST_READ100MB) {
-            thrput = (rwsize / 1000) / avg;
-            fprintf(stderr, "\n\t  Throughput: %llu MB/s (Read, %lu MB file)", thrput,
-                    rwsize / (1024 * 1024));
-        }
-
-        fprintf(stderr, "\n");
-
-        if (Iterations_save > 1) {
-            fprintf(stderr, "\n");
-        }
+        results_print_row(test, csv_output, averages, std_devs);
     }
+
+    /* Add summary row showing sum of all columns */
+    result_print_summary(averages, csv_output, teststorun);
+    /* TODO If running on Localhost with access to afpd.logs, print 'dircache statistics:' log line */
+}
+
+/* Safe integer conversion with validation */
+static int32_t safe_atoi(const char *str, const char *param_name,
+                         int32_t min_val,
+                         int32_t max_val)
+{
+    char *endptr;
+    int64_t val;
+
+    if (!str || *str == '\0') {
+        fprintf(stderr, "Error: Empty %s parameter\n", param_name);
+        clean_exit(ERROR_CONFIGURATION);
+    }
+
+    errno = 0;  /* Reset errno before conversion */
+    val = strtol(str, &endptr, 10);
+
+    /* Check for conversion errors */
+    if (errno == ERANGE || val < LONG_MIN || val > LONG_MAX) {
+        fprintf(stderr, "Error: %s parameter '%s' out of range\n", param_name, str);
+        clean_exit(ERROR_CONFIGURATION);
+    }
+
+    /* Check for non-numeric characters */
+    if (*endptr != '\0') {
+        fprintf(stderr,
+                "Error: Invalid %s parameter '%s' - contains non-numeric characters\n",
+                param_name, str);
+        clean_exit(ERROR_CONFIGURATION);
+    }
+
+    /* Check parameter-specific bounds */
+    if (val < min_val || val > max_val) {
+        fprintf(stderr, "Error: %s parameter %ld out of valid range [%d, %d]\n",
+                param_name, val, min_val, max_val);
+        clean_exit(ERROR_CONFIGURATION);
+    }
+
+    return (int32_t)val;
 }
 
 /* ------------------------- */
-void fatal_failed(void)
+void clean_exit(int exit_code)
 {
-    fprintf(stderr, "\tFATAL ERROR\n");
-    exit(1);
+    /* Only print error details if this is an error exit (exit_code > 0) */
+    if (exit_code > 0) {
+        fprintf(stderr, "\n\tERROR (Exit Code: %d)\n", exit_code);
+
+        /* Print error description based on exit code */
+        switch (exit_code) {
+        case ERROR_MEMORY_ALLOCATION:
+            fprintf(stderr, "\tDescription: Buffer/cache allocation failure\n");
+            break;
+
+        case ERROR_FILE_DIRECTORY_OPS:
+            fprintf(stderr, "\tDescription: File/Directory Create/delete/access failure\n");
+            break;
+
+        case ERROR_FORK_OPERATIONS:
+            fprintf(stderr, "\tDescription: Fork open/close failure\n");
+            break;
+
+        case ERROR_NETWORK_PROTOCOL:
+            fprintf(stderr, "\tDescription: Network/AFP protocol read/write error\n");
+            break;
+
+        case ERROR_THREAD_OPERATIONS:
+            fprintf(stderr, "\tDescription: Thread Operation failure\n");
+            break;
+
+        case ERROR_VALIDATION_TEST:
+            fprintf(stderr, "\tDescription: Test validation error\n");
+            break;
+
+        case ERROR_CONFIGURATION:
+            fprintf(stderr, "\tDescription: Invalid config parameter\n");
+            break;
+
+        case ERROR_VOLUME_OPERATIONS:
+            fprintf(stderr, "\tDescription: Volume open/access failure\n");
+            break;
+
+        default:
+            fprintf(stderr, "\tDescription: Unspecified error\n");
+            break;
+        }
+
+        fprintf(stderr, "\n");
+    }
+
+    /* Thread cleanup - attempt to join active thread if it exists */
+    if (active_thread) {
+        fprintf(stderr, "Attempting to clean up active thread...\n");
+
+        if (pthread_join(tid, NULL) != 0) {
+            fprintf(stderr, "Warning: Failed to join thread during cleanup\n");
+            pthread_cancel(tid);
+        }
+
+        active_thread = 0;
+    }
+
+    /* Perform cleanup to prevent resource leaks, AFP Session, Sockets, Connection, and struts */
+    if (Conn) {
+        FPLogOut(Conn);
+
+        /* Always close socket regardless of logout success */
+        if (Conn->dsi.socket >= 0) {
+            CloseClientSocket(Conn->dsi.socket);
+            Conn->dsi.socket = -1;
+        }
+
+        free(Conn);
+        Conn = NULL;
+    }
+
+    if (results) {
+        free(results);
+        results = NULL;
+    }
+
+    if (bigfilename) {
+        free(bigfilename);
+        bigfilename = NULL;
+    }
+
+    exit(exit_code);
 }
 
 /* --------------------------------- */
-int is_there(CONN *conn, int did, char *name)
+int32_t is_there(CONN *conn, uint16_t vol, int32_t did, char *name)
 {
     return FPGetFileDirParams(conn, vol, did, name,
                               (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID)
@@ -292,7 +798,7 @@ int is_there(CONN *conn, int did, char *name)
 }
 
 struct async_io_req {
-    unsigned long long air_count;
+    uint64_t air_count;
     size_t air_size;
 };
 
@@ -300,15 +806,15 @@ static void *rply_thread(void *p)
 {
     struct async_io_req *air = p;
     size_t size = air->air_size;
-    unsigned long long n = air->air_count;
+    uint64_t n = air->air_count;
     size_t stored;
     ssize_t len;
     char *buf = NULL;
     buf = malloc(size);
 
     if (!buf) {
-        fprintf(stderr, "Memory allocation failed in rply_thread\n");
-        return NULL;
+        fprintf(stderr, "Memory allocation failed for DSI buffer (%zu bytes)\n", size);
+        clean_exit(ERROR_MEMORY_ALLOCATION);
     }
 
     while (n--) {
@@ -340,14 +846,14 @@ exit:
 }
 
 /* ------------------------- */
-void run_test(const int dir)
+void run_test(const int32_t dir)
 {
     static char *data;
-    int i, maxi = 0;
-    int j, k;
-    int fork;
-    int test = 0;
-    int nowrite;
+    int32_t i, maxi = 0;
+    int32_t j, k;
+    int32_t fork;
+    int32_t test = 0;
+    int32_t nowrite;
     off_t offset;
     struct async_io_req air;
     static char temp[MAXPATHLEN];
@@ -358,30 +864,31 @@ void run_test(const int dir)
 
         if (!data) {
             fprintf(stderr, "Memory allocation failed for data buffer\n");
-            fatal_failed();
+            clean_exit(ERROR_MEMORY_ALLOCATION);
         }
     }
 
     /* --------------- */
     /* Test (1)        */
     if (teststorun[TEST_OPENSTATREAD]) {
+        /* Create files before test */
         for (i = 0; i < smallfiles; i++) {
             snprintf(temp, sizeof(temp), "File.small%d", i);
 
-            if (ntohl(AFPERR_NOOBJ) != is_there(Conn, dir, temp)) {
-                fatal_failed();
+            if (ntohl(AFPERR_NOOBJ) != is_there(Conn, vol, dir, temp)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             if (FPGetFileDirParams(Conn, vol, dir, "", 0, (1 << DIRPBIT_DID))) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             if (FPCreateFile(Conn, vol, 0, dir, temp)) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
-            if (is_there(Conn, dir, temp)) {
-                fatal_failed();
+            if (is_there(Conn, vol, dir, temp)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             if (FPGetFileDirParams(Conn, vol, dir, temp,
@@ -389,7 +896,7 @@ void run_test(const int dir)
                                    (1 << FILPBIT_CDATE) | (1 << FILPBIT_MDATE) | (1 << FILPBIT_DFLEN) |
                                    (1 << FILPBIT_RFLEN)
                                    , 0)) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             if (FPGetFileDirParams(Conn, vol, dir, temp,
@@ -398,7 +905,7 @@ void run_test(const int dir)
                                    (1 << FILPBIT_CDATE) | (1 << FILPBIT_MDATE) | (1 << FILPBIT_DFLEN) |
                                    (1 << FILPBIT_RFLEN)
                                    , 0)) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             fork = FPOpenFork(Conn, vol, OPENFORK_DATA,
@@ -407,20 +914,20 @@ void run_test(const int dir)
                               , dir, temp, OPENACC_WR | OPENACC_RD | OPENACC_DWR | OPENACC_DRD);
 
             if (!fork) {
-                fatal_failed();
+                clean_exit(ERROR_FORK_OPERATIONS);
             }
 
             if (FPGetForkParam(Conn, fork,
                                (1 << FILPBIT_PDID) | (1 << DIRPBIT_LNAME) | (1 << FILPBIT_DFLEN))) {
-                fatal_failed();
+                clean_exit(ERROR_FORK_OPERATIONS);
             }
 
             if (FPWrite(Conn, fork, 0, 20480, data, 0)) {
-                fatal_failed();
+                clean_exit(ERROR_NETWORK_PROTOCOL);
             }
 
             if (FPCloseFork(Conn, fork)) {
-                fatal_failed();
+                clean_exit(ERROR_NETWORK_PROTOCOL);
             }
 
             maxi = i;
@@ -437,104 +944,99 @@ void run_test(const int dir)
                         (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
                         (1 << DIRPBIT_ACCESS)
                        )) {
-            fatal_failed();
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
         starttimer();
 
+        /* Read files for test - OPTIMIZED to reduce AFP operations */
         for (i = 0; i <= maxi; i++) {
             snprintf(temp, sizeof(temp), "File.small%d", i);
 
-            if (is_there(Conn, dir, temp)) {
-                fatal_failed();
+            /* Stat operations first (3 AFP ops) */
+            if (is_there(Conn, vol, dir, temp)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             if (FPGetFileDirParams(Conn, vol, dir, temp, 0x72d, 0)) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             if (FPGetFileDirParams(Conn, vol, dir, temp, 0x73f, 0x133f)) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
-            fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp, OPENACC_RD);
-
-            if (!fork) {
-                fatal_failed();
-            }
-
-            if (FPGetForkParam(Conn, fork, (1 << FILPBIT_DFLEN))) {
-                fatal_failed();
-            }
-
-            if (FPRead(Conn, fork, 0, 512, data)) {
-                fatal_failed();
-            }
-
-            if (FPCloseFork(Conn, fork)) {
-                fatal_failed();
-            }
-
+            /* Open once with read+write permissions (1 AFP op) */
             fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp,
                               OPENACC_RD | OPENACC_DWR);
 
             if (!fork) {
-                fatal_failed();
+                clean_exit(ERROR_FORK_OPERATIONS);
+            }
+
+            /* Get fork params (2 AFP ops) */
+            if (FPGetForkParam(Conn, fork, (1 << FILPBIT_DFLEN))) {
+                clean_exit(ERROR_FORK_OPERATIONS);
             }
 
             if (FPGetForkParam(Conn, fork, 0x242)) {
-                fatal_failed();
+                clean_exit(ERROR_FORK_OPERATIONS);
             }
 
-            if (FPGetFileDirParams(Conn, vol, dir, temp, 0x72d, 0)) {
-                fatal_failed();
+            /* Read operation (1 AFP op) */
+            if (FPRead(Conn, fork, 0, 512, data)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
             }
 
+            /* Close fork (1 AFP op) */
             if (FPCloseFork(Conn, fork)) {
-                fatal_failed();
+                clean_exit(ERROR_NETWORK_PROTOCOL);
             }
         }
 
         stoptimer();
         addresult(TEST_OPENSTATREAD, iteration_counter);
 
-        /* ---------------- */
+        /* Clean up files after test */
         for (i = 0; i <= maxi; i++) {
             snprintf(temp, sizeof(temp), "File.small%d", i);
 
-            if (is_there(Conn, dir, temp)) {
-                fatal_failed();
+            if (is_there(Conn, vol, dir, temp)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             if (FPGetFileDirParams(Conn, vol, dir, temp, 0, (1 << FILPBIT_FNUM))) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             if (FPDelete(Conn, vol, dir, temp)) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
         }
 
         if (FPGetVolParam(Conn, vol, (1 << VOLPBIT_MDATE) | (1 << VOLPBIT_XBFREE))) {
-            fatal_failed();
+            clean_exit(ERROR_NETWORK_PROTOCOL);
         }
     }
 
     /* -------- */
     /* Test (2) */
     if (teststorun[TEST_WRITE100MB]) {
-        strcpy(temp, "File.big");
+        snprintf(temp, sizeof(temp), "File.big");
 
         if (FPCreateFile(Conn, vol, 0, dir, temp)) {
-            fatal_failed();
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
         if (FPGetFileDirParams(Conn, vol, dir, temp, 0x72d, 0)) {
-            fatal_failed();
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
         if (FPGetFileDirParams(Conn, vol, dir, temp, 0x73f, 0x133f)) {
-            fatal_failed();
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
         fork = FPOpenFork(Conn, vol, OPENFORK_DATA,
@@ -542,29 +1044,33 @@ void run_test(const int dir)
                           , dir, temp, OPENACC_WR | OPENACC_RD | OPENACC_DWR | OPENACC_DRD);
 
         if (!fork) {
-            fatal_failed();
+            clean_exit(ERROR_FORK_OPERATIONS);
         }
 
         if (FPGetForkParam(Conn, fork, (1 << FILPBIT_PDID))) {
-            fatal_failed();
+            clean_exit(ERROR_FORK_OPERATIONS);
         }
 
         air.air_count = numrw;
         air.air_size = FPWRITE_RPLY_SIZE;
-        int pthread_ret = pthread_create(&tid, NULL, rply_thread, &air);
+        int32_t pthread_ret = pthread_create(&tid, NULL, rply_thread, &air);
 
         if (pthread_ret != 0) {
             fprintf(stderr, "pthread_create failed: %d\n", pthread_ret);
-            fatal_failed();
+            clean_exit(ERROR_THREAD_OPERATIONS);
         }
 
+        active_thread = 1;  /* Mark thread as active */
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
         starttimer();
 
         for (i = 0, offset = 0; i < numrw;
                 offset += (dsi->server_quantum - FPWRITE_RQST_SIZE), i++) {
             if (FPWrite_ext_async(Conn, fork, offset,
                                   dsi->server_quantum - FPWRITE_RQST_SIZE, data, 0)) {
-                fatal_failed();
+                clean_exit(ERROR_NETWORK_PROTOCOL);
             }
         }
 
@@ -572,11 +1078,16 @@ void run_test(const int dir)
 
         if (pthread_ret != 0) {
             fprintf(stderr, "pthread_join failed: %d\n", pthread_ret);
-            fatal_failed();
+            /* Thread join failed, but thread may still be running */
+            /* Try pthread_cancel as cleanup attempt before fatal exit */
+            pthread_cancel(tid);
+            clean_exit(ERROR_THREAD_OPERATIONS);
         }
 
+        active_thread = 0;  /* Thread successfully joined */
+
         if (FPCloseFork(Conn, fork)) {
-            fatal_failed();
+            clean_exit(ERROR_NETWORK_PROTOCOL);
         }
 
         stoptimer();
@@ -587,15 +1098,15 @@ void run_test(const int dir)
     /* Test (3) */
     if (teststorun[TEST_READ100MB]) {
         if (!bigfilename) {
-            if (is_there(Conn, dir, temp) != AFP_OK) {
-                fatal_failed();
+            if (is_there(Conn, vol, dir, temp) != AFP_OK) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp,
                               OPENACC_RD | OPENACC_DWR);
         } else {
-            if (is_there(Conn, DIRDID_ROOT, bigfilename) != AFP_OK) {
-                fatal_failed();
+            if (is_there(Conn, vol, DIRDID_ROOT, bigfilename) != AFP_OK) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, DIRDID_ROOT, bigfilename,
@@ -603,28 +1114,32 @@ void run_test(const int dir)
         }
 
         if (!fork) {
-            fatal_failed();
+            clean_exit(ERROR_FORK_OPERATIONS);
         }
 
         if (FPGetForkParam(Conn, fork, 0x242)) {
-            fatal_failed();
+            clean_exit(ERROR_FORK_OPERATIONS);
         }
 
         air.air_count = numrw;
         air.air_size = (dsi->server_quantum - FPWRITE_RQST_SIZE) + 16;
-        int pthread_ret = pthread_create(&tid, NULL, rply_thread, &air);
+        int32_t pthread_ret = pthread_create(&tid, NULL, rply_thread, &air);
 
         if (pthread_ret != 0) {
             fprintf(stderr, "pthread_create failed: %d\n", pthread_ret);
-            fatal_failed();
+            clean_exit(ERROR_THREAD_OPERATIONS);
         }
 
+        active_thread = 1;  /* Mark thread as active */
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
         starttimer();
 
         for (i = 0; i < numrw ; i++) {
             if (FPRead_ext_async(Conn, fork, i * (dsi->server_quantum - FPWRITE_RQST_SIZE),
                                  dsi->server_quantum - FPWRITE_RQST_SIZE, data)) {
-                fatal_failed();
+                clean_exit(ERROR_NETWORK_PROTOCOL);
             }
         }
 
@@ -632,11 +1147,16 @@ void run_test(const int dir)
 
         if (pthread_ret != 0) {
             fprintf(stderr, "pthread_join failed: %d\n", pthread_ret);
-            fatal_failed();
+            /* Thread join failed, but thread may still be running */
+            /* Try pthread_cancel as cleanup attempt before fatal exit */
+            pthread_cancel(tid);
+            clean_exit(ERROR_THREAD_OPERATIONS);
         }
 
+        active_thread = 0;  /* Thread successfully joined */
+
         if (FPCloseFork(Conn, fork)) {
-            fatal_failed();
+            clean_exit(ERROR_NETWORK_PROTOCOL);
         }
 
         stoptimer();
@@ -651,29 +1171,29 @@ void run_test(const int dir)
     /* -------- */
     /* Test (4) */
     if (teststorun[TEST_LOCKUNLOCK]) {
-        strcpy(temp, "File.lock");
+        snprintf(temp, sizeof(temp), "File.lock");
 
-        if (ntohl(AFPERR_NOOBJ) != is_there(Conn, dir, temp)) {
-            fatal_failed();
+        if (ntohl(AFPERR_NOOBJ) != is_there(Conn, vol, dir, temp)) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
         if (FPGetFileDirParams(Conn, vol, dir, "", 0, (1 << DIRPBIT_DID))) {
-            fatal_failed();
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
         if (FPCreateFile(Conn, vol, 0, dir, temp)) {
-            fatal_failed();
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
-        if (is_there(Conn, dir, temp)) {
-            fatal_failed();
+        if (is_there(Conn, vol, dir, temp)) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
         if (FPGetFileDirParams(Conn, vol, dir, temp,
                                (1 << FILPBIT_FNUM) | (1 << FILPBIT_PDID) | (1 << FILPBIT_FINFO) |
                                (1 << FILPBIT_CDATE) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
                                , 0)) {
-            fatal_failed();
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
         fork = FPOpenFork(Conn, vol, OPENFORK_DATA,
@@ -681,11 +1201,11 @@ void run_test(const int dir)
                           , dir, temp, OPENACC_WR | OPENACC_RD | OPENACC_DWR | OPENACC_DRD);
 
         if (!fork) {
-            fatal_failed();
+            clean_exit(ERROR_FORK_OPERATIONS);
         }
 
         if (FPGetForkParam(Conn, fork, (1 << FILPBIT_PDID) | (1 << FILPBIT_DFLEN))) {
-            fatal_failed();
+            clean_exit(ERROR_FORK_OPERATIONS);
         }
 
         if (FPGetFileDirParams(Conn, vol, dir, temp,
@@ -693,68 +1213,71 @@ void run_test(const int dir)
                                (1 << FILPBIT_FNUM) |
                                (1 << FILPBIT_FINFO) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
                                , 0)) {
-            fatal_failed();
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
         if (FPWrite(Conn, fork, 0, 40000, data, 0)) {
-            fatal_failed();
+            clean_exit(ERROR_NETWORK_PROTOCOL);
         }
 
         if (FPCloseFork(Conn, fork)) {
-            fatal_failed();
+            clean_exit(ERROR_NETWORK_PROTOCOL);
         }
 
-        if (is_there(Conn, dir, temp)) {
-            fatal_failed();
+        if (is_there(Conn, vol, dir, temp)) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
         if (FPGetFileDirParams(Conn, vol, dir, temp, 0x73f, 0x133f)) {
-            fatal_failed();
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
         fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp, OPENACC_RD);
 
         if (!fork) {
-            fatal_failed();
+            clean_exit(ERROR_FORK_OPERATIONS);
         }
 
         if (FPGetForkParam(Conn, fork, (1 << FILPBIT_DFLEN))) {
-            fatal_failed();
+            clean_exit(ERROR_FORK_OPERATIONS);
         }
 
         if (FPRead(Conn, fork, 0, 512, data)) {
-            fatal_failed();
+            clean_exit(ERROR_NETWORK_PROTOCOL);
         }
 
         if (FPCloseFork(Conn, fork)) {
-            fatal_failed();
+            clean_exit(ERROR_NETWORK_PROTOCOL);
         }
 
         fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp,
                           OPENACC_RD | OPENACC_WR);
 
         if (!fork) {
-            fatal_failed();
+            clean_exit(ERROR_FORK_OPERATIONS);
         }
 
         if (FPGetForkParam(Conn, fork, 0x242)) {
-            fatal_failed();
+            clean_exit(ERROR_FORK_OPERATIONS);
         }
 
         if (FPGetFileDirParams(Conn, vol, dir, temp, 0x72d, 0)) {
-            fatal_failed();
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
         starttimer();
 
         for (j = 0; j < locking; j++) {
             for (i = 0; i <= 390; i += 10) {
                 if (FPByteLock(Conn, fork, 0, 0, i, 10)) {
-                    fatal_failed();
+                    clean_exit(ERROR_NETWORK_PROTOCOL);
                 }
 
                 if (FPByteLock(Conn, fork, 0, 1, i, 10)) {
-                    fatal_failed();
+                    clean_exit(ERROR_NETWORK_PROTOCOL);
                 }
             }
         }
@@ -762,29 +1285,32 @@ void run_test(const int dir)
         stoptimer();
         addresult(TEST_LOCKUNLOCK, iteration_counter);
 
-        if (is_there(Conn, dir, temp)) {
-            fatal_failed();
+        if (is_there(Conn, vol, dir, temp)) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
 
         if (FPCloseFork(Conn, fork)) {
-            fatal_failed();
+            clean_exit(ERROR_NETWORK_PROTOCOL);
         }
 
         if (FPDelete(Conn, vol, dir, "File.lock")) {
-            fatal_failed();
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
         }
     }
 
     /* -------- */
     /* Test (5) */
     if (teststorun[TEST_CREATE2000FILES]) {
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
         starttimer();
 
         for (i = 1; i <= create_enum_files; i++) {
             snprintf(temp, sizeof(temp), "File.0k%d", i);
 
             if (FPCreateFile(Conn, vol, 0, dir, temp)) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
                 break;
             }
 
@@ -792,7 +1318,7 @@ void run_test(const int dir)
                                    (1 << FILPBIT_FNUM) | (1 << FILPBIT_PDID) | (1 << FILPBIT_FINFO) |
                                    (1 << FILPBIT_CDATE) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
                                    , 0) != AFP_OK) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             maxi = i;  /* Track last successful file creation */
@@ -805,6 +1331,9 @@ void run_test(const int dir)
     /* -------- */
     /* Test (6) */
     if (teststorun[TEST_ENUM2000FILES]) {
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
         starttimer();
 
         if (FPEnumerateFull(Conn, vol, 1, 40, DSI_DATASIZ, dir, "",
@@ -816,7 +1345,7 @@ void run_test(const int dir)
                             (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
                             (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
                             (1 << DIRPBIT_ACCESS))) {
-            fatal_failed();
+            clean_exit(ERROR_NETWORK_PROTOCOL);
         }
 
         for (i = 41; (i + 40) < create_enum_files; i += 80) {
@@ -829,7 +1358,7 @@ void run_test(const int dir)
                                 (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
                                 (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
                                 (1 << DIRPBIT_ACCESS))) {
-                fatal_failed();
+                clean_exit(ERROR_NETWORK_PROTOCOL);
             }
 
             if (FPEnumerateFull(Conn, vol, i, 40, DSI_DATASIZ, dir, "",
@@ -841,7 +1370,7 @@ void run_test(const int dir)
                                 (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
                                 (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
                                 (1 << DIRPBIT_ACCESS))) {
-                fatal_failed();
+                clean_exit(ERROR_NETWORK_PROTOCOL);
             }
         }
 
@@ -852,13 +1381,16 @@ void run_test(const int dir)
     /* -------- */
     /* Test (7) */
     if (teststorun[TEST_DELETE2000FILES]) {
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
         starttimer();
 
         for (i = 1; i <= maxi; i++) {
             snprintf(temp, sizeof(temp), "File.0k%d", i);
 
             if (FPDelete(Conn, vol, dir, temp)) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
         }
 
@@ -872,6 +1404,9 @@ void run_test(const int dir)
         uint32_t idirs[DIRNUM];
         uint32_t jdirs[DIRNUM][DIRNUM];
         uint32_t kdirs[DIRNUM][DIRNUM][DIRNUM];
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
         starttimer();
 
         for (i = 0; i < DIRNUM; i++) {
@@ -913,26 +1448,23 @@ void run_test(const int dir)
                 || cache_files_per_dir > 50) {
             fprintf(stderr, "Invalid cache test configuration: dirs=%d, files_per_dir=%d\n",
                     cache_dirs, cache_files_per_dir);
-            fatal_failed();
+            clean_exit(ERROR_VALIDATION_TEST);
         }
 
         /* Use dynamic allocation to prevent stack overflow with VLAs */
         char (*cache_test_files)[32] = calloc(cache_dirs * cache_files_per_dir,
                                               sizeof(char[32]));
-        int *cache_test_dirs_arr = calloc(cache_dirs, sizeof(int));
+        int32_t *cache_test_dirs_arr = calloc(cache_dirs, sizeof(int32_t));
 
-        if (!cache_test_files || !cache_test_dirs_arr) {
-            fprintf(stderr, "Memory allocation failed for cache test arrays\n");
+        if (!cache_test_files) {
+            fprintf(stderr, "Memory allocation failed for test files cache\n");
+            clean_exit(ERROR_MEMORY_ALLOCATION);
+        }
 
-            if (cache_test_files) {
-                free(cache_test_files);
-            }
-
-            if (cache_test_dirs_arr) {
-                free(cache_test_dirs_arr);
-            }
-
-            fatal_failed();
+        if (!cache_test_dirs_arr) {
+            fprintf(stderr, "Memory allocation failed for test dirs array cache\n");
+            free(cache_test_files);  /* Free the successfully allocated memory from above */
+            clean_exit(ERROR_MEMORY_ALLOCATION);
         }
 
         /* Create test directories */
@@ -942,7 +1474,7 @@ void run_test(const int dir)
             if (!(cache_test_dirs_arr[i] = FPCreateDir(Conn, vol, dir, temp))) {
                 free(cache_test_files);
                 free(cache_test_dirs_arr);
-                fatal_failed();
+                clean_exit(ERROR_MEMORY_ALLOCATION);
             }
         }
 
@@ -956,12 +1488,15 @@ void run_test(const int dir)
                                  cache_test_files[i * cache_files_per_dir + j])) {
                     free(cache_test_files);
                     free(cache_test_dirs_arr);
-                    fatal_failed();
+                    clean_exit(ERROR_MEMORY_ALLOCATION);
                 }
             }
         }
 
         /* Now perform many repeated lookups to benefit from caching */
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
         starttimer();
 
         for (k = 0; k < cache_lookup_iterations; k++) {
@@ -969,8 +1504,8 @@ void run_test(const int dir)
                 /* Directory lookups - is_there() returns AFP_OK (0) when found */
                 snprintf(temp, sizeof(temp), "cache_dir_%d", i);
 
-                if (is_there(Conn, dir, temp) != AFP_OK) {
-                    fatal_failed();
+                if (is_there(Conn, vol, dir, temp) != AFP_OK) {
+                    clean_exit(ERROR_FILE_DIRECTORY_OPS);
                 }
 
                 /* File parameter requests (should hit cache) */
@@ -978,7 +1513,7 @@ void run_test(const int dir)
                     if (FPGetFileDirParams(Conn, vol, cache_test_dirs_arr[i],
                                            cache_test_files[i * cache_files_per_dir + j],
                                            (1 << FILPBIT_FNUM) | (1 << FILPBIT_PDID) | (1 << FILPBIT_DFLEN), 0)) {
-                        fatal_failed();
+                        clean_exit(ERROR_FILE_DIRECTORY_OPS);
                     }
                 }
             }
@@ -1004,6 +1539,9 @@ void run_test(const int dir)
     /* -------- */
     /* Test (10) - Mixed Cache Operations */
     if (teststorun[TEST_MIXED_CACHE_OPS]) {
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
         starttimer();
 
         /* Pattern: create -> stat -> enum -> stat -> delete (tests cache lifecycle) */
@@ -1012,13 +1550,13 @@ void run_test(const int dir)
 
             /* Create file */
             if (FPCreateFile(Conn, vol, 0, dir, temp)) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             /* Stat it (should cache the entry) */
             if (FPGetFileDirParams(Conn, vol, dir, temp,
                                    (1 << FILPBIT_FNUM) | (1 << FILPBIT_PDID) | (1 << FILPBIT_DFLEN), 0)) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             /* Enumerate directory (should use cached entries) */
@@ -1034,12 +1572,12 @@ void run_test(const int dir)
             /* Stat again (should hit cache) */
             if (FPGetFileDirParams(Conn, vol, dir, temp,
                                    (1 << FILPBIT_FNUM) | (1 << FILPBIT_CDATE) | (1 << FILPBIT_MDATE), 0)) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
 
             /* Delete (should invalidate cache entry) */
             if (FPDelete(Conn, vol, dir, temp)) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
         }
 
@@ -1053,7 +1591,7 @@ void run_test(const int dir)
         /* Validate configuration to prevent issues */
         if (deep_dir_levels <= 0 || deep_dir_levels > 100) {
             fprintf(stderr, "Invalid deep directory levels: %d\n", deep_dir_levels);
-            fatal_failed();
+            clean_exit(ERROR_CONFIGURATION);
         }
 
         /* Create a deep directory structure */
@@ -1061,7 +1599,7 @@ void run_test(const int dir)
 
         if (!deep_dirs) {
             fprintf(stderr, "Memory allocation failed for deep directories\n");
-            fatal_failed();
+            clean_exit(ERROR_MEMORY_ALLOCATION);
         }
 
         uint32_t current_dir = dir;
@@ -1072,7 +1610,7 @@ void run_test(const int dir)
 
             if (!(deep_dirs[i] = FPCreateDir(Conn, vol, current_dir, temp))) {
                 free(deep_dirs);
-                fatal_failed();
+                clean_exit(ERROR_MEMORY_ALLOCATION);
             }
 
             current_dir = deep_dirs[i];
@@ -1084,10 +1622,13 @@ void run_test(const int dir)
 
             if (FPCreateFile(Conn, vol, 0, current_dir, temp)) {
                 free(deep_dirs);
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
         }
 
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
         starttimer();
 
         /* Perform deep traversals - this benefits greatly from directory caching */
@@ -1099,24 +1640,21 @@ void run_test(const int dir)
                 snprintf(temp, sizeof(temp), "deep_%02d", i);
 
                 /* Directory lookup (should hit cache after first time) - is_there() returns AFP_OK when found */
-                if (is_there(Conn, current_dir, temp) != AFP_OK) {
+                if (is_there(Conn, vol, current_dir, temp) != AFP_OK) {
                     free(deep_dirs);
-                    fatal_failed();
+                    clean_exit(ERROR_FILE_DIRECTORY_OPS);
                 }
 
                 current_dir = deep_dirs[i];
             }
 
-            /* Access files in deep directory - limit to avoid excessive operations */
-            int files_to_access = (deep_test_files < 10) ? deep_test_files : 10;
-
-            for (i = 0; i < files_to_access; i++) {
+            for (i = 0; i < deep_test_files; i++) {
                 snprintf(temp, sizeof(temp), "deep_file_%d", i);
 
                 if (FPGetFileDirParams(Conn, vol, current_dir, temp,
                                        (1 << FILPBIT_FNUM) | (1 << FILPBIT_DFLEN), 0)) {
                     free(deep_dirs);
-                    fatal_failed();
+                    clean_exit(ERROR_FILE_DIRECTORY_OPS);
                 }
             }
         }
@@ -1149,7 +1687,7 @@ void run_test(const int dir)
             fprintf(stderr,
                     "Invalid validation test configuration: files=%d, iterations=%d\n",
                     validation_files, validation_iterations);
-            fatal_failed();
+            clean_exit(ERROR_VALIDATION_TEST);
         }
 
         /* Create test files for validation testing */
@@ -1157,10 +1695,13 @@ void run_test(const int dir)
             snprintf(temp, sizeof(temp), "valid_file_%d", i);
 
             if (FPCreateFile(Conn, vol, 0, dir, temp)) {
-                fatal_failed();
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
         }
 
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
         starttimer();
 
         /* Perform many repeated access operations
@@ -1173,17 +1714,17 @@ void run_test(const int dir)
                 /* Multiple parameter requests on same file */
                 if (FPGetFileDirParams(Conn, vol, dir, temp,
                                        (1 << FILPBIT_FNUM) | (1 << FILPBIT_PDID), 0)) {
-                    fatal_failed();
+                    clean_exit(ERROR_FILE_DIRECTORY_OPS);
                 }
 
                 if (FPGetFileDirParams(Conn, vol, dir, temp,
                                        (1 << FILPBIT_DFLEN) | (1 << FILPBIT_CDATE), 0)) {
-                    fatal_failed();
+                    clean_exit(ERROR_FILE_DIRECTORY_OPS);
                 }
 
                 if (FPGetFileDirParams(Conn, vol, dir, temp,
                                        (1 << FILPBIT_MDATE) | (1 << FILPBIT_FINFO), 0)) {
-                    fatal_failed();
+                    clean_exit(ERROR_FILE_DIRECTORY_OPS);
                 }
             }
         }
@@ -1206,9 +1747,9 @@ fin:
 /* =============================== */
 void usage(char *av0)
 {
-    int i = 0;
+    int32_t i = 0;
     fprintf(stdout,
-            "usage:\t%s [-34567GgVv] [-h host] [-p port] [-s vol] [-u user] [-w password] "
+            "usage:\t%s [-34567bcGgKVv] [-h host] [-p port] [-s vol] [-u user] [-w password] "
             "[-n iterations] [-f tests] [-F bigfile]\n", av0);
     fprintf(stdout, "\t-h\tserver host name (default localhost)\n");
     fprintf(stdout, "\t-p\tserver port (default 548)\n");
@@ -1220,21 +1761,23 @@ void usage(char *av0)
     fprintf(stdout, "\t-5\tAFP 3.2 version\n");
     fprintf(stdout, "\t-6\tAFP 3.3 version\n");
     fprintf(stdout, "\t-7\tAFP 3.4 version (default)\n");
-    fprintf(stdout, "\t-n\thow many iterations to run (default: 1)\n");
-    fprintf(stdout, "\t-v\tverbose\n");
-    fprintf(stdout, "\t-V\tvery verbose\n");
     fprintf(stdout, "\t-b\tdebug mode\n");
-    fprintf(stdout, "\t-g\tfast network (Gbit, file testsize 1 GB)\n");
-    fprintf(stdout,
-            "\t-G\tridiculously fast network (10 Gbit, file testsize 10 GB)\n");
+    fprintf(stdout, "\t-c\toutput results in CSV format (default: tabular)\n");
+    fprintf(stdout, "\t-K\trun cache-focused tests only (tests 8-11)\n");
     fprintf(stdout, "\t-f\ttests to run, eg 134 for tests 1, 3 and 4\n");
     fprintf(stdout,
             "\t-F\tuse this file located in the volume root for the read test (size must match -g and -G options)\n");
-    fprintf(stdout, "\t-C\trun cache-focused tests only (tests 8-11)\n");
+    fprintf(stdout, "\t-g\tfast network (Gbit, file testsize 1 GB)\n");
+    fprintf(stdout,
+            "\t-G\tridiculously fast network (10 Gbit, file testsize 10 GB)\n");
+    fprintf(stdout,
+            "\t-n\titerations to run (default: 2), for iterations > 5 outliers will be removed\n");
+    fprintf(stdout, "\t-v\tverbose\n");
+    fprintf(stdout, "\t-V\tvery verbose\n");
     fprintf(stdout, "\tAvailable tests:\n");
 
     for (i = 0; i < NUMTESTS; i++) {
-        fprintf(stdout, "\t(%u) %s", i + 1, resultstrings[i]);
+        fprintf(stdout, "\t(%u) %s", i + 1, test_names[i]);
 
         if (i >= TEST_CACHE_HITS) {
             fprintf(stdout, " [CACHE]");
@@ -1251,10 +1794,9 @@ void usage(char *av0)
 }
 
 /* ------------------------------- */
-int main(int ac, char **av)
+int main(int32_t ac, char **av)
 {
-    int cc, i, t;
-    int Debug = 0;
+    int32_t cc, i, t;
     static char *vers = "AFP3.4";
     static char *uam = "Cleartxt Passwrd";
 
@@ -1262,7 +1804,7 @@ int main(int ac, char **av)
         usage(av[0]);
     }
 
-    while ((cc = getopt(ac, av, "1234567bCGgVvF:f:h:n:p:s:u:w:")) != EOF) {
+    while ((cc = getopt(ac, av, "34567bcGgKVvF:f:h:n:p:s:u:w:")) != EOF) {
         switch (cc) {
         case '3':
             vers = "AFPX03";
@@ -1293,14 +1835,14 @@ int main(int ac, char **av)
             Debug = 1;
             break;
 
-        case 'C':
+        case 'K':
             /* Special handling for cache tests - set them directly */
             memset(teststorun, 0, NUMTESTS);
             teststorun[TEST_CACHE_HITS] = 1;
             teststorun[TEST_MIXED_CACHE_OPS] = 1;
             teststorun[TEST_DEEP_TRAVERSAL] = 1;
             teststorun[TEST_CACHE_VALIDATION] = 1;
-            Test = strdup("C");  /* Mark as cache-only mode */
+            Test = strdup("K");  /* Mark as cache-only mode */
 
             if (!Test) {
                 fprintf(stderr, "Memory allocation failed for Test string\n");
@@ -1309,11 +1851,15 @@ int main(int ac, char **av)
 
             break;
 
+        case 'c':
+            csv_output = 1;
+            break;
+
         case 'F':
             bigfilename = strdup(optarg);
 
             if (!bigfilename) {
-                fprintf(stderr, "Memory allocation failed for bigfilename\n");
+                fprintf(stderr, "Memory allocation failed for big filename\n");
                 exit(1);
             }
 
@@ -1348,7 +1894,7 @@ int main(int ac, char **av)
             break;
 
         case 'n':
-            Iterations = atoi(optarg);
+            Iterations = safe_atoi(optarg, "iterations", 1, 256);
 
             if (Iterations <= 0) {
                 fprintf(stderr, "Error: Number of iterations must be positive (got %d)\n",
@@ -1359,7 +1905,7 @@ int main(int ac, char **av)
             break;
 
         case 'p' :
-            Port = atoi(optarg);
+            Port = safe_atoi(optarg, "port", 1, 65535);
 
             if (Port <= 0) {
                 fprintf(stderr, "Bad port.\n");
@@ -1389,12 +1935,12 @@ int main(int ac, char **av)
             break;
 
         case 'V':
-            Quiet = 0;
+            lantest_Quiet = 0;
             Verbose = 1;
             break;
 
         case 'v':
-            Quiet = 0;
+            lantest_Quiet = 0;
             break;
 
         case 'w':
@@ -1417,7 +1963,7 @@ int main(int ac, char **av)
         struct passwd *result = NULL;
         uid_t uid = geteuid();
         char buf[1024];
-        int ret;
+        int32_t ret;
         ret = getpwuid_r(uid, &pwd, buf, sizeof(buf), &result);
 
         if (ret == 0 && result != NULL) {
@@ -1426,7 +1972,7 @@ int main(int ac, char **av)
         }
     }
 
-    if (!Quiet) {
+    if (!lantest_Quiet) {
         fprintf(stdout, "Connecting to host %s:%d\n", Server, Port);
     }
 
@@ -1445,7 +1991,7 @@ int main(int ac, char **av)
         exit(1);
     }
 
-    if (! Debug && freopen("/dev/null", "w", stdout) == NULL) {
+    if (lantest_Quiet && freopen("/dev/null", "w", stdout) == NULL) {
         fprintf(stderr, "Error: Could not redirect stdout to /dev/null\n");
         exit(1);
     }
@@ -1459,19 +2005,20 @@ int main(int ac, char **av)
 
 #endif
     Iterations_save = Iterations;
-    /* Allocate memory for 2D results array: Iterations x NUMTESTS */
-    results = calloc(Iterations, sizeof(unsigned long[NUMTESTS]));
+    /* Allocate memory for 3D results array: Iterations x NUMTESTS x NUM_MEASUREMENTS */
+    results = calloc(Iterations, sizeof(uint64_t[NUMTESTS][NUM_MEASUREMENTS]));
 
     if (!results) {
-        fprintf(stderr, "Memory allocation failed for results array\n");
-        exit(1);
+        fprintf(stderr,
+                "Memory allocation failed for 3D results array (%d iterations)\n",
+                Iterations);
+        clean_exit(ERROR_VALIDATION_TEST);
     }
 
     if (!Test) {
         memset(teststorun, 1, NUMTESTS);
-    } else if (strcmp(Test, "C") == 0) {
-        /* Cache-only mode was already set when parsing -C option */
-        /* No additional processing needed */
+    } else if (strcmp(Test, "K") == 0) {
+        /* Cache-only mode was already set when parsing -K option */
     } else {
         i = 0;
 
@@ -1500,12 +2047,14 @@ int main(int ac, char **av)
         }
     }
 
+    /* Setup Connection structure */
     if ((Conn = (CONN *)calloc(1, sizeof(CONN))) == NULL) {
         fprintf(stderr, "Memory allocation failed for connection structure\n");
         return 1;
     }
 
-    int sock;
+    /* Open socket and setup DSI connection */
+    int32_t sock;
     dsi = &Conn->dsi;
     sock = OpenClientSocket(Server, Port);
 
@@ -1516,7 +2065,7 @@ int main(int ac, char **av)
     dsi->socket = sock;
     Conn->afp_version = Version;
 
-    /* login */
+    /* Login to AFP server and open Vol */
     if (Version >= 30) {
         ExitCode = ntohs(FPopenLoginExt(Conn, vers, uam, User, Password));
     } else {
@@ -1526,34 +2075,68 @@ int main(int ac, char **av)
     vol  = FPOpenVol(Conn, Vol);
 
     if (vol == 0xffff) {
-        test_nottested();
+        fprintf(stderr, "Error: Failed to open volume '%s'\n", Vol);
+        clean_exit(ERROR_VOLUME_OPERATIONS);
     }
 
-    int dir;
+#ifdef __linux__
+    /* IO monitoring setup - only after AFP connection is established */
+    init_io_monitoring(User);
+
+    /* Warn if not localhost - only warn to allow testing with local interface IP for TCP network stack tests */
+    if (strcmp(Server, "localhost") != 0 && strcmp(Server, "127.0.0.1") != 0
+            && strstr(Server, "::") != NULL) {
+        fprintf(stderr,
+                "Warning: IO monitoring only works when afp_lantest is executed on the same host as the Netatalk server.\n"
+                "         Current server: %s (not localhost or 127.0.0.1)\n", Server);
+    }
+
+    fprintf(stdout, "\n");
+#endif /* __linux__ */
+    int32_t dir;
     char testdir[MAXPATHLEN];
     snprintf(testdir, sizeof(testdir), "LanTest-%d", getpid());
 
     if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, "", 0, (1 << DIRPBIT_DID))) {
-        fatal_failed();
+        clean_exit(ERROR_FILE_DIRECTORY_OPS);
     }
 
-    if (is_there(Conn, DIRDID_ROOT, testdir) == AFP_OK) {
-        fatal_failed();
+    /* Delete any existing testdir directory first to avoid conflicts */
+    if (is_there(Conn, vol, DIRDID_ROOT, testdir) == AFP_OK) {
+        if (!lantest_Quiet) {
+            fprintf(stdout, "Found existing test directory '%s', deleting it...\n",
+                    testdir);
+        }
+
+        if (FPDelete(Conn, vol, DIRDID_ROOT, testdir)) {
+            fprintf(stderr, "ERROR: Could not delete existing test directory '%s'\n",
+                    testdir);
+            fprintf(stderr,
+                    "The directory may not be empty. Please manually delete it and try again.\n");
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
+        }
+
+        /* Verify the directory was actually deleted */
+        if (is_there(Conn, vol, DIRDID_ROOT, testdir) == AFP_OK) {
+            fprintf(stderr,
+                    "ERROR: Test directory '%s' still exists after deletion attempt\n", testdir);
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
+        }
     }
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, testdir))) {
-        fatal_failed();
+        clean_exit(ERROR_FILE_DIRECTORY_OPS);
     }
 
     if (FPGetFileDirParams(Conn, vol, dir, "", 0, (1 << DIRPBIT_DID))) {
-        fatal_failed();
+        clean_exit(ERROR_FILE_DIRECTORY_OPS);
     }
 
-    if (is_there(Conn, DIRDID_ROOT, testdir) != AFP_OK) {
-        fatal_failed();
+    if (is_there(Conn, vol, DIRDID_ROOT, testdir) != AFP_OK) {
+        clean_exit(ERROR_FILE_DIRECTORY_OPS);
     }
 
-    for (int current_iteration = 0; current_iteration < Iterations;
+    for (int32_t current_iteration = 0; current_iteration < Iterations;
             current_iteration++) {
         /* Update global iteration counter for addresult() calls */
         iteration_counter = current_iteration;
@@ -1562,20 +2145,12 @@ int main(int ac, char **av)
 
     FPDelete(Conn, vol, dir, "");
 
-    if (ExitCode != AFP_OK && ! Debug) {
-        if (!Debug) {
-            printf("Error, ExitCode: %u. Run with -v to see what went wrong.\n", ExitCode);
-        }
-
-        goto exit;
+    if (ExitCode != AFP_OK && !Debug) {
+        printf("Error, ExitCode: %u. Run with -v or -b to see what went wrong.\n",
+               ExitCode);
+        clean_exit(ExitCode);
     }
 
     displayresults();
-exit:
-
-    if (Conn) {
-        FPLogOut(Conn);
-    }
-
-    return ExitCode;
+    clean_exit(ExitCode);
 }

--- a/test/testsuite/lantest_io_monitor.c
+++ b/test/testsuite/lantest_io_monitor.c
@@ -1,0 +1,687 @@
+/*
+ * Copyright (c) 2025, Andy Lemin (andylemin)
+ * Credits; Based on work by Netatalk contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/*
+ * lantest_io_monitor.c - Linux I/O monitoring for Netatalk performance testing
+ *
+ * Monitors system call I/O statistics for afpd and cnid_dbd processes during tests.
+ * Uses /proc_io filesystem (a secondary mount of proc) to track read/write syscalls.
+ * Automatically discovers target processes by name and user, handling both privilege-dropped
+ * processes (afpd) and root processes with user arguments (cnid_dbd).
+ * Provides before/after test IO metrics to measure actual filesystem activity during AFP operations.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef __linux__
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <pwd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <ctype.h>
+#include <stdint.h>
+
+#include "lantest_io_monitor.h"
+
+#include <limits.h>  /* For PATH_MAX */
+
+/* Global variables for IO monitoring */
+uint8_t io_monitoring_enabled = 0;
+pid_t afpd_pid = 0;
+pid_t cnid_dbd_pid = 0;
+uint64_t afpd_start_reads = 0, afpd_start_writes = 0;
+uint64_t cnid_start_reads = 0, cnid_start_writes = 0;
+uint64_t afpd_end_reads = 0, afpd_end_writes = 0;
+uint64_t cnid_end_reads = 0, cnid_end_writes = 0;
+
+/* Static helper function prototypes */
+static pid_t safe_parse_pid(const char *pidstr);
+static int32_t init_process_filter(ProcessFilter *filter,
+                                   const char *process_name,
+                                   const char *username, int32_t filter_by_cmdline);
+static int32_t check_process_name_match(const char *pid_dir,
+                                        const char *target_name);
+static int32_t check_cmdline_filter(const char *pid_dir, const char *username);
+static int32_t check_uid_filter(const char *pid_dir, uid_t target_uid);
+static int32_t process_proc_entry(const char *pid_dir,
+                                  const ProcessFilter *filter,
+                                  ProcessList *found);
+static void report_multiple_pids(const ProcessFilter *filter,
+                                 const ProcessList *found);
+
+/* Helper: Show warning about /proc_io availability */
+static void show_proc_io_warning(const char *specific_issue)
+{
+    static int32_t warning_shown = 0;
+
+    if (!warning_shown) {
+        fprintf(stderr,
+                "WARNING: %s. IO Monitoring disabled.\n"
+                "To enable IO monitoring, mount proc filesystem at /proc_io. "
+                "Ensure /proc_io mounted with 'gid' matching group of user running afp_lantest.\n"
+                "Eg, as root:\n"
+                "  mkdir -p /proc_io && mount -t proc -o hidepid=0,gid=0 proc /proc_io\n",
+                specific_issue);
+        warning_shown = 1;
+    }
+}
+
+/* Helper: Check if /proc_io is available and show warning if not */
+int32_t check_proc_io_availability(void)
+{
+    struct stat st;
+
+    /* Check if /proc_io exists */
+    if (stat("/proc_io", &st) != 0) {
+        show_proc_io_warning("/proc_io directory not found");
+        io_monitoring_enabled = 0;
+        return 0;
+    }
+
+    /* /proc_io exists, now check if it appears to be properly mounted */
+    DIR *proc_dir = opendir("/proc_io");
+
+    if (!proc_dir) {
+        show_proc_io_warning("Cannot open /proc_io directory");
+        io_monitoring_enabled = 0;
+        return 0;
+    }
+
+    /* Count entries in /proc_io to check if it's properly mounted */
+    struct dirent *entry;
+    int32_t entry_count = 0;
+
+    while ((entry = readdir(proc_dir)) != NULL && entry_count < 5) {
+        /* Skip . and .. */
+        if (strcmp(entry->d_name, ".") != 0 && strcmp(entry->d_name, "..") != 0) {
+            entry_count++;
+        }
+    }
+
+    closedir(proc_dir);
+
+    /* If /proc_io appears to be empty or nearly empty, it's likely not properly mounted */
+    if (entry_count < 3) {
+        char message[256];
+        snprintf(message, sizeof(message),
+                 "/proc_io directory appears to be empty (found %d entries)",
+                 entry_count);
+        show_proc_io_warning(message);
+        io_monitoring_enabled = 0;
+        return 0;
+    }
+
+    return 1;
+}
+
+/* Helper: Initialize process filter configuration */
+static int32_t init_process_filter(ProcessFilter *filter,
+                                   const char *process_name,
+                                   const char *username, int32_t filter_by_cmdline)
+{
+    filter->process_name = process_name;
+    filter->username = username;
+    filter->filter_by_cmdline = filter_by_cmdline;
+
+    if (!filter_by_cmdline) {
+        /* Convert username to UID for ownership-based filtering */
+        struct passwd *pwd = getpwnam(username);
+
+        if (!pwd) {
+            fprintf(stderr, "Error: Unable to find UID for user '%s'\n", username);
+            return -1;
+        }
+
+        filter->target_uid = pwd->pw_uid;
+        fprintf(stdout, "Looking for %s processes owned by user '%s' (UID: %u)\n",
+                process_name, username, filter->target_uid);
+    } else {
+        fprintf(stdout, "Looking for %s processes with -u %s in command line\n",
+                process_name, username);
+    }
+
+    return 0;
+}
+
+/* Helper: Check if process name matches target_name */
+static int32_t check_process_name_match(const char *pid_dir,
+                                        const char *target_name)
+{
+    char comm_path[256];
+    char comm_name[256];
+    FILE *comm_file;
+    snprintf(comm_path, sizeof(comm_path), "/proc_io/%s/comm", pid_dir);
+    comm_file = fopen(comm_path, "r");
+
+    if (!comm_file) {
+        fprintf(stderr, "Could not open %s\n", comm_path);
+        return 0;
+    }
+
+    int32_t matches = 0;
+
+    if (fgets(comm_name, sizeof(comm_name), comm_file)) {
+        comm_name[strcspn(comm_name, "\n")] = '\0';  /* Remove trailing newline */
+        matches = (strcmp(comm_name, target_name) == 0);
+    }
+
+    fclose(comm_file);
+    return matches;
+}
+
+/* Helper: Check if process matches cmdline filter (-u username) */
+static int32_t check_cmdline_filter(const char *pid_dir, const char *username)
+{
+    char cmdline_path[256];
+    char cmdline_buffer[1024];
+    FILE *cmdline_file;
+    snprintf(cmdline_path, sizeof(cmdline_path), "/proc_io/%s/cmdline", pid_dir);
+    cmdline_file = fopen(cmdline_path, "r");
+
+    if (!cmdline_file) {
+        fprintf(stderr, "Could not open %s\n", cmdline_path);
+        return 0;
+    }
+
+    size_t bytes_read = fread(cmdline_buffer, 1, sizeof(cmdline_buffer) - 1,
+                              cmdline_file);
+    cmdline_buffer[bytes_read] = '\0';
+    fclose(cmdline_file);
+
+    if (Debug) {
+        fprintf(stderr, "DEBUG: PID %s cmdline: ", pid_dir);
+
+        for (size_t i = 0; i < bytes_read; i++) {
+            if (cmdline_buffer[i] == '\0') {
+                fprintf(stderr, " ");
+            } else {
+                fprintf(stderr, "%c", cmdline_buffer[i]);
+            }
+        }
+    }
+
+    /* Parse null-separated command line arguments */
+    char *arg = cmdline_buffer;
+    char *end = cmdline_buffer + bytes_read;
+
+    while (arg < end) {
+        if (strcmp(arg, "-u") == 0) {
+            arg += strlen(arg) + 1;  /* Move to next argument */
+
+            if (arg < end && strcmp(arg, username) == 0) {
+                if (Debug) {
+                    fprintf(stderr, "DEBUG: Found matching -u %s in cmdline\n", username);
+                }
+
+                return 1;  /* Found matching -u username */
+            }
+        }
+
+        arg += strlen(arg) + 1;
+    }
+
+    if (Debug) {
+        fprintf(stderr, "DEBUG: No matching -u %s in cmdline\n", username);
+    }
+
+    return 0;
+}
+
+/* Helper: Check if process matches UID filter (ownership) */
+static int32_t check_uid_filter(const char *pid_dir, uid_t target_uid)
+{
+    char status_path[256];
+    char status_line[256];
+    FILE *status_file;
+    snprintf(status_path, sizeof(status_path), "/proc_io/%s/status", pid_dir);
+    status_file = fopen(status_path, "r");
+
+    if (!status_file) {
+        fprintf(stderr, "DEBUG: Failed to open %s\n", status_path);
+        return 0;
+    }
+
+    int32_t matches = 0;
+
+    while (fgets(status_line, sizeof(status_line), status_file)) {
+        if (strncmp(status_line, "Uid:", 4) == 0) {
+            uid_t real_uid, effective_uid;
+
+            if (sscanf(status_line, "Uid:\t%u\t%u", &real_uid, &effective_uid) == 2) {
+                /* Check if either real or effective UID matches */
+                matches = (real_uid == target_uid || effective_uid == target_uid);
+            }
+
+            break;
+        }
+    }
+
+    fclose(status_file);
+    return matches;
+}
+
+/* Helper: Process a single /proc directory entry */
+static int32_t process_proc_entry(const char *pid_dir,
+                                  const ProcessFilter *filter,
+                                  ProcessList *found)
+{
+    /* Skip non-numeric entries (must be PID directories) */
+    if (strspn(pid_dir, "0123456789") != strlen(pid_dir)) {
+        return 0;
+    }
+
+    /* Check if process name matches */
+    if (!check_process_name_match(pid_dir, filter->process_name)) {
+        return 0;
+    }
+
+    /* Apply appropriate filter based on configuration */
+    int32_t process_matches = 0;
+
+    if (filter->filter_by_cmdline) {
+        process_matches = check_cmdline_filter(pid_dir, filter->username);
+    } else {
+        process_matches = check_uid_filter(pid_dir, filter->target_uid);
+    }
+
+    /* Add to found list if matches */
+    if (process_matches && found->count < 10) {
+        pid_t pid = safe_parse_pid(pid_dir);
+
+        if (pid > 0) {
+            found->pids[found->count++] = pid;
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/* Helper: Report multiple PIDs found */
+static void report_multiple_pids(const ProcessFilter *filter,
+                                 const ProcessList *found)
+{
+    if (filter->filter_by_cmdline) {
+        fprintf(stderr, "Warning: Multiple %s processes with -u %s found (",
+                filter->process_name, filter->username);
+    } else {
+        fprintf(stderr, "Warning: Multiple %s processes owned by %s found (",
+                filter->process_name, filter->username);
+    }
+
+    for (int32_t i = 0; i < found->count; i++) {
+        fprintf(stderr, "%d", found->pids[i]);
+
+        if (i < found->count - 1) {
+            fprintf(stderr, ", ");
+        }
+    }
+
+    fprintf(stderr, "), using first: %d\n", found->pids[0]);
+}
+
+/* Main Netatalk process find function for IO monitoring */
+pid_t find_process_pid(const char *process_name, const char *username,
+                       int32_t filter_by_cmdline)
+{
+    /* Check prerequisites */
+    if (!io_monitoring_enabled) {
+        return 0;
+    }
+
+    /* Initialize filter configuration */
+    ProcessFilter filter;
+
+    if (init_process_filter(&filter, process_name, username,
+                            filter_by_cmdline) < 0) {
+        if (Debug) {
+            fprintf(stderr, "DEBUG: Failed to initialize process filter\n");
+        }
+
+        return 0;
+    }
+
+    /* Open /proc_io directory */
+    DIR *proc_dir = opendir("/proc_io");
+
+    if (!proc_dir) {
+        if (Debug) {
+            fprintf(stderr, "DEBUG: Failed to open /proc_io directory (errno: %d)\n",
+                    errno);
+        }
+
+        return 0;
+    }
+
+    /* Scan directory entries and collect matching PIDs */
+    ProcessList found = { .count = 0 };
+    struct dirent *entry;
+    int32_t entries_checked = 0;
+    int32_t total_entries = 0;
+
+    while ((entry = readdir(proc_dir)) != NULL && found.count < 10) {
+        total_entries++;
+
+        /* Only process numeric entries (PID directories) */
+        if (strspn(entry->d_name, "0123456789") == strlen(entry->d_name)) {
+            entries_checked++;
+            process_proc_entry(entry->d_name, &filter, &found);
+        }
+    }
+
+    closedir(proc_dir);
+
+    if (Debug) {
+        fprintf(stderr,
+                "DEBUG: /proc_io scan complete - total entries: %d, numeric PID directories: %d, matches found: %d\n",
+                total_entries, entries_checked, found.count);
+    }
+
+    /* Handle results */
+    if (found.count == 0) {
+        fprintf(stdout, "No matching processes found\n");
+        return 0;
+    }
+
+    if (found.count > 1) {
+        report_multiple_pids(&filter, &found);
+    }
+
+    return found.pids[0];
+}
+
+/* Read IO statistics from /proc_io/<pid>/io file.
+ * syscr: cumulative count of read system calls (read(), pread(), readv(), etc.)
+ * syscw: cumulative count of write system calls (write(), pwrite(), writev(), etc.) */
+static int32_t read_proc_io(pid_t pid, uint64_t *read_ops,
+                            uint64_t *write_ops)
+{
+    FILE *io_file;
+    char io_path[256];
+    char line[256];
+    int32_t found_read = 0, found_write = 0;
+    *read_ops = 0;
+    *write_ops = 0;
+    snprintf(io_path, sizeof(io_path), "/proc_io/%d/io", pid);
+    io_file = fopen(io_path, "r");
+
+    if (!io_file) {
+        fprintf(stderr, "Cannot open %s (errno: %d)\n", io_path, errno);
+        return 0;
+    }
+
+    while (fgets(line, sizeof(line), io_file) && (!found_read || !found_write)) {
+        if (sscanf(line, "syscr: %llu", read_ops) == 1) {
+            found_read = 1;
+        } else if (sscanf(line, "syscw: %llu", write_ops) == 1) {
+            found_write = 1;
+        }
+    }
+
+    fclose(io_file);
+
+    if (Debug) {
+        fprintf(stderr, "DEBUG: IO result (%d) - syscr: %llu, syscw: %llu\n", pid,
+                *read_ops, *write_ops);
+    }
+
+    return (found_read && found_write) ? 0 : -1;
+}
+
+/* Capture IO values - consolidated function for start and stop */
+void capture_io_values(int32_t is_start)
+{
+    if (!io_monitoring_enabled) {
+        return;
+    }
+
+    /* Process afpd_pid */
+    if (afpd_pid > 0) {
+        uint64_t *reads = is_start ? &afpd_start_reads : &afpd_end_reads;
+        uint64_t *writes = is_start ? &afpd_start_writes : &afpd_end_writes;
+
+        if (read_proc_io(afpd_pid, reads, writes) != 0) {
+            *reads = *writes = 0;
+        }
+    }
+
+    /* Process cnid_dbd_pid */
+    if (cnid_dbd_pid > 0) {
+        uint64_t *reads = is_start ? &cnid_start_reads : &cnid_end_reads;
+        uint64_t *writes = is_start ? &cnid_start_writes : &cnid_end_writes;
+
+        if (read_proc_io(cnid_dbd_pid, reads, writes) != 0) {
+            *reads = *writes = 0;
+        }
+    }
+}
+
+/* Get IO delta between stored cumulative counts - consolidated for read and write */
+uint64_t iodiff_io(pid_t pid, int32_t is_write)
+{
+    uint64_t start_val, end_val;
+
+    if (!io_monitoring_enabled || pid == 0) {
+        return 0;  /* Return 0 instead of -1 for unsigned return type */
+    }
+
+    if (pid == afpd_pid) {
+        start_val = is_write ? afpd_start_writes : afpd_start_reads;
+        end_val = is_write ? afpd_end_writes : afpd_end_reads;
+    } else if (pid == cnid_dbd_pid) {
+        start_val = is_write ? cnid_start_writes : cnid_start_reads;
+        end_val = is_write ? cnid_end_writes : cnid_end_reads;
+    } else {
+        return 0;
+    }
+
+    return (end_val > start_val) ? end_val - start_val : 0;
+}
+
+/* Safe PID string parsing helper */
+static pid_t safe_parse_pid(const char *pid_str)
+{
+    char *endptr;
+    long val;
+
+    if (!pid_str || *pid_str == '\0') {
+        return 0;  /* Invalid PID, return 0 to indicate failure */
+    }
+
+    /* PIDs should only contain digits */
+    if (strspn(pid_str, "0123456789") != strlen(pid_str)) {
+        return 0;  /* Invalid PID format */
+    }
+
+    errno = 0;
+    val = strtol(pid_str, &endptr, 10);
+
+    /* Check for conversion errors and valid PID range */
+    /* Use PID_MAX for proper bounds checking instead of INT_MAX */
+    if (errno == ERANGE || *endptr != '\0' || val <= 0 || val > PID_MAX) {
+        return 0;  /* Invalid PID */
+    }
+
+    return (pid_t)val;
+}
+
+/* Initialize IO monitoring by checking proc filesystem and finding required processes */
+void init_io_monitoring(const char *username)
+{
+    /* Check if /proc_io is available */
+    if (!check_proc_io_availability()) {
+        return;
+    }
+
+    fprintf(stdout, "IO monitoring: /proc_io is available\n");
+
+    /* Wait for child processes to be created */
+    if (Debug) {
+        fprintf(stderr,
+                "DEBUG: Waiting for login user child processes to be created...\n");
+    }
+
+    sleep(1);
+    /* Temporarily enable monitoring for process discovery */
+    io_monitoring_enabled = 1;
+    /* First, search for cnid_dbd (optional - doesn't drop privileges) */
+    cnid_dbd_pid = find_process_pid("cnid_dbd", username,
+                                    1);  /* Filter -u argument */
+
+    if (cnid_dbd_pid > 0) {
+        fprintf(stdout, "Found cnid_dbd process: PID %d\n", cnid_dbd_pid);
+    } else {
+        fprintf(stdout, "cnid_dbd not found (optional), continuing...\n");
+        cnid_dbd_pid = 0;  /* Explicitly set to 0 */
+    }
+
+    /* Always search for afpd (mandatory - drops privileges) */
+    int32_t attempts = 0;
+    const int32_t max_attempts = 3;
+
+    while (attempts < max_attempts) {
+        attempts++;
+        afpd_pid = find_process_pid("afpd", username, 0);  /* Filter ownership */
+
+        if (afpd_pid > 0) {
+            break;
+        }
+
+        if (attempts < max_attempts) {
+            sleep(1);
+        }
+    }
+
+    if (afpd_pid <= 0) {
+        fprintf(stderr,
+                "Warning: Could not find privilege-dropped afpd after %d attempts\n",
+                max_attempts);
+    }
+
+    if (afpd_pid > 0) {
+        fprintf(stdout, "Found privilege-dropped afpd process: PID %d\n", afpd_pid);
+    } else {
+        fprintf(stderr, "Error: afpd process not found (mandatory)\n");
+    }
+
+    /* Only check afpd since it's mandatory; cnid_dbd is optional */
+    if (afpd_pid > 0) {
+        /* Test that we can actually read from the processes we found */
+        int32_t afpd_valid = 0, cnid_dbd_valid = 0;
+        uint64_t dummy_read, dummy_write;
+        /* Validate afpd (mandatory) */
+        afpd_valid = (read_proc_io(afpd_pid, &dummy_read, &dummy_write) == 0);
+
+        if (!afpd_valid) {
+            fprintf(stderr, "Error: Cannot read /proc_io/%d/io for afpd\n", afpd_pid);
+            afpd_pid = 0;
+        }
+
+        /* Validate cnid_dbd if found (optional) */
+        if (cnid_dbd_pid > 0) {
+            cnid_dbd_valid = (read_proc_io(cnid_dbd_pid, &dummy_read, &dummy_write) == 0);
+
+            if (!cnid_dbd_valid) {
+                fprintf(stderr, "Warning: Cannot read /proc_io/%d/io for cnid_dbd (optional)\n",
+                        cnid_dbd_pid);
+                cnid_dbd_pid = 0;  /* Set to 0 to skip its monitoring */
+            }
+        }
+
+        /* Keep monitoring enabled only if afpd is valid */
+        if (afpd_pid > 0) {
+            /* afpd found and /proc_io readable - keep monitoring enabled */
+            if (cnid_dbd_pid > 0) {
+                fprintf(stdout, "IO monitoring enabled (afpd: %d, cnid_dbd: %d)\n",
+                        afpd_pid, cnid_dbd_pid);
+            } else {
+                fprintf(stdout, "IO monitoring enabled (afpd: %d, cnid_dbd: not found)\n",
+                        afpd_pid);
+            }
+        } else {
+            /* /proc_io available but cannot read from afpd - disable monitoring */
+            io_monitoring_enabled = 0;
+            fprintf(stderr,
+                    "IO monitoring disabled: cannot read IO statistics for afpd (mandatory)\n");
+        }
+    } else {
+        /* /proc_io available but afpd not found - disable monitoring */
+        io_monitoring_enabled = 0;
+        fprintf(stderr, "IO monitoring disabled: afpd not found (mandatory)\n");
+    }
+}
+
+#else /* !__linux__ */
+
+/* Stub implementations for non-Linux systems */
+
+#include <sys/types.h>
+#include <stdint.h>
+#include "lantest_io_monitor.h"
+
+/* Global variables - stub versions for non-Linux */
+uint8_t io_monitoring_enabled = 0;
+pid_t afpd_pid = 0;
+pid_t cnid_dbd_pid = 0;
+uint64_t afpd_start_reads = 0, afpd_start_writes = 0;
+uint64_t cnid_start_reads = 0, cnid_start_writes = 0;
+uint64_t afpd_end_reads = 0, afpd_end_writes = 0;
+uint64_t cnid_end_reads = 0, cnid_end_writes = 0;
+
+/* Stub function implementations */
+int32_t check_proc_io_availability(void)
+{
+    return 0;  /* IO monitoring not available on non-Linux */
+}
+
+pid_t find_process_pid(const char *process_name, const char *username,
+                       int32_t filter_by_cmdline)
+{
+    (void)process_name;
+    (void)username;
+    (void)filter_by_cmdline;
+    return 0;  /* Process not found */
+}
+
+void capture_io_values(int32_t is_start)
+{
+    (void)is_start;
+    /* No-op on non-Linux */
+}
+
+uint64_t iodiff_io(pid_t pid, int32_t is_write)
+{
+    (void)pid;
+    (void)is_write;
+    return 0;  /* No IO data available */
+}
+
+void init_io_monitoring(const char *username)
+{
+    (void)username;
+    /* IO monitoring is not available on non-Linux systems */
+    io_monitoring_enabled = 0;
+}
+
+#endif /* __linux__ */

--- a/test/testsuite/lantest_io_monitor.h
+++ b/test/testsuite/lantest_io_monitor.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025, Andy Lemin (andylemin)
+ * Credits; Based on work by Netatalk contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifndef LANTEST_IO_MONITOR_H
+#define LANTEST_IO_MONITOR_H
+
+#include <stdint.h>
+#include <sys/types.h>
+
+/* Define PID_MAX if not available from system headers */
+#ifndef PID_MAX
+/* Conservative default maximum PID value */
+#define PID_MAX 99999
+#endif
+
+/* Global Debug flag - controlled by -b option in lantest.c */
+extern uint8_t Debug;
+
+#ifdef __linux__
+
+/* Process filtering configuration for finding Netatalk daemons.
+ * Supports two modes: filter by process UID ownership (for afpd which drops privileges)
+ * or filter by cmdline -u argument (for cnid_dbd which runs as root). */
+typedef struct {
+    const char *process_name;
+    const char *username;
+    int32_t filter_by_cmdline;  /* 0 = filter by UID ownership, 1 = filter by cmdline -u arg */
+    uid_t target_uid;       /* For ownership filtering */
+} ProcessFilter;
+
+/* Container for discovered process IDs during /proc_io scanning.
+ * Stores up to 10 matching PIDs to detect multiple instances.
+ * count=0 means no match, count=1 is ideal, count>1 indicates duplicates. */
+typedef struct {
+    pid_t pids[10];
+    int32_t count;
+} ProcessList;
+
+/* External variables for IO monitoring */
+extern uint8_t io_monitoring_enabled;
+extern pid_t afpd_pid;
+extern pid_t cnid_dbd_pid;
+extern uint64_t afpd_start_reads, afpd_start_writes;
+extern uint64_t cnid_start_reads, cnid_start_writes;
+extern uint64_t afpd_end_reads, afpd_end_writes;
+extern uint64_t cnid_end_reads, cnid_end_writes;
+
+/* Constants for capture_io_values() */
+#define TEST_START 1
+#define TEST_STOP  0
+
+/* Function declarations */
+int32_t check_proc_io_availability(void);
+pid_t find_process_pid(const char *process_name, const char *username,
+                       int32_t filter_by_cmdline);
+void capture_io_values(int32_t is_start);
+uint64_t iodiff_io(pid_t pid, int32_t is_write);
+
+/* Initialization function */
+void init_io_monitoring(const char *username);
+
+#endif /* __linux__ */
+
+#endif /* LANTEST_IO_MONITOR_H */

--- a/test/testsuite/meson.build
+++ b/test/testsuite/meson.build
@@ -38,6 +38,7 @@ executable(
 
 lantest_sources = [
     'lantest.c',
+    'lantest_io_monitor.c',
 ]
 
 executable(

--- a/testsuite_alp.Dockerfile
+++ b/testsuite_alp.Dockerfile
@@ -1,18 +1,4 @@
-#
-# To test using this Dockerfile
-# Build Container Image: docker build -t netatalk-test:latest .
-
-# Init Container and Netatalk: docker run -d --network host --cap-add=NET_ADMIN --volume "<path to local folder>:/mnt/afpshare" --volume "<path to local folder>:/mnt/afpbackup" --env AFP_USER=test --env AFP_PASS=test --env SHARE_NAME='File Sharing' --env AFP_VERSION=7 --env AFP_GROUP=afpusers --env TZ=Europe/London --env INSECURE_AUTH=true --name netatalk-test netatalk-test:latest
-# Read Container Logs: docker logs netatalk-test
-# Run Netatalk Test: docker exec -it netatalk-test /usr/local/bin/afp_lantest -7 -h localhost -p 548 -u test -w test -s "File Sharing" -n 3
-# Stop Container: docker stop netatalk-test
-# Start Container: docker start netatalk-test netatalk-test
-
-# Init Container, Run Test, Shutdown: docker run --rm -it --network host --cap-add=NET_ADMIN --volume "<path to local folder>:/mnt/afpshare" --volume "<path to local folder>:/mnt/afpbackup" --env TESTSUITE=lan --env TEST_FLAGS="-n 2" --env AFP_USER=test --env AFP_PASS=test --env SHARE_NAME='File Sharing' --env AFP_VERSION=7 --env AFP_GROUP=afpusers --env TZ=Europe/London --env INSECURE_AUTH=true --name netatalk-test netatalk-test:latest
-
-# List Containers: docker ps -a
-# Delete Container Instance: docker rm netatalk-test
-# Delete Container Image: docker image rm netatalk-test
+# See https://github.com/Netatalk/netatalk/wiki/Testing for guidance
 
 ARG RUN_DEPS="\
     acl \

--- a/testsuite_deb.Dockerfile
+++ b/testsuite_deb.Dockerfile
@@ -1,3 +1,5 @@
+# See https://github.com/Netatalk/netatalk/wiki/Testing for guidance
+
 ARG RUN_DEPS="\
     ca-certificates \
     cracklib-runtime \


### PR DESCRIPTION
Key Changes:
- Added afp_lantest IO monitoring module to track disk operations for afpd/cnid_dbd processes when run on the same host as Netatalk
- Tracks read/write operations via /proc/[pid]/io during test execution
- Refactored 400+ line displayresults() into 4 functions
- Added TOTAL_AFP_OPS constant (80,686) and AFP operation counts per test
- Added aggregates summary with total/average times and throughput metrics
- Fixed is_there() calls to include volume parameter
- Added comprehensive documentation
- Docker: Added IO_MONITORING env variable and auto-mount of secondary /proc_io mount for systemd distributions
- Build: Added lantest_io_monitor.c to meson.build
- Updated afp_lantest docs and translation

This enables developers to quantify IO impact of AFP operations and validate performance optimizations.
IO monitoring is optional and backward compatible.

Statistics: 7 files changed, +1,392 lines (1,672 insertions, 280 deletions)

```
% docker run -it --rm --privileged --network host --cap-add=NET_ADMIN --volume "/Volumes/case-sensitive/test:/mnt/afpshare" --volume "/Volumes/case-sensitive/test:/mnt/afpbackup" --env IO_MONITORING=1 --env TESTSUITE=lan --env TEST_FLAGS="-n 2" --env AFP_USER=test --env AFP_PASS=test --env AFP_GROUP=test --env SHARE_NAME='File Sharing' --env INSECURE_AUTH=true --name netatalk-test netatalk-test:latest
*** Setting up environment
*** Setting up users and groups
*** Configuring shared volume
*** Fixing permissions
*** Removing residual lock files
*** Configuring Netatalk
NOTE: Set the `ATALKD_INTERFACE' environment variable to start DDP services.
Successfully created /proc_io with hidepid=0,gid=0 for I/O monitoring (gid=0 as TESTSUITE tests run as root)
*** Starting AFP server
*** Running testsuite: lan

+ afp_lantest -n 2 -7 -h 127.0.0.1 -p 548 -u test -w test -s 'File Sharing'
Connecting to host 127.0.0.1:548
IO monitoring: /proc_io is available
Looking for cnid_dbd processes with -u test in command line
Found cnid_dbd process: PID 40
Looking for afpd processes owned by user 'test' (UID: 1000)
Found privilege-dropped afpd process: PID 36
IO monitoring enabled (afpd: 36, cnid_dbd: 40)

Run 1 => Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]        1923 ms
         IO Operations; afpd: 6000 READs, 7002 WRITEs | cnid_dbd: 0 READs, 2 WRITEs
Run 1 => Writing one large file [103 AFP ops]                                  136 ms for 100 MB (avg. 771 MB/s)
         IO Operations; afpd: 0 READs, 299 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 1 => Reading one large file [102 AFP ops]                                   39 ms for 100 MB (avg. 2688 MB/s)
         IO Operations; afpd: 100 READs, 100 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 1 => Locking/Unlocking 10000 times each [20,000 AFP ops]                   799 ms
         IO Operations; afpd: 0 READs, 20000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 1 => Creating dir with 2000 files [4,000 AFP ops]                         4061 ms
         IO Operations; afpd: 2000 READs, 10005 WRITEs | cnid_dbd: 4 READs, 6150 WRITEs
Run 1 => Enumerate dir with 2000 files [~51 AFP ops]                           637 ms
         IO Operations; afpd: 1960 READs, 49 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 1 => Deleting dir with 2000 files [2,000 AFP ops]                         3176 ms
         IO Operations; afpd: 4000 READs, 4004 WRITEs | cnid_dbd: 2 READs, 6104 WRITEs
Run 1 => Create directory tree with 1000 dirs [1,110 AFP ops]                 1885 ms
         IO Operations; afpd: 0 READs, 4445 WRITEs | cnid_dbd: 4 READs, 2351 WRITEs
Run 1 => Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]        3625 ms
         IO Operations; afpd: 10000 READs, 11100 WRITEs | cnid_dbd: 0 READs, 100 WRITEs
Run 1 => Mixed cache operations (create/stat/enum/delete) [820 AFP ops]       1134 ms
         IO Operations; afpd: 820 READs, 1621 WRITEs | cnid_dbd: 0 READs, 1201 WRITEs
Run 1 => Deep path traversal (nested directory navigation) [3,500 AFP ops]     965 ms
         IO Operations; afpd: 2500 READs, 3550 WRITEs | cnid_dbd: 0 READs, 50 WRITEs
Run 1 => Cache validation efficiency (metadata changes) [30,000 AFP ops]      8529 ms
         IO Operations; afpd: 30000 READs, 30100 WRITEs | cnid_dbd: 0 READs, 100 WRITEs
Run 2 => Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]        2453 ms
         IO Operations; afpd: 6000 READs, 7002 WRITEs | cnid_dbd: 0 READs, 2 WRITEs
Run 2 => Writing one large file [103 AFP ops]                                   87 ms for 100 MB (avg. 1205 MB/s)
         IO Operations; afpd: 0 READs, 299 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 2 => Reading one large file [102 AFP ops]                                   36 ms for 100 MB (avg. 2912 MB/s)
         IO Operations; afpd: 100 READs, 100 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 2 => Locking/Unlocking 10000 times each [20,000 AFP ops]                   769 ms
         IO Operations; afpd: 0 READs, 20000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 2 => Creating dir with 2000 files [4,000 AFP ops]                         3442 ms
         IO Operations; afpd: 2000 READs, 10005 WRITEs | cnid_dbd: 7 READs, 6140 WRITEs
Run 2 => Enumerate dir with 2000 files [~51 AFP ops]                           805 ms
         IO Operations; afpd: 1960 READs, 49 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 2 => Deleting dir with 2000 files [2,000 AFP ops]                         2475 ms
         IO Operations; afpd: 4000 READs, 4003 WRITEs | cnid_dbd: 4 READs, 6180 WRITEs
Run 2 => Create directory tree with 1000 dirs [1,110 AFP ops]                 1701 ms
         IO Operations; afpd: 0 READs, 4442 WRITEs | cnid_dbd: 2 READs, 2267 WRITEs
Run 2 => Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]        2962 ms
         IO Operations; afpd: 10000 READs, 11100 WRITEs | cnid_dbd: 0 READs, 100 WRITEs
Run 2 => Mixed cache operations (create/stat/enum/delete) [820 AFP ops]        598 ms
         IO Operations; afpd: 820 READs, 1621 WRITEs | cnid_dbd: 2 READs, 1242 WRITEs
Run 2 => Deep path traversal (nested directory navigation) [3,500 AFP ops]     796 ms
         IO Operations; afpd: 2500 READs, 3550 WRITEs | cnid_dbd: 0 READs, 50 WRITEs
Run 2 => Cache validation efficiency (metadata changes) [30,000 AFP ops]      8431 ms
         IO Operations; afpd: 30000 READs, 30100 WRITEs | cnid_dbd: 0 READs, 100 WRITEs

Netatalk Lantest Results (Averages and standard deviations (±) for all tests, across 2 iterations (default))
============================================================================================================

Test                                                                Time_ms  Time± AFPD_R AFPD_R± AFPD_W AFPD_W± CNID_R CNID_R± CNID_W CNID_W±   MB/s
------------------------------------------------------------------ -------- ------ ------ ------- ------ ------- ------ ------- ------ ------- ------
Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]          2188  374.8   6000     0.0   7002     0.0      0     0.0      2     0.0      0
Writing one large file [103 AFP ops]                                    111   34.7      0     0.0    299     0.0      0     0.0      0     0.0    900
Reading one large file [102 AFP ops]                                     37    2.2    100     0.0    100     0.0      0     0.0      0     0.0   2702
Locking/Unlocking 10000 times each [20,000 AFP ops]                     784   21.2      0     0.0  20000     0.0      0     0.0      0     0.0      0
Creating dir with 2000 files [4,000 AFP ops]                           3751  437.7   2000     0.0  10005     0.0      5     2.2   6145     7.1      0
Enumerate dir with 2000 files [~51 AFP ops]                             721  118.8   1960     0.0     49     0.0      0     0.0      0     0.0      0
Deleting dir with 2000 files [2,000 AFP ops]                           2825  495.7   4000     0.0   4003     1.0      3     1.4   6142    53.7      0
Create directory tree with 1000 dirs [1,110 AFP ops]                   1793  130.1      0     0.0   4443     2.2      3     1.4   2309    59.4      0
Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]          3293  468.8  10000     0.0  11100     0.0      0     0.0    100     0.0      0
Mixed cache operations (create/stat/enum/delete) [820 AFP ops]          866  379.0    820     0.0   1621     0.0      2     0.0   1221    29.0      0
Deep path traversal (nested directory navigation) [3,500 AFP ops]       880  119.5   2500     0.0   3550     0.0      0     0.0     50     0.0      0
Cache validation efficiency (metadata changes) [30,000 AFP ops]        8480   69.3  30000     0.0  30100     0.0      0     0.0    100     0.0      0
------------------------------------------------------------------ -------- ------ ------ ------- ------ ------- ------ ------- ------ ------- ------
Sum of all AFP OPs = 80686                                            25729         57380          92272             13          16069               

Aggregates Summary:
-------------------
Average Time per AFP OP: 0.319 ms
Average AFPD Reads per AFP OP: 0.711
Average AFPD Writes per AFP OP: 1.144
```

Backwards compatibility;
```
% docker run -it --rm --network host --cap-add=NET_ADMIN --volume "/Volumes/case-sensitive/test:/mnt/afpshare" --volume "/Volumes/case-sensitive/test:/mnt/afpbackup" --env TESTSUITE=lan --env TEST_FLAGS="-n 2" --env AFP_USER=test --env AFP_PASS=test --env AFP_GROUP=test --env SHARE_NAME='File Sharing' --env INSECURE_AUTH=true --name netatalk-test netatalk-test:latest 
*** Setting up environment
*** Setting up users and groups
*** Configuring shared volume
*** Fixing permissions
*** Removing residual lock files
*** Configuring Netatalk
NOTE: Set the `ATALKD_INTERFACE' environment variable to start DDP services.
NOTE: TESTSUITE set to 'lan' for afp_lantest test, however IO_MONITORING=1 envvar not set (mounts /proc_io filesystem). IO monitoring disabled.
*** Starting AFP server
*** Running testsuite: lan

+ afp_lantest -n 2 -7 -h 127.0.0.1 -p 548 -u test -w test -s 'File Sharing'
Connecting to host 127.0.0.1:548
WARNING: /proc_io directory not found. IO Monitoring disabled.
To enable IO monitoring, mount proc filesystem at /proc_io. Ensure /proc_io mounted with 'gid' matching group of user running afp_lantest.
Eg, as root:
  mkdir -p /proc_io && mount -t proc -o hidepid=0,gid=0 proc /proc_io

Run 1 => Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]        2116 ms
Run 1 => Writing one large file [103 AFP ops]                                  246 ms for 100 MB (avg. 426 MB/s)
Run 1 => Reading one large file [102 AFP ops]                                   42 ms for 100 MB (avg. 2496 MB/s)
Run 1 => Locking/Unlocking 10000 times each [20,000 AFP ops]                   788 ms
Run 1 => Creating dir with 2000 files [4,000 AFP ops]                         3743 ms
Run 1 => Enumerate dir with 2000 files [~51 AFP ops]                          1097 ms
Run 1 => Deleting dir with 2000 files [2,000 AFP ops]                         2539 ms
Run 1 => Create directory tree with 1000 dirs [1,110 AFP ops]                 1703 ms
Run 1 => Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]        3600 ms
Run 1 => Mixed cache operations (create/stat/enum/delete) [820 AFP ops]        885 ms
Run 1 => Deep path traversal (nested directory navigation) [3,500 AFP ops]    1007 ms
Run 1 => Cache validation efficiency (metadata changes) [30,000 AFP ops]      8556 ms
Run 2 => Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]        2298 ms
Run 2 => Writing one large file [103 AFP ops]                                  101 ms for 100 MB (avg. 1038 MB/s)
Run 2 => Reading one large file [102 AFP ops]                                   41 ms for 100 MB (avg. 2557 MB/s)
Run 2 => Locking/Unlocking 10000 times each [20,000 AFP ops]                   793 ms
Run 2 => Creating dir with 2000 files [4,000 AFP ops]                         3420 ms
Run 2 => Enumerate dir with 2000 files [~51 AFP ops]                           686 ms
Run 2 => Deleting dir with 2000 files [2,000 AFP ops]                         3076 ms
Run 2 => Create directory tree with 1000 dirs [1,110 AFP ops]                 1896 ms
Run 2 => Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]        2992 ms
Run 2 => Mixed cache operations (create/stat/enum/delete) [820 AFP ops]        636 ms
Run 2 => Deep path traversal (nested directory navigation) [3,500 AFP ops]    1048 ms
Run 2 => Cache validation efficiency (metadata changes) [30,000 AFP ops]      8448 ms

Netatalk Lantest Results (Averages and standard deviations (±) for all tests, across 2 iterations (default))
============================================================================================================

Test                                                               Time_ms Time±   MB/s
------------------------------------------------------------------ ------- ------ ------
Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]         2207  128.7      0
Writing one large file [103 AFP ops]                                   173  102.5    578
Reading one large file [102 AFP ops]                                    41    1.0   2439
Locking/Unlocking 10000 times each [20,000 AFP ops]                    790    3.6      0
Creating dir with 2000 files [4,000 AFP ops]                          3581  228.4      0
Enumerate dir with 2000 files [~51 AFP ops]                            891  290.6      0
Deleting dir with 2000 files [2,000 AFP ops]                          2807  379.7      0
Create directory tree with 1000 dirs [1,110 AFP ops]                  1799  136.5      0
Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]         3296  429.9      0
Mixed cache operations (create/stat/enum/delete) [820 AFP ops]         760  176.1      0
Deep path traversal (nested directory navigation) [3,500 AFP ops]     1027   29.0      0
Cache validation efficiency (metadata changes) [30,000 AFP ops]       8502   76.4      0
------------------------------------------------------------------ ------- ------ ------
Sum of all AFP OPs = 80686                                           25874              

Aggregates Summary:
-------------------
Average Time per AFP OP: 0.321 ms
```