### PR TITLE
[4.4] libatalk: map logtype identifiers correctly with the enum

### DIFF
--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -724,7 +724,8 @@ should be logged.
 > By default afpd logs to syslog with a default logging setup equivalent
 to **default:note**
 >
-> logtypes: default, logger, cnid, afpd, dsi, uams, fce, ad, sl
+> logtypes: default, logger, cnid, afpdaemon, dsi, atalkdaemon, papdaemon,
+uams, fce, ad, spotlight
 >
 > loglevels: severe, error, warn, note, info, debug, debug6, debug7,
 debug8, debug9, maxdebug

--- a/libatalk/util/logger.c
+++ b/libatalk/util/logger.c
@@ -59,6 +59,8 @@ Netatalk 2001 (c)
   "CNID",                            \
   "AFPDaemon",                       \
   "DSI",                             \
+  "ATalkDaemon",                     \
+  "PAPDaemon",                       \
   "UAMS",                            \
   "FCE",                             \
   "ad",                              \


### PR DESCRIPTION
ATalkDaemon and PAPDaemon were present in the enum but absent from the string identifier array, shifting every entry from UAMS onward by -2. As a result, f.e. "spotlight:debug" in afp.conf resolved to logtype_fce (index 8) rather than logtype_sl (index 10), so Spotlight debug logging could never be enabled via the config file.

Add the two missing entries to restore correct alignment, while correcting man page documentation; this has
probably been broken ever since we grafted AppleTalk onto v4.0.