### PR TITLE
 netatalk: compile a dedicated dconf database, not update the system one

### DIFF
--- a/doc/manual/Installation.md
+++ b/doc/manual/Installation.md
@@ -235,9 +235,11 @@ and depends on the following third-party software:
 - DConf
 
     DConf is a low-level configuration database. Netatalk writes a
-    dconf keyfile listing the volumes to index, then runs *dconf
-    update* to compile it into the binary database. The LocalSearch
-    indexer reads this configuration on startup.
+    dconf keyfile listing the volumes to index under
+    */etc/dconf/db/netatalk.d*, then runs *dconf compile* to create the
+    Netatalk system database. The Netatalk profile is installed under
+    */etc/dconf/profile*, and locks prevent user database values from
+    overriding the generated volume list.
 
 - flex
 

--- a/etc/netatalk/netatalk.c
+++ b/etc/netatalk/netatalk.c
@@ -16,6 +16,7 @@
 #endif /* HAVE_CONFIG_H */
 
 #include <errno.h>
+#include <fcntl.h>
 #include <poll.h>
 #include <signal.h>
 #include <stdio.h>
@@ -130,13 +131,42 @@ static int makedirs(const char *path, mode_t mode)
     return 0;
 }
 
+/*! Open a dconf input file with permissions independent of the process umask */
+static FILE *open_dconf_file(const char *path)
+{
+    int fd, saved_errno;
+    FILE *fp;
+
+    if ((fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644)) == -1) {
+        return NULL;
+    }
+
+    /* open() does not update the mode of an existing file. */
+    if (fchmod(fd, 0644) == -1) {
+        saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    if ((fp = fdopen(fd, "w")) == NULL) {
+        saved_errno = errno;
+        close(fd);
+        errno = saved_errno;
+        return NULL;
+    }
+
+    return fp;
+}
+
 /*! Set indexers to index all our volumes via a dconf keyfile */
 static int set_sl_volumes(void)
 {
     EC_INIT;
     const struct vol *volumes, *vol;
     FILE *fp = NULL;
-    int sysret;
+    int status;
+    pid_t pid, waitret;
     bool first;
     EC_NULL_LOG(volumes = getvolumes());
 
@@ -147,7 +177,14 @@ static int set_sl_volumes(void)
         EC_FAIL;
     }
 
