### PR TITLE
 nad: introduce support for MacBinary and BinHex conversion

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@ with their contributions. Cheers.
 Thanks a bunch folks, wherever you are.
 
 - Wesley Craig <wesley.craig@umich.edu>
+- Charles Clark <cmclark@umich.edu>: megatron Macintosh file format transformer
 - Adrian Sun <asun@cobaltnet.com>
 - Steve Hirsch <shirsch@adelphia.net>: ProDOS II support/initial Randnum
 support

--- a/bin/nad/crc16.c
+++ b/bin/nad/crc16.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include "crc16.h"
+
+#define CRC16_XMODEM_POLY 0x1021u
+
+uint16_t crc16_xmodem_update(uint16_t crc, const void *buf, size_t len)
+{
+    const uint8_t *ptr = buf;
+
+    while (len-- > 0) {
+        crc ^= (uint16_t) * ptr++ << 8;
+
+        for (unsigned int bit = 0; bit < 8; bit++) {
+            if ((crc & 0x8000) != 0) {
+                crc = (uint16_t)((crc << 1) ^ CRC16_XMODEM_POLY);
+            } else {
+                crc = (uint16_t)(crc << 1);
+            }
+        }
+    }
+
+    return crc;
+}

--- a/bin/nad/crc16.h
+++ b/bin/nad/crc16.h
@@ -1,0 +1,9 @@
+#ifndef CRC16_H
+#define CRC16_H 1
+
+#include <stddef.h>
+#include <stdint.h>
+
+uint16_t crc16_xmodem_update(uint16_t crc, const void *buf, size_t len);
+
+#endif /* CRC16_H */

