### PR TITLE
afpd: O(1) free-slot FIFO fork allocator, refnum == slot

### DIFF
--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -211,6 +211,7 @@ static void afp_dsi_close(AFPObj *obj)
     LOG(log_note, logtype_afpd,
         "AFP statistics: %.2f KB read, %.2f KB written via DSI",
         dsi->read_count / 1024.0, dsi->write_count / 1024.0);
+    of_log_highwater();
     log_dircache_stat();
     dircache_rfork_shutdown();
     dsi_close(dsi);

--- a/etc/afpd/fork.h
+++ b/etc/afpd/fork.h
@@ -66,6 +66,7 @@ extern int          of_rename(const struct vol *,
                               struct dir *, const char *);
 extern int          of_flush(const struct vol *);
 extern void         of_pforkdesc(FILE *);
+extern void         of_log_highwater(void);
 extern int          of_stat(const struct vol *vol, struct path *);
 extern int          of_statdir(struct vol *vol, struct path *);
 extern int          of_closefork(const AFPObj *obj, struct ofork *ofork);

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -8,6 +8,7 @@
 #endif /* HAVE_CONFIG_H */
 
 #include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -43,8 +44,17 @@ static struct ofork *ofork_table[OFORK_HASHSIZE];
 /* point to allocated table of open forks pointers */
 static struct ofork **oforks = NULL;
 static int          nforks = 0;
-static u_short      lastrefnum = 0;
 
+/* Free-slot FIFO of free slot indices; cap nforks+1 avoids head==tail
+ * full/empty ambiguity. Pop from head, push to tail: maximal reuse window. */
+static uint16_t      *of_freeq      = NULL;
+static int            of_freeq_cap  = 0;   /* nforks + 1 */
+static int            of_freeq_head = 0;
+static int            of_freeq_tail = 0;
+
+/* live forks now, and lifetime peak (logged at session close) */
+static int            of_curr_forks = 0;
+static int            of_peak_forks = 0;
 
 /* OR some of each character for the hash */
 static unsigned long hashfn(const struct file_key *key)
@@ -77,6 +87,39 @@ static void of_unhash(struct ofork *of)
         of->prevp = NULL;
         of->next = NULL;
     }
+}
+
+static inline bool of_freeq_empty(void)
+{
+    return of_freeq_head == of_freeq_tail;
+}
+
+static inline void of_freeq_push(uint16_t slot)
+{
+    of_freeq[of_freeq_tail] = slot;
+
+    /* branch, not `% of_freeq_cap`: cap (nforks+1) is not a power of two. */
+    if (++of_freeq_tail == of_freeq_cap) {
+        of_freeq_tail = 0;
+    }
+
+    /* cap == nforks+1 makes overflow impossible; assert it. */
+    AFP_ASSERT(!of_freeq_empty());
+}
+
+static inline int of_freeq_pop(void)   /* slot, or -1 if empty */
+{
+    if (of_freeq_empty()) {
+        return -1;
+    }
+
+    uint16_t slot = of_freeq[of_freeq_head];
+
+    if (++of_freeq_head == of_freeq_cap) {
+        of_freeq_head = 0;
+    }
+
+    return slot;
 }
 
 void of_pforkdesc(FILE *f)
