### PR TITLE
meson: Explicitly enable the _XPG6 flag for Solaris builds

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2100,6 +2100,7 @@ elif host_os == 'sunos'
     cdata.set('__svr4__', 1)
     cdata.set('_ISOC9X_SOURCE', 1)
     cdata.set('_XOPEN_SOURCE', 600)
+    cdata.set('_XPG6', 1)
     cdata.set('SOLARIS', 1)
 elif host_os == 'darwin'
     cdata.set('HAVE_BROKEN_DBTOB', 1)


### PR DESCRIPTION
Everything points to _XPG6 being enabled by default when building on Solaris and Solaris-likes, but let's explicitly enable it to get consistently POSIX compatible prototypes