### PR TITLE
afpd: close() leaked fork on afp_openfork() error; guard refcount underflow; add fault-injection unit tests

### DIFF
--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -626,18 +626,22 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
         fullpathname(s_path->u_name),
         (fork == OPENFORK_DATA) ? "data" : "reso",
         !(access & OPENACC_WR) ? "O_RDONLY" : "O_RDWR");
-    ret = AFPERR_NOOBJ;
 
     /* First ad_open(), opens data or resource fork */
     if (ad_open(ofork->of_ad, upath, adflags, 0666) < 0) {
+        /* Set ret per case (no fall-through): the cleanup label returns ret and
+         * must not consult errno, which the cleanup ad_close()/close(2) clobbers. */
         switch (errno) {
         case EROFS:
             ret = AFPERR_VLOCK;
+            goto openfork_err;
 
         case EACCES:
+            ret = (access & OPENACC_WR) ? AFPERR_LOCK : AFPERR_ACCESS;
             goto openfork_err;
 
         case ENOENT:
+            ret = AFPERR_NOOBJ;
             goto openfork_err;
 
         case EMFILE :
@@ -676,6 +680,7 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
             if ((id = get_id(vol, ofork->of_ad, st, dir->d_did, upath,
                              strlen(upath))) == CNID_INVALID) {
                 LOG(log_error, logtype_afpd, "afp_createfile(\"%s\"): CNID error", upath);
+                ret = AFPERR_MISC;
                 goto openfork_err;
             }
 
@@ -692,6 +697,7 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
 
         case EROFS:
             ret = AFPERR_VLOCK;
+            goto openfork_err;
 
         case EMFILE :
         case ENFILE :
@@ -718,7 +724,7 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
 
     if ((ret = getforkparams(obj, ofork, bitmap, rbuf + 2 * sizeof(int16_t),
                              &buflen)) != AFP_OK) {
-        ad_close(ofork->of_ad, adflags | ADFLAGS_SETSHRMD);
+        /* No local ad_close(): the openfork_err label closes whatever is open. */
         goto openfork_err;
     }
 
@@ -734,11 +740,11 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
         ad_getattr(ofork->of_ad, &bshort);
 
         if ((bshort & htons(ATTRBIT_NOWRITE)) && (access & OPENACC_WR)) {
-            ad_close(ofork->of_ad, adflags | ADFLAGS_SETSHRMD);
-            of_dealloc(ofork);
+            ret = AFPERR_OLOCK;
             ofrefnum = 0;
             memcpy(rbuf, &ofrefnum, sizeof(ofrefnum));
-            return AFPERR_OLOCK;
+            /* No local ad_close()/of_dealloc(): the openfork_err label does it. */
+            goto openfork_err;
         }
     }
 
@@ -755,24 +761,27 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
         /* can we access the fork? */
         if (ret < 0) {
             ofork->of_flags |= AFPFORK_ERROR;
-            ret = errno;
-            ad_close(ofork->of_ad, adflags | ADFLAGS_SETSHRMD);
-            of_dealloc(ofork);
 
-            switch (ret) {
+            /* Map errno before the goto: the cleanup ad_close()/close(2)
+             * clobbers it. */
+            switch (errno) {
             case EAGAIN: /* return data anyway */
             case EACCES:
             case EINVAL:
                 ofrefnum = 0;
                 memcpy(rbuf, &ofrefnum, sizeof(ofrefnum));
-                return AFPERR_DENYCONF;
+                ret = AFPERR_DENYCONF;
+                break;
 
             default:
                 *rbuflen = 0;
-                LOG(log_error, logtype_afpd, "afp_openfork(%s): ad_lock: %s", s_path->m_name,
-                    strerror(ret));
-                return AFPERR_PARAM;
+                LOG(log_error, logtype_afpd, "afp_openfork(%s): ad_lock: %s",
+                    s_path->m_name, strerror(errno));
+                ret = AFPERR_PARAM;
+                break;
             }
+
+            goto openfork_err;
         }
 
         if (access & OPENACC_WR) {
@@ -790,12 +799,18 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
     memcpy(rbuf, &ofrefnum, sizeof(ofrefnum));
     return AFP_OK;
 openfork_err:
-    of_dealloc(ofork);
 
-    if (errno == EACCES) {
-        return (access & OPENACC_WR) ? AFPERR_LOCK : AFPERR_ACCESS;
+    /* Close whatever is actually open (data/rsrc from the first ad_open(), HF
+     * from the second), in every failure combination, exactly once.  SETSHRMD
+     * releases any share-mode locks ad_open_df() set; the AD_*_OPEN guard makes
+     * a failure before the first open close nothing.  ret was set per case. */
+    if (AD_DATA_OPEN(ofork->of_ad) || AD_META_OPEN(ofork->of_ad)
+            || AD_RSRC_OPEN(ofork->of_ad)) {
+        ad_close(ofork->of_ad,
+                 (ADFLAGS_DF | ADFLAGS_RF | ADFLAGS_HF) | ADFLAGS_SETSHRMD);
     }
 
+    of_dealloc(ofork);
     return ret;
 }
 

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -441,12 +441,19 @@ void of_dealloc(struct ofork *of)
 
     of_unhash(of);
     oforks[of->of_refnum % nforks] = NULL;
-    /* decrease refcount */
-    of->of_ad->ad_refcount--;
 
-    if (of->of_ad->ad_refcount <= 0) {
-        free(of->of_ad->ad_name);
-        free(of->of_ad);
+    /* decrease refcount; guard so a stray double-dealloc on a shared adouble is
+     * logged (and asserts in non-NDEBUG builds) instead of silently absorbed. */
+    if (of->of_ad->ad_refcount > 0) {
+        if (--of->of_ad->ad_refcount == 0) {
+            free(of->of_ad->ad_name);
+            free(of->of_ad);
+        }
+    } else {
+        LOG(log_error, logtype_afpd,
+            "of_dealloc: ad_refcount underflow (already %d) — stray double "
+            "of_dealloc()?", of->of_ad->ad_refcount);
+        AFP_ASSERT(of->of_ad->ad_refcount > 0);
     }
 
     free(of);

--- a/libatalk/adouble/ad_flush.c
+++ b/libatalk/adouble/ad_flush.c
@@ -521,10 +521,18 @@ int ad_close(struct adouble *ad, int adflags)
                 adf_lock_free(&ad->ad_data_fork);
             }
 
-        if (--ad->ad_data_fork.adf_refcount == 0) {
-            if (ad_data_closefd(ad) < 0) {
-                err = -1;
+        if (ad->ad_data_fork.adf_refcount > 0) {
+            if (--ad->ad_data_fork.adf_refcount == 0) {
+                if (ad_data_closefd(ad) < 0) {
+                    err = -1;
+                }
             }
+        } else {
+            LOG(log_error, logtype_ad,
+                "ad_close: data-fork adf_refcount underflow (already %d) — "
+                "stray double ad_close()? fd=%d",
+                ad->ad_data_fork.adf_refcount, ad_data_fileno(ad));
+            AFP_ASSERT(ad->ad_data_fork.adf_refcount > 0);
         }
     }
 
@@ -533,12 +541,20 @@ int ad_close(struct adouble *ad, int adflags)
             ad->ad_meta_refcount--;
         }
 
-        if (!(--ad->ad_mdp->adf_refcount)) {
-            if (close(ad_meta_fileno(ad)) < 0) {
-                err = -1;
-            }
+        if (ad->ad_mdp->adf_refcount > 0) {
+            if (!(--ad->ad_mdp->adf_refcount)) {
+                if (close(ad_meta_fileno(ad)) < 0) {
+                    err = -1;
+                }
 
-            ad_meta_fileno(ad) = -1;
+                ad_meta_fileno(ad) = -1;
+            }
+        } else {
+            LOG(log_error, logtype_ad,
+                "ad_close: meta-fork adf_refcount underflow (already %d) — "
+                "stray double ad_close()? fd=%d",
+                ad->ad_mdp->adf_refcount, ad_meta_fileno(ad));
+            AFP_ASSERT(ad->ad_mdp->adf_refcount > 0);
         }
     }
 
@@ -549,12 +565,20 @@ int ad_close(struct adouble *ad, int adflags)
                 ad->ad_meta_refcount--;
             }
 
-            if (!(--ad->ad_mdp->adf_refcount)) {
-                if (close(ad_meta_fileno(ad)) < 0) {
-                    err = -1;
-                }
+            if (ad->ad_mdp->adf_refcount > 0) {
+                if (!(--ad->ad_mdp->adf_refcount)) {
+                    if (close(ad_meta_fileno(ad)) < 0) {
+                        err = -1;
+                    }
 
-                ad_meta_fileno(ad) = -1;
+                    ad_meta_fileno(ad) = -1;
+                }
+            } else {
+                LOG(log_error, logtype_ad,
+                    "ad_close: meta-fork (v2 RF) adf_refcount underflow "
+                    "(already %d) — stray double ad_close()? fd=%d",
+                    ad->ad_mdp->adf_refcount, ad_meta_fileno(ad));
+                AFP_ASSERT(ad->ad_mdp->adf_refcount > 0);
             }
         }
 
@@ -565,14 +589,23 @@ int ad_close(struct adouble *ad, int adflags)
 
         /* Check version is EA and fd is not AD_SYMLINK (-2) or -1 */
         if ((ad->ad_vers == AD_VERSION_EA)
-                && (ad_reso_fileno(ad) >= 0)
-                && !(--ad->ad_rfp->adf_refcount)) {
-            if (close(ad->ad_rfp->adf_fd) < 0) {
-                err = -1;
-            }
+                && (ad_reso_fileno(ad) >= 0)) {
+            if (ad->ad_rfp->adf_refcount > 0) {
+                if (!(--ad->ad_rfp->adf_refcount)) {
+                    if (close(ad->ad_rfp->adf_fd) < 0) {
+                        err = -1;
+                    }
 
-            ad->ad_rlen = 0;
-            ad_reso_fileno(ad) = -1;
+                    ad->ad_rlen = 0;
+                    ad_reso_fileno(ad) = -1;
+                }
+            } else {
+                LOG(log_error, logtype_ad,
+                    "ad_close: reso-fork adf_refcount underflow (already %d) — "
+                    "stray double ad_close()? fd=%d",
+                    ad->ad_rfp->adf_refcount, ad_reso_fileno(ad));
+                AFP_ASSERT(ad->ad_rfp->adf_refcount > 0);
+            }
         }
     }
 

--- a/test/afpd/faultinject.c
+++ b/test/afpd/faultinject.c
@@ -1,0 +1,265 @@
+/*
+  Copyright (c) 2026 andylemin
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+*/
+
+/*!
+ * @file
+ * @brief Fault-injection framework for the afpdtest unit harness.
+ *
+ * One source, two roles selected by -DFAULTINJECT_PRELOAD:
+ *
+ *  - Linked into the afpdtest executable (no define): provides the `fi` control
+ *    block and fault_inject_reset().  A test arms a failure on `fi` right before
+ *    the operation under test and disarms it right after.
+ *
+ *  - Built as libfaultinject.so (-DFAULTINJECT_PRELOAD) and loaded via
+ *    LD_PRELOAD: interposes open/close/fcntl/fchdir at dynamic-symbol
+ *    resolution, so calls made INSIDE libatalk.so (ad_open/ad_close/ad_lock/…)
+ *    are intercepted — which a link-time --wrap on the executable cannot reach,
+ *    because libatalk is a shared library.  The interposer references the `fi`
+ *    block exported by the executable (export_dynamic), forwarding to the real
+ *    libc symbol via dlsym(RTLD_NEXT) unless a failure is armed.
+ *
+ * Trigger model (countdown + errno): the per-call "armed" flag enables
+ * interception; "fail_after" = N lets the next N armed calls succeed and fails
+ * call N+1 once, with the per-call "errno".  Because LD_PRELOAD interposition is
+ * global, the armed flag MUST be set only around the operation under test (and
+ * cleared with fault_inject_reset()), or unrelated infrastructure calls get hit.
+ *
+ * Interception is not reliable on every platform (notably macOS's two-level
+ * namespace ignores plain symbol preloads); the self-test probes whether it
+ * works and dependent tests skip when it does not.
+ */
+
+#include "faultinject.h"
+
+#ifndef FAULTINJECT_PRELOAD
+
+/* ---- Role 1: control block, linked into the afpdtest executable ---- */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+struct fault_inject fi;
+
+void fault_inject_reset(void)
+{
+    fi = (struct fault_inject) {
+        0
+    };
+}
+
+/*!
+ * @brief Is the LD_PRELOAD open() interposer active on this platform?
+ *
+ * Arms a one-shot open() failure and probes it against the given scratch path.
+ * Returns 1 if the injected failure fired (interception works), 0 otherwise
+ * (e.g. macOS two-level namespace, or the preload was not loaded).  Leaves `fi`
+ * reset.  Injection-dependent tests should gate on this and return TEST_SKIP
+ * when it is 0, so coverage stays honest per platform.
+ */
+int faultinject_open_works(const char *scratch_path)
+{
+    int worked;
+    int fd;
+    fault_inject_reset();
+    fi.open_armed = 1;
+    fi.open_fail_after = 0;          /* fail the very next open() */
+    fi.open_errno = EMFILE;
+    errno = 0;
+    fd = open(scratch_path, O_RDONLY | O_CREAT, 0600);
+    /* Interception works iff the armed failure fired (open returned -1/EMFILE);
+     * if it returned a real fd the preload is not active on this platform. */
+    worked = (fd < 0 && errno == EMFILE);
+
+    if (fd >= 0) {
+        close(fd);
+        (void)unlink(scratch_path);
+    }
+
+    fault_inject_reset();
+    return worked;
+}
+
+#else /* FAULTINJECT_PRELOAD */
+
+/* ---- Role 2: LD_PRELOAD interposer (libfaultinject.so) ---- */
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+/* `fi` is defined in the afpdtest executable and exported dynamically; this is
+ * the same object the test code arms.  A weak fallback keeps the preload
+ * self-consistent if ever loaded into a process that does not define it. */
+struct fault_inject __attribute__((weak)) fi;
+
+/* Returns 1 (and sets errno) when this armed counter should fire now. */
+static int fault_should_fire(int armed, int *fail_after, int errnum)
+{
+    if (!armed) {
+        return 0;
+    }
+
+    if (*fail_after > 0) {
+        (*fail_after)--;
+        return 0;
+    }
+
+    if (*fail_after == 0) {
+        *fail_after = -1;       /* fire once, then stop */
+        errno = errnum;
+        return 1;
+    }
+
+    return 0;
+}
+
+typedef int (*open_fn)(const char *, int, ...);
+typedef int (*close_fn)(int);
+typedef int (*fcntl_fn)(int, int, ...);
+typedef int (*fchdir_fn)(int);
+
+static open_fn   real_open;
+static close_fn  real_close;
+static fcntl_fn  real_fcntl;
+static fchdir_fn real_fchdir;
+
+#ifndef O_TMPFILE
+#define O_TMPFILE 0
+#endif
+
+/* A single open() definition covers both symbols libatalk may reference: under
+ * glibc with _FILE_OFFSET_BITS=64 (set globally) <fcntl.h> renames THIS
+ * definition to open64() — which is exactly the symbol LFS callers reference —
+ * while musl/non-LFS keeps it as open().  So there is no separate open64()
+ * interposer (a second definition would collide with the renamed one).
+ *
+ * open() takes a third mode_t argument ONLY when creating; reading the vararg
+ * otherwise is undefined behaviour. */
+int open(const char *path, int flags, ...)
+{
+    mode_t mode = 0;
+
+    if (flags & (O_CREAT | O_TMPFILE)) {
+        va_list ap;
+        va_start(ap, flags);
+        mode = (mode_t)va_arg(ap, int);
+        va_end(ap);
+    }
+
+    if (!real_open) {
+        real_open = (open_fn)dlsym(RTLD_NEXT, "open");
+    }
+
+    if (fault_should_fire(fi.open_armed, &fi.open_fail_after, fi.open_errno)) {
+        return -1;
+    }
+
+    return real_open(path, flags, mode);
+}
+
+int close(int fd)
+{
+    if (!real_close) {
+        real_close = (close_fn)dlsym(RTLD_NEXT, "close");
+    }
+
+    if (fault_should_fire(fi.close_armed, &fi.close_fail_after, fi.close_errno)) {
+        /* The fd IS still closed (mirror real close-on-error semantics); only
+         * the reported result is the injected failure. */
+        real_close(fd);
+        return -1;
+    }
+
+    return real_close(fd);
+}
+
+/* fcntl()'s third argument is command-dependent: absent (F_GETFD/F_GETFL), an
+ * int (F_SETFD/F_SETFL/F_DUPFD), or a pointer (F_SETLK/F_GETLK).  The vararg
+ * MUST be read and forwarded with the type the caller passed: reading an int
+ * arg as void* (or vice versa) is undefined behaviour, and on LP64 reads a
+ * 64-bit slot for a 32-bit value.  Since interposition is global we forward
+ * every fcntl() correctly, dispatching on the command's arg class -- not just
+ * the lock commands we arm. */
+int fcntl(int fd, int cmd, ...)
+{
+    int int_arg = 0;
+    void *ptr_arg = NULL;
+    /* Commands taking a pointer third arg (struct flock *). */
+    int has_ptr = (cmd == F_SETLK || cmd == F_SETLKW || cmd == F_GETLK
+#ifdef F_OFD_SETLK
+                   || cmd == F_OFD_SETLK || cmd == F_OFD_SETLKW
+                   || cmd == F_OFD_GETLK
+#endif
+                  );
+    /* Commands taking an int third arg. */
+    int has_int = (cmd == F_SETFD || cmd == F_SETFL || cmd == F_DUPFD
+#ifdef F_DUPFD_CLOEXEC
+                   || cmd == F_DUPFD_CLOEXEC
+#endif
+                  );
+    va_list ap;
+
+    if (has_ptr) {
+        va_start(ap, cmd);
+        ptr_arg = va_arg(ap, void *);
+        va_end(ap);
+    } else if (has_int) {
+        va_start(ap, cmd);
+        int_arg = va_arg(ap, int);
+        va_end(ap);
+    }
+
+    if (!real_fcntl) {
+        real_fcntl = (fcntl_fn)dlsym(RTLD_NEXT, "fcntl");
+    }
+
+    if (fault_should_fire(fi.fcntl_armed, &fi.fcntl_fail_after, fi.fcntl_errno)) {
+        return -1;
+    }
+
+    if (has_ptr) {
+        return real_fcntl(fd, cmd, ptr_arg);
+    }
+
+    if (has_int) {
+        return real_fcntl(fd, cmd, int_arg);
+    }
+
+    return real_fcntl(fd, cmd);
+}
+
+int fchdir(int fd)
+{
+    if (!real_fchdir) {
+        real_fchdir = (fchdir_fn)dlsym(RTLD_NEXT, "fchdir");
+    }
+
+    if (fault_should_fire(fi.fchdir_armed, &fi.fchdir_fail_after,
+                          fi.fchdir_errno)) {
+        return -1;
+    }
+
+    return real_fchdir(fd);
+}
+
+#endif /* FAULTINJECT_PRELOAD */

--- a/test/afpd/faultinject.h
+++ b/test/afpd/faultinject.h
@@ -1,0 +1,52 @@
+/*
+  Copyright (c) 2026 andylemin
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+*/
+
+#ifndef FAULTINJECT_H
+#define FAULTINJECT_H
+
+/*!
+ * @file
+ * @brief Test-only fault-injection control block (see faultinject.c).
+ *
+ * Usage in a test (LD_PRELOAD interposition is global, so arm narrowly):
+ *   fault_inject_reset();
+ *   fi.open_armed = 1; fi.open_fail_after = 1; fi.open_errno = EMFILE;
+ *   ... run only the operation under test ...
+ *   fault_inject_reset();
+ *
+ * fail_after = N: the next N armed calls succeed, call N+1 fails once.
+ */
+
+struct fault_inject {
+    int open_armed;
+    int open_fail_after;    /*!< succeed this many armed opens, then fail once */
+    int open_errno;
+    int close_armed;
+    int close_fail_after;
+    int close_errno;
+    int fcntl_armed;
+    int fcntl_fail_after;
+    int fcntl_errno;
+    int fchdir_armed;
+    int fchdir_fail_after;
+    int fchdir_errno;
+};
+
+extern struct fault_inject fi;
+
+void fault_inject_reset(void);
+
+int faultinject_open_works(const char *scratch_path);
+
+#endif /* FAULTINJECT_H */

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -183,6 +183,11 @@ if get_option('with-tests')
     afpdtest = executable(
         'afpdtest',
         afpdtest_dtrace_input,
+        # The fault-injection control block (fi) and the unit tests that use it
+        # live in the executable; export_dynamic below lets the LD_PRELOAD
+        # interposer (libfaultinject.so) resolve `fi` back into this binary.
+        'faultinject.c',
+        'subtests_lock.c',
         objects: test_objs,
         include_directories: test_includes,
         link_with: [test_internal_deps, libatalk],
@@ -195,6 +200,24 @@ if get_option('with-tests')
         link_language: use_spotlight_xapian ? 'cpp' : 'c',
         export_dynamic: true,
         install: false,
+    )
+
+    # LD_PRELOAD interposer: replaces open/close/fcntl/fchdir at dynamic-link
+    # resolution, so calls made INSIDE libatalk.so (ad_open/ad_close/…) are
+    # intercepted — which a link-time --wrap on afpdtest cannot reach.  Reads the
+    # `fi` control block exported by afpdtest; forwards to the real libc symbol
+    # via dlsym(RTLD_NEXT) unless a test has armed a failure.  Under glibc's
+    # _FILE_OFFSET_BITS=64 the single open() definition is renamed by <fcntl.h>
+    # to open64() (the symbol LFS callers reference), so no separate wrapper is
+    # needed — see faultinject.c.
+    faultinject_preload = shared_library(
+        'faultinject',
+        'faultinject.c',
+        include_directories: test_includes,
+        c_args: ['-DFAULTINJECT_PRELOAD'],
+        dependencies: cc.find_library('dl', required: false),
+        install: false,
+        build_by_default: true,
     )
 
     test_sh = find_program('test.sh')
@@ -210,6 +233,8 @@ if get_option('with-tests')
         afpdtest,
         args: ['--tap'],
         protocol: 'tap',
+        env: {'LD_PRELOAD': faultinject_preload.full_path()},
+        depends: faultinject_preload,
         verbose: true,
         is_parallel: false,
         priority: 0,

--- a/test/afpd/subtests_lock.c
+++ b/test/afpd/subtests_lock.c
@@ -1,0 +1,330 @@
+/*
+  Copyright (c) 2026 andylemin
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+*/
+
+/*!
+ * @file
+ * @brief Unit tests for afpd fork/adouble open, close and locking paths.
+ *
+ * Uses the LD_PRELOAD fault-injection shim (faultinject.c) to force libc
+ * failures the black-box spectest cannot reach.  Each test returns 0 on
+ * success, or a small nonzero code identifying the failure point (surfaced by
+ * the harness as "# got: N").
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <atalk/adouble.h>
+#include <atalk/logger.h>
+#include <atalk/volume.h>
+
+#include "faultinject.h"
+#include "subtests_lock.h"
+#include "test.h"      /* TEST_SKIP */
+
+/*!
+ * @brief Framework capability probe: does fault injection reach into libatalk?
+ *
+ * Category: framework integrity (meta-test).  Not a netatalk behavioural test —
+ * it validates the harness.  The LD_PRELOAD shim interposes libc symbols at
+ * dynamic-link resolution; this arms an EMFILE on the next open() and calls
+ * ad_open() (whose open() lives in the shared libatalk.so), then checks the
+ * open failed with the injected errno.
+ *
+ * Interception is not reliable on every platform — macOS's two-level namespace
+ * ignores a plain symbol preload, so the injected fault never fires there.  In
+ * that case this returns TEST_SKIP rather than failing: the result is then
+ * honest per-platform (injection-based tests run where the mechanism works and
+ * skip where it does not).
+ *
+ * The errno check lives only in the probe, which owns a direct open() it
+ * controls; after ad_open() returns, errno is unreliable (its EC_* error path
+ * runs close()/logging that can overwrite it), so the libatalk leg asserts only
+ * that the open FAILED while armed, not the specific errno.
+ */
+int utest_faultinject_selftest(const struct vol *vol)
+{
+    struct adouble ad;
+    char path[MAXPATHLEN + 1];
+    snprintf(path, sizeof(path), "%s/fi_selftest", vol->v_path);
+
+    /* Capability probe: does the preload intercept open() here, with the armed
+     * errno?  If not (e.g. macOS two-level namespace), skip — injection-
+     * dependent tests skip too. */
+    if (!faultinject_open_works(path)) {
+        return TEST_SKIP;
+    }
+
+    /* It works; also confirm injection reaches open() *inside libatalk* (via
+     * ad_open), not just a direct libc open from the executable. */
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR | ADFLAGS_CREATE,
+                0666) != 0) {
+        return 1;                    /* setup create failed */
+    }
+
+    ad_close(&ad, ADFLAGS_DF);
+    ad_init(&ad, vol);
+    fault_inject_reset();
+    fi.open_armed = 1;
+    fi.open_fail_after = 0;          /* fail the very next open */
+    fi.open_errno = EMFILE;
+    int ad_ret = ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR, 0666);
+    fault_inject_reset();
+
+    if (ad_ret == 0) {
+        ad_close(&ad, ADFLAGS_DF);   /* libatalk open not intercepted */
+        (void)unlink(path);
+        return 2;
+    }
+
+    (void)unlink(path);
+    return 0;
+}
+
+/* Is fd a currently-valid descriptor in this process? */
+static int fd_is_open(int fd)
+{
+    return fd >= 0 && fcntl(fd, F_GETFD) != -1;
+}
+
+/*!
+ * @brief afp_openfork() error cleanup closes an open fork's fd (no leak).
+ *
+ * Category: accounting invariant.  The invariant: after the open-error cleanup
+ * ad_close(DF|RF|HF|SETSHRMD), no fork fd survives.  When afp_openfork() fails
+ * partway it must close whatever the first ad_open() opened, or that fd leaks
+ * into the long-lived child.  Verified by accounting (not an fd-count scan, which
+ * is racy and Linux-only): capture the raw data-fork fd, run the cleanup, and
+ * assert two independent ledgers agree the fd is gone — the ad layer
+ * (ad_data_fileno == -1) AND the kernel (fcntl(fd) -> EBADF).  A negative control
+ * (fd open before cleanup) keeps the assertion from passing vacuously.
+ */
+int utest_openfork_no_fd_leak(const struct vol *vol)
+{
+    struct adouble ad;
+    char path[MAXPATHLEN + 1];
+    int dfd;
+    snprintf(path, sizeof(path), "%s/fi_leak", vol->v_path);
+    ad_init(&ad, vol);
+
+    /* First ad_open(): opens a real data-fork fd (refcount 1). */
+    if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR | ADFLAGS_CREATE,
+                0666) != 0) {
+        return 1;                    /* setup open failed */
+    }
+
+    dfd = ad_data_fileno(&ad);
+
+    /* Negative control: before cleanup the fd MUST be open, else the leak
+     * assertion below would pass vacuously. */
+    if (!fd_is_open(dfd)) {
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 2;                    /* fd not open after a successful open?! */
+    }
+
+    /* Run afp_openfork()'s error-path cleanup (close keyed on open-state). */
+    if (AD_DATA_OPEN(&ad) || AD_META_OPEN(&ad) || AD_RSRC_OPEN(&ad)) {
+        ad_close(&ad, (ADFLAGS_DF | ADFLAGS_RF | ADFLAGS_HF) | ADFLAGS_SETSHRMD);
+    }
+
+    (void)unlink(path);
+
+    /* ad-layer accounting: the data-fork fileno must be reset. */
+    if (ad_data_fileno(&ad) != -1) {
+        return 3;                    /* ad layer still records the fd open */
+    }
+
+    /* kernel truth: the captured fd must really be closed (the leak check). */
+    if (fd_is_open(dfd)) {
+        return 4;                    /* fd leaked: cleanup did not close it */
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief Shared-adouble open/close refcount + fileno ledger stays balanced.
+ *
+ * Category: accounting invariant (broad).  When several forks reference one
+ * inode they share a single struct adouble; ad_open_df()'s already-open path
+ * bumps the fd-level adf_refcount instead of opening a second fd, and ad_close()
+ * decrements it, closing the fd only at the last reference.  This pins down that
+ * whole family with one test by walking the ledger across a multi-reference
+ * open/close sequence and asserting the two coupled invariants at every step:
+ *   - the fd is open  iff  adf_refcount > 0   (fileno reset to -1 exactly at 0);
+ *   - refcount tracks references exactly (N opens need N closes; an early close
+ *     must NOT close the shared fd while a sibling reference remains).
+ * It is the regression net that protects every open/close/cleanup path the
+ * fork series touches.
+ */
+int utest_shared_adouble_refcount_balance(const struct vol *vol)
+{
+    struct adouble ad;
+    char path[MAXPATHLEN + 1];
+    int dfd;
+    snprintf(path, sizeof(path), "%s/fi_shared", vol->v_path);
+    ad_init(&ad, vol);
+
+    /* Reference 1: real open. */
+    if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR | ADFLAGS_CREATE,
+                0666) != 0) {
+        return 1;                    /* setup open failed */
+    }
+
+    dfd = ad_data_fileno(&ad);
+
+    if (dfd < 0 || ad.ad_data_fork.adf_refcount != 1 || !fd_is_open(dfd)) {
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 2;                    /* fresh open: expected refcount 1, fd open */
+    }
+
+    /* Reference 2: same adouble already open -> refcount++, same fd (no 2nd open). */
+    if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR, 0666) != 0) {
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 3;                    /* second reference open failed */
+    }
+
+    if (ad.ad_data_fork.adf_refcount != 2 || ad_data_fileno(&ad) != dfd) {
+        (void)unlink(path);
+        return 4;                    /* 2nd ref must share the fd, refcount 2 */
+    }
+
+    /* Release reference 2: refcount 2->1, fd MUST stay open (sibling holds it). */
+    ad_close(&ad, ADFLAGS_DF);
+
+    if (ad.ad_data_fork.adf_refcount != 1) {
+        (void)unlink(path);
+        return 5;                    /* refcount did not drop to 1 */
+    }
+
+    if (ad_data_fileno(&ad) != dfd || !fd_is_open(dfd)) {
+        (void)unlink(path);
+        return 6;                    /* shared fd wrongly closed at refcount 1 */
+    }
+
+    /* Release reference 1 (last): refcount 1->0, fd closed and fileno reset. */
+    ad_close(&ad, ADFLAGS_DF);
+    (void)unlink(path);
+
+    if (ad.ad_data_fork.adf_refcount != 0) {
+        return 7;                    /* last close did not zero the refcount */
+    }
+
+    if (ad_data_fileno(&ad) != -1) {
+        return 8;                    /* fileno not reset at last close */
+    }
+
+    if (fd_is_open(dfd)) {
+        return 9;                    /* fd leaked: not closed at last reference */
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief ad_close() hard-fails on an adf_refcount underflow.
+ *
+ * Category: targeted (nuanced).  Accounting invariants are too broad to reach
+ * this: the underflow guard's else-branch fires only in a desync no correct
+ * open/close sequence produces — fileno still valid (>= 0) yet adf_refcount
+ * already <= 0 (a balanced close clears the fileno exactly as the refcount hits
+ * 0).  The guard is defense-in-depth against a future stray double-close on a
+ * shared adouble, so the test deliberately manufactures that precise state:
+ * open the data fork, force adf_refcount to 0, then ad_close() — the outer
+ * fileno guard passes, the refcount else fires, AFP_ASSERT (live in
+ * debugoptimized) abort()s.
+ *
+ * AFP_ASSERT abort()s the process, so run it in a fork()ed child and assert the
+ * child died via SIGABRT; the parent (the harness) survives.  AFP_ASSERT
+ * self-gates on NDEBUG: in a release/NDEBUG build it compiles to a no-op and the
+ * guard cannot abort, so the test skips there rather than failing — its result
+ * is correctly build-type-aware.
+ */
+int utest_adclose_underflow_aborts(const struct vol *vol)
+{
+#ifdef NDEBUG
+    /* AFP_ASSERT is a no-op here; the guard logs but cannot abort. */
+    (void)vol;
+    return TEST_SKIP;
+#else
+    char path[MAXPATHLEN + 1];
+    pid_t pid;
+    int status;
+    snprintf(path, sizeof(path), "%s/fi_underflow", vol->v_path);
+    pid = fork();
+
+    if (pid < 0) {
+        LOG(log_error, logtype_afpd, "underflow: fork failed: %s", strerror(errno));
+        return 1;
+    }
+
+    if (pid == 0) {
+        /* Child: manufacture fileno>=0 with adf_refcount==0, then close. */
+        struct adouble ad;
+        ad_init(&ad, vol);
+
+        if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR | ADFLAGS_CREATE,
+                    0666) != 0) {
+            _exit(2);                /* setup failure, distinct from SIGABRT */
+        }
+
+        /* Desync: fd still open, but the fd-level refcount is exhausted. */
+        ad.ad_data_fork.adf_refcount = 0;
+        ad_close(&ad, ADFLAGS_DF);   /* fileno>=0 && refcount<=0 -> guard abort */
+        _exit(3);                    /* must not reach: guard did not fire */
+    }
+
+    /* Parent: reap and check the child aborted. */
+    if (waitpid(pid, &status, 0) != pid) {
+        LOG(log_error, logtype_afpd, "underflow: waitpid failed: %s",
+            strerror(errno));
+        (void)unlink(path);
+        return 4;
+    }
+
+    (void)unlink(path);
+
+    if (WIFSIGNALED(status) && WTERMSIG(status) == SIGABRT) {
+        return 0;                    /* guard fired as designed */
+    }
+
+    if (WIFEXITED(status)) {
+        LOG(log_error, logtype_afpd,
+            "underflow: child exited %d without aborting — guard did not fire",
+            WEXITSTATUS(status));
+    } else {
+        LOG(log_error, logtype_afpd,
+            "underflow: child died on signal %d, expected SIGABRT",
+            WTERMSIG(status));
+    }
+
+    return 5;
+#endif
+}

