### PR TITLE
afpd: harden follow symlinks against cross-device targets

### DIFF
--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -1348,13 +1348,18 @@ delete any files and directories within the vetoed directory.
 follow symlinks = *BOOLEAN* (default: *no*) **(V)**
 
 > The default setting is false thus symlinks are not followed on the
-server. This is the same behaviour as OS X's AFP server. Setting the
-option to true causes afpd to follow symlinks on the server. symlinks
-may point outside of the AFP volume, currently afpd doesn't do any
-checks for "wide symlinks".
+server.
+This is the same behaviour as Mac OS X's AFP server.
+Setting the option to true causes afpd to follow symlinks on the server.
 >
-> ***NOTE:*** This option will subtly break when the symlinks point across filesystem
-boundaries.
+> When a client creates a symlink via AFP, the target is validated:
+absolute paths, paths containing **..** components, relative paths that
+resolve outside the volume root, and targets on a different filesystem
+device than the volume are rejected.
+>
+> ***NOTE:*** This option is security-sensitive,
+and should only be enabled if you understand the security implications
+of allowing clients to follow symlinks on the server.
 
 invisible dots = *BOOLEAN* (default: *no*) **(V)**
 

--- a/doc/manual/Configuration.md
+++ b/doc/manual/Configuration.md
@@ -10,15 +10,6 @@ including Macs, Apple IIs, and other AFP clients.
 Configuration is managed through the *afp.conf* file,
 which uses an ini-style syntax.
 
-Netatalk provides remote backup functionality for macOS Time Machine over AFP.
-To make a volume a Time Machine target,
-set the volume option **time machine = yes**.
-
-Starting with Netatalk 2.1, UNIX symlinks are supported on the server.
-The semantics are the same as for NFS:
-symlinks are not resolved on the server side but are instead passed to the client for resolution,
-resulting in links that point somewhere inside the client's filesystem view.
-
 ### afp.conf
 
 *afp.conf* is the configuration file used by **afpd** to determine
@@ -76,3 +67,27 @@ For example, when */home* links to */usr/home*:
 
 For a detailed explanation of all available options,
 refer to the [afp.conf](afp.conf.5.html) man page.
