### PR TITLE
afpd: log when the root directory is name locked or rename fails

### DIFF
--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -628,6 +628,8 @@ int afp_rename(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
         }
     } else {
         if (sdir->d_did == DIRDID_ROOT) {   /* root directory */
+            LOG(log_debug, logtype_afpd,
+                "afp_rename: volume root cannot be renamed");
             return AFPERR_NORENAME;
         }
 

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -980,6 +980,24 @@ int afp_openvol(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf,
             setmessage(msg);
         }
 
+        {
+            struct adouble ad;
+            ad_init(&ad, volume);
+            if (!ad_metadata(".", ADFLAGS_DIR, &ad)) {
+                const char *fi = ad_entry(&ad, ADEID_FINDERI);
+                if (fi) {
+                    uint16_t fflags;
+                    memcpy(&fflags, fi + FINDERINFO_FRFLAGOFF, sizeof(fflags));
+                    if (fflags & htons(FINDERINFO_NAMELOCKED)) {
+                        LOG(log_note, logtype_afpd,
+                            "afp_openvol: volume root of \"%s\" has name locked FinderFlag set",
+                            volume->v_localname);
+                    }
+                }
+                ad_close(&ad, ADFLAGS_HF);
+            }
+        }
+
         free(vol_mname);
         server_ipc_volumes(obj);
         return AFP_OK;


### PR DESCRIPTION
the 'name locked' FinderFlag prevents both the renaming of the AFP volume as well as the changing of its Finder icon

adding logging for both the flag and a failure to rename to help users pinpoint why their volumes appear locked

thanks to Scott Small for the report and analysis