### PR TITLE
afpd: eliminate redundant metadata work in the FPCopyFile path

### DIFF
--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -2059,11 +2059,19 @@ int afp_copyfile(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 copy_exit:
 
     if (upath && err == AFP_OK) {
+#if defined(WITH_FCE) || defined(WITH_SPOTLIGHT)
+        /* upath is a bare filename and curdir is its parent (see the comment
+         * above mtoupath), so the absolute path comes from the cached
+         * d_fullpath — fullpathname()'s getcwd is not needed. */
+        char dstpath[MAXPATHLEN + 1];
+        snprintf(dstpath, sizeof(dstpath), "%s/%s",
+                 cfrombstr(curdir->d_fullpath), upath);
+#endif
 #ifdef WITH_FCE
-        fce_register(obj, FCE_FILE_CREATE, fullpathname(upath), NULL);
+        fce_register(obj, FCE_FILE_CREATE, dstpath, NULL);
 #endif /* WITH_FCE */
 #ifdef WITH_SPOTLIGHT
-        sl_index_event(obj, d_vol, SL_INDEX_FILE_CREATE, fullpathname(upath), NULL);
+        sl_index_event(obj, d_vol, SL_INDEX_FILE_CREATE, dstpath, NULL);
 #endif /* WITH_SPOTLIGHT */
         /* Send hint to afpd siblings — dest parent dir ctime changed due to copy */
         ipc_send_cache_hint(obj, d_vol->v_vid, curdir->d_did, CACHE_HINT_REFRESH);
@@ -2104,60 +2112,23 @@ int copyfile(struct vol *s_vol,
         adp = &ads;
     }
 
-    adflags = ADFLAGS_DF | ADFLAGS_HF | ADFLAGS_NOHF | ADFLAGS_RF | ADFLAGS_NORF;
+    /* The rfork is copied entirely by vfs_copyfile() below (the rfork EA via
+     * the EA loop, or the ._/.AppleDouble sidecar via copy_file), which does
+     * its own ENOENT-tolerated source probe.  Opening the rfork on the ad
+     * handles here would only duplicate that probe and pre-create an empty
+     * dest rfork for the vfs copy to overwrite, so the ad handles carry just
+     * the data fork and metadata. */
+    adflags = ADFLAGS_DF | ADFLAGS_HF | ADFLAGS_NOHF;
 
-    if (!held) {
-        /* not held: private handle, so ad_open/close is safe.  AD_RSRC_OPEN then
-         * reflects the on-disk rfork. */
-        if (ad_openat(adp, sfd, src, adflags | ADFLAGS_RDONLY) < 0) {
-            err = errno;
-            goto done;
-        }
+    /* not held: private handle, so ad_open/close is safe.  A held source
+     * reuses its fds instead — never ad_open/close onto of->of_ad. */
+    if (!held && ad_openat(adp, sfd, src, adflags | ADFLAGS_RDONLY) < 0) {
+        err = errno;
+        goto done;
+    }
 
-        if (!AD_META_OPEN(adp)) {
-            adflags &= ~ADFLAGS_HF;
-        }
-
-        if (!AD_RSRC_OPEN(adp)) {
-            adflags &= ~ADFLAGS_RF;
-        }
-    } else {
-        /* held: reuse fds, never ad_open/close onto of->of_ad.  Meta presence is
-         * read directly; the rfork may be closed on the held handle even when it
-         * exists on disk, so probe it with a PRIVATE adouble. */
-        if (!AD_META_OPEN(adp)) {
-            adflags &= ~ADFLAGS_HF;
-        }
-
-#if defined(HAVE_EAFD) && defined(SOLARIS)
-
-        /* Solaris O_XATTR rfork fd hangs off the data fd: a private rfork open
-         * would strand the held locks - fall back to the held handle's view. */
-        if (!AD_RSRC_OPEN(adp)) {
-            adflags &= ~ADFLAGS_RF;
-        }
-
-#else
-
-        if (!AD_RSRC_OPEN(adp)) {
-            struct adouble adprobe;
-            ad_init(&adprobe, s_vol);
-
-            if (ad_openat(&adprobe, sfd, src,
-                          ADFLAGS_RF | ADFLAGS_NORF | ADFLAGS_RDONLY) == 0) {
-                int has_rf = AD_RSRC_OPEN(&adprobe);
-                ad_close(&adprobe, ADFLAGS_RF | ADFLAGS_HF);
-
-                if (!has_rf) {
-                    adflags &= ~ADFLAGS_RF;
-                }
-            }
-
-            /* a hard open error leaves RF set: create the dest rfork, matching
-             * the not-held path's RF|NORF open. */
-        }
-
-#endif
+    if (!AD_META_OPEN(adp)) {
+        adflags &= ~ADFLAGS_HF;
     }
 
     /* saving stat exit code, thus saving us on one more stat later on */

--- a/libatalk/vfs/ea_sys.c
+++ b/libatalk/vfs/ea_sys.c
@@ -664,6 +664,16 @@ int sys_ea_copyfile(const struct vol *vol _U_, int sfd, const char *src,
             continue;
         }
 
+        /* Skip the Netatalk metadata EA: the caller (copyfile) creates the
+         * destination's own header via ad_open(ADFLAGS_CREATE) and stamps its
+         * identity with ad_setid/ad_flush afterwards.  Copying the source's
+         * EA here would only plant the source's CNID/dev/ino on the dest to
+         * be overwritten again.  Exact match: a user EA that merely shares
+         * the prefix (e.g. "org.netatalk.Metadata.backup") must still copy. */
+        if (!strcmp(name, AD_EA_META)) {
+            continue;
+        }
+
 #if defined(SOLARIS) && defined(HAVE_SYS_ATTR_H)
 
         /* Skip special attributes set by NFS server */

--- a/test/testsuite/FPCopyFile.c
+++ b/test/testsuite/FPCopyFile.c
@@ -1257,6 +1257,94 @@ test_exit:
     exit_test("FPCopyFile:test425: copy file with held-open resource fork");
 }
 
+/* ------------------------- */
+STATIC void test564()
+{
+    char *name  = "t564 source file";
+    char *name1 = "t564 copied file";
+    uint16_t vol = VolID;
+    int tp, tp1;
+    unsigned int ret;
+    uint16_t bitmap = (1 << FILPBIT_FNUM);
+    ENTER_TEST
+
+    if (!(get_vol_attrib(vol) & VOLPBIT_ATTR_FILEID)) {
+        test_skipped(T_ID);
+        goto test_exit;
+    }
+
+    if (FPCreateFile(Conn, vol, 0, DIRDID_ROOT, name)) {
+        test_nottested();
+        goto test_exit;
+    }
+
+    FAIL(FPCopyFile(Conn, vol, DIRDID_ROOT, vol, DIRDID_ROOT, name, "", name1))
+    tp = get_fid(Conn, vol, DIRDID_ROOT, name);
+    tp1 = get_fid(Conn, vol, DIRDID_ROOT, name1);
+
+    if (!tp || !tp1) {
+        test_nottested();
+        goto fin;
+    }
+
+    if (tp == tp1) {
+        if (!Quiet) {
+            fprintf(stdout, "\tFAILED source and copy share a file ID\n");
+        }
+
+        test_failed();
+        goto fin;
+    }
+
+    /* Both IDs must resolve independently: a copy whose stored identity
+     * still carried the source's CNID would leave one of these dangling
+     * or aliased to the other file. */
+    ret = FPResolveID(Conn, vol, tp, bitmap);
+
+    if (ret) {
+        if (!Quiet) {
+            fprintf(stdout, "\tFAILED source ID no longer resolves\n");
+        }
+
+        test_failed();
+        goto fin;
+    }
+
+    ret = FPResolveID(Conn, vol, tp1, bitmap);
+
+    if (ret) {
+        if (!Quiet) {
+            fprintf(stdout, "\tFAILED copy ID does not resolve\n");
+        }
+
+        test_failed();
+        goto fin;
+    }
+
+    /* Delete the source: the copy's ID must survive on its own. */
+    FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+    name = NULL;
+    ret = FPResolveID(Conn, vol, tp1, bitmap);
+
+    if (ret) {
+        if (!Quiet) {
+            fprintf(stdout, "\tFAILED copy ID lost after source deletion\n");
+        }
+
+        test_failed();
+    }
+
+fin:
+
+    if (name) {
+        FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name))
+    }
+
+    FAIL(FPDelete(Conn, vol, DIRDID_ROOT, name1))
+test_exit:
+    exit_test("FPCopyFile:test564: copy has its own file ID, independent of the source");
+}
+
 /* ----------- */
 void FPCopyFile_test()
 {
@@ -1277,4 +1365,5 @@ void FPCopyFile_test()
     test414();
     test424();
     test425();
+    test564();
 }


### PR DESCRIPTION
FPCopyFile did the same sidecar and metadata work in multiple layers, tripling parts of the per-copy cost:

- copyfile() opened the source rfork (and pre-created an empty dest rfork) that vfs_copyfile() then probed and copied again on its own; the ad handles now carry only the data fork and metadata, dropping the duplicate ENOENT probes and the held-handle rfork probe fallback
- sys_ea_copyfile() copied the source's netatalk Metadata EA onto the dest between the dest header create and the ad_setid identity stamp, planting the source's CNID/dev/ino only to be overwritten; the EA copy loop now skips the Metadata EA like the get/set/remove EA handlers already do
- the FCE/Spotlight notification path called fullpathname() (getcwd) twice per copy even when both subsystems are disabled; the path is now built from the cached curdir->d_fullpath

strace of one FPCopyFile: ~48 -> ~36 syscalls.

## Testing

Added spectest test564 - verifies that the copied file created by ServerCopy has its own ID