### PR TITLE
contrib: harden and install FCE notify script helper

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -27,6 +27,7 @@ meson setup build \
     -Dwith-acls=false \
     -Dwith-cracklib=false \
     -Dwith-cups=false \
+    -Dwith-fce=false \
     -Dwith-appletalk=false \
     -Dwith-gssapi=false \
     -Dwith-kerberos=false \

--- a/contrib/meson.build
+++ b/contrib/meson.build
@@ -1,5 +1,9 @@
 subdir('bin_utils')
 
+if have_fce
+    subdir('scripts')
+endif
+
 if have_appletalk
     subdir('a2boot')
     subdir('timelord')

--- a/contrib/scripts/fce_ev_script.sh
+++ b/contrib/scripts/fce_ev_script.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-usage="$(basename $0) [-h] [-v version] [-e event] [-P path] [-S source path] -- FCE sample script
+# Filesystem Change Event reporting helper for the 'fce notify script'
+# afp.conf option.
+
+usage="$(basename "$0") [-h] [-v version] [-e event] [-P path] [-S source path] -- FCE notification helper
 
 where:
     -h  show this help text
@@ -11,9 +14,14 @@ where:
     -u  username
     -p  pid
     -i  event ID
+
+environment:
+    NETATALK_FCE_LOG_FILE    append events to this file instead of syslog
+    NETATALK_FCE_LOGGER      logger command path, default: logger
+    NETATALK_FCE_LOG_TAG     syslog tag, default: netatalk-fce
 "
 
-while getopts ':hs:v:e:P:S:u:p:i:' option; do
+while getopts ':hv:e:P:S:u:p:i:' option; do
     case "$option" in
         h)
             echo "$usage"
@@ -49,23 +57,39 @@ while getopts ':hs:v:e:P:S:u:p:i:' option; do
 done
 shift $((OPTIND - 1))
 
-printf "FCE Event: $event" >> /tmp/fce.log
+message="FCE Event: ${event:-unknown}"
+
 if [ -n "$version" ]; then
-    printf ", protocol: $version" >> /tmp/fce.log
+    message="$message, protocol: $version"
 fi
 if [ -n "$evid" ]; then
-    printf ", ID: $evid" >> /tmp/fce.log
+    message="$message, ID: $evid"
 fi
 if [ -n "$pid" ]; then
-    printf ", pid: $pid" >> /tmp/fce.log
+    message="$message, pid: $pid"
 fi
 if [ -n "$user" ]; then
-    echo -n ", user: $user" >> /tmp/fce.log
+    message="$message, user: $user"
 fi
 if [ -n "$srcpath" ]; then
-    echo -n ", source: $srcpath" >> /tmp/fce.log
+    message="$message, source: $srcpath"
 fi
 if [ -n "$path" ]; then
-    echo -n ", path: $path" >> /tmp/fce.log
+    message="$message, path: $path"
 fi
-printf "\n" >> /tmp/fce.log
+
+if [ -n "$NETATALK_FCE_LOG_FILE" ]; then
+    printf '%s\n' "$message" >> "$NETATALK_FCE_LOG_FILE"
+    exit $?
+fi
+
+logger_cmd="${NETATALK_FCE_LOGGER:-logger}"
+logger_tag="${NETATALK_FCE_LOG_TAG:-netatalk-fce}"
+
+if command -v "$logger_cmd" > /dev/null 2>&1; then
+    "$logger_cmd" -t "$logger_tag" "$message"
+    exit $?
+fi
+
+printf '%s\n' "$message" >&2
+exit 0

--- a/contrib/scripts/meson.build
+++ b/contrib/scripts/meson.build
@@ -1,0 +1,11 @@
+fce_ev_script = configure_file(
+    input: 'fce_ev_script.sh',
+    output: 'fce_ev_script',
+    copy: true,
+)
+
+install_data(
+    fce_ev_script,
+    install_dir: libexecdir / 'netatalk',
+    install_mode: 'rwxr-xr-x',
+)

