### PR TITLE
testsuite: afp_lantest - Fixed SonarQube issues

### DIFF
--- a/doc/manpages/man1/afp_lantest.1.md
+++ b/doc/manpages/man1/afp_lantest.1.md
@@ -158,7 +158,8 @@ Run multiple iterations for statistical analysis:
 # Example with IO Monitoring
 
 IO Monitoring (Linux only) requires proc filesystem mounted at /proc_io with hidepid=0.
-Set gid to the group ID of the user running afp_lantest.
+Set *gid* to the group ID of the user running afp_lantest.
+
 For example, to run as root;
 `mkdir -p /proc_io && mount -t proc -o hidepid=0,gid=0 proc /proc_io`
 
@@ -246,7 +247,7 @@ For example, to run as root;
     Average AFPD Reads per AFP OP: 0.711
     Average AFPD Writes per AFP OP: 1.144
 
-## Result Columns
+## IO Monitoring Result Columns
 
     Time(ms) = Test runtime in milliseconds
     Time±    = Test runtime standard deviation
@@ -257,7 +258,10 @@ For example, to run as root;
 
     CNID_*   = IO measurements for the cnid_dbd process (optional)
 
-## Aggregates Summary
+Note; When performance testing with afp_lantest, ensure the afp.conf `log level` is set to `default:severe`.
+Anything more verbose and the counted AFPD_W IO values may include the log writes.
+
+## IO Monitoring Aggregates Summary
 
 The aggregate values are purely Intrinsic Metrics, as AFP operations are a mixture of reads, writes,
 and connection related operations.

--- a/test/testsuite/lantest_io_monitor.h
+++ b/test/testsuite/lantest_io_monitor.h
@@ -16,6 +16,7 @@
 #ifndef LANTEST_IO_MONITOR_H
 #define LANTEST_IO_MONITOR_H
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
 
@@ -26,7 +27,7 @@
 #endif
 
 /* Global Debug flag - controlled by -b option in lantest.c */
-extern uint8_t Debug;
+extern bool Debug;
 
 #ifdef __linux__
 
@@ -49,7 +50,7 @@ typedef struct {
 } ProcessList;
 
 /* External variables for IO monitoring */
-extern uint8_t io_monitoring_enabled;
+extern bool io_monitoring_enabled;
 extern pid_t afpd_pid;
 extern pid_t cnid_dbd_pid;
 extern uint64_t afpd_start_reads, afpd_start_writes;


### PR DESCRIPTION
No changes to afp_lantest other than resolving SonarQube issues and C99 standards

