### PR TITLE
meson: refactor the docs installation dir logic

### DIFF
--- a/doc/manpages/man1/meson.build
+++ b/doc/manpages/man1/meson.build
@@ -57,6 +57,6 @@ endforeach
 
 if get_option('with-website')
     foreach page : manfiles
-        install_data(page + '.1.md', install_dir: manual_install_path + '/en')
+        install_data(page + '.1.md', install_dir: docs_install_path + '/manual/en')
     endforeach
 endif

--- a/doc/manpages/man3/meson.build
+++ b/doc/manpages/man3/meson.build
@@ -25,6 +25,6 @@ endforeach
 
 if get_option('with-website')
     foreach page : manfiles
-        install_data(page + '.3.md', install_dir: manual_install_path + '/en')
+        install_data(page + '.3.md', install_dir: docs_install_path + '/manual/en')
     endforeach
 endif

--- a/doc/manpages/man4/meson.build
+++ b/doc/manpages/man4/meson.build
@@ -19,5 +19,5 @@ custom_target(
 )
 
 if get_option('with-website')
-    install_data(manfile + '.4.md', install_dir: manual_install_path + '/en')
+    install_data(manfile + '.4.md', install_dir: docs_install_path + '/manual/en')
 endif

--- a/doc/manpages/man5/meson.build
+++ b/doc/manpages/man5/meson.build
@@ -36,6 +36,6 @@ endforeach
 
 if get_option('with-website')
     foreach page : manfiles
-        install_data(page + '.5.md', install_dir: manual_install_path + '/en')
+        install_data(page + '.5.md', install_dir: docs_install_path + '/manual/en')
     endforeach
 endif

--- a/doc/manpages/man8/meson.build
+++ b/doc/manpages/man8/meson.build
@@ -43,6 +43,6 @@ endforeach
 
 if get_option('with-website')
     foreach page : manfiles
-        install_data(page + '.8.md', install_dir: manual_install_path + '/en')
+        install_data(page + '.8.md', install_dir: docs_install_path + '/manual/en')
     endforeach
 endif

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -19,7 +19,7 @@ if get_option('with-website')
     ]
 
     foreach page : manual_pages
-        install_data(page + '.md', install_dir: manual_install_path + '/en')
+        install_data(page + '.md', install_dir: docs_install_path + '/manual/en')
     endforeach
 endif
 
@@ -37,7 +37,7 @@ foreach page : manual_pages
             ],
             capture: true,
             install: true,
-            install_dir: manual_install_path,
+            install_dir: docs_install_path / 'manual',
         )
     elif cmarkgfm.found()
         custom_target(
@@ -53,7 +53,7 @@ foreach page : manual_pages
             ],
             capture: true,
             install: true,
-            install_dir: manual_install_path,
+            install_dir: docs_install_path / 'manual',
         )
     elif cmark.found()
         custom_target(
@@ -69,7 +69,7 @@ foreach page : manual_pages
             ],
             capture: true,
             install: true,
-            install_dir: manual_install_path,
+            install_dir: docs_install_path / 'manual',
         )
     endif
 endforeach

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -43,7 +43,15 @@ if build_dev_docs and doxygen.found()
 
     install_subdir(
         meson.current_build_dir() / 'developer',
-        install_dir: get_option('datadir') / 'doc' / meson.project_name(),
+        install_dir: datadir / 'doc' / meson.project_name(),
         strip_directory: false,
     )
+
+    if get_option('with-website')
+        install_subdir(
+            meson.current_build_dir() / 'developer',
+            install_dir: docs_install_path / 'public',
+            strip_directory: false,
+        )
+    endif
 endif

--- a/doc/translated/ja/meson.build
+++ b/doc/translated/ja/meson.build
@@ -65,7 +65,7 @@ endif
 
 if get_option('with-website')
     foreach page : manual_pages
-        install_data(page + '.md', install_dir: manual_install_path + '/ja')
+        install_data(page + '.md', install_dir: docs_install_path + '/manual/ja')
     endforeach
 else
     foreach page : manual_pages
@@ -82,7 +82,7 @@ else
                 ],
                 capture: true,
                 install: true,
-                install_dir: manual_install_path + '/ja',
+                install_dir: docs_install_path / 'manual' / 'ja',
             )
         elif cmarkgfm.found()
             custom_target(
@@ -98,7 +98,7 @@ else
                 ],
                 capture: true,
                 install: true,
-                install_dir: manual_install_path + '/ja',
+                install_dir: docs_install_path / 'manual' / 'ja',
             )
         elif cmark.found()
             custom_target(
@@ -114,7 +114,7 @@ else
                 ],
                 capture: true,
                 install: true,
-                install_dir: manual_install_path + '/ja',
+                install_dir: docs_install_path / 'manual' / 'ja',
             )
         endif
     endforeach

--- a/meson.build
+++ b/meson.build
@@ -97,10 +97,10 @@ else
     homedir = '/home'
 endif
 
-manual_install_path = get_option('with-manual-install-path')
+docs_install_path = datadir / 'doc' / meson.project_name()
 
-if manual_install_path == ''
-    manual_install_path = datadir / 'doc/netatalk/htmldocs'
+if get_option('with-docs-install-path') != ''
+    docs_install_path = get_option('with-docs-install-path')
 endif
 
 ##################
@@ -2326,7 +2326,7 @@ if 'readmes' in get_option('with-docs')
                 )
             endif
 
-            install_data(file + '.md', install_dir: manual_install_path)
+            install_data(file + '.md', install_dir: docs_install_path)
         else
             if pandoc.found()
                 custom_target(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -52,6 +52,12 @@ option(
     description: 'Enable SIGALARM timers and DSI tickles (eg for debugging with gdb/dbx/...)',
 )
 option(
+    'with-docs-install-path',
+    type: 'string',
+    value: '',
+    description: 'Set path where to install generated documentation',
+)
+option(
     'with-docs-l10n',
     type: 'boolean',
     value: false,
@@ -302,12 +308,6 @@ option(
     type: 'string',
     value: '',
     description: 'Set path to directory that contains the Netatalk lockfiles',
-)
-option(
-    'with-manual-install-path',
-    type: 'string',
-    value: '',
-    description: 'Set path where to install manual html pages',
 )
 option(
     'with-pam-path',


### PR DESCRIPTION
This renames the -Dwith-manual-install-dir option to -Dwith-docs-install-dir

The new option specifies the prefix for all docs, rather than the html manual subdir

In this way, we can use the same prefix for all kinds of generated docs: html manual, converted readmes, and the doxygen docs

Notably, when used in tandem with the -Dwith-website=true option, this helps this project's maintainers with automating the website maintenance