### PR TITLE
ad: make buffer size detection more portable in ad cp

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -256,6 +256,7 @@ check_headers = [
     'sys/extattr.h',
     'sys/mnttab.h',
     'sys/mount.h',
+    'sys/sysinfo.h',
     'sys/vfs.h',
     'sys/xattr.h',
     'ufs/quota.h',

--- a/meson_config.h
+++ b/meson_config.h
@@ -319,6 +319,9 @@
 /* Define to 1 if you have the <sys/mount.h> header file. */
 #mesondefine HAVE_SYS_MOUNT_H
 
+/* Define to 1 if you have the <sys/sysinfo.h> header file. */
+#mesondefine HAVE_SYS_SYSINFO_H
+
 /* Define to 1 if you have the <sys/vfs.h> header file. */
 #mesondefine HAVE_SYS_VFS_H
 


### PR DESCRIPTION
Replace _SC_PHYS_PAGES with more portable alternatives:
- Use _SC_PAGESIZE with getpagesize() fallback
- Add sysinfo() support for Linux systems
- Handle numeric overflow cases
- Maintain existing buffer size limits
- Keep fallback to small buffer size

This improves portability across different UNIX variants while preserving the performance benefits of larger buffers on systems with more memory.

The previous logic assumed that _SC_PHYS_PAGES is always defined, which is not the case on f.e. macOS 10.10 Yosemite and earlier