### PR TITLE
default cooldown of 14 days for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,19 @@ updates:
     directory: "/.clusterfuzzlite"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
 
   - package-ecosystem: "docker"
     directory: "/distrib/docker"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14
 
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 14


### PR DESCRIPTION
we are not dependent on the latest and greatest dependencies so a 14 day cooldown would be reasonable to reduce supply chain security risk, while reducing  maintainer overhead to review version bumps

note that this cooldown rule does not apply to security patches