### PR TITLE
docs: improve manual overview, AFP clients, MacIP gateway

### DIFF
--- a/doc/manpages/man8/macipgw.8.md
+++ b/doc/manpages/man8/macipgw.8.md
@@ -75,6 +75,18 @@ zone.
 
 > Specifies the netmask for the network.
 
+# Client Configuration
+
+Classic Mac TCP/IP clients discover **macipgw** through NBP as an
+*IPGATEWAY* in the configured AppleTalk zone. When a client requests an
+address, **macipgw** leases one from the configured network and returns
+the subnet mask, broadcast address, and optional name server. The first
+host address in the network is reserved for the gateway itself.
+
+Configure routing or NAT on the host system separately if MacIP clients
+should reach IP networks beyond the Netatalk host. **macipgw** only
+creates and manages the tunnel interface used for the MacIP subnet.
+
 # Examples
 
 ## Example: macipgw invocation

--- a/doc/manual/AppleTalk.md
+++ b/doc/manual/AppleTalk.md
@@ -269,6 +269,36 @@ that the configuration of all connected routers is exactly the same
 regarding netranges, published zone names and also the "standard zone"
 per segment
 
+## MacIP Gateway
+
+**macipgw** provides TCP/IP connectivity for Macintosh clients that are
+connected only through AppleTalk, such as LocalTalk or Apple Remote
+Access. MacIP encapsulates IP packets in AppleTalk packets; **macipgw**
+terminates those packets on a tunnel interface and forwards them through
+the host IP stack.
+
+A MacIP gateway needs a dedicated IP subnet for its clients. The first
+host address is reserved for the gateway itself, and the remaining
+addresses are leased to clients that request an address from the MacIP
+server. For example, with a network of 192.168.151.0 and a netmask of
+255.255.255.0, the gateway uses 192.168.151.1.
+
+Example *macipgw.conf*:
+
+    [Global]
+    network = 192.168.151.0
+    netmask = 255.255.255.0
+    nameserver = 8.8.8.8
+    zone = My Zone
+
+Classic Mac TCP/IP clients discover the gateway as an *IPGATEWAY* in the
+configured AppleTalk zone. Configure routing or NAT on the host system
+separately if MacIP clients should reach IP networks beyond the Netatalk
+host.
+
+For further information please have a look at the [macipgw](macipgw.8.html)
+manual page.
+
 ## Printing
 
 Netatalk can act both as a PAP client to

--- a/doc/manual/Configuration.md
+++ b/doc/manual/Configuration.md
@@ -2,12 +2,13 @@
 
 ## Setting up the AFP file server
 
-AFP (the Apple Filing Protocol) is a protocol originally created for Apple Macintosh file services.
-The final revision of the protocol, AFP 3.4, was introduced with OS X Lion (10.7).
+Netatalk's **afpd** daemon provides AFP file services to clients.
+You usually launch the AFP file service daemon through the **netatalk** controller daemon.
+The controller daemon manages the lifecycle of the AFP file service daemon,
+including Zeroconf service registration, and housekeeping for certain CNID backends
+and Spotlight indexing.
 
-Netatalk's **afpd** daemon provides AFP file services to clients,
-including Macs, Apple IIs, and other AFP clients.
-Configuration is managed through the *afp.conf* file,
+Configuration of both the daemons and the AFP volumes are managed through the *afp.conf* file,
 which uses an ini-style syntax.
 
 ### afp.conf

--- a/doc/manual/index.md
+++ b/doc/manual/index.md
@@ -1,15 +1,21 @@
 # Introduction to Netatalk
 
 Netatalk is an Open Source software package that can be used to turn a
-\*NIX machine into a performant and light-weight file server.
-Any computer with an AFP client can connect to a Netatalk server.
-AFP clients include macOS, Classic Mac OS, Apple II ProDOS or GS/OS,
-and other operating systems with 3rd party AFP client software.
+\*NIX machine into a performant and light-weight AFP file server.
 
-It provides a modern TCP/IP transport layer, as well as a traditional
-AppleTalk transport layer for very old Mac and Apple II clients.
+AFP (Apple Filing Protocol) is a network file system protocol originally
+developed by Apple for use in their Macintosh computers. It was the
+primary file sharing protocol for Mac OS for the better part of 30 years.
+AFP 3.4 is the latest version of the protocol, introduced with Mac OS X 10.8
+Mountain Lion. Netatalk can speak AFP 2 and AFP 3, allowing it to support
+a wide range of clients from the latest macOS to very old Classic Mac OS
+and Apple II machines.
 
-Using Netatalk's AFP 3.4 compliant file-server leads to noticeably
+A number of 3rd party AFP client implementations exist for other operating systems,
+including the _Netatalk Client_, which is an improved fork of _afpfs-ng_ that
+is available for Linux, FreeBSD, OpenBSD, NetBSD, and macOS.
+
+Using Netatalk's AFP 3.4 compliant file server leads to noticeably
 higher transmission speeds for macOS clients compared to Samba/NFS,
 while providing users with the best possible Mac-like user experience.
 It can read and write Mac metadata - macOS extended file attributes as
@@ -21,10 +27,17 @@ environments, including Kerberos, ACLs and LDAP. Modern macOS features
 such as Zeroconf (Bonjour) service discovery, Time Machine backups,
 and Spotlight indexed search are provided.
 
+## AppleTalk Services
+
+Netatalk provides a modern TCP/IP transport layer, as well as a traditional
+AppleTalk transport layer for very old Mac and Apple II clients.
+
 For AppleTalk networks with legacy Macs and Apple IIs, Netatalk provides
 a print server, time server, and Apple II network boot server. The print
 server is fully integrated with CUPS, allowing old Macs to discover and
 print to a modern CUPS/AirPrint compatible printer on the network.
+Netatalk can also provide a MacIP gateway, allowing AppleTalk-only
+Macintosh clients to reach TCP/IP networks.
 
 Additionally, Netatalk can be configured as an AppleTalk router through
 its AppleTalk Network Management daemon, providing both segmentation and


### PR DESCRIPTION
- Manual introduction page: paragraph explaining AFP, tout our own Netatalk Client a bit, split out AppleTalk services in a separate section
- Manual configuration page: remove explanation of AFP, add description of the netatalk controller daemon
- Manual appletalk page: add section on macipgw
- macipgw man page: add section on client configuration