### PR TITLE
ci: pin the meson python package to a specific hash

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,5 +1,7 @@
 FROM gcr.io/oss-fuzz-base/base-builder:v1@sha256:4c20153f428f2ddf623a725251c4b85f71eb19cf3718a33fa41f299a2c3a5226
 
+COPY .clusterfuzzlite/requirements-python.txt /tmp/requirements-python.txt
+
 RUN apt-get update \
 &&  apt-get install --yes --no-install-recommends \
     libevent-dev \
@@ -9,10 +11,17 @@ RUN apt-get update \
     ninja-build \
     pkg-config \
     python3-pip \
+    python3-venv \
     uuid-runtime \
     zlib1g-dev \
-&&  pip3 install --no-cache-dir meson \
+&&  python3 -m pip install --no-cache-dir --upgrade pip pipenv \
+&&  mkdir -p /opt/pydeps \
+&&  cd /opt/pydeps \
+&&  PIPENV_VENV_IN_PROJECT=1 pipenv --python 3 \
+&&  PIPENV_VENV_IN_PROJECT=1 pipenv run pip install --no-deps --require-hashes -r /tmp/requirements-python.txt \
 &&  rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/opt/pydeps/.venv/bin:${PATH}"
 
 COPY .clusterfuzzlite/build.sh $SRC/build.sh
 COPY bin/ $SRC/netatalk/bin/

--- a/.clusterfuzzlite/requirements-python.txt
+++ b/.clusterfuzzlite/requirements-python.txt
@@ -1,0 +1,2 @@
+meson==1.10.1 \
+    --hash=sha256:fe43d1cc2e6de146fbea78f3a062194bcc0e779efc8a0f0d7c35544dfb86731f

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     directory: "/.github/workflows"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/.clusterfuzzlite"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
like we do for all other dependencies, let's lock to a specific hash for python packages to protect against supply chain attacks