### PR TITLE
getzones: defensively release memory in optarg function

### DIFF
--- a/bin/getzones/getzones.c
+++ b/bin/getzones/getzones.c
@@ -116,6 +116,10 @@ int main(int argc, char *argv[])
                 ++errflg;
             }
 
+            if (requested_zone != NULL) {
+                free(requested_zone);
+            }
+
             requested_zone = strdup(optarg);
             lookup_type = ZIPOP_GNI;
             break;


### PR DESCRIPTION
Should prevent a theoretical memory leak condition flagged by SonarQube