### PR TITLE
ci: build on OpenBSD without search indexing stack

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -628,7 +628,6 @@ jobs:
             set -e
             pkg_add -I \
               avahi \
-              bison \
               cmark \
               db-4.6.21p8v0 \
               dbus \
@@ -637,15 +636,12 @@ jobs:
               iniparser \
               libevent \
               libgcrypt \
-              libtalloc \
-              localsearch-3.10.0 \
               mariadb-client \
               meson \
               openldap-client-2.6.10v0 \
               p5-Net-DBus \
               pkgconfig \
-              sqlite3-3.50.7p0 \
-              tinysparql-3.10.0
+              sqlite3-3.50.7p0
           run: |
             set -e
             meson setup build \


### PR DESCRIPTION
the localsearch/tinysparql stack on OpenBSD 7.8 pulls in pretty much all of the GNOME desktop environment, taking up unnecessary GBs of space on a headless server

let's save some time and storage by not building with Spotlight support in the CI build