### PR TITLE
afpd: normalise the FPDelete blocking model to POSIX/macOS/Samba semantics

### DIFF
--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -2293,12 +2293,25 @@ int deletefile(const struct vol *vol, int dirfd, char *file, int checkAttrib)
         break;
     }
 
-    /* An open with no deny claim does not block a delete: DELETE_BLOCKING_BAND_BITS
-     * excludes the "none" access markers (OPEN_NONE, which plants a band entry only
-     * so a mode-less open registers) and the read-only-open markers (OPEN_RD) for
-     * both data and rsrc.  Deny modes (DENY_*) and a write open (OPEN_WR) still
-     * block (left unchanged pending AFP/SMB spec and client validation). */
+    /* Delete-blocking policy: an open is just an open — no OPEN_* marker
+     * blocks, whatever its access mode or holder.  Only declared claims
+     * refuse: deny modes (DELETE_BLOCKING_BAND_BITS) and content byte-range
+     * locks.  Matches SMB/Samba share-mode semantics, where an existing
+     * handle's READ/WRITE access never blocks a delete.
+     *
+     * Deleting under a peer's open is safe: the peer child's fds stay valid
+     * on the unlinked inode (POSIX semantics — reads/writes complete, close
+     * works), its oforks and refnums are untouched, and only the directory
+     * entry is gone.  Nothing is invalidated in the holder's session. */
     if (df_locked || rf_locked || (band_held & DELETE_BLOCKING_BAND_BITS)) {
+        /* F_GETLK never reports this process's own locks, so the holder is
+         * another process: a peer session's child or a foreign locker. */
+        LOG(log_note, logtype_afpd,
+            "deletefile('%s'): refused (AFPERR_BUSY): cross-process claim:"
+            "%s%s band 0x%03x (blocking 0x%03x)", file,
+            df_locked ? " [data lock]" : "",
+            rf_locked ? " [rsrc lock]" : "",
+            band_held, band_held & DELETE_BLOCKING_BAND_BITS);
         return AFPERR_BUSY;
     }
 

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -800,7 +800,6 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
     struct vol  *vol;
     struct dir  *dir;
     struct path *s_path;
-    struct ofork *of;
     char        *upath;
     int         did;
     int         rc = AFP_OK;
@@ -967,26 +966,30 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 
             bdestroy(dname);
         }
-    } else if ((of = of_findname(vol, s_path))) {
-        /* This session still holds a tracked fork on the inode. */
-        LOG(log_note, logtype_afpd,
-            "afp_delete(\"%s\"): refused (AFPERR_BUSY): this session still has "
-            "an open fork: refnum %" PRIu16 ", name \"%s\", flags 0x%x"
-            "%s%s%s%s, dev/ino %ju/%ju",
-            upath, of->of_refnum, of_name(of), of->of_flags,
-            (of->of_flags & AFPFORK_DATA) ? " [data]" : "",
-            (of->of_flags & AFPFORK_RSRC) ? " [rsrc]" : "",
-            (of->of_flags & AFPFORK_DIRTY) ? " [dirty]" : "",
-            (of->of_flags & AFPFORK_MODIFIED) ? " [modified]" : "",
-            (uintmax_t)of->key.dev, (uintmax_t)of->key.inode);
-        rc = AFPERR_BUSY;
     } else {
         /* it's a file st_valid should always be true
          * only test for ENOENT because EACCES needs
          * to read meta data in deletefile
          */
+        const struct ofork *of;
+        uint16_t held_band = 0;
+        int held_content = 0;
+
         if (s_path->st_valid && s_path->st_errno == ENOENT) {
             rc = AFPERR_NOOBJ;
+        } else if ((of = of_findname(vol, s_path)) != NULL
+                   && of_delete_blocked(of, &held_band, &held_content)) {
+            /* Same-session claims block by the same policy as a peer's
+             * (deny modes and content locks; an open alone never blocks);
+             * one fork suffices to check, since siblings share the adouble
+             * that holds all of the session's claims.  Claim-free forks
+             * fall through and are swept after a successful delete. */
+            LOG(log_note, logtype_afpd,
+                "afp_delete(\"%s\"): refused (AFPERR_BUSY): same-session claim:"
+                "%s band 0x%03x (refnum %" PRIu16 ")", upath,
+                held_content ? " [content lock]" : "",
+                held_band, of->of_refnum);
+            rc = AFPERR_BUSY;
         } else {
             /* Validate target FILE inode to detect external replacement */
             LOG(log_debug, logtype_afpd,
@@ -1043,6 +1046,13 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
                 } else {
                     vol->v_tm_used -= s_path->st.st_size;
                 }
+
+                /* Sweep this session's remaining (no-claim) forks: they
+                 * reference the unlinked inode now.  Refusals above leave all
+                 * forks intact.  Last in the branch: of_closefork() overwrites
+                 * the static mtoupath() buffer that upath aliases, so no upath
+                 * consumer may run after this. */
+                of_close_inode_forks(obj, vol, s_path);
             }
         }
     }

--- a/etc/afpd/fork.h
+++ b/etc/afpd/fork.h
@@ -75,6 +75,10 @@ extern void         of_close_all_forks(const AFPObj *obj);
 extern struct adouble *of_ad(const struct vol *, struct path *,
                              struct adouble *);
 extern struct ofork *of_findnameat(int dirfd, struct path *path);
