### PR TITLE
docs, fixes: update profiling, compilation, manpage, meson options, dircache max size and other minor issues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -520,6 +520,7 @@ jobs:
               iniparser \
               libevent \
               libgcrypt \
+              libsunacl \
               localsearch \
               meson \
               mysql91-client \

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -195,7 +195,7 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
 
   flamegraph-spectest:
-    name: Flamegraph (spectest AFP 3.4)
+    name: Flamegraph (spectest AFP 3.4) (AFP_ASSERT active)
     needs: build-container-debug
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -365,14 +365,12 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             <!-- flamegraph-spectest -->
-            ## 🔥 Spectest (AFP 3.4) - Flamegraph
+            ## 🔥 Spectest (AFP 3.4) - Flamegraph (AFP_ASSERT active)
 
             **Commit:** `${{ github.event.pull_request.head.sha }}`
             **Profiling:** On-CPU sampling @ 999 Hz, DWARF call-graph, x86_64
             **Build:** `debugoptimized` (-O2 -g -fno-omit-frame-pointer)
-            **Unique stacks:** ${{ steps.flamegraph-summary.outputs.STACK_COUNT }}
-            **Test runtime:** ${{ steps.flamegraph-summary.outputs.TEST_RUNTIME }}
-            **SVG size:** ${{ steps.flamegraph-summary.outputs.SVG_SIZE }}
+            **Runtime:** ${{ steps.flamegraph-summary.outputs.TEST_RUNTIME }}, **Stacks:** ${{ steps.flamegraph-summary.outputs.STACK_COUNT }}, **SVG size:** ${{ steps.flamegraph-summary.outputs.SVG_SIZE }}
 
             🔥 **[Open interactive Flamegraph (SVG)](https://netatalk.github.io/netatalk/flamegraphs/flamegraph-${{ github.event.pull_request.head.sha }}.svg)**
 
@@ -388,9 +386,6 @@ jobs:
             ${{ steps.flamegraph-summary.outputs.TOP_FUNCS }}
 
             </details>
-
-            Open the SVG in a browser for interactive zoom, search (`Ctrl+F`),
-            and click-to-zoom. Wide frames near the top = CPU hotspots.
 
   afp-spectest-afp34-prod:
     name: AFP spec test (cnid:dbd) AFP 3.4 - Alpine (Prod)

--- a/doc/developer/profiling.md
+++ b/doc/developer/profiling.md
@@ -1,4 +1,4 @@
-!Flamegraph Profiling
+Flamegraph Profiling
 ====================
 
 Netatalk provides a containerized profiling workflow that generates

--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -555,7 +555,7 @@ each share.
 dircache size = *number* **(G)**
 
 > Maximum entries in the directory cache. Stores directories and optionally files.
-> Minimum: 1024 (1K). Default: 65536 (64K). Maximum: 2097152 (2M).
+> Minimum: 1024 (1K). Default: 65536 (64K). Maximum: 1048576 (1M).
 > Higher values improve hit ratios but use more memory.
 
 dircache validation freq = *number* **(G)**

--- a/doc/manual/Configuration.md
+++ b/doc/manual/Configuration.md
@@ -732,7 +732,7 @@ The given value is rounded up to the nearest power of 2. Each entry takes about
 192 bytes (on 64-bit systems), and each **afpd** child process
 for every connected user has its own cache. Consider the number of users when configuring `dircache size`.
 
-Default: 65536, Maximum: 2097152.
+Default: 65536, Maximum: 1048576.
 
 dircache validation freq = *number* **(G)**
 

--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -675,12 +675,14 @@ void afp_over_dsi(AFPObj *obj)
             if (dsi->flags & DSI_AFP_LOGGED_OUT) {
                 LOG(log_note, logtype_afpd,
                     "afp_over_dsi: client logged out, terminating DSI session");
+                idle_worker_shutdown();
                 afp_dsi_close(obj);
                 exit(0);
             }
 
             if (dsi->flags & DSI_RECONINPROG) {
                 LOG(log_note, logtype_afpd, "afp_over_dsi: failed reconnect");
+                idle_worker_shutdown();
                 afp_dsi_close(obj);
                 exit(0);
             }
@@ -745,6 +747,7 @@ void afp_over_dsi(AFPObj *obj)
         switch (cmd) {
         case DSIFUNC_CLOSE:
             LOG(log_debug, logtype_afpd, "DSI: close session request");
+            idle_worker_shutdown();
             afp_dsi_close(obj);
             LOG(log_note, logtype_afpd, "done");
             exit(0);

--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -1887,7 +1887,7 @@ int dircache_init(int reqsize)
     }
 
     /* Initialize the main dircache with requested size
-     * Bounds: MIN_DIRCACHE_SIZE (8K) to MAX_DIRCACHE_SIZE (2M)
+     * Bounds: MIN_DIRCACHE_SIZE (1K) to MAX_DIRCACHE_SIZE (1M)
      * Default: DEFAULT_DIRCACHE_SIZE (64K) if reqsize <= 0 or out of bounds */
     if (reqsize > 0 && reqsize >= MIN_DIRCACHE_SIZE
             && reqsize <= MAX_DIRCACHE_SIZE) {

--- a/etc/afpd/dircache.h
+++ b/etc/afpd/dircache.h
@@ -25,7 +25,7 @@
 /* Dircache size bounds */
 #define MIN_DIRCACHE_SIZE 1024             /* 1K minimum (testing/constrained systems) */
 #define DEFAULT_DIRCACHE_SIZE 65536        /* 64K default (production) */
-#define MAX_DIRCACHE_SIZE 2097152          /* 2M maximum (high-memory servers) */
+#define MAX_DIRCACHE_SIZE 1048576          /* 1M maximum (high-memory servers) */
 #define DIRCACHE_FREE_QUANTUM 256
 
 /* Max dircache entries removed per hash chain per idle worker iteration.

--- a/etc/afpd/idle_worker.c
+++ b/etc/afpd/idle_worker.c
@@ -298,6 +298,8 @@ void idle_worker_shutdown(void)
     pthread_cond_signal(&sleep_cond);
     pthread_mutex_unlock(&sleep_mutex);
     pthread_join(worker_tid, NULL);
+    /* Log stats while worker_started is still 1 */
+    idle_worker_log_stats();
     worker_started = 0;
     /* Drain any entries added after the worker's last idle cycle */
     dir_free_invalid_q();

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -49,7 +49,7 @@ option(
     'with-debugging',
     type: 'boolean',
     value: false,
-    description: 'Enable SIGALARM timers and DSI tickles (eg for debugging with gdb/dbx/...)',
+    description: 'Disable SIGALARM timers and DSI tickles (useful for debugging with gdb/dbx/...)',
 )
 option(
     'with-docs-install-path',


### PR DESCRIPTION
- dircache: fix MAX_DIRCACHE_SIZE from 2M to 1M entries; ARC mode already doubles internally for ghosts (c cached + c ghosts = 2c total hash entries), and MAX_DIRCACHE_SIZE only used for user config parsing.
- afp.conf.5.md: update dircache size maximum to 1M
- Configuration.md: update dircache size maximum to 1048576
- afp_dsi: add idle_worker_shutdown() calls before all session close/exit paths to ensure clean worker thread termination
- idle_worker: log stats during shutdown while state is still valid
- containers.yml: clarify flamegraph github workflow with "(AFP_ASSERT active)" - this is the only workflow where AFP_ASSERT's will fire, so if it fails we should make it clear what the difference is
- COMPILATION.md: add optional FreeBSD `libsunacl` package for ACL support
- profiling.md: fix markdown heading syntax
- meson_options.txt: fix with-debugging description (Enable -> Disable) to clarify that when debugging is enabled with-debugging = true, both tickles and sigalarms are disabled.