### PR TITLE
meson: don't pass header files as sources to the compiler

### DIFF
--- a/libatalk/unicode/charsets/meson.build
+++ b/libatalk/unicode/charsets/meson.build
@@ -1,28 +1,16 @@
 charsets_sources = [
     'generic_cjk.c',
-    'generic_cjk.h',
     'generic_mb.c',
-    'generic_mb.h',
     'mac_centraleurope.c',
-    'mac_centraleurope.h',
     'mac_chinese_simp.c',
-    'mac_chinese_simp.h',
     'mac_chinese_trad.c',
-    'mac_chinese_trad.h',
     'mac_cyrillic.c',
-    'mac_cyrillic.h',
     'mac_greek.c',
-    'mac_greek.h',
     'mac_hebrew.c',
-    'mac_hebrew.h',
     'mac_japanese.c',
-    'mac_japanese.h',
     'mac_korean.c',
-    'mac_korean.h',
     'mac_roman.c',
-    'mac_roman.h',
     'mac_turkish.c',
-    'mac_turkish.h',
 ]
 
 libcharsets = static_library(


### PR DESCRIPTION
these are the final remnants of a mistake while introducing the meson build system; in meson we only pass the C source files to the compiler