### PR TITLE
adouble: don't kill afpd on fchdir-restore failure in ad_metadataat/ad_openat

### DIFF
--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -2468,25 +2468,58 @@ int ad_metadataat(int dirfd, const char *name, int flags, struct adouble *adp)
     int cwdfd = -1;
 
     if (dirfd != -1) {
-        if (((cwdfd = open(".", O_RDONLY)) == -1) || (fchdir(dirfd) != 0)) {
-            ret = -1;
-            goto exit;
+        if ((cwdfd = open(".", O_RDONLY | O_DIRECTORY | O_CLOEXEC)) == -1) {
+            LOG(log_error, logtype_ad,
+                "ad_metadataat: cannot snapshot cwd: %s", strerror(errno));
+            return -1;
+        }
+
+        if (fchdir(dirfd) != 0) {
+            /* Preserve fchdir's errno across close(). */
+            int saved = errno;
+            LOG(log_error, logtype_ad,
+                "ad_metadataat: fchdir(target) failed: %s", strerror(saved));
+            close(cwdfd);
+            errno = saved;
+            return -1;
         }
     }
 
     if (ad_metadata(name, flags, adp) < 0) {
         ret = -1;
-        goto exit;
+        /* fall through: restore cwd before returning */
     }
 
     if (dirfd != -1) {
+        /* Captured before the restore so its chdir()/close() can't clobber the
+         * operation's errno (which callers map to an AFPERR). */
+        int saved = errno;
+
         if (fchdir(cwdfd) != 0) {
-            LOG(log_error, logtype_ad, "ad_openat: can't chdir back, exiting");
-            exit(EXITERR_SYS);
+            int restore_errno = errno;
+            /* The saved fd is the thing that failed, so cwd cannot be
+             * restored.  Anchor to "/" (always valid) so no relative path
+             * resolves against an unknown directory; the caller re-establishes
+             * cwd via movecwd() on its next path op. */
+            LOG(log_error, logtype_ad,
+                "ad_metadataat: cannot restore cwd (%s); anchoring to \"/\"",
+                strerror(restore_errno));
+
+            if (chdir("/") != 0) {
+                LOG(log_error, logtype_ad,
+                    "ad_metadataat: chdir(/) also failed: %s",
+                    strerror(errno));
+            }
+
+            /* When only the restore failed, that is the error to report. */
+            if (ret == 0) {
+                saved = restore_errno;
+            }
+
+            ret = -1;
+            errno = saved;
         }
     }
-
-exit:
 
     if (cwdfd != -1) {
         close(cwdfd);
@@ -2564,13 +2597,29 @@ int ad_openat(struct adouble  *ad,
 {
     EC_INIT;
     int cwdfd = -1;
+    int changed_cwd = 0;
     va_list args;
     mode_t mode = 0;
 
     if (dirfd != -1) {
-        if (((cwdfd = open(".", O_RDONLY)) == -1) || (fchdir(dirfd) != 0)) {
+        if ((cwdfd = open(".", O_RDONLY | O_DIRECTORY | O_CLOEXEC)) == -1) {
+            LOG(log_error, logtype_ad,
+                "ad_openat: cannot snapshot cwd: %s", strerror(errno));
             EC_FAIL;
         }
+
+        if (fchdir(dirfd) != 0) {
+            /* Preserve fchdir's errno across close(). */
+            int saved = errno;
+            LOG(log_error, logtype_ad,
+                "ad_openat: fchdir(target) failed: %s", strerror(saved));
+            close(cwdfd);
+            cwdfd = -1;
+            errno = saved;
+            EC_FAIL;
+        }
+
+        changed_cwd = 1;
     }
 
     va_start(args, adflags);
@@ -2582,14 +2631,38 @@ int ad_openat(struct adouble  *ad,
 
     va_end(args);
     EC_NEG1(ad_open(ad, path, adflags, mode));
+EC_CLEANUP:
 
-    if (dirfd != -1) {
+    /* Restore cwd on every exit path once we changed it, including the EC_NEG1
+     * failure above.  The saved fd is the thing that failed, so on restore
+     * failure anchor to "/" (always valid) rather than leaving cwd unknown;
+     * the caller re-establishes cwd via movecwd() on its next path op.
+     * If the operation failed, keep its errno so callers can map it to an
+     * AFPERR.  If it succeeded but the restore fails, surface the restore errno
+     * instead (otherwise we would return -1 with a stale/zero errno). */
+    if (changed_cwd) {
+        int saved = errno;
+
         if (fchdir(cwdfd) != 0) {
-            AFP_PANIC("ad_openat: can't chdir back");
+            int restore_errno = errno;
+            LOG(log_error, logtype_ad,
+                "ad_openat: cannot restore cwd (%s); anchoring to \"/\"",
+                strerror(restore_errno));
+
+            if (chdir("/") != 0) {
+                LOG(log_error, logtype_ad,
+                    "ad_openat: chdir(/) also failed: %s", strerror(errno));
+            }
+
+            /* When only the restore failed, that is the error to report. */
+            if (ret == 0) {
+                saved = restore_errno;
+            }
+
+            ret = -1;
+            errno = saved;
         }
     }
-
-EC_CLEANUP:
 
     if (cwdfd != -1) {
         close(cwdfd);

--- a/libatalk/util/logger.c
+++ b/libatalk/util/logger.c
@@ -470,8 +470,13 @@ void make_log_entry(enum loglevels loglevel, enum logtypes logtype,
     int fd, len;
     char *user_message, *log_message;
     va_list args;
+    /* A logger must not perturb the caller's errno: the write()/vasprintf()
+     * below set it, and callers commonly log on an error path and then act on
+     * errno.  Saved on entry, restored at exit. */
+    int saved_errno = errno;
 
     if (inlog) {
+        errno = saved_errno;
         return;
     }
 
@@ -490,6 +495,7 @@ void make_log_entry(enum loglevels loglevel, enum logtypes logtype,
 
             if (len == -1) {
                 inlog = 0;
+                errno = saved_errno;
                 return;
             }
 
@@ -498,6 +504,7 @@ void make_log_entry(enum loglevels loglevel, enum logtypes logtype,
         }
 
         inlog = 0;
+        errno = saved_errno;
         return;
     }
 
@@ -552,6 +559,7 @@ void make_log_entry(enum loglevels loglevel, enum logtypes logtype,
     free(user_message);
 exit:
     inlog = 0;
+    errno = saved_errno;
 }
 
 void setuplog(const char *logstr, const char *logfile,


### PR DESCRIPTION
Two related robustness fixes. The first resolves two process-killing error paths in the AppleDouble layer; the second fixes the errno-clobbering root cause that made those (and many other) error paths fragile.

Fix 1 — ad_metadataat() / ad_openat() no longer terminate the process
Bug. Both functions snapshot the current directory as an fd, fchdir() into a caller-supplied target dir, do their work, then fchdir() back. _If filesystem changes in anyway, during work afpd crashes_.

Two defects:
- Process termination on restore failure. If the fchdir() back failed, ad_metadataat() called exit() and ad_openat() called AFP_PANIC() — tearing down the entire afpd child.
- Skip-restore on early error. A failure after fchdir(dirfd) succeeded took an error exit that closed the saved fd but skipped the fchdir() back, leaving the process in the target directory.

Scope & trigger:
- ad_openat() is reachable — called with a real dirfd from copyfile() and the deletefile() data-fork open, so its AFP_PANIC fires on a restore failure (saved-cwd fd invalidated by an unmount, EIO on a flaky mount, or EACCES on revoked permission). Rare, but whole-process blast radius.
- ad_metadataat() is latent — its only checkAttrib=1 caller passes dirfd == -1, so this is forward-looking hardening.
The skip-restore defect triggers on any error after a successful fchdir(dirfd) on a real-dirfd call.

On restore failure, anchor cwd to / (always valid — the daemon chdir("/")'d at startup), log, and return -1 instead of terminating; afpd re-resolves cwd from the CNID via movecwd() on its next path op. Restore cwd on every exit path (fixes the skip-restore defect). Return a meaningful errno so copyfile/deletefile map it to the right AFPERR: keep the operation's errno when the operation failed, surface the restore errno when only the restore failed. Snapshot opens now use O_DIRECTORY | O_CLOEXEC, and the entry open/fchdir checks are split so the log identifies which failed.

Fix 2 — make_log_entry() is now errno-transparent
Root cause. The logger calls write(), vasprintf() (and open() on first use), all of which set errno.
So LOG() on an error path could clobber the errno a caller was about to act on. Only ~23 of the tree's ~3116 LOG() sites worked around this with manual save/restore — the rest silently assumed errno survived, which it didn't.

The existing 23 manual handling sites for errno persistence due to LOG can now be removed after this.
NB; The most common source of this corruption-on-corruption is when the LOG line itself fails when it cannot log the desired error string/variable for any reason (common issue).

make_log_entry() now saves errno on entry and restores it on every exit, as a diagnostic routine should (like perror/syslog). This fixes the class everywhere and lets Fix 1 drop the save/restore that only guarded LOG() — the remaining saves in ad_open.c guard real syscalls (close()/chdir()), not the logger. This avoids various transient log errors from corrupting Netatalk errors, mostly defensive/correctness/code-cleanup fix.