### PR TITLE
testsuite: initialize filedir params to avoid garbage data in the bitmap

### DIFF
--- a/test/testsuite/Error.c
+++ b/test/testsuite/Error.c
@@ -270,7 +270,7 @@ afp_enumerate
 static void cname_test(char *name)
 {
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) |
                       (1 << DIRPBIT_DID) |
                       (1 << DIRPBIT_ACCESS);
@@ -477,7 +477,7 @@ STATIC void test100()
     int dir;
     char *name = "t100 no obj error";
     char *name1 = "t100 no obj error/none";
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_ATTR);
     unsigned int ret;
     uint16_t vol = VolID;
@@ -562,7 +562,7 @@ STATIC void test101()
     char *name = "t101 no obj error";
     char *ndir = "t101 no";
     char *name1 = "t101 no/none";
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_ATTR);
     uint16_t vol = VolID;
     unsigned int ret;
@@ -680,7 +680,7 @@ STATIC void test102()
     char *name = "t102 access error";
     char *name1 = "t102 dir --";
     int ret;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_ATTR);
     uint16_t vol = VolID;
     DSI *dsi;
@@ -800,7 +800,7 @@ STATIC void test103()
     char *name1 = "t130 dir --";
     int ret;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_DID);
     uint16_t vol = VolID;
     const DSI *dsi;
@@ -999,7 +999,7 @@ STATIC void test105()
     unsigned int err;
     char *name = "t105 bad did";
     char *name1 = "t105 no obj error/none";
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_ATTR);
     uint16_t vol = VolID;
     DSI *dsi;
@@ -1075,7 +1075,7 @@ STATIC void test170()
     char *name = "test170.txt";
     char *name1 = "newtest170.txt";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int fork;
     int dir = DIRDID_ROOT_PARENT;
     unsigned int ret;
@@ -1250,7 +1250,7 @@ STATIC void test171()
     char *name = "test171.txt";
     char *name1 = "newtest171.txt";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int tdir = DIRDID_ROOT_PARENT;
     int fork;
     int dir = DIRDID_ROOT_PARENT;
@@ -1405,7 +1405,7 @@ STATIC void test173()
     char *name = "test173.txt";
     char *name1 = "newtest173.txt";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int tdir = 0;
     int fork;
     int dir = DIRDID_ROOT_PARENT;
@@ -1570,7 +1570,7 @@ STATIC void test174()
     char *name = "test174.txt";
     char *name1 = "newtest174.txt";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int tdir;
     int fork;
     int dir = DIRDID_ROOT_PARENT;

--- a/test/testsuite/FPAddAPPL.c
+++ b/test/testsuite/FPAddAPPL.c
@@ -82,7 +82,7 @@ STATIC void test301()
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << DIRPBIT_ACCESS) | (1 << DIRPBIT_DID);
     uint16_t fork;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int dir;
     ENTER_TEST
 

