### PR TITLE
libatalk: create utility function convert_utf8_to_mac()

### DIFF
--- a/bin/nad/nad_cp.c
+++ b/bin/nad/nad_cp.c
@@ -590,7 +590,7 @@ static int copy(const char *path,
             ad_setid(&ad, st.st_dev, st.st_ino, did, pdid, dvolume.db_stamp);
 
             if (dvolume.vol->v_adouble == AD_VERSION2) {
-                ad_setname(&ad, utompath(dvolume.vol, basename(to.p_path)));
+                ad_setname(&ad, convert_utf8_to_mac(dvolume.vol, basename(to.p_path)));
             }
 
             ad_setdate(&ad, AD_DATE_CREATE | AD_DATE_UNIX, (uint32_t) st.st_mtime);
@@ -667,7 +667,7 @@ static int copy(const char *path,
             ad_setid(&ad, st.st_dev, st.st_ino, cnid, did, dvolume.db_stamp);
 
             if (dvolume.vol->v_adouble == AD_VERSION2) {
-                ad_setname(&ad, utompath(dvolume.vol, basename(to.p_path)));
+                ad_setname(&ad, convert_utf8_to_mac(dvolume.vol, basename(to.p_path)));
             }
 
             ad_setdate(&ad, AD_DATE_CREATE | AD_DATE_UNIX, (uint32_t) st.st_mtime);

--- a/bin/nad/nad_util.c
+++ b/bin/nad/nad_util.c
@@ -147,50 +147,6 @@ void closevol(afpvol_t *vol)
     memset(vol, 0, sizeof(afpvol_t));
 }
 
-/*
-  Taken from afpd/desktop.c
-*/
-char *utompath(const struct vol *vol, const char *upath)
-{
-    /* for convert_charset dest_len parameter +2 */
-    static char  mpath[MAXPATHLEN + 2];
-    char         *m;
-    const char   *u;
-    uint16_t     flags = CONV_IGNORE | CONV_UNESCAPEHEX;
-    size_t       outlen;
-
-    if (!upath) {
-        return NULL;
-    }
-
-    m = mpath;
-    u = upath;
-    outlen = strlen(upath);
-
-    if (vol->v_casefold & AFPVOL_UTOMUPPER) {
-        flags |= CONV_TOUPPER;
-    } else if (vol->v_casefold & AFPVOL_UTOMLOWER) {
-        flags |= CONV_TOLOWER;
-    }
-
-    if (vol->v_flags & AFPVOL_EILSEQ) {
-        flags |= CONV__EILSEQ;
-    }
-
-    /* convert charsets */
-    if ((size_t) -1 == convert_charset(vol->v_volcharset,
-                                       CH_UTF8_MAC,
-                                       vol->v_maccharset,
-                                       u, outlen, mpath, MAXPATHLEN, &flags)) {
-        SLOG("Conversion from %s to %s for %s failed.",
-             vol->v_volcodepage, vol->v_maccodepage, u);
-        return NULL;
-    }
-
-    return m;
-}
-
-
 /*!
  * @brief Convert dot encoding of basename _in place_
  *

--- a/include/atalk/util.h
+++ b/include/atalk/util.h
@@ -239,10 +239,16 @@ extern cnid_t cnid_for_path(struct _cnid_db *cdb, const char *volpath,
                             const char *path, cnid_t *did);
 
 /******************************************************************
- * cnid.c
+ * gettok.c
  *****************************************************************/
 
 extern void initline(int, char *);
 extern int  parseline(int, char *);
+
+/******************************************************************
+ * pathconv.c
+ *****************************************************************/
+
+extern char *convert_utf8_to_mac(const struct vol *vol, const char *upath);
 
 #endif  /* _ATALK_UTIL_H */

--- a/libatalk/util/meson.build
+++ b/libatalk/util/meson.build
@@ -9,6 +9,7 @@ util_sources = [
     'locking.c',
     'logger.c',
     'netatalk_conf.c',
+    'pathconv.c',
     'queue.c',
     'server_child.c',
     'server_ipc.c',

--- a/libatalk/util/pathconv.c
+++ b/libatalk/util/pathconv.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 1990,1993 Regents of The University of Michigan.
+ * All Rights Reserved.  See COPYRIGHT.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <atalk/globals.h>
+#include <atalk/logger.h>
+#include <atalk/util.h>
+#include <atalk/volume.h>
+
+/*!
+ * @brief Convert a UTF-8 filename to a mangled Mac filename
+ *
+ * @param vol volume structure
+ * @param upath input path in UTF-8
+ *
+ * @return pointer to static buffer containing mangled Mac filename
+ *
+ * @sa utompath() in etc/afpd/desktop.c
+ */
+char *convert_utf8_to_mac(const struct vol *vol, const char *upath)
+{
+    /* for convert_charset dest_len parameter +2 */
+    static char  mpath[MAXPATHLEN + 2];
+    char         *m;
+    const char   *u;
+    uint16_t     flags = CONV_IGNORE | CONV_UNESCAPEHEX;
+    size_t       outlen;
+
+    if (!upath) {
+        return NULL;
+    }
+
+    m = mpath;
+    u = upath;
+    outlen = strnlen(upath, MAXPATHLEN);
+
+    if (vol->v_casefold & AFPVOL_UTOMUPPER) {
+        flags |= CONV_TOUPPER;
+    } else if (vol->v_casefold & AFPVOL_UTOMLOWER) {
+        flags |= CONV_TOLOWER;
+    }
+
+    if (vol->v_flags & AFPVOL_EILSEQ) {
+        flags |= CONV__EILSEQ;
+    }
+
+    /* convert charsets */
+    if ((size_t) -1 == convert_charset(vol->v_volcharset,
+                                       CH_UTF8_MAC,
+                                       vol->v_maccharset,
+                                       u, outlen, mpath, MAXPATHLEN, &flags)) {
+        LOG(log_error, logtype_default, "Conversion from %s to %s for %s failed.",
+            vol->v_volcodepage, vol->v_maccodepage, u);
+        return NULL;
+    }
+
+    return m;
+}


### PR DESCRIPTION
The convert_utf8_to_mac() function is based on utompath() which is implemented in etc/afpd/desktop.c but of a simpler, earlier form – we remove two duplicated implementations in nad and dbd respectively

In comparison, utompath() can handle other input charsets than UTF-8, while also doing Mac filename mangling after charset conversion

As a side note, utompath() in etc/afpd/desktop.c cannot easily be moved to libatalk since the mangling logic also sits in the afpd code, and has deep coupling with other afpd logic such as dirlookup(). A much larger refactoring would be needed here.