### PR TITLE
introduce a Spotlight backend built on Xapian

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
             dbus-dev \
             dconf \
             flex \
+            file-dev \
             gcc \
             glib \
             iniparser-dev \
@@ -67,7 +68,8 @@ jobs:
             sqlite-dev \
             talloc-dev \
             tinysparql-dev \
-            valgrind
+            valgrind \
+            xapian-core-dev
       - name: Configure
         run: |
           meson setup build \
@@ -122,6 +124,7 @@ jobs:
             db \
             dconf \
             flex \
+            file \
             gcc \
             iniparser \
             libev \
@@ -134,7 +137,8 @@ jobs:
             rpcsvc-proto \
             sqlite \
             talloc \
-            tinysparql
+            tinysparql \
+            xapian-core
       - name: Configure
         run: |
           meson setup build \
@@ -187,6 +191,7 @@ jobs:
             dconf-cli \
             file \
             flex \
+            g++ \
             gcc \
             libacl1-dev \
             libavahi-client-dev \
@@ -201,6 +206,7 @@ jobs:
             libiniparser-dev \
             libkrb5-dev \
             libldap2-dev \
+            libmagic-dev \
             libmariadb-dev \
             libpam0g-dev \
             libsqlite3-dev \
@@ -208,6 +214,7 @@ jobs:
             libtirpc-dev \
             libtracker-sparql-3.0-dev \
             libwrap0-dev \
+            libxapian-dev \
             meson \
             ninja-build \
             quota \
@@ -272,12 +279,14 @@ jobs:
             dbus-devel \
             dconf \
             flex \
+            gcc-c++ \
             glib2-devel \
             iniparser-devel \
             krb5-devel \
             libacl-devel \
             libdb-devel \
             libev-devel \
+            file-devel \
             libgcrypt-devel \
             libtalloc-devel \
             localsearch \
@@ -294,7 +303,8 @@ jobs:
             systemd \
             systemtap-sdt-devel \
             tinysparql-devel \
-            valgrind
+            valgrind \
+            xapian-core-devel
       - name: Configure
         run: |
           meson setup build \
@@ -349,6 +359,7 @@ jobs:
             dconf-cli \
             file \
             flex \
+            g++ \
             gcc \
             libacl1-dev \
             libavahi-client-dev \
@@ -362,12 +373,14 @@ jobs:
             libiniparser-dev \
             libkrb5-dev \
             libldap2-dev \
+            libmagic-dev \
             libmariadb-dev \
             libpam0g-dev \
             libtalloc-dev \
             libtirpc-dev \
             libtracker-sparql-3.0-dev \
             libwrap0-dev \
+            libxapian-dev \
             meson \
             ninja-build \
             quota \
@@ -426,10 +439,12 @@ jobs:
             cracklib \
             iniparser \
             libev \
+            libmagic \
             mariadb \
             meson \
             openldap \
-            talloc
+            talloc \
+            xapian
       - name: Configure
         run: |
           meson setup build \
@@ -484,6 +499,7 @@ jobs:
               db5 \
               iniparser \
               libev \
+              file \
               libgcrypt \
               meson \
               mysql80-client \
@@ -494,7 +510,8 @@ jobs:
               py39-sqlite3 \
               py39-tkinter \
               sqlite \
-              talloc
+              talloc \
+              xapian-core
           run: |
             set -e
             meson setup build \
@@ -539,6 +556,7 @@ jobs:
               flex \
               iniparser \
               libev \
+              file \
               libgcrypt \
               libsunacl \
               localsearch \
@@ -549,7 +567,8 @@ jobs:
               perl5 \
               pkgconf \
               sqlite3 \
-              talloc
+              talloc \
+              xapian-core
           run: |
             set -e
             meson setup build \
@@ -599,11 +618,13 @@ jobs:
               libev \
               libgcrypt \
               meson \
+              file \
               mysql-client \
               perl \
               pkg-config \
               sqlite3 \
-              talloc
+              talloc \
+              xapian
           run: |
             set -e
             meson setup build \
@@ -659,14 +680,17 @@ jobs:
               iniparser \
               libev \
               libgcrypt \
+              libmagic \
               libtalloc \
+              file \
               mariadb-client \
               meson \
               openldap-client-2.6.10v0 \
               openpam \
               p5-Net-DBus \
               pkgconfig \
-              sqlite3-3.50.7p0
+              sqlite3-3.50.7p0 \
+              xapian-core
           run: |
             set -e
             meson setup build \
@@ -721,11 +745,13 @@ jobs:
               gnome-tracker \
               iniparser \
               libev \
+              file \
               libgcrypt \
               meson \
               mysql-client \
               sqlite3 \
-              talloc
+              talloc \
+              xapian
           run: |
             set -e
             export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
@@ -783,8 +809,10 @@ jobs:
               library/cmark \
               library/glib2 \
               library/libev \
+              library/magic \
               library/security/cracklib \
               library/talloc \
+              library/xapian \
               runtime/perl \
               system/library/dbus \
               system/library/libdbus \

--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -39,6 +39,7 @@ jobs:
               cracklib-runtime \
               curl \
               flex \
+              g++ \
               gcc \
               git \
               libacl1-dev \
@@ -53,12 +54,14 @@ jobs:
               libiniparser-dev \
               libkrb5-dev \
               libldap2-dev \
+              libmagic-dev \
               libmariadb-dev \
               libpam0g-dev \
               libtalloc-dev \
               libtirpc-dev \
               libtracker-sparql-3.0-dev \
               libwrap0-dev \
+              libxapian-dev \
               meson \
               ninja-build \
               systemtap-sdt-dev \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -85,15 +85,16 @@ required at the bare minimum.
 | libtirpc **OR** libquota   | Quota support |
 | Perl                       | admin scripts |
 | po4a                       | localization of documentation |
