### PR TITLE
refactor potentially unsafe C library calls flagged by OpenBSD linker

### DIFF
--- a/bin/nad/ftw.c
+++ b/bin/nad/ftw.c
@@ -235,7 +235,7 @@ static char *mystpcpy(char *dest, const char *src, size_t dest_size)
 
         return dest;
     } else {
-        strcpy(dest, src);
+        strlcpy(dest, src, dest_size);
         return dest + src_len;
     }
 }

--- a/etc/afpd/appl.c
+++ b/etc/afpd/appl.c
@@ -273,7 +273,7 @@ int afp_addappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 
     dtf = dtfile(vol, creator, ".appl.temp");
     tempfile = obj->oldtmp;
-    strlcpy(tempfile, dtf, AFPOBJ_TMPSIZ);
+    strlcpy(tempfile, dtf, AFPOBJ_TMPSIZ + 1);
 
     if ((tfd = open(tempfile, O_RDWR | O_CREAT, 0666)) < 0) {
         return AFPERR_PARAM;
@@ -409,7 +409,7 @@ int afp_rmvappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
         return AFPERR_PARAM;
     }
 
-    strlcpy(tempfile, dtf, AFPOBJ_TMPSIZ);
+    strlcpy(tempfile, dtf, AFPOBJ_TMPSIZ + 1);
 
     if ((tfd = open(tempfile, O_RDWR | O_CREAT, 0666)) < 0) {
         close(sa.sdt_fd);

--- a/etc/afpd/appl.c
+++ b/etc/afpd/appl.c
@@ -272,6 +272,11 @@ int afp_addappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
     }
 
     dtf = dtfile(vol, creator, ".appl.temp");
+
+    if (!dtf) {
+        return AFPERR_PARAM;
+    }
+
     tempfile = obj->oldtmp;
     strlcpy(tempfile, dtf, AFPOBJ_TMPSIZ + 1);
 
@@ -400,6 +405,13 @@ int afp_rmvappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
     }
 
     dtf = dtfile(vol, creator, ".appl.temp");
+
+    if (!dtf) {
+        close(sa.sdt_fd);
+        sa.sdt_fd = -1;
+        return AFPERR_PARAM;
+    }
+
     /* Use existing tempfile buffers but check if the path fits */
     tempfile = obj->oldtmp;
 

--- a/etc/afpd/appl.c
+++ b/etc/afpd/appl.c
@@ -273,7 +273,7 @@ int afp_addappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 
     dtf = dtfile(vol, creator, ".appl.temp");
     tempfile = obj->oldtmp;
-    strcpy(tempfile, dtf);
+    strlcpy(tempfile, dtf, AFPOBJ_TMPSIZ);
 
     if ((tfd = open(tempfile, O_RDWR | O_CREAT, 0666)) < 0) {
         return AFPERR_PARAM;
@@ -409,7 +409,7 @@ int afp_rmvappl(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
         return AFPERR_PARAM;
     }
 
-    strcpy(tempfile, dtf);
+    strlcpy(tempfile, dtf, AFPOBJ_TMPSIZ);
 
     if ((tfd = open(tempfile, O_RDWR | O_CREAT, 0666)) < 0) {
         close(sa.sdt_fd);

--- a/etc/afpd/desktop.c
+++ b/etc/afpd/desktop.c
@@ -834,7 +834,7 @@ char *dtfile(const struct vol *vol, uint8_t creator[], char *ext)
     }
 
     *p = '\0';
-    strcat(path, ext);
+    strlcat(path, ext, sizeof(path));
     return path;
 }
 
@@ -852,7 +852,7 @@ char *mtoupath(const struct vol *vol, char *mpath, cnid_t did, int utf8)
     uint16_t	 flags;
 
     if (*mpath == '\0') {
-        strcpy(upath, ".");
+        strlcpy(upath, ".", sizeof(upath));
         return upath;
     }
 

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -380,7 +380,7 @@ static int cname_mtouname(const struct vol *vol, struct dir *dir,
                     return -1;
                 }
 
-                strcpy(ret->m_name, temp);
+                strlcpy(ret->m_name, temp, MAXPATHLEN + 1);
             }
         }
 
