### PR TITLE
afpd: Update file attribute handling for AFP 1.1 clients

### DIFF
--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -411,6 +411,7 @@ int getmetadata(const AFPObj *obj,
             path->m_name = utompath(vol, upath, id, utf8_encoding(vol->v_obj));
         }
     }
+
     /* If this is a ProDOS client, adjust date-time values to match local time */
     if (obj->afp_version < 30 && (bitmap & 1 << FILPBIT_PDINFO)) {
         timeoffset = 1;
@@ -433,6 +434,16 @@ int getmetadata(const AFPObj *obj,
             }
 
             ashort &= ~htons(vol->v_ignattr);
+
+            /*
+             * If this is an AFP 1.1 client we need to set the WriteInhibit
+             * flag if RenameInhibit and/or DeleteInhibit flags are set.
+             */
+            if (obj->afp_version < 20 && (ashort & htons(ATTRBIT_NORENAME)
+                                          || ashort & htons(ATTRBIT_NODELETE))) {
+                ashort |= htons(ATTRBIT_NOWRITE);
+            }
+
 #if 0
             /* FIXME do we want a visual clue if the file is read only
              */
@@ -465,6 +476,7 @@ int getmetadata(const AFPObj *obj,
             if (!adp || (ad_getdate(adp, AD_DATE_CREATE, &aint) < 0)) {
                 aint = AD_DATE_FROM_UNIX(st->st_mtime);
             }
+
             if (timeoffset == 1) {
                 set_utc_offset(&aint, TO_LOCALTIME);
             }
@@ -481,6 +493,7 @@ int getmetadata(const AFPObj *obj,
             } else {
                 aint = AD_DATE_FROM_UNIX(st->st_mtime);
             }
+
             if (timeoffset == 1) {
                 set_utc_offset(&aint, TO_LOCALTIME);
             }
@@ -493,6 +506,7 @@ int getmetadata(const AFPObj *obj,
             if (!adp || (ad_getdate(adp, AD_DATE_BACKUP, &aint) < 0)) {
                 aint = AD_DATE_START;
             }
+
             if (timeoffset == 1 && aint != AD_DATE_START) {
                 set_utc_offset(&aint, TO_LOCALTIME);
             }
@@ -1105,26 +1119,32 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
             change_mdate = 1;
             memcpy(&cdate, buf, sizeof(cdate));
             buf += sizeof(cdate);
+
             if (timeoffset == 1) {
                 set_utc_offset(&cdate, TO_UTC);
             }
+
             break;
 
         case FILPBIT_MDATE :
             memcpy(&newdate, buf, sizeof(newdate));
             buf += sizeof(newdate);
+
             if (timeoffset == 1) {
                 set_utc_offset(&newdate, TO_UTC);
             }
+
             break;
 
         case FILPBIT_BDATE :
             change_mdate = 1;
             memcpy(&bdate, buf, sizeof(bdate));
             buf += sizeof(bdate);
+
             if (timeoffset == 1 && bdate != AD_DATE_START) {
                 set_utc_offset(&bdate, TO_UTC);
             }
+
             break;
 
         case FILPBIT_FINFO :
@@ -1302,6 +1322,14 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
 
             ad_getattr(adp, &bshort);
             oshort = bshort;
+
+            /*
+             * AFP 1.1 clients need to also set or clear RenameInhibit
+             * and DeleteInhibit bits alongside WriteInhibit.
+             */
+            if (obj->afp_version < 20 && (ntohs(ashort) & ATTRBIT_NOWRITE)) {
+                ashort |= htons(ATTRBIT_NORENAME | ATTRBIT_NODELETE);
+            }
 
             if (ntohs(ashort) & ATTRBIT_SETCLR) {
                 ashort &= ~htons(vol->v_ignattr);


### PR DESCRIPTION
With AFP 2.0, Apple added two additional file attributes, `RenameInhibit` and `DeleteInhibit` while changing the name of the `ReadOnly` flag to `WriteInhibit`. In order to maintain compatibility with older clients, Apple specified rules for handling these flags.

- If the client requests a file with the `RenameInhibit` or `DeleteInhibit` flags set, we now set the `WriteInhibit` flag for AFP 1.1 clients.

- If an AFP 1.1 client sets or clears the `WriteInhibit` flag, we also set or clear the `RenameInhibit` and `DeleteInhibit` flags.