### PR TITLE
testsuite: Add additional ProDOS Info Bit (PDINFO) tests.

### DIFF
--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -2366,7 +2366,7 @@ int getdirparams(const AFPObj *obj,
                 /* ProDOS Info Block */
                 *data++ = 0x0f;
                 *data++ = 0;
-                ashort = htons(0x0200);
+                ashort = htons(0x0002);
                 memcpy(data, &ashort, sizeof(ashort));
                 data += sizeof(ashort);
                 memset(data, 0, sizeof(ashort));

--- a/test/testsuite/Error.c
+++ b/test/testsuite/Error.c
@@ -133,7 +133,7 @@ static int t35_add_filedir_parms(unsigned char *buf, int ofs, uint16_t bitmap,
 {
     struct afp_filedir_parms filedir = { 0 };
     filedir.isdir = isdir;
-    return ofs + afp_filedir_pack(buf + ofs, &filedir, bitmap, bitmap);
+    return ofs + afp_filedir_pack(Conn, buf + ofs, &filedir, bitmap, bitmap);
 }
 
 static const char *t35_variant_name(unsigned char variant)
@@ -804,7 +804,7 @@ static void cname_test(char *name)
     dsi = &Conn->dsi;
     FAIL(FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, 0, bitmap))
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (filedir.pdid != 2) {
         if (!Quiet) {
@@ -831,7 +831,7 @@ static void cname_test(char *name)
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (filedir.pdid != 2) {
         if (!Quiet) {
@@ -1344,7 +1344,7 @@ STATIC void test103()
 
     FAIL(FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name1, 0, bitmap))
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     dir = filedir.did;
     dt = FPOpenDT(Conn, vol);
 
@@ -1632,7 +1632,7 @@ STATIC void test170()
         goto test_exit;
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.isdir = 0;
         FAIL(htonl(AFPERR_PARAM) != FPSetFileParams(Conn, vol, DIRDID_ROOT_PARENT, "",
                 bitmap, &filedir))
@@ -1715,7 +1715,7 @@ STATIC void test170()
         goto test_exit;
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
         if (ntohl(AFPERR_NOOBJ) != FPSetFilDirParam(Conn, vol, DIRDID_ROOT_PARENT, "",
                 bitmap, &filedir)) {
@@ -1808,7 +1808,7 @@ STATIC void test171()
         goto test_exit;
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.isdir = 0;
         FAIL(htonl(AFPERR_NOOBJ) != FPSetFileParams(Conn, vol, tdir, tname, bitmap,
                 &filedir))
@@ -1875,7 +1875,7 @@ STATIC void test171()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         FAIL(ntohl(AFPERR_NOOBJ) != FPSetFilDirParam(Conn, vol, tdir, tname, bitmap,
                 &filedir))
     }
@@ -1963,7 +1963,7 @@ STATIC void test173()
         goto fin;
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.isdir = 0;
         FAIL(htonl(AFPERR_PARAM) != FPSetFileParams(Conn, vol, tdir, tname, bitmap,
                 &filedir))
@@ -2040,7 +2040,7 @@ STATIC void test173()
         goto test_exit;
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         FAIL(ntohl(AFPERR_PARAM) != FPSetFilDirParam(Conn, vol, tdir, tname, bitmap,
                 &filedir))
     }
@@ -2158,7 +2158,7 @@ STATIC void test174()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.isdir = 0;
         FAIL(htonl(AFPERR_NOOBJ) != FPSetFileParams(Conn, vol, tdir, tname, bitmap,
                 &filedir))
@@ -2240,7 +2240,7 @@ STATIC void test174()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         FAIL(ntohl(AFPERR_NOOBJ) != FPSetFilDirParam(Conn, vol, tdir, tname, bitmap,
                 &filedir))
     }

--- a/test/testsuite/FPAddAPPL.c
+++ b/test/testsuite/FPAddAPPL.c
@@ -145,7 +145,7 @@ STATIC void test301()
 
         bitmap = (1 << DIRPBIT_ACCESS);
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi2->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, 0, bitmap);
         filedir.access[0] = 0;
         filedir.access[1] = 0;
         filedir.access[2] = 0;

--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -649,7 +649,7 @@ static int create_trash(CONN *conn, uint16_t vol)
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     filedir.access[1] = 7;
     filedir.access[2] = 7;
@@ -688,7 +688,7 @@ static int create_map(CONN *conn, uint16_t vol, int dir, char *name)
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0x73f, 0);
+    afp_filedir_unpack(conn, &filedir, dsi->data + ofs, 0x73f, 0);
     filedir.attr = ATTRBIT_INVISIBLE | ATTRBIT_SETCLR ;
 
     if (FPSetFilDirParam(conn, vol, dir, name, (1 << DIRPBIT_ATTR), &filedir)) {
@@ -715,7 +715,7 @@ static int set_perm(CONN *conn, uint16_t vol, int dir)
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     filedir.access[1] = 0;
     filedir.access[2] = 0;
@@ -749,7 +749,7 @@ static int write_access(CONN *conn, uint16_t  vol, int dir)
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if ((filedir.access[0] & 7) == 7) {
         return 1;

--- a/test/testsuite/FPCatSearch.c
+++ b/test/testsuite/FPCatSearch.c
@@ -49,7 +49,7 @@ STATIC void test225()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     filedir.attr = 0x01a0 | ATTRBIT_SETCLR ;
     FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
     memset(&filedir, 0, sizeof(filedir));

--- a/test/testsuite/FPCatSearchExt.c
+++ b/test/testsuite/FPCatSearchExt.c
@@ -64,7 +64,7 @@ STATIC void test227()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     filedir.attr = 0x01a0 | ATTRBIT_SETCLR ;
     FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
     memset(&filedir, 0, sizeof(filedir));

--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -210,7 +210,7 @@ static void test_meta(char *name, char *name1, uint16_t vol2)
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         memcpy(filedir.finder_info, "PDF CARO", 8);
         memcpy(finder_info, filedir.finder_info, 32);
         FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
@@ -223,7 +223,7 @@ static void test_meta(char *name, char *name1, uint16_t vol2)
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (memcmp(finder_info, filedir.finder_info, 32)) {
             if (!Quiet) {
@@ -303,7 +303,7 @@ STATIC void test332()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         mdate = filedir.mdate;
     }
 
@@ -313,7 +313,7 @@ STATIC void test332()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (mdate != filedir.mdate)  {
             if (!Quiet) {
@@ -473,7 +473,7 @@ STATIC void test401()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 0770;
     filedir.access[0] = 0;
@@ -524,7 +524,7 @@ STATIC void test401()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 0444;
     filedir.access[0] = 0;
@@ -617,7 +617,7 @@ STATIC void test402()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 0222;
     filedir.access[0] = 0;
@@ -666,7 +666,7 @@ STATIC void test403()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 0770;
     filedir.access[0] = 0;
@@ -687,7 +687,7 @@ STATIC void test403()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 0444;
     filedir.access[0] = 0;
@@ -711,7 +711,7 @@ STATIC void test403()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if ((filedir.unix_priv & 0444) != 0444) {
         if (!Quiet) {
@@ -828,7 +828,7 @@ static void test_data(char *name, char *name1, uint16_t vol2)
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (filedir.dflen != 400 || filedir.rflen != 300) {
         if (!Quiet) {
@@ -902,7 +902,7 @@ static void test_data(char *name, char *name1, uint16_t vol2)
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (filedir.dflen != 400 || filedir.rflen != 300) {
         if (!Quiet) {

--- a/test/testsuite/FPCreateDir.c
+++ b/test/testsuite/FPCreateDir.c
@@ -360,7 +360,7 @@ STATIC void test357()
 
     FAIL(FPGetFileDirParams(Conn, vol, tdir, "", 0, bitmap))
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     filedir.access[1] = 0;
     filedir.access[2] = 0;
@@ -377,7 +377,7 @@ STATIC void test357()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.attr = ATTRBIT_NODELETE | ATTRBIT_SETCLR ;
     FAIL(FPSetDirParms(Conn2, vol2, DIRDID_ROOT, name, bitmap, &filedir))
 

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -186,7 +186,7 @@ STATIC void test172()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.isdir = 0;
         FAIL(htonl(AFPERR_NOOBJ) != FPSetFileParams(Conn, vol, tdir, tname, bitmap,
                 &filedir))
@@ -268,7 +268,7 @@ STATIC void test172()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         FAIL(ntohl(AFPERR_NOOBJ) != FPSetFilDirParam(Conn, vol, tdir, tname, bitmap,
                 &filedir))
     }
@@ -355,7 +355,7 @@ STATIC void test196()
     bitmap = (1 << DIRPBIT_ACCESS);
     FAIL(FPGetFileDirParams(Conn, vol, tdir, "", 0, bitmap))
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     filedir.access[1] = 7;
     filedir.access[2] = 7;
@@ -530,7 +530,7 @@ STATIC void test421()
     bitmap = (1 << DIRPBIT_ACCESS);
     FAIL(FPGetFileDirParams(Conn, vol, tdir, "", 0, bitmap))
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     filedir.access[1] = 7;
     filedir.access[2] = 7;

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -421,7 +421,7 @@ STATIC void test339()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     filedir.access[1] = 7;
     filedir.access[2] = 7;
@@ -608,7 +608,7 @@ STATIC void test370()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     filedir.access[1] = 7;
     filedir.access[2] = 7;

--- a/test/testsuite/FPEnumerate.c
+++ b/test/testsuite/FPEnumerate.c
@@ -506,9 +506,9 @@ STATIC void test218()
     filedir.isdir = isdir;
 
     if (isdir) {
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     } else {
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     }
 
     FAIL(FPDelete(Conn, vol, bdir, filedir.lname))
@@ -597,7 +597,7 @@ STATIC void test300(void)
             for (int j = 1; j <= tp; j++, b += b[0]) {
                 if (b[1]) {
                     filedir.isdir = 1;
-                    afp_filedir_unpack(&filedir, b + 2, 0, d_bitmap);
+                    afp_filedir_unpack(Conn, &filedir, b + 2, 0, d_bitmap);
 
                     if (cnt > size) {
                         size += 1000;
@@ -612,7 +612,7 @@ STATIC void test300(void)
                     cnt++;
                 } else {
                     filedir.isdir = 0;
-                    afp_filedir_unpack(&filedir, b + 2, f_bitmap, 0);
+                    afp_filedir_unpack(Conn, &filedir, b + 2, f_bitmap, 0);
                 }
 
                 if (!Quiet) {

--- a/test/testsuite/FPExchangeFiles.c
+++ b/test/testsuite/FPExchangeFiles.c
@@ -300,7 +300,7 @@ STATIC void test342()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     memcpy(filedir.finder_info, "TESTTEST", 8);
     memcpy(finder_info, filedir.finder_info, 32);
     FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
@@ -317,7 +317,7 @@ STATIC void test342()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (memcmp(finder_info, filedir.finder_info, 32) != 0) {
         if (!Quiet) {

--- a/test/testsuite/FPFlushFork.c
+++ b/test/testsuite/FPFlushFork.c
@@ -30,7 +30,8 @@ STATIC void test203()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->commands + 2 * sizeof(uint16_t), bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->commands + 2 * sizeof(uint16_t), bitmap,
+                       0);
     mdate = filedir.mdate;
     sleep(2);
     FAIL(FPFlushFork(Conn, fork))
@@ -41,7 +42,7 @@ STATIC void test203()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + sizeof(uint16_t), bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + sizeof(uint16_t), bitmap, 0);
 
     /* is that always true? ie over nfs */
     if (mdate != filedir.mdate) {
@@ -63,7 +64,7 @@ STATIC void test203()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + sizeof(uint16_t), bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + sizeof(uint16_t), bitmap, 0);
 
     /* is that always true? ie over nfs */
     if (mdate == filedir.mdate) {

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -182,7 +182,7 @@ STATIC void test94()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     offcnt = filedir.offcnt;
 
     if (!Quiet) {
@@ -197,7 +197,7 @@ STATIC void test94()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (!Quiet) {
         fprintf(stdout, "Modif date dir %x \n", filedir.mdate);
@@ -220,7 +220,7 @@ STATIC void test94()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (!Quiet) {
         fprintf(stdout, "Modif date dir %x\n", filedir.mdate);
@@ -232,7 +232,7 @@ STATIC void test94()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (offcnt != filedir.offcnt) {
         if (!Quiet) {
@@ -299,7 +299,7 @@ STATIC void test104()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (filedir.did != dir3) {
         if (!Quiet) {
@@ -326,7 +326,7 @@ STATIC void test104()
         goto fin;
     }
 
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (filedir.did != dir2) {
         if (!Quiet) {
@@ -360,7 +360,7 @@ STATIC void test104()
         goto fin;
     }
 
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (filedir.did != dir4) {
         if (!Quiet) {
@@ -552,7 +552,7 @@ STATIC void test307()
         test_nottested();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         result = (Conn->afp_version >= 30) ? filedir.utf8_name : filedir.lname;
 
         if (strcmp(result, name)) {
@@ -607,7 +607,7 @@ STATIC void test308()
         test_nottested();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         result = (Conn->afp_version >= 30) ? filedir.utf8_name : filedir.lname;
 
         if (strcmp(result, name)) {
@@ -953,7 +953,7 @@ static int probe_extmap(char *probe_name, const char *expected_finfo8)
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     FPDelete(Conn, vol, DIRDID_ROOT, probe_name);
     return memcmp(filedir.finder_info, expected_finfo8, 8) == 0;
 }
@@ -1001,7 +1001,7 @@ STATIC void test371()
         goto fin;
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (memcmp(filedir.finder_info, "????????", 8)) {
             if (!Quiet) {
@@ -1020,7 +1020,7 @@ STATIC void test371()
         goto fin;
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (memcmp(filedir.finder_info, "PDF CARO", 8)) {
             if (!Quiet) {
@@ -1080,7 +1080,7 @@ STATIC void test380()
         goto fin;
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (memcmp(filedir.finder_info, "WDBNMSWD", 8)) {
             if (!Quiet) {
@@ -1099,7 +1099,7 @@ STATIC void test380()
         goto fin;
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (memcmp(filedir.finder_info, "WDBNMSWD", 8)) {
             if (!Quiet) {
@@ -1139,14 +1139,14 @@ STATIC void test396()
         test_nottested();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, d_bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, d_bitmap);
     }
 
     if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, f_bitmap, d_bitmap)) {
         test_nottested();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, d_bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, d_bitmap);
     }
 
     FPCreateID(Conn, vol, dir, "");
@@ -1197,7 +1197,7 @@ STATIC void test423()
         goto fin;
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         fid = filedir.did;
         FAIL(FPResolveID(Conn, vol, filedir.did, bitmap))
     }
@@ -1208,7 +1208,7 @@ STATIC void test423()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (fid != filedir.did) {
             if (!Quiet) {
@@ -1244,6 +1244,7 @@ static void do_pdinfo_test(char *fname, const char *fourcc, uint8_t expect_type,
     const DSI *dsi = &Conn->dsi;
     struct afp_filedir_parms filedir = { 0 };
     const unsigned char *buf;
+    const char *creator = "pdos";
     uint8_t prodos_type;
     uint16_t prodos_aux;
     FPCreateFile(Conn, vol, 0, DIRDID_ROOT, fname);
@@ -1256,9 +1257,10 @@ static void do_pdinfo_test(char *fname, const char *fourcc, uint8_t expect_type,
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap_finfo, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap_finfo, 0);
     /* Overwrite the first 4 bytes with our test type */
     memcpy(filedir.finder_info, fourcc, 4);
+    memcpy(filedir.finder_info + 4, creator, 4);
 
     /* Set FinderInfo via AFP */
     if (FPSetFileParams(Conn, vol, DIRDID_ROOT, fname, bitmap_finfo, &filedir)) {
@@ -1274,9 +1276,10 @@ static void do_pdinfo_test(char *fname, const char *fourcc, uint8_t expect_type,
         return;
     }
 
-    buf = dsi->data + ofs;
-    prodos_type = buf[0];
-    prodos_aux = (uint16_t)(buf[2] << 8) | buf[3];
+    filedir.isdir = 0;
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap_pdinfo, 0);
+    prodos_type = filedir.pdinfo[0];
+    prodos_aux = (uint16_t)(filedir.pdinfo[3] << 8) | filedir.pdinfo[2];
 
     if (prodos_type != expect_type || prodos_aux != expect_aux) {
         test_failed();
@@ -1307,6 +1310,8 @@ STATIC void test440()
     do_pdinfo_test(name_psys, "PSYS", 0xff, 0x0000);
     /* PS16: type 'PS16' -> ProDOS type 0xb3, aux 0x0000 */
     do_pdinfo_test(name_ps16, "PS16", 0xb3, 0x0000);
+    /* PXYY: type 'pPTE' -> ProDOS type 0x50, aux 0x5445 */
+    do_pdinfo_test(name_ps16, "pPTE", 0x50, 0x5445);
 test_exit:
     exit_test("FPGetFileDirParms:test440: ProDOS Info Bit for legacy clients");
 }
@@ -1340,7 +1345,7 @@ STATIC void test441()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap_finfo, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap_finfo, 0);
     /* Set type to "APPL" and creator to "TEST" - an invalid combination */
     memcpy(filedir.finder_info, "APPLTEST", 8);
 
@@ -1359,9 +1364,10 @@ STATIC void test441()
         goto test_exit;
     }
 
-    buf = dsi->data + ofs;
-    prodos_type = buf[0];
-    prodos_aux = (uint16_t)(buf[2] << 8) | buf[3];
+    filedir.isdir = 0;
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap_pdinfo, 0);
+    prodos_type = filedir.pdinfo[0];
+    prodos_aux = (uint16_t)(filedir.pdinfo[3] << 8) | filedir.pdinfo[2];
 
     if (prodos_type != 0x00 || prodos_aux != 0x0000) {
         test_failed();
@@ -1376,9 +1382,10 @@ STATIC void test442()
 {
     char *dirname = "pdinfo_dir";
     uint16_t vol = VolID;
-    uint16_t bitmap_pdinfo = (1 << FILPBIT_PDINFO);
+    uint16_t bitmap_pdinfo = (1 << DIRPBIT_PDINFO);
     int ofs = 3 * sizeof(uint16_t);
     const DSI *dsi = &Conn->dsi;
+    struct afp_filedir_parms filedir = { 0 };
     const unsigned char *buf;
     uint8_t prodos_type;
     uint16_t prodos_aux;
@@ -1404,9 +1411,10 @@ STATIC void test442()
         goto test_exit;
     }
 
-    buf = dsi->data + ofs;
-    prodos_type = buf[0];
-    prodos_aux = (uint16_t)(buf[2] << 8) | buf[3];
+    filedir.isdir = 1;
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap_pdinfo);
+    prodos_type = filedir.pdinfo[0];
+    prodos_aux = (uint16_t)(filedir.pdinfo[3] << 8) | filedir.pdinfo[2];
 
     if (prodos_type != 0x0F || prodos_aux != 0x0200) {
         test_failed();

--- a/test/testsuite/FPGetUserInfo.c
+++ b/test/testsuite/FPGetUserInfo.c
@@ -25,7 +25,7 @@ STATIC void test75()
 
     FAIL(FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, 0, bitmap))
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     FAIL(htonl(AFPERR_PARAM) != FPGetUserInfo(Conn, 0, 0, 1))
     FAIL(htonl(AFPERR_BITMAP) != FPGetUserInfo(Conn, 1, 0, 0xff))
     ret = FPGetUserInfo(Conn, 1, 0, 3);

--- a/test/testsuite/FPMapID.c
+++ b/test/testsuite/FPMapID.c
@@ -26,7 +26,7 @@ STATIC void test208()
 
     FAIL(FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, 0, bitmap))
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     /* user to Mac roman */
     FAIL(FPMapID(Conn, 1, 0))
     /* user to Mac roman */

--- a/test/testsuite/FPMapName.c
+++ b/test/testsuite/FPMapName.c
@@ -28,7 +28,7 @@ STATIC void test180()
 
     FAIL(FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, 0, bitmap))
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     FAIL(FPMapID(Conn, 1, 0))   /* user to Mac roman */
     ret = FPMapID(Conn, 1, filedir.uid);  /* user to Mac roman */
 

--- a/test/testsuite/FPMoveAndRename.c
+++ b/test/testsuite/FPMoveAndRename.c
@@ -288,7 +288,7 @@ STATIC void test138()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.access[0] = 0;
         filedir.access[1] = 3;
         filedir.access[2] = 3;

--- a/test/testsuite/FPOpenFork.c
+++ b/test/testsuite/FPOpenFork.c
@@ -635,7 +635,7 @@ STATIC void test116()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     filedir.attr = ATTRBIT_NOWRITE | ATTRBIT_SETCLR ;
     bitmap = (1 << DIRPBIT_ATTR);
 
@@ -887,7 +887,7 @@ static void test_openmode(char *name, int type)
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi2->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, bitmap, 0);
 
         if (!(filedir.attr & what)) {
             test_failed();
@@ -908,7 +908,7 @@ static void test_openmode(char *name, int type)
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi2->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, bitmap, 0);
 
         if (!(filedir.attr & what)) {
             test_failed();
@@ -925,7 +925,7 @@ static void test_openmode(char *name, int type)
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi2->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, bitmap, 0);
 
         if (!(filedir.attr & what)) {
             test_failed();
@@ -942,7 +942,7 @@ static void test_openmode(char *name, int type)
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi2->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, bitmap, 0);
 
         if (filedir.attr & what) {
             test_failed();

--- a/test/testsuite/FPRename.c
+++ b/test/testsuite/FPRename.c
@@ -68,7 +68,7 @@ STATIC void test72()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.attr = ATTRBIT_NORENAME | ATTRBIT_SETCLR ;
         FAIL(FPSetDirParms(Conn, vol, dir1, "", bitmap, &filedir))
         ret = FPRename(Conn, vol, DIRDID_ROOT, ndel, "volume");
@@ -142,7 +142,7 @@ static int create_double_deleted_folder(uint16_t vol, char *name)
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     filedir.access[1] = 7;
     filedir.access[2] = 7;

--- a/test/testsuite/FPResolveID.c
+++ b/test/testsuite/FPResolveID.c
@@ -34,7 +34,7 @@ STATIC void test76()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL(FPResolveID(Conn, vol, filedir.did, bitmap))
         FAIL(htonl(AFPERR_BITMAP) != FPResolveID(Conn, vol, filedir.did, 0xffff))
     }
@@ -99,7 +99,7 @@ STATIC void test91()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL(FPDeleteID(Conn, vol, filedir.did))
     }
 
@@ -143,7 +143,7 @@ STATIC void test310()
         goto fin;
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     }
 
     FAIL(FPResolveID(Conn, vol, filedir.did, bitmap))
@@ -187,7 +187,7 @@ STATIC void test311()
         goto fin;
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     }
 
     FAIL(FPResolveID(Conn, vol, filedir.did, bitmap))
@@ -243,7 +243,7 @@ STATIC void test362()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL((FPResolveID(Conn, vol, filedir.did, bitmap)))
     }
 
@@ -288,7 +288,7 @@ STATIC void test417()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         fid = filedir.did;
         FAIL(FPResolveID(Conn, vol, filedir.did, bitmap))
     }
@@ -299,7 +299,7 @@ STATIC void test417()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (fid != filedir.did) {
             if (!Quiet) {

--- a/test/testsuite/FPSetDirParms.c
+++ b/test/testsuite/FPSetDirParms.c
@@ -30,7 +30,7 @@ STATIC void test82()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
 
     if (FPSetDirParms(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir)) {
@@ -44,7 +44,7 @@ STATIC void test82()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
 
     if (FPSetDirParms(Conn, vol, DIRDID_ROOT, "", bitmap, &filedir)) {
@@ -82,7 +82,7 @@ STATIC void test84()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.attr = ATTRBIT_NODELETE | ATTRBIT_SETCLR ;
         FAIL(FPSetDirParms(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
 
@@ -155,7 +155,7 @@ STATIC void test88()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.access[0] = 0;
         bitmap = (1 << DIRPBIT_ATTR);
         filedir.attr = ATTRBIT_INVISIBLE | ATTRBIT_SETCLR ;
@@ -244,7 +244,7 @@ STATIC void test107()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi2->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi2->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     uid = filedir.uid;
 
@@ -252,7 +252,7 @@ STATIC void test107()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi2->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, 0, bitmap);
         filedir.access[0] = 0;
         filedir.uid = uid;
         /* change owner */
@@ -263,7 +263,7 @@ STATIC void test107()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi2->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, 0, bitmap);
         filedir.access[0] = 0;
         filedir.uid = uid;
         FAIL(FPSetDirParms(Conn2, vol2, DIRDID_ROOT, ndir, bitmap2, &filedir))
@@ -273,7 +273,7 @@ STATIC void test107()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi2->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, 0, bitmap);
         filedir.access[0] = 0;
         filedir.uid = uid;
         ret = FPSetDirParms(Conn2, vol2, DIRDID_ROOT, "", bitmap2, &filedir);
@@ -333,7 +333,7 @@ STATIC void test189()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     FAIL(ntohl(AFPERR_BADTYPE) != FPSetDirParms(Conn, vol, dir, name1, bitmap,
             &filedir))
@@ -366,7 +366,7 @@ STATIC void test193()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         ret = FPSetDirParms(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir);
 
         if (not_valid(ret, /* MAC */AFPERR_PARAM, 0)) {
@@ -411,7 +411,7 @@ STATIC void test351()
 
     memset(&filedir, 0, sizeof(filedir));
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs,  0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs,  0, bitmap);
     bitmap = (1 << DIRPBIT_ACCESS);
     filedir.access[0] = 0;
     memcpy(old_access, filedir.access, sizeof(old_access));
@@ -477,7 +477,7 @@ STATIC void test352()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     bitmap = (1 << DIRPBIT_ACCESS);
     filedir.unix_priv = 0;
     filedir.access[0] = 0;
@@ -550,7 +550,7 @@ STATIC void test353()
 
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 1;
     filedir.access[0] = 0;
@@ -580,7 +580,7 @@ STATIC void test353()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 0;
     filedir.access[0] = 0;
@@ -633,7 +633,7 @@ STATIC void test354()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 0;
     filedir.access[0] = 0;
@@ -706,7 +706,7 @@ STATIC void test355()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs,  0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs,  0, bitmap);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 0;
     filedir.access[0] = 0;
@@ -776,7 +776,7 @@ STATIC void test356()
 
     memset(&filedir, 0, sizeof(filedir));
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs,  0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs,  0, bitmap);
     bitmap = (1 << DIRPBIT_UNIXPR);
     old_unixpriv = filedir.unix_priv;
     filedir.unix_priv = 0;
@@ -903,7 +903,7 @@ STATIC void test405()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (!(filedir.gid = check_group(filedir.gid))) {
         test_skipped(T_UNIX_GROUP);

--- a/test/testsuite/FPSetFileDirParms.c
+++ b/test/testsuite/FPSetFileDirParms.c
@@ -59,7 +59,7 @@ STATIC void test98()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         bitmap = (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE);
         ret = FPSetFilDirParam(Conn, vol, DIRDID_ROOT, rodir, bitmap, &filedir);
 
@@ -139,7 +139,7 @@ STATIC void test230()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
         if (!(S_ISDIR(filedir.unix_priv))) {
             if (!Quiet) {
@@ -197,7 +197,7 @@ STATIC void test230()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         bitmap = (1 << DIRPBIT_UNIXPR);
         filedir.unix_priv &= ~S_IWUSR;
         FAIL(FPSetFilDirParam(Conn, vol, dir, name, bitmap, &filedir))
@@ -226,7 +226,7 @@ STATIC void test230()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         bitmap = (1 << DIRPBIT_UNIXPR);
         filedir.unix_priv |= S_IWUSR;
         FAIL(FPSetFilDirParam(Conn, vol, dir, "", bitmap, &filedir))
@@ -298,7 +298,7 @@ STATIC void test231()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         bitmap = (1 << DIRPBIT_UNIXPR);
         filedir.unix_priv |= S_IWUSR | S_IWGRP | S_IRGRP | S_IWOTH | S_IROTH;
         FAIL(FPSetFilDirParam(Conn, vol, dir, "", bitmap, &filedir))
@@ -321,7 +321,7 @@ STATIC void test231()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         bitmap = (1 << DIRPBIT_UNIXPR);
         filedir.unix_priv &= ~(S_IWUSR | S_IWGRP | S_IWOTH);
         FAIL(FPSetFilDirParam(Conn, vol, dir, "", bitmap, &filedir))
@@ -342,7 +342,7 @@ STATIC void test231()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         bitmap = (1 << DIRPBIT_UNIXPR);
         filedir.unix_priv |= S_IWUSR;
         FAIL(FPSetFilDirParam(Conn, vol, dir, "", bitmap, &filedir))
@@ -399,7 +399,7 @@ STATIC void test232()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         bitmap = (1 << DIRPBIT_UNIXPR);
         filedir.unix_priv &= ~(S_IWUSR | S_IWGRP | S_IWOTH);
         filedir.access[0] = 0;
@@ -462,7 +462,7 @@ STATIC void test345()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         bitmap = (1 << DIRPBIT_UNIXPR);
         filedir.unix_priv = 0;
         filedir.access[0] = 0;
@@ -547,7 +547,7 @@ STATIC void test346()
         FAIL(FPDelete(Conn, vol, dir, name))
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         bitmap = (1 << DIRPBIT_UNIXPR);
         filedir.unix_priv = 0;
         filedir.access[0] = 0;
@@ -606,7 +606,7 @@ STATIC void test347()
 
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 1;
     filedir.access[0] = 0;
@@ -636,7 +636,7 @@ STATIC void test347()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 0;
     filedir.access[0] = 0;
@@ -689,7 +689,7 @@ STATIC void test348()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 0;
     filedir.access[0] = 0;
@@ -762,7 +762,7 @@ STATIC void test349()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs,  0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs,  0, bitmap);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 0;
     filedir.access[0] = 0;
@@ -832,7 +832,7 @@ STATIC void test350()
 
     memset(&filedir, 0, sizeof(filedir));
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs,  0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs,  0, bitmap);
     bitmap = (1 << DIRPBIT_UNIXPR);
     old_unixpriv = filedir.unix_priv;
     filedir.unix_priv = 0;
@@ -920,7 +920,7 @@ STATIC void test358()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     memcpy(old_access, filedir.access, sizeof(old_access));
     filedir.access[1] = filedir.access[2] = 0;
@@ -982,12 +982,12 @@ STATIC void test359()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     filedir.attr = ATTRBIT_NODELETE | ATTRBIT_SETCLR ;
     FAIL(FPSetFileParams(Conn, vol, dir,  name, (1 << FILPBIT_ATTR), &filedir))
     FAIL(ntohl(AFPERR_OLOCK) != FPDelete(Conn, vol, dir, name))
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 0;
     filedir.access[0] = 0;
@@ -1000,7 +1000,7 @@ STATIC void test359()
         goto fin2;
     }
 
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if ((filedir.attr & ATTRBIT_NODELETE) != ATTRBIT_NODELETE) {
         if (!Quiet) {
@@ -1087,12 +1087,12 @@ STATIC void test361()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     filedir.attr = ATTRBIT_NODELETE | ATTRBIT_SETCLR ;
     FAIL(FPSetFileParams(Conn, vol, dir,  name, (1 << FILPBIT_ATTR), &filedir))
     FAIL(ntohl(AFPERR_OLOCK) != FPDelete(Conn, vol, dir, name))
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.unix_priv = 0;
     filedir.access[0] = 0;
@@ -1105,7 +1105,7 @@ STATIC void test361()
         goto fin2;
     }
 
-    afp_filedir_unpack(&filedir, dsi2->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi2->data + ofs, bitmap, 0);
 
     if ((filedir.attr & ATTRBIT_NODELETE) != ATTRBIT_NODELETE) {
         if (!Quiet) {
@@ -1176,7 +1176,7 @@ STATIC void test400()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     bitmap = (1 << DIRPBIT_UNIXPR);
     filedir.uid = 100000;
     filedir.gid = 125000;

--- a/test/testsuite/FPSetFileParms.c
+++ b/test/testsuite/FPSetFileParms.c
@@ -34,7 +34,7 @@ STATIC void test83()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
         FAIL(htonl(AFPERR_NOOBJ) != FPSetFileParams(Conn, vol, DIRDID_ROOT, name1,
                 bitmap, &filedir))
@@ -72,7 +72,7 @@ STATIC void test96()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (!Quiet) {
         fprintf(stdout, "Modif date parent %x\n", filedir.mdate);
@@ -86,7 +86,7 @@ STATIC void test96()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (!Quiet) {
         fprintf(stdout, "Modif date file %x\n", filedir.mdate);
@@ -104,7 +104,7 @@ STATIC void test96()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (!Quiet) {
         fprintf(stdout, "Modif date file %x\n", filedir.mdate);
@@ -116,7 +116,7 @@ STATIC void test96()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (!Quiet) {
         fprintf(stdout, "Modif date parent %x\n", filedir.mdate);
@@ -149,7 +149,7 @@ STATIC void test118()
         test_nottested();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         filedir.attr = ATTRBIT_NODELETE | ATTRBIT_SETCLR ;
         FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
         FAIL(ntohl(AFPERR_OLOCK) != FPDelete(Conn, vol, DIRDID_ROOT, name))
@@ -198,7 +198,7 @@ STATIC void test122()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         /* wrong attrib (open fork set ) */
         ret = FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir);
 
@@ -253,7 +253,7 @@ STATIC void test318()
         test_nottested();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL(htonl(AFPERR_BITMAP) != FPSetFileParams(Conn, vol, DIRDID_ROOT, name,
                 bitmap, &filedir))
     }
@@ -303,7 +303,7 @@ static int afp_symlink(char *oldpath, char *newpath)
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     memcpy(filedir.finder_info, "slnkrhap", 8);
     bitmap = (1 << FILPBIT_FINFO);
 
@@ -448,7 +448,7 @@ STATIC void test429()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (!filedir.did || filedir.did != id) {
             if (!Quiet) {
@@ -504,6 +504,181 @@ test_exit:
 }
 
 
+STATIC void test433()
+{
+    char *name = "pdinfo_text";
+    uint16_t vol = VolID;
+    uint16_t bitmap_finfo = (1 << FILPBIT_FINFO);
+    uint16_t bitmap_pdinfo = (1 << FILPBIT_PDINFO);
+    uint16_t bitmap_date = (1 << FILPBIT_CDATE) | (1 << FILPBIT_BDATE) |
+                           (1 << FILPBIT_MDATE);
+    int ofs = 3 * sizeof(uint16_t);
+    DSI *dsi = &Conn->dsi;
+    struct afp_filedir_parms filedir;
+    ENTER_TEST
+
+    if (Conn->afp_version >= 30) {
+        test_skipped(T_AFP2);
+        goto test_exit;
+    }
+
+    FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name);
+
+    /* Update the date of the file to ensure AppleDouble is created */
+    if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, bitmap_date, 0)) {
+        test_failed();
+        goto fin;
+    }
+
+    filedir.isdir = 0;
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap_date, 0);
+    filedir.cdate += 1;
+    filedir.bdate += 1;
+    filedir.mdate += 1;
+
+    if (FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap_date, &filedir)) {
+        test_failed();
+        goto fin;
+    }
+
+    filedir.isdir = 0;
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap_pdinfo, 0);
+    /* ProDOS type */
+    filedir.pdinfo[0] = 0x50;
+    /* Unused bytes */
+    filedir.pdinfo[1] = 0x00;
+    /* Low byte of prodos_aux */
+    filedir.pdinfo[2] = 0x45;
+    /* High byte of prodos_aux */
+    filedir.pdinfo[3] = 0x54;
+    /* Unused bytes */
+    filedir.pdinfo[4] = 0x00;
+    /* Unused bytes */
+    filedir.pdinfo[5] = 0x00;
+
+    if (FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap_pdinfo, &filedir)) {
+        test_failed();
+        goto fin;
+    }
+
+    /* Now get FinderInfo and verify type/creator mapping */
+    if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, bitmap_finfo, 0)) {
+        test_failed();
+        goto fin;
+    }
+
+    filedir.isdir = 0;
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap_finfo, 0);
+
+    if (memcmp(filedir.finder_info, "pPTEpdos", 8) != 0) {
+        if (!Quiet) {
+            fprintf(stdout, "Mac creator/type needs to be pPTEpdos, was: %.8s - ",
+                    filedir.finder_info);
+
+            for (int i = 0; i < 8; i++) {
+                fprintf(stdout, "%02x ", (unsigned char)filedir.finder_info[i]);
+            }
+
+            fprintf(stdout, "\n");
+        }
+
+        test_failed();
+    }
+
+fin:
+    FPDelete(Conn, vol, DIRDID_ROOT, name);
+test_exit:
+    exit_test("FPSetFileParms:test433: set ProDOS $50/$5445, verify Mac pPTE/pdos mapping");
+}
+
+STATIC void test434()
+{
+    char *name = "pdinfo_text";
+    uint16_t vol = VolID;
+    uint16_t bitmap_finfo = (1 << FILPBIT_FINFO);
+    uint16_t bitmap_pdinfo = (1 << FILPBIT_PDINFO);
+    uint16_t bitmap_date = (1 << FILPBIT_CDATE) | (1 << FILPBIT_BDATE) |
+                           (1 << FILPBIT_MDATE);
+    int ofs = 3 * sizeof(uint16_t);
+    DSI *dsi = &Conn->dsi;
+    struct afp_filedir_parms filedir;
+    ENTER_TEST
+
+    if (Conn->afp_version >= 30) {
+        test_skipped(T_AFP2);
+        goto test_exit;
+    }
+
+    FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name);
+
+    /* Update the date of the file to ensure AppleDouble is created */
+    if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, bitmap_date, 0)) {
+        test_failed();
+        goto fin;
+    }
+
+    filedir.isdir = 0;
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap_date, 0);
+    filedir.cdate += 1;
+    filedir.bdate += 1;
+    filedir.mdate += 1;
+
+    if (FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap_date, &filedir)) {
+        test_failed();
+        goto fin;
+    }
+
+    filedir.isdir = 0;
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap_pdinfo, 0);
+    /* ProDOS type */
+    filedir.pdinfo[0] = 0x04;
+    /* Unused bytes */
+    filedir.pdinfo[1] = 0x00;
+    /* Low byte of prodos_aux */
+    filedir.pdinfo[2] = 0x00;
+    /* High byte of prodos_aux */
+    filedir.pdinfo[3] = 0x00;
+    /* Unused bytes */
+    filedir.pdinfo[4] = 0x00;
+    /* Unused bytes */
+    filedir.pdinfo[5] = 0x00;
+
+    if (FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap_pdinfo, &filedir)) {
+        test_failed();
+        goto fin;
+    }
+
+    /* Now get FinderInfo and verify type/creator mapping */
+    if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, bitmap_finfo, 0)) {
+        test_failed();
+        goto fin;
+    }
+
+    filedir.isdir = 0;
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap_finfo, 0);
+
+    if (memcmp(filedir.finder_info, "TEXTpdos", 8) != 0) {
+        if (!Quiet) {
+            fprintf(stdout, "Mac creator/type needs to be TEXTpdos, was: %.8s - ",
+                    filedir.finder_info);
+
+            for (int i = 0; i < 8; i++) {
+                fprintf(stdout, "%02x ", (unsigned char)filedir.finder_info[i]);
+            }
+
+            fprintf(stdout, "\n");
+        }
+
+        test_failed();
+    }
+
+fin:
+    FPDelete(Conn, vol, DIRDID_ROOT, name);
+test_exit:
+    exit_test("FPSetFileParms:test434: set ProDOS $04/$0000, verify Mac TEXT/pdos mapping");
+}
+
+
 /* ----------- */
 void FPSetFileParms_test()
 {
@@ -517,4 +692,6 @@ void FPSetFileParms_test()
     test428();
     test429();
     test430();
+    test433();
+    test434();
 }

--- a/test/testsuite/FPSetForkParms.c
+++ b/test/testsuite/FPSetForkParms.c
@@ -205,7 +205,7 @@ STATIC void test306()
     int fork;
     char *name = "t306 file.txt";
     uint16_t vol = VolID;
-    uint32_t data = (unsigned) -1;
+    uint32_t data = (unsigned) - 1;
     DSI *dsi;
     dsi = &Conn->dsi;
     ENTER_TEST

--- a/test/testsuite/FPSync.c
+++ b/test/testsuite/FPSync.c
@@ -29,7 +29,7 @@ STATIC void test2()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, (1 << DIRPBIT_DID));
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, (1 << DIRPBIT_DID));
 
     if (FPSyncDir(Conn, vol, filedir.did)) {
         test_failed();

--- a/test/testsuite/FPzzz.c
+++ b/test/testsuite/FPzzz.c
@@ -59,7 +59,7 @@ STATIC void test223()
     sleep(60 * 3);
     ret = FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name);
 
-    if (sigp || ret == (unsigned) -1) {
+    if (sigp || ret == (unsigned) - 1) {
         fprintf(stdout, "\tFAILED disconnected %d\n", sigp);
         test_failed();
         /* try to reconnect */
@@ -151,7 +151,7 @@ STATIC void test224()
     sleep(60 * 3);
     ret = FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name);
 
-    if (!sigp && ret != (unsigned) -1) {
+    if (!sigp && ret != (unsigned) - 1) {
         fprintf(stdout, "\tFAILED not disconnected \n");
         test_failed();
     } else {

--- a/test/testsuite/T2_Dircache_attack.c
+++ b/test/testsuite/T2_Dircache_attack.c
@@ -169,7 +169,7 @@ STATIC void test500()
     /* Manually check name and CNID */
     FAIL(FPGetFileDirParams(Conn, vol1, subdir2_id, renamedsubdir1, 0, bitmap));
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (filedir.did != subdir1_id) {
         if (!Quiet) {
@@ -240,7 +240,7 @@ STATIC void test501()
     /* Manually check name and CNID */
     FAIL(FPGetFileDirParams(Conn, vol1, subdir2_id, renamedsubdir1, 0, bitmap));
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (filedir.did != subdir1_id) {
         if (!Quiet) {
@@ -316,7 +316,7 @@ STATIC void test502()
     /* Manually check name and CNID */
     FAIL(FPGetFileDirParams(Conn, vol1, subdir1_id, "", 0, bitmap));
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (filedir.did != subdir1_id) {
         if (!Quiet) {
@@ -388,7 +388,7 @@ STATIC void test503()
     /* Manually check name and CNID */
     FAIL(FPGetFileDirParams(Conn, vol1, subdir1_id, "", 0, bitmap));
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (filedir.did != subdir1_id) {
         if (!Quiet) {
@@ -458,14 +458,14 @@ STATIC void test504()
     FAIL(FPCreateFile(Conn, vol1,  0, subdir2_id, "file1"));
     FAIL(FPGetFileDirParams(Conn, vol1, subdir2_id, "file1", 0, bitmap));
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     file_id = filedir.did;
     /* Move and rename dir with second connection */
     FAIL(FPMoveAndRename(Conn2, vol2, dir_id, dir_id, subdir1, renamedsubdir1));
     /* check CNID */
     FAIL(FPGetFileDirParams(Conn, vol1, subdir2_id, "file1", 0, bitmap));
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (filedir.did != file_id) {
         if (!Quiet) {
@@ -529,7 +529,7 @@ STATIC void test505()
     /* Manually check name and CNID */
     FAIL(FPGetFileDirParams(Conn, vol1, subdir2_id, "", 0, bitmap));
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (filedir.did != subdir2_id) {
         if (!Quiet) {
@@ -607,7 +607,7 @@ STATIC void test506()
     /* Manually check name and CNID */
     FAIL(FPGetFileDirParams(Conn, vol1, subdir2_id, "", 0, bitmap));
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (filedir.did != subdir2_id) {
         if (!Quiet) {

--- a/test/testsuite/T2_FPCopyFile.c
+++ b/test/testsuite/T2_FPCopyFile.c
@@ -52,7 +52,7 @@ STATIC void test373()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         mdate = filedir.mdate;
     }
 
@@ -62,7 +62,7 @@ STATIC void test373()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (mdate != filedir.mdate)  {
             if (!Quiet) {

--- a/test/testsuite/T2_FPDelete.c
+++ b/test/testsuite/T2_FPDelete.c
@@ -46,7 +46,7 @@ STATIC void test146()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.access[0] = 0;
         filedir.access[1] = 3; /* everyone */
         filedir.access[2] = 3; /* group */
@@ -170,7 +170,7 @@ STATIC void test507()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL((FPResolveID(Conn, vol, filedir.did, bitmap)))
     }
 
@@ -220,7 +220,7 @@ STATIC void test363()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     }
 
     sprintf(temp1, "%s/%s/.AppleDouble/%s", Path, name1, name);
@@ -290,7 +290,7 @@ STATIC void test364()
         goto fin;
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL((FPResolveID(Conn, vol, filedir.did, bitmap)))
     }
 

--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -409,7 +409,7 @@ STATIC void test106()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (filedir.did != dir3) {
         if (!Quiet) {
@@ -448,7 +448,7 @@ STATIC void test106()
                            bitmap)) {
         test_failed();
     } else {
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
         if (filedir.did != dir2) {
             if (!Quiet) {
@@ -478,7 +478,7 @@ STATIC void test106()
     if (FPGetFileDirParams(Conn, vol, dir3, "t104 dir4/", 0, bitmap)) {
         test_failed();
     } else {
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
         if (filedir.did != dir4) {
             if (!Quiet) {
@@ -869,7 +869,7 @@ STATIC void test336()
         test_nottested();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
         if (filedir.pdid != ntohl(dir)) {
             if (!Quiet) {
@@ -1062,7 +1062,7 @@ STATIC void test420()
         goto fin;
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         fid = filedir.did;
         FAIL(FPResolveID(Conn, vol, filedir.did, bitmap))
     }
@@ -1080,7 +1080,7 @@ STATIC void test420()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (fid != filedir.did) {
             if (!Quiet) {
@@ -1161,7 +1161,7 @@ STATIC void test545()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     memset(filedir.finder_info, 0, 32);
     memcpy(filedir.finder_info + 0, "INIT", 4);
     memcpy(filedir.finder_info + 4, "CRE1", 4);
@@ -1186,7 +1186,7 @@ STATIC void test545()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (memcmp(filedir.finder_info, "INIT", 4) != 0 ||
             memcmp(filedir.finder_info + 4, "CRE1", 4) != 0) {
@@ -1226,7 +1226,7 @@ STATIC void test545()
 
     memset(&filedir, 0, sizeof(filedir));
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi2->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, bitmap, 0);
     memset(filedir.finder_info, 0, 32);
     memcpy(filedir.finder_info + 0, "UPDT", 4);
     memcpy(filedir.finder_info + 4, "CLI2", 4);
@@ -1265,7 +1265,7 @@ STATIC void test545()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (memcmp(filedir.finder_info, "UPDT", 4) != 0 ||
             memcmp(filedir.finder_info + 4, "CLI2", 4) != 0) {

--- a/test/testsuite/T2_FPOpenFork.c
+++ b/test/testsuite/T2_FPOpenFork.c
@@ -781,7 +781,7 @@ STATIC void test372()
         goto fin;
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         memcpy(filedir.finder_info, "TEXTttxt", 8);
         FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, (1 << FILPBIT_FINFO),
                              &filedir))
@@ -885,7 +885,7 @@ STATIC void test388()
         goto fin;
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         memcpy(filedir.finder_info, "TEXTttxt", 8);
         FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, (1 << FILPBIT_FINFO),
                              &filedir))
@@ -989,7 +989,7 @@ STATIC void test392()
         goto fin;
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         memcpy(filedir.finder_info, "PDF CARO", 8);
         FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, (1 << FILPBIT_FINFO),
                              &filedir))
@@ -1243,7 +1243,7 @@ STATIC void test236()
             test_failed();
         }
 
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 1 << FILPBIT_UNIXPR, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 1 << FILPBIT_UNIXPR, 0);
 
         if (!(S_ISLNK(filedir.unix_priv))) {
             test_skipped(T_NOSYML);
@@ -1306,7 +1306,7 @@ STATIC void test237()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 1 << FILPBIT_UNIXPR, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 1 << FILPBIT_UNIXPR, 0);
 
     if (!(S_ISLNK(filedir.unix_priv))) {
         test_skipped(T_NOSYML);
@@ -1392,7 +1392,7 @@ STATIC void test238()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 1 << FILPBIT_UNIXPR, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 1 << FILPBIT_UNIXPR, 0);
 
     if (!(S_ISLNK(filedir.unix_priv))) {
         test_skipped(T_NOSYML);
@@ -1597,7 +1597,7 @@ STATIC void test431()
         test_failed();
     }
 
-    afp_filedir_unpack(&filedir, dsi->data + 6, (1 << FILPBIT_FINFO), 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + 6, (1 << FILPBIT_FINFO), 0);
 
     if (memcmp(filedir.finder_info, "TEXTTEST", 8)) {
         if (!Quiet) {
@@ -2374,7 +2374,7 @@ STATIC void test544()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, fbitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, fbitmap, 0);
 
     if (filedir.rflen != 500) {
         if (!Quiet) {
@@ -2460,7 +2460,7 @@ STATIC void test544()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, fbitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, fbitmap, 0);
 
     if (filedir.rflen != 800) {
         if (!Quiet) {
@@ -2826,7 +2826,7 @@ STATIC void test546()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi2->data + ofs, fbitmap, 0);
+    afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, fbitmap, 0);
 
     if (filedir.rflen != 200) {
         if (!Quiet) {

--- a/test/testsuite/T2_FPResolveID.c
+++ b/test/testsuite/T2_FPResolveID.c
@@ -41,7 +41,7 @@ STATIC void test129()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL((FPResolveID(Conn, vol, filedir.did, bitmap)))
     }
 
@@ -110,7 +110,7 @@ STATIC void test130()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL(FPResolveID(Conn, vol, filedir.did, bitmap))
     }
 
@@ -181,7 +181,7 @@ STATIC void test131()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL(FPResolveID(Conn, vol, filedir.did, bitmap))
     }
 
@@ -256,7 +256,7 @@ STATIC void test331()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         fid = filedir.did;
         FAIL(FPResolveID(Conn, vol, filedir.did, bitmap))
     }
@@ -299,7 +299,7 @@ STATIC void test331()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (fid != filedir.did) {
             if (!Quiet) {
@@ -431,7 +431,7 @@ STATIC void test360()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         fid = filedir.did;
         FAIL(FPResolveID(Conn, vol, filedir.did, bitmap))
     }
@@ -478,7 +478,7 @@ STATIC void test360()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (fid != filedir.did) {
             if (!Quiet) {
@@ -528,7 +528,7 @@ STATIC void test397()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL((FPResolveID(Conn, vol, filedir.did, bitmap)))
     }
 
@@ -598,7 +598,7 @@ STATIC void test412()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     fid = filedir.did;
     FAIL(FPResolveID(Conn, vol, fid, bitmap))
     sprintf(temp, "%s/%s", Path, ndir1);
@@ -640,7 +640,7 @@ STATIC void test412()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (fid != filedir.did) {
         if (!Quiet) {
@@ -700,7 +700,7 @@ STATIC void test413()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     fid = filedir.did;
     FAIL(FPResolveID(Conn, vol, fid, bitmap))
     sprintf(temp, "%s/%s/%s", Path, name1, name);
@@ -743,7 +743,7 @@ STATIC void test413()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (fid != filedir.did) {
         if (!Quiet) {
@@ -802,7 +802,7 @@ STATIC void test418()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     fid1 = filedir.did;
     FAIL(FPResolveID(Conn, vol, fid1, bitmap))
     /* create file2 */
@@ -814,7 +814,7 @@ STATIC void test418()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     fid2 = filedir.did;
     FAIL(FPResolveID(Conn, vol, fid2, bitmap))
     /* rename name1 --> tmp */
@@ -831,7 +831,7 @@ STATIC void test418()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (fid2 != filedir.did) {
         if (!Quiet) {
@@ -851,7 +851,7 @@ STATIC void test418()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (fid1 != filedir.did) {
         if (!Quiet) {

--- a/test/testsuite/T2_FPSetDirParms.c
+++ b/test/testsuite/T2_FPSetDirParms.c
@@ -36,7 +36,7 @@ STATIC void test121()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
         if (delete_unix_adouble(Path, name)) {
             goto fin;
@@ -212,7 +212,7 @@ STATIC void test528()
      * any cached permission information. */
     FAIL(FPGetFileDirParams(Conn, vol, DIRDID_ROOT, parent_name, 0, bitmap))
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (!Quiet && Verbose) {
         fprintf(stdout, "\t    Parent stat completed, cache should be invalidated\n");

--- a/test/testsuite/T2_FPSetFileParms.c
+++ b/test/testsuite/T2_FPSetFileParms.c
@@ -45,7 +45,7 @@ static int afp_symlink(char *oldpath, char *newpath)
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     memcpy(filedir.finder_info, "slnkrhap", 8);
     bitmap = (1 << FILPBIT_FINFO);
 
@@ -85,7 +85,7 @@ STATIC void test89()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         ret = FPSetFileParams(Conn, vol, dir, file, bitmap, &filedir);
 
         if (not_valid(ret, 0, AFPERR_ACCESS)) {
@@ -99,7 +99,7 @@ STATIC void test89()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL(FPSetFileParams(Conn, vol, dir, file, bitmap, &filedir))
     }
 
@@ -135,7 +135,7 @@ STATIC void test120()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         delete_unix_md(Path, "", name);
         FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
     }
@@ -282,7 +282,7 @@ STATIC void test543()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     /************************************
      * Step 3: Set custom FinderInfo with known pattern
@@ -346,7 +346,7 @@ STATIC void test543()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     /************************************
      * Step 5: Compare all 32 bytes byte-for-byte
@@ -447,7 +447,7 @@ STATIC void test543()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (memcmp(saved_finfo, filedir.finder_info, 32) != 0) {
         if (!Quiet) {
@@ -542,7 +542,7 @@ STATIC void test534()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (!Quiet && Verbose) {
         fprintf(stdout,
@@ -598,7 +598,7 @@ STATIC void test534()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     /************************************
      * Step 5: Compare each date value
@@ -691,7 +691,7 @@ STATIC void test534()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
     if (filedir.cdate != saved_cdate) {
         if (!Quiet) {
@@ -796,7 +796,7 @@ STATIC void test538()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     memset(filedir.finder_info, 0, 32);
     memcpy(filedir.finder_info + 0, "TSTA", 4);
     memcpy(filedir.finder_info + 4, "CRE1", 4);
@@ -845,7 +845,7 @@ STATIC void test538()
     }
 
     filedir2.isdir = 0;
-    afp_filedir_unpack(&filedir2, dsi2->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn2, &filedir2, dsi2->data + ofs, bitmap, 0);
 
     if (memcmp(saved_finfo, filedir2.finder_info, 32) != 0) {
         if (!Quiet) {
@@ -927,7 +927,7 @@ STATIC void test538()
     }
 
     filedir2.isdir = 0;
-    afp_filedir_unpack(&filedir2, dsi2->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn2, &filedir2, dsi2->data + ofs, bitmap, 0);
 
     if (memcmp(saved_finfo, filedir2.finder_info, 32) != 0) {
         if (!Quiet) {

--- a/test/testsuite/Utf8.c
+++ b/test/testsuite/Utf8.c
@@ -78,7 +78,7 @@ STATIC void test166()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (strcmp(filedir.lname, "\216.rtf")) {
             if (!Quiet) {
@@ -139,7 +139,7 @@ STATIC void test167()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (strcmp(filedir.lname, "l\210")) {
             if (!Quiet) {
@@ -369,7 +369,7 @@ STATIC void test234()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         sprintf(temp, "t23#%X", ntohl(filedir.did));
 
         if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp,
@@ -427,7 +427,7 @@ STATIC void test312()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         sprintf(temp, "t312-#%X", ntohl(filedir.did));
 
         if (ntohl(AFPERR_NOOBJ) != 	FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp,
@@ -441,7 +441,7 @@ STATIC void test312()
             test_failed();
         } else {
             filedir.isdir = 0;
-            afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+            afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
             if (strcmp(filedir.utf8_name, name) && !Quiet) {
                 fprintf(stdout, "\tFAILED %s should be %s\n", filedir.utf8_name, name);
@@ -574,7 +574,7 @@ STATIC void test337()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         sprintf(temp, "???#%X", ntohl(filedir.did));
 
         if (ntohl(AFPERR_NOOBJ) != 	FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp,
@@ -589,7 +589,7 @@ STATIC void test337()
             test_failed();
         } else {
             filedir.isdir = 0;
-            afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+            afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
             if (strcmp(filedir.utf8_name, name) && !Quiet) {
                 fprintf(stdout, "\tFAILED %s should be %s\n", filedir.utf8_name, name);
@@ -650,7 +650,7 @@ STATIC void test381()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (strcmp(filedir.lname, "l\210")) {
             if (!Quiet) {
@@ -707,7 +707,7 @@ STATIC void test382()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
         if (strcmp(filedir.lname, "l\210")) {
             if (!Quiet) {

--- a/test/testsuite/afparg_FPfuncs.c
+++ b/test/testsuite/afparg_FPfuncs.c
@@ -48,7 +48,7 @@ void FPResolveID_arg(char **argv)
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + 2, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + 2, bitmap, 0);
     fprintf(stdout, "Resolved ID %d to: '%s'\n", id, filedir.utf8_name);
 }
 
@@ -215,7 +215,7 @@ void FPEnumerate_arg(char **argv)
             for (int j = 1; j <= tp; j++, b += b[0]) {
                 if (b[1]) {
                     filedir.isdir = 1;
-                    afp_filedir_unpack(&filedir, b + 2, 0, d_bitmap);
+                    afp_filedir_unpack(Conn, &filedir, b + 2, 0, d_bitmap);
 
                     if (cnt > size) {
                         size += 1000;
@@ -230,7 +230,7 @@ void FPEnumerate_arg(char **argv)
                     cnt++;
                 } else {
                     filedir.isdir = 0;
-                    afp_filedir_unpack(&filedir, b + 2, f_bitmap, 0);
+                    afp_filedir_unpack(Conn, &filedir, b + 2, f_bitmap, 0);
                 }
 
                 if (!Quiet) {

--- a/test/testsuite/afpclient.c
+++ b/test/testsuite/afpclient.c
@@ -1131,7 +1131,7 @@ int afp_volume_pack(unsigned char *b, struct afp_volume_parms *parms,
 
 /* FIXME: redundant bitmap parameters !
  * FIXME: some of those parameters are not tested. */
-void afp_filedir_unpack(struct afp_filedir_parms *filedir,
+void afp_filedir_unpack(CONN *conn, struct afp_filedir_parms *filedir,
                         const unsigned char *b,
                         uint16_t rfbitmap, uint16_t rdbitmap)
 {
@@ -1221,18 +1221,21 @@ void afp_filedir_unpack(struct afp_filedir_parms *filedir,
 
         case FILPBIT_PDINFO: /* utf8 name */
             memcpy(filedir->pdinfo, b, sizeof(filedir->pdinfo));
+
             /* blindly try utf8 name */
-            memcpy(&i, b, sizeof(i));
-            i = ntohs(i);
+            if (UNICODE(conn)) {
+                memcpy(&i, b, sizeof(i));
+                i = ntohs(i);
 
-            if (i != 0) {
-                memcpy(&j, beg + i + 4, sizeof(j));
-                j = ntohs(j);
+                if (i != 0) {
+                    memcpy(&j, beg + i + 4, sizeof(j));
+                    j = ntohs(j);
 
-                /* hack */
-                if (j && j < 512 && (filedir->utf8_name = fp_malloc(j + 1))) {
-                    memcpy(filedir->utf8_name, beg + i + 6, j);
-                    filedir->utf8_name[j] = 0;
+                    /* hack */
+                    if (j && j < 512 && (filedir->utf8_name = fp_malloc(j + 1))) {
+                        memcpy(filedir->utf8_name, beg + i + 6, j);
+                        filedir->utf8_name[j] = 0;
+                    }
                 }
             }
 
@@ -1306,7 +1309,8 @@ void afp_filedir_unpack(struct afp_filedir_parms *filedir,
 }
 
 /* ---------------------- */
-int afp_filedir_pack(unsigned char *b, struct afp_filedir_parms *filedir,
+int afp_filedir_pack(CONN *conn, unsigned char *b,
+                     struct afp_filedir_parms *filedir,
                      uint16_t rfbitmap, uint16_t rdbitmap)
 {
     int isdir;
@@ -1372,8 +1376,13 @@ int afp_filedir_pack(unsigned char *b, struct afp_filedir_parms *filedir,
             break;
 
         case FILPBIT_PDINFO: /* utf8 name */
-            u_ofs = b;
-            b += 2;
+            if (UNICODE(conn)) {
+                u_ofs = b;
+            } else {
+                memcpy(b, filedir->pdinfo, sizeof(filedir->pdinfo));
+            }
+
+            b += sizeof(filedir->pdinfo);
             break;
 
         case FILPBIT_UNIXPR:
@@ -2296,10 +2305,12 @@ unsigned int AFPCatSearch(CONN *conn, uint16_t vol, uint32_t nbe, char *pos,
     temp = htonl(rbitmap);
     memcpy(dsi->commands + ofs, &temp, sizeof(temp));
     ofs += sizeof(temp);
-    len = afp_filedir_pack(dsi->commands + ofs + 2, filedir, rbitmap & 0xffff, 0);
+    len = afp_filedir_pack(conn, dsi->commands + ofs + 2, filedir, rbitmap & 0xffff,
+                           0);
     dsi->commands[ofs] = (uint8_t) len;
     ofs += len + 2;
-    len = afp_filedir_pack(dsi->commands + ofs + 2, filedir2, rbitmap & 0xffff, 0);
+    len = afp_filedir_pack(conn, dsi->commands + ofs + 2, filedir2,
+                           rbitmap & 0xffff, 0);
     dsi->commands[ofs] = (uint8_t) len;
     ofs += len + 2;
     SetLen(dsi, ofs);
@@ -2345,11 +2356,13 @@ unsigned int AFPCatSearchExt(CONN *conn, uint16_t vol, uint32_t  nbe, char *pos,
     temp = htonl(rbitmap);
     memcpy(dsi->commands + ofs, &temp, sizeof(temp));
     ofs += sizeof(temp);
-    len = afp_filedir_pack(dsi->commands + ofs + 2, filedir, rbitmap & 0xffff, 0);
+    len = afp_filedir_pack(conn, dsi->commands + ofs + 2, filedir, rbitmap & 0xffff,
+                           0);
     i = htons((uint16_t) len);
     memcpy(dsi->commands + ofs, &i, sizeof(i));
     ofs += len + 2;
-    len = afp_filedir_pack(dsi->commands + ofs + 2, filedir2, rbitmap & 0xffff, 0);
+    len = afp_filedir_pack(conn, dsi->commands + ofs + 2, filedir2,
+                           rbitmap & 0xffff, 0);
     i = htons((uint16_t) len);
     memcpy(dsi->commands + ofs, &i, sizeof(i));
     ofs += len + 2;

--- a/test/testsuite/afpclient.h
+++ b/test/testsuite/afpclient.h
@@ -258,10 +258,11 @@ struct afp_volume_parms {
 void afp_volume_unpack(struct afp_volume_parms *parms, unsigned char *b,
                        uint16_t rbitmap);
 
-void afp_filedir_unpack(struct afp_filedir_parms *filedir,
+void afp_filedir_unpack(CONN *conn, struct afp_filedir_parms *filedir,
                         const unsigned char *b,
                         uint16_t rfbitmap, uint16_t rdbitmap);
-int afp_filedir_pack(unsigned char *b, struct afp_filedir_parms *filedir,
+int afp_filedir_pack(CONN *conn, unsigned char *b,
+                     struct afp_filedir_parms *filedir,
                      uint16_t rfbitmap, uint16_t rdbitmap);
 
 /*

--- a/test/testsuite/afpcmd.c
+++ b/test/testsuite/afpcmd.c
@@ -1979,7 +1979,7 @@ unsigned int FPSetDirParms(CONN *conn, uint16_t vol, int did, char *name,
         ofs++;
     }
 
-    ofs += afp_filedir_pack(dsi->commands + ofs, dir, 0, bitmap);
+    ofs += afp_filedir_pack(conn, dsi->commands + ofs, dir, 0, bitmap);
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
@@ -2025,7 +2025,7 @@ unsigned int FPSetFileParams(CONN *conn, uint16_t vol, int did, char *name,
         ofs++;
     }
 
-    ofs += afp_filedir_pack(dsi->commands + ofs, fil, bitmap, 0);
+    ofs += afp_filedir_pack(conn, dsi->commands + ofs, fil, bitmap, 0);
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
@@ -2145,7 +2145,7 @@ unsigned int FPSetFilDirParam(CONN *conn, uint16_t vol, int did, char *name,
         ofs++;
     }
 
-    ofs += afp_filedir_pack(dsi->commands + ofs, fil, bitmap, bitmap);
+    ofs += afp_filedir_pack(conn, dsi->commands + ofs, fil, bitmap, bitmap);
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -86,7 +86,7 @@ int get_did(CONN *conn, uint16_t vol, int dir, char *name)
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(conn, &filedir, dsi->data + ofs, 0, bitmap);
 
     if (!filedir.did) {
         test_nottested();
@@ -108,7 +108,7 @@ int get_fid(CONN *conn, uint16_t vol, int dir, char *name)
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+        afp_filedir_unpack(conn, &filedir, dsi->data + ofs, bitmap, 0);
 
         if (!filedir.did) {
             test_failed();
@@ -128,7 +128,7 @@ uint32_t get_forklen(DSI *dsi, int type)
     uint32_t flen;
     filedir.isdir = 0;
     bitmap = len;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     flen = (type == OPENFORK_RSCS) ? filedir.rflen : filedir.dflen;
     return flen;
 }
@@ -239,7 +239,7 @@ int no_access_folder(uint16_t vol, int did, char *name)
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi2->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, 0, bitmap);
     bitmap = (1 << DIRPBIT_ACCESS);
     filedir.access[0] = 0;
     filedir.access[1] = 0;
@@ -346,7 +346,7 @@ int group_folder(uint16_t vol, int did, char *name)
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi2->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     filedir.access[1] = 0;
     filedir.access[2] = 7;
@@ -434,7 +434,7 @@ int read_only_folder(uint16_t vol, int did, char *name)
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi2->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     filedir.access[1] = 3;
     filedir.access[2] = 3;
@@ -513,7 +513,7 @@ int read_only_folder_with_file(uint16_t vol, int did, char *name, char *file)
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi2->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, 0, bitmap);
 
     if (FPCreateFile(Conn2, vol2,  0, dir, file)) {
         test_nottested();
@@ -591,7 +591,7 @@ int delete_folder(uint16_t vol, int did, char *name)
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi2->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     filedir.access[1] = 7;
     filedir.access[2] = 7;
@@ -652,7 +652,7 @@ int delete_folder_with_file(uint16_t vol, int did, char *name, char *file)
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi2->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn2, &filedir, dsi2->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     filedir.access[1] = 7;
     filedir.access[2] = 7;
@@ -996,7 +996,7 @@ int delete_directory_tree(CONN *conn, uint16_t volume,
 
     /* Extract directory ID for dirname from DSI following FPGetFileDirParams call */
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi_ptr->data + (3 * sizeof(uint16_t)), 0,
+    afp_filedir_unpack(conn, &filedir, dsi_ptr->data + (3 * sizeof(uint16_t)), 0,
                        (1 << DIRPBIT_DID));
     dir_id = filedir.did;
 
@@ -1100,7 +1100,7 @@ int delete_directory_tree(CONN *conn, uint16_t volume,
 
                 if (is_dir) {
                     /* Recurse subdirectory */
-                    afp_filedir_unpack(&filedir, entry_ptr + 2, 0, d_bitmap);
+                    afp_filedir_unpack(conn, &filedir, entry_ptr + 2, 0, d_bitmap);
 
                     if (filedir.lname && filedir.lname[0] != '\0') {
                         /* Pass current dir ID as new parent, and subdir entry name as dirname */
@@ -1109,7 +1109,7 @@ int delete_directory_tree(CONN *conn, uint16_t volume,
                     }
                 } else {
                     /* Delete file */
-                    afp_filedir_unpack(&filedir, entry_ptr + 2, f_bitmap, 0);
+                    afp_filedir_unpack(conn, &filedir, entry_ptr + 2, f_bitmap, 0);
 
                     if (filedir.lname && filedir.lname[0] != '\0') {
                         FPDelete(conn, volume, dir_id, filedir.lname);
@@ -1166,7 +1166,7 @@ void clear_volume(uint16_t vol, CONN *conn)
             break;
         }
 
-        afp_filedir_unpack(&filedir, conn->dsi.data + ofs, 0, bitmap);
+        afp_filedir_unpack(conn, &filedir, conn->dsi.data + ofs, 0, bitmap);
 
         if (filedir.isdir) {
             int result = delete_directory_tree(conn, vol, DIRDID_ROOT, filedir.lname);

--- a/test/testsuite/encoding_test.c
+++ b/test/testsuite/encoding_test.c
@@ -70,7 +70,7 @@ STATIC void test_western()
         }
 
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + ofs, f_bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, f_bitmap, 0);
         result = (Conn->afp_version >= 30) ? filedir.utf8_name : filedir.lname;
 
         if (strcmp(result, extascii[i])) {

--- a/test/testsuite/rotest.c
+++ b/test/testsuite/rotest.c
@@ -77,7 +77,7 @@ STATIC void test510()
     }
 
     filedir.isdir = 1;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, 0, bitmap);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     dir = strdup(filedir.lname);
 
     if (!dir) {
@@ -99,7 +99,7 @@ STATIC void test510()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     file = strdup(filedir.lname);
 
     if (!file) {
@@ -121,7 +121,7 @@ STATIC void test510()
     }
 
     filedir.isdir = 0;
-    afp_filedir_unpack(&filedir, dsi->data + ofs, bitmap, 0);
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     file1 = strdup(filedir.lname);
 
     if (!file1) {
@@ -149,7 +149,7 @@ STATIC void test510()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + 3 * sizeof(uint16_t), bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + 3 * sizeof(uint16_t), bitmap, 0);
         ret  = FPSetFileParams(Conn, VolID,  DIRDID_ROOT, file, bitmap, &filedir);
         check_test(ret);
     }
@@ -202,7 +202,7 @@ STATIC void test510()
         test_failed();
     } else {
         filedir.isdir = 0;
-        afp_filedir_unpack(&filedir, dsi->data + 3 * sizeof(uint16_t), bitmap, 0);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + 3 * sizeof(uint16_t), bitmap, 0);
         ret = FPSetFilDirParam(Conn, VolID,  DIRDID_ROOT, file, bitmap, &filedir);
         check_test(ret);
     }
@@ -214,7 +214,7 @@ STATIC void test510()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + 3 * sizeof(uint16_t), 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + 3 * sizeof(uint16_t), 0, bitmap);
         ret = FPSetFilDirParam(Conn, VolID,  DIRDID_ROOT, dir, bitmap, &filedir);
         check_test(ret);
     }
@@ -227,7 +227,7 @@ STATIC void test510()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + 3 * sizeof(uint16_t), 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + 3 * sizeof(uint16_t), 0, bitmap);
         ret = FPDelete(Conn, VolID, DIRDID_ROOT, dir);
 
         if (ret != htonl(AFPERR_VLOCK)) {
@@ -252,7 +252,7 @@ STATIC void test510()
         test_failed();
     } else {
         filedir.isdir = 1;
-        afp_filedir_unpack(&filedir, dsi->data + 3 * sizeof(uint16_t), 0, bitmap);
+        afp_filedir_unpack(Conn, &filedir, dsi->data + 3 * sizeof(uint16_t), 0, bitmap);
         ret = FPSetDirParms(Conn, VolID,  DIRDID_ROOT, dir, bitmap, &filedir);
         check_test(ret);
     }


### PR DESCRIPTION
- Updates `afp_filedir_pack()` and `afp_filedir_unpack()` functions to properly support PDINFO bit when connecting to a AFP 2.x client.
- Change `test440()` to add a custom ProDOS type test.
- Modified `test440()`, `test441()`, and `test442()` to properly unpack the ProDOS aux type. This is sent over the wire in little-endian order. Also fixed an endianness issue with afpd's sending of the ProDOS information for directories.
- Adds `test433()` and `test434()` to test writing of the ProDOS Info block with `FPSetFileParms` and verifies the mapping of ProDOS File Type/Aux Type to Macintosh File Type/Creator.

Fixes #2299