### PR TITLE
cnid: add credits blurb to sqlite implementation

### DIFF
--- a/libatalk/cnid/sqlite/cnid_sqlite.c
+++ b/libatalk/cnid/sqlite/cnid_sqlite.c
@@ -1,4 +1,9 @@
 /*
+ * CNID database implementation using SQLite embedded database engine.
+ * Built on proof-of-concept code written by Christopher Kobayashi in 2022
+ * for the netatalk-classic project, in turn based on the cnid_mysql.c
+ * implementation by Ralph Boehme.
+ *
  * Copyright (C) 2013 Ralph Boehme
  * Copyright (C) 2024-2026 Daniel Markstedt
  * All Rights Reserved.  See COPYING.


### PR DESCRIPTION
wrote this blurb as a record of lineage of the SQLite backend code -- Christopher Kobayashi never claimed personal copyright on the code, leaving Ralph's copyright header as-is, but I think he deserves special credits because the idea and design was all his.

he wrote the PoC some time in the spring and summer of 2022, but abandoned the project before completion; I took the partially working code in 2024 and fitted the missing scaffolding and rewrote the MySQL-isms not appropriate for SQLite.

here is the state of the code before I started working on it, for posterity: https://github.com/rdmark/netatalk-classic/commit/4d886240fc1e4286a500f6fcfb512075d50e5176