### PR TITLE
lantest: test improvements and optimisations, emit CSV aggregates, perf plotter labels

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1069,6 +1069,7 @@ jobs:
       AFP_TEST_ITERATIONS: 20
     outputs:
       slowest: ${{ steps.lantest-summary.outputs.SLOW }}
+      aggregates: ${{ steps.lantest-summary.outputs.AGG }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -1104,6 +1105,35 @@ jobs:
             exit 1
           fi
           echo "CSV lines: $(wc -l < lantest.csv)"
+      - name: Summarize lantest results
+        run: |
+          # Build a readable summary from lantest.csv for the run page.
+          # Per-test rows have a 6-field numeric tail
+          # (Time,Time±,Min,Max,Median,MB/s); the aggregate block is keyed by
+          # the "# Aggregate" marker that afp_lantest emits in CSV mode.
+          {
+            echo "## Lantest results (${{ env.AFP_TEST_ITERATIONS }} iterations)"
+            echo ""
+            echo "### Aggregates"
+            echo "| Metric | Value |"
+            echo "|--------|-------|"
+            awk -F, '
+              /^# Aggregate/ { agg = 1; next }
+              agg && NF == 2 { printf "| %s | %s |\n", $1, $2 }
+            ' lantest.csv
+            echo ""
+            echo "### Per-test median latency (slowest first)"
+            echo "| Test | Median ms | Min | Max | MB/s |"
+            echo "|------|-----------|-----|-----|------|"
+            awk -F, '
+              $(NF) ~ /^[0-9]+$/ && $(NF-1) ~ /^[0-9]+$/ && $(NF-2) ~ /^[0-9]+$/ \
+                && $(NF-3) ~ /^[0-9]+$/ && $(NF-4) ~ /^[0-9.]+$/ && $(NF-5) ~ /^[0-9]+$/ {
+                mbs = $(NF); median = $(NF-1); max = $(NF-2); min = $(NF-3)
+                name = $1; for (i = 2; i <= NF-6; i++) name = name "," $i
+                sub(/ *\[[^]]*\] *$/, "", name)
+                printf "%d\t| %s | %d | %d | %d | %d |\n", median, name, median, min, max, mbs
+              }' lantest.csv | sort -rn | cut -f2-
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Render latency chart (PNG)
         run: |
           # fonts-dejavu-core: the chart scripts request "DejaVu Sans"
@@ -1120,6 +1150,7 @@ jobs:
             --subtitle "commit ${SHORT_SHA} · candle: min–max wick, mean±σ box, median line" \
             --meta afp=3.4 \
             --meta iterations=${{ env.AFP_TEST_ITERATIONS }} \
+            --meta quantum_kb=1024 \
             --meta dircache_mode=arc \
             --meta dircache_size=65536 \
             --meta dircache_validation_freq=100
@@ -1140,10 +1171,21 @@ jobs:
               printf "%d\t%s\n", median, name
             }' lantest.csv | sort -rn | head -5 \
             | awk -F'\t' '{ printf "| %s | %s |\n", $2, $1 }')
