### PR TITLE
docker: harden RandNum UAM in production container

### DIFF
--- a/distrib/docker/env_setup_netatalk.sh
+++ b/distrib/docker/env_setup_netatalk.sh
@@ -91,8 +91,32 @@ fi
 
 echo "$AFP_USER:$AFP_PASS" | chpasswd > /dev/null 2>&1
 
-if [ -f "/etc/netatalk/afppasswd" ]; then
-    rm -f /etc/netatalk/afppasswd
+RANDNUM_PASSWD_FILE="/etc/netatalk/afppasswd"
+RANDNUM_KEY_FILE="$RANDNUM_PASSWD_FILE.key"
+
+ensure_randnum_key_file() {
+    if [ -f "$RANDNUM_KEY_FILE" ]; then
+        chown root:root "$RANDNUM_KEY_FILE" && chmod 600 "$RANDNUM_KEY_FILE"
+        return $?
+    fi
+
+    echo "*** Creating RandNum password key file"
+    old_umask=$(umask)
+    umask 077
+    randnum_key=$(od -An -N8 -tx1 /dev/urandom)
+    if ! printf '%s\n' "$randnum_key" | tr -d ' \n' > "$RANDNUM_KEY_FILE"; then
+        umask "$old_umask"
+        return 1
+    fi
+    if ! chown root:root "$RANDNUM_KEY_FILE" || ! chmod 600 "$RANDNUM_KEY_FILE"; then
+        umask "$old_umask"
+        return 1
+    fi
+    umask "$old_umask"
+}
+
+if [ -f "$RANDNUM_PASSWD_FILE" ]; then
+    rm -f "$RANDNUM_PASSWD_FILE"
 fi
 
 if [ -f "/etc/netatalk/afppasswd.srp" ]; then
@@ -103,10 +127,16 @@ UAMS="uams_dhx.so uams_dhx2.so"
 
 # Creating credentials for the RandNum UAM
 RANDNUM_OK=0
-afppasswd -c -r
+if [ -n "$INSECURE_AUTH" ]; then
+    if ensure_randnum_key_file; then
+        afppasswd -c -r
 
-if afppasswd -a "$AFP_USER" -f -r -w "$AFP_PASS" > /dev/null; then
-    RANDNUM_OK=1
+        if afppasswd -a "$AFP_USER" -f -r -w "$AFP_PASS" > /dev/null; then
+            RANDNUM_OK=1
+        fi
+    else
+        echo "ERROR: Failed to secure $RANDNUM_KEY_FILE; disabling RandNum UAM" >&2
+    fi
 fi
 
 # Creating credentials for the SRP UAM
@@ -137,7 +167,7 @@ elif [ -n "$AFP_USER2" ]; then
 
     echo "$AFP_USER2:$AFP_PASS2" | chpasswd > /dev/null 2>&1
 
-    if ! afppasswd -a "$AFP_USER2" -f -r -w "$AFP_PASS2" > /dev/null; then
+    if [ -n "$INSECURE_AUTH" ] && ! afppasswd -a "$AFP_USER2" -f -r -w "$AFP_PASS2" > /dev/null; then
         RANDNUM_OK=0
     fi
     if ! afppasswd -a "$AFP_USER2" -f -w "$AFP_PASS2" > /dev/null; then
@@ -147,7 +177,7 @@ fi
 
 if [ "$RANDNUM_OK" = "1" ]; then
     UAMS="$UAMS uams_randnum.so"
-else
+elif [ -n "$INSECURE_AUTH" ]; then
     echo "NOTE: uams_randnum.so will not be loaded"
 fi
 if [ "$SRP_OK" = "1" ]; then

--- a/doc/manual/Authentication.md
+++ b/doc/manual/Authentication.md
@@ -70,7 +70,8 @@ DHX2 is sufficient and provides the strongest encryption.
 
 - "Randnum exchange"/"2-Way Randnum exchange" uses only 56-bit DES for encryption,
   so it should also be avoided.
-  An additional disadvantage is that passwords must be stored as raw hex on the server.
+  An additional disadvantage is that passwords are stored separately on the server:
+  as raw hex by default, or DES-encrypted and hex-encoded when a key file is used.
 
     However, this is the strongest form of authentication available for
     Macintosh System Software 7.1 or earlier.
@@ -140,9 +141,9 @@ An overview of the officially supported UAMs on Macs.
 | ---------------- | ------------- | ---------------- | ---------------- | ------------ | ------------- | ---------------- | ---------------- |
 | Password length  | guest access  | max 8 chars      | max 8 chars      | max 64 chars | max 255 chars | Kerberos tickets | max 255 chars    |
 | Client support   | built-in into all Mac OS versions | built-in in all Mac OS versions except 10.0. Has to be activated explicitly in later Mac OS X versions | built-in into almost all Mac OS versions | built-in since AppleShare client 3.8.4, available as a plug-in for 3.8.3, integrated in macOS's AFP client | built-in since Mac OS X 10.2 | built-in since Mac OS X 10.2 | built-in since Mac OS X 10.7 |