@@ -404,7 +404,7 @@ static int cname_mtouname(const struct vol *vol, struct dir *dir,
              */
             if ((t = utompath(vol, ret->u_name, fileid, utf8_encoding(vol->v_obj)))) {
                 /* at last got our view of mac name */
-                strcpy(ret->m_name, t);
+                strlcpy(ret->m_name, t, MAXPATHLEN + 1);
             }
         }
     } /* afp_version >= 30 */

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -249,6 +249,7 @@ char *set_name(const struct vol *vol, char *data, cnid_t pid, char *name,
                cnid_t id, uint32_t utf8)
 {
     uint32_t   aint;
+    uint32_t   tp_len = 0;
     char        *tp = NULL;
     char        *src = name;
     aint = strlen(name);
@@ -259,6 +260,7 @@ char *set_name(const struct vol *vol, char *data, cnid_t pid, char *name,
             /* but name is an utf8 mac name */
             char *u, *m;
             /* global static variable... */
+            tp_len = aint;
             tp = strdup(name);
 
             if (!(u = mtoupath(vol, name, pid, 1)) || !(m = utompath(vol, u, id, 0))) {
@@ -294,7 +296,7 @@ char *set_name(const struct vol *vol, char *data, cnid_t pid, char *name,
     data += aint;
 
     if (tp) {
-        strcpy(name, tp);
+        memcpy(name, tp, tp_len + 1);
         free(tp);
     }
 
@@ -1872,7 +1874,7 @@ int afp_copyfile(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
     }
 
     newname = obj->newtmp;
-    strcpy(newname, s_path->m_name);
+    strlcpy(newname, s_path->m_name, AFPOBJ_TMPSIZ + 1);
     p = ctoupath(s_vol, curdir, newname);
 
     if (!p) {

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -1183,7 +1183,7 @@ int afp_moveandrename(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
     }
 
     if (!plen) {
-        strcpy(newname, oldname);
+        strlcpy(newname, oldname, AFPOBJ_TMPSIZ + 1);
     }
 
     /* This does the work */

--- a/etc/afpd/mangle.c
+++ b/etc/afpd/mangle.c
@@ -291,7 +291,8 @@ mangle(const struct vol *vol, char *filename, size_t filenamelen, char *uname,
     ext_len = mangle_extension(vol, uname, ext,
                                (flags & 2) ? CH_UTF8_MAC : vol->v_maccharset);
     m = mfilename;
-    k = sprintf(mangle_suffix, "%c%X", MANGLE_CHAR, ntohl(id));
+    k = snprintf(mangle_suffix, sizeof(mangle_suffix), "%c%X", MANGLE_CHAR,
+                 ntohl(id));
 
     if (filenamelen + k + ext_len > maxlen) {
         uint16_t opt = CONV_FORCE | CONV_UNESCAPEHEX;
@@ -306,10 +307,10 @@ mangle(const struct vol *vol, char *filename, size_t filenamelen, char *uname,
     }
 
     if (*m == 0) {
-        strcat(m, "???");
+        strlcat(m, "???", MAXPATHLEN);
     }
 
-    strcat(m, mangle_suffix);
+    strlcat(m, mangle_suffix, MAXPATHLEN);
 
     if (ext_len) {
         strncat(m, ext, ext_len);

--- a/etc/afpd/messages.c
+++ b/etc/afpd/messages.c
@@ -8,6 +8,7 @@
 #endif /* HAVE_CONFIG_H */
 
 #include <errno.h>
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -49,7 +50,7 @@ void readmessage(AFPObj *obj)
     /* Read server message from file defined as SERVERTEXT */
 #ifdef SERVERTEXT
     FILE *message;
-    char *filename;
+    char filename[MAXPATHLEN + 1];
     unsigned int i;
     int rc;
     static int c;
@@ -58,14 +59,8 @@ void readmessage(AFPObj *obj)
                  MAXMESGSIZE), MAXPATHLEN) : MAXMESGSIZE;
     i = 0;
     /* Construct file name SERVERTEXT/message.[pid] */
-    size_t filenamelen = sizeof(SERVERTEXT) + 15;
-
-    if (NULL == (filename = (char *) malloc(filenamelen))) {
-        LOG(log_error, logtype_afpd, "readmessage: malloc: %s", strerror(errno));
-        return;
-    }
-
-    snprintf(filename, filenamelen, "%s/message.%d", SERVERTEXT, obj->pid);
+    snprintf(filename, sizeof(filename), "%s/message.%" PRIiMAX,
+             SERVERTEXT, (intmax_t)obj->pid);
     LOG(log_debug9, logtype_afpd, "Reading file %s ", filename);
     message = fopen(filename, "r");
 
@@ -73,7 +68,7 @@ void readmessage(AFPObj *obj)
         /* try without the process id */
         LOG(log_info, logtype_afpd, "Unable to open file %s; trying without the pid",
             filename);
-        snprintf(filename, filenamelen, "%s/message", SERVERTEXT);
+        snprintf(filename, sizeof(filename), "%s/message", SERVERTEXT);
         message = fopen(filename, "r");
     }
 
@@ -109,7 +104,6 @@ void readmessage(AFPObj *obj)
         LOG(log_debug9, logtype_afpd, "Set server message to \"%s\"", servermesg);
     }
 
-    free(filename);
 #endif /* SERVERTEXT */
 }
 

--- a/etc/afpd/messages.c
+++ b/etc/afpd/messages.c
@@ -57,14 +57,15 @@ void readmessage(AFPObj *obj)
     maxmsgsize = (obj->proto == AFPPROTO_DSI) ? MIN(MAX(obj->dsi->attn_quantum,
                  MAXMESGSIZE), MAXPATHLEN) : MAXMESGSIZE;
     i = 0;
-
     /* Construct file name SERVERTEXT/message.[pid] */
-    if (NULL == (filename = (char *) malloc(sizeof(SERVERTEXT) + 15))) {
+    size_t filenamelen = sizeof(SERVERTEXT) + 15;
+
+    if (NULL == (filename = (char *) malloc(filenamelen))) {
         LOG(log_error, logtype_afpd, "readmessage: malloc: %s", strerror(errno));
         return;
     }
 
-    sprintf(filename, "%s/message.%d", SERVERTEXT, obj->pid);
+    snprintf(filename, filenamelen, "%s/message.%d", SERVERTEXT, obj->pid);
     LOG(log_debug9, logtype_afpd, "Reading file %s ", filename);
     message = fopen(filename, "r");
 
@@ -72,7 +73,7 @@ void readmessage(AFPObj *obj)
         /* try without the process id */
         LOG(log_info, logtype_afpd, "Unable to open file %s; trying without the pid",
             filename);
-        sprintf(filename, "%s/message", SERVERTEXT);
+        snprintf(filename, filenamelen, "%s/message", SERVERTEXT);
         message = fopen(filename, "r");
     }
 

--- a/etc/afpd/quota.c
+++ b/etc/afpd/quota.c
@@ -633,14 +633,12 @@ static int getquota(const AFPObj *obj, struct vol *vol, struct dqblk *dq,
         }
 
         if (vol->v_nfs) {
-            if ((vol->v_gvs = (char *)malloc(strlen(p) + 1)) == NULL) {
-                LOG(log_error, logtype_afpd, "getquota: malloc: %s", strerror(errno));
+            if ((vol->v_gvs = strdup(p)) == NULL) {
+                LOG(log_error, logtype_afpd, "getquota: strdup: %s", strerror(errno));
                 return AFPERR_MISC;
             }
-
-            strcpy(vol->v_gvs, p);
         } else {
-            sprintf(buf, "%s/quotas", p);
+            snprintf(buf, sizeof(buf), "%s/quotas", p);
 
             if ((vol->v_qfd = open(buf, O_RDONLY, 0)) < 0) {
                 LOG(log_info, logtype_afpd, "open %s: %s", buf, strerror(errno));
@@ -657,12 +655,10 @@ static int getquota(const AFPObj *obj, struct vol *vol, struct dqblk *dq,
             return AFPERR_PARAM;
         }
 
-        if ((vol->v_gvs = (char *)malloc(strlen(p) + 1)) == NULL) {
-            LOG(log_error, logtype_afpd, "getquota: malloc: %s", strerror(errno));
+        if ((vol->v_gvs = strdup(p)) == NULL) {
+            LOG(log_error, logtype_afpd, "getquota: strdup: %s", strerror(errno));
             return AFPERR_MISC;
         }
-
-        strcpy(vol->v_gvs, p);
     }
 
 #endif

--- a/test/afpd/afpfunc_helpers.c
+++ b/test/afpd/afpfunc_helpers.c
@@ -96,8 +96,10 @@ char **cnamewrap(const char *name)
     int len = 0;
     PUSHVAL(p, uint8_t, 3, len); /* path type */
     PUSHVAL(p, uint32_t, kTextEncodingUTF8, len); /* text encoding hint */
-    PUSHVAL(p, uint16_t, htons(strlen(name)), len);
-    strlcpy(p, name, sizeof(buf) - len);
+    size_t avail = sizeof(buf) - len - sizeof(uint16_t);
+    size_t namelen = strnlen(name, avail);
+    PUSHVAL(p, uint16_t, htons(namelen), len);
+    memcpy(p, name, namelen);
     p = buf;
     return &p;
 }

--- a/test/afpd/afpfunc_helpers.c
+++ b/test/afpd/afpfunc_helpers.c
@@ -97,7 +97,7 @@ char **cnamewrap(const char *name)
     PUSHVAL(p, uint8_t, 3, len); /* path type */
     PUSHVAL(p, uint32_t, kTextEncodingUTF8, len); /* text encoding hint */
     PUSHVAL(p, uint16_t, htons(strlen(name)), len);
-    strcpy(p, name);
+    strlcpy(p, name, sizeof(buf) - len);
     p = buf;
     return &p;
 }

--- a/test/afpd/subtests.c
+++ b/test/afpd/subtests.c
@@ -43,7 +43,7 @@ int test001_add_x_dirs(const struct vol *vol, cnid_t start, cnid_t end)
     char dirname[20];
 
     while (start++ < end) {
-        sprintf(dirname, "dir%04u", start);
+        snprintf(dirname, sizeof(dirname), "dir%04u", start);
         dir = dir_new(dirname, dirname, vol, DIRDID_ROOT, htonl(start),
                       bfromcstr(vol->v_path), 0);
 

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -615,13 +615,13 @@ STATIC void test308()
         }
     }
 
-    sprintf(temp, "t307#%X", ntohl(dir));
+    snprintf(temp, sizeof(temp), "t307#%X", ntohl(dir));
 
     if (!FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp, 0, bitmap)) {
         test_failed();
     }
 
-    sprintf(temp, "t308#%X", ntohl(dir));
+    snprintf(temp, sizeof(temp), "t308#%X", ntohl(dir));
 
     if (!FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp, 0, bitmap)) {
         test_failed();
@@ -683,10 +683,10 @@ STATIC void test324()
         test_nottested();
     }
 
-    sprintf(temp1, "#%X.txt", ntohl(id));
+    snprintf(temp1, sizeof(temp1), "#%X.txt", ntohl(id));
     memset(temp, 0, sizeof(temp));
     strncpy(temp, name, 31 - strlen(temp1));
-    strcat(temp, temp1);
+    strlcat(temp, temp1, sizeof(temp));
 
     if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp, bitmap, 0)) {
         test_failed();
@@ -738,10 +738,10 @@ STATIC void test326()
         goto test_exit;
     }
 
