### PR TITLE
testsuite: Refine when testing against Apple AFP servers.

### DIFF
--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -462,6 +462,11 @@ STATIC void test401()
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);
         goto test_exit;
@@ -563,6 +568,11 @@ STATIC void test402()
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);
         goto test_exit;
@@ -654,6 +664,11 @@ STATIC void test403()
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
+
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -724,6 +724,11 @@ STATIC void test535()
     int sock;
     ENTER_TEST
 
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
     if (!Conn2) {
         test_skipped(T_CONN2);
         goto test_exit;

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -707,19 +707,26 @@ STATIC void test326()
     int ret;
     int id;
     ENTER_TEST
-    ret = FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name);
-
-    if (ret) {
-        test_nottested();
-        goto test_exit;
-    }
 
     if (Conn->afp_version >= 30) {
         bitmap = (1 << FILPBIT_PDINFO);
     } else {
+        if (Mac) {
+            /* a Mac AFP 2.x can't create filename longer than 31 bytes */
+            test_skipped(T_MAC);
+            goto test_exit;
+        }
+
         /* FIXME: fails with afp 2.x despite the comment below */
         bitmap = (1 << DIRPBIT_LNAME);
         test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
+    ret = FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name);
+
+    if (ret) {
+        test_nottested();
         goto test_exit;
     }
 
@@ -742,8 +749,8 @@ STATIC void test326()
         test_failed();
     }
 
-test_exit:
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+test_exit:
     exit_test("FPGetFileDirParms:test326: long file name >31 bytes");
 }
 
@@ -1280,6 +1287,17 @@ static void do_pdinfo_test(char *fname, const char *fourcc, uint8_t expect_type,
     afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap_pdinfo, 0);
     prodos_type = filedir.pdinfo[0];
     prodos_aux = (uint16_t)(filedir.pdinfo[3] << 8) | filedir.pdinfo[2];
+
+    /*
+     * Apple's AFP servers will return an auxtype of 0xFFFF
+     * for PSYS/pdos and PS16/pdos mappings. The last two
+     * bytes of the ProDOS Info bit will also be 0xFF in
+     * these cases.
+     */
+    if ((prodos_aux == 0xFFFF) && (filedir.pdinfo[4] == 0xFF)
+            && (filedir.pdinfo[5] == 0xFF)) {
+        expect_aux = 0xFFFF;
+    }
 
     if (prodos_type != expect_type || prodos_aux != expect_aux) {
         test_failed();

--- a/test/testsuite/FPMoveAndRename.c
+++ b/test/testsuite/FPMoveAndRename.c
@@ -354,6 +354,12 @@ STATIC void test378()
     int ret;
     ENTER_TEST
 
+    /* AFP 2.x technically doesn't support case sensitive file system */
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
     if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
         test_failed();
         goto test_exit;

--- a/test/testsuite/FPSetDirParms.c
+++ b/test/testsuite/FPSetDirParms.c
@@ -525,6 +525,11 @@ STATIC void test353()
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
     if (get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV) {
         test_skipped(T_NO_UNIX_PREV);
         goto test_exit;
@@ -614,6 +619,11 @@ STATIC void test354()
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);
         goto test_exit;
@@ -681,6 +691,11 @@ STATIC void test355()
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
+
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);
@@ -755,6 +770,11 @@ STATIC void test356()
     int ret;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
+
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);
@@ -878,6 +898,11 @@ STATIC void test405()
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
+
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);

--- a/test/testsuite/FPSetFileDirParms.c
+++ b/test/testsuite/FPSetFileDirParms.c
@@ -369,6 +369,11 @@ STATIC void test232()
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
     if (!Conn2) {
         test_skipped(T_CONN2);
         goto test_exit;
@@ -436,6 +441,11 @@ STATIC void test345()
     int fork;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
+
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);
@@ -521,6 +531,11 @@ STATIC void test346()
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);
         goto test_exit;
@@ -580,6 +595,11 @@ STATIC void test347()
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
+
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
 
     if (get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV) {
         test_skipped(T_NO_UNIX_PREV);
@@ -670,6 +690,11 @@ STATIC void test348()
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);
         goto test_exit;
@@ -737,6 +762,11 @@ STATIC void test349()
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
+
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);
@@ -811,6 +841,11 @@ STATIC void test350()
     int ret;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
+
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);
@@ -958,6 +993,11 @@ STATIC void test359()
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);
         goto test_exit;
