### PR TITLE
GitHub CI: Refactor the SonarQube scan action with supported GitHub expressions

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -77,4 +77,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
-          args: "--define sonar.cfamily.compile-commands=\"${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json\" \n"
+          args: --define sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json


### PR DESCRIPTION


Addressing a new mandatory syntax introduced with v5.3.1 of the SonarQube scan action