### PR TITLE
ci: runner-normalized Adj Δ% column for the lantest dashboard

### DIFF
--- a/.github/scripts/perf_history.pl
+++ b/.github/scripts/perf_history.pl
@@ -41,11 +41,18 @@
 # Usage:
 #     perf_history.pl --history FILE --pr N --timestamp ISO8601 \
 #         --section name=metrics_file [--section name=metrics_file ...] \
+#         [--adjust name ...] [--adjust-exclude REGEX] \
 #         [--github-output FILE]
 #
 # For every --section the script writes a "<name>_table" and "<name>_inline"
 # output (empty string when there is no data) to --github-output (defaults
 # to $GITHUB_OUTPUT), and rewrites --history in place.
+#
+# Sections named by --adjust gain an "Adj %" column: each metric's
+# current/avg ratio divided by the section's runner baseline (the median
+# ratio across its table metrics, minus keys matching --adjust-exclude).
+# This cancels run-to-run runner-speed variance so genuine code effects
+# stand out; standouts beyond 5% render bold.
 
 use strict;
 use warnings;
@@ -181,11 +188,39 @@ sub upsert {
     $hist->{$key} = \@entries;
 }
 
+sub median {
+    my @sorted = sort { $a <=> $b } @_;
+    return unless @sorted;
+    my $mid = int(@sorted / 2);
+    return @sorted % 2 ? $sorted[$mid] : ($sorted[$mid - 1] + $sorted[$mid]) / 2;
+}
+
+# Runner-speed baseline for an adjusted section: the median of the
+# current/avg ratios across its history-backed table metrics.  All tests in
+# one run move together with the runner's speed, and the median ignores the
+# few a PR genuinely changed, so re-basing each ratio against it isolates
+# code effects from runner variance.  Keys matching the exclude pattern
+# (e.g. the IO-bound streaming tests, whose variance does not track the
+# CPU-bound op tests) contribute nothing and get no adjusted value.
+sub baseline_ratio {
+    my ($rows, $hist, $pr, $exclude_re) = @_;
+    my @ratios;
+    for my $row (@$rows) {
+        my ($render, $key, $name, $unit, $value) = @$row;
+        next unless $render eq 'table';
+        next if defined $exclude_re && $key =~ /$exclude_re/;
+        my ($avg) = hist_stats($hist, $key, $pr);
+        push @ratios, $value / $avg if defined $avg && $avg > 0;
+    }
+    return median(@ratios);
+}
+
 # Build the (table_md, inline_md) fragments for one section.
 sub render_section {
-    my ($rows, $hist, $pr) = @_;
+    my ($rows, $hist, $pr, $adjust, $exclude_re) = @_;
     my (@table_rows, @inline_bits);
     my $unit_hdr = '';
+    my $base_r   = $adjust ? baseline_ratio($rows, $hist, $pr, $exclude_re) : undef;
     for my $row (@$rows) {
         my ($render, $key, $name, $unit, $value) = @$row;
         my ($avg, $min, $max, $n) = hist_stats($hist, $key, $pr);
@@ -206,23 +241,49 @@ sub render_section {
               defined $avg
               ? (fmt_delta($value, $avg), fmt_value($avg), fmt_value($min), fmt_value($max))
               : ("\x{2014}") x 4;
+            if ($adjust) {
+                my $adj = "\x{2014}";
+                if (    defined $base_r
+                     && defined $avg
+                     && $avg > 0
+                     && (!defined $exclude_re || $key !~ /$exclude_re/)) {
+                    my $pct = 100.0 * ($value / $avg / $base_r - 1);
+                    $adj = sprintf('%+.1f%%', $pct);
+                    # standout beyond the run's baseline: a code effect,
+                    # not a runner property
+                    $adj = "**$adj**" if abs($pct) >= 5;
+                }
+                splice @cells, 1, 0, $adj;
+            }
             push @table_rows,
               sprintf(
-                      '| %s | %s | %s | %s | %s | %s |',
+                      '| %s | %s | ' . join(' | ', ('%s') x @cells) . ' |',
                       $name, fmt_value($value), @cells
               );
         }
     }
     my $table_md = '';
     if (@table_rows) {
+        my $adj_hdr = $adjust ? "Adj \x{394}% | " : '';
+        my $adj_sep = $adjust ? "-------|"        : '';
         $table_md =
-            "| Metric | Current ($unit_hdr) | Cur Avg \x{394}% | Hist avg "
+            "| Metric | Current ($unit_hdr) | Cur Avg \x{394}% | ${adj_hdr}Hist avg "
           . "| Hist min | Hist max |\n"
-          . "|--------|------------------|------------|----------"
+          . "|--------|------------------|------------|${adj_sep}----------"
           . "|----------|----------|\n"
           . join("\n", @table_rows);
+
+        if (defined $base_r) {
+            $table_md .= sprintf(
+                                   "\n\n_Run baseline: median op-test delta %+.1f%%. "
+                                 . "Adj \x{394}%% re-bases each delta against it; standouts \x{2265}5%% in bold._",
+                                 100.0 * ($base_r - 1)
+            );
+        }
     }
-    return ($table_md, join(" \x{b7} ", @inline_bits));
+    # One stat per line: markdown needs the trailing double-space for a
+    # line break inside the same paragraph.
+    return ($table_md, join("  \n", @inline_bits));
 }
 
 sub write_output {
@@ -234,17 +295,23 @@ sub main {
     my ($history_path, $pr, $timestamp);
     my @sections;
     my $github_output = $ENV{GITHUB_OUTPUT} // '/dev/null';
+    my @adjust_sections;
+    my $adjust_exclude;
     GetOptions(
-               'history=s'       => \$history_path,
-               'pr=i'            => \$pr,
-               'timestamp=s'     => \$timestamp,
-               'section=s'       => \@sections,
-               'github-output=s' => \$github_output,
+               'history=s'        => \$history_path,
+               'pr=i'             => \$pr,
+               'timestamp=s'      => \$timestamp,
+               'section=s'        => \@sections,
+               'adjust=s'         => \@adjust_sections,
+               'adjust-exclude=s' => \$adjust_exclude,
+               'github-output=s'  => \$github_output,
       )
       or die "usage: perf_history.pl --history FILE --pr N --timestamp TS "
-      . "--section NAME=FILE ... [--github-output FILE]\n";
+      . "--section NAME=FILE ... [--adjust NAME ...] "
+      . "[--adjust-exclude REGEX] [--github-output FILE]\n";
     die "missing --history/--pr/--timestamp\n"
       unless defined $history_path && defined $pr && defined $timestamp;
+    my %adjust = map { $_ => 1 } @adjust_sections;
 
     my $hist = load_history($history_path);
 
@@ -254,7 +321,8 @@ sub main {
         my ($name, $path) = split /=/, $spec, 2;
         die "bad --section (want NAME=FILE): $spec\n" unless defined $path && length $path;
         my $rows = load_metrics($path);
-        my ($table_md, $inline_md) = render_section($rows, $hist, $pr);
+        my ($table_md, $inline_md) =
+          render_section($rows, $hist, $pr, $adjust{$name}, $adjust_exclude);
         write_output($out, "${name}_table",  $table_md);
         write_output($out, "${name}_inline", $inline_md);
         upsert($hist, $_->[1], $pr, $timestamp, $_->[4]) for @$rows;

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1596,8 +1596,11 @@ jobs:
             --pr "$PR_NUMBER" \
             --timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             --section lantest=lantest-metrics.txt \
-            --section speedtest=speedtest-metrics.txt
+            --section speedtest=speedtest-metrics.txt \
+            --adjust lantest \
+            --adjust-exclude one_large_file
       - name: Publish updated history to gh-pages
+        id: history-publish
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
@@ -1629,13 +1632,18 @@ jobs:
               continue
             fi
             git reset --hard origin/gh-pages
+            # Emit the regenerated fragments as this step's outputs: the
+            # dashboard comment prefers them over the pre-retry ones, so the
+            # posted deltas always match the history actually published.
             perl ../.github/scripts/perf_history.pl \
               --history perf-history/history.yml \
               --pr "$PR_NUMBER" \
               --timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
               --section lantest=../lantest-metrics.txt \
               --section speedtest=../speedtest-metrics.txt \
-              --github-output /dev/null
+              --adjust lantest \
+              --adjust-exclude one_large_file \
+              --github-output "$GITHUB_OUTPUT"
             git add perf-history/history.yml
             if git diff --cached --quiet; then
               echo "No history change after regenerating on fresh head"
@@ -1694,12 +1702,12 @@ jobs:
 
             [![Speedtest throughput](https://netatalk.github.io/netatalk/speedtest/pr-${{ github.event.pull_request.number }}.png)](https://netatalk.github.io/netatalk/speedtest/pr-${{ github.event.pull_request.number }}.png)
 
-            ${{ steps.history.outputs.speedtest_inline }}
+            ${{ steps.history-publish.outputs.speedtest_inline || steps.history.outputs.speedtest_inline }}
 
             <details>
             <summary>🔝 Throughputs per operation (vs. historical average)</summary>
 
-            ${{ steps.history.outputs.speedtest_table }}
+            ${{ steps.history-publish.outputs.speedtest_table || steps.history.outputs.speedtest_table }}
 
             </details>
 
@@ -1707,12 +1715,12 @@ jobs:
 
             [![Lantest latency](https://netatalk.github.io/netatalk/lantest/pr-${{ github.event.pull_request.number }}.png)](https://netatalk.github.io/netatalk/lantest/pr-${{ github.event.pull_request.number }}.png)
 
-            ${{ steps.history.outputs.lantest_inline }}
+            ${{ steps.history-publish.outputs.lantest_inline || steps.history.outputs.lantest_inline }}
 
             <details>
             <summary>🐢 All operations (avg runtime, in test order, vs. historical average)</summary>
 
-            ${{ steps.history.outputs.lantest_table }}
+            ${{ steps.history-publish.outputs.lantest_table || steps.history.outputs.lantest_table }}
 
             </details>
 


### PR DESCRIPTION
Adds a runner-normalized **Adj Δ%** column to the lantest dashboard table, separating genuine code effects from CI runner speed variance.

## The problem

Every lantest op test in a CI run moves together with the runner it landed on: a fast host shifts all deltas down 1–3%, a slow one shifts them all up. A single run's `Cur Avg Δ%` therefore mixes two signals — the runner's speed relative to the historical fleet, and the PR's actual code effect. PR #3231 showed this clearly: every test drifted −1–3% (runner) while ServerCopy moved −18.5% (code).

## The method

This is the same trick as **median-of-ratios normalization** in genomics (DESeq2's size factors) and **market-relative returns** in finance: when most members of a population move with a common factor, the median isolates that factor because it ignores the minority that genuinely changed.

Walk-through, per dashboard render:

1. For each history-backed lantest table metric *i*, compute its ratio against its own historical average:
   `rᵢ = currentᵢ / hist_avgᵢ` (equivalently `1 + δᵢ`, where δᵢ is the raw delta)
2. Take the **run baseline** `m = median(rᵢ)` across those metrics — the runner's speed factor for this run. The median, not the mean, so the handful of tests the PR genuinely changed can't skew it.
3. Re-base each metric against the baseline, by **division**:
   `Adj Δᵢ = rᵢ / m − 1 = (1 + δᵢ) / (1 + m′) − 1` (where `m′ = m − 1` is the baseline expressed as a delta)
   Division rather than subtraction because runner speed is multiplicative — a runner that is 10% slower makes a 500 ms test 550 ms and a 100 ms test 110 ms; subtracting a flat 10 points would over-correct slow tests and under-correct fast ones.
4. Metrics with `|Adj Δ| ≥ 5%` render **bold**: standouts from the pack — code effects, not runner properties.
5. The baseline itself is printed under the table (`Run baseline: median op-test delta +10.0%`), so a strongly shifted run is visible at a glance.

Worked example (the scenario from #3231, simulated in testing — slow runner +10%, ServerCopy genuinely improved 18%):

| Metric | Current (ms) | Cur Avg Δ% | Adj Δ% | Hist avg |
|--------|--------------|------------|--------|----------|
| Creating 2000 files | 330 | +10.0% | +0.0% | 300 |
| Copying 2000 files server-side | 631 | −9.9% | **−18.1%** | 700 |
| Stat 2000 files | 275 | +10.0% | +0.0% | 250 |

The raw column shows the confounded −9.9%; the adjusted column recovers the true −18.1%.

## Scope decisions

- **`Cur Avg Δ%` stays.** Median-centering detects *differential* signals only — a change that shifts every test equally is indistinguishable from runner noise and gets normalized away by construction. Uniform regressions and broad improvements remain visible in the raw column, in the printed run baseline, and in the long-term `Avg total runtime` trend already stored in the YAML history.
- **Lantest only.** Speedtest metrics are not commensurable (peak/avg-mean/avg-max of four different operations), and runner IO variance does not track the CPU-bound op tests, so a speedtest median would be meaningless.
- **The 100MB streaming tests are excluded** (`--adjust-exclude one_large_file`) for the same reason: Write/Read 100MB are IO-bound and don't move with the CPU-bound op-test baseline. They contribute nothing to the median and show `—` in the adjusted column.
- **First run / no history**: the column renders `—` throughout and no baseline footer is printed.

## Mechanics

`perf_history.pl` gains `--adjust NAME` (per-section opt-in) and `--adjust-exclude REGEX`; both dashboard call sites (main merge and the push-retry regeneration) pass `--adjust lantest --adjust-exclude one_large_file`, so a retried publish regenerates identically.

## Testing

- Slow-runner simulation (all +10%, one −18% code improvement): baseline +10.0%, unaffected tests +0.0% adjusted, improvement recovered at −18.1% and bolded
- First-run empty history and excluded-metric rendering verified
- perltidy clean; both call sites verified; core-Perl only (no new dependencies)

Follow-up once history accumulates: replace the fixed 5% standout threshold with per-test historical stddev bands.
