### PR TITLE
test: expand afp_logintest with UAM test suite

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1032,14 +1032,14 @@ jobs:
             -e AFP_USER="atalk1" \
             -e AFP_PASS="$CONT_PASSWD" \
             -e AFP_GROUP="afpusers" \
-            -e AFP_UAMS="uams_guest.so uams_clrtxt.so uams_dhx.so" \
+            -e AFP_UAMS="uams_guest.so uams_clrtxt.so uams_randnum.so uams_dhx.so uams_dhx2.so uams_srp.so" \
             -e TESTSUITE="login" \
             -e VERBOSE="1" \
             -e AFP_VERSION="7" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
-  afp-logintest-afp21:
-    name: AFP login test AFP 2.1 - Alpine
+  afp-logintest-afp33:
+    name: AFP login test AFP 3.3 - Alpine
     needs: build-container-testsuite
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -1051,10 +1051,87 @@ jobs:
             -e AFP_USER="atalk1" \
             -e AFP_PASS="$CONT_PASSWD" \
             -e AFP_GROUP="afpusers" \
+            -e AFP_UAMS="uams_guest.so uams_clrtxt.so uams_randnum.so uams_dhx.so uams_dhx2.so uams_srp.so" \
+            -e TESTSUITE="login" \
+            -e VERBOSE="1" \
+            -e AFP_VERSION="6" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+  afp-logintest-afp32:
+    name: AFP login test AFP 3.2 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_PASS="$CONT_PASSWD" \
+            -e AFP_GROUP="afpusers" \
+            -e AFP_UAMS="uams_guest.so uams_clrtxt.so uams_randnum.so uams_dhx.so uams_dhx2.so" \
+            -e TESTSUITE="login" \
+            -e VERBOSE="1" \
+            -e AFP_VERSION="5" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+  afp-logintest-afp31:
+    name: AFP login test AFP 3.1 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_PASS="$CONT_PASSWD" \
+            -e AFP_GROUP="afpusers" \
+            -e AFP_UAMS="uams_guest.so uams_clrtxt.so uams_randnum.so uams_dhx.so uams_dhx2.so" \
+            -e TESTSUITE="login" \
+            -e VERBOSE="1" \
+            -e AFP_VERSION="4" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+  afp-logintest-afp30:
+    name: AFP login test AFP 3.0 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_PASS="$CONT_PASSWD" \
+            -e AFP_GROUP="afpusers" \
+            -e AFP_UAMS="uams_guest.so uams_clrtxt.so uams_randnum.so uams_dhx.so" \
+            -e TESTSUITE="login" \
+            -e VERBOSE="1" \
+            -e AFP_VERSION="3" \
+            ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
+
+  afp-logintest-afp22:
+    name: AFP login test AFP 2.2 - Alpine
+    needs: build-container-testsuite
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    steps:
+      - name: Run Netatalk testsuite
+        run: |
+          docker run --rm \
+            -e AFP_USER="atalk1" \
+            -e AFP_PASS="$CONT_PASSWD" \
+            -e AFP_GROUP="afpusers" \
+            -e AFP_UAMS="uams_guest.so uams_clrtxt.so uams_randnum.so" \
             -e INSECURE_AUTH="1" \
             -e TESTSUITE="login" \
             -e VERBOSE="1" \
-            -e AFP_VERSION="1" \
+            -e AFP_VERSION="2" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }}
 
   latencygraph-lantest:

--- a/distrib/docker/testsuite_alp.Dockerfile
+++ b/distrib/docker/testsuite_alp.Dockerfile
@@ -9,6 +9,7 @@ ARG RUN_DEPS="\
     glib \
     iniparser \
     krb5 \
+    libedit \
     libevent \
     libgcrypt \
     linux-pam \
@@ -26,14 +27,17 @@ ARG BUILD_DEPS="\
     acl-dev \
     avahi-dev \
     bison \
+    ca-certificates \
     cups-dev \
     db-dev \
     dbus-dev \
     build-base \
     flex \
     gcc \
+    gnupg \
     iniparser-dev \
     krb5-dev \
+    libedit-dev \
     libevent-dev \
     libgcrypt-dev \
     linux-pam-dev \
@@ -45,6 +49,7 @@ ARG BUILD_DEPS="\
     sqlite-dev \
     talloc-dev \
     tinysparql-dev \
+    xz \
     "
 
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b AS build
@@ -58,6 +63,32 @@ RUN apk update \
 &&  apk add --no-cache \
     $RUN_DEPS \
     $BUILD_DEPS
+
+WORKDIR /netatalk-client-code
+ADD "https://netatalk.io/NetatalkDistributionPublicKey.asc" netatalk-distribution.asc
+ADD "https://github.com/Netatalk/netatalk-client/releases/download/0.9.5/netatalk-client-0.9.5.tar.xz" netatalk-client.tar.xz
+ADD "https://github.com/Netatalk/netatalk-client/releases/download/0.9.5/netatalk-client-0.9.5.tar.xz.asc" netatalk-client.tar.xz.asc
+RUN gpg --batch --import netatalk-distribution.asc \
+&&  gpg --batch --list-keys --with-colons 835A65428C822F69C45B817A7B13E1BFE4DDE8BD \
+        | grep -q '^fpr:::::::::835A65428C822F69C45B817A7B13E1BFE4DDE8BD:' \
+&&  gpg --batch --verify netatalk-client.tar.xz.asc netatalk-client.tar.xz \
+&&  mkdir src \
+&&  tar -xJf netatalk-client.tar.xz \
+        -C src \
+        --strip-components=1 \
+&&  rm -rf \
+        netatalk-distribution.asc \
+        netatalk-client.tar.xz \
+        netatalk-client.tar.xz.asc \
+        /root/.gnupg
+
+RUN meson setup src/build src \
+    -Dbuildtype=debugoptimized \
+    -Dc_link_args=-Wl,-Bsymbolic-functions \
+    -Denable-docs=false \
+&&  meson compile -C src/build \
+&&  meson install --destdir=/staging/ -C src/build \
+&&  cp -a /staging/usr/local/. /usr/local/
 
 WORKDIR /netatalk-code
 COPY bin/ ./bin/

--- a/distrib/docker/webmin_module.Dockerfile
+++ b/distrib/docker/webmin_module.Dockerfile
@@ -13,7 +13,6 @@ ARG RUN_DEPS="\
     "
 ARG BUILD_DEPS="\
     build-essential \
-    curl \
     file \
     libdb-dev \
     libevent-dev \
@@ -36,12 +35,11 @@ ENV BUILD_DEPS=$BUILD_DEPS
 ENV PERLLIB=/usr/share/webmin
 
 ARG DEBIAN_FRONTEND=noninteractive
+ADD "https://raw.githubusercontent.com/webmin/webmin/${WEBMIN_COMMIT}/webmin-setup-repo.sh" webmin-setup-repo.sh
 RUN apt-get update \
 &&  apt-get install --yes --no-install-recommends \
     $RUN_DEPS \
     $BUILD_DEPS \
-&&  curl --fail --proto '=https' --show-error --location -o webmin-setup-repo.sh \
-    "https://raw.githubusercontent.com/webmin/webmin/${WEBMIN_COMMIT}/webmin-setup-repo.sh" \
 &&  printf '%s  webmin-setup-repo.sh\n' "${WEBMIN_SETUP_REPO_SHA256}" | sha256sum -c - \
 &&  sh webmin-setup-repo.sh --force \
 &&  apt-get install --yes --no-install-recommends webmin=${WEBMIN_VERSION} \

--- a/doc/manpages/man1/afp_logintest.1.md
+++ b/doc/manpages/man1/afp_logintest.1.md
@@ -10,9 +10,21 @@ afp_logintest — AFP authentication and DSI session test suite
 
 # Description
 
-**afp_logintest** is a testsuite for DSI sessions and authentication from an AFP client.
-It will run a range of happy path and corner case tests for establishing a DSI session
-with an AFP server and then use UAMs (User Authentication Methods) to authenticate with a user.
+**afp_logintest** is a testsuite for DSI sessions and authentication from an AFP
+client. It runs happy-path and corner-case tests for establishing a DSI session
+with an AFP server, then uses UAMs (User Authentication Methods) to authenticate
+with a user.
+
+The built-in login tests use Netatalk's native testsuite AFP client for raw DSI
+session coverage, malformed-protocol coverage, and direct UAM login checks.
+
+When Netatalk is built with libafpclient-backed UAM tests, **afp_logintest** also
+runs a UAM matrix that checks each selected UAM against libafpclient. For each
+selected libafpclient UAM, the test checks whether the UAM is known to
+libafpclient, whether the server advertises it when that can be discovered,
+whether login succeeds with the supplied credentials, whether login fails with
+an intentionally wrong password for credentialed UAMs, and whether a tiny
+authenticated AFP smoke request succeeds after login.
 
 # Options
 
@@ -41,13 +53,16 @@ with an AFP server and then use UAMs (User Authentication Methods) to authentica
 : Turn off ANSI colors in terminal output
 
 **-f** *test*
