### PR TITLE
afpd: remove obsolete dbd backend guard for CatSearch

### DIFF
--- a/etc/afpd/catsearch.c
+++ b/etc/afpd/catsearch.c
@@ -980,6 +980,7 @@ static int catsearch_db(const AFPObj *obj,
     static int num_matches;
     int ccr, r;
     int result = AFP_OK;
+    size_t namelen;
     struct path path;
     char *rrbuf = rbuf;
     char buffer[MAXPATHLEN + 2];
@@ -993,14 +994,16 @@ static int catsearch_db(const AFPObj *obj,
     }
 
     if (cur_pos == 0 || *pos == 0) {
-        if (convert_charset(vol->v_volcharset,
-                            vol->v_volcharset,
-                            vol->v_maccharset,
-                            uname,
-                            strlen(uname),
-                            buffer,
-                            MAXPATHLEN,
-                            &flags) == (size_t) -1) {
+        namelen = convert_charset(vol->v_volcharset,
+                                  vol->v_volcharset,
+                                  vol->v_maccharset,
+                                  uname,
+                                  strlen(uname),
+                                  buffer,
+                                  MAXPATHLEN,
+                                  &flags);
+
+        if (namelen == (size_t) -1) {
             LOG(log_error, logtype_afpd, "catsearch_db: conversion error");
             result = AFPERR_MISC;
             goto catsearch_end;
@@ -1010,7 +1013,7 @@ static int catsearch_db(const AFPObj *obj,
         AFP_CNID_START("cnid_find");
         num_matches = cnid_find(vol->v_cdb,
                                 buffer,
-                                strlen(uname),
+                                namelen,
                                 resbuf,
                                 sizeof(resbuf),
                                 NULL);

--- a/etc/afpd/catsearch.c
+++ b/etc/afpd/catsearch.c
@@ -1390,15 +1390,10 @@ static int catsearch_afp(AFPObj *obj _U_, char *ibuf, size_t ibuflen,
 
     if ((c1.rbitmap & (1U << FILPBIT_PDINFO))
             && !(c1.rbitmap & (1U << CATPBIT_PARTIAL))
-            && (strcmp(vol->v_cnidscheme, "dbd") == 0)
-            && (vol->v_flags & AFPVOL_SEARCHDB))
-        /* we've got a name and it's a dbd volume, so search CNID database */
-    {
+            && (vol->v_flags & AFPVOL_SEARCHDB)) {
         ret = catsearch_db(obj, vol, uname, rmatches, &catpos[0],
                            rbuf + 24, &nrecs, &rsize, ext);
-    } else
-        /* perform a slow filesystem tree search */
-    {
+    } else {
         ret = catsearch(obj, vol, vol->v_root, rmatches, &catpos[0], rbuf + 24, &nrecs,
                         &rsize, ext);
     }


### PR DESCRIPTION
until recently, cnid_find was only supported in the dbd backend so this guard was correct, but now all current CNID backends has this API so the guard must be removed

reported by NJRoadfan

additional hardening that was revealed after this fix:

catsearch_db converts the search term before passing it to cnid_find, but continued to use strlen(uname) as the length argument

when conversion changes the byte length, dbd could search a truncated term or read past the converted buffer; use the converted length returned by convert_charset instead