### PR TITLE
docs: list all available legacy icon styles in afp.conf man page

### DIFF
--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -1067,10 +1067,13 @@ If a custom icon is already associated with the volume, this option is ignored.
 Available icon styles:
 >
 > - **daemon**
+> - **declogo**
 > - **fileserver**
 > - **globe**
 > - **nas**
 > - **sdcard**
+> - **sunlogo**
+> - **viking**
 
 legacy volume size = *BOOLEAN* (default: *no*) **(V)**
 


### PR DESCRIPTION
Add icon styles 'declogo', 'sunlogo', and 'viking' to afp.conf man page.