### PR TITLE
remove obsolete crypt.h header inclusion

### DIFF
--- a/etc/uams/uams_dhx2_passwd.c
+++ b/etc/uams/uams_dhx2_passwd.c
@@ -20,10 +20,6 @@
 #include <time.h>
 #include <unistd.h>
 
-#ifdef HAVE_CRYPT_H
-#include <crypt.h>
-#endif
-
 #ifdef SHADOWPW
 #include <shadow.h>
 #endif

--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -18,10 +18,6 @@
 #include <time.h>
 #include <unistd.h>
 
-#ifdef HAVE_CRYPT_H
-#include <crypt.h>
-#endif /* ! HAVE_CRYPT_H */
-
 #ifdef SHADOWPW
 #include <shadow.h>
 #endif /* SHADOWPW */

--- a/etc/uams/uams_passwd.c
+++ b/etc/uams/uams_passwd.c
@@ -18,10 +18,6 @@
 #include <time.h>
 #include <unistd.h>
 
-#ifdef HAVE_CRYPT_H
-#include <crypt.h>
-#endif /* ! HAVE_CRYPT_H */
-
 #ifdef SHADOWPW
 #include <shadow.h>
 #endif /* SHADOWPW */

--- a/meson.build
+++ b/meson.build
@@ -263,7 +263,6 @@ endif
 check_headers = [
     'acl/libacl.h',
     'attr/xattr.h',
-    'crypt.h',
     'dlfcn.h',
     'iniparser/iniparser.h',
     'langinfo.h',

--- a/meson_config.h
+++ b/meson_config.h
@@ -67,9 +67,6 @@
 /* Define to 1 if you have the `crypt_checkpass' function. */
 #mesondefine HAVE_CRYPT_CHECKPASS
 
-/* Define to 1 if you have the <crypt.h> header file. */
-#mesondefine HAVE_CRYPT_H
-
 /* Define to enable CUPS Support */
 #mesondefine HAVE_CUPS
 


### PR DESCRIPTION
libcrypt is a 25 year old dependency that is long since obsolete, so sign that any symbols from this library is required anymore (supplanted by libgcrypt)