### PR TITLE
afpd: Update IPC state back to "active" after reconnect.

### DIFF
--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -314,6 +314,7 @@ static void handle_transfer_session(AFPObj *obj)
 
     LOG(log_note, logtype_afpd,
         "handle_transfer_session: successful primary reconnect");
+    ipc_child_state(obj, DSI_RUNNING);
 }
 
 /* Forward declaration — defined after alarm_handler */


### PR DESCRIPTION
Whenever a client went to sleep and later reconnected to the server, afpstats was still reporting that the client was "sleeping". This was due to not updating the client's state after a sucessful reconnect.