### PR TITLE
docs: tweak doxygen settings for better and more reliable output

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1046,7 +1046,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which Doxygen is
 # run.
 
-EXCLUDE                = */build/*
+EXCLUDE                =
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
@@ -1062,7 +1062,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = */build/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the


### PR DESCRIPTION
- Set the FULL_PATH_NAMES option to NO, so that the shortest unique pathname is used for each file in file list and page headers

The default YES setting includes the entire absolute path on the system the docs were built, which is irrelevant to readers

- Use EXCLUDE_PATTERNS to exclude the meson build dir which is more consistent than EXCLUDE