+extern int of_delete_blocked(const struct ofork *of, uint16_t *band,
+                             int *content);
+extern void of_close_inode_forks(const AFPObj *obj, const struct vol *vol,
+                                 struct path *path);
 extern int of_fstatat(int dirfd, struct path *path);
 
 enum of_locks_status { OF_LOCKS_ERROR = -1, OF_LOCKS_OK = 0, OF_LOCKS_NOENT = 1 };

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -487,6 +487,127 @@ struct ofork *of_findnameat(int dirfd, struct path *path)
 }
 
 /*!
+ * @brief Does this child hold a delete-blocking claim on the fork's file?
+ *
+ * The cross-process conflict check (deletefile()'s F_GETLK read) cannot by
+ * POSIX report the calling process's own locks, so the delete path asks this
+ * helper for the local complement: scan the session's own lock bookkeeping
+ * for the same claims and apply the same DELETE_BLOCKING_BAND_BITS policy —
+ * a deny mode or content byte-range lock refuses the delete whether its
+ * holder is a peer process or this session itself.  OPEN_* markers never
+ * block (an open is just an open; only declared claims do).
+ *
+ * Any one fork on the file suffices as @p of: sibling forks on an inode
+ * share one adouble, whose data-fork adf_lock[] holds ALL of the session's
+ * band entries (OPEN/DENY incl. the RSRC_* mirrors via rf2off) and its own
+ * content ranges; the rfork's adf_lock[] (reached via ad_rfp on the same
+ * adouble) holds only rfork content ranges.  So one lookup sees every claim
+ * — unlike the post-delete sweep, which must visit each fork to close it.
+ *
+ * @param[in]  of       a fork this child holds on the file
+ * @param[out] band     held blocking band bits, positional (may be NULL)
+ * @param[out] content  set if a content byte-range lock is held (may be NULL)
+ * @returns nonzero if the delete must be refused
+ */
+int of_delete_blocked(const struct ofork *of, uint16_t *band, int *content)
+{
+    const struct ad_fd *adf = &of->of_ad->ad_data_fork;
+    uint16_t bits = 0;
+    int bytelock = 0;
+
+    for (int i = 0; i < adf->adf_lockcount; i++) {
+        off_t start = adf->adf_lock[i].lock.l_start;
+
+        if (start >= AD_FILELOCK_BASE
+                && start - AD_FILELOCK_BASE < AD_FILELOCK_BAND_BITS) {
+            bits |= 1U << (start - AD_FILELOCK_BASE);
+        } else {
+            /* content range, or unclassifiable (negative / past the band):
+             * refuse rather than treat unknown state as no-claim */
+            bytelock = 1;
+        }
+    }
+
+    /* the rfork's own adf_lock[] holds only content ranges (its share-mode
+     * state lives on the data fd via rf2off) */
+    adf = of->of_ad->ad_rfp;
+
+    if (adf->adf_lockcount > 0) {
+        bytelock = 1;
+    }
+
+    bits &= DELETE_BLOCKING_BAND_BITS;
+
+    if (band != NULL) {
+        *band = bits;
+    }
+
+    if (content != NULL) {
+        *content = bytelock;
+    }
+
+    return bits || bytelock;
+}
+
+/*!
+ * @brief Close every fork this child holds on path's inode.
+ *
+ * Same-session sweep for FPDelete, called after a successful delete: every
+ * refusal condition (DeleteInhibit, peer claims, the session's own claims
+ * via of_delete_blocked()) has already passed and the file is unlinked, so
+ * only claim-free forks (any OPEN_* access, no deny mode, no content lock)
+ * reach this sweep.  Each fork is closed individually — the blocking check
+ * needs one fork (shared adouble), the close needs them all.
+ * of_closefork() deallocs even on flush error (nothing is stranded), so a
+ * failed close is logged and the sweep continues — matching of_closevol().
+ *
+ * @param[in] obj   the AFP session object
+ * @param[in] vol   volume the deleted file lived on
+ * @param[in] path  deleted file; path->st must be the pre-delete stat (the
+ *                  file no longer exists, so a re-stat cannot rebuild it)
+ */
+void of_close_inode_forks(const AFPObj *obj, const struct vol *vol,
+                          struct path *path)
+{
+    struct ofork *of;
+
+    /* The inode key must come from the caller's pre-delete stat: the name is
+     * already unlinked, so a re-stat inside of_findname() would ENOENT and
+     * the sweep would silently leak the forks it exists to close. */
+    if (!path->st_valid || path->st_errno) {
+        LOG(log_error, logtype_afpd,
+            "of_close_inode_forks(\"%s\"): stale path state (st_valid %d, "
+            "st_errno %d); fork sweep skipped", path->u_name,
+            path->st_valid, path->st_errno);
+        return;
+    }
+
+    /* of_closefork() rewrites the static mtoupath() buffer path->u_name may
+     * alias: snapshot the name for logging before the first close. */
+    char name[MAXPATHLEN + 1];
+    strlcpy(name, path->u_name, sizeof(name));
+
+    /* of_closefork() unhashes the fork it closes, so the loop converges. */
+    while ((of = of_findname(vol, path))) {
+        LOG(log_note, logtype_afpd,
+            "of_close_inode_forks(\"%s\"): self-clean refnum %" PRIu16
+            " flags 0x%x%s%s%s%s%s%s", name, of->of_refnum,
+            of->of_flags,
+            (of->of_flags & AFPFORK_DATA) ? " [data]" : "",
+            (of->of_flags & AFPFORK_RSRC) ? " [rsrc]" : "",
+            (of->of_flags & AFPFORK_ACCRD) ? " [rd]" : "",
+            (of->of_flags & AFPFORK_ACCWR) ? " [wr]" : "",
+            (of->of_flags & AFPFORK_DIRTY) ? " [dirty]" : "",
+            (of->of_flags & AFPFORK_MODIFIED) ? " [modified]" : "");
+
+        if (of_closefork(obj, of) < 0) {
+            LOG(log_error, logtype_afpd, "of_close_inode_forks: %s",
+                strerror(errno));
+        }
+    }
+}
+
+/*!
  * @brief Conflict GET (F_GETLK only): read another holder's locks on a file.
  *
  * Reuses a held fork's fd when one exists, else opens+closes a transient one.

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -303,13 +303,16 @@ struct adouble {
 #define ALL_BAND_BITS       ((1U << AD_FILELOCK_BAND_BITS) - 1)
 #define OPEN_BITS           (OPEN_WR_BIT | OPEN_RD_BIT \
                              | RSRC_OPEN_WR_BIT | RSRC_OPEN_RD_BIT)
-/* band bits that block a delete: all but the no-claim "open, no deny" markers.
- * Excludes OPEN_NONE (deny-none/access-none open) and OPEN_RD (read-only open,
- * no deny) for both data and rsrc: mere open-ness with no deny mode is not a
- * claim that should refuse a delete.  OPEN_WR and every DENY_* bit still block. */
+/* band bits that block a delete, one mask for every holder (this session or
+ * a peer): only explicit deny modes.  An OPEN_* marker (NONE/RD/WR, data or
+ * rsrc) records access, not a claim against others; the declared claims are
+ * deny modes and content byte-range locks (checked separately, always
+ * block).  Same model as SMB/Samba share modes, whose conflict engine never
+ * blocks on an existing handle's READ/WRITE access, only on a withheld
+ * share mode — and the engine runs identically for same-client and
+ * cross-client handles. */
 #define DELETE_BLOCKING_BAND_BITS                                       \
