### PR TITLE
docker: load RandNum/SRP UAMs only when password init succeeds

### DIFF
--- a/bin/afppasswd/afppasswd.c
+++ b/bin/afppasswd/afppasswd.c
@@ -282,7 +282,7 @@ static int update_srp_passwd(const char *path, const char *name, int flags,
     pass_len = strnlen(pass, SRP_PASSWDLEN + 1);
 
     if (pass_len > SRP_PASSWDLEN) {
-        fprintf(stderr, "afppasswd: max password length is %d.\n", SRP_PASSWDLEN);
+        fprintf(stderr, "afppasswd: max SRP password length is %d.\n", SRP_PASSWDLEN);
         return -1;
     }
 
@@ -421,7 +421,7 @@ found_entry:
         size_t passwd_len = strnlen(passwd, SRP_PASSWDLEN + 1);
 
         if (passwd_len > SRP_PASSWDLEN) {
-            fprintf(stderr, "afppasswd: max password length is %d.\n", SRP_PASSWDLEN);
+            fprintf(stderr, "afppasswd: max SRP password length is %d.\n", SRP_PASSWDLEN);
             err = -1;
             goto done;
         }
@@ -630,7 +630,7 @@ found_entry:
         size_t passwd_len = strnlen(passwd, PASSWDLEN + 1);
 
         if (passwd_len > PASSWDLEN) {
-            fprintf(stderr, "afppasswd: max password length is %d.\n", PASSWDLEN);
+            fprintf(stderr, "afppasswd: max RandNum password length is %d.\n", PASSWDLEN);
             err = -1;
             goto update_done;
         }
@@ -855,7 +855,7 @@ int main(int argc, char **argv)
 
     /* Validate password length for RandNum mode */
     if ((flags & OPT_RANDNUM) && strnlen(pass, PASSWDLEN + 1) > PASSWDLEN) {
-        fprintf(stderr, "afppasswd: max password length is %d.\n", PASSWDLEN);
+        fprintf(stderr, "afppasswd: max RandNum password length is %d.\n", PASSWDLEN);
         return -1;
     }
 
@@ -863,12 +863,12 @@ int main(int argc, char **argv)
 
     if (flags & OPT_CREATE) {
         if ((flags & OPT_ISROOT) == 0) {
-            fprintf(stderr, "afppasswd: only root can create the password file.\n");
+            fprintf(stderr, "afppasswd: only root can create the RandNum password file.\n");
             return -1;
         }
 
         if (!i && ((flags & OPT_FORCE) == 0)) {
-            fprintf(stderr, "afppasswd: password file already exists.\n");
+            fprintf(stderr, "afppasswd: RandNum password file already exists.\n");
             return -1;
         }
 

--- a/distrib/docker/compose.yml
+++ b/distrib/docker/compose.yml
@@ -11,6 +11,8 @@ services:
     environment:
       - AFP_USER=
       - AFP_PASS=
+      - AFP_USER2=
+      - AFP_PASS2=
       - AFP_GROUP=afpusers
       - ATALKD_INTERFACE=
       - TZ=

--- a/distrib/docker/debug_entrypoint_netatalk.sh
+++ b/distrib/docker/debug_entrypoint_netatalk.sh
@@ -210,13 +210,13 @@ stop_flamegraph_profiling() {
     NETATALK_SYMS="/tmp/netatalk_syms.txt"
     {
         # All Netatalk binaries (afpd is the profiled process)
-        nm -D /usr/local/sbin/netatalk 2>/dev/null
-        nm -D /usr/local/sbin/afpd 2>/dev/null
-        nm -D /usr/local/sbin/cnid_dbd 2>/dev/null
-        nm -D /usr/local/sbin/cnid_metad 2>/dev/null
+        nm -D /usr/local/sbin/netatalk 2> /dev/null
+        nm -D /usr/local/sbin/afpd 2> /dev/null
+        nm -D /usr/local/sbin/cnid_dbd 2> /dev/null
+        nm -D /usr/local/sbin/cnid_metad 2> /dev/null
         # Shared library and UAM modules
-        nm -D /usr/local/lib/libatalk.so* 2>/dev/null
-        nm -D /usr/local/lib/netatalk/*.so 2>/dev/null
+        nm -D /usr/local/lib/libatalk.so* 2> /dev/null
+        nm -D /usr/local/lib/netatalk/*.so 2> /dev/null
     } | awk '/^[0-9a-f]+ [TtWw] / { print $3 }' | sort -u > "$NETATALK_SYMS"
 
     NETATALK_SYM_COUNT=$(wc -l < "$NETATALK_SYMS")

--- a/distrib/docker/env_setup_netatalk.sh
+++ b/distrib/docker/env_setup_netatalk.sh
@@ -48,7 +48,7 @@ fi
 # Validate required environment variables and create users / groups
 # --------------------------------------------------------------------------
 
-echo "*** Setting up users and groups"
+echo "*** Setting up first AFP user"
 
 if [ -z "$AFP_USER" ]; then
     echo "ERROR: AFP_USER needs to be set to use this container." >&2
@@ -99,13 +99,23 @@ if [ -f "/etc/netatalk/afppasswd.srp" ]; then
     rm -f /etc/netatalk/afppasswd.srp
 fi
 
+UAMS="uams_dhx.so uams_dhx2.so"
+
 # Creating credentials for the RandNum UAM
+RANDNUM_OK=0
 afppasswd -c -r
-afppasswd -a "$AFP_USER" -f -r -w "$AFP_PASS" > /dev/null
+
+if afppasswd -a "$AFP_USER" -f -r -w "$AFP_PASS" > /dev/null; then
+    RANDNUM_OK=1
+fi
 
 # Creating credentials for the SRP UAM
+SRP_OK=0
 afppasswd -c
-afppasswd -a "$AFP_USER" -f -w "$AFP_PASS" > /dev/null
+
+if afppasswd -a "$AFP_USER" -f -w "$AFP_PASS" > /dev/null; then
+    SRP_OK=1
+fi
 
 # Optional second user
 if [ -n "$AFP_DROPBOX" ]; then
@@ -115,6 +125,8 @@ if [ -n "$AFP_DROPBOX" ]; then
         usermod -aG $AFP_GROUP nobody 2> /dev/null || true
     fi
 elif [ -n "$AFP_USER2" ]; then
+    echo "*** Setting up second AFP user"
+
     if [ "$DISTRO" = "$DISTRO_ALPINE" ]; then
         adduser --no-create-home --disabled-password "$AFP_USER2" 2> /dev/null || true
         addgroup "$AFP_USER2" "$AFP_GROUP"
@@ -122,9 +134,26 @@ elif [ -n "$AFP_USER2" ]; then
         adduser --no-create-home --disabled-password --gecos '' "$AFP_USER2" 2> /dev/null || true
         usermod -aG $AFP_GROUP $AFP_USER2 2> /dev/null || true
     fi
+
     echo "$AFP_USER2:$AFP_PASS2" | chpasswd > /dev/null 2>&1
-    afppasswd -a "$AFP_USER2" -f -r -w "$AFP_PASS2" > /dev/null
-    afppasswd -a "$AFP_USER2" -f -w "$AFP_PASS2" > /dev/null
+
+    if ! afppasswd -a "$AFP_USER2" -f -r -w "$AFP_PASS2" > /dev/null; then
+        RANDNUM_OK=0
+    fi
+    if ! afppasswd -a "$AFP_USER2" -f -w "$AFP_PASS2" > /dev/null; then
+        SRP_OK=0
+    fi
+fi
+
+if [ "$RANDNUM_OK" = "1" ]; then
+    UAMS="$UAMS uams_randnum.so"
+else
+    echo "NOTE: uams_randnum.so will not be loaded"
+fi
+if [ "$SRP_OK" = "1" ]; then
+    UAMS="$UAMS uams_srp.so"
+else
+    echo "NOTE: uams_srp.so will not be loaded"
 fi
 
 # --------------------------------------------------------------------------
@@ -170,8 +199,6 @@ fi
 # --------------------------------------------------------------------------
 
 echo "*** Configuring Netatalk"
-UAMS="uams_dhx.so uams_dhx2.so uams_randnum.so uams_srp.so"
-
 ATALK_NAME="${SERVER_NAME:-$(hostname | cut -d. -f1)}"
 
 [ -n "$VERBOSE" ] && TEST_FLAGS="$TEST_FLAGS -v"


### PR DESCRIPTION
both RandNum and SRP UAMs are unusable if the password initialization fails, so this makes it so that we build the UAM list only after checking the afppasswd command return codes

this removes the implicit constraint of 8 char passwords for all UAMs

includes an improvement to afppasswd itself so that it prints for which UAM password initialization fails, which is more actionable information for the user

thanks to Evan Peterson for the bug report