### PR TITLE
docs: import YAML::PP preserve constant directly

### DIFF
--- a/contrib/scripts/make_compile_docs.pl
+++ b/contrib/scripts/make_compile_docs.pl
@@ -18,7 +18,7 @@
 use strict;
 use warnings;
 use YAML::PP;
-use YAML::PP::Common qw/ :PRESERVE /;
+use YAML::PP::Common qw/ PRESERVE_ORDER /;
 
 if (@ARGV < 2 || grep { $_ eq '--help' || $_ eq '-h' } @ARGV) {
     print "Usage: $0 input_file output_file\n";


### PR DESCRIPTION
Ubuntu 22.04 ships YAML::PP 0.029, whose YAML::PP::Common module does not provide the :PRESERVE export tag used by newer releases.

Import PRESERVE_ORDER explicitly instead, which is the only constant this helper needs and keeps make_compile_docs.pl compatible with both old and new YAML::PP versions.