### PR TITLE
macos.netatalk.in: substitute lockfile path

### DIFF
--- a/distrib/initscripts/macos.netatalk.in
+++ b/distrib/initscripts/macos.netatalk.in
@@ -23,7 +23,7 @@ done
 # The start subroutine
 StartService() {
   ConsoleMessage "Starting netatalk fileserver..."
-  rm -f /var/run/netatalk.pid
+  rm -f @lockfile_path@/netatalk.pid
   @sbindir@/netatalk
 }
 
@@ -40,7 +40,7 @@ StopService() {
 # The restart subroutine
 RestartService() {
   StopService
-  rm -f /var/run/netatalk.pid
+  rm -f @lockfile_path@/netatalk.pid
   StartService
 }
 


### PR DESCRIPTION
The lockfile path is adjusted if `with-statedir-path` is set, so this path in `netatalkd` should reflect that. 