### PR TITLE
GitHub CI: add a build job on OpenIndiana

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -682,6 +682,74 @@ jobs:
             svcadm disable svc:/network/netatalk:default
             ninja -C build uninstall
 
+  build-openindiana:
+    name: OpenIndiana
+    runs-on: ubuntu-latest
+    if: 0 # pkg install process times out too frequently
+    timeout-minutes: 24
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Build on VM
+        uses: vmactions/openindiana-vm@e90777531e6e6cfc125a2e7e9741b8012cd6a10c # v1.0.1
+        with:
+          copyback: false
+          prepare: |
+            pkg install \
+              archiver/gnu-tar \
+              build/meson \
+              compress/gzip \
+              database/mariadb-114/client \
+              database/mariadb-114/library \
+              database/sqlite-3 \
+              developer/build/cmake \
+              developer/build/meson \
+              developer/build/ninja \
+              developer/build/pkg-config \
+              developer/gcc-14 \
+              library/cmark \
+              library/glib2 \
+              library/libevent2 \
+              library/security/cracklib \
+              runtime/perl \
+              system/library/dbus \
+              system/library/libdbus \
+              system/library/security/libgcrypt \
+              web/curl
+            curl --location -o iniparser.tar.gz \
+              https://gitlab.com/iniparser/iniparser/-/archive/v4.2.6/iniparser-v4.2.6.tar.gz
+            set +e # tar on illumos is too old to handle git tarballs cleanly
+            tar xzf iniparser.tar.gz
+            set -e
+            cd iniparser-v4.2.6
+            mkdir build
+            cd build
+            cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr/local ..
+            make all
+            make install
+          run: |
+            set -e
+            export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
+            meson setup build \
+              -Dbuildtype=release \
+              -Dpkg_config_path=/usr/lib/amd64/pkgconfig \
+              -Dwith-dbus-sysconf-path=/usr/share/dbus-1/system.d \
+              -Dwith-iniparser-path=/usr/local \
+              -Dwith-tests=true \
+              -Dwith-testsuite=true
+            meson compile -C build
+            meson test -C build
+            meson install -C build
+            /usr/local/sbin/netatalk -V
+            /usr/local/sbin/afpd -V
+            sleep 1
+            svcadm enable svc:/network/dns/multicast:default
+            svcadm enable svc:/network/netatalk:default
+            sleep 1
+            /usr/local/bin/asip-status localhost
+            svcadm disable svc:/network/netatalk:default
+            ninja -C build uninstall
+
   build-solaris:
     name: Solaris
     runs-on: ubuntu-latest


### PR DESCRIPTION
The vmactions project has recently added support for OpenIndiana

OpenIndiana is an OS that we have tested on manually in the past, and have build instructions captured in the wiki

However, the OpenIndiana repository servers are too slow to support running this in CI (takes 20+ minutes, and times out frequently) so I'm keeping it disabled for now

Still, might be handy to reactivate temporarily when needed