### PR TITLE
afpd: compliant error code for FPGetFileDirParms unknown Volume ID

### DIFF
--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -123,10 +123,8 @@ int afp_getfildirparams(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
     ibuf += sizeof(vid);
 
     if (NULL == (vol = getvolbyvid(vid))) {
-        /* was AFPERR_PARAM but it helps OS 10.3 when a volume has been removed
-         * from the list.
-         */
-        return AFPERR_ACCESS;
+        /* AFP 3.4 FPGetFileDirParms Table 32: unknown Volume ID is kFPParamErr. */
+        return AFPERR_PARAM;
     }
 
     memcpy(&did, ibuf, sizeof(did));


### PR DESCRIPTION
our code was emulating an OSX 10.3 quirk and returned AFPERR_ACCESS for unknown Volume ID in afp_getfiledirparams()

this changes our logic to be AFP 3.4 compliant, returning AFPERR_PARAM instead