### PR TITLE
netacnv: fix off-by-one that dropped the last -o flag

### DIFF
--- a/bin/misc/netacnv.c
+++ b/bin/misc/netacnv.c
@@ -40,7 +40,7 @@ static void usage(void)
     printf("Defaults: -f: UTF8-MAC, -t: UTF8, -m MAC_ROMAN\n");
     printf("Available conversion options:\n");
 
-    for (int i = 0; i < (sizeof(flag_map) / sizeof(struct flag_map) - 1); i++) {
+    for (size_t i = 0; i < sizeof(flag_map) / sizeof(struct flag_map); i++) {
         printf("%s\n", flag_map[i].flagname);
     }
 }
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
             break;
 
         case 'o':
-            for (int i = 0; i < sizeof(flag_map) / sizeof(struct flag_map) - 1; i++)
+            for (size_t i = 0; i < sizeof(flag_map) / sizeof(struct flag_map); i++)
                 if ((strcmp(flag_map[i].flagname, optarg)) == 0) {
                     flags |= flag_map[i].flag;
                 }


### PR DESCRIPTION
The flag_map[] iteration in both usage() and the -o option parser ran to sizeof(flag_map)/sizeof(struct flag_map) - 1, skipping the final entry. The array has no sentinel, so the -1 simply hid CONV_DECOMPOSE: passing -o CONV_DECOMPOSE was silently ignored and the help text omitted it.

Drop the -1 in both loops and switch the index to size_t to avoid the mixed-signed comparison.