### PR TITLE
testsuite: Enhance afp_speedtest with throughput statistics, TCP statistics, CSV export, and fix Local mode - baseline performance optimisations

### DIFF
--- a/doc/manpages/man1/afp_speedtest.1.md
+++ b/doc/manpages/man1/afp_speedtest.1.md
@@ -4,14 +4,25 @@ afp_speedtest — Simple AFP file transfer benchmarking tool
 
 # Synopsis
 
-**afp_speedtest** [-1234567aeiLnVvy] [-h *host*] [-p *port*] [-s *volume*] [-S *volume2*] [-u *user*]
-[-w *password*] [-n *iterations*] [-d *size*] [-q *quantum*] [-F *file*] [-f *test*]
+**afp_speedtest** [-1234567acDeiLTVvy] [-h *host*] [-p *port*] [-s *volume*] [-P *path*] [-S *volume2*]
+[-u *user*] [-w *password*] [-n *iterations*] [-W *warmup*] [-t *delay*] [-d *size*] [-z *sizes*]
+[-q *quantum*] [-r *requests*] [-F *file*] [-f *test*]
 
 # Description
 
-**afp_speedtest** is an AFP benchmark testsuite for read, write and copy operations.
-It can be run using either AFP commands or POSIX syscalls,
-handy for comparing netatalk speeds against other file transfer protocols.
+**afp_speedtest** is an AFP benchmark testsuite for read, write, copy and server-side copy operations.
+It can operate in two modes:
+
+- **AFP Mode** (default): Tests AFP protocol performance over the network
+- **Local Mode** (`-L`): Direct filesystem I/O baseline benchmarking using POSIX syscalls
+
+The tool supports comprehensive performance analysis including:
+
+- Multiple iteration testing with warmup runs
+- Statistical analysis (mean, median, standard deviation, percentiles)
+- File size sweeping to test performance across different file sizes
+- TCP network metrics tracking (AFP mode only)
+- CSV output format for data analysis
 
 # Options
 
@@ -39,53 +50,72 @@ handy for comparing netatalk speeds against other file transfer protocols.
 **-a**
 : Don't flush to disk after write
 
+**-c**
+: CSV output mode (automatically enables statistics and quiet mode)
+
 **-d** *size*
-: File size (Mbytes, default: 64)
+: File size in Mbytes (default: 64 MB, or default size sweep if not specified)
 
 **-D**
-: Use O_DIRECT in open flags (when in POSIX mode)
+: Disable O_DIRECT in Local mode (auto-enabled by default for realistic AFP comparison)
+: Use this flag to test buffered I/O performance with kernel page cache
+: Ignored in AFP mode (O_DIRECT not applicable)
 
 **-e**
 : Use sparse file
 
 **-f** *tests*
-: Specific tests to run (Read, Write, Copy, ServerCopy, default: Write)
+: Comma-separated list of tests to run: Read, Write, Copy, ServerCopy (default: Write)
+: Note: ServerCopy is automatically skipped in Local mode as it requires an AFP server
 
 **-F** *file*
-: Read from file in volume root folder (default: create a temporary file)
+: Read from existing file in volume root folder (default: creates temporary files)
 
 **-h** *host*
-: Server hostname or IP address (default: localhost)
+: Server hostname or IP address (default: localhost, ignored in Local mode)
 
 **-i**
 : Interactive mode – prompt user before each test (used for debugging)
 
 **-L**
-: Use POSIX calls instead of AFP
+: Local mode – use POSIX calls for direct filesystem I/O instead of AFP protocol
+: Must be used with `-P` to specify directory path
+: Provides baseline performance measurements without network/protocol overhead
 
 **-n** *iterations*
 : Number of test iterations to run (default: 1)
+: When > 1, automatically enables statistics output
 
 **-p** *port*
-: Server port number (default: 548)
+: Server port number (default: 548, ignored in Local mode)
+
+**-P** *path*
+: Local directory path for Local mode testing (required when using `-L`)
 
 **-q** *size*
-: Packet size (Kbytes, default: server quantum)
+: Packet/buffer size in Kbytes (default: detected server quantum in AFP mode, 1024 KB in Local mode)
 
 **-r** *number*
-: Number of outstanding requests (default: 1)
-
-**-R** *number*
-: Number of not interleaved outstanding requests (default: 1)
+: Number of outstanding pipelined requests for parallel I/O operations (default: 1)
+: Higher values allow multiple in-flight AFP requests, improving throughput on high-latency connections
+: Note: Values > 1 require careful tuning and may not benefit all scenarios
 
 **-s** *volume*
-: Volume name to mount for testing
+: Volume name to mount for testing (AFP mode only, ignored in Local mode)
 
 **-S** *volume*
-: Volume name for second volume to mount for testing
+: Second volume name for cross-volume copy testing (AFP mode only)
+
+**-t** *seconds*
+: Delay in seconds between test iterations (default: 0)
+: Useful for cooling down between iterations or simulating real-world usage patterns
+
+**-T**
+: Show statistics (mean, median, std dev, min, max, P95)
+: Automatically enabled when iterations > 1 or when using size sweep
 
 **-u** *user*
-: Username for authentication with AFP server (default: current uid)
+: Username for AFP server authentication (default: current uid, ignored in Local mode)
 
 **-v**
 : Verbose output
@@ -94,10 +124,20 @@ handy for comparing netatalk speeds against other file transfer protocols.
 : Very verbose output
 
 **-w** *password*
