### PR TITLE
update astyle rules for side comments and continuation indent

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -16,6 +16,7 @@
 --ignore-exclude-errors-x
 --indent=spaces=4
 --max-code-length=80
+--max-code-length-mode=ignore-side-comments
 --pad-comma
 --pad-header
 --pad-oper

--- a/.astylerc
+++ b/.astylerc
@@ -13,9 +13,14 @@
 --exclude=libatalk/unicode/precompose.h
 --exclude=libatalk/unicode/utf16_case.c
 --exclude=libatalk/unicode/utf16_casetable.h
+# workaround for astyle bug:
+# https://gitlab.com/saalen/astyle/-/work_items/111
+--exclude=etc/spotlight/xapian/sl_xapian.h
 --ignore-exclude-errors-x
 --indent=spaces=4
 --max-code-length=80
+--max-code-length-mode=ignore-side-comments
+--max-continuation-indent=60
 --pad-comma
 --pad-header
 --pad-oper

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,9 @@ jobs:
             shfmt \
             yamlfmt
           npm install --global --ignore-scripts markdownlint-cli2@0.22.0
-      - name: Build astyle 3.6.14 from source
+      - name: Build astyle 3.6.17 from source
         run: |
-          git clone --depth 1 --branch 3.6.14 \
+          git clone --depth 1 --branch 3.6.17 \
             https://gitlab.com/saalen/astyle.git /tmp/astyle
           cmake -S /tmp/astyle -B /tmp/astyle/build \
             -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     name: Code Formatting
     runs-on: ubuntu-latest
     container:
-      image: alpine:3.23.2
+      image: alpine:3.24.1
     steps:
       - name: Install dependencies
         run: |
@@ -30,6 +30,7 @@ jobs:
             build-base \
             ca-certificates \
             cmake \
+            curl \
             git \
             muon \
             nodejs \
@@ -37,11 +38,19 @@ jobs:
             perl-tidy \
             shfmt \
             yamlfmt
-          npm install --global --ignore-scripts markdownlint-cli2@0.22.0
-      - name: Build astyle 3.6.14 from source
+          curl --proto '=https' --location --fail -o /tmp/markdownlint-cli2.tgz \
+            https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.0.tgz
+          echo '98e0bd058fd71ad757dccf67dc080445defd174f92ef0d7cc81053348438e77b08f3b7ad65fa75cf879a8ea48c57bd026236f129ee64b4abd3d870a9bdc5b1f7  /tmp/markdownlint-cli2.tgz' \
+            | sha512sum -c -
+          npm install --global --ignore-scripts /tmp/markdownlint-cli2.tgz
+      - name: Build astyle from source
         run: |
-          git clone --depth 1 --branch 3.6.14 \
-            https://gitlab.com/saalen/astyle.git /tmp/astyle
+          curl --proto '=https' --location --fail -o /tmp/astyle.tar.gz \
+            https://gitlab.com/saalen/astyle/-/archive/3.6.18/astyle-3.6.18.tar.gz
+          echo '3cf671a726e9b14e75fd9ad862dc6b5500f948a12700bc842e9bd4bc3a9a9915  /tmp/astyle.tar.gz' \
+            | sha256sum -c -
+          mkdir -p /tmp/astyle
+          tar -xzf /tmp/astyle.tar.gz -C /tmp/astyle --strip-components=1
           cmake -S /tmp/astyle -B /tmp/astyle/build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=/usr/local

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,9 +189,9 @@ With automated enforcement of the style guide, the manual overhead of fiddling w
 
 ### Automatic formatting
 
-The style guide is automatically enforced with [astyle](https://gitlab.com/saalen/astyle) v3.6.x
+The style guide is automatically enforced with [astyle](https://gitlab.com/saalen/astyle) v3.6.17 or later.
 and an `.astylerc` options file.
-Before submitting new code, run `astyle --project --recursive '*.h' '*.c'` in the root of the netatalk source tree.
+Before submitting new code, run `astyle --project --recursive '*.h' '*.c' '*.cc'` in the root of the netatalk source tree.
 You can also use the `./contrib/scripts/codefmt.sh` convenience script to the same effect.
 
 ### Rules
@@ -232,11 +232,9 @@ int return_zero(int i)
 ```
 
 - Code comments
-  - C style comments, not C++ style
-  - Comments should come on the line before the code it describes
-    - Exception: Trailing Doxygen comments (see below)
-  - Single line: `/* Your comment goes here */`
-  - Multi line comments use a `*` prefix
+  - C style `/* comments */`, not C++ style `// comments`
+  - Trailing code comments should be used where appropriate, such as structure member definitions
+  - Multi line comments use vertically aligned `*` prefixes
 
 Ex.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,8 +189,8 @@ With automated enforcement of the style guide, the manual overhead of fiddling w
 
 ### Automatic formatting
 
-The style guide is automatically enforced with [astyle](https://gitlab.com/saalen/astyle) v3.6.17 or later.
-and an `.astylerc` options file.
+The style guide is automatically enforced with [astyle](https://gitlab.com/saalen/astyle) v3.6.17 or later
+and an `.astylerc` formatting options file.
 Before submitting new code, run `astyle --project --recursive '*.h' '*.c' '*.cc'` in the root of the netatalk source tree.
 You can also use the `./contrib/scripts/codefmt.sh` convenience script to the same effect.
 

--- a/bin/getzones/getzones.c
+++ b/bin/getzones/getzones.c
@@ -295,7 +295,7 @@ static void print_zones(short n, const char *buf, charset_t charset)
 
     for (; n--; buf += (*buf) + 1) {
         if ((size_t)(-1) == (zone_len = convert_string_allocate(charset,
-                                        CH_UNIX, buf + 1, *buf, &zone))) {
+            CH_UNIX, buf + 1, *buf, &zone))) {
             /* If the string conversion fails, just copy the MacRoman string
                and hope it makes sense as whatever our UNIX charset is */
             zone_len = *buf;
@@ -569,7 +569,7 @@ void do_query(struct sockaddr_at *dest, uint16_t network, charset_t charset)
             }
 
             replied_zone_count += print_and_count_zones_in_reply(buf + 3, length - 3,
-                                  charset);
+                charset);
 
             if (replied_zone_count >= expected_zone_count) {
                 break;

--- a/bin/getzones/getzones.c
+++ b/bin/getzones/getzones.c
@@ -30,7 +30,7 @@ static void print_gnireply(ssize_t len, uint8_t *buf, charset_t charset);
 void do_getnetinfo(struct sockaddr_at *dest, const char *zone_to_confirm,
                    charset_t charset);
 static int print_and_count_zones_in_reply(uint8_t *buf, size_t len,
-        charset_t charset);
+                                          charset_t charset);
 void do_query(struct sockaddr_at *dest, uint16_t network, charset_t charset);
 
 static void usage(char *s)
@@ -295,7 +295,7 @@ static void print_zones(short n, const char *buf, charset_t charset)
 
     for (; n--; buf += (*buf) + 1) {
         if ((size_t)(-1) == (zone_len = convert_string_allocate(charset,
-                                        CH_UNIX, buf + 1, *buf, &zone))) {
+                                                                CH_UNIX, buf + 1, *buf, &zone))) {
             /* If the string conversion fails, just copy the MacRoman string
                and hope it makes sense as whatever our UNIX charset is */
             zone_len = *buf;
@@ -569,7 +569,7 @@ void do_query(struct sockaddr_at *dest, uint16_t network, charset_t charset)
             }
 
             replied_zone_count += print_and_count_zones_in_reply(buf + 3, length - 3,
-                                  charset);
+                                                                 charset);
 
             if (replied_zone_count >= expected_zone_count) {
                 break;
@@ -579,7 +579,7 @@ void do_query(struct sockaddr_at *dest, uint16_t network, charset_t charset)
 }
 
 static int print_and_count_zones_in_reply(uint8_t *buf, size_t len,
-        charset_t charset)
+                                          charset_t charset)
 {
     uint8_t *cursor = buf;
     int count = 0;

--- a/bin/nad/ftw.c
+++ b/bin/nad/ftw.c
@@ -747,7 +747,7 @@ static int ftw_startup(const char *dir,
     data.maxdir = descriptors < 1 ? 1 : descriptors;
     data.actdir = 0;
     data.dirstreams = (struct dir_data **) alloca(data.maxdir
-                      * sizeof(struct dir_data *));
+        * sizeof(struct dir_data *));
     memset(data.dirstreams, '\0', data.maxdir * sizeof(struct dir_data *));
     /* PATH_MAX is always defined when we get here.  */
     data.dirbufsize = MAX(2 * strlen(dir), PATH_MAX);

--- a/bin/nad/ftw.c
+++ b/bin/nad/ftw.c
@@ -746,7 +746,7 @@ static int ftw_startup(const char *dir,
     data.maxdir = descriptors < 1 ? 1 : descriptors;
     data.actdir = 0;
     data.dirstreams = (struct dir_data **) alloca(data.maxdir
-                      * sizeof(struct dir_data *));
+                                                  * sizeof(struct dir_data *));
     memset(data.dirstreams, '\0', data.maxdir * sizeof(struct dir_data *));
     /* PATH_MAX is always defined when we get here.  */
     data.dirbufsize = MAX(2 * strlen(dir), PATH_MAX);

--- a/bin/nad/macbin.c
+++ b/bin/nad/macbin.c
@@ -84,7 +84,7 @@ static uint32_t macbin_u32_from_header(const unsigned char *header,
 }
 
 static uint16_t macbin_fdflags_from_header(const unsigned char *header,
-        int revision)
+                                           int revision)
 {
     unsigned char flags_low = 0;
 

--- a/bin/nad/nad_mv.c
+++ b/bin/nad/nad_mv.c
@@ -397,7 +397,7 @@ static int do_move(const char *from, const char *to)
         ad_init(&ad, dvolume.vol);
 
         if (ad_open(&ad, to, S_ISDIR(sb.st_mode) ? (ADFLAGS_DIR | ADFLAGS_HF |
-                    ADFLAGS_RDWR) : ADFLAGS_HF | ADFLAGS_RDWR) != 0) {
+                ADFLAGS_RDWR) : ADFLAGS_HF | ADFLAGS_RDWR) != 0) {
             NAD_INFO("Error opening adouble for: %s", to);
             return 1;
         }

--- a/bin/nad/nad_mv.c
+++ b/bin/nad/nad_mv.c
@@ -397,7 +397,7 @@ static int do_move(const char *from, const char *to)
         ad_init(&ad, dvolume.vol);
 
         if (ad_open(&ad, to, S_ISDIR(sb.st_mode) ? (ADFLAGS_DIR | ADFLAGS_HF |
-                    ADFLAGS_RDWR) : ADFLAGS_HF | ADFLAGS_RDWR) != 0) {
+                                                    ADFLAGS_RDWR) : ADFLAGS_HF | ADFLAGS_RDWR) != 0) {
             NAD_INFO("Error opening adouble for: %s", to);
             return 1;
         }

--- a/bin/nbp/nbplkup.c
+++ b/bin/nbp/nbplkup.c
@@ -192,7 +192,7 @@ int main(int ac, char **av)
 
     if (ac - optind == 1) {
         if ((size_t)(-1) == convert_string_allocate(CH_UNIX, chMac,
-                av[optind], -1, &convname)) {
+                                                    av[optind], -1, &convname)) {
             convname = av[optind];
         }
 

--- a/bin/nbp/nbprgstr.c
+++ b/bin/nbp/nbprgstr.c
@@ -83,7 +83,7 @@ int main(int ac, char **av)
 
     /* Convert the name */
     if ((size_t)(-1) == convert_string_allocate(CH_UNIX, chMac,
-            av[optind], -1, &convname)) {
+                                                av[optind], -1, &convname)) {
         convname = av[optind];
     }
 

--- a/bin/nbp/nbpunrgstr.c
+++ b/bin/nbp/nbpunrgstr.c
@@ -96,7 +96,7 @@ int main(int ac, char **av)
 
     /* Convert the name */
     if ((size_t)(-1) == convert_string_allocate(CH_UNIX, chMac,
-            av[optind], -1, &convname)) {
+                                                av[optind], -1, &convname)) {
         convname = av[optind];
     }
 

--- a/bin/rtmpqry/rtmpqry.c
+++ b/bin/rtmpqry/rtmpqry.c
@@ -45,7 +45,7 @@ static void usage(char *s)
     exit(1);
 }
 
-int main(int argc, char** argv)
+int main(int argc, char **argv)
 {
     int c;
     int error_flag = 0;
@@ -171,7 +171,7 @@ void do_rtmp_request(int sockfd, struct sockaddr_at *sa_remote)
     uint8_t buf[600];
     buf[0] = DDPTYPE_RTMPR;
     buf[1] = RTMPROP_REQUEST;
-    ssize_t ret = netddp_sendto(sockfd, buf, 2, 0, (struct sockaddr*)sa_remote,
+    ssize_t ret = netddp_sendto(sockfd, buf, 2, 0, (struct sockaddr *)sa_remote,
                                 (int)sizeof(struct sockaddr_at));
 
     if (ret < 0) {
@@ -201,7 +201,7 @@ void do_rtmp_request(int sockfd, struct sockaddr_at *sa_remote)
 
         /* Skip the DDP type which we checked above */
         uint8_t *cursor = buf + 1;
-        uint16_t router_net = ntohs(*(uint16_t*)cursor);
+        uint16_t router_net = ntohs(*(uint16_t *)cursor);
         cursor += 2;
         uint8_t id_len = *cursor++;
 
@@ -220,7 +220,7 @@ void do_rtmp_request(int sockfd, struct sockaddr_at *sa_remote)
 
         if (((cursor + 6) - buf) <= length) {
             extended_network = true;
-            net_start = ntohs(*(uint16_t*)cursor);
+            net_start = ntohs(*(uint16_t *)cursor);
             cursor += 2;
 
             /* magic number.  Why 0x80?  Who knows! */
@@ -229,7 +229,7 @@ void do_rtmp_request(int sockfd, struct sockaddr_at *sa_remote)
                 exit(1);
             }
 
-            net_end = ntohs(*(uint16_t*)cursor);
+            net_end = ntohs(*(uint16_t *)cursor);
             cursor += 2;
             /* Another magic byte: I assume this is the RTMP version as it's the same
                as bytes documented as RTMP version in other packets, but IA isn't
@@ -277,7 +277,7 @@ void do_rtmp_rdr(int sockfd, const struct sockaddr_at *sa_remote, bool get_all,
     }
 
     ssize_t ret_socket = netddp_sendto(sockfd, buf, 2, 0,
-                                       (const struct sockaddr*)sa_remote,
+                                       (const struct sockaddr *)sa_remote,
                                        (int)sizeof(struct sockaddr_at));
 
     if (ret_socket < 0) {
@@ -368,14 +368,14 @@ const uint8_t *print_rtmp_tuple(const uint8_t *buf, const uint8_t *cursor,
         }
     }
 
-    uint16_t net_start = ntohs(*(const uint16_t*)cursor);
+    uint16_t net_start = ntohs(*(const uint16_t *)cursor);
     cursor += 2;
     /* top bit of distance is the extended network bit we used above */
     uint8_t distance = (*cursor++) & 0x7f;
 
     /* If this is an extended tuple, we also have an end network and an RTMP version */
     if (tuple_extended) {
-        uint16_t net_end = ntohs(*(const uint16_t*)cursor);
+        uint16_t net_end = ntohs(*(const uint16_t *)cursor);
         cursor += 2;
         uint8_t rtmp_version = *cursor++;
 
@@ -414,7 +414,7 @@ void print_rtmp_data_packet(const uint8_t *buf, size_t len)
     }
 
     cursor++;
-    uint16_t router_net_num = ntohs(*(const uint16_t*)cursor);
+    uint16_t router_net_num = ntohs(*(const uint16_t *)cursor);
     cursor += 2;
     uint8_t id_len = *cursor++;
 

--- a/contrib/macipgw/macip.c
+++ b/contrib/macipgw/macip.c
@@ -141,10 +141,10 @@ static const char error_noip[] = "No Address Available.";
 static const char error_noop[] = "Unknown Operation.";
 
 _Static_assert(sizeof(error_noip) <= sizeof(((struct macip_req_data *)
-               0)->mipr_error),
+                                             0)->mipr_error),
                "error_noip does not fit in mipr_error");
 _Static_assert(sizeof(error_noop) <= sizeof(((struct macip_req_data *)
-               0)->mipr_error),
+                                             0)->mipr_error),
                "error_noop does not fit in mipr_error");
 
 static uint16_t cksum(char *buffer, int len)

--- a/contrib/macipgw/main.c
+++ b/contrib/macipgw/main.c
@@ -206,10 +206,10 @@ macip_options *read_options(const char *conf)
     options->network = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL, "network", "");
     options->netmask = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL, "netmask", "");
     options->nameserver = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL, "nameserver",
-                          "");
+        "");
     options->zone = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL, "zone", "");
     options->unprivileged_user = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL,
-                                 "unprivileged user", "");
+        "unprivileged user", "");
     iniparser_freedict(config);
     return options;
 }

--- a/contrib/macipgw/main.c
+++ b/contrib/macipgw/main.c
@@ -206,10 +206,10 @@ macip_options *read_options(const char *conf)
     options->network = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL, "network", "");
     options->netmask = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL, "netmask", "");
     options->nameserver = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL, "nameserver",
-                          "");
+                                              "");
     options->zone = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL, "zone", "");
     options->unprivileged_user = INIPARSER_GETSTRDUP(config, INISEC_GLOBAL,
-                                 "unprivileged user", "");
+                                                     "unprivileged user", "");
     iniparser_freedict(config);
     return options;
 }

--- a/etc/afpd/acls.c
+++ b/etc/afpd/acls.c
@@ -775,7 +775,7 @@ static acl_perm_t map_darwin_right_to_posix_permset(uint32_t darwin_ace_rights,
     }
 
     if (darwin_ace_rights & (DARWIN_ACE_WRITE_DATA | (is_dir ?
-                             DARWIN_ACE_DELETE_CHILD : 0))) {
+            DARWIN_ACE_DELETE_CHILD : 0))) {
         perm |= ACL_WRITE;
     }
 

--- a/etc/afpd/acls.c
+++ b/etc/afpd/acls.c
@@ -766,7 +766,7 @@ EC_CLEANUP:
  * @returns mapping result as acl_perm_t, -1 on error
  */
 static acl_perm_t map_darwin_right_to_posix_permset(uint32_t darwin_ace_rights,
-        int is_dir)
+                                                    int is_dir)
 {
     acl_perm_t perm = 0;
 
@@ -775,7 +775,7 @@ static acl_perm_t map_darwin_right_to_posix_permset(uint32_t darwin_ace_rights,
     }
 
     if (darwin_ace_rights & (DARWIN_ACE_WRITE_DATA | (is_dir ?
-                             DARWIN_ACE_DELETE_CHILD : 0))) {
+                                                      DARWIN_ACE_DELETE_CHILD : 0))) {
         perm |= ACL_WRITE;
     }
 

--- a/etc/afpd/afp_config.c
+++ b/etc/afpd/afp_config.c
@@ -168,10 +168,10 @@ int configinit(AFPObj *dsi_obj, AFPObj *asp_obj)
             size_t zone_len = strnlen(asp_obj->options.zone, MAX_ZONE_LENGTH);
 
             if ((size_t) -1 == (convert_string_allocate(asp_obj->options.unixcharset,
-                                asp_obj->options.maccharset,
-                                asp_obj->options.zone,
-                                zone_len,
-                                &Zone))) {
+                    asp_obj->options.maccharset,
+                    asp_obj->options.zone,
+                    zone_len,
+                    &Zone))) {
                 if ((Zone = strdup(asp_obj->options.zone)) == NULL) {
                     LOG(log_error, logtype_afpd, "malloc: %s", strerror(errno));
                     asp_close(asp);

--- a/etc/afpd/afp_config.c
+++ b/etc/afpd/afp_config.c
@@ -168,10 +168,10 @@ int configinit(AFPObj *dsi_obj, AFPObj *asp_obj)
             size_t zone_len = strnlen(asp_obj->options.zone, MAX_ZONE_LENGTH);
 
             if ((size_t) -1 == (convert_string_allocate(asp_obj->options.unixcharset,
-                                asp_obj->options.maccharset,
-                                asp_obj->options.zone,
-                                zone_len,
-                                &Zone))) {
+                                                        asp_obj->options.maccharset,
+                                                        asp_obj->options.zone,
+                                                        zone_len,
+                                                        &Zone))) {
                 if ((Zone = strdup(asp_obj->options.zone)) == NULL) {
                     LOG(log_error, logtype_afpd, "malloc: %s", strerror(errno));
                     asp_close(asp);

--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -1072,6 +1072,7 @@ void afp_over_dsi(AFPObj *obj)
 #ifdef WITH_FCE
         fce_pending_events(obj);
 #endif /* WITH_FCE */
-restart_outer: ;
+restart_outer:
+        ;
     }
 }

--- a/etc/afpd/appl.c
+++ b/etc/afpd/appl.c
@@ -182,7 +182,7 @@ makemacpath(const struct vol *vol, char *mpath, int mpathlen, struct dir *dir,
 {
     char	*p;
     int     reserved_space = sizeof(uint16_t) + sizeof(unsigned
-                             char[4]); /* u_short + appltag */
+        char[4]); /* u_short + appltag */
     p = mpath + mpathlen;
     p -= strlen(path);
 

--- a/etc/afpd/appl.c
+++ b/etc/afpd/appl.c
@@ -182,7 +182,7 @@ makemacpath(const struct vol *vol, char *mpath, int mpathlen, struct dir *dir,
 {
     char	*p;
     int     reserved_space = sizeof(uint16_t) + sizeof(unsigned
-                             char[4]); /* u_short + appltag */
+                                                       char[4]); /* u_short + appltag */
     p = mpath + mpathlen;
     p -= strlen(path);
 

--- a/etc/afpd/catsearch.c
+++ b/etc/afpd/catsearch.c
@@ -368,7 +368,7 @@ static struct adouble *adl_lkup(struct vol *vol, struct path *path,
          * Opportunistically populate cache if not yet loaded. */
         adp = of->of_ad;
         struct dir *cached = dircache_search_by_name(vol, curdir,
-                             path->u_name, strnlen(path->u_name, CNID_MAX_PATH_LEN));
+            path->u_name, strnlen(path->u_name, CNID_MAX_PATH_LEN));
 
         /* If cache AD is unset, store fork's live adouble */
         if (cached && cached->dcache_rlen < 0) {
@@ -500,7 +500,7 @@ static int crit_check(struct vol *vol, struct path *path)
     /* Check for filename */
     if (c1.rbitmap & (1U << DIRPBIT_LNAME)) {
         if ((size_t)(-1) == (len = convert_string(vol->v_maccharset, CH_UCS2,
-                                   path->m_name, -1, convbuf, 512))) {
+            path->m_name, -1, convbuf, 512))) {
             goto crit_check_ret;
         }
 
@@ -515,7 +515,7 @@ static int crit_check(struct vol *vol, struct path *path)
 
     if (c1.rbitmap & (1U << FILPBIT_PDINFO)) {
         if ((size_t)(-1) == (len = convert_charset(CH_UTF8_MAC, CH_UCS2, CH_UTF8,
-                                   path->m_name, strlen(path->m_name), convbuf, 512, &flags))) {
+            path->m_name, strlen(path->m_name), convbuf, 512, &flags))) {
             goto crit_check_ret;
         }
 

--- a/etc/afpd/catsearch.c
+++ b/etc/afpd/catsearch.c
@@ -371,7 +371,7 @@ static struct adouble *adl_lkup(struct vol *vol, struct path *path,
          * sentinel to a bogus positive entry. */
         adp = of->of_ad;
         struct dir *cached = dircache_search_by_name(vol, curdir,
-                             path->u_name, strnlen(path->u_name, CNID_MAX_PATH_LEN));
+                                                     path->u_name, strnlen(path->u_name, CNID_MAX_PATH_LEN));
 
         if (cached && cached->dcache_rlen < 0 && ad_meta_loaded(adp)) {
             ad_store_to_cache(adp, cached);
@@ -381,7 +381,7 @@ static struct adouble *adl_lkup(struct vol *vol, struct path *path,
         adp = &ad;
         struct dir *cached = isdir ? path->d_dir
                              : dircache_search_by_name(vol, curdir,
-                                 path->u_name, strnlen(path->u_name, CNID_MAX_PATH_LEN));
+                                                       path->u_name, strnlen(path->u_name, CNID_MAX_PATH_LEN));
 
         if (ad_metadata_cached(path->u_name, (isdir ? ADFLAGS_DIR : 0),
                                adp, vol, cached, false,
@@ -508,7 +508,7 @@ static int crit_check(struct vol *vol, struct path *path)
     /* Check for filename */
     if (c1.rbitmap & (1U << DIRPBIT_LNAME)) {
         if ((size_t)(-1) == (len = convert_string(vol->v_maccharset, CH_UCS2,
-                                   path->m_name, -1, convbuf, 512))) {
+                                                  path->m_name, -1, convbuf, 512))) {
             goto crit_check_ret;
         }
 
@@ -523,7 +523,7 @@ static int crit_check(struct vol *vol, struct path *path)
 
     if (c1.rbitmap & (1U << FILPBIT_PDINFO)) {
         if ((size_t)(-1) == (len = convert_charset(CH_UTF8_MAC, CH_UCS2, CH_UTF8,
-                                   path->m_name, strlen(path->m_name), convbuf, 512, &flags))) {
+                                                   path->m_name, strlen(path->m_name), convbuf, 512, &flags))) {
             goto crit_check_ret;
         }
 

--- a/etc/afpd/desktop.c
+++ b/etc/afpd/desktop.c
@@ -898,8 +898,8 @@ char *utompath(const struct vol *vol, char *upath, cnid_t id, int utf8)
 
     /* convert charsets */
     if ((size_t) -1 == (outlen = convert_charset(vol->v_volcharset,
-                                 utf8 ? CH_UTF8_MAC : vol->v_maccharset, vol->v_maccharset, u, outlen, mpath,
-                                 sizeof(mpath), &flags))) {
+        utf8 ? CH_UTF8_MAC : vol->v_maccharset, vol->v_maccharset, u, outlen, mpath,
+        sizeof(mpath), &flags))) {
         LOG(log_error, logtype_afpd, "Conversion from %s to %s for %s (%u) failed.",
             vol->v_volcodepage, vol->v_maccodepage, u, ntohl(id));
         goto utompath_error;

--- a/etc/afpd/desktop.c
+++ b/etc/afpd/desktop.c
@@ -909,8 +909,8 @@ char *utompath(const struct vol *vol, char *upath, cnid_t id, int utf8)
 
     /* convert charsets */
     if ((size_t) -1 == (outlen = convert_charset(vol->v_volcharset,
-                                 utf8 ? CH_UTF8_MAC : vol->v_maccharset, vol->v_maccharset, u, outlen, mpath,
-                                 sizeof(mpath), &flags))) {
+                                                 utf8 ? CH_UTF8_MAC : vol->v_maccharset, vol->v_maccharset, u, outlen, mpath,
+                                                 sizeof(mpath), &flags))) {
         LOG(log_error, logtype_afpd, "Conversion from %s to %s for %s (%u) failed.",
             vol->v_volcodepage, vol->v_maccodepage, u, ntohl(id));
         goto utompath_error;

--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -1721,7 +1721,7 @@ int dircache_remove_children(const struct vol *vol, struct dir *dir)
                 /* Expand to_remove array */
                 if (remove_count >= remove_capacity) {
                     remove_capacity = remove_capacity ? remove_capacity * 2 : 16;
-                    struct dir **tmp = realloc(to_remove, remove_capacity * sizeof(struct dir*));
+                    struct dir **tmp = realloc(to_remove, remove_capacity * sizeof(struct dir *));
 
                     if (!tmp) {
                         LOG(log_error, logtype_afpd,

--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -620,7 +620,7 @@ static void arc_ensure_ghost_capacity(arc_list_t target_list)
     size_t *target_size = (target_list == ARC_B1) ? &arc_cache.b1_size :
                           &arc_cache.b2_size;
     qnode_t *victim_node = arc_ghost_trim_candidate(target_queue,
-                           arc_promoting_ghost);
+                                                    arc_promoting_ghost);
 
     if (victim_node == NULL) {
         return;
@@ -1806,7 +1806,7 @@ int dircache_add(const struct vol *vol,
     /* Add it to the main dircache hash table (both modes), keeping the node
      * so removal can delete it without a keyed lookup */
     if ((dir->d_index_node = hash_alloc_insert_node(dircache, dir,
-                             dir)) == NULL) {
+                                                    dir)) == NULL) {
         LOG(log_error, logtype_afpd,
             "dircache_add: main hash insert failed for did:%u",
             ntohl(dir->d_did));
@@ -1818,7 +1818,7 @@ int dircache_add(const struct vol *vol,
 
     /* Add it to the did/name index (both modes) */
     if ((dir->d_didname_node = hash_alloc_insert_node(index_didname, dir,
-                               dir)) == NULL) {
+                                                      dir)) == NULL) {
         /* insert failed; Rollback main hash to keep counts consistent */
         LOG(log_error, logtype_afpd,
             "dircache_add: didname hash insert failed for did:%u, rolling back",
@@ -2160,7 +2160,7 @@ int dircache_reindex_didname(const struct vol *vol, struct dir *dir)
     /* Caller has already called dircache_remove(vol, dir, DIDNAME_INDEX)
      * and updated dir->d_pdid / dir->d_u_name. Re-insert with new key. */
     if ((dir->d_didname_node = hash_alloc_insert_node(index_didname, dir,
-                               dir)) == NULL) {
+                                                      dir)) == NULL) {
         LOG(log_error, logtype_afpd,
             "dircache_reindex_didname: re-insert failed for did:%u",
             ntohl(dir->d_did));

--- a/etc/afpd/dircache.h
+++ b/etc/afpd/dircache.h
@@ -47,7 +47,7 @@ extern void       dircache_remove(const struct vol *, struct dir *, int flag);
 extern struct dir *dircache_search_by_did(const struct vol *vol, cnid_t did);
 extern struct dir *dircache_lookup_parent(const struct vol *vol, cnid_t did);
 extern struct dir *dircache_search_by_name(const struct vol *,
-        const struct dir *dir, char *name, size_t len);
+                                           const struct dir *dir, char *name, size_t len);
 
 extern void       dircache_dump(void);
 extern void       log_dircache_stat(void);
@@ -55,13 +55,13 @@ extern unsigned int dircache_resolve_size(int reqsize);
 extern void       dircache_reset_validation_counter(void);
 extern void       dircache_report_invalid_entry(struct dir *dir);
 extern int        dircache_remove_children(const struct vol *vol,
-        struct dir *dir);
+                                           struct dir *dir);
 extern int        dircache_reindex_didname(const struct vol *vol,
-        struct dir *dir);
+                                           struct dir *dir);
 extern void       dircache_promote(struct dir *dir);
 extern void       process_cache_hints(AFPObj *obj);
 extern void       dircache_remove_children_defer(const struct vol *vol,
-        struct dir *dir);
+                                                 struct dir *dir);
 extern void       dircache_flush_deferred_for_vol(uint16_t vid);
 extern int        dircache_has_deferred_work(void);
 extern int        dircache_process_deferred_chain(void);

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -2008,7 +2008,7 @@ int movecwd(const struct vol *vol, struct dir *dir)
     /* Defensive NULL checks - return error instead of asserting */
     if (vol == NULL || dir == NULL) {
         LOG(log_error, logtype_afpd, "movecwd: NULL parameter (vol:%p, dir:%p)",
-            (void*)vol, (void*)dir);
+            (void *)vol, (void *)dir);
         afp_errno = AFPERR_PARAM;
         return -1;
     }

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -520,10 +520,10 @@ static struct dir *dirlookup_internal(const struct vol *vol, cnid_t did,
  * @returns Retried struct dir from CNID, or NULL on failure
  */
 static struct dir *dirlookup_internal_retry(const struct vol *vol,
-        cnid_t did,
-        int strict,
-        bstring *fullpath_ptr,
-        char **upath_ptr)
+                                            cnid_t did,
+                                            int strict,
+                                            bstring *fullpath_ptr,
+                                            char **upath_ptr)
 {
     LOG(log_debug, logtype_afpd,
         "dirlookup_internal(did:%u): stat failed, cleaning stale entries, retrying via CNID",
@@ -2118,7 +2118,7 @@ int movecwd(const struct vol *vol, struct dir *dir)
     /* Defensive NULL checks - return error instead of asserting */
     if (vol == NULL || dir == NULL) {
         LOG(log_error, logtype_afpd, "movecwd: NULL parameter (vol:%p, dir:%p)",
-            (void*)vol, (void*)dir);
+            (void *)vol, (void *)dir);
         afp_errno = AFPERR_PARAM;
         /* Callers read errno right after this returns */
         errno = EINVAL;
@@ -2850,7 +2850,7 @@ int setdirparams(struct vol *vol, struct path *path, uint16_t d_bitmap,
                 }
 
                 if ((bshort & htons(ATTRBIT_INVISIBLE)) != (oshort & htons(
-                            ATTRBIT_INVISIBLE))) {
+                                                                ATTRBIT_INVISIBLE))) {
                     change_parent_mdate = 1;
                 }
 

