### PR TITLE
docs: make the manpage generation script portable

### DIFF
--- a/doc/manpages/make_man.sh
+++ b/doc/manpages/make_man.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -o pipefail
-
 if [ "$#" -ne 5 ]; then
     echo "Usage: $0 <transcoder> <file> <manpage> <section> <version>"
     exit 1
@@ -21,7 +19,21 @@ if [ "${transcoder_name}" = "pandoc" ]; then
     ${transcoder} --from commonmark --to man "${input}"
 elif [ "${transcoder_name}" = "cmark" ] || [ "${transcoder_name}" = "cmark-gfm" ]; then
     # cleaning up cmark's non-portable code block style
-    ${transcoder} --smart --to man "${input}" | sed 's/\\f\[C\]/\\f[CR]/g'
+    tmpdir_base="${TMPDIR:-/tmp}/netatalk-make-man.$$"
+    tmpdir="${tmpdir_base}"
+    counter=0
+    while ! (umask 077 && mkdir "${tmpdir}") 2> /dev/null; do
+        counter=$((counter + 1))
+        if [ "${counter}" -ge 100 ]; then
+            echo "Unable to create a temporary directory in ${TMPDIR:-/tmp}" >&2
+            exit 1
+        fi
+        tmpdir="${tmpdir_base}.${counter}"
+    done
+    tmpfile="${tmpdir}/output"
+    trap 'rm -f "${tmpfile}"; rmdir "${tmpdir}"' 0
+    "${transcoder}" --smart --to man "${input}" > "${tmpfile}" || exit $?
+    sed 's/\\f\[C\]/\\f[CR]/g' "${tmpfile}"
 else
     echo "Unknown transcoder: ${transcoder_name}"
     exit 1


### PR DESCRIPTION
the pipefail flag isn't POSIX compatible, so replace it with temporary files to capture cmark failures