### PR TITLE
[4.4] uams: warn when Randnum afppasswd key file is missing

### DIFF
--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -161,9 +161,25 @@ static int afppasswd(const struct passwd *pwd,
     /* open the key file if it exists */
     strcpy(buf, path);
 
-    if (pathlen < (int) sizeof(buf) - 5) {
+    if (pathlen <= (int) sizeof(buf) - 5) {
         strcat(buf, ".key");
         keyfd = open(buf, O_RDONLY);
+
+        if (keyfd < 0) {
+            LOG(log_warning, logtype_uams,
+                "SECURITY WARNING: afppasswd key file \"%s\" is unavailable "
+                "(%s); Randnum passwords in \"%s\" are stored and used in "
+                "clear text. This insecure fallback is deprecated and will "
+                "become a hard failure in a future release.",
+                buf, strerror(errno), path);
+        }
+    } else {
+        LOG(log_warning, logtype_uams,
+            "SECURITY WARNING: afppasswd path \"%s\" is too long to locate "
+            "the companion key file; Randnum passwords are stored and used in "
+            "clear text. This insecure fallback is deprecated and will become "
+            "a hard failure in a future release.",
+            path);
     }
 
     pos = ftell(fp);


### PR DESCRIPTION
Log a security warning when the Randnum UAM falls back to clear-text afppasswd entries because the companion key file is not present or the configured path is too long.

The warning notes that this insecure fallback is deprecated and will become a hard failure in a future release.

Also allow the boundary case where the afppasswd path exactly leaves room for the ".key" suffix plus terminator, avoiding an unnecessary key-path failure.

Additionally: build astyle v3.6.14 from scratch for code formatting job, because they introduced multiple regression bugs in 3.6.15 (reported upstream).