### PR TITLE
Update copyright information in catsearch.c

### DIFF
--- a/etc/afpd/catsearch.c
+++ b/etc/afpd/catsearch.c
@@ -1,6 +1,6 @@
 /*
- * Netatalk 2002 (c)
  * Copyright (C) 1990, 1993 Regents of The University of Michigan
+ * Copyright (c) 2002 Rafal Lewczuk <rlewczuk@pronet.pl>
  * Copyright (C) 2010 Frank Lahm
  * All Rights Reserved. See COPYRIGHT
  */


### PR DESCRIPTION
Restore the original attribution to Rafal Lewczuk that was present in the original revision of this file in commit 6d6cc03 but fell off afterwards