### PR TITLE
ci: add libcrypt-dev to Debian build dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,6 +188,7 @@ jobs:
             libacl1-dev \
             libavahi-client-dev \
             libcrack2-dev \
+            libcrypt-dev \
             libcups2-dev \
             libdb-dev \
             libdbus-1-dev \


### PR DESCRIPTION
libcrypt will not be part of build essentials from Debian Forky onwards, so let's add it an an explicit build dependency