### PR TITLE
webmin: consistently refer to Netatalk as an AFP File Server

### DIFF
--- a/contrib/webmin_module/help/configs.html
+++ b/contrib/webmin_module/help/configs.html
@@ -1,6 +1,6 @@
 <header>Netatalk Help</header>
 
-<p>For general information on how to configure and operate Netatalk, refer to the <a href="https://netatalk.io/manual/en/">Netatalk Manual</a>.</p>
+<p>For general information on how to configure and operate the AFP File Server, refer to the <a href="https://netatalk.io/manual/en/">Netatalk Manual</a>.</p>
 
 <p>The Server and Volume options are explained in the <a href="https://netatalk.io/manual/en/afp.conf.5">afp.conf manual page</a>.</p>
 

--- a/contrib/webmin_module/lang/en
+++ b/contrib/webmin_module/lang/en
@@ -13,7 +13,7 @@ errmsg_parameter_error=Parameter error: Illegal value for parameter '$1'.
 errmsg_title=Error
 
 index_root=Webmin Home
-index_title=Netatalk AFP Server
+index_title=Netatalk AFP File Server
 index_version=Version $1
 index_ever=The $1 program was not found on your system. Either Netatalk is not installed, or your <a href='$2'> module configuration</a> is incorrect.
 

--- a/contrib/webmin_module/module.info.in
+++ b/contrib/webmin_module/module.info.in
@@ -1,5 +1,5 @@
 name=Netatalk Manager
 category=servers
 os_support=macos solaris *-linux freebsd openbsd netbsd
-desc=Netatalk Mac File Sharing
+desc=Netatalk AFP File Server
 version=@netatalk_version@


### PR DESCRIPTION
Consistently refer to Netatalk as an AFP File Server, to emphasize standards compliance and cross-platform support