### PR TITLE
testsuite: Clean test volumes between each spectest test execution

### DIFF
--- a/doc/manpages/man1/afp_spectest.1.md
+++ b/doc/manpages/man1/afp_spectest.1.md
@@ -4,7 +4,7 @@ afp_spectest — AFP specification compliance test suite
 
 # Synopsis
 
-**afp_spectest** [-1234567aCilmVvX] [-h *host*] [-H *host2*] [-p *port*] [-s *volume*] [-c *path to volume*]
+**afp_spectest** [-1234567aCEilmVvX] [-h *host*] [-H *host2*] [-p *port*] [-s *volume*] [-c *path to volume*]
 [-S *volume2*] [-u *user*] [-d *user2*] [-w *password*] [-f *test*]
 
 # Description
@@ -49,6 +49,11 @@ Single tests or entire testsets can be executed with the **-f** option.
 
 **-d** *user*
 : Second username for authentication
+
+**-E**
+: Empty the test volume before running tests
+
+> ***WARNING:*** This will delete all files and directories in the test volume!
 
 **-f** *test*
 : Specify test or testset to run

--- a/test/testsuite/FPRead.c
+++ b/test/testsuite/FPRead.c
@@ -1,17 +1,9 @@
 /* ----------------------------------------------
 */
 #include "specs.h"
+#include "afphelper.h"
 
-/* --------------------------------- */
-static int is_there(CONN *conn, int did, char *name)
-{
-    uint16_t vol = VolID;
-    return FPGetFileDirParams(conn, vol, did, name,
-                              (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID)
-                              ,
-                              (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID)
-                             );
-}
+int32_t is_there(CONN *conn, uint16_t volume, int32_t did, char *name);
 
 /* ------------------------- */
 STATIC void test5()
@@ -615,7 +607,7 @@ void test328()
     size = min(65536, dsi->server_quantum);
     data = calloc(1, size);
 
-    if (ntohl(AFPERR_NOOBJ) != is_there(Conn, DIRDID_ROOT, ndir)) {
+    if (ntohl(AFPERR_NOOBJ) != is_there(Conn, VolID, DIRDID_ROOT, ndir)) {
         test_nottested();
         goto fin;
     }
@@ -631,7 +623,7 @@ void test328()
         goto fin;
     }
 
-    if (ntohl(AFPERR_NOOBJ) != is_there(Conn, dir, "File.big")) {
+    if (ntohl(AFPERR_NOOBJ) != is_there(Conn, VolID, dir, "File.big")) {
         test_failed();
         goto fin1;
     }
@@ -650,7 +642,7 @@ void test328()
     /* --------------- */
     strcpy(temp, "File.big");
 
-    if (is_there(Conn, dir, temp)) {
+    if (is_there(Conn, VolID, dir, temp)) {
         test_failed();
         goto fin1;
     }
@@ -695,7 +687,7 @@ void test328()
         }
     }
 
-    if (is_there(Conn, dir, temp)) {
+    if (is_there(Conn, VolID, dir, temp)) {
         test_failed();
     }
 

--- a/test/testsuite/afparg.c
+++ b/test/testsuite/afparg.c
@@ -51,6 +51,7 @@ char *uam = "Cleartxt Passwrd";
 /* Unused but required in afphelper.c. Argh. */
 CONN       *Conn2;
 int        Mac = 0;
+int        EmptyVol = 0;
 char       Data[1] = "";
 int PassCount = 0;
 int FailCount = 0;

--- a/test/testsuite/afphelper.h
+++ b/test/testsuite/afphelper.h
@@ -58,7 +58,9 @@ extern int delete_folder_with_file(uint16_t vol, int did, char *name,
 extern int get_vol_attrib(uint16_t vol);
 extern int group_folder(uint16_t vol, int did, char *name);
 extern unsigned int get_vol_free(uint16_t vol);
+extern int32_t is_there(CONN *conn, uint16_t volume, int32_t did, char *name);
 extern int delete_directory_tree(CONN *conn, uint16_t volume,
                                  uint32_t parent_did, char *dirname);
+extern void clear_volume(uint16_t vol, CONN *conn);
 
 #endif

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -93,6 +93,7 @@ CONN *Conn;
 int ExitCode = 0;
 int Version = 34;
 int Mac = 0;
+int EmptyVol = 0;
 char Data[300000] = "";
 char    *Vol = "";
 char    *User = "";
@@ -850,15 +851,6 @@ static int cleanup_test_directory(CONN *conn, uint16_t volume, char *dirname)
 }
 
 /* --------------------------------- */
-int32_t is_there(CONN *conn, uint16_t volume, int32_t did, char *name)
-{
-    return FPGetFileDirParams(conn, volume, did, name,
-                              (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID)
-                              ,
-                              (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID)
-                             );
-}
-
 struct async_io_req {
     uint64_t air_count;
     size_t air_size;

--- a/test/testsuite/logintest.c
+++ b/test/testsuite/logintest.c
@@ -31,6 +31,7 @@ char    *Path;
 int     Version = 34;
 int     List = 0;
 int     Mac = 0;
+int     EmptyVol = 0;
 char    *Test;
 static char  *vers = "AFP3.4";
 

--- a/test/testsuite/spectest.c
+++ b/test/testsuite/spectest.c
@@ -332,6 +332,7 @@ int     List = 0;
 int     Mac = 0;
 char    *Test;
 int		Locking;
+int     EmptyVol = 0;
 enum adouble adouble = AD_EA;
 
 char *vers = "AFP3.4";
@@ -369,6 +370,8 @@ void usage(char *av0)
     fprintf(stdout,
             "\t-i\tinteractive mode, prompts before every test (debug purposes)\n");
     fprintf(stdout, "\t-C\tturn off terminal color output\n");
+    fprintf(stdout,
+            "\t-E\tempty test volume between tests (WARNING deletes all user data on volume)\n");
     exit(1);
 }
 
@@ -382,7 +385,7 @@ int main(int ac, char **av)
         usage(av[0]);
     }
 
