### PR TITLE
Fix code quality issues in rtmpqry and disambiguate comments

### DIFF
--- a/etc/papd/file.c
+++ b/etc/papd/file.c
@@ -59,7 +59,7 @@ int markline(struct papfile *pf, char **start, int *linelength, int *crlflength)
     }
 
 #endif
-    /* success, return 1 */
+    /* success */
     return 1;
 }
 

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -539,7 +539,6 @@ int cups_print_job(char *name, const char *filename, char *job, char *username,
     info = cupsCopyDestInfo(CUPS_HTTP_DEFAULT, dest);
 
     if (username != NULL) {
-        /* Add options using cupsAddOption() */
         num_options = cupsAddOption("job-originating-user-name", username, num_options,
                                     &options);
         num_options = cupsAddOption("originating-user-name", username, num_options,

--- a/include/atalk/ldapconfig.h
+++ b/include/atalk/ldapconfig.h
@@ -43,7 +43,7 @@ struct ldap_pref {
     int strorint;
     /* convert to int, but use string to int mapping array pref_array[] */
     int intfromarray;
-    /* -1 = mandatory, 0 = omittable/valid */
+    /* set to -1 if mandatory, 0 if omittable/valid */
     int valid;
     /* copy of 'valid', used when resettting config */
     int valid_save;

--- a/libatalk/cnid/last/cnid_last.c
+++ b/libatalk/cnid/last/cnid_last.c
@@ -124,7 +124,6 @@ static struct _cnid_db *cnid_last_new(struct vol *vol _U_)
     cdb->cnid_delete = cnid_last_delete;
     cdb->cnid_get = cnid_last_get;
     cdb->cnid_lookup = cnid_last_lookup;
-    /* cnid_last_nextid; */
     cdb->cnid_nextid = NULL;
     cdb->cnid_resolve = cnid_last_resolve;
     cdb->cnid_update = cnid_last_update;

--- a/libatalk/unicode/util_unistr.c
+++ b/libatalk/unicode/util_unistr.c
@@ -679,7 +679,7 @@ size_t precompose_w(ucs2_t *name, size_t inplen, ucs2_t *comp, size_t *outlen)
         /* Non-Combination Character */
         if (comb < 0x300) ;
         /* Unicode Standard Annex #15 A10.3 Hangul Composition */
-        /* Step 1 <L,V> */
+        /* Step 1: leading consonant, vowel */
         else if ((VBASE <= comb) && (comb <= VBASE + VCOUNT)) {
             if ((LBASE <= base) && (base < LBASE + LCOUNT)) {
                 result = 1;
@@ -688,7 +688,7 @@ size_t precompose_w(ucs2_t *name, size_t inplen, ucs2_t *comp, size_t *outlen)
                 base = SBASE + (lindex * VCOUNT + vindex) * TCOUNT;
             }
         }
-        /* Step 2 <LV,T> */
+        /* Step 2: leading vowel, trailing consonant */
         else if ((TBASE < comb) && (comb < TBASE + TCOUNT)) {
             if ((SBASE <= base) && (base < SBASE + SCOUNT)
                     && (((base - SBASE) % TCOUNT) == 0)) {

--- a/test/testsuite/afpclient.h
+++ b/test/testsuite/afpclient.h
@@ -123,30 +123,30 @@
 #define FILPBIT_EXTRFLEN 14
 #define FILPBIT_UNIXPR   15
 
-/* attribute bits. (d) = directory attribute bit as well. */
-/* invisible (d) */
+/* attribute bits. d = directory attribute bit as well. */
+/* invisible d */
 #define ATTRBIT_INVISIBLE (1<<0)
 /* multiuser */
 #define ATTRBIT_MULTIUSER (1<<1)
-/* system (d) */
+/* system d */
 #define ATTRBIT_SYSTEM    (1<<2)
 /* data fork already open */
 #define ATTRBIT_DOPEN     (1<<3)
 /* resource fork already open */
 #define ATTRBIT_ROPEN     (1<<4)
-/* shared area (d) */
+/* shared area d */
 #define ATTRBIT_SHARED    (1<<4)
 /* write inhibit(v2)/read-only(v1) bit */
 #define ATTRBIT_NOWRITE   (1<<5)
-/* backup needed (d) */
+/* backup needed d */
 #define ATTRBIT_BACKUP    (1<<6)
-/* rename inhibit (d) */
+/* rename inhibit d */
 #define ATTRBIT_NORENAME  (1<<7)
-/* delete inhibit (d) */
+/* delete inhibit d */
 #define ATTRBIT_NODELETE  (1<<8)
 /* copy protect */
 #define ATTRBIT_NOCOPY    (1<<10)
-/* set/clear bits (d) */
+/* set/clear bits d */
 #define ATTRBIT_SETCLR    (1<<15)
 
 /* ----------------------------- */


### PR DESCRIPTION
rtmqry: touch up a few variables to avoid implicit data type conversion

overall: rephrase and clean up code comments that SonarQube interpreted as commented-out C code