### PR TITLE
GitHub CI: fix additional bugs in the Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - name: Get version
         id: get_version
         run: |
@@ -157,7 +159,7 @@ jobs:
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
           context: .
-          file: distrib/docker/Dockerfile
+          file: distrib/docker/netatalk.Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm64
           push: true
           labels: ${{ steps.metadata.outputs.labels }}
@@ -171,6 +173,8 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - name: Get version
         id: get_version
         run: |
@@ -257,7 +261,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
         with:
-          file: distrib/docker/Dockerfile
+          file: distrib/docker/netatalk.Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm64
           push: true
           tags: |


### PR DESCRIPTION
consitently check out the release tag for all jobs, not to default to main branch

we renamed the primary container configuration to netatalk.Dockerfile