### PR TITLE
libatalk: overhaul copyright headers

### DIFF
--- a/libatalk/adouble/ad_attr.c
+++ b/libatalk/adouble/ad_attr.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 1998 Adrian Sun (asun@zoology.washington.edu)
+ * All rights reserved. See COPYRIGHT.
+ */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif /* HAVE_CONFIG_H */

--- a/libatalk/adouble/ad_date.c
+++ b/libatalk/adouble/ad_date.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 1998 Adrian Sun (asun@zoology.washington.edu)
+ * All rights reserved. See COPYRIGHT.
+ */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif /* HAVE_CONFIG_H */

--- a/libatalk/adouble/ad_size.c
+++ b/libatalk/adouble/ad_size.c
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright (c) 1997 Adrian Sun (asun@zoology.washington.edu)
  * All rights reserved. See COPYRIGHT.
  *

--- a/libatalk/asp/asp_tickle.c
+++ b/libatalk/asp/asp_tickle.c
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 1990,1991 Regents of The University of Michigan.
+ * All Rights Reserved.  See COPYRIGHT.
+ */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif /* HAVE_CONFIG_H */

--- a/libatalk/cnid/cnid_init.c
+++ b/libatalk/cnid/cnid_init.c
@@ -1,6 +1,4 @@
-
 /*
- *
  * Copyright (c) 2003 the Netatalk Team
  * Copyright (c) 2003 Rafal Lewczuk <rlewczuk@pronet.pl>
  *

--- a/libatalk/compat/rquota_xdr.c
+++ b/libatalk/compat/rquota_xdr.c
@@ -1,5 +1,4 @@
 /*
- *
  * taken from the quota-1.55 used on linux. here's the bsd copyright:
  *
  * Copyright (c) 1980, 1990 Regents of the University of California.

--- a/libatalk/dsi/dsi_close.c
+++ b/libatalk/dsi/dsi_close.c
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright (c) 1997 Adrian Sun (asun@zoology.washington.edu)
  * All rights reserved. See COPYRIGHT.
  */

--- a/libatalk/dsi/dsi_getsess.c
+++ b/libatalk/dsi/dsi_getsess.c
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright (c) 1997 Adrian Sun (asun@zoology.washington.edu)
  * All rights reserved. See COPYRIGHT.
  */

--- a/libatalk/dsi/dsi_getstat.c
+++ b/libatalk/dsi/dsi_getstat.c
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright (c) 1997 Adrian Sun (asun@zoology.washington.edu)
  * All rights reserved. See COPYRIGHT.
  */

--- a/libatalk/dsi/dsi_tickle.c
+++ b/libatalk/dsi/dsi_tickle.c
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright (c) 1997 Adrian Sun (asun@zoology.washington.edu)
  * All rights reserved. See COPYRIGHT.
  */

--- a/libatalk/dsi/dsi_write.c
+++ b/libatalk/dsi/dsi_write.c
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright (c) 1997 Adrian Sun (asun@zoology.washington.edu)
  * All rights reserved. See COPYRIGHT.
  *

--- a/libatalk/util/constant_time.c
+++ b/libatalk/util/constant_time.c
@@ -1,3 +1,12 @@
+/*
+ * Copyright (c) 2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif

--- a/libatalk/util/gettok.c
+++ b/libatalk/util/gettok.c
@@ -1,5 +1,4 @@
 /*
- *
  * Copyright (c) 1990,1994 Regents of The University of Michigan.
  * All Rights Reserved.  See COPYRIGHT.
  */

--- a/libatalk/util/logger.c
+++ b/libatalk/util/logger.c
@@ -1,8 +1,3 @@
-
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 /* =========================================================================
 
 logger.c was written by Simon Bazley (sibaz@sibaz.com)
@@ -12,6 +7,10 @@ Just incase, it is, thats the licence I'm applying to this file.
 Netatalk 2001 (c)
 
  */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
 
 #include <ctype.h>
 #include <errno.h>

--- a/libatalk/vfs/acl.c
+++ b/libatalk/vfs/acl.c
@@ -1,6 +1,5 @@
 /*
-  Copyright (c) 2009 Frank Lahm <franklahm@gmail.com>
-  Copyright (c) 2010 Frank Lahm <franklahm@gmail.com>
+  Copyright (c) 2009-2010 Frank Lahm <franklahm@gmail.com>
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
add a number of copyright headers and touch up others in libatalk

ad_attr.c,ad_date.c: files added between netatalk-1.4b2+asun2.1.1 and netatalk-1.4b2+asun2.1.3, ChangeLog notes that they were created by Adrian Sun in 1998

asp_tickle.c: code broken out of asp_getsess.c unchanged between netatalk-1.4b2 and netatalk-1.4b2+asun2.1.0 so applying the same copyright header as the former file

constant_time.c: created by myself recently, adding missing copyright header