### PR TITLE
afpstats: expose hostname for each afpd child process

### DIFF
--- a/contrib/bin_utils/afpstats.pl
+++ b/contrib/bin_utils/afpstats.pl
@@ -2,7 +2,7 @@
 #
 # AFP Statistics over D-Bus
 #
-# (c) 2024 Daniel Markstedt <daniel@mindani.net>
+# (c) 2024-2026 Daniel Markstedt <daniel@mindani.net>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -17,9 +17,24 @@
 
 use strict;
 use warnings;
+use File::Basename;
 use Net::DBus;
 
 sub main {
+    my $hostname_filter;
+
+    while (my $arg = shift @ARGV) {
+        if ($arg =~ /^(-v|--version)$/) {
+            printf('%s (Netatalk @netatalk_version@)' . "\n", basename($0));
+            exit 1;
+        } elsif ($arg =~ /^(-h|--hostname)$/) {
+            $hostname_filter = shift @ARGV;
+        } else {
+            printf("Usage: %s [-h hostname] [-v]\n", basename($0));
+            exit 1;
+        }
+    }
+
     my $bus = Net::DBus->system();
 
     eval {
@@ -29,12 +44,16 @@ sub main {
                                                  "org.netatalk.AFPStats"
         );
 
-        print "Connected user   PID      Login time        State          Mounted volumes\n";
+        print "Connected user   PID      Login time        State          Hostname          Mounted volumes\n";
 
         foreach my $user (@{$remote_object->GetUsers}) {
-            if ($user =~ /name: ([^,]+), pid: ([^,]+), logintime: ([^,]+), state: ([^,]+), volumes: (.+)/) {
-                my ($name, $pid, $logintime, $state, $volume) = ($1, $2, $3, $4, $5);
-                printf "%-17s%-9s%-18s%-15s%s\n", $name, $pid, $logintime, $state, $volume;
+            if ($user =~
+                 /^name: ([^,]+), pid: ([^,]+), logintime: ([^,]+), state: ([^,]+), volumes: (.*), hostname: (.+)/) {
+                my ($name, $pid, $logintime, $state, $volume, $hostname) = ($1, $2, $3, $4, $5, $6);
+                if (defined $hostname_filter && $hostname ne $hostname_filter) {
+                    next;
+                }
+                printf "%-17s%-9s%-18s%-15s%-18s%s\n", $name, $pid, $logintime, $state, $hostname, $volume;
             } else {
                 print "WARNING Unexpected output. This is probably a bug:\n" . $user . "\n";
             }

--- a/doc/manpages/man1/afpstats.1.md
+++ b/doc/manpages/man1/afpstats.1.md
@@ -4,12 +4,24 @@ afpstats — List netatalk AFP server statistics
 
 # Synopsis
 
-**afpstats**
+**afpstats** [-h *hostname*]
+
+**afpstats** [-v | \-\-version]
 
 # Description
 
 **afpstats** list information about users connected to the netatalk AFP server,
-their mounted volumes, and time of login.
+their mounted volumes, time of login, and other details.
+
+# Options
+
+**-h**, **\-\-hostname** *hostname*
+
+> Filter the output by the given hostname.
+
+**-v**, **\-\-version**
+
+> Show version and exit.
 
 # Note
 
@@ -22,10 +34,12 @@ Finally, to enable AFP statistics in netatalk at runtime, "**afpstats = yes**" m
 
 # Examples
 
-    $ afpstats
-    Connected user   PID      Login time        State          Mounted volumes
-    alice            452547   Apr 28 21:58:50   active         Test Volume, alice's Home
-    charlie          451969   Apr 28 21:21:32   active         My AFP Volume
+List all connected users to the AFP server running on *fileserver*:
+
+    $ afpstats --hostname fileserver
+    Connected user   PID      Login time        State          Hostname          Mounted volumes
+    alice            452547   Apr 28 21:58:50   active         fileserver        Test Volume, alice's Home
+    bob              451969   Apr 28 21:21:32   active         fileserver        My AFP Volume
 
 # See Also
 

--- a/etc/afpd/afpstats_obj.c
+++ b/etc/afpd/afpstats_obj.c
@@ -79,11 +79,11 @@ gboolean afpstats_obj_get_users(AFPStatsObj *obj _U_, gchar ***ret,
     server_child_t *childs = afpstats_get_and_lock_childs();
     afp_child_t *child;
     struct passwd *pw;
-    int i = 0, j;
+    int i = 0;
     char buf[256];
     names = g_new(char *, childs->servch_count + 1);
 
-    for (j = 0; j < CHILD_HASHSIZE && i < childs->servch_count; j++) {
+    for (int j = 0; j < CHILD_HASHSIZE && i < childs->servch_count; j++) {
         child = childs->servch_table[j];
 
         while (child) {
@@ -91,14 +91,15 @@ gboolean afpstats_obj_get_users(AFPStatsObj *obj _U_, gchar ***ret,
                 time_t time = child->afpch_logintime;
                 strftime(buf, sizeof(buf), "%b %d %H:%M:%S", localtime(&time));
                 names[i++] =
-                    g_strdup_printf("name: %s, pid: %d, logintime: %s, state: %s, volumes: %s",
+                    g_strdup_printf("name: %s, pid: %d, logintime: %s, state: %s, volumes: %s, hostname: %s",
                                     pw->pw_name, child->afpch_pid, buf,
                                     child->afpch_state == DSI_RUNNING ? "active" :
                                     child->afpch_state == DSI_SLEEPING ? "sleeping" :
                                     child->afpch_state == DSI_EXTSLEEP ? "sleeping" :
                                     child->afpch_state == DSI_DISCONNECTED ? "disconnected" :
                                     "unknown",
-                                    child->afpch_volumes ? child->afpch_volumes : "-");
+                                    child->afpch_volumes ? child->afpch_volumes : "-",
+                                    child->afpch_hostname ? child->afpch_hostname : "-");
             }
 
             child = child->afpch_next;

--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -333,7 +333,8 @@ static int login(AFPObj *obj, struct passwd *pwd, void (*logout)(void),
     obj->uid = pwd->pw_uid;
     obj->euid = geteuid();
     /* report to parent */
-    ipc_child_write(obj->ipc_fd, IPC_LOGINDONE, 0, "");
+    ipc_child_write(obj->ipc_fd, IPC_LOGINDONE, strlen(obj->options.hostname),
+                    obj->options.hostname);
     /* pam_umask or similar might have changed our umask */
     (void)umask(obj->options.umask);
 

--- a/include/atalk/server_child.h
+++ b/include/atalk/server_child.h
@@ -12,8 +12,9 @@
 
 /*!
  * @file
- * useful stuff for child processes. most of this is hidden in
- * server_child.c to ease changes in implementation
+ * @brief data structures and utility functions for child processes
+ *
+ * most of the implementation is in libatalk/util/server_child.c
  */
 
 #define CHILD_HASHSIZE 32
@@ -29,6 +30,7 @@ typedef struct afp_child {
     uint32_t  afpch_idlen;     /*!< clientid len (from the Mac client) */
     char     *afpch_clientid;  /*!< clientid (from the Mac client) */
     int       afpch_ipc_fd;    /*!< socket for IPC bw afpd parent and childs */
+    char     *afpch_hostname;  /*!< hostname of the server that the child is connected to */
     int16_t   afpch_state;     /*!< state of AFP session (eg active, sleeping, disconnected) */
     char     *afpch_volumes;   /*!< mounted volumes */
     struct afp_child **afpch_prevp;
@@ -58,7 +60,7 @@ extern int  server_child_transfer_session(server_child_t *children, pid_t,
         uid_t, int, uint16_t);
 extern void server_child_handler(server_child_t *);
 extern void server_child_login_done(server_child_t *children, pid_t pid,
-                                    uid_t);
+                                    uid_t, const char *);
 extern void server_reset_signal(void);
 
 #endif

--- a/include/atalk/server_ipc.h
+++ b/include/atalk/server_ipc.h
@@ -12,7 +12,7 @@
 #define IPC_LOGINDONE        4
 
 extern int ipc_server_read(server_child_t *children, int fd);
-extern int ipc_child_write(int fd, uint16_t command, int len, void *token);
+extern int ipc_child_write(int fd, uint16_t command, size_t len, void *token);
 extern int ipc_child_state(AFPObj *obj, uint16_t state);
 
 #endif /* IPC_GETSESSION_LOGIN */

--- a/libatalk/util/server_ipc.c
+++ b/libatalk/util/server_ipc.c
@@ -118,7 +118,8 @@ static int ipc_login_done(const struct ipc_header *ipc,
         ipc->child_pid, ipc->uid);
     server_child_login_done(children,
                             ipc->child_pid,
-                            ipc->uid);
+                            ipc->uid,
+                            ipc->msg);
     return 0;
 }
 
@@ -297,7 +298,7 @@ int ipc_server_read(server_child_t *children, int fd)
 }
 
 /* ----------------- */
-int ipc_child_write(int fd, uint16_t command, int len, void *msg)
+int ipc_child_write(int fd, uint16_t command, size_t len, void *msg)
 {
     char block[IPC_MAXMSGSIZE], *p;
     pid_t pid;


### PR DESCRIPTION
store server hostname in the child process data structure and expose it in the afpstats D-Bus message for printing

introduce an option in afpstats, --hostname, that filters the output by hostname; also add a --version option for good measure