### PR TITLE
netatalk: leverage D-Bus session bus auto activation for localsearch

### DIFF
--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -186,6 +186,10 @@ functionality.
     strings from source files and merge them with the translations
     stored in PO files.
 
+- talloc
+
+    Samba's talloc library is used for memory management in the Spotlight query parser.
+
 - TCP wrappers
 
     Wietse Venema's network logger, also known as TCPD or LOG_TCP.
@@ -202,9 +206,9 @@ functionality.
     This is mostly relevant for developers or package managers who want to regenerate
     the Unicode source files.
 
-### Spotlight dependencies
+### Spotlight LocalSearch backend dependencies
 
-Netatalk's Spotlight support relies on the following third-party software:
+The LocalSearch backend for Spotlight depends on the following third-party software:
 
 - bison
 
@@ -232,17 +236,10 @@ Netatalk's Spotlight support relies on the following third-party software:
     You can add metadata extraction support for additional file types
     by installing the appropriate Tracker extractors.
 
-- talloc
-
-    Samba's talloc library is used for memory management in the Spotlight query parser.
-
 - TinySPARQL
 
     The [TinySPARQL](https://tracker.gnome.org/) library is used
     for parsing SPARQL queries in the Spotlight support.
-
-**Note:** LocalSearch and TinySPARQL together were previously known as Tracker.
-Netatalk still supports the older Tracker v3 library and schema.
 
 ## Starting and stopping Netatalk
 

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -272,33 +272,6 @@ static void sigterm_impl(void)
     sigfillset(&sigs);
     sigdelset(&sigs, SIGCHLD);
     sigprocmask(SIG_SETMASK, &sigs, NULL);
-#ifdef SPOTLIGHT_BACKEND_LOCALSEARCH
-    int sysret = system(INDEXER_COMMAND " -t");
-
-    if (sysret == -1) {
-        LOG(log_error, logtype_afpd,
-            "sigterm_cb: system() failed to run Spotlight indexer stop: %s",
-            strerror(errno));
-    } else if (WIFEXITED(sysret) && WEXITSTATUS(sysret) != 0) {
-        LOG(log_error, logtype_afpd,
-            "sigterm_cb: Spotlight indexer stop exited with status %d",
-            WEXITSTATUS(sysret));
-    } else if (WIFSIGNALED(sysret)) {
-        int sig = WTERMSIG(sysret);
-
-        if (sig == SIGTERM || sig == SIGINT) {
-            LOG(log_info, logtype_afpd,
-                "sigterm_cb: Spotlight indexer stop interrupted by signal %d"
-                " (expected during shutdown)",
-                sig);
-        } else {
-            LOG(log_error, logtype_afpd,
-                "sigterm_cb: Spotlight indexer stop killed by signal %d",
-                sig);
-        }
-    }
-
-#endif
     kill_childs(SIGTERM, &afpd_pid, &cnid_metad_pid, &dbus_pid, NULL);
 }
 
@@ -306,33 +279,6 @@ static void sigterm_impl(void)
 static void sigquit_impl(void)
 {
     LOG(log_note, logtype_afpd, "Exiting on SIGQUIT");
-#ifdef SPOTLIGHT_BACKEND_LOCALSEARCH
-    int sysret = system(INDEXER_COMMAND " -t");
-
-    if (sysret == -1) {
-        LOG(log_error, logtype_afpd,
-            "sigquit_cb: system() failed to run Spotlight indexer stop: %s",
-            strerror(errno));
-    } else if (WIFEXITED(sysret) && WEXITSTATUS(sysret) != 0) {
-        LOG(log_error, logtype_afpd,
-            "sigquit_cb: Spotlight indexer stop exited with status %d",
-            WEXITSTATUS(sysret));
-    } else if (WIFSIGNALED(sysret)) {
-        int sig = WTERMSIG(sysret);
-
-        if (sig == SIGTERM || sig == SIGINT) {
-            LOG(log_info, logtype_afpd,
-                "sigquit_cb: Spotlight indexer stop interrupted by signal %d"
-                " (expected during shutdown)",
-                sig);
-        } else {
-            LOG(log_error, logtype_afpd,
-                "sigquit_cb: Spotlight indexer stop killed by signal %d",
-                sig);
-        }
-    }
-
-#endif
     kill_childs(SIGQUIT, &afpd_pid, &cnid_metad_pid, &dbus_pid, NULL);
 }
 
