### PR TITLE
afpd: validate CNID from get_id() before calling dircache_add()

### DIFF
--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -1250,7 +1250,8 @@ int dircache_add(const struct vol *vol,
 
     if (ntohl(dir->d_did) < CNID_START) {
         LOG(log_error, logtype_afpd,
-            "dircache_add(): did:%u is less than the allowed %d. Try rebuilding the CNID database for: \"%s\"",
+            "dircache_add(): did:%u is less than the allowed %d for: \"%s\". "
+            "This indicates a caller passed an invalid CNID (possible database error).",
             ntohl(dir->d_did), CNID_START,
             dir->d_u_name ? cfrombstr(dir->d_u_name) : "(null)");
     }

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -350,6 +350,14 @@ int getmetadata(const AFPObj *obj,
 
             if (cachedfile == NULL) {
                 id = get_id(vol, adp, st, dir->d_did, upath, len);
+
+                if (id < CNID_START) {
+                    LOG(log_error, logtype_afpd,
+                        "getmetadata: get_id failed for \"%s\", invalid id %u, afp_errno=%d (%s)",
+                        upath, id, afp_errno, AfpErr2name(afp_errno));
+                    return afp_errno;
+                }
+
                 /* Add it to the cache */
                 LOG(log_debug, logtype_afpd, "getmetadata: caching: did:%u, \"%s\", cnid:%u",
                     ntohl(dir->d_did), upath, ntohl(id));


### PR DESCRIPTION
Database connection failures cause get_id() to return CNID_INVALID (0), which triggered a panic when passed to dircache_add(). Now validate and return early before attempting cache operations.