--- a/etc/afpd/extattrs.c
+++ b/etc/afpd/extattrs.c
@@ -152,7 +152,7 @@ int afp_listextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
         ad_available = 1;
         size_t uname_len = strnlen(uname, CNID_MAX_PATH_LEN);
         struct dir *cached = dircache_search_by_name(vol, curdir,
-                             uname, uname_len);
+            uname, uname_len);
 
         /* If cache AD is unset, store fork's live adouble */
         if (cached && cached->dcache_rlen < 0) {

--- a/etc/afpd/extattrs.c
+++ b/etc/afpd/extattrs.c
@@ -156,7 +156,7 @@ int afp_listextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
         ad_available = 1;
         size_t uname_len = strnlen(uname, CNID_MAX_PATH_LEN);
         struct dir *cached = dircache_search_by_name(vol, curdir,
-                             uname, uname_len);
+                                                     uname, uname_len);
 
         if (cached && cached->dcache_rlen < 0 && ad_meta_loaded(adp)) {
             ad_store_to_cache(adp, cached);

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -835,7 +835,7 @@ int getfilparams(const AFPObj *obj, struct vol *vol, uint16_t bitmap,
             /* Fork-owned adouble — use directly, skip cache.
              * Opportunistically populate cache if not yet loaded. */
             struct dir *cachedfile = dircache_search_by_name(vol, dir,
-                                     upath, upath_len);
+                upath, upath_len);
 
             /* If cache AD is unset, store fork's live adouble */
             if (cachedfile && cachedfile->dcache_rlen < 0) {
@@ -844,7 +844,7 @@ int getfilparams(const AFPObj *obj, struct vol *vol, uint16_t bitmap,
         } else {
             /* No open fork — use ad_metadata_cached() */
             struct dir *cachedfile = dircache_search_by_name(vol, dir,
-                                     upath, upath_len);
+                upath, upath_len);
             ad_init(&ad, vol);
 
             if (ad_metadata_cached(upath, flags, &ad, vol, cachedfile, false,
@@ -1017,7 +1017,7 @@ createfile_iderr:
      * Eliminates per-file getxattr on first enumerate after creation. */
     {
         struct dir *cachedfile = dircache_search_by_name(vol, dir,
-                                 upath, (int)upath_len);
+            upath, (int)upath_len);
 
         if (!cachedfile && id != CNID_INVALID) {
             bstring fullpath = bstrcpy(dir->d_fullpath);
@@ -1310,7 +1310,7 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
                 {
                     size_t upath_slen = strnlen(upath, CNID_MAX_PATH_LEN);
                     struct dir *stale = dircache_search_by_name(vol, curdir,
-                                        upath, upath_slen);
+                        upath, upath_slen);
 
                     if (stale) {
                         dir_remove(vol, stale, 0);
@@ -1560,7 +1560,7 @@ setfilparam_done:
 
     if (!symlinked && upath) {
         cached = dircache_search_by_name(vol, curdir, upath, strnlen(upath,
-                                         CNID_MAX_PATH_LEN));
+            CNID_MAX_PATH_LEN));
     }
 
     if (isad) {
@@ -1715,7 +1715,7 @@ size_t mtoUTF8(const struct vol *vol, const char *src, size_t srclen,
     size_t    outlen;
 
     if ((size_t) -1 == (outlen = convert_string(vol->v_maccharset, CH_UTF8_MAC, src,
-                                 srclen, dest, destlen))) {
+        srclen, dest, destlen))) {
         return -1;
     }
 

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -81,14 +81,14 @@ static const uint8_t old_ufinderi[] = {
  * memoized d_cached first (strnlen and hash walk skipped on a hit), fall
  * back to the by-name search, and memoize the result for later consumers. */
 static struct dir *path_resolve_cached_file(const struct vol *vol,
-        const struct dir *dir, struct path *path)
+                                            const struct dir *dir, struct path *path)
 {
     struct dir *cached = path_cached_file(path);
 
     if (cached == NULL && path->u_name != NULL) {
         cached = dircache_search_by_name(vol, dir, path->u_name,
                                          strnlen(path->u_name,
-                                             CNID_MAX_PATH_LEN));
+                                                 CNID_MAX_PATH_LEN));
         path->d_cached = cached;
     }
 
@@ -1188,7 +1188,7 @@ createfile_iderr:
      * Eliminates per-file getxattr on first enumerate after creation. */
     {
         struct dir *cachedfile = dircache_search_by_name(vol, dir,
-                                 upath, (int)upath_len);
+                                                         upath, (int)upath_len);
 
         if (!cachedfile && id != CNID_INVALID) {
             bstring fullpath = fullpath_join(dir->d_fullpath, upath);
@@ -1221,7 +1221,7 @@ createfile_iderr:
     /* upath is a bare filename and curdir is its parent. */
     char event_path[MAXPATHLEN + 1];
     const char *created_path = dir_event_path(event_path, sizeof(event_path),
-                               curdir, upath);
+                                              curdir, upath);
 #endif
 #ifdef WITH_FCE
     fce_register(obj, FCE_FILE_CREATE, created_path, NULL);
@@ -1484,7 +1484,7 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
                 {
                     size_t upath_slen = strnlen(upath, CNID_MAX_PATH_LEN);
                     struct dir *stale = dircache_search_by_name(vol, curdir,
-                                        upath, upath_slen);
+                                                                upath, upath_slen);
 
                     if (stale) {
                         dir_remove(vol, stale, 0);
@@ -1626,7 +1626,7 @@ int setfilparams(const AFPObj *obj, struct vol *vol,
             }
 
             if ((bshort & htons(ATTRBIT_INVISIBLE)) != (oshort & htons(
-                        ATTRBIT_INVISIBLE))) {
+                                                            ATTRBIT_INVISIBLE))) {
                 change_parent_mdate = 1;
             }
 
@@ -1734,7 +1734,7 @@ setfilparam_done:
 
     if (!symlinked && upath) {
         cached = dircache_search_by_name(vol, curdir, upath, strnlen(upath,
-                                         CNID_MAX_PATH_LEN));
+            CNID_MAX_PATH_LEN));
     }
 
     if (isad) {
@@ -1889,7 +1889,7 @@ size_t mtoUTF8(const struct vol *vol, const char *src, size_t srclen,
     size_t    outlen;
 
     if ((size_t) -1 == (outlen = convert_string(vol->v_maccharset, CH_UTF8_MAC, src,
-                                 srclen, dest, destlen))) {
+                                                srclen, dest, destlen))) {
         return -1;
     }
 

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -174,7 +174,7 @@ int afp_getfildirparams(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
         *(rbuf + 2 * sizeof(uint16_t)) = (char) FILDIRBIT_ISDIR;
     } else {
         if (fbitmap && AFP_OK != (ret = getfilparams(obj, vol, fbitmap, s_path, curdir,
-                                        rbuf + 3 * sizeof(uint16_t), &buflen, 0))) {
+            rbuf + 3 * sizeof(uint16_t), &buflen, 0))) {
             return ret;
         }
 
@@ -327,7 +327,7 @@ static int moveandrename(const AFPObj *obj,
         }
 
         size_t oldunixname_len = oldunixname ? strnlen(oldunixname,
-                                 CNID_MAX_PATH_LEN) : 0;
+            CNID_MAX_PATH_LEN) : 0;
         AFP_CNID_START("cnid_get");
         id = cnid_get(vol->v_cdb, sdir->d_did, oldunixname, oldunixname_len);
         AFP_CNID_DONE();

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -175,7 +175,7 @@ int afp_getfildirparams(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
         *(rbuf + 2 * sizeof(uint16_t)) = (char) FILDIRBIT_ISDIR;
     } else {
         if (fbitmap && AFP_OK != (ret = getfilparams(obj, vol, fbitmap, s_path, curdir,
-                                        rbuf + 3 * sizeof(uint16_t), &buflen, 0))) {
+                                                     rbuf + 3 * sizeof(uint16_t), &buflen, 0))) {
             return ret;
         }
 
@@ -328,7 +328,7 @@ static int moveandrename(const AFPObj *obj,
         }
 
         size_t oldunixname_len = oldunixname ? strnlen(oldunixname,
-                                 CNID_MAX_PATH_LEN) : 0;
+                                                       CNID_MAX_PATH_LEN) : 0;
         AFP_CNID_START("cnid_get");
         id = cnid_get(vol->v_cdb, sdir->d_did, oldunixname, oldunixname_len);
         AFP_CNID_DONE();
@@ -956,7 +956,7 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 #if defined(WITH_FCE) || defined(WITH_SPOTLIGHT)
             char event_path[MAXPATHLEN + 1];
             const char *deleted_dir = dir_event_path(event_path,
-                                      sizeof(event_path), curdir, upath);
+                                                     sizeof(event_path), curdir, upath);
 #endif
 #ifdef WITH_FCE
             fce_register(obj, FCE_DIR_DELETE, deleted_dir, NULL);
@@ -980,8 +980,8 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
                  * the deleted directory's parent. */
                 char event_path[MAXPATHLEN + 1];
                 const char *deleted_dir = dir_event_path(event_path,
-                                          sizeof(event_path), curdir,
-                                          cfrombstr(dname));
+                                                         sizeof(event_path), curdir,
+                                                         cfrombstr(dname));
 #endif
 #ifdef WITH_FCE
                 fce_register(obj, FCE_DIR_DELETE, deleted_dir, NULL);
@@ -1052,7 +1052,7 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 #if defined(WITH_FCE) || defined(WITH_SPOTLIGHT)
                 char event_path[MAXPATHLEN + 1];
                 const char *deleted_file = dir_event_path(event_path,
-                                           sizeof(event_path), curdir, upath);
+                                                          sizeof(event_path), curdir, upath);
 #endif
 #ifdef WITH_FCE
                 fce_register(obj, FCE_FILE_DELETE, deleted_file, NULL);

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -378,7 +378,7 @@ static int fork_setmode(const AFPObj *obj _U_, struct adouble *adp, int eid,
 
     if (obj->options.flags & OPTION_SHARE_RESERV) {
         shmd.f_access = (access & OPENACC_RD ? F_RDACC : 0) | (access & OPENACC_WR ?
-                        F_WRACC : 0);
+            F_WRACC : 0);
 
         if (shmd.f_access == 0)
             /* we must give an access mode, otherwise fcntl will complain */
@@ -828,7 +828,7 @@ static void rfork_invalidate_for_ofork(const struct vol *vol,
     if (parentdir) {
         char *name = of_name(ofork);
         struct dir *cached = dircache_search_by_name(vol, parentdir,
-                             name, strnlen(name, MAXPATHLEN));
+            name, strnlen(name, MAXPATHLEN));
 
         if (cached) {
             dir_modify(vol, cached, &(struct dir_modify_args) {
@@ -969,7 +969,7 @@ int afp_setforkparams(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf _U_,
         }
 
         err = ad_rtruncate(ofork->of_ad, mtoupath(ofork->of_vol, of_name(ofork),
-                           ofork->of_did, utf8_encoding(obj)), size);
+            ofork->of_did, utf8_encoding(obj)), size);
 
         if (st_size > size) {
             ad_tmplock(ofork->of_ad, eid, ADLOCK_CLR, size, st_size - size,

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -417,7 +417,7 @@ static int fork_setmode(const AFPObj *obj _U_, struct adouble *adp, int eid,
 
     if (obj->options.flags & OPTION_SHARE_RESERV) {
         shmd.f_access = (access & OPENACC_RD ? F_RDACC : 0) | (access & OPENACC_WR ?
-                        F_WRACC : 0);
+                                                               F_WRACC : 0);
 
         if (shmd.f_access == 0)
             /* we must give an access mode, otherwise fcntl will complain */
@@ -866,7 +866,7 @@ static void rfork_invalidate_for_ofork(const struct vol *vol,
     if (parentdir) {
         char *name = of_name(ofork);
         struct dir *cached = dircache_search_by_name(vol, parentdir,
-                             name, strnlen(name, MAXPATHLEN));
+                                                     name, strnlen(name, MAXPATHLEN));
 
         if (cached) {
             dir_modify(vol, cached, &(struct dir_modify_args) {
@@ -1007,7 +1007,7 @@ int afp_setforkparams(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf _U_,
         }
 
         err = ad_rtruncate(ofork->of_ad, mtoupath(ofork->of_vol, of_name(ofork),
-                           ofork->of_did, utf8_encoding(obj)), size);
+                                                  ofork->of_did, utf8_encoding(obj)), size);
 
         if (st_size > size) {
             ad_tmplock(ofork->of_ad, eid, ADLOCK_CLR, size, st_size - size,

--- a/etc/afpd/mangle.c
+++ b/etc/afpd/mangle.c
@@ -83,7 +83,7 @@ static char *demangle_checks(const struct vol *vol, char *uname,
     flags = CONV_IGNORE | CONV_UNESCAPEHEX;
 
     if ((size_t) -1 == (len = convert_charset(vol->v_volcharset, vol->v_maccharset,
-                              0, uname, strlen(uname), buffer, sizeof(buffer), &flags))) {
+        0, uname, strlen(uname), buffer, sizeof(buffer), &flags))) {
         return mfilename;
     }
 
@@ -106,7 +106,7 @@ static char *demangle_checks(const struct vol *vol, char *uname,
         if (len) {
             /* convert the buffer to UTF8_MAC ... */
             if ((size_t) -1 == (len = convert_charset(vol->v_maccharset, CH_UTF8_MAC, 0,
-                                      buffer, len, buffer, sizeof(buffer), &flags))) {
+                buffer, len, buffer, sizeof(buffer), &flags))) {
                 return mfilename;
             }
 
@@ -130,7 +130,7 @@ static char *demangle_checks(const struct vol *vol, char *uname,
             /* characters have to match ... again a possible race FIXME			  */
 
             if ((size_t) -1 == (len = convert_charset(vol->v_volcharset, CH_UTF8_MAC, 0,
-                                      uname, strlen(uname), buffer, sizeof(buffer), &flags))) {
+                uname, strlen(uname), buffer, sizeof(buffer), &flags))) {
                 return mfilename;
             }
 

--- a/etc/afpd/mangle.c
+++ b/etc/afpd/mangle.c
@@ -83,7 +83,7 @@ static char *demangle_checks(const struct vol *vol, char *uname,
     flags = CONV_IGNORE | CONV_UNESCAPEHEX;
 
     if ((size_t) -1 == (len = convert_charset(vol->v_volcharset, vol->v_maccharset,
-                              0, uname, strlen(uname), buffer, sizeof(buffer), &flags))) {
+                                              0, uname, strlen(uname), buffer, sizeof(buffer), &flags))) {
         return mfilename;
     }
 
@@ -106,7 +106,7 @@ static char *demangle_checks(const struct vol *vol, char *uname,
         if (len) {
             /* convert the buffer to UTF8_MAC ... */
             if ((size_t) -1 == (len = convert_charset(vol->v_maccharset, CH_UTF8_MAC, 0,
-                                      buffer, len, buffer, sizeof(buffer), &flags))) {
+                                                      buffer, len, buffer, sizeof(buffer), &flags))) {
                 return mfilename;
             }
 
@@ -130,7 +130,7 @@ static char *demangle_checks(const struct vol *vol, char *uname,
             /* characters have to match ... again a possible race FIXME			  */
 
             if ((size_t) -1 == (len = convert_charset(vol->v_volcharset, CH_UTF8_MAC, 0,
-                                      uname, strlen(uname), buffer, sizeof(buffer), &flags))) {
+                                                      uname, strlen(uname), buffer, sizeof(buffer), &flags))) {
                 return mfilename;
             }
 

--- a/etc/afpd/messages.c
+++ b/etc/afpd/messages.c
@@ -56,7 +56,7 @@ void readmessage(AFPObj *obj)
     static int c;
     uint32_t maxmsgsize;
     maxmsgsize = (obj->proto == AFPPROTO_DSI) ? MIN(MAX(obj->dsi->attn_quantum,
-                 MAXMESGSIZE), MAXPATHLEN) : MAXMESGSIZE;
+        MAXMESGSIZE), MAXPATHLEN) : MAXMESGSIZE;
     i = 0;
     /* Construct file name SERVERTEXT/message.[pid] */
     snprintf(filename, sizeof(filename), "%s/message.%" PRIiMAX,
@@ -118,7 +118,7 @@ int afp_getsrvrmesg(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf,
     int utf8 = 0;
     *rbuflen = 0;
     msgsize = (obj->proto == AFPPROTO_DSI) ? MAX(obj->dsi->attn_quantum,
-              MAXMESGSIZE) : MAXMESGSIZE;
+        MAXMESGSIZE) : MAXMESGSIZE;
     memcpy(&type, ibuf + 2, sizeof(type));
     memcpy(&bitmap, ibuf + 4, sizeof(bitmap));
     message = servermesg;
@@ -169,8 +169,8 @@ int afp_getsrvrmesg(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf,
 
     if (msglen) {
         if ((size_t) -1 == (outlen = convert_string(obj->options.unixcharset,
-                                     utf8 ? CH_UTF8_MAC : obj->options.maccharset,
-                                     message, msglen, localized_message, msgsize))) {
+            utf8 ? CH_UTF8_MAC : obj->options.maccharset,
+            message, msglen, localized_message, msgsize))) {
             memcpy(rbuf + (utf8 ? 2 : 1), message, msglen); /*FIXME*/
             outlen = msglen;
         } else {

--- a/etc/afpd/messages.c
+++ b/etc/afpd/messages.c
@@ -56,7 +56,7 @@ void readmessage(AFPObj *obj)
     static int c;
     uint32_t maxmsgsize;
     maxmsgsize = (obj->proto == AFPPROTO_DSI) ? MIN(MAX(obj->dsi->attn_quantum,
-                 MAXMESGSIZE), MAXPATHLEN) : MAXMESGSIZE;
+                                                        MAXMESGSIZE), MAXPATHLEN) : MAXMESGSIZE;
     i = 0;
     /* Construct file name SERVERTEXT/message.[pid] */
     snprintf(filename, sizeof(filename), "%s/message.%" PRIiMAX,
@@ -118,7 +118,7 @@ int afp_getsrvrmesg(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf,
     int utf8 = 0;
     *rbuflen = 0;
     msgsize = (obj->proto == AFPPROTO_DSI) ? MAX(obj->dsi->attn_quantum,
-              MAXMESGSIZE) : MAXMESGSIZE;
+                                                 MAXMESGSIZE) : MAXMESGSIZE;
     memcpy(&type, ibuf + 2, sizeof(type));
     memcpy(&bitmap, ibuf + 4, sizeof(bitmap));
     message = servermesg;
@@ -169,8 +169,8 @@ int afp_getsrvrmesg(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf,
 
     if (msglen) {
         if ((size_t) -1 == (outlen = convert_string(obj->options.unixcharset,
-                                     utf8 ? CH_UTF8_MAC : obj->options.maccharset,
-                                     message, msglen, localized_message, msgsize))) {
+                                                    utf8 ? CH_UTF8_MAC : obj->options.maccharset,
+                                                    message, msglen, localized_message, msgsize))) {
             memcpy(rbuf + (utf8 ? 2 : 1), message, msglen); /*FIXME*/
             outlen = msglen;
         } else {

--- a/etc/afpd/quota.c
+++ b/etc/afpd/quota.c
@@ -738,7 +738,7 @@ int uquota_getvolspace(const AFPObj *obj, struct vol *vol, VolSpace *bfree,
         *btotal = *bfree = ~((VolSpace) 0);
     } else if (overquota(&dqblk)) {
         if (tobytes(dqblk.dqb_curblocks, this_bsize) > tobytes(dqblk.dqb_bsoftlimit,
-                this_bsize)) {
+                                                               this_bsize)) {
             *btotal = tobytes(dqblk.dqb_curblocks, this_bsize);
             *bfree = 0;
         } else {

--- a/etc/afpd/spotlight.c
+++ b/etc/afpd/spotlight.c
@@ -437,7 +437,7 @@ static bool create_result_handle(slq_t *slq)
     }
 
     query_results->cnids->ca_cnids = talloc_zero(query_results->cnids,
-                                     DALLOC_CTX);
+        DALLOC_CTX);
 
     if (query_results->cnids->ca_cnids == NULL) {
         return false;
@@ -1135,7 +1135,7 @@ static int sl_rpc_storeAttributesForOIDArray(const AFPObj *obj _U_,
         ts[1] = ts[0];
         utimensat(AT_FDCWD, path, ts, 0);
     } else if ((sl_time = dalloc_value_for_key(query, "DALLOC_CTX", 0, "DALLOC_CTX",
-                          1, "DALLOC_CTX", 1, "kMDItemLastUsedDate", "sl_time_t"))) {
+        1, "DALLOC_CTX", 1, "kMDItemLastUsedDate", "sl_time_t"))) {
         struct timespec ts[2] = {{0}};
         ts[0].tv_sec  = sl_time->tv_sec;
         ts[0].tv_nsec = sl_time->tv_usec * 1000;

--- a/etc/afpd/spotlight.c
+++ b/etc/afpd/spotlight.c
@@ -553,7 +553,7 @@ static bool create_result_handle(slq_t *slq)
     }
 
     query_results->cnids->ca_cnids = talloc_zero(query_results->cnids,
-                                     DALLOC_CTX);
+                                                 DALLOC_CTX);
 
     if (query_results->cnids->ca_cnids == NULL) {
         return false;
@@ -848,9 +848,9 @@ static bool localsearch_backend_active(const AFPObj *obj)
  ******************************************************************************/
 
 static int sl_rpc_fetchPropertiesForContext(const AFPObj *obj _U_,
-        const DALLOC_CTX *query _U_,
-        DALLOC_CTX *reply,
-        const struct vol *v)
+                                            const DALLOC_CTX *query _U_,
+                                            DALLOC_CTX *reply,
+                                            const struct vol *v)
 {
     EC_INIT;
     char *s;
@@ -1226,9 +1226,9 @@ EC_CLEANUP: {
 }
 
 static int sl_rpc_fetchQueryResultsForContext(const AFPObj *obj _U_,
-        const DALLOC_CTX *query,
-        DALLOC_CTX *reply,
-        const struct vol *v _U_)
+                                              const DALLOC_CTX *query,
+                                              DALLOC_CTX *reply,
+                                              const struct vol *v _U_)
 {
     EC_INIT;
     slq_t *slq = NULL;
@@ -1314,9 +1314,9 @@ EC_CLEANUP:
 }
 
 static int sl_rpc_storeAttributesForOIDArray(const AFPObj *obj _U_,
-        const DALLOC_CTX *query,
-        DALLOC_CTX *reply,
-        const struct vol *vol)
+                                             const DALLOC_CTX *query,
+                                             DALLOC_CTX *reply,
+                                             const struct vol *vol)
 {
     EC_INIT;
     uint64_t uint64;
@@ -1357,7 +1357,7 @@ static int sl_rpc_storeAttributesForOIDArray(const AFPObj *obj _U_,
         ts[1] = ts[0];
         utimensat(AT_FDCWD, path, ts, 0);
     } else if ((sl_time = dalloc_value_for_key(query, "DALLOC_CTX", 0, "DALLOC_CTX",
-                          1, "DALLOC_CTX", 1, "kMDItemLastUsedDate", "sl_time_t"))) {
+                                               1, "DALLOC_CTX", 1, "kMDItemLastUsedDate", "sl_time_t"))) {
         struct timespec ts[2] = {{0}};
         ts[0].tv_sec  = sl_time->tv_sec;
         ts[0].tv_nsec = sl_time->tv_usec * 1000;
@@ -1374,7 +1374,7 @@ EC_CLEANUP:
 }
 
 static int sl_rpc_fetchAttributeNamesForOIDArray(const AFPObj *obj _U_,
-        const DALLOC_CTX *query, DALLOC_CTX *reply, const struct vol *vol _U_)
+                                                 const DALLOC_CTX *query, DALLOC_CTX *reply, const struct vol *vol _U_)
 {
     EC_INIT;
     uint64_t uint64;
@@ -1420,7 +1420,7 @@ EC_CLEANUP:
 }
 
 static int sl_rpc_fetchAttributesForOIDArray(AFPObj *obj _U_,
-        const DALLOC_CTX *query, DALLOC_CTX *reply, const struct vol *vol)
+                                             const DALLOC_CTX *query, DALLOC_CTX *reply, const struct vol *vol)
 {
     EC_INIT;
     uint64_t uint64;

--- a/etc/afpd/spotlight_marshalling.c
+++ b/etc/afpd/spotlight_marshalling.c
@@ -231,7 +231,7 @@ static int sl_pack_bool(sl_bool_t bl, char *buf, int offset)
 {
     EC_INIT;
     EC_ZERO(slvalc(buf, offset, MAX_SLQ_DAT, sl_pack_tag(SQ_TYPE_BOOL, 1,
-                   bl ? 1 : 0)));
+            bl ? 1 : 0)));
 EC_CLEANUP:
 
     if (ret != 0) {
@@ -305,7 +305,7 @@ static int sl_pack_CNID(sl_cnids_t *cnids, char *buf, int offset, char *toc_buf,
     EC_ZERO(slvalc(toc_buf, *toc_idx * 8, MAX_SLQ_TOC,
                    sl_pack_tag(SQ_CPX_TYPE_CNIDS, (offset + SL_OFFSET_DELTA) / 8, 0)));
     EC_ZERO(slvalc(buf, offset, MAX_SLQ_DAT, sl_pack_tag(SQ_TYPE_COMPLEX, 1,
-                   *toc_idx + 1)));
+            *toc_idx + 1)));
     *toc_idx += 1;
     offset += 8;
     len = cnid_count + 1;
