### PR TITLE
GitHub CI: drop down to FreeBSD v14.3 as the v15.0 repos are broken

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -486,6 +486,7 @@ jobs:
       - name: Build on VM
         uses: vmactions/freebsd-vm@9832a7f21715c1303a1b9e7c00f96508266b4e09 # v1.3.6
         with:
+          release: "14.3"
           copyback: false
           prepare: |
             pkg install -y \


### PR DESCRIPTION
this is a hotfix to unblock the pipeline; this is the error with v15.0, which has been consistent the last 24h:

```
Number of packages to be installed: 255
  
  The process will require 1 GiB more space.
  218 MiB to be downloaded.
  [1/255] Fetching duktape-lib-2.7.0_1~afb127edfc.pkg: ........ done
  [2/255] Fetching freetype2-2.13.3~4797070f64.pkg: .......... done
  pkg: Failed to fetch https://pkg.freebsd.org/FreeBSD:15:amd64/quarterly/All/Hashed/gstreamer1-plugins-resindvd-1.26.8~c201884394.pkg: Not found
  pkg: Failed to fetch https://pkg.freebsd.org/FreeBSD:15:amd64/quarterly/All/Hashed/gstreamer1-plugins-resindvd-1.26.8~c201884394.pkg: Not found
```

the URLs are indeed 404 even in my browser here, filed a bug with the vmactions project, let's see what they say