-    sprintf(temp1, "#%X.txt", ntohl(id));
+    snprintf(temp1, sizeof(temp1), "#%X.txt", ntohl(id));
     memset(temp, 0, sizeof(temp));
     strncpy(temp, name, 31 - strlen(temp1));
-    strcat(temp, temp1);
+    strlcat(temp, temp1, sizeof(temp));
     ret = FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp, bitmap, 0);
 
     if ((Conn->afp_version >= 30 && ret != ntohl(AFPERR_NOOBJ))
@@ -789,19 +789,19 @@ STATIC void test333()
         test_nottested();
     }
 
-    sprintf(temp1, "#%X.txt", ntohl(id));
+    snprintf(temp1, sizeof(temp1), "#%X.txt", ntohl(id));
     memset(temp, 0, sizeof(temp));
     strncpy(temp, name, 31 - strlen(temp1));
-    strcat(temp, temp1);
+    strlcat(temp, temp1, sizeof(temp));
 
     if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp, bitmap, 0)) {
         test_failed();
     }
 
-    sprintf(temp1, "#0%X.txt", ntohl(id));
+    snprintf(temp1, sizeof(temp1), "#0%X.txt", ntohl(id));
     memset(temp, 0, sizeof(temp));
     strncpy(temp, name, 31 - strlen(temp1));
