### PR TITLE
[4.4] ci: remove Spotlight dependencies from DragonFlyBSD job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -446,7 +446,6 @@ jobs:
           prepare: |
             pkg install -y \
               avahi \
-              bison \
               cmark \
               db5 \
               iniparser \
@@ -460,9 +459,7 @@ jobs:
               py39-gdbm \
               py39-sqlite3 \
               py39-tkinter \
-              sqlite \
-              talloc \
-              tracker3
+              sqlite
           run: |
             set -e
             meson setup build \


### PR DESCRIPTION
tracker3 has fallen off the DragonFlyBSD ports repository, so let's remove the Spotlight stack for now

backport of a fix from the main branch to unblock the pipeline in the current branch