### PR TITLE
Update copyright notice in desktop.c

### DIFF
--- a/etc/afpd/desktop.c
+++ b/etc/afpd/desktop.c
@@ -1,5 +1,6 @@
 /*
- * See COPYRIGHT.
+ * Copyright (c) 1990,1993 Regents of The University of Michigan.
+ * All Rights Reserved.  See COPYRIGHT.
  *
  * bug:
  * afp_XXXcomment are (the only) functions able to open


### PR DESCRIPTION
Restore University of Michigan copyright attribution that fell off in commit 7c7e239 from February 2001. I think it was a copy paste mistake.