--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -636,7 +636,7 @@ static int create_trash(CONN *conn, uint16_t vol)
                       (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS);
     const DSI *dsi = &conn->dsi;
     int dir;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     dir  = FPCreateDir(conn, vol, DIRDID_ROOT, trash);
 
     if (!dir) {
@@ -675,7 +675,7 @@ static int create_trash(CONN *conn, uint16_t vol)
 static int create_map(CONN *conn, uint16_t vol, int dir, char *name)
 {
     const DSI *dsi = &conn->dsi;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int  ofs =  3 * sizeof(uint16_t);
     int fork;
 
@@ -708,7 +708,7 @@ static int set_perm(CONN *conn, uint16_t vol, int dir)
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS);
     const DSI *dsi = &conn->dsi;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
 
     if (FPGetFileDirParams(conn, vol, dir, "", 0, bitmap)) {
         return 0;
@@ -742,7 +742,7 @@ static int write_access(CONN *conn, uint16_t  vol, int dir)
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS);
     const DSI *dsi = &conn->dsi;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
 
     if (FPGetFileDirParams(conn, vol, dir, "", 0, bitmap)) {
         return 0;

--- a/test/testsuite/FPCatSearch.c
+++ b/test/testsuite/FPCatSearch.c
@@ -14,7 +14,7 @@ STATIC void test225()
     const DSI *dsi = &Conn->dsi;
     char pos[16];
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     struct afp_filedir_parms filedir2;
     unsigned int ret;
     ENTER_TEST

--- a/test/testsuite/FPCatSearchExt.c
+++ b/test/testsuite/FPCatSearchExt.c
@@ -15,7 +15,7 @@ STATIC void test227()
     const DSI *dsi;
     char pos[16];
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     struct afp_filedir_parms filedir2;
     unsigned int ret;
     ENTER_TEST
@@ -198,7 +198,7 @@ STATIC void test529()
     uint32_t match_count = 0;
     uint32_t temp;
     const DSI *dsi;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     struct afp_filedir_parms filedir2;
     int iteration = 0;
     ENTER_TEST

--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -187,7 +187,7 @@ static void test_meta(char *name, char *name1, uint16_t vol2)
     uint16_t vol = VolID;
     int tp, tp1;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     uint16_t bitmap;
     char finder_info[32];
@@ -274,7 +274,7 @@ STATIC void test332()
     uint16_t vol = VolID;
     int tp, tp1;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     uint16_t bitmap;
     uint32_t mdate = 0;
@@ -456,7 +456,7 @@ STATIC void test401()
     char *ndir = "t401 dir";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     int fork;
     const DSI *dsi = &Conn->dsi;
@@ -557,7 +557,7 @@ STATIC void test402()
     char *ndir = "t402 dir";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     int fork;
     const DSI *dsi = &Conn->dsi;
@@ -650,7 +650,7 @@ STATIC void test403()
     char *ndir = "t403 dir";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
@@ -761,7 +761,7 @@ static void test_data(char *name, char *name1, uint16_t vol2)
     int  dir = DIRDID_ROOT;
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     int fork;
     const DSI *dsi = &Conn->dsi;

--- a/test/testsuite/FPCreateDir.c
+++ b/test/testsuite/FPCreateDir.c
@@ -334,7 +334,7 @@ STATIC void test357()
     int tdir;
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
                       (1 << DIRPBIT_CDATE) |
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_UID) |

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -143,7 +143,7 @@ STATIC void test172()
     char *name = "test172.txt";
     char *name1 = "newtest172.txt";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int tdir;
     int fork;
     int dir = 0;
@@ -321,7 +321,7 @@ STATIC void test196()
     int tdir;
     int tdir1 = 0;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     uint16_t bitmap = (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) |
                       (1 << DIRPBIT_DID) | (1 << DIRPBIT_UID) |
@@ -508,7 +508,7 @@ STATIC void test421()
     uint16_t vol2;
     int tdir;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     uint16_t bitmap = (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) |
                       (1 << DIRPBIT_DID) | (1 << DIRPBIT_UID) |

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -345,7 +345,7 @@ STATIC void test339()
     int dir;
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << DIRPBIT_ACCESS);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -532,7 +532,7 @@ STATIC void test370()
     int dir;
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << DIRPBIT_ACCESS);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     ENTER_TEST
 
     if (Conn->afp_version < 30) {

--- a/test/testsuite/FPEnumerate.c
+++ b/test/testsuite/FPEnumerate.c
@@ -427,7 +427,7 @@ STATIC void test218()
     char *ndir  = "t218 enumerate dir";
     uint16_t vol = VolID;
     int  ofs =  4 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi;
     unsigned int ret;
     int bdir;
@@ -538,7 +538,7 @@ STATIC void test300(void)
     uint16_t i;
     const DSI *dsi;
     const unsigned char *b;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int *stack = NULL;
     int cnt = 0;
     int size = 1000;

--- a/test/testsuite/FPExchangeFiles.c
+++ b/test/testsuite/FPExchangeFiles.c
@@ -278,7 +278,7 @@ STATIC void test342()
     int fid_name1;
     int temp;
     uint16_t vol = VolID;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     char finder_info[32];
     uint16_t bitmap;
     const DSI *dsi = &Conn->dsi;

--- a/test/testsuite/FPFlushFork.c
+++ b/test/testsuite/FPFlushFork.c
@@ -9,7 +9,7 @@ STATIC void test203()
 {
     uint16_t vol = VolID;
     uint16_t bitmap = (1 << FILPBIT_MDATE);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int fork = 0;
     char *name = "t203 file";
     uint32_t mdate;

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -163,7 +163,7 @@ STATIC void test94()
     int  dir;
     char *name = "t94 invisible dir";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t vol = VolID;
     uint16_t bitmap = (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_MDATE) |
                       (1 << DIRPBIT_OFFCNT);
@@ -262,7 +262,7 @@ STATIC void test104()
     char *name5 = "t104 file";
     unsigned int  dir1 = 0, dir2 = 0, dir3 = 0, dir4 = 0;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     uint16_t vol = VolID;
     const DSI *dsi = &Conn->dsi;
@@ -531,7 +531,7 @@ STATIC void test307()
     uint16_t vol = VolID;
     const DSI *dsi = &Conn->dsi;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     unsigned int dir;
     char *result;
@@ -581,7 +581,7 @@ STATIC void test308()
     uint16_t vol = VolID;
     const DSI *dsi = &Conn->dsi;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     unsigned int dir;
     char *result;
@@ -652,7 +652,7 @@ STATIC void test324()
     uint16_t vol = VolID;
     DSI *dsi;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     unsigned int dir;
     char *result;
@@ -939,7 +939,7 @@ STATIC void test371()
     char *name1  = "t371 new name.pdf";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     uint16_t bitmap;
     ENTER_TEST
@@ -1005,7 +1005,7 @@ STATIC void test380()
     char *name  = "t380 file name.doc";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     uint16_t bitmap;
     uint16_t bitmap1 = (1 << FILPBIT_ATTR) | (1 << FILPBIT_FINFO) |
@@ -1070,7 +1070,7 @@ STATIC void test396()
     uint16_t vol = VolID;
     const DSI *dsi = &Conn->dsi;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t f_bitmap = 0x73f;
     uint16_t d_bitmap = 0x133f;
     unsigned int dir;
@@ -1114,7 +1114,7 @@ STATIC void test423()
     char *name1 = "t423 dir";
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM) | (1 << DIRPBIT_FINFO);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int fid = 0;
     uint16_t fork = 0;
     const DSI *dsi = &Conn->dsi;
@@ -1189,7 +1189,7 @@ static void do_pdinfo_test(char *fname, const char *fourcc, uint8_t expect_type,
     uint16_t bitmap_pdinfo = (1 << FILPBIT_PDINFO);
     int ofs = 3 * sizeof(uint16_t);
     const DSI *dsi = &Conn->dsi;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const unsigned char *buf;
     uint8_t prodos_type;
     uint16_t prodos_aux;
@@ -1266,7 +1266,7 @@ STATIC void test441()
     uint16_t bitmap_pdinfo = (1 << FILPBIT_PDINFO);
     int ofs = 3 * sizeof(uint16_t);
     const DSI *dsi = &Conn->dsi;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const unsigned char *buf;
     uint8_t prodos_type;
     uint16_t prodos_aux;

--- a/test/testsuite/FPGetUserInfo.c
+++ b/test/testsuite/FPGetUserInfo.c
@@ -12,7 +12,7 @@ STATIC void test75()
     int dir;
     int ret;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_UID) | (1 << DIRPBIT_GID);
     uint16_t vol = VolID;
     const DSI *dsi = &Conn->dsi;

--- a/test/testsuite/FPMapID.c
+++ b/test/testsuite/FPMapID.c
@@ -9,7 +9,7 @@ STATIC void test208()
     int  dir;
     char *name = "t208 test Map ID";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) |
                       (1 << DIRPBIT_MDATE)
                       | (1 << DIRPBIT_ACCESS) | (1 << DIRPBIT_FINFO) | (1 << DIRPBIT_UID) |

