### PR TITLE
afppasswd: manage Randnum key files programmatically

### DIFF
--- a/bin/afppasswd/afppasswd.c
+++ b/bin/afppasswd/afppasswd.c
@@ -138,6 +138,7 @@ static int randnum_read_keyfd(int keyfd, uint8_t key[DES_KEY_SZ],
     if (lseek(keyfd, 0, SEEK_SET) < 0) {
         fprintf(stderr, "afppasswd: could not seek Randnum key file%s%s: %s\n",
                 keypath ? " " : "", keypath ? keypath : "", strerror(errno));
+        explicit_bzero(encoded, sizeof(encoded));
         return -1;
     }
 
@@ -146,6 +147,7 @@ static int randnum_read_keyfd(int keyfd, uint8_t key[DES_KEY_SZ],
     if (keylen < 0) {
         fprintf(stderr, "afppasswd: could not read Randnum key file%s%s: %s\n",
                 keypath ? " " : "", keypath ? keypath : "", strerror(errno));
+        explicit_bzero(encoded, sizeof(encoded));
         return -1;
     }
 
@@ -154,6 +156,7 @@ static int randnum_read_keyfd(int keyfd, uint8_t key[DES_KEY_SZ],
         fprintf(stderr,
                 "afppasswd: invalid Randnum key file%s%s: expected 16 hexadecimal characters with an optional trailing newline.\n",
                 keypath ? " " : "", keypath ? keypath : "");
+        explicit_bzero(encoded, sizeof(encoded));
         return -1;
     }
 
@@ -162,6 +165,7 @@ static int randnum_read_keyfd(int keyfd, uint8_t key[DES_KEY_SZ],
             fprintf(stderr,
                     "afppasswd: invalid Randnum key file%s%s: expected hexadecimal characters only.\n",
                     keypath ? " " : "", keypath ? keypath : "");
+            explicit_bzero(encoded, sizeof(encoded));
             return -1;
         }
     }

--- a/bin/afppasswd/afppasswd.c
+++ b/bin/afppasswd/afppasswd.c
@@ -16,7 +16,7 @@
  *
  * **RandNum mode** (-r flag):
  * Manages legacy password file for use with the RandNum UAM.
- * Format: name:hex_password(16):last_login(16):fail_count(8)
+ * Format: username:hex_password(16):last_login(16):fail_count(8)
  */
 
 #ifdef HAVE_CONFIG_H
@@ -75,6 +75,11 @@
 #define HEXPASSWDLEN 16
 #define PASSWDLEN 8
 
+static int unhex(unsigned char x)
+{
+    return isdigit(x) ? x - '0' : toupper(x) + 10 - 'A';
+}
+
 /*
  * RFC 5054 group #2: 1536-bit MODP group. N is the safe prime, g = 2.
  */
@@ -106,72 +111,258 @@ static const unsigned char srp_N_bytes[SRP_NBYTES] = {
 };
 
 static char buf[MAXPATHLEN + 1];
+static const unsigned char hextable[] = "0123456789ABCDEF";
 
-/* if newpwd is null, convert buf from hex to binary. if newpwd isn't
- * null, convert newpwd to hex and save it in buf. */
-#define unhex(x)  (isdigit(x) ? (x) - '0' : toupper(x) + 10 - 'A')
-static void convert_passwd(char *buf, char *newpwd, const int keyfd)
+static int randnum_make_keypath(const char *path, char *keypath,
+                                size_t keypath_size)
 {
-    uint8_t key[HEXPASSWDLEN];
+    size_t path_len = strnlen(path, keypath_size);
+
+    if (path_len > keypath_size - sizeof(".key")) {
+        fprintf(stderr,
+                "afppasswd: Randnum password file path is too long to locate companion key file.\n");
+        return -1;
+    }
+
+    strlcpy(keypath, path, keypath_size);
+    strlcat(keypath, ".key", keypath_size);
+    return 0;
+}
+
+static int randnum_read_keyfd(int keyfd, uint8_t key[DES_KEY_SZ],
+                              const char *keypath)
+{
+    uint8_t encoded[HEXPASSWDLEN + 2];
+    ssize_t keylen;
+
+    if (lseek(keyfd, 0, SEEK_SET) < 0) {
+        fprintf(stderr, "afppasswd: could not seek Randnum key file%s%s: %s\n",
+                keypath ? " " : "", keypath ? keypath : "", strerror(errno));
+        return -1;
+    }
+
+    keylen = read(keyfd, encoded, sizeof(encoded));
+
+    if (keylen < 0) {
+        fprintf(stderr, "afppasswd: could not read Randnum key file%s%s: %s\n",
+                keypath ? " " : "", keypath ? keypath : "", strerror(errno));
+        return -1;
+    }
+
+    if (keylen != HEXPASSWDLEN &&
+            (keylen != HEXPASSWDLEN + 1 || encoded[HEXPASSWDLEN] != '\n')) {
+        fprintf(stderr,
+                "afppasswd: invalid Randnum key file%s%s: expected 16 hexadecimal characters with an optional trailing newline.\n",
+                keypath ? " " : "", keypath ? keypath : "");
+        return -1;
+    }
+
+    for (int i = 0; i < HEXPASSWDLEN; i++) {
+        if (!isxdigit(encoded[i])) {
+            fprintf(stderr,
+                    "afppasswd: invalid Randnum key file%s%s: expected hexadecimal characters only.\n",
+                    keypath ? " " : "", keypath ? keypath : "");
+            return -1;
+        }
+    }
+
+    for (int i = 0, j = 0; i < HEXPASSWDLEN; i += 2, j++) {
+        key[j] = (uint8_t)((unhex(encoded[i]) << 4) | unhex(encoded[i + 1]));
+    }
+
+    explicit_bzero(encoded, sizeof(encoded));
+    return 0;
+}
+
+static int randnum_open_keyfile(const char *path, int *keyfd_out)
+{
+    char keypath[MAXPATHLEN + 1];
+    uint8_t key[DES_KEY_SZ];
+    int keyfd;
+
+    if (randnum_make_keypath(path, keypath, sizeof(keypath)) < 0) {
+        return -1;
+    }
+
+    keyfd = open(keypath, O_RDONLY);
+
+    if (keyfd < 0) {
+        fprintf(stderr, "afppasswd: required Randnum key file %s is unavailable: %s\n",
+                keypath, strerror(errno));
+        return -1;
+    }
+
+    if (randnum_read_keyfd(keyfd, key, keypath) < 0) {
+        close(keyfd);
+        explicit_bzero(key, sizeof(key));
+        return -1;
+    }
+
+    explicit_bzero(key, sizeof(key));
+    *keyfd_out = keyfd;
+    return 0;
+}
+
+static int randnum_write_keyfile(const char *keypath)
+{
+    uint8_t key[DES_KEY_SZ];
+    char encoded[HEXPASSWDLEN + 1];
+    int fd;
+    gcry_randomize(key, sizeof(key), GCRY_STRONG_RANDOM);
+
+    for (int i = 0, j = 0; i < DES_KEY_SZ; i++, j += 2) {
+        encoded[j] = hextable[(key[i] & 0xF0) >> 4];
+        encoded[j + 1] = hextable[key[i] & 0x0F];
+    }
+
+    encoded[HEXPASSWDLEN] = '\n';
+    fd = open(keypath, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+
+    if (fd < 0) {
+        fprintf(stderr, "afppasswd: can't create Randnum key file %s: %s\n",
+                keypath, strerror(errno));
+        explicit_bzero(key, sizeof(key));
+        explicit_bzero(encoded, sizeof(encoded));
+        return -1;
+    }
+
+    if (fchmod(fd, 0600) < 0) {
+        fprintf(stderr, "afppasswd: can't set permissions on Randnum key file %s: %s\n",
+                keypath, strerror(errno));
+        close(fd);
+        explicit_bzero(key, sizeof(key));
+        explicit_bzero(encoded, sizeof(encoded));
+        return -1;
+    }
+
+    if (write(fd, encoded, sizeof(encoded)) != (ssize_t)sizeof(encoded)) {
+        fprintf(stderr, "afppasswd: problem writing Randnum key file %s: %s\n",
+                keypath, strerror(errno));
+        close(fd);
+        explicit_bzero(key, sizeof(key));
+        explicit_bzero(encoded, sizeof(encoded));
+        return -1;
+    }
+
+    close(fd);
+    explicit_bzero(key, sizeof(key));
+    explicit_bzero(encoded, sizeof(encoded));
+    return 0;
+}
+
+static int randnum_ensure_keyfile(const char *path, int flags)
+{
+    char keypath[MAXPATHLEN + 1];
+    uint8_t key[DES_KEY_SZ];
+    int keyfd;
+
+    if (randnum_make_keypath(path, keypath, sizeof(keypath)) < 0) {
+        return -1;
+    }
+
+    keyfd = open(keypath, O_RDONLY);
+
+    if (keyfd < 0) {
+        if (errno != ENOENT) {
+            fprintf(stderr, "afppasswd: can't open Randnum key file %s: %s\n",
+                    keypath, strerror(errno));
+            return -1;
+        }
+
+        return randnum_write_keyfile(keypath);
+    }
+
+    if (randnum_read_keyfd(keyfd, key, keypath) == 0) {
+        close(keyfd);
+        explicit_bzero(key, sizeof(key));
+        return 0;
+    }
+
+    close(keyfd);
+    explicit_bzero(key, sizeof(key));
+
+    if (!(flags & OPT_FORCE)) {
+        fprintf(stderr,
+                "afppasswd: use -f with -r -c to replace invalid Randnum key file %s.\n",
+                keypath);
+        return -1;
+    }
+
+    return randnum_write_keyfile(keypath);
+}
+
+/* if newpwd is null, convert passwd_buf from hex to binary. if newpwd isn't
+ * null, convert newpwd to hex and save it in passwd_buf. */
+static int convert_passwd(char *passwd_buf, char *newpwd, const int keyfd)
+{
+    uint8_t key[DES_KEY_SZ];
     unsigned int i, j;
-    gcry_cipher_hd_t ctx;
+    gcry_cipher_hd_t ctx = NULL;
     gcry_error_t ctxerror;
 
     if (!newpwd) {
         /* convert to binary */
-        for (i = j = 0; i < sizeof(key); i += 2, j++) {
-            buf[j] = (unhex(buf[i]) << 4) | unhex(buf[i + 1]);
+        for (i = j = 0; i < HEXPASSWDLEN; i += 2, j++) {
+            passwd_buf[j] = (char)(uint8_t)((unhex(passwd_buf[i]) << 4) |
+                                            unhex(passwd_buf[i + 1]));
         }
 
         if (j <= DES_KEY_SZ) {
-            memset(buf + j, 0, sizeof(key) - j);
+            memset(passwd_buf + j, 0, HEXPASSWDLEN - j);
         }
     }
 
-    if (keyfd > -1) {
-        lseek(keyfd, 0, SEEK_SET);
+    if (keyfd < 0 || randnum_read_keyfd(keyfd, key, NULL) < 0) {
+        return -1;
+    }
 
-        if (read(keyfd, key, sizeof(key)) < 0) {
-            fprintf(stderr, "could not read key (%s)\n", strerror(errno));
-        }
+    ctxerror = gcry_cipher_open(&ctx, GCRY_CIPHER_DES, GCRY_CIPHER_MODE_ECB, 0);
 
-        /* convert to binary */
-        for (i = j = 0; i < sizeof(key); i += 2, j++) {
-            key[j] = (unhex(key[i]) << 4) | unhex(key[i + 1]);
-        }
-
-        if (j <= DES_KEY_SZ) {
-            memset(key + j, 0, sizeof(key) - j);
-        }
-
-        ctxerror = gcry_cipher_open(&ctx, GCRY_CIPHER_DES, GCRY_CIPHER_MODE_ECB, 0);
-        ctxerror = gcry_cipher_setkey(ctx, key, DES_KEY_SZ);
+    if (ctxerror) {
+        fprintf(stderr, "afppasswd: gcry_cipher_open failed: %s\n",
+                gcry_strerror(ctxerror));
         explicit_bzero(key, sizeof(key));
+        return -1;
+    }
 
-        if (newpwd) {
-            ctxerror = gcry_cipher_encrypt(ctx, newpwd, DES_KEY_SZ, NULL, 0);
-        } else {
-            /* decrypt the password */
-            ctxerror = gcry_cipher_decrypt(ctx, buf, DES_KEY_SZ, NULL, 0);
-        }
+    ctxerror = gcry_cipher_setkey(ctx, key, DES_KEY_SZ);
+    explicit_bzero(key, sizeof(key));
 
+    if (ctxerror) {
+        fprintf(stderr, "afppasswd: gcry_cipher_setkey failed: %s\n",
+                gcry_strerror(ctxerror));
         gcry_cipher_close(ctx);
+        return -1;
     }
 
     if (newpwd) {
-        const unsigned char hextable[] = "0123456789ABCDEF";
+        ctxerror = gcry_cipher_encrypt(ctx, newpwd, DES_KEY_SZ, NULL, 0);
+    } else {
+        /* decrypt the password */
+        ctxerror = gcry_cipher_decrypt(ctx, passwd_buf, DES_KEY_SZ, NULL, 0);
+    }
 
+    if (ctxerror) {
+        fprintf(stderr, "afppasswd: Randnum password conversion failed: %s\n",
+                gcry_strerror(ctxerror));
+        gcry_cipher_close(ctx);
+        return -1;
+    }
+
+    gcry_cipher_close(ctx);
+
+    if (newpwd) {
         /* convert to hex */
         for (i = j = 0; i < DES_KEY_SZ; i++, j += 2) {
-            buf[j] = hextable[(newpwd[i] & 0xF0) >> 4];
-            buf[j + 1] = hextable[newpwd[i] & 0x0F];
+            passwd_buf[j] = hextable[(newpwd[i] & 0xF0) >> 4];
+            passwd_buf[j + 1] = hextable[newpwd[i] & 0x0F];
         }
     }
+
+    return 0;
 }
 
 /* -------------------- SRP verifier functions -------------------- */
-
-static const unsigned char hextable[] = "0123456789ABCDEF";
 
 /*
  * Compute SRP verifier: x = SHA1(salt | SHA1(username | ":" | password)),
@@ -561,18 +752,14 @@ static int update_passwd(const char *path, const char *name, int flags,
     size_t pass_len;
     size_t name_len;
 
-    if ((fp = fopen(path, "r+")) == NULL) {
-        fprintf(stderr, "afppasswd: can't open %s: %s\n", path, strerror(errno));
+    if (randnum_open_keyfile(path, &keyfd) < 0) {
         return -1;
     }
 
-    /* open the key file if it exists */
-    strlcpy(buf, path, sizeof(buf));
-    size_t path_len = strnlen(path, sizeof(buf));
-
-    if (path_len < sizeof(buf) - 5) {
-        strlcat(buf, ".key", sizeof(buf));
-        keyfd = open(buf, O_RDONLY);
+    if ((fp = fopen(path, "r+")) == NULL) {
+        fprintf(stderr, "afppasswd: can't open %s: %s\n", path, strerror(errno));
+        close(keyfd);
+        return -1;
     }
 
     pass_len = strnlen(pass, PASSWDLEN + 1);
@@ -615,7 +802,11 @@ found_entry:
     /* need to verify against old password */
     if ((flags & OPT_ISROOT) == 0) {
         passwd = getpass("Enter OLD AFP password: ");
-        convert_passwd(p, NULL, keyfd);
+
+        if (convert_passwd(p, NULL, keyfd) < 0) {
+            err = -1;
+            goto update_done;
+        }
 
         if (strncmp(passwd, p, PASSWDLEN)) {
             fprintf(stderr, "afppasswd: invalid password.\n");
@@ -675,7 +866,12 @@ found_entry:
     if (strcmp(passwd, password) == 0 || pass_len > 0) {
         struct flock lock;
         int fd = fileno(fp);
-        convert_passwd(p, password, keyfd);
+
+        if (convert_passwd(p, password, keyfd) < 0) {
+            err = -1;
+            goto update_done;
+        }
+
         lock.l_type = F_WRLCK;
         lock.l_start = pos;
         lock.l_len = 1;
@@ -685,7 +881,7 @@ found_entry:
         fwrite(buf, p - buf + HEXPASSWDLEN, 1, fp);
         lock.l_type = F_UNLCK;
         fcntl(fd, F_SETLK, &lock);
-        printf("afppasswd: updated password.\n");
+        printf("afppasswd: updated Randnum password.\n");
     } else {
         fprintf(stderr, "afppasswd: passwords don't match!\n");
         err = -1;
@@ -873,6 +1069,10 @@ int main(int argc, char **argv)
         }
 
         if (flags & OPT_RANDNUM) {
+            if (randnum_ensure_keyfile(path, flags) < 0) {
+                return -1;
+            }
+
             return create_file(path, uid_min);
         } else {
             return create_srp_file(path, uid_min);

--- a/distrib/docker/env_setup_netatalk.sh
+++ b/distrib/docker/env_setup_netatalk.sh
@@ -92,28 +92,6 @@ fi
 echo "$AFP_USER:$AFP_PASS" | chpasswd > /dev/null 2>&1
 
 RANDNUM_PASSWD_FILE="/etc/netatalk/afppasswd"
-RANDNUM_KEY_FILE="$RANDNUM_PASSWD_FILE.key"
-
-ensure_randnum_key_file() {
-    if [ -f "$RANDNUM_KEY_FILE" ]; then
-        chown root:root "$RANDNUM_KEY_FILE" && chmod 600 "$RANDNUM_KEY_FILE"
-        return $?
-    fi
-
-    echo "*** Creating RandNum password key file"
-    old_umask=$(umask)
-    umask 077
-    randnum_key=$(od -An -N8 -tx1 /dev/urandom)
-    if ! printf '%s\n' "$randnum_key" | tr -d ' \n' > "$RANDNUM_KEY_FILE"; then
-        umask "$old_umask"
-        return 1
-    fi
-    if ! chown root:root "$RANDNUM_KEY_FILE" || ! chmod 600 "$RANDNUM_KEY_FILE"; then
-        umask "$old_umask"
-        return 1
-    fi
-    umask "$old_umask"
-}
 
 if [ -f "$RANDNUM_PASSWD_FILE" ]; then
     rm -f "$RANDNUM_PASSWD_FILE"
@@ -148,14 +126,12 @@ esac
 # Creating credentials for the RandNum UAM
 RANDNUM_OK=0
 if [ "$RANDNUM_WANTED" = "1" ]; then
-    if ensure_randnum_key_file; then
-        afppasswd -c -r
-
+    if afppasswd -c -f -r; then
         if afppasswd -a "$AFP_USER" -f -r -w "$AFP_PASS" > /dev/null; then
             RANDNUM_OK=1
         fi
     else
-        echo "ERROR: Failed to secure $RANDNUM_KEY_FILE; disabling RandNum UAM" >&2
+        echo "ERROR: Failed to initialize RandNum password file; disabling RandNum UAM" >&2
     fi
 fi
 

--- a/doc/manpages/man1/afppasswd.1.md
+++ b/doc/manpages/man1/afppasswd.1.md
@@ -39,13 +39,15 @@ weak password protection and are discouraged. They should only be enabled
 to support very old AFP clients that cannot use SRP, DHX, or DHX2.
 Randnum requires a file named *afppasswd.key* at the same path as the
 *afppasswd* file. The key file contains a hex-encoded 8-byte DES key that
-Randnum uses to encrypt the stored password. The Randnum UAM refuses to load
-if the key file is missing or unavailable.
+Randnum uses to encrypt the stored password. **afppasswd -r -c** creates
+this key file if it is missing and validates an existing one. Randnum
+password updates refuse to proceed unless the key file is present and valid.
+The Randnum UAM logs a warning at startup when the key file is missing or
+invalid, but authentication and password changes still fail until it is fixed.
 
-The key file must begin with 16 hexadecimal characters, such as
-`0123456789ABCDEF`; Randnum reads those first 16 bytes as the key material,
-so a trailing newline after them is harmless. Generate a fresh random key for
-each server instead of reusing this example value.
+The key file must contain exactly 16 hexadecimal characters, such as
+`0123456789ABCDEF`, with an optional trailing newline. Generate a fresh random
+key for each server instead of reusing this example value.
 
 # Examples
 
@@ -69,6 +71,9 @@ Administrator managing the legacy Randnum file at a non-default path:
 
     example% sudo afppasswd -r -c -p /usr/local/etc/afppasswd
     example% sudo afppasswd -r -a olduser -p /usr/local/etc/afppasswd
+    Enter NEW AFP password: (hidden)
+    Enter NEW AFP password again: (hidden)
+    afppasswd: updated Randnum password.
 
 # Options
 
@@ -83,7 +88,8 @@ user and do not accept this option.
 > Create and initialise the password/verifier file. Existing entries are
 populated as placeholders for every local system user with a uid at or
 above the **-u** threshold; passwords still need to be set individually
-with **-a**.
+with **-a**. With **-r**, also create or validate the companion
+*afppasswd.key* file for the Randnum UAM.
 
 **-f**
 
@@ -133,6 +139,11 @@ directory. One line per user, formatted as
 > Default legacy Randnum file, located under the netatalk configuration
 directory. Used only with **-r**. Override with **-p** or with the
 "**passwd file**" option in **afp.conf**(5).
+
+*afppasswd.key*
+
+> Companion key file for the legacy Randnum file. It must contain exactly
+16 hexadecimal characters with an optional trailing newline.
 
 # See Also
 

--- a/doc/manual/Authentication.md
+++ b/doc/manual/Authentication.md
@@ -113,15 +113,15 @@ Randnum and SRP do not use system passwords directly. They both rely on
 separate files managed with **afppasswd**:
 
 - **Randnum** uses the legacy *afppasswd* file. It requires a key file
-  alongside the Randnum password file (same path with a `.key` suffix), and
-  refuses to load when the key file is missing or unavailable. Create
-  `<passwd file>.key` containing 16 hex characters (8 bytes) and restrict
-  permissions (for example, owner-readable only). Stored passwords are
-  DES-encrypted using that key.
+  alongside the Randnum password file (same path with a `.key` suffix).
+  **afppasswd -r -c** creates this key file if it is missing and validates an
+  existing one; password updates refuse to proceed unless the key file is
+  present and valid. The Randnum UAM logs a startup warning when the key file
+  is missing or invalid, but authentication and password changes still fail
+  until it is fixed. Stored passwords are DES-encrypted using that key.
 
-  For example, a valid key file begins with 16 hexadecimal characters, such
-  as `0123456789ABCDEF`; Randnum reads those first 16 bytes as the key
-  material, so a trailing newline after them is harmless. Generate a fresh
+  The key file must contain exactly 16 hexadecimal characters, such as
+  `0123456789ABCDEF`, with an optional trailing newline. Generate a fresh
   random key for each server instead of reusing this example value.
 
 - **SRP** uses *afppasswd.srp*, which stores per-user salts and verifiers.

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -112,6 +112,7 @@ static int afppasswd_read_keyfile(int keyfd, uint8_t key[DES_KEY_SZ])
 
     if (lseek(keyfd, 0, SEEK_SET) < 0) {
         LOG(log_info, logtype_uams, "lseek(keyfd) failed (%s)", strerror(errno));
+        explicit_bzero(encoded, sizeof(encoded));
         return -1;
     }
 
@@ -119,6 +120,7 @@ static int afppasswd_read_keyfile(int keyfd, uint8_t key[DES_KEY_SZ])
 
     if (keylen < 0) {
         LOG(log_info, logtype_uams, "read(keyfd) failed (%s)", strerror(errno));
+        explicit_bzero(encoded, sizeof(encoded));
         return -1;
     }
 
@@ -126,12 +128,14 @@ static int afppasswd_read_keyfile(int keyfd, uint8_t key[DES_KEY_SZ])
             (keylen != HEXPASSWDLEN + 1 || encoded[HEXPASSWDLEN] != '\n')) {
         LOG(log_info, logtype_uams,
             "invalid key length in afppasswd key file");
+        explicit_bzero(encoded, sizeof(encoded));
         return -1;
     }
 
     for (int i = 0; i < HEXPASSWDLEN; i++) {
         if (!isxdigit(encoded[i])) {
             LOG(log_info, logtype_uams, "invalid character in afppasswd key file");
+            explicit_bzero(encoded, sizeof(encoded));
             return -1;
         }
     }

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -60,7 +60,12 @@ static uint8_t         randbuf[8];
 
 
 #define PASSWD_ILLEGAL '*'
-#define unhex(x)  (isdigit(x) ? (x) - '0' : toupper(x) + 10 - 'A')
+#define HEXPASSWDLEN (DES_KEY_SZ * 2)
+
+static int unhex(unsigned char x)
+{
+    return isdigit(x) ? x - '0' : toupper(x) + 10 - 'A';
+}
 
 static int randnum_cipher_check(const char *op, gcry_error_t err)
 {
@@ -79,9 +84,9 @@ static int afppasswd_open_keyfile(const char *path, const int pathlen)
     int keyfd;
 
     if (pathlen > (int) sizeof(keypath) - 5) {
-        LOG(log_error, logtype_uams,
+        LOG(log_warning, logtype_uams,
             "UAM RandNum: afppasswd path \"%s\" is too long to locate "
-            "the required companion key file; refusing to use Randnum.",
+            "the required companion key file.",
             path);
         return -1;
     }
@@ -91,50 +96,96 @@ static int afppasswd_open_keyfile(const char *path, const int pathlen)
     keyfd = open(keypath, O_RDONLY);
 
     if (keyfd < 0) {
-        LOG(log_error, logtype_uams,
+        LOG(log_warning, logtype_uams,
             "UAM RandNum: required afppasswd key file \"%s\" is unavailable "
-            "(%s); refusing to use Randnum because passwords in \"%s\" "
-            "would otherwise be stored and used in clear text.",
+            "(%s); passwords in \"%s\" cannot be used securely without it.",
             keypath, strerror(errno), path);
     }
 
     return keyfd;
 }
 
-static int randnum_check_passwdfile_key(void *obj)
+static int afppasswd_read_keyfile(int keyfd, uint8_t key[DES_KEY_SZ])
+{
+    uint8_t encoded[HEXPASSWDLEN + 2];
+    ssize_t keylen;
+
+    if (lseek(keyfd, 0, SEEK_SET) < 0) {
+        LOG(log_info, logtype_uams, "lseek(keyfd) failed (%s)", strerror(errno));
+        return -1;
+    }
+
+    keylen = read(keyfd, encoded, sizeof(encoded));
+
+    if (keylen < 0) {
+        LOG(log_info, logtype_uams, "read(keyfd) failed (%s)", strerror(errno));
+        return -1;
+    }
+
+    if (keylen != HEXPASSWDLEN &&
+            (keylen != HEXPASSWDLEN + 1 || encoded[HEXPASSWDLEN] != '\n')) {
+        LOG(log_info, logtype_uams,
+            "invalid key length in afppasswd key file");
+        return -1;
+    }
+
+    for (int i = 0; i < HEXPASSWDLEN; i++) {
+        if (!isxdigit(encoded[i])) {
+            LOG(log_info, logtype_uams, "invalid character in afppasswd key file");
+            return -1;
+        }
+    }
+
+    for (int i = 0, j = 0; i < HEXPASSWDLEN; i += 2, j++) {
+        key[j] = (uint8_t)((unhex(encoded[i]) << 4) | unhex(encoded[i + 1]));
+    }
+
+    explicit_bzero(encoded, sizeof(encoded));
+    return 0;
+}
+
+static void randnum_warn_passwdfile_key(void *obj)
 {
     char *passwdfile = NULL;
+    uint8_t key[DES_KEY_SZ];
     int keyfd;
     size_t len = UAM_PASSWD_FILENAME;
 
     if (uam_afpserver_option(obj, UAM_OPTION_PASSWDOPT,
                              (void *) &passwdfile, &len) < 0) {
-        LOG(log_error, logtype_uams,
-            "UAM RandNum: failed to get afppasswd file option; refusing to load Randnum.");
-        return -1;
+        LOG(log_warning, logtype_uams,
+            "UAM RandNum: failed to get afppasswd file option; Randnum will register but authentication will fail until the password file and companion key are available.");
+        return;
     }
 
     if (!passwdfile || len == 0) {
-        LOG(log_error, logtype_uams,
-            "UAM RandNum: afppasswd file is not configured; refusing to load Randnum.");
-        return -1;
+        LOG(log_warning, logtype_uams,
+            "UAM RandNum: afppasswd file is not configured; Randnum will register but authentication will fail until the password file and companion key are available.");
+        return;
     }
 
     if (*passwdfile == '~') {
-        LOG(log_error, logtype_uams,
+        LOG(log_warning, logtype_uams,
             "UAM RandNum: home password files cannot be protected by the "
-            "required afppasswd key file; refusing to load Randnum.");
-        return -1;
+            "required afppasswd key file; Randnum will register but authentication will fail.");
+        return;
     }
 
     keyfd = afppasswd_open_keyfile(passwdfile, (int) len);
 
     if (keyfd < 0) {
-        return -1;
+        LOG(log_warning, logtype_uams,
+            "UAM RandNum: Randnum will register but authentication will fail until the required key file is available.");
+        return;
     }
 
+    if (afppasswd_read_keyfile(keyfd, key) < 0) {
+        LOG(log_warning, logtype_uams,
+            "UAM RandNum: Randnum will register but authentication will fail until the required key file is valid.");
+    }
+
+    explicit_bzero(key, sizeof(key));
     close(keyfd);
-    return 0;
 }
 
 /*!
@@ -165,12 +216,11 @@ static int afppasswd(const struct passwd *pwd,
                      unsigned char *passwd, int len,
                      const int set)
 {
-    uint8_t key[DES_KEY_SZ * 2];
+    uint8_t key[DES_KEY_SZ];
     char buf[MAXPATHLEN + 1], *p;
     FILE *fp;
     unsigned int i, j;
     int keyfd = -1, err = 0;
-    ssize_t keylen;
     off_t pos;
     gcry_cipher_hd_t ctx = NULL;
     gcry_error_t ctxerror;
@@ -223,45 +273,18 @@ afppasswd_found:
 
     if (!set) {
         /* convert to binary. */
-        for (i = j = 0; i < sizeof(key); i += 2, j++) {
+        for (i = j = 0; i < HEXPASSWDLEN; i += 2, j++) {
             p[j] = (unhex(p[i]) << 4) | unhex(p[i + 1]);
         }
 
         if (j <= DES_KEY_SZ) {
-            memset(p + j, 0, sizeof(key) - j);
+            memset(p + j, 0, HEXPASSWDLEN - j);
         }
     }
 
-    /* read in the hex representation of an 8-byte key */
-    keylen = read(keyfd, key, sizeof(key));
-
-    if (keylen < 0) {
-        LOG(log_info, logtype_uams, "read(keyfd) failed (%s)", strerror(errno));
+    if (afppasswd_read_keyfile(keyfd, key) < 0) {
         err = AFPERR_ACCESS;
         goto afppasswd_done;
-    }
-
-    if (keylen != sizeof(key)) {
-        LOG(log_info, logtype_uams, "invalid key length in afppasswd key file");
-        err = AFPERR_ACCESS;
-        goto afppasswd_done;
-    }
-
-    for (i = 0; i < sizeof(key); i++) {
-        if (!isxdigit(key[i])) {
-            LOG(log_info, logtype_uams, "invalid character in afppasswd key file");
-            err = AFPERR_ACCESS;
-            goto afppasswd_done;
-        }
-    }
-
-    /* convert to binary key */
-    for (i = j = 0; i < sizeof(key); i += 2, j++) {
-        key[j] = (unhex(key[i]) << 4) | unhex(key[i + 1]);
-    }
-
-    if (j <= DES_KEY_SZ) {
-        memset(key + j, 0, sizeof(key) - j);
     }
 
     ctxerror = gcry_cipher_open(&ctx, GCRY_CIPHER_DES, GCRY_CIPHER_MODE_ECB, 0);
@@ -272,6 +295,7 @@ afppasswd_found:
     }
 
     ctxerror = gcry_cipher_setkey(ctx, key, DES_KEY_SZ);
+    explicit_bzero(key, sizeof(key));
 
     if (randnum_cipher_check("gcry_cipher_setkey", ctxerror) < 0) {
         err = AFPERR_ACCESS;
@@ -306,16 +330,17 @@ afppasswd_close_cipher:
 
     if (set) {
         const unsigned char hextable[] = "0123456789ABCDEF";
+        uint8_t encoded[HEXPASSWDLEN];
         struct flock lock;
         int fd = fileno(fp);
 
         /* convert to hex password */
         for (i = j = 0; i < DES_KEY_SZ; i++, j += 2) {
-            key[j] = hextable[(passwd[i] & 0xF0) >> 4];
-            key[j + 1] = hextable[passwd[i] & 0x0F];
+            encoded[j] = hextable[(passwd[i] & 0xF0) >> 4];
+            encoded[j + 1] = hextable[passwd[i] & 0x0F];
         }
 
-        memcpy(p, key, sizeof(key));
+        memcpy(p, encoded, sizeof(encoded));
         /* get exclusive access to the user's password entry. we don't
          * worry so much on reads. in the worse possible case there, the
          * user will just need to re-enter their password. */
@@ -325,9 +350,10 @@ afppasswd_close_cipher:
         lock.l_whence = SEEK_SET;
         fseek(fp, pos, SEEK_SET);
         fcntl(fd, F_SETLKW, &lock);
-        fwrite(buf, p - buf + sizeof(key), 1, fp);
+        fwrite(buf, p - buf + sizeof(encoded), 1, fp);
         lock.l_type = F_UNLCK;
         fcntl(fd, F_SETLK, &lock);
+        explicit_bzero(encoded, sizeof(encoded));
     } else {
         memcpy(passwd, p, len);
     }
@@ -679,9 +705,7 @@ static int randnum_login_ext(void *obj, char *uname, struct passwd **uam_pwd,
 
 static int uam_setup(void *obj, const char *path)
 {
-    if (randnum_check_passwdfile_key(obj) < 0) {
-        return -1;
-    }
+    randnum_warn_passwdfile_key(obj);
 
     if (uam_register(UAM_SERVER_LOGIN_EXT, path, "Randnum exchange",
                      randnum_login, randnum_logincont, NULL, randnum_login_ext) < 0) {


### PR DESCRIPTION
Create and validate the companion afppasswd.key file when initializing Randnum password files, and require a valid key before Randnum password updates.

Relax the Randnum UAM startup check to warn only while preserving runtime enforcement for login and password changes.

Remove the manual scaffolding for afppasswd.key management in the container entrypoint script.

Document the generated key file and stricter key format.

Additionally, use explicit_bzero to purge key material in Randnum and afppasswd