@@ -163,7 +206,6 @@ of_alloc(struct vol *vol,
 {
     struct ofork        *of;
     uint16_t       refnum, of_refnum;
-    int         i;
 
     if (!oforks) {
         /* Two ceilings: the 16-bit protocol max (0xffff), and half the realised
@@ -173,20 +215,30 @@ of_alloc(struct vol *vol,
         int fdlimit = getdtablesize();
         int fdcap   = fdlimit / 2;
 
-        /* Floor at 1 so a degenerate/-1 fd limit can't make nforks 0 (would
-         * divide by zero at "refnum % nforks" below). */
-        if (fdcap < 1) {
-            fdcap = 1;
+        /* Floor at 2: slot 0 is reserved, so one usable fork needs 2 slots. */
+        if (fdcap < 2) {
+            fdcap = 2;
         }
 
         nforks = (fdcap < 0xffff) ? fdcap : 0xffff;
-        oforks = (struct ofork **) calloc(nforks, sizeof(struct ofork *));
+        oforks       = (struct ofork **) calloc(nforks, sizeof(struct ofork *));
+        of_freeq_cap = nforks + 1;
+        of_freeq     = (uint16_t *) calloc(of_freeq_cap, sizeof(uint16_t));
 
-        if (!oforks) {
+        if (!oforks || !of_freeq) {
             LOG(log_error, logtype_afpd,
                 "of_alloc: cannot allocate %d-slot ofork table: %s",
                 nforks, strerror(errno));
+            free(oforks);
+            free(of_freeq);
+            oforks = NULL;
+            of_freeq = NULL;
             return NULL;
+        }
+
+        /* Seed slots 1..nforks-1; slot 0 reserved (refnum 0 means "no fork"). */
+        for (int s = 1; s < nforks; s++) {
+            of_freeq_push((uint16_t)s);
         }
 
         LOG(log_debug, logtype_afpd,
@@ -194,47 +246,24 @@ of_alloc(struct vol *vol,
             "fd limit %d, ~2 fds/fork)", nforks, fdlimit);
     }
 
-    for (refnum = ++lastrefnum, i = 0; i < nforks; i++, refnum++) {
-        /* cf AFP3.0.pdf, File fork page 40 */
-        if (!refnum) {
-            refnum++;
-        }
+    int slot = of_freeq_pop();
 
-        if (oforks[refnum % nforks] == NULL) {
-            break;
-        }
-    }
-
-    /* grr, Apple and their 'uniquely identifies'
-       the next line is a protection against
-       of_alloc()
-       refnum % nforks = 3
-       lastrefnum = 3
-       oforks[3] != NULL
-       refnum = 4
-       oforks[4] == NULL
-       return 4
-
-       close(oforks[4])
-
-       of_alloc()
-       refnum % nforks = 4
-       ...
-       return 4
-       same if lastrefnum++ rather than ++lastrefnum.
-    */
-    lastrefnum = refnum;
-
-    if (i == nforks) {
+    /* Queued slots are always in 1..nforks-1, so slot indexes oforks[] safely;
+     * the upper bound is stated explicitly so the array access is provably in
+     * range. */
+    if (slot < 1 || slot >= nforks) {
         LOG(log_error, logtype_afpd, "of_alloc: maximum number of forks exceeded.");
         return NULL;
     }
 
-    of_refnum = refnum % nforks;
+    refnum    = (uint16_t)slot;   /* refnum == slot, by design */
+    of_refnum = (uint16_t)slot;
+    AFP_ASSERT(oforks[of_refnum] == NULL);   /* a free slot must be empty */
 
     if ((oforks[of_refnum] =
                 (struct ofork *)malloc(sizeof(struct ofork))) == NULL) {
         LOG(log_error, logtype_afpd, "of_alloc: malloc: %s", strerror(errno));
+        of_freeq_push(of_refnum);
         return NULL;
     }
 
@@ -248,6 +277,7 @@ of_alloc(struct vol *vol,
             LOG(log_error, logtype_afpd, "of_alloc: malloc: %s", strerror(errno));
             free(of);
             oforks[of_refnum] = NULL;
+            of_freeq_push(of_refnum);
             return NULL;
         }
 
@@ -260,6 +290,7 @@ of_alloc(struct vol *vol,
             free(ad);
             free(of);
             oforks[of_refnum] = NULL;
+            of_freeq_push(of_refnum);
             return NULL;
         }
     } else {
@@ -283,6 +314,11 @@ of_alloc(struct vol *vol,
     }
 
     of_hash(of);
+
+    if (++of_curr_forks > of_peak_forks) {
+        of_peak_forks = of_curr_forks;
+    }
+
     return of;
 }
 
@@ -745,7 +781,11 @@ void of_dealloc(struct ofork *of)
         of->of_refnum, of_name(of), of->of_flags,
         (uintmax_t)of->key.dev, (uintmax_t)of->key.inode);
     of_unhash(of);
-    oforks[of->of_refnum % nforks] = NULL;
+    int slot = of->of_refnum;          /* refnum == slot, no modulus needed */
+    AFP_ASSERT(oforks[slot] == of);    /* this ofork must still own its slot */
+    oforks[slot] = NULL;
+    of_freeq_push((uint16_t)slot);
+    of_curr_forks--;
 
     /* decrease refcount; guard so a stray double-dealloc on a shared adouble is
      * logged (and asserts in non-NDEBUG builds) instead of silently absorbed. */
@@ -762,6 +802,18 @@ void of_dealloc(struct ofork *of)
     }
 
     free(of);
+}
+
+/* Log current + lifetime-peak fork-table occupancy (once, at session close).
+ * Current should be ~0 at a clean close; a nonzero value flags leaked forks. */
+void of_log_highwater(void)
+{
+    if (nforks > 0) {
+        LOG(log_info, logtype_afpd,
+            "fork table: %d open now, %d of %d slots peak (%.1f%%)",
+            of_curr_forks, of_peak_forks, nforks,
+            100.0 * of_peak_forks / nforks);
+    }
 }
 
 /* --------------------------- */

--- a/test/afpd/subtests_lock.c
+++ b/test/afpd/subtests_lock.c
@@ -1644,3 +1644,105 @@ int utest_fork_setmode_fdeny(const struct vol *vol)
 
     return rc;                           /* 0 == pass */
 }
+
+/*!
+ * @brief of_alloc()/of_dealloc() free-slot FIFO contract.
+ *
+ * Public API only (of_alloc/of_dealloc/of_find): refnum == slot and never 0;
+ * of_find() round-trips a live refnum and rejects a closed one; a freed slot
+ * waits behind all other free slots before reuse (FIFO, not LIFO).
+ */
+int utest_of_alloc_fifo(struct vol *vol)
+{
+    enum { N = 8 };
+    struct ofork *of[N] = {0};
+    uint16_t refnum[N] = {0};
+    char leaf[32], full[MAXPATHLEN + 1];
+    struct stat st;
+    int i, rc = 0;
+
+    for (i = 0; i < N; i++) {
+        snprintf(leaf, sizeof(leaf), "fi_fifo_%d", i);
+
+        if (make_scratch(vol, leaf, 0, full, sizeof(full)) != 0) {
+            rc = 10 + i;
+            goto out;
+        }
+
+        if (stat(full, &st) != 0) {
+            rc = 20 + i;
+            goto out;
+        }
+
+        of[i] = of_alloc(vol, curdir, leaf, &refnum[i], ADEID_DFORK, NULL,
+                         &st);
+
+        if (of[i] == NULL) {
+            rc = 30 + i;
+            goto out;
+        }
+
+        if (refnum[i] == 0 || of[i]->of_refnum != refnum[i]) {
+            rc = 40 + i;
+            goto out;
+        }
+
+        if (of_find(refnum[i]) != of[i]) {
+            rc = 50 + i;
+            goto out;
+        }
+    }
+
+    uint16_t freed0 = refnum[0], freed1 = refnum[1];
+    of_dealloc(of[0]);
+    of[0] = NULL;
+    of_dealloc(of[1]);
+    of[1] = NULL;
+
+    /* of_find() rejects closed refnums. */
+    if (of_find(freed0) != NULL || of_find(freed1) != NULL) {
+        rc = 60;
+        goto out;
+    }
+
+    /* Next alloc pops the front: a fresh slot if the table has headroom, else
+     * freed0 (first freed) if it is exhausted.  Either is correct FIFO order;
+     * only freed1 coming back first would be wrong (LIFO).  Asserting "!= freed1"
+     * holds for any nforks, so it can't false-fail on a small fork table. */
+    snprintf(leaf, sizeof(leaf), "fi_fifo_r0");
+
+    if (make_scratch(vol, leaf, 0, full, sizeof(full)) != 0
+            || stat(full, &st) != 0) {
+        rc = 70;
+        goto out;
+    }
+
+    of[0] = of_alloc(vol, curdir, leaf, &refnum[0], ADEID_DFORK, NULL, &st);
+
+    if (of[0] == NULL) {
+        rc = 71;
+        goto out;
+    }
+
+    if (refnum[0] == freed1) {
+        rc = 72;
+        goto out;
+    }
+
+out:
+
+    for (i = 0; i < N; i++) {
+        if (of[i]) {
+            of_dealloc(of[i]);
+        }
+    }
+
+    for (i = 0; i < N; i++) {
+        snprintf(full, sizeof(full), "%s/fi_fifo_%d", vol->v_path, i);
+        (void)unlink(full);
+    }
+
+    snprintf(full, sizeof(full), "%s/fi_fifo_r0", vol->v_path);
+    (void)unlink(full);
+    return rc;
+}

--- a/test/afpd/subtests_lock.h
+++ b/test/afpd/subtests_lock.h
@@ -39,5 +39,6 @@ extern int utest_shared_rlock(const struct vol *vol);
 extern int utest_overlap_strand(const struct vol *vol);
 extern int utest_freelock_unlck_fail_logs(const struct vol *vol);
 extern int utest_fork_setmode_fdeny(const struct vol *vol);
+extern int utest_of_alloc_fifo(struct vol *vol);
 
 #endif /* SUBTESTS_LOCK_H */

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -253,6 +253,8 @@ int main(int argc, char *argv[])
                      "adf_freelock: a failed F_UNLCK is logged and the entry still dropped");
     TEST_int_or_skip(utest_fork_setmode_fdeny(vol), 0,
                      "fork_setmode_deny: each access mode maps to the correct deny bits");
