### PR TITLE
lantest: split stat/open/read/close test; add client and server copy tests

### DIFF
--- a/contrib/scripts/plot_lantest.pl
+++ b/contrib/scripts/plot_lantest.pl
@@ -20,7 +20,7 @@
 # afp_lantest, run with -c, prints one summary row per test:
 #
 #     Test,Time_ms,Time±,Min_ms,Max_ms,Median_ms,MB/s
-#     Open, stat and read 512 bytes from 1000 files [8,000 AFP ops],360,33.6,324,406,349,0
+#     Stat 2000 files [6,000 AFP ops],260,3.6,258,263,260,0
 #     ...
 #     Sum of all AFP OPs = 80686,4921,,
 #
@@ -63,20 +63,23 @@ my $ROW_TAIL_RE = qr/^(.+),(\d+),([\d.]+),(\d+),(\d+),(\d+),(\d+)\s*$/;
 # Map each lantest test (matched by a substring of its full name) to a short
 # axis label. Order matters: first matching substring wins.
 my @SHORT_LABELS = (
-                    ['Writing one large file' => 'Write 100MB'],
-                    ['Reading one large file' => 'Read 100MB'],
-                    ['Creating 2000 files'    => 'Create 2k'],
-                    ['Writing 1024 bytes'     => 'Write 2k'],
-                    ['Lock then unlock 2000'  => 'Fork lock 2k'],
-                    ['Stat, open, read'       => 'Stat/open/read 2k'],
-                    ['Enumerate dir'          => 'Enumerate 2k'],
-                    ['Deleting 2000 files'    => 'Delete 2k'],
-                    ['Byte-range lock/unlock' => 'Byte lock 2k'],
-                    ['Create directory tree'  => 'Create tree'],
-                    ['Directory cache hits'   => 'Dircache hits'],
-                    ['Mixed cache operations' => 'Mixed cache'],
-                    ['Deep path traversal'    => 'Deep traverse'],
-                    ['Cache validation'       => 'Cache validate'],
+                    ['Writing one large file'    => 'Write 100MB'],
+                    ['Reading one large file'    => 'Read 100MB'],
+                    ['Creating 2000 files'       => 'Create 2k'],
+                    ['Open, write 1024 bytes'    => 'Write 2k'],
+                    ['Open, read 512 bytes'      => 'Read 2k'],
+                    ['Copying 2000 files client' => 'Copy 2k'],
+                    ['Copying 2000 files server' => 'ServerCopy 2k'],
+                    ['Lock then unlock 2000'     => 'Fork lock 2k'],
+                    ['Stat 2000 files'           => 'Stat 2k'],
+                    ['Enumerate dir'             => 'Enumerate 2k'],
+                    ['Deleting 2000 files'       => 'Delete 2k'],
+                    ['Byte-range lock/unlock'    => 'Byte lock 2k'],
+                    ['Create directory tree'     => 'Create tree'],
+                    ['Directory cache hits'      => 'Dircache hits'],
+                    ['Mixed cache operations'    => 'Mixed cache'],
+                    ['Deep path traversal'       => 'Deep traverse'],
+                    ['Cache validation'          => 'Cache validate'],
 );
 
 # Map a verbose test name to a short axis label, falling back to the name with
@@ -252,14 +255,14 @@ set rmargin at screen 0.98
 set boxwidth 0.5
 # Y-axis titles as screen-pinned rotated labels (not per-panel "set ylabel"),
 # centered on each panel's height so they align despite differing tick widths.
-# Upper panel y 0.34-0.84 (mid 0.59), lower 0.18-0.30 (mid 0.24).
-set label 5 "Time (ms) — lower is faster" at screen 0.022, screen 0.59 \\
+# Upper panel y 0.30-0.84 (mid 0.57), lower 0.14-0.26 (mid 0.20).
+set label 5 "Time (ms) — lower is faster" at screen 0.022, screen 0.57 \\
     center rotate by 90 font "DejaVu Sans,7"
-set label 6 "Jitter (CoV %)" at screen 0.022, screen 0.24 \\
+set label 6 "Jitter (CoV %)" at screen 0.022, screen 0.20 \\
     center rotate by 90 font "DejaVu Sans,7"
 set label 7 \\
     "Coefficient of Variation (CoV) = stddev ÷ mean, as a normalized percent" \\
-    at screen 0.5, screen 0.06 center font "DejaVu Sans,6.5" \\
+    at screen 0.5, screen 0.025 center font "DejaVu Sans,6.5" \\
     textcolor rgb "#444444"
 # Dotted grid; minor (per-decade log) lines fainter so they don't read heavy.
 set grid ytics mytics linetype 1 dashtype (1,2) linewidth 1 \\
@@ -274,18 +277,18 @@ set multiplot
 
 # --- Upper panel: latency candlesticks (~70%; log y needs less height) ---
 set tmargin at screen 0.84
-set bmargin at screen 0.34
+set bmargin at screen 0.30
 set logscale y
 set yrange [$y_lo:$y_hi]
 set format y "%g"
 set ytics font ",6"
 # Blank x labels here; the lower panel labels the shared ticks.
 set xtics ($blank_tics)
-# Vertical dividers bracketing the shared-file pipeline (Create..Delete 2k),
+# Vertical dividers bracketing the 2000-file tests (Create 2k..Byte lock 2k),
 # drawn in both panels so the related series reads as one group.
 set arrow 1 from 1.5, graph 0 to 1.5, graph 1 nohead \\
     dashtype (4,3) linewidth 1 linecolor rgb "#999999" front
-set arrow 2 from 7.5, graph 0 to 7.5, graph 1 nohead \\
+set arrow 2 from 11.5, graph 0 to 11.5, graph 1 nohead \\
     dashtype (4,3) linewidth 1 linecolor rgb "#999999" front
 # Legend in the free top-left outer canvas, outside the plot area so it never
 # overlaps a candle.
@@ -320,12 +323,12 @@ unset label 1
 unset label 2
 unset logscale y
 unset key
-set tmargin at screen 0.30
-set bmargin at screen 0.18
+set tmargin at screen 0.26
+set bmargin at screen 0.14
 set yrange [0:$cov_hi]
 set format y "%g"
 set ytics $cov_tic font ",6"
