### PR TITLE
afpd: harden build_fce_packet() remaining accounting

### DIFF
--- a/etc/afpd/fce_api.c
+++ b/etc/afpd/fce_api.c
@@ -320,7 +320,7 @@ static ssize_t build_fce_packet(const AFPObj *obj,
         memcpy(p, user, userlen);
         p += userlen;
         datalen += userlen;
-        remaining -= userlen;
+        remaining -= sizeof(uint16) + userlen;
     }
 
     /* path */
@@ -340,7 +340,7 @@ static ssize_t build_fce_packet(const AFPObj *obj,
     memcpy(p, path, pathlen);
     p += pathlen;
     datalen += pathlen;
-    remaining -= pathlen;
+    remaining -= sizeof(uint16) + pathlen;
 
     /* optional: source path */
     if (oldpath && packet_info & FCE_EV_INFO_SRCPATH) {
@@ -424,7 +424,7 @@ static void send_fce_event(const AFPObj *obj, int event, const char *path,
 
         bstring cmd = bformat("%s -v %d -e %s -i %" PRIu32 "",
                               obj->fce_notify_script,
-                              FCE_PACKET_VERSION,
+                              obj->fce_version,
                               fce_event_names[event],
                               event_id);
 


### PR DESCRIPTION
build_fce_packet() had imperfect remaining accounting: after writing 16-bit length fields for username/path/source path, it advances p and datalen but does not subtract those length-field bytes from remaining

also fixes a straggler FCE packet version 1 marshalling bug, a leftover from the fix for SourceForge [Bug No.603](https://sourceforge.net/p/netatalk/bugs/603/)