### PR TITLE
afpd: eliminate per-entry rfork probes and per-op getcwd on hot paths

### DIFF
--- a/.github/scripts/perf_history.pl
+++ b/.github/scripts/perf_history.pl
@@ -49,10 +49,11 @@
 # to $GITHUB_OUTPUT), and rewrites --history in place.
 #
 # Sections named by --adjust gain an "Adj %" column: each metric's
-# current/avg ratio divided by the section's runner baseline (the median
-# ratio across its table metrics, minus keys matching --adjust-exclude).
-# This cancels run-to-run runner-speed variance so genuine code effects
-# stand out; standouts beyond 5% render bold.
+# current/avg delta shifted by the section's runner baseline (the median
+# delta across its table metrics, minus keys matching --adjust-exclude).
+# The MAD of the deltas is reported alongside the baseline as a
+# uniformity indicator. This cancels run-to-run runner-speed variance so
+# genuine code effects stand out; standouts beyond 5% render bold.
 
 use strict;
 use warnings;
@@ -196,23 +197,29 @@ sub median {
 }
 
 # Runner-speed baseline for an adjusted section: the median of the
-# current/avg ratios across its history-backed table metrics.  All tests in
-# one run move together with the runner's speed, and the median ignores the
-# few a PR genuinely changed, so re-basing each ratio against it isolates
-# code effects from runner variance.  Keys matching the exclude pattern
+# current/avg deltas across its history-backed table metrics, plus the MAD
+# (median absolute deviation) of those deltas.  All tests in one run move
+# together with the runner's speed, and the median ignores the few a PR
+# genuinely changed, so shifting each delta by it isolates code effects
+# from runner variance; the MAD shows how uniformly the run actually moved
+# (a large MAD means the shift is not common-mode and the adjusted column
+# should be read with suspicion).  Keys matching the exclude pattern
 # (e.g. the IO-bound streaming tests, whose variance does not track the
 # CPU-bound op tests) contribute nothing and get no adjusted value.
