### PR TITLE
afpd: Revert to non-reentrant getpwnam() in the uam module

### DIFF
--- a/etc/afpd/uam.c
+++ b/etc/afpd/uam.c
@@ -218,7 +218,6 @@ struct passwd *uam_getname(void *private, char *name, const int len)
 {
     AFPObj *obj = private;
     struct passwd *pwent = NULL;
-    struct passwd pwent_buf;
     static char username[256];
     static char user[256];
     static char pwname[256];
@@ -226,28 +225,15 @@ struct passwd *uam_getname(void *private, char *name, const int len)
     size_t namelen;
     size_t gecoslen = 0;
     size_t pwnamelen = 0;
-    long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
-
-    if (bufsize == -1) {
-        bufsize = 16384;
-    }
-
-    char *buffer = malloc(bufsize);
-
-    if (buffer == NULL) {
-        free(buffer);
-        return NULL;
-    }
-
+    /* Should ideally be using reentrant getpwnam functions, but would require
+       a broader rework of the uam interface. */
 #ifdef HAVE_GETPWNAM_SHADOW
-
-    if (pwent = getpwnam_shadow(name)) {
+    pwent = getpwnam_shadow(name);
 #else
-
-    if (getpwnam_r(name, &pwent_buf, buffer, sizeof(buffer), &pwent) == 0
-            && pwent != NULL) {
-        free(buffer);
+    pwent = getpwnam(name);
 #endif
+
+    if (pwent) {
         return pwent;
     }
 
@@ -265,7 +251,7 @@ struct passwd *uam_getname(void *private, char *name, const int len)
 
         if (bdata(princ) != NULL) {
             const char *bdatum = bdata(princ);
-            getpwnam_r(bdatum, &pwent_buf, buffer, sizeof(buffer), &pwent);
+            pwent = getpwnam(bdatum);
         }
 
         bdestroy(princ);
@@ -280,12 +266,10 @@ struct passwd *uam_getname(void *private, char *name, const int len)
                     MAXUSERLEN);
             }
 
-            free(buffer);
             return pwent;
         }
     }
 
-    free(buffer);
     namelen = convert_string((utf8_encoding(obj)) ? CH_UTF8_MAC :
                              obj->options.maccharset,
                              CH_UCS2, name, -1, username, sizeof(username));


### PR DESCRIPTION
Since afpd isn't a threading application, there is no pressing need to use the reentrant-safe way to fetch the passwd entry in uam_getname()

The reverted solution had flaws that led to a critical failure when attempting to authenticate in a complex ActiveDirectory environment