### PR TITLE
afpd: use designated initializer for Cur_Path

### DIFF
--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -82,14 +82,8 @@ struct dir rootParent = {
 };
 struct dir  *curdir = &rootParent;
 struct path Cur_Path = {
-    0,
-    "",  /* mac name */
-    ".", /* unix name */
-    0,   /* id */
-    NULL,/* pointer to struct dir */
-    0,   /* stat is not set */
-    0,   /* errno */
-    {0} /* struct stat */
+    .m_name = "",  /* mac name */
+    .u_name = ".", /* unix name */
 };
 
 /*


### PR DESCRIPTION
Adding st_fd to struct path shifted Cur_Path's positional initializer, causing the struct stat initializer {0} to be applied to the scalar st_fd member and producing a compiler warning.

Initialize only the nonzero path names with C11 designated initializers; the remaining members, including st_fd and struct stat, are guaranteed to be zero-initialized and future struct changes cannot shift the values.

Note: This was flagged as a compiler warning by gcc on OpenIndiana Hipster 2025