### PR TITLE
GitHub CI: Debian Trixie needs the gcc package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,6 +177,7 @@ jobs:
             cracklib-runtime \
             file \
             flex \
+            gcc \
             libacl1-dev \
             libavahi-client-dev \
             libcrack2-dev \


### PR DESCRIPTION
Unlike Bookworm, the latest Debian release doesn't have certain other development packages depend on gcc, so we need to pull it in explicitly