### PR TITLE
afpd:idle_worker: relax wake interval to 10ms and expand deferred queue

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -372,7 +372,7 @@ jobs:
             ## 🔥 Spectest (AFP 3.4) - Flamegraph (AFP_ASSERT active)
 
             **Commit:** `${{ github.event.pull_request.head.sha }}`
-            **Profiling:** On-CPU sampling @ 1009 Hz (prime), DWARF call-graph, x86_64
+            **Profiling:** On-CPU sampling @ 1019 Hz (prime), DWARF call-graph, x86_64
             **Build:** `debugoptimized` (-O2 -g -fno-omit-frame-pointer)
             **Total Runtime:** ${{ steps.flamegraph-summary.outputs.TEST_RUNTIME }}, **Netatalk Code-time:** ${{ steps.flamegraph-summary.outputs.SELF_TIME }},
             **Stacks:** ${{ steps.flamegraph-summary.outputs.STACK_COUNT }}, **SVG size:** ${{ steps.flamegraph-summary.outputs.SVG_SIZE }}

--- a/distrib/docker/debug_entrypoint_netatalk.sh
+++ b/distrib/docker/debug_entrypoint_netatalk.sh
@@ -64,10 +64,10 @@ PERF_FOLDED="/tmp/perf.folded"
 FLAMEGRAPH_SVG="/tmp/flamegraph.svg"
 PERF_PID=""
 
-# Perf sampling frequency (samples per second). Default 1009 Hz — a
+# Perf sampling frequency (samples per second). Default 1019 Hz — a
 # prime number chosen to avoid lockstep synchronization with timer
-# interrupts and the idle worker's 1ms polling interval.
-PERF_FREQ="${PERF_FREQ:-1009}"
+# interrupts and the idle worker's 10ms polling interval.
+PERF_FREQ="${PERF_FREQ:-1019}"
 
 start_flamegraph_profiling() {
     # Verify FlameGraph tools are available

--- a/doc/developer/dircache.md
+++ b/doc/developer/dircache.md
@@ -524,7 +524,7 @@ The idle worker uses **temporal separation** rather than locks: the worker
 thread and main thread never access shared dircache data concurrently.
 
 - `idle_worker_start()` — called just before `poll()`, sets `is_idle=1`
-  (the worker self-wakes every 1ms via `nanosleep()` and checks this flag)
+  (the worker self-wakes every 10ms via `nanosleep()` and checks this flag)
 - `idle_worker_stop()` — called immediately after `poll()` returns, sets
   `is_idle=0` and spins until the worker finishes its current unit of work
 - The worker checks `is_idle` per hash chain, yielding instantly when the

--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -138,7 +138,7 @@ struct deferred_cleanup {
 };
 
 /* Max deferred/queued entries before fallback to synchronous cleaning */
-#define MAX_DEFERRED_CLEANUPS 1024
+#define MAX_DEFERRED_CLEANUPS 5120
 
 static struct deferred_cleanup deferred_queue[MAX_DEFERRED_CLEANUPS];
 static int deferred_head = 0;

--- a/etc/afpd/idle_worker.c
+++ b/etc/afpd/idle_worker.c
@@ -30,8 +30,8 @@
 #include "directory.h"
 #include "idle_worker.h"
 
-/* Self-wake interval for the idle worker thread. 1ms ~0.05% CPU overhead */
-#define IDLE_WORKER_WAKE_MS 1
+/* Self-wake interval for the idle worker thread. 10ms ~0.005% CPU overhead */
+#define IDLE_WORKER_WAKE_MS 10
 _Static_assert(IDLE_WORKER_WAKE_MS < 1000,
                "Use a while loop for nanosecond normalization if IDLE_WORKER_WAKE_MS >= 1s");
 
@@ -82,7 +82,7 @@ static int idle_worker_has_work(void)
 /*!
  * @brief Worker thread main loop
  *
- * Uses nanosleep() for 1ms polling which is a direct SYS_nanosleep syscall
+ * Uses nanosleep() for 10ms polling which is a direct SYS_nanosleep syscall
  */
 static void *idle_worker_main(void *arg)
 {
@@ -271,8 +271,8 @@ void idle_worker_stop_signal_safe(void)
  * @brief Shut down the idle worker thread cleanly.
  *
  * Sets shutdown flag and joins thread. The worker observes shutdown_flag
- * at the top of its loop — after nanosleep() expires (≤1ms) and after any
- * work completes. Join latency is therefore 1ms plus remaining work time.
+ * at the top of its loop — after nanosleep() expires (≤10ms) and after any
+ * work completes. Join latency is therefore 10ms plus remaining work time.
  *
  * WARNING: Must NOT be called from signal handler context —
  * pthread_join is async-signal-unsafe. Use idle_worker_stop_signal_safe()


### PR DESCRIPTION
- Increase IDLE_WORKER_WAKE_MS from 1ms to 10ms; deferred work is eventually-consistent and does not need sub-millisecond latency.
- Expand MAX_DEFERRED_CLEANUPS from 1024 to 5120 to accommodate the longer drain interval under heavy directory churn.
- Bump perf sampling frequency from 1009 to 1019 Hz (higher prime) to avoid lockstep with the new 10ms (100 Hz) worker wake cycle.

This change should also resolve the occasional flamegraph analysis issue where we see idle_worker taking significant time in the flamegraph (becuase `perf` would sample at the exact same time as the idle_worker triggers, making it look like idle_worker takes more time than it actually does)