### PR TITLE
nad: avoid empty StuffIt resource sidecars

### DIFF
--- a/bin/nad/megatron.h
+++ b/bin/nad/megatron.h
@@ -33,6 +33,7 @@ struct vol;
 #define OPTION_STDOUT     (1 << 1)
 #define OPTION_VERBOSE    (1 << 2)
 #define OPTION_ADOUBLE    (1 << 3)
+#define OPTION_NORF       (1 << 4)
 
 #define FH_DATE_CREATE    (1 << 0)
 #define FH_DATE_MODIFY    (1 << 1)

--- a/bin/nad/nad_adouble.c
+++ b/bin/nad/nad_adouble.c
@@ -309,7 +309,11 @@ int nad_open(char *path, int openflags, struct FHeader *fh, int options _U_)
         return rc;
     } else {
         ad_init(&nad.ad, nad.vol);
-        nad.closeflags = ADFLAGS_DF | ADFLAGS_HF | ADFLAGS_RF;
+        nad.closeflags = ADFLAGS_DF | ADFLAGS_HF;
+
+        if (!(options & OPTION_NORF)) {
+            nad.closeflags |= ADFLAGS_RF;
+        }
 
         if (strlcpy(nad.macname, fh->name, sizeof(nad.macname))
                 >= sizeof(nad.macname)

--- a/bin/nad/nad_stuffit.c
+++ b/bin/nad/nad_stuffit.c
@@ -232,6 +232,33 @@ static int fill_header_from_entry(const StuffitEntryInfo *info,
     return 0;
 }
 
+static int validate_entry_fork_lengths(const StuffitEntryInfo *info,
+                                       const StuffitBytes *data,
+                                       const StuffitBytes *rsrc)
+{
+    if (info->data_len != data->len) {
+        fprintf(stderr,
+                "%s: data fork length mismatch: metadata says %zu, decoded fork is %zu\n",
+                info->name, info->data_len, data->len);
+        return -1;
+    }
+
+    if (info->resource_len != rsrc->len) {
+        fprintf(stderr,
+                "%s: resource fork length mismatch: metadata says %zu, decoded fork is %zu\n",
+                info->name, info->resource_len, rsrc->len);
+        return -1;
+    }
+
+    if (info->data_len > UINT32_MAX || info->resource_len > UINT32_MAX) {
+        fprintf(stderr, "%s: fork length exceeds AppleDouble header limit\n",
+                info->name);
+        return -1;
+    }
+
+    return 0;
+}
+
 static int write_fork_bytes(int fork, const uint8_t *ptr, size_t len)
 {
     size_t written = 0;
@@ -262,6 +289,7 @@ static int extract_file_entry(const StuffitEntryInfo *info,
     char base[ADEDLEN_NAME + 1];
     int cwd = -1;
     int opened = 0;
+    int options;
     int rc = -1;
 
     if (make_parent_dirs(info->name) < 0
@@ -288,14 +316,17 @@ static int extract_file_entry(const StuffitEntryInfo *info,
         goto done;
     }
 
-    if (nad_open(base, O_RDWR | O_CREAT | O_EXCL, &fh, OPTION_NONE) < 0) {
+    options = (rsrc->len == 0) ? OPTION_NORF : OPTION_NONE;
+
+    if (nad_open(base, O_RDWR | O_CREAT | O_EXCL, &fh, options) < 0) {
         goto done;
     }
 
     opened = 1;
 
     if (write_fork_bytes(DATA, data->ptr, data->len) < 0
-            || write_fork_bytes(RESOURCE, rsrc->ptr, rsrc->len) < 0) {
+            || (rsrc->len > 0
+                && write_fork_bytes(RESOURCE, rsrc->ptr, rsrc->len) < 0)) {
         goto done;
     }
 
@@ -361,6 +392,11 @@ static int unsit_archive(const char *path, AFPObj *obj)
 
         if (!entry_name_is_safe(info.name)) {
             fprintf(stderr, "%s: unsafe StuffIt entry name: %s\n", path, info.name);
+            rv = -1;
+            break;
+        }
+
+        if (validate_entry_fork_lengths(&info, &data, &rsrc) < 0) {
             rv = -1;
             break;
         }


### PR DESCRIPTION
When unsit extracts an entry with no resource-fork data, do not open the resource fork in the AppleDouble backend and skip the resource-fork write. Opening the RF path is enough for the EA backend to flush an AppleDouble sidecar containing only header/FinderInfo bytes, which creates unwanted ._ files for ordinary data-only files.

Add an internal OPTION_NORF mode so StuffIt extraction can preserve data and metadata without creating zero-length resource fork storage.