### PR TITLE
uams: require afppasswd key file for Randnum UAM

### DIFF
--- a/doc/manpages/man1/afppasswd.1.md
+++ b/doc/manpages/man1/afppasswd.1.md
@@ -37,9 +37,15 @@ The named user must already exist as a local system user.
 > ***NOTE:*** The legacy Randnum and 2-Way Randnum UAMs only provide
 weak password protection and are discouraged. They should only be enabled
 to support very old AFP clients that cannot use SRP, DHX, or DHX2.
-If a file named *afppasswd.key* exists at the same path as the *afppasswd* file,
-Randnum uses its hex-encoded 8-byte DES key to encrypt the stored password;
-otherwise the password is stored as raw hex.
+Randnum requires a file named *afppasswd.key* at the same path as the
+*afppasswd* file. The key file contains a hex-encoded 8-byte DES key that
+Randnum uses to encrypt the stored password. The Randnum UAM refuses to load
+if the key file is missing or unavailable.
+
+The key file must begin with 16 hexadecimal characters, such as
+`0123456789ABCDEF`; Randnum reads those first 16 bytes as the key material,
+so a trailing newline after them is harmless. Generate a fresh random key for
+each server instead of reusing this example value.
 
 # Examples
 

--- a/doc/manual/Authentication.md
+++ b/doc/manual/Authentication.md
@@ -71,7 +71,7 @@ DHX2 is sufficient and provides the strongest encryption.
 - "Randnum exchange"/"2-Way Randnum exchange" uses only 56-bit DES for encryption,
   so it should also be avoided.
   An additional disadvantage is that passwords are stored separately on the server:
-  as raw hex by default, or DES-encrypted and hex-encoded when a key file is used.
+  DES-encrypted and hex-encoded with a required key file.
 
     However, this is the strongest form of authentication available for
     Macintosh System Software 7.1 or earlier.
@@ -101,12 +101,17 @@ documentation.
 Randnum and SRP do not use system passwords directly. They both rely on
 separate files managed with **afppasswd**:
 
-- **Randnum** uses the legacy *afppasswd* file. By default it stores the raw
-  password as hex. If an optional key file exists alongside the Randnum
-  password file (same path with a `.key` suffix), the stored password is
-  DES-encrypted using that key instead. To use a key file, create
+- **Randnum** uses the legacy *afppasswd* file. It requires a key file
+  alongside the Randnum password file (same path with a `.key` suffix), and
+  refuses to load when the key file is missing or unavailable. Create
   `<passwd file>.key` containing 16 hex characters (8 bytes) and restrict
-  permissions (for example, owner-readable only).
+  permissions (for example, owner-readable only). Stored passwords are
+  DES-encrypted using that key.
+
+  For example, a valid key file begins with 16 hexadecimal characters, such
+  as `0123456789ABCDEF`; Randnum reads those first 16 bytes as the key
+  material, so a trailing newline after them is harmless. Generate a fresh
+  random key for each server instead of reusing this example value.
 
 - **SRP** uses *afppasswd.srp*, which stores per-user salts and verifiers.
 
@@ -143,7 +148,7 @@ An overview of the officially supported UAMs on Macs.
 | Client support   | built-in into all Mac OS versions | built-in in all Mac OS versions except 10.0. Has to be activated explicitly in later Mac OS X versions | built-in into almost all Mac OS versions | built-in since AppleShare client 3.8.4, available as a plug-in for 3.8.3, integrated in macOS's AFP client | built-in since Mac OS X 10.2 | built-in since Mac OS X 10.2 | built-in since Mac OS X 10.7 |
 | Encryption       | Enables guest access without authentication between client and server. | Password will be sent in cleartext over the wire. Just as bad as it sounds, therefore avoid at all costs. | 8-byte random numbers are sent over the wire, comparable with DES, 56 bits. Vulnerable to offline dictionary attack. Requires separately stored server-side passwords. | Password will be encrypted with 128 bit CAST, user will be authenticated against the server but not vice versa. Therefore weak against man-in-the-middle attacks. | Password will be encrypted with 128 bit CAST in CBC mode. User will be authenticated against the server but not vice versa. Therefore weak against man-in-the-middle attacks. | Password is not sent over the network. Due to the service principal detection method, this authentication method is vulnerable to man-in-the-middle attacks. | Password is never sent; SRP uses a verifier and mutual proofs (M1/M2) to authenticate both client and server, providing protection against man‑in‑the‑middle attacks. |
 | Server support   | uams_guest.so | uams_clrtxt.so   | uams_randnum.so  | uams_dhx.so  | uams_dhx2.so  | uams_gss.so      | uams_srp.so      |
