### PR TITLE
meson: print all features in configure summary, refactor sendfile logic

### DIFF
--- a/bin/nad/meson.build
+++ b/bin/nad/meson.build
@@ -54,6 +54,7 @@ if get_option('with-stuffit')
     endif
 
     nad_deps += stuffit
+    have_stuffit = true
     nad_c_args += '-DHAVE_STUFFIT'
 endif
 

--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -29,6 +29,8 @@ if have_acls
     libatalk_deps += acl_deps
 endif
 
+libatalk_deps += sendfile_deps
+
 if have_appletalk
     subdir('asp')
     subdir('atp')

--- a/meson.build
+++ b/meson.build
@@ -382,11 +382,6 @@ if socket.found()
     netatalk_common_link_args += '-lsocket'
 endif
 
-sendfile = cc.find_library('sendfile', required: false)
-if sendfile.found()
-    netatalk_common_link_args += '-lsendfile'
-endif
-
 nsl = cc.find_library('nsl', required: false)
 if nsl.found()
     netatalk_common_link_args += '-lnsl'
@@ -2171,30 +2166,36 @@ endif
 # Check for sendfile
 #
 
-enable_sendfile = get_option('with-sendfile')
+have_sendfile = false
+sendfile_deps = []
 
-if not enable_sendfile
-    have_sendfile = false
-elif host_os == 'linux'
-    cdata.set('SENDFILE_FLAVOR_LINUX', 1)
-    have_sendfile = cc.has_function('sendfile')
-    if have_sendfile
-        cdata.set('WITH_SENDFILE', 1)
+if get_option('with-sendfile')
+    sendfile = cc.find_library('sendfile', required: false)
+    if sendfile.found()
+        sendfile_deps += sendfile
     endif
-elif host_os == 'sunos'
-    cdata.set('SENDFILE_FLAVOR_SOLARIS', 1)
-    have_sendfile = cc.has_function('sendfile', dependencies: sendfile)
-    if have_sendfile
-        cdata.set('WITH_SENDFILE', 1)
-    endif
-    if cc.has_function('sendfilev', dependencies: sendfile)
-        cdata.set('HAVE_SENDFILEV', 1)
-    endif
-elif host_os == 'freebsd'
-    cdata.set('SENDFILE_FLAVOR_FREEBSD', 1)
-    have_sendfile = cc.has_function('sendfile')
-    if have_sendfile
-        cdata.set('WITH_SENDFILE', 1)
+
+    if host_os == 'linux'
+        cdata.set('SENDFILE_FLAVOR_LINUX', 1)
+        have_sendfile = cc.has_function('sendfile')
+        if have_sendfile
+            cdata.set('WITH_SENDFILE', 1)
+        endif
+    elif host_os == 'sunos'
+        cdata.set('SENDFILE_FLAVOR_SOLARIS', 1)
+        have_sendfile = cc.has_function('sendfile', dependencies: sendfile_deps)
+        if have_sendfile
+            cdata.set('WITH_SENDFILE', 1)
+        endif
+        if cc.has_function('sendfilev', dependencies: sendfile_deps)
+            cdata.set('HAVE_SENDFILEV', 1)
+        endif
+    elif host_os == 'freebsd'
+        cdata.set('SENDFILE_FLAVOR_FREEBSD', 1)
+        have_sendfile = cc.has_function('sendfile')
+        if have_sendfile
+            cdata.set('WITH_SENDFILE', 1)
+        endif
     endif
 endif
 
@@ -2659,6 +2660,7 @@ configure_file(
 #########################
 
 root_includes = include_directories(include_dirs)
+have_stuffit = false
 
 subdir('include')
 subdir('libatalk')
@@ -2749,10 +2751,10 @@ summary_info = {
     '  ACL': have_acls,
     '  AppleTalk': have_appletalk,
     '  Cracklib': have_cracklib,
-    '  CUPS': have_cups,
     '  dtrace probes': have_dtrace,
     '  FCE': have_fce,
     '  GSSAPI': have_gssapi,
+    '  Iconv': have_iconv,
     '  Kerberos': have_kerberos,
     '  LDAP': have_ldap,
     '  Quota': have_quota,
@@ -2763,6 +2765,7 @@ if have_quota
     }
 endif
 summary_info += {
+    '  Sendfile syscall': have_sendfile,
     '  Spotlight search': have_spotlight,
 }
 if have_spotlight
@@ -2779,7 +2782,7 @@ if enable_zeroconf
         '  Zeroconf provider': zeroconf_provider,
     }
 endif
-summary(summary_info, bool_yn: true, section: '  Features:')
+summary(summary_info, bool_yn: true, section: '  Netatalk Features:')
 
 summary_info = {
     '  dbus daemon path': dbus_daemonpath,
@@ -2800,9 +2803,17 @@ summary_info = {
 summary(summary_info, bool_yn: true, section: '  Documentation:')
 
 summary_info = {
-    '  afpd integration tests': get_option('with-tests'),
-    '  AFP testsuite': get_option('with-testsuite'),
-    '  UAM tests': testsuite_libafpclient.found(),
+    '  afpd': get_option('with-tests'),
+    '  fuzzing': get_option('with-fuzzing'),
+    '  testsuite': get_option('with-testsuite'),
+    '  UAM testsuite': testsuite_libafpclient.found(),
+}
+summary(summary_info, bool_yn: true, section: '  Tests:')
+
+summary_info = {
+    '  CUPS printing in papd': have_cups,
+    '  PAP backend for CUPS': get_option('with-cups-pap-backend'),
+    '  StuffIt support in nad': have_stuffit,
     '  Webmin module': have_webmin,
 }
 summary(summary_info, bool_yn: true, section: '  Extras:')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -10,6 +10,12 @@ option(
     description: 'Enable ACL support',
 )
 option(
+    'with-appletalk',
+    type: 'boolean',
+    value: false,
+    description: 'Enable the AppleTalk transport layer, services and utilities',
+)
+option(
     'with-cracklib',
     type: 'boolean',
     value: true,
@@ -26,12 +32,6 @@ option(
     type: 'boolean',
     value: false,
     description: 'Install the pap backend for CUPS',
-)
-option(
-    'with-appletalk',
-    type: 'boolean',
-    value: false,
-    description: 'Enable the AppleTalk transport layer, services and utilities',
 )
 option(
     'with-debug',
@@ -164,12 +164,6 @@ option(
     type: 'boolean',
     value: true,
     description: 'Enable sendfile syscall',
-)
-option(
-    'with-shell-check',
-    type: 'boolean',
-    value: true,
-    description: 'Enable checking for a valid shell',
 )
 option(
     'with-spotlight',

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -131,13 +131,13 @@ if get_option('with-tests')
     test_sh = find_program('test.sh')
 
     test(
-        'afpd integration tests - setup',
+        'afpd tests - setup',
         test_sh,
         is_parallel: false,
         priority: 1,
     )
     test(
-        'afpd integration tests - run',
+        'afpd tests - run',
         afpdtest,
         args: ['--tap'],
         protocol: 'tap',


### PR DESCRIPTION
all compile time features now get printed in narrower categories, with some adjustments of the meson scripts

- Netatalk Features section gets Iconv and Sendfile
- CUPS moved to Extras section since it's not a Netatalk feature
- Extras section gets a handful of additional features
- new Testing section, add in fuzzing

this also fixes the sendfile check which had OS specific branches that overrode the compile time option

minor cleanup of meson_options.txt and rename afpd tests