### PR TITLE
afpd: force-close stale forks during FPDelete to unblock deletion

### DIFF
--- a/distrib/docker/env_setup_netatalk.sh
+++ b/distrib/docker/env_setup_netatalk.sh
@@ -301,6 +301,7 @@ dircache mode = ${AFP_DIRCACHE_MODE:-lru}
 dircache validation freq = ${AFP_DIRCACHE_VALIDATION_FREQ:-1}
 dircache rfork budget = ${AFP_DIRCACHE_RFORK_BUDGET:-0}
 dircache rfork maxsize = ${AFP_DIRCACHE_RFORK_MAXSIZE:-1024}
+close stale rlocks = ${AFP_CLOSE_STALE_RLOCKS:-no}
 legacy icon = $AFP_LEGACY_ICON
 log file = /var/log/afpd.log
 log level = default:${AFP_LOGLEVEL:-info}

--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -608,6 +608,11 @@ close vol = *BOOLEAN* (default: *no*) **(G)**
 > Whether to close volumes possibly opened by clients when they're removed
 from the configuration and the configuration is reloaded.
 
+close stale rlocks = *BOOLEAN* (default: *no*) **(G)**
+
+> Whether to force-close stale forks holding only read byte-range
+locks when a client deletes a file.
+
 extmap file = *path* **(G)**
 
 > Sets the path to the file which defines file extension type/creator

--- a/doc/manual/Configuration.md
+++ b/doc/manual/Configuration.md
@@ -75,3 +75,26 @@ For example, when */home* links to */usr/home*:
 
 For a detailed explanation of all available options,
 refer to the [afp.conf](afp.conf.5.html) man page.
+
+### Stale fork cleanup on file deletion
+
+When a client deletes a file via AFP (FPDelete), the server checks for
+any open forks associated with the file (forks are internal tracking
+objects created when the client opens a file for reading and/or writing).
+Netatalk automatically cleans up any forks that are stale (client did not
+send a close for each open) — meaning they are not dirty (no
+pending metadata flush) and hold no locks. This allows file deletion to
+succeed even when a client has neglected to close before deleting the file.
+
+By default, forks holding locks of any type (read or write) are considered
+active and will prevent the delete from proceeding (the client receives
+a busy error). However, if **close stale rlocks** is set to **yes** in
+the Global section of *afp.conf*, forks that only hold read locks (and
+no write locks) will also be force-closed.
+
+Forks holding write locks always block deletion.
+
+Example:
+
+    [Global]
+    close stale rlocks = yes

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -926,14 +926,27 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 
             bdestroy(dname);
         }
