### PR TITLE
ci: build astyle from scratch for code formatting job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,9 @@ jobs:
       - name: Install dependencies
         run: |
           apk add --no-cache \
-            astyle \
+            build-base \
             ca-certificates \
+            cmake \
             git \
             muon \
             nodejs \
@@ -37,6 +38,16 @@ jobs:
             shfmt \
             yamlfmt
           npm install --global --ignore-scripts markdownlint-cli2@0.22.0
+      - name: Build astyle 3.6.14 from source
+        run: |
+          git clone --depth 1 --branch 3.6.14 \
+            https://gitlab.com/saalen/astyle.git /tmp/astyle
+          cmake -S /tmp/astyle -B /tmp/astyle/build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/usr/local
+          cmake --build /tmp/astyle/build -j"$(nproc)"
+          cmake --install /tmp/astyle/build
+          astyle --version
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
build astyle v3.6.14 from scratch for code formatting job, because they introduced multiple regression bugs in 3.6.15 (reported upstream)