### PR TITLE
ci(lantest): add % of total runtime to candle labels and full results table

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1155,30 +1155,44 @@ jobs:
             --meta dircache_size=65536 \
             --meta dircache_validation_freq=100
           echo "PNG size: $(du -h lantest.png | cut -f1)"
-      - name: Extract slowest tests for PR comment
+      - name: Extract per-test table and aggregates for PR comment
         id: lantest-summary
         run: |
-          # Top 5 tests by median time. Right-anchored parse: the trailing six
-          # fields are mean,stddev,min,max,median,mbs and the name (which may
-          # contain commas) precedes them. Require that exact numeric tail so
-          # afpd log lines (also comma-rich) are rejected.
+          # Full per-test results in execution order (matching the chart's
+          # x-axis left-to-right). Right-anchored parse: the trailing six fields
+          # are mean,stddev,min,max,median,mbs and the name (which may contain
+          # commas) precedes them. Require that exact numeric tail so afpd log
+          # lines (also comma-rich) are rejected. The mean is the per-test
+          # average runtime over the iterations — the same statistic the chart's
+          # candle labels and percentages use.
           SLOW=$(awk -F, '
             $(NF) ~ /^[0-9]+$/ && $(NF-1) ~ /^[0-9]+$/ && $(NF-2) ~ /^[0-9]+$/ \
               && $(NF-3) ~ /^[0-9]+$/ && $(NF-4) ~ /^[0-9.]+$/ && $(NF-5) ~ /^[0-9]+$/ {
-              median=$(NF-1)+0
+              mean=$(NF-5)+0
               name=$1; for (i=2; i<=NF-6; i++) name=name","$i
               sub(/ *\[[^]]*\] *$/, "", name)
-              printf "%d\t%s\n", median, name
-            }' lantest.csv | sort -rn | head -5 \
-            | awk -F'\t' '{ printf "| %s | %s |\n", $2, $1 }')
-          # Average time per AFP op (emitted by afp_lantest in CSV mode under
-          # the "# Aggregate" marker) as a single inline stat for the comment.
-          AGG=$(awk -F, '
+              printf "| %s | %d |\n", name, mean
+            }' lantest.csv)
+          # Two inline aggregate stats for the comment:
+          #   * Avg time per AFP op (from the "# Aggregate" block).
+          #   * Avg total runtime for all tests = sum of per-test means, which
+          #     afp_lantest already prints as the second field of the
+          #     "Sum of all AFP OPs = N,SUM,," row (SUM = summed means).
+          AVG_OP=$(awk -F, '
             /^# Aggregate/ { agg = 1; next }
-            agg && $1 == "Avg time per AFP op (ms)" {
-              printf "**Avg time per AFP op: %s ms**", $2
-            }
+            agg && $1 == "Avg time per AFP op (ms)" { print $2 }
           ' lantest.csv)
+          TOTAL=$(awk -F, '
+            /^Sum of all AFP OPs =/ { print $2 + 0; exit }
+          ' lantest.csv)
+          # Only emit a stat that actually parsed, so a truncated CSV drops the
+          # missing figure rather than rendering "Avg ...:  ms" in the comment.
+          AGG=""
+          [ -n "$TOTAL" ] && AGG="**Avg total runtime: ${TOTAL} ms**"
+          if [ -n "$AVG_OP" ]; then
+            [ -n "$AGG" ] && AGG="$AGG · "
+            AGG="${AGG}**Avg time per AFP op: ${AVG_OP} ms**"
+          fi
           {
             echo "SLOW<<EOFSLOW"
             echo "$SLOW"
@@ -1389,10 +1403,10 @@ jobs:
             ${{ needs.latencygraph-lantest.outputs.aggregates }}
 
             <details>
-            <summary>🐢 Slowest operations (median)</summary>
+            <summary>🐢 All operations (avg runtime, in test order)</summary>
 
-            | Test | Median (ms) |
-            |------|-------------|
+            | Test | Avg (ms) |
+            |------|----------|
             ${{ needs.latencygraph-lantest.outputs.slowest }}
 
             </details>

--- a/contrib/scripts/plot_lantest.pl
+++ b/contrib/scripts/plot_lantest.pl
@@ -128,6 +128,11 @@ sub build_info_lines {
         my $warm = $meta->{warmup} ? " +$meta->{warmup} warmup" : '';
         push @lines, "Iterations: $meta->{iterations}$warm";
     }
+    # Avg time one full pass over all tests takes = sum of per-test means
+    # (the same figure the candle labels' percentages are normalized against).
+    my $total_mean = 0;
+    $total_mean += $_->{mean} for @$tests;
+    push @lines, sprintf('Avg total runtime: %.0f ms', $total_mean);
     push @lines, "AFP: $meta->{afp}"               if $meta->{afp};
     push @lines, "Quantum: $meta->{quantum_kb} KB" if $meta->{quantum_kb};
     my @dc;
@@ -163,11 +168,28 @@ sub plot {
     }
     my $y_lo = $data_min / 1.6;
     $y_lo = 0.1 if $y_lo < 0.1;
-    my $y_hi = $data_max * 1.6;
+    # The candle-max labels sit a fixed character height above the tallest
+    # candle, so on a log axis they occupy more *decades* of headroom the wider
+    # the data range. Reserve top headroom as a fraction of the decade span
+    # (floored at ~0.2 decades = the former fixed 1.6x, so the common narrow
+    # range is unchanged), then place the axis top that many decades above the
+    # tallest candle so a candle pinned to the top of the scale still clears its
+    # label.
+    my $span_decades     = (log($data_max) - log($y_lo)) / log(10);
+    my $headroom_decades = 0.08 * $span_decades;
+    $headroom_decades = 0.2 if $headroom_decades < 0.2;
+    my $y_hi = $data_max * (10**$headroom_decades);
+
+    # Total mean runtime (sum of per-test means) is the denominator for each
+    # candle's "% of total runtime" label, so a test's share of one full pass
+    # is comparable across runs even when absolute times drift.
+    my $total_mean = 0;
+    $total_mean += $_->{mean} for @$tests;
 
     # Columns per candlestick: x, box_lo, wick_lo, box_hi, wick_hi, median,
-    # cov. Box = mean ± 1 stddev clamped to the wick; cov (stddev/mean %) is
-    # the normalized jitter plotted as bars in the lower panel.
+    # cov, mean, pct. Box = mean ± 1 stddev clamped to the wick; cov
+    # (stddev/mean %) is the normalized jitter plotted as bars in the lower
+    # panel. mean + pct drive the label printed above each candle.
     my $rows    = '';
     my $cov_max = 0;
     my (@tics, @blank_tics);
@@ -179,7 +201,8 @@ sub plot {
         $box_hi = $t->{max} if $box_hi > $t->{max};
         my $cov = $t->{mean} > 0 ? 100 * $t->{stddev} / $t->{mean} : 0;
         $cov_max = $cov if $cov > $cov_max;
-        $rows .= "$x $box_lo $t->{min} $box_hi $t->{max} $t->{median} $cov\n";
+        my $pct = $total_mean > 0 ? 100 * $t->{mean} / $total_mean : 0;
+        $rows .= "$x $box_lo $t->{min} $box_hi $t->{max} $t->{median} $cov " . "$t->{mean} $pct\n";
         push @tics, sprintf('"%s" %d', gp_quote($t->{label}), $x);
         push @blank_tics, sprintf('"" %d', $x);
         $x++;
@@ -280,8 +303,9 @@ plot \$DATA using 1:2:3:5:4 with candlesticks whiskerbars 0.48 \\
         linewidth 2 linecolor rgb "$MEDIAN_COLOR" notitle, \\
      \$DATA using (\$1 - 0.24):5:(0.48):(0.0) with vectors nohead \\
         linewidth 1 dashtype (2,1) linecolor rgb "$MAX_COLOR" notitle, \\
-     \$DATA using 1:5:(sprintf("%d", \$6)) with labels \\
-        offset 0,0.6 font ",5" textcolor rgb "$MEDIAN_COLOR" notitle, \\
+     \$DATA using 1:5:(\$9 < 10 ? sprintf("%d · %.1f%%", \$8, \$9) \\
+        : sprintf("%d · %.0f%%", \$8, \$9)) with labels \\
+        offset 0,0.6 font ",5" textcolor rgb "$BOX_COLOR" notitle, \\
      keyentry with lines linecolor rgb "$BOX_COLOR" linewidth 1 \\
         title "min–max range", \\
      keyentry with boxes fillstyle transparent solid 0.35 \\


### PR DESCRIPTION
Lantest candle labels now show each test's mean runtime and its relative share of the total (mean ms + % of total), so a test's proportion of one full pass is comparable across runs even when absolute times drift. The chart subtitle gains an 'Avg total runtime' figure (sum of per-test means).

The PR dashboard's 'Slowest operations (median)' section is replaced with a full per-test table of all tests by mean runtime (slowest first), and the inline aggregates now report avg total runtime alongside avg time per AFP op.