### PR TITLE
MySQL CNID Backend: improve charset performance, TCP performance, and test container config

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -252,6 +252,7 @@ jobs:
               -e DISABLE_TIMEMACHINE=1 \
               -e AFP_EXTMAP=1 \
               -e AFP_CNID_SQL_HOST=mariadb \
+              -e AFP_CNID_SQL_USER=root \
               -e AFP_CNID_SQL_PASS="$DB_PASSWD" \
               -e AFP_DIRCACHESIZE=131072 \
               -e AFP_DIRCACHE_VALIDATION_FREQ=100 \
@@ -367,6 +368,7 @@ jobs:
               -e AFP_REMOTE=1 \
               -e AFP_EXTMAP=1 \
               -e AFP_CNID_SQL_HOST=mariadb \
+              -e AFP_CNID_SQL_USER=root \
               -e AFP_CNID_SQL_PASS="$DB_PASSWD" \
               ${{ env.REGISTRY }}/netatalk/netatalk-testsuite-debian:${{ github.sha }}
 

--- a/distrib/docker/DOCKER.md
+++ b/distrib/docker/DOCKER.md
@@ -271,6 +271,9 @@ Set this environment variable to a specific value or string.
 | AFP_DIRCACHE_VALIDATION_FREQ    | The frequency to validate the directory cache                          |
 | AFP_DIRCACHE_METADATA_WINDOW    | The time window (in seconds) for metadata caching                      |
 | AFP_DIRCACHE_METADATA_THRESHOLD | The threshold (in seconds) for metadata caching                        |
+| AFP_MAC_CHARSET                 | Mac client charset (default: MAC_ROMAN); see afp.conf man page         |
+| AFP_UNIX_CHARSET                | Server filesystem charset (default: UTF8); see afp.conf man page       |
+| AFP_VOL_CHARSET                 | Volume charset (default: UTF8); see afp.conf man page                  |
 | TZ                              | The [timezone](https://nodatime.org/TimeZones) to use in the container |
 
 #### Boolean Type

--- a/distrib/docker/testsuite_alp.Dockerfile
+++ b/distrib/docker/testsuite_alp.Dockerfile
@@ -13,6 +13,7 @@ ARG RUN_DEPS="\
     libgcrypt \
     linux-pam \
     localsearch \
+    mariadb \
     mariadb-client \
     mariadb-connector-c \
     openldap \

--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -496,7 +496,12 @@ for most deployments. The default is **localhost:4700**.
 
 cnid mysql host = *MySQL server address* **(G)**
 
-> name or address of a MySQL server for use with the mysql CNID backend.
+> Name or address of a MySQL server for use with the mysql CNID backend.
+>
+> On Unix systems, setting this to **localhost** (or leaving it unset) causes
+> the MySQL client library to prefer Unix socket connections, which offers
+> better performance for a local database. Setting it to **127.0.0.1**
+> forces a TCP connection to the loopback interface.
 
 cnid mysql user = *MySQL user* **(G)**
 
@@ -508,8 +513,9 @@ cnid mysql pw = *password* **(G)**
 
 cnid mysql db = *database name* **(G)**
 
-> Name of an existing database for which the specified user has full
-privileges.
+> Name of the database to use for CNID storage. If the database does not
+> exist, Netatalk will attempt to create it automatically (requires the
+> specified user to have CREATE DATABASE privileges).
 
 cnid server = *ipaddress[:port]* **(G)**/**(V)**
 

--- a/meson.build
+++ b/meson.build
@@ -590,6 +590,10 @@ if 'mysql' in get_option('with-cnid-backends')
         endif
         cnid_backends += 'mysql'
         cdata.set('CNID_BACKEND_MYSQL', 1)
+        # Check for mysql_get_socket() function (added in MySQL 5.7.9 / MariaDB 10.0)
+        if cc.has_function('mysql_get_socket', dependencies: mysql_deps)
+            cdata.set('HAVE_MYSQL_GET_SOCKET', 1)
+        endif
     endif
 endif
 


### PR DESCRIPTION
MySQL CNID Backend: improve charset performance, TCP performance, and test container config

- Enable TCP_NODELAY for MySQL/MariaDB TCP connections to reduce query latency
- Reduce connection/read/write timeouts from 600s to 30s
- Set UTF-8 charset (utf8mb4) at connection time for UTF-8 volumes (avoid repeated dynamic detection overhead)
- Add improved logging for connection info and table creation
- Enhanced Docker entrypoint to support MySQL/MariaDB testing via TCP and Socket
- Add mariadb package to Alpine testsuite Dockerfile
- Update afp.conf documentation for MySQL backend options