### PR TITLE
[4.5] afpd: make SpotlightRPC big-endian safe

### DIFF
--- a/etc/afpd/spotlight.c
+++ b/etc/afpd/spotlight.c
@@ -72,6 +72,19 @@ static struct slq_state_names slq_state_names[] = {
 static int cnid_comp_fn(const void *p1, const void *p2);
 static bool create_result_handle(slq_t *slq);
 
+static uint32_t spotlight_get_be32(const char *buf, size_t offset)
+{
+    uint32_t val;
+    memcpy(&val, buf + offset, sizeof(val));
+    return ntohl(val);
+}
+
+static void spotlight_put_be32(char *buf, size_t offset, uint32_t val)
+{
+    val = htonl(val);
+    memcpy(buf + offset, &val, sizeof(val));
+}
+
 /************************************************
  * Misc utility functions
  ************************************************/
@@ -1385,17 +1398,23 @@ int afp_spotlight_rpc(AFPObj *obj, char *ibuf, size_t ibuflen,
         goto EC_CLEANUP;
     }
 
-    /*    IVAL(ibuf, 2): unknown, always 0x00008004, some flags ? */
-    cmd = RIVAL(ibuf, 6);
+    /*
+     * The FPSpotlightRPC envelope uses big-endian 32-bit fields.
+     * RIVAL() is reverse-host-order in this codebase, so it decodes
+     * these bytes correctly only on little-endian hosts.
+     *
+     * spotlight_get_be32(ibuf, 2): unknown, always 0x00008004, some flags ?
+     */
+    cmd = spotlight_get_be32(ibuf, 6);
     LOG(log_debug, logtype_sl, "afp_spotlight_rpc(cmd: %d)", cmd);
 
-    /*    IVAL(ibuf, 10: unknown, always 0x00000000 */
+    /* spotlight_get_be32(ibuf, 10): unknown, always 0x00000000 */
 
     switch (cmd) {
     case SPOTLIGHT_CMD_OPEN:
     case SPOTLIGHT_CMD_OPEN2:
-        RSIVAL(rbuf, 0, ntohs(vid));
-        RSIVAL(rbuf, 4, 0);
+        spotlight_put_be32(rbuf, 0, ntohs(vid));
+        spotlight_put_be32(rbuf, 4, 0);
         len = (int)strlcpy(rbuf + 8, vol->v_path, MAXPATHLEN) + 1;
         *rbuflen += 8 + len;
         LOG(log_debug, logtype_sl,
@@ -1406,7 +1425,7 @@ int afp_spotlight_rpc(AFPObj *obj, char *ibuf, size_t ibuflen,
 
     case SPOTLIGHT_CMD_FLAGS:
         /* Whatever this value means... flags? Helios uses 0x1eefface */
-        RSIVAL(rbuf, 0, 0x0100006b);
+        spotlight_put_be32(rbuf, 0, 0x0100006b);
         *rbuflen += 4;
         LOG(log_debug, logtype_sl,
             "SPOTLIGHT_CMD_FLAGS: returning 0x0100006b");

--- a/etc/afpd/spotlight_marshalling.c
+++ b/etc/afpd/spotlight_marshalling.c
@@ -88,6 +88,47 @@ static int sl_unpack_r(DALLOC_CTX *query, const char *buf, size_t buf_len,
  * Wrapper functions for the *VAL macros with bound checking
  **************************************************************************************************/
 
+static void sl_put_le32(char *buf, off_t off, uint32_t val)
+{
+    uint8_t *p = (uint8_t *)buf + off;
+    p[0] = (uint8_t)val;
+    p[1] = (uint8_t)(val >> 8);
+    p[2] = (uint8_t)(val >> 16);
+    p[3] = (uint8_t)(val >> 24);
+}
+
+static void sl_put_le64(char *buf, off_t off, uint64_t val)
+{
+    sl_put_le32(buf, off, (uint32_t)val);
+    sl_put_le32(buf, off + 4, (uint32_t)(val >> 32));
+}
+
+static uint64_t sl_get_le64(const char *buf, int offset)
+{
+    const uint8_t *p = (const uint8_t *)buf + offset;
+    return (uint64_t)p[0]
+           | ((uint64_t)p[1] << 8)
+           | ((uint64_t)p[2] << 16)
+           | ((uint64_t)p[3] << 24)
+           | ((uint64_t)p[4] << 32)
+           | ((uint64_t)p[5] << 40)
+           | ((uint64_t)p[6] << 48)
+           | ((uint64_t)p[7] << 56);
+}
+
+static uint64_t sl_get_be64(const char *buf, int offset)
+{
+    const uint8_t *p = (const uint8_t *)buf + offset;
+    return (uint64_t)p[7]
+           | ((uint64_t)p[6] << 8)
+           | ((uint64_t)p[5] << 16)
+           | ((uint64_t)p[4] << 24)
+           | ((uint64_t)p[3] << 32)
+           | ((uint64_t)p[2] << 40)
+           | ((uint64_t)p[1] << 48)
+           | ((uint64_t)p[0] << 56);
+}
+
 static int sivalc(char *buf, off_t off, off_t maxoff, uint32_t val)
 {
     if (off + sizeof(val) >= maxoff) {
@@ -95,7 +136,13 @@ static int sivalc(char *buf, off_t off, off_t maxoff, uint32_t val)
         return -1;
     }
 
-    SIVAL(buf, off, val);
+    /*
+     * sl_pack() emits the "432130dm" Spotlight payload variant, whose
+     * numeric fields are little-endian on the wire. Do not use Netatalk's
+     * SIVAL/SLVAL here: in this tree they write host order, not fixed
+     * little-endian, and that breaks Spotlight RPC on big-endian systems.
+     */
+    sl_put_le32(buf, off, val);
     return 0;
 }
 
@@ -106,7 +153,7 @@ static int slvalc(char *buf, off_t off, off_t maxoff, uint64_t val)
         return -1;
     }
 
-    SLVAL(buf, off, val);
+    sl_put_le64(buf, off, val);
     return 0;
 }
 
@@ -483,9 +530,9 @@ static bool sl_unpack_range_valid(size_t buf_len, int offset, size_t length)
 static uint64_t sl_unpack_uint64(const char *buf, int offset, uint encoding)
 {
     if (encoding == SL_ENC_LITTLE_ENDIAN) {
-        return LVAL(buf, offset);
+        return sl_get_le64(buf, offset);
     } else {
-        return RLVAL(buf, offset);
+        return sl_get_be64(buf, offset);
     }
 }
 
@@ -632,7 +679,7 @@ static int sl_unpack_floats(DALLOC_CTX *query, const char *buf, int offset,
     uint64_t query_data64;
     union {
         double d;
-        uint32_t w[2];
+        uint64_t w;
     } ieee_fp_union;
 
     if (sl_unpack_uint64_checked(buf, buf_len, offset, encoding,
@@ -646,26 +693,9 @@ static int sl_unpack_floats(DALLOC_CTX *query, const char *buf, int offset,
     i = 0;
 
     while (i++ < count) {
-        if (!sl_unpack_range_valid(buf_len, offset, sizeof(uint64_t))) {
+        if (sl_unpack_uint64_checked(buf, buf_len, offset, encoding,
+                                     &ieee_fp_union.w) < 0) {
             return -1;
-        }
-
-        if (encoding == SL_ENC_LITTLE_ENDIAN) {
-#ifdef WORDS_BIGENDIAN
-            ieee_fp_union.w[0] = IVAL(buf, offset + 4);
-            ieee_fp_union.w[1] = IVAL(buf, offset);
-#else
-            ieee_fp_union.w[0] = IVAL(buf, offset);
-            ieee_fp_union.w[1] = IVAL(buf, offset + 4);
-#endif
-        } else {
-#ifdef WORDS_BIGENDIAN
-            ieee_fp_union.w[0] = RIVAL(buf, offset);
-            ieee_fp_union.w[1] = RIVAL(buf, offset + 4);
-#else
-            ieee_fp_union.w[0] = RIVAL(buf, offset + 4);
-            ieee_fp_union.w[1] = RIVAL(buf, offset);
-#endif
         }
 
         dalloc_add_copy(query, &ieee_fp_union.d, double);

--- a/test/testsuite/FPSpotlightRPC.c
+++ b/test/testsuite/FPSpotlightRPC.c
@@ -24,6 +24,7 @@
  *      FPSpotlightOpen, which the fixture treats as test_nottested().
  */
 #include <stdio.h>
+#include <inttypes.h>
 #include <string.h>
 #include <unistd.h>
 #include <arpa/inet.h>
@@ -70,9 +71,67 @@ static int pag_create_dir_get_did(uint16_t vol, uint32_t parent_did,
     return FPCreateDir(Conn, vol, parent_did, name);
 }
 
+static void pag_log_ret(const char *testname, const char *op,
+                        unsigned int ret)
+{
+    if (!Quiet) {
+        fprintf(stdout, "\tFAILED: %s: %s returned %" PRIu32
+                " (%s), raw=0x%08x\n",
+                testname, op, ntohl(ret), afp_error(ret), ret);
+    }
+}
+
+static int pag_spotlight_open(uint16_t vol, const char *testname)
+{
+    unsigned int ret = FPSpotlightOpen(Conn, vol, NULL, 0);
+
+    if (ret == AFP_OK) {
+        return 1;
+    }
+
+    if (!Quiet) {
+        fprintf(stdout, "\t%s: %s: FPSpotlightOpen returned %" PRIu32
+                " (%s), raw=0x%08x\n",
+                ret == htonl(AFPERR_NOOP) ? "NOT TESTED" : "FAILED",
+                testname, ntohl(ret), afp_error(ret), ret);
+    }
+
+    if (ret == htonl(AFPERR_NOOP)) {
+        test_nottested();
+    } else {
+        test_failed();
+    }
+
+    return 0;
+}
+
+static void pag_log_create_dir_failure(const char *testname,
+                                       const char *dirname)
+{
+    if (!Quiet) {
+        unsigned int ret = Conn->dsi.header.dsi_code;
+        fprintf(stdout, "\tNOT TESTED: %s: FPCreateDir(\"%s\") returned "
+                        "no DID; dsi_code=%" PRIu32 " (%s), raw=0x%08x\n",
+                testname, dirname, ntohl(ret), afp_error(ret), ret);
+    }
+}
+
+static void pag_log_create_file_failure(const char *testname,
+                                        const char *filename,
+                                        unsigned int ret)
+{
+    if (!Quiet) {
+        fprintf(stdout, "\tNOT TESTED: %s: FPCreateFile(\"%s\") returned "
+                        "%" PRIu32 " (%s), raw=0x%08x\n",
+                testname, filename, ntohl(ret), afp_error(ret), ret);
+    }
+}
+
 STATIC void test547()
 {
+    const char *testname = "test547";
     uint16_t vol = VolID;
+    unsigned int ret;
     int got = 0;
     int dir_id;
     char fn[64];
@@ -86,8 +145,7 @@ STATIC void test547()
     /* FPSpotlightOpen returns AFPERR_NOOP if `spotlight = no` in
      * afp.conf, or AFP_OK on success. We do not need the populated
      * vol_path, so pass NULL/0 to skip the optional path-extract. */
-    if (FPSpotlightOpen(Conn, vol, NULL, 0) != AFP_OK) {
-        test_nottested();
+    if (!pag_spotlight_open(vol, testname)) {
         goto test_exit;
     }
 
@@ -99,14 +157,17 @@ STATIC void test547()
      * the high byte may sign-bit-set. Check for the failure sentinel
      * exactly, NOT `<= 0`. */
     if (dir_id == 0) {
+        pag_log_create_dir_failure(testname, PAG_DIR_SMALL);
         test_nottested();
         goto cleanup;
     }
 
     for (int i = 0; i < PAG_CORPUS_SMALL; i++) {
         snprintf(fn, sizeof(fn), PAG_PREFIX_530 "%05d.txt", i);
+        ret = FPCreateFile(Conn, vol, 0, dir_id, fn);
 
-        if (FPCreateFile(Conn, vol, 0, dir_id, fn) != AFP_OK) {
+        if (ret != AFP_OK) {
+            pag_log_create_file_failure(testname, fn, ret);
             test_nottested();
             goto cleanup;
         }
@@ -114,14 +175,20 @@ STATIC void test547()
 
     /* Use the long, test-unique prefix so the unscoped substring search
      * across the volume cannot pick up unrelated files. */
-    if (FPSpotlightOpenQuery(Conn, vol,
-                             "kMDItemFSName==\"" PAG_PREFIX_530 "*\"cd",
-                             0x1234) != AFP_OK) {
+    ret = FPSpotlightOpenQuery(Conn, vol,
+                               "kMDItemFSName==\"" PAG_PREFIX_530 "*\"cd",
+                               0x1234);
+
+    if (ret != AFP_OK) {
+        pag_log_ret(testname, "FPSpotlightOpenQuery", ret);
         test_failed();
         goto cleanup;
     }
 
-    if (FPSpotlightDrainResults(Conn, vol, 0x1234, &got) != AFP_OK) {
+    ret = FPSpotlightDrainResults(Conn, vol, 0x1234, &got);
+
+    if (ret != AFP_OK) {
+        pag_log_ret(testname, "FPSpotlightDrainResults", ret);
         test_failed();
         goto close_query;
     }
@@ -148,7 +215,9 @@ test_exit:
 
 STATIC void test548()
 {
+    const char *testname = "test548";
     uint16_t vol = VolID;
+    unsigned int ret;
     int got = 0;
     int dir_id;
     char fn[64];
@@ -159,8 +228,7 @@ STATIC void test548()
         goto test_exit;
     }
 
-    if (FPSpotlightOpen(Conn, vol, NULL, 0) != AFP_OK) {
-        test_nottested();
+    if (!pag_spotlight_open(vol, testname)) {
         goto test_exit;
     }
 
@@ -169,27 +237,36 @@ STATIC void test548()
 
     /* See test547: dir_id is a network-byte-order CNID stored as int. */
     if (dir_id == 0) {
+        pag_log_create_dir_failure(testname, PAG_DIR_PAGED);
         test_nottested();
         goto cleanup;
     }
 
     for (int i = 0; i < PAG_CORPUS_PAGED; i++) {
         snprintf(fn, sizeof(fn), PAG_PREFIX_531 "%05d.txt", i);
+        ret = FPCreateFile(Conn, vol, 0, dir_id, fn);
 
-        if (FPCreateFile(Conn, vol, 0, dir_id, fn) != AFP_OK) {
+        if (ret != AFP_OK) {
+            pag_log_create_file_failure(testname, fn, ret);
             test_nottested();
             goto cleanup;
         }
     }
 
-    if (FPSpotlightOpenQuery(Conn, vol,
-                             "kMDItemFSName==\"" PAG_PREFIX_531 "*\"cd",
-                             0x1235) != AFP_OK) {
+    ret = FPSpotlightOpenQuery(Conn, vol,
+                               "kMDItemFSName==\"" PAG_PREFIX_531 "*\"cd",
+                               0x1235);
+
+    if (ret != AFP_OK) {
+        pag_log_ret(testname, "FPSpotlightOpenQuery", ret);
         test_failed();
         goto cleanup;
     }
 
-    if (FPSpotlightDrainResults(Conn, vol, 0x1235, &got) != AFP_OK) {
+    ret = FPSpotlightDrainResults(Conn, vol, 0x1235, &got);
+
+    if (ret != AFP_OK) {
+        pag_log_ret(testname, "FPSpotlightDrainResults", ret);
         test_failed();
         goto close_query;
     }
@@ -216,6 +293,7 @@ test_exit:
 
 STATIC void test560()
 {
+    const char *testname = "test560";
     uint16_t vol = VolID;
     unsigned int ret;
     ENTER_TEST
@@ -225,8 +303,7 @@ STATIC void test560()
         goto test_exit;
     }
 
-    if (FPSpotlightOpen(Conn, vol, NULL, 0) != AFP_OK) {
-        test_nottested();
+    if (!pag_spotlight_open(vol, testname)) {
         goto test_exit;
     }
 
@@ -242,7 +319,8 @@ STATIC void test560()
     if (ret != htonl(AFPERR_MISC)) {
         if (!Quiet) {
             fprintf(stdout, "\tFAILED: undeclared TOC entry payload "
-                            "returned %d (%s), expected AFPERR_MISC\n",
+                            "returned %" PRIu32
+                            " (%s), expected AFPERR_MISC\n",
                     ntohl(ret), afp_error(ret));
         }
 
@@ -250,10 +328,15 @@ STATIC void test560()
         goto test_exit;
     }
 
-    if (FPSpotlightOpen(Conn, vol, NULL, 0) != AFP_OK) {
+    ret = FPSpotlightOpen(Conn, vol, NULL, 0);
+
+    if (ret != AFP_OK) {
         if (!Quiet) {
             fprintf(stdout, "\tFAILED: undeclared TOC entry payload "
-                            "left Spotlight RPC unusable\n");
+                            "left Spotlight RPC unusable: "
+                            "FPSpotlightOpen returned %" PRIu32
+                            " (%s), raw=0x%08x\n",
+                    ntohl(ret), afp_error(ret), ret);
         }
 
         test_failed();
@@ -265,6 +348,7 @@ test_exit:
 
 STATIC void test561()
 {
+    const char *testname = "test561";
     uint16_t vol = VolID;
     unsigned int ret;
     ENTER_TEST
@@ -274,8 +358,7 @@ STATIC void test561()
         goto test_exit;
     }
 
-    if (FPSpotlightOpen(Conn, vol, NULL, 0) != AFP_OK) {
-        test_nottested();
+    if (!pag_spotlight_open(vol, testname)) {
         goto test_exit;
     }
 
@@ -284,7 +367,7 @@ STATIC void test561()
     if (ret != htonl(AFPERR_MISC)) {
         if (!Quiet) {
             fprintf(stdout, "\tFAILED: oversized INT64 count returned "
-                            "%d (%s), expected AFPERR_MISC\n",
+                            "%" PRIu32 " (%s), expected AFPERR_MISC\n",
                     ntohl(ret), afp_error(ret));
         }
 
@@ -292,10 +375,15 @@ STATIC void test561()
         goto test_exit;
     }
 
-    if (FPSpotlightOpen(Conn, vol, NULL, 0) != AFP_OK) {
+    ret = FPSpotlightOpen(Conn, vol, NULL, 0);
+
+    if (ret != AFP_OK) {
         if (!Quiet) {
             fprintf(stdout, "\tFAILED: oversized INT64 count left "
-                            "Spotlight RPC unusable\n");
+                            "Spotlight RPC unusable: "
+                            "FPSpotlightOpen returned %" PRIu32
+                            " (%s), raw=0x%08x\n",
+                    ntohl(ret), afp_error(ret), ret);
         }
 
         test_failed();
@@ -307,6 +395,7 @@ test_exit:
 
 STATIC void test562()
 {
+    const char *testname = "test562";
     uint16_t vol = VolID;
     unsigned int ret;
     ENTER_TEST
@@ -316,8 +405,7 @@ STATIC void test562()
         goto test_exit;
     }
 
-    if (FPSpotlightOpen(Conn, vol, NULL, 0) != AFP_OK) {
-        test_nottested();
+    if (!pag_spotlight_open(vol, testname)) {
         goto test_exit;
     }
 
@@ -326,7 +414,7 @@ STATIC void test562()
     if (ret != htonl(AFPERR_MISC)) {
         if (!Quiet) {
             fprintf(stdout, "\tFAILED: out-of-range TOC index returned "
-                            "%d (%s), expected AFPERR_MISC\n",
+                            "%" PRIu32 " (%s), expected AFPERR_MISC\n",
                     ntohl(ret), afp_error(ret));
         }
 
@@ -334,10 +422,15 @@ STATIC void test562()
         goto test_exit;
     }
 
-    if (FPSpotlightOpen(Conn, vol, NULL, 0) != AFP_OK) {
+    ret = FPSpotlightOpen(Conn, vol, NULL, 0);
+
+    if (ret != AFP_OK) {
         if (!Quiet) {
             fprintf(stdout, "\tFAILED: out-of-range TOC index left "
-                            "Spotlight RPC unusable\n");
+                            "Spotlight RPC unusable: "
+                            "FPSpotlightOpen returned %" PRIu32
+                            " (%s), raw=0x%08x\n",
+                    ntohl(ret), afp_error(ret), ret);
         }
 
         test_failed();


### PR DESCRIPTION
two major bugs that made SpotlightRPC not function on a big-endian system (Debian on s390x)

## decode Spotlight RPC envelope as big-endian

The FPSpotlightRPC envelope carries its 32-bit fields in big-endian
wire order. Decoding the subcommand with RIVAL() only works on
little-endian hosts because Netatalk's R* byteorder macros mean
reverse-host-order, not network order.

Use explicit unaligned big-endian get/put helpers for the Spotlight
subcommand and simple OPEN/FLAGS reply fields so big-endian systems
dispatch SPOTLIGHT_CMD_OPEN and SPOTLIGHT_CMD_RPC correctly.

## use explicit Spotlight payload byte order

Spotlight DALLOC payloads are tagged with a byte-order magic string,
but the packer and unpacker used Netatalk's host-order SIVAL/SLVAL/LVAL
helpers. On big-endian systems this produced requests labelled as
little-endian while their numeric fields were written in host order,
causing sl_unpack_len() to reject valid FPSpotlightRPC queries with
AFPERR_MISC before the cnid backend ran.

Add explicit little-endian writers for the payload variant emitted
by sl_pack(), explicit little/big-endian readers for unpacking, and
decode floating point values through the same checked uint64 path.

## testsuite tests

capture and print AFP errors in SpotlightRPC tests, which gives us more actionable fail states