### PR TITLE
docs: build Doxygen docs for the yacc and lexer code

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -349,7 +349,7 @@ OPTIMIZE_OUTPUT_SLICE  = NO
 #
 # Note see also the list of default file extension mappings.
 
-EXTENSION_MAPPING      =
+EXTENSION_MAPPING      = y=C
 
 # If the MARKDOWN_SUPPORT tag is enabled then Doxygen pre-processes all comments
 # according to the Markdown format, which allows for more readable
@@ -1031,7 +1031,7 @@ INPUT_FILE_ENCODING    =
 # provided as Doxygen C comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08,
 # *.f18, *.f, *.for, *.vhd, *.vhdl, *.ucf, *.qsf and *.ice.
 
-FILE_PATTERNS          = */developer/*.md *.c *.h
+FILE_PATTERNS          = */developer/*.md *.c *.h *.l *.y
 
 # The RECURSIVE tag can be used to specify whether or not subdirectories should
 # be searched for input files as well.
@@ -1135,7 +1135,7 @@ INPUT_FILTER           =
 # need to set EXTENSION_MAPPING for the extension otherwise the files are not
 # properly processed by Doxygen.
 
-FILTER_PATTERNS        = *.md=./doxygen_filter_mermaid.sh
+FILTER_PATTERNS        = *.md=./doxygen_filter_mermaid.sh *.y=./doxygen_filter_yacc.sh
 
 # If the FILTER_SOURCE_FILES tag is set to YES, the input filter (if set using
 # INPUT_FILTER) will also be used to filter the input files that are used for

--- a/doc/doxygen_filter_yacc.sh
+++ b/doc/doxygen_filter_yacc.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+
+# Simple doxygen filter script for yacc/bison .y grammar files.
+# Strips yacc-specific syntax so Doxygen can parse the C code sections:
+#
+#   %{ ... %}    C prologue block — %{ / %} markers stripped, contents kept
+#   %directive   Single-line and brace-block yacc directives — skipped entirely
+#   %% ... %%    Grammar rules section — skipped entirely
+#   (after %%)   C epilogue — passed through unchanged
+#
+# Copyright (C) 2026  Daniel Markstedt <daniel@mindani.net>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+STATE=NORMAL
+brace_depth=0
+
+while IFS= read -r line; do
+    case "$STATE" in
+
+        NORMAL)
+            case "$line" in
+                '%%')
+                    # First %% — enter grammar rules section
+                    STATE=GRAMMAR
+                    ;;
+                '%{')
+                    # C prologue block starts — keep contents, drop markers
+                    STATE=C_BLOCK
+                    ;;
+                '%'*)
+                    # Yacc directive (e.g. %token, %union, %code, %define, %type).
+                    # If it opens a brace block, skip until the block closes.
+                    STATE=YACC_DIRECTIVE
+                    brace_depth=0
+                    opens=$(printf '%s' "$line" | tr -cd '{' | wc -c)
+                    closes=$(printf '%s' "$line" | tr -cd '}' | wc -c)
+                    brace_depth=$((brace_depth + opens - closes))
+                    if [ "$brace_depth" -le 0 ]; then
+                        # Single-line directive with no open brace block
+                        STATE=NORMAL
+                    fi
+                    ;;
+                *)
+                    printf '%s\n' "$line"
+                    ;;
+            esac
+            ;;
+
+        C_BLOCK)
+            # Inside %{ ... %} — output C code, stop at %}
+            case "$line" in
+                '%}') STATE=NORMAL ;;
+                *) printf '%s\n' "$line" ;;
+            esac
+            ;;
+
+        YACC_DIRECTIVE)
+            # Inside a brace-block yacc directive — skip lines, track depth
+            opens=$(printf '%s' "$line" | tr -cd '{' | wc -c)
+            closes=$(printf '%s' "$line" | tr -cd '}' | wc -c)
+            brace_depth=$((brace_depth + opens - closes))
+            if [ "$brace_depth" -le 0 ]; then
+                STATE=NORMAL
+            fi
+            ;;
+
+        GRAMMAR)
+            # Between the two %% markers — skip grammar rules
+            case "$line" in
+                '%%') STATE=EPILOGUE ;;
+                *) ;;
+            esac
+            ;;
+
+        EPILOGUE)
+            # C epilogue after second %% — pass through unchanged
+            printf '%s\n' "$line"
+            ;;
+
+        *)
+            ;;
+
+    esac
+done < "${1}"

--- a/etc/spotlight/sparql_parser.y
+++ b/etc/spotlight/sparql_parser.y
@@ -348,7 +348,7 @@ int yywrap()
     return 1;
 }
 
-/**
+/*!
  * Map a Spotlight RAW query string to a SPARQL query string
  *
  * @param[in]     slq            Spotlight query handle


### PR DESCRIPTION
make Doxygen parse *.y files as C, and strip out the yacc grammar for the purpose of documentation of the symbols