### PR TITLE
initscripts: fix OpenRC service script for netatalk

### DIFF
--- a/distrib/initscripts/openrc.netatalk.in
+++ b/distrib/initscripts/openrc.netatalk.in
@@ -8,7 +8,7 @@ description_reload="Reload configuration"
 
 name=$RC_SVCNAME
 command="@sbindir@/${RC_SVCNAME}"
-pidfile=@lockfile_path@
+pidfile="@lockfile_path@/${RC_SVCNAME}"
 
 depend() {
 		need net


### PR DESCRIPTION
Include the full path for the PID file, not just the lockfile path. Only including the lockfile path on Alpine Linux results in OpenRC falsely reporting that the netatalk service has crashed after a few seconds.

I think this may be due to OpenRC trying to use the lockfile directory as the PID file, and failing to do so. This could be occuring during netatalk forking, or some other event/state where OpenRC needs to access the PID file.