@@ -320,7 +320,7 @@ static int sl_pack_CNID(sl_cnids_t *cnids, char *buf, int offset, char *toc_buf,
 
     if (cnid_count > 0) {
         EC_ZERO(slvalc(buf, offset, MAX_SLQ_DAT, sl_pack_tag(cnids->ca_unkn1,
-                       cnid_count, cnids->ca_context)));
+                cnid_count, cnids->ca_context)));
         offset += 8;
 
         for (int i = 0; i < cnid_count; i++) {
@@ -348,7 +348,7 @@ static int sl_pack_array(sl_array_t *array, char *buf, int offset,
     EC_ZERO(slvalc(toc_buf, *toc_idx * 8, MAX_SLQ_TOC,
                    sl_pack_tag(SQ_CPX_TYPE_ARRAY, octets, count)));
     EC_ZERO(slvalc(buf, offset, MAX_SLQ_DAT, sl_pack_tag(SQ_TYPE_COMPLEX, 1,
-                   *toc_idx + 1)));
+            *toc_idx + 1)));
     *toc_idx += 1;
     offset += 8;
     EC_NEG1(offset = sl_pack_loop(array, buf, offset, toc_buf, toc_idx));
@@ -372,7 +372,7 @@ static int sl_pack_dict(sl_array_t *dict, char *buf, int offset, char *toc_buf,
                                (offset + SL_OFFSET_DELTA) / 8,
                                talloc_array_length(dict->dd_talloc_array))));
     EC_ZERO(slvalc(buf, offset, MAX_SLQ_DAT, sl_pack_tag(SQ_TYPE_COMPLEX, 1,
-                   *toc_idx + 1)));
+            *toc_idx + 1)));
     *toc_idx += 1;
     offset += 8;
     EC_NEG1(offset = sl_pack_loop(dict, buf, offset, toc_buf, toc_idx));
@@ -392,7 +392,7 @@ static int sl_pack_filemeta(sl_filemeta_t *fm, char *buf, int offset,
     int fmlen;                  /* lenght of filemeta */
     int saveoff = offset;
     EC_ZERO(slvalc(buf, offset, MAX_SLQ_DAT, sl_pack_tag(SQ_TYPE_COMPLEX, 1,
-                   *toc_idx + 1)));
+            *toc_idx + 1)));
     offset += 16;
     EC_NEG1(fmlen = sl_pack(fm, buf + offset));
     /* Check for empty filemeta array, if it's only 40 bytes, it's only the header but no content */
@@ -406,7 +406,7 @@ static int sl_pack_filemeta(sl_filemeta_t *fm, char *buf, int offset,
 
     /* 3rd parameter of sl_pack_tag has unknown meaning, but always 8 */
     EC_ZERO(slvalc(buf, saveoff + 8, MAX_SLQ_DAT, sl_pack_tag(SQ_TYPE_DATA,
-                   (fmlen / 8) + 1, 8)));
+            (fmlen / 8) + 1, 8)));
     EC_ZERO(slvalc(toc_buf, *toc_idx * 8, MAX_SLQ_TOC,
                    sl_pack_tag(SQ_CPX_TYPE_FILEMETA, (saveoff + SL_OFFSET_DELTA) / 8, fmlen / 8)));
     *toc_idx += 1;
@@ -437,11 +437,11 @@ static int sl_pack_string(char *s, char *buf, int offset, char *toc_buf,
                    sl_pack_tag(SQ_CPX_TYPE_STRING, (offset + SL_OFFSET_DELTA) / 8,
                                used_in_last_octet)));
     EC_ZERO(slvalc(buf, offset, MAX_SLQ_DAT, sl_pack_tag(SQ_TYPE_COMPLEX, 1,
-                   *toc_idx + 1)));
+            *toc_idx + 1)));
     *toc_idx += 1;
     offset += 8;
     EC_ZERO(slvalc(buf, offset, MAX_SLQ_DAT, sl_pack_tag(SQ_TYPE_DATA, octets + 1,
-                   used_in_last_octet)));
+            used_in_last_octet)));
     offset += 8;
 
     if (offset + octets * 8 > MAX_SLQ_DAT) {
@@ -874,7 +874,7 @@ static int sl_unpack_cpx(DALLOC_CTX *query,
             p = dalloc_strndup(query, buf + offset + 8, slen);
         } else {
             unicode_encoding = spotlight_get_utf16_string_encoding(buf, offset + 8, slen,
-                               encoding);
+                encoding);
             mark_exists = (unicode_encoding & SL_ENC_UTF_16);
 
             if (unicode_encoding & SL_ENC_BIG_ENDIAN) {
@@ -889,10 +889,10 @@ static int sl_unpack_cpx(DALLOC_CTX *query,
 
             size_t tmp_len;
             EC_NEG1(tmp_len = convert_string_allocate(CH_UCS2,
-                              CH_UTF8,
-                              buf + offset + (mark_exists ? 10 : 8),
-                              slen,
-                              &tmp));
+                CH_UTF8,
+                buf + offset + (mark_exists ? 10 : 8),
+                slen,
+                &tmp));
             p = dalloc_strndup(query, tmp, tmp_len);
             free(tmp);
         }
@@ -1129,7 +1129,7 @@ int sl_pack(DALLOC_CTX *query, char *buf)
     EC_ZERO(sivalc(buf, 8, MAX_SLQ_DAT, len / 8 + 1 + toc_index + 1));
     EC_ZERO(sivalc(buf, 12, MAX_SLQ_DAT, len / 8 + 1));
     EC_ZERO(slvalc(toc_buf, 0, MAX_SLQ_TOC, sl_pack_tag(SQ_TYPE_TOC, toc_index + 1,
-                   0)));
+            0)));
 
     if ((16 + len + ((toc_index + 1) * 8)) >= MAX_SLQ_DAT) {
         EC_FAIL;

--- a/etc/afpd/spotlight_marshalling.c
+++ b/etc/afpd/spotlight_marshalling.c
@@ -163,7 +163,7 @@ static int slvalc(char *buf, off_t off, off_t maxoff, uint64_t val)
  * @returns If there is no byte order mark, -1 is returned.
  */
 static uint spotlight_get_utf16_string_encoding(const char *buf, int offset,
-        int query_length, uint encoding)
+                                                int query_length, uint encoding)
 {
     uint utf16_encoding;
     /* Assumed encoding in absence of a bom is little endian */
@@ -232,7 +232,7 @@ static int sl_pack_bool(sl_bool_t bl, char *buf, int offset, off_t maxoff)
 {
     EC_INIT;
     EC_ZERO(slvalc(buf, offset, maxoff, sl_pack_tag(SQ_TYPE_BOOL, 1,
-                   bl ? 1 : 0)));
+                                                    bl ? 1 : 0)));
 EC_CLEANUP:
 
     if (ret != 0) {
@@ -306,7 +306,7 @@ static int sl_pack_CNID(sl_cnids_t *cnids, char *buf, int offset, off_t maxoff,
     EC_ZERO(slvalc(toc_buf, *toc_idx * 8, MAX_SLQ_TOC,
                    sl_pack_tag(SQ_CPX_TYPE_CNIDS, (offset + SL_OFFSET_DELTA) / 8, 0)));
     EC_ZERO(slvalc(buf, offset, maxoff, sl_pack_tag(SQ_TYPE_COMPLEX, 1,
-                   *toc_idx + 1)));
+                                                    *toc_idx + 1)));
     *toc_idx += 1;
     offset += 8;
     len = cnid_count + 1;
@@ -321,7 +321,7 @@ static int sl_pack_CNID(sl_cnids_t *cnids, char *buf, int offset, off_t maxoff,
 
     if (cnid_count > 0) {
         EC_ZERO(slvalc(buf, offset, maxoff, sl_pack_tag(cnids->ca_unkn1,
-                       cnid_count, cnids->ca_context)));
+                                                        cnid_count, cnids->ca_context)));
         offset += 8;
 
         for (int i = 0; i < cnid_count; i++) {
@@ -349,7 +349,7 @@ static int sl_pack_array(sl_array_t *array, char *buf, int offset, off_t maxoff,
     EC_ZERO(slvalc(toc_buf, *toc_idx * 8, MAX_SLQ_TOC,
                    sl_pack_tag(SQ_CPX_TYPE_ARRAY, octets, count)));
     EC_ZERO(slvalc(buf, offset, maxoff, sl_pack_tag(SQ_TYPE_COMPLEX, 1,
-                   *toc_idx + 1)));
+                                                    *toc_idx + 1)));
     *toc_idx += 1;
     offset += 8;
     EC_NEG1(offset = sl_pack_loop(array, buf, offset, maxoff, toc_buf, toc_idx));
@@ -373,7 +373,7 @@ static int sl_pack_dict(sl_array_t *dict, char *buf, int offset, off_t maxoff,
                                (offset + SL_OFFSET_DELTA) / 8,
                                talloc_array_length(dict->dd_talloc_array))));
     EC_ZERO(slvalc(buf, offset, maxoff, sl_pack_tag(SQ_TYPE_COMPLEX, 1,
-                   *toc_idx + 1)));
+                                                    *toc_idx + 1)));
     *toc_idx += 1;
     offset += 8;
     EC_NEG1(offset = sl_pack_loop(dict, buf, offset, maxoff, toc_buf, toc_idx));
@@ -393,7 +393,7 @@ static int sl_pack_filemeta(sl_filemeta_t *fm, char *buf, int offset,
     int fmlen;                  /* lenght of filemeta */
     int saveoff = offset;
     EC_ZERO(slvalc(buf, offset, maxoff, sl_pack_tag(SQ_TYPE_COMPLEX, 1,
-                   *toc_idx + 1)));
+                                                    *toc_idx + 1)));
     offset += 16;
 
     if (maxoff - offset <= 16) {
@@ -412,7 +412,7 @@ static int sl_pack_filemeta(sl_filemeta_t *fm, char *buf, int offset,
 
     /* 3rd parameter of sl_pack_tag has unknown meaning, but always 8 */
     EC_ZERO(slvalc(buf, saveoff + 8, maxoff, sl_pack_tag(SQ_TYPE_DATA,
-                   (fmlen / 8) + 1, 8)));
+                                                         (fmlen / 8) + 1, 8)));
     EC_ZERO(slvalc(toc_buf, *toc_idx * 8, MAX_SLQ_TOC,
                    sl_pack_tag(SQ_CPX_TYPE_FILEMETA, (saveoff + SL_OFFSET_DELTA) / 8, fmlen / 8)));
     *toc_idx += 1;
@@ -443,11 +443,11 @@ static int sl_pack_string(char *s, char *buf, int offset, char *toc_buf,
                    sl_pack_tag(SQ_CPX_TYPE_STRING, (offset + SL_OFFSET_DELTA) / 8,
                                used_in_last_octet)));
     EC_ZERO(slvalc(buf, offset, maxoff, sl_pack_tag(SQ_TYPE_COMPLEX, 1,
-                   *toc_idx + 1)));
+                                                    *toc_idx + 1)));
     *toc_idx += 1;
     offset += 8;
     EC_ZERO(slvalc(buf, offset, maxoff, sl_pack_tag(SQ_TYPE_DATA, octets + 1,
-                   used_in_last_octet)));
+                                                    used_in_last_octet)));
     offset += 8;
 
     if (offset < 0 || maxoff < 0 || octets > (maxoff - offset) / 8) {
@@ -881,7 +881,7 @@ static int sl_unpack_cpx(DALLOC_CTX *query,
             p = dalloc_strndup(query, buf + offset + 8, slen);
         } else {
             unicode_encoding = spotlight_get_utf16_string_encoding(buf, offset + 8, slen,
-                               encoding);
+                                                                   encoding);
             mark_exists = (unicode_encoding & SL_ENC_UTF_16);
 
             if (unicode_encoding & SL_ENC_BIG_ENDIAN) {
@@ -896,10 +896,10 @@ static int sl_unpack_cpx(DALLOC_CTX *query,
 
             size_t tmp_len;
             EC_NEG1(tmp_len = convert_string_allocate(CH_UCS2,
-                              CH_UTF8,
-                              buf + offset + (mark_exists ? 10 : 8),
-                              slen,
-                              &tmp));
+                                                      CH_UTF8,
+                                                      buf + offset + (mark_exists ? 10 : 8),
+                                                      slen,
+                                                      &tmp));
             p = dalloc_strndup(query, tmp, tmp_len);
             free(tmp);
         }
@@ -1150,7 +1150,7 @@ static int sl_pack_len(DALLOC_CTX *query, char *buf, off_t maxoff)
     EC_ZERO(sivalc(buf, 8, maxoff, len / 8 + 1 + toc_index + 1));
     EC_ZERO(sivalc(buf, 12, maxoff, len / 8 + 1));
     EC_ZERO(slvalc(toc_buf, 0, MAX_SLQ_TOC, sl_pack_tag(SQ_TYPE_TOC, toc_index + 1,
-                   0)));
+                                                        0)));
     toc_len = (toc_index + 1) * 8;
 
     if (16 + len + toc_len >= maxoff) {

--- a/etc/afpd/uam.c
+++ b/etc/afpd/uam.c
@@ -148,28 +148,28 @@ int uam_register(const int type, const char *path, const char *name, ...)
     case UAM_SERVER_LOGIN_EXT:
         /* expect four arguments */
         uam->u.uam_login.login = va_arg(ap, int (*)(void *, struct passwd **, char *,
-                                        int, char *, size_t *));
+            int, char *, size_t *));
         uam->u.uam_login.logincont = va_arg(ap, int (*)(void *, struct passwd **,
-                                            char *, int, char *, size_t *));
+            char *, int, char *, size_t *));
         uam->u.uam_login.logout = va_arg(ap, void (*)(void));
         uam->u.uam_login.login_ext = va_arg(ap, int (*)(void *, char *,
-                                            struct passwd **, char *, int, char *, size_t *));
+            struct passwd **, char *, int, char *, size_t *));
         break;
 
     case UAM_SERVER_LOGIN:
         /* expect three arguments */
         uam->u.uam_login.login_ext = NULL;
         uam->u.uam_login.login = va_arg(ap, int (*)(void *, struct passwd **, char *,
-                                        int, char *, size_t *));
+            int, char *, size_t *));
         uam->u.uam_login.logincont = va_arg(ap, int (*)(void *, struct passwd **,
-                                            char *, int, char *, size_t *));
+            char *, int, char *, size_t *));
         uam->u.uam_login.logout = va_arg(ap, void (*)(void));
         break;
 
     case UAM_SERVER_CHANGEPW:
         /* one argument */
         uam->u.uam_changepw = va_arg(ap, int (*)(void *, char *, struct passwd *,
-                                     char *, int, char *, size_t *));
+            char *, int, char *, size_t *));
         break;
 
     case UAM_SERVER_PRINTAUTH:

--- a/etc/afpd/uam.c
+++ b/etc/afpd/uam.c
@@ -148,28 +148,28 @@ int uam_register(const int type, const char *path, const char *name, ...)
     case UAM_SERVER_LOGIN_EXT:
         /* expect four arguments */
         uam->u.uam_login.login = va_arg(ap, int (*)(void *, struct passwd **, char *,
-                                        int, char *, size_t *));
+                                                    int, char *, size_t *));
         uam->u.uam_login.logincont = va_arg(ap, int (*)(void *, struct passwd **,
-                                            char *, int, char *, size_t *));
+                                                        char *, int, char *, size_t *));
         uam->u.uam_login.logout = va_arg(ap, void (*)(void));
         uam->u.uam_login.login_ext = va_arg(ap, int (*)(void *, char *,
-                                            struct passwd **, char *, int, char *, size_t *));
+                                                        struct passwd **, char *, int, char *, size_t *));
         break;
 
     case UAM_SERVER_LOGIN:
         /* expect three arguments */
         uam->u.uam_login.login_ext = NULL;
         uam->u.uam_login.login = va_arg(ap, int (*)(void *, struct passwd **, char *,
-                                        int, char *, size_t *));
+                                                    int, char *, size_t *));
         uam->u.uam_login.logincont = va_arg(ap, int (*)(void *, struct passwd **,
-                                            char *, int, char *, size_t *));
+                                                        char *, int, char *, size_t *));
         uam->u.uam_login.logout = va_arg(ap, void (*)(void));
         break;
 
     case UAM_SERVER_CHANGEPW:
         /* one argument */
         uam->u.uam_changepw = va_arg(ap, int (*)(void *, char *, struct passwd *,
-                                     char *, int, char *, size_t *));
+                                                 char *, int, char *, size_t *));
         break;
 
     case UAM_SERVER_PRINTAUTH:

--- a/etc/afpd/virtual_icon.c
+++ b/etc/afpd/virtual_icon.c
@@ -293,7 +293,7 @@ void virtual_icon_init(struct vol *vol)
 }
 
 const unsigned char *virtual_icon_get_rfork(const struct vol *vol,
-        size_t *outlen)
+                                            size_t *outlen)
 {
     if (!vol->v_icon_rfork) {
         *outlen = 0;

--- a/etc/afpd/virtual_icon.h
+++ b/etc/afpd/virtual_icon.h
@@ -26,7 +26,7 @@ int  real_icon_exists(const struct vol *vol);
 
 void virtual_icon_init(struct vol *vol);
 const unsigned char *virtual_icon_get_rfork(const struct vol *vol,
-        size_t *outlen);
+                                            size_t *outlen);
 
 int  virtual_icon_getfilparams(const AFPObj *obj,
                                struct vol *vol,

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -717,7 +717,7 @@ static int volume_codepage(AFPObj *obj, struct vol *volume)
     }
 
     if ((charset_t) -1 == (volume->v_volcharset = add_charset(
-                               volume->v_volcodepage))) {
+            volume->v_volcodepage))) {
         LOG(log_error, logtype_afpd, "Setting codepage %s as volume codepage failed",
             volume->v_volcodepage);
         return -1;
@@ -735,7 +735,7 @@ static int volume_codepage(AFPObj *obj, struct vol *volume)
     }
 
     if ((charset_t) -1 == (volume->v_maccharset = add_charset(
-                               volume->v_maccodepage))) {
+            volume->v_maccodepage))) {
         LOG(log_error, logtype_afpd, "Setting codepage %s as mac codepage failed",
             volume->v_maccodepage);
         return -1;

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -719,7 +719,7 @@ static int volume_codepage(AFPObj *obj, struct vol *volume)
     }
 
     if ((charset_t) -1 == (volume->v_volcharset = add_charset(
-                               volume->v_volcodepage))) {
+                                                      volume->v_volcodepage))) {
         LOG(log_error, logtype_afpd, "Setting codepage %s as volume codepage failed",
             volume->v_volcodepage);
         return -1;
@@ -737,7 +737,7 @@ static int volume_codepage(AFPObj *obj, struct vol *volume)
     }
 
     if ((charset_t) -1 == (volume->v_maccharset = add_charset(
-                               volume->v_maccodepage))) {
+                                                      volume->v_maccodepage))) {
         LOG(log_error, logtype_afpd, "Setting codepage %s as mac codepage failed",
             volume->v_maccodepage);
         return -1;

--- a/etc/afpd/volume.h
+++ b/etc/afpd/volume.h
@@ -15,8 +15,8 @@
 #include <atalk/volume.h>
 
 extern int              ustatfs_getvolspace(const struct vol *,
-        VolSpace *, VolSpace *,
-        uint32_t *);
+                                            VolSpace *, VolSpace *,
+                                            uint32_t *);
 extern void             setvoltime(AFPObj *, struct vol *);
 extern int              pollvoltime(AFPObj *);
 

--- a/etc/atalkd/config.c
+++ b/etc/atalkd/config.c
@@ -263,9 +263,9 @@ int writeconf(char *cf)
             for (l = iface->i_rt->rt_zt; l; l = l->l_next) {
                 /* codepage conversion */
                 if ((size_t)(-1) == (len = convert_string_allocate(CH_MAC, CH_UNIX,
-                                           ((struct ziptab *)l->l_data)->zt_name,
-                                           ((struct ziptab *)l->l_data)->zt_len,
-                                           &zonename))) {
+                    ((struct ziptab *)l->l_data)->zt_name,
+                    ((struct ziptab *)l->l_data)->zt_len,
+                    &zonename))) {
                     if (NULL ==
                             (zonename = strdup(((struct ziptab *)l->l_data)->zt_name))) {
                         LOG(log_error, logtype_atalkd, "malloc: %s",  strerror(errno));

--- a/etc/atalkd/config.c
+++ b/etc/atalkd/config.c
@@ -263,9 +263,9 @@ int writeconf(char *cf)
             for (l = iface->i_rt->rt_zt; l; l = l->l_next) {
                 /* codepage conversion */
                 if ((size_t)(-1) == (len = convert_string_allocate(CH_MAC, CH_UNIX,
-                                           ((struct ziptab *)l->l_data)->zt_name,
-                                           ((struct ziptab *)l->l_data)->zt_len,
-                                           &zonename))) {
+                                                                   ((struct ziptab *)l->l_data)->zt_name,
+                                                                   ((struct ziptab *)l->l_data)->zt_len,
+                                                                   &zonename))) {
                     if (NULL ==
                             (zonename = strdup(((struct ziptab *)l->l_data)->zt_name))) {
                         LOG(log_error, logtype_atalkd, "malloc: %s",  strerror(errno));
@@ -688,7 +688,7 @@ int zone(struct interface *iface, char **av)
 
     /* codepage conversion */
     if ((size_t)(-1) == convert_string_allocate(CH_UNIX, CH_MAC, av[0], -1,
-            &zname)) {
+                                                &zname)) {
         zname = strdup(av[0]);
     }
 

--- a/etc/atalkd/nbp.c
+++ b/etc/atalkd/nbp.c
@@ -172,7 +172,7 @@ int nbp_packet(struct atport *ap, struct sockaddr_at *from, char *data, int len)
         } else {
             for (zt = ziptab; zt; zt = zt->zt_next) {
                 if (zt->zt_len == nn.nn_zonelen && strndiacasecmp(zt->zt_name,
-                        nn.nn_zone, zt->zt_len) == 0) {
+                    nn.nn_zone, zt->zt_len) == 0) {
                     break;
                 }
             }
@@ -375,7 +375,7 @@ int nbp_packet(struct atport *ap, struct sockaddr_at *from, char *data, int len)
         } else {
             for (zt = ziptab; zt; zt = zt->zt_next) {
                 if (zt->zt_len == nn.nn_zonelen && strndiacasecmp(zt->zt_name,
-                        nn.nn_zone, zt->zt_len) == 0) {
+                    nn.nn_zone, zt->zt_len) == 0) {
                     break;
                 }
             }

--- a/etc/atalkd/nbp.c
+++ b/etc/atalkd/nbp.c
@@ -172,7 +172,7 @@ int nbp_packet(struct atport *ap, struct sockaddr_at *from, char *data, int len)
         } else {
             for (zt = ziptab; zt; zt = zt->zt_next) {
                 if (zt->zt_len == nn.nn_zonelen && strndiacasecmp(zt->zt_name,
-                        nn.nn_zone, zt->zt_len) == 0) {
+                                                                  nn.nn_zone, zt->zt_len) == 0) {
                     break;
                 }
             }
@@ -375,7 +375,7 @@ int nbp_packet(struct atport *ap, struct sockaddr_at *from, char *data, int len)
         } else {
             for (zt = ziptab; zt; zt = zt->zt_next) {
                 if (zt->zt_len == nn.nn_zonelen && strndiacasecmp(zt->zt_name,
-                        nn.nn_zone, zt->zt_len) == 0) {
+                                                                  nn.nn_zone, zt->zt_len) == 0) {
                     break;
                 }
             }

