### PR TITLE
libatalk: Fallback to ADv2 EAs with autodetect fails

### DIFF
--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -364,7 +364,7 @@ static void check_ea_support(struct vol *vol)
         if (haseas) {
             vol->v_vfs_ea = AFPVOL_EA_SYS;
         } else {
-            vol->v_vfs_ea = AFPVOL_EA_NONE;
+            vol->v_vfs_ea = AFPVOL_EA_AD;
         }
     }
 


### PR DESCRIPTION
If the volume's file system does not support native extended attributes and we are auto detecting support (`ea = ad` isn't explicitly set for the volume), make sure we fall back to using AppleDouble v2 style extended attributes via `AFPVOL_EA_AD`. Previously it was falling back to `AFPVOL_EA_NONE` completely disabling the storage of client extended attributes.