### PR TITLE
meson: Fix detection of libatomic

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -405,8 +405,23 @@ int main(void) {
 }
 '''
 if not cc.links(atomic_test_code, name: 'atomic builtins without -latomic')
-    cc.find_library('atomic', required: true)
-    netatalk_common_link_args = ['-latomic'] + netatalk_common_link_args
+    # Find the library: system paths, platform paths
+    atomic = cc.find_library('atomic', required: false)
+    foreach d : libsearch_dirs
+        if not atomic.found()
+            atomic = cc.find_library('atomic', dirs: d, required: false)
+            if atomic.found()
+                netatalk_common_link_args += ['-L' + d]
+            endif
+        endif
+    endforeach
+    if atomic.found()
+        netatalk_common_link_args += '-latomic'
+    endif
+    have_atomic = atomic.found()
+    if not have_atomic
+        error('libatomic is required! Please install it.')
+    endif
 endif
 
 add_global_link_arguments(netatalk_common_link_args, language: 'c')


### PR DESCRIPTION
Currently if the test for built-in GCC atomic functions fails, meson only searches for the libatomic library at the default location. Some platforms install the library in an alternate location (ex: NetBSD/m68k), so we search those additional locations. If the library is found, update the linker args to search that directory. Fixes #3043.