--- a/distrib/docker/debug_alp.Dockerfile
+++ b/distrib/docker/debug_alp.Dockerfile
@@ -77,6 +77,7 @@ COPY contrib/meson.build ./contrib/
 COPY contrib/a2boot/ ./contrib/a2boot/
 COPY contrib/bin_utils/ ./contrib/bin_utils/
 COPY contrib/macipgw/ ./contrib/macipgw/
+COPY contrib/scripts/ ./contrib/scripts/
 COPY contrib/timelord/ ./contrib/timelord/
 COPY distrib/docker/ ./distrib/docker/
 COPY etc/ ./etc/

--- a/distrib/docker/testsuite_alp.Dockerfile
+++ b/distrib/docker/testsuite_alp.Dockerfile
@@ -66,6 +66,7 @@ COPY contrib/meson.build ./contrib/
 COPY contrib/a2boot/ ./contrib/a2boot/
 COPY contrib/bin_utils/ ./contrib/bin_utils/
 COPY contrib/macipgw/ ./contrib/macipgw/
+COPY contrib/scripts/ ./contrib/scripts/
 COPY contrib/timelord/ ./contrib/timelord/
 COPY distrib/docker/ ./distrib/docker/
 COPY etc/ ./etc/

--- a/distrib/docker/testsuite_deb.Dockerfile
+++ b/distrib/docker/testsuite_deb.Dockerfile
@@ -76,6 +76,7 @@ COPY contrib/meson.build ./contrib/
 COPY contrib/a2boot/ ./contrib/a2boot/
 COPY contrib/bin_utils/ ./contrib/bin_utils/
 COPY contrib/macipgw/ ./contrib/macipgw/
+COPY contrib/scripts/ ./contrib/scripts/
 COPY contrib/timelord/ ./contrib/timelord/
 COPY distrib/docker/ ./distrib/docker/
 COPY etc/ ./etc/

--- a/distrib/docker/webmin_module.Dockerfile
+++ b/distrib/docker/webmin_module.Dockerfile
@@ -74,6 +74,7 @@ RUN sed -i 's/hide_service_controls=0/hide_service_controls=1/' /netatalk-code/c
     -Dwith-appletalk=true \
     -Dwith-docs= \
     -Dwith-dtrace=false \
+    -Dwith-fce=false \
     -Dwith-init-style=none \
     -Dwith-krbV-uam=false \
     -Dwith-pkgconfdir-path=/etc/netatalk \

--- a/doc/manpages/man1/fce_listen.1.md
+++ b/doc/manpages/man1/fce_listen.1.md
@@ -47,4 +47,4 @@ Listen to FCE events on localhost port 58585
 
 # See Also
 
-**afpd**(8)
+**afpd**(8), **fce_ev_script**(8)

--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -894,9 +894,8 @@ Must not end with a slash. Default: empty
 
 fce notify script = *path* **(G)**
 
-> Script which will be executed for every FCE event. See
-*contrib/scripts/fce_ev_script.sh* in the Netatalk source tree
-for an example script.
+> Script which will be executed for every FCE event. Netatalk installs
+**fce_ev_script**(8) as a notification helper under its libexec directory.
 
 ## Options for ACL handling
 

