### PR TITLE
Bump to bstring 1.0.2 subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -659,9 +659,7 @@ int main() {
 '''
 
 has_bgets = cc.compiles(bgets_test_code, name: 'bgets defined in standard C library')
-
-cdata.set('HAVE_LIBGEN_H_BGETS', has_bgets)
-
+cdata.set('HAVE_BGETS', has_bgets)
 bstring = dependency('bstring', required: false)
 
 if not bstring.found()

--- a/meson_config.h
+++ b/meson_config.h
@@ -199,8 +199,8 @@
 /* Define to 1 if you have the `lgetxattr' function. */
 #mesondefine HAVE_LGETXATTR
 
-/* define if libgen.h has the `bgets` function. */
-#mesondefine HAVE_LIBGEN_H_BGETS
+/* define if you have the `bgets` function. */
+#mesondefine HAVE_BGETS
 
 /* define if you have libquota */
 #mesondefine HAVE_LIBQUOTA

--- a/subprojects/bstring.wrap
+++ b/subprojects/bstring.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
-directory = bstring-1.0.1
-source_url = https://github.com/msteinert/bstring/releases/download/v1.0.1/bstring-1.0.1.tar.xz
-source_filename = bstring-1.0.1.tar.xz
-source_hash = a86b6b30f4ad2496784cc7f53eb449c994178b516935384c6707f381b9fe6056
+directory = bstring-1.0.2
+source_url = https://github.com/msteinert/bstring/releases/download/v1.0.2/bstring-1.0.2.tar.xz
+source_filename = bstring-1.0.2.tar.xz
+source_hash = 9d2d207385edeb39935c53f55da57501936b67939998f3e5c5ae91cb8063fbd0
 
 [provide]
 bstring = bstring_dep


### PR DESCRIPTION
The upstream project has released a new version with release notes:

- The build system, including parity between autotools & meson
- Quality indicators and cleanups (expanded CI, SonarCube)

https://github.com/msteinert/bstring/releases/tag/v1.0.2