### PR TITLE
testsuite: dynamically skip extension mapping tests when not configured

### DIFF
--- a/test/testsuite/testhelper.c
+++ b/test/testsuite/testhelper.c
@@ -130,6 +130,10 @@ void test_skipped(int why)
         s = "AppleDouble v2 to EA conversion enabled (convert appledouble = yes)";
         break;
 
+    case T_EXTMAP:
+        s = "extmap.conf type/creator mapping";
+        break;
+
     default:
         s = "UNKNOWN REASON - this is a bug";
         break;

--- a/test/testsuite/testhelper.h
+++ b/test/testsuite/testhelper.h
@@ -69,6 +69,7 @@
 #define T_CRED       30
 #define T_LOCALHOST  31
 #define T_V2CONV     32
+#define T_EXTMAP     33
 
 /* Define ansi colors */
 #define ANSI_RED      "\033[0;31m"


### PR DESCRIPTION
rather than failing the test outright, the extension mapping tests now perform a sanity check on the response from the AFP server and skips the test in this scenario instead

this allows for an easer on-the-fly execution of tests without having to touch extmap.conf in every test environment

there is a small risk that this new sanity check logging masks certain types of bugs, but I think that is an acceptable tradeoff since extension mapping as a feature is only relevant for Classic Mac OS