+
+### Backup Volumes
+
+Netatalk provides remote backup functionality for macOS Time Machine over AFP.
+To make a volume a Time Machine target,
+set the volume option **time machine = yes**.
+
+When used together with Zeroconf,
+the backup volume will be automatically advertised via Bonjour when the server is running,
+allowing macOS clients to discover and select it as a Time Machine backup destination.
+
+### Symlinks
+
+By default, symlinks are not followed on the server side but are instead passed to the client for
+resolution, resulting in links that point somewhere inside the client's filesystem view.
+This is the same behaviour as the historical Mac OS X AFP server.
+
+Server-side symlink following can be enabled per volume with **follow symlinks = yes**.
+When enabled, symlink targets created via AFP are validated: absolute paths, paths containing
+**..** components, targets that resolve outside the volume root, and targets on a different
+filesystem device are rejected.
+Note that pre-existing symlinks created outside of AFP are not subject to this validation.
+
+Be aware that enabling server-side symlink following can lead to security issues if not used carefully.

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -1962,6 +1962,37 @@ struct path *cname(struct vol *vol, struct dir *dir, char **cpath)
 }
 
 /*!
+ * @brief ochdir() wrapper that rejects chdir across filesystem device boundaries
+ *
+ * @param[in] dir   path to chdir to
+ * @param[in] vol   volume the path must reside on
+ *
+ * @returns 0 on success, 1 on symlink or device violation, -1 on syserror
+ */
+static int ochdir_vol(const char *dir, const struct vol *vol)
+{
+    struct stat st;
+    int ret = ochdir(dir, vol_syml_opt(vol));
+
+    if (ret != 0) {
+        return ret;
+    }
+
+    if (vol_syml_opt(vol) == 0) {
+        if (stat(".", &st) != 0) {
+            return -1;
+        }
+
+        if (st.st_dev != vol->v_dev) {
+            errno = EXDEV;
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+/*!
  * @brief chdir() to dir
  *
  * @param[in] vol   pointer to struct vol
@@ -1996,7 +2027,7 @@ int movecwd(const struct vol *vol, struct dir *dir)
     LOG(log_debug, logtype_afpd, "movecwd(to: did: %u, \"%s\")",
         ntohl(dir->d_did), dir->d_fullpath ? cfrombstr(dir->d_fullpath) : "(null)");
 
-    if ((ret = ochdir(cfrombstr(dir->d_fullpath), vol_syml_opt(vol))) != 0) {
+    if ((ret = ochdir_vol(cfrombstr(dir->d_fullpath), vol)) != 0) {
         /* Failed to change directory */
         LOG(log_debug, logtype_afpd, "movecwd(\"%s\"): %s",
             dir->d_fullpath ? cfrombstr(dir->d_fullpath) : "(null)", strerror(errno));
@@ -2019,7 +2050,7 @@ int movecwd(const struct vol *vol, struct dir *dir)
                 LOG(log_debug, logtype_afpd,
                     "movecwd: dirlookup_strict returned validated path \"%s\", attempting chdir",
                     dir->d_fullpath ? cfrombstr(dir->d_fullpath) : "(null)");
-                ret = ochdir(cfrombstr(dir->d_fullpath), vol_syml_opt(vol));
+                ret = ochdir_vol(cfrombstr(dir->d_fullpath), vol);
 
                 if (ret == 0) {
                     curdir = dir;
@@ -2039,14 +2070,14 @@ int movecwd(const struct vol *vol, struct dir *dir)
             /* Special movecwd requirement: sync process CWD with curdir pointer.
              * If curdir is at fallback, attempt to sync process CWD. */
             if (curdir && curdir->d_fullpath && curdir != &rootParent &&
-                    ochdir(cfrombstr(curdir->d_fullpath), vol_syml_opt(vol)) == 0) {
+                    ochdir_vol(cfrombstr(curdir->d_fullpath), vol) == 0) {
                 LOG(log_debug, logtype_afpd,
                     "movecwd: synced process CWD to curdir fallback");
             }
         }
 
         if (ret == 1) {
-            /* p is a symlink or getcwd failed */
+            /* path is a symlink, crosses a device boundary, or getcwd failed */
             afp_errno = AFPERR_BADTYPE;
 
             if (chdir(vol->v_path) < 0) {

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -149,7 +149,16 @@ static int symlink_target_safe(const struct vol *vol,
     resolved_target = realpath_safe(target_path);
 
     if (resolved_target) {
-        safe = path_is_inside_volume(vol, resolved_target);
+        if (path_is_inside_volume(vol, resolved_target)) {
+            struct stat vol_st, target_st;
+
+            if (stat(vol->v_path, &vol_st) == 0 &&
+                    stat(resolved_target, &target_st) == 0 &&
+                    vol_st.st_dev == target_st.st_dev) {
+                safe = 1;
+            }
+        }
+
         free(resolved_target);
     }
 


### PR DESCRIPTION
Two complementary checks are added to prevent symlinks from crossing filesystem device boundaries when the follow symlinks volume option is in use.

symlink_target_safe() in file.c now stats both the volume root and the resolved symlink target, rejecting the symlink if their st_dev values differ.

A new ochdir_vol() wrapper in directory.c calls ochdir() and then, when symlink following is active, stats the resulting working directory and rejects the chdir if it landed on a different device than the volume. This catches pre-existing or locally-created cross-device symlinks at traversal time, which creation-time validation cannot cover.

Documentation in afp.conf.5.md and doc/manual/Configuration.md is updated to reflect both validations and the remaining caveat about pre-existing symlinks.