-: Run a specific test
+: Run a specific test. If libafpclient-backed UAM tests are compiled in, *test*
+may also be one of the short UAM selectors listed by **-l**, or the full UAM
+protocol name.
 
 **-h** *host*
 : Server hostname or IP address (default: localhost)
 
 **-l**
-: List available tests
+: List available tests. If libafpclient-backed UAM tests are compiled in, this
+also lists the available UAM selectors.
 
 **-m**
 : Run tests in AppleShare (Mac) AFP server compatibility mode
@@ -81,34 +96,68 @@ see the test output for details on which tests failed due to missing UAMs.
 
 Additionally, in order to test non-Guest authentication, a username and password must be passed to the test runner.
 
+To exercise the full libafpclient-backed UAM matrix, configure the server with
+all required UAMs, for example:
+
+    [Global]
+    uam list = uams_guest.so uams_clrtxt.so uams_randnum.so uams_dhx.so uams_dhx2.so uams_srp.so
+
+Randnum and SRP tests require the corresponding server-side credential files.
+Use **afppasswd**(1) to manage those files.
+
 # Examples
 
-Run all tests against an AFP server running on 10.0.0.10, without user credentials
+List all available tests, including libafpclient-backed UAM tests when compiled
+in:
 
-    $ afp_logintest -h 10.0.0.10
-    Logintest:test1: DSI with no open session - PASSED
-    Logintest:test2: DSI with open session - PASSED
-    Logintest:test3: Guest login - PASSED
-    Logintest:test4: connection limit hit returns server-busy - PASSED
-    Logintest:test5: Clear text login - SKIPPED (username/password for the AFP server)
-    Logintest:test6: DSIOpenSession non zero parameter should be ignored by the server - SKIPPED (username/password for the AFP server)
-    Logintest:test7: DSI round-trip via renamed dsi_stream_send/dsi_cmd_receive - PASSED
-    Logintest:test8: FPLoginExt + No User Authent (direct) - PASSED
-    Logintest:test9: AFPLoginCont primitive round-trip - SKIPPED (username/password for the AFP server)
-    Logintest:test10: UAM matrix walk - PASSED
+    $ afp_logintest -l
+    Available tests. Run individually with the -f option.
+    test_dsi_getstatus_no_session
+    test_dsi_open_close_session
+    test_dsi_open_session_ignore_param
+    test_dsi_command_roundtrip
+    test_connection_limit
+    test_guest_login
+    test_cleartext_login
+    test_loginext_guest_direct
+    test_logincont_roundtrip
+    guest      No User Authent (libafpclient UAM)
+    cleartext  Cleartxt Passwrd (libafpclient UAM)
+    randnum    Randnum Exchange (libafpclient UAM)
+    randnum2   2-Way Randnum Exchange (libafpclient UAM)
+    dhx        DHCAST128 (libafpclient UAM)
+    dhx2       DHX2 (libafpclient UAM)
+    srp        SRP (libafpclient UAM)
+
+Run only the SRP UAM test:
+
+    $ afp_logintest -h localhost -u afpuser -w secret -f srp
+    UAM srp (SRP) - PASSED (login, smoke, and failure checks passed)
     =====================
     TEST RESULT SUMMARY
     ---------------------
-    Passed:     7
-    Skipped:    3
+    Passed:     1
+    Skipped:    0
     Failed:     0
     Not tested: 0
 
-    Skipped tests (precondition not met):
-        Logintest:test5: Clear text login
-        Logintest:test6: DSIOpenSession non zero parameter should be ignored by the server
-        Logintest:test9: AFPLoginCont primitive round-trip
+# Exit Status
+
+**0**
+: All selected tests passed or were skipped.
+
+**1**
+: At least one selected test failed.
+
+**2**
+: No selected test failed, but at least one selected test could not be run
+because setup or UAM support was unavailable.
 
 # See Also
 