--- a/test/testsuite/FPMapName.c
+++ b/test/testsuite/FPMapName.c
@@ -9,7 +9,7 @@ STATIC void test180()
     int  dir;
     char *name = "t180 test Map name";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) |
                       (1 << DIRPBIT_MDATE)
                       | (1 << DIRPBIT_ACCESS) | (1 << DIRPBIT_FINFO) | (1 << DIRPBIT_UID) |

--- a/test/testsuite/FPMoveAndRename.c
+++ b/test/testsuite/FPMoveAndRename.c
@@ -265,7 +265,7 @@ STATIC void test138()
     char *name = "t138 file";
     char *name1 = "t138 dir";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_ACCESS);
     uint16_t vol = VolID;
     const DSI *dsi = &Conn->dsi;

--- a/test/testsuite/FPOpenFork.c
+++ b/test/testsuite/FPOpenFork.c
@@ -617,7 +617,7 @@ STATIC void test116()
 {
     char *name = "t116 no write file";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_MDATE);
     int fork;
     uint16_t vol = VolID;
@@ -862,7 +862,7 @@ static void test_openmode(char *name, int type)
     const DSI *dsi2 = &Conn2->dsi;
     uint16_t vol2;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int what   = (type == OPENFORK_DATA) ? ATTRBIT_DOPEN : ATTRBIT_ROPEN;
     int nowhat = (type == OPENFORK_DATA) ? ATTRBIT_ROPEN : ATTRBIT_DOPEN;
     vol2  = FPOpenVol(Conn2, Vol);

