### PR TITLE
afpd: introduce runtime option for valid shellcheck

### DIFF
--- a/contrib/webmin_module/edit_global_section.cgi
+++ b/contrib/webmin_module/edit_global_section.cgi
@@ -338,6 +338,15 @@ print &ui_table_row(
                     . $text{'edit_global_section_passwd_minlen_help'}
 );
 
+@values = get_parameter_of_section($afpconfRef, $sectionRef, 'valid shellcheck', \%in);
+print &ui_table_row(
+                    $text{'edit_global_section_valid_shellcheck'},
+                    &build_select(
+                                  $afpconfRef, $sectionRef, \%in, 'valid shellcheck', $text{'edit_undefined'}, 'yes',
+                                  'yes',       'no',        'no'
+                    )
+);
+
 print &ui_table_end();
 print &ui_tabs_end_tab('mode', 'auth');
 

--- a/contrib/webmin_module/lang/en
+++ b/contrib/webmin_module/lang/en
@@ -198,6 +198,7 @@ edit_global_section_set_password=Allow users to change password
 edit_global_section_passwd_file=Password file
 edit_global_section_passwd_minlen=Minimum password length
 edit_global_section_passwd_minlen_help=Depends on support in UAM
+edit_global_section_valid_shellcheck=Check for valid login shell
 edit_global_section_advertise_ssh=Advertise SSH
 edit_global_section_afp_interfaces=AFP interfaces listen
 edit_global_section_afp_listen=AFP listen (IP address:port)

--- a/contrib/webmin_module/netatalk-lib.pl
+++ b/contrib/webmin_module/netatalk-lib.pl
@@ -89,6 +89,7 @@ our %netatalkParameterDefaults = (
                                   'unix charset'                => 'UTF8',
                                   'unix priv'                   => 'yes',
                                   'use sendfile'                => 'yes',
+                                  'valid shellcheck'            => 'yes',
                                   'veto message'                => 'no',
                                   'vol dbnest'                  => 'no',
                                   'vol dbpath'                  => '@localstatedir@/netatalk/CNID/',

--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -294,6 +294,14 @@ uam path = *path* **(G)**
 
 > Sets the default path for UAMs for this server.
 
+valid shellcheck = *BOOLEAN* (default: *yes*) **(G)**
+
+> Whether to check if the user's login shell is valid (i.e. listed in
+/etc/shells). If the user's shell is not valid, authentication will
+fail. This is a security feature to prevent users with nologin shells
+from logging in. Disable this option to allow users with nologin shells
+to log in.
+
 ## Charset Options
 
 With OS X Apple introduced the AFP3 protocol. One of the big changes

--- a/etc/afpd/afp_options.c
+++ b/etc/afpd/afp_options.c
@@ -110,12 +110,6 @@ static void show_version_extended(void)
 #else
     puts("No");
 #endif
-    printf("    Valid shell checks:\t");
-#ifndef DISABLE_SHELLCHECK
-    puts("Yes");
-#else
-    puts("No");
-#endif
     printf("      cracklib support:\t");
 #ifdef USE_CRACKLIB
     puts("Yes");

--- a/etc/papd/uam.c
+++ b/etc/papd/uam.c
@@ -229,8 +229,10 @@ struct passwd *uam_getname(void *dummy _U_, char *name, const int len)
     return pwent ? getpwnam(name) : NULL;
 }
 
-
-int uam_checkuser(const struct passwd *pwd)
+/* FIXME: the ability to disable valid shellcheck at papd runtime
+ * which will first require implementation in papd.conf
+ * and then propagation of the option flag here */
+int uam_checkuser(void *private _U_, const struct passwd *pwd)
 {
     char *p;
 
@@ -245,7 +247,6 @@ int uam_checkuser(const struct passwd *pwd)
     }
 
     endusershell();
-#ifndef DISABLE_SHELLCHECK
 
     if (!p) {
         LOG(log_info, logtype_papd, "illegal shell %s for %s", pwd->pw_shell,
@@ -253,8 +254,5 @@ int uam_checkuser(const struct passwd *pwd)
         return -1;
     }
 
-#endif /* DISABLE_SHELLCHECK */
     return 0;
 }
-
-

