### PR TITLE
afpd dircache: fix realloc leak, validate ghosts, improve error logging

### DIFF
--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -753,7 +753,7 @@ int afp_createfile(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
     memcpy(&did, ibuf, sizeof(did));
     ibuf += sizeof(did);
 
-    if (NULL == (dir = dirlookup(vol, did))) {
+    if (NULL == (dir = dirlookup_strict(vol, did))) {
         LOG(log_error, logtype_afpd,
             "afp_createfile: dirlookup failed for did:%u, returning afp_errno=%d",
             ntohl(did), afp_errno);

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -173,7 +173,7 @@ int afp_setfildirparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
     memcpy(&did, ibuf, sizeof(did));
     ibuf += sizeof(did);
 
-    if (NULL == (dir = dirlookup(vol, did))) {
+    if (NULL == (dir = dirlookup_strict(vol, did))) {
         return afp_errno;
     }
 

--- a/libatalk/util/queue.c
+++ b/libatalk/util/queue.c
@@ -183,7 +183,9 @@ void queue_destroy(q_t *q, void (*callback)(void *))
     void *p;
 
     while ((p = dequeue(q)) != NULL) {
-        callback(p);
+        if (callback) {
+            callback(p);
+        }
     }
 
     free(q);


### PR DESCRIPTION
- Fix realloc memory leak in dircache_remove_children() using temp variable
- Remove ghost-specific validation skip in search_by_did and search_by_name
- ARC ghost entries now validated identically to regular cached entries
- Remove redundant AFP_ASSERT(dir->qidx_node) in arc_case_i()
- Upgrade arc_replace() curdir-protection logs from log_debug to log_warning
- Remove overly strict ghost capacity post-condition assert
- Add NULL callback check in queue_destroy() to prevent latent crash
- Remove dead code t1_size==0 check inside t1_size>=1 branch in arc_replace()
- Use dirlookup_strict() in afp_setfildirparams, afp_createfile, afp_createdir
- Update dirlookup/dirlookup_strict doxygen comments