### PR TITLE
ci: sqlite CNID on tmpfs for perf jobs; faster mysql CNID backend

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -304,6 +304,8 @@ jobs:
               -e AFP_DIRCACHE_VALIDATION_FREQ=100 \
               -e AFP_DIRCACHE_RFORK_BUDGET=102400 \
               -e AFP_DIRCACHE_RFORK_MAXSIZE=1024 \
+              -e AFP_CNID_BACKEND=sqlite \
+              -e AFP_CNID_TMPFS=1 \
               -e TESTSUITE=spectest \
               -e AFP_VERSION=7 \
               -e FLAMEGRAPH=1 \
@@ -1248,6 +1250,7 @@ jobs:
       AFP_VERSION: 7
       AFP_VERSION_LABEL: "3.4"
       AFP_CNID_BACKEND: sqlite
+      AFP_CNID_LABEL: sqlite+tmpfs
       AFP_DIRCACHE_MODE: arc
       AFP_DIRCACHESIZE: 65536
       AFP_DIRCACHE_VALIDATION_FREQ: 100
@@ -1263,7 +1266,9 @@ jobs:
         run: |
           # -c (CSV) is passed via $TEST_FLAGS, which the entrypoint prepends
           # to afp_lantest.
-          docker run --rm \
+          # --privileged: AFP_CNID_TMPFS mounts a tmpfs over the CNID state
+          # dir so timings measure afpd, not the runner's fsync latency.
+          docker run --privileged --rm \
             -e AFP_USER="atalk1" \
             -e AFP_PASS="$CONT_PASSWD" \
             -e AFP_GROUP="afpusers" \
@@ -1272,6 +1277,7 @@ jobs:
             -e TESTSUITE="lan" \
             -e AFP_VERSION="${{ env.AFP_VERSION }}" \
             -e AFP_CNID_BACKEND="${{ env.AFP_CNID_BACKEND }}" \
+            -e AFP_CNID_TMPFS=1 \
             -e AFP_DIRCACHE_MODE="${{ env.AFP_DIRCACHE_MODE }}" \
             -e AFP_DIRCACHESIZE="${{ env.AFP_DIRCACHESIZE }}" \
             -e AFP_DIRCACHE_VALIDATION_FREQ="${{ env.AFP_DIRCACHE_VALIDATION_FREQ }}" \
@@ -1340,6 +1346,7 @@ jobs:
             --title "Netatalk AFP Lantest — per-test latency" \
             --subtitle "commit ${SHORT_SHA} · candle: min–max wick, mean±σ box, median line" \
             --meta afp=${{ env.AFP_VERSION_LABEL }} \
+            --meta cnid=${{ env.AFP_CNID_LABEL }} \
             --meta iterations=${{ env.AFP_TEST_ITERATIONS }} \
             --meta quantum_kb=$(( ${{ env.AFP_SERVER_QUANTUM }} / 1024 )) \
             --meta dircache_mode=${{ env.AFP_DIRCACHE_MODE }} \
@@ -1424,6 +1431,7 @@ jobs:
       AFP_VERSION: 7
       AFP_VERSION_LABEL: "3.4"
       AFP_CNID_BACKEND: sqlite
+      AFP_CNID_LABEL: sqlite+tmpfs
       AFP_DIRCACHE_MODE: arc
       AFP_DIRCACHESIZE: 65536
       AFP_DIRCACHE_VALIDATION_FREQ: 100
@@ -1439,7 +1447,9 @@ jobs:
         run: |
           # -c (CSV) and -z (size sweep) are passed via $TEST_FLAGS, which the
           # entrypoint prepends to afp_speedtest.
-          docker run --rm \
+          # --privileged: AFP_CNID_TMPFS mounts a tmpfs over the CNID state
+          # dir so timings measure afpd, not the runner's fsync latency.
+          docker run --privileged --rm \
             -e AFP_USER="atalk1" \
             -e AFP_PASS="$CONT_PASSWD" \
             -e AFP_GROUP="afpusers" \
@@ -1448,6 +1458,7 @@ jobs:
             -e TESTSUITE="speed" \
             -e AFP_VERSION="${{ env.AFP_VERSION }}" \
             -e AFP_CNID_BACKEND="${{ env.AFP_CNID_BACKEND }}" \
+            -e AFP_CNID_TMPFS=1 \
             -e AFP_DIRCACHE_MODE="${{ env.AFP_DIRCACHE_MODE }}" \
             -e AFP_DIRCACHESIZE="${{ env.AFP_DIRCACHESIZE }}" \
             -e AFP_DIRCACHE_VALIDATION_FREQ="${{ env.AFP_DIRCACHE_VALIDATION_FREQ }}" \
@@ -1487,6 +1498,7 @@ jobs:
             --title "Netatalk AFP Speedtest — throughput vs file size" \
             --subtitle "commit ${SHORT_SHA} · mean MB/s, shaded band = min–max" \
             --meta afp=${{ env.AFP_VERSION_LABEL }} \
+            --meta cnid=${{ env.AFP_CNID_LABEL }} \
             --meta iterations=${{ env.AFP_TEST_ITERATIONS }} \
             --meta quantum_kb=$(( ${{ env.AFP_SERVER_QUANTUM }} / 1024 )) \
             --meta dircache_mode=${{ env.AFP_DIRCACHE_MODE }} \

