### PR TITLE
ci: update MySQL client version in workflow

### DIFF
--- a/.github/workflows/spectest-vms.yml
+++ b/.github/workflows/spectest-vms.yml
@@ -129,7 +129,7 @@ jobs:
               libsunacl \
               localsearch \
               meson \
-              mysql96-client \
+              mysql97-client \
               openldap26-client \
               perl5 \
               pkgconf \
@@ -209,7 +209,7 @@ jobs:
               libsunacl \
               localsearch \
               meson \
-              mysql96-client \
+              mysql97-client \
               openldap26-client \
               perl5 \
               pkgconf \


### PR DESCRIPTION
mysql96-client is EOL and deleted from FreeBSD ports, so let's bump to mysql97-client which is the current version