### PR TITLE
[4.5] afpd: explicit header include in file.c

### DIFF
--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -16,6 +16,7 @@
 
 #include <atalk/adouble.h>
 #include <atalk/afp.h>
+#include <atalk/afp_util.h>
 #include <atalk/cnid.h>
 #include <atalk/dsi.h>
 #include <atalk/fce_api.h>


### PR DESCRIPTION
the Debian build wrapper has stringent implicit declaration rules, which leads to a hard compiler error without this header