### PR TITLE
meson: define unused attribute wrapper in config header

### DIFF
--- a/etc/afpd/hash.c
+++ b/etc/afpd/hash.c
@@ -16,6 +16,10 @@
  *
  * $Name:  $
  */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
 #define NDEBUG
 #include <assert.h>
 #include <stddef.h>

--- a/meson.build
+++ b/meson.build
@@ -266,7 +266,6 @@ endif
 
 netatalk_common_flags = [
     '-DHAVE_CONFIG_H',
-    '-D_U_=__attribute__((unused))',
     '-Wno-pedantic',
     '-Wno-extra',
     '-Wno-all',

--- a/meson_config.h
+++ b/meson_config.h
@@ -473,6 +473,21 @@
 /* Solaris compatibility macro */
 #mesondefine __svr4__
 
+/* Mark a declaration as intentionally unused when the compiler supports it. */
+#ifndef _U_
+#if defined(__has_attribute)
+#if __has_attribute(unused)
+#define _U_ __attribute__((unused))
+#else
+#define _U_
+#endif
+#elif defined(__GNUC__)
+#define _U_ __attribute__((unused))
+#else
+#define _U_
+#endif
+#endif
+
 /* Define to `__inline__' or `__inline' if that's what the C compiler
    calls it, or to nothing if 'inline' is not supported under any name.  */
 #ifndef __cplusplus


### PR DESCRIPTION
rather than a crude hard coded C flag, probe for attribute support in meson_config.h with a fallback to GNUC and finally an empty macro