### PR TITLE
[4.4] meson: fix bugs that prevent you from disabling dev docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -496,7 +496,7 @@ jobs:
               libgcrypt \
               localsearch \
               meson \
-              mysql91-client \
+              mysql96-client \
               openldap26-client \
               p5-Net-DBus \
               perl5 \

--- a/meson.build
+++ b/meson.build
@@ -2317,7 +2317,7 @@ doxygen = find_program('doxygen', required: false)
 build_man_docs = false
 build_html_docs = false
 build_readme_docs = false
-build_dev_docs = true
+build_dev_docs = false
 
 if 'readmes' in get_option('with-docs')
     make_compile_doc = find_program('contrib/scripts/make_compile_docs.pl', required: false)
@@ -2401,7 +2401,7 @@ if 'html_manual' in get_option('with-docs')
     endif
 endif
 
-if 'dev' in get_option('with-docs')
+if 'developer' in get_option('with-docs')
     if doxygen.found()
         build_dev_docs = true
     else


### PR DESCRIPTION
two silly mistakes introduced when first creating the developer docs build scripts made it so that they were always built regardles of meson options

Reported-by: Kilian Kempf