### PR TITLE
config: overhaul daemon configuration file comments

### DIFF
--- a/config/afp.conf.in
+++ b/config/afp.conf.in
@@ -1,5 +1,7 @@
 ;
-; Netatalk 4.x configuration file
+; Netatalk AFP file server configuration file
+;
+; See the `afp.conf' manual page for all available options
 ;
 
 [Global]

--- a/config/atalkd.conf
+++ b/config/atalkd.conf
@@ -1,3 +1,8 @@
-# AppleTalk daemon configuration (netatalk 4.x)
 #
-# See the `atalkd.conf' manual page for examples.
+# AppleTalk daemon (atalkd) configuration file
+# Part of the Netatalk suite
+#
+# Leave this file empty to allow atalkd to detect and configure
+# AppleTalk interfaces automatically
+#
+# See the `atalkd.conf' manual page for all available options

--- a/config/macipgw.conf
+++ b/config/macipgw.conf
@@ -1,6 +1,9 @@
-; MacIP Gateway daemon configuration (netatalk 4.x)
+;
+; MacIP Gateway daemon (macipgw) configuration file
+; Part of the Netatalk suite
 ;
 ; See the `macipgw.conf' manual page for all available options
+;
 
 [Global]
 ; network = 192.168.151.0

--- a/config/papd.conf
+++ b/config/papd.conf
@@ -1,6 +1,8 @@
-# PAP print server daemon configuration (Netatalk 4.x)
 #
-# See the `papd.conf' manual page for examples.
+# PAP print server daemon (papd) configuration file
+# Part of the Netatalk suite
+#
+# See the `papd.conf' manual page for all available options
 
-# Uncomment the following line to share all CUPS enabled printers.
+# Uncomment the following line to share all CUPS enabled printers
 # cupsautoadd:op=root:


### PR DESCRIPTION
Tweak the config file comment headers of all daemons in the Netatalk suite to clarify context and basic usage