@@ -1049,6 +1089,11 @@ STATIC void test361()
     const DSI *dsi = &Conn->dsi;
     const DSI *dsi2;
     ENTER_TEST
+
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
 
     if (!Conn2) {
         test_skipped(T_CONN2);
@@ -1151,6 +1196,11 @@ STATIC void test400()
     uint16_t bitmap = 0;
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
+
+    if (Conn->afp_version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
 
     if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_UNIXPRIV)) {
         test_skipped(T_UNIX_PREV);

--- a/test/testsuite/T2_Dircache_attack.c
+++ b/test/testsuite/T2_Dircache_attack.c
@@ -138,6 +138,11 @@ STATIC void test500()
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
 
+    if (Mac) {
+        test_skipped(T_MAC);
+        goto test_exit;
+    }
+
     if (!Conn2) {
         test_skipped(T_CONN2);
         goto test_exit;
@@ -212,6 +217,11 @@ STATIC void test501()
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
 
+    if (Mac) {
+        test_skipped(T_MAC);
+        goto test_exit;
+    }
+
     if (!Conn2) {
         test_skipped(T_CONN2);
         goto test_exit;
@@ -282,6 +292,11 @@ STATIC void test502()
     struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
+
+    if (Mac) {
+        test_skipped(T_MAC);
+        goto test_exit;
+    }
 
     if (!Conn2) {
         test_skipped(T_CONN2);
@@ -360,6 +375,11 @@ STATIC void test503()
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
 
+    if (Mac) {
+        test_skipped(T_MAC);
+        goto test_exit;
+    }
+
     if (!Conn2) {
         test_skipped(T_CONN2);
         goto test_exit;
@@ -431,6 +451,11 @@ STATIC void test504()
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
 
+    if (Mac) {
+        test_skipped(T_MAC);
+        goto test_exit;
+    }
+
     if (!Conn2) {
         test_skipped(T_CONN2);
         goto test_exit;
@@ -500,6 +525,11 @@ STATIC void test505()
     struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
+
+    if (Mac) {
+        test_skipped(T_MAC);
+        goto test_exit;
+    }
 
     if (!Conn2) {
         test_skipped(T_CONN2);
@@ -572,6 +602,11 @@ STATIC void test506()
     struct afp_filedir_parms filedir = { 0 };
     uint16_t bitmap = (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME);
     ENTER_TEST
+
+    if (Mac) {
+        test_skipped(T_MAC);
+        goto test_exit;
+    }
 
     if (!Conn2) {
         test_skipped(T_CONN2);
@@ -670,6 +705,12 @@ STATIC void test508()
     char dir_name[64];
     int created_count = 0;
     ENTER_TEST
+
+    if (Mac) {
+        test_skipped(T_MAC);
+        goto test_exit;
+    }
+
     /* Allocate array for directory IDs */
     dir_ids = calloc(NUM_DIRS, sizeof(uint32_t));
 
@@ -921,6 +962,12 @@ STATIC void test509()
     int created_count = 0;
     int accesses = 0;
     ENTER_TEST
+
+    if (Mac) {
+        test_skipped(T_MAC);
+        goto test_exit;
+    }
+
     /* Allocate array for directory IDs */
     dir_ids = calloc(NUM_DIRS, sizeof(uint32_t));
 

--- a/test/testsuite/T2_FPSetFileParms.c
+++ b/test/testsuite/T2_FPSetFileParms.c
@@ -257,6 +257,11 @@ STATIC void test543()
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
+    if (Mac) {
+        test_skipped(T_MAC);
+        goto test_exit;
+    }
+
     /************************************
      * Step 1: Create file
      ************************************/
@@ -517,6 +522,11 @@ STATIC void test534()
     const DSI *dsi = &Conn->dsi;
     ENTER_TEST
 
+    if (Mac) {
+        test_skipped(T_MAC);
+        goto test_exit;
+    }
+
     /************************************
      * Step 1: Create file
      ************************************/
@@ -764,6 +774,11 @@ STATIC void test538()
     const DSI *dsi = &Conn->dsi;
     const DSI *dsi2;
     ENTER_TEST
+
+    if (Mac) {
+        test_skipped(T_MAC);
+        goto test_exit;
+    }
 
     if (!Conn2) {
         test_skipped(T_CONN2);


### PR DESCRIPTION
- Disable DirCache Attack tests when testing against an Apple server.
- Refine ProDOS Info tests to reflect behavior observed from Apple's servers.
- Fix `test326()`
- Add additional guards for AFP 3.x specific tests.