### PR TITLE
meson: detect freebsd style init scripts for dragonflybsd

### DIFF
--- a/.github/workflows/spectest-vms.yml
+++ b/.github/workflows/spectest-vms.yml
@@ -62,14 +62,10 @@ jobs:
               xapian-core
           run: |
             set -e
-            # DragonflyBSD isn't in meson's init-style auto-detection; it is
-            # FreeBSD-derived and uses the same rc.d script, so select it
-            # explicitly to install /usr/local/etc/rc.d/netatalk.
             meson setup build \
               -Dbuildtype=debugoptimized \
               -Dwith-appletalk=true \
               -Dwith-eventloop=libev \
-              -Dwith-init-style=freebsd \
               -Dwith-tests=true \
               -Dwith-testsuite=true
             meson compile -C build

--- a/meson.build
+++ b/meson.build
@@ -2589,7 +2589,9 @@ if have_webmin
         init_a2boot_restart = 'service a2boot restart'
     elif 'freebsd' in init_style
         init_dir_override = get_option('with-init-dir')
-        if init_dir_override == ''
+        if init_dir_override != ''
+            init_dir = init_dir_override
+        else
             init_dir = '/usr/local/etc/rc.d'
         endif
         init_netatalk_start = init_dir + '/netatalk start'

--- a/meson.build
+++ b/meson.build
@@ -2269,7 +2269,7 @@ if 'auto' in init_style
             init_style = ['openrc']
             init_cmd = 'rc-service'
         endif
-    elif host_os == 'freebsd'
+    elif host_os in ['dragonfly', 'freebsd']
         init_style = ['freebsd']
     elif host_os == 'netbsd'
         init_style = ['netbsd']


### PR DESCRIPTION
a dragonflybsd system should be using freebsd style rc.d script, so let's detect this automatically through the build system

also fixes a tangential bug:  don't ignore the init dir override for Webmin freebsd commands