### PR TITLE
netddp: remove macros, define interface for netddp_{close, recvfrom, sendto}

### DIFF
--- a/include/atalk/netddp.h
+++ b/include/atalk/netddp.h
@@ -15,16 +15,29 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <unistd.h>
+
 #include <netatalk/at.h>
 
 extern int netddp_open(struct sockaddr_at *, struct sockaddr_at *);
 
-#include <unistd.h>
-#include <sys/types.h>
+static inline int netddp_close(int filedes)
+{
+    return close(filedes);
+}
 
-#define netddp_close(a)  close(a)
-#define netddp_sendto    sendto
-#define netddp_recvfrom  recvfrom
+static inline ssize_t netddp_sendto(int s, const void *msg, size_t len,
+                                    int flags, const struct sockaddr *to, socklen_t tolen)
+{
+    return sendto(s, msg, len, flags, to, tolen);
+}
+
+static inline ssize_t netddp_recvfrom(int s, void *buf, size_t len,
+                                      int flags, struct sockaddr *from,
+                                      socklen_t *fromlen)
+{
+    return recvfrom(s, buf, len, flags, from, fromlen);
+}
 
 #endif  /* NO_DDP */
 #endif /* netddp.h */


### PR DESCRIPTION
At present, netddp_close, netddp_recvfrom and netddp_sendto are just macros which fob off responsibility for their prototypes to the prototypes of their underlying functions defined in unistd.h.  In the interests of better typechecking and removing a barrier to using netddp as an actually useful abstraction boundary again, this PR replaces the macros with stub inline functions (which boils down to the same thing).  The prototypes chosen are those mandated by POSIX for the underlying socket calls, which seems the sensible option, except that I've removed 'restrict' at the insistance of sonarqube.