--- a/test/testsuite/FPRename.c
+++ b/test/testsuite/FPRename.c
@@ -46,7 +46,7 @@ STATIC void test72()
     char *name2 = "t72 dir";
     unsigned int ret;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t vol = VolID;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
@@ -110,7 +110,7 @@ static int create_double_deleted_folder(uint16_t vol, char *name)
     int tdir;
     int tdir1 = 0;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     const DSI *dsi2;
     uint16_t bitmap;

--- a/test/testsuite/FPResolveID.c
+++ b/test/testsuite/FPResolveID.c
@@ -12,7 +12,7 @@ STATIC void test76()
     char *name1 = "t76 Resolve ID dir";
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t vol = VolID;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
@@ -55,7 +55,7 @@ STATIC void test91()
     char *name1 = "t91 test ID dir";
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     unsigned int ret;
     uint16_t vol = VolID;
     const DSI *dsi = &Conn->dsi;
@@ -125,7 +125,7 @@ STATIC void test310()
     char *name1 = "t310 new name";
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t vol = VolID;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
@@ -164,7 +164,7 @@ STATIC void test311()
     char *name1 = "t311-\xd7\xa4\xd7\xaa\xd7\x99\xd7\x97\xd7\x94#11.mp3";
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = 0x693f;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t vol = VolID;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
@@ -267,7 +267,7 @@ STATIC void test417()
     char *name1 = "t417 dir";
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM) | (1 << DIRPBIT_FINFO);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int fid = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST

--- a/test/testsuite/FPSetDirParms.c
+++ b/test/testsuite/FPSetDirParms.c
@@ -10,7 +10,7 @@ STATIC void test82()
     int  dir;
     char *name = "t82 test dir";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) |
                       (1 << DIRPBIT_MDATE)
                       | (1 << DIRPBIT_ACCESS) | (1 << DIRPBIT_FINFO) | (1 << DIRPBIT_UID) |
@@ -64,7 +64,7 @@ STATIC void test84()
     int  dir;
     char *name = "t84 no delete dir";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
                       (1 << DIRPBIT_CDATE) |
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_UID) |
@@ -112,7 +112,7 @@ STATIC void test88()
     int  ofs =  3 * sizeof(uint16_t);
     int pdir = 0;
     int rdir = 0;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = DIRPBIT_ATTR | (1 << DIRPBIT_FINFO) | (1 << DIRPBIT_CDATE) |
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS);
@@ -202,7 +202,7 @@ STATIC void test107()
     char *name = "t107 test dir";
     char *ndir = "t107 no access";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) |
                       (1 << DIRPBIT_MDATE)
                       | (1 << DIRPBIT_ACCESS) | (1 << DIRPBIT_FINFO) | (1 << DIRPBIT_UID) |
@@ -309,7 +309,7 @@ STATIC void test189()
     char *name = "t189 error setdirparams";
     char *name1 = "t189 error setdirparams file";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_FINFO) | (1 << DIRPBIT_CDATE) |
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS);
@@ -350,7 +350,7 @@ STATIC void test193()
     int  dir;
     char *name = "t193 no delete dir";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_ACCESS);
     uint16_t vol = VolID;
     const DSI *dsi = &Conn->dsi;
