### PR TITLE
docs: for testsuite man pages, list -l option separately in synopsis

### DIFF
--- a/doc/manpages/man1/afp_spectest.1.md
+++ b/doc/manpages/man1/afp_spectest.1.md
@@ -4,8 +4,10 @@ afp_spectest — AFP specification compliance test suite
 
 # Synopsis
 
-**afp_spectest** [-1234567aCEilmVvX] [-h *host*] [-H *host2*] [-p *port*] [-s *volume*] [-c *path to volume*]
+**afp_spectest** [-1234567aCEimVvX] [-h *host*] [-H *host2*] [-p *port*] [-s *volume*] [-c *path to volume*]
 [-S *volume2*] [-u *user*] [-d *user2*] [-w *password*] [-f *test*]
+
+**afp_spectest** -l
 
 # Description
 

--- a/doc/manpages/man1/afparg.1.md
+++ b/doc/manpages/man1/afparg.1.md
@@ -4,7 +4,9 @@ afparg — Send commands to an AFP server
 
 # Synopsis
 
-**afparg** [-1234567lVv] [-h *host*] [-p *port*] [-s *volume*] [-u *user*] [-w *password*] [-f *command*]
+**afparg** [-1234567Vv] [-h *host*] [-p *port*] [-s *volume*] [-u *user*] [-w *password*] [-f *command*]
+
+**afparg** -l
 
 # Description
 


### PR DESCRIPTION
The -l option in afparg and afp_spectest prints to stdout and then exits, so as per man page convention it should be listed in a separate synopsis line since it cannot be combined with the other options