### PR TITLE
docker: dbus-daemon not needed in production container

### DIFF
--- a/distrib/docker/netatalk.Dockerfile
+++ b/distrib/docker/netatalk.Dockerfile
@@ -73,7 +73,6 @@ RUN meson setup build \
     -Dwith-afpstats=false \
     -Dwith-appletalk=true \
     -Dwith-cnid-backends=dbd,mysql,sqlite \
-    -Dwith-dbus-daemon-path=/usr/bin/dbus-daemon \
     -Dwith-dbus-sysconf-path=/etc \
     -Dwith-docs= \
     -Dwith-dtrace=false \


### PR DESCRIPTION
dbus-daemon is only launched by the localsearch search backend which is not active in the netatalk production container