### PR TITLE
rephrase descriptions of the netatalk suite to emphasize cross-platform

### DIFF
--- a/distrib/initscripts/freebsd.netatalk.in
+++ b/distrib/initscripts/freebsd.netatalk.in
@@ -31,8 +31,8 @@
 # REQUIRE: DAEMON @freebsd_zeroconf@
 # KEYWORD: shutdown
 #
-# AFP fileserver for Mac clients.  Add the following to /etc/rc.conf to
-# enable:
+# Netatalk AFP fileserver.
+# Add the following to /etc/rc.conf to enable:
 #
 # netatalk_enable="YES"
 #

--- a/distrib/initscripts/netbsd.netatalk.in
+++ b/distrib/initscripts/netbsd.netatalk.in
@@ -3,7 +3,7 @@
 # PROVIDE: netatalk
 # KEYWORD: shutdown
 #
-# AFP fileserver for Macintosh clients (netatalk @netatalk_version@)
+# Netatalk AFP fileserver (netatalk @netatalk_version@)
 
 . /etc/rc.subr
 

--- a/distrib/initscripts/systemd.netatalk.service.in
+++ b/distrib/initscripts/systemd.netatalk.service.in
@@ -1,7 +1,7 @@
 # This file is part of Netatalk @netatalk_version@.
 
 [Unit]
-Description=Netatalk AFP fileserver for Macintosh clients
+Description=Netatalk AFP fileserver
 Documentation=man:afp.conf(5) man:netatalk(8) man:afpd(8) man:cnid_metad(8) man:cnid_dbd(8)
 Documentation=https://netatalk.io/
 After=network-online.target avahi-daemon.service atalkd.service

