### PR TITLE
[4.5] ci: set Flamegraph job condition to false

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -199,7 +199,7 @@ jobs:
     needs: build-container-debug
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+    if: false
     concurrency:
       group: "pages"
       cancel-in-progress: false


### PR DESCRIPTION
disable the Flamegraph job for all events on the stable branch, since it's gotten out of sync with the main branch