### PR TITLE
bump to development version 4.4.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
     'netatalk',
     'c',
-    version: '4.3.3dev',
+    version: '4.4.0dev',
     license: 'GPLv2',
     default_options: ['warning_level=3', 'c_std=c11'],
     meson_version: '>=0.61.2',


### PR DESCRIPTION
branch-netatalk-4-3 has been branched off now, so let's indicate the next minor feature version