### PR TITLE
libatalk: Simplify error logging on parameter error in cnid_mysql_find()

### DIFF
--- a/libatalk/cnid/mysql/cnid_mysql.c
+++ b/libatalk/cnid/mysql/cnid_mysql.c
@@ -815,7 +815,7 @@ int cnid_mysql_find(struct _cnid_db *cdb, const char *name, size_t namelen,
                     void *buffer, size_t buflen)
 {
     EC_INIT;
-    CNID_mysql_private *db;
+    CNID_mysql_private *db = cdb->cnid_db_private;
     char *sql = NULL;
     char *namelike = NULL;
     MYSQL_RES *result = NULL;
@@ -827,9 +827,8 @@ int cnid_mysql_find(struct _cnid_db *cdb, const char *name, size_t namelen,
         "cnid_mysql_find: called with name='%s', namelen=%zu, buflen=%zu", name,
         namelen, buflen);
 
-    if (!cdb || !(db = cdb->cnid_db_private) || !name) {
-        LOG(log_error, logtype_cnid,
-            "cnid_mysql_find: Parameter error (cdb=%p, db=%p, name=%p)", cdb, db, name);
+    if (!cdb || !db || !name) {
+        LOG(log_error, logtype_cnid, "cnid_mysql_find: Parameter error");
         errno = CNID_ERR_PARAM;
         EC_FAIL;
     }


### PR DESCRIPTION
Don't log structure values in the case of parameter error to avoid the risk of accessing uninitialized value

Besides, the name is logged in a log entry just before this

Addresses a SonarQube reported uninitialized value access bug

Additionally, remove a side effect in the conditional statement