### PR TITLE
meson: add error flag for implicit function declaration

### DIFF
--- a/bin/dbd/cmd_dbd_scanvol.c
+++ b/bin/dbd/cmd_dbd_scanvol.c
@@ -16,6 +16,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <arpa/inet.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/etc/spotlight/localsearch/sl_localsearch.c
+++ b/etc/spotlight/localsearch/sl_localsearch.c
@@ -16,6 +16,7 @@
 #include "config.h"
 #endif
 
+#include <arpa/inet.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>

--- a/etc/spotlight/xapian/sl_xapian.c
+++ b/etc/spotlight/xapian/sl_xapian.c
@@ -13,6 +13,7 @@
 #include "config.h"
 #endif
 
+#include <arpa/inet.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>

--- a/etc/uams/uams_dhx2_pam.c
+++ b/etc/uams/uams_dhx2_pam.c
@@ -8,6 +8,7 @@
 #include "config.h"
 #endif /* HAVE_CONFIG_H */
 
+#include <arpa/inet.h>
 #include <errno.h>
 #include <gcrypt.h>
 #include <signal.h>
@@ -25,6 +26,7 @@
 #endif
 
 #include <atalk/afp.h>
+#include <atalk/compat.h>
 #include <atalk/constant_time.h>
 #include <atalk/globals.h>
 #include <atalk/logger.h>

--- a/etc/uams/uams_dhx2_passwd.c
+++ b/etc/uams/uams_dhx2_passwd.c
@@ -29,6 +29,7 @@
 #endif
 
 #include <atalk/afp.h>
+#include <atalk/compat.h>
 #include <atalk/logger.h>
 #include <atalk/uam.h>
 

--- a/etc/uams/uams_dhx_pam.c
+++ b/etc/uams/uams_dhx_pam.c
@@ -28,6 +28,7 @@
 #include <gcrypt.h>
 
 #include <atalk/afp.h>
+#include <atalk/compat.h>
 #include <atalk/logger.h>
 #include <atalk/uam.h>
 

--- a/etc/uams/uams_dhx_passwd.c
+++ b/etc/uams/uams_dhx_passwd.c
@@ -29,6 +29,7 @@
 #include <gcrypt.h>
 
 #include <atalk/afp.h>
+#include <atalk/compat.h>
 #include <atalk/logger.h>
 #include <atalk/uam.h>
 

--- a/etc/uams/uams_randnum.c
+++ b/etc/uams/uams_randnum.c
@@ -32,6 +32,7 @@
 
 #include <atalk/logger.h>
 #include <atalk/afp.h>
+#include <atalk/compat.h>
 #include <atalk/uam.h>
 #include <atalk/constant_time.h>
 

--- a/etc/uams/uams_srp.c
+++ b/etc/uams/uams_srp.c
@@ -38,6 +38,7 @@
 #include <unistd.h>
 
 #include <atalk/afp.h>
+#include <atalk/compat.h>
 #include <atalk/constant_time.h>
 #include <atalk/logger.h>
 #include <atalk/uam.h>

--- a/meson.build
+++ b/meson.build
@@ -273,6 +273,8 @@ netatalk_common_flags = [
     '-Wno-deprecated-declarations',
 ]
 
+netatalk_c_flags = cc.get_supported_arguments('-Werror=implicit-function-declaration')
+
 if host_os == 'linux'
     netatalk_common_flags += '-D_GNU_SOURCE'
 endif
@@ -282,6 +284,7 @@ if build_type == 'debug'
 endif
 
 add_global_arguments(netatalk_common_flags, language: 'c')
+add_global_arguments(netatalk_c_flags, language: 'c')
 
 netatalk_common_link_args = []
 

--- a/meson.build
+++ b/meson.build
@@ -277,6 +277,12 @@ netatalk_c_flags = cc.get_supported_arguments('-Werror=implicit-function-declara
 
 if host_os == 'linux'
     netatalk_common_flags += '-D_GNU_SOURCE'
+elif host_os == 'sunos'
+    netatalk_common_flags += [
+        '-D__EXTENSIONS__',
+        '-D_ISOC9X_SOURCE',
+        '-D_XOPEN_SOURCE=600',
+    ]
 endif
 
 if build_type == 'debug'
@@ -2443,7 +2449,6 @@ if host_os == 'freebsd'
     cdata.set('OPEN_NOFOLLOW_ERRNO', 'EMLINK')
 elif host_os == 'linux'
     use_glibc_at_header = cc.has_header('netatalk/at.h')
-    cdata.set('_GNU_SOURCE', 1)
     if cc.compiles(
         '''
 #include <sys/socket.h>
@@ -2470,10 +2475,7 @@ elif host_os == 'netbsd'
 elif host_os == 'openbsd'
     cdata.set('BSD4_4', 1)
 elif host_os == 'sunos'
-    cdata.set('__EXTENSIONS__', 1)
     cdata.set('__svr4__', 1)
-    cdata.set('_ISOC9X_SOURCE', 1)
-    cdata.set('_XOPEN_SOURCE', 600)
     cdata.set('SOLARIS', 1)
 elif host_os == 'darwin'
     cdata.set('HAVE_BROKEN_DBTOB', 1)

--- a/test/testsuite/afpclient.c
+++ b/test/testsuite/afpclient.c
@@ -1,5 +1,10 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <assert.h>
 #include <atalk/afp.h>
+#include <atalk/compat.h>
 
 #include "afpclient.h"
 #include "testhelper.h"


### PR DESCRIPTION
this emulates a recurring strictness error in Debian and Fedora build wrappers

this also leads to the need to set platform specific feature macros via compiler arguments: the libc prototype is gated by feature macros, and those need to be present from the compiler command line, before any system header in any file

Remove the defining of the same macros in config.h which is arguably a cargo cult carryover from the Autotools build system.

finally, explicitly include a range of header to appease the new stricter compiler flag