### PR TITLE
test: report afpd integration checks with TAP

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,7 +66,7 @@ required at the bare minimum.
 | Package    | Details |
 |------------|---------|
 | C compiler | clang or gcc are recommended |
-| meson      | v0.61.2 or later |
+| meson      | v0.62.0 or later |
 | ninja      | often packaged as `ninja-build` |
 
 ### Optional Features

--- a/meson.build
+++ b/meson.build
@@ -4,9 +4,7 @@ project(
     version: '4.5.0',
     license: 'GPLv2',
     default_options: ['warning_level=3', 'c_std=c11'],
-    meson_version: '>=0.61.2',
-    # Reserved for future use:
-    # meson_version: '>=0.62.0',
+    meson_version: '>=0.62.0',
 )
 
 cc = meson.get_compiler('c')
@@ -2742,7 +2740,8 @@ summary_info = {
 summary(summary_info, bool_yn: true, section: '  Documentation:')
 
 summary_info = {
-    '  Test suite': get_option('with-testsuite'),
+    '  afpd integration tests': get_option('with-tests'),
+    '  AFP testsuite': get_option('with-testsuite'),
     '  Webmin module': have_webmin,
 }
 summary(summary_info, bool_yn: true, section: '  Extras:')

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -208,6 +208,9 @@ if get_option('with-tests')
     test(
         'afpd integration tests - run',
         afpdtest,
+        args: ['--tap'],
+        protocol: 'tap',
+        verbose: true,
         is_parallel: false,
         priority: 0,
     )

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -21,6 +21,7 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <atalk/cnid.h>
 #include <atalk/directory.h>
@@ -45,17 +46,50 @@
 unsigned char nologin = 0;
 static AFPObj obj, aspobj;
 static char *args[] = {"test", "-F", "test.conf"};
+int test_output_tap = 0;
+int test_case_num = 0;
+FILE *test_report_stream = NULL;
 
-int main()
+int main(int argc, char *argv[])
 {
     int reti;
     uint16_t vid;
     struct vol *vol;
     struct dir *retdir;
     struct path *path;
+    int test_report_fd;
     signal(SIGPIPE, SIG_IGN);
+
+    if (argc == 2 && strcmp(argv[1], "--tap") == 0) {
+        test_output_tap = 1;
+    }
+
+    test_report_fd = dup(STDOUT_FILENO);
+
+    if (test_report_fd != -1) {
+        test_report_stream = fdopen(test_report_fd, "w");
+
+        if (test_report_stream == NULL) {
+            close(test_report_fd);
+        }
+    }
+
+    if (test_report_stream == NULL) {
+        if (test_output_tap) {
+            printf("Bail out! failed to initialize TAP output\n");
+            fflush(stdout);
+            exit(1);
+        }
+
+        test_report_stream = stdout;
+    }
+
+    if (test_output_tap) {
+        setvbuf(test_report_stream, NULL, _IONBF, 0);
+    }
+
     /* initialize */
-    printf("Initializing\n============\n");
+    test_section("Initializing", "============");
     TEST(setuplog("default:note", "/dev/tty", true));
     TEST(afp_options_parse_cmdline(&obj, 3, &args[0]));
     TEST_int(afp_config_parse(&obj, NULL), 0);
@@ -69,9 +103,13 @@ int main()
     obj.hint_fd = -1;
     /* Set global AFPobj — normally done by afp_over_dsi() which tests bypass */
     AFPobj = &obj;
-    printf("\n");
+
+    if (!test_output_tap) {
+        fprintf(test_stream(), "\n");
+    }
+
     /* now run tests */
-    printf("Running tests\n=============\n");
+    test_section("Running tests", "=============");
     TEST_expr(vid = openvol(&obj, "afpd_test"), vid != 0);
     TEST_expr(vol = getvolbyvid(vid), vol != NULL);
     /* test directory.c stuff */
@@ -97,4 +135,5 @@ int main()
     /* cleanup */
     closevol(&obj, vol);
     unload_volumes(&obj);
+    test_plan(test_case_num);
 }

--- a/test/afpd/test.h
+++ b/test/afpd/test.h
@@ -39,6 +39,15 @@
 #include "subtests.h"
 #include "volume.h"
 
+extern int test_output_tap;
+extern int test_case_num;
+extern FILE *test_report_stream;
+
+static inline FILE *test_stream(void)
+{
+    return test_report_stream ? test_report_stream : stdout;
+}
+
 static inline void alignok(int len)
 {
     int i = 1;
@@ -48,32 +57,110 @@ static inline void alignok(int len)
     }
 
     while (i--) {
-        printf(" ");
+        fprintf(test_stream(), " ");
+    }
+}
+
+static inline void test_plan(int count)
+{
+    if (test_output_tap) {
+        fprintf(test_stream(), "1..%d\n", count);
+        fflush(test_stream());
+    }
+}
+
+static inline void test_section(const char *title, const char *underline)
+{
+    if (!test_output_tap) {
+        fprintf(test_stream(), "%s\n%s\n", title, underline);
+    }
+}
+
+static inline void test_begin(const char *name)
+{
+    if (!test_output_tap) {
+        int name_len;
+        fprintf(test_stream(), "Testing: ");
+        name_len = fprintf(test_stream(), "%s", name);
+        fprintf(test_stream(), " ... ");
+
+        if (name_len >= 0) {
+            alignok(name_len);
+        }
+    }
+}
+
+static inline void test_ok(const char *name)
+{
+    if (test_output_tap) {
+        fprintf(test_stream(), "ok %d - %s\n", ++test_case_num, name);
+        fflush(test_stream());
+    } else {
+        fprintf(test_stream(), "[ok]\n");
+    }
+}
+
+static inline void test_fail(const char *name, const char *file, int line)
+{
+    if (test_output_tap) {
+        fprintf(test_stream(), "not ok %d - %s\n", ++test_case_num, name);
+        fprintf(test_stream(), "# failed at %s:%d\n", file, line);
+        fflush(test_stream());
+    } else {
+        fprintf(test_stream(), "[error]\n");
+    }
+}
+
+static inline void test_fail_int(const char *name, int got, int expected,
+                                 const char *file, int line)
+{
+    test_fail(name, file, line);
+
+    if (test_output_tap) {
+        fprintf(test_stream(), "# got: %d\n", got);
+        fprintf(test_stream(), "# expected: %d\n", expected);
+        fflush(test_stream());
+    }
+}
+
+static inline void test_abort(void)
+{
+    if (test_output_tap) {
+        fprintf(test_stream(), "Bail out! stopping after failed assertion\n");
+        fflush(test_stream());
     }
 }
 
 #define TEST(a) \
