### PR TITLE
contrib: fix codefmt.sh not failing CI when git safe.directory check fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,18 +41,8 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - name: Check C formatting
-        run: ./contrib/scripts/codefmt.sh -v -s c
-      - name: Check markdown formatting
-        run: ./contrib/scripts/codefmt.sh -v -s markdown
-      - name: Check meson formatting
-        run: ./contrib/scripts/codefmt.sh -v -s meson
-      - name: Check perl formatting
-        run: ./contrib/scripts/codefmt.sh -v -s perl
-      - name: Check shell script formatting
-        run: ./contrib/scripts/codefmt.sh -v -s shell
-      - name: Check yaml formatting
-        run: ./contrib/scripts/codefmt.sh -v -s yaml
+      - name: Check formatting
+        run: ./contrib/scripts/codefmt.sh -v
 
   markdown-linting:
     name: Markdown Linting

--- a/contrib/scripts/codefmt.sh
+++ b/contrib/scripts/codefmt.sh
@@ -47,9 +47,9 @@ while getopts "vs:" opt; do
     esac
 done
 
-if ! git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
-    echo "Warning: Not inside a git repository; will not be able to determine if any changes were made by this script" >&2
-else
+git config --global --add safe.directory "$PWD" > /dev/null 2>&1
+
+if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
     IS_GIT=1
     INITIAL_DIFF_HASH=$(git diff HEAD | git hash-object --stdin)
 fi
@@ -166,4 +166,7 @@ if [ $IS_GIT -eq 1 ]; then
         fi
         exit 0
     fi
+else
+    echo "Error: Not inside a git repository; cannot verify formatting changes" >&2
+    exit 2
 fi

--- a/contrib/webmin_module/edit_global_section.cgi
+++ b/contrib/webmin_module/edit_global_section.cgi
@@ -106,8 +106,8 @@ print &ui_table_row(
                     )
                     . &ui_checkbox('p_uam list', 'uams_guest.so', 'Guest',    $values[0] =~ /uams_guest.so/ ? 1 : 0)
                     . &ui_checkbox('p_uam list', 'uams_gss.so',   'Kerberos', $values[0] =~ /uams_gss.so/   ? 1 : 0)
-                    . &ui_checkbox('p_uam list', 'uams_srp.so',   'SRP',      $values[0] =~ /uams_srp.so/   ? 1 : 0)
-                    . "<br>" . $text{'edit_global_section_uam_list_note'}
+                    . &ui_checkbox('p_uam list', 'uams_srp.so',   'SRP', $values[0] =~ /uams_srp.so/ ? 1 : 0) . "<br>"
+                    . $text{'edit_global_section_uam_list_note'}
 );
 
 @values = get_parameter_of_section($afpconfRef, $sectionRef, 'log file', \%in);
@@ -143,18 +143,19 @@ my $log_rows_html = '';
 for my $pair (@log_pairs) {
     my ($t, $l) = @$pair;
     my $type_opts = "<option value=''>$undef_text</option>\n"
-                  . join('', map { "<option value='$_'" . ($t eq $_ ? " selected" : "") . ">$_</option>\n" } @log_types);
+      . join('', map { "<option value='$_'" . ($t eq $_ ? " selected" : "") . ">$_</option>\n" } @log_types);
     my $level_opts = "<option value=''>$undef_text</option>\n"
-                   . join('', map { "<option value='$_'" . ($l eq $_ ? " selected" : "") . ">$_</option>\n" } @log_levels);
-    $log_rows_html .= "<div class='log-entry-row' style='margin-bottom:4px'>"
-                    . "<select name='p_log_type'>$type_opts</select>"
-                    . " : <select name='p_log_level'>$level_opts</select>"
-                    . " <button type='button' onclick='removeLogRow(this)'>$remove_text</button>"
-                    . "</div>\n";
+      . join('', map { "<option value='$_'" . ($l eq $_ ? " selected" : "") . ">$_</option>\n" } @log_levels);
+    $log_rows_html .=
+        "<div class='log-entry-row' style='margin-bottom:4px'>"
+      . "<select name='p_log_type'>$type_opts</select>"
+      . " : <select name='p_log_level'>$level_opts</select>"
+      . " <button type='button' onclick='removeLogRow(this)'>$remove_text</button>"
+      . "</div>\n";
 }
 