--- a/bin/nad/hqx.c
+++ b/bin/nad/hqx.c
@@ -1,0 +1,996 @@
+/*
+ * Copyright (c) 1990,1991 Regents of The University of Michigan.
+ * Copyright (c) 2026 Daniel Markstedt <daniel@mindani.net>
+ * All Rights Reserved.  See COPYRIGHT.
+ *
+ * Macintosh file format transformer based on megatron by Charles Clark.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <sys/time.h>
+#include <sys/param.h>
+
+#include <string.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+#include <unistd.h>
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif /* HAVE_FCNTL_H */
+
+#include <netinet/in.h>
+
+#include <atalk/adouble.h>
+#include <netatalk/endian.h>
+
+#include "nad.h"
+#include "megatron.h"
+#include "nad_adouble.h"
+#include "hqx.h"
+#include "crc16.h"
+
+/*	String used to indicate standard input instead of a disk
+	file.  Should be a string not normally used for a file
+ */
+#ifndef	STDIN
+#	define	STDIN	"-"
+#endif /* ! STDIN */
+
+/*	Yes and no
+ */
+#define NOWAY		0
+#define SURETHANG	1
+
+/*	Looking for the first or any other line of a binhex file
+ */
+#define	FIRST		0
+#define OTHER		1
+
+/*	This is the binhex run length encoding character
+ */
+#define RUNCHAR		0x90
+
+/*	These are field sizes in bytes of various pieces of the
+	binhex header
+ */
+#define	BHH_VERSION		1
+#define	BHH_TCSIZ		8
+#define	BHH_FLAGSIZ		2
+#define	BHH_DATASIZ		4
+#define	BHH_RESSIZ		4
+#define BHH_CRCSIZ		2
+#define BHH_HEADSIZ		21
+
+static struct hqx_file_data {
+    uint32_t		forklen[ NUMFORKS ];
+    unsigned short		forkcrc[ NUMFORKS ];
+    int                 forkdone[ NUMFORKS ];
+    char		path[ MAXPATHLEN + 1];
+    unsigned short		headercrc;
+    int			filed;
+    int                 owns_fd;
+    unsigned char       outbuf[3];
+    int                 outcnt;
+    int                 linecol;
+    int                 writing;
+} 		hqx;
+
+extern char	*forkname[];
+static unsigned char	hqx7_buf[8192];
+static unsigned char	*hqx7_first;
+static unsigned char	*hqx7_last;
+static int	first_flag;
+static const unsigned char hqxchars[] =
+    "!\"#$%&'()*+,-012345689@ABCDEFGHIJKLMNPQRSTUVXYZ[`abcdefhijklmpqr";
+
+static int hqx_write_all(const void *buf, size_t len)
+{
+    const char *p = buf;
+
+    while (len > 0) {
+        ssize_t cc = write(hqx.filed, p, len);
+
+        if (cc <= 0) {
+            return -1;
+        }
+
+        p += cc;
+        len -= cc;
+    }
+
+    return 0;
+}
+
+static int hqx_put_char(unsigned char c)
+{
+    if (hqx.linecol >= 63) {
+        if (hqx_write_all("\n", 1) < 0) {
+            return -1;
+        }
+
+        hqx.linecol = 0;
+    }
+
+    if (hqx_write_all(&c, 1) < 0) {
+        return -1;
+    }
+
+    hqx.linecol++;
+    return 0;
+}
+
+static int hqx_emit_6bit(unsigned char b)
+{
+    hqx.outbuf[hqx.outcnt++] = b;
+
+    if (hqx.outcnt == 3) {
+        unsigned char out[4];
+        out[0] = hqxchars[(hqx.outbuf[0] >> 2) & 0x3f];
+        out[1] = hqxchars[((hqx.outbuf[0] << 4) | (hqx.outbuf[1] >> 4)) & 0x3f];
+        out[2] = hqxchars[((hqx.outbuf[1] << 2) | (hqx.outbuf[2] >> 6)) & 0x3f];
+        out[3] = hqxchars[hqx.outbuf[2] & 0x3f];
+
+        for (int i = 0; i < 4; i++) {
+            if (hqx_put_char(out[i]) < 0) {
+                return -1;
+            }
+        }
+
+        hqx.outcnt = 0;
+    }
+
+    return 0;
+}
+
+static int hqx_emit_byte(unsigned char b)
+{
+    if (hqx_emit_6bit(b) < 0) {
+        return -1;
+    }
+
+    if (b == RUNCHAR) {
+        return hqx_emit_6bit(0);
+    }
+
+    return 0;
+}
+
+static int hqx_emit_data(const void *buf, size_t len)
+{
+    const unsigned char *p = buf;
+
+    while (len-- > 0) {
+        if (hqx_emit_byte(*p++) < 0) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+static int hqx_flush_6bit(void)
+{
+    unsigned char out[3];
+    int outlen;
+
+    if (hqx.outcnt == 0) {
+        return 0;
+    }
+
+    hqx.outbuf[1] = hqx.outcnt > 1 ? hqx.outbuf[1] : 0;
+    hqx.outbuf[2] = 0;
+    out[0] = hqxchars[(hqx.outbuf[0] >> 2) & 0x3f];
+    out[1] = hqxchars[((hqx.outbuf[0] << 4) | (hqx.outbuf[1] >> 4)) & 0x3f];
+    out[2] = hqxchars[(hqx.outbuf[1] << 2) & 0x3f];
+    outlen = hqx.outcnt + 1;
+
+    for (int i = 0; i < outlen; i++) {
+        if (hqx_put_char(out[i]) < 0) {
+            return -1;
+        }
+    }
+
+    hqx.outcnt = 0;
+    return 0;
+}
+
+static int hqx_finish_fork(int fork)
+{
+    uint16_t crc;
+
+    if (hqx.forkdone[fork]) {
+        return 0;
+    }
+
+    if (hqx.forklen[fork] != 0) {
+        return -1;
+    }
+
+    crc = htons(hqx.forkcrc[fork]);
+
+    if (hqx_emit_data(&crc, sizeof(crc)) < 0) {
+        return -1;
+    }
+
+    hqx.forkdone[fork] = 1;
+    return 0;
+}
+
+/*!
+ * @brief Open a BinHex file for reading or writing
+ *
+ * This must be called before other hqx operations. When opening for
+ * reading, it skips the preamble and reads the BinHex header. When
+ * opening for writing, it initializes output state and writes the
+ * BinHex preamble and header.
+ *
+ * @param[in] hqxfile    input file path, or `-` for standard input
+ * @param[in] flags      open flags; `O_RDONLY` selects read mode
+ * @param[in,out] fh     file header to read or write
+ * @param[in] options    output options, such as `OPTION_STDOUT`
+ *
+ * @returns 0 on success, -1 on error
+ */
+int hqx_open(char *hqxfile, int flags, struct FHeader *fh, int options)
+{
+#if DEBUG
+    NAD_DEBUG("nad: entering hqx_open\n");
+#endif /* DEBUG */
+    hqx.filed = -1;
+    hqx.owns_fd = 0;
+
+    if (flags == O_RDONLY) {
+        hqx.writing = 0;
+        first_flag = 0;
+
+        if (strcmp(hqxfile, STDIN) == 0) {
+            hqx.filed = fileno(stdin);
+        } else if ((hqx.filed = open(hqxfile, O_RDONLY)) < 0) {
+            perror(hqxfile);
+            return -1;
+        } else {
+            hqx.owns_fd = 1;
+        }
+
+        if (skip_junk(FIRST) == 0 && hqx_header_read(fh) == 0) {
+#if DEBUG
+            off_t	pos;
+            pos = lseek(hqx.filed, 0, SEEK_CUR);
+            NAD_DEBUG("nad: current position is %ld\n", pos);
+#endif /* DEBUG */
+            return 0;
+        }
+
+        hqx_close(KEEP);
+        fprintf(stderr, "%s\n", hqxfile);
+        return -1;
+    } else {
+        memset(hqx.forkcrc, 0, sizeof(hqx.forkcrc));
+        memset(hqx.forkdone, 0, sizeof(hqx.forkdone));
+        hqx.forklen[DATA] = ntohl(fh->forklen[DATA]);
+        hqx.forklen[RESOURCE] = ntohl(fh->forklen[RESOURCE]);
+        hqx.outcnt = 0;
+        hqx.linecol = 0;
+        hqx.writing = 1;
+
+        if (options & OPTION_STDOUT) {
+            hqx.filed = fileno(stdout);
+            strlcpy(hqx.path, STDIN, sizeof(hqx.path));
+        } else {
+            if (strlcpy(hqx.path, fh->name, sizeof(hqx.path)) >= sizeof(hqx.path)
+                    || strlcpy(hqx.path, mtoupath(hqx.path), sizeof(hqx.path))
+                    >= sizeof(hqx.path)
+                    || strlcat(hqx.path, ".hqx", sizeof(hqx.path))
+                    >= sizeof(hqx.path)) {
+                fprintf(stderr, "Output path is too long: %s.hqx\n", fh->name);
+                return -1;
+            }
+
+            if ((hqx.filed = open(hqx.path, flags, 0666)) < 0) {
+                perror(hqx.path);
+                return -1;
+            }
+
+            hqx.owns_fd = 1;
+        }
+
+        static const char hqx_preamble[] =
+            "(This file must be converted with BinHex 4.0)\n\n:";
+
+        if (hqx_write_all(hqx_preamble, sizeof(hqx_preamble) - 1) < 0) {
+            hqx_close(TRASH);
+            return -1;
+        }
+
+        if (hqx_header_write(fh) != 0) {
+            hqx_close(TRASH);
+            fprintf(stderr, "%s\n", hqx.path);
+            return -1;
+        }
+
+        return 0;
+    }
+}
+
+/*!
+ * @brief Close the active BinHex file
+ *
+ * This must be called before opening another file with hqx_open().
+ * In write mode, `KEEP` finishes any remaining fork data, flushes the
+ * encoder, and writes the BinHex terminator. `TRASH` closes the output
+ * and removes the incomplete file.
+ *
+ * @param[in] keepflag    `KEEP` to keep the output, `TRASH` to discard it
+ *
+ * @returns 0 on success, -1 on error
+ */
+int hqx_close(int keepflag)
+{
+    if (keepflag == KEEP) {
+        if (hqx.writing
+                && (hqx_finish_fork(DATA) < 0
+                    || hqx_finish_fork(RESOURCE) < 0
+                    || hqx_flush_6bit() < 0
+                    || hqx_write_all(":\n", 2) < 0)) {
+            return -1;
+        }
+
+        if (hqx.owns_fd && hqx.filed >= 0) {
+            int rc = close(hqx.filed);
+            hqx.filed = -1;
+            hqx.owns_fd = 0;
+            return rc;
+        }
+
+        hqx.filed = -1;
+        return 0;
+    } else if (keepflag == TRASH) {
+        if (hqx.owns_fd && hqx.filed >= 0) {
+            close(hqx.filed);
+        }
+
+        hqx.filed = -1;
+        hqx.owns_fd = 0;
+
+        if ((strcmp(hqx.path, STDIN) != 0) && (unlink(hqx.path) < 0)) {
+            perror(hqx.path);
+        }
+
+        return 0;
+    } else {
+        return -1;
+    }
+}
+
+const char *hqx_path(void)
+{
+    return hqx.path;
+}
+
+/*!
+ * @brief Read decoded data from a BinHex fork
+ *
+ * Call this until it returns zero for each fork. When no fork data
+ * remains, the stored fork CRC is read and compared with the calculated
+ * CRC before returning zero.
+ *
+ * @note hqx_read() must be called enough times to return zero, and no
+ * more than that, for each fork.
+ *
+ * @param[in] fork       fork selector, `DATA` or `RESOURCE`
+ * @param[out] buffer    destination buffer
+ * @param[in] length     maximum number of bytes to read
+ *
+ * @returns number of bytes read, 0 when the fork is complete, -1 on error
+ */
+ssize_t hqx_read(int fork, char *buffer, size_t length)
+{
+    unsigned short		storedcrc;
+    size_t		readlen;
+    size_t		cc;
+#if DEBUG >= 3
+    {
+        off_t	pos;
+        pos = lseek(hqx.filed, 0, SEEK_CUR);
+        NAD_DEBUG("hqx_read: current position is %ld\n", pos);
+    }
+    NAD_DEBUG("hqx_read: fork is %s\n", forkname[ fork ]);
+    NAD_DEBUG("hqx_read: remaining length is %d\n", hqx.forklen[fork]);
+#endif /* DEBUG >= 3 */
+
+    if (hqx.forklen[fork] > 0x7FFFFFFF) {
+        fprintf(stderr, "Invalid %s fork length: %u\n",
+                forkname[fork],
+                hqx.forklen[fork]);
+        return -1;
+    }
+
+    if (hqx.forklen[ fork ] == 0) {
+        cc = hqx_7tobin((char *)&storedcrc, sizeof(storedcrc));
+
+        if (cc == sizeof(storedcrc)) {
+            storedcrc = ntohs(storedcrc);
+#if DEBUG >= 4
+            NAD_DEBUG("hqx_read: storedcrc\t\t%x\n", storedcrc);
+            NAD_DEBUG("hqx_read: observed crc\t\t%x\n\n", hqx.forkcrc[fork]);
+#endif /* DEBUG >= 4 */
+
+            if (storedcrc == hqx.forkcrc[ fork ]) {
+                return 0;
+            }
+
+            fprintf(stderr, "hqx_read: bad %s fork CRC\n",
+                    forkname[ fork ]);
+        }
+
+        return -1;
+    }
+
+    if (hqx.forklen[ fork ] < length) {
+        readlen = hqx.forklen[ fork ];
+    } else {
+        readlen = length;
+    }
+
+#if DEBUG >= 3
+    NAD_DEBUG("hqx_read: readlen is %d\n", readlen);
+#endif /* DEBUG >= 3 */
+    cc = hqx_7tobin(buffer, readlen);
+
+    if (cc > 0) {
+        hqx.forkcrc[ fork ] =
+            crc16_xmodem_update(hqx.forkcrc[ fork ], buffer, cc);
+        hqx.forklen[ fork ] -= cc;
+    }
+
+#if DEBUG >= 3
+    NAD_DEBUG("hqx_read: chars read is %d\n", cc);
+#endif /* DEBUG >= 3 */
+    return cc;
+}
+
+/*!
+ * @brief Read and validate a BinHex header
+ *
+ * This is called by hqx_open() before any fork data is read. It decodes
+ * the header fields, initializes fork lengths and CRC state, and verifies
+ * the header CRC.
+ *
+ * @param[out] fh    file header to populate
+ *
+ * @returns 0 on success, negative value on error
+ */
+int hqx_header_read(struct FHeader *fh)
+{
+    char		*headerbuf, *headerptr;
+    uint32_t		time_seconds;
+    unsigned short		mask;
+    unsigned short		header_crc;
+    char		namelen_byte;
+    unsigned char	namelen;
+    size_t              headerlen;
+    mask = htons(0xfcee);
+    hqx.headercrc = 0;
+
+    if (hqx_7tobin(&namelen_byte, sizeof(namelen_byte))
+            != sizeof(namelen_byte)) {
+        fprintf(stderr, "Premature end of file :");
+        return -2;
+    }
+
+    namelen = (unsigned char)namelen_byte;
+    hqx.headercrc = crc16_xmodem_update(hqx.headercrc, &namelen_byte,
+                                        sizeof(namelen_byte));
+    headerlen = namelen + BHH_HEADSIZ;
+
+    if ((headerbuf = (char *)malloc(headerlen)) == NULL) {
+        return -1;
+    }
+
+    if (hqx_7tobin(headerbuf, headerlen) != headerlen) {
+        free(headerbuf);
+        fprintf(stderr, "Premature end of file :");
+        return -2;
+    }
+
+    headerptr = headerbuf;
+    hqx.headercrc = crc16_xmodem_update(hqx.headercrc,
+                                        headerbuf, headerlen - BHH_CRCSIZ);
+
+    /*
+     * stuff from the hqx file header
+     */
+    if (namelen >= sizeof(fh->name)) {
+        free(headerbuf);
+        fprintf(stderr, "BinHex filename is too long :");
+        return -2;
+    }
+
+    memcpy(fh->name, headerptr, (int)namelen);
+    fh->name[namelen] = '\0';
+    headerptr += namelen;
+    headerptr += BHH_VERSION;
+    memcpy(&fh->finder_info,  headerptr, BHH_TCSIZ);
+    headerptr += BHH_TCSIZ;
+    memcpy(&fh->finder_info.fdFlags,  headerptr, BHH_FLAGSIZ);
+    fh->finder_info.fdFlags = fh->finder_info.fdFlags & mask;
+    headerptr += BHH_FLAGSIZ;
+    memcpy(&fh->forklen[ DATA ],  headerptr, BHH_DATASIZ);
+    hqx.forklen[ DATA ] = ntohl(fh->forklen[ DATA ]);
+    headerptr += BHH_DATASIZ;
+    memcpy(&fh->forklen[ RESOURCE ], headerptr, BHH_RESSIZ);
+    hqx.forklen[ RESOURCE ] = ntohl(fh->forklen[ RESOURCE ]);
+    headerptr += BHH_RESSIZ;
+    memcpy(&header_crc,  headerptr, BHH_CRCSIZ);
+    header_crc = ntohs(header_crc);
+    /*
+     * stuff that should be zero'ed out
+     */
+    fh->comment[0] = '\0';
+    fh->finder_info.fdLocation = 0;
+    fh->finder_info.fdFldr = 0;
+#if DEBUG >= 5
+    {
+        short		flags;
+        NAD_DEBUG("Values read by hqx_header_read\n");
+        NAD_DEBUG("name length\t\t%d\n", namelen);
+        NAD_DEBUG("file name\t\t%s\n", fh->name);
+        NAD_DEBUG("get info comment\t%s\n", fh->comment);
+        NAD_DEBUG("type\t\t\t%.*s\n", sizeof(fh->finder_info.fdType),
+                  &fh->finder_info.fdType);
+        NAD_DEBUG("creator\t\t\t%.*s\n",
+                  sizeof(fh->finder_info.fdCreator),
+                  &fh->finder_info.fdCreator);
+        memcpy(&flags, &fh->finder_info.fdFlags, sizeof(flags));
+        flags = ntohs(flags);
+        NAD_DEBUG("flags\t\t\t%x\n", flags);
+        NAD_DEBUG("data fork length\t%ld\n", hqx.forklen[DATA]);
+        NAD_DEBUG("resource fork length\t%ld\n", hqx.forklen[RESOURCE]);
+        NAD_DEBUG("header_crc\t\t%x\n", header_crc);
+        NAD_DEBUG("observed crc\t\t%x\n", hqx.headercrc);
+        NAD_DEBUG("\n");
+    }
+#endif /* DEBUG >= 5 */
+    /*
+     * create and modify times are figured from right now
+     */
+    time_seconds = AD_DATE_FROM_UNIX(time(NULL));
+    memcpy(&fh->create_date, &time_seconds,
+           sizeof(fh->create_date));
+    memcpy(&fh->mod_date, &time_seconds,
+           sizeof(fh->mod_date));
+    fh->backup_date = AD_DATE_START;
+    fh->date_flags = 0;
+    /*
+     * stuff that should be zero'ed out
+     */
+    fh->comment[0] = '\0';
+    memset(&fh->finder_info.fdLocation, 0,
+           sizeof(fh->finder_info.fdLocation));
+    memset(&fh->finder_info.fdFldr, 0, sizeof(fh->finder_info.fdFldr));
+    hqx.forkcrc[ DATA ] = 0;
+    hqx.forkcrc[ RESOURCE ] = 0;
+    free(headerbuf);
+
+    if (header_crc != hqx.headercrc) {
+        fprintf(stderr, "Bad header CRC:");
+        return -3;
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief Encode and write a BinHex header
+ *
+ * @param[in] fh    file header to write
+ *
+ * @returns 0 on success, -1 on error
+ */
+int hqx_header_write(struct FHeader *fh)
+{
+    unsigned char header[ADEDLEN_NAME + BHH_HEADSIZ + 1];
+    unsigned char *p = header;
+    size_t namelen;
+    uint16_t header_crc;
+    uint16_t flags;
+    namelen = strnlen(fh->name, sizeof(fh->name));
+
+    if (namelen > 63) {
+        fprintf(stderr, "BinHex filename is too long: %s\n", fh->name);
+        return -1;
+    }
+
+    *p++ = (unsigned char)namelen;
+    memcpy(p, fh->name, namelen);
+    p += namelen;
+    *p++ = 0; /* BinHex version */
+    memcpy(p, &fh->finder_info.fdType, sizeof(fh->finder_info.fdType));
+    p += sizeof(fh->finder_info.fdType);
+    memcpy(p, &fh->finder_info.fdCreator, sizeof(fh->finder_info.fdCreator));
+    p += sizeof(fh->finder_info.fdCreator);
+    flags = fh->finder_info.fdFlags & htons(0xfcee);
+    memcpy(p, &flags, sizeof(flags));
+    p += sizeof(flags);
+    memcpy(p, &fh->forklen[DATA], sizeof(fh->forklen[DATA]));
+    p += sizeof(fh->forklen[DATA]);
+    memcpy(p, &fh->forklen[RESOURCE], sizeof(fh->forklen[RESOURCE]));
+    p += sizeof(fh->forklen[RESOURCE]);
+    header_crc = htons(crc16_xmodem_update(0, header, p - header));
+    memcpy(p, &header_crc, sizeof(header_crc));
+    p += sizeof(header_crc);
+
+    if (hqx_emit_data(header, p - header) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+ssize_t hqx_write(int fork, char *buffer, size_t length)
+{
+    if (fork < 0 || fork >= NUMFORKS) {
+        return -1;
+    }
+
+    if (fork == RESOURCE && hqx_finish_fork(DATA) < 0) {
+        return -1;
+    }
+
+    if (hqx.forkdone[fork] || length > hqx.forklen[fork]) {
+        return -1;
+    }
+
+    hqx.forkcrc[fork] =
+        crc16_xmodem_update(hqx.forkcrc[fork], buffer, length);
+
+    if (hqx_emit_data(buffer, length) < 0) {
+        return -1;
+    }
+
+    hqx.forklen[fork] -= length;
+
+    if (hqx.forklen[fork] == 0 && hqx_finish_fork(fork) < 0) {
+        return -1;
+    }
+
+    return length;
+}
+
+/*!
+ * @brief Fill the BinHex text input buffer
+ *
+ * This is called from skip_junk() and hqx_7tobin(). It reads from the
+ * BinHex file into the hqx7 buffer and updates hqx7_first and hqx7_last
+ * to delimit valid data.
+ *
+ * @param[in] hqx7_ptr    pointer within hqx7_buf where reading should start
+ *
+ * @returns number of bytes read, 0 on end of file, -1 on error
+ */
+ssize_t hqx7_fill(unsigned char *hqx7_ptr)
+{
+    ssize_t		cc;
+    size_t		cs;
+    cs = hqx7_ptr - hqx7_buf;
+
+    if (cs >= sizeof(hqx7_buf)) {
+        return -1;
+    }
+
+    hqx7_first = hqx7_ptr;
+    cc = read(hqx.filed, (char *)hqx7_first, (sizeof(hqx7_buf) - cs));
+
+    if (cc < 0) {
+        perror("");
+        return cc;
+    }
+
+    hqx7_last = (hqx7_first + cc);
+    return cc;
+}
+
+/*
+char tr[] = "!\"#$%&'()*+,-012345689@ABCDEFGHIJKLMNPQRSTUVXYZ[`abcdefhijklmpqr";
+	     0 123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+	     0                1               2               3
+Input characters are translated to a number between 0 and 63 by direct
+array lookup.  0xFF signals a bad character.  0xFE is signals a legal
+character that should be skipped, namely '\n', '\r'.  0xFD signals ':'.
+0xFC signals a whitespace character.
+*/
+
+static const unsigned char hqxlookup[] = {
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFC, 0xFE, 0xFF, 0xFF, 0xFE, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFC, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+    0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0xFF, 0xFF,
+    0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0xFF,
+    0x14, 0x15, 0xFD, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D,
+    0x1E, 0x1F, 0x20, 0x21, 0x22, 0x23, 0x24, 0xFF,
+    0x25, 0x26, 0x27, 0x28, 0x29, 0x2A, 0x2B, 0xFF,
+    0x2C, 0x2D, 0x2E, 0x2F, 0xFF, 0xFF, 0xFF, 0xFF,
+    0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0xFF,
+    0x37, 0x38, 0x39, 0x3A, 0x3B, 0x3C, 0xFF, 0xFF,
+    0x3D, 0x3E, 0x3F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+};
+
+/*!
+ * @brief Skip non-BinHex text until encoded data is found
+ *
+ * This is called from hqx_open() to find the first valid BinHex line,
+ * and from hqx_7tobin() to find subsequent encoded lines.
+ *
+ * @param[in] line    `FIRST` for the first encoded line, `OTHER` thereafter
+ *
+ * @returns 0 on success, -1 if valid encoded data is not found
+ */
+int skip_junk(int line)
+{
+    int			found = NOWAY;
+    int			stopflag;
+    int			nc = 0;
+    unsigned char		c;
+    unsigned char		prevchar;
+
+    if (line == FIRST && hqx7_fill(hqx7_buf) <= 0) {
+        fprintf(stderr, "Premature end of file :");
+        return -1;
+    }
+
+    while (found == NOWAY) {
+        if (line == FIRST) {
+            if (*hqx7_first == ':') {
+                nc = c = 0;
+                stopflag = NOWAY;
+                hqx7_first++;
+
+                while ((stopflag == NOWAY) &&
+                        (nc < (hqx7_last - hqx7_first))) {
+                    switch (c = hqxlookup[ hqx7_first[ nc ]]) {
+                    case 0xFC :
+                    case 0xFF :
+                    case 0xFE :
+                    case 0xFD :
+                        stopflag = SURETHANG;
+                        break;
+
+                    default :
+                        nc++;
+                        break;
+                    }
+                }
+
+                if ((nc > 30) && (nc < 64) &&
+                        ((c == 0xFE) || (c == 0xFD))) {
+                    found = SURETHANG;
+                }
+            } else {
+                hqx7_first++;
+            }
+        } else {
+            if ((prevchar = hqxlookup[ *hqx7_first ]) == 0xFE) {
+                nc = c = 0;
+                stopflag = NOWAY;
+                hqx7_first++;
+
+                while ((stopflag == NOWAY) &&
+                        (nc < (hqx7_last - hqx7_first))) {
+                    switch (c = hqxlookup[ hqx7_first[ nc ]]) {
+                    case 0xFC :
+                    case 0xFE :
+                        if ((prevchar == 0xFC) || (prevchar == 0xFE)) {
+                            nc++;
+                            break;
+                        }
+
+                    /* fall through */
+                    case 0xFF :
+                    case 0xFD :
+                        stopflag = SURETHANG;
+                        break;
+
+                    default :
+                        prevchar = c;
+                        nc++;
+                        break;
+                    }
+                }
+
+                if (c == 0xFD) {
+                    found = SURETHANG;
+                } else if ((nc > 30) && (c == 0xFE)) {
+                    found = SURETHANG;
+                }
+            } else {
+                hqx7_first++;
+            }
+        }
+
+        if ((hqx7_last - hqx7_first) == nc) {
+            hqx7_buf[0] = (line == FIRST) ? ':' : '\n';
+            memmove(&hqx7_buf[1], hqx7_first, nc);
+            hqx7_first = &hqx7_buf[++nc];
+
+            if (hqx7_fill(hqx7_first) <= 0) {
+                fprintf(stderr, "Premature end of file :");
+                return -1;
+            }
+
+            hqx7_first = hqx7_buf;
+        }
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief Decode BinHex text data to binary
+ *
+ * This is called by hqx_header_read() for header data and by hqx_read()
+ * for fork data and CRC fields. It buffers decoded data so callers get
+ * the requested length unless end of file is reached.
+ *
+ * @param[out] outbuf    destination buffer for decoded bytes
+ * @param[in] datalen    number of decoded bytes requested
+ *
+ * @returns number of decoded bytes written to @p outbuf
+ */
+size_t hqx_7tobin(char *outbuf, size_t datalen)
+{
+    static unsigned char	hqx8[3];
+    static int		hqx8i;
+    static unsigned char	prev_hqx8;
+    static unsigned char	prev_out;
+    static unsigned char	prev_hqx7;
+    static int		eofflag;
+    unsigned char		hqx7[4];
+    int			hqx7i = 0;
+    ssize_t		cc;
+    char		*out_first;
+    const char		*out_last;
+#if DEBUG
+    NAD_DEBUG("hqx_7tobin: datalen entering %d\n", datalen);
+    NAD_DEBUG("hqx_7tobin: hqx8i entering %d\n", hqx8i);
+#endif /* DEBUG */
+
+    if (first_flag == 0) {
+        prev_hqx8 = 0;
+        prev_hqx7 = 0;
+        prev_out = 0;
+        hqx8i = 3;
+        first_flag = 1;
+        eofflag = 0;
+    }
+
+#if DEBUG
+    NAD_DEBUG("hqx_7tobin: hqx8i entering %d\n", hqx8i);
+#endif /* DEBUG */
+    out_first = outbuf;
+    out_last = out_first + datalen;
+
+    while ((out_first < out_last) && (eofflag == 0)) {
+        if (hqx7_first == hqx7_last) {
+            cc = hqx7_fill(hqx7_buf);
+
+            if (cc <= 0) {
+                eofflag = 1;
+                continue;
+            }
+        }
+
+        if (hqx8i > 2) {
+            while ((hqx7i < 4) && (hqx7_first < hqx7_last)) {
+                hqx7[ hqx7i ] = hqxlookup[ *hqx7_first ];
+
+                switch (hqx7[ hqx7i ]) {
+                case 0xFC :
+                    if ((prev_hqx7 == 0xFC) || (prev_hqx7 == 0xFE)) {
+                        hqx7_first++;
+                        break;
+                    }
+
+                /* fall through */
+                case 0xFD :
+                case 0xFF :
+                    eofflag = 1;
+
+                    while (hqx7i < 4) {
+                        hqx7[ hqx7i++ ] = 0;
+                    }
+
+                    break;
+
+                case 0xFE :
+                    prev_hqx7 = hqx7[ hqx7i ];
+
+                    if (skip_junk(OTHER) < 0) {
+                        fprintf(stderr, "\n");
+                        eofflag = 1;
+
+                        while (hqx7i < 4) {
+                            hqx7[ hqx7i++ ] = 0;
+                        }
+                    }
+
+                    break;
+
+                default :
+                    prev_hqx7 = hqx7[ hqx7i++ ];
+                    hqx7_first++;
+                    break;
+                }
+            }
+
+            if (hqx7i == 4) {
+                hqx8[ 0 ] = (unsigned char)((hqx7[ 0 ] << 2) | (hqx7[ 1 ] >> 4));
+                hqx8[ 1 ] = (unsigned char)((hqx7[ 1 ] << 4) | (hqx7[ 2 ] >> 2));
+                hqx8[ 2 ] = (unsigned char)((hqx7[ 2 ] << 6) | (hqx7[ 3 ]));
+                hqx7i = hqx8i = 0;
+            }
+        }
+
+        while ((hqx8i < 3) && (out_first < out_last)) {
+            if (prev_hqx8 == RUNCHAR) {
+                if (hqx8[ hqx8i ] == 0) {
+                    *out_first = prev_hqx8;
+                    prev_out = prev_hqx8;
+                    out_first++;
+                }
+
+                while ((out_first < out_last) && (hqx8[ hqx8i ] > 1)) {
+                    *out_first = prev_out;
+                    hqx8[ hqx8i ]--;
+                    out_first++;
+                }
+
+                if (hqx8[ hqx8i ] < 2) {
+                    prev_hqx8 = hqx8[ hqx8i ];
+                    hqx8i++;
+                }
+
+                continue;
+            }
+
+            prev_hqx8 = hqx8[ hqx8i ];
+
+            if (prev_hqx8 != RUNCHAR) {
+                *out_first = prev_hqx8;
+                prev_out = prev_hqx8;
+                out_first++;
+            }
+
+            hqx8i++;
+        }
+    }
+
+    return (out_first - outbuf);
+}

--- a/bin/nad/hqx.h
+++ b/bin/nad/hqx.h
@@ -1,0 +1,18 @@
+#ifndef _HQX_H
+#define _HQX_H 1
+
+/* Forward Declarations */
+struct FHeader;
+
+int skip_junk(int line);
+int hqx_open(char *hqxfile, int flags, struct FHeader *fh, int options);
+int hqx_close(int keepflag);
+const char *hqx_path(void);
+ssize_t hqx_read(int fork, char *buffer, size_t length);
+ssize_t hqx_write(int fork, char *buffer, size_t length);
+int hqx_header_read(struct FHeader *fh);
+int hqx_header_write(struct FHeader *fh);
+size_t hqx_7tobin(char *outbuf, size_t datalen);
+ssize_t hqx7_fill(unsigned char *hqx7_ptr);
+
+#endif /* _HQX_H */

--- a/bin/nad/macbin.c
+++ b/bin/nad/macbin.c
@@ -1,0 +1,868 @@
+/*
+ * Copyright (c) 1990,1991 Regents of The University of Michigan.
+ * Copyright (c) 2026 Daniel Markstedt <daniel@mindani.net>
+ * All Rights Reserved.  See COPYRIGHT.
+ *
+ * Macintosh file format transformer based on megatron by Charles Clark.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <sys/param.h>
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif /* HAVE_FCNTL_H */
+#include <unistd.h>
+#include <string.h>
+#include <strings.h>
+#include <ctype.h>
+#include <stdio.h>
+
+#include <atalk/adouble.h>
+#include <atalk/util.h>
+#include <netatalk/endian.h>
+#include "nad.h"
+#include "megatron.h"
+#include "macbin.h"
+#include "crc16.h"
+
+/* This allows nad to generate .bin files that won't choke other
+   well-known converter apps. It also makes sure that checksums
+   always match. (RLB) */
+#define MACBINARY_PLAY_NICE_WITH_OTHERS
+
+/*	String used to indicate standard input instead of a disk
+	file.  Should be a string not normally used for a file
+ */
+#ifndef	STDIN
+#	define	STDIN	"-"
+#endif /* STDIN */
+
+/*	Yes and no
+ */
+#define NOWAY		0
+#define SURETHANG	1
+
+/*	Size of a macbinary file header
+ */
+#define HEADBUFSIZ	128
+#define MACBIN_NAMELEN	63
+
+/*	Both input and output routines use this struct and the
+	following globals; therefore this module can only be used
+	for one of the two functions at a time.
+ */
+static struct bin_file_data {
+    uint32_t		forklen[ NUMFORKS ];
+    char		path[ MAXPATHLEN + 1];
+    int			filed;
+    int                 owns_fd;
+    off_t               filepos;
+    unsigned short		headercrc;
+} 		bin;
+
+extern char	*forkname[];
+static unsigned char	head_buf[HEADBUFSIZ];
+
+static uint16_t macbin_u16_from_bytes(unsigned char high, unsigned char low)
+{
+    unsigned int value = ((unsigned int)high << 8) | (unsigned int)low;
+    return (uint16_t)value;
+}
+
+static uint32_t macbin_u32_from_header(const unsigned char *header,
+                                       size_t offset)
+{
+    return ((uint32_t)header[offset] << 24)
+           | ((uint32_t)header[offset + 1] << 16)
+           | ((uint32_t)header[offset + 2] << 8)
+           | (uint32_t)header[offset + 3];
+}
+
+static uint16_t macbin_fdflags_from_header(const unsigned char *header,
+        int revision)
+{
+    unsigned char flags_low = 0;
+
+    if (revision >= 2) {
+        flags_low = header[101];
+#ifdef MACBINARY_PLAY_NICE_WITH_OTHERS
+
+        /* Some compatibility-oriented writers mirror the low byte at 74. */
+        if (flags_low == 0) {
+            flags_low = header[74];
+        }
+
+#endif /* MACBINARY_PLAY_NICE_WITH_OTHERS */
+    }
+
+    return htons(macbin_u16_from_bytes(header[73], flags_low));
+}
+
+static void macbin_fdflags_to_header(unsigned char *header, uint16_t fdflags)
+{
+    uint16_t flags = ntohs(fdflags);
+    header[73] = (unsigned char)(flags >> 8);
+#ifdef MACBINARY_PLAY_NICE_WITH_OTHERS
+    header[74] = (unsigned char)(flags & 0xff);
+#endif /* MACBINARY_PLAY_NICE_WITH_OTHERS */
+    header[101] = (unsigned char)(flags & 0xff);
+}
+
+static int macbin_ad_date_from_header(uint32_t mac_date, uint32_t *ad_date)
+{
+    *ad_date = AD_DATE_FROM_MAC(mac_date);
+    return set_utc_offset(ad_date, TO_UTC);
+}
+
+static int macbin_ad_date_to_header(uint32_t ad_date, uint32_t *mac_date)
+{
+    if (set_utc_offset(&ad_date, TO_LOCALTIME) != 0) {
+        return -1;
+    }
+
+    *mac_date = AD_DATE_TO_MAC(ad_date);
+    return 0;
+}
+
+static int macbin_discard_bytes(size_t length)
+{
+    unsigned char discard[HEADBUFSIZ];
+
+    while (length > 0) {
+        size_t readlen = length < sizeof(discard) ? length : sizeof(discard);
+        ssize_t cc = read(bin.filed, discard, readlen);
+
+        if (cc < 0) {
+            perror("Couldn't skip MacBinary padding:");
+            return -1;
+        }
+
+        if (cc == 0) {
+            fprintf(stderr,
+                    "Premature end of file while skipping MacBinary padding.\n");
+            return -1;
+        }
+
+        length -= (size_t)cc;
+        bin.filepos += cc;
+    }
+
+    return 0;
+}
+
+static int macbin_write_repeat(unsigned char value, size_t length)
+{
+    unsigned char buffer[HEADBUFSIZ];
+    memset(buffer, value, sizeof(buffer));
+
+    while (length > 0) {
+        size_t writelen = length < sizeof(buffer) ? length : sizeof(buffer);
+        ssize_t cc = write(bin.filed, buffer, writelen);
+
+        if (cc < 0) {
+            perror("Couldn't write to macbinary file:");
+            return -1;
+        }
+
+        if (cc == 0) {
+            fprintf(stderr, "Couldn't write to macbinary file: short write\n");
+            return -1;
+        }
+
+        length -= (size_t)cc;
+        bin.filepos += cc;
+    }
+
+    return 0;
+}
+
+static int macbin_skip_padding(void)
+{
+    off_t pos = lseek(bin.filed, 0, SEEK_CUR);
+    int seekable = 0;
+    size_t padding;
+
+    if (pos >= 0) {
+        seekable = 1;
+        bin.filepos = pos;
+    } else {
+        pos = bin.filepos;
+    }
+
+#if DEBUG
+    NAD_DEBUG("current position is %ld\n", pos);
+#endif /* DEBUG */
+    pos %= HEADBUFSIZ;
+
+    if (pos == 0) {
+        return 0;
+    }
+
+    padding = (size_t)(HEADBUFSIZ - pos);
+
+    if (seekable) {
+        pos = lseek(bin.filed, padding, SEEK_CUR);
+
+        if (pos >= 0) {
+            bin.filepos = pos;
+#if DEBUG
+            NAD_DEBUG("current position is %ld\n", pos);
+#endif /* DEBUG */
+            return 0;
+        }
+    }
+
+    if (macbin_discard_bytes(padding) < 0) {
+        return -1;
+    }
+
+#if DEBUG
+    NAD_DEBUG("current position is %ld\n", bin.filepos);
+#endif /* DEBUG */
+    return 0;
+}
+
+static int macbin_write_padding(void)
+{
+    unsigned char padchar = 0x7f;
+    /* Not sure why, but it seems this must be 0x7f to match
+       other converters, not 0. (RLB) */
+    off_t pos = lseek(bin.filed, 0, SEEK_CUR);
+    size_t padding;
+
+    if (pos >= 0) {
+        bin.filepos = pos;
+    } else {
+        pos = bin.filepos;
+    }
+
+#if DEBUG
+    NAD_DEBUG("current position is %ld\n", pos);
+#endif /* DEBUG */
+    pos %= HEADBUFSIZ;
+
+    if (pos == 0) {
+        return 0;
+    }
+
+    padding = (size_t)(HEADBUFSIZ - pos);
+
+    if (macbin_write_repeat(padchar, padding) < 0) {
+        return -1;
+    }
+
+#if DEBUG
+    NAD_DEBUG("current position is %ld\n", bin.filepos);
+#endif /* DEBUG */
+    return 0;
+}
+
+/*!
+ * @brief Open a MacBinary file for reading or writing
+ *
+ * This must be called before other MacBinary operations. When opening
+ * for reading, it validates and reads the MacBinary header. When opening
+ * for writing, it initializes output state and writes the header.
+ *
+ * @param[in] binfile    input file path, or `-` for standard input
+ * @param[in] flags      open flags; `O_RDONLY` selects read mode
+ * @param[in,out] fh     file header to read or write
+ * @param[in] options    output options, such as `OPTION_STDOUT`
+ *
+ * @returns 0 on success, -1 on error
+ */
+int bin_open(char *binfile, int flags, struct FHeader *fh, int options)
+{
+    int			rc;
+#if DEBUG
+    NAD_DEBUG("entering bin_open\n");
+#endif /* DEBUG */
+    bin.filed = -1;
+    bin.owns_fd = 0;
+
+    if (flags == O_RDONLY) {   /* input */
+        bin.filepos = 0;
+
+        if (strcmp(binfile, STDIN) == 0) {
+            bin.filed = fileno(stdin);
+        } else if ((bin.filed = open(binfile, flags)) < 0) {
+            perror(binfile);
+            return -1;
+        } else {
+            bin.owns_fd = 1;
+        }
+
+#if DEBUG
+        NAD_DEBUG("opened %s for read\n", binfile);
+#endif /* DEBUG */
+
+        if (((rc = test_header()) > 0) &&
+                (bin_header_read(fh, rc) == 0)) {
+            return 0;
+        }
+
+        fprintf(stderr, "%s is not a macbinary file.\n", binfile);
+
+        if (bin.owns_fd && bin.filed >= 0) {
+            close(bin.filed);
+        }
+
+        bin.filed = -1;
+        bin.owns_fd = 0;
+        return -1;
+    } else { /* output */
+        bin.filepos = 0;
+
+        if (options & OPTION_STDOUT) {
+            bin.filed = fileno(stdout);
+            strlcpy(bin.path, STDIN, sizeof(bin.path));
+        } else {
+#if DEBUG
+            NAD_DEBUG("sizeof bin.path\t\t\t%d\n", sizeof(bin.path));
+#endif /* DEBUG */
+
+            if (strlcpy(bin.path, fh->name, sizeof(bin.path)) >= sizeof(bin.path)
+                    || strlcpy(bin.path, mtoupath(bin.path), sizeof(bin.path))
+                    >= sizeof(bin.path)
+                    || strlcat(bin.path, ".bin", sizeof(bin.path))
+                    >= sizeof(bin.path)) {
+                fprintf(stderr, "Output path is too long: %s.bin\n", fh->name);
+                return -1;
+            }
+
+            if ((bin.filed = open(bin.path, flags, 0666)) < 0) {
+                perror(bin.path);
+                return -1;
+            }
+
+            bin.owns_fd = 1;
+#if DEBUG
+            NAD_DEBUG("opened %s for write\n",
+                      (options & OPTION_STDOUT) ? "(stdout)" : bin.path);
+#endif /* DEBUG */
+        }
+
+        if (bin_header_write(fh) != 0) {
+            bin_close(TRASH);
+            fprintf(stderr, "%s\n", bin.path);
+            return -1;
+        }
+
+        return 0;
+    }
+}
+
+/*!
+ * @brief Close the active MacBinary file
+ *
+ * This must be called before opening another file with bin_open().
+ * `KEEP` closes the file and preserves it. `TRASH` closes the file and
+ * removes incomplete output.
+ *
+ * @param[in] keepflag    `KEEP` to keep the output, `TRASH` to discard it
+ *
+ * @returns 0 on success, -1 on error
+ */
+int bin_close(int keepflag)
+{
+#if DEBUG
+    NAD_DEBUG("entering bin_close\n");
+#endif /* DEBUG */
+
+    if (keepflag == KEEP) {
+        if (bin.owns_fd && bin.filed >= 0) {
+            int rc = close(bin.filed);
+            bin.filed = -1;
+            bin.owns_fd = 0;
+            return rc;
+        }
+
+        bin.filed = -1;
+        return 0;
+    } else if (keepflag == TRASH) {
+        if (bin.owns_fd && bin.filed >= 0) {
+            close(bin.filed);
+        }
+
+        bin.filed = -1;
+        bin.owns_fd = 0;
+
+        if ((strcmp(bin.path, STDIN) != 0) &&
+                (unlink(bin.path) < 0)) {
+            perror(bin.path);
+        }
+
+        return 0;
+    } else {
+        return -1;
+    }
+}
+
+const char *bin_path(void)
+{
+    return bin.path;
+}
+
+/*!
+ * @brief Read data from a MacBinary fork
+ *
+ * Call this until it returns zero for each fork. When the data fork is
+ * complete, it skips MacBinary padding before the resource fork begins.
+ *
+ * @note bin_read() must be called enough times to return zero, and no
+ * more than that, for each fork.
+ *
+ * @param[in] fork       fork selector, `DATA` or `RESOURCE`
+ * @param[out] buffer    destination buffer
+ * @param[in] length     maximum number of bytes to read
+ *
+ * @returns number of bytes read, 0 when the fork is complete, -1 on error
+ */
+ssize_t bin_read(int fork, char *buffer, size_t length)
+{
+    char		*buf_ptr;
+    size_t		readlen;
+    ssize_t		cc = 1;
+#if DEBUG >= 3
+    NAD_DEBUG("bin_read: fork is %s\n", forkname[ fork ]);
+    NAD_DEBUG("bin_read: remaining length is %d\n", bin.forklen[fork]);
+#endif /* DEBUG >= 3 */
+
+    if (bin.forklen[fork] > 0x7FFFFFFF) {
+        fprintf(stderr, "Invalid %s fork length: %u\n",
+                forkname[fork],
+                bin.forklen[fork]);
+        return -1;
+    }
+
+    if (bin.forklen[ fork ] == 0) {
+        if (fork == DATA && macbin_skip_padding() < 0) {
+            return -1;
+        }
+
+        return 0;
+    }
+
+    if (bin.forklen[ fork ] < length) {
+        readlen = bin.forklen[ fork ];
+    } else {
+        readlen = length;
+    }
+
+#if DEBUG >= 3
+    NAD_DEBUG("bin_read: readlen is %d\n", readlen);
+    NAD_DEBUG("bin_read: cc is %d\n", cc);
+#endif /* DEBUG >= 3 */
+    buf_ptr = buffer;
+
+    while ((readlen > 0) && (cc > 0)) {
+        if ((cc = read(bin.filed, buf_ptr, readlen)) > 0) {
+#if DEBUG >= 3
+            NAD_DEBUG("bin_read: cc is %d\n", cc);
+#endif /* DEBUG >= 3 */
+            readlen -= cc;
+            buf_ptr += cc;
+            bin.filepos += cc;
+        }
+    }
+
+    if (cc >= 0) {
+        cc = buf_ptr - buffer;
+        bin.forklen[ fork ] -= cc;
+    }
+
+#if DEBUG >= 3
+    NAD_DEBUG("bin_read: chars read is %d\n", cc);
+#endif /* DEBUG >= 3 */
+    return cc;
+}
+
+/*!
+ * @brief Write data to a MacBinary fork
+ *
+ * Data must be written in fork order. The resource fork cannot be
+ * written until the data fork is complete. Padding is written when each
+ * fork is finished.
+ *
+ * @param[in] fork       fork selector, `DATA` or `RESOURCE`
+ * @param[in] buffer     source buffer
+ * @param[in] length     number of bytes to write
+ *
+ * @returns number of bytes written, -1 on error
+ */
+ssize_t bin_write(int fork, char *buffer, size_t length)
+{
+    const char		*buf_ptr;
+    ssize_t		writelen;
+    ssize_t		cc = 0;
+#if DEBUG >= 3
+    NAD_DEBUG("bin_write: fork is %s\n", forkname[ fork ]);
+    NAD_DEBUG("bin_write: remaining length is %d\n", bin.forklen[fork]);
+#endif /* DEBUG >= 3 */
+
+    if ((fork == RESOURCE) && (bin.forklen[ DATA ] != 0)) {
+        fprintf(stderr, "Forklength error.\n");
+        return -1;
+    }
+
+    buf_ptr = buffer;
+
+    if (bin.forklen[ fork ] >= length) {
+        writelen = length;
+    } else {
+        fprintf(stderr, "Forklength error.\n");
+        return -1;
+    }
+
+#if DEBUG >= 3
+    NAD_DEBUG("bin_write: write length is %d\n", writelen);
+#endif /* DEBUG >= 3 */
+
+    while (writelen > 0) {
+        cc = write(bin.filed, buf_ptr, writelen);
+
+        if (cc <= 0) {
+            break;
+        }
+
+        buf_ptr += cc;
+        writelen -= cc;
+        bin.filepos += cc;
+    }
+
+    if (writelen > 0) {
+        if (cc < 0) {
+            perror("Couldn't write to macbinary file:");
+            return cc;
+        }
+
+        fprintf(stderr, "Couldn't write to macbinary file: short write\n");
+        return -1;
+    }
+
+    bin.forklen[fork] -= length;
+
+    /*
+     * add the padding at end of data and resource forks
+     */
+
+    if (bin.forklen[ fork ] == 0 && macbin_write_padding() < 0) {
+        return -1;
+    }
+
+#if DEBUG
+    NAD_DEBUG("\n");
+#endif /* DEBUG */
+    return length;
+}
+
+/*!
+ * @brief Read a MacBinary header into a file header
+ *
+ * This is called by bin_open() before any fork data is read. It validates
+ * the MacBinary revision, decodes header fields, and initializes fork
+ * lengths.
+ *
+ * @param[out] fh         file header to populate
+ * @param[in] revision    MacBinary revision returned by test_header()
+ *
+ * @returns 0 on success, -1 on error
+ */
+int bin_header_read(struct FHeader *fh, int revision)
+{
+    /*
+     * Check the MacBinary revision before reading fields from the header.
+     * If it is not a macbinary file revision of I, II, or III, then return
+     * negative.
+     */
+    switch (revision) {
+    case 3:
+    case 2:
+    case 1:
+        break;
+
+    default:
+        return -1;
+    }
+
+    /*
+     * Go through and copy all the stuff you can get from the
+     * MacBinary header into the fh struct.  What fun!
+     */
+    if (head_buf[1] >= sizeof(fh->name)) {
+        return -1;
+    }
+
+    memcpy(fh->name, head_buf +  2, head_buf[ 1 ]);
+    fh->name[head_buf[1]] = '\0';
+    memcpy(&fh->create_date, head_buf +  91, 4);
+
+    if (macbin_ad_date_from_header(fh->create_date, &fh->create_date) != 0) {
+        return -1;
+    }
+
+    memcpy(&fh->mod_date, head_buf +  95, 4);
+
+    if (macbin_ad_date_from_header(fh->mod_date, &fh->mod_date) != 0) {
+        return -1;
+    }
+
+    fh->backup_date = AD_DATE_START;
+    fh->date_flags = FH_DATE_CREATE | FH_DATE_MODIFY;
+    memcpy(&fh->finder_info, head_buf +  65, 8);
+    fh->finder_info.fdFlags = macbin_fdflags_from_header(head_buf, revision);
+    memcpy(&fh->finder_info.fdLocation, head_buf + 75, 4);
+    memcpy(&fh->finder_info.fdFldr, head_buf +  79, 2);
+    memcpy(&fh->forklen[ DATA ],  head_buf + 83, 4);
+    bin.forklen[ DATA ] = ntohl(fh->forklen[ DATA ]);
+    memcpy(&fh->forklen[ RESOURCE ],  head_buf +  87, 4);
+    bin.forklen[ RESOURCE ] = ntohl(fh->forklen[ RESOURCE ]);
+    fh->comment[0] = '\0';
+
+    if (revision == 3) {
+        fh->finder_xinfo.fdScript = *(head_buf + 106);
+        fh->finder_xinfo.fdXFlags = *(head_buf + 107);
+    }
+
+#if DEBUG >= 5
+    {
+        short		flags;
+        long		flags_long;
+        NAD_DEBUG("Values read by bin_header_read\n");
+        NAD_DEBUG("name length\t\t%d\n", head_buf[ 1 ]);
+        NAD_DEBUG("file name\t\t%s\n", fh->name);
+        NAD_DEBUG("get info comment\t%s\n", fh->comment);
+        NAD_DEBUG("type\t\t\t%.*s\n", sizeof(fh->finder_info.fdType),
+                  &fh->finder_info.fdType);
+        NAD_DEBUG("creator\t\t\t%.*s\n",
+                  sizeof(fh->finder_info.fdCreator),
+                  &fh->finder_info.fdCreator);
+        memcpy(&flags, &fh->finder_info.fdFlags, sizeof(flags));
+        flags = ntohs(flags);
+        NAD_DEBUG("flags\t\t\t%x\n", flags);
+        /* Show fdLocation too (RLB) */
+        memcpy(&flags_long, &fh->finder_info.fdLocation,
+               sizeof(flags_long));
+        flags_long = ntohl(flags_long);
+        NAD_DEBUG("location flags\t\t%lx\n", flags_long);
+        NAD_DEBUG("data fork length\t%ld\n", bin.forklen[DATA]);
+        NAD_DEBUG("resource fork length\t%ld\n", bin.forklen[RESOURCE]);
+        NAD_DEBUG("\n");
+    }
+#endif /* DEBUG >= 5 */
+    return 0;
+}
+
+/*!
+ * @brief Write a file header as a MacBinary header
+ *
+ * This is called by bin_open() before any fork data is written. It
+ * encodes the file header as a MacBinary III header and initializes fork
+ * lengths.
+ *
+ * @param[in] fh    file header to write
+ *
+ * @returns 0 on success, -1 on error
+ */
+int bin_header_write(struct FHeader *fh)
+{
+    const char		*write_ptr;
+    uint32_t           t;
+    size_t             namelen;
+    size_t             wc;
+    ssize_t		wr;
+    memset(head_buf, 0, sizeof(head_buf));
+    namelen = strnlen(fh->name, sizeof(fh->name));
+
+    if (namelen > MACBIN_NAMELEN) {
+        fprintf(stderr, "MacBinary filename is too long: %s\n", fh->name);
+        return -1;
+    }
+
+    head_buf[ 1 ] = (unsigned char)namelen;
+    memcpy(head_buf + 2, fh->name, head_buf[ 1 ]);
+    memcpy(head_buf + 65, &fh->finder_info, 8);
+    macbin_fdflags_to_header(head_buf, fh->finder_info.fdFlags);
+    memcpy(head_buf + 75, &fh->finder_info.fdLocation, 4);
+    memcpy(head_buf + 79, &fh->finder_info.fdFldr, 2);
+    memcpy(head_buf + 83, &fh->forklen[ DATA ], 4);
+    memcpy(head_buf + 87, &fh->forklen[ RESOURCE ], 4);
+
+    if (macbin_ad_date_to_header(fh->create_date, &t) != 0) {
+        return -1;
+    }
+
+    memcpy(head_buf + 91, &t, sizeof(t));
+
+    if (macbin_ad_date_to_header(fh->mod_date, &t) != 0) {
+        return -1;
+    }
+
+    memcpy(head_buf + 95, &t, sizeof(t));
+    /* macbinary III */
+    memcpy(head_buf + 102, "mBIN", 4);
+    *(head_buf + 106) = fh->finder_xinfo.fdScript;
+    *(head_buf + 107) = fh->finder_xinfo.fdXFlags;
+    head_buf[ 122 ] = 130;
+    head_buf[ 123 ] = 129;
+    bin.headercrc = htons(crc16_xmodem_update(0, head_buf, 124));
+    memcpy(head_buf + 124, &bin.headercrc, sizeof(bin.headercrc));
+    bin.forklen[ DATA ] = ntohl(fh->forklen[ DATA ]);
+    bin.forklen[ RESOURCE ] = ntohl(fh->forklen[ RESOURCE ]);
+#if DEBUG >= 5
+    {
+        short	flags;
+        long	flags_long;
+        NAD_DEBUG("Values written by bin_header_write\n");
+        NAD_DEBUG("name length\t\t%d\n", head_buf[ 1 ]);
+        NAD_DEBUG("file name\t\t%s\n", (char *)&head_buf[ 2 ]);
+        NAD_DEBUG("type\t\t\t%.4s\n", (char *)&head_buf[ 65 ]);
+        NAD_DEBUG("creator\t\t\t%.4s\n", (char *)&head_buf[ 69 ]);
+        memcpy(&flags, &fh->finder_info.fdFlags, sizeof(flags));
+        flags = ntohs(flags);
+        NAD_DEBUG("flags\t\t\t%x\n", flags);
+        /* Show fdLocation too (RLB) */
+        memcpy(&flags_long, &fh->finder_info.fdLocation,
+               sizeof(flags_long));
+        flags_long = ntohl(flags_long);
+        NAD_DEBUG("location flags\t\t%ldx\n", flags_long);
+        NAD_DEBUG("data fork length\t%ld\n", bin.forklen[DATA]);
+        NAD_DEBUG("resource fork length\t%ld\n", bin.forklen[RESOURCE]);
+        NAD_DEBUG("\n");
+    }
+#endif /* DEBUG >= 5 */
+    write_ptr = (char *)head_buf;
+    wc = sizeof(head_buf);
+    wr = 0;
+
+    while (wc > 0) {
+        wr = write(bin.filed, write_ptr, wc);
+
+        if (wr <= 0) {
+            break;
+        }
+
+        write_ptr += (size_t)wr;
+        wc -= (size_t)wr;
+        bin.filepos += wr;
+    }
+
+    if (wr < 0) {
+        perror("Couldn't write macbinary header:");
+        return -1;
+    }
+
+    if (wc > 0) {
+        fprintf(stderr, "Couldn't write complete macbinary header.\n");
+        return -1;
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief Test the input header for a supported MacBinary revision
+ *
+ * Reads the first 128 bytes and determines whether the file is
+ * MacBinary, MacBinary II, MacBinary III, or not a MacBinary file.
+ *
+ * @note Apple's MacBinary II files can have a non-zero value at byte 74,
+ * so the byte 74 check is not very useful.
+ *
+ * @returns 1 for MacBinary, 2 for MacBinary II, 3 for MacBinary III,
+ * -1 if the header is invalid
+ */
+int test_header(void)
+{
+    const char          zeros[25] = "";
+    ssize_t		cc;
+    uint32_t            forklen;
+    unsigned short		header_crc;
+    unsigned char		namelen;
+#if DEBUG
+    NAD_DEBUG("entering test_header\n");
+#endif /* DEBUG */
+    cc = read(bin.filed, (char *)head_buf, sizeof(head_buf));
+
+    if (cc < 0) {
+        perror("Couldn't read MacBinary header:");
+        return -1;
+    }
+
+    if ((size_t)cc < sizeof(head_buf)) {
+        fprintf(stderr,
+                "Premature end of file while reading MacBinary header.\n");
+        return -1;
+    }
+
+    bin.filepos = cc;
+#if DEBUG
+    NAD_DEBUG("was able to read HEADBUFSIZ bytes\n");
+#endif /* DEBUG */
+
+    /* check for macbinary III header */
+    if (memcmp(head_buf + 102, "mBIN", 4) == 0) {
+        return 3;
+    }
+
+    /* check for macbinary II even if only one of the bytes is zero */
+    if ((head_buf[ 0 ] == 0) || (head_buf[ 74 ] == 0)) {
+#if DEBUG
+        NAD_DEBUG("byte 0 and 74 are both zero\n");
+#endif /* DEBUG */
+        bin.headercrc = crc16_xmodem_update(0, head_buf, 124);
+        memcpy(&header_crc, head_buf + 124, sizeof(header_crc));
+        header_crc = ntohs(header_crc);
+
+        if (header_crc == bin.headercrc) {
+            return 2;
+        }
+
+#if DEBUG
+        NAD_DEBUG("header crc didn't pan out\n");
+#endif /* DEBUG */
+    }
+
+    /* now see if we have a macbinary file. */
+    if (head_buf[ 82 ] != 0) {
+        return -1;
+    }
+
+    memcpy(&namelen, head_buf + 1, sizeof(namelen));
+#if DEBUG
+    NAD_DEBUG("name length is %d\n", namelen);
+#endif /* DEBUG */
+
+    if ((namelen < 1) || (namelen > MACBIN_NAMELEN)) {
+        return -1;
+    }
+
+    /* bytes 101 - 125 should be zero */
+    if (memcmp(head_buf + 101, zeros, sizeof(zeros)) != 0) {
+        return -1;
+    }
+
+    /* macbinary forks aren't larger than 0x7FFFFF */
+    /* we allow forks to be larger, breaking the specs */
+    forklen = macbin_u32_from_header(head_buf, 83);
+
+    if (forklen > 0x7FFFFFFFU) {
+        return -1;
+    }
+
+    forklen = macbin_u32_from_header(head_buf, 87);
+
+    if (forklen > 0x7FFFFFFFU) {
+        return -1;
+    }
+
+#if DEBUG
+    NAD_DEBUG("byte 82 is zero and name length is valid\n");
+#endif /* DEBUG */
+    return 1;
+}

--- a/bin/nad/macbin.h
+++ b/bin/nad/macbin.h
@@ -1,0 +1,16 @@
+#ifndef _MACBIN_H
+#define _MACBIN_H 1
+
+/* Forward Declarations */
+struct FHeader;
+
+int bin_open(char *binfile, int flags, struct FHeader *fh, int options);
+int bin_close(int keepflag);
+const char *bin_path(void);
+ssize_t bin_read(int fork, char *buffer, size_t length);
+ssize_t bin_write(int fork, char *buffer, size_t length);
+int bin_header_read(struct FHeader *fh, int revision);
+int bin_header_write(struct FHeader *fh);
+int test_header(void);
+
+#endif /* _MACBIN_H */

--- a/bin/nad/megatron.c
+++ b/bin/nad/megatron.c
@@ -1,0 +1,754 @@
+/*
+ * Copyright (c) 1990,1991 Regents of The University of Michigan.
+ * Copyright (c) 2026 Daniel Markstedt <daniel@mindani.net>
+ * All Rights Reserved.  See COPYRIGHT.
+ *
+ * Macintosh file format transformer based on megatron by Charles Clark.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pwd.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <atalk/adouble.h>
+#include <atalk/cnid.h>
+#include <atalk/netatalk_conf.h>
+#include <atalk/util.h>
+#include <atalk/volume.h>
+#include <netatalk/endian.h>
+
+#include "nad.h"
+#include "hqx.h"
+#include "macbin.h"
+#include "megatron.h"
+#include "nad_adouble.h"
+
+char *forkname[] = { "data", "resource" };
+static char forkbuf[8192];
+
+struct archive_mode {
+    const char *name;
+    int module;
+};
+
+static const struct archive_mode archive_modes[] = {
+    { "unhex", HEX2NAD },
+    { "unbin", BIN2NAD },
+    { "bin", NAD2BIN },
+    { "hex", NAD2HEX },
+};
+
+static void usage_archive(FILE *out)
+{
+    fprintf(out,
+            "Usage: nad [-F configfile] [--force] bin|hex|unbin|unhex [OPTIONS] [FILE...]\n");
+    fprintf(out, "\nCommands:\n");
+    fprintf(out, "  bin       Encode file to MacBinary (.bin)\n");
+    fprintf(out, "  hex       Encode file to BinHex (.hqx)\n");
+    fprintf(out, "  unbin     Decode MacBinary (.bin) file\n");
+    fprintf(out, "  unhex     Decode BinHex (.hqx) file\n");
+    fprintf(out, "\nOptions:\n");
+    fprintf(out,
+            "  --header         print input header information only, no conversion\n");
+    fprintf(out, "  --filename NAME  use NAME in the converted file header\n");
+    fprintf(out,
+            "  --stdout         write generated archive data to standard output\n");
+    fprintf(out,
+            "  --adouble        write AppleDouble sidecar metadata outside AFP volumes (default: EA)\n");
+    fprintf(out, "  --verbose        print diagnostic conversion details\n");
+    fprintf(out, "  -h, --help       show this help\n");
+}
+
+static int parse_archive_mode(const char *name)
+{
+    for (size_t i = 0; i < sizeof(archive_modes) / sizeof(archive_modes[0]); i++) {
+        if (strcmp(archive_modes[i].name, name) == 0) {
+            return archive_modes[i].module;
+        }
+    }
+
+    return -1;
+}
+
+static int mode_writes_metadata(int module)
+{
+    return module == HEX2NAD || module == BIN2NAD;
+}
+
+static int mode_reads_metadata(int module)
+{
+    return module == NAD2BIN || module == NAD2HEX;
+}
+
+static int mode_creates_volume_file(int module, int flags)
+{
+    if (flags & OPTION_HEADERONLY) {
+        return 0;
+    }
+
+    if (mode_writes_metadata(module)) {
+        return 1;
+    }
+
+    return mode_reads_metadata(module) && !(flags & OPTION_STDOUT);
+}
+
+static int from_open(int un, char *file, struct FHeader *fh, int flags)
+{
+    switch (un) {
+    case HEX2NAD:
+        return hqx_open(file, O_RDONLY, fh, flags);
+
+    case BIN2NAD:
+        return bin_open(file, O_RDONLY, fh, flags);
+
+    case NAD2BIN:
+    case NAD2HEX:
+        return nad_open(file, O_RDONLY, fh, flags);
+
+    default:
+        return -1;
+    }
+}
+
+static ssize_t from_read(int un, int fork, char *buf, size_t len)
+{
+    switch (un) {
+    case HEX2NAD:
+        return hqx_read(fork, buf, len);
+
+    case BIN2NAD:
+        return bin_read(fork, buf, len);
+
+    case NAD2BIN:
+    case NAD2HEX:
+        return nad_read(fork, buf, len);
+
+    default:
+        return -1;
+    }
+}
+
+static int from_close(int un)
+{
+    switch (un) {
+    case HEX2NAD:
+        return hqx_close(KEEP);
+
+    case BIN2NAD:
+        return bin_close(KEEP);
+
+    case NAD2BIN:
+    case NAD2HEX:
+        return nad_close(KEEP);
+
+    default:
+        return -1;
+    }
+}
+
+static int to_open(int to, char *file, struct FHeader *fh, int flags)
+{
+    switch (to) {
+    case HEX2NAD:
+    case BIN2NAD:
+        return nad_open(file, O_RDWR | O_CREAT | O_EXCL, fh, flags);
+
+    case NAD2BIN:
+        return bin_open(file, O_RDWR | O_CREAT | O_EXCL, fh, flags);
+
+    case NAD2HEX:
+        return hqx_open(file, O_RDWR | O_CREAT | O_EXCL, fh, flags);
+
+    default:
+        return -1;
+    }
+}
+
+static ssize_t to_write(int to, int fork, size_t bufc)
+{
+    switch (to) {
+    case HEX2NAD:
+    case BIN2NAD:
+        return nad_write(fork, forkbuf, bufc);
+
+    case NAD2BIN:
+        return bin_write(fork, forkbuf, bufc);
+
+    case NAD2HEX:
+        return hqx_write(fork, forkbuf, bufc);
+
+    default:
+        return -1;
+    }
+}
+
+static int to_close(int to, int keepflag)
+{
+    switch (to) {
+    case HEX2NAD:
+    case BIN2NAD:
+        return nad_close(keepflag);
+
+    case NAD2BIN:
+        return bin_close(keepflag);
+
+    case NAD2HEX:
+        return hqx_close(keepflag);
+
+    default:
+        return -1;
+    }
+}
+
+static const char *created_file_path(int module)
+{
+    switch (module) {
+    case NAD2BIN:
+        return bin_path();
+
+    case NAD2HEX:
+        return hqx_path();
+
+    default:
+        return NULL;
+    }
+}
+
+static int update_created_file_cnid(const struct nad_volume *volume,
+                                    const char *path)
+{
+    struct adouble ad;
+    struct stat st;
+    struct vol *vol;
+    cnid_t cnid;
+    cnid_t did;
+    int opened = 0;
+    int rv = -1;
+
+    if (path == NULL || strcmp(path, STDIN) == 0) {
+        return 0;
+    }
+
+    if (volume == NULL || volume->fallback || volume->skip_cnid
+            || volume->cnid_vol == NULL) {
+        return 0;
+    }
+
+    if (volume->cnid_vol->v_cdb == NULL) {
+        fprintf(stderr, "No CNID database selected for %s\n", path);
+        errno = EINVAL;
+        return -1;
+    }
+
+    vol = volume->cnid_vol;
+
+    if (lstat(path, &st) != 0) {
+        perror(path);
+        return -1;
+    }
+
+    cnid = cnid_for_path(vol->v_cdb, vol->v_path, path, &did);
+
+    if (cnid == CNID_INVALID) {
+        fprintf(stderr, "Error resolving CNID for %s\n", path);
+        errno = EIO;
+        return -1;
+    }
+
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, path, ADFLAGS_HF | ADFLAGS_RDWR | ADFLAGS_CREATE,
+                0666) != 0) {
+        fprintf(stderr, "Error opening metadata for %s\n", path);
+        return -1;
+    }
+
+    opened = 1;
+
+    if (ad_setid(&ad, st.st_dev, st.st_ino, cnid, did,
+                 volume->db_stamp) <= 0) {
+        fprintf(stderr, "Error storing CNID metadata for %s\n", path);
+        errno = EIO;
+        goto done;
+    }
+
+    if (ad_flush(&ad) < 0) {
+        fprintf(stderr, "Error flushing CNID metadata for %s\n", path);
+        goto done;
+    }
+
+    rv = 0;
+done:
+
+    if (opened && ad_close(&ad, ADFLAGS_HF) < 0) {
+        return -1;
+    }
+
+    return rv;
+}
+
+static void print_header_date(const char *label, uint32_t ad_date,
+                              int available)
+{
+    time_t t;
+    struct tm tm;
+    char buf[32];
+
+    if (!available) {
+        printf("%-20s%s\n", label, "(not available)");
+        return;
+    }
+
+    if (ad_date == AD_DATE_START) {
+        printf("%-20s%s\n", label, "(not set)");
+        return;
+    }
+
+    t = AD_DATE_TO_UNIX(ad_date);
+
+    if (localtime_r(&t, &tm) == NULL ||
+            strftime(buf, sizeof(buf), "%a %b %e %H:%M:%S %Y", &tm) == 0) {
+        printf("%-20s%s\n", label, "(invalid)");
+        return;
+    }
+
+    printf("%-20s%s\n", label, buf);
+}
+
+static void print_header(const struct FHeader *fh)
+{
+    char buf[5] = "";
+    printf("name:               %s\n", fh->name);
+    printf("comment:            %s\n", fh->comment);
+    memcpy(&buf, &fh->finder_info.fdCreator, sizeof(uint32_t));
+    printf("creator:            '%4s'\n", buf);
+    memcpy(&buf, &fh->finder_info.fdType, sizeof(uint32_t));
+    printf("type:               '%4s'\n", buf);
+
+    for (int i = 0; i < NUMFORKS; ++i) {
+        printf("fork length[%d]:     %u\n", i, ntohl(fh->forklen[i]));
+    }
+
+    print_header_date("creation date:", fh->create_date,
+                      fh->date_flags & FH_DATE_CREATE);
+    print_header_date("modification date:", fh->mod_date,
+                      fh->date_flags & FH_DATE_MODIFY);
+    print_header_date("backup date:", fh->backup_date,
+                      fh->date_flags & FH_DATE_BACKUP);
+}
+
+static int nad_archive_convert(char *path, int module, const char *newname,
+                               int flags, const struct nad_volume *volume)
+{
+    struct stat st;
+    struct FHeader fh;
+    ssize_t bufc;
+    size_t forkred;
+
+    if (strcmp(path, STDIN) != 0) {
+        if (stat(path, &st) < 0) {
+            perror(path);
+            return -1;
+        }
+
+        if (S_ISDIR(st.st_mode)) {
+            fprintf(stderr, "%s is a directory.\n", path);
+            return 0;
+        }
+    }
+
+    nad_set_volume(volume);
+    memset(&fh, 0, sizeof(fh));
+
+    if (from_open(module, path, &fh, flags) < 0) {
+        return -1;
+    }
+
+    if (flags & OPTION_HEADERONLY) {
+        print_header(&fh);
+        return from_close(module);
+    }
+
+    if (*newname && strlcpy(fh.name, newname, sizeof(fh.name)) >= sizeof(fh.name)) {
+        fprintf(stderr, "Filename is too long: %s\n", newname);
+        (void)from_close(module);
+        return -1;
+    }
+
+    if (to_open(module, path, &fh, flags) < 0) {
+        (void)from_close(module);
+        return -1;
+    }
+
+    for (int fork = 0; fork < NUMFORKS; fork++) {
+        forkred = 0;
+
+        while ((bufc = from_read(module, fork, forkbuf, sizeof(forkbuf))) > 0) {
+            if (to_write(module, fork, bufc) != bufc) {
+                fprintf(stderr, "%s: probable write error\n", path);
+                to_close(module, TRASH);
+                (void)from_close(module);
+                return -1;
+            }
+
+            forkred += bufc;
+        }
+
+        if ((bufc < 0) || (forkred != ntohl(fh.forklen[fork]))) {
+            fprintf(stderr, "%s: input fork length mismatch\n", path);
+            to_close(module, TRASH);
+            (void)from_close(module);
+            return -1;
+        }
+    }
+
+    if (to_close(module, KEEP) < 0) {
+        perror("nad");
+
+        if (!mode_writes_metadata(module)) {
+            (void)to_close(module, TRASH);
+        }
+
+        (void)from_close(module);
+        return -1;
+    }
+
+    if (mode_reads_metadata(module) && !(flags & OPTION_STDOUT)
+            && update_created_file_cnid(volume, created_file_path(module)) < 0) {
+        (void)from_close(module);
+        return -1;
+    }
+
+    return from_close(module);
+}
+
+static void close_metadata_volume(struct nad_volume *volume);
+
+static int validate_volume_metadata(const char *volpath, const struct vol *vol)
+{
+    if (vol->v_adouble != AD_VERSION2 && vol->v_adouble != AD_VERSION_EA) {
+        fprintf(stderr, "\"%s\" uses unsupported metadata format %u\n",
+                volpath, vol->v_adouble);
+        return -1;
+    }
+
+    return 0;
+}
+
+static struct vol fallback_volume;
+
+static void set_fallback_volume(struct nad_volume *volume, int flags)
+{
+    memset(&fallback_volume, 0, sizeof(fallback_volume));
+    fallback_volume.v_path = ".";
+    fallback_volume.v_adouble = (flags & OPTION_ADOUBLE)
+                                ? AD_VERSION2 : AD_VERSION_EA;
+    fallback_volume.v_ad_options = 0;
+
+    if (fallback_volume.v_adouble == AD_VERSION2) {
+        fallback_volume.ad_path = ad_path;
+    } else {
+#if defined(HAVE_EAFD) && defined(SOLARIS)
+        fallback_volume.ad_path = ad_path_ea;
+#else
+        fallback_volume.ad_path = ad_path_osx;
+#endif
+    }
+
+    volume->vol = &fallback_volume;
+    volume->fallback = true;
+    volume->skip_cnid = true;
+}
+
+static int resolve_metadata_volume(AFPObj *obj, int module,
+                                   const char *path, int flags,
+                                   struct nad_volume *volume)
+{
+    const char *volpath = path;
+    struct vol *vol;
+    struct vol *cnid_vol;
+    int cnid_flags = 0;
+    int open_cnid = mode_creates_volume_file(module, flags);
+    memset(volume, 0, sizeof(*volume));
+
+    if (mode_writes_metadata(module) || strcmp(path, STDIN) == 0) {
+        volpath = ".";
+    }
+
+    vol = getvolbypath(obj, volpath);
+
+    if (vol == NULL || vol->v_path == NULL) {
+        if (!forceflag) {
+            nad_not_inside_volume(stderr, volpath, 1);
+            return -1;
+        }
+
+        set_fallback_volume(volume, flags);
+        return 0;
+    }
+
+    if (validate_volume_metadata(volpath, vol) < 0) {
+        return -1;
+    }
+
+    volume->vol = vol;
+
+    if (!open_cnid) {
+        return 0;
+    }
+
+    cnid_vol = getvolbypath(obj, ".");
+
+    if (cnid_vol == NULL || cnid_vol->v_path == NULL) {
+        if (!forceflag) {
+            nad_not_inside_volume(stderr, ".", 1);
+            close_metadata_volume(volume);
+            return -1;
+        }
+
+        volume->skip_cnid = true;
+        return 0;
+    }
+
+    if (validate_volume_metadata(".", cnid_vol) < 0) {
+        return -1;
+    }
+
+    volume->cnid_vol = cnid_vol;
+
+    if (cnid_vol->v_cdb == NULL) {
+        if (cnid_vol->v_flags & AFPVOL_NODEV) {
+            cnid_flags |= CNID_FLAG_NODEV;
+        }
+
+        cnid_vol->v_cdb = cnid_open(cnid_vol, cnid_vol->v_cnidscheme,
+                                    cnid_flags);
+
+        if (cnid_vol->v_cdb == NULL) {
+            fprintf(stderr, "Can't initialize CNID database connection for %s\n",
+                    cnid_vol->v_path);
+            volume->vol = NULL;
+            volume->cnid_vol = NULL;
+            return -1;
+        }
+
+        volume->owns_cdb = true;
+    }
+
+    if (cnid_getstamp(cnid_vol->v_cdb, volume->db_stamp,
+                      sizeof(volume->db_stamp)) != 0) {
+        fprintf(stderr, "Can't read CNID database stamp for %s\n",
+                cnid_vol->v_path);
+        close_metadata_volume(volume);
+        return -1;
+    }
+
+    return 0;
+}
+
+static void close_metadata_volume(struct nad_volume *volume)
+{
+    if (volume->cnid_vol && volume->owns_cdb && volume->cnid_vol->v_cdb) {
+        cnid_close(volume->cnid_vol->v_cdb);
+        volume->cnid_vol->v_cdb = NULL;
+    }
+
+    memset(volume, 0, sizeof(*volume));
+}
+
+static int arg_is_option_with_value(const char *arg)
+{
+    return strcmp(arg, "--filename") == 0;
+}
+
+static int arg_is_flag_option(const char *arg)
+{
+    return strcmp(arg, "--header") == 0
+           || strcmp(arg, "--stdout") == 0
+           || strcmp(arg, "--adouble") == 0
+           || strcmp(arg, "--verbose") == 0;
+}
+
+static int set_newname(char *newname, size_t newname_len, const char *name)
+{
+    if (strlcpy(newname, name, newname_len) >= newname_len) {
+        fprintf(stderr, "nad: filename is too long: %s\n", name);
+        return -1;
+    }
+
+    return 0;
+}
+
+static int option_after_file(const char *arg)
+{
+    fprintf(stderr, "nad: option '%s' appears after a FILE argument\n", arg);
+    fprintf(stderr, "nad: place all options before FILE arguments\n");
+    return 1;
+}
+
+int nad_archive(int argc, char **argv, AFPObj *obj)
+{
+    int rc;
+    int rv = 0;
+    int module;
+    int flags = 0;
+    int saw_file = 0;
+    int saw_positional = 0;
+    int argi = 1;
+    char newname[ADEDLEN_NAME + 1];
+    newname[0] = '\0';
+
+    if (argc < 1) {
+        usage_archive(stderr);
+        return 1;
+    }
+
+    if (argc > 1 && (strcmp(argv[1], "--help") == 0
+                     || strcmp(argv[1], "-h") == 0)) {
+        usage_archive(stdout);
+        return 0;
+    }
+
+    module = parse_archive_mode(argv[0]);
+
+    if (module < 0) {
+        usage_archive(stderr);
+        return 1;
+    }
+
+    cnid_init();
+
+    for (int i = argi; i < argc;) {
+        const char *arg = argv[i];
+
+        if (arg_is_flag_option(arg)) {
+            if (saw_positional) {
+                option_after_file(arg);
+                usage_archive(stderr);
+                return 1;
+            }
+
+            if (strcmp(arg, "--header") == 0) {
+                flags |= OPTION_HEADERONLY;
+            } else if (strcmp(arg, "--stdout") == 0) {
+                flags |= OPTION_STDOUT;
+            } else if (strcmp(arg, "--adouble") == 0) {
+                flags |= OPTION_ADOUBLE;
+            } else if (strcmp(arg, "--verbose") == 0) {
+                flags |= OPTION_VERBOSE;
+            }
+
+            i++;
+            continue;
+        }
+
+        if (arg_is_option_with_value(arg)) {
+            if (saw_positional) {
+                option_after_file(arg);
+                usage_archive(stderr);
+                return 1;
+            }
+
+            if (i + 1 >= argc) {
+                fprintf(stderr, "nad: %s requires a name\n", arg);
+                usage_archive(stderr);
+                return 1;
+            }
+
+            i += 2;
+            continue;
+        }
+
+        if ((arg[0] == '-') && (strcmp(arg, STDIN) != 0)) {
+            fprintf(stderr, "nad: unknown option '%s'\n", arg);
+            usage_archive(stderr);
+            return 1;
+        }
+
+        saw_positional = 1;
+        i++;
+    }
+
+    nad_log_verbose = (flags & OPTION_VERBOSE) != 0;
+
+    while (argi < argc) {
+        const char *arg = argv[argi];
+        const char *effective_newname = newname;
+        struct nad_volume volume;
+
+        if (arg_is_flag_option(arg)) {
+            argi++;
+            continue;
+        }
+
+        if (strcmp(arg, "--filename") == 0) {
+            argi++;
+
+            if (argi >= argc) {
+                fprintf(stderr, "nad: --filename requires a name\n");
+                usage_archive(stderr);
+                return 1;
+            }
+
+            if (set_newname(newname, sizeof(newname), argv[argi]) != 0) {
+                return 1;
+            }
+
+            argi++;
+            continue;
+        }
+
+        saw_file = 1;
+
+        if (resolve_metadata_volume(obj, module, arg, flags, &volume) != 0) {
+            rv = 1;
+            argi++;
+            continue;
+        }
+
+        rc = nad_archive_convert(argv[argi], module, effective_newname, flags,
+                                 &volume);
+
+        if (rc != 0) {
+            rv = 1;
+        }
+
+        close_metadata_volume(&volume);
+        newname[0] = '\0';
+        argi++;
+    }
+
+    if (!saw_file) {
+        struct nad_volume volume;
+
+        if (mode_reads_metadata(module)) {
+            fprintf(stderr, "nad: command requires at least one path\n");
+            return 1;
+        }
+
+        if (resolve_metadata_volume(obj, module, STDIN, flags, &volume) != 0) {
+            rv = 1;
+        } else {
+            if (nad_archive_convert(STDIN, module, newname, flags, &volume) != 0) {
+                rv = 1;
+            }
+
+            close_metadata_volume(&volume);
+        }
+    }
+
+    return rv;
+}

--- a/bin/nad/megatron.h
+++ b/bin/nad/megatron.h
@@ -1,0 +1,104 @@
+#ifndef MEGATRON_H
+#define MEGATRON_H 1
+
+#include <atalk/adouble.h>
+#include <atalk/compat.h>
+#include <stdbool.h>
+
+struct vol;
+
+#ifndef	STDIN
+#	define	STDIN	"-"
+#endif /* ! STDIN */
+
+/*
+    Where it matters, data stored in either of these two structs is in
+    network byte order.  Any routines that need to interpret this data
+    locally would need to do the conversion.  Mostly this affects the
+    fork length variables.  Time values are affected as well, if any
+    routines actually need to look at them.
+ */
+
+#define DATA		0
+#define RESOURCE	1
+#define NUMFORKS	2
+
+#define HEX2NAD		0	/* unhex */
+#define BIN2NAD		1	/* unbin */
+#define NAD2BIN		2	/* bin */
+#define NAD2HEX		3	/* hex */
+
+#define OPTION_NONE       (0)
+#define OPTION_HEADERONLY (1 << 0)
+#define OPTION_STDOUT     (1 << 1)
+#define OPTION_VERBOSE    (1 << 2)
+#define OPTION_ADOUBLE    (1 << 3)
+
+#define FH_DATE_CREATE    (1 << 0)
+#define FH_DATE_MODIFY    (1 << 1)
+#define FH_DATE_BACKUP    (1 << 2)
+
+struct FInfo {
+    uint32_t		fdType;
+    uint32_t		fdCreator;
+    uint16_t		fdFlags;
+    uint32_t		fdLocation;
+    uint16_t		fdFldr;
+};
+
+struct FXInfo {
+    uint16_t           fdIconID;
+    uint16_t           fdUnused[3];
+    uint8_t            fdScript;
+    uint8_t            fdXFlags;
+    uint16_t           fdComment;
+    uint32_t           fdPutAway;
+};
+
+struct FHeader {
+    char		name[ ADEDLEN_NAME + 1 ];
+    char		comment[ ADEDLEN_COMMENT + 1 ];
+    uint32_t		forklen[ NUMFORKS ];
+    uint32_t		create_date;
+    uint32_t		mod_date;
+    uint32_t		backup_date;
+    unsigned int        date_flags;
+    struct FInfo	finder_info;
+    struct FXInfo       finder_xinfo;
+};
+
+struct nad_volume {
+    struct vol     *vol;
+    struct vol     *cnid_vol;
+    char           db_stamp[ADEDLEN_PRIVSYN];
+    bool           owns_cdb;
+    bool           fallback;
+    bool           skip_cnid;
+};
+
+#define FILEIOFF_CREATE	0
+#define FILEIOFF_MODIFY	4
+#define FILEIOFF_BACKUP	8
+#define FILEIOFF_ATTR	14
+#define FINDERIOFF_TYPE		0
+#define FINDERIOFF_CREATOR	4
+#define FINDERIOFF_FLAGS	8
+#define FINDERIOFF_LOC		10
+#define FINDERIOFF_FLDR		14
+#define FINDERIOFF_SCRIPT       24
+#define FINDERIOFF_XFLAGS       25
+
+#define	TRASH		0
+#define	KEEP		1
+
+#ifndef S_ISDIR
+#	define S_ISDIR(s)	(( s & S_IFMT ) == S_IFDIR )
+#endif /* ! S_ISDIR */
+
+extern char	*forkname[];
+extern char     *(*_mtoupath)(char *);
+extern char     *(*_utompath)(char *);
+#define mtoupath(s) (*_mtoupath)(s)
+#define utompath(s) (*_utompath)(s)
+
+#endif /* MEGATRON_H */

--- a/bin/nad/meson.build
+++ b/bin/nad/meson.build
@@ -1,5 +1,10 @@
 nad_sources = [
+    'crc16.c',
     'ftw.c',
+    'hqx.c',
+    'macbin.c',
+    'megatron.c',
+    'nad_adouble.c',
     'nad_cp.c',
     'nad_find.c',
     'nad_ls.c',

--- a/bin/nad/nad.c
+++ b/bin/nad/nad.c
@@ -51,6 +51,10 @@ typedef enum {
     CMD_FIND,
     CMD_MKDIR,
     CMD_RMDIR,
+    CMD_BIN,
+    CMD_HEX,
+    CMD_UNBIN,
+    CMD_UNHEX,
     CMD_VERSION
 } nad_command_t;
 
@@ -88,6 +92,22 @@ static nad_command_t get_command(const char *cmd)
         return CMD_RMDIR;
     }
 
+    if (STRCMP(cmd, ==, "bin")) {
+        return CMD_BIN;
+    }
+
+    if (STRCMP(cmd, ==, "hex")) {
+        return CMD_HEX;
+    }
+
+    if (STRCMP(cmd, ==, "unbin")) {
+        return CMD_UNBIN;
+    }
+
+    if (STRCMP(cmd, ==, "unhex")) {
+        return CMD_UNHEX;
+    }
+
     if (STRCMP(cmd, ==, "-v") || STRCMP(cmd, ==, "--version")) {
         return CMD_VERSION;
     }
@@ -97,7 +117,7 @@ static nad_command_t get_command(const char *cmd)
 
 static void usage_main(void)
 {
-    printf("Usage: nad [-F configfile] ls|cp|rm|mv|mkdir|rmdir|set|find [file|dir, ...]\n");
+    printf("Usage: nad [-F configfile] [--force] ls|cp|rm|mv|mkdir|rmdir|set|find|bin|hex|unbin|unhex [file|dir, ...]\n");
     printf("       nad -v|--version\n");
 }
 
@@ -124,6 +144,9 @@ int main(int argc, char **argv)
             }
 
             obj.cmdlineconfigfile = argv[arg_idx++];
+        } else if (strcmp(argv[arg_idx], "--force") == 0) {
+            forceflag = 1;
+            arg_idx++;
         } else {
             break;
         }
@@ -195,9 +218,15 @@ int main(int argc, char **argv)
     case CMD_RMDIR:
         return nad_rmdir(argc - arg_idx, argv + arg_idx, &obj);
 
+    case CMD_BIN:
+    case CMD_HEX:
+    case CMD_UNBIN:
+    case CMD_UNHEX:
+        return nad_archive(argc - arg_idx, argv + arg_idx, &obj);
+
     case CMD_VERSION:
         show_version();
-        return 1;
+        return 0;
 
     case CMD_UNKNOWN:
     default:

--- a/bin/nad/nad.h
+++ b/bin/nad/nad.h
@@ -17,6 +17,7 @@
 
 #include <arpa/inet.h>
 #include <signal.h>
+#include <stdio.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -30,15 +31,23 @@
 
 #define ADVOL_V2_OR_EA(ad) ((ad) == AD_VERSION2 || (ad) == AD_VERSION_EA)
 
-enum logtype {STD, DBG};
+#define NAD_INFO(...)                         \
+    do {                                      \
+        printf(__VA_ARGS__);                  \
+        putchar('\n');                        \
+    } while (0)
 
-#define SLOG(...)                             \
-    _log(STD, __VA_ARGS__)
+#define NAD_DEBUG(...)                        \
+    do {                                      \
+        if (nad_log_verbose) {                \
+            fprintf(stderr, __VA_ARGS__);     \
+        }                                     \
+    } while (0)
 
-#define ERROR(...)                              \
-    do {                                        \
-        _log(STD, __VA_ARGS__);                 \
-        exit(1);                                \
+#define NAD_FATAL(...)                        \
+    do {                                      \
+        NAD_INFO(__VA_ARGS__);                \
+        exit(1);                              \
     } while (0)
 
 typedef struct {
@@ -47,9 +56,9 @@ typedef struct {
     bool           owns_cdb;  /*!< true if this wrapper opened v_cdb */
 } afpvol_t;
 
-extern int log_verbose;             /*!< Logging flag */
+extern int nad_log_verbose;         /*!< Logging flag */
+extern int forceflag;               /*!< Allow operations outside AFP volumes */
 extern volatile sig_atomic_t alarmed; /*!< Signal flag for clean exit */
-extern void _log(enum logtype lt, char *fmt, ...);
 extern void set_signal(void);
 
 extern int nad_ls(int argc, char **argv, AFPObj *obj);
@@ -60,10 +69,12 @@ extern int nad_set(int argc, char **argv, AFPObj *obj);
 extern int nad_find(int argc, char **argv, AFPObj *obj);
 extern int nad_mkdir(int argc, char **argv, AFPObj *obj);
 extern int nad_rmdir(int argc, char **argv, AFPObj *obj);
+extern int nad_archive(int argc, char **argv, AFPObj *obj);
 
 /* ad_util.c */
 extern int openvol(AFPObj *obj, const char *path, afpvol_t *vol);
 extern int openvol_optional(AFPObj *obj, const char *path, afpvol_t *vol);
+extern void nad_not_inside_volume(FILE *out, const char *path, int force_hint);
 extern void closevol(afpvol_t *vol);
 extern cnid_t cnid_for_paths_parent(const afpvol_t *vol, const char *path,
                                     cnid_t *did);

--- a/bin/nad/nad_adouble.c
+++ b/bin/nad/nad_adouble.c
@@ -1,0 +1,803 @@
+/*
+ * Copyright (c) 1990,1991 Regents of The University of Michigan.
+ * Copyright (c) 2026 Daniel Markstedt <daniel@mindani.net>
+ * All Rights Reserved.  See COPYRIGHT.
+ *
+ * Macintosh file format transformer based on megatron by Charles Clark.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/uio.h>
+#include <ctype.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <dirent.h>
+#include <unistd.h>
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif /* HAVE_FCNTL_H */
+
+#include <atalk/adouble.h>
+#include <atalk/volume.h>
+#include <atalk/util.h>
+#include <netatalk/endian.h>
+#include "nad.h"
+#include "megatron.h"
+#include "nad_adouble.h"
+
+static const unsigned char hexdig[] = "0123456789abcdef";
+
+static char mtou_buf[MAXPATHLEN + 1], utom_buf[MAXPATHLEN + 1];
+
+static int cap_hexval(unsigned char c)
+{
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    }
+
+    if (c >= 'a' && c <= 'f') {
+        return c - 'a' + 10;
+    }
+
+    return -1;
+}
+
+static int cap_decode_byte(const unsigned char *in, unsigned char *out)
+{
+    int hi, lo;
+    hi = cap_hexval(in[0]);
+    lo = cap_hexval(in[1]);
+
+    if (hi < 0 || lo < 0) {
+        return 0;
+    }
+
+    *out = (unsigned char)((hi << 4) | lo);
+    return 1;
+}
+
+static void cap_escape_byte(unsigned char c, unsigned char **out)
+{
+    *(*out)++ = ':';
+    *(*out)++ = hexdig[(c & 0xf0) >> 4];
+    *(*out)++ = hexdig[c & 0x0f];
+}
+
+#ifdef DOWNCASE
+static unsigned char lower_byte(unsigned char c)
+{
+    return (unsigned char)(isupper(c) ? tolower(c) : c);
+}
+#endif /* DOWNCASE */
+
+static char *mtoupathcap(char *mpath)
+{
+    const unsigned char	*m;
+    unsigned char	*u, *umax;
+    int		i = 0;
+    m = (const unsigned char *)mpath;
+    u = (unsigned char *)mtou_buf;
+    umax = u + sizeof(mtou_buf) - 4;
+
+    while (*m != '\0' && u < umax) {
+        if (!isprint(*m) || *m == '/' || (i == 0 && (*m == '.'))) {
+            cap_escape_byte(*m, &u);
+        } else {
+#ifdef DOWNCASE
+            *u++ = lower_byte(*m);
+#else /* DOWNCASE */
+            *u++ = *m;
+#endif /* DOWNCASE */
+        }
+
+        i++;
+        m++;
+    }
+
+    *u = '\0';
+    return mtou_buf;
+}
+
+
+static char *utompathcap(char *upath)
+{
+    unsigned char	*m, *u;
+    unsigned char	decoded;
+    m = (unsigned char *)utom_buf;
+    u = (unsigned char *)upath;
+
+    while (*u != '\0') {
+        if (*u == ':' && *(u + 1) != '\0' && *(u + 2) != '\0'
+                && cap_decode_byte(u + 1, &decoded)) {
+            u += 2;
+            *m = decoded;
+        } else {
+#ifdef DOWNCASE
+            *m = diatolower(*u);
+#else /* DOWNCASE */
+            *m = *u;
+#endif /* DOWNCASE */
+        }
+
+        u++;
+        m++;
+    }
+
+    *m = '\0';
+    return utom_buf;
+}
+
+char *(*_mtoupath)(char *mpath) = mtoupathcap;
+char *(*_utompath)(char *upath) = utompathcap;
+
+
+static struct nad_file_data {
+    char		macname[ MAXPATHLEN + 1 ];
+    char		adpath[ 2 ][ MAXPATHLEN + 1];
+    int			offset[ NUMFORKS ];
+    int                 closeflags;
+    int                 write_metadata;
+    const struct nad_volume *volume;
+    struct vol          *vol;
+    struct adouble	ad;
+} nad;
+
+void nad_set_volume(const struct nad_volume *volume)
+{
+    nad.volume = volume;
+    nad.vol = volume ? volume->vol : NULL;
+}
+
+static int nad_adouble_dir(char *dir, size_t dirlen)
+{
+    char *slash;
+
+    if (strlcpy(dir, nad.adpath[RESOURCE], dirlen) >= dirlen) {
+        errno = ENAMETOOLONG;
+        return -1;
+    }
+
+    slash = strrchr(dir, '/');
+
+    if (slash == NULL) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    *slash = '\0';
+    return 0;
+}
+
+static int nad_prepare_adouble_dir(int parentfd, char *dir, size_t dirlen,
+                                   mode_t mode, struct stat *st, int *created)
+{
+    int dirfd;
+    *created = 0;
+
+    if (nad_adouble_dir(dir, dirlen) < 0) {
+        return -1;
+    }
+
+    /*
+     * New metadata directory is owner-accessible for the following ad_open(),
+     * then restore the inherited mode after both fork files have been created.
+     */
+    if (mkdirat(parentfd, dir, mode | S_IRWXU) < 0) {
+        if (errno != EEXIST) {
+            return -1;
+        }
+    } else {
+        *created = 1;
+    }
+
+    dirfd = openat(parentfd, dir, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
+
+    if (dirfd < 0) {
+        return -1;
+    }
+
+    if (fstat(dirfd, st) < 0) {
+        close(dirfd);
+        return -1;
+    }
+
+    if (*created && fchmod(dirfd, mode | S_IRWXU) < 0) {
+        close(dirfd);
+        return -1;
+    }
+
+    return dirfd;
+}
+
+static int nad_set_created_modes(mode_t data_mode, mode_t header_mode,
+                                 int dirfd, mode_t dir_mode,
+                                 int created_dir, int created_header)
+{
+    if (created_dir && fchmod(dirfd, dir_mode) < 0) {
+        return -1;
+    }
+
+    if (ad_data_fileno(&nad.ad) >= 0
+            && fchmod(ad_data_fileno(&nad.ad), data_mode) < 0) {
+        return -1;
+    }
+
+    if (created_header && ad_meta_fileno(&nad.ad) >= 0
+            && fchmod(ad_meta_fileno(&nad.ad), header_mode) < 0) {
+        return -1;
+    }
+
+    return 0;
+}
+
+int nad_open(char *path, int openflags, struct FHeader *fh, int options _U_)
+{
+    struct stat		st;
+    struct stat		ad_dir_st;
+    const char		*adpath;
+    char		ad_dirpath[MAXPATHLEN + 1];
+    int			rc;
+    int			created_ad_dir;
+    int			created_header;
+    int			parentfd;
+    int			ad_dirfd;
+    mode_t		data_mode;
+    mode_t		header_mode;
+    mode_t		dir_mode;
+    /*
+     * Depending upon openflags, set up nad.adpath for the open.  If it
+     * is for write, then stat the current directory to get its mode.
+     * Open the file.  Either fill or grab the adouble information.
+     */
+    nad.write_metadata = (openflags != O_RDONLY);
+
+    if (nad.vol == NULL) {
+        fprintf(stderr, "No AFP volume selected\n");
+        return -1;
+    }
+
+    if (openflags == O_RDONLY) {
+        ad_init(&nad.ad, nad.vol);
+        nad.closeflags = ADFLAGS_DF | ADFLAGS_HF | ADFLAGS_RF;
+
+        if (strlcpy(nad.adpath[0], path, sizeof(nad.adpath[0]))
+                >= sizeof(nad.adpath[0])) {
+            fprintf(stderr, "Path is too long: %s\n", path);
+            return -1;
+        }
+
+        adpath = nad.vol->ad_path(nad.adpath[0], ADFLAGS_HF);
+
+        if (adpath == NULL || strlcpy(nad.adpath[1], adpath,
+                                      sizeof(nad.adpath[1]))
+                >= sizeof(nad.adpath[1])) {
+            fprintf(stderr, "Metadata path is too long: %s\n", path);
+            return -1;
+        }
+
+        if (stat(nad.adpath[ DATA ], &st) < 0) {
+            perror("stat of data fork failed");
+            return -1;
+        }
+
+#if DEBUG
+        NAD_DEBUG("%s is adpath[0]\n", nad.adpath[0]);
+        NAD_DEBUG("%s is adpath[1]\n", nad.adpath[1]);
+#endif /* DEBUG */
+
+        if (ad_open(&nad.ad, nad.adpath[ 0 ],
+                    nad.closeflags | ADFLAGS_RDONLY) < 0) {
+            perror(nad.adpath[ 0 ]);
+            return -1;
+        }
+
+        rc = nad_header_read(fh);
+
+        if (rc < 0) {
+            ad_close(&nad.ad, nad.closeflags);
+        }
+
+        return rc;
+    } else {
+        ad_init(&nad.ad, nad.vol);
+        nad.closeflags = ADFLAGS_DF | ADFLAGS_HF | ADFLAGS_RF;
+
+        if (strlcpy(nad.macname, fh->name, sizeof(nad.macname))
+                >= sizeof(nad.macname)
+                || strlcpy(nad.adpath[0], mtoupath(nad.macname),
+                           sizeof(nad.adpath[0])) >= sizeof(nad.adpath[0])) {
+            fprintf(stderr, "Path is too long: %s\n", fh->name);
+            return -1;
+        }
+
+        adpath = nad.vol->ad_path(nad.adpath[0], ADFLAGS_HF);
+
+        if (adpath == NULL || strlcpy(nad.adpath[1], adpath,
+                                      sizeof(nad.adpath[1]))
+                >= sizeof(nad.adpath[1])) {
+            fprintf(stderr, "Metadata path is too long: %s\n", nad.adpath[0]);
+            return -1;
+        }
+
+#if DEBUG
+        NAD_DEBUG("%s\n", nad.macname);
+        NAD_DEBUG("%s is adpath[0]\n", nad.adpath[0]);
+        NAD_DEBUG("%s is adpath[1]\n", nad.adpath[1]);
+#endif /* DEBUG */
+        parentfd = open(".", O_RDONLY | O_DIRECTORY);
+
+        if (parentfd < 0) {
+            perror("open of . failed");
+            return -1;
+        }
+
+        if (fstat(parentfd, &st) < 0) {
+            perror("stat of . failed");
+            close(parentfd);
+            return -1;
+        }
+
+        data_mode = (mode_t)(st.st_mode & 0666);
+        dir_mode = (mode_t)(st.st_mode & 0777);
+
+        if (nad.vol->v_adouble == AD_VERSION2) {
+            ad_dirfd = nad_prepare_adouble_dir(parentfd, ad_dirpath,
+                                               sizeof(ad_dirpath), dir_mode,
+                                               &ad_dir_st, &created_ad_dir);
+
+            if (ad_dirfd < 0) {
+                perror("preparing AppleDouble directory failed");
+                close(parentfd);
+                return -1;
+            }
+
+            if (!created_ad_dir) {
+                header_mode = ad_hf_mode((mode_t)(data_mode & ad_dir_st.st_mode));
+            } else {
+                header_mode = ad_hf_mode(data_mode);
+            }
+
+            created_header = (fstatat(parentfd, nad.adpath[RESOURCE], &ad_dir_st,
+                                      AT_SYMLINK_NOFOLLOW) < 0
+                              && errno == ENOENT);
+        } else {
+            ad_dirfd = -1;
+            created_ad_dir = 0;
+            created_header = 0;
+            header_mode = data_mode;
+        }
+
+        rc = ad_openat(&nad.ad, parentfd, nad.adpath[ 0 ],
+                       nad.closeflags | ADFLAGS_RDWR
+                       | ADFLAGS_CREATE | ADFLAGS_EXCL,
+                       data_mode);
+
+        if (rc < 0) {
+            perror(nad.adpath[ 0 ]);
+
+            if (ad_dirfd >= 0 && created_ad_dir && fchmod(ad_dirfd, dir_mode) < 0) {
+                perror("restoring AppleDouble directory mode failed");
+            }
+
+            if (ad_dirfd >= 0) {
+                close(ad_dirfd);
+            }
+
+            close(parentfd);
+            return -1;
+        }
+
+        if (ad_dirfd >= 0
+                && nad_set_created_modes(data_mode, header_mode, ad_dirfd, dir_mode,
+                                         created_ad_dir, created_header) < 0) {
+            perror("setting AppleDouble modes failed");
+            ad_close(&nad.ad, nad.closeflags);
+
+            if (ad_dirfd >= 0) {
+                close(ad_dirfd);
+            }
+
+            close(parentfd);
+            return -1;
+        }
+
+        if (ad_dirfd >= 0) {
+            close(ad_dirfd);
+        }
+
+        close(parentfd);
+        rc = nad_header_write(fh);
+
+        if (rc < 0) {
+            ad_close(&nad.ad, nad.closeflags);
+        }
+
+        return rc;
+    }
+}
+
+int nad_header_read(struct FHeader *fh)
+{
+    uint32_t		temptime;
+    struct stat		st;
+    size_t		name_len;
+    ssize_t		rfork_len;
+    const char		*name;
+    const char          *finderi;
+    char 		*p;
+    name_len = ad_getentrylen(&nad.ad, ADEID_NAME);
+
+    if (name_len > 0) {
+        if (name_len >= sizeof(fh->name)) {
+            fprintf(stderr, "Mac filename is too long\n");
+            return -1;
+        }
+
+        name = ad_entry(&nad.ad, ADEID_NAME);
+
+        if (name == NULL) {
+            fprintf(stderr, "Invalid AppleDouble filename entry\n");
+            return -1;
+        }
+
+        memcpy(fh->name, name, name_len);
+        fh->name[name_len] = '\0';
+    }
+
+    /* just in case there's nothing in macname */
+    if (fh->name[0] == '\0') {
+        if (NULL == (p = strrchr(nad.adpath[DATA], '/'))) {
+            p = nad.adpath[DATA];
+        } else {
+            p++;
+        }
+
+        if (strlcpy(fh->name, utompath(p), sizeof(fh->name))
+                >= sizeof(fh->name)) {
+            fprintf(stderr, "Mac filename is too long: %s\n", p);
+            return -1;
+        }
+    }
+
+    if (stat(nad.adpath[ DATA ], &st) < 0) {
+        perror("stat of datafork failed");
+        return -1;
+    }
+
+    rfork_len = ad_size(&nad.ad, ADEID_RFORK);
+
+    if (st.st_size < 0 || (uintmax_t)st.st_size > UINT32_MAX) {
+        fprintf(stderr, "Data fork is too large: %jd bytes\n",
+                (intmax_t)st.st_size);
+        return -1;
+    }
+
+    if (rfork_len < 0 || (uintmax_t)rfork_len > UINT32_MAX) {
+        fprintf(stderr, "Resource fork is too large: %jd bytes\n",
+                (intmax_t)rfork_len);
+        return -1;
+    }
+
+    fh->forklen[ DATA ] = htonl((uint32_t)st.st_size);
+    fh->forklen[ RESOURCE ] = htonl((uint32_t)rfork_len);
+    fh->comment[0] = '\0';
+#if DEBUG
+    NAD_DEBUG("macname of file\t\t\t%.*s\n",
+              (int)strnlen(fh->name, sizeof(fh->name)),
+              fh->name);
+    NAD_DEBUG("size of data fork\t\t%d\n",
+              ntohl(fh->forklen[ DATA ]));
+    NAD_DEBUG("size of resource fork\t\t%d\n",
+              ntohl(fh->forklen[ RESOURCE ]));
+    NAD_DEBUG("get info comment\t\t\"%s\"\n", fh->comment);
+#endif /* DEBUG */
+    ad_getdate(&nad.ad, AD_DATE_CREATE, &temptime);
+    memcpy(&fh->create_date, &temptime, sizeof(temptime));
+    ad_getdate(&nad.ad, AD_DATE_MODIFY, &temptime);
+    memcpy(&fh->mod_date, &temptime, sizeof(temptime));
+    ad_getdate(&nad.ad, AD_DATE_BACKUP, &temptime);
+    memcpy(&fh->backup_date, &temptime, sizeof(temptime));
+    fh->date_flags = FH_DATE_CREATE | FH_DATE_MODIFY | FH_DATE_BACKUP;
+#if DEBUG
+    memcpy(&temptime, &fh->create_date, sizeof(temptime));
+    temptime = AD_DATE_TO_UNIX(temptime);
+    NAD_DEBUG("create_date seconds\t\t%lu\n", temptime);
+    memcpy(&temptime, &fh->mod_date, sizeof(temptime));
+    temptime = AD_DATE_TO_UNIX(temptime);
+    NAD_DEBUG("mod_date seconds\t\t%lu\n", temptime);
+    memcpy(&temptime, &fh->backup_date, sizeof(temptime));
+    temptime = AD_DATE_TO_UNIX(temptime);
+    NAD_DEBUG("backup_date seconds\t\t%lu\n", temptime);
+    NAD_DEBUG("size of finder_info\t\t%d\n", sizeof(fh->finder_info));
+#endif /* DEBUG */
+    finderi = ad_entry(&nad.ad, ADEID_FINDERI);
+
+    if (finderi == NULL) {
+        memset(&fh->finder_info, 0, sizeof(fh->finder_info));
+        memset(&fh->finder_xinfo, 0, sizeof(fh->finder_xinfo));
+    } else {
+        memcpy(&fh->finder_info.fdType, finderi + FINDERIOFF_TYPE,
+               sizeof(fh->finder_info.fdType));
+        memcpy(&fh->finder_info.fdCreator, finderi + FINDERIOFF_CREATOR,
+               sizeof(fh->finder_info.fdCreator));
+        memcpy(&fh->finder_info.fdFlags, finderi + FINDERIOFF_FLAGS,
+               sizeof(fh->finder_info.fdFlags));
+        memcpy(&fh->finder_info.fdLocation, finderi + FINDERIOFF_LOC,
+               sizeof(fh->finder_info.fdLocation));
+        memcpy(&fh->finder_info.fdFldr, finderi + FINDERIOFF_FLDR,
+               sizeof(fh->finder_info.fdFldr));
+        memcpy(&fh->finder_xinfo.fdScript, finderi + FINDERIOFF_SCRIPT,
+               sizeof(fh->finder_xinfo.fdScript));
+        memcpy(&fh->finder_xinfo.fdXFlags, finderi + FINDERIOFF_XFLAGS,
+               sizeof(fh->finder_xinfo.fdXFlags));
+    }
+
+#if DEBUG
+    {
+        short		flags;
+        NAD_DEBUG("finder_info.fdType\t\t%.*s\n",
+                  sizeof(fh->finder_info.fdType), &fh->finder_info.fdType);
+        NAD_DEBUG("finder_info.fdCreator\t\t%.*s\n",
+                  sizeof(fh->finder_info.fdCreator),
+                  &fh->finder_info.fdCreator);
+        NAD_DEBUG("nad type and creator\t\t%.*s\n\n",
+                  sizeof(fh->finder_info.fdType) +
+                  sizeof(fh->finder_info.fdCreator),
+                  ad_entry(&nad.ad, ADEID_FINDERI));
+        memcpy(&flags, ad_entry(&nad.ad, ADEID_FINDERI) +
+               FINDERIOFF_FLAGS, sizeof(flags));
+        NAD_DEBUG("nad.ad flags\t\t\t%x\n", flags);
+        NAD_DEBUG("fh flags\t\t\t%x\n", fh->finder_info.fdFlags);
+        NAD_DEBUG("fh script\t\t\t%x\n", fh->finder_xinfo.fdScript);
+        NAD_DEBUG("fh xflags\t\t\t%x\n", fh->finder_xinfo.fdXFlags);
+    }
+#endif /* DEBUG */
+    nad.offset[ DATA ] = nad.offset[ RESOURCE ] = 0;
+    return 0;
+}
+
+int nad_header_write(struct FHeader *fh)
+{
+    uint32_t		temptime;
+    size_t		name_len;
+    size_t		comment_len;
+    name_len = strnlen(nad.macname, sizeof(nad.macname));
+
+    if (name_len > ADEDLEN_NAME) {
+        fprintf(stderr, "Mac filename is too long: %s\n", nad.macname);
+        return -1;
+    }
+
+    comment_len = strnlen(fh->comment, sizeof(fh->comment));
+
+    if (comment_len > ADEDLEN_COMMENT) {
+        fprintf(stderr, "Mac comment is too long\n");
+        return -1;
+    }
+
+    if (nad.vol->v_adouble == AD_VERSION2) {
+        ad_setentrylen(&nad.ad, ADEID_NAME, name_len);
+        memcpy(ad_entry(&nad.ad, ADEID_NAME), nad.macname,
+               ad_getentrylen(&nad.ad, ADEID_NAME));
+    }
+
+    ad_setentrylen(&nad.ad, ADEID_COMMENT, comment_len);
+    memcpy(ad_entry(&nad.ad, ADEID_COMMENT), fh->comment,
+           ad_getentrylen(&nad.ad, ADEID_COMMENT));
+    ad_setentrylen(&nad.ad, ADEID_RFORK, ntohl(fh->forklen[ RESOURCE ]));
+#if DEBUG
+    NAD_DEBUG("ad_getentrylen\n");
+    NAD_DEBUG("ADEID_FINDERI\t\t\t%d\n",
+              ad_getentrylen(&nad.ad, ADEID_FINDERI));
+    NAD_DEBUG("ADEID_RFORK\t\t\t%d\n",
+              ad_getentrylen(&nad.ad, ADEID_RFORK));
+    NAD_DEBUG("ADEID_NAME\t\t\t%d\n",
+              ad_getentrylen(&nad.ad, ADEID_NAME));
+    NAD_DEBUG("ad_entry of ADEID_NAME\t\t%.*s\n",
+              ad_getentrylen(&nad.ad, ADEID_NAME),
+              ad_entry(&nad.ad, ADEID_NAME));
+    NAD_DEBUG("ADEID_COMMENT\t\t\t%d\n",
+              ad_getentrylen(&nad.ad, ADEID_COMMENT));
+#endif /* DEBUG */
+    memcpy(&temptime, &fh->create_date, sizeof(temptime));
+    ad_setdate(&nad.ad, AD_DATE_CREATE, temptime);
+    memcpy(&temptime, &fh->mod_date, sizeof(temptime));
+    ad_setdate(&nad.ad, AD_DATE_MODIFY, temptime);
+#if DEBUG
+    ad_getdate(&nad.ad, AD_DATE_CREATE, &temptime);
+    temptime = AD_DATE_TO_UNIX(temptime);
+    NAD_DEBUG("FILEIOFF_CREATE seconds\t\t%ld\n", temptime);
+    ad_getdate(&nad.ad, AD_DATE_MODIFY, &temptime);
+    temptime = AD_DATE_TO_UNIX(temptime);
+    NAD_DEBUG("FILEIOFF_MODIFY seconds\t\t%ld\n", temptime);
+#endif /* DEBUG */
+    memset(ad_entry(&nad.ad, ADEID_FINDERI), 0, ADEDLEN_FINDERI);
+    memcpy(ad_entry(&nad.ad, ADEID_FINDERI) + FINDERIOFF_TYPE,
+           &fh->finder_info.fdType, sizeof(fh->finder_info.fdType));
+    memcpy(ad_entry(&nad.ad, ADEID_FINDERI) + FINDERIOFF_CREATOR,
+           &fh->finder_info.fdCreator, sizeof(fh->finder_info.fdCreator));
+    memcpy(ad_entry(&nad.ad, ADEID_FINDERI) + FINDERIOFF_FLAGS,
+           &fh->finder_info.fdFlags, sizeof(fh->finder_info.fdFlags));
+    memcpy(ad_entry(&nad.ad, ADEID_FINDERI) + FINDERIOFF_LOC,
+           &fh->finder_info.fdLocation, sizeof(fh->finder_info.fdLocation));
+    memcpy(ad_entry(&nad.ad, ADEID_FINDERI) + FINDERIOFF_FLDR,
+           &fh->finder_info.fdFldr, sizeof(fh->finder_info.fdFldr));
+    memcpy(ad_entry(&nad.ad, ADEID_FINDERI) + FINDERIOFF_SCRIPT,
+           &fh->finder_xinfo.fdScript, sizeof(fh->finder_xinfo.fdScript));
+    memcpy(ad_entry(&nad.ad, ADEID_FINDERI) + FINDERIOFF_XFLAGS,
+           &fh->finder_xinfo.fdXFlags, sizeof(fh->finder_xinfo.fdXFlags));
+#if DEBUG
+    {
+        short		flags;
+        memcpy(&flags, (ad_entry(&nad.ad, ADEID_FINDERI) + FINDERIOFF_FLAGS),
+               sizeof(flags));
+        NAD_DEBUG("nad.ad flags\t\t\t%x\n", flags);
+        NAD_DEBUG("fh flags\t\t\t%x\n", fh->finder_info.fdFlags);
+        NAD_DEBUG("fh xflags\t\t\t%x\n", fh->finder_xinfo.fdXFlags);
+        NAD_DEBUG("type and creator\t\t%.*s\n\n",
+                  sizeof(fh->finder_info.fdType) +
+                  sizeof(fh->finder_info.fdCreator),
+                  ad_entry(&nad.ad, ADEID_FINDERI));
+    }
+#endif /* DEBUG */
+    nad.offset[ DATA ] = nad.offset[ RESOURCE ] = 0;
+    ad_flush(&nad.ad);
+    return 0;
+}
+
+static int		forkeid[] = { ADEID_DFORK, ADEID_RFORK };
+
+ssize_t nad_read(int fork, char *forkbuf, size_t bufc)
+{
+    ssize_t		cc = 0;
+#if DEBUG
+    NAD_DEBUG("Entering nad_read\n");
+#endif /* DEBUG */
+
+    if ((cc = ad_read(&nad.ad, forkeid[ fork ], nad.offset[ fork ],
+                      forkbuf, bufc)) < 0)  {
+        perror("Reading the appledouble file:");
+        return cc;
+    }
+
+    nad.offset[ fork ] += cc;
+#if DEBUG
+    NAD_DEBUG("Exiting nad_read\n");
+#endif /* DEBUG */
+    return cc;
+}
+
+ssize_t nad_write(int fork, char *forkbuf, size_t bufc)
+{
+    const char		*buf_ptr;
+    size_t		writelen;
+    ssize_t		cc = 0;
+#if DEBUG
+    NAD_DEBUG("Entering nad_write\n");
+#endif /* DEBUG */
+    writelen = bufc;
+    buf_ptr = forkbuf;
+
+    while (writelen > 0) {
+        cc =  ad_write(&nad.ad, forkeid[ fork ], nad.offset[ fork ],
+                       0, buf_ptr, writelen);
+
+        if (cc <= 0) {
+            break;
+        }
+
+        nad.offset[ fork ] += cc;
+        buf_ptr += cc;
+        writelen -= cc;
+    }
+
+    if (writelen > 0) {
+        if (cc < 0) {
+            perror("Writing the appledouble file:");
+            return cc;
+        }
+
+        fprintf(stderr, "Writing the appledouble file: short write\n");
+        return -1;
+    }
+
+    return bufc;
+}
+
+static int nad_update_cnid(void)
+{
+    struct stat st;
+    cnid_t cnid;
+    cnid_t did;
+
+    if (!nad.write_metadata) {
+        return 0;
+    }
+
+    if (nad.volume == NULL || nad.volume->fallback || nad.volume->skip_cnid
+            || nad.vol == NULL) {
+        return 0;
+    }
+
+    if (nad.vol->v_cdb == NULL) {
+        fprintf(stderr, "No CNID database selected for %s\n", nad.adpath[DATA]);
+        errno = EINVAL;
+        return -1;
+    }
+
+    if (lstat(nad.adpath[DATA], &st) != 0) {
+        perror(nad.adpath[DATA]);
+        return -1;
+    }
+
+    cnid = cnid_for_path(nad.vol->v_cdb, nad.vol->v_path, nad.adpath[DATA],
+                         &did);
+
+    if (cnid == CNID_INVALID) {
+        fprintf(stderr, "Error resolving CNID for %s\n", nad.adpath[DATA]);
+        errno = EIO;
+        return -1;
+    }
+
+    if (ad_setid(&nad.ad, st.st_dev, st.st_ino, cnid, did,
+                 nad.volume->db_stamp) <= 0) {
+        fprintf(stderr, "Error storing CNID metadata for %s\n", nad.adpath[DATA]);
+        errno = EIO;
+        return -1;
+    }
+
+    return 0;
+}
+
+int nad_close(int status)
+{
+    int			rv;
+    int                 close_rv;
+
+    if (status == KEEP) {
+        if ((rv = ad_flush(&nad.ad)) < 0) {
+            fprintf(stderr, "nad_close rv for flush %d\n", rv);
+        } else if (nad_update_cnid() < 0) {
+            rv = -1;
+        } else if ((rv = ad_flush(&nad.ad)) < 0) {
+            fprintf(stderr, "nad_close rv for CNID flush %d\n", rv);
+        }
+
+        if ((close_rv = ad_close(&nad.ad, nad.closeflags)) < 0) {
+            fprintf(stderr, "nad_close rv for close %d\n", close_rv);
+            return close_rv;
+        }
+
+        if (rv < 0) {
+            return rv;
+        }
+    } else if (status == TRASH) {
+        if ((close_rv = ad_close(&nad.ad, nad.closeflags)) < 0) {
+            fprintf(stderr, "nad_close rv for close %d\n", close_rv);
+        }
+
+        if (unlink(nad.adpath[ 0 ]) < 0) {
+            perror(nad.adpath[ 0 ]);
+        }
+
+        if (strcmp(nad.adpath[0], nad.adpath[1]) != 0
+                && unlink(nad.adpath[ 1 ]) < 0) {
+            perror(nad.adpath[ 1 ]);
+        }
+
+        return 0;
+    } else {
+        return -1;
+    }
+
+    return 0;
+}

--- a/bin/nad/nad_adouble.h
+++ b/bin/nad/nad_adouble.h
@@ -1,0 +1,16 @@
+#ifndef NAD_ADOUBLE_H
+#define NAD_ADOUBLE_H 1
+
+/* Forward Declarations */
+struct nad_volume;
+struct FHeader;
+
+void nad_set_volume(const struct nad_volume *volume);
+int nad_open(char *path, int openflags, struct FHeader *fh, int options);
+int nad_header_read(struct FHeader *fh);
+int nad_header_write(struct FHeader *fh);
+ssize_t nad_read(int fork, char *forkbuf, size_t bufc);
+ssize_t nad_write(int fork, char *forkbuf, size_t bufc);
+int nad_close(int status);
+
+#endif /* NAD_ADOUBLE_H */

--- a/bin/nad/nad_cp.c
+++ b/bin/nad/nad_cp.c
@@ -216,7 +216,7 @@ int nad_cp(int argc, char *argv[], AFPObj *obj)
     target = argv[--argc];
 
     if ((strlcpy(to.p_path, target, PATH_MAX)) >= PATH_MAX) {
-        ERROR("%s: name too long", target);
+        NAD_FATAL("%s: name too long", target);
     }
 
     to.p_end = to.p_path + strlen(to.p_path);
@@ -252,7 +252,7 @@ int nad_cp(int argc, char *argv[], AFPObj *obj)
     r = stat(to.p_path, &to_stat);
 
     if (r == -1 && errno != ENOENT) {
-        ERROR("%s", to.p_path);
+        NAD_FATAL("%s", to.p_path);
     }
 
     if (r == -1 || !S_ISDIR(to_stat.st_mode)) {
@@ -260,7 +260,7 @@ int nad_cp(int argc, char *argv[], AFPObj *obj)
          * Case (1).  Target is not a directory.
          */
         if (argc > 1) {
-            ERROR("%s is not a directory", to.p_path);
+            NAD_FATAL("%s is not a directory", to.p_path);
         }
 
         /*
@@ -284,9 +284,9 @@ int nad_cp(int argc, char *argv[], AFPObj *obj)
 
         if (have_trailing_slash && type == FILE_TO_FILE) {
             if (r == -1) {
-                ERROR("directory %s does not exist", to.p_path);
+                NAD_FATAL("directory %s does not exist", to.p_path);
             } else {
-                ERROR("%s is not a directory", to.p_path);
+                NAD_FATAL("%s is not a directory", to.p_path);
             }
         }
     } else
@@ -320,18 +320,11 @@ int nad_cp(int argc, char *argv[], AFPObj *obj)
             continue;
         }
 
-        if (!svolume.vol->v_path && !dvolume.vol->v_path) {
-            SLOG("Neither source nor destination is an AFP volume");
-            closevol(&svolume);
-            badcp = rval = 1;
-            continue;
-        }
-
         if (nftw(argv[i], copy, upfunc, 20, ftw_options) == -1) {
             if (alarmed) {
-                SLOG("...break");
+                NAD_INFO("...break");
             } else if (!badcp) {
-                SLOG("Error: %s: %s", argv[i], strerror(errno));
+                NAD_INFO("Error: %s: %s", argv[i], strerror(errno));
             }
         }
 
@@ -360,7 +353,7 @@ static int copy(const char *path,
 
     /* This currently doesn't work with "." */
     if (strcmp(path, ".") == 0) {
-        ERROR("\".\" not supported");
+        NAD_FATAL("\".\" not supported");
     }
 
     const char *dir = strrchr(path, '/');
@@ -423,7 +416,7 @@ static int copy(const char *path,
         *target_mid = 0;
 
         if (target_mid - to.p_path + nlen >= PATH_MAX) {
-            SLOG("%s%s: name too long (not copied)", to.p_path, p);
+            NAD_INFO("%s%s: name too long (not copied)", to.p_path, p);
             badcp = rval = 1;
             return 0;
         }
@@ -440,7 +433,7 @@ static int copy(const char *path,
     } else {
         if (to_stat.st_dev == statp->st_dev &&
                 to_stat.st_ino == statp->st_ino) {
-            SLOG("%s and %s are identical (not copied).", to.p_path, path);
+            NAD_INFO("%s and %s are identical (not copied).", to.p_path, path);
             badcp = rval = 1;
 
             if (S_ISDIR(statp->st_mode))
@@ -454,9 +447,9 @@ static int copy(const char *path,
 
         if (!S_ISDIR(statp->st_mode) &&
                 S_ISDIR(to_stat.st_mode)) {
-            SLOG("cannot overwrite directory %s with "
-                 "non-directory %s",
-                 to.p_path, path);
+            NAD_INFO("cannot overwrite directory %s with "
+                     "non-directory %s",
+                     to.p_path, path);
             badcp = rval = 1;
             return 0;
         }
@@ -467,7 +460,7 @@ static int copy(const char *path,
     /* Convert basename to appropriate volume encoding */
     if (dvolume.vol->v_path
             && (convert_dots_encoding(&svolume, &dvolume, to.p_path)) == -1) {
-        SLOG("Error converting name for %s", to.p_path);
+        NAD_INFO("Error converting name for %s", to.p_path);
         badcp = rval = 1;
         return -1;
     }
@@ -482,7 +475,7 @@ static int copy(const char *path,
 
     case S_IFDIR:
         if (!Rflag) {
-            SLOG("%s is a directory", path);
+            NAD_INFO("%s is a directory", path);
             badcp = rval = 1;
             return -1;
         }
@@ -497,11 +490,11 @@ static int copy(const char *path,
          */
         if (dne) {
             if (mkdir(to.p_path, statp->st_mode | S_IRWXU) < 0) {
-                ERROR("mkdir: %s: %s", to.p_path, strerror(errno));
+                NAD_FATAL("mkdir: %s: %s", to.p_path, strerror(errno));
             }
         } else if (!S_ISDIR(to_stat.st_mode)) {
             errno = ENOTDIR;
-            ERROR("%s", to.p_path);
+            NAD_FATAL("%s", to.p_path);
         }
 
         /* Create ad dir and copy ".Parent" */
@@ -519,7 +512,7 @@ static int copy(const char *path,
             /* copy metadata file */
             if (svolume.vol->v_path && ADVOL_V2_OR_EA(svolume.vol->v_adouble)
                     && dvolume.vol->vfs->vfs_copyfile(dvolume.vol, -1, path, to.p_path)) {
-                SLOG("Error copying adouble for %s -> %s", path, to.p_path);
+                NAD_INFO("Error copying adouble for %s -> %s", path, to.p_path);
                 badcp = rval = 1;
                 break;
             }
@@ -529,7 +522,7 @@ static int copy(const char *path,
 
             if ((did = cnid_for_path(dvolume.vol->v_cdb, dvolume.vol->v_path, to.p_path,
                                      &pdid)) == CNID_INVALID) {
-                SLOG("Error resolving CNID for %s", to.p_path);
+                NAD_INFO("Error resolving CNID for %s", to.p_path);
                 badcp = rval = 1;
                 return -1;
             }
@@ -547,7 +540,7 @@ static int copy(const char *path,
 
             if (ad_open(&ad, to.p_path,
                         ADFLAGS_HF | ADFLAGS_DIR | ADFLAGS_RDWR | ADFLAGS_CREATE, 0666) != 0) {
-                ERROR("Error opening adouble for: %s", to.p_path);
+                NAD_FATAL("Error opening adouble for: %s", to.p_path);
             }
 
             ad_setid(&ad, st.st_dev, st.st_ino, did, pdid, dvolume.db_stamp);
@@ -573,15 +566,15 @@ static int copy(const char *path,
 
     case S_IFBLK:
     case S_IFCHR:
-        SLOG("%s is a device file (not copied).", path);
+        NAD_INFO("%s is a device file (not copied).", path);
         break;
 
     case S_IFSOCK:
-        SLOG("%s is a socket (not copied).", path);
+        NAD_INFO("%s is a socket (not copied).", path);
         break;
 
     case S_IFIFO:
-        SLOG("%s is a FIFO (not copied).", path);
+        NAD_INFO("%s is a FIFO (not copied).", path);
         break;
 
     default:
@@ -595,7 +588,7 @@ static int copy(const char *path,
             /* copy ad-file */
             if (svolume.vol->v_path && ADVOL_V2_OR_EA(svolume.vol->v_adouble)
                     && dvolume.vol->vfs->vfs_copyfile(dvolume.vol, -1, path, to.p_path)) {
-                SLOG("Error copying adouble for %s -> %s", path, to.p_path);
+                NAD_INFO("Error copying adouble for %s -> %s", path, to.p_path);
                 badcp = rval = 1;
                 break;
             }
@@ -606,7 +599,7 @@ static int copy(const char *path,
 
             if ((cnid = cnid_for_path(dvolume.vol->v_cdb, dvolume.vol->v_path, to.p_path,
                                       &did)) == CNID_INVALID) {
-                SLOG("Error resolving CNID for %s", to.p_path);
+                NAD_INFO("Error resolving CNID for %s", to.p_path);
                 badcp = rval = 1;
                 return -1;
             }
@@ -624,7 +617,7 @@ static int copy(const char *path,
 
             if (ad_open(&ad, to.p_path, ADFLAGS_HF | ADFLAGS_RDWR | ADFLAGS_CREATE,
                         0666) != 0) {
-                ERROR("Error opening adouble for: %s", to.p_path);
+                NAD_FATAL("Error opening adouble for: %s", to.p_path);
             }
 
             ad_setid(&ad, st.st_dev, st.st_ino, cnid, did, dvolume.db_stamp);
@@ -679,7 +672,7 @@ static int ftw_copy_file(const struct FTW *entp _U_,
     char *p;
 
     if ((from_fd = open(spath, O_RDONLY, 0)) == -1) {
-        SLOG("%s: %s", spath, strerror(errno));
+        NAD_INFO("%s: %s", spath, strerror(errno));
         return 1;
     }
 
@@ -738,7 +731,7 @@ static int ftw_copy_file(const struct FTW *entp _U_,
     }
 
     if (to_fd == -1) {
-        SLOG("%s: %s", to.p_path, strerror(errno));
+        NAD_INFO("%s: %s", to.p_path, strerror(errno));
         (void)close(from_fd);
         return 1;
     }
@@ -775,13 +768,13 @@ static int ftw_copy_file(const struct FTW *entp _U_,
         }
 
         if (wcount != (ssize_t)wresid) {
-            SLOG("%s: %s", to.p_path, strerror(errno));
+            NAD_INFO("%s: %s", to.p_path, strerror(errno));
             rval = 1;
         }
 
         /* Some systems don't unmap on close(2). */
         if (munmap(p, sp->st_size) < 0) {
-            SLOG("%s: %s", spath, strerror(errno));
+            NAD_INFO("%s: %s", spath, strerror(errno));
             rval = 1;
         }
     } else {
@@ -822,7 +815,7 @@ static int ftw_copy_file(const struct FTW *entp _U_,
             buf = malloc(bufsize);
 
             if (buf == NULL) {
-                ERROR("Not enough memory");
+                NAD_FATAL("Not enough memory");
             }
         }
 
@@ -845,14 +838,14 @@ static int ftw_copy_file(const struct FTW *entp _U_,
             }
 
             if (wcount != (ssize_t)wresid) {
-                SLOG("%s: %s", to.p_path, strerror(errno));
+                NAD_INFO("%s: %s", to.p_path, strerror(errno));
                 rval = 1;
                 break;
             }
         }
 
         if (rcount < 0) {
-            SLOG("%s: %s", spath, strerror(errno));
+            NAD_INFO("%s: %s", spath, strerror(errno));
             rval = 1;
         }
     }
@@ -869,7 +862,7 @@ static int ftw_copy_file(const struct FTW *entp _U_,
     }
 
     if (close(to_fd)) {
-        SLOG("%s: %s", to.p_path, strerror(errno));
+        NAD_INFO("%s: %s", to.p_path, strerror(errno));
         rval = 1;
     }
 
@@ -886,24 +879,24 @@ static int ftw_copy_link(const struct FTW *p _U_,
     char llink[PATH_MAX];
 
     if ((len = (int) readlink(spath, llink, sizeof(llink) - 1)) == -1) {
-        SLOG("readlink: %s: %s", spath, strerror(errno));
+        NAD_INFO("readlink: %s: %s", spath, strerror(errno));
         return 1;
     }
 
     if (len < 0 || len >= sizeof(llink)) {
-        SLOG("readlink: %s: invalid link length", spath);
+        NAD_INFO("readlink: %s: invalid link length", spath);
         return 1;
     }
 
     llink[len] = '\0';
 
     if (exists && unlink(to.p_path)) {
-        SLOG("unlink: %s: %s", to.p_path, strerror(errno));
+        NAD_INFO("unlink: %s: %s", to.p_path, strerror(errno));
         return 1;
     }
 
     if (symlink(llink, to.p_path)) {
-        SLOG("symlink: %s: %s", llink, strerror(errno));
+        NAD_INFO("symlink: %s: %s", llink, strerror(errno));
         return 1;
     }
 
@@ -928,7 +921,7 @@ static int setfile(const struct stat *fs, int fd)
     atalk_timespec_to_timeval(&tv[1], &mtime_ts);
 
     if (utimes(to.p_path, tv)) {
-        SLOG("utimes: %s", to.p_path);
+        NAD_INFO("utimes: %s", to.p_path);
         rval = 1;
     }
 
@@ -965,7 +958,7 @@ static int setfile(const struct stat *fs, int fd)
         }
 
         if (result != 0 && errno != EPERM) {
-            SLOG("chown: %s: %s", to.p_path, strerror(errno));
+            NAD_INFO("chown: %s: %s", to.p_path, strerror(errno));
             rval = 1;
         }
 
@@ -974,7 +967,7 @@ static int setfile(const struct stat *fs, int fd)
 
     if ((!gotstat || mode != ts.st_mode)
             && (fdval ? fchmod(fd, mode) : chmod(to.p_path, mode))) {
-        SLOG("chmod: %s: %s", to.p_path, strerror(errno));
+        NAD_INFO("chmod: %s: %s", to.p_path, strerror(errno));
         rval = 1;
     }
 
@@ -984,7 +977,7 @@ static int setfile(const struct stat *fs, int fd)
         fchflags(fd, fs->st_flags) :
         (islink ? lchflags(to.p_path, fs->st_flags) :
          chflags(to.p_path, fs->st_flags))) {
-        SLOG("chflags: %s: %s", to.p_path, strerror(errno));
+        NAD_INFO("chflags: %s: %s", to.p_path, strerror(errno));
         rval = 1;
     }
 

--- a/bin/nad/nad_find.c
+++ b/bin/nad/nad_find.c
@@ -22,8 +22,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <dirent.h>
 
 #include <bstrlib.h>
 
@@ -48,6 +50,61 @@ static void usage_find(void)
         "   -v   Use VOLUME_PATH as the volume to search rather than\n"
         "        the current working directory.\n"
     );
+}
+
+static int filesystem_find(const char *path, const char *needle, int *found)
+{
+    struct stat st;
+    const char *base;
+
+    if (lstat(path, &st) != 0) {
+        NAD_INFO("%s: %s", path, strerror(errno));
+        return -1;
+    }
+
+    base = strrchr(path, '/');
+    base = base ? base + 1 : path;
+
+    if (strstr(base, needle) != NULL) {
+        printf("%s\n", path);
+        *found = 1;
+    }
+
+    if (!S_ISDIR(st.st_mode)) {
+        return 0;
+    }
+
+    DIR *dir = opendir(path);
+
+    if (dir == NULL) {
+        NAD_INFO("%s: %s", path, strerror(errno));
+        return -1;
+    }
+
+    struct dirent *ent;
+
+    while ((ent = readdir(dir)) != NULL) {
+        char child[MAXPATHLEN + 1];
+
+        if (DIR_DOT_OR_DOTDOT(ent->d_name)) {
+            continue;
+        }
+
+        if (snprintf(child, sizeof(child), "%s/%s", path, ent->d_name)
+                >= (int)sizeof(child)) {
+            NAD_INFO("%s/%s: name too long", path, ent->d_name);
+            closedir(dir);
+            return -1;
+        }
+
+        if (filesystem_find(child, needle, found) != 0) {
+            closedir(dir);
+            return -1;
+        }
+    }
+
+    closedir(dir);
+    return 0;
 }
 
 /*!
@@ -181,9 +238,17 @@ int nad_find(int argc, char **argv, AFPObj *obj)
     set_signal();
     cnid_init();
 
-    if (openvol(obj, srchvol, &vol) != 0) {
+    if (openvol_optional(obj, srchvol, &vol) != 0) {
         free((void *)srchvol);
         return 1;
+    }
+
+    if (vol.vol->v_path == NULL) {
+        int found = 0;
+        ret = filesystem_find(srchvol, argv[optind], &found) == 0 && found ? 0 : 1;
+        closevol(&vol);
+        free((void *)srchvol);
+        return ret;
     }
 
     free((void *)srchvol);
@@ -198,7 +263,7 @@ int nad_find(int argc, char **argv, AFPObj *obj)
                         namebuf,
                         MAXPATHLEN,
                         &flags) == (size_t) -1) {
-        ERROR("conversion error");
+        NAD_FATAL("conversion error");
     }
 
     int count;
@@ -236,7 +301,7 @@ int nad_find(int argc, char **argv, AFPObj *obj)
                 }
 
                 if (bstr_list_push(pathlist, bfromcstr(name)) < 0) {
-                    ERROR("bstr_list_push failed for \"%s\"", name);
+                    NAD_FATAL("bstr_list_push failed for \"%s\"", name);
                     bstrListDestroy(pathlist);
                     bdestroy(volpath);
                     return 1;
@@ -244,7 +309,7 @@ int nad_find(int argc, char **argv, AFPObj *obj)
             }
 
             if (bstr_list_push(pathlist, volpath) < 0) {
-                ERROR("bstr_list_push failed for volume path");
+                NAD_FATAL("bstr_list_push failed for volume path");
                 bstrListDestroy(pathlist);
                 bdestroy(volpath);
                 return 1;

--- a/bin/nad/nad_ls.c
+++ b/bin/nad/nad_ls.c
@@ -211,7 +211,8 @@ static void print_flags(char *path, afpvol_t *vol, const struct stat *st)
         adflags = ADFLAGS_DIR;
     }
 
-    if (vol->vol == NULL || vol->vol->v_path == NULL) {
+    if (vol->vol == NULL) {
+        printf(" ----------- ------ --- ---- ----   !NO-CNID ");
         return;
     }
 
@@ -226,7 +227,9 @@ static void print_flags(char *path, afpvol_t *vol, const struct stat *st)
          * fallback only triggers for the volume root's parent,
          * which is the virtual DIRDID_ROOT_PARENT node (CNID 1).
          */
-        if (strcmp(path, "..") == 0) {
+        if (vol->vol->v_path == NULL) {
+            printf("   !NO-CNID ");
+        } else if (strcmp(path, "..") == 0) {
             printf("  %10u ", ntohl(DIRDID_ROOT_PARENT));
         } else {
             printf("  !ADVOL_CACHE ");
@@ -396,13 +399,18 @@ static void print_flags(char *path, afpvol_t *vol, const struct stat *st)
     }
 
     putchar(' ');
-    /* CNID */
-    cnid = ad_forcegetid(&ad);
 
-    if (cnid) {
-        printf(" %10u ", ntohl(cnid));
+    /* CNID */
+    if (vol->vol->v_path == NULL) {
+        printf("   !NO-CNID ");
     } else {
-        printf(" !ADVOL_CACHE ");
+        cnid = ad_forcegetid(&ad);
+
+        if (cnid) {
+            printf(" %10u ", ntohl(cnid));
+        } else {
+            printf(" !ADVOL_CACHE ");
+        }
     }
 
     ad_close(&ad, ADFLAGS_HF);
@@ -701,7 +709,7 @@ static int ad_ls_r(char *path, afpvol_t *vol)
         }
 
         /* Check for netatalk special folders e.g. ".AppleDB" or ".AppleDesktop" */
-        if (check_netatalk_dirs(ep->d_name) != NULL) {
+        if (vol->vol->v_path && check_netatalk_dirs(ep->d_name) != NULL) {
             continue;
         }
 
@@ -753,7 +761,7 @@ static int ad_ls_r(char *path, afpvol_t *vol)
             }
 
             /* Check for netatalk special folders e.g. ".AppleDB" or ".AppleDesktop" */
-            if (check_netatalk_dirs(ep->d_name) != NULL) {
+            if (vol->vol->v_path && check_netatalk_dirs(ep->d_name) != NULL) {
                 continue;
             }
 
@@ -838,7 +846,7 @@ int nad_ls(int argc, char **argv, AFPObj *obj)
     cnid_init();
 
     if ((argc - optind) == 0) {
-        if (openvol(obj, ".", &vol) != 0) {
+        if (openvol_optional(obj, ".", &vol) != 0) {
             return 1;
         }
 
@@ -863,7 +871,7 @@ int nad_ls(int argc, char **argv, AFPObj *obj)
             first = 1;
             recursion = 0;
 
-            if (openvol(obj, argv[optind], &vol) != 0) {
+            if (openvol_optional(obj, argv[optind], &vol) != 0) {
                 rval = 1;
                 goto next;
             }
@@ -897,7 +905,7 @@ next:
             first = 1;
             recursion = 0;
 
-            if (openvol(obj, argv[optind], &vol) != 0) {
+            if (openvol_optional(obj, argv[optind], &vol) != 0) {
                 rval = 1;
                 goto next2;
             }

--- a/bin/nad/nad_mkdir.c
+++ b/bin/nad/nad_mkdir.c
@@ -67,7 +67,7 @@ static int mkdir_with_cnid(const char *path, mode_t mode, afpvol_t *vol)
     struct stat st;
 
     if (mkdir(path, mode) != 0) {
-        SLOG("mkdir: %s: %s", path, strerror(errno));
+        NAD_INFO("mkdir: %s: %s", path, strerror(errno));
         return -1;
     }
 
@@ -85,12 +85,12 @@ static int mkdir_with_cnid(const char *path, mode_t mode, afpvol_t *vol)
 
     if ((did = cnid_for_path(vol->vol->v_cdb, vol->vol->v_path, path,
                              &pdid)) == CNID_INVALID) {
-        SLOG("Error resolving CNID for %s", path);
+        NAD_INFO("Error resolving CNID for %s", path);
         return -1;
     }
 
     if (lstat(path, &st) != 0) {
-        SLOG("lstat: %s: %s", path, strerror(errno));
+        NAD_INFO("lstat: %s: %s", path, strerror(errno));
         return -1;
     }
 
@@ -99,7 +99,7 @@ static int mkdir_with_cnid(const char *path, mode_t mode, afpvol_t *vol)
     if (ad_open(&ad, path,
                 ADFLAGS_HF | ADFLAGS_DIR | ADFLAGS_RDWR | ADFLAGS_CREATE,
                 0666) != 0) {
-        SLOG("Error opening adouble for: %s", path);
+        NAD_INFO("Error opening adouble for: %s", path);
         return -1;
     }
 
@@ -151,7 +151,7 @@ static int do_mkdir(const char *path, afpvol_t *vol)
     char buf[MAXPATHLEN + 1];
 
     if (strlcpy(buf, path, sizeof(buf)) >= sizeof(buf)) {
-        SLOG("Path too long: %s", path);
+        NAD_INFO("Path too long: %s", path);
         return 1;
     }
 
@@ -165,7 +165,7 @@ static int do_mkdir(const char *path, afpvol_t *vol)
 
         if (lstat(buf, &st) != 0) {
             if (errno != ENOENT) {
-                SLOG("lstat: %s: %s", buf, strerror(errno));
+                NAD_INFO("lstat: %s: %s", buf, strerror(errno));
                 return 1;
             }
 
@@ -177,7 +177,7 @@ static int do_mkdir(const char *path, afpvol_t *vol)
                 printf("%s\n", buf);
             }
         } else if (!S_ISDIR(st.st_mode)) {
-            SLOG("%s: Not a directory", buf);
+            NAD_INFO("%s: Not a directory", buf);
             return 1;
         }
 
@@ -187,7 +187,7 @@ static int do_mkdir(const char *path, afpvol_t *vol)
     /* Create the final directory */
     if (lstat(buf, &st) != 0) {
         if (errno != ENOENT) {
-            SLOG("lstat: %s: %s", buf, strerror(errno));
+            NAD_INFO("lstat: %s: %s", buf, strerror(errno));
             return 1;
         }
 
@@ -199,7 +199,7 @@ static int do_mkdir(const char *path, afpvol_t *vol)
             printf("%s\n", buf);
         }
     } else if (!S_ISDIR(st.st_mode)) {
-        SLOG("%s: Not a directory", buf);
+        NAD_INFO("%s: Not a directory", buf);
         return 1;
     }
 
@@ -240,11 +240,11 @@ int nad_mkdir(int argc, char *argv[], AFPObj *obj)
 
     for (int i = 0; i < argc; i++) {
         if (alarmed) {
-            SLOG("...break");
+            NAD_INFO("...break");
             break;
         }
 
-        if (openvol(obj, argv[i], &volume) != 0) {
+        if (openvol_optional(obj, argv[i], &volume) != 0) {
             rval = 1;
             continue;
         }

--- a/bin/nad/nad_mv.c
+++ b/bin/nad/nad_mv.c
@@ -144,13 +144,6 @@ int nad_mv(int argc, char *argv[], AFPObj *obj)
             return 1;
         }
 
-        if (!svolume.vol->v_path && !dvolume.vol->v_path) {
-            SLOG("Neither source nor destination is an AFP volume");
-            closevol(&svolume);
-            closevol(&dvolume);
-            return 1;
-        }
-
         rval = do_move(argv[0], argv[1]);
         closevol(&svolume);
         closevol(&dvolume);
@@ -159,14 +152,14 @@ int nad_mv(int argc, char *argv[], AFPObj *obj)
 
     /* It's a directory, move each file into it. */
     if (strlen(argv[argc - 1]) >= sizeof(path)) {
-        SLOG("%s: destination pathname too long", argv[argc - 1]);
+        NAD_INFO("%s: destination pathname too long", argv[argc - 1]);
         return 1;
     }
 
     size_t copied = strlcpy(path, argv[argc - 1], sizeof(path));
 
     if (copied >= sizeof(path)) {
-        SLOG("%s: destination pathname too long", argv[argc - 1]);
+        NAD_INFO("%s: destination pathname too long", argv[argc - 1]);
         return 1;
     }
 
@@ -187,7 +180,7 @@ int nad_mv(int argc, char *argv[], AFPObj *obj)
         char *src_copy = strdup(argv[i]);
 
         if (src_copy == NULL) {
-            SLOG("Memory allocation error");
+            NAD_INFO("Memory allocation error");
             rval = 1;
             continue;
         }
@@ -196,7 +189,7 @@ int nad_mv(int argc, char *argv[], AFPObj *obj)
         len = strnlen(base_name, PATH_MAX);
 
         if ((baselen + len) >= PATH_MAX) {
-            SLOG("%s: destination pathname too long", argv[i]);
+            NAD_INFO("%s: destination pathname too long", argv[i]);
             free(src_copy);
             rval = 1;
             continue;
@@ -204,17 +197,13 @@ int nad_mv(int argc, char *argv[], AFPObj *obj)
 
         /* Copy safely with bounds checking */
         if (strlcpy(endp, base_name, PATH_MAX - baselen) >= (PATH_MAX - baselen)) {
-            SLOG("%s: destination pathname too long", argv[i]);
+            NAD_INFO("%s: destination pathname too long", argv[i]);
             free(src_copy);
             rval = 1;
             continue;
         }
 
         if (openvol_optional(obj, argv[i], &svolume) != 0) {
-            rval = 1;
-        } else if (!svolume.vol->v_path && !dvolume.vol->v_path) {
-            SLOG("Neither source nor destination is an AFP volume");
-            closevol(&svolume);
             rval = 1;
         } else {
             if (do_move(argv[i], path)) {
@@ -244,7 +233,7 @@ static int do_move(const char *from, const char *to)
     if (!fflg && !access(to, F_OK)) {
         /* prompt only if source exist */
         if (lstat(from, &sb) == -1) {
-            SLOG("%s: %s", from, strerror(errno));
+            NAD_INFO("%s: %s", from, strerror(errno));
             return 1;
         }
 
@@ -280,6 +269,24 @@ static int do_move(const char *from, const char *to)
 
     int mustcopy = 0;
 
+    if (!svolume.vol->v_path && !dvolume.vol->v_path) {
+        if (renameat(AT_FDCWD, from, AT_FDCWD, to) == 0) {
+            if (vflg) {
+                printf("%s -> %s\n", from, to);
+            }
+
+            return 0;
+        }
+
+        if (errno != EXDEV) {
+            NAD_INFO("rename %s to %s: %s", from, to, strerror(errno));
+            return 1;
+        }
+
+        mustcopy = 1;
+        goto docopy;
+    }
+
     /*
      * Besides the usual EXDEV we copy instead of moving if
      * 1) source AFP volume != dest AFP volume
@@ -296,20 +303,20 @@ static int do_move(const char *from, const char *to)
     if (!mustcopy) {
         if ((cnid = cnid_for_path(svolume.vol->v_cdb, svolume.vol->v_path, from,
                                   &did)) == CNID_INVALID) {
-            SLOG("Couldn't resolve CNID for %s", from);
+            NAD_INFO("Couldn't resolve CNID for %s", from);
             return -1;
         }
 
         int srcfd = open(from, O_RDONLY);
 
         if (srcfd == -1) {
-            SLOG("Can't open %s: %s", from, strerror(errno));
+            NAD_INFO("Can't open %s: %s", from, strerror(errno));
             return -1;
         }
 
         if (fstat(srcfd, &sb) != 0) {
             close(srcfd);
-            SLOG("Can't fstat %s: %s", from, strerror(errno));
+            NAD_INFO("Can't fstat %s: %s", from, strerror(errno));
             return -1;
         }
 
@@ -324,13 +331,13 @@ static int do_move(const char *from, const char *to)
                  * filesystem, it can be recreated at the destination.
                  */
                 if (lstat(from, &sb) == -1) {
-                    SLOG("%s: %s", from, strerror(errno));
+                    NAD_INFO("%s: %s", from, strerror(errno));
                     return -1;
                 }
 
                 /* Can't mv(1) a mount point. */
                 if (!S_ISLNK(sb.st_mode) && realpath(from, path) == NULL) {
-                    SLOG("cannot resolve %s: %s: %s", from, path, strerror(errno));
+                    NAD_INFO("cannot resolve %s: %s: %s", from, path, strerror(errno));
                     return 1;
                 }
 
@@ -338,7 +345,7 @@ static int do_move(const char *from, const char *to)
                 mustcopy = 1;
                 goto docopy;
             } else { /* != EXDEV */
-                SLOG("rename %s to %s: %s", from, to, strerror(errno));
+                NAD_INFO("rename %s to %s: %s", from, to, strerror(errno));
                 return 1;
             }
         } /* rename != 0*/
@@ -348,7 +355,7 @@ static int do_move(const char *from, const char *to)
         switch (sb.st_mode & S_IFMT) {
         case S_IFREG:
             if (dvolume.vol->vfs->vfs_renamefile(dvolume.vol, -1, from, to) != 0) {
-                SLOG("Error moving adouble file for %s", from);
+                NAD_INFO("Error moving adouble file for %s", from);
                 return -1;
             }
 
@@ -358,7 +365,7 @@ static int do_move(const char *from, const char *to)
             break;
 
         default:
-            SLOG("Not a file or dir: %s", from);
+            NAD_INFO("Not a file or dir: %s", from);
             return -1;
         }
 
@@ -366,12 +373,12 @@ static int do_move(const char *from, const char *to)
         cnid_t newpdid, newdid;
 
         if ((newdid = cnid_for_paths_parent(&dvolume, to, &newpdid)) == CNID_INVALID) {
-            SLOG("Couldn't resolve CNID for parent of %s", to);
+            NAD_INFO("Couldn't resolve CNID for parent of %s", to);
             return -1;
         }
 
         if (stat(to, &sb) != 0) {
-            SLOG("Can't stat %s: %s", to, strerror(errno));
+            NAD_INFO("Can't stat %s: %s", to, strerror(errno));
             return 1;
         }
 
@@ -380,7 +387,7 @@ static int do_move(const char *from, const char *to)
 
         if (cnid_update(dvolume.vol->v_cdb, cnid, &sb, newdid, name,
                         strlen(name)) != 0) {
-            SLOG("Can't update CNID for: %s", to);
+            NAD_INFO("Can't update CNID for: %s", to);
             free(p);
             return 1;
         }
@@ -391,7 +398,7 @@ static int do_move(const char *from, const char *to)
 
         if (ad_open(&ad, to, S_ISDIR(sb.st_mode) ? (ADFLAGS_DIR | ADFLAGS_HF |
                     ADFLAGS_RDWR) : ADFLAGS_HF | ADFLAGS_RDWR) != 0) {
-            SLOG("Error opening adouble for: %s", to);
+            NAD_INFO("Error opening adouble for: %s", to);
             return 1;
         }
 
@@ -463,17 +470,17 @@ static int copy(const char *from, const char *to)
         /* Destination path exists. */
         if (S_ISDIR(sb.st_mode)) {
             if (rmdir(to) != 0) {
-                SLOG("rmdir %s: %s", to, strerror(errno));
+                NAD_INFO("rmdir %s: %s", to, strerror(errno));
                 return 1;
             }
         } else {
             if (unlink(to) != 0) {
-                SLOG("unlink %s: %s", to, strerror(errno));
+                NAD_INFO("unlink %s: %s", to, strerror(errno));
                 return 1;
             }
         }
     } else if (errno != ENOENT) {
-        SLOG("%s: %s", to, strerror(errno));
+        NAD_INFO("%s: %s", to, strerror(errno));
         return 1;
     }
 
@@ -485,7 +492,7 @@ static int copy(const char *from, const char *to)
         optind = 1;
 
         if (nad_cp(4, (char **)cp_argv, afp_obj) != 0) {
-            SLOG("cp -R %s %s: failed", from, to);
+            NAD_INFO("cp -R %s %s: failed", from, to);
             return 1;
         }
     }
@@ -496,12 +503,12 @@ static int copy(const char *from, const char *to)
         optind = 1;
 
         if (nad_rm(3, (char **)rm_argv, afp_obj) != 0) {
-            SLOG("rm -R %s: failed", from);
+            NAD_INFO("rm -R %s: failed", from);
             return 1;
         }
     } else {
         if (remove_path(from) != 0) {
-            SLOG("remove %s: %s", from, strerror(errno));
+            NAD_INFO("remove %s: %s", from, strerror(errno));
             return 1;
         }
     }

--- a/bin/nad/nad_rm.c
+++ b/bin/nad/nad_rm.c
@@ -130,20 +130,20 @@ int nad_rm(int argc, char *argv[], AFPObj *obj)
 
     for (int i = 0; argv[i] != NULL; i++) {
         /* Load .volinfo file for source */
-        if (openvol(obj, argv[i], &volume) != 0) {
+        if (openvol_optional(obj, argv[i], &volume) != 0) {
             badrm = rval = 1;
             continue;
         }
 
         if (nftw(argv[i], rm, upfunc, 20, FTW_DEPTH | FTW_PHYS) == -1) {
             if (alarmed) {
-                SLOG("...break");
+                NAD_INFO("...break");
             } else {
-                SLOG("Error: %s", argv[i]);
+                NAD_INFO("Error: %s", argv[i]);
             }
-
-            closevol(&volume);
         }
+
+        closevol(&volume);
     }
 
     return rval;
@@ -161,7 +161,7 @@ static int rm(const char *path,
     }
 
     if (volume.vol == NULL) {
-        SLOG("Error: could not open volume for %s (not removed)", path);
+        NAD_INFO("Error: could not open volume for %s (not removed)", path);
         badrm = rval = 1;
         return -1;
     }
@@ -196,12 +196,12 @@ static int rm(const char *path,
 
             if ((cnid = cnid_for_path(volume.vol->v_cdb, volume.vol->v_path, path,
                                       &did)) == CNID_INVALID) {
-                SLOG("Error resolving CNID for %s", path);
+                NAD_INFO("Error resolving CNID for %s", path);
                 return -1;
             }
 
             if (cnid_delete(volume.vol->v_cdb, cnid) != 0) {
-                SLOG("Error removing CNID %u for %s", ntohl(cnid), path);
+                NAD_INFO("Error removing CNID %u for %s", ntohl(cnid), path);
                 return -1;
             }
         }
@@ -215,7 +215,7 @@ static int rm(const char *path,
 
     case S_IFDIR:
         if (!Rflag) {
-            SLOG("%s is a directory", path);
+            NAD_INFO("%s is a directory", path);
             return FTW_SKIP_SUBTREE;
         }
 
@@ -224,7 +224,7 @@ static int rm(const char *path,
                     && (strstr(path, ".AppleDouble") != NULL)) {
                 /* should be adouble dir itself */
                 if (rmdir(path) != 0) {
-                    SLOG("Error removing dir \"%s\": %s", path, strerror(errno));
+                    NAD_INFO("Error removing dir \"%s\": %s", path, strerror(errno));
                     badrm = rval = 1;
                     return -1;
                 }
@@ -235,18 +235,18 @@ static int rm(const char *path,
             /* Get CNID of Parent and add new childir to CNID database */
             if ((did = cnid_for_path(volume.vol->v_cdb, volume.vol->v_path, path,
                                      &pdid)) == CNID_INVALID) {
-                SLOG("Error resolving CNID for %s", path);
+                NAD_INFO("Error resolving CNID for %s", path);
                 return -1;
             }
 
             if (cnid_delete(volume.vol->v_cdb, did) != 0) {
-                SLOG("Error removing CNID %u for %s", ntohl(did), path);
+                NAD_INFO("Error removing CNID %u for %s", ntohl(did), path);
                 return -1;
             }
         }
 
         if (rmdir(path) != 0) {
-            SLOG("Error removing dir \"%s\": %s", path, strerror(errno));
+            NAD_INFO("Error removing dir \"%s\": %s", path, strerror(errno));
             badrm = rval = 1;
             return -1;
         }
@@ -255,17 +255,17 @@ static int rm(const char *path,
 
     case S_IFBLK:
     case S_IFCHR:
-        SLOG("%s is a device file.", path);
+        NAD_INFO("%s is a device file.", path);
         badrm = rval = 1;
         break;
 
     case S_IFSOCK:
-        SLOG("%s is a socket.", path);
+        NAD_INFO("%s is a socket.", path);
         badrm = rval = 1;
         break;
 
     case S_IFIFO:
-        SLOG("%s is a FIFO.", path);
+        NAD_INFO("%s is a FIFO.", path);
         badrm = rval = 1;
         break;
 
@@ -286,12 +286,12 @@ static int rm(const char *path,
 
             if ((cnid = cnid_for_path(volume.vol->v_cdb, volume.vol->v_path, path,
                                       &did)) == CNID_INVALID) {
-                SLOG("Error resolving CNID for %s", path);
+                NAD_INFO("Error resolving CNID for %s", path);
                 return -1;
             }
 
             if (cnid_delete(volume.vol->v_cdb, cnid) != 0) {
-                SLOG("Error removing CNID %u for %s", ntohl(cnid), path);
+                NAD_INFO("Error removing CNID %u for %s", ntohl(cnid), path);
                 return -1;
             }
 

--- a/bin/nad/nad_rmdir.c
+++ b/bin/nad/nad_rmdir.c
@@ -63,6 +63,10 @@ static int is_protected_dir(const char *path, const afpvol_t *vol)
 {
     char resolved[PATH_MAX];
 
+    if (vol->vol == NULL || vol->vol->v_path == NULL) {
+        return 0;
+    }
+
     if (realpath(path, resolved) == NULL) {
         return 0;
     }
@@ -78,9 +82,9 @@ static int is_protected_dir(const char *path, const afpvol_t *vol)
 
     if (*r == '\0' && (*remainder == '/' || *remainder == '\0')) {
         if (*remainder == '\0') {
-            SLOG("Refusing to remove volume root: %s", path);
+            NAD_INFO("Refusing to remove volume root: %s", path);
         } else {
-            SLOG("Refusing to remove volume root parent: %s", path);
+            NAD_INFO("Refusing to remove volume root parent: %s", path);
         }
 
         return 1;
@@ -101,7 +105,7 @@ static int rmdir_with_cnid(const char *path, afpvol_t *vol)
 {
     cnid_t did, pdid;
 
-    if (is_protected_dir(path, vol)) {
+    if (vol->vol->v_path && is_protected_dir(path, vol)) {
         return -1;
     }
 
@@ -109,7 +113,7 @@ static int rmdir_with_cnid(const char *path, afpvol_t *vol)
         /* Resolve CNID before any modifications */
         if ((did = cnid_for_path(vol->vol->v_cdb, vol->vol->v_path, path,
                                  &pdid)) == CNID_INVALID) {
-            SLOG("Error resolving CNID for %s", path);
+            NAD_INFO("Error resolving CNID for %s", path);
             return -1;
         }
 
@@ -130,18 +134,18 @@ static int rmdir_with_cnid(const char *path, afpvol_t *vol)
         }
 
         if (rmdir(path) != 0) {
-            SLOG("rmdir: %s: %s", path, strerror(errno));
+            NAD_INFO("rmdir: %s: %s", path, strerror(errno));
             return -1;
         }
 
         /* Only delete CNID after successful removal from disk */
         if (cnid_delete(vol->vol->v_cdb, did) != 0) {
-            SLOG("Error removing CNID %u for %s", ntohl(did), path);
+            NAD_INFO("Error removing CNID %u for %s", ntohl(did), path);
             return -1;
         }
     } else {
         if (rmdir(path) != 0) {
-            SLOG("rmdir: %s: %s", path, strerror(errno));
+            NAD_INFO("rmdir: %s: %s", path, strerror(errno));
             return -1;
         }
     }
@@ -179,7 +183,7 @@ static int do_rmdir(const char *path, afpvol_t *vol)
     size_t len = strlcpy(buf, path, sizeof(buf));
 
     if (len >= sizeof(buf)) {
-        SLOG("Path too long: %s", path);
+        NAD_INFO("Path too long: %s", path);
         return 1;
     }
 
@@ -200,7 +204,7 @@ static int do_rmdir(const char *path, afpvol_t *vol)
 
         *slash = '\0';
 
-        if (is_protected_dir(buf, vol)) {
+        if (vol->vol->v_path && is_protected_dir(buf, vol)) {
             break;
         }
 
@@ -250,11 +254,11 @@ int nad_rmdir(int argc, char *argv[], AFPObj *obj)
 
     for (int i = 0; i < argc; i++) {
         if (alarmed) {
-            SLOG("...break");
+            NAD_INFO("...break");
             break;
         }
 
-        if (openvol(obj, argv[i], &volume) != 0) {
+        if (openvol_optional(obj, argv[i], &volume) != 0) {
             rval = 1;
             continue;
         }

--- a/bin/nad/nad_set.c
+++ b/bin/nad/nad_set.c
@@ -353,7 +353,7 @@ int nad_set(int argc, char **argv, AFPObj *obj)
 
     cnid_init();
 
-    if (openvol(obj, argv[optind], &vol) != 0) {
+    if (openvol_optional(obj, argv[optind], &vol) != 0) {
         return 1;
     }
 

--- a/bin/nad/nad_util.c
+++ b/bin/nad/nad_util.c
@@ -36,7 +36,6 @@
 #include <fcntl.h>
 #include <libgen.h>
 #include <limits.h>
-#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -63,6 +62,7 @@
 #include <sys/types.h>
 #endif /* HAVE_POSIX_ACLS */
 
+#include <atalk/adouble.h>
 #include <atalk/cnid.h>
 #include <atalk/errchk.h>
 #include <atalk/globals.h>
@@ -71,11 +71,22 @@
 #include <atalk/unicode.h>
 #include <atalk/util.h>
 
-
 #include "nad.h"
 
-int log_verbose;             /*!< Logging flag */
+int nad_log_verbose;         /*!< Logging flag */
+int forceflag;               /*!< Allow operations outside AFP volumes */
 volatile sig_atomic_t alarmed; /*!< Signal flag for clean exit */
+
+void nad_not_inside_volume(FILE *out, const char *path, int force_hint)
+{
+    fprintf(out, "\"%s\" is not inside an AFP volume", path);
+
+    if (force_hint) {
+        fprintf(out, " (use 'nad --force ...' to override)");
+    }
+
+    fputc('\n', out);
+}
 
 static void sig_handler(int signo _U_)
 {
@@ -91,11 +102,11 @@ void set_signal(void)
     sigemptyset(&sv.sa_mask);
 
     if (sigaction(SIGTERM, &sv, NULL) < 0) {
-        ERROR("error in sigaction(SIGTERM): %s", strerror(errno));
+        NAD_FATAL("error in sigaction(SIGTERM): %s", strerror(errno));
     }
 
     if (sigaction(SIGINT, &sv, NULL) < 0) {
-        ERROR("error in sigaction(SIGINT): %s", strerror(errno));
+        NAD_FATAL("error in sigaction(SIGINT): %s", strerror(errno));
     }
 
     memset(&sv, 0, sizeof(struct sigaction));
@@ -103,35 +114,33 @@ void set_signal(void)
     sigemptyset(&sv.sa_mask);
 
     if (sigaction(SIGABRT, &sv, NULL) < 0) {
-        ERROR("error in sigaction(SIGABRT): %s", strerror(errno));
+        NAD_FATAL("error in sigaction(SIGABRT): %s", strerror(errno));
     }
 
     if (sigaction(SIGHUP, &sv, NULL) < 0) {
-        ERROR("error in sigaction(SIGHUP): %s", strerror(errno));
+        NAD_FATAL("error in sigaction(SIGHUP): %s", strerror(errno));
     }
 
     if (sigaction(SIGQUIT, &sv, NULL) < 0) {
-        ERROR("error in sigaction(SIGQUIT): %s", strerror(errno));
-    }
-}
-
-void _log(enum logtype lt, char *fmt, ...)
-{
-    int len _U_;
-    static char logbuffer[1024];
-    va_list args;
-
-    if ((lt == STD) || (log_verbose == 1)) {
-        va_start(args, fmt);
-        len = vsnprintf(logbuffer, 1023, fmt, args);
-        va_end(args);
-        logbuffer[1023] = 0;
-        printf("%s\n", logbuffer);
+        NAD_FATAL("error in sigaction(SIGQUIT): %s", strerror(errno));
     }
 }
 
 /*! Static stub volume for paths outside any AFP volume */
 static struct vol null_vol;
+
+static void init_null_vol(void)
+{
+    memset(&null_vol, 0, sizeof(struct vol));
+    null_vol.v_adouble = AD_VERSION_EA;
+    null_vol.v_ad_options = 0;
+    null_vol.v_vfs_ea = AFPVOL_EA_SYS;
+#if defined(HAVE_EAFD) && defined(SOLARIS)
+    null_vol.ad_path = ad_path_ea;
+#else
+    null_vol.ad_path = ad_path_osx;
+#endif
+}
 
 /*!
  * @brief Open an AFP volume, or return a stub for non-AFP paths
@@ -156,7 +165,12 @@ int openvol_optional(AFPObj *obj, const char *path, afpvol_t *vol)
     memset(vol, 0, sizeof(afpvol_t));
 
     if ((vol->vol = getvolbypath(obj, path)) == NULL) {
-        memset(&null_vol, 0, sizeof(struct vol));
+        if (!forceflag) {
+            nad_not_inside_volume(stdout, path, 1);
+            return -1;
+        }
+
+        init_null_vol();
         vol->vol = &null_vol;
         return 0;
     }
@@ -164,12 +178,12 @@ int openvol_optional(AFPObj *obj, const char *path, afpvol_t *vol)
     /* Sanity checks to ensure we can touch this volume */
     if (vol->vol->v_adouble != AD_VERSION2
             && vol->vol->v_adouble != AD_VERSION_EA) {
-        ERROR("Unsupported adouble versions: %u", vol->vol->v_adouble);
+        NAD_FATAL("Unsupported adouble versions: %u", vol->vol->v_adouble);
     }
 
     if (vol->vol->v_vfs_ea != AFPVOL_EA_AD && vol->vol->v_vfs_ea != AFPVOL_EA_SYS
             && vol->vol->v_vfs_ea != AFPVOL_EA_NONE) {
-        ERROR("Unsupported Extended Attributes option: %u", vol->vol->v_vfs_ea);
+        NAD_FATAL("Unsupported Extended Attributes option: %u", vol->vol->v_vfs_ea);
     }
 
     if (vol->vol->v_cdb) {
@@ -183,8 +197,8 @@ int openvol_optional(AFPObj *obj, const char *path, afpvol_t *vol)
         if ((vol->vol->v_cdb = cnid_open(vol->vol,
                                          vol->vol->v_cnidscheme,
                                          flags)) == NULL) {
-            ERROR("Can't initialize CNID database connection for %s",
-                  vol->vol->v_path);
+            NAD_FATAL("Can't initialize CNID database connection for %s",
+                      vol->vol->v_path);
         }
 
         vol->owns_cdb = true;
@@ -214,7 +228,7 @@ int openvol(AFPObj *obj, const char *path, afpvol_t *vol)
     }
 
     if (!vol->vol->v_path) {
-        SLOG("\"%s\" is not inside an AFP volume", path);
+        nad_not_inside_volume(stdout, path, 0);
         memset(vol, 0, sizeof(afpvol_t));
         return -1;
     }
@@ -356,4 +370,3 @@ EC_CLEANUP:
 
     return cnid;
 }
-

--- a/doc/manpages/man1/nad.1.md
+++ b/doc/manpages/man1/nad.1.md
@@ -4,35 +4,51 @@ nad - Netatalk AppleDouble file utility suite
 
 # Synopsis
 
-**nad** [-F *configfile*] [ls | cp | mv | rm | mkdir | rmdir | set | find] [...]
+**nad** [-F *configfile*] [\-\-force] [ls | cp | mv | rm | mkdir | rmdir | set | find | bin | hex | unbin | unhex] [...]
 
 **nad** [-v | \-\-version]
 
 # Description
 
 **nad** is a file utility suite that can be used on a Netatalk host
-to manipulate files and directories in AFP shared volumes.
+to manipulate files and directories, including files in AFP shared volumes.
 AppleDouble data, which could be one of extended attributes of files,
 .\_ files, or files in **.AppleDouble** directories,
 as well as the CNID databases are updated appropriately
 when files in the shared Netatalk volume are modified.
+By default, **nad** refuses to operate on paths outside configured AFP
+volumes. Use **\-\-force** to override this validation.
 
 Using **nad** is preferable over the operating system's native file operation commands
-on files and directories in a Netatalk shared volume, because it preserves the integrity
+on files and directories in a Netatalk AFP volume, because it preserves the integrity
 of Mac OS metadata and accuracy of the CNID database.
 
-It depends on Netatalk running on the host system and the AFP volume being
-shared by Netatalk.
-
-Only users with appropriate permissions to access the files and directories
+Only users with appropriate permissions to access AFP files and directories
 can use **nad** to manipulate them.
 It is sensitive to afp.conf settings such as *valid users* and *invalid users*.
+
+When used with **\-\-force** outside AFP volumes, **nad** can manipulate files
+and directories while making a best effort to preserve Mac OS metadata using
+extended attributes or AppleDouble sidecar files, depending on the options
+used. CNID database updates are skipped outside AFP volumes.
+
+The **bin**, **hex**, **unbin**, and **unhex** commands transform files
+between Netatalk metadata, MacBinary, and BinHex formats. They preserve data
+forks, resource forks, and Finder metadata when moving files between classic
+Mac archive formats and Netatalk-managed storage.
+
+The file format transformer commands are based on *megatron* by Charles Clark.
 
 # Options
 
 **-F** *configfile*
 
 > Use *configfile* as the full path to the Netatalk configuration file.
+
+**\-\-force**
+
+> Allow operations on paths outside configured AFP volumes. Outside AFP
+volumes, CNID database updates are skipped.
 
 # Available Commands
 
@@ -71,6 +87,16 @@ Set metadata on files.
 Find files and directories.
 
 > nad find [-v volume_path] {name}
+
+Convert between Netatalk metadata, MacBinary, and BinHex.
+
+> nad bin [\-\-header] [\-\-filename NAME] [\-\-stdout] [\-\-adouble] [\-\-verbose] FILE [...]
+>
+> nad hex [\-\-header] [\-\-filename NAME] [\-\-stdout] [\-\-adouble] [\-\-verbose] FILE [...]
+>
+> nad unbin [\-\-header] [\-\-filename NAME] [\-\-adouble] [\-\-verbose] [SOURCEFILE [...]]
+>
+> nad unhex [\-\-header] [\-\-filename NAME] [\-\-adouble] [\-\-verbose] [SOURCEFILE [...]]
 
 Show version.
 
@@ -142,10 +168,11 @@ each named src_file is copied to the destination dst_directory. The
 names of the files themselves are not changed. If cp detects an attempt
 to copy a file to itself, the copy will fail.
 
-When a copy targeting an AFP volume is detected, its CNID database
-daemon is connected and all copies will also go through the CNID
-database. AppleDouble data are also copied and created as needed when
-the target is an AFP volume.
+Source and destination paths must be inside configured AFP volumes unless
+**\-\-force** is used. When a copy targeting an AFP volume is detected, its
+CNID database daemon is connected and all copies will also go through the
+CNID database. AppleDouble data are also copied and created as needed when the
+target is an AFP volume.
 
 Options:
 
@@ -198,7 +225,9 @@ contents of the directory are copied rather than the directory itself.
 Move files and directories.
 
 Move files around within an AFP volume, updating the CNID database as
-needed. If either condition below is true, the files are copied and removed from the source.
+needed. Source and destination paths must be inside configured AFP volumes
+unless **\-\-force** is used. If either condition below is true, the files are
+copied and removed from the source.
 
 - source or destination is not an AFP volume
 
@@ -345,16 +374,100 @@ Uppercase letter sets the flag, lowercase removes the flag.
 
 # nad find
 
-Find files and directories in an AFP volume.
+Find files and directories.
 
 This returns a list of paths that wholly or partially match the given name.
+Inside AFP volumes, the CNID database is searched. With **\-\-force** outside
+AFP volumes, the filesystem is traversed from the selected path.
 
 It takes one option:
 
 **-v** *path*
 
 > Use path to the shared volume to search rather than the current working
-directory.
+directory. With **\-\-force** outside AFP volumes, use path as the filesystem
+traversal root.
+
+# nad bin, hex, unbin, unhex
+
+Encode and decode MacBinary and BinHex, while reading and storing Mac OS
+metadata (resource forks and FinderInfo) in the metadata format used by
+Netatalk. Inside AFP volumes, the configured Netatalk volume metadata format
+is used and CNID metadata is updated.
+
+The command reads *afp.conf*, resolves each relevant path to a configured
+AFP volume, and uses that volume's metadata format when the path is inside
+an AFP volume. AppleDouble v2 volumes (**ea = ad**) use AppleDouble
+sidecar files. Extended Attributes volumes (**ea = sys**) use Netatalk's
+EA/sys-xattr metadata path.
+
+When operating with **\-\-force** outside an AFP volume, **nad** uses
+filesystem EA metadata by default and silently skips CNID database updates.
+Use **\-\-adouble** to use AppleDouble sidecar metadata outside AFP volumes
+instead.
+
+The filename used for an output file is the filename encoded in the
+source file, unless **\-\-filename** is supplied. MacBinary output files are
+created with a *.bin* extension. BinHex output files are created with a
+*.hqx* extension.
+
+Commands:
+
+**bin**
+
+> Convert Netatalk metadata, data fork, and resource fork to MacBinary
+(*.bin*).
+
+**hex**
+
+> Convert Netatalk metadata, data fork, and resource fork to BinHex
+(*.hqx*).
+
+**unbin**
+
+> Convert MacBinary (*.bin*) input to the current AFP volume's metadata
+format, or filesystem EA metadata outside an AFP volume.
+
+**unhex**
+
+> Convert BinHex (*.hqx*) input to the current AFP volume's metadata
+format, or filesystem EA metadata outside an AFP volume.
+
+Options:
+
+**\-\-header**
+
+> Print header information for the selected input format instead of performing
+a conversion. For **bin** and **hex**, this prints Netatalk metadata. For
+**unbin** and **unhex**, this prints the archive header.
+
+**\-\-filename** *NAME*
+
+> Use *NAME* in the converted file header instead of the name encoded in the
+source file. An appropriate file extension is still added to the output file.
+
+**\-\-stdout**
+
+> Write generated MacBinary or BinHex data to standard output.
+
+**\-\-adouble**
+
+> Write AppleDouble sidecar metadata instead of filesystem EA metadata outside
+AFP volumes. Configured AFP volumes continue to use the metadata format from
+*afp.conf*.
+
+**\-\-verbose**
+
+> Print diagnostic conversion details. Without this option, normal conversion
+is silent unless an error occurs.
+
+**-h**, **\-\-help**
+
+> Display archive command help and exit.
+
+If no *SOURCEFILE* is given, or if *SOURCEFILE* is '-', **unbin** and
+**unhex** read archive data from standard input. Options must appear before
+positional *FILE* arguments.
 
 # Examples
 
@@ -386,6 +499,35 @@ Find files with "Report" in the name in the shared AFP volume at /srv/afpshare:
     /srv/afpshare/Documents/2025/Report January 2025.doc
     /srv/afpshare/Documents/2024/Report December 2024.doc
     /srv/afpshare/Documents/Report Template.doc
+
+Convert a file to MacBinary:
+
+    nad bin /srv/afpshare/picture
+
+Convert a file to BinHex:
+
+    nad hex /srv/afpshare/picture
+
+Convert MacBinary input into filesystem EA metadata outside an AFP volume:
+
+    nad --force unbin /tmp/picture.bin
+
+Convert BinHex input to the current AFP volume's metadata format:
+
+    nad unhex file.hqx
+
+Inspect a MacBinary header:
+
+    $ nad unbin --header MacTCP_Ping_2.0.2.sea_.bin
+    name:               MacTCP Ping 2.0.2.sea
+    comment:
+    creator:            'aust'
+    type:               'APPL'
+    fork length[0]:     24419
+    fork length[1]:     18774
+    creation date:      Wed May 17 19:41:57 1995
+    modification date:  Wed May 17 19:41:58 1995
+    backup date:        (not set)
 
 # See also
 

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -43,53 +43,6 @@
 #include "virtual_icon.h"
 #include "volume.h"
 
-/*!
- * @brief Convert an AFP date-time value between local time and UTC.
- * @param aint_p AFP date-time to be converted.
- * @param offset_dir Which direction we want to convert the timestamp.
- */
-int set_utc_offset(uint32_t *aint_p, int offset_dir)
-{
-    /* If we somehow pass the earliest AFP date-time available, just exit. */
-    if (*aint_p == AD_DATE_START) {
-        return 0;
-    }
-
-    struct timeval tv;
-
-    tv.tv_sec = AD_DATE_TO_UNIX(*aint_p);
-    tv.tv_usec = 0;
-    struct tm tm;
-
-    if (offset_dir == TO_LOCALTIME) {
-        if (localtime_r(&tv.tv_sec, &tm) == NULL) {
-            LOG(log_error, logtype_default, "set_utc_offset: localtime_r: %s",
-                strerror(errno));
-            return -1;
-        }
-
-        tv.tv_sec = timegm(&tm);
-        *aint_p = AD_DATE_FROM_UNIX(tv.tv_sec);
-    } else {
-        /*
-         * This won't work reliably during the transition to/from DST.
-         * The timestamp may be a hour off during the transistion back
-         * to standard time at 0200 hours.
-         */
-        if (gmtime_r(&tv.tv_sec, &tm) == NULL) {
-            LOG(log_error, logtype_default, "set_utc_offset: gmtime_r: %s",
-                strerror(errno));
-            return -1;
-        }
-
-        tm.tm_isdst = -1;
-        tv.tv_sec = mktime(&tm);
-        *aint_p = AD_DATE_FROM_UNIX(tv.tv_sec);
-    }
-
-    return 0;
-}
-
 static int virtual_icon_reply(const AFPObj *obj, struct vol *vol,
                               uint16_t fbitmap, uint16_t dbitmap,
                               char *rbuf, size_t *rbuflen)

--- a/etc/afpd/filedir.h
+++ b/etc/afpd/filedir.h
@@ -9,10 +9,6 @@
 
 extern struct afp_options default_options;
 
-#define TO_UTC 0
-#define TO_LOCALTIME 1
-
-extern int set_utc_offset(uint32_t *aint_p, int offset_dir);
 extern char *ctoupath(const struct vol *, struct dir *, char *);
 extern char *absupath(const struct vol *, struct dir *, char *);
 extern int veto_file(const char *veto_str, const char *path);

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -292,6 +292,14 @@ struct adouble {
 #define AD_DATE_DELTA         946684800
 #define AD_DATE_FROM_UNIX(x)  htonl((x) - AD_DATE_DELTA)
 #define AD_DATE_TO_UNIX(x)    (ntohl(x) + AD_DATE_DELTA)
+#define AD_DATE_MAC_DELTA     3029529600U
+#define AD_DATE_FROM_MAC(x)   htonl(ntohl(x) - AD_DATE_MAC_DELTA)
+#define AD_DATE_TO_MAC(x)     htonl(ntohl(x) + AD_DATE_MAC_DELTA)
+
+typedef enum {
+    TO_UTC = 0,
+    TO_LOCALTIME = 1
+} ad_time_offset_dir_t;
 
 /* various finder offset and info bits */
 #define FINDERINFO_FRTYPEOFF   0
@@ -450,6 +458,7 @@ extern off_t ad_size(const struct adouble *, uint32_t);
 /* ad_date.c */
 extern int ad_setdate(struct adouble *, unsigned int, uint32_t);
 extern int ad_getdate(const struct adouble *, unsigned int, uint32_t *);
+extern int set_utc_offset(uint32_t *, ad_time_offset_dir_t);
 
 /* ad_attr.c */
 extern int       ad_setattr(const struct adouble *, const uint16_t);

--- a/libatalk/adouble/ad_date.c
+++ b/libatalk/adouble/ad_date.c
@@ -3,9 +3,60 @@
 #endif /* HAVE_CONFIG_H */
 
 #include <arpa/inet.h>
+#include <errno.h>
 #include <string.h>
+#include <sys/time.h>
+#include <time.h>
 
 #include <atalk/adouble.h>
+#include <atalk/logger.h>
+
+/*!
+ * @brief Convert an AFP date-time value between local time and UTC.
+ * @param aint_p AFP date-time to be converted.
+ * @param offset_dir Which direction we want to convert the timestamp.
+ */
+int set_utc_offset(uint32_t *aint_p, ad_time_offset_dir_t offset_dir)
+{
+    /* If we somehow pass the earliest AFP date-time available, just exit. */
+    if (*aint_p == AD_DATE_START) {
+        return 0;
+    }
+
+    struct timeval tv;
+
+    tv.tv_sec = AD_DATE_TO_UNIX(*aint_p);
+    tv.tv_usec = 0;
+    struct tm tm;
+
+    if (offset_dir == TO_LOCALTIME) {
+        if (localtime_r(&tv.tv_sec, &tm) == NULL) {
+            LOG(log_error, logtype_default, "set_utc_offset: localtime_r: %s",
+                strerror(errno));
+            return -1;
+        }
+
+        tv.tv_sec = timegm(&tm);
+        *aint_p = AD_DATE_FROM_UNIX(tv.tv_sec);
+    } else {
+        /*
+         * This won't work reliably during the transition to/from DST.
+         * The timestamp may be a hour off during the transistion back
+         * to standard time at 0200 hours.
+         */
+        if (gmtime_r(&tv.tv_sec, &tm) == NULL) {
+            LOG(log_error, logtype_default, "set_utc_offset: gmtime_r: %s",
+                strerror(errno));
+            return -1;
+        }
+
+        tm.tm_isdst = -1;
+        tv.tv_sec = mktime(&tm);
+        *aint_p = AD_DATE_FROM_UNIX(tv.tv_sec);
+    }
+
+    return 0;
+}
 
 int ad_setdate(struct adouble *ad,
                unsigned int dateoff, uint32_t date)


### PR DESCRIPTION
this functionality is built on the historical 'megatron' tool which was shipped with netatalk since v1.2 but removed in v3.0; it uses the same foundational structure, but has been overhauled for robustness and usability

- moved away from symlink invocation to positional commands in `nad`
- make it read afp.conf to be aware of AFP volume paths and filesystem metadata scheme
- leverage libatalk VFS subsystem to support conversion to and from both AppleDouble v2 and EA
- added support for updaing CNID database when files are created in an AFP volume
- added support for BinHex encoding (previously only decoding was supported)
- removed the direct BinHex to MacBinary conversion path (`hqx2bin`): use a two step process with Netatalk metadata as the intermediate step
- make stdout quiet by default, and introduce `--verbose` flag to print diagnostic information
- replaced the original CRC-16 Xmodem encoding lookup table with a minimal implementation from scratch
- removed the ancient AppleSingle format, which libatalk VFS no longer handles
- removed the Shift JIS and EUC-JP character encoding conversion routines
- credit to original creator of megatron [Charles Clark](https://websites.umich.edu/~rsug/netatalk/archive/admins/1992/0032.html) (reportedly introduced with netatalk v1.2)
- added standard UMich copyright headers aligned with the other netatalk source files of that era

modifications to nad:

- allow for file operations in any arbitrary file system location
- skip AFP volume initialization and CNID db operations on non-AFP paths
- naive nad find implementation for non-AFP paths
- consolidate logging routines, new interface is NAD_INFO, NAD_FATAL, NAD_DEBUG

modifications elsewhere:

- set_utc_offset utility function moved from afpd to libatalk/adouble
- consolidate Mac epoch constants from megatron.h to adouble.h

mapping new and old commands:

| action | megatron command | nad command|
| --- | --- | --- |
| convert MacBinary (.bin) to Netatalk EA/AD | `unbin` | `nad unbin` |
| convert BinHex (.hqx) to Netatalk EA/AD | `unhex` | `nad unhex` |
| convert AppleSingle to AppleDouble | `unsingle` | _removed_ |
| convert BinHex (.hqx) to MacBinary (.bin) | `hqx2bin` | `nad unhex; nad bin` |
| convert AppleSingle to MacBinary (.bin) | `single2bin` | _removed_ |
| convert Netatalk EA/AD to MacBinary (.bin) | `macbinary` | `nad bin` |
| convert Netatalk EA/AD to BinHex (.hqx) | - | `nad hex` |
| show MacBinary header | `binheader` | `nad unbin --header` |
| show BinHex header | - | `nad unhex --header` |
| show Netatalk EA/AD header | `nadheader` | `nad bin --header` _OR_ `nad hex --header` |