-set xtics rotate by 12 right font ",6" ($tics)
+set xtics rotate by 16 right font ",6" ($tics)
 # Narrower than the 0.5 candle boxes so the jitter bars read as a distinct mark.
 set boxwidth 0.3
 plot \$DATA using 1:7 with boxes \\

--- a/doc/manpages/man1/afp_lantest.1.md
+++ b/doc/manpages/man1/afp_lantest.1.md
@@ -56,7 +56,7 @@ features.
 : Server hostname or IP address (default: localhost)
 
 **-K**
-: Run cache-focused tests only (tests 11-14)
+: Run cache-focused tests only (tests 14-17)
 
 **-n** *iterations*
 : Number of test iterations to run (default: 2). For iterations > 5 outliers will be removed
@@ -92,54 +92,102 @@ Configure the UAM in netatalk's afp.conf:
 The following tests are available:
 
 Most tests operate on a shared set of 2000 files, normalized so their timings
-are comparable. Tests 3-8 form a pipeline over the same 2000 files (create,
-write, lock, read, enumerate, delete); selecting any of them implies test 3.
+are comparable. Tests 3-11 form a pipeline over the same 2000 files (create,
+write, read, copy, server-copy, stat, enumerate, lock, delete); selecting any
+of them implies test 3.
+
+Each test's AFP operation count below covers only the timed region; setup and
+cleanup operations (marked untimed) are excluded from the timing and the count.
 
 **(1) Writing one large file**
-: Measures sustained write performance
+: Measures sustained write performance. Timed: ~100 quantum-sized FPWriteExt
+calls plus the final FPCloseFork [103 AFP ops]. Untimed setup: FPCreateFile,
+FPGetFileDirParms x2, FPOpenFork, FPGetForkParms.
 
 **(2) Reading one large file**
-: Measures sustained read performance
+: Measures sustained read performance. Timed: ~100 quantum-sized FPReadExt
+calls plus the final FPCloseFork [102 AFP ops]. Untimed setup:
+FPGetFileDirParms, FPOpenFork, FPGetForkParms.
 
 **(3) Creating 2000 files**
-: Tests file creation performance
+: Tests file creation performance. Timed, per file: FPCreateFile +
+FPGetFileDirParms [2 x 2000 = 4,000 AFP ops].
 
-**(4) Writing 1024 bytes to 2000 files**
-: Tests write performance over many small files (implies test 3)
+**(4) Open, write 1024 bytes, close 2000 files**
+: Tests the full small-write lifecycle per file (implies test 3). Timed, per
+file: FPOpenFork + FPWrite + FPCloseFork [3 x 2000 = 6,000 AFP ops].
 
-**(5) Lock then unlock 2000 open forks**
-: Tests refnum lookup and lock setup against a full open-fork table (implies test 3)
+**(5) Open, read 512 bytes, close 2000 files**
+: Tests the full small-read lifecycle a real client pays per file, including
+the lock management carried by each open and close (implies tests 3, 4).
+Mirrors test 4's timed open+write+close so the read and write results are
+directly comparable. Timed, per file: FPOpenFork + FPRead + FPCloseFork
+[3 x 2000 = 6,000 AFP ops].
 
-**(6) Stat, open, read 512 bytes, close 2000 files**
-: Tests basic file access patterns with many small operations (implies tests 3, 4)
+**(6) Copying 2000 files client-side**
+: Tests copying where the client reads each file's data and writes it back to
+a new file, as file managers without server-side copy do (implies tests 3, 4).
+Timed, per file: FPOpenFork + FPRead + FPCloseFork on the source, then
+FPCreateFile + FPOpenFork + FPWrite + FPCloseFork on the copy
+[7 x 2000 = 14,000 AFP ops]. Untimed cleanup: FPDelete per copy.
 
-**(7) Enumerate dir with 2000 files**
-: Tests directory enumeration with many files (implies test 3)
+**(7) Copying 2000 files server-side**
+: Tests FPCopyFile, where the data never crosses the wire (implies tests 3, 4).
+Timed, per file: FPCopyFile [1 x 2000 = 2,000 AFP ops]. Untimed cleanup:
+FPDelete per copy. Contrast with test 6 to see the round-trip savings.
 
-**(8) Deleting 2000 files**
-: Tests file deletion performance (implies test 3)
+**(8) Stat 2000 files**
+: Tests file lookup and metadata query performance (implies test 3). Timed,
+per file: three FPGetFileDirParms requests with varying bitmaps
+[3 x 2000 = 6,000 AFP ops].
 
-**(9) Byte-range lock/unlock 2000 ranges in one fork**
-: Tests per-fork byte-range lock tracking with many locks held at once
+**(9) Enumerate dir with 2000 files**
+: Tests directory enumeration with many files (implies test 3). Timed:
+FPEnumerateExt2 in 40-entry chunks over the 2000-file directory
+[~51 AFP ops].
 
-**(10) Create directory tree with 1000 dirs**
-: Tests nested directory creation (10 x 10 x 10)
+**(10) Lock then unlock 2000 open forks**
+: Tests refnum lookup and lock setup against a full open-fork table (implies
+test 3). Timed: FPByteRangeLock lock + unlock on each fork
+[2 x 2000 = 4,000 AFP ops]. Untimed: FPOpenFork x2000 setup,
+FPCloseFork x2000 cleanup.
 
-**(11) Directory cache hits [CACHE]**
-: Tests directory and file lookup performance (20 dirs x 100 files)
+**(11) Deleting 2000 files**
+: Tests file deletion performance (implies test 3). Timed, per file: FPDelete
+[1 x 2000 = 2,000 AFP ops].
 
-**(12) Mixed cache operations [CACHE]**
-: Tests mixed create/stat/enum/delete operations over 1000 files
+**(12) Byte-range lock/unlock 2000 ranges in one fork**
+: Tests per-fork byte-range lock tracking with many locks held at once. Timed:
+FPByteRangeLock lock x2000 then unlock x2000 on distinct ranges in a single
+fork [4,000 AFP ops]. Untimed: file create/write/open setup and cleanup.
 
-**(13) Deep path traversal [CACHE]**
-: Tests 100 walks of a 20-level deep directory tree
+**(13) Create directory tree with 1000 dirs**
+: Tests nested directory creation (10 x 10 x 10). Timed: FPCreateDir per
+directory [1,110 AFP ops]. Untimed cleanup: FPDelete per directory.
 
