### PR TITLE
nad: implement ls -a flag with . and .. entries

### DIFF
--- a/bin/nad/nad_ls.c
+++ b/bin/nad/nad_ls.c
@@ -35,6 +35,7 @@
 
 #include <atalk/adouble.h>
 #include <atalk/cnid.h>
+#include <atalk/directory.h>
 
 #include "nad.h"
 
@@ -256,6 +257,20 @@ static void print_flags(char *path, afpvol_t *vol, const struct stat *st)
     ad_init(&ad, vol->vol);
 
     if (ad_metadata(path, adflags, &ad) < 0) {
+        /* Print placeholder columns to maintain alignment */
+        printf(" ----------- ------ --- ---- ----");
+
+        /*
+         * ad_metadata succeeds for .. in non-root dirs, so this
+         * fallback only triggers for the volume root's parent,
+         * which is the virtual DIRDID_ROOT_PARENT node (CNID 1).
+         */
+        if (strcmp(path, "..") == 0) {
+            printf("  %10u ", ntohl(DIRDID_ROOT_PARENT));
+        } else {
+            printf("  !ADVOL_CACHE ");
+        }
+
         return;
     }
 
@@ -679,12 +694,35 @@ static int ad_ls_r(char *path, afpvol_t *vol)
     unsigned int col_count = 0;
 
     if (! ls_l) {
-        col_names = malloc(n * sizeof(char *));
+        col_names = malloc((n + 2) * sizeof(char *));
 
         if (col_names == NULL) {
             perror("malloc");
             ret = -1;
             goto exit;
+        }
+    }
+
+    /* Print . and .. first when -a is set */
+    if (ls_a) {
+        dirempty = 0;
+
+        if (recursion && ! dirprinted) {
+            printf("\n%s:\n", cwdpath);
+            dirprinted = 1;
+        }
+
+        if (ls_l) {
+            if (lstat(".", &st) >= 0) {
+                ad_print(".", &st, vol);
+            }
+
+            if (lstat("..", &st) >= 0) {
+                ad_print("..", &st, vol);
+            }
+        } else if (col_names != NULL) {
+            col_names[col_count++] = ".";
+            col_names[col_count++] = "..";
         }
     }
 
@@ -696,7 +734,7 @@ static int ad_ls_r(char *path, afpvol_t *vol)
             goto exit;
         }
 
-        /* Check if its "." or ".." */
+        /* Skip . and .. (handled above when -a is set) */
         if (DIR_DOT_OR_DOTDOT(ep->d_name)) {
             continue;
         }
@@ -735,13 +773,7 @@ static int ad_ls_r(char *path, afpvol_t *vol)
     }
 
     if (! ls_l && ! dirempty) {
-        if (ls_d) {
-            for (i = 0; i < col_count; i++) {
-                printf("%s\n", col_names[i]);
-            }
-        } else {
-            print_columns(col_names, col_count);
-        }
+        print_columns(col_names, col_count);
     }
 
     /* Second run: recurse to dirs */

--- a/doc/manpages/man1/nad.1.md
+++ b/doc/manpages/man1/nad.1.md
@@ -38,7 +38,7 @@ It is sensitive to afp.conf settings such as *valid users* and *invalid users*.
 
 List files and directories.
 
-> nad ls [-dRl[u]] {file|directory [...]}
+> nad ls [-adlRu] {file|directory [...]}
 
 Copy files and directories.
 
@@ -70,19 +70,26 @@ Show version.
 
 # nad ls
 
-List files and directories. Options:
+List files and directories in an AFP volume.
+AppleDouble metadata and CNIDs are displayed in long output mode.
+
+Options:
+
+**-a**
+
+> Include directory entries whose names begin with a dot (.)
 
 **-d**
 
 > Directories are listed as plain files
 
-**-R**
-
-> list subdirectories recursively
-
 **-l**
 
 > Long output, list AFP info
+
+**-R**
+
+> List subdirectories recursively
 
 **-u**
 
@@ -307,6 +314,8 @@ directory.
 List files in a shared AFP volume:
 
     $ nad ls -al /srv/afpshare
+    ---Nic-s--- ------ --- ---- ----           2   .
+    ----------- ------ --- ---- ----           1   ..
     ----i---b-- ------ --- APPL SBMC          40   AppleShare IP Browser
     ---------v- ------ --- ---- ----          36   Network Trash Folder
     -------s-v- ------ --- ---- ----          35   TheVolumeSettingsFolder


### PR DESCRIPTION
Print . (current dir) and .. (parent dir) at the top of the listing when using the -a flag, matching standard ls behavior.

Use the well-known virtual CNID for the root parent directory, and print placeholder AFP flag columns when AppleDouble metadata is unavailable, to maintain column alignment in long output mode.

Also remove dead code in the ls_d column output branch, which was unreachable since -d causes an early return before scanning entries.

In the nad man page, update example and document -a flag