@@ -390,7 +390,7 @@ STATIC void test351()
     char *name = "t351 file";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     uint8_t old_access[4];
     int ret;
@@ -458,7 +458,7 @@ STATIC void test352()
     char *ndir = "t352 dir";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     uint8_t old_access[4];
     const DSI *dsi = &Conn->dsi;
@@ -520,7 +520,7 @@ STATIC void test353()
     char *ndir = "t353 dir";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
@@ -609,7 +609,7 @@ STATIC void test354()
     char *name = "t354 file";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
@@ -677,7 +677,7 @@ STATIC void test355()
     char *name = "t355 file";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
@@ -749,7 +749,7 @@ STATIC void test356()
     char *name = "t356 file";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     int old_unixpriv;
     int ret;
@@ -874,7 +874,7 @@ STATIC void test405()
     char *ndir = "t405 dir";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST

--- a/test/testsuite/FPSetFileDirParms.c
+++ b/test/testsuite/FPSetFileDirParms.c
@@ -16,7 +16,7 @@ STATIC void test98()
     int pdir = 0;
     int rdir = 0;
     int ret;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) |
                       (1 << DIRPBIT_DID)
                       | (1 << DIRPBIT_UID) | (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS)
@@ -106,7 +106,7 @@ STATIC void test230()
     char *ndir = "t230 dir";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     int fork;
     const DSI *dsi = &Conn->dsi;
@@ -247,7 +247,7 @@ STATIC void test231()
     char *name1 = "t231 file user 2";
     char *ndir = "t231 dir";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     uint16_t vol = VolID;
     uint16_t vol2;
@@ -364,7 +364,7 @@ STATIC void test232()
     char *ndir = "t232 dir";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
@@ -431,7 +431,7 @@ STATIC void test345()
     char *ndir = "t345 dir";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     int fork;
     const DSI *dsi = &Conn->dsi;
@@ -516,7 +516,7 @@ STATIC void test346()
     char *ndir = "t346 dir";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
@@ -576,7 +576,7 @@ STATIC void test347()
     char *ndir = "t347 dir";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
@@ -665,7 +665,7 @@ STATIC void test348()
     char *name = "t348 file";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
@@ -733,7 +733,7 @@ STATIC void test349()
     char *name = "t349 file";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
@@ -805,7 +805,7 @@ STATIC void test350()
     char *name = "t350 file";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     int old_unixpriv;
     int ret;
@@ -957,7 +957,7 @@ STATIC void test359()
     char *ndir = "t359 dir";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     int ret;
     const DSI *dsi = &Conn->dsi;
@@ -1046,7 +1046,7 @@ STATIC void test361()
     char *name = "t361 file.pdf";
     char *ndir = "t361 dir";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     int ret;
     uint16_t vol = VolID;
@@ -1152,7 +1152,7 @@ STATIC void test400()
     char *ndir = "t400 dir";
     uint16_t vol = VolID;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST

--- a/test/testsuite/FPSetFileParms.c
+++ b/test/testsuite/FPSetFileParms.c
@@ -11,7 +11,7 @@ STATIC void test83()
     char *ndir = "t83 dir";
     int  dir;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << FILPBIT_ATTR) | (1 << FILPBIT_FINFO) |
                       (1 << FILPBIT_CDATE) |
                       (1 << FILPBIT_BDATE) | (1 << FILPBIT_MDATE);
@@ -54,7 +54,7 @@ STATIC void test96()
 {
     char *name = "t96 invisible file";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_MDATE);
     uint16_t vol = VolID;
     const DSI *dsi;
@@ -133,7 +133,7 @@ STATIC void test118()
 {
     char *name = "t118 no delete file";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << FILPBIT_ATTR);
     uint16_t vol = VolID;
     const DSI *dsi;
