### PR TITLE
testsuite: overhaul DSI test client and expand logintest

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1093,7 +1093,7 @@ jobs:
             -e AFP_USER="atalk1" \
             -e AFP_PASS="$CONT_PASSWD" \
             -e AFP_GROUP="afpusers" \
-            -e INSECURE_AUTH="1" \
+            -e AFP_UAMS="uams_guest.so uams_clrtxt.so uams_dhx.so" \
             -e VERBOSE="1" \
             -e TESTSUITE="login" \
             -e AFP_VERSION="7" \

--- a/doc/manpages/man1/afp_logintest.1.md
+++ b/doc/manpages/man1/afp_logintest.1.md
@@ -4,13 +4,15 @@ afp_logintest — AFP authentication and DSI session test suite
 
 # Synopsis
 
-**afp_logintest** [-1234567CmVv] [-h *host*] [-p *port*] [-s *volume*] [-u *user*] [-w *password*]
+**afp_logintest** [-1234567CmVv] [-f *test*] [-h *host*] [-p *port*] [-s *volume*] [-u *user*] [-w *password*]
+
+**afp_logintest** -l
 
 # Description
 
 **afp_logintest** is a testsuite for DSI sessions and authentication from an AFP client.
 It will run a range of happy path and corner case tests for establishing a DSI session
-with an AFP server and then use a subset of available UAMs to authenticate with a user.
+with an AFP server and then use UAMs (User Authentication Methods) to authenticate with a user.
 
 # Options
 
@@ -38,8 +40,14 @@ with an AFP server and then use a subset of available UAMs to authenticate with 
 **-C**
 : Turn off ANSI colors in terminal output
 
+**-f** *test*
+: Run a specific test
+
 **-h** *host*
 : Server hostname or IP address (default: localhost)
+
+**-l**
+: List available tests
 
 **-m**
 : Run tests in AppleShare (Mac) AFP server compatibility mode
@@ -68,6 +76,9 @@ Configure the UAMs in netatalk's afp.conf:
     [Global]
     uam list = uams_clrtxt.so uams_guest.so
 
+Other tests may require additional UAMs to be configured;
+see the test output for details on which tests failed due to missing UAMs.
+
 Additionally, in order to test non-Guest authentication, a username and password must be passed to the test runner.
 
 # Examples
@@ -78,8 +89,25 @@ Run all tests against an AFP server running on 10.0.0.10, without user credentia
     Logintest:test1: DSI with no open session - PASSED
     Logintest:test2: DSI with open session - PASSED
     Logintest:test3: Guest login - PASSED
+    Logintest:test4: connection limit hit returns server-busy - PASSED
     Logintest:test5: Clear text login - SKIPPED (username/password for the AFP server)
     Logintest:test6: DSIOpenSession non zero parameter should be ignored by the server - SKIPPED (username/password for the AFP server)
+    Logintest:test7: DSI round-trip via renamed dsi_stream_send/dsi_cmd_receive - PASSED
+    Logintest:test8: FPLoginExt + No User Authent (direct) - PASSED
+    Logintest:test9: AFPLoginCont primitive round-trip - SKIPPED (username/password for the AFP server)
+    Logintest:test10: UAM matrix walk - PASSED
+    =====================
+    TEST RESULT SUMMARY
+    ---------------------
+    Passed:     7
+    Skipped:    3
+    Failed:     0
+    Not tested: 0
+
+    Skipped tests (precondition not met):
+        Logintest:test5: Clear text login
+        Logintest:test6: DSIOpenSession non zero parameter should be ignored by the server
+        Logintest:test9: AFPLoginCont primitive round-trip
 
 # See Also
 

