### PR TITLE
Revert "GitHub CI: drop down to FreeBSD v14.3 as the v15.0 repos are currently broken"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -486,7 +486,6 @@ jobs:
       - name: Build on VM
         uses: vmactions/freebsd-vm@9832a7f21715c1303a1b9e7c00f96508266b4e09 # v1.3.6
         with:
-          release: "14.3"
           copyback: false
           prepare: |
             pkg install -y \


### PR DESCRIPTION
the FreeBSD v15.0 repository has recovered now so we can remove the override