### PR TITLE
[4.4] cnid: handle error when attempting to look up did<2 in sqlite backend

### DIFF
--- a/libatalk/cnid/sqlite/cnid_sqlite.c
+++ b/libatalk/cnid/sqlite/cnid_sqlite.c
@@ -498,6 +498,13 @@ cnid_t cnid_sqlite_lookup(struct _cnid_db *cdb, const struct stat *st,
         EC_FAIL;
     }
 
+    if (ntohl(did) < 2) {
+        LOG(log_warning, logtype_cnid,
+            "cnid_sqlite_lookup: not looking up illegal did: %" PRIu32, ntohl(did));
+        errno = CNID_INVALID;
+        EC_FAIL;
+    }
+
     strlcpy(stmt_param_name, name, sizeof(stmt_param_name));
     stmt_param_name_len = len;
     stmt_param_did = ntohl(did);


### PR DESCRIPTION
in rare cases, the cnid_sqlite_lookup() gets called with did=0 which is then treated as a failed lookup and triggers the database repair logic which may lead to database corruption

rather than running the database lookup we check for did<2, log a warning and exit with CNID_INVALID

this is a hotfix for the stable release branch; in the development version we plan to refactor database repair logic to be more sturdy