--- a/test/afpd/subtests_lock.h
+++ b/test/afpd/subtests_lock.h
@@ -1,0 +1,25 @@
+/*
+  Copyright (c) 2026 andylemin
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+*/
+
+#ifndef SUBTESTS_LOCK_H
+#define SUBTESTS_LOCK_H
+
+#include <atalk/volume.h>
+
+extern int utest_faultinject_selftest(const struct vol *vol);
+extern int utest_openfork_no_fd_leak(const struct vol *vol);
+extern int utest_shared_adouble_refcount_balance(const struct vol *vol);
+extern int utest_adclose_underflow_aborts(const struct vol *vol);
+
+#endif /* SUBTESTS_LOCK_H */

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -40,6 +40,7 @@
 #include "filedir.h"
 #include "hash.h"
 #include "subtests.h"
+#include "subtests_lock.h"
 #include "test.h"
 #include "volume.h"
 
@@ -90,19 +91,28 @@ int main(int argc, char *argv[])
 
     /* initialize */
     test_section("Initializing", "============");
-    TEST(setuplog("default:note", "/dev/tty", true));
-    TEST(afp_options_parse_cmdline(&obj, 3, &args[0]));
-    TEST_int(afp_config_parse(&obj, NULL), 0);
+    /* Log to stderr, not /dev/tty: under a non-interactive runner (CI, meson
+     * test, docker run) there is no controlling terminal, so /dev/tty writes
+     * fail with ENXIO and every LOG() is silently dropped.  stderr is captured. */
+    TEST(setuplog("default:note", "/dev/stderr", true),
+         "init logging to stderr");
+    TEST(afp_options_parse_cmdline(&obj, 3, &args[0]),
+         "parse afpd command-line options");
+    TEST_int(afp_config_parse(&obj, NULL), 0,
+             "parse afp.conf into AFPObj config");
     TEST_expr(reti = 0,
               obj.options.Cnid_srv != NULL
-              && strcmp(obj.options.Cnid_srv, "127.0.0.1") == 0);
+              && strcmp(obj.options.Cnid_srv, "127.0.0.1") == 0,
+              "config: CNID server parsed as 127.0.0.1");
     TEST_expr(reti = 0,
               obj.options.Cnid_port != NULL
-              && strcmp(obj.options.Cnid_port, "4700") == 0);
-    TEST_int(configinit(&obj, &aspobj), 0);
-    TEST(cnid_init());
-    TEST(load_volumes(&obj, LV_ALL));
-    TEST_int(dircache_init(8192), 0);
+              && strcmp(obj.options.Cnid_port, "4700") == 0,
+              "config: CNID port parsed as 4700");
+    TEST_int(configinit(&obj, &aspobj), 0,
+             "initialize server config state");
+    TEST(cnid_init(), "initialize CNID subsystem");
+    TEST(load_volumes(&obj, LV_ALL), "load all volumes from config");
+    TEST_int(dircache_init(8192), 0, "initialize dircache (8192 entries)");
     obj.afp_version = 34;
     /* No IPC channel or dircache hint pipe in test harness */
     obj.ipc_fd = -1;
