### PR TITLE
afpd: enhance LRU promote, fix moveandrename stale paths, fix 'mac charset' option, improve fork logging

### DIFF
--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -629,7 +629,9 @@ int afp_setforkparams(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf _U_,
 
     if (NULL == (ofork = of_find(ofrefnum))) {
         LOG(log_error, logtype_afpd,
-            "afp_setforkparams: of_find(%d) could not locate fork", ofrefnum);
+            "afp_setforkparams: of_find(%" PRIu16 ") could not locate fork"
+            " (ntohs: %" PRIu16 ")",
+            ofrefnum, ntohs(ofrefnum));
         return AFPERR_PARAM;
     }
 
@@ -799,8 +801,10 @@ static int byte_lock(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
     ibuf += sizeof(ofrefnum);
 
     if (NULL == (ofork = of_find(ofrefnum))) {
-        LOG(log_error, logtype_afpd, "byte_lock: of_find(%d) could not locate fork",
-            ofrefnum);
+        LOG(log_error, logtype_afpd,
+            "byte_lock: of_find(%" PRIu16 ") could not locate fork"
+            " (ntohs: %" PRIu16 ")",
+            ofrefnum, ntohs(ofrefnum));
         return AFPERR_PARAM;
     }
 
@@ -942,8 +946,10 @@ static int read_fork(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
     ibuf += sizeof(u_short);
 
     if (NULL == (ofork = of_find(ofrefnum))) {
-        LOG(log_error, logtype_afpd, "afp_read: of_find(%d) could not locate fork",
-            ofrefnum);
+        LOG(log_error, logtype_afpd,
+            "afp_read: of_find(%" PRIu16 ") could not locate fork"
+            " (ntohs: %" PRIu16 ")",
+            ofrefnum, ntohs(ofrefnum));
         err = AFPERR_PARAM;
         goto afp_read_err;
     }
@@ -1174,8 +1180,10 @@ int afp_flushfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
     memcpy(&ofrefnum, ibuf, sizeof(ofrefnum));
 
     if (NULL == (ofork = of_find(ofrefnum))) {
-        LOG(log_error, logtype_afpd, "afp_flushfork: of_find(%d) could not locate fork",
-            ofrefnum);
+        LOG(log_error, logtype_afpd,
+            "afp_flushfork: of_find(%" PRIu16 ") could not locate fork"
+            " (ntohs: %" PRIu16 ")",
+            ofrefnum, ntohs(ofrefnum));
         return AFPERR_PARAM;
     }
 
@@ -1207,8 +1215,10 @@ int afp_syncfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
     ibuf += sizeof(ofrefnum);
 
     if (NULL == (ofork = of_find(ofrefnum))) {
-        LOG(log_error, logtype_afpd, "afpd_syncfork: of_find(%d) could not locate fork",
-            ofrefnum);
+        LOG(log_error, logtype_afpd,
+            "afp_syncfork: of_find(%" PRIu16 ") could not locate fork"
+            " (ntohs: %" PRIu16 ")",
+            ofrefnum, ntohs(ofrefnum));
         return AFPERR_PARAM;
     }
 
@@ -1276,8 +1286,11 @@ int afp_closefork(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
     memcpy(&ofrefnum, ibuf, sizeof(ofrefnum));
 
     if (NULL == (ofork = of_find(ofrefnum))) {
-        LOG(log_error, logtype_afpd, "afp_closefork: of_find(%d) could not locate fork",
-            ofrefnum);
+        LOG(log_debug, logtype_afpd,
+            "afp_closefork: of_find(%" PRIu16 ") could not locate fork"
+            " (wire bytes: 0x%02x%02x; stale close from client)",
+            ofrefnum,
+            (unsigned char)ibuf[0], (unsigned char)ibuf[1]);
         return AFPERR_PARAM;
     }
 
@@ -1363,8 +1376,10 @@ static int write_fork(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf,
     reqcount = get_off_t(&ibuf, is64);
 
     if (NULL == (ofork = of_find(ofrefnum))) {
-        LOG(log_error, logtype_afpd, "afp_write: of_find(%d) could not locate fork",
-            ofrefnum);
+        LOG(log_error, logtype_afpd,
+            "afp_write: of_find(%" PRIu16 ") could not locate fork"
+            " (ntohs: %" PRIu16 ")",
+            ofrefnum, ntohs(ofrefnum));
         err = AFPERR_PARAM;
         goto afp_write_err;
     }
@@ -1617,7 +1632,9 @@ int afp_getforkparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf,
 
     if (NULL == (ofork = of_find(ofrefnum))) {
         LOG(log_error, logtype_afpd,
-            "afp_getforkparams: of_find(%d) could not locate fork", ofrefnum);
+            "afp_getforkparams: of_find(%" PRIu16 ") could not locate fork"
+            " (ntohs: %" PRIu16 ")",
+            ofrefnum, ntohs(ofrefnum));
         return AFPERR_PARAM;
     }
 

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -264,11 +264,25 @@ of_alloc(struct vol *vol,
 
 struct ofork *of_find(const uint16_t ofrefnum)
 {
+    struct ofork *of;
+
     if (!oforks || !nforks) {
         return NULL;
     }
 
-    return oforks[ofrefnum % nforks];
+    of = oforks[ofrefnum % nforks];
+
+    if (of && of->of_refnum != ofrefnum) {
+        /* Slot collision: different fork now occupies this slot. */
+        LOG(log_error, logtype_afpd,
+            "of_find(%" PRIu16 "): slot %d occupied by refnum %" PRIu16
+            " (\"%s\"), requested fork already closed",
+            ofrefnum, ofrefnum % nforks,
+            of->of_refnum, of_name(of));
+        return NULL;
+    }
+
+    return of;
 }
 
 /* -------------------------- */

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -1078,7 +1078,8 @@ static struct vol *creatvol(AFPObj *obj,
     /* mac charset is in [G] and [V] */
     if ((val = getoption_str(obj->iniconfig, section, "mac charset", preset,
                              NULL))) {
-        if (strncasecmp(val, "MAC", 3) != 0) {
+        if (strncasecmp(val, "MAC", 3) != 0
+                && strcasecmp(val, "UTF8-MAC") != 0) {
             LOG(log_warning, logtype_afpd, "Is '%s' really mac charset? ", val);
         }
 
@@ -2969,7 +2970,8 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
         options->maccodepage = strdup("MAC_ROMAN");
         set_charset_name(CH_MAC, "MAC_ROMAN");
     } else {
-        if (strncasecmp(p, "MAC", 3) != 0) {
+        if (strncasecmp(p, "MAC", 3) != 0
+                && strcasecmp(p, "UTF8-MAC") != 0) {
             LOG(log_warning, logtype_afpd, "'%s' is not a valid Mac charset", p);
         }
 


### PR DESCRIPTION
dircache: enhanced dircache_promote() for LRU mode to move entries to MRU position of LRU cache to prevent premature eviction (LRU no longer FIFO! - most frequent entries survive rollover)

filedir: fix moveandrename() use-after-free of sdir->d_fullpath in LOG/FCE events (sdir mutated during rename). Use dirlookup_strict() to prevent stale cache lookups for critical operation. Remove obsolete self-heal block.

ofork: fix of_find() slot collision bug after refnum rollover. After many thousand fork open/close cycles, lastrefnum wraps and different refnums map to the same slot (refnum % nforks). Without validation, a stale close could silently close the wrong fork (data corruption risk). Now validate of_refnum matches requested refnum.

fork: add byte-order diagnostics (ntohs, wire bytes) to all of_find() failures for easier troubleshooting of refnum mismatch issues.

config: fix 'mac charset' afp.conf option validation rejecting documented 'UTF8-MAC'. The parser only checked for names starting with 'MAC' but 'UTF8-MAC' is a valid registered Mac charset with CHARSET_CLIENT flag set. Setting 'mac charset = UTF8-MAC' was resulting in a fall back to the slower 'MAC_ROMAN'.

UTF8-MAC is netatalk's built-in charset that handles NFD (decomposed Unicode) which macOS uses natively. It has CHARSET_CLIENT | CHARSET_DECOMPOSED flags, meaning it uses netatalk's own C conversion code rather than system iconv(). UTF8 for unix/vol charset similarly uses the built-in with CHARSET_VOLUME | CHARSET_PRECOMPOSED — again native C code. All character conversions route through UCS-2 internally, and since all three charsets have utf8_pull/utf8_push functions, no system iconv is invoked at any point in the conversion chain.
In contrast, the default MAC_ROMAN requires single-byte ↔ UCS-2 table lookups and can only represent 256 characters, making it both slower for Unicode text and lossy for non-Western scripts.