--- a/etc/afpd/main.c
+++ b/etc/afpd/main.c
@@ -596,7 +596,10 @@ static afp_child_t *dsi_start(AFPObj *obj, DSI *dsi,
     afp_child_t *child = NULL;
 
     if (dsi_getsession(dsi, server_children, obj->options.tickleval, &child) != 0) {
-        LOG(log_error, logtype_afpd, "dsi_start: session error: %s", strerror(errno));
+        if (errno) {
+            LOG(log_error, logtype_afpd, "dsi_start: session error: %s", strerror(errno));
+        }
+
         return NULL;
     }
 

--- a/libatalk/dsi/dsi_getsess.c
+++ b/libatalk/dsi/dsi_getsess.c
@@ -41,6 +41,46 @@ int dsi_getsession(DSI *dsi, server_child_t *serv_children, int tickleval,
     int hint_pipe[2];  /* Dedicated pipe for parent→child dircache hint delivery */
     afp_child_t *child;
 
+    /* Pre-fork session limit check: reject without forking to avoid a
+     * fork+SIGKILL cycle per over-cap connection.  MSG_DONTWAIT keeps the
+     * parent non-blocking; if the client's DSIOpenSession header hasn't
+     * arrived yet we still send SERVBUSY but with requestID=0 instead of
+     * echoing the client's ID.  The post-fork check in server_child_add
+     * remains as defence-in-depth for the narrow race window. */
+    if (serv_children->servch_count >= serv_children->servch_nsessions) {
+        socklen_t addrlen = sizeof(dsi->client);
+        uint8_t block[DSI_BLOCKSIZ];
+        ssize_t n;
+        LOG(log_note, logtype_dsi,
+            "dsi_getsess: at session cap (%d/%d), rejecting without fork",
+            serv_children->servch_count, serv_children->servch_nsessions);
+        dsi->socket = accept(dsi->serversock,
+                             (struct sockaddr *)&dsi->client, &addrlen);
+
+        if (dsi->socket >= 0) {
+            n = recv(dsi->socket, block, DSI_BLOCKSIZ, MSG_DONTWAIT);
+            memset(&dsi->header, 0, sizeof(dsi->header));
+            dsi->header.dsi_flags = DSIFL_REPLY;
+            dsi->header.dsi_command = DSIFUNC_OPEN;
+
+            if (n == DSI_BLOCKSIZ)
+                memcpy(&dsi->header.dsi_requestID, block + 2,
+                       sizeof(dsi->header.dsi_requestID));
+            else {
+                dsi->header.dsi_requestID = 0;
+            }
+
+            dsi->header.dsi_data.dsi_code = htonl(DSIERR_SERVBUSY);
+            dsi->cmdlen = 0;
+            dsi_send(dsi);
+            close(dsi->socket);
+            dsi->socket = -1;
+        }
+
+        errno = 0;
+        return -1;
+    }
+
     if (socketpair(PF_UNIX, SOCK_STREAM, 0, ipc_fds) < 0) {
         LOG(log_error, logtype_dsi, "dsi_getsess: %s", strerror(errno));
         return -1;
@@ -108,6 +148,8 @@ int dsi_getsession(DSI *dsi, server_child_t *serv_children, int tickleval,
             dsi_send(dsi);
             dsi->header.dsi_data.dsi_code = DSIERR_OK;
             kill(pid, SIGKILL);
+            dsi->proto_close(dsi);
+            return -1;
         }
 
         dsi->proto_close(dsi);

--- a/test/testsuite/Error.c
+++ b/test/testsuite/Error.c
@@ -573,8 +573,8 @@ STATIC void test35()
         cmd = afp_cmd_with_vol[i].cmd;
         expected = ntohl(afp_cmd_with_vol[i].expected);
         FAIL(t35_build_request(dsi, cmd, afp_cmd_with_vol[i].variant, bad_ref) < 0)
-        my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
-        my_dsi_cmd_receive(dsi);
+        dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+        dsi_cmd_receive(dsi);
         ret = dsi->header.dsi_code;
 
         if (expected != ret) {
@@ -599,8 +599,8 @@ STATIC void test35()
         cmd = afp_cmd_with_dt[i].cmd;
         expected = ntohl(afp_cmd_with_dt[i].expected);
         FAIL(t35_build_request(dsi, cmd, afp_cmd_with_dt[i].variant, bad_ref) < 0)
-        my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
-        my_dsi_cmd_receive(dsi);
+        dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+        dsi_cmd_receive(dsi);
         ret = dsi->header.dsi_code;
 
         if (expected != ret) {
@@ -681,8 +681,8 @@ STATIC void test36()
         dsi->datalen = ofs;
         dsi->header.dsi_len = htonl(dsi->datalen);
         dsi->header.dsi_code = 0;
-        my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
-        my_dsi_cmd_receive(dsi);
+        dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+        dsi_cmd_receive(dsi);
         ret = dsi->header.dsi_code;
 
         if (ntohl(AFPERR_NOOBJ) != ret) {
@@ -751,8 +751,8 @@ STATIC void test37()
         dsi->datalen = ofs;
         dsi->header.dsi_len = htonl(dsi->datalen);
         dsi->header.dsi_code = 0;
-        my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
-        my_dsi_cmd_receive(dsi);
+        dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+        dsi_cmd_receive(dsi);
         ret = dsi->header.dsi_code;
 
         if (ntohl(AFPERR_NOOBJ) != ret) {
@@ -822,7 +822,7 @@ static void cname_test(char *name)
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FAIL(FPEnumerate(Conn, vol, DIRDID_ROOT, "", 0, bitmap))
 
     if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, 0, bitmap)) {
@@ -1034,7 +1034,7 @@ STATIC void test100()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerate(Conn, vol, DIRDID_ROOT, name1,
                       (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                       (1 << FILPBIT_FINFO) |
@@ -1134,7 +1134,7 @@ STATIC void test101()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerate(Conn, vol, DIRDID_ROOT, name1,
                       (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                       (1 << FILPBIT_FINFO) |
@@ -1255,7 +1255,7 @@ STATIC void test102()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
 
     if (ntohl(AFPERR_ACCESS) != FPEnumerate(Conn, vol, DIRDID_ROOT, name1,
                                             (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
@@ -1389,7 +1389,7 @@ STATIC void test103()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerate(Conn, vol, dir, "",
                       (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                       (1 << FILPBIT_FINFO) |
@@ -1556,7 +1556,7 @@ STATIC void test105()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
 
     if (err  != FPEnumerate(Conn, vol, dir, name1,
                             (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
@@ -1737,7 +1737,7 @@ STATIC void test170()
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
 
     /* ---- enumerate.c ---- */
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (ntohl(AFPERR_NOOBJ) != FPEnumerate(Conn, vol, DIRDID_ROOT_PARENT, "",
                                            (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                                            (1 << FILPBIT_FINFO) |
@@ -1892,7 +1892,7 @@ STATIC void test171()
             tname))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
     /* ---- enumerate.c ---- */
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerate(Conn, vol, tdir, tname,
                       (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                       (1 << FILPBIT_FINFO) |
@@ -2058,7 +2058,7 @@ STATIC void test173()
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
 
     /* ---- enumerate.c ---- */
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (ntohl(AFPERR_PARAM) != FPEnumerate(Conn, vol, tdir, tname,
                                            (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                                            (1 << FILPBIT_FINFO) |
@@ -2258,7 +2258,7 @@ STATIC void test174()
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
 
     /* ---- enumerate.c ---- */
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (ntohl(AFPERR_NODIR) != FPEnumerate(Conn, vol, tdir, tname,
                                            (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                                            (1 << FILPBIT_FINFO) |

--- a/test/testsuite/FPAddAPPL.c
+++ b/test/testsuite/FPAddAPPL.c
@@ -97,7 +97,7 @@ STATIC void test301()
 
         test_failed();
         ret = FPCreateFile(Conn, vol, 0, dir, file);
-        /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+        /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
         FPEnumerate(Conn, vol, dir, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR),
                     (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) |

--- a/test/testsuite/FPCreateDir.c
+++ b/test/testsuite/FPCreateDir.c
@@ -53,7 +53,7 @@ STATIC void test26()
         goto fin;
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FPEnumerate(Conn, vol, DIRDID_ROOT, "",
                 (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM),
                 (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |

--- a/test/testsuite/FPCreateFile.c
+++ b/test/testsuite/FPCreateFile.c
@@ -135,7 +135,7 @@ STATIC void test393()
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name))
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name1))
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, DIRDID_ROOT, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -285,7 +285,7 @@ STATIC void test172()
             tname))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
     /* ---- enumerate.c ---- */
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerate(Conn, vol, tdir, tname,
                       (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                       (1 << FILPBIT_FINFO) |

--- a/test/testsuite/FPDisconnectOldSession.c
+++ b/test/testsuite/FPDisconnectOldSession.c
@@ -756,7 +756,7 @@ STATIC void test535()
     FAIL(FPGetFileDirParams(Conn, vol, dir, file1, bitmap, 0))
     FAIL(FPGetFileDirParams(Conn, vol, dir, file2, bitmap, 0))
     FAIL(FPGetFileDirParams(Conn, vol, dir, file3, bitmap, 0))
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FAIL(FPEnumerate(Conn, vol, dir, "", bitmap, bitmap))
 
     if (!Quiet && Verbose) {

--- a/test/testsuite/FPEnumerate.c
+++ b/test/testsuite/FPEnumerate.c
@@ -46,7 +46,7 @@ STATIC void test28()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir1, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -106,7 +106,7 @@ STATIC void test34()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FPEnumerate(Conn, vol, DIRDID_ROOT, "",
                 (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM),
                 (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
@@ -154,7 +154,7 @@ STATIC void test38()
 
     memcpy(&did, dsi->data + 3 * sizeof(uint16_t), sizeof(did));
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, DIRDID_ROOT, name,
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -228,7 +228,7 @@ STATIC void test40()
 
     FAIL(FPCreateFile(Conn, vol, 0, dir, name1))
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -293,7 +293,7 @@ STATIC void test41()
         goto fin;
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -392,7 +392,7 @@ STATIC void test93()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerate(Conn, vol, DIRDID_ROOT, name,
                       (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                       (1 << FILPBIT_FINFO) |
@@ -451,7 +451,7 @@ STATIC void test218()
 
     bitmap = (1 << FILPBIT_LNAME);
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (htonl(AFPERR_NOOBJ) != FPEnumerateFull(Conn, vol, 1, 1, 800,  bdir, "",
             bitmap, bitmap)) {
         test_nottested();
@@ -584,7 +584,7 @@ STATIC void test300(void)
             goto test_exit;
         }
 
-        /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+        /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
         while (!(ret = FPEnumerateFull(Conn, vol, i, 150, 8000,  dir, "", f_bitmap,
                                        d_bitmap))) {
             /* FPResolveID will trash dsi->data */
@@ -719,7 +719,7 @@ STATIC void test533()
         fprintf(stdout, "\t  Step 2: Client 1 starts enumerate (first batch)\n");
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     ret = FPEnumerateFull(Conn, vol, 1, 20, 8000, dir, "", f_bitmap, d_bitmap);
 
     if (ret) {

--- a/test/testsuite/FPEnumerateExt.c
+++ b/test/testsuite/FPEnumerateExt.c
@@ -20,7 +20,7 @@ STATIC void test23()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (Conn->afp_version < 30) {
         if (ntohl(AFPERR_NOOP) != FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                 (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)

--- a/test/testsuite/FPEnumerateExt2.c
+++ b/test/testsuite/FPEnumerateExt2.c
@@ -26,7 +26,7 @@ STATIC void test25()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FPEnumerate_ext2(Conn, vol, DIRDID_ROOT, "",
                      (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
                      | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN),
@@ -83,7 +83,7 @@ STATIC void test211()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (Conn->afp_version < 31) {
         if (ntohl(AFPERR_NOOP) != FPEnumerate_ext2(Conn, vol, DIRDID_ROOT, "",
                 (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -144,9 +144,9 @@ STATIC void test70()
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_stream_receive(dsi, dsi->data, DSI_DATASIZ, &dsi->datalen);
+    dsi_stream_receive(dsi, dsi->data, DSI_DATASIZ, &dsi->datalen);
     dump_header(dsi);
 
     if (dsi->header.dsi_code != htonl(AFPERR_PARAM)) {

--- a/test/testsuite/FPGetSessionToken.c
+++ b/test/testsuite/FPGetSessionToken.c
@@ -40,7 +40,7 @@ STATIC void test220()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (Conn->afp_version < 30) {
         if (ntohl(AFPERR_NOOP) != FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                 (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)

--- a/test/testsuite/FPReadExt.c
+++ b/test/testsuite/FPReadExt.c
@@ -29,7 +29,7 @@ STATIC void test22()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                         (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
                         | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0)) {

--- a/test/testsuite/FPRename.c
+++ b/test/testsuite/FPRename.c
@@ -337,7 +337,7 @@ STATIC void test219()
         goto fin;
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     bitmap = (1 << FILPBIT_LNAME);
     FAIL(FPEnumerate(Conn, vol, DIRDID_ROOT, "", bitmap, bitmap))
     FAIL(FPEnumerate(Conn2, vol2,  DIRDID_ROOT, "", bitmap, bitmap))

--- a/test/testsuite/FPSetFileDirParms.c
+++ b/test/testsuite/FPSetFileDirParms.c
@@ -964,7 +964,7 @@ STATIC void test358()
     FAIL(FPSetFilDirParam(Conn, vol, dir, "", bitmap, &filedir))
     FAIL(FPGetFileDirParams(Conn2, vol2, dir, "", bitmap, bitmap))
     bitmap = (1 << FILPBIT_LNAME);
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FAIL(FPEnumerateFull(Conn, vol, 1, 5, 800,  dir, "", bitmap, bitmap))
     FAIL(htonl(AFPERR_ACCESS) != FPEnumerateFull(Conn2, vol2, 1, 5, 800,  dir, "",
             bitmap, bitmap))

--- a/test/testsuite/FPWriteExt.c
+++ b/test/testsuite/FPWriteExt.c
@@ -37,7 +37,7 @@ STATIC void test148()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                         (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
                         | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0)) {
@@ -154,7 +154,7 @@ STATIC void test207()
         goto test_exit;
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                         (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
                         | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN),

--- a/test/testsuite/T2_FPDelete.c
+++ b/test/testsuite/T2_FPDelete.c
@@ -62,7 +62,7 @@ STATIC void test146()
         test_failed();
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FAIL(FPEnumerate(Conn2, vol2,  DIRDID_ROOT, "", 0, bitmap))
     FAIL(ntohl(AFPERR_ACCESS) != FPDelete(Conn2, vol2,  dir, name))
     fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, dir, name,

--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -39,7 +39,7 @@ STATIC void test32()
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name1))
     FAIL(FPCreateFile(Conn, vol, 0, dir, name1))
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -157,7 +157,7 @@ STATIC void test33()
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name1))
     FAIL(FPCreateFile(Conn, vol, 0, dir, name1))
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, DIRDID_ROOT, name,
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -275,7 +275,7 @@ STATIC void test42()
         goto fin;
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (ntohl(AFPERR_NOOBJ) != FPEnumerate(Conn, vol, dir, "",
                                            (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                                            (1 << FILPBIT_FINFO) |
@@ -627,7 +627,7 @@ STATIC void test182()
 
     FAIL(FPCreateFile(Conn, vol, 0, dir, name1))
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |
@@ -914,7 +914,7 @@ STATIC void test340()
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name1))
     FAIL(FPCreateFile(Conn, vol, 0, dir, name1))
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |

--- a/test/testsuite/T2_FPGetVolParms.c
+++ b/test/testsuite/T2_FPGetVolParms.c
@@ -176,7 +176,7 @@ STATIC void test532()
         fprintf(stdout, "\t  Step 6: Verify enumeration still works correctly\n");
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, DIRDID_ROOT, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM),
                     (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_DID))) {

--- a/test/testsuite/T2_FPOpenFork.c
+++ b/test/testsuite/T2_FPOpenFork.c
@@ -1550,7 +1550,7 @@ STATIC void test431()
     }
 
     /* Enumerate triggers v2→EA conversion (if 'convert appledouble = yes').
-     * NB: FPEnumerate* uses my_dsi_data_receive (should be normalised).
+     * NB: FPEnumerate* uses dsi_data_receive (should be normalised).
      * See afphelper.c:delete_directory_tree() */
     if (FPEnumerate_ext2(Conn, vol, DIRDID_ROOT, "",
                          (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN),

--- a/test/testsuite/T2_FPResolveID.c
+++ b/test/testsuite/T2_FPResolveID.c
@@ -619,7 +619,7 @@ STATIC void test412()
 
     FPResolveID(Conn, vol, fid, bitmap);
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir2, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |

--- a/test/testsuite/Utf8.c
+++ b/test/testsuite/Utf8.c
@@ -89,7 +89,7 @@ STATIC void test166()
         }
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                     (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
                     | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0);
@@ -150,7 +150,7 @@ STATIC void test167()
         }
     }
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
                     (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
                     | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0);
@@ -201,7 +201,7 @@ STATIC void test181()
     FAIL(FPCloseVol(Conn, vol))
     vol = VolID = FPOpenVol(Conn, Vol);
 
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (FPEnumerate(Conn, vol, dir1, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
                     (1 << FILPBIT_FINFO) |

--- a/test/testsuite/afparg_FPfuncs.c
+++ b/test/testsuite/afparg_FPfuncs.c
@@ -201,7 +201,7 @@ void FPEnumerate_arg(char **argv)
             goto fin;
         }
 
-        /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+        /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
 
         while (!(ret = FPEnumerateFull(Conn, vol, i, 150, 8000,  dir, "", f_bitmap,
                                        d_bitmap))) {

--- a/test/testsuite/afpclient.c
+++ b/test/testsuite/afpclient.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <atalk/afp.h>
 
 #include "afpclient.h"
@@ -19,6 +20,7 @@ int	Color = 1;
 int OpenClientSocket(char *host, int port)
 {
     int sock = -1;
+    assert(host);
     struct addrinfo hints;
     struct addrinfo *res;
     struct addrinfo *ressave;
@@ -398,6 +400,7 @@ unsigned int DSIOpenSession(CONN *conn)
 {
     DSI *dsi;
     uint32_t i = 0;
+    assert(conn);
     dsi = &conn->dsi;
     /* DSIOpenSession */
     memset(&dsi->header, 0, sizeof(dsi->header));
@@ -437,6 +440,7 @@ unsigned int DSIOpenSession(CONN *conn)
 unsigned int DSIGetStatus(CONN *conn)
 {
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     memset(&dsi->header, 0, sizeof(dsi->header));
     dsi->header.dsi_flags = DSIFL_REQUEST;
@@ -455,6 +459,7 @@ unsigned int DSIGetStatus(CONN *conn)
 unsigned int DSICloseSession(CONN *conn)
 {
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     memset(&dsi->header, 0, sizeof(dsi->header));
     dsi->header.dsi_flags = DSIFL_REQUEST;
@@ -475,6 +480,7 @@ unsigned int AFPopenLogin(CONN *conn, const char *vers, const char *uam,
     uint8_t len;
     int ofs;
     DSI *dsi = &conn->dsi;
+    assert(conn && vers && uam && usr && pwd);
 
     if (DSIOpenSession(conn)) {
         return dsi->header.dsi_code;
@@ -555,6 +561,7 @@ unsigned int AFPopenLoginExt(CONN *conn,
     size_t usr_len;
     int ofs;
     DSI *dsi = &conn->dsi;
+    assert(conn && vers && uam && usr);
 
     if (DSIOpenSession(conn)) {
         return dsi->header.dsi_code;
@@ -569,14 +576,17 @@ unsigned int AFPopenLoginExt(CONN *conn,
     ofs += sizeof(temp16);
     len = (uint8_t) strnlen(vers, UINT8_MAX);
     dsi->commands[ofs++] = len;
+    assert((size_t)ofs + len <= DSI_CMDSIZ);
     memcpy(&dsi->commands[ofs], vers, len);
     ofs += len;
     len = (uint8_t) strnlen(uam, UINT8_MAX);
     dsi->commands[ofs++] = len;
+    assert((size_t)ofs + len <= DSI_CMDSIZ);
     memcpy(&dsi->commands[ofs], uam, len);
     ofs += len;
     /* UserNameType = 3 (UTF-8), UserName as AFPName (uint16_t length). */
     usr_len = strnlen(usr, UINT16_MAX);
+    assert((size_t)ofs + 3 + usr_len <= DSI_CMDSIZ);
     dsi->commands[ofs++] = 3;
     temp16 = htons((uint16_t) usr_len);
     memcpy(&dsi->commands[ofs], &temp16, sizeof(temp16));
@@ -597,6 +607,7 @@ unsigned int AFPopenLoginExt(CONN *conn,
     }
 
     if (auth_info && auth_info_len) {
+        assert((size_t)ofs + auth_info_len <= DSI_CMDSIZ);
         memcpy(&dsi->commands[ofs], auth_info, auth_info_len);
         ofs += auth_info_len;
     }
@@ -618,6 +629,7 @@ unsigned int AFPopenLoginExt_pwd(CONN *conn,
                                  const char *usr, const char *pwd)
 {
     uint8_t pwbuf[PASSWDLEN];
+    assert(conn && vers);
 
     /* The Cleartxt Passwrd UAM over FPLoginExt has been broken in netatalk
      * for years; afpfs-ng works around it by always using FPLogin for
@@ -653,6 +665,7 @@ unsigned int AFPLoginCont(CONN *conn,
     uint16_t id_be;
     int ofs;
     DSI *dsi = &conn->dsi;
+    assert(conn);
     SendInit(dsi);
     ofs = 0;
     dsi->commands[ofs++] = AFP_LOGINCONT;
@@ -662,6 +675,7 @@ unsigned int AFPLoginCont(CONN *conn,
     ofs += sizeof(id_be);
 
     if (auth_info && auth_info_len) {
+        assert((size_t)ofs + auth_info_len <= DSI_CMDSIZ);
         memcpy(&dsi->commands[ofs], auth_info, auth_info_len);
         ofs += auth_info_len;
     }
@@ -684,6 +698,7 @@ unsigned int AFPChangePW(CONN *conn, char *uam, char *usr, char *opwd,
     uint8_t len;
     int ofs;
     DSI *dsi;
+    assert(conn && uam && usr);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -727,6 +742,7 @@ unsigned int AFPChangePW(CONN *conn, char *uam, char *usr, char *opwd,
 unsigned int AFPLogOut(CONN *conn)
 {
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendCmd(dsi, AFP_LOGOUT);
     dsi_full_receive(dsi, dsi->commands, DSI_CMDSIZ);
@@ -740,6 +756,7 @@ unsigned int AFPzzz(CONN *conn, int flag)
     int 		ofs = 0;
     DSI			*dsi = &conn->dsi;
     uint32_t   temp;
+    assert(conn);
     SendInit(dsi);
     dsi->commands[ofs++] = AFP_ZZZ;
     dsi->commands[ofs++] = 0;
@@ -758,6 +775,7 @@ unsigned int AFPzzz(CONN *conn, int flag)
 unsigned int AFPGetSrvrInfo(CONN *conn)
 {
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendCmd(dsi, AFP_GETSRVINFO);
     dsi_cmd_receive(dsi);
@@ -768,6 +786,7 @@ unsigned int AFPGetSrvrInfo(CONN *conn)
 unsigned int AFPGetSrvrParms(CONN *conn)
 {
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendCmd(dsi, AFP_GETSRVPARAM);
     dsi_data_receive(dsi);
@@ -779,6 +798,7 @@ unsigned int AFPGetSrvrMsg(CONN *conn, uint16_t type, uint16_t bitmap)
 {
     int ofs;
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -800,6 +820,7 @@ unsigned int AFPGetSrvrMsg(CONN *conn, uint16_t type, uint16_t bitmap)
 unsigned int AFPCloseVol(CONN *conn, uint16_t vol)
 {
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendCmdWithU16(dsi, AFP_CLOSEVOL, vol);
     dsi_cmd_receive(dsi);
@@ -810,6 +831,7 @@ unsigned int AFPCloseVol(CONN *conn, uint16_t vol)
 unsigned int AFPCloseDT(CONN *conn, uint16_t vol)
 {
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendCmdWithU16(dsi, AFP_CLOSEDT, vol);
     dsi_cmd_receive(dsi);
@@ -820,6 +842,7 @@ unsigned int AFPCloseDT(CONN *conn, uint16_t vol)
 unsigned int AFPCloseFork(CONN *conn, uint16_t fork)
 {
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendCmdWithU16(dsi, AFP_CLOSEFORK, fork);
     dsi_cmd_receive(dsi);
@@ -832,6 +855,7 @@ unsigned int AFPByteLock(CONN *conn, uint16_t fork, int end, int mode,
 {
     int ofs;
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -898,6 +922,7 @@ unsigned int AFPByteLock_ext(CONN *conn, uint16_t fork, int end, int mode,
 {
     int ofs;
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -920,6 +945,7 @@ unsigned int AFPSetForkParam(CONN *conn, uint16_t fork,  uint16_t bitmap,
     int ofs;
     DSI *dsi;
     int is64 = bitmap & ((1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN));
+    assert(conn);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -942,6 +968,7 @@ unsigned int AFPSetForkParam(CONN *conn, uint16_t fork,  uint16_t bitmap,
 unsigned int AFPFlush(CONN *conn, uint16_t vol)
 {
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendCmdWithU16(dsi, AFP_FLUSH, vol);
     dsi_cmd_receive(dsi);
@@ -952,6 +979,7 @@ unsigned int AFPFlush(CONN *conn, uint16_t vol)
 unsigned int AFPFlushFork(CONN *conn, uint16_t vol)
 {
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendCmdWithU16(dsi, AFP_FLUSHFORK, vol);
     dsi_cmd_receive(dsi);
@@ -965,6 +993,7 @@ uint16_t AFPOpenVol(CONN *conn, char *vol, uint16_t bitmap)
     uint16_t result, volID = 0;
     uint8_t len;
     DSI *dsi;
+    assert(conn && vol);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -1014,6 +1043,7 @@ uint16_t AFPOpenVol(CONN *conn, char *vol, uint16_t bitmap)
 int strp2c(char *cstr, const unsigned char *pstr)
 {
     int i;
+    assert(cstr && pstr);
 
     for (i = 0; i < pstr[0]; i++) {
         cstr[i] = pstr[i + 1];
@@ -1040,6 +1070,7 @@ void *fp_malloc(size_t size)
 /* -------------------------------  */
 char *strp2cdup(unsigned char *src)
 {
+    assert(src);
     char *r = fp_malloc(*src + 1);
     strp2c(r, src);
     return r;
@@ -1072,6 +1103,7 @@ void afp_volume_unpack(struct afp_volume_parms *parms, unsigned char *b,
 {
     uint16_t i;
     uint32_t l;
+    assert(parms && b);
 
     if (rbitmap & (1 << VOLPBIT_ATTR)) {
         memcpy(&i, b, sizeof(i));
@@ -1151,6 +1183,7 @@ int afp_volume_pack(unsigned char *b, struct afp_volume_parms *parms,
     uint32_t l;
     int bit = 0;
     const unsigned char *beg = b;
+    assert(b && parms);
 
     while (bitmap != 0) {
         while ((bitmap & 1) == 0) {
@@ -1232,6 +1265,7 @@ void afp_filedir_unpack(CONN *conn, struct afp_filedir_parms *filedir,
     int bit = 0;
     uint16_t bitmap;
     const unsigned char *beg = b;
+    assert(conn && filedir && b);
     isdir = filedir->isdir;
     bitmap = isdir ? rdbitmap : rfbitmap;
 
@@ -1411,6 +1445,7 @@ int afp_filedir_pack(CONN *conn, unsigned char *b,
     const unsigned char *beg = b;
     unsigned char *l_ofs = NULL;
     unsigned char *u_ofs = NULL;
+    assert(conn && b && filedir);
     isdir = filedir->isdir;
     bitmap = isdir ? rdbitmap : rfbitmap;
 
@@ -1575,6 +1610,7 @@ unsigned int AFPGetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap)
 {
     int ofs;
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -1599,6 +1635,7 @@ unsigned int AFPSetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap,
     int ofs;
     DSI *dsi;
     uint16_t tp;
+    assert(conn && parms);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -1622,6 +1659,8 @@ unsigned int AFPSetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap,
 */
 void u2mac(uint8_t *dst, char *name, int len)
 {
+    assert(dst && name);
+
     while (len) {
         if (Convert && *name == '/') {
             *dst = 0;
@@ -1646,6 +1685,7 @@ int FPset_name(CONN *conn, int ofs, char *name)
     uint16_t len16;
     uint32_t hint = htonl(kTextEncodingUTF8);
     DSI *dsi;
+    assert(conn && name);
     dsi = &conn->dsi;
 
     if (UNICODE(conn) && !Force_type2) {
@@ -1675,6 +1715,7 @@ unsigned int  AFPCreateFile(CONN *conn, uint16_t vol, char type, int did,
 {
     int ofs;
     DSI *dsi;
+    assert(conn && name);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -1699,6 +1740,7 @@ unsigned int AFPWriteHeader(DSI *dsi, uint16_t fork, int offset, int size,
     int ofs;
     int rsize;
     uint32_t temp;
+    assert(dsi);
     memset(dsi->commands, 0, DSI_CMDSIZ);
     memset(&dsi->header, 0, sizeof(dsi->header));
     dsi->header.dsi_flags = DSIFL_REQUEST;
@@ -1728,6 +1770,7 @@ unsigned int AFPWriteFooter(DSI *dsi, uint16_t fork _U_, int offset, int size,
                             char *data _U_, char whence)
 {
     uint32_t last;
+    assert(dsi);
     dsi_cmd_receive(dsi);
 
     if (!dsi->header.dsi_code) {
@@ -1754,6 +1797,7 @@ unsigned int AFPWrite(CONN *conn, uint16_t fork, int offset, int size,
                       char *data, char whence)
 {
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     AFPWriteHeader(dsi, fork, offset, size, data, whence);
     return AFPWriteFooter(dsi, fork, offset, size, data, whence);
@@ -1767,6 +1811,7 @@ unsigned int AFPWrite_ext(CONN *conn, uint16_t fork, off_t offset, off_t size,
     DSI *dsi;
     off_t last;
     unsigned char *ptr;
+    assert(conn);
     dsi = &conn->dsi;
     memset(dsi->commands, 0, DSI_CMDSIZ);
     memset(&dsi->header, 0, sizeof(dsi->header));
@@ -1812,6 +1857,7 @@ unsigned int AFPWrite_ext_async(CONN *conn, uint16_t fork, off_t offset,
 {
     int ofs;
     DSI *dsi = &conn->dsi;
+    assert(conn);
     memset(dsi->commands, 0, DSI_CMDSIZ);
     memset(&dsi->header, 0, sizeof(dsi->header));
     dsi->header.dsi_flags = DSIFL_REQUEST;
@@ -1841,6 +1887,7 @@ uint16_t  AFPOpenFork(CONN *conn, uint16_t vol, char type, uint16_t bitmap,
     int ofs;
     uint16_t ofork = 0, result;
     DSI *dsi;
+    assert(conn && name);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -1876,18 +1923,21 @@ uint16_t  AFPOpenFork(CONN *conn, uint16_t vol, char type, uint16_t bitmap,
 /* ------------------------------- */
 unsigned int AFPDelete(CONN *conn, uint16_t vol, int did, char *name)
 {
+    assert(conn && name);
     return  SendCmdVolDidCname(conn, AFP_DELETE, vol, did, name);
 }
 
 /* ------------------------------- */
 unsigned int AFPGetComment(CONN *conn, uint16_t vol, int did, char *name)
 {
+    assert(conn && name);
     return  SendCmdVolDidCname(conn, AFP_GETCMT, vol, did, name);
 }
 
 /* ------------------------------- */
 unsigned int AFPRemoveComment(CONN *conn, uint16_t vol, int did, char *name)
 {
+    assert(conn && name);
     return  SendCmdVolDidCname(conn, AFP_RMVCMT, vol, did, name);
 }
 
@@ -1898,6 +1948,7 @@ unsigned int AFPAddComment(CONN *conn, uint16_t vol, int did, char *name,
     int ofs;
     uint8_t len;
     DSI *dsi;
+    assert(conn && name && cmt);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -1932,6 +1983,7 @@ unsigned int AFPGetSessionToken(CONN *conn, int type, uint32_t time, int len,
     uint16_t tp = htons((uint16_t) type);
     uint32_t temp;
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -1970,6 +2022,7 @@ unsigned int AFPDisconnectOldSession(CONN *conn, uint16_t type, int len,
     uint16_t tp = htons(type);
     uint32_t temp;
     DSI *dsi;
+    assert(conn && token);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -1995,6 +2048,7 @@ unsigned int AFPGetUserInfo(CONN *conn, char flag, int id, uint16_t bitmap)
     int ofs;
     uint16_t type = htons(bitmap);
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2018,6 +2072,7 @@ unsigned int AFPMapID(CONN *conn, char fn, int id)
 {
     int ofs;
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2040,6 +2095,7 @@ unsigned int AFPMapName(CONN *conn, char fn, char *name)
     int ofs;
     uint16_t len, l;
     DSI *dsi;
+    assert(conn && name);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2078,6 +2134,7 @@ unsigned int AFPBadPacket(CONN *conn, char fn, char *name)
     int ofs;
     uint16_t l;
     DSI *dsi;
+    assert(conn && name);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2101,6 +2158,7 @@ unsigned int AFPReadHeader(DSI *dsi, uint16_t fork, int offset, int size,
 {
     int ofs;
     uint32_t  temp;
+    assert(dsi);
     SendInit(dsi);
     ofs = 0;
     dsi->commands[ofs++] = AFP_READ;
@@ -2125,6 +2183,7 @@ unsigned int AFPReadFooter(DSI *dsi, uint16_t fork _U_, int offset _U_,
                            int size, char *data)
 {
     int rsize;
+    assert(dsi && data);
     dsi_cmd_receive(dsi);
     memcpy(data, dsi->commands, dsi->cmdlen);
     rsize =  ntohl(dsi->header.dsi_len);
@@ -2145,6 +2204,7 @@ unsigned int AFPRead(CONN *conn, uint16_t fork, int offset, int size,
                      char *data)
 {
     DSI *dsi;
+    assert(conn && data);
     dsi = &conn->dsi;
     AFPReadHeader(dsi, fork, offset, size, data);
     return AFPReadFooter(dsi, fork, offset, size, data);
@@ -2159,6 +2219,7 @@ unsigned int AFPRead_ext(CONN *conn, uint16_t fork, off_t offset, off_t size,
     int ofs;
     int rsize;
     DSI *dsi;
+    assert(conn && data);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2208,6 +2269,7 @@ unsigned int AFPRead_ext_async(CONN *conn, uint16_t fork, off_t offset,
 {
     int ofs;
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2228,6 +2290,7 @@ unsigned int  AFPCreateDir(CONN *conn, uint16_t vol, int did, char *name)
     int ofs;
     unsigned int dir = 0;
     DSI *dsi;
+    assert(conn && name);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2259,6 +2322,7 @@ unsigned int AFPGetForkParam(CONN *conn, uint16_t fork, uint16_t bitmap)
 {
     int ofs;
     DSI *dsi;
+    assert(conn);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2284,6 +2348,7 @@ unsigned int AFPGetAPPL(CONN *conn, uint16_t dt, char *name, uint16_t index,
     int ofs;
     uint16_t bitmap;
     DSI *dsi;
+    assert(conn && name);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2313,6 +2378,7 @@ unsigned int AFPAddAPPL(CONN *conn, uint16_t dt, int did, char *creator,
 {
     int ofs;
     DSI *dsi;
+    assert(conn && creator && name);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2341,6 +2407,7 @@ unsigned int AFPRemoveAPPL(CONN *conn, uint16_t dt, int did, char *creator,
 {
     int ofs;
     DSI *dsi;
+    assert(conn && creator && name);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2371,6 +2438,7 @@ unsigned int AFPCatSearch(CONN *conn, uint16_t vol, uint32_t nbe, char *pos,
     DSI *dsi;
     uint32_t temp;
     uint16_t bitmap;
+    assert(conn && pos && filedir && filedir2);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2422,6 +2490,7 @@ unsigned int AFPCatSearchExt(CONN *conn, uint16_t vol, uint32_t  nbe, char *pos,
     uint32_t temp;
     uint16_t bitmap;
     uint16_t i;
+    assert(conn && pos && filedir && filedir2);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2470,6 +2539,7 @@ unsigned int AFPGetACL(CONN *conn, uint16_t vol, int did, uint16_t bitmap,
 {
     int ofs;
     DSI *dsi;
+    assert(conn && name);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2499,6 +2569,7 @@ unsigned int AFPSetACL(CONN *conn, uint16_t vol, int did, uint16_t bitmap,
 {
     int ofs;
     DSI *dsi;
+    assert(conn && name);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2549,6 +2620,7 @@ unsigned int AFPGetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap,
     DSI *dsi;
     long long reqcount = -1;
     uint16_t len;
+    assert(conn && pathname && attrname);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2601,6 +2673,7 @@ unsigned int AFPListExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap,
 {
     int ofs;
     DSI *dsi;
+    assert(conn && pathname);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2637,6 +2710,7 @@ unsigned int AFPSetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap,
     DSI *dsi;
     uint16_t len;
     uint32_t datalen;
+    assert(conn && pathname && attrname && data);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;
@@ -2686,6 +2760,7 @@ unsigned int AFPRemoveExtAttr(CONN *conn, uint16_t vol, int did,
     int ofs;
     DSI *dsi;
     uint16_t len;
+    assert(conn && pathname && attrname);
     dsi = &conn->dsi;
     SendInit(dsi);
     ofs = 0;

--- a/test/testsuite/afpclient.c
+++ b/test/testsuite/afpclient.c
@@ -72,7 +72,7 @@ int CloseClientSocket(int fd)
 
 /*! read raw data. return actual bytes read. this will wait until
  * it gets length bytes */
-size_t my_dsi_stream_read(DSI *dsi, void *data, const size_t length)
+size_t dsi_stream_read(DSI *dsi, void *data, const size_t length)
 {
     size_t stored;
     ssize_t len;
@@ -92,10 +92,9 @@ size_t my_dsi_stream_read(DSI *dsi, void *data, const size_t length)
                         (len < 0) ? strerror(errno) : "EOF");
             }
 
-            if (!len) {
-                dsi->header.dsi_code = 0xffffffff;
-            }
-
+            /* Mark the header as invalid so callers see a non-zero dsi_code
+             * rather than mistaking the zeroed header for a success response. */
+            dsi->header.dsi_code = 0xffffffff;
             break;
         }
     }
@@ -110,7 +109,7 @@ int dsi_read_header(DSI *dsi)
     char block[DSI_BLOCKSIZ];
 
     /* read in the header */
-    if (my_dsi_stream_read(dsi, block, sizeof(block)) != sizeof(block)) {
+    if (dsi_stream_read(dsi, block, sizeof(block)) != sizeof(block)) {
         return -1;
     }
 
@@ -128,8 +127,8 @@ int dsi_read_header(DSI *dsi)
 /*! read data. function on success. 0 on failure. data length gets
  * stored in length variable. this should really use size_t's, but
  * that would require changes elsewhere. */
-int my_dsi_stream_receive(DSI *dsi, void *buf, const size_t ilength,
-                          size_t *rlength)
+int dsi_stream_receive(DSI *dsi, void *buf, const size_t ilength,
+                       size_t *rlength)
 {
     int ret;
 
@@ -140,7 +139,7 @@ int my_dsi_stream_receive(DSI *dsi, void *buf, const size_t ilength,
     /* make sure we don't over-write our buffers. */
     *rlength = min(ntohl(dsi->header.dsi_len), ilength);
 
-    if (my_dsi_stream_read(dsi, buf, *rlength) != *rlength) {
+    if (dsi_stream_read(dsi, buf, *rlength) != *rlength) {
         return 0;
     }
 
@@ -148,7 +147,7 @@ int my_dsi_stream_receive(DSI *dsi, void *buf, const size_t ilength,
 }
 
 /* ======================================================= */
-size_t my_dsi_stream_write(DSI *dsi, void *data, const size_t length)
+size_t dsi_stream_write(DSI *dsi, void *data, const size_t length)
 {
     size_t written;
     ssize_t len;
@@ -179,7 +178,7 @@ size_t my_dsi_stream_write(DSI *dsi, void *data, const size_t length)
 /*! write data. 0 on failure. this assumes that dsi_len will never
  * cause an overflow in the data buffer. */
 static int use_writev = 1;
-int my_dsi_stream_send(DSI *dsi, void *buf, size_t length)
+int dsi_stream_send(DSI *dsi, void *buf, size_t length)
 {
     char block[DSI_BLOCKSIZ];
     struct iovec iov[2];
@@ -198,7 +197,7 @@ int my_dsi_stream_send(DSI *dsi, void *buf, size_t length)
     }
 
     if (!length) { /* just write the header */
-        length = (my_dsi_stream_write(dsi, block, sizeof(block)) == sizeof(block));
+        length = (dsi_stream_write(dsi, block, sizeof(block)) == sizeof(block));
         /* really 0 on failure, 1 on success */
         return (int) length;
     }
@@ -220,7 +219,7 @@ int my_dsi_stream_send(DSI *dsi, void *buf, size_t length)
                 break;
             } else if (len < 0) { /* error */
                 if (!Quiet) {
-                    fprintf(stdout, "my_dsi_stream_send: %s", strerror(errno));
+                    fprintf(stdout, "dsi_stream_send: %s", strerror(errno));
                 }
 
                 return 0;
@@ -243,8 +242,8 @@ int my_dsi_stream_send(DSI *dsi, void *buf, size_t length)
         }
     } else {
         /* write the header then data */
-        if ((my_dsi_stream_write(dsi, block, sizeof(block)) != sizeof(block)) ||
-                (my_dsi_stream_write(dsi, buf, length) != length)) {
+        if ((dsi_stream_write(dsi, block, sizeof(block)) != sizeof(block)) ||
+                (dsi_stream_write(dsi, buf, length) != length)) {
             return 0;
         }
     }
@@ -253,7 +252,7 @@ int my_dsi_stream_send(DSI *dsi, void *buf, size_t length)
 }
 
 /* ------------------------------------- */
-void my_dsi_tickle(DSI *dsi)
+void dsi_tickle(DSI *dsi)
 {
     char block[DSI_BLOCKSIZ];
     uint16_t id;
@@ -263,19 +262,19 @@ void my_dsi_tickle(DSI *dsi)
     block[1] = DSIFUNC_TICKLE;
     memcpy(block + 2, &id, sizeof(id));
     /* code = len = reserved = 0 */
-    my_dsi_stream_write(dsi, block, DSI_BLOCKSIZ);
+    dsi_stream_write(dsi, block, DSI_BLOCKSIZ);
 }
 
 /* ------------------------------------- */
 int Attention_received;
 
-static int my_dsi_receive(DSI *x, unsigned char *buf, size_t length)
+static int dsi_receive(DSI *x, unsigned char *buf, size_t length)
 {
     int ret;
     Attention_received = 0;
 
     while (1) {
-        ret = my_dsi_stream_receive(x, buf, length, &x->cmdlen);
+        ret = dsi_stream_receive(x, buf, length, &x->cmdlen);
 
         if (ret == DSIFUNC_ATTN) {
             Attention_received = 1;
@@ -283,7 +282,7 @@ static int my_dsi_receive(DSI *x, unsigned char *buf, size_t length)
         } else if (ret == DSIFUNC_CLOSE) {
             continue;
         } else if (ret == DSIFUNC_TICKLE) {
-            my_dsi_tickle(x);
+            dsi_tickle(x);
         } else {
             break;
         }
@@ -293,19 +292,19 @@ static int my_dsi_receive(DSI *x, unsigned char *buf, size_t length)
 }
 
 /* ------------------------------------- */
-static int my_dsi_full_receive(DSI *x, unsigned char *buf, int length)
+static int dsi_full_receive(DSI *x, unsigned char *buf, int length)
 {
     int ret;
     Attention_received = 0;
 
     while (1) {
-        ret = my_dsi_stream_receive(x, buf, length, &x->cmdlen);
+        ret = dsi_stream_receive(x, buf, length, &x->cmdlen);
 
         if (ret == DSIFUNC_ATTN) {
             Attention_received = 1;
             continue;
         } else if (ret == DSIFUNC_TICKLE) {
-            my_dsi_tickle(x);
+            dsi_tickle(x);
         } else {
             break;
         }
@@ -315,15 +314,15 @@ static int my_dsi_full_receive(DSI *x, unsigned char *buf, int length)
 }
 
 /* ------------------------------------- */
-int my_dsi_cmd_receive(DSI *x)
+int dsi_cmd_receive(DSI *x)
 {
-    return my_dsi_receive(x, x->commands, DSI_CMDSIZ);
+    return dsi_receive(x, x->commands, DSI_CMDSIZ);
 }
 
 /* ------------------------------------- */
-int my_dsi_data_receive(DSI *x)
+int dsi_data_receive(DSI *x)
 {
-    return my_dsi_receive(x, x->data, DSI_DATASIZ);
+    return dsi_receive(x, x->data, DSI_DATASIZ);
 }
 
 /* ------------------------------- */
@@ -352,7 +351,7 @@ static int  SendCmd(DSI *dsi, uint8_t cmd)
     ofs = 0;
     dsi->commands[ofs++] = cmd;
     SetLen(dsi, ofs);
-    return my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    return dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 }
 
 /* ------------------------------- */
@@ -366,7 +365,7 @@ static int  SendCmdWithU16(DSI *dsi, uint8_t cmd, uint16_t param)
     memcpy(dsi->commands + ofs, &param, sizeof(param));
     ofs += sizeof(param);
     SetLen(dsi, ofs);
-    return my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    return dsi_stream_send(dsi, dsi->commands, dsi->datalen);
 }
 
 /* ------------------------- */
@@ -386,9 +385,9 @@ static unsigned int SendCmdVolDidCname(CONN *conn, uint8_t cmd, uint16_t vol,
     ofs += sizeof(did);
     ofs = FPset_name(conn, ofs, name);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -410,8 +409,8 @@ unsigned int DSIOpenSession(CONN *conn)
     dsi->commands[1] = sizeof(i);
     i = htonl(DSI_DEFQUANT);
     memcpy(dsi->commands + 2, &i, sizeof(i));
-    my_dsi_send(dsi);
-    my_dsi_cmd_receive(dsi);
+    dsi_send(dsi);
+    dsi_cmd_receive(dsi);
 #if 0
     dump_header(dsi);
 
@@ -444,8 +443,8 @@ unsigned int DSIGetStatus(CONN *conn)
     dsi->header.dsi_command = DSIFUNC_STAT;
     dsi->header.dsi_requestID = htons(dsi_clientID(dsi));
     dsi->cmdlen = 0;
-    my_dsi_send(dsi);
-    my_dsi_cmd_receive(dsi);
+    dsi_send(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -462,7 +461,7 @@ unsigned int DSICloseSession(CONN *conn)
     dsi->header.dsi_command = DSIFUNC_CLOSE;
     dsi->header.dsi_requestID = htons(dsi_clientID(dsi));
     dsi->cmdlen = 0;
-    my_dsi_send(dsi);
+    dsi_send(dsi);
     return 0;
 }
 
@@ -470,8 +469,8 @@ unsigned int DSICloseSession(CONN *conn)
 	@bug spec violation in netatalk
 	FPlogout ==> dsiclose
 */
-unsigned int AFPopenLogin(CONN *conn, char *vers, char *uam, char *usr,
-                          char *pwd)
+unsigned int AFPopenLogin(CONN *conn, const char *vers, const char *uam,
+                          const char *usr, const char *pwd)
 {
     uint8_t len;
     int ofs;
@@ -510,80 +509,171 @@ unsigned int AFPopenLogin(CONN *conn, char *vers, char *uam, char *usr,
     }
 
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
+/* Capture FPLoginExt/FPLoginCont reply block on kFPAuthContinue.
+ * Reply payload layout (AFP Reference table 51): int16_t ID, then UAM-specific
+ * UserAuthInfo. */
+static void capture_login_cont(CONN *conn)
+{
+    const DSI *dsi = &conn->dsi;
+    uint16_t id_be;
+    conn->login_cont_id = 0;
+    conn->login_cont_len = 0;
+
+    if (dsi->cmdlen < sizeof(id_be)) {
+        return;
+    }
+
+    memcpy(&id_be, dsi->commands, sizeof(id_be));
+    conn->login_cont_id = ntohs(id_be);
+    conn->login_cont_len = dsi->cmdlen - sizeof(id_be);
+
+    if (conn->login_cont_len > sizeof(dsi->commands) - sizeof(id_be)) {
+        conn->login_cont_len = sizeof(dsi->commands) - sizeof(id_be);
+    }
+
+    memcpy(conn->login_cont_data, dsi->commands + sizeof(id_be),
+           conn->login_cont_len);
+}
+
 /* ---------------------------- */
-unsigned int AFPopenLoginExt(CONN *conn, char *vers, char *uam, char *usr,
-                             char *pwd)
+/* FPLoginExt wire layout per AFP spec §FPLoginExt and netatalk server
+ * parser in etc/afpd/auth.c:778-903. UserAuthInfo is opaque to this
+ * function; callers pass the UAM-specific blob. */
+unsigned int AFPopenLoginExt(CONN *conn,
+                             const char *vers, const char *uam,
+                             const char *usr,
+                             const void *auth_info, size_t auth_info_len)
 {
     uint8_t len;
-    uint16_t len16;
     uint16_t temp16;
+    size_t usr_len;
     int ofs;
-    DSI *dsi;
-    dsi = &conn->dsi;
+    DSI *dsi = &conn->dsi;
 
     if (DSIOpenSession(conn)) {
         return dsi->header.dsi_code;
     }
 
-    /* -------------- */
     SendInit(dsi);
     ofs = 0;
     dsi->commands[ofs++] = AFP_LOGIN_EXT;
-    dsi->commands[ofs++] = 0; /* pad */
-    temp16 = 0;		/* flag */
+    dsi->commands[ofs++] = 0;
+    temp16 = 0;
     memcpy(&dsi->commands[ofs], &temp16, sizeof(temp16));
     ofs += sizeof(temp16);
-    len = (uint8_t) strlen(vers);
+    len = (uint8_t) strnlen(vers, UINT8_MAX);
     dsi->commands[ofs++] = len;
     memcpy(&dsi->commands[ofs], vers, len);
     ofs += len;
-    len = (uint8_t) strlen(uam);
+    len = (uint8_t) strnlen(uam, UINT8_MAX);
     dsi->commands[ofs++] = len;
     memcpy(&dsi->commands[ofs], uam, len);
     ofs += len;
-    len16 = (uint16_t) strlen(usr);
-    /* user name */
+    /* UserNameType = 3 (UTF-8), UserName as AFPName (uint16_t length). */
+    usr_len = strnlen(usr, UINT16_MAX);
     dsi->commands[ofs++] = 3;
-    temp16 = htons(len16);
+    temp16 = htons((uint16_t) usr_len);
     memcpy(&dsi->commands[ofs], &temp16, sizeof(temp16));
     ofs += sizeof(temp16);
-    memcpy(&dsi->commands[ofs], usr, len16);
-    ofs += len16;
-    /* directory service */
+    memcpy(&dsi->commands[ofs], usr, usr_len);
+    ofs += usr_len;
+    /* PathType = 3, empty directory service pathname. */
     dsi->commands[ofs++] = 3;
     temp16 = 0;
     memcpy(&dsi->commands[ofs], &temp16, sizeof(temp16));
     ofs += sizeof(temp16);
 
+    /* Pad to even offset before UserAuthInfo. The server checks pointer
+     * alignment (auth.c:900); this matches as long as dsi->commands starts
+     * at an even address, which is true for the heap-allocated CONN. */
     if (ofs & 1) {
         dsi->commands[ofs++] = 0;
     }
 
-    /* now the uam parts */
-#if 0
-    len = len16;
-    dsi->commands[ofs++] = len;
-    memcpy(&dsi->commands[ofs], usr, len);
-    ofs += len;
-#endif
-
-    /* HACK */
-    if (len16) {
-        len = (uint8_t) strlen(pwd);
-        memcpy(&dsi->commands[ofs], pwd, len);
-        ofs += PASSWDLEN;
+    if (auth_info && auth_info_len) {
+        memcpy(&dsi->commands[ofs], auth_info, auth_info_len);
+        ofs += auth_info_len;
     }
 
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
-    /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_cmd_receive(dsi);
+
+    if (dsi->header.dsi_code == htonl((uint32_t) AFPERR_AUTHCONT)) {
+        capture_login_cont(conn);
+    }
+
+    return dsi->header.dsi_code;
+}
+
+/* ---------------------------- */
+unsigned int AFPopenLoginExt_pwd(CONN *conn,
+                                 const char *vers, const char *uam,
+                                 const char *usr, const char *pwd)
+{
+    uint8_t pwbuf[PASSWDLEN];
+
+    /* The Cleartxt Passwrd UAM over FPLoginExt has been broken in netatalk
+     * for years; afpfs-ng works around it by always using FPLogin for
+     * cleartext. Mirror that here so the wrapper still works for callers
+     * that don't care which AFP command is used under the hood. */
+    if (uam && strcmp(uam, "Cleartxt Passwrd") == 0) {
+        return AFPopenLogin(conn, vers, uam, usr ? usr : "", pwd ? pwd : "");
+    }
+
+    memset(pwbuf, 0, sizeof(pwbuf));
+
+    if (pwd) {
+        size_t pwlen = strnlen(pwd, PASSWDLEN);
+        memcpy(pwbuf, pwd, pwlen);
+    }
+
+    /* No User Authent / empty user: server expects no UserAuthInfo at all,
+     * matching the historical "if (len16)" gate this wrapper replaces. */
+    if (!usr || !*usr) {
+        return AFPopenLoginExt(conn, vers, uam, "", NULL, 0);
+    }
+
+    return AFPopenLoginExt(conn, vers, uam, usr, pwbuf, PASSWDLEN);
+}
+
+/* ---------------------------- */
+/* FPLoginCont wire layout per AFP spec §FPLoginCont and server parser at
+ * etc/afpd/auth.c:922-944. Caller must have populated conn->login_cont_id
+ * from a previous FPLoginExt/FPLoginCont that returned kFPAuthContinue. */
+unsigned int AFPLoginCont(CONN *conn,
+                          const void *auth_info, size_t auth_info_len)
+{
+    uint16_t id_be;
+    int ofs;
+    DSI *dsi = &conn->dsi;
+    SendInit(dsi);
+    ofs = 0;
+    dsi->commands[ofs++] = AFP_LOGINCONT;
+    dsi->commands[ofs++] = 0;
+    id_be = htons(conn->login_cont_id);
+    memcpy(&dsi->commands[ofs], &id_be, sizeof(id_be));
+    ofs += sizeof(id_be);
+
+    if (auth_info && auth_info_len) {
+        memcpy(&dsi->commands[ofs], auth_info, auth_info_len);
+        ofs += auth_info_len;
+    }
+
+    SetLen(dsi, ofs);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_cmd_receive(dsi);
+
+    if (dsi->header.dsi_code == htonl((uint32_t) AFPERR_AUTHCONT)) {
+        capture_login_cont(conn);
+    }
+
     return dsi->header.dsi_code;
 }
 
@@ -628,9 +718,9 @@ unsigned int AFPChangePW(CONN *conn, char *uam, char *usr, char *opwd,
     }
 
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 /* ------------------------------- */
@@ -639,7 +729,7 @@ unsigned int AFPLogOut(CONN *conn)
     DSI *dsi;
     dsi = &conn->dsi;
     SendCmd(dsi, AFP_LOGOUT);
-    my_dsi_full_receive(dsi, dsi->commands, DSI_CMDSIZ);
+    dsi_full_receive(dsi, dsi->commands, DSI_CMDSIZ);
     DSICloseSession(conn);
     return dsi->header.dsi_code;
 }
@@ -658,9 +748,9 @@ unsigned int AFPzzz(CONN *conn, int flag)
     memcpy(dsi->commands + ofs, &temp, sizeof(temp));
     ofs += sizeof(temp);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -670,7 +760,7 @@ unsigned int AFPGetSrvrInfo(CONN *conn)
     DSI *dsi;
     dsi = &conn->dsi;
     SendCmd(dsi, AFP_GETSRVINFO);
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -680,7 +770,7 @@ unsigned int AFPGetSrvrParms(CONN *conn)
     DSI *dsi;
     dsi = &conn->dsi;
     SendCmd(dsi, AFP_GETSRVPARAM);
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -701,8 +791,8 @@ unsigned int AFPGetSrvrMsg(CONN *conn, uint16_t type, uint16_t bitmap)
     memcpy(dsi->commands + ofs, &bitmap, sizeof(bitmap));
     ofs += sizeof(bitmap);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
-    my_dsi_cmd_receive(dsi);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -712,7 +802,7 @@ unsigned int AFPCloseVol(CONN *conn, uint16_t vol)
     DSI *dsi;
     dsi = &conn->dsi;
     SendCmdWithU16(dsi, AFP_CLOSEVOL, vol);
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -722,7 +812,7 @@ unsigned int AFPCloseDT(CONN *conn, uint16_t vol)
     DSI *dsi;
     dsi = &conn->dsi;
     SendCmdWithU16(dsi, AFP_CLOSEDT, vol);
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -732,7 +822,7 @@ unsigned int AFPCloseFork(CONN *conn, uint16_t fork)
     DSI *dsi;
     dsi = &conn->dsi;
     SendCmdWithU16(dsi, AFP_CLOSEFORK, fork);
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -756,8 +846,8 @@ unsigned int AFPByteLock(CONN *conn, uint16_t fork, int end, int mode,
     memcpy(dsi->commands + ofs, &size, sizeof(size));
     ofs += sizeof(size);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
-    my_dsi_cmd_receive(dsi);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -818,8 +908,8 @@ unsigned int AFPByteLock_ext(CONN *conn, uint16_t fork, int end, int mode,
     ofs += set_off_t(offset, dsi->commands + ofs, 1);
     ofs += set_off_t(size, dsi->commands + ofs, 1);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
-    my_dsi_cmd_receive(dsi);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -842,9 +932,9 @@ unsigned int AFPSetForkParam(CONN *conn, uint16_t fork,  uint16_t bitmap,
     ofs += sizeof(bitmap);
     ofs += set_off_t(size, dsi->commands + ofs, is64);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -854,7 +944,7 @@ unsigned int AFPFlush(CONN *conn, uint16_t vol)
     DSI *dsi;
     dsi = &conn->dsi;
     SendCmdWithU16(dsi, AFP_FLUSH, vol);
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -864,7 +954,7 @@ unsigned int AFPFlushFork(CONN *conn, uint16_t vol)
     DSI *dsi;
     dsi = &conn->dsi;
     SendCmdWithU16(dsi, AFP_FLUSHFORK, vol);
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -894,9 +984,9 @@ uint16_t AFPOpenVol(CONN *conn, char *vol, uint16_t bitmap)
     }
 
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
 
     if (!dsi->header.dsi_code) {
         ofs = 0;
@@ -1496,9 +1586,9 @@ unsigned int AFPGetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap)
     memcpy(dsi->commands + ofs, &bitmap, sizeof(bitmap));
     ofs += 2;
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -1521,9 +1611,9 @@ unsigned int AFPSetVolParam(CONN *conn, uint16_t vol, uint16_t bitmap,
     ofs += sizeof(tp);
     ofs += afp_volume_pack(dsi->commands + ofs, parms, bitmap);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -1596,9 +1686,9 @@ unsigned int  AFPCreateFile(CONN *conn, uint16_t vol, char type, int did,
     ofs += sizeof(did);
     ofs = FPset_name(conn, ofs, name);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -1628,8 +1718,8 @@ unsigned int AFPWriteHeader(DSI *dsi, uint16_t fork, int offset, int size,
     dsi->datalen = ofs;		/* 12*/
     dsi->header.dsi_len = htonl((uint32_t) dsi->datalen + size);
     dsi->header.dsi_code = htonl(ofs);
-    my_dsi_stream_send(dsi, dsi->commands, ofs);
-    my_dsi_stream_write(dsi, data, size);
+    dsi_stream_send(dsi, dsi->commands, ofs);
+    dsi_stream_write(dsi, data, size);
     return 0;
 }
 
@@ -1638,7 +1728,7 @@ unsigned int AFPWriteFooter(DSI *dsi, uint16_t fork _U_, int offset, int size,
                             char *data _U_, char whence)
 {
     uint32_t last;
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
 
     if (!dsi->header.dsi_code) {
         if (dsi->cmdlen != 4) {
@@ -1693,9 +1783,9 @@ unsigned int AFPWrite_ext(CONN *conn, uint16_t fork, off_t offset, off_t size,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen + size);
     dsi->header.dsi_code = htonl(ofs);
-    my_dsi_stream_send(dsi, dsi->commands, ofs);
-    my_dsi_stream_write(dsi, data, size);
-    my_dsi_cmd_receive(dsi);
+    dsi_stream_send(dsi, dsi->commands, ofs);
+    dsi_stream_write(dsi, data, size);
+    dsi_cmd_receive(dsi);
 
     if (!dsi->header.dsi_code) {
         if (dsi->cmdlen != 8) {
@@ -1737,8 +1827,8 @@ unsigned int AFPWrite_ext_async(CONN *conn, uint16_t fork, off_t offset,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen + size);
     dsi->header.dsi_code = htonl(ofs);
-    my_dsi_stream_send(dsi, dsi->commands, ofs);
-    my_dsi_stream_write(dsi, data, size);
+    dsi_stream_send(dsi, dsi->commands, ofs);
+    dsi_stream_write(dsi, data, size);
     return 0;
 }
 
@@ -1768,9 +1858,9 @@ uint16_t  AFPOpenFork(CONN *conn, uint16_t vol, char type, uint16_t bitmap,
     ofs += sizeof(access);
     ofs = FPset_name(conn, ofs, name);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
 
     if (!dsi->header.dsi_code) {
         ofs = 0;
@@ -1828,9 +1918,9 @@ unsigned int AFPAddComment(CONN *conn, uint16_t vol, int did, char *name,
     memcpy(dsi->commands + ofs, cmt, len);
     ofs += len;
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -1866,9 +1956,9 @@ unsigned int AFPGetSessionToken(CONN *conn, int type, uint32_t time, int len,
     }
 
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -1893,9 +1983,9 @@ unsigned int AFPDisconnectOldSession(CONN *conn, uint16_t type, int len,
     memcpy(dsi->commands + ofs, token, len);
     ofs += len;
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -1917,9 +2007,9 @@ unsigned int AFPGetUserInfo(CONN *conn, char flag, int id, uint16_t bitmap)
     memcpy(dsi->commands + ofs, &type, sizeof(type));
     ofs += sizeof(type);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -1938,9 +2028,9 @@ unsigned int AFPMapID(CONN *conn, char fn, int id)
     memcpy(dsi->commands + ofs, &id, sizeof(id));
     ofs += sizeof(id);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -1976,9 +2066,9 @@ unsigned int AFPMapName(CONN *conn, char fn, char *name)
     memcpy(dsi->commands + ofs, name, len);
     ofs += len;
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -1999,9 +2089,9 @@ unsigned int AFPBadPacket(CONN *conn, char fn, char *name)
     memcpy(dsi->commands + ofs, name, sizeof(&name));
     ofs += sizeof(&name);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -2026,7 +2116,7 @@ unsigned int AFPReadHeader(DSI *dsi, uint16_t fork, int offset, int size,
     dsi->commands[ofs++] = 0;	/* NewLineMask */
     dsi->commands[ofs++] = 0;	/* NewLineChar */
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     return 0;
 }
 
@@ -2035,11 +2125,11 @@ unsigned int AFPReadFooter(DSI *dsi, uint16_t fork _U_, int offset _U_,
                            int size, char *data)
 {
     int rsize;
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     memcpy(data, dsi->commands, dsi->cmdlen);
     rsize =  ntohl(dsi->header.dsi_len);
     rsize -= dsi->cmdlen;
-    my_dsi_stream_read(dsi, data + dsi->cmdlen, rsize);
+    dsi_stream_read(dsi, data + dsi->cmdlen, rsize);
 
     if (dsi->header.dsi_code) {
         return dsi->header.dsi_code;
@@ -2079,10 +2169,10 @@ unsigned int AFPRead_ext(CONN *conn, uint16_t fork, off_t offset, off_t size,
     ofs += set_off_t(offset, dsi->commands + ofs, 1);
     ofs += set_off_t(size, dsi->commands + ofs, 1);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
 #if 0
-    my_dsi_stream_receive(dsi, dsi->data, DSI_DATASIZ, &dsi->datalen);
+    dsi_stream_receive(dsi, dsi->data, DSI_DATASIZ, &dsi->datalen);
     dump_header(dsi);
     rsize =  ntohl(dsi->header.dsi_len);
     rsize -= dsi->datalen;
@@ -2090,7 +2180,7 @@ unsigned int AFPRead_ext(CONN *conn, uint16_t fork, off_t offset, off_t size,
     while (rsize > 0) {
         int len = min(rsize, DSI_DATASIZ);
 
-        if (my_dsi_stream_read(dsi, dsi->data, len) != len) {
+        if (dsi_stream_read(dsi, dsi->data, len) != len) {
             break;
         }
 
@@ -2098,11 +2188,11 @@ unsigned int AFPRead_ext(CONN *conn, uint16_t fork, off_t offset, off_t size,
     }
 
 #endif
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     memcpy(data, dsi->commands, dsi->cmdlen);
     rsize =  ntohl(dsi->header.dsi_len);
     rsize -= dsi->cmdlen;
-    my_dsi_stream_read(dsi, data + dsi->cmdlen, rsize);
+    dsi_stream_read(dsi, data + dsi->cmdlen, rsize);
 
     if (dsi->header.dsi_code) {
         return dsi->header.dsi_code;
@@ -2128,7 +2218,7 @@ unsigned int AFPRead_ext_async(CONN *conn, uint16_t fork, off_t offset,
     ofs += set_off_t(offset, dsi->commands + ofs, 1);
     ofs += set_off_t(size, dsi->commands + ofs, 1);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     return 0;
 }
 
@@ -2149,9 +2239,9 @@ unsigned int  AFPCreateDir(CONN *conn, uint16_t vol, int did, char *name)
     ofs += sizeof(did);
     ofs = FPset_name(conn, ofs, name);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
 
     if (!dsi->header.dsi_code) {
         memcpy(&dir, dsi->commands, sizeof(dir));			/* did */
@@ -2180,9 +2270,9 @@ unsigned int AFPGetForkParam(CONN *conn, uint16_t fork, uint16_t bitmap)
     memcpy(dsi->commands + ofs, &bitmap, sizeof(bitmap)); /* bitmap */
     ofs += sizeof(bitmap);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -2210,9 +2300,9 @@ unsigned int AFPGetAPPL(CONN *conn, uint16_t dt, char *name, uint16_t index,
     memcpy(dsi->commands + ofs, &bitmap, sizeof(bitmap));
     ofs += sizeof(bitmap);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -2238,9 +2328,9 @@ unsigned int AFPAddAPPL(CONN *conn, uint16_t dt, int did, char *creator,
     ofs += sizeof(tag);
     ofs = FPset_name(conn, ofs, name);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -2264,9 +2354,9 @@ unsigned int AFPRemoveAPPL(CONN *conn, uint16_t dt, int did, char *creator,
     ofs += 4;
     ofs = FPset_name(conn, ofs, name);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -2314,9 +2404,9 @@ unsigned int AFPCatSearch(CONN *conn, uint16_t vol, uint32_t nbe, char *pos,
     dsi->commands[ofs] = (uint8_t) len;
     ofs += len + 2;
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -2367,9 +2457,9 @@ unsigned int AFPCatSearchExt(CONN *conn, uint16_t vol, uint32_t  nbe, char *pos,
     memcpy(dsi->commands + ofs, &i, sizeof(i));
     ofs += len + 2;
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -2396,9 +2486,9 @@ unsigned int AFPGetACL(CONN *conn, uint16_t vol, int did, uint16_t bitmap,
     ofs += 4;
     ofs = FPset_name(conn, ofs, name);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -2444,9 +2534,9 @@ unsigned int AFPSetACL(CONN *conn, uint16_t vol, int did, uint16_t bitmap,
     }
 
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -2497,9 +2587,9 @@ unsigned int AFPGetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap,
     memcpy(&dsi->commands[ofs], attrname, len);
     ofs += len;
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -2532,9 +2622,9 @@ unsigned int AFPListExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap,
     ofs += sizeof(maxsize);
     ofs = FPset_name(conn, ofs, pathname);
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -2584,9 +2674,9 @@ unsigned int AFPSetExtAttr(CONN *conn, uint16_t vol, int did, uint16_t bitmap,
     memcpy(&dsi->commands[ofs], data, datalen);
     ofs += datalen;
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 
@@ -2623,8 +2713,8 @@ unsigned int AFPRemoveExtAttr(CONN *conn, uint16_t vol, int did,
     memcpy(&dsi->commands[ofs], attrname, len);
     ofs += len;
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }

--- a/test/testsuite/afpclient.h
+++ b/test/testsuite/afpclient.h
@@ -180,6 +180,13 @@ typedef struct CONN {
 #endif
     int type;
     int afp_version;
+
+    /* Captured on kFPAuthContinue from FPLoginExt or FPLoginCont.
+     * UAM helpers can read login_cont_data/_len and pass login_cont_id
+     * back into AFPLoginCont for the next round trip. */
+    uint16_t login_cont_id;
+    size_t   login_cont_len;
+    uint8_t  login_cont_data[DSI_CMDSIZ];
 } CONN;
 
 extern CONN *Conn, *Conn2;
@@ -188,15 +195,8 @@ extern CONN *Conn, *Conn2;
 
 #define PASSWDLEN 8
 
-#define dsi_clientID(x)   ((x)->clientID++)
-
-#define my_dsi_send(x)       do { \
-    (x)->header.dsi_len = htonl((x)->cmdlen); \
-    my_dsi_stream_send((x), (x)->commands, (x)->cmdlen); \
-} while (0)
-
-int my_dsi_cmd_receive(DSI *x);
-int my_dsi_data_receive(DSI *x);
+int dsi_cmd_receive(DSI *x);
+int dsi_data_receive(DSI *x);
 
 void SendInit(DSI *dsi);
 void SetLen(DSI *dsi, int ofs);
@@ -259,22 +259,34 @@ int OpenClientSocket(char *host, int port);
 int CloseClientSocket(int fd);
 
 
-size_t my_dsi_stream_read(DSI *dsi, void *data, const size_t length);
-int my_dsi_stream_receive(DSI *dsi, void *buf, const size_t ilength,
-                          size_t *rlength);
-size_t my_dsi_stream_write(DSI *dsi, void *data, const size_t length);
-int my_dsi_stream_send(DSI *dsi, void *buf, size_t length);
-uint16_t my_dsi_cmd_nwriterply_async(CONN *conn, uint64_t n);
 void dump_header(DSI *dsi);
 
 unsigned int DSIOpenSession(CONN *conn);
 unsigned int DSIGetStatus(CONN *conn);
 unsigned int DSICloseSession(CONN *conn);
 
-unsigned int AFPopenLogin(CONN *conn, char *vers, char *uam, char *usr,
-                          char *pwd);
-unsigned int AFPopenLoginExt(CONN *conn, char *vers, char *uam, char *usr,
-                             char *pwd);
+unsigned int AFPopenLogin(CONN *conn, const char *vers, const char *uam,
+                          const char *usr, const char *pwd);
+
+/* Build an FPLoginExt with an arbitrary UserAuthInfo payload.
+ * Callers that need plain 8-byte cleartext padding should use
+ * AFPopenLoginExt_pwd() instead. */
+unsigned int AFPopenLoginExt(CONN *conn,
+                             const char *vers, const char *uam,
+                             const char *usr,
+                             const void *auth_info, size_t auth_info_len);
+
+/* Convenience wrapper: FPLoginExt with the 8-byte zero-padded cleartext
+ * password payload that No-User-Authent and Cleartxt-Passwrd UAMs expect. */
+unsigned int AFPopenLoginExt_pwd(CONN *conn,
+                                 const char *vers, const char *uam,
+                                 const char *usr, const char *pwd);
+
+/* FPLoginCont with an arbitrary UserAuthInfo payload. Uses
+ * conn->login_cont_id captured from the previous FPLoginExt/FPLoginCont
+ * reply, and refreshes conn->login_cont_* on kFPAuthContinue. */
+unsigned int AFPLoginCont(CONN *conn,
+                          const void *auth_info, size_t auth_info_len);
 unsigned int AFPLogOut(CONN *conn);
 unsigned int AFPChangePW(CONN *conn, char *uam, char *usr, char *opwd,
                          char *pwd);

--- a/test/testsuite/afpcmd.c
+++ b/test/testsuite/afpcmd.c
@@ -621,12 +621,7 @@ unsigned int FPopenLoginExt(CONN *conn, char *vers, char *uam, char *usr,
                 __func__, vers, uam, usr);
     }
 
-#if 0
-    /* FIXME: Workaround for AFPopenLoginExt() being broken */
-    ret = AFPopenLoginExt(conn, vers, uam, usr, pwd);
-#else
-    ret = AFPopenLogin(conn, vers, uam, usr, pwd);
-#endif
+    ret = AFPopenLoginExt_pwd(conn, vers, uam, usr, pwd);
     dump_header(dsi);
     return ret;
 }
@@ -876,9 +871,9 @@ uint16_t  FPOpenDT(CONN *conn, uint16_t vol)
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     dump_header(dsi);
 
     if (!dsi->header.dsi_code) {
@@ -930,9 +925,9 @@ unsigned int FPGetIcon(CONN *conn, uint16_t dt, char *creator, char *type,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -974,10 +969,10 @@ unsigned int FPAddIcon(CONN *conn, uint16_t dt, char *creator, char *type,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen + size);
     dsi->header.dsi_code = htonl(ofs);
-    my_dsi_stream_send(dsi, dsi->commands, ofs);
-    my_dsi_stream_write(dsi, data, size);
+    dsi_stream_send(dsi, dsi->commands, ofs);
+    dsi_stream_write(dsi, data, size);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -1012,9 +1007,9 @@ unsigned int FPGetIconInfo(CONN *conn, uint16_t dt, unsigned char *creator,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -1182,15 +1177,15 @@ unsigned int FPCloseDir(CONN *conn, uint16_t vol, int did)
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
 
 /* -------------------------------
-* FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree()
+* FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree()
 */
 unsigned int FPEnumerate(CONN *conn,
                          uint16_t vol,
@@ -1244,16 +1239,16 @@ unsigned int FPEnumerate(CONN *conn,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
 
 
 /* -------------------------------
-* FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree()
+* FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree()
 */
 unsigned int FPEnumerateFull(CONN *conn,
                              uint16_t vol,
@@ -1314,9 +1309,9 @@ unsigned int FPEnumerateFull(CONN *conn,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -1357,9 +1352,9 @@ unsigned int FPGetFileDirParams(CONN *conn, uint16_t vol, int did, char *name,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -1392,9 +1387,9 @@ unsigned int FPCreateID(CONN *conn, uint16_t vol, int did, char *name)
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -1426,9 +1421,9 @@ unsigned int FPDeleteID(CONN *conn, uint16_t vol, int did)
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -1463,14 +1458,14 @@ unsigned int FPResolveID(CONN *conn, uint16_t vol, int did, uint16_t bitmap)
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
 /* -------------------------------
-* FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree()
+* FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree()
 */
 unsigned int FPEnumerate_ext(CONN *conn, uint16_t vol, int did, char *name,
                              uint16_t f_bitmap, uint16_t d_bitmap)
@@ -1527,15 +1522,15 @@ unsigned int FPEnumerate_ext(CONN *conn, uint16_t vol, int did, char *name,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
 
 /* -------------------------------
-* FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree()
+* FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree()
 */
 unsigned int FPEnumerate_ext2(CONN *conn, uint16_t vol, int did, char *name,
                               uint16_t f_bitmap, uint16_t d_bitmap)
@@ -1593,15 +1588,15 @@ unsigned int FPEnumerate_ext2(CONN *conn, uint16_t vol, int did, char *name,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
 
 /* -------------------------------
-* FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree()
+* FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree()
 */
 unsigned int FPEnumerateExt2Full(CONN *conn,
                                  uint16_t vol,
@@ -1666,9 +1661,9 @@ unsigned int FPEnumerateExt2Full(CONN *conn,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -1777,9 +1772,9 @@ unsigned int FPOpenDir(CONN *conn, uint16_t vol, int did, char *name)
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
 
     if (!dsi->header.dsi_code) {
@@ -1983,9 +1978,9 @@ unsigned int FPSetDirParms(CONN *conn, uint16_t vol, int did, char *name,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -2029,9 +2024,9 @@ unsigned int FPSetFileParams(CONN *conn, uint16_t vol, int did, char *name,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -2061,9 +2056,9 @@ unsigned int FPSyncDir(CONN *conn, uint16_t vol, int did)
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -2149,9 +2144,9 @@ unsigned int FPSetFilDirParam(CONN *conn, uint16_t vol, int did, char *name,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_cmd_receive(dsi);
+    dsi_cmd_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -2190,9 +2185,9 @@ unsigned int FPCopyFile(CONN *conn, uint16_t svol, int sdid, uint16_t dvol,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -2229,9 +2224,9 @@ unsigned int FPExchangeFile(CONN *conn, uint16_t vol, int sdid, int ddid,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -2268,9 +2263,9 @@ unsigned int FPMoveAndRename(CONN *conn, uint16_t svol, int sdid, int ddid,
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }
@@ -2302,9 +2297,9 @@ unsigned int FPRename(CONN *conn, uint16_t svol, int sdid, char *src, char *dst)
     dsi->datalen = ofs;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_code = 0;
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
     /* ------------------ */
-    my_dsi_data_receive(dsi);
+    dsi_data_receive(dsi);
     dump_header(dsi);
     return dsi->header.dsi_code;
 }

--- a/test/testsuite/afpcmd_spotlight.c
+++ b/test/testsuite/afpcmd_spotlight.c
@@ -118,8 +118,8 @@ static unsigned int spotlight_send(CONN *conn,
     }
 
     SetLen(dsi, ofs);
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
-    my_dsi_data_receive(dsi);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_data_receive(dsi);
     return dsi->header.dsi_code;
 }
 

--- a/test/testsuite/afphelper.c
+++ b/test/testsuite/afphelper.c
@@ -62,8 +62,8 @@ void illegal_fork(DSI *dsi, char cmd, char *name)
         fprintf(stdout, "AFP call  %d\n\n", cmd);
     }
 
-    my_dsi_stream_send(dsi, dsi->commands, dsi->datalen);
-    my_dsi_cmd_receive(dsi);
+    dsi_stream_send(dsi, dsi->commands, dsi->datalen);
+    dsi_cmd_receive(dsi);
     dump_header(dsi);
 
     if (ntohl(AFPERR_PARAM) != dsi->header.dsi_code) {
@@ -273,7 +273,7 @@ int no_access_folder(uint16_t vol, int did, char *name)
         /* Mac OSX here does strange things
          * for when things go wrong */
         test_nottested();
-        /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+        /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
         FPEnumerate(Conn2, vol2,  DIRDID_ROOT, "",
                     (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR),
                     (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) |
@@ -1049,11 +1049,11 @@ int delete_directory_tree_by_did(CONN *conn, uint16_t volume, uint32_t dir_id)
         }
 
         /* Process batch */
-        /* WARN: FPEnumerate and FPEnumerate* use my_dsi_data_receive, other commands use my_dsi_cmd_receive.
-         my_dsi_data_receive stores data length in 'cmdlen', not 'datalen'?
-         my_dsi_cmd_receive (line 321) - receives data into DSI_CMDSIZ buffer (x->commands)
-         my_dsi_data_receive (line 327) - receives data into DSI_DATASIZ buffer (x->data)
-         So my_dsi_data_receive data is received into dsi->data buffer, not dsi->commands.
+        /* WARN: FPEnumerate and FPEnumerate* use dsi_data_receive, other commands use dsi_cmd_receive.
+         dsi_data_receive stores data length in 'cmdlen', not 'datalen'?
+         dsi_cmd_receive (line 321) - receives data into DSI_CMDSIZ buffer (x->commands)
+         dsi_data_receive (line 327) - receives data into DSI_DATASIZ buffer (x->data)
+         So dsi_data_receive data is received into dsi->data buffer, not dsi->commands.
          &conn->dsi->cmdlen = datalen
          &conn->dsi->data + 0 = fbitmap
          &conn->dsi->data + 2 = dbitmap

--- a/test/testsuite/dsi.h
+++ b/test/testsuite/dsi.h
@@ -16,12 +16,16 @@
 
 /*!
  * @file
- * @brief DSI (Data Stream Interface) protocol definitions
- * modified for the afptest test-suite
+ * @brief DSI (Data Stream Interface) protocol definitions for the test-suite.
  *
- * The interface for the test-suite differs from the libatalk DSI interface
- * in that is retains a statically allocated buffer for commands
- * as well as smaller command and data buffer sizes that fit in 16 bit size fields.
+ * Client-side DSI used by the afptest tools. Unlike the libatalk server-side
+ * DSI implementation, this variant:
+ *  - has no proto_open/proto_close, no listening socket, no AFPObj
+ *  - uses statically allocated buffers (commands[DSI_CMDSIZ],
+ *    data[DSI_DATASIZ]) sized to fit 16-bit AFP length fields
+ *  - only implements the stream send/receive primitives a client needs;
+ *    server-side helpers (dsi_init, dsi_readinit, dsi_writeinit, etc.) are
+ *    intentionally not provided here
  *
  * What a DSI packet looks like:
  * @code
@@ -52,8 +56,6 @@ struct dsi_block {
 
 #define DSI_CMDSIZ        800
 #define DSI_DATASIZ       8192
-/* child and parent processes might interpret a couple of these
- * differently. */
 typedef struct DSI {
     struct dsi_block header;
     struct sockaddr_in server, client;
@@ -117,41 +119,18 @@ typedef struct DSI {
 /*! default port number */
 #define DSI_AFPOVERTCP_PORT 548
 
-/*! basic initialization: dsi_init.c */
-extern DSI *dsi_init(
-    const char * /*program*/,
-    const char * /*host*/, const char * /*address*/,
-    const int /*port*/, const int /*proxy*/,
-    const uint32_t /* server quantum */);
-extern void dsi_setstatus(DSI *, uint8_t *, const int);
-
-/* in dsi_getsess.c */
-extern void dsi_kill(int);
-
-/* low-level stream commands -- in dsi_stream.c */
-extern size_t dsi_stream_write(DSI *, void *, const size_t);
+/* low-level stream commands -- implemented in afpclient.c */
 extern size_t dsi_stream_read(DSI *, void *, const size_t);
-extern int dsi_stream_send(DSI *, void *, size_t);
 extern int dsi_stream_receive(DSI *, void *, const size_t, size_t *);
-
-/* client writes -- dsi_write.c */
-extern size_t dsi_writeinit(DSI *, void *, const size_t);
-extern size_t dsi_write(DSI *, void *, const size_t);
-extern void   dsi_writeflush(DSI *);
-#define dsi_wrtreply(a,b)  dsi_cmdreply(a,b)
-
-/* client reads -- dsi_read.c */
-extern ssize_t dsi_readinit(DSI *, void *, const size_t, const size_t,
-                            const int);
-extern ssize_t dsi_read(DSI *, void *, const size_t);
-extern void dsi_readdone(DSI *);
+extern size_t dsi_stream_write(DSI *, void *, const size_t);
+extern int dsi_stream_send(DSI *, void *, size_t);
 
 /* some useful macros */
+#define dsi_clientID(x)   ((x)->clientID++)
 #define dsi_serverID(x)   ((x)->serverID++)
 #define dsi_send(x)       do { \
     (x)->header.dsi_len = htonl((x)->cmdlen); \
     dsi_stream_send((x), (x)->commands, (x)->cmdlen); \
 } while (0)
-#define dsi_receive(x)    (dsi_stream_receive((x), (x)->commands, \
-					      DSI_CMDSIZ, &(x)->cmdlen))
+
 #endif /* atalk/dsi.h */

--- a/test/testsuite/logintest.c
+++ b/test/testsuite/logintest.c
@@ -1,3 +1,4 @@
+#include <dlfcn.h>
 #include <getopt.h>
 
 #include "afpclient.h"
@@ -40,9 +41,7 @@ static char  *vers = "AFP3.4";
 
 STATIC void connect_server(CONN *conn)
 {
-    DSI *dsi;
     int sock;
-    dsi = &conn->dsi;
     sock = OpenClientSocket(Server, Port);
 
     if (sock < 0) {
@@ -50,7 +49,13 @@ STATIC void connect_server(CONN *conn)
         exit(ExitCode);
     }
 
-    dsi->socket = sock;
+    memset(&conn->dsi, 0, sizeof(conn->dsi));
+    conn->dsi.socket = sock;
+    /* Guard against a server that accepts the TCP connection but stalls before
+     * replying (e.g. parent busy reaping prior children after a connection-limit
+     * test). Without this, dsi_stream_read blocks in read() indefinitely. */
+    struct timeval tv = { .tv_sec = 15, .tv_usec = 0 };
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
 }
 
 /* ------------------------- */
@@ -152,61 +157,100 @@ test_exit:
     exit_test("Logintest:test3: Guest login");
 }
 
-/* ------------------------- */
-/* FIXME: when max connections is exceeded the server still returns
- * code DSIERR_OK and not DSIERR_TOOMANY (Netatalk 4.0.3, 3.1.12) */
+/* With Netatalk we define the default as 200 maximum connections,
+ * while with the AFP server on Mac OS X 10.7 Lion the default is 10.
+ * Therefore, test up to 201 to exercise either limit. */
+#define TEST4_MAX_CONNS 201
+
+/* The AFP Reference defines kFPNoMoreSessions (-1068) for FPLogin/FPLoginExt
+ * when the server is at its session cap (Table 50: FPLoginExt result
+ * codes), but says nothing about a DSI-layer error code for this case.
+ * netatalk actually enforces the cap one layer down, in dsi_getsess.c,
+ * by sending DSIERR_SERVBUSY (0xFBD1) on the DSIOpenSession reply — so
+ * the client never reaches the FPLogin stage. This test accepts either
+ * code as "limit hit". */
 STATIC void test4(void)
 {
-    CONN conn[50];
-    int  i;
-    int  cnt = 0;
-    int  ret;
+    static char *uam = "No User Authent";
+    CONN conn[TEST4_MAX_CONNS];
+    int cnt = 0;
+    unsigned int ret = 0;
+    uint32_t code_host;
+    int hit_limit = 0;
     ENTER_TEST
 
-    for (i = 0; i < 50; i++) {
-        connect_server(&conn[i]);
-        Dsi = &conn[i].dsi;
-
+    for (int i = 0; i < TEST4_MAX_CONNS; i++) {
         if (!Quiet) {
-            fprintf(stdout, "DSIOpenSession number %d\n", i);
+            fprintf(stdout, "conn %d\n", i);
         }
 
-        if ((ret = DSIOpenSession(&conn[i]))) {
-            if (ret != DSIERR_TOOMANY) {
-                test_failed();
-                goto test_exit;
-            }
+        connect_server(&conn[i]);
+        Dsi = &conn[i].dsi;
+        cnt++;
 
-            cnt = i;
+        if (Version >= 30) {
+            ret = FPopenLoginExt(&conn[i], vers, uam, "", "");
+        } else {
+            ret = FPopenLogin(&conn[i], vers, uam, "", "");
+        }
+
+        code_host = ntohl(ret);
+
+        if (code_host == (uint32_t) AFPERR_MAXSESS
+                || code_host == DSIERR_SERVBUSY) {
+            hit_limit = 1;
             break;
         }
 
-        if (!Quiet) {
-            fprintf(stdout, "DSIOpenSession return code %04x\n", ret);
+        if (ret) {
+            if (!Quiet) {
+                fprintf(stdout,
+                        "Unexpected login error at conn %d: %d (%s)\n",
+                        i, code_host, afp_error(ret));
+            }
+
+            test_failed();
+            goto cleanup;
         }
     }
 
-    if (!cnt) {
+    if (!hit_limit) {
         if (!Quiet) {
-            fprintf(stdout, "All connections succeeded\n");
+            fprintf(stdout,
+                    "All %d logins succeeded; server cap is > %d\n",
+                    cnt, cnt);
         }
 
         test_nottested();
-        goto test_exit;
     }
 
-    for (i = 0; i < cnt; i++) {
-        Dsi = &conn[i].dsi;
+cleanup:
+    /* Send DSICloseSession on all connections that have an open DSI session,
+     * then close sockets. DSIERR_SERVBUSY means DSIOpenSession itself was
+     * rejected -- no DSI session was established, so skip DSICloseSession for
+     * that slot and just shut its socket. AFPERR_MAXSESS means DSIOpenSession
+     * succeeded but AFP rejected the login -- the DSI session IS open and must
+     * be properly closed, or the server keeps the slot occupied. Sleep after to
+     * let the server reap workers, otherwise the next test may fail with
+     * SERVBUSY waiting for a free fork slot. */
+    {
+        int failed_idx = (hit_limit && code_host == DSIERR_SERVBUSY) ? cnt - 1 : -1;
 
-        if (DSICloseSession(&conn[i])) {
-            test_failed();
-            goto test_exit;
+        for (int j = 0; j < cnt; j++) {
+            if (j != failed_idx) {
+                DSICloseSession(&conn[j]);
+            }
+
+            CloseClientSocket(conn[j].dsi.socket);
         }
     }
 
-test_exit:
-    CloseClientSocket(Dsi->socket);
-    exit_test("Logintest:test4: too many connections");
+    if (cnt > 0) {
+        fflush(stdout);
+        sleep(3);
+    }
+
+    exit_test("Logintest:test4: connection limit hit returns server-busy");
 }
 
 /* ------------------------- */
@@ -264,8 +308,8 @@ STATIC void test6(void)
     dsi->commands[1] = sizeof(i);
     i = htonl(DSI_DEFQUANT);
     memcpy(dsi->commands + 2, &i, sizeof(i));
-    my_dsi_send(dsi);
-    my_dsi_cmd_receive(dsi);
+    dsi_send(dsi);
+    dsi_cmd_receive(dsi);
 
     if (!User || Password[0] == '\0') {
         test_skipped(T_CRED);
@@ -291,11 +335,319 @@ test_exit:
     exit_test("Logintest:test6: DSIOpenSession non zero parameter should be ignored by the server");
 }
 
+/* Direct round-trip through the renamed dsi_stream_send / dsi_cmd_receive
+ * primitives. Sends an unknown AFP command (255) to an open but
+ * unauthenticated session; expect AFPERR_NOOP from the server's switch
+ * dispatcher. Catches regressions in the I/O layer. */
+STATIC void test7(void)
+{
+    DSI *dsi;
+    ENTER_TEST
+    connect_server(Conn);
+    Dsi = &Conn->dsi;
+    dsi = Dsi;
+
+    if (DSIOpenSession(Conn)) {
+        test_failed();
+        goto test_exit;
+    }
+
+    memset(&dsi->header, 0, sizeof(dsi->header));
+    dsi->header.dsi_flags = DSIFL_REQUEST;
+    dsi->header.dsi_command = DSIFUNC_CMD;
+    dsi->header.dsi_requestID = htons(dsi_clientID(dsi));
+    dsi->commands[0] = 0xFF;            /* unknown AFP command */
+    dsi->commands[1] = 0;
+    dsi->cmdlen = 2;
+    dsi_send(dsi);
+    dsi_cmd_receive(dsi);
+
+    /* Any non-zero error code means the round trip worked. A zero result
+     * would mean the server accepted an unknown command, which would be a
+     * server bug, not a client one. */
+    if (dsi->header.dsi_code == 0) {
+        test_failed();
+        goto test_exit;
+    }
+
+    if (DSICloseSession(Conn)) {
+        test_failed();
+        goto test_exit;
+    }
+
+test_exit:
+    CloseClientSocket(Dsi->socket);
+    exit_test("Logintest:test7: DSI round-trip via renamed dsi_stream_send/dsi_cmd_receive");
+}
+
+/* FPLoginExt + No User Authent via AFPopenLoginExt_pwd directly, bypassing
+ * the FPopenLoginExt wrapper. Validates the post-B1 wire format
+ * independently of the wrapper's version-branching. AFP >= 3.0 only. */
+STATIC void test8(void)
+{
+    static const char *uam = "No User Authent";
+    unsigned int ret;
+    ENTER_TEST
+    connect_server(Conn);
+    Dsi = &Conn->dsi;
+
+    if (Version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
+    ret = AFPopenLoginExt_pwd(Conn, vers, uam, "", "");
+
+    if (ret) {
+        test_failed();
+        goto test_exit;
+    }
+
+    if (FPLogOut(Conn)) {
+        test_failed();
+    }
+
+test_exit:
+    CloseClientSocket(Dsi->socket);
+    exit_test("Logintest:test8: FPLoginExt + No User Authent (direct)");
+}
+
+/* Smoke test for AFPLoginCont primitive (Part B4). Drives DHCAST128 with
+ * an empty UserAuthInfo to provoke kFPAuthContinue, then sends garbage
+ * via AFPLoginCont to verify the wire format reaches the server's
+ * logincont entry point. Skipped if the server does not load DHCAST128
+ * (returns AFPERR_BADUAM) or doesn't return kFPAuthContinue. Does NOT
+ * authenticate -- this only exercises the round-trip plumbing. */
+STATIC void test9(void)
+{
+    static const char *uam = "DHCAST128";
+    unsigned int ret;
+    uint8_t garbage[16];
+    ENTER_TEST
+    connect_server(Conn);
+    Dsi = &Conn->dsi;
+
+    if (Version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
+    if (!User) {
+        test_skipped(T_CRED);
+        goto test_exit;
+    }
+
+    ret = AFPopenLoginExt(Conn, vers, uam, User, NULL, 0);
+
+    if (ntohl(ret) != (uint32_t) AFPERR_AUTHCONT) {
+        if (!Quiet) {
+            fprintf(stdout,
+                    "AFPopenLoginExt returned %d (%s), expected AFPERR_AUTHCONT\n",
+                    ntohl(ret), afp_error(ret));
+        }
+
+        test_nottested();
+        goto test_exit;
+    }
+
+    if (Conn->login_cont_len == 0) {
+        /* Got AUTHCONT but no payload captured -- that's a real bug. */
+        test_failed();
+        goto test_exit;
+    }
+
+    memset(garbage, 0xAA, sizeof(garbage));
+    ret = AFPLoginCont(Conn, garbage, sizeof(garbage));
+
+    /* Any non-zero result is acceptable: the server rejected our garbage
+     * response, which means AFPLoginCont reached the UAM. A zero result
+     * would mean we authenticated with random bytes, which is impossible
+     * unless something is very wrong. */
+    if (ret == 0) {
+        test_failed();
+    }
+
+test_exit:
+    CloseClientSocket(Dsi->socket);
+    exit_test("Logintest:test9: AFPLoginCont primitive round-trip");
+}
+
+/* UAM dispatch table. Each runner returns dsi_code (0 == success).
+ * Plug-in point for DHX/DHX2/SRP later -- add a runner that drives the
+ * corresponding crypto via AFPopenLoginExt + AFPLoginCont, then list it
+ * here. */
+struct uam_test {
+    const char *uam_name;
+    unsigned int (*run)(CONN *conn, const char *vers,
+                        const char *user, const char *pwd);
+    int needs_cred;       /* 1 = skip if !User/!Password */
+};
+
+static unsigned int run_nua(CONN *conn, const char *pvers,
+                            const char *user _U_, const char *pwd _U_)
+{
+    return AFPopenLoginExt_pwd(conn, pvers, "No User Authent", "", "");
+}
+
+static unsigned int run_cleartxt(CONN *conn, const char *pvers,
+                                 const char *user, const char *pwd)
+{
+    return AFPopenLoginExt_pwd(conn, pvers, "Cleartxt Passwrd", user, pwd);
+}
+
+static const struct uam_test uam_matrix[] = {
+    { "No User Authent",  run_nua,      0 },
+    { "Cleartxt Passwrd", run_cleartxt, 1 },
+    /* Plug-in slots (need crypto helpers, see comment above):
+     * { "Randnum Exchange", run_randnum,  1 },
+     * { "2-Way Randnum exchange", run_randnum2,  1 },
+     * { "DHCAST128", run_dhx,  1 },
+     * { "DHX2",      run_dhx2, 1 },
+     * { "SRP",       run_srp,  1 },
+     */
+    { NULL, NULL, 0 }
+};
+
+STATIC void test10(void)
+{
+    ENTER_TEST
+
+    if (Version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
+    for (const struct uam_test *e = uam_matrix; e->uam_name; e++) {
+        if (e->needs_cred && (!User || Password[0] == '\0')) {
+            if (!Quiet) {
+                fprintf(stdout, "  [%s] skipped (no credentials)\n",
+                        e->uam_name);
+            }
+
+            continue;
+        }
+
+        connect_server(Conn);
+        Dsi = &Conn->dsi;
+        unsigned int ret = e->run(Conn, vers, User, Password);
+
+        if (ret) {
+            if (!Quiet) {
+                fprintf(stdout, "  [%s] failed: dsi_code=0x%x\n",
+                        e->uam_name, ntohl(ret));
+            }
+
+            test_failed();
+        } else {
+            Conn->afp_version = Version;
+            FPLogOut(Conn);
+
+            if (!Quiet) {
+                fprintf(stdout, "  [%s] ok\n", e->uam_name);
+            }
+        }
+
+        CloseClientSocket(Dsi->socket);
+    }
+
+test_exit:
+    exit_test("Logintest:test10: UAM matrix walk");
+}
+
+struct test_fn {
+    const char *name;
+    void (*fn)(void);
+};
+
+static struct test_fn Test_list[] = {
+    { "test1",  test1  },
+    { "test2",  test2  },
+    { "test3",  test3  },
+    { "test4",  test4  },
+    { "test5",  test5  },
+    { "test6",  test6  },
+    { "test7",  test7  },
+    { "test8",  test8  },
+    { "test9",  test9  },
+    { "test10", test10 },
+    { NULL, NULL },
+};
+
+/* =============================== */
+static void list_tests(void)
+{
+    int i = 0;
+    fprintf(stdout, "Available tests. Run individually with the -f option.\n");
+
+    while (Test_list[i].name != NULL) {
+        fprintf(stdout, "%s\n", Test_list[i].name);
+        i++;
+    }
+}
+
+/* ----------- */
+static void run_one(char *name)
+{
+    int i = 0;
+    void *handle = NULL;
+    void (*fn)(void) = NULL;
+    char *error;
+
+    while (Test_list[i].name != NULL) {
+        if (!strcmp(Test_list[i].name, name)) {
+            break;
+        }
+
+        i++;
+    }
+
+    if (Test_list[i].name == NULL) {
+        handle = dlopen(NULL, RTLD_NOW);
+
+        if (handle) {
+            dlerror();
+            fn = dlsym(handle, name);
+
+            if ((error = dlerror()) != NULL) {
+                fprintf(stdout, "%s\n", error);
+                dlclose(handle);
+                handle = NULL;
+            }
+        } else {
+            fprintf(stdout, "%s\n", dlerror());
+        }
+
+        if (!handle || !fn) {
+            test_nottested();
+            return;
+        }
+    } else {
+        fn = Test_list[i].fn;
+    }
+
+    (*fn)();
+
+    if (handle) {
+        dlclose(handle);
+    }
+}
+
+/* ----------- */
+static void run_all(void)
+{
+    int i = 0;
+
+    while (Test_list[i].name != NULL) {
+        Test_list[i].fn();
+        i++;
+    }
+}
+
 /* =============================== */
 void usage(char *av0)
 {
     fprintf(stdout,
-            "usage:\t%s [-1234567CmVv] [-h host] [-p port] [-s vol] [-u user] [-w password]\n",
+            "usage:\t%s [-1234567CmVv] [-h host] [-p port] [-u user] [-w password] [-f test]\n",
             av0);
     fprintf(stdout, "\t-m\tserver is a Mac\n");
     fprintf(stdout, "\t-h\tserver host name (default localhost)\n");
@@ -312,6 +664,8 @@ void usage(char *av0)
     fprintf(stdout, "\t-v\tverbose\n");
     fprintf(stdout, "\t-V\tvery verbose\n");
     fprintf(stdout, "\t-C\tturn off terminal color output\n");
+    fprintf(stdout, "\t-f\ttest to run\n");
+    fprintf(stdout, "\t-l\tlist tests\n");
     exit(1);
 }
 
@@ -324,7 +678,7 @@ int main(int ac, char **av)
         usage(av[0]);
     }
 
-    while ((cc = getopt(ac, av, "1234567CmVvh:p:u:w:")) != EOF) {
+    while ((cc = getopt(ac, av, "1234567CmVvf:h:lp:u:w:")) != EOF) {
         switch (cc) {
         case '1':
             vers = "AFPVersion 2.1";
@@ -365,8 +719,16 @@ int main(int ac, char **av)
             Color = 0;
             break;
 
+        case 'f':
+            Test = strdup(optarg);
+            break;
+
         case 'h':
             Server = strdup(optarg);
+            break;
+
+        case 'l':
+            List = 1;
             break;
 
         case 'm':
@@ -405,6 +767,11 @@ int main(int ac, char **av)
         }
     }
 
+    if (List) {
+        list_tests();
+        exit(2);
+    }
+
     if (!Quiet) {
         fprintf(stdout, "Connecting to host %s:%d\n", Server, Port);
     }
@@ -413,20 +780,43 @@ int main(int ac, char **av)
         return 1;
     }
 
-    test1();
-    test2();
-    test3();
-#if 0
-    test4();
-#endif
-    test5();
-    test6();
-    fprintf(stdout, "===================\n");
-    fprintf(stdout, "TEST RESULT SUMMARY\n");
-    fprintf(stdout, "-------------------\n");
+    if (Test != NULL) {
+        run_one(Test);
+    } else {
+        run_all();
+    }
+
+    fprintf(stdout, "=====================\n");
+    fprintf(stdout, " TEST RESULT SUMMARY\n");
+    fprintf(stdout, "---------------------\n");
     fprintf(stdout, "  Passed:     %d\n", PassCount);
-    fprintf(stdout, "  Failed:     %d\n", FailCount);
     fprintf(stdout, "  Skipped:    %d\n", SkipCount);
+    fprintf(stdout, "  Failed:     %d\n", FailCount);
     fprintf(stdout, "  Not tested: %d\n", NotTestedCount);
+
+    if (SkipCount) {
+        fprintf(stdout, "\n  Skipped tests (precondition not met):\n");
+
+        for (int i = 0; i < SkipCount; i++) {
+            fprintf(stdout, "    %s\n", SkippedTests[i]);
+        }
+    }
+
+    if (FailCount) {
+        fprintf(stdout, "\n  Failed tests:\n");
+
+        for (int i = 0; i < FailCount; i++) {
+            fprintf(stdout, "    %s\n", FailedTests[i]);
+        }
+    }
+
+    if (NotTestedCount) {
+        fprintf(stdout, "\n  Not tested tests (setup step failed):\n");
+
+        for (int i = 0; i < NotTestedCount; i++) {
+            fprintf(stdout, "    %s\n", NotTestedTests[i]);
+        }
+    }
+
     return ExitCode;
 }

--- a/test/testsuite/rotest.c
+++ b/test/testsuite/rotest.c
@@ -67,7 +67,7 @@ STATIC void test510()
     }
 
     /* get a directory */
-    /* FIXME: FPEnumerate* uses my_dsi_data_receive. See afphelper.c:delete_directory_tree() */
+    /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     bitmap = (1 << DIRPBIT_LNAME);
     ret = FPEnumerateFull(Conn, VolID, 1, 1, 800,  DIRDID_ROOT, "", 0, bitmap);
 


### PR DESCRIPTION
This changeset enables the AFP 3.x LoginExt method which opens up for broader UAM support in the AFP test client. We fix up the long-disabled test4 that exercises the DSI session max connection limit while adding a handful of new login tests (not a complete set, just a few sanity tests to get started.)

We also fix a handful of latent bugs in DSI session code.

## DSI function namespace cleanup

Drop the my_dsi_* prefix from all test-client DSI I/O functions to align with the libatalk server-side naming convention: my_dsi_stream_read/write/ send/receive, my_dsi_tickle, my_dsi_cmd_receive, my_dsi_data_receive all
become their unprefixed equivalents. Affects call sites and comments across afpclient.c, afpcmd.c, and ~25 test modules. dsi.h is pruned of server-side extern declarations (dsi_init, dsi_setstatus, dsi_kill, dsi_writeinit,
dsi_write, dsi_writeflush, dsi_wrtreply, dsi_readinit, dsi_read, dsi_readdone) that the test client never uses; dsi_clientID migrates from afpclient.h to dsi.h where dsi_serverID already lives.

dsi_stream_read: unconditionally set dsi_code to 0xffffffff on short/EOF reads so callers cannot mistake a zeroed header for a success response.

## AFPopenLoginExt / AFPLoginCont / AFPopenLoginExt_pwd

Rewrite AFPopenLoginExt with a correct wire format: auth_info is now an opaque blob, UserAuthInfo is padded to an even offset, and kFPAuthContinue replies are captured by a new capture_login_cont() helper that saves the UAM continuation ID and payload into three new CONN fields (login_cont_id, login_cont_len, login_cont_data[DSI_CMDSIZ]).

Add AFPLoginCont() implementing FPLoginCont for multi-round UAMs: sends the saved continuation ID (re-encoded big-endian) with an arbitrary auth_info blob, and re-runs capture_login_cont() on another AFPERR_AUTHCONT reply.

Add AFPopenLoginExt_pwd() as a convenience wrapper: routes to AFPopenLogin for Cleartxt (FPLoginExt + Cleartxt is broken in netatalk), passes NULL auth_info for anonymous, and zero-pads the password to PASSWDLEN bytes for all other UAMs.

FPopenLoginExt() in afpcmd.c now calls AFPopenLoginExt_pwd() directly.

## afp_logintest improvements

- connect_server(): zero-initialise the DSI struct and install a 15-second SO_RCVTIMEO to prevent indefinite blocking when the server stalls after accept()
- test4(): expand connection array to 201 (TEST4_MAX_CONNS), drive a full AFP login (FPopenLoginExt / FPopenLogin) rather than raw DSIOpenSession, accept both DSIERR_SERVBUSY (DSI-layer cap) and AFPERR_MAXSESS (AFP-layer cap) as "limit hit", skip DSICloseSession on SERVBUSY (no session was established), and sleep 3 s after teardown to let the server reap workers
- test7() (new): DSI I/O round-trip smoke test — sends an unknown AFP command (0xFF) and verifies a non-zero dsi_code is returned; catches regressions in the renamed send/receive path independently of the login tests
- test8() (new): exercises AFPopenLoginExt_pwd() directly with No User Authent on AFP >= 3.0, bypassing FPopenLoginExt version-branching
- test9() (new): AFPLoginCont smoke test — provokes kFPAuthContinue via DHCAST128 then sends 16 bytes of garbage; verifies the round-trip reaches the UAM layer without crashing the server; skipped if DHCAST128 is absent or server does not return AFPERR_AUTHCONT
- test10() (new): UAM matrix walker over a dispatch table; covers No User Authent and Cleartxt Passwrd with placeholder slots for Randnum Exchange, 2-Way Randnum, DHCAST128, DHX2, and SRP

## Test runner infrastructure

- -f <name>: run a single test by symbol name
- -l: list all registered tests and exit with code 2
- aggressive parameter assertion in the afpclient interface

## libatalk/dsi: fix session-cap enforcement in dsi_getsession

Two bugs when server_child_add returns NULL because the session cap is reached (introduced in GitHub https://github.com/Netatalk/netatalk/pull/2831):

1. Post-fork path fell through to *childp = NULL; return 0, which made the parent process enter the child code path in dsi_start(), calling afp_over_dsi() and exit()ing, killing the listener. Fixed by calling dsi->proto_close() and returning -1 inside the failure block.

2. SERVBUSY was sent with dsi_command=0 and dsi_requestID=0 because the parent never reads the DSI header (the child reads it after the fork). Clients that match responses by request ID would discard the reply and time out. Fixed by adding a pre-fork cap check that accepts the TCP connection without forking, reads the DSIOpenSession header with MSG_DONTWAIT (non-blocking, no DoS risk), and sends a correctly-formed SERVBUSY with the echoed command and request ID before returning -1. Eliminates the fork+SIGKILL cycle for every over-cap connection. The post-fork check in server_child_add remains as defence-in-depth.

In afpd: log DSI session error only when errno is set