### PR TITLE
dbd: clear AFPVOL_NOV2TOEACONV flag to allow AD to xattr conversion

### DIFF
--- a/bin/dbd/cmd_dbd.c
+++ b/bin/dbd/cmd_dbd.c
@@ -308,6 +308,10 @@ int main(int argc, char **argv)
         exit(EXIT_FAILURE);
     }
 
+    if (flags & DBD_FLAGS_V2TOEA) {
+        vol->v_flags &= ~AFPVOL_NOV2TOEACONV;
+    }
+
     /* Sanity checks to ensure we can touch this volume */
     if (vol->v_vfs_ea != AFPVOL_EA_AD && vol->v_vfs_ea != AFPVOL_EA_SYS) {
         dbd_log(LOGSTD, "Unknown Extended Attributes option: %u", vol->v_vfs_ea);


### PR DESCRIPTION
when afp.conf is set to 'convert appledouble = no' we enable the AFPVOL_NOV2TOEACONV flag, however the dbd tool should always be allowed to convert AD to xattr so clear the flag when running dbd