-my $js_types  = join(',', map { "\"$_\"" } @log_types);
-my $js_levels = join(',', map { "\"$_\"" } @log_levels);
+my $js_types  = join(',', map {"\"$_\""} @log_types);
+my $js_levels = join(',', map {"\"$_\""} @log_levels);
 
 my $log_widget_html = qq{<div id="log_entries">
 $log_rows_html</div>

--- a/contrib/webmin_module/edit_vol_section.cgi
+++ b/contrib/webmin_module/edit_vol_section.cgi
@@ -434,23 +434,23 @@ if ($subject ne 'homes') {
     print &ui_table_row(
                         $text{'edit_global_section_legacy_icon'},
                         &build_select(
-                                    $afpconfRef, $sectionRef, \%in, 'legacy icon', $text{'edit_undefined'},
-                                    'daemon',
-                                    'daemon',
-                                    'declogo',
-                                    'declogo',
-                                    'fileserver',
-                                    'fileserver',
-                                    'globe',
-                                    'globe',
-                                    'nas',
-                                    'nas',
-                                    'sdcard',
-                                    'sdcard',
-                                    'sunlogo',
-                                    'sunlogo',
-                                    'viking',
-                                    'viking'
+                                      $afpconfRef, $sectionRef, \%in, 'legacy icon', $text{'edit_undefined'},
+                                      'daemon',
+                                      'daemon',
+                                      'declogo',
+                                      'declogo',
+                                      'fileserver',
+                                      'fileserver',
+                                      'globe',
+                                      'globe',
+                                      'nas',
+                                      'nas',
+                                      'sdcard',
+                                      'sdcard',
+                                      'sunlogo',
+                                      'sunlogo',
+                                      'viking',
+                                      'viking'
                         )
     );
 

--- a/contrib/webmin_module/save_global_section.cgi
+++ b/contrib/webmin_module/save_global_section.cgi
@@ -47,7 +47,7 @@ eval {
     my @_log_pairs  = ();
     for my $i (0 .. $#_log_types) {
         push @_log_pairs, $_log_types[$i] . ':' . $_log_levels[$i]
-            if $_log_types[$i] && $_log_levels[$i];
+          if $_log_types[$i] && $_log_levels[$i];
     }
     $in{'p_log level'} = join(',', @_log_pairs);
     delete $in{'p_log_type'};

--- a/doc/doxygen_filter_yacc.sh
+++ b/doc/doxygen_filter_yacc.sh
@@ -90,8 +90,7 @@ while IFS= read -r line; do
             printf '%s\n' "$line"
             ;;
 
-        *)
-            ;;
+        *) ;;
 
     esac
 done < "${1}"

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -2553,26 +2553,32 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap,
             change_mdate = 1;
             memcpy(&cdate, buf, sizeof(cdate));
             buf += sizeof(cdate);
+
             if (timeoffset == 1) {
                 set_utc_offset(&cdate, TO_UTC);
             }
+
             break;
 
         case DIRPBIT_MDATE :
             memcpy(&newdate, buf, sizeof(newdate));
             buf += sizeof(newdate);
+
             if (timeoffset == 1) {
                 set_utc_offset(&newdate, TO_UTC);
             }
+
             break;
 
         case DIRPBIT_BDATE :
             change_mdate = 1;
             memcpy(&bdate, buf, sizeof(bdate));
             buf += sizeof(bdate);
+
             if (timeoffset == 1 && bdate != AD_DATE_START) {
                 set_utc_offset(&bdate, TO_UTC);
             }
+
             break;
 
         case DIRPBIT_FINFO :

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -40,7 +40,7 @@
 #include "virtual_icon.h"
 #include "volume.h"
 
-/*! 
+/*!
  * @brief Convert an AFP date-time value between local time and UTC.
  * @param aint_p AFP date-time to be converted.
  * @param offset_dir Which direction we want to convert the timestamp.
@@ -51,33 +51,39 @@ int set_utc_offset(uint32_t *aint_p, int offset_dir)
     if (*aint_p == AD_DATE_START) {
         return 0;
     }
+
     struct timeval tv;
+
     tv.tv_sec = AD_DATE_TO_UNIX(*aint_p);
     tv.tv_usec = 0;
     struct tm tm;
 
     if (offset_dir == TO_LOCALTIME) {
         if (localtime_r(&tv.tv_sec, &tm) == NULL) {
-            LOG(log_error, logtype_default, "set_utc_offset: localtime_r: %s", strerror(errno));
+            LOG(log_error, logtype_default, "set_utc_offset: localtime_r: %s",
+                strerror(errno));
             return -1;
         }
+
         tv.tv_sec = timegm(&tm);
         *aint_p = AD_DATE_FROM_UNIX(tv.tv_sec);
-    }
-    else {
-        /* 
-         * This won't work reliably during the transition to/from DST. 
+    } else {
+        /*
+         * This won't work reliably during the transition to/from DST.
          * The timestamp may be a hour off during the transistion back
          * to standard time at 0200 hours.
          */
         if (gmtime_r(&tv.tv_sec, &tm) == NULL) {
-            LOG(log_error, logtype_default, "set_utc_offset: gmtime_r: %s", strerror(errno));
+            LOG(log_error, logtype_default, "set_utc_offset: gmtime_r: %s",
+                strerror(errno));
             return -1;
         }
+
         tm.tm_isdst = -1;
         tv.tv_sec = mktime(&tm);
         *aint_p = AD_DATE_FROM_UNIX(tv.tv_sec);
     }
+
     return 0;
 }
 


### PR DESCRIPTION
add git safe.directory config to override GitHub security model rule that prevented the formatting validation to take effect in the CI job

also, exit with error at the end if git is unavailable when change detection is needed so that the CI job will fail properly

some recently added C, Perl, and shellscript code hadn't gotten formatted because of this