@@ -167,7 +167,7 @@ STATIC void test122()
 {
     char *name = "t122 setfilparam open fork";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int fork;
     int fork1;
     int ret;
@@ -232,7 +232,7 @@ STATIC void test318()
 {
     char *name = "t318 PDinfo error";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << FILPBIT_PDINFO);
     uint16_t vol = VolID;
     const DSI *dsi;
@@ -267,7 +267,7 @@ test_exit:
 static int afp_symlink(char *oldpath, char *newpath)
 {
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap;
     uint16_t vol = VolID;
     const DSI *dsi;
@@ -320,7 +320,7 @@ STATIC void test427()
     char *name = "t427 Symlink";
     char *dest = "t427 dest";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap;
     uint16_t vol = VolID;
     DSI *dsi;
@@ -414,7 +414,7 @@ STATIC void test429()
     char *name = "t429 Symlink";
     char *dest = "t429 dest";
     int  ofs =  sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << FILPBIT_FNUM);
     uint16_t vol = VolID;
     const DSI *dsi;
@@ -476,7 +476,7 @@ STATIC void test430()
     char *name = "t430 Symlink";
     char *dest = "t430 dest";
     int  ofs =  sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << FILPBIT_FNUM);
     uint16_t vol = VolID;
     DSI *dsi;

--- a/test/testsuite/FPSync.c
+++ b/test/testsuite/FPSync.c
@@ -10,7 +10,7 @@ STATIC void test2()
     const DSI *dsi = &Conn->dsi;
     char *name = "t2 sync dir";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     ENTER_TEST
 
     if (FPSyncDir(Conn, vol, DIRDID_ROOT)) {

--- a/test/testsuite/T2_Dircache_attack.c
+++ b/test/testsuite/T2_Dircache_attack.c
@@ -134,7 +134,7 @@ STATIC void test500()
     char *renamedsubdir1 = "t500 renamedsubdir1";
     uint32_t dir_id, subdir1_id, subdir2_id;
     int ofs = 3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
 
@@ -208,7 +208,7 @@ STATIC void test501()
     char *renamedsubdir1 = "t501 renamedsubdir1";
     uint32_t dir_id, subdir1_id, subdir2_id;
     int ofs = 3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
 
@@ -279,7 +279,7 @@ STATIC void test502()
     char *renamedsubdir1 = "t502 renamedsubdir1";
     uint32_t dir_id, subdir1_id, subdir2_id;
     int ofs = 3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
 
@@ -356,7 +356,7 @@ STATIC void test503()
     char *renamedsubdir1 = "t503 renamedsubdir1";
     uint32_t dir_id, subdir1_id, subdir2_id;
     int ofs = 3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
 
@@ -427,7 +427,7 @@ STATIC void test504()
     char *renamedsubdir1 = "t504 renamedsubdir1";
     uint32_t dir_id, subdir1_id, subdir2_id, file_id;
     int ofs = 3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
 
@@ -497,7 +497,7 @@ STATIC void test505()
     char *renamedsubdir1 = "t505 renamedsubdir1";
     uint32_t dir_id, subdir1_id, subdir2_id;
     int ofs = 3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
 
@@ -569,7 +569,7 @@ STATIC void test506()
     char *renamedsubdir1 = "t506 renamedsubdir1";
     uint32_t dir_id, subdir1_id, subdir2_id, poisondir_id;
     int ofs = 3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
 

--- a/test/testsuite/T2_FPCopyFile.c
+++ b/test/testsuite/T2_FPCopyFile.c
@@ -13,7 +13,7 @@ STATIC void test373()
     uint16_t vol = VolID;
     int tp, tp1;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     uint16_t bitmap;
     uint32_t mdate = 0;

--- a/test/testsuite/T2_FPDelete.c
+++ b/test/testsuite/T2_FPDelete.c
@@ -16,7 +16,7 @@ STATIC void test146()
     char *name = "t146 file";
     char *name1 = "t146 dir";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_ACCESS);
     uint16_t vol = VolID;
     uint16_t vol2;
@@ -193,7 +193,7 @@ STATIC void test363()
     char *name1 = "t363 GetForkParams dir";
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     int fork;
     ENTER_TEST
@@ -269,7 +269,7 @@ STATIC void test364()
     char *name1 = "t364 Delete ID dir";
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 

--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -369,7 +369,7 @@ STATIC void test106()
     unsigned int dir3 = 0;
     unsigned int dir4 = 0;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
 
