### PR TITLE
ci: create a Ubuntu build job with 32 bit toolchain

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -376,6 +376,7 @@ jobs:
             libmagic-dev \
             libmariadb-dev \
             libpam0g-dev \
+            libsqlite3-dev \
             libtalloc-dev \
             libtirpc-dev \
             libtracker-sparql-3.0-dev \
@@ -420,3 +421,84 @@ jobs:
           name: meson-logs-${{ github.job }}
           path: build/meson-logs
 
+  build-ubuntu-32bit:
+    name: Ubuntu Linux (32-bit)
+    runs-on: ubuntu-latest
+    timeout-minutes: 24
+    container:
+      image: ubuntu:25.10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Install 32-bit toolchain and dependencies
+        run: |
+          dpkg --add-architecture i386
+          apt-get update
+          apt-get install --assume-yes --no-install-recommends \
+            ca-certificates \
+            cmark-gfm \
+            cracklib-runtime \
+            dconf-cli \
+            file \
+            g++-multilib \
+            gcc-multilib \
+            libacl1-dev:i386 \
+            libavahi-client-dev:i386 \
+            libcrack2-dev:i386 \
+            libcups2-dev:i386 \
+            libdb-dev:i386 \
+            libdbus-1-dev:i386 \
+            libevent-dev:i386 \
+            libgcrypt20-dev:i386 \
+            libiniparser-dev:i386 \
+            libkrb5-dev:i386 \
+            libldap2-dev:i386 \
+            libmagic-dev:i386 \
+            libpam0g-dev:i386 \
+            libtalloc-dev:i386 \
+            libtirpc-dev:i386 \
+            libwrap0-dev:i386 \
+            libsqlite3-dev:i386 \
+            libxapian-dev:i386 \
+            meson \
+            ninja-build \
+            pkg-config \
+            quota \
+            systemtap-sdt-dev \
+            tcpd
+      - name: Configure (32-bit)
+        env:
+          CFLAGS: -m32
+          CXXFLAGS: -m32
+          LDFLAGS: -m32
+          PKG_CONFIG_LIBDIR: /usr/lib/i386-linux-gnu/pkgconfig:/usr/share/pkgconfig
+        run: |
+          meson setup build \
+            -Dbuildtype=debugoptimized \
+            -Dwith-appletalk=true \
+            -Dwith-dtrace=false \
+            -Dwith-init-hooks=false \
+            -Dwith-tests=true \
+            -Dwith-testsuite=true
+      - name: Build
+        run: meson compile -C build
+      - name: Verify 32-bit binary
+        run: file build/etc/afpd/afpd | grep -q 'ELF 32-bit'
+      - name: Run integration tests
+        run: meson test -C build
+      - name: Install
+        run: meson install -C build
+      - name: Check netatalk capabilities
+        run: |
+          netatalk -V
+          afpd -V
+          atalkd -V
+          a2boot -V
+          macipgw -V
+          papd -V
+          timelord -V
+      - name: Upload meson logs
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: meson-logs-${{ github.job }}
+          path: build/meson-logs


### PR DESCRIPTION
emulating a 32 bit build by forcing 32 bit toolchain on a 64 bit system

the current repos are missing 32 bit versions of libmariadb and libtracker-sparql-3.0 so skipping those features for now

despite the dtrace library being present, Ubuntu is missing a sys/sdt.h header which I'm chalking down as an Ubuntu bug and disabling it