### PR TITLE
ci: use OpenBSD native clang, remove nonexistent dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -667,26 +667,22 @@ jobs:
               cmark \
               db-4.6.21p8v0 \
               dbus \
-              gcc-11.2.0p19 \
               heimdal \
               iniparser \
               libev \
               libgcrypt \
               libmagic \
               libtalloc \
-              file \
               mariadb-client \
               meson \
               openldap-client-2.6.10v0 \
               openpam \
-              pkgconfig \
               sqlite3-3.50.7p0 \
               xapian-core
           run: |
             set -e
             meson setup build \
               -Dbuildtype=release \
-              -Dpkg_config_path=/usr/local/lib/pkgconfig \
               -Dwith-eventloop=libev \
               -Dwith-gssapi-path=/usr/local/heimdal \
               -Dwith-kerberos-path=/usr/local/heimdal \


### PR DESCRIPTION
rather than installing gcc, let's build with OpenBSD native clang

remove a few dependencies that are invalid, silently skipped by pkg_add