### PR TITLE
meson: introduce option to force the building of subprojects

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -667,7 +667,7 @@ has_bgets = cc.compiles(bgets_test_code, name: 'bgets defined in standard C libr
 cdata.set('HAVE_BGETS', has_bgets)
 bstring = dependency('bstring', required: false)
 
-if not bstring.found()
+if not bstring.found() or get_option('with-subprojects')
     bstring_proj = subproject('bstring')
     bstring = bstring_proj.get_variable('bstring_dep')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -178,6 +178,12 @@ option(
     description: 'Create the Netatalk state directories if they do not exist',
 )
 option(
+    'with-subprojects',
+    type: 'boolean',
+    value: false,
+    description: 'Always build subprojects',
+)
+option(
     'with-tcp-wrappers',
     type: 'boolean',
     value: true,


### PR DESCRIPTION
by enabling'-Dwith-subprojects' you make meson fetch the tarballs and build subprojects, even if the dependency was found on the system

this has the side effect that you can build netatalk distribution tarballs with bundled subprojects on any system