### PR TITLE
GitHub CI: remove redundant sqlite dependency on macOS build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -394,6 +394,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
+          brew upgrade
           brew install \
             bstring \
             cmark-gfm \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,8 +401,7 @@ jobs:
             iniparser \
             mariadb \
             meson \
-            openldap \
-            sqlite
+            openldap
       - name: Configure
         run: |
           meson setup build \


### PR DESCRIPTION
In the macOS runner's Homebrew environment there's already a sqlite library available so we keep getting a warning in every actions run

Also, run brew upgrade in macOS job to avoid intermittent fail state