### PR TITLE
adouble: give ad2openflags a fallback access mode; open exchange metadata RDWR

### DIFF
--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -2954,7 +2954,9 @@ int afp_exchangefiles(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
         ad_init_offsets(&adtmp);
 
         if (!AD_META_OPEN(adsp)) {
-            if (ad_open(adsp, p, ADFLAGS_HF) != 0) {
+            /* RDWR: this block rewrites the metadata header (ad_flush only
+             * persists when the fd carries O_RDWR). */
+            if (ad_open(adsp, p, ADFLAGS_HF | ADFLAGS_RDWR) != 0) {
                 err = AFPERR_MISC;
                 goto err_temp_to_dest;
             }
@@ -2963,7 +2965,7 @@ int afp_exchangefiles(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
         }
 
         if (!AD_META_OPEN(addp)) {
-            if (ad_open(addp, upath, ADFLAGS_HF) != 0) {
+            if (ad_open(addp, upath, ADFLAGS_HF | ADFLAGS_RDWR) != 0) {
                 err = AFPERR_MISC;
 
                 if (opened_ads) {

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -1121,6 +1121,19 @@ static int ad2openflags(const struct adouble *ad, int adfile, int adflags)
         oflags |= O_NOFOLLOW;
     }
 
+    /* POSIX open(2) needs an explicit access mode.  Detect a missing one at the
+     * adflags level: O_RDONLY is 0, so testing oflags can't tell "no mode" from
+     * a real read-only open, but ADFLAGS_RDWR/ADFLAGS_RDONLY are distinct bits.
+     * Strict backends (FreeBSD, FUSE) reject access-mode-less flags with EINVAL;
+     * default to O_RDONLY. */
+    if (!(adflags & (ADFLAGS_RDWR | ADFLAGS_RDONLY))) {
+        LOG(log_warning, logtype_ad,
+            "ad2openflags: missing access mode (adflags=0x%x adfile=0x%x); "
+            "defaulting to O_RDONLY", adflags, adfile);
+        /* No-op on the bits (O_RDONLY==0); documents the read-only default. */
+        oflags |= O_RDONLY;
+    }
+
     return oflags;
 }
 #ifdef __APPLE__


### PR DESCRIPTION
`ad2openflags()` is the single funnel translating `ADFLAGS_*` to the `O_*` flags for `open(2)`, feeding `ad_open_df`/`hf_v2`/`hf_ea`/`rf_ea`.  If a caller passed neither `ADFLAGS_RDWR` nor `ADFLAGS_RDONLY`, no access-mode bit was set and `open()` was invoked with `flags == 0`.
Linux defines `O_RDONLY == 0`, so that looks like a read-only open by accident; strict-POSIX backends (FreeBSD, FUSE, illumos) check `(flags & O_ACCMODE) != 0` and reject it with `EINVAL`.

This resolves GitHub #65.

The only access-mode-less callers in the tree were the two metadata opens in `afp_exchangefiles()`'s header-swap block, so `FPExchangeFiles` failed with `AFPERR_PARAM` on those backends.

Two fixes:

  * ad2openflags(): if neither `ADFLAGS_RDWR` nor `ADFLAGS_RDONLY` is set, default to read-only and log the offender.  The check is on `adflags`, not oflags: `O_RDONLY == 0` means a finished `oflags` can't distinguish "no mode" from a real read-only open, whereas `ADFLAGS_RDWR`/`RDONLY` are distinct bits.  This is a portability safety net for any future caller, not the exchange fix.

  * afp_exchangefiles(): open both metadata forks `ADFLAGS_HF` | `ADFLAGS_RDWR`. `RDWR` (not `RDONLY`) is required because this block rewrites the header and `ad_flush()` only persists when the fd carries `O_RDWR`.  `RDONLY` would also have been wrong-but-quiet: the v2 backend force-upgrades `HF` to `O_RDWR` only inside the `ADFLAGS_RDONLY` branch, but the EA backend does not, so on EA the swap would be silently dropped while `FPExchangeFiles` reported success.  `RDWR` is correct on both backends.

With both offenders fixed the new warning fires only on a genuine programming error (verified: zero occurrences across the full spectest run, all `FPExchangeFiles` cases green).