### PR TITLE
add exclusion for webmin_module images in sonar config

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -8,7 +8,7 @@ sonar.scm.provider=git
 
 # Don't analyze dynamically generated files, or the privileged perftest
 # harness (dev/CI-only tooling that must run as root for netns/tc/ethtool)
-sonar.exclusions=**/build/**,**/subprojects/**,etc/spotlight/sparql_parser.*,etc/spotlight/spotlight_rawquery_lexer.c,include/atalk/afp_dtrace.h,distrib/docker/perftest/**
+sonar.exclusions=**/build/**,**/subprojects/**,etc/spotlight/sparql_parser.*,etc/spotlight/spotlight_rawquery_lexer.c,include/atalk/afp_dtrace.h,distrib/docker/perftest/**,contrib/webmin_module/images/**
 
 # Disabling code duplication rule for test code, Unicode lookup tables, and bitmap byte arrays
 sonar.cpd.exclusions=test/**,libatalk/unicode/precompose.h,libatalk/unicode/utf16_case.c,libatalk/unicode/utf16_casetable.h,etc/afpd/icon.c


### PR DESCRIPTION
the scanner was attempting to analyze the binary image files in the Webmin module tree and throwing errors like:

`Invalid character encountered in file /__w/netatalk/netatalk/contrib/webmin_module/images/digest.png at line 1 for encoding UTF-8.`

this seems like a bug in SonarQube but let's work around it in our configuration