-    strcat(temp, temp1);
+    strlcat(temp, temp1, sizeof(temp));
 
     if (!FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp, bitmap, 0)) {
         test_failed();
@@ -846,19 +846,19 @@ STATIC void test334()
         test_nottested();
     }
 
-    sprintf(temp1, "#%X", ntohl(id));
+    snprintf(temp1, sizeof(temp1), "#%X", ntohl(id));
     memset(temp, 0, sizeof(temp));
     strncpy(temp, name, 31 - strlen(temp1));
-    strcat(temp, temp1);
+    strlcat(temp, temp1, sizeof(temp));
 
     if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp, bitmap, 0)) {
         test_failed();
     }
 
-    sprintf(temp1, "#%X.", ntohl(id));
+    snprintf(temp1, sizeof(temp1), "#%X.", ntohl(id));
     memset(temp, 0, sizeof(temp));
     strncpy(temp, name, 31 - strlen(temp1));
-    strcat(temp, temp1);
+    strlcat(temp, temp1, sizeof(temp));
 
     if (!FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp, bitmap, 0)) {
         test_failed();
@@ -912,10 +912,10 @@ STATIC void test335()
         test_nottested();
     }
 
-    sprintf(temp1, "#%X.txt", ntohl(id));
+    snprintf(temp1, sizeof(temp1), "#%X.txt", ntohl(id));
     memset(temp, 0, sizeof(temp));
     strncpy(temp, name, 31 - strlen(temp1));
-    strcat(temp, temp1);
+    strlcat(temp, temp1, sizeof(temp));
 
     if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp, bitmap, 0)) {
         test_failed();

--- a/test/testsuite/T2_FPByteRangeLock.c
+++ b/test/testsuite/T2_FPByteRangeLock.c
@@ -62,10 +62,10 @@ static void test_bytelock(uint16_t vol2, char *name, int type)
         FPCloseFork(Conn, fork);
     }
 
