### PR TITLE
dircache optimisation: replace strncmp with blength pre-check + memcmp in child scan

### DIFF
--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -1715,7 +1715,8 @@ int dircache_remove_children(const struct vol *vol, struct dir *dir)
 
             /* Check if entry's path starts with parent's path followed by '/' */
             if (parent_path && entry_path && parent_len > 0 &&
-                    strncmp(entry_path, parent_path, parent_len) == 0 &&
+                    (size_t)blength(entry->d_fullpath) > parent_len &&
+                    memcmp(entry_path, parent_path, parent_len) == 0 &&
                     entry_path[parent_len] == '/') {
                 /* Expand to_remove array */
                 if (remove_count >= remove_capacity) {
@@ -2780,8 +2781,9 @@ void dircache_flush_deferred_for_vol(uint16_t vid)
                                 const char *ep = cfrombstr(entry->d_fullpath);
 
                                 if (ep &&
-                                        strncmp(ep, deferred_queue[idx].parent_path,
-                                                deferred_queue[idx].parent_len) == 0 &&
+                                        (size_t)blength(entry->d_fullpath) > deferred_queue[idx].parent_len &&
+                                        memcmp(ep, deferred_queue[idx].parent_path,
+                                               deferred_queue[idx].parent_len) == 0 &&
                                         ep[deferred_queue[idx].parent_len] == '/') {
                                     dir_remove_and_free(vol, entry);
                                 }
@@ -2889,7 +2891,8 @@ int dircache_process_deferred_chain(void)
             const char *ep = cfrombstr(entry->d_fullpath);
 
             if (ep &&
-                    strncmp(ep, dc->parent_path, dc->parent_len) == 0 &&
+                    (size_t)blength(entry->d_fullpath) > dc->parent_len &&
+                    memcmp(ep, dc->parent_path, dc->parent_len) == 0 &&
                     ep[dc->parent_len] == '/') {
                 if (remove_count < DEFERRED_CHAIN_BATCH) {
                     to_remove[remove_count++] = entry;

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -983,17 +983,21 @@ int afp_openvol(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf,
         {
             struct adouble ad;
             ad_init(&ad, volume);
+
             if (!ad_metadata(".", ADFLAGS_DIR, &ad)) {
                 const char *fi = ad_entry(&ad, ADEID_FINDERI);
+
                 if (fi) {
                     uint16_t fflags;
                     memcpy(&fflags, fi + FINDERINFO_FRFLAGOFF, sizeof(fflags));
+
                     if (fflags & htons(FINDERINFO_NAMELOCKED)) {
                         LOG(log_note, logtype_afpd,
                             "afp_openvol: volume root of \"%s\" has name locked FinderFlag set",
                             volume->v_localname);
                     }
                 }
+
                 ad_close(&ad, ADFLAGS_HF);
             }
         }


### PR DESCRIPTION
Replace strncmp() with (size_t)blength() pre-check and memcmp() in three descendant-path matching sites: dircache_remove_children(), dircache_flush_deferred_for_vol(), and dircache_process_deferred_chain().

The blength() pre-check is an O(1) integer comparison that rejects entries with paths shorter than or equal to the parent allowing a quick skip by avoiding string comparison entirely.
memcmp() enables SIMD-optimized comparison without per-byte NUL checking overhead which is much faster than the string compare.

I have just compared a before and after flame graph;

## Key Results

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| `strncmp` CPU share | **4.24%** (73M samples) | **0.05%** (1M) | **99% eliminated** |
| Child-removal total CPU | **5.63%** (97M) | **3.76%** (72M) | **33% reduction** |

### Baseline

| Symbol | Samples | % of Total |
|--------|---------|------------|
| `strncmp` (in `dircache_remove_children`) | 56,056,056 | 3.25% |
| `strncmp` (in `dircache_process_deferred_chain`) | 16,016,016 | 0.93% |
| `strncmp@plt` | 1,001,001 | 0.06% |
| **Total `strncmp`** | **73,073,073** | **4.24%** |

### Optimized (this)

| Symbol | Samples | % of Total |
|--------|---------|------------|
| `strncmp` (unrelated path) | 1,001,001 | 0.05% |
| `memcmp` | 1,001,001 | 0.05% |
| **Total comparison** | **2,002,002** | **0.10%** |

The `blength()` O(1) pre-check filters out most cache entries before any byte comparison occurs, reducing comparison overhead from 73M to 2M samples — a **97% reduction**.

This change should significantly harden Netatalk against refresh attacks and reduce CPU - this cleaning was already deferred to idle times, while not handling AFP user commands, but we still want it to be faster.

The deferred scan's 3.76% is dominated by irreducible O(N) hash traversal (`hash_chain_head`, loop overhead), not string comparison.

Confirmed on ARM64 as well;

![flamegraph_arm64_memcmp_spectest](https://github.com/user-attachments/assets/4b6b7841-2851-4b95-9e0d-1cb6e381b395)
