### PR TITLE
meson: standardize boolean option naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,6 +294,38 @@ static int dbif_init_rootinfo(DBD *dbd, int version)
 We use [Muon](https://github.com/annacrombie/muon)'s opinionated formatter - `muon fmt` -
 to format all the meson.build files as it applies the meson syntax recommendations to all files.
 
+### Boolean variable naming
+
+Meson Boolean variables should describe both what the value means and where it
+comes from. Use the following prefixes consistently:
+
+- `enable_*` for user-requested features or candidate implementations,
+  normally read directly from a `with-*` Meson option.
+- `have_*` for capabilities confirmed by platform or dependency checks.
+- `use_*` for providers, backends, or implementations actually selected for
+  the build. This may come directly from an option when no availability check
+  is required.
+- `build_*` for build modes or classes of generated artifacts, such as
+  documentation and tests.
+- `install_*` for installation actions or hooks.
+
+For other Boolean actions, use a positive verb phrase such as
+`create_statedirs`, `overwrite_config`, or `regenerate_unicode_data`. Avoid
+negated names and avoid using `with_*` for local variables; `with-*` is reserved
+for Meson option names.
+
+Example of combining user intent and platform checks to determine whether
+a feature is available:
+
+```meson
+enable_acls = get_option('with-acls')
+have_acls = enable_acls and acl_dependencies_found
+```
+
+If an enabled feature requires no platform or dependency check, use its
+`enable_*` variable directly rather than creating an equivalent `have_*`
+variable.
+
 Install muon and save the following script as 'muonfmt' in your local bin directory (chmod +x it too):
 
 ```meson

--- a/bin/meson.build
+++ b/bin/meson.build
@@ -3,7 +3,7 @@ subdir('dbd')
 subdir('misc')
 subdir('nad')
 
-if have_appletalk
+if enable_appletalk
     subdir('aecho')
     subdir('getzones')
     subdir('nbp')

--- a/bin/misc/meson.build
+++ b/bin/misc/meson.build
@@ -21,7 +21,7 @@ executable(
     install: false,
 )
 
-if have_fce
+if enable_fce
     executable(
         'fce_listen',
         ['fce.c'],

--- a/bin/nad/meson.build
+++ b/bin/nad/meson.build
@@ -28,7 +28,7 @@ if use_mysql_backend
     nad_deps += mysqlclient
 endif
 
-if get_option('with-stuffit')
+if enable_stuffit
     nad_sources += 'nad_stuffit.c'
 
     stuffit = dependency('stuffit-ffi', required: false)
@@ -54,7 +54,6 @@ if get_option('with-stuffit')
     endif
 
     nad_deps += stuffit
-    have_stuffit = true
     nad_c_args += '-DHAVE_STUFFIT'
 endif
 

--- a/config/meson.build
+++ b/config/meson.build
@@ -4,7 +4,7 @@ afp_conf = configure_file(
     configuration: cdata,
 )
 
-if (fs.exists(pkgconfdir / 'afp.conf') and not get_option('with-overwrite'))
+if fs.exists(pkgconfdir / 'afp.conf') and not overwrite_config
     message('will not replace existing', pkgconfdir / 'afp.conf')
 else
     install_data(afp_conf, install_dir: pkgconfdir, install_tag: 'config')
@@ -19,10 +19,7 @@ if have_spotlight and use_spotlight_localsearch
         configuration: cdata,
     )
 
-    if (
-        fs.exists(pkgconfdir / 'dbus-session.conf')
-        and not get_option('with-overwrite')
-    )
+    if (fs.exists(pkgconfdir / 'dbus-session.conf') and not overwrite_config)
         message('will not replace existing', pkgconfdir / 'dbus-session.conf')
     else
         install_data(dbus_session_conf, install_dir: pkgconfdir, install_tag: 'config')
@@ -31,7 +28,7 @@ endif
 
 static_conf_files = ['extmap.conf']
 
-if have_appletalk
+if enable_appletalk
     static_conf_files += ['atalkd.conf', 'macipgw.conf', 'papd.conf']
 endif
 
@@ -45,7 +42,7 @@ else
     cups_libdir = '/usr/lib'
 endif
 
-if have_appletalk and have_cups and get_option('with-cups-pap-backend')
+if enable_appletalk and have_cups and install_cups_pap_backend
     configure_file(
         input: 'pap.in',
         output: 'pap',
@@ -57,14 +54,14 @@ if have_appletalk and have_cups and get_option('with-cups-pap-backend')
 endif
 
 foreach file : static_conf_files
-    if (fs.exists(pkgconfdir / file) and not get_option('with-overwrite'))
+    if fs.exists(pkgconfdir / file) and not overwrite_config
         message('will not replace existing', pkgconfdir / file)
     else
         install_data(file, install_dir: pkgconfdir, install_tag: 'config')
     endif
 endforeach
 
-if (fs.exists('/etc/ld.so.conf.d') and get_option('with-ldsoconf'))
+if fs.exists('/etc/ld.so.conf.d') and enable_ldsoconf
     configure_file(
         input: 'libatalk.conf.in',
         output: 'libatalk.conf',
@@ -75,7 +72,7 @@ if (fs.exists('/etc/ld.so.conf.d') and get_option('with-ldsoconf'))
     )
 endif
 
-if get_option('with-statedir-creation')
+if create_statedirs
     install_data(
         'README',
         install_dir: localstatedir / 'netatalk/CNID',

--- a/config/pam/meson.build
+++ b/config/pam/meson.build
@@ -4,7 +4,7 @@ netatalk_pamd = configure_file(
     configuration: cdata,
 )
 
-if (fs.exists(pam_confdir / 'netatalk') and not get_option('with-overwrite'))
+if fs.exists(pam_confdir / 'netatalk') and not overwrite_config
     message('will not replace existing', pam_confdir / 'netatalk')
 else
     install_data(netatalk_pamd, install_dir: pam_confdir, install_tag: 'config')

--- a/contrib/meson.build
+++ b/contrib/meson.build
@@ -1,10 +1,10 @@
 subdir('bin_utils')
 
-if have_fce
+if enable_fce
     subdir('scripts')
 endif
 
-if have_appletalk
+if enable_appletalk
     subdir('a2boot')
     subdir('timelord')
     if host_os in ['freebsd', 'linux', 'netbsd', 'openbsd']
@@ -12,6 +12,6 @@ if have_appletalk
     endif
 endif
 
-if have_webmin
+if build_webmin
     subdir('webmin_module')
 endif

--- a/contrib/webmin_module/meson.build
+++ b/contrib/webmin_module/meson.build
@@ -54,7 +54,7 @@ meson.add_install_script(
     install_tag: 'webmin',
 )
 
-if install_webmin and get_option('with-install-hooks')
+if install_webmin and install_hooks
     meson.add_install_script(
         webmin,
         webmin_tarball,

--- a/distrib/initscripts/meson.build
+++ b/distrib/initscripts/meson.build
@@ -16,7 +16,7 @@ if 'debian-sysv' in init_style
     endif
     init_dirs += init_dir
     service_data = ['netatalk']
-    if have_appletalk
+    if enable_appletalk
         service_data += [
             'a2boot',
             'atalkd',
@@ -36,7 +36,7 @@ if 'debian-sysv' in init_style
             install_tag: 'runtime',
         )
     endforeach
-    if get_option('with-init-hooks')
+    if install_init_hooks
         foreach service : service_data
             meson.add_install_script(
                 find_program('update-rc.d'),
@@ -63,7 +63,7 @@ if 'freebsd' in init_style
         install_mode: 'rwxr-xr-x',
         install_tag: 'runtime',
     )
-    if get_option('with-init-hooks')
+    if install_init_hooks
         meson.add_install_script(
             find_program('sh'),
             '/usr/local/etc/rc.d/netatalk',
@@ -96,7 +96,7 @@ if 'macos-launchd' in init_style
     )
     if (
         not fs.exists(init_dir / 'io.netatalk.daemon.plist')
-        and get_option('with-init-hooks')
+        and install_init_hooks
     )
         if fs.exists(init_dir / 'com.netatalk.daemon.plist')
             meson.add_install_script(
@@ -131,7 +131,7 @@ if 'netbsd' in init_style
     endif
     init_dirs += init_dir
     service_data = ['netatalk']
-    if have_appletalk
+    if enable_appletalk
         service_data += [
             'a2boot',
             'atalkd',
@@ -167,7 +167,7 @@ if 'openbsd' in init_style
         install_mode: 'rwxr-xr-x',
         install_tag: 'runtime',
     )
-    if get_option('with-init-hooks')
+    if install_init_hooks
         meson.add_install_script(
             find_program('rcctl'),
             '-d', 'enable',
@@ -182,7 +182,7 @@ if 'openrc' in init_style
     endif
     init_dirs += init_dir
     service_data = ['netatalk']
-    if have_appletalk
+    if enable_appletalk
         service_data += [
             'a2boot',
             'atalkd',
@@ -202,7 +202,7 @@ if 'openrc' in init_style
             install_tag: 'runtime',
         )
     endforeach
-    if get_option('with-init-hooks')
+    if install_init_hooks
         foreach service : service_data
             meson.add_install_script(
                 find_program('rc-update'),
@@ -227,7 +227,7 @@ if 'solaris' in init_style
         install_dir: init_dir,
         install_tag: 'runtime',
     )
-    if get_option('with-init-hooks')
+    if install_init_hooks
         meson.add_install_script(
             find_program('svcadm'),
             'restart',
@@ -242,7 +242,7 @@ if 'systemd' in init_style
     endif
     init_dirs += init_dir
     service_data = ['netatalk']
-    if have_appletalk
+    if enable_appletalk
         service_data += [
             'a2boot',
             'atalkd',
@@ -261,7 +261,7 @@ if 'systemd' in init_style
             install_tag: 'runtime',
         )
     endforeach
-    if get_option('with-init-hooks')
+    if install_init_hooks
         meson.add_install_script(find_program('systemctl'), 'daemon-reload')
     endif
 endif

--- a/doc/manpages/man1/meson.build
+++ b/doc/manpages/man1/meson.build
@@ -9,7 +9,7 @@ manfiles = [
     'nad',
 ]
 
-if have_appletalk
+if enable_appletalk
     manfiles += [
         'aecho',
         'getzones',
@@ -26,7 +26,7 @@ if have_appletalk
     )
 endif
 
-if get_option('with-testsuite')
+if build_testsuite
     manfiles += [
         'afp_lantest',
         'afp_logintest',
@@ -59,7 +59,7 @@ foreach man : manfiles
     )
 endforeach
 
-if get_option('with-website')
+if build_website
     foreach page : manfiles
         install_data(page + '.1.md', install_dir: docs_install_path + '/manual/en')
     endforeach

--- a/doc/manpages/man5/meson.build
+++ b/doc/manpages/man5/meson.build
@@ -5,7 +5,7 @@ manfiles = [
     'extmap.conf',
 ]
 
-if have_appletalk
+if enable_appletalk
     manfiles += [
         'atalkd.conf',
         'papd.conf',
@@ -35,7 +35,7 @@ foreach man : manfiles
     )
 endforeach
 
-if get_option('with-website')
+if build_website
     foreach page : manfiles
         install_data(page + '.5.md', install_dir: docs_install_path + '/manual/en')
     endforeach

--- a/doc/manpages/man8/meson.build
+++ b/doc/manpages/man8/meson.build
@@ -3,20 +3,20 @@ manfiles = [
     'netatalk',
 ]
 
-if have_fce
+if enable_fce
     manfiles += [
         'fce_ev_script',
     ]
 endif
 
-if use_dbd_backend
+if build_dbd_docs
     manfiles += [
         'cnid_dbd',
         'cnid_metad',
     ]
 endif
 
-if have_appletalk
+if enable_appletalk
     manfiles += [
         'a2boot',
         'atalkd',
@@ -48,7 +48,7 @@ foreach man : manfiles
     )
 endforeach
 
-if get_option('with-website')
+if build_website
     foreach page : manfiles
         install_data(page + '.8.md', install_dir: docs_install_path + '/manual/en')
     endforeach

--- a/doc/manual/meson.build
+++ b/doc/manual/meson.build
@@ -15,7 +15,7 @@ manual_pages = [
     'Upgrading',
 ]
 
-if get_option('with-website')
+if build_website
     manual_pages += [
         '_Sidebar',
     ]

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -7,7 +7,7 @@ navlinks = '_Navlinks.md'
 if build_html_docs
     subdir('manual')
 
-    if get_option('with-docs-l10n')
+    if build_docs_l10n
         po4a = find_program('po4a', required: true)
         if po4a.found()
             run_command(
@@ -33,7 +33,7 @@ if build_dev_docs and doxygen.found()
     doxyfile_conf.set('ABS_TOP_SRCDIR', meson.project_source_root())
     doxyfile_conf.set('OUTPUT_DIR', meson.current_build_dir())
 
-    if get_option('with-doxygen-strict')
+    if strict_doxygen
         doxyfile_conf.set('WARN_AS_ERROR', 'YES')
     else
         doxyfile_conf.set('WARN_AS_ERROR', 'NO')
@@ -49,7 +49,7 @@ if build_dev_docs and doxygen.found()
         strip_directory: false,
     )
 
-    if get_option('with-website')
+    if build_website
         install_subdir(
             meson.current_build_dir() / 'developer',
             install_dir: docs_install_path / 'public',

--- a/doc/translated/ja/meson.build
+++ b/doc/translated/ja/meson.build
@@ -15,7 +15,7 @@ manual_pages = [
     'Upgrading',
 ]
 
-if get_option('with-website')
+if build_website
     manual_pages += [
         '_Sidebar',
         'a2boot.8',
@@ -56,7 +56,7 @@ if get_option('with-website')
     ]
 endif
 
-if get_option('with-website')
+if build_website
     foreach page : manual_pages
         install_data(page + '.md', install_dir: docs_install_path + '/manual/ja')
     endforeach

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -36,7 +36,7 @@ afpd_common_internal_deps = []
 afpd_common_link_args = []
 afpd_common_includes = [root_includes]
 
-if have_fce
+if enable_fce
     afpd_common_sources += files(
         'fce_api.c',
         'fce_util.c',
@@ -97,7 +97,7 @@ if threads.found()
     afpd_common_external_deps += threads
 endif
 
-if have_appletalk
+if enable_appletalk
     afpd_common_sources += files('afp_asp.c')
 endif
 

--- a/etc/meson.build
+++ b/etc/meson.build
@@ -10,7 +10,7 @@ if use_dbd_backend
     subdir('cnid_dbd')
 endif
 
-if have_appletalk
+if enable_appletalk
     subdir('atalkd')
     subdir('papd')
 endif

--- a/etc/papd/meson.build
+++ b/etc/papd/meson.build
@@ -56,6 +56,6 @@ executable(
     install_rpath: rpath_libdir,
 )
 
-if have_cups and get_option('with-statedir-creation')
+if have_cups and create_statedirs
     install_emptydir(spooldir, install_mode: 'rwxrwxrwx')
 endif

--- a/libatalk/meson.build
+++ b/libatalk/meson.build
@@ -31,7 +31,7 @@ endif
 
 libatalk_deps += sendfile_deps
 
-if have_appletalk
+if enable_appletalk
     subdir('asp')
     subdir('atp')
     subdir('nbp')
@@ -62,7 +62,7 @@ libatalk = library(
     install_rpath: rpath_libdir,
 )
 
-if host_os == 'linux' and get_option('with-install-hooks')
+if host_os == 'linux' and install_hooks
     ldconfig = find_program('ldconfig', required: false)
     if ldconfig.found()
         if run_command(ldconfig, '-N', '-X', check: false).returncode() == 0

--- a/libatalk/unicode/meson.build
+++ b/libatalk/unicode/meson.build
@@ -1,6 +1,6 @@
 subdir('charsets')
 
-if get_option('with-unicode-data')
+if regenerate_unicode_data
     unicode_dirs = [
         meson.current_source_dir(),
         '/usr/share/unicode',

--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,58 @@ endif
 uname = find_program('uname', required: false)
 uname_stdout = run_command(uname, '-a', check: false).stdout().strip()
 
+#################
+# Build options #
+#################
+
+enable_acls = get_option('with-acls')
+enable_appletalk = get_option('with-appletalk')
+enable_cracklib = get_option('with-cracklib')
+enable_cups = get_option('with-cups')
+enable_dbd_backend = 'dbd' in get_option('with-cnid-backends')
+enable_debug = get_option('with-debug')
+enable_debugging = get_option('with-debugging')
+enable_dtrace = get_option('with-dtrace')
+enable_fce = get_option('with-fce')
+enable_gssapi = get_option('with-gssapi')
+enable_iconv = get_option('with-libiconv')
+enable_kerberos = get_option('with-kerberos')
+enable_krb5_uam = get_option('with-krbV-uam')
+enable_ldap = get_option('with-ldap')
+enable_ldsoconf = get_option('with-ldsoconf')
+enable_mysql_backend = 'mysql' in get_option('with-cnid-backends')
+enable_pam = get_option('with-pam')
+enable_quota = get_option('with-quota')
+enable_rpath = get_option('with-rpath')
+enable_sendfile = get_option('with-sendfile')
+enable_spotlight = get_option('with-spotlight')
+enable_spotlight_cnid = 'cnid' in get_option('with-spotlight-backends')
+enable_spotlight_localsearch = 'localsearch' in get_option('with-spotlight-backends')
+enable_spotlight_xapian = 'xapian' in get_option('with-spotlight-backends')
+enable_sqlite_backend = 'sqlite' in get_option('with-cnid-backends')
+enable_stuffit = get_option('with-stuffit')
+enable_tcpwrap = get_option('with-tcp-wrappers')
+enable_zeroconf = get_option('with-zeroconf')
+
+build_afpd_tests = get_option('with-tests')
+build_docs_l10n = get_option('with-docs-l10n')
+build_docs_only = get_option('with-docs-only')
+build_fuzzing = get_option('with-fuzzing')
+build_testsuite = get_option('with-testsuite')
+build_testsuite_uams = get_option('with-testsuite-uams')
+build_webmin = get_option('with-webmin')
+build_website = get_option('with-website')
+
+create_statedirs = get_option('with-statedir-creation')
+install_cups_pap_backend = get_option('with-cups-pap-backend')
+install_hooks = get_option('with-install-hooks')
+install_init_hooks = get_option('with-init-hooks')
+overwrite_config = get_option('with-overwrite')
+regenerate_unicode_data = get_option('with-unicode-data')
+strict_doxygen = get_option('with-doxygen-strict')
+use_homebrew = get_option('with-homebrew')
+use_subprojects = get_option('with-subprojects')
+
 #########
 # Paths #
 #########
@@ -92,10 +144,9 @@ if get_option('with-docs-install-path') != ''
     docs_install_path = get_option('with-docs-install-path')
 endif
 
-with_docs_only = get_option('with-docs-only')
 docs_options = get_option('with-docs')
 
-if with_docs_only and docs_options == []
+if build_docs_only and docs_options == []
     error('with-docs-only requires at least one documentation type in with-docs')
 endif
 
@@ -139,7 +190,7 @@ if 'readmes' in docs_options
         'SECURITY',
     ]
 
-    if get_option('with-website') and perl.found()
+    if build_website and perl.found()
         make_compile_doc = find_program('contrib/scripts/make_compile_docs.pl', required: true)
         run_command(
             make_compile_doc,
@@ -153,7 +204,7 @@ if 'readmes' in docs_options
     endif
 
     foreach file : readmes_md
-        if get_option('with-website')
+        if build_website
             install_data(file + '.md', install_dir: docs_install_path / 'manual')
         else
             if pandoc.found()
@@ -224,9 +275,8 @@ if 'developer' in docs_options
     endif
 endif
 
-if with_docs_only
-    use_dbd_backend = 'dbd' in get_option('with-cnid-backends')
-    have_appletalk = get_option('with-appletalk')
+if build_docs_only
+    build_dbd_docs = enable_dbd_backend
 
     if docs_options != []
         subdir('doc')
@@ -296,7 +346,7 @@ add_global_arguments(netatalk_c_flags, language: 'c')
 
 netatalk_common_link_args = []
 
-if 'xapian' in get_option('with-spotlight-backends')
+if enable_spotlight_xapian
     cpp_found = add_languages('cpp', native: false, required: false)
     if cpp_found
         add_global_arguments(netatalk_common_flags, language: 'cpp')
@@ -341,7 +391,7 @@ endif
 # note: the brew app is not visible from within the brew build wrapper iteslf,
 # so rather than checking for brew we apply a blanket prefix
 brew_prefix = ''
-if get_option('with-homebrew') == true
+if use_homebrew
     if host_os == 'darwin'
         if cpu == 'aarch64' and fs.is_dir('/opt/homebrew')
             brew_prefix = '/opt/homebrew'
@@ -598,7 +648,7 @@ endif
 
 rpath_libdir = ''
 
-if host_os == 'sunos' or host_os == 'netbsd' or get_option('with-rpath')
+if host_os == 'sunos' or host_os == 'netbsd' or enable_rpath
     rpath_libdir = libdir
 endif
 
@@ -616,7 +666,7 @@ use_dbd_backend = false
 have_bdb = false
 grep = find_program('grep', required: false)
 
-if 'dbd' in get_option('with-cnid-backends')
+if enable_dbd_backend
     bdb_path = get_option('with-bdb-path')
     bdb_include_path_override = get_option('with-bdb-include-path')
     bdb_req_version = get_option('with-bdb-version')
@@ -796,7 +846,7 @@ mariadb = dependency('libmariadb', required: false)
 
 use_mysql_backend = false
 
-if 'mysql' in get_option('with-cnid-backends')
+if enable_mysql_backend
     if mysqlclient.found()
         mysql_deps = mysqlclient
     else
@@ -828,7 +878,7 @@ sqlite_deps = dependency('sqlite3', required: false)
 
 use_sqlite_backend = false
 
-if 'sqlite' in get_option('with-cnid-backends') and sqlite_deps.found()
+if enable_sqlite_backend and sqlite_deps.found()
     use_sqlite_backend = true
     if cnid_backends != ''
         cnid_backends += ' | '
@@ -876,7 +926,7 @@ has_bgets = cc.compiles(bgets_test_code, name: 'bgets defined in standard C libr
 cdata.set('HAVE_BGETS', has_bgets)
 bstring = dependency('bstring', required: false)
 
-if not bstring.found() or get_option('with-subprojects')
+if not bstring.found() or use_subprojects
     bstring_proj = subproject('bstring')
     bstring = bstring_proj.get_variable('bstring_dep')
 endif
@@ -1058,8 +1108,6 @@ endif
 # Check whether Kerberos V UAM should be compiled
 #
 
-enable_krb5_uam = get_option('with-krbV-uam')
-
 if not enable_krb5_uam
     have_krb5_uam = false
     have_gssapi = false
@@ -1069,7 +1117,6 @@ else
     # Check for GSSAPI
     #
 
-    enable_gssapi = get_option('with-gssapi')
     gssapi_path = get_option('with-gssapi-path')
 
     gss_libs = []
@@ -1129,7 +1176,6 @@ else
     # Check for Kerberos V
     #
 
-    enable_kerberos = get_option('with-kerberos')
     kerberos_path = get_option('with-kerberos-path')
 
     kerberos_includes = []
@@ -1213,8 +1259,6 @@ endif
 # Check for optional Zeroconf support
 #
 
-enable_zeroconf = get_option('with-zeroconf')
-
 have_zeroconf = false
 
 zeroconf_provider = ''
@@ -1294,17 +1338,17 @@ use_spotlight_xapian = false
 spotlight_backends = ''
 dbus_daemonpath = get_option('with-dbus-daemon-path')
 
-if get_option('with-spotlight')
+if enable_spotlight
     talloc = dependency('talloc', required: false)
 
     if talloc.found()
-        if 'cnid' in get_option('with-spotlight-backends')
+        if enable_spotlight_cnid
             use_spotlight_cnid = true
             spotlight_backends = 'cnid'
             cdata.set('SPOTLIGHT_BACKEND_CNID', 1)
         endif
 
-        if 'localsearch' in get_option('with-spotlight-backends')
+        if enable_spotlight_localsearch
             if host_os == 'darwin'
                 if brew_prefix != ''
                     bison = find_program(brew_prefix / 'opt/bison/bin/bison', required: false)
@@ -1441,7 +1485,7 @@ if get_option('with-spotlight')
             endif
         endif
 
-        if 'xapian' in get_option('with-spotlight-backends')
+        if enable_spotlight_xapian
             xapian = dependency('xapian-core', required: false)
             libmagic = dependency('libmagic', required: false)
 
@@ -1491,7 +1535,7 @@ endif
 cups = dependency('cups', required: false, version: '>=1.6')
 spooldir = ''
 
-if get_option('with-cups') and get_option('with-appletalk')
+if enable_cups and enable_appletalk
     spooldir = localstatedir / 'spool' / 'netatalk'
 
     spooldir_override = get_option('with-spooldir')
@@ -1515,8 +1559,6 @@ endif
 #
 # Check for quota support
 #
-
-enable_quota = get_option('with-quota')
 
 prop = cc.find_library('prop', required: false)
 quota = cc.find_library('quota', required: false)
@@ -1686,8 +1728,6 @@ endif
 # Check for ACL support
 #
 
-enable_acls = get_option('with-acls')
-
 acl_deps = []
 acl_includes = []
 acl_link_args = []
@@ -1781,7 +1821,6 @@ endif
 # Check for LDAP support, for client-side ACL visibility
 #
 
-enable_ldap = get_option('with-ldap')
 ldap_path = get_option('with-ldap-path')
 
 ldap_link_args = []
@@ -1845,7 +1884,6 @@ endif
 # Check for iconv support
 #
 
-enable_iconv = get_option('with-libiconv')
 iconv_path = get_option('with-libiconv-path')
 
 iconv = dependency('iconv', required: false)
@@ -1933,7 +1971,6 @@ endif
 # Check for PAM support
 #
 
-enable_pam = get_option('with-pam')
 pam_path = get_option('with-pam-path')
 pam_conf_path = get_option('with-pam-config-path')
 
@@ -2186,7 +2223,7 @@ endif
 have_sendfile = false
 sendfile_deps = []
 
-if get_option('with-sendfile')
+if enable_sendfile
     sendfile = cc.find_library('sendfile', required: false)
     if sendfile.found()
         sendfile_deps += sendfile
@@ -2229,8 +2266,6 @@ endif
 # Check for dtrace
 #
 
-enable_dtrace = get_option('with-dtrace')
-
 dtrace = find_program('dtrace', required: false)
 libelf = cc.find_library('elf', required: false)
 dtrace_command = [
@@ -2265,9 +2300,7 @@ endif
 # Check whether to enable FCE (File Change Events)
 #
 
-have_fce = get_option('with-fce')
-
-if have_fce
+if enable_fce
     cdata.set('WITH_FCE', 1)
 endif
 
@@ -2308,7 +2341,7 @@ if 'auto' in init_style
     endif
 endif
 
-if init_cmd != '' and get_option('with-init-hooks')
+if init_cmd != '' and install_init_hooks
     init_program = find_program(init_cmd, required: not init_style_auto)
     if not init_program.found()
         warning(init_cmd + ' not found, defaulting to no init scripts')
@@ -2321,7 +2354,6 @@ endif
 # Check for cracklib support
 #
 
-enable_cracklib = get_option('with-cracklib')
 cracklib_path = get_option('with-cracklib-path')
 
 crack = cc.find_library('crack', dirs: libsearch_dirs, required: false)
@@ -2372,8 +2404,6 @@ endif
 # Check for TCP wrappers support
 #
 
-enable_tcpwrap = get_option('with-tcp-wrappers')
-
 wrap = cc.find_library('wrap', required: false)
 
 if not enable_tcpwrap
@@ -2409,21 +2439,14 @@ endif
 # Check whether to enable DDP (AppleTalk)
 #
 
-enable_appletalk = get_option('with-appletalk')
-
 if not enable_appletalk
-    have_appletalk = false
     cdata.set('NO_DDP', 1)
-else
-    have_appletalk = true
 endif
 
 #
 # Check whether to install the Netatalk Webmin Module
 #
 
-with_webmin = get_option('with-webmin')
-have_webmin = false
 install_webmin = false
 
 webmin_dirs = [
@@ -2432,10 +2455,9 @@ webmin_dirs = [
     '/opt/webmin',
 ]
 
-if with_webmin
+if build_webmin
     tar = find_program('tar', required: true)
     webmin_install_script = 'install-module.pl'
-    have_webmin = true
     foreach dir : webmin_dirs
         if fs.exists(dir / webmin_install_script)
             webmin = find_program(dir / webmin_install_script, required: true)
@@ -2503,7 +2525,7 @@ endif
 # Check whether to enable debug code
 #
 
-if get_option('with-debug')
+if enable_debug
     cdata.set('DEBUG', 1)
 endif
 
@@ -2511,7 +2533,7 @@ endif
 # Check whether to enable debugging
 #
 
-if get_option('with-debugging')
+if enable_debugging
     cdata.set('DEBUGGING', 1)
 endif
 
@@ -2544,7 +2566,7 @@ if perl.found()
     cdata.set('PERL', perl.full_path())
 endif
 
-if have_webmin
+if build_webmin
     init_netatalk_start = ''
     init_netatalk_stop = ''
     init_netatalk_restart = ''
@@ -2677,8 +2699,6 @@ configure_file(
 #########################
 
 root_includes = include_directories(include_dirs)
-have_stuffit = false
-
 subdir('include')
 subdir('libatalk')
 subdir('bin')
@@ -2688,6 +2708,7 @@ subdir('contrib')
 subdir('sys')
 
 if docs_options != []
+    build_dbd_docs = use_dbd_backend
     subdir('doc')
 endif
 
@@ -2696,7 +2717,7 @@ if 'none' not in init_style
 endif
 
 testsuite_libafpclient = disabler()
-if get_option('with-tests') or get_option('with-testsuite') or get_option('with-fuzzing')
+if build_afpd_tests or build_testsuite or build_fuzzing
     subdir('test')
 endif
 
@@ -2766,10 +2787,10 @@ summary(summary_info, bool_yn: true, section: '  User Authentication Methods:')
 
 summary_info = {
     '  ACL': have_acls,
-    '  AppleTalk': have_appletalk,
+    '  AppleTalk': enable_appletalk,
     '  Cracklib': have_cracklib,
     '  dtrace probes': have_dtrace,
-    '  FCE': have_fce,
+    '  FCE': enable_fce,
     '  GSSAPI': have_gssapi,
     '  Iconv': have_iconv,
     '  Kerberos': have_kerberos,
@@ -2820,17 +2841,17 @@ summary_info = {
 summary(summary_info, bool_yn: true, section: '  Documentation:')
 
 summary_info = {
-    '  afpd': get_option('with-tests'),
-    '  fuzzing': get_option('with-fuzzing'),
-    '  testsuite': get_option('with-testsuite'),
+    '  afpd': build_afpd_tests,
+    '  fuzzing': build_fuzzing,
+    '  testsuite': build_testsuite,
     '  UAM testsuite': testsuite_libafpclient.found(),
 }
 summary(summary_info, bool_yn: true, section: '  Tests:')
 
 summary_info = {
     '  CUPS printing in papd': have_cups,
-    '  PAP backend for CUPS': get_option('with-cups-pap-backend'),
-    '  StuffIt support in nad': have_stuffit,
-    '  Webmin module': have_webmin,
+    '  PAP backend for CUPS': install_cups_pap_backend,
+    '  StuffIt support in nad': enable_stuffit,
+    '  Webmin module': build_webmin,
 }
 summary(summary_info, bool_yn: true, section: '  Extras:')

--- a/sys/meson.build
+++ b/sys/meson.build
@@ -1,3 +1,3 @@
-if have_appletalk
+if enable_appletalk
     subdir('netatalk')
 endif

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -9,7 +9,7 @@ test_internal_deps = [] + afpd_common_internal_deps
 test_link_args = [] + afpd_common_link_args
 test_includes = [] + afpd_common_includes
 
-if get_option('with-tests')
+if build_afpd_tests
 
     # For dtrace probes we need to invoke dtrace on all input files, before
     # linking the final executable.
@@ -150,7 +150,7 @@ if get_option('with-tests')
 
 endif
 
-if get_option('with-fuzzing')
+if build_fuzzing
     fuzz_engine = get_option('with-fuzzing-engine')
 
     if fuzz_engine != ''

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,4 +1,4 @@
-if get_option('with-tests')
+if build_afpd_tests
     if use_sqlite_backend
         subdir('afpd')
     else
@@ -8,11 +8,11 @@ if get_option('with-tests')
     endif
 endif
 
-if get_option('with-testsuite')
+if build_testsuite
     subdir('testsuite')
 endif
 
-if not get_option('with-tests') and get_option('with-fuzzing')
+if not build_afpd_tests and build_fuzzing
     if use_sqlite_backend
         subdir('afpd')
     endif

--- a/test/testsuite/meson.build
+++ b/test/testsuite/meson.build
@@ -4,9 +4,7 @@ if threads.found()
     afptest_external_deps += threads
 endif
 
-enable_testsuite_uams = get_option('with-testsuite-uams')
-
-if enable_testsuite_uams
+if build_testsuite_uams
     testsuite_libafpclient = dependency('libafpclient', required: false)
 endif
 
@@ -93,7 +91,7 @@ login_test_sources = [
 login_test_deps = []
 login_test_c_args = []
 
-if enable_testsuite_uams
+if build_testsuite_uams
     if testsuite_libafpclient.found()
         login_test_sources += [
             'logintest_uam.c',


### PR DESCRIPTION
Centralize Boolean build options near the top of the root build file and name them according to intent, detected availability, selected implementation, build target, or installation action.

Update all Meson consumers, distinguish docs-only DBD documentation selection from the dependency-backed backend choice, and document the naming convention in CONTRIBUTING.md.