--- a/etc/cnid_dbd/dbd_lookup.c
+++ b/etc/cnid_dbd/dbd_lookup.c
@@ -213,7 +213,7 @@ int dbd_lookup(DBD *dbd, struct cnid_dbd_rqst *rqst, struct cnid_dbd_rply *rply)
 
     /* Check for type (file/dir) mismatch */
     if ((devino && (type_devino != rqst->type)) || (didname
-            && (type_didname != rqst->type))) {
+                                                    && (type_didname != rqst->type))) {
         if (devino && (type_devino != rqst->type)) {
             /* one is a dir one is a file, remove from db */
             LOG(log_debug, logtype_cnid,

--- a/etc/cnid_dbd/dbif.c
+++ b/etc/cnid_dbd/dbif.c
@@ -611,7 +611,7 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
 
         if (dbd->db_table[i].flags) {
             if ((ret = dbd->db_table[i].db->set_flags(dbd->db_table[i].db,
-                       dbd->db_table[i].flags))) {
+                dbd->db_table[i].flags))) {
                 LOG(log_error, logtype_cnid, "error setting flags for database %s: %s",
                     dbd->db_table[i].name, db_strerror(ret));
                 return -1;
@@ -621,9 +621,9 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
         /* In memory db */
         if (! dbd->db_env) {
             if ((ret = dbd->db_table[i].db->set_cachesize(dbd->db_table[i].db,
-                       0,
-                       dbp->cachesize,
-                       4)) /* split in 4 memory chunks */
+                0,
+                dbp->cachesize,
+                4)) /* split in 4 memory chunks */
                     < 0)  {
                 LOG(log_error, logtype_cnid,
                     "error setting cachesize %u KB for database %s: %s",
@@ -647,7 +647,7 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
             LOG(log_info, logtype_cnid, "Truncating CNID index.");
 
             if ((ret = dbd->db_table[i].db->truncate(dbd->db_table[i].db, NULL, &count,
-                       0))) {
+                0))) {
                 LOG(log_error, logtype_cnid, "error truncating database %s: %s",
                     dbd->db_table[i].name, db_strerror(ret));
                 return -1;
@@ -663,10 +663,10 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
     }
 
     if ((ret = dbd->db_table[0].db->associate(dbd->db_table[DBIF_CNID].db,
-               dbd->db_txn,
-               dbd->db_table[DBIF_IDX_DIDNAME].db,
-               didname,
-               reindex ? DB_CREATE : 0))
+        dbd->db_txn,
+        dbd->db_table[DBIF_IDX_DIDNAME].db,
+        didname,
+        reindex ? DB_CREATE : 0))
             != 0) {
         LOG(log_error, logtype_cnid, "Failed to associate didname database: %s",
             db_strerror(ret));
@@ -682,10 +682,10 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
     }
 
     if ((ret = dbd->db_table[0].db->associate(dbd->db_table[0].db,
-               dbd->db_txn,
-               dbd->db_table[DBIF_IDX_DEVINO].db,
-               devino,
-               reindex ? DB_CREATE : 0))
+        dbd->db_txn,
+        dbd->db_table[DBIF_IDX_DEVINO].db,
+        devino,
+        reindex ? DB_CREATE : 0))
             != 0) {
         LOG(log_error, logtype_cnid, "Failed to associate devino database: %s",
             db_strerror(ret));
@@ -713,13 +713,13 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
     }
 
     if ((ret = dbd->db_table[0].db->associate(dbd->db_table[0].db,
-               dbd->db_txn,
-               dbd->db_table[DBIF_IDX_NAME].db,
-               idxname,
-               (reindex
-                ||
-                ((CNID_VERSION == CNID_VERSION_1) && (version == CNID_VERSION_0)))
-               ? DB_CREATE : 0)) != 0) {
+        dbd->db_txn,
+        dbd->db_table[DBIF_IDX_NAME].db,
+        idxname,
+        (reindex
+         ||
+         ((CNID_VERSION == CNID_VERSION_1) && (version == CNID_VERSION_0)))
+        ? DB_CREATE : 0)) != 0) {
         LOG(log_error, logtype_cnid, "Failed to associate name index: %s",
             db_strerror(ret));
         return -1;

--- a/etc/cnid_dbd/dbif.c
+++ b/etc/cnid_dbd/dbif.c
@@ -612,7 +612,7 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
 
         if (dbd->db_table[i].flags) {
             if ((ret = dbd->db_table[i].db->set_flags(dbd->db_table[i].db,
-                       dbd->db_table[i].flags))) {
+                                                      dbd->db_table[i].flags))) {
                 LOG(log_error, logtype_cnid, "error setting flags for database %s: %s",
                     dbd->db_table[i].name, db_strerror(ret));
                 return -1;
@@ -622,9 +622,9 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
         /* In memory db */
         if (! dbd->db_env) {
             if ((ret = dbd->db_table[i].db->set_cachesize(dbd->db_table[i].db,
-                       0,
-                       dbp->cachesize,
-                       4)) /* split in 4 memory chunks */
+                                                          0,
+                                                          dbp->cachesize,
+                                                          4)) /* split in 4 memory chunks */
                     < 0)  {
                 LOG(log_error, logtype_cnid,
                     "error setting cachesize %u KB for database %s: %s",
@@ -648,7 +648,7 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
             LOG(log_info, logtype_cnid, "Truncating CNID index.");
 
             if ((ret = dbd->db_table[i].db->truncate(dbd->db_table[i].db, NULL, &count,
-                       0))) {
+                                                     0))) {
                 LOG(log_error, logtype_cnid, "error truncating database %s: %s",
                     dbd->db_table[i].name, db_strerror(ret));
                 return -1;
@@ -664,10 +664,10 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
     }
 
     if ((ret = dbd->db_table[0].db->associate(dbd->db_table[DBIF_CNID].db,
-               dbd->db_txn,
-               dbd->db_table[DBIF_IDX_DIDNAME].db,
-               didname,
-               reindex ? DB_CREATE : 0))
+                                              dbd->db_txn,
+                                              dbd->db_table[DBIF_IDX_DIDNAME].db,
+                                              didname,
+                                              reindex ? DB_CREATE : 0))
             != 0) {
         LOG(log_error, logtype_cnid, "Failed to associate didname database: %s",
             db_strerror(ret));
@@ -683,10 +683,10 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
     }
 
     if ((ret = dbd->db_table[0].db->associate(dbd->db_table[0].db,
-               dbd->db_txn,
-               dbd->db_table[DBIF_IDX_DEVINO].db,
-               devino,
-               reindex ? DB_CREATE : 0))
+                                              dbd->db_txn,
+                                              dbd->db_table[DBIF_IDX_DEVINO].db,
+                                              devino,
+                                              reindex ? DB_CREATE : 0))
             != 0) {
         LOG(log_error, logtype_cnid, "Failed to associate devino database: %s",
             db_strerror(ret));
@@ -714,13 +714,13 @@ int dbif_open(DBD *dbd, struct db_param *dbp, int reindex)
     }
 
     if ((ret = dbd->db_table[0].db->associate(dbd->db_table[0].db,
-               dbd->db_txn,
-               dbd->db_table[DBIF_IDX_NAME].db,
-               idxname,
-               (reindex
-                ||
-                ((CNID_VERSION == CNID_VERSION_1) && (version == CNID_VERSION_0)))
-               ? DB_CREATE : 0)) != 0) {
+                                              dbd->db_txn,
+                                              dbd->db_table[DBIF_IDX_NAME].db,
+                                              idxname,
+                                              (reindex
+                                               ||
+                                               ((CNID_VERSION == CNID_VERSION_1) && (version == CNID_VERSION_0)))
+                                              ? DB_CREATE : 0)) != 0) {
         LOG(log_error, logtype_cnid, "Failed to associate name index: %s",
             db_strerror(ret));
         return -1;

--- a/etc/netatalk/afp_avahi.c
+++ b/etc/netatalk/afp_avahi.c
@@ -137,15 +137,15 @@ static void register_stuff(void)
         }
 
         if (i && avahi_entry_group_add_service_strlst(ctx->group,
-                AVAHI_IF_UNSPEC,
-                AVAHI_PROTO_UNSPEC,
-                0,
-                name,
-                ADISK_SERVICE_TYPE,
-                NULL,
-                NULL,
-                9, /* discard */
-                strlist) < 0) {
+                                                      AVAHI_IF_UNSPEC,
+                                                      AVAHI_PROTO_UNSPEC,
+                                                      0,
+                                                      name,
+                                                      ADISK_SERVICE_TYPE,
+                                                      NULL,
+                                                      NULL,
+                                                      9, /* discard */
+                                                      strlist) < 0) {
             LOG(log_error, logtype_afpd, "Failed to add service: %s",
                 avahi_strerror(avahi_client_errno(ctx->client)));
             goto fail;
@@ -156,15 +156,15 @@ static void register_stuff(void)
                                                     ctx->obj->options.mimicmodel);
 
             if (avahi_entry_group_add_service_strlst(ctx->group,
-                    AVAHI_IF_UNSPEC,
-                    AVAHI_PROTO_UNSPEC,
-                    0,
-                    name,
-                    DEV_INFO_SERVICE_TYPE,
-                    NULL,
-                    NULL,
-                    0,
-                    strlist2) < 0) {
+                                                     AVAHI_IF_UNSPEC,
+                                                     AVAHI_PROTO_UNSPEC,
+                                                     0,
+                                                     name,
+                                                     DEV_INFO_SERVICE_TYPE,
+                                                     NULL,
+                                                     NULL,
+                                                     0,
+                                                     strlist2) < 0) {
                 LOG(log_error, logtype_afpd, "Failed to add service: %s",
                     avahi_strerror(avahi_client_errno(ctx->client)));
                 goto fail;
@@ -253,7 +253,7 @@ static void client_callback(AvahiClient *client,
 
             /* Reconnect to the server */
             if (!(ctx->client = avahi_client_new(avahi_threaded_poll_get(
-                    ctx->threaded_poll),
+                                                     ctx->threaded_poll),
                                                  AVAHI_CLIENT_NO_FAIL,
                                                  client_callback,
                                                  ctx,
@@ -308,7 +308,7 @@ void av_zeroconf_register(const AFPObj *obj)
 
     /* now we need to acquire a client */
     if (!(ctx->client = avahi_client_new(avahi_threaded_poll_get(
-            ctx->threaded_poll),
+                                             ctx->threaded_poll),
                                          AVAHI_CLIENT_NO_FAIL,
                                          client_callback,
                                          NULL,

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -808,7 +808,7 @@ int main(int argc, char **argv)
     if (volumes_loaded && !conf_cnid_scheme_in_use(&obj, "dbd")) {
         cnid_metad_pid = NETATALK_SRV_OPTIONAL;
     } else if ((cnid_metad_pid = run_process(_PATH_CNID_METAD, "-d", "-F",
-                                 obj.options.configfile, NULL)) == NETATALK_SRV_ERROR) {
+                                             obj.options.configfile, NULL)) == NETATALK_SRV_ERROR) {
         LOG(log_error, logtype_afpd, "Error starting 'cnid_metad'");
         netatalk_exit(EXITERR_CONF);
     }

--- a/etc/papd/comment.h
+++ b/etc/papd/comment.h
@@ -59,7 +59,7 @@ extern char			*comcont;
 void compop(void);
 void compush(struct papd_comment *);
 int comswitch(struct papd_comment *, int (*)(struct papfile *, struct papfile *,
-              struct sockaddr_at *));
+        struct sockaddr_at *));
 int comcmp(char *, char *, char *, int);
 struct papd_comment *commatch(char *, char *, struct papd_comment *);
 char *comtoken(char *, char *, char *, char *);

--- a/etc/papd/comment.h
+++ b/etc/papd/comment.h
@@ -59,7 +59,7 @@ extern char			*comcont;
 void compop(void);
 void compush(struct papd_comment *);
 int comswitch(struct papd_comment *, int (*)(struct papfile *, struct papfile *,
-              struct sockaddr_at *));
+                                             struct sockaddr_at *));
 int comcmp(char *, char *, char *, int);
 struct papd_comment *commatch(char *, char *, struct papd_comment *);
 char *comtoken(char *, char *, char *, char *);

--- a/etc/papd/lp.c
+++ b/etc/papd/lp.c
@@ -247,7 +247,7 @@ static void translate(charset_t from, charset_t dest, char **option)
 
         if (from) {
             if ((size_t) -1 != (convert_string_allocate(from, dest, *option, -1,
-                                &translated))) {
+                    &translated))) {
                 free(*option);
                 *option = translated;
             }

--- a/etc/papd/lp.c
+++ b/etc/papd/lp.c
@@ -247,7 +247,7 @@ static void translate(charset_t from, charset_t dest, char **option)
 
         if (from) {
             if ((size_t) -1 != (convert_string_allocate(from, dest, *option, -1,
-                                &translated))) {
+                                                        &translated))) {
                 free(*option);
                 *option = translated;
             }

--- a/etc/papd/main.c
+++ b/etc/papd/main.c
@@ -299,7 +299,7 @@ int main(int ac, char **av)
 
         if (!(pr->p_flags & P_CUPS)) {
             if ((size_t) -1 != convert_string_allocate(CH_UNIX, CH_MAC, pr->p_name, -1,
-                    &atname)) {
+                                                       &atname)) {
                 pr->p_u_name = pr->p_name;
                 pr->p_name = atname;
             }

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -201,9 +201,9 @@ const char *cups_get_printer_ppd(char *name)
     const char *make_model = cupsGetOption("printer-make-and-model",
                                            dest->num_options, dest->options);
     const char *printer_uri_supported = cupsGetOption("printer-uri-supported",
-                                        dest->num_options, dest->options);
+        dest->num_options, dest->options);
     const char *printer_is_temporary = cupsGetOption("printer-is-temporary",
-                                       dest->num_options, dest->options);
+        dest->num_options, dest->options);
 
     /* Is this a DNS-SD discovered printer? Connect directly to it. */
     if (!printer_uri_supported || !strcmp(printer_is_temporary, "true")) {
@@ -389,9 +389,9 @@ cups_get_printer_status(struct printer *pr)
      * Collect the needed attributes...
      */
     const char *printer_uri_supported = cupsGetOption("printer-uri-supported",
-                                        dest->num_options, dest->options);
+        dest->num_options, dest->options);
     const char *printer_is_temporary = cupsGetOption("printer-is-temporary",
-                                       dest->num_options, dest->options);
+        dest->num_options, dest->options);
     memset(pr->p_status, 0, sizeof(pr->p_status));
 
     /* DNS-SD discovered IPP printer: Get status directly from printer */

--- a/etc/papd/print_cups.c
+++ b/etc/papd/print_cups.c
@@ -201,9 +201,9 @@ const char *cups_get_printer_ppd(char *name)
     const char *make_model = cupsGetOption("printer-make-and-model",
                                            dest->num_options, dest->options);
     const char *printer_uri_supported = cupsGetOption("printer-uri-supported",
-                                        dest->num_options, dest->options);
+                                                      dest->num_options, dest->options);
     const char *printer_is_temporary = cupsGetOption("printer-is-temporary",
-                                       dest->num_options, dest->options);
+                                                     dest->num_options, dest->options);
 
     /* Is this a DNS-SD discovered printer? Connect directly to it. */
     if (!printer_uri_supported || !strcmp(printer_is_temporary, "true")) {
@@ -389,9 +389,9 @@ cups_get_printer_status(struct printer *pr)
      * Collect the needed attributes...
      */
     const char *printer_uri_supported = cupsGetOption("printer-uri-supported",
-                                        dest->num_options, dest->options);
+                                                      dest->num_options, dest->options);
     const char *printer_is_temporary = cupsGetOption("printer-is-temporary",
-                                       dest->num_options, dest->options);
+                                                     dest->num_options, dest->options);
     memset(pr->p_status, 0, sizeof(pr->p_status));
 
     /* DNS-SD discovered IPP printer: Get status directly from printer */

--- a/etc/papd/queries.c
+++ b/etc/papd/queries.c
@@ -740,7 +740,7 @@ int cq_rbilogin(struct papfile *in, struct papfile *out,
             }
 
             if (!*uamtype || (papd_uam = auth_uamfind(UAM_SERVER_PRINTAUTH,
-                                         uamtype, strlen(uamtype))) == NULL) {
+                uamtype, strlen(uamtype))) == NULL) {
                 LOG(log_info, logtype_papd, "Could not find uam: %s", uamtype);
                 append(out, rbiloginbad, strlen(rbiloginbad));
                 append(out, rbiloginerrstr, strlen(rbiloginerrstr));

--- a/etc/papd/queries.c
+++ b/etc/papd/queries.c
@@ -740,7 +740,7 @@ int cq_rbilogin(struct papfile *in, struct papfile *out,
             }
 
             if (!*uamtype || (papd_uam = auth_uamfind(UAM_SERVER_PRINTAUTH,
-                                         uamtype, strlen(uamtype))) == NULL) {
+                                                      uamtype, strlen(uamtype))) == NULL) {
                 LOG(log_info, logtype_papd, "Could not find uam: %s", uamtype);
                 append(out, rbiloginbad, strlen(rbiloginbad));
                 append(out, rbiloginerrstr, strlen(rbiloginerrstr));

--- a/etc/spotlight/xapian/sl_xapian.h
+++ b/etc/spotlight/xapian/sl_xapian.h
@@ -15,46 +15,46 @@ extern "C" {
 #endif
 
 int sl_xapian_reconcile(const char *db_path,
-                        const char *volume_path,
-                        const char *volume_uuid,
-                        char *errbuf,
-                        size_t errlen);
+const char *volume_path,
+const char *volume_uuid,
+char *errbuf,
+size_t errlen);
 int sl_xapian_index_ready(const char *db_path,
-                          const char *volume_path,
-                          const char *volume_uuid,
-                          char *errbuf,
-                          size_t errlen);
+const char *volume_path,
+const char *volume_uuid,
+char *errbuf,
+size_t errlen);
 int sl_xapian_query(const char *db_path,
-                    const char *scope,
-                    const char *qstring,
-                    size_t offset,
-                    size_t limit,
-                    char ***paths,
-                    size_t *count,
-                    int *more,
-                    char *errbuf,
-                    size_t errlen);
+const char *scope,
+const char *qstring,
+size_t offset,
+size_t limit,
+char ***paths,
+size_t *count,
+int *more,
+char *errbuf,
+size_t errlen);
 int sl_xapian_upsert_path(const char *db_path,
-                          const char *path,
-                          char *errbuf,
-                          size_t errlen);
+const char *path,
+char *errbuf,
+size_t errlen);
 int sl_xapian_delete_path(const char *db_path,
-                          const char *path,
-                          char *errbuf,
-                          size_t errlen);
+const char *path,
+char *errbuf,
+size_t errlen);
 int sl_xapian_delete_prefix(const char *db_path,
-                            const char *path,
-                            char *errbuf,
-                            size_t errlen);
+const char *path,
+char *errbuf,
+size_t errlen);
 int sl_xapian_reindex_subtree(const char *db_path,
-                              const char *volume_path,
-                              const char *path,
-                              const char *oldpath,
-                              char *errbuf,
-                              size_t errlen);
+const char *volume_path,
+const char *path,
+const char *oldpath,
+char *errbuf,
+size_t errlen);
 int sl_xapian_mark_dirty(const char *db_path,
-                         char *errbuf,
-                         size_t errlen);
+char *errbuf,
+size_t errlen);
 void sl_xapian_free_paths(char **paths, size_t count);
 
 #ifdef __cplusplus

--- a/etc/spotlight/xapian/xapian_wrapper.cc
+++ b/etc/spotlight/xapian/xapian_wrapper.cc
@@ -990,7 +990,7 @@ void collect_values_after_key(const std::string &q,
         }
 
         if (std::string value = strip_wildcards(q.substr(quote1 + 1,
-                                                quote2 - quote1 - 1)); !value.empty()) {
+            quote2 - quote1 - 1)); !value.empty()) {
             values.push_back(value);
         }
 
@@ -1017,7 +1017,7 @@ std::vector<std::string> collect_any_values(const std::string &q)
         }
 
         if (std::string value = strip_wildcards(q.substr(quote1 + 1,
-                                                quote2 - quote1 - 1)); !value.empty()) {
+            quote2 - quote1 - 1)); !value.empty()) {
             values.push_back(value);
         }
 

--- a/etc/spotlight/xapian/xapian_wrapper.cc
+++ b/etc/spotlight/xapian/xapian_wrapper.cc
@@ -990,7 +990,7 @@ void collect_values_after_key(const std::string &q,
         }
 
         if (std::string value = strip_wildcards(q.substr(quote1 + 1,
-                                                quote2 - quote1 - 1)); !value.empty()) {
+                                                         quote2 - quote1 - 1)); !value.empty()) {
             values.push_back(value);
         }
 
@@ -1017,7 +1017,7 @@ std::vector<std::string> collect_any_values(const std::string &q)
         }
 
         if (std::string value = strip_wildcards(q.substr(quote1 + 1,
-                                                quote2 - quote1 - 1)); !value.empty()) {
+                                                         quote2 - quote1 - 1)); !value.empty()) {
             values.push_back(value);
         }
 
@@ -1541,11 +1541,11 @@ extern "C" int sl_xapian_delete_prefix(const char *db_path,
 }
 
 extern "C" int sl_xapian_reindex_subtree(const char *db_path,
-        const char *volume_path,
-        const char *path,
-        const char *oldpath,
-        char *errbuf,
-        size_t errlen)
+                                         const char *volume_path,
+                                         const char *path,
+                                         const char *oldpath,
+                                         char *errbuf,
+                                         size_t errlen)
 {
     try {
         std::string magic_error;

--- a/etc/uams/uams_srp.c
+++ b/etc/uams/uams_srp.c
@@ -734,7 +734,7 @@ static int srp_logincont(void *obj _U_, struct passwd **uam_pwd,
     mpi_to_padded_buf(S_binary, SRP_NBYTES, S);
     size_t S_stripped_len;
     const unsigned char *S_stripped = strip_leading_zeros(S_binary, SRP_NBYTES,
-                                      &S_stripped_len);
+        &S_stripped_len);
 
     if (mgf1_sha1(S_stripped, S_stripped_len, K, sizeof(K)) != 0) {
         LOG(log_error, logtype_uams, "srp_logincont: MGF1 failed");
@@ -748,7 +748,7 @@ static int srp_logincont(void *obj _U_, struct passwd **uam_pwd,
     /* H(N) — hash of N with leading zeros stripped */
     size_t N_stripped_len;
     const unsigned char *N_stripped = strip_leading_zeros(srp_N_bytes, SRP_NBYTES,
-                                      &N_stripped_len);
+        &N_stripped_len);
     unsigned char H_N[SRP_SHA1_LEN];
 
     if (sha1_multi(H_N, N_stripped, N_stripped_len, NULL) != 0) {
@@ -803,9 +803,9 @@ static int srp_logincont(void *obj _U_, struct passwd **uam_pwd,
      */
     size_t A_stripped_len, B_stripped_len;
     const unsigned char *A_stripped = strip_leading_zeros(A_buf, SRP_NBYTES,
-                                      &A_stripped_len);
+        &A_stripped_len);
     const unsigned char *B_stripped = strip_leading_zeros(session_B_buf, SRP_NBYTES,
-                                      &B_stripped_len);
+        &B_stripped_len);
     unsigned char M1_expected[SRP_SHA1_LEN];
 
     if (sha1_multi(M1_expected,

--- a/etc/uams/uams_srp.c
+++ b/etc/uams/uams_srp.c
@@ -113,7 +113,7 @@ static struct passwd *srppwd;
  * @returns pointer to the first non-zero byte (or last byte if all zeros).
  */
 static const unsigned char *strip_leading_zeros(const unsigned char *buf,
-        size_t len, size_t *out_len)
+                                                size_t len, size_t *out_len)
 {
     while (len > 1 && *buf == 0) {
         buf++;
@@ -742,7 +742,7 @@ static int srp_logincont(void *obj _U_, struct passwd **uam_pwd,
     mpi_to_padded_buf(S_binary, SRP_NBYTES, S);
     size_t S_stripped_len;
     const unsigned char *S_stripped = strip_leading_zeros(S_binary, SRP_NBYTES,
-                                      &S_stripped_len);
+                                                          &S_stripped_len);
 
     if (mgf1_sha1(S_stripped, S_stripped_len, K, sizeof(K)) != 0) {
         LOG(log_error, logtype_uams, "srp_logincont: MGF1 failed");
@@ -756,7 +756,7 @@ static int srp_logincont(void *obj _U_, struct passwd **uam_pwd,
     /* H(N) — hash of N with leading zeros stripped */
     size_t N_stripped_len;
     const unsigned char *N_stripped = strip_leading_zeros(srp_N_bytes, SRP_NBYTES,
-                                      &N_stripped_len);
+                                                          &N_stripped_len);
     unsigned char H_N[SRP_SHA1_LEN];
 
     if (sha1_multi(H_N, N_stripped, N_stripped_len, NULL) != 0) {
@@ -811,9 +811,9 @@ static int srp_logincont(void *obj _U_, struct passwd **uam_pwd,
      */
     size_t A_stripped_len, B_stripped_len;
     const unsigned char *A_stripped = strip_leading_zeros(A_buf, SRP_NBYTES,
-                                      &A_stripped_len);
+                                                          &A_stripped_len);
     const unsigned char *B_stripped = strip_leading_zeros(session_B_buf, SRP_NBYTES,
-                                      &B_stripped_len);
+                                                          &B_stripped_len);
     unsigned char M1_expected[SRP_SHA1_LEN];
 
     if (sha1_multi(M1_expected,

--- a/include/atalk/compat.h
+++ b/include/atalk/compat.h
@@ -81,7 +81,7 @@ static inline struct timespec atalk_stat_atime_timespec(const struct stat *st)
 }
 
 static inline void atalk_timespec_to_timeval(struct timeval *tv,
-        const struct timespec *ts)
+                                             const struct timespec *ts)
 {
     tv->tv_sec = ts->tv_sec;
     tv->tv_usec = ts->tv_nsec / 1000;

--- a/include/atalk/netatalk_conf.h
+++ b/include/atalk/netatalk_conf.h
@@ -27,7 +27,7 @@ extern int        load_afp_conf_vols(AFPObj *obj, lv_flags_t flags);
 extern void       unload_volumes(AFPObj *obj);
 extern struct vol *getvolumes(void);
 extern int        conf_cnid_scheme_in_use(const AFPObj *obj,
-        const char *scheme);
+                                          const char *scheme);
 extern struct vol *getvolbyvid(const uint16_t);
 extern struct vol *getvolbypath(AFPObj *obj, const char *path);
 extern struct vol *getvolbyname(const char *name);
@@ -37,7 +37,7 @@ extern void       volume_unlink(struct vol *volume);
 #define NETATALK_READBUF_LIMIT ((uint64_t)1 << 30)
 
 extern int        netatalk_readbuf_clamp(int readbuf, uint32_t quantum,
-        uint64_t limit);
+                                         uint64_t limit);
 
 /* Extension type/creator mapping */
 struct extmap *getdefextmap(void);

--- a/include/atalk/server_child.h
+++ b/include/atalk/server_child.h
@@ -63,10 +63,10 @@ extern void server_child_kill_one_by_id(server_child_t *children, pid_t pid,
                                         uid_t, uint32_t len, char *id,
                                         uint32_t boottime);
 extern int  server_child_set_session_token(server_child_t *children, pid_t pid,
-        uid_t uid, const void *token, size_t token_len);
+                                           uid_t uid, const void *token, size_t token_len);
 extern int  server_child_transfer_session(server_child_t *children, uid_t uid,
-        const void *token, size_t token_len, int afp_socket,
-        uint16_t DSI_requestID);
+                                          const void *token, size_t token_len, int afp_socket,
+                                          uint16_t DSI_requestID);
 extern void server_child_handler(server_child_t *);
 extern void server_child_login_done(server_child_t *children, pid_t pid,
                                     uid_t, const char *client_address);

--- a/include/atalk/uam.h
+++ b/include/atalk/uam.h
@@ -80,7 +80,7 @@ struct session_info {
 
 /* register and unregister uams with these functions */
 extern UAM_MODULE_EXPORT int uam_register(const int, const char *, const char *,
-        ...);
+                                          ...);
 extern UAM_MODULE_EXPORT void uam_unregister(const int, const char *);
 
 /* helper functions */
@@ -89,8 +89,8 @@ extern UAM_MODULE_EXPORT int uam_checkuser(void *, const struct passwd *);
 
 /* afp helper functions */
 extern UAM_MODULE_EXPORT int uam_afp_read(void *, char *, size_t *,
-        int (*)(void *, void *, const int));
+                                          int (*)(void *, void *, const int));
 extern UAM_MODULE_EXPORT int uam_afpserver_option(void *, const int, void *,
-        size_t *);
+                                                  size_t *);
 
 #endif

--- a/include/atalk/unicode.h
+++ b/include/atalk/unicode.h
@@ -120,7 +120,7 @@ extern size_t   charset_strupper(charset_t, const char *, size_t, char *,
 extern size_t   charset_strlower(charset_t, const char *, size_t, char *,
                                  size_t);
 extern size_t   ucs2_to_charset_allocate(charset_t, char **dest,
-        const ucs2_t *src);
+                                         const ucs2_t *src);
 extern size_t   ucs2_to_charset(charset_t, const ucs2_t *src, char *dest,
                                 size_t);
 

--- a/libatalk/acl/ldap.c
+++ b/libatalk/acl/ldap.c
@@ -122,11 +122,11 @@ struct pref_array prefs_array[] = {
  * You MUST dispatch the queries timely, otherwise the LDAP handle might timeout.
  */
 static int ldap_getattr_fromfilter_withbase_scope(const char *searchbase,
-        const char *filter,
-        char *attributes[],
-        int scope,
-        ldapcon_t conflags,
-        char **result)
+                                                  const char *filter,
+                                                  char *attributes[],
+                                                  int scope,
+                                                  ldapcon_t conflags,
+                                                  char **result)
 {
     int ret;
     int ldaperr;

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -691,7 +691,7 @@ static int ad_convert_osx(const char *path, struct adouble *ad)
     ad_setentrylen(ad, ADEID_FINDERI, ADEDLEN_FINDERI);
     ad->ad_rlen = ad_getentrylen(ad, ADEID_RFORK);
     ad_setentryoff(ad, ADEID_RFORK, ad_getentryoff(ad,
-                   ADEID_FINDERI) + ADEDLEN_FINDERI);
+            ADEID_FINDERI) + ADEDLEN_FINDERI);
     EC_ZERO_LOG(ftruncate(ad_reso_fileno(ad),
                           ad_getentryoff(ad, ADEID_RFORK)
                           + ad_getentrylen(ad, ADEID_RFORK)));
@@ -1707,7 +1707,7 @@ static int ad_open_rf_ea(const char *path, int adflags, int mode,
     }
 
     if ((ad_reso_fileno(ad) = sys_getxattrfd(ad_meta_fileno(ad), AD_EA_RESO,
-                              oflags)) == -1) {
+        oflags)) == -1) {
         if (!(adflags & ADFLAGS_CREATE)) {
             switch (errno) {
             case EACCES:
@@ -1727,7 +1727,7 @@ static int ad_open_rf_ea(const char *path, int adflags, int mode,
                 oflags |= O_RDONLY;
 
                 if ((ad_reso_fileno(ad) = sys_getxattrfd(ad_meta_fileno(ad), AD_EA_RESO,
-                                          oflags)) == -1) {
+                    oflags)) == -1) {
                     LOG(log_error, logtype_ad, "ad_open_rf_ea(\"%s\"): \"%s\"", fullpathname(path),
                         strerror(errno));
                     EC_FAIL;
@@ -1746,7 +1746,7 @@ static int ad_open_rf_ea(const char *path, int adflags, int mode,
         } else {
             oflags |= O_CREAT;
             EC_NEG1_LOG(ad_reso_fileno(ad) = sys_getxattrfd(ad_meta_fileno(ad),
-                                             AD_EA_RESO, oflags, 0666));
+                AD_EA_RESO, oflags, 0666));
         }
     }
 
@@ -2422,7 +2422,7 @@ int ad_open(struct adouble *ad, const char *path, int adflags, ...)
 
     if (adflags & ADFLAGS_CREATE) {
         mode = (sizeof(mode_t) < sizeof(int) ? va_arg(args, int) : va_arg(args,
-                mode_t));
+            mode_t));
     }
 
     va_end(args);
@@ -2660,7 +2660,7 @@ int ad_openat(struct adouble  *ad,
 
     if (adflags & ADFLAGS_CREATE) {
         mode = (sizeof(mode_t) < sizeof(int) ? va_arg(args, int) : va_arg(args,
-                mode_t));
+            mode_t));
     }
 
     va_end(args);

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -693,7 +693,7 @@ static int ad_convert_osx(const char *path, struct adouble *ad)
     ad_setentrylen(ad, ADEID_FINDERI, ADEDLEN_FINDERI);
     ad->ad_rlen = ad_getentrylen(ad, ADEID_RFORK);
     ad_setentryoff(ad, ADEID_RFORK, ad_getentryoff(ad,
-                   ADEID_FINDERI) + ADEDLEN_FINDERI);
+                                                   ADEID_FINDERI) + ADEDLEN_FINDERI);
     EC_ZERO_LOG(ftruncate(ad_reso_fileno(ad),
                           ad_getentryoff(ad, ADEID_RFORK)
                           + ad_getentrylen(ad, ADEID_RFORK)));
@@ -1709,7 +1709,7 @@ static int ad_open_rf_ea(const char *path, int adflags, int mode,
     }
 
     if ((ad_reso_fileno(ad) = sys_getxattrfd(ad_meta_fileno(ad), AD_EA_RESO,
-                              oflags)) == -1) {
+                                             oflags)) == -1) {
         if (!(adflags & ADFLAGS_CREATE)) {
             switch (errno) {
             case EACCES:
@@ -1729,7 +1729,7 @@ static int ad_open_rf_ea(const char *path, int adflags, int mode,
                 oflags |= O_RDONLY;
 
                 if ((ad_reso_fileno(ad) = sys_getxattrfd(ad_meta_fileno(ad), AD_EA_RESO,
-                                          oflags)) == -1) {
+                                                         oflags)) == -1) {
                     LOG(log_error, logtype_ad, "ad_open_rf_ea(\"%s\"): \"%s\"", fullpathname(path),
                         strerror(errno));
                     EC_FAIL;
@@ -1748,7 +1748,7 @@ static int ad_open_rf_ea(const char *path, int adflags, int mode,
         } else {
             oflags |= O_CREAT;
             EC_NEG1_LOG(ad_reso_fileno(ad) = sys_getxattrfd(ad_meta_fileno(ad),
-                                             AD_EA_RESO, oflags, 0666));
+                                                            AD_EA_RESO, oflags, 0666));
         }
     }
 
@@ -2424,7 +2424,7 @@ int ad_open(struct adouble *ad, const char *path, int adflags, ...)
 
     if (adflags & ADFLAGS_CREATE) {
         mode = (sizeof(mode_t) < sizeof(int) ? va_arg(args, int) : va_arg(args,
-                mode_t));
+            mode_t));
     }
 
     va_end(args);
