### PR TITLE
GitHub CI: run SonarQube analysis on Ubuntu container image

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -23,21 +23,24 @@ jobs:
       (github.event_name == 'push' && github.actor != 'dependabot[bot]' && github.actor != 'dependabot') || (github.event_name
       == 'pull_request' && !github.event.pull_request.head.repo.fork && github.actor != 'dependabot[bot]' && github.actor
       != 'dependabot')
+    container:
+      image: ubuntu:25.10
     env:
       BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-      - name: Install Build Wrapper
-        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install --assume-yes --no-install-recommends \
+          apt-get update
+          apt-get install --assume-yes --no-install-recommends \
               bison \
+              ca-certificates \
               cracklib-runtime \
+              curl \
               flex \
+              gcc \
               libacl1-dev \
               libavahi-client-dev \
               libcrack2-dev \
@@ -59,7 +62,10 @@ jobs:
               meson \
               ninja-build \
               systemtap-sdt-dev \
-              tracker-miner-fs
+              tracker-miner-fs \
+              unzip
+      - name: Install Build Wrapper
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
       - name: Run build wrapper
         run: |
           mkdir -p ${{ env.BUILD_WRAPPER_OUT_DIR }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,5 +8,8 @@ sonar.sourceEncoding=UTF-8
 sonar.projectName=netatalk
 sonar.projectVersion=4.4
 
+# Don't analyze dynamically generated files
+sonar.exclusions=**/build/**,**/subprojects/**,etc/spotlight/sparql_parser.*,etc/spotlight/spotlight_rawquery_lexer.c,include/atalk/afp_dtrace.h
+
 # Disabling code duplication rule for test code and Unicode lookup tables
 sonar.cpd.exclusions=test/**,libatalk/unicode/precompose.h,libatalk/unicode/utf16_case.c,libatalk/unicode/utf16_casetable.h


### PR DESCRIPTION
This should give the static analysis job much more consistently fast run time

- using the raw GitHub Ubuntu runner is slow and inefficient
- adds an explicit SonarQube scanner rule to not analyze build dir