### PR TITLE
dbd: add -i option to invalidate AppleDouble CNID hints

### DIFF
--- a/bin/dbd/cmd_dbd.c
+++ b/bin/dbd/cmd_dbd.c
@@ -140,7 +140,7 @@ int main(int argc, char **argv)
     const char *username = NULL;
     int c;
 
-    while ((c = getopt(argc, argv, ":cfF:irstu:vV")) != -1) {
+    while ((c = getopt(argc, argv, ":cfF:istu:vV")) != -1) {
         switch (c) {
         case 'c':
             flags |= DBD_FLAGS_V2TOEA;
@@ -156,10 +156,6 @@ int main(int argc, char **argv)
 
         case 'F':
             obj.cmdlineconfigfile = strdup(optarg);
-            break;
-
-        case 'r':
-            /* the default */
             break;
 
         case 's':

--- a/bin/dbd/cmd_dbd.c
+++ b/bin/dbd/cmd_dbd.c
@@ -95,7 +95,7 @@ static void set_signal(void)
 
 static void usage(void)
 {
-    printf("Usage: dbd [-cfFstuvV] <path to netatalk volume>\n\n"
+    printf("Usage: dbd [-cfFistuvV] <path to netatalk volume>\n\n"
            "dbd scans all file and directories of AFP volumes, updating the\n"
            "CNID database of the volume. dbd must be run with appropriate\n"
            "permissions i.e. as root.\n\n"
@@ -105,6 +105,7 @@ static void usage(void)
            "   -c convert from adouble:v2 to adouble:ea\n"
            "   -F location of the afp.conf config file\n"
            "   -f delete and recreate CNID database\n"
+           "   -i invalidate CNID hints in AppleDouble files\n"
            "   -t show statistics while running\n"
            "   -u username for use with AFP volumes using user variable $u\n"
            "   -v verbose\n"
@@ -139,7 +140,7 @@ int main(int argc, char **argv)
     const char *username = NULL;
     int c;
 
-    while ((c = getopt(argc, argv, ":cfF:rstu:vV")) != -1) {
+    while ((c = getopt(argc, argv, ":cfF:irstu:vV")) != -1) {
         switch (c) {
         case 'c':
             flags |= DBD_FLAGS_V2TOEA;
@@ -147,6 +148,10 @@ int main(int argc, char **argv)
 
         case 'f':
             flags |= DBD_FLAGS_FORCE;
+            break;
+
+        case 'i':
+            flags |= DBD_FLAGS_STRIP_AD;
             break;
 
         case 'F':

--- a/bin/dbd/cmd_dbd.h
+++ b/bin/dbd/cmd_dbd.h
@@ -14,6 +14,7 @@ typedef unsigned int dbd_flags_t;
 #define DBD_FLAGS_STATS    (1 << 2)
 #define DBD_FLAGS_V2TOEA   (1 << 3) /*!< Convert adouble:v2 to adouble:ea */
 #define DBD_FLAGS_VERBOSE  (1 << 4)
+#define DBD_FLAGS_STRIP_AD (1 << 5) /*!< Invalidate AppleDouble CNID hints */
 
 #define ADv2_DIRNAME ".AppleDouble"
 

--- a/bin/dbd/cmd_dbd_scanvol.c
+++ b/bin/dbd/cmd_dbd_scanvol.c
@@ -646,7 +646,21 @@ static cnid_t check_cnid(const char *name, cnid_t did, struct stat *st,
     /* Get CNID from ad-file */
     ad_cnid = CNID_INVALID;
 
-    if (ADFILE_OK) {
+    if (dbd_flags & DBD_FLAGS_STRIP_AD) {
+        dbd_log(LOGDEBUG, "Ignoring AppleDouble CNID hint for '%s/%s'", cwdbuf, name);
+
+        if (ADFILE_OK && vol->v_adouble == AD_VERSION_EA) {
+            int oflags = (dbd_flags & DBD_FLAGS_SCAN) ? ADFLAGS_RDONLY : ADFLAGS_RDWR;
+            ad_init(&ad, vol);
+
+            if (ad_open(&ad, name, adflags | oflags) != 0) {
+                dbd_log(LOGDEBUG, "File without meta EA: \"%s/%s\"", cwdbuf, name);
+                adfile_ok = 1;
+            } else {
+                ad_close(&ad, ADFLAGS_HF);
+            }
+        }
+    } else if (ADFILE_OK) {
         ad_init(&ad, vol);
 
         if (ad_open(&ad, name, adflags | ADFLAGS_RDWR) != 0) {
@@ -679,7 +693,7 @@ static cnid_t check_cnid(const char *name, cnid_t did, struct stat *st,
     }
 
     /* Compare CNID from db and adouble file */
-    if (ad_cnid != db_cnid && adfile_ok == 0) {
+    if (ad_cnid != db_cnid && adfile_ok == 0 && !(dbd_flags & DBD_FLAGS_SCAN)) {
         /* Mismatch, overwrite ad file with value from db */
         dbd_log(LOGSTD, "CNID mismatch for '%s/%s', CNID db: %u, ad-file: %u",
                 cwdbuf, name, ntohl(db_cnid), ntohl(ad_cnid));

--- a/doc/manpages/man1/dbd.1.md
+++ b/doc/manpages/man1/dbd.1.md
@@ -4,7 +4,7 @@ dbd — CNID database maintenance utility
 
 # Synopsis
 
-**dbd** [-cfFstuv] [*volumepath*]
+**dbd** [-cfFistuv] [*volumepath*]
 
 **dbd** [-V]
 
@@ -34,6 +34,12 @@ this tool can be used with any CNID backend.
 **-F**
 
 > location of the *afp.conf* config file
+
+**-i**
+
+> invalidate CNID hints stored in AppleDouble files,
+so existing database entries are used instead of stale AD hints;
+combine with **-f** to assign fresh CNIDs to all files and directories
 
 **-s**
 


### PR DESCRIPTION
When nested volumes leave behind stale CNID hints in AppleDouble files, dbd -f alone cannot fix them because cnid_add() still receives the stale hint. The new -i flag skips reading AD hints entirely, letting the database assign fresh CNIDs which are then written back to the AppleDouble files.

Also fix two bugs in check_cnid() with DBD_FLAGS_STRIP_AD set: on AD_VERSION_EA volumes, files without a meta EA would incorrectly return CNID_INVALID because the adfile_ok probe was skipped; and the CNID overwrite path lacked a DBD_FLAGS_SCAN guard, causing filesystem writes in read-only scan mode.

Finally, remove vestigal -r option argument that has no logic