### PR TITLE
ci: switch to NetBSD pkgsrc mirror for build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -580,7 +580,7 @@ jobs:
           sync: sshfs
           prepare: |
             set -e
-            export PKG_PATH="http://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f '1 2' -d.)/All"
+            export PKG_PATH="http://ftp.fr.netbsd.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f '1 2' -d.)/All"
             pkg_add \
               cmark \
               db5 \


### PR DESCRIPTION
the main ftp.netbsd.org mirror has been down for most of the day so let's switch over to a mirror for now; using the one of the few that seems to work is the French mirror (Universite de Pierre et Marie Curie)