@@ -2662,7 +2662,7 @@ int ad_openat(struct adouble  *ad,
 
     if (adflags & ADFLAGS_CREATE) {
         mode = (sizeof(mode_t) < sizeof(int) ? va_arg(args, int) : va_arg(args,
-                mode_t));
+            mode_t));
     }
 
     va_end(args);

--- a/libatalk/cnid/sqlite/cnid_sqlite.c
+++ b/libatalk/cnid/sqlite/cnid_sqlite.c
@@ -992,7 +992,7 @@ EC_CLEANUP:
     return id;
 }
 
-char *cnid_sqlite_resolve(struct _cnid_db *cdb, cnid_t * id, void *buffer,
+char *cnid_sqlite_resolve(struct _cnid_db *cdb, cnid_t *id, void *buffer,
                           size_t len)
 {
     EC_INIT;

--- a/libatalk/cnid/sqlite/cnid_sqlite.c
+++ b/libatalk/cnid/sqlite/cnid_sqlite.c
@@ -1356,7 +1356,7 @@ EC_CLEANUP:
     return id;
 }
 
-char *cnid_sqlite_resolve(struct _cnid_db *cdb, cnid_t * id, void *buffer,
+char *cnid_sqlite_resolve(struct _cnid_db *cdb, cnid_t *id, void *buffer,
                           size_t len)
 {
     EC_INIT;
@@ -1834,7 +1834,7 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
     EC_NULL(cdb = cnid_sqlite_new(vol));
     EC_NULL(db =
                 (CNID_sqlite_private *) calloc(1,
-                    sizeof(CNID_sqlite_private)));
+                                               sizeof(CNID_sqlite_private)));
     cdb->cnid_db_private = db;
 
     if (vol->v_dbpath) {
@@ -2045,7 +2045,7 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
                     "cnid_sqlite_open: refusing to act on malformed stale volume "
                     "UUID for path '%s'; removing its entry", vol->v_path);
                 removed = cnid_sqlite_delete_volumes_row(db->cnid_sqlite_con,
-                          stale_uuids[i]) == 0;
+                                                         stale_uuids[i]) == 0;
 
                 if (!removed) {
                     LOG(log_warning, logtype_cnid,
@@ -2072,12 +2072,12 @@ struct _cnid_db *cnid_sqlite_open(struct cnid_open_args *args)
 
             if (removed) {
                 removed = cnid_sqlite_delete_sequence_row(db->cnid_sqlite_con,
-                          stale_uuids[i]) == 0;
+                                                          stale_uuids[i]) == 0;
             }
 
             if (removed) {
                 removed = cnid_sqlite_delete_volumes_row(db->cnid_sqlite_con,
-                          stale_uuids[i]) == 0;
+                                                         stale_uuids[i]) == 0;
             }
 
             if (!removed) {

--- a/libatalk/dsi/dsi_tcp.c
+++ b/libatalk/dsi/dsi_tcp.c
@@ -279,8 +279,8 @@ static pid_t dsi_tcp_open(DSI *dsi)
                                   DSI_SERVQUANT_DEF : dsi->server_quantum,
                                   mss);
         dsi->dsireadbuf = netatalk_readbuf_clamp((int)dsi->dsireadbuf,
-                          dsi->server_quantum,
-                          NETATALK_READBUF_LIMIT);
+                                                 dsi->server_quantum,
+                                                 NETATALK_READBUF_LIMIT);
 
         if (mss == 0) {
             LOG(log_warning, logtype_dsi,

--- a/libatalk/unicode/charcnv.c
+++ b/libatalk/unicode/charcnv.c
@@ -146,7 +146,7 @@ charset_t add_charset(const char *name)
 
     /* First try to setup the required conversions */
     conv_handles[cur_charset_t][CH_UCS2] = atalk_iconv_open(charset_name(CH_UCS2),
-                                           name);
+        name);
 
     if (conv_handles[cur_charset_t][CH_UCS2] == (atalk_iconv_t) -1) {
         LOG(log_error, logtype_default,
@@ -157,7 +157,7 @@ charset_t add_charset(const char *name)
     }
 
     conv_handles[CH_UCS2][cur_charset_t] = atalk_iconv_open(name,
-                                           charset_name(CH_UCS2));
+        charset_name(CH_UCS2));
 
     if (conv_handles[CH_UCS2][cur_charset_t] == (atalk_iconv_t) -1) {
         LOG(log_error, logtype_default,
@@ -310,7 +310,7 @@ size_t convert_string(charset_t from, charset_t to,
 
     /* convert from_set to UCS2 */
     if ((size_t) -1 == (o_len = convert_string_internal(from, CH_UCS2, src, srclen,
-                                (char *) buffer, sizeof(buffer)))) {
+        (char *) buffer, sizeof(buffer)))) {
         LOG(log_error, logtype_default, "Conversion failed ( %s to CH_UCS2 )",
             charset_name(from));
         return (size_t) -1;
@@ -335,7 +335,7 @@ size_t convert_string(charset_t from, charset_t to,
 
     /* Convert UCS2 to to_set */
     if ((size_t)(-1) == (o_len = convert_string_internal(CH_UCS2, to, (char *) u,
-                                 i_len, dest, destlen))) {
+        i_len, dest, destlen))) {
         LOG(log_error, logtype_default, "Conversion failed (CH_UCS2 to %s):%s",
             charset_name(to), strerror(errno));
         return (size_t) -1;
@@ -467,7 +467,7 @@ size_t convert_string_allocate(charset_t from, charset_t to,
 
     /* convert from_set to UCS2 */
     if ((size_t)(-1) == (o_len = convert_string_internal(from, CH_UCS2, src, srclen,
-                                 buffer, sizeof(buffer)))) {
+        buffer, sizeof(buffer)))) {
         LOG(log_error, logtype_default, "Conversion failed ( %s to CH_UCS2 )",
             charset_name(from));
         return (size_t) -1;
@@ -492,7 +492,7 @@ size_t convert_string_allocate(charset_t from, charset_t to,
 
     /* Convert UCS2 to to_set */
     if ((size_t) -1 == (o_len = convert_string_allocate_internal(CH_UCS2, to,
-                                (char *)u, i_len, dest))) {
+        (char *)u, i_len, dest))) {
         LOG(log_error, logtype_default, "Conversion failed (CH_UCS2 to %s):%s",
             charset_name(to), strerror(errno));
     }
@@ -581,7 +581,7 @@ size_t charset_precompose(charset_t ch, char *src, size_t inlen, char *dst,
     size_t ilen;
 
     if ((size_t)(-1) == (len = convert_string_allocate_internal(ch, CH_UCS2, src,
-                               inlen, &buffer))) {
+        inlen, &buffer))) {
         return len;
     }
 
@@ -593,7 +593,7 @@ size_t charset_precompose(charset_t ch, char *src, size_t inlen, char *dst,
     }
 
     if ((size_t)(-1) == (len = convert_string_internal(CH_UCS2, ch, (char *)u, ilen,
-                               dst, outlen))) {
+        dst, outlen))) {
         free(buffer);
         return (size_t) -1;
     }
@@ -611,7 +611,7 @@ size_t charset_decompose(charset_t ch, char *src, size_t inlen, char *dst,
     size_t ilen;
 
     if ((size_t)(-1) == (len = convert_string_allocate_internal(ch, CH_UCS2, src,
-                               inlen, &buffer))) {
+        inlen, &buffer))) {
         return len;
     }
 
@@ -623,7 +623,7 @@ size_t charset_decompose(charset_t ch, char *src, size_t inlen, char *dst,
     }
 
     if ((size_t)(-1) == (len = convert_string_internal(CH_UCS2, ch, (char *)u, ilen,
-                               dst, outlen))) {
+        dst, outlen))) {
         free(buffer);
         return (size_t) -1;
     }
@@ -1000,8 +1000,8 @@ size_t convert_charset(charset_t from_set, charset_t to_set,
     errno = 0;
 
     if ((size_t)(-1) == (o_len = pull_charset_flags(from_set, to_set, cap_charset,
-                                 src, src_len,
-                                 (char *) buffer, sizeof(buffer) - 2, flags))) {
+        src, src_len,
+        (char *) buffer, sizeof(buffer) - 2, flags))) {
         LOG(log_error, logtype_default,
             "Conversion failed ( %s to CH_UCS2 ), errno %i, %s", charset_name(from_set),
             errno, src);
@@ -1058,7 +1058,7 @@ size_t convert_charset(charset_t from_set, charset_t to_set,
 
     /* Convert UCS2 to to_set */
     if ((size_t)(-1) == (o_len = push_charset_flags(to_set, cap_charset, (char *)u,
-                                 i_len, dest, dest_capacity, flags))) {
+        i_len, dest, dest_capacity, flags))) {
         LOG(log_error, logtype_default,
             "Conversion failed (CH_UCS2 to %s):%s", charset_name(to_set), strerror(errno));
         return (size_t) -1;

--- a/libatalk/unicode/charcnv.c
+++ b/libatalk/unicode/charcnv.c
@@ -146,7 +146,7 @@ charset_t add_charset(const char *name)
 
     /* First try to setup the required conversions */
     conv_handles[cur_charset_t][CH_UCS2] = atalk_iconv_open(charset_name(CH_UCS2),
-                                           name);
+                                                            name);
 
     if (conv_handles[cur_charset_t][CH_UCS2] == (atalk_iconv_t) -1) {
         LOG(log_error, logtype_default,
@@ -157,7 +157,7 @@ charset_t add_charset(const char *name)
     }
 
     conv_handles[CH_UCS2][cur_charset_t] = atalk_iconv_open(name,
-                                           charset_name(CH_UCS2));
+                                                            charset_name(CH_UCS2));
 
     if (conv_handles[CH_UCS2][cur_charset_t] == (atalk_iconv_t) -1) {
         LOG(log_error, logtype_default,
@@ -310,7 +310,7 @@ size_t convert_string(charset_t from, charset_t to,
 
     /* convert from_set to UCS2 */
     if ((size_t) -1 == (o_len = convert_string_internal(from, CH_UCS2, src, srclen,
-                                (char *) buffer, sizeof(buffer)))) {
+                                                        (char *) buffer, sizeof(buffer)))) {
         LOG(log_error, logtype_default, "Conversion failed ( %s to CH_UCS2 )",
             charset_name(from));
         return (size_t) -1;
@@ -335,7 +335,7 @@ size_t convert_string(charset_t from, charset_t to,
 
     /* Convert UCS2 to to_set */
     if ((size_t)(-1) == (o_len = convert_string_internal(CH_UCS2, to, (char *) u,
-                                 i_len, dest, destlen))) {
+                                                         i_len, dest, destlen))) {
         LOG(log_error, logtype_default, "Conversion failed (CH_UCS2 to %s):%s",
             charset_name(to), strerror(errno));
         return (size_t) -1;
@@ -361,7 +361,7 @@ size_t convert_string(charset_t from, charset_t to,
  */
 
 static size_t convert_string_allocate_internal(charset_t from, charset_t to,
-        void const *src, size_t srclen, char **dest)
+                                               void const *src, size_t srclen, char **dest)
 {
     size_t i_len, o_len, destlen;
     size_t retval;
@@ -467,7 +467,7 @@ size_t convert_string_allocate(charset_t from, charset_t to,
 
     /* convert from_set to UCS2 */
     if ((size_t)(-1) == (o_len = convert_string_internal(from, CH_UCS2, src, srclen,
-                                 buffer, sizeof(buffer)))) {
+                                                         buffer, sizeof(buffer)))) {
         LOG(log_error, logtype_default, "Conversion failed ( %s to CH_UCS2 )",
             charset_name(from));
         return (size_t) -1;
@@ -492,7 +492,7 @@ size_t convert_string_allocate(charset_t from, charset_t to,
 
     /* Convert UCS2 to to_set */
     if ((size_t) -1 == (o_len = convert_string_allocate_internal(CH_UCS2, to,
-                                (char *)u, i_len, dest))) {
+        (char *)u, i_len, dest))) {
         LOG(log_error, logtype_default, "Conversion failed (CH_UCS2 to %s):%s",
             charset_name(to), strerror(errno));
     }
@@ -581,7 +581,7 @@ size_t charset_precompose(charset_t ch, char *src, size_t inlen, char *dst,
     size_t ilen;
 
     if ((size_t)(-1) == (len = convert_string_allocate_internal(ch, CH_UCS2, src,
-                               inlen, &buffer))) {
+                                                                inlen, &buffer))) {
         return len;
     }
 
@@ -593,7 +593,7 @@ size_t charset_precompose(charset_t ch, char *src, size_t inlen, char *dst,
     }
 
     if ((size_t)(-1) == (len = convert_string_internal(CH_UCS2, ch, (char *)u, ilen,
-                               dst, outlen))) {
+                                                       dst, outlen))) {
         free(buffer);
         return (size_t) -1;
     }
@@ -611,7 +611,7 @@ size_t charset_decompose(charset_t ch, char *src, size_t inlen, char *dst,
     size_t ilen;
 
     if ((size_t)(-1) == (len = convert_string_allocate_internal(ch, CH_UCS2, src,
-                               inlen, &buffer))) {
+                                                                inlen, &buffer))) {
         return len;
     }
 
@@ -623,7 +623,7 @@ size_t charset_decompose(charset_t ch, char *src, size_t inlen, char *dst,
     }
 
     if ((size_t)(-1) == (len = convert_string_internal(CH_UCS2, ch, (char *)u, ilen,
-                               dst, outlen))) {
+                                                       dst, outlen))) {
         free(buffer);
         return (size_t) -1;
     }
@@ -1000,8 +1000,8 @@ size_t convert_charset(charset_t from_set, charset_t to_set,
     errno = 0;
 
     if ((size_t)(-1) == (o_len = pull_charset_flags(from_set, to_set, cap_charset,
-                                 src, src_len,
-                                 (char *) buffer, sizeof(buffer) - 2, flags))) {
+                                                    src, src_len,
+                                                    (char *) buffer, sizeof(buffer) - 2, flags))) {
         LOG(log_error, logtype_default,
             "Conversion failed ( %s to CH_UCS2 ), errno %i, %s", charset_name(from_set),
             errno, src);
@@ -1017,7 +1017,7 @@ size_t convert_charset(charset_t from_set, charset_t to_set,
     u = buffer2;
 
     if (CHECK_FLAGS(flags, CONV_DECOMPOSE) || (charsets[to_set]
-            && (charsets[to_set]->flags & CHARSET_DECOMPOSED))) {
+                                               && (charsets[to_set]->flags & CHARSET_DECOMPOSED))) {
         if ((size_t) -1 == (i_len = decompose_w(buffer, o_len, u, &i_len))) {
             return (size_t) -1;
         }
@@ -1058,7 +1058,7 @@ size_t convert_charset(charset_t from_set, charset_t to_set,
 
     /* Convert UCS2 to to_set */
     if ((size_t)(-1) == (o_len = push_charset_flags(to_set, cap_charset, (char *)u,
-                                 i_len, dest, dest_capacity, flags))) {
+                                                    i_len, dest, dest_capacity, flags))) {
         LOG(log_error, logtype_default,
             "Conversion failed (CH_UCS2 to %s):%s", charset_name(to_set), strerror(errno));
         return (size_t) -1;

--- a/libatalk/unicode/charsets/generic_cjk.c
+++ b/libatalk/unicode/charsets/generic_cjk.c
@@ -40,7 +40,7 @@ static size_t cjk_iconv(void *cd, char **inbuf, char *end,
 }
 
 size_t cjk_generic_push(size_t (*char_func)(uint8_t *, const ucs2_t *,
-                        size_t *),
+        size_t *),
                         void *cd, char **inbuf, size_t *inbytesleft,
                         char **outbuf, size_t *outbytesleft)
 {
@@ -101,7 +101,7 @@ size_t cjk_generic_push(size_t (*char_func)(uint8_t *, const ucs2_t *,
 }
 
 size_t cjk_generic_pull(size_t (*char_func)(ucs2_t *, const uint8_t *,
-                        size_t *),
+        size_t *),
                         void *cd, char **inbuf, size_t *inbytesleft,
                         char **outbuf, size_t *outbytesleft)
 {

--- a/libatalk/unicode/charsets/generic_cjk.c
+++ b/libatalk/unicode/charsets/generic_cjk.c
@@ -40,7 +40,7 @@ static size_t cjk_iconv(void *cd, char **inbuf, char *end,
 }
 
 size_t cjk_generic_push(size_t (*char_func)(uint8_t *, const ucs2_t *,
-                        size_t *),
+                                            size_t *),
                         void *cd, char **inbuf, size_t *inbytesleft,
                         char **outbuf, size_t *outbytesleft)
 {
@@ -101,7 +101,7 @@ size_t cjk_generic_push(size_t (*char_func)(uint8_t *, const ucs2_t *,
 }
 
 size_t cjk_generic_pull(size_t (*char_func)(ucs2_t *, const uint8_t *,
-                        size_t *),
+                                            size_t *),
                         void *cd, char **inbuf, size_t *inbytesleft,
                         char **outbuf, size_t *outbytesleft)
 {

--- a/libatalk/unicode/charsets/mac_chinese_simp.c
+++ b/libatalk/unicode/charsets/mac_chinese_simp.c
@@ -50,7 +50,7 @@ struct charset_functions charset_mac_chinese_simp = {
 };
 
 static size_t mac_chinese_simp_char_push(uint8_t *out, const ucs2_t *in,
-        size_t *size)
+                                         size_t *size)
 {
     ucs2_t wc = in[0];
 
@@ -87,7 +87,7 @@ static size_t mac_chinese_simp_push(void *cd, char **inbuf, size_t *inbytesleft,
 }
 
 static size_t mac_chinese_simp_char_pull(ucs2_t *out, const uint8_t *in,
-        size_t *size)
+                                         size_t *size)
 {
     uint16_t c = in[0];
 

--- a/libatalk/unicode/charsets/mac_chinese_trad.c
+++ b/libatalk/unicode/charsets/mac_chinese_trad.c
@@ -50,7 +50,7 @@ struct charset_functions charset_mac_chinese_trad = {
 };
 
 static size_t mac_chinese_trad_char_push(uint8_t *out, const ucs2_t *in,
-        size_t *size)
+                                         size_t *size)
 {
     ucs2_t wc = in[0];
 
@@ -93,7 +93,7 @@ static size_t mac_chinese_trad_push(void *cd, char **inbuf, size_t *inbytesleft,
 }
 
 static size_t mac_chinese_trad_char_pull(ucs2_t *out, const uint8_t *in,
-        size_t *size)
+                                         size_t *size)
 {
     uint16_t c = in[0];
 

--- a/libatalk/unicode/util_unistr.c
+++ b/libatalk/unicode/util_unistr.c
@@ -311,7 +311,7 @@ int strcasecmp_w(const ucs2_t *a, const ucs2_t *b)
     while (*a && *b) {
         if ((0xD800 <= *a) && (*a < 0xDC00)) {
             if ((ret = tolower_sp((uint32_t) * a << 16 | (uint32_t)a[1]) - tolower_sp((
-                           uint32_t) * b << 16 | (uint32_t)b[1]))) {
+                    uint32_t) * b << 16 | (uint32_t)b[1]))) {
                 return ret;
             }
 
@@ -348,7 +348,7 @@ int strncasecmp_w(const ucs2_t *a, const ucs2_t *b, size_t len)
     while ((n < len) && *a && *b) {
         if ((0xD800 <= *a) && (*a < 0xDC00)) {
             if ((ret = tolower_sp((uint32_t) * a << 16 | (uint32_t)a[1]) - tolower_sp((
-                           uint32_t) * b << 16 | (uint32_t)b[1]))) {
+                    uint32_t) * b << 16 | (uint32_t)b[1]))) {
                 return ret;
             }
 
@@ -451,7 +451,7 @@ static uint32_t do_precomposition_sp(unsigned int base_sp, unsigned int comb_sp)
     while (max >= min) {
         mid = (min + max) / 2;
         that_sp = ((uint64_t)precompositions_sp[mid].base_sp << 32) | ((
-                      uint64_t)precompositions_sp[mid].comb_sp);
+                uint64_t)precompositions_sp[mid].comb_sp);
 
         if (that_sp < sought_sp) {
             min = mid + 1;
@@ -515,7 +515,7 @@ static uint64_t do_decomposition_sp(unsigned int base_sp)
             max = mid - 1;
         } else {
             result_sp = ((uint64_t)decompositions_sp[mid].base_sp << 32) | ((
-                            uint64_t)decompositions_sp[mid].comb_sp);
+                    uint64_t)decompositions_sp[mid].comb_sp);
             return result_sp;
         }
     }

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -1265,7 +1265,7 @@ static struct vol *creatvol(AFPObj *obj,
         }
 
         if (hostaccessvol(obj, section, getoption_str(obj->iniconfig, section,
-                          "hosts deny", preset, NULL)) == 1) {
+                "hosts deny", preset, NULL)) == 1) {
             LOG(log_debug, logtype_afpd,
                 "creatvol: host is in hosts deny list for volume \"%s\"",
                 section);
@@ -1273,7 +1273,7 @@ static struct vol *creatvol(AFPObj *obj,
         }
 
         if (hostaccessvol(obj, section, getoption_str(obj->iniconfig, section,
-                          "hosts allow", preset, NULL)) == 0) {
+                "hosts allow", preset, NULL)) == 0) {
             LOG(log_debug, logtype_afpd,
                 "creatvol: host is NOT in hosts allow list for volume \"%s\"",
                 section);
@@ -1619,7 +1619,7 @@ static struct vol *creatvol(AFPObj *obj,
             (accessvol(obj, getoption_str(obj->iniconfig, section, "rolist", preset, NULL),
                        pwd->pw_name) == 1
              || accessvol(obj, getoption_str(obj->iniconfig, section, "rwlist", preset,
-                          NULL), pwd->pw_name) == 0)
+                     NULL), pwd->pw_name) == 0)
        ) {
         volume->v_flags |= AFPVOL_RO;
     }
@@ -2817,7 +2817,7 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     options->logfile = getoption_strdup(config, INISEC_GLOBAL, "log file", NULL,
                                         NULL);
     options->log_us_timestamp = getoption_bool(config, INISEC_GLOBAL,
-                                "log microseconds", NULL, 1);
+        "log microseconds", NULL, 1);
     setuplog(options->logconfig, options->logfile, options->log_us_timestamp);
 
     /* "server options" boolean options */
@@ -2899,44 +2899,44 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
 
     /* figure out options w values */
     options->loginmesg      = getoption_strdup(config, INISEC_GLOBAL,
-                              "login message",  NULL, NULL);
+        "login message",  NULL, NULL);
     options->guest          = getoption_strdup(config, INISEC_GLOBAL,
-                              "guest account",  NULL, "nobody");
+        "guest account",  NULL, "nobody");
     options->extmapfile     = getoption_strdup(config, INISEC_GLOBAL, "extmap file",
-                              NULL, _PATH_CONFDIR "extmap.conf");
+        NULL, _PATH_CONFDIR "extmap.conf");
     options->passwdfile     = getoption_strdup(config, INISEC_GLOBAL, "passwd file",
-                              NULL, _PATH_AFPDPWFILE);
+        NULL, _PATH_AFPDPWFILE);
     options->srppasswdfile  = getoption_strdup(config, INISEC_GLOBAL,
-                              "srp passwd file",
-                              NULL, _PATH_AFPDSRPPWFILE);
+        "srp passwd file",
+        NULL, _PATH_AFPDSRPPWFILE);
     options->uampath        = getoption_strdup(config, INISEC_GLOBAL, "uam path",
-                              NULL, _PATH_AFPDUAMPATH);
+        NULL, _PATH_AFPDUAMPATH);
     options->uamlist        = getoption_strdup(config, INISEC_GLOBAL, "uam list",
-                              NULL, "uams_dhx2.so");
+        NULL, "uams_dhx2.so");
     options->port           = getoption_strdup(config, INISEC_GLOBAL, "afp port",
-                              NULL, "548");
+        NULL, "548");
     options->signatureopt   = getoption_strdup(config, INISEC_GLOBAL, "signature",
-                              NULL, "");
+        NULL, "");
     options->k5service      = getoption_strdup(config, INISEC_GLOBAL, "k5 service",
-                              NULL, NULL);
+        NULL, NULL);
     options->k5realm        = getoption_strdup(config, INISEC_GLOBAL, "k5 realm",
-                              NULL, NULL);
+        NULL, NULL);
     options->listen         = getoption_strdup(config, INISEC_GLOBAL, "afp listen",
-                              NULL, NULL);
+        NULL, NULL);
     options->interfaces     = getoption_strdup(config, INISEC_GLOBAL,
-                              "afp interfaces", NULL, NULL);
+        "afp interfaces", NULL, NULL);
     options->ntdomain       = getoption_strdup(config, INISEC_GLOBAL, "nt domain",
-                              NULL, NULL);
+        NULL, NULL);
     options->addomain       = getoption_strdup(config, INISEC_GLOBAL, "ad domain",
-                              NULL, NULL);
+        NULL, NULL);
     options->ntseparator    = getoption_strdup(config, INISEC_GLOBAL,
-                              "nt separator",   NULL, NULL);
+        "nt separator",   NULL, NULL);
     options->legacyicon     = getoption_strdup(config, INISEC_GLOBAL, "legacy icon",
-                              NULL, "");
+        NULL, "");
     options->mimicmodel     = getoption_strdup(config, INISEC_GLOBAL, "mimic model",
-                              NULL, NULL);
+        NULL, NULL);
     options->servername     = getoption_strdup(config, INISEC_GLOBAL, "server name",
-                              NULL, NULL);
+        NULL, NULL);
 
     if (options->servername == NULL) {
         options->servername = getoption_strdup(config, INISEC_GLOBAL, "zeroconf name",
@@ -2949,19 +2949,19 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     }
 
     options->ignored_attr   = getoption_strdup(config, INISEC_GLOBAL,
-                              "ignored attributes", NULL, NULL);
+        "ignored attributes", NULL, NULL);
     options->cnid_mysql_host = getoption_strdup(config, INISEC_GLOBAL,
-                               "cnid mysql host", NULL, NULL);
+        "cnid mysql host", NULL, NULL);
     options->cnid_mysql_user = getoption_strdup(config, INISEC_GLOBAL,
-                               "cnid mysql user", NULL, NULL);
+        "cnid mysql user", NULL, NULL);
     options->cnid_mysql_pw  = getoption_strdup(config, INISEC_GLOBAL,
-                              "cnid mysql pw", NULL, NULL);
+        "cnid mysql pw", NULL, NULL);
     options->cnid_mysql_db  = getoption_strdup(config, INISEC_GLOBAL,
-                              "cnid mysql db",  NULL, NULL);
+        "cnid mysql db",  NULL, NULL);
     options->connections    = getoption_int(config, INISEC_GLOBAL,
                                             "max connections", NULL, 200);
     options->passwdminlen   = (unsigned char) getoption_int(config, INISEC_GLOBAL,
-                              "passwd minlen", NULL, 0);
+        "passwd minlen", NULL, 0);
     options->tickleval      = getoption_int(config, INISEC_GLOBAL, "tickleval",
                                             NULL, 30);
     options->timeout        = getoption_int(config, INISEC_GLOBAL, "timeout",
@@ -2969,9 +2969,9 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     options->dsireadbuf     = getoption_int(config, INISEC_GLOBAL, "dsireadbuf",
                                             NULL, 12);
     options->server_quantum = getoption_uint32_strict(config, INISEC_GLOBAL,
-                              "server quantum", NULL,
-                              DSI_SERVQUANT_MIN, DSI_SERVQUANT_MAX,
-                              DSI_SERVQUANT_DEF);
+        "server quantum", NULL,
+        DSI_SERVQUANT_MIN, DSI_SERVQUANT_MAX,
+        DSI_SERVQUANT_DEF);
     options->volnamelen     = getoption_int(config, INISEC_GLOBAL, "volnamelen",
                                             NULL, 80);
     options->dircachesize   = getoption_int(config, INISEC_GLOBAL, "dircache size",
@@ -3010,14 +3010,14 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     }
     /* Parse dircache validation parameter */
     options->dircache_validation_freq = getoption_int(config, INISEC_GLOBAL,
-                                        "dircache validation freq", NULL,
-                                        DEFAULT_DIRCACHE_VALIDATION_FREQ);
+        "dircache validation freq", NULL,
+        DEFAULT_DIRCACHE_VALIDATION_FREQ);
     /* Tier 2: Resource Fork data cache configuration.
      * Hard caps defined in globals.h: RFORK_BUDGET_MAX_KB, RFORK_ENTRY_MAX_KB.
      * On 32-bit platforms, clamp to SIZE_MAX / 1024 to prevent overflow
      * when converting KB to bytes in dircache_init(). */
     options->dircache_rfork_budget = getoption_int(config, INISEC_GLOBAL,
-                                     "dircache rfork budget", NULL, 0);
+        "dircache rfork budget", NULL, 0);
 
     if (options->dircache_rfork_budget < 0) {
         options->dircache_rfork_budget = 0;
@@ -3039,7 +3039,7 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
 
 #endif
     options->dircache_rfork_maxentry = getoption_int(config, INISEC_GLOBAL,
-                                       "dircache rfork maxsize", NULL, 1024);
+        "dircache rfork maxsize", NULL, 1024);
 
     if (options->dircache_rfork_maxentry < 0) {
         options->dircache_rfork_maxentry = 0;

--- a/libatalk/util/netatalk_conf.c
+++ b/libatalk/util/netatalk_conf.c
@@ -1561,7 +1561,7 @@ static struct vol *creatvol(AFPObj *obj,
         }
 
         if (hostaccessvol(obj, section, getoption_str(obj->iniconfig, section,
-                          "hosts deny", preset, NULL)) == 1) {
+                                                      "hosts deny", preset, NULL)) == 1) {
             LOG(log_debug, logtype_afpd,
                 "creatvol: host is in hosts deny list for volume \"%s\"",
                 section);
@@ -1569,7 +1569,7 @@ static struct vol *creatvol(AFPObj *obj,
         }
 
         if (hostaccessvol(obj, section, getoption_str(obj->iniconfig, section,
-                          "hosts allow", preset, NULL)) == 0) {
+                                                      "hosts allow", preset, NULL)) == 0) {
             LOG(log_debug, logtype_afpd,
                 "creatvol: host is NOT in hosts allow list for volume \"%s\"",
                 section);
@@ -1902,7 +1902,7 @@ static struct vol *creatvol(AFPObj *obj,
             (accessvol(obj, getoption_str(obj->iniconfig, section, "rolist", preset, NULL),
                        pwd->pw_name) == 1
              || accessvol(obj, getoption_str(obj->iniconfig, section, "rwlist", preset,
-                          NULL), pwd->pw_name) == 0)
+                                             NULL), pwd->pw_name) == 0)
        ) {
         volume->v_flags |= AFPVOL_RO;
     }
