### PR TITLE
introduce bstring compatibility header

### DIFF
--- a/.github/workflows/spectest-vms.yml
+++ b/.github/workflows/spectest-vms.yml
@@ -28,6 +28,7 @@ env:
   CMARK_TARBALL_URL: https://github.com/commonmark/cmark/archive/refs/tags/0.31.2.tar.gz
   INIPARSER_TARBALL_URL: https://gitlab.com/iniparser/iniparser/-/archive/v4.2.6/iniparser-v4.2.6.tar.gz
   SMARTOS_BOOTSTRAP_URL: https://pkgsrc.smartos.org/packages/SmartOS/bootstrap/bootstrap-2025Q4-x86_64.tar.gz
+  SMARTOS_BOOTSTRAP_SHA256: 4842f72b610d44cf98560253b6bf16ff4056016e5fe2c6932bc195156ac75772
   STUFFIT_RS_TARBALL_URL: https://github.com/benletchford/stuffit-rs/archive/refs/tags/v0.2.0.tar.gz
 
 jobs:
@@ -467,6 +468,11 @@ jobs:
             # The bootstrap is used to install the required dependencies for building netatalk on OmniOS.
             # This step can be skipped if the bootstrap is already installed.
             curl --proto '=https' --location --fail -o bootstrap.tar.gz "${{ env.SMARTOS_BOOTSTRAP_URL }}"
+            bootstrap_sha256=$(digest -a sha256 bootstrap.tar.gz)
+            if [ "$bootstrap_sha256" != "${{ env.SMARTOS_BOOTSTRAP_SHA256 }}" ]; then
+              echo "bootstrap.tar.gz SHA-256 mismatch" >&2
+              exit 1
+            fi
             tar -zxpf bootstrap.tar.gz -C /
             export PATH=/opt/local/sbin:/opt/local/bin:/usr/gnu/bin:/usr/bin:/usr/sbin:/sbin:$PATH
             pkgin -y install \

--- a/bin/nad/nad_cp.c
+++ b/bin/nad/nad_cp.c
@@ -65,9 +65,8 @@
 #include <sys/sysinfo.h>
 #endif
 
-#include <bstrlib.h>
-
 #include <atalk/adouble.h>
+#include <atalk/bstrlib_compat.h>
 #include <atalk/queue.h>
 #include <atalk/unix.h>
 #include <atalk/util.h>

--- a/bin/nad/nad_mkdir.c
+++ b/bin/nad/nad_mkdir.c
@@ -27,9 +27,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <bstrlib.h>
-
 #include <atalk/adouble.h>
+#include <atalk/bstrlib_compat.h>
 #include <atalk/util.h>
 #include <atalk/vfs.h>
 #include <atalk/volume.h>

--- a/bin/nad/nad_mv.c
+++ b/bin/nad/nad_mv.c
@@ -28,9 +28,8 @@
 #include <dirent.h>
 #include <unistd.h>
 
-#include <bstrlib.h>
-
 #include <atalk/adouble.h>
+#include <atalk/bstrlib_compat.h>
 #include <atalk/queue.h>
 #include <atalk/unix.h>
 #include <atalk/util.h>

--- a/bin/nad/nad_util.c
+++ b/bin/nad/nad_util.c
@@ -40,8 +40,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <bstrlib.h>
-
 #ifdef HAVE_FREEBSD_SUNACL
 #include <sunacl.h>
 #endif
@@ -63,6 +61,7 @@
 #endif /* HAVE_POSIX_ACLS */
 
 #include <atalk/adouble.h>
+#include <atalk/bstrlib_compat.h>
 #include <atalk/cnid.h>
 #include <atalk/errchk.h>
 #include <atalk/globals.h>

--- a/include/atalk/bstrlib_compat.h
+++ b/include/atalk/bstrlib_compat.h
@@ -1,0 +1,22 @@
+/*
+ * Compatibility wrapper for bstring.
+ *
+ * illumos declares a legacy bgets() function in libgen.h with a signature
+ * that conflicts with bstring's bgets().  Netatalk does not use bstring's
+ * bgets(), so hide that declaration while processing the system header.
+ */
+
+#ifndef ATALK_BSTRLIB_COMPAT_H
+#define ATALK_BSTRLIB_COMPAT_H 1
+
+#ifdef __sun
+#define bgets netatalk_unused_bstring_bgets
+#endif
+
+#include <bstrlib.h>
+
+#ifdef __sun
+#undef bgets
+#endif
+
+#endif /* ATALK_BSTRLIB_COMPAT_H */

--- a/libatalk/util/cnid.c
+++ b/libatalk/util/cnid.c
@@ -47,8 +47,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <bstrlib.h>
-
+#include <atalk/bstrlib_compat.h>
 #include <atalk/cnid.h>
 #include <atalk/errchk.h>
 #include <atalk/logger.h>

--- a/libatalk/util/unix.c
+++ b/libatalk/util/unix.c
@@ -38,6 +38,7 @@
 #include <atalk/acl.h>
 #include <atalk/adouble.h>
 #include <atalk/afp.h>
+#include <atalk/bstrlib_compat.h>
 #include <atalk/compat.h>
 #include <atalk/ea.h>
 #include <atalk/errchk.h>

--- a/libatalk/vfs/vfs.c
+++ b/libatalk/vfs/vfs.c
@@ -29,11 +29,10 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include <bstrlib.h>
-
 #include <atalk/acl.h>
 #include <atalk/adouble.h>
 #include <atalk/afp.h>
+#include <atalk/bstrlib_compat.h>
 #include <atalk/compat.h>
 #include <atalk/directory.h>
 #include <atalk/ea.h>


### PR DESCRIPTION
there is a long-running portability wrinkle in the bstring library in that it declares a 'bgets' symbol in the public API which directly conflicts with the libgen API in Solaris/illumos

https://docs.oracle.com/cd/E86824_01/html/E54772/libgen-3lib.html#REFMAN3Flibgen-3lib

we have worked around this in our own bstring builds by compiling away that symbol on Solaris/illumos

however, we have now encountered a bstring binary package in the wild (SmartOS pkgsrc) which does not have this workaround

therefore, I propose this compatibility header that undefs away the symbol instead, since we do not use it anywhere in our codebase

this also includes a sha256 validation of the SmartOS bootstrap tarball in our OmniOS CI build pipeline