### PR TITLE
[4.4] docker: bump production container alpine base image from 3.23.2 to 3.23.4

### DIFF
--- a/distrib/docker/netatalk.Dockerfile
+++ b/distrib/docker/netatalk.Dockerfile
@@ -35,7 +35,7 @@ ARG BUILD_DEPS="\
     sqlite-dev \
     "
 
-FROM alpine:3.23.2@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62 AS build
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS build
 
 ARG RUN_DEPS
 ARG BUILD_DEPS
@@ -86,7 +86,7 @@ RUN meson setup build \
 
 RUN meson install --destdir=/staging/ -C build
 
-FROM alpine:3.23.2@sha256:865b95f46d98cf867a156fe4a135ad3fe50d2056aa3f25ed31662dff6da4eb62 AS deploy
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS deploy
 
 ARG RUN_DEPS
 ENV RUN_DEPS=$RUN_DEPS


### PR DESCRIPTION
the latest alpine base image contains numerous security patches, which are prudent to apply to the stable production container