### PR TITLE
netatalk: replace gsettings with dconf keyfile for indexer config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,6 +182,7 @@ jobs:
             ca-certificates \
             cmark-gfm \
             cracklib-runtime \
+            dconf-cli \
             file \
             flex \
             gcc \
@@ -342,6 +343,7 @@ jobs:
             ca-certificates \
             cmark-gfm \
             cracklib-runtime \
+            dconf-cli \
             file \
             flex \
             gcc \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,35 +67,39 @@ required at the bare minimum.
 |------------|---------|
 | C compiler | clang or gcc are recommended |
 | meson      | v0.61.2 or later |
-| ninja      | Often packaged as `ninja-build` |
+| ninja      | often packaged as `ninja-build` |
 
 ### Optional Spotlight Support
 
 | Package    | Details |
 |------------|---------|
-| D-Bus      | Also used by avahi and afpstats |
+| bison      | or compatible Yacc parser |
+| D-Bus      | also used by avahi and afpstats |
+| DConf      | sometimes packaged as `dconf-cli` |
+| GLib 2     | gsettings is used to determine the localsearch schema |
+| flex       | or compatible lexer |
 | localsearch **OR** tracker | v3.0 or later |
 | talloc     |  |
-| bison      |  |
-| flex       |  |
+| tinysparql |  |
 
 ### Optional Features
 
 | Package      | Details |
 |--------------|---------|
