### PR TITLE
afpd: relative-stat dircache validation via a parent-dirfd cache

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -302,6 +302,8 @@ jobs:
               -e AFP_DIRCACHESIZE=1024 \
               -e AFP_DIRCACHE_MODE=arc \
               -e AFP_DIRCACHE_VALIDATION_FREQ=100 \
+              -e AFP_DIRCACHE_RFORK_BUDGET=102400 \
+              -e AFP_DIRCACHE_RFORK_MAXSIZE=1024 \
               -e TESTSUITE=spectest \
               -e AFP_VERSION=7 \
               -e FLAMEGRAPH=1 \
@@ -407,8 +409,8 @@ jobs:
               -e AFP_DIRCACHESIZE=1048576 \
               -e AFP_DIRCACHE_VALIDATION_FREQ=100 \
               -e AFP_DIRCACHE_MODE=arc \
-              -e AFP_DIRCACHE_RFORK_BUDGET=1048576000 \
-              -e AFP_DIRCACHE_RFORK_MAXSIZE=1048576 \
+              -e AFP_DIRCACHE_RFORK_BUDGET=1048576 \
+              -e AFP_DIRCACHE_RFORK_MAXSIZE=1024 \
               -e AFP_CONVERT_APPLEDOUBLE=no \
               ${{ env.REGISTRY }}/netatalk/netatalk:${{ github.sha }}
       - name: Run Netatalk testsuite
@@ -471,8 +473,8 @@ jobs:
               -e AFP_DIRCACHESIZE=1048576 \
               -e AFP_DIRCACHE_VALIDATION_FREQ=100 \
               -e AFP_DIRCACHE_MODE=arc \
-              -e AFP_DIRCACHE_RFORK_BUDGET=1048576000 \
-              -e AFP_DIRCACHE_RFORK_MAXSIZE=1048576 \
+              -e AFP_DIRCACHE_RFORK_BUDGET=1048576 \
+              -e AFP_DIRCACHE_RFORK_MAXSIZE=1024 \
               -e AFP_CONVERT_APPLEDOUBLE=no \
               ${{ env.REGISTRY }}/netatalk/netatalk:${{ github.sha }}
       - name: Run Netatalk testsuite
@@ -526,8 +528,8 @@ jobs:
               -e AFP_DIRCACHESIZE=1048576 \
               -e AFP_DIRCACHE_VALIDATION_FREQ=100 \
               -e AFP_DIRCACHE_MODE=arc \
-              -e AFP_DIRCACHE_RFORK_BUDGET=1048576000 \
-              -e AFP_DIRCACHE_RFORK_MAXSIZE=1048576 \
+              -e AFP_DIRCACHE_RFORK_BUDGET=1048576 \
+              -e AFP_DIRCACHE_RFORK_MAXSIZE=1024 \
               -e AFP_CONVERT_APPLEDOUBLE=no \
               ${{ env.REGISTRY }}/netatalk/netatalk:${{ github.sha }}
       - name: Run Netatalk testsuite
@@ -1216,7 +1218,17 @@ jobs:
     permissions:
       contents: write
     env:
+      # Single source of truth: these feed BOTH the container (-e) and the
+      # chart --meta labels, so the plot header always shows the real config.
       AFP_TEST_ITERATIONS: 20
+      AFP_VERSION: 7
+      AFP_VERSION_LABEL: "3.4"
+      AFP_DIRCACHE_MODE: arc
+      AFP_DIRCACHESIZE: 65536
+      AFP_DIRCACHE_VALIDATION_FREQ: 100
+      AFP_SERVER_QUANTUM: 1048576
+      AFP_DIRCACHE_RFORK_BUDGET: 102400
+      AFP_DIRCACHE_RFORK_MAXSIZE: 1024
     outputs:
       slowest: ${{ steps.lantest-summary.outputs.SLOW }}
       aggregates: ${{ steps.lantest-summary.outputs.AGG }}
@@ -1234,9 +1246,13 @@ jobs:
             -e SHARE_NAME="test1" \
             -e INSECURE_AUTH="1" \
             -e TESTSUITE="lan" \
-            -e AFP_VERSION="7" \
-            -e AFP_DIRCACHE_MODE="arc" \
-            -e AFP_DIRCACHE_VALIDATION_FREQ="100" \
+            -e AFP_VERSION="${{ env.AFP_VERSION }}" \
+            -e AFP_DIRCACHE_MODE="${{ env.AFP_DIRCACHE_MODE }}" \
+            -e AFP_DIRCACHESIZE="${{ env.AFP_DIRCACHESIZE }}" \
+            -e AFP_DIRCACHE_VALIDATION_FREQ="${{ env.AFP_DIRCACHE_VALIDATION_FREQ }}" \
+            -e AFP_SERVER_QUANTUM="${{ env.AFP_SERVER_QUANTUM }}" \
+            -e AFP_DIRCACHE_RFORK_BUDGET="${{ env.AFP_DIRCACHE_RFORK_BUDGET }}" \
+            -e AFP_DIRCACHE_RFORK_MAXSIZE="${{ env.AFP_DIRCACHE_RFORK_MAXSIZE }}" \
             -e AFP_TEST_ITERATIONS="${{ env.AFP_TEST_ITERATIONS }}" \
             -e TEST_FLAGS="-c" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }} \
@@ -1298,12 +1314,13 @@ jobs:
             -o lantest \
             --title "Netatalk AFP Lantest — per-test latency" \
             --subtitle "commit ${SHORT_SHA} · candle: min–max wick, mean±σ box, median line" \
-            --meta afp=3.4 \
+            --meta afp=${{ env.AFP_VERSION_LABEL }} \
             --meta iterations=${{ env.AFP_TEST_ITERATIONS }} \
-            --meta quantum_kb=1024 \
-            --meta dircache_mode=arc \
-            --meta dircache_size=65536 \
-            --meta dircache_validation_freq=100
+            --meta quantum_kb=$(( ${{ env.AFP_SERVER_QUANTUM }} / 1024 )) \
+            --meta dircache_mode=${{ env.AFP_DIRCACHE_MODE }} \
+            --meta dircache_size=${{ env.AFP_DIRCACHESIZE }} \
+            --meta dircache_validation_freq=${{ env.AFP_DIRCACHE_VALIDATION_FREQ }} \
+            --meta rfork_budget_kb=${{ env.AFP_DIRCACHE_RFORK_BUDGET }}
           echo "PNG size: $(du -h lantest.png | cut -f1)"
       - name: Extract per-test table and aggregates for PR comment
         id: lantest-summary
@@ -1374,7 +1391,17 @@ jobs:
     permissions:
       contents: write
     env:
+      # Single source of truth: these feed BOTH the container (-e) and the
+      # chart --meta labels, so the plot header always shows the real config.
       AFP_TEST_ITERATIONS: 20
+      AFP_VERSION: 7
+      AFP_VERSION_LABEL: "3.4"
+      AFP_DIRCACHE_MODE: arc
+      AFP_DIRCACHESIZE: 65536
+      AFP_DIRCACHE_VALIDATION_FREQ: 100
+      AFP_SERVER_QUANTUM: 1048576
+      AFP_DIRCACHE_RFORK_BUDGET: 102400
+      AFP_DIRCACHE_RFORK_MAXSIZE: 1024
     outputs:
       peaks: ${{ steps.speedtest-summary.outputs.PEAKS }}
     steps:
@@ -1391,11 +1418,13 @@ jobs:
             -e SHARE_NAME="test1" \
             -e INSECURE_AUTH="1" \
             -e TESTSUITE="speed" \
-            -e AFP_VERSION="7" \
-            -e AFP_DIRCACHE_MODE="arc" \
-            -e AFP_DIRCACHE_VALIDATION_FREQ="100" \
-            -e AFP_DIRCACHE_RFORK_BUDGET="1048576000" \
-            -e AFP_DIRCACHE_RFORK_MAXSIZE="1048576" \
+            -e AFP_VERSION="${{ env.AFP_VERSION }}" \
+            -e AFP_DIRCACHE_MODE="${{ env.AFP_DIRCACHE_MODE }}" \
+            -e AFP_DIRCACHESIZE="${{ env.AFP_DIRCACHESIZE }}" \
+            -e AFP_DIRCACHE_VALIDATION_FREQ="${{ env.AFP_DIRCACHE_VALIDATION_FREQ }}" \
+            -e AFP_SERVER_QUANTUM="${{ env.AFP_SERVER_QUANTUM }}" \
+            -e AFP_DIRCACHE_RFORK_BUDGET="${{ env.AFP_DIRCACHE_RFORK_BUDGET }}" \
+            -e AFP_DIRCACHE_RFORK_MAXSIZE="${{ env.AFP_DIRCACHE_RFORK_MAXSIZE }}" \
             -e AFP_TEST_ITERATIONS="${{ env.AFP_TEST_ITERATIONS }}" \
             -e TEST_FLAGS="-c -z 0.00390625,0.0078125,0.015625,0.03125,0.0625,0.125,0.25,0.5,1,2,4,8,16,32,64,128,256" \
             ${{ env.REGISTRY }}/netatalk/netatalk-testsuite:${{ github.sha }} \
@@ -1428,11 +1457,12 @@ jobs:
             -o speedtest \
             --title "Netatalk AFP Speedtest — throughput vs file size" \
             --subtitle "commit ${SHORT_SHA} · mean MB/s, shaded band = min–max" \
-            --meta afp=3.4 \
-            --meta quantum_kb=1024 \
-            --meta dircache_mode=arc \
-            --meta dircache_size=65536 \
-            --meta dircache_validation_freq=100 \
+            --meta afp=${{ env.AFP_VERSION_LABEL }} \
+            --meta iterations=${{ env.AFP_TEST_ITERATIONS }} \
+            --meta quantum_kb=$(( ${{ env.AFP_SERVER_QUANTUM }} / 1024 )) \
+            --meta dircache_mode=${{ env.AFP_DIRCACHE_MODE }} \
+            --meta dircache_size=${{ env.AFP_DIRCACHESIZE }} \
+            --meta dircache_validation_freq=${{ env.AFP_DIRCACHE_VALIDATION_FREQ }} \
             --meta warmup=1
           echo "PNG size: $(du -h speedtest.png | cut -f1)"
       - name: Extract per-operation peak throughput for PR comment

--- a/contrib/scripts/plot_lantest.pl
+++ b/contrib/scripts/plot_lantest.pl
@@ -143,6 +143,13 @@ sub build_info_lines {
     push @dc, "size $meta->{dircache_size}" if $meta->{dircache_size};
     push @dc, "freq $meta->{dircache_validation_freq}"
       if $meta->{dircache_validation_freq};
+
+    if (defined $meta->{rfork_budget_kb}) {
+        push @dc, $meta->{rfork_budget_kb} > 0
+          ? "rfork budget $meta->{rfork_budget_kb} KiB"
+          : 'rfork off';
+    }
+
     push @lines, 'Dircache: ' . join(' · ', @dc) if @dc;
     return @lines;
 }

--- a/etc/afpd/afp_dsi.c
+++ b/etc/afpd/afp_dsi.c
@@ -50,6 +50,7 @@
 
 #include "auth.h"
 #include "dircache.h"
+#include "pfd_cache.h"
 #include "directory.h"
 #include "fork.h"
 #include "idle_worker.h"
@@ -213,6 +214,8 @@ static void afp_dsi_close(AFPObj *obj)
         dsi->read_count / 1024.0, dsi->write_count / 1024.0);
     of_log_highwater();
     log_dircache_stat();
+    pfd_log_stats();
+    pfd_shutdown();
     dircache_rfork_shutdown();
     dsi_close(dsi);
 }

--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -39,6 +39,7 @@
 #include "ad_cache.h"
 #include "dircache.h"
 #include "directory.h"
+#include "pfd_cache.h"
 #include "hash.h"
 #include "idle_worker.h"
 
@@ -466,6 +467,30 @@ static void arc_verify_invariants(void)
 }
 
 /*!
+ * @brief Hash-removed entry: defer its free to end-of-request.
+ *
+ * Caller must have removed the entry from both hash indexes and every
+ * ARC/LRU queue. Deferring keeps pointers handed out earlier in this
+ * request valid (consumers gate on d_did != CNID_INVALID) — ARC ghost
+ * eviction can reach entries that WERE returned this request, so an
+ * inline free here could dangle a held pointer. On qnode OOM (effectively
+ * unreachable: the kernel OOM killer fires first) leak the entry instead;
+ * dir_remove makes the same choice.
+ */
+static void dircache_defer_free(struct dir *dir)
+{
+    dir->d_did = CNID_INVALID;
+
+    if (enqueue(invalid_dircache_entries, dir) == NULL) {
+        LOG(log_error, logtype_afpd,
+            "dircache_defer_free: enqueue failed (OOM), entry leaked");
+        return;
+    }
+
+    iw_note_work();
+}
+
+/*!
  * @brief Ensure ghost directory has room for one more entry
  *
  * Maintains the ARC invariant: B1 + B2 ≤ c
@@ -508,9 +533,8 @@ static void arc_ensure_ghost_capacity(arc_list_t target_list)
                 ntohl(ghost->d_did),
                 arc_cache.b1_size,
                 arc_cache.b2_size);
-            /* Remove from hash tables and free */
             dircache_remove(NULL, ghost, DIRCACHE | DIDNAME_INDEX);
-            dir_free(ghost);
+            dircache_defer_free(ghost);
         }
     }
 }
@@ -925,9 +949,9 @@ static void arc_case_iv(struct dir *dir)
             if (ghost) {
                 arc_cache.b1_size--;
                 ghost->qidx_node = NULL;  /* Clear queue pointer after dequeue */
-                /* Ghost is a full struct dir - remove from hash tables and free */
+                /* Ghost is a full struct dir - remove from hash, defer free */
                 dircache_remove(NULL, ghost, DIRCACHE | DIDNAME_INDEX);
-                dir_free(ghost);
+                dircache_defer_free(ghost);
             }
 
             if (arc_replace(0) != 0) {
@@ -960,7 +984,7 @@ static void arc_case_iv(struct dir *dir)
 
                 victim->qidx_node = NULL;
                 dircache_remove(NULL, victim, DIRCACHE | DIDNAME_INDEX);
-                dir_free(victim);
+                dircache_defer_free(victim);
             } else {
                 LOG(log_warning, logtype_afpd,
                     "arc_case_iv(i): cannot evict, all entries are curdir "
@@ -977,9 +1001,9 @@ static void arc_case_iv(struct dir *dir)
             if (ghost) {
                 arc_cache.b2_size--;
                 ghost->qidx_node = NULL;  /* Clear queue pointer after dequeue */
-                /* Ghost is a full struct dir - remove from hash tables and free */
+                /* Ghost is a full struct dir - remove from hash, defer free */
                 dircache_remove(NULL, ghost, DIRCACHE | DIDNAME_INDEX);
-                dir_free(ghost);
+                dircache_defer_free(ghost);
             }
         }
 
@@ -1149,7 +1173,7 @@ static void dircache_evict(void)
         }
 
         dircache_remove(NULL, dir, DIRCACHE | DIDNAME_INDEX); /* 3 */
