### PR TITLE
docs: scan *.c files with Doxygen as well

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1031,7 +1031,7 @@ INPUT_FILE_ENCODING    =
 # provided as Doxygen C comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f18, *.f, *.for, *.vhd, *.vhdl, *.ucf, *.qsf and *.ice.
 
-FILE_PATTERNS          = */DEVELOPER.md *.h
+FILE_PATTERNS          = */DEVELOPER.md *.c *.h
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.


### PR DESCRIPTION
In reality, interfaces are often documented in the C source files rather than the header files, so let's scan all of them as well

If function documentation moves decisively into the headers in the future, we can revisit this choice