### PR TITLE
update changelog for stable release v4.5.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,71 +1,146 @@
 Netatalk Changelog
 ==================
 
-Changes in 4.5.0beta
---------------------
+Changes in 4.5.0
+----------------
 
-* BREAKING: libatalk: cnid_find() ABI changed — gained a `bool *more_available` out-parameter and a
-  400-byte minimum result-buffer requirement. The libatalk soversion has been bumped accordingly.
-  Out-of-tree consumers that link against libatalk must be rebuilt against the new headers.
-* NEW: afpd: Spotlight searches against the CNID, SQLite, and MySQL backends now return up to 10000
-  results per query, or as many as fit within a 10-second wall-clock budget.
-* NEW: afpd: Spotlight filename queries shorter than 3 characters are silently ignored by the
-  Spotlight backend (return 0 results). `nad find` and FPCatSearch / CatSearchExt continue to accept
-  1- and 2-character prefixes unchanged.
+* CVE-2026-7835,CVE-2026-44059: libatalk/util: fix privilege toggle and log format
+* CVE-2026-7836,CVE-2026-44070: libatalk/unicode: cap realloc and fix hextoint
+* CVE-2026-7837: libatalk/adouble: use fd-based sticky-dir xattr writes
+* CVE-2026-44053: libatalk: remove DHCAST128 UAM from default configuration
+* CVE-2026-44056: afpd: fix strcat stack overflow in setdeskmode/setdeskowner
+* CVE-2026-44058: uams: remove 'admin auth user' option
+* CVE-2026-44061: uams: use constant-time comparisons in Randnum UAMs
+* CVE-2026-44063: libatalk/acl: escape LDAP filter values
+* CVE-2026-44065: papd: fix off-by-two in lp_write foomatic translation
+* CVE-2026-44067: libatalk/vfs: bound EA header parsing
+* CVE-2026-44069: libatalk/util: bound volxlate address formatting
+* CVE-2026-44071: libatalk/cnid: re-enable FORTIFY_SOURCE in mysql backend
+* CVE-2026-44072: cnid_dbd: abort on chdir failure before system()
+* CVE-2026-44073: uams: treat seteuid failures as fatal
+* CVE-2026-44074: libatalk/vfs: fix ACL errno check
+* CVE-2026-44075: libatalk/dsi: add missing break in dsi_opensession
+* BREAKING: libatalk: cnid_find() ABI changed — gained a 'bool *more_available' out-parameter and a
+       400-byte minimum result-buffer requirement. The libatalk soversion has been bumped to v20.
+       Out-of-tree consumers that link against libatalk must be rebuilt against the new headers.
+* NEW: libatalk: Added volume option 'volume uuid' to define static UUID, GitHub #2619
+* NEW: libatalk: Log a warning when deprecated afp.conf option is being used, GitHub #2746
+* UPD: libatalk: turn on spotlight and search db options by default, GitHub #2923
+* UPD: libatalk: Converted adf_lock macros to functions, GitHub #2645
+* UPD: libatalk: Backwards compatibility with iniparser v3, GitHub #2715
+* UPD: libatalk: Regenerated utf16 case lookup tables with Unicode v17.0.0, GitHub #2594
+* FIX: libatalk: Fixed UUID instability for dynamic volumes with non-AFP clients, GitHub #2809
+* FIX: libatalk: reject nested volume paths to prevent CNID crash, GitHub #2862
+* FIX: libatalk: fix IPv4 interface detection and connectivity on NetBSD, GitHub #2859
 * NEW: afpd: Introduced ARC (Adaptive Replacement Cache) option for directory cache, GitHub #2668
 * NEW: afpd: Added enumerate cache, AppleDouble support in cache, and inter-process cache sync, GitHub #2733
 * NEW: afpd: Added Tier-2 ResourceFork caching framework, GitHub #2783
 * NEW: afpd: Added idle worker thread for background dircache maintenance, GitHub #2808
 * NEW: afpd: Introduced a default global 'cnid scheme' afp.conf option, GitHub #2689
 * NEW: afpd: Synthesize virtual Icon\r file in volume root for Classic Mac OS, GitHub #2775, #2820, #2833