-    (ALL_BAND_BITS & ~(OPEN_NONE_BIT | RSRC_OPEN_NONE_BIT               \
-                       | OPEN_RD_BIT | RSRC_OPEN_RD_BIT))
+    (DENY_WR_BIT | DENY_RD_BIT | RSRC_DENY_WR_BIT | RSRC_DENY_RD_BIT)
 
 /* time stuff. we overload the bits a little.  */
 #define AD_DATE_CREATE         0

--- a/test/testsuite/FPCloseFork.c
+++ b/test/testsuite/FPCloseFork.c
@@ -28,15 +28,16 @@ STATIC void test186()
         goto test_exit;
     }
 
+    /* an unmatched close must leave real forks intact */
+    FAIL(htonl(AFPERR_PARAM) != FPCloseFork(Conn, 0))
+    FAIL(FPGetForkParam(Conn, fork, 1 << FILPBIT_DFLEN))
     FAIL(FPCloseFork(Conn, fork))
     /* double close */
     FAIL(htonl(AFPERR_PARAM) != FPCloseFork(Conn, fork))
     FAIL(htonl(AFPERR_PARAM) != FPCloseFork(Conn, 0))
-
-    if (FPDelete(Conn, vol, DIRDID_ROOT, name)) {
-        test_nottested();
-    }
-
+    /* FAIL, not test_nottested(): the latter would overwrite a FAILED
+     * verdict from the assertions above with NOT TESTED */
+    FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
 test_exit:
     exit_test("FPCloseFork:test186: FPCloseFork");
 }

--- a/test/testsuite/FPDelete.c
+++ b/test/testsuite/FPDelete.c
@@ -5,43 +5,6 @@
 #include "testhelper.h"
 
 /* ------------------------- */
-STATIC void test13()
-{
-    uint16_t bitmap = 0;
-    uint16_t vol = VolID;
-    char *name = "t13 file";
-    int ret = 0;
-    int fork;
-    ENTER_TEST
-
-    if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
-        test_nottested();
-        goto test_exit;
-    }
-
-    fork = FPOpenFork(Conn, vol, OPENFORK_DATA, bitmap, DIRDID_ROOT, name,
-                      OPENACC_WR | OPENACC_RD);
-
-    if (!fork) {
-        test_nottested();
-        goto fin;
-    }
-
-    FAIL(FPWrite(Conn, fork, 0, 2000, Data, 0))
-    ret = FPDelete(Conn, vol, DIRDID_ROOT, name);
-
-    if (!ret) {
-        test_failed();
-    }
-
-    FAIL(FPCloseFork(Conn, fork))
-fin:
-    FAIL(ret && FPDelete(Conn, vol, DIRDID_ROOT, name))
-test_exit:
-    exit_test("FPDelete:test13: delete open file same connection");
-}
-
-/* ------------------------- */
 STATIC void test27()
 {
     char *name  = "t27 file";
@@ -92,8 +55,9 @@ STATIC  void test74()
 
     dsi2 = &Conn2->dsi;
     vol2  = FPOpenVol(Conn2, Vol);
+    /* deny-write claim: an open alone does not block a delete */
     fork = FPOpenFork(Conn, vol, type, bitmap, DIRDID_ROOT, name,
-                      OPENACC_WR | OPENACC_RD);
+                      OPENACC_WR | OPENACC_RD | OPENACC_DWR);
 
     if (!fork) {
         test_failed();
@@ -799,11 +763,388 @@ test_exit:
     exit_test("FPDelete:test610: read-only open does not block delete");
 }
 
