### PR TITLE
afpd: fix ad_lock.c release-path over-release, strands, and share-mode defects

### DIFF
--- a/doc/manpages/man5/afp.conf.5.md
+++ b/doc/manpages/man5/afp.conf.5.md
@@ -396,9 +396,15 @@ option.
 
 afp read locks = *BOOLEAN* (default: *no*) **(G)**
 
-> Whether to apply locks to the byte region read in FPRead calls. The AFP
-spec mandates this, but it's not really in line with UNIX semantics and
-is a performance hog.
+> Enforces byte-range locks on reads and writes. Required when the same
+share is accessed through another protocol such as SMB/Samba. Can be *no* for a
+small performance gain otherwise.
+>
+> With it off, an app that locks part of a file is not protected from another
+app reading or writing that same part at the same time, which can lead to
+corrupted files or stale reads for apps that rely on locking (for example
+databases or shared documents). Whole-file protections — open/deny modes and
+delete/rename safety — still work either way.
 
 disconnect time = *number* **(G)**
 

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -272,6 +272,16 @@ static int sum_neg(int is64, off_t offset, off_t reqcount)
     return 0;
 }
 
+/* f_deny reservation bits for an FPOpenFork access mode.  Each deny bit is set
+ * independently and ORed; the parenthesised ternaries stop `|` from swallowing the
+ * left side as a condition.  Parameterised on the constants so
+ * utest_fork_setmode_fdeny can exercise it without <sys/fcntl.h> / fshare_t. */
+int fork_setmode_deny(int access, int f_rddny, int f_wrdny, int f_nodny)
+{
+    return (access & OPENACC_DRD ? f_rddny : f_nodny)
+           | (access & OPENACC_DWR ? f_wrdny : f_nodny);
+}
+
 static int fork_setmode(const AFPObj *obj _U_, struct adouble *adp, int eid,
                         int access, int ofrefnum)
 {
@@ -386,8 +396,7 @@ static int fork_setmode(const AFPObj *obj _U_, struct adouble *adp, int eid,
             shmd.f_access = F_RDACC;
         }
 
-        shmd.f_deny = (access & OPENACC_DRD ? F_RDDNY : F_NODNY) |
-                      (access & OPENACC_DWR) ? F_WRDNY : 0;
+        shmd.f_deny = fork_setmode_deny(access, F_RDDNY, F_WRDNY, F_NODNY);
         shmd.f_id = ofrefnum;
         int fd = (eid == ADEID_DFORK) ? ad_data_fileno(adp) : ad_reso_fileno(adp);
 

--- a/etc/afpd/fork.h
+++ b/etc/afpd/fork.h
@@ -87,6 +87,8 @@ extern int of_get_locks(const struct vol *vol, int dirfd, struct path *path,
 
 /* in fork.c */
 extern int          flushfork(struct ofork *);
+extern int          fork_setmode_deny(int access, int f_rddny, int f_wrdny,
+                                      int f_nodny);
 
 /* FP functions */
 int afp_openfork(AFPObj *obj, char *ibuf, size_t ibuflen, char *rbuf,

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -839,8 +839,7 @@ int of_closefork(const AFPObj *obj, struct ofork *ofork)
     }
 
 #endif /* WITH_FCE */
-    ad_unlock(ofork->of_ad, ofork->of_refnum,
-              ofork->of_flags & AFPFORK_ERROR ? 0 : 1);
+    ad_unlock(ofork->of_ad, ofork->of_refnum);
 #ifdef HAVE_FSHARE_T
 
     if (obj->options.flags & OPTION_SHARE_RESERV) {

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -160,10 +160,16 @@ struct ad_entry {
     ssize_t   ade_len;
 };
 
+typedef struct adf_lock_shared {
+    int   count;
+    off_t start;
+    off_t end;
+} adf_lock_shared_t;
+
 typedef struct adf_lock_t {
     struct flock lock;
     int user;
-    int *refcount; /*!< handle read locks with multiple users */
+    adf_lock_shared_t *refcount;
 } adf_lock_t;
 
 struct ad_fd {
@@ -427,7 +433,7 @@ extern int ad_testlock_whole(struct adouble *adp, int eid);
 extern uint16_t ad_openforks(struct adouble *adp, uint16_t);
 extern int ad_lock(struct adouble *, uint32_t eid, int type, off_t off,
                    off_t len, int fork);
-extern void ad_unlock(struct adouble *, int fork, int unlckbrl);
+extern void ad_unlock(struct adouble *, int fork);
 extern void adf_lock_init(struct ad_fd *adf);
 extern void adf_lock_free(struct ad_fd *adf);
 extern int ad_tmplock(struct adouble *, uint32_t eid, int type, off_t off,

--- a/libatalk/adouble/ad_lock.c
+++ b/libatalk/adouble/ad_lock.c
@@ -122,15 +122,44 @@ static int OVERLAP(off_t a, off_t alen, off_t b, off_t blen)
 #define ARRAY_BLOCK_SIZE 10
 #define ARRAY_FREE_DELTA 100
 
+/* adf_freelock() re-asserts surviving locks after a data-zone union unlock;
+ * adf_relockrange() is defined below, so forward-declare it here. */
+static void adf_relockrange(struct ad_fd *ad, int fd, off_t off, off_t len);
+
 /*! remove a lock and compact space if necessary */
 static void adf_freelock(struct ad_fd *ad, const int i)
 {
     adf_lock_t *lock = ad->adf_lock + i;
+    int    last_free = 0;
+    int    do_relock = 0;
+    off_t  ul_start = 0, ul_len = 0;
 
-    if (--(*lock->refcount) < 1) {
+    if (--(lock->refcount->count) < 1) {
+        last_free = 1;
+        struct flock ul = lock->lock;   /* own range; inherits l_whence=SEEK_SET */
+        ul.l_type = F_UNLCK;
+
+        /* Data-zone group: release the coalesced union the kernel formed and
+         * re-assert survivors after compaction.  Band entry: no union (single
+         * fixed offset, never coalesced) - release its own range and skip the
+         * relock. */
+        if (lock->lock.l_start < AD_FILELOCK_BASE) {
+            ul_start   = lock->refcount->start;
+            ul_len     = lock->refcount->end - lock->refcount->start;
+            ul.l_start = ul_start;
+            ul.l_len   = ul_len;
+            do_relock  = 1;
+        }
+
         free(lock->refcount);
-        lock->lock.l_type = F_UNLCK;
-        set_lock(ad->adf_fd, F_SETLK, &lock->lock); /* unlock */
+
+        if (set_lock(ad->adf_fd, F_SETLK, &ul) < 0) {
+            LOG(log_error, logtype_ad,
+                "adf_freelock: F_UNLCK fd=%d off=%jd len=%jd: %s - kernel lock "
+                "may be stranded until this process's last close of the file",
+                ad->adf_fd, (intmax_t)ul.l_start, (intmax_t)ul.l_len,
+                strerror(errno));
+        }
     }
 
     ad->adf_lockcount--;
@@ -155,32 +184,32 @@ static void adf_freelock(struct ad_fd *ad, const int i)
             ad->adf_lockmax = ad->adf_lockcount + ARRAY_FREE_DELTA;
         }
     }
+
+    /* re-assert data-zone survivors AFTER compaction removed the dying entry */
+    if (last_free && do_relock) {
+        adf_relockrange(ad, ad->adf_fd, ul_start, ul_len);
+    }
 }
 
 
-/* this needs to deal with the following cases:
- * 1) free all UNIX byterange lock from any fork
- * 2) free all locks of the requested fork
+/* AFP spec: "All locks held by a user are unlocked when the user closes the
+ * fork", where a "user" is one OForkRefNum (== fork == lock[i].user).  Release
+ * only THIS fork's locks; a sibling fork on the same shared ad_fd keeps its own.
  *
  * i converted to using arrays of locks. everytime a lock
  * gets removed, we shift all of the locks down.
  */
 static void adf_unlock(struct adouble *ad _U_, struct ad_fd *adf,
-                       const int fork, int unlckbrl)
+                       const int fork)
 {
     adf_lock_t *lock = adf->adf_lock;
     int i;
 
     for (i = 0; i < adf->adf_lockcount; i++) {
-        if ((unlckbrl && lock[i].lock.l_start < AD_FILELOCK_BASE)
-                || lock[i].user == fork) {
-            /* we're really going to delete this lock. note: read locks
-               are the only ones that allow refcounts > 1 */
+        if (lock[i].user == fork) {
             adf_freelock(adf, i);
-            /* we shifted things down, so we need to backtrack */
-            i--;
-            /* unlikely but realloc may have change adf_lock */
-            lock = adf->adf_lock;
+            i--;                       /* compaction shifted the tail down */
+            lock = adf->adf_lock;      /* realloc may have moved the array */
         }
     }
 }
@@ -244,7 +273,7 @@ void adf_lock_free(struct ad_fd *adf)
         }
 
         /* Only free refcount memory when last reference */
-        if (--(*lock->refcount) < 1) {
+        if (--(lock->refcount->count) < 1) {
             free(lock->refcount);
         }
     }
@@ -512,6 +541,17 @@ int ad_lock(struct adouble *ad, uint32_t eid, int locktype, off_t off,
     /* byte_lock(len=-1) lock whole file */
     if (len == BYTELOCK_MAX) {
         lock.l_len -= lock.l_start; /* otherwise  EOVERFLOW error */
+
+        if (lock.l_len <= 0) {
+            /* Whole-file lock at/after the last lockable offset: nothing to lock,
+             * and the data-zone union bookkeeping (l_start + l_len) needs
+             * l_len > 0.  l_start already includes the rfork entry offset, so one
+             * check covers both forks.  EINVAL -> byte_lock() returns
+             * AFPERR_RANGEOVR. */
+            errno = EINVAL;
+            ret = -1;               /* no lock placed: exit skips the F_UNLCK */
+            goto exit;
+        }
     }
 
     /* see if it's locked by another fork.
@@ -562,6 +602,9 @@ int ad_lock(struct adouble *ad, uint32_t eid, int locktype, off_t off,
 
     /* we upgraded this lock. */
     if (adflock && (type & ADLOCK_UPGRADE)) {
+        /* If ADLOCK_UPGRADE ever gets a caller: a widening RD upgrade on a
+         * shared entry must also extend refcount->start/end like the create/join
+         * path below, or the group union under-records and re-strands. */
         memcpy(&adflock->lock, &lock, sizeof(lock));
         goto exit;
     }
@@ -594,13 +637,36 @@ int ad_lock(struct adouble *ad, uint32_t eid, int locktype, off_t off,
     adflock->user = fork;
 
     if (oldlock > -1) {
+        /* join an existing overlapping-read group: adopt its shared struct. */
         adflock->refcount = (adf->adf_lock + oldlock)->refcount;
-    } else if ((adflock->refcount = calloc(1, sizeof(int))) == NULL) {
-        ret = fcntl_lock_err = 1;
+
+        /* Widen the coalesced union; data-zone entries only (band entries are
+         * single fixed offsets that never coalesce). */
+        if (lock.l_start < AD_FILELOCK_BASE) {
+            off_t this_end = lock.l_start + lock.l_len;
+
+            if (lock.l_start < adflock->refcount->start) {
+                adflock->refcount->start = lock.l_start;
+            }
+
+            if (this_end > adflock->refcount->end) {
+                adflock->refcount->end = this_end;
+            }
+        }
+    } else if ((adflock->refcount = calloc(1, sizeof(adf_lock_shared_t))) == NULL) {
+        ret = -1;                   /* callers test `< 0`; +1 read as success */
+        fcntl_lock_err = 1;         /* still trigger the kernel-lock rollback */
         goto exit;
+    } else {
+        /* new group: union = this entry's own range, DATA-ZONE entries only.
+         * calloc leaves start/end 0 for band entries, which never read them. */
+        if (lock.l_start < AD_FILELOCK_BASE) {
+            adflock->refcount->start = lock.l_start;
+            adflock->refcount->end   = lock.l_start + lock.l_len;
+        }
     }
 
-    (*adflock->refcount)++;
+    adflock->refcount->count++;
     adf->adf_lockcount++;
 exit:
 
@@ -641,7 +707,7 @@ int ad_tmplock(struct adouble *ad, uint32_t eid, int locktype, off_t off,
     if (eid == ADEID_DFORK) {
         adf = &ad->ad_data_fork;
     } else {
-        adf = &ad->ad_resource_fork;
+        adf = ad->ad_rfp;                  /* match ad_lock(): backend indirection */
 
         if (adf->adf_fd == -1) {
             /* there's no resource fork. return success */
@@ -695,16 +761,16 @@ exit:
 }
 
 /* --------------------- */
-void ad_unlock(struct adouble *ad, const int fork, int unlckbrl)
+void ad_unlock(struct adouble *ad, const int fork)
 {
-    LOG(log_debug, logtype_ad, "ad_unlock(unlckbrl: %d): BEGIN", unlckbrl);
+    LOG(log_debug, logtype_ad, "ad_unlock(fork: %d): BEGIN", fork);
 
     if (ad_data_fileno(ad) != -1) {
-        adf_unlock(ad, &ad->ad_data_fork, fork, unlckbrl);
+        adf_unlock(ad, &ad->ad_data_fork, fork);
     }
 
     if (ad_reso_fileno(ad) != -1) {
-        adf_unlock(ad, &ad->ad_resource_fork, fork, unlckbrl);
+        adf_unlock(ad, ad->ad_rfp, fork);   /* rfork indirection, matching ad_lock() */
     }
 
     LOG(log_debug, logtype_ad, "ad_unlock: END");

--- a/test/afpd/subtests_lock.c
+++ b/test/afpd/subtests_lock.c
@@ -865,7 +865,7 @@ int utest_testlock_range_no_self_report(const struct vol *vol)
 
     range_ret = ad_testlock_range(&ad, ADEID_DFORK, AD_FILELOCK_OPEN_RD, 1);
     scan_ret  = ad_testlock(&ad, ADEID_DFORK, AD_FILELOCK_OPEN_RD);
-    ad_unlock(&ad, 0, 1);
+    ad_unlock(&ad, 0);
     ad_close(&ad, ADFLAGS_DF);
     (void)unlink(path);
 
@@ -1220,7 +1220,7 @@ int utest_deletefile_quirk(struct vol *vol)
     held_before = peer_try_lock(full, F_WRLCK, 0, 100);
 
     if (held_before != 0) {
-        ad_unlock(of->of_ad, ofrefnum, 1);
+        ad_unlock(of->of_ad, ofrefnum);
         ad_close(of->of_ad, ADFLAGS_DF);
         of_dealloc(of);
         (void)unlink(full);
@@ -1235,7 +1235,7 @@ int utest_deletefile_quirk(struct vol *vol)
     /* a peer must STILL see the lock after the GET: if the GET had opened and
      * closed a transient fd to the inode, our process's lock would be gone */
     held_after = peer_try_lock(full, F_WRLCK, 0, 100);
-    ad_unlock(of->of_ad, ofrefnum, 1);
+    ad_unlock(of->of_ad, ofrefnum);
     ad_close(of->of_ad, ADFLAGS_DF);
     of_dealloc(of);
     (void)unlink(full);
@@ -1432,4 +1432,215 @@ int utest_deletefile_nodelete(const struct vol *vol)
     }
 
     return 0;
+}
+
+/*!
+ * @brief Two same-range read locks from two fork owners share one refcount; the
+ * kernel lock survives the first release and drops only on the last.
+ */
+int utest_shared_rlock(const struct vol *vol)
+{
+    struct adouble ad;
+    char path[MAXPATHLEN + 1];
+    int  rc = 0;
+    snprintf(path, sizeof(path), "%s/fi_shared_rlock", vol->v_path);
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR | ADFLAGS_CREATE,
+                0666) != 0) {
+        (void)unlink(path);
+        return 1;                        /* setup open failed */
+    }
+
+    /* Two read locks, same range [0,100), distinct fork owners 1 and 2:
+     * adf_findxlock matches the overlap and they share one refcount group. */
+    if (ad_lock(&ad, ADEID_DFORK, ADLOCK_RD, 0, 100, 1) < 0
+            || ad_lock(&ad, ADEID_DFORK, ADLOCK_RD, 0, 100, 2) < 0) {
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 2;                        /* setup lock failed */
+    }
+
+    /* Release owner 1: group count 2->1, kernel lock must REMAIN. */
+    ad_unlock(&ad, 1);
+
+    if (peer_try_lock(path, F_WRLCK, 0, 100) != 0) {
+        rc = 3;                          /* expected 0 == still held */
+    }
+
+    /* Release owner 2: group count 1->0, kernel lock must be GONE. */
+    ad_unlock(&ad, 2);
+
+    if (!rc && peer_try_lock(path, F_WRLCK, 0, 100) != 1) {
+        rc = 4;                          /* expected 1 == range now free */
+    }
+
+    ad_close(&ad, ADFLAGS_DF);
+    (void)unlink(path);
+    return rc;                           /* 0 == pass */
+}
+
+/*!
+ * @brief Overlapping read locks from two fork owners coalesce in the kernel; the
+ * union unlock must release the whole coalesced range, leaving no stranded
+ * remainder.
+ */
+int utest_overlap_strand(const struct vol *vol)
+{
+    struct adouble ad;
+    char path[MAXPATHLEN + 1];
+    int  rc = 0;
+    snprintf(path, sizeof(path), "%s/fi_overlap_strand", vol->v_path);
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR | ADFLAGS_CREATE,
+                0666) != 0) {
+        (void)unlink(path);
+        return 1;                        /* setup open failed */
+    }
+
+    if (ad_lock(&ad, ADEID_DFORK, ADLOCK_RD, 0, 100, 1) < 0
+            || ad_lock(&ad, ADEID_DFORK, ADLOCK_RD, 50, 100, 2) < 0) {
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 2;                        /* setup lock failed ([50,150)) */
+    }
+
+    /* Positive control: release owner 1 only; owner 2's [50,150) must survive. */
+    ad_unlock(&ad, 1);
+
+    if (peer_try_lock(path, F_WRLCK, 50, 100) != 0) {
+        rc = 3;                          /* expected 0 == [50,150) still held */
+    }
+
+    /* Release owner 2 (last): the whole coalesced [0,150) must be gone - no
+     * stranded [0,50) remainder. */
+    ad_unlock(&ad, 2);
+
+    if (!rc && peer_try_lock(path, F_WRLCK, 0, 150) != 1) {
+        rc = 4;                          /* expected 1 == all of [0,150) free */
+    }
+
+    ad_close(&ad, ADFLAGS_DF);
+    (void)unlink(path);
+    return rc;                           /* 0 == pass */
+}
+
+/*!
+ * @brief A failed refcount-0 F_UNLCK in adf_freelock() is logged and the entry
+ * still dropped (log-drop-continue), not silently swallowed.
+ */
+int utest_freelock_unlck_fail_logs(const struct vol *vol)
+{
+    struct adouble ad;
+    char path[MAXPATHLEN + 1];
+    char logf[MAXPATHLEN + 1];
+    int  rc = 0;
+    FILE *lf;
+    char buf[4096];
+    int  found = 0;
+
+    if (!test_capability(TEST_CAP_FAULT_INJECT, vol)) {
+        return TEST_SKIP;
+    }
+
+    snprintf(path, sizeof(path), "%s/fi_unlck_fail", vol->v_path);
+    snprintf(logf, sizeof(logf), "%s/fi_unlck_fail.log", vol->v_path);
+    fault_inject_reset();
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, path, ADFLAGS_DF | ADFLAGS_RDWR | ADFLAGS_CREATE,
+                0666) != 0) {
+        (void)unlink(path);
+        return 1;                        /* setup open failed */
+    }
+
+    /* Place a data-zone read lock (fork owner id 1). */
+    if (ad_lock(&ad, ADEID_DFORK, ADLOCK_RD, 0, 100, 1) < 0) {
+        ad_close(&ad, ADFLAGS_DF);
+        (void)unlink(path);
+        return 2;                        /* setup lock failed */
+    }
+
+    /* Route logs to a temp file so the log_error is observable. */
+    setuplog("default:error", logf, true);
+    /* Arm the NEXT fcntl (the ADLOCK_CLR path issues no fcntl before the F_UNLCK,
+     * so the armed failure lands exactly on adf_freelock's unlock). */
+    fi.fcntl_armed = 1;
+    fi.fcntl_fail_after = 0;             /* fail the very next fcntl, once */
+    fi.fcntl_errno = ENOLCK;
+    fi.fcntl_watch = 1;
+    ad_unlock(&ad, 1);
+    fi.fcntl_armed = 0;
+    fi.fcntl_watch = 0;
+
+    /* (a) the release attempted the F_UNLCK ... */
+    if (fi.lock_last_type != F_UNLCK) {
+        rc = 3;
+    }
+
+    /* (b) ... and dropped the array entry anyway (log-drop-continue). */
+    if (ad.ad_data_fork.adf_lockcount != 0) {
+        rc = rc ? rc : 4;
+    }
+
+    /* (c) the kernel lock stranded: a peer still conflicts on [0,100). */
+    if (peer_try_lock(path, F_WRLCK, 0, 100) != 0) {
+        rc = rc ? rc : 5;               /* expected 0 == conflict (held) */
+    }
+
+    /* (d) the failure was logged, not silent. */
+    lf = fopen(logf, "r");
+
+    if (lf) {
+        while (fgets(buf, sizeof(buf), lf)) {
+            if (strstr(buf, "adf_freelock") && strstr(buf, "F_UNLCK")) {
+                found = 1;
+                break;
+            }
+        }
+
+        fclose(lf);
+    }
+
+    if (!found) {
+        rc = rc ? rc : 6;
+    }
+
+    /* Restore the harness logging and clean up. */
+    setuplog("default:note", "/dev/stderr", true);
+    ad_close(&ad, ADFLAGS_DF);
+    (void)unlink(path);
+    (void)unlink(logf);
+    return rc;                           /* 0 == pass */
+}
+
+/*!
+ * @brief fork_setmode_deny() maps each access mode to the right F_SHARE deny bits.
+ * The pre-fix expression mis-parsed via operator precedence, collapsing every
+ * input to the deny-write bit or 0.
+ */
+int utest_fork_setmode_fdeny(const struct vol *vol)
+{
+    const int RD = 1, WR = 2, NO = 0;   /* sentinel deny bits (illumos values) */
+    int rc = 0;
+    (void)vol;                          /* pure expression test, no volume I/O */
+
+    if (fork_setmode_deny(0, RD, WR, NO) != NO) {
+        rc = 1;                          /* no deny -> NODNY */
+    }
+
+    if (fork_setmode_deny(OPENACC_DRD, RD, WR, NO) != RD) {
+        rc = rc ? rc : 2;                /* deny-read only -> RDDNY */
+    }
+
+    if (fork_setmode_deny(OPENACC_DWR, RD, WR, NO) != WR) {
+        rc = rc ? rc : 3;                /* deny-write only -> WRDNY */
+    }
+
+    if (fork_setmode_deny(OPENACC_DRD | OPENACC_DWR, RD, WR, NO) != (RD | WR)) {
+        rc = rc ? rc : 4;                /* deny-both -> RDDNY | WRDNY */
+    }
+
+    return rc;                           /* 0 == pass */
 }

--- a/test/afpd/subtests_lock.h
+++ b/test/afpd/subtests_lock.h
@@ -35,4 +35,9 @@ extern int utest_deletefile_quirk_hazard(const struct vol *vol);
 extern int utest_deletefile_quirk(struct vol *vol);
 extern int utest_deletefile_nodelete(const struct vol *vol);
 
+extern int utest_shared_rlock(const struct vol *vol);
+extern int utest_overlap_strand(const struct vol *vol);
+extern int utest_freelock_unlck_fail_logs(const struct vol *vol);
+extern int utest_fork_setmode_fdeny(const struct vol *vol);
+
 #endif /* SUBTESTS_LOCK_H */

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -244,6 +244,15 @@ int main(int argc, char *argv[])
      * NULL and the test skips, like any other unmet capability). */
     TEST_int_or_skip(volsys ? utest_deletefile_nodelete(volsys) : TEST_SKIP, 0,
                      "deletefile honours NODELETE (ea=sys backend)");
