### PR TITLE
meson: consistently define install target tags

### DIFF
--- a/config/meson.build
+++ b/config/meson.build
@@ -7,7 +7,7 @@ afp_conf = configure_file(
 if (fs.exists(pkgconfdir / 'afp.conf') and not get_option('with-overwrite'))
     message('will not replace existing', pkgconfdir / 'afp.conf')
 else
-    install_data(afp_conf, install_dir: pkgconfdir)
+    install_data(afp_conf, install_dir: pkgconfdir, install_tag: 'config')
 endif
 
 if have_spotlight
@@ -23,7 +23,7 @@ if have_spotlight
     )
         message('will not replace existing', pkgconfdir / 'dbus-session.conf')
     else
-        install_data(dbus_session_conf, install_dir: pkgconfdir)
+        install_data(dbus_session_conf, install_dir: pkgconfdir, install_tag: 'config')
     endif
 endif
 
@@ -37,7 +37,11 @@ if have_afpstats
             dbus_sysconfpath / 'netatalk-dbus.conf',
         )
     else
-        install_data('netatalk-dbus.conf', install_dir: dbus_sysconfpath)
+        install_data(
+            'netatalk-dbus.conf',
+            install_dir: dbus_sysconfpath,
+            install_tag: 'config',
+        )
     endif
 endif
 
@@ -64,6 +68,7 @@ if have_appletalk and have_cups and get_option('with-cups-pap-backend')
         configuration: cdata,
         install: true,
         install_dir: cups_libdir / 'cups/backend',
+        install_tag: 'runtime',
     )
 endif
 
@@ -71,7 +76,7 @@ foreach file : static_conf_files
     if (fs.exists(pkgconfdir / file) and not get_option('with-overwrite'))
         message('will not replace existing', pkgconfdir / file)
     else
-        install_data(file, install_dir: pkgconfdir)
+        install_data(file, install_dir: pkgconfdir, install_tag: 'config')
     endif
 endforeach
 
@@ -82,11 +87,16 @@ if (fs.exists('/etc/ld.so.conf.d') and get_option('with-ldsoconf'))
         configuration: cdata,
         install: true,
         install_dir: '/etc/ld.so.conf.d',
+        install_tag: 'config',
     )
 endif
 
 if get_option('with-statedir-creation')
-    install_data('README', install_dir: localstatedir / 'netatalk/CNID')
+    install_data(
+        'README',
+        install_dir: localstatedir / 'netatalk/CNID',
+        install_tag: 'doc',
+    )
 endif
 
 if have_pam

--- a/config/pam/meson.build
+++ b/config/pam/meson.build
@@ -7,5 +7,5 @@ netatalk_pamd = configure_file(
 if (fs.exists(pam_confdir / 'netatalk') and not get_option('with-overwrite'))
     message('will not replace existing', pam_confdir / 'netatalk')
 else
-    install_data(netatalk_pamd, install_dir: pam_confdir)
+    install_data(netatalk_pamd, install_dir: pam_confdir, install_tag: 'config')
 endif

--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -33,6 +33,7 @@ if 'debian-sysv' in init_style
             install: true,
             install_dir: init_dir,
             install_mode: 'rwxr-xr-x',
+            install_tag: 'runtime',
         )
     endforeach
     if get_option('with-init-hooks')
@@ -60,6 +61,7 @@ if 'freebsd' in init_style
         install: true,
         install_dir: init_dir,
         install_mode: 'rwxr-xr-x',
+        install_tag: 'runtime',
     )
     if get_option('with-init-hooks')
         meson.add_install_script(
@@ -82,6 +84,7 @@ if 'macos-launchd' in init_style
         install: true,
         install_dir: bindir,
         install_mode: 'rwxr-xr-x',
+        install_tag: 'runtime',
     )
     configure_file(
         input: 'macos.netatalk.plist.in',
@@ -89,6 +92,7 @@ if 'macos-launchd' in init_style
         configuration: cdata,
         install: true,
         install_dir: init_dir,
+        install_tag: 'runtime',
     )
     if (
         not fs.exists(init_dir / 'io.netatalk.daemon.plist')
@@ -144,6 +148,7 @@ if 'netbsd' in init_style
             install: true,
             install_dir: init_dir,
             install_mode: 'rwxr-xr-x',
+            install_tag: 'runtime',
         )
     endforeach
 endif
@@ -160,6 +165,7 @@ if 'openbsd' in init_style
         install: true,
         install_dir: init_dir,
         install_mode: 'rwxr-xr-x',
