### PR TITLE
ci: standardize workflow conditions and syntax

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,10 @@
 name: Builds
+
 on:
   push:
     branches:
       - main
       - branch-*
-    paths-ignore:
-      - "**.md"
-      - "**/COPYING"
-      - "**/README*"
-      - "COPYRIGHT"
   pull_request:
     branches:
       - main
@@ -17,11 +13,6 @@ on:
       - opened
       - synchronize
       - reopened
-    paths-ignore:
-      - "**.md"
-      - "**/COPYING"
-      - "**/README*"
-      - "COPYRIGHT"
 
 permissions:
   contents: read

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -1,4 +1,5 @@
 name: Code Analysis
+
 on:
   push:
     branches:

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,23 +1,18 @@
 name: Containers
+
 on:
   push:
-    branches: ["main"]
-    paths-ignore:
-      - "**.md"
-      - "**/COPYING"
-      - "**/README*"
-      - ".github/workflows/build.yml"
-      - "contrib/webmin_module/**"
-      - "COPYRIGHT"
+    branches:
+      - main
+      - branch-*
   pull_request:
-    branches: ["main"]
-    paths-ignore:
-      - "**.md"
-      - "**/COPYING"
-      - "**/README*"
-      - ".github/workflows/build.yml"
-      - "contrib/webmin_module/**"
-      - "COPYRIGHT"
+    branches:
+      - main
+      - branch-*
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 permissions:
   contents: read

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,4 +1,5 @@
 name: ClusterFuzzLite
+
 on:
   push:
     branches:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,10 +1,12 @@
 name: Scorecard supply-chain security
+
 on:
   branch_protection_rule:
   schedule:
     - cron: '45 23 * * 0'
   push:
-    branches: ["main"]
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/spectest-macos.yml
+++ b/.github/workflows/spectest-macos.yml
@@ -1,14 +1,10 @@
 name: macOS Spec Tests
+
 on:
   push:
     branches:
       - main
       - branch-*
-    paths-ignore:
-      - "**.md"
-      - "**/COPYING"
-      - "**/README*"
-      - "COPYRIGHT"
   pull_request:
     branches:
       - main
@@ -17,11 +13,6 @@ on:
       - opened
       - synchronize
       - reopened
-    paths-ignore:
-      - "**.md"
-      - "**/COPYING"
-      - "**/README*"
-      - "COPYRIGHT"
 
 permissions:
   contents: read

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,4 +1,5 @@
 name: Deploy static content to Pages
+
 on:
   push:
     branches: ["main"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: Tests
+
 on:
   push:
     branches:


### PR DESCRIPTION
this removes file path conditions except where absolutely necessary, the argument being that the build system operate on all of these files and there may be unexpected dependencies

also minor cleanup of the syntax in the headers of all workflows