-    if ((fp = fopen(INDEXER_DCONF_DB_DIR "/10-spotlight", "w")) == NULL) {
+    if (makedirs(INDEXER_DCONF_DB_DIR "/locks", 0755) != 0) {
+        LOG(log_error, logtype_sl,
+            "set_sl_volumes: failed to create " INDEXER_DCONF_DB_DIR "/locks: %s",
+            strerror(errno));
+        EC_FAIL;
+    }
+
+    if ((fp = open_dconf_file(INDEXER_DCONF_DB_DIR "/10-spotlight")) == NULL) {
         LOG(log_error, logtype_sl,
             "set_sl_volumes: failed to open " INDEXER_DCONF_DB_DIR "/10-spotlight: %s",
             strerror(errno));
@@ -177,7 +214,7 @@ static int set_sl_volumes(void)
     }
 
     if (first) {
-        /* No Spotlight volumes: emit typed empty array so dconf update parses it */
+        /* No Spotlight volumes: emit typed empty array so dconf compile parses it */
         fprintf(fp, "index-recursive-directories=@as []\n");
     } else {
         fprintf(fp, "]\n");
@@ -192,24 +229,79 @@ static int set_sl_volumes(void)
         EC_FAIL;
     }
 
-    fclose(fp);
-    fp = NULL;
-    sysret = system(DCONF_UPDATE_COMMAND);
-
-    if (sysret == -1) {
+    if (fclose(fp) != 0) {
+        fp = NULL;
         LOG(log_error, logtype_sl,
-            "set_sl_volumes: system() failed to run 'dconf update': %s",
+            "set_sl_volumes: failed to close " INDEXER_DCONF_DB_DIR
+            "/10-spotlight: %s", strerror(errno));
+        EC_FAIL;
+    }
+
+    fp = NULL;
+
+    if ((fp = open_dconf_file(INDEXER_DCONF_DB_DIR "/locks/spotlight")) == NULL) {
+        LOG(log_error, logtype_sl,
+            "set_sl_volumes: failed to open " INDEXER_DCONF_DB_DIR
+            "/locks/spotlight: %s", strerror(errno));
+        EC_FAIL;
+    }
+
+    fprintf(fp, "/" INDEXER_DCONF_PATH "/index-recursive-directories\n");
+    fprintf(fp, "/" INDEXER_DCONF_PATH "/index-single-directories\n");
+
+    if (fflush(fp) != 0) {
+        LOG(log_error, logtype_sl,
+            "set_sl_volumes: failed to write " INDEXER_DCONF_DB_DIR
+            "/locks/spotlight: %s", strerror(errno));
+        EC_FAIL;
+    }
+
+    if (fclose(fp) != 0) {
+        fp = NULL;
+        LOG(log_error, logtype_sl,
+            "set_sl_volumes: failed to close " INDEXER_DCONF_DB_DIR
+            "/locks/spotlight: %s", strerror(errno));
+        EC_FAIL;
+    }
+
+    fp = NULL;
+
+    if ((pid = fork()) == -1) {
+        LOG(log_error, logtype_sl,
+            "set_sl_volumes: failed to fork for 'dconf compile': %s",
             strerror(errno));
         EC_FAIL;
-    } else if (WIFEXITED(sysret) && WEXITSTATUS(sysret) != 0) {
+    }
+
+    if (pid == 0) {
+        int exec_errno;
+        execl(INDEXER_DCONF_COMMAND, INDEXER_DCONF_COMMAND, "compile",
+              INDEXER_DCONF_DB, INDEXER_DCONF_DB_DIR, NULL);
+        exec_errno = errno;
         LOG(log_error, logtype_sl,
-            "set_sl_volumes: 'dconf update' exited with status %d",
-            WEXITSTATUS(sysret));
+            "set_sl_volumes: failed to execute '%s compile': %s",
+            INDEXER_DCONF_COMMAND, strerror(exec_errno));
+        _exit(127);
+    }
+
+    do {
+        waitret = waitpid(pid, &status, 0);
+    } while (waitret == -1 && errno == EINTR);
+
+    if (waitret == -1) {
+        LOG(log_error, logtype_sl,
+            "set_sl_volumes: failed to wait for 'dconf compile': %s",
+            strerror(errno));
         EC_FAIL;
-    } else if (WIFSIGNALED(sysret)) {
+    } else if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
         LOG(log_error, logtype_sl,
-            "set_sl_volumes: 'dconf update' killed by signal %d",
-            WTERMSIG(sysret));
+            "set_sl_volumes: 'dconf compile' exited with status %d",
+            WEXITSTATUS(status));
+        EC_FAIL;
+    } else if (WIFSIGNALED(status)) {
+        LOG(log_error, logtype_sl,
+            "set_sl_volumes: 'dconf compile' killed by signal %d",
+            WTERMSIG(status));
         EC_FAIL;
     }
 
@@ -742,8 +834,9 @@ int main(int argc, char **argv)
         setenv("DBUS_SESSION_BUS_ADDRESS", "unix:path=" _PATH_STATEDIR "spotlight.ipc",
                1);
         setenv("DCONF_PROFILE", INDEXER_DCONF_PROFILE, 1);
-        setenv("XDG_DATA_HOME", _PATH_STATEDIR, 0);
-        setenv("XDG_CACHE_HOME", _PATH_STATEDIR, 0);
+        setenv("XDG_CONFIG_HOME", _PATH_STATEDIR, 1);
+        setenv("XDG_DATA_HOME", _PATH_STATEDIR, 1);
+        setenv("XDG_CACHE_HOME", _PATH_STATEDIR, 1);
         setenv("TRACKER_USE_LOG_FILES", "1", 0);
         dbus_path = INIPARSER_GETSTR(obj.iniconfig, INISEC_GLOBAL, "dbus daemon",
                                      DBUS_DAEMON_PATH);

--- a/etc/spotlight/localsearch/sl_localsearch.c
+++ b/etc/spotlight/localsearch/sl_localsearch.c
@@ -301,8 +301,9 @@ static int sl_localsearch_init(AFPObj *obj)
     sl_ctx->cancellable = g_cancellable_new();
     setenv("DBUS_SESSION_BUS_ADDRESS",
            "unix:path=" _PATH_STATEDIR "spotlight.ipc", 1);
-    setenv("XDG_DATA_HOME",          _PATH_STATEDIR, 0);
-    setenv("XDG_CACHE_HOME",         _PATH_STATEDIR, 0);
+    setenv("XDG_CONFIG_HOME",        _PATH_STATEDIR, 1);
+    setenv("XDG_DATA_HOME",          _PATH_STATEDIR, 1);
+    setenv("XDG_CACHE_HOME",         _PATH_STATEDIR, 1);
     setenv("TRACKER_USE_LOG_FILES",  "1",             0);
     sl_ctx->tracker_con =
         tracker_sparql_connection_bus_new(INDEXER_DBUS_NAME, NULL, NULL, &error);

