### PR TITLE
cnid: implement cnid_find() in the sqlite backend

### DIFF
--- a/include/atalk/cnid_sqlite_private.h
+++ b/include/atalk/cnid_sqlite_private.h
@@ -20,6 +20,7 @@ typedef struct CNID_sqlite_private {
     sqlite3_stmt *cnid_resolve_stmt;
     sqlite3_stmt *cnid_delete_stmt;
     sqlite3_stmt *cnid_getstamp_stmt;
+    sqlite3_stmt *cnid_find_stmt;
 } CNID_sqlite_private;
 
 #endif


### PR DESCRIPTION
The find API function in the CNID library is used specifically by the "nad find" command, which can be handy in a pinch