### PR TITLE
afpd: fix error handling in afp_exchangefiles and auth_load

### DIFF
--- a/etc/afpd/auth.c
+++ b/etc/afpd/auth.c
@@ -1295,7 +1295,7 @@ int auth_load(AFPObj *obj, const char *path, const char *list)
                 LOG(log_error, logtype_afpd, "uam: %s load failure", p);
             }
         } else {
-            LOG(log_info, logtype_afpd, "uam: uam not found (status=%d)", stat(name, &st));
+            LOG(log_info, logtype_afpd, "uam: uam not found (%s)", strerror(errno));
         }
 
         p = strtok_r(NULL, ", ", &last);

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -2955,7 +2955,8 @@ int afp_exchangefiles(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
 
         if (!AD_META_OPEN(adsp)) {
             if (ad_open(adsp, p, ADFLAGS_HF) != 0) {
-                return -1;
+                err = AFPERR_MISC;
+                goto err_temp_to_dest;
             }
 
             opened_ads = true;
@@ -2963,21 +2964,57 @@ int afp_exchangefiles(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
 
         if (!AD_META_OPEN(addp)) {
             if (ad_open(addp, upath, ADFLAGS_HF) != 0) {
-                return -1;
+                err = AFPERR_MISC;
+
+                if (opened_ads) {
+                    ad_close(adsp, ADFLAGS_HF);
+                }
+
+                goto err_temp_to_dest;
             }
 
             opened_add = true;
         }
 
         if (ad_copy_header(&adtmp, adsp) != 0) {
+            err = AFPERR_MISC;
+
+            if (opened_ads) {
+                ad_close(adsp, ADFLAGS_HF);
+            }
+
+            if (opened_add) {
+                ad_close(addp, ADFLAGS_HF);
+            }
+
             goto err_temp_to_dest;
         }
 
         if (ad_copy_header(adsp, addp) != 0) {
+            err = AFPERR_MISC;
+
+            if (opened_ads) {
+                ad_close(adsp, ADFLAGS_HF);
+            }
+
+            if (opened_add) {
+                ad_close(addp, ADFLAGS_HF);
+            }
+
             goto err_temp_to_dest;
         }
 
         if (ad_copy_header(addp, &adtmp) != 0) {
+            err = AFPERR_MISC;
+
+            if (opened_ads) {
+                ad_close(adsp, ADFLAGS_HF);
+            }
+
+            if (opened_add) {
+                ad_close(addp, ADFLAGS_HF);
+            }
+
             goto err_temp_to_dest;
         }
 


### PR DESCRIPTION
After enabling debugoptimised (and AFP_ASSERT) on all CI workflows the macos workflow started asserting.
These fixes resolve this. Fix confirmed using #3075 

afp_exchangefiles, metadata-swap block (only reached after the file renames, so a wrong error here leaves the volume half-swapped):
- two bare `return -1` returned a non-AFP error code and skipped the rename unwind, leaking the open adoubles; set AFPERR_MISC and goto the unwind path (closing the source adouble we opened first)
- the three ad_copy_header() failure branches jumped to the unwind path without setting err, so a metadata-copy failure rolled back the swap but returned AFP_OK (silent success on a failed exchange); set AFPERR_MISC

auth_load: the uam-not-found log called stat() a second time to print a status, clobbering errno; print strerror(errno) from the original stat.