### PR TITLE
afpd: report ad_close() failure in of_closefork() instead of swallowing it

### DIFF
--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -1767,7 +1767,7 @@ int afp_closefork(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
     if (of_closefork(obj, ofork) < 0) {
         LOG(log_error, logtype_afpd, "afp_closefork: of_closefork: %s",
             strerror(errno));
-        return AFPERR_PARAM;
+        return AFPERR_MISC;
     }
 
     return AFP_OK;

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -474,6 +474,7 @@ int of_closefork(const AFPObj *obj, struct ofork *ofork)
     struct timeval      tv;
     int         adflags = 0;
     int                 ret;
+    int                 saved_errno = 0;
     struct dir *dir;
     bstring forkpath = NULL;
     adflags = 0;
@@ -678,7 +679,19 @@ int of_closefork(const AFPObj *obj, struct ofork *ofork)
     }
 
     if (ad_close(ofork->of_ad, adflags | ADFLAGS_SETSHRMD) < 0) {
+        /* A failed close(2) is a deferred flush error: the fd is already
+         * detached and locks were released by F_UNLCK before the close, so
+         * nothing is stranded.  Log and deallocate normally; the client gets
+         * the error code.  Stash errno: the unlink/dealloc/bdestroy below would
+         * otherwise clobber it before callers read it. */
+        saved_errno = errno;
         ret = -1;
+        LOG(log_error, logtype_afpd,
+            "of_closefork: ad_close failed for fork %" PRIu16 " (\"%s\") "
+            "dev=%ju ino=%ju: %s",
+            ofork->of_refnum, of_name(ofork),
+            (uintmax_t)ofork->key.dev, (uintmax_t)ofork->key.inode,
+            strerror(saved_errno));
     }
 
 #ifdef WITH_SPOTLIGHT
@@ -699,6 +712,10 @@ int of_closefork(const AFPObj *obj, struct ofork *ofork)
 
     if (forkpath) {
         bdestroy(forkpath);
+    }
+
+    if (ret < 0) {
+        errno = saved_errno;
     }
 
     return ret;


### PR DESCRIPTION
An observability fix: a failed close(2) during fork teardown was being silently swallowed and reported to the client as a misleading error code.

The bug
ad_close() returns -1 when its internal close(2) fails, but of_closefork() used that return only to set its own ret — with no log. The failure was invisible to operators, and surfaced to the client as a generic AFPERR_PARAM with no record of why the close failed.

Scope & when it triggers
Fires whenever close(2) fails during FPCloseFork — i.e. a deferred flush/writeback error (EIO/ENOSPC/EDQUOT) reported at close time.

Crucially, the existing behaviour is already functionally safe — this is not a stranded-lock or leaked-fd bug:
- The kernel detaches the fd even when close() returns an error (fileno is reset to -1 regardless).
ad_close() releases all byte-range locks via F_UNLCK before the close(), so a close error cannot strand a lock.
- The freed ofork slot is safe to reuse — a reused slot gets a fresh adouble + fresh fd, so the failed close leaves no stale fd reachable.
- The only residual exposure is the missing diagnostic and a slightly inaccurate client error code.

The fix
Pure observability — no recovery, no session teardown:

- of_closefork() now logs the close failure with the fork's refnum, name, dev and ino, then falls through to the normal of_dealloc() exactly as before.
- afp_closefork() returns AFPERR_MISC instead of AFPERR_PARAM — a flush/writeback failure is not a parameter error, and AFPERR_MISC gives the client an accurate "something went wrong server-side" signal to surface or retry.
- ad_close() is unchanged — returning -1 on a failed close is correct.
No behaviour change on the success path.