### PR TITLE
nad: add an -F option for reading a custom afp.conf file

### DIFF
--- a/doc/manpages/man1/nad.1.md
+++ b/doc/manpages/man1/nad.1.md
@@ -4,7 +4,7 @@ nad - Netatalk AppleDouble file utility suite
 
 # Synopsis
 
-**nad** [ls | cp | mv | rm | set | find] [...]
+**nad** [-F *configfile*] [ls | cp | mv | rm | set | find] [...]
 
 **nad** [-v | \-\-version]
 
@@ -27,6 +27,12 @@ shared by Netatalk.
 Only users with appropriate permissions to access the files and directories
 can use **nad** to manipulate them.
 It is sensitive to afp.conf settings such as *valid users* and *invalid users*.
+
+# Options
+
+**-F** *configfile*
+
+> Use *configfile* as the full path to the Netatalk configuration file.
 
 # Available Commands
 


### PR DESCRIPTION
if you pass '-F /path/to/afp.conf' as the first parameter to nad, it will read this file instead of the default defined at compile time