### PR TITLE
[4.2] GitHub CI: Bring build jobs up to date and secure them

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     container:
-      image: alpine:latest
+      image: alpine:3.22.1
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     container:
-      image: archlinux:latest
+      image: archlinux:base-devel-20250824.0.410029
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     container:
-      image: debian:latest
+      image: debian:13.0
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 12
     container:
-      image: fedora:latest
+      image: fedora:42
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,7 @@ jobs:
             cracklib-runtime \
             file \
             flex \
+            gcc \
             libacl1-dev \
             libavahi-client-dev \
             libcrack2-dev \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -643,8 +643,8 @@ jobs:
             pkg install \
               build-essential \
               pkg-config
-            curl -O https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-trunk-x86_64-20240116.tar.gz
-            tar -zxpf bootstrap-trunk-x86_64-20240116.tar.gz -C /
+            curl -o bootstrap.tar.gz https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-2024Q4-x86_64.tar.gz
+            tar -zxpf bootstrap.tar.gz -C /
             export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
             pkgin -y install \
               avahi \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -429,7 +429,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/dragonflybsd-vm@v1
+        uses: vmactions/dragonflybsd-vm@ff1f01c32b9e82f2ba388d0ff270442bcd6ceddc # v1.1.1
         with:
           copyback: false
           usesh: true
@@ -475,7 +475,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/freebsd-vm@v1
+        uses: vmactions/freebsd-vm@05856381fab64eeee9b038a0818f6cec649ca17a # v1.2.3
         with:
           copyback: false
           prepare: |
@@ -525,7 +525,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/netbsd-vm@v1
+        uses: vmactions/netbsd-vm@d0228be27fbaba19418cc1b332609a895cf16561 # v1.1.9
         with:
           copyback: false
           prepare: |
@@ -583,7 +583,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/openbsd-vm@v1
+        uses: vmactions/openbsd-vm@1e7cc4fa7727646d3cf5921289b1f5c9d1a88f3c # v1.2.0
         with:
           copyback: false
           prepare: |
@@ -637,7 +637,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/omnios-vm@v1
+        uses: vmactions/omnios-vm@c31844c7abe722cd7c97df82cab1f1fab1e5339f # v1.1.1
         with:
           copyback: false
           prepare: |
@@ -690,7 +690,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Build on VM
-        uses: vmactions/solaris-vm@v1
+        uses: vmactions/solaris-vm@58cbd70c6e051860f9b8f65908cc582938fbbdba # v1.1.5
         with:
           copyback: false
           prepare: |


### PR DESCRIPTION
Debian Trixie needs the gcc package, and bump OmniOS bootstrap

Use specific release hashes for docker images and vmactions actions