### PR TITLE
afp.conf: default cnid server host-only port

### DIFF
--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -482,11 +482,13 @@ registration if Avahi or mDNSResponder were compiled in.
 Global configurations specific to the CNID database backends, which
 controls how the database is stored and accessed.
 
-cnid listen = *ip address[:port] [ip address[:port] ...]* **(G)**
+cnid listen = *host[:port]* **(G)**
 
-> Specifies the IP address and port that the CNID server should listen on.
-This should match the address and port of the **cnid server** option
-for most deployments. The default is **localhost:4700**.
+> Specifies the hostname or IP address and port that the CNID server should listen on.
+The host must resolve to a local address that cnid_metad can bind.
+This should match the address and port of the **cnid server** option for most
+deployments. The default is **localhost:4700**. When only a hostname or IP
+address is specified, the default port 4700 is used.
 
 cnid mysql host = *MySQL server address* **(G)**
 
@@ -526,14 +528,15 @@ Requires datbase administration, giving you full control over how the CNID data 
 > *sqlite*: uses the SQLite embedded database library.
 It is performant and lean, requiring no external database or daemon.
 
-cnid server = *ipaddress[:port]* **(G)**/**(V)**
+cnid server = *host[:port]* **(G)**/**(V)**
 
-> Specifies the IP address and port of a cnid_metad server, required
+> Specifies the hostname or IP address and port of a cnid_metad server, required
 for the CNID dbd backend. This should match the address and port of the
 **cnid listen** option for most deployments. Defaults to localhost:4700.
+When only a hostname or IP address is specified, the default port 4700 is used.
 >
-> The network address may be specified either in dotted-decimal format
-for IPv4 or in hexadecimal format for IPv6.
+> Hostnames and IPv4 addresses are accepted. Hostnames may resolve to IPv4
+or IPv6 addresses.
 
 vol dbpath = *path* **(G)**/**(V)**
 

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -1359,7 +1359,7 @@ static struct vol *creatvol(AFPObj *obj,
         EC_NULL(p = strdup(val));
         volume->v_cnidserver = p;
 
-        if ((q = strrchr(val, ':'))) {
+        if ((q = strrchr(p, ':'))) {
             *q++ = 0;
             volume->v_cnidport = strdup(q);
         } else {
@@ -3112,23 +3112,20 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
         free(p);
     }
 
-    q = getoption_strdup(config, INISEC_GLOBAL, "cnid server", NULL,
-                         "localhost:4700");
+    EC_NULL_LOG(q = getoption_strdup(config, INISEC_GLOBAL, "cnid server", NULL,
+                                     "localhost:4700"));
     r = strrchr(q, ':');
 
     if (r) {
         size_t hostname_length = r - q;
-        options->Cnid_srv = (char *)malloc(hostname_length + 1);
-
-        if (options->Cnid_srv) {
-            strlcpy(options->Cnid_srv, q, hostname_length + 1);
-        }
-
-        options->Cnid_port = strdup(r + 1);
+        EC_NULL_LOG(options->Cnid_srv = (char *)malloc(hostname_length + 1));
+        strlcpy(options->Cnid_srv, q, hostname_length + 1);
+        EC_NULL_LOG(options->Cnid_port = strdup(r + 1));
     } else {
         LOG(log_debug, logtype_afpd,
             "CNID Server: no port number detected, so falling back to default 4700");
-        options->Cnid_port = strdup("4700");
+        EC_NULL_LOG(options->Cnid_srv = strdup(q));
+        EC_NULL_LOG(options->Cnid_port = strdup("4700"));
     }
 
     LOG(log_debug, logtype_afpd, "CNID Server: %s:%s", options->Cnid_srv,

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -59,6 +59,12 @@ int main()
     TEST(setuplog("default:note", "/dev/tty", true));
     TEST(afp_options_parse_cmdline(&obj, 3, &args[0]));
     TEST_int(afp_config_parse(&obj, NULL), 0);
+    TEST_expr(reti = 0,
+              obj.options.Cnid_srv != NULL
+              && strcmp(obj.options.Cnid_srv, "127.0.0.1") == 0);
+    TEST_expr(reti = 0,
+              obj.options.Cnid_port != NULL
+              && strcmp(obj.options.Cnid_port, "4700") == 0);
     TEST_int(configinit(&obj, &aspobj), 0);
     TEST(cnid_init());
     TEST(load_volumes(&obj, LV_ALL));
@@ -74,6 +80,12 @@ int main()
     printf("Running tests\n=============\n");
     TEST_expr(vid = openvol(&obj, "afpd_test"), vid != 0);
     TEST_expr(vol = getvolbyvid(vid), vol != NULL);
+    TEST_expr(reti = 0,
+              vol->v_cnidserver != NULL
+              && strcmp(vol->v_cnidserver, "localhost") == 0);
+    TEST_expr(reti = 0,
+              vol->v_cnidport != NULL
+              && strcmp(vol->v_cnidport, "4700") == 0);
     /* test directory.c stuff */
     TEST_expr(retdir = dirlookup(vol, DIRDID_ROOT_PARENT), retdir != NULL);
     TEST_expr(retdir = dirlookup(vol, DIRDID_ROOT), retdir != NULL);

--- a/test/afpd/test.sh
+++ b/test/afpd/test.sh
@@ -27,9 +27,11 @@ afp port = 10548
 log file = $(pwd)/meson-logs/afpd.log
 log level = default:debug
 signature = $SIGNATURE
+cnid server = 127.0.0.1
 
 [test]
 cnid scheme = sqlite
+cnid server = localhost:4700
 ea = none
 path = $AFPTESTVOLUME
 vol dbpath = $AFPTESTCNID


### PR DESCRIPTION
Preserve the configured CNID server host when no port is specified and default the port to 4700. Also split volume-level host:port values on the owned copy so the stored server name is clean.

Check CNID server parsing allocations before logging or using the parsed host and port, avoiding NULL string arguments on allocation failure.

Clarify cnid server/listen documentation for hostnames and the default port.

Add afpd integration test coverage for host-only global CNID server config.

Reported-by: plouflechien (@pm)