### PR TITLE
ci: use OmniOS variant with build-essential for build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -693,6 +693,7 @@ jobs:
       - name: Build on VM
         uses: vmactions/omnios-vm@cfa22c687939a88f4938c03c5413062dd3642eac # v1.2.8
         with:
+          release: r151056-build
           copyback: true
           prepare: |
             set -e


### PR DESCRIPTION
the preloaded build-essential package should make for quicker bootstrap of the build environment

edit: yep, now `pkg install` installs <100KB, down from 170MB before