-* NEW: afpstats: Expose hostname for each afpd child process, GitHub #2720
-* NEW: cnid: Added support for 'cnid dev = no' in MySQL and SQLite backends, GitHub #2806
-* NEW: libatalk: Added volume option 'volume uuid' to define static UUID, GitHub #2619
-* NEW: libatalk: Log a warning when deprecated afp.conf option is being used, GitHub #2746
-* NEW: meson: Introduced option to force the building of subprojects, GitHub #2652
-* NEW: nad: Added an -F option for reading a custom afp.conf file, GitHub #2722
-* NEW: nad: Implemented mkdir and rmdir commands, GitHub #2823
+* NEW: afpd: introduce pluggable Spotlight search backend architecture and CNID backend, GitHub #2923
+* NEW: afpd: introduce experimental Spotlight backend built on Xapian, GitHub #2940
+* NEW: afpd: Spotlight searches against the CNID, SQLite, and MySQL backends now return up to 10000
+       results per query, or as many as fit within a 10-second wall-clock budget, GitHub #3001
+* NEW: afpd: Spotlight filename queries shorter than 3 characters are silently ignored by the
+       Spotlight backend (return 0 results). 'nad find' and FPCatSearch / CatSearchExt continue to accept
+       1- and 2-character prefixes unchanged, GitHub #3001
 * UPD: afpd: Turn 'convert appledouble' option off by default, GitHub #2734
-* UPD: afpd: Use C11 atomic operations in dircache for 32 bit OS compatibility, GitHub #2756
 * UPD: afpd: Improved signal handlers and refactored away unreachable code, GitHub #2796
 * UPD: afpd: Optimized dircache child scan with blength pre-check and memcmp, GitHub #2827
+* FIX: afpd: Fixed moveandrename stale paths and 'mac charset' option, GitHub #2754
+* FIX: afpd: Validated CNID from get_id() before calling dircache_add(), GitHub #2697
+* FIX: afpd: add support for Spotlight wildcard queries with SPARQL, GitHub #2915
+* FIX: afpd: handle Spotlight search paths in nested arrays for macOS Tahoe, GitHub #2916
+* FIX: afpd: fix Spotlight timestamps and add additional attributes, GitHub #2878
+* FIX: afpd: fix connection limit off-by-one condition, GitHub #2985
+* FIX: afpd: make signal handlers async-signal-safe to fix crash on macOS, GitHub #2860
+* FIX: afpd: harden follow symlinks against cross-device targets, GitHub #3006
+* REM: afpd: Removed superseded dircache metadata window/threshold parameters, GitHub #2683
+* REM: afpd: Removed obsoleted 'dircache files' option, GitHub #2783
+* NEW: cnid: Added support for 'cnid dev = no' in MySQL and SQLite backends, GitHub #2806
 * UPD: cnid: Improved MySQL backend charset and TCP performance, GitHub #2649
+* FIX: cnid: Disallow looking up did<2 in sqlite backend, GitHub #2632
+* FIX: cnid: Fixed permissions for multi-user access to SQLite db files, GitHub #2805
+* REM: cnid: Removed the obsolete 'last' CNID backend, GitHub #2634
+* NEW: netatalk: support libev as alternative to libevent2, GitHub #2869
+* UPD: netatalk: replace gsettings with dconf keyfile for LocalSearch indexer config, GitHub #2902
+* UPD: netatalk: start localsearch indexer only when configured as spotlight backend, GitHub #2980
+* NEW: uams: add SRP (Secure Remote Password) user authentication method, GitHub #2876
+* UPD: uams: require afppasswd key file for Randnum UAM, GitHub #2974
+* FIX: uams: Fixed password corruption when changing password in Cleartxt PAM UAM, GitHub #2699
+* FIX: uams: fix PAM auth with forking modules on OpenBSD, GitHub #2854
+* NEW: afppasswd: manage Randnum key files programmatically, GitHub #2995
+* NEW: afpstats: print hostname for each afpd child process, GitHub #2720
+* NEW: nad: Added an -F option for reading a custom afp.conf file, GitHub #2722
+* NEW: nad: Implemented mkdir and rmdir commands, GitHub #2823
+* UPD: nad: Organized ls output into columns and sanitized filenames, GitHub #2804
+* UPD: nad: Implemented ls -a flag with . and .. entries, GitHub #2821
+* UPD: nad: Overhauled file operations that cross AFP volume boundary, GitHub #2828
+* NEW: dbd: add -i option to invalidate AppleDouble CNID hints, GitHub #2863
 * UPD: dbd: Decoupled the dbd binary from cnid_dbd with improvements, GitHub #2685