@@ -633,7 +579,6 @@ static void show_netatalk_paths(void)
 #ifdef SPOTLIGHT_BACKEND_LOCALSEARCH
     printf("               dbus-daemon:\t%s\n", DBUS_DAEMON_PATH);
     printf("         dbus-session.conf:\t%s\n", _PATH_CONFDIR "dbus-session.conf");
-    printf("           indexer manager:\t%s\n", INDEXER_COMMAND);
 #endif
 #ifndef SOLARIS
     printf("        netatalk lock file:\t%s\n", PATH_NETATALK_LOCK);
@@ -790,22 +735,6 @@ int main(int argc, char **argv)
         /* Allow dbus some time to start up */
         sleep(1);
         set_sl_volumes();
-        LOG(log_note, logtype_default, "Starting indexer: " INDEXER_COMMAND " -s");
-        int sysret = system(INDEXER_COMMAND " -s");
-
-        if (sysret == -1) {
-            LOG(log_error, logtype_default,
-                "system() failed to run Spotlight indexer start: %s", strerror(errno));
-            netatalk_exit(EXITERR_CONF);
-        } else if (WIFEXITED(sysret) && WEXITSTATUS(sysret) != 0) {
-            LOG(log_error, logtype_default, "Spotlight indexer start exited with status %d",
-                WEXITSTATUS(sysret));
-            netatalk_exit(EXITERR_CONF);
-        } else if (WIFSIGNALED(sysret)) {
-            LOG(log_error, logtype_default, "Spotlight indexer start killed by signal %d",
-                WTERMSIG(sysret));
-            netatalk_exit(EXITERR_CONF);
-        }
     }
 
 #endif

--- a/meson.build
+++ b/meson.build
@@ -1100,132 +1100,133 @@ endif
 have_spotlight = false
 use_spotlight_cnid = false
 use_spotlight_localsearch = false
+spotlight_backends = ''
 
 if get_option('with-spotlight')
-    spotlight_backends = ''
     talloc = dependency('talloc', required: false)
 
-    if 'cnid' in get_option('with-spotlight-backends')
-        if talloc.found()
+    if talloc.found()
+        if 'cnid' in get_option('with-spotlight-backends')
             use_spotlight_cnid = true
             spotlight_backends = 'cnid'
             cdata.set('SPOTLIGHT_BACKEND_CNID', 1)
-        else
-            warning('talloc library required for cnid Spotlight search backend')
         endif
-    endif
 
-    if 'localsearch' in get_option('with-spotlight-backends')
-        if host_os == 'darwin'
-            if brew_prefix != ''
-                bison = find_program(brew_prefix / 'opt/bison/bin/bison', required: false)
+        if 'localsearch' in get_option('with-spotlight-backends')
+            if host_os == 'darwin'
+                if brew_prefix != ''
+                    bison = find_program(brew_prefix / 'opt/bison/bin/bison', required: false)
+                else
+                    bison = find_program('/opt/local/bin/bison', required: false)
+                endif
             else
-                bison = find_program('/opt/local/bin/bison', required: false)
+                bison = find_program('bison', required: false)
             endif
-        else
-            bison = find_program('bison', required: false)
-        endif
 
-        flex = find_program('flex', required: false)
-        if not use_spotlight_cnid
-            talloc = dependency('talloc', required: false)
-        endif
+            flex = find_program('flex', required: false)
 
-        # Check for SPARQL
+            # Check for SPARQL
 
