### PR TITLE
libatalk: add Umich copyright notice to two adouble source files

### DIFF
--- a/libatalk/adouble/ad_attr.c
+++ b/libatalk/adouble/ad_attr.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1998 Adrian Sun (asun@zoology.washington.edu)
+ * Copyright (c) 1990,1991 Regents of The University of Michigan.
  * All rights reserved. See COPYRIGHT.
  */
 

--- a/libatalk/adouble/ad_date.c
+++ b/libatalk/adouble/ad_date.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1998 Adrian Sun (asun@zoology.washington.edu)
+ * Copyright (c) 1990,1991 Regents of The University of Michigan.
  * All rights reserved. See COPYRIGHT.
  */
 


### PR DESCRIPTION
as per a conversation with Adrian Sun, a Umich copyright is appropriate since these files were originally created through a refactoring of earlier code