### PR TITLE
ci: force refresh of OpenIndiana packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -795,6 +795,8 @@ jobs:
           copyback: true
           prepare: |
             set -e
+            pkg refresh --full
+            pkg update -v
             pkg install \
               archiver/gnu-tar \
               compress/gzip \


### PR DESCRIPTION
the current vmactions OpenIndiana VM is seemingly out of sync with remote repositories

a full refresh of packages may be time consuming but necessary until vmactions update their images