-sub baseline_ratio {
+sub baseline_delta {
     my ($rows, $hist, $pr, $exclude_re) = @_;
-    my @ratios;
+    my @deltas;
     for my $row (@$rows) {
         my ($render, $key, $name, $unit, $value) = @$row;
         next unless $render eq 'table';
         next if defined $exclude_re && $key =~ /$exclude_re/;
         my ($avg) = hist_stats($hist, $key, $pr);
-        push @ratios, $value / $avg if defined $avg && $avg > 0;
+        push @deltas, 100.0 * ($value / $avg - 1) if defined $avg && $avg > 0;
     }
-    return median(@ratios);
+    my $med = median(@deltas);
+    return unless defined $med;
+    my $mad = median(map { abs($_ - $med) } @deltas);
+    return ($med, $mad);
 }
 
 # Build the (table_md, inline_md) fragments for one section.
@@ -220,7 +227,9 @@ sub render_section {
     my ($rows, $hist, $pr, $adjust, $exclude_re) = @_;
     my (@table_rows, @inline_bits);
     my $unit_hdr = '';
-    my $base_r   = $adjust ? baseline_ratio($rows, $hist, $pr, $exclude_re) : undef;
+    my ($base_d, $base_mad);
+    ($base_d, $base_mad) = baseline_delta($rows, $hist, $pr, $exclude_re)
+      if $adjust;
     for my $row (@$rows) {
         my ($render, $key, $name, $unit, $value) = @$row;
         my ($avg, $min, $max, $n) = hist_stats($hist, $key, $pr);
@@ -243,11 +252,11 @@ sub render_section {
               : ("\x{2014}") x 4;
             if ($adjust) {
                 my $adj = "\x{2014}";
-                if (    defined $base_r
+                if (    defined $base_d
                      && defined $avg
                      && $avg > 0
                      && (!defined $exclude_re || $key !~ /$exclude_re/)) {
-                    my $pct = 100.0 * ($value / $avg / $base_r - 1);
+                    my $pct = 100.0 * ($value / $avg - 1) - $base_d;
                     $adj = sprintf('%+.1f%%', $pct);
                     # standout beyond the run's baseline: a code effect,
                     # not a runner property
@@ -273,11 +282,13 @@ sub render_section {
           . "|----------|----------|\n"
           . join("\n", @table_rows);
 
-        if (defined $base_r) {
+        if (defined $base_d) {
             $table_md .= sprintf(
-                                   "\n\n_Run baseline: median op-test delta %+.1f%%. "
-                                 . "Adj \x{394}%% re-bases each delta against it; standouts \x{2265}5%% in bold._",
-                                 100.0 * ($base_r - 1)
+                                   "\n\n_Run baseline: median op-test delta %+.1f%%, MAD %.1f%%. "
+                                 . "Adj \x{394}%% shifts each delta by the median; standouts \x{2265}5%% in bold. "
+                                 . "A large MAD means the run did not move uniformly \x{2014} "
+                                 . "read the adjusted column with caution._",
+                                 $base_d, $base_mad
             );
         }
     }

--- a/etc/afpd/ad_cache.c
+++ b/etc/afpd/ad_cache.c
@@ -24,6 +24,7 @@
 
 #include <atalk/adouble.h>
 #include <atalk/directory.h>
+#include <atalk/ea.h>
 #include <atalk/errchk.h>
 #include <atalk/logger.h>
 #include <atalk/util.h>
@@ -174,14 +175,14 @@ int ad_metadata_cached(const char *name, int flags, struct adouble *adp,
             ad_rebuild_from_cache(adp, dir);
             ad_cache_hits++;
             return 0;
-        } else if (dir->dcache_rlen == (off_t) -2) {
-            /* Confirmed no AD exists and ctime unchanged — still no AD */
+        } else if (ad_rlen_meta_absent(dir->dcache_rlen)) {
+            /* Confirmed no AD metadata and ctime unchanged — still none */
             ad_cache_no_ad++;
             errno = ENOENT;
             return -1;
         }
 
-        /* dcache_rlen == -1: not yet loaded (or just invalidated), fall through */
+        /* AD_RLEN_UNKNOWN: not yet loaded (or just invalidated), fall through */
     }
 
     if (!strict && dir && dir->dcache_rlen >= 0) {
@@ -202,7 +203,7 @@ int ad_metadata_cached(const char *name, int flags, struct adouble *adp,
         return 0;
     }
 
-    if (dir && dir->dcache_rlen == (off_t) -2) {
+    if (dir && ad_rlen_meta_absent(dir->dcache_rlen)) {
         /* If caller provided a recent stat and ctime/inode changed,
          * the AD file may have been created since — re-check on disk. */
         if (recent_st
@@ -215,7 +216,7 @@ int ad_metadata_cached(const char *name, int flags, struct adouble *adp,
             goto disk_read;
         }
 
-        /* Confirmed no AD exists and ctime unchanged — still no AD */
+        /* Confirmed no AD metadata and ctime unchanged — still none */
         ad_cache_no_ad++;
         errno = ENOENT;
         return -1;
@@ -239,14 +240,36 @@ disk_read:
         ad_close(adp, ADFLAGS_HF | flags);
     } else if (ret < 0 && errno == ENOENT && dir
                && dir->d_did != CNID_INVALID) {
-        /* Free rfork buffer FIRST — rfork_cache_free() uses dcache_rlen for budget.
-         * Setting rlen = -2 before freeing would corrupt rfork_cache_used tracking. */
+        int saved_errno = errno;
+
+        /* Free rfork buffer FIRST — rfork_cache_free() uses dcache_rlen for
+         * budget. Minting a sentinel before freeing would corrupt
+         * rfork_cache_used tracking. */
         if (dir->dcache_rfork_buf) {
             rfork_cache_free(dir);
             rfork_stat_invalidated++;
         }
 
-        dir->dcache_rlen = (off_t) -2;
+        /* Metadata ENOENT does not prove the rfork is absent: with ea=sys
+         * it is a separate EA (Samba vfs_fruit, macOS-native writers).
+         * ad_reso_size() returns 0 for any failure, so errno must confirm
+         * absence before minting NO_AD; an ambiguous probe leaves UNKNOWN.
+         * Directories have no resource fork. */
+        if (flags & ADFLAGS_DIR) {
+            dir->dcache_rlen = AD_RLEN_NO_AD;
+        } else {
+            errno = 0;
+            off_t rlen = ad_reso_size(name, 0, NULL);
+
+            if (rlen > 0) {
+                dir->dcache_rlen = AD_RLEN_RFORK_ONLY;
+            } else if (rlen == 0 && (errno == 0 || errno == ENOENT
+                                     || errno == ENOATTR)) {
+                dir->dcache_rlen = AD_RLEN_NO_AD;
+            }
+        }
+
+        errno = saved_errno;
     }
 
     return ret;
@@ -357,7 +380,7 @@ void rfork_cache_evict_to_budget(size_t needed)
  *
  * Allocates dcache_rlen bytes and does ad_read(adp, eid, 0, buf, dcache_rlen).
  * ad_read() handles all storage formats (EA, macOS xattr, AD v2 sidecar).
- * Guards: returns -1 if !AD_RSRC_OPEN(adp) (fd not open), dcache_rlen <= 0,
+ * Guards: returns -1 if !ad_rsrc_open(adp) (fd not open), dcache_rlen <= 0,
  * or rlen > rfork_max_entry_size.
  * Validates that ad_read returns exactly dcache_rlen bytes — if not, the fork
  * size changed since Tier 1 metadata was cached: invalidates ALL cached AD
@@ -384,7 +407,7 @@ int rfork_cache_store_from_fd(struct dir *entry, struct adouble *adp, int eid)
         rfork_cache_free(entry);
     }
 
-    if (!AD_RSRC_OPEN(adp)) {
+    if (!ad_rsrc_open(adp)) {
         return -1;
     }
 
@@ -436,7 +459,7 @@ int rfork_cache_store_from_fd(struct dir *entry, struct adouble *adp, int eid)
             "rfork_cache_store_from_fd: short read (%zd vs %lld) — "
             "external change detected, invalidating AD cache (did:%u)",
             bytes_read, (long long)entry->dcache_rlen, ntohl(entry->d_did));
-        entry->dcache_rlen = (off_t) -1;
+        entry->dcache_rlen = AD_RLEN_UNKNOWN;
         memset(entry->dcache_finderinfo, 0, 32);
         memset(entry->dcache_filedatesi, 0, 16);
         memset(entry->dcache_afpfilei, 0, 4);

--- a/etc/afpd/catsearch.c
+++ b/etc/afpd/catsearch.c
@@ -2,6 +2,7 @@
  * Copyright (C) 1990, 1993 Regents of The University of Michigan
  * Copyright (c) 2002 Rafal Lewczuk <rlewczuk@pronet.pl>
  * Copyright (C) 2010 Frank Lahm
+ * Copyright (c) 2026 Andy Lemin (andylemin)
  * All Rights Reserved. See COPYRIGHT
  */
 
@@ -364,13 +365,15 @@ static struct adouble *adl_lkup(struct vol *vol, struct path *path,
 
     if (!isdir && (of = of_findname(vol, path))) {
         /* Fork-owned adouble — use directly, skip cache.
-         * Opportunistically populate cache if not yet loaded. */
+         * Opportunistically populate cache if not yet loaded.
+         * ad_meta_loaded(): a fork open without metadata leaves the
+         * adouble's header zeroed — storing it would flip a negative
+         * sentinel to a bogus positive entry. */
         adp = of->of_ad;
         struct dir *cached = dircache_search_by_name(vol, curdir,
                              path->u_name, strnlen(path->u_name, CNID_MAX_PATH_LEN));
 
-        /* If cache AD is unset, store fork's live adouble */
-        if (cached && cached->dcache_rlen < 0) {
+        if (cached && cached->dcache_rlen < 0 && ad_meta_loaded(adp)) {
             ad_store_to_cache(adp, cached);
         }
     } else {

--- a/etc/afpd/desktop.c
+++ b/etc/afpd/desktop.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1990,1993 Regents of The University of Michigan.
+ * Copyright (c) 2026 Andy Lemin (andylemin)
  * All Rights Reserved.  See COPYRIGHT.
  */
 
@@ -1067,21 +1068,29 @@ static int ad_getcomment(struct vol *vol, struct path *path, char *rbuf,
         adp = of->of_ad;
     }
 
+    struct dir *cached = isadir ? path->d_dir
+                         : dircache_search_by_name(vol, curdir, upath, strnlen(upath,
+                             CNID_MAX_PATH_LEN));
+
+    /* ADEID_COMMENT is not in the Tier 1 cache, so a cache hit cannot
+     * serve the comment itself — but the negative AD cache can answer
+     * "no metadata, hence no comment" without a disk probe. Only with a
+     * ctime/inode-validated entry and no open fork (an open fork may
+     * have just created metadata). */
+    if (adp == &ad && cached && ad_rlen_meta_absent(cached->dcache_rlen)
+            && path->st_valid && path->st_errno == 0
+            && cached->dcache_ctime == path->st.st_ctime
+            && cached->dcache_ino == path->st.st_ino) {
+        return AFPERR_NOITEM;
+    }
+
     if (ad_metadata(upath, (isadir ? ADFLAGS_DIR : 0), adp) < 0) {
         return AFPERR_NOITEM;
     }
 
-    /* Opportunistic AD cache population (ADEID_COMMENT not in Tier 1 cache,
-     * but we can populate Tier 1 fields while we have the AD open) */
-    {
-        struct dir *cached = isadir ? path->d_dir
-                             : dircache_search_by_name(vol, curdir, upath, strnlen(upath,
-                                 CNID_MAX_PATH_LEN));
-
-        /* If cache AD is unset, store fork's live adouble */
-        if (cached && cached->dcache_rlen < 0) {
-            ad_store_to_cache(adp, cached);
-        }
+    /* Opportunistic AD cache population while the AD is open */
+    if (cached && cached->dcache_rlen < 0) {
+        ad_store_to_cache(adp, cached);
     }
 
     if (!ad_getentryoff(adp, ADEID_COMMENT) || !ad_entry(adp, ADEID_COMMENT)) {

--- a/etc/afpd/dircache.c
+++ b/etc/afpd/dircache.c
@@ -2482,8 +2482,10 @@ void dircache_dump(void)
 
         if (dir->dcache_rlen >= 0) {
             ad_cache_state = "cached";
-        } else if (dir->dcache_rlen == (off_t) -1) {
+        } else if (dir->dcache_rlen == AD_RLEN_UNKNOWN) {
             ad_cache_state = "unloaded";
+        } else if (dir->dcache_rlen == AD_RLEN_RFORK_ONLY) {
+            ad_cache_state = "rfork";
         } else {
             ad_cache_state = "absent";
         }

--- a/etc/afpd/directory.c
+++ b/etc/afpd/directory.c
@@ -76,8 +76,8 @@ struct dir rootParent = {
     .dcache_mode = S_IFDIR | 0755,
     /* rootParent.d_rights_cache init to 0xffffffff ('access rights not set/unknown') */
     .d_rights_cache = 0xffffffff,
-    /* dcache_rlen init to -1 ('resource fork length unknown/not set') */
-    .dcache_rlen = (off_t) -1,
+    /* dcache_rlen init to AD_RLEN_UNKNOWN ('not yet loaded') */
+    .dcache_rlen = AD_RLEN_UNKNOWN,
     /* All other fields zero-initialized by C11 designated init rules */
 };
 struct dir  *curdir = &rootParent;
@@ -933,7 +933,7 @@ struct dir *dir_new(const char *m_name,
     dir->dcache_gid = st->st_gid;
     dir->dcache_size = st->st_size;
     /* Not yet loaded — triggers ad_metadata() on first access */
-    dir->dcache_rlen = (off_t) - 1;
+    dir->dcache_rlen = AD_RLEN_UNKNOWN;
 
     if (!S_ISDIR(st->st_mode)) {
         dir->d_flags = DIRF_ISFILE;
@@ -1215,7 +1215,7 @@ int dir_modify(const struct vol *vol, struct dir *dir,
             }
 
             /* Different inode = different file. AD is always stale. */
-            dir->dcache_rlen = (off_t) -1;
+            dir->dcache_rlen = AD_RLEN_UNKNOWN;
             /* Refresh CNID from database */
             cnid_t new_cnid = CNID_INVALID;
             AFP_CNID_START("cnid_lookup");
@@ -1227,7 +1227,7 @@ int dir_modify(const struct vol *vol, struct dir *dir,
             if (new_cnid == CNID_INVALID) {
                 if (dir == curdir) {
                     /* Do not remove curdir — callers rely on it being valid.
-                     * AD cache already invalidated (dcache_rlen = -1 above) */
+                     * AD cache already invalidated (AD_RLEN_UNKNOWN above) */
                     LOG(log_error, logtype_afpd,
                         "dir_modify: inode change on curdir! — no CNID for "
                         "new inode, keeping stale entry (did:%u, ino:%llu->%llu)",
@@ -1265,7 +1265,7 @@ int dir_modify(const struct vol *vol, struct dir *dir,
                         ntohl(new_cnid));
                 }
             }
-        } else if (ctime_changed && dir->dcache_rlen != (off_t) -1) {
+        } else if (ctime_changed && dir->dcache_rlen != AD_RLEN_UNKNOWN) {
             /* Free rfork buffer FIRST — rfork_cache_free() uses dcache_rlen for budget.
              * Setting rlen = -1 before freeing would corrupt rfork_cache_used tracking. */
             if (dir->dcache_rfork_buf) {
@@ -1275,7 +1275,8 @@ int dir_modify(const struct vol *vol, struct dir *dir,
 
             /* Ctime changed (same inode): metadata modified externally.
              * Invalidate AD cache — re-read from disk on next access.
-             * Covers dcache_rlen >= 0 (cached AD) and dcache_rlen == -2 (no AD)
+             * Covers dcache_rlen >= 0 (cached AD) and the negative
+             * sentinels (AD_RLEN_NO_AD, AD_RLEN_RFORK_ONLY).
              * When DCMOD_AD is also set, ad_store_to_cache() runs after
              * this section and re-populates dcache_rlen with caller data. */
             LOG(log_debug, logtype_afpd,
@@ -1283,7 +1284,7 @@ int dir_modify(const struct vol *vol, struct dir *dir,
                 "did:%u (ctime:%ld->%ld)",
                 ntohl(dir->d_did),
                 (long)dir->dcache_ctime, (long)args->st->st_ctime);
-            dir->dcache_rlen = (off_t) -1;
+            dir->dcache_rlen = AD_RLEN_UNKNOWN;
         }
 
         dir->dcache_ctime = args->st->st_ctime;
@@ -1346,7 +1347,7 @@ int dir_modify(const struct vol *vol, struct dir *dir,
             rfork_stat_invalidated++;
         }
 
-        dir->dcache_rlen = (off_t) -1;
+        dir->dcache_rlen = AD_RLEN_UNKNOWN;
         memset(dir->dcache_finderinfo, 0, 32);
         memset(dir->dcache_filedatesi, 0, 16);
         memset(dir->dcache_afpfilei, 0, 4);
@@ -3316,6 +3317,27 @@ int renamedir(struct vol *vol,
     }
 
     return AFP_OK;
+}
+
+const char *dir_event_path(char *buf, size_t buflen,
+                           const struct dir *parent,
+                           const char *name)
+{
+    if (parent == NULL || parent->d_fullpath == NULL) {
+        return fullpathname(name);
+    }
+
+    int len = snprintf(buf, buflen, "%s/%s",
+                       cfrombstr(parent->d_fullpath), name);
+
+    if (len < 0 || (size_t)len >= buflen) {
+        /* Never emit a clipped event path; the getcwd-based builder
+         * bounds against MAXPATHLEN, matching the kernel's own path
+         * limit. */
+        return fullpathname(name);
+    }
+
+    return buf;
 }
 
 /*! delete an empty directory */

--- a/etc/afpd/extattrs.c
+++ b/etc/afpd/extattrs.c
@@ -1,5 +1,6 @@
 /*
   Copyright (c) 2009 Frank Lahm <franklahm@gmail.com>
+  Copyright (c) 2026 Andy Lemin (andylemin)
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -148,14 +149,16 @@ int afp_listextattr(AFPObj *obj _U_, char *ibuf, size_t ibuflen _U_, char *rbuf,
 
     if (opened) {
         /* Fork-owned adouble — use directly, skip cache.
-         * Opportunistically populate cache if not yet loaded. */
+         * Opportunistically populate cache if not yet loaded.
+         * ad_meta_loaded(): a fork open without metadata leaves the
+         * adouble's header zeroed — storing it would flip a negative
+         * sentinel to a bogus positive entry. */
         ad_available = 1;
         size_t uname_len = strnlen(uname, CNID_MAX_PATH_LEN);
         struct dir *cached = dircache_search_by_name(vol, curdir,
                              uname, uname_len);
 
-        /* If cache AD is unset, store fork's live adouble */
-        if (cached && cached->dcache_rlen < 0) {
+        if (cached && cached->dcache_rlen < 0 && ad_meta_loaded(adp)) {
             ad_store_to_cache(adp, cached);
         }
     } else {

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1990,1993 Regents of The University of Michigan.
+ * Copyright (c) 2026 Andy Lemin (andylemin)
  * All Rights Reserved.  See COPYRIGHT.
  */
 
@@ -765,7 +766,15 @@ int getmetadata(const AFPObj *obj,
                     aint = htonl(adp->ad_rlen);
                 }
             } else {
-                rlen = ad_reso_size(path->u_name, 0, NULL);
+                /* Only NO_AD may answer rlen = 0 without a probe;
+                 * UNKNOWN and RFORK_ONLY keep the on-disk fallback. */
+                const struct dir *cachedfile = path_cached_file(path);
+
+                if (cachedfile && cachedfile->dcache_rlen == AD_RLEN_NO_AD) {
+                    rlen = 0;
+                } else {
+                    rlen = ad_reso_size(path->u_name, 0, NULL);
+                }
 
                 if (rlen > 0xffffffff) {
                     rlen = 0xffffffff;
@@ -848,7 +857,16 @@ int getmetadata(const AFPObj *obj,
                 memcpy(data, &aint, sizeof(aint));
                 data += sizeof(aint);
             } else {
-                int64_t rlen = hton64(ad_reso_size(path->u_name, 0, NULL));
+                const struct dir *cachedfile = path_cached_file(path);
+                off_t r;
+
+                if (cachedfile && cachedfile->dcache_rlen == AD_RLEN_NO_AD) {
+                    r = 0;
+                } else {
+                    r = ad_reso_size(path->u_name, 0, NULL);
+                }
+
+                int64_t rlen = hton64(r);
                 memcpy(data, &rlen, sizeof(rlen));
                 data += sizeof(rlen);
             }
@@ -945,11 +963,14 @@ int getfilparams(const AFPObj *obj, struct vol *vol, uint16_t bitmap,
 
         if (adp != &ad) {
             /* Fork-owned adouble — use directly, skip cache.
-             * Opportunistically populate cache if not yet loaded. */
+             * Opportunistically populate cache if not yet loaded.
+             * ad_meta_loaded(): a fork open without metadata leaves the
+             * adouble's header zeroed — storing it would flip a negative
+             * sentinel to a bogus positive entry. */
             struct dir *cachedfile = path_resolve_cached_file(vol, dir, path);
 
-            /* If cache AD is unset, store fork's live adouble */
-            if (cachedfile && cachedfile->dcache_rlen < 0) {
+            if (cachedfile && cachedfile->dcache_rlen < 0
+                    && ad_meta_loaded(adp)) {
                 ad_store_to_cache(adp, cachedfile);
             }
         } else {
@@ -1156,11 +1177,17 @@ createfile_iderr:
         }
     }
     ad_close(&ad, ADFLAGS_DF | ADFLAGS_HF);
+#if defined(WITH_FCE) || defined(WITH_SPOTLIGHT)
+    /* upath is a bare filename and curdir is its parent. */
+    char event_path[MAXPATHLEN + 1];
+    const char *created_path = dir_event_path(event_path, sizeof(event_path),
+                               curdir, upath);
+#endif
 #ifdef WITH_FCE
-    fce_register(obj, FCE_FILE_CREATE, fullpathname(upath), NULL);
+    fce_register(obj, FCE_FILE_CREATE, created_path, NULL);
 #endif /* WITH_FCE */
 #ifdef WITH_SPOTLIGHT
-    sl_index_event(obj, vol, SL_INDEX_FILE_CREATE, fullpathname(upath), NULL);
+    sl_index_event(obj, vol, SL_INDEX_FILE_CREATE, created_path, NULL);
 #endif /* WITH_SPOTLIGHT */
 
     /* Defensive check: curdir may be corrupted by race conditions or cname() failures */
@@ -1960,7 +1987,7 @@ int afp_copyfile(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
     } else if (!(ad_data_fileno(adp) >= 0 || ad_data_fileno(adp) == AD_SYMLINK)) {
         /* held with no usable data fd: copy_fork reads it, and a transient open
          * would strand the holder's locks - refuse.  Test the fd directly (like
-         * of_get_locks), not AD_DATA_OPEN: on EA the base fd is valid with
+         * of_get_locks), not ad_data_open(): on EA the base fd is valid with
          * ad_data_refcount == 0. */
         return AFPERR_DENYCONF;
     }
@@ -1980,7 +2007,7 @@ int afp_copyfile(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
             goto copy_exit;
         }
 
-        if (AD_RSRC_OPEN(adp) && fcntl(ad_reso_fileno(adp), F_SHARE, &shmd) != 0) {
+        if (ad_rsrc_open(adp) && fcntl(ad_reso_fileno(adp), F_SHARE, &shmd) != 0) {
             retvalue = AFPERR_DENYCONF;
             goto copy_exit;
         }
@@ -2060,12 +2087,10 @@ copy_exit:
 
     if (upath && err == AFP_OK) {
 #if defined(WITH_FCE) || defined(WITH_SPOTLIGHT)
-        /* upath is a bare filename and curdir is its parent (see the comment
-         * above mtoupath), so the absolute path comes from the cached
-         * d_fullpath — fullpathname()'s getcwd is not needed. */
-        char dstpath[MAXPATHLEN + 1];
-        snprintf(dstpath, sizeof(dstpath), "%s/%s",
-                 cfrombstr(curdir->d_fullpath), upath);
+        /* upath is a bare filename and curdir is its parent. */
+        char event_path[MAXPATHLEN + 1];
+        const char *dstpath = dir_event_path(event_path, sizeof(event_path),
+                                             curdir, upath);
 #endif
 #ifdef WITH_FCE
         fce_register(obj, FCE_FILE_CREATE, dstpath, NULL);
@@ -2127,7 +2152,7 @@ int copyfile(struct vol *s_vol,
         goto done;
     }
 
-    if (!AD_META_OPEN(adp)) {
+    if (!ad_meta_open(adp)) {
         adflags &= ~ADFLAGS_HF;
     }
 
@@ -2188,8 +2213,8 @@ int copyfile(struct vol *s_vol,
             strerror(errno));
     }
 
-    if (AD_META_OPEN(&add)) {
-        if (AD_META_OPEN(adp)) {
+    if (ad_meta_open(&add)) {
+        if (ad_meta_open(adp)) {
             ad_copy_header(&add, adp);
         }
 
@@ -2314,7 +2339,7 @@ int deletefile(const struct vol *vol, int dirfd, char *file, int checkAttrib)
                                   : of_findname(vol, &dpath);
         uint16_t      attr = 0;
 
-        if (ofm != NULL && AD_META_OPEN(ofm->of_ad)) {
+        if (ofm != NULL && ad_meta_open(ofm->of_ad)) {
             ad_getattr(ofm->of_ad, &attr);
         } else {
             /* No usable in-core header: read it privately.  ADFLAGS_CHECK_OF opens
@@ -3107,14 +3132,14 @@ int afp_exchangefiles(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
         goto err_temp_to_dest;
     }
 
-    if (AD_META_OPEN(adsp) || AD_META_OPEN(addp)) {
+    if (ad_meta_open(adsp) || ad_meta_open(addp)) {
         struct adouble adtmp;
         bool opened_ads = false;
         bool opened_add = false;
         ad_init(&adtmp, vol);
         ad_init_offsets(&adtmp);
 
-        if (!AD_META_OPEN(adsp)) {
+        if (!ad_meta_open(adsp)) {
             /* RDWR: this block rewrites the metadata header (ad_flush only
              * persists when the fd carries O_RDWR). */
             if (ad_open(adsp, p, ADFLAGS_HF | ADFLAGS_RDWR) != 0) {
@@ -3125,7 +3150,7 @@ int afp_exchangefiles(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
             opened_ads = true;
         }
 
-        if (!AD_META_OPEN(addp)) {
+        if (!ad_meta_open(addp)) {
             if (ad_open(addp, upath, ADFLAGS_HF | ADFLAGS_RDWR) != 0) {
                 err = AFPERR_MISC;
 

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1990,1993 Regents of The University of Michigan.
+ * Copyright (c) 2026 Andy Lemin (andylemin)
  * All Rights Reserved.  See COPYRIGHT.
  */
 
@@ -510,12 +511,17 @@ static int moveandrename(const AFPObj *obj,
                 /* Refresh failed, purged — NULL sdir to prevent use-after-free */
                 sdir = NULL;
             }
+#if defined(WITH_FCE) || defined(WITH_SPOTLIGHT)
+            char event_path[MAXPATHLEN + 1];
+            const char *dir_dst = dir_event_path(event_path,
+                                                 sizeof(event_path), curdir, upath);
+#endif
 #ifdef WITH_FCE
-            fce_register(obj, FCE_DIR_MOVE, fullpathname(upath), oldunixname);
+            fce_register(obj, FCE_DIR_MOVE, dir_dst, oldunixname);
 #endif /* WITH_FCE */
 #ifdef WITH_SPOTLIGHT
             sl_index_event(obj, vol, SL_INDEX_DIR_MOVE,
-                           fullpathname(upath), bdata(saved_sdir_fullpath));
+                           dir_dst, bdata(saved_sdir_fullpath));
 #endif /* WITH_SPOTLIGHT */
         }
 
@@ -532,31 +538,28 @@ static int moveandrename(const AFPObj *obj,
             /* Refresh failed, purged — NULL cachedfile */
             cachedfile = NULL;
         }
-#ifdef WITH_FCE
-
-        /* Send FCE event */
-        if (isdir) {
-            /* Dir FCE already sent above inside the isdir block */
-        } else {
-            bstring srcpath = bformat("%s/%s", bdata(saved_sdir_fullpath), oldunixname);
-            fce_register(obj, FCE_FILE_MOVE, fullpathname(upath), bdata(srcpath));
-            bdestroy(srcpath);
-        }
-
-#endif /* WITH_FCE */
-#ifdef WITH_SPOTLIGHT
+#if defined(WITH_FCE) || defined(WITH_SPOTLIGHT)
 
         if (!isdir) {
-            bstring srcpath = bformat("%s/%s", bdata(saved_sdir_fullpath), oldunixname);
+            char event_path[MAXPATHLEN + 1];
+            const char *file_dst = dir_event_path(event_path,
+                                                  sizeof(event_path), curdir, upath);
+            bstring srcpath = bformat("%s/%s", bdata(saved_sdir_fullpath),
+                                      oldunixname);
 
             if (srcpath != NULL) {
+#ifdef WITH_FCE
+                fce_register(obj, FCE_FILE_MOVE, file_dst, bdata(srcpath));
+#endif
+#ifdef WITH_SPOTLIGHT
                 sl_index_event(obj, vol, SL_INDEX_FILE_MOVE,
-                               fullpathname(upath), bdata(srcpath));
+                               file_dst, bdata(srcpath));
+#endif
                 bdestroy(srcpath);
             }
         }
 
-#endif /* WITH_SPOTLIGHT */
+#endif /* WITH_FCE || WITH_SPOTLIGHT */
 
         /* Fixup adouble info — separate ad_open for CNID write.
          * adflags includes ADFLAGS_DIR for directories (set at line 301). */
@@ -938,11 +941,16 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 
             /* Parent dir ctime changed */
             ipc_send_cache_hint(obj, vol->v_vid, curdir->d_did, CACHE_HINT_REFRESH);
+#if defined(WITH_FCE) || defined(WITH_SPOTLIGHT)
+            char event_path[MAXPATHLEN + 1];
+            const char *deleted_dir = dir_event_path(event_path,
+                                      sizeof(event_path), curdir, upath);
+#endif
 #ifdef WITH_FCE
-            fce_register(obj, FCE_DIR_DELETE, fullpathname(upath), NULL);
+            fce_register(obj, FCE_DIR_DELETE, deleted_dir, NULL);
 #endif /* WITH_FCE */
 #ifdef WITH_SPOTLIGHT
-            sl_index_event(obj, vol, SL_INDEX_DIR_DELETE, fullpathname(upath), NULL);
+            sl_index_event(obj, vol, SL_INDEX_DIR_DELETE, deleted_dir, NULL);
 #endif /* WITH_SPOTLIGHT */
         } else {
             /* we have to cache this, the structs are lost in deletcurdir*/
@@ -955,12 +963,20 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 
             /* deletecurdir() also handles CNID and dircache cleanup */
             if ((rc = deletecurdir(vol)) == AFP_OK) {
+#if defined(WITH_FCE) || defined(WITH_SPOTLIGHT)
+                /* deletecurdir() moved cwd to the parent: curdir is now
+                 * the deleted directory's parent. */
+                char event_path[MAXPATHLEN + 1];
+                const char *deleted_dir = dir_event_path(event_path,
+                                          sizeof(event_path), curdir,
+                                          cfrombstr(dname));
+#endif
 #ifdef WITH_FCE
-                fce_register(obj, FCE_DIR_DELETE, fullpathname(cfrombstr(dname)), NULL);
+                fce_register(obj, FCE_DIR_DELETE, deleted_dir, NULL);
 #endif /* WITH_FCE */
 #ifdef WITH_SPOTLIGHT
                 sl_index_event(obj, vol, SL_INDEX_DIR_DELETE,
-                               fullpathname(cfrombstr(dname)), NULL);
+                               deleted_dir, NULL);
 #endif /* WITH_SPOTLIGHT */
             }
 
@@ -1026,11 +1042,16 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
 
             /* deletefile() also handles CNID and dircache cleanup */
             if ((rc = deletefile(vol, -1, upath, 1)) == AFP_OK) {
+#if defined(WITH_FCE) || defined(WITH_SPOTLIGHT)
+                char event_path[MAXPATHLEN + 1];
+                const char *deleted_file = dir_event_path(event_path,
+                                           sizeof(event_path), curdir, upath);
+#endif
 #ifdef WITH_FCE
-                fce_register(obj, FCE_FILE_DELETE, fullpathname(upath), NULL);
+                fce_register(obj, FCE_FILE_DELETE, deleted_file, NULL);
 #endif /* WITH_FCE */
 #ifdef WITH_SPOTLIGHT
-                sl_index_event(obj, vol, SL_INDEX_FILE_DELETE, fullpathname(upath), NULL);
+                sl_index_event(obj, vol, SL_INDEX_FILE_DELETE, deleted_file, NULL);
 #endif /* WITH_SPOTLIGHT */
 
                 /* Send hints to afpd siblings — file deleted */

--- a/etc/afpd/fork.c
+++ b/etc/afpd/fork.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1990,1993 Regents of The University of Michigan.
  * Copyright (c) 2010      Frank Lahm
+ * Copyright (c) 2026 Andy Lemin (andylemin)
  *
  * All Rights Reserved.  See COPYRIGHT.
  */
@@ -175,7 +176,7 @@ static int getforkparams(const AFPObj *obj, struct ofork *ofork,
         return AFPERR_BITMAP;
     }
 
-    if (! AD_META_OPEN(ofork->of_ad)) {
+    if (! ad_meta_open(ofork->of_ad)) {
         adp = NULL;
     } else {
         adp = ofork->of_ad;
@@ -841,8 +842,8 @@ openfork_err:
      * from the second), in every failure combination, exactly once.  SETSHRMD
      * releases any share-mode locks ad_open_df() set; the AD_*_OPEN guard makes
      * a failure before the first open close nothing.  ret was set per case. */
-    if (AD_DATA_OPEN(ofork->of_ad) || AD_META_OPEN(ofork->of_ad)
-            || AD_RSRC_OPEN(ofork->of_ad)) {
+    if (ad_data_open(ofork->of_ad) || ad_meta_open(ofork->of_ad)
+            || ad_rsrc_open(ofork->of_ad)) {
         ad_close(ofork->of_ad,
                  (ADFLAGS_DF | ADFLAGS_RF | ADFLAGS_HF) | ADFLAGS_SETSHRMD);
     }
@@ -1541,7 +1542,7 @@ static int read_fork(AFPObj *obj, char *ibuf, size_t ibuflen _U_,
             rfork_cache_free(cached_entry);
             rfork_stat_invalidated++;
             rfork_stat_misses++;     /* Size mismatch counts as a miss */
-            cached_entry->dcache_rlen = (off_t) -1;
+            cached_entry->dcache_rlen = AD_RLEN_UNKNOWN;
             memset(cached_entry->dcache_finderinfo, 0, 32);
             memset(cached_entry->dcache_filedatesi, 0, 16);
             memset(cached_entry->dcache_afpfilei, 0, 4);
@@ -2196,7 +2197,7 @@ int afp_getforkparams(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf,
         return AFPERR_PARAM;
     }
 
-    if (AD_META_OPEN(ofork->of_ad)) {
+    if (ad_meta_open(ofork->of_ad)) {
         if (ad_refresh(NULL, ofork->of_ad) < 0) {
             LOG(log_error, logtype_afpd, "getforkparams(%s): ad_refresh: %s",
                 of_name(ofork), strerror(errno));

--- a/etc/afpd/ofork.c
+++ b/etc/afpd/ofork.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1996 Regents of The University of Michigan.
+ * Copyright (c) 2026 Andy Lemin (andylemin)
  * All Rights Reserved.  See COPYRIGHT.
  */
 
@@ -723,7 +724,7 @@ int of_get_locks(const struct vol *vol, int dirfd, struct path *path,
 
     /* --- rfork fd: separate inode; never opened onto of->of_ad --- */
     if (rf_get) {
-        if (of != NULL && AD_RSRC_OPEN(of->of_ad)) {
+        if (of != NULL && ad_rsrc_open(of->of_ad)) {
             radp = of->of_ad;            /* reuse held rfork, never close */
         } else if (of != NULL) {
             /* hold a fork but not the rfork.  On HAVE_EAFD && SOLARIS the rfork's
@@ -752,7 +753,7 @@ int of_get_locks(const struct vol *vol, int dirfd, struct path *path,
                  * open (the base fd may have, e.g. on Solaris). */
                 r_opened = 1;
 
-                if (AD_RSRC_OPEN(&adrf)) {
+                if (ad_rsrc_open(&adrf)) {
                     radp = &adrf;
                 }
             } else {
@@ -789,7 +790,7 @@ int of_get_locks(const struct vol *vol, int dirfd, struct path *path,
                  * the rfork actually opened. */
                 r_opened = 1;
 
-                if (AD_RSRC_OPEN(&adrf)) {
+                if (ad_rsrc_open(&adrf)) {
                     radp = &adrf;
                 }
             } else if (roerr == ENOENT) {
@@ -1019,14 +1020,14 @@ int of_closefork(const AFPObj *obj, struct ofork *ofork)
         fshare_t shmd;
         shmd.f_id = ofork->of_refnum;
 
-        if (AD_DATA_OPEN(ofork->of_ad)
+        if (ad_data_open(ofork->of_ad)
                 && fcntl(ad_data_fileno(ofork->of_ad), F_UNSHARE, &shmd) < 0) {
             LOG(log_warning, logtype_afpd,
                 "of_closefork: F_UNSHARE on data fork failed for refnum %"
                 PRIu16 ": %s", ofork->of_refnum, strerror(errno));
         }
 
-        if (AD_RSRC_OPEN(ofork->of_ad)
+        if (ad_rsrc_open(ofork->of_ad)
                 && fcntl(ad_reso_fileno(ofork->of_ad), F_UNSHARE, &shmd) < 0) {
             LOG(log_warning, logtype_afpd,
                 "of_closefork: F_UNSHARE on rsrc fork failed for refnum %"

--- a/include/atalk/adouble.h
+++ b/include/atalk/adouble.h
@@ -398,10 +398,33 @@ typedef enum {
 #define ad_reso_fileno(ad)  ((ad)->ad_rfp->adf_fd)
 #define ad_meta_fileno(ad)  ((ad)->ad_mdp->adf_fd)
 
-/* -1: not open, AD_SYMLINK (-2): it's a symlink */
-#define AD_DATA_OPEN(ad) (((ad)->ad_data_refcount) && (ad_data_fileno(ad) >= 0))
-#define AD_META_OPEN(ad) (((ad)->ad_meta_refcount) && (ad_meta_fileno(ad) >= 0))
-#define AD_RSRC_OPEN(ad) (((ad)->ad_reso_refcount) && (ad_reso_fileno(ad) >= 0))
+/* fd states: -1 = not open, AD_SYMLINK (-2) = it's a symlink */
+static inline int ad_data_open(const struct adouble *ad)
+{
+    return ad->ad_data_refcount && ad_data_fileno(ad) >= 0;
+}
+
+static inline int ad_meta_open(const struct adouble *ad)
+{
+    return ad->ad_meta_refcount && ad_meta_fileno(ad) >= 0;
+}
+
+static inline int ad_rsrc_open(const struct adouble *ad)
+{
+    return ad->ad_reso_refcount && ad_reso_fileno(ad) >= 0;
+}
+
+/*! Metadata header read into ad; unlike ad_meta_open(), true also for
+ * ea RDONLY opens, which read the EA by path and hold no fd. Symlinks
+ * short-circuit the metadata open with the refcount already taken and
+ * the header never read — both fds must be checked, as ea marks the
+ * meta fd and v2 the data fd. */
+static inline int ad_meta_loaded(const struct adouble *ad)
+{
+    return ad->ad_meta_refcount > 0
+           && ad_meta_fileno(ad) != AD_SYMLINK
+           && ad_data_fileno(ad) != AD_SYMLINK;
+}
 
 #define ad_getversion(ad)   ((ad)->ad_version)
 

--- a/include/atalk/directory.h
+++ b/include/atalk/directory.h
@@ -53,6 +53,20 @@
 #define DIRF_CNID	   (1<<5) /*!< renumerate id */
 #define DIRF_ARC_GHOST (1<<6) /*!< ARC ghost entry (in B1/B2) */
 
+/* dcache_rlen states. AD_RLEN_NO_RFORK is the floor of the positive
+ * range, not a sentinel: test >= 0 for "metadata cached". */
+#define AD_RLEN_NO_RFORK   ((off_t) 0)   /*!< AD metadata present, no rfork */
+#define AD_RLEN_UNKNOWN    ((off_t) -1)  /*!< not yet loaded */
+#define AD_RLEN_NO_AD      ((off_t) -2)  /*!< no AD metadata, no rfork */
+#define AD_RLEN_RFORK_ONLY ((off_t) -3)  /*!< no AD metadata; rfork present,
+                                          * size not cached */
+
+/*! AD metadata confirmed absent — ad_metadata() would fail ENOENT. */
+static inline int ad_rlen_meta_absent(off_t rlen)
+{
+    return rlen == AD_RLEN_NO_AD || rlen == AD_RLEN_RFORK_ONLY;
+}
+
 struct dir { // NOSONAR (max 20 fields) — fields are intentionally grouped for cache locality
     /* Fields requiring 8-byte alignment: pointers, time_t, ino_t, off_t */
     bstring     d_fullpath;          /*!< complete unix path to dir (or file) */
@@ -81,10 +95,9 @@ struct dir { // NOSONAR (max 20 fields) — fields are intentionally grouped for
                                       * used to detect changes in the dircache */
     time_t      dcache_mtime;        /*!< st_mtime: modification time */
     off_t       dcache_size;         /*!< st_size: file size (for FILPBIT_DFLEN) */
-    off_t       dcache_rlen;         /*!< Cached resource fork length.
-                                      * -1 = not yet loaded (triggers ad_metadata on first access),
-                                      * -2 = confirmed no AD exists (avoids repeated getxattr ENOENT),
-                                      * >= 0 = AD loaded and cached resource fork length value. */
+    /*! Cached resource fork length: >= 0 when AD metadata is cached,
+     * else one of the AD_RLEN_* sentinels above. */
+    off_t       dcache_rlen;
 
     /* Fields requiring 4-byte alignment: int, uint32_t, cnid_t, mode_t, uid_t, gid_t */
     int         d_flags;             /*!< directory flags */
@@ -147,6 +160,14 @@ static inline struct dir *path_cached_file(const struct path *path)
 
     return NULL;
 }
+
+/*! Absolute path of a child of parent for FCE/Spotlight event strings,
+ * built from the cached d_fullpath — no getcwd. Falls back to
+ * fullpathname() when the parent or its path is unavailable. Returns
+ * buf, or fullpathname()'s static buffer on the fallback path. */
+extern const char *dir_event_path(char *buf, size_t buflen,
+                                  const struct dir *parent,
+                                  const char *name);
 
 static inline int path_isadir(struct path *o_path)
 {

--- a/libatalk/adouble/ad_flush.c
+++ b/libatalk/adouble/ad_flush.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 1990,1991 Regents of The University of Michigan.
  * Copyright (c) 2010      Frank Lahm
+ * Copyright (c) 2026 Andy Lemin (andylemin)
  * All Rights Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and
@@ -306,7 +307,7 @@ static int ad_flush_hf(struct adouble *ad)
             break;
 
         case AD_VERSION_EA:
-            if (AD_META_OPEN(ad)) {
+            if (ad_meta_open(ad)) {
 #ifdef __APPLE__
                 char *FinderInfo;
                 char NativeFinderInfo[ADEDLEN_FINDERI] = {'\0'};
@@ -450,11 +451,11 @@ int ad_flush(struct adouble *ad)
     EC_INIT;
     LOG(log_debug, logtype_ad, "ad_flush(%s)", adflags2logstr(ad->ad_adflags));
 
-    if (AD_META_OPEN(ad)) {
+    if (ad_meta_open(ad)) {
         EC_ZERO(ad_flush_hf(ad));
     }
 
-    if (AD_RSRC_OPEN(ad)) {
+    if (ad_rsrc_open(ad)) {
         EC_ZERO(ad_flush_rf(ad));
     }
 

--- a/libatalk/adouble/ad_open.c
+++ b/libatalk/adouble/ad_open.c
@@ -2,6 +2,7 @@
  * Copyright (c) 1999 Adrian Sun (asun@u.washington.edu)
  * Copyright (c) 1990,1991 Regents of The University of Michigan.
  * Copyright (c) 2010 Frank Lahm
+ * Copyright (c) 2026 Andy Lemin (andylemin)
  *
  * All Rights Reserved.
  *
@@ -1657,11 +1658,11 @@ static int ad_open_rf_v2(const char *path, int adflags, int mode _U_,
      */
     LOG(log_debug, logtype_ad, "ad_open_rf_v2(\"%s\"): BEGIN", fullpathname(path));
 
-    if (!AD_META_OPEN(ad) && !(adflags & (ADFLAGS_NORF | ADFLAGS_RDONLY))) {
+    if (!ad_meta_open(ad) && !(adflags & (ADFLAGS_NORF | ADFLAGS_RDONLY))) {
         EC_FAIL;
     }
 
-    if (AD_META_OPEN(ad)) {
+    if (ad_meta_open(ad)) {
         ad->ad_reso_refcount++;
     }
 
@@ -2575,7 +2576,7 @@ int ad_refresh(const char *path, struct adouble *ad)
 
     case AD_VERSION_EA:
 #ifdef HAVE_EAFD
-        if (AD_META_OPEN(ad)) {
+        if (ad_meta_open(ad)) {
             if (ad_data_fileno(ad) == -1) {
                 return -1;
             }
@@ -2583,7 +2584,7 @@ int ad_refresh(const char *path, struct adouble *ad)
             /* TODO: read meta EA */
         }
 
-        if (AD_RSRC_OPEN(ad)) {
+        if (ad_rsrc_open(ad)) {
             if (ad_reso_fileno(ad) == -1) {
                 return -1;
             }
@@ -2599,7 +2600,7 @@ int ad_refresh(const char *path, struct adouble *ad)
 
 #else
 
-        if (AD_META_OPEN(ad)) {
+        if (ad_meta_open(ad)) {
             if (ad_data_fileno(ad) == -1) {
                 return -1;
             }
@@ -2607,7 +2608,7 @@ int ad_refresh(const char *path, struct adouble *ad)
             /* TODO: read meta EA */
         }
 
-        if (AD_RSRC_OPEN(ad)) {
+        if (ad_rsrc_open(ad)) {
             if (ad_reso_fileno(ad) == -1) {
                 return -1;
             }

--- a/libatalk/adouble/ad_read.c
+++ b/libatalk/adouble/ad_read.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 1990,1991 Regents of The University of Michigan.
+ * Copyright (c) 2026 Andy Lemin (andylemin)
  * All Rights Reserved.
  *
  * Permission to use, copy, modify, and distribute this software and
@@ -86,7 +87,7 @@ ssize_t ad_read(struct adouble *ad, const uint32_t eid, off_t off, char *buf,
             cc = adf_pread(&ad->ad_data_fork, buf, buflen, off);
         }
     } else {
-        if (! AD_RSRC_OPEN(ad))
+        if (! ad_rsrc_open(ad))
             /* resource fork is not open ( cf etc/afp/fork.c) */
         {
             return 0;

--- a/test/afpd/subtests.c
+++ b/test/afpd/subtests.c
@@ -1,5 +1,6 @@
 /*
   Copyright (c) 2010 Frank Lahm <franklahm@gmail.com>
+  Copyright (c) 2026 Andy Lemin (andylemin)
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -26,6 +27,7 @@
 #include <atalk/adouble.h>
 #include <atalk/cnid.h>
 #include <atalk/directory.h>
+#include <atalk/ea.h>
 #include <atalk/globals.h>
 #include <atalk/logger.h>
 #include <atalk/queue.h>
@@ -374,5 +376,143 @@ out:
     }
 
     dir_free_invalid_q();
+    return ret;
+}
+
+/* ea=sys can hold a resource fork with no metadata EA (Samba vfs_fruit,
+ * macOS-native writers). Such a file must mint AD_RLEN_RFORK_ONLY, not
+ * AD_RLEN_NO_AD, and its RFLEN must come from the on-disk fork. */
+int test006_rflen_rfork_without_metadata(struct vol *vol)
+{
+    static const char rdata[] = "t006-resource-fork-payload";
+    struct dir *root, *entry = NULL;
+    struct adouble ad;
+    struct path p;
+    struct stat st;
+    char fpath[MAXPATHLEN + 1], sidecar[MAXPATHLEN + 1];
+    char buf[4096];
+    size_t buflen = 0;
+    static char fname[] = "t006_file";
+    uint32_t rlen_wire;
+    int ret = -1;
+    int rc;
+    int cwd_fd = -1;
+
+    if ((root = dirlookup(vol, DIRDID_ROOT)) == NULL) {
+        return -1;
+    }
+
+    snprintf(fpath, sizeof(fpath), "%s/%s", vol->v_path, fname);
+    snprintf(sidecar, sizeof(sidecar), "%s/._%s", vol->v_path, fname);
+
+    /* getmetadata resolves u_name relative to cwd — afpd is always
+     * fchdir'd into curdir; mirror that for this volume's root */
+    if ((cwd_fd = open(".", O_RDONLY)) < 0 || chdir(vol->v_path) != 0) {
+        if (cwd_fd >= 0) {
+            close(cwd_fd);
+        }
+
+        return -1;
+    }
+
+    ad_init(&ad, vol);
+
+    if (ad_open(&ad, fpath,
+                ADFLAGS_DF | ADFLAGS_HF | ADFLAGS_RF | ADFLAGS_RDWR |
+                ADFLAGS_CREATE, 0600) != 0) {
+        goto out;
+    }
+
+    if (ad_write(&ad, ADEID_RFORK, 0, 0, rdata,
+                 sizeof(rdata)) != (ssize_t)sizeof(rdata)) {
+        ad_close(&ad, ADFLAGS_DF | ADFLAGS_HF | ADFLAGS_RF);
+        goto out;
+    }
+
+    ad_flush(&ad);
+    ad_close(&ad, ADFLAGS_DF | ADFLAGS_HF | ADFLAGS_RF);
+
+    /* Strip ONLY the metadata, as a foreign writer never creates it;
+     * the resource fork stays. Metadata not in an EA (no xattr support,
+     * or a v2 sidecar volume where metadata and rfork share the file):
+     * the mixed state cannot exist there — skip. */
+    if (sys_lremovexattr(fpath, AD_EA_META) != 0) {
+        ret = TEST_SKIP;
+        goto out;
+    }
+
+    if (stat(fpath, &st) != 0) {
+        goto out;
+    }
+
+    bstring fullpath = bfromcstr(fpath);
+
+    if (fullpath == NULL) {
+        goto out;
+    }
+
+    /* dir_new takes ownership of fullpath only on success */
+    entry = dir_new(fname, fname, vol, DIRDID_ROOT, htonl(30006),
+                    fullpath, &st);
+
+    if (entry == NULL) {
+        bdestroy(fullpath);
+        goto out;
+    }
+
+    if (dircache_add(vol, entry) != 0) {
+        dir_free(entry);
+        entry = NULL;
+        goto out;
+    }
+
+    /* One FPGetFileParms for RFLEN: the metadata read inside fails ENOENT
+     * (mint point), and the reply must still carry the on-disk fork size */
+    memset(&p, 0, sizeof(p));
+    p.u_name = fname;
+    p.m_name = fname;
+    p.st = st;
+    p.st_valid = 1;
+    rc = getfilparams(AFPobj, vol, 1 << FILPBIT_RFLEN, &p, root,
+                      buf, &buflen, 0);
+
+    if (rc != AFP_OK || buflen < sizeof(rlen_wire)) {
+        fprintf(stderr, "t006: getfilparams rc %d buflen %zu\n", rc, buflen);
+        goto out;
+    }
+
+    memcpy(&rlen_wire, buf, sizeof(rlen_wire));
+
+    if (ntohl(rlen_wire) != sizeof(rdata)) {
+        fprintf(stderr,
+                "t006: RFLEN %u, want %zu (rfork masked by negative AD cache)\n",
+                ntohl(rlen_wire), sizeof(rdata));
+        goto out;
+    }
+
+    /* NO_AD here would pin RFLEN at 0; UNKNOWN would re-read the
+     * metadata from disk on every access */
+    if (entry->dcache_rlen != AD_RLEN_RFORK_ONLY) {
+        fprintf(stderr, "t006: dcache_rlen %lld, want AD_RLEN_RFORK_ONLY\n",
+                (long long)entry->dcache_rlen);
+        goto out;
+    }
+
+    ret = 0;
+out:
+
+    if (entry) {
+        dir_remove(vol, entry, 0);
+    }
+
+    dir_free_invalid_q();
+    unlink(fpath);
+    unlink(sidecar);
+
+    if (fchdir(cwd_fd) != 0 && ret == 0) {
+        ret = -1;
+    }
+
+    close(cwd_fd);
     return ret;
 }

--- a/test/afpd/subtests.h
+++ b/test/afpd/subtests.h
@@ -43,4 +43,5 @@ extern int test002_rem_x_dirs(const struct vol *vol, cnid_t start, cnid_t end);
 extern int test003_dir_add_error_no_double_free(struct vol *vol);
 extern int test004_getmetadata_nostat_keeps_cache(struct vol *vol);
 extern int test005_getmetadata_open_fork_outlives_path(struct vol *vol);
+extern int test006_rflen_rfork_without_metadata(struct vol *vol);
 #endif  /* SUBTESTS_H */

--- a/test/afpd/subtests_lock.c
+++ b/test/afpd/subtests_lock.c
@@ -156,7 +156,7 @@ int utest_openfork_no_fd_leak(const struct vol *vol)
     }
 
     /* Run afp_openfork()'s error-path cleanup (close keyed on open-state). */
-    if (AD_DATA_OPEN(&ad) || AD_META_OPEN(&ad) || AD_RSRC_OPEN(&ad)) {
+    if (ad_data_open(&ad) || ad_meta_open(&ad) || ad_rsrc_open(&ad)) {
         ad_close(&ad, (ADFLAGS_DF | ADFLAGS_RF | ADFLAGS_HF) | ADFLAGS_SETSHRMD);
     }
 

--- a/test/afpd/test.c
+++ b/test/afpd/test.c
@@ -1,5 +1,6 @@
 /*
   Copyright (c) 2010 Frank Lahm <franklahm@gmail.com>
+  Copyright (c) 2026 Andy Lemin (andylemin)
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License as published by
@@ -593,6 +594,11 @@ int main(int argc, char *argv[])
      * and the dead path must not be minted into the dircache */
     TEST_int(test005_getmetadata_open_fork_outlives_path(vol), 0,
              "getmetadata: open fork identified via held fd when path is gone");
+    /* ea=sys can hold a resource fork with no metadata EA (foreign
+     * writers); the negative AD cache must not mask its length */
+    TEST_int_or_skip(volsys ? test006_rflen_rfork_without_metadata(volsys)
+                     : TEST_SKIP, 0,
+                     "getmetadata: rfork without metadata EA reports real RFLEN");
     /* pfd cache: strict ostat equivalence (quiescent), and the
      * divergence window — probe bound + three-way sync-check no-thrash */
     TEST_int(test_pfd_ostat_equivalence(vol), 0,

--- a/test/testsuite/lantest.c
+++ b/test/testsuite/lantest.c
@@ -1446,45 +1446,62 @@ void run_test(const int32_t dir)
 
     /* -------- */
     if (teststorun[TEST_ENUM2000FILES]) {
+        /* Finder browses with FPEnumerateExt2 (AFP 3.1+): UTF-8 names
+         * (PDINFO), 64-bit fork lengths (EXTDFLEN/EXTRFLEN), and UNIX
+         * privileges — EXTRFLEN on every file entry is what drives the
+         * per-entry rfork path in getmetadata. The server registers the
+         * verb from 3.1; pre-3.1 sessions keep the legacy enumerate. */
+        const bool use_ext2 = Version >= 31;
+        const uint16_t finder_f_bitmap = use_ext2 ?
+                                         (1 << FILPBIT_ATTR) | (1 << FILPBIT_PDID) | (1 << FILPBIT_CDATE) |
+                                         (1 << FILPBIT_MDATE) | (1 << FILPBIT_BDATE) | (1 << FILPBIT_FINFO) |
+                                         (1 << FILPBIT_FNUM) | (1 << FILPBIT_EXTDFLEN) | (1 << FILPBIT_PDINFO) |
+                                         (1 << FILPBIT_EXTRFLEN) | (1 << FILPBIT_UNIXPR)
+                                         :
+                                         (1 << FILPBIT_ATTR) | (1 << FILPBIT_PDID) | (1 << FILPBIT_CDATE) |
+                                         (1 << FILPBIT_MDATE) | (1 << FILPBIT_BDATE) | (1 << FILPBIT_FINFO) |
+                                         (1 << FILPBIT_FNUM) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_LNAME) |
+                                         (1 << FILPBIT_RFLEN);
+        const uint16_t finder_d_bitmap = use_ext2 ?
+                                         (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_CDATE) |
+                                         (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_FINFO) |
+                                         (1 << DIRPBIT_DID) | (1 << DIRPBIT_OFFCNT) | (1 << DIRPBIT_ACCESS) |
+                                         (1 << DIRPBIT_PDINFO) | (1 << DIRPBIT_UNIXPR)
+                                         :
+                                         (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_CDATE) |
+                                         (1 << DIRPBIT_MDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_FINFO) |
+                                         (1 << DIRPBIT_DID) | (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_ACCESS);
 #ifdef __linux__
         capture_io_values(TEST_START);
 #endif
         starttimer();
 
-        if (FPEnumerateFull(Conn, vol, 1, 40, DSI_DATASIZ, dir, "",
-                            (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
-                            (1 << FILPBIT_FINFO) | (1 << FILPBIT_CDATE) | (1 << FILPBIT_BDATE) |
-                            (1 << FILPBIT_MDATE) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
-                            ,
-                            (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
-                            (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
-                            (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-                            (1 << DIRPBIT_ACCESS))) {
+        if (use_ext2
+                ? FPEnumerateExt2Full(Conn, vol, dir, "",
+                                      finder_f_bitmap, finder_d_bitmap, 1, 40)
+                : FPEnumerateFull(Conn, vol, 1, 40, DSI_DATASIZ, dir, "",
+                                  finder_f_bitmap, finder_d_bitmap)) {
             clean_exit(ERROR_NETWORK_PROTOCOL);
         }
 
         for (int32_t i = 41; (i + 40) < create_enum_files; i += 80) {
-            if (FPEnumerateFull(Conn, vol, (uint16_t)(i + 40), 40, DSI_DATASIZ, dir, "",
-                                (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
-                                (1 << FILPBIT_FINFO) | (1 << FILPBIT_CDATE) | (1 << FILPBIT_BDATE) |
-                                (1 << FILPBIT_MDATE) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
-                                ,
-                                (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
-                                (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
-                                (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-                                (1 << DIRPBIT_ACCESS))) {
+            if (use_ext2
+                    ? FPEnumerateExt2Full(Conn, vol, dir, "",
+                                          finder_f_bitmap, finder_d_bitmap,
+                                          (uint32_t)(i + 40), 40)
+                    : FPEnumerateFull(Conn, vol, (uint16_t)(i + 40), 40,
+                                      DSI_DATASIZ, dir, "",
+                                      finder_f_bitmap, finder_d_bitmap)) {
                 clean_exit(ERROR_NETWORK_PROTOCOL);
             }
 
-            if (FPEnumerateFull(Conn, vol, (uint16_t)i, 40, DSI_DATASIZ, dir, "",
-                                (1 << FILPBIT_LNAME) | (1 << FILPBIT_FNUM) | (1 << FILPBIT_ATTR) |
-                                (1 << FILPBIT_FINFO) | (1 << FILPBIT_CDATE) | (1 << FILPBIT_BDATE) |
-                                (1 << FILPBIT_MDATE) | (1 << FILPBIT_DFLEN) | (1 << FILPBIT_RFLEN)
-                                ,
-                                (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_ATTR) | (1 << DIRPBIT_FINFO) |
-                                (1 << DIRPBIT_CDATE) | (1 << DIRPBIT_BDATE) | (1 << DIRPBIT_MDATE) |
-                                (1 << DIRPBIT_LNAME) | (1 << DIRPBIT_PDID) | (1 << DIRPBIT_DID) |
-                                (1 << DIRPBIT_ACCESS))) {
+            if (use_ext2
+                    ? FPEnumerateExt2Full(Conn, vol, dir, "",
+                                          finder_f_bitmap, finder_d_bitmap,
+                                          (uint32_t)i, 40)
+                    : FPEnumerateFull(Conn, vol, (uint16_t)i, 40,
+                                      DSI_DATASIZ, dir, "",
+                                      finder_f_bitmap, finder_d_bitmap)) {
                 clean_exit(ERROR_NETWORK_PROTOCOL);
             }
         }


### PR DESCRIPTION
Two syscall eliminations on the metadata hot paths, each verified with A/B strace against an unmodified build on identical container workloads.

## Wiring up the negative side of the AD cache

The dircache's Tier 1 AD metadata cache and Tier 2 rfork data cache were built to serve *positive* answers: metadata fields and fork bytes we know exist. This PR wires up the negative signals — when we know there is *nothing* to cache, that confirmed absence is itself the cached answer, and serving it must cost zero filesystem contact.

`dcache_rlen` now carries the full state contract as named defines:

| state | value | metadata | rfork | what the cache answers |
|---|---|---|---|---|
| `AD_RLEN_NO_RFORK` | `0` | cached | absent | everything: Tier 1 fields, RFLEN 0 |
| fork length | `> 0` | cached | present | everything; Tier 2 eligible |
| `AD_RLEN_UNKNOWN` | `-1` | unknown | unknown | nothing: disk read on next access |
| `AD_RLEN_NO_AD` | `-2` | absent | absent | metadata ENOENT **and** RFLEN 0 |
| `AD_RLEN_RFORK_ONLY` | `-3` | absent | present | metadata ENOENT; fork size stays on-disk truth |

`AD_RLEN_NO_RFORK` is the floor of the positive range, not a sentinel — consumers test `>= 0` for "metadata cached". Only `NO_AD` authorizes the zero-contact RFLEN answer; `RFORK_ONLY` exists because with `ea = sys` the metadata and the resource fork are separate EAs, so files written by Samba's vfs_fruit or macOS-native tools carry a fork with no netatalk metadata — collapsing that state into either neighbour would each be wrong (`NO_AD` would pin their RFLEN at 0; `UNKNOWN` would re-read disk on every access).

**Minting.** The negative states are minted at the single point where the metadata read fails ENOENT: one `ad_reso_size()` probe classifies the miss — once **per ctime change**, never per read. `ad_reso_size()` returns 0 for *any* failure, so the probe's errno must corroborate absence before `NO_AD` is recorded; a transient error (EIO etc.) leaves `UNKNOWN` and retries next access rather than caching a false absence. Directories mint `NO_AD` unconditionally.

**Consuming.** All negative-state interpretation lives at one choke point (`ad_metadata_cached()`, where both `NO_AD` and `RFORK_ONLY` serve the metadata ENOENT from cache) plus the RFLEN/EXTRFLEN fast paths (which act only on `NO_AD`). `ad_getcomment()` previously bypassed the cache with a raw `ad_metadata()` call and now honours the same contract: a ctime/inode-validated entry with no metadata answers "no comment" without touching disk, skipped when an open fork may have just created metadata. Invalidation needs no new wiring — every existing reset path already writes `UNKNOWN`, which covers all sentinels.

**Guarding the positive side.** The opportunistic stores on the fork-owned adouble paths are gated on a new `ad_meta_loaded()` predicate: a fork opened on a file without metadata carries a zeroed header, and storing it would flip a negative sentinel into a positive entry serving zeroed FinderInfo (bypassing the extension-derived type/creator fallback). An fd-based open test is the wrong gate here — ea RDONLY metadata opens read the EA by path and hold no fd, so it would reject valid metadata on the common enumerate-with-open-fork path. Symlinks need explicit exclusion: both `ad_open_hf` backends short-circuit with the meta refcount already taken and no header read, so the predicate also rejects `AD_SYMLINK` on either fd (ea marks the meta fd, v2 the data fd). Alongside it, the `AD_DATA_OPEN`/`AD_META_OPEN`/`AD_RSRC_OPEN` predicate macros become static inline functions (`ad_data_open()`, `ad_meta_open()`, `ad_rsrc_open()`): type-checked, side-effect safe, and consistent with the new helper. The `ad_*_fileno` accessors stay macros — they are assigned to as lvalues.

**Coverage.** A unit test writes a resource fork, strips only the metadata EA (the foreign-writer state), and asserts both the reported RFLEN and the minted state — `RFORK_ONLY`, not `NO_AD`, not `UNKNOWN`.

## The rfork probe that survived every cache

`getmetadata()`'s RFLEN/EXTRFLEN branches fall back to `ad_reso_size()` — a sidecar stat (ea=ad) or rfork-EA probe (ea=sys) — whenever no adouble handle is present. But that no-handle case is routinely the negative-cached answer, and the correct reply is 0 with no filesystem contact.

This sits inside the per-entry reply loop of directory enumeration — the hottest workload a file server has. macOS Finder requests EXTRFLEN for every entry of every enumeration batch, nearly all files are fork-less, and the probe survives a fully warm cache: N syscalls per batch, per browse, forever, on all deployments. The fix consults the request's already-resolved dircache entry (threaded via `path->d_cached`, guarded by the `path_cached_file()` staleness accessor) and answers 0 when `NO_AD` is authoritative. `UNKNOWN`, `RFORK_ONLY`, and genuinely uncached files keep the on-disk probe; open-fork callers are untouched.

### Aligning lantest with Finder's request shape

The lantest Enumerate test did not reproduce this cost: it spoke AFP 2 — `FPEnumerate` with `LNAME` and 32-bit `DFLEN`/`RFLEN` — a request shape no modern client sends, which is precisely how this overhead stayed hidden from the dashboard while every real Finder browse paid it. The test now issues `FPEnumerateExt2` with Finder's bitmap (`PDINFO`, `EXTDFLEN`, `EXTRFLEN`, `UNIXPR`), the same request macOS sends per enumeration batch. The server registers that verb from AFP 3.1, so the supported `-3` (AFP 3.0) run keeps the legacy enumerate with the closest 3.0 bitmap. Batch size, interleave pattern, and op count are unchanged on both paths.

Two caveats on what the dashboard will show. The Enumerate metric's 9-PR history predates the verb change, so its first run breaks comparability — the median-shift baseline absorbs the common-mode part, but read that row's first delta as the test changing, not the code. And lantest creates its files through AFP, so every entry carries AD metadata and enumerate exercises the warm positive cache; the negative-cache win applies to foreign files (rsync'd trees, SMB-written shares) that a pure AFP client cannot create. The A/B evidence below therefore uses a Finder-shaped workload against fork-less files (afparg FPEnumerate with Finder's file bitmap, cache-hot, 500 fork-less files):

| cache-hot enumerate, 500 fork-less files | before | after | reduction |
|---|---|---|---|
| per-entry sidecar/AD probes | 1005 (~2/entry) | 500 (~1/entry) | **50%** |
| stat-family syscalls total | 2040 | 1535 | **25%** |

The remaining ~1 probe per entry comes from the FPGetFileDirParms path each entry also receives in this workload — a separate lookup shape in the FPGetFileDirParms pipeline, not the enumeration reply loop this PR targets.

## getcwd before the FCE/Spotlight gate

C evaluates arguments before the call, so every `fce_register(..., fullpathname(upath), ...)` site paid a getcwd() syscall per create/rename/delete even with FCE unconfigured and Spotlight off — the no-listener early exits live inside the callees. The parent directory's absolute path is already cached in the dircache entry: a shared `dir_event_path()` helper builds the event path from `d_fullpath` (getcwd-free) and falls back to `fullpathname()` when no entry is available. The FPCopyFile site already open-coded this pattern and is converted to the helper; the file-move FCE and Spotlight blocks, which each built the same source path independently, are combined into one.

Merging those file-move blocks also fixes their divergent NULL handling: on `bformat()` failure the FCE arm previously sent a MOVE event with a NULL source path while the Spotlight arm skipped — both now skip, never emitting a half-formed event.

`dir_event_path()` never emits a clipped event string: on snprintf truncation it falls back to `fullpathname()`, whose MAXPATHLEN bound matches the kernel's own path limit.

Sites deliberately not changed: `fullpathname()` inside `LOG(...)` argument lists — the LOG macro's level check gates evaluation lazily.

| create+delete of 2000 files | before | after |
|---|---|---|
| getcwd | 14013 | 6011 |

The remainder is `ochdir()`'s symlink-escape verification, which is load-bearing and stays.

Path equivalence is by construction — `v_path` is canonicalized with `realpath()` at volume creation, so `d_fullpath` is rooted at the same physical path getcwd reports — and proven empirically: an `fce_listen` capture of 54 move/delete events across the FPMoveAndRename and FPDelete spectest suites is byte-identical before and after, including the post-`deletecurdir` parent-path case.

## Testing

- Both spectest legs green (ea=sys 350/0, ea=ad 354/0)
- afpd unit suite green (76 ok), including the new fork-without-metadata state test
- FCE event-path correctness proven by listener capture equality (spectests don't assert FCE payloads)
- No wall-clock claims: these are syscall eliminations whose effect scales with syscall cost (containers, security modules, NFS-backed volumes)