@@ -3192,7 +3192,7 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     options->logfile = getoption_strdup(config, INISEC_GLOBAL, "log file", NULL,
                                         NULL);
     options->log_us_timestamp = getoption_bool(config, INISEC_GLOBAL,
-                                "log microseconds", NULL, 1);
+                                               "log microseconds", NULL, 1);
     setuplog(options->logconfig, options->logfile, options->log_us_timestamp);
 
     /* "server options" boolean options */
@@ -3251,12 +3251,12 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
      * explicit new-key value always beats the alias. */
     {
         const char *raw_alias = INIPARSER_GETSTR(config, INISEC_GLOBAL,
-                                "afp read locks", NULL);
+                                                 "afp read locks", NULL);
         int strict_locking = conf_parse_bool("strict locking",
                                              INIPARSER_GETSTR(config,
-                                                 INISEC_GLOBAL,
-                                                 "strict locking",
-                                                 NULL));
+                                                              INISEC_GLOBAL,
+                                                              "strict locking",
+                                                              NULL));
 
         /* Notice keys on key presence with a non-empty value (valid or
          * not), not on parse success; empty counts as unset. */
@@ -3305,44 +3305,44 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
 
     /* figure out options w values */
     options->loginmesg      = getoption_strdup(config, INISEC_GLOBAL,
-                              "login message",  NULL, NULL);
+                                               "login message",  NULL, NULL);
     options->guest          = getoption_strdup(config, INISEC_GLOBAL,
-                              "guest account",  NULL, "nobody");
+                                               "guest account",  NULL, "nobody");
     options->extmapfile     = getoption_strdup(config, INISEC_GLOBAL, "extmap file",
-                              NULL, _PATH_CONFDIR "extmap.conf");
+                                               NULL, _PATH_CONFDIR "extmap.conf");
     options->passwdfile     = getoption_strdup(config, INISEC_GLOBAL, "passwd file",
-                              NULL, _PATH_AFPDPWFILE);
+                                               NULL, _PATH_AFPDPWFILE);
     options->srppasswdfile  = getoption_strdup(config, INISEC_GLOBAL,
-                              "srp passwd file",
-                              NULL, _PATH_AFPDSRPPWFILE);
+                                               "srp passwd file",
+                                               NULL, _PATH_AFPDSRPPWFILE);
     options->uampath        = getoption_strdup(config, INISEC_GLOBAL, "uam path",
-                              NULL, _PATH_AFPDUAMPATH);
+                                               NULL, _PATH_AFPDUAMPATH);
     options->uamlist        = getoption_strdup(config, INISEC_GLOBAL, "uam list",
-                              NULL, "uams_dhx2.so");
+                                               NULL, "uams_dhx2.so");
     options->port           = getoption_strdup(config, INISEC_GLOBAL, "afp port",
-                              NULL, "548");
+                                               NULL, "548");
     options->signatureopt   = getoption_strdup(config, INISEC_GLOBAL, "signature",
-                              NULL, "");
+                                               NULL, "");
     options->k5service      = getoption_strdup(config, INISEC_GLOBAL, "k5 service",
-                              NULL, NULL);
+                                               NULL, NULL);
     options->k5realm        = getoption_strdup(config, INISEC_GLOBAL, "k5 realm",
-                              NULL, NULL);
+                                               NULL, NULL);
     options->listen         = getoption_strdup(config, INISEC_GLOBAL, "afp listen",
-                              NULL, NULL);
+                                               NULL, NULL);
     options->interfaces     = getoption_strdup(config, INISEC_GLOBAL,
-                              "afp interfaces", NULL, NULL);
+                                               "afp interfaces", NULL, NULL);
     options->ntdomain       = getoption_strdup(config, INISEC_GLOBAL, "nt domain",
-                              NULL, NULL);
+                                               NULL, NULL);
     options->addomain       = getoption_strdup(config, INISEC_GLOBAL, "ad domain",
-                              NULL, NULL);
+                                               NULL, NULL);
     options->ntseparator    = getoption_strdup(config, INISEC_GLOBAL,
-                              "nt separator",   NULL, NULL);
+                                               "nt separator",   NULL, NULL);
     options->legacyicon     = getoption_strdup(config, INISEC_GLOBAL, "legacy icon",
-                              NULL, "");
+                                               NULL, "");
     options->mimicmodel     = getoption_strdup(config, INISEC_GLOBAL, "mimic model",
-                              NULL, NULL);
+                                               NULL, NULL);
     options->servername     = getoption_strdup(config, INISEC_GLOBAL, "server name",
-                              NULL, NULL);
+                                               NULL, NULL);
 
     if (options->servername == NULL) {
         options->servername = getoption_strdup(config, INISEC_GLOBAL, "zeroconf name",
@@ -3355,19 +3355,19 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     }
 
     options->ignored_attr   = getoption_strdup(config, INISEC_GLOBAL,
-                              "ignored attributes", NULL, NULL);
+                                               "ignored attributes", NULL, NULL);
     options->cnid_mysql_host = getoption_strdup(config, INISEC_GLOBAL,
-                               "cnid mysql host", NULL, NULL);
+                                                "cnid mysql host", NULL, NULL);
     options->cnid_mysql_user = getoption_strdup(config, INISEC_GLOBAL,
-                               "cnid mysql user", NULL, NULL);
+                                                "cnid mysql user", NULL, NULL);
     options->cnid_mysql_pw  = getoption_strdup(config, INISEC_GLOBAL,
-                              "cnid mysql pw", NULL, NULL);
+                                               "cnid mysql pw", NULL, NULL);
     options->cnid_mysql_db  = getoption_strdup(config, INISEC_GLOBAL,
-                              "cnid mysql db",  NULL, NULL);
+                                               "cnid mysql db",  NULL, NULL);
     options->connections    = getoption_int(config, INISEC_GLOBAL,
                                             "max connections", NULL, 200);
     options->passwdminlen   = (unsigned char) getoption_int(config, INISEC_GLOBAL,
-                              "passwd minlen", NULL, 0);
+                                                            "passwd minlen", NULL, 0);
     options->tickleval      = getoption_int(config, INISEC_GLOBAL, "tickleval",
                                             NULL, 30);
     options->timeout        = getoption_int(config, INISEC_GLOBAL, "timeout",
@@ -3375,9 +3375,9 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
     options->dsireadbuf     = getoption_int(config, INISEC_GLOBAL, "dsireadbuf",
                                             NULL, 32);
     options->server_quantum = getoption_uint32_strict(config, INISEC_GLOBAL,
-                              "server quantum", NULL,
-                              DSI_SERVQUANT_MIN, UINT32_MAX,
-                              DSI_SERVQUANT_DEF);
+                                                      "server quantum", NULL,
+                                                      DSI_SERVQUANT_MIN, UINT32_MAX,
+                                                      DSI_SERVQUANT_DEF);
 
     if (options->server_quantum > DSI_SERVQUANT_MAX) {
         LOG(log_warning, logtype_afpd,
@@ -3442,7 +3442,7 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
      * On 32-bit platforms, clamp to SIZE_MAX / 1024 to prevent overflow
      * when converting KB to bytes in dircache_init(). */
     options->dircache_rfork_budget = getoption_int(config, INISEC_GLOBAL,
-                                     "dircache rfork budget", NULL, 32768);
+                                                   "dircache rfork budget", NULL, 32768);
     /* multi protocol adjusts defaults only: record whether the key was set */
     options->dircache_rfork_budget_explicit =
         conf_key_present(config, "dircache rfork budget");
@@ -3467,7 +3467,7 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
 
 #endif
     options->dircache_rfork_maxentry = getoption_int(config, INISEC_GLOBAL,
-                                       "dircache rfork maxsize", NULL, 1024);
+                                                     "dircache rfork maxsize", NULL, 1024);
 
     if (options->dircache_rfork_maxentry < 0) {
         options->dircache_rfork_maxentry = 0;
@@ -3499,9 +3499,9 @@ int afp_config_parse(AFPObj *AFPObj, char *processname)
      * canonical key decides the value. */
     {
         const char *raw_alias = INIPARSER_GETSTR(config, INISEC_GLOBAL,
-                                "sparql results limit", NULL);
+                                                 "sparql results limit", NULL);
         const char *raw_canon = INIPARSER_GETSTR(config, INISEC_GLOBAL,
-                                "spotlight results limit", NULL);
+                                                 "spotlight results limit", NULL);
         const char *key = (raw_canon && *raw_canon)
                           ? "spotlight results limit"
                           : ((raw_alias

--- a/libatalk/vfs/ea_ad.c
+++ b/libatalk/vfs/ea_ad.c
@@ -98,9 +98,9 @@ static char *mtoupath(const struct vol *vol, const char *mpath)
     outlen = MAXPATHLEN;
 
     if ((size_t) -1 == (outlen = convert_charset(CH_UTF8_MAC,
-                                 vol->v_volcharset,
-                                 vol->v_maccharset,
-                                 m, inplen, u, outlen, &flags))) {
+        vol->v_volcharset,
+        vol->v_maccharset,
+        m, inplen, u, outlen, &flags))) {
         return NULL;
     }
 
@@ -196,7 +196,7 @@ static int unpack_header(struct ea *ea)
         }
 
         (*(ea->ea_entries))[count].ea_namelen = strlen((*
-                                                (ea->ea_entries))[count].ea_name);
+            (ea->ea_entries))[count].ea_name);
         buf += (*(ea->ea_entries))[count].ea_namelen + 1;
         LOG(log_maxdebug, logtype_afpd,
             "unpack_header: entry no:%u,\"%s\", size: %u, namelen: %u", count,

--- a/libatalk/vfs/ea_ad.c
+++ b/libatalk/vfs/ea_ad.c
@@ -98,9 +98,9 @@ static char *mtoupath(const struct vol *vol, const char *mpath)
     outlen = MAXPATHLEN;
 
     if ((size_t) -1 == (outlen = convert_charset(CH_UTF8_MAC,
-                                 vol->v_volcharset,
-                                 vol->v_maccharset,
-                                 m, inplen, u, outlen, &flags))) {
+                                                 vol->v_volcharset,
+                                                 vol->v_maccharset,
+                                                 m, inplen, u, outlen, &flags))) {
         return NULL;
     }
 
@@ -196,7 +196,7 @@ static int unpack_header(struct ea *ea)
         }
 
         (*(ea->ea_entries))[count].ea_namelen = strlen((*
-                                                (ea->ea_entries))[count].ea_name);
+                                                        (ea->ea_entries))[count].ea_name);
         buf += (*(ea->ea_entries))[count].ea_namelen + 1;
         LOG(log_maxdebug, logtype_afpd,
             "unpack_header: entry no:%u,\"%s\", size: %u, namelen: %u", count,

--- a/libatalk/vfs/vfs.c
+++ b/libatalk/vfs/vfs.c
@@ -946,7 +946,7 @@ static int vfs_solaris_acl(const struct vol *vol, const char *path, int cmd,
     for (int i = 0; i < VFS_MODULES_MAX; i++) {
         if (vol->vfs_modules[i] && vol->vfs_modules[i]->vfs_solaris_acl) {
             int curr_ret = vol->vfs_modules[i]->vfs_solaris_acl(vol, path, cmd, count,
-                           aces);
+                aces);
 
             if (curr_ret != AFP_OK) {
                 ret = curr_ret;
@@ -1018,7 +1018,7 @@ static int vfs_ea_getsize(const struct vol *vol, char *rbuf,
     for (int i = 0; i < VFS_MODULES_MAX; i++) {
         if (vol->vfs_modules[i] && vol->vfs_modules[i]->vfs_ea_getsize) {
             int curr_ret = vol->vfs_modules[i]->vfs_ea_getsize(vol, rbuf, rbuflen, uname,
-                           oflag, attruname, fd);
+                oflag, attruname, fd);
 
             if (curr_ret != AFP_OK) {
                 ret = curr_ret;
@@ -1042,7 +1042,7 @@ static int vfs_ea_getcontent(const struct vol *vol, char *rbuf, size_t *rbuflen,
     for (int i = 0; i < VFS_MODULES_MAX; i++) {
         if (vol->vfs_modules[i] && vol->vfs_modules[i]->vfs_ea_getcontent) {
             int curr_ret = vol->vfs_modules[i]->vfs_ea_getcontent(vol, rbuf, rbuflen, uname,
-                           oflag, attruname, maxreply, fd);
+                oflag, attruname, maxreply, fd);
 
             if (curr_ret != AFP_OK) {
                 ret = curr_ret;
@@ -1062,7 +1062,7 @@ static int vfs_ea_list(const struct vol *vol,
     for (int i = 0; i < VFS_MODULES_MAX; i++) {
         if (vol->vfs_modules[i] && vol->vfs_modules[i]->vfs_ea_list) {
             int curr_ret = vol->vfs_modules[i]->vfs_ea_list(vol, attrnamebuf, buflen, uname,
-                           oflag, fd);
+                oflag, fd);
 
             if (curr_ret != AFP_OK) {
                 ret = curr_ret;
@@ -1086,7 +1086,7 @@ static int vfs_ea_set(const struct vol *vol, const char *uname,
     for (int i = 0; i < VFS_MODULES_MAX; i++) {
         if (vol->vfs_modules[i] && vol->vfs_modules[i]->vfs_ea_set) {
             int curr_ret = vol->vfs_modules[i]->vfs_ea_set(vol, uname, attruname, ibuf,
-                           attrsize, oflag, fd);
+                attrsize, oflag, fd);
 
             if (curr_ret != AFP_OK) {
                 ret = curr_ret;
@@ -1109,7 +1109,7 @@ static int vfs_ea_remove(const struct vol *vol, const char *uname,
     for (int i = 0; i < VFS_MODULES_MAX; i++) {
         if (vol->vfs_modules[i] && vol->vfs_modules[i]->vfs_ea_remove) {
             int curr_ret = vol->vfs_modules[i]->vfs_ea_remove(vol, uname, attruname, oflag,
-                           fd);
+                fd);
 
             if (curr_ret != AFP_OK) {
                 ret = curr_ret;

--- a/libatalk/vfs/vfs.c
+++ b/libatalk/vfs/vfs.c
@@ -543,7 +543,7 @@ static int RF_renamedir_ea(const struct vol *vol _U_, int dirfd _U_,
 
 /* Returns 1 if the entry is NOT an ._ file */
 static int deletecurdir_ea_osx_chkifempty_loop(const struct vol *vol,
-        struct dirent *de, char *name, void *data _U_, int flag _U_)
+                                               struct dirent *de, char *name, void *data _U_, int flag _U_)
 {
     if (de->d_name[0] != '.' || de->d_name[0] == '_') {
         return 1;
@@ -945,7 +945,7 @@ static int vfs_solaris_acl(const struct vol *vol, const char *path, int cmd,
     for (int i = 0; i < VFS_MODULES_MAX; i++) {
         if (vol->vfs_modules[i] && vol->vfs_modules[i]->vfs_solaris_acl) {
             int curr_ret = vol->vfs_modules[i]->vfs_solaris_acl(vol, path, cmd, count,
-                           aces);
+                                                                aces);
 
             if (curr_ret != AFP_OK) {
                 ret = curr_ret;
@@ -1017,7 +1017,7 @@ static int vfs_ea_getsize(const struct vol *vol, char *rbuf,
     for (int i = 0; i < VFS_MODULES_MAX; i++) {
         if (vol->vfs_modules[i] && vol->vfs_modules[i]->vfs_ea_getsize) {
             int curr_ret = vol->vfs_modules[i]->vfs_ea_getsize(vol, rbuf, rbuflen, uname,
-                           oflag, attruname, fd);
+                                                               oflag, attruname, fd);
 
             if (curr_ret != AFP_OK) {
                 ret = curr_ret;
@@ -1041,7 +1041,7 @@ static int vfs_ea_getcontent(const struct vol *vol, char *rbuf, size_t *rbuflen,
     for (int i = 0; i < VFS_MODULES_MAX; i++) {
         if (vol->vfs_modules[i] && vol->vfs_modules[i]->vfs_ea_getcontent) {
             int curr_ret = vol->vfs_modules[i]->vfs_ea_getcontent(vol, rbuf, rbuflen, uname,
-                           oflag, attruname, maxreply, fd);
+                                                                  oflag, attruname, maxreply, fd);
 
             if (curr_ret != AFP_OK) {
                 ret = curr_ret;
@@ -1061,7 +1061,7 @@ static int vfs_ea_list(const struct vol *vol,
     for (int i = 0; i < VFS_MODULES_MAX; i++) {
         if (vol->vfs_modules[i] && vol->vfs_modules[i]->vfs_ea_list) {
             int curr_ret = vol->vfs_modules[i]->vfs_ea_list(vol, attrnamebuf, buflen, uname,
-                           oflag, fd);
+                                                            oflag, fd);
 
             if (curr_ret != AFP_OK) {
                 ret = curr_ret;
@@ -1085,7 +1085,7 @@ static int vfs_ea_set(const struct vol *vol, const char *uname,
     for (int i = 0; i < VFS_MODULES_MAX; i++) {
         if (vol->vfs_modules[i] && vol->vfs_modules[i]->vfs_ea_set) {
             int curr_ret = vol->vfs_modules[i]->vfs_ea_set(vol, uname, attruname, ibuf,
-                           attrsize, oflag, fd);
+                                                           attrsize, oflag, fd);
 
             if (curr_ret != AFP_OK) {
                 ret = curr_ret;
@@ -1108,7 +1108,7 @@ static int vfs_ea_remove(const struct vol *vol, const char *uname,
     for (int i = 0; i < VFS_MODULES_MAX; i++) {
         if (vol->vfs_modules[i] && vol->vfs_modules[i]->vfs_ea_remove) {
             int curr_ret = vol->vfs_modules[i]->vfs_ea_remove(vol, uname, attruname, oflag,
-                           fd);
+                                                              fd);
 
             if (curr_ret != AFP_OK) {
                 ret = curr_ret;

--- a/sys/netatalk/aarp.c
+++ b/sys/netatalk/aarp.c
@@ -224,7 +224,7 @@ int aarpresolve(struct arpcom *ac, struct mbuf *m, struct sockaddr_at *destsat,
 
     if (at_broadcast(destsat)) {
         if ((aa = (struct at_ifaddr *)at_ifawithnet(destsat,
-                  ((struct ifnet *)ac)->if_addrlist)) == NULL) {
+            ((struct ifnet *)ac)->if_addrlist)) == NULL) {
             m_freem(m);
             return 0;
         }
@@ -362,7 +362,7 @@ void at_aarpinput(struct arpcom *ac, struct mbuf *m)
         sat.sat_addr.s_net = net;
 
         if ((aa = (struct at_ifaddr *)at_ifawithnet(&sat,
-                  ac->ac_if.if_addrlist)) == NULL) {
+            ac->ac_if.if_addrlist)) == NULL) {
             m_freem(m);
             return;
         }

--- a/sys/netatalk/aarp.c
+++ b/sys/netatalk/aarp.c
@@ -224,7 +224,7 @@ int aarpresolve(struct arpcom *ac, struct mbuf *m, struct sockaddr_at *destsat,
 
     if (at_broadcast(destsat)) {
         if ((aa = (struct at_ifaddr *)at_ifawithnet(destsat,
-                  ((struct ifnet *)ac)->if_addrlist)) == NULL) {
+                                                    ((struct ifnet *)ac)->if_addrlist)) == NULL) {
             m_freem(m);
             return 0;
         }
@@ -362,7 +362,7 @@ void at_aarpinput(struct arpcom *ac, struct mbuf *m)
         sat.sat_addr.s_net = net;
 
         if ((aa = (struct at_ifaddr *)at_ifawithnet(&sat,
-                  ac->ac_if.if_addrlist)) == NULL) {
+                                                    ac->ac_if.if_addrlist)) == NULL) {
             m_freem(m);
             return;
         }

--- a/sys/netatalk/at_control.c
+++ b/sys/netatalk/at_control.c
@@ -431,7 +431,7 @@ struct sockaddr_at	*sat;
         }
 
         for (i = nnets, netinc = 1; i > 0; net = ntohs(nr.nr_firstnet) +
-                ((net - ntohs(nr.nr_firstnet) + netinc) % nnets), i--) {
+            ((net - ntohs(nr.nr_firstnet) + netinc) % nnets), i--) {
             AA_SAT(aa)->sat_addr.s_net = htons(net);
 
             for (j = 0, nodeinc = time.tv_sec | 1; j < 256;

--- a/sys/netatalk/at_control.c
+++ b/sys/netatalk/at_control.c
@@ -431,7 +431,7 @@ struct sockaddr_at	*sat;
         }
 
         for (i = nnets, netinc = 1; i > 0; net = ntohs(nr.nr_firstnet) +
-                ((net - ntohs(nr.nr_firstnet) + netinc) % nnets), i--) {
+                                                 ((net - ntohs(nr.nr_firstnet) + netinc) % nnets), i--) {
             AA_SAT(aa)->sat_addr.s_net = htons(net);
 
             for (j = 0, nodeinc = time.tv_sec | 1; j < 256;

--- a/sys/netatalk/ddp_usrreq.c
+++ b/sys/netatalk/ddp_usrreq.c
@@ -528,7 +528,7 @@ struct at_ifaddr	*aa;
 
         /* 0.255 to socket on receiving interface */
         if (to->sat_addr.s_node == ATADDR_BCAST && (to->sat_addr.s_net == 0 ||
-                to->sat_addr.s_net == ddp->ddp_lsat.sat_addr.s_net) &&
+                                                    to->sat_addr.s_net == ddp->ddp_lsat.sat_addr.s_net) &&
                 ddp->ddp_lsat.sat_addr.s_net == AA_SAT(aa)->sat_addr.s_net) {
             break;
         }

--- a/test/afpd/subtests.c
+++ b/test/afpd/subtests.c
@@ -224,7 +224,7 @@ out:
      * different pointer — remove whatever the cache now holds. */
     {
         struct dir *now = dircache_search_by_name(vol, root, fname,
-                          strlen(fname));
+                                                  strlen(fname));
 
         if (now) {
             dir_remove(vol, now, 0);
@@ -382,7 +382,7 @@ out:
     {
         /* Reruns and later tests start clean */
         struct dir *now = dircache_search_by_name(vol, root, fname,
-                          strlen(fname));
+                                                  strlen(fname));
 
         if (now) {
             dir_remove(vol, now, 0);

--- a/test/afpd/subtests.h
+++ b/test/afpd/subtests.h
@@ -48,6 +48,6 @@ extern int test007_add_over_existing_key_leaves_one(struct vol *vol);
 extern int test008_reindex_over_stale_key_expunges(struct vol *vol);
 extern int test009_file_add_over_curdir_did(struct vol *vol);
 extern int test010_full_cache_accepts_adds(struct vol *vol,
-        unsigned int cache_size);
+                                           unsigned int cache_size);
 extern int dircache_test_ghost_trim_selection(void);
 #endif  /* SUBTESTS_H */

--- a/test/afpd/subtests_conf.c
+++ b/test/afpd/subtests_conf.c
@@ -426,7 +426,7 @@ int utest_conf_permission_options_require_unix_priv(void)
         mode_t expected_effective_file_perm = cases[i].expect_unix_priv
                                               ? cases[i].expected_file_perm : 0;
         mode_t expected_effective_directory_perm = cases[i].expect_unix_priv
-            ? cases[i].expected_directory_perm : 0;
+                                                   ? cases[i].expected_directory_perm : 0;
 
         if (vol == NULL || unix_priv != cases[i].expect_unix_priv
                 || vol->v_umask != cases[i].expected_umask

--- a/test/testsuite/Error.c
+++ b/test/testsuite/Error.c
@@ -899,7 +899,7 @@ STATIC void test95()
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name2))
     /* sdid bad */
     FAIL(ntohl(AFPERR_NOOBJ) != FPExchangeFile(Conn, vol, dir, DIRDID_ROOT, name,
-            name1))
+                                               name1))
     /* name bad */
     ret = FPExchangeFile(Conn, vol, DIRDID_ROOT, DIRDID_ROOT, name, name1);
 
@@ -937,7 +937,7 @@ STATIC void test95()
 
     if (fork) {
         if (ntohl(AFPERR_DENYCONF) != FPCopyFile(Conn, vol, DIRDID_ROOT, vol,
-                DIRDID_ROOT, name, "", name1)) {
+                                                 DIRDID_ROOT, name, "", name1)) {
             fprintf(stdout, "\tFAILED\n");
         }
 
@@ -947,7 +947,7 @@ STATIC void test95()
 #endif
     /* sdid bad */
     FAIL(ntohl(AFPERR_NOOBJ) != FPExchangeFile(Conn, vol, DIRDID_ROOT, dir, name,
-            name1))
+                                               name1))
     /* name bad */
     ret = FPExchangeFile(Conn, vol, DIRDID_ROOT, DIRDID_ROOT, name, name1);
 
@@ -957,10 +957,10 @@ STATIC void test95()
 
     /* same object */
     FAIL(ntohl(AFPERR_SAMEOBJ) != FPExchangeFile(Conn, vol, DIRDID_ROOT,
-            DIRDID_ROOT, name, name))
+                                                 DIRDID_ROOT, name, name))
     /* a dir */
     FAIL(ntohl(AFPERR_BADTYPE) != FPExchangeFile(Conn, vol, DIRDID_ROOT,
-            DIRDID_ROOT, name, ""))
+                                                 DIRDID_ROOT, name, ""))
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name1))
     FAIL(FPExchangeFile(Conn, vol, DIRDID_ROOT, DIRDID_ROOT, name, name1))
     delete_folder(vol, DIRDID_ROOT, pname);
@@ -1012,14 +1012,14 @@ STATIC void test100()
     ENTER_TEST
     dt = FPOpenDT(Conn, vol);
     FAIL(ntohl(AFPERR_NOOBJ) != FPAddComment(Conn, vol, DIRDID_ROOT, name1,
-            "essai"))
+                                             "essai"))
     FAIL(ntohl(AFPERR_NOOBJ) != FPGetComment(Conn, vol, DIRDID_ROOT, name1))
     FAIL(ntohl(AFPERR_NOOBJ) != FPRemoveComment(Conn, vol, DIRDID_ROOT, name1))
     FAIL(FPCloseDT(Conn, dt))
     filedir.isdir = 1;
     filedir.attr = ATTRBIT_NODELETE | ATTRBIT_SETCLR ;
     FAIL(ntohl(AFPERR_NOOBJ) != FPSetDirParms(Conn, vol, DIRDID_ROOT, name1, bitmap,
-            &filedir))
+                                              &filedir))
 
     if ((dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name1))) {
         test_failed();
@@ -1065,18 +1065,18 @@ STATIC void test100()
 
     /* FIXME ? */
     if (ntohl(AFPERR_NOOBJ) != FPExchangeFile(Conn, vol, DIRDID_ROOT, DIRDID_ROOT,
-            name1, name)) {
+                                              name1, name)) {
         test_failed();
     }
 
     FAIL(ntohl(AFPERR_NOOBJ) != FPSetFileParams(Conn, vol, DIRDID_ROOT, name1,
-            bitmap, &filedir))
+                                                bitmap, &filedir))
     FAIL(ntohl(AFPERR_NOOBJ) != FPSetFilDirParam(Conn, vol, DIRDID_ROOT, name1,
-            bitmap, &filedir))
+                                                 bitmap, &filedir))
     FAIL(ntohl(AFPERR_NOOBJ) != FPRename(Conn, vol, DIRDID_ROOT, name1, name))
     FAIL(ntohl(AFPERR_NOOBJ) != FPDelete(Conn, vol, DIRDID_ROOT, name1))
     FAIL(ntohl(AFPERR_NOOBJ) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, DIRDID_ROOT,
-            name1, name))
+                                                name1, name))
     exit_test("Error:test100: no obj cname error (AFPERR_NOOBJ)");
 }
 
@@ -1107,7 +1107,7 @@ STATIC void test101()
 
     dt = FPOpenDT(Conn, vol);
     FAIL(ntohl(AFPERR_ACCESS) != FPAddComment(Conn, vol, DIRDID_ROOT, name1,
-            "essai"))
+                                              "essai"))
     ret = FPGetComment(Conn, vol, DIRDID_ROOT, name1);
 
     if (not_valid(ret, /* MAC */AFPERR_NOOBJ, AFPERR_ACCESS)) {
@@ -1119,7 +1119,7 @@ STATIC void test101()
     filedir.isdir = 1;
     filedir.attr = ATTRBIT_NODELETE | ATTRBIT_SETCLR ;
     FAIL(ntohl(AFPERR_ACCESS) != FPSetDirParms(Conn, vol, DIRDID_ROOT, name1,
-            bitmap, &filedir))
+                                               bitmap, &filedir))
 
     if ((dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name1))) {
         test_failed();
@@ -1167,11 +1167,11 @@ STATIC void test101()
     }
 
     FAIL(ntohl(AFPERR_ACCESS) != FPSetFileParams(Conn, vol, DIRDID_ROOT, name1,
-            bitmap, &filedir))
+                                                 bitmap, &filedir))
     FAIL(ntohl(AFPERR_ACCESS) != FPRename(Conn, vol, DIRDID_ROOT, name1, name))
     FAIL(ntohl(AFPERR_ACCESS) != FPDelete(Conn, vol, DIRDID_ROOT, name1))
     FAIL(ntohl(AFPERR_ACCESS) != FPMoveAndRename(Conn, vol, DIRDID_ROOT,
-            DIRDID_ROOT, name1, name))
+                                                 DIRDID_ROOT, name1, name))
     delete_folder(vol, DIRDID_ROOT, ndir);
 test_exit:
     exit_test("Error:test101: access error cname");
@@ -1234,7 +1234,7 @@ STATIC void test102()
     filedir.isdir = 1;
     filedir.attr = ATTRBIT_NODELETE | ATTRBIT_SETCLR ;
     FAIL(ntohl(AFPERR_ACCESS) != FPSetDirParms(Conn, vol, DIRDID_ROOT, name1,
-            bitmap, &filedir))
+                                               bitmap, &filedir))
 
     if ((dir = FPCreateDir(Conn, vol, DIRDID_ROOT, name1))) {
         test_failed();
@@ -1270,7 +1270,7 @@ STATIC void test102()
     }
 
     FAIL(ntohl(AFPERR_BADTYPE) != FPCopyFile(Conn, vol, DIRDID_ROOT, vol,
-            DIRDID_ROOT, name1, "", name))
+                                             DIRDID_ROOT, name1, "", name))
 
     if (get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID) {
         FAIL(ntohl(AFPERR_BADTYPE) != FPCreateID(Conn, vol, DIRDID_ROOT, name1))
@@ -1283,7 +1283,7 @@ STATIC void test102()
     }
 
     FAIL(ntohl(AFPERR_BADTYPE) != FPSetFileParams(Conn, vol, DIRDID_ROOT, name1,
-            bitmap, &filedir))
+                                                  bitmap, &filedir))
 
     if (FPRename(Conn, vol, DIRDID_ROOT, name1, name)) {
 #if 0
@@ -1635,7 +1635,7 @@ STATIC void test170()
         afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.isdir = 0;
         FAIL(htonl(AFPERR_PARAM) != FPSetFileParams(Conn, vol, DIRDID_ROOT_PARENT, "",
-                bitmap, &filedir))
+                                                    bitmap, &filedir))
     }
 
     /* -------------------- */