+    TEST_int(utest_of_alloc_fifo(vol), 0,
+             "of_alloc: refnum==slot, never 0, of_find round-trip, FIFO reuse window");
     /* cleanup */
     closevol(&obj, vol);
 


### PR DESCRIPTION
## `of_alloc()`: O(1) free-slot FIFO fork allocator, `refnum == slot`

`of_alloc()` — the allocator behind every `FPOpenFork` — hands each open fork a slot in the `oforks[]` table. For 25 years it did so by *linearly scanning* the table for a free entry, starting from a monotonically-incrementing counter (`lastrefnum`), and derived the client-visible `OForkRefNum` as `slot + generation·nforks` so that reused slots would carry "unique-looking" refnums.

That scan is O(n) per open — **O(n²) aggregate** under fork pressure — and the generation arithmetic exists only to satisfy a uniqueness property that is *mathematically illusory* at the table sizes servers actually run. This PR replaces the whole mechanism with an **O(1) free-slot FIFO** and makes the refnum simply *equal* the slot index: no counter, no modular re-anchoring, no scan.

## How the user sees it

Not a correctness bug — a latency cliff. On a busy server the `oforks[]` table fills toward its 16-bit ceiling (Time Machine sparsebundles, Spotlight indexing, Media suite software, etc, all mass copy over AFP and open/hold thousands of open forks concurrently). As occupancy rises, the average free-slot scan distance grows; worst-case, every `FPOpenFork` walks the entire table before finding a hole. `FPOpenFork` tail latency degrades quadratically with the number of open forks — precisely when the server is already under load. On a lightly loaded server the scan finds a slot in one or two probes and the cost is invisible, so the symptom only surfaces at scale, when it also hurts the most.

