### PR TITLE
consistently use the Zeroconf term

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ so Netatalk can act as a seamless bridge between new and old Macs.
 
 Compared to cross-platform file sharing protocols like NFS and FTP, Netatalk delivers a Mac-like user experience,
 with seamless integration of Mac filesystem metadata - notably Extended Attributes on macOS and resource forks
-on Classic Mac OS - as well as compatibility with modern macOS features such as Bonjour, Time Machine, and Spotlight.
+on Classic Mac OS - as well as compatibility with modern macOS features such as Zeroconf (Bonjour) service discovery,
+Time Machine backups, and Spotlight indexed search.
 
 Compared to [Samba](https://www.samba.org/) (SMB),
 Netatalk has [demonstrably faster transfer speeds](https://netatalk.io/docs/Benchmarks),

--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -111,11 +111,11 @@ functionality.
     while on others you have to install supporting packages to enable this
     functionality.
 
-- Avahi or mDNSresponder for Bonjour
+- Avahi or mDNSresponder for Zeroconf
 
-    Mac OS X 10.2 and later uses Bonjour (a.k.a. Zeroconf) for automatic
-    service discovery. Netatalk can advertise AFP file sharing and Time
-    Machine volumes by using Avahi or mDNSResponder.
+    Mac OS X 10.2 and later uses Zeroconf for automatic service discovery.
+    Netatalk can advertise AFP file sharing and Time Machine volumes
+    by using Avahi or mDNSResponder.
 
     When using Avahi, D-Bus is also required, and the Avahi library must
     have been built with D-Bus support.

--- a/doc/manual/index.md
+++ b/doc/manual/index.md
@@ -18,8 +18,8 @@ of new and old Macs.
 
 Netatalk ships with range of capabilities to accommodate most deployment
 environments, including Kerberos, ACLs and LDAP. Modern macOS features
-such as Bonjour service discovery, Time Machine backups, and Spotlight
-indexed search are provided.
+such as Zeroconf (Bonjour) service discovery, Time Machine backups,
+and Spotlight indexed search are provided.
 
 For AppleTalk networks with legacy Macs and Apple IIs, Netatalk provides
 a print server, time server, and Apple II network boot server. The print

--- a/etc/netatalk/afp_avahi.c
+++ b/etc/netatalk/afp_avahi.c
@@ -119,7 +119,7 @@ static void register_stuff(void)
             }
         }
 
-        LOG(log_info, logtype_afpd, "Registering server '%s' with Bonjour", name);
+        LOG(log_info, logtype_afpd, "Registering server '%s' with Zeroconf", name);
 
         if (avahi_entry_group_add_service(ctx->group,
                                           AVAHI_IF_UNSPEC,

--- a/include/atalk/dsi.h
+++ b/include/atalk/dsi.h
@@ -88,7 +88,7 @@ typedef struct DSI {
     char     *end;
 
 #ifdef USE_ZEROCONF
-    char *bonjourname;      /*!< server name as UTF8 maxlen MAXINSTANCENAMELEN */
+    char *zeroconfname;      /*!< server name as UTF8 maxlen MAXINSTANCENAMELEN */
     int zeroconf_registered;
 #endif
 

--- a/libatalk/dsi/dsi_tcp.c
+++ b/libatalk/dsi/dsi_tcp.c
@@ -111,8 +111,8 @@ void dsi_free(DSI *dsi)
     free(dsi->buffer);
     dsi->buffer = NULL;
 #ifdef USE_ZEROCONF
-    free(dsi->bonjourname);
-    dsi->bonjourname = NULL;
+    free(dsi->zeroconfname);
+    dsi->zeroconfname = NULL;
 #endif
 }
 

--- a/meson.build
+++ b/meson.build
@@ -949,7 +949,7 @@ have_dns = (
 
 if enable_zeroconf
     if host_os == 'darwin'
-        # On Darwin/macOS, prefer mDNS (Bonjour) over Avahi
+        # On Darwin/macOS, prefer mDNS over Avahi
         if have_dns
             have_zeroconf = true
             cdata.set('USE_ZEROCONF', 1)
@@ -983,7 +983,7 @@ endif
 
 if enable_zeroconf and not have_zeroconf
     warning(
-        'Zeroconf (Bonjour) support requested but required libraries not found',
+        'Zeroconf support requested but required libraries not found',
         'Please install Avahi or mDNS',
     )
 endif


### PR DESCRIPTION
we were using the terms Zeroconf and Bonjour interchangeably to refer to the same thing; this consistently standardizes on Zeroconf both in documentation and code

this is a breaking change of the API in the dsi.h header