### PR TITLE
docker: build the sqlite CNID backend in the Alpine production container

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -272,6 +272,53 @@ jobs:
               -e AFP_CNID_SQL_PASS="$DB_PASSWD" \
               ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
+  afp-spectest-sqlite-afp34-prod:
+    name: AFP spec test (cnid:sqlite) AFP 3.4 - Alpine (Prod)
+    needs:
+      - build-container
+      - build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Create Docker network
+        run: |
+          docker network create afp_network
+      - name: Run Netatalk
+        run: |
+          docker run --detach \
+              --name afp_server \
+              --network afp_network \
+              -e AFP_USER=atalk1 \
+              -e AFP_USER2=atalk2 \
+              -e AFP_PASS="$CONT_PASSWD" \
+              -e AFP_PASS2="$CONT_PASSWD" \
+              -e AFP_GROUP=afpusers \
+              -e AFP_CNID_BACKEND=sqlite \
+              -e SHARE_NAME=test1 \
+              -e SHARE_NAME2=test2 \
+              -e INSECURE_AUTH=1 \
+              -e DISABLE_TIMEMACHINE=1 \
+              -e AFP_EXTMAP=1 \
+              ${{ env.REGISTRY }}/netatalk/netatalk:${{ github.sha }}
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+              --network afp_network \
+              -e AFP_USER=atalk1 \
+              -e AFP_USER2=atalk2 \
+              -e AFP_PASS="$CONT_PASSWD" \
+              -e AFP_PASS2="$CONT_PASSWD" \
+              -e AFP_GROUP=afpusers \
+              -e SHARE_NAME=test1 \
+              -e SHARE_NAME2=test2 \
+              -e VERBOSE=1 \
+              -e TESTSUITE=spectest \
+              -e AFP_VERSION=7 \
+              -e AFP_REMOTE=1 \
+              -e AFP_HOST=afp_server \
+              ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
   afp-spectest-mysql-afp34-debian:
     name: AFP spec test (cnid:mysql) AFP 3.4 - Debian
     needs: build-container-testsuite-debian

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ARG RUN_DEPS="\
     mariadb-client \
     mariadb-connector-c \
     openldap \
+    sqlite \
     tzdata \
     "
 ARG BUILD_DEPS="\
@@ -31,6 +32,7 @@ ARG BUILD_DEPS="\
     ninja \
     openldap-dev \
     pkgconfig \
+    sqlite-dev \
     "
 
 FROM alpine:3.22.1@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1 AS build
@@ -53,7 +55,7 @@ RUN meson setup build \
     -Dwith-acls=false \
     -Dwith-afpstats=false \
     -Dwith-appletalk=true \
-    -Dwith-cnid-backends=dbd,mysql \
+    -Dwith-cnid-backends=dbd,mysql,sqlite \
     -Dwith-dbus-daemon-path=/usr/bin/dbus-daemon \
     -Dwith-dbus-sysconf-path=/etc \
     -Dwith-docs= \


### PR DESCRIPTION
Since the sqlite CNID backend is now considered stable, let's build and make it available in the production netatalk container