### PR TITLE
docs: touch up language in documentation

### DIFF
--- a/doc/manpages/man1/afppasswd.1.md
+++ b/doc/manpages/man1/afppasswd.1.md
@@ -26,7 +26,7 @@ There are two invocation styles:
 
 - *As root*, **afppasswd** manages credentials for any system user.
   The user is named with **-a** *username* (which both adds new entries
-  and updates existing ones), or the entire file is initialised at once
+  and updates existing ones), or the entire file is initialized at once
   with **-c**.
 - *As a regular user*, **afppasswd** takes no positional arguments and
   changes the calling user's own AFP password: for SRP by default and for
@@ -85,7 +85,7 @@ user and do not accept this option.
 
 **-c**
 
-> Create and initialise the password/verifier file. Existing entries are
+> Create and initialize the password/verifier file. Existing entries are
 populated as placeholders for every local system user with a uid at or
 above the **-u** threshold; passwords still need to be set individually
 with **-a**. With **-r**, also create or validate the companion

--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -518,7 +518,7 @@ Not all backends may be available with your netatalk installation.
 Run **afpd -v** to see a list of available backends, as well as which one is the default.
 >
 > *dbd*: uses Berkeley DB, with database reads and writes managed through the **cnid_dbd** daemon.
-It is recommended for most deployments.
+It is deprecated and not recommended for new deployments.
 >
 > *mysql*: connects to a MySQL (or MariaDB) database instance that has been provisioned for use with Netatalk.
 Requires datbase administration, giving you full control over how the CNID data is stored.

--- a/doc/manual/Authentication.md
+++ b/doc/manual/Authentication.md
@@ -2,7 +2,7 @@
 
 ## AFP authentication basics
 
-Apple chose a flexible model called "User Authentication Modules" (UAMs)
+Apple chose a flexible model called "User Authentication Methods" (UAMs)
 for authentication between AFP clients and servers.
 An AFP client connecting to an AFP server first requests the list of UAMs that the server supports,
 then chooses the one with the strongest encryption that the client also supports.

--- a/doc/manual/CNID.md
+++ b/doc/manual/CNID.md
@@ -54,7 +54,7 @@ Rather than accessing the database directly,
 **afpd** processes communicate with one or more **cnid_dbd** daemon processes over a wire protocol.
 The **cnid_dbd** daemon is responsible for database reads and updates.
 
-This is the most reliable and proven backend, recommended for most deployments.
+It is deprecated and not recommended for new deployments.
 
 ## mysql
 

--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -71,7 +71,7 @@ packages that can be installed to enhance Netatalk's functionality.
 - Libgcrypt
 
     The [Libgcrypt](https://gnupg.org/software/libgcrypt/) library
-    supplies the encryption for the standard User Authentication Modules
+    supplies the encryption for the standard User Authentication Methods
     (UAMs). They are: DHX2, DHCAST128 (a.k.a. DHX) and RandNum.
 
 #### CNID database backends

--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -80,7 +80,7 @@ At least one of the below database libraries is required to power the CNID schem
 
 - Berkeley DB
 
-    The default *dbd* (*Database Daemon*) CNID backend for netatalk uses Berkeley DB to store
+    The *dbd* (*Database Daemon*) CNID backend for netatalk uses Berkeley DB to store
     unique file identifiers.
 
     The recommended Berekeley DB version is 5.3, while versions 4.6 and later should work as well.
@@ -96,7 +96,8 @@ At least one of the below database libraries is required to power the CNID schem
 - SQLite v3
 
     The SQLite library version 3 enables the *sqlite* CNID backend
-    which is an alternative zero-configuration backend.
+    which is an embedded database option that does not require a separate database server
+    to be set up and maintained by the system administrator.
 
 ### Optional third-party software
 


### PR DESCRIPTION
- change spelling of 'initialise' to 'initialize' in documentation to align with the project language standard
- the correct term is 'User Authentication Methods' (not 'Modules') as per [Apple docs](https://developer.apple.com/library/archive/documentation/Networking/Conceptual/AFP/AFPSecurity/AFPSecurity.html#//apple_ref/doc/uid/TP40000854-CH232-SW1)
- note that the dbd CNID backend is considered deprecated