### PR TITLE
GitHub CI: Install shared bstring library on macOS build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -395,6 +395,7 @@ jobs:
         run: |
           brew update
           brew install \
+            bstring \
             cmark-gfm \
             cracklib \
             iniparser \


### PR DESCRIPTION
The bstring library has started getting distributed as shared library package in Homebrew