### PR TITLE
docs: improve AppleTalk network layer diagram

### DIFF
--- a/doc/DEVELOPER.md
+++ b/doc/DEVELOPER.md
@@ -13,16 +13,16 @@ The complete stack looks like this on a BSD-derived system:
      |                            |
     ASP    PAP                   DSI
       \   /                       |
-       ATP RTMP NBP ZIP AEP       |
+       ATP RTMP NBP ZIP AEP       | (port:548)
         |    |   |   |   |        |
    -+---------------------------------------------------+- (kernel boundary)
     |                    Socket                         |
     +-----------------------+------------+--------------+
     |                       |     TCP    |    UDP       |
     |          DDP          +------------+--------------+
-    |                       |           IP              |
+    |                       |       IP v4 or v6         |
     +-----------------------+---------------------------+
-    |                Network-Interface                  |
+    |                Network Interface                  |
     +---------------------------------------------------+
 ```
 


### PR DESCRIPTION
A handful of minor tweaks to make the AppleTalk diagram aligned with the later TCP-only diagram