### PR TITLE
overhaul the compilation readme generator script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
             -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
-      - name: Run integration tests
+      - name: Test
         run: meson test -C build
       - name: Run memory profiling
         run: meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
@@ -155,7 +155,7 @@ jobs:
             -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
-      - name: Run integration tests
+      - name: Test
         run: meson test -C build
       - name: Install
         run: meson install -C build
@@ -240,7 +240,7 @@ jobs:
             -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
-      - name: Run integration tests
+      - name: Test
         run: meson test -C build
       - name: Run memory profiling
         run: meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
@@ -318,7 +318,7 @@ jobs:
             -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
-      - name: Run integration tests
+      - name: Test
         run: meson test -C build
       - name: Run memory profiling
         run: meson test --wrapper='valgrind --leak-check=full --error-exitcode=1' -C build
@@ -401,7 +401,7 @@ jobs:
             -Dwith-testsuite=true
       - name: Build
         run: meson compile -C build
-      - name: Run integration tests
+      - name: Test
         run: meson test -C build
       - name: Install
         run: meson install -C build
@@ -483,7 +483,7 @@ jobs:
         run: meson compile -C build
       - name: Verify 32-bit binary
         run: file build/etc/afpd/afpd | grep -q 'ELF 32-bit'
-      - name: Run integration tests
+      - name: Test
         run: meson test -C build
       - name: Install
         run: meson install -C build

--- a/.github/workflows/spectest-macos.yml
+++ b/.github/workflows/spectest-macos.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   spectest-macos:
-    name: AFP spec test (ea:sys) AFP 3.4 - macOS
+    name: AFP Spectest - macOS (ea:sys)
     runs-on: macos-latest
     timeout-minutes: 24
     env:
@@ -61,7 +61,7 @@ jobs:
       - name: Build
         run: meson compile -C build
 
-      - name: Run integration tests
+      - name: Test
         run: meson test -C build
 
       - name: Install

--- a/.github/workflows/spectest-vms.yml
+++ b/.github/workflows/spectest-vms.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   spectest-dflybsd:
-    name: AFP Spectest - DragonflyBSD (sys:ad, HAMMER2)
+    name: AFP Spectest - DragonFlyBSD (sys:ad, HAMMER2)
     runs-on: ubuntu-latest
     timeout-minutes: 24
     steps:
@@ -397,6 +397,10 @@ jobs:
             pkg install \
               build-essential \
               pkg-config
+            # This installs the SmartOS pkgsrc bootstrap, which is a self-contained pkgsrc environment
+            # containing a pkgin package manager and a /opt/local prefix.
+            # The bootstrap is used to install the required dependencies for building netatalk on OmniOS.
+            # This step can be skipped if the bootstrap is already installed.
             curl -o bootstrap.tar.gz https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-2025Q4-x86_64.tar.gz
             tar -zxpf bootstrap.tar.gz -C /
             export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
@@ -482,7 +486,8 @@ jobs:
               web/curl
             curl --location -o iniparser.tar.gz \
               https://gitlab.com/iniparser/iniparser/-/archive/v4.2.6/iniparser-v4.2.6.tar.gz
-            set +e # tar on illumos is too old to handle git tarballs cleanly
+            # tar on illumos is too old to handle git tarballs cleanly
+            set +e
             tar xzf iniparser.tar.gz
             set -e
             cd iniparser-v4.2.6
@@ -559,7 +564,8 @@ jobs:
               https://github.com/commonmark/cmark/archive/refs/tags/0.31.1.tar.gz
             curl --location -o iniparser.tar.gz \
               https://gitlab.com/iniparser/iniparser/-/archive/v4.2.6/iniparser-v4.2.6.tar.gz
-            set +e # tar on Solaris is too old to handle git tarballs cleanly
+            # tar on Solaris is too old to handle git tarballs cleanly
+            set +e
             tar xzf cmark.tar.gz
             tar xzf iniparser.tar.gz
             set -e

