### PR TITLE
ci: bump NetBSD VM action version to v1.4.2

### DIFF
--- a/.github/workflows/spectest-vms.yml
+++ b/.github/workflows/spectest-vms.yml
@@ -290,7 +290,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Build on VM
-        uses: vmactions/netbsd-vm@99816dccf75edf233ed6cd00a159e3a5b85ea373 # v1.4.0
+        uses: vmactions/netbsd-vm@0c26a4c4a5e234038862a4a53a00c905b8a107c9 # v1.4.2
         with:
           copyback: true
           sync: sshfs


### PR DESCRIPTION
the latest vmactions/netbsd-vm comes with stability fixes for sshfs sync among other things, so we will hopefully get more consistent pipelines with this update