### PR TITLE
IPC-Hints: Batch cache hint relaying with flush thread

### DIFF
--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -2496,63 +2496,14 @@ void dircache_reset_validation_counter(void)
 
 /***********************************************************************************
  * Cross-process dircache hint receiver (parent→child via dedicated hint pipe)
+ *
+ * Bulk framed read: single read() drains up to MAX_HINTS_PER_CYCLE hints,
+ * then parses in 22-byte (IPC_HEADERLEN + payload) increments.
  ***********************************************************************************/
 
-/*!
- * @brief Read one cache hint from the dedicated hint pipe (non-blocking)
- *
- * Reads from obj->hint_fd — the dedicated pipe for parent→child hints.
- * POSIX pipe atomicity: write() of ≤ PIPE_BUF bytes is atomic, so each
- * read() returns either a complete message or nothing.
- *
- * @param[in]  obj   AFPObj with hint_fd (pipe read end)
- * @param[out] hint  Populated on success
- * @returns    1 if hint read, 0 if no data available, -1 on error
- */
-static int ipc_recv_cache_hint(AFPObj *obj, struct ipc_cache_hint_payload *hint)
-{
-    char buf[IPC_MAXMSGSIZE];
-    ssize_t ret;
-
-    if (obj->hint_fd < 0) {
-        return -1;
-    }
-
-    /* Read complete hint message from pipe — atomic delivery guaranteed */
-    ret = read(obj->hint_fd, buf,
-               IPC_HEADERLEN + sizeof(struct ipc_cache_hint_payload));
-
-    if (ret == 0) {
-        /* EOF — parent process crashed (pipe write end closed).
-         * Close and disable to prevent POLLHUP spin loop. */
-        LOG(log_error, logtype_afpd,
-            "ipc_recv_cache_hint: hint pipe closed, parent lost, service restart required");
-        close(obj->hint_fd);
-        obj->hint_fd = -1;
-        return -1;
-    }
-
-    if (ret < 0) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK) {
-            return 0;    /* No data available */
-        }
-
-        return -1;     /* Unexpected error */
-    }
-
-    if (ret != IPC_HEADERLEN + (ssize_t)sizeof(struct ipc_cache_hint_payload)) {
-        /* Should never happen for atomic pipe writes, but defensive */
-        LOG(log_warning, logtype_afpd,
-            "ipc_recv_cache_hint: unexpected read size %zd (expected %zu)",
-            ret, IPC_HEADERLEN + sizeof(struct ipc_cache_hint_payload));
-        cache_hint_stat.hints_no_match++;
-        return 0;
-    }
-
-    /* Extract payload from after the IPC header */
-    memcpy(hint, buf + IPC_HEADERLEN, sizeof(*hint));
-    return 1;
-}
+#define MAX_HINTS_PER_CYCLE 32
+#define HINT_READ_BUF_SIZE  (MAX_HINTS_PER_CYCLE * \
+    (IPC_HEADERLEN + sizeof(struct ipc_cache_hint_payload)))
 
 /*!
  * @brief Process cross-process dircache invalidation hints
@@ -2569,13 +2520,48 @@ static int ipc_recv_cache_hint(AFPObj *obj, struct ipc_cache_hint_payload *hint)
  */
 void process_cache_hints(AFPObj *obj)
 {
-    struct ipc_cache_hint_payload hint = {0};
+    static char buf[HINT_READ_BUF_SIZE];
+    static size_t carry = 0;  /* bytes carried over from previous read */
+    const size_t msg_size = IPC_HEADERLEN + sizeof(struct ipc_cache_hint_payload);
     struct stat st;
     int hints_processed = 0;
-#define MAX_HINTS_PER_CYCLE 32
 
-    while (hints_processed < MAX_HINTS_PER_CYCLE &&
-            ipc_recv_cache_hint(obj, &hint) > 0) {
+    if (obj->hint_fd < 0) {
+        return;
+    }
+
+    /* Read into buffer after any carried-over partial message bytes */
+    ssize_t n = read(obj->hint_fd, buf + carry, sizeof(buf) - carry);
+
+    if (n == 0) {
+        /* EOF — parent process crashed (pipe write end closed) */
+        LOG(log_error, logtype_afpd,
+            "process_cache_hints: hint pipe closed, parent lost");
+        close(obj->hint_fd);
+        obj->hint_fd = -1;
+        carry = 0;
+        return;
+    }
+
+    if (n < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            return;
+        }
+
+        LOG(log_error, logtype_afpd,
+            "process_cache_hints: read error: %s", strerror(errno));
+        carry = 0;
+        return;
+    }
+
+    size_t total = carry + (size_t)n;
+    size_t offset = 0;
+
+    while (offset + msg_size <= total
+            && hints_processed < MAX_HINTS_PER_CYCLE) {
+        struct ipc_cache_hint_payload hint;
+        memcpy(&hint, buf + offset + IPC_HEADERLEN, sizeof(hint));
+        offset += msg_size;
         cache_hint_stat.hints_received++;
         /* Resolve volume from vid (already network byte order).
          * Cannot be const — passed to dir_remove/dir_modify which take non-const vol. */
@@ -2599,15 +2585,12 @@ void process_cache_hints(AFPObj *obj)
 
         if (!hn) {
             cache_hint_stat.hints_no_match++;
-            continue;  /* Not in our cache — nothing to invalidate */
+            continue;
         }
 
         struct dir *entry = hnode_get(hn);
 
         cache_hint_stat.hints_acted_on++;
-        /* Save fields for logging BEFORE dispatch — dir_remove() may free entry */
-        cnid_t log_cnid = hint.cnid;
-        int log_is_ghost = (entry->d_flags & DIRF_ARC_GHOST) ? 1 : 0;
 
         switch (hint.event) {
         case CACHE_HINT_REFRESH:
@@ -2630,7 +2613,6 @@ void process_cache_hints(AFPObj *obj)
             break;
 
         case CACHE_HINT_DELETE:
-            /* Direct removal — no ostat needed for deleted entries */
             dir_remove(vol, entry, 0);
             break;
 
@@ -2638,7 +2620,7 @@ void process_cache_hints(AFPObj *obj)
 
             /* Remove all children first, then handle parent entry */
             if (!(entry->d_flags & DIRF_ISFILE)) {
-                dircache_remove_children_defer(vol, entry);  /* O(1) enqueue */
+                dircache_remove_children_defer(vol, entry);
             }
 
             /* Then remove or refresh the parent itself */
@@ -2661,19 +2643,20 @@ void process_cache_hints(AFPObj *obj)
             break;
         }
 
-        LOG(log_debug, logtype_afpd,
-            "process_cache_hints: %s did:%u%s from sibling",
-            hint.event == CACHE_HINT_REFRESH ? "refresh" :
-            hint.event == CACHE_HINT_DELETE ? "delete" :
-            hint.event == CACHE_HINT_DELETE_CHILDREN ? "delete-children" : "unknown",
-            ntohl(log_cnid),
-            log_is_ghost ? " (ghost)" : "");
         hints_processed++;
+    }
+
+    /* Carry over any trailing partial message bytes for the next read */
+    carry = total - offset;
+
+    if (carry > 0) {
+        memmove(buf, buf + offset, carry);
     }
 
     if (hints_processed > 0) {
         LOG(log_debug, logtype_afpd,
-            "process_cache_hints: processed %d hints this cycle", hints_processed);
+            "process_cache_hints: processed %d hints this cycle",
+            hints_processed);
     }
 }
 