--- a/doc/manpages/man8/fce_ev_script.8.md
+++ b/doc/manpages/man8/fce_ev_script.8.md
@@ -1,0 +1,97 @@
+# Name
+
+fce_ev_script — Netatalk Filesystem Change Events notification helper
+
+# Synopsis
+
+**fce_ev_script** [-h] [-v *version*] [-e *event*] [-i *id*] [-P *path*] [-S *source*] [-p *pid*] [-u *user*]
+
+# Description
+
+**fce_ev_script** is a notification helper for Netatalk's Filesystem Change
+Event (FCE) mechanism.  It is intended to be used with the **fce notify script**
+option in *afp.conf*.
+
+When **afpd** emits an FCE event and **fce notify script** is configured,
+**afpd** executes the configured script in the background and passes event
+details as command-line options.
+
+By default, **fce_ev_script** writes events to syslog with the tag
+*netatalk-fce*.  If the **NETATALK_FCE_LOG_FILE** environment variable is set,
+events are appended to that file instead.
+
+> **Note:** This utility requires netatalk to be built with FCE support enabled
+> (the *-Dwith-fce=true* meson build option, which is enabled by default).
+
+# Options
+
+**-h**
+: Show help text and exit.
+
+**-v** *version*
+: FCE script argument version.
+
+**-e** *event*
+: FCE event name, such as *FCE_FILE_CREATE*.
+
+**-i** *id*
+: FCE event id.
+
+**-P** *path*
+: Event path.
+
+**-S** *source*
+: Source path for move or rename events.
+
+**-p** *pid*
+: Process id of the **afpd** process that emitted the event.
+
+**-u** *user*
+: AFP session user that emitted the event.
+
+# Environment
+
+**NETATALK_FCE_LOG_FILE**
+: Append event lines to this file instead of syslog.  The file must be writable
+by the AFP session users that may trigger events.
+
+**NETATALK_FCE_LOGGER**
+: Logger command to use when **NETATALK_FCE_LOG_FILE** is not set.  Default:
+*logger*.
+
+**NETATALK_FCE_LOG_TAG**
+: Syslog tag to use when **NETATALK_FCE_LOG_FILE** is not set.  Default:
+*netatalk-fce*.
+
+# Execution Context
+
+**afpd** executes the configured notification script as the AFP session user,
+not necessarily as root or as the user that started Netatalk.
+
+The configured script path must be executable by that user, and every parent
+directory in the path must be searchable by that user.  If file logging is
+enabled with **NETATALK_FCE_LOG_FILE**, the log file must also be writable by
+that user.
+
+# Examples
+
+Configure **afpd** to run the installed helper for each FCE event:
+
+    [Global]
+    fce notify script = /usr/local/libexec/netatalk/fce_ev_script
+    fce version = 2
+    fce events = fmod,fdel,ddel,fcre,dcre,fmov,dmov,login,logout
+
+Replace */usr/local/libexec* with the libexec directory configured for your
+installation.
+
+For diagnostic file logging, wrap the helper and set **NETATALK_FCE_LOG_FILE**:
+
+    #!/bin/sh
+    NETATALK_FCE_LOG_FILE=/tmp/fce.log
+    export NETATALK_FCE_LOG_FILE
+    exec /usr/local/libexec/netatalk/fce_ev_script "$@"
+
+# See Also
+
+**afpd**(8), **afp.conf**(5), **fce_listen**(1)

--- a/doc/manpages/man8/meson.build
+++ b/doc/manpages/man8/meson.build
@@ -3,6 +3,12 @@ manfiles = [
     'netatalk',
 ]
 
