### PR TITLE
[4.4] meson: detect and configure endianness preprocessor flag

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -247,6 +247,10 @@ endif
 
 add_global_link_arguments(netatalk_common_link_args, language: 'c')
 
+if host_machine.endian() == 'big'
+    cdata.set('WORDS_BIGENDIAN', 1)
+endif
+
 #################
 # Header checks #
 #################

--- a/meson_config.h
+++ b/meson_config.h
@@ -1,6 +1,3 @@
-/* Define if building universal (internal helper macro) */
-#mesondefine AC_APPLE_UNIVERSAL_BUILD
-
 /* BSD compatiblity macro */
 #mesondefine BSD4_4
 
@@ -426,15 +423,7 @@
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
-#if defined AC_APPLE_UNIVERSAL_BUILD
-# if defined __BIG_ENDIAN__
-#  define WORDS_BIGENDIAN 1
-# endif
-#else
-# ifndef WORDS_BIGENDIAN
-#  undef WORDS_BIGENDIAN
-# endif
-#endif
+#mesondefine WORDS_BIGENDIAN
 
 /* xattr functions have additional options */
 #mesondefine XATTR_ADD_OPT


### PR DESCRIPTION
replace the Autotool-ism for endianness macro that doesn't work with Meson, with some surrounding cleanup

we can now build with big-endian byte order support on f.e. s390x architecture