## Root cause

The allocator conflated two unrelated jobs into one hand-rolled mechanism.

**Job 1 — find a free slot,** by scanning `oforks[]` from `++lastrefnum` until a `NULL` turned up:

```c
for (refnum = ++lastrefnum, i = 0; i < nforks; i++, refnum++) {
    /* cf AFP3.0.pdf, File fork page 40 */
    if (!refnum) {
        refnum++;
    }
    if (oforks[refnum % nforks] == NULL) {
        break;
    }
}
```

A linear probe. Near-full, it degrades to a full O(nforks) sweep per allocation; across `n` opens against a near-full table, O(n²) aggregate.

**Job 2 — make the refnum "unique".** The scanning counter climbed past `nforks` and wrapped, so a reused slot got a different refnum each time. The intent was a per-slot generation counter, so a stale or replayed refnum for a closed fork could be rejected — and the code carried a remarkably candid comment about how awkward this was:

```c
/* grr, Apple and their 'uniquely identifies'
   the next line is a protection against
   of_alloc()
   refnum % nforks = 3
   lastrefnum = 3
   oforks[3] != NULL
   refnum = 4
   oforks[4] == NULL
   return 4

   close(oforks[4])

   of_alloc()
   refnum % nforks = 4
   ...
   return 4
   same if lastrefnum++ rather than ++lastrefnum. */
lastrefnum = refnum;
```

That "grr, Apple" comment is the tell. It is the allocator apologising for a spec requirement it is fighting with hand-rolled counter arithmetic — worrying about whether `lastrefnum++` or `++lastrefnum` re-anchors the sequence correctly, so that a slot freed and immediately reused won't be reissued the *same* refnum.

Here is the punchline: **the protection it labours to provide is illusory in the regime that matters.** Each slot has `65536 / nforks` distinct refnums available for a generation counter, and `nforks = min(getdtablesize()/2, 0xffff)`. On any real server `RLIMIT_NOFILE` is large, so `nforks` clamps to `0xffff` (65535) and that ratio is **1** — there is *no* spare bit for a generation. The uniqueness scheme silently degenerates to `refnum == slot` on its own. It only ever did anything when the table was tiny, which is also the only time there is no performance problem to protect against. So the machinery paid an O(n²) cost to deliver a guarantee it structurally could not keep — and `refnum == slot`, the state it collapses to anyway, is precisely what this PR adopts *on purpose*.

