### PR TITLE
nad: protect against potential memory leak in xgetcwd()

### DIFF
--- a/bin/nad/ftw.c
+++ b/bin/nad/ftw.c
@@ -249,11 +249,26 @@ static char *xgetcwd(void)
     path_max = (unsigned) PATH_MAX;
     path_max += 2;        /* The getcwd docs say to do this. */
     cwd = malloc(path_max);
+
+    if (cwd == NULL) {
+        return NULL;
+    }
+
     errno = 0;
 
     while ((ret = getcwd(cwd, path_max)) == NULL && errno == ERANGE) {
+        char *new_cwd;
         path_max += 512;
-        cwd = realloc(cwd, path_max);
+        new_cwd = realloc(cwd, path_max);
+
+        if (new_cwd == NULL) {
+            int save_errno = errno;
+            free(cwd);
+            errno = save_errno;
+            return NULL;
+        }
+
+        cwd = new_cwd;
         errno = 0;
     }
 


### PR DESCRIPTION
this adds handling of errors in malloc and realloc, which could potentially lead to NULL pointer being returned