@@ -778,7 +778,7 @@ STATIC void test336()
     int ret;
     int id;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     ENTER_TEST
 
     if (!Conn2) {
@@ -1024,7 +1024,7 @@ STATIC void test420()
     char *name1 = "t420 dir";
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM) | (1 << DIRPBIT_FINFO);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int fid = 0;
     uint16_t fork = 0;
     const DSI *dsi = &Conn->dsi;

--- a/test/testsuite/T2_FPOpenFork.c
+++ b/test/testsuite/T2_FPOpenFork.c
@@ -756,7 +756,7 @@ STATIC void test372()
     uint16_t vol = VolID;
     uint16_t fork;
     int ofs = 3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     uint16_t bitmap;
     int fd;
@@ -860,7 +860,7 @@ STATIC void test388()
     uint16_t vol = VolID;
     uint16_t fork;
     int ofs = 3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     uint16_t bitmap;
     int fd;
@@ -964,7 +964,7 @@ STATIC void test392()
     uint16_t vol = VolID;
     uint16_t fork;
     int ofs = 3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     uint16_t bitmap;
     int fd;
@@ -1183,7 +1183,7 @@ STATIC void test236()
     int testdir, etcdir;
     uint16_t fork = 0;
     uint16_t vol = VolID, bitmap;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     int ofs = 3 * sizeof(uint16_t);
     ENTER_TEST
@@ -1273,7 +1273,7 @@ STATIC void test237()
     int testdir;
     uint16_t fork = 0;
     uint16_t vol = VolID, bitmap;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     int ofs = 3 * sizeof(uint16_t);
     ENTER_TEST
@@ -1355,7 +1355,7 @@ STATIC void test238()
     int  testdir;
     uint16_t fork = 0;
     uint16_t vol = VolID, bitmap;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     int ofs = 3 * sizeof(uint16_t);
     ENTER_TEST

--- a/test/testsuite/T2_FPSetDirParms.c
+++ b/test/testsuite/T2_FPSetDirParms.c
@@ -11,7 +11,7 @@ STATIC void test121()
     int  dir;
     char *name = "t121 test dir setdirparam";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_FINFO) | (1 << DIRPBIT_CDATE) |
                       (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE);
     uint16_t vol = VolID;
@@ -87,7 +87,7 @@ STATIC void test528()
     uint16_t vol = VolID;
     int  ofs = 3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << DIRPBIT_ACCESS) | (1 << DIRPBIT_UNIXPR);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 

--- a/test/testsuite/T2_FPSetFileParms.c
+++ b/test/testsuite/T2_FPSetFileParms.c
@@ -9,7 +9,7 @@
 static int afp_symlink(char *oldpath, char *newpath)
 {
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap;
     uint16_t vol = VolID;
     const DSI *dsi;
@@ -63,7 +63,7 @@ STATIC void test89()
     char *file = "t89 test error setfilparam";
     char *name = "t89 error setfilparams dir";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << FILPBIT_FINFO) | (1 << FILPBIT_CDATE) |
                       (1 << FILPBIT_BDATE) | (1 << FILPBIT_MDATE);
     uint16_t vol = VolID;
@@ -113,7 +113,7 @@ STATIC void test120()
 {
     char *name = "t120 test file setfilparam";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << FILPBIT_ATTR) | (1 << FILPBIT_FINFO) |
                       (1 << FILPBIT_CDATE) |
                       (1 << FILPBIT_BDATE) | (1 << FILPBIT_MDATE);
