### PR TITLE
afpd: harden copyfile held-handle use; fix ad_write rlen-on-error; rfork-cache guard/log

### DIFF
--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -288,7 +288,7 @@ static int copydir(struct vol *vol, struct dir *ddir, int dirfd, char *src,
                     goto copydir_done;
                 }
             } else if (AFP_OK != (err = copyfile(vol, vol, ddir, dirfd, spath, dpath, NULL,
-                                                 NULL))) {
+                                                 NULL, 0))) {
                 goto copydir_done;
             } else {
                 /* keep the same time stamp. */

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -1656,7 +1656,7 @@ int renamefile(struct vol *vol, struct dir *ddir, int sdir_fd, char *src,
             }
 
             if (AFP_OK != (rc = copyfile(vol, vol, ddir, sdir_fd, src, dst, newname,
-                                         NULL))) {
+                                         NULL, 0))) {
                 /* on error copyfile delete dest */
                 return rc;
             }
@@ -1836,32 +1836,47 @@ int afp_copyfile(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
         return AFPERR_BADTYPE;
     }
 
-    /* don't allow copies when the file is open.
-     * XXX: the spec only calls for read/deny write access.
-     *      however, copyfile doesn't have any of that info,
-     *      and locks need to stay coherent. as a result,
-     *      we just balk if the file is opened already. */
+    /* A held source must reuse its fds: never ad_open/ad_close a second handle
+     * onto the live of->of_ad.  A transient close can strand the holder's
+     * process-owned POSIX locks and perturbs the shared refcount; of_get_locks
+     * follows the same rule.  A not-held adp is a private throwaway. */
+    const struct ofork *of = of_findname(s_vol, s_path);
+    int held = (of != NULL);
     adp = of_ad(s_vol, s_path, &ad);
 
