### PR TITLE
ci: require hashes when installing python dependency

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -11,17 +11,10 @@ RUN apt-get update \
     ninja-build \
     pkg-config \
     python3-pip \
-    python3-venv \
     uuid-runtime \
     zlib1g-dev \
-&&  python3 -m pip install --no-cache-dir --upgrade pip pipenv \
-&&  mkdir -p /opt/pydeps \
-&&  cd /opt/pydeps \
-&&  PIPENV_VENV_IN_PROJECT=1 pipenv --python 3 \
-&&  PIPENV_VENV_IN_PROJECT=1 pipenv run pip install --no-deps --require-hashes -r /tmp/requirements-python.txt \
+&&  pip install --no-deps --require-hashes -r /tmp/requirements-python.txt \
 &&  rm -rf /var/lib/apt/lists/*
-
-ENV PATH="/opt/pydeps/.venv/bin:${PATH}"
 
 COPY .clusterfuzzlite/build.sh $SRC/build.sh
 COPY bin/ $SRC/netatalk/bin/

--- a/.clusterfuzzlite/requirements-python.txt
+++ b/.clusterfuzzlite/requirements-python.txt
@@ -1,2 +1,1 @@
-meson==1.10.1 \
-    --hash=sha256:fe43d1cc2e6de146fbea78f3a062194bcc0e779efc8a0f0d7c35544dfb86731f
+meson==1.10.1 --hash=sha256:fe43d1cc2e6de146fbea78f3a062194bcc0e779efc8a0f0d7c35544dfb86731f


### PR DESCRIPTION
this is a second attempt at a supply chain security sensitive method of installing the python dependency for the fuzzer container

the pipenv setup turned out to be overkill, instead I'm explicitly flagging the pip install command with --require-hashes