--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -89,7 +89,7 @@ static int pwd_login(void *obj, char *username, int ulen,
 
     LOG(log_info, logtype_uams, "dhx login: %s", username);
 
-    if (uam_checkuser(dhxpwd) < 0) {
+    if (uam_checkuser(obj, dhxpwd) < 0) {
         return AFPERR_NOTAUTH;
     }
 

--- a/etc/uams/uams_gss.c
+++ b/etc/uams/uams_gss.c
@@ -482,7 +482,7 @@ static int gss_logincont(void *obj,
         return AFPERR_NOTAUTH;
     }
 
-    if (uam_checkuser(pwd) < 0) {
+    if (uam_checkuser(obj, pwd) < 0) {
         LOG_LOGINCONT(log_info, "`%s'' not a valid user", username);
         return AFPERR_NOTAUTH;
     }

--- a/etc/uams/uams_pam.c
+++ b/etc/uams/uams_pam.c
@@ -157,6 +157,12 @@ static int login(void *obj, char *username, int ulen,  struct passwd **uam_pwd,
         return AFPERR_NOTAUTH;
     }
 
+    if (uam_checkuser(NULL, pwd) < 0) {
+        free(PAM_password);
+        PAM_password = NULL;
+        return AFPERR_NOTAUTH;
+    }
+
     LOG(log_info, logtype_uams, "cleartext login: %s", username);
     PAM_username = username;
     PAM_password = ibuf; /* Set these things up for the conv function */

--- a/etc/uams/uams_pam.c
+++ b/etc/uams/uams_pam.c
@@ -462,7 +462,7 @@ static int pam_printer(char *start, char *stop, char *username,
         return -1;
     }
 
-    if (uam_checkuser(pwd) < 0) {
+    if (uam_checkuser(NULL, pwd) < 0) {
         /* syslog of error happens in uam_checkuser */
         free(PAM_password);
         PAM_password = NULL;

--- a/etc/uams/uams_passwd.c
+++ b/etc/uams/uams_passwd.c
@@ -61,7 +61,7 @@ static int pwd_login(void *obj, char *username, int ulen,
 
     LOG(log_info, logtype_uams, "cleartext login: %s", username);
 
-    if (uam_checkuser(pwd) < 0) {
+    if (uam_checkuser(obj, pwd) < 0) {
         LOG(log_info, logtype_uams, "not a valid user");
         return AFPERR_NOTAUTH;
     }
@@ -248,7 +248,7 @@ static int passwd_printer(char	*start, char *stop, char *username,
         return -1;
     }
 
-    if (uam_checkuser(pwd) < 0) {
+    if (uam_checkuser(NULL, pwd) < 0) {
         /* syslog of error happens in uam_checkuser */
         return -1;
     }

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -339,7 +339,7 @@ static int rand_login(void *obj, char *username, int ulen,
 
     LOG(log_info, logtype_uams, "randnum/rand2num login: %s", username);
 
-    if (uam_checkuser(randpwd) < 0) {
+    if (uam_checkuser(obj, randpwd) < 0) {
         return AFPERR_NOTAUTH;
     }
 
@@ -483,7 +483,7 @@ static int randnum_changepw(void *obj, const char *username _U_,
             GCRYPT_VERSION);
     }
 
-    if (uam_checkuser(pwd) < 0) {
+    if (uam_checkuser(obj, pwd) < 0) {
         return AFPERR_ACCESS;
     }
 

--- a/include/atalk/globals.h
+++ b/include/atalk/globals.h
@@ -67,6 +67,7 @@
 #define OPTION_RECVFILE      (1 << 15)
 #define OPTION_SPOTLIGHT_EXPR (1 << 16) /* whether to allow Spotlight logic expressions */
 #define OPTION_DDP     (1 << 17) /* whether to allow connections via appletalk/ddp */
+#define OPTION_VALID_SHELLCHECK (1 << 18) /* whether to check for valid login shell */
 
 #define PASSWD_NONE     0
 #define PASSWD_SET     (1 << 0)

--- a/include/atalk/uam.h
+++ b/include/atalk/uam.h
@@ -88,7 +88,7 @@ extern UAM_MODULE_EXPORT void uam_unregister(const int, const char *);
 
 /* helper functions */
 extern UAM_MODULE_EXPORT struct passwd *uam_getname(void *, char *, const int);
-extern UAM_MODULE_EXPORT int uam_checkuser(const struct passwd *);
+extern UAM_MODULE_EXPORT int uam_checkuser(void *, const struct passwd *);
 
 /* afp helper functions */
 extern UAM_MODULE_EXPORT int uam_afp_read(void *, char *, size_t *,

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2524,6 +2524,10 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
         options->flags |= OPTION_SPOTLIGHT_EXPR;
     }
 
+    if (getoption_bool(config, INISEC_GLOBAL, "valid shellcheck", NULL, 1)) {
+        options->flags |= OPTION_VALID_SHELLCHECK;
+    }
+
     /* figure out options w values */
     options->loginmesg      = getoption_strdup(config, INISEC_GLOBAL,
                               "login message",  NULL, NULL);

--- a/meson.build
+++ b/meson.build
@@ -2128,14 +2128,6 @@ if get_option('with-debugging')
 endif
 
 #
-# Check for optional valid-shell-check support
-#
-
-if not get_option('with-shell-check')
-    cdata.set('DISABLE_SHELLCHECK', 1)
-endif
-
-#
 # Variable substitution
 #
 

--- a/meson_config.h
+++ b/meson_config.h
@@ -31,9 +31,6 @@
 /* Default CNID scheme to be used */
 #mesondefine DEFAULT_CNID_SCHEME
 
-/* Define if shell check should be disabled */
-#mesondefine DISABLE_SHELLCHECK
-
 /* Available Extended Attributes modules */
 #mesondefine EA_MODULES
 


### PR DESCRIPTION
Remove the compile time disable valid shellcheck option in favor for a runtime option configurable in afp.conf

A known issue is that papd doesn't have the capability to configure valid shellcheck or even propagates the global papd settings to the UAM library;
for now we always keep valid shellcheck enabled for papd and leave a FIXME in the code

Also, fixes a bug where valid shellcheck was never done in the ClearTxt PAM UAM for afpd (but was doing it for papd auth)