+* FIX: nad: More sophisticated check for the MAXPHYS macro, GitHub #2717
+* FIX: nad: Centralized volume validation and fixed inconsistent error handling, GitHub #2803
+* FIX: papd: Hardened config parsing with graceful error recovery, GitHub #2696
+* FIX: timelord: fix local time offset when DST is in effect, GitHub #2895
+* NEW: meson: Introduced option to force the building of subprojects, GitHub #2652
+* UPD: meson: Updated the bstring library subproject to version 1.1.0, GitHub #2829
+* UPD: meson: make FCE a compile-time build option, GitHub #2872
+* FIX: meson: Detect big-endian architecture correctly, GitHub #2694
+* FIX: meson: fix quota support on NetBSD by detecting libquota correctly, GitHub #2858
+* FIX: initscripts: netatalk systemd now depends on network-online.target, GitHub #2639
+* REM: contrib: Removed obsolete macusers script, GitHub #2723
+* UPD: testsuite: Enhanced afp_speedtest with throughput statistics, TCP statistics, and CSV export, GitHub #2687
+* UPD: testsuite: add afp_spectest module for Spotlight RPC testing, GitHub #3001
+* UPD: testsuite: overhaul DSI test client and expand afp_logintest coverage, GitHub #2992
+* FIX: testsuite: Initialized filedir params to avoid garbage data in the bitmap, GitHub #2688
 * UPD: docs: Revised CNID configuration details in afp.conf man page, GitHub #2608
 * UPD: docs: Overhauled the documentation for the 'search db' option, GitHub #2620
 * UPD: docs: Revamped AFP Signature/UUID conf man pages, GitHub #2623
 * UPD: docs: Integrated AppleTalk man page contents into Doxygen docs, GitHub #2624
 * UPD: docs: Improved descriptions of CNID backends, set/save password options, GitHub #2690
 * UPD: docs: Split up Configuration into multiple manual chapters, GitHub #2825
