### PR TITLE
afpd: use fixed-width AFP text encoding hints

### DIFF
--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -2194,7 +2194,6 @@ int getdirparams(const AFPObj *obj,
     uint32_t           aint;
     uint16_t       ashort;
     int                 ret;
-    uint32_t           utf8 = 0;
     cnid_t              pdid;
     struct stat *st = &s_path->st;
     char *upath = s_path->u_name;
@@ -2383,8 +2382,6 @@ int getdirparams(const AFPObj *obj,
         case DIRPBIT_PDINFO :
             if (obj->afp_version >= 30) {
                 /* UTF8 name */
-                utf8 = kTextEncodingUTF8;
-
                 /* root of parent can have a null name */
                 if (dir->d_m_name) {
                     utf_nameoff = data;
@@ -2440,13 +2437,15 @@ int getdirparams(const AFPObj *obj,
     if (l_nameoff) {
         ashort = htons(data - buf);
         memcpy(l_nameoff, &ashort, sizeof(ashort));
-        data = set_name(vol, data, pdid, cfrombstr(dir->d_m_name), dir->d_did, 0);
+        data = set_name(vol, data, pdid, cfrombstr(dir->d_m_name), dir->d_did,
+                        false);
     }
 
     if (utf_nameoff) {
         ashort = htons(data - buf);
         memcpy(utf_nameoff, &ashort, sizeof(ashort));
-        data = set_name(vol, data, pdid, cfrombstr(dir->d_m_name), dir->d_did, utf8);
+        data = set_name(vol, data, pdid, cfrombstr(dir->d_m_name), dir->d_did,
+                        true);
     }
 
     *buflen = data - buf;

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -246,7 +246,7 @@ void *get_finderinfo(const struct vol *vol, const char *upath,
 /* ---------------------
 */
 char *set_name(const struct vol *vol, char *data, cnid_t pid, char *name,
-               cnid_t id, uint32_t utf8)
+               cnid_t id, bool utf8)
 {
     uint32_t   aint;
     uint32_t   tp_len = 0;
@@ -277,6 +277,7 @@ char *set_name(const struct vol *vol, char *data, cnid_t pid, char *name,
 
         *data++ = aint;
     } else {
+        uint32_t encoding_hint;
         uint16_t temp;
 
         /* FIXME safeguard, anyway if no ascii char it's game over */
@@ -284,9 +285,9 @@ char *set_name(const struct vol *vol, char *data, cnid_t pid, char *name,
             aint = UTF8FILELEN_EARLY;
         }
 
-        utf8 = (uint32_t) vol->v_kTextEncoding;
-        memcpy(data, &utf8, sizeof(utf8));
-        data += sizeof(utf8);
+        encoding_hint = vol->v_kTextEncoding;
+        memcpy(data, &encoding_hint, sizeof(encoding_hint));
+        data += sizeof(encoding_hint);
         temp = htons(aint);
         memcpy(data, &temp, sizeof(temp));
         data += sizeof(temp);
@@ -411,7 +412,6 @@ int getmetadata(const AFPObj *obj,
     cnid_t              id = 0;
     uint16_t		ashort;
     uint8_t              achar, fdType[4];
-    uint32_t           utf8 = 0;
     struct stat         *st;
     struct maccess	ma;
     int                 timeoffset = 0;
@@ -673,7 +673,6 @@ int getmetadata(const AFPObj *obj,
            <shirsch@adelphia.net> */
         case FILPBIT_PDINFO :
             if (obj->afp_version >= 30) { /* UTF8 name */
-                utf8 = kTextEncodingUTF8;
                 utf_nameoff = data;
                 data += sizeof(uint16_t);
                 aint = 0;
@@ -794,13 +793,13 @@ int getmetadata(const AFPObj *obj,
     if (l_nameoff) {
         ashort = htons(data - buf);
         memcpy(l_nameoff, &ashort, sizeof(ashort));
-        data = set_name(vol, data, dir->d_did, path->m_name, id, 0);
+        data = set_name(vol, data, dir->d_did, path->m_name, id, false);
     }
 
     if (utf_nameoff) {
         ashort = htons(data - buf);
         memcpy(utf_nameoff, &ashort, sizeof(ashort));
-        data = set_name(vol, data, dir->d_did, path->m_name, id, utf8);
+        data = set_name(vol, data, dir->d_did, path->m_name, id, true);
     }
 
     *buflen = data - buf;

--- a/etc/afpd/file.h
+++ b/etc/afpd/file.h
@@ -52,11 +52,15 @@ extern const uint8_t	ufinderi[];
 #define FILPBIT_EXTRFLEN 14
 #define FILPBIT_UNIXPR   15
 
-#define kTextEncodingUTF8 0x08000103
+#define kTextEncodingUTF8 UINT32_C(0x08000103)
 
-/*! Mac OS encodings*/
+/*! AFP 3.4 text encoding identifiers.
+ *
+ * Availability in this enum does not imply that Netatalk has a converter for
+ * the encoding.
+ */
 typedef enum {
-    kTextEncodingMacRoman         = 0L,
+    kTextEncodingMacRoman         = 0,
     kTextEncodingMacJapanese      = 1,
     kTextEncodingMacChineseTrad   = 2,
     kTextEncodingMacKorean        = 3,
@@ -96,10 +100,71 @@ typedef enum {
     kTextEncodingMacCeltic        = 39,
     kTextEncodingMacGaelic        = 40,
     kTextEncodingMacKeyboardGlyphs = 41,
+    kTextEncodingMacUnicode       = 126,
+    kTextEncodingMacFarsi         = 140,
+    kTextEncodingMacUkrainian     = 152,
+    kTextEncodingMacInuit         = 236,
+    kTextEncodingMacVT100         = 252,
+    kTextEncodingMacHFS           = 255,
+    kTextEncodingUnicodeDefault   = 256,
+    kTextEncodingUnicodeV1_1      = 257,
+    kTextEncodingISO10646_1993    = 257,
+    kTextEncodingUnicodeV2_0      = 259,
+    kTextEncodingUnicodeV2_1      = 259,
+    kTextEncodingUnicodeV3_0      = 260,
+    kTextEncodingISOLatin1        = 513,
+    kTextEncodingISOLatin2        = 514,
+    kTextEncodingISOLatin3        = 515,
+    kTextEncodingISOLatin4        = 516,
+    kTextEncodingISOLatinCyrillic = 517,
+    kTextEncodingISOLatinArabic   = 518,
+    kTextEncodingISOLatinGreek    = 519,
+    kTextEncodingISOLatinHebrew   = 520,
+    kTextEncodingISOLatin5        = 521,
+    kTextEncodingISOLatin6        = 522,
+    kTextEncodingISOLatin7        = 525,
+    kTextEncodingISOLatin8        = 526,
+    kTextEncodingISOLatin9        = 527,
+    kTextEncodingDOSLatinUS       = 1024,
+    kTextEncodingDOSGreek         = 1029,
+    kTextEncodingDOSBalticRim     = 1030,
+    kTextEncodingDOSLatin1        = 1040,
+    kTextEncodingDOSGreek1        = 1041,
+    kTextEncodingDOSLatin2        = 1042,
+    kTextEncodingDOSCyrillic      = 1043,
+    kTextEncodingDOSTurkish       = 1044,
+    kTextEncodingDOSPortuguese    = 1045,
+    kTextEncodingDOSIcelandic     = 1046,
+    kTextEncodingDOSHebrew        = 1047,
+    kTextEncodingDOSCanadianFrench = 1048,
+    kTextEncodingDOSArabic        = 1049,
+    kTextEncodingDOSNordic        = 1050,
+    kTextEncodingDOSRussian       = 1051,
+    kTextEncodingDOSGreek2        = 1052,
+    kTextEncodingDOSThai          = 1053,
+    kTextEncodingDOSJapanese      = 1056,
+    kTextEncodingDOSChineseSimplif = 1057,
+    kTextEncodingDOSKorean        = 1058,
+    kTextEncodingDOSChineseTrad   = 1059,
+    kTextEncodingWindowsLatin1    = 1280,
+    kTextEncodingWindowsANSI      = 1280,
+    kTextEncodingWindowsLatin2    = 1281,
+    kTextEncodingWindowsCyrillic  = 1282,
+    kTextEncodingWindowsGreek     = 1283,
+    kTextEncodingWindowsLatin5    = 1284,
+    kTextEncodingWindowsHebrew    = 1285,
+    kTextEncodingWindowsArabic    = 1286,
+    kTextEncodingWindowsBalticRim = 1287,
+    kTextEncodingWindowsVietnamese = 1288,
+    kTextEncodingWindowsKoreanJohab = 1296,
+    kTextEncodingUS_ASCII         = 1536,
+    kTextEncodingJIS_X0201_76     = 1568,
+    kTextEncodingJIS_X0208_83     = 1569,
+    kTextEncodingJIS_X0208_90     = 1570,
 } kTextEncoding_t;
 
 extern char *set_name(const struct vol *, char *, cnid_t, char *, cnid_t,
-                      uint32_t);
+                      bool);
 
 extern struct extmap	*getextmap(const char *);
 extern struct extmap	*getdefextmap(void);

--- a/etc/afpd/virtual_icon.c
+++ b/etc/afpd/virtual_icon.c
@@ -321,7 +321,6 @@ int virtual_icon_getfilparams(const AFPObj *obj,
     char *utf_nameoff = NULL;
     uint16_t ashort;
     uint32_t aint;
-    uint32_t utf8 = 0;
     int bit = 0;
     uint16_t bmap = bitmap;
     cnid_t id = htonl(VIRTUAL_ICON_CNID);
@@ -410,7 +409,6 @@ int virtual_icon_getfilparams(const AFPObj *obj,
 
         case FILPBIT_PDINFO:
             if (obj->afp_version >= 30) {
-                utf8 = kTextEncodingUTF8;
                 utf_nameoff = data;
                 data += sizeof(uint16_t);
                 aint = 0;
@@ -450,14 +448,14 @@ int virtual_icon_getfilparams(const AFPObj *obj,
         ashort = htons((uint16_t)(data - buf));
         memcpy(l_nameoff, &ashort, sizeof(ashort));
         data = set_name(vol, data, DIRDID_ROOT, (char *)name,
-                        htonl(VIRTUAL_ICON_CNID), 0);
+                        htonl(VIRTUAL_ICON_CNID), false);
     }
 
     if (utf_nameoff) {
         ashort = htons((uint16_t)(data - buf));
         memcpy(utf_nameoff, &ashort, sizeof(ashort));
         data = set_name(vol, data, DIRDID_ROOT, (char *)name,
-                        htonl(VIRTUAL_ICON_CNID), utf8);
+                        htonl(VIRTUAL_ICON_CNID), true);
     }
 
     *buflen = data - buf;

--- a/include/atalk/unicode.h
+++ b/include/atalk/unicode.h
@@ -65,7 +65,7 @@ typedef enum {CH_UCS2 = 0, CH_UTF8 = 1, CH_MAC = 2, CH_UNIX = 3, CH_UTF8_MAC = 4
 
 struct charset_functions {
     const char *name;
-    const long kTextEncoding;
+    const uint32_t kTextEncoding;
     size_t (*pull)(void *, char **inbuf, size_t *inbytesleft,
                    char **outbuf, size_t *outbytesleft);
     size_t (*push)(void *, char **inbuf, size_t *inbytesleft,

--- a/include/atalk/volume.h
+++ b/include/atalk/volume.h
@@ -43,8 +43,7 @@ struct vol {
     charset_t       v_maccharset;
     uint16_t        v_mtou_flags;    /*!< flags for convert_charset in mtoupath */
     uint16_t        v_utom_flags;
-    /* FIXME: should be a u_int32_t ? */
-    long            v_kTextEncoding; /*!< mac charset encoding in network order */
+    uint32_t        v_kTextEncoding; /*!< AFP text encoding hint in network order */
     size_t          max_filename;
     char            *v_veto;
     int             v_adouble;    /*!< adouble format: v1, v2 */

--- a/test/afpd/afpfunc_helpers.c
+++ b/test/afpd/afpfunc_helpers.c
@@ -66,7 +66,7 @@ static int push_path(char **bufp, const char *name)
     int slen = strlen(name);
     char *p = *bufp;
     PUSHVAL(p, uint8_t, 3, len); /* path type */
-    PUSHVAL(p, uint32_t, kTextEncodingUTF8, len); /* text encoding hint */
+    PUSHVAL(p, uint32_t, htonl(kTextEncodingUTF8), len); /* text encoding hint */
     PUSHVAL(p, uint16_t, htons(slen), len);
 
     if (slen) {
@@ -95,7 +95,7 @@ char **cnamewrap(const char *name)
     static char *p = buf;
     int len = 0;
     PUSHVAL(p, uint8_t, 3, len); /* path type */
-    PUSHVAL(p, uint32_t, kTextEncodingUTF8, len); /* text encoding hint */
+    PUSHVAL(p, uint32_t, htonl(kTextEncodingUTF8), len); /* text encoding hint */
     size_t avail = sizeof(buf) - len - sizeof(uint16_t);
     size_t namelen = strnlen(name, avail);
     PUSHVAL(p, uint16_t, htons(namelen), len);
@@ -220,4 +220,3 @@ uint16_t openvol(AFPObj *obj, const char *name)
     memcpy(&vid, p, 2);
     return vid;
 }
-


### PR DESCRIPTION
AFPName carries a four-byte, big-endian text encoding hint. Restore v_kTextEncoding to uint32_t (which was mistakenly reverted in commit d6224b7) and use the same fixed-width type in the charset registry, removing architecture-dependent long storage and narrowing casts.

Expand kTextEncoding_t to cover the complete AFP 3.4 text encoding identifier list. Document that defining an identifier does not imply that Netatalk implements a converter for it, and make the composed UTF-8 constant explicitly uint32_t.

Change set_name()'s final argument to bool because it selects legacy versus UTF-8 name serialization; it never supplies the encoding value. Update callers to pass true or false and continue copying the volume's cached network-order hint for AFPName output.

Convert UTF-8 encoding hints with htonl() in the AFP test packet helpers so their generated AFPNames are big-endian on little-endian hosts.