### PR TITLE
GitHub CI: top level permissions is contents:read for all jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,9 @@ on:
       - "**/README*"
       - "COPYRIGHT"
 
+permissions:
+  contents: read
+
 jobs:
   build-alpine:
     name: Alpine Linux

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -13,6 +13,9 @@ on:
       - synchronize
       - reopened
 
+permissions:
+  contents: read
+
 jobs:
   static_analysis:
     name: SonarQube Static Analysis

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -19,6 +19,9 @@ on:
       - "contrib/webmin_module/**"
       - "COPYRIGHT"
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   REPO: ${{ github.repository }}
@@ -32,7 +35,6 @@ jobs:
     timeout-minutes: 5
     if: ${{ !github.event.pull_request.head.repo.fork }}
     permissions:
-      contents: read
       packages: write
     steps:
       - name: Checkout repo
@@ -67,7 +69,6 @@ jobs:
     timeout-minutes: 5
     if: ${{ !github.event.pull_request.head.repo.fork }}
     permissions:
-      contents: read
       packages: write
     steps:
       - name: Checkout repo
@@ -102,7 +103,6 @@ jobs:
     timeout-minutes: 5
     if: ${{ !github.event.pull_request.head.repo.fork }}
     permissions:
-      contents: read
       packages: write
     steps:
       - name: Checkout repo
@@ -137,7 +137,6 @@ jobs:
     timeout-minutes: 5
     if: ${{ !github.event.pull_request.head.repo.fork }}
     permissions:
-      contents: read
       packages: write
     steps:
       - name: Checkout repo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   GHCR_REGISTRY: ghcr.io
   REPO: ${{ github.repository }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   analysis:
     name: Scorecard analysis

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -8,6 +8,9 @@ on:
       - 'meson.build'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: "pages"
   cancel-in-progress: false
@@ -19,7 +22,6 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       pages: write
       id-token: write
     container:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,9 @@ on:
       - synchronize
       - reopened
 
+permissions:
+  contents: read
+
 jobs:
   formatting:
     name: Code Formatting


### PR DESCRIPTION
We previously had top level "read-all" permissions for all workflows, which were removed in an recent commit.

However upon careful consideration, it's arguably preferable to have an explicit top level permissions configuration rather than relying on GitHub's implicit defaults (which may change over time.)

Therefore, I suggest we bring back a more restrictive "contents:read" top level permission for all workflows.

As a side note, SonarQube introduced a restrictive new rule on December 22nd 2025 which forbade all top level permissions in GitHub workflows. I argue this is overzealous so I disabled this rule in our quality configuration.