-| Encryption       | Enables guest access without authentication between client and server. | Password will be sent in cleartext over the wire. Just as bad as it sounds, therefore avoid at all costs. | 8-byte random numbers are sent over the wire, comparable with DES, 56 bits. Vulnerable to offline dictionary attack. Requires passwords in clear on the server. | Password will be encrypted with 128 bit CAST, user will be authenticated against the server but not vice versa. Therefore weak against man-in-the-middle attacks. | Password will be encrypted with 128 bit CAST in CBC mode. User will be authenticated against the server but not vice versa. Therefore weak against man-in-the-middle attacks. | Password is not sent over the network. Due to the service principal detection method, this authentication method is vulnerable to man-in-the-middle attacks. | Password is never sent; SRP uses a verifier and mutual proofs (M1/M2) to authenticate both client and server, providing protection against man‑in‑the‑middle attacks. |
+| Encryption       | Enables guest access without authentication between client and server. | Password will be sent in cleartext over the wire. Just as bad as it sounds, therefore avoid at all costs. | 8-byte random numbers are sent over the wire, comparable with DES, 56 bits. Vulnerable to offline dictionary attack. Requires separately stored server-side passwords. | Password will be encrypted with 128 bit CAST, user will be authenticated against the server but not vice versa. Therefore weak against man-in-the-middle attacks. | Password will be encrypted with 128 bit CAST in CBC mode. User will be authenticated against the server but not vice versa. Therefore weak against man-in-the-middle attacks. | Password is not sent over the network. Due to the service principal detection method, this authentication method is vulnerable to man-in-the-middle attacks. | Password is never sent; SRP uses a verifier and mutual proofs (M1/M2) to authenticate both client and server, providing protection against man‑in‑the‑middle attacks. |
 | Server support   | uams_guest.so | uams_clrtxt.so   | uams_randnum.so  | uams_dhx.so  | uams_dhx2.so  | uams_gss.so      | uams_srp.so      |
-| Password storage | None          | Either system auth or PAM | Separate *afppasswd* file; raw hex or DES-encrypted with *.key* | Either system auth or PAM | Either system auth or PAM | At the Kerberos Key Distribution Center | In a separate *afppasswd.srp* verifier file |
+| Password storage | None          | Either system auth or PAM | Separate *afppasswd* file; raw hex by default, or DES-encrypted hex with *.key* | Either system auth or PAM | Either system auth or PAM | At the Kerberos Key Distribution Center | In a separate *afppasswd.srp* verifier file |
 
 Note that a number of open-source and other third-party AFP clients exist.
 Refer to their documentation for a list of supported UAMs.

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -141,6 +141,7 @@ static int afppasswd(const struct passwd *pwd,
     FILE *fp;
     unsigned int i, j;
     int keyfd = -1, err = 0;
+    ssize_t keylen;
     off_t pos;
     gcry_cipher_hd_t ctx;
     gcry_error_t ctxerror;
@@ -205,12 +206,30 @@ afppasswd_found:
 
     if (keyfd > -1) {
         /* read in the hex representation of an 8-byte key */
-        if (read(keyfd, key, sizeof(key)) < 0) {
+        keylen = read(keyfd, key, sizeof(key));
+
+        if (keylen < 0) {
             LOG(log_info, logtype_uams, "read(keyfd) failed (%s)", strerror(errno));
+            err = AFPERR_ACCESS;
+            goto afppasswd_done;
+        }
+
+        if (keylen != sizeof(key)) {
+            LOG(log_info, logtype_uams, "invalid key length in afppasswd key file");
+            err = AFPERR_ACCESS;
+            goto afppasswd_done;
+        }
+
+        for (i = 0; i < sizeof(key); i++) {
+            if (!isxdigit(key[i])) {
+                LOG(log_info, logtype_uams, "invalid character in afppasswd key file");
+                err = AFPERR_ACCESS;
+                goto afppasswd_done;
+            }
         }
 
         /* convert to binary key */
-        for (i = j = 0; i < strlen((char *) key); i += 2, j++) {
+        for (i = j = 0; i < sizeof(key); i += 2, j++) {
             key[j] = (unhex(key[i]) << 4) | unhex(key[i + 1]);
         }
 


### PR DESCRIPTION
two measures to make the RandNum UAM safer in the container

- DES encrypt the afppasswd file with afppasswd.key
- create the afppasswd file only with INSECURE_AUTH

also: crisper description of RandNum password storage in the manual, and hardening of the RandNum UAM key file read bounds and integrity checks