-        sparql_found = false
-        tinysparql = dependency('tinysparql-3.0', required: false)
-        tracker_sparql = dependency('tracker-sparql-3.0', required: false)
+            sparql_found = false
+            tinysparql = dependency('tinysparql-3.0', required: false)
+            tracker_sparql = dependency('tracker-sparql-3.0', required: false)
 
-        if tinysparql.found()
-            sparql_found = true
-            sparql = tinysparql
-        elif tracker_sparql.found()
-            sparql_found = true
-            sparql = tracker_sparql
-            cdata.set('HAVE_TRACKER3', 1)
-        endif
-
-        # Check for indexer
-
-        indexer_found = false
-        localsearch = find_program('localsearch', required: false)
-        tracker3 = find_program('tracker3', required: false)
-        gsettings = find_program('gsettings', required: false)
-        dconf = find_program('dconf', required: false)
-
-        localsearch3_schema_found = false
-        tracker3_schema_found = false
-        if gsettings.found()
-            localsearch3_schema_check = run_command(
-                gsettings,
-                'list-keys',
-                'org.freedesktop.LocalSearch3.Miner.Files',
-                check: false,
-            )
-            tracker3_schema_check = run_command(
-                gsettings,
-                'list-keys',
-                'org.freedesktop.Tracker3.Miner.Files',
-                check: false,
-            )
-            localsearch3_schema_found = localsearch3_schema_check.returncode() == 0
-            tracker3_schema_found = tracker3_schema_check.returncode() == 0
-        endif
-
-        indexer = disabler()
-        if localsearch.found()
-            indexer = localsearch
-        elif tracker3.found()
-            indexer = tracker3
-        endif
-
-        if indexer.found() and localsearch3_schema_found
-            indexer_found = true
-            cdata.set('INDEXER_DBUS_NAME', '"org.freedesktop.LocalSearch3"')
-            cdata.set(
-                'INDEXER_DCONF_PATH',
-                '"org/freedesktop/localsearch/miner/files"',
-            )
-            cdata.set('INDEXER_COMMAND', '"' + indexer.full_path() + ' daemon"')
-        elif indexer.found() and tracker3_schema_found
-            indexer_found = true
-            cdata.set('INDEXER_DBUS_NAME', '"org.freedesktop.Tracker3.Miner.Files"')
-            cdata.set(
-                'INDEXER_DCONF_PATH',
-                '"org/freedesktop/tracker/miner/files"',
-            )
-            cdata.set('INDEXER_COMMAND', '"' + indexer.full_path() + ' daemon"')
-        endif
-
-        cdata.set('INDEXER_DCONF_DB_DIR', '"/etc/dconf/db/netatalk.d"')
-        cdata.set('INDEXER_DCONF_PROFILE', '"/etc/dconf/profile/netatalk"')
-
-        use_spotlight_localsearch = (
-            sparql_found
-            and indexer_found
-            and dconf.found()
-            and talloc.found()
-            and flex.found()
-            and bison.found()
-        )
-
-        if use_spotlight_localsearch
-            if spotlight_backends != ''
-                spotlight_backends += ' | '
+            if tinysparql.found()
+                sparql_found = true
+                sparql = tinysparql
+            elif tracker_sparql.found()
+                sparql_found = true
+                sparql = tracker_sparql
+                cdata.set('HAVE_TRACKER3', 1)
             endif
-            spotlight_backends += 'localsearch'
-            cdata.set('SPOTLIGHT_BACKEND_LOCALSEARCH', 1)
-            cdata.set('DCONF_UPDATE_COMMAND', '"' + dconf.full_path() + ' update"')
-            install_emptydir('/etc/dconf/db')
-            if get_option('with-install-hooks')
-                meson.add_install_script(dconf, 'update')
+
+            # Check for indexer
+
+            indexer_found = false
+            localsearch = find_program('localsearch', required: false)
+            tracker3 = find_program('tracker3', required: false)
+            gsettings = find_program('gsettings', required: false)
+            dconf = find_program('dconf', required: false)
+
+            localsearch3_schema_found = false
+            tracker3_schema_found = false
+            if gsettings.found()
+                localsearch3_schema_check = run_command(
+                    gsettings,
+                    'list-keys',
+                    'org.freedesktop.LocalSearch3.Miner.Files',
+                    check: false,
+                )
+                tracker3_schema_check = run_command(
+                    gsettings,
+                    'list-keys',
+                    'org.freedesktop.Tracker3.Miner.Files',
+                    check: false,
+                )
+                localsearch3_schema_found = localsearch3_schema_check.returncode() == 0
+                tracker3_schema_found = tracker3_schema_check.returncode() == 0
             endif