-| Password storage | None          | Either system auth or PAM | Separate *afppasswd* file; raw hex by default, or DES-encrypted hex with *.key* | Either system auth or PAM | Either system auth or PAM | At the Kerberos Key Distribution Center | In a separate *afppasswd.srp* verifier file |
+| Password storage | None          | Either system auth or PAM | Separate *afppasswd* file (DES-encrypted) | Either system auth or PAM | Either system auth or PAM | At the Kerberos Key Distribution Center | Separate *afppasswd.srp* verifier file |
 
 Note that a number of open-source and other third-party AFP clients exist.
 Refer to their documentation for a list of supported UAMs.

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -18,7 +18,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/param.h>
-#include <sys/stat.h>
 #include <unistd.h>
 
 #ifdef USE_CRACKLIB
@@ -47,72 +46,90 @@ static uint8_t         randbuf[8];
 		      ((unsigned long)a)) & 0xffff)
 
 
-/*! handle ~/.passwd. courtesy of shirsch@ibm.net. */
-static  int home_passwd(const struct passwd *pwd,
-                        const char *path, const int pathlen _U_,
-                        unsigned char *passwd, const int len,
-                        const int set)
-{
-    struct stat st;
-    int fd, i;
-
-    if ((fd = open(path, set ? O_WRONLY : O_RDONLY)) < 0) {
-        LOG(log_error, logtype_uams, "Failed to open %s", path);
-        return AFPERR_ACCESS;
-    }
-
-    if (fstat(fd, &st) < 0) {
-        goto home_passwd_fail;
-    }
-
-    /* If any of these are true, disallow login:
-     * - not a regular file
-     * - gid or uid don't match user
-     * - anyone else has permissions of any sort
-     */
-    if (!S_ISREG(st.st_mode) || (pwd->pw_uid != st.st_uid) ||
-            (pwd->pw_gid != st.st_gid) ||
-            (st.st_mode & (S_IRWXG | S_IRWXO))) {
-        LOG(log_info, logtype_uams, "Insecure permissions found for %s.", path);
-        goto home_passwd_fail;
-    }
-
-    /* get the password */
-    if (set) {
-        if (write(fd, passwd, len) < 0) {
-            LOG(log_error, logtype_uams, "Failed to write to %s", path);
-            goto home_passwd_fail;
-        }
-    } else {
-        if (read(fd, passwd, len) < 0) {
-            LOG(log_error, logtype_uams, "Failed to read from %s", path);
-            goto home_passwd_fail;
-        }
-
-        /* get rid of pesky characters */
-        for (i = 0; i < len; i++)
-            if ((passwd[i] != ' ') && isspace(passwd[i])) {
-                passwd[i] = '\0';
-            }
-    }
-
-    close(fd);
-    return AFP_OK;
-home_passwd_fail:
-    close(fd);
-    return AFPERR_ACCESS;
-}
-
-
 #define PASSWD_ILLEGAL '*'
 #define unhex(x)  (isdigit(x) ? (x) - '0' : toupper(x) + 10 - 'A')
 