@@ -150,7 +150,7 @@ STATIC void test426()
 {
     char *name = "t426 Symlink";
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap;
     uint16_t vol = VolID;
     DSI *dsi;

--- a/test/testsuite/afparg_FPfuncs.c
+++ b/test/testsuite/afparg_FPfuncs.c
@@ -21,7 +21,7 @@ void FPResolveID_arg(char **argv)
     uint16_t bitmap = (1 << FILPBIT_PDINFO);
     uint32_t id;
     const DSI *dsi = &Conn->dsi;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     fprintf(stdout, "======================\n");
     fprintf(stdout, "FPResolveID with args:\n");
     id = atoi(argv[0]);
@@ -149,7 +149,7 @@ void FPEnumerate_arg(char **argv)
     uint16_t i;
     const DSI *dsi = &Conn->dsi;
     const unsigned char *b;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int *stack = NULL;
     int cnt = 0;
     int size = 1000;

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -75,7 +75,7 @@ int get_did(CONN *conn, uint16_t vol, int dir, char *name)
 {
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << DIRPBIT_DID);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi;
     dsi = &conn->dsi;
     filedir.did = 0;
@@ -100,7 +100,7 @@ int get_fid(CONN *conn, uint16_t vol, int dir, char *name)
 {
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi = &conn->dsi;
     filedir.did = 0;
 
@@ -124,7 +124,7 @@ uint32_t get_forklen(DSI *dsi, int type)
     uint16_t bitmap = 0;
     int len = (type == OPENFORK_RSCS) ? (1 << FILPBIT_RFLEN) : (1 << FILPBIT_DFLEN);
     int  ofs =  sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     uint32_t flen;
     filedir.isdir = 0;
     bitmap = len;
@@ -187,7 +187,7 @@ int no_access_folder(uint16_t vol, int did, char *name)
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << DIRPBIT_ACCESS) | (1 << DIRPBIT_UID) |
                       (1 << DIRPBIT_GID);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     DSI *dsi, *dsi2;
     uint32_t uid;
 
@@ -315,7 +315,7 @@ int group_folder(uint16_t vol, int did, char *name)
     uint16_t vol2;
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << DIRPBIT_ACCESS);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     DSI *dsi, *dsi2;
 
     if (!Conn2) {
@@ -404,7 +404,7 @@ int read_only_folder(uint16_t vol, int did, char *name)
     uint16_t vol2;
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << DIRPBIT_ACCESS);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi2;
 
     if (!Conn2) {
@@ -483,7 +483,7 @@ int read_only_folder_with_file(uint16_t vol, int did, char *name, char *file)
     uint16_t vol2;
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << DIRPBIT_ACCESS);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi2;
 
     if (!Conn2) {
@@ -565,7 +565,7 @@ int delete_folder(uint16_t vol, int did, char *name)
     uint16_t vol2;
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << DIRPBIT_ACCESS);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi2;
 
     if (!Conn2) {
@@ -626,7 +626,7 @@ int delete_folder_with_file(uint16_t vol, int did, char *name, char *file)
     uint16_t vol2;
     int  ofs =  3 * sizeof(uint16_t);
     uint16_t bitmap = (1 << DIRPBIT_ACCESS) | (1 << DIRPBIT_DID);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi2;
 
     if (!Conn2) {
@@ -971,7 +971,7 @@ int32_t is_there(CONN *conn, uint16_t volume, int32_t did, char *name)
 int delete_directory_tree(CONN *conn, uint16_t volume,
                           uint32_t parent_did, char *dirname)
 {
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi_ptr = &conn->dsi;
     uint32_t dir_id;
     uint16_t f_bitmap, d_bitmap;
@@ -1156,7 +1156,7 @@ void clear_volume(uint16_t vol, CONN *conn)
 {
     uint16_t bitmap = (1 << FILPBIT_FNUM) | (1 << DIRPBIT_PDID);
     uint32_t dir_id = DIRDID_ROOT;
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     int ofs = 3 * sizeof(uint16_t);
 
     while (1) {

--- a/test/testsuite/encoding_test.c
+++ b/test/testsuite/encoding_test.c
@@ -47,7 +47,7 @@ STATIC void test_western()
     uint16_t vol = VolID;
     uint16_t f_bitmap;
     int  ofs =  3 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     char *result;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST

--- a/test/testsuite/rotest.c
+++ b/test/testsuite/rotest.c
@@ -31,7 +31,7 @@ STATIC void test510()
     char *ndir = "read only dir";
     char *nfile = "read only file";
     int  ofs =  4 * sizeof(uint16_t);
-    struct afp_filedir_parms filedir;
+    struct afp_filedir_parms filedir = { 0 };
     char *file = NULL;
     char *file1 = NULL;
     char *dir = NULL;


### PR DESCRIPTION
test358 was reading unitialized data into the DIRPBIT_ACCESS bit which caused flaky behavior later when attempting to delete the test dir on big endian platforms

eliminate the retry workaround that was masking the actual underlying bug

apply the same initialization fix consistently across the testsuite code to preempt similar issues elsewhere