### PR TITLE
cnid: refactor sqlite lookup to a safer two phase logic

### DIFF
--- a/include/atalk/cnid_sqlite_private.h
+++ b/include/atalk/cnid_sqlite_private.h
@@ -12,7 +12,8 @@ typedef struct CNID_sqlite_private {
     sqlite3 *cnid_sqlite_con;
     char *cnid_sqlite_voluuid_str;
     cnid_t cnid_sqlite_hint;
-    sqlite3_stmt *cnid_lookup_stmt;
+    sqlite3_stmt *cnid_lookup_devino_stmt;
+    sqlite3_stmt *cnid_lookup_didname_stmt;
     sqlite3_stmt *cnid_add_stmt;
     sqlite3_stmt *cnid_put_stmt;
     sqlite3_stmt *cnid_get_stmt;


### PR DESCRIPTION
Replaced the ambiguous single OR-clause SQL query in cnid_sqlite_lookup() with two separate queries for (DevNo, InodeNo) and (Did, Name) lookups, matching the dbd daemon's two-index architecture.

This enables clear decision logic with five distinct cases mirroring dbd_lookup.c and eliminates complex duplicate row handling.

Fixed database corruption bug where did=0 could be written during hint-based updates by adding explicit DID validation before calling cnid_sqlite_update(), preventing invalid AFP directory IDs from corrupting the database.

Breakdown of the decision cases:

Case | Condition | Action
-- | -- | --
1 | Neither found | Return NOT FOUND
2 | Both found, IDs match | Return ID ✅
3 | Both found, IDs differ | Delete both, return NOT FOUND
4 | devino only | Check hint → Update if match, else delete
5 | didname only | Delete stale entry, return NOT FOUND

