### PR TITLE
contrib: add copyright and license to fce_ev_script.sh

### DIFF
--- a/contrib/scripts/fce_ev_script.sh
+++ b/contrib/scripts/fce_ev_script.sh
@@ -2,6 +2,18 @@
 
 # Filesystem Change Event reporting helper for the 'fce notify script'
 # afp.conf option.
+#
+# Copyright (C) 2014 Ralph Boehme <sloowfranklin@gmail.com>
+#
+#  This program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
 
 usage="$(basename "$0") [-h] [-v version] [-e event] [-P path] [-S source path] -- FCE notification helper
 


### PR DESCRIPTION
add copyright notice and a GNU GPL v2 license grant to this shell script, reflecting the author's usual copyright blurb and choice of license from contemporaneous code