### PR TITLE
initscripts: netatalk systemd depends on network-online.target

### DIFF
--- a/distrib/initscripts/systemd.netatalk.service.in
+++ b/distrib/initscripts/systemd.netatalk.service.in
@@ -4,7 +4,7 @@
 Description=Netatalk AFP fileserver for Macintosh clients
 Documentation=man:afp.conf(5) man:netatalk(8) man:afpd(8) man:cnid_metad(8) man:cnid_dbd(8)
 Documentation=https://netatalk.io/
-After=network.target avahi-daemon.service atalkd.service
+After=network-online.target avahi-daemon.service atalkd.service
 
 [Service]
 Type=forking


### PR DESCRIPTION
wait for a live network before starting the netatalk systemd service, which aligns with the configuration of all the other services we have

thanks to BarSebastian for the suggestion