### PR TITLE
fix UUID instability for dynamic volumes with non-AFP clients

### DIFF
--- a/bin/dbd/cmd_dbd.c
+++ b/bin/dbd/cmd_dbd.c
@@ -250,6 +250,24 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    /* Validate that the path is the root of the volume, not a subdirectory */
+    char *resolved_volpath = realpath_safe(volpath);
+
+    if (resolved_volpath == NULL) {
+        dbd_log(LOGSTD, "Can't resolve path '%s'", volpath);
+        exit(EXIT_FAILURE);
+    }
+
+    if (strcmp(resolved_volpath, vol->v_path) != 0) {
+        dbd_log(LOGSTD,
+                "'%s' is not the root of an AFP volume. Expected volume root: '%s'",
+                resolved_volpath, vol->v_path);
+        free(resolved_volpath);
+        exit(EXIT_FAILURE);
+    }
+
+    free(resolved_volpath);
+
     if (load_charset(vol) != 0) {
         dbd_log(LOGSTD, "Couldn't load charsets for '%s'", volpath);
         exit(EXIT_FAILURE);

--- a/bin/dbd/cmd_dbd_scanvol.c
+++ b/bin/dbd/cmd_dbd_scanvol.c
@@ -755,7 +755,13 @@ static int dbd_readdir(int volroot, cnid_t did)
     }
 
     if ((dp = opendir(".")) == NULL) {
-        dbd_log(LOGSTD, "Couldn't open the directory: %s", strerror(errno));
+        if (errno == EACCES || errno == EPERM) {
+            dbd_log(LOGSTD, "Skipping directory '%s': %s", cwdbuf, strerror(errno));
+            return 0;
+        }
+
+        dbd_log(LOGSTD, "Couldn't open the directory '%s': %s", cwdbuf,
+                strerror(errno));
         return -1;
     }
 

--- a/libatalk/cnid/mysql/cnid_mysql.c
+++ b/libatalk/cnid/mysql/cnid_mysql.c
@@ -1170,6 +1170,46 @@ struct _cnid_db *cnid_mysql_open(struct cnid_open_args *args)
 
     free(sql);
     sql = NULL;
+    /*
+     * Clean up stale volume entries for the same path but with a different UUID.
+     * This can happen when the UUID config file is rewritten without the entry
+     * for this volume (e.g. [Homes] volumes not loaded during load_volumes),
+     * causing a new UUID to be generated on the next open.
+     */
+    EC_NEG1(asprintf(&sql,
+                     "SELECT VolUUID FROM volumes WHERE VolPath='%s' AND VolUUID != '%s'",
+                     vol->v_path, db->cnid_mysql_voluuid_str));
+
+    if (cnid_mysql_execute(db->cnid_mysql_con, sql) == 0) {
+        MYSQL_RES *stale_result = mysql_store_result(db->cnid_mysql_con);
+
+        if (stale_result) {
+            MYSQL_ROW stale_row;
+
+            while ((stale_row = mysql_fetch_row(stale_result))) {
+                LOG(log_warning, logtype_cnid,
+                    "cnid_mysql_open: removing stale volume entry UUID '%s' for path '%s'",
+                    stale_row[0], vol->v_path);
+                char *drop_sql = NULL;
+
+                if (asprintf(&drop_sql, "DROP TABLE IF EXISTS `%s`", stale_row[0]) != -1) {
+                    cnid_mysql_execute(db->cnid_mysql_con, drop_sql);
+                    free(drop_sql);
+                }
+            }
+
+            mysql_free_result(stale_result);
+            free(sql);
+            sql = NULL;
+            EC_NEG1(asprintf(&sql,
+                             "DELETE FROM volumes WHERE VolPath='%s' AND VolUUID != '%s'",
+                             vol->v_path, db->cnid_mysql_voluuid_str));
+            cnid_mysql_execute(db->cnid_mysql_con, sql);
+        }
+    }
+
+    free(sql);
+    sql = NULL;
     time_t now = time(NULL);
     char stamp[8];
     memset(stamp, 0, 8);

--- a/libatalk/cnid/sqlite/cnid_sqlite.c
+++ b/libatalk/cnid/sqlite/cnid_sqlite.c
@@ -15,6 +15,7 @@
 
 #include <arpa/inet.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <net/if.h>
 #include <netdb.h>