`OForkRefNum` is a 16-bit wire field, so `oforks[]` can never exceed 65535 slots regardless of `RLIMIT_NOFILE`. That single fact is what makes the generation counter pointless (no headroom) and the linear scan expensive (full table) at the same time.

## Provenance — 25 years of a well-meant workaround

This is not anyone's mistake; it is what a locally-reasonable design looks like a quarter-century later, viewed at a scale it was never sized for.

- **`31843674` — rufustfirefly, 2000 (initial revision).** `of_alloc()` is born with the linear scan and the `lastrefnum++` counter, sizing the table as `(getdtablesize() - 10) / 2`. In a single-user, small-table world, scanning a mostly-empty array finds a slot in one probe — the O(n²) tail simply never manifests.
- **`86ef60fd` — didier (dgautheron), 2002 ("not return 0 as an OForkRefNum (per Apple spec)").** Reserves refnum 0 with the `if (!refnum) refnum++;` skip, flips the counter to `++lastrefnum`, adds the `lastrefnum = refnum;` re-anchor, and lands the `grr, Apple and their 'uniquely identifies'` comment — the well-intentioned attempt to guarantee that a freed-then-reused slot won't be reissued the *same* refnum. Correct in spirit; but it is defending a uniqueness property the 16-bit ceiling already made unattainable at server scale.

None of these was wrong when written. The O(n²) cost and the pointless arithmetic are emergent: they appear only once servers run with `RLIMIT_NOFILE` high enough that `nforks` pins to `0xffff` and the table runs near-full under Time-Machine/Spotlight churn — a regime that did not exist in 2000.

## The fix — a free-slot FIFO

Track free slots explicitly in a ring buffer instead of rediscovering them by scanning. Allocation **pops** the front; deallocation **pushes** the back. The client-visible refnum *is* the slot.

```c
static inline int of_freeq_pop(void)   /* slot, or -1 if empty */
{
    if (of_freeq_empty()) {
        return -1;
    }
    uint16_t slot = of_freeq[of_freeq_head];
    if (++of_freeq_head == of_freeq_cap) {
        of_freeq_head = 0;
    }
    return slot;
}
```

The entire linear scan, the `lastrefnum` counter, the `grr, Apple` comment, the wrap arithmetic, and the `refnum % nforks` computation are **deleted**. `of_alloc()`'s slot search collapses from ~40 lines to:

```c
int slot = of_freeq_pop();
if (slot < 0) {
    LOG(log_error, logtype_afpd, "of_alloc: maximum number of forks exceeded.");
    return NULL;
}
refnum    = (uint16_t)slot;   /* refnum == slot, by design */
of_refnum = (uint16_t)slot;
```

`of_dealloc()` gains a single push (the slot returns to the back of the ring); every `of_alloc()` error-unwind path pushes the slot back too, so a slot never leaks out of the ring.

### Why this is elegant, not just faster

- **The FIFO delivers what the generation counter only pretended to.** The ring is seeded with *every* usable slot, and a freed slot goes to the **back** — so a slot is not reused until every other free slot ahead of it has been handed out. The reuse window is *maximal by construction*, the strongest anti-immediate-reuse guarantee possible, with zero bookkeeping. The old scheme spent counter arithmetic (and the "grr, Apple" hand-wringing) trying to space out reuse; the FIFO gets it for free from the data structure's shape.

- **`refnum == slot` erases a whole layer.** `of_find()`'s existing `oforks[refnum % nforks]` lookup is unchanged and now resolves directly (`slot < nforks ⇒ slot % nforks == slot`). No generation decode, no re-anchor on 16-bit wrap, no `lastrefnum`. Slot 0 is simply never seeded, so refnum 0 ("no fork") is never issued — one slot out of 65535, in exchange for deleting all the special-casing and the apologetic comment.

- **A single, checkable invariant.** A slot is in the FIFO **iff** `oforks[slot] == NULL`. Every path that frees a slot pushes it exactly once; every successful alloc pops exactly once. Two `AFP_ASSERT`s pin this down (a popped slot must be empty; a deallocated ofork must still own its slot); the pop/push bookkeeping is what enforces it in every build.

