### PR TITLE
Release versions 3.2 and 2.4 are now End Of Life

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,10 +18,10 @@ For instance, if 4.0 and 4.1 are supported, and we release 4.2, then support for
 | 4.2.x   | ✓         | Aug 5, 2026         |
 | 4.1.x   | X         | -                   |
 | 4.0.x   | X         | -                   |
-| 3.2.x   | ✓         | Sep 28, 2025        |
+| 3.2.x   | X         | -                   |
 | 3.1.x   | X         | -                   |
 | 3.0.x   | X         | -                   |
-| 2.4.x   | ✓         | Sep 28, 2025        |
+| 2.4.x   | X         | -                   |
 | < 2.4   | X         | -                   |
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
Since a full 12 months have passed since the release of netatalk 4.0, the 3.x and 2.x release series are considered EOL and will no longer get security patches