-    printf("Testing: %s ... ", (#a) ); \
-    alignok(strlen(#a));               \
-    a;                                 \
-    printf("[ok]\n");
+    do {                               \
+        test_begin(#a);                \
+        a;                             \
+        test_ok(#a);                   \
+    } while (0)
 
 #define TEST_int(a, b) \
-    printf("Testing: %s ... ", (#a) );            \
-    alignok(strlen(#a));                          \
-    if ((reti = (a)) != b) {                      \
-        printf("[error]\n");                      \
-        exit(1);                                  \
-    } else { printf("[ok]\n"); }
+    do {                                           \
+        test_begin(#a);                            \
+        if ((reti = (a)) != b) {                   \
+            test_fail_int(#a, reti, b, __FILE__,   \
+                          __LINE__);               \
+            test_abort();                           \
+            exit(1);                               \
+        } else {                                   \
+            test_ok(#a);                           \
+        }                                          \
+    } while (0)
 
-#define TEST_expr(a, b)                              \
-    printf("Testing: %s ... ", (#a) );               \
-    alignok(strlen(#a));                             \
-    a;                                               \
-    if (b) {                                         \
-        printf("[ok]\n");                            \
-    } else {                                         \
-        printf("[error]\n");                         \
-        exit(1);                                     \
-    }
+#define TEST_expr(a, b)                           \
+    do {                                          \
+        test_begin(#a);                           \
+        a;                                        \
+        if (b) {                                  \
+            test_ok(#a);                          \
+        } else {                                  \
+            test_fail(#a, __FILE__, __LINE__);    \
+            test_abort();                         \
+            exit(1);                              \
+        }                                         \
+    } while (0)
 #endif  /* TEST_H */


### PR DESCRIPTION
Add a TAP output mode to the afpd integration test harness and run it through Meson's TAP protocol so individual assertions are visible in Meson test output. Preserve the existing direct-run output by default and keep TAP output on the original stdout even after afpd logging setup.

Bump the Meson requirement to 0.62.0 from 0.61.2 for verbose TAP test reporting and print the afpd integration tests in the setup summary.

With this change, you get verbose test reports from the afpd integration tests when run through the meson harness:

```shell
✗ meson test -C build   
ninja: Entering directory `/Users/dmark/dev/netatalk2/build'
ninja: no work to do.
1/2 netatalk:afpd integration tests - setup        OK              0.03s
2/2 netatalk:afpd integration tests - run          RUNNING       
>>> LD_LIBRARY_PATH=/Users/dmark/dev/netatalk2/build/libatalk MALLOC_PERTURB_=20 ASAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1 MSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_summary=1:print_stacktrace=1 DYLD_LIBRARY_PATH=/Users/dmark/dev/netatalk2/build/libatalk MESON_TEST_ITERATION=1 /Users/dmark/dev/netatalk2/build/test/afpd/afpdtest --tap
▶ 2/2 - setuplog("default:note", "/dev/tty", true) OK            
▶ 2/2 - afp_options_parse_cmdline(&obj, 3, &args[0]) OK            
▶ 2/2 - afp_config_parse(&obj, NULL)               OK            
▶ 2/2 - configinit(&obj, &aspobj)                  OK            
▶ 2/2 - cnid_init()                                OK            
▶ 2/2 - load_volumes(&obj, LV_ALL)                 OK            
▶ 2/2 - dircache_init(8192)                        OK            
▶ 2/2 - vid = openvol(&obj, "afpd_test")           OK            
▶ 2/2 - vol = getvolbyvid(vid)                     OK            
▶ 2/2 - retdir = dirlookup(vol, DIRDID_ROOT_PARENT) OK            
▶ 2/2 - retdir = dirlookup(vol, DIRDID_ROOT)       OK            
▶ 2/2 - path = cname(vol, retdir, cnamewrap("Network Trash Folder")) OK            
▶ 2/2 - retdir = dirlookup(vol, DIRDID_ROOT)       OK            
▶ 2/2 - getfiledirparms(&obj, vid, DIRDID_ROOT_PARENT, "afpd_test") OK            
▶ 2/2 - getfiledirparms(&obj, vid, DIRDID_ROOT, "") OK            
▶ 2/2 - reti = createdir(&obj, vid, DIRDID_ROOT, "dir1") OK            
▶ 2/2 - getfiledirparms(&obj, vid, DIRDID_ROOT, "dir1") OK            
▶ 2/2 - getfiledirparms(&obj, vid, DIRDID_ROOT, "\000\000") OK            
▶ 2/2 - createfile(&obj, vid, DIRDID_ROOT, "dir1/file1") OK            
▶ 2/2 - delete (&obj, vid, DIRDID_ROOT, "dir1/file1") OK            
▶ 2/2 - delete (&obj, vid, DIRDID_ROOT, "dir1")    OK            
▶ 2/2 - createfile(&obj, vid, DIRDID_ROOT, "file1") OK            
▶ 2/2 - getfiledirparms(&obj, vid, DIRDID_ROOT, "file1") OK            
▶ 2/2 - delete (&obj, vid, DIRDID_ROOT, "file1")   OK            
▶ 2/2 - enumerate(&obj, vid, DIRDID_ROOT)          OK            
2/2 netatalk:afpd integration tests - run          OK              0.22s   25 subtests passed


Ok:                2   
Fail:              0   
```