### PR TITLE
Add SCM provider configuration for SonarQube

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,6 +3,7 @@ sonar.projectKey=Netatalk_netatalk
 sonar.organization=netatalk
 sonar.sources=.
 sonar.sourceEncoding=UTF-8
+sonar.scm.provider=git
 
 # This is the project name and version displayed in the SonarQube Cloud UI
 sonar.projectName=netatalk


### PR DESCRIPTION
The SonarQube Cloud SCM autodetection has started failing, so let's explicitly set it to git