### PR TITLE
ci: add Webmin module installation steps and checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,9 @@ jobs:
           cd build/meson-dist
           sha256sum "${{ steps.get_version.outputs.tarball_name }}.tar.xz" > "${{ steps.get_version.outputs.tarball_name }}.tar.xz.sha256sum"
           sha512sum "${{ steps.get_version.outputs.tarball_name }}.tar.xz" > "${{ steps.get_version.outputs.tarball_name }}.tar.xz.sha512sum"
+          cd ../contrib/webmin_module
+          sha256sum "${{ steps.get_version.outputs.tarball_name }}.wbm.gz" > "${{ steps.get_version.outputs.tarball_name }}.wbm.gz.sha256sum"
+          sha512sum "${{ steps.get_version.outputs.tarball_name }}.wbm.gz" > "${{ steps.get_version.outputs.tarball_name }}.wbm.gz.sha512sum"
       - name: Create release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
@@ -89,7 +92,10 @@ jobs:
 
             All users of previous Netatalk versions are encouraged to upgrade to ${{ steps.get_version.outputs.version }}.
 
-            This is a source-only release. To build:
+            ## Installation
+
+            ${{ steps.get_version.outputs.tarball_name }}.tar.xz is the Netatalk source distribution.
+            See [INSTALL](https://netatalk.io/install) for required dependencies, then build with:
 
             ```shell
             # Extract the source
@@ -103,11 +109,21 @@ jobs:
             # Install
             sudo meson install -C build
             ```
+
+            ${{ steps.get_version.outputs.tarball_name }}.wbm.gz is the Webmin module tarball.
+            To install the module:
+
+            ```shell
+            # Adjust the path to match your Webmin installation
+            /usr/share/webmin/install-module.pl ${{ steps.get_version.outputs.tarball_name }}.wbm.gz
+            ```
           files: |
             build/meson-dist/${{ steps.get_version.outputs.tarball_name }}.tar.xz
             build/meson-dist/${{ steps.get_version.outputs.tarball_name }}.tar.xz.sha256sum
             build/meson-dist/${{ steps.get_version.outputs.tarball_name }}.tar.xz.sha512sum
             build/contrib/webmin_module/${{ steps.get_version.outputs.tarball_name }}.wbm.gz
+            build/contrib/webmin_module/${{ steps.get_version.outputs.tarball_name }}.wbm.gz.sha256sum
+            build/contrib/webmin_module/${{ steps.get_version.outputs.tarball_name }}.wbm.gz.sha512sum
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
added instructions for installing the Webmin module tarball to the release notes that are generated by this workflow

generate sha256sum and sha512sum checksum files for Webmin module tarball just like for the netatalk tarball