### PR TITLE
ci: explicitly skip rebuild for build jobs that use sshfs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -537,8 +537,8 @@ jobs:
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build
-            meson test -C build
-            meson install -C build
+            meson test -C build --no-rebuild
+            meson install -C build --no-rebuild
             netatalk -V
             afpd -V
             /usr/local/etc/rc.d/netatalk start
@@ -591,8 +591,8 @@ jobs:
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build
-            meson test -C build
-            meson install -C build
+            meson test -C build --no-rebuild
+            meson install -C build --no-rebuild
             netatalk -V
             afpd -V
             atalkd -V
@@ -656,8 +656,8 @@ jobs:
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build
-            meson test -C build
-            meson install -C build
+            meson test -C build --no-rebuild
+            meson install -C build --no-rebuild
             netatalk -V
             afpd -V
             rcctl -d start netatalk


### PR DESCRIPTION
the inconsistent time stamp on build files when using sshfs to sync the build job file systems cause intermittent failures when rebuilds are triggered, so let's prevent said rebuilds which should hopefully lead to more consistent FreeBSD / NetBSD / OpenBSD workflow builds