### PR TITLE
ci: bump dependencies for OpenBSD 7.9 build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -675,9 +675,9 @@ jobs:
               libtalloc \
               mariadb-client \
               meson \
-              openldap-client-2.6.10v0 \
+              openldap-client-2.6.13v0-gssapi \
               openpam \
-              sqlite3-3.50.7p0 \
+              sqlite3 \
               xapian-core
           run: |
             set -e


### PR DESCRIPTION
OpenBSD 7.9 is now the default distribution in the vmactions runner, so a number of port versions need to be adjusted accordingly