### PR TITLE
ci: install libbstring dependency for OmniOS

### DIFF
--- a/.github/workflows/spectest-vms.yml
+++ b/.github/workflows/spectest-vms.yml
@@ -479,6 +479,7 @@ jobs:
               iniparser \
               libev \
               file \
+              libbstring \
               libgcrypt \
               meson \
               mysql-client \


### PR DESCRIPTION
the SmartOS pkgsrc repo has recently started distributing a binary libbstring package, so let's use it instead of building it from scratch