--- a/etc/afpd/main.c
+++ b/etc/afpd/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1990,1993 Regents of The University of Michigan.
+ * Copyright (c) 2025-2026 Andy Lemin (andylemin)
  * All Rights Reserved.  See COPYRIGHT.
  */
 
@@ -401,6 +402,13 @@ int main(int ac, char **av)
     pthread_sigmask(SIG_UNBLOCK, &sigs, NULL);
     /* Initialize */
     cnid_init();
+
+    /* Start hint flush thread — Startup failure is fatal. */
+    if (hint_flush_start(server_children) != 0) {
+        LOG(log_error, logtype_afpd,
+            "main: FATAL: hint flush thread failed to start");
+        afp_exit(EXITERR_SYS);
+    }
 
     /* watch atp, dsi sockets and ipc parent/child file descriptor. */
     if (!(init_listening_sockets(&dsi_obj, &asp_obj))) {

--- a/include/atalk/server_ipc.h
+++ b/include/atalk/server_ipc.h
@@ -45,4 +45,7 @@ extern int ipc_send_cache_hint(const AFPObj *obj, uint16_t vid, cnid_t cnid,
                                uint8_t event);
 extern unsigned long long ipc_get_hints_sent(void);
 
+extern int hint_flush_start(server_child_t *children);
+extern void hint_flush_stop(void);
+
 #endif /* ATALK_SERVER_IPC_H */

--- a/libatalk/util/server_child.c
+++ b/libatalk/util/server_child.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1997 Adrian Sun (asun@zoology.washington.edu)
- * Copyright (c) 2013 Frank Lahm <franklahm@gmail.com
+ * Copyright (c) 2013 Frank Lahm <franklahm@gmail.com>
+ * Copyright (c) 2025-2026 Andy Lemin (andylemin)
  * All rights reserved. See COPYRIGHT.
  */
 
@@ -116,6 +117,14 @@ afp_child_t *server_child_add(server_child_t *children, pid_t pid, int ipc_fd,
 {
     afp_child_t *child = NULL;
     pthread_mutex_lock(&children->servch_lock);
+
+    /* Enforce configured session limit */
+    if (children->servch_count >= children->servch_nsessions) {
+        LOG(log_error, logtype_default,
+            "server_child_add: at max users capacity (%d/%d), rejecting pid [%d]",
+            children->servch_count, children->servch_nsessions, pid);
+        goto exit;
+    }
 
     /* it's possible that the child could have already died before the
      * pthread_sigmask. we need to check for this. */

--- a/libatalk/util/server_ipc.c
+++ b/libatalk/util/server_ipc.c
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025-2026 Andy Lemin (andylemin)
  * All rights reserved. See COPYRIGHT.
  */
 
@@ -15,6 +16,7 @@
 #include <limits.h>
 #include <pthread.h>
 #include <signal.h>
+#include <stdatomic.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -59,6 +61,309 @@ static char *ipc_cmd_str[] = { "IPC_DISCOLDSESSION",
                                "IPC_LOGINDONE",
                                "IPC_CACHE_HINT"
                              };
+
+/***********************************************************************************
+ * Cache hint batching infrastructure
+ * Main thread appends hints to buffer under lock, flush thread copies+clears under
+ * same lock, then writes to sibling afpd processes from copy without any lock held
+ ***********************************************************************************/
+
+/* Max hints per buffer. Must satisfy HINT_BATCH_SIZE >= arrival_rate × write_phase_time.
+ * Worst case: 50 siblings × 1000 hints/sec rate limit = 50K hints/sec. write phase for 50
+ * siblings on macOS (PIPE_BUF=512 * 6 writes/sibling × 5μs/write) = 1.5ms; hints during
+ * write = 50000 × 0.0015 = 75. Buffer = 128 provides 1.7× headroom for worst case. */
+#define HINT_BATCH_SIZE         128
+#define HINT_FLUSH_INTERVAL_MS   50  /* Flush thread wakeup interval */
+_Static_assert(HINT_FLUSH_INTERVAL_MS < 1000,
+               "Use a while loop for nanosecond normalization if HINT_FLUSH_INTERVAL_MS >= 1s");
+#define HINT_RATE_LIMIT        1000  /* Max hints/second per child (attack guard) */
+
+/* Per-child rate tracking — fixed array indexed by PID % RATE_TRACK_SIZE.
+ * Hash collisions are benign — worst case a child gets a slightly wrong
+ * rate count from sharing a slot with another child. */
+#define RATE_TRACK_SIZE 256
+
+/* Intentionally NOT packed — natural alignment gives better performance
+ * sizeof typically 16 bytes on LP64 due to padding after vid (2→4) and event (1→4). */
+struct hint_entry {
+    uint16_t vid;
+    cnid_t   cnid;
+    uint8_t  event;      /* Hint type */
+    pid_t    source_pid; /* Exclude source from relay */
+};
+
+/* Single accumulation buffer — protected by flush_mutex */
+static struct {
+    struct hint_entry entries[HINT_BATCH_SIZE];
+    int count;
+} hint_buf;
+
+/* Flush thread synchronization */
+static pthread_t flush_tid;
+static pthread_mutex_t flush_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t flush_cond = PTHREAD_COND_INITIALIZER;
+static pthread_cond_t flush_drained = PTHREAD_COND_INITIALIZER;
+static _Atomic int flush_shutdown = 0;
+
+static struct {
+    pid_t  pid;
+    time_t window_start;
+    int    count_in_window;
+} rate_track[RATE_TRACK_SIZE];
+
+/* Parent-side statistics — logged periodically from flush thread */
+static _Atomic unsigned long long hints_batched = 0;
+static _Atomic unsigned long long hints_rate_dropped = 0;
+static _Atomic unsigned long long flush_count = 0;
+
+/* Returns current hint count for this child in the current 1-second window.
+ * Resets window if second has changed. Called from main thread only. */
+static int check_and_increment_rate(pid_t child_pid)
+{
+    int idx = child_pid % RATE_TRACK_SIZE;
+    time_t now = time(NULL);
+
+    if (rate_track[idx].pid != child_pid || rate_track[idx].window_start != now) {
+        rate_track[idx].pid = child_pid;
+        rate_track[idx].window_start = now;
+        rate_track[idx].count_in_window = 1;
+        return 1;
+    }
+
+    return ++rate_track[idx].count_in_window;
+}
+
+/*!
+ * @brief Snapshot all sibling hint pipe fds and PIDs under lock.
+ *
+ * Allocates arrays for fds and pids, iterates all CHILD_HASHSIZE hash
+ * buckets collecting afpch_hint_fd and afpch_pid for each child with
+ * a valid hint fd. Caller must free both arrays.
+ *
+ * @param[in]  children    Server child table
+ * @param[out] out_fds     Allocated array of hint pipe fds
+ * @param[out] out_pids    Allocated array of corresponding PIDs
+ * @param[out] out_count   Number of entries in both arrays
+ */
+static void snapshot_sibling_fds(server_child_t *children,
+                                 int **out_fds, pid_t **out_pids,
+                                 int *out_count)
+{
+    *out_fds = NULL;
+    *out_pids = NULL;
+    *out_count = 0;
+    int *fds = malloc(children->servch_nsessions * sizeof(int));
+    pid_t *pids = malloc(children->servch_nsessions * sizeof(pid_t));
+
+    if (!fds || !pids) {
+        free(fds);
+        free(pids);
+        return;
+    }
+
+    int count = 0;
+    pthread_mutex_lock(&children->servch_lock);
+
+    for (int i = 0; i < CHILD_HASHSIZE; i++) {
+        for (afp_child_t *child = children->servch_table[i]; child;
+                child = child->afpch_next) {
+            if (child->afpch_hint_fd >= 0) {
+                /* dup() under lock — our copy survives even if the child
+                 * exits and the parent closes the original fd before we
+                 * finish writing. Without dup(), fd reuse could direct
+                 * writes to an unrelated descriptor. */
+                int dfd = dup(child->afpch_hint_fd);
+
+                if (dfd >= 0) {
+                    fds[count] = dfd;
+                    pids[count] = child->afpch_pid;
+                    count++;
+                }
+            }
+        }
+    }
+
+    pthread_mutex_unlock(&children->servch_lock);
+    *out_fds = fds;
+    *out_pids = pids;
+    *out_count = count;
+}
+
+/*!
+ * @brief Serialize a hint_entry to IPC wire format.
+ *
+ * Writes IPC_HEADERLEN + sizeof(ipc_cache_hint_payload) = 22 bytes
+ * to the output buffer. The header PID/UID fields are set to the
+ * source child's PID (for receiver logging) with UID 0.
+ *
+ * @param[out] buf   Output buffer (must have ≥ 22 bytes available)
+ * @param[in]  e     Hint entry to serialize
+ * @returns    Number of bytes written (always 22)
+ */
+static int serialize_hint(char *buf, const struct hint_entry *e)
+{
+    char *p = buf;
+    uint16_t cmd = IPC_CACHE_HINT;
+    uint32_t len = sizeof(struct ipc_cache_hint_payload);
+    uid_t uid = 0;
+    memset(p, 0, IPC_HEADERLEN + sizeof(struct ipc_cache_hint_payload));
+    memcpy(p, &cmd, sizeof(cmd));
+    p += sizeof(cmd);
+    memcpy(p, &e->source_pid, sizeof(pid_t));
+    p += sizeof(pid_t);
+    memcpy(p, &uid, sizeof(uid_t));
+    p += sizeof(uid_t);
+    memcpy(p, &len, sizeof(uint32_t));
+    p += sizeof(uint32_t);
+    struct ipc_cache_hint_payload payload = {
+        .event = e->event,
+        .reserved = 0,
+        .vid = e->vid,
+        .cnid = e->cnid,
+    };
+    memcpy(p, &payload, sizeof(payload));
+    return IPC_HEADERLEN + sizeof(struct ipc_cache_hint_payload);
+}
+
+static void *hint_flush_thread(void *arg)
+{
+    server_child_t *children = (server_child_t *)arg;
+    struct hint_entry local_buf[HINT_BATCH_SIZE];
+    /* Block all signals — flush thread must not receive process signals */
+    sigset_t sigs;
+    sigfillset(&sigs);
+    pthread_sigmask(SIG_BLOCK, &sigs, NULL);
+
+    while (!atomic_load(&flush_shutdown)) {
+        /* Sleep for 50ms or until signaled */
+        struct timespec ts;
+        pthread_mutex_lock(&flush_mutex);
+
+        if (hint_buf.count == 0 && !atomic_load(&flush_shutdown)) {
+            clock_gettime(CLOCK_REALTIME, &ts);
+            ts.tv_nsec += HINT_FLUSH_INTERVAL_MS * 1000000L;
+
+            if (ts.tv_nsec >= 1000000000L) {
+                ts.tv_sec++;
+                ts.tv_nsec -= 1000000000L;
+            }
+
+            pthread_cond_timedwait(&flush_cond, &flush_mutex, &ts);
+        }
+
+        /* Copy buffer contents to local array and clear.
+         * Signal flush_drained to wake any blocked producer. */
+        int local_count = hint_buf.count;
+
+        if (local_count > 0) {
+            memcpy(local_buf, hint_buf.entries,
+                   local_count * sizeof(struct hint_entry));
+            hint_buf.count = 0;
+            pthread_cond_signal(&flush_drained);
+        }
+
+        pthread_mutex_unlock(&flush_mutex);
+
+        if (local_count == 0) {
+            continue;
+        }
+
+        /* Sort by priority: REFRESH(0) first, DELETE(1), DELETE_CHILDREN(2) last.
+         * O(n) counting + scatter pass — no allocations. */
+        struct hint_entry sorted[HINT_BATCH_SIZE];
+        int counts[3] = {0};
+
+        for (int h = 0; h < local_count; h++) {
+            counts[local_buf[h].event]++;
+        }
+
+        int offsets[3] = {0, counts[0], counts[0] + counts[1]};
+
+        for (int h = 0; h < local_count; h++) {
+            int e = local_buf[h].event;
+            sorted[offsets[e]++] = local_buf[h];
+        }
+
+        /* Snapshot sibling fds ONCE for the entire batch */
+        int *child_fds = NULL;
+        pid_t *child_pids = NULL;
+        int child_count = 0;
+        snapshot_sibling_fds(children, &child_fds, &child_pids,
+                             &child_count);
+
+        if (child_count == 0 || !child_fds) {
+            free(child_fds);
+            free(child_pids);
+            continue;
+        }
+
+        /* Build and send per-sibling batch in PIPE_BUF-safe chunks.
+         * Each chunk contains only complete 22-byte messages, so
+         * writes ≤ PIPE_BUF are POSIX-guaranteed atomic — no partial */
+        const size_t msg_size = IPC_HEADERLEN +
+                                sizeof(struct ipc_cache_hint_payload);
+        const int msgs_per_chunk = PIPE_BUF / msg_size;
+        const size_t chunk_limit = msgs_per_chunk * msg_size;
+        char write_buf[HINT_BATCH_SIZE * (IPC_HEADERLEN +
+                                          sizeof(struct ipc_cache_hint_payload))];
+
+        for (int s = 0; s < child_count; s++) {
+            int write_len = 0;
+
+            for (int h = 0; h < local_count; h++) {
+                if (child_pids[s] == sorted[h].source_pid) {
+                    continue;    /* Skip source child */
+                }
+
+                write_len += serialize_hint(write_buf + write_len,
+                                            &sorted[h]);
+
+                /* Flush chunk when it reaches PIPE_BUF-safe limit */
+                if ((size_t)write_len >= chunk_limit) {
+                    ssize_t ret = write(child_fds[s], write_buf,
+                                        write_len);
+
+                    if (ret < 0) {
+                        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+                            LOG(log_debug, logtype_afpd,
+                                "hint_flush: write failed fd=%d: %s",
+                                child_fds[s], strerror(errno));
+                        }
+
+                        write_len = 0;
+                        break;  /* Pipe full or error — next sibling */
+                    }
+
+                    write_len = 0;
+                }
+            }
+
+            /* Flush any remaining partial chunk */
+            if (write_len > 0) {
+                ssize_t ret = write(child_fds[s], write_buf, write_len);
+
+                if (ret < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+                    LOG(log_debug, logtype_afpd,
+                        "hint_flush: write failed fd=%d: %s",
+                        child_fds[s], strerror(errno));
+                }
+            }
+        }
+
+        atomic_fetch_add(&hints_batched, local_count);
+        atomic_fetch_add(&flush_count, 1);
+
+        /* Close dup'd fds — our private copies from snapshot_sibling_fds */
+        for (int s = 0; s < child_count; s++) {
+            close(child_fds[s]);
+        }
+
+        free(child_fds);
+        free(child_pids);
+    }
+
+    return NULL;
+}
 
 /*!
  * @brief Pass afp_socket to old disconnected session if one has a matching token (token = pid)
@@ -173,82 +478,85 @@ EC_CLEANUP:
 }
 
 /*!
- * @brief Relay a dircache hint from one child to all siblings
+ * @brief Buffer a dircache hint for batched relay to siblings
  *
- * Iterates ALL hash buckets in the child table (CHILD_HASHSIZE = 32).
- * Writes to each sibling's dedicated hint pipe (afpch_hint_fd) using
- * non-blocking write(). Hints dropped on EAGAIN (graceful degradation).
- * Pipe writes ≤ PIPE_BUF are POSIX-guaranteed atomic — our 22-byte
- * messages always arrive complete without framing concerns.
- *
- * Releases servch_lock BEFORE write loop to prevent blocking other IPC
- * operations during relay.
+ * Main thread appends to hint_buf under flush_mutex; the flush thread
+ * drains and writes batches to siblings.
  */
 static int ipc_relay_cache_hint(struct ipc_header *ipc,
                                 server_child_t *children)
 {
-    /* Pre-build the wire message OUTSIDE lock — reduces critical section */
-    char block[IPC_MAXMSGSIZE];
-    char *p = block;
-    uint16_t cmd = IPC_CACHE_HINT;
-    uint32_t len = ipc->len;
-    memset(block, 0, IPC_MAXMSGSIZE);
-    memcpy(p, &cmd, sizeof(cmd));
-    p += sizeof(cmd);
-    memcpy(p, &ipc->child_pid, sizeof(pid_t));
-    p += sizeof(pid_t);
-    memcpy(p, &ipc->uid, sizeof(uid_t));
-    p += sizeof(uid_t);
-    memcpy(p, &len, sizeof(uint32_t));
-    p += sizeof(uint32_t);
-    memcpy(p, ipc->msg, ipc->len);
-    ssize_t total_len = IPC_HEADERLEN + ipc->len;
-    /* Snapshot sibling hint pipe fds under lock, then release before writing.
-     * Sized to configured max sessions for safety margin. */
-    int *child_fds = malloc(children->servch_nsessions * sizeof(int));
-
-    if (!child_fds) {
-        return 0;    /* OOM: drop hint gracefully */
+    /* Validate payload length before accessing */
+    if (ipc->len < sizeof(struct ipc_cache_hint_payload)) {
+        LOG(log_warning, logtype_afpd,
+            "ipc_relay_cache_hint: short payload (%u < %zu) from pid %u",
+            ipc->len, sizeof(struct ipc_cache_hint_payload),
+            ipc->child_pid);
+        return 0;
     }
 
-    int child_count = 0;
-    pthread_mutex_lock(&children->servch_lock);
+    struct ipc_cache_hint_payload hint;
 
-    /* Iterate ALL hash buckets — servch_table is a hash table, not a single list */
-    for (int i = 0; i < CHILD_HASHSIZE; i++) {
-        for (afp_child_t *child = children->servch_table[i]; child;
-                child = child->afpch_next) {
-            if (child->afpch_pid != ipc->child_pid && child->afpch_hint_fd >= 0) {
-                child_fds[child_count++] = child->afpch_hint_fd;
-            }
-        }
+    memcpy(&hint, ipc->msg, sizeof(hint));
+
+    /* Skip relay when no siblings exist */
+    if (children->servch_count <= 1) {
+        return 0;
     }
 
-    pthread_mutex_unlock(&children->servch_lock);  /* Release BEFORE write loop */
-    /* Write to all siblings' hint pipes WITHOUT holding lock.
-     * Pipe writes ≤ PIPE_BUF are POSIX-guaranteed atomic. */
-    LOG(log_debug, logtype_afpd,
-        "ipc_relay_cache_hint: relaying to %d siblings", child_count);
+    /* Validate event type — reject unknown values at ingestion to prevent
+     * out-of-bounds access in the flush thread's counting sort. */
+    if (hint.event > CACHE_HINT_DELETE_CHILDREN) {
+        LOG(log_warning, logtype_afpd,
+            "ipc_relay_cache_hint: invalid event %u from pid %u, dropped",
+            hint.event, ipc->child_pid);
+        return 0;
+    }
 
-    for (int i = 0; i < child_count; i++) {
-        ssize_t ret = write(child_fds[i], block, total_len);
+    /* Rate-limit check (attack guard) */
+    if (check_and_increment_rate(ipc->child_pid) > HINT_RATE_LIMIT) {
+        atomic_fetch_add(&hints_rate_dropped, 1);
 
-        if (ret > 0 && ret != total_len) {
-            /* Partial write should never happen for ≤ PIPE_BUF writes */
+        /* Log only first exceed per window to avoid log flooding */
+        if (rate_track[ipc->child_pid % RATE_TRACK_SIZE].count_in_window
+                == HINT_RATE_LIMIT + 1) {
             LOG(log_warning, logtype_afpd,
-                "ipc_relay_cache_hint: partial write (%zd of %zd)", ret, total_len);
-        } else if (ret < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
-            /* EBADF/EPIPE: child crashed or closed pipe — non-fatal */
-            LOG(log_debug, logtype_afpd,
-                "ipc_relay_cache_hint: write failed fd=%d: %s",
-                child_fds[i], strerror(errno));
+                "ipc_relay_cache_hint: rate limit exceeded for pid %u",
+                ipc->child_pid);
         }
 
-        /* EAGAIN/EWOULDBLOCK: pipe buffer full, hint silently dropped */
+        return 0;
     }
 
-    free(child_fds);
-    /* Always return 0 — relay failures are handled gracefully via drop */
+    /* Append to buffer under lock */
+    pthread_mutex_lock(&flush_mutex);
+
+    /* Buffer full — signal flush thread and wait for it to drain.
+     * flush thread sleeping: wait bounded by wake latency + memcpy time (~1-10μs).
+     * flush thread mid-write: wait bounded by remaining write cycle time + memcpy */
+    if (hint_buf.count >= HINT_BATCH_SIZE) {
+        pthread_cond_signal(&flush_cond);
+
+        while (hint_buf.count >= HINT_BATCH_SIZE
+                && !atomic_load(&flush_shutdown)) {
+            pthread_cond_wait(&flush_drained, &flush_mutex);
+        }
+    }
+
+    hint_buf.entries[hint_buf.count] = (struct hint_entry) {
+        .vid = hint.vid,
+        .cnid = hint.cnid,
+        .event = hint.event,
+        .source_pid = ipc->child_pid,
+    };
+    hint_buf.count++;
+
+    /* Signal flush thread if buffer is now full */
+    if (hint_buf.count >= HINT_BATCH_SIZE) {
+        pthread_cond_signal(&flush_cond);
+    }
+
+    pthread_mutex_unlock(&flush_mutex);
     return 0;
 }
 
@@ -451,6 +759,62 @@ int ipc_child_write(int fd, uint16_t command, size_t len, void *msg)
 int ipc_child_state(AFPObj *obj, uint16_t state)
 {
     return ipc_child_write(obj->ipc_fd, IPC_STATE, sizeof(uint16_t), &state);
+}
+
+/***********************************************************************************
+ * Hint flush thread lifecycle (parent-side only)
+ ***********************************************************************************/
+
+/*!
+ * @brief Prevent child from touching flush infrastructure after fork().
+ *
+ * Single atomic store — no mutex/condvar reinit needed since the child
+ * never accesses the flush thread's synchronization primitives.
+ */
+static void hint_flush_child_atfork(void)
+{
+    atomic_store(&flush_shutdown, 1);
+}
+
+/*!
+ * @brief Start the hint flush thread. Called from parent after child table init.
+ */
+int hint_flush_start(server_child_t *children)
+{
+    pthread_atfork(NULL, NULL, hint_flush_child_atfork);
+    int ret = pthread_create(&flush_tid, NULL, hint_flush_thread, children);
+
+    if (ret != 0) {
+        LOG(log_error, logtype_afpd,
+            "hint_flush_start: pthread_create failed: %s", strerror(ret));
+        return -1;
+    }
+
+    LOG(log_info, logtype_afpd, "hint_flush_start: flush thread started");
+    return 0;
+}
+
+/*!
+ * @brief Stop the hint flush thread. Best-effort — called during parent shutdown.
+ *
+ * Note: The parent's SIGTERM handler calls _exit(0) directly, so this
+ * may not be reached. That is acceptable — SIGTERM also kills all children,
+ */
+void hint_flush_stop(void)
+{
+    atomic_store(&flush_shutdown, 1);
+    pthread_mutex_lock(&flush_mutex);
+    pthread_cond_signal(&flush_cond);
+    pthread_cond_signal(&flush_drained);
+    pthread_mutex_unlock(&flush_mutex);
+    pthread_join(flush_tid, NULL);
+    /* Final statistics */
+    LOG(log_debug, logtype_afpd,
+        "hint_flush_stop: final stats: flushes=%llu, hints_batched=%llu, "
+        "rate_dropped=%llu",
+        atomic_load(&flush_count),
+        atomic_load(&hints_batched),
+        atomic_load(&hints_rate_dropped));
 }
 
 /***********************************************************************************

--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -1238,6 +1238,8 @@ STATIC void test545()
     }
 
     FPCloseVol(Conn2, vol2);
+    /* Allow time for batched IPC hint delivery (flush thread interval is 50ms) */
+    sleep(1);
 
     /************************************
      * Step 5: Read FinderInfo via Conn - should see Conn2's change


### PR DESCRIPTION
Replace synchronous per-hint write() relay with batched accumulation and a dedicated flush thread. Hints are buffered under a single mutex and flushed every 50ms or when the 128-entry buffer fills, using PIPE_BUF-safe chunked writes with priority sorting.

- Add flush thread with 50ms timer and buffer-full signal
- Add per-child rate limiter (1000 hints/sec attack guard)
- Add single-session skip (servch_count <= 1)
- Add server_child_add() capacity enforcement
- Add pthread_atfork handler for fork-safety of flush mutex
- Add payload length validation in ipc_relay_cache_hint
- Add _Static_assert guard for HINT_FLUSH_INTERVAL_MS < 1000
- Use memcpy for IPC payload deserialization (alignment-safe)
- Use carry-over buffer for partial message framing in receiver
- Use dup() for hint pipe fd snapshot to prevent fd-reuse races
- Use pthread_create return value for error reporting (not errno)
- Replace per-hint read() receiver with bulk framed read
- Add 1s sleep to test545 for batched hint delivery timing

Parent CPU for hint relay: 21.45% -> 3.61% (83% reduction).