--- a/contrib/scripts/make_compile_docs.pl
+++ b/contrib/scripts/make_compile_docs.pl
@@ -1,8 +1,8 @@
 #!/usr/bin/env perl
 
-# This script generates the compilation readme from the GitHub build.yml file.
+# This script generates a compilation readme from GitHub workflow files
 #
-# (c) 2025 Daniel Markstedt <daniel@mindani.net>
+# (c) 2025-2026 Daniel Markstedt <daniel@mindani.net>
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -20,25 +20,99 @@ use warnings;
 use YAML::PP;
 use YAML::PP::Common qw/ PRESERVE_ORDER /;
 
-if (@ARGV < 2 || grep { $_ eq '--help' || $_ eq '-h' } @ARGV) {
-    print "Usage: $0 input_file output_file\n";
-    print "  input_file   Path to the build.yml file (required)\n";
+if (grep { $_ eq '--help' || $_ eq '-h' } @ARGV) {
+    print "Usage: $0 input_file [input_file ...] output_file\n";
+    print "  input_file   Path to a workflow YAML file (one or more required)\n";
     print "  output_file  Path to the output markdown file (required)\n";
-    exit((@ARGV < 2) ? 1 : 0);
+    exit 0;
 }
 
-my $input_file  = $ARGV[0];
-my $output_file = $ARGV[1];
+if (@ARGV < 2) {
+    print "Usage: $0 input_file [input_file ...] output_file\n";
+    print "  input_file   Path to a workflow YAML file (one or more required)\n";
+    print "  output_file  Path to the output markdown file (required)\n";
+    exit 1;
+}
 
-unless (-e $input_file) {
-    die "Error: Input file '$input_file' does not exist.\n";
+my $output_file = pop @ARGV;
+my @input_files = @ARGV;
+
+foreach my $input_file (@input_files) {
+    unless (-e $input_file) {
+        die "Error: Input file '$input_file' does not exist.\n";
+    }
 }
 
 my $ypp = YAML::PP->new(preserve => PRESERVE_ORDER);
-my $workflow;
-eval { $workflow = $ypp->load_file($input_file); };
-if ($@) {
-    die "Error parsing YAML file: $@\n";
+
+sub format_shell_command {
+    my ($shell) = @_;
+
+    return unless defined $shell;
+
+    $shell =~ s/\\\n\s+//g;
+    $shell =~ s/-Dbuildtype=debugoptimized/-Dbuildtype=release/g;
+    $shell =~ s/-Dwith-init-hooks=false/-Dwith-init-hooks=true/g;
+    $shell =~ s/^\s*set\b[^\n]*(?:\n|$)//gm;
+    $shell =~ s/^\s*.*-V\s*(?:\n|$)//gm;
+    $shell =~ s/\n+$//;
+
+    return $shell;
+}
+
+sub wanted_step {
+    my ($step) = @_;
+
+    return unless exists $step->{name};
+
+    my %wanted = map { $_ => 1 } (
+                                  'Install dependencies',
+                                  'Configure',
+                                  'Build',
+                                  'Test',
+                                  'Install',
+                                  'Build on VM',
+    );
+
+    return $wanted{$step->{name}};
+}
+
+sub format_job_name {
+    my ($name) = @_;
+
+    if ($name =~ /-\s*([^(]+?)\s*\(/) {
+        return $1;
+    }
+
+    return $name;
+}
+
+sub render_step {
+    my ($markdown, $step) = @_;
+
+    if (exists $step->{uses} && $step->{uses} =~ /^vmactions\//) {
+        push @{$markdown},
+          "Install dependencies",
+          "",
+          "```shell",
+          format_shell_command($step->{with}->{prepare}),
+          "```",
+          "",
+          "Build and install",
+          "",
+          "```shell",
+          format_shell_command($step->{with}->{run}),
+          "```",
+          "";
+    } else {
+        push @{$markdown},
+          $step->{name},
+          "",
+          "```shell",
+          format_shell_command($step->{run}),
+          "```",
+          "";
+    }
 }
 
 my @markdown = (
@@ -48,67 +122,34 @@ my @markdown = (
             "Before starting, please read through the [Install Quick Start](https://netatalk.io/install) guide first.",
             "You need to have a local clone of Netatalk's source code before proceeding.",
             "",
-            "Please note that these steps are automatically generated from the CI jobs,",
-            "and may not always be optimized for standalone execution.",
+            "```shell",
+            "git clone https://github.com/Netatalk/netatalk.git",
+            "cd netatalk",
+            "```",
+            "",
+            "**Note:** Installation commands may require `sudo` privileges depending on your system configuration.",
             "",
 );
 
-foreach my $key (keys %{$workflow->{jobs}}) {
-    my $job = $workflow->{jobs}->{$key};
+foreach my $input_file (@input_files) {
+    my $workflow;
+    eval { $workflow = $ypp->load_file($input_file); };
+    if ($@) {
+        die "Error parsing YAML file '$input_file': $@\n";
+    }
 
-    # No need to document the SonarQube job
-    next if $job->{name} eq "Static Analysis";
+    foreach my $key (keys %{$workflow->{jobs}}) {
+        my $job = $workflow->{jobs}->{$key};
 
-    push @markdown, "## " . $job->{name}, "";
+        next if $job->{name} =~ /\(32-bit\)$/;
 
-    foreach my $step (@{$job->{steps}}) {
-        # Skip unnamed steps
-        next unless exists $step->{name};
+        my @steps = grep { wanted_step($_) } @{$job->{steps}};
+        next unless @steps;
 
-        # Skip GitHub actions steps irrelevant to documentation
-        next if exists $step->{uses} && $step->{uses} =~ /^actions\//;
+        push @markdown, "## " . format_job_name($job->{name}), "";
 
-        # Adjust line breaks for better readability
-        if (exists $step->{run}) {
-            $step->{run} =~ s/\\\n\s+//g;
-            $step->{run} =~ s/\n+$//;
-        }
-
-        if (exists $step->{with}) {
-            if (exists $step->{with}->{prepare}) {
-                $step->{with}->{prepare} =~ s/\\\n\s+//g;
-                $step->{with}->{prepare} =~ s/\n+$//;
-            }
-
-            if (exists $step->{with}->{run}) {
-                $step->{with}->{run} =~ s/\\\n\s+//g;
-                $step->{with}->{run} =~ s/\n+$//;
-            }
-        }
-
-        # There are two types of jobs with different structures
-        if (exists $step->{uses} && $step->{uses} =~ /^vmactions\//) {
-            push @markdown,
-              "Install required packages",
-              "",
-              "```shell",
-              $step->{with}->{prepare},
-              "```",
-              "",
-              "Build and install",
-              "",
-              "```shell",
-              $step->{with}->{run},
-              "```",
-              "";
-        } else {
-            push @markdown,
-              $step->{name},
-              "",
-              "```shell",
-              $step->{run},
-              "```",
-              "";
+        foreach my $step (@steps) {
+            render_step(\@markdown, $step);
         }
     }
 }

--- a/meson.build
+++ b/meson.build
@@ -143,6 +143,8 @@ if 'readmes' in docs_options
         run_command(
             make_compile_doc,
             '.github/workflows/build.yml',
+            '.github/workflows/spectest-macos.yml',
+            '.github/workflows/spectest-vms.yml',
             'COMPILATION.md',
             check: true,
         )


### PR DESCRIPTION
the build workflow jobs are now spread across multiple files, so the generator script is modified to take multiple files as arguments

we also introduce granular filtering of the contents to produce a tighter resulting readme with less irrelevant cruft from the yaml code

touch up labels and comments in the workflow jobs for better readability and better resulting compilation readme output