+/* -------------------------
+ * test611  A write-open with no deny mode does not block a cross-session
+ *          delete.
+ *
+ * Conn opens the data fork read-write with no deny claim; Conn2's FPDelete
+ * must succeed.  An open — even for write — is access, not a claim; only
+ * deny modes and content locks block (SMB share-mode semantics, where
+ * existing WRITE access never blocks a delete).  The holder's fds stay
+ * valid on the unlinked inode; nothing in the holder's session is
+ * invalidated.  Companion to test610 (OPEN_RD) and test608 (OPEN_NONE).
+ */
+STATIC void test611()
+{
+    char *name = "t611 open_wr nonblock";
+    uint16_t vol = VolID;
+    uint16_t vol2;
+    uint16_t fork;
+    unsigned int dret;
+    ENTER_TEST
+
+    if (!Conn2) {
+        test_skipped(T_CONN2);
+        goto test_exit;
+    }
+
+    if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, DIRDID_ROOT, name,
+                      OPENACC_RD | OPENACC_WR /* no deny */);
+
+    if (!fork) {
+        test_nottested();
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+        goto test_exit;
+    }
+
+    FAIL(FPWrite(Conn, fork, 0, 2000, Data, 0))
+    vol2 = FPOpenVol(Conn2, Vol);
+
+    if (vol2 == 0xffff) {
+        test_nottested();
+        goto cleanup;
+    }
+
+    dret = FPDelete(Conn2, vol2, DIRDID_ROOT, name);
+    FAIL(AFP_OK != dret)   /* a no-deny write-open must not block delete */
+    FAIL(FPCloseVol(Conn2, vol2))
+    /* the holder's fork survives the peer's delete: still readable, and the
+     * client-side close still works (POSIX unlinked-but-open semantics) */
+    FAIL(FPRead(Conn, fork, 0, 100, Data))
+    FAIL(FPCloseFork(Conn, fork))
+    goto test_exit;
+cleanup:
+    FPCloseFork(Conn, fork);
+    FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+test_exit:
+    exit_test("FPDelete:test611: no-deny write-open does not block delete");
+}
+
+/* -------------------------
+ * test612  A same-session stale fork does not block a delete.
+ *
+ * Conn opens the data fork read-only (Preview's shape), never closes it, and
+ * deletes the file on the same connection.  The server closes the session's
+ * own tracked fork and the delete succeeds: the deleting session owns every
+ * fork in its child, so an unclosed fork must not make the file undeletable.
+ */
+STATIC void test612()
+{
+    char *name = "t612 selfclean";
+    uint16_t vol = VolID;
+    uint16_t fork;
+    unsigned int dret;
+    ENTER_TEST
+
+    if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, DIRDID_ROOT, name,
+                      OPENACC_RD);
+
+    if (!fork) {
+        test_nottested();
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+        goto test_exit;
+    }
+
+    dret = FPDelete(Conn, vol, DIRDID_ROOT, name);
+    FAIL(dret != AFP_OK)   /* a same-session stale fork must not block delete */
+
+    if (dret == AFP_OK) {
+        /* the sweep invalidated the refnum: the close must miss */
+        FAIL(ntohl(AFPERR_PARAM) != FPCloseFork(Conn, fork))
+    } else {
+        FPCloseFork(Conn, fork);
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+    }
+
+test_exit:
+    exit_test("FPDelete:test612: same-session stale fork swept on delete");
+}
+
+/* -------------------------
+ * test613  ALL same-session stale forks close on delete, not just one.
+ *
+ * As test612 but with two unclosed forks (data + rsrc, two refnums) on the
+ * inode.  The delete must succeed, which requires the server to close every
+ * tracked fork on the inode, covering the rsrc/adouble close branch.
+ */
+STATIC void test613()
+{
+    char *name = "t613 selfclean2";
+    uint16_t vol = VolID;
+    uint16_t fork;
+    uint16_t fork2;
+    unsigned int dret;
+    ENTER_TEST
+
+    if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, DIRDID_ROOT, name,
+                      OPENACC_RD);
+
+    if (!fork) {
+        test_nottested();
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+        goto test_exit;
+    }
+
+    fork2 = FPOpenFork(Conn, vol, OPENFORK_RSCS, 0, DIRDID_ROOT, name,
+                       OPENACC_RD);
+
+    if (!fork2) {
+        test_nottested();
+        FAIL(FPCloseFork(Conn, fork))
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+        goto test_exit;
+    }
+
+    dret = FPDelete(Conn, vol, DIRDID_ROOT, name);
+    FAIL(dret != AFP_OK)   /* every same-session fork on the inode sweeps */
+
+    if (dret == AFP_OK) {
+        /* the sweep invalidated BOTH refnums: each close must miss */
+        FAIL(ntohl(AFPERR_PARAM) != FPCloseFork(Conn, fork))
+        FAIL(ntohl(AFPERR_PARAM) != FPCloseFork(Conn, fork2))
+    } else {
+        FPCloseFork(Conn, fork);
+        FPCloseFork(Conn, fork2);
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+    }
+
+test_exit:
+    exit_test("FPDelete:test613: all same-session forks swept on delete");
+}
+
+/* -------------------------
+ * test614  A same-session deny-mode fork blocks the delete; a plain
+ *          write-open does not.
+ *
+ * The delete-blocking policy is holder-agnostic and claim-based: only deny
+ * modes and content locks refuse; an open — even write — is not a claim
+ * (QuickLook leaks write-opens, and SMB/POSIX deletes succeed under them).
+ * Phase 1: open with a deny-write claim, write, FPDelete on the same
+ * connection: refused AFPERR_BUSY and the fork stays usable; delete
+ * succeeds after close.  Phase 2: open plain read-write, write, FPDelete:
+ * succeeds, the fork is swept.
+ */
+STATIC void test614()
+{
+    char *name = "t614 own deny blocks";
+    uint16_t vol = VolID;
+    uint16_t fork;
+    unsigned int dret;
+    ENTER_TEST
+
+    if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, DIRDID_ROOT, name,
+                      OPENACC_RD | OPENACC_WR | OPENACC_DWR);
+
+    if (!fork) {
+        test_nottested();
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+        goto test_exit;
+    }
+
+    FAIL(FPWrite(Conn, fork, 0, 2000, Data, 0))
+    FAIL(ntohl(AFPERR_BUSY) != FPDelete(Conn, vol, DIRDID_ROOT, name))
+    /* the refused delete must not have touched the open fork */
+    FAIL(FPGetForkParam(Conn, fork, 1 << FILPBIT_DFLEN))
+
+    if (FPCloseFork(Conn, fork)) {
+        /* a still-open deny fork would make the file undeletable: retry */
+        test_failed();
+        FPCloseFork(Conn, fork);
+    }
+
+    FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+
+    /* phase 2: a plain write-open (no deny) does not block; the fork sweeps */
+    if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, DIRDID_ROOT, name,
+                      OPENACC_RD | OPENACC_WR);
+
+    if (!fork) {
+        test_nottested();
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+        goto test_exit;
+    }
+
+    FAIL(FPWrite(Conn, fork, 0, 2000, Data, 0))
+    dret = FPDelete(Conn, vol, DIRDID_ROOT, name);
+    FAIL(dret != AFP_OK)   /* a write-open with no deny must not block */
+
+    if (dret == AFP_OK) {
+        /* the sweep invalidated the refnum: the close must miss */
+        FAIL(ntohl(AFPERR_PARAM) != FPCloseFork(Conn, fork))
+    } else {
+        FPCloseFork(Conn, fork);
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+    }
+
+test_exit:
+    exit_test("FPDelete:test614: own deny blocks delete; write-open sweeps");
+}
+
+/* -------------------------
+ * test615  A once-written file with only a no-claim fork left deletes.
+ *
+ * Write via a read-write fork, flush, close it (the OPEN_WR claim is
+ * released), then leak a read-only fork; the same-session delete must
+ * succeed.  Pins that having-been-written is history, not a claim: only a
+ * live OPEN_WR/deny/content lock blocks, never dirty/modified state.
+ */
+STATIC void test615()
+{
+    char *name = "t615 written then rd leak";
+    uint16_t vol = VolID;
+    uint16_t fork;
+    unsigned int dret;
+    ENTER_TEST
+
+    if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, DIRDID_ROOT, name,
+                      OPENACC_RD | OPENACC_WR);
+
+    if (!fork) {
+        test_nottested();
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+        goto test_exit;
+    }
+
+    FAIL(FPWrite(Conn, fork, 0, 2000, Data, 0))
+    FAIL(FPFlushFork(Conn, fork))
+    FAIL(FPCloseFork(Conn, fork))
+    fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, DIRDID_ROOT, name,
+                      OPENACC_RD);
+
+    if (!fork) {
+        test_nottested();
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+        goto test_exit;
+    }
+
+    dret = FPDelete(Conn, vol, DIRDID_ROOT, name);
+    FAIL(dret != AFP_OK)   /* once-written is not a claim; the RD fork sweeps */
+
+    if (dret == AFP_OK) {
+        /* the sweep invalidated the refnum: the close must miss */
+        FAIL(ntohl(AFPERR_PARAM) != FPCloseFork(Conn, fork))
+    } else {
+        FPCloseFork(Conn, fork);
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+    }
+
+test_exit:
+    exit_test("FPDelete:test615: once-written file with rd-only fork deletes");
+}
+
+/* -------------------------
+ * test616  A refused delete leaves the session's open fork intact.
+ *
+ * DeleteInhibit blocks the delete before any fork cleanup: with the bit set
+ * and a same-session fork open, FPDelete returns AFPERR_OLOCK and the fork
+ * refnum must still be usable.  Clearing the bit lets the delete succeed and
+ * only then is the fork server-closed.
+ */
+STATIC void test616()
+{
+    char *name = "t616 olock keeps fork";
+    int  ofs = 3 * sizeof(uint16_t);
+    struct afp_filedir_parms filedir = { 0 };
+    uint16_t bitmap = (1 << FILPBIT_ATTR);
+    uint16_t vol = VolID;
+    uint16_t fork;
+    unsigned int dret;
+    const DSI *dsi;
+    ENTER_TEST
+    dsi = &Conn->dsi;
+
+    if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, DIRDID_ROOT, name,
+                      OPENACC_RD);
+
+    if (!fork) {
+        test_nottested();
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+        goto test_exit;
+    }
+
+    if (FPGetFileDirParams(Conn, vol, DIRDID_ROOT, name, bitmap, 0)) {
+        test_nottested();
+        goto cleanup;
+    }
+
+    filedir.isdir = 0;
+    afp_filedir_unpack(Conn, &filedir, dsi->data + ofs, bitmap, 0);
+    filedir.attr = ATTRBIT_NODELETE | ATTRBIT_SETCLR;
+
+    if (FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir)) {
+        test_nottested();
+        goto cleanup;
+    }
+
+    FAIL(ntohl(AFPERR_OLOCK) != FPDelete(Conn, vol, DIRDID_ROOT, name))
+    /* the refused delete must not have touched the open fork */
+    FAIL(FPGetForkParam(Conn, fork, 1 << FILPBIT_DFLEN))
+    filedir.attr = ATTRBIT_NODELETE;
+
+    if (FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir)) {
+        /* the clear must not be left set: retry it via cleanup */
+        test_failed();
+        goto cleanup;
+    }
+
+    dret = FPDelete(Conn, vol, DIRDID_ROOT, name);
+    FAIL(dret != AFP_OK)
+
+    if (dret == AFP_OK) {
+        /* the sweep invalidated the refnum: the close must miss */
+        FAIL(ntohl(AFPERR_PARAM) != FPCloseFork(Conn, fork))
+        goto test_exit;
+    }
+
+cleanup:
+    FPCloseFork(Conn, fork);
+    /* clear any inhibit we may have set, then remove */
+    filedir.attr = ATTRBIT_NODELETE;
+    FPSetFileParams(Conn, vol, DIRDID_ROOT, name, bitmap, &filedir);
+    FPDelete(Conn, vol, DIRDID_ROOT, name);
+test_exit:
+    exit_test("FPDelete:test616: refused delete leaves open fork intact");
+}
+
 /* ----------- */
 void FPDelete_test()
 {
     ENTER_TESTSET
-    test13();
     test27();
     test74();
     test172();
@@ -815,4 +1156,10 @@ void FPDelete_test()
     test608();
     test609();
     test610();
+    test611();
+    test612();
+    test613();
+    test614();
+    test615();
+    test616();
 }