-| avahi **OR** mDNSresponder | For Zeroconf support |
-| cmark **OR** cmark-gfm **OR** pandoc | For generating documentation |
-| cracklib and cracklib dictionary | For password strength check in afppasswd |
-| GLib 2 and GIO             | For afpstats support |
-| Kerberos V                 | For krbV UAM support |
-| libacl                     | For ACL support |
-| libldap                    | For LDAP support |
-| libpam                     | For PAM support |
-| libtirpc **OR** libquota   | For Quota support |
-| Perl                       | For admin scripts |
-| po4a                       | For localization of documentation |
-| tcpwrap                    | For TCP wrapper support |
-| [UnicodeData.txt](https://www.unicode.org/Public/UNIDATA/UnicodeData.txt) | For regenerating Unicode lookup tables |
+| avahi **OR** mDNSresponder | Zeroconf support |
+| cmark **OR** cmark-gfm **OR** pandoc | generating documentation |
+| cracklib and cracklib dictionary | password strength check in afppasswd |
+| D-Bus daemon               | afpstats support (also transient dependency for avahi and localsearch) |
+| GLib 2 and GIO             | afpstats support |
+| Kerberos V                 | krbV UAM support |
+| libacl                     | ACL support |
+| libldap                    | LDAP support |
+| libpam                     | PAM support |
+| libtirpc **OR** libquota   | Quota support |
+| Perl                       | admin scripts |
+| po4a                       | localization of documentation |
+| tcpwrap                    | TCP wrapper support |
+| [UnicodeData.txt](https://www.unicode.org/Public/UNIDATA/UnicodeData.txt) | regenerating Unicode lookup tables |
 
 ## Build the software
 

--- a/config/dconf/meson.build
+++ b/config/dconf/meson.build
@@ -1,0 +1,5 @@
+install_data(
+    'netatalk',
+    install_dir: '/etc/dconf/profile',
+    install_tag: 'config',
+)

--- a/config/dconf/netatalk
+++ b/config/dconf/netatalk
@@ -1,0 +1,2 @@
+user-db:user
+system-db:netatalk

--- a/config/meson.build
+++ b/config/meson.build
@@ -11,6 +11,8 @@ else
 endif
 
 if have_spotlight
+    subdir('dconf')
+
     dbus_session_conf = configure_file(
         input: 'dbus-session.conf.in',
         output: 'dbus-session.conf',

--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -194,17 +194,6 @@ functionality.
     detection of host name spoofing or host address spoofing; booby traps
     to implement an early-warning system.
 
-- LocalSearch or Tracker
-
-    Netatalk uses [GNOME LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/index.html),
-    or Tracker as it was previously known, version 3 or later as the metadata backend for Spotlight
-    compatible search indexing.
-
-- talloc / bison / flex
-
-    Samba's talloc library, a Yacc parser such as bison, and a lexer like
-    flex are also required for Spotlight.
-
 - UnicodeData.txt
 
     The [Unicode Character Database](https://www.unicode.org/Public/UNIDATA/UnicodeData.txt)
@@ -212,6 +201,48 @@ functionality.
 
     This is mostly relevant for developers or package managers who want to regenerate
     the Unicode source files.
+
+### Spotlight dependencies
+
+Netatalk's Spotlight support relies on the following third-party software:
+
+- bison
+
+    A Yacc parser such as bison is required to build the SPARQL query parser
+    for Spotlight support.
+
+- DConf
+
+    DConf is a low-level configuration system that can be used to store
+    Netatalk's Spotlight related settings. It is used in combination with
+    D-Bus to trigger updates of the Spotlight indexer when Netatalk's
+    configuration changes.
+
+- flex
+
+    A lexer like flex is required to build the SPARQL query parser for
+    Spotlight support.
+
+- LocalSearch
+
+    Netatalk uses [GNOME LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/index.html),
+    or Tracker as it was previously known, version 3 or later as the metadata extractor for Spotlight
+    compatible search indexing.
+
+    You can add metadata extraction support for additional file types
+    by installing the appropriate Tracker extractors.
+
+- talloc
+
+    Samba's talloc library is used for memory management in the Spotlight query parser.
+
+- TinySPARQL
+
+    The [TinySPARQL](https://tracker.gnome.org/) library is used
+    for parsing SPARQL queries in the Spotlight support.
+
+**Note:** LocalSearch and TinySPARQL together were previously known as Tracker.
+Netatalk still supports the older Tracker v3 library and schema.
 
 ## Starting and stopping Netatalk
 

--- a/etc/afpd/spotlight.c
+++ b/etc/afpd/spotlight.c
@@ -485,9 +485,11 @@ static bool add_results(sl_array_t *array, slq_t *slq)
     }
 
     LOG(log_debug, logtype_sl,
-        "dispatching %d result(s) to client, status %" PRIu64 " (ctx1: %" PRIx64
-        ", ctx2: %" PRIx64 ")",
-        slq->query_results->num_results, status, slq->slq_ctx1, slq->slq_ctx2);
+        "add_results: dispatching %d result(s), status %" PRIu64
+        ", state=%s (ctx1: %" PRIx64 ", ctx2: %" PRIx64 ")",
+        slq->query_results->num_results, status,
+        slq_state_names[slq->slq_state].state_name,
+        slq->slq_ctx1, slq->slq_ctx2);
     dalloc_add_copy(array, &status, uint64_t);
     dalloc_add(array, slq->query_results->cnids, sl_cnids_t);
 
@@ -744,7 +746,9 @@ static void tracker_cursor_cb(GObject      *object,
     }
 
     if (!more_results) {
-        LOG(log_debug, logtype_sl, "tracker_cursor_cb: done");
+        LOG(log_debug, logtype_sl,
+            "tracker_cursor_cb: done, %d result(s) accumulated in this batch",
+            slq->query_results ? slq->query_results->num_results : -1);
         slq->slq_state = SLQ_STATE_DONE;
         return;
     }
@@ -801,8 +805,8 @@ static void tracker_cursor_cb(GObject      *object,
         }
     }
 
-    LOG(log_debug, logtype_sl, "adding result CNID %" PRIu32 ": %s",
-        ntohl(id), path);
+    LOG(log_debug, logtype_sl, "adding result CNID %" PRIu32 " (%s): %s",
+        ntohl(id), S_ISDIR(sb.st_mode) ? "dir" : "file", path);
     dalloc_add_copy(slq->query_results->cnids->ca_cnids,
                     &uint64var, uint64_t);
     ok = add_filemeta(slq->slq_reqinfo, slq->query_results->fm_array,
@@ -931,6 +935,14 @@ static int sl_rpc_fetchPropertiesForContext(const AFPObj *obj,
     b = true;
     dalloc_add_copy(dict, &b, sl_bool_t);
     dalloc_add(reply, dict, sl_dict_t);
+    LOG(log_debug, logtype_sl,
+        "fetchPropertiesForContext: vol=\"%s\", uuid=%s, is_backup=%s",
+        v->v_localname,
+        v->v_uuid ? v->v_uuid : "(null)",
+        (v->v_flags & AFPVOL_TM) ? "true" : "false");
+    LOG(log_debug, logtype_sl,
+        "fetchPropertiesForContext: kMDSStorePathScopes=\"%s\"",
+        v->v_path);
 EC_CLEANUP:
     EC_EXIT;
 }
@@ -1567,12 +1579,18 @@ int afp_spotlight_rpc(AFPObj *obj, char *ibuf, size_t ibuflen,
         RSIVAL(rbuf, 4, 0);
         len = (int)strlcpy(rbuf + 8, vol->v_path, MAXPATHLEN) + 1;
         *rbuflen += 8 + len;
+        LOG(log_debug, logtype_sl,
+            "SPOTLIGHT_CMD_OPEN%s: vid=%" PRIu16 ", path=\"%s\"",
+            cmd == SPOTLIGHT_CMD_OPEN2 ? "2" : "",
+            ntohs(vid), vol->v_path);
         break;
 
     case SPOTLIGHT_CMD_FLAGS:
         /* Whatever this value means... flags? Helios uses 0x1eefface */
         RSIVAL(rbuf, 0, 0x0100006b);
         *rbuflen += 4;
+        LOG(log_debug, logtype_sl,
+            "SPOTLIGHT_CMD_FLAGS: returning 0x0100006b");
         break;
 
     case SPOTLIGHT_CMD_RPC:

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -22,6 +22,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/param.h>
+#include <sys/stat.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/time.h>
@@ -99,82 +100,111 @@ static bool service_running(pid_t pid)
 }
 
 #ifdef WITH_SPOTLIGHT
-/*! Set indexers to index all our volumes */
+/*! Create directory and all missing parent directories (like mkdir -p) */
+static int makedirs(const char *path, mode_t mode)
+{
+    char tmp[PATH_MAX];
+    char *p;
+
+    if (strlcpy(tmp, path, sizeof(tmp)) >= sizeof(tmp)) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+
+    for (p = tmp + 1; *p; p++) {
+        if (*p == '/') {
+            *p = '\0';
+
+            if (mkdir(tmp, mode) != 0 && errno != EEXIST) {
+                return -1;
+            }
+
+            *p = '/';
+        }
+    }
+
+    if (mkdir(tmp, mode) != 0 && errno != EEXIST) {
+        return -1;
+    }
+
+    return 0;
+}
+
+/*! Set indexers to index all our volumes via a dconf keyfile */
 static int set_sl_volumes(void)
 {
     EC_INIT;
     const struct vol *volumes, *vol;
-    struct bstrList *vollist = bstrListCreate();
+    FILE *fp = NULL;
     int sysret;
-    bstring sep = bfromcstr(", ");
-    bstring volnamelist = NULL, cmd = NULL;
+    bool first;
     EC_NULL_LOG(volumes = getvolumes());
+
+    if (makedirs(INDEXER_DCONF_DB_DIR, 0755) != 0) {
+        LOG(log_error, logtype_sl,
+            "set_sl_volumes: failed to create " INDEXER_DCONF_DB_DIR ": %s",
+            strerror(errno));
+        EC_FAIL;
+    }
+
+    if ((fp = fopen(INDEXER_DCONF_DB_DIR "/10-spotlight", "w")) == NULL) {
+        LOG(log_error, logtype_sl,
+            "set_sl_volumes: failed to open " INDEXER_DCONF_DB_DIR "/10-spotlight: %s",
+            strerror(errno));
+        EC_FAIL;
+    }
+
+    fprintf(fp, "[" INDEXER_DCONF_PATH "]\n");
+    /* Collect Spotlight-enabled volume paths */
+    first = true;
 
     for (vol = volumes; vol; vol = vol->v_next) {
         if (vol->v_flags & AFPVOL_SPOTLIGHT) {
-            bstring volnamequot = bformat("'%s'", vol->v_path);
-
-            if (vollist->qty == vollist->mlen
-                    && bstrListAlloc(vollist, vollist->qty + 1) != BSTR_OK) {
-                LOG(log_error, logtype_default,
-                    "set_sl_volumes: failed to initialize indexing for %s",
-                    bdata(volnamequot));
+            if (first) {
+                fprintf(fp, "index-recursive-directories=['%s'", vol->v_path);
+                first = false;
+            } else {
+                fprintf(fp, ", '%s'", vol->v_path);
             }
-
-            vollist->entry[vollist->qty] = volnamequot;
-            vollist->qty++;
         }
     }
 
-    volnamelist = bjoin(vollist, sep);
-    cmd = bformat("gsettings set " INDEXER_DBUS_NAME
-                  " index-recursive-directories \"[%s]\"",
-                  bdata(volnamelist) ? bdata(volnamelist) : "");
-    LOG(log_debug, logtype_sl, "set_sl_volumes: %s", bdata(cmd));
-    sysret = system(bdata(cmd));
+    if (first) {
+        /* No Spotlight volumes: emit typed empty array so dconf update parses it */
+        fprintf(fp, "index-recursive-directories=@as []\n");
+    } else {
+        fprintf(fp, "]\n");
+    }
 
-    if (sysret == -1) {
-        LOG(log_error, logtype_sl, "set_sl_volumes: system() failed to run '%s': %s",
-            bdata(cmd), strerror(errno));
-        EC_FAIL;
-    } else if (sysret != 0) {
-        LOG(log_error, logtype_sl, "set_sl_volumes: command '%s' exited with status %d",
-            bdata(cmd), WEXITSTATUS(sysret));
+    fprintf(fp, "index-single-directories=@as []\n");
+
+    if (fflush(fp) != 0) {
+        LOG(log_error, logtype_sl,
+            "set_sl_volumes: failed to write " INDEXER_DCONF_DB_DIR "/10-spotlight: %s",
+            strerror(errno));
         EC_FAIL;
     }
 
-    /* Disable default root user home indexing */
-    sysret = system("gsettings set " INDEXER_DBUS_NAME
-                    " index-single-directories \"[]\"");
+    fclose(fp);
+    fp = NULL;
+    sysret = system(DCONF_UPDATE_COMMAND);
 
     if (sysret == -1) {
         LOG(log_error, logtype_sl,
-            "set_sl_volumes: system() failed to run disable home indexing: %s",
+            "set_sl_volumes: system() failed to run 'dconf update': %s",
             strerror(errno));
         EC_FAIL;
     } else if (sysret != 0) {
         LOG(log_error, logtype_sl,
-            "set_sl_volumes: disable home indexing exited with status %d",
+            "set_sl_volumes: 'dconf update' exited with status %d",
             WEXITSTATUS(sysret));
         EC_FAIL;
     }
 
 EC_CLEANUP:
 
-    if (cmd) {
-        bdestroy(cmd);
-    }
-
-    if (sep) {
-        bdestroy(sep);
-    }
-
-    if (vollist) {
-        bstrListDestroy(vollist);
-    }
-
-    if (volnamelist) {
-        bdestroy(volnamelist);
+    if (fp) {
+        fclose(fp);
     }
 
     EC_EXIT;
@@ -593,7 +623,6 @@ int main(int argc, char **argv)
 #ifndef WITH_LIBEV
     struct timeval tv;
 #endif
-    int sysret;
     /* Log SIGBUS/SIGSEGV SBT */
     fault_setup(NULL);
 
@@ -712,6 +741,7 @@ int main(int argc, char **argv)
     if (obj.options.flags & OPTION_SPOTLIGHT) {
         setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=" _PATH_STATEDIR "spotlight.ipc",
                1);
+        setenv("DCONF_PROFILE", INDEXER_DCONF_PROFILE, 1);
         setenv("XDG_DATA_HOME", _PATH_STATEDIR, 0);
         setenv("XDG_CACHE_HOME", _PATH_STATEDIR, 0);
         setenv("TRACKER_USE_LOG_FILES", "1", 0);
@@ -730,7 +760,7 @@ int main(int argc, char **argv)
         sleep(1);
         set_sl_volumes();
         LOG(log_note, logtype_default, "Starting indexer: " INDEXER_COMMAND " -s");
-        sysret = system(INDEXER_COMMAND " -s");
+        int sysret = system(INDEXER_COMMAND " -s");
 
         if (sysret == -1) {
             LOG(log_error, logtype_default,

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -194,10 +194,15 @@ static int set_sl_volumes(void)
             "set_sl_volumes: system() failed to run 'dconf update': %s",
             strerror(errno));
         EC_FAIL;
-    } else if (sysret != 0) {
+    } else if (WIFEXITED(sysret) && WEXITSTATUS(sysret) != 0) {
         LOG(log_error, logtype_sl,
             "set_sl_volumes: 'dconf update' exited with status %d",
             WEXITSTATUS(sysret));
+        EC_FAIL;
+    } else if (WIFSIGNALED(sysret)) {
+        LOG(log_error, logtype_sl,
+            "set_sl_volumes: 'dconf update' killed by signal %d",
+            WTERMSIG(sysret));
         EC_FAIL;
     }
 
@@ -274,10 +279,14 @@ static void sigterm_impl(void)
         LOG(log_error, logtype_afpd,
             "sigterm_cb: system() failed to run Spotlight indexer stop: %s",
             strerror(errno));
-    } else if (sysret != 0) {
+    } else if (WIFEXITED(sysret) && WEXITSTATUS(sysret) != 0) {
         LOG(log_error, logtype_afpd,
             "sigterm_cb: Spotlight indexer stop exited with status %d",
             WEXITSTATUS(sysret));
+    } else if (WIFSIGNALED(sysret)) {
+        LOG(log_error, logtype_afpd,
+            "sigterm_cb: Spotlight indexer stop killed by signal %d",
+            WTERMSIG(sysret));
     }
 
 #endif
@@ -295,10 +304,14 @@ static void sigquit_impl(void)
         LOG(log_error, logtype_afpd,
             "sigquit_cb: system() failed to run Spotlight indexer stop: %s",
             strerror(errno));
-    } else if (sysret != 0) {
+    } else if (WIFEXITED(sysret) && WEXITSTATUS(sysret) != 0) {
         LOG(log_error, logtype_afpd,
             "sigquit_cb: Spotlight indexer stop exited with status %d",
             WEXITSTATUS(sysret));
+    } else if (WIFSIGNALED(sysret)) {
+        LOG(log_error, logtype_afpd,
+            "sigquit_cb: Spotlight indexer stop killed by signal %d",
+            WTERMSIG(sysret));
     }
 
 #endif
@@ -766,9 +779,13 @@ int main(int argc, char **argv)
             LOG(log_error, logtype_default,
                 "system() failed to run Spotlight indexer start: %s", strerror(errno));
             netatalk_exit(EXITERR_CONF);
-        } else if (sysret != 0) {
+        } else if (WIFEXITED(sysret) && WEXITSTATUS(sysret) != 0) {
             LOG(log_error, logtype_default, "Spotlight indexer start exited with status %d",
                 WEXITSTATUS(sysret));
+            netatalk_exit(EXITERR_CONF);
+        } else if (WIFSIGNALED(sysret)) {
+            LOG(log_error, logtype_default, "Spotlight indexer start killed by signal %d",
+                WTERMSIG(sysret));
             netatalk_exit(EXITERR_CONF);
         }
     }

--- a/meson.build
+++ b/meson.build
@@ -1118,20 +1118,59 @@ if get_option('with-spotlight')
     indexer_found = false
     localsearch = find_program('localsearch', required: false)
     tracker3 = find_program('tracker3', required: false)
+    gsettings = find_program('gsettings', required: false)
+    dconf = find_program('dconf', required: false)
 
-    if localsearch.found()
-        indexer_found = true
-        cdata.set('INDEXER_DBUS_NAME', '"org.freedesktop.LocalSearch3"')
-        cdata.set('INDEXER_COMMAND', '"' + localsearch.full_path() + ' daemon"')
-    elif tracker3.found()
-        indexer_found = true
-        cdata.set('INDEXER_DBUS_NAME', '"org.freedesktop.Tracker3.Miner.Files"')
-        cdata.set('INDEXER_COMMAND', '"' + tracker3.full_path() + ' daemon"')
+    localsearch3_schema_found = false
+    tracker3_schema_found = false
+    if gsettings.found()
+        localsearch3_schema_check = run_command(
+            gsettings,
+            'list-keys',
+            'org.freedesktop.LocalSearch3.Miner.Files',
+            check: false,
+        )
+        tracker3_schema_check = run_command(
+            gsettings,
+            'list-keys',
+            'org.freedesktop.Tracker3.Miner.Files',
+            check: false,
+        )
+        localsearch3_schema_found = localsearch3_schema_check.returncode() == 0
+        tracker3_schema_found = tracker3_schema_check.returncode() == 0
     endif
 
+    indexer = disabler()
+    if localsearch.found()
+        indexer = localsearch
+    elif tracker3.found()
+        indexer = tracker3
+    endif
+
+    if indexer.found() and localsearch3_schema_found
+        indexer_found = true
+        cdata.set('INDEXER_DBUS_NAME', '"org.freedesktop.LocalSearch3"')
+        cdata.set(
+            'INDEXER_DCONF_PATH',
+            '"org/freedesktop/localsearch/miner/files"',
+        )
+        cdata.set('INDEXER_COMMAND', '"' + indexer.full_path() + ' daemon"')
+    elif indexer.found() and tracker3_schema_found
+        indexer_found = true
+        cdata.set('INDEXER_DBUS_NAME', '"org.freedesktop.Tracker3.Miner.Files"')
+        cdata.set(
+            'INDEXER_DCONF_PATH',
+            '"org/freedesktop/tracker/miner/files"',
+        )
+        cdata.set('INDEXER_COMMAND', '"' + indexer.full_path() + ' daemon"')
+    endif
+
+    cdata.set('INDEXER_DCONF_DB_DIR', '"/etc/dconf/db/netatalk.d"')
+    cdata.set('INDEXER_DCONF_PROFILE', '"/etc/dconf/profile/netatalk"')
     have_spotlight = (
         sparql_found
         and indexer_found
+        and dconf.found()
         and talloc.found()
         and flex.found()
         and bison.found()
@@ -1139,9 +1178,13 @@ if get_option('with-spotlight')
 
     if have_spotlight
         cdata.set('WITH_SPOTLIGHT', 1)
+        cdata.set('DCONF_UPDATE_COMMAND', '"' + dconf.full_path() + ' update"')
+        if get_option('with-install-hooks')
+            meson.add_install_script(dconf, 'update')
+        endif
     else
         warning(
-            'Spotlight support requested but required libraries not found',
+            'Spotlight support requested but one or more required dependencies not found',
         )
     endif
 endif

--- a/meson_config.h
+++ b/meson_config.h
@@ -403,6 +403,18 @@
 /* Indexer D-Bus name */
 #mesondefine INDEXER_DBUS_NAME
 
+/* Indexer dconf keyfile path (schema with dots replaced by slashes, lowercased) */
+#mesondefine INDEXER_DCONF_PATH
+
+/* Directory for the netatalk dconf database keyfiles */
+#mesondefine INDEXER_DCONF_DB_DIR
+
+/* Path to the netatalk dconf profile file */
+#mesondefine INDEXER_DCONF_PROFILE
+
+/* dconf update command with absolute path */
+#mesondefine DCONF_UPDATE_COMMAND
+
 /* Define if cracklib should be used */
 #mesondefine USE_CRACKLIB
 


### PR DESCRIPTION
The current gsettings set approach to starting the localsearch indexer is unreliable at runtime because gsettings requires a dconf-service on the session bus, which netatalk's private dbus-daemon does not auto-activate.

Replace set_sl_volumes() with a dconf keyfile writer: it creates /etc/dconf/db/netatalk.d/10-spotlight and runs dconf update, which works without any session bus. Add DCONF_PROFILE env so the indexer reads from the netatalk-specific database. Ship config/dconf/netatalk (system-db:netatalk) as the dconf profile, installed to $sysconfdir/dconf/profile/. Detect the dconf binary at build time and gate have_spotlight on it instead of gsettings.

This introduces a new runtime dependency dconf instead of gsettings.

In meson, decouple indexer binary detection from GSettings schema detection:

On Debian Trixie, the localsearch binary is present but ships the Tracker3 GSettings schema rather than LocalSearch3. Decouple binary and schema selection so that any available binary (localsearch preferred, tracker3 as fallback) is paired with whichever schema is actually installed.