### PR TITLE
doc: escape square brackets in papd.conf man page

### DIFF
--- a/doc/manpages/man5/papd.conf.5.md
+++ b/doc/manpages/man5/papd.conf.5.md
@@ -12,7 +12,7 @@ The format of papd.conf is derived from **printcap**(5) and can contain
 configurations for one or more printers. Any line not prefixed with *\#*
 is interpreted. The configuration lines are composed like this:
 
-*printername:[options]*
+*printername:\[options\]*
 
 On systems running a System V printing system, the simplest case is to
 have either no papd.conf, or to have one that has no active lines. In
@@ -55,7 +55,7 @@ authentication for the printer.
 > The *co* option allows options to be passed through to CUPS (e.g.
 *co="protocol=TBCP"* or *co="raw"*).
 
-**cupsautoadd[:type][@zone]**
+**cupsautoadd\[:type\]\[@zone\]**
 
 > If used as the first entry in papd.conf this will share all CUPS
 printers via papd. type/zone settings as well as other parameters


### PR DESCRIPTION
square brackets have special meaning in markdown syntax so let's escape them when used literally

this should appease the markdown linter