--- a/contrib/scripts/plot_lantest.pl
+++ b/contrib/scripts/plot_lantest.pl
@@ -141,6 +141,7 @@ sub build_info_lines {
     $total_mean += $_->{mean} for @$tests;
     push @lines, sprintf('Avg total runtime: %.0f ms', $total_mean);
     push @lines, "AFP: $meta->{afp}"               if $meta->{afp};
+    push @lines, "CNID: $meta->{cnid}"             if $meta->{cnid};
     push @lines, "Quantum: $meta->{quantum_kb} KB" if $meta->{quantum_kb};
     my @dc;
     push @dc, uc $meta->{dircache_mode}     if $meta->{dircache_mode};

--- a/contrib/scripts/plot_speedtest.pl
+++ b/contrib/scripts/plot_speedtest.pl
@@ -169,6 +169,7 @@ sub build_info_lines {
     }
     push @lines, 'Ops: ' . join(', ', @ops);
     push @lines, "AFP: $meta->{afp}"                if $meta->{afp};
+    push @lines, "CNID: $meta->{cnid}"              if $meta->{cnid};
     push @lines, "Quantum: $meta->{quantum_kb} KiB" if $meta->{quantum_kb};
     my @dc;
     push @dc, uc $meta->{dircache_mode}     if $meta->{dircache_mode};

--- a/distrib/docker/env_setup_netatalk.sh
+++ b/distrib/docker/env_setup_netatalk.sh
@@ -25,6 +25,7 @@
 #   - Lock file cleanup
 #   - Netatalk configuration variable preparation
 #   - MySQL / MariaDB CNID backend bootstrap
+#   - CNID store tmpfs mount for benchmarking (AFP_CNID_TMPFS)
 #   - afp.conf generation (unless MANUAL_CONFIG is set)
 #   - extmap.conf activation
 #   - AppleTalk (DDP) service startup
@@ -497,11 +498,18 @@ if [ "$AFP_CNID_BACKEND" = "mysql" ]; then
             echo "*** Initializing MariaDB data directory"
             mysql_install_db --user=mysql --datadir=/var/lib/mysql > /dev/null 2>&1
         fi
-        # Configure MariaDB to listen on TCP 127.0.0.1 in addition to Unix socket
+        # Listen on TCP 127.0.0.1 in addition to the Unix socket. The tuning
+        # below preserves durability: every commit still reaches the disk.
         cat > /etc/my.cnf.d/netatalk.cnf << 'MYCNF'
 [mysqld]
 bind-address = 127.0.0.1
 skip-networking = 0
+skip-name-resolve
+innodb_flush_method = O_DIRECT
+innodb_flush_neighbors = 0
+innodb_buffer_pool_size = 512M
+innodb_log_buffer_size = 64M
+innodb_log_file_size = 512M
 MYCNF
         # Start MariaDB with TCP enabled
         mariadbd-safe --user=mysql &
@@ -529,6 +537,37 @@ CREATE USER IF NOT EXISTS '$AFP_CNID_SQL_USER_SQL'@'127.0.0.1' IDENTIFIED BY '$A
 GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, ALTER ON \`$AFP_CNID_SQL_DB_SQL\`.* TO '$AFP_CNID_SQL_USER_SQL'@'127.0.0.1';
 FLUSH PRIVILEGES;
 EOSQL
+    fi
+fi
+
+# --------------------------------------------------------------------------
+# CNID store on tmpfs (benchmarking)
+# --------------------------------------------------------------------------
+
+# AFP_CNID_TMPFS: mount a tmpfs over the CNID state directory so
+# benchmarks measure the AFP server rather than storage sync latency.
+# Benchmarking only — the CNID database is lost when the container stops.
+# Requires --privileged (or CAP_SYS_ADMIN); fails hard rather than
+# silently falling back to disk. The state directory is compiled into
+# afpd and varies by build prefix, so query the binary rather than
+# assume a path; NETATALK_STATEDIR overrides.
+if [ -n "$AFP_CNID_TMPFS" ]; then
+    if [ -z "$NETATALK_STATEDIR" ]; then
+        NETATALK_STATEDIR=$(afpd -V 2> /dev/null \
+            | sed -n 's/^ *state directory:[[:space:]]*//p' | sed 's:/$::')
+    fi
+    if [ -z "$NETATALK_STATEDIR" ]; then
+        echo "ERROR: AFP_CNID_TMPFS is set but the state directory could not" \
+            "be determined from 'afpd -V'; set NETATALK_STATEDIR" >&2
+        exit 1
+    fi
+    mkdir -p "$NETATALK_STATEDIR/CNID"
+    if mount -t tmpfs -o mode=1777 tmpfs "$NETATALK_STATEDIR/CNID"; then
+        echo "*** Mounted tmpfs on $NETATALK_STATEDIR/CNID for CNID storage"
+    else
+        echo "ERROR: AFP_CNID_TMPFS is set but the tmpfs mount failed;" \
+            "the container must run with --privileged" >&2
+        exit 1
     fi
 fi
 

--- a/etc/afpd/file.c
+++ b/etc/afpd/file.c
@@ -1795,7 +1795,7 @@ int renamefile(struct vol *vol, struct dir *ddir, int sdir_fd, char *src,
                 return rc;
             }
 
-            return deletefile(vol, sdir_fd, src, 0);
+            return deletefile(vol, sdir_fd, src, 0, NULL);
 
         default :
             return AFPERR_PARAM;
@@ -2179,7 +2179,7 @@ int copyfile(struct vol *s_vol,
              * non-EEXIST reason, or dst appeared via a race), so the conflict
              * check governs the cleanup unlink: if it reports the object as
              * held or unreadable, do not remove it — log and leave it. */
-            int dret = deletefile(d_vol, -1, dst, 0);
+            int dret = deletefile(d_vol, -1, dst, 0, NULL);
 
             if (dret != AFP_OK && dret != AFPERR_NOOBJ) {
                 LOG(log_error, logtype_afpd,
@@ -2253,7 +2253,7 @@ error:
          * above succeeded, so nothing pre-existed).  Log if the conflict check
          * refuses (e.g. a peer raced an open on it), so a stranded temp file is
          * diagnosable rather than silent. */
-        int dret = deletefile(d_vol, -1, dst, 0);
+        int dret = deletefile(d_vol, -1, dst, 0, NULL);
 
         if (dret != AFP_OK && dret != AFPERR_NOOBJ) {
             LOG(log_error, logtype_afpd,
@@ -2299,6 +2299,10 @@ done:
 /* -----------------------------------
    vol: not NULL delete cnid entry. then we are in curdir and file is a only filename
    checkAttrib:   1 check kFPDeleteInhibitBit (deletefile called by afp_delete)
+   idp:           in: caller-resolved CNID (must come from an inode-validated
+                  dircache entry) or CNID_INVALID to resolve here after the
+                  unlink; out: the CNID that was deleted. NULL when the caller
+                  has neither.
 
    NODELETE check -> one conflict GET -> policy -> unlink -> CNID/dircache
    cleanup (afp_delete only).
@@ -2311,7 +2315,8 @@ done:
 /*!
  * @note dirfd can be used for unlinkat semantics
  */
-int deletefile(const struct vol *vol, int dirfd, char *file, int checkAttrib)
+int deletefile(const struct vol *vol, int dirfd, char *file, int checkAttrib,
+               cnid_t *idp)
 {
     struct path  dpath = {0};
     int          df_locked = 0, rf_locked = 0;
@@ -2424,16 +2429,23 @@ int deletefile(const struct vol *vol, int dirfd, char *file, int checkAttrib)
     if (!(err = vol->vfs->vfs_deletefile(vol, dirfd, file))
             && !(err = netatalk_unlinkat(dirfd, file))
             && checkAttrib) {
-        cnid_t      id;
         struct dir *cachedfile;
-        AFP_CNID_START("cnid_get");
-        id = cnid_get(vol->v_cdb, curdir->d_did, file, strlen(file));
-        AFP_CNID_DONE();
+        cnid_t      id = idp ? *idp : CNID_INVALID;
+
+        if (id == CNID_INVALID) {
+            AFP_CNID_START("cnid_get");
+            id = cnid_get(vol->v_cdb, curdir->d_did, file, strlen(file));
+            AFP_CNID_DONE();
+        }
 
         if (id) {
             AFP_CNID_START("cnid_delete");
             cnid_delete(vol->v_cdb, id);
             AFP_CNID_DONE();
+        }
+
+        if (idp) {
+            *idp = id;
         }
 
         AFP_ASSERT(file != NULL);

--- a/etc/afpd/file.h
+++ b/etc/afpd/file.h
@@ -178,7 +178,7 @@ extern int renamefile(struct vol *, struct dir *, int, char *, char *, char *,
                       struct adouble *);
 extern int copyfile(struct vol *, struct vol *, struct dir *, int, char *,
                     char *, char *, struct adouble *, int);
-extern int deletefile(const struct vol *, int, char *, int);
+extern int deletefile(const struct vol *, int, char *, int, cnid_t *);
 
 extern int getmetadata(const AFPObj *obj, struct vol *vol, uint16_t bitmap,
                        struct path *path,

--- a/etc/afpd/filedir.c
+++ b/etc/afpd/filedir.c
@@ -1029,19 +1029,14 @@ int afp_delete(AFPObj *obj, char *ibuf, size_t ibuflen _U_, char *rbuf _U_,
                 return AFPERR_NOOBJ;
             }
 
-            /* Pre-resolve CNID BEFORE deletefile() — it calls cnid_delete()
-             * which removes the CNID from the database */
-            cnid_t file_cnid = CNID_INVALID;
-
-            if (cachedfile) {
-                file_cnid = cachedfile->d_did;
-            } else if (upath) {
-                size_t ulen = strnlen(upath, CNID_MAX_PATH_LEN);
-                file_cnid = cnid_get(vol->v_cdb, curdir->d_did, upath, ulen);
-            }
+            /* The dircache id was inode-validated just above; without a cache
+             * hit, deletefile() resolves the CNID itself after the unlink
+             * (authoritative against concurrent renames) and reports it back
+             * here for the sibling cache hint. */
+            cnid_t file_cnid = cachedfile ? cachedfile->d_did : CNID_INVALID;
 
             /* deletefile() also handles CNID and dircache cleanup */
-            if ((rc = deletefile(vol, -1, upath, 1)) == AFP_OK) {
+            if ((rc = deletefile(vol, -1, upath, 1, &file_cnid)) == AFP_OK) {
 #if defined(WITH_FCE) || defined(WITH_SPOTLIGHT)
                 char event_path[MAXPATHLEN + 1];
                 const char *deleted_file = dir_event_path(event_path,

--- a/include/atalk/cnid_mysql_private.h
+++ b/include/atalk/cnid_mysql_private.h
@@ -15,6 +15,10 @@ typedef struct CNID_mysql_private {
     MYSQL_STMT   *cnid_lookup_stmt;
     MYSQL_STMT   *cnid_add_stmt;
     MYSQL_STMT   *cnid_put_stmt;
+    MYSQL_STMT   *cnid_get_stmt;
+    MYSQL_STMT   *cnid_delete_stmt;
+    MYSQL_STMT   *cnid_resolve_stmt;
+    MYSQL_STMT   *cnid_purge_stmt;
 } CNID_mysql_private;
 
 #endif

--- a/libatalk/cnid/mysql/cnid_mysql.c
+++ b/libatalk/cnid/mysql/cnid_mysql.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) Ralph Boehme 2013
+ * Copyright (c) 2026 Andy Lemin (andylemin)
  * All Rights Reserved.  See COPYING.
  *
  * This program is free software; you can redistribute it and/or modify
@@ -44,6 +45,10 @@
 
 static MYSQL_BIND lookup_param[4], lookup_result[5];
 static MYSQL_BIND add_param[4], put_param[5];
+static MYSQL_BIND get_param[2], get_result[1];
+static MYSQL_BIND delete_param[1];
+static MYSQL_BIND resolve_param[1], resolve_result[2];
+static MYSQL_BIND purge_param[5];
 
 /*!
  * Prepared statement parameters
@@ -64,6 +69,10 @@ static char               lookup_result_name[MAXPATHLEN];
 static unsigned long      lookup_result_name_len;
 static unsigned long long lookup_result_dev;
 static unsigned long long lookup_result_ino;
+static unsigned long long get_result_id;
+static unsigned long long resolve_result_did;
+static char               resolve_result_name[MAXPATHLEN];
+static unsigned long      resolve_result_name_len;
 
 static int init_prepared_stmt_lookup(CNID_mysql_private *db)
 {
@@ -181,21 +190,197 @@ EC_CLEANUP:
     EC_EXIT;
 }
 
+static int init_prepared_stmt_get(CNID_mysql_private *db)
+{
+    EC_INIT;
+    char *sql = NULL;
+    get_param[0].buffer_type   = MYSQL_TYPE_STRING;
+    get_param[0].buffer        = &stmt_param_name;
+    get_param[0].buffer_length = sizeof(stmt_param_name);
+    get_param[0].length        = &stmt_param_name_len;
+    get_param[1].buffer_type   = MYSQL_TYPE_LONGLONG;
+    get_param[1].buffer        = &stmt_param_did;
+    get_param[1].is_unsigned   = true;
+    get_result[0].buffer_type  = MYSQL_TYPE_LONGLONG;
+    get_result[0].buffer       = &get_result_id;
+    get_result[0].is_unsigned  = true;
+    EC_NULL(db->cnid_get_stmt = mysql_stmt_init(db->cnid_mysql_con));
+    EC_NEG1(asprintf(&sql, "SELECT Id FROM `%s` WHERE Name=? AND Did=?",
+                     db->cnid_mysql_voluuid_str));
+    EC_ZERO_LOG(mysql_stmt_prepare(db->cnid_get_stmt, sql, strlen(sql)));
+    EC_ZERO_LOG(mysql_stmt_bind_param(db->cnid_get_stmt, get_param));
+EC_CLEANUP:
+
+    if (sql) {
+        free(sql);
+    }
+
+    EC_EXIT;
+}
+
+static int init_prepared_stmt_delete(CNID_mysql_private *db)
+{
+    EC_INIT;
+    char *sql = NULL;
+    delete_param[0].buffer_type = MYSQL_TYPE_LONGLONG;
+    delete_param[0].buffer      = &stmt_param_id;
+    delete_param[0].is_unsigned = true;
+    EC_NULL(db->cnid_delete_stmt = mysql_stmt_init(db->cnid_mysql_con));
+    EC_NEG1(asprintf(&sql, "DELETE FROM `%s` WHERE Id=?",
+                     db->cnid_mysql_voluuid_str));
+    EC_ZERO_LOG(mysql_stmt_prepare(db->cnid_delete_stmt, sql, strlen(sql)));
+    EC_ZERO_LOG(mysql_stmt_bind_param(db->cnid_delete_stmt, delete_param));
+EC_CLEANUP:
+
+    if (sql) {
+        free(sql);
+    }
+
+    EC_EXIT;
+}
+
+static int init_prepared_stmt_resolve(CNID_mysql_private *db)
+{
+    EC_INIT;
+    char *sql = NULL;
+    resolve_param[0].buffer_type    = MYSQL_TYPE_LONGLONG;
+    resolve_param[0].buffer         = &stmt_param_id;
+    resolve_param[0].is_unsigned    = true;
+    resolve_result[0].buffer_type   = MYSQL_TYPE_LONGLONG;
+    resolve_result[0].buffer        = &resolve_result_did;
+    resolve_result[0].is_unsigned   = true;
+    resolve_result[1].buffer_type   = MYSQL_TYPE_STRING;
+    resolve_result[1].buffer        = &resolve_result_name;
+    resolve_result[1].buffer_length = sizeof(resolve_result_name);
+    resolve_result[1].length        = &resolve_result_name_len;
+    EC_NULL(db->cnid_resolve_stmt = mysql_stmt_init(db->cnid_mysql_con));
+    EC_NEG1(asprintf(&sql, "SELECT Did, Name FROM `%s` WHERE Id=?",
+                     db->cnid_mysql_voluuid_str));
+    EC_ZERO_LOG(mysql_stmt_prepare(db->cnid_resolve_stmt, sql, strlen(sql)));
+    EC_ZERO_LOG(mysql_stmt_bind_param(db->cnid_resolve_stmt, resolve_param));
+EC_CLEANUP:
+
+    if (sql) {
+        free(sql);
+    }
+
+    EC_EXIT;
+}
+
+static int init_prepared_stmt_purge(CNID_mysql_private *db)
+{
+    EC_INIT;
+    char *sql = NULL;
+    purge_param[0].buffer_type   = MYSQL_TYPE_LONGLONG;
+    purge_param[0].buffer        = &stmt_param_id;
+    purge_param[0].is_unsigned   = true;
+    purge_param[1].buffer_type   = MYSQL_TYPE_LONGLONG;
+    purge_param[1].buffer        = &stmt_param_did;
+    purge_param[1].is_unsigned   = true;
+    purge_param[2].buffer_type   = MYSQL_TYPE_STRING;
+    purge_param[2].buffer        = &stmt_param_name;
+    purge_param[2].buffer_length = sizeof(stmt_param_name);
+    purge_param[2].length        = &stmt_param_name_len;
+    purge_param[3].buffer_type   = MYSQL_TYPE_LONGLONG;
+    purge_param[3].buffer        = &stmt_param_dev;
+    purge_param[3].is_unsigned   = true;
+    purge_param[4].buffer_type   = MYSQL_TYPE_LONGLONG;
+    purge_param[4].buffer        = &stmt_param_ino;
+    purge_param[4].is_unsigned   = true;
+    EC_NULL(db->cnid_purge_stmt = mysql_stmt_init(db->cnid_mysql_con));
+    EC_NEG1(asprintf(&sql,
+                     "DELETE FROM `%s` WHERE Id=? OR (Did=? AND Name=?) "
+                     "OR (DevNo=? AND InodeNo=?)",
+                     db->cnid_mysql_voluuid_str));
+    EC_ZERO_LOG(mysql_stmt_prepare(db->cnid_purge_stmt, sql, strlen(sql)));
+    EC_ZERO_LOG(mysql_stmt_bind_param(db->cnid_purge_stmt, purge_param));
+EC_CLEANUP:
+
+    if (sql) {
+        free(sql);
+    }
+
+    EC_EXIT;
+}
+
 static int init_prepared_stmt(CNID_mysql_private *db)
 {
     EC_INIT;
     EC_ZERO(init_prepared_stmt_lookup(db));
     EC_ZERO(init_prepared_stmt_add(db));
     EC_ZERO(init_prepared_stmt_put(db));
+    EC_ZERO(init_prepared_stmt_get(db));
+    EC_ZERO(init_prepared_stmt_delete(db));
+    EC_ZERO(init_prepared_stmt_resolve(db));
+    EC_ZERO(init_prepared_stmt_purge(db));
 EC_CLEANUP:
     EC_EXIT;
 }
 
+/*!
+ * NULL-safe and NULLs each handle: a failed recovery leaves a mix of
+ * closed and live handles, and a later close or re-init must neither
+ * double-close nor leak the survivors.
+ */
 static void close_prepared_stmt(CNID_mysql_private *db)
 {
-    mysql_stmt_close(db->cnid_lookup_stmt);
-    mysql_stmt_close(db->cnid_add_stmt);
-    mysql_stmt_close(db->cnid_put_stmt);
+    MYSQL_STMT **stmts[] = {
+        &db->cnid_lookup_stmt, &db->cnid_add_stmt, &db->cnid_put_stmt,
+        &db->cnid_get_stmt, &db->cnid_delete_stmt, &db->cnid_resolve_stmt,
+        &db->cnid_purge_stmt,
+    };
+
+    for (size_t i = 0; i < sizeof(stmts) / sizeof(stmts[0]); i++) {
+        if (*stmts[i]) {
+            mysql_stmt_close(*stmts[i]);
+            *stmts[i] = NULL;
+        }
+    }
+}
+
+/*!
+ * stmtp must point at the handle field in CNID_mysql_private:
+ * CR_SERVER_LOST recovery reallocates every handle, and the retry
+ * must execute the fresh one. Recovery also invalidates any other
+ * statement's in-flight stored result.
+ */
+static int cnid_mysql_stmt_execute(CNID_mysql_private *db, MYSQL_STMT **stmtp)
+{
+    EC_INIT;
+    bool retry = true;
+
+    /* A failed earlier recovery leaves handles NULL; re-prepare before use. */
+    if (*stmtp == NULL) {
+        close_prepared_stmt(db);
+        EC_ZERO(init_prepared_stmt(db));
+    }
+
+    while (retry) {
+        retry = false;
+
+        if (mysql_stmt_execute(*stmtp)) {
+            switch (mysql_stmt_errno(*stmtp)) {
+            case CR_SERVER_LOST:
+                close_prepared_stmt(db);
+                EC_ZERO(init_prepared_stmt(db));
+                retry = true;
+                continue;
+
+            default:
+                LOG(log_error, logtype_cnid, "MySQL statement error: %s",
+                    mysql_stmt_error(*stmtp));
+                EC_FAIL;
+            }
+        }
+    }
+
+EC_CLEANUP:
+
+    if (ret != 0) {
+        errno = CNID_ERR_DB;
+    }
+
+    EC_EXIT;
 }
 
 static int cnid_mysql_execute(MYSQL *con, const char *sql)
@@ -217,7 +402,6 @@ int cnid_mysql_delete(struct _cnid_db *cdb, const cnid_t id)
 {
     EC_INIT;
     CNID_mysql_private *db;
-    char *sql = NULL;
 
     if (!cdb || !(db = cdb->cnid_db_private) || !id) {
         LOG(log_error, logtype_cnid, "cnid_mysql_delete: Parameter error");
@@ -227,9 +411,8 @@ int cnid_mysql_delete(struct _cnid_db *cdb, const cnid_t id)
 
     LOG(log_debug, logtype_cnid, "cnid_mysql_delete(%" PRIu32 "): BEGIN",
         ntohl(id));
-    EC_NEG1(asprintf(&sql, "DELETE FROM `%s` WHERE Id=%" PRIu32,
-                     db->cnid_mysql_voluuid_str, ntohl(id)));
-    EC_NEG1(cnid_mysql_execute(db->cnid_mysql_con, sql));
+    stmt_param_id = ntohl(id);
+    EC_ZERO(cnid_mysql_stmt_execute(db, &db->cnid_delete_stmt));
     LOG(log_debug, logtype_cnid, "cnid_mysql_delete(%" PRIu32 "): END", ntohl(id));
 EC_CLEANUP:
     EC_EXIT;
@@ -270,8 +453,6 @@ int cnid_mysql_update(struct _cnid_db *cdb,
 {
     EC_INIT;
     CNID_mysql_private *db;
-    char *sql = NULL;
-    MYSQL_STMT *delete_stmt = NULL;
     cnid_t update_id = 0;
 
     if (!cdb || !(db = cdb->cnid_db_private) || !id || !st || !name) {
@@ -295,44 +476,13 @@ int cnid_mysql_update(struct _cnid_db *cdb,
     uint64_t ino = st->st_ino;
 
     do {
-        MYSQL_BIND delete_param[2];
-        unsigned long delete_name_len = len;
-        uint64_t delete_did = ntohl(did);
-        EC_NEG1(asprintf(&sql, "DELETE FROM `%s` WHERE Id=%" PRIu32,
-                         db->cnid_mysql_voluuid_str, ntohl(id)));
-        EC_NEG1(cnid_mysql_execute(db->cnid_mysql_con, sql));
-        free(sql);
-        sql = NULL;
-        EC_NULL(delete_stmt = mysql_stmt_init(db->cnid_mysql_con));
-        EC_NEG1(asprintf(&sql, "DELETE FROM `%s` WHERE Did=? AND Name=?",
-                         db->cnid_mysql_voluuid_str));
-        EC_ZERO_LOG(mysql_stmt_prepare(delete_stmt, sql, strlen(sql)));
-        free(sql);
-        sql = NULL;
-        memset(delete_param, 0, sizeof(delete_param));
-        delete_param[0].buffer_type = MYSQL_TYPE_LONGLONG;
-        delete_param[0].buffer = &delete_did;
-        delete_param[0].is_unsigned = true;
-        delete_param[1].buffer_type = MYSQL_TYPE_STRING;
-        delete_param[1].buffer = (char *)name;
-        delete_param[1].buffer_length = len;
-        delete_param[1].length = &delete_name_len;
-        EC_ZERO_LOG(mysql_stmt_bind_param(delete_stmt, delete_param));
-        EC_ZERO_LOG(mysql_stmt_execute(delete_stmt));
-        mysql_stmt_close(delete_stmt);
-        delete_stmt = NULL;
-        EC_NEG1(asprintf(&sql, "DELETE FROM `%s` WHERE DevNo=%" PRIu64 " AND InodeNo=%"
-                         PRIu64,
-                         db->cnid_mysql_voluuid_str, dev, ino));
-        EC_NEG1(cnid_mysql_execute(db->cnid_mysql_con, sql));
-        free(sql);
-        sql = NULL;
         stmt_param_id = ntohl(id);
         strncpy(stmt_param_name, name, sizeof(stmt_param_name));
         stmt_param_name_len = len;
         stmt_param_did = ntohl(did);
         stmt_param_dev = dev;
         stmt_param_ino = ino;
+        EC_ZERO(cnid_mysql_stmt_execute(db, &db->cnid_purge_stmt));
 
         if (mysql_stmt_execute(db->cnid_put_stmt)) {
             switch (mysql_stmt_errno(db->cnid_put_stmt)) {
@@ -358,15 +508,6 @@ int cnid_mysql_update(struct _cnid_db *cdb,
     } while (update_id != ntohl(id));
 
 EC_CLEANUP:
-
-    if (delete_stmt) {
-        mysql_stmt_close(delete_stmt);
-    }
-
-    if (sql) {
-        free(sql);
-    }
-
     EC_EXIT;
 }
 
@@ -409,25 +550,7 @@ cnid_t cnid_mysql_lookup(struct _cnid_db *cdb,
     stmt_param_did = ntohl(did);
     stmt_param_dev = dev;
     stmt_param_ino = ino;
-    bool retry = true;
-
-    while (retry) {
-        retry = false;
-
-        if (mysql_stmt_execute(db->cnid_lookup_stmt)) {
-            switch (mysql_stmt_errno(db->cnid_lookup_stmt)) {
-            case CR_SERVER_LOST:
-                close_prepared_stmt(db);
-                EC_ZERO(init_prepared_stmt(db));
-                retry = true;
-                continue;
-
-            default:
-                EC_FAIL;
-            }
-        }
-    }
-
+    EC_ZERO(cnid_mysql_stmt_execute(db, &db->cnid_lookup_stmt));
     EC_ZERO_LOG(mysql_stmt_store_result(db->cnid_lookup_stmt));
     have_result = true;
     EC_ZERO_LOG(mysql_stmt_bind_result(db->cnid_lookup_stmt, lookup_result));
@@ -449,11 +572,21 @@ cnid_t cnid_mysql_lookup(struct _cnid_db *cdb,
         EC_ZERO(mysql_stmt_fetch(db->cnid_lookup_stmt));
         break;
 
-    case 2:
+    case 2: {
+        /* a mismatch, delete both and return not found. Fetch both ids
+         * before deleting: a CR_SERVER_LOST recovery inside delete
+         * re-prepares every statement and would invalidate a fetch
+         * still in flight on the lookup handle. */
+        cnid_t mismatched[2];
+        int nfetched = 0;
 
-        /* a mismatch, delete both and return not found */
-        while (mysql_stmt_fetch(db->cnid_lookup_stmt) == 0) {
-            if (cnid_mysql_delete(cdb, htonl((cnid_t)lookup_result_id))) {
+        while (nfetched < 2
+                && mysql_stmt_fetch(db->cnid_lookup_stmt) == 0) {
+            mismatched[nfetched++] = htonl((cnid_t)lookup_result_id);
+        }
+
+        for (int i = 0; i < nfetched; i++) {
+            if (cnid_mysql_delete(cdb, mismatched[i])) {
                 LOG(log_error, logtype_cnid, "MySQL query error: %s",
                     mysql_error(db->cnid_mysql_con));
                 errno = CNID_ERR_DB;
@@ -463,6 +596,7 @@ cnid_t cnid_mysql_lookup(struct _cnid_db *cdb,
 
         errno = CNID_DBD_RES_NOTFOUND;
         EC_FAIL;
+    }
 
     default:
         errno = CNID_ERR_DB;
@@ -678,14 +812,7 @@ cnid_t cnid_mysql_get(struct _cnid_db *cdb, cnid_t did, const char *name,
 {
     EC_INIT;
     CNID_mysql_private *db;
-    char *sql = NULL;
     cnid_t id = CNID_INVALID;
-    MYSQL_STMT *stmt = NULL;
-    MYSQL_BIND param[2];
-    MYSQL_BIND result[1];
-    unsigned long name_len = len;
-    uint64_t did_param = ntohl(did);
-    unsigned long long result_id = 0;
     bool have_result = false;
 
     if (!cdb || !(db = cdb->cnid_db_private) || !name) {
@@ -703,49 +830,24 @@ cnid_t cnid_mysql_get(struct _cnid_db *cdb, cnid_t did, const char *name,
     LOG(log_debug, logtype_cnid,
         "cnid_mysql_get(did: %" PRIu32 ", name: \"%s\"): START",
         ntohl(did), name);
-    EC_NULL(stmt = mysql_stmt_init(db->cnid_mysql_con));
-    EC_NEG1(asprintf(&sql, "SELECT Id FROM `%s` "
-                           "WHERE Name=? AND Did=?",
-                     db->cnid_mysql_voluuid_str));
-    EC_ZERO_LOG(mysql_stmt_prepare(stmt, sql, strlen(sql)));
-    free(sql);
-    sql = NULL;
-    memset(param, 0, sizeof(param));
-    param[0].buffer_type = MYSQL_TYPE_STRING;
-    param[0].buffer = (char *)name;
-    param[0].buffer_length = len;
-    param[0].length = &name_len;
-    param[1].buffer_type = MYSQL_TYPE_LONGLONG;
-    param[1].buffer = &did_param;
-    param[1].is_unsigned = true;
-    EC_ZERO_LOG(mysql_stmt_bind_param(stmt, param));
-    memset(result, 0, sizeof(result));
-    result[0].buffer_type = MYSQL_TYPE_LONGLONG;
-    result[0].buffer = &result_id;
-    result[0].is_unsigned = true;
-    EC_ZERO_LOG(mysql_stmt_bind_result(stmt, result));
-    EC_ZERO_LOG(mysql_stmt_execute(stmt));
-    EC_ZERO_LOG(mysql_stmt_store_result(stmt));
+    strncpy(stmt_param_name, name, sizeof(stmt_param_name));
+    stmt_param_name_len = len;
+    stmt_param_did = ntohl(did);
+    EC_ZERO(cnid_mysql_stmt_execute(db, &db->cnid_get_stmt));
+    EC_ZERO_LOG(mysql_stmt_store_result(db->cnid_get_stmt));
     have_result = true;
+    EC_ZERO_LOG(mysql_stmt_bind_result(db->cnid_get_stmt, get_result));
 
-    if (mysql_stmt_num_rows(stmt)) {
-        EC_ZERO(mysql_stmt_fetch(stmt));
-        id = htonl((uint32_t)result_id);
+    if (mysql_stmt_num_rows(db->cnid_get_stmt)) {
+        EC_ZERO(mysql_stmt_fetch(db->cnid_get_stmt));
+        id = htonl((uint32_t)get_result_id);
     }
 
 EC_CLEANUP:
     LOG(log_debug, logtype_cnid, "cnid_mysql_get: id: %" PRIu32, ntohl(id));
 
     if (have_result) {
-        mysql_stmt_free_result(stmt);
-    }
-
-    if (stmt) {
-        mysql_stmt_close(stmt);
-    }
-
-    if (sql) {
-        free(sql);
+        mysql_stmt_free_result(db->cnid_get_stmt);
     }
 
     return id;
@@ -756,9 +858,7 @@ char *cnid_mysql_resolve(struct _cnid_db *cdb, cnid_t *id, void *buffer,
 {
     EC_INIT;
     CNID_mysql_private *db;
-    char *sql = NULL;
-    MYSQL_RES *result = NULL;
-    MYSQL_ROW row;
+    bool have_result = false;
 
     if (!cdb || !(db = cdb->cnid_db_private)) {
         LOG(log_error, logtype_cnid, "cnid_mysql_get: Parameter error");
@@ -766,28 +866,26 @@ char *cnid_mysql_resolve(struct _cnid_db *cdb, cnid_t *id, void *buffer,
         EC_FAIL;
     }
 
-    EC_NEG1(asprintf(&sql, "SELECT Did, Name FROM `%s` WHERE Id=%" PRIu32,
-                     db->cnid_mysql_voluuid_str, ntohl(*id)));
-    EC_NEG1(cnid_mysql_execute(db->cnid_mysql_con, sql));
-    free(sql);
-    sql = NULL;
-    EC_NULL(result = mysql_store_result(db->cnid_mysql_con));
+    stmt_param_id = ntohl(*id);
+    EC_ZERO(cnid_mysql_stmt_execute(db, &db->cnid_resolve_stmt));
+    EC_ZERO_LOG(mysql_stmt_store_result(db->cnid_resolve_stmt));
+    have_result = true;
+    EC_ZERO_LOG(mysql_stmt_bind_result(db->cnid_resolve_stmt, resolve_result));
 
-    if (mysql_num_rows(result) != 1) {
+    if (mysql_stmt_num_rows(db->cnid_resolve_stmt) != 1) {
         EC_FAIL;
     }
 
-    row = mysql_fetch_row(result);
-    *id = htonl(atoi(row[0]));
-    strncpy(buffer, row[1], len);
+    EC_ZERO(mysql_stmt_fetch(db->cnid_resolve_stmt));
+    /* The connector is not guaranteed to NUL-terminate string results;
+     * Name is VARCHAR(255) against a MAXPATHLEN buffer, so there is room. */
+    resolve_result_name[resolve_result_name_len] = '\0';
+    *id = htonl((uint32_t)resolve_result_did);
+    strncpy(buffer, resolve_result_name, len);
 EC_CLEANUP:
 
-    if (result) {
-        mysql_free_result(result);
-    }
-
-    if (sql) {
-        free(sql);
+    if (have_result) {
+        mysql_stmt_free_result(db->cnid_resolve_stmt);
     }
 
     if (ret != 0) {

--- a/test/afpd/subtests_lock.c
+++ b/test/afpd/subtests_lock.c
@@ -1237,7 +1237,7 @@ int utest_deletefile_nodelete(const struct vol *vol)
     ad_flush(&ad);
     ad_close(&ad, ADFLAGS_HF);
     /* delete must be refused while NODELETE is set */
-    rc = deletefile(vol, dirfd, leaf, 1);
+    rc = deletefile(vol, dirfd, leaf, 1, NULL);
 
     if (rc != AFPERR_OLOCK) {
         close(dirfd);
@@ -1268,7 +1268,7 @@ int utest_deletefile_nodelete(const struct vol *vol)
 
     ad_flush(&ad);
     ad_close(&ad, ADFLAGS_HF);
-    rc = deletefile(vol, dirfd, leaf, 1);
+    rc = deletefile(vol, dirfd, leaf, 1, NULL);
     close(dirfd);
 
     if (rc != AFP_OK) {


### PR DESCRIPTION
While working on #3241 we noticed the lantest results split into two groups. The CPU-bound tests scale with the CI runner's CPU and move together from run to run. The CNID-write-heavy tests don't: they swing with the runner's disk. One dashboard run made this obvious — every CPU-bound row came in about 25% fast while the CNID-write rows were up to 34% slow, on the same runner in the same run. When half the rows answer to the CPU and the other half to the disk, the group can't be trended as a whole, and no amount of baseline normalization fixes it (this is exactly what the MAD indicator flags).

This PR tackles both ends of that problem:

1. **CI**: the perf jobs (LatencyGraph lantest, PerfGraph speedtest, FlameGraph spectest) keep the sqlite CNID backend but move its store onto a tmpfs. Every row becomes CPU-bound and the group trends as one.
2. **Production mysql backend**: profiling the same paths turned up real waste in the mysql backend — statements re-prepared on every call and avoidable round trips. Those are fixed here, along with better MariaDB defaults for the container.

## CI fix: tmpfs under the existing backend

The disk gets into the timings through sqlite's WAL checkpoints, which wait on fsync — and GitHub runners sit on shared VM storage where fsync cost varies wildly.

An earlier revision of this PR solved that by switching the perf jobs to the mysql backend with a durability-off MariaDB tuning. It worked, but it bought disk independence by paying a client/server round trip on every operation (creating 2000 files took 518 ms vs sqlite's 309 ms on the same host). A tmpfs under the CNID store gets the same disk independence for free: no socket, no backend change, and the dashboard keeps measuring the code path users actually run.

- A new `AFP_CNID_TMPFS` gate in `env_setup_netatalk.sh` mounts a tmpfs over the CNID state directory before afpd starts. The directory is read from `afpd -V` rather than hardcoded, so the script works across build prefixes and distros. Off by default: production containers and every other CI job keep the on-disk store.
- If the mount is refused (container not `--privileged`), the entrypoint exits rather than falling back to disk. A misconfigured job fails loudly instead of quietly publishing disk-bound numbers.
- The three perf jobs set `AFP_CNID_TMPFS=1`; lantest and speedtest gain `--privileged` (flamegraph already had it).
- The lantest/speedtest chart headers now name the CNID store (`CNID: sqlite+tmpfs`) via a new `--meta cnid=` label, so dashboard history stays readable across the change.

## mysql backend: round trips and statement reuse

Profiling found three kinds of waste in the hot CNID paths:

| defect | fix | round trips |
|---|---|---|
| `cnid_mysql_get` built, prepared and closed its statement on every call; `cnid_mysql_delete`/`cnid_mysql_resolve` sent ad-hoc text mariadbd re-parsed per call | connection-scoped prepared statements alongside the existing lookup/add/put set; shared CR_SERVER_LOST reprepare-and-retry helper; statement errors now log `mysql_stmt_error()` and set `CNID_ERR_DB` uniformly; fixes an sql-string leak in delete | get: prepare+execute → 1 execute |
| `cnid_mysql_update` (rename/repair) issued three sequential DELETEs (by Id, by Did+Name, by DevNo+InodeNo) plus the re-insert, the second DELETE prepared and thrown away per call | one prepared DELETE covering all three unique keys; atomic, so a concurrent insert can no longer land between the deletes | 4 → 2 per rename |
| `afp_delete` resolved the file's CNID for the sibling cache hint, then `deletefile()` resolved the same CNID again before `cnid_delete` | `deletefile` takes an in/out CNID: `afp_delete` passes its inode-validated dircache id in (hot path, no lookup); with no cached id, `deletefile` resolves it **after the unlink** — authoritative against concurrent renames — and reports it back for the sibling cache hint (overwrite/cleanup callers pass NULL, unchanged behavior) | FPDelete: 3 → 1 (dircache-hot), 3 → 2 (cold) |

The multi-key DELETE was verified against the optimizer before landing — EXPLAIN on a populated 20k-row table, prepared with bound parameters (MariaDB 11.8.8):

```
type: index_merge
key: PRIMARY,DidName,DevIno   key_len: 8,1026,16
Extra: Using union(PRIMARY,DidName,DevIno); Using where
```

We also evaluated an upsert for `cnid_mysql_add` (`INSERT … ON DUPLICATE KEY UPDATE Id=LAST_INSERT_ID(Id)`) and rejected it after testing. Two problems: when the (Did,Name) and (DevNo,InodeNo) unique keys match two *different* rows — which happens when a file is replaced via an inode shuffle — the upsert's repair arm itself fails with ER_DUP_ENTRY and would retry forever. And every duplicate hit burns an AUTO_INCREMENT id, so routine directory enumeration would slowly march the volume toward the CNID-depletion table reset. `add` keeps its lookup-then-insert flow.

## Measured: mysql before/after, with sqlite as the reference

All runs: afp_lantest, 20 iterations, CI perf config (dircache arc/65536/freq 100, quantum 1M), same host, same image build. Worth keeping in mind while reading: sqlite is a library inside each afpd process, while mysql and dbd are separate processes reached over a Unix socket, so the gaps between the backends are mostly IPC overhead. The mysql runs use the container-local MariaDB; dbd is the default backend (afpd → cnid_dbd daemon, BDB storage); the sqlite runs cover both the on-disk store (fast local NVMe) and the tmpfs store (the exact CI configuration). Medians in ms:

| lantest row | mysql before | mysql after | Δ mysql | dbd | sqlite (disk) | sqlite (tmpfs) |
|---|---|---|---|---|---|---|
| Deleting 2000 files | 723 | 445 | **-38%** | 421 | 154 | 157 |
| Mixed cache ops (create/stat/enum/delete) on 500 files | 397 | 306 | **-23%** | 211 | 117 | 120 |
| Copying 1000 files client-side | 539 | 461 | -14% | 389 | 380 | 372 |
| Create 2000 dirs tree | 699 | 607 | -13% | 429 | 230 | 205 |
| Copying 2000 files server-side | 691 | 625 | -10% | 454 | 219 | 199 |
| Creating 2000 files | 716 | 658 | -8% | 468 | 272 | 260 |
| Open, write 1 KiB, close 2000 files | 287 | 281 | -2% | 290 | 285 | 290 |
| Open, read 1 KiB, close 2000 files | 279 | 271 | -3% | 281 | 282 | 264 |
| Stat 2000 files *(control: already 1 prepared RT)* | 169 | 170 | ±0 | 173 | 175 | 176 |
| Lock/unlock 2000 open forks *(no CNID)* | 161 | 161 | ±0 | 173 | 169 | 160 |
| Byte-range lock/unlock 2000 ranges *(no CNID)* | 160 | 161 | ±0 | 166 | 174 | 171 |
| **Total median, all 17 tests** | **5092** | **4406** | **-13%** | **3725** | **2744** | **2665** |
| **Avg per AFP op (49,326 ops)** | **103 µs** | **89 µs** | **-14%** | **76 µs** | **56 µs** | **54 µs** |

The three flat rows are the sanity check: Stat was already a single prepared round trip, and the two lock rows never touch CNID at all, so if the host had drifted between runs it would have shown there first. Variance also dropped across the board — Delete's σ went from 204 ms to 53 ms — which follows from fewer round trips meaning fewer chances to get unlucky with scheduling.

The sqlite columns put the mysql work in context — and it matters that lantest is almost exclusively a *write* benchmark (create, delete, copy, rename). On CNID mutation rows sqlite stays ahead, because every remaining mysql round trip is still a socket send/receive plus a mariadbd wakeup — but the gap closed a lot (Delete: mysql was 4.7× sqlite before these commits, 2.9× after). On the read-side rows, the picture inverts: the prepared-statement mysql backend is now the fastest of the three backends even for a single user (Stat 170 vs dbd 173 vs sqlite 175; 1-KiB open/close read 271 vs 281 vs 282). mysql only loses on writes at single-user load — a read-heavy workload (browsing, enumeration, metadata lookups, which dominate real desktop use) is already fastest on mysql.

The dbd column is the fairest comparison for the mysql work, since dbd pays the same Unix-socket IPC. Before these commits mysql trailed dbd badly (Delete: 723 vs 421, 72% slower); after them it reaches parity on Delete (445 vs 421, overlapping σ) and Stat (170 vs 173), though dbd still leads on create/copy where mysql's add path spends two round trips. mysql is also now the steadier of the two IPC backends — dbd's σ runs 2–4× wider (its client-copy row hit a 965 ms outlier; mysql-after's worst σ is 62 ms).

The tmpfs column lands within 3% of disk — but only because this test host has a local NVMe drive whose sync latency is nearly as low as memory. That is not the situation on the CI runners: they sit on shared, virtualized storage where an fsync can cost anywhere from microseconds to tens of milliseconds depending on what the neighbors are doing. So don't read the near-identical columns as "tmpfs doesn't matter" — on this host there was simply no disk penalty to remove. What the tmpfs run does show, even here, is the mechanism working: the CNID-write rows' σ roughly halved (Create dirs ±31.5 → ±15.9 ms, Create files ±39.3 → ±15.8, ServerCopy ±29.0 → ±14.6) as WAL sync latency left the numbers. On the CI runners, where that latency term is large and erratic instead of small and steady, removing it is the whole point.

One caveat: single-connection lantest is the best case for sqlite and dbd alike, and both degrade rapidly once real users arrive. Each connected user gets its own afpd process. With sqlite, those processes contend on the shared database file lock; with dbd, they all funnel through the single cnid_dbd daemon per volume, which serializes every request. Either way, throughput collapses after just a few concurrent users. mysql is the exception: mariadbd handles concurrent connections natively, so per-user afpd processes don't queue behind each other and we see no comparable degradation as users are added. Our recommendation: sqlite for up to ~5 concurrent users, mysql beyond that (and for multi-server deployments sharing one CNID database, which is what it's for). That's why the PR does both things: sqlite stays the default for small single-host installs and the CI perf backend, and mysql stops paying overhead it never needed to.

## MariaDB container defaults

The container-local MariaDB picks up a few defaults suited to the CNID workload (many small transactions, modest working set). All of them preserve durability — every commit still reaches the disk:

| setting | value | effect |
|---|---|---|
| skip-name-resolve | — | no DNS on connect |
| innodb_flush_method | O_DIRECT | skip the page-cache double buffering, fsync semantics unchanged |
| innodb_flush_neighbors | 0 | no HDD-era neighbor flushing |
| innodb_buffer_pool_size | 512M | working set stays in memory |
| innodb_log_file_size | 512M | fewer checkpoints |
| innodb_log_buffer_size | 64M | large transactions never force premature log writes |

## Testing

- spectest cnid:mysql leg after each backend commit: 348 passed / 0 failed
- BOTH spectest legs (cnid:mysql and default ea=sys) for the afpd change, which touches shared delete-path code: 348 / 0 each
- `meson test` afpd unit suites: 84 subtests, 0 failures — including the `deletefile` NODELETE tests that exercise the new parameter
- Statement-interaction check in C against libmysql: `cnid_mysql_lookup`'s mismatch path executes the prepared DELETE mid-fetch of the lookup's buffered result set — clean (`mysql_stmt_store_result` buffering makes the nested execute safe)
- tmpfs gate: mounted and fail-hard paths exercised locally; `sh -n`, workflow YAML parse, `perl -c` on both plot scripts

















