### PR TITLE
ci: explicitly install BerkeleyDB in macOS spectest

### DIFF
--- a/.github/workflows/spectest-macos.yml
+++ b/.github/workflows/spectest-macos.yml
@@ -37,6 +37,7 @@ jobs:
         run: |
           brew update
           brew install \
+            berkeley-db@5 \
             bstring \
             cmark-gfm \
             cracklib \


### PR DESCRIPTION
something changed in the macOS runner that led to berkeley-db no longer being installed by default, so we now need to explicitly install it otherwise the spectest execution fails when the dbd CNID backend is not found