-    while ((cc = getopt(ac, av, "1234567aCilmVvXc:d:f:H:h:p:S:s:u:w:")) != EOF) {
+    while ((cc = getopt(ac, av, "1234567aCEilmVvXc:d:f:H:h:p:S:s:u:w:")) != EOF) {
         switch (cc) {
         case '1':
             vers = "AFPVersion 2.1";
@@ -433,6 +436,10 @@ int main(int ac, char **av)
 
         case 'd':
             User2 = strdup(optarg);
+            break;
+
+        case 'E':
+            EmptyVol = 1;
             break;
 
         case 'f' :

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -7,12 +7,16 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
+#include "afphelper.h"
+
 /* For compiling os OS X */
 #ifndef MAP_ANONYMOUS
 #ifdef MAP_ANON
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 #endif
+
+int32_t is_there(CONN *conn, uint16_t volume, int32_t did, char *name);
 
 uint16_t VolID;
 uint16_t VolID2;
@@ -57,6 +61,7 @@ static int Direct = 0;
 /* not used */
 CONN *Conn2;
 int  Mac = 0;
+int EmptyVol = 0;
 int PassCount = 0;
 int FailCount = 0;
 int SkipCount = 0;
@@ -539,16 +544,6 @@ static void press_enter(char *s)
 
     while (fgetc(stdin) != '\n')
         ;
-}
-
-/* --------------------------------- */
-int is_there(CONN *conn, uint16_t vol, int did, char *name)
-{
-    return VFS.getfiledirparams(conn, vol, did, name,
-                                (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID)
-                                ,
-                                (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID)
-                               );
 }
 
 /* ------------------ */

--- a/test/testsuite/test.h
+++ b/test/testsuite/test.h
@@ -184,6 +184,7 @@ extern int Color;
 extern int Interactive;
 extern int Throttle;
 extern int Bigendian;
+extern int EmptyVol;
 
 extern int PassCount;
 extern int FailCount;

--- a/test/testsuite/testhelper.c
+++ b/test/testsuite/testhelper.c
@@ -2,6 +2,7 @@
 */
 
 #include "specs.h"
+#include "afphelper.h"
 
 static int CurTestResult;
 static char *Why;
@@ -165,6 +166,14 @@ void test_nottested(void)
 /* ------------------------- */
 void enter_test(void)
 {
+    if (EmptyVol) {
+        clear_volume(VolID, Conn);
+
+        if (Conn2) {
+            clear_volume(VolID, Conn2);
+        }
+    }
+
     CurTestResult = 0;
     Why = "";
 }


### PR DESCRIPTION
Enumerate and delete all files and directories in Vol and Vol2 through a new utility function called clear_volume() in afphelper

A new `-E` option to afp_spectest enables this mode (default: off) while the other test suites don't use it

Lingering files between test executions may lead to unexpected test results, so using this option can give you more consistent results, or give you a shortcut for cleaning up a test volume before running tests

Refactor the testsuite to use is_there() from afphelper globally