-| talloc                     | Spotlight search |
+| talloc                     | Spotlight support |
 | tcpwrap                    | TCP wrapper support |
 | [UnicodeData.txt](https://www.unicode.org/Public/UNIDATA/UnicodeData.txt) | regenerating Unicode lookup tables |
 
 ### Optional Spotlight Backends
 
-With `talloc` you get filename search functionality via the Netatalk CNID database.
-If you want more advanced search functionality with file contents and metadata,
-install the LocalSearch dependencies.
+In order to enable more advanced Spotlight search functionality such as content searching or metadata,
+install the dependencies for one of the following search backends.
+
+#### LocalSearch
 
 | Package    | Details |
 |------------|---------|
@@ -104,6 +105,14 @@ install the LocalSearch dependencies.
 | flex       | or compatible lexer |
 | localsearch **OR** tracker | v3.0 or later |
 | tinysparql |  |
+
+#### Xapian
+
+| Package      | Details |
+|--------------|---------|
+| C++ compiler | clang++ or g++ are recommended |
+| libmagic     | MIME type detection; sometimes packaged as `file` |
+| xapian-core  |  |
 
 ## Build the software
 

--- a/contrib/scripts/codefmt.sh
+++ b/contrib/scripts/codefmt.sh
@@ -58,11 +58,11 @@ if [ "$SOURCE_TYPE" = "c" ] || [ "$SOURCE_TYPE" = "" ]; then
     if command -v astyle > /dev/null 2>&1; then
         FORMATTER_CMD="astyle --options=.astylerc --recursive --suffix=none"
         if [ $VERBOSE -eq 1 ]; then
-            echo "Formatting C sources..."
+            echo "Formatting C / C++ sources..."
         else
             FORMATTER_CMD="$FORMATTER_CMD --quiet"
         fi
-        eval "$FORMATTER_CMD '*.h' '*.c'"
+        eval "$FORMATTER_CMD '*.h' '*.c' '*.cc'"
     else
         echo "Error: astyle not found in PATH" >&2
         exit 2

--- a/doc/developer/indexing.md
+++ b/doc/developer/indexing.md
@@ -1,18 +1,241 @@
-Indexing for Spotlight Search
-=============================
+# Indexed Spotlight Search
 
-Starting with version 3.1 Netatalk supports Spotlight searching.
-Netatalk uses GNOME TinySPARQL/[LocalSearch](https://gnome.pages.gitlab.gnome.org/localsearch/)
-(previously known as Tracker) as metadata store, indexer and search engine.
+Starting with version 3.1 Netatalk supports Spotlight-compatible
+searching for macOS clients.
 
-Limitations and notes
----------------------
+The AFP Spotlight RPC implementation lives in `etc/afpd/spotlight.c`.
+It is shared by all Spotlight search backends. Query execution is delegated
+to a per-volume backend selected with the `spotlight backend` configuration
+option.
 
-* Large filesystems
+**Note**: Remote Netatalk volumes are searchable through **Finder search**
+in macOS, not through the Spotlight Search widget.
+Spotlight Search is reserved for local volumes.
+This is a macOS client behavior and not a Netatalk limitation.
+
+## Backend interface
+
+Spotlight backends implement the `sl_backend_ops` vtable declared in
+`include/atalk/spotlight.h`.
+
+| Hook | Purpose |
+|------|---------|
+| `sbo_init` | Initialize backend process or connection state. |
+| `sbo_close` | Release backend global state on shutdown. |
+| `sbo_open_query` | Start or execute a Spotlight query. |
+| `sbo_fetch_results` | Fill the next page of query results. |
+| `sbo_close_query` | Cancel and free per-query backend state. |
+| `sbo_index_event` | Optional hook for incremental index updates. |
+
+The common query handle is `slq_t`. It carries the query string, search
+scope, requested metadata, optional CNID filter, result limit, query state,
+and backend-private query state.
+
+Enabled backend ops are declared in `etc/spotlight/sl_backends.h`.
+At volume open time, `etc/afpd/volume.c` binds `vol->v_sl_backend` to one
+of the compiled backends.
+
+## Data flow overview
+
+```mermaid
+flowchart TD
+    Client["macOS Finder search"] --> RPC["AFP Spotlight RPC<br/>etc/afpd/spotlight.c"]
+    RPC --> Query["slq_t query handle<br/>scope, query string, CNID filter, requested metadata"]
+    Volume["Volume open<br/>etc/afpd/volume.c"] --> Select["Select per-volume<br/>spotlight backend"]
+    Select --> Ops["sl_backend_ops vtable"]
+    Query --> Ops
+
+    Ops -->|"sbo_open_query<br/>sbo_fetch_results"| CNID["cnid backend"]
+    Ops -->|"sbo_open_query<br/>sbo_fetch_results"| LocalSearch["localsearch backend"]
+    Ops -->|"sbo_open_query<br/>sbo_fetch_results"| Xapian["xapian backend"]
+
+    CNID --> CNIDStore[("Netatalk CNID database")]
+    LocalSearch --> LocalSearchStore[("LocalSearch or Tracker index")]
+    Xapian --> XapianStore[("Netatalk Xapian index")]
+
+    CNIDStore --> Candidates["Candidate CNIDs or paths"]
+    LocalSearchStore --> Candidates
+    XapianStore --> Candidates
+
+    Candidates --> Filter["Common result validation<br/>scope, stat, access, CNID filter"]
+    Filter --> Metadata["add_filemeta<br/>requested result metadata"]
+    Metadata --> Results["query_results<br/>CNID array plus metadata array"]
+    Results --> Reply["Spotlight RPC reply"]
+    Reply --> Client
+
+    FileEvents["AFP file and directory changes"] --> IndexEvent["sl_index_event"]
+    IndexEvent -->|"optional sbo_index_event"| Ops
+```
+
+## Available backends
+
+| Backend | Source | Storage | Query model | Index updates |
+|---------|--------|---------|-------------|---------------|
+| `cnid` | `etc/spotlight/cnid/` | Netatalk CNID database | Filename-oriented search through `cnid_find()` | No separate Spotlight index |
+| `localsearch` | `etc/spotlight/localsearch/` | GNOME LocalSearch/Tracker over D-Bus/SPARQL | Metadata and full-text query mapping | Managed by LocalSearch/Tracker |
+| `xapian` | `etc/spotlight/xapian/` | Per-volume Xapian database | Filename, plain text, MIME/type/category terms | AFP file events plus full reconciliation |
+
+The Meson option `with-spotlight-backends` controls which backends are
+built. Supported values are `cnid`, `localsearch`, and `xapian`.
+
+The global `sparql results limit` option is shared by LocalSearch and
+Xapian despite its historical name. A value of `0` leaves LocalSearch
+SPARQL queries unlimited. Xapian applies a 10000 candidate-result safety
+cap in that case because the backend materializes candidate paths before
+paging validated results back to the client. The CNID backend has its own
+fixed CNID search reply cap.
+
+## Query flow
+
+1. The macOS client sends an AFP Spotlight RPC.
+2. `etc/afpd/spotlight.c` unpacks the request into an `slq_t`.
+3. The selected backend handles `sbo_open_query`.
+4. The backend finds candidate paths or CNIDs.
+5. Before returning results, backends validate paths with `stat()` and
+   access checks, resolve or filter CNIDs, and call `add_filemeta()`.
+6. Results are returned in pages as CNID arrays plus metadata arrays.
+
+All current backends ultimately return filesystem results through the same
+`query_results` structure.
+
+## CNID backend
+
+The CNID backend is the smallest backend. It extracts a filename search
+term from common Spotlight predicates such as `kMDItemFSName`,
+`kMDItemDisplayName`, `_kMDItemFileName`, and simple `*==` wildcard
+queries.
+
+It searches the Netatalk CNID database with `cnid_find()`, resolves CNIDs
+back to paths with `cnid_resolve()`, and returns matching files. It does
+not maintain a separate Spotlight index and does not implement
+`sbo_index_event`.
+
+## LocalSearch backend
+
+The LocalSearch backend maps Spotlight RAW query strings to SPARQL using
+the lexer, parser, and attribute map in `etc/spotlight/localsearch/`.
+
+It keeps a process-level Tracker/LocalSearch connection in `AFPObj::sl_ctx`
+and uses asynchronous SPARQL queries. Returned URIs are converted back to
+Unix paths, checked against the filesystem, resolved to CNIDs, and packed
+into Spotlight result pages.
+
+The `spotlight attributes` option can restrict which mapped Spotlight
+attributes are accepted by the SPARQL mapper.
+
+## Xapian backend
+
+The Xapian backend is split into a C backend adapter and a C++ wrapper:
+
+| File | Responsibility |
+|------|----------------|
+| `sl_xapian.c` | Implements `sl_backend_ops`, result paging, CNID filtering, state directory setup, and incremental event routing. |
+| `sl_xapian.h` | C ABI between C backend code and the C++ libxapian implementation. |
+| `xapian_wrapper.cc` | Owns libxapian, libmagic, full reconciliation, document indexing, query building, and exception handling. |
+
+Each volume uses a database under:
+
+```shell
+_PATH_STATEDIR/spotlight/xapian/<volume uuid>
+```
+
+On first query for a volume, the backend reconciles the Xapian database by
+walking the volume, indexing visible regular files and directories, and
+deleting stale documents. Each Xapian document stores the path, type,
+mtime, size, MIME type, and terms for filename, body text, MIME, and
+category search.
+
+The Xapian index is shared per volume, not per AFP user. For that reason,
+body text is indexed only from regular files that are world-readable,
+readable by the indexing process, plain-text-like, and below the text size
+limit. Files readable to a specific AFP user but not world-readable may be
+found by filename or type, but not by `kMDItemTextContent`.
+
+AFP file and directory operations call `sl_index_event()`. The Xapian
+backend uses those events to upsert changed paths, delete removed paths,
+delete directory prefixes, or reindex only the affected subtree after
+directory moves. If subtree reindexing fails, the backend marks the index
+dirty so a later query can repair it with reconciliation.
+
+## Supported metadata attributes
+
+Spotlight attribute support depends on the selected backend. There are two
+different kinds of support:
+
+* query support: attributes that can be used in a Spotlight search predicate;
+* result metadata support: attributes that Netatalk can return for a matched
+  filesystem object.
+
+### Searchable attributes
+
+The following table lists the Spotlight attributes currently supported in
+search predicates, based on Apple's
+[MDItem object](https://developer.apple.com/documentation/coreservices/mditemref/)
+Core Services file metadata standard.
+
+| Description | Spotlight Key | CNID | LocalSearch | Xapian |
+|-------------|---------------|------|-------------|--------|
+| Name | `kMDItemDisplayName`, `kMDItemFSName`, `_kMDItemFileName` | yes | yes | yes |
+| Any-term wildcard search | `*` / `*==` query form | filename only | filename or full text | filename or plain-text body |
+| Document content | `kMDItemTextContent` | no | yes | plain text files only |
+| File type / kind | `_kMDItemGroupId`, `kMDItemContentTypeTree` | no | yes | yes |
+| File type / kind | `kMDItemContentType`, `kMDItemKind` | no | no | yes |
+| File modification date | `kMDItemFSContentChangeDate`, `kMDItemContentModificationDate`, `kMDItemAttributeChangeDate` | no | yes | no |
+| Content creation date | `kMDItemContentCreationDate` | no | yes | no |
+| Last used date | `kMDItemLastUsedDate` | no | yes | no |
+| Authors / creator | `kMDItemAuthors`, `kMDItemCreator` | no | yes | no |
+| Copyright | `kMDItemCopyright` | no | yes | no |
+| Country | `kMDItemCountry` | no | yes | no |
+| Duration | `kMDItemDurationSeconds` | no | yes | no |
+| Number of pages | `kMDItemNumberOfPages` | no | yes | no |
+| Document title | `kMDItemTitle` | no | yes | no |
+| Pixel width | `kMDItemPixelWidth` | no | yes | no |
+| Pixel height | `kMDItemPixelHeight` | no | yes | no |
+| Color space | `kMDItemColorSpace` | no | yes | no |
+| Bits per sample | `kMDItemBitsPerSample` | no | yes | no |
+| Focal length | `kMDItemFocalLength` | no | yes | no |
+| ISO speed | `kMDItemISOSpeed` | no | yes | no |
+| Orientation | `kMDItemOrientation` | no | yes | no |
+| Resolution width | `kMDItemResolutionWidthDPI` | no | yes | no |
+| Resolution height | `kMDItemResolutionHeightDPI` | no | yes | no |
+| Exposure time | `kMDItemExposureTimeSeconds` | no | yes | no |
+| Composer | `kMDItemComposer` | no | yes | no |
+| Musical genre | `kMDItemMusicalGenre` | no | yes | no |
+
+### Returned result metadata
+
+All backends use the shared `add_filemeta()` helper when returning results.
+The following result metadata keys are currently populated from filesystem
+metadata when requested:
+
+| Description | Spotlight Key |
+|-------------|---------------|
+| Name | `kMDItemDisplayName`, `kMDItemFSName`, `_kMDItemFileName` |
+| Path | `kMDItemPath` |
+| Size | `kMDItemFSSize`, `kMDItemLogicalSize` |
+| Owner user ID | `kMDItemFSOwnerUserID` |
+| Owner group ID | `kMDItemFSOwnerGroupID` |
+| File modification date | `kMDItemFSContentChangeDate`, `kMDItemContentModificationDate` |
+| Last used date | `kMDItemLastUsedDate` |
+| Content creation date | `kMDItemContentCreationDate`, when supported by the platform stat structure |
+
+Requested result attributes outside this list are returned as nil.
+
+## Limitations and notes
+
+* CNID backend
+
+    The CNID backend depends on CNID database consistency and is intended
+    for simple filename search rather than full Spotlight metadata search.
+
+* LocalSearch backend
+
+    The LocalSearch backend depends on LocalSearch/Tracker, TinySPARQL,
+    GLib, D-Bus, and the host indexer's filesystem monitoring behavior.
 
     Tracker on Linux uses the inotify Kernel filesystem change event API
     for tracking filesystem changes. On large filesystems this may be
-    problematic since the inotify API doesn't offer recursive directory
+    problematic since the inotify API does not offer recursive directory
     watches but instead requires that for every subdirectory watches must
     be added individually.
 
@@ -20,46 +243,19 @@ Limitations and notes
     unknown which limitations and resource consumption this Solaris
     subsystem may have.
 
-    We therefore recommend to disable live filesystem monitoring and let
-    Tracker periodically scan filesystems for changes instead, see the
-    Tracker configuration options enable-monitors and crawling-interval below.
+    A known limitation means that shared volumes in a user's home directory
+    may not get indexed by LocalSearch/Tracker. As a workaround, keep the
+    shared volumes you want to have indexed elsewhere on the host filesystem.
 
-* Indexing home directories
+* Xapian backend
 
-    A known limitation with the current implementation means that shared
-    volumes in a user's home directory does not get indexed by Spotlight.
+    The Xapian backend is managed by Netatalk itself. Its index is local to
+    the Netatalk state directory and is refreshed by a full reconciliation
+    on first use, then by AFP-originated file events. Changes made outside
+    AFP may not be reflected until reconciliation runs again.
 
-    As a workaround, keep the shared volumes you want to have indexed
-    elsewhere on the host filesystem.
-
-Supported metadata attributes
------------------------------
-
-The following table lists the supported Spotlight metadata attributes,
-based on Apple's [MDItem object](https://developer.apple.com/documentation/coreservices/mditemref/)
-Core Services file metadata standard.
-
-| Description | Spotlight Key |
-|-------------|---------------|
-| Name | kMDItemDisplayName, kMDItemFSName |
-| Document content (full text search) | kMDItemTextContent |
-| File type | \_kMDItemGroupId, kMDItemContentTypeTree |
-| File modification date | kMDItemFSContentChangeDate, kMDItemContentModificationDate, kMDItemAttributeChangeDate |
-| Content Creation date | kMDItemContentCreationDate |
-| The author, or authors, of the contents of the file | kMDItemAuthors, kMDItemCreator |
-| The name of the country where the item was created | kMDItemCountry |
-| Duration | kMDItemDurationSeconds |
-| Number of pages | kMDItemNumberOfPages |
-| Document title | kMDItemTitle |
-| The width, in pixels, of the contents. For example, the image width or the video frame width | kMDItemPixelWidth |
-| The height, in pixels, of the contents. For example, the image height or the video frame height | kMDItemPixelHeight |
-| The color space model used by the document contents | kMDItemColorSpace |
-| The number of bits per sample | kMDItemBitsPerSample |
-| Focal length of the lens, in millimeters | kMDItemFocalLength |
-| ISO speed | kMDItemISOSpeed |
-| Orientation of the document. Possible values are 0 (landscape) and 1 (portrait) | kMDItemOrientation |
-| Resolution width, in DPI | kMDItemResolutionWidthDPI |
-| Resolution height, in DPI | kMDItemResolutionHeightDPI |
-| Exposure time, in seconds | kMDItemExposureTimeSeconds |
-| The composer of the music contained in the audio file | kMDItemComposer |
-| The musical genre of the song or composition | kMDItemMusicalGenre |
+    Body text indexing is intentionally limited to world-readable regular
+    files, because the Xapian database is a shared per-volume index. This
+    avoids adding private file contents to shared index terms, but means
+    content searches can miss files that the connected AFP user can read
+    through owner, group, or ACL permissions.

--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -701,8 +701,9 @@ covering Spotlight and Catalog Search.
 
 dbus daemon = *path* **(G)**
 
-> Sets the path to dbus-daemon binary used by the Spotlight feature. Can
-be used when the compile-time default path does not match the runtime
+> Sets the path to dbus-daemon binary used to launch a private D-Bus
+for the LocalSearch backend.
+Can be used when the compile-time default path does not match the runtime
 environment.
 >
 > If support is compiled into Netatalk, you may alternatively use
@@ -723,30 +724,51 @@ sparql results limit = *NUMBER* (default: *UNLIMITED*) **(G)**
 
 > Impose a limit on the number of results queried from Tracker or
 LocalSearch via SPARQL queries.
+>
+> The *xapian* backend also uses this value as its per-query result limit,
+despite the historical option name. When set to *0*, LocalSearch queries
+are unlimited, while the *xapian* backend applies an internal safety cap
+of 10000 candidate results. Set a larger nonzero value to raise the
+*xapian* cap. The *cnid* backend does not use this option and is limited
+by its fixed CNID search reply cap.
 
 spotlight = *BOOLEAN* (default: *yes*) **(G)**/**(V)**
 
-> Whether to enable Spotlight searches. Note: once the global option is
-enabled, any volume that is not enabled won't be searchable at all. See
-also *dbus daemon* option.
+> Whether to enable Spotlight-compatible searches.
+As a global option, this sets the default for volumes. As a volume option,
+it overrides the global default for that volume.
+>
+> A volume is searchable only when its effective **spotlight** setting is
+enabled and a supported **spotlight backend** is available for that volume.
 
 spotlight attributes = *COMMA SEPARATED STRING* (default: *EMPTY*) **(G)**
 
-> A list of attributes that are allowed to be used in Spotlight searches.
-By default all attributes can be searched, passing a string limits
-attributes to elements of the string. Example:
+> A list of Spotlight query attributes accepted by the *localsearch*
+backend. By default all attributes known to the LocalSearch SPARQL mapper
+can be searched; passing a string limits searchable attributes to elements
+of the string. Example:
 
     spotlight attributes = *,kMDItemTextContent
+
+> This option does not affect the *cnid* or *xapian* backends.
 
 spotlight backend = *backend* (default: *cnid*) **(G)**/**(V)**
 
 > Search backend used by the Spotlight feature.
 Most Netatalk configurations will have the *cnid* backend available,
 which allows simple file name matching search on shared volumes.
+>
+> If support is compiled into Netatalk, you may alternatively use
+the *localsearch* or *xapian* backends, which enable more advanced search
+capabilities, including full text search and file metadata search.
+Run **netatalk -v** to see which backends are available in your installation.
 
 spotlight expr = *BOOLEAN* (default: *yes*) **(G)**
 
-> Whether to allow the use of logic expression in searches.
+> Whether the *localsearch* backend allows Spotlight logic expressions
+when translating Spotlight RAW queries to SPARQL.
+>
+> This option does not affect the *cnid* or *xapian* backends.
 
 ## Logging Options
 

--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -206,9 +206,20 @@ functionality.
     This is mostly relevant for developers or package managers who want to regenerate
     the Unicode source files.
 
+- Xapian
+
+    The [Xapian](https://xapian.org/) library is used for Netatalk-managed
+    filename, plain-text content, and MIME type indexing.
+
+- libmagic
+
+    The libmagic library is used by the Xapian Spotlight backend to identify
+    file MIME types.
+
 ### Spotlight LocalSearch backend dependencies
 
-The LocalSearch backend for Spotlight depends on the following third-party software:
+The LocalSearch backend for Spotlight enables rich file content and metadata matching,
+and depends on the following third-party software:
 
 - bison
 

--- a/doc/manual/Search.md
+++ b/doc/manual/Search.md
@@ -23,7 +23,7 @@ Spotlight query handling uses a pluggable backend architecture.
 The AFP Spotlight RPC protocol layer is shared,
 while query execution is delegated to a backend selected per volume.
 
-You can select the backend with the volume option **search backend**.
+You can select the backend with the volume option **spotlight backend**.
 If not set, the default is **cnid**.
 
 Example:
@@ -37,7 +37,7 @@ Example:
 
     [Media]
     path = /srv/afp/media
-    spotlight backend = localsearch
+    spotlight backend = xapian
 
     [Private]
     path = /srv/afp/private
@@ -53,16 +53,27 @@ Available Spotlight backends:
   Uses the LocalSearch/Tracker SPARQL backend for broader file contents and metadata indexing/search.
   This backend requires LocalSearch/Tracker, TinySPARQL, GLib, D-Bus, and related tooling.
 
+- **xapian**
+  Uses a per-volume Xapian index maintained by Netatalk for filename, plain-text content, and MIME type search.
+  This backend requires xapian-core and libmagic.
+
+The **xapian** backend stores a shared per-volume index. To avoid indexing
+private file contents into that shared index, it indexes body text only for
+regular files that are world-readable, readable by the indexing process,
+plain-text-like, and below the backend's text size limit. Files readable to
+a specific AFP user but not world-readable can still match filename and type
+queries, but may not match content queries such as `kMDItemTextContent`.
+
 ### Building Spotlight backends
 
-The Meson option **with-search-backends** controls which Spotlight backends are built.
-Supported values are **cnid** and **localsearch**.
+The Meson option **with-spotlight-backends** controls which Spotlight backends are built.
+Supported values are **cnid**, **localsearch**, and **xapian**.
 
 Example:
 
-    meson setup build -Dwith-search-backends=cnid,localsearch
+    meson setup build -Dwith-spotlight-backends=cnid,localsearch,xapian
 
-The default build enables both backends when their dependencies are available.
+The default build enables the selected backends when their dependencies are available.
 
 ### D-Bus daemon for localsearch
 

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -34,6 +34,9 @@
 #include <atalk/logger.h>
 #include <atalk/netatalk_conf.h>
 #include <atalk/server_ipc.h>
+#ifdef WITH_SPOTLIGHT
+#include <atalk/spotlight.h>
+#endif
 #include <atalk/unix.h>
 #include <atalk/util.h>
 #include <atalk/uuid.h>
@@ -3139,6 +3142,9 @@ int afp_createdir(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf,
 #ifdef WITH_FCE
     fce_register(obj, FCE_DIR_CREATE, bdata(curdir->d_fullpath), NULL);
 #endif /* WITH_FCE */
+#ifdef WITH_SPOTLIGHT
+    sl_index_event(obj, vol, SL_INDEX_DIR_CREATE, bdata(curdir->d_fullpath), NULL);
+#endif /* WITH_SPOTLIGHT */
     ad_flush(&ad);
     /* Eagerly populate AD cache for newly created directory */
     ad_store_to_cache(&ad, dir);

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -947,6 +947,9 @@ createfile_iderr:
 #ifdef WITH_FCE
     fce_register(obj, FCE_FILE_CREATE, fullpathname(upath), NULL);
 #endif /* WITH_FCE */
+#ifdef WITH_SPOTLIGHT
+    sl_index_event(obj, vol, SL_INDEX_FILE_CREATE, fullpathname(upath), NULL);
+#endif /* WITH_SPOTLIGHT */
 
     /* Defensive check: curdir may be corrupted by race conditions or cname() failures */
     if (curdir == NULL) {
@@ -1826,6 +1829,9 @@ copy_exit:
 #ifdef WITH_FCE
         fce_register(obj, FCE_FILE_CREATE, fullpathname(upath), NULL);
 #endif /* WITH_FCE */
+#ifdef WITH_SPOTLIGHT
+        sl_index_event(obj, d_vol, SL_INDEX_FILE_CREATE, fullpathname(upath), NULL);
+#endif /* WITH_SPOTLIGHT */
         /* Send hint to afpd siblings — dest parent dir ctime changed due to copy */
         ipc_send_cache_hint(obj, d_vol->v_vid, curdir->d_did, CACHE_HINT_REFRESH);
     }

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -25,6 +25,9 @@
 #include <atalk/logger.h>
 #include <atalk/netatalk_conf.h>
 #include <atalk/server_ipc.h>
+#ifdef WITH_SPOTLIGHT
+#include <atalk/spotlight.h>
+#endif
 #include <atalk/unix.h>
 #include <atalk/util.h>
 #include <atalk/vfs.h>
@@ -401,6 +404,12 @@ static int moveandrename(const AFPObj *obj,
     /* Save sdir->d_fullpath for LOG and FCE events — sdir may be modified during rename */
     saved_sdir_fullpath = bstrcpy(sdir->d_fullpath);
 
+    if (saved_sdir_fullpath == NULL) {
+        LOG(log_error, logtype_afpd, "moveandrename: out of memory");
+        free(oldunixname);
+        return AFPERR_MISC;
+    }
+
     /*
      * we are in the dest folder so we need to use
      *   a) oldunixname for ad_open
@@ -551,6 +560,10 @@ static int moveandrename(const AFPObj *obj,
 #ifdef WITH_FCE
             fce_register(obj, FCE_DIR_MOVE, fullpathname(upath), oldunixname);
 #endif /* WITH_FCE */
+#ifdef WITH_SPOTLIGHT
+            sl_index_event(obj, vol, SL_INDEX_DIR_MOVE,
+                           fullpathname(upath), bdata(saved_sdir_fullpath));
+#endif /* WITH_SPOTLIGHT */
         }
 
         /* File rename: update cache entry if pre-acquired */
@@ -578,6 +591,19 @@ static int moveandrename(const AFPObj *obj,
         }
 
 #endif /* WITH_FCE */
+#ifdef WITH_SPOTLIGHT
+
+        if (!isdir) {
+            bstring srcpath = bformat("%s/%s", bdata(saved_sdir_fullpath), oldunixname);
+
+            if (srcpath != NULL) {
+                sl_index_event(obj, vol, SL_INDEX_FILE_MOVE,
+                               fullpathname(upath), bdata(srcpath));
+                bdestroy(srcpath);
+            }
+        }
+
+#endif /* WITH_SPOTLIGHT */
 
         /* Fixup adouble info — separate ad_open for CNID write.
          * adflags includes ADFLAGS_DIR for directories (set at line 301). */
@@ -962,6 +988,9 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 #ifdef WITH_FCE
             fce_register(obj, FCE_DIR_DELETE, fullpathname(upath), NULL);
 #endif /* WITH_FCE */
+#ifdef WITH_SPOTLIGHT
+            sl_index_event(obj, vol, SL_INDEX_DIR_DELETE, fullpathname(upath), NULL);
+#endif /* WITH_SPOTLIGHT */
         } else {
             /* we have to cache this, the structs are lost in deletcurdir*/
             /* but we need the positive returncode to send our event */
@@ -976,6 +1005,10 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 #ifdef WITH_FCE
                 fce_register(obj, FCE_DIR_DELETE, fullpathname(cfrombstr(dname)), NULL);
 #endif /* WITH_FCE */
+#ifdef WITH_SPOTLIGHT
+                sl_index_event(obj, vol, SL_INDEX_DIR_DELETE,
+                               fullpathname(cfrombstr(dname)), NULL);
+#endif /* WITH_SPOTLIGHT */
             }
 
             bdestroy(dname);
@@ -1028,6 +1061,9 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 #ifdef WITH_FCE
                 fce_register(obj, FCE_FILE_DELETE, fullpathname(upath), NULL);
 #endif /* WITH_FCE */
+#ifdef WITH_SPOTLIGHT
+                sl_index_event(obj, vol, SL_INDEX_FILE_DELETE, fullpathname(upath), NULL);
+#endif /* WITH_SPOTLIGHT */
 
                 /* Send hints to afpd siblings — file deleted */
                 if (file_cnid != CNID_INVALID) {

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -59,6 +59,9 @@ if have_spotlight
     if use_spotlight_localsearch
         afpd_external_deps += [glib, sparql]
     endif
+    if use_spotlight_xapian
+        afpd_external_deps += [xapian, libmagic]
+    endif
 endif
 
 if have_afpstats
@@ -210,6 +213,7 @@ executable(
         uamdir,
     ],
     link_args: netatalk_common_link_args,
+    link_language: use_spotlight_xapian ? 'cpp' : 'c',
     export_dynamic: true,
     install: true,
     install_dir: sbindir,

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -22,6 +22,9 @@
 #include <atalk/globals.h>
 #include <atalk/logger.h>
 #include <atalk/server_ipc.h>
+#ifdef WITH_SPOTLIGHT
+#include <atalk/spotlight.h>
+#endif
 #include <atalk/util.h>
 
 #include "ad_cache.h"
@@ -658,6 +661,15 @@ int of_closefork(const AFPObj *obj, struct ofork *ofork)
     if (ad_close(ofork->of_ad, adflags | ADFLAGS_SETSHRMD) < 0) {
         ret = -1;
     }
+
+#ifdef WITH_SPOTLIGHT
+
+    if (ret == 0 && (ofork->of_flags & AFPFORK_MODIFIED) && forkpath) {
+        sl_index_event(obj, ofork->of_vol, SL_INDEX_FILE_MODIFY,
+                       bdata(forkpath), NULL);
+    }
+
+#endif /* WITH_SPOTLIGHT */
 
     /* Unlink the emptied Icon\r file after ad_close has released fds */
     if (delete_icon && forkpath && bdata(forkpath)) {

--- a/etc/afpd/spotlight.c
+++ b/etc/afpd/spotlight.c
@@ -89,6 +89,21 @@ static char *tab_level(TALLOC_CTX *mem_ctx, int level)
     return string;
 }
 
+int sl_index_event(const AFPObj *obj,
+                   const struct vol *vol,
+                   sl_index_event_t event,
+                   const char *path,
+                   const char *oldpath)
+{
+    if (vol == NULL || !(vol->v_flags & AFPVOL_SPOTLIGHT)
+            || vol->v_sl_backend == NULL
+            || vol->v_sl_backend->sbo_index_event == NULL) {
+        return 0;
+    }
+
+    return vol->v_sl_backend->sbo_index_event(obj, vol, event, path, oldpath);
+}
+
 static char *dd_dump(DALLOC_CTX *dd, int nestinglevel)
 {
     const char *type;

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -972,6 +972,13 @@ int afp_openvol(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf,
         }
 
 #endif
+#ifdef SPOTLIGHT_BACKEND_XAPIAN
+
+        if (strcasecmp(bname, "xapian") == 0) {
+            volume->v_sl_backend = &sl_xapian_ops;
+        }
+
+#endif
 
         if (volume->v_sl_backend == NULL) {
             LOG(log_warning, logtype_afpd,

--- a/etc/spotlight/meson.build
+++ b/etc/spotlight/meson.build
@@ -1,5 +1,10 @@
 libspotlight_backends_libs = []
 
+if use_spotlight_xapian
+    subdir('xapian')
+    libspotlight_backends_libs += libspotlight_xapian
+endif
+
 if use_spotlight_localsearch
     subdir('localsearch')
     libspotlight_backends_libs += libspotlight_localsearch

--- a/etc/spotlight/sl_backends.h
+++ b/etc/spotlight/sl_backends.h
@@ -8,12 +8,16 @@
 
 #include <atalk/spotlight.h>
 
+#ifdef SPOTLIGHT_BACKEND_CNID
+extern const sl_backend_ops sl_cnid_ops;
+#endif
+
 #ifdef SPOTLIGHT_BACKEND_LOCALSEARCH
 extern const sl_backend_ops sl_localsearch_ops;
 #endif
 
-#ifdef SPOTLIGHT_BACKEND_CNID
-extern const sl_backend_ops sl_cnid_ops;
+#ifdef SPOTLIGHT_BACKEND_XAPIAN
+extern const sl_backend_ops sl_xapian_ops;
 #endif
 
 #endif /* SPOTLIGHT_BACKENDS_H */

--- a/etc/spotlight/xapian/meson.build
+++ b/etc/spotlight/xapian/meson.build
@@ -1,0 +1,25 @@
+libspotlight_xapian = static_library(
+    'spotlight_xapian',
+    [
+        'sl_xapian.c',
+        'xapian_wrapper.cc',
+    ],
+    dependencies: [
+        bstring,
+        iniparser,
+        libmagic,
+        talloc,
+        xapian,
+    ],
+    include_directories: root_includes,
+    c_args: [
+        '-DSPOTLIGHT_BACKEND_XAPIAN=1',
+        statedir,
+    ],
+    cpp_args: [
+        '-DSPOTLIGHT_BACKEND_XAPIAN=1',
+        statedir,
+    ],
+    override_options: ['cpp_std=c++17'],
+    install: false,
+)

--- a/etc/spotlight/xapian/sl_xapian.c
+++ b/etc/spotlight/xapian/sl_xapian.c
@@ -1,0 +1,612 @@
+/*
+ * Spotlight Xapian backend for Netatalk.
+ *
+ * Copyright (c) 2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <talloc.h>
+
+#include <atalk/cnid.h>
+#include <atalk/errchk.h>
+#include <atalk/globals.h>
+#include <atalk/logger.h>
+#include <atalk/spotlight.h>
+#include <atalk/unix.h>
+#include <atalk/util.h>
+#include <atalk/volume.h>
+
+#include "etc/spotlight/spotlight_private.h"
+#include "etc/spotlight/xapian/sl_xapian.h"
+
+#define SL_XAPIAN_PAGE_SIZE 20
+/* Safety cap used when the global result limit is configured as unlimited. */
+#define SL_XAPIAN_DEFAULT_LIMIT 10000
+#define SL_XAPIAN_DB_ID_MAX 128
+
+struct sl_xapian_seeded {
+    char *volpath;
+    struct sl_xapian_seeded *next;
+};
+
+struct sl_xapian_query {
+    char **paths;
+    size_t count;
+    size_t pos;
+};
+
+static struct sl_xapian_seeded *seeded_volumes;
+
+static int sl_xapian_mkdir_state(const char *path, mode_t mode, char *errbuf,
+                                 size_t errlen)
+{
+    struct stat st;
+
+    if (mkdir(path, mode) != 0 && errno != EEXIST) {
+        snprintf(errbuf, errlen, "%s: %s", path, strerror(errno));
+        return -1;
+    }
+
+    if (stat(path, &st) != 0) {
+        snprintf(errbuf, errlen, "%s: %s", path, strerror(errno));
+        return -1;
+    }
+
+    if (!S_ISDIR(st.st_mode)) {
+        snprintf(errbuf, errlen, "%s exists but is not a directory", path);
+        return -1;
+    }
+
+    if ((st.st_mode & mode) != mode && chmod(path, mode) != 0) {
+        snprintf(errbuf, errlen, "%s: chmod failed: %s", path, strerror(errno));
+        return -1;
+    }
+
+    return 0;
+}
+
+static int sl_xapian_ensure_state_root(char *errbuf, size_t errlen)
+{
+    int ret = 0;
+    become_root();
+
+    if (sl_xapian_mkdir_state(_PATH_STATEDIR "spotlight", 0755,
+                              errbuf, errlen) != 0
+            || sl_xapian_mkdir_state(_PATH_STATEDIR "spotlight/xapian", 01777,
+                                     errbuf, errlen) != 0) {
+        ret = -1;
+    }
+
+    unbecome_root();
+    return ret;
+}
+
+static int cnid_comp_fn(const void *p1, const void *p2)
+{
+    const uint64_t *c1 = p1, *c2 = p2;
+
+    if (*c1 == *c2) {
+        return 0;
+    }
+
+    return (*c1 < *c2) ? -1 : 1;
+}
+
+static bool sl_xapian_path_in_scope(const char *path, const char *scope)
+{
+    if (path == NULL || scope == NULL) {
+        return false;
+    }
+
+    if (scope[0] == '\0' || (scope[0] == '/' && scope[1] == '\0')) {
+        return true;
+    }
+
+    while (*scope != '\0' && *scope == *path) {
+        scope++;
+        path++;
+    }
+
+    if (*scope != '\0') {
+        return false;
+    }
+
+    return *path == '\0' || *path == '/';
+}
+
+static bool sl_xapian_seeded(const struct vol *vol)
+{
+    for (struct sl_xapian_seeded *p = seeded_volumes; p != NULL; p = p->next) {
+        if (strcmp(p->volpath, vol->v_path) == 0) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static int sl_xapian_mark_seeded(const struct vol *vol)
+{
+    struct sl_xapian_seeded *p;
+    p = calloc(1, sizeof(*p));
+
+    if (p == NULL) {
+        return -1;
+    }
+
+    p->volpath = strdup(vol->v_path);
+
+    if (p->volpath == NULL) {
+        free(p);
+        return -1;
+    }
+
+    p->next = seeded_volumes;
+    seeded_volumes = p;
+    return 0;
+}
+
+static void sl_xapian_unmark_seeded(const struct vol *vol)
+{
+    struct sl_xapian_seeded **pp = &seeded_volumes;
+
+    if (vol == NULL) {
+        return;
+    }
+
+    while (*pp != NULL) {
+        struct sl_xapian_seeded *p = *pp;
+
+        if (strcmp(p->volpath, vol->v_path) == 0) {
+            *pp = p->next;
+            free(p->volpath);
+            free(p);
+            return;
+        }
+
+        pp = &p->next;
+    }
+}
+
+static bool sl_xapian_db_id_char_safe(unsigned char c)
+{
+    return (c >= 'A' && c <= 'Z')
+           || (c >= 'a' && c <= 'z')
+           || (c >= '0' && c <= '9')
+           || c == '-' || c == '_' || c == '.';
+}
+
+static uint64_t sl_xapian_fnv1a_update(uint64_t hash, const char *s)
+{
+    while (s != NULL && *s != '\0') {
+        hash ^= (unsigned char) * s++;
+        hash *= 1099511628211ULL;
+    }
+
+    return hash;
+}
+
+static bool sl_xapian_db_id_safe(const char *id)
+{
+    size_t len;
+
+    if (id == NULL || id[0] == '\0') {
+        return false;
+    }
+
+    if (strcmp(id, ".") == 0 || strcmp(id, "..") == 0) {
+        return false;
+    }
+
+    len = strnlen(id, SL_XAPIAN_DB_ID_MAX + 1);
+
+    if (len > SL_XAPIAN_DB_ID_MAX) {
+        return false;
+    }
+
+    for (size_t i = 0; i < len; i++) {
+        if (!sl_xapian_db_id_char_safe((unsigned char)id[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+static uint64_t sl_xapian_db_id_hash(const struct vol *vol, const char *id)
+{
+    uint64_t hash = 1469598103934665603ULL;
+    hash = sl_xapian_fnv1a_update(hash, id);
+    hash = sl_xapian_fnv1a_update(hash, "\xff");
+    return sl_xapian_fnv1a_update(hash, vol ? vol->v_path : NULL);
+}
+
+static char *sl_xapian_db_path(TALLOC_CTX *mem_ctx, const struct vol *vol)
+{
+    const char *uuid = vol->v_uuid && vol->v_uuid[0] != '\0'
+                       ? vol->v_uuid : vol->v_localname;
+    char *db_id;
+
+    if (uuid == NULL || uuid[0] == '\0') {
+        uuid = "unknown";
+    }
+
+    if (sl_xapian_db_id_safe(uuid)) {
+        db_id = talloc_strdup(mem_ctx, uuid);
+    } else {
+        db_id = talloc_asprintf(mem_ctx, "unsafe-%016" PRIx64,
+                                sl_xapian_db_id_hash(vol, uuid));
+    }
+
+    if (db_id == NULL) {
+        return NULL;
+    }
+
+    return talloc_asprintf(mem_ctx, _PATH_STATEDIR "spotlight/xapian/%s", db_id);
+}
+
+static const char *sl_xapian_volume_uuid(const struct vol *vol)
+{
+    if (vol == NULL) {
+        return "";
+    }
+
+    if (vol->v_uuid != NULL && vol->v_uuid[0] != '\0') {
+        return vol->v_uuid;
+    }
+
+    if (vol->v_localname != NULL && vol->v_localname[0] != '\0') {
+        return vol->v_localname;
+    }
+
+    return "";
+}
+
+static int sl_xapian_ensure_seeded(slq_t *slq, const char *db_path)
+{
+    char errbuf[512] = {0};
+    const char *volume_uuid = sl_xapian_volume_uuid(slq->slq_vol);
+    int ready;
+
+    if (sl_xapian_seeded(slq->slq_vol)) {
+        return 0;
+    }
+
+    if (sl_xapian_ensure_state_root(errbuf, sizeof(errbuf)) != 0) {
+        LOG(log_error, logtype_sl,
+            "xapian backend: failed to prepare state directory: %s",
+            errbuf);
+        return -1;
+    }
+
+    ready = sl_xapian_index_ready(db_path, slq->slq_vol->v_path, volume_uuid,
+                                  errbuf, sizeof(errbuf));
+
+    if (ready > 0) {
+        if (sl_xapian_mark_seeded(slq->slq_vol) != 0) {
+            LOG(log_error, logtype_sl, "xapian backend: out of memory");
+            return -1;
+        }
+
+        return 0;
+    }
+
+    if (ready < 0) {
+        LOG(log_warning, logtype_sl,
+            "xapian backend: index metadata check failed for %s: %s",
+            slq->slq_vol->v_path, errbuf);
+    }
+
+    LOG(log_info, logtype_sl,
+        "xapian backend: reconciling index for volume %s",
+        slq->slq_vol->v_path);
+
+    if (sl_xapian_reconcile(db_path, slq->slq_vol->v_path, volume_uuid,
+                            errbuf, sizeof(errbuf)) != 0) {
+        LOG(log_error, logtype_sl,
+            "xapian backend: reconcile failed for %s: %s",
+            slq->slq_vol->v_path, errbuf);
+        return -1;
+    }
+
+    if (sl_xapian_mark_seeded(slq->slq_vol) != 0) {
+        LOG(log_error, logtype_sl, "xapian backend: out of memory");
+        return -1;
+    }
+
+    return 0;
+}
+
+static int sl_xapian_fill_results(slq_t *slq)
+{
+    EC_INIT;
+    struct sl_xapian_query *xsq = slq->slq_backend_private;
+    int page_count = 0;
+
+    if (slq->query_results == NULL) {
+        LOG(log_error, logtype_sl, "xapian backend: no result handle");
+        slq->slq_state = SLQ_STATE_ERROR;
+        EC_FAIL;
+    }
+
+    if (xsq == NULL) {
+        slq->slq_state = SLQ_STATE_ERROR;
+        EC_FAIL;
+    }
+
+    while (xsq->pos < xsq->count && page_count < SL_XAPIAN_PAGE_SIZE) {
+        const char *path = xsq->paths[xsq->pos++];
+        struct stat sb;
+        cnid_t did, id;
+        uint64_t uint64var;
+        bool ok;
+
+        if (!sl_xapian_path_in_scope(path, slq->slq_scope)) {
+            continue;
+        }
+
+        if (stat(path, &sb) != 0) {
+            LOG(log_debug, logtype_sl,
+                "xapian backend: skipping stale result: %s", path);
+            continue;
+        }
+
+        if (access(path, R_OK) != 0) {
+            LOG(log_debug, logtype_sl,
+                "xapian backend: access denied: %s", path);
+            continue;
+        }
+
+        id = cnid_for_path(slq->slq_vol->v_cdb, slq->slq_vol->v_path, path, &did);
+
+        if (id == CNID_INVALID) {
+            LOG(log_debug, logtype_sl,
+                "xapian backend: no CNID for result: %s", path);
+            continue;
+        }
+
+        uint64var = ntohl(id);
+
+        if (slq->slq_cnids) {
+            ok = bsearch(&uint64var, slq->slq_cnids, slq->slq_cnids_num,
+                         sizeof(uint64_t), cnid_comp_fn);
+
+            if (!ok) {
+                continue;
+            }
+        }
+
+        dalloc_add_copy(slq->query_results->cnids->ca_cnids,
+                        &uint64var, uint64_t);
+        ok = add_filemeta(slq->slq_reqinfo, slq->query_results->fm_array,
+                          path, &sb);
+
+        if (!ok) {
+            LOG(log_error, logtype_sl, "xapian backend: add_filemeta error");
+            slq->slq_state = SLQ_STATE_ERROR;
+            EC_FAIL;
+        }
+
+        slq->query_results->num_results++;
+        page_count++;
+    }
+
+    slq->slq_state = xsq->pos < xsq->count ? SLQ_STATE_FULL : SLQ_STATE_DONE;
+EC_CLEANUP:
+    EC_EXIT;
+}
+
+static int sl_xapian_init(AFPObj *obj _U_)
+{
+    static bool initialized;
+
+    if (initialized) {
+        return 0;
+    }
+
+    LOG(log_info, logtype_sl, "Initializing xapian backend");
+    initialized = true;
+    return 0;
+}
+
+static void sl_xapian_close(AFPObj *obj _U_)
+{
+    struct sl_xapian_seeded *p = seeded_volumes;
+
+    while (p != NULL) {
+        struct sl_xapian_seeded *next = p->next;
+        free(p->volpath);
+        free(p);
+        p = next;
+    }
+
+    seeded_volumes = NULL;
+}
+
+static int sl_xapian_open_query(slq_t *slq)
+{
+    EC_INIT;
+    struct sl_xapian_query *xsq;
+    const char *db_path = NULL;
+    char errbuf[512] = {0};
+    size_t limit;
+    int more = 0;
+    xsq = talloc_zero(slq, struct sl_xapian_query);
+
+    if (xsq == NULL) {
+        slq->slq_state = SLQ_STATE_ERROR;
+        EC_FAIL;
+    }
+
+    slq->slq_backend_private = xsq;
+    db_path = sl_xapian_db_path(slq, slq->slq_vol);
+
+    if (db_path == NULL) {
+        slq->slq_state = SLQ_STATE_ERROR;
+        EC_FAIL;
+    }
+
+    EC_ZERO(sl_xapian_ensure_seeded(slq, db_path));
+    limit = slq->slq_result_limit ? slq->slq_result_limit : SL_XAPIAN_DEFAULT_LIMIT;
+
+    if (sl_xapian_query(db_path, slq->slq_scope, slq->slq_qstring,
+                        0, limit, &xsq->paths, &xsq->count, &more,
+                        errbuf, sizeof(errbuf)) != 0) {
+        LOG(log_error, logtype_sl,
+            "xapian backend: query failed: %s", errbuf);
+        slq->slq_state = SLQ_STATE_ERROR;
+        EC_FAIL;
+    }
+
+    LOG(log_debug, logtype_sl,
+        "xapian backend: query returned %zu candidate result(s)%s",
+        xsq->count, more ? " (truncated)" : "");
+
+    if (more) {
+        LOG(log_info, logtype_sl,
+            "xapian backend: query truncated at %zu candidate result(s); "
+            "set \"sparql results limit\" to a larger nonzero value to raise the cap",
+            limit);
+    }
+
+    EC_ZERO(sl_xapian_fill_results(slq));
+EC_CLEANUP:
+    EC_EXIT;
+}
+
+static int sl_xapian_fetch_results(slq_t *slq)
+{
+    if (slq->query_results == NULL) {
+        LOG(log_error, logtype_sl, "xapian backend: no result handle");
+        slq->slq_state = SLQ_STATE_ERROR;
+        return -1;
+    }
+
+    if (slq->query_results->num_results > 0 || slq->slq_state == SLQ_STATE_DONE) {
+        return 0;
+    }
+
+    return sl_xapian_fill_results(slq);
+}
+
+static void sl_xapian_close_query(slq_t *slq)
+{
+    struct sl_xapian_query *xsq = slq->slq_backend_private;
+
+    if (xsq != NULL) {
+        sl_xapian_free_paths(xsq->paths, xsq->count);
+        xsq->paths = NULL;
+        xsq->count = 0;
+        talloc_free(xsq);
+        slq->slq_backend_private = NULL;
+    }
+}
+
+static int sl_xapian_index_event(const AFPObj *obj _U_,
+                                 const struct vol *vol,
+                                 sl_index_event_t event,
+                                 const char *path,
+                                 const char *oldpath)
+{
+    TALLOC_CTX *tmp = talloc_new(NULL);
+    const char *db_path;
+    char errbuf[512] = {0};
+    int ret = 0;
+
+    if (tmp == NULL) {
+        return -1;
+    }
+
+    db_path = sl_xapian_db_path(tmp, vol);
+
+    if (db_path == NULL) {
+        talloc_free(tmp);
+        return -1;
+    }
+
+    if (sl_xapian_ensure_state_root(errbuf, sizeof(errbuf)) != 0) {
+        LOG(log_warning, logtype_sl,
+            "xapian backend: failed to prepare state directory: %s",
+            errbuf);
+        talloc_free(tmp);
+        return -1;
+    }
+
+    switch (event) {
+    case SL_INDEX_FILE_CREATE:
+    case SL_INDEX_DIR_CREATE:
+    case SL_INDEX_FILE_MODIFY:
+        ret = sl_xapian_upsert_path(db_path, path, errbuf, sizeof(errbuf));
+        break;
+
+    case SL_INDEX_FILE_DELETE:
+        ret = sl_xapian_delete_path(db_path, path, errbuf, sizeof(errbuf));
+        break;
+
+    case SL_INDEX_DIR_DELETE:
+        ret = sl_xapian_delete_prefix(db_path, path, errbuf, sizeof(errbuf));
+        break;
+
+    case SL_INDEX_FILE_MOVE:
+        ret = sl_xapian_delete_path(db_path, oldpath, errbuf, sizeof(errbuf));
+
+        if (ret == 0) {
+            ret = sl_xapian_upsert_path(db_path, path, errbuf, sizeof(errbuf));
+        }
+
+        break;
+
+    case SL_INDEX_DIR_MOVE:
+        ret = sl_xapian_reindex_subtree(db_path, vol->v_path, path, oldpath,
+                                        errbuf, sizeof(errbuf));
+        break;
+    }
+
+    if (ret != 0) {
+        char dirty_errbuf[512] = {0};
+        sl_xapian_unmark_seeded(vol);
+
+        if (sl_xapian_mark_dirty(db_path, dirty_errbuf,
+                                 sizeof(dirty_errbuf)) != 0) {
+            LOG(log_warning, logtype_sl,
+                "xapian backend: failed to mark index dirty for %s: %s",
+                vol->v_path, dirty_errbuf);
+        }
+
+        LOG(log_warning, logtype_sl,
+            "xapian backend: incremental index update failed for %s: %s",
+            path ? path : "(null)", errbuf);
+    }
+
+    talloc_free(tmp);
+    return ret;
+}
+
+const sl_backend_ops sl_xapian_ops = {
+    .sbo_name          = "xapian",
+    .sbo_init          = sl_xapian_init,
+    .sbo_close         = sl_xapian_close,
+    .sbo_open_query    = sl_xapian_open_query,
+    .sbo_fetch_results = sl_xapian_fetch_results,
+    .sbo_close_query   = sl_xapian_close_query,
+    .sbo_index_event   = sl_xapian_index_event,
+};

--- a/etc/spotlight/xapian/sl_xapian.h
+++ b/etc/spotlight/xapian/sl_xapian.h
@@ -1,0 +1,64 @@
+/*
+ * C wrapper boundary for the Spotlight Xapian backend.
+ *
+ * The implementation is C++ because libxapian exposes a C++ API.  All
+ * functions here catch C++ exceptions before returning to C callers.
+ */
+
+#ifndef SL_XAPIAN_H
+#define SL_XAPIAN_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int sl_xapian_reconcile(const char *db_path,
+                        const char *volume_path,
+                        const char *volume_uuid,
+                        char *errbuf,
+                        size_t errlen);
+int sl_xapian_index_ready(const char *db_path,
+                          const char *volume_path,
+                          const char *volume_uuid,
+                          char *errbuf,
+                          size_t errlen);
+int sl_xapian_query(const char *db_path,
+                    const char *scope,
+                    const char *qstring,
+                    size_t offset,
+                    size_t limit,
+                    char ***paths,
+                    size_t *count,
+                    int *more,
+                    char *errbuf,
+                    size_t errlen);
+int sl_xapian_upsert_path(const char *db_path,
+                          const char *path,
+                          char *errbuf,
+                          size_t errlen);
+int sl_xapian_delete_path(const char *db_path,
+                          const char *path,
+                          char *errbuf,
+                          size_t errlen);
+int sl_xapian_delete_prefix(const char *db_path,
+                            const char *path,
+                            char *errbuf,
+                            size_t errlen);
+int sl_xapian_reindex_subtree(const char *db_path,
+                              const char *volume_path,
+                              const char *path,
+                              const char *oldpath,
+                              char *errbuf,
+                              size_t errlen);
+int sl_xapian_mark_dirty(const char *db_path,
+                         char *errbuf,
+                         size_t errlen);
+void sl_xapian_free_paths(char **paths, size_t count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SL_XAPIAN_H */

--- a/etc/spotlight/xapian/xapian_wrapper.cc
+++ b/etc/spotlight/xapian/xapian_wrapper.cc
@@ -1,0 +1,1652 @@
+/*
+ * Xapian implementation for the Netatalk Spotlight backend.
+ *
+ * Copyright (c) 2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "etc/spotlight/xapian/sl_xapian.h"
+
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cctype>
+#include <exception>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <xapian.h>
+#include <magic.h>
+
+namespace
+{
+
+const Xapian::valueno VALUE_PATH = 0;
+const Xapian::valueno VALUE_TYPE = 1;
+const Xapian::valueno VALUE_MTIME = 2;
+const Xapian::valueno VALUE_SIZE = 3;
+const Xapian::valueno VALUE_MIME = 4;
+const Xapian::valueno VALUE_GENERATION = 5;
+const size_t TEXT_MAX_BYTES = 16 * 1024 * 1024;
+const size_t TEXT_SAMPLE_BYTES = 4096;
+const char METADATA_SCHEMA_VERSION[] = "netatalk.schema_version";
+const char METADATA_VOLUME_UUID[] = "netatalk.volume_uuid";
+const char METADATA_VOLUME_PATH[] = "netatalk.volume_path";
+const char METADATA_LAST_COMPLETE_GENERATION[] =
+    "netatalk.last_complete_generation";
+const char METADATA_RECONCILE_IN_PROGRESS[] =
+    "netatalk.reconcile_in_progress";
+const char METADATA_DIRTY[] = "netatalk.dirty";
+const char INDEX_SCHEMA_VERSION[] = "1";
+
+class XapianTransaction
+{
+public:
+    explicit XapianTransaction(Xapian::WritableDatabase &db) : db(db)
+    {
+        db.begin_transaction();
+        active = true;
+    }
+
+    ~XapianTransaction()
+    {
+        if (active) {
+            try {
+                db.cancel_transaction();
+            } catch (...) {
+                // Destructors must not throw.
+            }
+        }
+    }
+
+    XapianTransaction(const XapianTransaction &) = delete;
+    XapianTransaction &operator=(const XapianTransaction &) = delete;
+
+    void commit()
+    {
+        db.commit_transaction();
+        active = false;
+    }
+
+    void cancel()
+    {
+        db.cancel_transaction();
+        active = false;
+    }
+
+private:
+    Xapian::WritableDatabase &db;
+    bool active = false;
+};
+
+class MagicCookie
+{
+public:
+    MagicCookie() = default;
+    ~MagicCookie()
+    {
+        if (cookie != nullptr) {
+            magic_close(cookie);
+        }
+    }
+
+    MagicCookie(const MagicCookie &) = delete;
+    MagicCookie &operator=(const MagicCookie &) = delete;
+
+    bool open(std::string &errmsg)
+    {
+        cookie = magic_open(MAGIC_MIME_TYPE);
+
+        if (cookie == nullptr) {
+            errmsg = "magic_open failed";
+            return false;
+        }
+
+        if (magic_load(cookie, nullptr) != 0) {
+            errmsg = magic_error(cookie) ? magic_error(cookie) : "magic_load failed";
+            magic_close(cookie);
+            cookie = nullptr;
+            return false;
+        }
+
+        return true;
+    }
+
+    magic_t get() const
+    {
+        return cookie;
+    }
+
+private:
+    magic_t cookie = nullptr;
+};
+
+void set_error(char *errbuf, size_t errlen, const std::string &msg)
+{
+    if (errbuf == nullptr || errlen == 0) {
+        return;
+    }
+
+    snprintf(errbuf, errlen, "%s", msg.c_str());
+}
+
+bool mkdir_one(const std::string &path, std::string &errmsg)
+{
+    if (path.empty()) {
+        return true;
+    }
+
+    if (mkdir(path.c_str(), 0775) == 0) {
+        return true;
+    }
+
+    int saved_errno = errno;
+
+    if (saved_errno == EEXIST) {
+        struct stat st;
+
+        if (stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode)) {
+            return true;
+        }
+
+        if (stat(path.c_str(), &st) != 0) {
+            saved_errno = errno;
+            errmsg = path + ": " + strerror(saved_errno);
+        } else {
+            errmsg = path + ": exists but is not a directory";
+        }
+
+        return false;
+    }
+
+    errmsg = path + ": " + strerror(saved_errno);
+    return false;
+}
+
+bool mkdir_p(const std::string &path, std::string &errmsg)
+{
+    std::string partial;
+
+    if (path.empty()) {
+        errmsg = "empty path";
+        return false;
+    }
+
+    if (path[0] == '/') {
+        partial = "/";
+    }
+
+    size_t start = (path[0] == '/') ? 1 : 0;
+
+    while (start < path.size()) {
+        size_t slash = path.find('/', start);
+
+        if (std::string part = path.substr(start, slash - start); !part.empty()) {
+            if (partial.size() > 1 && partial[partial.size() - 1] != '/') {
+                partial += '/';
+            }
+
+            partial += part;
+
+            if (!mkdir_one(partial, errmsg)) {
+                return false;
+            }
+        }
+
+        if (slash == std::string::npos) {
+            break;
+        }
+
+        start = slash + 1;
+    }
+
+    return true;
+}
+
+std::string dirname_of(const std::string &path)
+{
+    size_t slash = path.rfind('/');
+
+    if (slash == std::string::npos) {
+        return ".";
+    }
+
+    if (slash == 0) {
+        return "/";
+    }
+
+    return path.substr(0, slash);
+}
+
+std::string basename_of(const std::string &path)
+{
+    size_t slash = path.rfind('/');
+
+    if (slash == std::string::npos) {
+        return path;
+    }
+
+    return path.substr(slash + 1);
+}
+
+bool metadata_name(const char *name)
+{
+    return strcmp(name, ".") == 0
+           || strcmp(name, "..") == 0
+           || strcmp(name, ".AppleDB") == 0
+           || strcmp(name, ".AppleDesktop") == 0
+           || strcmp(name, ".AppleDouble") == 0
+           || strcmp(name, ".Parent") == 0
+           || strncmp(name, "._", 2) == 0;
+}
+
+bool path_in_scope(const std::string &path, const std::string &scope)
+{
+    if (scope.empty() || scope == "/") {
+        return true;
+    }
+
+    if (path == scope) {
+        return true;
+    }
+
+    return path.size() > scope.size()
+           && path.compare(0, scope.size(), scope) == 0
+           && path[scope.size()] == '/';
+}
+
+std::string fnv1a_hex(const std::string &s)
+{
+    uint64_t hash = 1469598103934665603ULL;
+    char buf[32];
+
+    for (char c : s) {
+        hash ^= static_cast<unsigned char>(c);
+        hash *= 1099511628211ULL;
+    }
+
+    snprintf(buf, sizeof(buf), "%016llx", static_cast<unsigned long long>(hash));
+    return std::string(buf);
+}
+
+std::string unique_term_for_path(const std::string &path)
+{
+    return std::string("Q") + fnv1a_hex(path);
+}
+
+std::string number_value(uint64_t n)
+{
+    std::ostringstream os;
+    os << n;
+    return os.str();
+}
+
+bool parse_uint64_value(const std::string &s, uint64_t &out)
+{
+    if (s.empty()) {
+        return false;
+    }
+
+    char *end = nullptr;
+    errno = 0;
+    unsigned long long value = strtoull(s.c_str(), &end, 10);
+
+    if (errno != 0 || end == s.c_str() || *end != '\0') {
+        return false;
+    }
+
+    out = static_cast<uint64_t>(value);
+    return true;
+}
+
+std::string next_generation_id(const Xapian::Database &db)
+{
+    uint64_t last = 0;
+    uint64_t in_progress = 0;
+    parse_uint64_value(db.get_metadata(METADATA_LAST_COMPLETE_GENERATION), last);
+    parse_uint64_value(db.get_metadata(METADATA_RECONCILE_IN_PROGRESS),
+                       in_progress);
+    return number_value(std::max(last, in_progress) + 1);
+}
+
+bool truthy_metadata(const std::string &value)
+{
+    return value == "1" || value == "true" || value == "yes";
+}
+
+bool index_metadata_valid(const Xapian::Database &db,
+                          const std::string &volume_path,
+                          const std::string &volume_uuid)
+{
+    if (db.get_metadata(METADATA_SCHEMA_VERSION) != INDEX_SCHEMA_VERSION) {
+        return false;
+    }
+
+    if (db.get_metadata(METADATA_VOLUME_PATH) != volume_path) {
+        return false;
+    }
+
+    if (!volume_uuid.empty()
+            && db.get_metadata(METADATA_VOLUME_UUID) != volume_uuid) {
+        return false;
+    }
+
+    if (db.get_metadata(METADATA_LAST_COMPLETE_GENERATION).empty()) {
+        return false;
+    }
+
+    if (!db.get_metadata(METADATA_RECONCILE_IN_PROGRESS).empty()) {
+        return false;
+    }
+
+    return !truthy_metadata(db.get_metadata(METADATA_DIRTY));
+}
+
+void set_complete_metadata(Xapian::WritableDatabase &db,
+                           const std::string &volume_path,
+                           const std::string &volume_uuid,
+                           const std::string &generation)
+{
+    db.set_metadata(METADATA_SCHEMA_VERSION, INDEX_SCHEMA_VERSION);
+    db.set_metadata(METADATA_VOLUME_UUID, volume_uuid);
+    db.set_metadata(METADATA_VOLUME_PATH, volume_path);
+    db.set_metadata(METADATA_LAST_COMPLETE_GENERATION, generation);
+    db.set_metadata(METADATA_RECONCILE_IN_PROGRESS, "");
+    db.set_metadata(METADATA_DIRTY, "0");
+}
+
+std::string lower_string(const std::string &s)
+{
+    std::string out = s;
+
+    for (char &c : out) {
+        c = static_cast<char>(tolower(static_cast<unsigned char>(c)));
+    }
+
+    return out;
+}
+
+std::string trim_mime(const std::string &mime)
+{
+    size_t start = 0;
+    size_t end = mime.find(';');
+    std::string s = lower_string(mime.substr(0, end));
+
+    while (start < s.size() && isspace(static_cast<unsigned char>(s[start]))) {
+        start++;
+    }
+
+    end = s.size();
+
+    while (end > start && isspace(static_cast<unsigned char>(s[end - 1]))) {
+        end--;
+    }
+
+    return s.substr(start, end - start);
+}
+
+template <size_t N>
+bool has_suffix(const std::string &s, const char (&suffix)[N])
+{
+    return s.size() >= N - 1
+           && s.compare(s.size() - (N - 1), N - 1, suffix) == 0;
+}
+
+template <size_t N>
+bool starts_with(const std::string &s, const char (&prefix)[N])
+{
+    return s.compare(0, N - 1, prefix) == 0;
+}
+
+std::string exact_term(const char *prefix, const std::string &value)
+{
+    return std::string(prefix) + lower_string(value);
+}
+
+void add_exact_term(Xapian::Document &doc,
+                    const char *prefix,
+                    const std::string &value)
+{
+    if (!value.empty()) {
+        doc.add_term(exact_term(prefix, value));
+    }
+}
+
+void add_category_term(Xapian::Document &doc, const char *category)
+{
+    add_exact_term(doc, "XK", category);
+}
+
+bool source_mime_or_name(const std::string &mime,
+                         const std::string &lower_path)
+{
+    static const char *source_mimes[] = {
+        "application/ecmascript",
+        "application/javascript",
+        "application/json",
+        "application/x-csh",
+        "application/x-perl",
+        "application/x-php",
+        "application/x-python",
+        "application/x-ruby",
+        "application/x-shellscript",
+        "application/x-sh",
+        "application/x-tcl",
+        "text/css",
+        "text/ecmascript",
+        "text/javascript",
+        "text/x-asm",
+        "text/x-c",
+        "text/x-c++",
+        "text/x-cmake",
+        "text/x-diff",
+        "text/x-java",
+        "text/x-makefile",
+        "text/x-objcsrc",
+        "text/x-patch",
+        "text/x-python",
+        "text/x-script",
+        "text/x-shellscript",
+        nullptr
+    };
+
+    for (size_t i = 0; source_mimes[i] != nullptr; i++) {
+        if (mime == source_mimes[i]) {
+            return true;
+        }
+    }
+
+    return has_suffix(lower_path, ".c")
+           || has_suffix(lower_path, ".cc")
+           || has_suffix(lower_path, ".cpp")
+           || has_suffix(lower_path, ".cxx")
+           || has_suffix(lower_path, ".h")
+           || has_suffix(lower_path, ".hh")
+           || has_suffix(lower_path, ".hpp")
+           || has_suffix(lower_path, ".java")
+           || has_suffix(lower_path, ".js")
+           || has_suffix(lower_path, ".json")
+           || has_suffix(lower_path, ".m")
+           || has_suffix(lower_path, ".mm")
+           || has_suffix(lower_path, ".php")
+           || has_suffix(lower_path, ".pl")
+           || has_suffix(lower_path, ".py")
+           || has_suffix(lower_path, ".rb")
+           || has_suffix(lower_path, ".sh")
+           || has_suffix(lower_path, ".swift");
+}
+
+bool presentation_mime(const std::string &mime)
+{
+    return mime == "application/vnd.ms-powerpoint"
+           || mime == "application/vnd.oasis.opendocument.presentation"
+           || mime ==
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+           || mime == "application/x-iwork-keynote-sffkey";
+}
+
+bool font_mime(const std::string &mime)
+{
+    return starts_with(mime, "font/")
+           || starts_with(mime, "application/font")
+           || starts_with(mime, "application/x-font")
+           || mime == "application/vnd.ms-fontobject";
+}
+
+bool executable_mime(const std::string &mime)
+{
+    return mime == "application/x-executable"
+           || mime == "application/x-mach-binary"
+           || mime == "application/x-pie-executable"
+           || mime == "application/x-sharedlib"
+           || mime == "application/x-dosexec"
+           || mime == "application/vnd.microsoft.portable-executable";
+}
+
+bool document_mime(const std::string &mime)
+{
+    return starts_with(mime, "text/")
+           || mime == "application/msword"
+           || mime == "application/pdf"
+           || mime == "application/rtf"
+           || mime == "application/vnd.oasis.opendocument.text"
+           || mime ==
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+           || mime == "application/xhtml+xml"
+           || mime == "application/xml"
+           || presentation_mime(mime);
+}
+
+std::string detect_mime(magic_t magic,
+                        const std::string &path,
+                        const struct stat &st)
+{
+    if (S_ISDIR(st.st_mode)) {
+        return "inode/directory";
+    }
+
+    if (!S_ISREG(st.st_mode) || access(path.c_str(), R_OK) != 0) {
+        return "";
+    }
+
+    const char *mime = magic != nullptr ? magic_file(magic, path.c_str()) : nullptr;
+
+    if (mime == nullptr || mime[0] == '\0') {
+        return "application/octet-stream";
+    }
+
+    return trim_mime(mime);
+}
+
+void index_document_mime(Xapian::Document &doc,
+                         const std::string &path,
+                         const struct stat &st,
+                         magic_t magic)
+{
+    std::string mime = detect_mime(magic, path, st);
+    std::string lower_path = lower_string(path);
+
+    if (!mime.empty()) {
+        doc.add_value(VALUE_MIME, mime);
+        add_exact_term(doc, "XM", mime);
+    }
+
+    if (S_ISDIR(st.st_mode)) {
+        add_category_term(doc, "folder");
+
+        if (has_suffix(lower_path, ".app")) {
+            add_category_term(doc, "software");
+        }
+
+        return;
+    }
+
+    if (starts_with(mime, "image/")) {
+        add_category_term(doc, "image");
+    }
+
+    if (starts_with(mime, "audio/")) {
+        add_category_term(doc, "audio");
+    }
+
+    if (starts_with(mime, "video/")) {
+        add_category_term(doc, "video");
+    }
+
+    if (starts_with(mime, "text/")) {
+        add_category_term(doc, "text");
+    }
+
+    if (mime == "application/pdf") {
+        add_category_term(doc, "pdf");
+    }
+
+    if (source_mime_or_name(mime, lower_path)) {
+        add_category_term(doc, "source");
+        add_category_term(doc, "text");
+    }
+
+    if (executable_mime(mime) || (S_ISREG(st.st_mode) && (st.st_mode & 0111))) {
+        add_category_term(doc, "executable");
+        add_category_term(doc, "software");
+    }
+
+    if (font_mime(mime)) {
+        add_category_term(doc, "font");
+    }
+
+    if (presentation_mime(mime)) {
+        add_category_term(doc, "presentation");
+    }
+
+    if (document_mime(mime) || source_mime_or_name(mime, lower_path)) {
+        add_category_term(doc, "document");
+    }
+}
+
+bool read_text_file(const std::string &path,
+                    const struct stat &st,
+                    std::string &text)
+{
+    if (!S_ISREG(st.st_mode) || st.st_size <= 0
+            || static_cast<uint64_t>(st.st_size) > TEXT_MAX_BYTES
+            || (st.st_mode & S_IROTH) == 0) {
+        return false;
+    }
+
+    int fd = open(path.c_str(),
+                  O_RDONLY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK);
+
+    if (fd < 0) {
+        return false;
+    }
+
+    if (struct stat fst; fstat(fd, &fst) != 0
+            || !S_ISREG(fst.st_mode)
+            || fst.st_dev != st.st_dev
+            || fst.st_ino != st.st_ino
+            || fst.st_size != st.st_size) {
+        close(fd);
+        return false;
+    }
+
+    std::vector<char> buf(static_cast<size_t>(st.st_size));
+    size_t off = 0;
+
+    while (off < buf.size()) {
+        ssize_t n = read(fd, &buf[off], buf.size() - off);
+
+        if (n < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+
+            close(fd);
+            return false;
+        }
+
+        if (n == 0) {
+            break;
+        }
+
+        off += static_cast<size_t>(n);
+    }
+
+    close(fd);
+
+    if (memchr(buf.data(), '\0', std::min(off, TEXT_SAMPLE_BYTES)) != nullptr) {
+        return false;
+    }
+
+    if (memchr(buf.data(), '\0', off) != nullptr) {
+        return false;
+    }
+
+    text.assign(buf.data(), off);
+    return true;
+}
+
+void index_document_text(const Xapian::Document &doc,
+                         const std::string &path,
+                         const struct stat &st)
+{
+    std::string name = basename_of(path);
+    Xapian::TermGenerator tg;
+    tg.set_document(doc);
+    tg.index_text(name, 10, "S");
+
+    if (S_ISREG(st.st_mode)) {
+        std::string text;
+
+        if (read_text_file(path, st, text)) {
+            tg.increase_termpos();
+            tg.index_text(text, 1, "B");
+        }
+    }
+}
+
+void upsert_document(Xapian::WritableDatabase &db,
+                     const std::string &path,
+                     const struct stat &st,
+                     magic_t magic,
+                     const std::string *generation = nullptr)
+{
+    if (!S_ISDIR(st.st_mode) && !S_ISREG(st.st_mode)) {
+        db.delete_document(unique_term_for_path(path));
+        return;
+    }
+
+    Xapian::Document doc;
+    std::string unique = unique_term_for_path(path);
+    doc.add_term(unique);
+    doc.set_data(path);
+    doc.add_value(VALUE_PATH, path);
+    doc.add_value(VALUE_TYPE, S_ISDIR(st.st_mode) ? "d" : "f");
+    doc.add_value(VALUE_MTIME, number_value(static_cast<uint64_t>(st.st_mtime)));
+    doc.add_value(VALUE_SIZE, number_value(static_cast<uint64_t>(st.st_size)));
+
+    if (generation != nullptr) {
+        doc.add_value(VALUE_GENERATION, *generation);
+    }
+
+    index_document_mime(doc, path, st, magic);
+    index_document_text(doc, path, st);
+    db.replace_document(unique, doc);
+}
+
+void preserve_existing_documents(Xapian::WritableDatabase &db,
+                                 const std::string &scope,
+                                 const std::string &generation)
+{
+    Xapian::docid last = db.get_lastdocid();
+
+    for (Xapian::docid id = 1; id <= last; id++) {
+        try {
+            Xapian::Document doc = db.get_document(id);
+
+            if (std::string path = doc.get_value(VALUE_PATH);
+                    !path.empty() && path_in_scope(path, scope)) {
+                doc.add_value(VALUE_GENERATION, generation);
+                db.replace_document(id, doc);
+            }
+        } catch (const Xapian::DocNotFoundError &) {
+            // gaps are normal in Xapian docid sequences; skip silently
+        }
+    }
+}
+
+bool walk_volume(Xapian::WritableDatabase &db,
+                 const std::string &path,
+                 dev_t volume_dev,
+                 magic_t magic,
+                 const std::string &generation,
+                 std::string &errmsg)
+{
+    struct stat st;
+
+    if (lstat(path.c_str(), &st) != 0) {
+        preserve_existing_documents(db, path, generation);
+        return true;
+    }
+
+    if (st.st_dev != volume_dev) {
+        return true;
+    }
+
+    upsert_document(db, path, st, magic, &generation);
+
+    if (!S_ISDIR(st.st_mode)) {
+        return true;
+    }
+
+    DIR *dir = opendir(path.c_str());
+
+    if (dir == nullptr) {
+        preserve_existing_documents(db, path, generation);
+        return true;
+    }
+
+    const struct dirent *de;
+
+    for (;;) {
+        errno = 0;
+        de = readdir(dir);
+
+        if (de == nullptr) {
+            break;
+        }
+
+        if (metadata_name(de->d_name)) {
+            continue;
+        }
+
+        std::string child = path;
+
+        if (!child.empty() && child[child.size() - 1] != '/') {
+            child += '/';
+        }
+
+        child += de->d_name;
+
+        if (!walk_volume(db, child, volume_dev, magic, generation, errmsg)) {
+            closedir(dir);
+            return false;
+        }
+    }
+
+    if (errno != 0) {
+        preserve_existing_documents(db, path, generation);
+        closedir(dir);
+        return true;
+    }
+
+    closedir(dir);
+    return true;
+}
+
+bool walk_subtree(Xapian::WritableDatabase &db,
+                  const std::string &path,
+                  dev_t volume_dev,
+                  magic_t magic,
+                  const std::string *generation,
+                  std::string &errmsg)
+{
+    struct stat st;
+
+    if (lstat(path.c_str(), &st) != 0) {
+        errmsg = path + ": " + strerror(errno);
+        return false;
+    }
+
+    if (st.st_dev != volume_dev) {
+        return true;
+    }
+
+    upsert_document(db, path, st, magic, generation);
+
+    if (!S_ISDIR(st.st_mode)) {
+        return true;
+    }
+
+    DIR *dir = opendir(path.c_str());
+
+    if (dir == nullptr) {
+        errmsg = path + ": " + strerror(errno);
+        return false;
+    }
+
+    const struct dirent *de;
+
+    for (;;) {
+        errno = 0;
+        de = readdir(dir);
+
+        if (de == nullptr) {
+            break;
+        }
+
+        if (metadata_name(de->d_name)) {
+            continue;
+        }
+
+        std::string child = path;
+
+        if (!child.empty() && child[child.size() - 1] != '/') {
+            child += '/';
+        }
+
+        child += de->d_name;
+
+        if (!walk_subtree(db, child, volume_dev, magic, generation, errmsg)) {
+            closedir(dir);
+            return false;
+        }
+    }
+
+    if (errno != 0) {
+        errmsg = path + ": " + strerror(errno);
+        closedir(dir);
+        return false;
+    }
+
+    closedir(dir);
+    return true;
+}
+
+void delete_stale_documents(Xapian::WritableDatabase &db,
+                            const std::string &volume_path,
+                            const std::string &generation)
+{
+    Xapian::docid last = db.get_lastdocid();
+
+    for (Xapian::docid id = 1; id <= last; id++) {
+        try {
+            Xapian::Document doc = db.get_document(id);
+
+            if (std::string path = doc.get_value(VALUE_PATH);
+                    !path.empty()
+                    && path_in_scope(path, volume_path)
+                    && doc.get_value(VALUE_GENERATION) != generation) {
+                db.delete_document(id);
+            }
+        } catch (const Xapian::DocNotFoundError &) {
+            // gaps are normal in Xapian docid sequences; skip silently
+        }
+    }
+}
+
+void delete_prefix_documents(Xapian::WritableDatabase &db,
+                             const std::string &prefix)
+{
+    if (prefix.empty()) {
+        return;
+    }
+
+    Xapian::docid last = db.get_lastdocid();
+
+    for (Xapian::docid id = 1; id <= last; id++) {
+        try {
+            if (std::string docpath = db.get_document(id).get_value(VALUE_PATH);
+                    docpath == prefix
+                    || (docpath.size() > prefix.size()
+                        && docpath.compare(0, prefix.size(), prefix) == 0
+                        && docpath[prefix.size()] == '/')) {
+                db.delete_document(id);
+            }
+        } catch (const Xapian::DocNotFoundError &) {
+            // gaps are normal in Xapian docid sequences; skip silently
+        }
+    }
+}
+
+void chmod_database_path(const std::string &db_path);
+
+void mark_dirty(Xapian::WritableDatabase &db)
+{
+    db.set_metadata(METADATA_DIRTY, "1");
+}
+
+std::string strip_wildcards(const std::string &s)
+{
+    size_t start = 0;
+    size_t end = s.size();
+
+    while (start < end && s[start] == '*') {
+        start++;
+    }
+
+    while (end > start && s[end - 1] == '*') {
+        end--;
+    }
+
+    return s.substr(start, end - start);
+}
+
+void collect_values_after_key(const std::string &q,
+                              const char *key,
+                              std::vector<std::string> &values)
+{
+    size_t pos = 0;
+    std::string needle(key);
+
+    while ((pos = q.find(needle, pos)) != std::string::npos) {
+        if (size_t after_key = pos + needle.size();
+                after_key < q.size()
+                && (isalnum(static_cast<unsigned char>(q[after_key]))
+                    || q[after_key] == '_')) {
+            pos = after_key;
+            continue;
+        }
+
+        size_t quote1 = q.find('"', pos + needle.size());
+
+        if (quote1 == std::string::npos) {
+            break;
+        }
+
+        size_t quote2 = q.find('"', quote1 + 1);
+
+        if (quote2 == std::string::npos) {
+            break;
+        }
+
+        if (std::string value = strip_wildcards(q.substr(quote1 + 1,
+                                                quote2 - quote1 - 1)); !value.empty()) {
+            values.push_back(value);
+        }
+
+        pos = quote2 + 1;
+    }
+}
+
+std::vector<std::string> collect_any_values(const std::string &q)
+{
+    std::vector<std::string> values;
+    size_t pos = 0;
+
+    while ((pos = q.find("*==", pos)) != std::string::npos) {
+        size_t quote1 = q.find('"', pos + 3);
+
+        if (quote1 == std::string::npos) {
+            break;
+        }
+
+        size_t quote2 = q.find('"', quote1 + 1);
+
+        if (quote2 == std::string::npos) {
+            break;
+        }
+
+        if (std::string value = strip_wildcards(q.substr(quote1 + 1,
+                                                quote2 - quote1 - 1)); !value.empty()) {
+            values.push_back(value);
+        }
+
+        pos = quote2 + 1;
+    }
+
+    return values;
+}
+
+Xapian::Query parse_prefixed(const Xapian::Database &db,
+                             const std::string &term,
+                             const std::string &prefix)
+{
+    Xapian::QueryParser qp;
+    qp.set_database(db);
+    qp.set_default_op(Xapian::Query::OP_AND);
+    unsigned flags = Xapian::QueryParser::FLAG_WILDCARD
+                     | Xapian::QueryParser::FLAG_PARTIAL;
+    return qp.parse_query(term, flags, prefix);
+}
+
+void append_mime_term(std::vector<std::string> &terms, const char *mime)
+{
+    terms.push_back(exact_term("XM", mime));
+}
+
+void append_category_term(std::vector<std::string> &terms,
+                          const char *category)
+{
+    terms.push_back(exact_term("XK", category));
+}
+
+void append_type_terms_for_value(const std::string &raw_value,
+                                 std::vector<std::string> &terms)
+{
+    std::string value = lower_string(raw_value);
+
+    if (value.find('/') != std::string::npos) {
+        append_mime_term(terms, value.c_str());
+        return;
+    }
+
+    if (value == "9" || value == "public.folder") {
+        append_category_term(terms, "folder");
+    } else if (value == "13" || value == "public.image") {
+        append_category_term(terms, "image");
+    } else if (value == "10" || value == "public.audio") {
+        append_category_term(terms, "audio");
+    } else if (value == "7" || value == "public.movie" || value == "public.video") {
+        append_category_term(terms, "video");
+    } else if (value == "8") {
+        append_category_term(terms, "executable");
+    } else if (value == "12") {
+        append_category_term(terms, "presentation");
+    } else if (value == "4") {
+        append_category_term(terms, "font");
+    } else if (value == "public.content") {
+        append_category_term(terms, "document");
+    } else if (value == "public.text") {
+        append_category_term(terms, "text");
+    } else if (value == "public.source-code") {
+        append_category_term(terms, "source");
+    } else if (value == "com.apple.application") {
+        append_category_term(terms, "software");
+    } else if (value == "11" || value == "com.adobe.pdf") {
+        append_mime_term(terms, "application/pdf");
+    } else if (value == "public.jpeg") {
+        append_mime_term(terms, "image/jpeg");
+    } else if (value == "public.tiff") {
+        append_mime_term(terms, "image/tiff");
+    } else if (value == "com.compuserve.gif") {
+        append_mime_term(terms, "image/gif");
+    } else if (value == "public.png") {
+        append_mime_term(terms, "image/png");
+    } else if (value == "com.microsoft.bmp") {
+        append_mime_term(terms, "image/bmp");
+        append_mime_term(terms, "image/x-ms-bmp");
+    } else if (value == "public.mp3") {
+        append_mime_term(terms, "audio/mpeg");
+    } else if (value == "public.mpeg-4-audio") {
+        append_mime_term(terms, "audio/aac");
+        append_mime_term(terms, "audio/mp4");
+        append_mime_term(terms, "audio/x-aac");
+    } else if (value == "public.plain-text") {
+        append_mime_term(terms, "text/plain");
+    } else if (value == "public.rtf") {
+        append_mime_term(terms, "application/rtf");
+        append_mime_term(terms, "text/rtf");
+    } else if (value == "public.html") {
+        append_mime_term(terms, "application/xhtml+xml");
+        append_mime_term(terms, "text/html");
+    } else if (value == "public.xml") {
+        append_mime_term(terms, "application/xml");
+        append_mime_term(terms, "text/xml");
+    }
+}
+
+Xapian::Query no_match_query()
+{
+    return Xapian::Query("XNOMATCH__");
+}
+
+Xapian::Query type_query_for_value(const std::string &value)
+{
+    std::vector<std::string> terms;
+    append_type_terms_for_value(value, terms);
+
+    if (terms.empty()) {
+        return no_match_query();
+    }
+
+    if (terms.size() == 1) {
+        return Xapian::Query(terms[0]);
+    }
+
+    std::vector<Xapian::Query> queries;
+
+    for (const auto &term : terms) {
+        queries.push_back(Xapian::Query(term));
+    }
+
+    return Xapian::Query(Xapian::Query::OP_OR,
+                         queries.begin(), queries.end());
+}
+
+bool build_query(const Xapian::Database &db,
+                 const char *qstring,
+                 Xapian::Query &query)
+{
+    std::string q = qstring ? qstring : "";
+    std::vector<Xapian::Query> clauses;
+    std::vector<std::string> name_terms;
+    std::vector<std::string> text_terms;
+    std::vector<std::string> type_terms;
+    std::vector<std::string> any_terms;
+    collect_values_after_key(q, "kMDItemFSName", name_terms);
+    collect_values_after_key(q, "kMDItemDisplayName", name_terms);
+    collect_values_after_key(q, "_kMDItemFileName", name_terms);
+    collect_values_after_key(q, "kMDItemTextContent", text_terms);
+    collect_values_after_key(q, "kMDItemKind", type_terms);
+    collect_values_after_key(q, "kMDItemContentType", type_terms);
+    collect_values_after_key(q, "kMDItemContentTypeTree", type_terms);
+    collect_values_after_key(q, "_kMDItemGroupId", type_terms);
+    any_terms = collect_any_values(q);
+
+    for (const auto &term : name_terms) {
+        clauses.push_back(parse_prefixed(db, term, "S"));
+    }
+
+    for (const auto &term : text_terms) {
+        clauses.push_back(parse_prefixed(db, term, "B"));
+    }
+
+    for (const auto &term : type_terms) {
+        clauses.push_back(type_query_for_value(term));
+    }
+
+    for (const auto &term : any_terms) {
+        Xapian::Query nameq = parse_prefixed(db, term, "S");
+        Xapian::Query bodyq = parse_prefixed(db, term, "B");
+        clauses.push_back(Xapian::Query(Xapian::Query::OP_OR, nameq, bodyq));
+    }
+
+    if (clauses.empty()) {
+        return false;
+    }
+
+    query = Xapian::Query(Xapian::Query::OP_AND,
+                          clauses.begin(), clauses.end());
+    return true;
+}
+
+bool ensure_database_parent(const std::string &db_path,
+                            char *errbuf,
+                            size_t errlen)
+{
+    std::string parent = dirname_of(db_path);
+    std::string errmsg;
+
+    if (mkdir_p(parent, errmsg)) {
+        return true;
+    }
+
+    set_error(errbuf, errlen,
+              std::string("could not create Xapian database parent ")
+              + parent + ": " + errmsg);
+    return false;
+}
+
+void chmod_database_path(const std::string &db_path)
+{
+    int dirfd = open(db_path.c_str(),
+                     O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+
+    if (dirfd < 0) {
+        return;
+    }
+
+    fchmod(dirfd, 0777);
+    DIR *dir = fdopendir(dirfd);
+
+    if (dir == nullptr) {
+        close(dirfd);
+        return;
+    }
+
+    const struct dirent *de;
+
+    while ((de = readdir(dir)) != nullptr) {
+        if (strcmp(de->d_name, ".") == 0 || strcmp(de->d_name, "..") == 0) {
+            continue;
+        }
+
+        struct stat st;
+
+        if (fstatat(dirfd, de->d_name, &st, AT_SYMLINK_NOFOLLOW) != 0) {
+            continue;
+        }
+
+        if (!S_ISDIR(st.st_mode) && !S_ISREG(st.st_mode)) {
+            continue;
+        }
+
+        int flags = O_RDONLY | O_NOFOLLOW | O_CLOEXEC;
+
+        if (S_ISDIR(st.st_mode)) {
+            flags |= O_DIRECTORY;
+        }
+
+        int fd = openat(dirfd, de->d_name, flags);
+
+        if (fd < 0) {
+            continue;
+        }
+
+        fchmod(fd, S_ISDIR(st.st_mode) ? 0777 : 0666);
+        close(fd);
+    }
+
+    closedir(dir);
+}
+
+} // namespace
+
+extern "C" int sl_xapian_reconcile(const char *db_path,
+                                   const char *volume_path,
+                                   const char *volume_uuid,
+                                   char *errbuf,
+                                   size_t errlen)
+{
+    try {
+        std::string magic_error;
+        MagicCookie magic;
+
+        if (db_path == nullptr || volume_path == nullptr) {
+            set_error(errbuf, errlen, "missing Xapian database or volume path");
+            return -1;
+        }
+
+        if (!ensure_database_parent(db_path, errbuf, errlen)) {
+            return -1;
+        }
+
+        if (!magic.open(magic_error)) {
+            set_error(errbuf, errlen,
+                      std::string("could not initialize libmagic: ") + magic_error);
+            return -1;
+        }
+
+        Xapian::WritableDatabase db(db_path, Xapian::DB_CREATE_OR_OPEN);
+        std::string generation = next_generation_id(db);
+        std::string walk_error;
+        struct stat root_st;
+
+        if (lstat(volume_path, &root_st) != 0) {
+            set_error(errbuf, errlen,
+                      std::string(volume_path) + ": " + strerror(errno));
+            return -1;
+        }
+
+        XapianTransaction tx(db);
+        db.set_metadata(METADATA_RECONCILE_IN_PROGRESS, generation);
+        db.set_metadata(METADATA_DIRTY, "1");
+
+        if (!walk_volume(db, volume_path, root_st.st_dev, magic.get(),
+                         generation, walk_error)) {
+            tx.cancel();
+            set_error(errbuf, errlen,
+                      std::string("could not reconcile Xapian index: ")
+                      + walk_error);
+            return -1;
+        }
+
+        delete_stale_documents(db, volume_path, generation);
+        set_complete_metadata(db, volume_path, volume_uuid ? volume_uuid : "",
+                              generation);
+        tx.commit();
+        chmod_database_path(db_path);
+        return 0;
+    } catch (const std::exception &e) {
+        set_error(errbuf, errlen, e.what());
+        return -1;
+    } catch (...) {
+        set_error(errbuf, errlen, "unknown Xapian exception");
+        return -1;
+    }
+}
+
+extern "C" int sl_xapian_index_ready(const char *db_path,
+                                     const char *volume_path,
+                                     const char *volume_uuid,
+                                     char *errbuf,
+                                     size_t errlen)
+{
+    try {
+        if (db_path == nullptr || volume_path == nullptr) {
+            set_error(errbuf, errlen, "missing Xapian database or volume path");
+            return -1;
+        }
+
+        Xapian::Database db(db_path);
+        const char *uuid = volume_uuid ? volume_uuid : "";
+        bool ready = index_metadata_valid(db, volume_path, uuid);
+        return ready ? 1 : 0;
+    } catch (const Xapian::DatabaseOpeningError &) {
+        return 0;
+    } catch (const std::exception &e) {
+        set_error(errbuf, errlen, e.what());
+        return -1;
+    } catch (...) {
+        set_error(errbuf, errlen, "unknown Xapian exception");
+        return -1;
+    }
+}
+
+extern "C" int sl_xapian_query(const char *db_path,
+                               const char *scope,
+                               const char *qstring,
+                               size_t offset,
+                               size_t limit,
+                               char ***paths,
+                               size_t *count,
+                               int *more,
+                               char *errbuf,
+                               size_t errlen)
+{
+    try {
+        if (paths == nullptr || count == nullptr || more == nullptr) {
+            set_error(errbuf, errlen, "missing Xapian query output pointer");
+            return -1;
+        }
+
+        *paths = nullptr;
+        *count = 0;
+        *more = 0;
+
+        if (db_path == nullptr || scope == nullptr || qstring == nullptr) {
+            set_error(errbuf, errlen, "missing Xapian query input");
+            return -1;
+        }
+
+        Xapian::Database db(db_path);
+        Xapian::Query query;
+
+        if (!build_query(db, qstring, query)) {
+            return 0;
+        }
+
+        Xapian::doccount ask = limit == 0 ? 10000 : static_cast<Xapian::doccount>
+                               (limit);
+        Xapian::Enquire enquire(db);
+        enquire.set_query(query);
+        Xapian::MSet matches = enquire.get_mset(static_cast<Xapian::doccount>(offset),
+                                                ask + 1);
+        std::vector<std::string> out;
+
+        for (auto it = matches.begin(); it != matches.end(); ++it) {
+            if (out.size() >= ask) {
+                *more = 1;
+                break;
+            }
+
+            if (std::string path = it.get_document().get_value(VALUE_PATH);
+                    !path.empty() && path_in_scope(path, scope)
+                    && access(path.c_str(), F_OK) == 0) {
+                out.push_back(path);
+            }
+        }
+
+        if (out.empty()) {
+            return 0;
+        }
+
+        char **arr = static_cast<char **>(calloc(out.size(), sizeof(char *)));
+
+        if (arr == nullptr) {
+            set_error(errbuf, errlen, "out of memory");
+            return -1;
+        }
+
+        for (size_t i = 0; i < out.size(); i++) {
+            arr[i] = strdup(out[i].c_str());
+
+            if (arr[i] == nullptr) {
+                sl_xapian_free_paths(arr, i);
+                set_error(errbuf, errlen, "out of memory");
+                return -1;
+            }
+        }
+
+        *paths = arr;
+        *count = out.size();
+        return 0;
+    } catch (const std::exception &e) {
+        set_error(errbuf, errlen, e.what());
+        return -1;
+    } catch (...) {
+        set_error(errbuf, errlen, "unknown Xapian exception");
+        return -1;
+    }
+}
+
+extern "C" int sl_xapian_upsert_path(const char *db_path,
+                                     const char *path,
+                                     char *errbuf,
+                                     size_t errlen)
+{
+    try {
+        std::string magic_error;
+        MagicCookie magic;
+
+        if (db_path == nullptr || path == nullptr) {
+            return 0;
+        }
+
+        struct stat st;
+
+        if (lstat(path, &st) != 0) {
+            return sl_xapian_delete_path(db_path, path, errbuf, errlen);
+        }
+
+        if (!ensure_database_parent(db_path, errbuf, errlen)) {
+            return -1;
+        }
+
+        if (!magic.open(magic_error)) {
+            set_error(errbuf, errlen,
+                      std::string("could not initialize libmagic: ") + magic_error);
+            return -1;
+        }
+
+        Xapian::WritableDatabase db(db_path, Xapian::DB_CREATE_OR_OPEN);
+        upsert_document(db, path, st, magic.get());
+        db.commit();
+        chmod_database_path(db_path);
+        return 0;
+    } catch (const std::exception &e) {
+        set_error(errbuf, errlen, e.what());
+        return -1;
+    } catch (...) {
+        set_error(errbuf, errlen, "unknown Xapian exception");
+        return -1;
+    }
+}
+
+extern "C" int sl_xapian_delete_path(const char *db_path,
+                                     const char *path,
+                                     char *errbuf,
+                                     size_t errlen)
+{
+    try {
+        if (db_path == nullptr || path == nullptr) {
+            return 0;
+        }
+
+        if (!ensure_database_parent(db_path, errbuf, errlen)) {
+            return -1;
+        }
+
+        Xapian::WritableDatabase db(db_path, Xapian::DB_CREATE_OR_OPEN);
+        db.delete_document(unique_term_for_path(path));
+        db.commit();
+        chmod_database_path(db_path);
+        return 0;
+    } catch (const std::exception &e) {
+        set_error(errbuf, errlen, e.what());
+        return -1;
+    } catch (...) {
+        set_error(errbuf, errlen, "unknown Xapian exception");
+        return -1;
+    }
+}
+
+extern "C" int sl_xapian_delete_prefix(const char *db_path,
+                                       const char *path,
+                                       char *errbuf,
+                                       size_t errlen)
+{
+    try {
+        if (db_path == nullptr || path == nullptr) {
+            return 0;
+        }
+
+        if (!ensure_database_parent(db_path, errbuf, errlen)) {
+            return -1;
+        }
+
+        Xapian::WritableDatabase db(db_path, Xapian::DB_CREATE_OR_OPEN);
+        delete_prefix_documents(db, path);
+        db.commit();
+        chmod_database_path(db_path);
+        return 0;
+    } catch (const std::exception &e) {
+        set_error(errbuf, errlen, e.what());
+        return -1;
+    } catch (...) {
+        set_error(errbuf, errlen, "unknown Xapian exception");
+        return -1;
+    }
+}
+
+extern "C" int sl_xapian_reindex_subtree(const char *db_path,
+        const char *volume_path,
+        const char *path,
+        const char *oldpath,
+        char *errbuf,
+        size_t errlen)
+{
+    try {
+        std::string magic_error;
+        MagicCookie magic;
+
+        if (db_path == nullptr || volume_path == nullptr
+                || path == nullptr || path[0] == '\0'
+                || oldpath == nullptr || oldpath[0] == '\0') {
+            set_error(errbuf, errlen, "missing Xapian subtree reindex input");
+            return -1;
+        }
+
+        if (!ensure_database_parent(db_path, errbuf, errlen)) {
+            sl_xapian_mark_dirty(db_path, nullptr, 0);
+            return -1;
+        }
+
+        if (!magic.open(magic_error)) {
+            set_error(errbuf, errlen,
+                      std::string("could not initialize libmagic: ") + magic_error);
+            sl_xapian_mark_dirty(db_path, nullptr, 0);
+            return -1;
+        }
+
+        struct stat root_st;
+
+        if (lstat(volume_path, &root_st) != 0) {
+            set_error(errbuf, errlen,
+                      std::string(volume_path) + ": " + strerror(errno));
+            sl_xapian_mark_dirty(db_path, nullptr, 0);
+            return -1;
+        }
+
+        Xapian::WritableDatabase db(db_path, Xapian::DB_CREATE_OR_OPEN);
+        std::string generation = db.get_metadata(METADATA_LAST_COMPLETE_GENERATION);
+        const std::string *generation_ptr = generation.empty() ? nullptr : &generation;
+        std::string walk_error;
+        XapianTransaction tx(db);
+        delete_prefix_documents(db, oldpath);
+
+        if (!walk_subtree(db, path, root_st.st_dev, magic.get(),
+                          generation_ptr, walk_error)) {
+            tx.cancel();
+            mark_dirty(db);
+            db.commit();
+            chmod_database_path(db_path);
+            set_error(errbuf, errlen,
+                      std::string("could not reindex moved subtree: ") + walk_error);
+            return -1;
+        }
+
+        tx.commit();
+        chmod_database_path(db_path);
+        return 0;
+    } catch (const std::exception &e) {
+        set_error(errbuf, errlen, e.what());
+        sl_xapian_mark_dirty(db_path, nullptr, 0);
+        return -1;
+    } catch (...) {
+        set_error(errbuf, errlen, "unknown Xapian exception");
+        sl_xapian_mark_dirty(db_path, nullptr, 0);
+        return -1;
+    }
+}
+
+extern "C" int sl_xapian_mark_dirty(const char *db_path,
+                                    char *errbuf,
+                                    size_t errlen)
+{
+    try {
+        if (db_path == nullptr) {
+            set_error(errbuf, errlen, "missing Xapian database path");
+            return -1;
+        }
+
+        if (!ensure_database_parent(db_path, errbuf, errlen)) {
+            return -1;
+        }
+
+        Xapian::WritableDatabase db(db_path, Xapian::DB_CREATE_OR_OPEN);
+        mark_dirty(db);
+        db.commit();
+        chmod_database_path(db_path);
+        return 0;
+    } catch (const std::exception &e) {
+        set_error(errbuf, errlen, e.what());
+        return -1;
+    } catch (...) {
+        set_error(errbuf, errlen, "unknown Xapian exception");
+        return -1;
+    }
+}
+
+extern "C" void sl_xapian_free_paths(char **paths, size_t count)
+{
+    if (paths == nullptr) {
+        return;
+    }
+
+    for (size_t i = 0; i < count; i++) {
+        free(paths[i]);
+    }
+
+    free(paths);
+}

--- a/include/atalk/spotlight.h
+++ b/include/atalk/spotlight.h
@@ -72,6 +72,17 @@ typedef enum {
     SLQ_STATE_ERROR	          /*!< an error happended somewhere         */
 } slq_state_t;
 
+/*! file-system changes a Spotlight backend may index incrementally */
+typedef enum {
+    SL_INDEX_FILE_MODIFY,
+    SL_INDEX_FILE_DELETE,
+    SL_INDEX_DIR_DELETE,
+    SL_INDEX_FILE_CREATE,
+    SL_INDEX_DIR_CREATE,
+    SL_INDEX_FILE_MOVE,
+    SL_INDEX_DIR_MOVE
+} sl_index_event_t;
+
 /*! Handle for query results */
 struct sl_rslts {
     int         num_results;
@@ -124,6 +135,13 @@ typedef struct sl_backend_ops {
 
     /* Cancel and clean up query state. */
     void (*sbo_close_query)(slq_t *slq);
+
+    /* Optional incremental index update hook. */
+    int  (*sbo_index_event)(const AFPObj *obj,
+                            const struct vol *vol,
+                            sl_index_event_t event,
+                            const char *path,
+                            const char *oldpath);
 } sl_backend_ops;
 
 /******************************************************************************
@@ -132,6 +150,11 @@ typedef struct sl_backend_ops {
 
 extern int afp_spotlight_rpc(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
                              char *rbuf, size_t *rbuflen);
+extern int sl_index_event(const AFPObj *obj,
+                          const struct vol *vol,
+                          sl_index_event_t event,
+                          const char *path,
+                          const char *oldpath);
 extern int sl_pack(DALLOC_CTX *query, char *buf);
 extern int sl_unpack(DALLOC_CTX *query, const char *buf);
 extern void configure_spotlight_attributes(const char *attributes);

--- a/meson.build
+++ b/meson.build
@@ -130,6 +130,15 @@ add_global_arguments(netatalk_common_flags, language: 'c')
 
 netatalk_common_link_args = []
 
+if 'xapian' in get_option('with-spotlight-backends')
+    cpp_found = add_languages('cpp', native: false, required: false)
+    if cpp_found
+        add_global_arguments(netatalk_common_flags, language: 'cpp')
+    endif
+else
+    cpp_found = false
+endif
+
 # Per target
 
 afpd = '-D_PATH_AFPD="' + sbindir + '/afpd"'
@@ -247,6 +256,9 @@ if not cc.links(atomic_test_code, name: 'atomic builtins without -latomic')
 endif
 
 add_global_link_arguments(netatalk_common_link_args, language: 'c')
+if cpp_found
+    add_global_link_arguments(netatalk_common_link_args, language: 'cpp')
+endif
 
 if host_machine.endian() == 'big'
     cdata.set('WORDS_BIGENDIAN', 1)
@@ -1100,6 +1112,7 @@ endif
 have_spotlight = false
 use_spotlight_cnid = false
 use_spotlight_localsearch = false
+use_spotlight_xapian = false
 spotlight_backends = ''
 
 if get_option('with-spotlight')
@@ -1225,11 +1238,43 @@ if get_option('with-spotlight')
                 )
             endif
         endif
+
+        if 'xapian' in get_option('with-spotlight-backends')
+            xapian = dependency('xapian-core', required: false)
+            libmagic = dependency('libmagic', required: false)
+
+            if not libmagic.found()
+                magic_lib = cc.find_library('magic', required: false)
+
+                if magic_lib.found() and cc.has_header('magic.h') and cc.has_function(
+                    'magic_open',
+                    prefix: '#include <magic.h>',
+                    dependencies: magic_lib,
+                )
+                    libmagic = magic_lib
+                endif
+            endif
+
+            if cpp_found and xapian.found() and libmagic.found()
+                use_spotlight_xapian = true
+
+                if spotlight_backends != ''
+                    spotlight_backends += ' | '
+                endif
+
+                spotlight_backends += 'xapian'
+                cdata.set('SPOTLIGHT_BACKEND_XAPIAN', 1)
+            else
+                warning(
+                    'xapian Spotlight search backend requested but one or more dependencies were not found',
+                )
+            endif
+        endif
     else
         warning('talloc library required for Spotlight search support')
     endif
 
-    have_spotlight = use_spotlight_cnid or use_spotlight_localsearch
+    have_spotlight = use_spotlight_cnid or use_spotlight_localsearch or use_spotlight_xapian
 endif
 
 if have_spotlight
@@ -2706,7 +2751,7 @@ summary_info += {
 }
 if have_spotlight
     summary_info += {
-        '  Search backends': spotlight_backends != '' ? spotlight_backends : 'none',
+        '  Spotlight backends': spotlight_backends != '' ? spotlight_backends : 'none',
     }
 endif
 summary_info += {

--- a/meson_config.h
+++ b/meson_config.h
@@ -397,6 +397,9 @@
 /* Whether the LocalSearch Spotlight search backend is supported */
 #mesondefine SPOTLIGHT_BACKEND_LOCALSEARCH
 
+/* Whether the Xapian Spotlight search backend is supported */
+#mesondefine SPOTLIGHT_BACKEND_XAPIAN
+
 /* List of supported Spotlight search backends */
 #mesondefine SPOTLIGHT_BACKENDS
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -441,7 +441,7 @@ option(
 option(
     'with-spotlight-backends',
     type: 'array',
-    choices: ['cnid', 'localsearch'],
-    value: ['cnid', 'localsearch'],
+    choices: ['cnid', 'localsearch', 'xapian'],
+    value: ['cnid', 'localsearch', 'xapian'],
     description: 'Spotlight search backends to build',
 )

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -55,6 +55,9 @@ if have_spotlight
     if use_spotlight_localsearch
         test_external_deps += [glib, sparql]
     endif
+    if use_spotlight_xapian
+        test_external_deps += [xapian, libmagic]
+    endif
 endif
 
 if have_acls
@@ -189,6 +192,7 @@ if get_option('with-tests')
         ],
         c_args: ['-DAPPLCNAME', dversion, messagedir, uamdir, confdir, statedir],
         link_args: test_link_args,
+        link_language: use_spotlight_xapian ? 'cpp' : 'c',
         export_dynamic: true,
         install: false,
     )
@@ -247,6 +251,7 @@ if get_option('with-fuzzing')
             fuzz_c_args,
         ],
         link_args: fuzz_link_args,
+        link_language: use_spotlight_xapian ? 'cpp' : 'c',
         install: false,
         build_by_default: false,
     )


### PR DESCRIPTION
implement a Netatalk-managed Xapian Spotlight backend with filename, plain-text content, and MIME type search; compared to the cnid backend it is more full-featured, supporting all three query modes of macOS Finder search, while compared to the localsearch backend it is much more light-weight, with fewer build and run time dependencies and less scaffolding for running the indexer

Xapian has a C++ API, so this introduces a wrapper with the C interface for Spotlight backends, while handling the detection of a C++ compiler in Meson; we set C++17 as the baseline standard, since this is what Xapian 2.0 uses

dependencies are xapian-core and libmagic (file) for MIME type detection

control this feature at compile time with the -Dwith-spotlight-backends=xapian meson option

at runtime, configure 'spotlight backend = xapian' in afp.conf

----

## implementation notes

The key interface is sl_backend_ops in include/atalk/spotlight.h. Each backend implements init, close, open_query, fetch_results, close_query, and optionally index_event. sl_backends.h exposes the compiled-in ops instances, while volume.c binds a volume to cnid, localsearch, or xapian.

Xapian is split between sl_xapian.c the C backend/vtable adapter and result marshaller; xapian_wrapper.cc the C++ libxapian/libmagic implementation behind the C ABI in sl_xapian.h. The Xapian DB lives under _PATH_STATEDIR/spotlight/xapian/<volume uuid>, seeded by a full reconcile on first query per volume, then kept current through AFP file event hooks where possible.

in the current implementation, the AFP daemon (afpd) for each connected user is responsible for on-demand indexing and reconciliation. I have taken measures to avoid heavy blocking operations, but there is an inherent weakness in this multiple readers + multiple writers structure, long term having a dedicated indexer daemon should be evaluated.

```mermaid
flowchart TD
    XAPIAN_C["Xapian C backend<br/>etc/spotlight/xapian/sl_xapian.c"] -->|"C ABI calls"| WRAP["C++ xapian_wrapper.cc<br/>exception-safe libxapian boundary"]

    XAPIAN_C -->|"first query per volume"| ENSURE["sl_xapian_ensure_seeded"]
    ENSURE -->|"process fast path"| SEED["seeded_volumes list"]
    ENSURE -->|"authoritative check"| META["Xapian metadata<br/>schema_version, volume_uuid/path<br/>last_complete_generation<br/>reconcile_in_progress, dirty"]
    META -->|"valid complete index"| XAPIAN_C
    META -->|"missing, incompatible, dirty"| RECON["sl_xapian_reconcile"]

    RECON -->|"new generation id"| WALK["full volume walk"]
    WALK -->|"upsert docs with generation"| XDB[("Xapian database")]
    RECON -->|"delete docs whose generation<br/>does not match completed scan"| XDB
    RECON -->|"commit complete metadata"| META

    FILEOPS["AFP file and directory events<br/>create, modify, move, delete"] -->|"create or modify"| UPSERT["sl_xapian_upsert_path"]
    FILEOPS -->|"file delete"| DEL["sl_xapian_delete_path"]
    FILEOPS -->|"directory delete"| DELP["sl_xapian_delete_prefix"]
    FILEOPS -->|"file move"| MOVF["delete old path<br/>upsert new path"]
    FILEOPS -->|"directory move"| MOVD["sl_xapian_reindex_subtree<br/>delete old prefix<br/>walk new subtree"]

    MOVD -->|"success"| XDB
    MOVD -->|"failure"| DIRTY["mark metadata dirty<br/>unmark seeded volume"]
    DIRTY --> META

```