### PR TITLE
meson: prefer sqlite and mysql over dbd as default CNID backend

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -833,12 +833,12 @@ summary_backends = cnid_backends
 
 # Determine default CNID backend
 
-if use_dbd_backend
-    default_backend = 'dbd'
-elif use_sqlite_backend
+if use_sqlite_backend
     default_backend = 'sqlite'
 elif use_mysql_backend
     default_backend = 'mysql'
+elif use_dbd_backend
+    default_backend = 'dbd'
 else
     error('No CNID backends selected for compilation')
 endif


### PR DESCRIPTION
as part of the dbd deprecation effort, set sqlite as the default backend when available, with a fallback to mysql, and finally dbd only when the other two are not available

the documentation is already updated to indicate dbd as a deprecated backend