-**afp_lantest**(1), **afp_spectest**(1), **afparg**(1), **afpd**(8)
+**afp_lantest**(1), **afp_spectest**(1), **afparg**(1), **afppasswd**(1),
+**afpd**(8), **afp.conf**(5)
+
+# Author
+
+[Contributors to the Netatalk Project](https://netatalk.io/contributors)

--- a/meson.build
+++ b/meson.build
@@ -2676,6 +2676,7 @@ if 'none' not in init_style
     subdir('distrib')
 endif
 
+testsuite_libafpclient = disabler()
 if get_option('with-tests') or get_option('with-testsuite') or get_option('with-fuzzing')
     subdir('test')
 endif
@@ -2801,6 +2802,7 @@ summary(summary_info, bool_yn: true, section: '  Documentation:')
 summary_info = {
     '  afpd integration tests': get_option('with-tests'),
     '  AFP testsuite': get_option('with-testsuite'),
+    '  UAM tests': testsuite_libafpclient.found(),
     '  Webmin module': have_webmin,
 }
 summary(summary_info, bool_yn: true, section: '  Extras:')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -214,6 +214,12 @@ option(
     description: 'Compile the AFP test suite',
 )
 option(
+    'with-testsuite-uams',
+    type: 'boolean',
+    value: true,
+    description: 'Compile libafpclient-backed UAM tests into afp_logintest',
+)
+option(
     'with-fuzzing',
     type: 'boolean',
     value: false,

--- a/test/testsuite/logintest.c
+++ b/test/testsuite/logintest.c
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2026 Daniel Markstedt <daniel@mindani.net>
+ * Based on work by Rafal Lewczuk, Didier Gautheron, and Frank Lahm
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
 #include <dlfcn.h>
 #include <getopt.h>
 
@@ -5,6 +20,9 @@
 #include "afpcmd.h"
 #include "afphelper.h"
 #include "testhelper.h"
+#ifdef HAVE_TESTSUITE_LIBAFPCLIENT
+#include "logintest_uam.h"
+#endif
 
 uint16_t VolID;
 
@@ -37,541 +55,65 @@ int     List = 0;
 int     Mac = 0;
 int     EmptyVol = 0;
 char    *Test;
-static char  *vers = "AFP3.4";
-
-STATIC void connect_server(CONN *conn)
-{
-    int sock;
-    sock = OpenClientSocket(Server, Port);
-
-    if (sock < 0) {
-        test_nottested();
-        exit(ExitCode);
-    }
-
-    memset(&conn->dsi, 0, sizeof(conn->dsi));
-    conn->dsi.socket = sock;
-    /* Guard against a server that accepts the TCP connection but stalls before
-     * replying (e.g. parent busy reaping prior children after a connection-limit
-     * test). Without this, dsi_stream_read blocks in read() indefinitely. */
-    struct timeval tv = { .tv_sec = 15, .tv_usec = 0 };
-    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-}
-
-/* ------------------------- */
-STATIC void test1(void)
-{
-    ENTER_TEST
-    connect_server(Conn);
-    Dsi = &Conn->dsi;
-
-    if (!Quiet) {
-        fprintf(stdout, "DSIGetStatus\n");
-    }
-
-    if (DSIGetStatus(Conn)) {
-        test_failed();
-    }
-
-    CloseClientSocket(Dsi->socket);
-    exit_test("Logintest:test1: DSI with no open session");
-}
-
-/* ------------------------- */
-STATIC void test2(void)
-{
-    ENTER_TEST
-    connect_server(Conn);
-    Dsi = &Conn->dsi;
-
-    if (!Quiet) {
-        fprintf(stdout, "DSIOpenSession\n");
-    }
-
-    if (DSIOpenSession(Conn)) {
-        test_failed();
-        goto test_exit;
-    }
-
-    if (Mac) {
-        if (!Quiet) {
-            fprintf(stdout, "DSIGetStatus\n");
-        }
-
-        if (DSIGetStatus(Conn)) {
-            test_failed();
-            goto test_exit;
-        }
-    }
-
-    if (!Quiet) {
-        fprintf(stdout, "DSICloseSession\n");
-    }
-
-    if (DSICloseSession(Conn)) {
-        test_failed();
-        goto test_exit;
-    }
-
-    CloseClientSocket(Dsi->socket);
-test_exit:
-    exit_test("Logintest:test2: DSI with open session");
-}
-
-/* ------------------------- */
-STATIC void test3(void)
-{
-    static char *uam = "No User Authent";
-    int ret;
-    ENTER_TEST
-    connect_server(Conn);
-    Dsi = &Conn->dsi;
-
-    if (Version >= 30) {
-        ret = FPopenLoginExt(Conn, vers, uam, "", "");
-    } else {
-        ret = FPopenLogin(Conn, vers, uam, "", "");
-    }
-
-    if (ret) {
-        test_failed();
-        goto test_exit;
-    }
-
-    if (Mac) {
-        fprintf(stdout, "DSIGetStatus\n");
-
-        if (DSIGetStatus(Conn)) {
-            test_failed();
-            goto test_exit;
-        }
-    }
-
-    if (FPLogOut(Conn)) {
-        test_failed();
-        goto test_exit;
-    }
-
-test_exit:
-    CloseClientSocket(Dsi->socket);
-    exit_test("Logintest:test3: Guest login");
-}
-
-/* With Netatalk we define the default as 200 maximum connections,
- * while with the AFP server on Mac OS X 10.7 Lion the default is 10.
- * Therefore, test up to 201 to exercise either limit. */
-#define TEST4_MAX_CONNS 201
-
-/* The AFP Reference defines kFPNoMoreSessions (-1068) for FPLogin/FPLoginExt
- * when the server is at its session cap (Table 50: FPLoginExt result
- * codes), but says nothing about a DSI-layer error code for this case.
- * netatalk actually enforces the cap one layer down, in dsi_getsess.c,
- * by sending DSIERR_SERVBUSY (0xFBD1) on the DSIOpenSession reply — so
- * the client never reaches the FPLogin stage. This test accepts either
- * code as "limit hit". */
-STATIC void test4(void)
-{
-    static char *uam = "No User Authent";
-    CONN conn[TEST4_MAX_CONNS];
-    int cnt = 0;
-    unsigned int ret = 0;
-    uint32_t code_host;
-    int hit_limit = 0;
-    ENTER_TEST
-
-    for (int i = 0; i < TEST4_MAX_CONNS; i++) {
-        if (!Quiet) {
-            fprintf(stdout, "conn %d\n", i);
-        }
-
-        connect_server(&conn[i]);
-        Dsi = &conn[i].dsi;
-        cnt++;
-
-        if (Version >= 30) {
-            ret = FPopenLoginExt(&conn[i], vers, uam, "", "");
-        } else {
-            ret = FPopenLogin(&conn[i], vers, uam, "", "");
-        }
-
-        code_host = ntohl(ret);
-
-        if (code_host == (uint32_t) AFPERR_MAXSESS
-                || code_host == DSIERR_SERVBUSY) {
-            hit_limit = 1;
-            break;
-        }
-
-        if (ret) {
-            if (!Quiet) {
-                fprintf(stdout,
-                        "Unexpected login error at conn %d: %d (%s)\n",
-                        i, code_host, afp_error(ret));
-            }
-
-            test_failed();
-            goto cleanup;
-        }
-    }
-
-    if (!hit_limit) {
-        if (!Quiet) {
-            fprintf(stdout,
-                    "All %d logins succeeded; server cap is > %d\n",
-                    cnt, cnt);
-        }
-
-        test_nottested();
-    }
-
-cleanup:
-    /* Send DSICloseSession on all connections that have an open DSI session,
-     * then close sockets. DSIERR_SERVBUSY means DSIOpenSession itself was
-     * rejected -- no DSI session was established, so skip DSICloseSession for
-     * that slot and just shut its socket. AFPERR_MAXSESS means DSIOpenSession
-     * succeeded but AFP rejected the login -- the DSI session IS open and must
-     * be properly closed, or the server keeps the slot occupied. Sleep after to
-     * let the server reap workers, otherwise the next test may fail with
-     * SERVBUSY waiting for a free fork slot. */
-    {
-        int failed_idx = (hit_limit && code_host == DSIERR_SERVBUSY) ? cnt - 1 : -1;
-
-        for (int j = 0; j < cnt; j++) {
-            if (j != failed_idx) {
-                DSICloseSession(&conn[j]);
-            }
-
-            CloseClientSocket(conn[j].dsi.socket);
-        }
-    }
-
-    if (cnt > 0) {
-        fflush(stdout);
-        sleep(3);
-    }
-
-    exit_test("Logintest:test4: connection limit hit returns server-busy");
-}
-
-/* ------------------------- */
-STATIC void test5(void)
-{
-    static char *uam = "Cleartxt Passwrd";
-    int ret;
-    ENTER_TEST
-    connect_server(Conn);
-    Dsi = &Conn->dsi;
-
-    if (!User || Password[0] == '\0') {
-        test_skipped(T_CRED);
-        goto test_exit;
-    }
-
-    if (Version >= 30) {
-        ret = FPopenLoginExt(Conn, vers, uam, User, Password);
-    } else {
-        ret = FPopenLogin(Conn, vers, uam, User, Password);
-    }
-
-    if (ret) {
-        test_failed();
-        goto test_exit;
-    }
-
-    Conn->afp_version = Version;
-
-    if (FPLogOut(Conn)) {
-        test_failed();
-    }
-
-test_exit:
-    CloseClientSocket(Dsi->socket);
-    exit_test("Logintest:test5: Clear text login");
-}
-
-/* ------------------------- */
-STATIC void test6(void)
-{
-    DSI *dsi;
-    uint32_t i = 0;
-    connect_server(Conn);
-    Dsi = &Conn->dsi;
-    dsi = Dsi;
-    /* DSIOpenSession */
-    memset(&dsi->header, 0, sizeof(dsi->header));
-    dsi->header.dsi_flags = DSIFL_REQUEST;
-    dsi->header.dsi_command = DSIFUNC_OPEN;
-    dsi->header.dsi_requestID = htons(dsi_clientID(dsi));
-    dsi->header.dsi_code = 6;
-    dsi->cmdlen = 2 + sizeof(i);
-    dsi->commands[0] = DSIOPT_ATTNQUANT;
-    dsi->commands[1] = sizeof(i);
-    i = htonl(DSI_DEFQUANT);
-    memcpy(dsi->commands + 2, &i, sizeof(i));
-    dsi_send(dsi);
-    dsi_cmd_receive(dsi);
-
-    if (!User || Password[0] == '\0') {
-        test_skipped(T_CRED);
-        goto test_exit;
-    }
-
-    if (dsi->header.dsi_code) {
-        test_failed();
-        goto test_exit;
-    }
-
-    if (!Quiet) {
-        fprintf(stdout, "DSICloseSession\n");
-    }
-
-    if (DSICloseSession(Conn)) {
-        test_failed();
-        goto test_exit;
-    }
-
-test_exit:
-    CloseClientSocket(Dsi->socket);
-    exit_test("Logintest:test6: DSIOpenSession non zero parameter should be ignored by the server");
-}
-
-/* Direct round-trip through the renamed dsi_stream_send / dsi_cmd_receive
- * primitives. Sends an unknown AFP command (255) to an open but
- * unauthenticated session; expect AFPERR_NOOP from the server's switch
- * dispatcher. Catches regressions in the I/O layer. */
-STATIC void test7(void)
-{
-    DSI *dsi;
-    ENTER_TEST
-    connect_server(Conn);
-    Dsi = &Conn->dsi;
-    dsi = Dsi;
-
-    if (DSIOpenSession(Conn)) {
-        test_failed();
-        goto test_exit;
-    }
-
-    memset(&dsi->header, 0, sizeof(dsi->header));
-    dsi->header.dsi_flags = DSIFL_REQUEST;
-    dsi->header.dsi_command = DSIFUNC_CMD;
-    dsi->header.dsi_requestID = htons(dsi_clientID(dsi));
-    dsi->commands[0] = 0xFF;            /* unknown AFP command */
-    dsi->commands[1] = 0;
-    dsi->cmdlen = 2;
-    dsi_send(dsi);
-    dsi_cmd_receive(dsi);
-
-    /* Any non-zero error code means the round trip worked. A zero result
-     * would mean the server accepted an unknown command, which would be a
-     * server bug, not a client one. */
-    if (dsi->header.dsi_code == 0) {
-        test_failed();
-        goto test_exit;
-    }
-
-    if (DSICloseSession(Conn)) {
-        test_failed();
-        goto test_exit;
-    }
-
-test_exit:
-    CloseClientSocket(Dsi->socket);
-    exit_test("Logintest:test7: DSI round-trip via renamed dsi_stream_send/dsi_cmd_receive");
-}
-
-/* FPLoginExt + No User Authent via AFPopenLoginExt_pwd directly, bypassing
- * the FPopenLoginExt wrapper. Validates the post-B1 wire format
- * independently of the wrapper's version-branching. AFP >= 3.0 only. */
-STATIC void test8(void)
-{
-    static const char *uam = "No User Authent";
-    unsigned int ret;
-    ENTER_TEST
-    connect_server(Conn);
-    Dsi = &Conn->dsi;
-
-    if (Version < 30) {
-        test_skipped(T_AFP3);
-        goto test_exit;
-    }
-
-    ret = AFPopenLoginExt_pwd(Conn, vers, uam, "", "");
-
-    if (ret) {
-        test_failed();
-        goto test_exit;
-    }
-
-    if (FPLogOut(Conn)) {
-        test_failed();
-    }
-
-test_exit:
-    CloseClientSocket(Dsi->socket);
-    exit_test("Logintest:test8: FPLoginExt + No User Authent (direct)");
-}
-
-/* Smoke test for AFPLoginCont primitive (Part B4). Drives DHCAST128 with
- * an empty UserAuthInfo to provoke kFPAuthContinue, then sends garbage
- * via AFPLoginCont to verify the wire format reaches the server's
- * logincont entry point. Skipped if the server does not load DHCAST128
- * (returns AFPERR_BADUAM) or doesn't return kFPAuthContinue. Does NOT
- * authenticate -- this only exercises the round-trip plumbing. */
-STATIC void test9(void)
-{
-    static const char *uam = "DHCAST128";
-    unsigned int ret;
-    uint8_t garbage[16];
-    ENTER_TEST
-    connect_server(Conn);
-    Dsi = &Conn->dsi;
-
-    if (Version < 30) {
-        test_skipped(T_AFP3);
-        goto test_exit;
-    }
-
-    if (!User) {
-        test_skipped(T_CRED);
-        goto test_exit;
-    }
-
-    ret = AFPopenLoginExt(Conn, vers, uam, User, NULL, 0);
-
-    if (ntohl(ret) != (uint32_t) AFPERR_AUTHCONT) {
-        if (!Quiet) {
-            fprintf(stdout,
-                    "AFPopenLoginExt returned %d (%s), expected AFPERR_AUTHCONT\n",
-                    ntohl(ret), afp_error(ret));
-        }
-
-        test_nottested();
-        goto test_exit;
-    }
-
-    if (Conn->login_cont_len == 0) {
-        /* Got AUTHCONT but no payload captured -- that's a real bug. */
-        test_failed();
-        goto test_exit;
-    }
-
-    memset(garbage, 0xAA, sizeof(garbage));
-    ret = AFPLoginCont(Conn, garbage, sizeof(garbage));
-
-    /* Any non-zero result is acceptable: the server rejected our garbage
-     * response, which means AFPLoginCont reached the UAM. A zero result
-     * would mean we authenticated with random bytes, which is impossible
-     * unless something is very wrong. */
-    if (ret == 0) {
-        test_failed();
-    }
-
-test_exit:
-    CloseClientSocket(Dsi->socket);
-    exit_test("Logintest:test9: AFPLoginCont primitive round-trip");
-}
-
-/* UAM dispatch table. Each runner returns dsi_code (0 == success).
- * Plug-in point for DHX/DHX2/SRP later -- add a runner that drives the
- * corresponding crypto via AFPopenLoginExt + AFPLoginCont, then list it
- * here. */
-struct uam_test {
-    const char *uam_name;
-    unsigned int (*run)(CONN *conn, const char *vers,
-                        const char *user, const char *pwd);
-    int needs_cred;       /* 1 = skip if !User/!Password */
-};
-
-static unsigned int run_nua(CONN *conn, const char *pvers,
-                            const char *user _U_, const char *pwd _U_)
-{
-    return AFPopenLoginExt_pwd(conn, pvers, "No User Authent", "", "");
-}
-
-static unsigned int run_cleartxt(CONN *conn, const char *pvers,
-                                 const char *user, const char *pwd)
-{
-    return AFPopenLoginExt_pwd(conn, pvers, "Cleartxt Passwrd", user, pwd);
-}
-
-static const struct uam_test uam_matrix[] = {
-    { "No User Authent",  run_nua,      0 },
-    { "Cleartxt Passwrd", run_cleartxt, 1 },
-    /* Plug-in slots (need crypto helpers, see comment above):
-     * { "Randnum Exchange", run_randnum,  1 },
-     * { "2-Way Randnum exchange", run_randnum2,  1 },
-     * { "DHCAST128", run_dhx,  1 },
-     * { "DHX2",      run_dhx2, 1 },
-     * { "SRP",       run_srp,  1 },
-     */
-    { NULL, NULL, 0 }
-};
-
-STATIC void test10(void)
-{
-    ENTER_TEST
-
-    if (Version < 30) {
-        test_skipped(T_AFP3);
-        goto test_exit;
-    }
-
-    for (const struct uam_test *e = uam_matrix; e->uam_name; e++) {
-        if (e->needs_cred && (!User || Password[0] == '\0')) {
-            if (!Quiet) {
-                fprintf(stdout, "  [%s] skipped (no credentials)\n",
-                        e->uam_name);
-            }
-
-            continue;
-        }
-
-        connect_server(Conn);
-        Dsi = &Conn->dsi;
-        unsigned int ret = e->run(Conn, vers, User, Password);
-
-        if (ret) {
-            if (!Quiet) {
-                fprintf(stdout, "  [%s] failed: dsi_code=0x%x\n",
-                        e->uam_name, ntohl(ret));
-            }
-
-            test_failed();
-        } else {
-            Conn->afp_version = Version;
-            FPLogOut(Conn);
-
-            if (!Quiet) {
-                fprintf(stdout, "  [%s] ok\n", e->uam_name);
-            }
-        }
-
-        CloseClientSocket(Dsi->socket);
-    }
-
-test_exit:
-    exit_test("Logintest:test10: UAM matrix walk");
-}
+char *vers = "AFP3.4";
+
+#define FN(a) a
+#define EXT_FN(a) extern void FN(a)(void)
+
+EXT_FN(test_dsi_getstatus_no_session);
+EXT_FN(test_dsi_open_close_session);
+EXT_FN(test_dsi_open_session_ignore_param);
+EXT_FN(test_dsi_command_roundtrip);
+EXT_FN(test_connection_limit);
+EXT_FN(test_guest_login);
+EXT_FN(test_cleartext_login);
+EXT_FN(test_loginext_guest_direct);
+EXT_FN(test_logincont_roundtrip);
 
 struct test_fn {
     const char *name;
     void (*fn)(void);
 };
 
+#define FN_N(a) { # a, FN(a) },
+
 static struct test_fn Test_list[] = {
-    { "test1",  test1  },
-    { "test2",  test2  },
-    { "test3",  test3  },
-    { "test4",  test4  },
-    { "test5",  test5  },
-    { "test6",  test6  },
-    { "test7",  test7  },
-    { "test8",  test8  },
-    { "test9",  test9  },
-    { "test10", test10 },
+    FN_N(test_dsi_getstatus_no_session)
+    FN_N(test_dsi_open_close_session)
+    FN_N(test_dsi_open_session_ignore_param)
+    FN_N(test_dsi_command_roundtrip)
+    FN_N(test_connection_limit)
+    FN_N(test_guest_login)
+    FN_N(test_cleartext_login)
+    FN_N(test_loginext_guest_direct)
+    FN_N(test_logincont_roundtrip)
     { NULL, NULL },
 };
+
+#ifdef HAVE_TESTSUITE_LIBAFPCLIENT
+static void list_uam_tests(void)
+{
+    for (const struct uamtest_entry *entry = uamtest_entries;
+            entry->selector; entry++) {
+        fprintf(stdout, "%-10s %s (libafpclient UAM)\n", entry->selector,
+                entry->uam);
+    }
+}
+
+static const struct uamtest_entry *find_uam_test(const char *name)
+{
+    for (const struct uamtest_entry *entry = uamtest_entries;
+            entry->selector; entry++) {
+        if (!strcmp(entry->selector, name) || !strcmp(entry->uam, name)) {
+            return entry;
+        }
+    }
+
+    return NULL;
+}
+#endif
+
+
 
 /* =============================== */
 static void list_tests(void)
@@ -583,6 +125,10 @@ static void list_tests(void)
         fprintf(stdout, "%s\n", Test_list[i].name);
         i++;
     }
+
+#ifdef HAVE_TESTSUITE_LIBAFPCLIENT
+    list_uam_tests();
+#endif
 }
 
 /* ----------- */
