### PR TITLE
[4.4] libatalk: fix OOB access when "end_of_list_marker" is passed as logtype

### DIFF
--- a/libatalk/util/logger.c
+++ b/libatalk/util/logger.c
@@ -407,7 +407,7 @@ static void setuplog_internal(const char *loglevel, const char *logtype,
         }
     }
 
-    if (typenum >= num_logtype_strings) {
+    if (typenum >= (unsigned int)logtype_end_of_list_marker) {
         return;
     }
 


### PR DESCRIPTION
The bound check in setuplog_internal() compared typenum against num_logtype_strings, which includes the sentinel "end_of_list_marker" entry. This allowed typenum == logtype_end_of_list_marker (11) to pass the guard and index type_configs[] out of bounds (sized for indices 0-10).

Fix by comparing against logtype_end_of_list_marker directly, which is the actual size of type_configs[].