--- a/meson.build
+++ b/meson.build
@@ -1390,8 +1390,18 @@ if get_option('with-spotlight')
                 )
             endif
 
-            cdata.set('INDEXER_DCONF_DB_DIR', '"/etc/dconf/db/netatalk.d"')
-            cdata.set('INDEXER_DCONF_PROFILE', '"/etc/dconf/profile/netatalk"')
+            cdata.set(
+                'INDEXER_DCONF_DB',
+                '"/etc/dconf/db/netatalk"',
+            )
+            cdata.set(
+                'INDEXER_DCONF_DB_DIR',
+                '"/etc/dconf/db/netatalk.d"',
+            )
+            cdata.set(
+                'INDEXER_DCONF_PROFILE',
+                '"/etc/dconf/profile/netatalk"',
+            )
 
             use_spotlight_localsearch = (
                 sparql_found
@@ -1409,14 +1419,7 @@ if get_option('with-spotlight')
                 endif
                 spotlight_backends += 'localsearch'
                 cdata.set('SPOTLIGHT_BACKEND_LOCALSEARCH', 1)
-                cdata.set(
-                    'DCONF_UPDATE_COMMAND',
-                    '"' + dconf.full_path() + ' update"',
-                )
-                install_emptydir('/etc/dconf/db')
-                if get_option('with-install-hooks')
-                    meson.add_install_script(dconf, 'update')
-                endif
+                cdata.set('INDEXER_DCONF_COMMAND', '"' + dconf.full_path() + '"')
             else
                 warning(
                     'localsearch Spotlight search backend requested but one or more required dependencies not found',

--- a/meson_config.h
+++ b/meson_config.h
@@ -340,6 +340,24 @@
 /* Define as const if the declaration of iconv() needs const. */
 #mesondefine ICONV_CONST
 
+/* Indexer D-Bus name */
+#mesondefine INDEXER_DBUS_NAME
+
+/* dconf command with absolute path */
+#mesondefine INDEXER_DCONF_COMMAND
+
+/* Path to the compiled netatalk dconf database */
+#mesondefine INDEXER_DCONF_DB
+
+/* Directory for the netatalk dconf database keyfiles */
+#mesondefine INDEXER_DCONF_DB_DIR
+
+/* Indexer dconf keyfile path (schema with dots replaced by slashes, lowercased) */
+#mesondefine INDEXER_DCONF_PATH
+
+/* Path to the netatalk dconf profile file */
+#mesondefine INDEXER_DCONF_PROFILE
+
 /* OS is Linux */
 #mesondefine LINUX
 
@@ -402,21 +420,6 @@
 
 /* Define if TCP wrappers should be used */
 #mesondefine TCPWRAP
-
-/* Indexer D-Bus name */
-#mesondefine INDEXER_DBUS_NAME
-
-/* Indexer dconf keyfile path (schema with dots replaced by slashes, lowercased) */
-#mesondefine INDEXER_DCONF_PATH
-
-/* Directory for the netatalk dconf database keyfiles */
-#mesondefine INDEXER_DCONF_DB_DIR
-
-/* Path to the netatalk dconf profile file */
-#mesondefine INDEXER_DCONF_PROFILE
-
-/* dconf update command with absolute path */
-#mesondefine DCONF_UPDATE_COMMAND
 
 /* Define if cracklib should be used */
 #mesondefine USE_CRACKLIB

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -103,7 +103,7 @@ option(
     'with-install-hooks',
     type: 'boolean',
     value: true,
-    description: 'Enable OS specific install hooks',
+    description: 'Convenience hooks for end users, should be disabled for package maintainers',
 )
 option(
     'with-kerberos',


### PR DESCRIPTION
dconf update scans /etc/dconf/db and may rebuild every system database, including databases unrelated to Netatalk. This is inappropriate during staged package installation and unnecessarily broad at runtime. Since Netatalk owns only netatalk.d, use dconf compile to build the dedicated netatalk database from that directory explicitly. The daemon already performs this compilation when its volume configuration changes, so the install-time refresh is both redundant and liable to modify the build host.

Keep the conventional profile and database locations under /etc/dconf, while replacing the global dconf update invocation with a direct compile of Netatalk’s database. Run the compiler with fork and exec for detailed failure reporting, and drop the install-time update hook so package builds do not modify the host.

Lock the generated LocalSearch directory keys so values in the writable user database cannot override the configured volume list. Force the private LocalSearch session’s XDG configuration, data, and cache homes into Netatalk’s state directory so inherited environment variables cannot relocate its state.

Clarify that install hooks are intended as an end-user convenience and should be disabled by package maintainers.