### PR TITLE
testsuite: CatSearch test code quality and layout cleanup

### DIFF
--- a/test/testsuite/FPCatSearch.c
+++ b/test/testsuite/FPCatSearch.c
@@ -28,10 +28,10 @@ STATIC void test225()
     memset(&filedir, 0, sizeof(filedir));
     filedir.attr = 0x01a0;			/* various lock attributes */
     FAIL(htonl(AFPERR_BITMAP) != FPCatSearch(Conn, vol, 10, pos,
-            0,  /* d_bitmap*/ 0, bitmap, &filedir, &filedir))
+            0, /* d_bitmap */ 0, bitmap, &filedir, &filedir))
     filedir.attr = 0x01a0;			/* various lock attributes */
-    ret = FPCatSearch(Conn, vol, 10, pos, 0x42,  /* d_bitmap*/ 0, bitmap, &filedir,
-                      &filedir);
+    ret = FPCatSearch(Conn, vol, 10, pos, 0x42, /* d_bitmap */ 0,
+                      bitmap, &filedir, &filedir);
 
     if (ret != htonl(AFPERR_EOF)) {
         test_failed();
@@ -55,8 +55,8 @@ STATIC void test225()
     memset(&filedir, 0, sizeof(filedir));
     /* ------------------- */
     filedir.attr = 0x01a0;			/* lock attributes */
-    ret  = FPCatSearch(Conn, vol, 10, pos, 0x42,  /* d_bitmap*/ 0, bitmap, &filedir,
-                       &filedir);
+    ret  = FPCatSearch(Conn, vol, 10, pos, 0x42, /* d_bitmap*/ 0, bitmap,
+                       &filedir, &filedir);
 
     if (ret != htonl(AFPERR_EOF)) {
         test_failed();
@@ -75,7 +75,7 @@ STATIC void test225()
 
     /* ------------------- */
     filedir.attr = 0x0100;			/* lock attributes */
-    ret  = FPCatSearch(Conn, vol, 10, pos, 0x42,  /* d_bitmap*/ 0, bitmap, &filedir,
+    ret  = FPCatSearch(Conn, vol, 10, pos, 0x42, /* d_bitmap */ 0, bitmap, &filedir,
                        &filedir);
 
     if (ret != htonl(AFPERR_EOF)) {
@@ -94,7 +94,6 @@ STATIC void test225()
     }
 
     /* -------------------- */
-#if 1
     memset(&filedir, 0, sizeof(filedir));
     memset(&filedir2, 0, sizeof(filedir2));
     filedir.lname = "Data";
@@ -108,7 +107,6 @@ STATIC void test225()
     }
 
     /* -------------------- */
-#endif
     memset(&filedir, 0, sizeof(filedir));
     filedir.attr = 0x01a0;
     FAIL(FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir))
@@ -167,7 +165,6 @@ STATIC void test551()
         test_failed();
     }
 
-test_exit:
     exit_test("FPCatSearch:test551: truncated search-spec payload");
 }
 

--- a/test/testsuite/FPCatSearchExt.c
+++ b/test/testsuite/FPCatSearchExt.c
@@ -86,8 +86,8 @@ STATIC void test227()
     memset(pos, 0, sizeof(pos));
     memset(&filedir, 0, sizeof(filedir));
     filedir.attr = 0x01a0;			/* various lock attributes */
-    ret = FPCatSearchExt(Conn, vol, 10, pos, 0,  /* d_bitmap*/ 0, bitmap, &filedir,
-                         &filedir);
+    ret = FPCatSearchExt(Conn, vol, 10, pos, 0, /* d_bitmap */ 0, bitmap,
+                         &filedir, &filedir);
 
     if (Conn->afp_version < 30) {
         if (htonl(AFPERR_NOOP) != ret) {
@@ -108,7 +108,7 @@ STATIC void test227()
         goto test_exit;
     }
 
-    ret = FPCatSearchExt(Conn, vol, 10, pos, 0x42,  /* d_bitmap*/ 0, bitmap,
+    ret = FPCatSearchExt(Conn, vol, 10, pos, 0x42, /* d_bitmap */ 0, bitmap,
                          &filedir, &filedir);
 
     if (ret != htonl(AFPERR_EOF)) {
@@ -133,7 +133,7 @@ STATIC void test227()
     memset(&filedir, 0, sizeof(filedir));
     /* ------------------- */
     filedir.attr = 0x01a0;			/* lock attributes */
-    ret  = FPCatSearchExt(Conn, vol, 10, pos, 0x42,  /* d_bitmap*/ 0, bitmap,
+    ret  = FPCatSearchExt(Conn, vol, 10, pos, 0x42, /* d_bitmap */ 0, bitmap,
                           &filedir, &filedir);
 
     if (ret != htonl(AFPERR_EOF)) {
@@ -153,7 +153,7 @@ STATIC void test227()
 
     /* ------------------- */
     filedir.attr = 0x0100;			/* lock attributes */
-    ret  = FPCatSearchExt(Conn, vol, 10, pos, 0x42,  /* d_bitmap*/ 0, bitmap,
+    ret  = FPCatSearchExt(Conn, vol, 10, pos, 0x42, /* d_bitmap */ 0, bitmap,
                           &filedir, &filedir);
 
     if (ret != htonl(AFPERR_EOF)) {
@@ -488,7 +488,7 @@ test_exit:
 /* ------------------------- */
 STATIC void test530()
 {
-    DSI *dsi;
+    const DSI *dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -511,7 +511,7 @@ test_exit:
 /* ------------------------- */
 STATIC void test549()
 {
-    DSI *dsi;
+    const DSI *dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -537,7 +537,7 @@ STATIC void test550()
     uint16_t name_offset;
     unsigned char spec1[2];
     unsigned char spec2[3];
-    DSI *dsi;
+    const DSI *dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -568,7 +568,7 @@ STATIC void test552()
     uint16_t name_offset;
     unsigned char spec1[6];
     unsigned char spec2[6];
-    DSI *dsi;
+    const DSI *dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -598,7 +598,7 @@ STATIC void test553()
     uint16_t name_len;
     unsigned char spec1[7];
     unsigned char spec2[6];
-    DSI *dsi;
+    const DSI *dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -625,7 +625,7 @@ test_exit:
 /* ------------------------- */
 STATIC void test554()
 {
-    DSI *dsi;
+    const DSI *dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {
@@ -651,7 +651,7 @@ STATIC void test555()
     uint16_t offset;
     uint16_t name_len;
     unsigned char spec1[23];
-    DSI *dsi;
+    const DSI *dsi;
     ENTER_TEST
 
     if (Conn->afp_version < 30) {


### PR DESCRIPTION
a handful of minor code smells flagged by SonarQube: apply const keyword on unchanging pointer, and remove unused exit label

also, minor stylistic cleanup