### PR TITLE
testsuite: flag immutable pointers as const in test functions

### DIFF
--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -764,9 +764,8 @@ static void test_data(char *name, char *name1, uint16_t vol2)
     struct afp_filedir_parms filedir;
     uint16_t bitmap = 0;
     int fork;
-    DSI *dsi;
+    const DSI *dsi = &Conn->dsi;
     char data[20];
-    dsi = &Conn->dsi;
 
     if (FPCreateFile(Conn, vol, 0, dir, name)) {
         test_nottested();

--- a/test/testsuite/Utf8.c
+++ b/test/testsuite/Utf8.c
@@ -48,7 +48,7 @@ STATIC void test166()
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
     struct afp_filedir_parms filedir = { 0 };
-    DSI *dsi = &Conn->dsi;
+    const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {

--- a/test/testsuite/afparg_FPfuncs.c
+++ b/test/testsuite/afparg_FPfuncs.c
@@ -148,7 +148,7 @@ void FPEnumerate_arg(char **argv)
     uint16_t tp;
     uint16_t i;
     const DSI *dsi = &Conn->dsi;
-    unsigned char *b;
+    const unsigned char *b;
     struct afp_filedir_parms filedir;
     int *stack = NULL;
     int cnt = 0;


### PR DESCRIPTION
A handful of stragglers flagged by SonarQube after the last commit