### PR TITLE
afpd: make of_unhash() idempotent

### DIFF
--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -72,6 +72,9 @@ static void of_unhash(struct ofork *of)
         }
 
         *(of->prevp) = of->next;
+        /* Idempotent: a second call short-circuits on the prevp guard. */
+        of->prevp = NULL;
+        of->next = NULL;
     }
 }
 


### PR DESCRIPTION
`of_unhash()` removes an `ofork` from its hash-collision chain but left the unlinked node's own `of->prevp/of->next` pointing into that chain.  Because the function guards its work with `if (of->prevp)`, a second call on the same node would re-enter and re-run the pointer surgery through now-stale pointers (`of->next` possibly freed or relinked, `of->prevp` a freed slot) -- a write through a dangling pointer.

Not reachable today: `of_unhash()` has a single caller, `of_dealloc()`, which frees the ofork immediately afterward, so no path unhashes a node twice - this is defensive hardening ahead of upcoming planned ofork-lifecycle rework (free-slot reuse bookkeeping), where an accidental double-unhash would be a silent heap corruption.