### PR TITLE
afpd: let sleeping sessions handle deferred reconnects

### DIFF
--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -779,8 +779,9 @@ void afp_over_dsi(AFPObj *obj)
                 break;                          /* NO idle — data ready */
             }
 
-            /* [B] State check — handle sleep/disconnected/die */
-            if (dsi->flags & (DSI_EXTSLEEP | DSI_SLEEPING | DSI_DISCONNECTED | DSI_DIE)) {
+            /* [B] State check — disconnected/die bypass poll; sleeping must
+             * still poll so deferred SIGURG reconnects can wake via self-pipe. */
+            if (dsi->flags & (DSI_DISCONNECTED | DSI_DIE)) {
                 if (obj->hint_fd >= 0) {
                     process_cache_hints(obj);
                 }


### PR DESCRIPTION
After the signal-safety refactor, SIGURG only sets transfer_pending and wakes the self-pipe. Sleeping AFP sessions were still bypassing poll() and blocking in dsi_stream_receive(), so the deferred reconnect handler never ran.

Allow sleeping sessions to remain in the poll path so self-pipe wakeups can process primary reconnects, while keeping disconnected and dying sessions on the existing special-state path.