@@ -116,34 +126,64 @@ int main(int argc, char *argv[])
 
     /* now run tests */
     test_section("Running tests", "=============");
-    TEST_expr(vid = openvol(&obj, "afpd_test"), vid != 0);
-    TEST_expr(vol = getvolbyvid(vid), vol != NULL);
+    TEST_expr(vid = openvol(&obj, "afpd_test"), vid != 0,
+              "open the afpd_test volume");
+    TEST_expr(vol = getvolbyvid(vid), vol != NULL,
+              "resolve volume by volume id");
     TEST_expr(reti = 0,
               vol->v_cnidserver != NULL
-              && strcmp(vol->v_cnidserver, "localhost") == 0);
+              && strcmp(vol->v_cnidserver, "localhost") == 0,
+              "volume: CNID server is localhost");
     TEST_expr(reti = 0,
               vol->v_cnidport != NULL
-              && strcmp(vol->v_cnidport, "4700") == 0);
+              && strcmp(vol->v_cnidport, "4700") == 0,
+              "volume: CNID port is 4700");
     /* test directory.c stuff */
-    TEST_expr(retdir = dirlookup(vol, DIRDID_ROOT_PARENT), retdir != NULL);
-    TEST_expr(retdir = dirlookup(vol, DIRDID_ROOT), retdir != NULL);
+    TEST_expr(retdir = dirlookup(vol, DIRDID_ROOT_PARENT), retdir != NULL,
+              "dirlookup: root parent directory");
+    TEST_expr(retdir = dirlookup(vol, DIRDID_ROOT), retdir != NULL,
+              "dirlookup: root directory");
     TEST_expr(path = cname(vol, retdir, cnamewrap("Network Trash Folder")),
-              path != NULL);
-    TEST_expr(retdir = dirlookup(vol, DIRDID_ROOT), retdir != NULL);
-    TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT_PARENT, "afpd_test"), 0);
-    TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT, ""), 0);
+              path != NULL,
+              "cname: resolve 'Network Trash Folder'");
+    TEST_expr(retdir = dirlookup(vol, DIRDID_ROOT), retdir != NULL,
+              "dirlookup: root directory again");
+    TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT_PARENT, "afpd_test"), 0,
+             "getfiledirparms: volume root");
+    TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT, ""), 0,
+             "getfiledirparms: root dir, empty name");
     TEST_expr(reti = createdir(&obj, vid, DIRDID_ROOT, "dir1"),
-              reti == 0 || reti == AFPERR_EXIST);
-    TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT, "dir1"), 0);
-    TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT, "\000\000"), 0);
-    TEST_int(createfile(&obj, vid, DIRDID_ROOT, "dir1/file1"), 0);
-    TEST_int(delete (&obj, vid, DIRDID_ROOT, "dir1/file1"), 0);
-    TEST_int(delete (&obj, vid, DIRDID_ROOT, "dir1"), 0);
-    TEST_int(createfile(&obj, vid, DIRDID_ROOT, "file1"), 0);
-    TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT, "file1"), 0);
-    TEST_int(delete (&obj, vid, DIRDID_ROOT, "file1"), 0);
+              reti == 0 || reti == AFPERR_EXIST,
+              "createdir: 'dir1' (created or already exists)");
+    TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT, "dir1"), 0,
+             "getfiledirparms: 'dir1'");
+    TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT, "\000\000"), 0,
+             "getfiledirparms: null-name edge case");
+    TEST_int(createfile(&obj, vid, DIRDID_ROOT, "dir1/file1"), 0,
+             "createfile: 'dir1/file1'");
+    TEST_int(delete (&obj, vid, DIRDID_ROOT, "dir1/file1"), 0,
+             "delete: 'dir1/file1'");
+    TEST_int(delete (&obj, vid, DIRDID_ROOT, "dir1"), 0,
+             "delete: 'dir1' directory");
+    TEST_int(createfile(&obj, vid, DIRDID_ROOT, "file1"), 0,
+             "createfile: 'file1' at root");
+    TEST_int(getfiledirparms(&obj, vid, DIRDID_ROOT, "file1"), 0,
+             "getfiledirparms: 'file1'");
+    TEST_int(delete (&obj, vid, DIRDID_ROOT, "file1"), 0,
+             "delete: 'file1'");
     /* test enumerate.c stuff */