-        dir_free(dir);                                        /* 4 */
+        dircache_defer_free(dir);                             /* 4 */
     }
 
     AFP_ASSERT(queue_count == dircache->hash_nodecount);
@@ -1162,6 +1186,117 @@ static void dircache_evict(void)
 /********************************************************
  * Interface
  ********************************************************/
+
+/* The file-vs-directory gone-event mapping is a sender invariant the hint
+ * receiver keys on (CACHE_HINT_DELETE is treated as file-only when
+ * deciding whether a pfd slot may exist) — one definition only. */
+static uint8_t gone_event_for(const struct dir *dir)
+{
+    return (dir->d_flags & DIRF_ISFILE)
+           ? CACHE_HINT_DELETE
+           : CACHE_HINT_DELETE_CHILDREN;
+}
+
+/*!
+ * @brief Validation discovered the entry gone: expunge + hint siblings.
+ *
+ * One pipe message replaces each sibling re-discovering the change by its
+ * own full-path stat. The hint reports evidence (gone); a same-named
+ * recreate is harmless — hints only invalidate, receivers rebuild.
+ */
+static void validation_expunge_and_hint(const struct vol *vol,
+                                        struct dir *cdir)
+{
+    /* Capture before dir_remove invalidates d_did */
+    cnid_t gone_did = cdir->d_did;
+    uint8_t gone_event = gone_event_for(cdir);
+    (void)dir_remove(vol, cdir, 1);  /* Invalid, Expunged during validation */
+    ipc_send_cache_hint(AFPobj, vol->v_vid, gone_did, gone_event);
+    dircache_stat.expunged++;
+    dircache_stat.misses++;  /* Count expunge as miss */
+}
+
+/*!
+ * @brief Validation saw an ino/ctime change: refresh in-place + hint.
+ *
+ * Hints: an inode change (object replaced) broadcasts REFRESH under the
+ * entry's current DID and, when dir_modify re-keyed it, under the old DID
+ * too — siblings cache the object under the old key. A ctime-only change
+ * sends nothing: fork writes advance ctime on every flush, and
+ * broadcasting those would rebuild sibling AD/rfork caches per write;
+ * pure metadata changes propagate via each sibling's own validation.
+ *
+ * @returns 0 if the entry survived (refreshed in-place), -1 if dir_modify
+ *          evicted it (inode change + CNID miss) — hint sent either way.
+ */
+static int validation_refresh_and_hint(const struct vol *vol,
+                                       struct dir *cdir, struct stat *st)
+{
+    /* Capture before dir_modify may invalidate or re-key the entry */
+    cnid_t old_did = cdir->d_did;
+    uint8_t gone_event = gone_event_for(cdir);
+    bool ino_changed = (cdir->dcache_ino != 0
+                        && cdir->dcache_ino != st->st_ino);
+    dir_modify(vol, cdir, &(struct dir_modify_args) {
+        .flags = DCMOD_STAT,
+        .st = st
+    });
+
+    /* dir_modify may evict the entry (inode change + CNID miss) */
+    if (cdir->d_did == CNID_INVALID) {
+        ipc_send_cache_hint(AFPobj, vol->v_vid, old_did, gone_event);
+        dircache_stat.expunged++;
+        dircache_stat.misses++;
+        return -1;
+    }
+
+    if (ino_changed) {
+        ipc_send_cache_hint(AFPobj, vol->v_vid, cdir->d_did,
+                            CACHE_HINT_REFRESH);
+
+        if (cdir->d_did != old_did) {
+            /* Re-keyed: siblings hold the object under the OLD DID */
+            ipc_send_cache_hint(AFPobj, vol->v_vid, old_did,
+                                CACHE_HINT_REFRESH);
+        }
+    }
+
+    return 0;
+}
+
+/*!
+ * @brief Plain index probe for pfd_cache parent resolution.
+ *
+ * Never validates, never mutates, never promotes. Filters ARC ghosts
+ * (their identity fields are frozen and unvalidated — treating one as a
+ * live parent would let the pfd sync-check pass against stale identity)
+ * and file entries (a parent must be a directory).
+ */
+struct dir *dircache_lookup_parent(const struct vol *vol, cnid_t did)
+{
+    struct dir key;
+    hnode_t *hn;
+    struct dir *d;
+
+    if (did == CNID_INVALID || ntohl(did) < CNID_START) {
+        return NULL;
+    }
+
+    key.d_vid = vol->v_vid;
+    key.d_did = did;
+
+    if ((hn = hash_lookup(dircache, &key)) == NULL) {
+        return NULL;
+    }
+
+    d = hnode_get(hn);
+
+    if (d->d_flags & (DIRF_ARC_GHOST | DIRF_ISFILE)) {
+        return NULL;
+    }
+
+    return d;
+}
 
 /*!
  * @brief Search the dircache via a CNID for a directory
@@ -1231,13 +1366,11 @@ struct dir *dircache_search_by_did(const struct vol *vol, cnid_t cnid)
          * Internal netatalk operations invalidate cache explicitly via dir_remove(). */
         if (should_validate_cache_entry()) {
             /* Check if file still exists */
-            if (ostat(cfrombstr(cdir->d_fullpath), &st, vol_syml_opt(vol)) != 0) {
+            if (pfd_ostat(vol, cdir, &st, vol_syml_opt(vol)) != 0) {
                 LOG(log_debug, logtype_afpd,
                     "dircache(cnid:%u): {missing:\"%s\"}",
                     ntohl(cnid), cfrombstr(cdir->d_fullpath));
-                (void)dir_remove(vol, cdir, 1);  /* Invalid, Expunged during validation */
-                dircache_stat.expunged++;
-                dircache_stat.misses++;  /* Count expunge as miss */
+                validation_expunge_and_hint(vol, cdir);
                 return NULL;
             }
 
@@ -1257,20 +1390,8 @@ struct dir *dircache_search_by_did(const struct vol *vol, cnid_t cnid)
                     ntohl(cnid), cdir->d_u_name ? cfrombstr(cdir->d_u_name) : "(null)",
                     (unsigned long long)cdir->dcache_ino, (unsigned long long)st.st_ino,
                     (long)cdir->dcache_ctime, (long)st.st_ctime);
-                /* Refresh stat in-place via dir_modify(DCMOD_STAT).
-                 * Handles inode changes (CNID refresh + AD invalidation)
-                 * and ctime changes (AD invalidation + stat update).
-                 * Avoids destroying the entire entry and forcing a
-                 * full rebuild from the CNID database. */
-                dir_modify(vol, cdir, &(struct dir_modify_args) {
-                    .flags = DCMOD_STAT,
-                    .st = &st
-                });
 
-                /* dir_modify may evict the entry (inode change + CNID miss) */
-                if (cdir->d_did == CNID_INVALID) {
-                    dircache_stat.expunged++;
-                    dircache_stat.misses++;
+                if (validation_refresh_and_hint(vol, cdir, &st) != 0) {
                     return NULL;
                 }
 
@@ -1378,13 +1499,11 @@ struct dir *dircache_search_by_name(const struct vol *vol,
          * Internal netatalk operations invalidate cache explicitly via dir_remove(). */
         if (should_validate_cache_entry()) {
             /* Check if file still exists */
-            if (ostat(cfrombstr(cdir->d_fullpath), &st, vol_syml_opt(vol)) != 0) {
+            if (pfd_ostat(vol, cdir, &st, vol_syml_opt(vol)) != 0) {
                 LOG(log_debug, logtype_afpd,
                     "dircache(did:%u,\"%s\"): {missing:\"%s\"}",
                     ntohl(dir->d_did), name, cfrombstr(cdir->d_fullpath));
-                (void)dir_remove(vol, cdir, 1);  /* Invalid, Expunged during validation */
-                dircache_stat.expunged++;
-                dircache_stat.misses++;  /* Count expunge as miss */
+                validation_expunge_and_hint(vol, cdir);
                 return NULL;
             }
 
@@ -1404,20 +1523,8 @@ struct dir *dircache_search_by_name(const struct vol *vol,
                     ntohl(dir->d_did), name,
                     (unsigned long long)cdir->dcache_ino, (unsigned long long)st.st_ino,
                     (long)cdir->dcache_ctime, (long)st.st_ctime);
-                /* Refresh stat in-place via dir_modify(DCMOD_STAT).
-                 * Handles inode changes (CNID refresh + AD invalidation)
-                 * and ctime changes (AD invalidation + stat update).
-                 * Avoids destroying the entire entry and forcing a
-                 * full rebuild from the CNID database. */
-                dir_modify(vol, cdir, &(struct dir_modify_args) {
-                    .flags = DCMOD_STAT,
-                    .st = &st
-                });
 
-                /* dir_modify may evict the entry (inode change + CNID miss) */
-                if (cdir->d_did == CNID_INVALID) {
-                    dircache_stat.expunged++;
-                    dircache_stat.misses++;
+                if (validation_refresh_and_hint(vol, cdir, &st) != 0) {
                     return NULL;
                 }
 
@@ -1705,6 +1812,15 @@ void dircache_remove(const struct vol *vol _U_, struct dir *dir, int flags)
                 hash_delete_free(dircache, hn);
             }
         }
+    }
+
+    /* Unpublish is the one choke point every removal funnels through
+     * (dir_remove, deferred chains, capacity eviction, ARC ghost deletion,
+     * dir_modify re-key) — purge here so no removal path can forget and
+     * leave a slot pinning the directory's fd. Keyed on d_vid because
+     * eviction callers pass vol == NULL. Files never own slots. */
+    if ((flags & DIRCACHE) && !(dir->d_flags & DIRF_ISFILE)) {
+        pfd_purge(dir->d_vid, dir->d_did);
     }
 
     LOG(log_debug, logtype_afpd, "dircache(did:%u,\"%s\"): {removed}",
@@ -2637,6 +2753,15 @@ void process_cache_hints(AFPObj *obj)
         hnode_t *hn = hash_lookup(dircache, &key);
 
         if (!hn) {
+            /* Entry already evicted locally, but a pfd slot keyed on this
+             * DID may survive it. Only directory-capable events consult:
+             * CACHE_HINT_DELETE is sent exclusively for file deletions
+             * (sender invariant), so file-delete storms cost zero scans. */
+            if (hint.event == CACHE_HINT_DELETE_CHILDREN
+                    || hint.event == CACHE_HINT_REFRESH) {
+                pfd_purge(vol->v_vid, hint.cnid);
+            }
+
             cache_hint_stat.hints_no_match++;
             continue;
         }
@@ -2893,6 +3018,8 @@ void dircache_flush_deferred_for_vol(uint16_t vid)
 
     /* Compact: advance head past any dead entries */
     deferred_compact_head();
+    /* Slot retirement for the closing volume lives in closevol(), which
+     * every close path (afp_closevol, logout's close_all_vol) runs. */
 }
 
 /* Called by idle worker — returns true if deferred work exists */

--- a/etc/afpd/dircache.h
+++ b/etc/afpd/dircache.h
@@ -42,8 +42,10 @@ extern int        dircache_init(int reqsize);
 extern int        dircache_add(const struct vol *, struct dir *);
 extern void       dircache_remove(const struct vol *, struct dir *, int flag);
 extern struct dir *dircache_search_by_did(const struct vol *vol, cnid_t did);
+extern struct dir *dircache_lookup_parent(const struct vol *vol, cnid_t did);
 extern struct dir *dircache_search_by_name(const struct vol *,
         const struct dir *dir, char *name, size_t len);
+
 extern void       dircache_dump(void);
 extern void       log_dircache_stat(void);
 extern int        dircache_set_validation_params(unsigned int freq);

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -44,6 +44,7 @@
 
 #include "desktop.h"
 #include "dircache.h"
+#include "pfd_cache.h"
 #include "ad_cache.h"
 #include "directory.h"
 #include "idle_worker.h"
@@ -683,9 +684,8 @@ static struct dir *dirlookup_internal(const struct vol *vol, cnid_t did,
     }
 
     /* Build the fullpath from cached parent-chain + CNID's upath */
-    if ((fullpath = bstrcpy(pdir->d_fullpath)) == NULL
-            || bconchar(fullpath, '/') != BSTR_OK
-            || bcatcstr(fullpath, upath) != BSTR_OK) { /* 5 */
+    if ((fullpath = fullpath_join(pdir->d_fullpath, upath)) == NULL) { /* 5 */
+        afp_errno = AFPERR_MISC;
         err = 1;
         goto exit;
     }
@@ -735,12 +735,14 @@ static struct dir *dirlookup_internal(const struct vol *vol, cnid_t did,
                        &st)) == NULL) { /* 6 */
         LOG(log_error, logtype_afpd, DIRLOOKUP_LOG_FMT ": {%s, %s}: %s", ntohl(did),
             mpath, upath, strerror(errno));
+        afp_errno = AFPERR_MISC;
         err = 1;
         goto exit;
     }
 
     /* Add new struct to the cache */
     if (dircache_add(vol, ret) != 0) { /* 7 */
+        afp_errno = AFPERR_MISC;
         err = 1;
         goto exit;
     }
@@ -953,6 +955,49 @@ struct dir *dir_new(const char *m_name,
 }
 
 /*!
+ * @brief Build "parent/name" as a new bstring from a length-known leaf
+ *
+ * One sized allocation, no growth reallocs: bcatblk's grow check
+ * (mlen <= slen + len) stays false at the sized fit, and the extra byte
+ * keeps bconchar's balloc(slen + 2) below mlen even for nlen == 0.
+ *
+ * @param[in] parent  parent directory fullpath (required)
+ * @param[in] name    leaf name in server side encoding (required)
+ * @param[in] nlen    strlen of name
+ *
+ * @returns new bstring (caller owns), NULL on allocation failure —
+ *          never a partial join
+ */
+bstring fullpath_join_blk(const bstring parent, const char *name, int nlen)
+{
+    bstring path = bfromcstralloc(blength(parent) + 1 + nlen + 2, "");
+
+    if (path == NULL
+            || bcatblk(path, bdata(parent), blength(parent)) != BSTR_OK
+            || bconchar(path, '/') != BSTR_OK
+            || bcatblk(path, name, nlen) != BSTR_OK) {
+        bdestroy(path);
+        return NULL;
+    }
+
+    return path;
+}
+
+/*!
+ * @brief Build "parent/name" as a new bstring
+ *
+ * @param[in] parent  parent directory fullpath (required)
+ * @param[in] name    leaf name in server side encoding (required)
+ *
+ * @returns new bstring (caller owns), NULL on allocation failure —
+ *          never a partial join
+ */
+bstring fullpath_join(const bstring parent, const char *name)
+{
+    return fullpath_join_blk(parent, name, (int)strlen(name));
+}
+
+/*!
  * @brief Free a struct dir and all its members
  *
  * @param dir (rw) pointer to struct dir
@@ -1078,6 +1123,23 @@ int dir_modify(const struct vol *vol, struct dir *dir,
             args->new_uname ? args->new_uname
             : (dir->d_u_name ? cfrombstr(dir->d_u_name) : "(null)"),
             needs_reindex);
+        /* The only fallible step: join the new path before any mutation,
+         * so failure leaves the entry untouched and fully indexed. A
+         * truncated d_fullpath would validate against the wrong object. */
+        bstring newpath = NULL;
+
+        if (args->new_pdir_path != NULL) {
+            const char *uname = args->new_uname ? args->new_uname : cfrombstr(
+                                    dir->d_u_name);
+            newpath = fullpath_join(args->new_pdir_path, uname);
+
+            if (newpath == NULL) {
+                LOG(log_error, logtype_afpd,
+                    "dir_modify: path join failed, entry unchanged did:%u",
+                    ntohl(dir->d_did));
+                return -1;
+            }
+        }
 
         /* Remove from DID/name index if key is changing */
         if (needs_reindex) {
@@ -1113,13 +1175,9 @@ int dir_modify(const struct vol *vol, struct dir *dir,
             }
         }
 
-        if (args->new_pdir_path != NULL) {
-            const char *uname = args->new_uname ? args->new_uname : cfrombstr(
-                                    dir->d_u_name);
+        if (newpath != NULL) {
             bdestroy(dir->d_fullpath);
-            dir->d_fullpath = bstrcpy(args->new_pdir_path);
-            bconchar(dir->d_fullpath, '/');
-            bcatcstr(dir->d_fullpath, uname);
+            dir->d_fullpath = newpath;
         }
 
         /* Re-insert into DID/name index if key changed.
@@ -1150,6 +1208,11 @@ int dir_modify(const struct vol *vol, struct dir *dir,
                               dir->dcache_ctime != args->st->st_ctime);
 
         if (ino_changed) {
+            /* Object replaced — a cached parent fd would pin the old
+             * object. Needed here because the entry survives in place
+             * when the CNID is unchanged (no dircache_remove runs). */
+            pfd_purge(vol->v_vid, dir->d_did);
+
             /* Free rfork buffer FIRST — rfork_cache_free() uses dcache_rlen for budget.
              * Setting rlen = -1 before freeing would corrupt rfork_cache_used tracking. */
             if (dir->dcache_rfork_buf) {
@@ -1363,6 +1426,10 @@ struct dir *dir_add(struct vol *vol, const struct dir *dir, struct path *path,
             dircache_dump();
             AFP_PANIC("dir_add");
         }
+
+        /* dir_remove() queued the stray on invalid_dircache_entries; the
+         * exit block below must not free it a second time */
+        cdir = NULL;
     }
 
     /* get_id needs adp for reading CNID from adouble file */
@@ -1396,9 +1463,7 @@ struct dir *dir_add(struct vol *vol, const struct dir *dir, struct path *path,
     }
 
     /* Build fullpath */
-    if (((fullpath = bstrcpy(dir->d_fullpath)) == NULL)  /* 3 */
-            || (bconchar(fullpath, '/') != BSTR_OK)
-            || (bcatcstr(fullpath, path->u_name)) != BSTR_OK) {
+    if ((fullpath = fullpath_join(dir->d_fullpath, path->u_name)) == NULL) { /* 3 */
         LOG(log_error, logtype_afpd, "dir_add: fullpath: %s", strerror(errno));
         err = 3;
         goto exit;
@@ -1547,7 +1612,7 @@ int dir_remove(const struct vol *vol, struct dir *dir, int report_invalid)
         dircache_report_invalid_entry(dir);
     }
 
-    /* Remove the dircache entry */
+    /* Remove the dircache entry (also purges the entry's pfd slot) */
     dircache_remove(vol, dir, DIRCACHE | DIDNAME_INDEX | QUEUE_INDEX); /* 2 */
     /* Queue pruned entry for memory deallocation */
     enqueue(invalid_dircache_entries, dir); /* 3 */

--- a/etc/afpd/directory.h
+++ b/etc/afpd/directory.h
@@ -114,6 +114,9 @@ extern void        dir_remove_and_free(const struct vol *, struct dir *);
 typedef int (*dir_loop)(struct dirent *, char *, void *);
 
 extern void        dir_free_invalid_q(void);
+extern bstring     fullpath_join(const bstring parent, const char *name);
+extern bstring     fullpath_join_blk(const bstring parent, const char *name,
+                                     int nlen);
 extern struct dir  *dir_new(const char *mname, const char *uname,
                             const struct vol *,
                             cnid_t pdid, cnid_t did, bstring fullpath, struct stat *);

--- a/etc/afpd/enumerate.c
+++ b/etc/afpd/enumerate.c
@@ -398,6 +398,9 @@ static int enumerate(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_,
             s_path.st_errno = 0;
             /* Pass CNID so getmetadata() skips redundant cache lookup */
             s_path.id = cached->d_did;
+            /* Pass the entry itself so getfilparams()/getmetadata() skip
+             * their own dircache_search_by_name() for this name */
+            s_path.d_cached = cached;
             /* Use cached mac name to skip utompath() charset conversion */
             s_path.m_name = cfrombstr(cached->d_m_name);
             LOG(log_maxdebug, logtype_afpd,

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -76,6 +76,24 @@ static const uint8_t old_ufinderi[] = {
     'T', 'E', 'X', 'T', 'U', 'N', 'I', 'X'
 };
 
+/* Resolve a file path's dircache entry once per request: consult the
+ * memoized d_cached first (strnlen and hash walk skipped on a hit), fall
+ * back to the by-name search, and memoize the result for later consumers. */
+static struct dir *path_resolve_cached_file(const struct vol *vol,
+        const struct dir *dir, struct path *path)
+{
+    struct dir *cached = path_cached_file(path);
+
+    if (cached == NULL && path->u_name != NULL) {
+        cached = dircache_search_by_name(vol, dir, path->u_name,
+                                         strnlen(path->u_name,
+                                             CNID_MAX_PATH_LEN));
+        path->d_cached = cached;
+    }
+
+    return cached;
+}
+
 static int has_dotdot_component(const char *path)
 {
     const char *p = path;
@@ -426,14 +444,23 @@ int getmetadata(const AFPObj *obj,
                 && utf8_encoding(obj)) /* FIXME should be m_name utf8 filename */
             || (bitmap & (1 << FILPBIT_FNUM))) {
         if (!path->id) {
-            bstring fullpath;
+            bstring fullpath = NULL;
             struct dir *cachedfile;
+            int path_live = 1;
             int len = upath ? (int)strnlen(upath, CNID_MAX_PATH_LEN) : 0;
 
-            if ((cachedfile = dircache_search_by_name(vol, dir, upath, len)) != NULL) {
-                /* Compare fresh stat inode matches dircache entry */
-                if (cachedfile->dcache_ino == st->st_ino) {
+            if ((cachedfile = path_resolve_cached_file(vol, dir, path)) != NULL) {
+                /* Compare fresh stat inode matches dircache entry — only
+                 * when the caller actually filled the stat: an unfilled
+                 * path->st is not evidence of external replacement */
+                if (!path->st_valid || cachedfile->dcache_ino == st->st_ino) {
                     id = cachedfile->d_did;
+                } else if (path->st_fd) {
+                    /* fd-derived stat: the held object no longer matches
+                     * what the path names. The entry may be right for the
+                     * path — leave it; identity for THIS request must come
+                     * from the held object, below. */
+                    cachedfile = NULL;
                 } else {
                     /* File replaced externally - invalidate dircache */
                     LOG(log_debug, logtype_afpd,
@@ -445,51 +472,138 @@ int getmetadata(const AFPObj *obj,
             }
 
             if (cachedfile == NULL) {
-                id = get_id(vol, adp, st, dir->d_did, upath, len);
-
-                if (id < CNID_START) {
-                    LOG(log_error, logtype_afpd,
-                        "getmetadata: get_id failed for \"%s\", invalid id %u, afp_errno=%d (%s)",
-                        upath, id, afp_errno, AfpErr2name(afp_errno));
-                    return afp_errno;
+                /* The pre-stat, liveness probe and dir_new all consume the
+                 * entry's path */
+                if ((fullpath = fullpath_join(dir->d_fullpath, upath)) == NULL) {
+                    LOG(log_error, logtype_afpd, "getmetadata: fullpath: %s",
+                        strerror(errno));
+                    return AFPERR_MISC;
                 }
 
-                /* Add it to the cache */
-                LOG(log_debug, logtype_afpd, "getmetadata: caching: did:%u, \"%s\", cnid:%u",
-                    ntohl(dir->d_did), upath, ntohl(id));
+                /* get_id() and dir_new() below mint identity from *st:
+                 * with an unfilled stat (name-only bitmaps) that would
+                 * store zero ino/size/dates in the CNID DB and dircache.
+                 * Fill it here. */
+                int name_unoccupied = 0;
+
+                if (!path->st_valid) {
+                    if (ostat(cfrombstr(fullpath), st, vol_syml_opt(vol)) == 0) {
+                        path->st_valid = 1;
+                        path->st_errno = 0;
+                    } else if (adp != NULL && errno == ENOENT) {
+                        /* Only a held fork's request reaches here without
+                         * a stat (name-only bitmaps, no object fd — e.g. a
+                         * v2 resource-fork-only open): the fork outlived
+                         * its path. adp's header was bound to the held
+                         * object when the fork was opened. */
+                        path_live = 0;
+                        name_unoccupied = 1;
+                    } else {
+                        bdestroy(fullpath);
+                        return AFPERR_NOOBJ;
+                    }
+                } else if (path->st_fd) {
+                    /* fd-derived stat: an open fork can outlive its path
+                     * (renamed/deleted by another session). Only a path
+                     * that still names the held object may be minted. */
+                    struct stat pst;
+
+                    if (ostat(cfrombstr(fullpath), &pst, vol_syml_opt(vol)) != 0) {
+                        path_live = 0;
+                        name_unoccupied = (errno == ENOENT);
+                    } else if (pst.st_dev != st->st_dev
+                               || pst.st_ino != st->st_ino) {
+                        /* The name is occupied by a DIFFERENT object */
+                        path_live = 0;
+                    }
+                }
+
+                if (!path_live) {
+                    /* The held object's path is gone. Its CNID may only be
+                     * read: get_id/cnid_add here would rebind the object's
+                     * live DB record to the dead location (and cnid_lookup
+                     * deletes/rewrites on a dev/ino match at another name —
+                     * not a read). The dead path must enter neither the
+                     * dircache nor the DB. */
+                    bdestroy(fullpath);
+                    fullpath = NULL;
+
+                    /* Adouble header id, dev/ino-verified when we have the
+                     * object's stat; header-trusted otherwise (bound at
+                     * fork open) */
+                    if (adp == NULL) {
+                        id = CNID_INVALID;
+                    } else if (path->st_valid) {
+                        id = ad_getid(adp, st->st_dev, st->st_ino, 0,
+                                      vol->v_stamp);
+                    } else {
+                        id = ad_forcegetid(adp);
+                    }
+
+                    if ((id == CNID_INVALID || ntohl(id) < CNID_START)
+                            && name_unoccupied && vol->v_cdb != NULL) {
+                        /* Nothing lives at the name, so a record still
+                         * registered there can only be the held object's.
+                         * With the name occupied by another object this
+                         * read would return the replacement's identity —
+                         * refuse instead. */
+                        AFP_CNID_START("cnid_get");
+                        id = cnid_get(vol->v_cdb, dir->d_did, upath, len);
+                        AFP_CNID_DONE();
+                    }
+
+                    if (id == CNID_INVALID || ntohl(id) < CNID_START) {
+                        return AFPERR_NOOBJ;
+                    }
+                } else {
+                    id = get_id(vol, adp, st, dir->d_did, upath, len);
+
+                    if (id < CNID_START) {
+                        LOG(log_error, logtype_afpd,
+                            "getmetadata: get_id failed for \"%s\", invalid id %u, afp_errno=%d (%s)",
+                            upath, id, afp_errno, AfpErr2name(afp_errno));
+                        bdestroy(fullpath);
+                        return afp_errno;
+                    }
+                }
 
                 /* Get macname from unixname first */
                 if (path->m_name == NULL) {
                     if ((path->m_name = utompath(vol, upath, id, utf8_encoding(obj))) == NULL) {
                         LOG(log_error, logtype_afpd, "getmetadata: utompath error");
+                        bdestroy(fullpath);
                         return AFPERR_MISC;
                     }
                 }
 
-                /* Build fullpath */
-                if (((fullpath = bstrcpy(dir->d_fullpath)) == NULL)
-                        || (bconchar(fullpath, '/') != BSTR_OK)
-                        || (bcatcstr(fullpath, upath)) != BSTR_OK) {
-                    LOG(log_error, logtype_afpd, "getmetadata: fullpath: %s", strerror(errno));
-                    bdestroy(fullpath);
-                    return AFPERR_MISC;
-                }
+                if (path_live) {
+                    /* Add it to the cache */
+                    LOG(log_debug, logtype_afpd,
+                        "getmetadata: caching: did:%u, \"%s\", cnid:%u",
+                        ntohl(dir->d_did), upath, ntohl(id));
 
-                if ((cachedfile = dir_new(path->m_name, upath, vol, dir->d_did, id, fullpath,
-                                          st)) == NULL) {
-                    LOG(log_error, logtype_afpd, "getmetadata: error from dir_new");
-                    return AFPERR_MISC;
-                }
+                    /* dir_new takes ownership of fullpath */
+                    if ((cachedfile = dir_new(path->m_name, upath, vol, dir->d_did, id, fullpath,
+                                              st)) == NULL) {
+                        LOG(log_error, logtype_afpd, "getmetadata: error from dir_new");
+                        bdestroy(fullpath);
+                        return AFPERR_MISC;
+                    }
 
-                if ((dircache_add(vol, cachedfile)) != 0) {
-                    LOG(log_error, logtype_afpd, "getmetadata: fatal dircache error");
-                    return AFPERR_MISC;
-                }
+                    if ((dircache_add(vol, cachedfile)) != 0) {
+                        LOG(log_error, logtype_afpd, "getmetadata: fatal dircache error");
+                        dir_free(cachedfile);
+                        return AFPERR_MISC;
+                    }
 
-                /* Proactively populate AD cache from adp that was just read
-                 * from disk — entry was just created so has no AD data yet */
-                if (adp && adp->ad_rlen >= 0) {
-                    ad_store_to_cache(adp, cachedfile);
+                    /* Proactively populate AD cache from adp that was just read
+                     * from disk — entry was just created so has no AD data yet */
+                    if (adp && adp->ad_rlen >= 0) {
+                        ad_store_to_cache(adp, cachedfile);
+                    }
+
+                    /* Memoize for later consumers in this request */
+                    path->d_cached = cachedfile;
                 }
             }
         } else {
@@ -828,13 +942,11 @@ int getfilparams(const AFPObj *obj, struct vol *vol, uint16_t bitmap,
                  && (bitmap & (1 << FILPBIT_ATTR))) ? ADFLAGS_CHECK_OF : 0;
         adp = of_ad(vol, path, &ad);
         upath = path->u_name;
-        size_t upath_len = strnlen(upath, CNID_MAX_PATH_LEN);
 
         if (adp != &ad) {
             /* Fork-owned adouble — use directly, skip cache.
              * Opportunistically populate cache if not yet loaded. */
-            struct dir *cachedfile = dircache_search_by_name(vol, dir,
-                                     upath, upath_len);
+            struct dir *cachedfile = path_resolve_cached_file(vol, dir, path);
 
             /* If cache AD is unset, store fork's live adouble */
             if (cachedfile && cachedfile->dcache_rlen < 0) {
@@ -842,8 +954,7 @@ int getfilparams(const AFPObj *obj, struct vol *vol, uint16_t bitmap,
             }
         } else {
             /* No open fork — use ad_metadata_cached() */
-            struct dir *cachedfile = dircache_search_by_name(vol, dir,
-                                     upath, upath_len);
+            struct dir *cachedfile = path_resolve_cached_file(vol, dir, path);
             ad_init(&ad, vol);
 
             if (ad_metadata_cached(upath, flags, &ad, vol, cachedfile, false,
@@ -1019,10 +1130,9 @@ createfile_iderr:
                                  upath, (int)upath_len);
 
         if (!cachedfile && id != CNID_INVALID) {
-            bstring fullpath = bstrcpy(dir->d_fullpath);
+            bstring fullpath = fullpath_join(dir->d_fullpath, upath);
 
-            if (fullpath && bconchar(fullpath, '/') == BSTR_OK
-                    && bcatcstr(fullpath, upath) == BSTR_OK) {
+            if (fullpath) {
                 cachedfile = dir_new(path, upath, vol, dir->d_did,
                                      id, fullpath, &st);
 
@@ -1038,8 +1148,6 @@ createfile_iderr:
                     /* dir_new failed — did not take ownership of fullpath, free it */
                     bdestroy(fullpath);
                 }
-            } else {
-                bdestroy(fullpath);
             }
         }
 

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -1075,15 +1075,7 @@ char *absupath(const struct vol *vol, struct dir *dir, char *u)
         return NULL;
     }
 
-    if ((path = bstrcpy(dir->d_fullpath)) == NULL) {
-        return NULL;
-    }
-
-    if (bcatcstr(path, "/") != BSTR_OK) {
-        return NULL;
-    }
-
-    if (bcatcstr(path, u) != BSTR_OK) {
+    if ((path = fullpath_join(dir->d_fullpath, u)) == NULL) {
         return NULL;
     }
 

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -158,6 +158,7 @@ static int getforkparams(const AFPObj *obj, struct ofork *ofork,
     struct adouble  *adp;
     struct dir      *dir;
     struct vol      *vol;
+    memset(&path, 0, sizeof(path));
 
     /* Virtual forks use synthesized params */
     if (ofork->of_flags & AFPFORK_VIRTUAL) {
@@ -181,7 +182,15 @@ static int getforkparams(const AFPObj *obj, struct ofork *ofork,
     }
 
     vol = ofork->of_vol;
-    dir = dirlookup(vol, ofork->of_did);
+
+    /* The fork can outlive its parent directory's CNID entry (deleted by
+     * another session, hint-driven expunge). dirlookup sets afp_errno to
+     * distinguish gone (AFPERR_NOOBJ) from transient resolution failure;
+     * get_afp_errno screens the internal DID1 sentinel and paths that
+     * left it unset. */
+    if ((dir = dirlookup(vol, ofork->of_did)) == NULL) {
+        return get_afp_errno(AFPERR_NOOBJ);
+    }
 
     if (NULL == (path.u_name = mtoupath(vol, of_name(ofork), dir->d_did,
                                         utf8_encoding(obj)))) {
@@ -196,19 +205,38 @@ static int getforkparams(const AFPObj *obj, struct ofork *ofork,
                   (1 << FILPBIT_FNUM) | (1 << FILPBIT_CDATE) |
                   (1 << FILPBIT_MDATE) | (1 << FILPBIT_BDATE))) {
         if (ad_data_fileno(ofork->of_ad) <= 0) {
-            /* 0 is for symlink */
+            /* 0 is for symlink. A v2 resource-fork-only fork holds no fd
+             * on the object itself (the rfork fd is the ._ sidecar, whose
+             * inode must not stand in for the object's) — when the held
+             * fork's path is gone, proceed with st unfilled: identity
+             * comes from the adouble header, dates already do. */
             if (movecwd(vol, dir) < 0) {
                 return AFPERR_NOOBJ;
             }
 
-            if (lstat(path.u_name, st) < 0) {
+            if (lstat(path.u_name, st) == 0) {
+                path.st_valid = 1;
+            } else if (adp == NULL || errno != ENOENT) {
                 return AFPERR_NOOBJ;
             }
         } else {
             if (fstat(ad_data_fileno(ofork->of_ad), st) < 0) {
                 return AFPERR_BITMAP;
             }
+
+            path.st_valid = 1;
+            path.st_fd = 1;
         }
+    } else if ((bitmap & (1 << FILPBIT_LNAME)) && utf8_encoding(obj)
+               && ad_data_fileno(ofork->of_ad) > 0
+               && fstat(ad_data_fileno(ofork->of_ad), st) == 0) {
+        /* The only name-only bitmap shape whose identity block runs in
+         * getmetadata (m_name is always set here, FNUM is in the stat
+         * block above): provide the held object's stat so a fork that
+         * outlived its path still resolves. Other name-only bitmaps skip
+         * the syscall entirely. */
+        path.st_valid = 1;
+        path.st_fd = 1;
     }
 
     return getmetadata(obj, vol, bitmap, &path, dir, buf, buflen, adp);
@@ -419,7 +447,7 @@ int afp_openfork(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
     struct dir      *dir;
     struct ofork    *ofork, *opened;
     struct adouble  *adsame = NULL;
-    size_t          buflen;
+    size_t          buflen = 0;
     int             ret, adflags, eid;
     uint32_t        did;
     uint16_t        vid, bitmap, access, ofrefnum;
@@ -2149,7 +2177,7 @@ int afp_getforkparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf,
     struct ofork    *ofork;
     int             ret;
     uint16_t       ofrefnum, bitmap;
-    size_t          buflen;
+    size_t          buflen = 0;
     ibuf += 2;
     memcpy(&ofrefnum, ibuf, sizeof(ofrefnum));
     ibuf += sizeof(ofrefnum);

--- a/etc/afpd/meson.build
+++ b/etc/afpd/meson.build
@@ -22,6 +22,7 @@ afpd_common_sources = files(
     'mangle.c',
     'messages.c',
     'ofork.c',
+    'pfd_cache.c',
     'status.c',
     'switch.c',
     'uam.c',

--- a/etc/afpd/pfd_cache.c
+++ b/etc/afpd/pfd_cache.c
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2026 Andy Lemin (andylemin)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+/*
+ * Parent-directory fd cache: transparent acceleration for dircache
+ * validation stats. pfd_ostat() is a drop-in for
+ * ostat(cfrombstr(entry->d_fullpath), st, options) — identical result and
+ * errno whenever the filesystem is quiescent; any impediment falls back
+ * to the full-path form internally. Callers never see fds. Under
+ * concurrent external mutation (rename-away + recreate of the parent)
+ * the two forms may answer from different world views until the
+ * re-ground probe converges — each answer is truthful for one view,
+ * never a third state (see the divergence-window tests).
+ *
+ * Threading: pfd_ostat() runs on the main thread only. pfd_purge()/
+ * pfd_purge_vol() additionally run on the idle worker under the
+ * iw_grant/iw_revoke temporal-separation handshake (via
+ * dircache_remove from the deferred chains) — never concurrently with
+ * main-thread pfd calls, so the module needs no locks and MUST NOT grow
+ * state shared outside that discipline.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <atalk/directory.h>
+#include <atalk/logger.h>
+#include <atalk/util.h>
+
+#include "dircache.h"
+#include "directory.h"
+#include "pfd_cache.h"
+#include "volume.h"
+
+#define PFD_SLOTS 16
+
+#if defined(O_PATH)
+#define PFD_OPEN_FLAGS (O_PATH | O_DIRECTORY | O_NOFOLLOW)
+#elif defined(O_SEARCH)
+#define PFD_OPEN_FLAGS (O_SEARCH | O_DIRECTORY)
+#else
+/* Execute-only directories fail to open with O_RDONLY; pfd_get() then
+ * returns -1 and the wrapper falls back to full-path ostat (correct,
+ * slower). */
+#define PFD_OPEN_FLAGS (O_RDONLY | O_DIRECTORY)
+#endif
+
+struct pfd_slot {
+    /* network order, as stored in struct dir */
+    cnid_t   did;
+    uint16_t vid;
+    /* -1 = empty slot */
+    int      fd;
+    /* identity of the object fd was opened on */
+    dev_t    dev;
+    ino_t    ino;
+    /* parent->dcache_ino observed at fill time — lets the sync-check tell
+     * "dircache learned since fill" (act) from "slot learned via the
+     * probe, dircache lagging" (serve; no thrash) */
+    ino_t    fill_dcache_ino;
+    /* hits since the last re-ground probe */
+    uint32_t uses;
+};
+
+/* slots[0] is MRU; a hit moves its slot to the front (memmove of at most
+ * 15 small structs — cheaper than list links at this size). */
+static struct pfd_slot pfd_slots[PFD_SLOTS];
+static int pfd_initialized;
+
+static struct pfd_stats pfd_stat;
+
+static void pfd_init_once(void)
+{
+    if (!pfd_initialized) {
+        for (int i = 0; i < PFD_SLOTS; i++) {
+            pfd_slots[i].fd = -1;
+        }
+
+        pfd_initialized = 1;
+    }
+}
+
+static void slot_retire(struct pfd_slot *s)
+{
+    if (s->fd >= 0) {
+        close(s->fd);
+    }
+
+    s->fd = -1;
+    s->did = CNID_INVALID;
+    s->vid = 0;
+    s->uses = 0;
+}
+
+/* Open parent's path, record the opened object's identity. -1 on failure
+ * (slot left empty). */
+static int slot_fill(struct pfd_slot *s, const struct vol *vol,
+                     const struct dir *parent)
+{
+    struct stat st;
+    int fd = open(cfrombstr(parent->d_fullpath), PFD_OPEN_FLAGS);
+
+    if (fd < 0) {
+        return -1;
+    }
+
+    if (fstat(fd, &st) != 0) {
+        close(fd);
+        return -1;
+    }
+
+    s->fd = fd;
+    s->dev = st.st_dev;
+    s->ino = st.st_ino;
+    s->fill_dcache_ino = parent->dcache_ino;
+    s->did = parent->d_did;
+    s->vid = vol->v_vid;
+    s->uses = 0;
+    pfd_stat.opens++;
+    return fd;
+}
+
+static void slot_move_to_front(int i)
+{
+    if (i > 0) {
+        struct pfd_slot tmp = pfd_slots[i];
+        memmove(&pfd_slots[1], &pfd_slots[0], (size_t)i * sizeof(tmp));
+        pfd_slots[0] = tmp;
+    }
+}
+
+/* Resolve parent to a directory fd. -1 = no usable fd (caller falls back).
+ * Main thread only. */
+static int pfd_get(const struct vol *vol, const struct dir *parent)
+{
+    pfd_init_once();
+
+    for (int i = 0; i < PFD_SLOTS; i++) {
+        struct pfd_slot *s = &pfd_slots[i];
+
+        if (s->fd < 0 || s->vid != vol->v_vid || s->did != parent->d_did) {
+            continue;
+        }
+
+        /* Sync-check against the fill-time baseline, not the slot's own
+         * ino: after a probe refill the slot is FRESHER than the dircache,
+         * and comparing slot.ino to the still-stale dcache_ino directly
+         * would close+open on every hit until the entry catches up.
+         * dcache_ino unchanged since fill → serve; changed and matching
+         * the slot → re-baseline; changed and different → the dircache
+         * learned of a replacement this slot hasn't seen → refill. */
+        if (parent->dcache_ino != s->fill_dcache_ino) {
+            if (parent->dcache_ino == s->ino) {
+                s->fill_dcache_ino = parent->dcache_ino;
+            } else {
+                slot_retire(s);
+
+                if (slot_fill(s, vol, parent) < 0) {
+                    return -1;
+                }
+
+                pfd_stat.sync_refreshes++;
+            }
+        }
+
+        if (++s->uses >= PFD_REGROUND_INTERVAL) {
+            /* Absolute-path probe: catches an external rename-away +
+             * recreate of the parent, which no cache-vs-cache compare
+             * can see. */
+            struct stat gst;
+            s->uses = 0;
+            pfd_stat.regrounds++;
+
+            if (ostat(cfrombstr(parent->d_fullpath), &gst,
+                      vol_syml_opt(vol)) != 0
+                    || gst.st_dev != s->dev || gst.st_ino != s->ino) {
+                slot_retire(s);
+
+                if (slot_fill(s, vol, parent) < 0) {
+                    return -1;
+                }
+
+                pfd_stat.probe_refreshes++;
+            }
+        }
+
+        slot_move_to_front(i);
+        pfd_stat.hits++;
+        return pfd_slots[0].fd;
+    }
+
+    /* Miss: prefer an empty slot (purges leave holes); evict the LRU
+     * tail only when full. */
+    {
+        int target = PFD_SLOTS - 1;
+
+        for (int i = 0; i < PFD_SLOTS; i++) {
+            if (pfd_slots[i].fd < 0) {
+                target = i;
+                break;
+            }
+        }
+
+        slot_retire(&pfd_slots[target]);
+
+        if (slot_fill(&pfd_slots[target], vol, parent) < 0) {
+            return -1;
+        }
+
+        slot_move_to_front(target);
+    }
+    return pfd_slots[0].fd;
+}
+
+/* The relative stat just proved (parent fd, basename) names the live
+ * object, so entry's true path is parent's path + '/' + basename. An
+ * internal rename re-paths the parent in place and defers the children:
+ * until the worker runs, a child's d_fullpath still names the old
+ * location. A relative stat cannot see that, so the serving side must
+ * keep the string true itself: verify the parent-prefix invariant on
+ * every success and rebuild d_fullpath in place on mismatch — same
+ * object, no expunge.
+ *
+ * Cost when the path is intact (every non-rename call): one integer
+ * length compare, one byte load, one short memcmp — noise next to the
+ * fstatat it rides on. */
+static void pfd_repair_path(struct dir *entry, const struct dir *parent)
+{
+    int plen = blength(parent->d_fullpath);
+    int nlen = blength(entry->d_u_name);
+    const char *ep = bdata(entry->d_fullpath);
+    const char *pp = bdata(parent->d_fullpath);
+
+    if (ep != NULL && pp != NULL
+            && blength(entry->d_fullpath) == plen + 1 + nlen
+            && ep[plen] == '/'
+            && memcmp(ep, pp, (size_t)plen) == 0) {
+        return;
+    }
+
+    /* Both lengths are known: one exactly-sized allocation, no strlen,
+     * no realloc */
+    bstring repaired = fullpath_join_blk(parent->d_fullpath,
+                                         bdata(entry->d_u_name), nlen);
+
+    if (repaired == NULL) {
+        /* Keep the stale string; the next validation retries */
+        return;
+    }
+
+    LOG(log_debug, logtype_afpd, "pfd_repair_path: \"%s\" -> \"%s\"",
+        ep ? ep : "(null)", cfrombstr(repaired));
+    bdestroy(entry->d_fullpath);
+    entry->d_fullpath = repaired;
+    pfd_stat.path_repairs++;
+}
+
+/*!
+ * @brief ostat(cfrombstr(entry->d_fullpath), st, options), accelerated.
+ *
+ * Resolves entry's parent to a cached dir fd and fstatat()s the leaf name;
+ * any impediment (no parent entry, ghost parent, open failure) falls back
+ * to the full-path ostat internally. Callers cannot observe which path ran:
+ * return value and errno are exactly what ostat would produce.
+ *
+ * On success the entry's d_fullpath is additionally repaired against the
+ * parent's — the relative stat can outlive a rename the path string hasn't
+ * caught up with (see pfd_repair_path).
+ */
+int pfd_ostat(const struct vol *vol, struct dir *entry,
+              struct stat *st, int options)
+{
+    const struct dir *parent = NULL;
+
+    if (entry->d_did != DIRDID_ROOT && entry->d_did != DIRDID_ROOT_PARENT
+            && entry->d_u_name != NULL) {
+        if (entry->d_pdid == DIRDID_ROOT) {
+            /* The volume root is never in the dircache hash but is always
+             * live on the vol with d_fullpath = v_path and dcache_ino
+             * populated by dir_new() at afp_openvol(). */
+            parent = vol->v_root;
+        } else if (entry->d_pdid != DIRDID_ROOT_PARENT) {
+            parent = dircache_lookup_parent(vol, entry->d_pdid);
+        }
+    }
+
+    if (parent != NULL && parent->d_fullpath != NULL
+            && parent->dcache_ino != 0) {
+        int fd = pfd_get(vol, parent);
+
+        if (fd >= 0) {
+            /* fd is verified >= 0: ostatat(-1, ...) means AT_FDCWD (a
+             * CWD-relative stat) and must never occur. */
+            int rc = ostatat(fd, cfrombstr(entry->d_u_name), st, options);
+
+            if (rc == 0) {
+                pfd_repair_path(entry, parent);
+            }
+
+            return rc;
+        }
+    }
+
+    pfd_stat.fallbacks++;
+    return ostat(cfrombstr(entry->d_fullpath), st, options);
+}
+
+/* Retire the slot for (vid, did) if present. Keyed on the raw vid so the
+ * unpublish choke point (dircache_remove) can purge from the entry's own
+ * d_vid — several of its callers pass vol == NULL. Runs on the main thread
+ * AND on the idle worker (deferred chains) under temporal separation. */
+void pfd_purge(uint16_t vid, cnid_t did)
+{
+    if (!pfd_initialized) {
+        return;
+    }
+
+    for (int i = 0; i < PFD_SLOTS; i++) {
+        if (pfd_slots[i].fd >= 0 && pfd_slots[i].vid == vid
+                && pfd_slots[i].did == did) {
+            slot_retire(&pfd_slots[i]);
+            pfd_stat.purges++;
+            return;
+        }
+    }
+}
+
+void pfd_purge_vol(uint16_t vid)
+{
+    if (!pfd_initialized) {
+        return;
+    }
+
+    for (int i = 0; i < PFD_SLOTS; i++) {
+        if (pfd_slots[i].fd >= 0 && pfd_slots[i].vid == vid) {
+            slot_retire(&pfd_slots[i]);
+            pfd_stat.purges++;
+        }
+    }
+}
+
+void pfd_shutdown(void)
+{
+    if (!pfd_initialized) {
+        return;
+    }
+
+    for (int i = 0; i < PFD_SLOTS; i++) {
+        slot_retire(&pfd_slots[i]);
+    }
+}
+
+void pfd_stats_get(struct pfd_stats *out)
+{
+    *out = pfd_stat;
+}
+
+void pfd_log_stats(void)
+{
+    /* Healthy shape: hits >> opens, refresh counters near zero. Either
+     * refresh counter approaching hits means slots are being rebuilt
+     * per-call — pathological; report it. */
+    LOG(log_info, logtype_afpd,
+        "pfd_cache: %llu hits, %llu opens, %llu sync-refreshes, "
+        "%llu probe-refreshes, %llu regrounds, %llu fallbacks, %llu purges, "
+        "%llu path-repairs",
+        pfd_stat.hits, pfd_stat.opens, pfd_stat.sync_refreshes,
+        pfd_stat.probe_refreshes, pfd_stat.regrounds, pfd_stat.fallbacks,
+        pfd_stat.purges, pfd_stat.path_repairs);
+}

--- a/etc/afpd/pfd_cache.h
+++ b/etc/afpd/pfd_cache.h
@@ -1,0 +1,37 @@
+/* Parent-directory fd cache — module and threading contract documented in
+ * pfd_cache.c */
+
+#ifndef AFPD_PFD_CACHE_H
+#define AFPD_PFD_CACHE_H 1
+
+#include <sys/stat.h>
+
+#include <atalk/directory.h>
+
+#include "volume.h"
+
+/* One absolute re-ground probe per this many uses of a slot — the
+ * ground-truth bound on rename-away staleness (unit tests assert on it) */
+#define PFD_REGROUND_INTERVAL 256
+
+struct pfd_stats {
+    unsigned long long hits;            /*!< fd served */
+    unsigned long long opens;           /*!< slot fills (full path resolutions) */
+    unsigned long long
+    sync_refreshes;  /*!< dircache-learned mismatches, refilled */
+    unsigned long long probe_refreshes; /*!< re-ground probe mismatches, refilled */
+    unsigned long long regrounds;       /*!< absolute-path probes issued */
+    unsigned long long fallbacks;       /*!< fell back to full-path ostat */
+    unsigned long long purges;          /*!< slots retired by purge hooks */
+    unsigned long long path_repairs;    /*!< stale d_fullpath rebuilt from parent */
+};
+
+extern int  pfd_ostat(const struct vol *vol, struct dir *entry,
+                      struct stat *st, int options);
+extern void pfd_purge(uint16_t vid, cnid_t did);
+extern void pfd_purge_vol(uint16_t vid);
+extern void pfd_shutdown(void);
+extern void pfd_log_stats(void);
+extern void pfd_stats_get(struct pfd_stats *out);
+
+#endif /* AFPD_PFD_CACHE_H */

--- a/etc/afpd/volume.c
+++ b/etc/afpd/volume.c
@@ -67,6 +67,7 @@
 #include "fork.h"
 #include "hash.h"
 #include "mangle.h"
+#include "pfd_cache.h"
 #include "unix.h"
 #include "virtual_icon.h"
 #include "volume.h"
@@ -1080,6 +1081,11 @@ void closevol(const AFPObj *obj, struct vol *vol)
 
     vol->v_flags &= ~AFPVOL_OPEN;
     of_closevol(obj, vol);
+    /* Retire the volume's pfd slots: their O_PATH fds would otherwise
+     * outlive the close (pinning directories against unmount), and since
+     * struct vol and v_vid persist across logout/re-login a surviving
+     * slot would satisfy (vid, did) matches after re-open. */
+    pfd_purge_vol(vol->v_vid);
     dir_free(vol->v_root);
     vol->v_root = NULL;
 

--- a/include/atalk/directory.h
+++ b/include/atalk/directory.h
@@ -128,8 +128,25 @@ struct path {
     struct dir  *d_dir;
     int         st_valid;           /*!< does st_errno and st set */
     int         st_errno;
+    /* st was filled by fstat on an open fd: the object is live but the
+     * path may no longer name it. 0 = path-derived stat. */
+    int         st_fd;
     struct stat st;
+    /* Caller-resolved dircache entry for a FILE path; NULL = unknown.
+     * Directories use d_dir. Valid for the current request only. */
+    struct dir  *d_cached;
 };
+
+/*! d_cached accessor enforcing the staleness rule: an entry invalidated
+ * mid-request (dir_remove sets d_did = CNID_INVALID) reads as absent. */
+static inline struct dir *path_cached_file(const struct path *path)
+{
+    if (path->d_cached && path->d_cached->d_did != CNID_INVALID) {
+        return path->d_cached;
+    }
+
+    return NULL;
+}
 
 static inline int path_isadir(struct path *o_path)
 {

--- a/test/afpd/meson.build
+++ b/test/afpd/meson.build
@@ -95,6 +95,7 @@ if build_afpd_tests
         'faultinject.c',
         'test_capabilities.c',
         'subtests_lock.c',
+        'subtests_pfd.c',
         include_directories: test_includes,
         objects: afpdtest_objects,
         link_whole: afpdtest_link_whole,

--- a/test/afpd/subtests.c
+++ b/test/afpd/subtests.c
@@ -17,10 +17,13 @@
 #endif /* HAVE_CONFIG_H */
 
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
+#include <atalk/adouble.h>
 #include <atalk/cnid.h>
 #include <atalk/directory.h>
 #include <atalk/globals.h>
@@ -32,6 +35,7 @@
 #include "afp_config.h"
 #include "dircache.h"
 #include "directory.h"
+#include "file.h"
 #include "hash.h"
 #include "subtests.h"
 #include "test.h"
@@ -71,4 +75,304 @@ int test002_rem_x_dirs(const struct vol *vol, cnid_t start, cnid_t end)
     }
 
     return 0;
+}
+
+/* dir_add() error path vs a stray cache entry: the stray is routed through
+ * dir_remove() (which queues it on invalid_dircache_entries for deferred
+ * free), then a later step fails.  The exit block must NOT free the queued
+ * entry a second time — dir_free_invalid_q() owns that free.  Detection is
+ * by the sanitizer/valgrind leg: a double free aborts the run. */
+int test003_dir_add_error_no_double_free(struct vol *vol)
+{
+    const struct dir *root;
+    struct dir *stray, *ret;
+    struct path path;
+    struct stat st;
+    struct _cnid_db *saved_cdb;
+    static char uname[] = "straydir_t003";
+
+    if ((root = dirlookup(vol, DIRDID_ROOT)) == NULL) {
+        return -1;
+    }
+
+    if (stat(vol->v_path, &st) != 0) {
+        return -1;
+    }
+
+    /* Plant a stray entry for (root, uname).  Fullpath points at the volume
+     * root so the lookup validation stat succeeds and returns the entry. */
+    stray = dir_new(uname, uname, vol, DIRDID_ROOT, htonl(30003),
+                    bfromcstr(vol->v_path), &st);
+
+    if (stray == NULL || dircache_add(vol, stray) != 0) {
+        return -1;
+    }
+
+    /* Force the get_id() step to fail: with v_cdb == NULL it returns
+     * CNID_INVALID, taking dir_add's err=1 exit path right after the stray
+     * has been dir_remove()'d (queued). */
+    saved_cdb = vol->v_cdb;
+    vol->v_cdb = NULL;
+    memset(&path, 0, sizeof(path));
+    path.u_name = uname;
+    ret = dir_add(vol, root, &path, (int)strlen(uname));
+    vol->v_cdb = saved_cdb;
+
+    if (ret != NULL) {
+        /* error path not taken — test preconditions broken */
+        return -1;
+    }
+
+    /* Drain the deferred-free queue (normally end-of-request).  If dir_add's
+     * exit block freed the queued stray itself, this is a double free — the
+     * sanitizer/valgrind leg aborts here. */
+    dir_free_invalid_q();
+    return 0;
+}
+
+/* getmetadata() must not treat an unfilled struct path stat as evidence of
+ * external replacement.  getforkparams()'s LNAME-only bitmap reaches the
+ * CNID block with path.st all-zeros (no stat-filling bit requested); the
+ * ino-mismatch check would compare dcache_ino against st_ino == 0 and
+ * expunge a perfectly valid dircache entry on every call. */
+int test004_getmetadata_nostat_keeps_cache(struct vol *vol)
+{
+    struct dir *root, *entry;
+    struct path p;
+    struct stat st;
+    char fpath[MAXPATHLEN + 1];
+    char buf[4096];
+    size_t buflen = 0;
+    static char fname[] = "t004_file";
+    int ret = -1;
+
+    if ((root = dirlookup(vol, DIRDID_ROOT)) == NULL) {
+        return -1;
+    }
+
+    snprintf(fpath, sizeof(fpath), "%s/%s", vol->v_path, fname);
+    FILE *fh = fopen(fpath, "w");
+
+    if (fh == NULL) {
+        return -1;
+    }
+
+    fputs("t004", fh);
+    fclose(fh);
+
+    if (stat(fpath, &st) != 0) {
+        unlink(fpath);
+        return -1;
+    }
+
+    entry = dir_new(fname, fname, vol, DIRDID_ROOT, htonl(30004),
+                    bfromcstr(fpath), &st);
+
+    if (entry == NULL || dircache_add(vol, entry) != 0) {
+        unlink(fpath);
+        return -1;
+    }
+
+    /* Mirror getforkparams()'s LNAME-only state: zeroed path, no id, and
+     * the stat block never ran (st all-zeros, st_valid 0). */
+    memset(&p, 0, sizeof(p));
+    p.u_name = fname;
+    p.m_name = fname;
+
+    if (getmetadata(AFPobj, vol, 1 << FILPBIT_LNAME, &p, root,
+                    buf, &buflen, NULL) != AFP_OK) {
+        goto out;
+    }
+
+    /* The cached entry must survive: an unfilled stat is not evidence of
+     * replacement (a zero-ino compare would expunge it here). */
+    if (entry->d_did == CNID_INVALID) {
+        /* stderr, not test_stream(): this file is also linked into the
+         * fuzz target, which does not carry test.c's globals */
+        fprintf(stderr,
+                "t004: valid dircache entry expunged on unfilled stat\n");
+        goto out;
+    }
+
+    ret = 0;
+out:
+    /* On failure a replacement entry may have been re-added under a
+     * different pointer — remove whatever the cache now holds. */
+    {
+        struct dir *now = dircache_search_by_name(vol, root, fname,
+                          strlen(fname));
+
+        if (now) {
+            dir_remove(vol, now, 0);
+        }
+    }
+
+    if (entry->d_did != CNID_INVALID) {
+        dir_remove(vol, entry, 0);
+    }
+
+    dir_free_invalid_q();
+    unlink(fpath);
+    return ret;
+}
+
+/* An open fork legitimately outlives its path (renamed/unlinked by another
+ * session).  getforkparams provides the object's stat from the held fd
+ * (st_fd); with the path dead, getmetadata must answer identity by READ
+ * (adouble id or, only while the name is unoccupied, the CNID DB record),
+ * never mint the dead path into the dircache, and never rebind the CNID
+ * DB record.  Exercised in the production data-fork-only shape (fd-derived
+ * stat, adp == NULL) across two legs:
+ *   unlink  — name unoccupied: the registered record answers, unchanged;
+ *   replace — another object now occupies the dead name: its identity
+ *             must never be returned for the held fork (refusal is the
+ *             only honest answer without an adouble header), and its
+ *             record must not be rebound. */
+int test005_getmetadata_open_fork_outlives_path(struct vol *vol)
+{
+    struct dir *root;
+    struct adouble ad;
+    struct path p;
+    struct stat st, st2;
+    char fpath[MAXPATHLEN + 1];
+    char buf[4096];
+    size_t buflen = 0;
+    static char fname[] = "t005_file";
+    cnid_t live_id = CNID_INVALID, replacement_id = CNID_INVALID;
+    cnid_t got;
+    int ret = -1;
+    int replacement_fd = -1;
+    int rc;
+
+    if ((root = dirlookup(vol, DIRDID_ROOT)) == NULL) {
+        return -1;
+    }
+
+    snprintf(fpath, sizeof(fpath), "%s/%s", vol->v_path, fname);
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, fpath, ADFLAGS_DF | ADFLAGS_RDWR | ADFLAGS_CREATE,
+                0600) != 0) {
+        return -1;
+    }
+
+    /* Register the object's CNID while the path is live, as any real
+     * access would have */
+    if (fstat(ad_data_fileno(&ad), &st) != 0
+            || (live_id = cnid_add(vol->v_cdb, &st, DIRDID_ROOT, fname,
+                                   strlen(fname), 0)) == CNID_INVALID) {
+        goto out;
+    }
+
+    /* getforkparams shape for a data-fork-only fork: st filled by fstat
+     * on the held fd (st_fd), adp NULL (no metadata open) */
+    memset(&p, 0, sizeof(p));
+    p.u_name = fname;
+    p.m_name = fname;
+    p.st = st;
+    p.st_valid = 1;
+    p.st_fd = 1;
+
+    /* --- Leg 1: unlink — the other session removes the file --- */
+    if (unlink(fpath) != 0) {
+        goto out;
+    }
+
+    rc = getmetadata(AFPobj, vol, 1 << FILPBIT_FNUM, &p, root,
+                     buf, &buflen, NULL);
+
+    if (rc != AFP_OK) {
+        fprintf(stderr,
+                "t005: held fork failed getmetadata after unlink (rc %d)\n",
+                rc);
+        goto out;
+    }
+
+    /* The dead path must not have been cached. Probe the request-scoped
+     * memo, not the by-name index — that lookup validates (stat) and
+     * would expunge the dead entry, masking the mint. */
+    if (p.d_cached != NULL) {
+        fprintf(stderr, "t005: dead path minted into the dircache\n");
+        goto out;
+    }
+
+    if (cnid_get(vol->v_cdb, DIRDID_ROOT, fname, strlen(fname)) != live_id) {
+        fprintf(stderr, "t005: CNID DB record rebound after unlink leg\n");
+        goto out;
+    }
+
+    /* --- Leg 2: replace — a different object now occupies the name --- */
+    /* Path-based on purpose: this test IS the racing second session — it
+     * recreates the just-unlinked name, exactly the replacement race the
+     * held fork's identity answer must survive. O_EXCL guarantees a fresh
+     * object. */
+    replacement_fd = open(fpath, O_WRONLY | O_CREAT | O_EXCL, 0600); // NOSONAR
+
+    if (replacement_fd < 0 || fstat(replacement_fd, &st2) != 0) {
+        goto out;
+    }
+
+    /* The replacement registers itself, taking over the (did, name)
+     * record — the renamer/creator side of a real race does this */
+    if ((replacement_id = cnid_add(vol->v_cdb, &st2, DIRDID_ROOT, fname,
+                                   strlen(fname), 0)) == CNID_INVALID) {
+        goto out;
+    }
+
+    memset(&p, 0, sizeof(p));
+    p.u_name = fname;
+    p.m_name = fname;
+    p.st = st;
+    p.st_valid = 1;
+    p.st_fd = 1;
+    rc = getmetadata(AFPobj, vol, 1 << FILPBIT_FNUM, &p, root,
+                     buf, &buflen, NULL);
+
+    if (rc == AFP_OK) {
+        memcpy(&got, buf, sizeof(got));
+
+        if (got == replacement_id) {
+            fprintf(stderr,
+                    "t005: held fork answered with the replacement's CNID\n");
+            goto out;
+        }
+    }
+
+    /* Either refusal (NOOBJ) or a non-replacement id is acceptable; the
+     * replacement's record must be untouched either way */
+    if (cnid_get(vol->v_cdb, DIRDID_ROOT, fname,
+                 strlen(fname)) != replacement_id) {
+        fprintf(stderr, "t005: replacement's CNID record rebound\n");
+        goto out;
+    }
+
+    ret = 0;
+out:
+
+    if (replacement_fd >= 0) {
+        close(replacement_fd);
+    }
+
+    ad_close(&ad, ADFLAGS_DF);
+    unlink(fpath);
+    {
+        /* Reruns and later tests start clean */
+        struct dir *now = dircache_search_by_name(vol, root, fname,
+                          strlen(fname));
+
+        if (now) {
+            dir_remove(vol, now, 0);
+        }
+    }
+
+    if (live_id != CNID_INVALID) {
+        cnid_delete(vol->v_cdb, live_id);
+    }
+
+    if (replacement_id != CNID_INVALID) {
+        cnid_delete(vol->v_cdb, replacement_id);
+    }
+
+    dir_free_invalid_q();
+    return ret;
 }

--- a/test/afpd/subtests.h
+++ b/test/afpd/subtests.h
@@ -40,4 +40,7 @@
 
 extern int test001_add_x_dirs(const struct vol *vol, cnid_t start, cnid_t end);
 extern int test002_rem_x_dirs(const struct vol *vol, cnid_t start, cnid_t end);
+extern int test003_dir_add_error_no_double_free(struct vol *vol);
+extern int test004_getmetadata_nostat_keeps_cache(struct vol *vol);
+extern int test005_getmetadata_open_fork_outlives_path(struct vol *vol);
 #endif  /* SUBTESTS_H */

--- a/test/afpd/subtests_pfd.c
+++ b/test/afpd/subtests_pfd.c
@@ -1,0 +1,525 @@
+/*
+  Copyright (c) 2026 Andy Lemin (andylemin)
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation; either version 2 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+*/
+
+/*
+ * pfd_ostat() vs plain ostat(d_fullpath) equivalence harness.
+ *
+ * Quiescent equivalence: no external mutation between the two calls — return
+ * value, errno, and every consumed struct stat field must be identical
+ * across the matrix (existing/ENOENT, root-parented and deep-parented,
+ * slot absent/present, ghost-parented must fall back).
+ *
+ * Divergence window: external mutation raced between the calls —
+ * assert the permitted-outcome set (one of two truthful world views,
+ * never a third state) and the probe bound: a rename-away+recreate is
+ * detected within PFD_REGROUND_INTERVAL uses, and after the probe refill
+ * the slot serves WITHOUT re-opening while the dircache entry still lags
+ * (pins the three-way sync-check; a naive compare re-opens every hit).
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif /* HAVE_CONFIG_H */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <atalk/cnid.h>
+#include <atalk/directory.h>
+#include <atalk/logger.h>
+#include <atalk/util.h>
+#include <atalk/volume.h>
+
+#include "afpfunc_helpers.h"
+#include "dircache.h"
+#include "directory.h"
+#include "pfd_cache.h"
+#include "subtests_pfd.h"
+#include "test.h"
+#include "volume.h"
+
+/* Compare the stat fields the dircache validation sites consume */
+static int st_fields_equal(const struct stat *a, const struct stat *b)
+{
+    return a->st_dev == b->st_dev && a->st_ino == b->st_ino
+           && a->st_ctime == b->st_ctime && a->st_mode == b->st_mode
+           && a->st_mtime == b->st_mtime && a->st_uid == b->st_uid
+           && a->st_gid == b->st_gid && a->st_size == b->st_size;
+}
+
+/* One equivalence point: run both forms, demand identical rc/errno and,
+ * on success, identical consumed fields. */
+static int equiv_check(const struct vol *vol, struct dir *entry,
+                       const char *label)
+{
+    struct stat st_pfd, st_plain;
+    int rc_pfd, rc_plain, errno_pfd, errno_plain;
+    memset(&st_pfd, 0xAA, sizeof(st_pfd));
+    memset(&st_plain, 0x55, sizeof(st_plain));
+    errno = 0;
+    rc_pfd = pfd_ostat(vol, entry, &st_pfd, vol_syml_opt(vol));
+    errno_pfd = errno;
+    errno = 0;
+    rc_plain = ostat(cfrombstr(entry->d_fullpath), &st_plain,
+                     vol_syml_opt(vol));
+    errno_plain = errno;
+
+    if (rc_pfd != rc_plain) {
+        fprintf(test_stream(), "# pfd-equiv %s: rc %d != %d\n", label, rc_pfd,
+                rc_plain);
+        return -1;
+    }
+
+    if (rc_pfd != 0 && errno_pfd != errno_plain) {
+        fprintf(test_stream(), "# pfd-equiv %s: errno %d != %d\n", label, errno_pfd,
+                errno_plain);
+        return -1;
+    }
+
+    if (rc_pfd == 0 && !st_fields_equal(&st_pfd, &st_plain)) {
+        fprintf(test_stream(), "# pfd-equiv %s: stat fields differ\n", label);
+        return -1;
+    }
+
+    return 0;
+}
+
+/* Build a real directory + child file under the volume root, with live
+ * dircache entries for both, mirroring what dirlookup/dir_add produce.
+ * On failure nothing stays cached (the caller cannot clean up what it
+ * never received). */
+static struct dir *make_tree(struct vol *vol, const char *dname,
+                             const char *fname, cnid_t ddid, cnid_t fdid,
+                             struct dir **file_out)
+{
+    char pbuf[MAXPATHLEN + 1];
+    struct stat st;
+    struct dir *d, *f;
+    bstring dpath, fpath;
+    snprintf(pbuf, sizeof(pbuf), "%s/%s", vol->v_path, dname);
+
+    if (mkdir(pbuf, 0700) != 0 && errno != EEXIST) {
+        return NULL;
+    }
+
+    if (stat(pbuf, &st) != 0) {
+        return NULL;
+    }
+
+    dpath = bfromcstr(pbuf);
+    d = dir_new(dname, dname, vol, DIRDID_ROOT, ddid, dpath, &st);
+
+    if (d == NULL) {
+        bdestroy(dpath);
+        return NULL;
+    }
+
+    if (dircache_add(vol, d) != 0) {
+        dir_free(d);
+        return NULL;
+    }
+
+    snprintf(pbuf, sizeof(pbuf), "%s/%s/%s", vol->v_path, dname, fname);
+    int tfd = open(pbuf, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+
+    if (tfd < 0) {
+        goto fail_dir;
+    }
+
+    (void)!write(tfd, "eq", 2);
+    close(tfd);
+
+    if (stat(pbuf, &st) != 0) {
+        goto fail_dir;
+    }
+
+    fpath = bfromcstr(pbuf);
+    f = dir_new(fname, fname, vol, ddid, fdid, fpath, &st);
+
+    if (f == NULL) {
+        bdestroy(fpath);
+        goto fail_dir;
+    }
+
+    if (dircache_add(vol, f) != 0) {
+        dir_free(f);
+        goto fail_dir;
+    }
+
+    *file_out = f;
+    return d;
+fail_dir:
+    dir_remove(vol, d, 0);
+    dir_free_invalid_q();
+    return NULL;
+}
+
+static void unmake_tree(struct vol *vol, const char *dname, const char *fname)
+{
+    char pbuf[MAXPATHLEN + 1];
+    snprintf(pbuf, sizeof(pbuf), "%s/%s/%s", vol->v_path, dname, fname);
+    unlink(pbuf);
+    snprintf(pbuf, sizeof(pbuf), "%s/%s", vol->v_path, dname);
+    rmdir(pbuf);
+}
+
+/* Quiescent equivalence matrix */
+int test_pfd_ostat_equivalence(struct vol *vol)
+{
+    struct dir *d = NULL, *f = NULL, *rootkid = NULL;
+    struct stat st;
+    char pbuf[MAXPATHLEN + 1];
+    int ret = -1;
+
+    /* deep-parented file entry (parent in dircache) */
+    if ((d = make_tree(vol, "pfd_eq_dir", "pfd_eq_file", htonl(50001),
+                       htonl(50002), &f)) == NULL) {
+        goto out;
+    }
+
+    /* 1: existing file, deep parent — twice (slot absent, then present) */
+    if (equiv_check(vol, f, "deep-existing/slot-miss") != 0
+            || equiv_check(vol, f, "deep-existing/slot-hit") != 0) {
+        goto out;
+    }
+
+    /* 2: existing dir entry whose parent is the volume root */
+    snprintf(pbuf, sizeof(pbuf), "%s/pfd_eq_dir", vol->v_path);
+
+    if (stat(pbuf, &st) != 0) {
+        goto out;
+    }
+
+    rootkid = d;
+
+    if (equiv_check(vol, rootkid, "root-parented") != 0) {
+        goto out;
+    }
+
+    /* 3: ENOENT — delete the file on disk, entries still cached */
+    snprintf(pbuf, sizeof(pbuf), "%s/pfd_eq_dir/pfd_eq_file", vol->v_path);
+    unlink(pbuf);
+
+    if (equiv_check(vol, f, "enoent") != 0) {
+        goto out;
+    }
+
+    /* 4: ghost-parented entry must fall back to the identical full-path
+     * form: force the parent to read as a ghost, compare, restore */
+    d->d_flags |= DIRF_ARC_GHOST;
+
+    if (equiv_check(vol, f, "ghost-parent-fallback") != 0) {
+        d->d_flags &= ~DIRF_ARC_GHOST;
+        goto out;
+    }
+
+    d->d_flags &= ~DIRF_ARC_GHOST;
+    ret = 0;
+out:
+
+    if (f) {
+        dir_remove(vol, f, 0);
+    }
+
+    if (d) {
+        dir_remove(vol, d, 0);
+    }
+
+    dir_free_invalid_q();
+    unmake_tree(vol, "pfd_eq_dir", "pfd_eq_file");
+    return ret;
+}
+
+/* Internal rename: parent entry re-pathed in place (dir_modify DCMOD_PATH,
+ * same inode), children deferred — the window where a child's d_fullpath is
+ * stale while its parent's is already correct. Validation through the pfd
+ * path must not serve the dead path: it must repair d_fullpath from the
+ * parent (same object, so no expunge needed). Plain ostat self-healed here
+ * by ENOENT+expunge; serving the stale string is the one forbidden outcome. */
+int test_pfd_rename_repairs_child_path(struct vol *vol)
+{
+    struct dir *d = NULL, *f = NULL;
+    struct stat st;
+    char oldp[MAXPATHLEN + 1], newp[MAXPATHLEN + 1], expect[MAXPATHLEN + 1];
+    int ret = -1;
+    snprintf(oldp, sizeof(oldp), "%s/pfd_rp_dir", vol->v_path);
+    snprintf(newp, sizeof(newp), "%s/pfd_rp_new", vol->v_path);
+    snprintf(expect, sizeof(expect), "%s/pfd_rp_new/pfd_rp_file", vol->v_path);
+
+    if ((d = make_tree(vol, "pfd_rp_dir", "pfd_rp_file", htonl(50021),
+                       htonl(50022), &f)) == NULL) {
+        goto out;
+    }
+
+    /* Warm the slot so the parent fd predates the rename */
+    if (pfd_ostat(vol, f, &st, vol_syml_opt(vol)) != 0) {
+        goto out;
+    }
+
+    /* The internal-rename shape: disk renamed, parent entry re-pathed in
+     * place (same did, same inode), child entry untouched (deferred). */
+    if (rename(oldp, newp) != 0) {
+        goto out;
+    }
+
+    {
+        bstring rootpath = bfromcstr(vol->v_path);
+
+        if (dir_modify(vol, d, &(struct dir_modify_args) {
+        .flags = DCMOD_PATH,
+        .new_pdid = DIRDID_ROOT,
+        .new_mname = "pfd_rp_new",
+        .new_uname = "pfd_rp_new",
+        .new_pdir_path = rootpath
+    }) != 0) {
+            bdestroy(rootpath);
+            goto out;
+        }
+        bdestroy(rootpath);
+    }
+
+    /* Validate the child: the relative stat succeeds (parent fd + basename
+     * both still true), so the entry survives — but its d_fullpath must
+     * come out repaired to the parent's new path, never the dead one. */
+    if (pfd_ostat(vol, f, &st, vol_syml_opt(vol)) != 0) {
+        goto out;
+    }
+
+    if (f->d_fullpath == NULL
+            || strcmp(cfrombstr(f->d_fullpath), expect) != 0) {
+        fprintf(test_stream(),
+                "# pfd-repair: child path \"%s\", want \"%s\"\n",
+                f->d_fullpath ? cfrombstr(f->d_fullpath) : "(null)", expect);
+        goto out;
+    }
+
+    ret = 0;
+out:
+
+    if (f) {
+        dir_remove(vol, f, 0);
+    }
+
+    if (d) {
+        dir_remove(vol, d, 0);
+    }
+
+    dir_free_invalid_q();
+    unlink(expect);
+    rmdir(newp);
+    unmake_tree(vol, "pfd_rp_dir", "pfd_rp_file");
+    return ret;
+}
+
+/* Volume close must retire every slot keyed on the volume: the O_PATH fds
+ * otherwise outlive the close (pinning directories against unmount) and,
+ * because struct vol and v_vid persist across logout/re-login, a stale
+ * slot would satisfy (vid, did) matches for a directory replaced while
+ * the volume was closed. The test drives the documented logout/re-login
+ * cycle (closevol, assert, reopen) and leaves the volume as it found it —
+ * the harness keeps ownership of the final close. */
+int test_pfd_vol_close_purges_slots(AFPObj *obj, struct vol *vol)
+{
+    struct dir *d = NULL, *f = NULL;
+    struct stat st;
+    struct pfd_stats before, after;
+    int ret = -1;
+    int closed = 0;
+
+    if ((d = make_tree(vol, "pfd_cv_dir", "pfd_cv_file", htonl(50031),
+                       htonl(50032), &f)) == NULL) {
+        goto out;
+    }
+
+    /* Warm a slot keyed on (v_vid, d->d_did) */
+    if (pfd_ostat(vol, f, &st, vol_syml_opt(vol)) != 0) {
+        goto out;
+    }
+
+    /* Close with the entries still cached — the dircache is not flushed
+     * by a volume close, so the slot must be retired by closevol itself,
+     * not by an entry-removal side effect. Mirror the real close paths
+     * (afp_closevol, close_all_vol), which clear curdir first. */
+    curdir = NULL;
+    pfd_stats_get(&before);
+    closevol(obj, vol);
+    closed = 1;
+    pfd_stats_get(&after);
+
+    if (after.purges <= before.purges) {
+        fprintf(test_stream(),
+                "# pfd-volclose: slot survived closevol (purges %llu -> %llu)\n",
+                before.purges, after.purges);
+        goto out;
+    }
+
+    ret = 0;
+out:
+
+    if (f) {
+        dir_remove(vol, f, 0);
+    }
+
+    if (d) {
+        dir_remove(vol, d, 0);
+    }
+
+    dir_free_invalid_q();
+    unmake_tree(vol, "pfd_cv_dir", "pfd_cv_file");
+
+    /* Re-login: same struct vol and v_vid, fresh v_root/CNID handle */
+    if (closed && openvol(obj, "afpd_test") == 0) {
+        fprintf(test_stream(), "# pfd-volclose: reopen after close failed\n");
+        ret = -1;
+    }
+
+    return ret;
+}
+
+/* Divergence window: probe bound + no-thrash */
+int test_pfd_probe_rename_detection(struct vol *vol)
+{
+    struct dir *d = NULL, *f = NULL;
+    struct stat st;
+    struct pfd_stats before, after;
+    char oldp[MAXPATHLEN + 1], movedp[MAXPATHLEN + 1], childp[MAXPATHLEN + 1];
+    int ret = -1;
+    int rc;
+    /* Cleanup consumes these; early gotos must not unlink garbage paths */
+    snprintf(oldp, sizeof(oldp), "%s/pfd_mv_dir", vol->v_path);
+    snprintf(movedp, sizeof(movedp), "%s/pfd_mv_away", vol->v_path);
+    snprintf(childp, sizeof(childp), "%s/pfd_mv_dir/pfd_mv_file", vol->v_path);
+
+    if ((d = make_tree(vol, "pfd_mv_dir", "pfd_mv_file", htonl(50011),
+                       htonl(50012), &f)) == NULL) {
+        goto out;
+    }
+
+    /* Warm the slot */
+    if (pfd_ostat(vol, f, &st, vol_syml_opt(vol)) != 0) {
+        goto out;
+    }
+
+    /* External rename-away + recreate: the one real staleness case */
+
+    /* Path-based on purpose: this test IS the external mutator — it
+     * simulates a foreign process renaming the directory away and
+     * recreating the path, exactly the race the probe must detect.
+     * Nothing here trusts the pre-race resolution. */
+    if (rename(oldp, movedp) != 0
+            || mkdir(oldp, 0700) != 0) { // NOSONAR (TOCTOU is the scenario under test)
+        goto out;
+    }
+
+    int nfd = open(childp, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+
+    if (nfd < 0) {
+        goto out;
+    }
+
+    (void)!write(nfd, "new-world", 9);
+    /* Permitted-outcome set: every result until the probe fires must be a
+     * truthful answer from ONE of the two coherent worlds — the old object
+     * (old ino via the held fd) or the new path (new ino) — never a third
+     * state. Drive PFD_REGROUND_INTERVAL uses; the probe must detect the
+     * rename within the bound. */
+    struct stat old_st, new_st;
+
+    /* Identity via the creating fd (no path re-resolution race) */
+    if (fstat(nfd, &new_st) != 0) {
+        close(nfd);
+        goto out;
+    }
+
+    close(nfd);
+    old_st = st; /* old-world identity captured by the warmup call */
+    pfd_stats_get(&before);
+    int detected = 0;
+
+    for (int i = 0; i < PFD_REGROUND_INTERVAL + 2; i++) {
+        rc = pfd_ostat(vol, f, &st, vol_syml_opt(vol));
+
+        if (rc == 0 && st.st_ino == new_st.st_ino) {
+            detected = 1; /* new world reached */
+            break;
+        }
+
+        if (rc == 0 && st.st_ino != old_st.st_ino) {
+            fprintf(test_stream(), "# pfd-probe: third-state ino %llu\n",
+                    (unsigned long long)st.st_ino);
+            goto out; /* neither old nor new world: forbidden */
+        }
+
+        /* rc != 0 (ENOENT through a refilled fd while only the old world
+         * had the child) is also truthful; keep driving */
+    }
+
+    pfd_stats_get(&after);
+
+    if (!detected) {
+        fprintf(test_stream(), "# pfd-probe: probe did not converge within %d uses\n",
+                PFD_REGROUND_INTERVAL + 2);
+        goto out;
+    }
+
+    if (after.probe_refreshes == before.probe_refreshes) {
+        fprintf(test_stream(), "# pfd-probe: convergence without a probe refresh?\n");
+        goto out;
+    }
+
+    /* No-thrash: the slot now holds the new object while f's PARENT
+     * dircache entry (d) still records the old ino. Further hits must
+     * serve without re-opening: opens and sync_refreshes stay flat. */
+    pfd_stats_get(&before);
+
+    for (int i = 0; i < 16; i++) {
+        (void)pfd_ostat(vol, f, &st, vol_syml_opt(vol));
+    }
+
+    pfd_stats_get(&after);
+
+    if (after.opens != before.opens
+            || after.sync_refreshes != before.sync_refreshes) {
+        fprintf(test_stream(),
+                "# pfd-probe thrash: opens %llu->%llu sync_refreshes %llu->%llu\n",
+                before.opens, after.opens, before.sync_refreshes,
+                after.sync_refreshes);
+        goto out;
+    }
+
+    ret = 0;
+out:
+
+    if (f) {
+        dir_remove(vol, f, 0);
+    }
+
+    if (d) {
+        dir_remove(vol, d, 0);
+    }
+
+    dir_free_invalid_q();
+    unlink(childp);
+    snprintf(childp, sizeof(childp), "%s/pfd_mv_away/pfd_mv_file", vol->v_path);
+    unlink(childp);
+    unmake_tree(vol, "pfd_mv_dir", "pfd_mv_file");
+    snprintf(oldp, sizeof(oldp), "%s/pfd_mv_away", vol->v_path);
+    rmdir(oldp);
+    return ret;
+}

--- a/test/afpd/subtests_pfd.h
+++ b/test/afpd/subtests_pfd.h
@@ -1,0 +1,12 @@
+#ifndef SUBTESTS_PFD_H
+#define SUBTESTS_PFD_H
+
+#include <atalk/globals.h>
+#include <atalk/volume.h>
+
+extern int test_pfd_ostat_equivalence(struct vol *vol);
+extern int test_pfd_rename_repairs_child_path(struct vol *vol);
+extern int test_pfd_probe_rename_detection(struct vol *vol);
+extern int test_pfd_vol_close_purges_slots(AFPObj *obj, struct vol *vol);
+
+#endif /* SUBTESTS_PFD_H */

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -43,6 +43,7 @@
 #include "hash.h"
 #include "subtests.h"
 #include "subtests_lock.h"
+#include "subtests_pfd.h"
 #include "test.h"
 #include "test_capabilities.h"
 #include "volume.h"
@@ -552,6 +553,27 @@ int main(int argc, char *argv[])
     /* test enumerate.c stuff */
     TEST_int(enumerate(&obj, vid, DIRDID_ROOT), 0,
              "enumerate: root directory contents");
+    /* dircache lifetime: dir_add error path must not double-free a stray
+     * entry already queued on invalid_dircache_entries (sanitizer leg
+     * aborts on the second free) */
+    TEST_int(test003_dir_add_error_no_double_free(vol), 0,
+             "dir_add error path: queued stray entry not freed twice");
+    /* getmetadata must not expunge a valid entry when the caller's stat
+     * was never filled (LNAME-only FPGetForkParms shape) */
+    TEST_int(test004_getmetadata_nostat_keeps_cache(vol), 0,
+             "getmetadata: unfilled stat is not external-replacement evidence");
+    /* an open fork outlives its path: identity comes from the held fd,
+     * and the dead path must not be minted into the dircache */
+    TEST_int(test005_getmetadata_open_fork_outlives_path(vol), 0,
+             "getmetadata: open fork identified via held fd when path is gone");
+    /* pfd cache: strict ostat equivalence (quiescent), and the
+     * divergence window — probe bound + three-way sync-check no-thrash */
+    TEST_int(test_pfd_ostat_equivalence(vol), 0,
+             "pfd_ostat: byte-identical to ostat across the quiescent matrix");
+    TEST_int(test_pfd_rename_repairs_child_path(vol), 0,
+             "pfd_ostat: stale child d_fullpath repaired from re-pathed parent");
+    TEST_int(test_pfd_probe_rename_detection(vol), 0,
+             "pfd_ostat: rename-away caught by probe bound; no refill thrash");
     /* fork/adouble fault-injection unit tests (TEST_int_or_skip: tests that
      * cannot run on this platform/build return TEST_SKIP rather than failing) */
     TEST_int_or_skip(utest_faultinject_selftest(vol), 0,
@@ -605,8 +627,16 @@ int main(int argc, char *argv[])
                      "fork_setmode_deny: each access mode maps to the correct deny bits");
     TEST_int(utest_of_alloc_fifo(vol), 0,
              "of_alloc: refnum==slot, never 0, of_find round-trip, FIFO reuse window");
-    /* cleanup */
-    closevol(&obj, vol);
+    /* drives a full closevol/openvol cycle on vol and hands it back open */
+    TEST_int(test_pfd_vol_close_purges_slots(&obj, vol), 0,
+             "closevol: pfd slots keyed on the volume are retired");
+    /* cleanup — vol may be closed if the cycle's reopen failed (closevol
+     * is not idempotent: dir_free(v_root) has no NULL guard) */
+    curdir = NULL;
+
+    if (vol->v_flags & AFPVOL_OPEN) {
+        closevol(&obj, vol);
+    }
 
     if (volsys) {
         closevol(&obj, volsys);


### PR DESCRIPTION
Dircache validation had two independent costs on the hottest path a file server has (directory enumeration): 1) every validation stat was an **absolute path walk from `/`** — per-component dentry, permission, and LSM checks, and on network filesystems potentially a revalidation round-trip per component — paid on *every* cache hit at the default `dircache validation freq = 1`; and 2) every enumerated file was **looked up in the dircache twice** — `enumerate()` resolves the entry, then `getfilparams()`/`getmetadata()` immediately repeat the same by-name lookup (with its own validation stat) for the same entry.

This PR fixes both independently: validation stats become a **single-component `fstatat` against a small cache of parent-directory fds** (the pfd cache), and the duplicate lookup is **eliminated** by passing the already-resolved entry through `struct path`. Per request: N relative stats (plus ~N/256 absolute ground-truth probes) replace N — or 2N with the duplicate — full-path walks. Two latent bugs found during the work are fixed with red-first tests.

## Staging for the Performance Dashboard

An initial temp commit was used to switch the dashboard runners (FlameGraph spectest, LatencyGraph lantest, PerfGraph speedtest) to `dircache validation freq = 1` and single-sources each job's configuration (one job-level `env:` block feeds both the container `-e` flags and the chart `--meta` labels, so plot headers can never disagree with the actual run config). Its dashboard run captured the **before** numbers; the second commit then captured the **after** — runs in comments below (commits now squashed).

## Root cause

**Cost 1 — absolute-path validation.** The by-name dircache index is keyed `(volume, parent DID, name)` — the natural validation question is "does *name* still exist *under this parent* with the same identity?". But both hot validation sites answered it with `ostat(entry->d_fullpath)`: a full path walk that re-resolves every ancestor component on every check, doing per-component work the kernel then throws away. `fstatat(parent_fd, name)` answers exactly the indexed question with a single component resolution — netatalk already had the `ostatat()` wrapper (`O_NOFOLLOW` → `AT_SYMLINK_NOFOLLOW`, so volume symlink policy carries over bit-for-bit), and meson hard-requires `fstatat`.

**Cost 2 — the duplicate lookup.** `enumerate()` does `dircache_search_by_name()` per entry to reconstruct stat data from the cache, then calls `getfilparams()` for the same entry — which performs its own `dircache_search_by_name()` (in both of its adouble branches), and `getmetadata()`'s CNID block a third. Same key, same result: repeated hash lookup + ARC bookkeeping, and (pre-pfd) a repeated full-path validation stat. At freq=1 this doubled the per-entry stat cost of every enumeration.

## Design

### The pfd cache (`etc/afpd/pfd_cache.c/.h`)

`pfd_ostat(vol, entry, st, opts)` is a transparent drop-in for the validation `ostat`: it resolves the entry's parent to a cached `O_PATH|O_DIRECTORY` fd (16-slot MRU-front LRU keyed `(vid, did)`; `O_SEARCH` or `O_RDONLY` fallback on non-Linux) and issues one `fstatat`. Identical result and errno in all cases; **any** impediment (uncached parent, ARC-ghost parent, file parent, open failure) falls back to the full-path form internally. fds never cross the wrapper boundary, and the fallback is exercised continuously in normal operation, so it cannot rot. Always on — no config knob; the transparency contract is proven by tests rather than gated by an off switch.

Coherence rests on exactly three mechanisms:

| mechanism | cost | catches |
|---|---|---|
| three-way sync-check per hit | 0 syscalls (integer compares vs a fill-time baseline) | the dircache learning of a replacement the slot hasn't seen — without re-open thrash when the *slot* is the fresher side (post-probe) |
| absolute re-ground probe every 256 uses of a slot | 1 `ostat` amortized ~1/256 | external rename-away+recreate of the parent — the one case no fd-relative check can see; bounds staleness to ≤256 served answers per slot, independently at every level |
| slot retirement at the unpublish choke point | O(16) scan, on the mutation only | `dircache_remove()` purges the entry's slot, covering every removal path (dir_remove, deferred chains, capacity eviction, ARC ghost deletion, dir_modify re-key) so no future path can forget its own hook; plus `dir_modify` on inode change (entry survives in place), the hint hash-miss branch, `closevol()` for all of a volume's slots (v_vid persists across logout/re-login), and session shutdown. Never on a freq tick. Directory entries only — file expunges skip the guaranteed-miss scan |
| in-place path repair after a successful relative stat | 1 length compare + 1 byte + short memcmp per hit | an internal parent rename re-paths the parent in place and defers the children — the relative stat serves the (correct) object while the child's `d_fullpath` string still names the old location; the prefix check rebuilds it from the parent in one sized allocation, same object, no expunge |

One call, end to end (three stages: resolve parent → parent fd → relative stat + repair):

```mermaid
flowchart TD
    subgraph resolve ["1 · resolve parent"]
        direction LR
        A["pfd_ostat(vol, entry,<br/>st, opts)"] --> B{"parent?<br/>root child → v_root<br/>else parent lookup"}
    end

    subgraph slot ["2 · parent fd (16-slot LRU)"]
        direction LR
        C{"slot for<br/>(vid, did)?"}
        C -- miss --> D["fill: open O_PATH + fstat<br/>record dev/ino +<br/>dcache_ino baseline"]
        C -- hit --> E{"sync-check:<br/>parent dcache_ino<br/>vs fill baseline"}
        E -- unchanged --> G{"256th<br/>use?"}
        E -- "== slot ino" --> F["re-baseline,<br/>no re-open"]
        F --> G
        E -- "≠ slot ino" --> D
        G -- yes --> P["re-ground probe:<br/>ostat(parent),<br/>dev/ino vs slot"]
        P -- moved --> D
    end

    subgraph stat ["3 · relative stat + repair"]
        direction LR
        H["fstatat(parent_fd, name)"]
        H -- "rc ≠ 0" --> R["return rc/errno<br/>(truthful ENOENT)"]
        H -- "rc == 0" --> J{"d_fullpath prefix<br/>== parent path?"}
        J -- yes --> K["return 0"]
        J -- "no (deferred child of<br/>internal rename)" --> L["rebuild d_fullpath<br/>from parent, in place"]
        L --> K
    end

    B -- found --> C
    D -- ok --> H
    G -- no --> H
    P -- match --> H
    B -- "no entry / ghost /<br/>no path or ino" --> FB["fallback: ostat(d_fullpath)<br/>byte-identical to the old path"]
    D -- "open fails" --> FB
```

Recovery paths (`dirlookup_strict`'s parent recursion, IPC hint processing) deliberately keep full-path `ostat`: their contract is a fresh read of the whole path binding, and a recovery mechanism must not trust the cache under suspicion.

### Duplicate-lookup elimination

`struct path` gains one field, `d_cached` — the dircache entry the caller already resolved (a field, not a parameter: `getfilparams()` has five call sites and `struct path` already travels the whole chain). `enumerate()` sets it beside the `s_path.id` it already passes; consumers gate through a `path_cached_file()` accessor that treats a mid-request invalidation (`d_did == CNID_INVALID`) as absent, and fall back to today's lookup when unset — non-enumerate callers are byte-for-byte unchanged.

The handoff is only safe because the **request-lifetime guarantee** underneath it was made real: the five cache-capacity eviction sites (ARC ghost deletions ×3, ARC victim, legacy-LRU evict) freed `struct dir` synchronously — a lookup-triggered eviction could free the entry `d_cached` points at mid-request, and no flag check helps against freed memory. All five now defer through `invalid_dircache_entries` via a shared `dircache_defer_free()` (inline-free fallback on qnode OOM, so nothing can leak), drained only at end-of-request or by the idle worker while the main thread is parked in `poll()`.

### Discovery-to-hint promotion

Previously, a validation that discovered an external change only bumped a counter — every sibling afpd child then re-discovered the same mutation independently (a full-path stat plus expunge/CNID-repair work each). The discovering child now broadcasts the standard cache hints: `DELETE`/`DELETE_CHILDREN` on expunge; `REFRESH` only on **inode change** — sent under the entry's current DID *and*, when the CNID refresh re-keyed the entry, under the old DID too (siblings hold the object under the old key). ctime-only changes deliberately send nothing: fork writes advance ctime on every flush, and broadcasting those would rebuild sibling AD/rfork caches once per write — pure metadata changes propagate lazily via each sibling's own validation, exactly as before.

## Latent bugs found and fixed (red-first)

1. **Double free on the `dir_add()` error path.** A stray cache entry routed through `dir_remove()` is queued for deferred free, but `cdir` was not reset — a subsequent `get_id()`/`utompath()` failure had the exit block freeing the queued entry a second time. Red test (valgrind leg: 2 invalid frees, exit 99) → one-line fix → green.
2. **`getmetadata()` treated an unfilled caller stat as evidence of external replacement.** `getforkparams()`'s name-only bitmaps (e.g. `FILPBIT_LNAME`) reach the CNID block with `path.st` unset; the inode compare against `st_ino == 0` is a guaranteed mismatch that **expunged a valid dircache entry on every such FPGetForkParms** and forced a CNID rebuild. The compare is now gated on `st_valid` (and `getforkparams` sets it where it fills the stat). Latent before: stack garbage made the wrong compare probabilistic; zeroing the struct made it deterministic and visible. Red test → green. On the dircache-miss leg the same unfilled stat would have minted zero ino/size/dates into the CNID DB and dircache via `get_id()`/`dir_new()`; getmetadata now stats the object before minting identity.
3. **An open fork legitimately outlives its path** (renamed/unlinked by another session) — previously such a request failed `AFPERR_NOOBJ`. `struct path` gains `st_fd`, marking a stat filled from an open fd (object live, path possibly stale); `getforkparams` sets it in its fstat branch, fstat()s the held fd for the one name-only bitmap shape whose identity block can run (LNAME under UTF-8 — other name-only bitmaps pay zero syscalls), and its no-object-fd branch (v2 resource-fork-only forks, whose rfork fd is the `._` sidecar and must not stand in for the object) tolerates ENOENT on a held fork. On a dircache miss with an fd-derived stat, getmetadata probes the path once (dev/ino vs the held object), tracking whether the name is **unoccupied** or **taken by a different object**: live paths mint normally; a **dead path answers identity by read only** — `ad_getid` dev/ino-verified (`ad_forcegetid` for the header-bound rfork-only case), falling back to the DB record *only while the name is unoccupied*, where it can only be the held object's — never when another object holds the name (its identity must not be returned for the held fork), and never via `get_id`/`cnid_add` or `cnid_lookup`, which rewrite the DB on dev/ino or name matches. Every dead-path id passes the same `CNID_START` gate as minted ids. Dead paths enter neither the dircache nor the DB. Red tests (production data-fork-only shape; unlink and replace legs) → green.
4. **`getforkparams()` dereferenced `dirlookup()`'s result without a NULL check** — a fork can outlive its parent directory's CNID entry (deleted by another session, hint-driven expunge). It now returns `get_afp_errno(AFPERR_NOOBJ)` (screening the internal DID1 sentinel), and dirlookup's alloc-failure paths now set `afp_errno` so no NULL return can leak a stale success code.
5. **`dir_modify()`'s path rebuild checked no bstring return codes** — a failed concat silently installed a truncated `d_fullpath` that later validation stats would trust. Path joins now go through shared `fullpath_join()`/`fullpath_join_blk()` helpers (one exactly-sized allocation, zero growth reallocs, never a partial join), and dir_modify runs the fallible join **before** any mutation, so failure leaves the entry unchanged and fully indexed. `absupath`'s hand-rolled join (which also leaked on error paths) converted too.

## Why fd-relative validation is safe (and more graceful under concurrent renames)

A directory fd pins the directory *object*, not its path — POSIX semantics shared by every mainstream filesystem. That is exactly the property this design leans on:

**When another user renames a parent directory mid-operation**, files under it keep working. Validation through the cached parent fd, the process CWD, and any open fork fds all reference the same (renamed) object, so in-flight reads, writes, and metadata operations continue transparently at the directory's new location — one coherent view. The user picks up the new name naturally on their next traversal through that level when path resolution re-reads the tree, or when the re-ground probe (≤256 uses per slot) refreshes the cached fd.

**Before this change, the same rename was disruptive.** Absolute-path validation re-resolved the old path from `/` on every check: entries under a renamed parent started failing (or resolved to whatever new directory landed at the old path) the moment the rename happened, while the CWD and open forks still pointed at the old object — a mixed state that broke other users' in-flight operations against a tree that still existed, merely under a new name.

So the fd-relative model doesn't weaken coherence — it aligns validation with how the rest of the server (and POSIX itself) already treats renamed objects: operations follow the object; names catch up on the next lookup. Deletes are unaffected: an fd on a deleted directory answers only ENOENT, so removal is detected immediately (verified empirically). The always-on full-path fallback covers every case where no trustworthy parent fd exists.

## Behaviour changes

- Validation stats resolve fd-relatively with automatic full-path fallback; the ino/ctime compare and `dir_modify(DCMOD_STAT)` refresh logic are unchanged at both converted sites.
- External **rename-away + recreate** of a cached directory is now detected by the slot's own absolute probe within ≤256 uses per slot (previously: noticed at the child level on the next absolute stat). The interim state is *better-formed* than before: validation answers, the process CWD, and open fork fds all agree on one coherent (old-world) object, where the old code could serve a mixed state. Delete+recreate self-corrects immediately via ENOENT through the old fd (verified empirically).
- Validation-discovered external changes now propagate to sibling afpd processes via cache hints (previously counter-only). One hint per expunged/refreshed entry — the same rate netatalk-side mutations already produce; the sender is non-blocking and drops on a full pipe (hints are advisory; fail-on-use validation remains the backstop).
- Session close logs one pfd stats line (hits / opens / sync-refreshes / probe-refreshes / regrounds / fallbacks / purges); either refresh counter approaching hits is the documented pathological signature.
- Man page (`dircache validation freq`): documents the new cost model and the guidance — shared volumes keep freq=1 (now cheap); netatalk-exclusive volumes can use freq=100, which sacrifices nothing since netatalk-to-netatalk coherence is push-based and freq-independent.

## Testing

Unit tests (afpd suite, run under valgrind — 0 errors):
- **test003_dir_add_error_no_double_free** — dir_add error path must not double-free a queued stray entry (red first, green with the fix).
- **test004_getmetadata_nostat_keeps_cache** — getmetadata keeps a valid cache entry when the caller's stat was never filled (red first, green with the `st_valid` gate).
- **test005_getmetadata_open_fork_outlives_path** — an open fork whose path is gone still resolves identity honestly, exercised in the production data-fork-only shape (fd-derived stat via `st_fd`, `adp == NULL`) across two legs: **unlink** (name unoccupied — the registered record answers, unchanged; dead path not cached) and **replace** (another object occupies the name — its identity is never returned for the held fork and its record is not rebound). Red first on both legs; green with the occupancy-gated read-only identity design.
- **test_pfd_ostat_equivalence** — `pfd_ostat` is byte-identical to plain `ostat` (rc, errno, every consumed stat field) across the quiescent matrix: deep- and root-parented entries, slot miss/hit, ENOENT, ghost-parent fallback.
- **test_pfd_rename_repairs_child_path** — after an internal parent rename (entry re-pathed in place, child deferred), validating the child repairs its `d_fullpath` to the parent's new path — never serves the dead one (red first: the stale path was served; green with the in-place repair).
- **test_pfd_vol_close_purges_slots** — `closevol()` retires every slot keyed on the volume; the test drives a full closevol/openvol cycle and hands the volume back open (red first: slots survived logout; green with the closevol purge).
- **test_pfd_probe_rename_detection** — divergence-window contract under external rename-away+recreate: results are only ever one of the two truthful world views (old object via the held fd, or the new path) — never a third state; probe convergence within 256 uses; and **no refill thrash** after the probe (opens/sync-refreshes stay flat while the dircache entry still lags — pins the three-way sync-check; a naive slot-vs-dircache compare fails this by re-opening every hit).

Integration: spectest green on both legs (default and `AFP_ADOUBLE=1`), single-container loopback, after every stage of the work.

## Not in this PR (follow-ups)

- `of_closefork()`'s post-write cache refresh still stats by absolute path (a genuine full-path walk per dirty-fork close) — a pfd_ostat candidate once this lands, but it needs the fork's `struct dir` threaded through.
- The CWD-relative bare-name stat class (`of_stat(u_name)`, `of_statdir`, post-op refreshes) is untouched: correct today and already single-component; migrating it onto fd-anchored `*at()` calls (and `movecwd()` → `fchdir()` on cached fds) is a separate, larger work item this module is structured to serve.
- The 16-slot LRU size is sized for current single-connection AFP; revisit the count (not the design) if multi-connection lands.
- `dircache validation freq` default remains 1; any default change is a separate discussion — this PR makes freq=1 more affordable rather than arguing for a different sampling rate.