@@ -602,6 +148,15 @@ static void run_one(char *name)
     }
 
     if (Test_list[i].name == NULL) {
+#ifdef HAVE_TESTSUITE_LIBAFPCLIENT
+        const struct uamtest_entry *uam_entry = find_uam_test(name);
+
+        if (uam_entry) {
+            uamtest_run_selected(uam_entry->selector);
+            return;
+        }
+
+#endif
         handle = dlopen(NULL, RTLD_NOW);
 
         if (handle) {
@@ -641,6 +196,10 @@ static void run_all(void)
         Test_list[i].fn();
         i++;
     }
+
+#ifdef HAVE_TESTSUITE_LIBAFPCLIENT
+    uamtest_run_selected(NULL);
+#endif
 }
 
 /* =============================== */
@@ -664,7 +223,11 @@ void usage(char *av0)
     fprintf(stdout, "\t-v\tverbose\n");
     fprintf(stdout, "\t-V\tvery verbose\n");
     fprintf(stdout, "\t-C\tturn off terminal color output\n");
-    fprintf(stdout, "\t-f\ttest to run\n");
+    fprintf(stdout, "\t-f\ttest to run");
+#ifdef HAVE_TESTSUITE_LIBAFPCLIENT
+    fprintf(stdout, " (or UAM selector/name)");
+#endif
+    fprintf(stdout, "\n");
     fprintf(stdout, "\t-l\tlist tests\n");
     exit(1);
 }