+    /* release-path correctness: per-fork unlock, coalesced-union release, unlock-fail log */
+    TEST_int_or_skip(utest_shared_rlock(vol), 0,
+                     "shared read lock: kernel lock survives first release, drops on last");
+    TEST_int_or_skip(utest_overlap_strand(vol), 0,
+                     "overlapping read locks: union unlock leaves no stranded remainder");
+    TEST_int_or_skip(utest_freelock_unlck_fail_logs(vol), 0,
+                     "adf_freelock: a failed F_UNLCK is logged and the entry still dropped");
+    TEST_int_or_skip(utest_fork_setmode_fdeny(vol), 0,
+                     "fork_setmode_deny: each access mode maps to the correct deny bits");
     /* cleanup */
     closevol(&obj, vol);
 

--- a/test/testsuite/FPByteRangeLock.c
+++ b/test/testsuite/FPByteRangeLock.c
@@ -583,9 +583,8 @@ test_exit:
 STATIC void test410()
 {
     char *name = "t410 DF FPByteLock 2 users";
-    int fork;
-    int fork1 = 0;
-    int fork2 = 0;
+    uint16_t fork;
+    uint16_t fork1 = 0;
     uint16_t vol = VolID;
     uint16_t bitmap = 0;
     uint16_t vol2;
@@ -595,12 +594,6 @@ STATIC void test410()
 
     if (!Conn2) {
         test_skipped(T_CONN2);
-        goto test_exit;
-    }
-
-    if (adouble == AD_V2) {
-        /* this fails on adouble v2, because in Netatalk 3 we now close locks on file close */
-        test_skipped(T_ADEA);
         goto test_exit;
     }
 
@@ -632,7 +625,7 @@ STATIC void test410()
         goto fin;
     }
 