-: Password for authentication with AFP server
+: Password for AFP server authentication (ignored in Local mode)
+
+**-W** *warmup*
+: Number of warmup runs excluded from statistics (default: 1)
+: Warmup runs are marked with [W#] prefix and not included in statistics
 
 **-y**
-: Use a new file for each run (default: same file)
+: Use a new file for each run (default: reuse same filename)
+
+**-z** *sizes*
+: File size sweep mode – comma-separated list of sizes in MB
+: Example: `-z 0.004,0.008,0.016,0.032,0.064,0.128,0.256,0.512,1,2,4,8,16,32,64,128,256,512`
+: Minimum: 0.004 MB (4 KB), Maximum: 1024 MB
+: If neither `-d` nor `-z` is specified, uses default 18-size sweep: 4KB,8KB,16KB,32KB,64KB,128KB,256KB,512KB,1MB,2MB,4MB,8MB,16MB,32MB,64MB,128MB,256MB,512MB
 
 # Configuration
 
@@ -107,42 +147,93 @@ Configure the UAM in netatalk's afp.conf:
     [Global]
     uam list = uams_clrtxt.so
 
+# Output Modes
+
+## Text Mode (Default)
+
+Displays formatted tables with:
+
+- Per-iteration timing results with throughput
+- Statistical summaries (when enabled)
+- Network/TCP metrics comparison tables (AFP mode only)
+- File size performance summary table (size sweep mode)
+- TCP metrics evolution table (AFP mode with size sweep)
+
+## CSV Mode (`-c`)
+
+Generates three CSV tables for data analysis:
+
+1. **Test Data Table**: Individual iteration results (test_name, iteration, file_size_mb, microseconds, throughput_mbs)
+2. **File Size Summary Table**: Aggregated statistics per file size (mean, median, min, max throughput and timing)
+3. **TCP Metrics Evolution Table** (AFP mode only): Initial vs final TCP metrics across all tests
+
 # Examples
 
-Run 5 iterations each of the four benchmark tests: Read,Write,Copy,ServerCopy
+## AFP Mode Examples
 
-    $ afp_speedtest -h 10.0.0.10 -s speed1 -u myuser -w mypass -n 5 -f Read,Write,Copy,ServerCopy
-    Read quantum 1048576, size 67108864 
-    run	 microsec	  KB/s
-    1	   251577	273154.84
-    2	   222635	308664.31
-    3	   226490	303410.66
-    4	   228992	300095.53
-    5	   220840	311173.16
+Run 5 iterations of all four benchmark tests over AFP:
 
-    Write quantum 1048576, size 67108864
-    run	 microsec	  KB/s
-    1	   210057	327146.81
-    2	   195791	350983.84
-    3	   193921	354368.41
-    4	   208458	329656.22
-    5	   206792	332312.06
+    afp_speedtest -h 10.0.0.10 -s speed1 -u myuser -w mypass -n 5 -f Read,Write,Copy,ServerCopy
 
-    Copy quantum 1048576, size 67108864 
-    run	 microsec	  KB/s
-    1	   418005	164398.70
-    2	   392906	174900.55
-    3	   400815	171449.36
-    4	   392021	175295.39
-    5	   390320	176059.33
+Run a single 64 MB write test:
 
-    ServerCopy quantum 1048576, size 67108864 
-    run	 microsec	  KB/s
-    1	    20585	3338327.75
-    2	    21986	3125601.50
-    3	    21762	3157774.00
-    4	    21913	3136014.00
-    5	    20832	3298746.00
+    afp_speedtest -h 10.0.0.10 -s speed1 -u myuser -w mypass -d 64 -f Write
+
+Run file size sweep with 10 iterations per size and export to CSV:
+
+    afp_speedtest -h 10.0.0.10 -s speed1 -u myuser -w mypass -n 10 -c -f Read,Write > results.csv
+
+## Local Mode Examples
+
+Baseline filesystem performance with 5 iterations:
+
+    afp_speedtest -L -P /mnt/fast_disk -n 5 -f Read,Write,Copy
+
+Local mode with custom file size sweep:
+
+    afp_speedtest -L -P /tmp/test -z 1,4,16,64,256 -n 3 -f Read,Write
+
+Local mode with buffered I/O (O_DIRECT disabled) and CSV output:
+
+    afp_speedtest -L -D -P /mnt/nvme -c -n 10 -f Read,Write > nvme_buffered.csv
+
+Local mode with O_DIRECT (default, for AFP comparison):
+
+    afp_speedtest -L -P /mnt/nvme -c -n 10 -f Read,Write > nvme_direct.csv
+
+# Output Example
+
+    AFP Speedtest - Configuration
+    ════════════════════════════════════════
+     Mode:            Local (Direct Filesystem I/O)
+     AFP Version:     N/A (Local)
+     Directory:       /tmp/speedtest
+     Tests:           Read,Write,Copy
+     File Size:       64 MB
+     Iterations:      5
+     Warmup Runs:     1
+     Statistics:      Enabled
+    
+    
+    ===== Test Passes for Read =====
+    Read quantum 1024 KB, size 64 MB
+    Warmup: 1 runs, Measured: 5 runs
+    run	  microsec	  MB/s
+    [W1]	    11739	5451.91
+    1	     9511	6729.05
+    2	     9700	6597.94
+    3	     9174	6976.24
+    4	     8949	7151.64
+    5	     9050	7071.82
+    
+    ===== Statistics for Read =====
+    File Size:      64 MB
+    Iterations:     5
+    Mean:           9277 μs (6898.93 MB/s)
+    Median:         9174 μs (6976.24 MB/s)
+    Std Dev:        284 μs (3.06%)
+    Min:            8949 μs (7151.64 MB/s)
+    Max:            9700 μs (6597.94 MB/s)
 
 # See Also
 

--- a/test/testsuite/afp_tcp_analytics.c
+++ b/test/testsuite/afp_tcp_analytics.c
@@ -1,0 +1,766 @@
+/*
+ * Copyright (c) 2026, Andy Lemin (andylemin)
+ * Credits; Based on work by Netatalk contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "afp_tcp_analytics.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+
+#include "dsi.h"
+
+/* TCP metrics via getsockopt()
+ * Supported: Linux, FreeBSD, OpenBSD, NetBSD (TCP_INFO), macOS (TCP_CONNECTION_INFO)
+ * Unsupported fields set to -1 and skipped in output */
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+#define HAS_TCP_INFO 1
+
+/* Detect which tcp_info fields are available based on kernel/platform
+ * These fields don't exist on Alpine Linux and older kernels */
+#if defined(__GLIBC__) && __GLIBC__ >= 2 && __GLIBC_MINOR__ >= 17
+#define HAS_TCPI_RCV_WND 1
+#define HAS_TCPI_REORDERING 1
+#define HAS_TCPI_LOST 1
+#define HAS_TCPI_RCV_SPACE 1
+#endif
+
+#elif defined(__APPLE__)
+#define HAS_TCP_CONNECTION_INFO 1
+/* macOS uses TCP_CONNECTION_INFO instead of TCP_INFO */
+#ifndef TCP_CONNECTION_INFO
+#define TCP_CONNECTION_INFO 0x106  /* From sys/socket.h on macOS */
+#endif
+#endif
+
+#define KILOBYTE 1024
+#define MEGABYTE (KILOBYTE*KILOBYTE)
+
+/*!
+ * @brief Initialize TCP analytics session
+ * @note Must be called before any other tcp_analytics functions
+*/
+void tcp_analytics_init(TcpAnalyticsSession *session, TcpOutputFormat format,
+                        int enable_session)
+{
+    memset(session, 0, sizeof(*session));
+    session->format = format;
+    session->enable_session_tracking = enable_session;
+}
+
+/*!
+ * @brief Capture TCP metrics from connection socket via getsockopt()
+ * @note Supports Linux, FreeBSD, NetBSD, OpenBSD (TCP_INFO), macOS (TCP_CONNECTION_INFO)
+*/
+int tcp_analytics_capture(CONN *conn, TcpMetrics *metrics)
+{
+    if (!conn) {
+        return -1;
+    }
+
+    const DSI *conn_dsi = &conn->dsi;
+    int sock = conn_dsi->socket;
+
+    if (sock < 0) {
+        return -1;
+    }
+
+    socklen_t optlen;
+    memset(metrics, 0, sizeof(*metrics));
+    /* Server quantum from DSI negotiation */
+    metrics->server_quantum = conn_dsi->server_quantum;
+    /* TCP send buffer */
+    optlen = sizeof(metrics->tcp_send_buffer);
+
+    if (getsockopt(sock, SOL_SOCKET, SO_SNDBUF,
+                   &metrics->tcp_send_buffer, &optlen) < 0) {
+        metrics->tcp_send_buffer = -1;
+    }
+
+    /* TCP receive buffer */
+    optlen = sizeof(metrics->tcp_recv_buffer);
+
+    if (getsockopt(sock, SOL_SOCKET, SO_RCVBUF,
+                   &metrics->tcp_recv_buffer, &optlen) < 0) {
+        metrics->tcp_recv_buffer = -1;
+    }
+
+    /* TCP MSS */
+    optlen = sizeof(metrics->tcp_mss);
+
+    if (getsockopt(sock, IPPROTO_TCP, TCP_MAXSEG,
+                   &metrics->tcp_mss, &optlen) < 0) {
+        metrics->tcp_mss = -1;
+    }
+
+#ifdef HAS_TCP_CONNECTION_INFO
+    /* macOS TCP_CONNECTION_INFO */
+    struct tcp_connection_info conn_info;
+    memset(&conn_info, 0, sizeof(conn_info));
+    optlen = sizeof(conn_info);
+
+    if (getsockopt(sock, IPPROTO_TCP, TCP_CONNECTION_INFO, &conn_info,
+                   &optlen) == 0) {
+        /* Map macOS tcp_connection_info fields to our metrics */
+        metrics->tcp_congestion_window = conn_info.tcpi_snd_cwnd;
+        metrics->tcp_slow_start_threshold = conn_info.tcpi_snd_ssthresh;
+        metrics->tcp_rtt = conn_info.tcpi_srtt;       /* Smoothed RTT in microseconds */
+        metrics->tcp_rtt_variance = conn_info.tcpi_rttvar;
+        metrics->tcp_retrans = conn_info.tcpi_txretransmitpackets;
+        metrics->tcp_total_retrans = -1;  /* Not directly available */
+        metrics->tcp_reordering = -1;     /* Not available on macOS */
+        metrics->tcp_lost = -1;           /* Not available on macOS */
+        metrics->tcp_send_mss = conn_info.tcpi_maxseg;
+        metrics->tcp_recv_mss = -1;       /* Not available on macOS */
+        metrics->tcp_adv_mss = -1;        /* Not available on macOS */
+        metrics->tcp_recv_space = -1;     /* Not available on macOS */
+    } else {
+        /* getsockopt failed - set all to defaults */
+        metrics->tcp_congestion_window = -1;
+        metrics->tcp_slow_start_threshold = -1;
+        metrics->tcp_rtt = 0;
+        metrics->tcp_rtt_variance = 0;
+        metrics->tcp_retrans = -1;
+        metrics->tcp_total_retrans = -1;
+        metrics->tcp_reordering = -1;
+        metrics->tcp_lost = -1;
+        metrics->tcp_send_mss = -1;
+        metrics->tcp_recv_mss = -1;
+        metrics->tcp_adv_mss = -1;
+        metrics->tcp_recv_space = -1;
+    }
+
+#elif defined(HAS_TCP_INFO)
+    /* Linux/FreeBSD TCP_INFO
+     * Strategy: Use runtime size checking to handle fields that may not exist on older kernels.
+     * The actual structure size returned by getsockopt tells us which fields are available.
+     */
+    struct tcp_info tcp_info;
+    memset(&tcp_info, 0, sizeof(tcp_info));
+    optlen = sizeof(tcp_info);
+
+    if (getsockopt(sock, IPPROTO_TCP, TCP_INFO, &tcp_info, &optlen) == 0) {
+        /* Macro to safely extract fields based on structure size returned by kernel */
+#define TCPI_SAFE_GET(field) \
+            ((optlen >= ((char*)&tcp_info.field - (char*)&tcp_info) + sizeof(tcp_info.field)))
+        /* Core window/congestion metrics - available on most systems
+         * NOTE: tcpi_snd_wnd (actual window size) doesn't exist on Alpine/Debian.
+         * Using tcpi_snd_cwnd (congestion window) which is universally available. */
+        metrics->tcp_congestion_window = TCPI_SAFE_GET(tcpi_snd_cwnd) ?
+                                         tcp_info.tcpi_snd_cwnd : -1;
+        metrics->tcp_slow_start_threshold = TCPI_SAFE_GET(tcpi_snd_ssthresh) ?
+                                            tcp_info.tcpi_snd_ssthresh : -1;
+        /* RTT metrics - widely available on Linux/FreeBSD */
+        metrics->tcp_rtt = TCPI_SAFE_GET(tcpi_rtt) ? tcp_info.tcpi_rtt : 0;
+        metrics->tcp_rtt_variance = TCPI_SAFE_GET(tcpi_rttvar) ? tcp_info.tcpi_rttvar :
+                                    0;
+        /* Retransmission metrics - available on most systems
+         * Use -1 to indicate "not supported" so we can distinguish from "0 retrans" (valid)
+         * Note: FreeBSD/NetBSD use __ prefix for some fields */
+#if defined(__FreeBSD__) || defined(__NetBSD__)
+        metrics->tcp_retrans = TCPI_SAFE_GET(__tcpi_retrans) ? (int)
+                               tcp_info.__tcpi_retrans : -1;
+        metrics->tcp_total_retrans = -1;  /* Not available on FreeBSD/NetBSD */
+#else
+        metrics->tcp_retrans = TCPI_SAFE_GET(tcpi_retrans) ? (int)
+                               tcp_info.tcpi_retrans : -1;
+        metrics->tcp_total_retrans = TCPI_SAFE_GET(tcpi_total_retrans) ?
+                                     (int)tcp_info.tcpi_total_retrans : -1;
+#endif
+        /* Loss/reordering metrics - may not exist on older kernels
+         * Note: FreeBSD/NetBSD use __ prefix for some fields */
+#if defined(__FreeBSD__) || defined(__NetBSD__)
+        metrics->tcp_reordering = TCPI_SAFE_GET(__tcpi_reordering) ?
+                                  (int)tcp_info.__tcpi_reordering : -1;
+        metrics->tcp_lost = TCPI_SAFE_GET(__tcpi_lost) ? (int)tcp_info.__tcpi_lost : -1;
+#else
+        metrics->tcp_reordering = TCPI_SAFE_GET(tcpi_reordering) ?
+                                  (int)tcp_info.tcpi_reordering : -1;
+        metrics->tcp_lost = TCPI_SAFE_GET(tcpi_lost) ? (int)tcp_info.tcpi_lost : -1;
+#endif
+        /* MSS metrics - widely available
+         * Note: FreeBSD uses __ prefix for advmss */
+        metrics->tcp_send_mss = TCPI_SAFE_GET(tcpi_snd_mss) ? tcp_info.tcpi_snd_mss :
+                                -1;
+        metrics->tcp_recv_mss = TCPI_SAFE_GET(tcpi_rcv_mss) ? tcp_info.tcpi_rcv_mss :
+                                -1;
+#if defined(__FreeBSD__) || defined(__NetBSD__)
+        metrics->tcp_adv_mss = TCPI_SAFE_GET(__tcpi_advmss) ? tcp_info.__tcpi_advmss :
+                               -1;
+#else
+        metrics->tcp_adv_mss = TCPI_SAFE_GET(tcpi_advmss) ? tcp_info.tcpi_advmss : -1;
+#endif
+        /* Receive space - may not exist on older kernels */
+        metrics->tcp_recv_space = TCPI_SAFE_GET(tcpi_rcv_space) ?
+                                  tcp_info.tcpi_rcv_space : -1;
+#undef TCPI_SAFE_GET
+    } else {
+        /* getsockopt failed - set all to defaults */
+        metrics->tcp_congestion_window = -1;
+        metrics->tcp_slow_start_threshold = -1;
+        metrics->tcp_rtt = 0;
+        metrics->tcp_rtt_variance = 0;
+        metrics->tcp_retrans = -1;
+        metrics->tcp_total_retrans = -1;
+        metrics->tcp_reordering = -1;
+        metrics->tcp_lost = -1;
+        metrics->tcp_send_mss = -1;
+        metrics->tcp_recv_mss = -1;
+        metrics->tcp_adv_mss = -1;
+        metrics->tcp_recv_space = -1;
+    }
+
+#else
+    /* TCP_INFO not available on this platform */
+    metrics->tcp_congestion_window = -1;
+    metrics->tcp_slow_start_threshold = -1;
+    metrics->tcp_rtt = 0;
+    metrics->tcp_rtt_variance = 0;
+    metrics->tcp_retrans = -1;
+    metrics->tcp_total_retrans = -1;
+    metrics->tcp_reordering = -1;
+    metrics->tcp_lost = -1;
+    metrics->tcp_send_mss = -1;
+    metrics->tcp_recv_mss = -1;
+    metrics->tcp_adv_mss = -1;
+    metrics->tcp_recv_space = -1;
+#endif
+    /* Detect localhost */
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    optlen = sizeof(addr);
+
+    if (getpeername(sock, (struct sockaddr *)&addr, &optlen) == 0) {
+        uint32_t ip = ntohl(addr.sin_addr.s_addr);
+        metrics->is_localhost = ((ip >> 24) == 127); /* 127.x.x.x */
+    } else {
+        metrics->is_localhost = 0;
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief Mark session start - capture "initial" metrics for size sweep mode
+*/
+int tcp_analytics_session_start(TcpAnalyticsSession *session, CONN *conn)
+{
+    return tcp_analytics_capture(conn, &session->initial);
+}
+
+/*!
+ * @brief Mark test start - capture "before" metrics
+*/
+int tcp_analytics_test_start(TcpAnalyticsSession *session, CONN *conn,
+                             off_t file_size)
+{
+    session->current_size = file_size;
+    return tcp_analytics_capture(conn, &session->before);
+}
+
+/*!
+ * @brief Print before/after TCP metrics comparison for single test
+*/
+static void print_per_test_comparison(const TcpAnalyticsSession *session)
+{
+    const TcpMetrics *before = &session->before;
+    const TcpMetrics *after = &session->after;
+    off_t size = session->current_size;
+
+    if (session->format == TCP_OUTPUT_CSV) {
+        return;  /* Suppress table in CSV mode */
+    }
+
+    fprintf(stdout, "\n=========== Network & DSI Metrics for File Size: ");
+
+    if (size < MEGABYTE) {
+        fprintf(stdout, "%ld KB ===========\n", size / KILOBYTE);
+    } else {
+        fprintf(stdout, "%ld MB ===========\n", size / MEGABYTE);
+    }
+
+    fprintf(stdout, "Connection Type: %s\n",
+            before->is_localhost ? "Localhost" : "Network");
+    fprintf(stdout, "Server Quantum:  %u bytes (%.1f KB)\n\n",
+            before->server_quantum,
+            before->server_quantum / 1024.0);
+    fprintf(stdout, "%-20s %15s %15s %15s\n", "Metric", "Before", "After", "Delta");
+    fprintf(stdout, "%-20s %15s %15s %15s\n", "------", "------", "-----", "-----");
+
+    if (before->tcp_send_buffer > 0) {
+        int delta = after->tcp_send_buffer - before->tcp_send_buffer;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d KB", before->tcp_send_buffer / 1024);
+        snprintf(a, sizeof(a), "%d KB", after->tcp_send_buffer / 1024);
+        snprintf(d, sizeof(d), "%+d KB", delta / 1024);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP Send Buffer", b, a, d);
+    }
+
+    if (before->tcp_recv_buffer > 0) {
+        int delta = after->tcp_recv_buffer - before->tcp_recv_buffer;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d KB", before->tcp_recv_buffer / 1024);
+        snprintf(a, sizeof(a), "%d KB", after->tcp_recv_buffer / 1024);
+        snprintf(d, sizeof(d), "%+d KB", delta / 1024);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP Recv Buffer", b, a, d);
+    }
+
+    if (before->tcp_mss > 0) {
+        int delta = after->tcp_mss - before->tcp_mss;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d B", before->tcp_mss);
+        snprintf(a, sizeof(a), "%d B", after->tcp_mss);
+        snprintf(d, sizeof(d), "%+d B", delta);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP MSS", b, a, d);
+    }
+
+    if (before->tcp_congestion_window > 0) {
+        int delta = after->tcp_congestion_window - before->tcp_congestion_window;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d", before->tcp_congestion_window);
+        snprintf(a, sizeof(a), "%d", after->tcp_congestion_window);
+        snprintf(d, sizeof(d), "%+d", delta);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP Cwnd (segs)", b, a, d);
+    }
+
+    if (before->tcp_slow_start_threshold > 0) {
+        int delta = after->tcp_slow_start_threshold - before->tcp_slow_start_threshold;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d", before->tcp_slow_start_threshold);
+        snprintf(a, sizeof(a), "%d", after->tcp_slow_start_threshold);
+        snprintf(d, sizeof(d), "%+d", delta);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP SSThresh", b, a, d);
+    }
+
+    if (before->tcp_rtt > 0) {
+        int delta = (int)after->tcp_rtt - (int)before->tcp_rtt;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%.2f ms", before->tcp_rtt / 1000.0);
+        snprintf(a, sizeof(a), "%.2f ms", after->tcp_rtt / 1000.0);
+        snprintf(d, sizeof(d), "%+.2f ms", delta / 1000.0);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP RTT", b, a, d);
+    }
+
+    if (before->tcp_rtt_variance > 0) {
+        int delta = (int)after->tcp_rtt_variance - (int)before->tcp_rtt_variance;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%.2f ms", before->tcp_rtt_variance / 1000.0);
+        snprintf(a, sizeof(a), "%.2f ms", after->tcp_rtt_variance / 1000.0);
+        snprintf(d, sizeof(d), "%+.2f ms", delta / 1000.0);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP RTT Variance", b, a, d);
+    }
+
+    /* Retransmissions and losses - only display if supported by kernel */
+    if (before->tcp_retrans >= 0) {
+        int delta_retrans = after->tcp_retrans - before->tcp_retrans;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d", before->tcp_retrans);
+        snprintf(a, sizeof(a), "%d", after->tcp_retrans);
+        snprintf(d, sizeof(d), "%+d", delta_retrans);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP Retrans", b, a, d);
+    }
+
+    if (before->tcp_total_retrans >= 0) {
+        int delta_total = after->tcp_total_retrans - before->tcp_total_retrans;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d", before->tcp_total_retrans);
+        snprintf(a, sizeof(a), "%d", after->tcp_total_retrans);
+        snprintf(d, sizeof(d), "%+d", delta_total);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP Total Retrans", b, a, d);
+    }
+
+    if (before->tcp_lost >= 0) {
+        int delta_lost = after->tcp_lost - before->tcp_lost;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d", before->tcp_lost);
+        snprintf(a, sizeof(a), "%d", after->tcp_lost);
+        snprintf(d, sizeof(d), "%+d", delta_lost);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP Lost", b, a, d);
+    }
+
+    if (before->tcp_reordering >= 0) {
+        int delta = after->tcp_reordering - before->tcp_reordering;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d", before->tcp_reordering);
+        snprintf(a, sizeof(a), "%d", after->tcp_reordering);
+        snprintf(d, sizeof(d), "%+d", delta);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP Reordering", b, a, d);
+    }
+
+    /* MSS metrics */
+    if (before->tcp_send_mss > 0) {
+        int delta = after->tcp_send_mss - before->tcp_send_mss;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d B", before->tcp_send_mss);
+        snprintf(a, sizeof(a), "%d B", after->tcp_send_mss);
+        snprintf(d, sizeof(d), "%+d B", delta);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP Send MSS", b, a, d);
+    }
+
+    if (before->tcp_recv_mss > 0) {
+        int delta = after->tcp_recv_mss - before->tcp_recv_mss;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d B", before->tcp_recv_mss);
+        snprintf(a, sizeof(a), "%d B", after->tcp_recv_mss);
+        snprintf(d, sizeof(d), "%+d B", delta);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP Recv MSS", b, a, d);
+    }
+
+    if (before->tcp_adv_mss > 0) {
+        int delta = after->tcp_adv_mss - before->tcp_adv_mss;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d B", before->tcp_adv_mss);
+        snprintf(a, sizeof(a), "%d B", after->tcp_adv_mss);
+        snprintf(d, sizeof(d), "%+d B", delta);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP Adv MSS", b, a, d);
+    }
+
+    if (before->tcp_recv_space > 0) {
+        int delta = after->tcp_recv_space - before->tcp_recv_space;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d KB", before->tcp_recv_space / 1024);
+        snprintf(a, sizeof(a), "%d KB", after->tcp_recv_space / 1024);
+        snprintf(d, sizeof(d), "%+d KB", delta / 1024);
+        fprintf(stdout, "%-20s %15s %15s %15s\n", "TCP Recv Space", b, a, d);
+    }
+
+    fprintf(stdout,
+            "====================================================================\n");
+}
+
+/*!
+ * @brief Mark test end - capture "after" metrics and print per-test comparison
+*/
+int tcp_analytics_test_end(TcpAnalyticsSession *session, CONN *conn)
+{
+    int ret = tcp_analytics_capture(conn, &session->after);
+
+    if (ret < 0) {
+        return ret;
+    }
+
+    /* Print per-test comparison */
+    print_per_test_comparison(session);
+    return 0;
+}
+
+/*!
+ * @brief Print initial/final TCP metrics summary for size sweep session
+*/
+static void print_session_summary(const TcpAnalyticsSession *session)
+{
+    const TcpMetrics *initial = &session->initial;
+    const TcpMetrics *final = &session->final;
+
+    if (session->format == TCP_OUTPUT_CSV) {
+        /* CSV header for TCP summary */
+        fprintf(stdout, "\n# TCP Metrics Evolution Summary\n");
+        fprintf(stdout, "metric,initial,final,delta\n");
+
+        if (initial->tcp_send_buffer > 0) {
+            fprintf(stdout, "tcp_send_buffer_kb,%d,%d,%d\n",
+                    initial->tcp_send_buffer / 1024,
+                    final->tcp_send_buffer / 1024,
+                    (final->tcp_send_buffer - initial->tcp_send_buffer) / 1024);
+        }
+
+        if (initial->tcp_recv_buffer > 0) {
+            fprintf(stdout, "tcp_recv_buffer_kb,%d,%d,%d\n",
+                    initial->tcp_recv_buffer / 1024,
+                    final->tcp_recv_buffer / 1024,
+                    (final->tcp_recv_buffer - initial->tcp_recv_buffer) / 1024);
+        }
+
+        if (initial->tcp_mss > 0) {
+            fprintf(stdout, "tcp_mss_bytes,%d,%d,%d\n",
+                    initial->tcp_mss,
+                    final->tcp_mss,
+                    final->tcp_mss - initial->tcp_mss);
+        }
+
+        if (initial->tcp_congestion_window >= 0) {
+            fprintf(stdout, "tcp_cwnd_segments,%d,%d,%d\n",
+                    initial->tcp_congestion_window,
+                    final->tcp_congestion_window,
+                    final->tcp_congestion_window - initial->tcp_congestion_window);
+        }
+
+        if (initial->tcp_slow_start_threshold >= 0) {
+            fprintf(stdout, "tcp_ssthresh_segments,%d,%d,%d\n",
+                    initial->tcp_slow_start_threshold,
+                    final->tcp_slow_start_threshold,
+                    final->tcp_slow_start_threshold - initial->tcp_slow_start_threshold);
+        }
+
+        if (initial->tcp_rtt > 0) {
+            fprintf(stdout, "tcp_rtt_ms,%.2f,%.2f,%.2f\n",
+                    initial->tcp_rtt / 1000.0,
+                    final->tcp_rtt / 1000.0,
+                    ((int)final->tcp_rtt - (int)initial->tcp_rtt) / 1000.0);
+        }
+
+        if (initial->tcp_rtt_variance > 0) {
+            fprintf(stdout, "tcp_rtt_variance_ms,%.2f,%.2f,%.2f\n",
+                    initial->tcp_rtt_variance / 1000.0,
+                    final->tcp_rtt_variance / 1000.0,
+                    ((int)final->tcp_rtt_variance - (int)initial->tcp_rtt_variance) / 1000.0);
+        }
+
+        if (initial->tcp_retrans >= 0) {
+            fprintf(stdout, "tcp_retrans_current,%d,%d,%d\n",
+                    initial->tcp_retrans,
+                    final->tcp_retrans,
+                    final->tcp_retrans - initial->tcp_retrans);
+        }
+
+        if (initial->tcp_total_retrans >= 0) {
+            fprintf(stdout, "tcp_total_retrans,%d,%d,%d\n",
+                    initial->tcp_total_retrans,
+                    final->tcp_total_retrans,
+                    final->tcp_total_retrans - initial->tcp_total_retrans);
+        }
+
+        if (initial->tcp_lost >= 0) {
+            fprintf(stdout, "tcp_lost_packets,%d,%d,%d\n",
+                    initial->tcp_lost,
+                    final->tcp_lost,
+                    final->tcp_lost - initial->tcp_lost);
+        }
+
+        if (initial->tcp_reordering >= 0) {
+            fprintf(stdout, "tcp_reordering,%d,%d,%d\n",
+                    initial->tcp_reordering,
+                    final->tcp_reordering,
+                    final->tcp_reordering - initial->tcp_reordering);
+        }
+
+        if (initial->tcp_send_mss > 0) {
+            fprintf(stdout, "tcp_send_mss_bytes,%d,%d,%d\n",
+                    initial->tcp_send_mss,
+                    final->tcp_send_mss,
+                    final->tcp_send_mss - initial->tcp_send_mss);
+        }
+
+        if (initial->tcp_recv_mss > 0) {
+            fprintf(stdout, "tcp_recv_mss_bytes,%d,%d,%d\n",
+                    initial->tcp_recv_mss,
+                    final->tcp_recv_mss,
+                    final->tcp_recv_mss - initial->tcp_recv_mss);
+        }
+
+        if (initial->tcp_adv_mss > 0) {
+            fprintf(stdout, "tcp_adv_mss_bytes,%d,%d,%d\n",
+                    initial->tcp_adv_mss,
+                    final->tcp_adv_mss,
+                    final->tcp_adv_mss - initial->tcp_adv_mss);
+        }
+
+        if (initial->tcp_recv_space > 0) {
+            fprintf(stdout, "tcp_recv_space_kb,%d,%d,%d\n",
+                    initial->tcp_recv_space / 1024,
+                    final->tcp_recv_space / 1024,
+                    (final->tcp_recv_space - initial->tcp_recv_space) / 1024);
+        }
+
+        return;
+    }
+
+    fprintf(stdout, "\n");
+    fprintf(stdout,
+            "╔═════════════════════════════════════════════════════════════════════════╗\n");
+    fprintf(stdout,
+            "║                 TCP Metrics Evolution Across All Tests                  ║\n");
+    fprintf(stdout,
+            "╠═════════════════════════════════════════════════════════════════════════╣\n");
+    fprintf(stdout,
+            "║ %-24s │ %13s │ %13s │ %13s ║\n",
+            "Metric", "Initial", "Final", "Total Δ");
+    fprintf(stdout,
+            "╠═════════════════════════════════════════════════════════════════════════╣\n");
+
+    /* Socket Buffers */
+    if (initial->tcp_send_buffer > 0) {
+        int delta = final->tcp_send_buffer - initial->tcp_send_buffer;
+        fprintf(stdout, "║ %-24s │ %10d KB │ %10d KB │ %9d KB ║\n",
+                "TCP Send Buffer",
+                initial->tcp_send_buffer / 1024,
+                final->tcp_send_buffer / 1024,
+                delta / 1024);
+    }
+
+    if (initial->tcp_recv_buffer > 0) {
+        int delta = final->tcp_recv_buffer - initial->tcp_recv_buffer;
+        fprintf(stdout, "║ %-24s │ %10d KB │ %10d KB │ %9d KB ║\n",
+                "TCP Recv Buffer",
+                initial->tcp_recv_buffer / 1024,
+                final->tcp_recv_buffer / 1024,
+                delta / 1024);
+    }
+
+    /* MSS Values - format as "NUMBER B" right-aligned in 13 chars */
+    if (initial->tcp_mss > 0) {
+        int delta = final->tcp_mss - initial->tcp_mss;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d B", initial->tcp_mss);
+        snprintf(a, sizeof(a), "%d B", final->tcp_mss);
+        snprintf(d, sizeof(d), "%d B", delta);
+        fprintf(stdout, "║ %-24s │ %13s │ %13s │ %12s ║\n",
+                "TCP MSS", b, a, d);
+    }
+
+    /* Congestion Window */
+    if (initial->tcp_congestion_window >= 0) {
+        int delta = final->tcp_congestion_window - initial->tcp_congestion_window;
+        fprintf(stdout, "║ %-24s │ %13d │ %13d │ %12d ║\n",
+                "Cwnd (segments)",
+                initial->tcp_congestion_window,
+                final->tcp_congestion_window,
+                delta);
+    }
+
+    /* Slow Start Threshold */
+    if (initial->tcp_slow_start_threshold >= 0) {
+        int delta = final->tcp_slow_start_threshold - initial->tcp_slow_start_threshold;
+        fprintf(stdout, "║ %-24s │ %13d │ %13d │ %12d ║\n",
+                "SSThresh (segments)",
+                initial->tcp_slow_start_threshold,
+                final->tcp_slow_start_threshold,
+                delta);
+    }
+
+    /* RTT */
+    if (initial->tcp_rtt > 0) {
+        int delta = (int)final->tcp_rtt - (int)initial->tcp_rtt;
+        fprintf(stdout, "║ %-24s │ %10.2f ms │ %10.2f ms │ %9.2f ms ║\n",
+                "RTT",
+                initial->tcp_rtt / 1000.0,
+                final->tcp_rtt / 1000.0,
+                delta / 1000.0);
+    }
+
+    /* RTT Variance */
+    if (initial->tcp_rtt_variance > 0) {
+        int delta = (int)final->tcp_rtt_variance - (int)initial->tcp_rtt_variance;
+        fprintf(stdout, "║ %-24s │ %10.2f ms │ %10.2f ms │ %9.2f ms ║\n",
+                "RTT Variance",
+                initial->tcp_rtt_variance / 1000.0,
+                final->tcp_rtt_variance / 1000.0,
+                delta / 1000.0);
+    }
+
+    /* Current Retransmissions */
+    if (initial->tcp_retrans >= 0) {
+        int delta = final->tcp_retrans - initial->tcp_retrans;
+        fprintf(stdout, "║ %-24s │ %13d │ %13d │ %12d ║\n",
+                "Retrans (current)",
+                initial->tcp_retrans,
+                final->tcp_retrans,
+                delta);
+    }
+
+    /* Total Retransmissions */
+    if (initial->tcp_total_retrans >= 0) {
+        int delta = final->tcp_total_retrans - initial->tcp_total_retrans;
+        fprintf(stdout, "║ %-24s │ %13d │ %13d │ %12d ║\n",
+                "Total Retrans",
+                initial->tcp_total_retrans,
+                final->tcp_total_retrans,
+                delta);
+    }
+
+    /* Lost Packets (if available) */
+    if (initial->tcp_lost >= 0) {
+        int delta = final->tcp_lost - initial->tcp_lost;
+        fprintf(stdout, "║ %-24s │ %13d │ %13d │ %12d ║\n",
+                "Lost Packets",
+                initial->tcp_lost,
+                final->tcp_lost,
+                delta);
+    }
+
+    /* Reordering (if available) */
+    if (initial->tcp_reordering >= 0) {
+        int delta = final->tcp_reordering - initial->tcp_reordering;
+        fprintf(stdout, "║ %-24s │ %13d │ %13d │ %12d ║\n",
+                "Reordering",
+                initial->tcp_reordering,
+                final->tcp_reordering,
+                delta);
+    }
+
+    if (initial->tcp_send_mss > 0) {
+        int delta = final->tcp_send_mss - initial->tcp_send_mss;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d B", initial->tcp_send_mss);
+        snprintf(a, sizeof(a), "%d B", final->tcp_send_mss);
+        snprintf(d, sizeof(d), "%d B", delta);
+        fprintf(stdout, "║ %-24s │ %13s │ %13s │ %12s ║\n",
+                "TCP Send MSS", b, a, d);
+    }
+
+    if (initial->tcp_recv_mss > 0) {
+        int delta = final->tcp_recv_mss - initial->tcp_recv_mss;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d B", initial->tcp_recv_mss);
+        snprintf(a, sizeof(a), "%d B", final->tcp_recv_mss);
+        snprintf(d, sizeof(d), "%d B", delta);
+        fprintf(stdout, "║ %-24s │ %13s │ %13s │ %12s ║\n",
+                "TCP Recv MSS", b, a, d);
+    }
+
+    if (initial->tcp_adv_mss > 0) {
+        int delta = final->tcp_adv_mss - initial->tcp_adv_mss;
+        char b[16], a[16], d[16];
+        snprintf(b, sizeof(b), "%d B", initial->tcp_adv_mss);
+        snprintf(a, sizeof(a), "%d B", final->tcp_adv_mss);
+        snprintf(d, sizeof(d), "%d B", delta);
+        fprintf(stdout, "║ %-24s │ %13s │ %13s │ %12s ║\n",
+                "TCP Adv MSS", b, a, d);
+    }
+
+    /* Receive Space (if available) */
+    if (initial->tcp_recv_space > 0) {
+        int delta = final->tcp_recv_space - initial->tcp_recv_space;
+        fprintf(stdout, "║ %-24s │ %10d KB │ %10d KB │ %9d KB ║\n",
+                "TCP Recv Space",
+                initial->tcp_recv_space / 1024,
+                final->tcp_recv_space / 1024,
+                delta / 1024);
+    }
+
+    fprintf(stdout,
+            "╚═════════════════════════════════════════════════════════════════════════╝\n\n");
+}
+
+/*!
+ * @brief Mark session end - capture "final" metrics and print session summary
+*/
+int tcp_analytics_session_end(TcpAnalyticsSession *session, CONN *conn)
+{
+    int ret = tcp_analytics_capture(conn, &session->final);
+
+    if (ret < 0) {
+        return ret;
+    }
+
+    /* Print session summary */
+    print_session_summary(session);
+    return 0;
+}

--- a/test/testsuite/afp_tcp_analytics.h
+++ b/test/testsuite/afp_tcp_analytics.h
@@ -1,0 +1,57 @@
+#ifndef AFP_TCP_ANALYTICS_H
+#define AFP_TCP_ANALYTICS_H
+
+#include <stdint.h>
+#include <sys/types.h>  /* for off_t */
+#include "afpclient.h"  /* for CONN */
+
+/* Output format enumeration */
+typedef enum {
+    TCP_OUTPUT_TEXT,
+    TCP_OUTPUT_CSV
+} TcpOutputFormat;
+
+/* TCP metrics structure */
+typedef struct {
+    uint32_t server_quantum;
+    int tcp_send_buffer;
+    int tcp_recv_buffer;
+    int tcp_send_window;
+    int tcp_mss;
+    int tcp_congestion_window;
+    int tcp_slow_start_threshold;
+    uint32_t tcp_rtt;
+    uint32_t tcp_rtt_variance;
+    int tcp_retrans;
+    int tcp_total_retrans;
+    int tcp_reordering;
+    int tcp_lost;
+    int tcp_send_mss;
+    int tcp_recv_mss;
+    int tcp_adv_mss;
+    int tcp_recv_space;
+    int is_localhost;
+} TcpMetrics;
+
+/* Session handle for tracking metrics across multiple tests */
+typedef struct {
+    TcpMetrics initial;              /* Captured at session start */
+    TcpMetrics before;               /* Captured before current test */
+    TcpMetrics after;                /* Captured after current test */
+    TcpMetrics final;                /* Captured at session end */
+    off_t current_size;              /* Current test file size */
+    TcpOutputFormat format;          /* TEXT or CSV */
+    int enable_session_tracking;     /* For size sweep mode */
+} TcpAnalyticsSession;
+
+/* API Functions */
+void tcp_analytics_init(TcpAnalyticsSession *session, TcpOutputFormat format,
+                        int enable_session);
+int tcp_analytics_capture(CONN *conn, TcpMetrics *metrics);
+int tcp_analytics_session_start(TcpAnalyticsSession *session, CONN *conn);
+int tcp_analytics_test_start(TcpAnalyticsSession *session, CONN *conn,
+                             off_t file_size);
+int tcp_analytics_test_end(TcpAnalyticsSession *session, CONN *conn);
+int tcp_analytics_session_end(TcpAnalyticsSession *session, CONN *conn);
+
+#endif /* AFP_TCP_ANALYTICS_H */

--- a/test/testsuite/meson.build
+++ b/test/testsuite/meson.build
@@ -72,13 +72,15 @@ executable(
 
 speedtest_sources = [
     'speedtest.c',
+    'speedtest_local_vfs.c',
+    'afp_tcp_analytics.c',
 ]
 
 executable(
     'afp_speedtest',
     speedtest_sources,
     include_directories: root_includes,
-    link_args: ['-rdynamic'],
+    link_args: ['-rdynamic', '-lm'],
     link_with: libafptest,
     install: true,
     install_rpath: rpath_libdir,

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -1,20 +1,42 @@
+/*
+ * Copyright (c) 2026, Andy Lemin (andylemin)
+ * Credits; Based on work by Netatalk contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
+#include <math.h>
 #include <signal.h>
+#include <string.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
 
 #include "afpclient.h"
 #include "afpcmd.h"
 #include "afphelper.h"
 #include "testhelper.h"
+#include "afp_tcp_analytics.h"
+#include "speedtest_local_vfs.h"
 
 /* For compiling on OS X */
 #ifndef MAP_ANONYMOUS
@@ -40,12 +62,45 @@ struct timeval Timer_end;
 #define KILOBYTE 1024
 #define MEGABYTE (KILOBYTE*KILOBYTE)
 
+/* Statistics calculation support */
+#define MAX_ITERATIONS 1000
+
+typedef struct {
+    unsigned long long values[MAX_ITERATIONS];
+    int count;
+    double mean;
+    double median;
+    double stddev;
+    unsigned long long min;
+    unsigned long long max;
+    double percentile_95;  /* Only shown when n >= 20 */
+    double cv_percent;     /* coefficient of variation */
+} TestStats;
+
+/* Global statistics tracking */
+static TestStats current_test_stats;
+static int enable_statistics = 0;
+static int in_warmup_phase = 0;
+
+/* Output format control */
+typedef enum {
+    OUTPUT_TEXT,
+    OUTPUT_CSV
+} OutputFormat;
+
+static OutputFormat output_format = OUTPUT_TEXT;
+static int csv_header_printed = 0;
+
+/* TCP Analytics session for network metrics tracking */
+static TcpAnalyticsSession tcp_session;
+
 /* ------------------------------- */
 char    *Server = "localhost";
 static int     Port = DSI_AFPOVERTCP_PORT;
 static char    *Password = "";
 char    *Vol = "";
 char    *Vol2 = "";
+static char    *LocalPath = "";  /* Local filesystem path for -L mode */
 char    *User;
 int     Version = 34;
 char    *Test = "Write";
@@ -55,15 +110,48 @@ char *vers = "AFP3.4";
 char *uam = "Cleartxt Passwrd";
 
 static int Count = 1;
+static int WarmupRuns = 1;
+static int DelaySeconds = 0;
 static off_t Size = 64 * MEGABYTE;
+
+/* File size sweeping support */
+#define MAX_SIZE_SWEEP 32
+static int size_sweep_enabled = 0;
+static off_t size_sweep_values[MAX_SIZE_SWEEP];
+static int size_sweep_count = 0;
+
+typedef struct {
+    double file_size_mb;  /* Use double to support fractional MB (e.g., 0.004 for 4KB) */
+    double mean_throughput_mbs;
+    double median_throughput_mbs;
+    unsigned long long mean_time_us;
+    unsigned long long median_time_us;
+    unsigned long long min_time_us;
+    unsigned long long max_time_us;
+    double stddev_us;
+} SizeSweepResult;
+
+/* Per-test type result tracking for size sweep mode */
+typedef struct {
+    SizeSweepResult read_results[MAX_SIZE_SWEEP];
+    SizeSweepResult write_results[MAX_SIZE_SWEEP];
+    SizeSweepResult copy_results[MAX_SIZE_SWEEP];
+    SizeSweepResult servercopy_results[MAX_SIZE_SWEEP];
+    int read_count;
+    int write_count;
+    int copy_count;
+    int servercopy_count;
+} AllTestResults;
+
+static AllTestResults all_results;
+
 static size_t Quantum = 0;
 static int Request = 1;
-static int Req = 1;
 static int Delete = 0;
 static int Sparse = 0;
 static int Local = 0;
 static int Flush = 1;
-static int Direct = 0;
+static int Direct = 1;
 
 /* not used */
 CONN *Conn2;
@@ -76,28 +164,6 @@ int NotTestedCount = 0;
 char FailedTests[1024][256] = {{0}};
 char NotTestedTests[1024][256] = {{0}};
 char SkippedTests[1024][256] = {{0}};
-
-struct vfs {
-    unsigned int (*getfiledirparams)(CONN *, uint16_t, int, char *, uint16_t,
-                                     uint16_t);
-    unsigned int (*createdir)(CONN *, uint16_t, int, char *);
-    unsigned int (*createfile)(CONN *, uint16_t, char, int, char *);
-    uint16_t (*openfork)(CONN *, uint16_t, int, uint16_t, int, char *, int);
-    unsigned int (*writeheader)(DSI *, uint16_t, int, int, char *, char);
-    unsigned int (*writefooter)(DSI *, uint16_t, int, int, char *, char);
-    unsigned int (*flushfork)(CONN *, uint16_t);
-    unsigned int (*closefork)(CONN *, uint16_t);
-    unsigned int (*delete)(CONN *, uint16_t, int, char *);
-    unsigned int (*setforkparam)(CONN *, uint16_t,  uint16_t, off_t);
-    unsigned int (*write)(CONN *, uint16_t, long long, int, char *, char);
-    unsigned int (*read)(CONN *, uint16_t, long long, int, char *);
-    unsigned int (*readheader)(DSI *, uint16_t, int, int, char *);
-    unsigned int (*readfooter)(DSI *, uint16_t, int, int, char *);
-    unsigned int (*copyfile)(CONN *, uint16_t, int, uint16_t, int, char *, char *,
-                             char *);
-    uint16_t (*openvol)(CONN *, char *);
-    unsigned int (*closevol)(CONN *conn, uint16_t vol);
-};
 
 struct vfs VFS = {
     FPGetFileDirParams,
@@ -119,424 +185,9 @@ struct vfs VFS = {
     FPCloseVol
 };
 
-/* very small heaps for Posix access */
-#define  MAXDIR 10
-#define MAXVOL 3
-static char *Dir_heap[MAXVOL][MAXDIR];
-
-static char *Vol_heap[MAXVOL];
-
-/* -------------- */
-uint16_t local_openvol(CONN *conn, char *vol)
-{
-    uint16_t i;
-    int fd;
-
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "Open Vol %s \n\n", vol);
-    }
-
-    fd = open(vol, O_RDONLY | O_DIRECTORY);
-
-    if (fd < 0) {
-        return 0xffff;
-    }
-
-    for (i = 0; i < MAXVOL; i++) {
-        if (Vol_heap[i] == NULL) {
-            if (fchdir(fd) < 0) {
-                close(fd);
-                break;
-            }
-
-            close(fd);
-            Vol_heap[i] = strdup(vol);
-            Dir_heap[i][2] = strdup(vol);
-            return i;
-        }
-    }
-
-    return 0xffff;
-}
-
-/* ------------------------------- */
-unsigned int local_closevol(CONN *conn, uint16_t vol)
-{
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "Close Vol %d\n\n", vol);
-    }
-
-    return ntohl(AFP_OK);
-}
-
-/* ------------- */
-static char temp[MAXPATHLEN + 1];
-static int local_chdir(uint16_t vol, int did)
-{
-    if (vol > MAXVOL || did > MAXDIR) {
-        return -1;
-    }
-
-    if (!Vol_heap[vol] || !Dir_heap[vol][did]) {
-        return -1;
-    }
-
-    if (chdir(Dir_heap[vol][did])) {
-        return -1;
-    }
-
-    return 0;
-}
-
-/* ------------- */
-unsigned int local_createdir(CONN *conn, uint16_t vol, int did, char *name)
-{
-    unsigned int i;
-    int dirfd;
-
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "Create Directory Vol %d did : 0x%x <%s>\n\n", vol, ntohl(did),
-                name);
-    }
-
-    did = ntohl(did);
-
-    if (local_chdir(vol, did) < 0) {
-        return 0;
-    }
-
-    for (i = 3; i < MAXDIR; i++) {
-        if (Dir_heap[vol][i] == NULL) {
-            if (mkdir(name, 0777) != 0) {
-                return ntohl(AFPERR_NOOBJ);
-            }
-
-            dirfd = open(name, O_RDONLY | O_DIRECTORY);
-
-            if (dirfd < 0) {
-                return 0;
-            }
-
-            if (fchdir(dirfd) != 0) {
-                close(dirfd);
-                return 0;
-            }
-
-            if (getcwd(temp, sizeof(temp)) == NULL) {
-                close(dirfd);
-                return 0;
-            }
-
-            close(dirfd);
-            Dir_heap[vol][i] = strdup(temp);
-            return htonl(i);
-        }
-    }
-
-    return 0;
-}
-
-/* -------------- */
-unsigned int local_getfiledirparams(CONN *conn, uint16_t vol, int did,
-                                    char *name, uint16_t f_bitmap, uint16_t d_bitmap)
-{
-    struct stat st;
-    did = ntohl(did);
-
-    if (local_chdir(vol, did) < 0) {
-        return ntohl(AFPERR_NOOBJ);
-    }
-
-    if (*name != 0) {
-        if (!stat(name, &st)) {
-            return ntohl(AFP_OK);
-        }
-    }
-
-    return ntohl(AFPERR_NOOBJ);
-}
-
-/* ------------- */
-unsigned int local_delete(CONN *conn, uint16_t vol, int did, char *name)
-{
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "FPDelete Vol %d did : 0x%x <%s>\n\n", vol, ntohl(did), name);
-    }
-
-    did = ntohl(did);
-
-    if (local_chdir(vol, did) < 0) {
-        return ntohl(AFPERR_PARAM);
-    }
-
-    if (*name != 0) {
-        if (unlink(name)) {
-            return ntohl(AFPERR_NOOBJ);
-        }
-    } else if (rmdir(Dir_heap[vol][did])) {
-        return ntohl(AFPERR_NOOBJ);
-    }
-
-    return ntohl(AFP_OK);
-}
-
-/* ------------------------- */
-unsigned int local_createfile(CONN *conn, uint16_t vol, char type, int did,
-                              char *name)
-{
-    int fd;
-
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "Create File %s Vol %d did : 0x%x <%s>\n\n",
-                type ? "HARD" : "SOFT", vol, ntohl(did), name);
-    }
-
-    did = ntohl(did);
-
-    if (local_chdir(vol, did) < 0) {
-        return ntohl(AFPERR_PARAM);
-    }
-
-    fd = open(name, O_RDWR | O_CREAT, 0666);
-
-    if (fd == -1) {
-        return ntohl(AFPERR_NOOBJ);
-    }
-
-    close(fd);
-    return ntohl(AFP_OK);
-}
-
-/* ------------------------- */
-#ifndef O_DIRECT
-/* XXX hack */
-#define O_DIRECT 040000
-#endif
-
-uint16_t local_openfork(CONN *conn, uint16_t vol, int type, uint16_t bitmap,
-                        int did, char *name, int access)
-{
-    int fd;
-    int flags = O_RDWR;
-
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "Open Fork %s Vol %d did : 0x%x <%s> access %x\n\n",
-                (type == OPENFORK_DATA) ? "data" : "resource",
-                vol, ntohl(did), name, access);
-    }
-
-    if (Direct) {
-        flags |= O_DIRECT;
-    }
-
-    did = ntohl(did);
-
-    if (local_chdir(vol, did) < 0) {
-        return (uint16_t) ntohl(AFPERR_PARAM);
-    }
-
-    fd = open(name, flags, 0666);
-
-    if (fd == -1) {
-        return (uint16_t) ntohl(AFPERR_NOOBJ);
-    }
-
-    close(fd);
-    return (uint16_t) ntohl(AFP_OK);
-}
-
-/* ------------------------------- */
-unsigned int local_writeheader(DSI *dsi, uint16_t fork, int offset, int size,
-                               char *data, char whence)
-{
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "send write header fork %d  offset %d size %d from 0x%x\n\n",
-                fork, offset, size, (unsigned)whence);
-    }
-
-    if (lseek(fork, offset, SEEK_SET) == (off_t) -1) {
-        return ntohl(AFPERR_EOF);
-    }
-
-    if (write(fork, data, size) != size) {
-        return ntohl(AFPERR_EOF);
-    }
-
-    return ntohl(AFP_OK);
-}
-
-/* ------------------------------- */
-unsigned int local_writefooter(DSI *dsi, uint16_t fork, int offset, int size,
-                               char *data, char whence)
-{
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "get write footer fork %d  offset %d size %d from 0x%x\n\n",
-                fork, offset, size, (unsigned)whence);
-    }
-
-    return ntohl(AFP_OK);
-}
-
-/* ------------------------------- */
-unsigned int local_flushfork(CONN *conn, uint16_t fork)
-{
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "Flush fork %d\n\n", fork);
-    }
-
-    if (fsync(fork) < 0) {
-        return ntohl(AFPERR_PARAM);
-    }
-
-    return ntohl(AFP_OK);
-}
-
-/* ------------------------------- */
-unsigned int local_closefork(CONN *conn, uint16_t fork)
-{
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "Close Fork %d\n\n", fork);
-    }
-
-    if (close(fork)) {
-        return ntohl(AFPERR_PARAM);
-    }
-
-    return ntohl(AFP_OK);
-}
-
-/* ------------------------------- */
-unsigned int local_setforkparam(CONN *conn, uint16_t fork,  uint16_t bitmap,
-                                off_t size)
-{
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "Set Fork param fork %d bitmap 0x%x size %ld\n\n", fork, bitmap,
-                size);
-    }
-
-    if (ftruncate(fork, size)) {
-        return ntohl(AFPERR_PARAM);
-    }
-
-    return ntohl(AFP_OK);
-}
-
-/* ------------------------------- */
-unsigned int local_write(CONN *conn, uint16_t fork, long long offset, int size,
-                         char *data, char whence)
-{
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "write fork %d  offset %lld size %d from 0x%x\n\n", fork,
-                offset, size, (unsigned)whence);
-    }
-
-    if (lseek(fork, offset, SEEK_SET) == (off_t) -1) {
-        return ntohl(AFPERR_EOF);
-    }
-
-    if (write(fork, data, size) != size) {
-        return ntohl(AFPERR_EOF);
-    }
-
-    return ntohl(AFP_OK);
-}
-
-/* ------------------------------- */
-unsigned int local_read(CONN *conn, uint16_t fork, long long offset, int size,
-                        char *data)
-{
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "read fork %d  offset %lld size %d\n\n", fork, offset, size);
-    }
-
-    if (lseek(fork, offset, SEEK_SET) == (off_t) -1) {
-        return ntohl(AFPERR_EOF);
-    }
-
-    if (read(fork, data, size) != size) {
-        return ntohl(AFPERR_EOF);
-    }
-
-    return ntohl(AFP_OK);
-}
-
-/* ------------------------------- */
-unsigned int local_readheader(DSI *dsi, uint16_t fork, int offset, int size,
-                              char *data)
-{
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "send read header fork %d  offset %d size %d\n\n", fork, offset,
-                size);
-    }
-
-    return ntohl(AFP_OK);
-}
-
-/* ------------------------------- */
-unsigned int local_readfooter(DSI *dsi, uint16_t fork, int offset, int size,
-                              char *data)
-{
-    if (!Quiet) {
-        fprintf(stdout, "---------------------\n");
-        fprintf(stdout, "get read reply fork %d  offset %d size %d\n\n", fork, offset,
-                size);
-    }
-
-    if (lseek(fork, offset, SEEK_SET) == (off_t) -1) {
-        return ntohl(AFPERR_EOF);
-    }
-
-    if (read(fork, data, size) != size) {
-        return ntohl(AFPERR_EOF);
-    }
-
-    return ntohl(AFP_OK);
-}
-
-/* ------------------------------- */
-unsigned int local_copyfile(struct CONN *conn, uint16_t svol, int sdid,
-                            uint16_t dvol, int ddid, char *src, char *buf, char *dst)
-{
-    return ntohl(AFPERR_PARAM);
-}
-
-/* ------------------------------- */
-struct vfs local_VFS = {
-    local_getfiledirparams,
-    local_createdir,
-    local_createfile,
-    local_openfork,
-    local_writeheader,
-    local_writefooter,
-    local_flushfork,
-    local_closefork,
-    local_delete,
-    local_setforkparam,
-    local_write,
-    local_read,
-    local_readheader,
-    local_readfooter,
-    local_copyfile,
-    local_openvol,
-    local_closevol
-};
-
-
-/* =============================== */
+/*!
+ * @brief Display message and wait for user to press Enter
+ */
 static void press_enter(char *s)
 {
     if (!Interactive) {
@@ -566,70 +217,645 @@ unsigned long long delta(void)
     return e - s;
 }
 
-/* ------------------ */
-static void header(void)
+/*!
+ * @brief Compare function for qsort() to sort unsigned long long values
+ */
+static int compare_ulonglong(const void *a, const void *b)
 {
-    fprintf(stdout, "run\t microsec\t  KB/s\n");
+    unsigned long long aa = *(const unsigned long long *)a;
+    unsigned long long bb = *(const unsigned long long *)b;
+
+    if (aa < bb) {
+        return -1;
+    }
+
+    if (aa > bb) {
+        return 1;
+    }
+
+    return 0;
 }
 
-/* ------------------ */
-static void timer_footer(void)
+/*!
+ * @brief Calculate mean, median, stddev, and percentiles from timing samples
+ */
+static void calculate_statistics(TestStats *stats)
+{
+    if (stats->count == 0) {
+        return;
+    }
+
+    /* Calculate mean */
+    unsigned long long sum = 0;
+
+    for (int i = 0; i < stats->count; i++) {
+        sum += stats->values[i];
+    }
+
+    stats->mean = (double)sum / (double)stats->count;
+    /* Sort for median and percentiles */
+    unsigned long long sorted[MAX_ITERATIONS];
+    memcpy(sorted, stats->values, stats->count * sizeof(unsigned long long));
+    qsort(sorted, stats->count, sizeof(unsigned long long), compare_ulonglong);
+    /* Min and max */
+    stats->min = sorted[0];
+    stats->max = sorted[stats->count - 1];
+
+    /* Median */
+    if (stats->count % 2 == 0) {
+        stats->median = ((double)sorted[stats->count / 2 - 1] +
+                         (double)sorted[stats->count / 2]) / 2.0;
+    } else {
+        stats->median = (double)sorted[stats->count / 2];
+    }
+
+    /* Percentiles */
+    int p95_idx = (int)((stats->count - 1) * 0.95);
+    stats->percentile_95 = (double)sorted[p95_idx];
+    /* Standard deviation */
+    double variance = 0;
+
+    for (int i = 0; i < stats->count; i++) {
+        double diff = (double)stats->values[i] - stats->mean;
+        variance += diff * diff;
+    }
+
+    stats->stddev = sqrt(variance / (double)stats->count);
+
+    /* Coefficient of variation */
+    if (stats->mean > 0) {
+        stats->cv_percent = (stats->stddev / stats->mean) * 100.0;
+    } else {
+        stats->cv_percent = 0;
+    }
+}
+
+/*!
+ * @brief Record single timing measurement for current test
+ */
+static void record_timing(unsigned long long microseconds)
+{
+    if (enable_statistics && !in_warmup_phase &&
+            current_test_stats.count < MAX_ITERATIONS) {
+        current_test_stats.values[current_test_stats.count++] = microseconds;
+    }
+}
+
+/*!
+ * @brief Reset statistics counters for next test iteration
+ */
+static void reset_statistics(void)
+{
+    memset(&current_test_stats, 0, sizeof(current_test_stats));
+}
+
+/*!
+ * @brief Print statistics in human-readable text format
+ */
+static void print_statistics_text(const char *test_name)
+{
+    if (current_test_stats.count < 2) {
+        return;  /* Need at least 2 samples for meaningful statistics */
+    }
+
+    calculate_statistics(&current_test_stats);
+    fprintf(stdout, "\n===== Statistics for %s =====\n", test_name);
+
+    if (Size < MEGABYTE) {
+        fprintf(stdout, "File Size:      %ld KB\n", Size / KILOBYTE);
+    } else {
+        fprintf(stdout, "File Size:      %ld MB\n", Size / MEGABYTE);
+    }
+
+    fprintf(stdout, "Iterations:     %d\n", current_test_stats.count);
+
+    /* MB/s = (bytes * 1,000,000 μs/s) / (microseconds * 1,048,576 bytes/MB) */
+    /* Guard against division by zero for operations faster than timer resolution */
+    if (current_test_stats.mean > 0) {
+        fprintf(stdout, "Mean:           %.0f μs (%.2f MB/s)\n",
+                current_test_stats.mean,
+                ((double)Size * 1000000.0) / (MEGABYTE * current_test_stats.mean));
+    } else {
+        fprintf(stdout, "Mean:           <1 μs (too fast to measure)\n");
+    }
+
+    if (current_test_stats.median > 0) {
+        fprintf(stdout, "Median:         %.0f μs (%.2f MB/s)\n",
+                current_test_stats.median,
+                ((double)Size * 1000000.0) / (MEGABYTE * current_test_stats.median));
+    } else {
+        fprintf(stdout, "Median:         <1 μs (too fast to measure)\n");
+    }
+
+    fprintf(stdout, "Std Dev:        %.0f μs (%.2f%%)\n",
+            current_test_stats.stddev, current_test_stats.cv_percent);
+
+    if (current_test_stats.min > 0) {
+        fprintf(stdout, "Min:            %llu μs (%.2f MB/s)\n",
+                current_test_stats.min,
+                ((double)Size * 1000000.0) / (MEGABYTE * (double)current_test_stats.min));
+    } else {
+        fprintf(stdout, "Min:            <1 μs (too fast to measure)\n");
+    }
+
+    if (current_test_stats.max > 0) {
+        fprintf(stdout, "Max:            %llu μs (%.2f MB/s)\n",
+                current_test_stats.max,
+                ((double)Size * 1000000.0) / (MEGABYTE * (double)current_test_stats.max));
+    } else {
+        fprintf(stdout, "Max:            <1 μs (too fast to measure)\n");
+    }
+
+    /* Only show P95 if we have enough samples for it to be meaningful */
+    if (current_test_stats.count >= 20) {
+        if (current_test_stats.percentile_95 > 0) {
+            fprintf(stdout, "P95:            %.0f μs (%.2f MB/s)\n",
+                    current_test_stats.percentile_95,
+                    ((double)Size * 1000000.0) / (MEGABYTE * current_test_stats.percentile_95));
+        } else {
+            fprintf(stdout, "P95:            <1 μs (too fast to measure)\n");
+        }
+    }
+}
+
+/*!
+ * @brief Print CSV header row with column names
+ */
+static void print_csv_header(void)
+{
+    if (csv_header_printed) {
+        return;
+    }
+
+    fprintf(stdout,
+            "test_name,iteration,file_size_mb,microseconds,throughput_mbs\n");
+    csv_header_printed = 1;
+}
+
+/*!
+ * @brief Print single CSV row with test results
+ */
+static void print_csv_row(const char *test_name, int iteration, off_t file_size)
+{
+    if (!in_warmup_phase) {
+        unsigned long long d = delta();
+        double throughput_mbs = (d > 0) ?
+                                ((double)file_size * 1000000.0) / (MEGABYTE * (double)d) : 0.0;
+        fprintf(stdout, "%s,%d,%.3f,%llu,%.2f\n",
+                test_name, iteration,
+                (double)file_size / MEGABYTE,
+                d, throughput_mbs);
+    }
+}
+
+/*!
+ * @brief Print CSV statistics row with mean, median, stddev, percentiles
+ */
+static void print_csv_statistics(const char *test_name, off_t file_size)
+{
+    if (current_test_stats.count < 2) {
+        return;
+    }
+
+    calculate_statistics(&current_test_stats);
+    double file_size_mb = (double)file_size / MEGABYTE;
+    /* Guard against division by zero */
+    double mean_throughput = (current_test_stats.mean > 0) ?
+                             ((double)file_size * 1000000.0) / (MEGABYTE * current_test_stats.mean) : 0.0;
+    double median_throughput = (current_test_stats.median > 0) ?
+                               ((double)file_size * 1000000.0) / (MEGABYTE * current_test_stats.median) : 0.0;
+    double min_throughput = (current_test_stats.min > 0) ?
+                            ((double)file_size * 1000000.0) / (MEGABYTE * (double)current_test_stats.min) :
+                            0.0;
+    double max_throughput = (current_test_stats.max > 0) ?
+                            ((double)file_size * 1000000.0) / (MEGABYTE * (double)current_test_stats.max) :
+                            0.0;
+    fprintf(stdout, "%s_mean,,%.3f,%llu,%.2f\n",
+            test_name, file_size_mb,
+            (unsigned long long)current_test_stats.mean,
+            mean_throughput);
+    fprintf(stdout, "%s_median,,%.3f,%llu,%.2f\n",
+            test_name, file_size_mb,
+            (unsigned long long)current_test_stats.median,
+            median_throughput);
+    fprintf(stdout, "%s_stddev,,%.3f,%llu,\n",
+            test_name, file_size_mb,
+            (unsigned long long)current_test_stats.stddev);
+    fprintf(stdout, "%s_min,,%.3f,%llu,%.2f\n",
+            test_name, file_size_mb,
+            current_test_stats.min,
+            min_throughput);
+    fprintf(stdout, "%s_max,,%.3f,%llu,%.2f\n",
+            test_name, file_size_mb,
+            current_test_stats.max,
+            max_throughput);
+}
+
+/* Forward declaration for size sweep wrapper */
+static void run_one(char *name);
+
+/* ------------------- */
+
+static void print_test_summary(const char *test_name,
+                               const SizeSweepResult *results, int result_count)
+{
+    if (result_count == 0) {
+        return;
+    }
+
+    if (output_format == OUTPUT_CSV) {
+        /* CSV header for size sweep results */
+        fprintf(stdout, "\n# File Size Performance Summary for %s\n", test_name);
+        fprintf(stdout,
+                "file_size_mb,mean_throughput_mbs,median_throughput_mbs,min_throughput_mbs,max_throughput_mbs,stddev_ms,mean_time_ms\n");
+
+        for (int i = 0; i < result_count; i++) {
+            off_t file_size_bytes = (off_t)(results[i].file_size_mb * MEGABYTE);
+            /* Guard against division by zero */
+            double max_throughput_mbs = (results[i].min_time_us > 0) ?
+                                        ((double)file_size_bytes * 1000000.0) / (MEGABYTE * (double)
+                                            results[i].min_time_us) : 0.0;
+            double min_throughput_mbs = (results[i].max_time_us > 0) ?
+                                        ((double)file_size_bytes * 1000000.0) / (MEGABYTE * (double)
+                                            results[i].max_time_us) : 0.0;
+            fprintf(stdout, "%.3f,%.2f,%.2f,%.2f,%.2f,%.1f,%.1f\n",
+                    results[i].file_size_mb,
+                    results[i].mean_throughput_mbs,
+                    results[i].median_throughput_mbs,
+                    min_throughput_mbs,
+                    max_throughput_mbs,
+                    results[i].stddev_us / 1000.0,
+                    (double)results[i].mean_time_us / 1000.0);
+        }
+
+        return;
+    }
+
+    /* TEXT format */
+    fprintf(stdout, "\n");
+    fprintf(stdout,
+            "╔══════════════════════════════════════════════════════════════════════════════════════╗\n");
+    fprintf(stdout,
+            "║                      File Size Performance Summary for %-30s║\n",
+            test_name);
+    fprintf(stdout,
+            "╠══════════════════════════════════════════════════════════════════════════════════════╣\n");
+    fprintf(stdout,
+            "║ %8s │ %10s │ %12s │ %9s │ %9s │ %10s │ %8s ║\n",
+            "Size", "Mean(MB/s)", "Median(MB/s)", "Min(MB/s)", "Max(MB/s)", "StdDev(ms)",
+            "Mean(ms)");
+    fprintf(stdout,
+            "╠══════════════════════════════════════════════════════════════════════════════════════╣\n");
+
+    for (int i = 0; i < result_count; i++) {
+        off_t file_size_bytes = (off_t)(results[i].file_size_mb * MEGABYTE);
+        /* min_time_us = fastest = max throughput, max_time_us = slowest = min throughput */
+        /* Guard against division by zero */
+        double max_throughput_mbs = (results[i].min_time_us > 0) ?
+                                    ((double)file_size_bytes * 1000000.0) / (MEGABYTE * (double)
+                                        results[i].min_time_us) : 0.0;
+        double min_throughput_mbs = (results[i].max_time_us > 0) ?
+                                    ((double)file_size_bytes * 1000000.0) / (MEGABYTE * (double)
+                                        results[i].max_time_us) : 0.0;
+        /* Format size with units: KB for <1MB, MB for >=1MB */
+        char size_str[12];
+
+        if (file_size_bytes < MEGABYTE) {
+            snprintf(size_str, sizeof(size_str), "%ld KB", file_size_bytes / KILOBYTE);
+        } else {
+            snprintf(size_str, sizeof(size_str), "%ld MB", file_size_bytes / MEGABYTE);
+        }
+
+        fprintf(stdout,
+                "║ %8s │ %10.2f │ %12.2f │ %9.2f │ %9.2f │ %10.1f │ %8.1f ║\n",
+                size_str,
+                results[i].mean_throughput_mbs,
+                results[i].median_throughput_mbs,
+                min_throughput_mbs,
+                max_throughput_mbs,
+                results[i].stddev_us / 1000.0,
+                (double)results[i].mean_time_us / 1000.0);
+    }
+
+    fprintf(stdout,
+            "╚══════════════════════════════════════════════════════════════════════════════════════╝\n");
+}
+
+/*!
+ * @brief Print file size performance summary tables for all test types
+ */
+static void print_size_sweep_tables(void)
+{
+    /* Print separate table for each test type that has results */
+    if (all_results.read_count > 0) {
+        print_test_summary("Read", all_results.read_results, all_results.read_count);
+    }
+
+    if (all_results.write_count > 0) {
+        print_test_summary("Write", all_results.write_results, all_results.write_count);
+    }
+
+    if (all_results.copy_count > 0) {
+        print_test_summary("Copy", all_results.copy_results, all_results.copy_count);
+    }
+
+    if (all_results.servercopy_count > 0) {
+        print_test_summary("ServerCopy", all_results.servercopy_results,
+                           all_results.servercopy_count);
+    }
+
+    /* Display TCP metrics evolution summary for size sweep mode */
+    if (!Local && enable_statistics) {
+        tcp_analytics_session_end(&tcp_session, Conn);
+    }
+}
+
+/*!
+ * @brief Execute test with file size sweep mode enabled
+ */
+static void run_one_with_size_sweep(char *test_name)
+{
+    if (!size_sweep_enabled) {
+        /* Normal single-size run */
+        run_one(test_name);
+        return;
+    }
+
+    /* Size sweep mode - initialize volume IDs to ensure proper open/close logic */
+    VolID = 0xffff;
+    VolID2 = 0xffff;
+    off_t original_size = Size;
+    /* Initialize all_results structure */
+    memset(&all_results, 0, sizeof(AllTestResults));
+
+    for (int i = 0; i < size_sweep_count; i++) {
+        Size = size_sweep_values[i];
+
+        if (output_format == OUTPUT_TEXT) {
+            fprintf(stdout, "\n========================================\n");
+
+            if (Size < MEGABYTE) {
+                fprintf(stdout, "**** Testing with File Size: %ld KB ****\n", Size / KILOBYTE);
+            } else {
+                fprintf(stdout, "**** Testing with File Size: %ld MB ****\n", Size / MEGABYTE);
+            }
+
+            fprintf(stdout, "========================================\n");
+        }
+
+        /* Run test for this size */
+        run_one(test_name);
+
+        /* In Local mode with size sweep: reset Dir_heap to avoid hitting MAXDIR limit
+         * Keep volume entry intact (Vol_heap[0]) but free all directory entries */
+        if (Local && i < size_sweep_count - 1) {  /* Not after last iteration */
+            for (int vol_idx = 0; vol_idx < MAXVOL; vol_idx++) {
+                if (Vol_heap[vol_idx] != NULL) {
+                    /* Keep Vol_heap[vol_idx] but reset directory entries */
+                    for (int dir_idx = 3; dir_idx < MAXDIR; dir_idx++) {
+                        if (Dir_heap[vol_idx][dir_idx] != NULL) {
+                            free(Dir_heap[vol_idx][dir_idx]);
+                            Dir_heap[vol_idx][dir_idx] = NULL;
+                        }
+                    }
+                }
+            }
+        }
+
+        /* Results are now collected inside each test function */
+    }
+
+    Size = original_size;  /* Restore */
+
+    /* Close volumes after all size sweep iterations complete */
+    if (VolID != 0xffff) {
+        VFS.closevol(Conn, VolID);
+    }
+
+    if (*Vol2 && VolID2 != 0xffff) {
+        VFS.closevol(Conn, VolID2);
+    }
+
+    /* Clean up test directories after ALL size sweep iterations complete */
+    if (Local) {
+        /* Local mode: use system rm -rf (POSIX operations, not AFP) */
+        char cleanup_cmd[MAXPATHLEN * 2];
+        int cleanup_pid = getpid();
+        snprintf(cleanup_cmd, sizeof(cleanup_cmd),
+                 "rm -rf %s/ReadTest-%d %s/WriteTest-%d %s/CopyTest-%d %s/ServerCopyTest-%d 2>/dev/null",
+                 Vol, cleanup_pid, Vol, cleanup_pid, Vol, cleanup_pid, Vol, cleanup_pid);
+        system(cleanup_cmd);
+    }
+
+    /* Display comparison tables - one per test type */
+    print_size_sweep_tables();
+}
+
+/*!
+ * @brief Print results and collect statistics for size sweep mode
+ */
+static void print_and_collect_results(const char *test_name)
+{
+    if (!enable_statistics || current_test_stats.count == 0) {
+        return;
+    }
+
+    /* Print statistics */
+    if (output_format == OUTPUT_CSV) {
+        print_csv_statistics(test_name, Size);
+    } else {
+        print_statistics_text(test_name);
+    }
+
+    /* Collect results for size sweep mode */
+    if (!size_sweep_enabled) {
+        return;
+    }
+
+    SizeSweepResult result;
+    result.file_size_mb = (double)Size / (double)MEGABYTE;
+    result.mean_time_us = (unsigned long long)current_test_stats.mean;
+    result.median_time_us = (unsigned long long)current_test_stats.median;
+    result.min_time_us = current_test_stats.min;
+    result.max_time_us = current_test_stats.max;
+    result.stddev_us = current_test_stats.stddev;
+    result.mean_throughput_mbs = (current_test_stats.mean > 0) ?
+                                 ((double)Size * 1000000.0) / ((double)MEGABYTE * current_test_stats.mean) : 0.0;
+    result.median_throughput_mbs = (current_test_stats.median > 0) ?
+                                   ((double)Size * 1000000.0) / ((double)MEGABYTE * current_test_stats.median) :
+                                   0.0;
+
+    /* Determine which array to store in based on test_name */
+    if (strcmp(test_name, "Read") == 0) {
+        all_results.read_results[all_results.read_count++] = result;
+    } else if (strcmp(test_name, "Write") == 0) {
+        all_results.write_results[all_results.write_count++] = result;
+    } else if (strcmp(test_name, "Copy") == 0) {
+        all_results.copy_results[all_results.copy_count++] = result;
+    } else if (strcmp(test_name, "ServerCopy") == 0) {
+        all_results.servercopy_results[all_results.servercopy_count++] = result;
+    }
+}
+
+/* ------------------- */
+static int check_test_dir_exists(uint16_t vol, char *dir_name,
+                                 const char *test_name)
+{
+    uint16_t dir_bitmap = (uint16_t)((1U << DIRPBIT_LNAME) | (1U << DIRPBIT_PDID));
+
+    if (ntohl(AFPERR_NOOBJ) != VFS.getfiledirparams(Conn, vol, DIRDID_ROOT,
+            dir_name,
+            dir_bitmap, dir_bitmap)) {
+        fprintf(stderr, "Warning: %s test skipped - directory '%s' already exists\n",
+                test_name, dir_name);
+        test_nottested();
+        return 1;  /* exists */
+    }
+
+    return 0;  /* doesn't exist */
+}
+
+/*!
+ * @brief Print iteration number marker for progress tracking
+ */
+static void print_iteration_marker(int iteration, int display_iter)
+{
+    if (output_format != OUTPUT_TEXT) {
+        return;
+    }
+
+    if (in_warmup_phase) {
+        fprintf(stdout, "[W%d]\t", iteration);
+    } else {
+        fprintf(stdout, "%d\t", display_iter);
+    }
+}
+
+/*!
+ * @brief Print test header with name and configuration
+ */
+static void print_test_header(const char *test_name)
+{
+    if (output_format != OUTPUT_TEXT) {
+        return;
+    }
+
+    fprintf(stdout, "\n===== Test Passes for %s =====\n", test_name);
+    const char *sparse_note = Sparse ? "sparse file" : "";
+
+    if (Size < MEGABYTE) {
+        fprintf(stdout, "%s quantum %ld KB, size %ld KB %s\n",
+                test_name, Quantum / KILOBYTE, Size / KILOBYTE, sparse_note);
+    } else {
+        fprintf(stdout, "%s quantum %ld KB, size %ld MB %s\n",
+                test_name, Quantum / KILOBYTE, Size / MEGABYTE, sparse_note);
+    }
+}
+
+/*!
+ * @brief Print test header with timestamp
+ */
+static void header(void)
+{
+    if (output_format == OUTPUT_CSV) {
+        print_csv_header();
+    } else {
+        if (WarmupRuns > 0) {
+            fprintf(stdout, "Warmup: %d runs, Measured: %d runs\n", WarmupRuns, Count);
+        }
+
+        fprintf(stdout, "run\t %9s\t%6s\n", "microsec", "MB/s");
+    }
+}
+
+/*!
+ * @brief Print timing results and record statistics after test iteration
+ */
+static void timer_footer(const char *test_name, int iteration)
 {
     unsigned long long d;
     gettimeofday(&Timer_end, NULL);
     d = delta();
-    fprintf(stdout, "%9lld\t%.2f\n", d,
-            ((float)Size * MEGABYTE / (float)d) / KILOBYTE);
+    /* Record timing for statistics */
+    record_timing(d);
+
+    if (output_format == OUTPUT_CSV) {
+        if (!in_warmup_phase) {
+            double throughput_mbs = (d > 0) ?
+                                    ((double)Size * 1000000.0) / (MEGABYTE * (double)d) : 0.0;
+            fprintf(stdout, "%s,%d,%.3f,%llu,%.2f\n",
+                    test_name, iteration,
+                    (double)Size / MEGABYTE,
+                    d, throughput_mbs);
+        }
+    } else {
+        /* Convert to MB/s: Size in bytes, d in microseconds */
+        if (d > 0) {
+            double throughput_mbs = ((double)Size * 1000000.0) / (MEGABYTE * (double)d);
+            fprintf(stdout, "%9lld\t%.2f\n", d, throughput_mbs);
+        } else {
+            fprintf(stdout, "       <1\t(too fast)\n");
+        }
+    }
 }
 
-/* ------------------ */
+/*!
+ * @brief Execute Write test with configured file size and iterations
+ */
 void Write(void)
 {
     int dir = 0;
-    int fork = 0;
+    uint16_t fork = 0;
     int id = getpid();
     static char temp[MAXPATHLEN];
-    int vol = VolID;
+    uint16_t vol = VolID;
     off_t  offset;
     off_t  offset_r;
     off_t  written;
     off_t  written_r;
     size_t nbe;
     size_t nbe_r;
-    int i;
     int push;
     DSI *dsi;
-    fprintf(stdout, "Write quantum %ld, size %ld\n", Quantum, Size);
+    reset_statistics();
+    print_test_header("Write");
     header();
     sprintf(temp, "WriteTest-%d", id);
 
-    if (ntohl(AFPERR_NOOBJ) != is_there(Conn, VolID, DIRDID_ROOT, temp)) {
-        test_nottested();
+    if (check_test_dir_exists(vol, temp, "Write")) {
         return;
     }
 
     if (!(dir = VFS.createdir(Conn, vol, DIRDID_ROOT, temp))) {
+        fprintf(stderr, "Error: Write test failed to create directory '%s'\n", temp);
         test_nottested();
         goto fin;
     }
 
     if (VFS.createfile(Conn, vol, 0, dir, "File")) {
+        fprintf(stderr, "Error: Write test failed to create file 'File'\n");
         test_failed();
         goto fin;
     }
 
     dsi = &Conn->dsi;
+    int total_runs = WarmupRuns + Count;
 
-    for (i = 1; i <= Count; i++) {
-        fork = VFS.openfork(Conn, vol, OPENFORK_DATA, (1 << FILPBIT_FNUM), dir, "File",
+    for (int i = 1; i <= total_runs; i++) {
+        /* Set warmup phase flag */
+        in_warmup_phase = (i <= WarmupRuns);
+        int display_iter = in_warmup_phase ? i : (i - WarmupRuns);
+        fork = VFS.openfork(Conn, vol, OPENFORK_DATA, (uint16_t)(1U << FILPBIT_FNUM),
+                            dir, "File",
                             OPENACC_WR | OPENACC_RD | OPENACC_DWR | OPENACC_DRD);
 
         if (!fork) {
+            fprintf(stderr, "Error: Write test failed to open fork at iteration %d\n", i);
             test_failed();
             goto fin1;
         }
 
-        fprintf(stdout, "%d\t", i);
+        print_iteration_marker(i, display_iter);
         gettimeofday(&Timer_start, NULL);
         nbe = nbe_r = Quantum;
         written = written_r = Size;
@@ -686,7 +912,7 @@ void Write(void)
             goto fin1;
         }
 
-        timer_footer();
+        timer_footer("Write", display_iter);
 
         if (VFS.closefork(Conn, fork)) {
             test_failed();
@@ -694,6 +920,11 @@ void Write(void)
         }
 
         fork = 0;
+
+        /* Add delay between iterations (not after last iteration) */
+        if (DelaySeconds > 0 && i < total_runs) {
+            sleep(DelaySeconds);
+        }
 
         if (Delete) {
             if (VFS.delete(Conn, vol, dir, "File")
@@ -707,25 +938,28 @@ void Write(void)
 fin1:
 
     if (fork && VFS.closefork(Conn, fork)) {
-        test_failed();
+        fprintf(stderr, "Warning: Write cleanup - failed to close fork\n");
     }
 
     if (VFS.delete(Conn, vol, dir, "File")) {
-        test_failed();
+        fprintf(stderr, "Warning: Write cleanup - failed to delete file 'File'\n");
     }
 
 fin:
 
     if (VFS.delete(Conn, vol, dir, "")) {
-        test_failed();
+        fprintf(stderr, "Warning: Write cleanup - failed to delete directory\n");
     }
 
-    fprintf(stdout, "\n");
+    /* Print statistics and collect results */
+    print_and_collect_results("Write");
     return;
 }
 
-/* ------------------------ */
-int init_fork(int fork)
+/*!
+ * @brief Initialize fork by truncating to 0 then setting to File_size
+ */
+int init_fork(uint16_t fork)
 {
     off_t  written;
     off_t  offset;
@@ -733,7 +967,7 @@ int init_fork(int fork)
 
     if (Sparse) {
         /* assume server will create a sparse file */
-        if (VFS.setforkparam(Conn, fork, (1 << FILPBIT_DFLEN), Size)) {
+        if (VFS.setforkparam(Conn, fork, (uint16_t)(1U << FILPBIT_DFLEN), Size)) {
             return -1;
         }
 
@@ -764,7 +998,9 @@ int init_fork(int fork)
     return 0;
 }
 
-/* ------------------ */
+/*!
+ * @brief Get file descriptor from fork (AFP or Local mode)
+ */
 static int getfd(CONN *conn, int fork)
 {
     DSI *dsi;
@@ -777,19 +1013,21 @@ static int getfd(CONN *conn, int fork)
     return dsi->socket;
 }
 
-/* ------------------ */
+/*!
+ * @brief Execute Copy test with configured file size and iterations
+ */
 void Copy(void)
 {
     int dir = 0;
     int dir2 = 0;
-    int fork = 0;
-    int fork2 = 0;
+    uint16_t fork = 0;
+    uint16_t fork2 = 0;
     int fork_fd;
     int fork2_fd;
     int id = getpid();
     static char temp[MAXPATHLEN];
-    int vol = VolID;
-    int vol2 = VolID2;
+    uint16_t vol = VolID;
+    uint16_t vol2 = VolID2;
     off_t  written;
     off_t  written_r;
     off_t  written_w;
@@ -799,20 +1037,18 @@ void Copy(void)
     size_t nbe;
     size_t nbe_r;
     size_t nbe_w;
-    int i;
     int push;
     DSI *dsi;
     int max = Request;
     int cnt = 0;
     dsi = &Conn->dsi;
-    fprintf(stdout, "Copy quantum %ld, size %ld %s\n", Quantum, Size,
-            Sparse ? "sparse file" : "");
+    reset_statistics();
+    print_test_header("Copy");
     header();
     sprintf(temp, "CopyTest-%d", id);
 
     if (!Filename) {
-        if (ntohl(AFPERR_NOOBJ) != is_there(Conn, VolID, DIRDID_ROOT, temp)) {
-            test_nottested();
+        if (check_test_dir_exists(vol, temp, "Copy")) {
             return;
         }
     } else {
@@ -858,8 +1094,14 @@ void Copy(void)
         goto fin;
     }
 
-    for (i = 1; i <= Count; i++) {
-        fork = VFS.openfork(Conn, vol, OPENFORK_DATA, (1 << FILPBIT_FNUM), dir, temp,
+    int total_runs = WarmupRuns + Count;
+
+    for (int i = 1; i <= total_runs; i++) {
+        /* Set warmup phase flag */
+        in_warmup_phase = (i <= WarmupRuns);
+        int display_iter = in_warmup_phase ? i : (i - WarmupRuns);
+        fork = VFS.openfork(Conn, vol, OPENFORK_DATA, (uint16_t)(1U << FILPBIT_FNUM),
+                            dir, temp,
                             OPENACC_WR | OPENACC_RD | OPENACC_DWR | OPENACC_DRD);
 
         if (!fork) {
@@ -867,7 +1109,8 @@ void Copy(void)
             goto fin1;
         }
 
-        fork2 = VFS.openfork(Conn, vol2, OPENFORK_DATA, (1 << FILPBIT_FNUM), dir2,
+        fork2 = VFS.openfork(Conn, vol2, OPENFORK_DATA, (uint16_t)(1U << FILPBIT_FNUM),
+                             dir2,
                              "Destination", OPENACC_WR | OPENACC_RD | OPENACC_DWR | OPENACC_DRD);
 
         if (!fork2) {
@@ -884,7 +1127,7 @@ void Copy(void)
 
         fork_fd = getfd(Conn, fork);
         fork2_fd = getfd(Conn, fork2);
-        fprintf(stdout, "%d\t", i);
+        print_iteration_marker(i, display_iter);
         gettimeofday(&Timer_start, NULL);
         nbe = nbe_r = nbe_w = Quantum;
         written = written_r = written_w = Size;
@@ -924,6 +1167,11 @@ void Copy(void)
                 }
 
                 if (cnt >= max * 2 - 1) {
+                    /* Adjust write size if remaining data is smaller than quantum */
+                    if (written_w < Quantum) {
+                        nbe_w = written_w;
+                    }
+
                     if (VFS.writefooter(dsi, fork2, offset_w, nbe_w, Buffer, 0)) {
                         test_failed();
                         goto fin1;
@@ -980,7 +1228,7 @@ void Copy(void)
             offset_w += nbe_w;
         }
 
-        timer_footer();
+        timer_footer("Copy", display_iter);
 
         if (VFS.closefork(Conn, fork)) {
             test_failed();
@@ -995,6 +1243,11 @@ void Copy(void)
         }
 
         fork2 = 0;
+
+        /* Add delay between iterations (not after last iteration) */
+        if (DelaySeconds > 0 && i < total_runs) {
+            sleep(DelaySeconds);
+        }
 
         if (Delete) {
             if (!Filename && VFS.delete(Conn, vol, dir, temp)) {
@@ -1020,53 +1273,68 @@ void Copy(void)
 fin1:
 
     if (fork && VFS.closefork(Conn, fork)) {
-        test_failed();
+        fprintf(stderr, "Warning: Copy cleanup - failed to close fork\n");
     }
 
     if (fork2 && VFS.closefork(Conn, fork2)) {
-        test_failed();
+        fprintf(stderr, "Warning: Copy cleanup - failed to close fork2\n");
     }
 
     if (!Filename && VFS.delete(Conn, vol, dir, temp)) {
-        test_failed();
+        fprintf(stderr, "Warning: Copy cleanup - failed to delete source file\n");
     }
 
     if (VFS.delete(Conn, vol2,  dir2, "Destination")) {
-        test_failed();
+        fprintf(stderr, "Warning: Copy cleanup - failed to delete destination file\n");
     }
 
 fin:
 
     if (!Filename && dir && VFS.delete(Conn, vol, dir, "")) {
-        test_failed();
+        fprintf(stderr, "Warning: Copy cleanup - failed to delete source directory\n");
     }
 
     if (dir2 && dir2 != dir && VFS.delete(Conn, vol2,  dir2, "")) {
-        test_failed();
+        fprintf(stderr,
+                "Warning: Copy cleanup - failed to delete destination directory\n");
     }
 
-    fprintf(stdout, "\n");
+    /* Print statistics and collect results */
+    print_and_collect_results("Copy");
     return;
 }
 
-/* ------------------ */
+/*!
+ * @brief Execute ServerCopy test with configured file size and iterations
+ */
 void ServerCopy(void)
 {
     int dir = 0;
     int dir2 = 0;
-    int fork = 0;
+    uint16_t fork = 0;
     int id = getpid();
     static char temp[MAXPATHLEN];
-    int vol = VolID;
-    int vol2 = VolID2;
-    int i;
-    fprintf(stdout, "ServerCopy quantum %ld, size %ld %s\n", Quantum, Size,
-            Sparse ? "sparse file" : "");
+    uint16_t vol = VolID;
+    uint16_t vol2 = VolID2;
+
+    /* ServerCopy requires AFP server - skip in Local mode */
+    if (Local) {
+        if (output_format == OUTPUT_TEXT) {
+            fprintf(stdout, "\n===== Test Passes for ServerCopy =====\n");
+            fprintf(stdout,
+                    "ServerCopy test skipped in Local mode (requires AFP server)\n");
+        }
+
+        test_skipped(0);  /* Skip reason: Local mode - ServerCopy requires AFP server */
+        return;
+    }
+
+    reset_statistics();
+    print_test_header("ServerCopy");
     header();
     sprintf(temp, "ServerCopyTest-%d", id);
 
-    if (ntohl(AFPERR_NOOBJ) != is_there(Conn, VolID, DIRDID_ROOT, temp)) {
-        test_nottested();
+    if (check_test_dir_exists(vol, temp, "ServerCopy")) {
         return;
     }
 
@@ -1093,8 +1361,14 @@ void ServerCopy(void)
         goto fin;
     }
 
-    for (i = 1; i <= Count; i++) {
-        fork = VFS.openfork(Conn, vol, OPENFORK_DATA, (1 << FILPBIT_FNUM), dir,
+    int total_runs = WarmupRuns + Count;
+
+    for (int i = 1; i <= total_runs; i++) {
+        /* Set warmup phase flag */
+        in_warmup_phase = (i <= WarmupRuns);
+        int display_iter = in_warmup_phase ? i : (i - WarmupRuns);
+        fork = VFS.openfork(Conn, vol, OPENFORK_DATA, (uint16_t)(1U << FILPBIT_FNUM),
+                            dir,
                             "Source", OPENACC_WR | OPENACC_RD);
 
         if (!fork) {
@@ -1115,7 +1389,7 @@ void ServerCopy(void)
         }
 
         fork = 0;
-        fprintf(stdout, "%d\t", i);
+        print_iteration_marker(i, display_iter);
         gettimeofday(&Timer_start, NULL);
 
         if (VFS.copyfile(Conn, vol, dir, vol2, dir2, "Source", "", "Destination")) {
@@ -1123,7 +1397,7 @@ void ServerCopy(void)
             goto fin1;
         }
 
-        timer_footer();
+        timer_footer("ServerCopy", display_iter);
 
         if (Delete) {
             if (VFS.delete(Conn, vol, dir, "Source")) {
@@ -1146,36 +1420,41 @@ void ServerCopy(void)
 fin1:
 
     if (fork && VFS.closefork(Conn, fork)) {
-        test_failed();
+        fprintf(stderr, "Warning: ServerCopy cleanup - failed to close fork\n");
     }
 
     if (VFS.delete(Conn, vol, dir, "Source")) {
-        test_failed();
+        fprintf(stderr, "Warning: ServerCopy cleanup - failed to delete source file\n");
     }
 
     VFS.delete(Conn, vol2,  dir2, "Destination");
 fin:
 
     if (dir && VFS.delete(Conn, vol, dir, "")) {
-        test_failed();
+        fprintf(stderr,
+                "Warning: ServerCopy cleanup - failed to delete source directory\n");
     }
 
     if (dir2 && dir2 != dir && VFS.delete(Conn, vol2,  dir2, "")) {
-        test_failed();
+        fprintf(stderr,
+                "Warning: ServerCopy cleanup - failed to delete destination directory\n");
     }
 
-    fprintf(stdout, "\n");
+    /* Print statistics and collect results */
+    print_and_collect_results("ServerCopy");
     return;
 }
 
-/* ------------------ */
+/*!
+ * @brief Execute Read test with configured file size and iterations
+ */
 void Read(void)
 {
     int dir = 0;
-    int fork = 0;
+    uint16_t fork = 0;
     int id = getpid();
     static char temp[MAXPATHLEN];
-    int vol = VolID;
+    uint16_t vol = VolID;
     off_t  written;
     off_t  written_r;
     off_t  offset = 0;
@@ -1183,26 +1462,26 @@ void Read(void)
     size_t nbe;
     size_t nbe_r;
     DSI *dsi;
-    int i;
     int push;
-    fprintf(stdout, "Read quantum %ld, size %ld %s\n", Quantum, Size,
-            Sparse ? "sparse file" : "");
+    reset_statistics();
+    print_test_header("Read");
     header();
 
     if (!Filename) {
         sprintf(temp, "ReadTest-%d", id);
 
-        if (ntohl(AFPERR_NOOBJ) != is_there(Conn, VolID, DIRDID_ROOT, temp)) {
-            test_nottested();
+        if (check_test_dir_exists(vol, temp, "Read")) {
             return;
         }
 
         if (!(dir = VFS.createdir(Conn, vol, DIRDID_ROOT, temp))) {
+            fprintf(stderr, "Error: Read test failed to create directory '%s'\n", temp);
             test_nottested();
             goto fin;
         }
 
         if (VFS.createfile(Conn, vol, 0, dir, "File")) {
+            fprintf(stderr, "Error: Read test failed to create file 'File'\n");
             test_failed();
             goto fin;
         }
@@ -1219,9 +1498,14 @@ void Read(void)
     }
 
     dsi = &Conn->dsi;
+    int total_runs = WarmupRuns + Count;
 
-    for (i = 1; i <= Count; i++) {
-        fork = VFS.openfork(Conn, vol, OPENFORK_DATA, (1 << FILPBIT_FNUM), dir, temp,
+    for (int i = 1; i <= total_runs; i++) {
+        /* Set warmup phase flag */
+        in_warmup_phase = (i <= WarmupRuns);
+        int display_iter = in_warmup_phase ? i : (i - WarmupRuns);
+        fork = VFS.openfork(Conn, vol, OPENFORK_DATA, (uint16_t)(1U << FILPBIT_FNUM),
+                            dir, temp,
                             OPENACC_WR | OPENACC_RD | OPENACC_DWR | OPENACC_DRD);
 
         if (!fork) {
@@ -1242,7 +1526,7 @@ void Read(void)
         offset = 0;
         offset_r = 0;
         push = 0;
-        fprintf(stdout, "%d\t", i);
+        print_iteration_marker(i, display_iter);
         gettimeofday(&Timer_start, NULL);
 
         while (written) {
@@ -1290,13 +1574,18 @@ void Read(void)
             offset_r += nbe_r;
         }
 
-        timer_footer();
+        timer_footer("Read", display_iter);
 
         if (VFS.closefork(Conn, fork)) {
             test_failed();
         }
 
         fork = 0;
+
+        /* Add delay between iterations (not after last iteration) */
+        if (DelaySeconds > 0 && i < total_runs) {
+            sleep(DelaySeconds);
+        }
 
         if (!Filename && Delete) {
             if (VFS.delete(Conn, vol, dir, temp)) {
@@ -1313,20 +1602,21 @@ void Read(void)
 fin1:
 
     if (fork && VFS.closefork(Conn, fork)) {
-        test_failed();
+        fprintf(stderr, "Warning: Read cleanup - failed to close fork\n");
     }
 
     if (!Filename && VFS.delete(Conn, vol, dir, temp)) {
-        test_failed();
+        fprintf(stderr, "Warning: Read cleanup - failed to delete file\n");
     }
 
 fin:
 
     if (!Filename && VFS.delete(Conn, vol, dir, "")) {
-        test_failed();
+        fprintf(stderr, "Warning: Read cleanup - failed to delete directory\n");
     }
 
-    fprintf(stdout, "\n");
+    /* Print statistics and collect results */
+    print_and_collect_results("Read");
     return;
 }
 
@@ -1347,28 +1637,94 @@ static struct test_entry test_table[] = {
     { NULL, NULL }
 };
 
+/*!
+ * @brief Execute single test by name (Read/Write/Copy/ServerCopy)
+ */
 static void run_one(char *name)
 {
     char *token;
     char *tp;
-    dsi = &Conn->dsi;
-    press_enter("Opening volume.");
-    VolID = VFS.openvol(Conn, Vol);
 
-    if (VolID == 0xffff) {
-        test_nottested();
-        return;
+    /* Print welcome message and test configuration */
+    if (output_format == OUTPUT_TEXT) {
+        fprintf(stdout, "\n");
+        fprintf(stdout, "AFP Speedtest - Configuration\n");
+        fprintf(stdout,
+                "════════════════════════════════════════\n");
+
+        if (Local) {
+            fprintf(stdout, " Mode:            Local (Direct Filesystem I/O)\n");
+            fprintf(stdout, " AFP Version:     N/A (Local)\n");
+            fprintf(stdout, " Directory:       %s\n", Vol);
+        } else {
+            fprintf(stdout, " Server:          %s\n", Server);
+            fprintf(stdout, " AFP Version:     %s\n", vers);
+            fprintf(stdout, " Volume:          %s\n", Vol);
+        }
+
+        fprintf(stdout, " Tests:           %s\n", name);
+
+        if (Size < MEGABYTE) {
+            fprintf(stdout, " File Size:       %ld KB\n", Size / KILOBYTE);
+        } else {
+            fprintf(stdout, " File Size:       %ld MB\n", Size / MEGABYTE);
+        }
+
+        fprintf(stdout, " Iterations:      %d\n", Count);
+        fprintf(stdout, " Warmup Runs:     %d\n", WarmupRuns);
+
+        if (DelaySeconds > 0) {
+            fprintf(stdout, " Delay:           %d seconds\n", DelaySeconds);
+        }
+
+        if (enable_statistics) {
+            fprintf(stdout, " Statistics:      Enabled\n");
+        }
+
+        fprintf(stdout, "\n");
     }
 
-    if (*Vol2) {
-        VolID2 = VFS.openvol(Conn, Vol2);
+    dsi = &Conn->dsi;
 
-        if (VolID2 == 0xffff) {
+    /* In size sweep mode, volumes remain open across size iterations.
+     * Only open if not already open (VolID == 0xffff means not yet opened). */
+    if (!size_sweep_enabled || VolID == 0xffff) {
+        press_enter("Opening volume.");
+        VolID = VFS.openvol(Conn, Vol);
+
+        if (VolID == 0xffff) {
+            fprintf(stderr, "Error: Failed to open volume/directory '%s'\n", Vol);
             test_nottested();
             return;
         }
+    }
+
+    if (*Vol2) {
+        /* Only open Vol2 if not already open */
+        if (!size_sweep_enabled || VolID2 == 0xffff) {
+            VolID2 = VFS.openvol(Conn, Vol2);
+
+            if (VolID2 == 0xffff) {
+                test_nottested();
+                return;
+            }
+        }
     } else {
         VolID2 = VolID;
+    }
+
+    /* Capture network metrics before this test */
+    if (!Local && enable_statistics) {
+        /* For size sweep: initialize session on first test */
+        if (size_sweep_enabled &&
+                all_results.read_count == 0 &&
+                all_results.write_count == 0 &&
+                all_results.copy_count == 0 &&
+                all_results.servercopy_count == 0) {
+            tcp_analytics_session_start(&tcp_session, Conn);
+        }
+
+        tcp_analytics_test_start(&tcp_session, Conn, Size);
     }
 
     /* check server quantum size */
@@ -1425,27 +1781,56 @@ static void run_one(char *name)
     }
 
     free(tp);
-    VFS.closevol(Conn, VolID);
 
-    if (*Vol2) {
-        VFS.closevol(Conn, VolID2);
+    /* Capture network metrics after this test and print comparison */
+    if (!Local && enable_statistics) {
+        tcp_analytics_test_end(&tcp_session, Conn);
     }
+
+    /* In size sweep mode, keep volumes open across all size iterations
+     * Only close after all sizes tested (handled in run_one_with_size_sweep) */
+    if (!size_sweep_enabled) {
+        VFS.closevol(Conn, VolID);
+
+        if (*Vol2) {
+            VFS.closevol(Conn, VolID2);
+        }
+
+        /* Clean up test directories - only in non-sweep mode or after all sweeps complete */
+        if (Local) {
+            /* Local mode: use system rm -rf (POSIX operations, not AFP) */
+            char cleanup_cmd[MAXPATHLEN * 2];
+            int cleanup_pid = getpid();
+            snprintf(cleanup_cmd, sizeof(cleanup_cmd),
+                     "rm -rf %s/ReadTest-%d %s/WriteTest-%d %s/CopyTest-%d %s/ServerCopyTest-%d 2>/dev/null",
+                     Vol, cleanup_pid, Vol, cleanup_pid, Vol, cleanup_pid, Vol, cleanup_pid);
+            system(cleanup_cmd);
+        }
+    }
+
+    /* AFP mode: tests clean up properly via VFS.delete() in fin: sections */
 }
 
-/* =============================== */
+/*!
+ * @brief Display usage information and exit
+ */
 void usage(char *av0)
 {
     fprintf(stdout,
-            "usage:\t%s [-1234567aeLnVvy] [-h host] [-p port] [-s vol] [-S vol2] [-u user] [-w password] [-n iterations] "
-            "[-d size] [-q quantum] [-f test] [-F file] \n", av0);
+            "usage:\t%s [-1234567acDeiLTVvy] [-h host] [-p port] [-s vol] [-P path] [-S vol2] [-u user] [-w password] [-n iterations] [-W warmup] "
+            "[-t delay] [-d size] [-z sizes] [-q quantum] [-r requests] [-f test] [-F file] \n",
+            av0);
     fprintf(stdout, "\t-h\tserver host name (default localhost)\n");
     fprintf(stdout, "\t-p\tserver port (default 548)\n");
-    fprintf(stdout, "\t-s\tvolume to mount\n");
+    fprintf(stdout, "\t-s\tvolume/share to mount (AFP mode)\n");
+    fprintf(stdout, "\t-P\tlocal directory path (Local mode with -L)\n");
     fprintf(stdout, "\t-S\tsecond volume to mount\n");
     fprintf(stdout, "\t-u\tuser name (default uid)\n");
     fprintf(stdout, "\t-w\tpassword\n");
+    fprintf(stdout, "\t-c\toutput in CSV format (auto-enables statistics)\n");
     fprintf(stdout, "\t-L\tuse posix calls (default AFP calls)\n");
-    fprintf(stdout, "\t-D\twith -L use O_DIRECT in open flags (default no)\n");
+    fprintf(stdout,
+            "\t-D\tdisable O_DIRECT in Local mode (default: auto-enabled)\n");
     fprintf(stdout, "\t-1\tAFP 2.1 version\n");
     fprintf(stdout, "\t-2\tAFP 2.2 version\n");
     fprintf(stdout, "\t-3\tAFP 3.0 version\n");
@@ -1454,11 +1839,16 @@ void usage(char *av0)
     fprintf(stdout, "\t-6\tAFP 3.3 version\n");
     fprintf(stdout, "\t-7\tAFP 3.4 version (default)\n");
     fprintf(stdout, "\t-n\thow many iterations to run (default: 1)\n");
-    fprintf(stdout, "\t-d\tfile size (Mbytes, default 64)\n");
-    fprintf(stdout, "\t-q\tpacket size (Kbytes, default server quantum)\n");
-    fprintf(stdout, "\t-r\tnumber of outstanding requests (default 1)\n");
+    fprintf(stdout, "\t-W\twarmup runs excluded from statistics (default: 1)\n");
+    fprintf(stdout, "\t-T\tshow statistics (auto-enabled when n > 1)\n");
     fprintf(stdout,
-            "\t-R\tnumber of not interleaved outstanding requests (default 1)\n");
+            "\t-t\tdelay in seconds between test iterations (default: 0)\n");
+    fprintf(stdout, "\t-d\tfile size (Mbytes, default 64)\n");
+    fprintf(stdout,
+            "\t-z\tfile size sweep, comma-separated list in MB (e.g., '0.004,1,2,4,8,16') (max 1024)\n");
+    fprintf(stdout, "\t-q\tpacket size (Kbytes, default server quantum)\n");
+    fprintf(stdout,
+            "\t-r\tnumber of outstanding requests for pipelining (default 1)\n");
     fprintf(stdout, "\t-y\tuse a new file for each run (default same file)\n");
     fprintf(stdout, "\t-e\tsparse file (default no)\n");
     fprintf(stdout, "\t-a\tdon't flush to disk after write (default yes)\n");
@@ -1473,7 +1863,9 @@ void usage(char *av0)
     exit(1);
 }
 
-/* ------------------------------- */
+/*!
+ * @brief Main entry point: parse arguments, setup connection, run tests
+ */
 int main(int ac, char **av)
 {
     int cc;
@@ -1483,7 +1875,7 @@ int main(int ac, char **av)
     }
 
     while ((cc = getopt(ac, av,
-                        "1234567aeDiLVvyc:d:F:f:h:n:o:p:q:R:r:S:s:u:w:")) != EOF) {
+                        "1234567aceDiLTVvyd:F:f:h:n:p:P:q:r:S:s:t:u:w:W:z:")) != EOF) {
         switch (cc) {
         case '1':
             vers = "AFPVersion 2.1";
@@ -1524,8 +1916,15 @@ int main(int ac, char **av)
             Flush = 0;
             break;
 
+        case 'c':
+            output_format = OUTPUT_CSV;
+            Quiet = 1;  /* CSV mode is always quiet */
+            enable_statistics = 1;  /* Auto-enable statistics for CSV */
+            break;
+
         case 'D':
-            Direct = 1;
+            /* -D flag: disable O_DIRECT in Local mode (auto-enabled by default) */
+            Direct = 0;
             break;
 
         case 'd':
@@ -1570,12 +1969,12 @@ int main(int ac, char **av)
 
             break;
 
-        case 'q':
-            Quantum = atoi(optarg) * KILOBYTE;
+        case 'P':
+            LocalPath = strdup(optarg);
             break;
 
-        case 'R':
-            Req = atoi(optarg);
+        case 'q':
+            Quantum = atoi(optarg) * KILOBYTE;
             break;
 
         case 'r':
@@ -1587,7 +1986,26 @@ int main(int ac, char **av)
             break;
 
         case 's':
-            Vol = strdup(optarg);
+
+            /* Ignore -s in Local mode (use -P instead) */
+            if (!Local) {
+                Vol = strdup(optarg);
+            }
+
+            break;
+
+        case 'T':
+            enable_statistics = 1;
+            break;
+
+        case 't':
+            DelaySeconds = atoi(optarg);
+
+            if (DelaySeconds < 0) {
+                fprintf(stderr, "Invalid delay: %s (must be >= 0)\n", optarg);
+                exit(1);
+            }
+
             break;
 
         case 'u':
@@ -1607,29 +2025,161 @@ int main(int ac, char **av)
             Password = strdup(optarg);
             break;
 
+        case 'W':
+            WarmupRuns = atoi(optarg);
+
+            if (WarmupRuns < 0 || WarmupRuns > MAX_ITERATIONS) {
+                fprintf(stderr, "Invalid warmup runs: %s (max %d)\n",
+                        optarg, MAX_ITERATIONS);
+                exit(1);
+            }
+
+            break;
+
         case 'y':
             Delete = 1;
             break;
+
+        case 'z': {
+            char *token = strtok(optarg, ",");
+
+            while (token && size_sweep_count < MAX_SIZE_SWEEP) {
+                double size_mb = atof(token);
+
+                if (size_mb < 0.004 || size_mb > 1024) {
+                    fprintf(stderr,
+                            "Invalid size in sweep: %s (must be between 0.004 and 1024 MB)\n", token);
+                    exit(1);
+                }
+
+                size_sweep_values[size_sweep_count++] = (off_t)(size_mb * MEGABYTE);
+                token = strtok(NULL, ",");
+            }
+
+            if (size_sweep_count == 0) {
+                fprintf(stderr, "No valid sizes provided for sweep\n");
+                exit(1);
+            }
+
+            size_sweep_enabled = 1;
+            /* Auto-enable statistics for size sweep */
+            enable_statistics = 1;
+        }
+        break;
 
         default :
             usage(av[0]);
         }
     }
 
-    if (!Quiet) {
-        fprintf(stdout, "Connecting to host %s:%d\n", Server, Port);
+    /* Set default size sweep if no -d or -z was specified */
+    if (!size_sweep_enabled && Size == 64 * MEGABYTE) {
+        /* Default sweep: 4K,8K,16K,32K,64K,128K,256K,512K,1M,2M,4M,8M,16M,32M,64M,128M,256M,512M */
+        size_sweep_values[0] = 4 * KILOBYTE;
+        size_sweep_values[1] = 8 * KILOBYTE;
+        size_sweep_values[2] = 16 * KILOBYTE;
+        size_sweep_values[3] = 32 * KILOBYTE;
+        size_sweep_values[4] = 64 * KILOBYTE;
+        size_sweep_values[5] = 128 * KILOBYTE;
+        size_sweep_values[6] = 256 * KILOBYTE;
+        size_sweep_values[7] = 512 * KILOBYTE;
+        size_sweep_values[8] = 1 * MEGABYTE;
+        size_sweep_values[9] = 2 * MEGABYTE;
+        size_sweep_values[10] = 4 * MEGABYTE;
+        size_sweep_values[11] = 8 * MEGABYTE;
+        size_sweep_values[12] = 16 * MEGABYTE;
+        size_sweep_values[13] = 32 * MEGABYTE;
+        size_sweep_values[14] = 64 * MEGABYTE;
+        size_sweep_values[15] = 128 * MEGABYTE;
+        size_sweep_values[16] = 256 * MEGABYTE;
+        size_sweep_values[17] = 512 * MEGABYTE;
+        size_sweep_count = 18;
+        size_sweep_enabled = 1;
+        enable_statistics = 1;
     }
 
-    if (User != NULL && User[0] == '\0') {
-        fprintf(stdout, "Error: Define a user with -u\n");
+    /* Validate Local mode requirements */
+    if (Local) {
+        if (LocalPath == NULL || LocalPath[0] == '\0') {
+            fprintf(stderr, "Error: Local mode (-L) requires a directory path with -P\n");
+            fprintf(stderr, "Example: afp_speedtest -L -P /path/to/directory\n");
+            exit(1);
+        }
+
+        /* Use LocalPath as Vol for local operations */
+        Vol = LocalPath;
+
+        /* Ensure the directory exists - try mkdir, accept EEXIST */
+        if (mkdir(Vol, 0750) != 0) {
+            if (errno == EEXIST) {
+                /* Directory exists - verify it's actually a directory */
+                struct stat st;
+
+                if (stat(Vol, &st) != 0) {
+                    fprintf(stderr, "Error: Cannot stat '%s': %s\n", Vol, strerror(errno));
+                    exit(1);
+                }
+
+                if (!S_ISDIR(st.st_mode)) {
+                    fprintf(stderr, "Error: '%s' exists but is not a directory\n", Vol);
+                    exit(1);
+                }
+            } else {
+                fprintf(stderr, "Error: Failed to create directory '%s': %s\n", Vol,
+                        strerror(errno));
+                exit(1);
+            }
+        } else {
+            fprintf(stderr, "INFO: Created directory: %s\n", Vol);
+        }
+
+        /* Always warn about ignored AFP parameters in Local mode (important info) */
+        fprintf(stderr,
+                "INFO: Local mode (-L) active - ignoring AFP parameters (-h, -p, -u, -w, -s)\n");
+        fprintf(stderr, "INFO: Using local filesystem path: %s\n", Vol);
+        fprintf(stderr, "INFO: O_DIRECT mode: %s%s\n",
+                Direct ? "ENABLED" : "DISABLED",
+                Direct ? " (bypasses kernel page cache for realistic AFP comparison)" :
+                " (buffered I/O testing)");
+    } else {
+        /* Normal AFP mode validation */
+        /* O_DIRECT is only relevant in Local mode - disable for AFP */
+        Direct = 0;
+
+        if (!Quiet) {
+            fprintf(stdout, "Connecting to host %s:%d\n", Server, Port);
+        }
+
+        if (User != NULL && User[0] == '\0') {
+            fprintf(stdout, "Error: Define a user with -u\n");
+        }
+
+        if (Password != NULL && Password[0] == '\0') {
+            fprintf(stdout, "Error: Define a password with -w\n");
+        }
+
+        if (Vol != NULL && Vol[0] == '\0') {
+            fprintf(stdout, "Error: Define a volume with -s\n");
+        }
     }
 
-    if (Password != NULL && Password[0] == '\0') {
-        fprintf(stdout, "Error: Define a password with -w\n");
+    /* Validate total iterations */
+    if (WarmupRuns + Count > MAX_ITERATIONS) {
+        fprintf(stderr, "Total runs (%d warmup + %d test) exceeds max %d\n",
+                WarmupRuns, Count, MAX_ITERATIONS);
+        exit(1);
     }
 
-    if (Vol != NULL && Vol[0] == '\0') {
-        fprintf(stdout, "Error: Define a volume with -s\n");
+    /* Auto-enable statistics when multiple iterations */
+    if (Count > 1 && !enable_statistics) {
+        enable_statistics = 1;
+    }
+
+    /* Initialize TCP analytics session */
+    if (!Local && enable_statistics) {
+        tcp_analytics_init(&tcp_session,
+                           output_format == OUTPUT_CSV ? TCP_OUTPUT_CSV : TCP_OUTPUT_TEXT,
+                           size_sweep_enabled);
     }
 
     /**************************
@@ -1640,9 +2190,13 @@ int main(int ac, char **av)
     }
 
     if (Local) {
+        /* Configure Local VFS */
+        Local_VFS_Quiet = Quiet;
+        Local_VFS_Direct = Direct;
         Dsi = &Conn->dsi;
         dsi = Dsi;
-        dsi->server_quantum = 512 * KILOBYTE;
+        /* Use 1 MB quantum for Local mode - no network overhead, optimized for filesystem I/O */
+        dsi->server_quantum = 1 * MEGABYTE;
         VFS = local_VFS;
     } else {
         int sock;
@@ -1667,7 +2221,7 @@ int main(int ac, char **av)
     Conn->afp_version = Version;
     /*********************************
     */
-    run_one(Test);
+    run_one_with_size_sweep(Test);
 
     if (!Local) {
         FPLogOut(Conn);

--- a/test/testsuite/speedtest_local_vfs.c
+++ b/test/testsuite/speedtest_local_vfs.c
@@ -1,0 +1,519 @@
+/*
+ * Copyright (c) 2026, Andy Lemin (andylemin)
+ * Credits; Based on work by Netatalk contributors
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "speedtest_local_vfs.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include "afpcmd.h"
+
+/* For compiling on OS X and platforms without O_DIRECT */
+#ifndef O_DIRECT
+/* XXX hack */
+#define O_DIRECT 040000
+#endif
+
+/* Exported global variables */
+char *Dir_heap[MAXVOL][MAXDIR];
+char *Vol_heap[MAXVOL];
+int Local_VFS_Quiet = 0;
+int Local_VFS_Direct = 1;
+
+/* Note: Many Local VFS functions have CONN/DSI parameters for compatibility with VFS
+ * function pointer table (to match AFP function signatures), but these parameters
+ * are unused since Local mode operates on file descriptors, not AFP connections.
+ * Similarly, some no-op functions have all parameters unused. All unused parameters
+ * are marked with _U_ attribute to satisfy static analyzers. */
+
+/*!
+ * @brief Change to directory in Local VFS heap
+*/
+static int local_chdir(uint16_t vol, int did)
+{
+    if (vol > MAXVOL || did > MAXDIR) {
+        return -1;
+    }
+
+    if (!Vol_heap[vol] || !Dir_heap[vol][did]) {
+        return -1;
+    }
+
+    if (chdir(Dir_heap[vol][did])) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief Open directory as volume in Local mode
+*/
+uint16_t local_openvol(CONN *conn _U_, char *vol)
+{
+    int fd;
+
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "Open Vol %s \n\n", vol);
+    }
+
+    fd = open(vol, O_RDONLY | O_DIRECTORY);
+
+    if (fd < 0) {
+        fprintf(stderr, "Error: Failed to open directory '%s': %s\n", vol,
+                strerror(errno));
+        return 0xffff;
+    }
+
+    for (uint16_t i = 0; i < MAXVOL; i++) {
+        if (Vol_heap[i] == NULL) {
+            if (fchdir(fd) < 0) {
+                close(fd);
+                break;
+            }
+
+            close(fd);
+            Vol_heap[i] = strdup(vol);
+            Dir_heap[i][2] = strdup(vol);
+            return i;
+        }
+    }
+
+    return 0xffff;
+}
+
+/*!
+ * @brief Close volume and cleanup heaps
+*/
+unsigned int local_closevol(CONN *conn _U_, uint16_t vol)
+{
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "Close Vol %d\n\n", vol);
+    }
+
+    /* Clean up volume heap to allow reopening in size sweep mode */
+    if (vol < MAXVOL && Vol_heap[vol] != NULL) {
+        free(Vol_heap[vol]);
+        Vol_heap[vol] = NULL;
+
+        /* Clean up directory heap for this volume */
+        for (uint16_t i = 0; i < MAXDIR; i++) {
+            if (Dir_heap[vol][i] != NULL) {
+                free(Dir_heap[vol][i]);
+                Dir_heap[vol][i] = NULL;
+            }
+        }
+    }
+
+    return ntohl(AFP_OK);
+}
+
+/*!
+ * @brief Create directory via mkdir() and add to heap
+*/
+unsigned int local_createdir(CONN *conn _U_, uint16_t vol, int did, char *name)
+{
+    int dirfd;
+
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "Create Directory Vol %d did : 0x%x <%s>\n\n", vol, ntohl(did),
+                name);
+    }
+
+    did = ntohl(did);
+
+    if (local_chdir(vol, did) < 0) {
+        return 0;
+    }
+
+    for (unsigned int i = 3; i < MAXDIR; i++) {
+        if (Dir_heap[vol][i] == NULL) {
+            char temp[MAXPATHLEN + 1];
+
+            if (mkdir(name, 0750) != 0) {
+                fprintf(stderr, "Error: Failed to create directory '%s': %s\n", name,
+                        strerror(errno));
+                return ntohl(AFPERR_NOOBJ);
+            }
+
+            dirfd = open(name, O_RDONLY | O_DIRECTORY);
+
+            if (dirfd < 0) {
+                return 0;
+            }
+
+            if (fchdir(dirfd) != 0) {
+                close(dirfd);
+                return 0;
+            }
+
+            if (getcwd(temp, sizeof(temp)) == NULL) {
+                close(dirfd);
+                return 0;
+            }
+
+            close(dirfd);
+            Dir_heap[vol][i] = strdup(temp);
+            return htonl(i);
+        }
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief Check file/directory existence via stat()
+*/
+unsigned int local_getfiledirparams(CONN *conn _U_, uint16_t vol, int did,
+                                    char *name, uint16_t f_bitmap _U_, uint16_t d_bitmap _U_)
+{
+    struct stat st;
+    did = ntohl(did);
+    /* Suppress unused warning */
+    (void)f_bitmap;
+    (void)d_bitmap;
+
+    if (local_chdir(vol, did) < 0) {
+        return ntohl(AFPERR_NOOBJ);
+    }
+
+    if (*name != 0 && !stat(name, &st)) {
+        return ntohl(AFP_OK);
+    }
+
+    return ntohl(AFPERR_NOOBJ);
+}
+
+/*!
+ * @brief Delete file/directory via unlink()/rmdir()
+*/
+unsigned int local_delete(CONN *conn _U_, uint16_t vol, int did, char *name)
+{
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "FPDelete Vol %d did : 0x%x <%s>\n\n", vol, ntohl(did), name);
+    }
+
+    did = ntohl(did);
+
+    if (local_chdir(vol, did) < 0) {
+        return ntohl(AFPERR_PARAM);
+    }
+
+    if (*name != 0) {
+        if (unlink(name)) {
+            fprintf(stderr, "Error: Failed to delete file '%s': %s\n", name,
+                    strerror(errno));
+            return ntohl(AFPERR_NOOBJ);
+        }
+    } else if (rmdir(Dir_heap[vol][did])) {
+        fprintf(stderr, "Error: Failed to delete directory '%s': %s\n",
+                Dir_heap[vol][did] ? Dir_heap[vol][did] : "(null)", strerror(errno));
+        return ntohl(AFPERR_NOOBJ);
+    }
+
+    return ntohl(AFP_OK);
+}
+
+/*!
+ * @brief Create file via open()
+*/
+unsigned int local_createfile(CONN *conn _U_, uint16_t vol, char type, int did,
+                              char *name)
+{
+    int fd;
+
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "Create File %s Vol %d did : 0x%x <%s>\n\n",
+                type ? "HARD" : "SOFT", vol, ntohl(did), name);
+    }
+
+    did = ntohl(did);
+
+    if (local_chdir(vol, did) < 0) {
+        return ntohl(AFPERR_PARAM);
+    }
+
+    fd = open(name, O_RDWR | O_CREAT, 0640);
+
+    if (fd == -1) {
+        fprintf(stderr, "Error: Failed to create file '%s': %s\n", name,
+                strerror(errno));
+        return ntohl(AFPERR_NOOBJ);
+    }
+
+    close(fd);
+    return ntohl(AFP_OK);
+}
+
+/*!
+ * @brief Open file fork and return file descriptor as fork handle
+ */
+uint16_t local_openfork(CONN *conn _U_, uint16_t vol, int type,
+                        uint16_t bitmap _U_,
+                        int did, char *name, int access)
+{
+    int fd;
+    int flags = O_RDWR;
+
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "Open Fork %s Vol %d did : 0x%x <%s> access %x\n\n",
+                (type == OPENFORK_DATA) ? "data" : "resource",
+                vol, ntohl(did), name, access);
+    }
+
+    if (Local_VFS_Direct) {
+        flags |= O_DIRECT;
+    }
+
+    did = ntohl(did);
+
+    if (local_chdir(vol, did) < 0) {
+        return (uint16_t) ntohl(AFPERR_PARAM);
+    }
+
+    fd = open(name, flags, 0640);
+
+    if (fd == -1) {
+        fprintf(stderr, "Error: Failed to open file '%s': %s\n", name, strerror(errno));
+        return (uint16_t) ntohl(AFPERR_NOOBJ);
+    }
+
+    /* In Local mode, return the fd itself (it IS the fork) */
+    return (uint16_t)(fd & 0xFFFF);
+}
+
+/*!
+ * @brief Write data via lseek() + write() syscalls
+ */
+unsigned int local_writeheader(DSI *dsi _U_, uint16_t fork, int offset,
+                               int size,
+                               char *data, char whence)
+{
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "send write header fork %d  offset %d size %d from 0x%x\n\n",
+                fork, offset, size, (unsigned)whence);
+    }
+
+    if (lseek(fork, offset, SEEK_SET) == (off_t) -1) {
+        return ntohl(AFPERR_EOF);
+    }
+
+    if (write(fork, data, size) != size) {
+        return ntohl(AFPERR_EOF);
+    }
+
+    return ntohl(AFP_OK);
+}
+
+/*!
+ * @brief No-op write footer (AFP compatibility)
+ */
+unsigned int local_writefooter(DSI *dsi _U_, uint16_t fork, int offset,
+                               int size,
+                               char *data _U_, char whence)
+{
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "get write footer fork %d  offset %d size %d from 0x%x\n\n",
+                fork, offset, size, (unsigned)whence);
+    }
+
+    return ntohl(AFP_OK);
+}
+
+/*!
+ * @brief Flush file data to disk via fsync()
+*/
+unsigned int local_flushfork(CONN *conn _U_, uint16_t fork)
+{
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "Flush fork %d\n\n", fork);
+    }
+
+    if (fsync(fork) < 0) {
+        return ntohl(AFPERR_PARAM);
+    }
+
+    return ntohl(AFP_OK);
+}
+
+/*!
+ * @brief Close file descriptor
+*/
+unsigned int local_closefork(CONN *conn _U_, uint16_t fork)
+{
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "Close Fork %d\n\n", fork);
+    }
+
+    if (close(fork)) {
+        return ntohl(AFPERR_PARAM);
+    }
+
+    return ntohl(AFP_OK);
+}
+
+/*!
+ * @brief Set file size via ftruncate()
+*/
+unsigned int local_setforkparam(CONN *conn _U_, uint16_t fork,  uint16_t bitmap,
+                                off_t size)
+{
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "Set Fork param fork %d bitmap 0x%x size %ld\n\n", fork, bitmap,
+                size);
+    }
+
+    if (ftruncate(fork, size)) {
+        return ntohl(AFPERR_PARAM);
+    }
+
+    return ntohl(AFP_OK);
+}
+
+/*!
+ * @brief Write data to file via lseek() + write()
+ */
+unsigned int local_write(CONN *conn _U_, uint16_t fork, long long offset,
+                         int size,
+                         char *data, char whence)
+{
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "write fork %d  offset %lld size %d from 0x%x\n\n", fork,
+                offset, size, (unsigned)whence);
+    }
+
+    if (lseek(fork, offset, SEEK_SET) == (off_t) -1) {
+        return ntohl(AFPERR_EOF);
+    }
+
+    if (write(fork, data, size) != size) {
+        return ntohl(AFPERR_EOF);
+    }
+
+    return ntohl(AFP_OK);
+}
+
+/*!
+ * @brief Read data from file via lseek() + read()
+ */
+unsigned int local_read(CONN *conn _U_, uint16_t fork, long long offset,
+                        int size,
+                        char *data)
+{
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "read fork %d  offset %lld size %d\n\n", fork, offset, size);
+    }
+
+    if (lseek(fork, offset, SEEK_SET) == (off_t) -1) {
+        return ntohl(AFPERR_EOF);
+    }
+
+    if (read(fork, data, size) != size) {
+        return ntohl(AFPERR_EOF);
+    }
+
+    return ntohl(AFP_OK);
+}
+
+/*!
+ * @brief No-op read header (AFP compatibility)
+*/
+unsigned int local_readheader(DSI *dsi _U_, uint16_t fork, int offset, int size,
+                              char *data _U_)
+{
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "send read header fork %d  offset %d size %d\n\n", fork, offset,
+                size);
+    }
+
+    return ntohl(AFP_OK);
+}
+
+/*!
+ * @brief Read data footer via lseek() + read()
+*/
+unsigned int local_readfooter(DSI *dsi _U_, uint16_t fork, int offset, int size,
+                              char *data)
+{
+    if (!Local_VFS_Quiet) {
+        fprintf(stdout, "---------------------\n");
+        fprintf(stdout, "get read reply fork %d  offset %d size %d\n\n", fork, offset,
+                size);
+    }
+
+    if (lseek(fork, offset, SEEK_SET) == (off_t) -1) {
+        return ntohl(AFPERR_EOF);
+    }
+
+    if (read(fork, data, size) != size) {
+        return ntohl(AFPERR_EOF);
+    }
+
+    return ntohl(AFP_OK);
+}
+
+/*!
+ * @brief Copy file operation (not implemented, returns error)
+ */
+unsigned int local_copyfile(struct CONN *conn _U_, uint16_t svol _U_,
+                            int sdid _U_,
+                            uint16_t dvol _U_, int ddid _U_, char *src _U_, char *buf _U_, char *dst _U_)
+{
+    return ntohl(AFPERR_PARAM);
+}
+
+/* ------------------------------- */
+struct vfs local_VFS = {
+    local_getfiledirparams,
+    local_createdir,
+    local_createfile,
+    local_openfork,
+    local_writeheader,
+    local_writefooter,
+    local_flushfork,
+    local_closefork,
+    local_delete,
+    local_setforkparam,
+    local_write,
+    local_read,
+    local_readheader,
+    local_readfooter,
+    local_copyfile,
+    local_openvol,
+    local_closevol
+};

--- a/test/testsuite/speedtest_local_vfs.h
+++ b/test/testsuite/speedtest_local_vfs.h
@@ -1,0 +1,77 @@
+#ifndef SPEEDTEST_LOCAL_VFS_H
+#define SPEEDTEST_LOCAL_VFS_H
+
+#include <stdint.h>
+#include <sys/types.h>  /* for off_t */
+#include "afpclient.h"
+#include "dsi.h"        /* for DSI type */
+
+/* Local VFS directory/volume tracking */
+#define MAXDIR 32
+#define MAXVOL 3
+
+/* Heap management - exposed for size sweep cleanup in speedtest.c */
+extern char *Dir_heap[MAXVOL][MAXDIR];
+extern char *Vol_heap[MAXVOL];
+
+/* Configuration - must be set by caller before using Local VFS */
+extern int Local_VFS_Quiet;   /* Suppress verbose output */
+extern int Local_VFS_Direct;  /* Enable O_DIRECT flag */
+
+/* Local VFS function declarations */
+uint16_t local_openvol(CONN *conn, char *vol);
+unsigned int local_closevol(CONN *conn, uint16_t vol);
+unsigned int local_getfiledirparams(CONN *conn, uint16_t vol, int did,
+                                    char *name, uint16_t f_bitmap, uint16_t d_bitmap);
+unsigned int local_createdir(CONN *conn, uint16_t vol, int did, char *name);
+unsigned int local_createfile(CONN *conn, uint16_t vol, char type, int did,
+                              char *name);
+uint16_t local_openfork(CONN *conn, uint16_t vol, int type, uint16_t bitmap,
+                        int did, char *name, int access);
+unsigned int local_writeheader(DSI *dsi, uint16_t fork, int offset, int size,
+                               char *data, char whence);
+unsigned int local_writefooter(DSI *dsi, uint16_t fork, int offset, int size,
+                               char *data, char whence);
+unsigned int local_flushfork(CONN *conn, uint16_t fork);
+unsigned int local_closefork(CONN *conn, uint16_t fork);
+unsigned int local_delete(CONN *conn, uint16_t vol, int did, char *name);
+unsigned int local_setforkparam(CONN *conn, uint16_t fork, uint16_t bitmap,
+                                off_t size);
+unsigned int local_write(CONN *conn, uint16_t fork, long long offset, int size,
+                         char *data, char whence);
+unsigned int local_read(CONN *conn, uint16_t fork, long long offset, int size,
+                        char *data);
+unsigned int local_readheader(DSI *dsi, uint16_t fork, int offset, int size,
+                              char *data);
+unsigned int local_readfooter(DSI *dsi, uint16_t fork, int offset, int size,
+                              char *data);
+unsigned int local_copyfile(struct CONN *conn, uint16_t svol, int sdid,
+                            uint16_t dvol, int ddid, char *src, char *buf, char *dst);
+
+/* VFS function pointer structure */
+struct vfs {
+    unsigned int (*getfiledirparams)(CONN *, uint16_t, int, char *, uint16_t,
+                                     uint16_t);
+    unsigned int (*createdir)(CONN *, uint16_t, int, char *);
+    unsigned int (*createfile)(CONN *, uint16_t, char, int, char *);
+    uint16_t (*openfork)(CONN *, uint16_t, int, uint16_t, int, char *, int);
+    unsigned int (*writeheader)(DSI *, uint16_t, int, int, char *, char);
+    unsigned int (*writefooter)(DSI *, uint16_t, int, int, char *, char);
+    unsigned int (*flushfork)(CONN *, uint16_t);
+    unsigned int (*closefork)(CONN *, uint16_t);
+    unsigned int (*delete)(CONN *, uint16_t, int, char *);
+    unsigned int (*setforkparam)(CONN *, uint16_t,  uint16_t, off_t);
+    unsigned int (*write)(CONN *, uint16_t, long long, int, char *, char);
+    unsigned int (*read)(CONN *, uint16_t, long long, int, char *);
+    unsigned int (*readheader)(DSI *, uint16_t, int, int, char *);
+    unsigned int (*readfooter)(DSI *, uint16_t, int, int, char *);
+    unsigned int (*copyfile)(CONN *, uint16_t, int, uint16_t, int, char *, char *,
+                             char *);
+    uint16_t (*openvol)(CONN *, char *);
+    unsigned int (*closevol)(CONN *conn, uint16_t vol);
+};
+
+/* VFS structure - populated with local functions */
+extern struct vfs local_VFS;
+
+#endif /* SPEEDTEST_LOCAL_VFS_H */

--- a/test/testsuite/testhelper.c
+++ b/test/testsuite/testhelper.c
@@ -146,8 +146,10 @@ void test_skipped(int why)
 }
 
 /* ------------------------- */
-void test_failed(void)
+void test_failed_at(const char *file, int line)
 {
+    fprintf(stderr, "\n*** ERROR: test_failed() called at %s:%d ***\n", file, line);
+    
     if (!Quiet) {
         fprintf(stderr, "\tFAILED\n");
     }

--- a/test/testsuite/testhelper.h
+++ b/test/testsuite/testhelper.h
@@ -87,11 +87,14 @@
 #define ANSI_BOLD     "\033[1m"
 
 /* Function declarations */
-extern void test_failed(void);
+extern void test_failed_at(const char *file, int line);
 extern void test_skipped(int why);
 extern void test_nottested(void);
 extern void enter_test(void);
 extern void exit_test(char *name);
+
+/* Wrapper macro for automatic file/line tracking */
+#define test_failed() test_failed_at(__FILE__, __LINE__)
 
 /* Types */
 enum adouble {


### PR DESCRIPTION
testsuite: Enhance afp_speedtest with throughput statistics, TCP statistics, CSV export, and fix Local mode.

This change provides the framework for testing and validating future performance optimisations and modernize `speedtest`.

Major enhancements to afp_speedtest for comprehensive performance analysis:

New Features:
- CSV output mode (-c): three tables for test data, size summary, TCP metrics
- Local mode (-L -P): direct filesystem I/O baseline benchmarking with O_DIRECT
- File size sweep (-z): test multiple sizes, default 18-size sweep (4KB-512MB)
- Statistics: mean, median, standard deviation, percentiles, coefficient of variation
- Warmup runs (-W): excluded from statistics to reduce cold-start bias
- TCP metrics tracking: evolution table showing initial vs final network state (AFP mode)
- Delay between iterations (-t): for cooling down or simulating usage patterns
- O_DIRECT auto-enable: Local mode defaults to direct I/O for AFP comparison (-D to disable)

Improvements:
- Fix Local mode (-L) implementation with proper VFS abstraction
- Add proper file size units display (KB for <1MB, MB for ≥1MB)
- Add mode-appropriate configuration display
- Add division by zero guards for sub-microsecond operations

Documentation:
- Comprehensive man page update with all flags, modes, and examples
- CSV format specification and output mode descriptions

Build:
- Add -lm linker flag for statistics math functions
- Enhanced test_failed() with file:line debugging info

Validated with default 18-size sweep in both AFP and Local modes (exit code 0).

```
docker run --rm -e AFP_USER="atalk1" -e AFP_PASS="t3st1ng1" -e AFP_GROUP="afpusers" -e SHARE_NAME="test1" -e INSECURE_AUTH="1" -e TESTSUITE="speed" -e AFP_VERSION="7" netatalk_test:final 2>&1
*** Setting up environment
*** Setting up users and groups
usermod: no changes
*** Configuring shared volume
*** Fixing permissions
*** Removing residual lock files
*** Configuring Netatalk
NOTE: Set the `ATALKD_INTERFACE' environment variable to start DDP services.
*** Starting AFP server
*** Running testsuite: speed

+ TEST_EXIT_CODE=0
+ afp_speedtest -7 -h 127.0.0.1 -p 548 -u atalk1 -w t3st1ng1 -s test1 -n 5 -f Read,Write,Copy,ServerCopy

========================================
**** Testing with File Size: 4 KB ****
========================================

AFP Speedtest - Configuration
════════════════════════════════════════
 Server:          127.0.0.1
 AFP Version:     AFP3.4
 Volume:          test1
 Tests:           Read,Write,Copy,ServerCopy
 File Size:       4 KB
 Iterations:      5
 Warmup Runs:     1
 Statistics:      Enabled


===== Test Passes for Read =====
Read quantum 1024 KB, size 4 KB 
Warmup: 1 runs, Measured: 5 runs
run       microsec        MB/s
[W1]           85       45.96
1              86       45.42
2              89       43.89
3              52       75.12
4              37       105.57
5              34       114.89

===== Statistics for Read =====
File Size:      4 KB
Iterations:     5
Mean:           60 μs (65.54 MB/s)
Median:         52 μs (75.12 MB/s)
Std Dev:        24 μs (39.60%)
Min:            34 μs (114.89 MB/s)
Max:            89 μs (43.89 MB/s)

===== Test Passes for Write =====
Write quantum 1024 KB, size 4 KB
Warmup: 1 runs, Measured: 5 runs
run       microsec        MB/s
[W1]          878       4.45
1             827       4.72
2            1297       3.01
3             878       4.45
4            1170       3.34
5             975       4.01

===== Statistics for Write =====
File Size:      4 KB
Iterations:     5
Mean:           1029 μs (3.79 MB/s)
Median:         975 μs (4.01 MB/s)
Std Dev:        178 μs (17.28%)
Min:            827 μs (4.72 MB/s)
Max:            1297 μs (3.01 MB/s)

===== Test Passes for Copy =====
Copy quantum 1024 KB, size 4 KB 
Warmup: 1 runs, Measured: 5 runs
run       microsec        MB/s
[W1]          201       19.43
1             261       14.97
2             211       18.51
3             207       18.87
4             213       18.34
5             227       17.21

===== Statistics for Copy =====
File Size:      4 KB
Iterations:     5
Mean:           224 μs (17.45 MB/s)
Median:         213 μs (18.34 MB/s)
Std Dev:        20 μs (8.84%)
Min:            207 μs (18.87 MB/s)
Max:            261 μs (14.97 MB/s)

===== Test Passes for ServerCopy =====
ServerCopy quantum 1024 KB, size 4 KB 
Warmup: 1 runs, Measured: 5 runs
run       microsec        MB/s
[W1]          411       9.50
1             238       16.41
2             298       13.11
3             351       11.13
4             296       13.20
5            1042       3.75

===== Statistics for ServerCopy =====
File Size:      4 KB
Iterations:     5
Mean:           445 μs (8.78 MB/s)
Median:         298 μs (13.11 MB/s)
Std Dev:        301 μs (67.56%)
Min:            238 μs (16.41 MB/s)
Max:            1042 μs (3.75 MB/s)

=========== Network & DSI Metrics for File Size: 4 KB ===========
Connection Type: Localhost
Server Quantum:  1048576 bytes (1024.0 KB)

Metric                        Before           After           Delta
------                        ------           -----           -----
TCP Send Buffer              2565 KB         2565 KB           +0 KB
TCP Recv Buffer               128 KB          128 KB           +0 KB
TCP MSS                      32768 B         52288 B        +19520 B
TCP Cwnd (segs)                   10              10              +0
TCP SSThresh              2147483647      2147483647              +0
TCP RTT                      4.47 ms         0.30 ms        -4.17 ms
TCP RTT Variance             8.88 ms         0.16 ms        -8.71 ms
TCP Retrans                        0               0              +0
TCP Total Retrans                  0               0              +0
TCP Lost                           0               0              +0
TCP Reordering                     3               3              +0
TCP Send MSS                 32768 B         52288 B        +19520 B
TCP Recv MSS                   536 B          4112 B         +3576 B
TCP Adv MSS                  65483 B         65483 B            +0 B
TCP Recv Space                 63 KB           63 KB           +0 KB
====================================================================

.
.
.

========================================
**** Testing with File Size: 512 MB ****
========================================

AFP Speedtest - Configuration
════════════════════════════════════════
 Server:          127.0.0.1
 AFP Version:     AFP3.4
 Volume:          test1
 Tests:           Read,Write,Copy,ServerCopy
 File Size:       512 MB
 Iterations:      5
 Warmup Runs:     1
 Statistics:      Enabled


===== Test Passes for Read =====
Read quantum 1024 KB, size 512 MB 
Warmup: 1 runs, Measured: 5 runs
run       microsec        MB/s
[W1]       106763       4795.67
1           71882       7122.78
2           73364       6978.90
3           72867       7026.50
4           83074       6163.18
5           75297       6799.74

===== Statistics for Read =====
File Size:      512 MB
Iterations:     5
Mean:           75297 μs (6799.76 MB/s)
Median:         73364 μs (6978.90 MB/s)
Std Dev:        4044 μs (5.37%)
Min:            71882 μs (7122.78 MB/s)
Max:            83074 μs (6163.18 MB/s)

===== Test Passes for Write =====
Write quantum 1024 KB, size 512 MB
Warmup: 1 runs, Measured: 5 runs
run       microsec        MB/s
[W1]      1170446       437.44
1          697423       734.13
2          295167       1734.61
3          432793       1183.01
4          519213       986.11
5          331890       1542.68

===== Statistics for Write =====
File Size:      512 MB
Iterations:     5
Mean:           455297 μs (1124.54 MB/s)
Median:         432793 μs (1183.01 MB/s)
Std Dev:        144283 μs (31.69%)
Min:            295167 μs (1734.61 MB/s)
Max:            697423 μs (734.13 MB/s)

===== Test Passes for Copy =====
Copy quantum 1024 KB, size 512 MB 
Warmup: 1 runs, Measured: 5 runs
run       microsec        MB/s
[W1]       305828       1674.14
1          171801       2980.19
2          157522       3250.34
3          151381       3382.19
4          139149       3679.51
5          157346       3253.98

===== Statistics for Copy =====
File Size:      512 MB
Iterations:     5
Mean:           155440 μs (3293.88 MB/s)
Median:         157346 μs (3253.98 MB/s)
Std Dev:        10560 μs (6.79%)
Min:            139149 μs (3679.51 MB/s)
Max:            171801 μs (2980.19 MB/s)

===== Test Passes for ServerCopy =====
ServerCopy quantum 1024 KB, size 512 MB 
Warmup: 1 runs, Measured: 5 runs
run       microsec        MB/s
[W1]       129372       3957.58
1          112578       4547.96
2          111465       4593.37
3          117388       4361.60
4          115701       4425.20
5          119261       4293.11

===== Statistics for ServerCopy =====
File Size:      512 MB
Iterations:     5
Mean:           115279 μs (4441.41 MB/s)
Median:         115701 μs (4425.20 MB/s)
Std Dev:        2909 μs (2.52%)
Min:            111465 μs (4593.37 MB/s)
Max:            119261 μs (4293.11 MB/s)

=========== Network & DSI Metrics for File Size: 512 MB ===========
Connection Type: Localhost
Server Quantum:  1048576 bytes (1024.0 KB)

Metric                        Before           After           Delta
------                        ------           -----           -----
TCP Send Buffer              2565 KB         2565 KB           +0 KB
TCP Recv Buffer              6144 KB         6144 KB           +0 KB
TCP MSS                      65483 B         65483 B            +0 B
TCP Cwnd (segs)                   10              10              +0
TCP SSThresh                      20              20              +0
TCP RTT                      8.42 ms         9.62 ms        +1.20 ms
TCP RTT Variance            11.94 ms        14.27 ms        +2.33 ms
TCP Retrans                        0               0              +0
TCP Total Retrans                  0               0              +0
TCP Lost                           0               0              +0
TCP Reordering                     3               3              +0
TCP Send MSS                 65483 B         65483 B            +0 B
TCP Recv MSS                 65483 B         65483 B            +0 B
TCP Adv MSS                  65483 B         65483 B            +0 B
TCP Recv Space               7103 KB         7168 KB          +64 KB
====================================================================

╔══════════════════════════════════════════════════════════════════════════════════════╗
║                      File Size Performance Summary for Read                          ║
╠══════════════════════════════════════════════════════════════════════════════════════╣
║     Size │ Mean(MB/s) │ Median(MB/s) │ Min(MB/s) │ Max(MB/s) │ StdDev(ms) │ Mean(ms) ║
╠══════════════════════════════════════════════════════════════════════════════════════╣
║     4 KB │      65.54 │        75.12 │     43.89 │    114.89 │        0.0 │      0.1 ║
║     8 KB │      82.94 │        74.40 │     59.64 │    134.70 │        0.0 │      0.1 ║
║    16 KB │     132.42 │       156.25 │     74.40 │    208.33 │        0.0 │      0.1 ║
║    32 KB │     831.12 │       868.06 │    679.35 │   1008.06 │        0.0 │      0.0 ║
║    64 KB │    1917.18 │      2016.13 │   1736.11 │   2016.13 │        0.0 │      0.0 ║
║   128 KB │    1090.75 │      1086.96 │    827.81 │   1453.49 │        0.0 │      0.1 ║
║   256 KB │    5458.52 │      5434.78 │   5102.04 │   5813.95 │        0.0 │      0.0 ║
║   512 KB │    6983.24 │      7246.38 │   6250.00 │   7692.31 │        0.0 │      0.1 ║
║     1 MB │    4240.88 │      4739.34 │   2808.99 │   6802.72 │        0.1 │      0.2 ║
║     2 MB │    8503.40 │      8888.89 │   7722.01 │   9259.26 │        0.0 │      0.2 ║
║     4 MB │    7312.61 │      8113.59 │   4842.62 │   9433.96 │        0.1 │      0.5 ║
║     8 MB │    7801.83 │      7850.83 │   6855.18 │   9142.86 │        0.1 │      1.0 ║
║    16 MB │    5157.63 │      5004.69 │   4636.34 │   5882.35 │        0.3 │      3.1 ║
║    32 MB │    4781.97 │      4797.60 │   4649.81 │   4918.54 │        0.2 │      6.7 ║
║    64 MB │    4138.48 │      4203.61 │   3826.15 │   4460.24 │        0.9 │     15.5 ║
║   128 MB │    4239.93 │      5287.29 │   2600.89 │   5417.30 │        9.8 │     30.2 ║
║   256 MB │    5693.72 │      5917.84 │   4805.35 │   6359.93 │        4.7 │     45.0 ║
║   512 MB │    6799.76 │      6978.90 │   6163.18 │   7122.78 │        4.0 │     75.3 ║
╚══════════════════════════════════════════════════════════════════════════════════════╝

╔══════════════════════════════════════════════════════════════════════════════════════╗
║                      File Size Performance Summary for Write                         ║
╠══════════════════════════════════════════════════════════════════════════════════════╣
║     Size │ Mean(MB/s) │ Median(MB/s) │ Min(MB/s) │ Max(MB/s) │ StdDev(ms) │ Mean(ms) ║
╠══════════════════════════════════════════════════════════════════════════════════════╣
║     4 KB │       3.79 │         4.01 │      3.01 │      4.72 │        0.2 │      1.0 ║
║     8 KB │       6.83 │         6.75 │      5.24 │      9.31 │        0.2 │      1.1 ║
║    16 KB │      13.24 │        13.40 │     10.93 │     17.74 │        0.2 │      1.2 ║
║    32 KB │      54.54 │        58.19 │     27.65 │    142.69 │        0.3 │      0.6 ║
║    64 KB │     190.09 │       258.26 │    120.42 │    330.69 │        0.1 │      0.3 ║
║   128 KB │     107.52 │        92.11 │     75.94 │    206.95 │        0.4 │      1.2 ║
║   256 KB │     338.11 │       431.03 │    145.01 │    865.05 │        0.5 │      0.7 ║
║   512 KB │     652.23 │       666.67 │    423.01 │   1165.50 │        0.2 │      0.8 ║
║     1 MB │    1011.94 │      1012.15 │    866.55 │   1207.73 │        0.1 │      1.0 ║
║     2 MB │     686.48 │       755.00 │    460.62 │   1228.50 │        1.1 │      2.9 ║
║     4 MB │     818.80 │       755.57 │    693.24 │   1520.33 │        1.1 │      4.9 ║
║     8 MB │    1045.81 │       966.42 │    826.19 │   1970.44 │        2.0 │      7.6 ║
║    16 MB │     944.98 │      1069.38 │    567.84 │   1364.61 │        6.0 │     16.9 ║
║    32 MB │    1377.66 │      1339.87 │   1319.04 │   1532.13 │        1.2 │     23.2 ║
║    64 MB │    1358.45 │      1419.86 │   1230.34 │   1449.28 │        3.3 │     47.1 ║
║   128 MB │    1422.67 │      1464.68 │   1312.78 │   1572.21 │        6.3 │     90.0 ║
║   256 MB │    1446.51 │      1448.34 │   1306.38 │   1578.94 │       12.7 │    177.0 ║
║   512 MB │    1124.54 │      1183.01 │    734.13 │   1734.61 │      144.3 │    455.3 ║
╚══════════════════════════════════════════════════════════════════════════════════════╝

╔══════════════════════════════════════════════════════════════════════════════════════╗
║                      File Size Performance Summary for Copy                          ║
╠══════════════════════════════════════════════════════════════════════════════════════╣
║     Size │ Mean(MB/s) │ Median(MB/s) │ Min(MB/s) │ Max(MB/s) │ StdDev(ms) │ Mean(ms) ║
╠══════════════════════════════════════════════════════════════════════════════════════╣
║     4 KB │      17.45 │        18.34 │     14.97 │     18.87 │        0.0 │      0.2 ║
║     8 KB │      42.51 │        39.66 │     36.34 │     57.44 │        0.0 │      0.2 ║
║    16 KB │     105.43 │       139.51 │     66.21 │    200.32 │        0.1 │      0.1 ║
║    32 KB │     349.55 │       473.48 │    215.52 │    504.03 │        0.0 │      0.1 ║
║    64 KB │     667.74 │       762.20 │    504.03 │    932.84 │        0.0 │      0.1 ║
║   128 KB │    1008.06 │      1404.49 │    634.52 │   1453.49 │        0.0 │      0.1 ║
║   256 KB │    2200.70 │      2155.17 │   2066.12 │   2380.95 │        0.0 │      0.1 ║
║   512 KB │    2648.31 │      2717.39 │   2252.25 │   3030.30 │        0.0 │      0.2 ║
║     1 MB │    3728.56 │      3649.64 │   3558.72 │   4016.06 │        0.0 │      0.3 ║
║     2 MB │    3437.61 │      3703.70 │   2906.98 │   3868.47 │        0.1 │      0.6 ║
║     4 MB │    3116.24 │      3169.57 │   2943.34 │   3305.79 │        0.1 │      1.3 ║
║     8 MB │    1874.50 │      2056.56 │   1467.35 │   2270.15 │        0.7 │      4.3 ║
║    16 MB │    1985.36 │      1994.76 │   1863.28 │   2109.98 │        0.3 │      8.1 ║
║    32 MB │    2026.80 │      2019.18 │   1900.35 │   2192.68 │        0.8 │     15.8 ║
║    64 MB │    1740.21 │      1628.21 │   1549.67 │   2032.52 │        4.1 │     36.8 ║
║   128 MB │    2492.21 │      2459.46 │   2180.95 │   2849.89 │        5.1 │     51.4 ║
║   256 MB │    2846.57 │      2880.81 │   2658.72 │   3022.00 │        4.4 │     89.9 ║
║   512 MB │    3293.88 │      3253.98 │   2980.19 │   3679.51 │       10.6 │    155.4 ║
╚══════════════════════════════════════════════════════════════════════════════════════╝

╔══════════════════════════════════════════════════════════════════════════════════════╗
║                      File Size Performance Summary for ServerCopy                    ║
╠══════════════════════════════════════════════════════════════════════════════════════╣
║     Size │ Mean(MB/s) │ Median(MB/s) │ Min(MB/s) │ Max(MB/s) │ StdDev(ms) │ Mean(ms) ║
╠══════════════════════════════════════════════════════════════════════════════════════╣
║     4 KB │       8.78 │        13.11 │      3.75 │     16.41 │        0.3 │      0.4 ║
║     8 KB │      20.35 │        22.58 │     10.84 │     38.68 │        0.2 │      0.4 ║
║    16 KB │      44.04 │        79.72 │     15.21 │     91.91 │        0.3 │      0.4 ║
║    32 KB │      88.08 │       173.61 │     42.57 │    197.78 │        0.2 │      0.4 ║
║    64 KB │     208.61 │       330.69 │     83.00 │    367.65 │        0.2 │      0.3 ║
║   128 KB │     335.48 │       457.88 │    180.64 │    631.31 │        0.2 │      0.4 ║
║   256 KB │     846.88 │      1016.26 │    519.75 │   1077.59 │        0.1 │      0.3 ║
║   512 KB │    1516.99 │      1824.82 │    872.60 │   2127.66 │        0.1 │      0.3 ║
║     1 MB │    1923.08 │      2247.19 │   1457.73 │   2450.98 │        0.1 │      0.5 ║
║     2 MB │    2151.46 │      2068.25 │   1879.70 │   2816.90 │        0.1 │      0.9 ║
║     4 MB │    3056.70 │      3037.21 │   2560.82 │   3745.32 │        0.2 │      1.3 ║
║     8 MB │    2356.82 │      2446.48 │   1985.60 │   2635.05 │        0.3 │      3.4 ║
║    16 MB │    2301.16 │      2313.48 │   1988.81 │   2804.56 │        0.8 │      7.0 ║
║    32 MB │    2363.33 │      2374.94 │   2064.78 │   2604.80 │        1.1 │     13.5 ║
║    64 MB │    1854.52 │      1796.14 │   1730.57 │   2281.40 │        3.3 │     34.5 ║
║   128 MB │    3315.05 │      3268.39 │   3199.92 │   3474.11 │        1.3 │     38.6 ║
║   256 MB │    3379.43 │      3393.70 │   3132.80 │   3711.81 │        5.3 │     75.8 ║
║   512 MB │    4441.41 │      4425.20 │   4293.11 │   4593.37 │        2.9 │    115.3 ║
╚══════════════════════════════════════════════════════════════════════════════════════╝

╔═════════════════════════════════════════════════════════════════════════╗
║                 TCP Metrics Evolution Across All Tests                  ║
╠═════════════════════════════════════════════════════════════════════════╣
║ Metric                   │       Initial │         Final │      Total Δ ║
╠═════════════════════════════════════════════════════════════════════════╣
║ TCP Send Buffer          │       2565 KB │       2565 KB │         0 KB ║
║ TCP Recv Buffer          │        128 KB │       6144 KB │      6016 KB ║
║ TCP MSS                  │       32768 B │       65483 B │      32715 B ║
║ Cwnd (segments)          │            10 │            10 │            0 ║
║ SSThresh (segments)      │    2147483647 │            20 │  -2147483627 ║
║ RTT                      │       4.47 ms │       9.62 ms │      5.15 ms ║
║ RTT Variance             │       8.88 ms │      14.27 ms │      5.39 ms ║
║ Retrans (current)        │             0 │             0 │            0 ║
║ Total Retrans            │             0 │             0 │            0 ║
║ Lost Packets             │             0 │             0 │            0 ║
║ Reordering               │             3 │             3 │            0 ║
║ TCP Send MSS             │       32768 B │       65483 B │      32715 B ║
║ TCP Recv MSS             │         536 B │       65483 B │      64947 B ║
║ TCP Adv MSS              │       65483 B │       65483 B │          0 B ║
║ TCP Recv Space           │         63 KB │       7168 KB │      7104 KB ║
╚═════════════════════════════════════════════════════════════════════════╝
```