### PR TITLE
nad: centralize volume validation and fix inconsistent error handling

### DIFF
--- a/bin/nad/nad_cp.c
+++ b/bin/nad/nad_cp.c
@@ -358,20 +358,15 @@ int ad_cp(int argc, char *argv[], AFPObj *obj)
     /* Inhereting perms in ad_mkdir etc requires this */
     ad_setfuid(0);
 #endif
+
     /* Load .volinfo file for destination*/
-    openvol(obj, to.p_path, &dvolume);
+    if (openvol(obj, to.p_path, &dvolume) != 0) {
+        return 1;
+    }
 
     for (int i = 0; argv[i] != NULL; i++) {
         /* Load .volinfo file for source */
-        if (openvol(obj, argv[i], &svolume) != 0 || svolume.vol == NULL) {
-            SLOG("Error: could not open source volume for %s", argv[i]);
-            badcp = rval = 1;
-            continue;
-        }
-
-        if (openvol(obj, to.p_path, &dvolume) != 0 || dvolume.vol == NULL) {
-            SLOG("Error: could not open destination volume for %s", to.p_path);
-            closevol(&svolume);
+        if (openvol(obj, argv[i], &svolume) != 0) {
             badcp = rval = 1;
             continue;
         }

--- a/bin/nad/nad_find.c
+++ b/bin/nad/nad_find.c
@@ -220,7 +220,8 @@ int ad_find(int argc, char **argv, AFPObj *obj)
     cnid_init();
 
     if (openvol(obj, srchvol, &vol) != 0) {
-        ERROR("Can't open volume \"%s\"", srchvol);
+        free((void *)srchvol);
+        return 1;
     }
 
     free((void *)srchvol);

--- a/bin/nad/nad_ls.c
+++ b/bin/nad/nad_ls.c
@@ -730,11 +730,15 @@ int ad_ls(int argc, char **argv, AFPObj *obj)
     cnid_init();
 
     if ((argc - optind) == 0) {
-        openvol(obj, ".", &vol);
+        if (openvol(obj, ".", &vol) != 0) {
+            return 1;
+        }
+
         ad_ls_r(".", &vol);
         closevol(&vol);
     } else {
         int havefile = 0;
+        int rval = 0;
         firstarg = optind;
 
         /* First run: only print files from argv paths */
@@ -750,7 +754,12 @@ int ad_ls(int argc, char **argv, AFPObj *obj)
             havefile = 1;
             first = 1;
             recursion = 0;
-            openvol(obj, argv[optind], &vol);
+
+            if (openvol(obj, argv[optind], &vol) != 0) {
+                rval = 1;
+                goto next;
+            }
+
             ad_ls_r(argv[optind], &vol);
             closevol(&vol);
 next:
@@ -779,12 +788,19 @@ next:
 
             first = 1;
             recursion = 0;
-            openvol(obj, argv[optind], &vol);
+
+            if (openvol(obj, argv[optind], &vol) != 0) {
+                rval = 1;
+                goto next2;
+            }
+
             ad_ls_r(argv[optind], &vol);
             closevol(&vol);
 next2:
             optind++;
         }
+
+        return rval;
     }
 
     return 0;

--- a/bin/nad/nad_mv.c
+++ b/bin/nad/nad_mv.c
@@ -171,7 +171,6 @@ int ad_mv(int argc, char *argv[], AFPObj *obj)
     cnid_init();
 
     if (openvol(obj, argv[argc - 1], &dvolume) != 0) {
-        SLOG("Error opening CNID database for source \"%s\": ", argv[argc - 1]);
         return 1;
     }
 
@@ -185,7 +184,6 @@ int ad_mv(int argc, char *argv[], AFPObj *obj)
         }
 
         if (openvol(obj, argv[0], &svolume) != 0) {
-            SLOG("Error: could not open volume for destination \"%s\": ", argv[0]);
             return 1;
         }
 
@@ -248,13 +246,15 @@ int ad_mv(int argc, char *argv[], AFPObj *obj)
                 SLOG("%s: destination pathname too long", *argv);
                 rval = 1;
             } else {
-                openvol(obj, *argv, &svolume);
-
-                if (do_move(*argv, path)) {
+                if (openvol(obj, *argv, &svolume) != 0) {
                     rval = 1;
-                }
+                } else {
+                    if (do_move(*argv, path)) {
+                        rval = 1;
+                    }
 
-                closevol(&svolume);
+                    closevol(&svolume);
+                }
             }
         }
 

--- a/bin/nad/nad_rm.c
+++ b/bin/nad/nad_rm.c
@@ -175,10 +175,7 @@ int ad_rm(int argc, char *argv[], AFPObj *obj)
 
     for (int i = 0; argv[i] != NULL; i++) {
         /* Load .volinfo file for source */
-        openvol(obj, argv[i], &volume);
-
-        if (volume.vol == NULL) {
-            SLOG("Error: could not open volume for %s (not removed)", argv[i]);
+        if (openvol(obj, argv[i], &volume) != 0) {
             badrm = rval = 1;
             continue;
         }

--- a/bin/nad/nad_set.c
+++ b/bin/nad/nad_set.c
@@ -350,10 +350,9 @@ int ad_set(int argc, char **argv, AFPObj *obj)
     }
 
     cnid_init();
-    openvol(obj, argv[optind], &vol);
 
-    if (vol.vol == NULL || vol.vol->v_path == NULL) {
-        exit(1);
+    if (openvol(obj, argv[optind], &vol) != 0) {
+        return 1;
     }
 
     if (stat(argv[optind], &st) != 0) {

--- a/bin/nad/nad_util.c
+++ b/bin/nad/nad_util.c
@@ -106,6 +106,7 @@ int openvol(AFPObj *obj, const char *path, afpvol_t *vol)
     memset(vol, 0, sizeof(afpvol_t));
 
     if ((vol->vol = getvolbypath(obj, path)) == NULL) {
+        SLOG("Error: \"%s\" is not inside a Netatalk volume", path);
         return -1;
     }
 


### PR DESCRIPTION
Add a user-facing error message in openvol() when a path is not inside a Netatalk volume, replacing the patchwork of per-command messages that were inconsistent, incorrect, or missing entirely.

Fix all openvol() call sites to check the return value:
- nad_ls: was silently ignoring failures (3 unchecked calls)
- nad_set: was calling exit(1) with no error message
- nad_cp: had a redundant unchecked call before the loop
- nad_mv: had swapped source/destination error labels, plus an unchecked call in the multi-file path
- nad_rm: checked vol.vol == NULL but not the return value
- nad_find: had a redundant error message and a memory leak on the error path