+if have_fce
+    manfiles += [
+        'fce_ev_script',
+    ]
+endif
+
 if use_dbd_backend
     manfiles += [
         'cnid_dbd',

--- a/doc/manual/FCE.md
+++ b/doc/manual/FCE.md
@@ -1,40 +1,211 @@
 # Filesystem Change Events
 
-Netatalk includes a filesystem change event (FCE) mechanism that allows **afpd** processes
-to notify interested listeners about certain filesystem events via UDP network datagrams.
+Netatalk includes a filesystem change event (FCE) mechanism that allows **afpd**
+processes to report selected AFP session and filesystem activity.
 
-This feature is disabled by default.
-To enable it,
-set the **fce listener** option in *afp.conf* to the hostname
-or IP address of the host that should listen for FCE events.
+There are two ways to capture emitted FCE events:
 
-Netatalk distributes a simple FCE listener application called **fce_listen**.
-It prints any UDP datagrams received from the AFP server.
-Its source code also serves as documentation for the format of the UDP packets.
+- send FCE packets over UDP to one or more listener applications
+- execute a local notification script for every emitted event
 
-## FCE v1
+The two methods are independent.  A server may use either one, or both at the
+same time.
 
-The supported FCE v1 events are:
+FCE support must be enabled at build time.  The Meson option is
+*-Dwith-fce=true*, which is enabled by default.
 
-- file modification (fmod)
+## Events
 
-- file deletion (fdel)
+The following event names are used in the **fce events** option:
 
-- directory deletion (ddel)
+- file modification (**fmod**)
+- file deletion (**fdel**)
+- directory deletion (**ddel**)
+- file creation (**fcre**)
+- directory creation (**dcre**)
+- file move or rename (**fmov**)
+- directory move or rename (**dmov**)
+- user login (**login**)
+- user logout (**logout**)
 
-- file creation (fcre)
+FCE protocol version 1 supports the basic file and directory events:
 
-- directory creation (dcre)
+- **fmod**
+- **fdel**
+- **ddel**
+- **fcre**
+- **dcre**
 
-## FCE v2
+FCE protocol version 2 adds event metadata such as the process id and user name,
+and is required for move, login, and logout events:
 
-FCE v2 events provide additional context such as the user who performed the action.
-FCE v2 also adds the following events:
+- **fmov**
+- **dmov**
+- **login**
+- **logout**
 
-- file moving (fmov)
+For new deployments, use **fce version = 2**.
 
-- directory moving (dmov)
+## Capturing Events with UDP
 
-- user login (login)
+The **fce listener** option sends FCE events as UDP datagrams to a host and
+optional port:
 
-- user logout (logout)
+```ini
+[Global]
+fce listener = localhost:12250
+fce version = 2
+fce events = fmod,fdel,ddel,fcre,dcre,fmov,dmov,login,logout
+```
+
+If no port is specified, Netatalk uses port *12250*.
+Multiple listeners can be configured by adding **fce listener** more than once.
+
+Netatalk includes a simple listener application, **fce_listen**, that can be used
+for testing:
+
+```sh
+$ fce_listen -h localhost -p 12250
+Listening for Netatalk FCE datagrams on localhost:12250...
+FCE Start
+ID: 1, Event: FCE_LOGIN, pid: 429924, user: myuser, Path:
+ID: 2, Event: FCE_FILE_CREATE, pid: 429924, user: myuser, Path: /srv/afp/untitled folder
+ID: 3, Event: FCE_DIR_MOVE, pid: 429924, user: myuser, source: /srv/afp/untitled folder, Path: /srv/afp/My Folder
+```
+
+UDP delivery is useful for external indexers, audit collectors, or other
+programs that should receive events without being executed by **afpd**.
+Because UDP is not reliable, receivers should use the FCE event id to detect
+missing packets.
+
+If a burst of filesystem activity causes packet loss, **fce sendwait** can add a
+small delay between emitted UDP events:
+
+```ini
+[Global]
+fce listener = localhost:12250
+fce sendwait = 10
+```
+
+The value is in milliseconds and must be between *0* and *999*.
+
+## Capturing Events with a Script
+
+The **fce notify script** option executes a local script for every emitted FCE
+event:
+
+```ini
+[Global]
+fce notify script = /usr/local/libexec/netatalk/fce_ev_script
+fce version = 2
+fce events = fmod,fdel,ddel,fcre,dcre,fmov,dmov,login,logout
+```
+
+The script method does not require **fce listener**.
+It can be used by itself, or together with UDP listeners.
+
+Netatalk runs the script in the background through */bin/sh -c*.
+The configured script path is followed by command-line options describing the
+event.  For example:
+
+```sh
+running /usr/local/libexec/netatalk/fce_ev_script -v 2 -e FCE_FILE_CREATE -i 2 -P '/srv/afp/Example File' -p 60246 -u 'myuser' as user 503
+```
+
+The options passed to the script are:
+
+- **-v VERSION**: FCE script argument version
+- **-e EVENT**: event name, such as **FCE_FILE_CREATE**
+- **-i ID**: event id
+- **-P PATH**: event path, when the event has a path
+- **-S SOURCE**: source path for move or rename events
+- **-p PID**: **afpd** process id
+- **-u USER**: AFP session user
+
+The **-p** and **-u** options are available with **fce version = 2**.
+
+The installed **fce_ev_script** helper accepts these options and writes a
+human-readable event line to syslog with the tag *netatalk-fce*.
+The source script is maintained as *contrib/scripts/fce_ev_script.sh*.
+
+Example output:
+
+```text
+FCE Event: FCE_FILE_MOVE, protocol: 2, ID: 4, pid: 429924, user: myuser, source: /srv/afp/old.txt, path: /srv/afp/new.txt
+```
+
+## Script Execution Environment
+
+The notification script is executed as the AFP session user, not necessarily as
+root or as the user that started Netatalk.
+
+This has a few practical consequences:
+
+- the script path must be executable by the AFP session user
+- every parent directory in the script path must be searchable by that user
+- files written by the script must be writable by that user
+- relative paths should be avoided because the helper changes directory to */*
+  before executing the command
+
+The build system installs the helper under Netatalk's libexec directory.
+Replace */usr/local/libexec* with the libexec directory configured for your
+installation.
+Configure **afpd** with that installed path:
+
+```ini
+[Global]
+fce notify script = /usr/local/libexec/netatalk/fce_ev_script
+```
+
+For diagnostic file logging, wrap the helper and set
+**NETATALK_FCE_LOG_FILE**:
+
+```sh
+#!/bin/sh
+NETATALK_FCE_LOG_FILE=/tmp/fce.log
+export NETATALK_FCE_LOG_FILE
+exec /usr/local/libexec/netatalk/fce_ev_script "$@"
+```
+
+If file logging is enabled but */tmp/fce.log* is not updated, check the owner
+and mode of the log file.
+
+## Event Filtering and Coalescing
+
+The **fce events** option controls which events are emitted:
+
+```ini
+[Global]
+fce events = fcre,dcre,fmov,dmov
+```
+
+The **fce ignore names** option suppresses events for selected filenames.
+The default ignored name is *.DS_Store*.
+
+```ini
+[Global]
+fce ignore names = .DS_Store,Thumbs.db
+```
+
+The **fce ignore directories** option suppresses events below selected absolute
+directory paths.  The paths must not end with a slash.
+
+```ini
+[Global]
+fce ignore directories = /srv/afp/cache,/srv/afp/tmp
+```
+
+The **fce coalesce** option can reduce noisy create and delete event bursts:
+
+```ini
+[Global]
+fce coalesce = all
+```
+
+File modification events are delayed by **fce holdfmod**, which defaults to
+*60* seconds.  For immediate script testing, set it to *0*:
+
+```ini
+[Global]
+fce holdfmod = 0
+```

--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,7 @@ bindir = prefix / get_option('bindir')
 datadir = prefix / get_option('datadir')
 includedir = prefix / get_option('includedir')
 libdir = prefix / get_option('libdir')
+libexecdir = prefix / get_option('libexecdir')
 mandir = prefix / get_option('mandir')
 sbindir = prefix / get_option('sbindir')
 sysconfdir = prefix / get_option('sysconfdir')
@@ -2512,6 +2513,7 @@ cdata.set('exec_prefix', exec_prefix)
 cdata.set('datadir', datadir)
 cdata.set('homedir', homedir)
 cdata.set('libdir', libdir)
+cdata.set('libexecdir', libexecdir)
 cdata.set('includedir', includedir)
 cdata.set('localstatedir', localstatedir)
 cdata.set('lockfile_path', lockfile_path)
@@ -2698,6 +2700,7 @@ summary_info = {
     'Executable directory': bindir,
     'Header file directory': get_option('prefix') / get_option('includedir'),
     'Library directory': libdir,
+    'Library executable directory': libexecdir,
     'Manual page directory': mandir,
     'System executable directory': sbindir,
     'Package conf directory': pkgconfdir,


### PR DESCRIPTION
Install the FCE notify script as a libexec helper when FCE support is enabled so downstream packages include it. Harden the helper to log via syslog by default while retaining optional file logging through NETATALK_FCE_LOG_FILE.

Set the executable bit on the FCE notify script since afpd invokes it with /bin/sh when events are emitted.

Document the helper with a new fce_ev_script(8) man page, update afp.conf and fce_listen references, and expand the FCE manual chapter with UDP and script capture examples.