### PR TITLE
libatalk: map logtype identifiers correctly with the enum

### DIFF
--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -744,7 +744,8 @@ should be logged.
 > By default afpd logs to syslog with a default logging setup equivalent
 to **default:note**
 >
-> logtypes: default, logger, cnid, afpd, dsi, uams, fce, ad, sl
+> logtypes: default, logger, cnid, afpdaemon, dsi, atalkdaemon, papdaemon,
+uams, fce, ad, spotlight
 >
 > loglevels: severe, error, warn, note, info, debug, debug6, debug7,
 debug8, debug9, maxdebug

--- a/libatalk/util/logger.c
+++ b/libatalk/util/logger.c
@@ -60,6 +60,8 @@ Netatalk 2001 (c)
   "CNID",                            \
   "AFPDaemon",                       \
   "DSI",                             \
+  "ATalkDaemon",                     \
+  "PAPDaemon",                       \
   "UAMS",                            \
   "FCE",                             \
   "ad",                              \

--- a/libatalk/util/logger.c
+++ b/libatalk/util/logger.c
@@ -410,7 +410,7 @@ static void setuplog_internal(const char *loglevel, const char *logtype,
         }
     }
 
-    if (typenum >= num_logtype_strings) {
+    if (typenum >= (unsigned int)logtype_end_of_list_marker) {
         return;
     }
 


### PR DESCRIPTION
ATalkDaemon and PAPDaemon were present in the enum but absent from the string identifier array, shifting every entry from UAMS onward by -2. As a result, f.e. "spotlight:debug" in afp.conf resolved to logtype_fce (index 8) rather than logtype_sl (index 10), so Spotlight debug logging could never be enabled via the config file.

Add the two missing entries to restore correct alignment, while correcting man page documentation; this has
probably been broken ever since we grafted AppleTalk onto v4.0.

Also: fix OOB access when "end_of_list_marker" is passed as logtype 

The bound check in setuplog_internal() compared typenum against num_logtype_strings, which includes the sentinel "end_of_list_marker" entry. This allowed typenum == logtype_end_of_list_marker (11) to pass the guard and index type_configs[] out of bounds (sized for indices 0-10).

Fix by comparing against logtype_end_of_list_marker directly, which is the actual size of type_configs[].