+          # Average time per AFP op (emitted by afp_lantest in CSV mode under
+          # the "# Aggregate" marker) as a single inline stat for the comment.
+          AGG=$(awk -F, '
+            /^# Aggregate/ { agg = 1; next }
+            agg && $1 == "Avg time per AFP op (ms)" {
+              printf "**Avg time per AFP op: %s ms**", $2
+            }
+          ' lantest.csv)
           {
             echo "SLOW<<EOFSLOW"
             echo "$SLOW"
             echo "EOFSLOW"
+            echo "AGG<<EOFAGG"
+            echo "$AGG"
+            echo "EOFAGG"
           } >> "$GITHUB_OUTPUT"
       - name: Upload lantest artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -1343,6 +1385,8 @@ jobs:
             ## ⏱️ [Lantest](https://netatalk.io/manual/en/afp_lantest.1) (AFP 3.4) - LatencyGraph
 
             [![Lantest latency](https://netatalk.github.io/netatalk/lantest/pr-${{ github.event.pull_request.number }}.png)](https://netatalk.github.io/netatalk/lantest/pr-${{ github.event.pull_request.number }}.png)
+
+            ${{ needs.latencygraph-lantest.outputs.aggregates }}
 
             <details>
             <summary>🐢 Slowest operations (median)</summary>

--- a/contrib/scripts/plot_lantest.pl
+++ b/contrib/scripts/plot_lantest.pl
@@ -48,31 +48,30 @@ use Getopt::Long qw(GetOptions);
 my $BACKGROUND_COLOR = '#F6F8FA';
 my $BOX_COLOR        = '#1f77b4';
 my $MEDIAN_COLOR     = '#d62728';
-# Max caps in the median hue but alpha-blended (#80… = 50% transparent)
-# so they read lighter than the solid median line.
+# Max caps alpha-blended (#80 = 50% transparent) so they read lighter.
 my $MAX_COLOR = '#80d62728';
-# Coefficient-of-variation (jitter) bars in the lower panel.
 my $COV_COLOR = '#ff7f0e';
 
 # 11 x 5.2 inches at 130 dpi, matching the former matplotlib renderer.
 my $WIDTH_PX  = 1430;
 my $HEIGHT_PX = 590;
 
-# A summary data row ends with the numeric columns the candlestick needs:
-#   ...,Time_ms,Time±,Min_ms,Max_ms,Median_ms,MB/s
-# Match those trailing fields so a comma-containing test name is left intact.
+# Match the 6 trailing numeric fields so a comma-containing test name (group
+# 1) is left intact: Time_ms,Time±,Min_ms,Max_ms,Median_ms,MB/s.
 my $ROW_TAIL_RE = qr/^(.+),(\d+),([\d.]+),(\d+),(\d+),(\d+),(\d+)\s*$/;
 
 # Map each lantest test (matched by a substring of its full name) to a short
 # axis label. Order matters: first matching substring wins.
 my @SHORT_LABELS = (
-                    ['Open, stat and read'    => 'Open/stat/read'],
                     ['Writing one large file' => 'Write 100MB'],
                     ['Reading one large file' => 'Read 100MB'],
-                    ['Locking/Unlocking'      => 'Lock/unlock'],
-                    ['Creating dir with'      => 'Create 2000'],
-                    ['Enumerate dir'          => 'Enumerate'],
-                    ['Deleting dir'           => 'Delete 2000'],
+                    ['Creating 2000 files'    => 'Create 2k'],
+                    ['Writing 1024 bytes'     => 'Write 2k'],
+                    ['Lock then unlock 2000'  => 'Fork lock 2k'],
+                    ['Stat, open, read'       => 'Stat/open/read 2k'],
+                    ['Enumerate dir'          => 'Enumerate 2k'],
+                    ['Deleting 2000 files'    => 'Delete 2k'],
+                    ['Byte-range lock/unlock' => 'Byte lock 2k'],
                     ['Create directory tree'  => 'Create tree'],
                     ['Directory cache hits'   => 'Dircache hits'],
                     ['Mixed cache operations' => 'Mixed cache'],
@@ -80,9 +79,8 @@ my @SHORT_LABELS = (
                     ['Cache validation'       => 'Cache validate'],
 );
 
-# Map a verbose lantest test name to a short axis tick label. Falls back to
-# the name with its trailing "[N AFP ops]" annotation stripped if no keyword
-# matches (keeps new/renamed tests readable).
+# Map a verbose test name to a short axis label, falling back to the name with
+# its trailing "[N AFP ops]" annotation stripped if no keyword matches.
 sub short_label {
     my ($name) = @_;
     for my $pair (@SHORT_LABELS) {
@@ -99,9 +97,7 @@ sub short_label {
     return $stripped;
 }
 
-# Parse afp_lantest CSV into an ordered list of per-test hashes. Each hash
-# has: name, label, mean, stddev, min, max, median. Rows are returned in
-# file order (the test execution order).
+# Parse afp_lantest CSV into per-test hashes in file (execution) order.
 sub parse_csv {
     my ($path) = @_;
     my @tests;
@@ -124,7 +120,7 @@ sub parse_csv {
     return \@tests;
 }
 
-# Compose the run-config lines shown under the chart subtitle.
+# Run-config lines shown under the chart subtitle.
 sub build_info_lines {
     my ($tests, $meta) = @_;
     my @lines = ('Tests: ' . scalar(@$tests));
@@ -132,7 +128,8 @@ sub build_info_lines {
         my $warm = $meta->{warmup} ? " +$meta->{warmup} warmup" : '';
         push @lines, "Iterations: $meta->{iterations}$warm";
     }
-    push @lines, "AFP: $meta->{afp}" if $meta->{afp};
+    push @lines, "AFP: $meta->{afp}"               if $meta->{afp};
+    push @lines, "Quantum: $meta->{quantum_kb} KB" if $meta->{quantum_kb};
     my @dc;
     push @dc, uc $meta->{dircache_mode}     if $meta->{dircache_mode};
     push @dc, "size $meta->{dircache_size}" if $meta->{dircache_size};
@@ -142,8 +139,7 @@ sub build_info_lines {
     return @lines;
 }
 
-# Escape a string for embedding in a double-quoted gnuplot string.
-# Literal newlines become \n escapes (gnuplot renders them as line breaks).
+# Escape a string for a double-quoted gnuplot string (newline -> \n escape).
 sub gp_quote {
     my ($s) = @_;
     $s =~ s/\\/\\\\/g;
@@ -152,7 +148,6 @@ sub gp_quote {
     return $s;
 }
 
-# Render the latency candlestick chart to <out_base>.png via gnuplot.
 sub plot {
     my ($tests, $out_base, $title, $subtitle, $meta) = @_;
     if (!@$tests) {
@@ -168,14 +163,11 @@ sub plot {
     }
     my $y_lo = $data_min / 1.6;
     $y_lo = 0.1 if $y_lo < 0.1;
-    # Same padding as the matplotlib renderer; the legend is opaque and
-    # drawn on top of the data, so it needs no extra headroom.
     my $y_hi = $data_max * 1.6;
 
-    # Candlestick columns: x, box_lo, wick_lo, box_hi, wick_hi, median, cov.
-    # Box = mean ± 1 stddev, clamped to the min..max wick. cov is the
-    # coefficient of variation (stddev/mean, as a percent) — a normalised
-    # jitter measure plotted as bars in the lower panel.
+    # Columns per candlestick: x, box_lo, wick_lo, box_hi, wick_hi, median,
+    # cov. Box = mean ± 1 stddev clamped to the wick; cov (stddev/mean %) is
+    # the normalized jitter plotted as bars in the lower panel.
     my $rows    = '';
     my $cov_max = 0;
     my (@tics, @blank_tics);
@@ -194,9 +186,8 @@ sub plot {
     }
     my $tics       = join(', ', @tics);
     my $blank_tics = join(', ', @blank_tics);
-    # Headroom above the tallest jitter bar; floor so an all-quiet run still
-    # gives the panel a sensible scale. A coarse tick interval keeps the thin
-    # band uncluttered (≈2 ticks: one near the top, plus 0).
+    # Headroom above the tallest jitter bar (floor for an all-quiet run); a
+    # coarse tick interval keeps the thin band uncluttered.
     my $cov_hi  = $cov_max > 0 ? $cov_max * 1.25 : 5;
     my $cov_tic = $cov_hi > 20 ? 20              : ($cov_hi > 10 ? 10 : 5);
 
@@ -213,49 +204,41 @@ sub plot {
     my $gp_bin = $ENV{GNUPLOT_BIN} || 'gnuplot';
     open my $gp, '|-', $gp_bin or die "cannot run $gp_bin: $!\n";
     print $gp <<"EOF";
-# DejaVu Sans is matplotlib's default face; pangocairo falls back to the
-# system sans when it is absent, so this renders everywhere. The 1.8
-# fontscale/linewidth/pointscale matches matplotlib's dpi=130 rendering
-# (130/72), so point sizes below mirror the old matplotlib values.
+# fontscale/linewidth/pointscale 1.8 matches matplotlib's dpi=130 (130/72),
+# so the point sizes below mirror the old matplotlib values. DejaVu Sans is
+# matplotlib's default; pangocairo falls back to system sans if it is absent.
 set terminal pngcairo noenhanced size $WIDTH_PX,$HEIGHT_PX \\
     fontscale 1.8 linewidth 1.8 pointscale 1.8 \\
     background rgb "$BACKGROUND_COLOR" font "DejaVu Sans,8"
 set output "@{[ gp_quote($png) ]}"
 
-# Full matplotlib-style frame: box border, ticks outward on left/bottom.
 set border 15 linewidth 0.8 linecolor rgb "#333333"
 set tics nomirror out scale 0.6
 
-# Manually placed title block above the panels (a fixed gap between the bold
-# title and the subtitle, like the matplotlib layout).
+# Title block manually placed above the panels for a fixed title/subtitle gap.
 set label 1 "$suptitle" at screen 0.5, screen 0.95 center \\
     font "DejaVu Sans:Bold,12"
 set label 2 "$header" at screen 0.5, screen 0.885 center \\
-    font "DejaVu Sans,6.5" textcolor rgb "#222222"
+    font "DejaVu Sans,5.5" textcolor rgb "#222222"
 
-# Shared x range and fixed side margins so the two stacked panels line up
-# exactly (pinning lmargin/rmargin stops gnuplot from auto-sizing each panel
-# to its own y-tick label width, which would misalign the columns).
+# Pin lmargin/rmargin so the two stacked panels share an x extent (otherwise
+# gnuplot sizes each to its own y-tick width and the columns misalign).
 set xrange [-0.6:$xmax]
 set lmargin at screen 0.075
 set rmargin at screen 0.98
 set boxwidth 0.5
-# Y-axis titles as rotated labels pinned at a fixed screen x, one centred on
-# each panel's height. Using screen coords (not per-panel "set ylabel") keeps
-# both titles vertically aligned regardless of differing tick-label widths
-# (e.g. "1000" upper vs "20" lower). Upper panel spans y 0.34-0.84 (mid 0.59),
-# lower spans 0.18-0.30 (mid 0.24).
+# Y-axis titles as screen-pinned rotated labels (not per-panel "set ylabel"),
+# centered on each panel's height so they align despite differing tick widths.
+# Upper panel y 0.34-0.84 (mid 0.59), lower 0.18-0.30 (mid 0.24).
 set label 5 "Time (ms) — lower is faster" at screen 0.022, screen 0.59 \\
     center rotate by 90 font "DejaVu Sans,7"
 set label 6 "Jitter (CoV %)" at screen 0.022, screen 0.24 \\
     center rotate by 90 font "DejaVu Sans,7"
-# Caption defining CoV, in the freed space below the lower panel's x labels.
 set label 7 \\
-    "Coefficient of Variation (CoV) = stddev ÷ mean, as a normalised percent" \\
+    "Coefficient of Variation (CoV) = stddev ÷ mean, as a normalized percent" \\
     at screen 0.5, screen 0.06 center font "DejaVu Sans,6.5" \\
     textcolor rgb "#444444"
-# Fine dotted grid matching the speedtest chart. Major lines at #BBBBBB;
-# the per-decade minor log lines a touch fainter so they don't read heavy.
+# Dotted grid; minor (per-decade log) lines fainter so they don't read heavy.
 set grid ytics mytics linetype 1 dashtype (1,2) linewidth 1 \\
     linecolor rgb "#BBBBBB", linetype 1 dashtype (1,2) linewidth 1 \\
     linecolor rgb "#DDDDDD"
@@ -266,29 +249,29 @@ EOD
 
 set multiplot
 
-# --- Upper panel: per-test latency candlesticks. Log y compresses the
-# range, so it needs less height than a linear plot would. ---
+# --- Upper panel: latency candlesticks (~70%; log y needs less height) ---
 set tmargin at screen 0.84
 set bmargin at screen 0.34
 set logscale y
 set yrange [$y_lo:$y_hi]
-# Plain millisecond integers on the log axis (no 10^n scientific ticks).
 set format y "%g"
 set ytics font ",6"
-# x tick marks are shared, but only the lower panel labels them (blank
-# labels here keep the tick positions aligned across the two panels).
+# Blank x labels here; the lower panel labels the shared ticks.
 set xtics ($blank_tics)
-# Legend pinned to the free top-left of the outer canvas (above the panel,
-# left of the centred title/subtitle) so it sits entirely outside the plot
-# area and never overlaps a candle.
+# Vertical dividers bracketing the shared-file pipeline (Create..Delete 2k),
+# drawn in both panels so the related series reads as one group.
+set arrow 1 from 1.5, graph 0 to 1.5, graph 1 nohead \\
+    dashtype (4,3) linewidth 1 linecolor rgb "#999999" front
+set arrow 2 from 7.5, graph 0 to 7.5, graph 1 nohead \\
+    dashtype (4,3) linewidth 1 linecolor rgb "#999999" front
+# Legend in the free top-left outer canvas, outside the plot area so it never
+# overlaps a candle.
 set key at screen 0.005, screen 0.995 top left Left reverse samplen 1.5 \\
     width -1 spacing 1.1 font ",6" \\
     box linewidth 0.6 linecolor rgb "#CCCCCC" opaque fillcolor rgb "#F5F5F5"
 
-# Whisker caps at 0.48 of boxwidth = matplotlib's ±0.12 caps vs 0.5 box.
-# A dotted cap marks the max (slowest of the runs) at the top of the range.
-# The keyentry items reproduce matplotlib's legend: one entry per candle
-# element rather than one per plot command.
+# Whisker caps at 0.48 boxwidth = matplotlib's ±0.12 caps. The dotted cap is
+# the max (slowest run). keyentry items give one legend row per candle element.
 plot \$DATA using 1:2:3:5:4 with candlesticks whiskerbars 0.48 \\
         linecolor rgb "$BOX_COLOR" linewidth 1 \\
         fillstyle transparent solid 0.35 border lc rgb "$BOX_COLOR" \\
@@ -297,6 +280,8 @@ plot \$DATA using 1:2:3:5:4 with candlesticks whiskerbars 0.48 \\
         linewidth 2 linecolor rgb "$MEDIAN_COLOR" notitle, \\
      \$DATA using (\$1 - 0.24):5:(0.48):(0.0) with vectors nohead \\
         linewidth 1 dashtype (2,1) linecolor rgb "$MAX_COLOR" notitle, \\
+     \$DATA using 1:5:(sprintf("%d", \$6)) with labels \\
+        offset 0,0.6 font ",5" textcolor rgb "$MEDIAN_COLOR" notitle, \\
      keyentry with lines linecolor rgb "$BOX_COLOR" linewidth 1 \\
         title "min–max range", \\
      keyentry with boxes fillstyle transparent solid 0.35 \\
@@ -306,8 +291,7 @@ plot \$DATA using 1:2:3:5:4 with candlesticks whiskerbars 0.48 \\
      keyentry with lines linewidth 1 dashtype (2,1) \\
         linecolor rgb "$MAX_COLOR" title "max (slowest run)"
 
-# --- Lower panel: jitter (coefficient of variation) bars. A thin band —
-# only a rough magnitude is needed, so it stays narrow. ---
+# --- Lower panel: jitter (CoV) bars (~20%, a thin band) ---
 unset label 1
 unset label 2
 unset logscale y
@@ -316,13 +300,9 @@ set tmargin at screen 0.30
 set bmargin at screen 0.18
 set yrange [0:$cov_hi]
 set format y "%g"
-# Few ticks — the panel is a thin band where only rough magnitude matters.
 set ytics $cov_tic font ",6"
-# Only this lower panel labels the shared x ticks (the test names).
-set xtics rotate by 15 right font ",6" ($tics)
-# Narrower than the 0.5-wide candle boxes (so the jitter panel reads as a
-# distinct mark, not a mimic of the upper panel's mean±σ boxes) but wide
-# enough to register as bars.
+set xtics rotate by 12 right font ",6" ($tics)
+# Narrower than the 0.5 candle boxes so the jitter bars read as a distinct mark.
 set boxwidth 0.3
 plot \$DATA using 1:7 with boxes \\
         fillstyle solid 0.7 border lc rgb "$COV_COLOR" \\

--- a/contrib/scripts/plot_speedtest.pl
+++ b/contrib/scripts/plot_speedtest.pl
@@ -43,7 +43,7 @@ use strict;
 use warnings;
 use Getopt::Long qw(GetOptions);
 
-# Operations in the order the speedtest runs them, with stable colours so
+# Operations in the order the speedtest runs them, with stable colors so
 # the chart reads the same across commits.
 my @OPERATIONS = qw(Read Write Copy ServerCopy);
 my %OP_COLORS = (
@@ -64,12 +64,9 @@ my $HEIGHT_PX = 676;
 # Column header line that immediately precedes the data rows.
 my $COLUMN_HEADER_PREFIX = 'file_size_bytes,';
 
-# Parse a speedtest CSV capture. Returns (results, meta) where:
-#   * results = {operation => [row_hash, ...]}, each row_hash with keys
-#     size_bytes, mean, median, min, max; rows sorted by ascending size.
-#   * meta = hash of run metadata derived from the capture: "iterations"
-#     (max per-iteration index seen) plus any key=value pairs from an
-#     optional "# Config: k=v,k=v" line emitted by the tool.
+# Parse a speedtest CSV capture into (results, meta): results = {op => [rows
+# sorted by size]}; meta = run metadata (iterations from the max per-iteration
+# index seen, plus any key=value pairs from an optional "# Config:" line).
 sub parse_csv {
     my ($path) = @_;
     my (%results, %meta);
@@ -148,7 +145,7 @@ sub format_size {
     return sprintf('%dM', $kib / 1024.0 + 0.5);
 }
 
-# Known operations first (stable colour/order), then any unexpected ones.
+# Known operations first (stable color/order), then any unexpected ones.
 sub ordered_ops {
     my ($results) = @_;
     my @ops = grep { $results->{$_} } @OPERATIONS;
@@ -159,16 +156,12 @@ sub ordered_ops {
     return @ops;
 }
 
-# Compose the run-config lines shown in the chart's info box. Values come
-# from the CSV where available (size range, iterations) and from --meta
-# key=value pairs the caller injects for things the CSV cannot carry
-# (quantum, ARC dircache, AFP version). Missing values are omitted rather
-# than guessed.
+# Run-config lines shown in the chart's info box, from the CSV and --meta.
+# Missing values are omitted rather than guessed. Size sweep is omitted (the
+# X axis already shows the range).
 sub build_info_lines {
     my ($results, $meta) = @_;
     my @ops = ordered_ops($results);
-
-    # Size sweep is omitted here — the X axis already shows the range.
     my @lines;
     if ($meta->{iterations}) {
         my $warm = $meta->{warmup} ? " +$meta->{warmup} warmup" : '';
@@ -186,8 +179,7 @@ sub build_info_lines {
     return @lines;
 }
 
-# Escape a string for embedding in a double-quoted gnuplot string.
-# Literal newlines become \n escapes (gnuplot renders them as line breaks).
+# Escape a string for a double-quoted gnuplot string (newline -> \n escape).
 sub gp_quote {
     my ($s) = @_;
     $s =~ s/\\/\\\\/g;
@@ -196,7 +188,6 @@ sub gp_quote {
     return $s;
 }
 
-# Render the throughput-vs-size chart to <out_base>.png via gnuplot.
 sub plot {
     my ($results, $out_base, $title, $subtitle, $baseline, $meta) = @_;
     my @ordered = ordered_ops($results);
@@ -225,27 +216,23 @@ sub plot {
         }
         $blocks .= "EOD\n";
 
-        # min..max band gives a sense of run-to-run variance.
+        # min..max band shows run-to-run variance.
         push @bands,
           "\$$tag using 1:3:4 with filledcurves "
           . "fillcolor rgb \"$color\" fillstyle transparent solid 0.12 "
           . 'notitle';
-        # Mean throughput line.
         push @meancurves,
           "\$$tag using 1:2 with linespoints linewidth 2 pointtype 7 "
           . "pointsize 0.5 linecolor rgb \"$color\" notitle";
-        # Max (best run) traces the top of the band, drawn as a dotted line
-        # in the op colour but alpha-blended (#80… = 50% transparent) so
-        # it reads lighter than the solid mean.
+        # Max (best run) traces the band top, alpha-blended (#80 = 50%
+        # transparent) so it reads lighter than the solid mean.
         my $light = '#80' . substr($color, 1);
         push @maxes,
           "\$$tag using 1:4 with lines dashtype (2,1) linewidth 1 " . "linecolor rgb \"$light\" notitle";
 
-        # Two horizontal references per op: the mean of the per-size mean
-        # series as a solid line (matching the solid mean curve) and the mean
-        # of the max series as a dotted line (matching the dotted max hats).
-        # Value labels sit just inside the plot edges so they never overlap
-        # the Y ticks.
+        # Two horizontal references per op: solid = mean of the per-size means
+        # (pairs with the solid mean curve), dotted = mean of the maxes (pairs
+        # with the dotted max hats).
         my ($sum_mean, $sum_max) = (0, 0);
         for my $r (@$rows) {
             $sum_mean += $r->{mean};
@@ -263,10 +250,9 @@ sub plot {
                   '%s with lines dashtype (2,1) linewidth 1 linecolor rgb "%s" ' . 'notitle',
                   $avg_max, $light
           );
-        # "boxed" gives the matplotlib-style white backing behind the value
-        # so it stays readable over the grid (see set style textbox). The
-        # avg-mean label is left-anchored at the Y axis; the avg-max label
-        # is right-aligned (the right edge) so the two never collide.
+        # Value labels: avg-mean left-anchored at the Y axis, avg-max
+        # right-anchored at the right edge, so the two never collide. "boxed"
+        # gives a white backing (see set style textbox) for grid readability.
         push @labels,
           sprintf(
                     'set label %d "%.0f" at graph 0.012, first %s left front '
@@ -280,8 +266,8 @@ sub plot {
                   $idx + 30, $avg_max, $avg_max, $color
           );
 
-        # Legend: only the per-op mean curve (the avg-max/quantum overlays are
-        # explained by the on-chart labels, keeping the key compact).
+        # Legend: only the per-op mean curve; the avg-max/quantum overlays are
+        # explained by the on-chart labels, keeping the key compact.
         push @keyentries,
           sprintf(
                     'keyentry with linespoints linewidth 2 pointtype 7 '
@@ -289,9 +275,8 @@ sub plot {
                   $color, gp_quote($op)
           );
 
-        # Mark the dircache quantum (1 MB) on the Read curve: label the
-        # data point at exactly 1 MiB so the rfork-cache boundary is
-        # visible on the chart.
+        # Mark the dircache quantum (1 MiB) on the Read curve so the
+        # rfork-cache boundary is visible.
         if ($op eq 'Read') {
             for my $r (@$rows) {
                 next unless $r->{size_bytes} == 1024 * 1024;
@@ -355,21 +340,18 @@ sub plot {
     my $gp_bin = $ENV{GNUPLOT_BIN} || 'gnuplot';
     open my $gp, '|-', $gp_bin or die "cannot run $gp_bin: $!\n";
     print $gp <<"EOF";
-# DejaVu Sans is matplotlib's default face; pangocairo falls back to the
-# system sans when it is absent, so this renders everywhere. The 1.8
-# fontscale/linewidth/pointscale matches matplotlib's dpi=130 rendering
-# (130/72), so point sizes below mirror the old matplotlib values.
+# fontscale/linewidth/pointscale 1.8 matches matplotlib's dpi=130 (130/72),
+# so the point sizes below mirror the old matplotlib values. DejaVu Sans is
+# matplotlib's default; pangocairo falls back to system sans if it is absent.
 set terminal pngcairo noenhanced size $WIDTH_PX,$HEIGHT_PX \\
     fontscale 1.8 linewidth 1.8 pointscale 1.8 \\
     background rgb "$BACKGROUND_COLOR" font "DejaVu Sans,7"
 set output "@{[ gp_quote($png) ]}"
 
-# Full matplotlib-style frame: box border, ticks outward on left/bottom.
 set border 15 linewidth 0.8 linecolor rgb "#333333"
 set tics nomirror out scale 0.6
 
-# Reserve the top band for the manually placed title block (a fixed gap
-# between the bold title and the subtitle, like the matplotlib layout).
+# Title block manually placed above the plot for a fixed title/subtitle gap.
 set tmargin at screen 0.84
 set bmargin at screen 0.12
 set label 1 "$suptitle" at screen 0.5, screen 0.95 center \\
@@ -378,27 +360,21 @@ set label 2 "$header" at screen 0.5, screen 0.885 center \\
     font "DejaVu Sans,5.5" textcolor rgb "#222222"
 
 set logscale x 2
-# Tiny right-margin factor so the boundary tick label is not clipped.
+# 1.001 factor so the boundary tick label is not clipped.
 set xrange [$all_sizes[0]:@{[ $all_sizes[-1] * 1.001 ]}]
 set xtics font ",7" ($tics)
 set xlabel "File size"
 set ylabel "Throughput (MB/s)"
-# Fine dotted grid matching the lantest chart. Major lines at #BBBBBB;
-# minor lines a touch fainter so they don't read heavy.
+# Dotted grid; minor lines fainter so they don't read heavy.
 set grid xtics ytics mxtics mytics linetype 1 dashtype (1,2) linewidth 1 \\
     linecolor rgb "#BBBBBB", linetype 1 dashtype (1,2) linewidth 1 \\
     linecolor rgb "#DDDDDD"
-# Legend pinned to the free top-left of the outer canvas (above the plot,
-# left of the centred title/subtitle) so it sits entirely outside the plot
-# area and never overlaps a data curve.
+# Legend in the free top-left outer canvas, outside the plot area.
 set key at screen 0.005, screen 0.995 top left Left reverse samplen 1.5 \\
     width -1 spacing 1.1 font ",6" \\
     box linewidth 0.6 linecolor rgb "#CCCCCC" opaque fillcolor rgb "#F5F5F5"
-# White backing for the boxed mean-value labels (matplotlib bbox style).
 set style textbox opaque fillcolor rgb "#FFFFFF" noborder margins 0.6,0.6
-# Column headers over the two value-label stacks. Each value is a mean
-# across the size sweep: "avg mean" at the left (Y axis), "avg max" at
-# the right edge.
+# Column headers over the two value-label stacks (means across the sweep).
 set label 3 "avg mean" at graph 0.012, graph 1.02 left front \\
     font "DejaVu Sans:Bold,6" textcolor rgb "#444444"
 set label 4 "avg max" at graph 0.988, graph 1.02 right front \\

--- a/doc/manpages/man1/afp_lantest.1.md
+++ b/doc/manpages/man1/afp_lantest.1.md
@@ -56,7 +56,7 @@ features.
 : Server hostname or IP address (default: localhost)
 
 **-K**
-: Run cache-focused tests only (tests 9-12)
+: Run cache-focused tests only (tests 11-14)
 
 **-n** *iterations*
 : Number of test iterations to run (default: 2). For iterations > 5 outliers will be removed
@@ -91,45 +91,55 @@ Configure the UAM in netatalk's afp.conf:
 
 The following tests are available:
 
-**(1) Opening, stating and reading 512 bytes from 1000 files**
-: Tests basic file access patterns with many small operations
+Most tests operate on a shared set of 2000 files, normalized so their timings
+are comparable. Tests 3-8 form a pipeline over the same 2000 files (create,
+write, lock, read, enumerate, delete); selecting any of them implies test 3.
 
-**(2) Writing one large file**
+**(1) Writing one large file**
 : Measures sustained write performance
 
-**(3) Reading one large file**
+**(2) Reading one large file**
 : Measures sustained read performance
 
-**(4) Locking/Unlocking 10000 times each**
-: Tests file locking performance
+**(3) Creating 2000 files**
+: Tests file creation performance
 
-**(5) Creating dir with 2000 files**
-: Tests directory creation and file creation performance
+**(4) Writing 1024 bytes to 2000 files**
+: Tests write performance over many small files (implies test 3)
 
-**(6) Enumerate dir with 2000 files**
-: Tests directory enumeration with many files
+**(5) Lock then unlock 2000 open forks**
+: Tests refnum lookup and lock setup against a full open-fork table (implies test 3)
 
-**(7) Deleting dir with 2000 files**
-: Tests directory and file deletion performance
+**(6) Stat, open, read 512 bytes, close 2000 files**
+: Tests basic file access patterns with many small operations (implies tests 3, 4)
 
-**(8) Create directory tree with 1000 dirs**
-: Tests nested directory creation
+**(7) Enumerate dir with 2000 files**
+: Tests directory enumeration with many files (implies test 3)
 
-**(9) Directory cache hits [CACHE]**
-: Tests directory and file lookup performance (1000 dirs + 10000 files)
+**(8) Deleting 2000 files**
+: Tests file deletion performance (implies test 3)
 
-**(10) Mixed cache operations [CACHE]**
-: Tests mixed create/stat/enum/delete operations
+**(9) Byte-range lock/unlock 2000 ranges in one fork**
+: Tests per-fork byte-range lock tracking with many locks held at once
 
-**(11) Deep path traversal [CACHE]**
-: Tests performance with deep directory structures
+**(10) Create directory tree with 1000 dirs**
+: Tests nested directory creation (10 x 10 x 10)
 
-**(12) Cache validation [CACHE]**
-: Tests directory cache validation mechanisms
+**(11) Directory cache hits [CACHE]**
+: Tests directory and file lookup performance (20 dirs x 100 files)
+
+**(12) Mixed cache operations [CACHE]**
+: Tests mixed create/stat/enum/delete operations over 1000 files
+
+**(13) Deep path traversal [CACHE]**
+: Tests 100 walks of a 20-level deep directory tree
+
+**(14) Cache validation [CACHE]**
+: Tests cache revalidation over 2000 files (3 metadata lookups each)
 
 ## Cache-Focused Tests
 
-Tests 9-12 are specifically designed to highlight directory cache performance improvements in
+Tests 11-14 are specifically designed to highlight directory cache performance improvements in
 netatalk. These tests benefit significantly from optimized cache validation and probabilistic
 validation features. Use the **-K** option to run only these cache-focused tests.
 
@@ -170,79 +180,61 @@ For example, to run as root;
     Found privilege-dropped afpd process for user 'test': PID 36
     IO monitoring enabled (afpd: 36, cnid_dbd: 40)
 
-    Run 1 => Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]        4230 ms
-            IO Operations; afpd: 6000 READs, 7002 WRITEs | cnid_dbd: 0 READs, 2 WRITEs
-    Run 1 => Writing one large file [103 AFP ops]                                  166 ms for 100 MB (avg. 631 MB/s)
-            IO Operations; afpd: 0 READs, 299 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 1 => Reading one large file [102 AFP ops]                                   55 ms for 100 MB (avg. 1906 MB/s)
-            IO Operations; afpd: 100 READs, 100 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 1 => Locking/Unlocking 10000 times each [20,000 AFP ops]                   859 ms
-            IO Operations; afpd: 0 READs, 20000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 1 => Creating dir with 2000 files [4,000 AFP ops]                         4927 ms
-            IO Operations; afpd: 2000 READs, 10006 WRITEs | cnid_dbd: 4 READs, 6151 WRITEs
-    Run 1 => Enumerate dir with 2000 files [~51 AFP ops]                          1740 ms
-            IO Operations; afpd: 1959 READs, 50 WRITEs | cnid_dbd: 0 READs, 2 WRITEs
-    Run 1 => Deleting dir with 2000 files [2,000 AFP ops]                         3362 ms
-            IO Operations; afpd: 4000 READs, 4004 WRITEs | cnid_dbd: 4 READs, 6177 WRITEs
-    Run 1 => Create directory tree with 1000 dirs [1,110 AFP ops]                 2081 ms
-            IO Operations; afpd: 0 READs, 4445 WRITEs | cnid_dbd: 2 READs, 2279 WRITEs
-    Run 1 => Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]        5552 ms
-            IO Operations; afpd: 10000 READs, 11100 WRITEs | cnid_dbd: 0 READs, 100 WRITEs
-    Run 1 => Mixed cache operations (create/stat/enum/delete) [820 AFP ops]       1215 ms
-            IO Operations; afpd: 820 READs, 1623 WRITEs | cnid_dbd: 0 READs, 1203 WRITEs
-    Run 1 => Deep path traversal (nested directory navigation) [3,500 AFP ops]    1835 ms
-            IO Operations; afpd: 2500 READs, 3550 WRITEs | cnid_dbd: 0 READs, 50 WRITEs
-    Run 1 => Cache validation efficiency (metadata changes) [30,000 AFP ops]     14559 ms
-            IO Operations; afpd: 30000 READs, 30100 WRITEs | cnid_dbd: 0 READs, 100 WRITEs
-    Run 2 => Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]        3801 ms
-            IO Operations; afpd: 6000 READs, 7005 WRITEs | cnid_dbd: 0 READs, 5 WRITEs
-    Run 2 => Writing one large file [103 AFP ops]                                  115 ms for 100 MB (avg. 911 MB/s)
-            IO Operations; afpd: 0 READs, 299 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 2 => Reading one large file [102 AFP ops]                                   47 ms for 100 MB (avg. 2231 MB/s)
-            IO Operations; afpd: 100 READs, 100 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 2 => Locking/Unlocking 10000 times each [20,000 AFP ops]                  1061 ms
-            IO Operations; afpd: 0 READs, 20000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 2 => Creating dir with 2000 files [4,000 AFP ops]                         4739 ms
-            IO Operations; afpd: 2000 READs, 10005 WRITEs | cnid_dbd: 7 READs, 6141 WRITEs
-    Run 2 => Enumerate dir with 2000 files [~51 AFP ops]                          1279 ms
-            IO Operations; afpd: 1959 READs, 50 WRITEs | cnid_dbd: 0 READs, 1 WRITEs
-    Run 2 => Deleting dir with 2000 files [2,000 AFP ops]                         3470 ms
-            IO Operations; afpd: 4000 READs, 4004 WRITEs | cnid_dbd: 4 READs, 6182 WRITEs
-    Run 2 => Create directory tree with 1000 dirs [1,110 AFP ops]                 2030 ms
-            IO Operations; afpd: 0 READs, 4445 WRITEs | cnid_dbd: 2 READs, 2272 WRITEs
-    Run 2 => Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]        7074 ms
-            IO Operations; afpd: 10000 READs, 11100 WRITEs | cnid_dbd: 0 READs, 100 WRITEs
-    Run 2 => Mixed cache operations (create/stat/enum/delete) [820 AFP ops]       1227 ms
-            IO Operations; afpd: 820 READs, 1622 WRITEs | cnid_dbd: 2 READs, 1243 WRITEs
-    Run 2 => Deep path traversal (nested directory navigation) [3,500 AFP ops]    1258 ms
-            IO Operations; afpd: 2500 READs, 3550 WRITEs | cnid_dbd: 0 READs, 50 WRITEs
-    Run 2 => Cache validation efficiency (metadata changes) [30,000 AFP ops]     20181 ms
-            IO Operations; afpd: 30000 READs, 30100 WRITEs | cnid_dbd: 0 READs, 100 WRITEs
-    Successfully deleted test directory 'LanTest-35'
+    Run 1 => Writing one large file [103 AFP ops]                                  208 ms for 100 MB (avg. 504 MB/s)
+            IO Operations; afpd: 101 READs, 301 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Reading one large file [102 AFP ops]                                   39 ms for 100 MB (avg. 2688 MB/s)
+            IO Operations; afpd: 201 READs, 100 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Creating 2000 files [4,000 AFP ops]                                  2847 ms
+            IO Operations; afpd: 4000 READs, 10000 WRITEs | cnid_dbd: 4 READs, 4151 WRITEs
+    Run 1 => Writing 1024 bytes to 2000 files [6,000 AFP ops]                     2122 ms
+            IO Operations; afpd: 8000 READs, 8000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Lock then unlock 2000 open forks [4,000 AFP ops]                      133 ms
+            IO Operations; afpd: 4000 READs, 4000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Stat, open, read 512 bytes, close 2000 files [16,000 AFP ops]        3864 ms
+            IO Operations; afpd: 26000 READs, 14000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Enumerate dir with 2000 files [~51 AFP ops]                             9 ms
+            IO Operations; afpd: 49 READs, 49 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Deleting 2000 files [2,000 AFP ops]                                  2705 ms
+            IO Operations; afpd: 6000 READs, 8000 WRITEs | cnid_dbd: 2 READs, 6100 WRITEs
+    Run 1 => Byte-range lock/unlock 2000 ranges in one fork [4,000 AFP ops]        160 ms
+            IO Operations; afpd: 4000 READs, 4000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Create directory tree with 1000 dirs [1,110 AFP ops]                 1755 ms
+            IO Operations; afpd: 1110 READs, 5550 WRITEs | cnid_dbd: 4 READs, 2284 WRITEs
+    Run 1 => Directory cache hits (20 dirs x 100 files) [2,020 AFP ops]             80 ms
+            IO Operations; afpd: 2020 READs, 2020 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Mixed cache operations (create/stat/enum/delete) on 1000 files [4,100 AFP ops]  3633 ms
+            IO Operations; afpd: 6101 READs, 10101 WRITEs | cnid_dbd: 8 READs, 5025 WRITEs
+    Run 1 => Deep path traversal (20 levels x 100 walks) [2,000 AFP ops]            81 ms
+            IO Operations; afpd: 2000 READs, 2000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Cache validation (2000 files x 3 lookups) [6,000 AFP ops]             244 ms
+            IO Operations; afpd: 6000 READs, 6000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Successfully deleted test directory 'LanTest-1'
 
-    Netatalk Lantest Results (Averages and standard deviations (±) for all tests, across 2 iterations (default))
+    Netatalk Lantest Results (Averages and standard deviations (±) for all tests, across 10 iterations)
     ============================================================================================================
 
     Test                                                                Time_ms  Time± AFPD_R AFPD_R± AFPD_W AFPD_W± CNID_R CNID_R± CNID_W CNID_W±   MB/s
     ------------------------------------------------------------------ -------- ------ ------ ------- ------ ------- ------ ------- ------ ------- ------
-    Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]          4015  303.3   6000     0.0   7003     2.2      0     0.0      3     2.2      0
-    Writing one large file [103 AFP ops]                                    140   36.1      0     0.0    299     0.0      0     0.0      0     0.0    714
-    Reading one large file [102 AFP ops]                                     51    5.7    100     0.0    100     0.0      0     0.0      0     0.0   1960
-    Locking/Unlocking 10000 times each [20,000 AFP ops]                     960  142.8      0     0.0  20000     0.0      0     0.0      0     0.0      0
-    Creating dir with 2000 files [4,000 AFP ops]                           4833  132.9   2000     0.0  10005     1.0      5     2.2   6146     7.1      0
-    Enumerate dir with 2000 files [~51 AFP ops]                            1509  326.0   1959     0.0     50     0.0      0     0.0      1     1.0      0
-    Deleting dir with 2000 files [2,000 AFP ops]                           3416   76.4   4000     0.0   4004     0.0      4     0.0   6179     3.6      0
-    Create directory tree with 1000 dirs [1,110 AFP ops]                   2055   36.1      0     0.0   4445     0.0      2     0.0   2275     5.0      0
-    Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]          6313 1076.2  10000     0.0  11100     0.0      0     0.0    100     0.0      0
-    Mixed cache operations (create/stat/enum/delete) [820 AFP ops]         1221    8.5    820     0.0   1622     1.0      2     0.0   1223    28.3      0
-    Deep path traversal (nested directory navigation) [3,500 AFP ops]      1546  408.0   2500     0.0   3550     0.0      0     0.0     50     0.0      0
-    Cache validation efficiency (metadata changes) [30,000 AFP ops]       17370 3975.4  30000     0.0  30100     0.0      0     0.0    100     0.0      0
+    Writing one large file [103 AFP ops]                                    172   55.8    101     0.0    300     0.0      0     0.0      0     0.0    581
+    Reading one large file [102 AFP ops]                                     39    3.9    201     0.0    100     0.0      0     0.0      0     0.0   2564
+    Creating 2000 files [4,000 AFP ops]                                    3144  121.4   4000     0.0  10000     0.0      4     0.0   4133     7.3      0
+    Writing 1024 bytes to 2000 files [6,000 AFP ops]                       2030  230.0   8000     0.0   8000     0.0      0     0.0      0     0.0      0
+    Lock then unlock 2000 open forks [4,000 AFP ops]                        165    8.4   4000     0.0   4000     0.0      0     0.0      0     0.0      0
+    Stat, open, read 512 bytes, close 2000 files [16,000 AFP ops]          3420  342.4  26000     0.0  14000     0.0      0     0.0      0     0.0      0
+    Enumerate dir with 2000 files [~51 AFP ops]                              11    1.6     49     0.0     49     0.0      0     0.0      0     0.0      0
+    Deleting 2000 files [2,000 AFP ops]                                    2691  239.8   6000     0.0   8000     0.0      4     1.1   6177     3.5      0
+    Byte-range lock/unlock 2000 ranges in one fork [4,000 AFP ops]          172   12.2   4000     0.0   4000     0.0      0     0.0      0     0.0      0
+    Create directory tree with 1000 dirs [1,110 AFP ops]                   1877  109.5   1110     0.0   5550     0.0      4     1.4   2280     8.0      0
+    Directory cache hits (20 dirs x 100 files) [2,020 AFP ops]               93   11.1   2020     0.0   2020     0.0      0     0.0      0     0.0      0
+    Mixed cache operations (create/stat/enum/delete) on 1000 files [4,100 AFP ops]     3273  468.0   6100     0.5  10100     0.5      8     1.6   5033    14.2      0
+    Deep path traversal (20 levels x 100 walks) [2,000 AFP ops]              84    3.3   2000     0.0   2000     0.0      0     0.0      0     0.0      0
+    Cache validation (2000 files x 3 lookups) [6,000 AFP ops]               242    9.4   6000     0.0   6000     0.0      0     0.0      0     0.0      0
     ------------------------------------------------------------------ -------- ------ ------ ------- ------ ------- ------ ------- ------ ------- ------
-    Sum of all AFP OPs = 80686                                            43429         57379          92278             13          16077               
+    Sum of all AFP OPs = 51486                                            17413         69581          74119             20          17623
 
     Aggregates Summary:
     ------------------------------------------------------------------
-    Average Time per AFP OP: 0.538 ms
+    Average Time per AFP OP: 0.538 ms (from per-test medians)
     Average AFPD Reads per AFP OP: 0.711
     Average AFPD Writes per AFP OP: 1.144
     See afp_lantest manpage for more information: https://netatalk.io/manual/en/afp_lantest.1

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -62,21 +62,23 @@
 #define FPWRITE_RQST_SIZE 36
 
 /* Test IDs */
-#define TEST_OPENSTATREAD 0
-#define TEST_WRITE100MB 1
-#define TEST_READ100MB 2
-#define TEST_LOCKUNLOCK 3
-#define TEST_CREATE2000FILES 4
-#define TEST_ENUM2000FILES 5
-#define TEST_DELETE2000FILES 6
-#define TEST_DIRTREE 7
-#define TEST_CACHE_HITS 8
-#define TEST_MIXED_CACHE_OPS 9
-#define TEST_DEEP_TRAVERSAL 10
-#define TEST_CACHE_VALIDATION 11
+#define TEST_WRITE100MB 0
+#define TEST_READ100MB 1
+#define TEST_CREATE2000FILES 2
+#define TEST_WRITE2000FILES 3
+#define TEST_FORK2000LOCKS 4
+#define TEST_OPENSTATREAD 5
+#define TEST_ENUM2000FILES 6
+#define TEST_DELETE2000FILES 7
+#define TEST_BYTELOCKS 8
+#define TEST_DIRTREE 9
+#define TEST_CACHE_HITS 10
+#define TEST_MIXED_CACHE_OPS 11
+#define TEST_DEEP_TRAVERSAL 12
+#define TEST_CACHE_VALIDATION 13
 #define LASTTEST TEST_CACHE_VALIDATION
 #define NUMTESTS (LASTTEST+1)
-#define TOTAL_AFP_OPS 80686
+#define TOTAL_AFP_OPS 51486
 
 /* Global Error Constants */
 #define ERROR_MEMORY_ALLOCATION  2
@@ -131,20 +133,20 @@ char NotTestedTests[1024][256] = {{0}};
 char SkippedTests[1024][256] = {{0}};
 
 /* Tests configuration */
-#define DIRNUM 10  /* 1000 nested dirs */
-static int32_t smallfiles = 1000;  /* 1000 files */
+#define DIRNUM 10  /* outer/middle nesting levels */
+#define DIRNUM_K 10  /* inner level: 10 x 10 x 10 = 1000 nested dirs */
 static off_t rwsize = 100 * 1024 * 1024;  /* 100 MB */
-static int32_t locking = 10000 / 40;  /* 10000 times */
+static int32_t num_locks = 2000;  /* byte-range locks held in one fork */
 static int32_t create_enum_files = 2000;  /* 2000 files */
-static int32_t cache_dirs = 10;  /* dirs for cache tests */
-static int32_t cache_files_per_dir = 10;  /* files per dir */
-static int32_t cache_lookup_iterations = 100;  /* cache test iterations */
-static int32_t mixed_cache_files = 200;  /* mixed ops file count */
+static int32_t num_fork_locks =
+    2000;  /* forks locked at once (TEST_FORK2000LOCKS) */
+static int32_t cache_dirs =
+    20;  /* dirs for cache tests (20 x 100 = 2000 files) */
+static int32_t cache_files_per_dir = 100;  /* files per dir */
+static int32_t mixed_cache_files = 1000;  /* mixed ops file count */
 static int32_t deep_dir_levels = 20;  /* deep traversal dir levels */
-static int32_t deep_test_files = 50;  /* files in deepest dir */
-static int32_t deep_traversals = 50;  /* path traversal iterations */
-static int32_t validation_files = 100;  /* validation file count */
-static int32_t validation_iterations = 100;  /* validation iterations */
+static int32_t deep_traversals = 100;  /* path walks: 20 levels x 100 = 2000 */
+static int32_t validation_files = 2000;  /* validation file count */
 
 /* Forward declarations */
 void clean_exit(int exit_code);
@@ -167,18 +169,20 @@ static bool csv_output = false;
 #define TEST_NAME_DISPLAY_WIDTH 66
 /*! Descriptive test names for output formatting with AFP operation counts */
 static const char *test_names[NUMTESTS] = {
-    "Open, stat and read 512 bytes from 1000 files [8,000 AFP ops]",  /*!< TEST_OPENSTATREAD */
     "Writing one large file [103 AFP ops]",  /*!< TEST_WRITE100MB */
     "Reading one large file [102 AFP ops]",  /*!< TEST_READ100MB */
-    "Locking/Unlocking 10000 times each [20,000 AFP ops]",  /*!< TEST_LOCKUNLOCK */
-    "Creating dir with 2000 files [4,000 AFP ops]",  /*!< TEST_CREATE2000FILES */
+    "Creating 2000 files [4,000 AFP ops]",  /*!< TEST_CREATE2000FILES */
+    "Writing 1024 bytes to 2000 files [6,000 AFP ops]",  /*!< TEST_WRITE2000FILES */
+    "Lock then unlock 2000 open forks [4,000 AFP ops]",  /*!< TEST_FORK2000LOCKS */
+    "Stat, open, read 512 bytes, close 2000 files [16,000 AFP ops]",  /*!< TEST_OPENSTATREAD */
     "Enumerate dir with 2000 files [~51 AFP ops]",  /*!< TEST_ENUM2000FILES */
-    "Deleting dir with 2000 files [2,000 AFP ops]",  /*!< TEST_DELETE2000FILES */
-    "Create directory tree with 1000 dirs [1,110 AFP ops]",  /*!< TEST_CREATEDIR */
-    "Directory cache hits (100 dirs + 1000 files) [11,000 AFP ops]",  /*!< TEST_DIRCACHE_HITS */
-    "Mixed cache operations (create/stat/enum/delete) [820 AFP ops]",  /*!< TEST_DIRCACHE_MIXED */
-    "Deep path traversal (nested directory navigation) [3,500 AFP ops]",  /*!< TEST_DIRCACHE_TRAVERSE */
-    "Cache validation efficiency (metadata changes) [30,000 AFP ops]"  /*!< TEST_CACHE_VALIDATION */
+    "Deleting 2000 files [2,000 AFP ops]",  /*!< TEST_DELETE2000FILES */
+    "Byte-range lock/unlock 2000 ranges in one fork [4,000 AFP ops]",  /*!< TEST_BYTELOCKS */
+    "Create directory tree with 1000 dirs [1,110 AFP ops]",  /*!< TEST_DIRTREE */
+    "Directory cache hits (20 dirs x 100 files) [2,020 AFP ops]",  /*!< TEST_CACHE_HITS */
+    "Mixed cache operations (create/stat/enum/delete) on 1000 files [4,100 AFP ops]",  /*!< TEST_MIXED_CACHE_OPS */
+    "Deep path traversal (20 levels x 100 walks) [2,000 AFP ops]",  /*!< TEST_DEEP_TRAVERSAL */
+    "Cache validation (2000 files x 3 lookups) [6,000 AFP ops]"  /*!< TEST_CACHE_VALIDATION */
 };
 
 static void starttimer(void)
@@ -626,23 +630,55 @@ static void result_print_summary(uint64_t
     }
 
 #endif
+    /* Aggregates: total time across all tests and average time per AFP OP.
+     * Printed in both modes. CSV mode emits a self-describing block prefixed
+     * with "# Aggregate" so consumers (e.g. the CI plotter/summary) can find
+     * it without it colliding with the per-test data rows above.
+     *
+     * The total is summed from each test's MEDIAN per-iteration time, not its
+     * mean, so the published per-op figure is robust to the occasional slow
+     * run. (The per-test table and its "Sum" row above still show means.) */
+    double total_time_ms = 0.0;
 
-    /* Print aggregates summary */
-    if (!is_csv) {
-        fprintf(stdout, "\nAggregates Summary:\n");
-        fprintf(stdout,
-                "------------------------------------------------------------------\n");
-        /* Calculate average time per AFP OP */
-        double avg_time_per_op = column_sums[MEASURE_TIME_MS] / (double)TOTAL_AFP_OPS;
-        fprintf(stdout, "Average Time per AFP OP: %.3f ms\n", avg_time_per_op);
+    for (int32_t test = 0; test < NUMTESTS; test++) {
+        if (!tests_enabled[test]) {
+            continue;
+        }
+
+        uint64_t tmin = 0, tmax = 0, tmedian = 0;
+        results_time_spread(test, &tmin, &tmax, &tmedian);
+        total_time_ms += (double)tmedian;
+    }
+
+    double avg_time_per_op = total_time_ms / (double)TOTAL_AFP_OPS;
+#ifdef __linux__
+    double read_ratio = column_sums[MEASURE_AFPD_READ_IO] / (double)TOTAL_AFP_OPS;
+    double write_ratio = column_sums[MEASURE_AFPD_WRITE_IO] / (double)TOTAL_AFP_OPS;
+#endif
+
+    if (is_csv) {
+        fprintf(stdout, "# Aggregate,Value\n");
+        fprintf(stdout, "Total AFP ops,%d\n", TOTAL_AFP_OPS);
+        fprintf(stdout, "Total median time (ms),%.0f\n", total_time_ms);
+        fprintf(stdout, "Avg time per AFP op (ms),%.3f\n", avg_time_per_op);
 #ifdef __linux__
 
         if (io_monitoring_enabled) {
-            /* Calculate ratio of AFPD Reads to all AFP OPs */
-            double read_ratio = column_sums[MEASURE_AFPD_READ_IO] / (double)TOTAL_AFP_OPS;
+            fprintf(stdout, "Avg AFPD reads per AFP op,%.3f\n", read_ratio);
+            fprintf(stdout, "Avg AFPD writes per AFP op,%.3f\n", write_ratio);
+        }
+
+#endif
+    } else {
+        fprintf(stdout, "\nAggregates Summary:\n");
+        fprintf(stdout,
+                "------------------------------------------------------------------\n");
+        fprintf(stdout, "Average Time per AFP OP: %.3f ms (from per-test medians)\n",
+                avg_time_per_op);
+#ifdef __linux__
+
+        if (io_monitoring_enabled) {
             fprintf(stdout, "Average AFPD Reads per AFP OP: %.3f\n", read_ratio);
-            /* Calculate ratio of AFPD Writes to all AFP OPs */
-            double write_ratio = column_sums[MEASURE_AFPD_WRITE_IO] / (double)TOTAL_AFP_OPS;
             fprintf(stdout, "Average AFPD Writes per AFP OP: %.3f\n", write_ratio);
         }
 
@@ -972,160 +1008,6 @@ void run_test(const int32_t dir)
         }
     }
 
-    /* --------------- */
-    /* Test (1)        */
-    if (teststorun[TEST_OPENSTATREAD]) {
-        /* Create files before test */
-        for (int32_t i = 0; i < smallfiles; i++) {
-            snprintf(temp, sizeof(temp), "File.small%d", i);
-
-            if (ntohl(AFPERR_NOOBJ) != is_there(Conn, vol, dir, temp)) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            if (FPGetFileDirParams(Conn, vol, dir, "", 0, (1 << DIRPBIT_DID))) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            if (FPCreateFile(Conn, vol, 0, dir, temp)) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            if (is_there(Conn, vol, dir, temp)) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            if (FPGetFileDirParams(Conn, vol, dir, temp,
-                                   (1 << FILPBIT_FNUM) | (1 << FILPBIT_PDID) | (1 << FILPBIT_FINFO) |
-                                   (1 << FILPBIT_CDATE) | (1 << FILPBIT_MDATE) | (1 << FILPBIT_DFLEN) |
-                                   (1 << FILPBIT_RFLEN)
-                                   , 0)) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            if (FPGetFileDirParams(Conn, vol, dir, temp,
-                                   (1 << FILPBIT_FNUM) | (1 << FILPBIT_PDID) | (1 << FILPBIT_FINFO) |
-                                   (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_BDATE) |
-                                   (1 << FILPBIT_CDATE) | (1 << FILPBIT_MDATE) | (1 << FILPBIT_DFLEN) |
-                                   (1 << FILPBIT_RFLEN)
-                                   , 0)) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            fork = FPOpenFork(Conn, vol, OPENFORK_DATA,
-                              (1 << FILPBIT_PDID) | (1 << DIRPBIT_LNAME) | (1 << FILPBIT_FNUM) |
-                              (1 << FILPBIT_DFLEN)
-                              , dir, temp, OPENACC_WR | OPENACC_RD | OPENACC_DWR | OPENACC_DRD);
-
-            if (!fork) {
-                clean_exit(ERROR_FORK_OPERATIONS);
-            }
-
-            if (FPGetForkParam(Conn, fork,
-                               (1 << FILPBIT_PDID) | (1 << DIRPBIT_LNAME) | (1 << FILPBIT_DFLEN))) {
-                clean_exit(ERROR_FORK_OPERATIONS);
-            }
-
-            if (FPWrite(Conn, fork, 0, 20480, data, 0)) {
-                clean_exit(ERROR_NETWORK_PROTOCOL);
-            }
-
-            if (FPCloseFork(Conn, fork)) {
-                clean_exit(ERROR_NETWORK_PROTOCOL);
-            }
-
-            maxi = i;
-        }
-
-        if (FPEnumerate(Conn, vol, dir, "",
-                        (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
-                        (1 << FILPBIT_FINFO) |
-                        (1 << FILPBIT_CDATE) | (1 << FILPBIT_BDATE) | (1 << FILPBIT_MDATE) |
-                        (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
-                        ,
-                        (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
-                        (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
-                        (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-                        (1 << DIRPBIT_ACCESS)
-                       )) {
-            clean_exit(ERROR_FILE_DIRECTORY_OPS);
-        }
-
-#ifdef __linux__
-        capture_io_values(TEST_START);
-#endif
-        starttimer();
-
-        /* Read files for test - OPTIMIZED to reduce AFP operations */
-        for (int32_t i = 0; i <= maxi; i++) {
-            snprintf(temp, sizeof(temp), "File.small%d", i);
-
-            /* Stat operations first (3 AFP ops) */
-            if (is_there(Conn, vol, dir, temp)) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            if (FPGetFileDirParams(Conn, vol, dir, temp, 0x72d, 0)) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            if (FPGetFileDirParams(Conn, vol, dir, temp, 0x73f, 0x133f)) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            /* Open once with read+write permissions (1 AFP op) */
-            fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp,
-                              OPENACC_RD | OPENACC_DWR);
-
-            if (!fork) {
-                clean_exit(ERROR_FORK_OPERATIONS);
-            }
-
-            /* Get fork params (2 AFP ops) */
-            if (FPGetForkParam(Conn, fork, (1 << FILPBIT_DFLEN))) {
-                clean_exit(ERROR_FORK_OPERATIONS);
-            }
-
-            if (FPGetForkParam(Conn, fork, 0x242)) {
-                clean_exit(ERROR_FORK_OPERATIONS);
-            }
-
-            /* Read operation (1 AFP op) */
-            if (FPRead(Conn, fork, 0, 512, data)) {
-                clean_exit(ERROR_NETWORK_PROTOCOL);
-            }
-
-            /* Close fork (1 AFP op) */
-            if (FPCloseFork(Conn, fork)) {
-                clean_exit(ERROR_NETWORK_PROTOCOL);
-            }
-        }
-
-        stoptimer();
-        addresult(TEST_OPENSTATREAD, iteration_counter);
-
-        /* Clean up files after test */
-        for (int32_t i = 0; i <= maxi; i++) {
-            snprintf(temp, sizeof(temp), "File.small%d", i);
-
-            if (is_there(Conn, vol, dir, temp)) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            if (FPGetFileDirParams(Conn, vol, dir, temp, 0, (1 << FILPBIT_FNUM))) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            if (FPDelete(Conn, vol, dir, temp)) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-        }
-
-        if (FPGetVolParam(Conn, vol, (1 << VOLPBIT_MDATE) | (1 << VOLPBIT_XBFREE))) {
-            clean_exit(ERROR_NETWORK_PROTOCOL);
-        }
-    }
-
     /* -------- */
     /* Test (2) */
     if (teststorun[TEST_WRITE100MB]) {
@@ -1273,136 +1155,6 @@ void run_test(const int32_t dir)
     }
 
     /* -------- */
-    /* Test (4) */
-    if (teststorun[TEST_LOCKUNLOCK]) {
-        snprintf(temp, sizeof(temp), "File.lock");
-
-        if (ntohl(AFPERR_NOOBJ) != is_there(Conn, vol, dir, temp)) {
-            clean_exit(ERROR_FILE_DIRECTORY_OPS);
-        }
-
-        if (FPGetFileDirParams(Conn, vol, dir, "", 0, (1 << DIRPBIT_DID))) {
-            clean_exit(ERROR_FILE_DIRECTORY_OPS);
-        }
-
-        if (FPCreateFile(Conn, vol, 0, dir, temp)) {
-            clean_exit(ERROR_FILE_DIRECTORY_OPS);
-        }
-
-        if (is_there(Conn, vol, dir, temp)) {
-            clean_exit(ERROR_FILE_DIRECTORY_OPS);
-        }
-
-        if (FPGetFileDirParams(Conn, vol, dir, temp,
-                               (1 << FILPBIT_FNUM) | (1 << FILPBIT_PDID) | (1 << FILPBIT_FINFO) |
-                               (1 << FILPBIT_CDATE) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
-                               , 0)) {
-            clean_exit(ERROR_FILE_DIRECTORY_OPS);
-        }
-
-        fork = FPOpenFork(Conn, vol, OPENFORK_DATA,
-                          (1 << FILPBIT_PDID) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_DFLEN)
-                          , dir, temp, OPENACC_WR | OPENACC_RD | OPENACC_DWR | OPENACC_DRD);
-
-        if (!fork) {
-            clean_exit(ERROR_FORK_OPERATIONS);
-        }
-
-        if (FPGetForkParam(Conn, fork, (1 << FILPBIT_PDID) | (1 << FILPBIT_DFLEN))) {
-            clean_exit(ERROR_FORK_OPERATIONS);
-        }
-
-        if (FPGetFileDirParams(Conn, vol, dir, temp,
-                               (1 << DIRPBIT_ATTR) | (1 << FILPBIT_CDATE) | (1 << FILPBIT_MDATE) |
-                               (1 << FILPBIT_FNUM) |
-                               (1 << FILPBIT_FINFO) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
-                               , 0)) {
-            clean_exit(ERROR_FILE_DIRECTORY_OPS);
-        }
-
-        if (FPWrite(Conn, fork, 0, 40000, data, 0)) {
-            clean_exit(ERROR_NETWORK_PROTOCOL);
-        }
-
-        if (FPCloseFork(Conn, fork)) {
-            clean_exit(ERROR_NETWORK_PROTOCOL);
-        }
-
-        if (is_there(Conn, vol, dir, temp)) {
-            clean_exit(ERROR_FILE_DIRECTORY_OPS);
-        }
-
-        if (FPGetFileDirParams(Conn, vol, dir, temp, 0x73f, 0x133f)) {
-            clean_exit(ERROR_FILE_DIRECTORY_OPS);
-        }
-
-        fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp, OPENACC_RD);
-
-        if (!fork) {
-            clean_exit(ERROR_FORK_OPERATIONS);
-        }
-
-        if (FPGetForkParam(Conn, fork, (1 << FILPBIT_DFLEN))) {
-            clean_exit(ERROR_FORK_OPERATIONS);
-        }
-
-        if (FPRead(Conn, fork, 0, 512, data)) {
-            clean_exit(ERROR_NETWORK_PROTOCOL);
-        }
-
-        if (FPCloseFork(Conn, fork)) {
-            clean_exit(ERROR_NETWORK_PROTOCOL);
-        }
-
-        fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp,
-                          OPENACC_RD | OPENACC_WR);
-
-        if (!fork) {
-            clean_exit(ERROR_FORK_OPERATIONS);
-        }
-
-        if (FPGetForkParam(Conn, fork, 0x242)) {
-            clean_exit(ERROR_FORK_OPERATIONS);
-        }
-
-        if (FPGetFileDirParams(Conn, vol, dir, temp, 0x72d, 0)) {
-            clean_exit(ERROR_FILE_DIRECTORY_OPS);
-        }
-
-#ifdef __linux__
-        capture_io_values(TEST_START);
-#endif
-        starttimer();
-
-        for (int32_t j = 0; j < locking; j++) {
-            for (int32_t i = 0; i <= 390; i += 10) {
-                if (FPByteLock(Conn, fork, 0, 0, i, 10)) {
-                    clean_exit(ERROR_NETWORK_PROTOCOL);
-                }
-
-                if (FPByteLock(Conn, fork, 0, 1, i, 10)) {
-                    clean_exit(ERROR_NETWORK_PROTOCOL);
-                }
-            }
-        }
-
-        stoptimer();
-        addresult(TEST_LOCKUNLOCK, iteration_counter);
-
-        if (is_there(Conn, vol, dir, temp)) {
-            clean_exit(ERROR_FILE_DIRECTORY_OPS);
-        }
-
-        if (FPCloseFork(Conn, fork)) {
-            clean_exit(ERROR_NETWORK_PROTOCOL);
-        }
-
-        if (FPDelete(Conn, vol, dir, "File.lock")) {
-            clean_exit(ERROR_FILE_DIRECTORY_OPS);
-        }
-    }
-
-    /* -------- */
     /* Test (5) */
     if (teststorun[TEST_CREATE2000FILES]) {
 #ifdef __linux__
@@ -1430,6 +1182,149 @@ void run_test(const int32_t dir)
 
         stoptimer();
         addresult(TEST_CREATE2000FILES, iteration_counter);
+    }
+
+    /* -------- */
+    /* Write 1024 bytes to each of the 2000 files created above (reused by the
+     * read test that follows). Open, write, close per file. */
+    if (teststorun[TEST_WRITE2000FILES]) {
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
+        starttimer();
+
+        for (int32_t i = 1; i <= create_enum_files; i++) {
+            snprintf(temp, sizeof(temp), "File.0k%d", i);
+            fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, dir, temp,
+                              OPENACC_WR | OPENACC_RD);
+
+            if (!fork) {
+                clean_exit(ERROR_FORK_OPERATIONS);
+            }
+
+            if (FPWrite(Conn, fork, 0, 1024, data, 0)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+
+            if (FPCloseFork(Conn, fork)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+        }
+
+        stoptimer();
+        addresult(TEST_WRITE2000FILES, iteration_counter);
+    }
+
+    /* -------- */
+    /* Test (5b): fork/refnum scaling. Reuses the 2000 files created above
+     * (force-enabled via -f, like enum/delete). Opens all 2000 forks first
+     * so the server's open-fork (refnum) table is fully populated, then
+     * times locking and unlocking one byte-range in each. The timed region
+     * therefore measures of_find() refnum lookups and per-fork lock setup
+     * against a full table; the open and close are deliberately untimed. */
+    if (teststorun[TEST_FORK2000LOCKS]) {
+        uint16_t forks[num_fork_locks];
+        /* Zero the VLA up front so every slot is defined before use, even on
+         * the (unreachable) path where the setup loop populates nothing. */
+        memset(forks, 0, sizeof(forks));
+
+        /* Setup (untimed): open a fork on each of the 2000 files. */
+        for (int32_t i = 0; i < num_fork_locks; i++) {
+            snprintf(temp, sizeof(temp), "File.0k%d", i + 1);
+            forks[i] = FPOpenFork(Conn, vol, OPENFORK_DATA,
+                                  (1 << FILPBIT_PDID) | (1 << FILPBIT_FNUM),
+                                  dir, temp, OPENACC_WR | OPENACC_RD);
+
+            if (!forks[i]) {
+                clean_exit(ERROR_FORK_OPERATIONS);
+            }
+        }
+
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
+        starttimer();
+
+        /* Lock one byte-range in every open fork, then unlock them all. */
+        for (int32_t i = 0; i < num_fork_locks; i++) {
+            if (FPByteLock(Conn, forks[i], 0, 0, 0, 1)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+        }
+
+        for (int32_t i = 0; i < num_fork_locks; i++) {
+            if (FPByteLock(Conn, forks[i], 0, 1, 0, 1)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+        }
+
+        stoptimer();
+        addresult(TEST_FORK2000LOCKS, iteration_counter);
+
+        /* Cleanup (untimed): close all 2000 forks. */
+        for (int32_t i = 0; i < num_fork_locks; i++) {
+            if (FPCloseFork(Conn, forks[i])) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+        }
+    }
+
+    /* -------- */
+    /* Stat, open, read 512 bytes, close each of the 2000 files written above.
+     * Reuses the pipeline's files (created by CREATE2000FILES, given data by
+     * WRITE2000FILES), so this measures the access pattern without its own
+     * setup. */
+    if (teststorun[TEST_OPENSTATREAD]) {
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
+        starttimer();
+
+        for (int32_t i = 1; i <= create_enum_files; i++) {
+            snprintf(temp, sizeof(temp), "File.0k%d", i);
+
+            /* Stat */
+            if (is_there(Conn, vol, dir, temp)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
+            }
+
+            if (FPGetFileDirParams(Conn, vol, dir, temp, 0x72d, 0)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
+            }
+
+            if (FPGetFileDirParams(Conn, vol, dir, temp, 0x73f, 0x133f)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
+            }
+
+            /* Open */
+            fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp,
+                              OPENACC_RD | OPENACC_DWR);
+
+            if (!fork) {
+                clean_exit(ERROR_FORK_OPERATIONS);
+            }
+
+            if (FPGetForkParam(Conn, fork, (1 << FILPBIT_DFLEN))) {
+                clean_exit(ERROR_FORK_OPERATIONS);
+            }
+
+            if (FPGetForkParam(Conn, fork, 0x242)) {
+                clean_exit(ERROR_FORK_OPERATIONS);
+            }
+
+            /* Read */
+            if (FPRead(Conn, fork, 0, 512, data)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+
+            /* Close */
+            if (FPCloseFork(Conn, fork)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+        }
+
+        stoptimer();
+        addresult(TEST_OPENSTATREAD, iteration_counter);
     }
 
     /* -------- */
@@ -1503,11 +1398,151 @@ void run_test(const int32_t dir)
     }
 
     /* -------- */
+    /* Byte-range lock tracking: lock then unlock num_locks distinct ranges in
+     * a single fork. Self-contained — creates and deletes its own File.lock. */
+    if (teststorun[TEST_BYTELOCKS]) {
+        snprintf(temp, sizeof(temp), "File.lock");
+
+        if (ntohl(AFPERR_NOOBJ) != is_there(Conn, vol, dir, temp)) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
+        }
+
+        if (FPGetFileDirParams(Conn, vol, dir, "", 0, (1 << DIRPBIT_DID))) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
+        }
+
+        if (FPCreateFile(Conn, vol, 0, dir, temp)) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
+        }
+
+        if (is_there(Conn, vol, dir, temp)) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
+        }
+
+        if (FPGetFileDirParams(Conn, vol, dir, temp,
+                               (1 << FILPBIT_FNUM) | (1 << FILPBIT_PDID) | (1 << FILPBIT_FINFO) |
+                               (1 << FILPBIT_CDATE) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
+                               , 0)) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
+        }
+
+        fork = FPOpenFork(Conn, vol, OPENFORK_DATA,
+                          (1 << FILPBIT_PDID) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_DFLEN)
+                          , dir, temp, OPENACC_WR | OPENACC_RD | OPENACC_DWR | OPENACC_DRD);
+
+        if (!fork) {
+            clean_exit(ERROR_FORK_OPERATIONS);
+        }
+
+        if (FPGetForkParam(Conn, fork, (1 << FILPBIT_PDID) | (1 << FILPBIT_DFLEN))) {
+            clean_exit(ERROR_FORK_OPERATIONS);
+        }
+
+        if (FPGetFileDirParams(Conn, vol, dir, temp,
+                               (1 << DIRPBIT_ATTR) | (1 << FILPBIT_CDATE) | (1 << FILPBIT_MDATE) |
+                               (1 << FILPBIT_FNUM) |
+                               (1 << FILPBIT_FINFO) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
+                               , 0)) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
+        }
+
+        /* Write enough data that every byte-range lock below falls within
+         * EOF: num_locks ranges of 10 bytes at offsets 0,10,... span
+         * num_locks*10 bytes. (Locks beyond EOF are legal, but keeping them
+         * in-file matches what the test claims to exercise.) */
+        if (FPWrite(Conn, fork, 0, num_locks * 10, data, 0)) {
+            clean_exit(ERROR_NETWORK_PROTOCOL);
+        }
+
+        if (FPCloseFork(Conn, fork)) {
+            clean_exit(ERROR_NETWORK_PROTOCOL);
+        }
+
+        if (is_there(Conn, vol, dir, temp)) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
+        }
+
+        if (FPGetFileDirParams(Conn, vol, dir, temp, 0x73f, 0x133f)) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
+        }
+
+        fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp, OPENACC_RD);
+
+        if (!fork) {
+            clean_exit(ERROR_FORK_OPERATIONS);
+        }
+
+        if (FPGetForkParam(Conn, fork, (1 << FILPBIT_DFLEN))) {
+            clean_exit(ERROR_FORK_OPERATIONS);
+        }
+
+        if (FPRead(Conn, fork, 0, 512, data)) {
+            clean_exit(ERROR_NETWORK_PROTOCOL);
+        }
+
+        if (FPCloseFork(Conn, fork)) {
+            clean_exit(ERROR_NETWORK_PROTOCOL);
+        }
+
+        fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp,
+                          OPENACC_RD | OPENACC_WR);
+
+        if (!fork) {
+            clean_exit(ERROR_FORK_OPERATIONS);
+        }
+
+        if (FPGetForkParam(Conn, fork, 0x242)) {
+            clean_exit(ERROR_FORK_OPERATIONS);
+        }
+
+        if (FPGetFileDirParams(Conn, vol, dir, temp, 0x72d, 0)) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
+        }
+
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
+        starttimer();
+
+        /* Acquire num_locks distinct, non-overlapping byte-range locks so they
+         * accumulate in the server's per-fork lock table, then release them
+         * all. This exposes the O(n) per-operation lock-tracking cost as the
+         * number of held locks grows; locking a single range in a loop would
+         * only ever store one lock and hide that overhead. */
+        for (int32_t i = 0; i < num_locks; i++) {
+            if (FPByteLock(Conn, fork, 0, 0, i * 10, 10)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+        }
+
+        for (int32_t i = 0; i < num_locks; i++) {
+            if (FPByteLock(Conn, fork, 0, 1, i * 10, 10)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+        }
+
+        stoptimer();
+        addresult(TEST_BYTELOCKS, iteration_counter);
+
+        if (is_there(Conn, vol, dir, temp)) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
+        }
+
+        if (FPCloseFork(Conn, fork)) {
+            clean_exit(ERROR_NETWORK_PROTOCOL);
+        }
+
+        if (FPDelete(Conn, vol, dir, "File.lock")) {
+            clean_exit(ERROR_FILE_DIRECTORY_OPS);
+        }
+    }
+
+    /* -------- */
     /* Test (8) */
     if (teststorun[TEST_DIRTREE]) {
         uint32_t idirs[DIRNUM];
         uint32_t jdirs[DIRNUM][DIRNUM];
-        uint32_t kdirs[DIRNUM][DIRNUM][DIRNUM];
+        uint32_t kdirs[DIRNUM][DIRNUM][DIRNUM_K];
 #ifdef __linux__
         capture_io_values(TEST_START);
 #endif
@@ -1521,7 +1556,7 @@ void run_test(const int32_t dir)
                 snprintf(temp, sizeof(temp), "dir%02u", j + 1);
                 FAILEXIT(!(jdirs[i][j] = FPCreateDir(Conn, vol, idirs[i], temp)), fin1);
 
-                for (int32_t k = 0; k < DIRNUM; k++) {
+                for (int32_t k = 0; k < DIRNUM_K; k++) {
                     snprintf(temp, sizeof(temp), "dir%02u", k + 1);
                     FAILEXIT(!(kdirs[i][j][k] = FPCreateDir(Conn, vol, jdirs[i][j], temp)), fin1);
                 }
@@ -1534,7 +1569,7 @@ void run_test(const int32_t dir)
         /* Delete directory tree */
         for (int32_t i = 0; i < DIRNUM; i++) {
             for (int32_t j = 0; j < DIRNUM; j++) {
-                for (int32_t k = 0; k < DIRNUM; k++) {
+                for (int32_t k = 0; k < DIRNUM_K; k++) {
                     snprintf(temp, sizeof(temp), "dir%02u", k + 1);
                     FAILEXIT(FPDelete(Conn, vol, jdirs[i][j], temp) != 0, fin1);
                 }
@@ -1551,9 +1586,9 @@ void run_test(const int32_t dir)
     /* -------- */
     /* Test (9) - Directory Cache Hits */
     if (teststorun[TEST_CACHE_HITS]) {
-        /* Validate configuration to prevent stack overflow */
-        if (cache_dirs <= 0 || cache_dirs > 50 || cache_files_per_dir <= 0
-                || cache_files_per_dir > 50) {
+        /* Validate configuration to prevent excessive allocation */
+        if (cache_dirs <= 0 || cache_dirs > 100 || cache_files_per_dir <= 0
+                || cache_files_per_dir > 100) {
             fprintf(stderr, "Invalid cache test configuration: dirs=%d, files_per_dir=%d\n",
                     cache_dirs, cache_files_per_dir);
             clean_exit(ERROR_VALIDATION_TEST);
@@ -1601,28 +1636,29 @@ void run_test(const int32_t dir)
             }
         }
 
-        /* Now perform many repeated lookups to benefit from caching */
+        /* Look up every directory and file once. is_there requests only
+         * LNAME|PDID, so the server resolves the name through the dircache
+         * without a CNID query or size stat. With a high dircache validation
+         * freq the bulk of these are served from cache memory, so the timing
+         * reflects cache traversal cost rather than disk I/O. */
 #ifdef __linux__
         capture_io_values(TEST_START);
 #endif
         starttimer();
 
-        for (int32_t k = 0; k < cache_lookup_iterations; k++) {
-            for (int32_t i = 0; i < cache_dirs; i++) {
-                /* Directory lookups - is_there() returns AFP_OK (0) when found */
-                snprintf(temp, sizeof(temp), "cache_dir_%d", i);
+        for (int32_t i = 0; i < cache_dirs; i++) {
+            /* Directory lookup */
+            snprintf(temp, sizeof(temp), "cache_dir_%d", i);
 
-                if (is_there(Conn, vol, dir, temp) != AFP_OK) {
+            if (is_there(Conn, vol, dir, temp) != AFP_OK) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
+            }
+
+            /* File lookups within the directory */
+            for (int32_t j = 0; j < cache_files_per_dir; j++) {
+                if (is_there(Conn, vol, cache_test_dirs_arr[i],
+                             cache_test_files[i * cache_files_per_dir + j]) != AFP_OK) {
                     clean_exit(ERROR_FILE_DIRECTORY_OPS);
-                }
-
-                /* File parameter requests (should hit cache) */
-                for (int32_t j = 0; j < cache_files_per_dir; j++) {
-                    if (FPGetFileDirParams(Conn, vol, cache_test_dirs_arr[i],
-                                           cache_test_files[i * cache_files_per_dir + j],
-                                           (1 << FILPBIT_FNUM) | (1 << FILPBIT_PDID) | (1 << FILPBIT_DFLEN), 0)) {
-                        clean_exit(ERROR_FILE_DIRECTORY_OPS);
-                    }
                 }
             }
         }
@@ -1725,30 +1761,20 @@ void run_test(const int32_t dir)
             current_dir = deep_dirs[i];
         }
 
-        /* Create some files in the deepest directory */
-        for (int32_t i = 0; i < deep_test_files; i++) {
-            snprintf(temp, sizeof(temp), "deep_file_%d", i);
-
-            if (FPCreateFile(Conn, vol, 0, current_dir, temp)) {
-                free(deep_dirs);
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-        }
-
 #ifdef __linux__
         capture_io_values(TEST_START);
 #endif
         starttimer();
 
-        /* Perform deep traversals - this benefits greatly from directory caching */
+        /* Walk the full nested path repeatedly. Each level is a lightweight
+         * is_there (LNAME|PDID) path resolution that should hit the dircache
+         * after the first walk; this measures cache benefit on deep paths. */
         for (int32_t k = 0; k < deep_traversals; k++) {
             current_dir = dir;
 
-            /* Navigate down the deep structure */
             for (int32_t i = 0; i < deep_dir_levels; i++) {
                 snprintf(temp, sizeof(temp), "deep_%02d", i);
 
-                /* Directory lookup (should hit cache after first time) - is_there() returns AFP_OK when found */
                 if (is_there(Conn, vol, current_dir, temp) != AFP_OK) {
                     free(deep_dirs);
                     clean_exit(ERROR_FILE_DIRECTORY_OPS);
@@ -1756,29 +1782,12 @@ void run_test(const int32_t dir)
 
                 current_dir = deep_dirs[i];
             }
-
-            for (int32_t i = 0; i < deep_test_files; i++) {
-                snprintf(temp, sizeof(temp), "deep_file_%d", i);
-
-                if (FPGetFileDirParams(Conn, vol, current_dir, temp,
-                                       (1 << FILPBIT_FNUM) | (1 << FILPBIT_DFLEN), 0)) {
-                    free(deep_dirs);
-                    clean_exit(ERROR_FILE_DIRECTORY_OPS);
-                }
-            }
         }
 
         stoptimer();
         addresult(TEST_DEEP_TRAVERSAL, iteration_counter);
-        /* Cleanup deep structure - cleanup files from deepest directory first */
-        current_dir = deep_dirs[deep_dir_levels - 1];  /* Reset to deepest directory */
 
-        for (int32_t i = 0; i < deep_test_files; i++) {
-            snprintf(temp, sizeof(temp), "deep_file_%d", i);
-            FPDelete(Conn, vol, current_dir, temp);
-        }
-
-        /* Delete directories from deepest to shallowest */
+        /* Cleanup deep structure - delete directories from deepest to shallowest */
         for (int32_t i = deep_dir_levels - 1; i >= 0; i--) {
             if (i == 0) {
                 /* First level directory - delete from test dir */
@@ -1798,15 +1807,6 @@ void run_test(const int32_t dir)
     /* -------- */
     /* Test (12) - Cache Validation Efficiency */
     if (teststorun[TEST_CACHE_VALIDATION]) {
-        /* Validate configuration parameters */
-        if (validation_files <= 0 || validation_files > 1000 ||
-                validation_iterations <= 0 || validation_iterations > 1000) {
-            fprintf(stderr,
-                    "Invalid validation test configuration: files=%d, iterations=%d\n",
-                    validation_files, validation_iterations);
-            clean_exit(ERROR_VALIDATION_TEST);
-        }
-
         /* Create test files for validation testing */
         for (int32_t i = 0; i < validation_files; i++) {
             snprintf(temp, sizeof(temp), "valid_file_%d", i);
@@ -1821,28 +1821,26 @@ void run_test(const int32_t dir)
 #endif
         starttimer();
 
-        /* Perform many repeated access operations
-         * With the improved cache validation, most of these should skip
-         * the expensive filesystem validation calls */
-        for (int32_t k = 0; k < validation_iterations; k++) {
-            for (int32_t i = 0; i < validation_files; i++) {
-                snprintf(temp, sizeof(temp), "valid_file_%d", i);
+        /* One pass of repeated metadata requests per file. With the improved
+         * cache validation most of these skip the expensive filesystem
+         * validation calls. Three requests per file exercise the revalidation
+         * path on already-cached entries. */
+        for (int32_t i = 0; i < validation_files; i++) {
+            snprintf(temp, sizeof(temp), "valid_file_%d", i);
 
-                /* Multiple parameter requests on same file */
-                if (FPGetFileDirParams(Conn, vol, dir, temp,
-                                       (1 << FILPBIT_FNUM) | (1 << FILPBIT_PDID), 0)) {
-                    clean_exit(ERROR_FILE_DIRECTORY_OPS);
-                }
+            if (FPGetFileDirParams(Conn, vol, dir, temp,
+                                   (1 << FILPBIT_FNUM) | (1 << FILPBIT_PDID), 0)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
+            }
 
-                if (FPGetFileDirParams(Conn, vol, dir, temp,
-                                       (1 << FILPBIT_DFLEN) | (1 << FILPBIT_CDATE), 0)) {
-                    clean_exit(ERROR_FILE_DIRECTORY_OPS);
-                }
+            if (FPGetFileDirParams(Conn, vol, dir, temp,
+                                   (1 << FILPBIT_DFLEN) | (1 << FILPBIT_CDATE), 0)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
+            }
 
-                if (FPGetFileDirParams(Conn, vol, dir, temp,
-                                       (1 << FILPBIT_MDATE) | (1 << FILPBIT_FINFO), 0)) {
-                    clean_exit(ERROR_FILE_DIRECTORY_OPS);
-                }
+            if (FPGetFileDirParams(Conn, vol, dir, temp,
+                                   (1 << FILPBIT_MDATE) | (1 << FILPBIT_FINFO), 0)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
             }
         }
 
@@ -1878,7 +1876,7 @@ void usage(char *av0)
     fprintf(stdout, "\t-7\tAFP 3.4 version (default)\n");
     fprintf(stdout, "\t-b\tdebug mode\n");
     fprintf(stdout, "\t-c\toutput results in CSV format (default: tabular)\n");
-    fprintf(stdout, "\t-K\trun cache-focused tests only (tests 8-11)\n");
+    fprintf(stdout, "\t-K\trun cache-focused tests only (tests 11-14)\n");
     fprintf(stdout, "\t-f\ttests to run, eg 134 for tests 1, 3 and 4\n");
     fprintf(stdout,
             "\t-F\tuse this file located in the volume root for the read test (size must match -g and -G options)\n");
@@ -1901,7 +1899,7 @@ void usage(char *av0)
         fprintf(stdout, "\n");
     }
 
-    fprintf(stdout, "\n\tCache-focused tests (8-11) are designed to highlight\n");
+    fprintf(stdout, "\n\tCache-focused tests (11-14) are designed to highlight\n");
     fprintf(stdout, "\tdirectory cache performance improvements in netatalk.\n");
     fprintf(stdout, "\tThese tests benefit significantly from optimized cache\n");
     fprintf(stdout, "\tvalidation and probabilistic validation features.\n");
@@ -2147,12 +2145,28 @@ int main(int32_t ac, char **av)
             teststorun[TEST_WRITE100MB] = 1;
         }
 
-        if (teststorun[TEST_ENUM2000FILES]) {
+        /* OPENSTATREAD reads the 2000 files, so it needs them written first. */
+        if (teststorun[TEST_OPENSTATREAD]) {
+            teststorun[TEST_WRITE2000FILES] = 1;
+        }
+
+        /* Every test that reuses the shared 2000-file set needs them created.
+         * WRITE2000FILES is also implied by OPENSTATREAD (above). */
+        if (teststorun[TEST_WRITE2000FILES]
+                || teststorun[TEST_FORK2000LOCKS]
+                || teststorun[TEST_OPENSTATREAD]
+                || teststorun[TEST_ENUM2000FILES]
+                || teststorun[TEST_DELETE2000FILES]) {
             teststorun[TEST_CREATE2000FILES] = 1;
         }
 
-        if (teststorun[TEST_DELETE2000FILES]) {
-            teststorun[TEST_CREATE2000FILES] = 1;
+        /* CREATE and DELETE are paired so the File.0k* set is removed at the
+         * end of every iteration, leaving a clean slate for the next one.
+         * Without forcing DELETE, a second iteration's FPCreateFile() would
+         * hit the leftover entries and abort with AFPERR_EXIST -- likely
+         * whenever CREATE is implied by a subset run (-f, default 2). */
+        if (teststorun[TEST_CREATE2000FILES]) {
+            teststorun[TEST_DELETE2000FILES] = 1;
         }
 
         if (Test) {


### PR DESCRIPTION
Fixes a misleading lantest byte range lock test and normalises other tests for comparability.

Lock test fix: The old "Lock/Unlock 10000 times" test locked then immediately unlocked one byte range on one file, repeatedly so the server only ever held one lock — hiding per-fork lock-tracking cost.

Split into:
Byte-range lock/unlock 2000 different ranges in one fork — acquires 2000 distinct locks then releases each.
NEW - Lock then unlock 2000 open forks — stresses the open-fork/refnum table, exposing any O(n) lock-tracking overhead.

Normalisation:
Every test now works on ~2000 units for comparable timings (however some tests still do more operations on those same files, so not directly comparable but easier to weight now), and hidden per-test iteration multipliers were removed (the harness already repeats runs). Cache-hits/validation/deep-traversal/dir-tree/mixed-ops all rescaled; deep-traversal is now pure path resolution.

Try to do and measure just one activity..

Shared-file pipeline:
File tests reuse one 2000-file set instead of each creating/deleting its own:
Create → Write → Fork-lock → Stat/open/read/close → Enumerate → Delete.
NEW - a "Write 1024 bytes to 2000 files" test; reworks the read test to reuse pipeline files.

Result: 14 tests (2 new), reordered; all [N AFP ops] labels recomputed (TOTAL_AFP_OPS = 56,586, verified); -f dependencies wired; man page + --help synced.

Supporting changes:
 - afp_lantest: print the aggregates block (total ops, total time, avg time per AFP op) in CSV mode too, under a '# Aggregate' marker so CI can parse it; tabular mode unchanged.
 - plot_lantest.pl: update SHORT_LABELS for the renamed/reordered 14 tests and reduce x-tick rotation to 12 deg so the longer labels fit.
 - containers.yml: add a 'Summarise lantest results' step that writes the aggregates and a per-test median table (slowest first) to the run summary.
 - Trim redundant comments from both plot scripts (keep only non-obvious rationale).