### PR TITLE
GitHub CI: Pin CI build base images, and split out distribution tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     container:
-      image: alpine:latest
+      image: alpine:3.22.1
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install dependencies
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     container:
-      image: archlinux:latest
+      image: archlinux:base-devel-20250824.0.410029
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install dependencies
@@ -167,7 +167,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     container:
-      image: debian:latest
+      image: debian:13.0
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install dependencies
@@ -245,7 +245,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     container:
-      image: fedora:latest
+      image: fedora:42
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,17 +314,21 @@ jobs:
     name: Ubuntu Linux
     runs-on: ubuntu-latest
     timeout-minutes: 12
+    container:
+      image: ubuntu:25.10
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install --assume-yes --no-install-recommends \
+          apt-get update
+          apt-get install --assume-yes --no-install-recommends \
             bison \
+            ca-certificates \
             cmark-gfm \
             cracklib-runtime \
             file \
             flex \
+            gcc \
             libacl1-dev \
             libavahi-client-dev \
             libcrack2-dev \
@@ -362,10 +366,10 @@ jobs:
             -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
-      - name: Run distribution tests
-        run: meson dist -C build
+      - name: Run integration tests
+        run: meson test -C build
       - name: Install
-        run: sudo meson install -C build
+        run: meson install -C build
       - name: Check netatalk capabilities
         run: |
           netatalk -V
@@ -375,15 +379,8 @@ jobs:
           macipgw -V
           papd -V
           timelord -V
-      - name: Start netatalk
-        run: |
-          sudo systemctl start netatalk
-          sleep 1
-          asip-status localhost
-      - name: Stop netatalk
-        run: sudo systemctl stop netatalk
       - name: Uninstall
-        run: sudo ninja -C build uninstall
+        run: ninja -C build uninstall
 
   build-macos:
     name: macOS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,3 +60,27 @@ jobs:
       - uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e
         with:
           globs: '**/*.md'
+
+  distribution-tests:
+    name: Distribution Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --assume-yes --no-install-recommends \
+            libevent-dev \
+            libgcrypt20-dev \
+            libiniparser-dev \
+            meson \
+            ninja-build
+      - name: Configure
+        run: |
+          meson setup build \
+            -Dbuildtype=release \
+            -Dwith-init-hooks=false \
+            -Dwith-tests=true
+      - name: Run distribution tests
+        run: meson dist -C build


### PR DESCRIPTION
Pin all builds to the latest stable Linux distro image version tag, for extra protection against supply chain attacks

Transition the Ubuntu Build job to use the latest stable Ubuntu image rather than the raw GitHub runner, and split out the dist check step