### PR TITLE
nad: overhaul file operations that cross AFP volume boundary

### DIFF
--- a/bin/nad/nad.h
+++ b/bin/nad/nad.h
@@ -51,6 +51,7 @@ enum logtype {STD, DBG};
 typedef struct {
     struct vol     *vol;
     char           db_stamp[ADEDLEN_PRIVSYN];
+    bool           owns_cdb;  /*!< true if this wrapper opened v_cdb */
 } afpvol_t;
 
 extern int log_verbose;             /*!< Logging flag */
@@ -69,6 +70,7 @@ extern int nad_rmdir(int argc, char **argv, AFPObj *obj);
 
 /* ad_util.c */
 extern int openvol(AFPObj *obj, const char *path, afpvol_t *vol);
+extern int openvol_optional(AFPObj *obj, const char *path, afpvol_t *vol);
 extern void closevol(afpvol_t *vol);
 extern cnid_t cnid_for_paths_parent(const afpvol_t *vol, const char *path,
                                     cnid_t *did);

--- a/bin/nad/nad_cp.c
+++ b/bin/nad/nad_cp.c
@@ -309,13 +309,20 @@ int nad_cp(int argc, char *argv[], AFPObj *obj)
 #endif
 
     /* Load .volinfo file for destination*/
-    if (openvol(obj, to.p_path, &dvolume) != 0) {
+    if (openvol_optional(obj, to.p_path, &dvolume) != 0) {
         return 1;
     }
 
     for (int i = 0; argv[i] != NULL; i++) {
         /* Load .volinfo file for source */
-        if (openvol(obj, argv[i], &svolume) != 0) {
+        if (openvol_optional(obj, argv[i], &svolume) != 0) {
+            badcp = rval = 1;
+            continue;
+        }
+
+        if (!svolume.vol->v_path && !dvolume.vol->v_path) {
+            SLOG("Neither source nor destination is an AFP volume");
+            closevol(&svolume);
             badcp = rval = 1;
             continue;
         }
@@ -323,18 +330,15 @@ int nad_cp(int argc, char *argv[], AFPObj *obj)
         if (nftw(argv[i], copy, upfunc, 20, ftw_options) == -1) {
             if (alarmed) {
                 SLOG("...break");
-            } else {
+            } else if (!badcp) {
                 SLOG("Error: %s: %s", argv[i], strerror(errno));
             }
-
-            closevol(&svolume);
-            closevol(&dvolume);
         }
 
         closevol(&svolume);
-        closevol(&dvolume);
     }
 
+    closevol(&dvolume);
     return rval;
 }
 
@@ -367,7 +371,8 @@ static int copy(const char *path,
         dir++;
     }
 
-    if (!dvolume.vol->vfs->vfs_validupath(dvolume.vol, dir)) {
+    if (dvolume.vol->v_path
+            && !dvolume.vol->vfs->vfs_validupath(dvolume.vol, dir)) {
         return FTW_SKIP_SUBTREE;
     }
 
@@ -716,7 +721,11 @@ static int ftw_copy_file(const struct FTW *entp _U_,
             /* remove existing destination file name,
              * create a new file  */
             (void)unlink(to.p_path);
-            (void)dvolume.vol->vfs->vfs_deletefile(dvolume.vol, -1, to.p_path);
+
+            if (dvolume.vol->v_path) {
+                (void)dvolume.vol->vfs->vfs_deletefile(dvolume.vol, -1, to.p_path);
+            }
+
             to_fd = open(to.p_path, O_WRONLY | O_TRUNC | O_CREAT,
                          sp->st_mode & ~(S_ISUID | S_ISGID));
         } else {

--- a/bin/nad/nad_mv.c
+++ b/bin/nad/nad_mv.c
@@ -25,7 +25,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/wait.h>
+#include <dirent.h>
 #include <unistd.h>
 
 #include <bstrlib.h>
@@ -46,6 +46,7 @@
 
 static int fflg, iflg, nflg, vflg;
 
+static AFPObj *afp_obj;
 static afpvol_t svolume, dvolume;
 static cnid_t did, pdid;
 static int copy(const char *, const char *);
@@ -124,8 +125,9 @@ int nad_mv(int argc, char *argv[], AFPObj *obj)
 
     set_signal();
     cnid_init();
+    afp_obj = obj;
 
-    if (openvol(obj, argv[argc - 1], &dvolume) != 0) {
+    if (openvol_optional(obj, argv[argc - 1], &dvolume) != 0) {
         return 1;
     }
 
@@ -138,14 +140,21 @@ int nad_mv(int argc, char *argv[], AFPObj *obj)
             usage_mv();
         }
 
-        if (openvol(obj, argv[0], &svolume) != 0) {
+        if (openvol_optional(obj, argv[0], &svolume) != 0) {
             return 1;
         }
 
-        do_move(argv[0], argv[1]);
+        if (!svolume.vol->v_path && !dvolume.vol->v_path) {
+            SLOG("Neither source nor destination is an AFP volume");
+            closevol(&svolume);
+            closevol(&dvolume);
+            return 1;
+        }
+
+        rval = do_move(argv[0], argv[1]);
         closevol(&svolume);
         closevol(&dvolume);
-        return 1;
+        return rval;
     }
 
     /* It's a directory, move each file into it. */
@@ -171,7 +180,7 @@ int nad_mv(int argc, char *argv[], AFPObj *obj)
 
     rval = 0;
 
-    for (int i = 0; i < argc; i++) {
+    for (int i = 0; i < argc - 1; i++) {
         /*
          * Find the last component of the source pathname using basename
          */
@@ -187,30 +196,32 @@ int nad_mv(int argc, char *argv[], AFPObj *obj)
         len = strnlen(base_name, PATH_MAX);
 
         if ((baselen + len) >= PATH_MAX) {
-            SLOG("%s: base name too long", base_name);
+            SLOG("%s: destination pathname too long", argv[i]);
             free(src_copy);
-            return 1;
+            rval = 1;
+            continue;
         }
 
-        if ((baselen + len) >= PATH_MAX) {
-            SLOG("%s: destination pathname too long", *argv);
+        /* Copy safely with bounds checking */
+        if (strlcpy(endp, base_name, PATH_MAX - baselen) >= (PATH_MAX - baselen)) {
+            SLOG("%s: destination pathname too long", argv[i]);
+            free(src_copy);
+            rval = 1;
+            continue;
+        }
+
+        if (openvol_optional(obj, argv[i], &svolume) != 0) {
+            rval = 1;
+        } else if (!svolume.vol->v_path && !dvolume.vol->v_path) {
+            SLOG("Neither source nor destination is an AFP volume");
+            closevol(&svolume);
             rval = 1;
         } else {
-            /* Copy safely with bounds checking */
-            if (strlcpy(endp, base_name, PATH_MAX - baselen) >= (PATH_MAX - baselen)) {
-                SLOG("%s: destination pathname too long", *argv);
+            if (do_move(argv[i], path)) {
                 rval = 1;
-            } else {
-                if (openvol(obj, *argv, &svolume) != 0) {
-                    rval = 1;
-                } else {
-                    if (do_move(*argv, path)) {
-                        rval = 1;
-                    }
-
-                    closevol(&svolume);
-                }
             }
+
+            closevol(&svolume);
         }
 
         free(src_copy);
@@ -322,6 +333,10 @@ static int do_move(const char *from, const char *to)
                     SLOG("cannot resolve %s: %s: %s", from, path, strerror(errno));
                     return 1;
                 }
+
+                /* Cross-device: fall through to copy-and-remove */
+                mustcopy = 1;
+                goto docopy;
             } else { /* != EXDEV */
                 SLOG("rename %s to %s: %s", from, to, strerror(errno));
                 return 1;
@@ -391,6 +406,8 @@ static int do_move(const char *from, const char *to)
         return 0;
     }
 
+docopy:
+
     if (mustcopy) {
         return copy(from, to);
     }
@@ -399,10 +416,48 @@ static int do_move(const char *from, const char *to)
     return -1;
 }
 
+static int remove_path(const char *path)
+{
+    struct stat sb;
+
+    if (lstat(path, &sb) != 0) {
+        return -1;
+    }
+
+    if (S_ISDIR(sb.st_mode)) {
+        DIR *d = opendir(path);
+
+        if (d == NULL) {
+            return -1;
+        }
+
+        struct dirent *ent;
+
+        char child[MAXPATHLEN];
+
+        while ((ent = readdir(d)) != NULL) {
+            if (DIR_DOT_OR_DOTDOT(ent->d_name)) {
+                continue;
+            }
+
+            snprintf(child, sizeof(child), "%s/%s", path, ent->d_name);
+
+            if (remove_path(child) != 0) {
+                closedir(d);
+                return -1;
+            }
+        }
+
+        closedir(d);
+        return rmdir(path);
+    }
+
+    return unlink(path);
+}
+
 static int copy(const char *from, const char *to)
 {
     struct stat sb;
-    int pid, status;
 
     if (lstat(to, &sb) == 0) {
         /* Destination path exists. */
@@ -423,63 +478,32 @@ static int copy(const char *from, const char *to)
     }
 
     /* Copy source to destination. */
-    if (!(pid = fork())) {
-        execl(_PATH_NAD, "nad", "cp", vflg ? "-Rpv" : "-Rp", from, to, (char *)NULL);
-        _exit(1);
-    }
+    {
+        const char *cp_argv[] = {
+            "cp", vflg ? "-Rpv" : "-Rp", from, to, NULL
+        };
+        optind = 1;
 
-    while ((waitpid(pid, &status, 0)) == -1) {
-        if (errno == EINTR) {
-            continue;
+        if (nad_cp(4, (char **)cp_argv, afp_obj) != 0) {
+            SLOG("cp -R %s %s: failed", from, to);
+            return 1;
         }
-
-        SLOG("%s cp -R %s %s: waitpid: %s", _PATH_NAD, from, to, strerror(errno));
-        return 1;
-    }
-
-    if (!WIFEXITED(status)) {
-        SLOG("%s cp -R %s %s: did not terminate normally", _PATH_NAD, from, to);
-        return 1;
-    }
-
-    switch (WEXITSTATUS(status)) {
-    case 0:
-        break;
-
-    default:
-        SLOG("%s cp -R %s %s: terminated with %d (non-zero) status",
-             _PATH_NAD, from, to, WEXITSTATUS(status));
-        return 1;
     }
 
     /* Delete the source. */
-    if (!(pid = fork())) {
-        execl(_PATH_NAD, "nad", "rm", "-R", from, (char *)NULL);
-        _exit(1);
-    }
+    if (svolume.vol->v_path) {
+        const char *rm_argv[] = { "rm", "-R", from, NULL };
+        optind = 1;
 
-    while ((waitpid(pid, &status, 0)) == -1) {
-        if (errno == EINTR) {
-            continue;
+        if (nad_rm(3, (char **)rm_argv, afp_obj) != 0) {
+            SLOG("rm -R %s: failed", from);
+            return 1;
         }
-
-        SLOG("%s rm -R %s: waitpid: %s", _PATH_NAD, from, strerror(errno));
-        return 1;
-    }
-
-    if (!WIFEXITED(status)) {
-        SLOG("%s rm -R %s: did not terminate normally", _PATH_NAD, from);
-        return 1;
-    }
-
-    switch (WEXITSTATUS(status)) {
-    case 0:
-        break;
-
-    default:
-        SLOG("%s rm -R %s: terminated with %d (non-zero) status",
-             _PATH_NAD, from, WEXITSTATUS(status));
-        return 1;
+    } else {
+        if (remove_path(from) != 0) {
+            SLOG("remove %s: %s", from, strerror(errno));
+            return 1;
+        }
     }
 
     return 0;

--- a/bin/nad/nad_util.c
+++ b/bin/nad/nad_util.c
@@ -130,23 +130,35 @@ void _log(enum logtype lt, char *fmt, ...)
     }
 }
 
+/*! Static stub volume for paths outside any AFP volume */
+static struct vol null_vol;
+
 /*!
- * @brief Load volinfo and initialize struct vol
+ * @brief Open an AFP volume, or return a stub for non-AFP paths
+ *
+ * If the path is inside an AFP volume, the volume's CNID database is
+ * opened.  If the path is outside any AFP volume, a stub volume with
+ * v_path=NULL and v_cdb=NULL is returned so that callers can use
+ * v_path as a guard for AFP-specific operations.
+ *
+ * This is intended for commands like mv and cp that may operate across
+ * AFP and non-AFP paths.
  *
  * @param[in] obj        AFPObj of the current connection
  * @param[in] path       path to evaluate
  * @param[in,out] vol    structure to initialize
  *
- * @returns 0 on success, exits on error
+ * @returns 0 on success, -1 on error
  */
-int openvol(AFPObj *obj, const char *path, afpvol_t *vol)
+int openvol_optional(AFPObj *obj, const char *path, afpvol_t *vol)
 {
     int flags = 0;
     memset(vol, 0, sizeof(afpvol_t));
 
     if ((vol->vol = getvolbypath(obj, path)) == NULL) {
-        SLOG("Error: \"%s\" is not inside a Netatalk volume", path);
-        return -1;
+        memset(&null_vol, 0, sizeof(struct vol));
+        vol->vol = &null_vol;
+        return 0;
     }
 
     /* Sanity checks to ensure we can touch this volume */
@@ -160,15 +172,22 @@ int openvol(AFPObj *obj, const char *path, afpvol_t *vol)
         ERROR("Unsupported Extended Attributes option: %u", vol->vol->v_vfs_ea);
     }
 
-    if (vol->vol->v_flags & AFPVOL_NODEV) {
-        flags |= CNID_FLAG_NODEV;
-    }
+    if (vol->vol->v_cdb) {
+        /* Another afpvol_t already opened this volume's CNID db */
+        vol->owns_cdb = false;
+    } else {
+        if (vol->vol->v_flags & AFPVOL_NODEV) {
+            flags |= CNID_FLAG_NODEV;
+        }
 
-    if ((vol->vol->v_cdb = cnid_open(vol->vol,
-                                     vol->vol->v_cnidscheme,
-                                     flags)) == NULL) {
-        ERROR("Can't initialize CNID database connection for %s",
-              vol->vol->v_path);
+        if ((vol->vol->v_cdb = cnid_open(vol->vol,
+                                         vol->vol->v_cnidscheme,
+                                         flags)) == NULL) {
+            ERROR("Can't initialize CNID database connection for %s",
+                  vol->vol->v_path);
+        }
+
+        vol->owns_cdb = true;
     }
 
     cnid_getstamp(vol->vol->v_cdb,
@@ -177,9 +196,36 @@ int openvol(AFPObj *obj, const char *path, afpvol_t *vol)
     return 0;
 }
 
+/*!
+ * @brief Load volinfo and initialize struct vol
+ *
+ * The path must be inside an AFP volume.  Returns -1 if it is not.
+ *
+ * @param[in] obj        AFPObj of the current connection
+ * @param[in] path       path to evaluate
+ * @param[in,out] vol    structure to initialize
+ *
+ * @returns 0 on success, -1 on error
+ */
+int openvol(AFPObj *obj, const char *path, afpvol_t *vol)
+{
+    if (openvol_optional(obj, path, vol) != 0) {
+        return -1;
+    }
+
+    if (!vol->vol->v_path) {
+        SLOG("\"%s\" is not inside an AFP volume", path);
+        memset(vol, 0, sizeof(afpvol_t));
+        return -1;
+    }
+
+    return 0;
+}
+
 void closevol(afpvol_t *vol)
 {
-    if (vol->vol && vol->vol->v_cdb) {
+    if (vol->vol && vol->vol != &null_vol
+            && vol->vol->v_cdb && vol->owns_cdb) {
         cnid_close(vol->vol->v_cdb);
         vol->vol->v_cdb = NULL;
     }


### PR DESCRIPTION
Fix mv and cp to fully support operations between AFP volumes and regular filesystem paths, and between two different AFP volumes.

Introduce openvol_optional() for mv and cp that returns a stub volume (v_path=NULL) for non-AFP paths, while openvol() remains strict for all other commands (ls, rm, set, find, mkdir, rmdir). Validate that at least one path is an AFP volume before proceeding with mv or cp.

Bug fixes:
- nad_mv always returned 1 (failure) for single-file moves regardless of whether the move succeeded
- nad_mv EXDEV handling fell through to CNID/adouble update code instead of the copy-and-remove path, corrupting metadata
- nad_mv multi-file loop iterated over destination as a source and used argv[0] instead of argv[i], causing double-move attempts
- nad_mv copy-and-remove used nad rm for non-AFP source paths which would fail the strict openvol() check; use recursive unlink instead
- nad_cp double-closed both volumes on nftw error and closed dvolume inside the per-source loop
- nad_cp dereferenced NULL VFS function pointers (vfs_validupath, vfs_deletefile) for non-AFP destinations
- nad_cp printed spurious "Undefined error: 0" when nftw was aborted by the copy callback (e.g. directory without -R flag)