### PR TITLE
testsuite: cleanup of DSI struct pointers in test functions

### DIFF
--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -545,7 +545,7 @@ STATIC void test410()
     uint16_t vol = VolID;
     uint16_t bitmap = 0;
     uint16_t vol2;
-    DSI *dsi2;
+    const DSI *dsi2;
     int type = OPENFORK_DATA;
     ENTER_TEST
 
@@ -634,10 +634,9 @@ static int create_trash(CONN *conn, uint16_t vol)
     uint16_t bitmap = DIRPBIT_ATTR | (1 << DIRPBIT_FINFO) | (1 << DIRPBIT_CDATE) |
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS);
-    DSI *dsi;
+    const DSI *dsi = &conn->dsi;
     int dir;
     struct afp_filedir_parms filedir;
-    dsi = &conn->dsi;
     dir  = FPCreateDir(conn, vol, DIRDID_ROOT, trash);
 
     if (!dir) {
@@ -675,11 +674,10 @@ static int create_trash(CONN *conn, uint16_t vol)
 /* ------------------- */
 static int create_map(CONN *conn, uint16_t vol, int dir, char *name)
 {
-    DSI *dsi;
+    const DSI *dsi = &conn->dsi;
     struct afp_filedir_parms filedir;
     int  ofs =  3 * sizeof(uint16_t);
     int fork;
-    dsi = &conn->dsi;
 
     if (FPCreateFile(conn, vol, 0, dir, name)) {
         return 0;
@@ -709,9 +707,8 @@ static int set_perm(CONN *conn, uint16_t vol, int dir)
     uint16_t bitmap = DIRPBIT_ATTR | (1 << DIRPBIT_FINFO) | (1 << DIRPBIT_CDATE) |
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS);
-    DSI *dsi;
+    const DSI *dsi = &conn->dsi;
     struct afp_filedir_parms filedir;
-    dsi = &conn->dsi;
 
     if (FPGetFileDirParams(conn, vol, dir, "", 0, bitmap)) {
         return 0;
@@ -744,9 +741,8 @@ static int write_access(CONN *conn, uint16_t  vol, int dir)
     uint16_t bitmap = DIRPBIT_ATTR | (1 << DIRPBIT_FINFO) | (1 << DIRPBIT_CDATE) |
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS);
-    DSI *dsi;
+    const DSI *dsi = &conn->dsi;
     struct afp_filedir_parms filedir;
-    dsi = &conn->dsi;
 
     if (FPGetFileDirParams(conn, vol, dir, "", 0, bitmap)) {
         return 0;

--- a/test/testsuite/FPCatSearch.c
+++ b/test/testsuite/FPCatSearch.c
@@ -11,14 +11,13 @@ STATIC void test225()
     char *name = "t225 file.txt";
     uint16_t vol = VolID;
     uint32_t temp;
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     char pos[16];
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     struct afp_filedir_parms filedir2;
     unsigned int ret;
     ENTER_TEST
-    dsi = &Conn->dsi;
 
     if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
         test_nottested();

--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -188,7 +188,7 @@ static void test_meta(char *name, char *name1, uint16_t vol2)
     int tp, tp1;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t bitmap;
     char finder_info[32];
 
@@ -275,7 +275,7 @@ STATIC void test332()
     int tp, tp1;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t bitmap;
     uint32_t mdate = 0;
     ENTER_TEST
@@ -459,8 +459,7 @@ STATIC void test401()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
     int fork;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
@@ -561,8 +560,7 @@ STATIC void test402()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
     int fork;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
@@ -654,8 +652,7 @@ STATIC void test403()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
@@ -744,8 +741,6 @@ STATIC void test406()
     char *name1 = "new ducky.tif";
     uint16_t vol = VolID;
     uint16_t bitmap = 0;
-    DSI *dsi;
-    dsi = &Conn->dsi;
     ENTER_TEST
     bitmap = (1 <<  FILPBIT_PDINFO) | (1 << FILPBIT_PDID) | (1 << FILPBIT_FNUM) |
              (1 << FILPBIT_ATTR);

--- a/test/testsuite/FPCreateDir.c
+++ b/test/testsuite/FPCreateDir.c
@@ -340,8 +340,8 @@ STATIC void test357()
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID);
     uint16_t vol2;
-    DSI *dsi;
-    DSI *dsi2;
+    const DSI *dsi;
+    const DSI *dsi2;
     unsigned int ret;
     ENTER_TEST
 

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -149,9 +149,8 @@ STATIC void test172()
     int dir = 0;
     unsigned int ret;
     uint16_t vol = VolID;
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     int dt;
-    dsi = &Conn->dsi;
     ENTER_TEST
     memset(&filedir, 0, sizeof(filedir));
     tdir  = FPCreateDir(Conn, vol, DIRDID_ROOT, tname);
@@ -323,7 +322,7 @@ STATIC void test196()
     int tdir1 = 0;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t bitmap = (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) |
                       (1 << DIRPBIT_DID) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS);
@@ -510,7 +509,7 @@ STATIC void test421()
     int tdir;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t bitmap = (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) |
                       (1 << DIRPBIT_DID) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS);

