### PR TITLE
afpd: check that username is a string before assigning in log_dircache_stat()

### DIFF
--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -629,7 +629,7 @@ void log_dircache_stat(void)
     /* Get username from AFPobj if available */
     extern AFPObj *AFPobj;
     const char *username = (AFPobj
-                            && AFPobj->username) ? AFPobj->username : "unknown";
+                            && AFPobj->username[0]) ? AFPobj->username : "unknown";
     LOG(log_info, logtype_afpd,
         "dircache statistics: (user: %s) "
         "entries: %lu, lookups: %llu, hits: %llu (%.1f%%), misses: %llu, "


### PR DESCRIPTION
The validation of AFPobj->username in this ternary statement always evaluates as true because the username struct member is defined as a char array with fixed width, and therefore always has a valid pointer

Instead, we check that the first char in the array is non-null to validate that it is actually a string