### PR TITLE
docs: add algorithm prefix to integritry hash for Mermaid script

### DIFF
--- a/doc/header.html
+++ b/doc/header.html
@@ -31,7 +31,7 @@ $extrastylesheet
 <body>
 <script
     src="https://cdn.jsdelivr.net/npm/mermaid@11.12.0/dist/mermaid.min.js"
-    integrity="o+g/BxPwhi0C3RK7oQBxQuNimeafQ3GE/ST4iT2BxVI4Wzt60SH4pq9iXVYujjaS"
+    integrity="sha384-o+g/BxPwhi0C3RK7oQBxQuNimeafQ3GE/ST4iT2BxVI4Wzt60SH4pq9iXVYujjaS"
     crossorigin="anonymous"
 ></script>
 <!--BEGIN FULL_SIDEBAR-->


### PR DESCRIPTION
The sha384 prefix is needed to specify the algorithm for the integrity hash for the javascript library that we load for the Doxygen docs

This resolves a validator.nu html5 validation error