-        else
-            warning(
-                'localsearch Spotlight search backend requested but one or more required dependencies not found',
+
+            indexer = disabler()
+            if localsearch.found()
+                indexer = localsearch
+            elif tracker3.found()
+                indexer = tracker3
+            endif
+
+            if indexer.found() and localsearch3_schema_found
+                indexer_found = true
+                cdata.set('INDEXER_DBUS_NAME', '"org.freedesktop.LocalSearch3"')
+                cdata.set(
+                    'INDEXER_DCONF_PATH',
+                    '"org/freedesktop/localsearch/miner/files"',
+                )
+            elif indexer.found() and tracker3_schema_found
+                indexer_found = true
+                cdata.set(
+                    'INDEXER_DBUS_NAME',
+                    '"org.freedesktop.Tracker3.Miner.Files"',
+                )
+                cdata.set(
+                    'INDEXER_DCONF_PATH',
+                    '"org/freedesktop/tracker/miner/files"',
+                )
+            endif
+
+            cdata.set('INDEXER_DCONF_DB_DIR', '"/etc/dconf/db/netatalk.d"')
+            cdata.set('INDEXER_DCONF_PROFILE', '"/etc/dconf/profile/netatalk"')
+
+            use_spotlight_localsearch = (
+                sparql_found
+                and indexer_found
+                and dconf.found()
+                and talloc.found()
+                and flex.found()
+                and bison.found()
             )
+
+            if use_spotlight_localsearch
+                if spotlight_backends != ''
+                    spotlight_backends += ' | '
+                endif
+                spotlight_backends += 'localsearch'
+                cdata.set('SPOTLIGHT_BACKEND_LOCALSEARCH', 1)
+                cdata.set(
+                    'DCONF_UPDATE_COMMAND',
+                    '"' + dconf.full_path() + ' update"',
+                )
+                install_emptydir('/etc/dconf/db')
+                if get_option('with-install-hooks')
+                    meson.add_install_script(dconf, 'update')
+                endif
+            else
+                warning(
+                    'localsearch Spotlight search backend requested but one or more required dependencies not found',
+                )
+            endif
         endif
+    else
+        warning('talloc library required for Spotlight search support')
     endif
 
     have_spotlight = use_spotlight_cnid or use_spotlight_localsearch

--- a/meson_config.h
+++ b/meson_config.h
@@ -403,9 +403,6 @@
 /* Define if TCP wrappers should be used */
 #mesondefine TCPWRAP
 
-/* Indexer managing command */
-#mesondefine INDEXER_COMMAND
-
 /* Indexer D-Bus name */
 #mesondefine INDEXER_DBUS_NAME
 


### PR DESCRIPTION
we have so far been using the 'daemon' subcommand of tracker/localsearch to manually launch the indexer daemon from the netatalk controller daemon

however this subcommand was completely removed with localsearch v3.10, so this changeset instead relies on the native auto activation on the D-Bus session bus to launch the indexer

the first SPARQL connection from sl_localsearch_init(), our private dbus-daemon sees no provider for org.freedesktop.LocalSearch3, reads the auto-activation file, and forks localsearch; the indexer then claims the bus name and the SPARQL connection succeeds

shutdown is implicit: when Netatalk SIGTERMs dbus_pid, the indexer's bus connection drops and it exits on its own; no need to send an explicit termination command like previously