### PR TITLE
afpd: Adjust date-time values for Apple II clients.

### DIFF
--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -2164,6 +2164,7 @@ int getdirparams(const AFPObj *obj,
     cnid_t              pdid;
     struct stat *st = &s_path->st;
     char *upath = s_path->u_name;
+    int                 timeoffset = 0;
 
     if (bitmap & ((1 << DIRPBIT_ATTR)  |
                   (1 << DIRPBIT_CDATE) |
@@ -2181,6 +2182,11 @@ int getdirparams(const AFPObj *obj,
 
     pdid = dir->d_pdid;
     data = buf;
+
+    /* If this is a ProDOS client, adjust date-time values to match local time */
+    if (obj->afp_version < 30 && (bitmap & 1 << FILPBIT_PDINFO)) {
+        timeoffset = 1;
+    }
 
     while (bitmap != 0) {
         while ((bitmap & 1) == 0) {
@@ -2215,12 +2221,21 @@ int getdirparams(const AFPObj *obj,
                 aint = AD_DATE_FROM_UNIX(st->st_mtime);
             }
 
+            if (timeoffset == 1) {
+                set_utc_offset(&aint, TO_LOCALTIME);
+            }
+
             memcpy(data, &aint, sizeof(aint));
             data += sizeof(aint);
             break;
 
         case DIRPBIT_MDATE :
             aint = AD_DATE_FROM_UNIX(st->st_mtime);
+
+            if (timeoffset == 1) {
+                set_utc_offset(&aint, TO_LOCALTIME);
+            }
+
             memcpy(data, &aint, sizeof(aint));
             data += sizeof(aint);
             break;
@@ -2228,6 +2243,10 @@ int getdirparams(const AFPObj *obj,
         case DIRPBIT_BDATE :
             if (!ad_available || (ad_getdate(&ad, AD_DATE_BACKUP, &aint) < 0)) {
                 aint = AD_DATE_START;
+            }
+
+            if (timeoffset == 1 && aint != AD_DATE_START) {
+                set_utc_offset(&aint, TO_LOCALTIME);
             }
 
             memcpy(data, &aint, sizeof(aint));
@@ -2493,23 +2512,29 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap,
     char                *ade = NULL;
     struct dir          *dir;
     int         bit, isad = 0;
-    int                 cdate, bdate;
+    uint32_t                 cdate, bdate;
     int                 owner, group;
     uint16_t       ashort, bshort, oshort;
     int                 err = AFP_OK;
     int                 change_mdate = 0;
     int                 change_parent_mdate = 0;
-    int                 newdate = 0;
+    uint32_t                 newdate = 0;
     uint16_t           bitmap = d_bitmap;
     uint8_t              finder_buf[32];
     uint32_t       upriv;
     mode_t              mpriv = 0;
+    int                 timeoffset = 0;
     bool                set_upriv = false, set_maccess = false;
     LOG(log_debug, logtype_afpd, "setdirparams(\"%s\", bitmap: %02x)", path->u_name,
         bitmap);
     bit = 0;
     upath = path->u_name;
     dir   = path->d_dir;
+
+    /* If this is a ProDOS client, adjust date-time values to match UTC time */
+    if (vol->v_obj->afp_version < 30 && (bitmap & 1 << FILPBIT_PDINFO)) {
+        timeoffset = 1;
+    }
 
     while (bitmap != 0) {
         while ((bitmap & 1) == 0) {
@@ -2528,17 +2553,26 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap,
             change_mdate = 1;
             memcpy(&cdate, buf, sizeof(cdate));
             buf += sizeof(cdate);
+            if (timeoffset == 1) {
+                set_utc_offset(&cdate, TO_UTC);
+            }
             break;
 
         case DIRPBIT_MDATE :
             memcpy(&newdate, buf, sizeof(newdate));
             buf += sizeof(newdate);
+            if (timeoffset == 1) {
+                set_utc_offset(&newdate, TO_UTC);
+            }
             break;
 
         case DIRPBIT_BDATE :
             change_mdate = 1;
             memcpy(&bdate, buf, sizeof(bdate));
             buf += sizeof(bdate);
+            if (timeoffset == 1 && bdate != AD_DATE_START) {
+                set_utc_offset(&bdate, TO_UTC);
+            }
             break;
 
         case DIRPBIT_FINFO :

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -321,6 +321,7 @@ int getmetadata(const AFPObj *obj,
     uint32_t           utf8 = 0;
     struct stat         *st;
     struct maccess	ma;
+    int                 timeoffset = 0;
     LOG(log_debug, logtype_afpd, "getmetadata(\"%s\")", path->u_name);
     upath = path->u_name;
     st = &path->st;
@@ -410,6 +411,10 @@ int getmetadata(const AFPObj *obj,
             path->m_name = utompath(vol, upath, id, utf8_encoding(vol->v_obj));
         }
     }
+    /* If this is a ProDOS client, adjust date-time values to match local time */
+    if (obj->afp_version < 30 && (bitmap & 1 << FILPBIT_PDINFO)) {
+        timeoffset = 1;
+    }
 
     while (bitmap != 0) {
         while ((bitmap & 1) == 0) {
@@ -460,6 +465,9 @@ int getmetadata(const AFPObj *obj,
             if (!adp || (ad_getdate(adp, AD_DATE_CREATE, &aint) < 0)) {
                 aint = AD_DATE_FROM_UNIX(st->st_mtime);
             }
+            if (timeoffset == 1) {
+                set_utc_offset(&aint, TO_LOCALTIME);
+            }
 
             memcpy(data, &aint, sizeof(aint));
             data += sizeof(aint);
@@ -473,6 +481,9 @@ int getmetadata(const AFPObj *obj,
             } else {
                 aint = AD_DATE_FROM_UNIX(st->st_mtime);
             }
+            if (timeoffset == 1) {
+                set_utc_offset(&aint, TO_LOCALTIME);
+            }
 
             memcpy(data, &aint, sizeof(int));
             data += sizeof(int);
@@ -481,6 +492,9 @@ int getmetadata(const AFPObj *obj,
         case FILPBIT_BDATE :
             if (!adp || (ad_getdate(adp, AD_DATE_BACKUP, &aint) < 0)) {
                 aint = AD_DATE_START;
+            }
+            if (timeoffset == 1 && aint != AD_DATE_START) {
+                set_utc_offset(&aint, TO_LOCALTIME);
             }
 
             memcpy(data, &aint, sizeof(int));
@@ -1036,7 +1050,7 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
     struct utimbuf	ut;
     int                 change_mdate = 0;
     int                 change_parent_mdate = 0;
-    int                 newdate = 0;
+    uint32_t                 newdate = 0;
     struct timeval      tv;
     uid_t		f_uid;
     gid_t		f_gid;
@@ -1047,6 +1061,7 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
     int fp;
     ssize_t len;
     char symbuf[MAXPATHLEN + 1];
+    int                 timeoffset = 0;
     LOG(log_debug9, logtype_afpd, "begin setfilparams:");
 
     if (path == NULL) {
@@ -1062,6 +1077,11 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
 
     /* with unix priv maybe we have to change adouble file priv first */
     bit = 0;
+
+    /* If this is a ProDOS client, adjust date-time values to match UTC time */
+    if (obj->afp_version < 30 && (bitmap & 1 << FILPBIT_PDINFO)) {
+        timeoffset = 1;
+    }
 
     while (bitmap != 0) {
         while ((bitmap & 1) == 0) {
@@ -1085,17 +1105,26 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
             change_mdate = 1;
             memcpy(&cdate, buf, sizeof(cdate));
             buf += sizeof(cdate);
+            if (timeoffset == 1) {
+                set_utc_offset(&cdate, TO_UTC);
+            }
             break;
 
         case FILPBIT_MDATE :
             memcpy(&newdate, buf, sizeof(newdate));
             buf += sizeof(newdate);
+            if (timeoffset == 1) {
+                set_utc_offset(&newdate, TO_UTC);
+            }
             break;
 
         case FILPBIT_BDATE :
             change_mdate = 1;
             memcpy(&bdate, buf, sizeof(bdate));
             buf += sizeof(bdate);
+            if (timeoffset == 1 && bdate != AD_DATE_START) {
+                set_utc_offset(&bdate, TO_UTC);
+            }
             break;
 
         case FILPBIT_FINFO :

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -40,6 +40,47 @@
 #include "virtual_icon.h"
 #include "volume.h"
 
+/*! 
+ * @brief Convert an AFP date-time value between local time and UTC.
+ * @param aint_p AFP date-time to be converted.
+ * @param offset_dir Which direction we want to convert the timestamp.
+ */
+int set_utc_offset(uint32_t *aint_p, int offset_dir)
+{
+    /* If we somehow pass the earliest AFP date-time available, just exit. */
+    if (*aint_p == AD_DATE_START) {
+        return 0;
+    }
+    struct timeval tv;
+    tv.tv_sec = AD_DATE_TO_UNIX(*aint_p);
+    tv.tv_usec = 0;
+    struct tm tm;
+
+    if (offset_dir == TO_LOCALTIME) {
+        if (localtime_r(&tv.tv_sec, &tm) == NULL) {
+            LOG(log_error, logtype_default, "set_utc_offset: localtime_r: %s", strerror(errno));
+            return -1;
+        }
+        tv.tv_sec = timegm(&tm);
+        *aint_p = AD_DATE_FROM_UNIX(tv.tv_sec);
+    }
+    else {
+        /* 
+         * This won't work reliably during the transition to/from DST. 
+         * The timestamp may be a hour off during the transistion back
+         * to standard time at 0200 hours.
+         */
+        if (gmtime_r(&tv.tv_sec, &tm) == NULL) {
+            LOG(log_error, logtype_default, "set_utc_offset: gmtime_r: %s", strerror(errno));
+            return -1;
+        }
+        tm.tm_isdst = -1;
+        tv.tv_sec = mktime(&tm);
+        *aint_p = AD_DATE_FROM_UNIX(tv.tv_sec);
+    }
+    return 0;
+}
+
 static int virtual_icon_reply(const AFPObj *obj, struct vol *vol,
                               uint16_t fbitmap, uint16_t dbitmap,
                               char *rbuf, size_t *rbuflen)

--- a/etc/afpd/filedir.h
+++ b/etc/afpd/filedir.h
@@ -9,6 +9,10 @@
 
 extern struct afp_options default_options;
 
+#define TO_UTC 0
+#define TO_LOCALTIME 1
+
+extern int set_utc_offset(uint32_t *aint_p, int offset_dir);
 extern char *ctoupath(const struct vol *, struct dir *, char *);
 extern char *absupath(const struct vol *, struct dir *, char *);
 extern int veto_file(const char *veto_str, const char *path);


### PR DESCRIPTION
Unlike Macintosh clients, Apple II clients do not apply an offset to date-time values as described in page 13-22 of "Inside AppleTalk". Since Netatalk maintains all date-time values in UTC, this resulted in the wrong date-time values appearing on Apple II clients. Additionally, incorrect date-time values were being written to the server by the client as well.

Observed behavior of Apple II clients show that they almost always set the ProDOS Info bit when reading or writing date-time values via the FPGetFileDirParams and FPSetFileDirParams calls. When this condition is met, shift the date-time value to server's local time when sending to client and shift any date-time received by to client to UTC.

It goes without saying, that this will only work correctly if both the Apple II client and the server's local time are set to the same time zone.

Fixes #2899