@@ -1251,6 +1252,7 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
     bstring dbpath = NULL;
     const char *dbpath_str = NULL;
     int sqlite_return;
+    bool is_root = false;
     EC_NULL(cdb = cnid_sqlite_new(vol));
     EC_NULL(db =
                 (CNID_sqlite_private *) calloc(1,
@@ -1265,28 +1267,54 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
     }
 
     become_root();
+    is_root = true;
 
-    if (mkdir(dirpath, 0755) != 0) {
-        if (errno == EEXIST) {
-            struct stat st;
+    if (mkdir(dirpath, 01777) != 0 && errno != EEXIST) {
+        LOG(log_error, logtype_cnid, "Failed to create CNID DB directory '%s': %s",
+            dirpath, strerror(errno));
+        EC_FAIL;
+    }
 
-            if (stat(dirpath, &st) != 0 || !S_ISDIR(st.st_mode)) {
-                LOG(log_error, logtype_cnid, "'%s' exists but is not a directory", dirpath);
-                EC_FAIL;
-            }
-        } else {
-            LOG(log_error, logtype_cnid, "Failed to create CNID DB directory '%s': %s",
+    int dirfd = open(dirpath, O_RDONLY | O_DIRECTORY);
+
+    if (dirfd == -1) {
+        LOG(log_error, logtype_cnid, "Failed to open CNID DB directory '%s': %s",
+            dirpath, strerror(errno));
+        EC_FAIL;
+    }
+
+    struct stat st;
+
+    if (fstat(dirfd, &st) != 0 || !S_ISDIR(st.st_mode)) {
+        LOG(log_error, logtype_cnid, "'%s' exists but is not a directory", dirpath);
+        close(dirfd);
+        EC_FAIL;
+    }
+
+    /* Set directory permissions to world-writable with sticky bit.
+     * SQLite WAL mode requires write access to the directory for journal files.
+     * The sticky bit prevents users from deleting each other's files. */
+    if (fchmod(dirfd, 01777) != 0) {
+        if (errno == EPERM || errno == EACCES) {
+            LOG(log_debug, logtype_cnid,
+                "cnid_sqlite_open: no permissions to set permissions on dir %s: %s",
                 dirpath, strerror(errno));
-            EC_FAIL;
+        } else {
+            LOG(log_error, logtype_cnid,
+                "cnid_sqlite_open: Failed to set permissions on dir %s: %s",
+                dirpath, strerror(errno));
         }
     }
 
+    close(dirfd);
     unbecome_root();
+    is_root = false;
     EC_NULL(dbpath = bformat("%s/%s.sqlite", dirpath, vol->v_localname));
     dbpath_str = bdata(dbpath);
     EC_NULL(db->cnid_sqlite_voluuid_str = uuid_strip_dashes(vol->v_uuid));
     EC_ZERO(sqlite3_initialize());
     become_root();
+    is_root = true;
 
     if (sqlite3_open_v2(dbpath_str,
                         &db->cnid_sqlite_con,
@@ -1338,7 +1366,76 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
         EC_FAIL;
     }
 
-    unbecome_root();
+    /*
+     * Clean up stale volume entries for the same path but with a different UUID.
+     * This can happen when the UUID config file is rewritten without the entry
+     * for this volume (e.g. [Homes] volumes not loaded during load_volumes),
+     * causing a new UUID to be generated on the next open.
+     */
+    if (sqlite3_prepare_v2(db->cnid_sqlite_con,
+                           "SELECT VolUUID FROM volumes WHERE VolPath = ? AND VolUUID != ?",
+                           -1, &transient_stmt, NULL) == SQLITE_OK) {
+        sqlite3_bind_text(transient_stmt, 1, vol->v_path, -1, SQLITE_STATIC);
+        sqlite3_bind_text(transient_stmt, 2, db->cnid_sqlite_voluuid_str, -1,
+                          SQLITE_STATIC);
+        /* Collect stale UUIDs first, then clean up after finalizing the
+         * statement.  Executing DROP TABLE while the SELECT is still
+         * stepping would change the schema cookie and could cause
+         * sqlite3_step() to return SQLITE_SCHEMA, aborting the loop
+         * early and leaving stale entries behind. */
+        char *stale_uuids[64];
+        int stale_count = 0;
+
+        while (sqlite3_step(transient_stmt) == SQLITE_ROW
+                && stale_count < 64) {
+            const char *stale_uuid = (const char *)sqlite3_column_text(transient_stmt, 0);
+
+            if (stale_uuid) {
+                stale_uuids[stale_count] = strdup(stale_uuid);
+
+                if (stale_uuids[stale_count]) {
+                    stale_count++;
+                }
+            }
+        }
+
+        sqlite3_finalize(transient_stmt);
+        transient_stmt = NULL;
+
+        for (int i = 0; i < stale_count; i++) {
+            LOG(log_warning, logtype_cnid,
+                "cnid_sqlite_open: removing stale volume entry UUID '%s' for path '%s'",
+                stale_uuids[i], vol->v_path);
+            char *drop_sql = NULL;
+
+            if (asprintf(&drop_sql, "DROP TABLE IF EXISTS \"%s\"", stale_uuids[i]) != -1) {
+                cnid_sqlite_execute(db->cnid_sqlite_con, drop_sql);
+                free(drop_sql);
+            }
+
+            if (asprintf(&drop_sql,
+                         "DELETE FROM sqlite_sequence WHERE name = '%s'", stale_uuids[i]) != -1) {
+                cnid_sqlite_execute(db->cnid_sqlite_con, drop_sql);
+                free(drop_sql);
+            }
+
+            free(stale_uuids[i]);
+        }
+
+        /* Remove stale volume rows */
+        sqlite3_stmt *delete_stmt = NULL;
+
+        if (sqlite3_prepare_v2(db->cnid_sqlite_con,
+                               "DELETE FROM volumes WHERE VolPath = ? AND VolUUID != ?",
+                               -1, &delete_stmt, NULL) == SQLITE_OK) {
+            sqlite3_bind_text(delete_stmt, 1, vol->v_path, -1, SQLITE_STATIC);
+            sqlite3_bind_text(delete_stmt, 2, db->cnid_sqlite_voluuid_str, -1,
+                              SQLITE_STATIC);
+            sqlite3_step(delete_stmt);
+            sqlite3_finalize(delete_stmt);
+        }
+    }
+
     /* Create a blob.  The MySQL code used an escape string function,
            but we're going to use a prepared statement */
     time_t now = time(NULL);
@@ -1375,6 +1472,8 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
     sqlite3_clear_bindings(transient_stmt);
     sqlite3_finalize(transient_stmt);
     transient_stmt = NULL;
+    unbecome_root();
+    is_root = false;
 
     /*
      * Check whether CNID set overflowed before.
@@ -1529,6 +1628,10 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
         "Finished initializing sqlite CNID module for volume '%s'",
         vol->v_path);
 EC_CLEANUP:
+
+    if (is_root) {
+        unbecome_root();
+    }
 
     if (transient_stmt) {
         sqlite3_finalize(transient_stmt);

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2137,10 +2137,13 @@ int load_volumes(AFPObj *obj, lv_flags_t flags)
     }
 
     /*
-     * Now that we an up to date list of volumes, rewrite
+     * Now that we have an up to date list of volumes, rewrite
      * afp_voluuid.conf to get rid of deleted volumes.
+     * Only do this in AFP sessions where the full volume list is loaded,
+     * otherwise non-AFP callers (dbd, nad) would erase UUIDs for
+     * dynamically created volumes like [Homes] shares.
      */
-    if (flags & LV_ALL) {
+    if ((flags & LV_ALL) && IS_AFP_SESSION(obj)) {
         become_root();
         ret = rewrite_vol_uuid_conf(obj, Volumes);
         unbecome_root();


### PR DESCRIPTION
Non-AFP clients (dbd, nad) triggered rewrite_vol_uuid_conf() during load_volumes(), which truncated and rewrote afp_voluuid.conf without [Homes] entries since those volumes are only created dynamically. Each subsequent open generated a new UUID, orphaning the old CNID table and volume row in the database. Over time this accumulated stale data.

- Guard rewrite_vol_uuid_conf with IS_AFP_SESSION so only AFP sessions with the full volume list rewrite the UUID file
- Add stale UUID cleanup in SQLite and MySQL backends: on open, detect and remove volume entries with matching path but different UUID
- Validate in dbd that the given path is the exact volume root, not a subdirectory
- Handle EACCES/EPERM in dbd_readdir gracefully by skipping inaccessible directories instead of aborting the entire scan