-**(14) Cache validation [CACHE]**
-: Tests cache revalidation over 2000 files (3 metadata lookups each)
+**(14) Directory cache hits [CACHE]**
+: Tests directory and file lookup performance (20 dirs x 100 files). Timed:
+FPGetFileDirParms per directory and per file [2,020 AFP ops]. Untimed:
+FPCreateDir/FPCreateFile setup, FPDelete cleanup.
+
+**(15) Mixed cache operations [CACHE]**
+: Tests the cache lifecycle over 1000 files (implies nothing; self-contained).
+Timed, per file: FPCreateFile + FPGetFileDirParms + FPGetFileDirParms +
+FPDelete, plus FPEnumerate every 10th file [4 x 1000 + 100 = 4,100 AFP ops].
+
+**(16) Deep path traversal [CACHE]**
+: Tests 100 walks of a 20-level deep directory tree. Timed: FPGetFileDirParms
+per level per walk [20 x 100 = 2,000 AFP ops]. Untimed: FPCreateDir setup,
+FPDelete cleanup.
+
+**(17) Cache validation [CACHE]**
+: Tests cache revalidation over 2000 files. Timed, per file: three
+FPGetFileDirParms metadata lookups [3 x 2000 = 6,000 AFP ops]. Untimed:
+FPCreateFile setup, FPDelete cleanup.
 
 ## Cache-Focused Tests
 
-Tests 11-14 are specifically designed to highlight directory cache performance improvements in
+Tests 14-17 are specifically designed to highlight directory cache performance improvements in
 netatalk. These tests benefit significantly from optimized cache validation and probabilistic
 validation features. Use the **-K** option to run only these cache-focused tests.
 
@@ -176,72 +224,81 @@ For example, to run as root;
     afp_lantest -n 2 -7 -h 127.0.0.1 -p 548 -u test -w test -s 'File Sharing'
     Connecting to host 127.0.0.1:548
     IO monitoring: /proc_io is available
-    Found cnid_dbd process for user 'test': PID 40
-    Found privilege-dropped afpd process for user 'test': PID 36
-    IO monitoring enabled (afpd: 36, cnid_dbd: 40)
+    Found cnid_dbd process for user 'test': PID 46
+    Found privilege-dropped afpd process for user 'test': PID 41
+    IO monitoring enabled (afpd: 41, cnid_dbd: 46)
 
