### PR TITLE
meson.build: check for init bins only if installing service

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1897,7 +1897,7 @@ if 'auto' in init_style
     endif
 endif
 
-if init_cmd != ''
+if init_cmd != '' and get_option('with-init-hooks')
     init_program = find_program(init_cmd, required: not init_style_auto)
     if not init_program.found()
         warning(init_cmd + ' not found, defaulting to no init scripts')


### PR DESCRIPTION
The block preventing init script creation if the associated binaries aren't found (added in https://github.com/Netatalk/netatalk/pull/1747) can be skipped if configuration of the service is being skipped via `--with-init-hooks` being false. This allows e.g. Homebrew bottles to have the init scripts included when built (https://github.com/Homebrew/homebrew-core/pull/235533). 