### PR TITLE
ci: add pkg update command to FreeBSD build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -524,6 +524,7 @@ jobs:
           sync: sshfs
           prepare: |
             set -e
+            pkg update
             pkg install -y \
               avahi \
               bison \


### PR DESCRIPTION
the vmactions FreeBSD environment is in a state where `pkg update` has to be run, it errors out without it