### PR TITLE
doc: substitute manpage markdown titles for website

### DIFF
--- a/doc/manpages/man1/meson.build
+++ b/doc/manpages/man1/meson.build
@@ -61,6 +61,14 @@ endforeach
 
 if build_website
     foreach page : manfiles
-        install_data(page + '.1.md', install_dir: docs_install_path + '/manual/en')
+        custom_target(
+            'website_' + page,
+            input: page + '.1.md',
+            output: page + '.1.md',
+            command: ['sed', 's/^# Name$/# ' + page + '/', '@INPUT@'],
+            capture: true,
+            install: true,
+            install_dir: docs_install_path + '/manual/en',
+        )
     endforeach
 endif

--- a/doc/manpages/man5/meson.build
+++ b/doc/manpages/man5/meson.build
@@ -37,6 +37,14 @@ endforeach
 
 if build_website
     foreach page : manfiles
-        install_data(page + '.5.md', install_dir: docs_install_path + '/manual/en')
+        custom_target(
+            'website_' + page,
+            input: page + '.5.md',
+            output: page + '.5.md',
+            command: ['sed', 's/^# Name$/# ' + page + '/', '@INPUT@'],
+            capture: true,
+            install: true,
+            install_dir: docs_install_path + '/manual/en',
+        )
     endforeach
 endif

--- a/doc/manpages/man8/meson.build
+++ b/doc/manpages/man8/meson.build
@@ -50,6 +50,14 @@ endforeach
 
 if build_website
     foreach page : manfiles
-        install_data(page + '.8.md', install_dir: docs_install_path + '/manual/en')
+        custom_target(
+            'website_' + page,
+            input: page + '.8.md',
+            output: page + '.8.md',
+            command: ['sed', 's/^# Name$/# ' + page + '/', '@INPUT@'],
+            capture: true,
+            install: true,
+            install_dir: docs_install_path + '/manual/en',
+        )
     endforeach
 endif

--- a/doc/translated/ja/meson.build
+++ b/doc/translated/ja/meson.build
@@ -58,7 +58,20 @@ endif
 
 if build_website
     foreach page : manual_pages
-        install_data(page + '.md', install_dir: docs_install_path + '/manual/ja')
+        custom_target(
+            'website_' + page,
+            input: page + '.md',
+            output: page + '.md',
+            command: [
+                'sed',
+                '-e', 's/^# 名前$/# ' + page + '/',
+                '-e', '1s/[.][0-9][0-9]*$//',
+                '@INPUT@',
+            ],
+            capture: true,
+            install: true,
+            install_dir: docs_install_path + '/manual/ja',
+        )
     endforeach
 else
     foreach page : manual_pages


### PR DESCRIPTION
when publishing on the web, it's better to have a unique title for each rendered man page rather than the default 'Name' everywhere