--- a/test/testsuite/FPFlushFork.c
+++ b/test/testsuite/FPFlushFork.c
@@ -13,7 +13,7 @@ STATIC void test203()
     int fork = 0;
     char *name = "t203 file";
     uint32_t mdate;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -167,9 +167,8 @@ STATIC void test94()
     uint16_t vol = VolID;
     uint16_t bitmap = (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_MDATE) |
                       (1 << DIRPBIT_OFFCNT);
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     int offcnt;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name))) {
@@ -266,8 +265,7 @@ STATIC void test104()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     uint16_t vol = VolID;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir1 = FPCreateDir(Conn, vol, DIRDID_ROOT, name1))) {
@@ -531,13 +529,12 @@ STATIC void test307()
 {
     char *name = "t307 dir#2";
     uint16_t vol = VolID;
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
     unsigned int dir;
     char *result;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name))) {
@@ -582,13 +579,12 @@ STATIC void test308()
 {
     char *name = "t308 dir";
     uint16_t vol = VolID;
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
     unsigned int dir;
     char *result;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Conn->afp_version >= 30) {
@@ -944,7 +940,7 @@ STATIC void test371()
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t bitmap;
     ENTER_TEST
 
@@ -1010,7 +1006,7 @@ STATIC void test380()
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t bitmap;
     uint16_t bitmap1 = (1 << FILPBIT_ATTR) | (1 << FILPBIT_FINFO) |
                        (1 << FILPBIT_CDATE) |
@@ -1072,13 +1068,12 @@ STATIC void test396()
 {
     char *name = "t396 dir";
     uint16_t vol = VolID;
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t f_bitmap = 0x73f;
     uint16_t d_bitmap = 0x133f;
     unsigned int dir;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name))) {
@@ -1122,7 +1117,7 @@ STATIC void test423()
     struct afp_filedir_parms filedir;
     int fid = 0;
     uint16_t fork = 0;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name1))) {
@@ -1193,7 +1188,7 @@ static void do_pdinfo_test(char *fname, const char *fourcc, uint8_t expect_type,
     uint16_t bitmap_finfo = (1 << FILPBIT_FINFO);
     uint16_t bitmap_pdinfo = (1 << FILPBIT_PDINFO);
     int ofs = 3 * sizeof(uint16_t);
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     struct afp_filedir_parms filedir;
     const unsigned char *buf;
     uint8_t prodos_type;
@@ -1270,7 +1265,7 @@ STATIC void test441()
     uint16_t bitmap_finfo = (1 << FILPBIT_FINFO);
     uint16_t bitmap_pdinfo = (1 << FILPBIT_PDINFO);
     int ofs = 3 * sizeof(uint16_t);
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     struct afp_filedir_parms filedir;
     const unsigned char *buf;
     uint8_t prodos_type;

--- a/test/testsuite/FPGetUserInfo.c
+++ b/test/testsuite/FPGetUserInfo.c
@@ -15,7 +15,7 @@ STATIC void test75()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = (1 << DIRPBIT_UID) | (1 << DIRPBIT_GID);
     uint16_t vol = VolID;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name))) {

--- a/test/testsuite/FPMapID.c
+++ b/test/testsuite/FPMapID.c
@@ -16,7 +16,7 @@ STATIC void test208()
                       (1 << DIRPBIT_GID) ;
     unsigned int ret;
     uint16_t vol = VolID;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name))) {

--- a/test/testsuite/FPMoveAndRename.c
+++ b/test/testsuite/FPMoveAndRename.c
@@ -268,8 +268,7 @@ STATIC void test138()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = (1 << DIRPBIT_ACCESS);
     uint16_t vol = VolID;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name1))) {

--- a/test/testsuite/FPOpenFork.c
+++ b/test/testsuite/FPOpenFork.c
@@ -4,9 +4,7 @@
 #include "afphelper.h"
 #include "testhelper.h"
 
-/* --------------------------
-FIXME
-*/
+/* -------------------------- */
 STATIC void test14()
 {
     uint16_t bitmap = 0;
@@ -623,8 +621,7 @@ STATIC void test116()
     uint16_t bitmap = (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_MDATE);
     int fork;
     uint16_t vol = VolID;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
@@ -862,15 +859,12 @@ static void test_openmode(char *name, int type)
     int fork1;
     uint16_t bitmap = (1 << FILPBIT_ATTR) | (1 << FILPBIT_FINFO);
     uint16_t vol = VolID;
-    DSI *dsi;
-    DSI *dsi2;
+    const DSI *dsi2 = &Conn2->dsi;
     uint16_t vol2;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     int what   = (type == OPENFORK_DATA) ? ATTRBIT_DOPEN : ATTRBIT_ROPEN;
     int nowhat = (type == OPENFORK_DATA) ? ATTRBIT_ROPEN : ATTRBIT_DOPEN;
-    dsi = &Conn->dsi;
-    dsi2 = &Conn2->dsi;
     vol2  = FPOpenVol(Conn2, Vol);
 
     if (vol2 == 0xffff) {

--- a/test/testsuite/FPRename.c
+++ b/test/testsuite/FPRename.c
@@ -48,8 +48,7 @@ STATIC void test72()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t vol = VolID;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name2))) {
@@ -110,10 +109,10 @@ static int create_double_deleted_folder(uint16_t vol, char *name)
     uint16_t vol2;
     int tdir;
     int tdir1 = 0;
-    DSI *dsi2;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
+    const DSI *dsi2;
     uint16_t bitmap;
     int tp, tp1;
     tdir  = FPCreateDir(Conn, vol, DIRDID_ROOT, name);

--- a/test/testsuite/FPResolveID.c
+++ b/test/testsuite/FPResolveID.c
@@ -14,8 +14,7 @@ STATIC void test76()
     uint16_t bitmap = (1 << FILPBIT_FNUM);
     struct afp_filedir_parms filedir;
     uint16_t vol = VolID;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
@@ -59,8 +58,7 @@ STATIC void test91()
     struct afp_filedir_parms filedir;
     unsigned int ret;
     uint16_t vol = VolID;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID)) {
@@ -129,8 +127,7 @@ STATIC void test310()
     uint16_t bitmap = (1 << FILPBIT_FNUM);
     struct afp_filedir_parms filedir;
     uint16_t vol = VolID;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID)) {
@@ -169,8 +166,7 @@ STATIC void test311()
     uint16_t bitmap = 0x693f;
     struct afp_filedir_parms filedir;
     uint16_t vol = VolID;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -208,14 +204,14 @@ STATIC void test362()
 {
     int  dir;
     uint16_t vol = VolID;
+    uint16_t vol2;
     char *name = "t362 Resolve ID file";
     char *name1 = "t362 Resolve ID dir";
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM);
     struct afp_filedir_parms filedir = { 0 };
-    DSI *dsi = &Conn->dsi;
-    uint16_t vol2;
-    DSI *dsi2;
+    const DSI *dsi = &Conn->dsi;
+    const DSI *dsi2;
     ENTER_TEST
 
     if (!Conn2) {
@@ -273,7 +269,7 @@ STATIC void test417()
     uint16_t bitmap = (1 << FILPBIT_FNUM) | (1 << DIRPBIT_FINFO);
     struct afp_filedir_parms filedir;
     int fid = 0;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name1))) {

--- a/test/testsuite/FPSetDirParms.c
+++ b/test/testsuite/FPSetDirParms.c
@@ -16,8 +16,7 @@ STATIC void test82()
                       | (1 << DIRPBIT_ACCESS) | (1 << DIRPBIT_FINFO) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID) ;
     uint16_t vol = VolID;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name))) {
@@ -71,8 +70,7 @@ STATIC void test84()
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID);
     uint16_t vol = VolID;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name))) {
@@ -119,9 +117,8 @@ STATIC void test88()
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS);
     uint16_t vol = VolID;
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     unsigned int ret;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!Conn2) {
@@ -212,13 +209,11 @@ STATIC void test107()
                       (1 << DIRPBIT_GID) ;
     uint16_t bitmap2 = (1 << DIRPBIT_ACCESS) | (1 << DIRPBIT_UID) |
                        (1 << DIRPBIT_GID) ;
-    uint16_t vol2;
     int uid;
     int ret;
     uint16_t vol = VolID;
-    DSI *dsi;
-    DSI *dsi2;
-    dsi = &Conn->dsi;
+    uint16_t vol2;
+    const DSI *dsi2;
     ENTER_TEST
 
     if (!Conn2) {
@@ -319,8 +314,7 @@ STATIC void test189()
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS);
     uint16_t vol = VolID;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name))) {
@@ -359,9 +353,8 @@ STATIC void test193()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = (1 << DIRPBIT_ACCESS);
     uint16_t vol = VolID;
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     int ret;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name))) {
@@ -401,8 +394,7 @@ STATIC void test351()
     uint16_t bitmap = 0;
     uint8_t old_access[4];
     int ret;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, ndir))) {
@@ -469,8 +461,7 @@ STATIC void test352()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
     uint8_t old_access[4];
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(dir = FPCreateDir(Conn, vol, DIRDID_ROOT, ndir))) {
@@ -531,8 +522,7 @@ STATIC void test353()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV) {
@@ -621,8 +611,7 @@ STATIC void test354()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
@@ -690,8 +679,7 @@ STATIC void test355()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
@@ -765,8 +753,7 @@ STATIC void test356()
     uint16_t bitmap = 0;
     int old_unixpriv;
     int ret;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
@@ -889,8 +876,7 @@ STATIC void test405()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {

--- a/test/testsuite/FPSetFileDirParms.c
+++ b/test/testsuite/FPSetFileDirParms.c
@@ -22,8 +22,7 @@ STATIC void test98()
                       | (1 << DIRPBIT_UID) | (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS)
                       | (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE);
     uint16_t vol = VolID;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!Conn2) {
@@ -110,8 +109,7 @@ STATIC void test230()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
     int fork;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -248,14 +246,13 @@ STATIC void test231()
     char *name = "t231 file";
     char *name1 = "t231 file user 2";
     char *ndir = "t231 dir";
-    uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
+    uint16_t vol = VolID;
     uint16_t vol2;
-    DSI *dsi2;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
+    const DSI *dsi2;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -369,8 +366,7 @@ STATIC void test232()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!Conn2) {
@@ -438,8 +434,7 @@ STATIC void test345()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
     int fork;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
@@ -523,8 +518,7 @@ STATIC void test346()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
@@ -584,8 +578,7 @@ STATIC void test347()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV) {
@@ -674,8 +667,7 @@ STATIC void test348()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
@@ -743,8 +735,7 @@ STATIC void test349()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
@@ -818,8 +809,7 @@ STATIC void test350()
     uint16_t bitmap = 0;
     int old_unixpriv;
     int ret;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
@@ -889,18 +879,17 @@ STATIC void test358()
     char *name = "t358 file";
     char *name1 = "t358 file user 2";
     char *ndir = "t358 dir";
-    uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
+    uint16_t vol = VolID;
     uint16_t vol2;
     uint8_t old_access[4];
-    DSI *dsi2;
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
+    const DSI *dsi2;
     int maxattempts = 10;
     int attempt = 0;
     int ret;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Bigendian) {
@@ -995,8 +984,7 @@ STATIC void test359()
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
     int ret;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
@@ -1081,15 +1069,14 @@ STATIC void test361()
     int  dir = 0;
     char *name = "t361 file.pdf";
     char *ndir = "t361 dir";
-    uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
     int ret;
-    DSI *dsi;
-    DSI *dsi2;
+    uint16_t vol = VolID;
     uint16_t vol2;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
+    const DSI *dsi2;
     ENTER_TEST
 
     if (!Conn2) {
@@ -1191,8 +1178,7 @@ STATIC void test400()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {

--- a/test/testsuite/FPSync.c
+++ b/test/testsuite/FPSync.c
@@ -7,11 +7,10 @@
 STATIC void test2()
 {
     uint16_t vol = VolID;
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     char *name = "t2 sync dir";
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (FPSyncDir(Conn, vol, DIRDID_ROOT)) {

--- a/test/testsuite/T2_Dircache_attack.c
+++ b/test/testsuite/T2_Dircache_attack.c
@@ -125,7 +125,7 @@
 /*! move and rename dir, enumerate new parent, stat renamed dir */
 STATIC void test500()
 {
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t vol1 = VolID;
     uint16_t vol2;
     char *dir = "t500 dir";
@@ -199,7 +199,7 @@ test_exit:
 /*! move and rename dir, then stat it */
 STATIC void test501()
 {
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t vol1 = VolID;
     uint16_t vol2;
     char *dir = "t501 dir";
@@ -270,7 +270,7 @@ test_exit:
 /*! move and rename dir, enumerate renamed dir */
 STATIC void test502()
 {
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t vol1 = VolID;
     uint16_t vol2;
     char *dir = "t502 dir";
@@ -347,7 +347,7 @@ test_exit:
 /*! move and rename dir, stat renamed dir */
 STATIC void test503()
 {
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t vol1 = VolID;
     uint16_t vol2;
     char *dir = "t503 dir";
@@ -418,7 +418,7 @@ test_exit:
 /*! rename topdir, stat file in subdir of renamed topdir */
 STATIC void test504()
 {
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t vol1 = VolID;
     uint16_t vol2;
     char *dir = "t504 dir";
@@ -488,7 +488,7 @@ test_exit:
 /*! rename dir, stat subdir in renamed dir */
 STATIC void test505()
 {
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t vol1 = VolID;
     uint16_t vol2;
     char *dir = "t505 dir";
@@ -560,7 +560,7 @@ test_exit:
 /*! stat subdir in poisened path */
 STATIC void test506()
 {
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t vol1 = VolID;
     uint16_t vol2;
     char *dir = "t506 dir";

--- a/test/testsuite/T2_FPCopyFile.c
+++ b/test/testsuite/T2_FPCopyFile.c
@@ -14,7 +14,7 @@ STATIC void test373()
     int tp, tp1;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     uint16_t bitmap;
     uint32_t mdate = 0;
     ENTER_TEST

--- a/test/testsuite/T2_FPDelete.c
+++ b/test/testsuite/T2_FPDelete.c
@@ -18,10 +18,10 @@ STATIC void test146()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     uint16_t bitmap = (1 << DIRPBIT_ACCESS);
-    uint16_t vol2;
     uint16_t vol = VolID;
-    DSI *dsi = &Conn->dsi;
-    DSI *dsi2;
+    uint16_t vol2;
+    const DSI *dsi = &Conn->dsi;
+    const DSI *dsi2;
     int ret;
     ENTER_TEST
 
@@ -151,7 +151,7 @@ STATIC void test507()
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM);
     struct afp_filedir_parms filedir = { 0 };
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Path[0] == '\0') {
@@ -194,7 +194,7 @@ STATIC void test363()
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM);
     struct afp_filedir_parms filedir;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     int fork;
     ENTER_TEST
 
@@ -270,7 +270,7 @@ STATIC void test364()
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM);
     struct afp_filedir_parms filedir;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Path[0] == '\0') {

--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -363,7 +363,7 @@ STATIC void test106()
     char *name5 = "t104 file";
     char *name6 = "t104 dir2_1";
     uint16_t vol = VolID;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     unsigned int dir1 = 0;
     unsigned int dir2 = 0;
     unsigned int dir3 = 0;
@@ -770,16 +770,15 @@ STATIC void test336()
     char *name = "t336 very long dirname (more than 31 bytes)";
     char *ndir = "t336 dir";
     uint16_t vol = VolID;
-    DSI *dsi;
+    uint16_t vol2;
+    const DSI *dsi = &Conn->dsi;
+    const DSI *dsi2;
     unsigned int  dir;
     uint16_t bitmap = 0;
     int ret;
     int id;
-    uint16_t vol2;
-    DSI *dsi2;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (!Conn2) {
@@ -1028,7 +1027,7 @@ STATIC void test420()
     struct afp_filedir_parms filedir;
     int fid = 0;
     uint16_t fork = 0;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Path[0] == '\0') {

--- a/test/testsuite/T2_FPResolveID.c
+++ b/test/testsuite/T2_FPResolveID.c
@@ -22,7 +22,7 @@ STATIC void test129()
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM);
     struct afp_filedir_parms filedir = { 0 };
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Path[0] == '\0') {
@@ -89,7 +89,7 @@ STATIC void test130()
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM);
     struct afp_filedir_parms filedir = { 0 };
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     int ret;
     ENTER_TEST
 
@@ -162,7 +162,7 @@ STATIC void test131()
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM);
     struct afp_filedir_parms filedir = { 0 };
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Path[0] == '\0') {
@@ -232,7 +232,7 @@ STATIC void test331()
     uint16_t bitmap = (1 << FILPBIT_FNUM) | (1 << DIRPBIT_FINFO);
     struct afp_filedir_parms filedir = { 0 };
     int fid = 0;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Path[0] == '\0') {
@@ -394,7 +394,7 @@ STATIC void test360()
     struct afp_filedir_parms filedir = { 0 };
     int fid = 0;
     int fork = 0;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Path[0] == '\0') {
@@ -514,7 +514,7 @@ STATIC void test397()
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM);
     struct afp_filedir_parms filedir = { 0 };
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Path[0] == '\0') {
@@ -572,7 +572,7 @@ STATIC void test412()
     uint16_t bitmap = (1 << FILPBIT_FNUM) | (1 << DIRPBIT_FINFO);
     struct afp_filedir_parms filedir = { 0 };
     int fid = 0;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Path[0] == '\0') {
@@ -674,7 +674,7 @@ STATIC void test413()
     uint16_t bitmap = (1 << FILPBIT_FNUM) | (1 << DIRPBIT_FINFO);
     struct afp_filedir_parms filedir = { 0 };
     int fid = 0;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Path[0] == '\0') {
@@ -780,7 +780,7 @@ STATIC void test418()
     struct afp_filedir_parms filedir = { 0 };
     int fid1 = 0;
     int fid2 = 0;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Path[0] == '\0') {

--- a/test/testsuite/Utf8.c
+++ b/test/testsuite/Utf8.c
@@ -12,7 +12,7 @@ STATIC void test162()
     char ndir[4];
     int dir;
     uint16_t vol = VolID;
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -113,7 +113,7 @@ STATIC void test167()
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir = { 0 };
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Bigendian) {
@@ -350,11 +350,10 @@ STATIC void test234()
 {
     char *name = "t234 file\314\201";
     uint16_t vol = VolID;
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -409,11 +408,10 @@ STATIC void test312()
 {
     char *name = "t312-\xd7\xa4\xd7\xaa\xd7\x99\xd7\x97\xd7\x94.mp3";
     uint16_t vol = VolID;
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -477,10 +475,8 @@ STATIC void test313()
 {
     char *name = "t313-\xd7\xa4\xd7\xaa\xd7\x99\xd7\x97\xd7\x94 dir";
     uint16_t vol = VolID;
-    DSI *dsi;
     int  dir;
     uint16_t bitmap = 0;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -523,9 +519,7 @@ STATIC void test314()
 {
     char *name = "test314#1";
     uint16_t vol = VolID;
-    DSI *dsi;
     uint16_t bitmap = 0;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -561,11 +555,10 @@ STATIC void test337()
 {
     char *name = "\xd7\xa4\xd7\xaa\xd7\x99\xd7\x97\xd7\x94 test 337.mp3";
     uint16_t vol = VolID;
-    DSI *dsi;
+    DSI *dsi = &Conn->dsi;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
-    dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -636,7 +629,7 @@ STATIC void test381()
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir = { 0 };
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Bigendian) {
@@ -698,7 +691,7 @@ STATIC void test382()
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir = { 0 };
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Bigendian) {

--- a/test/testsuite/afparg_FPfuncs.c
+++ b/test/testsuite/afparg_FPfuncs.c
@@ -20,9 +20,8 @@ void FPResolveID_arg(char **argv)
     unsigned int ret, ofs = 3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_PDINFO);
     uint32_t id;
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     struct afp_filedir_parms filedir;
-    dsi = &Conn->dsi;
     fprintf(stdout, "======================\n");
     fprintf(stdout, "FPResolveID with args:\n");
     id = atoi(argv[0]);
@@ -148,13 +147,12 @@ void FPEnumerate_arg(char **argv)
     int dir;
     uint16_t tp;
     uint16_t i;
-    const DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     unsigned char *b;
     struct afp_filedir_parms filedir;
     int *stack = NULL;
     int cnt = 0;
     int size = 1000;
-    dsi = &Conn->dsi;
     f_bitmap = (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) | (1 << FILPBIT_FINFO) |
                (1 << FILPBIT_CDATE) | (1 << FILPBIT_BDATE) | (1 << FILPBIT_MDATE) |
                (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN);

--- a/test/testsuite/encoding_test.c
+++ b/test/testsuite/encoding_test.c
@@ -49,8 +49,7 @@ STATIC void test_western()
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir;
     char *result;
-    DSI *dsi;
-    dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Conn->afp_version >= 30) {


### PR DESCRIPTION
Discard unused variables, use const keyword on immutable variables, assign on the same line as declaration, rearrange variable declaration, remove dead FIXME