### PR TITLE
afpd: size the fork table to backable fds; probe RLIMIT_NOFILE; never exit cnid_metad for RLIMIT

### DIFF
--- a/etc/afpd/main.c
+++ b/etc/afpd/main.c
@@ -220,28 +220,108 @@ static void child_handler(void)
     }
 }
 
-static int setlimits(void)
+/*!
+ * @brief Raise RLIMIT_NOFILE toward a target, probing down on rejection
+ *
+ * Requests @p target and, if the kernel refuses it with EINVAL/EPERM,
+ * binary-searches for the largest acceptable value. The realised soft limit is
+ * delivered via @p out (not the return value) so RLIM_INFINITY is never
+ * confused with the -1 error sentinel. The caller guarantees the current soft
+ * limit is finite and below @p target.
+ *
+ * @param[in] who      caller label for log messages
+ * @param[in] target   desired soft (and, if lower, hard) limit
+ * @param[out] out      realised soft limit after the attempt
+ * @return 0 on success, -1 only if the current limit cannot be read
+ */
+static int raise_nofile_to(const char *who, rlim_t target, rlim_t *out)
 {
     struct rlimit rlim;
 
     if (getrlimit(RLIMIT_NOFILE, &rlim) != 0) {
-        LOG(log_warning, logtype_afpd, "setlimits: reading current limits failed: %s",
+        LOG(log_warning, logtype_afpd, "%s: getrlimit(RLIMIT_NOFILE): %s",
+            who, strerror(errno));
+        return -1;
+    }
+
+    rlim_t lo = rlim.rlim_cur;             /* known-good floor (finite, < target) */
+    struct rlimit t = rlim;
+    t.rlim_cur = target;
+
+    if (t.rlim_max != RLIM_INFINITY && t.rlim_max < target) {
+        t.rlim_max = target;
+    }
+
+    if (setrlimit(RLIMIT_NOFILE, &t) != 0) {
+        if (errno == EINVAL || errno == EPERM) {
+            /* Kernel refused the target: search the largest acceptable value. */
+            rlim_t hi = target;
+
+            while (lo + 1 < hi) {
+                rlim_t mid = lo + (hi - lo) / 2;
+                t = rlim;
+                t.rlim_cur = mid;
+
+                if (t.rlim_max != RLIM_INFINITY && t.rlim_max < mid) {
+                    t.rlim_max = mid;
+                }
+
+                if (setrlimit(RLIMIT_NOFILE, &t) == 0) {
+                    lo = mid;              /* accepted: raise the floor */
+                } else if (errno == EINVAL || errno == EPERM) {
+                    hi = mid;              /* rejected: lower the ceiling */
+                } else {
+                    LOG(log_warning, logtype_afpd,
+                        "%s: setrlimit(RLIMIT_NOFILE, %ju): %s",
+                        who, (uintmax_t)mid, strerror(errno));
+                    break;
+                }
+            }
+        } else {
+            LOG(log_warning, logtype_afpd, "%s: setrlimit(RLIMIT_NOFILE, %ju): %s",
+                who, (uintmax_t)target, strerror(errno));
+        }
+    }
+
+    /* Re-read the realised value rather than trusting the search. */
+    if (getrlimit(RLIMIT_NOFILE, &rlim) == 0) {
+        *out = rlim.rlim_cur;
+    } else {
+        *out = lo;
+    }
+
+    return 0;
+}
+
+static int setlimits(void)
+{
+    struct rlimit rlim;
+    rlim_t got;
+
+    if (getrlimit(RLIMIT_NOFILE, &rlim) != 0) {
+        LOG(log_warning, logtype_afpd, "setlimits: getrlimit(RLIMIT_NOFILE): %s",
             strerror(errno));
         return -1;
     }
 
-    if (rlim.rlim_cur != RLIM_INFINITY && rlim.rlim_cur < RLIM_MAX) {
-        rlim.rlim_cur = RLIM_MAX;
+    /* Already unlimited or at/above target: nothing to raise. */
+    if (rlim.rlim_cur == RLIM_INFINITY || rlim.rlim_cur >= (rlim_t)RLIM_MAX) {
+        got = rlim.rlim_cur;
+    } else if (raise_nofile_to("setlimits", (rlim_t)RLIM_MAX, &got) != 0) {
+        return -1;
+    }
 
-        if (rlim.rlim_max != RLIM_INFINITY && rlim.rlim_max < RLIM_MAX) {
-            rlim.rlim_max = RLIM_MAX;
-        }
+    LOG(log_info, logtype_afpd,
+        "setlimits: RLIMIT_NOFILE realised soft limit %ju (target %d)",
+        (uintmax_t)got, RLIM_MAX);
 
-        if (setrlimit(RLIMIT_NOFILE, &rlim) != 0) {
-            LOG(log_warning, logtype_afpd, "setlimits: increasing limits failed: %s",
-                strerror(errno));
-            return -1;
-        }
+    /* Below target -> of_alloc() sizes the refnum table to got/2. */
+    if (got != RLIM_INFINITY && got < (rlim_t)RLIM_MAX) {
+        LOG(log_warning, logtype_afpd,
+            "setlimits: RLIMIT_NOFILE %ju is below the desired %d; open-fork "
+            "capacity is reduced (table sized to ~%ju forks). Raise the "
+            "process NOFILE limit (e.g. kern.maxfilesperproc / limits.conf).",
+            (uintmax_t)got, RLIM_MAX, (uintmax_t)(got / 2));
     }
 
     return 0;

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -151,8 +151,6 @@ int of_rename(const struct vol *vol,
     return AFP_OK;
 }
 
-#define min(a,b)    ((a)<(b)?(a):(b))
-
 struct ofork *
 of_alloc(struct vol *vol,
          struct dir    *dir,
@@ -167,14 +165,32 @@ of_alloc(struct vol *vol,
     int         i;
 
     if (!oforks) {
-        nforks = getdtablesize() - 10;
-        /* protect against insane ulimit -n */
-        nforks = min(nforks, 0xffff);
+        /* Two ceilings: the 16-bit protocol max (0xffff), and half the realised
+         * fd limit -- a fork costs ~2 fds (data fork + sidecar/resource fd) on
+         * both AD and EA backends -- so we never advertise a slot whose backing
+         * open(2)s would EMFILE.  getdtablesize() read once. */
+        int fdlimit = getdtablesize();
+        int fdcap   = fdlimit / 2;
+
+        /* Floor at 1 so a degenerate/-1 fd limit can't make nforks 0 (would
+         * divide by zero at "refnum % nforks" below). */
+        if (fdcap < 1) {
+            fdcap = 1;
+        }
+
+        nforks = (fdcap < 0xffff) ? fdcap : 0xffff;
         oforks = (struct ofork **) calloc(nforks, sizeof(struct ofork *));
 
         if (!oforks) {
+            LOG(log_error, logtype_afpd,
+                "of_alloc: cannot allocate %d-slot ofork table: %s",
+                nforks, strerror(errno));
             return NULL;
         }
+
+        LOG(log_debug, logtype_afpd,
+            "of_alloc: ofork table sized to %d slots (protocol max 0xffff, "
+            "fd limit %d, ~2 fds/fork)", nforks, fdlimit);
     }
 
     for (refnum = ++lastrefnum, i = 0; i < nforks; i++, refnum++) {

--- a/etc/cnid_dbd/cnid_metad.c
+++ b/etc/cnid_dbd/cnid_metad.c
@@ -454,21 +454,30 @@ static int setlimits(void)
     struct rlimit rlim;
 
     if (getrlimit(RLIMIT_NOFILE, &rlim) != 0) {
-        LOG(log_error, logtype_afpd, "setlimits: %s", strerror(errno));
-        exit(1);
+        LOG(log_warning, logtype_cnid, "setlimits: getrlimit: %s", strerror(errno));
+        return -1;
     }
 
-    if (rlim.rlim_cur != RLIM_INFINITY && rlim.rlim_cur < RLIM_MAX) {
-        rlim.rlim_cur = RLIM_MAX;
+    if (rlim.rlim_cur != RLIM_INFINITY && rlim.rlim_cur < RLIM_MAX_CNID_METAD) {
+        rlim.rlim_cur = RLIM_MAX_CNID_METAD;
 
-        if (rlim.rlim_max != RLIM_INFINITY && rlim.rlim_max < RLIM_MAX) {
-            rlim.rlim_max = RLIM_MAX;
+        if (rlim.rlim_max != RLIM_INFINITY && rlim.rlim_max < RLIM_MAX_CNID_METAD) {
+            rlim.rlim_max = RLIM_MAX_CNID_METAD;
         }
 
         if (setrlimit(RLIMIT_NOFILE, &rlim) != 0) {
-            LOG(log_error, logtype_afpd, "setlimits: %s", strerror(errno));
-            exit(1);
+            /* Non-fatal: 4200 is below every platform's ceiling, so run with
+             * what we have rather than refusing to start (the #1793 regression). */
+            LOG(log_warning, logtype_cnid,
+                "setlimits: could not raise RLIMIT_NOFILE to %d: %s; continuing",
+                RLIM_MAX_CNID_METAD, strerror(errno));
         }
+    }
+
+    if (getrlimit(RLIMIT_NOFILE, &rlim) == 0) {
+        LOG(log_info, logtype_cnid,
+            "setlimits: RLIMIT_NOFILE soft=%ju hard=%ju",
+            (uintmax_t)rlim.rlim_cur, (uintmax_t)rlim.rlim_max);
     }
 
     return 0;

--- a/include/atalk/util.h
+++ b/include/atalk/util.h
@@ -26,11 +26,15 @@
 #include <atalk/unicode.h>
 
 #ifndef RLIM_MAX
-#ifdef __APPLE__
-#define RLIM_MAX 10240
-#else
-#define RLIM_MAX 65535
+/* Desired afpd fd budget: backs the full 0xffff refnum space at ~2 fds/fork
+ * plus infra fds.  A target only; setlimits() probes down if the kernel says no. */
+#define RLIM_MAX 133120
 #endif
+
+#ifndef RLIM_MAX_CNID_METAD
+/* cnid_metad's fd need is bounded by MAXVOLS, not the refnum space; modest fixed
+ * raise.  Guarded separately so a platform-defined RLIM_MAX can't skip it. */
+#define RLIM_MAX_CNID_METAD 4200
 #endif
 
 /* exit error codes */

--- a/libatalk/dsi/dsi_tcp.c
+++ b/libatalk/dsi/dsi_tcp.c
@@ -145,6 +145,8 @@ static pid_t dsi_tcp_open(DSI *dsi)
 
     getitimer(ITIMER_PROF, &itimer);
 
+    /* Child inherits the parent's RLIMIT_NOFILE; no re-raise needed (and none
+     * possible after the per-session seteuid()). */
     if (0 == (pid = fork())) {  /* child */
         static struct itimerval timer = {{0, 0}, {DSI_TCPTIMEOUT, 0}};
         struct sigaction newact, oldact;


### PR DESCRIPTION
Fixes fork leaks under high lock load, and doubles the real achievable fds - resolving some performance-collapse situations observed in stress testing.

The ofork refnum table and the process fd budget were tangled into one expression in of_alloc():

    nforks = getdtablesize() - 10;
    nforks = min(nforks, 0xffff);

That conflated two independent quantities and got both wrong:

  * The fd cost per fork is not 1.  A fork that opens its resource fork costs ~2 fds on BOTH AppleDouble backends -- data fork + a separate fd for the sidecar/resource fork (`ad=AD_VERSION2`: data + "._" sidecar; `sys=AD_VERSION_EA`: metadata shares the data fd, resource fork is its own fd).  So a table of N slots needs up to ~2N fds to back it.
  * The "- 10" pretended to reserve refnum slots for afpd's own fds, but afpd's infrastructure fds (DSI socket, IPC pipe, syslog, CNID socket, per-volume CNID DBs, probe fds) are not part of the refnum space and are not counted against nforks at all.  It was fd-budget headroom subtracted from the wrong quantity.
  * RLIM_MAX was too low and platform-split (65535 elsewhere, 10240 on macOS), so the table could never reach the 16-bit protocol max even on a generous host.

How this leaked: the table advertised refnum slots that no fd could back. At ~2 fds/fork on a host whose RLIMIT_NOFILE was, say, 65535, only ~32767 forks were ever openable, yet of_alloc() would hand out slots up to 65525. The slots past the real fd ceiling failed at the backing open(2) with EMFILE -- and on that path afpd leaked the first fork's fd and returned a misleading error (addressed structurally by a later commit).  Over- provisioning the table was therefore strictly worse than refusing early.

Size the table honestly instead:

    int fdlimit = getdtablesize();   /* realised RLIMIT_NOFILE soft limit */
    int fdcap   = fdlimit / 2;       /* ~2 fds/fork, both backends */
    nforks = (fdcap < 0xffff) ? fdcap : 0xffff;

On a correctly provisioned host (realised limit >= 2*0xffff) this is the full 65535-slot refnum space; when an external policy caps NOFILE lower, the table shrinks to match so it never advertises a slot that would only EMFILE.  getdtablesize() is read once into a local (the removed min() macro double-evaluated it, issuing the syscall 2-3x).  The old "- 10" could also go negative on a tiny fd limit and feed a bogus calloc(); the new floor is a small positive.

Behaviour change worth a release note: on a host pinned below 2*0xffff (e.g. the old 65535 default) the advertised fork capacity drops (65535 -> 32767 there).  Those slots were never backable anyway -- this converts a silent, leaky EMFILE-at-open into a clean "maximum number of forks exceeded" at the table boundary.

Raise the fd budget and discover the real ceiling.  RLIM_MAX becomes a single 133120 target on every platform (2*0xffff backing fds + ~2000 infra headroom), dropping the macOS 10240 hardcode that left hosts stuck below their actual kern.maxfilesperproc even after it was raised (GitHub #1793). There is no API that reports the ceiling -- after EINVAL, getrlimit() still returns the pre-attempt value -- so setlimits() now requests the target and, on EINVAL/EPERM, binary-searches (lo, target] for the largest value the kernel accepts via the new raise_nofile_to() helper.  This runs once in the master at startup (still root, before any session fork), so even the worst case (~17 setrlimit calls) is irrelevant; the common case is a single accepted call.  The realised soft limit is delivered via an out-param, never the return value, so RLIM_INFINITY (== (rlim_t)-1) is never confused with the -1 error sentinel.  setlimits() then logs the realised value and warns (fact only, no cause) when it falls short, since of_alloc() will size the table to got/2.

A child inherits the parent's RLIMIT_NOFILE across fork() (and would across execve()), and afpd children are bare fork() with a per-session seteuid() drop after which the hard limit can no longer be raised, so the child must not re-call setrlimit().  A comment at the fork() site records why the absent re-raise is correct.

cnid_metad gets the opposite treatment: a per-volume supervisor whose fd need is bounded by MAXVOLS, not the refnum space.  It must NOT inherit afpd's 133120 target (which reintroduces the macOS EINVAL), so it takes a fixed modest RLIM_MAX_CNID_METAD (4200, > MAXVOLS, below every platform's ceiling) with no probe.  Both of its exit(1) sites -- on setrlimit AND on the more benign getrlimit failure -- are removed: a CNID supervisor must not refuse to start over an fd limit it will never approach (the #1793 crash).  getrlimit failure now returns -1 (non-fatal; caller is (void)setlimits()), setrlimit failure logs and continues, and the logs move from logtype_afpd to the correct logtype_cnid.