### PR TITLE
afpd: ProDOS Info cleanup.

### DIFF
--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -2184,7 +2184,7 @@ int getdirparams(const AFPObj *obj,
     data = buf;
 
     /* If this is a ProDOS client, adjust date-time values to match local time */
-    if (obj->afp_version < 30 && (bitmap & 1 << FILPBIT_PDINFO)) {
+    if (obj->afp_version < 30 && (bitmap & 1 << DIRPBIT_PDINFO)) {
         timeoffset = 1;
     }
 
@@ -2532,7 +2532,7 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap,
     dir   = path->d_dir;
 
     /* If this is a ProDOS client, adjust date-time values to match UTC time */
-    if (vol->v_obj->afp_version < 30 && (bitmap & 1 << FILPBIT_PDINFO)) {
+    if (vol->v_obj->afp_version < 30 && (bitmap & 1 << DIRPBIT_PDINFO)) {
         timeoffset = 1;
     }
 

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -604,7 +604,7 @@ int getmetadata(const AFPObj *obj,
                         ashort = 0x0000;
                     } else if (fdType[0] == 'p') {
                         achar = fdType[1];
-                        ashort = (fdType[2] * 256) + fdType[3];
+                        ashort = htons((fdType[3] * 256) + fdType[2]);
                     } else {
                         achar = '\x00';
                         ashort = 0x0000;


### PR DESCRIPTION
- Fix a potential endianness issue with the ProDOS Info block sent with a `FPGetFileParms` request. The current packing of the ProDOS auxtype would likely fail to work on big-endian order hosts.
- Use the proper macro for directories when doing localtime-UTC detection.