-    TEST_int(enumerate(&obj, vid, DIRDID_ROOT), 0);
+    TEST_int(enumerate(&obj, vid, DIRDID_ROOT), 0,
+             "enumerate: root directory contents");
+    /* fork/adouble fault-injection unit tests (TEST_int_or_skip: tests that
+     * cannot run on this platform/build return TEST_SKIP rather than failing) */
+    TEST_int_or_skip(utest_faultinject_selftest(vol), 0,
+                     "fault-injection: LD_PRELOAD interposer is active");
+    TEST_int_or_skip(utest_openfork_no_fd_leak(vol), 0,
+                     "afp_openfork() error path closes the leaked fork");
+    TEST_int_or_skip(utest_shared_adouble_refcount_balance(vol), 0,
+                     "shared adouble: ad_close() refcount balance, no early fd close");
+    TEST_int_or_skip(utest_adclose_underflow_aborts(vol), 0,
+                     "ad_close() hard-fails (abort) on adf_refcount underflow");
     /* cleanup */
     closevol(&obj, vol);
     unload_volumes(&obj);

--- a/test/afpd/test.h
+++ b/test/afpd/test.h
@@ -131,36 +131,76 @@ static inline void test_abort(void)
     }
 }
 
-#define TEST(a) \
+/*! Sentinel return value: a test could not run on this platform/build and is
+ *  skipped (not a failure).  Mirrors the conventional autotools/meson skip
+ *  exit code; surfaced as a TAP "ok N - name # SKIP" directive. */
+#define TEST_SKIP 77
+
+static inline void test_skip(const char *name)
+{
+    if (test_output_tap) {
+        fprintf(test_stream(), "ok %d - %s # SKIP\n", ++test_case_num, name);
+        fflush(test_stream());
+    } else {
+        fprintf(test_stream(), "[skip]\n");
+    }
+}
+
+/* Every TEST* macro takes a trailing human-readable summary `desc` that becomes
+ * the test NAME in the output: the text after "ok N - " in TAP mode (what
+ * `meson test` shows), and after "Testing: " in plain mode.  `desc` is REQUIRED
+ * -- it is what makes the run self-describing ("ok 25 - openfork() error path
+ * closes the leaked fork" instead of an opaque stringified expression).  On
+ * failure, file:line still pinpoints the offending call. */
+
+#define TEST(a, desc) \
     do {                               \
-        test_begin(#a);                \
+        test_begin(desc);              \
         a;                             \
-        test_ok(#a);                   \
+        test_ok(desc);                 \
     } while (0)
 
-#define TEST_int(a, b) \
+#define TEST_int(a, b, desc) \
     do {                                           \
-        test_begin(#a);                            \
+        test_begin(desc);                          \
         if ((reti = (a)) != b) {                   \
-            test_fail_int(#a, reti, b, __FILE__,   \
+            test_fail_int(desc, reti, b, __FILE__, \
                           __LINE__);               \
             test_abort();                           \
             exit(1);                               \
         } else {                                   \
-            test_ok(#a);                           \
+            test_ok(desc);                         \
         }                                          \
     } while (0)
 
-#define TEST_expr(a, b)                           \
+#define TEST_expr(a, b, desc)                     \
     do {                                          \
-        test_begin(#a);                           \
+        test_begin(desc);                         \
         a;                                        \
         if (b) {                                  \
-            test_ok(#a);                          \
+            test_ok(desc);                        \
         } else {                                  \
-            test_fail(#a, __FILE__, __LINE__);    \
+            test_fail(desc, __FILE__, __LINE__);  \
             test_abort();                         \
             exit(1);                              \
         }                                         \
+    } while (0)
+
+/*! Like TEST_int, but a TEST_SKIP return marks the test skipped (not failed),
+ *  for tests that cannot run on the current platform or build configuration. */
+#define TEST_int_or_skip(a, b, desc)               \
+    do {                                           \
+        test_begin(desc);                          \
+        reti = (a);                                \
+        if (reti == TEST_SKIP) {                   \
+            test_skip(desc);                       \
+        } else if (reti != b) {                    \
+            test_fail_int(desc, reti, b, __FILE__, \
+                          __LINE__);               \
+            test_abort();                          \
+            exit(1);                               \
+        } else {                                   \
+            test_ok(desc);                         \
+        }                                          \
     } while (0)
 #endif  /* TEST_H */


### PR DESCRIPTION
afp_openfork() opens the data/resource fork, then a second ad_open() for the AppleDouble metadata fork, then does getforkparams / WriteInhibit / fork_setmode.  On failure after the first ad_open() succeeded, control jumped to the openfork_err: label, which ran:
    
        openfork_err:
            of_dealloc(ofork);
            if (errno == EACCES) return ...;
            return ret;
    
of_dealloc() unhashes the ofork, drops the struct-adouble refcount and frees it, but never calls ad_close().  So the fd opened by the first ad_open() was leaked into the long-lived afpd child every time a later step reached the label: the metadata open failing with EROFS/EMFILE/ENFILE/EISDIR, getforkparams failing, or the WriteInhibit branch firing.
The lock side effects of that first open (share-mode F_SETLK from ad_open_df) were likewise never released.
    
 Two switch statements compounded it: the EROFS case lacked a break and fell through, so a read-only mount returned AFPERR_NFILE ("too many open files") instead of AFPERR_VLOCK, and the label could not derive the right code from errno because the cleanup close(2) clobbers it.
    
Scope: reachable on every read-only mount (EROFS) and under fd pressure (EMFILE/ENFILE); each occurrence is a permanent fd leak until the session ends.  Latent on the common read-write success path.
    
Fix.  Each error case sets ret explicitly (no fall-through), and every failure after the first ad_open() funnels through the single openfork_err: label, which closes whatever is actually open -- ad_close(DF|RF|HF|SETSHRMD) keyed on the AD_*_OPEN state, exactly once -- before of_dealloc().

The metadata-open, getforkparams, WriteInhibit and fork_setmode error paths all goto the label rather than running their own cleanup, so the fd and its share-mode locks are released in every failure combination.  fork_setmode's bespoke errno->AFPERR mapping (EAGAIN/EACCES/EINVAL -> AFPERR_DENYCONF, else AFPERR_PARAM) is done before the goto, while errno still holds the fault value, because the cleanup ad_close()/close(2) clobbers it.  SETSHRMD releases the data fork's share-mode locks; the open-state guard makes a failure before the first open close nothing.
    
Defense-in-depth: ad_close()'s four adf_refcount decrements (data, HF meta, AD_VERSION2 RF-closes-HF, EA reso) and of_dealloc()'s struct-level ad_refcount decrement are underflow-guarded.  A decrement that would go below zero -- a stray double ad_close()/of_dealloc() on a shared adouble -- is logged and trips AFP_ASSERT (active in non-NDEBUG builds) instead of silently corrupting the count and closing a sibling fork's fd. Behaviour-neutral on every correct path.
    
Testing:
Build-time fault-injection unit test framework (test/afpd/).  afpdtest links the real afpd objects plus libatalk, so it can drive ad_open/ad_close/of_alloc directly in one process against a scratch volume -- reaching faults the black-box spectest cannot.

Because libatalk is a shared library, a link-time --wrap on the executable cannot intercept its internal libc calls, so faultinject.c is built two ways from one source: compiled into afpdtest it provides the `fi` control block; built as libfaultinject.so (-DFAULTINJECT_PRELOAD) and LD_PRELOADed it interposes open/close/fcntl/fchdir at dynamic resolution, forwarding to the real symbol via dlsym(RTLD_NEXT) unless a failure is armed.  Under glibc with _FILE_OFFSET_BITS=64 the single open() definition is renamed by <fcntl.h> to open64() (the symbol LFS callers reference), so no separate open64() interposer is needed.

A test arms an fi armed/fail_after/errno counter narrowly around the call under test and resets after.  test.c logs to /dev/stderr rather than /dev/tty (no controlling terminal under meson test / CI / docker, where /dev/tty writes ENXIO and every LOG() was silently dropped), so a passing run is clean and a failure emits context; each utest_* returns 0 or a distinct nonzero code surfaced as "# got: N".
    
Interception is not reliable on every platform -- macOS's two-level namespace ignores a plain symbol preload -- so the self-test is a capability probe that returns TEST_SKIP when injection does not reach libatalk, and injection-dependent tests skip too, keeping coverage honest per platform.
    
Tests (subtests_lock.c), two kinds -- broad accounting-invariant tests that pin a ledger across a family of sequences, and targeted tests for nuance accounting cannot see:
    
 - utest_faultinject_selftest (framework): probes whether the preload intercepts open() here, then arms EMFILE on the next open and confirms ad_open() inside libatalk fails -- gates the injection mechanism itself; the errno check lives only in the probe because ad_open()'s error path clobbers errno.
 - utest_openfork_no_fd_leak (accounting): runs the openfork_err cleanup on an open data fork and asserts both ledgers agree the fd is gone (ad_data_fileno == -1 and fcntl(fd) -> EBADF), with a negative control so it cannot pass vacuously -- the regression net for this fix.
 - utest_shared_adouble_refcount_balance (accounting): walks a multi-reference open/close sequence asserting adf_refcount and fileno stay coupled (fd open iff refcount > 0; an early close must not close the shared fd).
 - utest_adclose_underflow_aborts (targeted): manufactures the fileno>=0 / refcount<=0 desync the guard defends and asserts ad_close() trips AFP_ASSERT -> SIGABRT, run in a fork()ed child so the harness survives; skips under NDEBUG where AFP_ASSERT is a no-op.

Make the unit test summary string a required argument of the TEST/TEST_int/TEST_expr/TEST_int_or_skip macros:
Unit tests are now self-describing.