### PR TITLE
GitHub CI: fix one more bug in the Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Create release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
-          tag_name: ${{ steps.get_version.outputs.tag }}
+          tag_name: ${{ env.RELEASE_TAG }}
           name: Netatalk ${{ steps.get_version.outputs.version }}
           draft: true
           generate_release_notes: true


### PR DESCRIPTION
use the RELEASE_TAG env variable instead of the unreliable steps output data