### PR TITLE
docs: append compilation instructions to INSTALL.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Generated source files
-COMPILATION.md
 etc/spotlight/sparql_parser.c
 etc/spotlight/sparql_parser.h
 etc/spotlight/spotlight_rawquery_lexer.c

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,4 +1,4 @@
-# Netatalk Installation Quick Start
+# Netatalk Installation
 
 This guide covers installing Netatalk from source on UNIX-like operating systems.
 
@@ -167,10 +167,3 @@ Please see [meson_options.txt](https://github.com/Netatalk/netatalk/blob/main/me
 for full details of all Netatalk-specific options,
 and the [Meson documentation](https://mesonbuild.com/Builtin-options.html)
 for details of generic Meson options.
-
-## See also
-
-The Netatalk manual has further resources to aid building and installation.
-
-- [Installation chapter](https://netatalk.io/manual/en/Installation): detailed descriptions of each dependency
-- [Compilation chapter](https://netatalk.io/compilation): concrete build steps for each supported operating system

--- a/contrib/scripts/make_compile_docs.pl
+++ b/contrib/scripts/make_compile_docs.pl
@@ -1,6 +1,7 @@
 #!/usr/bin/env perl
 
-# This script generates a compilation readme from GitHub workflow files
+# Generates compilation instructions from GitHub workflow files
+# meant to be appended to the INSTALL.md file
 #
 # (c) 2025-2026 Daniel Markstedt <daniel@mindani.net>
 #
@@ -116,19 +117,13 @@ sub render_step {
 }
 
 my @markdown = (
-            "# Compile Netatalk from Source",
-            "",
-            "Below are instructions on how to compile Netatalk from source for specific operating systems.",
-            "Before starting, please read through the [Install Quick Start](https://netatalk.io/install) guide first.",
-            "You need to have a local clone of Netatalk's source code before proceeding.",
-            "",
-            "```shell",
-            "git clone https://github.com/Netatalk/netatalk.git",
-            "cd netatalk",
-            "```",
-            "",
-            "**Note:** Installation commands may require `sudo` privileges depending on your system configuration.",
-            "",
+               "",
+               "## OS Specific Compilation Examples",
+               "",
+               "Below are instructions on how to compile Netatalk from source for specific operating systems.",
+               "",
+               "**Note:** Installation commands may require `sudo` privileges depending on your system configuration.",
+               "",
 );
 
 foreach my $input_file (@input_files) {
@@ -146,7 +141,7 @@ foreach my $input_file (@input_files) {
         my @steps = grep { wanted_step($_) } @{$job->{steps}};
         next unless @steps;
 
-        push @markdown, "## " . format_job_name($job->{name}), "";
+        push @markdown, "### " . format_job_name($job->{name}), "";
 
         foreach my $step (@steps) {
             render_step(\@markdown, $step);
@@ -154,8 +149,19 @@ foreach my $input_file (@input_files) {
     }
 }
 
-open(my $fh, '>', $output_file) or die "Could not open file '$output_file' for writing: $!";
+my $needs_leading_newline = -s $output_file;
+if ($needs_leading_newline) {
+    open(my $existing_fh, '<', $output_file)
+      or die "Could not open file '$output_file' for reading: $!";
+    seek($existing_fh, -1, 2)
+      or die "Could not seek in file '$output_file': $!";
+    $needs_leading_newline = <$existing_fh> ne "\n";
+    close $existing_fh;
+}
+
+open(my $fh, '>>', $output_file) or die "Could not open file '$output_file' for appending: $!";
+print $fh "\n" if $needs_leading_newline;
 print $fh join("\n", @markdown);
 close $fh;
 
-print "Wrote to $output_file\n";
+print "Appended to $output_file\n";

--- a/meson.build
+++ b/meson.build
@@ -197,10 +197,9 @@ if 'readmes' in docs_options
             '.github/workflows/build.yml',
             '.github/workflows/spectest-macos.yml',
             '.github/workflows/spectest-vms.yml',
-            'COMPILATION.md',
+            'INSTALL.md',
             check: true,
         )
-        readmes_md += ['COMPILATION']
     endif
 
     foreach file : readmes_md


### PR DESCRIPTION
rather than generating a separate COMPILATION.md file, append its contents to INSTALL.md for a more obvious grouping of information