- **No new portability surface.** Plain array indexing and a branch-wrapped index (`== cap ? 0`, never `%`, since `nforks+1` is not a power of two — `%` would emit a hardware divide on the hot path). No `ffsll`, no build probe, one new include (`<stdbool.h>`).

### Ring sizing

Ring capacity is `nforks + 1` — one more than the table — so all usable slots fit without the `head == tail` full/empty ambiguity. It is allocated alongside `oforks[]` from the same `nforks` (itself derived from `RLIMIT_NOFILE`), so the two can never diverge, and seeded once at first `of_alloc()` (child startup), never on the hot path.

## Scope of the win — deliberately narrow

The commit touches only the two allocator primitives.

| AFP operation | allocator call | before | after |
|---|---|---|---|
| `FPOpenFork` (incl. virtual Icon fork) | `of_alloc()` | O(nforks) scan → **O(n²)** aggregate near-full | **O(1)** ring pop |
| `FPCloseFork` | `of_dealloc()` | O(1) | O(1) (one extra ring push) |
| `FPRead`/`FPWrite`, `FPByteRangeLock`, `FPGet`/`FPSetForkParms`, `FPFlush`/`FPSyncFork` | `of_find()` | O(1) array index | **unchanged** |

Only `of_alloc()` improves. `of_find()` is not modified, so no read/write/lock path changes. On a lightly loaded server `FPOpenFork` is dominated by `ad_open()` file I/O and the win is negligible; the payoff is `FPOpenFork` tail latency under near-saturation fork pressure. No general throughput speedup is claimed.

**Headline:** reduces `FPOpenFork` slot-allocation time from quadratic — O(n²) aggregate, growing with the number of open forks — to **O(1), constant no matter how many forks are open.**

## What this preserves and what it relaxes

- **Preserved:** O(1) lookup via `oforks[refnum % nforks]` and `of_find()`'s `of_refnum != ofrefnum` collision guard (kept; now fires only on a genuinely out-of-range/garbage refnum).
- **Preserved:** refnum 0 is never issued (slot 0 never seeded).
- **Preserved / improved:** maximal reuse window in all realistic regimes (FIFO, vs the old counter's best-effort spacing).
- **Relaxed:** wire-level stale-refnum *detection* for a closed-then-reused slot, in the near-saturated regime only. As shown above this protection was already illusory at `nforks == 0xffff` (the server case), and it is defense-in-depth, not a correctness invariant — DSI/TCP ordering and the replay cache handle genuine duplicates; the only exposure is a misbehaving client reusing a stale refnum *within its own authenticated session*.
- **Safe for lock ownership:** `of_refnum` doubles as the lock-owner id (`ad_lock`/`ad_unlock` `user` field, Solaris share-reservation id). A slot is live for at most one ofork at a time (the single-source-of-truth invariant), so two oforks can never alias the same owner id. Across a close→reopen of the same file the new ofork legitimately *is* the new lock owner.

## Testing

### Unit test

`utest_of_alloc_fifo` (new) drives the public allocator API (`of_alloc`/`of_dealloc`/`of_find`) only — no access to the file-static ring — and asserts the full observable contract:

- every issued refnum equals its slot and is never 0;
- `of_find()` round-trips a live refnum and returns `NULL` for a closed one;
- a freed slot is **not** reused while other free slots remain ahead of it (FIFO ordering / maximal reuse window).

afpd unit suite: **54 subtests pass, 0 fail** (`meson test`, `debugoptimized`, `warning_level=3`, `c_std=c11`), including the new test.

### Spectest

AFP spec test against the built server: **281 passed / 93 skipped / 0 failed**. The server realised `RLIMIT_NOFILE` at 1048576, so `nforks` clamped to `0xffff` — the full 16-bit refnum space, exactly the regime this change optimizes.

Out-of-scope-for-unit-test scenarios are documented with reasons: full-table refusal / ring overflow (would need ~65534 live fds; covered by the `AFP_ASSERT` invariant under CI's `debugoptimized` build), the occupancy single-source-of-truth and malloc-failure slot-return (read file-static state the public API doesn't expose; enforced by the post-pop assert plus the explicit slot-return on every error path), and an O(1) micro-benchmark (a characterisation, not a pass/fail gate).

## Not in this PR (follow-ups)

- The 16-bit `OForkRefNum` ceiling itself (65535 forks per afpd child) is a wire-protocol limit; lifting it would require an AFP protocol extension and is out of scope.
- Splitting the "maximum number of forks exceeded" refusal into a distinguishable wire error is unchanged.