@@ -1680,7 +1680,7 @@ STATIC void test170()
     /* ---- directory.c ---- */
     filedir.isdir = 1;
     FAIL(ntohl(AFPERR_NOOBJ) != FPSetDirParms(Conn, vol, DIRDID_ROOT_PARENT, "",
-            bitmap, &filedir))
+                                              bitmap, &filedir))
     /* ---------------- */
     dir  = FPCreateDir(Conn, vol, DIRDID_ROOT_PARENT, "");
 
@@ -1700,10 +1700,10 @@ STATIC void test170()
     /* ---- filedir.c ---- */
 
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, DIRDID_ROOT_PARENT, "",
-            0,
-            (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-            (1 << DIRPBIT_UID) |
-            (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS))
+                                                  0,
+                                                  (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                                  (1 << DIRPBIT_UID) |
+                                                  (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS))
        ) {
         test_failed();
         goto test_exit;
@@ -1718,7 +1718,7 @@ STATIC void test170()
         afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
 
         if (ntohl(AFPERR_NOOBJ) != FPSetFilDirParam(Conn, vol, DIRDID_ROOT_PARENT, "",
-                bitmap, &filedir)) {
+                                                    bitmap, &filedir)) {
             test_failed();
             goto test_exit;
         }
@@ -1730,10 +1730,10 @@ STATIC void test170()
     FAIL(ntohl(AFPERR_NOOBJ) != FPDelete(Conn, vol, DIRDID_ROOT_PARENT, ""))
     /* ---------------- */
     FAIL(ntohl(AFPERR_NOOBJ) != FPMoveAndRename(Conn, vol, DIRDID_ROOT_PARENT,
-            DIRDID_ROOT, "", name1))
+                                                DIRDID_ROOT, "", name1))
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name))
     FAIL(ntohl(AFPERR_NOOBJ) != FPMoveAndRename(Conn, vol, DIRDID_ROOT,
-            DIRDID_ROOT_PARENT, name, ""))
+                                                DIRDID_ROOT_PARENT, name, ""))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
 
     /* ---- enumerate.c ---- */
@@ -1754,7 +1754,7 @@ STATIC void test170()
     /* ---- desktop.c ---- */
     dt = FPOpenDT(Conn, vol);
     FAIL(ntohl(AFPERR_NOOBJ) != FPAddComment(Conn, vol, DIRDID_ROOT_PARENT, "",
-            "Comment"))
+                                             "Comment"))
     FAIL(ntohl(AFPERR_NOOBJ) != FPGetComment(Conn, vol, DIRDID_ROOT_PARENT, ""))
     FAIL(ntohl(AFPERR_NOOBJ) != FPRemoveComment(Conn, vol, DIRDID_ROOT_PARENT, ""))
     FAIL(FPCloseDT(Conn, dt))
@@ -1811,7 +1811,7 @@ STATIC void test171()
         afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.isdir = 0;
         FAIL(htonl(AFPERR_NOOBJ) != FPSetFileParams(Conn, vol, tdir, tname, bitmap,
-                &filedir))
+                                                    &filedir))
     }
 
     /* -------------------- */
@@ -1843,13 +1843,13 @@ STATIC void test171()
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name1))
     FAIL(ntohl(AFPERR_NOOBJ) != FPExchangeFile(Conn, vol, tdir, dir, tname, name1))
     FAIL(ntohl(AFPERR_NOOBJ) != FPExchangeFile(Conn, vol, DIRDID_ROOT, tdir, name,
-            tname))
+                                               tname))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name1))
     /* ---- directory.c ---- */
     filedir.isdir = 1;
     FAIL(ntohl(AFPERR_NOOBJ) != FPSetDirParms(Conn, vol, tdir, tname, bitmap,
-            &filedir))
+                                              &filedir))
     /* ---------------- */
     dir  = FPCreateDir(Conn, vol, tdir, tname);
 
@@ -1863,9 +1863,9 @@ STATIC void test171()
     /* ---- filedir.c ---- */
 
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, tdir, tname, 0,
-            (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-            (1 << DIRPBIT_UID) |
-            (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS))
+                                                  (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                                  (1 << DIRPBIT_UID) |
+                                                  (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS))
        ) {
         test_failed();
     }
@@ -1877,7 +1877,7 @@ STATIC void test171()
         filedir.isdir = 1;
         afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         FAIL(ntohl(AFPERR_NOOBJ) != FPSetFilDirParam(Conn, vol, tdir, tname, bitmap,
-                &filedir))
+                                                     &filedir))
     }
 
     /* ---------------- */
@@ -1886,10 +1886,10 @@ STATIC void test171()
     FAIL(ntohl(AFPERR_NOOBJ) != FPDelete(Conn, vol, tdir, tname))
     /* ---------------- */
     FAIL(ntohl(AFPERR_NOOBJ) != FPMoveAndRename(Conn, vol, tdir, DIRDID_ROOT, tname,
-            name1))
+                                                name1))
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name))
     FAIL(ntohl(AFPERR_NOOBJ) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, tdir, name,
-            tname))
+                                                tname))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
     /* ---- enumerate.c ---- */
     /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
@@ -1966,7 +1966,7 @@ STATIC void test173()
         afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.isdir = 0;
         FAIL(htonl(AFPERR_PARAM) != FPSetFileParams(Conn, vol, tdir, tname, bitmap,
-                &filedir))
+                                                    &filedir))
     }
 
     /* -------------------- */
@@ -2000,13 +2000,13 @@ STATIC void test173()
     }
 
     FAIL(ntohl(AFPERR_PARAM) != FPExchangeFile(Conn, vol, DIRDID_ROOT, tdir, name,
-            tname))
+                                               tname))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name1))
     /* ---- directory.c ---- */
     filedir.isdir = 1;
     FAIL(ntohl(AFPERR_PARAM) != FPSetDirParms(Conn, vol, tdir, tname, bitmap,
-            &filedir))
+                                              &filedir))
     /* ---------------- */
     dir  = FPCreateDir(Conn, vol, tdir, tname);
 
@@ -2026,9 +2026,9 @@ STATIC void test173()
     /* ---- filedir.c ---- */
 
     if (ntohl(AFPERR_PARAM) != FPGetFileDirParams(Conn, vol, tdir, tname, 0,
-            (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-            (1 << DIRPBIT_UID) |
-            (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS))
+                                                  (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                                  (1 << DIRPBIT_UID) |
+                                                  (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS))
        ) {
         test_failed();
         goto test_exit;
@@ -2042,7 +2042,7 @@ STATIC void test173()
         filedir.isdir = 1;
         afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         FAIL(ntohl(AFPERR_PARAM) != FPSetFilDirParam(Conn, vol, tdir, tname, bitmap,
-                &filedir))
+                                                     &filedir))
     }
 
     /* ---------------- */
@@ -2051,10 +2051,10 @@ STATIC void test173()
     FAIL(ntohl(AFPERR_PARAM) != FPDelete(Conn, vol, tdir, tname))
     /* ---------------- */
     FAIL(ntohl(AFPERR_PARAM) != FPMoveAndRename(Conn, vol, tdir, DIRDID_ROOT, tname,
-            name1))
+                                                name1))
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name))
     FAIL(ntohl(AFPERR_PARAM) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, tdir, name,
-            tname))
+                                                tname))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
 
     /* ---- enumerate.c ---- */
@@ -2161,7 +2161,7 @@ STATIC void test174()
         afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.isdir = 0;
         FAIL(htonl(AFPERR_NOOBJ) != FPSetFileParams(Conn, vol, tdir, tname, bitmap,
-                &filedir))
+                                                    &filedir))
     }
 
     /* -------------------- */
@@ -2204,13 +2204,13 @@ STATIC void test174()
     }
 
     FAIL(ntohl(AFPERR_NOOBJ) != FPExchangeFile(Conn, vol, DIRDID_ROOT, tdir, name,
-            tname))
+                                               tname))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name1))
     /* ---- directory.c ---- */
     filedir.isdir = 1;
     FAIL(ntohl(AFPERR_NOOBJ) != FPSetDirParms(Conn, vol, tdir, tname, bitmap,
-            &filedir))
+                                              &filedir))
     /* ---------------- */
     dir  = FPCreateDir(Conn, vol, tdir, tname);
 
@@ -2228,9 +2228,9 @@ STATIC void test174()
     /* ---- filedir.c ---- */
 
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, tdir, tname, 0,
-            (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-            (1 << DIRPBIT_UID) |
-            (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS))
+                                                  (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                                  (1 << DIRPBIT_UID) |
+                                                  (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS))
        ) {
         test_failed();
     }
@@ -2242,7 +2242,7 @@ STATIC void test174()
         filedir.isdir = 1;
         afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         FAIL(ntohl(AFPERR_NOOBJ) != FPSetFilDirParam(Conn, vol, tdir, tname, bitmap,
-                &filedir))
+                                                     &filedir))
     }
 
     /* ---------------- */
@@ -2251,10 +2251,10 @@ STATIC void test174()
     FAIL(ntohl(AFPERR_NOOBJ) != FPDelete(Conn, vol, tdir, tname))
     /* ---------------- */
     FAIL(ntohl(AFPERR_NOOBJ) != FPMoveAndRename(Conn, vol, tdir, DIRDID_ROOT, tname,
-            name1))
+                                                name1))
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name))
     FAIL(ntohl(AFPERR_NOOBJ) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, tdir, name,
-            tname))
+                                                tname))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
 
     /* ---- enumerate.c ---- */

--- a/test/testsuite/FPAddComment.c
+++ b/test/testsuite/FPAddComment.c
@@ -98,7 +98,7 @@ STATIC void test55()
 #if 0
 
     if (ntohl(AFPERR_ACCESS) != FPAddComment(Conn, vol, DIRDID_ROOT,
-            "bogus folder", "essai")) {
+                                             "bogus folder", "essai")) {
         fprintf(stdout, "\tFAILED\n");
         return;
     }

--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -276,8 +276,8 @@ static void test_bytelock2(char *name, int type)
         FAIL(htonl(AFPERR_LOCK) != FPByteLock_ext(Conn, fork1, 0, 0, 20, 60));
 
         if (htonl(AFPERR_LOCK) != FPByteLock_ext(Conn, fork1, 0, 0,
-                ((off_t)1 << 32) + 2,
-                60)) {
+                                                 ((off_t)1 << 32) + 2,
+                                                 60)) {
             test_failed();
             FAIL(FPByteLock_ext(Conn, fork1, 0, 1, ((off_t)1 << 32) + 2, 60));
         }
@@ -306,7 +306,7 @@ static void test_bytelock2(char *name, int type)
 #if 0
 
         if (htonl(AFPERR_LOCK) != FPByteLock_ext(Conn2, fork1, 0, 0,
-                ((off_t)1 << 32) + 2, 60)) {
+                                                 ((off_t)1 << 32) + 2, 60)) {
             test_failed();
             FPByteLock_ext(Conn2, fork1, 0, 1, ((off_t)1 << 32) + 2, 60);
         }

--- a/test/testsuite/FPByteRangeLockExt.c
+++ b/test/testsuite/FPByteRangeLockExt.c
@@ -34,9 +34,9 @@ static void test_bytelock_ext(uint16_t vol, char *name, int type)
     FAIL(FPByteLock_ext(Conn, fork, 0, 0 /* set */, 0, 100))
     FAIL(htonl(AFPERR_PARAM) != FPByteLock_ext(Conn, fork, 0, 0, -1, 75))
     FAIL(htonl(AFPERR_NORANGE) != FPByteLock_ext(Conn, fork, 0, 1 /* clear */, 0,
-            75))
+                                                 75))
     FAIL(htonl(AFPERR_RANGEOVR) != FPByteLock_ext(Conn, fork, 0, 0, 80 /* set */,
-            100))
+                                                  100))
     fork1 = FPOpenFork(Conn, vol, type, bitmap, DIRDID_ROOT, name,
                        OPENACC_WR | OPENACC_RD);
 
@@ -55,7 +55,7 @@ static void test_bytelock_ext(uint16_t vol, char *name, int type)
     /* Netatalk 2 doesn't drop locks when a fork is closed, 3 does */
     FPByteLock_ext(Conn, fork, 0, 1 /* clear */, 0, 100);
     FAIL(htonl(AFPERR_NORANGE) != FPByteLock_ext(Conn, fork, 0, 1 /* clear */, 0,
-            50))
+                                                 50))
     FAIL(FPSetForkParam(Conn, fork, len, 200))
 
     if (FPByteLock_ext(Conn, fork, 1 /* end */, 0 /* set */, 0, 100)) {
@@ -71,9 +71,9 @@ static void test_bytelock_ext(uint16_t vol, char *name, int type)
     }
 
     FAIL(htonl(AFPERR_PARAM) != FPByteLock_ext(Conn, fork, 0 /* start */,
-            0 /* set */, 0, 0))
+                                               0 /* set */, 0, 0))
     FAIL(htonl(AFPERR_PARAM) != FPByteLock_ext(Conn, fork, 0 /* start */,
-            0 /* set */, 0, -2))
+                                               0 /* set */, 0, -2))
     FAIL(FPCloseFork(Conn, fork))
     FAIL(htonl(AFPERR_PARAM) != FPByteLock_ext(Conn, fork, 0, 0 /* set */, 0, 100))
 fin:

--- a/test/testsuite/FPCatSearch.c
+++ b/test/testsuite/FPCatSearch.c
@@ -28,7 +28,7 @@ STATIC void test225()
     memset(&filedir, 0, sizeof(filedir));
     filedir.attr = 0x01a0;			/* various lock attributes */
     FAIL(htonl(AFPERR_BITMAP) != FPCatSearch(Conn, vol, 10, pos,
-            0, /* d_bitmap */ 0, bitmap, &filedir, &filedir))
+                                             0, /* d_bitmap */ 0, bitmap, &filedir, &filedir))
     filedir.attr = 0x01a0;			/* various lock attributes */
     ret = FPCatSearch(Conn, vol, 10, pos, 0x42, /* d_bitmap */ 0,
                       bitmap, &filedir, &filedir);

--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -43,10 +43,10 @@ STATIC void test71()
     vol  = FPOpenVol(Conn, Vol);
     /* cname unchdirable */
     FAIL(ntohl(AFPERR_BADTYPE) != FPCopyFile(Conn, vol, DIRDID_ROOT, vol,
-            DIRDID_ROOT, ndir, "", name1))
+                                             DIRDID_ROOT, ndir, "", name1))
     /* second time once bar is in the cache */
     FAIL(ntohl(AFPERR_BADTYPE) != FPCopyFile(Conn, vol, DIRDID_ROOT, vol,
-            DIRDID_ROOT, ndir, "", name1))
+                                             DIRDID_ROOT, ndir, "", name1))
 
     if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
         test_failed();
@@ -73,7 +73,7 @@ STATIC void test71()
 
     if (fork) {
         FAIL(ntohl(AFPERR_DENYCONF) != FPCopyFile(Conn, vol, DIRDID_ROOT, vol,
-                DIRDID_ROOT, name, "", name1))
+                                                  DIRDID_ROOT, name, "", name1))
         FAIL(FPCloseFork(Conn, fork))
     } else {
         test_failed();
@@ -381,7 +381,7 @@ STATIC void test374()
 
     if (fork) {
         FAIL(ntohl(AFPERR_DENYCONF) != FPCopyFile(Conn2, vol2, DIRDID_ROOT, vol2,
-                DIRDID_ROOT, name, "", name1))
+                                                  DIRDID_ROOT, name, "", name1))
         FAIL(FPCloseFork(Conn, fork))
     } else {
         test_failed();
@@ -642,7 +642,7 @@ STATIC void test402()
     }
 
     FAIL(ntohl(AFPERR_DENYCONF) != FPCopyFile(Conn, vol, dir, vol, dir, name, "",
-            name1))
+                                              name1))
 fin1:
     FAIL(FPDelete(Conn, vol, dir, name))
 fin:
@@ -1068,7 +1068,7 @@ STATIC void test414()
 
     /* wrong destdir */
     FAIL(ntohl(AFPERR_BADTYPE) != FPCopyFile(Conn, vol, DIRDID_ROOT, vol,
-            DIRDID_ROOT, name, name, name1))
+                                             DIRDID_ROOT, name, name, name1))
     FAIL(ntohl(AFPERR_NOOBJ) != FPCopyFile(Conn, vol, DIRDID_ROOT, vol, DIRDID_ROOT,
                                            name, name2, name1))
 

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -153,7 +153,7 @@ STATIC void test172()
         afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         filedir.isdir = 0;
         FAIL(htonl(AFPERR_NOOBJ) != FPSetFileParams(Conn, vol, tdir, tname, bitmap,
-                &filedir))
+                                                    &filedir))
     }
 
     /* -------------------- */
@@ -196,13 +196,13 @@ STATIC void test172()
     }
 
     FAIL(ntohl(AFPERR_NOOBJ) != FPExchangeFile(Conn, vol, DIRDID_ROOT, tdir, name,
-            tname))
+                                               tname))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name1))
     /* ---- directory.c ---- */
     filedir.isdir = 1;
     FAIL(ntohl(AFPERR_NOOBJ) != FPSetDirParms(Conn, vol, tdir, tname, bitmap,
-            &filedir))
+                                              &filedir))
     /* ---------------- */
     dir  = FPCreateDir(Conn, vol, tdir, tname);
 
@@ -220,9 +220,9 @@ STATIC void test172()
     /* ---- filedir.c ---- */
 
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, tdir, tname, 0,
-            (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-            (1 << DIRPBIT_UID) |
-            (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS))
+                                                  (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                                  (1 << DIRPBIT_UID) |
+                                                  (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS))
        ) {
         test_failed();
     }
@@ -234,7 +234,7 @@ STATIC void test172()
         filedir.isdir = 1;
         afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
         FAIL(ntohl(AFPERR_NOOBJ) != FPSetFilDirParam(Conn, vol, tdir, tname, bitmap,
-                &filedir))
+                                                     &filedir))
     }
 
     /* ---------------- */
@@ -243,10 +243,10 @@ STATIC void test172()
     FAIL(ntohl(AFPERR_NOOBJ) != FPDelete(Conn, vol, tdir, tname))
     /* ---------------- */
     FAIL(ntohl(AFPERR_NOOBJ) != FPMoveAndRename(Conn, vol, tdir, DIRDID_ROOT, tname,
-            name1))
+                                                name1))
     FAIL(FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name))
     FAIL(ntohl(AFPERR_NOOBJ) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, tdir, name,
-            tname))
+                                                tname))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
     /* ---- enumerate.c ---- */
     /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */

--- a/test/testsuite/FPEnumerate.c
+++ b/test/testsuite/FPEnumerate.c
@@ -100,8 +100,8 @@ STATIC void test34()
     ENTER_TEST
 
     if (ntohl(AFPERR_ACCESS) != FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, 0,
-            (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-            (1 << DIRPBIT_ACCESS))) {
+                                                   (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                                   (1 << DIRPBIT_ACCESS))) {
         test_failed();
         goto test_exit;
     }
@@ -114,8 +114,8 @@ STATIC void test34()
                );
 
     if (ntohl(AFPERR_ACCESS) != FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, 0,
-            (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-            (1 << DIRPBIT_ACCESS))
+                                                   (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                                   (1 << DIRPBIT_ACCESS))
        ) {
         test_failed();
         goto test_exit;
@@ -247,7 +247,7 @@ STATIC void test40()
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
 
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, dir, "", 0,
-            (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) | (1 << DIRPBIT_ACCESS))) {
+                                                  (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) | (1 << DIRPBIT_ACCESS))) {
         test_failed();
     }
 
@@ -453,7 +453,7 @@ STATIC void test218()
 
     /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (htonl(AFPERR_NOOBJ) != FPEnumerateFull(Conn, vol, 1, 1, 800,  bdir, "",
-            bitmap, bitmap)) {
+                                               bitmap, bitmap)) {
         test_nottested();
         goto fin;
     }
@@ -478,17 +478,17 @@ STATIC void test218()
     }
 
     FAIL(htonl(AFPERR_PARAM) != FPEnumerateFull(Conn, vol, 0, 1, 800,  bdir, "",
-            bitmap, 0))
+                                                bitmap, 0))
     FAIL(htonl(AFPERR_PARAM) != FPEnumerateFull(Conn, vol, 1, 1, 2,  bdir, "",
-            bitmap, bitmap))
+                                                bitmap, bitmap))
     FAIL(FPEnumerateFull(Conn, vol, 1, 5, 800,  bdir, "", bitmap, bitmap))
     FAIL(htonl(AFPERR_NOOBJ) != FPEnumerateFull(Conn, vol, 1, 0, 800,  bdir, "",
-            bitmap, bitmap))
+                                                bitmap, bitmap))
     FAIL(FPEnumerateFull(Conn, vol, 2, 5, 800,  bdir, "", bitmap, bitmap))
     FAIL(htonl(AFPERR_NOOBJ) != FPEnumerateFull(Conn, vol, 4, 1, 800,  bdir, "",
-            bitmap, bitmap))
+                                                bitmap, bitmap))
     FAIL(htonl(AFPERR_NOOBJ) != FPEnumerateFull(Conn, vol, 5, 1, 800,  bdir, "",
-            bitmap, bitmap))
+                                                bitmap, bitmap))
     /* get the third */
     isdir = 0;
     ret = FPEnumerateFull(Conn, VolID, 3, 1, 800,  bdir, "", bitmap, 0);
@@ -519,7 +519,7 @@ fin:
     FPDelete(Conn, vol, bdir, ndir);
     FPDelete(Conn, vol, bdir, ndir1);
     FAIL(htonl(AFPERR_NOOBJ) != FPEnumerateFull(Conn, vol, 1, 1, 800,  bdir, "",
-            bitmap, bitmap))
+                                                bitmap, bitmap))
     FPDelete(Conn, vol, DIRDID_ROOT, base);
 test_exit:
     exit_test("FPEnumerate:test218: enumerate arguments");

--- a/test/testsuite/FPEnumerateExt.c
+++ b/test/testsuite/FPEnumerateExt.c
@@ -23,8 +23,8 @@ STATIC void test23()
     /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (Conn->afp_version < 30) {
         if (ntohl(AFPERR_NOOP) != FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
-                (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
-                | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0xffff)) {
+                                                  (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
+                                                  | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0xffff)) {
             test_failed();
         }
 

--- a/test/testsuite/FPEnumerateExt2.c
+++ b/test/testsuite/FPEnumerateExt2.c
@@ -86,8 +86,8 @@ STATIC void test211()
     /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (Conn->afp_version < 31) {
         if (ntohl(AFPERR_NOOP) != FPEnumerate_ext2(Conn, vol, DIRDID_ROOT, "",
-                (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
-                | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0xffff)) {
+                                                   (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
+                                                   | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0xffff)) {
             test_failed();
         }
 

--- a/test/testsuite/FPGetExtAttr.c
+++ b/test/testsuite/FPGetExtAttr.c
@@ -60,7 +60,7 @@ STATIC void test399()
     }
 
     if (ntohl(AFPERR_MISC) != FPRemoveExtAttr(Conn, vol, DIRDID_ROOT, 0, file,
-            attr_name)) {
+                                              attr_name)) {
         test_failed();
     }
 
@@ -146,13 +146,13 @@ STATIC void test432()
      * specifying an req_count of 7.
      */
     FAIL(htonl(AFPERR_PARAM) != FPGetExtAttr(Conn, vol, DIRDID_ROOT, 0, 1, file,
-            attr_name));
+                                             attr_name));
     FAIL(htonl(AFPERR_PARAM) != FPGetExtAttr(Conn, vol, DIRDID_ROOT, 0, 6, file,
-            attr_name));
+                                             attr_name));
     FAIL(htonl(AFPERR_PARAM) != FPGetExtAttr(Conn, vol, DIRDID_ROOT, 0, 7, file,
-            attr_name));
+                                             attr_name));
     FAIL(htonl(AFPERR_PARAM) != FPGetExtAttr(Conn, vol, DIRDID_ROOT, 0, 15, file,
-            attr_name));
+                                             attr_name));
     FAIL(FPGetExtAttr(Conn, vol, DIRDID_ROOT, 0, 16, file, attr_name));
     FAIL(FPGetExtAttr(Conn, vol, DIRDID_ROOT, 0, 17, file, attr_name));
     memcpy(&attrlen, dsi->data + 2, 4);

--- a/test/testsuite/FPGetFileDirParms.c
+++ b/test/testsuite/FPGetFileDirParms.c
@@ -68,10 +68,10 @@ STATIC void test58()
     ENTER_TEST
 
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, DIRDID_ROOT_PARENT, "",
-            0,
-            (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-            (1 << DIRPBIT_UID) |
-            (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS))
+                                                  0,
+                                                  (1 <<  DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                                  (1 << DIRPBIT_UID) |
+                                                  (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS))
        ) {
         test_failed();
     }
@@ -411,7 +411,7 @@ STATIC void test132()
     }
 
     FAIL(htonl(AFPERR_BITMAP) != FPGetFileDirParams(Conn, vol, dir, name, 0xffff,
-            0))
+                                                    0))
     FAIL(htonl(AFPERR_BITMAP) != FPGetFileDirParams(Conn, vol, dir, "", 0, 0xffff))
     bitmap = (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
              (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
@@ -565,7 +565,7 @@ STATIC void test307()
     }
 
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, DIRDID_ROOT, "???#2",
-            0, bitmap)) {
+                                                  0, bitmap)) {
         test_failed();
     }
 

--- a/test/testsuite/FPGetIconInfo.c
+++ b/test/testsuite/FPGetIconInfo.c
@@ -24,7 +24,7 @@ STATIC void test213()
 
     FAIL(FPGetIconInfo(Conn,  dt, (unsigned char *) "ttxt", 1))
     FAIL(htonl(AFPERR_NOITEM) != FPGetIconInfo(Conn,  dt, (unsigned char *) "ttxt",
-            256))
+                                               256))
 
     if (!Mac) {
         ret = FPGetIconInfo(Conn,  dt, (unsigned char *) "UNIX", 1);
@@ -38,7 +38,7 @@ STATIC void test213()
             goto fin;
         } else {
             FAIL(htonl(AFPERR_NOITEM) != FPGetIconInfo(Conn,  dt, (unsigned char *) "UNIX",
-                    2))
+                                                       2))
         }
     }
 

