### PR TITLE
ci: remove sync option from NetBSD build job

### DIFF
--- a/.github/workflows/spectest-vms.yml
+++ b/.github/workflows/spectest-vms.yml
@@ -293,7 +293,6 @@ jobs:
         uses: vmactions/netbsd-vm@0c26a4c4a5e234038862a4a53a00c905b8a107c9 # v1.4.2
         with:
           copyback: true
-          sync: sshfs
           prepare: |
             set -e
             export PKG_PATH="https://ftp.NetBSD.org/pub/pkgsrc/packages/NetBSD/$(uname -p)/$(uname -r|cut -f '1 2' -d.)/All"


### PR DESCRIPTION
removed 'sync: sshfs' option from VM build step, which allows it to fall back to the default sync option in this VM

let's see if this gives us more stable pipeline outcomes