### PR TITLE
testsuite: Resolve the last handful of code quality issues in lantest

### DIFF
--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -593,7 +593,6 @@ static void result_print_summary(uint64_t
 
 static void displayresults(void)
 {
-    uint64_t sum;
     uint64_t max, min;
 
     /* Eliminate runaways for all measurement types */
@@ -861,7 +860,6 @@ void run_test(const int32_t dir)
     static char *data;
     int32_t maxi = 0;
     uint16_t fork;
-    off_t offset;
     struct async_io_req air;
     static char temp[MAXPATHLEN];
     numrw = rwsize / (dsi->server_quantum - FPWRITE_RQST_SIZE);
@@ -1753,7 +1751,6 @@ fin1:
 /* =============================== */
 void usage(char *av0)
 {
-    int32_t i = 0;
     fprintf(stdout,
             "usage:\t%s [-34567bcGgKVv] [-h host] [-p port] [-s vol] [-u user] [-w password] "
             "[-n iterations] [-f tests] [-F bigfile]\n", av0);

--- a/test/testsuite/lantest_io_monitor.c
+++ b/test/testsuite/lantest_io_monitor.c
@@ -199,10 +199,11 @@ static int32_t check_process_name_match(const char *pid_dir,
     int32_t matches = 0;
 
     if (fgets(comm_name, sizeof(comm_name), comm_file)) {
+        comm_name[COMM_BUFFER_SIZE - 1] = '\0';
         /* Safely remove trailing newline with bounds checking */
         size_t newline_pos = strcspn(comm_name, "\n");
 
-        if (newline_pos < sizeof(comm_name)) {
+        if (newline_pos < COMM_BUFFER_SIZE - 1) {
             comm_name[newline_pos] = '\0';
         }
 

--- a/test/testsuite/lantest_io_monitor.c
+++ b/test/testsuite/lantest_io_monitor.c
@@ -123,7 +123,7 @@ int32_t check_proc_io_availability(void)
     /* Count entries in /proc_io to check if it's properly mounted */
     /* Note: readdir() returns non-const pointer per POSIX standard */
     /* NOSONAR: False positive - API requires non-const pointer */
-    struct dirent *entry;
+    struct dirent *entry; //NOSONAR
     int32_t entry_count = 0;
 
     while ((entry = readdir(proc_dir)) != NULL && entry_count < 5) {
@@ -401,7 +401,7 @@ pid_t find_process_pid(const char *process_name, const char *username,
     ProcessList found = { .count = 0 };
     /* Note: readdir() returns non-const pointer per POSIX standard */
     /* NOSONAR: False positive - API requires non-const pointer */
-    struct dirent *entry;
+    struct dirent *entry; //NOSONAR
     int32_t entries_checked = 0;
     int32_t total_entries = 0;
 


### PR DESCRIPTION
- Remove a handful of declared but unused variables in lantest
- Use the NOSONAR syntax that SonarQube expects to skip analysis
- Extra protection against buffer overflow in check_process_name_match()