Testing ok
```
+ afp_lantest -n 2 -7 -h 127.0.0.1 -p 548 -u test -w test -s 'File Sharing'
Connecting to host 127.0.0.1:548
IO monitoring: /proc_io is available
Looking for cnid_dbd processes with -u test in command line
Found cnid_dbd process: PID 40
Looking for afpd processes owned by user 'test' (UID: 1000)
Found privilege-dropped afpd process: PID 36
IO monitoring enabled (afpd: 36, cnid_dbd: 40)

Run 1 => Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]        2509 ms
         IO Operations; afpd: 6000 READs, 7004 WRITEs | cnid_dbd: 0 READs, 4 WRITEs
Run 1 => Writing one large file [103 AFP ops]                                  232 ms for 100 MB (avg. 451 MB/s)
         IO Operations; afpd: 0 READs, 299 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 1 => Reading one large file [102 AFP ops]                                   45 ms for 100 MB (avg. 2330 MB/s)
         IO Operations; afpd: 102 READs, 102 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 1 => Locking/Unlocking 10000 times each [20,000 AFP ops]                   855 ms
         IO Operations; afpd: 0 READs, 20000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 1 => Creating dir with 2000 files [4,000 AFP ops]                         3298 ms
         IO Operations; afpd: 2000 READs, 10004 WRITEs | cnid_dbd: 4 READs, 6147 WRITEs
Run 1 => Enumerate dir with 2000 files [~51 AFP ops]                           709 ms
         IO Operations; afpd: 1960 READs, 49 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 1 => Deleting dir with 2000 files [2,000 AFP ops]                         2338 ms
         IO Operations; afpd: 4000 READs, 4003 WRITEs | cnid_dbd: 2 READs, 6102 WRITEs
Run 1 => Create directory tree with 1000 dirs [1,110 AFP ops]                 1571 ms
         IO Operations; afpd: 0 READs, 4445 WRITEs | cnid_dbd: 4 READs, 2349 WRITEs
Run 1 => Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]        2963 ms
         IO Operations; afpd: 10000 READs, 11100 WRITEs | cnid_dbd: 0 READs, 100 WRITEs
Run 1 => Mixed cache operations (create/stat/enum/delete) [820 AFP ops]        564 ms
         IO Operations; afpd: 820 READs, 1620 WRITEs | cnid_dbd: 0 READs, 1200 WRITEs
Run 1 => Deep path traversal (nested directory navigation) [3,500 AFP ops]     852 ms
         IO Operations; afpd: 2500 READs, 3550 WRITEs | cnid_dbd: 0 READs, 50 WRITEs
Run 1 => Cache validation efficiency (metadata changes) [30,000 AFP ops]      8523 ms
         IO Operations; afpd: 30000 READs, 30100 WRITEs | cnid_dbd: 0 READs, 100 WRITEs
Run 2 => Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]        2190 ms
         IO Operations; afpd: 6000 READs, 7003 WRITEs | cnid_dbd: 0 READs, 3 WRITEs
Run 2 => Writing one large file [103 AFP ops]                                  107 ms for 100 MB (avg. 979 MB/s)
         IO Operations; afpd: 0 READs, 299 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 2 => Reading one large file [102 AFP ops]                                   35 ms for 100 MB (avg. 2995 MB/s)
         IO Operations; afpd: 100 READs, 100 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 2 => Locking/Unlocking 10000 times each [20,000 AFP ops]                   790 ms
         IO Operations; afpd: 0 READs, 20000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 2 => Creating dir with 2000 files [4,000 AFP ops]                         3674 ms
         IO Operations; afpd: 2000 READs, 10005 WRITEs | cnid_dbd: 7 READs, 6138 WRITEs
Run 2 => Enumerate dir with 2000 files [~51 AFP ops]                           917 ms
         IO Operations; afpd: 1960 READs, 49 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
Run 2 => Deleting dir with 2000 files [2,000 AFP ops]                         2610 ms
         IO Operations; afpd: 4000 READs, 4003 WRITEs | cnid_dbd: 4 READs, 6178 WRITEs
Run 2 => Create directory tree with 1000 dirs [1,110 AFP ops]                 1609 ms
         IO Operations; afpd: 0 READs, 4445 WRITEs | cnid_dbd: 2 READs, 2269 WRITEs
Run 2 => Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]        2905 ms
         IO Operations; afpd: 10000 READs, 11100 WRITEs | cnid_dbd: 0 READs, 100 WRITEs
Run 2 => Mixed cache operations (create/stat/enum/delete) [820 AFP ops]        683 ms
         IO Operations; afpd: 820 READs, 1621 WRITEs | cnid_dbd: 2 READs, 1241 WRITEs
Run 2 => Deep path traversal (nested directory navigation) [3,500 AFP ops]     876 ms
         IO Operations; afpd: 2500 READs, 3550 WRITEs | cnid_dbd: 0 READs, 50 WRITEs
Run 2 => Cache validation efficiency (metadata changes) [30,000 AFP ops]      8493 ms
         IO Operations; afpd: 30000 READs, 30100 WRITEs | cnid_dbd: 0 READs, 100 WRITEs

Netatalk Lantest Results (Averages and standard deviations (±) for all tests, across 2 iterations (default))
============================================================================================================

Test                                                                Time_ms  Time± AFPD_R AFPD_R± AFPD_W AFPD_W± CNID_R CNID_R± CNID_W CNID_W±   MB/s
------------------------------------------------------------------ -------- ------ ------ ------- ------ ------- ------ ------- ------ ------- ------
Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]          2349  225.6   6000     0.0   7003     1.0      0     0.0      3     1.0      0
Writing one large file [103 AFP ops]                                    169   88.4      0     0.0    299     0.0      0     0.0      0     0.0    591
Reading one large file [102 AFP ops]                                     40    7.1    101     1.4    101     1.4      0     0.0      0     0.0   2500
Locking/Unlocking 10000 times each [20,000 AFP ops]                     822   46.0      0     0.0  20000     0.0      0     0.0      0     0.0      0
Creating dir with 2000 files [4,000 AFP ops]                           3486  265.9   2000     0.0  10004     1.0      5     2.2   6142     6.4      0
Enumerate dir with 2000 files [~51 AFP ops]                             813  147.1   1960     0.0     49     0.0      0     0.0      0     0.0      0
Deleting dir with 2000 files [2,000 AFP ops]                           2474  192.3   4000     0.0   4003     0.0      3     1.4   6140    53.7      0
Create directory tree with 1000 dirs [1,110 AFP ops]                   1590   26.9      0     0.0   4445     0.0      3     1.4   2309    56.6      0
Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]          2934   41.0  10000     0.0  11100     0.0      0     0.0    100     0.0      0
Mixed cache operations (create/stat/enum/delete) [820 AFP ops]          623   84.1    820     0.0   1620     1.0      2     0.0   1220    29.0      0
Deep path traversal (nested directory navigation) [3,500 AFP ops]       864   17.0   2500     0.0   3550     0.0      0     0.0     50     0.0      0
Cache validation efficiency (metadata changes) [30,000 AFP ops]        8508   21.2  30000     0.0  30100     0.0      0     0.0    100     0.0      0
------------------------------------------------------------------ -------- ------ ------ ------- ------ ------- ------ ------- ------ ------- ------
Sum of all AFP OPs = 80686                                            24672         57381          92274             13          16064

Aggregates Summary:
-------------------
Average Time per AFP OP: 0.306 ms
Average AFPD Reads per AFP OP: 0.711
Average AFPD Writes per AFP OP: 1.144
Aggregate values are purely Intrinsic Metrics, as AFP operations are a mixture of reads, writes, and connection related operations.
See afp_lantest manpage for more information: https://netatalk.io/manual/en/afp_lantest.1
```