--- a/doc/developer/dircache.md
+++ b/doc/developer/dircache.md
@@ -88,7 +88,7 @@ When a client browses a Netatalk network folder, here's the actual sequence:
 
 ```mermaid
 sequenceDiagram
-    participant Client as Mac Client
+    participant Client as AFP Client
     participant Netatalk
     participant Disk as Filesystem
     participant PageCache as Page Cache

--- a/doc/manpages/man8/timelord.8.md
+++ b/doc/manpages/man8/timelord.8.md
@@ -1,6 +1,6 @@
 # Name
 
-timelord — Macintosh time server daemon
+timelord — AppleTalk time server daemon
 
 # Synopsis
 
@@ -10,15 +10,17 @@ timelord — Macintosh time server daemon
 
 # Description
 
-**timelord** is a simple time server for Macintosh computers that use the
-*tardis* client. It has the same capabilities as the "Timelord" CDEV for
-Macintosh.
+**timelord** is a simple time server for Macintosh and Apple II computers that use
+a client called *tardis*. It has the same capabilities as the *Timelord* CDEV for
+Macintosh, created at the University of Melbourne.
 
-**tardis** is implemented as a Chooser extension. In the Chooser, choose
-the **timelord** instance to synchronize the Mac's system time with. Once
-synchronized, **tardis** will automatically synchronize with the server at
-boot, or scheduled at regular intervals while the Mac is running (the
-latter requires tardis 1.4).
+The **tardis** client for Macintosh is implemented as a Chooser extension.
+In the Chooser, pick the **timelord** instance to synchronize the Mac's system time with.
+Once synchronized, **tardis** will automatically synchronize with the server at boot,
+or scheduled at regular intervals while the Mac is running (the latter requires tardis 1.4).
+
+A **tardis** client for Apple II computers is also available,
+as part of the MG's DaveX Utilities suite.
 
 # Options
 

--- a/doc/manual/AppleTalk.md
+++ b/doc/manual/AppleTalk.md
@@ -13,17 +13,15 @@ page in the Netatalk wiki for details on how to enable AppleTalk support in your
 ### To use AppleTalk or not
 
 You'll need the AppleTalk support built into Netatalk to provide file
-services to older AFP clients not capable of using AFP over TCP. It also
-enables printing services via PAP by **papd**, a timeserver
-**timelord** for older Mac clients, and NetBoot server **a2boot** for
-Apple II clients.
+services to older AFP clients not capable of using AFP over TCP.
+It also enables printing services via PAP by **papd**,
+a timeserver **timelord** for older Mac or Apple II clients,
+and a network boot server **a2boot** for Apple II clients.
 
-In addition, if you are serving Classic Mac OS clients, you might
-consider using AppleTalk for service propagation/location, having the
-ease of use for your network clients in mind. The Apple engineers
-implemented a way to easily locate an AFP server via AppleTalk but
-establishing the AFP connection itself via AFP over TCP (see the
-developer documentation for details on this cool feature, too).
+In addition, if you are serving Classic Mac OS or Apple II clients,
+you should consider using AppleTalk for service propagation/location.
+The AppleShare client in Mac OS 9, for instance, uses AppleTalk for service discovery,
+while establishing the AFP connection itself via AFP over TCP.
 
 To use the different base AppleTalk protocols with Netatalk, one has to
 use **atalkd**. It can also be used as an AppleTalk router to connect

--- a/doc/manual/Configuration.md
+++ b/doc/manual/Configuration.md
@@ -2,14 +2,11 @@
 
 ## Setting up the AFP file server
 
-AFP (the Apple Filing Protocol) is a protocol used on the Apple Macintosh
-for file services. The protocol has evolved over the years.
-The final revision of the protocol, AFP 3.4, was introduced
-with OS X Lion (10.7).
+AFP (the Apple Filing Protocol) is a protocol originally created for Apple Macintosh file services.
+The final revision of the protocol, AFP 3.4, was introduced with OS X Lion (10.7).
 
-Netatalk's **afpd** daemon offers AFP fileservices to Apple clients. The
-configuration is managed through the *afp.conf* file which uses an ini
-style configuration syntax.
+Netatalk's **afpd** daemon offers AFP fileservices to clients, including Macs, Apple IIs, and other AFP clients.
+The configuration is managed through the *afp.conf* file which uses an ini style configuration syntax.
 
 Netatalk provides compatibility with Time Machine for remote backups,
 and Spotlight for indexed searching.
@@ -410,14 +407,14 @@ accidentally to unauthorized access. In case you must enable guest
 access take care that you enforce this on a per volume base using the
 access controls.
 
-    Note: "No User Authent" is required to use Apple II NetBoot services
+    Note: "No User Authent" is required to use Apple II network boot services
     (**a2boot**) to boot an Apple //e over AFP.
 
 - The "ClearTxt Passwrd" UAM is as bad as it sounds since passwords go
 unencrypted over the wire. Try to avoid it at both the server's side
 as well as on the client's.
 
-    Note: If you want to provide Mac OS 8/9 clients with NetBoot-services
+    Note: If you want to provide Mac OS 8/9 clients with network boot services,
     then you need uams_cleartxt.so since the AFP-client integrated into
     the Mac's firmware can only deal with this basic form of
     authentication.
@@ -480,7 +477,7 @@ that the UAM in question supplies. So think about eliminating weak UAMs like
 
 ### Netatalk UAM overview table
 
-A small overview of the officially supported UAMs.
+A small overview of the officially supported UAMs on Macs.
 
 | UAM              | No User Auth  | Cleartxt Passwrd | RandNum Exchange | DHCAST128    | DHX2          | Kerberos V       |
 |------------------|---------------|------------------|------------------|--------------|---------------|------------------|
@@ -489,6 +486,9 @@ A small overview of the officially supported UAMs.
 | Encryption       | Enables guest access without authentication between client and server. | Password will be sent in cleartext over the wire. Just as bad as it sounds, therefore avoid at all if possible (note: providing NetBoot services requires the ClearTxt UAM) | 8-byte random numbers are sent over the wire, comparable with DES, 56 bits. Vulnerable to offline dictionary attack. Requires passwords in clear on the server. | Password will be encrypted with 128 bit CAST, user will be authenticated against the server but not vice versa. Therefore weak against man-in-the-middle attacks. | Password will be encrypted with 128 bit CAST in CBC mode. User will be authenticated against the server but not vice versa. Therefore weak against man-in-the-middle attacks. | Password is not sent over the network. Due to the service principal detection method, this authentication method is vulnerable to man-in-the-middle attacks. |
 | Server support   | uams_guest.so | uams_cleartxt.so | uams_randnum.so  | uams_dhx.so  | uams_dhx2.so  | uams_gss.so      |
 | Password storage | None          | Either system auth or PAM | Passwords stored in clear text in a separate text file | Either system auth or PAM | Either system auth or PAM | At the Kerberos Key Distribution Center |
+
+Note that there exists a number of open source and other 3rd party AFP clients.
+Refer to their documentation for a list of supported UAMs.
 
 ## ACL Support
 

--- a/doc/manual/index.md
+++ b/doc/manual/index.md
@@ -1,9 +1,13 @@
 # Introduction to Netatalk
 
 Netatalk is an Open Source software package that can be used to turn a
-\*NIX machine into a performant and light-weight file server for
-Macintosh computers. It provides a TCP/IP as well as a traditional
-AppleTalk transport layer.
+\*NIX machine into a performant and light-weight file server.
+Any computer with an AFP client can connect to a Netatalk server.
+AFP clients include macOS, Classic Mac OS, Apple II ProDOS or GS/OS,
+and other operating systems with 3rd party AFP client software.
+
+It provides a modern TCP/IP transport layer, as well as a traditional
+AppleTalk transport layer for very old Mac and Apple II clients.
 
 Using Netatalk's AFP 3.4 compliant file-server leads to noticeably
 higher transmission speeds for macOS clients compared to Samba/NFS,
@@ -18,7 +22,7 @@ such as Bonjour service discovery, Time Machine backups, and Spotlight
 indexed search are provided.
 
 For AppleTalk networks with legacy Macs and Apple IIs, Netatalk provides
-a print server, time server, and Apple II NetBoot server. The print
+a print server, time server, and Apple II network boot server. The print
 server is fully integrated with CUPS, allowing old Macs to discover and
 print to a modern CUPS/AirPrint compatible printer on the network.
 

--- a/etc/afpd/enumerate.c
+++ b/etc/afpd/enumerate.c
@@ -93,7 +93,7 @@ static int enumerate_loop(struct dirent *de, char *mname _U_, void *data)
  * - empty the trash
  *
  * afp_enumerate return an empty listing but offspring count != 0 in afp_getdirparams
- * and the Mac doesn't try to call afp_delete!
+ * and the client doesn't try to call afp_delete!
  *
  * @sa https://sourceforge.net/p/netatalk/bugs/97/
  *

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -503,8 +503,8 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
     memcpy(rbuf, &bitmap, sizeof(uint16_t));
     rbuf += sizeof(uint16_t);
 
-    /* check  WriteInhibit bit if we have a resource fork
-     * the test is done here, after some Mac trafic capture
+    /* check WriteInhibit bit if we have a resource fork
+     * the test is done here, after some client traffic capture
      */
     if (ad_meta_fileno(ofork->of_ad) != -1) {   /* META */
         ad_getattr(ofork->of_ad, &bshort);

--- a/test/testsuite/testhelper.c
+++ b/test/testsuite/testhelper.c
@@ -83,7 +83,7 @@ void test_skipped(int why)
         break;
 
     case T_MAC:
-        s = "needs Mac OS AFP server";
+        s = "not compatible with AppleShare AFP server";
         break;
 
     case T_ACL:


### PR DESCRIPTION
in docs, man pages, and elsewhere, emphasize that this is a cross-platform AFP server that works with Macs, Apple IIs, and 3rd party AFP clients

rephrase verbiage that suggests that Macs are the only AFP clients, or use other less ambiguous terms