-    } else if (of_findname(vol, s_path)) {
-        rc = AFPERR_BUSY;
     } else {
+        /* It's a file. Check for open forks before attempting delete.
+         * of_findname() is a cheap hash lookup — no syscalls. */
+        if (of_findname(vol, s_path)) {
+            /* File has open forks — attempt stale fork cleanup */
+            if (of_close_stale_forks(obj, s_path) != 0) {
+                /* Active forks remain (dirty/locked) — cannot delete */
+                rc = AFPERR_BUSY;
+            } else if (of_findname(vol, s_path)) {
+                /* Safety: forks still present after cleanup */
+                rc = AFPERR_BUSY;
+            }
+        }
+
         /* it's a file st_valid should always be true
          * only test for ENOENT because EACCES needs
          * to read meta data in deletefile
          */
-        if (s_path->st_valid && s_path->st_errno == ENOENT) {
+        if (rc != AFP_OK) {
+            /* Fork check or stale cleanup failed — skip deletion */
+        } else if (s_path->st_valid && s_path->st_errno == ENOENT) {
             rc = AFPERR_NOOBJ;
         } else {
             /* Validate target FILE inode to detect external replacement */
@@ -969,8 +982,20 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
                 file_cnid = cnid_get(vol->v_cdb, curdir->d_did, upath, ulen);
             }
 
-            /* deletefile() also handles CNID and dircache cleanup */
-            if ((rc = deletefile(vol, -1, upath, 1)) == AFP_OK) {
+            /* Optimistic delete — try without fork pre-check.
+             * If it fails with AFPERR_BUSY (open forks hold locks),
+             * attempt stale fork cleanup and retry once. */
+            rc = deletefile(vol, -1, upath, 1);
+
+            if (rc == AFPERR_BUSY && of_findname(vol, s_path)) {
+                /* Delete blocked by open forks — try cleaning stale ones */
+                if (of_close_stale_forks(obj, s_path) == 0) {
+                    /* All stale forks closed — retry delete */
+                    rc = deletefile(vol, -1, upath, 1);
+                }
+            }
+
+            if (rc == AFP_OK) {
                 fce_register(obj, FCE_FILE_DELETE, fullpathname(upath), NULL);
 
                 /* Send hints to afpd siblings — file deleted */

--- a/etc/afpd/fork.h
+++ b/etc/afpd/fork.h
@@ -69,6 +69,7 @@ extern void         of_pforkdesc(FILE *);
 extern int          of_stat(const struct vol *vol, struct path *);
 extern int          of_statdir(struct vol *vol, struct path *);
 extern int          of_closefork(const AFPObj *obj, struct ofork *ofork);
+extern int          of_close_stale_forks(const AFPObj *, struct path *);
 extern void         of_closevol(const AFPObj *obj, const struct vol *vol);
 extern void         of_close_all_forks(const AFPObj *obj);
 extern struct adouble *of_ad(const struct vol *, struct path *,

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -203,7 +203,9 @@ of_alloc(struct vol *vol,
     lastrefnum = refnum;
 
     if (i == nforks) {
-        LOG(log_error, logtype_afpd, "of_alloc: maximum number of forks exceeded.");
+        LOG(log_error, logtype_afpd,
+            "of_alloc: maximum number of forks (%d) reached for "
+            "\"%s\"", nforks, path);
         return NULL;
     }
 
@@ -670,6 +672,117 @@ int of_closefork(const AFPObj *obj, struct ofork *ofork)
     return ret;
 }
 
+/*!
+ * @brief Force-close stale forks for a file to unblock deletion
+ *
+ * Iterates all open forks matching the target file/directory
+ * (by dev/ino) and closes any that are safe to force-close:
+ *   - Not DIRTY (no pending AD header changes)
+ *   - No outstanding locks on the shared adouble
+ *
+ * AFPFORK_MODIFIED is intentionally not checked: since the file is
+ * being deleted, any data written via FPWrite is already on disk and
+ * will be destroyed by the subsequent unlink().
+ *
+ * @param obj    AFP object (session context)
+ * @param path   Path structure with valid st_dev/st_ino
+ *
+ * @return 0 if all forks were closed (or none found), -1 if any
+ *         active fork remains that cannot be safely closed
+ */
+int of_close_stale_forks(const AFPObj *obj, struct path *path)
+{
+    struct file_key key;
+    int active_remaining = 0;
+
+    if (!path->st_valid || path->st_errno) {
+        return -1;
+    }
+
+    key.dev = path->st.st_dev;
+    key.inode = path->st.st_ino;
+    struct ofork *of = ofork_table[hashfn(&key)];
+
+    while (of != NULL) {
+        struct ofork *next = of->next;  /* save before potential dealloc */
+
+        if (key.dev != of->key.dev || key.inode != of->key.inode) {
+            /* Different file — skip */
+        } else if (!of->of_ad) {
+            /* Guard: of_ad must be valid for of_name() and of_closefork() */
+            LOG(log_error, logtype_afpd,
+                "of_close_stale_forks: fork refnum:%u has NULL adouble, "
+                "skipping", of->of_refnum);
+            active_remaining++;
+        } else if (of->of_flags & AFPFORK_ACCWR) {
+            /* Safety check 1: fork opened with write access — the client
+             * may write more data at any time. Never force-close. */
+            LOG(log_warning, logtype_afpd,
+                "of_close_stale_forks: fork refnum:%u opened for write, "
+                "skipping", of->of_refnum);
+            active_remaining++;
+        } else if (of->of_flags & AFPFORK_DIRTY) {
+            /* Safety check 2: Is DIRTY - pending flush */
+            LOG(log_warning, logtype_afpd,
+                "of_close_stale_forks: fork refnum:%u has DIRTY flag, "
+                "skipping (pending flush)",
+                of->of_refnum);
+            active_remaining++;
+        } else if (adf_has_wrlocks(&of->of_ad->ad_data_fork) ||
+                   adf_has_wrlocks(of->of_ad->ad_rfp)) {
+            /* Safety check 3: write locks
+             * Write locks indicate a potentially active writer. */
+            LOG(log_warning, logtype_afpd,
+                "of_close_stale_forks: fork refnum:%u — adouble holds "
+                "write locks (data:%d rsrc:%d total), skipping",
+                of->of_refnum,
+                of->of_ad->ad_data_fork.adf_lockcount,
+                of->of_ad->ad_rfp->adf_lockcount);
+            active_remaining++;
+        } else if ((of->of_ad->ad_data_fork.adf_lockcount > 0 ||
+                    of->of_ad->ad_rfp->adf_lockcount > 0) &&
+                   !(obj->options.flags & OPTION_CLOSE_STALE_RLOCKS)) {
+            /* Safety check 3: read-only locks present, but "close stale
+             * rlocks" is disabled — fall back to conservative behavior. */
+            LOG(log_warning, logtype_afpd,
+                "of_close_stale_forks: fork refnum:%u — adouble holds "
+                "read locks (data:%d rsrc:%d), skipping "
+                "(close stale rlocks = no)",
+                of->of_refnum,
+                of->of_ad->ad_data_fork.adf_lockcount,
+                of->of_ad->ad_rfp->adf_lockcount);
+            active_remaining++;
+        } else {
+            /* Fork is safe to force-close:
+             * - Not dirty, no write locks
+             * - Either no locks at all, or only read locks with
+             *   "close stale rlocks" enabled */
+            LOG(log_warning, logtype_afpd,
+                "of_close_stale_forks: force-closing stale fork refnum:%u "
+                "name:\"%s\" flags:0x%x access:%s "
+                "(not dirty, no write locks, rdlocks data:%d rsrc:%d)",
+                of->of_refnum, of_name(of), of->of_flags,
+                (of->of_flags & AFPFORK_ACCWR) ? "write" :
+                (of->of_flags & AFPFORK_ACCRD) ? "read" : "none",
+                of->of_ad->ad_data_fork.adf_lockcount,
+                of->of_ad->ad_rfp->adf_lockcount);
+            /* Note: of_closefork() may emit FCE_FILE_MODIFY for MODIFIED
+             * stale forks. This is harmless — the subsequent deletefile()
+             * emits FCE_FILE_DELETE, and well-behaved FCE consumers handle
+             * MODIFY→DELETE sequences correctly.
+             *
+             * The zero-length resource fork check in of_closefork() may
+             * also unlink the AppleDouble file early. This is safe because
+             * the delete path handles ENOENT gracefully. */
+            of_closefork(obj, of);
+        }
+
+        of = next;
+    }
+
+    return active_remaining ? -1 : 0;
+}
+
 struct adouble *of_ad(const struct vol *vol, struct path *path,
                       struct adouble *ad)
 {
@@ -692,6 +805,7 @@ struct adouble *of_ad(const struct vol *vol, struct path *path,
 void of_closevol(const AFPObj *obj, const struct vol *vol)
 {
     int refnum;
+    int closed_count = 0;
 
     if (!oforks) {
         return;
@@ -699,10 +813,20 @@ void of_closevol(const AFPObj *obj, const struct vol *vol)
 
     for (refnum = 0; refnum < nforks; refnum++) {
         if (oforks[refnum] != NULL && oforks[refnum]->of_vol == vol) {
+            closed_count++;
+
             if (of_closefork(obj, oforks[refnum]) < 0) {
                 LOG(log_error, logtype_afpd, "of_closevol: %s", strerror(errno));
             }
         }
+    }
+
+    if (closed_count > 0) {
+        LOG(log_info, logtype_afpd,
+            "Closing Volume: closed %d open fork(s) for user \"%s\" "
+            "vol \"%s\"",
+            closed_count, obj->username,
+            vol->v_localname ? vol->v_localname : "unknown");
     }
 
     return;
@@ -714,6 +838,7 @@ void of_closevol(const AFPObj *obj, const struct vol *vol)
 void of_close_all_forks(const AFPObj *obj)
 {
     int refnum;
+    int closed_count = 0;
 
     if (!oforks) {
         return;
@@ -721,10 +846,18 @@ void of_close_all_forks(const AFPObj *obj)
 
     for (refnum = 0; refnum < nforks; refnum++) {
         if (oforks[refnum] != NULL) {
+            closed_count++;
+
             if (of_closefork(obj, oforks[refnum]) < 0) {
                 LOG(log_error, logtype_afpd, "of_close_all_forks: %s", strerror(errno));
             }
         }
+    }
+
+    if (closed_count > 0) {
+        LOG(log_info, logtype_afpd,
+            "Session shutdown for \"%s\": closed %d open fork(s)",
+            obj->username, closed_count);
     }
 
     return;

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -394,6 +394,7 @@ extern int ad_lock(struct adouble *, uint32_t eid, int type, off_t off,
 extern void ad_unlock(struct adouble *, int fork, int unlckbrl);
 extern void adf_lock_init(struct ad_fd *adf);
 extern void adf_lock_free(struct ad_fd *adf);
+extern int  adf_has_wrlocks(const struct ad_fd *adf);
 extern int ad_tmplock(struct adouble *, uint32_t eid, int type, off_t off,
                       off_t len, int fork);
 

--- a/include/atalk/globals.h
+++ b/include/atalk/globals.h
@@ -74,6 +74,7 @@
 #define OPTION_SPOTLIGHT_EXPR (1 << 16) /*!< whether to allow Spotlight logic expressions */
 #define OPTION_DDP     (1 << 17) /*!< whether to allow connections via appletalk/ddp */
 #define OPTION_VALID_SHELLCHECK (1 << 18) /*!< whether to check for valid login shell */
+#define OPTION_CLOSE_STALE_RLOCKS (1 << 19) /*!< whether to force-close read-locked stale forks on delete */
 
 #define PASSWD_NONE     0
 #define PASSWD_SET     (1 << 0)

--- a/libatalk/adouble/ad_lock.c
+++ b/libatalk/adouble/ad_lock.c
@@ -207,6 +207,32 @@ void adf_lock_init(struct ad_fd *adf)
 }
 
 /*!
+ * @brief Check if an ad_fd holds any write (exclusive) locks
+ *
+ * Scans the tracked lock array for F_WRLCK entries. Read locks (F_RDLCK)
+ * are not counted. Used by of_close_stale_forks() to distinguish between
+ * read-only locked forks (safe to force-close on delete) and write-locked
+ * forks (potentially mid-write, must block).
+ *
+ * @param[in] adf  File descriptor structure to inspect
+ * @return 1 if at least one write lock exists, 0 otherwise
+ */
+int adf_has_wrlocks(const struct ad_fd *adf)
+{
+    if (!adf || adf->adf_lockcount == 0) {
+        return 0;
+    }
+
+    for (int i = 0; i < adf->adf_lockcount; i++) {
+        if (adf->adf_lock[i].lock.l_type == F_WRLCK) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/*!
  * @brief Free all locks in an ad_fd structure
  *
  * Iterates through all locks in the ad_fd lock array, releasing fcntl locks

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2604,6 +2604,10 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
         options->flags |= OPTION_AFP_READ_LOCK;
     }
 
+    if (getoption_bool(config, INISEC_GLOBAL, "close stale rlocks", NULL, 0)) {
+        options->flags |= OPTION_CLOSE_STALE_RLOCKS;
+    }
+
     if (getoption_bool(config, INISEC_GLOBAL, "spotlight", NULL, 0)) {
         options->flags |= OPTION_SPOTLIGHT_VOL;
     }


### PR DESCRIPTION
Non-compliant AFP clients (e.g. Preview.app) sometimes leave open forks after completing operations, causing FPDelete to return AFPERR_BUSY when trying to delete after viewing.

Add of_close_stale_forks() which iterates all open forks matching the target file (by dev/ino) and force-closes any fork that passes both safety checks:
  - Not DIRTY (no pending AD header metadata flush)
  - No outstanding locks on the shared adouble

AFPFORK_MODIFIED is intentionally not checked since the file is being deleted and any data written via FPWrite is already on disk.

In afp_delete(), when of_findname() detects open forks, attempt stale fork cleanup before returning AFPERR_BUSY. If all forks are closed, re-verify with of_findname() and proceed to deletion. If any fork remains active (dirty or locked), return AFPERR_BUSY as before.

This is safe because:
  - No data loss: file is being deleted, written data is on disk
  - No lock violations: explicit lock check before force-close
  - Per-FD refcounting respected: of_closefork() properly decrements
  - Scope limited to FPDelete: normal fork lifecycle unaffected
  - Post-close behavior identical to session disconnect cleanup

Extensive investigation and debugging (2 weeks of testing with logs and Wireshark - I found it hard to believe Apple are the ones who violate the spec sometimes) was performed to validate that this is NOT a Netatalk issue.
Tracing AFP operations from some clients (such as macOS Ventura) using specific applications, it was proven that the AFP spec is sometimes violated by clients. 
The spec states if a client opens a file for Read, and opens it for Writing later, the client must still close both open's - not just the most privileged open.

_As there is only a single file descriptor on the client, it is understandable that sometimes this tracking fails and only one close is received for the client's fd (instead of an exact close for each original open), leaving a stale fork on the server - subsequently blocking deletions._

This forced-cleanup does not violate the AFP specification.