### PR TITLE
deletefile(): POSIX-lock-safe, GET-only open-conflict check, and fix no-access/no-lock open blocking delete

### DIFF
--- a/distrib/docker/testsuite_alp.Dockerfile
+++ b/distrib/docker/testsuite_alp.Dockerfile
@@ -94,6 +94,8 @@ RUN meson setup build \
     -Dwith-testsuite=true \
 &&  meson compile -C build
 
+RUN meson test -C build --print-errorlogs
+
 RUN meson install --destdir=/staging/ -C build
 
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS deploy

--- a/distrib/docker/testsuite_deb.Dockerfile
+++ b/distrib/docker/testsuite_deb.Dockerfile
@@ -107,6 +107,8 @@ RUN meson setup build \
     -Dwith-testsuite=true \
 &&  meson compile -C build
 
+RUN meson test -C build --print-errorlogs
+
 RUN meson install --destdir=/staging/ -C build
 
 FROM debian:13.5-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e AS deploy

--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -993,7 +993,7 @@ void afp_over_dsi(AFPObj *obj)
             function = (uint8_t) dsi->commands[0];
             /* AFP replay cache */
             rc_idx = dsi->clientID % REPLAYCACHE_SIZE;
-            LOG(log_debug, logtype_dsi, "DSI request ID: %u", dsi->clientID);
+            LOG(log_maxdebug, logtype_dsi, "DSI request ID: %u", dsi->clientID);
 
             if (replaycache[rc_idx].DSIreqID == dsi->clientID
                     && replaycache[rc_idx].AFPcommand == function) {
@@ -1007,14 +1007,14 @@ void afp_over_dsi(AFPObj *obj)
                 if (afp_switch[function]) {
                     dsi->datalen = DSI_DATASIZ;
                     dsi->flags |= DSI_RUNNING;
-                    LOG(log_debug, logtype_afpd, "<== Start AFP command: %s",
+                    LOG(log_maxdebug, logtype_afpd, "<== Start AFP command: %s",
                         AfpNum2name(function));
                     AFP_AFPFUNC_START(function, (char *)AfpNum2name(function));
                     err = (*afp_switch[function])(obj,
                                                   (char *)dsi->commands, dsi->cmdlen,
                                                   (char *)&dsi->data, &dsi->datalen);
                     AFP_AFPFUNC_DONE(function, (char *)AfpNum2name(function));
-                    LOG(log_debug, logtype_afpd, "==> Finished AFP command: %s -> %s",
+                    LOG(log_maxdebug, logtype_afpd, "==> Finished AFP command: %s -> %s",
                         AfpNum2name(function), AfpErr2name(err));
 
                     if (!idle_worker_is_active()) {
@@ -1054,14 +1054,14 @@ void afp_over_dsi(AFPObj *obj)
             if (afp_switch[function] != NULL) {
                 dsi->datalen = DSI_DATASIZ;
                 dsi->flags |= DSI_RUNNING;
-                LOG(log_debug, logtype_afpd, "<== Start AFP command: %s",
+                LOG(log_maxdebug, logtype_afpd, "<== Start AFP command: %s",
                     AfpNum2name(function));
                 AFP_AFPFUNC_START(function, (char *)AfpNum2name(function));
                 err = (*afp_switch[function])(obj,
                                               (char *)dsi->commands, dsi->cmdlen,
                                               (char *)&dsi->data, &dsi->datalen);
                 AFP_AFPFUNC_DONE(function, (char *)AfpNum2name(function));
-                LOG(log_debug, logtype_afpd, "==> Finished AFP command: %s -> %s",
+                LOG(log_maxdebug, logtype_afpd, "==> Finished AFP command: %s -> %s",
                     AfpNum2name(function), AfpErr2name(err));
                 dsi->flags &= ~DSI_RUNNING;
             } else {

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -2012,7 +2012,18 @@ int copyfile(struct vol *s_vol,
         ad_close(adp, adflags);
 
         if (EEXIST != err) {
-            deletefile(d_vol, -1, dst, 0);
+            /* dst ownership is not certain here (the create failed for a
+             * non-EEXIST reason, or dst appeared via a race), so the conflict
+             * check governs the cleanup unlink: if it reports the object as
+             * held or unreadable, do not remove it — log and leave it. */
+            int dret = deletefile(d_vol, -1, dst, 0);
+
+            if (dret != AFP_OK && dret != AFPERR_NOOBJ) {
+                LOG(log_error, logtype_afpd,
+                    "copyfile('%s'): could not remove partial destination: %d",
+                    dst, dret);
+            }
+
             goto done;
         }
 
@@ -2072,7 +2083,17 @@ error:
     }
 
     if (err) {
-        deletefile(d_vol, -1, dst, 0);
+        /* dst is the server's own freshly-created file (the CREATE|EXCL open
+         * above succeeded, so nothing pre-existed).  Log if the conflict check
+         * refuses (e.g. a peer raced an open on it), so a stranded temp file is
+         * diagnosable rather than silent. */
+        int dret = deletefile(d_vol, -1, dst, 0);
+
+        if (dret != AFP_OK && dret != AFPERR_NOOBJ) {
+            LOG(log_error, logtype_afpd,
+                "copyfile('%s'): could not remove failed-copy destination: %d",
+                dst, dret);
+        }
     } else if (stat_result == 0) {
         /* set dest modification date to src date */
         struct utimbuf	ut;
@@ -2111,44 +2132,25 @@ done:
 
 /* -----------------------------------
    vol: not NULL delete cnid entry. then we are in curdir and file is a only filename
-   checkAttrib:   1 check kFPDeleteInhibitBit (deletfile called by afp_delete)
+   checkAttrib:   1 check kFPDeleteInhibitBit (deletefile called by afp_delete)
 
-   when deletefile is called we don't have lock on it, file is closed (for us)
-   untrue if called by renamefile
+   NODELETE check -> one conflict GET -> policy -> unlink -> CNID/dircache
+   cleanup (afp_delete only).
 
-   ad_open always try to open file RDWR first and ad_lock takes care of
-   WRITE lock on read only file.
+   The conflict read goes through of_get_locks(), which reuses a held fork's fd
+   instead of opening+closing a transient one, so it never drops a lock this child
+   holds on the target inode.  The unlink itself needs no fd.
 */
-
-static int check_attrib(const struct vol *vol, struct adouble *adp)
-{
-    uint16_t   bshort = 0;
-    ad_getattr(adp, &bshort);
-
-    /*
-     * Does kFPDeleteInhibitBit (bit 8) set?
-     */
-    if (!(vol->v_ignattr & ATTRBIT_NODELETE)
-            && (bshort & htons(ATTRBIT_NODELETE))) {
-        return AFPERR_OLOCK;
-    }
-
-    if (bshort & htons(ATTRBIT_DOPEN | ATTRBIT_ROPEN)) {
-        return AFPERR_BUSY;
-    }
-
-    return 0;
-}
 
 /*!
  * @note dirfd can be used for unlinkat semantics
  */
 int deletefile(const struct vol *vol, int dirfd, char *file, int checkAttrib)
 {
-    struct adouble	ad;
-    struct adouble      *adp = NULL;
-    int			adflags, err = AFP_OK;
-    int			meta = 0;
+    struct path  dpath = {0};
+    int          df_locked = 0, rf_locked = 0;
+    uint16_t     band_held = 0;
+    int          err = AFP_OK;
 
     if (file == NULL) {
         LOG(log_error, logtype_afpd, "deletefile: file parameter is NULL");
@@ -2156,109 +2158,112 @@ int deletefile(const struct vol *vol, int dirfd, char *file, int checkAttrib)
     }
 
     LOG(log_debug, logtype_afpd, "deletefile('%s')", file);
-    ad_init(&ad, vol);
+    /* of_get_locks() stats this fresh (of_findname/at), resolving "do we hold a
+     * fork on this inode?" and reporting a missing target as OF_LOCKS_NOENT. */
+    dpath.u_name = file;
 
+    /* --- NODELETE / kFPDeleteInhibitBit (afp_delete only) ---
+     * Read the in-core header when a fork with loaded metadata is held (no open),
+     * else a private ad_metadata().  Never ad_open(HF) onto of->of_ad: on v2 the
+     * ._ sidecar shares the rfork inode and on EA the meta fd is the data fd, so a
+     * transient meta open+close there would strand a held lock.  The EA metadata
+     * read must stay RDONLY (an RDWR read would open() the data inode). */
     if (checkAttrib) {
-        /* was EACCESS error try to get only metadata */
-        /* we never want to create a resource fork here, we are going to delete it
-         * moreover sometimes deletefile is called with a no existent file and
-         * ad_open would create a 0 byte resource fork
-        */
-        if (ad_metadataat(dirfd, file, ADFLAGS_CHECK_OF, &ad) == 0) {
-            if ((err = check_attrib(vol, &ad))) {
-                ad_close(&ad, ADFLAGS_HF | ADFLAGS_CHECK_OF);
-                return err;
+        const struct ofork *ofm = (dirfd != -1) ? of_findnameat(dirfd, &dpath)
+                                  : of_findname(vol, &dpath);
+        uint16_t      attr = 0;
+
+        if (ofm != NULL && AD_META_OPEN(ofm->of_ad)) {
+            ad_getattr(ofm->of_ad, &attr);
+        } else {
+            /* No usable in-core header: read it privately.  ADFLAGS_CHECK_OF opens
+             * the data fork (-> SETSHRMD -> DF), so an EACCES on a no-access file
+             * propagates and ad_metadata() retries the read as root; flags=0 would
+             * read the EA by path, get EACCES masked to ENOENT, and miss the bit.
+             * The transient open+close strands no lock of ours: this branch only
+             * runs when no metadata-bearing fork is held on the inode. */
+            struct adouble admeta;
+            ad_init(&admeta, vol);
+
+            if (ad_metadataat(dirfd, file, ADFLAGS_CHECK_OF, &admeta) == 0) {
+                ad_getattr(&admeta, &attr);
+                ad_close(&admeta, ADFLAGS_HF | ADFLAGS_CHECK_OF);
+            } else if (errno != ENOENT) {
+                /* Fail closed: an errored metadata read leaves NODELETE unknown,
+                 * so refuse rather than risk bypassing it.  ENOENT is not an error
+                 * here - a file with no header simply has no NODELETE bit. */
+                LOG(log_error, logtype_afpd,
+                    "deletefile('%s'): NODELETE metadata read failed (%s); refusing "
+                    "delete with AFPERR_ACCESS", file, strerror(errno));
+                return AFPERR_ACCESS;
             }
+        }
 
-            meta = 1;
+        if (!(vol->v_ignattr & ATTRBIT_NODELETE)
+                && (attr & htons(ATTRBIT_NODELETE))) {
+            return AFPERR_OLOCK;
         }
     }
 
-    /* try to open both forks at once */
-    adflags = ADFLAGS_DF;
+    /* --- one conflict GET: data + rfork content + full band ---
+     * try_root = 1 always: the band is the server's own bookkeeping, so even the
+     * checkAttrib==0 overwrite callers read it as root (the unlink still runs as
+     * the user).  Fail closed on an indeterminate read. */
+    switch (of_get_locks(vol, dirfd, &dpath,
+                         1, 0, 0,        /* data content: whole data zone */
+                         1, 0, 0,        /* rfork content: whole rfork zone */
+                         ALL_BAND_BITS, 1,
+                         &df_locked, &rf_locked, &band_held)) {
+    case OF_LOCKS_NOENT:
+        return AFPERR_NOOBJ;
 
-    if (ad_openat(&ad, dirfd, file,
-                  adflags | ADFLAGS_RF | ADFLAGS_NORF | ADFLAGS_RDONLY) < 0) {
-        switch (errno) {
-        case ENOENT:
-            err = AFPERR_NOOBJ;
-            goto end;
+    case OF_LOCKS_ERROR:
+        /* indeterminate lock state -> refuse, never unlink.  AFPERR_ACCESS is the
+         * client-visible code for the dominant EACCES cause; the log keeps the
+         * rarer causes (a hard F_GETLK error, a held ofork with no data fd)
+         * diagnosable. */
+        LOG(log_error, logtype_afpd,
+            "deletefile('%s'): conflict GET indeterminate (could not read lock "
+            "state); refusing delete with AFPERR_ACCESS", file);
+        return AFPERR_ACCESS;
 
-        case EACCES: /* maybe it's a file with no write mode for us */
-            break;   /* was return AFPERR_ACCESS;*/
-
-        case EROFS:
-            err = AFPERR_VLOCK;
-            goto end;
-
-        default:
-            err = AFPERR_PARAM;
-            goto end;
-        }
-    } else {
-        adp = &ad;
+    default:                       /* OF_LOCKS_OK */
+        break;
     }
 
-    if (adp && AD_RSRC_OPEN(adp)) {   /* there's a resource fork */
-        adflags |= ADFLAGS_RF;
-
-        /* FIXME we have a pb here because we want to know if a file is open
-         * there's a 'priority inversion' if you can't open the resource fork RW
-         * you can delete it if it's open because you can't get a write lock.
-         *
-         * ADLOCK_FILELOCK means the whole resource fork, not only after the
-         * metadatas
-         *
-         * FIXME it doesn't work for RFORK open read only and fork open without deny mode
-         */
-        if (ad_tmplock(&ad, ADEID_RFORK, ADLOCK_WR | ADLOCK_FILELOCK, 0, 0, 0) < 0) {
-            err = AFPERR_BUSY;
-            goto end;
-        }
+    /* An open with no deny claim does not block a delete: DELETE_BLOCKING_BAND_BITS
+     * excludes the "none" access markers (OPEN_NONE, which plants a band entry only
+     * so a mode-less open registers) and the read-only-open markers (OPEN_RD) for
+     * both data and rsrc.  Deny modes (DENY_*) and a write open (OPEN_WR) still
+     * block (left unchanged pending AFP/SMB spec and client validation). */
+    if (df_locked || rf_locked || (band_held & DELETE_BLOCKING_BAND_BITS)) {
+        return AFPERR_BUSY;
     }
 
-    if (adp && ad_tmplock(&ad, ADEID_DFORK, ADLOCK_WR, 0, 0, 0) < 0) {
-        LOG(log_error, logtype_afpd, "deletefile('%s'): ad_tmplock error: %s", file,
-            strerror(errno));
-        err = AFPERR_BUSY;
-    } else if (!(err = vol->vfs->vfs_deletefile(vol, dirfd, file))
-               && !(err = netatalk_unlinkat(dirfd, file))) {
-        cnid_t id;
+    /* checkAttrib is last in the && so the unlink is never short-circuited away
+     * for the rename/copy-overwrite callers. */
+    if (!(err = vol->vfs->vfs_deletefile(vol, dirfd, file))
+            && !(err = netatalk_unlinkat(dirfd, file))
+            && checkAttrib) {
+        cnid_t      id;
         struct dir *cachedfile;
+        AFP_CNID_START("cnid_get");
+        id = cnid_get(vol->v_cdb, curdir->d_did, file, strlen(file));
+        AFP_CNID_DONE();
 
-        if (checkAttrib) {
-            /* Delete CNID */
-            AFP_CNID_START("cnid_get");
-            id = cnid_get(vol->v_cdb, curdir->d_did, file, strlen(file));
+        if (id) {
+            AFP_CNID_START("cnid_delete");
+            cnid_delete(vol->v_cdb, id);
             AFP_CNID_DONE();
-
-            if (id) {
-                AFP_CNID_START("cnid_delete");
-                cnid_delete(vol->v_cdb, id);
-                AFP_CNID_DONE();
-            }
-
-            /* Remove file from dircache */
-            /* file guaranteed non-NULL (checked at function entry) */
-            AFP_ASSERT(file != NULL);
-            cachedfile = dircache_search_by_name(vol, curdir, file,
-                                                 strnlen(file, CNID_MAX_PATH_LEN));
-
-            if (cachedfile) {
-                dir_remove(vol, cachedfile, 0);  /* User-initiated delete cleanup */
-            }
         }
-    }
 
-end:
+        AFP_ASSERT(file != NULL);
+        cachedfile = dircache_search_by_name(vol, curdir, file,
+                                             strnlen(file, CNID_MAX_PATH_LEN));
 
-    if (meta) {
-        ad_close(&ad, ADFLAGS_HF | ADFLAGS_CHECK_OF);
-    }
-
-    if (adp) {
-        /* ad_close removes locks if any */
-        ad_close(&ad, adflags);
+        if (cachedfile) {
+            dir_remove(vol, cachedfile, 0);  /* User-initiated delete cleanup */
+        }
     }
 
     return err;

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -800,6 +800,7 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
     struct vol  *vol;
     struct dir  *dir;
     struct path *s_path;
+    struct ofork *of;
     char        *upath;
     int         did;
     int         rc = AFP_OK;
@@ -966,7 +967,18 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 
             bdestroy(dname);
         }
-    } else if (of_findname(vol, s_path)) {
+    } else if ((of = of_findname(vol, s_path))) {
+        /* This session still holds a tracked fork on the inode. */
+        LOG(log_note, logtype_afpd,
+            "afp_delete(\"%s\"): refused (AFPERR_BUSY): this session still has "
+            "an open fork: refnum %" PRIu16 ", name \"%s\", flags 0x%x"
+            "%s%s%s%s, dev/ino %ju/%ju",
+            upath, of->of_refnum, of_name(of), of->of_flags,
+            (of->of_flags & AFPFORK_DATA) ? " [data]" : "",
+            (of->of_flags & AFPFORK_RSRC) ? " [rsrc]" : "",
+            (of->of_flags & AFPFORK_DIRTY) ? " [dirty]" : "",
+            (of->of_flags & AFPFORK_MODIFIED) ? " [modified]" : "",
+            (uintmax_t)of->key.dev, (uintmax_t)of->key.inode);
         rc = AFPERR_BUSY;
     } else {
         /* it's a file st_valid should always be true

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -1429,7 +1429,7 @@ static int read_fork(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
         dsi = obj->dsi;
         /* reqcount isn't always truthful. we need to deal with that. */
         size = ad_size(ofork->of_ad, eid);
-        LOG(log_debug, logtype_afpd,
+        LOG(log_maxdebug, logtype_afpd,
             "afp_read(fork: %" PRIu16 " [%s], off: %" PRIu64 ", len: %" PRIu64 ", size: %"
             PRIu64 ")",
             ofork->of_refnum, (ofork->of_flags & AFPFORK_DATA) ? "data" : "reso", offset,
@@ -1546,7 +1546,7 @@ static int read_fork(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
             goto afp_read_done;
         }
 
-        LOG(log_debug, logtype_afpd,
+        LOG(log_maxdebug, logtype_afpd,
             "afp_read(name: \"%s\", offset: %jd, reqcount: %jd): got %jd bytes from file",
             of_name(ofork), (intmax_t)offset, (intmax_t)reqcount, (intmax_t)*rbuflen);
         offset += *rbuflen;
@@ -1768,9 +1768,12 @@ int afp_closefork(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
     memcpy(&ofrefnum, ibuf, sizeof(ofrefnum));
 
     if (NULL == (ofork = of_find(ofrefnum))) {
-        LOG(log_debug, logtype_afpd,
+        /* A close we cannot match leaves any real fork it targeted tracked
+         * forever (and its inode undeletable this session). */
+        LOG(log_warning, logtype_afpd,
             "afp_closefork: of_find(%" PRIu16 ") could not locate fork"
-            " (wire bytes: 0x%02x%02x; stale close from client)",
+            " (wire bytes: 0x%02x%02x; stale close from client, or a fork"
+            " this session leaked)",
             ofrefnum,
             (unsigned char)ibuf[0], (unsigned char)ibuf[1]);
         return AFPERR_PARAM;
@@ -1794,7 +1797,7 @@ static ssize_t write_file(struct ofork *ofork, int eid,
                           size_t rbuflen)
 {
     ssize_t cc;
-    LOG(log_debug, logtype_afpd, "write_file(off: %ju, size: %zu)",
+    LOG(log_maxdebug, logtype_afpd, "write_file(off: %ju, size: %zu)",
         (uintmax_t)offset, rbuflen);
 
     if ((cc = ad_write(ofork->of_ad, eid, offset, 0,
@@ -1866,7 +1869,7 @@ static int write_fork(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf,
         goto afp_write_err;
     }
 
-    LOG(log_debug, logtype_afpd,
+    LOG(log_maxdebug, logtype_afpd,
         "afp_write(fork: %" PRIu16 " [%s], off: %" PRIu64 ", size: %" PRIu64 ")",
         ofork->of_refnum, (ofork->of_flags & AFPFORK_DATA) ? "data" : "reso", offset,
         reqcount);
@@ -2053,7 +2056,7 @@ afp_write_loop:
                 return cc;
             }
 
-            LOG(log_debug, logtype_afpd, "afp_write: wrote: %jd, offset: %jd",
+            LOG(log_maxdebug, logtype_afpd, "afp_write: wrote: %jd, offset: %jd",
                 (intmax_t)cc, (intmax_t)offset);
             offset += cc;
         }

--- a/etc/afpd/fork.h
+++ b/etc/afpd/fork.h
@@ -76,6 +76,14 @@ extern struct adouble *of_ad(const struct vol *, struct path *,
 extern struct ofork *of_findnameat(int dirfd, struct path *path);
 extern int of_fstatat(int dirfd, struct path *path);
 
+enum of_locks_status { OF_LOCKS_ERROR = -1, OF_LOCKS_OK = 0, OF_LOCKS_NOENT = 1 };
+
+extern int of_get_locks(const struct vol *vol, int dirfd, struct path *path,
+                        int df_get, off_t df_off, off_t df_len,
+                        int rf_get, off_t rf_off, off_t rf_len,
+                        uint16_t band_request, int try_root,
+                        int *df_locked, int *rf_locked, uint16_t *band_held);
+
 
 /* in fork.c */
 extern int          flushfork(struct ofork *);

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -25,6 +25,7 @@
 #ifdef WITH_SPOTLIGHT
 #include <atalk/spotlight.h>
 #endif
+#include <atalk/unix.h>
 #include <atalk/util.h>
 
 #include "ad_cache.h"
@@ -449,12 +450,300 @@ struct ofork *of_findnameat(int dirfd, struct path *path)
     return NULL;
 }
 
+/*!
+ * @brief Conflict GET (F_GETLK only): read another holder's locks on a file.
+ *
+ * Reuses a held fork's fd when one exists, else opens+closes a transient one.
+ * Reading through a held fd (never a transient open+close on an inode we hold a
+ * lock on) is what keeps the held byte locks from being dropped on close.  The
+ * rfork is never opened onto of->of_ad (would corrupt ad_rlen / underflow the v2
+ * meta refcount).
+ *
+ * @param[in]  vol          volume the target lives on
+ * @param[in]  dirfd        directory fd for openat-style resolution, or -1
+ * @param[in]  path         target; both fork inodes derive from it
+ * @param[in]  df_get       probe data-fork content if non-zero
+ * @param[in]  df_off       data-fork content offset
+ * @param[in]  df_len       data-fork content length (0 = whole data zone)
+ * @param[in]  rf_get       probe resource-fork content if non-zero
+ * @param[in]  rf_off       resource-fork content offset
+ * @param[in]  rf_len       resource-fork content length (0 = whole zone)
+ * @param[in]  band_request share-mode band bitmap; OR together the per-offset
+ *                          *_BIT aliases from adouble.h (or ALL_BAND_BITS for all
+ *                          ten).  Bit n maps to offset AD_FILELOCK_BASE + n.
+ * @param[in]  try_root     retry the open as root on EACCES (the band is the
+ *                          server's own bookkeeping, not a user permission)
+ * @param[out] df_locked    set if the data-fork content range is locked
+ * @param[out] rf_locked    set if the resource-fork content range is locked
+ * @param[out] band_held    positional bitmap of held band bits (same positions
+ *                          as band_request)
+ *
+ * @returns OF_LOCKS_OK (0)    outputs valid (all 0 == nothing locked)
+ *          OF_LOCKS_NOENT (1) target absent; outputs stay zeroed
+ *          OF_LOCKS_ERROR(-1) lock state indeterminate -> caller must fail closed
+ *          Outputs are zeroed on entry and only populated on OF_LOCKS_OK, so a
+ *          caller that ignores the return still reads zeros, never stale data -
+ *          but the return MUST be checked (zeros do not mean "no locks").
+ *
+ * Data/band fd is fail-closed (any non-ENOENT failure -> ERROR).  The
+ * rfork-content leg is best-effort (rf_locked stays 0 on open failure / the
+ * HAVE_EAFD && SOLARIS skip; the rfork band is still read via the data fd).
+ */
+int of_get_locks(const struct vol *vol, int dirfd, struct path *path,
+                 int df_get, off_t df_off, off_t df_len,
+                 int rf_get, off_t rf_off, off_t rf_len,
+                 uint16_t band_request, int try_root,
+                 int *df_locked, int *rf_locked, uint16_t *band_held)
+{
+    struct ofork   *of;
+    struct adouble  addata;
+    struct adouble  adrf;
+    struct adouble *dadp = NULL;
+    struct adouble *radp = NULL;
+    uint16_t        held = 0;
+    int             d_opened = 0, r_opened = 0, rc = OF_LOCKS_OK;
+    int             dflk = 0, rflk = 0;
+    int             need_data = (df_get || band_request);
+    *df_locked = 0;
+    *rf_locked = 0;
+    *band_held = 0;
+    of = (dirfd != -1) ? of_findnameat(dirfd, path) : of_findname(vol, path);
+
+    /* of_findname[at]() stat()s the target (filling path->st_errno) and returns
+     * NULL when it does not exist.  Map a provably-absent target to NOENT here, so
+     * the tri-valued contract holds for every request shape - including an
+     * rfork-only probe, whose ADFLAGS_NORF open would otherwise succeed (no rfork
+     * is not an error) and leave a missing file reported as OF_LOCKS_OK. */
+    if (of == NULL && path->st_errno == ENOENT) {
+        rc = OF_LOCKS_NOENT;
+        goto done;
+    }
+
+    /* --- data fd: carries data content + the whole band --- */
+    if (need_data) {
+        if (of != NULL && (ad_data_fileno(of->of_ad) >= 0
+                           || ad_data_fileno(of->of_ad) == AD_SYMLINK)) {
+            dadp = of->of_ad;            /* reuse held fd, never close */
+        } else if (of != NULL) {
+            /* held ofork with a closed data fd: GETting through -1 would
+             * short-circuit to "no conflict" (fail-OPEN), so refuse */
+            LOG(log_error, logtype_afpd,
+                "of_get_locks(\"%s\"): held ofork has no data fd (refnum %" PRIu16
+                ") - failing closed", path->u_name, of->of_refnum);
+            rc = OF_LOCKS_ERROR;
+            goto done;
+        }
+
+        if (dadp == NULL) {
+            /* DF|RDONLY, no SETSHRMD (a F_GETLK test needs no write access; the
+             * probe sets F_WRLCK explicitly regardless of fd mode) and no HF
+             * (metadata is not a lock surface). */
+            int dflags = ADFLAGS_DF | ADFLAGS_RDONLY;
+            int derr, oerr;
+            ad_init(&addata, vol);
+            derr = ad_openat(&addata, dirfd, path->u_name, dflags);
+            oerr = errno;
+
+            if (derr < 0 && oerr == EACCES && try_root) {
+                become_root();
+                derr = ad_openat(&addata, dirfd, path->u_name, dflags);
+                oerr = errno;            /* before unbecome_root: seteuid sets errno */
+                unbecome_root();
+            }
+
+            if (derr == 0) {
+                dadp = &addata;
+                d_opened = 1;
+            } else if (oerr == ENOENT) {
+                rc = OF_LOCKS_NOENT;
+                goto done;
+            } else {
+                rc = OF_LOCKS_ERROR;     /* fail closed */
+                goto done;
+            }
+        }
+    }
+
+    /* --- rfork fd: separate inode; never opened onto of->of_ad --- */
+    if (rf_get) {
+        if (of != NULL && AD_RSRC_OPEN(of->of_ad)) {
+            radp = of->of_ad;            /* reuse held rfork, never close */
+        } else if (of != NULL) {
+            /* hold a fork but not the rfork.  On HAVE_EAFD && SOLARIS the rfork's
+             * O_XATTR fd hangs off the data fd, so a private open here would open a
+             * second fd to an inode we hold a lock on, and closing it would drop
+             * that lock -> skip.  Other backends open the rfork as a separate
+             * object and are safe. */
+#if !(defined(HAVE_EAFD) && defined(SOLARIS))
+            int rerr, roerr;
+            ad_init(&adrf, vol);
+            rerr = ad_openat(&adrf, dirfd, path->u_name,
+                             ADFLAGS_RF | ADFLAGS_NORF | ADFLAGS_RDONLY);
+            roerr = errno;
+
+            if (rerr < 0 && roerr == EACCES && try_root) {
+                become_root();
+                rerr = ad_openat(&adrf, dirfd, path->u_name,
+                                 ADFLAGS_RF | ADFLAGS_NORF | ADFLAGS_RDONLY);
+                /* roerr is not re-read: any failure here is unconditional ERROR */
+                unbecome_root();
+            }
+
+            if (rerr == 0) {
+                /* ADFLAGS_NORF returns 0 with no rfork opened when none is present;
+                 * probe only when the rfork actually opened, but close whatever did
+                 * open (the base fd may have, e.g. on Solaris). */
+                r_opened = 1;
+
+                if (AD_RSRC_OPEN(&adrf)) {
+                    radp = &adrf;
+                }
+            } else {
+                /* ADFLAGS_NORF masks only a missing rfork, not a hard error, so a
+                 * failure here means the rfork lock state is indeterminate: fail
+                 * closed rather than let the caller read it as "unlocked". */
+                rc = OF_LOCKS_ERROR;
+                goto done;
+            }
+
+#endif
+        } else {
+            /* no fork held: a transient open strands nothing.  HAVE_EAFD &&
+             * SOLARIS needs DF too (the O_XATTR base fd). */
+            int rflags = ADFLAGS_RF | ADFLAGS_NORF | ADFLAGS_RDONLY;
+            int rerr, roerr;
+#if defined(HAVE_EAFD) && defined(SOLARIS)
+            rflags |= ADFLAGS_DF;
+#endif
+            ad_init(&adrf, vol);
+            rerr = ad_openat(&adrf, dirfd, path->u_name, rflags);
+            roerr = errno;
+
+            if (rerr < 0 && roerr == EACCES && try_root) {
+                become_root();
+                rerr = ad_openat(&adrf, dirfd, path->u_name, rflags);
+                roerr = errno;
+                unbecome_root();
+            }
+
+            if (rerr == 0) {
+                /* close whatever opened (on Solaris ADFLAGS_DF opens the O_XATTR
+                 * base fd even when the rfork itself does not open); probe only when
+                 * the rfork actually opened. */
+                r_opened = 1;
+
+                if (AD_RSRC_OPEN(&adrf)) {
+                    radp = &adrf;
+                }
+            } else if (roerr == ENOENT) {
+                /* target vanished after the lookup (race): definitely absent */
+                rc = OF_LOCKS_NOENT;
+                goto done;
+            } else {
+                /* hard error (not masked by NORF): indeterminate -> fail closed */
+                rc = OF_LOCKS_ERROR;
+                goto done;
+            }
+        }
+    }
+
+    /* rfork content: one range probe (no band lives on the rfork fd) */
+    if (rf_get && radp != NULL) {
+        int r = ad_testlock_range(radp, ADEID_RFORK, rf_off, rf_len);
+
+        if (r < 0) {
+            rc = OF_LOCKS_ERROR;
+            goto done;
+        }
+
+        rflk = (r > 0);
+    }
+
+    /* data fd: whole-fd fast path when >= 2 dimensions requested, else probe the
+     * one dimension directly.  band_request & (band_request-1) tests ">= 2 bits". */
+    if (dadp != NULL) {
+        int band_multi = (band_request & (band_request - 1)) != 0;
+        int use_whole  = (df_get && band_request != 0) || band_multi;
+        int resolve    = 1;
+
+        if (use_whole) {
+            int whole = ad_testlock_whole(dadp, ADEID_DFORK);
+
+            if (whole < 0) {
+                rc = OF_LOCKS_ERROR;
+                goto done;
+            }
+
+            resolve = (whole > 0);       /* clear => data fd holds nothing */
+        }
+
+        if (resolve) {
+            if (df_get) {
+                int r = ad_testlock_range(dadp, ADEID_DFORK, df_off, df_len);
+
+                if (r < 0) {
+                    rc = OF_LOCKS_ERROR;
+                    goto done;
+                }
+
+                dflk = (r > 0);
+            }
+
+            for (int bit = 0; bit < AD_FILELOCK_BAND_BITS; bit++) {
+                int r;
+
+                if (!(band_request & (1U << bit))) {
+                    continue;
+                }
+
+                r = ad_testlock_range(dadp, ADEID_DFORK, AD_FILELOCK_BASE + bit, 1);
+
+                if (r < 0) {
+                    rc = OF_LOCKS_ERROR;
+                    goto done;
+                }
+
+                if (r > 0) {
+                    held |= (uint16_t)(1U << bit);
+                }
+            }
+        }
+    }
+
+done:
+
+    if (d_opened) {
+        ad_close(&addata, ADFLAGS_DF);
+    }
+
+    if (r_opened) {
+        ad_close(&adrf, ADFLAGS_RF | ADFLAGS_HF
+#if defined(HAVE_EAFD) && defined(SOLARIS)
+                 | ADFLAGS_DF
+#endif
+                );
+    }
+
+    if (rc == OF_LOCKS_OK) {
+        *df_locked = dflk;
+        *rf_locked = rflk;
+        *band_held = held;
+    }
+
+    return rc;
+}
+
 void of_dealloc(struct ofork *of)
 {
     if (!oforks) {
         return;
     }
 
+    /* pairs each removal with its afp_openfork open */
+    LOG(log_debug, logtype_afpd,
+        "of_dealloc(refnum %" PRIu16 ", \"%s\", flags 0x%x, dev/ino %ju/%ju)",
+        of->of_refnum, of_name(of), of->of_flags,
+        (uintmax_t)of->key.dev, (uintmax_t)of->key.inode);
     of_unhash(of);
     oforks[of->of_refnum % nforks] = NULL;
 

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -280,6 +280,31 @@ struct adouble {
 #define AD_FILELOCK_OPEN_NONE      (AD_FILELOCK_BASE + 8)
 #define AD_FILELOCK_RSRC_OPEN_NONE (AD_FILELOCK_BASE + 9)
 
+/* share-mode band as a bitmap: bit n == AD_FILELOCK_BASE + n */
+#define AD_FILELOCK_BAND_BITS  10
+
+#define OPEN_WR_BIT         (1U << (AD_FILELOCK_OPEN_WR        - AD_FILELOCK_BASE))
+#define OPEN_RD_BIT         (1U << (AD_FILELOCK_OPEN_RD        - AD_FILELOCK_BASE))
+#define RSRC_OPEN_WR_BIT    (1U << (AD_FILELOCK_RSRC_OPEN_WR   - AD_FILELOCK_BASE))
+#define RSRC_OPEN_RD_BIT    (1U << (AD_FILELOCK_RSRC_OPEN_RD   - AD_FILELOCK_BASE))
+#define DENY_WR_BIT         (1U << (AD_FILELOCK_DENY_WR        - AD_FILELOCK_BASE))
+#define DENY_RD_BIT         (1U << (AD_FILELOCK_DENY_RD        - AD_FILELOCK_BASE))
+#define RSRC_DENY_WR_BIT    (1U << (AD_FILELOCK_RSRC_DENY_WR   - AD_FILELOCK_BASE))
+#define RSRC_DENY_RD_BIT    (1U << (AD_FILELOCK_RSRC_DENY_RD   - AD_FILELOCK_BASE))
+#define OPEN_NONE_BIT       (1U << (AD_FILELOCK_OPEN_NONE      - AD_FILELOCK_BASE))
+#define RSRC_OPEN_NONE_BIT  (1U << (AD_FILELOCK_RSRC_OPEN_NONE - AD_FILELOCK_BASE))
+
+#define ALL_BAND_BITS       ((1U << AD_FILELOCK_BAND_BITS) - 1)
+#define OPEN_BITS           (OPEN_WR_BIT | OPEN_RD_BIT \
+                             | RSRC_OPEN_WR_BIT | RSRC_OPEN_RD_BIT)
+/* band bits that block a delete: all but the no-claim "open, no deny" markers.
+ * Excludes OPEN_NONE (deny-none/access-none open) and OPEN_RD (read-only open,
+ * no deny) for both data and rsrc: mere open-ness with no deny mode is not a
+ * claim that should refuse a delete.  OPEN_WR and every DENY_* bit still block. */
+#define DELETE_BLOCKING_BAND_BITS                                       \
+    (ALL_BAND_BITS & ~(OPEN_NONE_BIT | RSRC_OPEN_NONE_BIT               \
+                       | OPEN_RD_BIT | RSRC_OPEN_RD_BIT))
+
 /* time stuff. we overload the bits a little.  */
 #define AD_DATE_CREATE         0
 #define AD_DATE_MODIFY         4
@@ -396,6 +421,9 @@ extern int fsetrsrcea(struct adouble *ad, int fd, const char *eaname,
 
 /* ad_lock.c */
 extern int ad_testlock(struct adouble *adp, int eid, off_t off);
+extern int ad_testlock_range(struct adouble *adp, int eid, off_t off,
+                             off_t len);
+extern int ad_testlock_whole(struct adouble *adp, int eid);
 extern uint16_t ad_openforks(struct adouble *adp, uint16_t);
 extern int ad_lock(struct adouble *, uint32_t eid, int type, off_t off,
                    off_t len, int fork);

--- a/libatalk/adouble/ad_lock.c
+++ b/libatalk/adouble/ad_lock.c
@@ -741,6 +741,162 @@ int ad_testlock(struct adouble *ad, int eid, const off_t off)
 }
 
 /*!
+ * @brief GET-only range probe: does another process hold a conflicting lock?
+ *
+ * Tests whether another process holds a conflicting lock on [off, off+len) of
+ * fork @p eid.  Unlike ad_testlock()/testlock() this does not scan our own
+ * adf_lock[] array first: it is kernel F_GETLK only.  By POSIX, F_GETLK never
+ * reports the calling process's own locks, so this can be called through a fd of
+ * a fork we hold open without self-reporting our own band/byte entries — exactly
+ * the conflict read a delete needs (it must see only other holders).  It never
+ * issues F_SETLK, so it has no acquire/release lifetime and cannot strand a lock.
+ *
+ * Key behaviours:
+ *
+ *  - No adf_lock[] array scan — kernel F_GETLK only (no self-report).
+ *  - Always probes with an explicit F_WRLCK.  A write probe conflicts with a
+ *    peer's read or write lock, so it sees the F_RDLCK share-mode band entries.
+ *    F_GETLK only tests, so the probe type is independent of the fd's
+ *    O_RDWR/O_RDONLY mode (cf. testlock(), which picks F_RDLCK on an RO fd and
+ *    would miss the band).
+ *  - eid dispatch: ADEID_DFORK uses the data fd at the literal offset, which also
+ *    covers the whole share-mode band (OPEN, DENY and RSRC mirrors), since the
+ *    band lives on the data fd via rf2off().  ADEID_RFORK uses the resource fork's
+ *    own fd (ad_rfp) at off + ad_getentryoff(), matching ad_lock()'s rfork
+ *    non-FILELOCK branch.  Band offsets are never passed with ADEID_RFORK; a band
+ *    offset is recognised as off >= AD_FILELOCK_BASE.
+ *  - Zone clamp on data-zone requests only (off < AD_FILELOCK_BASE): a len == 0
+ *    ("whole data zone") or over-long request is bounded to the data zone, never
+ *    a POSIX l_len == 0 ("to infinity") that would sweep the share-mode band.
+ *    An explicit band probe (off >= AD_FILELOCK_BASE) passes through unclamped.
+ *
+ * @param[in,out] ad   handle
+ * @param[in] eid      ADEID_DFORK (data + band) or ADEID_RFORK (rfork content)
+ * @param[in] off      offset (content) or a band offset (>= AD_FILELOCK_BASE)
+ * @param[in] len      length; 0 == whole data zone (data-zone requests only)
+ *
+ * @returns  1 = a conflicting lock exists (incl. F_GETLK EACCES/EAGAIN, reported
+ *               as locked/indeterminate — fail safe, matching testlock());
+ *           0 = no conflict (incl. no fd to probe);
+ *          -1 = hard error (caller must refuse the operation, never proceed).
+ */
+int ad_testlock_range(struct adouble *ad, int eid, off_t off, off_t len)
+{
+    const struct ad_fd *adf;
+    struct flock  lock;
+    LOG(log_debug, logtype_ad,
+        "ad_testlock_range(%s, off: %jd (%s), len: %jd): BEGIN",
+        eid == ADEID_DFORK ? "data" : "reso",
+        (intmax_t)off, shmdstrfromoff(off), (intmax_t)len);
+
+    /* dispatch to the correct fd and offset */
+    if (eid == ADEID_DFORK) {
+        adf = &ad->ad_data_fork;
+        lock.l_start = off;
+    } else {
+        adf = ad->ad_rfp;
+        lock.l_start = off + ad_getentryoff(ad, ADEID_RFORK);
+    }
+
+    /* No fd to probe (rfork not open / no sidecar): nothing of another process
+     * can be locked here through this handle. */
+    if (adf->adf_fd == -1) {
+        return 0;
+    }
+
+    /* zone clamp — data-zone requests only, by subtraction against the actual
+     * lock position (for ADEID_RFORK l_start already includes the resource-fork
+     * entry offset).  An explicit band probe (off >= AD_FILELOCK_BASE) reads the
+     * sentinel zone and is left unclamped. */
+    if (off < AD_FILELOCK_BASE) {
+        if (lock.l_start >= BYTELOCK_MAX) {
+            /* nothing in the data zone left to test */
+            return 0;
+        }
+
+        /* compare by subtraction: `l_start + len` overflows off_t for huge len */
+        off_t zone_max = BYTELOCK_MAX - lock.l_start;   /* >= 1 */
+
+        if (len == 0 || len > zone_max) {
+            len = zone_max;
+        }
+
+        if (len <= 0) {
+            return 0;
+        }
+    }
+
+    /* explicit F_WRLCK (sees a peer's F_RDLCK band entry on any fd mode), kernel
+     * F_GETLK only, no adf_lock[] scan */
+    lock.l_type   = F_WRLCK;
+    lock.l_whence = SEEK_SET;
+    lock.l_len    = len;
+
+    if (set_lock(adf->adf_fd, F_GETLK, &lock) < 0) {
+        /* EACCES/EAGAIN: kernel declined to answer — treat as locked/
+         * indeterminate (matches testlock()).  Any other error is a hard -1;
+         * the caller must refuse, never proceed. */
+        LOG(log_debug, logtype_ad,
+            "ad_testlock_range: F_GETLK fd=%d off=%jd len=%jd: %s",
+            adf->adf_fd, (intmax_t)lock.l_start, (intmax_t)lock.l_len,
+            strerror(errno));
+        return (errno == EACCES || errno == EAGAIN) ? 1 : -1;
+    }
+
+    LOG(log_debug, logtype_ad, "ad_testlock_range: END: %d",
+        (lock.l_type == F_UNLCK) ? 0 : 1);
+    return (lock.l_type == F_UNLCK) ? 0 : 1;
+}
+
+/*!
+ * @brief GET-only whole-fd probe: does another process hold any lock on the fd?
+ *
+ * The negative-case fast path.  Issues one F_GETLK over the entire fd of fork
+ * @p eid — deliberately unclamped (l_start = 0, l_len = 0 = "to infinity"), so on
+ * the data fd it spans the data content zone and the whole share-mode band, a
+ * strict superset of every ad_testlock_range dimension on that fd.  A clear (0)
+ * result proves the fd holds nothing, letting a caller skip the per-dimension
+ * content + per-bit band probes; a hit (1) forces the fidelity-preserving
+ * per-dimension resolution.
+ *
+ * This is the one probe that must span the band, so unlike ad_testlock_range it
+ * is not zone-clamped.  That is sound only because its sole use is the
+ * all-or-nothing fast path, never a per-dimension result.  Like ad_testlock_range
+ * it is kernel F_GETLK only (no array scan), probes with an explicit F_WRLCK, and
+ * shares the same fail-safe contract.
+ *
+ * Callers pass ADEID_DFORK: the rfork fd carries only a content range and no
+ * band, so a whole-fd probe there would collapse 1->1 and force the real range
+ * probe anyway (a net extra syscall) — the rfork is read with ad_testlock_range
+ * directly.
+ *
+ * @returns  1 = some lock exists (incl. F_GETLK EACCES/EAGAIN — fail safe);
+ *           0 = wholly clear (incl. no fd to probe);
+ *          -1 = hard error (caller must fail closed).
+ */
+int ad_testlock_whole(struct adouble *ad, int eid)
+{
+    const struct ad_fd *adf;
+    struct flock  lock;
+    adf = (eid == ADEID_DFORK) ? &ad->ad_data_fork : ad->ad_rfp;
+
+    if (adf->adf_fd == -1) {
+        return 0;
+    }
+
+    lock.l_type   = F_WRLCK;   /* sees a peer's F_RDLCK band too */
+    lock.l_whence = SEEK_SET;
+    lock.l_start  = 0;
+    lock.l_len    = 0;         /* whole fd to infinity — deliberately unclamped */
+
+    if (set_lock(adf->adf_fd, F_GETLK, &lock) < 0) {
+        return (errno == EACCES || errno == EAGAIN) ? 1 : -1;   /* fail safe */
+    }
+
+    return (lock.l_type == F_UNLCK) ? 0 : 1;
+}
+
+/*!
  * @brief Return if a file is open by another process.
  *
  * Optimized for the common case:

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -1058,7 +1058,11 @@ static int ad_error(struct adouble *ad, int adflags)
 {
     int err _U_ = errno;
 
-    if (adflags & ADFLAGS_NOHF) { /* 1 */
+    /* (1) ADFLAGS_NOHF: a *missing* metadata/header fork is not an error.  Suppress
+     * only the benign "absent" errnos; a hard error (EIO, EACCES, ...) propagates so
+     * a caller cannot mistake an unreadable header for "no header". */
+    if ((adflags & ADFLAGS_NOHF)
+            && (errno == ENOENT || errno == ENOATTR)) {
         return 0;
     }
 
@@ -1822,6 +1826,12 @@ static int ad_open_rf_ea(const char *path, int adflags, int mode,
 EC_CLEANUP:
 
     if (ret != 0) {
+        /* Capture the open-failure errno before the close()/ad_close() below can
+         * clobber it: ADFLAGS_NORF suppresses only a *missing* resource fork
+         * (ENOENT/ENOATTR), not a hard error (EIO, EACCES, ...), so a caller cannot
+         * mistake an unreadable rfork for "no rfork". */
+        int open_errno = errno;
+
         if (opened && (ad_reso_fileno(ad) != -1)) {
             close(ad_reso_fileno(ad));
             ad_reso_fileno(ad) = -1;
@@ -1829,7 +1839,8 @@ EC_CLEANUP:
             ad->ad_rfp->adf_refcount = 0;
         }
 
-        if (adflags & ADFLAGS_NORF) {
+        if ((adflags & ADFLAGS_NORF)
+                && (open_errno == ENOENT || open_errno == ENOATTR)) {
             ret = 0;
         } else {
             int err = errno;

--- a/libatalk/adouble/ad_write.c
+++ b/libatalk/adouble/ad_write.c
@@ -63,7 +63,7 @@ ssize_t ad_write(struct adouble *ad, uint32_t eid, off_t off, int end,
         return -1;
     }
 
-    LOG(log_debug, logtype_ad, "ad_write: off: %ju, size: %zu, eabuflen: %zu",
+    LOG(log_maxdebug, logtype_ad, "ad_write: off: %ju, size: %zu, eabuflen: %zu",
         (uintmax_t)off, buflen, ad->ad_rlen);
 
     if (eid == ADEID_DFORK) {

--- a/libatalk/dsi/dsi_cmdreply.c
+++ b/libatalk/dsi/dsi_cmdreply.c
@@ -19,13 +19,13 @@
 int dsi_cmdreply(DSI *dsi, const int err)
 {
     int ret;
-    LOG(log_debug, logtype_dsi, "dsi_cmdreply(DSI ID: %u, len: %zd): START",
+    LOG(log_maxdebug, logtype_dsi, "dsi_cmdreply(DSI ID: %u, len: %zd): START",
         dsi->clientID, dsi->datalen);
     dsi->header.dsi_flags = DSIFL_REPLY;
     dsi->header.dsi_len = htonl(dsi->datalen);
     dsi->header.dsi_data.dsi_code = htonl(err);
     ret = dsi_stream_send(dsi, dsi->data, dsi->datalen);
-    LOG(log_debug, logtype_dsi, "dsi_cmdreply(DSI ID: %u, len: %zd): END",
+    LOG(log_maxdebug, logtype_dsi, "dsi_cmdreply(DSI ID: %u, len: %zd): END",
         dsi->clientID, dsi->datalen);
     return ret;
 }

--- a/libatalk/dsi/dsi_stream.c
+++ b/libatalk/dsi/dsi_stream.c
@@ -68,7 +68,7 @@ static int dsi_peek(DSI *dsi)
     int    len;
     int    maxfd;
     int    ret;
-    LOG(log_debug, logtype_dsi, "dsi_peek");
+    LOG(log_maxdebug, logtype_dsi, "dsi_peek");
     maxfd = dsi->socket + 1;
 
     while (1) {
@@ -116,7 +116,7 @@ static int dsi_peek(DSI *dsi)
 
         if (FD_ISSET(dsi->socket, &writefds)) {
             /* we can write again */
-            LOG(log_debug, logtype_dsi, "dsi_peek: can write again");
+            LOG(log_maxdebug, logtype_dsi, "dsi_peek: can write again");
             break;
         }
 
@@ -139,7 +139,7 @@ static int dsi_peek(DSI *dsi)
                 return -1;
             }
 
-            LOG(log_debug, logtype_dsi, "dsi_peek: read %d bytes", len);
+            LOG(log_maxdebug, logtype_dsi, "dsi_peek: read %d bytes", len);
             dsi->eof += len;
         }
     }
@@ -174,7 +174,7 @@ static size_t from_buf(DSI *dsi, uint8_t *buf, size_t count)
         }
     }
 
-    LOG(log_debug, logtype_dsi,
+    LOG(log_maxdebug, logtype_dsi,
         "from_buf(read: %u, unread:%u , space left: %u): returning %u",
         dsi->start - dsi->buffer, dsi->eof - dsi->start, dsi->end - dsi->eof, nbe);
     return nbe;
@@ -711,6 +711,7 @@ int dsi_stream_receive(DSI *dsi)
         return 0;
     }
 
-    LOG(log_debug, logtype_dsi, "dsi_stream_receive: DSI cmdlen: %zd", dsi->cmdlen);
+    LOG(log_maxdebug, logtype_dsi, "dsi_stream_receive: DSI cmdlen: %zd",
+        dsi->cmdlen);
     return block[1];
 }

--- a/test/afpd/faultinject.c
+++ b/test/afpd/faultinject.c
@@ -134,11 +134,14 @@ static int fault_should_fire(int armed, int *fail_after, int errnum)
 }
 
 typedef int (*open_fn)(const char *, int, ...);
+typedef int (*open2_fn)(const char *, int);
 typedef int (*close_fn)(int);
 typedef int (*fcntl_fn)(int, int, ...);
 typedef int (*fchdir_fn)(int);
 
 static open_fn   real_open;
+static open2_fn  real_open_2;
+static open2_fn  real_open64_2;
 static close_fn  real_close;
 static fcntl_fn  real_fcntl;
 static fchdir_fn real_fchdir;
@@ -146,6 +149,19 @@ static fchdir_fn real_fchdir;
 #ifndef O_TMPFILE
 #define O_TMPFILE 0
 #endif
+
+/* Record then decide, shared by every open-family interposer.  Record before
+ * the decision so count/flags reflect the attempt; only while armed.  Returns 1
+ * when the caller should inject the failure (errno already set). */
+static int open_armed_should_fire(int flags)
+{
+    if (fi.open_armed) {
+        fi.open_calls++;
+        fi.open_last_flags = flags;
+    }
+
+    return fault_should_fire(fi.open_armed, &fi.open_fail_after, fi.open_errno);
+}
 
 /* A single open() definition covers both symbols libatalk may reference: under
  * glibc with _FILE_OFFSET_BITS=64 (set globally) <fcntl.h> renames THIS
@@ -170,21 +186,48 @@ int open(const char *path, int flags, ...)
         real_open = (open_fn)dlsym(RTLD_NEXT, "open");
     }
 
-    /* Record the flags of every armed open() so a test can inspect WHAT a retry
-     * re-opened with (e.g. assert a read-only downgrade retry dropped O_TRUNC),
-     * not merely that an open happened.  Recorded before the failure decision so
-     * the count and flags reflect the attempt regardless of outcome; only while
-     * armed, to stay inert for unrelated infrastructure opens. */
-    if (fi.open_armed) {
-        fi.open_calls++;
-        fi.open_last_flags = flags;
-    }
-
-    if (fault_should_fire(fi.open_armed, &fi.open_fail_after, fi.open_errno)) {
+    if (open_armed_should_fire(flags)) {
         return -1;
     }
 
     return real_open(path, flags, mode);
+}
+
+/* _FORTIFY_SOURCE (default on Ubuntu's GCC, glibc >= 2.42) rewrites a no-mode
+ * open(path, flags) to __open_2()/__open64_2() instead of open()/open64().
+ * Every of_get_locks/deletefile probe open is no-O_CREAT, so without these
+ * interposers an armed failure never fires on a fortified build and a
+ * fail-closed test reads a real ENOENT as "no rfork".  No O_CREAT here means no
+ * mode argument.  The __asm__ labels pin the real symbol names: under
+ * _FILE_OFFSET_BITS=64 the identifier __open_2 would itself emit __open64_2 and
+ * collide, so private identifiers keep both interposers distinct (LFS + 32-bit). */
+int fi_open_2(const char *path, int flags) __asm__("__open_2");
+int fi_open64_2(const char *path, int flags) __asm__("__open64_2");
+
+int fi_open_2(const char *path, int flags)
+{
+    if (!real_open_2) {
+        real_open_2 = (open2_fn)dlsym(RTLD_NEXT, "__open_2");
+    }
+
+    if (open_armed_should_fire(flags)) {
+        return -1;
+    }
+
+    return real_open_2(path, flags);
+}
+
+int fi_open64_2(const char *path, int flags)
+{
+    if (!real_open64_2) {
+        real_open64_2 = (open2_fn)dlsym(RTLD_NEXT, "__open64_2");
+    }
+
+    if (open_armed_should_fire(flags)) {
+        return -1;
+    }
+
+    return real_open64_2(path, flags);
 }
 
 int close(int fd)
@@ -241,6 +284,24 @@ int fcntl(int fd, int cmd, ...)
 
     if (!real_fcntl) {
         real_fcntl = (fcntl_fn)dlsym(RTLD_NEXT, "fcntl");
+    }
+
+    /* Record lock-fcntl calls so a test can assert HOW a probe locked (count,
+     * range, type) — e.g. that a range probe never issues l_len == 0 (which would
+     * sweep the share-mode band).  Only while watching, to stay inert otherwise. */
+    if (fi.fcntl_watch && has_ptr && ptr_arg != NULL
+            && (cmd == F_GETLK || cmd == F_SETLK || cmd == F_SETLKW)) {
+        const struct flock *flk = ptr_arg;
+
+        if (cmd == F_GETLK) {
+            fi.getlk_calls++;
+        } else {
+            fi.setlk_calls++;
+        }
+
+        fi.lock_last_type  = flk->l_type;
+        fi.lock_last_start = flk->l_start;
+        fi.lock_last_len   = flk->l_len;
     }
 
     if (fault_should_fire(fi.fcntl_armed, &fi.fcntl_fail_after, fi.fcntl_errno)) {

--- a/test/afpd/faultinject.h
+++ b/test/afpd/faultinject.h
@@ -15,6 +15,8 @@
 #ifndef FAULTINJECT_H
 #define FAULTINJECT_H
 
+#include <sys/types.h>   /* off_t */
+
 /*!
  * @file
  * @brief Test-only fault-injection control block (see faultinject.c).
@@ -40,6 +42,15 @@ struct fault_inject {
     int fcntl_armed;
     int fcntl_fail_after;
     int fcntl_errno;
+    /* Observe the lock calls a probe issues, so a test can assert HOW it probed
+     * (count, range, type), not just the result.  Updated on every F_GETLK/F_SETLK
+     * fcntl when fcntl_watch is set; reset by fault_inject_reset(). */
+    int   fcntl_watch;       /*!< record lock-fcntl calls into the fields below */
+    int   getlk_calls;       /*!< count of F_GETLK calls seen while watching */
+    int   setlk_calls;       /*!< count of F_SETLK/F_SETLKW calls seen */
+    int   lock_last_type;    /*!< l_type of the most recent watched lock fcntl */
+    off_t lock_last_start;   /*!< l_start of the most recent watched lock fcntl */
+    off_t lock_last_len;     /*!< l_len   of the most recent watched lock fcntl */
     int fchdir_armed;
     int fchdir_fail_after;
     int fchdir_errno;

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -93,6 +93,7 @@ if get_option('with-tests')
         # live in the executable; export_dynamic below lets the LD_PRELOAD
         # interposer (libfaultinject.so) resolve `fi` back into this binary.
         'faultinject.c',
+        'test_capabilities.c',
         'subtests_lock.c',
         include_directories: test_includes,
         objects: afpdtest_objects,

--- a/test/afpd/subtests_lock.c
+++ b/test/afpd/subtests_lock.c
@@ -36,13 +36,20 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+#include <signal.h>
+
 #include <atalk/adouble.h>
+#include <atalk/directory.h>
 #include <atalk/logger.h>
 #include <atalk/volume.h>
 
+#include "directory.h"
 #include "faultinject.h"
+#include "file.h"
+#include "fork.h"
 #include "subtests_lock.h"
 #include "test.h"      /* TEST_SKIP */
+#include "test_capabilities.h"
 
 /*!
  * @brief Framework capability probe: does fault injection reach into libatalk?
@@ -73,7 +80,7 @@ int utest_faultinject_selftest(const struct vol *vol)
     /* Capability probe: does the preload intercept open() here, with the armed
      * errno?  If not (e.g. macOS two-level namespace), skip — injection-
      * dependent tests skip too. */
-    if (!faultinject_open_works(path)) {
+    if (!test_capability(TEST_CAP_FAULT_INJECT, vol)) {
         return TEST_SKIP;
     }
 
@@ -120,7 +127,7 @@ static int fd_is_open(int fd)
  * into the long-lived child.  Verified by accounting (not an fd-count scan, which
  * is racy and Linux-only): capture the raw data-fork fd, run the cleanup, and
  * assert two independent ledgers agree the fd is gone — the ad layer
- * (ad_data_fileno == -1) AND the kernel (fcntl(fd) -> EBADF).  A negative control
+ * (ad_data_fileno == -1) and the kernel (fcntl(fd) -> EBADF).  A negative control
  * (fd open before cleanup) keeps the assertion from passing vacuously.
  */
 int utest_openfork_no_fd_leak(const struct vol *vol)
@@ -139,7 +146,7 @@ int utest_openfork_no_fd_leak(const struct vol *vol)
 
     dfd = ad_data_fileno(&ad);
 
-    /* Negative control: before cleanup the fd MUST be open, else the leak
+    /* Negative control: before cleanup the fd must be open, else the leak
      * assertion below would pass vacuously. */
     if (!fd_is_open(dfd)) {
         ad_close(&ad, ADFLAGS_DF);
@@ -178,7 +185,7 @@ int utest_openfork_no_fd_leak(const struct vol *vol)
  * open/close sequence and asserting the two coupled invariants at every step:
  *   - the fd is open  iff  adf_refcount > 0   (fileno reset to -1 exactly at 0);
  *   - refcount tracks references exactly (N opens need N closes; an early close
- *     must NOT close the shared fd while a sibling reference remains).
+ *     must not close the shared fd while a sibling reference remains).
  * It is the regression net that protects every open/close/cleanup path the
  * fork series touches.
  */
@@ -216,7 +223,7 @@ int utest_shared_adouble_refcount_balance(const struct vol *vol)
         return 4;                    /* 2nd ref must share the fd, refcount 2 */
     }
 
-    /* Release reference 2: refcount 2->1, fd MUST stay open (sibling holds it). */
+    /* Release reference 2: refcount 2->1, fd must stay open (sibling holds it). */
     ad_close(&ad, ADFLAGS_DF);
 
     if (ad.ad_data_fork.adf_refcount != 1) {
@@ -337,7 +344,7 @@ int utest_adclose_underflow_aborts(const struct vol *vol)
  * EACCES/EPERM/EROFS; the retry must strip O_TRUNC/O_CREAT/O_EXCL, not just flip
  * the access mode, or a SETSHRMD|RDONLY|TRUNC caller would truncate on the retry
  * a file it asked to open read-only.  No fd/refcount ledger sees this -- the bug
- * is in WHICH flags the second open() carries -- so drive the retry and inspect
+ * is in which flags the second open() carries -- so drive the retry and inspect
  * the flags the shim recorded.  ad2openflags() makes attempt 1 O_RDWR|O_TRUNC;
  * arming EACCES on it forces the retry, whose flags land in open_last_flags
  * (open_calls == 2).  Skips where the shim cannot intercept libatalk's open().
@@ -349,7 +356,7 @@ int utest_ro_retry_strips_destructive_flags(const struct vol *vol)
     int ad_ret, retry_flags, calls;
     snprintf(path, sizeof(path), "%s/fi_ro_retry", vol->v_path);
 
-    if (!faultinject_open_works(path)) {
+    if (!test_capability(TEST_CAP_FAULT_INJECT, vol)) {
         return TEST_SKIP;
     }
 
@@ -398,6 +405,1030 @@ int utest_ro_retry_strips_destructive_flags(const struct vol *vol)
 
     if (ad_ret != 0) {
         return 5;                    /* read-only retry open failed */
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief ad2openflags(): RDONLY+SETSHRMD on the data fork is promoted to O_RDWR
+ *        (share-mode locks need a writable fd); plain RDONLY stays O_RDONLY.
+ *
+ * Category: targeted.  This promotion is load-bearing and easy to break silently
+ * (O_RDONLY is 0, so a regression only surfaces as subtle lock behaviour or
+ * strict-backend EINVAL).  The access mode has no fd/refcount ledger; observe it
+ * via the shim, which records each armed open()'s flags in fi.open_last_flags.
+ * Arm with open_fail_after = -1 to record without failing.  Skips where the shim
+ * cannot intercept libatalk's open().
+ */
+int utest_ad2openflags_accmode(const struct vol *vol)
+{
+    struct adouble ad;
+    char path[MAXPATHLEN + 1];
+    int ad_ret, shrmd_flags, ro_flags;
+    snprintf(path, sizeof(path), "%s/fi_ad2openflags", vol->v_path);
+
+    if (!test_capability(TEST_CAP_FAULT_INJECT, vol)) {
+        return TEST_SKIP;
+    }
+
+    fault_inject_reset();
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR | ADFLAGS_CREATE, 0666) != 0) {
+        (void)unlink(path);
+        return 1;                    /* setup create failed */
+    }
+
+    ad_close(&ad, ADFLAGS_DF);
+    /* (1) RDONLY + SETSHRMD must be promoted to O_RDWR */
+    ad_init(&ad, vol);
+    fault_inject_reset();
+    fi.open_armed = 1;
+    fi.open_fail_after = -1;         /* record flags, never fail */
+    ad_ret = ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDONLY | ADFLAGS_SETSHRMD);
+    shrmd_flags = fi.open_last_flags;
+    fault_inject_reset();
+
+    if (ad_ret == 0) {
+        ad_close(&ad, ADFLAGS_DF);
+    }
+
+    /* (2) plain RDONLY (no SETSHRMD) must stay O_RDONLY */
+    ad_init(&ad, vol);
+    fault_inject_reset();
+    fi.open_armed = 1;
+    fi.open_fail_after = -1;
+    ad_ret = ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDONLY);
+    ro_flags = fi.open_last_flags;
+    fault_inject_reset();
+
+    if (ad_ret == 0) {
+        ad_close(&ad, ADFLAGS_DF);
+    }
+
+    (void)unlink(path);
+
+    if ((shrmd_flags & O_ACCMODE) != O_RDWR) {
+        return 2;                    /* SETSHRMD|RDONLY not promoted to O_RDWR */
+    }
+
+    if ((ro_flags & O_ACCMODE) != O_RDONLY) {
+        return 3;                    /* plain RDONLY wrongly opened writable */
+    }
+
+    return 0;
+}
+
+/* ====================================================================== *
+ * Delete-conflict GET tests (ad_testlock_range / ad_testlock_whole /
+ * of_get_locks / deletefile).
+ *
+ * F_GETLK never reports the calling process's own locks, so a conflict a
+ * probe must see has to be held by ANOTHER process.  peer_hold_lock() forks a
+ * child that takes a real fcntl lock on the backing file and parks until told
+ * to exit, giving the parent a genuine cross-process holder to probe against.
+ * ====================================================================== */
+
+/* A forked peer holding a byte-range lock on a path until released. */
+struct peer {
+    pid_t pid;
+    int   to_child;      /* parent writes 1 byte here to tell the peer to exit */
+    int   from_child;    /* peer writes 1 byte here once the lock is held */
+};
+
+/* Fork a child that opens `path` and takes an fcntl lock of `type`
+ * (F_RDLCK/F_WRLCK) over [start, start+len).  Returns 0 and fills *p on success
+ * (the lock is held by the time this returns), -1 on failure. */
+static int peer_hold_lock(struct peer *p, const char *path, short type,
+                          off_t start, off_t len)
+{
+    int up[2], down[2];
+    char b;
+
+    if (pipe(up) < 0) {
+        return -1;
+    }
+
+    if (pipe(down) < 0) {
+        close(up[0]);
+        close(up[1]);
+        return -1;
+    }
+
+    p->pid = fork();
+
+    if (p->pid < 0) {
+        close(up[0]);
+        close(up[1]);
+        close(down[0]);
+        close(down[1]);
+        return -1;
+    }
+
+    if (p->pid == 0) {
+        /* child: take the lock, signal "held", wait for the release byte */
+        struct flock fl = {0};
+        int fd = open(path, O_RDWR);
+
+        if (fd < 0) {
+            _exit(1);
+        }
+
+        fl.l_type = type;
+        fl.l_whence = SEEK_SET;
+        fl.l_start = start;
+        fl.l_len = len;
+
+        if (fcntl(fd, F_SETLK, &fl) < 0) {
+            _exit(2);
+        }
+
+        b = 1;
+
+        if (write(up[1], &b, 1) != 1) {
+            _exit(3);
+        }
+
+        (void)read(down[0], &b, 1);   /* park until released */
+        _exit(0);
+    }
+
+    /* parent */
+    close(up[1]);
+    close(down[0]);
+    p->to_child = down[1];
+    p->from_child = up[0];
+
+    /* block until the peer reports the lock is held */
+    if (read(p->from_child, &b, 1) != 1) {
+        close(p->to_child);
+        close(p->from_child);
+        return -1;
+    }
+
+    return 0;
+}
+
+/* Release the peer (let it exit) and reap it. */
+static void peer_release(struct peer *p)
+{
+    char b = 1;
+    int status;
+    (void)write(p->to_child, &b, 1);
+    close(p->to_child);
+    close(p->from_child);
+    (void)waitpid(p->pid, &status, 0);
+}
+
+/* In a forked child, try to take an fcntl lock of `type` over [start,start+len)
+ * on `path`.  Returns 1 if the lock was acquired (range free), 0 if it conflicted
+ * (range held by another process), -1 on a fork/open error.  Cross-process, so it
+ * sees a lock this process holds (which our own F_GETLK never would).  The result
+ * is reported over a pipe rather than the child's exit status. */
+static int peer_try_lock(const char *path, short type, off_t start, off_t len)
+{
+    int pfd[2];
+    pid_t pid;
+    int status;
+    char res;
+
+    if (pipe(pfd) < 0) {
+        return -1;
+    }
+
+    pid = fork();
+
+    if (pid < 0) {
+        close(pfd[0]);
+        close(pfd[1]);
+        return -1;
+    }
+
+    if (pid == 0) {
+        struct flock fl = {0};
+        int fd = open(path, O_RDWR);
+        char r;
+
+        if (fd < 0) {
+            r = 2;                   /* could not open */
+        } else {
+            fl.l_type = type;
+            fl.l_whence = SEEK_SET;
+            fl.l_start = start;
+            fl.l_len = len;
+            /* 1 = acquired (range free), 0 = conflict (range held) */
+            r = (fcntl(fd, F_SETLK, &fl) == 0) ? 1 : 0;
+        }
+
+        (void)write(pfd[1], &r, 1);
+        _exit(0);
+    }
+
+    close(pfd[1]);
+
+    if (read(pfd[0], &res, 1) != 1) {
+        res = 2;                     /* child died without reporting */
+    }
+
+    close(pfd[0]);
+    (void)waitpid(pid, &status, 0);
+
+    if (res == 2) {
+        return -1;                   /* child could not open the file */
+    }
+
+    return res == 1 ? 1 : 0;
+}
+
+/* Seed a struct path for the conflict helpers: u_name only, st_valid 0 so
+ * of_findname()/of_get_locks() stat it fresh. */
+static void seed_path(struct path *path, char *u_name)
+{
+    memset(path, 0, sizeof(*path));
+    path->u_name = u_name;
+}
+
+/* Create a scratch file of `size` bytes under the volume, returning its full
+ * path in out[]/outlen.  Returns 0 on success. */
+static int make_scratch(const struct vol *vol, const char *leaf,
+                        off_t size, char *out, size_t outlen)
+{
+    struct adouble ad;
+    int n = snprintf(out, outlen, "%s/%s", vol->v_path, leaf);
+
+    if (n < 0 || (size_t)n >= outlen) {
+        return -1;
+    }
+
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, out, ADFLAGS_DF | ADFLAGS_RDWR | ADFLAGS_CREATE, 0666) != 0) {
+        return -1;
+    }
+
+    if (size > 0) {
+        (void)ftruncate(ad_data_fileno(&ad), size);
+    }
+
+    ad_close(&ad, ADFLAGS_DF);
+    return 0;
+}
+
+/*!
+ * @brief ad_testlock_range() clamps a data-zone probe; never sweeps the band.
+ *
+ * Category: targeted.  A whole-data-zone request (len == 0) must be bounded to
+ * the data zone (issued l_len != 0, l_start + l_len <= BYTELOCK_MAX), not turned
+ * into a POSIX l_len == 0 ("to infinity") that would reach the share-mode band.
+ * An explicit band probe (off >= AD_FILELOCK_BASE) must pass through unclamped.
+ * Observed via the shim's lock-fcntl recorder.  Skips where the shim cannot
+ * intercept libatalk's fcntl().
+ */
+int utest_testlock_range_clamp(const struct vol *vol)
+{
+    struct adouble ad;
+    char path[MAXPATHLEN + 1];
+    off_t whole_len;
+
+    if (!test_capability(TEST_CAP_FAULT_INJECT, vol)) {
+        return TEST_SKIP;
+    }
+
+    if (make_scratch(vol, "fi_clamp", 200, path, sizeof(path)) != 0) {
+        return 1;
+    }
+
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR, 0666) != 0) {
+        (void)unlink(path);
+        return 2;
+    }
+
+    /* whole data zone (len 0): must be clamped, one F_GETLK, l_len finite */
+    fault_inject_reset();
+    fi.fcntl_watch = 1;
+    (void)ad_testlock_range(&ad, ADEID_DFORK, 0, 0);
+    whole_len = fi.lock_last_len;
+
+    if (fi.getlk_calls != 1) {
+        fault_inject_reset();
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 3;                    /* expected exactly one F_GETLK */
+    }
+
+    if (fi.lock_last_type != F_WRLCK) {
+        fault_inject_reset();
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 4;                    /* must probe with explicit F_WRLCK */
+    }
+
+    if (whole_len == 0) {
+        fault_inject_reset();
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 5;                    /* len 0 == "to infinity": sweeps the band */
+    }
+
+    if (fi.lock_last_start + whole_len > BYTELOCK_MAX) {
+        fault_inject_reset();
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 6;                    /* clamp must stay within the data zone */
+    }
+
+    /* explicit band probe: passes through unclamped (l_start at the sentinel) */
+    fi.getlk_calls = 0;
+    (void)ad_testlock_range(&ad, ADEID_DFORK, AD_FILELOCK_OPEN_WR, 1);
+
+    if (fi.getlk_calls != 1 || fi.lock_last_start != AD_FILELOCK_OPEN_WR
+            || fi.lock_last_len != 1) {
+        fault_inject_reset();
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 7;                    /* band probe must read the sentinel offset */
+    }
+
+    fault_inject_reset();
+    ad_close(&ad, ADFLAGS_DF);
+    (void)unlink(path);
+    return 0;
+}
+
+/*!
+ * @brief ad_testlock_whole() issues one unclamped F_GETLK over the whole fd.
+ *
+ * Category: targeted.  The fast-path probe must be deliberately unclamped
+ * (l_start == 0, l_len == 0) so it spans the data zone and the share-mode band
+ * in a single call, and report a peer's band lock as a conflict.  Uses a forked
+ * peer holding a band-offset lock; skips without shim fcntl interception.
+ */
+int utest_testlock_whole(const struct vol *vol)
+{
+    struct adouble ad;
+    char path[MAXPATHLEN + 1];
+    struct peer peer;
+    int held;
+
+    if (!test_capability(TEST_CAP_FAULT_INJECT, vol)) {
+        return TEST_SKIP;
+    }
+
+    if (make_scratch(vol, "fi_whole", 100, path, sizeof(path)) != 0) {
+        return 1;
+    }
+
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR, 0666) != 0) {
+        (void)unlink(path);
+        return 2;
+    }
+
+    /* clear fd: one unclamped F_GETLK, reports 0 */
+    fault_inject_reset();
+    fi.fcntl_watch = 1;
+    held = ad_testlock_whole(&ad, ADEID_DFORK);
+
+    if (fi.getlk_calls != 1 || fi.lock_last_start != 0 || fi.lock_last_len != 0) {
+        fault_inject_reset();
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 3;                    /* must be exactly one l_start=0,l_len=0 GETLK */
+    }
+
+    if (held != 0) {
+        fault_inject_reset();
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 4;                    /* clear file must report 0 */
+    }
+
+    fault_inject_reset();
+
+    /* a peer holding a band-offset lock must be seen by the whole-fd probe */
+    if (peer_hold_lock(&peer, path, F_WRLCK, AD_FILELOCK_OPEN_WR, 1) != 0) {
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 5;
+    }
+
+    held = ad_testlock_whole(&ad, ADEID_DFORK);
+    peer_release(&peer);
+    ad_close(&ad, ADFLAGS_DF);
+    (void)unlink(path);
+
+    if (held != 1) {
+        return 6;                    /* unclamped probe must span the band */
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief ad_testlock_range() does not report this process's own band entry.
+ *
+ * Category: targeted (the crux of using a sibling primitive).  Plant an
+ * OPEN_RD band entry owned by this process via ad_lock(), then ad_testlock_range
+ * on the same offset must return 0 (kernel F_GETLK never reports our own locks),
+ * while the array-scanning ad_testlock() returns 1 on the same handle.  No shim
+ * needed.
+ */
+int utest_testlock_range_no_self_report(const struct vol *vol)
+{
+    struct adouble ad;
+    char path[MAXPATHLEN + 1];
+    int range_ret, scan_ret;
+
+    if (make_scratch(vol, "fi_self", 100, path, sizeof(path)) != 0) {
+        return 1;
+    }
+
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR | ADFLAGS_SETSHRMD,
+                0666) != 0) {
+        (void)unlink(path);
+        return 2;
+    }
+
+    /* plant an OPEN_RD band entry owned by this handle */
+    if (ad_lock(&ad, ADEID_DFORK, ADLOCK_RD | ADLOCK_FILELOCK,
+                AD_FILELOCK_OPEN_RD, 1, 0) < 0) {
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 3;
+    }
+
+    range_ret = ad_testlock_range(&ad, ADEID_DFORK, AD_FILELOCK_OPEN_RD, 1);
+    scan_ret  = ad_testlock(&ad, ADEID_DFORK, AD_FILELOCK_OPEN_RD);
+    ad_unlock(&ad, 0, 1);
+    ad_close(&ad, ADFLAGS_DF);
+    (void)unlink(path);
+
+    if (range_ret != 0) {
+        return 4;                    /* F_GETLK wrongly reported our own lock */
+    }
+
+    if (scan_ret != 1) {
+        return 5;                    /* control: array scan should self-match */
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief ad_testlock_range()'s F_WRLCK probe sees a peer's F_RDLCK band entry.
+ *
+ * Category: targeted (the read-lock visibility the old detector missed).  The
+ * legacy delete probe opened the fork read-only and so issued an F_RDLCK test,
+ * which does not conflict with another holder's read lock — a peer read-lock (and
+ * the F_RDLCK share-mode band entries) were invisible.  ad_testlock_range() always
+ * probes with an explicit F_WRLCK, which conflicts with a peer's read OR write
+ * lock, so it must report a peer's F_RDLCK as a conflict.  A forked peer holds an
+ * F_RDLCK at a band offset; assert the range probe returns 1.  Control: the same
+ * offset with no peer returns 0.  Cross-process (our own F_GETLK never reports our
+ * own locks), no shim needed.
+ */
+int utest_testlock_range_wrlck_sees_rdlck(const struct vol *vol)
+{
+    struct adouble ad;
+    char path[MAXPATHLEN + 1];
+    struct peer peer;
+    int seen, clear;
+
+    if (make_scratch(vol, "fi_rdlck", 100, path, sizeof(path)) != 0) {
+        return 1;
+    }
+
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR, 0666) != 0) {
+        (void)unlink(path);
+        return 2;
+    }
+
+    /* control: no peer -> the band offset is free */
+    clear = ad_testlock_range(&ad, ADEID_DFORK, AD_FILELOCK_OPEN_RD, 1);
+
+    if (clear != 0) {
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 3;                    /* offset must be free before the peer locks */
+    }
+
+    /* a peer holds a READ lock at the band offset */
+    if (peer_hold_lock(&peer, path, F_RDLCK, AD_FILELOCK_OPEN_RD, 1) != 0) {
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 4;
+    }
+
+    seen = ad_testlock_range(&ad, ADEID_DFORK, AD_FILELOCK_OPEN_RD, 1);
+    peer_release(&peer);
+    ad_close(&ad, ADFLAGS_DF);
+    (void)unlink(path);
+
+    if (seen != 1) {
+        return 5;                    /* F_WRLCK probe must see the peer's F_RDLCK */
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief of_get_locks(): positional band bitmap, independent df/rf, tri-valued.
+ *
+ * Category: targeted.  With a peer holding a DENY_WR band lock, request a subset
+ * of band bits plus the data range and assert: the held bit comes back in its own
+ * position, an unrequested neighbour bit stays 0, df/rf flags are independent, and
+ * the status is OF_LOCKS_OK (separate from the data).  Cross-process peer.
+ */
+int utest_of_get_locks_contract(const struct vol *vol)
+{
+    char path[MAXPATHLEN + 1];
+    struct path dpath;
+    struct peer peer;
+    int rc, dfl = 0, rfl = 0;
+    uint16_t band = 0;
+
+    if (make_scratch(vol, "fi_contract", 100, path, sizeof(path)) != 0) {
+        return 1;
+    }
+
+    if (peer_hold_lock(&peer, path, F_WRLCK, AD_FILELOCK_DENY_WR, 1) != 0) {
+        (void)unlink(path);
+        return 2;
+    }
+
+    seed_path(&dpath, path);
+    /* request DENY_WR (held) and DENY_RD (free); no data/rf content */
+    rc = of_get_locks(vol, -1, &dpath, 0, 0, 0, 0, 0, 0,
+                      DENY_WR_BIT | DENY_RD_BIT, 1, &dfl, &rfl, &band);
+    peer_release(&peer);
+    (void)unlink(path);
+
+    if (rc != OF_LOCKS_OK) {
+        return 3;                    /* readable state must be OF_LOCKS_OK */
+    }
+
+    if (!(band & DENY_WR_BIT)) {
+        return 4;                    /* the held bit must be reported... */
+    }
+
+    if (band & DENY_RD_BIT) {
+        return 5;                    /* ...and an unrequested neighbour must not */
+    }
+
+    if (dfl != 0 || rfl != 0) {
+        return 6;                    /* no content lock held: df/rf must be 0 */
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief of_get_locks(): >=2-dimension whole-fd fast path, per-bit on a hit.
+ *
+ * Category: targeted.  With >= 2 data-fd dimensions requested on a clear file,
+ * exactly one whole-fd F_GETLK is issued and the per-bit band loop is skipped.
+ * With a peer band lock present, the whole-fd probe hits and the per-bit loop then
+ * runs and attributes the exact bit.  Counts F_GETLK via the shim.
+ */
+int utest_of_get_locks_fastpath(const struct vol *vol)
+{
+    char path[MAXPATHLEN + 1];
+    struct path dpath;
+    struct peer peer;
+    int rc, dfl = 0, rfl = 0;
+    uint16_t band = 0;
+
+    if (!test_capability(TEST_CAP_FAULT_INJECT, vol)) {
+        return TEST_SKIP;
+    }
+
+    if (make_scratch(vol, "fi_fast", 100, path, sizeof(path)) != 0) {
+        return 1;
+    }
+
+    seed_path(&dpath, path);
+    /* clear file, data range + all band bits (many dimensions): one whole-fd
+     * GETLK, band loop skipped */
+    fault_inject_reset();
+    fi.fcntl_watch = 1;
+    rc = of_get_locks(vol, -1, &dpath, 1, 0, 0, 0, 0, 0,
+                      ALL_BAND_BITS, 1, &dfl, &rfl, &band);
+
+    if (rc != OF_LOCKS_OK || band != 0 || dfl != 0) {
+        fault_inject_reset();
+        (void)unlink(path);
+        return 2;
+    }
+
+    if (fi.getlk_calls != 1) {
+        fault_inject_reset();
+        (void)unlink(path);
+        return 3;                    /* clear file must resolve in one whole-fd GETLK */
+    }
+
+    fault_inject_reset();
+
+    /* peer holds DENY_WR: whole-fd probe hits, per-bit loop attributes the bit */
+    if (peer_hold_lock(&peer, path, F_WRLCK, AD_FILELOCK_DENY_WR, 1) != 0) {
+        (void)unlink(path);
+        return 4;
+    }
+
+    band = 0;
+    rc = of_get_locks(vol, -1, &dpath, 1, 0, 0, 0, 0, 0,
+                      ALL_BAND_BITS, 1, &dfl, &rfl, &band);
+    peer_release(&peer);
+    (void)unlink(path);
+
+    if (rc != OF_LOCKS_OK) {
+        return 5;
+    }
+
+    if (!(band & DENY_WR_BIT)) {
+        return 6;                    /* on a hit, the exact bit must be attributed */
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief of_get_locks(): indeterminate -> OF_LOCKS_ERROR; missing -> NOENT.
+ *
+ * Category: targeted (fail-closed contract).  A missing target returns
+ * OF_LOCKS_NOENT (definite: no locks), distinct from an unreadable one.  A forced
+ * F_GETLK hard error (shim fcntl -> EIO) must return OF_LOCKS_ERROR, never a
+ * silent "no conflict".  Skips without shim fcntl interception for the error leg.
+ */
+int utest_of_get_locks_failclosed(const struct vol *vol)
+{
+    char path[MAXPATHLEN + 1];
+    struct path dpath;
+    int rc, dfl = 0, rfl = 0;
+    uint16_t band = 0;
+
+    /* NOENT: a name that does not exist */
+    if (snprintf(path, sizeof(path), "%s/fi_absent",
+                 vol->v_path) >= (int)sizeof(path)) {
+        return 1;
+    }
+
+    (void)unlink(path);
+    seed_path(&dpath, path);
+    rc = of_get_locks(vol, -1, &dpath, 1, 0, 0, 0, 0, 0,
+                      ALL_BAND_BITS, 1, &dfl, &rfl, &band);
+
+    if (rc != OF_LOCKS_NOENT) {
+        return 2;                    /* missing target must be NOENT, not ERROR/OK */
+    }
+
+    /* NOENT also for an rfork-only request (no data/band probe): the missing
+     * target must not slip through as OF_LOCKS_OK. */
+    seed_path(&dpath, path);
+    rc = of_get_locks(vol, -1, &dpath, 0, 0, 0, 1, 0, 0,
+                      0, 1, &dfl, &rfl, &band);
+
+    if (rc != OF_LOCKS_NOENT) {
+        return 5;                    /* rfork-only missing target must be NOENT */
+    }
+
+    /* ERROR: force a hard F_GETLK failure on a real file */
+    if (!test_capability(TEST_CAP_FAULT_INJECT, vol)) {
+        return TEST_SKIP;
+    }
+
+    if (make_scratch(vol, "fi_failclosed", 100, path, sizeof(path)) != 0) {
+        return 3;
+    }
+
+    seed_path(&dpath, path);
+    fault_inject_reset();
+    fi.fcntl_armed = 1;
+    fi.fcntl_fail_after = 0;          /* fail the next lock fcntl once */
+    fi.fcntl_errno = EIO;             /* a hard error, not EACCES/EAGAIN */
+    rc = of_get_locks(vol, -1, &dpath, 1, 0, 0, 0, 0, 0,
+                      ALL_BAND_BITS, 1, &dfl, &rfl, &band);
+    fault_inject_reset();
+    (void)unlink(path);
+
+    if (rc != OF_LOCKS_ERROR) {
+        return 4;                    /* hard GETLK error must fail closed */
+    }
+
+    /* ERROR: a hard rfork-open failure (EIO, not the benign "no rfork" ENOENT)
+     * must fail closed - ADFLAGS_NORF suppresses only a missing rfork. */
+    if (make_scratch(vol, "fi_rf_failclosed", 100, path, sizeof(path)) != 0) {
+        return 6;
+    }
+
+    seed_path(&dpath, path);
+    fault_inject_reset();
+    fi.open_armed = 1;
+    fi.open_fail_after = 0;            /* fail the next open() once */
+    fi.open_errno = EIO;             /* hard error, not ENOENT/EACCES */
+    rc = of_get_locks(vol, -1, &dpath, 0, 0, 0, 1, 0, 0,
+                      0, 1, &dfl, &rfl, &band);
+    fault_inject_reset();
+    (void)unlink(path);
+
+    if (rc != OF_LOCKS_ERROR) {
+        return 7;                    /* hard rfork-open error must fail closed */
+    }
+
+    /* Benign control (no fault injection): an existing file with NO resource fork
+     * must read OK, not error - ADFLAGS_NORF must keep treating a *missing* rfork as
+     * "nothing locked".  This is the no-regression guard for the NORF change. */
+    if (make_scratch(vol, "fi_rf_absent", 100, path, sizeof(path)) != 0) {
+        return 8;
+    }
+
+    seed_path(&dpath, path);
+    rc = of_get_locks(vol, -1, &dpath, 0, 0, 0, 1, 0, 0,
+                      0, 1, &dfl, &rfl, &band);
+    (void)unlink(path);
+
+    if (rc != OF_LOCKS_OK || rfl != 0) {
+        return 9;                    /* absent rfork must be OK + unlocked */
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief deletefile()'s conflict GET through a held fd preserves the held lock.
+ *
+ * Category: targeted (the same-process lock-on-close repro).  Register a tracked
+ * ofork holding a byte-range lock on an inode, then drive of_get_locks() the way
+ * deletefile() does (reusing the held fd, opening nothing).  Assert the conflict
+ * read succeeds and a post-call F_GETLK in this process still shows the held lock
+ * (a transient open+close would have dropped it).  No peer / no shim needed.
+ */
+int utest_deletefile_quirk(struct vol *vol)
+{
+    char leaf[64];
+    char full[MAXPATHLEN + 1];
+    struct path dpath;
+    struct ofork *of;
+    struct stat st;
+    uint16_t ofrefnum = 0;
+    int rc, dfl = 0, rfl = 0;
+    uint16_t band = 0;
+    int held_before, held_after;
+    snprintf(leaf, sizeof(leaf), "fi_quirk");
+
+    if (make_scratch(vol, leaf, 200, full, sizeof(full)) != 0) {
+        return 1;
+    }
+
+    if (stat(full, &st) != 0) {
+        (void)unlink(full);
+        return 2;
+    }
+
+    /* register a tracked ofork on the inode, like afp_openfork() */
+    of = of_alloc(vol, curdir, leaf, &ofrefnum, ADEID_DFORK,
+                  NULL, &st);
+
+    if (of == NULL) {
+        (void)unlink(full);
+        return 3;
+    }
+
+    if (ad_open(of->of_ad, full, ADFLAGS_DF | ADFLAGS_RDWR | ADFLAGS_SETSHRMD,
+                0666) != 0) {
+        of_dealloc(of);
+        (void)unlink(full);
+        return 4;
+    }
+
+    /* the held fork takes a content byte-range lock */
+    if (ad_lock(of->of_ad, ADEID_DFORK, ADLOCK_WR, 0, 100, ofrefnum) < 0) {
+        ad_close(of->of_ad, ADFLAGS_DF);
+        of_dealloc(of);
+        (void)unlink(full);
+        return 5;
+    }
+
+    /* a peer must see the held lock as a conflict BEFORE the GET (control) */
+    held_before = peer_try_lock(full, F_WRLCK, 0, 100);
+
+    if (held_before != 0) {
+        ad_unlock(of->of_ad, ofrefnum, 1);
+        ad_close(of->of_ad, ADFLAGS_DF);
+        of_dealloc(of);
+        (void)unlink(full);
+        return 6;                    /* lock not actually held -> test invalid */
+    }
+
+    /* drive the delete-time conflict GET; it must reuse of->of_ad's fd and so
+     * open+close no second fd to the inode (which would drop the held lock) */
+    seed_path(&dpath, full);
+    rc = of_get_locks(vol, -1, &dpath, 1, 0, 0, 1, 0, 0,
+                      ALL_BAND_BITS, 1, &dfl, &rfl, &band);
+    /* a peer must STILL see the lock after the GET: if the GET had opened and
+     * closed a transient fd to the inode, our process's lock would be gone */
+    held_after = peer_try_lock(full, F_WRLCK, 0, 100);
+    ad_unlock(of->of_ad, ofrefnum, 1);
+    ad_close(of->of_ad, ADFLAGS_DF);
+    of_dealloc(of);
+    (void)unlink(full);
+
+    if (rc != OF_LOCKS_OK) {
+        return 7;                    /* conflict read itself failed */
+    }
+
+    if (held_after != 0) {
+        return 8;                    /* held lock was dropped by the conflict GET */
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief Negative control: demonstrate the POSIX close-drops-locks hazard is real.
+ *
+ * Category: targeted (the hazard utest_deletefile_quirk's cure defends against).
+ * POSIX advisory locks are owned by the process, so closing ANY fd to an inode
+ * drops every lock the process holds on it.  This test reproduces that hazard
+ * directly: take a lock through one fd, then open and close a SECOND, transient fd
+ * to the same inode, and observe (via a peer) that the lock is now gone — exactly
+ * what the legacy delete-time transient open+close did to a held fork's lock.
+ *
+ * Without this control, utest_deletefile_quirk's "the lock survived" could pass
+ * vacuously on a platform that never drops the lock in the first place.  Here, if
+ * the transient close does NOT drop the lock, this platform does not exhibit the
+ * quirk, so there is nothing to defend against: return TEST_SKIP (the cure is
+ * trivially safe here and its positive result is not meaningful).  A reproduced
+ * hazard returns 0 — the danger is real, and the cure test then proves 9B avoids
+ * it.  Cross-process peer (our own F_GETLK never reports our own locks).
+ */
+int utest_deletefile_quirk_hazard(const struct vol *vol)
+{
+    char path[MAXPATHLEN + 1];
+    struct flock fl = {0};
+    int held_fd, transient_fd;
+    int held_before, held_after;
+
+    if (make_scratch(vol, "fi_quirk_hazard", 200, path, sizeof(path)) != 0) {
+        return 1;
+    }
+
+    /* fd 1: take a write lock on [0,100) and keep it open */
+    held_fd = open(path, O_RDWR);
+
+    if (held_fd < 0) {
+        (void)unlink(path);
+        return 2;
+    }
+
+    fl.l_type = F_WRLCK;
+    fl.l_whence = SEEK_SET;
+    fl.l_start = 0;
+    fl.l_len = 100;
+
+    if (fcntl(held_fd, F_SETLK, &fl) < 0) {
+        close(held_fd);
+        (void)unlink(path);
+        return 3;
+    }
+
+    /* a peer must see the lock as held (control on the control) */
+    held_before = peer_try_lock(path, F_WRLCK, 0, 100);
+
+    if (held_before != 0) {
+        close(held_fd);
+        (void)unlink(path);
+        return 4;                    /* lock not actually held -> test invalid */
+    }
+
+    /* the hazard: open a SECOND fd to the same inode and close it.  Under POSIX
+     * record-lock semantics this drops the lock taken on held_fd. */
+    transient_fd = open(path, O_RDONLY);
+
+    if (transient_fd < 0) {
+        close(held_fd);
+        (void)unlink(path);
+        return 5;
+    }
+
+    close(transient_fd);
+    /* did the transient close drop our lock?  Ask the peer again. */
+    held_after = peer_try_lock(path, F_WRLCK, 0, 100);
+    close(held_fd);
+    (void)unlink(path);
+
+    if (held_after == 0) {
+        /* lock still held: this platform does NOT exhibit the quirk (e.g. OFD or
+         * BSD per-fd semantics), so there is no hazard to defend against here. */
+        return TEST_SKIP;
+    }
+
+    if (held_after != 1) {
+        return 6;                    /* peer_try_lock error */
+    }
+
+    /* lock dropped by the transient close: the hazard is real on this platform */
+    return 0;
+}
+
+/*!
+ * @brief deletefile() honours the NODELETE attribute (per backend).
+ *
+ * Category: targeted (FU-D, the NODELETE read path).  Create a file, set
+ * ATTRBIT_NODELETE, and assert deletefile(checkAttrib=1) returns AFPERR_OLOCK and
+ * leaves the file; clear it and assert the delete succeeds.  Driven with the
+ * volume's own backend (called once per backend from test.c).
+ */
+int utest_deletefile_nodelete(const struct vol *vol)
+{
+    struct adouble ad;
+    char full[MAXPATHLEN + 1];
+    char leaf[64];
+    int rc;
+    int dirfd;
+    struct stat st;
+    snprintf(leaf, sizeof(leaf), "fi_nodelete");
+
+    if (make_scratch(vol, leaf, 0, full, sizeof(full)) != 0) {
+        return 1;
+    }
+
+    /* deletefile() resolves `leaf` against `dirfd` (else the global curdir, which
+     * points at whichever volume was last chdir'd into).  Pass the volume root fd
+     * so the test is correct for any volume, not just the cwd one. */
+    dirfd = open(vol->v_path, O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+
+    if (dirfd < 0) {
+        (void)unlink(full);
+        return 10;
+    }
+
+    /* set NODELETE via the metadata header */
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, full, ADFLAGS_HF | ADFLAGS_RDWR | ADFLAGS_CREATE, 0666) != 0) {
+        (void)unlink(full);
+        return 2;
+    }
+
+    if (ad_setattr(&ad, htons(ATTRBIT_NODELETE)) != 0) {
+        ad_close(&ad, ADFLAGS_HF);
+        (void)unlink(full);
+        return 3;
+    }
+
+    ad_flush(&ad);
+    ad_close(&ad, ADFLAGS_HF);
+    /* delete must be refused while NODELETE is set */
+    rc = deletefile(vol, dirfd, leaf, 1);
+
+    if (rc != AFPERR_OLOCK) {
+        close(dirfd);
+        (void)unlink(full);
+        return 4;                    /* NODELETE not honoured */
+    }
+
+    if (stat(full, &st) != 0) {
+        close(dirfd);
+        return 5;                    /* file wrongly removed despite OLOCK */
+    }
+
+    /* clear NODELETE, delete must now succeed */
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, full, ADFLAGS_HF | ADFLAGS_RDWR, 0666) != 0) {
+        close(dirfd);
+        (void)unlink(full);
+        return 6;
+    }
+
+    if (ad_setattr(&ad, 0) != 0) {
+        ad_close(&ad, ADFLAGS_HF);
+        close(dirfd);
+        (void)unlink(full);
+        return 7;
+    }
+
+    ad_flush(&ad);
+    ad_close(&ad, ADFLAGS_HF);
+    rc = deletefile(vol, dirfd, leaf, 1);
+    close(dirfd);
+
+    if (rc != AFP_OK) {
+        (void)unlink(full);
+        return 8;                    /* delete refused after NODELETE cleared */
+    }
+
+    if (stat(full, &st) == 0) {
+        (void)unlink(full);
+        return 9;                    /* delete returned OK but file remains */
     }
 
     return 0;

--- a/test/afpd/subtests_lock.h
+++ b/test/afpd/subtests_lock.h
@@ -22,5 +22,17 @@ extern int utest_openfork_no_fd_leak(const struct vol *vol);
 extern int utest_shared_adouble_refcount_balance(const struct vol *vol);
 extern int utest_adclose_underflow_aborts(const struct vol *vol);
 extern int utest_ro_retry_strips_destructive_flags(const struct vol *vol);
+extern int utest_ad2openflags_accmode(const struct vol *vol);
+
+extern int utest_testlock_range_clamp(const struct vol *vol);
+extern int utest_testlock_whole(const struct vol *vol);
+extern int utest_testlock_range_no_self_report(const struct vol *vol);
+extern int utest_testlock_range_wrlck_sees_rdlck(const struct vol *vol);
+extern int utest_of_get_locks_contract(const struct vol *vol);
+extern int utest_of_get_locks_fastpath(const struct vol *vol);
+extern int utest_of_get_locks_failclosed(const struct vol *vol);
+extern int utest_deletefile_quirk_hazard(const struct vol *vol);
+extern int utest_deletefile_quirk(struct vol *vol);
+extern int utest_deletefile_nodelete(const struct vol *vol);
 
 #endif /* SUBTESTS_LOCK_H */

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -42,11 +42,16 @@
 #include "subtests.h"
 #include "subtests_lock.h"
 #include "test.h"
+#include "test_capabilities.h"
 #include "volume.h"
 
 unsigned char nologin = 0;
 static AFPObj obj, aspobj;
-static char *args[] = {"test", "-F", "test.conf"};
+/* args[2] is filled with an absolute path to test.conf at startup: opening a
+ * second volume triggers a load_volumes() config reload, and by then afpd has
+ * fchdir()'d into a volume, so a relative "test.conf" would no longer resolve. */
+static char  confpath[MAXPATHLEN + 1];
+static char *args[] = {"test", "-F", confpath};
 int test_output_tap = 0;
 int test_case_num = 0;
 FILE *test_report_stream = NULL;
@@ -55,11 +60,19 @@ int main(int argc, char *argv[])
 {
     int reti;
     uint16_t vid;
+    uint16_t vidsys;
     struct vol *vol;
+    struct vol *volsys;
     struct dir *retdir;
     struct path *path;
     int test_report_fd;
     signal(SIGPIPE, SIG_IGN);
+
+    /* Resolve test.conf to an absolute path before any chdir (see args[] note). */
+    if (realpath("test.conf", confpath) == NULL) {
+        /* fall back to the relative name; single-volume use still works */
+        snprintf(confpath, sizeof(confpath), "test.conf");
+    }
 
     if (argc == 2 && strcmp(argv[1], "--tap") == 0) {
         test_output_tap = 1;
@@ -130,14 +143,29 @@ int main(int argc, char *argv[])
               "open the afpd_test volume");
     TEST_expr(vol = getvolbyvid(vid), vol != NULL,
               "resolve volume by volume id");
+    /* Second volume on the ea=sys backend (metadata in EAs, not a ._ sidecar), so
+     * the backend-specific tests can run both legs in-process — but only where the
+     * filesystem actually supports user xattrs.  openvol() does not write-probe, so
+     * gate on the capability (a real xattr round-trip) to skip honestly elsewhere. */
+    volsys = NULL;
+
+    if (test_capability(TEST_CAP_EA_SYS, vol)) {
+        TEST_expr(vidsys = openvol(&obj, "afpd_test_sys"), vidsys != 0,
+                  "open the afpd_test_sys (ea=sys) volume");
+        TEST_expr(volsys = getvolbyvid(vidsys), volsys != NULL,
+                  "resolve ea=sys volume by volume id");
+    }
+
+    /* No volume-level "cnid server" (only the dbd backend uses it), so the volume
+     * inherits the Global value; the port exercises the no-port default. */
     TEST_expr(reti = 0,
               vol->v_cnidserver != NULL
-              && strcmp(vol->v_cnidserver, "localhost") == 0,
-              "volume: CNID server is localhost");
+              && strcmp(vol->v_cnidserver, "127.0.0.1") == 0,
+              "volume: CNID server inherited from Global");
     TEST_expr(reti = 0,
               vol->v_cnidport != NULL
               && strcmp(vol->v_cnidport, "4700") == 0,
-              "volume: CNID port is 4700");
+              "volume: CNID port defaults to 4700");
     /* test directory.c stuff */
     TEST_expr(retdir = dirlookup(vol, DIRDID_ROOT_PARENT), retdir != NULL,
               "dirlookup: root parent directory");
@@ -186,8 +214,43 @@ int main(int argc, char *argv[])
                      "ad_close() hard-fails (abort) on adf_refcount underflow");
     TEST_int_or_skip(utest_ro_retry_strips_destructive_flags(vol), 0,
                      "read-only downgrade retry strips O_TRUNC (no truncate)");
+    TEST_int_or_skip(utest_ad2openflags_accmode(vol), 0,
+                     "ad2openflags: SETSHRMD|RDONLY promoted to O_RDWR, plain RDONLY stays RO");
+    /* delete-conflict GET / of_get_locks / ad_testlock_range unit tests */
+    TEST_int_or_skip(utest_testlock_range_clamp(vol), 0,
+                     "ad_testlock_range: data-zone probe is clamped, never sweeps the band");
+    TEST_int_or_skip(utest_testlock_whole(vol), 0,
+                     "ad_testlock_whole: one unclamped F_GETLK spanning content + band");
+    TEST_int_or_skip(utest_testlock_range_no_self_report(vol), 0,
+                     "ad_testlock_range: F_GETLK does not report our own band entry");
+    TEST_int_or_skip(utest_testlock_range_wrlck_sees_rdlck(vol), 0,
+                     "ad_testlock_range: F_WRLCK probe sees a peer's F_RDLCK band entry");
+    TEST_int_or_skip(utest_of_get_locks_contract(vol), 0,
+                     "of_get_locks: positional band bitmap, independent df/rf, tri-valued");
+    TEST_int_or_skip(utest_of_get_locks_fastpath(vol), 0,
+                     "of_get_locks: >=2-dimension whole-fd fast path, per-bit on a hit");
+    TEST_int_or_skip(utest_of_get_locks_failclosed(vol), 0,
+                     "of_get_locks: fail-closed/NOENT/absent-rfork (v2 backend)");
+    /* same fail-closed + NORF error-handling contract on the ea=sys backend */
+    TEST_int_or_skip(volsys ? utest_of_get_locks_failclosed(volsys) : TEST_SKIP, 0,
+                     "of_get_locks: fail-closed/NOENT/absent-rfork (ea=sys backend)");
+    TEST_int_or_skip(utest_deletefile_quirk_hazard(vol), 0,
+                     "POSIX close-drops-locks hazard is real here (negative control)");
+    TEST_int_or_skip(utest_deletefile_quirk(vol), 0,
+                     "deletefile conflict GET through a held fd preserves the held lock");
+    TEST_int_or_skip(utest_deletefile_nodelete(vol), 0,
+                     "deletefile honours NODELETE (v2 backend)");
+    /* ea=sys leg: only where the filesystem supports user xattrs (else volsys is
+     * NULL and the test skips, like any other unmet capability). */
+    TEST_int_or_skip(volsys ? utest_deletefile_nodelete(volsys) : TEST_SKIP, 0,
+                     "deletefile honours NODELETE (ea=sys backend)");
     /* cleanup */
     closevol(&obj, vol);
+
+    if (volsys) {
+        closevol(&obj, volsys);
+    }
+
     unload_volumes(&obj);
     test_plan(test_case_num);
 }

--- a/test/afpd/test.sh
+++ b/test/afpd/test.sh
@@ -12,8 +12,21 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+AFPTESTVOLUMESYS=$(mktemp -d /tmp/AFPtestvolumeSys-XXXXXX)
+if [ $? -ne 0 ]; then
+    echo Error creating ea=sys AFP test volume >&2
+    exit 1
+fi
+
+AFPTESTCNIDSYS=$(mktemp -d /tmp/AFPtestCNIDSys-XXXXXX)
+if [ $? -ne 0 ]; then
+    echo Error creating ea=sys CNID test directory >&2
+    exit 1
+fi
+
 SIGNATURE=$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 16)
 VOLUUID=$(uuidgen | tr 'a-z' 'A-Z')
+VOLUUIDSYS=$(uuidgen | tr 'a-z' 'A-Z')
 
 if [ -f test.conf ]; then
     echo "Removing stale configuration template test.conf ..."
@@ -31,11 +44,18 @@ cnid server = 127.0.0.1
 
 [test]
 cnid scheme = sqlite
-cnid server = localhost:4700
 ea = none
 path = $AFPTESTVOLUME
 vol dbpath = $AFPTESTCNID
 volume name = afpd_test
 volume uuid = $VOLUUID
+
+[testsys]
+cnid scheme = sqlite
+ea = sys
+path = $AFPTESTVOLUMESYS
+vol dbpath = $AFPTESTCNIDSYS
+volume name = afpd_test_sys
+volume uuid = $VOLUUIDSYS
 EOF
 echo [ok]

--- a/test/afpd/test_capabilities.c
+++ b/test/afpd/test_capabilities.c
@@ -1,0 +1,161 @@
+/*
+  Copyright (c) 2026 andylemin
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+*/
+
+/*!
+ * @file
+ * @brief Test capabilities: environment/build features a unit test may depend on.
+ *
+ * Some tests can only run where a feature is present (the LD_PRELOAD shim reaches
+ * libatalk; the filesystem supports user extended attributes for an ea=sys
+ * volume).  A test probes the capability it needs and returns TEST_SKIP when it is
+ * absent, so coverage stays honest per platform rather than failing where the
+ * feature is simply unavailable.  Each capability is probed once by actually
+ * exercising it (e.g. an xattr round-trip), not by trusting a higher-level
+ * operation that may succeed without the underlying support; the result is
+ * cached for the run.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/param.h>
+#include <unistd.h>
+
+#include <atalk/ea.h>
+#include <atalk/volume.h>
+
+#include "faultinject.h"
+#include "test_capabilities.h"
+
+/* Cached probe results: -1 = not yet probed, 0 = absent, 1 = present. */
+static int cap_cache[] = {
+    [TEST_CAP_FAULT_INJECT] = -1,
+    [TEST_CAP_EA_SYS]       = -1,
+};
+
+/*! @brief Short capability name for skip/log messages. */
+const char *test_capability_name(enum test_capability cap)
+{
+    switch (cap) {
+    case TEST_CAP_FAULT_INJECT:
+        return "fault-injection (LD_PRELOAD)";
+
+    case TEST_CAP_EA_SYS:
+        return "user extended attributes (ea=sys)";
+
+    default:
+        return "unknown";
+    }
+}
+
+/*!
+ * @brief Does the filesystem under vol->v_path support user extended attributes?
+ *
+ * Round-trips a real xattr on a scratch file: set, read back, remove.  An ea=sys
+ * volume stores AppleDouble metadata in xattrs, so without this the volume opens
+ * (openvol() does not write-probe) but every metadata write fails — which would
+ * surface as a test failure rather than an honest skip.  Probing here keeps the
+ * skip honest.
+ */
+static int probe_ea_sys(const struct vol *vol)
+{
+    char path[MAXPATHLEN + 1];
+    char buf[4];
+    int fd;
+    int ok = 0;
+
+    if (snprintf(path, sizeof(path), "%s/.cap_ea_probe", vol->v_path)
+            >= (int)sizeof(path)) {
+        return 0;
+    }
+
+    fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0600);
+
+    if (fd < 0) {
+        return 0;
+    }
+
+    close(fd);
+
+    /* set -> read back -> verify; AD_EA_META is netatalk's own metadata EA name,
+     * so the probe uses the exact namespace an ea=sys volume writes. */
+    if (sys_setxattr(path, AD_EA_META, "ok", 2, 0) == 0
+            && sys_getxattr(path, AD_EA_META, buf, sizeof(buf)) == 2) {
+        ok = 1;
+    }
+
+    (void)sys_removexattr(path, AD_EA_META);
+    (void)unlink(path);
+    return ok;
+}
+
+/*!
+ * @brief Is the LD_PRELOAD interposer active and reaching libc here?
+ *
+ * Arms a one-shot open() failure and checks it fired.  macOS's two-level
+ * namespace ignores a plain symbol preload, so the injection never takes effect
+ * there and fault-injection-dependent tests skip.
+ */
+static int probe_fault_inject(const struct vol *vol)
+{
+    char path[MAXPATHLEN + 1];
+
+    if (snprintf(path, sizeof(path), "%s/.cap_fi_probe", vol->v_path)
+            >= (int)sizeof(path)) {
+        return 0;
+    }
+
+    return faultinject_open_works(path);
+}
+
+/*!
+ * @brief Probe a capability; the result is cached for the run.
+ *
+ * @param cap  the capability to probe
+ * @param vol  supplies a filesystem path for capabilities probed against the
+ *             volume (TEST_CAP_EA_SYS, TEST_CAP_FAULT_INJECT use vol->v_path for
+ *             a scratch file); must not be NULL.
+ * @returns    1 if the capability is available, 0 otherwise.
+ */
+int test_capability(enum test_capability cap, const struct vol *vol)
+{
+    if (cap < 0 || cap >= (int)(sizeof(cap_cache) / sizeof(cap_cache[0]))) {
+        return 0;
+    }
+
+    if (cap_cache[cap] != -1) {
+        return cap_cache[cap];
+    }
+
+    switch (cap) {
+    case TEST_CAP_FAULT_INJECT:
+        cap_cache[cap] = probe_fault_inject(vol);
+        break;
+
+    case TEST_CAP_EA_SYS:
+        cap_cache[cap] = probe_ea_sys(vol);
+        break;
+
+    default:
+        cap_cache[cap] = 0;
+        break;
+    }
+
+    return cap_cache[cap];
+}

--- a/test/afpd/test_capabilities.h
+++ b/test/afpd/test_capabilities.h
@@ -1,0 +1,29 @@
+/*
+  Copyright (c) 2026 andylemin
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+*/
+
+#ifndef TEST_CAPABILITIES_H
+#define TEST_CAPABILITIES_H
+
+#include <atalk/volume.h>
+
+enum test_capability {
+    TEST_CAP_FAULT_INJECT,   /* LD_PRELOAD libc interposition reaches libatalk */
+    TEST_CAP_EA_SYS,         /* the test filesystem supports user xattrs (ea=sys) */
+};
+
+int test_capability(enum test_capability cap, const struct vol *vol);
+
+const char *test_capability_name(enum test_capability cap);
+
+#endif /* TEST_CAPABILITIES_H */

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -604,6 +604,201 @@ test_exit:
 }
 
 
+/* -------------------------------------------------------------------------
+ * test609  Cross-session DeleteInhibit (kFPDeleteInhibitBit) lifecycle.
+ *
+ * Session 1 (Conn) sets ATTRBIT_NODELETE, session 2 (Conn2) deletes:
+ *
+ *   1. Conn  FPCreateFile, then FPSetFileParams ATTRBIT_NODELETE|SETCLR  (set)
+ *   2. Conn2 FPDelete  -> assert AFPERR_OLOCK            (cross-session refuse)
+ *   3. Conn  FPSetFileParams ATTRBIT_NODELETE (SETCLR off => clear)
+ *   4. Conn2 FPDelete  -> assert success                (cross-session allow)
+ */
+STATIC void test609()
+{
+    char *name = "t609 deleteinhibit xsession";
+    int  ofs = 3 * sizeof(uint16_t);
+    struct afp_filedir_parms filedir = { 0 };
+    uint16_t bitmap = (1 << FILPBIT_ATTR);
+    uint16_t vol = VolID;
+    uint16_t vol2;
+    const DSI *dsi;
+    ENTER_TEST
+    dsi = &Conn->dsi;
+
+    if (!Conn2) {
+        test_skipped(T_CONN2);
+        goto test_exit;
+    }
+
+    if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    vol2 = FPOpenVol(Conn2, Vol);
+
+    if (vol2 == 0xffff) {
+        test_nottested();
+        goto cleanup_file;
+    }
+
+    /* read current attrs so the unpacked struct is well-formed before we
+     * OR in NODELETE */
+    if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, bitmap, 0)) {
+        test_nottested();
+        goto cleanup_vol2;
+    }
+
+    filedir.isdir = 0;
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
+    /* (1) session 1 sets DeleteInhibit */
+    filedir.attr = ATTRBIT_NODELETE | ATTRBIT_SETCLR;
+    FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
+    /* (2) session 2 delete must be refused cross-session */
+    FAIL(ntohl(AFPERR_OLOCK) != FPDelete(Conn2, vol2, DIRDID_ROOT, name))
+    /* (3) session 1 clears it (SETCLR off => clear the named bits) */
+    filedir.attr = ATTRBIT_NODELETE;
+    FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
+    /* (4) session 2 delete must now succeed cross-session (also disposes the
+     *     file, so no explicit cleanup delete below) */
+    FAIL(FPDelete(Conn2, vol2, DIRDID_ROOT, name))
+    FAIL(FPCloseVol(Conn2, vol2))
+    goto test_exit;
+cleanup_vol2:
+    FPCloseVol(Conn2, vol2);
+cleanup_file:
+    /* clear any inhibit we may have set, then remove via session 1 */
+    filedir.attr = ATTRBIT_NODELETE;
+    FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir);
+    FPDelete(Conn, vol, DIRDID_ROOT, name);
+test_exit:
+    exit_test("FPDelete:test609: cross-session DeleteInhibit lifecycle");
+}
+
+/* -------------------------------------------------------------------------
+ * test608  An open with no access mode (no Read/Write/DenyRead/DenyWrite) does
+ *          not block a cross-session delete.
+ *
+ * Conn opens the data fork with access == 0 — a fork that is open but holds no
+ * deny mode and reserves no access. Per the AFP sharing model a "none" access
+ * open makes no claim against other users, so Conn2 FPDelete must succeed.
+ *
+ * The delete-time conflict check is selective: a "none" access open plants only
+ * the OPEN_NONE share-mode marker, which the delete gate ignores (it blocks only
+ * on a deny mode or a held content lock). A bare open therefore does not refuse a
+ * cross-session delete.
+ */
+STATIC void test608()
+{
+    char *name = "t608 open_none nonblock";
+    uint16_t vol = VolID;
+    uint16_t vol2;
+    uint16_t fork;
+    unsigned int dret;
+    ENTER_TEST
+
+    if (!Conn2) {
+        test_skipped(T_CONN2);
+        goto test_exit;
+    }
+
+    if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, DIRDID_ROOT, name,
+                      0 /* no access */);
+
+    if (!fork) {
+        /* server may reject access==0 */
+        test_nottested();
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+        goto test_exit;
+    }
+
+    vol2 = FPOpenVol(Conn2, Vol);
+
+    if (vol2 == 0xffff) {
+        test_nottested();
+        goto cleanup;
+    }
+
+    dret = FPDelete(Conn2, vol2, DIRDID_ROOT, name);
+    FAIL(AFP_OK != dret)   /* a no-access open must not block delete */
+    FAIL(FPCloseVol(Conn2, vol2))
+    /* file is gone (Conn2 deleted it); close our fork, do not re-delete */
+    FAIL(FPCloseFork(Conn, fork))
+    goto test_exit;
+cleanup:
+    FPCloseFork(Conn, fork);
+    FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+test_exit:
+    exit_test("FPDelete:test608: open with no access mode does not block delete");
+}
+
+/* -------------------------
+ * test610  A read-only open with no deny mode does not block a cross-session
+ *          delete.
+ *
+ * Conn opens the data fork OPENACC_RD only (read access, no write, no deny).
+ * Per the AFP sharing model "someone has it open read-only, no deny" is not a
+ * claim that should refuse a delete, so Conn2 FPDelete must succeed.
+ *
+ * Mechanism: a read-only, no-deny open plants only the OPEN_RD share-mode marker
+ * (and, for the rsrc case, RSRC_OPEN_RD).  DELETE_BLOCKING_BAND_BITS excludes both
+ * OPEN_RD and OPEN_NONE, so the delete gate ignores them and blocks only on a deny
+ * mode, DeleteInhibit, or a held content lock.  Companion to test608 (OPEN_NONE).
+ */
+STATIC void test610()
+{
+    char *name = "t610 open_rd nonblock";
+    uint16_t vol = VolID;
+    uint16_t vol2;
+    uint16_t fork;
+    unsigned int dret;
+    ENTER_TEST
+
+    if (!Conn2) {
+        test_skipped(T_CONN2);
+        goto test_exit;
+    }
+
+    if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, DIRDID_ROOT, name,
+                      OPENACC_RD /* read only, no deny */);
+
+    if (!fork) {
+        test_nottested();
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+        goto test_exit;
+    }
+
+    vol2 = FPOpenVol(Conn2, Vol);
+
+    if (vol2 == 0xffff) {
+        test_nottested();
+        goto cleanup;
+    }
+
+    dret = FPDelete(Conn2, vol2, DIRDID_ROOT, name);
+    FAIL(AFP_OK != dret)   /* a read-only, no-deny open must not block delete */
+    FAIL(FPCloseVol(Conn2, vol2))
+    /* file is gone (Conn2 deleted it); close our fork, do not re-delete */
+    FAIL(FPCloseFork(Conn, fork))
+    goto test_exit;
+cleanup:
+    FPCloseFork(Conn, fork);
+    FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+test_exit:
+    exit_test("FPDelete:test610: read-only open does not block delete");
+}
+
 /* ----------- */
 void FPDelete_test()
 {
@@ -617,4 +812,7 @@ void FPDelete_test()
     test369();
     test421();
     test422();
+    test608();
+    test609();
+    test610();
 }

--- a/test/testsuite/T2_Lock_attack.c
+++ b/test/testsuite/T2_Lock_attack.c
@@ -1,7 +1,7 @@
 /* ----------------------------------------------
  * Tier-2 lock "attack" tests.
  *
- * Observe the KERNEL'S lock state directly (raw fcntl on the backing file via
+ * Observe the kernel's lock state directly (raw fcntl on the backing file via
  * -c Path), independently of afpd's own bookkeeping.  Auto-skip without a local
  * path (-c) or a second connection.
  */
@@ -40,11 +40,10 @@ static int data_fork_path(char *out, size_t outlen, char *sub, char *name)
 /* F_GETLK probe from a throwaway fd: 1 = kernel reports a conflicting lock on
  * [off,len); 0 = range free; -1 = open/fcntl error.
  *
- * NOTE on Quirk A self-interference: this helper opens and CLOSES its own fd.
- * That is safe here precisely because it runs in the SPECTEST CLIENT process,
- * which holds no afpd locks - the close drops nothing of ours.  (This is the
- * opposite of the server-side bug, where afpd closing a probe fd dropped its
- * own locks.) */
+ * Note on self-interference: this helper opens and closes its own fd.  That is
+ * safe here precisely because it runs in the spectest client process, which holds
+ * no afpd locks - the close drops nothing of ours.  (This is the opposite of the
+ * server-side bug, where afpd closing a probe fd dropped its own locks.) */
 static int kernel_lock_held(char *path, off_t off, off_t len)
 {
     struct flock fl;
@@ -81,18 +80,18 @@ static int kernel_lock_held(char *path, off_t off, off_t len)
 
 /* ------------------------------------------------------------------ *
  * test600  Cross-session delete-probe does not corrupt a holder's lock.
- *          KERNEL-observed.  NOT a Quirk-A repro.
+ *          Kernel-observed.
  *
  * Conn locks [0,100] on the data fork; F_GETLK confirms the kernel records it.
  * Conn2 attempts FPDelete (in Conn2's child this fires the ADFLAGS_CHECK_OF
- * probe open+close on the inode).  Assert the delete returns AFPERR_BUSY AND
+ * probe open+close on the inode).  Assert the delete returns AFPERR_BUSY and
  * Conn's lock is still held afterwards.
  *
- * NOTE: this does NOT exercise Quirk A.  Quirk A is same-process; Conn and Conn2
- * are separate afpd children, so Conn2's probe close cannot drop Conn's locks -
- * this test passes on both the buggy and fixed server.  Its value is that no
- * other test asserts "held byte lock -> cross-session FPDelete is BUSY and the
- * deleter's probe path leaves the holder's lock intact."
+ * Note: Conn and Conn2 are separate afpd children, so Conn2's probe close cannot
+ * drop Conn's locks (the close-drops-own-locks effect is same-process only) - this
+ * test passes on both the buggy and fixed server.  Its value is that no other test
+ * asserts "held byte lock -> cross-session FPDelete is BUSY and the deleter's probe
+ * path leaves the holder's lock intact."
  * ------------------------------------------------------------------ */
 STATIC void test600()
 {
@@ -192,10 +191,10 @@ test_exit:
 
 /* ------------------------------------------------------------------ *
  * test603  Shared share-mode read-lock preservation (refcount > 1),
- *          KERNEL-observed.
+ *          kernel-observed.
  *
- * Two deny-none read opens of one fork in ONE session share the AD_FILELOCK_OPEN_RD
- * share-mode lock with a refcount of 2. Closing the first open must NOT drop the
+ * Two deny-none read opens of one fork in one session share the AD_FILELOCK_OPEN_RD
+ * share-mode lock with a refcount of 2. Closing the first open must not drop the
  * kernel lock (refcount 2->1); closing the second must (refcount ->0).
  * ------------------------------------------------------------------ */
 STATIC void test603()
@@ -299,7 +298,7 @@ test_exit:
 }
 
 /* ------------------------------------------------------------------ *
- * test604  Last-close teardown releases every range, KERNEL-observed.
+ * test604  Last-close teardown releases every range, kernel-observed.
  * ------------------------------------------------------------------ */
 STATIC void test604()
 {
@@ -372,16 +371,16 @@ test_exit:
 }
 
 /* ------------------------------------------------------------------ *
- * test613  AFPERR_BUSY holder telemetry: `external` class.
+ * test605  A foreign-process share-mode band lock blocks delete.
  *
- * A NON-afpd process (this test) holds a raw fcntl lock on the data-fork
- * share-mode region.  A cross-session FPDelete should return BUSY; the afpd log
- * (captured by CI) must classify the holder `external`.  Spectest asserts only
- * the client-visible BUSY; the log half is the CI scraper's job.
+ * A non-afpd process (this test) takes a raw F_WRLCK at the AD_FILELOCK_OPEN_WR
+ * band offset on the data fork's backing file, with no afpd fork held.  A
+ * cross-session FPDelete must detect the open-fork band lock and return
+ * AFPERR_BUSY.
  * ------------------------------------------------------------------ */
-STATIC void test613()
+STATIC void test605()
 {
-    char *dname = "t613";
+    char *dname = "t605";
     char *name = "f";
     uint16_t vol = VolID;
     uint16_t vol2;
@@ -432,7 +431,7 @@ STATIC void test613()
 
     if (fcntl(fd, F_SETLK, &fl) < 0) {
         if (!Quiet) {
-            fprintf(stdout, "\tcould not take foreign lock: %s\n", strerror(errno));
+            fprintf(stdout, "\tcould not take foreign band lock: %s\n", strerror(errno));
         }
 
         test_nottested();
@@ -446,19 +445,9 @@ STATIC void test613()
         goto cleanup;
     }
 
+    /* the foreign band lock must block the cross-session delete */
     dret = FPDelete(Conn2, vol2, dir, name);
-
-    if (ntohl(AFPERR_BUSY) != dret) {
-        /* external-holder detection on delete is platform/build dependent;
-         * don't hard-fail, but record it. */
-        if (!Quiet) {
-            fprintf(stdout, "\tNOTE: delete returned 0x%x, expected AFPERR_BUSY\n",
-                    ntohl(dret));
-        }
-
-        test_nottested();
-    }
-
+    FAIL(ntohl(AFPERR_BUSY) != dret)
     FAIL(FPCloseVol(Conn2, vol2))
 cleanup:
 
@@ -473,7 +462,7 @@ cleanup:
 
     delete_directory_tree(Conn, vol, DIRDID_ROOT, dname);
 test_exit:
-    exit_test("T2LockAttack:test613: AFPERR_BUSY external holder");
+    exit_test("T2LockAttack:test605: foreign band lock blocks delete");
 }
 
 /* ------------------------------------------------------------------ *
@@ -481,8 +470,8 @@ test_exit:
  *
  * Conn opens a file inside a test directory and takes a byte lock. While it is
  * held:
- *   - deleting the PARENT directory returns AFPERR_DIRNEMPT (offspring present);
- *   - deleting the FILE from a second session returns AFPERR_BUSY (open by a user).
+ *   - deleting the parent directory returns AFPERR_DIRNEMPT (offspring present);
+ *   - deleting the file from a second session returns AFPERR_BUSY (open by a user).
  * After Conn closes the fork, both the file and the directory delete cleanly.
  * Exercises the delete-vs-lock contention surface and the recursive cleanup of a
  * directory whose contents were locked.
@@ -554,6 +543,128 @@ test_exit:
     exit_test("T2LockAttack:test620: delete contention on a dir with a locked file");
 }
 
+/* ------------------------------------------------------------------ *
+ * test607  Delete vs a foreign-process data-content read lock.
+ *
+ * A non-afpd process (e.g. Samba) takes an fcntl(F_RDLCK) on content [0,100] of
+ * the backing file, with no AFP fork open. The current server refuses a
+ * cross-session FPDelete (AFPERR_BUSY) because its delete-time check takes a
+ * whole-file trial lock that overlaps any byte-range lock — it blocks on any byte
+ * lock, which is too coarse.
+ *
+ * The correct outcome for a foreign read lock is not yet finalised and depends on
+ * an ownership-escalation rule still under design:
+ *   - a write byte-range lock / a file open for writing is active modification and
+ *     should block a delete;
+ *   - a read byte-range lock should not block the file's Unix owner (ownership is
+ *     the escalation), but blocking a non-owner whose target is being read may be
+ *     acceptable.
+ * Until that policy is decided this test is not wired into the testset (its body
+ * is kept ready for when the expected outcome is finalised).
+ * ------------------------------------------------------------------ */
+STATIC void test607()
+{
+    char *dname = "t607";
+    char *name = "f";
+    uint16_t vol = VolID;
+    uint16_t vol2;
+    uint16_t fork;
+    int dir;
+    int fd = -1;
+    struct flock fl;
+    unsigned int dret;
+    ENTER_TEST
+
+    if (Path[0] == '\0') {
+        test_skipped(T_PATH);
+        goto test_exit;
+    }
+
+    if (!Conn2) {
+        test_skipped(T_CONN2);
+        goto test_exit;
+    }
+
+    dir = FPCreateDir(Conn, vol, DIRDID_ROOT, dname);
+
+    if (!dir) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    if (FPCreateFile(Conn, vol, 0, dir, name)) {
+        test_nottested();
+        goto cleanup;
+    }
+
+    /* give the file > 100 bytes so the content range is real */
+    fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, dir, name,
+                      OPENACC_RD | OPENACC_WR);
+
+    if (!fork) {
+        test_nottested();
+        goto cleanup;
+    }
+
+    FAIL(FPSetForkParam(Conn, fork, (1 << FILPBIT_DFLEN), 200))
+    FAIL(FPCloseFork(Conn, fork))
+
+    if (data_fork_path(temp, sizeof(temp), dname, name) < 0) {
+        test_nottested();
+        goto cleanup;
+    }
+
+    fd = open(temp, O_RDWR, 0);
+
+    if (fd < 0) {
+        test_nottested();
+        goto cleanup;
+    }
+
+    fl.l_type   = F_RDLCK;                  /* a foreign read content lock */
+    fl.l_whence = SEEK_SET;
+    fl.l_start  = 0;
+    fl.l_len    = 100;
+
+    if (fcntl(fd, F_SETLK, &fl) < 0) {
+        if (!Quiet) {
+            fprintf(stdout, "\tcould not take foreign read lock: %s\n", strerror(errno));
+        }
+
+        test_nottested();
+        goto cleanup;
+    }
+
+    vol2 = FPOpenVol(Conn2, Vol);
+
+    if (vol2 == 0xffff) {
+        test_nottested();
+        goto cleanup;
+    }
+
+    /* The assertion below encodes today's over-broad "any byte lock blocks"
+     * outcome only as scaffolding; the real expected result is undecided (it
+     * depends on a file-ownership escalation rule) and must be set once that
+     * policy is finalised.  Until then this test is not wired into the testset. */
+    dret = FPDelete(Conn2, vol2, dir, name);
+    FAIL(ntohl(AFPERR_BUSY) != dret)
+    FAIL(FPCloseVol(Conn2, vol2))
+cleanup:
+
+    if (fd >= 0) {
+        fl.l_type = F_UNLCK;
+        fl.l_whence = SEEK_SET;
+        fl.l_start = 0;
+        fl.l_len = 100;
+        fcntl(fd, F_SETLK, &fl);
+        close(fd);
+    }
+
+    delete_directory_tree(Conn, vol, DIRDID_ROOT, dname);
+test_exit:
+    exit_test("T2LockAttack:test607: delete vs foreign content read lock");
+}
+
 /* ----------- */
 void T2LockAttack_test()
 {
@@ -561,6 +672,9 @@ void T2LockAttack_test()
     test600();
     test603();
     test604();
-    test613();
+    test605();
+    /* test607 (delete vs foreign content read lock) is intentionally not wired in
+     * yet: its expected outcome depends on an undecided ownership-escalation
+     * policy. */
     test620();
 }


### PR DESCRIPTION
`deletefile()`'s open-conflict check (decides whether a peer holds a lock/share-mode that must block the delete) accreted three layers that are no longer aligned, with five distinct defects: 1) stranded held locks on every platform, 2) over-blocking on `FPDelete`, 3) a dead check on rename/copy-overwrite, 4) invisible deny modes, and 5) a fail-open that unlinks when lock state can't be read.

This PR replaces the whole check with one `F_GETLK` (read-only) conflict read, through an existing held fd, or one safely-transient fd, and which reads lock state per-bit and is fail-closed, fixing all five).

## Root cause

POSIX advisory locks are owned by the process, not the fd: closing any fd to a file releases every lock on all fds the process holds on it (`fcntl(2)`; same on the BSDs, Solaris/illumos, AIX). `F_OFD_SETLK` avoids this but is absent on the BSDs/Solaris/AIX, so it is not an option.

In the kernel: an `F_SETLK` lock is keyed on the `(inode, process)` pair, **not** on the open file description or the fd number. The kernel keeps the lock list on the inode and tags each entry with the owning process (Linux `struct file_lock.fl_owner`/`fl_pid`; the BSDs key on `p_leader`; Solaris/illumos on the proc). The fd you used to *take* the lock is not recorded against it. So when *any* `close(2)` runs on *any* fd pointing at that inode, the kernel walks the inode's lock list and drops **every** entry owned by this process — there is no per-fd accounting to scope the release to the fd being closed. The man page states the consequence directly:

> *"If a process closes any file descriptor referring to a file, then all of the process's locks on that file are released, regardless of the file descriptor(s) on which the locks were obtained. This is bad: it means that a process can lose its locks on a file … because of a function call buried in a library."* — `fcntl(2)`, "Record locks"

That last sentence is exactly netatalk's situation: the "function call buried in a library" is `deletefile()` opening a transient second fd to probe, then closing it — silently discarding the share-mode lock the client's *open fork* still relies on, through a completely unrelated fd. `F_OFD_SETLK` keys the lock on the open file description instead, so a close of a different fd leaves it intact — but it does not exist on the BSDs/Solaris/AIX, so the fix cannot depend on it.

The old `deletefile()` trial-acquired a lock through a transient second fd at two sites — the `checkAttrib` NODELETE probe (`ad_metadataat(CHECK_OF)`) and the body `ad_openat` + `ad_tmplock`. Closing either transient fd dropped the session's own share-mode lock on the inode, so a just-opened-for-read file then read as busy. A trial-SET also answers the wrong question ("could I lock the whole fork?") rather than "does a peer hold a lock/share-mode the spec says blocks delete?".

## How the old detector got here (5 commits, ~12 years)

This is not anyone's mistake — it is what incremental, well-intentioned patches add up to when each is locally correct but no one revisits the whole. The trial-lock detector was assembled over a decade:

- **`31843674` — rufustfirefly, 2000 (initial revision).** `deletefile()` is born with the trial-acquire model: open the fork, `ad_tmplock()` it, infer "in use" from whether the lock is granted. Reasonable in a single-user world where the POSIX close-drops-locks trap rarely bit.
- **`3606b9e3` — jmarcus, 2002 ("trash will work in multi-user environments… read-write/read-only lock issues").** Extends the body probe to a whole-resource-fork `ADLOCK_FILELOCK` trial lock so an open file blocks deletion across sessions. This commit also *documented its own limits* — both surviving `FIXME`s are his: the "priority inversion" note, and *"doesn't work for RFORK open read only and fork open without deny mode"*. Defects 2 and 3 trace to the whole-fork trial lock introduced here.
- **`170ad4c6` — didg, 2003 (renamefile concurrent-access rework).** Reworks `renamefile()`/copy-overwrite and routes them through `deletefile(checkAttrib=0)`. Because that path never runs the attribute probe, its fd stays `O_RDONLY` and the trial `ADLOCK_WR` silently downgrades to a read lock — defect 3, the "rename slips through where delete is refused" half.
- **`96afda34` — didg, 2006 ("SFM compatible format for adouble").** Adds `check_attrib()` (the NODELETE / DOPEN / ROPEN attribute probe) and the `ad_openforks` band reader. That reader only ever probes the OPEN band bits (+0..+3), never `DENY_*` — defect 4 — and the CHECK_OF attribute open is what later forces the body fd to `O_RDWR` and produces the over-broad sweep of defect 2.
- **`0576bda9` — Frank Lahm, 2012 ("Refactor the locking").** Makes *"close locks on file close"* the accepted model (`of_closefork()` → `ad_unlock()` drops the fork's byte locks on every close), turning the close-drops-locks trap from edge case into routine — defect 1. The spectest recorded the flip: the old test asserting locks survive a sibling close (`test78`) was disabled as an *"unfixed `adf_unlock()` bug"* and replaced by one asserting the *inverse* (`test410`: *"in Netatalk 3 we now close locks on file close"*, `FPCloseFork` annotated *"this should drop the byterange lock!"*).

None of these is wrong in isolation; the defects above are emergent — the seams between the layers, surfacing once the 2012 refactor plus `F_OFD`-less platforms and EA backends made the close-drops-locks trap routine.

### Coverage matrix — what each layer could actually detect

Each conflict dimension a delete *should* weigh, against what the old detector saw on each of its two paths (`afp_delete`, i.e. `checkAttrib=1`, vs `rename`/`copy-overwrite`, i.e. `checkAttrib=0`), and what the new read does. This is the mental translation table: read down "new" and every cell is a deliberate ✓.

Legend: ✓ = detected and handled correctly · ~ = detected but **over-broad** (blocks more than it should) · ✗ = **blind** (never detected) · ✗-strand = actively *broke* state.

| conflict dimension | old `afp_delete` | old `rename`/`copy` | new code |
|---|---|---|---|
| NODELETE attribute (kFPDeleteInhibitBit) | ✓ (96afda34) | ✗ never checked | ✓ both paths |
| peer **data** content **write** lock | ✓ (2000) | ✓ (WR-probe survives the RD downgrade vs a peer WR) | ✓ |
| peer **data** content **read** lock | ✓ (RDWR body probe) | ✗ (RD-probe, RD-vs-RD doesn't conflict) | ✓ |
| peer **resource** content lock | ✓ (2000 → whole-rfork 2002) | ✗ (RD downgrade) | ✓ |
| share-mode **OPEN_RD/WR** (mere open) | ~ blocks (band sweep) | ✗ blind | ✓ OPEN_RD excluded from blocking, OPEN_WR still blocks (requires dirty fork accounting) |
| share-mode **DENY_RD/WR** | ~ blocks (sweep, not isolated) | ✗ blind | ✓ blocks (isolated bit) |
| **RSRC** share-mode mirrors (+2/3, +6/7) | ~ | ✗ | ✓ |
| **OPEN_NONE** marker (+8/9) | ~ blocks (**wrong** — claims nothing) | ✗ | ✓ excluded from blocking |
| own (same-process) held locks | ✗-strand | ✗-strand | ✓ never stranded |
| unreadable lock state | ✗ unlinks anyway | ✗ unlinks anyway | ✓ refuses (fail-closed) |

**What no old layer ever covered** (✗ across both old columns, now ✓): a peer's read-only content lock on the rename/copy path; the `DENY_*` band as a thing distinct from "anything is open"; same-process safety (every path stranded the caller's own locks); and fail-closed behaviour (every path could unlink on an unreadable probe).

**Where coverage is still deliberately not 100%** — the new read *sees* everything above, but two policy/cosmetic gaps remain, tracked in "Not in this PR":

- A **bare read-only open** (`OPEN_RD`, no deny, no byte lock) still blocks delete. The new code reads it correctly; *whether it should block* is an unresolved AFP/SMB-semantics question, so the policy mask conservatively keeps blocking it for now.
- The refusal reason is still a single `AFPERR_BUSY`, not split into `AFPERR_DENYCONF` vs `AFPERR_BUSY` — the read now *knows* which bit blocked, but the wire code isn't yet differentiated.

(Cross-process conflicts are *not* a gap: `F_GETLK` reports other processes' locks/band by design, so a peer afpd child's holds are seen regardless of the held-fd-reuse optimisation, which is purely same-process.)

## Lock layout (for the per-bit read)

Lock state is `fcntl` byte ranges partitioned by offset across two fds:

| fd | offset zone | contents |
|---|---|---|
| data fd | `[0, BYTELOCK_MAX]` | content byte-range locks (`FPByteRangeLock`) |
| data fd | `[AD_FILELOCK_BASE … +9]` (past EOF) | 10-entry share-mode band |
| resource-fork fd | `[0, BYTELOCK_MAX]` | resource content (only dimension not on the data fd) |

The share-mode band is ten fixed offsets past EOF, each a one-bit flag for an AFP open/deny/none state planted by `fork_setmode()`:

| offset (from base) | symbol | group |
|---|---|---|
| +0 / +1 | OPEN_WR / OPEN_RD | open access (data) |
| +2 / +3 | RSRC_OPEN_WR / RSRC_OPEN_RD | open access (resource mirror) |
| +4 / +5 | DENY_WR / DENY_RD | deny modes (data) |
| +6 / +7 | RSRC_DENY_WR / RSRC_DENY_RD | deny modes (resource mirror) |
| +8 / +9 | OPEN_NONE / RSRC_OPEN_NONE | "open, claiming nothing" markers |

Two POSIX properties the read relies on: band entries are stored `F_RDLCK`, so a probe must use `F_WRLCK` to detect them (a read lock does not conflict with a read lock); and `F_GETLK` never reports the caller's own locks (afpd is process-per-session, so a probe through a held fd reports only peers).

## Defects in the old detector (one function, five faults)

1. **Stranded locks (all platforms).** Both transient-fd probe sites drop the session's own locks on close.
2. **Over-blocks on `FPDelete`.** The NODELETE probe forces the data fd `O_RDWR` (CHECK_OF ⇒ SETSHRMD ⇒ `O_RDWR`); the body reuses it, so `ad_tmplock(ADLOCK_WR,0,0)` is a real `F_WRLCK` over `[0,∞)` that sweeps the band and conflicts with any entry, including no-claim markers (verified at maxdebug).
3. **Dead on rename/copy-overwrite (`checkAttrib=0`).** No CHECK_OF open, so the body fd is `O_RDONLY` and `ad_tmplock(ADLOCK_WR)` downgrades to `F_RDLCK` — blind to the band and to a peer read lock. (This is why rename slipped through where delete was refused.)
4. **Deny modes invisible.** The only band reader (`ad_openforks`) probes +0..+3 only, never `DENY_*`; `OPEN_NONE` (+8) and v2 resource-fork-only opens also unseen.
5. **Fail-open.** On `EACCES`/failed probe open the handle stayed `NULL`, the trial locks were skipped, and the code unlinked anyway.

Two of these were already flagged in-tree. The `deletefile()` resource-fork block on `main` carried two long-standing `FIXME`s, both from jmarcus's 2002 commit, and this PR's restructure **deletes the block that held them** — they are resolved, not relocated:

- **FIXME A — "priority inversion".** *"we have a pb here because we want to know if a file is open; there's a 'priority inversion' if you can't open the resource fork RW you can delete it if it's open because you can't get a write lock."* This is the trial-acquire model admitting it conflates *"can I lock it?"* with *"may I delete it?"*. The `F_GETLK` read separates the two (read state, then decide policy), so the inversion disappears.
- **FIXME B — "doesn't work for RFORK open read only and fork open without deny mode".** The exact statement of defect 3 (and part of 4): an RDONLY-downgraded probe sees neither a peer's read-only open nor the share-mode band. The explicit-`F_WRLCK` per-bit read sees both.

Worked example (the spectest case that flips RED→GREEN): a no-access open (`fork_setmode` plants only `OPEN_NONE`, an `F_RDLCK`, base+8 — spec: "None access allows no further access to the fork"); a cross-session `FPDelete`'s `F_WRLCK` over `[0,∞)` (defect 2) hits that marker and returns `AFPERR_BUSY`. One unbounded trial lock cannot exclude `OPEN_NONE` or distinguish it from `DENY_WR` — a per-bit read plus a policy decision is required.

## Fix

Invariant: this afpd child can only hold a lock on a file via an fd it keeps open in the owning ofork. So the conflict read is `F_GETLK`-only with two branches: reuse the held fd if the fork is open (no open/close → no strand), else open one transient fd (no lock held → nothing to strand). `deletefile()` becomes: NODELETE → one conflict read → policy → unlink, fail-closed (indeterminate read → `AFPERR_ACCESS` + log, never unlink).

New primitives:

- **`ad_testlock_range(ad, eid, off, len)`** (`libatalk/adouble/ad_lock.c`) — ranged `F_GETLK`; no `adf_lock[]` scan (no self-report through a held fd); explicit `F_WRLCK` (sees peer `F_RDLCK` band entries on any fd mode); zone-clamps a data-zone request by subtraction (`len > MAX - start`) so `len==0` never becomes "to infinity" into the band and never overflows `off_t`.
- **`ad_testlock_whole(ad, eid)`** — one unclamped whole-data-fd `F_GETLK` (content + band) as a negative-case fast path.
- **`of_get_locks(vol, dirfd, path, …)`** (`etc/afpd/ofork.c`) — single entry point; afpd-side because it needs `oforks[]` to find a held fd. Resolves held-or-transient fd per fork, reads data + resource content + each band bit, retries the open as root on `EACCES` (band is server bookkeeping, not a user permission; the unlink still runs as the user; `become_root`/`unbecome_root` paired, `errno` captured before restore). Returns tri-valued `OF_LOCKS_OK` / `OF_LOCKS_NOENT` / `OF_LOCKS_ERROR` and a positional band bitmap (bit *n* == base+*n*).

Platform-agnostic: no OFD, no build probe. One source conditional, `#if HAVE_EAFD && SOLARIS`, for the backend where the resource fork is an `O_XATTR` fd off the data fd.

`ad_open` NORF/NOHF error handling is also narrowed: a *missing* resource fork / header (`ENOENT`/`ENOATTR`) stays a non-error, but a hard open error (EIO, EACCES) now propagates instead of being masked to success — so `of_get_locks` fails closed on an indeterminate resource-fork read rather than reading it as unlocked.

### How each element maps to a defect / FIXME

Every fault above is closed by a specific design element — nothing is left open:

| # | Defect / FIXME | Closed by |
|---|---|---|
| 1 | Stranded held locks (all platforms) | `F_GETLK`-only read + held-fd-reuse / safely-transient branches — the open/close that strands a lock never happens |
| 2 | Over-blocks on `FPDelete` (whole-`[0,∞)` `F_WRLCK` sweeps the band) | per-bit `ad_testlock_range` + zone clamp (data probe can't reach the band) + `DELETE_BLOCKING_BAND_BITS` policy (no-claim markers excluded) |
| 3 / FIXME B | Dead on rename/copy-overwrite; RDONLY-downgraded probe | explicit `F_WRLCK` in `ad_testlock_range` — independent of fd mode, so it sees a peer's read open and the band on every caller |
| 4 | Deny modes / `OPEN_NONE` / rfork-only opens invisible | `of_get_locks` reads **every** band bit positionally (data + resource mirror), not just +0..+3 |
| 5 | Fail-open (unlink on unreadable state) | tri-valued return; `OF_LOCKS_ERROR` → `AFPERR_ACCESS` + log, never unlink; plus the `ad_open` NORF/NOHF narrowing so a hard read error is no longer masked to "unlocked" |
| FIXME A | "priority inversion" (can't-lock conflated with may-delete) | read state first (`F_GETLK`), then a separate policy decision — the two questions are no longer fused into one trial-SET |

The rewrite **removes** the `check_attrib()` + `ad_tmplock` block that carried both FIXMEs, so neither comment is relocated or left behind — `grep` for "priority inversion" / "RFORK open read only" in the tree now returns nothing.

## Behaviour changes
- `copyfile()`'s two error-path cleanup deletes now honour `deletefile()`'s return (no blind force-unlink of an uncertain-ownership destination; logs a refused removal).
- A no-access open no longer blocks delete: `DELETE_BLOCKING_BAND_BITS` excludes `OPEN_NONE`/`RSRC_OPEN_NONE` (one-line policy edit on the new per-bit read). Deny modes, open-for-write, and content byte-range locks still block.
- A plain open readonly no longer blocks delete: `DELETE_BLOCKING_BAND_BITS` excludes `OPEN_RD`/`RSRC_OPEN_RD` (one-line policy edit on the new per-bit read). Deny modes, open-for-write, and content byte-range locks still block.

Delete allowed with `OPEN_NONE`/`RSRC_OPEN_NONE`/`OPEN_RD`/`RSRC_OPEN_RD`; *This aligns with the AFP specification and with Samba.*
The AFP spec does not authoritatively require a bare read-access open to block a delete: its FPDelete result-code table (Reference, Table 16) lists only kFPObjectLocked (DeleteInhibit) as a held-claim refusal — kFPFileBusy is not even a listed FPDelete result — and the File Sharing Modes chapter builds all synchronization from deny modes, where a plain access mode ("None access allows no further access... except to close it") restricts nobody. Only an explicit deny mode is a claim against other users.
Samba matches this: source3/smbd/open.c share_conflict() gates a delete solely on the holder's FILE_SHARE_DELETE grant (the deny-type axis), never on whether the existing open was for read or write - *So both AFP and Samba users now get the same experience on the same share.*

Note, samba even allows delete for *open for write*. Both AFP and Samba docs focus on DENY modes. However I am stopping short of allowing delete on open for write, as this would require additional code changes to enable the delete sequence to check for DIRTY un-flushed pages and some other write pending semantics (which must always block delete even if user did not open for write with DENY mode. Deleting before forkflush has risk of corruption.

## Testing
### Spectests
- test605 — A foreign (non-afpd) process holding a raw F_WRLCK share-mode band lock (OPEN_WR offset) makes a cross-session FPDelete correctly return AFPERR_BUSY.
- test608 — A "NONE"-access open (no Read/Write/DenyRead/DenyWrite → only an OPEN_NONE marker) does not block a cross-session FPDelete, which must succeed.
- test609 — Cross-session DeleteInhibit lifecycle: session 1 sets ATTRBIT_NODELETE → session 2 FPDelete is refused AFPERR_OLOCK; session 1 clears it → session 2 FPDelete succeeds.
- test610 — A "OPEN_RD"-access open (no Write/DenyRead/DenyWrite → only an OPEN_RD marker) does not block a cross-session FPDelete, which must succeed.
- AFP spectest: ea:sys 340 pass / 0 fail, ea:ad 341 pass / 0 fail.

### Unit tests
- New Unit Tests = 11
- afpd unit suite: 49/49, on both `ea=ad` (v2) and `ea=sys`. Covers: same-process close-drops-locks hazard control + the cure (held lock survives the read, via a forked peer); no self-report; `F_WRLCK` sees a peer `F_RDLCK`; zone clamp bounds `l_len`; ≥2-dimension whole-fd fast path; fail-closed `ERROR`, `NOENT`, and absent-resource-fork → `OK`; NODELETE on both backends. A capability probe skips fault-injection/`ea=sys` tests where unsupported.
- Fault-injection harness: also interposes `__open_2`/`__open64_2` so probe opens are intercepted under `_FORTIFY_SOURCE` (Ubuntu/glibc ≥ 2.42), where no-`O_CREAT` opens are rewritten away from `open`/`open64`. Verified on glibc and musl.

## Not in this PR (follow-ups)

- Pre-existing `afp_copyfile` held-source resource-fork-handle corruption.
- Pre-existing 32-bit lock-range / band-overlap clamp.
- Splitting the delete refusal into `AFPERR_DENYCONF` vs `AFPERR_BUSY`.
- Investigate the 2012 close-drops-locks behaviour itself (`of_closefork()` → `ad_unlock()` in `0576bda9`): a single `FPCloseFork` still releases *every* fork's byte-range locks on the inode. This PR only stops the *delete probe* from triggering it; the general per-fork lock-release fix is unaddressed.
- Pending that fix, re-evaluate whether `test410`'s expectation should revert and `test78` be re-enabled — i.e. assert locks *survive* a sibling close again, rather than the suite encoding the bug as expected behaviour.

---

Every commit in this locking fix/audit series manipulates one or more layers of the stack below.
The diagram is the single source of truth for *what owns what* and *what the kernel actually tracks* — the lock/fork bugs are all divergences between the netatalk-side bookkeeping (left) and the kernel-side reality (right).

```mermaid
%%{init: {'flowchart': {'curve': 'basis'}, 'themeVariables': {'edgeLabelBackground': '#e5e7eb'}}}%%
flowchart TD
    %% ── colour legend (by resource TYPE); rounded nodes via ("...") shape
    %%   wire/protocol = blue   netatalk tables = purple
    %%   netatalk structs = teal   lock bookkeeping = amber
    %%   kernel resources = red    on-disk = grey
    classDef wire   fill:#1e3a8a,stroke:#1e40af,color:#eff6ff,stroke-width:1px;
    classDef table  fill:#5b21b6,stroke:#6d28d9,color:#f5f3ff,stroke-width:1px;
    classDef struct fill:#0f766e,stroke:#0d9488,color:#f0fdfa,stroke-width:1px;
    classDef lock   fill:#b45309,stroke:#d97706,color:#fffbeb,stroke-width:1px;
    classDef kernel fill:#9f1239,stroke:#be123c,color:#fff1f2,stroke-width:1px;
    classDef disk   fill:#374151,stroke:#4b5563,color:#f9fafb,stroke-width:1px;

    subgraph WIRE["🌐 AFP wire protocol (client ⇄ afpd)"]
        OP("AFP op<br/><i>FPOpenFork · FPRead · FPByteRangeLock<br/>FPCloseFork · FPDelete · FPGetFileParms</i>")
        REFNUM("OForkRefNum (16-bit)<br/>1..0xffff, 0 reserved<br/><i>the only fork handle the client holds</i>")
    end

    subgraph AFPD["🟣 afpd child — one process per DSI session — netatalk bookkeeping"]
        direction TB

        subgraph TABLE["refnum table + inode index · etc/afpd/ofork.c"]
            OFORKS("oforks[] — struct ofork *[nforks]<br/>nforks = min(0xffff, getdtablesize()/2) · commit 0<br/>slot = refnum % nforks · refnum == slot · commit 12")
            HASH("ofork_table[64] — hash by (dev,inode)<br/><i>of_findname / of_findnameat / of_ad</i>")
            FREEQ("of_freeq[] — FIFO of free slots · commit 12<br/>O(1) alloc/free · refnum = slot")
        end

        OFORK("struct ofork — one per FPOpenFork<br/>of_refnum (uint16_t · = slot · = lock-owner id)<br/>key = {dev, inode}<br/>of_flags (RSRC / ACCWR / DIRTY / ERROR)")

        ADOUBLE("struct adouble — ONE per inode per child<br/><i>shared across sibling oforks via ad_ref</i><br/>ad_refcount (struct-level · freed at 0)<br/>ad_vers (AD_VERSION2 | AD_VERSION_EA)<br/>ad_open_forks (DOPEN/ROPEN) · data/meta/reso refcounts")

        subgraph FORKS["struct ad_fd members + backend indirections"]
            DF("ad_data_fork — struct ad_fd<br/>adf_fd (real OS fd | -1 | AD_SYMLINK)<br/>adf_refcount (fd-level)")
            RF("ad_resource_fork — struct ad_fd<br/>adf_fd · adf_refcount")
            MDP("ad_mdp → metadata fork<br/><i>(indirection)</i>")
            RFP("ad_rfp → resource fork<br/><i>(indirection)</i>")
        end

        LOCKARR("adf_lock[] — adf_lock_t per lock (0..N, grows on demand)<br/>struct flock (l_start · l_len · l_type)<br/>user = of_refnum (owner) · refcount* (shared reads)<br/>holds BOTH: share-mode band (AD_FILELOCK_*) + byte ranges")
    end

    subgraph KERNEL["🔴 OS kernel — the real resources"]
        direction TB
        FDLIMIT("RLIMIT_NOFILE (per process)<br/>raised toward RLIM_MAX = 133120 · commit 0<br/>~2 fds per fork on EA backends")
        OSFD("open file descriptions / fd table<br/><i>one real fd per opened fork file</i>")
        POSIXLOCK("POSIX advisory record locks · fcntl(F_SETLK)<br/><b>owned by the PROCESS</b><br/>⚠ POSIX Quirk: closing ANY fd to the inode drops<br/>ALL this process's locks on that inode")
        SHARE("Solaris/illumos F_SHARE reservations<br/><i>HAVE_FSHARE_T · OPTION_SHARE_RESERV</i>")
        INODE("inode on disk<br/><i>data fork + ._ sidecar (v2) or EA (ea)</i>")
    end

    %% ═══ cardinalities: 1 (exactly one) · 0..1 (optional) · 1..N · N..1 (shared)
    OP -->|"1"| REFNUM
    REFNUM -->|"1:1 · refnum == slot (commit 12)"| OFORKS
    OFORKS -->|"occupied slot → 1 ofork"| OFORK
    HASH -.->|"inode lookup · delete probe · of_ad"| OFORK
    FREEQ -.->|"free slots only"| OFORKS
    OFORK -->|"1 (mandatory) · N oforks : 1 adouble (ad_ref)"| ADOUBLE
    ADOUBLE ==>|"1 (data fork: always the lock/fd anchor)"| DF
    ADOUBLE -->|"0..1 (resource fork: OPTIONAL — ADFLAGS_NORF)"| RF
    ADOUBLE --> MDP
    ADOUBLE --> RFP

    %% backend-specific indirection wiring (which ad_fd the indirections point at)
    MDP -. "ea → ad_data_fork (HF shares data fd)" .-> DF
    MDP -. "v2 → ad_resource_fork (HF+RF share ._ fd)" .-> RF
    RFP -. "both backends → ad_resource_fork" .-> RF

    %% locks: one MANDATORY share-mode lock per open fork, plus 0..N byte-range
    DF ==>|"1 mandatory share-mode lock per fork<br/>(fork_setmode: AD_FILELOCK_OPEN_* — incl. OPEN_NONE)<br/>+ 0..N byte-range (FPByteRangeLock) · rfork share via rf2off"| LOCKARR
    RF -->|"0..N byte-range locks on the rfork's own fd"| LOCKARR

    %% netatalk bookkeeping mapped onto real kernel resources
    DF -->|"1:1 when open (adf_fd ≥ 0; else -1 / AD_SYMLINK)"| OSFD
    RF -->|"0..1 (only if rfork opened)"| OSFD
    OSFD -->|"counts against"| FDLIMIT
    OSFD -->|"1:1"| INODE
    LOCKARR -->|"each lock → set_lock(): F_SETLK · all platforms"| POSIXLOCK
    LOCKARR -. "0..N · Solaris + OPTION_SHARE_RESERV only" .-> SHARE
    POSIXLOCK -->|"keyed on inode + process"| INODE
    SHARE --> INODE

    %% the bug surface
    POSIXLOCK -. "⚠ POSIX Quirk drops these — commit 9B keeps the<br/>delete probe off transient fds (reuse a held fd,<br/>or probe only when none held)" .-> LOCKARR

    %% ── apply colours by type ──────────────────────────────────────────
    class OP,REFNUM wire;
    class OFORKS,HASH,FREEQ table;
    class OFORK,ADOUBLE,DF,RF,MDP,RFP struct;
    class LOCKARR lock;
    class FDLIMIT,OSFD,POSIXLOCK,SHARE kernel;
    class INODE disk;

    %% grey-white background for the outer/inner container boxes
    style WIRE   fill:#f1f5f9,stroke:#cbd5e1,color:#334155;
    style AFPD   fill:#f8fafc,stroke:#cbd5e1,color:#334155;
    style TABLE  fill:#eef2f6,stroke:#d1d9e0,color:#334155;
    style FORKS  fill:#eef2f6,stroke:#d1d9e0,color:#334155;
    style KERNEL fill:#f1f5f9,stroke:#cbd5e1,color:#334155;

    %% highlight the POSIX Quirk bug edge in red (last edge declared, index 23)
    linkStyle 23 stroke:#dc2626,stroke-width:2px;
```
