### PR TITLE
adouble: log silently-dropped set_lock() returns in ad_lock cleanup and adf_relockrange

### DIFF
--- a/libatalk/adouble/ad_lock.c
+++ b/libatalk/adouble/ad_lock.c
@@ -257,12 +257,23 @@ void adf_lock_free(struct ad_fd *adf)
  * else. */
 static void adf_relockrange(struct ad_fd *ad, int fd, off_t off, off_t len)
 {
-    adf_lock_t *lock = ad->adf_lock;
     int i;
 
     for (i = 0; i < ad->adf_lockcount; i++) {
-        if (OVERLAP(off, len, lock[i].lock.l_start, lock[i].lock.l_len)) {
-            set_lock(fd, F_SETLK, &lock[i].lock);
+        adf_lock_t *lock = &ad->adf_lock[i];
+
+        if (!OVERLAP(off, len, lock->lock.l_start, lock->lock.l_len)) {
+            continue;
+        }
+
+        /* Optimistic restore: the temp-lock release already succeeded and the
+         * guarded operation is done, so log a failed range but never fail. */
+        if (set_lock(fd, F_SETLK, &lock->lock) < 0) {
+            LOG(log_error, logtype_ad,
+                "adf_relockrange: F_SETLK fd=%d off=%jd len=%jd type=%d: %s",
+                fd, (intmax_t)lock->lock.l_start,
+                (intmax_t)lock->lock.l_len, lock->lock.l_type,
+                strerror(errno));
         }
     }
 }
@@ -596,7 +607,14 @@ exit:
     if (ret != 0) {
         if (fcntl_lock_err != 0) {
             lock.l_type = F_UNLCK;
-            set_lock(adf->adf_fd, F_SETLK, &lock);
+
+            if (set_lock(adf->adf_fd, F_SETLK, &lock) < 0) {
+                LOG(log_error, logtype_ad,
+                    "ad_lock: cleanup F_UNLCK failed fd=%d off=%jd len=%jd: %s "
+                    "— kernel lock may be stranded until process exit",
+                    adf->adf_fd, (intmax_t)lock.l_start,
+                    (intmax_t)lock.l_len, strerror(errno));
+            }
         }
     }
 


### PR DESCRIPTION
An observability fix for two spots in ad_lock.c where a set_lock() (i.e. fcntl()) return value is dropped on the floor, leaving userspace and kernel lock state diverged with no trace.

The bug
Two sibling defects, both silently-ignored set_lock() returns:

- ad_lock() cleanup unlock. When a lock is acquired but a subsequent bookkeeping step fails, the exit: cleanup releases the kernel lock with F_UNLCK — but ignored its return. If that unlock fails, the kernel keeps a lock userspace no longer tracks.
- adf_relockrange(). After a temp-lock release incidentally clears overlapping byte-range locks, this re-applies them with F_SETLK — but ignored its return. If a range fails to re-apply (EAGAIN/EBADF/ENOLCK), userspace keeps claiming a lock the kernel has refused.

Scope & when it triggers
- ad_lock() cleanup fires on the rare allocation-failure paths that set fcntl_lock_err — the per-lock refcount calloc() failure and the adf_lock[] realloc() growth failure — both funnelling through the same exit: unlock.
- adf_relockrange() runs on the release path of ad_tmplock() whenever a temp-lock release has to restore real byte-range locks. Failures are rare, but their only symptom is unexplained AFPERR_BUSY on ranges userspace believes it holds.

The fix
Pure observability — no control-flow change:
- ad_lock()'s cleanup now logs the F_UNLCK failure. There's no recovery short of process exit, but the operator gets visibility.
- adf_relockrange() stays void and optimistic — the temp-lock release already succeeded and the guarded operation is done, so a failed re-apply must not fail the release — but now logs each range that couldn't be restored.
- 
set_lock() preserves fcntl()'s errno to its caller, and both sites read it in the LOG argument before anything else runs, so the reported errno is accurate.

No behaviour change on the success path.