-    if (ad_open(adp, s_path->u_name,
-                ADFLAGS_DF | ADFLAGS_HF | ADFLAGS_NOHF | ADFLAGS_RDONLY | ADFLAGS_SETSHRMD) <
-            0) {
+    if (!held) {
+        if (ad_open(adp, s_path->u_name,
+                    ADFLAGS_DF | ADFLAGS_HF | ADFLAGS_NOHF | ADFLAGS_RDONLY
+                    | ADFLAGS_SETSHRMD) < 0) {
+            return AFPERR_DENYCONF;
+        }
+    } else if (!(ad_data_fileno(adp) >= 0 || ad_data_fileno(adp) == AD_SYMLINK)) {
+        /* held with no usable data fd: copy_fork reads it, and a transient open
+         * would strand the holder's locks - refuse.  Test the fd directly (like
+         * of_get_locks), not AD_DATA_OPEN: on EA the base fd is valid with
+         * ad_data_refcount == 0. */
         return AFPERR_DENYCONF;
     }
 
 #ifdef HAVE_FSHARE_T
-    fshare_t shmd;
-    shmd.f_access = F_RDACC;
-    shmd.f_deny = F_NODNY;
 
-    if (fcntl(ad_data_fileno(adp), F_SHARE, &shmd) != 0) {
-        retvalue = AFPERR_DENYCONF;
-        goto copy_exit;
-    }
+    /* Only for a freshly-opened source: on a held fd this would plant an
+     * uninitialized-f_id reservation (released only by the !held close below)
+     * over the holder's own fork_setmode reservation. */
+    if (!held) {
+        fshare_t shmd;
+        shmd.f_access = F_RDACC;
+        shmd.f_deny = F_NODNY;
 
-    if (AD_RSRC_OPEN(adp) && fcntl(ad_reso_fileno(adp), F_SHARE, &shmd) != 0) {
-        retvalue = AFPERR_DENYCONF;
-        goto copy_exit;
+        if (fcntl(ad_data_fileno(adp), F_SHARE, &shmd) != 0) {
+            retvalue = AFPERR_DENYCONF;
+            goto copy_exit;
+        }
+
+        if (AD_RSRC_OPEN(adp) && fcntl(ad_reso_fileno(adp), F_SHARE, &shmd) != 0) {
+            retvalue = AFPERR_DENYCONF;
+            goto copy_exit;
+        }
     }
 
 #endif
@@ -1926,7 +1941,8 @@ int afp_copyfile(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
         goto copy_exit;
     }
 
-    if ((err = copyfile(s_vol, d_vol, curdir, -1, p, upath, newname, adp)) < 0) {
+    if ((err = copyfile(s_vol, d_vol, curdir, -1, p, upath, newname, adp,
+                        held)) < 0) {
         retvalue = err;
         goto copy_exit;
     }
@@ -1946,7 +1962,10 @@ copy_exit:
         ipc_send_cache_hint(obj, d_vol->v_vid, curdir->d_did, CACHE_HINT_REFRESH);
     }
 
-    ad_close(adp, ADFLAGS_DF | ADFLAGS_HF | ADFLAGS_SETSHRMD);
+    if (!held) {
+        ad_close(adp, ADFLAGS_DF | ADFLAGS_HF | ADFLAGS_SETSHRMD);
+    }
+
     return retvalue;
 }
 
@@ -1962,7 +1981,8 @@ int copyfile(struct vol *s_vol,
              char *src,
              char *dst,
              char *newname,
-             struct adouble *adp)
+             struct adouble *adp,
+             int held)
 {
     struct adouble	ads, add;
     int			err = 0;
@@ -1979,21 +1999,58 @@ int copyfile(struct vol *s_vol,
 
     adflags = ADFLAGS_DF | ADFLAGS_HF | ADFLAGS_NOHF | ADFLAGS_RF | ADFLAGS_NORF;
 
-    if (ad_openat(adp, sfd, src, adflags | ADFLAGS_RDONLY) < 0) {
-        err = errno;
-        goto done;
-    }
+    if (!held) {
+        /* not held: private handle, so ad_open/close is safe.  AD_RSRC_OPEN then
+         * reflects the on-disk rfork. */
+        if (ad_openat(adp, sfd, src, adflags | ADFLAGS_RDONLY) < 0) {
+            err = errno;
+            goto done;
+        }
 
-    if (!AD_META_OPEN(adp))
-        /* no resource fork, don't create one for dst file */
-    {
-        adflags &= ~ADFLAGS_HF;
-    }
+        if (!AD_META_OPEN(adp)) {
+            adflags &= ~ADFLAGS_HF;
+        }
 
-    if (!AD_RSRC_OPEN(adp))
-        /* no resource fork, don't create one for dst file */
-    {
-        adflags &= ~ADFLAGS_RF;
+        if (!AD_RSRC_OPEN(adp)) {
+            adflags &= ~ADFLAGS_RF;
+        }
+    } else {
+        /* held: reuse fds, never ad_open/close onto of->of_ad.  Meta presence is
+         * read directly; the rfork may be closed on the held handle even when it
+         * exists on disk, so probe it with a PRIVATE adouble. */
+        if (!AD_META_OPEN(adp)) {
+            adflags &= ~ADFLAGS_HF;
+        }
+
+#if defined(HAVE_EAFD) && defined(SOLARIS)
+
+        /* Solaris O_XATTR rfork fd hangs off the data fd: a private rfork open
+         * would strand the held locks - fall back to the held handle's view. */
+        if (!AD_RSRC_OPEN(adp)) {
+            adflags &= ~ADFLAGS_RF;
+        }
+
+#else
+
+        if (!AD_RSRC_OPEN(adp)) {
+            struct adouble adprobe;
+            ad_init(&adprobe, s_vol);
+
+            if (ad_openat(&adprobe, sfd, src,
+                          ADFLAGS_RF | ADFLAGS_NORF | ADFLAGS_RDONLY) == 0) {
+                int has_rf = AD_RSRC_OPEN(&adprobe);
+                ad_close(&adprobe, ADFLAGS_RF | ADFLAGS_HF);
+
+                if (!has_rf) {
+                    adflags &= ~ADFLAGS_RF;
+                }
+            }
+
+            /* a hard open error leaves RF set: create the dest rfork, matching
+             * the not-held path's RF|NORF open. */
+        }
+
+#endif
     }
 
     /* saving stat exit code, thus saving us on one more stat later on */
@@ -2009,7 +2066,10 @@ int copyfile(struct vol *s_vol,
     if (ad_open(&add, dst, adflags | ADFLAGS_RDWR | ADFLAGS_CREATE | ADFLAGS_EXCL,
                 st.st_mode | S_IRUSR | S_IWUSR) < 0) {
         err = errno;
-        ad_close(adp, adflags);
+
+        if (!held) {
+            ad_close(adp, adflags);
+        }
 
         if (EEXIST != err) {
             /* dst ownership is not certain here (the create failed for a
@@ -2076,7 +2136,10 @@ int copyfile(struct vol *s_vol,
     }
 
 error:
-    ad_close(adp, adflags);
+
+    if (!held) {
+        ad_close(adp, adflags);
+    }
 
     if (ad_close(&add, adflags) < 0) {
         err = errno;

--- a/etc/afpd/file.h
+++ b/etc/afpd/file.h
@@ -112,7 +112,7 @@ extern int setfilparams(const AFPObj *obj, struct vol *, struct path *,
 extern int renamefile(struct vol *, struct dir *, int, char *, char *, char *,
                       struct adouble *);
 extern int copyfile(struct vol *, struct vol *, struct dir *, int, char *,
-                    char *, char *, struct adouble *);
+                    char *, char *, struct adouble *, int);
 extern int deletefile(const struct vol *, int, char *, int);
 
 extern int getmetadata(const AFPObj *obj, struct vol *vol, uint16_t bitmap,

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -1207,6 +1207,13 @@ static int rfork_cache_serve_from_buf(DSI *dsi, struct dir *cached_entry,
 {
     ssize_t cc;
 
+    if (cached_entry->dcache_rfork_buf == NULL) {
+        LOG(log_error, logtype_afpd,
+            "rfork_cache_serve_from_buf: NULL buffer (did:%u)",
+            ntohl(cached_entry->d_did));
+        return -1;
+    }
+
     /* Defense-in-depth: validate bounds before any memcpy from rfork buffer.
      * Callers maintain offset + reqcount <= dcache_rlen, but verify here to
      * prevent heap over-read if invariants are ever violated. */
@@ -1221,6 +1228,12 @@ static int rfork_cache_serve_from_buf(DSI *dsi, struct dir *cached_entry,
         return -1;
     }
 
+    LOG(log_debug, logtype_afpd,
+        "rfork_cache_serve_from_buf: serving rfork from cache "
+        "(offset:%lld, reqcount:%lld, rlen:%lld, did:%u)",
+        (long long)offset, (long long)reqcount,
+        (long long)cached_entry->dcache_rlen,
+        ntohl(cached_entry->d_did));
     *rbuflen = MIN(reqcount, dsi->server_quantum);
     memcpy(ibuf, (char *)cached_entry->dcache_rfork_buf + offset, *rbuflen);
     offset += *rbuflen;

--- a/libatalk/adouble/ad_write.c
+++ b/libatalk/adouble/ad_write.c
@@ -97,6 +97,10 @@ ssize_t ad_write(struct adouble *ad, uint32_t eid, off_t off, int end,
 
         cc = adf_pwrite(&ad->ad_resource_fork, buf, buflen, r_off);
 
+        if (cc < 0) {
+            return -1;    /* nothing written; do NOT touch ad_rlen */
+        }
+
         if (ad->ad_rlen < off + cc) {
             ad->ad_rlen = off + cc;
         }

--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -1132,6 +1132,131 @@ test_exit:
 }
 
 
+/* ------------------------- */
+/* Copy a file whose resource fork this session still holds open, then close the
+ * fork.  The copy must succeed and preserve both forks, and the holder's close
+ * must return cleanly. */
+STATIC void test425()
+{
+    int      dir = DIRDID_ROOT;
+    uint16_t vol = VolID;
+    int      ofs = 3 * sizeof(uint16_t);
+    struct afp_filedir_parms filedir = { 0 };
+    uint16_t bitmap;
+    uint16_t fork = 0;
+    uint16_t dfork = 0;
+    const DSI *dsi = &Conn->dsi;
+    char     data[20];
+    char *name  = "t425 held rfork src";
+    char *name1 = "t425 copy dest";
+    ENTER_TEST
+
+    if (FPCreateFile(Conn, vol, 0, dir, name)) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    dfork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, dir, name,
+                       OPENACC_WR | OPENACC_RD);
+
+    if (!dfork) {
+        test_nottested();
+        goto fin;
+    }
+
+    if (FPSetForkParam(Conn, dfork, (1 << FILPBIT_DFLEN), 9)) {
+        FPCloseFork(Conn, dfork);
+        test_nottested();
+        goto fin;
+    }
+
+    if (FPWrite(Conn, dfork, 0, 9, "Data fork", 0)) {
+        FPCloseFork(Conn, dfork);
+        test_nottested();
+        goto fin;
+    }
+
+    FPCloseFork(Conn, dfork);
+    dfork = 0;
+    /* open the resource fork and keep it open across the copy */
+    fork = FPOpenFork(Conn, vol, OPENFORK_RSCS, 0, dir, name,
+                      OPENACC_WR | OPENACC_RD);
+
+    if (!fork) {
+        test_nottested();
+        goto fin;
+    }
+
+    if (FPSetForkParam(Conn, fork, (1 << FILPBIT_RFLEN), 13)) {
+        test_nottested();
+        goto fin;
+    }
+
+    if (FPWrite(Conn, fork, 0, 13, "Resource fork", 0)) {
+        test_nottested();
+        goto fin;
+    }
+
+    FAIL(FPCopyFile(Conn, vol, dir, vol, dir, name, "", name1))
+    FAIL(FPCloseFork(Conn, fork))
+    fork = 0;
+    bitmap = (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN);
+
+    if (FPGetFileDirParams(Conn, vol, dir, name1, bitmap, 0)) {
+        test_failed();
+        goto fin;
+    }
+
+    filedir.isdir = 0;
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
+
+    if (filedir.dflen != 9 || filedir.rflen != 13) {
+        if (!Quiet) {
+            fprintf(stdout, "\tFAILED after copy wrong size (data %d, resource %d)\n",
+                    filedir.dflen, filedir.rflen);
+        }
+
+        test_failed();
+        goto fin;
+    }
+
+    memset(data, 0, sizeof(data));
+    fork = FPOpenFork(Conn, vol, OPENFORK_RSCS, 0, dir, name1,
+                      OPENACC_RD);
+
+    if (!fork) {
+        test_failed();
+        goto fin;
+    }
+
+    if (FPRead(Conn, fork, 0, 13, data)) {
+        test_failed();
+    } else if (memcmp(data, "Resource fork", 13)) {
+        if (!Quiet) {
+            fprintf(stdout, "\tFAILED not \"Resource fork\" read after copy\n");
+        }
+
+        test_failed();
+    }
+
+    FPCloseFork(Conn, fork);
+    fork = 0;
+    FAIL(FPDelete(Conn, vol, dir, name1))
+fin:
+
+    if (fork) {
+        FPCloseFork(Conn, fork);
+    }
+
+    if (dfork) {
+        FPCloseFork(Conn, dfork);
+    }
+
+    FPDelete(Conn, vol, dir, name);
+test_exit:
+    exit_test("FPCopyFile:test425: copy file with held-open resource fork");
+}
+
 /* ----------- */
 void FPCopyFile_test()
 {
@@ -1151,4 +1276,5 @@ void FPCopyFile_test()
     test409();
     test414();
     test424();
+    test425();
 }


### PR DESCRIPTION
Three small, independent correctness/robustness changes in the fork/adouble paths. Each is self-contained and could stand alone.

## `copyfile` — reuse a held handle, don't open/close onto it (hardening)

When the copy source is already open by the session, `of_ad()` returns the live `of->of_ad`, and `afp_copyfile()`/`copyfile()` then run `ad_open`/`ad_close` cycles **on that handle**. The refcount arithmetic happens to balance (verified on an `AD_VERSION2` volume — the shared count returns to zero cleanly, no `AFP_ASSERT`), so this does not crash today, but mutating a client-owned handle is fragile: a transient `ad_close` can drop the holder's process-owned POSIX advisory locks, and it couples copyfile to `ad_close`'s internal accounting.

Fix: reuse the held fds and never `ad_open`/`ad_close` `of->of_ad`, mirroring the rule `of_get_locks()` already follows. The destination fork-set is discovered from the on-disk resource fork via a private probe adouble (with the `HAVE_EAFD && SOLARIS` guard, where a private rfork open would strand the held locks). A held rfork-only source with no data fd is refused rather than opened transiently. Adds `FPCopyFile:test425`, the only test that exercises the held-source path.

## `ad_write` — don't fold a write error into `ad_rlen`

The `ADEID_RFORK` branch updated `ad_rlen` from `adf_pwrite()`'s return **before** checking it, so a failed rfork write (`ENOSPC`/`EDQUOT`/`EIO`) set `ad_rlen` to a length for bytes never written — which `ad_flush()` then persists. Now checks `cc < 0` first and leaves `ad_rlen` untouched on error. Backend-independent.

## `fork.c` — rfork-cache serve guard + log

`rfork_cache_serve_from_buf()` now rejects a NULL cache buffer before the `memcpy` (defense-in-depth against a broken invariant) and logs served-from-cache hits at `debug`, matching the AD-cache serve path.

## Testing

Full `testsuite_alp` container build; `ea:ad` spectest **345 passed, 0 failed** (`test425` green). Compiles clean, no new warnings.
