### PR TITLE
post-security patching improvements and bug fixes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,44 @@ That said, we will try to take action on your report as soon as possible!
 
 | CVE ID | Subject | Disclosure Date | Affected Versions | Fixed Versions |
 |--------|---------|-----------------|-------------------|----------------|
+| [CVE-2026-45699](https://netatalk.io/security/CVE-2026-45699.html) | Stack-based buffer overflow in copydir() | 2026/05/13 | 3.2.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-45698](https://netatalk.io/security/CVE-2026-45698.html) | Stack-based buffer overflow in deletedir() | 2026/05/13 | 3.2.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-45356](https://netatalk.io/security/CVE-2026-45356.html) | Integer underflow in Spotlight RPC count decrement | 2026/05/13 | 3.1.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-45355](https://netatalk.io/security/CVE-2026-45355.html) | Integer underflow to heap OOB read | 2026/05/13 | 3.1.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-45354](https://netatalk.io/security/CVE-2026-45354.html) | Pre-authentication DSI protocol desync | 2026/05/13 | 1.5.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44076](https://netatalk.io/security/CVE-2026-44076.html) | Shell injection via volume path | 2026/05/13 | 3.1.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44075](https://netatalk.io/security/CVE-2026-44075.html) | Missing break in DSI OpenSession | 2026/05/13 | 1.5.0 - 4.4.2 | 4.5.0 |
+| [CVE-2026-44074](https://netatalk.io/security/CVE-2026-44074.html) | Bitwise OR of errno values | 2026/05/13 | 2.1.0 - 4.4.2 | 4.5.0 |
+| [CVE-2026-44073](https://netatalk.io/security/CVE-2026-44073.html) | seteuid failure ignored in auth modules | 2026/05/13 | 1.5.0 - 4.4.2 | 4.5.0 |
+| [CVE-2026-44072](https://netatalk.io/security/CVE-2026-44072.html) | system() after failed chdir() | 2026/05/13 | 2.2.1 - 4.4.2 | 4.5.0 |
+| [CVE-2026-44071](https://netatalk.io/security/CVE-2026-44071.html) | FORTIFY_SOURCE disabled | 2026/05/13 | 3.1.2 - 4.4.2 | 4.5.0 |
+| [CVE-2026-44070](https://netatalk.io/security/CVE-2026-44070.html) | Unbounded realloc in charset conversion | 2026/05/13 | 2.0.0 - 4.4.2 | 4.5.0 |
+| [CVE-2026-44069](https://netatalk.io/security/CVE-2026-44069.html) | Integer underflow in volxlate | 2026/05/13 | 3.0.0 - 4.4.2 | 4.5.0 |
+| [CVE-2026-44068](https://netatalk.io/security/CVE-2026-44068.html) | EA path traversal via incomplete sanitization | 2026/05/13 | 2.1.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44067](https://netatalk.io/security/CVE-2026-44067.html) | EA header parsing heap over-read | 2026/05/13 | 2.1.0 - 4.4.2 | 4.5.0 |
+| [CVE-2026-44066](https://netatalk.io/security/CVE-2026-44066.html) | Heap out-of-bounds reads in Spotlight RPC unmarshalling | 2026/05/13 | 3.0.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44065](https://netatalk.io/security/CVE-2026-44065.html) | Off-by-two in papd lp_write() | 2026/05/13 | 2.0.0 - 4.4.2 | 4.5.0 |
+| [CVE-2026-44064](https://netatalk.io/security/CVE-2026-44064.html) | ASP session ID out-of-bounds access | 2026/05/13 | 1.3 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44063](https://netatalk.io/security/CVE-2026-44063.html) | LDAP filter injection | 2026/05/13 | 2.1.0 - 4.4.2 | 4.5.0 |
+| [CVE-2026-44062](https://netatalk.io/security/CVE-2026-44062.html) | Missing o_len bounds check in pull_charset_flags() | 2026/05/13 | 2.0.4 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44061](https://netatalk.io/security/CVE-2026-44061.html) | DES-ECB auth with timing side channel | 2026/05/13 | 1.5.0 - 4.4.2 | 4.5.0 |
+| [CVE-2026-44060](https://netatalk.io/security/CVE-2026-44060.html) | Integer underflow in dsi_writeinit() leads to denial of service | 2026/05/13 | 1.5.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44059](https://netatalk.io/security/CVE-2026-44059.html) | Non-reentrant privilege toggle | 2026/05/13 | 2.2.5 - 4.4.2 | 4.5.0 |
+| [CVE-2026-44058](https://netatalk.io/security/CVE-2026-44058.html) | Authentication bypass via admin auth user | 2026/05/13 | 2.2.2 - 4.4.2 | 4.5.0 |
+| [CVE-2026-44057](https://netatalk.io/security/CVE-2026-44057.html) | Dead bounds check in Spotlight RPC unmarshaller | 2026/05/13 | 3.0.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44056](https://netatalk.io/security/CVE-2026-44056.html) | Stack buffer overflow in desktop.c | 2026/05/13 | 1.3 - 4.2.2 | 4.5.0 |
+| [CVE-2026-44055](https://netatalk.io/security/CVE-2026-44055.html) | Bitwise OR logic bug enables shell injection | 2026/05/13 | 3.1.4 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44054](https://netatalk.io/security/CVE-2026-44054.html) | Predictable afpd session token | 2026/05/13 | 2.0.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44053](https://netatalk.io/security/CVE-2026-44053.html) | Weak cryptography in DHCAST128 UAM | 2026/05/13 | 1.5.0 - 4.2.2 | 4.5.0 |
+| [CVE-2026-44052](https://netatalk.io/security/CVE-2026-44052.html) | LDAP simple-bind password exposure in log output | 2026/05/13 | 2.1.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44051](https://netatalk.io/security/CVE-2026-44051.html) | Arbitrary file read via attacker-controlled symlink creation | 2026/05/13 | 3.0.2 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44050](https://netatalk.io/security/CVE-2026-44050.html) | Heap buffer overflow in CNID daemon comm_rcv() | 2026/05/13 | 2.0.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44049](https://netatalk.io/security/CVE-2026-44049.html) | Out-of-bounds write in convert_charset() null termination | 2026/05/13 | 2.0.4 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44048](https://netatalk.io/security/CVE-2026-44048.html) | Stack buffer overflow via UCS-2 type confusion in convert_charset() | 2026/05/13 | 2.0.4 - 4.4.2 | 4.4.3 |
+| [CVE-2026-44047](https://netatalk.io/security/CVE-2026-44047.html) | SQL injection in MySQL CNID backend | 2026/05/13 | 3.1.0 - 4.4.2 | 4.4.3 |
+| [CVE-2026-7837](https://netatalk.io/security/CVE-2026-7837.html)   | TOCTOU with root privilege in ad_flush | 2026/05/13 | 3.0.0 - 4.4.2 | 4.5.0 |
+| [CVE-2026-7836](https://netatalk.io/security/CVE-2026-7836.html)   | hextoint macro uppercase bug | 2026/05/13 | 2.0.0 - 4.4.2 | 4.5.0 |
+| [CVE-2026-7835](https://netatalk.io/security/CVE-2026-7835.html)   | Format string argument mismatch | 2026/05/13 | 3.0.3 - 4.4.2 | 4.5.0 |
 | [CVE-2024-38441](https://netatalk.io/security/CVE-2024-38441.html) | Heap out-of-bounds write in directory.c  | 2024/06/28   | 2.0.0 - 2.4.0, 3.0.0 - 3.1.18, 3.2.0  | 2.4.1, 3.1.19, 3.2.1 |
 | [CVE-2024-38440](https://netatalk.io/security/CVE-2024-38440.html) | Heap out-of-bounds write in uams_dhx_pam.c | 2024/06/28 | 1.5.0 - 2.4.0, 3.0.0 - 3.1.18, 3.2.0| 2.4.1, 3.1.19, 3.2.1 |
 | [CVE-2024-38439](https://netatalk.io/security/CVE-2024-38439.html) | Heap out-of-bounds write in uams_pam.c   | 2024/06/28   | 1.5.0 - 2.4.0, 3.0.0 - 3.1.18, 3.2.0| 2.4.1, 3.1.19, 3.2.1 |

--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -687,7 +687,6 @@ static int logincont2(void *obj_in, struct passwd **uam_pwd,
 
         LOG(log_info, logtype_uams, "DHX2: PAM_Error: %s", pam_strerror(pamh,
                 PAM_error));
-
         goto error_ctx;
     }
 

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -355,35 +355,6 @@ static int randpass(const struct passwd *pwd, const char *file,
     uid_t uid = geteuid();
     i = strlen(file);
 
-    if (*file == '~') {
-        char path[MAXPATHLEN + 1];
-
-        if ((strlen(pwd->pw_dir) + i - 1) > MAXPATHLEN) {
-            return AFPERR_PARAM;
-        }
-
-        strcpy(path,  pwd->pw_dir);
-        strcat(path, "/");
-        strcat(path, file + 2);
-
-        /* change ourselves to the user */
-        if (!uid && (seteuid(pwd->pw_uid) < 0)) {
-            LOG(log_error, logtype_uams, "seteuid(%i) failed (%s)", pwd->pw_uid,
-                strerror(errno));
-            return AFPERR_MISC;
-        }
-
-        i = home_passwd(pwd, path, i, passwd, len, set);
-
-        /* change ourselves back to root */
-        if (!uid && (seteuid(0) < 0)) {
-            LOG(log_error, logtype_uams, "seteuid(%i) failed (%s)", 0, strerror(errno));
-            return AFPERR_MISC;
-        }
-
-        return i;
-    }
-
     if (i > MAXPATHLEN) {
         return AFPERR_PARAM;
     }

--- a/libatalk/acl/ldap.c
+++ b/libatalk/acl/ldap.c
@@ -358,17 +358,6 @@ static char *gen_uuid_filter(const char *uuidstr_in, const char *attr_filter)
  * Interface
  ********************************************************/
 
-/*!
- * @brief Search UUID for name in LDAP
- *
- * Caller must free uuid_string when done with it
- *
- * @param[in] name          name to search
- * @param[in] type          type of USER or GROUP
- * @param[out] uuid_string  result as pointer to allocated UUID-string
- *
- * @returns 0 on success, -1 on error or not found
- */
 /* Escape a string for use in an LDAP filter per RFC 4515. */
 static int ldap_escape_filter_value(const char *src, char *dst, size_t dstlen)
 {
@@ -397,6 +386,17 @@ static int ldap_escape_filter_value(const char *src, char *dst, size_t dstlen)
     return 0;
 }
 
+/*!
+ * @brief Search UUID for name in LDAP
+ *
+ * Caller must free uuid_string when done with it
+ *
+ * @param[in] name          name to search
+ * @param[in] type          type of USER or GROUP
+ * @param[out] uuid_string  result as pointer to allocated UUID-string
+ *
+ * @returns 0 on success, -1 on error or not found
+ */
 int ldap_getuuidfromname(const char *name, uuidtype_t type, char **uuid_string)
 {
     int ret;

--- a/libatalk/util/server_child.c
+++ b/libatalk/util/server_child.c
@@ -32,6 +32,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <atalk/compat.h>
 #include <atalk/errchk.h>
 #include <atalk/logger.h>
 #include <atalk/server_child.h>
@@ -192,7 +193,8 @@ int server_child_remove(server_child_t *children, pid_t pid)
     }
 
     if (child->afpch_sessiontoken) {
-        memset(child->afpch_sessiontoken, 0, child->afpch_sessiontoken_len);
+        explicit_bzero(child->afpch_sessiontoken,
+                       child->afpch_sessiontoken_len);
         free(child->afpch_sessiontoken);
         child->afpch_sessiontoken = NULL;
     }
@@ -248,7 +250,8 @@ void server_child_free(server_child_t *children)
             }
 
             if (child->afpch_sessiontoken) {
-                memset(child->afpch_sessiontoken, 0, child->afpch_sessiontoken_len);
+                explicit_bzero(child->afpch_sessiontoken,
+                               child->afpch_sessiontoken_len);
                 free(child->afpch_sessiontoken);
             }
 
@@ -340,7 +343,8 @@ int server_child_set_session_token(server_child_t *children, pid_t pid,
     }
 
     if (child->afpch_sessiontoken) {
-        memset(child->afpch_sessiontoken, 0, child->afpch_sessiontoken_len);
+        explicit_bzero(child->afpch_sessiontoken,
+                       child->afpch_sessiontoken_len);
         free(child->afpch_sessiontoken);
     }
 
@@ -353,7 +357,7 @@ EC_CLEANUP:
 #endif
 
     if (sessiontoken) {
-        memset(sessiontoken, 0, token_len);
+        explicit_bzero(sessiontoken, token_len);
         free(sessiontoken);
     }
 

--- a/test/testsuite/FPMoveAndRename.c
+++ b/test/testsuite/FPMoveAndRename.c
@@ -1,8 +1,17 @@
 /* ----------------------------------------------
 */
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/param.h>
+
+#include <atalk/compat.h>
+
 #include "afpcmd.h"
 #include "afphelper.h"
 #include "testhelper.h"
+
+#define TESTSUITE_NAME_MAX 255
 
 /* ------------------------- */
 STATIC void test43()
@@ -385,25 +394,140 @@ test_exit:
     exit_test("FPMoveAndRename:test378: dest file exist but diff only by case, is this one OK");
 }
 
-#define DEEP_TREE_DEPTH 20
+#define DEEP_TREE_TARGET_COMPONENT_LEN 200
+#define DEEP_TREE_DEFAULT_VOLUME_PREFIX_LEN 26
+#define DEEP_TREE_LEAF_NAME "testfile"
+
+struct test460_tree_plan {
+    int depth;
+    size_t component_len;
+};
+
+static size_t test460_volume_prefix_len(void)
+{
+    size_t len;
+
+    if (!Path || Path[0] == '\0') {
+        return DEEP_TREE_DEFAULT_VOLUME_PREFIX_LEN;
+    }
+
+    len = strnlen(Path, MAXPATHLEN);
+
+    if (len == MAXPATHLEN) {
+        return MAXPATHLEN;
+    }
+
+    return len + (Path[len - 1] == '/' ? 0 : 1);
+}
+
+static int test460_component_len(const char *name, size_t *len)
+{
+    if (!name || !len) {
+        return -1;
+    }
+
+    *len = strnlen(name, TESTSUITE_NAME_MAX + 1);
+
+    if (*len > TESTSUITE_NAME_MAX) {
+        return -1;
+    }
+
+    return 0;
+}
+
+static int test460_tree_plan(const char *toplevel, const char *dst_renamed,
+                             const char *leaf_name,
+                             struct test460_tree_plan *plan)
+{
+    size_t max_path = MAXPATHLEN - 1;
+    size_t prefix_len = test460_volume_prefix_len();
+    size_t toplevel_len;
+    size_t dst_renamed_len;
+    size_t rename_delta;
+    size_t leaf_name_len;
+    size_t leaf_len;
+    size_t fixed_len;
+    size_t max_depth;
+    size_t best_score = (size_t) -1;
+    memset(plan, 0, sizeof(*plan));
+
+    if (test460_component_len(toplevel, &toplevel_len) < 0
+            || test460_component_len(dst_renamed, &dst_renamed_len) < 0
+            || test460_component_len(leaf_name, &leaf_name_len) < 0) {
+        return -1;
+    }
+
+    if (dst_renamed_len <= toplevel_len) {
+        return -1;
+    }
+
+    rename_delta = dst_renamed_len - toplevel_len;
+    leaf_len = leaf_name_len + 1; /* slash + leaf */
+
+    if (prefix_len > max_path || toplevel_len > max_path - prefix_len
+            || leaf_len > max_path - prefix_len - toplevel_len) {
+        return -1;
+    }
+
+    fixed_len = prefix_len + toplevel_len + leaf_len;
+    max_depth = (max_path - fixed_len) / 2; /* slash + at least one char */
+
+    for (int depth = 1; (size_t)depth <= max_depth; depth++) {
+        for (size_t component_len = 1; component_len <= TESTSUITE_NAME_MAX;
+                component_len++) {
+            size_t full_len = fixed_len + (size_t)depth * (component_len + 1);
+            size_t score;
+
+            if (full_len > max_path || full_len + rename_delta <= max_path) {
+                continue;
+            }
+
+            score = component_len > DEEP_TREE_TARGET_COMPONENT_LEN
+                    ? component_len - DEEP_TREE_TARGET_COMPONENT_LEN
+                    : DEEP_TREE_TARGET_COMPONENT_LEN - component_len;
+
+            if (score < best_score
+                    || (score == best_score && depth > plan->depth)) {
+                plan->depth = depth;
+                plan->component_len = component_len;
+                best_score = score;
+            }
+        }
+    }
+
+    return plan->depth > 0 ? 0 : -1;
+}
 
 /* ------------------------- */
 STATIC void test460()
 {
     uint16_t vol = VolID;
-    int dirs[DEEP_TREE_DEPTH + 1];
+    int *dirs = NULL;
+    struct test460_tree_plan plan;
     int ret;
-    int i;
     char *toplevel    = "t_cdov";         /* 6-char root dir */
     char *dst_renamed =
-        "t_cdov_renamed"; /* 14-char dest; dpath is 10 chars shorter than spath */
-    char  sub_name[201];
+        "t_cdov_renamed";
+    char  sub_name[TESTSUITE_NAME_MAX + 1];
     ENTER_TEST
-    memset(dirs, 0, sizeof(dirs));
+
+    if (test460_tree_plan(toplevel, dst_renamed, DEEP_TREE_LEAF_NAME,
+                          &plan) < 0) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    dirs = calloc((size_t)plan.depth + 1, sizeof(*dirs));
+
+    if (!dirs) {
+        test_nottested();
+        goto test_exit;
+    }
+
     /*
-     * Build a DEEP_TREE_DEPTH-level tree.  At level 20 (Linux MAXPATHLEN=4096):
-     *   spath actual rem = 51 bytes → overflow by 204 bytes
-     *   dpath actual rem = 61 bytes → overflow by 194 bytes
+     * Build a tree whose leaf still fits in this platform's MAXPATHLEN,
+     * including the local volume path when known, but whose leaf would exceed
+     * that limit after renaming the top-level directory.
      */
     dirs[0] = FPCreateDir(Conn, vol, DIRDID_ROOT, toplevel);
 
@@ -412,9 +536,9 @@ STATIC void test460()
         goto test_exit;
     }
 
-    for (i = 1; i <= DEEP_TREE_DEPTH; i++) {
-        memset(sub_name, 'a' + (i - 1), 200);
-        sub_name[200] = '\0';
+    for (int i = 1; i <= plan.depth; i++) {
+        memset(sub_name, 'a' + ((i - 1) % 26), plan.component_len);
+        sub_name[plan.component_len] = '\0';
         dirs[i] = FPCreateDir(Conn, vol, dirs[i - 1], sub_name);
 
         if (!dirs[i]) {
@@ -423,7 +547,7 @@ STATIC void test460()
         }
     }
 
-    if (FPCreateFile(Conn, vol, 0, dirs[DEEP_TREE_DEPTH], "testfile")) {
+    if (FPCreateFile(Conn, vol, 0, dirs[plan.depth], DEEP_TREE_LEAF_NAME)) {
         test_nottested();
         goto cleanup;
     }
@@ -448,11 +572,12 @@ STATIC void test460()
 
 cleanup:
 
-    if (dirs[0]) {
+    if (dirs && dirs[0]) {
         delete_directory_tree(Conn, vol, DIRDID_ROOT, toplevel);
     }
 
 test_exit:
+    free(dirs);
     exit_test("FPMoveAndRename:test460: deeply nested rename with path overflow");
 }
 

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -1,6 +1,7 @@
 /* ----------------------------------------------
 */
 
+#include <limits.h>
 #include <signal.h>
 #include <stdarg.h>
 

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -1,15 +1,19 @@
 /* ----------------------------------------------
 */
 
-#include <limits.h>
 #include <signal.h>
 #include <stdarg.h>
+#include <stdlib.h>
+
+#include <atalk/compat.h>
 
 #include "afpclient.h"
 #include "afphelper.h"
 #include "afpcmd.h"
 #include "afphelper.h"
 #include "testhelper.h"
+
+#define AFPHELPER_NAME_MAX 255
 
 int Loglevel = AFP_LOG_INFO;
 
@@ -951,73 +955,84 @@ int32_t is_there(CONN *conn, uint16_t volume, int32_t did, char *name)
                              );
 }
 
+static int copy_filedir_name(char *dst, size_t dstlen,
+                             const struct afp_filedir_parms *filedir)
+{
+    const char *name;
+
+    if (dstlen == 0) {
+        return -1;
+    }
+
+    name = filedir->utf8_name ? filedir->utf8_name : filedir->lname;
+
+    if (!name || name[0] == '\0') {
+        dst[0] = '\0';
+        return -1;
+    }
+
+    if (strlcpy(dst, name, dstlen) >= dstlen) {
+        dst[0] = '\0';
+        return -1;
+    }
+
+    return 0;
+}
+
+static void free_filedir_names(struct afp_filedir_parms *filedir)
+{
+    free(filedir->lname);
+    free(filedir->sname);
+    free(filedir->utf8_name);
+    filedir->lname = NULL;
+    filedir->sname = NULL;
+    filedir->utf8_name = NULL;
+}
+
 /*!
- * @brief depth-first recursively delete a directory tree
+ * @brief depth-first recursively delete a directory tree by DID
  *
- * Algorithm:
- * 1. Try simple delete (works if directory is empty)
- * 2. If not empty, get directory ID
- * 3. Enumerate contents and for each entry:
- *    - If it's a file: delete it immediately
- *    - If it's a directory: recurse into it
- * 4. After all contents are deleted, delete the now-empty directory
- *
- * @param conn       AFP connection
- * @param volume     Volume ID
- * @param parent_did Parent directory ID
- * @param dirname    Directory name to delete
+ * @param conn   AFP connection
+ * @param volume Volume ID
+ * @param dir_id Directory ID to delete
  *
  * @returns 0 on success, -1 on failure
  */
-int delete_directory_tree(CONN *conn, uint16_t volume,
-                          uint32_t parent_did, char *dirname)
+int delete_directory_tree_by_did(CONN *conn, uint16_t volume, uint32_t dir_id)
 {
     struct afp_filedir_parms filedir = { 0 };
     const DSI *dsi_ptr = &conn->dsi;
-    uint32_t dir_id;
     uint16_t f_bitmap, d_bitmap;
     unsigned int ret;
     uint16_t entry_count;
     const unsigned char *entry_ptr;
     const unsigned char *data_end;
 
-    /* Step 1: Try simple delete - optimal case for empty directories */
-    if (FPDelete(conn, volume, parent_did, dirname) == AFP_OK) {
+    /* Step 1: Try simple delete - optimal case for empty directories. */
+    if (FPDelete(conn, volume, dir_id, "") == AFP_OK) {
         return 0;
     }
 
-    /* Step 2: dirname directory not empty - get its ID for enumeration */
-    if (FPGetFileDirParams(conn, volume, parent_did, dirname, 0,
-                           (1 << DIRPBIT_DID)) != AFP_OK) {
-        /* Directory doesn't exist or access denied */
-        fprintf(stderr, "[delete_directory_tree] Failed to get directory ID for '%s'\n",
-                dirname);
-        return -1;
-    }
-
-    /* Extract directory ID for dirname from DSI following FPGetFileDirParams call */
-    filedir.isdir = 1;
-    afp_filedir_unpack(conn, &filedir, dsi_ptr->data + (3 * sizeof(uint16_t)), 0,
-                       (1 << DIRPBIT_DID));
-    dir_id = filedir.did;
-
-    /* Invalid directory ID */
     if (dir_id == 0) {
-        fprintf(stderr, "[delete_directory_tree] Got invalid directory ID for '%s'\n",
-                dirname);
+        fprintf(stderr, "[delete_directory_tree_by_did] Got invalid directory ID\n");
         return -1;
     }
 
-    /* Step 3: Enumerate and process contents - names for deletion & dir IDs for recursion */
-    f_bitmap = (1 << FILPBIT_LNAME);
+    /* Step 2: Enumerate contents. Use names for files, but DIDs for dirs. */
+    f_bitmap = (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM);
     d_bitmap = (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_DID);
-    /* Call FPEnumerate until AFPERR_NOOBJ (no more entries) */
+
+    if (conn->afp_version >= 30) {
+        f_bitmap |= (1 << FILPBIT_PDINFO);
+        d_bitmap |= (1 << DIRPBIT_PDINFO);
+    }
+
+    /* Call FPEnumerate until AFPERR_NOOBJ or until deletion stops making progress. */
     int total_files_deleted = 0;
     int total_dirs_deleted = 0;
     int enumeration_round = 0;
-    int max_rounds = 100;
 
-    while (enumeration_round < max_rounds) {
+    while (1) {
         enumeration_round++;
         /* FPEnumerate batch of entries */
         ret = FPEnumerate(conn, volume, dir_id, "", f_bitmap, d_bitmap);
@@ -1027,8 +1042,9 @@ int delete_directory_tree(CONN *conn, uint16_t volume,
             break;
         } else if (ret != AFP_OK) {
             fprintf(stderr,
-                    "[delete_directory_tree] Enumeration failed for '%s' (error: 0x%08x)\n",
-                    dirname, ret);
+                    "[delete_directory_tree_by_did] Enumeration failed for DID 0x%x "
+                    "(error: 0x%08x)\n",
+                    ntohl(dir_id), ret);
             break;
         }
 
@@ -1044,7 +1060,8 @@ int delete_directory_tree(CONN *conn, uint16_t volume,
          &conn->dsi->data + 4 = count
          &conn->dsi->data + 6 = data */
         if (dsi_ptr->cmdlen < 6) {
-            fprintf(stderr, "[delete_directory_tree] Response too small (%lu bytes)\n",
+            fprintf(stderr,
+                    "[delete_directory_tree_by_did] Response too small (%lu bytes)\n",
                     dsi_ptr->cmdlen);
             break;
         }
@@ -1058,165 +1075,252 @@ int delete_directory_tree(CONN *conn, uint16_t volume,
             break;
         }
 
+        if (dsi_ptr->cmdlen <= 6) {
+            fprintf(stderr,
+                    "[delete_directory_tree_by_did] Response has %u entries "
+                    "but no entry data\n",
+                    entry_count);
+            break;
+        }
+
         /* Process each entry data */
-        if (dsi_ptr->cmdlen > 6) {
-            entry_ptr = dsi_ptr->data + 6;
-            data_end = dsi_ptr->data + dsi_ptr->cmdlen;
-            int batch_files_deleted = 0;
-            int batch_dirs_deleted = 0;
+        entry_ptr = dsi_ptr->data + 6;
+        data_end = dsi_ptr->data + dsi_ptr->cmdlen;
+        int batch_files_deleted = 0;
+        int batch_dirs_deleted = 0;
 
-            for (int i = 0; i < entry_count; i++) {
-                /* Bounds checking */
-                if (entry_ptr >= data_end || entry_ptr + 2 > data_end) {
-                    fprintf(stderr,
-                            "[delete_directory_tree] Reached end of data at entry %d of %u\n",
-                            i, entry_count);
-                    break;
-                }
-
-                /* Validate entry length */
-                uint8_t entry_len = entry_ptr[0];
-                uint8_t is_dir = entry_ptr[1];
-
-                /* Validate entry length */
-                if (entry_len == 0) {
-                    /* Zero length means end of entries */
-                    break;
-                }
-
-                if (entry_ptr + entry_len > data_end) {
-                    /* Might be padding at the end of the batch */
-                    if (!Quiet) {
-                        fprintf(stdout,
-                                "[delete_directory_tree] Warning: Entry %d length %u extends beyond buffer\n",
-                                i, entry_len);
-                    }
-
-                    break;
-                }
-
-                /* Unpack entry to get name */
-                memset(&filedir, 0, sizeof(filedir)); /* Clear structure first */
-                filedir.isdir = is_dir;
-
-                if (is_dir) {
-                    /* Recurse subdirectory.
-                     * IMPORTANT: copy the name before calling delete_directory_tree.
-                     * That recursive call runs FPEnumerate (my_dsi_data_receive) which
-                     * overwrites dsi->data, invalidating any pointer into it such as
-                     * filedir.lname.  The local copy survives the overwrite. */
-                    char subdir_name[NAME_MAX + 1];
-                    afp_filedir_unpack(conn, &filedir, entry_ptr + 2, 0, d_bitmap);
-
-                    if (filedir.lname && filedir.lname[0] != '\0') {
-                        strncpy(subdir_name, filedir.lname, NAME_MAX);
-                        subdir_name[NAME_MAX] = '\0';
-
-                        if (delete_directory_tree(conn, volume, dir_id, subdir_name) == 0) {
-                            batch_dirs_deleted++;
-                        }
-                    }
-                } else {
-                    /* Delete file.
-                     * FPDelete uses my_dsi_cmd_receive (not data_receive), so dsi->data
-                     * is not overwritten and filedir.lname stays valid. */
-                    afp_filedir_unpack(conn, &filedir, entry_ptr + 2, f_bitmap, 0);
-
-                    if (filedir.lname && filedir.lname[0] != '\0') {
-                        if (FPDelete(conn, volume, dir_id, filedir.lname) == AFP_OK) {
-                            batch_files_deleted++;
-                        }
-                    }
-                }
-
-                entry_ptr += entry_len;
-            }
-
-            total_files_deleted += batch_files_deleted;
-            total_dirs_deleted += batch_dirs_deleted;
-
-            /* If nothing was deleted this round, further iterations will not
-             * make progress.  Stop now rather than spinning. */
-            if (batch_files_deleted == 0 && batch_dirs_deleted == 0) {
+        for (int i = 0; i < entry_count; i++) {
+            /* Bounds checking */
+            if (entry_ptr >= data_end || entry_ptr + 2 > data_end) {
                 fprintf(stderr,
-                        "[delete_directory_tree] No progress deleting '%s' contents; "
-                        "aborting after %d rounds\n",
-                        dirname, enumeration_round);
+                        "[delete_directory_tree_by_did] Reached end of data at entry %d of %u\n",
+                        i, entry_count);
                 break;
             }
+
+            /* Validate entry length */
+            uint8_t entry_len = entry_ptr[0];
+            uint8_t is_dir = (entry_ptr[1] == FILDIRBIT_ISDIR);
+
+            /* Validate entry length */
+            if (entry_len == 0) {
+                /* Zero length means end of entries */
+                break;
+            }
+
+            if (entry_ptr + entry_len > data_end) {
+                /* Might be padding at the end of the batch */
+                if (!Quiet) {
+                    fprintf(stdout,
+                            "[delete_directory_tree_by_did] Warning: Entry %d length %u extends beyond buffer\n",
+                            i, entry_len);
+                }
+
+                break;
+            }
+
+            /* Unpack entry to get name */
+            memset(&filedir, 0, sizeof(filedir)); /* Clear structure first */
+            filedir.isdir = is_dir;
+
+            if (is_dir) {
+                char child_name[AFPHELPER_NAME_MAX + 1];
+                int child_deleted = 0;
+                afp_filedir_unpack(conn, &filedir, entry_ptr + 2, 0, d_bitmap);
+
+                if (filedir.did
+                        && delete_directory_tree_by_did(conn, volume, filedir.did) == 0) {
+                    batch_dirs_deleted++;
+                    child_deleted = 1;
+                }
+
+                if (!child_deleted
+                        && copy_filedir_name(child_name, sizeof(child_name),
+                                             &filedir) == 0
+                        && FPDelete(conn, volume, dir_id, child_name) == AFP_OK) {
+                    batch_files_deleted++;
+                }
+
+                free_filedir_names(&filedir);
+                break;
+            } else {
+                char filename[AFPHELPER_NAME_MAX + 1];
+                afp_filedir_unpack(conn, &filedir, entry_ptr + 2, f_bitmap, 0);
+
+                if (copy_filedir_name(filename, sizeof(filename), &filedir) == 0
+                        && FPDelete(conn, volume, dir_id, filename) == AFP_OK) {
+                    batch_files_deleted++;
+                }
+
+                free_filedir_names(&filedir);
+            }
+
+            entry_ptr += entry_len;
+        }
+
+        total_files_deleted += batch_files_deleted;
+        total_dirs_deleted += batch_dirs_deleted;
+
+        /* If nothing was deleted this round, further iterations will not
+         * make progress. Stop now rather than spinning. */
+        if (batch_files_deleted == 0 && batch_dirs_deleted == 0) {
+            fprintf(stderr,
+                    "[delete_directory_tree_by_did] No progress deleting DID 0x%x contents; "
+                    "aborting after %d rounds\n",
+                    ntohl(dir_id), enumeration_round);
+            break;
         }
     }
 
     if (!Quiet) {
         fprintf(stdout,
-                "[delete_directory_tree] Total for '%s': Deleted %d files, deleted %d dirs in %d rounds\n",
-                dirname, total_files_deleted, total_dirs_deleted, enumeration_round);
+                "[delete_directory_tree_by_did] Total for DID 0x%x: "
+                "Deleted %d files, deleted %d dirs in %d rounds\n",
+                ntohl(dir_id), total_files_deleted, total_dirs_deleted, enumeration_round);
     }
 
-    /* Step 4: Delete the now-empty directory */
-    ret = FPDelete(conn, volume, parent_did, dirname);
-
-    if (ret != AFP_OK) {
-        /* Trying to delete dirname by its own ID */
-        ret = FPDelete(conn, volume, dir_id, "");
-    }
+    /* Step 3: Delete the now-empty directory. */
+    ret = FPDelete(conn, volume, dir_id, "");
 
     if (!Quiet) {
         if (ret == AFP_OK) {
-            fprintf(stdout, "[delete_directory_tree] Successfully deleted '%s'\n", dirname);
+            fprintf(stdout,
+                    "[delete_directory_tree_by_did] Successfully deleted DID 0x%x\n",
+                    ntohl(dir_id));
         } else {
             fprintf(stderr,
-                    "[delete_directory_tree] Failed to delete '%s' (error: 0x%08x)\n",
-                    dirname, ret);
+                    "[delete_directory_tree_by_did] Failed to delete DID 0x%x "
+                    "(error: 0x%08x)\n",
+                    ntohl(dir_id), ret);
         }
     }
 
     return (ret == AFP_OK) ? 0 : -1;
 }
 
+/*!
+ * @brief depth-first recursively delete a directory tree by parent DID and name
+ *
+ * Resolves the starting directory once, then deletes descendants by DID so
+ * cleanup does not depend on round-tripping mangled long names from enumerate.
+ *
+ * @param conn       AFP connection
+ * @param volume     Volume ID
+ * @param parent_did Parent directory ID
+ * @param dirname    Directory name to delete
+ *
+ * @returns 0 on success, -1 on failure
+ */
+int delete_directory_tree(CONN *conn, uint16_t volume,
+                          uint32_t parent_did, char *dirname)
+{
+    struct afp_filedir_parms filedir = { 0 };
+    const DSI *dsi_ptr = &conn->dsi;
+    uint32_t dir_id;
+
+    /* Try direct name deletion first - optimal case for empty directories. */
+    if (FPDelete(conn, volume, parent_did, dirname) == AFP_OK) {
+        return 0;
+    }
+
+    if (FPGetFileDirParams(conn, volume, parent_did, dirname, 0,
+                           (1 << DIRPBIT_DID)) != AFP_OK) {
+        fprintf(stderr, "[delete_directory_tree] Failed to get directory ID for '%s'\n",
+                dirname);
+        return -1;
+    }
+
+    filedir.isdir = 1;
+    afp_filedir_unpack(conn, &filedir, dsi_ptr->data + (3 * sizeof(uint16_t)), 0,
+                       (1 << DIRPBIT_DID));
+    dir_id = filedir.did;
+
+    if (dir_id == 0) {
+        fprintf(stderr, "[delete_directory_tree] Got invalid directory ID for '%s'\n",
+                dirname);
+        return -1;
+    }
+
+    return delete_directory_tree_by_did(conn, volume, dir_id);
+}
+
 void clear_volume(uint16_t vol, CONN *conn)
 {
-    uint16_t bitmap = (1 << FILPBIT_FNUM) | (1 << DIRPBIT_PDID);
+    uint16_t f_bitmap = (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM);
+    uint16_t d_bitmap = (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_DID);
     uint32_t dir_id = DIRDID_ROOT;
     struct afp_filedir_parms filedir = { 0 };
     int ofs = 3 * sizeof(uint16_t);
 
+    if (conn->afp_version >= 30) {
+        f_bitmap |= (1 << FILPBIT_PDINFO);
+        d_bitmap |= (1 << DIRPBIT_PDINFO);
+    }
+
     while (1) {
-        int ret = FPEnumerate(conn, vol, dir_id, "", bitmap, bitmap);
+        const unsigned char *entry;
+        int ret = FPEnumerate(conn, vol, dir_id, "", f_bitmap, d_bitmap);
 
         if (ret != AFP_OK) {
             break;
         }
 
-        afp_filedir_unpack(conn, &filedir, conn->dsi.data + ofs, 0, bitmap);
+        if (conn->dsi.cmdlen < (size_t)ofs + 2) {
+            break;
+        }
+
+        entry = conn->dsi.data + ofs;
+
+        if (entry[0] == 0) {
+            break;
+        }
+
+        memset(&filedir, 0, sizeof(filedir));
+        filedir.isdir = (entry[1] == FILDIRBIT_ISDIR);
+        afp_filedir_unpack(conn, &filedir, entry + 2, f_bitmap, d_bitmap);
 
         if (filedir.isdir) {
-            int result = delete_directory_tree(conn, vol, DIRDID_ROOT, filedir.lname);
+            char dirname[AFPHELPER_NAME_MAX + 1];
+            int result;
+
+            if (copy_filedir_name(dirname, sizeof(dirname), &filedir) != 0) {
+                free_filedir_names(&filedir);
+                break;
+            }
+
+            result = delete_directory_tree_by_did(conn, vol, filedir.did);
 
             if (result == 0) {
                 if (!Quiet) {
-                    fprintf(stdout, "deleted test directory '%s'\n", filedir.lname);
+                    fprintf(stdout, "deleted test directory '%s'\n", dirname);
                 }
             } else {
-                result = FPDelete(conn, vol, DIRDID_ROOT, filedir.lname);
+                result = FPDelete(conn, vol, DIRDID_ROOT, dirname);
 
                 if (result == AFP_OK && !Quiet) {
                     fprintf(stdout, "deleted test directory '%s' (on retry)\n",
-                            filedir.lname);
+                            dirname);
                 }
 
-                if (is_there(conn, vol, DIRDID_ROOT, filedir.lname) != AFP_OK && !Quiet) {
+                if (is_there(conn, vol, DIRDID_ROOT, dirname) != AFP_OK && !Quiet) {
                     fprintf(stdout, "could not delete directory '%s' because it no longer exists\n",
-                            filedir.lname);
+                            dirname);
                 }
 
                 if (!Quiet) {
-                    fprintf(stdout, "failed to delete test directory '%s'\n",
-                            filedir.lname);
+                    fprintf(stdout, "failed to delete test directory '%s'\n", dirname);
                 }
             }
+
+            free_filedir_names(&filedir);
         } else {
-            FPDelete(conn, vol, dir_id, filedir.lname);
+            char filename[AFPHELPER_NAME_MAX + 1];
+
+            if (copy_filedir_name(filename, sizeof(filename), &filedir) == 0) {
+                FPDelete(conn, vol, dir_id, filename);
+            }
+
+            free_filedir_names(&filedir);
         }
     }
 }

--- a/test/testsuite/afphelper.h
+++ b/test/testsuite/afphelper.h
@@ -56,6 +56,8 @@ extern int not_valid(unsigned int ret, int mac_error, int afpd_error);
 extern int not_valid_bitmap(unsigned int ret, unsigned int bitmap,
                             int afpd_error);
 extern int32_t is_there(CONN *conn, uint16_t volume, int32_t did, char *name);
+extern int delete_directory_tree_by_did(CONN *conn, uint16_t volume,
+                                        uint32_t dir_id);
 extern int delete_directory_tree(CONN *conn, uint16_t volume,
                                  uint32_t parent_did, char *dirname);
 extern void clear_volume(uint16_t vol, CONN *conn);


### PR DESCRIPTION
this is a suite of fixes and improvements following the big batch of security patches that should bring the pipeline for the main branch back to green

note that these are needed only on the main branch, the stable 4.4 branch has a different shape

* clean up from a previous merge failure for a Randnum patch (the merge accidentally brought back a previous deleted block)
* libatalk/util: explicitly clear reconnect tokens from memory
* testsuite: harden test460 path overflow coverage and introduce more sturdy helper for deleting dir tree
* libatalk: fix up doxygen code commend for LDAP filter
* remove superfluous newline
* testsuite: missing header include for Solaris
* update list of advisories