--- a/test/testsuite/logintest_dsi.c
+++ b/test/testsuite/logintest_dsi.c
@@ -1,0 +1,494 @@
+/*
+ * Copyright (c) 2026 Daniel Markstedt <daniel@mindani.net>
+ * Based on work by Rafal Lewczuk, Didier Gautheron, and Frank Lahm
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <atalk/afp.h>
+
+#include "afpclient.h"
+#include "afpcmd.h"
+#include "afphelper.h"
+#include "testhelper.h"
+
+extern int Port;
+extern char *Password;
+extern char *User;
+extern char *vers;
+extern DSI *Dsi;
+
+static void connect_server(CONN *conn)
+{
+    int sock;
+    sock = OpenClientSocket(Server, Port);
+
+    if (sock < 0) {
+        test_nottested();
+        exit(ExitCode);
+    }
+
+    memset(&conn->dsi, 0, sizeof(conn->dsi));
+    conn->dsi.socket = sock;
+    /* Guard against a server that accepts the TCP connection but stalls before
+     * replying (e.g. parent busy reaping prior children after a connection-limit
+     * test). Without this, dsi_stream_read blocks in read() indefinitely. */
+    struct timeval tv = { .tv_sec = 15, .tv_usec = 0 };
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+}
+
+static int is_bad_uam(unsigned int ret)
+{
+    return ntohl(ret) == (uint32_t)AFPERR_BADUAM;
+}
+
+/* ------------------------- */
+void test_dsi_getstatus_no_session(void)
+{
+    ENTER_TEST
+    connect_server(Conn);
+    Dsi = &Conn->dsi;
+
+    if (!Quiet) {
+        fprintf(stdout, "DSIGetStatus\n");
+    }
+
+    if (DSIGetStatus(Conn)) {
+        test_failed();
+    }
+
+    CloseClientSocket(Dsi->socket);
+    exit_test("Logintest:dsi_getstatus_no_session: DSI with no open session");
+}
+
+/* ------------------------- */
+void test_dsi_open_close_session(void)
+{
+    ENTER_TEST
+    connect_server(Conn);
+    Dsi = &Conn->dsi;
+
+    if (!Quiet) {
+        fprintf(stdout, "DSIOpenSession\n");
+    }
+
+    if (DSIOpenSession(Conn)) {
+        test_failed();
+        goto test_exit;
+    }
+
+    if (Mac) {
+        if (!Quiet) {
+            fprintf(stdout, "DSIGetStatus\n");
+        }
+
+        if (DSIGetStatus(Conn)) {
+            test_failed();
+            goto test_exit;
+        }
+    }
+
+    if (!Quiet) {
+        fprintf(stdout, "DSICloseSession\n");
+    }
+
+    if (DSICloseSession(Conn)) {
+        test_failed();
+        goto test_exit;
+    }
+
+    CloseClientSocket(Dsi->socket);
+test_exit:
+    exit_test("Logintest:dsi_open_close_session: DSI with open session");
+}
+
+/* ------------------------- */
+void test_dsi_open_session_ignore_param(void)
+{
+    DSI *dsi;
+    uint32_t i = 0;
+    ENTER_TEST
+    connect_server(Conn);
+    Dsi = &Conn->dsi;
+    dsi = Dsi;
+    /* DSIOpenSession */
+    memset(&dsi->header, 0, sizeof(dsi->header));
+    dsi->header.dsi_flags = DSIFL_REQUEST;
+    dsi->header.dsi_command = DSIFUNC_OPEN;
+    dsi->header.dsi_requestID = htons(dsi_clientID(dsi));
+    dsi->header.dsi_code = 6;
+    dsi->cmdlen = 2 + sizeof(i);
+    dsi->commands[0] = DSIOPT_ATTNQUANT;
+    dsi->commands[1] = sizeof(i);
+    i = htonl(DSI_DEFQUANT);
+    memcpy(dsi->commands + 2, &i, sizeof(i));
+    dsi_send(dsi);
+    dsi_cmd_receive(dsi);
+
+    if (dsi->header.dsi_code) {
+        test_failed();
+        goto test_exit;
+    }
+
+    if (!Quiet) {
+        fprintf(stdout, "DSICloseSession\n");
+    }
+
+    if (DSICloseSession(Conn)) {
+        test_failed();
+        goto test_exit;
+    }
+
+test_exit:
+    CloseClientSocket(Dsi->socket);
+    exit_test("Logintest:dsi_open_session_ignore_param: DSIOpenSession non zero parameter should be ignored by the server");
+}
+
+/* Direct round-trip through the renamed dsi_stream_send / dsi_cmd_receive
+ * primitives. Sends an unknown AFP command (255) to an open but
+ * unauthenticated session; expect AFPERR_NOOP from the server's switch
+ * dispatcher. Catches regressions in the I/O layer. */
+void test_dsi_command_roundtrip(void)
+{
+    DSI *dsi;
+    ENTER_TEST
+    connect_server(Conn);
+    Dsi = &Conn->dsi;
+    dsi = Dsi;
+
+    if (DSIOpenSession(Conn)) {
+        test_failed();
+        goto test_exit;
+    }
+
+    memset(&dsi->header, 0, sizeof(dsi->header));
+    dsi->header.dsi_flags = DSIFL_REQUEST;
+    dsi->header.dsi_command = DSIFUNC_CMD;
+    dsi->header.dsi_requestID = htons(dsi_clientID(dsi));
+    dsi->commands[0] = 0xFF;            /* unknown AFP command */
+    dsi->commands[1] = 0;
+    dsi->cmdlen = 2;
+    dsi_send(dsi);
+    dsi_cmd_receive(dsi);
+
+    /* Any non-zero error code means the round trip worked. A zero result
+     * would mean the server accepted an unknown command, which would be a
+     * server bug, not a client one. */
+    if (dsi->header.dsi_code == 0) {
+        test_failed();
+        goto test_exit;
+    }
+
+    if (DSICloseSession(Conn)) {
+        test_failed();
+        goto test_exit;
+    }
+
+test_exit:
+    CloseClientSocket(Dsi->socket);
+    exit_test("Logintest:dsi_command_roundtrip: DSI round-trip via renamed dsi_stream_send/dsi_cmd_receive");
+}
+
+/* With Netatalk we define the default as 200 maximum connections,
+ * while with the AFP server on Mac OS X 10.7 Lion the default is 10.
+ * Therefore, test up to 201 to exercise either limit. */
+#define TEST_MAX_CONNS 201
+
+/* The AFP Reference defines kFPNoMoreSessions (-1068) for FPLogin/FPLoginExt
+ * when the server is at its session cap (Table 50: FPLoginExt result
+ * codes), but says nothing about a DSI-layer error code for this case.
+ * netatalk actually enforces the cap one layer down, in dsi_getsess.c,
+ * by sending DSIERR_SERVBUSY (0xFBD1) on the DSIOpenSession reply — so
+ * the client never reaches the FPLogin stage. This test accepts either
+ * code as "limit hit". */
+void test_connection_limit(void)
+{
+    static char *uam = "No User Authent";
+    CONN conn[TEST_MAX_CONNS];
+    int cnt = 0;
+    unsigned int ret = 0;
+    uint32_t code_host;
+    int hit_limit = 0;
+    ENTER_TEST
+
+    for (int i = 0; i < TEST_MAX_CONNS; i++) {
+        if (!Quiet) {
+            fprintf(stdout, "conn %d\n", i);
+        }
+
+        connect_server(&conn[i]);
+        Dsi = &conn[i].dsi;
+        cnt++;
+
+        if (Version >= 30) {
+            ret = FPopenLoginExt(&conn[i], vers, uam, "", "");
+        } else {
+            ret = FPopenLogin(&conn[i], vers, uam, "", "");
+        }
+
+        code_host = ntohl(ret);
+
+        if (code_host == (uint32_t) AFPERR_MAXSESS
+                || code_host == DSIERR_SERVBUSY) {
+            hit_limit = 1;
+            break;
+        }
+
+        if (ret) {
+            if (is_bad_uam(ret)) {
+                test_skipped(T_UAM);
+                goto cleanup;
+            }
+
+            if (!Quiet) {
+                fprintf(stdout,
+                        "Unexpected login error at conn %d: %d (%s)\n",
+                        i, code_host, afp_error(ret));
+            }
+
+            test_failed();
+            goto cleanup;
+        }
+    }
+
+    if (!hit_limit) {
+        if (!Quiet) {
+            fprintf(stdout,
+                    "All %d logins succeeded; server cap is > %d\n",
+                    cnt, cnt);
+        }
+
+        test_nottested();
+    }
+
+cleanup:
+    /* Send DSICloseSession on all connections that have an open DSI session,
+     * then close sockets. DSIERR_SERVBUSY means DSIOpenSession itself was
+     * rejected -- no DSI session was established, so skip DSICloseSession for
+     * that slot and just shut its socket. AFPERR_MAXSESS means DSIOpenSession
+     * succeeded but AFP rejected the login -- the DSI session IS open and must
+     * be properly closed, or the server keeps the slot occupied. Sleep after to
+     * let the server reap workers, otherwise the next test may fail with
+     * SERVBUSY waiting for a free fork slot. */
+    {
+        int failed_idx = (hit_limit && code_host == DSIERR_SERVBUSY) ? cnt - 1 : -1;
+
+        for (int j = 0; j < cnt; j++) {
+            if (j != failed_idx) {
+                DSICloseSession(&conn[j]);
+            }
+
+            CloseClientSocket(conn[j].dsi.socket);
+        }
+    }
+
+    if (cnt > 0) {
+        fflush(stdout);
+        sleep(3);
+    }
+
+    exit_test("Logintest:connection_limit: connection limit hit returns server-busy");
+}
+
+/* Raw AFP helper coverage. The libafpclient-backed UAM matrix also checks
+ * guest authentication, but through a different client stack; keep this test
+ * as a direct FPLogin/FPLoginExt smoke test, including AFP 2.x fallback. */
+void test_guest_login(void)
+{
+    static char *uam = "No User Authent";
+    int ret;
+    ENTER_TEST
+    connect_server(Conn);
+    Dsi = &Conn->dsi;
+
+    if (Version >= 30) {
+        ret = FPopenLoginExt(Conn, vers, uam, "", "");
+    } else {
+        ret = FPopenLogin(Conn, vers, uam, "", "");
+    }
+
+    if (ret) {
+        if (is_bad_uam(ret)) {
+            test_skipped(T_UAM);
+            goto test_exit;
+        }
+
+        test_failed();
+        goto test_exit;
+    }
+
+    if (Mac) {
+        fprintf(stdout, "DSIGetStatus\n");
+
+        if (DSIGetStatus(Conn)) {
+            test_failed();
+            goto test_exit;
+        }
+    }
+
+    if (FPLogOut(Conn)) {
+        test_failed();
+        goto test_exit;
+    }
+
+test_exit:
+    CloseClientSocket(Dsi->socket);
+    exit_test("Logintest:guest_login: Guest login");
+}
+
+/* Raw AFP helper coverage. The libafpclient-backed UAM matrix has broader
+ * cleartext UAM assertions; this test stays as a minimal direct login/logout
+ * check for the testsuite-local AFP packet helpers. */
+void test_cleartext_login(void)
+{
+    static char *uam = "Cleartxt Passwrd";
+    int ret;
+    ENTER_TEST
+    connect_server(Conn);
+    Dsi = &Conn->dsi;
+
+    if (!User || Password[0] == '\0') {
+        test_skipped(T_CRED);
+        goto test_exit;
+    }
+
+    if (Version >= 30) {
+        ret = FPopenLoginExt(Conn, vers, uam, User, Password);
+    } else {
+        ret = FPopenLogin(Conn, vers, uam, User, Password);
+    }
+
+    if (ret) {
+        if (is_bad_uam(ret)) {
+            test_skipped(T_UAM);
+            goto test_exit;
+        }
+
+        test_failed();
+        goto test_exit;
+    }
+
+    Conn->afp_version = Version;
+
+    if (FPLogOut(Conn)) {
+        test_failed();
+    }
+
+test_exit:
+    CloseClientSocket(Dsi->socket);
+    exit_test("Logintest:cleartext_login: Clear text login");
+}
+
+/* FPLoginExt + No User Authent via AFPopenLoginExt_pwd directly, bypassing
+ * the FPopenLoginExt wrapper. Validates the post-B1 wire format
+ * independently of the wrapper's version-branching. AFP >= 3.0 only. */
+void test_loginext_guest_direct(void)
+{
+    static const char *uam = "No User Authent";
+    unsigned int ret;
+    ENTER_TEST
+    connect_server(Conn);
+    Dsi = &Conn->dsi;
+
+    if (Version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
+    ret = AFPopenLoginExt_pwd(Conn, vers, uam, "", "");
+
+    if (ret) {
+        if (is_bad_uam(ret)) {
+            test_skipped(T_UAM);
+            goto test_exit;
+        }
+
+        test_failed();
+        goto test_exit;
+    }
+
+    if (FPLogOut(Conn)) {
+        test_failed();
+    }
+
+test_exit:
+    CloseClientSocket(Dsi->socket);
+    exit_test("Logintest:loginext_guest_direct: FPLoginExt + No User Authent (direct)");
+}
+
+/* Smoke test for AFPLoginCont primitive (Part B4). Drives DHCAST128 with
+ * an empty UserAuthInfo to provoke kFPAuthContinue, then sends garbage
+ * via AFPLoginCont to verify the wire format reaches the server's
+ * logincont entry point. Skipped if the server does not load DHCAST128
+ * (returns AFPERR_BADUAM) or doesn't return kFPAuthContinue. Does NOT
+ * authenticate -- this only exercises the round-trip plumbing. */
+void test_logincont_roundtrip(void)
+{
+    static const char *uam = "DHCAST128";
+    unsigned int ret;
+    uint8_t garbage[16];
+    ENTER_TEST
+    connect_server(Conn);
+    Dsi = &Conn->dsi;
+
+    if (Version < 30) {
+        test_skipped(T_AFP3);
+        goto test_exit;
+    }
+
+    if (!User) {
+        test_skipped(T_CRED);
+        goto test_exit;
+    }
+
+    ret = AFPopenLoginExt(Conn, vers, uam, User, NULL, 0);
+
+    if (ntohl(ret) != (uint32_t) AFPERR_AUTHCONT) {
+        if (is_bad_uam(ret)) {
+            test_skipped(T_UAM);
+            goto test_exit;
+        }
+
+        if (!Quiet) {
+            fprintf(stdout,
+                    "AFPopenLoginExt returned %d (%s), expected AFPERR_AUTHCONT\n",
+                    ntohl(ret), afp_error(ret));
+        }
+
+        test_nottested();
+        goto test_exit;
+    }
+
+    if (Conn->login_cont_len == 0) {
+        /* Got AUTHCONT but no payload captured -- that's a real bug. */
+        test_failed();
+        goto test_exit;
+    }
+
+    memset(garbage, 0xAA, sizeof(garbage));
+    ret = AFPLoginCont(Conn, garbage, sizeof(garbage));
+
+    /* Any non-zero result is acceptable: the server rejected our garbage
+     * response, which means AFPLoginCont reached the UAM. A zero result
+     * would mean we authenticated with random bytes, which is impossible
+     * unless something is very wrong. */
+    if (ret == 0) {
+        test_failed();
+    }
+
+test_exit:
+    CloseClientSocket(Dsi->socket);
+    exit_test("Logintest:logincont_roundtrip: AFPLoginCont primitive round-trip");
+}

--- a/test/testsuite/logintest_uam.c
+++ b/test/testsuite/logintest_uam.c
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <getopt.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include <afp.h>
+#include <uams_def.h>
+
+#include "testhelper.h"
+#include "logintest_uam.h"
+#include "uamtest_libafpclient.h"
+
+enum test_result {
+    RESULT_PASS,
+    RESULT_FAIL,
+    RESULT_NOTTESTED,
+    RESULT_SKIP,
+};
+
+const struct uamtest_entry uamtest_entries[] = {
+    { "guest",     "No User Authent",        false, false },
+    { "cleartext", "Cleartxt Passwrd",       true,  true  },
+    { "randnum",   "Randnum Exchange",       true,  true  },
+    { "randnum2",  "2-Way Randnum Exchange", true,  true  },
+    { "dhx",       "DHCAST128",              true,  true  },
+    { "dhx2",      "DHX2",                   true,  true  },
+    { "srp",       "SRP",                    true,  true  },
+    { NULL, NULL, false, false }
+};
+
+extern char *Password;
+extern int Port;
+
+static unsigned int advertised_uams;
+static bool advertised_known;
+
+static const char *result_text(enum test_result result)
+{
+    switch (result) {
+    case RESULT_PASS:
+        return Color ? ANSI_BGREEN "PASSED" ANSI_NORMAL : "PASSED";
+
+    case RESULT_FAIL:
+        return Color ? ANSI_BRED "FAILED" ANSI_NORMAL : "FAILED";
+
+    case RESULT_NOTTESTED:
+        return Color ? ANSI_BYELLOW "NOT TESTED" ANSI_NORMAL : "NOT TESTED";
+
+    case RESULT_SKIP:
+        return Color ? ANSI_BBLUE "SKIPPED" ANSI_NORMAL : "SKIPPED";
+    }
+
+    return "UNKNOWN";
+}
+
+static void remember_test_name(char tests[1024][256], int index,
+                               const struct uamtest_entry *entry)
+{
+    snprintf(tests[index], 256, "UAM %s (%s)", entry->selector, entry->uam);
+}
+
+static void record_result(const struct uamtest_entry *entry,
+                          enum test_result result, const char *reason)
+{
+    switch (result) {
+    case RESULT_PASS:
+        PassCount++;
+        break;
+
+    case RESULT_FAIL:
+        remember_test_name(FailedTests, FailCount, entry);
+        FailCount++;
+        ExitCode = 1;
+        break;
+
+    case RESULT_NOTTESTED:
+        remember_test_name(NotTestedTests, NotTestedCount, entry);
+        NotTestedCount++;
+
+        if (!ExitCode) {
+            ExitCode = 2;
+        }
+
+        break;
+
+    case RESULT_SKIP:
+        remember_test_name(SkippedTests, SkipCount, entry);
+        SkipCount++;
+        break;
+    }
+
+    fprintf(stdout, "UAM %s (%s) - %s", entry->selector, entry->uam,
+            result_text(result));
+
+    if (reason && *reason) {
+        fprintf(stdout, " (%s)", reason);
+    }
+
+    fprintf(stdout, "\n");
+}
+
+static bool entry_matches(const struct uamtest_entry *entry, const char *filter)
+{
+    return !filter || strcmp(filter, entry->selector) == 0
+           || strcmp(filter, entry->uam) == 0;
+}
+
+void uamtest_list_tests(void)
+{
+    for (const struct uamtest_entry *entry = uamtest_entries;
+            entry->selector; entry++) {
+        fprintf(stdout, "%-10s %s (libafpclient UAM)\n", entry->selector,
+                entry->uam);
+    }
+}
+
+static bool has_credentials(void)
+{
+    return User && *User && Password && *Password;
+}
+
+static void make_wrong_password(char *buf, size_t buflen)
+{
+    char replacement;
+
+    if (!Password || !*Password) {
+        snprintf(buf, buflen, "netatalk-wrong-password");
+        return;
+    }
+
+    snprintf(buf, buflen, "%s", Password);
+
+    if (buflen < 2) {
+        return;
+    }
+
+    /* Randnum, 2-Way Randnum, and classic cleartext only use the first
+     * eight password bytes. Mutate byte 0 so the negative test really is
+     * different for those UAMs too. Pick values that differ by more than
+     * DES parity/ignored-bit behavior. */
+    replacement = (buf[0] == 'X') ? 'q' : 'X';
+    buf[0] = replacement;
+
+    if (strcmp(buf, Password) == 0) {
+        snprintf(buf, buflen, "netatalk-wrong-password");
+    }
+}
+
+static enum test_result run_one(const struct uamtest_entry *entry,
+                                char *reason, size_t reason_len)
+{
+    struct uamtest_session *session = NULL;
+    struct uamtest_session *wrong_session = NULL;
+    const char *canonical;
+    unsigned int mask;
+    unsigned int using_uam;
+    char wrong_password[AFP_MAX_PASSWORD_LEN];
+    int using_version;
+    canonical = uamtest_libafpclient_resolve_uam(entry->uam);
+    mask = uamtest_libafpclient_uam_mask(entry->uam);
+
+    if (mask == 0) {
+        snprintf(reason, reason_len, "libafpclient does not know this UAM");
+        return RESULT_NOTTESTED;
+    }
+
+    if (advertised_known && (advertised_uams & mask) == 0) {
+        snprintf(reason, reason_len, "server did not advertise support");
+        return RESULT_SKIP;
+    }
+
+    if (entry->needs_credentials && !has_credentials()) {
+        snprintf(reason, reason_len, "username/password required");
+        return RESULT_SKIP;
+    }
+
+    if (!Quiet) {
+        fprintf(stdout, "Testing %s\n", canonical ? canonical : entry->uam);
+    }
+
+    if (uamtest_libafpclient_connect(&session, Server, Port, Version,
+                                     entry->uam,
+                                     entry->needs_credentials ? User : "",
+                                     entry->needs_credentials ? Password : "")
+            != 0) {
+        if (advertised_known && (advertised_uams & mask) != 0) {
+            snprintf(reason, reason_len, "advertised UAM failed to authenticate");
+            return RESULT_FAIL;
+        }
+
+        snprintf(reason, reason_len, "UAM not supported by protocol");
+        return RESULT_SKIP;
+    }
+
+    using_uam = uamtest_libafpclient_using_uam(session);
+
+    if ((using_uam & mask) == 0) {
+        uamtest_libafpclient_close(&session);
+        snprintf(reason, reason_len, "libafpclient selected a different UAM");
+        return RESULT_FAIL;
+    }
+
+    using_version = uamtest_libafpclient_using_version(session);
+
+    if (using_version != 0 && using_version > Version) {
+        uamtest_libafpclient_close(&session);
+        snprintf(reason, reason_len, "negotiated AFP%d above requested AFP%d",
+                 using_version, Version);
+        return RESULT_FAIL;
+    }
+
+    if (uamtest_libafpclient_smoke(session) != 0) {
+        uamtest_libafpclient_close(&session);
+        snprintf(reason, reason_len, "authenticated AFP smoke failed");
+        return RESULT_FAIL;
+    }
+
+    if (entry->check_wrong_password) {
+        make_wrong_password(wrong_password, sizeof(wrong_password));
+
+        if (uamtest_libafpclient_connect(&wrong_session, Server, Port,
+                                         Version, entry->uam, User,
+                                         wrong_password) == 0) {
+            uamtest_libafpclient_close(&wrong_session);
+            uamtest_libafpclient_close(&session);
+            snprintf(reason, reason_len, "wrong password authenticated");
+            return RESULT_FAIL;
+        }
+    }
+
+    uamtest_libafpclient_close(&session);
+    snprintf(reason, reason_len, "login, smoke, and failure checks passed");
+    return RESULT_PASS;
+}
+
+int uamtest_has_test(const char *filter)
+{
+    for (const struct uamtest_entry *entry = uamtest_entries;
+            entry->selector; entry++) {
+        if (entry_matches(entry, filter)) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+int uamtest_run_selected(const char *filter)
+{
+    bool matched = false;
+    advertised_uams = uamtest_libafpclient_discover_uams(Server, Port,
+                      Version, User ? User : "", Password ? Password : "",
+                      &advertised_known);
+
+    if (Verbose && advertised_known) {
+        char *uam_list = uam_bitmap_to_string(advertised_uams);
+        fprintf(stdout, "Advertised UAMs: %s\n", uam_list ? uam_list : "(none)");
+    } else if (Verbose) {
+        fprintf(stdout, "Advertised UAMs: unavailable before per-UAM login\n");
+    }
+
+    for (const struct uamtest_entry *entry = uamtest_entries;
+            entry->selector; entry++) {
+        char reason[256] = "";
+        enum test_result result;
+
+        if (!entry_matches(entry, filter)) {
+            continue;
+        }
+
+        matched = true;
+        result = run_one(entry, reason, sizeof(reason));
+        record_result(entry, result, reason);
+    }
+
+    if (!matched) {
+        fprintf(stderr, "Unknown UAM test: %s\n", filter);
+        return 1;
+    }
+
+    return ExitCode;
+}

--- a/test/testsuite/logintest_uam.h
+++ b/test/testsuite/logintest_uam.h
@@ -1,0 +1,19 @@
+#ifndef LOGINTEST_UAM_H
+#define LOGINTEST_UAM_H
+
+#include <stdbool.h>
+
+struct uamtest_entry {
+    const char *selector;
+    const char *uam;
+    bool needs_credentials;
+    bool check_wrong_password;
+};
+
+extern const struct uamtest_entry uamtest_entries[];
+
+void uamtest_list_tests(void);
+int uamtest_has_test(const char *filter);
+int uamtest_run_selected(const char *filter);
+
+#endif

--- a/test/testsuite/meson.build
+++ b/test/testsuite/meson.build
@@ -4,6 +4,12 @@ if threads.found()
     afptest_external_deps += threads
 endif
 
+enable_testsuite_uams = get_option('with-testsuite-uams')
+
+if enable_testsuite_uams
+    testsuite_libafpclient = dependency('libafpclient', required: false)
+endif
+
 libafptest_sources = [
     'adoublehelper.c',
     'afpclient.c',
@@ -81,12 +87,36 @@ executable(
 
 login_test_sources = [
     'logintest.c',
+    'logintest_dsi.c',
 ]
+
+login_test_deps = []
+login_test_c_args = []
+
+if enable_testsuite_uams
+    if testsuite_libafpclient.found()
+        login_test_sources += [
+            'logintest_uam.c',
+            'uamtest_libafpclient.c',
+        ]
+        login_test_deps += testsuite_libafpclient
+        if threads.found()
+            login_test_deps += threads
+        endif
+        login_test_c_args += ['-DHAVE_TESTSUITE_LIBAFPCLIENT=1']
+    else
+        warning(
+            'libafpclient-backed UAM tests requested but libafpclient was not found',
+        )
+    endif
+endif
 
 executable(
     'afp_logintest',
     login_test_sources,
     include_directories: root_includes,
+    dependencies: login_test_deps,
+    c_args: login_test_c_args,
     link_args: ['-rdynamic'],
     link_with: libafptest,
     install: true,

--- a/test/testsuite/testhelper.c
+++ b/test/testsuite/testhelper.c
@@ -138,6 +138,10 @@ void test_skipped(int why)
         s = "extmap.conf type/creator mapping";
         break;
 
+    case T_UAM:
+        s = "required UAM support on the AFP server";
+        break;
+
     default:
         s = "UNKNOWN REASON - this is a bug";
         break;

--- a/test/testsuite/testhelper.h
+++ b/test/testsuite/testhelper.h
@@ -68,6 +68,7 @@
 #define T_LOCALHOST  31
 #define T_V2CONV     32
 #define T_EXTMAP     33
+#define T_UAM        34
 
 /* Define ansi colors */
 #define ANSI_RED      "\033[0;31m"

--- a/test/testsuite/uamtest_libafpclient.c
+++ b/test/testsuite/uamtest_libafpclient.c
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2026 Daniel Markstedt <daniel@mindani.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "uamtest_libafpclient.h"
+
+#include <pthread.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <afp.h>
+#include <libafpclient.h>
+#include <uams_def.h>
+
+#include "testhelper.h"
+
+struct uamtest_session {
+    struct afp_server *server;
+};
+
+static pthread_mutex_t init_lock = PTHREAD_MUTEX_INITIALIZER;
+static int initialized;
+static pthread_t loop_thread;
+
+static void uamtest_libafpclient_log(void *priv, enum logtypes logtype,
+                                     int loglevel, const char *message)
+{
+    (void)priv;
+    (void)logtype;
+
+    if (Quiet) {
+        return;
+    }
+
+    if (!Verbose && loglevel > LOG_INFO) {
+        return;
+    }
+
+    fprintf(stdout, "%s\n", message ? message : "(null)");
+}
+
+static struct libafpclient uamtest_libafpclient = {
+    .unmount_volume = NULL,
+    .log_for_client = uamtest_libafpclient_log,
+    .forced_ending_hook = NULL,
+    .scan_extra_fds = NULL,
+    .loop_started = NULL,
+};
+
+static void fill_request(struct afp_connection_request *req,
+                         const char *host, int port, int afp_version,
+                         const char *user, const char *password,
+                         unsigned int uam_mask)
+{
+    memset(req, 0, sizeof(*req));
+    afp_default_url(&req->url);
+    snprintf(req->url.servername, sizeof(req->url.servername), "%s", host);
+    snprintf(req->url.username, sizeof(req->url.username), "%s", user ? user : "");
+    snprintf(req->url.password, sizeof(req->url.password), "%s",
+             password ? password : "");
+    req->url.port = port;
+    req->url.requested_version = afp_version;
+    req->uam_mask = uam_mask;
+}
+
+int uamtest_libafpclient_init(void)
+{
+    pthread_mutex_lock(&init_lock);
+
+    if (!initialized) {
+        libafpclient_register(&uamtest_libafpclient);
+        init_uams();
+        afp_main_quick_startup(&loop_thread);
+        initialized = 1;
+    }
+
+    pthread_mutex_unlock(&init_lock);
+    return 0;
+}
+
+unsigned int uamtest_libafpclient_uam_mask(const char *uam)
+{
+    if (!uam || !*uam) {
+        return 0;
+    }
+
+    return find_uam_by_name(uam);
+}
+
+const char *uamtest_libafpclient_resolve_uam(const char *uam)
+{
+    if (!uam || !*uam) {
+        return NULL;
+    }
+
+    return resolve_uam_shorthand(uam);
+}
+
+unsigned int uamtest_libafpclient_discover_uams(const char *host, int port,
+        int afp_version,
+        const char *user,
+        const char *password,
+        bool *known)
+{
+    struct afp_connection_request req;
+    struct afp_server *server;
+    unsigned int supported = 0;
+
+    if (known) {
+        *known = false;
+    }
+
+    (void)user;
+    (void)password;
+
+    if (uamtest_libafpclient_init() != 0) {
+        return 0;
+    }
+
+    /* Discovery only needs the server's advertised UAM bitmap.  Use guest auth
+     * so this probe does not silently exercise an encrypted UAM before the
+     * per-UAM tests can report which selector is running. */
+    fill_request(&req, host, port, afp_version, "", "", UAM_NOUSERAUTHENT);
+    server = afp_server_full_connect(NULL, &req);
+
+    if (!server) {
+        return 0;
+    }
+
+    supported = server->supported_uams;
+
+    if (known) {
+        *known = true;
+    }
+
+    afp_logout(server, 1);
+    afp_server_remove(server);
+    return supported;
+}
+
+int uamtest_libafpclient_connect(struct uamtest_session **session,
+                                 const char *host, int port,
+                                 int afp_version, const char *uam,
+                                 const char *user, const char *password)
+{
+    struct afp_connection_request req;
+    struct afp_server *server;
+    unsigned int uam_mask;
+
+    if (!session || !host || !uam) {
+        return -1;
+    }
+
+    *session = NULL;
+
+    if (uamtest_libafpclient_init() != 0) {
+        return -1;
+    }
+
+    uam_mask = find_uam_by_name(uam);
+
+    if (uam_mask == 0) {
+        return -1;
+    }
+
+    fill_request(&req, host, port, afp_version, user, password, uam_mask);
+    server = afp_server_full_connect(NULL, &req);
+
+    if (!server) {
+        return -1;
+    }
+
+    *session = calloc(1, sizeof(**session));
+
+    if (!*session) {
+        afp_logout(server, 1);
+        afp_server_remove(server);
+        return -1;
+    }
+
+    (*session)->server = server;
+    return 0;
+}
+
+unsigned int uamtest_libafpclient_supported_uams(
+    const struct uamtest_session *session)
+{
+    if (!session || !session->server) {
+        return 0;
+    }
+
+    return session->server->supported_uams;
+}
+
+unsigned int uamtest_libafpclient_using_uam(
+    const struct uamtest_session *session)
+{
+    if (!session || !session->server) {
+        return 0;
+    }
+
+    return session->server->using_uam;
+}
+
+int uamtest_libafpclient_using_version(
+    const struct uamtest_session *session)
+{
+    if (!session || !session->server || !session->server->using_version) {
+        return 0;
+    }
+
+    return session->server->using_version->av_number;
+}
+
+int uamtest_libafpclient_smoke(struct uamtest_session *session)
+{
+    if (!session || !session->server) {
+        return -1;
+    }
+
+    return afp_getsrvrparms(session->server);
+}
+
+void uamtest_libafpclient_close(struct uamtest_session **session)
+{
+    if (!session || !*session) {
+        return;
+    }
+
+    if ((*session)->server) {
+        afp_logout((*session)->server, 1);
+        afp_server_remove((*session)->server);
+    }
+
+    free(*session);
+    *session = NULL;
+}

--- a/test/testsuite/uamtest_libafpclient.h
+++ b/test/testsuite/uamtest_libafpclient.h
@@ -1,0 +1,29 @@
+#ifndef UAMTEST_LIBAFPCLIENT_H
+#define UAMTEST_LIBAFPCLIENT_H
+
+#include <stdbool.h>
+
+struct uamtest_session;
+
+int uamtest_libafpclient_init(void);
+unsigned int uamtest_libafpclient_uam_mask(const char *uam);
+const char *uamtest_libafpclient_resolve_uam(const char *uam);
+unsigned int uamtest_libafpclient_discover_uams(const char *host, int port,
+        int afp_version,
+        const char *user,
+        const char *password,
+        bool *known);
+int uamtest_libafpclient_connect(struct uamtest_session **session,
+                                 const char *host, int port,
+                                 int afp_version, const char *uam,
+                                 const char *user, const char *password);
+unsigned int uamtest_libafpclient_supported_uams(
+    const struct uamtest_session *session);
+unsigned int uamtest_libafpclient_using_uam(
+    const struct uamtest_session *session);
+int uamtest_libafpclient_using_version(
+    const struct uamtest_session *session);
+int uamtest_libafpclient_smoke(struct uamtest_session *session);
+void uamtest_libafpclient_close(struct uamtest_session **session);
+
+#endif


### PR DESCRIPTION
leverage Netatalk Client's libafpclient shared library to build a test suite covering basic success and failure cases of each password based UAM

afp_logintest now runs a matrix that checks each UAM against libafpclient. For each selected libafpclient UAM, the test checks whether the UAM is known to libafpclient, whether the server advertises it when that can be discovered,
whether login succeeds with the supplied credentials, whether login fails with an intentionally wrong password for credentialed UAMs, and whether a tiny authenticated AFP smoke request succeeds after login.

the legacy tests in afp_logintest have been refactored, cleaned up, and renamed for this context; when libafpclient is not available, only the legacy tests will be built

expand the logintest jobs in the CI workflow to cover all supported AFP versions with appropriate UAMs for that version; however, removing the AFP 2.1 job because Netatalk does not in fact advertise AFP 2.1 support, which libafpclient checks for and throws an error for the mismatch

consistently use the 'ADD' containerfile keyword instead of curl