### PR TITLE
libatalk/util: create constant time helper for safe secrets comparison

### DIFF
--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -25,6 +25,7 @@
 #endif
 
 #include <atalk/afp.h>
+#include <atalk/constant_time.h>
 #include <atalk/globals.h>
 #include <atalk/logger.h>
 #include <atalk/uam.h>
@@ -881,7 +882,7 @@ static int changepw_3(void *obj _U_,
     ibuf[511] = '\0';
 
     /* check if new and old password are equal */
-    if (memcmp(ibuf, ibuf + 256, 255) == 0) {
+    if (atalk_ct_memcmp(ibuf, ibuf + 256, 255) == 0) {
         LOG(log_info, logtype_uams, "DHX2 Chgpwd: new and old password are equal");
         ret = AFPERR_PWDSAME;
         goto error_ctx;

--- a/etc/uams/uams_pam.c
+++ b/etc/uams/uams_pam.c
@@ -24,6 +24,7 @@
 #endif
 
 #include <atalk/afp.h>
+#include <atalk/constant_time.h>
 #include <atalk/uam.h>
 #include <atalk/util.h>
 #include <atalk/logger.h>
@@ -370,7 +371,7 @@ static int pam_changepw(void *obj _U_, char *username,
     explicit_bzero(ibuf, PASSWDLEN * 2);
 
     /* Quick check for the same password */
-    if (memcmp(oldpw, newpw, PASSWDLEN) == 0) {
+    if (atalk_ct_memcmp(oldpw, newpw, PASSWDLEN) == 0) {
         explicit_bzero(oldpw, PASSWDLEN);
         explicit_bzero(newpw, PASSWDLEN);
         return AFPERR_PWDSAME;

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -33,23 +33,11 @@
 #include <atalk/logger.h>
 #include <atalk/afp.h>
 #include <atalk/uam.h>
+#include <atalk/constant_time.h>
 
 #define PASSWDLEN 8
 
 static unsigned char seskey[8];
-
-static int ct_memcmp(const void *a, const void *b, size_t n)
-{
-    const unsigned char *pa = (const unsigned char *)a;
-    const unsigned char *pb = (const unsigned char *)b;
-    unsigned char diff = 0;
-
-    for (size_t i = 0; i < n; i++) {
-        diff |= pa[i] ^ pb[i];
-    }
-
-    return diff != 0;
-}
 static struct passwd	*randpwd;
 static uint8_t         randbuf[8];
 
@@ -461,7 +449,7 @@ static int randnum_logincont(void *obj, struct passwd **uam_pwd,
     gcry_cipher_close(ctx);
 
     /* test against what the client sent */
-    if (ct_memcmp(randbuf, ibuf, sizeof(randbuf))) {
+    if (atalk_ct_memcmp(randbuf, ibuf, sizeof(randbuf))) {
         /* != */
         explicit_bzero(randbuf, sizeof(randbuf));
         return AFPERR_NOTAUTH;
@@ -507,7 +495,7 @@ static int rand2num_logincont(void *obj, struct passwd **uam_pwd,
     ctxerror = gcry_cipher_encrypt(ctx, randbuf, sizeof(randbuf), NULL, 0);
 
     /* test against client's reply */
-    if (ct_memcmp(randbuf, ibuf, sizeof(randbuf))) {
+    if (atalk_ct_memcmp(randbuf, ibuf, sizeof(randbuf))) {
         /* != */
         explicit_bzero(randbuf, sizeof(randbuf));
         gcry_cipher_close(ctx);
@@ -577,9 +565,9 @@ static int randnum_changepw(void *obj, const char *username _U_,
     ctxerror = gcry_cipher_decrypt(ctx, ibuf, PASSWDLEN, NULL, 0);
     gcry_cipher_close(ctx);
 
-    if (ct_memcmp(seskey, ibuf, sizeof(seskey))) {
+    if (atalk_ct_memcmp(seskey, ibuf, sizeof(seskey))) {
         err = AFPERR_NOTAUTH;
-    } else if (ct_memcmp(seskey, ibuf + PASSWDLEN, sizeof(seskey)) == 0) {
+    } else if (atalk_ct_memcmp(seskey, ibuf + PASSWDLEN, sizeof(seskey)) == 0) {
         err = AFPERR_PWDSAME;
     }
 

--- a/etc/uams/uams_srp.c
+++ b/etc/uams/uams_srp.c
@@ -38,6 +38,7 @@
 #include <unistd.h>
 
 #include <atalk/afp.h>
+#include <atalk/constant_time.h>
 #include <atalk/logger.h>
 #include <atalk/uam.h>
 
@@ -105,23 +106,6 @@ static char session_username[UAM_USERNAMELEN + 1];
 static struct passwd *srppwd;
 
 /* -------------------- Crypto helpers -------------------- */
-
-/*!
- * @brief Constant-time memory comparison to avoid timing oracles.
- * @returns non-zero if the buffers differ, 0 if equal.
- */
-static int ct_memcmp(const unsigned char *a, const unsigned char *b, size_t n)
-{
-    /* Use volatile to prevent compiler optimizations
-     * that could leak timing information. */
-    volatile unsigned char diff = 0;
-
-    while (n--) {
-        diff |= *a++ ^ *b++;
-    }
-
-    return diff != 0;
-}
 
 /*!
  * @brief Strip leading zero bytes from a big-endian integer buffer.
@@ -835,7 +819,7 @@ static int srp_logincont(void *obj _U_, struct passwd **uam_pwd,
         goto fail;
     }
 
-    if (ct_memcmp(M1_received, M1_expected, SRP_SHA1_LEN)) {
+    if (atalk_ct_memcmp(M1_received, M1_expected, SRP_SHA1_LEN)) {
         LOG(log_info, logtype_uams, "srp_logincont: M1 verification failed for %s",
             session_username);
         ret = SRP_AUTH_FAILURE;

--- a/include/atalk/constant_time.h
+++ b/include/atalk/constant_time.h
@@ -1,0 +1,8 @@
+#ifndef _ATALK_CONSTANT_TIME_H
+#define _ATALK_CONSTANT_TIME_H 1
+
+#include <stddef.h>
+
+extern int atalk_ct_memcmp(const void *, const void *, size_t);
+
+#endif

--- a/include/atalk/meson.build
+++ b/include/atalk/meson.build
@@ -7,6 +7,7 @@ headers = [
     'asp.h',
     'atp.h',
     'cnid.h',
+    'constant_time.h',
     'ddp.h',
     'ea.h',
     'globals.h',

--- a/libatalk/util/constant_time.c
+++ b/libatalk/util/constant_time.c
@@ -1,0 +1,29 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <atalk/constant_time.h>
+
+/*!
+ * @brief Constant-time memory equality check.
+ *
+ * Compares exactly @p n bytes and returns 0 if the buffers are equal,
+ * non-zero if they differ.
+ *
+ * @note Unlike memcmp(), this function does not provide
+ * lexicographic ordering and must not be used for sorting.
+ *
+ * @returns 0 if the buffers are equal, non-zero if they differ.
+ */
+int atalk_ct_memcmp(const void *a, const void *b, size_t n)
+{
+    const unsigned char *pa = a;
+    const unsigned char *pb = b;
+    volatile unsigned char diff = 0;
+
+    for (size_t i = 0; i < n; i++) {
+        diff |= pa[i] ^ pb[i];
+    }
+
+    return diff != 0;
+}

--- a/libatalk/util/meson.build
+++ b/libatalk/util/meson.build
@@ -2,6 +2,7 @@ util_sources = [
     'afp_util.c',
     'atalk_addr.c',
     'bprint.c',
+    'constant_time.c',
     'cnid.c',
     'fault.c',
     'getiface.c',

--- a/libatalk/util/server_child.c
+++ b/libatalk/util/server_child.c
@@ -33,6 +33,7 @@
 #include <unistd.h>
 
 #include <atalk/compat.h>
+#include <atalk/constant_time.h>
 #include <atalk/errchk.h>
 #include <atalk/logger.h>
 #include <atalk/server_child.h>
@@ -56,19 +57,6 @@
 
 /* hash/child functions: hash OR's pid */
 #define HASH(i) ((((i) >> 8) ^ (i)) & (CHILD_HASHSIZE - 1))
-
-static int ct_memcmp(const void *a, const void *b, size_t n)
-{
-    const unsigned char *pa = a;
-    const unsigned char *pb = b;
-    volatile unsigned char diff = 0;
-
-    while (n--) {
-        diff |= *pa++ ^ *pb++;
-    }
-
-    return diff != 0;
-}
 
 static inline void hash_child(afp_child_t **htable, afp_child_t *child)
 {
@@ -391,7 +379,7 @@ int server_child_transfer_session(server_child_t *children,
         for (child = children->servch_table[i]; child; child = child->afpch_next) {
             if (child->afpch_sessiontoken_len == token_len
                     && child->afpch_sessiontoken != NULL
-                    && ct_memcmp(child->afpch_sessiontoken, token, token_len) == 0) {
+                    && atalk_ct_memcmp(child->afpch_sessiontoken, token, token_len) == 0) {
                 goto found;
             }
         }


### PR DESCRIPTION
Add a shared atalk_ct_memcmp() helper and use it for SRP proof checks, RandNum challenge/password checks, PAM password changing, and AFP reconnect token checks.

The helper compares already-generated sensitive byte strings without returning early on the first mismatch. This avoids memcmp()-style timing leaks when checking authentication material or reconnect tokens.