+static int randnum_cipher_check(const char *op, gcry_error_t err)
+{
+    if (!err) {
+        return 0;
+    }
+
+    LOG(log_error, logtype_uams, "UAM RandNum: %s failed: %s", op,
+        gcry_strerror(err));
+    return -1;
+}
+
+static int afppasswd_open_keyfile(const char *path, const int pathlen)
+{
+    char keypath[MAXPATHLEN + 1];
+    int keyfd;
+
+    if (pathlen > (int) sizeof(keypath) - 5) {
+        LOG(log_error, logtype_uams,
+            "UAM RandNum: afppasswd path \"%s\" is too long to locate "
+            "the required companion key file; refusing to use Randnum.",
+            path);
+        return -1;
+    }
+
+    strlcpy(keypath, path, sizeof(keypath));
+    strlcat(keypath, ".key", sizeof(keypath));
+    keyfd = open(keypath, O_RDONLY);
+
+    if (keyfd < 0) {
+        LOG(log_error, logtype_uams,
+            "UAM RandNum: required afppasswd key file \"%s\" is unavailable "
+            "(%s); refusing to use Randnum because passwords in \"%s\" "
+            "would otherwise be stored and used in clear text.",
+            keypath, strerror(errno), path);
+    }
+
+    return keyfd;
+}
+
+static int randnum_check_passwdfile_key(void *obj)
+{
+    char *passwdfile = NULL;
+    int keyfd;
+    size_t len = UAM_PASSWD_FILENAME;
+
+    if (uam_afpserver_option(obj, UAM_OPTION_PASSWDOPT,
+                             (void *) &passwdfile, &len) < 0) {
+        LOG(log_error, logtype_uams,
+            "UAM RandNum: failed to get afppasswd file option; refusing to load Randnum.");
+        return -1;
+    }
+
+    if (!passwdfile || len == 0) {
+        LOG(log_error, logtype_uams,
+            "UAM RandNum: afppasswd file is not configured; refusing to load Randnum.");
+        return -1;
+    }
+
+    if (*passwdfile == '~') {
+        LOG(log_error, logtype_uams,
+            "UAM RandNum: home password files cannot be protected by the "
+            "required afppasswd key file; refusing to load Randnum.");
+        return -1;
+    }
+
+    keyfd = afppasswd_open_keyfile(passwdfile, (int) len);
+
+    if (keyfd < 0) {
+        return -1;
+    }
+
+    close(keyfd);
+    return 0;
+}
+
 /*!
- * @brief handle /path/afppasswd with an optional key file.
+ * @brief handle /path/afppasswd with a required key file.
  * we're a lot more trusting of this file.
  * @note we use our own password entry writing bits
  * as we want to avoid tromping over global variables.
- * in addition, we look for a key file and use that if it's there.
+ * in addition, we require a key file and fail if it is not available.
  *
  * here are the formats:
  *
@@ -122,8 +139,7 @@ home_passwd_fail:
  * username:password:last login date:failedcount
  * @endcode
  *
- * password is just the hex equivalent of either the ASCII password
- * (if the key file doesn't exist) or the des encrypted password.
+ * password is just the hex equivalent of the DES encrypted password.
  *
  * key file
  * --------
@@ -143,7 +159,7 @@ static int afppasswd(const struct passwd *pwd,
     int keyfd = -1, err = 0;
     ssize_t keylen;
     off_t pos;
-    gcry_cipher_hd_t ctx;
+    gcry_cipher_hd_t ctx = NULL;
     gcry_error_t ctxerror;
 
     if (!gcry_check_version(UAM_NEED_LIBGCRYPT_VERSION)) {
@@ -158,12 +174,11 @@ static int afppasswd(const struct passwd *pwd,
         return AFPERR_ACCESS;
     }
 
-    /* open the key file if it exists */
-    strcpy(buf, path);
+    keyfd = afppasswd_open_keyfile(path, pathlen);
 
-    if (pathlen < (int) sizeof(buf) - 5) {
-        strcat(buf, ".key");
-        keyfd = open(buf, O_RDONLY);
+    if (keyfd < 0) {
+        err = AFPERR_ACCESS;
+        goto afppasswd_done;
     }
 
     pos = ftell(fp);
@@ -204,52 +219,76 @@ afppasswd_found:
         }
     }
 