-    if (FPCloseFork(Conn, fork1)) { /* this should drop the byterange lock! */
+    if (FPCloseFork(Conn, fork1)) { /* sibling close must NOT drop fork's lock */
         test_failed();
         FPCloseFork(Conn, fork);
         goto fin;
@@ -656,7 +649,9 @@ STATIC void test410()
         goto fin2;
     }
 
-    if (FPByteLock(Conn2, fork1, 0, 0 /* set */, 0, 100)) {
+    /* fork still holds [0,100): the sibling close did not drop it, so a
+     * different session's acquire of the same range must be refused. */
+    if (htonl(AFPERR_LOCK) != FPByteLock(Conn2, fork1, 0, 0 /* set */, 0, 100)) {
         test_failed();
     }
 
@@ -1417,11 +1412,7 @@ void FPByteRangeLock_test()
     test63();
     test64();
     test65();
-    /* test78() disabled: reproduces an as-yet-unfixed adf_unlock() bug (a
-     * single fork close releases every fork's byte-range locks) and its
-     * failure was blocking unrelated PRs from pushing container images.
-     * Re-enable once the per-fork lock-release fix lands. */
-    /* test78(); */
+    test78();
     test79();
     test80();
     test329();


### PR DESCRIPTION
`afp read locks = yes` should be the default for a correct and AFP-compliant system, but it has not been for ~14 years (since the option was introduced); as full locking coherence has always been broken (since 2000). The option was added in 2012 to jump over the brokenness. This PR finally fixes it!

In the coming months we will switch to `afp read locks = yes` as the default to restore the now fixed functionality (which is important to avoid corruption and critical for Samba interoperability, we will leave the option for the performance conscious not running Samba).

---

POSIX advisory locks are owned by the process, and two forks opened on one inode inside one afpd child share a single `struct ad_fd` and one `adf_lock[]` array (via `ad_ref()` in `of_alloc()`). So "which locks does closing this fork release?" is a pure userspace bookkeeping question — the kernel fd is *not* closed on a non-final fork close. The 2012 rework answered that question with a sledgehammer, and three related release-path invariants were never tightened around it.

The AFP spec is explicit about the intended answer:

> *"Lock conflicts are determined by the value of `OForkRefNum`. … the two open fork reference numbers are considered two different 'users'."* — and — *"All locks held by a user are unlocked when the user closes the fork."*

A "user" is one `OForkRefNum` (`= ofork->of_refnum = lock[i].user`). Closing a fork must release **that fork's** locks and leave every sibling's intact. The release path did not.

## How the release path got here

Not anyone's mistake — the emergent result of locally-correct patches during the 2011–2012 fcntl-locking reactivation, none of which revisited the whole:

- **`f56d2cae` — Frank Lahm, 2012-01-27 ("Fix locking: drop all byterange locks for a file when closing one fork").** Rewrote `adf_unlock()`'s intent comment from *"fork is the only user of the lock"* to *"free all UNIX byterange lock from any fork"* and added the blanket `l_start < AD_FILELOCK_BASE` clause. Defect 1. The spectest recorded the flip: `test78` (locks survive a sibling close) was disabled as an *"unfixed `adf_unlock()` bug"* and `test410` was written to assert the inverse.
- **`799de0e7` — Frank Lahm, 2012-01-30 ("More logging").** Consolidated `ad_lock()`'s error paths into the `ret`/`fcntl_lock_err`/`exit:` form and, in doing so, set the `calloc`-failure return to a stray `+1`. Defect 4. (The sibling `realloc`-failure branch two lines up correctly uses `-1`.)
- The shared-refcount adopt-on-*overlap* logic and the `adf_freelock()` single-range unlock predate and outlived the rework — correct when locks were disjoint, wrong once the kernel began coalescing overlapping same-process ranges. Defects 2 and 3.

## Defects (one release path, six faults)

**1 — `adf_unlock()` over-releases (the "sledgehammer").** On any fork close it freed *every* data-zone byte-range lock on the shared array, ignoring `lock[i].user`. Closing fork B dropped fork A's still-held lock; a third party could then lock or write A's range — two clients believing they own it. Backend-independent. This is why `test78` was disabled. **Introduced in 2012.**

Fixing that alone shifts the whole release burden onto the owning fork's own close, where two latent hazards then bite — so both are fixed here:

**2 — `adf_freelock()` dropped the `set_lock(F_UNLCK)` return.** On the refcount→0 release it removed the array entry unconditionally but ignored a failed kernel unlock. A failure (`EBADF`/`ENOLCK`/…) left the lock held in the kernel with no `adf_lock[]` owner — the inode reads busy to peers until the process's last close, with no trace. **In the original 2000 code.**

**3 — the coalesced-remainder strand.** `ad_lock()` lets a new read lock share the refcount of any *overlapping* (not just identical) read lock from another fork, while the kernel coalesces same-process overlapping locks into one range (Linux `posix_lock_inode`; FreeBSD `lf_setlock`). At last-free, `adf_freelock()` unlocked only the final entry's *own* range, stranding the coalesced remainder:

```
A read-locks [0,100)     kernel: [0,100)
B read-locks [50,150)    kernel coalesces to [0,150); B joins A's refcount group
A closes                 refcount 2→1, no unlock; group has forgotten [0,50)
B closes                 refcount →0, F_UNLCK [50,150) only → kernel keeps [0,50)
```

A peer's write into `[0,50)` is phantom-blocked until the fd's last close. **In the original 2000 code (the root cause).**

**4 — OOM rollback returned `+1`.** On `calloc` failure `ad_lock()` returned `+1`; every caller tests `< 0`, so the rolled-back lock was reported as success — the client got `AFP_OK` for a lock held by neither the kernel nor the array. **Introduced in 2012.**

**5 — `ad_tmplock()` rfork dispatch divergence.** It resolved the resource fork via `&ad->ad_resource_fork` while `ad_lock()` uses `ad->ad_rfp`. Identical objects today, but a backend repointing `ad_rfp` would place and account rfork locks on different arrays for one fork — silent divergence. Latent, fixed for convergence. **Introduced in 2012.**

**6 — Solaris `F_SHARE` `f_deny` precedence (`fork_setmode()`).** The deny mode was built with an unparenthesised ternary; since `|` binds tighter than `?:`, the whole left side became a condition and every deny mode collapsed to `F_WRDNY` or `0`. A `DenyRead` registered against the kernel as `DenyWrite`, and the read-deny half of a deny-both open was dropped. The `F_SHARE` reservation is the *only* cross-protocol deny layer (the `AD_FILELOCK_DENY_*` band is AFP-vs-AFP only), so other openers — including NFS/SMB/local — were refused the wrong access. Solaris/illumos only. **Introduced in 2012.**

## Coverage matrix

Legend: ✓ correct · ✗ wrong/silent · ✗-strand actively broke kernel state.

| release-path invariant | old | new |
|---|---|---|
| sibling close preserves the holder's lock | ✗-strand (blanket free) | ✓ owner-only (`lock[i].user == fork`) |
| owner close releases the holder's lock | ✓ | ✓ |
| failed `F_UNLCK` at last-free | ✗ silent strand | ✓ logged, entry still dropped |
| coalesced overlapping-read union released whole | ✗ remainder stranded | ✓ union unlock + survivor re-assert |
| `calloc`-fail rollback reported to caller | ✗ `+1` read as success | ✓ `-1` |
| rfork lock array (`ad_lock` vs `ad_tmplock`) | ✗ divergent indirection | ✓ both use `ad_rfp` |
| Solaris `f_deny` reservation | ✗ collapsed by precedence | ✓ parenthesised, per-bit |

## Fix

- **`adf_unlock()`** matches on owner only; the now-unused `unlckbrl` parameter is removed through the chain (`ad_unlock()`, prototype, `of_closefork()`, test callers).
- **`adf_freelock()`** captures and logs the `F_UNLCK` return (log-drop-continue: the entry is still dropped, so userspace under-claims and converges at fd close, and the anomaly is now visible to the operator rather than silent).
- **Coalesced union.** The bare `int *refcount` becomes `adf_lock_shared_t { count; start; end; }`; `ad_lock()` records each group's coalesced union `[start,end)` as entries join, and `adf_freelock()` at last-free `F_UNLCK`s the union then re-asserts any survivor the broad unlock clipped (the established unlock-then-restore idiom from `ad_tmplock()`). The union math runs **for data-zone entries only**: share-mode band entries are single fixed offsets that never coalesce — and `RSRC_OPEN_NONE` sits at `off_t` max, where an exclusive `l_start + l_len` would overflow — so band entries release their own range exactly as before. A whole-file lock requested at/after the last lockable offset is now rejected (`AFPERR_RANGEOVR`) so the union arithmetic always sees `l_len > 0`.
- **`ad_lock()`** OOM rollback returns `-1`.
- **`ad_tmplock()`** uses `ad->ad_rfp`.
- **`fork_setmode_deny()`** — the two-ternary `f_deny` computation is extracted into a small helper (fixing the precedence and making it unit-testable off-Solaris) and called from the `HAVE_FSHARE_T` block.

## Behaviour changes

- Closing a fork no longer drops a sibling fork's byte-range locks on the same file — a peer's `FPByteRangeLock`/`FPWrite`/`FPRead` over the held range is refused (with `afp read locks`) until the *holding* fork closes. This is the pre-2012, spec-conformant behaviour; restoring the old blanket teardown behind an operator option is a follow-up.
- On Solaris/illumos with share reservations enabled, `DenyRead` and deny-both opens now register the correct kernel `F_SHARE` reservation.

---

## `afp read locks = no` vs `= yes` (scope of this PR)
The option (global, **default `no`**) gates exactly the implicit advisory lock `afp_read`/`afp_write` take around each `FPRead`/`FPWrite`. Those 10 gates wrap five balanced acquire/release pairs — with `= no` both halves are skipped.

`FPByteRangeLock` itself, the delete/rename conflict reads, and share-mode/deny enforcement (Eg as per #3145) are **not** gated; these always run in both modes.

- **`= yes`** — An `FPRead`/`FPWrite` over a range another user holds is refused `AFPERR_LOCK`. This is the full spec-compliant path this PR fixes (and what test78/test410 assert).
- **`= no`** (still default for now) — an `FPByteRangeLock` is still placed and conflict-checked against other locks, but `FPRead`/`FPWrite` is **not** checked (spec-invalid). A client's advisory lock is not enforced against peer I/O — a real data-integrity gap for lock-dependent clients (databases, shared documents etc), masked by the fact the lock still succeeds. It is the historical default because the 2012 locking code defects made enabling it unsafe.

This PR does not change the (`= no`) skip logic (verified correct and unchanged). The fixes in `ad_lock.c` (which has no option awareness), harden both modes — the un-gated paths (`FPByteRangeLock`, delete-conflict, share-mode) benefit under `= no`.

What remains enforced with `= no`:

| Mechanism | With `= no`? | Notes |
|---|---|---|
| `FPByteRangeLock` placement | ✅ placed | client locks still take real kernel locks |
| `FPByteRangeLock` vs `FPByteRangeLock` conflict | ✅ enforced | `ad_lock`→`adf_findxlock`, unconditional |
| Share-mode / deny modes (`OpenDeny*` at open) | ✅ enforced | `fork_setmode`, ungated |
| `FPDelete` / rename-overwrite conflict check | ✅ enforced | `of_get_locks` (PR #3145), unconditional |
| Read/write honouring a byte-range lock | ❌ skipped | the only thing the option gates |

**Warning: The gap under `= no`: a range one client locked does _not_ block another client's read/write of it. Locks are placed and conflict with other locks, but not actually checked with plain I/O (this is why we must set the default to `yes`).**

## Testing

**Spectests.** Re-enable `FPByteRangeLock:test78` (holder's lock survives a sibling close). Correct `test410`, which encoded the old drop-on-sibling-close behaviour: flip its cross-session acquire to expect `AFPERR_LOCK`, and drop the backend-specific skip (the bug and fix are backend-independent). Verified locally on ea:sys and ea:ad, with `afp read locks` on and off — **Failed: 0** in every leg; test78 + test410 PASS where the read-lock assertions run (they correctly skip when `afp read locks = no`, since the write-vs-lock enforcement they assert is itself gated on that option). The `afp-spectest-readlocks-afp34` CI job exercises this.

**Unit tests** (`test/afpd/subtests_lock.c`, gated on the existing fault-injection capability):

- `utest_shared_rlock` — two same-range read locks share a refcount; the kernel lock survives the first release, drops on the last.
- `utest_overlap_strand` — the coalesced-remainder case above; RED before the union fix, GREEN after (proven via a forked-peer `F_GETLK`, since a process can't see its own locks).
- `utest_freelock_unlck_fail_logs` — a forced `F_UNLCK` failure is logged and the entry still dropped.
- `utest_fork_setmode_fdeny` — each access mode maps to the correct deny bits.

## Not in this PR (follow-ups)

- **Bug 4 (OOM sign) ships without a dedicated test.** Its trigger is a 4-byte `calloc` returning NULL, which under default overcommit never happens (the OOM killer fires first), and the leak CI can't force an allocation-failure return-sign path. The one-line fix matches its `realloc`-fail sibling and is guarded by review.
- **Bug 5 (`ad_tmplock` dispatch) ships without a test.** It is latent (`ad_rfp == &ad_resource_fork` on both backends today); the only assertion a test could make would forbid the very `ad_rfp` flexibility the fix exists to make safe.