-* UPD: libatalk: Converted adf_lock macros to functions, GitHub #2645
-* UPD: libatalk: Backwards compatibility with iniparser v3, GitHub #2715
-* UPD: libatalk: Regenerated utf16 case lookup tables with Unicode v17.0.0, GitHub #2594
-* UPD: meson: Package release tarball with subprojects, GitHub #2658
-* UPD: nad: Organized ls output into columns and sanitized filenames, GitHub #2804
-* UPD: nad: Implemented ls -a flag with . and .. entries, GitHub #2821
-* UPD: nad: Overhauled file operations that cross AFP volume boundary, GitHub #2828
-* UPD: testsuite: Enhanced afp_speedtest with throughput statistics, TCP statistics, and CSV export, GitHub #2687
-* UPD: Updated the bstring library subproject to version 1.1.0, GitHub #2829
-* FIX: afpd: Fixed implicit declaration of function AfpErr2name, GitHub #2664
-* FIX: afpd: Fixed dircache realloc leak, validated ghosts, improved error logging, GitHub #2693
-* FIX: afpd: Fixed moveandrename stale paths and 'mac charset' option, GitHub #2754
-* FIX: afpd: Validated CNID from get_id() before calling dircache_add(), GitHub #2697
-* FIX: cnid: Fixed sqlite backend bugs, added post init validation and logging, GitHub #2672
-* FIX: cnid: Disallow looking up did<2 in sqlite backend, GitHub #2632
-* FIX: cnid: Fixed permissions for multi-user access to SQLite db files, GitHub #2805
-* FIX: initscripts: netatalk systemd now depends on network-online.target, GitHub #2639
-* FIX: libatalk: Fixed UUID instability for dynamic volumes with non-AFP clients, GitHub #2809
-* FIX: meson: Detect big-endian architecture correctly, GitHub #2694
-* FIX: meson: Fixed bugs that prevent disabling dev docs, GitHub #2840
-* FIX: nad: More sophisticated check for the MAXPHYS macro, GitHub #2717
-* FIX: nad: Centralized volume validation and fixed inconsistent error handling, GitHub #2803
-* FIX: papd: Hardened config parsing with graceful error recovery, GitHub #2696
-* FIX: testsuite: Initialized filedir params to avoid garbage data in the bitmap, GitHub #2688
-* FIX: uams: Fixed password corruption when changing password in Cleartxt PAM UAM, GitHub #2699
-* REM: afpd: Removed superseded dircache metadata window/threshold parameters, GitHub #2683
-* REM: afpd: Removed obsoleted 'dircache files' option, GitHub #2783
-* REM: cnid: Removed the obsolete 'last' CNID backend, GitHub #2634
-* REM: contrib: Removed obsolete macusers script, GitHub #2723
+
+Changes in 4.4.3
+----------------
+
+* FIX: CVE-2026-44047: cnid: fix MySQL CNID filename SQL injection
+* FIX: CVE-2026-44048: libatalk: fix UCS-2 terminator bounds in charset conversion
+* FIX: CVE-2026-44049: libatalk: reserve charset terminator space in conversion
+* FIX: CVE-2026-44050: cnid: validate CNID request name length in DBD backend
+* FIX: CVE-2026-44051: afpd: validate symlink targets from FinderInfo
+* FIX: CVE-2026-44052: libatalk: avoid logging LDAP bind passwords
+* FIX: CVE-2026-44054: afpd: randomize reconnect session token
+* FIX: CVE-2026-44055: afpd: correct bitwise check and escape user in FCE notify script
+* FIX: CVE-2026-44057,CVE-2026-44066: afpd: fix spotlight unmarshalling depth and dead check
+* FIX: CVE-2026-44060: libatalk: fix write underflow in dsi_writeinit
+* FIX: CVE-2026-44062: libatalk: guard UCS2 slash and colon writes
+* FIX: CVE-2026-44064: libatalk: bounds-check ASP session ID
+* FIX: CVE-2026-44068: libatalk: reject slash in EA names in VFS module
+* FIX: CVE-2026-44076: netatalk: fix Spotlight volume path shell quoting
+* FIX: CVE-2026-45354: libatalk: guard cmdlen override to DSIWrite to prevent DoS
+* FIX: CVE-2026-45355: afpd: signed integer underflow in sl_unpack_cpx string length
+* FIX: CVE-2026-45356: afpd: guard against unsigned underflow in sl_unpack_loop count decrement
+* FIX: CVE-2026-45698,CVE-2026-45699: afpd: fix stack buffer overflow in copydir() and deletedir()
+* FIX: uams: harden RandNum key file read bounds and integrity checks, GitHub #2964
+* UPD: uams: warn when Randnum afppasswd key file is missing, GitHub #2973
+* FIX: libatalk: map identifiers correctly for all logtypes, GitHub #2903
+* FIX: libatalk: fix OOB access when loading logtype, GitHub #2904
+* UPD: docker: bump production container alpine base image from 3.23.2 to 3.23.4, GitHub #2920
+* FIX: docker: load RandNum UAM only when password init succeeds, GitHub #2922
+* UPD: docker: harden RandNum UAM in production container, GitHub #2965
+* NEW: docker: introduce AFP_UAMS option for fine grained control of UAMs, GitHub #2975
+* UPD: docs: discourage the use of DHCAST128 UAM and 'admin auth user' option, GitHub #2972
+
+Changes in 4.4.2
+----------------
+
+* FIX: afpd: use C11 atomic operations in dircache, conditional check for libatomic, GitHub #2767
+* FIX: afpd: fix implicit declaration of function AfpErr2name, GitHub #2662
+* FIX: afpd: fix LRU cache eviction crash and dangling pointers, GitHub #2779
+* FIX: cnid: fix sqlite backend bugs, add post init validation and logging, GitHub #2673
+* FIX: meson: fix bugs that prevent you from disabling dev docs, GitHub #2882
+* UPD: macusers: add a deprecation warning for this script, GitHub #2768
 
 Changes in 4.4.1
 ----------------
@@ -77,6 +152,7 @@ Changes in 4.4.1
 * UPD: docs: revamp AFP Signature/UUID conf man pages, GitHub #2623
 * UPD: docs: overhaul the documentation for the 'search db' option, GitHub #2620
 * UPD: docs: revise CNID configuration details in afp.conf man page, GitHub #2608
+* UPD: meson: Package release tarball with subprojects, GitHub #2657
 
 Changes in 4.4.0
 ----------------


### PR DESCRIPTION
pull in and consolidate changelog for v4.4.2 and v4.4.3 for completeness, and fold the v4.5.0beta changelog into v4.5.0 proper