### PR TITLE
remove redundant project version setting for SonarQube Cloud

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,6 @@ sonar.organization=netatalk
 sonar.sources=.
 sonar.sourceEncoding=UTF-8
 sonar.projectName=netatalk
-sonar.projectVersion=4.4
 sonar.scm.provider=git
 
 # Don't analyze dynamically generated files


### PR DESCRIPTION
the project version is used to label scans on sonarcloud.io and mostly a cosmetic thing, so rather than having the management overhead of keeping this in sync with the project version, I propose we remove it altogether from this configuration file