### PR TITLE
Consider the sqlite CNID backend stable

### DIFF
--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -1080,25 +1080,19 @@ cnid scheme = *backend* **(V)**
 Run **afpd -v** to see a list of available backends,
 as well as which one is the default.
 >
-> *dbd* is a zero-configuration, full-featured, and reliable backend
-using Berkeley DB, where database access is managed through
-the **cnid_dbd** daemon.
+> *dbd* uses Berkeley DB, with database reads and writes managed through the **cnid_dbd** daemon.
+It is recommended for most deployments.
 >
-> The *last* backend uses a read-only, in-memory Trivial Database.
-It can be used to mount CD-ROMs and similar read-only media, for instance.
+> The *sqlite* backend uses the SQLite embedded database library.
+It is performant and lean, requiring no external database or daemon.
 >
 > The *mysql* backend requires that a MySQL (or MariaDB) database instance
 has been provisioned for use with Netatalk.
 The upside is that you get full control over how the CNID data is stored,
 which makes for a robust and scalable solution.
 >
-> The EXPERIMENTAL *sqlite* backend is a zero-configuration backend
-that uses the SQLite library. It is performant and lean, requiring
-no external database or daemon.
->
-> ***WARNING:*** The *sqlite* backend should only be used for testing purposes
-and not in a production setting.
-Please take a backup of your data before enabling this backend.
+> The *last* backend uses a read-only, in-memory Trivial Database.
+It can be used to mount CD-ROMs and similar read-only media, for instance.
 
 ea = *sys* | *samba* | *ad* | *none* (default: auto detect) **(V)**
 

--- a/doc/manual/Configuration.md
+++ b/doc/manual/Configuration.md
@@ -143,15 +143,10 @@ controlled by the **cnid_metad** daemon.
 
 This is the most reliable and proven backend for daily use.
 
-### last
+### sqlite
 
-The last backend is an in-memory Trivial Database (tdb). It is not persistent,
-with IDs valid only for the current session. Starting with netatalk 3.0,
-it operates in *read only mode*. This backend is useful e.g. for
-mounting CD-ROMs, or for automated testing.
-
-This is basically equivalent to how **afpd** stored CNID data in netatalk
-1.5 and earlier.
+A performant and lean CNID database backend that uses the SQLite v3
+embedded database engine.
 
 ### mysql
 
@@ -161,13 +156,15 @@ to connect to it over the network.
 
 See **afp.conf**(5) for documentation of the configuration options.
 
-### sqlite
+### last
 
-A zero-configuration database backend that uses the SQLite v3
-embedded database engine.
+The last backend is an in-memory Trivial Database (tdb). It is not persistent,
+with IDs valid only for the current session. Starting with netatalk 3.0,
+it operates in *read only mode*. This backend is useful e.g. for
+mounting CD-ROMs, or for automated testing.
 
-This backend is considered experimental and should only be used
-for testing.
+This is basically equivalent to how **afpd** stored CNID data in netatalk
+1.5 and earlier.
 
 ## Charsets/Unicode
 

--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -102,8 +102,6 @@ for daily use.
 
     The SQLite library version 3 enables the SQLite CNID backend
     which is an alternative zero-configuration backend.
-    This backend is **experimental** and should be used only for
-    testing purposes.
 
 ### Optional third-party software
 

--- a/libatalk/cnid/cnid.c
+++ b/libatalk/cnid/cnid.c
@@ -57,16 +57,6 @@ void cnid_register(struct _cnid_module *module)
     }
 
     LOG(log_info, logtype_afpd, "Registering CNID module [%s]", module->name);
-
-    if (0 == strcmp(module->name, "sqlite")) {
-        LOG(log_warning, logtype_afpd,
-            "CNID module [%s] is considered EXPERIMENTAL and may not work as expected!\n"
-            "Make sure you take backups of your data before proceeding "
-            "and do not use in production deployments (yet).\n"
-            "Please report any issues that you find to the Netatalk developers.",
-            module->name);
-    }
-
     ptr = &(module->db_list);
     list_add_tail(ptr, &modules);
 }


### PR DESCRIPTION
Remove the warning when loading the sqlite backend library

Remove the notes in documentation about it being experimental

Refactor the description of the CNID backends