### PR TITLE
afpd: use C11 atomic operations in dircache, conditional check for libatomic

### DIFF
--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -1002,7 +1002,7 @@ static unsigned long queue_count;
 static int should_validate_cache_entry(void)
 {
     /* Thread-safe increment using compiler builtins */
-    uint64_t count = __sync_fetch_and_add(&validation_counter, 1);
+    uint64_t count = __atomic_fetch_add(&validation_counter, 1, __ATOMIC_SEQ_CST);
 
     /* Validate every Nth access to detect external changes */
     if (dircache_validation_freq == 0) {
@@ -1933,7 +1933,7 @@ void log_dircache_stat(void)
      */
     if (dircache_validation_freq > 0 && dircache_stat.hits > 0) {
         /* Thread-safe read of validation counter */
-        uint64_t counter_value = __sync_fetch_and_add(&validation_counter, 0);
+        uint64_t counter_value = __atomic_load_n(&validation_counter, __ATOMIC_SEQ_CST);
         validation_ratio = ((double)counter_value / (double)dircache_validation_freq) /
                            (double)dircache_stat.hits * 100.0;
     }
@@ -1962,7 +1962,7 @@ void log_dircache_stat(void)
         uint64_t entries_returned = dircache_stat.hits + dircache_stat.ghost_hits;
 
         if (dircache_validation_freq > 0 && entries_returned > 0) {
-            uint64_t counter_value = __sync_fetch_and_add(&validation_counter, 0);
+            uint64_t counter_value = __atomic_load_n(&validation_counter, __ATOMIC_SEQ_CST);
             validations_performed = counter_value / dircache_validation_freq;
             validation_ratio = ((double)counter_value / (double)dircache_validation_freq) /
                                (double)entries_returned * 100.0;
@@ -2062,8 +2062,8 @@ void log_dircache_stat(void)
             dircache_stat.hits, hit_ratio,
             dircache_stat.misses,
             miss_ratio,
-            dircache_validation_freq > 0 ? __sync_fetch_and_add(&validation_counter,
-                    0) / dircache_validation_freq : 0, validation_ratio,
+            dircache_validation_freq > 0 ? __atomic_load_n(&validation_counter,
+                    __ATOMIC_SEQ_CST) / dircache_validation_freq : 0, validation_ratio,
             dircache_stat.added,
             dircache_stat.removed,
             dircache_stat.expunged,
@@ -2312,7 +2312,7 @@ int dircache_set_validation_params(unsigned int freq)
 
     dircache_validation_freq = freq;
     /* Thread-safe reset of validation counter using compiler builtins */
-    __sync_lock_test_and_set(&validation_counter, 0);
+    (void)__atomic_exchange_n(&validation_counter, 0, __ATOMIC_SEQ_CST);
     LOG(log_info, logtype_afpd,
         "dircache: validation parameters updated (freq=%u), counter reset", freq);
     return 0;
@@ -2327,7 +2327,7 @@ int dircache_set_validation_params(unsigned int freq)
 void dircache_reset_validation_counter(void)
 {
     /* Thread-safe reset using compiler builtins */
-    __sync_lock_test_and_set(&validation_counter, 0);
+    (void)__atomic_exchange_n(&validation_counter, 0, __ATOMIC_SEQ_CST);
     LOG(log_debug, logtype_afpd, "dircache: validation counter reset");
 }
 

--- a/meson.build
+++ b/meson.build
@@ -226,6 +226,25 @@ if math.found()
     netatalk_common_link_args += '-lm'
 endif
 
+# Check if GCC atomic builtins need explicit libatomic linkage.
+# On some platforms (e.g. 32-bit ARM, MIPS) 64-bit atomics are not inlined
+# by the compiler and require an explicit -latomic link flag.
+atomic_test_code = '''
+#include <stdint.h>
+int main(void) {
+    uint64_t x = 0;
+    __atomic_fetch_add(&x, 1, __ATOMIC_SEQ_CST);
+    __atomic_load_n(&x, __ATOMIC_SEQ_CST);
+    uint64_t y = __atomic_exchange_n(&x, 1, __ATOMIC_SEQ_CST);
+    (void)y;
+    return 0;
+}
+'''
+if not cc.links(atomic_test_code, name: 'atomic builtins without -latomic')
+    cc.find_library('atomic', required: true)
+    netatalk_common_link_args = ['-latomic'] + netatalk_common_link_args
+endif
+
 add_global_link_arguments(netatalk_common_link_args, language: 'c')
 
 if host_machine.endian() == 'big'


### PR DESCRIPTION

replace the legacy sync built-ins that won't work on many 32 bit systems

add conditional check for atomic keywords in meson and link with libatomic if needed

based on patch by Sergey Fedorov