### PR TITLE
nad: more sophisticated check for the MAXPHYS macro

### DIFF
--- a/bin/nad/nad_cp.c
+++ b/bin/nad/nad_cp.c
@@ -709,7 +709,7 @@ static int copy(const char *path,
 /*! Maximum buffer size in bytes - do not allow it to grow larger than this */
 #define BUFSIZE_MAX (2*1024*1024)
 
-#if ! defined __APPLE__ && ! defined __FreeBSD__
+#ifndef MAXPHYS
 /*! Small (default) buffer size in bytes. It's inefficient for this to be smaller than MAXPHYS */
 #define MAXPHYS (64 * 1024)
 #endif


### PR DESCRIPTION
rather than hard coding the check for macOS and FreeBSD, define the macro only if it isn't already defined by the OS

DragonflyBSD, for instance, also has defined in a system C library header