### PR TITLE
idle-worker: three-flag lock-free idle worker handshake; covered-job cancellation for deferred dircache cleanup

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -160,6 +160,79 @@ jobs:
           labels: ${{ steps.metadata.outputs.labels }}
           tags: ${{ steps.metadata.outputs.tags }}
 
+  build-container-tsan:
+    name: Build TSAN testsuite container
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    permissions:
+      packages: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Create image name
+        run: |
+          echo "IMAGE_NAME=${REPO,,}-testsuite-tsan" >> ${GITHUB_ENV}
+      - name: Login to container registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: metadata
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: type=raw,value=${{ github.sha }}
+      - name: Build and push container image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: distrib/docker/testsuite_deb.Dockerfile
+          push: true
+          build-args: |
+            EXTRA_MESON_ARGS=-Db_sanitize=thread
+            EXTRA_RUN_DEPS=libtsan2
+          labels: ${{ steps.metadata.outputs.labels }}
+          tags: ${{ steps.metadata.outputs.tags }}
+
+  tsan-spectest:
+    name: Spectest + lantest under ThreadSanitizer
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: build-container-tsan
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    steps:
+      - name: Lower ASLR entropy for TSAN shadow-memory compatibility
+        run: sudo sysctl vm.mmap_rnd_bits=28
+      - name: Create image name
+        run: |
+          echo "IMAGE_NAME=${REPO,,}-testsuite-tsan" >> ${GITHUB_ENV}
+      - name: Run spectest under TSAN
+        run: |
+          docker run --privileged --rm \
+              -e AFP_USER=atalk1 -e AFP_USER2=atalk2 \
+              -e AFP_PASS="$CONT_PASSWD" -e AFP_PASS2="$CONT_PASSWD" \
+              -e AFP_GROUP=afpusers \
+              -e SHARE_NAME=test1 -e SHARE_NAME2=test2 \
+              -e INSECURE_AUTH=1 -e DISABLE_TIMEMACHINE=1 \
+              -e TESTSUITE=spectest -e AFP_VERSION=7 \
+              -e AFP_CNID_BACKEND=sqlite \
+              -e TSAN_OPTIONS="halt_on_error=1 abort_on_error=1" \
+              ${{ env.REGISTRY }}/${IMAGE_NAME}:${{ github.sha }}
+      - name: Run lantest under TSAN
+        run: |
+          docker run --privileged --rm \
+              -e AFP_USER=atalk1 -e AFP_PASS="$CONT_PASSWD" \
+              -e AFP_GROUP=afpusers -e SHARE_NAME=test1 \
+              -e INSECURE_AUTH=1 -e DISABLE_TIMEMACHINE=1 \
+              -e TESTSUITE=lan -e AFP_VERSION=7 \
+              -e AFP_TEST_ITERATIONS=2 \
+              -e AFP_CNID_BACKEND=sqlite \
+              -e TSAN_OPTIONS="halt_on_error=1 abort_on_error=1" \
+              ${{ env.REGISTRY }}/${IMAGE_NAME}:${{ github.sha }}
+
   build-container-debug:
     name: Build debug profiling container
     runs-on: ubuntu-latest

--- a/distrib/docker/debug_entrypoint_netatalk.sh
+++ b/distrib/docker/debug_entrypoint_netatalk.sh
@@ -67,7 +67,7 @@ PERF_PID=""
 # Perf sampling frequency (samples per second). Default 907 Hz —
 # higher resolution to make narrow Netatalk frames visible. The
 # previous lockstep-with-idle-worker concern is now handled by the
