### PR TITLE
docs: revamp AFP Signature/UUID conf man pages

### DIFF
--- a/doc/manpages/man5/afp_signature.conf.5.md
+++ b/doc/manpages/man5/afp_signature.conf.5.md
@@ -17,18 +17,18 @@ characters for a 16-byte server signature.
 All leading spaces and tabs are ignored. Blank lines are ignored. The
 lines prefixed with \# are ignored. Any illegal lines are ignored.
 
-> ***NOTE:*** The server signature is a unique 16-byte identifier used to prevent
+The server signature is a unique 16-byte identifier used to prevent
 users from logging on to the same server twice.
->
-> Netatalk 2.0 and earlier generated a server signature by using
+
+Netatalk 2.0 and earlier generated a server signature by using
 *gethostid()*. This led to a problem where multiple servers could end up with
 the same signature because the hostid is not unique enough.
->
-> Current netatalk generates the signature from random numbers and saves
+
+Current netatalk generates the signature from random numbers and saves
 it into afp_signature.conf upon initial startup. For subsequent starts, it is
 read from this file.
->
-> This file should not be thoughtlessly edited or copied onto another
+
+> ***NOTE:*** This file should not be thoughtlessly edited or copied onto another
 server.
 >
 > If you want to set the signature intentionally, use the option

--- a/doc/manpages/man5/afp_voluuid.conf.5.md
+++ b/doc/manpages/man5/afp_voluuid.conf.5.md
@@ -16,12 +16,13 @@ string representation of a UUID.
 All leading spaces and tabs are ignored. Blank lines are ignored. The
 lines prefixed with \# are ignored. Any illegal lines are ignored.
 
-> ***NOTE:*** This UUID is advertised by Zeroconf in order to provide robust
+This UUID is advertised by Zeroconf in order to provide robust
 disambiguation of Time Machine volumes.
->
-> It is also used by the MySQL CNID backend.
->
-> This file should not be thoughtlessly edited or copied onto another
+
+It is also used by the MySQL and SQLite CNID backends as the name
+of the database table storing the CNID information for the volume.
+
+> ***NOTE:*** This file should not be thoughtlessly edited or copied onto another
 server.
 
 # Examples


### PR DESCRIPTION
move several paragraphs to the top level rather than nesting under NOTE, and call out that the SQLite CNID backend also use the UUID internally