--- a/test/testsuite/FPGetSessionToken.c
+++ b/test/testsuite/FPGetSessionToken.c
@@ -43,8 +43,8 @@ STATIC void test220()
     /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     if (Conn->afp_version < 30) {
         if (ntohl(AFPERR_NOOP) != FPEnumerate_ext(Conn, vol, DIRDID_ROOT, "",
-                (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
-                | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0xffff)) {
+                                                  (1 << FILPBIT_PDINFO) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_EXTRFLEN)
+                                                  | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN), 0xffff)) {
             test_failed();
         }
 

--- a/test/testsuite/FPMoveAndRename.c
+++ b/test/testsuite/FPMoveAndRename.c
@@ -135,7 +135,7 @@ STATIC void test73()
 
     /* bad ddid */
     FAIL(ntohl(AFPERR_NOOBJ) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, dir, name,
-            name1))
+                                                name1))
     FAIL(!(dir1 = FPCreateDir(Conn, vol, DIRDID_ROOT, name2)))
     FAIL(FPMoveAndRename(Conn, vol, DIRDID_ROOT, dir1, name, ""))
     FAIL(ntohl(AFPERR_NOOBJ) != FPDelete(Conn, vol, DIRDID_ROOT, name))
@@ -154,7 +154,7 @@ STATIC void test73()
 
     if (fork) {
         FAIL(ntohl(AFPERR_EXIST) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, DIRDID_ROOT,
-                name1, name))
+                                                    name1, name))
         FAIL(FPCloseFork(Conn, fork))
     }
 
@@ -253,9 +253,9 @@ STATIC void test123()
     }
 
     FAIL(ntohl(AFPERR_CANTMOVE) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, dir,
-            name, ""))
+                                                   name, ""))
     FAIL(ntohl(AFPERR_CANTMOVE) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, dir,
-            name, "new"))
+                                                   name, "new"))
     FAIL(FPMoveAndRename(Conn, vol, dir2, dir4, "", ""))
 fin:
     FAIL(dir5 && FPDelete(Conn, vol, dir5, ""))
@@ -306,7 +306,7 @@ STATIC void test138()
     }
 
     FAIL(ntohl(AFPERR_ACCESS) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, dir, name,
-            ""))
+                                                 ""))
     filedir.access[1] = 7;
     filedir.access[2] = 7;
     filedir.access[3] = 7;
@@ -384,7 +384,7 @@ STATIC void test378()
         FAIL(FPMoveAndRename(Conn, vol, DIRDID_ROOT, DIRDID_ROOT, name, name1))
     } else {
         FAIL(htonl(AFPERR_EXIST) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, DIRDID_ROOT,
-                name, name1))
+                                                    name, name1))
     }
 
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name1))

--- a/test/testsuite/FPRead.c
+++ b/test/testsuite/FPRead.c
@@ -97,7 +97,7 @@ STATIC void test5()
     }
 
     if (ntohl(AFPERR_ACCESS) != FPSetForkParam(Conn, fork, (1 << FILPBIT_DFLEN),
-            0)) {
+                                               0)) {
         test_failed();
         goto fin2;
     }
@@ -217,7 +217,7 @@ STATIC void test46()
     }
 
     if (ntohl(AFPERR_ACCESS) != FPSetForkParam(Conn, fork, (1 << FILPBIT_RFLEN),
-            0)) {
+                                               0)) {
         test_failed();
         goto fin1;
     }

--- a/test/testsuite/FPRemoveComment.c
+++ b/test/testsuite/FPRemoveComment.c
@@ -91,7 +91,7 @@ STATIC void test54()
 #if 0
 
     if (ntohl(AFPERR_NOITEM) != FPRemoveComment(Conn, vol, DIRDID_ROOT,
-            "bogus folder")) {
+                                                "bogus folder")) {
         fprintf(stdout, "\tFAILED\n");
     }
 

--- a/test/testsuite/FPSetDirParms.c
+++ b/test/testsuite/FPSetDirParms.c
@@ -572,7 +572,7 @@ STATIC void test353()
              (1 << DIRPBIT_UNIXPR);
 
     if (/* htonl(AFPERR_BITMAP) != */ FPGetFileDirParams(Conn, vol, dir, name,
-                                      bitmap, 0)) {
+            bitmap, 0)) {
         test_failed();
         goto fin1;
     }

--- a/test/testsuite/FPSetDirParms.c
+++ b/test/testsuite/FPSetDirParms.c
@@ -174,11 +174,11 @@ STATIC void test88()
 
         bitmap = (1 << DIRPBIT_UID) | (1 << DIRPBIT_GID) | (1 << DIRPBIT_ACCESS);
         FAIL(ntohl(AFPERR_ACCESS) != FPSetDirParms(Conn, vol, DIRDID_ROOT, ndir, bitmap,
-                &filedir))
+                                                   &filedir))
         FAIL(ntohl(AFPERR_BADTYPE) != FPSetDirParms(Conn, vol, dir, name1, bitmap,
-                &filedir))
+                                                    &filedir))
         FAIL(ntohl(AFPERR_NOOBJ) != FPSetDirParms(Conn, vol, dir, name2, bitmap,
-                &filedir))
+                                                  &filedir))
     }
 
 fin:
@@ -336,7 +336,7 @@ STATIC void test189()
     afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, 0, bitmap);
     filedir.access[0] = 0;
     FAIL(ntohl(AFPERR_BADTYPE) != FPSetDirParms(Conn, vol, dir, name1, bitmap,
-            &filedir))
+                                                &filedir))
     FAIL(FPDelete(Conn, vol, dir, name1))
 fin:
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
@@ -562,7 +562,7 @@ STATIC void test353()
     filedir.access[1] = filedir.access[2] = filedir.access[3] = 0;
 
     if (htonl(AFPERR_BITMAP) != FPSetDirParms(Conn, vol, dir, "", bitmap,
-            &filedir)) {
+                                              &filedir)) {
         test_failed();
         filedir.unix_priv = S_IRUSR | S_IWUSR;
         FAIL(FPSetDirParms(Conn, vol, dir, "", bitmap, &filedir))
@@ -572,7 +572,7 @@ STATIC void test353()
              (1 << DIRPBIT_UNIXPR);
 
     if (/* htonl(AFPERR_BITMAP) != */ FPGetFileDirParams(Conn, vol, dir, name,
-                                      bitmap, 0)) {
+                                                         bitmap, 0)) {
         test_failed();
         goto fin1;
     }
@@ -592,7 +592,7 @@ STATIC void test353()
     filedir.access[1] = filedir.access[2] = filedir.access[3] = 0;
 
     if (htonl(AFPERR_BITMAP) != FPSetFilDirParam(Conn, vol, dir, name, bitmap,
-            &filedir)) {
+                                                 &filedir)) {
         test_failed();
         filedir.unix_priv = S_IRUSR | S_IWUSR;
         FAIL(FPSetFilDirParam(Conn, vol, dir, name, bitmap, &filedir))

--- a/test/testsuite/FPSetFileDirParms.c
+++ b/test/testsuite/FPSetFileDirParms.c
@@ -643,7 +643,7 @@ STATIC void test347()
              (1 << DIRPBIT_UNIXPR);
 
     if (/* htonl(AFPERR_BITMAP) != */ FPGetFileDirParams(Conn, vol, dir, name,
-                                      bitmap, 0)) {
+            bitmap, 0)) {
         test_failed();
         goto fin1;
     }

--- a/test/testsuite/FPSetFileDirParms.c
+++ b/test/testsuite/FPSetFileDirParms.c
@@ -81,7 +81,7 @@ STATIC void test98()
 
         FAIL(FPSetFilDirParam(Conn, vol, dir, name1, bitmap, &filedir))
         FAIL(ntohl(AFPERR_NOOBJ) != FPSetFilDirParam(Conn, vol, DIRDID_ROOT, name1,
-                bitmap, &filedir))
+                                                     bitmap, &filedir))
         FAIL(FPSetFilDirParam(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
     }
 
@@ -633,7 +633,7 @@ STATIC void test347()
     filedir.access[1] = filedir.access[2] = filedir.access[3] = 0;
 
     if (htonl(AFPERR_BITMAP) != FPSetFilDirParam(Conn, vol, dir, "", bitmap,
-            &filedir)) {
+                                                 &filedir)) {
         test_failed();
         filedir.unix_priv = S_IRUSR | S_IWUSR;
         FAIL(FPSetFilDirParam(Conn, vol, dir, "", bitmap, &filedir))
@@ -643,7 +643,7 @@ STATIC void test347()
              (1 << DIRPBIT_UNIXPR);
 
     if (/* htonl(AFPERR_BITMAP) != */ FPGetFileDirParams(Conn, vol, dir, name,
-                                      bitmap, 0)) {
+                                                         bitmap, 0)) {
         test_failed();
         goto fin1;
     }
@@ -663,7 +663,7 @@ STATIC void test347()
     filedir.access[1] = filedir.access[2] = filedir.access[3] = 0;
 
     if (htonl(AFPERR_BITMAP) != FPSetFilDirParam(Conn, vol, dir, name, bitmap,
-            &filedir)) {
+                                                 &filedir)) {
         test_failed();
         filedir.unix_priv = S_IRUSR | S_IWUSR;
         FAIL(FPSetFilDirParam(Conn, vol, dir, name, bitmap, &filedir))
@@ -967,7 +967,7 @@ STATIC void test358()
     /* FIXME: FPEnumerate* uses dsi_data_receive. See afphelper.c:delete_directory_tree() */
     FAIL(FPEnumerateFull(Conn, vol, 1, 5, 800,  dir, "", bitmap, bitmap))
     FAIL(htonl(AFPERR_ACCESS) != FPEnumerateFull(Conn2, vol2, 1, 5, 800,  dir, "",
-            bitmap, bitmap))
+                                                 bitmap, bitmap))
     memcpy(filedir.access, old_access, sizeof(old_access));
     bitmap = (1 << DIRPBIT_ACCESS);
     FAIL(FPSetDirParms(Conn, vol, dir, "", bitmap, &filedir))

--- a/test/testsuite/FPSetFileParms.c
+++ b/test/testsuite/FPSetFileParms.c
@@ -37,9 +37,9 @@ STATIC void test83()
         afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
         FAIL(htonl(AFPERR_NOOBJ) != FPSetFileParams(Conn, vol, DIRDID_ROOT, name1,
-                bitmap, &filedir))
+                                                    bitmap, &filedir))
         FAIL(htonl(AFPERR_BADTYPE) != FPSetFileParams(Conn, vol, DIRDID_ROOT, ndir,
-                bitmap, &filedir))
+                                                      bitmap, &filedir))
     }
 
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
@@ -210,7 +210,7 @@ STATIC void test122()
                  (1 << FILPBIT_MDATE);
         FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
         FAIL(htonl(AFPERR_BITMAP) != FPSetFileParams(Conn, vol, DIRDID_ROOT, name,
-                0xffff, &filedir))
+                                                     0xffff, &filedir))
     }
 
     fork1 = FPOpenFork(Conn, vol, type, 0, DIRDID_ROOT, name, OPENACC_RD);
@@ -255,7 +255,7 @@ STATIC void test318()
         filedir.isdir = 0;
         afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
         FAIL(htonl(AFPERR_BITMAP) != FPSetFileParams(Conn, vol, DIRDID_ROOT, name,
-                bitmap, &filedir))
+                                                     bitmap, &filedir))
     }
 
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))

--- a/test/testsuite/FPSetForkParms.c
+++ b/test/testsuite/FPSetForkParms.c
@@ -115,11 +115,11 @@ STATIC void test141()
     }
 
     FAIL(ntohl(AFPERR_BITMAP) != FPSetForkParam(Conn, fork, (1 << FILPBIT_RFLEN),
-            0))
+                                                0))
 
     if (Conn->afp_version < 30) {
         FAIL(ntohl(AFPERR_BITMAP) != FPSetForkParam(Conn, fork, (1 << FILPBIT_EXTDFLEN),
-                0))
+                                                    0))
     }
 
     FAIL(FPCloseFork(Conn, fork))
@@ -132,11 +132,11 @@ STATIC void test141()
     }
 
     FAIL(ntohl(AFPERR_BITMAP) != FPSetForkParam(Conn, fork, (1 << FILPBIT_DFLEN),
-            0))
+                                                0))
 
     if (Conn->afp_version < 30) {
         FAIL(ntohl(AFPERR_BITMAP) != FPSetForkParam(Conn, fork, (1 << FILPBIT_EXTRFLEN),
-                0))
+                                                    0))
     }
 
     FAIL(FPCloseFork(Conn, fork))
@@ -180,7 +180,7 @@ STATIC void test217()
     FAIL(FPSetForkParam(Conn, fork, (1 << FILPBIT_EXTDFLEN), 0))
     FAIL(ntohl(AFPERR_EOF) != FPRead(Conn, fork, 1, 1, Data))
     FAIL(ntohl(AFPERR_PARAM) != FPSetForkParam(Conn, fork, (1 << FILPBIT_EXTDFLEN),
-            1 << 31))
+                                               1 << 31))
     ret = FPSetForkParam(Conn, fork, (1 << FILPBIT_EXTDFLEN), (1UL << 31));
 
     if (ret) {

--- a/test/testsuite/T2_FPByteRangeLock.c
+++ b/test/testsuite/T2_FPByteRangeLock.c
@@ -87,7 +87,7 @@ static void test_bytelock(uint16_t vol2, char *name, int type)
         lock.l_whence = SEEK_SET;
 
         if ((ret = fcntl(fd, F_SETLK, &lock)) >= 0 || (errno != EACCES
-                && errno != EAGAIN)) {
+            && errno != EAGAIN)) {
             if (!ret >= 0) {
                 errno = 0;
             }

--- a/test/testsuite/T2_FPByteRangeLock.c
+++ b/test/testsuite/T2_FPByteRangeLock.c
@@ -87,7 +87,7 @@ static void test_bytelock(uint16_t vol2, char *name, int type)
         lock.l_whence = SEEK_SET;
 
         if ((ret = fcntl(fd, F_SETLK, &lock)) >= 0 || (errno != EACCES
-                && errno != EAGAIN)) {
+                                                       && errno != EAGAIN)) {
             if (!ret >= 0) {
                 errno = 0;
             }

--- a/test/testsuite/T2_FPGetFileDirParms.c
+++ b/test/testsuite/T2_FPGetFileDirParms.c
@@ -92,12 +92,12 @@ STATIC void test32()
     }
 
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, dir, "",
-            0
-            ,
-            (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
-            (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
-            (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-            (1 << DIRPBIT_ACCESS)
+                                                  0
+                                                  ,
+                                                  (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
+                                                  (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
+                                                  (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                                  (1 << DIRPBIT_ACCESS)
                                                  )
        ) {
         test_failed();
@@ -208,12 +208,12 @@ STATIC void test33()
     }
 
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name,
-            0
-            ,
-            (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
-            (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
-            (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-            (1 << DIRPBIT_ACCESS)
+                                                  0
+                                                  ,
+                                                  (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
+                                                  (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
+                                                  (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                                  (1 << DIRPBIT_ACCESS)
                                                  )
        ) {
         test_failed();
@@ -304,12 +304,12 @@ STATIC void test42()
 
     /* our curdir is in the deleted folder so no error! */
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, dir, "bar",
-            0
-            ,
-            (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
-            (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
-            (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-            (1 << DIRPBIT_ACCESS)
+                                                  0
+                                                  ,
+                                                  (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
+                                                  (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
+                                                  (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                                  (1 << DIRPBIT_ACCESS)
                                                  )
        ) {
         test_failed();
@@ -660,12 +660,12 @@ STATIC void test182()
     }
 
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, dir, "",
-            0
-            ,
-            (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
-            (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
-            (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-            (1 << DIRPBIT_ACCESS)
+                                                  0
+                                                  ,
+                                                  (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
+                                                  (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
+                                                  (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                                  (1 << DIRPBIT_ACCESS)
                                                  )
        ) {
         test_failed();
@@ -979,12 +979,12 @@ STATIC void test340()
     }
 
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, dir, "",
-            0
-            ,
-            (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
-            (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
-            (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-            (1 << DIRPBIT_ACCESS)
+                                                  0
+                                                  ,
+                                                  (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
+                                                  (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
+                                                  (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                                  (1 << DIRPBIT_ACCESS)
                                                  )
        ) {
         test_failed();

--- a/test/testsuite/T2_FPResolveID.c
+++ b/test/testsuite/T2_FPResolveID.c
@@ -352,7 +352,7 @@ static int get_fs_lock(char *folder, char *file)
         }
 
         if ((ret = fcntl(fd, F_SETLK, &lock)) >= 0 || (errno != EACCES
-                && errno != EAGAIN)) {
+            && errno != EAGAIN)) {
             if (!ret >= 0) {
                 errno = 0;
             }

--- a/test/testsuite/T2_FPResolveID.c
+++ b/test/testsuite/T2_FPResolveID.c
@@ -352,7 +352,7 @@ static int get_fs_lock(char *folder, char *file)
         }
 
         if ((ret = fcntl(fd, F_SETLK, &lock)) >= 0 || (errno != EACCES
-                && errno != EAGAIN)) {
+                                                       && errno != EAGAIN)) {
             if (!ret >= 0) {
                 errno = 0;
             }

--- a/test/testsuite/T2_FPSetDirParms.c
+++ b/test/testsuite/T2_FPSetDirParms.c
@@ -44,7 +44,7 @@ STATIC void test121()
 
         FAIL(FPSetDirParms(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
         FAIL(htonl(AFPERR_BITMAP) != FPSetDirParms(Conn, vol, DIRDID_ROOT, name, 0xffff,
-                &filedir))
+                                                   &filedir))
     }
 
 fin:

--- a/test/testsuite/Utf8.c
+++ b/test/testsuite/Utf8.c
@@ -270,7 +270,7 @@ STATIC void test185()
 
     FAIL(ntohl(AFPERR_PARAM) != FPRename(Conn, vol, DIRDID_ROOT, name, name1))
     FAIL(ntohl(AFPERR_PARAM) != FPMoveAndRename(Conn, vol, DIRDID_ROOT, DIRDID_ROOT,
-            name, name1))
+                                                name, name1))
     FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
     FPFlush(Conn, vol);
 test_exit:
@@ -315,7 +315,7 @@ STATIC void test233()
     sprintf(temp, "t23#%X", ntohl(dir));
 
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp, 0,
-            bitmap)) {
+                                                  bitmap)) {
         /* MAC OK */
         test_failed();
     }
@@ -325,7 +325,7 @@ STATIC void test233()
     sprintf(temp, "t233 dire#%X", ntohl(dir));
 
     if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp, 0,
-            bitmap)) {
+                                                  bitmap)) {
         /* MAC OK */
         test_failed();
     }
@@ -373,7 +373,7 @@ STATIC void test234()
         sprintf(temp, "t23#%X", ntohl(filedir.did));
 
         if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp,
-                bitmap, 0)) {
+                                                      bitmap, 0)) {
             test_failed();
         }
 
@@ -382,7 +382,7 @@ STATIC void test234()
         sprintf(temp, "t234 file#%X", ntohl(filedir.did));
 
         if (ntohl(AFPERR_NOOBJ) != FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp,
-                bitmap, 0)) {
+                                                      bitmap, 0)) {
             test_failed();
         }
 
@@ -431,7 +431,7 @@ STATIC void test312()
         sprintf(temp, "t312-#%X", ntohl(filedir.did));
 
         if (ntohl(AFPERR_NOOBJ) != 	FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp,
-                bitmap, 0)) {
+                                                       bitmap, 0)) {
             test_failed();
         }
 
@@ -451,7 +451,7 @@ STATIC void test312()
         sprintf(temp, "t3-#%X.mp3", ntohl(filedir.did));
 
         if (ntohl(AFPERR_NOOBJ) != 	FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp,
-                bitmap, 0)) {
+                                                       bitmap, 0)) {
             test_failed();
         }
     }
@@ -578,7 +578,7 @@ STATIC void test337()
         sprintf(temp, "???#%X", ntohl(filedir.did));
 
         if (ntohl(AFPERR_NOOBJ) != 	FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp,
-                bitmap, 0)) {
+                                                       bitmap, 0)) {
             /* MAC OK */
             test_failed();
         }
@@ -599,7 +599,7 @@ STATIC void test337()
         sprintf(temp, "t#%X.mp3", ntohl(filedir.did));
 
         if (ntohl(AFPERR_NOOBJ) != 	FPGetFileDirParams(Conn, vol, DIRDID_ROOT, temp,
-                bitmap, 0)) {
+                                                       bitmap, 0)) {
             /* MAC OK */
             test_failed();
         }

--- a/test/testsuite/afpcmd.h
+++ b/test/testsuite/afpcmd.h
@@ -10,23 +10,23 @@ extern unsigned int FPSpotlightOpen(CONN *conn, uint16_t vid,
                                     char *vol_path_out,
                                     size_t vol_path_buflen);
 extern unsigned int FPSpotlightOpenQuery(CONN *conn, uint16_t vid,
-        const char *query_dsl,
-        uint64_t ctx);
+                                         const char *query_dsl,
+                                         uint64_t ctx);
 extern unsigned int FPSpotlightOpenQueryScoped(CONN *conn, uint16_t vid,
-        const char *query_dsl,
-        const char *scope,
-        uint64_t ctx);
+                                               const char *query_dsl,
+                                               const char *scope,
+                                               uint64_t ctx);
 extern unsigned int FPSpotlightDrainResults(CONN *conn, uint16_t vid,
-        uint64_t ctx,
-        int *total_results_out);
+                                            uint64_t ctx,
+                                            int *total_results_out);
 extern unsigned int FPSpotlightCloseQuery(CONN *conn, uint16_t vid,
-        uint64_t ctx);
+                                          uint64_t ctx);
 extern unsigned int FPSpotlightFetchPropertiesWithShrunkTOC(CONN *conn,
-        uint16_t vid);
+                                                            uint16_t vid);
 extern unsigned int FPSpotlightFetchPropertiesWithLargeTOCIndex(CONN *conn,
         uint16_t vid);
 extern unsigned int FPSpotlightRPCWithLargeInt64Count(CONN *conn,
-        uint16_t vid);
+                                                      uint16_t vid);
 extern unsigned int FPSpotlightPackFilemetaOverflowProbe(void);
 
 extern unsigned int FPopenLogin(CONN *conn, char *vers, char *uam, char *usr,
@@ -40,7 +40,7 @@ extern unsigned int FPMapName(CONN *conn, char fn, char *name);
 extern unsigned int FPGetSessionToken(CONN *conn, int type, uint32_t time,
                                       int len, char *token);
 extern unsigned int FPDisconnectOldSession(CONN *conn, uint16_t type, int len,
-        char *token);
+                                           char *token);
 
 extern unsigned int FPGetSrvrInfo(CONN *conn);
 extern unsigned int FPGetSrvrParms(CONN *conn);

--- a/test/testsuite/afpcmd_spotlight.c
+++ b/test/testsuite/afpcmd_spotlight.c
@@ -220,7 +220,7 @@ unsigned int FPSpotlightFetchPropertiesWithShrunkTOC(CONN *conn, uint16_t vid)
  *        tag references a far out-of-range TOC index
  */
 unsigned int FPSpotlightFetchPropertiesWithLargeTOCIndex(CONN *conn,
-        uint16_t vid)
+                                                         uint16_t vid)
 {
     char rpcbuf[SL_PACK_BUFLEN];
     int  rpclen;
@@ -252,7 +252,7 @@ unsigned int FPSpotlightRPCWithLargeInt64Count(CONN *conn, uint16_t vid)
     spotlight_test_put_le32(rpcbuf, 12, 3);
     spotlight_test_put_le64(rpcbuf, 16,
                             spotlight_test_pack_tag(TEST_SQ_TYPE_INT64, 2,
-                                    0x7fffffff));
+                                                    0x7fffffff));
     spotlight_test_put_le64(rpcbuf, 24, 0);
     spotlight_test_put_le64(rpcbuf, 32,
                             spotlight_test_pack_tag(TEST_SQ_TYPE_TOC, 1, 0));
@@ -420,9 +420,9 @@ unsigned int FPSpotlightOpen(CONN *conn, uint16_t vid,
  * and "uint64_t", 2.
  */
 static unsigned int spotlight_open_query_send(CONN *conn, uint16_t vid,
-        const char *query_dsl,
-        const char *scope,
-        uint64_t ctx)
+                                              const char *query_dsl,
+                                              const char *scope,
+                                              uint64_t ctx)
 {
     /* sl_pack writes up to SL_PACK_BUFLEN bytes regardless of caller
      * buffer; see comment at top of this TU. */

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -2351,8 +2351,8 @@ int main(int32_t ac, char **av)
     /* Login to AFP server */
     if (afptest_uam) {
         ExitCode = ntohs((uint16_t)afptest_uam_login(Conn, vers,
-                         afptest_uam, User,
-                         Password));
+                                                     afptest_uam, User,
+                                                     Password));
     } else if (Version >= 30) {
         ExitCode = ntohs((uint16_t)FPopenLoginExt(Conn, vers, uam, User, Password));
     } else {

--- a/test/testsuite/logintest_uam.c
+++ b/test/testsuite/logintest_uam.c
@@ -269,8 +269,8 @@ int uamtest_run_selected(const char *filter)
 {
     bool matched = false;
     advertised_uams = uamtest_libafpclient_discover_uams(Server, Port,
-                      Version, User ? User : "", Password ? Password : "",
-                      &advertised_known);
+                                                         Version, User ? User : "", Password ? Password : "",
+                                                         &advertised_known);
 
     if (Verbose && advertised_known) {
         char *uam_list = uam_bitmap_to_string(advertised_uams);

--- a/test/testsuite/rotest.c
+++ b/test/testsuite/rotest.c
@@ -241,9 +241,9 @@ STATIC void test510()
 
     FAIL(htonl(AFPERR_VLOCK) != FPDelete(Conn, VolID, DIRDID_ROOT, file))
     FAIL(htonl(AFPERR_VLOCK) != FPMoveAndRename(Conn, VolID, DIRDID_ROOT,
-            DIRDID_ROOT, file, nfile))
+                                                DIRDID_ROOT, file, nfile))
     FAIL(htonl(AFPERR_VLOCK) != FPMoveAndRename(Conn, VolID, DIRDID_ROOT,
-            DIRDID_ROOT, dir, ndir))
+                                                DIRDID_ROOT, dir, ndir))
     /* -- directory.c -- */
     bitmap = (1 << DIRPBIT_FINFO) | (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) |
              (1 << DIRPBIT_MDATE);

--- a/test/testsuite/speedtest.c
+++ b/test/testsuite/speedtest.c
@@ -692,8 +692,8 @@ static int check_test_dir_exists(uint16_t vol, char *dir_name,
     uint16_t dir_bitmap = (uint16_t)((1U << DIRPBIT_LNAME) | (1U << DIRPBIT_PDID));
 
     if (ntohl(AFPERR_NOOBJ) != VFS.getfiledirparams(Conn, vol, DIRDID_ROOT,
-            dir_name,
-            dir_bitmap, dir_bitmap)) {
+                                                    dir_name,
+                                                    dir_bitmap, dir_bitmap)) {
         fprintf(stderr, "Warning: %s test skipped - directory '%s' already exists\n",
                 test_name, dir_name);
         test_nottested();

--- a/test/testsuite/uamtest_libafpclient.c
+++ b/test/testsuite/uamtest_libafpclient.c
@@ -113,10 +113,10 @@ const char *uamtest_libafpclient_resolve_uam(const char *uam)
 }
 
 unsigned int uamtest_libafpclient_discover_uams(const char *host, int port,
-        int afp_version,
-        const char *user,
-        const char *password,
-        bool *known)
+                                                int afp_version,
+                                                const char *user,
+                                                const char *password,
+                                                bool *known)
 {
     struct afp_connection_request req;
     struct afp_server *server;

--- a/test/testsuite/uamtest_libafpclient.h
+++ b/test/testsuite/uamtest_libafpclient.h
@@ -9,10 +9,10 @@ int uamtest_libafpclient_init(void);
 unsigned int uamtest_libafpclient_uam_mask(const char *uam);
 const char *uamtest_libafpclient_resolve_uam(const char *uam);
 unsigned int uamtest_libafpclient_discover_uams(const char *host, int port,
-        int afp_version,
-        const char *user,
-        const char *password,
-        bool *known);
+                                                int afp_version,
+                                                const char *user,
+                                                const char *password,
+                                                bool *known);
 int uamtest_libafpclient_connect(struct uamtest_session **session,
                                  const char *host, int port,
                                  int afp_version, const char *uam,


### PR DESCRIPTION
astyle v3.6.17 introduces a column width override for trailing code comments, so we apply this rule and now require astyle v3.6.17 or later

in parallel, this version of astyle started enforcing a minimal continuation indentation which caused bracket and equal sign aligned indentation to collapse -- we now enforce a max continuation indentation of 60 chars to counteract this, which triggers a handful of restyling (for the better in my opinion)

add an override for sl_xapian.h which is affected by astyle bug https://gitlab.com/saalen/astyle/-/work_items/111

update the coding style guide to formally allow trailing code comments and mandate specific astyle versions that are supported

harden the whole code formatting CI job:

- bump to the latest Alpine base image
- build astyle from tarball instead of git clone in the formatting GitHub CI job
- install the markdownlint-cli2 tarball with npm instead of remotely
- do checksum validation of both tarballs

reformat C source files with astyle v3.6.18