### PR TITLE
[4.4] Fix implicit declaration of function AfpErr2name

### DIFF
--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -23,6 +23,7 @@
 
 #include <atalk/adouble.h>
 #include <atalk/afp.h>
+#include <atalk/afp_util.h>
 #include <atalk/cnid.h>
 #include <atalk/errchk.h>
 #include <atalk/fce_api.h>

--- a/etc/afpd/extattrs.c
+++ b/etc/afpd/extattrs.c
@@ -23,6 +23,7 @@
 
 #include <atalk/adouble.h>
 #include <atalk/afp.h>
+#include <atalk/afp_util.h>
 #include <atalk/ea.h>
 #include <atalk/globals.h>
 #include <atalk/logger.h>


### PR DESCRIPTION
fixes #2660 

PR is against branch-netatalk-4-4