-    strcpy(temp, Path);
-    strcat(temp, (type == OPENFORK_RSCS
-                  && adouble == AD_V2) ? "/.AppleDouble/" : "/");
-    strcat(temp, name);
+    strlcpy(temp, Path, sizeof(temp));
+    strlcat(temp, (type == OPENFORK_RSCS
+                   && adouble == AD_V2) ? "/.AppleDouble/" : "/", sizeof(temp));
+    strlcat(temp, name, sizeof(temp));
 
     if (!Quiet) {
         fprintf(stdout, " \n---------------------\n");

--- a/test/testsuite/T2_FPDelete.c
+++ b/test/testsuite/T2_FPDelete.c
@@ -85,7 +85,7 @@ STATIC void test146()
     FAIL(ntohl(AFPERR_BUSY) != FPDelete(Conn2, vol2,  dir, name))
 
     if (adouble == AD_V2) {
-        sprintf(temp, "%s/%s/.AppleDouble/%s", Path, name1, name);
+        snprintf(temp, sizeof(temp), "%s/%s/.AppleDouble/%s", Path, name1, name);
 
         if (chmod(temp, 0644) < 0) {
             if (!Quiet) {
@@ -223,7 +223,7 @@ STATIC void test363()
         afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
     }
 
-    sprintf(temp1, "%s/%s/.AppleDouble/%s", Path, name1, name);
+    snprintf(temp1, sizeof(temp1), "%s/%s/.AppleDouble/%s", Path, name1, name);
 
     if (unlink(temp1) < 0) {
         if (!Quiet) {
@@ -233,7 +233,7 @@ STATIC void test363()
         test_failed();
     }
 
-    sprintf(temp1, "%s/%s/%s", Path, name1, name);
+    snprintf(temp1, sizeof(temp1), "%s/%s/%s", Path, name1, name);
 
     if (unlink(temp1) < 0) {
         if (!Quiet) {

--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -823,10 +823,10 @@ STATIC void test336()
         bitmap = (1 << DIRPBIT_LNAME);
     }
 
-    sprintf(temp1, "#%X", ntohl(id));
+    snprintf(temp1, sizeof(temp1), "#%X", ntohl(id));
     memset(temp, 0, sizeof(temp));
     strncpy(temp, name, 31 - strlen(temp1));
-    strcat(temp, temp1);
+    strlcat(temp, temp1, sizeof(temp));
 
     if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp, 0, bitmap)) {
         test_failed();

--- a/test/testsuite/T2_FPResolveID.c
+++ b/test/testsuite/T2_FPResolveID.c
@@ -46,7 +46,7 @@ STATIC void test129()
     }
 
     if (adouble == AD_V2) {
-        sprintf(temp1, "%s/%s/.AppleDouble/%s", Path, name1, name);
+        snprintf(temp1, sizeof(temp1), "%s/%s/.AppleDouble/%s", Path, name1, name);
 
         if (unlink(temp1) < 0) {
             if (!Quiet) {
@@ -57,7 +57,7 @@ STATIC void test129()
         }
     }
 
-    sprintf(temp1, "%s/%s/%s", Path, name1, name);
+    snprintf(temp1, sizeof(temp1), "%s/%s/%s", Path, name1, name);
 
     if (unlink(temp1) < 0) {
         if (!Quiet) {

--- a/test/testsuite/adoublehelper.c
+++ b/test/testsuite/adoublehelper.c
@@ -18,9 +18,9 @@ int delete_unix_md(char *path, char *name, char *file)
 {
     if (adouble == AD_V2) {
         if (!*file) {
-            sprintf(temp, "%s/%s/.AppleDouble/.Parent", path, name);
+            snprintf(temp, sizeof(temp), "%s/%s/.AppleDouble/.Parent", path, name);
         } else {
-            sprintf(temp, "%s/%s/.AppleDouble/%s", path, name, file);
+            snprintf(temp, sizeof(temp), "%s/%s/.AppleDouble/%s", path, name, file);
         }
 
         if (!Quiet) {
@@ -35,7 +35,7 @@ int delete_unix_md(char *path, char *name, char *file)
             return -1;
         }
     } else {
-        sprintf(temp, "%s/%s/%s", path, name, file);
+        snprintf(temp, sizeof(temp), "%s/%s/%s", path, name, file);
 
         if (sys_lremovexattr(temp, AD_EA_META) != 0) {
             if (!Quiet) {
@@ -57,9 +57,9 @@ int delete_unix_rf(char *path, char *name, char *file)
 {
     if (adouble == AD_V2) {
         if (!*file) {
-            sprintf(temp, "%s/%s/.AppleDouble/.Parent", path, name);
+            snprintf(temp, sizeof(temp), "%s/%s/.AppleDouble/.Parent", path, name);
         } else {
-            sprintf(temp, "%s/%s/.AppleDouble/%s", path, name, file);
+            snprintf(temp, sizeof(temp), "%s/%s/.AppleDouble/%s", path, name, file);
         }
 
         if (!Quiet) {
@@ -77,7 +77,7 @@ int delete_unix_rf(char *path, char *name, char *file)
 #ifdef HAVE_EAFD
 
         if (file) {
-            sprintf(temp, "%s/%s/%s", path, name, file);
+            snprintf(temp, sizeof(temp), "%s/%s/%s", path, name, file);
 
             if (sys_lremovexattr(temp, AD_EA_RESO) != 0) {
                 if (!Quiet) {
@@ -92,7 +92,7 @@ int delete_unix_rf(char *path, char *name, char *file)
 #else
 
         if (file) {
-            sprintf(temp, "%s/%s/._%s", path, name, file);
+            snprintf(temp, sizeof(temp), "%s/%s/._%s", path, name, file);
 
             if (!Quiet) {
                 fprintf(stdout, "unlink(%s)\n", temp);
@@ -124,7 +124,7 @@ int delete_unix_file(char *path, char *name, char *file)
         rc = -1;
     }
 
-    sprintf(temp, "%s/%s/%s", path, name, file);
+    snprintf(temp, sizeof(temp), "%s/%s/%s", path, name, file);
 
     if (!Quiet) {
         fprintf(stdout, "unlink(%s)\n", temp);
@@ -144,8 +144,8 @@ int delete_unix_file(char *path, char *name, char *file)
 /*! Rename a file and its resource fork */
 int rename_unix_file(char *path, char *dir, char *src, char *dst)
 {
-    sprintf(temp, "%s/%s/%s", Path, dir, src);
-    sprintf(temp1, "%s/%s/%s", Path, dir, dst);
+    snprintf(temp, sizeof(temp), "%s/%s/%s", Path, dir, src);
+    snprintf(temp1, sizeof(temp1), "%s/%s/%s", Path, dir, dst);
 
     if (!Quiet) {
         fprintf(stdout, "rename %s %s\n", temp, temp1);
@@ -162,8 +162,8 @@ int rename_unix_file(char *path, char *dir, char *src, char *dst)
     }
 
     if (adouble == AD_V2) {
-        sprintf(temp, "%s/%s/.AppleDouble/%s", Path, dir, src);
-        sprintf(temp1, "%s/%s/.AppleDouble/%s", Path, dir, dst);
+        snprintf(temp, sizeof(temp), "%s/%s/.AppleDouble/%s", Path, dir, src);
+        snprintf(temp1, sizeof(temp1), "%s/%s/.AppleDouble/%s", Path, dir, dst);
 
         if (!Quiet) {
             fprintf(stdout, "rename %s %s\n", temp, temp1);
@@ -180,8 +180,8 @@ int rename_unix_file(char *path, char *dir, char *src, char *dst)
         }
     } else {
 #ifndef HAVE_EAFD
-        sprintf(temp, "%s/%s/._%s", Path, dir, src);
-        sprintf(temp1, "%s/%s/._%s", Path, dir, dst);
+        snprintf(temp, sizeof(temp), "%s/%s/._%s", Path, dir, src);
+        snprintf(temp1, sizeof(temp1), "%s/%s/._%s", Path, dir, dst);
 
         if (!Quiet) {
             fprintf(stdout, "rename %s %s\n", temp, temp1);
@@ -206,7 +206,7 @@ int rename_unix_file(char *path, char *dir, char *src, char *dst)
 /*! unlink file only, dont care about adouble file */
 int unlink_unix_file(char *path, char *name, char *file)
 {
-    sprintf(temp, "%s/%s/%s", path, name, file);
+    snprintf(temp, sizeof(temp), "%s/%s/%s", path, name, file);
 
     if (!Quiet) {
         fprintf(stdout, "unlink(%s)\n", temp);
@@ -227,7 +227,7 @@ int unlink_unix_file(char *path, char *name, char *file)
 /* ----------------------------- */
 int symlink_unix_file(char *target, char *path, char *source)
 {
-    sprintf(temp, "%s/%s", path, source);
+    snprintf(temp, sizeof(temp), "%s/%s", path, source);
 
     if (!Quiet) {
         fprintf(stdout, "symlink(%s -> %s)\n", temp, target);
@@ -250,7 +250,7 @@ int symlink_unix_file(char *target, char *path, char *source)
 int delete_unix_adouble(char *path, char *name)
 {
     if (adouble == AD_EA) {
-        sprintf(temp, "%s/%s", path, name);
+        snprintf(temp, sizeof(temp), "%s/%s", path, name);
         sys_lremovexattr(temp, AD_EA_META);
         sys_lremovexattr(temp, AD_EA_RESO);
     } else {
@@ -258,7 +258,7 @@ int delete_unix_adouble(char *path, char *name)
             fprintf(stdout, "rmdir(%s/.AppleDouble) \n", name);
         }
 
-        sprintf(temp, "%s/%s/.AppleDouble/.Parent", path, name);
+        snprintf(temp, sizeof(temp), "%s/%s/.AppleDouble/.Parent", path, name);
 
         if (unlink(temp) < 0) {
             if (!Quiet) {
@@ -269,7 +269,7 @@ int delete_unix_adouble(char *path, char *name)
             return -1;
         }
 
-        sprintf(temp, "%s/%s/.AppleDouble", path, name);
+        snprintf(temp, sizeof(temp), "%s/%s/.AppleDouble", path, name);
 
         if (rmdir(temp) < 0) {
             if (!Quiet) {
@@ -291,7 +291,7 @@ static int chmod_unix_adouble(char *path, char *name, int mode)
         return 0;
     }
 
-    sprintf(temp, "%s/%s/.AppleDouble", path, name);
+    snprintf(temp, sizeof(temp), "%s/%s/.AppleDouble", path, name);
 
     if (!Quiet) {
         fprintf(stdout, "chmod (%s, %o)\n", temp, mode);
@@ -315,8 +315,8 @@ int chmod_unix_meta(char *path, char *name, char *file, mode_t mode)
 {
     if (adouble == AD_EA) {
 #if defined (HAVE_EAFD) && defined (SOLARIS)
-        sprintf(temp, "runat '%s/%s/%s' chmod 0%o %s", path, name, file, mode,
-                AD_EA_META);
+        snprintf(temp, sizeof(temp), "runat '%s/%s/%s' chmod 0%o %s", path, name, file,
+                 mode, AD_EA_META);
 
         if (!Quiet) {
             fprintf(stdout, "%s\n", temp);
@@ -336,7 +336,7 @@ int chmod_unix_meta(char *path, char *name, char *file, mode_t mode)
         return 0;
 #endif
     } else {
-        sprintf(temp, "%s/%s/.AppleDouble/%s", path, name, file);
+        snprintf(temp, sizeof(temp), "%s/%s/.AppleDouble/%s", path, name, file);
 
         if (!Quiet) {
             fprintf(stdout, "chmod (%s, 0%o)\n", temp, mode);
@@ -361,8 +361,8 @@ int chmod_unix_rfork(char *path, char *name, char *file, mode_t mode)
 {
     if (adouble == AD_EA) {
 #if defined (HAVE_EAFD) && defined (SOLARIS)
-        sprintf(temp, "runat '%s/%s/%s' chmod 0%o %s", path, name, file, mode,
-                AD_EA_RESO);
+        snprintf(temp, sizeof(temp), "runat '%s/%s/%s' chmod 0%o %s", path, name, file,
+                 mode, AD_EA_RESO);
 
         if (!Quiet) {
             fprintf(stdout, "%s\n", temp);
@@ -380,7 +380,7 @@ int chmod_unix_rfork(char *path, char *name, char *file, mode_t mode)
         return 0;
 #else
 #ifndef __APPLE__
-        sprintf(temp, "%s/%s/._%s", path, name, file);
+        snprintf(temp, sizeof(temp), "%s/%s/._%s", path, name, file);
 
         if (!Quiet) {
             fprintf(stdout, "chmod(%s, 0%o)\n", temp, mode);
@@ -399,7 +399,7 @@ int chmod_unix_rfork(char *path, char *name, char *file, mode_t mode)
         return 0;
 #endif
     } else {
-        sprintf(temp, "%s/%s/.AppleDouble/%s", path, name, file);
+        snprintf(temp, sizeof(temp), "%s/%s/.AppleDouble/%s", path, name, file);
 
         if (!Quiet) {
             fprintf(stdout, "chmod (%s, 0%o)\n", temp, mode);
@@ -432,7 +432,7 @@ int delete_unix_dir(char *path, char *name)
             return -1;
         }
 
-    sprintf(temp, "%s/%s", path, name);
+    snprintf(temp, sizeof(temp), "%s/%s", path, name);
 
     if (rmdir(temp) < 0) {
         if (!Quiet) {

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -813,62 +813,74 @@ static char *bitmap2text(unsigned int bitmap)
     temp[0] = 0;
 
     if (BITERR_NOOBJ & bitmap) {
-        sprintf(temp, "%d %s ", AFPERR_NOOBJ, afp_error(htonl(AFPERR_NOOBJ)));
+        snprintf(temp, sizeof(temp), "%d %s ", AFPERR_NOOBJ,
+                 afp_error(htonl(AFPERR_NOOBJ)));
     }
 
     if (BITERR_NODIR & bitmap) {
-        sprintf(temp1, "%d %s ", AFPERR_NODIR, afp_error(htonl(AFPERR_NODIR)));
-        strcat(temp, temp1);
+        snprintf(temp1, sizeof(temp1), "%d %s ", AFPERR_NODIR,
+                 afp_error(htonl(AFPERR_NODIR)));
+        strlcat(temp, temp1, sizeof(temp));
     }
 
     if (BITERR_PARAM & bitmap) {
-        sprintf(temp1, "%d %s ", AFPERR_PARAM, afp_error(htonl(AFPERR_PARAM)));
-        strcat(temp, temp1);
+        snprintf(temp1, sizeof(temp1), "%d %s ", AFPERR_PARAM,
+                 afp_error(htonl(AFPERR_PARAM)));
+        strlcat(temp, temp1, sizeof(temp));
     }
 
     if (BITERR_BUSY & bitmap) {
-        sprintf(temp1, "%d %s ", AFPERR_BUSY, afp_error(htonl(AFPERR_BUSY)));
-        strcat(temp, temp1);
+        snprintf(temp1, sizeof(temp1), "%d %s ", AFPERR_BUSY,
+                 afp_error(htonl(AFPERR_BUSY)));
+        strlcat(temp, temp1, sizeof(temp));
     }
 
     if (BITERR_BADTYPE & bitmap) {
-        sprintf(temp1, "%d %s ", AFPERR_BADTYPE, afp_error(htonl(AFPERR_BADTYPE)));
-        strcat(temp, temp1);
+        snprintf(temp1, sizeof(temp1), "%d %s ", AFPERR_BADTYPE,
+                 afp_error(htonl(AFPERR_BADTYPE)));
+        strlcat(temp, temp1, sizeof(temp));
     }
 
     if (BITERR_NOITEM & bitmap) {
-        sprintf(temp1, "%d %s ", AFPERR_NOITEM, afp_error(htonl(AFPERR_NOITEM)));
-        strcat(temp, temp1);
+        snprintf(temp1, sizeof(temp1), "%d %s ", AFPERR_NOITEM,
+                 afp_error(htonl(AFPERR_NOITEM)));
+        strlcat(temp, temp1, sizeof(temp));
     }
 
     if (BITERR_DENYCONF & bitmap) {
-        sprintf(temp1, "%d %s ", AFPERR_DENYCONF, afp_error(htonl(AFPERR_DENYCONF)));
-        strcat(temp, temp1);
+        snprintf(temp1, sizeof(temp1), "%d %s ", AFPERR_DENYCONF,
+                 afp_error(htonl(AFPERR_DENYCONF)));
+        strlcat(temp, temp1, sizeof(temp));
     }
 
     if (BITERR_NFILE & bitmap) {
-        sprintf(temp1, "%d %s ", AFPERR_NFILE, afp_error(htonl(AFPERR_NFILE)));
-        strcat(temp, temp1);
+        snprintf(temp1, sizeof(temp1), "%d %s ", AFPERR_NFILE,
+                 afp_error(htonl(AFPERR_NFILE)));
+        strlcat(temp, temp1, sizeof(temp));
     }
 
     if (BITERR_ACCESS & bitmap) {
-        sprintf(temp1, "%d %s ", AFPERR_ACCESS, afp_error(htonl(AFPERR_ACCESS)));
-        strcat(temp, temp1);
+        snprintf(temp1, sizeof(temp1), "%d %s ", AFPERR_ACCESS,
+                 afp_error(htonl(AFPERR_ACCESS)));
+        strlcat(temp, temp1, sizeof(temp));
     }
 
     if (BITERR_NOID & bitmap) {
-        sprintf(temp1, "%d %s ", AFPERR_NOID, afp_error(htonl(AFPERR_NOID)));
-        strcat(temp, temp1);
+        snprintf(temp1, sizeof(temp1), "%d %s ", AFPERR_NOID,
+                 afp_error(htonl(AFPERR_NOID)));
+        strlcat(temp, temp1, sizeof(temp));
     }
 
     if (BITERR_BITMAP & bitmap) {
-        sprintf(temp1, "%d %s ", AFPERR_BITMAP, afp_error(htonl(AFPERR_BITMAP)));
-        strcat(temp, temp1);
+        snprintf(temp1, sizeof(temp1), "%d %s ", AFPERR_BITMAP,
+                 afp_error(htonl(AFPERR_BITMAP)));
+        strlcat(temp, temp1, sizeof(temp));
     }
 
     if (BITERR_MISC & bitmap) {
-        sprintf(temp1, "%d %s ", AFPERR_MISC, afp_error(htonl(AFPERR_MISC)));
-        strcat(temp, temp1);
+        snprintf(temp1, sizeof(temp1), "%d %s ", AFPERR_MISC,
+                 afp_error(htonl(AFPERR_MISC)));
+        strlcat(temp, temp1, sizeof(temp));
     }
 
     return temp;

--- a/test/testsuite/encoding_test.c
+++ b/test/testsuite/encoding_test.c
@@ -86,7 +86,7 @@ STATIC void test_western()
 
     if (Path[0] != '\0') {
         int fd;
-        sprintf(temp, "%s/:test", Path);
+        snprintf(temp, sizeof(temp), "%s/:test", Path);
         fd = open(temp, O_RDWR | O_CREAT, 0666);
 
         if (fd < 0) {

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -805,7 +805,7 @@ void Write(void)
     reset_statistics();
     print_test_header("Write");
     header();
-    sprintf(temp, "WriteTest-%d", id);
+    snprintf(temp, sizeof(temp), "WriteTest-%d", id);
 
     if (check_test_dir_exists(vol, temp, "Write")) {
         return;
@@ -1030,7 +1030,7 @@ void Copy(void)
     reset_statistics();
     print_test_header("Copy");
     header();
-    sprintf(temp, "CopyTest-%d", id);
+    snprintf(temp, sizeof(temp), "CopyTest-%d", id);
 
     if (!Filename) {
         if (check_test_dir_exists(vol, temp, "Copy")) {
@@ -1064,14 +1064,14 @@ void Copy(void)
     }
 
     if (!Filename) {
-        strcpy(temp, "Source");
+        strlcpy(temp, "Source", sizeof(temp));
 
         if (VFS.createfile(Conn, vol, 0, dir, temp)) {
             test_failed();
             goto fin;
         }
     } else {
-        strcpy(temp, Filename);
+        strlcpy(temp, Filename, sizeof(temp));
     }
 
     if (VFS.createfile(Conn, vol2,  0, dir2, "Destination")) {
@@ -1317,7 +1317,7 @@ void ServerCopy(void)
     reset_statistics();
     print_test_header("ServerCopy");
     header();
-    sprintf(temp, "ServerCopyTest-%d", id);
+    snprintf(temp, sizeof(temp), "ServerCopyTest-%d", id);
 
     if (check_test_dir_exists(vol, temp, "ServerCopy")) {
         return;
@@ -1453,7 +1453,7 @@ void Read(void)
     header();
 
     if (!Filename) {
-        sprintf(temp, "ReadTest-%d", id);
+        snprintf(temp, sizeof(temp), "ReadTest-%d", id);
 
         if (check_test_dir_exists(vol, temp, "Read")) {
             return;
@@ -1471,10 +1471,10 @@ void Read(void)
             goto fin;
         }
 
-        strcpy(temp, "File");
+        strlcpy(temp, "File", sizeof(temp));
     } else {
         dir = DIRDID_ROOT;
-        strcpy(temp, Filename);
+        strlcpy(temp, Filename, sizeof(temp));
 
         if (ntohl(AFP_OK) != is_there(Conn, VolID, dir, temp)) {
             test_nottested();


### PR DESCRIPTION
Buffer safety in production code:

- mangle(): sprintf -> snprintf with sizeof(mangle_suffix); strcat ->
  strlcat(m, ..., MAXPATHLEN) for the mangle suffix and fallback "???"
- quota/getquota(): malloc+strcpy pairs replaced with strdup(); sprintf
  for the NFS quotas path replaced with snprintf(buf, sizeof(buf), ...)
- messages/readmessage(): malloc size captured in filenamelen, both
  sprintf calls replaced with snprintf(filename, filenamelen, ...)
- nad/ftw: strcpy in mystpcpy (already bounds-checked) -> strlcpy
- appl/afp_addappl and afp_rmvappl: strcpy(obj->oldtmp, dtf) ->
  strlcpy(..., AFPOBJ_TMPSIZ)
- desktop/setdeskmode and setdeskowner: strcpy/strcat into modbuf[13] ->
  strlcpy/strlcat with sizeof(modbuf)
- desktop/dtfile: strcat(path, ext) -> strlcat(..., sizeof(path))
- desktop/mtoupath: strcpy(upath, ".") -> strlcpy(..., sizeof(upath))

Test code brought to the same standard:

- afpfunc_helpers/cnamewrap: strcpy -> strlcpy(p, name, sizeof(buf)-len)
- afphelper/bitmap2text: all sprintf+strcat pairs -> snprintf+strlcat
- speedtest Write/Copy/ServerCopy/Read: sprintf -> snprintf, strcpy ->
  strlcpy, all with sizeof(temp)
- T2_FPByteRangeLock/test_bytelock: strcpy/strcat chain -> strlcpy/strlcat
- subtests/test001_add_x_dirs: sprintf -> snprintf
- T2_FPResolveID/test129: sprintf -> snprintf
- T2_FPGetFileDirParms/test336: sprintf -> snprintf;
  strcat -> strlcat(..., sizeof(temp))

----

afpd: use full appl buffer size AFPOBJ_TMPSIZ+1 in strlcpy

oldtmp is declared as char oldtmp[AFPOBJ_TMPSIZ + 1], but both strlcpy calls were passing AFPOBJ_TMPSIZ as the size limit, causing a path of exactly MAXPATHLEN bytes to be silently truncated and potentially directing open()/rename() at the wrong temp file.

----

afpd: messages MAXPATHLEN+1 stack buffer for message filename

sizeof(SERVERTEXT) + 15 left only six bytes for the PID decimal representation; a pid_t can require up to ten digits, causing snprintf to truncate and unlink() to operate on the wrong path.

Replace the dynamically-allocated buffer with a stack-local char filename[MAXPATHLEN + 1] and use sizeof(filename) in both snprintf calls, which also eliminates the malloc/free pair.

----

testsuite: fix afp helper length/data mismatch in cnamewrap

The advertised path length was taken from strlen(name) before strlcpy could truncate, producing a malformed AFP request where the uint16_t length field claimed more bytes than were actually present in the buffer.

AFP 3 (UTF-8) paths are length-prefixed, not null-terminated, so strlcpy was also the wrong primitive. Fix by:
- computing the available space after the length field header up front
- clamping namelen to that space before encoding it into the uint16_t field
- using memcpy to write exactly namelen bytes, keeping length and data
  in sync regardless of the input size

----

afpd,testsuite: replace unsafe strcpy/sprintf with bounded equivalents

Replace remaining sprintf/strcpy/strcat calls flagged by the OpenBSD linker with snprintf/strlcpy/strlcat/memcpy throughout afpd and the test suite. Key fixes beyond mechanical substitution:

- appl.c afp_addappl/afp_rmvappl: guard against NULL return from
  dtfile() before passing dtf to strlcpy; rmvappl also closes sdt_fd
  on this new error path to match existing cleanup
- file.c set_name: save strlen(name) into tp_len at the strdup site
  so the restore memcpy uses tp_len+1 instead of a redundant strlen
- filedir.c afp_moveandrename: strcpy(newname, oldname) -> strlcpy with
  AFPOBJ_TMPSIZ+1, matching the size used for the same buffers nearby
- T2_FPDelete.c: all sprintf(temp/temp1, ...) -> snprintf with sizeof