### PR TITLE
GitHub CI: remove NetBSD packages with dbus dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -539,24 +539,18 @@ jobs:
           prepare: |
             export PKG_PATH="http://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f '1 2' -d.)/All"
             pkg_add \
-              bison \
               cmark \
               db5 \
-              flex \
               gcc13 \
-              gnome-tracker \
               heimdal \
               iniparser \
-              libcups \
               libevent \
               libgcrypt \
               meson \
               mysql-client \
-              p5-Net-DBus \
               perl \
               pkg-config \
-              sqlite3 \
-              talloc
+              sqlite3
           run: |
             set -e
             meson setup build \


### PR DESCRIPTION
The dependency tree for dbus in NetBSD 10 is broken currently, which means that gnome-tracker and libcups cannot be installed

I've been told that dbus support in NetBSD is an afterthought; the downstream pkgsrc packaging doesn't these use dependencies either

https://cvsweb.netbsd.org/bsdweb.cgi/pkgsrc/net/netatalk4/

For simplicity's sake, let's stop building with Spotlight and CUPS support altogether on this platform