-    if (keyfd > -1) {
-        /* read in the hex representation of an 8-byte key */
-        keylen = read(keyfd, key, sizeof(key));
+    /* read in the hex representation of an 8-byte key */
+    keylen = read(keyfd, key, sizeof(key));
 
-        if (keylen < 0) {
-            LOG(log_info, logtype_uams, "read(keyfd) failed (%s)", strerror(errno));
+    if (keylen < 0) {
+        LOG(log_info, logtype_uams, "read(keyfd) failed (%s)", strerror(errno));
+        err = AFPERR_ACCESS;
+        goto afppasswd_done;
+    }
+
+    if (keylen != sizeof(key)) {
+        LOG(log_info, logtype_uams, "invalid key length in afppasswd key file");
+        err = AFPERR_ACCESS;
+        goto afppasswd_done;
+    }
+
+    for (i = 0; i < sizeof(key); i++) {
+        if (!isxdigit(key[i])) {
+            LOG(log_info, logtype_uams, "invalid character in afppasswd key file");
             err = AFPERR_ACCESS;
             goto afppasswd_done;
         }
+    }
 
-        if (keylen != sizeof(key)) {
-            LOG(log_info, logtype_uams, "invalid key length in afppasswd key file");
+    /* convert to binary key */
+    for (i = j = 0; i < sizeof(key); i += 2, j++) {
+        key[j] = (unhex(key[i]) << 4) | unhex(key[i + 1]);
+    }
+
+    if (j <= DES_KEY_SZ) {
+        memset(key + j, 0, sizeof(key) - j);
+    }
+
+    ctxerror = gcry_cipher_open(&ctx, GCRY_CIPHER_DES, GCRY_CIPHER_MODE_ECB, 0);
+
+    if (randnum_cipher_check("gcry_cipher_open", ctxerror) < 0) {
+        err = AFPERR_ACCESS;
+        goto afppasswd_done;
+    }
+
+    ctxerror = gcry_cipher_setkey(ctx, key, DES_KEY_SZ);
+
+    if (randnum_cipher_check("gcry_cipher_setkey", ctxerror) < 0) {
+        err = AFPERR_ACCESS;
+        goto afppasswd_close_cipher;
+    }
+
+    if (set) {
+        /* NOTE: this takes advantage of the fact that passwd doesn't
+         *       get used after this call if it's being set. */
+        ctxerror = gcry_cipher_encrypt(ctx, passwd, len, NULL, 0);
+
+        if (randnum_cipher_check("gcry_cipher_encrypt", ctxerror) < 0) {
             err = AFPERR_ACCESS;
-            goto afppasswd_done;
+            goto afppasswd_close_cipher;
         }
+    } else {
+        /* decrypt the password */
+        ctxerror = gcry_cipher_decrypt(ctx, p, DES_KEY_SZ, NULL, 0);
 
-        for (i = 0; i < sizeof(key); i++) {
-            if (!isxdigit(key[i])) {
-                LOG(log_info, logtype_uams, "invalid character in afppasswd key file");
-                err = AFPERR_ACCESS;
-                goto afppasswd_done;
-            }
+        if (randnum_cipher_check("gcry_cipher_decrypt", ctxerror) < 0) {
+            err = AFPERR_ACCESS;
+            goto afppasswd_close_cipher;
         }
+    }
 
-        /* convert to binary key */
-        for (i = j = 0; i < sizeof(key); i += 2, j++) {
-            key[j] = (unhex(key[i]) << 4) | unhex(key[i + 1]);
-        }
+afppasswd_close_cipher:
+    gcry_cipher_close(ctx);
 
-        if (j <= DES_KEY_SZ) {
-            memset(key + j, 0, sizeof(key) - j);
-        }
-
-        ctxerror = gcry_cipher_open(&ctx, GCRY_CIPHER_DES, GCRY_CIPHER_MODE_ECB, 0);
-        ctxerror = gcry_cipher_setkey(ctx, key, DES_KEY_SZ);
-
-        if (set) {
-            /* NOTE: this takes advantage of the fact that passwd doesn't
-             *       get used after this call if it's being set. */
-            ctxerror = gcry_cipher_encrypt(ctx, passwd, len, NULL, 0);
-        } else {
-            /* decrypt the password */
-            ctxerror = gcry_cipher_decrypt(ctx, p, DES_KEY_SZ, NULL, 0);
-        }
-
-        gcry_cipher_close(ctx);
+    if (err) {
+        goto afppasswd_done;
     }
 
     if (set) {
@@ -294,44 +333,14 @@ afppasswd_done:
 
 /*!
  * @brief this sets the uid.
- * @note it needs to do slightly different things
- * depending upon whether or not the password is in ~/.passwd
- * or in a global location
+ * @note the afppasswd file must be read and updated as root.
  */
 static int randpass(const struct passwd *pwd, const char *file,
                     unsigned char *passwd, const int len, const int set)
 {
     int i;
     uid_t uid = geteuid();
-    /* Build pathname to user's '.passwd' file */
     i = strlen(file);
-
-    if (*file == '~') {
-        char path[MAXPATHLEN + 1];
-
-        if ((strlen(pwd->pw_dir) + i - 1) > MAXPATHLEN) {
-            return AFPERR_PARAM;
-        }
-
-        strcpy(path,  pwd->pw_dir);
-        strcat(path, "/");
-        strcat(path, file + 2);
-
-        /* change ourselves to the user */
-        if (!uid && (seteuid(pwd->pw_uid) < 0)) {
-            LOG(log_info, logtype_uams, "seteuid(%i) failed (%s)", pwd->pw_uid,
-                strerror(errno));
-        }
-
-        i = home_passwd(pwd, path, i, passwd, len, set);
-
-        /* change ourselves back to root */
-        if (!uid && (seteuid(0) < 0)) {
-            LOG(log_info, logtype_uams, "seteuid(%i) failed (%s)", 0, strerror(errno));
-        }
-
-        return i;
-    }
 
     if (i > MAXPATHLEN) {
         return AFPERR_PARAM;
@@ -655,6 +664,10 @@ static int randnum_login_ext(void *obj, char *uname, struct passwd **uam_pwd,
 
 static int uam_setup(void *obj, const char *path)
 {
+    if (randnum_check_passwdfile_key(obj) < 0) {
+        return -1;
+    }
+
     if (uam_register(UAM_SERVER_LOGIN_EXT, path, "Randnum exchange",
                      randnum_login, randnum_logincont, NULL, randnum_login_ext) < 0) {
         return -1;


### PR DESCRIPTION
Refuse to load the Randnum UAM when the configured afppasswd file cannot be paired with a readable .key file used for DES encryption of the stored passwords. Also reject the legacy home password-file mode, which cannot use the required companion key file.

Keep the runtime afppasswd path from falling back to clear-text password storage if the key file is unavailable after startup, and update the documentation with the required key-file format and an example value.

Also allow the boundary case where the afppasswd path exactly leaves room for the ".key" suffix plus terminator, avoiding an unnecessary key-path failure.

Additionally: build astyle v3.6.14 from scratch for code formatting job, because they introduced multiple regression bugs in 3.6.15 (reported upstream).