### PR TITLE
spotlight: add support for localsearch indexing of home directories

### DIFF
--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -732,11 +732,14 @@ of 10000 candidate results. Set a larger nonzero value to raise the
 *xapian* cap. The *cnid* backend does not use this option and is limited
 by its fixed CNID search reply cap.
 
-spotlight = *BOOLEAN* (default: *yes*) **(G)**/**(V)**
+spotlight = *BOOLEAN* (default: *yes*) **(G)**/**(V)**/**(H)**
 
 > Whether to enable Spotlight-compatible searches.
-As a global option, this sets the default for volumes. As a volume option,
-it overrides the global default for that volume.
+As a global option, this sets the default for volumes and home directories.
+As a volume or Homes option, it overrides the global default.
+When enabled for the Homes section, the directory specified by
+**basedir regex** is submitted to the search indexer, covering all user
+home directories beneath it.
 >
 > A volume is searchable only when its effective **spotlight** setting is
 enabled and a supported **spotlight backend** is available for that volume.

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -169,6 +169,22 @@ static int set_sl_volumes(void)
         }
     }
 
+    int global_sl = INIPARSER_GETBOOL(obj.iniconfig, INISEC_GLOBAL, "spotlight", 1);
+
+    if (INIPARSER_GETBOOL(obj.iniconfig, INISEC_HOMES, "spotlight", global_sl)) {
+        const char *basedir = INIPARSER_GETSTR(obj.iniconfig, INISEC_HOMES,
+                                               "basedir regex", NULL);
+
+        if (basedir && *basedir) {
+            if (first) {
+                fprintf(fp, "index-recursive-directories=['%s'", basedir);
+                first = false;
+            } else {
+                fprintf(fp, ", '%s'", basedir);
+            }
+        }
+    }
+
     if (first) {
         /* No Spotlight volumes: emit typed empty array so dconf update parses it */
         fprintf(fp, "index-recursive-directories=@as []\n");

--- a/include/atalk/iniparser_util.h
+++ b/include/atalk/iniparser_util.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Daniel Markstedt
+ * Copyright (C) 2024-2026 Daniel Markstedt
  * All Rights Reserved.  See COPYING.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -29,6 +29,12 @@
 
 #define INISEC_GLOBAL "global"
 #define INISEC_HOMES  "homes"
+
+#define INIPARSER_GETBOOL(config, section, key, default) ({           \
+    char _option[MAXOPTLEN];                                          \
+    snprintf(_option, sizeof(_option), "%s:%s", section, key);        \
+    iniparser_getboolean(config, _option, default);                   \
+})
 
 #define INIPARSER_GETSTR(config, section, key, default) ({            \
     char _option[MAXOPTLEN];                                          \

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -2779,6 +2779,20 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
         options->flags |= OPTION_SPOTLIGHT_VOL;
     }
 
+    {
+        /* OPTION_SPOTLIGHT is normally set by creatvol() per named volume, but
+         * [Homes] volumes are resolved per-user at login and never reach creatvol()
+         * in the master process, so we set the flag here if Homes spotlight is on. */
+        int global_sl = options->flags & OPTION_SPOTLIGHT_VOL ? 1 : 0;
+        const char *homes_basedir = getoption_str(config, INISEC_HOMES,
+                                    "basedir regex", NULL, NULL);
+
+        if (getoption_bool(config, INISEC_HOMES, "spotlight", NULL, global_sl)
+                && homes_basedir && *homes_basedir) {
+            options->flags |= OPTION_SPOTLIGHT;
+        }
+    }
+
     if (getoption_bool(config, INISEC_GLOBAL, "veto message", NULL, 0)) {
         options->flags |= OPTION_VETOMSG;
     }


### PR DESCRIPTION
The [Homes] spotlight option (default: inherits from [Global]) controls whether the basedir regex path is submitted to the search indexer, covering all user home directories beneath it.

Because [Homes] volumes are resolved per-user at login and never pass through creatvol() in the master process, OPTION_SPOTLIGHT must be set explicitly during config parsing when Homes spotlight is enabled -- otherwise the localsearch dbus infrastructure is never started.

Add INIPARSER_GETBOOL macro parallel to the other iniparser wrapper macros.