+        install_tag: 'runtime',
     )
     if get_option('with-init-hooks')
         meson.add_install_script(
@@ -193,6 +199,7 @@ if 'openrc' in init_style
             install: true,
             install_dir: init_dir,
             install_mode: 'rwxr-xr-x',
+            install_tag: 'runtime',
         )
     endforeach
     if get_option('with-init-hooks')
@@ -218,6 +225,7 @@ if 'solaris' in init_style
         configuration: cdata,
         install: true,
         install_dir: init_dir,
+        install_tag: 'runtime',
     )
     if get_option('with-init-hooks')
         meson.add_install_script(
@@ -250,6 +258,7 @@ if 'systemd' in init_style
             configuration: cdata,
             install: true,
             install_dir: init_dir,
+            install_tag: 'runtime',
         )
     endforeach
     if get_option('with-init-hooks')

--- a/doc/manpages/man1/meson.build
+++ b/doc/manpages/man1/meson.build
@@ -19,7 +19,11 @@ if have_appletalk
         'rtmpqry',
     ]
 
-    install_data(['nbp.1', 'nbpunrgstr.1'], install_dir: mandir / 'man1')
+    install_data(
+        ['nbp.1', 'nbpunrgstr.1'],
+        install_dir: mandir / 'man1',
+        install_tag: 'man',
+    )
 endif
 
 if get_option('with-testsuite')
@@ -31,7 +35,7 @@ if get_option('with-testsuite')
         'afparg',
     ]
 
-    install_data('afptest.1', install_dir: mandir / 'man1')
+    install_data('afptest.1', install_dir: mandir / 'man1', install_tag: 'man')
 endif
 
 foreach man : manfiles
@@ -50,6 +54,7 @@ foreach man : manfiles
         capture: true,
         install: true,
         install_dir: mandir / 'man1',
+        install_tag: 'man',
         build_by_default: true,
     )
 endforeach

--- a/doc/manpages/man5/meson.build
+++ b/doc/manpages/man5/meson.build
@@ -11,7 +11,7 @@ if have_appletalk
         'papd.conf',
     ]
 
-    install_data('macipgw.conf.5', install_dir: mandir / 'man5')
+    install_data('macipgw.conf.5', install_dir: mandir / 'man5', install_tag: 'man')
 endif
 
 foreach man : manfiles
@@ -30,6 +30,7 @@ foreach man : manfiles
         capture: true,
         install: true,
         install_dir: mandir / 'man5',
+        install_tag: 'man',
         build_by_default: true,
     )
 endforeach

--- a/doc/manpages/man8/meson.build
+++ b/doc/manpages/man8/meson.build
@@ -37,6 +37,7 @@ foreach man : manfiles
         capture: true,
         install: true,
         install_dir: mandir / 'man8',
+        install_tag: 'man',
         build_by_default: true,
     )
 endforeach

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -38,6 +38,7 @@ foreach page : manual_pages
             capture: true,
             install: true,
             install_dir: docs_install_path / 'manual',
+            install_tag: 'doc',
         )
     elif cmarkgfm.found()
         custom_target(
@@ -54,6 +55,7 @@ foreach page : manual_pages
             capture: true,
             install: true,
             install_dir: docs_install_path / 'manual',
+            install_tag: 'doc',
         )
     elif cmark.found()
         custom_target(
@@ -70,6 +72,7 @@ foreach page : manual_pages
             capture: true,
             install: true,
             install_dir: docs_install_path / 'manual',
+            install_tag: 'doc',
         )
     endif
 endforeach

--- a/meson.build
+++ b/meson.build
@@ -2343,6 +2343,7 @@ if 'readmes' in get_option('with-docs')
                     capture: true,
                     install: true,
                     install_dir: datadir / 'doc/netatalk',
+                    install_tag: 'doc',
                 )
             elif cmarkgfm.found()
                 custom_target(
@@ -2359,9 +2360,14 @@ if 'readmes' in get_option('with-docs')
                     capture: true,
                     install: true,
                     install_dir: datadir / 'doc/netatalk',
+                    install_tag: 'doc',
                 )
             else
-                install_data(file + '.md', install_dir: datadir / 'doc/netatalk')
+                install_data(
+                    file + '.md',
+                    install_dir: datadir / 'doc/netatalk',
+                    install_tag: 'doc',
+                )
             endif
         endif
     endforeach

--- a/test/testsuite/data/meson.build
+++ b/test/testsuite/data/meson.build
@@ -1,4 +1,5 @@
 install_data(
     'test431_data',
     install_dir: datadir / 'netatalk' / 'test-data',
+    install_tag: 'runtime',
 )


### PR DESCRIPTION
this creates a tag for all install targets in the meson build system, allowing for fine grained control of installations per file category