### PR TITLE
test: Consistently initialize buffers before use in afpd component tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,8 @@ jobs:
             rpcsvc-proto-dev \
             sqlite-dev \
             talloc-dev \
-            tinysparql-dev
+            tinysparql-dev \
+            valgrind
       - name: Configure
         run: |
           meson setup build \
@@ -87,6 +88,8 @@ jobs:
         run: meson compile -C build
       - name: Run integration tests
         run: meson test -C build
+      - name: Run memory profiling
+        run: meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
       - name: Install
         run: meson install -C build
       - name: Check netatalk capabilities
@@ -203,7 +206,8 @@ jobs:
             systemtap-sdt-dev \
             tcpd \
             tracker \
-            tracker-miner-fs
+            tracker-miner-fs \
+            valgrind
       - name: Configure
         run: |
           meson setup build \
@@ -220,6 +224,8 @@ jobs:
         run: meson compile -C build
       - name: Run integration tests
         run: meson test -C build
+      - name: Run memory profiling
+        run: meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
       - name: Install
         run: meson install -C build
       - name: Check netatalk capabilities
@@ -272,7 +278,8 @@ jobs:
             sqlite-devel \
             systemd \
             systemtap-sdt-devel \
-            tinysparql-devel
+            tinysparql-devel \
+            valgrind
       - name: Configure
         run: |
           meson setup build \
@@ -287,6 +294,8 @@ jobs:
         run: meson compile -C build
       - name: Run integration tests
         run: meson test -C build
+      - name: Run memory profiling
+        run: meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
       - name: Install
         run: sudo meson install -C build
       - name: Check netatalk capabilities

--- a/test/afpd/afpfunc_helpers.c
+++ b/test/afpd/afpfunc_helpers.c
@@ -91,7 +91,7 @@ static int push_path(char **bufp, const char *name)
 
 char **cnamewrap(const char *name)
 {
-    static char buf[256];
+    static char buf[256] = { 0 };
     static char *p = buf;
     int len = 0;
     PUSHVAL(p, uint8_t, 3, len); /* path type */
@@ -104,8 +104,7 @@ char **cnamewrap(const char *name)
 
 int getfiledirparms(AFPObj *obj, uint16_t vid, cnid_t did, const char *name)
 {
-    const int bufsize = 256;
-    char buf[bufsize];
+    static char buf[256] = { 0 };
     char *p = buf;
     int len = 0;
     ADD(p, len, 2);
@@ -119,8 +118,7 @@ int getfiledirparms(AFPObj *obj, uint16_t vid, cnid_t did, const char *name)
 
 int createdir(AFPObj *obj, uint16_t vid, cnid_t did, const char *name)
 {
-    const int bufsize = 256;
-    char buf[bufsize];
+    static char buf[256] = { 0 };
     char *p = buf;
     int len = 0;
     ADD(p, len, 2);
@@ -132,8 +130,7 @@ int createdir(AFPObj *obj, uint16_t vid, cnid_t did, const char *name)
 
 int createfile(AFPObj *obj, uint16_t vid, cnid_t did, const char *name)
 {
-    const int bufsize = 256;
-    char buf[bufsize];
+    static char buf[256] = { 0 };
     char *p = buf;
     int len = 0;
     PUSHVAL(p, uint16_t, htons(128), len); /* hard create */
@@ -145,8 +142,7 @@ int createfile(AFPObj *obj, uint16_t vid, cnid_t did, const char *name)
 
 int delete (AFPObj *obj, uint16_t vid, cnid_t did, const char *name)
 {
-    const int bufsize = 256;
-    char buf[bufsize];
+    static char buf[256] = { 0 };
     char *p = buf;
     int len = 0;
     PUSHVAL(p, uint16_t, htons(128), len); /* hard create */
@@ -158,8 +154,7 @@ int delete (AFPObj *obj, uint16_t vid, cnid_t did, const char *name)
 
 int enumerate(AFPObj *obj, uint16_t vid, cnid_t did)
 {
-    const int bufsize = 256;
-    char buf[bufsize];
+    static char buf[256] = { 0 };
     char *p = buf;
     int len = 0;
     int ret;
@@ -186,11 +181,9 @@ uint16_t openvol(AFPObj *obj, const char *name)
     int ret;
     uint16_t bitmap;
     uint16_t vid;
-    const int bufsize = 32;
-    char buf[bufsize];
+    static char buf[32] = { 0 };
     char *p = buf;
     char len = strlen(name);
-    memset(p, 0, bufsize);
     p += 2;
     /* bitmap */
     bitmap = htons(1 << VOLPBIT_VID);


### PR DESCRIPTION
Addressing uninitialized memory usage flagged by valgrind

With this fix, you can run the tests successfully in a valgrind wrapper, e.g. through meson:

```
meson setup build -Dwith-tests=true
meson compile -C build
meson test --wrapper='valgrind --leak-check=full --track-origins=yes' -C build
```

when run on Linux with valgrind installed this should give you:

```
ninja: Entering directory `/home/dmark/netatalk/build'
ninja: no work to do.
1/2 afpd integration tests - setup        OK              0.32s
2/2 afpd integration tests - run          OK              6.66s

Ok:                 2   
Expected Fail:      0   
Fail:               0   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0   

Full log written to /home/dmark/netatalk/build/meson-logs/testlog-valgrind.txt
```

And now when this is working, let's run valgrind in select Linux CI jobs!