### PR TITLE
afpd: report client address in afpstats

### DIFF
--- a/contrib/bin_utils/afpstats.pl
+++ b/contrib/bin_utils/afpstats.pl
@@ -23,7 +23,7 @@ use IO::Socket::UNIX;
 my $DEFAULT_SOCKET = '@localstatedir@/netatalk/afpstats.sock';
 
 sub usage {
-    printf("Usage: %s [-h hostname] [-s socket] [-v]\n", basename($0));
+    printf("Usage: %s [-h client-address] [-s socket] [-v]\n", basename($0));
     exit 1;
 }
 
@@ -67,7 +67,7 @@ sub main {
         exit 1;
     }
 
-    my @header = ('Connected user', 'PID', 'Login time', 'State', 'Protocol', 'Hostname', 'Mounted volumes');
+    my @header = ('Connected user', 'PID', 'Login time', 'State', 'Protocol', 'Client address', 'Mounted volumes');
     my @rows;
 
     while (defined(my $user = <$sock>)) {

--- a/doc/manpages/man1/afpstats.1.md
+++ b/doc/manpages/man1/afpstats.1.md
@@ -4,7 +4,7 @@ afpstats — List Netatalk AFP server statistics
 
 # Synopsis
 
-**afpstats** [-h *hostname*] [-s *socket*]
+**afpstats** [-h *client-address*] [-s *socket*]
 
 **afpstats** [-v | \-\-version]
 
@@ -20,9 +20,11 @@ to that group.
 
 # Options
 
-**-h**, **\-\-hostname** *hostname*
+**-h**, **\-\-hostname** *client-address*
 
-> Filter the output by the given hostname.
+> Filter the output by the given client hostname or address.
+> TCP/IP sessions use the resolved client hostname, falling back to the IP address.
+> AppleTalk sessions use the client DDP address in *net.node* form.
 
 **-s**, **\-\-socket** *path*
 
@@ -43,12 +45,12 @@ The socket path also depends on search permissions for the parent directory.
 
 # Examples
 
-List all connected users to the AFP server running on *fileserver*:
+List connected users:
 
-    $ afpstats --hostname fileserver
-    Connected user  PID     Login time       State     Protocol  Hostname    Mounted volumes
-    alice           452547  Apr 28 21:58:50  active    TCP/IP    fileserver  Data Vault, alice's Home
-    bob             451969  Apr 28 21:21:32  sleeping  TCP/IP    fileserver  My AFP Volume
+    $ afpstats
+    Connected user  PID     Login time       State     Protocol   Client address     Mounted volumes
+    alice           452547  Apr 28 21:58:50  sleeping  TCP/IP     workstation.local  Data Vault, alice's Home
+    bob             451969  Apr 28 21:21:32  active    AppleTalk  65280.12           My AFP Volume
 
 # See Also
 

--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -12,11 +12,13 @@
 #include <errno.h>
 #include <grp.h>
 #include <limits.h>
+#include <netdb.h>
 #include <pwd.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -24,7 +26,11 @@
 #include <unistd.h>
 
 #include <atalk/afp.h>
+#ifndef NO_DDP
+#include <atalk/asp.h>
+#endif
 #include <atalk/compat.h>
+#include <atalk/dsi.h>
 #include <atalk/fce_api.h>
 #include <atalk/globals.h>
 #include <atalk/logger.h>
@@ -62,6 +68,49 @@ static struct uam_obj uam_changepw = {"", "", 0, {{NULL, NULL, NULL, NULL}}, &ua
 };
 
 static struct uam_obj *afp_uam = NULL;
+
+static socklen_t sockaddr_len(const struct sockaddr *sa)
+{
+    switch (sa->sa_family) {
+    case AF_INET:
+        return sizeof(struct sockaddr_in);
+
+    case AF_INET6:
+        return sizeof(struct sockaddr_in6);
+
+    default:
+        return sizeof(struct sockaddr_storage);
+    }
+}
+
+static const char *client_address(AFPObj *obj)
+{
+    static char host[NI_MAXHOST];
+
+    if (obj->proto == AFPPROTO_DSI && obj->dsi) {
+        const struct sockaddr *sa = (const struct sockaddr *)&obj->dsi->client;
+
+        if (getnameinfo(sa, sockaddr_len(sa), host, sizeof(host), NULL, 0,
+                        NI_NAMEREQD) == 0) {
+            return host;
+        }
+
+        return getip_string(sa);
+    }
+
+#ifndef NO_DDP
+
+    if (obj->proto == AFPPROTO_ASP && obj->handle) {
+        const struct ASP *asp = obj->handle;
+        snprintf(host, sizeof(host), "%u.%u",
+                 ntohs(asp->asp_sat.sat_addr.s_net),
+                 asp->asp_sat.sat_addr.s_node);
+        return host;
+    }
+
+#endif
+    return "-";
+}
 
 
 void status_versions(char *data,
@@ -338,9 +387,10 @@ static int login(AFPObj *obj, struct passwd *pwd, void (*logout)(void),
     obj->euid = geteuid();
     obj->pid = getpid();
     /* report to parent */
+    const char *address = client_address(obj);
     ipc_child_write(obj, IPC_LOGINDONE,
-                    strnlen(obj->options.hostname, IPC_MAXMSGSIZE - IPC_HEADERLEN),
-                    obj->options.hostname);
+                    strnlen(address, IPC_MAXMSGSIZE - IPC_HEADERLEN),
+                    (void *)address);
 
     if (obj->proto == AFPPROTO_ASP) {
         ipc_child_state(obj, ASP_RUNNING);

--- a/include/atalk/server_child.h
+++ b/include/atalk/server_child.h
@@ -36,7 +36,7 @@ typedef struct afp_child {
     char     *afpch_sessiontoken; /*!< opaque reconnect token */
     int       afpch_ipc_fd;    /*!< socket for IPC bw afpd parent and childs */
     int       afpch_hint_fd;   /*!< pipe write/parent end for sending cache hints to child */
-    char     *afpch_hostname;  /*!< hostname of the server that the child is connected to */
+    char     *afpch_hostname;  /*!< hostname or address of the connected client */
     int16_t   afpch_state;     /*!< state of AFP session (eg active, sleeping, disconnected) */
     char     *afpch_volumes;   /*!< mounted volumes */
     struct afp_child **afpch_prevp;
@@ -69,7 +69,7 @@ extern int  server_child_transfer_session(server_child_t *children, uid_t uid,
         uint16_t DSI_requestID);
 extern void server_child_handler(server_child_t *);
 extern void server_child_login_done(server_child_t *children, pid_t pid,
-                                    uid_t, const char *);
+                                    uid_t, const char *client_address);
 extern void server_reset_signal(void);
 
 #endif

--- a/libatalk/util/server_child.c
+++ b/libatalk/util/server_child.c
@@ -456,7 +456,7 @@ void server_child_kill_one_by_id(server_child_t *children, pid_t pid,
 }
 
 void server_child_login_done(server_child_t *children, pid_t pid,
-                             uid_t uid, const char *hostname)
+                             uid_t uid, const char *client_address)
 {
     afp_child_t *child;
     afp_child_t *tmp;
@@ -477,7 +477,9 @@ void server_child_login_done(server_child_t *children, pid_t pid,
                     free(child->afpch_hostname);
                 }
 
-                child->afpch_hostname = hostname ? strdup(hostname) : NULL;
+                child->afpch_hostname = client_address
+                                        ? strdup(client_address)
+                                        : NULL;
             }
 
             child = tmp;


### PR DESCRIPTION
Send the connected client host/address in the login IPC payload instead of the configured server hostname. Resolve TCP clients to reverse-DNS names when available, fall back to normalized IP strings, and report AppleTalk sessions by DDP net.node address.

**Before**

    $ afpstats
    Connected user   PID      Login time        State          Mounted volumes
    alice            452547   Apr 28 21:58:50   active         Test Volume, alice's Home
    bob              451969   Apr 28 21:21:32   active         My AFP Volume

**After**

    $ afpstats
    Connected user  PID     Login time       State     Protocol   Client address     Mounted volumes
    alice           452547  Apr 28 21:58:50  sleeping  TCP/IP     workstation.local  Data Vault, alice's Home
    bob             451969  Apr 28 21:21:32  active    AppleTalk  65280.12           My AFP Volume