### PR TITLE
afpd: fix connection limit off-by-one condition

### DIFF
--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -276,7 +276,7 @@ static int login(AFPObj *obj, struct passwd *pwd, void (*logout)(void),
         return AFPERR_NOTAUTH;
     }
 
-    if (obj->cnx_cnt > obj->cnx_max) {
+    if (obj->cnx_cnt >= obj->cnx_max) {
         LOG(log_error, logtype_dsi, "login: too many connections, limit: %d",
             obj->cnx_max);
         return AFPERR_MAXSESS;


### PR DESCRIPTION
The previous condition allowed one more connection than configured: f.e. 201 for the default 200

cnx_cnt is captured in the child at fork time, before the parent calls server_child_add — so it counts existing connections, not including the current one. The > check introduced in an earlier commit assumed cnx_cnt already included the current connection and over-corrected, allowing one connection beyond the configured limit. Restore >= so the limit is enforced as configured.