### PR TITLE
meson: error out if no writable CNID backend selected for compilation

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -50,7 +50,7 @@ These are the libraries that are hard requirements for netatalk.
 
 ### CNID Backend Requirements
 
-One or more of the below is required to build the respective CNID backend.
+At least one CNID backend is required for netatalk to function.
 
 | Package      | Backend | Details |
 |--------------|---------|---------|

--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -76,31 +76,26 @@ packages that can be installed to enhance Netatalk's functionality.
 
 #### CNID database backends
 
-At least one of the below database libraries is required
-to power the CNID scheme of your choice.
-Without one of these, only the *last* backend will be available
-which operates in read-only mode and therefore not recommended
-for daily use.
+At least one of the below database libraries is required to power the CNID scheme of your choice.
 
 - Berkeley DB
 
-    The default dbd CNID backend for netatalk uses Berkeley DB to store
-    unique file identifiers. At the time of writing you need at least
-    version 4.6.
+    The default *dbd* (*Database Daemon*) CNID backend for netatalk uses Berkeley DB to store
+    unique file identifiers.
 
-    The recommended version is 5.3, the final release under the permissive
-    Sleepycat license, and therefore the most widely distributed version.
+    The recommended Berekeley DB version is 5.3, while versions 4.6 and later should work as well.
+    Version 6 and later should generally be avoided due to licensing issues.
 
-- MySQL or MariaDB
+- MySQL Client or MariaDB Client
 
     By leveraging a MySQL-compatible client library, netatalk can be built
-    with a MySQL CNID backend that is highly scalable and reliable.
+    with the *mysql* CNID backend that is highly scalable and reliable.
     The administrator has to provide a separate database instance for use with
     this backend.
 
 - SQLite v3
 
-    The SQLite library version 3 enables the SQLite CNID backend
+    The SQLite library version 3 enables the *sqlite* CNID backend
     which is an alternative zero-configuration backend.
 
 ### Optional third-party software

--- a/meson.build
+++ b/meson.build
@@ -623,7 +623,9 @@ if default_backend == ''
     elif use_mysql_backend
         default_backend = 'mysql'
     elif use_last_backend
-        default_backend = 'last'
+        error(
+            'No writable CNID backend selected for compilation; need at least one of dbd, sqlite or mysql',
+        )
     else
         error('No CNID backends selected for compilation')
     endif


### PR DESCRIPTION
Since the last backend is read-only, we want to error out rather than automatically selecting it as the default CNID backend in the absence of any other backend

You can still force the last backend as default with -Dwith-cnid-default-backend if you absolutely want to (but I cannot see when this would be useful)

This effectively introduces a hard build dependency on at least one of the three database libraries: bdb, mysql, or sqlite