### PR TITLE
Update bstring to version 1.0.3

### DIFF
--- a/subprojects/bstring.wrap
+++ b/subprojects/bstring.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
-directory = bstring-1.0.2
-source_url = https://github.com/msteinert/bstring/releases/download/v1.0.2/bstring-1.0.2.tar.xz
-source_filename = bstring-1.0.2.tar.xz
-source_hash = 9d2d207385edeb39935c53f55da57501936b67939998f3e5c5ae91cb8063fbd0
+directory = bstring-1.0.3
+source_url = https://github.com/msteinert/bstring/releases/download/v1.0.3/bstring-1.0.3.tar.xz
+source_filename = bstring-1.0.3.tar.xz
+source_hash = 90db08fd33e9494aea3f00f9b71cdcf3114c65457ee35558e8274df6ebac43f3
 
 [provide]
 bstring = bstring_dep


### PR DESCRIPTION
The bstring library v1.0.3 has two fixes relevant to netatalk:

- Library version string is now equal to the project version, rather than a static 1.0.0
- The pkg-config bstring.pc file correctly points to the developer header install location, so that the installed library can be used for development