### PR TITLE
GitHub CI: use job level permissions consistently

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,6 @@ on:
       - "**/README*"
       - "COPYRIGHT"
 
-permissions: read-all
-
 jobs:
   build-alpine:
     name: Alpine Linux

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -13,8 +13,6 @@ on:
       - synchronize
       - reopened
 
-permissions: read-all
-
 jobs:
   static_analysis:
     name: SonarQube Static Analysis

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -19,7 +19,6 @@ on:
       - "contrib/webmin_module/**"
       - "COPYRIGHT"
 
-permissions: read-all
 env:
   REGISTRY: ghcr.io
   REPO: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ on:
         required: true
         type: string
 
-permissions: read-all
-
 env:
   GHCR_REGISTRY: ghcr.io
   REPO: ${{ github.repository }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,8 +6,6 @@ on:
   push:
     branches: ["main"]
 
-permissions: read-all
-
 jobs:
   analysis:
     name: Scorecard analysis

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -6,13 +6,7 @@ on:
       - '.github/workflows/static.yml'
       - 'doc/**'
       - 'meson.build'
-
   workflow_dispatch:
-
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: "pages"
@@ -24,6 +18,10 @@ jobs:
       name: html-manual
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     container:
       image: debian:trixie
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ on:
       - synchronize
       - reopened
 
-permissions: read-all
-
 jobs:
   formatting:
     name: Code Formatting


### PR DESCRIPTION
remove superfluous global permissions and move a handful to the job level

tightening up permissions makes for a safer default state for all jobs