### PR TITLE
adouble: strip destructive flags on read-only downgrade retry, log fcntl(F_UNSHARE) failures in of_closefork()

### DIFF
--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -547,12 +547,18 @@ int of_closefork(const AFPObj *obj, struct ofork *ofork)
         fshare_t shmd;
         shmd.f_id = ofork->of_refnum;
 
-        if (AD_DATA_OPEN(ofork->of_ad)) {
-            fcntl(ad_data_fileno(ofork->of_ad), F_UNSHARE, &shmd);
+        if (AD_DATA_OPEN(ofork->of_ad)
+                && fcntl(ad_data_fileno(ofork->of_ad), F_UNSHARE, &shmd) < 0) {
+            LOG(log_warning, logtype_afpd,
+                "of_closefork: F_UNSHARE on data fork failed for refnum %"
+                PRIu16 ": %s", ofork->of_refnum, strerror(errno));
         }
 
-        if (AD_RSRC_OPEN(ofork->of_ad)) {
-            fcntl(ad_reso_fileno(ofork->of_ad), F_UNSHARE, &shmd);
+        if (AD_RSRC_OPEN(ofork->of_ad)
+                && fcntl(ad_reso_fileno(ofork->of_ad), F_UNSHARE, &shmd) < 0) {
+            LOG(log_warning, logtype_afpd,
+                "of_closefork: F_UNSHARE on rsrc fork failed for refnum %"
+                PRIu16 ": %s", ofork->of_refnum, strerror(errno));
         }
     }
 

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -1165,7 +1165,7 @@ static int ad_open_df(const char *path, int adflags, mode_t mode,
 {
     EC_INIT;
     struct stat st_dir;
-    int         oflags;
+    int         oflags, oflags_orig;
     mode_t      admode;
     int         st_invalid = -1;
     ssize_t     lsz;
@@ -1192,6 +1192,7 @@ static int ad_open_df(const char *path, int adflags, mode_t mode,
     }
 
     oflags = ad2openflags(ad, ADFLAGS_DF, adflags);
+    oflags_orig = oflags;       /* caller's intent, for the read-only-retry check */
     admode = mode;
 
     if (adflags & ADFLAGS_CREATE) {
@@ -1236,7 +1237,17 @@ static int ad_open_df(const char *path, int adflags, mode_t mode,
         case EPERM:
         case EROFS:
             if ((adflags & ADFLAGS_SETSHRMD) && (adflags & ADFLAGS_RDONLY)) {
-                oflags &= ~O_RDWR;
+                /* Strict read-only re-open: strip any write-implying or
+                 * destructive flag ad2openflags() may have set; only the
+                 * access mode and the surviving flags (e.g. O_NOFOLLOW) stay. */
+                if (oflags_orig & (O_CREAT | O_EXCL | O_TRUNC)) {
+                    LOG(log_warning, logtype_ad,
+                        "ad_open_df: SETSHRMD|RDONLY caller passed "
+                        "O_CREAT/O_EXCL/O_TRUNC (0x%x); stripped on retry",
+                        oflags_orig);
+                }
+
+                oflags &= ~(O_RDWR | O_WRONLY | O_CREAT | O_EXCL | O_TRUNC);
                 oflags |= O_RDONLY;
                 EC_NEG1(ad->ad_data_fork.adf_fd = open(path, oflags, admode));
                 break;
@@ -1326,7 +1337,11 @@ static int ad_open_hf_v2(const char *path, int adflags, mode_t mode,
         case EPERM:
         case EROFS:
             if ((adflags & ADFLAGS_RDONLY) && (adflags & ADFLAGS_SETSHRMD)) {
-                nocreatflags &= ~O_RDWR;
+                /* Strict read-only re-open: also drop O_TRUNC so a downgrade
+                 * retry can never truncate the metadata file.  O_CREAT/O_EXCL
+                 * are already absent from nocreatflags (stripped at its
+                 * construction).  Mirrors ad_open_df()'s retry mask. */
+                nocreatflags &= ~(O_RDWR | O_TRUNC);
                 nocreatflags |= O_RDONLY;
                 EC_NEG1(ad_meta_fileno(ad) = open(ad_p, nocreatflags));
                 ad->ad_mdp->adf_flags = nocreatflags;
@@ -1700,7 +1715,11 @@ static int ad_open_rf_ea(const char *path, int adflags, int mode,
                     EC_FAIL;
                 }
 
-                oflags &= ~O_RDWR;
+                /* Strict read-only re-open: also drop O_TRUNC so a downgrade
+                 * retry can never truncate the resource fork.  O_CREAT is
+                 * already absent (stripped at oflags construction above).
+                 * Mirrors ad_open_df()'s retry mask. */
+                oflags &= ~(O_RDWR | O_TRUNC);
                 oflags |= O_RDONLY;
 
                 if ((ad_reso_fileno(ad) = sys_getxattrfd(ad_meta_fileno(ad), AD_EA_RESO,
@@ -1742,7 +1761,11 @@ static int ad_open_rf_ea(const char *path, int adflags, int mode,
                     EC_FAIL;
                 }
 
-                oflags &= ~O_RDWR;
+                /* Strict read-only re-open: also drop O_TRUNC so a downgrade
+                 * retry can never truncate the resource fork.  O_CREAT is
+                 * already absent (stripped at oflags construction above).
+                 * Mirrors ad_open_df()'s retry mask. */
+                oflags &= ~(O_RDWR | O_TRUNC);
                 oflags |= O_RDONLY;
 
                 if ((ad_reso_fileno(ad) = open(rfpath, oflags)) == -1) {

--- a/test/afpd/faultinject.c
+++ b/test/afpd/faultinject.c
@@ -170,6 +170,16 @@ int open(const char *path, int flags, ...)
         real_open = (open_fn)dlsym(RTLD_NEXT, "open");
     }
 
+    /* Record the flags of every armed open() so a test can inspect WHAT a retry
+     * re-opened with (e.g. assert a read-only downgrade retry dropped O_TRUNC),
+     * not merely that an open happened.  Recorded before the failure decision so
+     * the count and flags reflect the attempt regardless of outcome; only while
+     * armed, to stay inert for unrelated infrastructure opens. */
+    if (fi.open_armed) {
+        fi.open_calls++;
+        fi.open_last_flags = flags;
+    }
+
     if (fault_should_fire(fi.open_armed, &fi.open_fail_after, fi.open_errno)) {
         return -1;
     }

--- a/test/afpd/faultinject.h
+++ b/test/afpd/faultinject.h
@@ -32,6 +32,8 @@ struct fault_inject {
     int open_armed;
     int open_fail_after;    /*!< succeed this many armed opens, then fail once */
     int open_errno;
+    int open_calls;         /*!< count of armed open() calls seen */
+    int open_last_flags;    /*!< flags arg of the most recent armed open() */
     int close_armed;
     int close_fail_after;
     int close_errno;

--- a/test/afpd/subtests_lock.c
+++ b/test/afpd/subtests_lock.c
@@ -328,3 +328,77 @@ int utest_adclose_underflow_aborts(const struct vol *vol)
     return 5;
 #endif
 }
+
+/*!
+ * @brief Read-only downgrade retry re-opens without destructive flags.
+ *
+ * Category: targeted (nuanced).  ad_open_df() retries a failed open() read-only
+ * when the caller passed ADFLAGS_SETSHRMD | ADFLAGS_RDONLY and attempt 1 hit
+ * EACCES/EPERM/EROFS; the retry must strip O_TRUNC/O_CREAT/O_EXCL, not just flip
+ * the access mode, or a SETSHRMD|RDONLY|TRUNC caller would truncate on the retry
+ * a file it asked to open read-only.  No fd/refcount ledger sees this -- the bug
+ * is in WHICH flags the second open() carries -- so drive the retry and inspect
+ * the flags the shim recorded.  ad2openflags() makes attempt 1 O_RDWR|O_TRUNC;
+ * arming EACCES on it forces the retry, whose flags land in open_last_flags
+ * (open_calls == 2).  Skips where the shim cannot intercept libatalk's open().
+ */
+int utest_ro_retry_strips_destructive_flags(const struct vol *vol)
+{
+    struct adouble ad;
+    char path[MAXPATHLEN + 1];
+    int ad_ret, retry_flags, calls;
+    snprintf(path, sizeof(path), "%s/fi_ro_retry", vol->v_path);
+
+    if (!faultinject_open_works(path)) {
+        return TEST_SKIP;
+    }
+
+    /* Disarm any injection a prior test left armed before the pre-create setup,
+     * so a stale fi.open_armed cannot fail it or skew open_calls. */
+    fault_inject_reset();
+    /* Pre-create: the RDONLY retry (no O_CREAT) needs the file to exist. */
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR | ADFLAGS_CREATE,
+                0666) != 0) {
+        (void)unlink(path);          /* may have been created before failing */
+        return 1;                    /* setup create failed */
+    }
+
+    ad_close(&ad, ADFLAGS_DF);
+    ad_init(&ad, vol);
+    fault_inject_reset();
+    fi.open_armed = 1;
+    fi.open_fail_after = 0;           /* attempt 1 fails EACCES; retry runs */
+    fi.open_errno = EACCES;
+    ad_ret = ad_open(&ad, path,
+                     ADFLAGS_DF | ADFLAGS_RDONLY | ADFLAGS_SETSHRMD | ADFLAGS_TRUNC,
+                     0666);
+    calls = fi.open_calls;
+    retry_flags = fi.open_last_flags;
+    fault_inject_reset();
+
+    if (ad_ret == 0) {
+        ad_close(&ad, ADFLAGS_DF);
+    }
+
+    (void)unlink(path);
+
+    if (calls != 2) {
+        return 2;                    /* negative control: retry did not run */
+    }
+
+    if (retry_flags & O_TRUNC) {
+        return 3;                    /* destructive flag survived the RO retry */
+    }
+
+    if (retry_flags & (O_RDWR | O_WRONLY)) {
+        return 4;                    /* retry not downgraded to read-only */
+    }
+
+    if (ad_ret != 0) {
+        return 5;                    /* read-only retry open failed */
+    }
+
+    return 0;
+}

--- a/test/afpd/subtests_lock.h
+++ b/test/afpd/subtests_lock.h
@@ -21,5 +21,6 @@ extern int utest_faultinject_selftest(const struct vol *vol);
 extern int utest_openfork_no_fd_leak(const struct vol *vol);
 extern int utest_shared_adouble_refcount_balance(const struct vol *vol);
 extern int utest_adclose_underflow_aborts(const struct vol *vol);
+extern int utest_ro_retry_strips_destructive_flags(const struct vol *vol);
 
 #endif /* SUBTESTS_LOCK_H */

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -184,6 +184,8 @@ int main(int argc, char *argv[])
                      "shared adouble: ad_close() refcount balance, no early fd close");
     TEST_int_or_skip(utest_adclose_underflow_aborts(vol), 0,
                      "ad_close() hard-fails (abort) on adf_refcount underflow");
+    TEST_int_or_skip(utest_ro_retry_strips_destructive_flags(vol), 0,
+                     "read-only downgrade retry strips O_TRUNC (no truncate)");
     /* cleanup */
     closevol(&obj, vol);
     unload_volumes(&obj);


### PR DESCRIPTION
Commit 1 — afpd: log fcntl(F_UNSHARE) failures in of_closefork()
The bug. On Solaris/illumos, of_closefork() releases the kernel share reservation with fcntl(fd, F_UNSHARE, …) but ignored the return value. If F_UNSHARE fails (e.g. EBADF/EINVAL on a stale share id), the reservation persists in the kernel after ad_close() closes the fd — leaking it until the afpd child exits, with zero operator visibility.

Scope. Solaris/illumos only (HAVE_FSHARE_T), and only when share reservations are enabled (OPTION_SHARE_RESERV). Manifests as a long-running afpd slowly accumulating orphaned ZFS/UFS share locks on busy mounts.

When triggered. Every fork close where the F_UNSHARE syscall fails — rare, but completely silent today.

The fix. Check each F_UNSHARE return (data fork + resource fork) and emit a log_warning naming the fork and refnum on failure. There's no recovery path for a stuck reservation short of process exit, so the actionable improvement is visibility — an operator can now see it happening instead of debugging a mystery fd/lock leak. No behaviour change on the success path.

Commit 2 — adouble: strip destructive flags on read-only downgrade retry
The bug. When open() for a fork fails with EACCES/EPERM/EROFS and the caller asked for a read-only share-mode open, the adouble layer retries by downgrading O_RDWR → O_RDONLY. But the retry only flipped the access-mode bits — any O_TRUNC / O_CREAT / O_EXCL that ad2openflags() had set survived into the read-only re-open. That's a silent-data-loss class: a retry could truncate (or create) a file the operation had asked to open read-only.

Scope. Four sibling retry sites in libatalk/adouble/ad_open.c:

ad_open_df() — data fork
ad_open_hf_v2() — AppleDouble v2 ._ metadata fork
ad_open_rf_ea() — EA-backend resource fork (two branches: Solaris sys_getxattrfd() and the non-Solaris open())

When triggered — latent today. A full audit of every ad_open() caller confirms no current caller combines a read-only share-mode/resource open with TRUNC/CREATE/EXCL, so the retry is never reached with a destructive flag set. This is defensive hardening against a future caller, not a presently-reachable data-loss path. (Belt-and-braces: an O_TRUNC retry after an EACCES/EROFS failure would itself fail for lack of write permission — but relying on that is fragile, which is the point of the fix.)

The fix. Widen each retry's clearing mask so a read-only re-open is strictly read-only:

ad_open_df(): ~(O_RDWR | O_WRONLY | O_CREAT | O_EXCL | O_TRUNC)
ad_open_hf_v2() / ad_open_rf_ea(): ~(O_RDWR | O_TRUNC) (O_CREAT/O_EXCL are already stripped at their nocreatflags/oflags construction)
Critically, only the retry branches are touched — the initial opens keep their flags, so FPCreateFile's load-bearing O_TRUNC (which truncates a stale ._ AppleDouble header on create-over-existing) is unaffected. ad_open_df() also logs a warning if a caller's original flags included O_CREAT/O_EXCL/O_TRUNC, so any future offending caller can be identified and cleaned up.

Tests:
Added utest_ro_retry_strips_destructive_flags, covering the ad_open_df() read-only retry using the fault-injection unit test harness. It forces the first open() to fail, drives a SETSHRMD | RDONLY | TRUNC open, and asserts the retry re-opens without O_TRUNC — directly catching the bug this PR fixes. Bisection-verified (fails pre-fix, passes post-fix) and skips where the preload can't intercept libatalk (e.g. macOS); the hf_v2/rf_ea siblings share the same mask and are covered by inspection.