--- a/test/testsuite/T2_FPDelete.c
+++ b/test/testsuite/T2_FPDelete.c
@@ -66,7 +66,7 @@ STATIC void test146()
     FAIL(FPEnumerate(Conn2, vol2,  DIRDID_ROOT, "", 0, bitmap))
     FAIL(ntohl(AFPERR_ACCESS) != FPDelete(Conn2, vol2,  dir, name))
     fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, dir, name,
-                      OPENACC_WR | OPENACC_RD);
+                      OPENACC_WR | OPENACC_RD | OPENACC_DWR);
 
     if (!fork) {
         test_failed();
@@ -107,7 +107,7 @@ STATIC void test146()
         FAIL(FPCloseFork(Conn, fork))
         FAIL(FPCreateFile(Conn, vol, 0, dir, name))
         fork = FPOpenFork(Conn, vol, OPENFORK_DATA, 0, dir, name,
-                          OPENACC_WR | OPENACC_RD);
+                          OPENACC_WR | OPENACC_RD | OPENACC_DWR);
 
         if (!fork) {
             test_failed();
@@ -126,7 +126,7 @@ STATIC void test146()
 
     FAIL(FPCloseFork(Conn, fork))
     fork1 = FPOpenFork(Conn2, vol2, OPENFORK_DATA, 0, dir, name,
-                       OPENACC_WR | OPENACC_RD);
+                       OPENACC_WR | OPENACC_RD | OPENACC_DWR);
 
     if (!fork1) {
         test_failed();

--- a/test/testsuite/T2_Lock_attack.c
+++ b/test/testsuite/T2_Lock_attack.c
@@ -373,9 +373,9 @@ test_exit:
 /* ------------------------------------------------------------------ *
  * test605  A foreign-process share-mode band lock blocks delete.
  *
- * A non-afpd process (this test) takes a raw F_WRLCK at the AD_FILELOCK_OPEN_WR
+ * A non-afpd process (this test) takes a raw F_WRLCK at the AD_FILELOCK_DENY_WR
  * band offset on the data fork's backing file, with no afpd fork held.  A
- * cross-session FPDelete must detect the open-fork band lock and return
+ * cross-session FPDelete must detect the deny-mode band lock and return
  * AFPERR_BUSY.
  * ------------------------------------------------------------------ */
 STATIC void test605()
@@ -426,7 +426,7 @@ STATIC void test605()
 
     fl.l_type   = F_WRLCK;
     fl.l_whence = SEEK_SET;
-    fl.l_start  = AD_FILELOCK_OPEN_WR;
+    fl.l_start  = AD_FILELOCK_DENY_WR;
     fl.l_len    = 1;
 
     if (fcntl(fd, F_SETLK, &fl) < 0) {
@@ -454,7 +454,7 @@ cleanup:
     if (fd >= 0) {
         fl.l_type = F_UNLCK;
         fl.l_whence = SEEK_SET;
-        fl.l_start = AD_FILELOCK_OPEN_WR;
+        fl.l_start = AD_FILELOCK_DENY_WR;
         fl.l_len = 1;
         fcntl(fd, F_SETLK, &fl);
         close(fd);
@@ -546,21 +546,10 @@ test_exit:
 /* ------------------------------------------------------------------ *
  * test607  Delete vs a foreign-process data-content read lock.
  *
- * A non-afpd process (e.g. Samba) takes an fcntl(F_RDLCK) on content [0,100] of
- * the backing file, with no AFP fork open. The current server refuses a
- * cross-session FPDelete (AFPERR_BUSY) because its delete-time check takes a
- * whole-file trial lock that overlaps any byte-range lock — it blocks on any byte
- * lock, which is too coarse.
- *
- * The correct outcome for a foreign read lock is not yet finalised and depends on
- * an ownership-escalation rule still under design:
- *   - a write byte-range lock / a file open for writing is active modification and
- *     should block a delete;
- *   - a read byte-range lock should not block the file's Unix owner (ownership is
- *     the escalation), but blocking a non-owner whose target is being read may be
- *     acceptable.
- * Until that policy is decided this test is not wired into the testset (its body
- * is kept ready for when the expected outcome is finalised).
+ * A non-afpd process (e.g. Samba) takes an fcntl(F_RDLCK) on content
+ * [0,100] of the backing file, with no AFP fork open.  A content
+ * byte-range lock — read or write, AFP or foreign — means the file is in
+ * use: the cross-session FPDelete must refuse with AFPERR_BUSY.
  * ------------------------------------------------------------------ */
 STATIC void test607()
 {
@@ -642,10 +631,7 @@ STATIC void test607()
         goto cleanup;
     }
 
-    /* The assertion below encodes today's over-broad "any byte lock blocks"
-     * outcome only as scaffolding; the real expected result is undecided (it
-     * depends on a file-ownership escalation rule) and must be set once that
-     * policy is finalised.  Until then this test is not wired into the testset. */
+    /* A held content lock blocks the delete, whoever holds it. */
     dret = FPDelete(Conn2, vol2, dir, name);
     FAIL(ntohl(AFPERR_BUSY) != dret)
     FAIL(FPCloseVol(Conn2, vol2))
@@ -673,8 +659,6 @@ void T2LockAttack_test()
     test603();
     test604();
     test605();
-    /* test607 (delete vs foreign content read lock) is intentionally not wired in
-     * yet: its expected outcome depends on an undecided ownership-escalation
-     * policy. */
+    test607();
     test620();
 }


### PR DESCRIPTION
`FPDelete` refused deletes on any same-session open fork — including forks the macOS client leaks by design — wedging files as "in use" until afpd restarts. 

This PR normalises the delete-blocking model to match the semantics of every other filesystem a macOS user touches (POSIX unlink, local macOS vol, SMB/Samba etc): **an open is just an open; only a declared claim blocks a delete.** After a successful delete, any remaining dangling forks on the inode are swept, un-wedging the session.
Only Netatalk was the more strict exception.

## The field bug and its root cause

Reproduced live: view files with QuickLook/Preview over AFP, then delete them — Finder reports "in use" (`AFPERR_BUSY`) forever; only an afpd restart clears it.

The trace shows the macOS client opening the file `OPEN_RD`, then upgrading by opening a second `OPEN_WR` fork, then sending `FPCloseFork` for **only the first refnum**. The write fork leaks. The client's model is a single vnode whose access it upgrades and closes once; AFP has no upgrade verb (each fork "must be opened/closed separately; a unique fork reference is returned for each fork" — FPOpenFork, Reference) and requires each closed separately (FPCloseFork "invalidates *the* open fork reference number").

If the client does not close every fork individually it is technically non-conformant, however even Apple do this themselves (some apps do not close every open, and the official AFP client does not auto close on behalf of lazy/buggy apps).

Thankfully this commit both makes Netatalk more consistent with other filesystems, and also overcomes this client issue at the same time.

`afp_delete()`'s tracked-fork gate (`of_findname` → `AFPERR_BUSY`) aggressively refused every delete of a file with *any* same-session fork, so one leaked refnum made the file permanently wedged in that session.

## The normalised model

One rule, one mask, every holder (this session or a peer user session):

| Condition on the file | Blocks `FPDelete`? |
|---|---|
| `OPEN_NONE` / `OPEN_RD` / `OPEN_WR` (± RSRC mirrors) — any holder | **No** — an open records access, not a claim |
| `DENY_RD` / `DENY_WR` (± RSRC mirrors) — any holder | **Yes** → `AFPERR_BUSY` |
| Content byte-range lock (data or rsrc zone) — any holder | **Yes** → `AFPERR_BUSY` |
| DeleteInhibit (`kFPDeleteInhibitBit`) | **Yes** → `AFPERR_OLOCK` (unchanged) |
| `AFPFORK_DIRTY`/`MODIFIED` (was-once-written state) | **No** — history kept for FCE, not a claim |

Why this is the correct model, per reference systems:

- **POSIX:** `unlink(2)` succeeds regardless of open fds — the name goes, the inode lives until last close.
- **Local macOS:** Finder-delete of a file Preview holds open succeeds; the app writes into the orphaned inode.
- **Samba** (`source3/smbd/open.c` `share_conflict()`/`mask_conflict()`): a delete is blocked *solely* by a withheld share mode (`FILE_SHARE_DELETE` axis), never by an existing handle's READ/WRITE access — and the engine runs identically for same-client and cross-client handles. `unlink_internals()` is literally an internal open with `DELETE_ACCESS` + delete-on-close, so delete-vs-open reduces to that same share check. A QuickLook'd file deletes fine over SMB; the macOS SMB client always grants `FILE_SHARE_DELETE`.
- **AFP spec:** FPDelete's result-code table (Reference, Table 16) lists only `kFPObjectLocked` (DeleteInhibit) as a held-claim refusal; the File Sharing Modes chapter builds all synchronisation from **deny modes**. AFP's deny modes are its share modes; its byte-range locks are its explicit in-use declarations; access modes are neither.

This completes the direction started in #3145 (which stopped short of `OPEN_WR`, pending "DIRTY un-flushed pages" analysis): DSI runs a strictly serial command loop and `afp_write` drains its payload within the command, so when `FPDelete` executes no write can be in flight — the flush-risk that justified blocking on `OPEN_WR` cannot occur. Dirty/modified flags are bookkeeping for FCE notifications, not claims.

**Deleting under a peer's open is safe:** the peer child's fds stay valid on the unlinked inode (reads and writes complete, close works), and its oforks and refnums are untouched — only the directory entry is gone. Nothing is invalidated in the holder's session (pinned by test611, which reads and closes the holder's fork *after* the peer's delete).

## Mechanics

Two readers, one policy mask (`DELETE_BLOCKING_BAND_BITS`, now the four `DENY_*` bits):

- **Peer claims** — read by `deletefile()`'s `F_GETLK` conflict GET (#3145's mechanism), unchanged. The refusal now logs which claim blocked (data/rsrc content lock, band bits held vs blocking) — previously the only silent ambiguous refusal on the path.
- **Same-session claims** — invisible to `F_GETLK` by POSIX (it never reports the caller's own locks), so `afp_delete()` gains the local complement: new `of_delete_blocked()` scans the held fork's own `adf_lock[]` bookkeeping with the same mask and refuses with the same `AFPERR_BUSY`. One fork suffices to check: siblings share the adouble, whose data-fork `adf_lock[]` holds all the session's band entries (incl. RSRC mirrors via `rf2off`).
- **The sweep** — only after a successful delete, this session's remaining (claim-free) forks on the inode are closed via the normal `of_closefork()` path (locks released, dealloc): new `of_close_inode_forks()` loops `of_findname()`+`of_closefork()` (the close unhashes the fork, so it converges). It gates on the caller's pre-delete stat (the name is unlinked; a re-stat cannot rebuild the key — violation is logged, never silent), and runs after the last consumer of `upath` (`of_closefork()` rewrites the static `mtoupath()` buffer `upath` aliases; the logged name is snapshotted for the same reason). Every refusal path returns *before* any fork is touched — a refused delete leaves all refnums fully usable (pinned by test616).

**Wire contract** (pinned, spec-checked): `AFPERR_BUSY` = claim conflict (`kFPFileBusy`, the Discussion's code for an in-use delete), `AFPERR_ACCESS` = indeterminate lock state, fail-closed, always logged, `AFPERR_OLOCK` = DeleteInhibit. `AFPERR_DENYCONF` is deliberately **not** used: it is an open-time code (documented only for FPOpenFork/FPCopyFile) and a delete opens nothing; same-session vs cross-process attribution lives in the logs, never on the wire.

## Behaviour changes

- A same-session open fork — any access mode, no deny — no longer blocks `FPDelete`; after the delete succeeds the session's forks on the inode are server-closed (a straggler op on a swept refnum gets `AFPERR_PARAM`).
- A **peer's** no-deny write-open no longer blocks `FPDelete` (was: blocked). Deny modes, content byte-range locks, and DeleteInhibit block exactly as before — for every holder, owner included.
- The `deletefile()` lock-conflict refusal is now attributable from the log (claim type + band bits); the same-session refusal logs the refnum and its claim.

## Testing

### Spectests
- **test611** — a peer's no-deny write-open does not block delete; the holder's fork survives (readable + closeable after).
- **test612/613** — leaked read-only fork (QuickLook shape), then data+rsrc pair: same-session delete succeeds, forks swept.
- **test614** — the claim rule both ways: own deny-write open refuses `AFPERR_BUSY` with the fork left usable; own plain write-open sweeps.
- **test615** — written-is-not-a-claim: write+flush+close, re-open read-only, delete succeeds.
- **test616** — a refused delete leaves the open fork intact: DeleteInhibit + open fork → `AFPERR_OLOCK`, refnum still answers `FPGetForkParam`; delete succeeds after clearing the bit.
- **test13 retired** — it asserted the unconditional any-open refusal this PR removes (test614 is its successor).
- **test74 / T2:test146** flipped to hold deny-write claims (they keep pinning the blocking path); **T2:test605** plants its foreign band lock at `AD_FILELOCK_DENY_WR`; **T2:test607** wired (foreign content read lock blocks).
- **FPCloseFork:test186** extended: an unmatched close (bogus refnum) while a real fork is open returns `AFPERR_PARAM` and leaves the real fork usable.
- AFP 3.4 spectest: **ea=sys 349 pass / 0 fail, ea=ad 353 pass / 0 fail**.

### Unit tests
- afpd unit suite 66/66 green (both backends) — including the #3145 lock-read suite this PR builds on (no-self-report, zone clamp, fail-closed GET).

### Live validation
- Reproduced the field bug on a live macOS client (QuickLook), captured the leak trace (RD open → WR upgrade-open → single close), and verified the fix un-wedges the delete.

## Not in this PR

- **Rename/move verb symmetry** (Commit 17B in the series plan): `moveandrename()` still refuses on any same-session open (`AFPERR_EXIST`).
*Ie, We assume that any move/rename that would result in a clobber is unintended and continues to be blocked (leave it to the user to resolve the conflict).*