### PR TITLE
standardize on the @ style for handle credits

### DIFF
--- a/etc/afpd/ad_cache.c
+++ b/etc/afpd/ad_cache.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026 Andy Lemin (andylemin)
+ * Copyright (c) 2026 Andy Lemin (@andylemin)
  *
  * AD (AppleDouble) metadata cache layer for dircache.
  * Provides ad_store_to_cache(), ad_rebuild_from_cache(), and

--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2010 Frank Lahm <franklahm@gmail.com>
- * Copyright (c) 2025-2026 Andy Lemin (andylemin)
+ * Copyright (c) 2025-2026 Andy Lemin (@andylemin)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1990,1993 Regents of The University of Michigan.
- * Copyright (c) 2025-2026 Andy Lemin (andylemin)
+ * Copyright (c) 2025-2026 Andy Lemin (@andylemin)
  *
  * All Rights Reserved.  See COPYRIGHT.
  * You may also use it under the terms of the General Public License (GPL). See COPYING.

--- a/etc/afpd/directory.h
+++ b/etc/afpd/directory.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1990,1991 Regents of The University of Michigan.
- * Copyright (c) 2025 Andy Lemin (andylemin)
+ * Copyright (c) 2025 Andy Lemin (@andylemin)
  * All Rights Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and

--- a/etc/afpd/main.c
+++ b/etc/afpd/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1990,1993 Regents of The University of Michigan.
- * Copyright (c) 2025-2026 Andy Lemin (andylemin)
+ * Copyright (c) 2025-2026 Andy Lemin (@andylemin)
  * All Rights Reserved.  See COPYRIGHT.
  */
 

--- a/libatalk/util/server_child.c
+++ b/libatalk/util/server_child.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1997 Adrian Sun (asun@zoology.washington.edu)
  * Copyright (c) 2013 Frank Lahm <franklahm@gmail.com>
- * Copyright (c) 2025-2026 Andy Lemin (andylemin)
+ * Copyright (c) 2025-2026 Andy Lemin (@andylemin)
  * All rights reserved. See COPYRIGHT.
  */
 

--- a/libatalk/util/server_ipc.c
+++ b/libatalk/util/server_ipc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025-2026 Andy Lemin (andylemin)
+ * Copyright (c) 2025-2026 Andy Lemin (@andylemin)
  * All rights reserved. See COPYRIGHT.
  */
 

--- a/test/testsuite/afp_tcp_analytics.c
+++ b/test/testsuite/afp_tcp_analytics.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Andy Lemin (andylemin)
+ * Copyright (c) 2026, Andy Lemin (@andylemin)
  * Credits; Based on work by Netatalk contributors
  *
  * This program is free software; you can redistribute it and/or modify

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Andy Lemin (andylemin)
+ * Copyright (c) 2025, Andy Lemin (@andylemin)
  * Credits; Based on work by Rafal Lewczuk, Didier Gautheron, Frank Lahm, and Netatalk contributors
  *
  * This program is free software; you can redistribute it and/or modify

--- a/test/testsuite/lantest_dircache_stats.c
+++ b/test/testsuite/lantest_dircache_stats.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Andy Lemin (andylemin)
+ * Copyright (c) 2025, Andy Lemin (@andylemin)
  * Credits; Based on work by Netatalk contributors
  *
  * This program is free software; you can redistribute it and/or modify

--- a/test/testsuite/lantest_io_monitor.c
+++ b/test/testsuite/lantest_io_monitor.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Andy Lemin (andylemin)
+ * Copyright (c) 2025, Andy Lemin (@andylemin)
  * Credits; Based on work by Netatalk contributors
  *
  * This program is free software; you can redistribute it and/or modify

--- a/test/testsuite/lantest_io_monitor.h
+++ b/test/testsuite/lantest_io_monitor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025, Andy Lemin (andylemin)
+ * Copyright (c) 2025, Andy Lemin (@andylemin)
  * Credits; Based on work by Netatalk contributors
  *
  * This program is free software; you can redistribute it and/or modify

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Andy Lemin (andylemin)
+ * Copyright (c) 2026, Andy Lemin (@andylemin)
  * Credits; Based on work by Netatalk contributors
  *
  * This program is free software; you can redistribute it and/or modify

--- a/test/testsuite/speedtest_local_vfs.c
+++ b/test/testsuite/speedtest_local_vfs.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, Andy Lemin (andylemin)
+ * Copyright (c) 2026, Andy Lemin (@andylemin)
  * Credits; Based on work by Netatalk contributors
  *
  * This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
aligns on a single style for each time @andylemin is credited :)

this makes the Debian copyright tool happy and gives easier to manage output