### PR TITLE
docs: replace the C font style with CR in cmark manpages

### DIFF
--- a/doc/manpages/make_man.sh
+++ b/doc/manpages/make_man.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -o pipefail
+
 if [ "$#" -ne 5 ]; then
     echo "Usage: $0 <transcoder> <file> <manpage> <section> <version>"
     exit 1
@@ -16,9 +18,10 @@ transcoder_name=$(basename "${transcoder}")
 echo ".TH \"${man}\" \"${sec}\" \"\" \"Netatalk ${ver}\" \"Netatalk AFP Fileserver Manual\""
 
 if [ "${transcoder_name}" = "pandoc" ]; then
-    ${transcoder} --from commonmark --to man ${input}
+    ${transcoder} --from commonmark --to man "${input}"
 elif [ "${transcoder_name}" = "cmark" ] || [ "${transcoder_name}" = "cmark-gfm" ]; then
-    ${transcoder} --smart --to man ${input}
+    # cleaning up cmark's non-portable code block style
+    ${transcoder} --smart --to man "${input}" | sed 's/\\f\[C\]/\\f[CR]/g'
 else
     echo "Unknown transcoder: ${transcoder_name}"
     exit 1


### PR DESCRIPTION
code blocks in markdown is transcoded to the 'C' font style (Courier monospace) in troff when processed with cmark / cmark-gfm

the groff parser treats this style as invalid for a man page and will throw warning messages, becuase it's a non-standard style

this modification to the filter script replaces the 'C' font styles with 'CR' style in formatted man pages, which aligns with pandoc output