### PR TITLE
Enable OpenIndiana build in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -762,7 +762,6 @@ jobs:
   build-openindiana:
     name: OpenIndiana
     runs-on: ubuntu-latest
-    if: 0 # pkg install process times out too frequently
     timeout-minutes: 24
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Removed condition that prevents the OpenIndiana build from running.