### PR TITLE
backwards compatibility with iniparser v3

### DIFF
--- a/include/atalk/iniparser_util.h
+++ b/include/atalk/iniparser_util.h
@@ -17,6 +17,12 @@
 #include <iniparser.h>
 #endif
 
+#ifdef HAVE_INIPARSER_CONST_DICTIONARY
+#define INIPARSER_DICTIONARY const dictionary
+#else
+#define INIPARSER_DICTIONARY dictionary
+#endif
+
 /**********************************************************************************************
  * Ini config manipulation macros
  **********************************************************************************************/

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -774,7 +774,7 @@ static int hostaccessvol(const AFPObj *obj, const char *volname _U_,
  *
  * @returns       const option string from "vol" or "defsec", or "defval" if not found
  */
-static const char *getoption_str(const dictionary *conf, const char *vol,
+static const char *getoption_str(INIPARSER_DICTIONARY *conf, const char *vol,
                                  const char *opt, const char *defsec, const char *defval)
 {
     const char *result;
@@ -806,7 +806,7 @@ static const char *getoption_str(const dictionary *conf, const char *vol,
  *
  * @returns       dynamically allocated option string from "vol" or "defsec", or "defval" if not found
  */
-static char *getoption_strdup(const dictionary *conf, const char *vol,
+static char *getoption_strdup(INIPARSER_DICTIONARY *conf, const char *vol,
                               const char *opt, const char *defsec, const char *defval)
 {
     char *result;
@@ -840,7 +840,7 @@ static char *getoption_strdup(const dictionary *conf, const char *vol,
  *
  * @returns       const option string from "vol" or "defsec", or "defval" if not found
  */
-static int getoption_bool(const dictionary *conf, const char *vol,
+static int getoption_bool(INIPARSER_DICTIONARY *conf, const char *vol,
                           const char *opt, const char *defsec, int defval)
 {
     int result;
@@ -871,7 +871,7 @@ static int getoption_bool(const dictionary *conf, const char *vol,
  *
  * @returns       int option from "vol" or "defsec", or "defval" if not found
  */
-static int getoption_int(const dictionary *conf, const char *vol,
+static int getoption_int(INIPARSER_DICTIONARY *conf, const char *vol,
                          const char *opt, const char *defsec, int defval)
 {
     int result;
@@ -906,7 +906,7 @@ static int getoption_int(const dictionary *conf, const char *vol,
  *
  * @returns       const option string from "vol" or "defsec", or "defval" if not found
  */
-static int vdgoption_bool(const dictionary *conf, const char *vol,
+static int vdgoption_bool(INIPARSER_DICTIONARY *conf, const char *vol,
                           const char *opt, const char *defsec, int defval)
 {
     int result;

--- a/meson.build
+++ b/meson.build
@@ -668,6 +668,36 @@ if not iniparser.found()
     error('iniparser library required but not found!')
 endif
 
+iniparser_const_test_code = '''
+#include <iniparser.h>
+int main() {
+    const dictionary *d = 0;
+    iniparser_getboolean(d, "", 0);
+    return 0;
+}
+'''
+
+if cdata.has('HAVE_INIPARSER_INIPARSER_H')
+    iniparser_const_test_code = '''
+#include <iniparser/iniparser.h>
+int main() {
+    const dictionary *d = 0;
+    iniparser_getboolean(d, "", 0);
+    return 0;
+}
+'''
+endif
+
+have_iniparser_const = cc.compiles(
+    iniparser_const_test_code,
+    dependencies: iniparser,
+    name: 'iniparser functions accept const dictionary',
+)
+
+if have_iniparser_const
+    cdata.set('HAVE_INIPARSER_CONST_DICTIONARY', 1)
+endif
+
 #
 # Check for POSIX threads
 #

--- a/meson_config.h
+++ b/meson_config.h
@@ -160,6 +160,9 @@
 /* Define to 1 if you have the <iniparser/iniparser.h> header file. */
 #mesondefine HAVE_INIPARSER_INIPARSER_H
 
+/* Define to 1 if iniparser functions accept const dictionary pointers. */
+#mesondefine HAVE_INIPARSER_CONST_DICTIONARY
+
 /* Define if Kerberos 5 is available */
 #mesondefine HAVE_KERBEROS
 


### PR DESCRIPTION
for our purposes, there is only one noticeable difference between the latest v4 and the v3 iniparser library that is distributed with f.e. OpenBSD or NetBSD:

the iniparser_get* functions take a non-const dictionary first argument rather than a const dictionary first argument

this adds a preprocessor macro plus build time capability detection to silence compiler warnings and potential errors