### PR TITLE
GitHub CI: update the path to the generated html manual

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
-          path: '/usr/local/share/doc/netatalk/htmldocs'
+          path: '/usr/local/share/doc/netatalk/manual'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
In a previous PR, we changed the default dir name of the generated manual from htmldocs to manual