-# post-hoc folded-stack filter for idle_worker_main → nanosleep.
+# post-hoc folded-stack filter for iw_main → nanosleep.
 PERF_FREQ="${PERF_FREQ:-907}"
 
 start_flamegraph_profiling() {
@@ -155,19 +155,19 @@ stop_flamegraph_profiling() {
     # e.g. "afpd;__clone;__clone;__clone;start;..." → "afpd;__clone;start;..."
     perl -pi -e 's/;__clone(?:;__clone)+/;__clone/g' "$PERF_FOLDED"
 
-    # Drop folded-stack samples where idle_worker_main calls nanosleep.
+    # Drop folded-stack samples where iw_main calls nanosleep.
     # The idle worker runs in its own thread, so time it spends in
     # nanosleep is unrelated to the main afpd worker's CPU time on the
     # AFP request path. Even with a prime PERF_FREQ, perf sampling
     # occasionally aligns with the idle worker's poll wake-ups and
-    # produces a misleading ~5% nanosleep tower under idle_worker_main.
+    # produces a misleading ~5% nanosleep tower under iw_main.
     #
-    # Once we see idle_worker_main → nanosleep at any depth, drop the
+    # Once we see iw_main → nanosleep at any depth, drop the
     # whole sample regardless of what kernel frames sit above nanosleep
     # (__schedule, hrtimer_*, finish_task_switch, entry_SYSCALL_64,
-    # etc.). idle_worker_main itself stays visible if it has any
+    # etc.). iw_main itself stays visible if it has any
     # non-nanosleep on-CPU stack.
-    grep -Ev ';idle_worker_main;nanosleep(_\[k\])?[;[:space:]]' \
+    grep -Ev ';iw_main;nanosleep(_\[k\])?[;[:space:]]' \
         "$PERF_FOLDED" > "${PERF_FOLDED}.tmp"
     mv "${PERF_FOLDED}.tmp" "$PERF_FOLDED"
 

--- a/distrib/docker/testsuite_deb.Dockerfile
+++ b/distrib/docker/testsuite_deb.Dockerfile
@@ -90,6 +90,8 @@ COPY meson_options.txt .
 COPY meson.build .
 RUN rm -rf build
 
+ARG EXTRA_MESON_ARGS=""
+
 RUN meson setup build \
     -Dbuildtype=debugoptimized \
     -Dwith-appletalk=true \
@@ -106,6 +108,7 @@ RUN meson setup build \
     -Dwith-tcp-wrappers=false \
     -Dwith-tests=true \
     -Dwith-testsuite=true \
+    $EXTRA_MESON_ARGS \
 &&  meson compile -C build
 
 RUN meson test -C build --print-errorlogs
@@ -119,9 +122,12 @@ ENV RUN_DEPS=$RUN_DEPS
 
 COPY --from=build /staging/ /
 
+ARG EXTRA_RUN_DEPS=""
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-&&  apt-get install --yes --no-install-recommends $RUN_DEPS
+&&  apt-get install --yes --no-install-recommends $RUN_DEPS $EXTRA_RUN_DEPS \
+&&  rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /netatalk-code/distrib/docker/config_watch.sh /config_watch.sh
 COPY /distrib/docker/env_setup_netatalk.sh /env_setup.sh

--- a/doc/developer/dircache.md
+++ b/doc/developer/dircache.md
@@ -407,6 +407,9 @@ These metrics are reported for both cache modes:
 - **expunged**: Invalid entries detected and removed during cache validation before use
 - **invalid_on_use**: Entries found invalid when actually used (tune `dircache validation freq` if high)
 - **evicted**: Entries removed due to cache capacity limits
+- **covered_cancelled**: Deferred delete-children jobs cancelled because a
+  completed ancestor scan already removed their entries (tree deletes; see
+  Part 8)
 - **validation_freq**: Current validation frequency setting
 
 ### LRU Mode Statistics
@@ -422,7 +425,7 @@ LRU mode provides straightforward hit/miss metrics:
 dircache statistics (LRU): (user: jdoe) entries: 98234, max_entries: 131072,
 config_max: 131072, lookups: 2458716, hits: 1806407 (73.5%), misses: 652309 (26.5%),
 validations: ~24587 (1.0%), added: 152341, removed: 54107, expunged: 8921,
-invalid_on_use: 234, evicted: 53873, validation_freq: 100
+invalid_on_use: 234, evicted: 53873, covered_cancelled: 67, validation_freq: 100
 ```
 
 ### ARC Mode Statistics
@@ -472,7 +475,7 @@ dircache statistics (ARC): (user: jdoe) entries: 98234, ghost_entries: 32838,
 max_entries: 131072, config_max: 131072, lookups: 2458716, hits: 1954327 (79.5%),
 ghost_hits: 322351 (13.1%), total_hits: (92.6%), misses: 182038 (7.4%),
 validations: 21365 (0.9%), added: 152341, removed: 54107, expunged: 7234,
-invalid_on_use: 187, evicted: 53873, validation_freq: 100
+invalid_on_use: 187, evicted: 53873, covered_cancelled: 67, validation_freq: 100
 
 ARC ghost performance: ghost_hits: 322351 (13.1%), ghost_hits(B1=198423, B2=123928),
 learning_benefit: (13.1%)
@@ -521,14 +524,27 @@ is blocked waiting for client data.
 ### Architecture
 
 The idle worker uses **temporal separation** rather than locks: the worker
-thread and main thread never access shared dircache data concurrently.
+thread and main thread never access shared dircache data concurrently. Three
+seq_cst atomic flags coordinate the handshake (`idle_worker.c`):
 
-- `idle_worker_start()` — called just before `poll()`, sets `is_idle=1`
-  (the worker self-wakes every 10ms via `nanosleep()` and checks this flag)
-- `idle_worker_stop()` — called immediately after `poll()` returns, sets
-  `is_idle=0` and spins until the worker finishes its current unit of work
-- The worker checks `is_idle` per hash chain, yielding instantly when the
-  main thread reclaims access
+- `iw_has_work` — set by the main thread at every enqueue
+  (`iw_note_work()`), cleared by the worker only on full drain
+- `iw_can_work` — main thread only: `iw_grant()` sets it just before
+  blocking in `poll()`, and only when `iw_has_work` is set; `iw_revoke()`
+  clears it after `poll()` returns. With no pending work, no grant is
+  issued and the post-poll path performs no atomic operations at all.
+- `iw_is_working` — worker only: published *before* re-checking
+  `iw_can_work` (Dekker store-then-check), so either the worker sees the
+  revoke and aborts before touching shared data, or main sees
+  `iw_is_working==1` and waits
+
+The worker self-wakes every 10ms via `nanosleep()` and acts only on a
+granted window. It re-checks `iw_can_work` per unit of work — per invalid
+entry freed and per `dir_remove_and_free()` inside a chain batch — so a
+revoke stops it within ~one removal (~1µs). Main's reclaim
+(`iw_wait_release()`) is a single load in the expected case, then a bounded
+cpu-relax spin, then 100µs sleeps — bounding single-core reclaim latency
+that an empty spin would stretch to a scheduler quantum.
 
 ### Deferred Work Types
 
@@ -537,34 +553,54 @@ thread and main thread never access shared dircache data concurrently.
    periods instead of at the end of every AFP command
 2. **Deferred child cleanup** — `dircache_remove_children_defer()` enqueues
    an O(1) descriptor; the worker walks hash chains incrementally, removing
-   stale children in batches of 16 per chain
+   stale children in batches of 16 per chain. Jobs are consumed LIFO: AFP
+   deletes bottom-up, so a tree's covering root-most job is enqueued last,
+   and each completed scan is memoized (byte path, volume, scan-start seq).
+   A popped job that predates the memoized scan and sits at or below its
+   path is already purged — dropped in O(1) without a scan. When every
+   pending job sits at one depth (flat sibling bursts), one merged
+   full-table scan serves all of them: at uniform depth an entry's
+   candidate ancestor is unique and is binary-searched against the sorted
+   member paths. Drops and batch retirements are counted in
+   `covered_cancelled` (dircache statistics).
 
 ### Graceful Degradation
 
 If the worker thread fails to start (e.g., `pthread_create()` failure or
 platforms without lock-free atomics), all operations fall back to synchronous
-behavior transparently. The `idle_worker_is_active()` guard ensures the
+behavior transparently. The `iw_is_active()` guard ensures the
 `dir_free_invalid_q()` call is preserved in the DSIFUNC_CMD handler when
 the worker is not running.
 
-### Signal Safety
+### Shutdown
 
-`afp_dsi_close()` can be called from signal handler context. It uses
-`idle_worker_stop_signal_safe()` which performs only a single atomic store
-(no spin, no mutex). Since all `afp_dsi_close()` paths end in `exit()`,
-the kernel terminates the worker thread.
+`iw_shutdown()` joins the worker (bounded by the 10ms tick — all callers
+run after the main loop revoked the grant) and **abandons** any still-queued
+cleanup work: every caller exits immediately afterwards, the cache dies with
+the process, and the OS reclaims queue memory. Exit paths through
+`afp_dsi_close()` use `iw_revoke_signal_safe()` (a single lock-free atomic
+store, no wait) as a belt-and-braces revoke.
 
 ### Statistics
 
 Worker statistics are logged at session close:
 
 ```txt
-idle_worker stats: cycles=1234 completed=1100 interrupted=134
+iw stats: noted=9341 grants=22849 cycles=1562 completed=1495 interrupted=67 aborted=0 invalid_freed=4910 chains=8734720
 ```
 
-- **cycles**: Total idle cycles entered
-- **completed**: Cycles that finished all pending work
-- **interrupted**: Cycles cut short by `poll()` returning (client data arrived)
+- **noted**: `iw_note_work()` calls — idle-work enqueues by the main thread
+- **grants**: poll cycles that granted the worker the idle window
+  (only issued when work was pending)
+- **cycles**: granted windows the worker acted on (validated grants)
+- **completed**: cycles that drained all pending work
+- **interrupted**: cycles revoked mid-drain (client data arrived);
+  remaining work carries over to a later grant
+- **aborted**: Dekker aborts — grant revoked between the worker's wake and
+  its first touch of shared data (touched nothing)
+- **invalid_freed**: entries freed from the invalid queue by the worker
+- **chains**: `dircache_process_deferred_chain()` calls (hash-chain scan
+  units)
 
 ---
 

--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -159,12 +159,12 @@ static void afp_dsi_close(AFPObj *obj)
 {
     DSI *dsi = obj->dsi;
     sigset_t sigs;
-    /* Sets is_idle=0 — no spin. Async-signal-safe (single atomic store only).
-     * Worker stops at next is_idle check. No spin needed because all
-     * afp_dsi_close() paths end in exit() which terminates the worker. */
-    idle_worker_stop_signal_safe();
+    /* Revokes iw_can_work — no wait. Async-signal-safe (single atomic
+     * store). All afp_dsi_close() paths run post-revoke in main-loop
+     * context and end in exit(); the store is belt-and-braces. */
+    iw_revoke_signal_safe();
     /* Log idle worker stats AFTER stop but BEFORE log_dircache_stat() */
-    idle_worker_log_stats();
+    iw_log_stats();
     close(obj->ipc_fd);
     obj->ipc_fd = -1;
 
@@ -173,9 +173,9 @@ static void afp_dsi_close(AFPObj *obj)
         obj->hint_fd = -1;
     }
 
-    /* we may have been called from a signal handler caught when afpd was running
-     * as uid 0, that's the wrong user for volume's prexec_close scripts if any,
-     * restore our login user
+    /* euid may not be the login user if an error path exited mid-command
+     * (e.g. after become_root()); volume prexec_close scripts need the
+     * login user, restore it
      */
     if (geteuid() != obj->uid) {
         if (seteuid(obj->uid) < 0) {
@@ -562,7 +562,7 @@ static int process_deferred_signals(AFPObj *obj)
     /* Primary reconnect (SIGURG) */
     if (transfer_pending) {
         transfer_pending = 0;
-        idle_worker_stop();
+        iw_revoke();
         handle_transfer_session(obj);
         return 1;
     }
@@ -722,7 +722,7 @@ void afp_over_dsi(AFPObj *obj)
     }
 
     /* Start idle worker thread — failure is non-fatal (synchronous fallback) */
-    (void)idle_worker_init();
+    (void)iw_init();
 
     /* set TCP snd/rcv buf */
     if (obj->options.tcp_rcvbuf) {
@@ -812,14 +812,15 @@ void afp_over_dsi(AFPObj *obj)
             pfds[nfds].fd = sigpipe_fd[0];
             pfds[nfds].events = POLLIN;
             nfds++;
-            /* Signal idle worker to start — we are about to block in poll().
-             * idle_worker_start() is async-signal-safe (single atomic store) */
-            idle_worker_start();
+            /* Grant the idle worker the poll window — only if work is
+             * pending (iw_has_work); otherwise no grant and the paired
+             * iw_revoke() is free. Main-loop context only. */
+            iw_grant();
             /* [D] BLOCK IN POLL */
             int ret = poll(pfds, nfds, -1);
-            /* WARNING: idle_worker_stop() must be called before ANY
+            /* WARNING: iw_revoke() must be called before ANY
              * break/continue after this point */
-            idle_worker_stop();
+            iw_revoke();
 
             /* [E] poll error handling */
             if (ret < 0) {
@@ -889,7 +890,7 @@ void afp_over_dsi(AFPObj *obj)
             /* A deferred SIGURG may have arrived during dsi_stream_receive */
             if (transfer_pending) {
                 transfer_pending = 0;
-                idle_worker_stop();
+                iw_revoke();
                 handle_transfer_session(obj);
                 continue;
             }
@@ -898,14 +899,14 @@ void afp_over_dsi(AFPObj *obj)
             if (dsi->flags & DSI_AFP_LOGGED_OUT) {
                 LOG(log_note, logtype_afpd,
                     "afp_over_dsi: client logged out, terminating DSI session");
-                idle_worker_shutdown();
+                iw_shutdown();
                 afp_dsi_close(obj);
                 exit(0);
             }
 
             if (dsi->flags & DSI_RECONINPROG) {
                 LOG(log_note, logtype_afpd, "afp_over_dsi: failed reconnect");
-                idle_worker_shutdown();
+                iw_shutdown();
                 afp_dsi_close(obj);
                 exit(0);
             }
@@ -975,7 +976,7 @@ void afp_over_dsi(AFPObj *obj)
         switch (cmd) {
         case DSIFUNC_CLOSE:
             LOG(log_debug, logtype_afpd, "DSI: close session request");
-            idle_worker_shutdown();
+            iw_shutdown();
             afp_dsi_close(obj);
             LOG(log_note, logtype_afpd, "done");
             exit(0);
@@ -1020,7 +1021,7 @@ void afp_over_dsi(AFPObj *obj)
                     LOG(log_maxdebug, logtype_afpd, "==> Finished AFP command: %s -> %s",
                         AfpNum2name(function), AfpErr2name(err));
 
-                    if (!idle_worker_is_active()) {
+                    if (!iw_is_active()) {
                         dir_free_invalid_q();
                     }
 

--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -127,20 +127,65 @@ static inline hnode_t *hash_chain_head(hash_t *hash, hashcount_t chain)
 }
 
 /* Deferred cleanup queue — accessed by idle worker.
- * THREADING: main thread enqueues (tail/count++), worker dequeues (head/count--).
- * Never concurrent — temporal separation enforced by idle_worker_start/stop.
- * Plain int is correct; seq_cst fences on is_idle/bg_running ensure visibility. */
+ * THREADING: main thread enqueues at the tail; the worker consumes LIFO
+ * from the tail and compacts dead slots from both ends.
+ * Never concurrent — temporal separation enforced by iw_grant/iw_revoke.
+ * Plain int is correct; seq_cst fences on iw_can_work/iw_is_working ensure
+ * visibility. */
 struct deferred_cleanup {
     char *parent_path;
     size_t parent_len;
     uint16_t v_vid;             /* Volume ID via getvolbyvid() */
     hashcount_t chain_idx;      /* resumable scan progress */
+    unsigned int seq;           /* enqueue order, for covered-cancellation */
+    unsigned int depth;         /* number of '/' in parent_path */
 };
+
+/* Monotonic enqueue counter (main thread writes, worker reads — never
+ * concurrent per the iw_can_work/iw_is_working temporal contract) */
+static unsigned int deferred_seq = 0;
+
+/* Sequence number the currently-scanning job started at; memoized on
+ * completion so jobs enqueued before the scan can be dropped when popped */
+static unsigned int deferred_scan_started_seq = 0;
+
+/* Ring index of the job currently being scanned, -1 = none */
+static int deferred_active = -1;
+
+/* Depth watermarks over jobs enqueued since the ring last drained
+ * (killed jobs do not narrow them — errs toward skipping a batch, never
+ * toward a wrong one). Equal watermarks prove no such job can be a
+ * strict '/'-boundary descendant of another (a descendant has strictly
+ * more slashes), enabling the merged flat batch scan. */
+static unsigned int deferred_depth_min = 0;
+static unsigned int deferred_depth_max = 0;
+
+/* Covering-scan memo: byte path of the most recently completed single-job
+ * scan and the seq that scan started at. Jobs popped later that were
+ * enqueued before that scan and sit at or strictly below the memoized
+ * path are already purged — dropped in O(1) without their own scan.
+ * All comparisons are raw byte memcmp with stored lengths. */
+static char *deferred_cover_path = NULL;
+static size_t deferred_cover_len = 0;
+static uint16_t deferred_cover_vid = 0;
+static unsigned int deferred_cover_seq = 0;
+
+/* Flat batch scan: when every pending job sits at one depth, a single
+ * full-table scan serves them all — each entry's unique candidate
+ * ancestor is its path truncated at the (depth+1)-th slash, matched
+ * against the sorted member paths. */
+static int deferred_batch_active = 0;
+static unsigned int deferred_batch_seq = 0;
+static unsigned int deferred_batch_depth = 0;
+static hashcount_t deferred_batch_chain_idx = 0;
+static int deferred_batch_n = 0;
 
 /* Max deferred/queued entries before fallback to synchronous cleaning */
 #define MAX_DEFERRED_CLEANUPS 5120
 
 static struct deferred_cleanup deferred_queue[MAX_DEFERRED_CLEANUPS];
+/* Sorted (vid, path-bytes) member index for the flat batch scan */
+static int deferred_batch_idx[MAX_DEFERRED_CLEANUPS];
 static int deferred_head = 0;
 static int deferred_tail = 0;
 static int deferred_count = 0;
@@ -171,6 +216,8 @@ static struct dircache_stat {
     unsigned long long evicted;
     /*! entries that failed when used */
     unsigned long long invalid_on_use;
+    /*! deferred jobs cancelled as covered by a completed ancestor scan */
+    unsigned long long covered_cancelled;
 } dircache_stat;
 
 /* Tier 2: Resource Fork data cache statistics.
@@ -2077,7 +2124,7 @@ void log_dircache_stat(void)
             "lookups: %llu, hits: %llu (%.1f%%), ghost_hits: %llu (%.1f%%), total_hits: (%.1f%%), misses: %llu (%.1f%%), "
             "validations: %llu (%.1f%%), "
             "added: %llu, removed: %llu, expunged: %llu, invalid_on_use: %llu, "
-            "evicted: %llu, validation_freq: %u",
+            "evicted: %llu, covered_cancelled: %llu, validation_freq: %u",
             username,
             total_cached,
             total_ghosts,
@@ -2098,6 +2145,7 @@ void log_dircache_stat(void)
             dircache_stat.expunged,
             dircache_stat.invalid_on_use,
             total_arc_evictions,
+            dircache_stat.covered_cancelled,
             dircache_validation_freq);
         /* ARC-specific details: ghost hits breakdown and learning metrics */
         LOG(log_info, logtype_afpd,
@@ -2148,7 +2196,7 @@ void log_dircache_stat(void)
             "entries: %lu, max_entries: %lu (%lu KB), config_max: %u, lookups: %llu, hits: %llu (%.1f%%), misses: %llu (%.1f%%), "
             "validations: %llu (%.1f%%), "
             "added: %llu, removed: %llu, expunged: %llu, invalid_on_use: %llu, evicted: %llu, "
-            "validation_freq: %u",
+            "covered_cancelled: %llu, validation_freq: %u",
             username,
             queue_count,
             queue_count_max,
@@ -2165,6 +2213,7 @@ void log_dircache_stat(void)
             dircache_stat.expunged,
             dircache_stat.invalid_on_use,
             dircache_stat.evicted,
+            dircache_stat.covered_cancelled,
             dircache_validation_freq);
     }
 
@@ -2703,8 +2752,8 @@ void dircache_remove_children_defer(const struct vol *vol, struct dir *dir)
     }
 
     /* Fallback if worker not running or queue full */
-    if (!idle_worker_is_active() || deferred_count >= MAX_DEFERRED_CLEANUPS) {
-        if (idle_worker_is_active() && deferred_count >= MAX_DEFERRED_CLEANUPS) {
+    if (!iw_is_active() || deferred_count >= MAX_DEFERRED_CLEANUPS) {
+        if (iw_is_active() && deferred_count >= MAX_DEFERRED_CLEANUPS) {
             LOG(log_warning, logtype_afpd,
                 "dircache_remove_children_defer: deferred queue full (%d/%d), "
                 "falling back to synchronous removal for \"%s\"",
@@ -2718,31 +2767,87 @@ void dircache_remove_children_defer(const struct vol *vol, struct dir *dir)
 
     struct deferred_cleanup *dc = &deferred_queue[deferred_tail];
 
-    dc->parent_path = strdup(cfrombstr(dir->d_fullpath));
+    /* Byte-exact copy: length from the bstring, no NUL scan, raw memcmp
+     * identity everywhere downstream */
+    size_t plen = (size_t)blength(dir->d_fullpath);
+    const char *pdata = bdata(dir->d_fullpath);
+
+    if (!pdata) {
+        dircache_remove_children(vol, dir);
+        return;
+    }
+
+    dc->parent_path = malloc(plen + 1);
 
     if (!dc->parent_path) {
         dircache_remove_children(vol, dir);
         return;
     }
 
-    dc->parent_len = strnlen(dc->parent_path, MAXPATHLEN);
+    memcpy(dc->parent_path, pdata, plen);
+    dc->parent_path[plen] = '\0';
+    dc->parent_len = plen;
     dc->v_vid = vol->v_vid;
     dc->chain_idx = 0;
+    dc->seq = deferred_seq++;
+    dc->depth = 0;
+
+    for (size_t bi = 0; bi < plen; bi++) {
+        if (dc->parent_path[bi] == '/') {
+            dc->depth++;
+        }
+    }
+
+    if (deferred_count == 0) {
+        deferred_depth_min = dc->depth;
+        deferred_depth_max = dc->depth;
+    } else {
+        if (dc->depth < deferred_depth_min) {
+            deferred_depth_min = dc->depth;
+        }
+
+        if (dc->depth > deferred_depth_max) {
+            deferred_depth_max = dc->depth;
+        }
+    }
+
     deferred_tail = (deferred_tail + 1) % MAX_DEFERRED_CLEANUPS;
     deferred_count++;
+    iw_note_work();
     LOG(log_debug, logtype_afpd,
         "dircache_remove_children_defer: queued \"%s\" (%d pending)",
         cfrombstr(dir->d_fullpath), deferred_count);
 }
+
+static void deferred_job_kill(int idx);
+static void deferred_compact_head(void);
 
 /*!
  * @brief Process deferred cleanup entries for a closing volume synchronously.
  *
  * @pre: Worker is dormant (called during AFP command processing).
  * Called from afp_closevol() before volume structures are freed.
+ * Drops the preselected active-job cursor if it points at this volume.
  */
 void dircache_flush_deferred_for_vol(uint16_t vid)
 {
+    if (deferred_active >= 0 &&
+            deferred_queue[deferred_active].v_vid == vid) {
+        deferred_active = -1;
+    }
+
+    /* Flush kills slots, invalidating an in-flight batch's member index
+     * and the covering memo for this volume — drop both; kills are
+     * idempotent so a restarted batch is correct */
+    deferred_batch_active = 0;
+    deferred_batch_n = 0;
+
+    if (deferred_cover_path && deferred_cover_vid == vid) {
+        free(deferred_cover_path);
+        deferred_cover_path = NULL;
+        deferred_cover_len = 0;
+    }
+
     int remaining = deferred_count;
 
     for (int i = 0; i < remaining; i++) {
@@ -2780,29 +2885,14 @@ void dircache_flush_deferred_for_vol(uint16_t vid)
                         }
                     }
                 }
-
-                free(deferred_queue[idx].parent_path);
             }
 
-            deferred_queue[idx].parent_path = NULL;
-            deferred_queue[idx].v_vid = 0;
+            deferred_job_kill(idx);
         }
     }
 
     /* Compact: advance head past any dead entries */
-    while (deferred_count > 0) {
-        struct deferred_cleanup *dc = &deferred_queue[deferred_head];
-
-        if (dc->v_vid != 0 && dc->parent_path != NULL) {
-            break;
-        }
-
-        free(dc->parent_path);  /* safe if NULL */
-        dc->parent_path = NULL;
-        dc->v_vid = 0;
-        deferred_head = (deferred_head + 1) % MAX_DEFERRED_CLEANUPS;
-        deferred_count--;
-    }
+    deferred_compact_head();
 }
 
 /* Called by idle worker — returns true if deferred work exists */
@@ -2812,11 +2902,342 @@ int dircache_has_deferred_work(void)
 }
 
 /*!
- * @brief Process one hash chain from the current deferred cleanup job.
+ * @brief Free a job slot without completing it (volume gone / covered).
+ */
+static void deferred_job_kill(int idx)
+{
+    free(deferred_queue[idx].parent_path);
+    deferred_queue[idx].parent_path = NULL;
+    deferred_queue[idx].v_vid = 0;
+}
+
+/*!
+ * @brief Advance deferred_head past dead slots, keeping count consistent.
+ */
+static void deferred_compact_head(void)
+{
+    while (deferred_count > 0 &&
+            deferred_queue[deferred_head].parent_path == NULL) {
+        deferred_queue[deferred_head].v_vid = 0;
+        deferred_head = (deferred_head + 1) % MAX_DEFERRED_CLEANUPS;
+        deferred_count--;
+    }
+}
+
+/*!
+ * @brief Test path strictly below parent: byte-prefix at a '/' boundary.
  *
- * Called by idle worker. Walks a single hash chain, collects up to
- * DEFERRED_CHAIN_BATCH matching children, and removes+frees them via
- * dir_remove_and_free(). Entries matching curdir are skipped.
+ * The boundary byte check rejects sibling prefixes ("/A/BC" under "/A/B").
+ *
+ * @returns 1 if path is a strict descendant of parent_path, else 0
+ */
+static int path_is_strict_child(const char *path, size_t len,
+                                const char *parent_path, size_t parent_len)
+{
+    return path && len > parent_len &&
+           memcmp(path, parent_path, parent_len) == 0 &&
+           path[parent_len] == '/';
+}
+
+/*!
+ * @brief Remember a completed scan as the covering memo.
+ */
+static void deferred_cover_set(const struct deferred_cleanup *done,
+                               unsigned int scan_seq)
+{
+    free(deferred_cover_path);
+    deferred_cover_path = malloc(done->parent_len + 1);
+
+    if (!deferred_cover_path) {
+        deferred_cover_len = 0;
+        return;
+    }
+
+    memcpy(deferred_cover_path, done->parent_path, done->parent_len);
+    deferred_cover_path[done->parent_len] = '\0';
+    deferred_cover_len = done->parent_len;
+    deferred_cover_vid = done->v_vid;
+    deferred_cover_seq = scan_seq;
+}
+
+/*!
+ * @brief Test whether a popped job is covered by the memoized scan.
+ *
+ * Covered iff enqueued before that scan started (serial-number compare:
+ * the unsigned seq difference exceeds half the counter space iff the job
+ * predates the scan, fully defined across wraparound), same volume, and
+ * its byte path equals or sits strictly below the memoized path at a '/'
+ * boundary.
+ *
+ * @returns 1 if the job's entries were already purged, else 0
+ */
+static int deferred_cover_drops(const struct deferred_cleanup *j)
+{
+    return deferred_cover_path &&
+           (j->seq - deferred_cover_seq) >= 0x80000000u &&
+           j->v_vid == deferred_cover_vid &&
+           (j->parent_len == deferred_cover_len
+            ? memcmp(j->parent_path, deferred_cover_path,
+                     deferred_cover_len) == 0
+            : path_is_strict_child(j->parent_path, j->parent_len,
+                                   deferred_cover_path,
+                                   deferred_cover_len));
+}
+
+/*!
+ * @brief Compact deferred_tail backwards past dead slots.
+ *
+ * LIFO consumption retires slots at the tail; head compaction still
+ * handles slots killed by the volume flush.
+ */
+static void deferred_compact_tail(void)
+{
+    while (deferred_count > 0) {
+        int last = (deferred_tail + MAX_DEFERRED_CLEANUPS - 1)
+                   % MAX_DEFERRED_CLEANUPS;
+
+        if (deferred_queue[last].parent_path != NULL) {
+            break;
+        }
+
+        deferred_queue[last].v_vid = 0;
+        deferred_tail = last;
+        deferred_count--;
+    }
+
+    if (deferred_count == 0) {
+        deferred_depth_min = 0;
+        deferred_depth_max = 0;
+    }
+}
+
+/*!
+ * @brief qsort comparator for batch members: vid, then path bytes.
+ */
+static int deferred_batch_cmp(const void *a, const void *b)
+{
+    const struct deferred_cleanup *ja = &deferred_queue[*(const int *)a];
+    const struct deferred_cleanup *jb = &deferred_queue[*(const int *)b];
+
+    if (ja->v_vid != jb->v_vid) {
+        return ja->v_vid < jb->v_vid ? -1 : 1;
+    }
+
+    size_t n = ja->parent_len < jb->parent_len ? ja->parent_len
+               : jb->parent_len;
+    int c = memcmp(ja->parent_path, jb->parent_path, n);
+
+    if (c != 0) {
+        return c;
+    }
+
+    return ja->parent_len < jb->parent_len ? -1
+           : ja->parent_len > jb->parent_len ? 1 : 0;
+}
+
+/*!
+ * @brief Test whether an entry path is covered by a batch member.
+ *
+ * The candidate ancestor is unique at uniform depth: the entry path
+ * truncated at its (batch_depth+1)-th slash. Binary search over the
+ * sorted member index; byte comparisons only.
+ *
+ * @returns member index-array position, or -1
+ */
+static int deferred_batch_match(uint16_t vid, const char *ep, size_t elen)
+{
+    unsigned int slashes = 0;
+    size_t cand_len = 0;
+
+    for (size_t bi = 0; bi < elen; bi++) {
+        if (ep[bi] == '/') {
+            slashes++;
+
+            if (slashes == deferred_batch_depth + 1) {
+                cand_len = bi;
+                break;
+            }
+        }
+    }
+
+    /* Entry at or above member depth cannot be a strict descendant */
+    if (cand_len == 0) {
+        return -1;
+    }
+
+    int lo = 0;
+    int hi = deferred_batch_n - 1;
+
+    while (lo <= hi) {
+        int mid = lo + (hi - lo) / 2;
+        const struct deferred_cleanup *m =
+                &deferred_queue[deferred_batch_idx[mid]];
+        int c;
+
+        if (vid != m->v_vid) {
+            c = vid < m->v_vid ? -1 : 1;
+        } else {
+            size_t n = cand_len < m->parent_len ? cand_len : m->parent_len;
+            c = memcmp(ep, m->parent_path, n);
+
+            if (c == 0) {
+                c = cand_len < m->parent_len ? -1
+                    : cand_len > m->parent_len ? 1 : 0;
+            }
+        }
+
+        if (c == 0) {
+            return mid;
+        }
+
+        if (c < 0) {
+            hi = mid - 1;
+        } else {
+            lo = mid + 1;
+        }
+    }
+
+    return -1;
+}
+
+/*!
+ * @brief Start a flat batch scan over every live pending job.
+ *
+ * @pre deferred_depth_min == deferred_depth_max and no batch is active.
+ * @returns 1 if the batch was armed, 0 if no live members exist
+ */
+static int deferred_batch_start(void)
+{
+    deferred_batch_n = 0;
+
+    for (int i = 0; i < deferred_count; i++) {
+        int idx = (deferred_head + i) % MAX_DEFERRED_CLEANUPS;
+
+        if (deferred_queue[idx].parent_path) {
+            deferred_batch_idx[deferred_batch_n++] = idx;
+        }
+    }
+
+    if (deferred_batch_n == 0) {
+        return 0;
+    }
+
+    qsort(deferred_batch_idx, deferred_batch_n, sizeof(int),
+          deferred_batch_cmp);
+    deferred_batch_active = 1;
+    deferred_batch_seq = deferred_seq;
+    deferred_batch_depth = deferred_depth_min;
+    deferred_batch_chain_idx = 0;
+    return 1;
+}
+
+/*!
+ * @brief Finish the flat batch scan: retire every pre-batch member.
+ *
+ * Mid-batch enqueues (seq >= batch seq) stay pending — their entries may
+ * sit in chains the batch already passed.
+ */
+static void deferred_batch_complete(void)
+{
+    for (int i = 0; i < deferred_batch_n; i++) {
+        int idx = deferred_batch_idx[i];
+
+        if (deferred_queue[idx].parent_path &&
+                (deferred_queue[idx].seq - deferred_batch_seq)
+                >= 0x80000000u) {
+            deferred_job_kill(idx);
+            dircache_stat.covered_cancelled++;
+        }
+    }
+
+    deferred_batch_active = 0;
+    deferred_batch_n = 0;
+    deferred_compact_tail();
+    deferred_compact_head();
+}
+
+/*!
+ * @brief Scan one hash chain for the flat batch: purge every entry whose
+ *        unique candidate ancestor is a batch member.
+ *
+ * @returns 1 if more chains remain, 0 when the batch completed
+ */
+static int deferred_batch_chain(void)
+{
+    hashcount_t nchains = hash_size(dircache);
+
+    if (deferred_batch_chain_idx >= nchains) {
+        deferred_batch_complete();
+        return deferred_count > 0;
+    }
+
+    struct dir *to_remove[DEFERRED_CHAIN_BATCH];
+
+    int remove_count = 0;
+    hnode_t *node = hash_chain_head(dircache, deferred_batch_chain_idx);
+
+    while (node) {
+        hnode_t *next = node->hash_next;
+        struct dir *entry = hnode_get(node);
+
+        if (entry == curdir) {
+            node = next;
+            continue;
+        }
+
+        if (entry->d_did != CNID_INVALID && entry->d_fullpath) {
+            const char *ep = cfrombstr(entry->d_fullpath);
+            size_t elen = (size_t)blength(entry->d_fullpath);
+
+            if (ep &&
+                    deferred_batch_match(entry->d_vid, ep, elen) >= 0) {
+                if (remove_count < DEFERRED_CHAIN_BATCH) {
+                    to_remove[remove_count++] = entry;
+                } else {
+                    break;  /* Batch full — will re-scan this chain */
+                }
+            }
+        }
+
+        node = next;
+    }
+
+    for (int i = 0; i < remove_count; i++) {
+        if (!iw_grant_active()) {
+            return 1;
+        }
+
+        AFP_ASSERT(to_remove[i] != curdir);
+        const struct vol *vol =
+            getvolbyvid(to_remove[i]->d_vid);
+
+        if (vol) {
+            dir_remove_and_free(vol, to_remove[i]);
+        }
+    }
+
+    if (remove_count < DEFERRED_CHAIN_BATCH) {
+        deferred_batch_chain_idx++;
+
+        if (deferred_batch_chain_idx >= nchains) {
+            deferred_batch_complete();
+            return deferred_count > 0;
+        }
+    }
+
+    return 1;
+}
+
+/*!
+ * @brief Process one unit of deferred cleanup.
+ *
+ * Called by idle worker under a validated grant. Jobs are consumed LIFO:
+ * AFP deletes bottom-up, so a tree's covering root-most job arrives last
+ * and its single scan purges the whole subtree; the covering memo then
+ * drops the tree's remaining jobs in O(1) as they pop. When every pending
+ * job sits at one depth, one merged batch scan serves all of them.
+ * Every removal re-checks iw_can_work; scans resume via their chain
+ * cursors across granted cycles.
  *
  * @returns 1 if more work remains, 0 if all deferred work is complete
  */
@@ -2826,35 +3247,66 @@ int dircache_process_deferred_chain(void)
         return 0;
     }
 
-    struct deferred_cleanup *dc = &deferred_queue[deferred_head];
+    if (deferred_batch_active) {
+        return deferred_batch_chain();
+    }
+
+    /* Select LIFO: newest live job at the tail */
+    if (deferred_active < 0) {
+        deferred_compact_tail();
+        deferred_compact_head();
+
+        if (deferred_count == 0) {
+            return 0;
+        }
+
+        /* Uniform depth across a multi-job queue: merge into one scan */
+        if (deferred_count > 1 &&
+                deferred_depth_min == deferred_depth_max) {
+            if (deferred_batch_start()) {
+                return deferred_batch_chain();
+            }
+
+            return deferred_count > 0;
+        }
+
+        int last = (deferred_tail + MAX_DEFERRED_CLEANUPS - 1)
+                   % MAX_DEFERRED_CLEANUPS;
+        const struct deferred_cleanup *cand = &deferred_queue[last];
+
+        /* Already purged by the memoized covering scan: drop in O(1) */
+        if (deferred_cover_drops(cand)) {
+            deferred_job_kill(last);
+            dircache_stat.covered_cancelled++;
+            deferred_compact_tail();
+            return deferred_count > 0;
+        }
+
+        deferred_active = last;
+        deferred_scan_started_seq = deferred_seq;
+    }
+
+    struct deferred_cleanup *dc = &deferred_queue[deferred_active];
 
     /* Volume safety — look up by VID, skip if volume was closed */
     const struct vol *vol = getvolbyvid(dc->v_vid);
 
     if (!vol) {
-        /* Volume was closed — discard this deferred entry */
-        free(dc->parent_path);
-        dc->parent_path = NULL;
-        deferred_head = (deferred_head + 1) % MAX_DEFERRED_CLEANUPS;
-        deferred_count--;
-        return deferred_count > 0;
-    }
-
-    if (!dc->parent_path) {
-        /* Defensive: parent_path should never be NULL for a committed entry */
-        deferred_head = (deferred_head + 1) % MAX_DEFERRED_CLEANUPS;
-        deferred_count--;
+        deferred_job_kill(deferred_active);
+        deferred_active = -1;
+        deferred_compact_tail();
+        deferred_compact_head();
         return deferred_count > 0;
     }
 
     hashcount_t nchains = hash_size(dircache);
 
     if (dc->chain_idx >= nchains) {
-        /* All chains scanned — job complete */
-        free(dc->parent_path);
-        dc->parent_path = NULL;
-        deferred_head = (deferred_head + 1) % MAX_DEFERRED_CLEANUPS;
-        deferred_count--;
+        deferred_cover_set(dc, deferred_scan_started_seq);
+        deferred_job_kill(deferred_active);
+        deferred_active = -1;
+        deferred_compact_tail();
+        deferred_compact_head();
         return deferred_count > 0;
     }
 
@@ -2877,10 +3329,8 @@ int dircache_process_deferred_chain(void)
                 entry->d_fullpath) {
             const char *ep = cfrombstr(entry->d_fullpath);
 
-            if (ep &&
-                    (size_t)blength(entry->d_fullpath) > dc->parent_len &&
-                    memcmp(ep, dc->parent_path, dc->parent_len) == 0 &&
-                    ep[dc->parent_len] == '/') {
+            if (path_is_strict_child(ep, (size_t)blength(entry->d_fullpath),
+                                     dc->parent_path, dc->parent_len)) {
                 if (remove_count < DEFERRED_CHAIN_BATCH) {
                     to_remove[remove_count++] = entry;
                 } else {
@@ -2892,8 +3342,16 @@ int dircache_process_deferred_chain(void)
         node = next;
     }
 
-    /* Remove and free collected entries directly */
+    /* Remove and free collected entries directly.
+     * iw_can_work is re-checked before EVERY removal so a revoke stops the
+     * worker within ~one dir_remove_and_free (~1µs); chain_idx is not
+     * advanced, so the next granted cycle rescans this chain — entries
+     * already removed no longer match and are not double-freed. */
     for (int i = 0; i < remove_count; i++) {
+        if (!iw_grant_active()) {
+            return 1;
+        }
+
         AFP_ASSERT(to_remove[i] != curdir);
         dir_remove_and_free(vol, to_remove[i]);
     }
@@ -2903,10 +3361,11 @@ int dircache_process_deferred_chain(void)
         dc->chain_idx++;
 
         if (dc->chain_idx >= nchains) {
-            free(dc->parent_path);
-            dc->parent_path = NULL;
-            deferred_head = (deferred_head + 1) % MAX_DEFERRED_CLEANUPS;
-            deferred_count--;
+            deferred_cover_set(dc, deferred_scan_started_seq);
+            deferred_job_kill(deferred_active);
+            deferred_active = -1;
+            deferred_compact_tail();
+            deferred_compact_head();
             return deferred_count > 0;
         }
     }

--- a/etc/afpd/dircache.h
+++ b/etc/afpd/dircache.h
@@ -28,9 +28,7 @@
 #define MAX_DIRCACHE_SIZE 1048576          /* 1M maximum (high-memory servers) */
 #define DIRCACHE_FREE_QUANTUM 256
 
-/* Max dircache entries removed per hash chain per idle worker iteration.
- * 16 is compromise between latency (~1μs per dir_free × 16 = ~16μs per batch)
- * and is_idle polling frequency (instant yield to AFP commands) */
+/* Batch collect bound per chain scan; iw_can_work re-checked per removal */
 #define DEFERRED_CHAIN_BATCH 16
 
 /* flags for dircache_remove */

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -105,8 +105,9 @@ struct path Cur_Path = {
  * This queue is accessed by both the main thread and the idle worker thread,
  * but NEVER concurrently. Temporal separation is enforced by:
  *   - Main thread: accesses during AFP command processing (worker dormant)
- *   - Worker thread: accesses during idle periods (main thread in poll())
- *   - idle_worker_stop() spin-wait guarantees the transition
+ *   - Worker thread: accesses only within its iw_is_working==1 window,
+ *     entered only under an iw_can_work grant (main blocked in poll())
+ *   - iw_revoke()'s wait-for-release guarantees the transition
  *
  * The queue implementation (queue.c) is NOT thread-safe. Do NOT add
  * concurrent access without adding synchronization.
@@ -1550,6 +1551,7 @@ int dir_remove(const struct vol *vol, struct dir *dir, int report_invalid)
     dircache_remove(vol, dir, DIRCACHE | DIDNAME_INDEX | QUEUE_INDEX); /* 2 */
     /* Queue pruned entry for memory deallocation */
     enqueue(invalid_dircache_entries, dir); /* 3 */
+    iw_note_work();
 
     /* Only null out curdir if we're removing a directory */
     if (curdir == dir && !(dir->d_flags & DIRF_ISFILE)) { /* 4 */

--- a/etc/afpd/idle_worker.c
+++ b/etc/afpd/idle_worker.c
@@ -31,96 +31,174 @@
 #include "idle_worker.h"
 
 /* Self-wake interval for the idle worker thread. 10ms ~0.005% CPU overhead */
-#define IDLE_WORKER_WAKE_MS 10
-_Static_assert(IDLE_WORKER_WAKE_MS < 1000,
-               "Use a while loop for nanosecond normalization if IDLE_WORKER_WAKE_MS >= 1s");
+#define IW_WAKE_MS 10
+_Static_assert(IW_WAKE_MS < 1000,
+               "Use a while loop for nanosecond normalization if IW_WAKE_MS >= 1s");
 
-/* Atomic coordination flags.
- * Using default memory_order_seq_cst for all atomic operations. Could use
- * acquire/release for ~25ns savings on ARM, but seq_cst is simpler and the
- * overhead is negligible relative to nanosleep() syscall cost (~1-5μs). */
-static atomic_int is_idle = 0;
-static atomic_int bg_running = 0;
-static atomic_int shutdown_flag = 0;
+/* iw_wait_release() phase 1: bounded cpu-relax spin iterations.
+ * With per-removal iw_can_work checks the worker residual after a revoke is
+ * ~one dir_remove_and_free (~1µs); 128 pause iterations (~5-13µs on modern
+ * x86) cover it on multi-core without ever sleeping. */
+#define IW_SPIN_ITERATIONS 128
 
-static pthread_t worker_tid;
-static int       worker_started = 0;
+/* iw_wait_release() phase 2: sleep quantum while waiting on a preempted or
+ * single-core worker. 100µs bounds the single-core reclaim latency; an
+ * empty spin here would burn a 1-10ms scheduler quantum starving the
+ * worker it waits on. */
+#define IW_WAIT_SLEEP_NS 100000L
 
-/* Worker thread metrics */
+#if defined(__x86_64__) || defined(__i386__)
+#define IW_CPU_RELAX() __builtin_ia32_pause()
+#elif defined(__aarch64__) || defined(__arm__)
+#define IW_CPU_RELAX() __asm__ __volatile__("yield" ::: "memory")
+#else
+#define IW_CPU_RELAX() __asm__ __volatile__("" ::: "memory")
+#endif
+
+/*
+ * Handshake flags — seq_cst everywhere (C11 default). Both sides store one
+ * flag then load the other (StoreLoad); acquire/release does not order that
+ * and races on store-buffer forwarding.
+ *   iw_has_work   set by main at every enqueue (iw_note_work), cleared by
+ *                 the worker only on full drain, before iw_is_working
+ *   iw_can_work   main only: granted while blocked in poll(), then revoked
+ *   iw_is_working worker only: published before re-checking iw_can_work
+ *                 (Dekker store-then-check), cleared on abort/interrupt/done
+ */
+static atomic_int iw_has_work = 0;
+static atomic_int iw_can_work = 0;
+static atomic_int iw_is_working = 0;
+static atomic_int iw_shutdown_flag = 0;
+
+static pthread_t iw_tid;
+static int       iw_started = 0;
+
+/* Main-thread-only: whether the current poll() cycle granted iw_can_work.
+ * Lets iw_revoke() skip all atomics when no grant was issued. */
+static int iw_granted = 0;
+
+/* Cumulative statistics. Relaxed atomics: written by both threads, read by
+ * iw_log_stats() while the worker may still be alive; counters carry no
+ * synchronization role. */
 static struct {
-    unsigned int cycles_started;      /* idle cycles entered */
-    unsigned int cycles_completed;    /* idle cycles that finished all work */
-    unsigned int cycles_interrupted;  /* idle cycles cut short by poll() return */
-} worker_stat;
+    /* iw_note_work() calls (enqueues) */
+    atomic_uint work_noted;
+    /* poll cycles that granted */
+    atomic_uint grants;
+    /* validated grants acted on */
+    atomic_uint cycles_started;
+    /* full drains (iw_has_work cleared) */
+    atomic_uint cycles_completed;
+    /* revoked mid-drain */
+    atomic_uint cycles_interrupted;
+    /* Dekker abort before touching data */
+    atomic_uint cycles_aborted;
+    /* invalid queue entries freed */
+    atomic_uint invalid_freed;
+    /* dircache_process_deferred_chain calls */
+    atomic_uint chains_processed;
+} iw_stat;
+
+#define IW_STAT_INC(field) \
+    atomic_fetch_add_explicit(&iw_stat.field, 1, memory_order_relaxed)
+
+/* Compile-time check for lock-free atomics.
+ * iw_revoke_signal_safe() may run in signal-handler context where atomic
+ * operations must be lock-free (no hidden mutex). On platforms where
+ * ATOMIC_INT_LOCK_FREE != 2 the idle worker is disabled entirely and all
+ * producers/consumers take the synchronous fallback paths. */
+#if ATOMIC_INT_LOCK_FREE != 2
+
+int iw_init(void)
+{
+    LOG(log_warning, logtype_afpd,
+        "iw_init: lock-free atomics unavailable, using synchronous fallback");
+    return -1;
+}
+
+void iw_grant(void) { }
+void iw_revoke(void) { }
+void iw_revoke_signal_safe(void) { }
+void iw_shutdown(void) { }
+void iw_note_work(void) { }
+int  iw_grant_active(void)
+{
+    return 0;
+}
+int  iw_is_active(void)
+{
+    return 0;
+}
+void iw_log_stats(void) { }
+
+#else /* ATOMIC_INT_LOCK_FREE == 2 */
 
 /*!
- * @brief Check if any idle work is pending (work-availability predicate).
+ * @brief Work-pending predicate.
  *
- * This function serves two purposes:
- * 1. Idle guard: the is_idle check ensures the worker does not start work
- *    when the main thread is NOT in poll(). Also prevents work during the
- *    window between idle_worker_stop() and the next idle_worker_start().
- * 2. Work-availability predicate: returns true only if there is actual
- *    work to perform. If new work types are added to the idle worker
- *    (e.g., FCE event dispatch), their pending-work check MUST be added
- *    here — otherwise the worker will sleep through available work.
+ * Only valid on the worker thread while iw_is_working==1: inside that
+ * window main is either blocked in poll() or waiting in iw_wait_release(),
+ * so the non-atomic queue reads cannot race with producer writes.
  */
-static int idle_worker_has_work(void)
+static int iw_work_pending(void)
 {
-    if (!atomic_load(&is_idle)) {
-        return 0;
-    }
-
-    /* Non-atomic read of queue sentinel pointers is safe here because:
-     * 1. atomic_load(&is_idle) with seq_cst provides a full memory fence
-     * 2. is_idle==1 means main thread is in poll() (cannot modify queue) */
     return (invalid_dircache_entries &&
             invalid_dircache_entries->next != invalid_dircache_entries)
            || dircache_has_deferred_work();
 }
 
 /*!
- * @brief Worker thread main loop
+ * @brief Worker thread main loop.
  *
- * Uses nanosleep() for 10ms polling which is a direct SYS_nanosleep syscall
+ * Single tier: sleep IW_WAKE_MS, then act only on a granted window.
+ * iw_can_work==1 implies work exists (main grants only with iw_has_work
+ * set), so no discovery pass is needed.
+ *
+ * Dekker start: iw_is_working is published BEFORE the re-check of
+ * iw_can_work. Either this thread sees the revoke and aborts before
+ * touching shared data, or main sees iw_is_working==1 and waits in
+ * iw_wait_release() — seq_cst guarantees at least one of the two.
  */
-static void *idle_worker_main(void *arg)
+static void *iw_main(void *arg)
 {
     (void)arg;
-    /* Block all Signals — worker thread must not receive process signals */
+    /* Block all signals — worker thread must not receive process signals */
     sigset_t sigs;
     sigfillset(&sigs);
     pthread_sigmask(SIG_BLOCK, &sigs, NULL);
     const struct timespec sleep_ts = {
         .tv_sec = 0,
-        .tv_nsec = IDLE_WORKER_WAKE_MS * 1000000L
+        .tv_nsec = IW_WAKE_MS * 1000000L
     };
 
-    while (!atomic_load(&shutdown_flag)) {
-        /* nanosleep uses hrtimer internally; the thread is off-CPU
-         * EINTR is harmless: worker thread blocks signals, and
-         * an early wake just re-checks and sleeps again. */
+    while (!atomic_load(&iw_shutdown_flag)) {
+        /* nanosleep uses hrtimer internally; the thread is off-CPU.
+         * EINTR is harmless: signals are blocked, an early wake just
+         * re-checks and sleeps again. */
         nanosleep(&sleep_ts, NULL);
 
-        /* Check if work exists AND main thread is idle */
-        if (!idle_worker_has_work()) {
+        if (!atomic_load(&iw_can_work)) {
             continue;
         }
 
-        /* Note: there is a benign race where idle_worker_stop() may
-         * complete its spin (seeing bg_running==0) before we set it to 1.
-         * This is safe because all work loops below re-check is_idle
-         * before touching shared data */
-        atomic_store(&bg_running, 1);
-        worker_stat.cycles_started++;
+        atomic_store(&iw_is_working, 1);
 
-        /* Process jobs in priority order, checking is_idle per unit of work.
-         * Priority 1: Free entries queued by AFP command handlers.
-         * Priority 2: Deferred dircache_remove_children scans and cleaning. */
+        if (!atomic_load(&iw_can_work)) {
+            /* Revoked between our load and our publish — abort having
+             * touched nothing. */
+            atomic_store(&iw_is_working, 0);
+            IW_STAT_INC(cycles_aborted);
+            continue;
+        }
 
-        /* Free invalidated dircache entries
-         * queued by main thread's dir_remove() during AFP commands */
-        while (atomic_load(&is_idle)) {
+        IW_STAT_INC(cycles_started);
+
+        /* Grant validated: main is in poll(). Process jobs in priority
+         * order, re-checking iw_can_work per unit of work.
+         * Priority 1: free entries queued by dir_remove().
+         * Priority 2: deferred dircache_remove_children chain scans
+         *             (internally re-checks iw_can_work per removal). */
+        while (atomic_load(&iw_can_work)) {
             struct dir *dir = (struct dir *)dequeue(invalid_dircache_entries);
 
             if (!dir) {
@@ -128,53 +206,70 @@ static void *idle_worker_main(void *arg)
             }
 
             dir_free(dir);
+            IW_STAT_INC(invalid_freed);
         }
 
-        /* Clean stale dircache entries — includes ARC ghost entries */
-        while (atomic_load(&is_idle) && dircache_has_deferred_work()) {
-            /* Process one hash chain per iteration */
+        while (atomic_load(&iw_can_work) && dircache_has_deferred_work()) {
             dircache_process_deferred_chain();
+            IW_STAT_INC(chains_processed);
         }
 
-        if (!atomic_load(&is_idle)) {
-            worker_stat.cycles_interrupted++;
+        if (iw_work_pending()) {
+            /* Revoked mid-drain. iw_has_work stays 1 (sticky) so main
+             * re-grants on a later poll cycle. */
+            IW_STAT_INC(cycles_interrupted);
         } else {
-            worker_stat.cycles_completed++;
+            /* Full drain: clear iw_has_work BEFORE releasing — main
+             * cannot produce until it observes iw_is_working==0, so this
+             * store can never clobber a fresh iw_has_work=1. */
+            atomic_store(&iw_has_work, 0);
+            IW_STAT_INC(cycles_completed);
         }
 
-        /* Done or interrupted — signal dormant */
-        atomic_store(&bg_running, 0);
+        atomic_store(&iw_is_working, 0);
     }
 
     return NULL;
 }
 
-/* Compile-time check for lock-free atomics — required for signal safety.
- * idle_worker_stop_signal_safe() is called from signal handler context where
- * atomic operations must be lock-free (no hidden mutex).
- * On exotic platforms (old MIPS, some RISC-V) where ATOMIC_INT_LOCK_FREE != 2,
- * the idle worker is disabled entirely at compile time. */
-#if ATOMIC_INT_LOCK_FREE != 2
-
-int idle_worker_init(void)
+/*!
+ * @brief Wait until the worker has released the shared-data window.
+ *
+ * Phase 0: single load — the expected case (worker finished during the
+ *          poll block, or aborted) returns immediately, zero spin.
+ * Phase 1: bounded spin with cpu-relax. Worker residual after a revoke is
+ *          ~one removal (~1µs) thanks to per-unit checks, so on
+ *          multi-core this phase almost always completes.
+ * Phase 2: 100µs nanosleeps. On single-core the first sleep yields the CPU
+ *          so the (preempted) worker can run, observe the revoke within one
+ *          removal, and release. An empty spin here would burn a 1-10ms
+ *          scheduler quantum starving the very worker it waits on.
+ *          nanosleep EINTR (SIGALRM tickles etc.) is harmless: the loop
+ *          re-checks and handlers only set flags.
+ */
+static void iw_wait_release(void)
 {
-    LOG(log_warning, logtype_afpd,
-        "idle_worker_init: lock-free atomics unavailable, "
-        "using synchronous fallback");
-    return -1;
-}
+    if (!atomic_load(&iw_is_working)) {
+        return;
+    }
 
-void idle_worker_start(void) { }
-void idle_worker_stop(void) { }
-void idle_worker_stop_signal_safe(void) { }
-void idle_worker_shutdown(void) { }
-int  idle_worker_is_active(void)
-{
-    return 0;
-}
-void idle_worker_log_stats(void) { }
+    for (int i = 0; i < IW_SPIN_ITERATIONS; i++) {
+        IW_CPU_RELAX();
 
-#else /* ATOMIC_INT_LOCK_FREE == 2 */
+        if (!atomic_load(&iw_is_working)) {
+            return;
+        }
+    }
+
+    const struct timespec sleep_ts = {
+        .tv_sec = 0,
+        .tv_nsec = IW_WAIT_SLEEP_NS
+    };
+
+    while (atomic_load(&iw_is_working)) {
+        nanosleep(&sleep_ts, NULL);
+    }
+}
 
 /*!
  * @brief Initialize the idle worker thread.
@@ -183,137 +278,178 @@ void idle_worker_log_stats(void) { }
  * Must be called in the afpd child session process (post-fork).
  * The child process does not fork again.
  *
- * Returns -1 (triggering synchronous fallback) if:
- * - pthread_create() fails
+ * Returns -1 (triggering synchronous fallback) if pthread_create() fails.
  */
-int idle_worker_init(void)
+int iw_init(void)
 {
-    if (pthread_create(&worker_tid, NULL, idle_worker_main, NULL) != 0) {
+    if (pthread_create(&iw_tid, NULL, iw_main, NULL) != 0) {
         LOG(log_error, logtype_afpd,
-            "idle_worker_init: pthread_create failed: %s", strerror(errno));
+            "iw_init: pthread_create failed: %s", strerror(errno));
         return -1;
     }
 
-    worker_started = 1;
-    LOG(log_info, logtype_afpd, "idle_worker_init: worker thread started");
+    iw_started = 1;
+    LOG(log_info, logtype_afpd, "iw_init: worker thread started");
     return 0;
 }
 
 /*!
- * @brief Signal the idle worker that the main thread is about to enter poll().
+ * @brief Producer hook: note that idle work was enqueued.
  *
- * Sets is_idle=1 — worker self-wakes via nanosleep to check for work.
- * This function is async-signal-safe (single atomic store only).
- * No signal masking is needed by the caller.
+ * MUST be called on the main thread only, immediately after enqueueing to
+ * any idle-work queue, while the worker is dormant — which is every
+ * AFP-command / cache-hint context, since those run outside the grant
+ * window by construction.
  */
-void idle_worker_start(void)
+void iw_note_work(void)
 {
-    if (!worker_started) {
+    if (!iw_started) {
         return;
     }
 
-    atomic_store(&is_idle, 1);
+    atomic_store(&iw_has_work, 1);
+    IW_STAT_INC(work_noted);
 }
 
 /*!
- * @brief Reclaim exclusive access from the idle worker after poll() returns.
+ * @brief Conditionally grant the worker the shared-data window.
  *
- * Sets is_idle=0 and spins until the worker finishes its current unit of
- * work (bg_running==0). On multi-core systems this completes in nanoseconds.
- * On single-core systems, the OS scheduler will preempt the spinning main
- * thread within one time quantum (~1-10ms), allowing the worker to observe
- * is_idle==0 and clear bg_running.
- *
- * NOT async-signal-safe due to the spin loop — use idle_worker_stop_signal_safe()
- * from signal handler context instead.
+ * Called immediately before blocking in poll(). Grants only if work is
+ * pending: with no work, no grant is issued and the paired
+ * iw_revoke() is a single plain-int check — the no-work hot path performs
+ * one atomic load here and nothing after poll().
+ * Main-loop context only (writes the plain-int iw_granted and stats).
  */
-void idle_worker_stop(void)
+void iw_grant(void)
 {
-    if (!worker_started) {
+    if (!iw_started) {
         return;
     }
 
-    atomic_store(&is_idle, 0);
-
-    /* Spin until worker finishes current unit of work.
-     * No sched_yield() — not async-signal-safe on all platforms, and the
-     * OS preemptive scheduler handles single-core fairness adequately.
-     * On multi-core: completes in nanoseconds (worker checks is_idle per chain).
-     * On single-core: OS preempts within one scheduler quantum (~1-10ms). */
-    while (atomic_load(&bg_running)) {
-        /* empty spin */
+    if (!atomic_load(&iw_has_work)) {
+        return;
     }
+
+    atomic_store(&iw_can_work, 1);
+    iw_granted = 1;
+    IW_STAT_INC(grants);
 }
 
 /*!
- * @brief Signal-safe variant of idle_worker_stop() for signal handler context.
+ * @brief Revoke the grant and reclaim exclusive access after poll() returns.
  *
- * Sets is_idle=0 but does NOT spin on bg_running. This is safe because all
- * code paths that call this function (via afp_dsi_die() → afp_dsi_close())
- * end in exit(), which terminates the worker thread via process exit.
- * The worker will observe is_idle==0 at its next check and stop modifying
- * shared data, but we do not wait for that — exit() handles cleanup.
+ * MUST be called before ANY shared-data access after poll() (including the
+ * EINTR path). Not async-signal-safe (may nanosleep) — signal-context
+ * paths use iw_revoke_signal_safe().
  *
- * Uses only atomic_store() which is async-signal-safe when
- * ATOMIC_INT_LOCK_FREE==2 (verified at compile time).
+ * Dekker: the iw_can_work=0 store precedes the iw_is_working load
+ * inside iw_wait_release(); seq_cst makes the crossing with the worker's
+ * publish-then-recheck safe.
  */
-void idle_worker_stop_signal_safe(void)
+void iw_revoke(void)
 {
-    if (!worker_started) {
+    if (!iw_started || !iw_granted) {
+        /* No grant this cycle: iw_is_working is provably 0 (worker can only
+         * publish after observing iw_can_work==1, which was never set).
+         * Zero atomics on this path. */
         return;
     }
 
-    atomic_store(&is_idle, 0);
-    /* No spin — caller ends in exit(). Worker thread terminated by kernel. */
+    atomic_store(&iw_can_work, 0);
+    iw_wait_release();
+    iw_granted = 0;
 }
 
 /*!
- * @brief Shut down the idle worker thread cleanly.
+ * @brief Signal-safe revoke for exit paths.
  *
- * Sets shutdown flag and joins thread. The worker observes shutdown_flag
- * at the top of its loop — after nanosleep() expires (≤10ms) and after any
- * work completes. Join latency is therefore 10ms plus remaining work time.
- *
- * WARNING: Must NOT be called from signal handler context —
- * pthread_join is async-signal-unsafe. Use idle_worker_stop_signal_safe()
- * in signal handlers instead.
+ * Single lock-free store; does NOT wait for release. Safe because every
+ * caller reaches exit() without returning to AFP command processing, and
+ * at every call site the grant was already revoked by the main loop (the
+ * store is belt-and-braces against future signal-context close paths).
+ * Does not touch iw_granted (not async-signal-safe to reason about; the
+ * process is exiting).
  */
-void idle_worker_shutdown(void)
+void iw_revoke_signal_safe(void)
 {
-    if (!worker_started) {
+    if (!iw_started) {
         return;
     }
 
-    atomic_store(&shutdown_flag, 1);
-    pthread_join(worker_tid, NULL);
-    /* Log stats while worker_started is still 1 */
-    idle_worker_log_stats();
-    worker_started = 0;
-    /* Drain any entries added after the worker's last idle cycle */
-    dir_free_invalid_q();
+    atomic_store(&iw_can_work, 0);
 }
 
-int idle_worker_is_active(void)
+/*!
+ * @brief Shut down the idle worker thread, ABANDONING all queued work.
+ *
+ * The session is ending and every caller exits immediately afterwards
+ * — outstanding dircache cleanup is redundant: the whole cache dies
+ * with the process, and the OS reclaims queue memory at exit(). No drain
+ * is performed.
+ *
+ * Join is bounded: all call sites run after the main loop revoked the
+ * grant, so the worker is dormant in its 10ms tick — it observes
+ * iw_shutdown_flag within IW_WAKE_MS and exits.
+ *
+ * WARNING: not signal-context-safe (pthread_join); callers are main-loop
+ * paths only. Never call on a path that continues serving AFP commands.
+ */
+void iw_shutdown(void)
 {
-    return worker_started;
+    if (!iw_started) {
+        return;
+    }
+
+    atomic_store(&iw_can_work, 0);
+    atomic_store(&iw_shutdown_flag, 1);
+    pthread_join(iw_tid, NULL);
+    /* Log stats while iw_started is still 1 */
+    iw_log_stats();
+    iw_started = 0;
+    /* Queued work intentionally abandoned — caller exits immediately. */
+}
+
+/*!
+ * @brief Revoke-check accessor for worker-side drain code outside this file
+ *        (dircache_process_deferred_chain per-removal check).
+ */
+int iw_grant_active(void)
+{
+    return atomic_load(&iw_can_work);
+}
+
+/*!
+ * @brief True when the worker thread is running (synchronous fallbacks
+ *        apply when it is not).
+ */
+int iw_is_active(void)
+{
+    return iw_started;
 }
 
 /*!
  * @brief Log idle worker statistics.
  *
- * Called from session close (afp_dsi_close).
+ * Called from session close (afp_dsi_close) and iw_shutdown(). Relaxed
+ * reads; the worker may still be alive on die paths (no join there).
  */
-void idle_worker_log_stats(void)
+void iw_log_stats(void)
 {
-    if (!worker_started) {
+    if (!iw_started) {
         return;
     }
 
     LOG(log_info, logtype_afpd,
-        "idle_worker stats: cycles=%u completed=%u interrupted=%u",
-        worker_stat.cycles_started,
-        worker_stat.cycles_completed,
-        worker_stat.cycles_interrupted);
+        "iw stats: noted=%u grants=%u cycles=%u completed=%u "
+        "interrupted=%u aborted=%u invalid_freed=%u chains=%u",
+        atomic_load_explicit(&iw_stat.work_noted, memory_order_relaxed),
+        atomic_load_explicit(&iw_stat.grants, memory_order_relaxed),
+        atomic_load_explicit(&iw_stat.cycles_started, memory_order_relaxed),
+        atomic_load_explicit(&iw_stat.cycles_completed, memory_order_relaxed),
+        atomic_load_explicit(&iw_stat.cycles_interrupted, memory_order_relaxed),
+        atomic_load_explicit(&iw_stat.cycles_aborted, memory_order_relaxed),
+        atomic_load_explicit(&iw_stat.invalid_freed, memory_order_relaxed),
+        atomic_load_explicit(&iw_stat.chains_processed, memory_order_relaxed));
 }
 
 #endif /* ATOMIC_INT_LOCK_FREE */

--- a/etc/afpd/idle_worker.h
+++ b/etc/afpd/idle_worker.h
@@ -15,12 +15,16 @@
 #ifndef IDLE_WORKER_H
 #define IDLE_WORKER_H
 
-extern int  idle_worker_init(void);
-extern void idle_worker_start(void);
-extern void idle_worker_stop(void);
-extern void idle_worker_stop_signal_safe(void);
-extern void idle_worker_shutdown(void);
-extern int  idle_worker_is_active(void);
-extern void idle_worker_log_stats(void);
+/* Lock-free idle worker — handshake contract documented in idle_worker.c */
+
+extern int  iw_init(void);
+extern void iw_grant(void);
+extern void iw_revoke(void);
+extern void iw_revoke_signal_safe(void);
+extern void iw_shutdown(void);
+extern void iw_note_work(void);
+extern int  iw_grant_active(void);
+extern int  iw_is_active(void);
+extern void iw_log_stats(void);
 
 #endif /* IDLE_WORKER_H */


### PR DESCRIPTION
The afpd idle worker (a per-session background thread that does dircache housekeeping while the main thread is blocked in `poll()`) coordinated with the main thread through two flags: main set `is_idle` before *every* `poll()` and cleared it after, then **busy-spun** until the worker acknowledged — even when the worker had no work, and even when the work had finished long ago. On single-core hosts that empty spin starved the very worker it was waiting for, burning a 1–10 ms scheduler quantum that landed directly on first-byte request latency. The old work-discovery gate also read queue sentinels outside any synchronized window — a formal data race (not TSAN-clean).

This PR replaces the handshake with three seq_cst atomic flags, each with a single owner, such that **the main thread never waits unless `poll()` returns while the worker is actively mid-work — and then only for microseconds**.

## The three-flag design

| Flag | Written by | Meaning |
|---|---|---|
| `iw_has_work` | main sets at every enqueue; worker clears on full drain | ≥1 idle job pending |
| `iw_can_work` | main only | grant: main is in `poll()`, worker may touch shared data |
| `iw_is_working` | worker only | worker is (or may be about to be) touching shared data |

Main grants only when work exists (`iw_has_work` is producer-set, so main knows first-hand — no discovery latency). The worker publishes `iw_is_working` *before* re-checking the grant (Dekker store-then-check: either the worker sees the revoke and aborts having touched nothing, or main sees `iw_is_working` and waits — seq_cst guarantees at least one side observes the other). The worker re-checks the grant per unit of work, down to every single entry removal, so a revoke stops it within ~one removal.

## Worked example

Client deletes a directory, then the session goes quiet:

1. `dir_remove()` enqueues the stale cache entry and sets `iw_has_work` (one atomic store — this is main's only overhead at enqueue).
2. Main finishes the command, reaches `poll()`: loads `iw_has_work` (1) → stores `iw_can_work=1` → blocks.
3. The worker's 10 ms tick sees the grant, publishes `iw_is_working=1`, re-checks the grant, drains the queue, clears `iw_has_work`, clears `iw_is_working`. Session still quiet; main still in `poll()`.
4. A request arrives. Main stores `iw_can_work=0`, loads `iw_is_working` — **0, return immediately**. No spin: the work finished during the poll window.
5. Next command enqueues nothing → at the next `poll()`, `iw_has_work` is 0 → **no grant, and the post-poll path does nothing at all** (with no grant issued, `iw_is_working` is provably 0, so not even a load is needed).

The only remaining wait is the race the design cannot remove: the request arrives *while* the worker is mid-unit. Main's reclaim is then phase 0 (one load), a bounded cpu-relax spin (~128 pauses), then 100 µs sleeps — and the worker notices the revoke at its next per-unit check:

| Worker is inside… | Revoke noticed after… | Bound |
|---|---|---|
| nanosleep tick | n/a — `iw_is_working` is 0 | phase 0, no wait |
| invalid-queue drain | current `dir_free()` completes | ~1 µs (pure memory work, no syscalls) |
| removal batch | current removal completes (checked before **every** removal) | ~1 µs |
| covered-job cancellation walk | ≤64 slot inspections (walk suspends, resumes next grant) | ~1–2 µs |
| chain walk (collect phase) | end of current hash chain | 0–2 nodes at default sizing ≈ ns |
| flat-queue fast path | O(1) retire | ns |

On single-core the bounds gain scheduler latency: the first 100 µs sleep yields the CPU, the worker finishes its ~1 µs residual, main resumes — ~100–200 µs worst case, versus the 1–10 ms quantum the old spin burned.

Summary of when main waits:

| Scenario | Old design | New design |
|---|---|---|
| No work pending | 3 atomics + possible spin | 1 load pre-poll, **zero post-poll** |
| Work finished during poll | spin until ack | 1 load, no spin |
| Poll exits while worker mid-unit (multi-core) | spin for unit residual | ~1–2 µs |
| Poll exits while worker mid-unit (single-core) | 1–10 ms scheduler quantum | ~100–200 µs |

<img width="1451" height="962" alt="IdleWorker_statemachine" src="https://github.com/user-attachments/assets/bf6c6a49-fe0c-457b-80a5-6cc496c7659b" />

## Deferred delete-child entry improvements

Deleting a tree enqueues one deferred cleanup job per directory, and every job scanned the entire dircache hash table even though the root-most job's scan removes every descendant entry. Two mechanisms remove the redundancy, with no ring walks at all:

- **LIFO consumption with a covering-scan memo.** AFP deletes bottom-up, so a tree's covering root-most job is enqueued last; the worker consumes the ring LIFO and memoizes each completed scan's byte path and start sequence. A popped job that was enqueued before that scan and sits at or below the memoized path is already purged — dropped in O(1). A tree delete costs ~1 full scan instead of N; a re-created-and-re-deleted directory is exempted by the sequence stamp.
- **Merged batch scan for flat bursts.** When every pending job sits at one depth (the common bulk-delete shape, where no job can cover another), one full-table scan serves all of them: at uniform depth an entry's candidate ancestor is unique — its path truncated at the next slash boundary — and is binary-searched against the sorted member paths. N sibling scans collapse to one.

Path identity is raw bytes throughout (lengths carried explicitly, `memcmp` comparisons, no locale or normalization). Drops and batch retirements are counted in the new `covered_cancelled` dircache statistic.

Session shutdown now abandons queued cleanup outright (the cache dies with the process; every caller exits immediately), so teardown never waits on a backlog.

## Verification

- Full spectest green, both legs (default and `ea = ad`), at each code commit.
- **New TSAN CI job** (Debian testsuite image built with `-Db_sanitize=thread`, sqlite CNID backend, `halt_on_error=1`, no suppressions): full spectest green — the old sentinel-read race is gone, and the job hard-fails on any future race in netatalk code.
- Counter evidence from full runs: `covered_cancelled: 55–67` on nested-delete sessions; `iw stats` showing thousands of granted cycles with `aborted=0` and clean mid-drain interrupts.
- Flamegraph note: the CI folded-stack filter that strips idle-worker nanosleep samples matches the worker's thread-entry symbol by name; it is updated for the rename in the same change. Dashboard runs generated mid-review, between the rename and the filter update, overstate the idle-worker region — only the latest dashboard on this PR is a valid comparison against `main`.

---

This commit looks complex but actually reduces overall complexity.
The triple semaphores remove checks and timer handling and makes the state machine more robust. And the LIFO purging with a single "last entry" memory removes a lot of machinery for the same performance.

This has resulted in % reductions in spectest delete operations, and reduced AFP command latency.

PS; Enabling the TSAN CI failed when using CNID backend - DBD fails TSAN! 😉