-    Run 1 => Writing one large file [103 AFP ops]                                  208 ms for 100 MB (avg. 504 MB/s)
-            IO Operations; afpd: 101 READs, 301 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 1 => Reading one large file [102 AFP ops]                                   39 ms for 100 MB (avg. 2688 MB/s)
-            IO Operations; afpd: 201 READs, 100 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 1 => Creating 2000 files [4,000 AFP ops]                                  2847 ms
-            IO Operations; afpd: 4000 READs, 10000 WRITEs | cnid_dbd: 4 READs, 4151 WRITEs
-    Run 1 => Writing 1024 bytes to 2000 files [6,000 AFP ops]                     2122 ms
-            IO Operations; afpd: 8000 READs, 8000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 1 => Lock then unlock 2000 open forks [4,000 AFP ops]                      133 ms
-            IO Operations; afpd: 4000 READs, 4000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 1 => Stat, open, read 512 bytes, close 2000 files [16,000 AFP ops]        3864 ms
-            IO Operations; afpd: 26000 READs, 14000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 1 => Enumerate dir with 2000 files [~51 AFP ops]                             9 ms
-            IO Operations; afpd: 49 READs, 49 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 1 => Deleting 2000 files [2,000 AFP ops]                                  2705 ms
-            IO Operations; afpd: 6000 READs, 8000 WRITEs | cnid_dbd: 2 READs, 6100 WRITEs
-    Run 1 => Byte-range lock/unlock 2000 ranges in one fork [4,000 AFP ops]        160 ms
-            IO Operations; afpd: 4000 READs, 4000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 1 => Create directory tree with 1000 dirs [1,110 AFP ops]                 1755 ms
-            IO Operations; afpd: 1110 READs, 5550 WRITEs | cnid_dbd: 4 READs, 2284 WRITEs
-    Run 1 => Directory cache hits (20 dirs x 100 files) [2,020 AFP ops]             80 ms
-            IO Operations; afpd: 2020 READs, 2020 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 1 => Mixed cache operations (create/stat/enum/delete) on 1000 files [4,100 AFP ops]  3633 ms
-            IO Operations; afpd: 6101 READs, 10101 WRITEs | cnid_dbd: 8 READs, 5025 WRITEs
-    Run 1 => Deep path traversal (20 levels x 100 walks) [2,000 AFP ops]            81 ms
-            IO Operations; afpd: 2000 READs, 2000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Run 1 => Cache validation (2000 files x 3 lookups) [6,000 AFP ops]             244 ms
-            IO Operations; afpd: 6000 READs, 6000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
-    Successfully deleted test directory 'LanTest-1'
+    Run 1 => Writing one large file [103 AFP ops]                                   42 ms for 100 MB (avg. 2496 MB/s)
+             IO Operations; afpd: 101 READs, 301 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Reading one large file [102 AFP ops]                                   19 ms for 100 MB (avg. 5518 MB/s)
+             IO Operations; afpd: 277 READs, 176 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Creating 2000 files [4,000 AFP ops]                                   444 ms
+             IO Operations; afpd: 4000 READs, 6000 WRITEs | cnid_dbd: 4 READs, 4151 WRITEs
+    Run 1 => Open, write 1024 bytes, close 2000 files [6,000 AFP ops]              267 ms
+             IO Operations; afpd: 6000 READs, 8000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Open, read 512 bytes, close 2000 files [6,000 AFP ops]                258 ms
+             IO Operations; afpd: 8000 READs, 4000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Copying 2000 files client-side [14,000 AFP ops]                       726 ms
+             IO Operations; afpd: 16000 READs, 16000 WRITEs | cnid_dbd: 2 READs, 4101 WRITEs
+    Run 1 => Copying 2000 files server-side [2,000 AFP ops]                        503 ms
+             IO Operations; afpd: 6000 READs, 8000 WRITEs | cnid_dbd: 4 READs, 4143 WRITEs
+    Run 1 => Stat 2000 files [6,000 AFP ops]                                       233 ms
+             IO Operations; afpd: 6000 READs, 6000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Enumerate dir with 2000 files [~51 AFP ops]                             3 ms
+             IO Operations; afpd: 49 READs, 49 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Lock then unlock 2000 open forks [4,000 AFP ops]                      155 ms
+             IO Operations; afpd: 4000 READs, 4000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Deleting 2000 files [2,000 AFP ops]                                   440 ms
+             IO Operations; afpd: 2000 READs, 8000 WRITEs | cnid_dbd: 7 READs, 6186 WRITEs
+    Run 1 => Byte-range lock/unlock 2000 ranges in one fork [4,000 AFP ops]        157 ms
+             IO Operations; afpd: 4000 READs, 4000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Create directory tree with 1000 dirs [1,110 AFP ops]                  223 ms
+             IO Operations; afpd: 1110 READs, 3330 WRITEs | cnid_dbd: 4 READs, 2350 WRITEs
+    Run 1 => Directory cache hits (20 dirs x 100 files) [2,020 AFP ops]             70 ms
+             IO Operations; afpd: 2020 READs, 2020 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Mixed cache operations (create/stat/enum/delete) on 1000 files [4,    382 ms
+             IO Operations; afpd: 4100 READs, 8100 WRITEs | cnid_dbd: 4 READs, 5037 WRITEs
+    Run 1 => Deep path traversal (20 levels x 100 walks) [2,000 AFP ops]            72 ms
+             IO Operations; afpd: 2000 READs, 2000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Run 1 => Cache validation (2000 files x 3 lookups) [6,000 AFP ops]             232 ms
+             IO Operations; afpd: 6000 READs, 6000 WRITEs | cnid_dbd: 0 READs, 0 WRITEs
+    Successfully deleted test directory 'LanTest-40'
 
-    Netatalk Lantest Results (Averages and standard deviations (±) for all tests, across 10 iterations)
+    Netatalk Lantest Results (Averages and standard deviations (±) for all tests, across 2 iterations (default))
     ============================================================================================================
 
     Test                                                                Time_ms  Time± AFPD_R AFPD_R± AFPD_W AFPD_W± CNID_R CNID_R± CNID_W CNID_W±   MB/s
     ------------------------------------------------------------------ -------- ------ ------ ------- ------ ------- ------ ------- ------ ------- ------
-    Writing one large file [103 AFP ops]                                    172   55.8    101     0.0    300     0.0      0     0.0      0     0.0    581
-    Reading one large file [102 AFP ops]                                     39    3.9    201     0.0    100     0.0      0     0.0      0     0.0   2564
-    Creating 2000 files [4,000 AFP ops]                                    3144  121.4   4000     0.0  10000     0.0      4     0.0   4133     7.3      0
-    Writing 1024 bytes to 2000 files [6,000 AFP ops]                       2030  230.0   8000     0.0   8000     0.0      0     0.0      0     0.0      0
-    Lock then unlock 2000 open forks [4,000 AFP ops]                        165    8.4   4000     0.0   4000     0.0      0     0.0      0     0.0      0
-    Stat, open, read 512 bytes, close 2000 files [16,000 AFP ops]          3420  342.4  26000     0.0  14000     0.0      0     0.0      0     0.0      0
-    Enumerate dir with 2000 files [~51 AFP ops]                              11    1.6     49     0.0     49     0.0      0     0.0      0     0.0      0
-    Deleting 2000 files [2,000 AFP ops]                                    2691  239.8   6000     0.0   8000     0.0      4     1.1   6177     3.5      0
-    Byte-range lock/unlock 2000 ranges in one fork [4,000 AFP ops]          172   12.2   4000     0.0   4000     0.0      0     0.0      0     0.0      0
-    Create directory tree with 1000 dirs [1,110 AFP ops]                   1877  109.5   1110     0.0   5550     0.0      4     1.4   2280     8.0      0
-    Directory cache hits (20 dirs x 100 files) [2,020 AFP ops]               93   11.1   2020     0.0   2020     0.0      0     0.0      0     0.0      0
-    Mixed cache operations (create/stat/enum/delete) on 1000 files [4,100 AFP ops]     3273  468.0   6100     0.5  10100     0.5      8     1.6   5033    14.2      0
-    Deep path traversal (20 levels x 100 walks) [2,000 AFP ops]              84    3.3   2000     0.0   2000     0.0      0     0.0      0     0.0      0
-    Cache validation (2000 files x 3 lookups) [6,000 AFP ops]               242    9.4   6000     0.0   6000     0.0      0     0.0      0     0.0      0
+    Writing one large file [103 AFP ops]                                     40    2.2    101     0.0    300     1.0      0     0.0      0     0.0   2500
+    Reading one large file [102 AFP ops]                                     17    2.2    273     5.0    172     5.0      0     0.0      0     0.0   5882
+    Creating 2000 files [4,000 AFP ops]                                     407   51.6   4000     0.0   6000     0.0      4     0.0   4138    18.4      0
+    Open, write 1024 bytes, close 2000 files [6,000 AFP ops]                261    7.8   6000     0.0   8000     0.0      0     0.0      0     0.0      0
+    Open, read 512 bytes, close 2000 files [6,000 AFP ops]                  260    2.8   8000     0.0   4000     0.0      0     0.0      0     0.0      0
+    Copying 2000 files client-side [14,000 AFP ops]                         673   75.0  16000     0.0  16000     0.0      3     1.4   4127    37.5      0
+    Copying 2000 files server-side [2,000 AFP ops]                          448   77.8   6000     0.0   8000     0.0      4     0.0   4137     7.8      0
+    Stat 2000 files [6,000 AFP ops]                                         232    1.0   6000     0.0   6000     0.0      0     0.0      0     0.0      0
+    Enumerate dir with 2000 files [~51 AFP ops]                               3    1.0     49     0.0     49     0.0      0     0.0      0     0.0      0
+    Lock then unlock 2000 open forks [4,000 AFP ops]                        153    2.2   4000     0.0   4000     0.0      0     0.0      0     0.0      0
+    Deleting 2000 files [2,000 AFP ops]                                     416   33.2   2000     0.0   8000     0.0      5     2.2   6187     1.4      0
+    Byte-range lock/unlock 2000 ranges in one fork [4,000 AFP ops]          155    2.2   4000     0.0   4000     0.0      0     0.0      0     0.0      0
+    Create directory tree with 1000 dirs [1,110 AFP ops]                    208   21.2   1110     0.0   3330     0.0      3     1.4   2305    62.9      0
+    Directory cache hits (20 dirs x 100 files) [2,020 AFP ops]               70    1.0   2020     0.0   2020     0.0      0     0.0      0     0.0      0
+    Mixed cache operations (create/stat/enum/delete) on 1000 files [4,100 AFP ops]      381    1.4   4100     0.0   8100     0.0      4     0.0   5045    11.3      0
+    Deep path traversal (20 levels x 100 walks) [2,000 AFP ops]              72    0.0   2000     0.0   2000     0.0      0     0.0      0     0.0      0
+    Cache validation (2000 files x 3 lookups) [6,000 AFP ops]               230    2.8   6000     0.0   6000     0.0      0     0.0      0     0.0      0
     ------------------------------------------------------------------ -------- ------ ------ ------- ------ ------- ------ ------- ------ ------- ------
-    Sum of all AFP OPs = 51486                                            17413         69581          74119             20          17623
+    Sum of all AFP OPs = 63486                                             4026         71653          85971             23          25939               
 
     Aggregates Summary:
     ------------------------------------------------------------------
-    Average Time per AFP OP: 0.538 ms (from per-test medians)
-    Average AFPD Reads per AFP OP: 0.711
-    Average AFPD Writes per AFP OP: 1.144
+    Average Time per AFP OP: 0.063 ms (from per-test medians)
+    Average AFPD Reads per AFP OP: 1.129
+    Average AFPD Writes per AFP OP: 1.354
     See afp_lantest manpage for more information: https://netatalk.io/manual/en/afp_lantest.1
 
     Dircache Statistics (/var/log/afpd.log):
     ------------------------------------------------------------------
-    Sep 24 13:30:15.702673 afpd[36] {dircache.c:632} (info:AFPDaemon): dircache statistics: (user: test) entries: 0, lookups: 244476, hits: 227977 (93.3%), misses: 9228, added: 9552, removed: 9552, expunged: 7271, evicted: 0
+    Jul 12 06:42:28.768144 afpd[41] {dircache.c:2074} (info:AFPDaemon): dircache statistics (ARC): (user: test) entries: 0, ghost_entries: 0, max_entries: 4001 (750 KB), config_max: 65536, lookups: 310256, hits: 281770 (90.8%), ghost_hits: 0 (0.0%), total_hits: (90.8%), misses: 28486 (9.2%), validations: 2819 (1.0%), added: 20305, removed: 20305, expunged: 181, invalid_on_use: 181, evicted: 0, validation_freq: 100
 
 ## IO Monitoring Result Columns
 
@@ -290,10 +347,10 @@ For more information see [Testing Wiki](https://netatalk.io/docs/Testing)
 
 # Notes
 
-- Tests that involve large file operations (tests 2 and 3) will create temporary files in the
+- Tests that involve large file operations (tests 1 and 2) will create temporary files in the
   test volume
 - The **-g** and **-G** options significantly increase test file sizes and test duration
-- Cache-focused tests (8-11) provide the most insight into netatalk's directory cache performance
+- Cache-focused tests (14-17) provide the most insight into netatalk's directory cache performance
 - Multiple iterations (**-n**) are recommended for consistent performance measurements
 - The tool requires write access to the specified AFP volume
 

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -66,19 +66,25 @@
 #define TEST_READ100MB 1
 #define TEST_CREATE2000FILES 2
 #define TEST_WRITE2000FILES 3
-#define TEST_FORK2000LOCKS 4
-#define TEST_OPENSTATREAD 5
-#define TEST_ENUM2000FILES 6
-#define TEST_DELETE2000FILES 7
-#define TEST_BYTELOCKS 8
-#define TEST_DIRTREE 9
-#define TEST_CACHE_HITS 10
-#define TEST_MIXED_CACHE_OPS 11
-#define TEST_DEEP_TRAVERSAL 12
-#define TEST_CACHE_VALIDATION 13
+#define TEST_READ2000FILES 4
+#define TEST_COPY2000FILES 5
+#define TEST_SERVERCOPY2000FILES 6
+#define TEST_STAT2000FILES 7
+#define TEST_ENUM2000FILES 8
+#define TEST_FORK2000LOCKS 9
+#define TEST_DELETE2000FILES 10
+#define TEST_BYTELOCKS 11
+#define TEST_DIRTREE 12
+#define TEST_CACHE_HITS 13
+#define TEST_MIXED_CACHE_OPS 14
+#define TEST_DEEP_TRAVERSAL 15
+#define TEST_CACHE_VALIDATION 16
 #define LASTTEST TEST_CACHE_VALIDATION
 #define NUMTESTS (LASTTEST+1)
-#define TOTAL_AFP_OPS 51486
+/* Timed AFP requests issued by one full pass over every test; recomputed
+ * whenever a test's timed loop changes. See the per-test "[N AFP ops]"
+ * annotations in test_names[] — this is their sum. */
+#define TOTAL_AFP_OPS 63486
 
 /* Global Error Constants */
 #define ERROR_MEMORY_ALLOCATION  2
@@ -172,10 +178,13 @@ static const char *test_names[NUMTESTS] = {
     "Writing one large file [103 AFP ops]",  /*!< TEST_WRITE100MB */
     "Reading one large file [102 AFP ops]",  /*!< TEST_READ100MB */
     "Creating 2000 files [4,000 AFP ops]",  /*!< TEST_CREATE2000FILES */
-    "Writing 1024 bytes to 2000 files [6,000 AFP ops]",  /*!< TEST_WRITE2000FILES */
-    "Lock then unlock 2000 open forks [4,000 AFP ops]",  /*!< TEST_FORK2000LOCKS */
-    "Stat, open, read 512 bytes, close 2000 files [16,000 AFP ops]",  /*!< TEST_OPENSTATREAD */
+    "Open, write 1024 bytes, close 2000 files [6,000 AFP ops]",  /*!< TEST_WRITE2000FILES */
+    "Open, read 512 bytes, close 2000 files [6,000 AFP ops]",  /*!< TEST_READ2000FILES */
+    "Copying 2000 files client-side [14,000 AFP ops]",  /*!< TEST_COPY2000FILES */
+    "Copying 2000 files server-side [2,000 AFP ops]",  /*!< TEST_SERVERCOPY2000FILES */
+    "Stat 2000 files [6,000 AFP ops]",  /*!< TEST_STAT2000FILES */
     "Enumerate dir with 2000 files [~51 AFP ops]",  /*!< TEST_ENUM2000FILES */
+    "Lock then unlock 2000 open forks [4,000 AFP ops]",  /*!< TEST_FORK2000LOCKS */
     "Deleting 2000 files [2,000 AFP ops]",  /*!< TEST_DELETE2000FILES */
     "Byte-range lock/unlock 2000 ranges in one fork [4,000 AFP ops]",  /*!< TEST_BYTELOCKS */
     "Create directory tree with 1000 dirs [1,110 AFP ops]",  /*!< TEST_DIRTREE */
@@ -1009,7 +1018,7 @@ void run_test(const int32_t dir)
     }
 
     /* -------- */
-    /* Test (2) */
+    /* Test (1) */
     if (teststorun[TEST_WRITE100MB]) {
         snprintf(temp, sizeof(temp), "File.big");
 
@@ -1081,7 +1090,7 @@ void run_test(const int32_t dir)
     }
 
     /* -------- */
-    /* Test (3) */
+    /* Test (2) */
     if (teststorun[TEST_READ100MB]) {
         if (!bigfilename) {
             if (is_there(Conn, vol, dir, temp) != AFP_OK) {
@@ -1149,13 +1158,13 @@ void run_test(const int32_t dir)
         addresult(TEST_READ100MB, iteration_counter);
     }
 
-    /* Remove test 2+3 testfile */
+    /* Remove test 1+2 testfile */
     if (teststorun[TEST_WRITE100MB]) {
         FPDelete(Conn, vol, dir, "File.big");
     }
 
     /* -------- */
-    /* Test (5) */
+    /* Test (3) */
     if (teststorun[TEST_CREATE2000FILES]) {
 #ifdef __linux__
         capture_io_values(TEST_START);
@@ -1216,7 +1225,219 @@ void run_test(const int32_t dir)
     }
 
     /* -------- */
-    /* Test (5b): fork/refnum scaling. Reuses the 2000 files created above
+    /* Open, read 512 bytes, close each of the 2000 files written above: the
+     * full small-read lifecycle a real client pays per file, including the
+     * per-open/close lock management. Mirrors WRITE2000FILES's timed
+     * open+write+close so the read and write candles are directly
+     * comparable; the metadata stats live in STAT2000FILES. */
+    if (teststorun[TEST_READ2000FILES]) {
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
+        starttimer();
+
+        for (int32_t i = 1; i <= create_enum_files; i++) {
+            snprintf(temp, sizeof(temp), "File.0k%d", i);
+            fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp,
+                              OPENACC_RD | OPENACC_DWR);
+
+            if (!fork) {
+                clean_exit(ERROR_FORK_OPERATIONS);
+            }
+
+            if (FPRead(Conn, fork, 0, 512, data)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+
+            if (FPCloseFork(Conn, fork)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+        }
+
+        stoptimer();
+        addresult(TEST_READ2000FILES, iteration_counter);
+    }
+
+    /* -------- */
+    /* Client-side copy: duplicate each of the 2000 1k files by pulling the
+     * data over the wire and pushing it back (open, read, close, create,
+     * open, write, close per file). Reuses the pipeline's written files;
+     * the copies are deleted untimed afterwards. */
+    if (teststorun[TEST_COPY2000FILES]) {
+        static char temp2[MAXPATHLEN];
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
+        starttimer();
+
+        for (int32_t i = 1; i <= create_enum_files; i++) {
+            snprintf(temp, sizeof(temp), "File.0k%d", i);
+            snprintf(temp2, sizeof(temp2), "File.cp%d", i);
+            fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp,
+                              OPENACC_RD | OPENACC_DWR);
+
+            if (!fork) {
+                clean_exit(ERROR_FORK_OPERATIONS);
+            }
+
+            if (FPRead(Conn, fork, 0, 1024, data)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+
+            if (FPCloseFork(Conn, fork)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+
+            if (FPCreateFile(Conn, vol, 0, dir, temp2)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
+            }
+
+            fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, dir, temp2,
+                              OPENACC_WR | OPENACC_RD);
+
+            if (!fork) {
+                clean_exit(ERROR_FORK_OPERATIONS);
+            }
+
+            if (FPWrite(Conn, fork, 0, 1024, data, 0)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+
+            if (FPCloseFork(Conn, fork)) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+        }
+
+        stoptimer();
+        addresult(TEST_COPY2000FILES, iteration_counter);
+
+        /* Cleanup (untimed): remove the copies. */
+        for (int32_t i = 1; i <= create_enum_files; i++) {
+            snprintf(temp2, sizeof(temp2), "File.cp%d", i);
+
+            if (FPDelete(Conn, vol, dir, temp2)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
+            }
+        }
+    }
+
+    /* -------- */
+    /* Server-side copy: duplicate the same 2000 files with FPCopyFile, so
+     * the data never crosses the wire (one AFP op per file). Contrast with
+     * the client-side copy above to show the round-trip savings. The copies
+     * are deleted untimed afterwards. */
+    if (teststorun[TEST_SERVERCOPY2000FILES]) {
+        static char temp2[MAXPATHLEN];
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
+        starttimer();
+
+        for (int32_t i = 1; i <= create_enum_files; i++) {
+            snprintf(temp, sizeof(temp), "File.0k%d", i);
+            snprintf(temp2, sizeof(temp2), "File.sc%d", i);
+
+            if (FPCopyFile(Conn, vol, dir, vol, dir, temp, "", temp2)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
+            }
+        }
+
+        stoptimer();
+        addresult(TEST_SERVERCOPY2000FILES, iteration_counter);
+
+        /* Cleanup (untimed): remove the copies. */
+        for (int32_t i = 1; i <= create_enum_files; i++) {
+            snprintf(temp2, sizeof(temp2), "File.sc%d", i);
+
+            if (FPDelete(Conn, vol, dir, temp2)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
+            }
+        }
+    }
+
+    /* -------- */
+    /* Stat each of the 2000 files created above: the same three metadata
+     * requests per file the old stat/open/read/close test issued in its stat
+     * phase. Reuses the pipeline's files, so this measures pure lookup and
+     * GetFileDirParams latency without any fork traffic. */
+    if (teststorun[TEST_STAT2000FILES]) {
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
+        starttimer();
+
+        for (int32_t i = 1; i <= create_enum_files; i++) {
+            snprintf(temp, sizeof(temp), "File.0k%d", i);
+
+            if (is_there(Conn, vol, dir, temp)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
+            }
+
+            if (FPGetFileDirParams(Conn, vol, dir, temp, 0x72d, 0)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
+            }
+
+            if (FPGetFileDirParams(Conn, vol, dir, temp, 0x73f, 0x133f)) {
+                clean_exit(ERROR_FILE_DIRECTORY_OPS);
+            }
+        }
+
+        stoptimer();
+        addresult(TEST_STAT2000FILES, iteration_counter);
+    }
+
+    /* -------- */
+    /* Test (9) */
+    if (teststorun[TEST_ENUM2000FILES]) {
+#ifdef __linux__
+        capture_io_values(TEST_START);
+#endif
+        starttimer();
+
+        if (FPEnumerateFull(Conn, vol, 1, 40, DSI_DATASIZ, dir, "",
+                            (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
+                            (1 << FILPBIT_FINFO) | (1 << FILPBIT_CDATE) | (1 << FILPBIT_BDATE) |
+                            (1 << FILPBIT_MDATE) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
+                            ,
+                            (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
+                            (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
+                            (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                            (1 << DIRPBIT_ACCESS))) {
+            clean_exit(ERROR_NETWORK_PROTOCOL);
+        }
+
+        for (int32_t i = 41; (i + 40) < create_enum_files; i += 80) {
+            if (FPEnumerateFull(Conn, vol, (uint16_t)(i + 40), 40, DSI_DATASIZ, dir, "",
+                                (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
+                                (1 << FILPBIT_FINFO) | (1 << FILPBIT_CDATE) | (1 << FILPBIT_BDATE) |
+                                (1 << FILPBIT_MDATE) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
+                                ,
+                                (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
+                                (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
+                                (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                (1 << DIRPBIT_ACCESS))) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+
+            if (FPEnumerateFull(Conn, vol, (uint16_t)i, 40, DSI_DATASIZ, dir, "",
+                                (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
+                                (1 << FILPBIT_FINFO) | (1 << FILPBIT_CDATE) | (1 << FILPBIT_BDATE) |
+                                (1 << FILPBIT_MDATE) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
+                                ,
+                                (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
+                                (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
+                                (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
+                                (1 << DIRPBIT_ACCESS))) {
+                clean_exit(ERROR_NETWORK_PROTOCOL);
+            }
+        }
+
+        stoptimer();
+        addresult(TEST_ENUM2000FILES, iteration_counter);
+    }
+
+    /* -------- */
+    /* Test (10): fork/refnum scaling. Reuses the 2000 files created above
      * (force-enabled via -f, like enum/delete). Opens all 2000 forks first
      * so the server's open-fork (refnum) table is fully populated, then
      * times locking and unlocking one byte-range in each. The timed region
@@ -1270,115 +1491,7 @@ void run_test(const int32_t dir)
     }
 
     /* -------- */
-    /* Stat, open, read 512 bytes, close each of the 2000 files written above.
-     * Reuses the pipeline's files (created by CREATE2000FILES, given data by
-     * WRITE2000FILES), so this measures the access pattern without its own
-     * setup. */
-    if (teststorun[TEST_OPENSTATREAD]) {
-#ifdef __linux__
-        capture_io_values(TEST_START);
-#endif
-        starttimer();
-
-        for (int32_t i = 1; i <= create_enum_files; i++) {
-            snprintf(temp, sizeof(temp), "File.0k%d", i);
-
-            /* Stat */
-            if (is_there(Conn, vol, dir, temp)) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            if (FPGetFileDirParams(Conn, vol, dir, temp, 0x72d, 0)) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            if (FPGetFileDirParams(Conn, vol, dir, temp, 0x73f, 0x133f)) {
-                clean_exit(ERROR_FILE_DIRECTORY_OPS);
-            }
-
-            /* Open */
-            fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0x342, dir, temp,
-                              OPENACC_RD | OPENACC_DWR);
-
-            if (!fork) {
-                clean_exit(ERROR_FORK_OPERATIONS);
-            }
-
-            if (FPGetForkParam(Conn, fork, (1 << FILPBIT_DFLEN))) {
-                clean_exit(ERROR_FORK_OPERATIONS);
-            }
-
-            if (FPGetForkParam(Conn, fork, 0x242)) {
-                clean_exit(ERROR_FORK_OPERATIONS);
-            }
-
-            /* Read */
-            if (FPRead(Conn, fork, 0, 512, data)) {
-                clean_exit(ERROR_NETWORK_PROTOCOL);
-            }
-
-            /* Close */
-            if (FPCloseFork(Conn, fork)) {
-                clean_exit(ERROR_NETWORK_PROTOCOL);
-            }
-        }
-
-        stoptimer();
-        addresult(TEST_OPENSTATREAD, iteration_counter);
-    }
-
-    /* -------- */
-    /* Test (6) */
-    if (teststorun[TEST_ENUM2000FILES]) {
-#ifdef __linux__
-        capture_io_values(TEST_START);
-#endif
-        starttimer();
-
-        if (FPEnumerateFull(Conn, vol, 1, 40, DSI_DATASIZ, dir, "",
-                            (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
-                            (1 << FILPBIT_FINFO) | (1 << FILPBIT_CDATE) | (1 << FILPBIT_BDATE) |
-                            (1 << FILPBIT_MDATE) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
-                            ,
-                            (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
-                            (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
-                            (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-                            (1 << DIRPBIT_ACCESS))) {
-            clean_exit(ERROR_NETWORK_PROTOCOL);
-        }
-
-        for (int32_t i = 41; (i + 40) < create_enum_files; i += 80) {
-            if (FPEnumerateFull(Conn, vol, (uint16_t)(i + 40), 40, DSI_DATASIZ, dir, "",
-                                (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
-                                (1 << FILPBIT_FINFO) | (1 << FILPBIT_CDATE) | (1 << FILPBIT_BDATE) |
-                                (1 << FILPBIT_MDATE) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
-                                ,
-                                (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
-                                (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
-                                (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-                                (1 << DIRPBIT_ACCESS))) {
-                clean_exit(ERROR_NETWORK_PROTOCOL);
-            }
-
-            if (FPEnumerateFull(Conn, vol, (uint16_t)i, 40, DSI_DATASIZ, dir, "",
-                                (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
-                                (1 << FILPBIT_FINFO) | (1 << FILPBIT_CDATE) | (1 << FILPBIT_BDATE) |
-                                (1 << FILPBIT_MDATE) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
-                                ,
-                                (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
-                                (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
-                                (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-                                (1 << DIRPBIT_ACCESS))) {
-                clean_exit(ERROR_NETWORK_PROTOCOL);
-            }
-        }
-
-        stoptimer();
-        addresult(TEST_ENUM2000FILES, iteration_counter);
-    }
-
-    /* -------- */
-    /* Test (7) */
+    /* Test (11) */
     if (teststorun[TEST_DELETE2000FILES]) {
 #ifdef __linux__
         capture_io_values(TEST_START);
@@ -1538,7 +1651,7 @@ void run_test(const int32_t dir)
     }
 
     /* -------- */
-    /* Test (8) */
+    /* Test (13) */
     if (teststorun[TEST_DIRTREE]) {
         uint32_t idirs[DIRNUM];
         uint32_t jdirs[DIRNUM][DIRNUM];
@@ -1584,7 +1697,7 @@ void run_test(const int32_t dir)
     }
 
     /* -------- */
-    /* Test (9) - Directory Cache Hits */
+    /* Test (14) - Directory Cache Hits */
     if (teststorun[TEST_CACHE_HITS]) {
         /* Validate configuration to prevent excessive allocation */
         if (cache_dirs <= 0 || cache_dirs > 100 || cache_files_per_dir <= 0
@@ -1682,7 +1795,7 @@ void run_test(const int32_t dir)
     }
 
     /* -------- */
-    /* Test (10) - Mixed Cache Operations */
+    /* Test (15) - Mixed Cache Operations */
     if (teststorun[TEST_MIXED_CACHE_OPS]) {
 #ifdef __linux__
         capture_io_values(TEST_START);
@@ -1731,7 +1844,7 @@ void run_test(const int32_t dir)
     }
 
     /* -------- */
-    /* Test (11) - Deep Path Traversal */
+    /* Test (16) - Deep Path Traversal */
     if (teststorun[TEST_DEEP_TRAVERSAL]) {
         /* Validate configuration to prevent issues */
         if (deep_dir_levels <= 0 || deep_dir_levels > 100) {
@@ -1805,7 +1918,7 @@ void run_test(const int32_t dir)
     }
 
     /* -------- */
-    /* Test (12) - Cache Validation Efficiency */
+    /* Test (17) - Cache Validation Efficiency */
     if (teststorun[TEST_CACHE_VALIDATION]) {
         /* Create test files for validation testing */
         for (int32_t i = 0; i < validation_files; i++) {
@@ -1876,7 +1989,7 @@ void usage(char *av0)
     fprintf(stdout, "\t-7\tAFP 3.4 version (default)\n");
     fprintf(stdout, "\t-b\tdebug mode\n");
     fprintf(stdout, "\t-c\toutput results in CSV format (default: tabular)\n");
-    fprintf(stdout, "\t-K\trun cache-focused tests only (tests 11-14)\n");
+    fprintf(stdout, "\t-K\trun cache-focused tests only (tests 14-17)\n");
     fprintf(stdout, "\t-f\ttests to run, eg 134 for tests 1, 3 and 4\n");
     fprintf(stdout,
             "\t-F\tuse this file located in the volume root for the read test (size must match -g and -G options)\n");
@@ -1899,7 +2012,7 @@ void usage(char *av0)
         fprintf(stdout, "\n");
     }
 
-    fprintf(stdout, "\n\tCache-focused tests (11-14) are designed to highlight\n");
+    fprintf(stdout, "\n\tCache-focused tests (14-17) are designed to highlight\n");
     fprintf(stdout, "\tdirectory cache performance improvements in netatalk.\n");
     fprintf(stdout, "\tThese tests benefit significantly from optimized cache\n");
     fprintf(stdout, "\tvalidation and probabilistic validation features.\n");
@@ -2145,16 +2258,19 @@ int main(int32_t ac, char **av)
             teststorun[TEST_WRITE100MB] = 1;
         }
 
-        /* OPENSTATREAD reads the 2000 files, so it needs them written first. */
-        if (teststorun[TEST_OPENSTATREAD]) {
+        /* READ2000FILES and both copy tests read the 2000 files' contents,
+         * so they need them written first. */
+        if (teststorun[TEST_READ2000FILES]
+                || teststorun[TEST_COPY2000FILES]
+                || teststorun[TEST_SERVERCOPY2000FILES]) {
             teststorun[TEST_WRITE2000FILES] = 1;
         }
 
         /* Every test that reuses the shared 2000-file set needs them created.
-         * WRITE2000FILES is also implied by OPENSTATREAD (above). */
+         * WRITE2000FILES may also be implied above. */
         if (teststorun[TEST_WRITE2000FILES]
                 || teststorun[TEST_FORK2000LOCKS]
-                || teststorun[TEST_OPENSTATREAD]
+                || teststorun[TEST_STAT2000FILES]
                 || teststorun[TEST_ENUM2000FILES]
                 || teststorun[TEST_DELETE2000FILES]) {
             teststorun[TEST_CREATE2000FILES] = 1;


### PR DESCRIPTION
Split the combined "Stat, open, read 512 bytes, close 2000 files" test into two focused tests: "Stat 2000 files" (the same three metadata requests per file) and "Read 512 bytes from 2000 files" (one FPRead per file, with the opens and closes untimed so the timed region is pure small-read latency).

Add two copy tests over the same shared 2000-file set, ordered after the small-file write test: a client-side copy (open/read/close then create/open/write/close per file) and a server-side copy (one FPCopyFile per file), so the round-trip savings of server-side copy is directly visible on the latency chart.

Update the LatencyGraph plot script with short labels for the new tests and widen the divider bracket to span the whole 2000-file group (Create 2k through Byte lock 2k). Tighten the bottom margin and x-label rotation. Refresh the manpage with per-test AFP operation breakdowns and a current example capture; TOTAL_AFP_OPS is now 59486.