### PR TITLE
spotlight: drain ready localsearch callbacks on fetch

### DIFF
--- a/etc/spotlight/localsearch/sl_localsearch.c
+++ b/etc/spotlight/localsearch/sl_localsearch.c
@@ -164,7 +164,7 @@ static void tracker_cursor_cb(GObject      *object,
 
     if (uri == NULL) {
         LOG(log_debug, logtype_sl, "no URI for result");
-        return;
+        goto exit;
     }
 
     LOG(log_debug, logtype_sl, "URI: %s", uri);
@@ -394,6 +394,21 @@ static int sl_localsearch_fetch_results(slq_t *slq)
         slq->slq_state = SLQ_STATE_RESULTS;
         tracker_sparql_cursor_next_async(lsq->cursor, ctx->cancellable,
                                          tracker_cursor_cb, slq);
+    }
+
+    /*
+     * The AFP client may poll immediately after query_cb has queued the
+     * first cursor_next_async() but before the cursor callback has run.
+     * Drain callbacks that are already ready so fetchQueryResults can return
+     * the first available page, or DONE for an empty result set, instead of
+     * repeatedly returning empty pending pages.
+     */
+    while ((slq->slq_state == SLQ_STATE_RUNNING
+            || slq->slq_state == SLQ_STATE_RESULTS)
+            && slq->query_results != NULL
+            && slq->query_results->num_results == 0
+            && g_main_context_iteration(NULL, false)) {
+        ;
     }
 
     return 0;


### PR DESCRIPTION
The AFP client can poll fetchQueryResultsForContext immediately after the Tracker query callback has queued the first cursor_next_async(), but before the cursor callback has populated the current page or marked the query done.

Run ready GLib main-context callbacks while the current page is still empty so localsearch returns the first available result page, or DONE for an empty result set, instead of repeated empty pending pages. Also continue cursor iteration when Tracker returns a row without a URI.