### PR TITLE
GitHub CI: bump Arch, Alpine, Debian, Fedora to the latest image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 24
     container:
-      image: alpine:3.22.1
+      image: alpine:3.23.2
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install dependencies
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 24
     container:
-      image: archlinux:base-devel-20250824.0.410029
+      image: archlinux:base-devel
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install dependencies
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 24
     container:
-      image: debian:13.0
+      image: debian:13.3
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install dependencies
@@ -264,7 +264,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 24
     container:
-      image: fedora:42
+      image: fedora:43
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       - name: Install dependencies


### PR DESCRIPTION
I realized that dependebot doesn't manage version bumps of base images for actions jobs; they were starting to get quite aged, which led to the Arch builds failing because the certificate used to sign the packages clearly had expired.

Recent versioned Arch tags didn't work in GitHub actions so sticking with the nonversioned `archlinux:base-devel` for now